### PR TITLE
Use publishing-api token on whitehall frontend.

### DIFF
--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -183,11 +183,11 @@ class govuk::apps::whitehall(
         varname => 'GOVUK_ASSET_ROOT',
         value   => "//whitehall-admin.${app_domain}";
     }
+  }
 
-    govuk::app::envvar { "${title}-PUBLISHING_API_BEARER_TOKEN":
-      app     => 'whitehall',
-      varname => 'PUBLISHING_API_BEARER_TOKEN',
-      value   => $publishing_api_bearer_token,
-    }
+  govuk::app::envvar { "${title}-PUBLISHING_API_BEARER_TOKEN":
+    app     => 'whitehall',
+    varname => 'PUBLISHING_API_BEARER_TOKEN',
+    value   => $publishing_api_bearer_token,
   }
 }


### PR DESCRIPTION
The deploy scripts run the publish_special_routes task on both admin and frontend machines, so the token needs to be present in both cases.