### PR TITLE
Disable email-campaign-api Procfile worker

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -10,6 +10,7 @@ base::supported_kernel::enabled: true
 cron::weekly_dow: 1
 
 govuk::apps::email_alert_monitor::enabled: true
+govuk::apps::email_campaign_api::enable_procfile_worker: true
 govuk::apps::email_campaign_api::mongodb_nodes:
   - 'api-mongo-1.api'
   - 'api-mongo-2.api'

--- a/modules/govuk/manifests/apps/email_campaign_api.pp
+++ b/modules/govuk/manifests/apps/email_campaign_api.pp
@@ -27,7 +27,7 @@
 class govuk::apps::email_campaign_api(
   $port = 3110,
   $enabled = true,
-  $enable_procfile_worker = true,
+  $enable_procfile_worker = false,
   $errbit_api_key = undef,
   $errbit_environment_name,
   $errbit_host=undef,


### PR DESCRIPTION
This has been alerting in production for the last 26 days so I think we should disable it for now.