### PR TITLE
Change directory for CDN logs processing

### DIFF
--- a/modules/govuk/manifests/apps/govuk_cdn_logs_monitor.pp
+++ b/modules/govuk/manifests/apps/govuk_cdn_logs_monitor.pp
@@ -22,7 +22,7 @@
 class govuk::apps::govuk_cdn_logs_monitor (
   $enabled = true,
   $cdn_log_dir = '/mnt/logs_cdn',
-  $processed_data_dir = '/mnt/logs_cdn_processed/data',
+  $processed_data_dir = '/mnt/logs_cdn/data',
 ) {
   if $enabled {
     Govuk::App::Envvar {


### PR DESCRIPTION
We're going to put this data back onto the original mount now that we don't need much space. We're also going to be removing lots of the old CDN logs which will free up a lot of disk space.
