### PR TITLE
Let the Departmental Projects contractors access Integration Jenkins

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -50,6 +50,7 @@ govuk_jenkins::config::admins:
   - bradleywright
   - brendanbutler
   - chrispatuzzo
+  - christophwong
   - ci_alphagov
   - danielroseman
   - davidbasalla
@@ -72,6 +73,7 @@ govuk_jenkins::config::admins:
   - paulmartin
   - richardboulton
   - rosafox
+  - seemasatish
   - stevelaing
   - stuartgale
   - tadast


### PR DESCRIPTION
- Christoph and Seema didn't have access to see anything on the Integration Deploy Jenkins.