### PR TITLE
Add content_store app to draft_content_store nodes

### DIFF
--- a/hieradata/class/draft_content_store.yaml
+++ b/hieradata/class/draft_content_store.yaml
@@ -8,6 +8,9 @@ govuk::apps::content_store::mongodb_nodes:
   - 'api-mongo-3.api'
 govuk::apps::content_store::vhost: 'draft-content-store'
 
+govuk::node::s_base::apps:
+  - content_store
+
 lv:
   data:
     pv: '/dev/sdb1'


### PR DESCRIPTION
I missed this in 648f0dfd8b3f93afe09b2fe699af65e61efc656e because the draft_content_store node class was the only one that didn't already have its applications in hieradata (the draft backends and frontends already did).

/cc @alphagov/team-publishing-platform 
