### PR TITLE
Allow Rummager to listen to RabbitMQ messages

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -221,6 +221,11 @@ govuk::apps::panopticon::rabbitmq_hosts:
   - rabbitmq-2.backend
   - rabbitmq-3.backend
 
+govuk::apps::rummager::rabbitmq_hosts:
+  - rabbitmq-1.backend
+  - rabbitmq-2.backend
+  - rabbitmq-3.backend
+
 govuk::apps::licencefinder::mongodb_nodes:
   - 'mongo-1.backend'
   - 'mongo-2.backend'

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -162,6 +162,7 @@ govuk::apps::router_api::mongodb_nodes: ['localhost']
 govuk::apps::router_api::router_nodes: ['localhost:3055']
 govuk::apps::router_api::vhost: 'router-api'
 govuk::apps::rummager::enable_procfile_worker: false
+govuk::apps::rummager::rabbitmq_hosts: ['localhost']
 govuk::apps::signon::enable_procfile_worker: false
 govuk::apps::signon::redis_url: redis://localhost:6379/0
 govuk::apps::smartanswers::expose_govspeak: true

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -20,6 +20,7 @@ govuk::apps::event_store::enabled: true
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
 govuk::apps::mapit::enabled: true
 govuk::apps::publicapi::backdrop_host: 'www.preview.performance.service.gov.uk'
+govuk::apps::rummager::enable_publishing_api_document_indexer: true
 govuk::apps::signon::enable_logstream: true
 govuk::apps::smartanswers::expose_govspeak: true
 govuk::apps::specialist_publisher::publish_pre_production_finders: true


### PR DESCRIPTION
Currently, changes to topics and other tags in content-tagger don't cause the search index (accessed via rummager) to be updated correspondingly. We want such changes to be reflected as soon as possible in the search index.

This change adds rabbitMQ settings to rummager

Part of: https://trello.com/c/lRnxI2x5/472-make-rummager-index-the-tags-in-the-links-hash