### PR TITLE
Generate /etc/govuk.htpasswd from a template

### DIFF
--- a/hieradata/development_credentials.yaml
+++ b/hieradata/development_credentials.yaml
@@ -6,12 +6,15 @@ collectd::plugin::postgresql::password: 'password'
 http_username: 'username'
 http_password: 'password'
 
-govuk::htpasswd::http_passhash: 'N04wQhwGA777s'
 govuk_mysql::server::monitoring::collectd_mysql_password: 'password'
 govuk_rabbitmq::monitoring_password: monitoring
 govuk_rabbitmq::root_password: root
 
 govuk::apps::mapit::db_password: 'mapit'
+
+govuk::htpasswd::http_users:
+  betademo: 'password'
+  govuk:  '$2y$05$a6oye5LFUMqBK/h6F/UFV.bhQllgJSJ7vLZDNsj5h0vELCmewYaI.'
 
 icinga::plugin::check_rabbitmq_consumers::monitoring_password: "%{hiera('govuk_rabbitmq::monitoring_password')}"
 

--- a/hieradata/vagrant_credentials.yaml
+++ b/hieradata/vagrant_credentials.yaml
@@ -117,7 +117,9 @@ govuk_cdnlogs::server_crt: |
 govuk::deploy::aws_ses_smtp_username: 'a_username'
 govuk::deploy::aws_ses_smtp_password: 'a_password'
 
-govuk::htpasswd::http_passhash: 'N04wQhwGA777s'
+govuk::htpasswd::http_users:
+  betademo: 'N04wQhwGA777s'
+  govuk:  '$2y$05$a6oye5LFUMqBK/h6F/UFV.bhQllgJSJ7vLZDNsj5h0vELCmewYaI.'
 
 govuk_mysql::server::debian_sys_maint::mysql_debian_sys_maint: 'Pengeequ3Tee0eeFiex0Neeboo0laiMe'
 govuk_mysql::server::monitoring::collectd_mysql_password: 'password'

--- a/modules/govuk/manifests/htpasswd.pp
+++ b/modules/govuk/manifests/htpasswd.pp
@@ -4,20 +4,18 @@
 #
 # === Parameters
 #
-# [*http_username*]
-#   Basic auth username
-#
-# [*http_passhash*]
-#   Hash of a password created with `htpasswd`
+# [*http_users*]
+#   Array of users with a password hash.
 #
 class govuk::htpasswd (
-  $http_username = 'notset',
-  $http_passhash = 'notset',
+  $http_users = {},
 ){
+
+  validate_hash($http_users)
 
   file { '/etc/govuk.htpasswd':
     ensure  => 'present',
-    content => "${http_username}:${http_passhash}",
+    content => template('govuk/etc/govuk.htpasswd.erb'),
   }
 
 }

--- a/modules/govuk/templates/etc/govuk.htpasswd.erb
+++ b/modules/govuk/templates/etc/govuk.htpasswd.erb
@@ -1,0 +1,3 @@
+<% @http_users.each do |user, passhash| -%>
+<%= user %>:<%= passhash %>
+<% end -%>


### PR DESCRIPTION
Generate /etc/govuk.htpasswd from a template so that we can
- rotate usernames and passwords
- have multiple usernames and passwords
