### PR TITLE
Move assets include to whitehall-admin only

### DIFF
--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -42,8 +42,6 @@ class govuk::apps::whitehall(
     require                => Package['unzip'],
   }
 
-  include assets
-
   if $configure_frontend == true {
 
     govuk::app::nginx_vhost { 'whitehall-frontend':
@@ -62,6 +60,7 @@ class govuk::apps::whitehall(
   }
 
   if $configure_admin == true {
+    include assets
 
     govuk::app::nginx_vhost { 'whitehall-admin':
       vhost                 => "whitehall-admin.${app_domain}",


### PR DESCRIPTION
I moved this by mistake in 8a521aba6192c277811d16ba610bec64ed0651fe.

Moving this means that the whitehall-frontend machines mount the NFS share, which is not correct.

The whitehall frontend machines don't need the NFS mount which means they don't need the assets user.
