### PR TITLE
Reboot MongoDB machines overnight

### DIFF
--- a/hieradata/class/api_mongo.yaml
+++ b/hieradata/class/api_mongo.yaml
@@ -1,6 +1,6 @@
 ---
 
-govuk::safe_to_reboot::can_reboot: 'careful'
+govuk::safe_to_reboot::can_reboot: 'overnight'
 govuk::safe_to_reboot::reason: 'Check for primary, reboot secondaries, step down primary, reboot primary'
 
 lv:

--- a/hieradata/class/email_campaign_mongo.yaml
+++ b/hieradata/class/email_campaign_mongo.yaml
@@ -1,6 +1,6 @@
 ---
 
-govuk::safe_to_reboot::can_reboot: 'careful'
+govuk::safe_to_reboot::can_reboot: 'overnight'
 govuk::safe_to_reboot::reason: 'Check for primary, reboot secondaries, step down primary, reboot primary'
 
 lv:

--- a/hieradata/class/mongo.yaml
+++ b/hieradata/class/mongo.yaml
@@ -1,6 +1,6 @@
 ---
 
-govuk::safe_to_reboot::can_reboot: 'careful'
+govuk::safe_to_reboot::can_reboot: 'overnight'
 govuk::safe_to_reboot::reason: 'Check for primary, reboot secondaries, step down primary, reboot primary'
 
 lv:

--- a/hieradata/class/performance_mongo.yaml
+++ b/hieradata/class/performance_mongo.yaml
@@ -1,6 +1,6 @@
 ---
 
-govuk::safe_to_reboot::can_reboot: 'careful'
+govuk::safe_to_reboot::can_reboot: 'overnight'
 govuk::safe_to_reboot::reason: 'Check for primary, reboot secondaries, step down primary, reboot primary'
 
 lv:

--- a/hieradata/class/router_backend.yaml
+++ b/hieradata/class/router_backend.yaml
@@ -14,7 +14,7 @@ govuk::apps::router_api::vhost: 'router-api'
 govuk::node::s_base::apps:
   - router_api
 
-govuk::safe_to_reboot::can_reboot: 'careful'
+govuk::safe_to_reboot::can_reboot: 'overnight'
 govuk::safe_to_reboot::reason: 'Check for primary, reboot secondaries, step down primary, reboot primary'
 
 lv:

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -343,7 +343,6 @@ govuk_sudo::sudo_conf:
   ubuntu:
     content: 'ubuntu ALL=(ALL) NOPASSWD:ALL'
 
-govuk_unattended_reboot::enabled: true
 govuk_unattended_reboot::monitoring_basic_auth:
   username: "%{hiera('http_username')}"
   password: "%{hiera('http_password')}"

--- a/modules/govuk_unattended_reboot/files/etc/unattended-reboot/check/02_mongodb
+++ b/modules/govuk_unattended_reboot/files/etc/unattended-reboot/check/02_mongodb
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+
+# Test whether the replica set is healthy. The value of `ok` should
+# be 1 which will cause grep to exit with code 0.
+mongo --quiet --eval 'rs.status().ok' | grep --quiet 1
+
+# Test whether this node is the primary. The conditional will evaluate
+# to false if the node is safe to reboot which will cause grep to exit
+# with code 0.
+# FIXME: This could be extended to step down the primary and then carry
+# on with the reboot.
+mongo --quiet --eval 'db.isMaster().primary === db.isMaster().me' | grep --quiet false
+
+exit 0

--- a/modules/govuk_unattended_reboot/manifests/init.pp
+++ b/modules/govuk_unattended_reboot/manifests/init.pp
@@ -7,14 +7,13 @@
 #
 # [*enabled*]
 #   Whether to enable unattended reboots.
-#   Default: false
 #
 # [*monitoring_basic_auth*]
 #   A hash containing a `username` and a `password` to access monitoring
 #   which is protected by basic authentication.
 #
 class govuk_unattended_reboot (
-  $enabled = false,
+  $enabled = true,
   $monitoring_basic_auth = {},
 ) {
 

--- a/modules/govuk_unattended_reboot/manifests/mongodb.pp
+++ b/modules/govuk_unattended_reboot/manifests/mongodb.pp
@@ -1,0 +1,19 @@
+# == Class: govuk_unattended_reboot::mongodb
+#
+# Installs a script which ensures that a MongoDB server
+# can be rebooted.
+#
+class govuk_unattended_reboot::mongodb {
+
+  $config_directory = '/etc/unattended-reboot'
+  $check_scripts_directory = "${config_directory}/check"
+
+  file { "${check_scripts_directory}/02_mongodb":
+    ensure  => present,
+    mode    => '0755',
+    owner   => 'root',
+    group   => 'root',
+    source  => "puppet:///modules/govuk_unattended_reboot/${check_scripts_directory}/02_mongodb",
+    require => File[$check_scripts_directory],
+  }
+}

--- a/modules/mongodb/manifests/server.pp
+++ b/modules/mongodb/manifests/server.pp
@@ -41,6 +41,7 @@ class mongodb::server (
     }
   }
 
+  include govuk_unattended_reboot::mongodb
   include mongodb::repository
 
   if $development {


### PR DESCRIPTION
This script emulates the checks we perform when rebooting a MongoDB machine using Fabric:

- Make sure the cluster is healthy
- Make sure the candidate to reboot is not the primary

I've explicitly not introduced the logic around stepping down the primary to reboot it so that the first version of this is less complicated. This is still safe, it just means that we won't reboot the primary overnight until an election takes place at some other time.