### PR TITLE
Add logic to monitor VPN endpoints

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -836,6 +836,20 @@ monitoring::checks::smokey::features:
   check_draft_environment:
     feature: draft_environment
 
+monitoring::checks::vpn_tunnels::endpoints:
+  check_ping_api_gateway_dr:
+    check_command: "check_ping_external!%{hiera('environment_ip_prefix')}.12.1!10.0,20%!50.0,60%"
+    service_description: "Unable to ping DR API VPN gateway"
+  check_ping_backend_gateway_dr:
+    check_command: "check_ping_external!%{hiera('environment_ip_prefix')}.11.1!10.0,20%!50.0,60%"
+    service_description: "Unable to ping DR Backend VPN gateway"
+  check_ping_redirector_gateway_dr:
+    check_command: "check_ping_external!%{hiera('environment_ip_prefix')}.13.1!10.0,20%!50.0,60%"
+    service_description: "Unable to ping DR Redirector VPN gateway"
+  check_ping_router_gateway_dr:
+    check_command: "check_ping_external!%{hiera('environment_ip_prefix')}.9.1!10.0,20%!50.0,60%"
+    service_description: "Unable to ping DR Router VPN gateway"
+
 nginx::package::version: '1.4.6-1ubuntu3.1'
 
 nodejs::version: '0.10.37-1chl1~%{::lsbdistcodename}1'

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -620,6 +620,8 @@ monitoring::contacts::slack_username: 'Production Icinga'
 monitoring::contacts::slack_alert_url: "https://alert.%{hiera('app_domain')}/cgi-bin/icinga/status.cgi"
 monitoring::edge::enabled: true
 monitoring::pagerduty_drill::enabled: true
+# FIXME: Remove this line after testing completed
+monitoring::checks::vpn_tunnels::enabled: false
 
 postfix::smarthost:
   - 'email-smtp.us-east-1.amazonaws.com:587'

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -513,6 +513,8 @@ icinga::nginx::enable_basic_auth: false
 licensify::apps::licensing_web_forms::enabled: false
 
 monitoring::checks::ses::region: eu-west-1
+# FIXME: Remove this line after testing completed
+monitoring::checks::vpn_tunnels::enabled: false
 
 postfix::smarthost:
 - 'email-smtp.us-east-1.amazonaws.com:587'

--- a/modules/monitoring/files/etc/nagios3/conf.d/check_ping_external.cfg
+++ b/modules/monitoring/files/etc/nagios3/conf.d/check_ping_external.cfg
@@ -1,0 +1,4 @@
+define command {
+  command_name check_ping_external
+  command_line /usr/lib/nagios/plugins/check_ping -H '$ARG1$' -w '$ARG2$' -c '$ARG3$'
+}

--- a/modules/monitoring/manifests/checks.pp
+++ b/modules/monitoring/manifests/checks.pp
@@ -19,6 +19,7 @@ class monitoring::checks (
   include monitoring::checks::ses
   include monitoring::checks::smokey
   include monitoring::checks::reboots
+  include monitoring::checks::vpn_tunnels
 
   $app_domain = hiera('app_domain')
 

--- a/modules/monitoring/manifests/checks/vpn_tunnels.pp
+++ b/modules/monitoring/manifests/checks/vpn_tunnels.pp
@@ -1,0 +1,35 @@
+# == Class: monitoring::checks::vpn_tunnels
+#
+# Sets up host checks for the gateways of remote VPN tunnels.
+#
+# === Parameters
+#
+# [*enabled*]
+#   Should we monitor the VPN tunnels?
+#
+# [*endpoints*]
+#   Hash of the endpoints to monitor
+#
+class monitoring::checks::vpn_tunnels (
+  $enabled = true,
+  $endpoints = {},
+) {
+
+  validate_hash($endpoints)
+
+  icinga::check_config { 'check_ping_external':
+      source  => 'puppet:///modules/monitoring/etc/nagios3/conf.d/check_ping_external.cfg',
+  }
+
+  $defaults = {
+    host_name           => $::fqdn,
+    service_description => 'Unable to ping VPN gateway',
+    notification_period => 'inoffice',
+    use                 => 'govuk_high_priority',
+    notes_url           => monitoring_docs_url(vpn-gateway-down),
+  }
+
+  if $enabled {
+    create_resources('icinga::check', $endpoints, $defaults)
+  }
+}


### PR DESCRIPTION
We need a way to be able to monitor the status of a VPN (and be able to set hosts dependent on that check).

This commit adds a new `check_ping_external` command because we do not want to create a separate Icinga host for each VPN gateway, but the default `check_ping` command will monitor what is set for host_name, which is dependent on creating an Icinga host.

This can also be used to monitor any external machine if required.
