### PR TITLE
Use the current version of puppet-syntax

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,7 +25,7 @@ GEM
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
-    facter (2.2.0)
+    facter (2.4.4)
       CFPropertyList (~> 2.2.6)
     faraday (0.9.0)
       multipart-post (>= 1.2, < 3)
@@ -44,7 +44,7 @@ GEM
     highline (1.6.21)
     i18n (0.6.11)
     json (1.8.1)
-    json_pure (1.8.1)
+    json_pure (1.8.3)
     librarian (0.1.2)
       highline
       thor (~> 0.15)
@@ -68,8 +68,7 @@ GEM
       json_pure
       rgen (~> 0.6.5)
     puppet-lint (1.0.1)
-    puppet-syntax (1.1.1)
-      puppet (>= 2.7.0)
+    puppet-syntax (2.1.0)
       rake
     puppet_forge (1.0.3)
       her (~> 0.6)
@@ -78,7 +77,7 @@ GEM
       rake
       rspec (>= 2.9.0)
       rspec-puppet (>= 0.1.1)
-    rake (10.1.0)
+    rake (10.5.0)
     rgen (0.6.6)
     rspec (3.3.0)
       rspec-core (~> 3.3.0)


### PR DESCRIPTION
We should be testing our own code. The other updates are from the
bundle update puppet-syntax command and seem to cause no issues when
running tests.