### PR TITLE
Remove publishing api import db

### DIFF
--- a/modules/govuk/manifests/apps/publishing_api/db.pp
+++ b/modules/govuk/manifests/apps/publishing_api/db.pp
@@ -18,10 +18,4 @@ class govuk::apps::publishing_api::db (
     allow_auth_from_backend => true,
     backend_ip_range        => $backend_ip_range,
   }
-  govuk_postgresql::db { 'publishing_api_import':
-    user                    => 'publishing_api',
-    password                => $password,
-    allow_auth_from_backend => true,
-    backend_ip_range        => $backend_ip_range,
-  }
 }


### PR DESCRIPTION
This can be merged post deployment freeze.

The import of content store data back into the publishing api via the
publishing api import database has been completed. The database can be
removed.
The puppet postgresql class doesn't support `ensure => absent` so the
databases will need to be removed manually after this PR has been deployed.
