### PR TITLE
Stop blacklisting `s_test` spec

### DIFF
--- a/lib/tasks/spec.rake
+++ b/lib/tasks/spec.rake
@@ -25,7 +25,6 @@ namespace :spec do
       postgresql_base
       redis_base
       ruby_app_server
-      test
       transition_postgresql_base
     )
 


### PR DESCRIPTION
The manifest that would try to be tested was removed in aab2c3b318b1df7f2a1f287edca0b468384c36e1.