### PR TITLE
Set bearer token for pp-big-screen-view.

### DIFF
--- a/modules/govuk/manifests/apps/performanceplatform_big_screen_view.pp
+++ b/modules/govuk/manifests/apps/performanceplatform_big_screen_view.pp
@@ -9,8 +9,13 @@
 #   Whether the app is enabled.
 #   Default: true
 #
+# [*publishing_api_bearer_token*]
+#   The bearer token to use when communicating with Publishing API.
+#   Default: undef
+#
 class govuk::apps::performanceplatform_big_screen_view (
   $enabled = false,
+  $publishing_api_bearer_token = undef,
 ) {
   include govuk::deploy
 
@@ -28,6 +33,19 @@ class govuk::apps::performanceplatform_big_screen_view (
       vhost           => $vhost_full,
       ssl_only        => true,
       app_port        => 3058,
+    }
+    # Since this is not a full app, we need to ensure env dir exists.
+    file { ["/etc/govuk/${app_name}", "/etc/govuk/${app_name}/env.d"]:
+      ensure  => 'directory',
+      purge   => true,
+      recurse => true,
+      force   => true,
+    }
+    govuk::app::envvar { "${app_name}-PUBLISHING_API_BEARER_TOKEN":
+      app            => $app_name,
+      varname        => 'PUBLISHING_API_BEARER_TOKEN',
+      value          => $publishing_api_bearer_token,
+      notify_service => false,
     }
   }
 }


### PR DESCRIPTION
Since this does not use the govuk::app class, we need to set create the env dir explicitly.