### PR TITLE
Signon: Enable new-style logging

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -23,7 +23,6 @@ govuk::apps::mapit::enabled: true
 govuk::apps::publicapi::backdrop_host: 'www.preview.performance.service.gov.uk'
 govuk::apps::rummager::enable_publishing_api_document_indexer: true
 govuk::apps::share_sale_publisher::enabled: true
-govuk::apps::signon::enable_logstream: true
 govuk::apps::smartanswers::expose_govspeak: true
 govuk::apps::specialist_publisher::publish_pre_production_finders: true
 govuk::apps::sidekiq_monitoring::enabled: true

--- a/modules/govuk/manifests/apps/signon.pp
+++ b/modules/govuk/manifests/apps/signon.pp
@@ -27,14 +27,14 @@ class govuk::apps::signon(
   $app_name = 'signon'
 
   govuk::app { $app_name:
-    app_type           => 'rack',
-    port               => $port,
-    vhost_ssl_only     => true,
-    health_check_path  => '/users/sign_in',
-    legacy_logging     => false,
-    vhost_aliases      => ['signonotron'],
-    asset_pipeline     => true,
-    deny_framing       => true,
+    app_type          => 'rack',
+    port              => $port,
+    vhost_ssl_only    => true,
+    health_check_path => '/users/sign_in',
+    legacy_logging    => false,
+    vhost_aliases     => ['signonotron'],
+    asset_pipeline    => true,
+    deny_framing      => true,
   }
 
   Govuk::App::Envvar {

--- a/modules/govuk/manifests/apps/signon.pp
+++ b/modules/govuk/manifests/apps/signon.pp
@@ -22,15 +22,9 @@ class govuk::apps::signon(
   $port = '3016',
   $enable_procfile_worker = true,
   $devise_secret_key = undef,
-  $enable_logstream = false,
   $redis_url = undef,
 ) {
   $app_name = 'signon'
-
-  $ensure_logstream = $enable_logstream ? {
-    true  => 'present',
-    false => 'absent'
-  }
 
   govuk::app { $app_name:
     app_type           => 'rack',
@@ -39,7 +33,6 @@ class govuk::apps::signon(
     health_check_path  => '/users/sign_in',
     legacy_logging     => false,
     vhost_aliases      => ['signonotron'],
-    logstream          => $ensure_logstream,
     asset_pipeline     => true,
     deny_framing       => true,
   }

--- a/modules/govuk/manifests/apps/signon.pp
+++ b/modules/govuk/manifests/apps/signon.pp
@@ -37,7 +37,7 @@ class govuk::apps::signon(
     port               => $port,
     vhost_ssl_only     => true,
     health_check_path  => '/users/sign_in',
-    log_format_is_json => true,
+    legacy_logging     => false,
     vhost_aliases      => ['signonotron'],
     logstream          => $ensure_logstream,
     asset_pipeline     => true,


### PR DESCRIPTION
This updates the log collection to collect the application logs from
stdout and stderr instead of reading from logfiles that the app creates
itself.

To be deployed after https://github.com/alphagov/signonotron2/pull/464