### PR TITLE
Ensure service is stopped before removing script

### DIFF
--- a/modules/govuk/manifests/procfile/worker.pp
+++ b/modules/govuk/manifests/procfile/worker.pp
@@ -54,11 +54,14 @@ define govuk::procfile::worker (
       }
     }
   } else {
-    service { $service_name:
-      ensure => false,
-    } ->
+    exec { "stop_service_${service_name}":
+      command => "service ${service_name} stop",
+      onlyif  => "service ${service_name} status | grep running",
+    }
+
     file { "/etc/init/${service_name}.conf":
-      ensure => absent,
+      ensure  => absent,
+      require => Exec["stop_service_${service_name}"],
     }
   }
 }


### PR DESCRIPTION
The ordering arrow (`->`) that we added previously will apply changes in this order:

1. `service` will schedule the stopping of the service. The scheduling will cause the service to be stopped at the end of this Puppet run.
2. `file` resource will remove the init file.
3. The stopped of the service that was scheduled in (1) will run and fail because the file resource has been removed.

Instead of doing that, we can run an `exec` to stop the service manually (but only if it's running) and then remove the file after that command has executed.