### PR TITLE
Warn the user if it’s been > 3 days since a puppet run

### DIFF
--- a/modules/govuk/manifests/node/s_development.pp
+++ b/modules/govuk/manifests/node/s_development.pp
@@ -25,6 +25,7 @@ class govuk::node::s_development (
   include govuk_rabbitmq
   include redis
   include tmpreaper
+  include last_puppet_run
 
   include govuk::python
   include govuk::testing_tools

--- a/modules/govuk/manifests/node/s_development.pp
+++ b/modules/govuk/manifests/node/s_development.pp
@@ -16,16 +16,16 @@ class govuk::node::s_development (
   include golang
   include govuk_apt::disable_pipelining
   include govuk_mysql::libdev
+  include govuk_rabbitmq
   include hosts::development
   include imagemagick
+  include last_puppet_run
   include memcached
   include mongodb::server
   include mysql::client
   include nodejs
-  include govuk_rabbitmq
   include redis
   include tmpreaper
-  include last_puppet_run
 
   include govuk::python
   include govuk::testing_tools

--- a/modules/last_puppet_run/files/etc/profile.d/last_puppet_run.sh
+++ b/modules/last_puppet_run/files/etc/profile.d/last_puppet_run.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+last_run=`sudo stat -c %Y /var/lib/puppet/state/last_run_report.yaml`
+time_now=`date +%s`
+difference=$((time_now - last_run))
+three_days=259200
+
+if [ "$difference" -gt "$three_days" ]; then
+  yellow="\e[0;33m"
+  reset="\e[0m"
+
+  echo -e "${yellow}It has been more than 3 days since you last ran govuk_puppet.${reset}"
+fi

--- a/modules/last_puppet_run/manifests/init.pp
+++ b/modules/last_puppet_run/manifests/init.pp
@@ -1,0 +1,11 @@
+# == Class: last_puppet_run
+#
+# Checks to see if puppet has been run recently for use on a dev VM.
+#
+class last_puppet_run {
+  file { '/etc/profile.d/last_puppet_run.sh':
+    ensure => present,
+    mode   => '0755',
+    source => 'puppet:///modules/last_puppet_run/etc/profile.d/last_puppet_run.sh',
+  }
+}


### PR DESCRIPTION
I wrote a little script that warns the user if it's been more than 3 days since they last ran puppet. I'm not too familiar with puppet. Please could someone check that I've done things correctly, e.g. only including this module for use on the dev vm.