### PR TITLE
Deprecate `govuk::node::s_ruby_app_server`

### DIFF
--- a/lib/tasks/spec.rake
+++ b/lib/tasks/spec.rake
@@ -20,11 +20,11 @@ namespace :spec do
     # machine classes, and therefore aren't intended to be instantiated directly.
     $nodes_spec_blacklist_classes = %w(
       api_postgresql_base
+      app_server
       asset_base
       base
       postgresql_base
       redis_base
-      ruby_app_server
       transition_postgresql_base
     )
 

--- a/modules/govuk/manifests/node/s_api.pp
+++ b/modules/govuk/manifests/node/s_api.pp
@@ -3,7 +3,7 @@
 class govuk::node::s_api inherits govuk::node::s_base {
   include nginx
 
-  include govuk::node::s_ruby_app_server
+  include govuk::node::s_app_server
 
   include govuk_postgresql::client
 

--- a/modules/govuk/manifests/node/s_app_server.pp
+++ b/modules/govuk/manifests/node/s_app_server.pp
@@ -1,5 +1,11 @@
-# FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
-class govuk::node::s_ruby_app_server {
+# == Class: govuk::node::s_app_server
+#
+# A class containing dependencies for application servers. This class
+# is deprecated; nothing new should be added to it and things should
+# be removed over time. The classes this includes and the packages it
+# installs are too broad.
+#
+class govuk::node::s_app_server {
   include govuk_mysql::libdev
   include govuk_rbenv::all
   include mysql::client

--- a/modules/govuk/manifests/node/s_backend.pp
+++ b/modules/govuk/manifests/node/s_backend.pp
@@ -4,7 +4,7 @@
 # publishing, administration and management applications.
 #
 class govuk::node::s_backend inherits govuk::node::s_base {
-  include govuk::node::s_ruby_app_server
+  include govuk::node::s_app_server
 
   limits::limits { 'root_nofile':
     ensure     => present,

--- a/modules/govuk/manifests/node/s_bouncer.pp
+++ b/modules/govuk/manifests/node/s_bouncer.pp
@@ -2,7 +2,7 @@
 class govuk::node::s_bouncer inherits govuk::node::s_base {
 
   include govuk_bouncer::gor
-  include govuk::node::s_ruby_app_server
+  include govuk::node::s_app_server
   include nginx
 
   @@icinga::check::graphite { "check_nginx_connections_writing_${::hostname}":

--- a/modules/govuk/manifests/node/s_cache.pp
+++ b/modules/govuk/manifests/node/s_cache.pp
@@ -85,7 +85,7 @@ class govuk::node::s_cache (
   }
 
   if $enable_authenticating_proxy {
-    include govuk::node::s_ruby_app_server
+    include govuk::node::s_app_server
     class { 'govuk::apps::authenticating_proxy':
       govuk_upstream_uri => 'http://localhost:3054',
     }

--- a/modules/govuk/manifests/node/s_calculators_frontend.pp
+++ b/modules/govuk/manifests/node/s_calculators_frontend.pp
@@ -1,6 +1,6 @@
 # FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
 class govuk::node::s_calculators_frontend inherits govuk::node::s_base {
-  include govuk::node::s_ruby_app_server
+  include govuk::node::s_app_server
 
   include nginx
 

--- a/modules/govuk/manifests/node/s_content_store.pp
+++ b/modules/govuk/manifests/node/s_content_store.pp
@@ -1,6 +1,6 @@
 # FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
 class govuk::node::s_content_store inherits govuk::node::s_base {
-  include govuk::node::s_ruby_app_server
+  include govuk::node::s_app_server
 
   include nginx
 

--- a/modules/govuk/manifests/node/s_efg_frontend.pp
+++ b/modules/govuk/manifests/node/s_efg_frontend.pp
@@ -1,6 +1,6 @@
 # FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
 class govuk::node::s_efg_frontend inherits govuk::node::s_base {
-  include govuk::node::s_ruby_app_server
+  include govuk::node::s_app_server
 
   include nginx
 }

--- a/modules/govuk/manifests/node/s_email_campaign_api.pp
+++ b/modules/govuk/manifests/node/s_email_campaign_api.pp
@@ -3,7 +3,7 @@
 # App server used for email-campaign app
 #
 class govuk::node::s_email_campaign_api inherits govuk::node::s_base {
-  include govuk::node::s_ruby_app_server
+  include govuk::node::s_app_server
 
   include nginx
 

--- a/modules/govuk/manifests/node/s_email_campaign_frontend.pp
+++ b/modules/govuk/manifests/node/s_email_campaign_frontend.pp
@@ -3,7 +3,7 @@
 # Frontend machines for email campaigns.
 #
 class govuk::node::s_email_campaign_frontend inherits govuk::node::s_base {
-  include govuk::node::s_ruby_app_server
+  include govuk::node::s_app_server
 
   include nginx
 

--- a/modules/govuk/manifests/node/s_exception_handler.pp
+++ b/modules/govuk/manifests/node/s_exception_handler.pp
@@ -4,7 +4,7 @@
 #
 class govuk::node::s_exception_handler inherits govuk::node::s_base {
   include mongodb::server
-  include govuk::node::s_ruby_app_server
+  include govuk::node::s_app_server
   include nginx
 
   Govuk::Mount['/var/lib/mongodb'] -> Class['mongodb::server']

--- a/modules/govuk/manifests/node/s_frontend.pp
+++ b/modules/govuk/manifests/node/s_frontend.pp
@@ -5,7 +5,7 @@
 #
 class govuk::node::s_frontend inherits govuk::node::s_base {
 
-  include govuk::node::s_ruby_app_server
+  include govuk::node::s_app_server
 
   include nginx
 

--- a/modules/govuk/manifests/node/s_logs_cdn.pp
+++ b/modules/govuk/manifests/node/s_logs_cdn.pp
@@ -1,5 +1,5 @@
 # FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
 class govuk::node::s_logs_cdn inherits govuk::node::s_base {
   include govuk_cdnlogs
-  include govuk::node::s_ruby_app_server
+  include govuk::node::s_app_server
 }

--- a/modules/govuk/manifests/node/s_router_backend.pp
+++ b/modules/govuk/manifests/node/s_router_backend.pp
@@ -5,7 +5,7 @@
 class govuk::node::s_router_backend inherits govuk::node::s_base {
   include mongodb::server
 
-  include govuk::node::s_ruby_app_server
+  include govuk::node::s_app_server
 
   include nginx
 

--- a/modules/govuk/manifests/node/s_search.pp
+++ b/modules/govuk/manifests/node/s_search.pp
@@ -3,7 +3,7 @@
 # Machines for running the search applications (initially rummager) in the api vDC
 #
 class govuk::node::s_search inherits govuk::node::s_base {
-  include govuk::node::s_ruby_app_server
+  include govuk::node::s_app_server
 
   include nginx
 

--- a/modules/govuk/manifests/node/s_whitehall_backend.pp
+++ b/modules/govuk/manifests/node/s_whitehall_backend.pp
@@ -3,7 +3,7 @@ class govuk::node::s_whitehall_backend (
   $sync_mirror = false
 ) inherits govuk::node::s_base {
 
-  include govuk::node::s_ruby_app_server
+  include govuk::node::s_app_server
   include nginx
 
   include imagemagick

--- a/modules/govuk/manifests/node/s_whitehall_frontend.pp
+++ b/modules/govuk/manifests/node/s_whitehall_frontend.pp
@@ -1,6 +1,6 @@
 # FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
 class govuk::node::s_whitehall_frontend inherits govuk::node::s_base {
-  include govuk::node::s_ruby_app_server
+  include govuk::node::s_app_server
   include nginx
 
   $app_domain = hiera('app_domain')


### PR DESCRIPTION
This class is not helpful. It's badly named because it includes lots of things which aren't required by Ruby app servers. We should stop using it.