### PR TITLE
Use capitalised first letter in 'Process'

### DIFF
--- a/modules/govuk/templates/node/s_asset_base/process-uploaded-attachments.sh
+++ b/modules/govuk/templates/node/s_asset_base/process-uploaded-attachments.sh
@@ -51,7 +51,7 @@ CODE=0
 OUTPUT="Last run status processing $INCOMING_DIR"
 
 # Send a passive check to check the freshness threshold
-printf "<%= @ipaddress %>\tprocess attachments last run\t$CODE\t$OUTPUT\n" | /usr/sbin/send_nsca -H alert.cluster >/dev/null
+printf "<%= @ipaddress %>\tProcess attachments last run\t$CODE\t$OUTPUT\n" | /usr/sbin/send_nsca -H alert.cluster >/dev/null
 
 # Clean up empty directories in `incoming` which have not been modified recently.
 find "$INCOMING_DIR" -mindepth 1 -type d -mmin +10 -empty -delete


### PR DESCRIPTION
...so that the service description matches the service description in
the Icinga check. These descriptions are case sensitive, so we'll see
false freshness alerts for this check if they don't match case.

From:
http://docs.icinga.org/latest/en/nsca.html

> Host name (and service description, if applicable) are case sensitive
> and have to match the definition in Icinga.