### PR TITLE
Remove users

### DIFF
--- a/modules/users/manifests/chrisroos.pp
+++ b/modules/users/manifests/chrisroos.pp
@@ -1,8 +1,0 @@
-# Creates the chrisroos user
-class users::chrisroos {
-  govuk::user { 'chrisroos':
-    fullname => 'Chris Roos',
-    email    => 'chris.roos@digital.cabinet-office.gov.uk',
-    ssh_key  => 'ssh-rsa REPLACE ME',
-  }
-}

--- a/modules/users/manifests/gemmaleigh.pp
+++ b/modules/users/manifests/gemmaleigh.pp
@@ -1,8 +1,0 @@
-# Creates the gemmaleigh user
-class users::gemmaleigh {
-  govuk::user { 'gemmaleigh':
-    fullname => 'Gemma Leigh',
-    email    => 'gemma.leigh@digital.cabinet-office.gov.uk',
-    ssh_key  => 'ssh-rsa REPLACE ME',
-  }
-}

--- a/modules/users/manifests/jamesmead.pp
+++ b/modules/users/manifests/jamesmead.pp
@@ -1,8 +1,0 @@
-# Creates the jamesmead user
-class users::jamesmead {
-  govuk::user { 'jamesmead':
-    fullname => 'James Mead',
-    email    => 'james.mead@digital.cabinet-office.gov.uk',
-    ssh_key  => 'ssh-rsa REPLACE ME',
-  }
-}

--- a/modules/users/manifests/joshmyers.pp
+++ b/modules/users/manifests/joshmyers.pp
@@ -1,8 +1,0 @@
-# Creates the joshmyers user
-class users::joshmyers {
-  govuk::user { 'joshmyers':
-    fullname => 'Josh Myers',
-    email    => 'josh.myers@digital.cabinet-office.gov.uk',
-    ssh_key  => 'ssh-rsa REPLACE ME',
-  }
-}

--- a/modules/users/manifests/leelongmore.pp
+++ b/modules/users/manifests/leelongmore.pp
@@ -1,8 +1,0 @@
-# Creates the leelongmore user
-class users::leelongmore {
-  govuk::user { 'leelongmore':
-    fullname => 'Lee Longmore',
-    email    => 'lee.longmore@digital.cabinet-office.gov.uk',
-    ssh_key  => 'ssh-rsa REPLACE ME',
-  }
-}

--- a/modules/users/manifests/marksheldon.pp
+++ b/modules/users/manifests/marksheldon.pp
@@ -1,8 +1,0 @@
-# Creates the marksheldon user
-class users::marksheldon {
-  govuk::user { 'marksheldon':
-    fullname => 'Mark Sheldon',
-    email    => 'mark.sheldon@digital.cabinet-office.gov.uk',
-    ssh_key  => 'ssh-rsa REPLACE ME',
-  }
-}

--- a/modules/users/manifests/stephenrichards.pp
+++ b/modules/users/manifests/stephenrichards.pp
@@ -1,8 +1,0 @@
-# Creates the stephenrichards user
-class users::stephenrichards {
-  govuk::user { 'stephenrichards':
-    fullname => 'Stephen Richards',
-    email    => 'stephen.richards@digital.cabinet-office.gov.uk',
-    ssh_key  => 'ssh-rsa REPLACE ME',
-  }
-}

--- a/modules/users/manifests/tijmenbrommet.pp
+++ b/modules/users/manifests/tijmenbrommet.pp
@@ -1,8 +1,0 @@
-# Creates the tijmenbrommet user
-class users::tijmenbrommet {
-  govuk::user { 'tijmenbrommet':
-    fullname => 'Tijmen Brommet',
-    email    => 'tijmen.brommet@digital.cabinet-office.gov.uk',
-    ssh_key  => 'ssh-rsa REPLACE ME',
-  }
-}

--- a/modules/users/manifests/timothymower.pp
+++ b/modules/users/manifests/timothymower.pp
@@ -1,8 +1,0 @@
-# Creates the timothymower user
-class users::timothymower {
-  govuk::user { 'timothymower':
-    fullname => 'Timothy Mower',
-    email    => 'timothy.mower@digital.cabinet-office.gov.uk',
-    ssh_key  => 'ssh-rsa REPLACE ME',
-  }
-}


### PR DESCRIPTION
For various reasons, e.g. annual leave, these users are unable to rotate
their SSH key immediately (as mitigation against CVE-2016-0777).

Until they are able to rotate their keys, we may as well remove their
users (rather than have a public key of `REPLACE ME`).

* * *

Also, remove users that have left GOV.UK.