### PR TITLE
Add ASSET_MANAGER_BEARER_TOKEN to Service Manual Publisher

### DIFF
--- a/modules/govuk/manifests/apps/service_manual_publisher.pp
+++ b/modules/govuk/manifests/apps/service_manual_publisher.pp
@@ -39,6 +39,10 @@
 #   The bearer token to use when communicating with Publishing API.
 #   Default: undef
 #
+# [*asset_manager_bearer_token*]
+#   The bearer token to use when communicating with Asset Manager.
+#   Default: undef
+#
 class govuk::apps::service_manual_publisher(
   $db_hostname = 'postgresql-primary-1.backend',
   $db_name = 'service-manual-publisher_production',
@@ -51,6 +55,7 @@ class govuk::apps::service_manual_publisher(
   $secret_key_base = undef,
   $disable_publishing = false,
   $publishing_api_bearer_token = undef,
+  $asset_manager_bearer_token = undef,
 ) {
 
   include govuk_postgresql::client #installs libpq-dev package needed for pg gem
@@ -81,6 +86,9 @@ class govuk::apps::service_manual_publisher(
     "${title}-PUBLISHING_API_BEARER_TOKEN":
       varname => 'PUBLISHING_API_BEARER_TOKEN',
       value   => $publishing_api_bearer_token;
+    "${title}-ASSET_MANAGER_BEARER_TOKEN":
+      varname => 'ASSET_MANAGER_BEARER_TOKEN',
+      value   => $asset_manager_bearer_token;
   }
 
   if $disable_publishing {


### PR DESCRIPTION
As of [1] Service Manual Publisher uses asset manager to upload images. A
bearer token [2] is required to use the API.

I've chatted to @dsingleton on slack and he mentioned more work needs to be done in the private repo to encrypt the token and pass it to puppet. I don't have access to that repo so I'll ask someone from 2ndline to help me when I'm back in the office.

[1] - https://github.com/alphagov/service-manual-publisher/pull/129
[2] - https://github.com/alphagov/service-manual-publisher/blob/tt_image_uploads/config/initializers/asset_manager.rb#L6