### PR TITLE
Change attachment sync in integration to 11am

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -150,7 +150,7 @@ govuk::node::s_api_lb::search_servers:
   - "search-2.api"
 
 govuk::node::s_asset_base::firewall_allow_ip_range: '10.1.3.0/24'
-govuk::node::s_asset_master::copy_attachments_hour: 9
+govuk::node::s_asset_master::copy_attachments_hour: 11
 govuk::node::s_asset_master::flag_new_whitehall_attachment_processing: true
 govuk::node::s_backend_lb::backend_servers:
   - 'backend-1.backend'

--- a/modules/govuk/manifests/node/s_asset_slave.pp
+++ b/modules/govuk/manifests/node/s_asset_slave.pp
@@ -96,7 +96,7 @@ class govuk::node::s_asset_slave (
     }
   }
 
-  $master_metrics_hostname = regsubst($::fqdn_metrics, 'slave', 'master')
+  $master_metrics_hostname = regsubst($::fqdn_metrics, 'slave-\d', 'master-1')
   $graphite_mnt_uploads_metric = 'df-mnt-uploads.df_complex-used'
   $master_metric = "${master_metrics_hostname}.${graphite_mnt_uploads_metric}"
   $slave_metric = "${::fqdn_metrics}.${graphite_mnt_uploads_metric}"


### PR DESCRIPTION
The data sync for attachments from production to integration has happened between these times for the last 4 days:

- 10:49 to 10:58
- 10:45 to 10:56
- 10:37 to 10:46
- 10:41 to 10:49

We want this final rsync of attachments to run after the data sync so that the number of alerts in integration is minimised. This commit will make it run between 1100 and 1200 so it should only alert for a few minutes in integration.