### PR TITLE
Add matmoore to integration jenkins admins

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -65,6 +65,7 @@ govuk_jenkins::config::admins:
   - jennyduckett
   - leenagupte
   - mathildathompson
+  - matmoore
   - mattbostock
   - matteograssotti
   - murraysteele


### PR DESCRIPTION
Currently I have access to integration but not any of the jenkins
jobs that deploy to it :disappointed: 