### PR TITLE
Move backup hour back

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -4,6 +4,7 @@ app_domain: 'integration.publishing.service.gov.uk'
 backup::mysql::rotation_daily: '2'
 backup::mysql::rotation_weekly: '6'
 backup::mysql::rotation_monthly: '28'
+backup::server::backup_hour: 8
 
 base::supported_kernel::enabled: true
 

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -1,6 +1,8 @@
 ---
 app_domain: 'staging.publishing.service.gov.uk'
 
+backup::server::backup_hour: 8
+
 base::supported_kernel::enabled: true
 
 cron::daily_hour: 6

--- a/modules/backup/manifests/server.pp
+++ b/modules/backup/manifests/server.pp
@@ -10,8 +10,13 @@
 #
 #   Default: ''
 #
+# [*backup_hour*]
+#   Specify when a backup should occur.
+#   Default: 7am
+#
 class backup::server (
   $backup_private_key = '',
+  $backup_hour = 7,
 ) {
 
   include backup::client
@@ -44,7 +49,7 @@ class backup::server (
   cron { 'cron_govuk-backup_daily':
     command => 'run-parts /etc/backup',
     user    => 'govuk-backup',
-    hour    => '7',
+    hour    => $backup_hour,
     minute  => '0',
   }
 


### PR DESCRIPTION
Due to the change in 0a82ba86220778486e9386dbc26ff094eeb6f2b0 the backup conflicted with the local backup task, so the backup wasn't pulled off the server.

I knew in my gut that the previous "simple change" would have knock-on effects somewhere. Perhaps it would be better to move the env-sync-and-backup task back, and add a lockfile to servers that are receiving the sync so they do not reboot (which is why I think the sync takes place at the time it does)? 