### PR TITLE
Update Freshness Threshold for Licensify Sync

### DIFF
--- a/modules/govuk_jenkins/manifests/job/copy_licensify_data_to_staging.pp
+++ b/modules/govuk_jenkins/manifests/job/copy_licensify_data_to_staging.pp
@@ -19,7 +19,7 @@ class govuk_jenkins::job::copy_licensify_data_to_staging (
   @@icinga::passive_check { "${check_name}_${::hostname}":
     service_description => $service_description,
     host_name           => $::fqdn,
-    freshness_threshold => 115200,
+    freshness_threshold => 612000,
     action_url          => $job_url,
   }
 }


### PR DESCRIPTION
This job only runs once a week, but the freshhold was set to 32 hours. This commit sets it to 1 week and 2 hours so we don't get needlessly alerted when it correctly doesn't run for 32 hours.
