### PR TITLE
Add a jenkins job to publish existing content

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -86,6 +86,7 @@ govuk_jenkins::job_builder::manage_jobs: true
 govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::data_sync_complete_integration
   - govuk_jenkins::job::departmental_projects_publish_content_change
+  - govuk_jenkins::job::departmental_projects_publish_existing_content  
   - govuk_jenkins::job::deploy_app
   - govuk_jenkins::job::deploy_cdn
   - govuk_jenkins::job::deploy_licensify

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -92,6 +92,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::copy_licensify_data_to_staging
   - govuk_jenkins::job::copy_sanitised_whitehall_database
   - govuk_jenkins::job::departmental_projects_publish_content_change
+  - govuk_jenkins::job::departmental_projects_publish_existing_content
   - govuk_jenkins::job::deploy_app
   - govuk_jenkins::job::deploy_cdn
   - govuk_jenkins::job::deploy_licensify

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -31,6 +31,7 @@ govuk_jenkins::job_builder::manage_jobs: true
 govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::data_sync_complete_staging
   - govuk_jenkins::job::departmental_projects_publish_content_change
+  - govuk_jenkins::job::departmental_projects_publish_existing_content
   - govuk_jenkins::job::deploy_app
   - govuk_jenkins::job::deploy_cdn
   - govuk_jenkins::job::deploy_licensify

--- a/modules/govuk_jenkins/manifests/job/departmental_projects_publish_existing_content.pp
+++ b/modules/govuk_jenkins/manifests/job/departmental_projects_publish_existing_content.pp
@@ -1,0 +1,11 @@
+# == Class: govuk_jenkins::job::departmental_projects_publish_existing_content
+#
+# Create a file on disk that can be parsed by jenkins-job-builder
+#
+class govuk_jenkins::job::departmental_projects_publish_existing_content {
+  file { '/etc/jenkins_jobs/jobs/departmental_projects_publish_existing_content.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/departmental_projects_publish_existing_content.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+}

--- a/modules/govuk_jenkins/templates/jobs/departmental_projects_publish_existing_content.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/departmental_projects_publish_existing_content.yaml.erb
@@ -1,0 +1,24 @@
+---
+- scm:
+    name: dp_publish_existing_content
+    scm:
+        - git:
+            url: https://github.gds/email-campaign/email-campaign-frontend
+            branches:
+              - master
+
+- job:
+    name: Departmental_projects_publish_existing_content
+    display-name: Departmental_projects_publish_existing_content
+    project-type: freestyle
+    description: "<p>Publish content already on live site in content store</p>"
+    scm:
+      - dp_publish_existing_content
+    logrotate:
+      artifactNumToKeep: 30
+    builders:
+        - shell: |
+            ssh deploy@email-campaign-frontend-1.frontend "cd /var/apps/email-campaign-frontend && govuk_setenv email-campaign-frontend bundle exec rake publish_content:publish_existing_content"
+    wrappers:
+        - ansicolor:
+            colormap: xterm


### PR DESCRIPTION
Add a jenkins job to publish hardcoded content which is
currently on the site to content store.
Add job to envs - integration, staging and production.