### PR TITLE
Set sudo to false for travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
-sudo: true
+sudo: false
 rvm:
   - 1.9.3
 install:


### PR DESCRIPTION
`bundler` fails to install `hiera-eyaml` on the precise image the non
container travis infrastructure uses by setting false we get the trusty
image which works.