### PR TITLE
Add a non-analyzed "path_exact" field in logstash

### DIFF
--- a/modules/govuk/files/node/s_logs_elasticsearch/logstash-template.json
+++ b/modules/govuk/files/node/s_logs_elasticsearch/logstash-template.json
@@ -73,6 +73,14 @@
             "last_success": {
               "type": "date",
               "include_in_all": false
+            },
+            "path": {
+              "type": "string",
+              "copy_to": "@fields.path_exact"
+            },
+            "path_exact": {
+              "index": "not_analyzed",
+              "type": "string"
             }
           },
           "type": "object"


### PR DESCRIPTION
The path field contains the path component of the URL.  It is currently
analyzed, which means that searches will match if any of the individual
paths in the search match.  (And that quotes can be used to make a
search which matches all URLs in which certain components occur in
order.)

This is useful, but we also sometimes want to do an exact match search
for a path.  This commit adds a "path_exact" field, which elasticsearch
will populate by copying the "path" field, but will not analyze, so
searches on it will be exact.

The `path_exact` field can then also be used in a "terms aggregation" to
display a list of the most frequent paths matching a query.  I want to
use this to make a dashboard of the most frequent paths which have
started returning 404s, but used to work.