### PR TITLE
[#110487746] Protect single user mode

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -80,6 +80,10 @@ backup::offsite::jobs:
     minute: 13,
     # No encryption because of size and sensitivity
 
+base::packages::gems:
+  ruby-shadow:
+    ensure: 2.5.0
+
 base::packages::packages:
   - 'ack-grep'
   - 'bzip2'

--- a/hieradata/development_credentials.yaml
+++ b/hieradata/development_credentials.yaml
@@ -20,6 +20,9 @@ icinga::plugin::check_rabbitmq_consumers::monitoring_password: "%{hiera('govuk_r
 
 mysql_nagios: 'geavvujDovJefdoryenRedKokbiskim9'
 
+# This encrypted password was generated with `mkpasswd --method=sha-512` and a password of 'password'
+users::root_password_encrypted: '$6$gwBpG15Z0dCJ$.8BBgOp4zu6vOwxckV1RiQ73hz440NKY4TC/ViUELkDMhvfDfHyIiFg2guwKcmjsxd4AZLDz7Va3IUK4WCDn31'
+
 wildcard_alphagov_crt: |
     -----BEGIN CERTIFICATE-----
     MIID7TCCAtWgAwIBAgIJAMVuKOcew/ZlMA0GCSqGSIb3DQEBBQUAMFcxCzAJBgNV

--- a/hieradata/vagrant_credentials.yaml
+++ b/hieradata/vagrant_credentials.yaml
@@ -173,6 +173,9 @@ openconnect::user: 'REDACTED'
 openconnect::pass: 'REDACTED'
 openconnect::url: 'https://REDACTED/REDACTED'
 
+# This encrypted password was generated with `mkpasswd --method=sha-512` and a password of 'password'
+users::root_password_encrypted: '$6$gwBpG15Z0dCJ$.8BBgOp4zu6vOwxckV1RiQ73hz440NKY4TC/ViUELkDMhvfDfHyIiFg2guwKcmjsxd4AZLDz7Va3IUK4WCDn31'
+
 wildcard_alphagov_crt: |
     -----BEGIN CERTIFICATE-----
     MIID7TCCAtWgAwIBAgIJAMVuKOcew/ZlMA0GCSqGSIb3DQEBBQUAMFcxCzAJBgNV

--- a/modules/base/manifests/packages.pp
+++ b/modules/base/manifests/packages.pp
@@ -4,6 +4,9 @@
 #
 # === Parameters
 #
+# [*gems*]
+#   A hash of gems to install.
+#
 # [*packages*]
 #   An array of packages to install.
 #
@@ -11,6 +14,7 @@
 #   Which version of the `ruby` package to install
 #
 class base::packages (
+  $gems = {},
   $packages = [],
   $ruby_version = installed,
 ) {
@@ -36,6 +40,8 @@ class base::packages (
     ensure  => $ruby_version,
     require => Package['libruby1.9.1'],
   }
+
+  create_resources('package', $gems, { provider => 'gem' })
 
   # FIXME: Remove `alternatives` resource once we've stopped using Precise
   if $::lsbdistcodename == 'precise' {

--- a/modules/users/manifests/init.pp
+++ b/modules/users/manifests/init.pp
@@ -12,6 +12,10 @@
 #   List of pentest user accounts to add.
 #   Default: []
 #
+# [*root_password_encrypted*]
+#   A string which is in the format that the operating system requires passwords
+#   (eg a SHA-512 hash on Ubuntu).
+#
 # [*usernames*]
 #   Users to add to all servers
 #   Default: '[]'
@@ -19,10 +23,17 @@
 class users (
   $pentest_machines = [],
   $pentest_usernames = [],
+  $root_password_encrypted,
   $usernames = [],
 ) {
 
   validate_array($pentest_machines, $pentest_usernames, $usernames)
+
+  user { 'root':
+    ensure   => present,
+    password => $root_password_encrypted,
+    require  => Package['ruby-shadow'],
+  }
 
   # Remove unmanaged UIDs >= 500 (users, not system accounts),
   # In order to have no user accounts defined and purge existing accounts, you *must*

--- a/spec/fixtures/hieradata/common.yaml
+++ b/spec/fixtures/hieradata/common.yaml
@@ -43,6 +43,8 @@ router::assets_origin::vhost_name: "assets-origin.%{hiera('app_domain')}"
 
 users::pentest_machines: ['foo']
 users::pentest_usernames: ['andre_the_giant']
+# This encrypted password was generated with `mkpasswd --method=sha-512` and a password of 'password'
+users::root_password_encrypted: '$6$gwBpG15Z0dCJ$.8BBgOp4zu6vOwxckV1RiQ73hz440NKY4TC/ViUELkDMhvfDfHyIiFg2guwKcmjsxd4AZLDz7Va3IUK4WCDn31'
 
 www_crt: WWW_CRT
 www_key: WWW_KEY


### PR DESCRIPTION
This pull request shows what I think are 2 approaches for protecting single user mode.
- Disable recovery mode in grub
- Set root password (I haven't got this to work yet, if anyone has any ideas why I'd appreciate it)

```
Debug: /User[root]: Provider useradd does not support features manages_passwords; not managing attribute password
```

I thought installing the package would solve that but it doesn't seem to have.
