### PR TITLE
Call smokey as a normal build, not a parameterized one.

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_puppet.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_puppet.yaml.erb
@@ -26,9 +26,8 @@
     publishers:
         - description-setter:
             regexp: 'Deployed ([^ ]+) \(resolved'
-        - trigger-parameterized-builds:
-            - project: Smokey
-              condition: 'SUCCESS'
+        - trigger:
+            project: Smokey
     wrappers:
         - ansicolor:
             colormap: xterm


### PR DESCRIPTION
We're seeing issues with Jenkins failing to trigger the Smokey
job once deploy_puppet has run. This change brings deploy puppet in line with deploy_app,
which does not present the same issue.
