### PR TITLE
Purge dictionary packages

### DIFF
--- a/modules/govuk/manifests/node/s_development.pp
+++ b/modules/govuk/manifests/node/s_development.pp
@@ -149,7 +149,7 @@ class govuk::node::s_development (
 
   package {
     'sqlite3':        ensure => 'installed'; # gds-sso uses sqlite3 to run its test suite
-    'wbritish-small': ensure => installed;
+    'wbritish-small': ensure => purged; # FIXME: Remove once purged from most dev VMs
     'vegeta':         ensure => installed; # vegeta is used by the router test suite
     'mawk-1.3.4':     ensure => installed; # Provides /opt/mawk required by pre-transition-stats
   }

--- a/modules/govuk/manifests/node/s_ruby_app_server.pp
+++ b/modules/govuk/manifests/node/s_ruby_app_server.pp
@@ -8,9 +8,10 @@ class govuk::node::s_ruby_app_server {
   # which depends on ExecJS, depends on Node.js
   include nodejs
 
+  # FIXME: Remove once purged from production
   package {
-    'dictionaries-common': ensure => installed;
-    'wbritish-small':      ensure => installed;
-    'miscfiles':           ensure => installed;
+    'dictionaries-common': ensure => purged;
+    'wbritish-small':      ensure => purged;
+    'miscfiles':           ensure => purged;
   }
 }


### PR DESCRIPTION
These packages were added years ago with the following commit messages:

- Passphrase entropy checkign needs a dictionary.
- Add in missing dictionary pkg

However, dictionaries-common and miscfiles aren't installed on the dev VM so applications can't need them anymore.

wbritish-small is on the dev VM, but I would be surprised if we still needed it for anything.