### PR TITLE
Make offsite backup disk monitoring checks unique

### DIFF
--- a/modules/backup/manifests/offsite/monitoring.pp
+++ b/modules/backup/manifests/offsite/monitoring.pp
@@ -22,28 +22,28 @@ class backup::offsite::monitoring(
 
   icinga::check { "check_disk_${offsite_hostname}":
     check_command       => 'check_nrpe_1arg!check_disk',
-    service_description => 'high disk usage',
+    service_description => 'low available disk space',
     use                 => 'govuk_high_priority',
     host_name           => $offsite_fqdn,
   }
 
   icinga::check { "check_disk_backup-data_${offsite_hostname}":
     check_command       => 'check_nrpe_1arg!check_disk_backup-data',
-    service_description => 'high disk usage',
+    service_description => 'low available disk space /srv/backup-data',
     use                 => 'govuk_high_priority',
     host_name           => $offsite_fqdn,
   }
 
   icinga::check { "check_disk_backup-assets_${offsite_hostname}":
     check_command       => 'check_nrpe_1arg!check_disk_backup-assets',
-    service_description => 'high disk usage',
+    service_description => 'low available disk space /srv/backup-assets',
     use                 => 'govuk_high_priority',
     host_name           => $offsite_fqdn,
   }
 
   icinga::check { "check_disk_logs-backup_${offsite_hostname}":
     check_command       => 'check_nrpe_1arg!check_disk_logs-backup',
-    service_description => 'high disk usage',
+    service_description => 'low available disk space /srv/logs-backup',
     use                 => 'govuk_high_priority',
     host_name           => $offsite_fqdn,
   }


### PR DESCRIPTION
Icinga ignores checks which have duplicate service description.
Make the descriptions unique and more descriptive
