### PR TITLE
[#109899450] Service dependency for vpn hosts

### DIFF
--- a/modules/govuk/lib/facter/vdc.rb
+++ b/modules/govuk/lib/facter/vdc.rb
@@ -1,0 +1,13 @@
+# Fact which specifies the name of the vDC of a node
+
+Facter.add("vdc") do
+  setcode do
+    env_octet = Facter.value(:ipaddress).split('.')[2].to_i
+    vdc = Facter.value(:domain).split('.').first
+    if env_octet > 7
+      vdc + '_dr'
+    else
+      vdc
+    end
+  end
+end

--- a/modules/icinga/manifests/client/checks.pp
+++ b/modules/icinga/manifests/client/checks.pp
@@ -1,7 +1,17 @@
-# FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
+# == Class: icinga::client::checks
+#
+# This class provides the default checks for a client machine.
+#
+# === Parameters:
+# [*disk_time_warn*]
+#   The disk time in milliseconds that will causing a warning state.
+#
+# [*disk_time_critical*]
+#   The disk time in milliseconds that will cause a critical state.
+#
 class icinga::client::checks (
-  $disk_time_warn = 100, # milliseconds
-  $disk_time_critical = 200 # milliseconds
+  $disk_time_warn = 100,
+  $disk_time_critical = 200,
 ) {
 
   include icinga::client::check_cputype

--- a/modules/icinga/manifests/service_dependency.pp
+++ b/modules/icinga/manifests/service_dependency.pp
@@ -1,0 +1,73 @@
+# == Define: icinga::service_dependency
+#
+# This creates a service dependency for the host service that other host
+# services are dependent on.
+#
+# Most of these params relate to Nagios service configuration directives:
+#
+# https://assets.nagios.com/downloads/nagioscore/docs/nagioscore/3/en/objectdefinitions.html#servicedependency
+#
+# === Parameters:
+#
+# [*dependent_host_name*]
+#   This host is dependent on `host_name`. The title of an `Icinga::Host`
+#   resource, usually `$::fqdn`.
+#
+# [*host_name*]
+#   The host upon which the service that causes the dependency runs on.
+#
+# [*service_description*]
+#   Description of the service that is dependent services rely upon.
+#
+# [*check_command*]
+#   Command used to check whether the service is healthy.
+#
+# [*dependent_service_decription*]
+#   Description of the service where functionality is changed depending on the
+#   status of `service_description`.
+#
+# [*execution_failure_criteria*]
+#   A comma-seperated set of criteria that determine what state the service is
+#   in for how actively the dependent service is checked.
+#   Default: 'n': none (services are always checked)
+#
+# [*notifcation_failure_criteria*]
+#   A comma-seperated set of criteria that determines when notifcations should
+#   suppressed for the dependent service.
+#   Default: 'w,c': warning state, critical state
+#
+define icinga::service_dependency (
+  $dependent_host_name,
+  $host_name                      = undef,
+  $service_description            = undef,
+  $dependent_service_description  = undef,
+  $execution_failure_criteria     = 'n',
+  $notification_failure_criteria  = 'w,c',
+) {
+
+  validate_re($service_description, '^(\w|\s|\-|/|\[|\]|:|\.)*$', "Icinga check \"${dependent_service_description}\" contains invalid characters")
+
+  if $service_description == undef {
+    fail("Must provide a \$service_description to Icinga::Service_dependency[${title}]")
+  }
+  if $dependent_service_description == undef {
+    fail("Must provide a \$dependent_service_description to Icinga::Service_dependency[${title}]")
+  }
+
+  if $dependent_host_name == undef {
+    fail("Must provide a \$host_name to Icinga::Service_dependency[${title}]")
+  }
+
+  $filename = "/etc/icinga/conf.d/icinga_host_${dependent_host_name}/${title}.cfg"
+  $content = template('icinga/service_dependency.erb')
+
+  Icinga::Host[$host_name] -> Icinga::Service_dependency[$title]
+
+  file { $filename:
+    ensure  => present,
+    content => $content,
+    require => Class['icinga::package'],
+    notify  => Class['icinga::service'],
+  }
+
+}

--- a/modules/icinga/templates/service_dependency.erb
+++ b/modules/icinga/templates/service_dependency.erb
@@ -1,0 +1,8 @@
+define servicedependency {
+        host_name                       <%= @host_name %>
+        service_description             <%= @service_description %>
+        dependent_host_name             <%= @dependent_host_name %>
+        dependent_service_description   <%= @dependent_service_description %>
+        execution_failure_criteria      <%= @execution_failure_criteria %>
+        notification_failure_criteria   <%= @notification_failure_criteria %>
+        }

--- a/modules/monitoring/manifests/checks/external_ping.pp
+++ b/modules/monitoring/manifests/checks/external_ping.pp
@@ -68,7 +68,7 @@ define monitoring::checks::external_ping(
 
   icinga::check { "check_external_ping_${title}":
     host_name           => $::fqdn,
-    service_description => "Unable to ping ${title} at ${host}",
+    service_description => "Unable to ping ${title}",
     notification_period => $notification_period,
     use                 => $use,
     notes_url           => $notes_url,

--- a/modules/monitoring/manifests/checks/vpn_tunnels.pp
+++ b/modules/monitoring/manifests/checks/vpn_tunnels.pp
@@ -23,5 +23,7 @@ class monitoring::checks::vpn_tunnels (
 
   if $enabled {
     create_resources('monitoring::checks::external_ping', $endpoints, $defaults)
+
+    Icinga::Service_dependency <<| |>>
   }
 }

--- a/modules/monitoring/manifests/client.pp
+++ b/modules/monitoring/manifests/client.pp
@@ -8,6 +8,10 @@ class monitoring::client {
   include collectd
   include collectd::plugin::tcp
 
+  if ($::vdc == 'licensify') or ($::vdc == 'efg') or ($::vdc =~ /^*_dr$/)  {
+    include monitoring::client::vpn_service_dependency
+  }
+
   # Provides:
   # - `notify-reboot-required` which is referenced in the `postinst`
   #   of some packages in order to request that the system be rebooted at a

--- a/modules/monitoring/manifests/client/vpn_service_dependency.pp
+++ b/modules/monitoring/manifests/client/vpn_service_dependency.pp
@@ -1,0 +1,18 @@
+# == Class: monitoring::client::vpn_service_dependency
+#
+# Creates service dependencies for hosts that connect to the monitoring server
+# over a VPN against the state of their VPN gateway.
+#
+class monitoring::client::vpn_service_dependency {
+  $host_name = 'monitoring-1.management'
+  $service_description = "Unable to ping vpn_gateway_${::vdc}"
+  $dependent_service_description = '*'
+  $app_domain = hiera('app_domain')
+
+  @@icinga::service_dependency { "dependency_vpn_${::hostname}":
+    host_name                     => "${host_name}.${app_domain}",
+    service_description           => $service_description,
+    dependent_host_name           => $::fqdn,
+    dependent_service_description => $dependent_service_description,
+  }
+}

--- a/modules/monitoring/manifests/client/vpn_service_dependency.pp
+++ b/modules/monitoring/manifests/client/vpn_service_dependency.pp
@@ -3,14 +3,25 @@
 # Creates service dependencies for hosts that connect to the monitoring server
 # over a VPN against the state of their VPN gateway.
 #
-class monitoring::client::vpn_service_dependency {
-  $host_name = 'monitoring-1.management'
-  $service_description = "Unable to ping vpn_gateway_${::vdc}"
+# === Parameters:
+#
+# [*monitoring_host*]
+#   The monitoring host which monitors the VPN gateway, and thus which the
+#   dependent service relies upon.
+#
+# [*service_description*]
+#   The full description of the service that the status the dependent services
+#   rely to define execution and notification behaviour.
+#
+class monitoring::client::vpn_service_dependency (
+  $monitoring_host = 'monitoring-1.management',
+  $service_description = "Unable to ping vpn_gateway_${::vdc}",
+) {
   $dependent_service_description = '*'
   $app_domain = hiera('app_domain')
 
   @@icinga::service_dependency { "dependency_vpn_${::hostname}":
-    host_name                     => "${host_name}.${app_domain}",
+    host_name                     => "${monitoring_host}.${app_domain}",
     service_description           => $service_description,
     dependent_host_name           => $::fqdn,
     dependent_service_description => $dependent_service_description,


### PR DESCRIPTION
**Affects monitoring so careful rollout required**

In 6f49a3512e905a156e8f8ca35dbcc9dee5fac721 we created a check which failed if the monitoring server was unable to ping the remote gateway of a VPN tunnel. 

This looks to add dependency for any nodes that rely on a VPN to communicate with the monitoring server (EFG, Licensify or any DR nodes). 

Each node creates an exported resource which specifies itself and all it's services to be dependent on monitoring-1 and the gateway service for the same vDC in which it lives. In it's current form it will create the configuration inside of `/etc/icinga/conf.d/icinga_host_api-mongo-4.api.dev.gov.uk/` (as an example) which I think helps keep the configuration split correctly between the hosts, but thoughts welcomed on this approach.

The `vdc` Facter fact is key in helping to determine which machines need to export their resource and in assigning the right service to be dependent upon.

---

Testing in Vagrant creates this configuration file in the location specified:
```
vagrant@monitoring-1:/etc/icinga/conf.d$ cat icinga_host_licensify-frontend-1.licensify.dev.gov.uk/dependency_vpn_licensify-frontend-1.cfg
define servicedependency {
        host_name                       monitoring-1.management.dev.gov.uk
        service_description             Unable to ping vpn_gateway_licensify
        dependent_host_name             licensify-frontend-1.licensify.dev.gov.uk
        dependent_service_description   *
        execution_failure_criteria      n
        notification_failure_criteria   w,c
        }
```

In terms of `execution_failure_criteria` and `notification_failure_criteria`, this means that the nodes will _always_ be actively checked, but will stop "notifications" if the `service_description` goes into a Warning or Critical state. **I welcome discussion if this is the correct thing, and requires some testing in Integration to make sure it does the correct thing**