### PR TITLE
Add leeway to rkhunter passive check

### DIFF
--- a/modules/rkhunter/manifests/monitoring.pp
+++ b/modules/rkhunter/manifests/monitoring.pp
@@ -52,8 +52,8 @@ class rkhunter::monitoring {
   @@icinga::passive_check { "check_rkhunter_${::hostname}":
     service_description => 'rkhunter warnings',
     host_name           => $::fqdn,
-    # 86400 seconds in a day, so 90000 seconds in 25 hours (cron should run daily)
-    freshness_threshold => 90000,
+    # 26 hours (cron should run daily, with some leeway)
+    freshness_threshold => 93600,
     notes_url           => monitoring_docs_url(rkhunter-warnings),
     require             => File['/etc/cron.daily/rkhunter-passive-check'],
   }


### PR DESCRIPTION
Currently 25 hours, but for whatever reason sometimes the job runs a little later than it should and creates a bunch of alerts which clog up our monitoring. While it's important to run, I think we're safe to
increase the freshness threshold on this alert.