### PR TITLE
Remove common_credentials Hiera layer

### DIFF
--- a/hiera.yml
+++ b/hiera.yml
@@ -6,7 +6,6 @@
   - '%{::environment}_credentials'
   - '%{::environment}'
   - 'common.%{::lsbdistcodename}'
-  - 'common_credentials'
   - 'common'
 :backends:
   - eyaml


### PR DESCRIPTION
We removed `common_credentials.yaml` in
https://github.gds/gds/deployment/commit/6dddd52f0ee84976e4e97e37449dc11b6cad338c

Our tooling for Hiera eYAML GPG (a Rakefile) does not support
encrypting credentials in `common_credentials.yaml`.

There are so few credentials in this file, we decided that it's simpler
to duplicate them between these environments than introduce additional
complexity in our tooling to handle this edge case. We should ideally
have as few credentials as possible shared between environments.