### PR TITLE
Add HTML verification page for DWP YouTube channel

### DIFF
--- a/modules/router/templates/router_include.conf.erb
+++ b/modules/router/templates/router_include.conf.erb
@@ -61,6 +61,12 @@ location / {
 
   <%- end -%>
 
+  # HTML verification for DWP YouTube channel
+  location = /dla-ending/google6db9c061ce178960.html {
+    add_header Content-Type text/html;
+    return 200 '';
+  }
+
   location /robots.txt {
     root /usr/share/nginx/www;
   }


### PR DESCRIPTION
Story:
https://trello.com/c/HfhQgKbR/18-youtube-verification-page-for-dwp
Zendesk ticket: https://govuk.zendesk.com/agent/tickets/1199172

The Department for Work and Pensions (DWP) have asked us to add a HTML
verification page so that YouTube will allow them to link to GOV.UK from
a YouTube video.

I don't yet have the content for the HTML verification page, so the file
I'm adding here is empty.

It seems a shame to have do to this in Puppet; ideally we'd have an
easier way of doing this. Doing it this way is preferable to DNS
verification as we'd have to request a DNS record change from JANET.