### PR TITLE
Add fields emitted by CDN logs monitor to logstash config

### DIFF
--- a/modules/govuk/files/node/s_logs_elasticsearch/logstash-template.json
+++ b/modules/govuk/files/node/s_logs_elasticsearch/logstash-template.json
@@ -65,6 +65,14 @@
             "parameters": {
               "index": "not_analyzed",
               "type": "object"
+            },
+            "cdn_backend": {
+              "index": "not_analyzed",
+              "type": "string"
+            },
+            "last_success": {
+              "type": "date",
+              "include_in_all": false
             }
           },
           "type": "object"


### PR DESCRIPTION
The `cdn_backend` field indicates which CDN backend handled the request, and
is one of a set of possible string values, so we don't want it analyzed
(it's similar to the `@tags` field).

The `last_success` field indicates the time at which we last recorded a
successful access to the resource.  This is populated only for records
which are reporting a failure of an access to a resource which has
previously been known to succeed.

It's a date, so it's good to tell elasticsearch this rather than rely on
it guessing correctly.