### PR TITLE
Disable legacy logging for cdn-logs-monitor

### DIFF
--- a/modules/govuk/manifests/apps/govuk_cdn_logs_monitor.pp
+++ b/modules/govuk/manifests/apps/govuk_cdn_logs_monitor.pp
@@ -39,7 +39,8 @@ class govuk::apps::govuk_cdn_logs_monitor (
     govuk::app { 'govuk-cdn-logs-monitor':
       app_type           => 'bare',
       command            => 'bundle exec ruby scripts/monitor_logs.rb',
-      enable_nginx_vhost => false
+      enable_nginx_vhost => false,
+      legacy_logging     => false,
     }
   }
 }


### PR DESCRIPTION
This app is using the new 12-factor logging style, of sending logstash
output to stdout, and other logging to stderr.
