### PR TITLE
Increase Postgres backup partitions

### DIFF
--- a/hieradata/class/postgresql_primary.yaml
+++ b/hieradata/class/postgresql_primary.yaml
@@ -11,7 +11,9 @@ govuk_postgresql::server::primary::slave_addresses:
 
 lv:
   postgresql:
-    pv: '/dev/sdb1'
+    pv:
+      - '/dev/sdb1'
+      - '/dev/sdd1'
     vg: 'backups'
   data:
     pv: '/dev/sdc1'


### PR DESCRIPTION
In both Production and Staging the partitions for Postgres backups are right on the edge of filling up in space, and presumably will continue to rise as time goes by.

This change seeks to double the size of the disks so we don't have to worry about this for a while.

Related to https://github.gds/gds/govuk-provisioning/pull/515