### PR TITLE
Government Frontend: Enable new-style logging

### DIFF
--- a/modules/govuk/manifests/apps/government_frontend.pp
+++ b/modules/govuk/manifests/apps/government_frontend.pp
@@ -23,7 +23,7 @@ class govuk::apps::government_frontend(
     port                  => $port,
     vhost_ssl_only        => true,
     health_check_path     => '/healthcheck',
-    log_format_is_json    => true,
+    legacy_logging        => false,
     asset_pipeline        => true,
     asset_pipeline_prefix => 'government-frontend',
     vhost                 => $vhost,


### PR DESCRIPTION
This updates the log collection to collect the application logs from
stdout and stderr instead of reading from logfiles that the app creates
itself.

Precedent: https://github.gds/gds/puppet/pull/3623