### PR TITLE
Restrict boto timeout/retry settings

### DIFF
--- a/modules/monitoring/files/etc/boto.cfg
+++ b/modules/monitoring/files/etc/boto.cfg
@@ -1,0 +1,3 @@
+[boto]
+http_socket_timeout = 5
+num_retries = 2

--- a/modules/monitoring/manifests/checks/ses.pp
+++ b/modules/monitoring/manifests/checks/ses.pp
@@ -36,6 +36,12 @@ class monitoring::checks::ses (
         provider => pip,
     }
 
+    file { '/etc/boto.cfg' :
+      ensure => present,
+      mode   => '0744',
+      source => 'puppet:///modules/monitoring/etc/boto.cfg'
+    }
+
     icinga::plugin { 'check_aws_quota':
         source  => 'puppet:///modules/monitoring/usr/lib/nagios/plugins/check_aws_quota',
         require => Package['boto']


### PR DESCRIPTION
This should change CRITICAL alerts to UNKNOWNs when we have issues talking to AWS.

We use boto for SES in the check_aws_quote icinga plugin.

By default boto is very patient - failed requests can be retried 5 times, and
the http socket timeout is a minute.

The check itself times out at a minute so we want to shorten this so that it
can be handled by the plugin itself. We already have a catch all exception
handler that reports the result as UNKNOWN.

https://trello.com/c/WYsEieXt/12-improve-amazon-web-services-aws-simple-email-service-ses-quota-alert