### PR TITLE
Add fqdn_short Facter fact and use for Icinga

### DIFF
--- a/modules/govuk/lib/facter/fqdn_metrics.rb
+++ b/modules/govuk/lib/facter/fqdn_metrics.rb
@@ -4,10 +4,9 @@
 
 Facter.add("fqdn_metrics") do
  setcode do
-    fqdn = Facter.value("fqdn").dup
-    fqdn.gsub!(/\./, '_')
-    fqdn.gsub!(/_publishing_service_gov_uk$/, '')
+    fqdn_metrics = Facter.value("fqdn_short").dup
+    fqdn_metrics.gsub!(/\./, '_')
 
-    fqdn
+    fqdn_metrics
   end
 end

--- a/modules/govuk/lib/facter/fqdn_short.rb
+++ b/modules/govuk/lib/facter/fqdn_short.rb
@@ -1,0 +1,10 @@
+# Facter fact that provides a shorter machine name
+
+Facter.add("fqdn_short") do
+  setcode do
+    fqdn_short = Facter.value("fqdn").dup
+    fqdn_short.gsub!(/\.publishing\.service\.gov\.uk$/, '')
+
+    fqdn_short
+  end
+end

--- a/modules/govuk/spec/facter/fqdn_short_spec.rb
+++ b/modules/govuk/spec/facter/fqdn_short_spec.rb
@@ -1,0 +1,25 @@
+# Put module's plugins on LOAD_PATH.
+dir = File.expand_path('../../', File.dirname(__FILE__))
+$LOAD_PATH.unshift File.join(dir, 'lib')
+
+# We don't need rspec-puppet from spec_helper. Just facter.
+require 'facter'
+
+describe 'fqdn_short' do
+  before :each do
+    Facter.clear
+  end
+
+  {
+    "host-1.vdc.publishing.service.gov.uk"             => "host-1.vdc",
+    "host-1.vdc.staging.publishing.service.gov.uk"     => "host-1.vdc.staging",
+    "host-1.vdc.integration.publishing.service.gov.uk" => "host-1.vdc.integration",
+  }.each do |fqdn, fqdn_short_expected|
+    describe "fqdn => #{fqdn}" do
+      it {
+        expect(Facter.fact(:fqdn)).to receive(:value).and_return(fqdn)
+        expect(Facter.fact(:fqdn_short).value).to eq(fqdn_short_expected)
+      }
+    end
+  end
+end

--- a/modules/icinga/templates/host.erb
+++ b/modules/icinga/templates/host.erb
@@ -1,7 +1,8 @@
 define host {
-        use        <%= @use %>
-        alias      <%= @hostalias %>
-        address    <%= @address %>
-        host_name  <%= @hostalias %>
-        hostgroups all
+        use          <%= @use %>
+        alias        <%= @hostalias %>
+        address      <%= @address %>
+        display_name <%= @fqdn_short %>
+        host_name    <%= @hostalias %>
+        hostgroups   all
 }


### PR DESCRIPTION
This fact is similar to `fqdn_metrics` except it uses dots rather than underscores. This means I've been able to refacter (lol, Facter) `fqdn_metrics` to depend on `fqdn_short`.