### PR TITLE
Monitor disk space on mirror machines

### DIFF
--- a/modules/monitoring/manifests/checks/mirror.pp
+++ b/modules/monitoring/manifests/checks/mirror.pp
@@ -20,6 +20,12 @@ class monitoring::checks::mirror (
     $provider1_subdomain = 'mirror.provider1.production.govuk.service.gov.uk'
     $provider0_vhost     = "www-origin.${provider0_subdomain}"
     $provider1_vhost     = "www-origin.${provider1_subdomain}"
+    
+    icinga::host { "mirror0.${provider0_subdomain}":
+      host_name => 'mirror0.provider0',
+      hostalias => "mirror0.${provider0_subdomain}",
+      address   => "mirror0.${provider0_subdomain}",
+    }
 
     icinga::check { 'check_mirror0_provider0_up_to_date':
       check_command       => "check_mirror_age!mirror0.${provider0_subdomain}!${provider0_vhost}",
@@ -43,6 +49,84 @@ class monitoring::checks::mirror (
       check_command       => "check_mirror_age!mirror1.${provider1_subdomain}!${provider1_vhost}",
       host_name           => $::fqdn,
       service_description => 'mirror1.provider1 site out of date',
+    }
+
+    icinga::host { "mirror1.${provider0_subdomain}":
+      host_name => 'mirror1.provider0',
+      hostalias => "mirror1.${provider0_subdomain}",
+      address   => "mirror1.${provider0_subdomain}",
+    }
+
+    icinga::host { "mirror0.${provider1_subdomain}":
+      host_name => 'mirror0.provider1',
+      hostalias => "mirror0.${provider1_subdomain}",
+      address   => "mirror0.${provider1_subdomain}",
+    }
+
+    icinga::host { "mirror1.${provider1_subdomain}":
+      host_name => 'mirror1.provider1',
+      hostalias => "mirror1.${provider1_subdomain}",
+      address   => "mirror1.${provider1_subdomain}",
+    }
+
+    icinga::check { 'check_mirror0_provider0_disk':
+      check_command       => 'check_nrpe_1arg!check_disk',
+      service_description => 'low available disk space',
+      use                 => 'govuk_high_priority',
+      host_name           => "mirror0.${provider0_subdomain}",
+      require             => Icinga::Host["mirror0.${provider0_subdomain}"],
+    }
+
+    icinga::check { 'check_mirror1_provider0_disk':
+      check_command       => 'check_nrpe_1arg!check_disk',
+      service_description => 'low available disk space',
+      use                 => 'govuk_high_priority',
+      host_name           => "mirror1.${provider0_subdomain}",
+      require             => Icinga::Host["mirror1.${provider0_subdomain}"],
+    }
+
+    icinga::check { 'check_mirror0_provider1_disk':
+      check_command       => 'check_nrpe_1arg!check_disk',
+      service_description => 'low available disk space',
+      use                 => 'govuk_high_priority',
+      host_name           => "mirror0.${provider1_subdomain}",
+      require             => Icinga::Host["mirror0.${provider1_subdomain}"],
+    }
+
+    icinga::check { 'check_mirror1_provider1_disk':
+      check_command       => 'check_nrpe_1arg!check_disk',
+      service_description => 'low available disk space',
+      use                 => 'govuk_high_priority',
+      host_name           => "mirror1.${provider1_subdomain}",
+      require             => Icinga::Host["mirror1.${provider1_subdomain}"],
+    }
+
+    icinga::check { 'check_mirror0_provider0_disk_mirror-data':
+      check_command       => 'check_nrpe_1arg!check_disk_mirror-data',
+      service_description => 'low available disk space on /srv/mirror_data',
+      use                 => 'govuk_high_priority',
+      host_name           => "mirror0.${provider0_subdomain}",
+    }
+
+    icinga::check { 'check_mirror1_provider0_disk_mirror-data':
+      check_command       => 'check_nrpe_1arg!check_disk_mirror-data',
+      service_description => 'low available disk space on /srv/mirror_data',
+      use                 => 'govuk_high_priority',
+      host_name           => "mirror1.${provider0_subdomain}",
+    }
+
+    icinga::check { 'check_mirror0_provider1_disk_mirror-data':
+      check_command       => 'check_nrpe_1arg!check_disk_mirror-data',
+      service_description => 'low available disk space on /srv/mirror_data',
+      use                 => 'govuk_high_priority',
+      host_name           => "mirror0.${provider1_subdomain}",
+    }
+
+    icinga::check { 'check_mirror1_provider1_disk_mirror-data':
+      check_command       => 'check_nrpe_1arg!check_disk_mirror-data',
+      service_description => 'low available disk space on /srv/mirror_data',
+      use                 => 'govuk_high_priority',
+      host_name           => "mirror1.${provider1_subdomain}",
     }
   }
 }


### PR DESCRIPTION
Story: https://trello.com/b/5IG9uHUg/gov-uk-2nd-line

__Depends on https://github.com/alphagov/govuk_mirror-puppet/pull/86__

Add Icinga checks for disk space on:

- all filesystems
- the filesystem mounted at `/srv/mirror-data`

...on our off-site mirrors. These disk checks follow the same pattern as
our other disk space checks, in that they have a general check for all
filesystems and a specific check for each mountpoint of interest.

I've also added `Icinga::Host` resources necessary for these checks to
work.

There's quite a lot of duplication here but I'd rather refactor
that separately as I'm on Second Line and otherwise might not get this
story finished in time before I rotate off.