### PR TITLE
[Do not merge until public] Run tests against Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: ruby
+sudo: true
+rvm:
+  - 1.9.3
+install:
+  - bundle install
+  - bundle exec rake librarian:install
+script:
+  - bundle exec rake lint
+  - bundle exec rake all_but_lint


### PR DESCRIPTION
Now that the Puppet repository is public, we can run our tests on Travis.

This allows us to run tests against pull requests from forks of the repo (which we can't do with Jenkins).
