### PR TITLE
Set up email alert monitoring in Icinga

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -96,6 +96,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::deploy_licensify
   - govuk_jenkins::job::deploy_puppet
   - govuk_jenkins::job::deploy_router_data
+  - govuk_jenkins::job::email_alert_check
   - govuk_jenkins::job::fetch_prototype_taxonomy_data
   - govuk_jenkins::job::gds_production_backup
   - govuk_jenkins::job::govuk_cdn_nightly_2xx_status_collection

--- a/modules/govuk_jenkins/manifests/job/email_alert_check.pp
+++ b/modules/govuk_jenkins/manifests/job/email_alert_check.pp
@@ -1,0 +1,44 @@
+# == Class: govuk_jenkins::job::email_alert_check
+#
+# Create a file on disk that can be parsed by jenkins-job-builder
+#
+# === Parameters
+#
+# [*google_oauth_credentials*]
+#   JSON blob with oauth credentials with access to the googleapi@ email account.
+#
+# [*google_client_id*]
+#   Google app client ID.
+#
+# [*google_client_secret*]
+#   Google app client secret.
+#
+# [*emails_that_should_receive_drug_alerts*]
+#   Email addresses subscribed to drug alerts.
+#
+class govuk_jenkins::job::email_alert_check (
+  $google_oauth_credentials = undef,
+  $google_client_id = undef,
+  $google_client_secret = undef,
+  $emails_that_should_receive_drug_alerts = undef,
+  $app_domain = hiera('app_domain'),
+) {
+
+  $check_name = 'email_alert_check'
+  $service_description = 'Email alert check'
+  $job_url = "https://deploy.${app_domain}/job/email-alert-check/"
+
+  file { '/etc/jenkins_jobs/jobs/email_alert_check.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/email_alert_check.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+
+  @@icinga::passive_check { "${check_name}_${::hostname}":
+    service_description => $service_description,
+    host_name           => $::fqdn,
+    freshness_threshold => 5400, # 90 minutes
+    action_url          => $job_url,
+    notes_url           => monitoring_docs_url(email-alerts),
+  }
+}

--- a/modules/govuk_jenkins/templates/jobs/email_alert_check.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/email_alert_check.yaml.erb
@@ -1,0 +1,55 @@
+---
+- scm:
+    name: email-alert-check
+    scm:
+        - git:
+            url: git@github.com:alphagov/email-alert-monitoring.git
+            branches:
+              - master
+
+- job:
+    name: email-alert-check
+    display-name: EmailAlertCheck
+    project-type: freestyle
+    description: "This job checks if email alerts have been emailed"
+    scm:
+      - email-alert-check
+    logrotate:
+        artifactNumToKeep: 100
+    triggers:
+        - timed: '21 * * * *' # every hour on the 21st minute
+    builders:
+        - shell: |
+            bundle install
+            bundle exec rake run
+    publishers:
+      - trigger-parameterized-builds:
+        - project: Success_Passive_Check
+          condition: 'SUCCESS'
+          predefined-parameters: |
+            NSCA_CHECK_DESCRIPTION=<%= @service_description %>
+            NSCA_OUTPUT=<%= @service_description %> success
+        - project: Failure_Passive_Check
+          condition: 'FAILED'
+          predefined-parameters: |
+            NSCA_CHECK_DESCRIPTION=<%= @service_description %>
+            NSCA_OUTPUT=<%= @service_description %> failed
+    wrappers:
+        - ansicolor:
+            colormap: xterm
+        - inject-passwords:
+            global: false
+            mask-password-params: true
+            job-passwords:
+              - name: GOOGLE_OAUTH_CREDENTIALS
+                password:
+                  '<%= @google_oauth_credentials %>'
+              - name: GOOGLE_CLIENT_ID
+                password:
+                  '<%= @google_client_id %>'
+              - name: GOOGLE_CLIENT_SECRET
+                password:
+                  '<%= @google_client_secret %>'
+              - name: EMAILS_THAT_SHOULD_RECEIVE_DRUG_ALERTS
+                password:
+                  '<%= @emails_that_should_receive_drug_alerts %>'


### PR DESCRIPTION
We want to verify that emails are sent for all [drug alerts and medical device alerts](https://www.gov.uk/drug-device-alerts).

This commit sets up a Jenkins job, which runs every hour. It also sets up a Icinga "passive alert", which will notify us if the job has not run successfully in the last hour and a half.

The jenkins job runs a script that actually checks if the emails have been sent: https://github.com/alphagov/email-alert-monitoring/pull/1

The code for the [tagging migration verifier](https://github.com/alphagov/govuk-puppet/blob/master/modules/govuk_jenkins/manifests/job/tagging_migration_check.pp) is used as an example for this PR.

We enable the alert only on production because only production sends out actual emails.

Trello: https://trello.com/c/GGGYpRXd
