### PR TITLE
Export the `reload_service` Icinga plugin

### DIFF
--- a/modules/icinga/manifests/client.pp
+++ b/modules/icinga/manifests/client.pp
@@ -44,4 +44,5 @@ class icinga::client {
 
   Icinga::Nrpe_config <| |>
   Icinga::Plugin <| |>
+  Icinga::Plugin <<| |>>
 }

--- a/modules/monitoring/manifests/event_handler/app_high_memory.pp
+++ b/modules/monitoring/manifests/event_handler/app_high_memory.pp
@@ -10,13 +10,13 @@ class monitoring::event_handler::app_high_memory () {
     require => File['/usr/local/bin/event_handlers/govuk_app_high_memory.sh'],
   }
 
-  @icinga::plugin { 'reload_service':
-    source => 'puppet:///modules/monitoring/usr/lib/nagios/plugins/reload_service',
-  }
-
   file { '/usr/local/bin/event_handlers/govuk_app_high_memory.sh':
     source => 'puppet:///modules/govuk/usr/local/bin/event_handlers/govuk_app_high_memory.sh',
     mode   => '0755',
+  }
+
+  @@icinga::plugin { 'reload_service':
+    source => 'puppet:///modules/monitoring/usr/lib/nagios/plugins/reload_service',
   }
 
 }


### PR DESCRIPTION
Story: https://trello.com/c/8U5ou5rr/77-gracefully-kill-unicorn-workers-if-they-use-too-much-ram

The `reload_service` plugin needs to be installed on every machine, so
make it an exported resource that's collected by the `icinga::client`
class.