### PR TITLE
Update Deploy Licensify Integration job

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -115,6 +115,7 @@ govuk_jenkins::job_builder::jobs:
 govuk_jenkins::job_builder::environment: 'integration'
 
 govuk_jenkins::job::deploy_app::alphagov_deployment_branch: 'master'
+govuk_jenkins::job::deploy_licensify::alphagov_deployment_branch: 'master'
 govuk_jenkins::job::deploy_puppet::commitish: 'preview'
 
 govuk_jenkins::job::network_config_deploy::environments:

--- a/modules/govuk_jenkins/manifests/job/deploy_licensify.pp
+++ b/modules/govuk_jenkins/manifests/job/deploy_licensify.pp
@@ -4,10 +4,15 @@
 #
 # === Parameters
 #
+# [*alphagov_deployment_branch*]
+#   The branch of the `alphagov-deployment` repository to use to
+#   deploy applications
+#
 # [*ci_new_jenkins_api_key*]
 #   API key to download build artefacts from CI servers
 #
 class govuk_jenkins::job::deploy_licensify (
+  $alphagov_deployment_branch = 'release',
   $ci_new_jenkins_api_key = undef,
 ) {
   file { '/etc/jenkins_jobs/jobs/deploy_licensify.yaml':

--- a/modules/govuk_jenkins/templates/jobs/deploy_licensify.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_licensify.yaml.erb
@@ -5,7 +5,7 @@
         - git:
             url: git@github.gds:gds/alphagov-deployment.git
             branches:
-              - release
+              - <%= @alphagov_deployment_branch %>
             wipe-workspace: false
 
 - job:


### PR DESCRIPTION
This was updated for other jobs (ud489b) but not for Licensify which caused a problem when trying to deploy in Integration.
