### PR TITLE
Update daily hour for maintenance

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -8,6 +8,7 @@ backup::mysql::rotation_monthly: '28'
 base::supported_kernel::enabled: true
 
 cron::weekly_dow: 1
+cron::daily_hour: 6
 
 govuk::apps::email_alert_monitor::enabled: true
 govuk::apps::email_campaign_api::enable_procfile_worker: true


### PR DESCRIPTION
While machines are meant to boot up at 04:30, this seeks to ensure that daily tasks are always run if the machines take a while to come up.