### PR TITLE
Update Staging daily cron hour

### DIFF
--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -3,6 +3,8 @@ app_domain: 'staging.publishing.service.gov.uk'
 
 base::supported_kernel::enabled: true
 
+cron::daily_hour: 6
+
 environment_ip_prefix: '10.2'
 
 govuk::apps::content_register::db::backend_ip_range: '10.2.3.0/24'

--- a/modules/cron/manifests/init.pp
+++ b/modules/cron/manifests/init.pp
@@ -14,11 +14,17 @@
 #   integer between 0 and 7 inclusive - 1 is Monday, 2 is Tuesday etc.)
 #   Default: 7 (Sunday)
 #
+# [*daily_hour*]
+#   The hour of the day to run cron.daily jobs (an integer between 0 - 23)
+#   Default: 5
+#
 class cron (
   $weekly_dow = 7,
+  $daily_hour = 5,
 ) {
 
   validate_integer($weekly_dow, 7, 0)
+  validate_integer($daily_hour, 23, 0)
 
   resources { 'cron':
     purge => true,

--- a/modules/cron/templates/etc/crontab.erb
+++ b/modules/cron/templates/etc/crontab.erb
@@ -9,7 +9,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 
 # m h dom mon dow user  command
 <%= @hourly_min %> *    * * *   root    cd / && run-parts --report /etc/cron.hourly
-<%= @daily_min %> 5    * * *   root    test -x /usr/sbin/anacron || ( cd / && run-parts --report /etc/cron.daily )
+<%= @daily_min %> <%= @daily_hour %>    * * *   root    test -x /usr/sbin/anacron || ( cd / && run-parts --report /etc/cron.daily )
 <%= @weekly_min %> 6    * * <%= @weekly_dow %>   root    test -x /usr/sbin/anacron || ( cd / && run-parts --report /etc/cron.weekly )
 <%= @monthly_min %> 6    1 * *   root    test -x /usr/sbin/anacron || ( cd / && run-parts --report /etc/cron.monthly )
 #


### PR DESCRIPTION
Interested to hear if changing the time of cron daily will cause any other problems elsewhere; it may also be worth setting this to late in the day/first thing in the morning in Integration as some of these tasks are missed due to the servers being shut down. 