### PR TITLE
Move non-creds from deployment hieradata

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -321,6 +321,12 @@ govuk_jenkins::config::github_api_uri: "%{hiera('govuk_jenkins::config::github_w
 govuk_jenkins::config::github_web_uri: "https://%{hiera('govuk_jenkins::github_enterprise_hostname')}"
 govuk_jenkins::job::deploy_app::app_domain: "%{hiera('app_domain')}"
 
+govuk_jenkins::job::smokey::auth_username: "%{hiera('http_username')}"
+govuk_jenkins::job::smokey::auth_password: "%{hiera('http_password')}"
+govuk_jenkins::job::smokey::smokey_bearer_token: "%{hiera('smokey_bearer_token')}"
+govuk_jenkins::job::smokey::signon_email: "%{hiera('smokey_signon_email')}"
+govuk_jenkins::job::smokey::signon_password: "%{hiera('smokey_signon_password')}"
+
 govuk_mysql::server::expire_log_days: 3
 govuk_mysql::server::monitoring::master::plaintext_mysql_password: "%{hiera('mysql_nagios')}"
 govuk_mysql::server::monitoring::slave::plaintext_mysql_password: "%{hiera('mysql_nagios')}"


### PR DESCRIPTION
These are stored in the deployment repo, but they're only hiera lookups so they can actually go in here.