### PR TITLE
[#103428080] Add the hostname parameter to the jenkins job.

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/bouncer_cdn.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/bouncer_cdn.yaml.erb
@@ -47,3 +47,9 @@
             <%- if @cdn_password_encrypted -%>
             default: <%= @cdn_password_encrypted %>
             <%- end -%>
+        - hostname:
+            name: BOUNCER_HOSTNAME
+            description: The bouncer origin hostname.
+            <%- if @app_domain -%>
+            default: bouncer.<%= @app_domain %>
+            <%- end -%>


### PR DESCRIPTION
We now use this in the deployment script and vcl.
Defaults to the correct fqdn in stage and prod.

Related to the functionality added in https://github.gds/gds/cdn-configs/pull/95/files
