### PR TITLE
Keep CDN logs for only 30 days

### DIFF
--- a/modules/govuk_cdnlogs/spec/classes/govuk_cdnlogs_spec.rb
+++ b/modules/govuk_cdnlogs/spec/classes/govuk_cdnlogs_spec.rb
@@ -100,7 +100,7 @@ ruleset\(name="cdn-giraffe"\) \{
       end
       it 'should rotate daily' do
         is_expected.to contain_file('/etc/logrotate.d/cdnlogs')
-          .with_content(/rotate 365$/)
+          .with_content(/rotate 30$/)
       end
       it { is_expected.to contain_file('/etc/logrotate.cdn_logs_hourly.conf')
             .without_content(/rotate/) }

--- a/modules/govuk_cdnlogs/templates/etc/logrotate.d/cdnlogs.erb
+++ b/modules/govuk_cdnlogs/templates/etc/logrotate.d/cdnlogs.erb
@@ -9,7 +9,7 @@ to_rotate_daily.map { |name| "#{ @log_dir }/cdn-#{ name }.log" }.join("\n")
 -%>
 
 {
-  rotate 365
+  rotate 30
   daily
   dateext
   compress


### PR DESCRIPTION
**This change is raised as a direct result of a monitoring alert due to low disk space on logs-cdn-1**

We only need to keep CDN logs for 30 days at most (as confirmed by @daibach). This change updates the daily rotation period from 365 to 30 days to meet this demand.

This will change rotation from 365 daily to 30 daily for the following logs:

`cdn-assets.log`
`cdn-govuk.log`

As per the change @jennyd made in cf5a8e4e the `cdn-bouncer.log` are exempt from the daily rotation, and so are not affected by this change.

We also have quite a few logs within the `/mnt/logs_cdn/old` directory which, as the name suggests, are quite old:

paulmartin@production-logs-cdn-1:~$ ls /mnt/logs_cdn/old/ |wc -l
2068
paulmartin@production-logs-cdn-1:~$ du -sh /mnt/logs_cdn/old/
64G	/mnt/logs_cdn/old/

I would be interested to know what we should be doing with these logs as that'll help clear disk space if they are no longer needed.