### PR TITLE
Move seed-crawler cron to cron.daily

### DIFF
--- a/modules/govuk_crawler/manifests/init.pp
+++ b/modules/govuk_crawler/manifests/init.pp
@@ -182,14 +182,11 @@ class govuk_crawler(
     }
   }
 
-  cron { 'seed-crawler':
-    ensure      => $seed_ensure,
-    user        => $crawler_user,
-    hour        => 18,
-    minute      => 0,
-    environment => ['MAILTO=""'],
-    command     => "/usr/bin/setlock -n ${seeder_lock_path} ${seeder_script_wrapper_path}",
-    require     => [File[$seeder_script_wrapper_path], Package['daemontools']],
+  file { '/etc/cron.d/seed-crawler':
+    ensure  => $seed_ensure,
+    mode    => '0755',
+    content => template('govuk_crawler/seed-crawler-wrapper-cron.erb'),
+    require => [File[$seeder_script_wrapper_path], Package['daemontools']],
   }
 
   $sync_ensure = $sync_enable ? {

--- a/modules/govuk_crawler/spec/classes/govuk_crawler_spec.rb
+++ b/modules/govuk_crawler/spec/classes/govuk_crawler_spec.rb
@@ -26,7 +26,7 @@ describe 'govuk_crawler', :type => :class do
 
   describe "seed_enable" do
     context "false (default)" do
-      it { is_expected.to contain_cron('seed-crawler').with_ensure('absent') }
+      it { is_expected.to contain_file('/etc/cron.d/seed-crawler').with_ensure('absent') }
     end
 
     context "true" do
@@ -36,7 +36,7 @@ describe 'govuk_crawler', :type => :class do
         })
       }
 
-      it { is_expected.to contain_cron('seed-crawler').with_ensure('present') }
+      it { is_expected.to contain_file('/etc/cron.d/seed-crawler').with_ensure('present') }
     end
   end
 

--- a/modules/govuk_crawler/templates/seed-crawler-wrapper-cron.erb
+++ b/modules/govuk_crawler/templates/seed-crawler-wrapper-cron.erb
@@ -1,0 +1,1 @@
+0 6 * * * <%= @crawler_user %> /usr/bin/setlock -n <%= @seeder_lock_path %> <%= @seeder_script_wrapper_path %>


### PR DESCRIPTION
Cron.daily runs first thing in the morning, whereas before this ran at 6pm.

We have an alert to ensure this has been run in the last 24h which is
currently never be the case on Mondays, because integration is down over the
weekend.