### PR TITLE
Remove service manual feature flag for government frontend

### DIFF
--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -45,7 +45,6 @@ govuk::apps::event_store::mongodb_servers: ['localhost']
 govuk::apps::frontend::enable_homepage_nocache_location: false
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
 govuk::apps::hmrc_manuals_api::enable_procfile_worker: false
-govuk::apps::government_frontend::enable_service_manual: true
 govuk::apps::government_frontend::vhost: 'government-frontend'
 govuk::apps::govuk_cdn_logs_monitor::enabled: false
 govuk::apps::govuk_delivery::enable_procfile_worker: false

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -19,7 +19,6 @@ govuk::apps::email_campaign_api::mongodb_nodes:
   - 'api-mongo-3.api'
 govuk::apps::errbit::errbit_email_from: 'govuk-winston+errbit-integration@digital.cabinet-office.gov.uk'
 govuk::apps::event_store::enabled: true
-govuk::apps::government_frontend::enable_service_manual: true
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
 govuk::apps::mapit::enabled: true
 govuk::apps::policy_publisher::db::backend_ip_range: '10.1.3.0/24'

--- a/hieradata/preview.yaml
+++ b/hieradata/preview.yaml
@@ -16,7 +16,6 @@ govuk::apps::email_campaign_api::mongodb_nodes:
   - 'api-mongo-3.api'
 govuk::apps::errbit::errbit_email_from: 'govuk-winston+errbit-preview@digital.cabinet-office.gov.uk'
 govuk::apps::event_store::enabled: true
-govuk::apps::government_frontend::enable_service_manual: true
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
 govuk::apps::mapit::enabled: true
 govuk::apps::publicapi::backdrop_host: 'www.preview.performance.service.gov.uk'

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -10,7 +10,6 @@ govuk::apps::content_tagger::db::backend_ip_range: '10.2.3.0/24'
 govuk::apps::email_alert_api::db::backend_ip_range: '10.2.3.0/24'
 govuk::apps::email_alert_monitor::db::backend_ip_range: '10.2.3.0/24'
 govuk::apps::errbit::errbit_email_from: 'govuk-winston+errbit-staging@digital.cabinet-office.gov.uk'
-govuk::apps::government_frontend::enable_service_manual: true
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::panopticon::enable_procfile_worker: false
 govuk::apps::policy_publisher::db::backend_ip_range: '10.2.3.0/24'

--- a/modules/govuk/manifests/apps/government_frontend.pp
+++ b/modules/govuk/manifests/apps/government_frontend.pp
@@ -10,25 +10,14 @@
 # [*port*]
 #   What port should the app run on?
 #
-# [*enable_service_manual*]
-#   A feature flag to enable rendering Service Manual formats
-#
 class govuk::apps::government_frontend(
   $vhost,
   $port = '3090',
-  $enable_service_manual = false,
 ) {
   Govuk::App::Envvar {
     app => 'government-frontend',
   }
 
-  if $enable_service_manual {
-    govuk::app::envvar {
-      "${title}-FLAG_ENABLE_SERVICE_MANUAL":
-        varname => 'FLAG_ENABLE_SERVICE_MANUAL',
-        value   => '1';
-    }
-  }
   govuk::app { 'government-frontend':
     app_type              => 'rack',
     port                  => $port,


### PR DESCRIPTION
Service Manual Publisher is in production and this feature flag is no longer
used as of https://github.com/alphagov/government-frontend/pull/68
