### PR TITLE
Update default execution_failure_criteria

### DIFF
--- a/modules/icinga/manifests/service_dependency.pp
+++ b/modules/icinga/manifests/service_dependency.pp
@@ -29,7 +29,7 @@
 # [*execution_failure_criteria*]
 #   A comma-seperated set of criteria that determine what state the service is
 #   in for how actively the dependent service is checked.
-#   Default: 'n': none (services are always checked)
+#   Default: 'w,c': warning state, critical state
 #
 # [*notifcation_failure_criteria*]
 #   A comma-seperated set of criteria that determines when notifcations should
@@ -41,7 +41,7 @@ define icinga::service_dependency (
   $host_name                      = undef,
   $service_description            = undef,
   $dependent_service_description  = undef,
-  $execution_failure_criteria     = 'n',
+  $execution_failure_criteria     = 'w,c',
   $notification_failure_criteria  = 'w,c',
 ) {
 


### PR DESCRIPTION
This changes the default behaviour so that if the master service is either warning or critical, then active checks are disabled for the dependent services.

This is changed from just notification behaviour previously, so even if a master service was warning or critical, the Icinga dashboard was still spammed with alerts that we did not want to see, but notifications (i.e sending out emails) were disabled.