### PR TITLE
Add a param to enable check_support_default_queue_size for the support app

### DIFF
--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -513,6 +513,7 @@ icinga::nginx::enable_basic_auth: false
 #Do not enable this without speaking to Brad first
 licensify::apps::licensing_web_forms::enabled: false
 
+monitoring::checks::enable_support_check: false
 monitoring::checks::ses::region: eu-west-1
 
 # FIXME: Remove this line to enable after testing completed in Integration

--- a/modules/monitoring/manifests/checks.pp
+++ b/modules/monitoring/manifests/checks.pp
@@ -10,9 +10,13 @@
 # [*http_password*]
 #   Password for $http_username
 #
+# [*enable_support_check*]
+#   Enable monitoring for check_support_default_queue_size
+#
 class monitoring::checks (
   $http_username = 'UNSET',
   $http_password = 'UNSET',
+  $enable_support_check = true,
 ) {
   include monitoring::checks::mirror
   include monitoring::checks::pingdom
@@ -94,15 +98,15 @@ class monitoring::checks (
   }
   # END signon
 
-  # START support
-  icinga::check::graphite { 'check_support_default_queue_size':
-    target    => 'stats.gauges.govuk.app.support.queues.default',
-    warning   => 10,
-    critical  => 20,
-    desc      => 'support app background processing: unexpectedly large default queue size',
-    host_name => $::fqdn,
+  if $enable_support_check {
+    icinga::check::graphite { 'check_support_default_queue_size':
+      target    => 'stats.gauges.govuk.app.support.queues.default',
+      warning   => 10,
+      critical  => 20,
+      desc      => 'support app background processing: unexpectedly large default queue size',
+      host_name => $::fqdn,
+    }
   }
-  # END support
 
   icinga::plugin { 'check_hsts_headers':
     source => 'puppet:///modules/monitoring/usr/lib/nagios/plugins/check_hsts_headers',


### PR DESCRIPTION
This functionality is never used in staging but is used in integration
and production so we want to gate its deployment by environment. Defaults to
true so only stage should see a change.