### PR TITLE
Move creation of CDN logs processed directory

### DIFF
--- a/modules/govuk/manifests/apps/govuk_cdn_logs_monitor.pp
+++ b/modules/govuk/manifests/apps/govuk_cdn_logs_monitor.pp
@@ -25,6 +25,13 @@ class govuk::apps::govuk_cdn_logs_monitor (
   $processed_data_dir = '/mnt/logs_cdn/data',
 ) {
   if $enabled {
+    file { $processed_data_dir:
+      ensure => directory,
+      mode   => '0755',
+      owner  => 'deploy',
+      group  => 'deploy',
+    }
+
     Govuk::App::Envvar {
       app => 'govuk-cdn-logs-monitor',
     }

--- a/modules/govuk_cdnlogs/manifests/init.pp
+++ b/modules/govuk_cdnlogs/manifests/init.pp
@@ -53,13 +53,6 @@ class govuk_cdnlogs (
     notify  => Class['rsyslog::service'],
   }
 
-  file { '/mnt/logs_cdn_processed/data':
-    ensure => directory,
-    mode   => '0755',
-    owner  => 'deploy',
-    group  => 'deploy',
-  }
-
   if !empty($ports) {
     @ufw::allow { 'rsyslog-cdn-logs':
       port => $ports,


### PR DESCRIPTION
Moving this into the `govuk::apps::govuk_cdn_logs_monitor` class removes duplication. I missed this `file` resource when I changed the directory recently.