### PR TITLE
Add a jenkins job to run a rake task:

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -85,6 +85,7 @@ govuk_jenkins::config::admins:
 govuk_jenkins::job_builder::manage_jobs: true
 govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::data_sync_complete_integration
+  - govuk_jenkins::job::departmental_projects_publish_content_change
   - govuk_jenkins::job::deploy_app
   - govuk_jenkins::job::deploy_cdn
   - govuk_jenkins::job::deploy_licensify

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -91,6 +91,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::copy_data_to_staging
   - govuk_jenkins::job::copy_licensify_data_to_staging
   - govuk_jenkins::job::copy_sanitised_whitehall_database
+  - govuk_jenkins::job::departmental_projects_publish_content_change
   - govuk_jenkins::job::deploy_app
   - govuk_jenkins::job::deploy_cdn
   - govuk_jenkins::job::deploy_licensify

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -30,6 +30,7 @@ govuk_jenkins::config::manage_config: true
 govuk_jenkins::job_builder::manage_jobs: true
 govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::data_sync_complete_staging
+  - govuk_jenkins::job::departmental_projects_publish_content_change
   - govuk_jenkins::job::deploy_app
   - govuk_jenkins::job::deploy_cdn
   - govuk_jenkins::job::deploy_licensify

--- a/modules/govuk_jenkins/manifests/job/departmental_projects_publish_content_change.pp
+++ b/modules/govuk_jenkins/manifests/job/departmental_projects_publish_content_change.pp
@@ -1,0 +1,11 @@
+# == Class: govuk_jenkins::job::departmental_projects_publish_content_change
+#
+# Create a file on disk that can be parsed by jenkins-job-builder
+#
+class govuk_jenkins::job::departmental_projects_publish_content_change {
+  file { '/etc/jenkins_jobs/jobs/departmental_projects_publish_content_change.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/departmental_projects_publish_content_change.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+}

--- a/modules/govuk_jenkins/templates/jobs/departmental_projects_publish_content_change.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/departmental_projects_publish_content_change.yaml.erb
@@ -1,0 +1,27 @@
+---
+- scm:
+    name: dp_publish_content_change
+    scm:
+        - git:
+            url: https://github.gds/email-campaign/email-campaign-frontend
+            branches:
+              - master
+
+- job:
+    name: Departmental_projects_publish_content_change
+    display-name: Departmental_projects_publish_content_change
+    project-type: freestyle
+    description: "<p>Supports github publishing by running rake tasks to publish changed content</p>"
+    scm:
+      - dp_publish_content_change
+    logrotate:
+      artifactNumToKeep: 30
+    builders:
+        - shell: |
+            ssh deploy@email-campaign-frontend-1.frontend "cd /var/apps/email-campaign-frontend && govuk_setenv email-campaign-frontend bundle exec rake publish_content:draft_and_publish_all"
+    triggers:
+        - project: email-campaign-frontend
+          condition: 'SUCCESS'
+    wrappers:
+        - ansicolor:
+            colormap: xterm

--- a/modules/govuk_jenkins/templates/jobs/departmental_projects_publish_content_change.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/departmental_projects_publish_content_change.yaml.erb
@@ -19,9 +19,6 @@
     builders:
         - shell: |
             ssh deploy@email-campaign-frontend-1.frontend "cd /var/apps/email-campaign-frontend && govuk_setenv email-campaign-frontend bundle exec rake publish_content:draft_and_publish_all"
-    triggers:
-        - project: email-campaign-frontend
-          condition: 'SUCCESS'
     wrappers:
         - ansicolor:
             colormap: xterm


### PR DESCRIPTION
That will take content from yaml files in email-campaign-frontend repo and
move it to draft content store using publishing api

The job is configured to run after every push in the repo