### PR TITLE
Add notification_period to icinga::host

### DIFF
--- a/modules/icinga/manifests/host.pp
+++ b/modules/icinga/manifests/host.pp
@@ -27,6 +27,10 @@
 #    for example a router. If the parent is down then it will be assumed that
 #    the child will also be down.
 #
+#  [*notification_period*]
+#    The icinga::timeperiod for when Icinga will send out notifications
+#    if this host is unavailable.
+#
 define icinga::host (
   $hostalias  = $::fqdn,
   $address    = $::ipaddress,
@@ -34,6 +38,7 @@ define icinga::host (
   $host_name  = $::fqdn,
   $display_name = $::fqdn_short,
   $parents = undef,
+  $notification_period = '24x7',
 ) {
 
   file {"/etc/icinga/conf.d/icinga_host_${title}":

--- a/modules/icinga/spec/defines/icinga__host_spec.rb
+++ b/modules/icinga/spec/defines/icinga__host_spec.rb
@@ -6,6 +6,8 @@ describe 'icinga::host', :type => :define do
   it { is_expected.to contain_file('/etc/icinga/conf.d/icinga_host_bruce-forsyth.cfg') }
   it { is_expected.to contain_file('/etc/icinga/conf.d/icinga_host_bruce-forsyth.cfg').without_content(/parents/) }
 
+  it { is_expected.to contain_file('/etc/icinga/conf.d/icinga_host_bruce-forsyth.cfg').with_content(/notification_period\s+24x7/) }
+
   context 'Host parents required' do
     let(:params) {{
       'parents' => 'vpn_gateway_test'

--- a/modules/icinga/templates/host.erb
+++ b/modules/icinga/templates/host.erb
@@ -1,11 +1,12 @@
 define host {
-        use          <%= @use %>
-        alias        <%= @hostalias %>
-        address      <%= @address %>
-        display_name <%= @display_name %>
-        host_name    <%= @hostalias %>
-        hostgroups   all
+        use                  <%= @use %>
+        alias                <%= @hostalias %>
+        address              <%= @address %>
+        display_name         <%= @display_name %>
+        host_name            <%= @hostalias %>
+        hostgroups           all
+        notification_period  <%= @notification_period %>
         <%- if @parents -%>
-        parents      <%= @parents %>
+        parents              <%= @parents %>
         <%- end -%>
 }

--- a/modules/monitoring/manifests/network_checks.pp
+++ b/modules/monitoring/manifests/network_checks.pp
@@ -12,10 +12,11 @@ define monitoring::network_checks (
   $address,
 ) {
     icinga::host { $title:
-      host_name    => $title,
-      hostalias    => $title,
-      address      => $address,
-      display_name => $title,
+      host_name           => $title,
+      hostalias           => $title,
+      address             => $address,
+      display_name        => $title,
+      notification_period => 'inoffice',
     }
 
     icinga::check { "check_ping_${title}":


### PR DESCRIPTION
We're using `icinga::host` to set up hosts for our VPN gateways, but we don't want the alerting for these to be as noisy as for normal hosts.

This commit allows us to set a notification_period on an Icinga host and makes sure that the VPN gateways only alert in office hours.