### PR TITLE
Tidy .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,6 @@
 .rspec
 # Written by Cap and read by puppet_config_version
 REVISION
-.vagrant
+/development/.vagrant
 /development/Vagrantfile.localconfig
 /gpg/random_seed

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,16 @@
+ # Used by Puppet Librarian
 .tmp/
 /vendor/modules/
+
 # Put "--profile" in a file called .rspec to get per-test timing results
 .rspec
+
 # Written by Cap and read by puppet_config_version
 REVISION
+
+# Used by Vagrant
 /development/.vagrant
 /development/Vagrantfile.localconfig
+
+# Used by Puppet Hiera eYAML GPG
 /gpg/random_seed

--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,5 @@
-*~
-.#*
-\#*
-.idea
-.project
 .tmp/
-/.bundle/
-/.gems/
-/build/
 /vendor/modules/
-.DS_Store
 # Put "--profile" in a file called .rspec to get per-test timing results
 .rspec
 # Written by Cap and read by puppet_config_version


### PR DESCRIPTION
The `.gitignore` file contains a number of files or directories that
are more appropriate in a user's global gitignore rather than in this
project-specific `.gitignore`.

For example, we are ignoring files generated by:

- bundler, depending on your configuration
- emacs
- geppeto (a Puppet IDE)
- rubygems
- IntelliJ
- `.DS_Store` files created by OS X

...and so on. Rather than clutter `.gitignore` with files specific to
each editor, leave it to developers to configure their global
`.gitignore`. This makes it easier for these files to be accidentally
committed, but then they could just as easily accidentally be committed
other repositories worked on by those users and maintaining `.gitignore`
files across all our repositories in this way is undesirable.