### PR TITLE
Use a md5 hash for the govuk password.

### DIFF
--- a/hieradata/vagrant_credentials.yaml
+++ b/hieradata/vagrant_credentials.yaml
@@ -119,7 +119,7 @@ govuk::deploy::aws_ses_smtp_password: 'a_password'
 
 govuk::htpasswd::http_users:
   betademo: 'N04wQhwGA777s'
-  govuk:  '$2y$05$a6oye5LFUMqBK/h6F/UFV.bhQllgJSJ7vLZDNsj5h0vELCmewYaI.'
+  govuk:  '$apr1$S6ZNQMaM$K1QdclQvrI33AKAPui5Ft1'
 
 govuk_mysql::server::debian_sys_maint::mysql_debian_sys_maint: 'Pengeequ3Tee0eeFiex0Neeboo0laiMe'
 govuk_mysql::server::monitoring::collectd_mysql_password: 'password'


### PR DESCRIPTION
NginX only supports crypt, md5 and SHA for password hashes. bcrypt is
not yet supported.
http://nginx.org/en/docs/http/ngx_http_auth_basic_module.html
