### PR TITLE
Set backend_ip_range for content_tagger app

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -156,6 +156,7 @@ govuk::apps::content_register::rabbitmq_hosts:
   - rabbitmq-3.backend
 
 govuk::apps::content_tagger::db_hostname: "postgresql-primary-1.backend"
+govuk::apps::content_tagger::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 
 govuk::apps::efg::vhost_name: "www.sflg.gov.uk"
 

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -54,7 +54,6 @@ base::supported_kernel::enabled: true
 environment_ip_prefix: '10.3'
 
 govuk::apps::content_register::db::backend_ip_range: '10.3.3.0/24'
-govuk::apps::content_tagger::db::backend_ip_range: '10.3.3.0/24'
 govuk::apps::email_alert_api::db::backend_ip_range: '10.3.3.0/24'
 govuk::apps::email_alert_monitor::db::backend_ip_range: '10.3.3.0/24'
 govuk::apps::errbit::errbit_email_from: 'govuk-winston+errbit-production@digital.cabinet-office.gov.uk'

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -6,7 +6,6 @@ base::supported_kernel::enabled: true
 environment_ip_prefix: '10.2'
 
 govuk::apps::content_register::db::backend_ip_range: '10.2.3.0/24'
-govuk::apps::content_tagger::db::backend_ip_range: '10.2.3.0/24'
 govuk::apps::email_alert_api::db::backend_ip_range: '10.2.3.0/24'
 govuk::apps::email_alert_monitor::db::backend_ip_range: '10.2.3.0/24'
 govuk::apps::errbit::errbit_email_from: 'govuk-winston+errbit-staging@digital.cabinet-office.gov.uk'


### PR DESCRIPTION
This parameter is set incorrectly in the integration environment. We can use a hiera lookup to set this consistently in `common.yaml`.
