### PR TITLE
In Integration, don't show a picture of the badger in Deploy_App

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
@@ -12,7 +12,7 @@
     name: Deploy_App
     display-name: Deploy_App
     project-type: freestyle
-    description: "<a href=\"http://www.flickr.com/photos/fatty/9158066939/\">\r\n  <img src=\"https://farm3.staticflickr.com/2835/9158066939_374360ed56_n.jpg\">\r\n</a>\r\n <h2>You can monitor the application health using the <a href=\"https://grafana.<%= @app_domain %>/#/dashboard/file/application_http_error_codes.json\">4XX and 5XX status dashboard</a></h2>\r\n"
+    description: "<% if @environment != 'integration' %><a href=\"http://www.flickr.com/photos/fatty/9158066939/\">\r\n  <img src=\"https://farm3.staticflickr.com/2835/9158066939_374360ed56_n.jpg\">\r\n</a>\r\n<% end %><h2>You can monitor the application health using the <a href=\"https://grafana.<%= @app_domain %>/#/dashboard/file/application_http_error_codes.json\">4XX and 5XX status dashboard</a></h2>\r\n"
     <%- if @auth_token -%>
     auth-token: <%= @auth_token %>
     <%- end -%>


### PR DESCRIPTION
- The picture can stay on Production and Staging as the badger's rules
  do apply there, but Integration is free to use as we wish.

(Not sure if this is right or not, but when I've got my head around testing it displays fine, if necessary I'll fix it.)
