### PR TITLE
Sanitize publishing API data in integration.

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -105,6 +105,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::passive_checks
   - govuk_jenkins::job::performance_platform_smokey
   - govuk_jenkins::job::run_whitehall_data_migrations
+  - govuk_jenkins::job::sanitize_publishing_api_data
   - govuk_jenkins::job::service_manual_rebuild_search_index
   - govuk_jenkins::job::smokey
   - govuk_jenkins::job::smokey_deploy

--- a/modules/govuk_jenkins/manifests/job/sanitize_publishing_api_data.pp
+++ b/modules/govuk_jenkins/manifests/job/sanitize_publishing_api_data.pp
@@ -1,0 +1,17 @@
+# == Class:
+# govuk_jenkins::job::sanitize_publishing_api_data
+#
+# === Parameters
+#
+# [*auth_token*]
+#   Token to allow this job to be triggered remotely
+#
+class govuk_jenkins::job::sanitize_publishing_api_data (
+  $auth_token = undef,
+) {
+  file { '/etc/jenkins_jobs/jobs/sanitize_publishing_api_data.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/sanitize_publishing_api_data.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+}

--- a/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
@@ -40,6 +40,7 @@
             - project: <%= job %>
               condition: 'SUCCESS'
             <%- end -%>
+            - project: Sanitize_publishing_API_data
         - postbuildscript:
             builders:
                - shell: |

--- a/modules/govuk_jenkins/templates/jobs/sanitize_publishing_api_data.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/sanitize_publishing_api_data.yaml.erb
@@ -1,0 +1,14 @@
+---
+- job:
+    name: Sanitize_publishing_API_data
+    display-name: Sanitize_publishing_API_data
+    project-type: freestyle
+    description: "Discards access limited drafts after data sync completes."
+    <%- if @auth_token -%>
+    auth-token: <%= @auth_token %>
+    <%- end -%>
+    logrotate:
+      artifactNumToKeep: 10
+    builders:
+       - shell: |
+           ssh deploy@backend-1.backend 'cd /var/apps/publishing-api && sudo -u deploy govuk_setenv publishing-api bundle exec rake sanitize_data'


### PR DESCRIPTION
Triggers a rake task which discards access limited drafts.
