### PR TITLE
Bugfix display_name in Icinga

### DIFF
--- a/modules/icinga/manifests/host.pp
+++ b/modules/icinga/manifests/host.pp
@@ -3,7 +3,8 @@ define icinga::host (
   $hostalias  = $::fqdn,
   $address    = $::ipaddress,
   $use        = 'generic-host',
-  $host_name  = $::fqdn
+  $host_name  = $::fqdn,
+  $display_name = $::fqdn_short,
 ) {
 
   file {"/etc/icinga/conf.d/icinga_host_${title}":

--- a/modules/icinga/templates/host.erb
+++ b/modules/icinga/templates/host.erb
@@ -2,7 +2,7 @@ define host {
         use          <%= @use %>
         alias        <%= @hostalias %>
         address      <%= @address %>
-        display_name <%= @fqdn_short %>
+        display_name <%= @display_name %>
         host_name    <%= @hostalias %>
         hostgroups   all
 }


### PR DESCRIPTION
Looking up this Facter fact inside the template means that the fact will always evaluate the value it is on the monitoring machine, which changes the display name of every machine to be `monitoring-1`.

Looking up the fact in the defined type means that it's evaluated on the client host.