### PR TITLE
Add UFW rule for asset slave using NFS

### DIFF
--- a/hieradata/class/asset_master.yaml
+++ b/hieradata/class/asset_master.yaml
@@ -1,5 +1,11 @@
 ---
 
+govuk::node::s_asset_master::asset_slave_ip_ranges:
+  asset_slave_1_nfs:
+    from: "%{hiera('environment_ip_prefix')}.3.21"
+  asset_slave_2_nfs:
+    from: "%{hiera('environment_ip_prefix')}.11.21"
+
 govuk::safe_to_reboot::can_reboot: 'no'
 govuk::safe_to_reboot::reason: 'Mounted by backend machines, causes attachment delivery failures'
 

--- a/modules/govuk/manifests/node/s_asset_master.pp
+++ b/modules/govuk/manifests/node/s_asset_master.pp
@@ -8,11 +8,17 @@
 #   This specifies the hour at which the full daily sync should
 #   occur.
 #
+# [*asset_slave_ip_ranges*]
+#   A hash of IP addresses that the asset slave machines run on.
+#
 class govuk::node::s_asset_master (
   $copy_attachments_hour = 4,
+  $asset_slave_ip_ranges = {},
 ) inherits govuk::node::s_asset_base {
 
   include assets::ssh_private_key
+
+  create_resources('ufw::allow', $asset_slave_ip_ranges)
 
   file { '/var/run/virus_scan':
     ensure => directory,


### PR DESCRIPTION
The asset slave machines need to connect to the asset master using NFS.

asset-slave-1 is currently allowed to connect because of the broad rule in `s_asset_base` which allows all backend machines to connect to the asset-master.

I'd rather not extend that broad rule to include asset-slave-2 (running on a different IP range in the disaster recovery organisation) so instead I've set up new UFW rules which are different:

- They only apply to the asset_master rather than the asset_base class
- They're explicit about being for the asset_slave only

In an ideal world I'd like to limit these rules by port number too, but I don't know enough about what ports NFS uses (it seems to use lots of high numbered ports).