### PR TITLE
[108858698] Update daily sync time in Integration

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -149,6 +149,7 @@ govuk::node::s_api_lb::search_servers:
   - "search-2.api"
 
 govuk::node::s_asset_base::firewall_allow_ip_range: '10.1.3.0/24'
+govuk::node::s_asset_master::copy_attachments_hour: 9
 govuk::node::s_asset_master::flag_new_whitehall_attachment_processing: true
 govuk::node::s_backend_lb::backend_servers:
   - 'backend-1.backend'


### PR DESCRIPTION
The machines in Integration are switched off over night, which means that the daily sync of Whitehall attachments (ensuring any that may have been missed for $reasons) have not been caught and the asset-slave nodes are out of sync with the asset-master node.

The job itself isn't directly impacting so 09:00 should be fine to sync them up.