### PR TITLE
Add AWS S3 key and secret for rummager

### DIFF
--- a/modules/govuk/manifests/apps/rummager.pp
+++ b/modules/govuk/manifests/apps/rummager.pp
@@ -25,6 +25,14 @@
 #   The bearer token to use when communicating with Publishing API.
 #   Default: undef
 #
+# [*aws_s3_key*]
+#   AWS access key for uploading API search index snapshots
+#   Default: undef
+#
+# [*aws_s3_secret*]
+#   AWS access secret for uploading API search index snapshots
+#   Default: undef
+#
 # [*rabbitmq_hosts*]
 #   RabbitMQ hosts to connect to.
 #   Default: localhost
@@ -42,6 +50,8 @@ class govuk::apps::rummager(
   $enable_procfile_worker = true,
   $enable_publishing_api_document_indexer = false,
   $publishing_api_bearer_token = undef,
+  $aws_s3_key = undef,
+  $aws_s3_secret = undef,
   $rabbitmq_hosts = ['localhost'],
   $rabbitmq_user = 'rummager',
   $rabbitmq_password = 'rummager',
@@ -103,5 +113,11 @@ class govuk::apps::rummager(
     "${title}-PUBLISHING_API_BEARER_TOKEN":
       varname => 'PUBLISHING_API_BEARER_TOKEN',
       value   => $publishing_api_bearer_token;
+    "${title}-AWS_S3_KEY":
+      varname => 'AWS_S3_KEY',
+      value   => $aws_s3_key;
+    "${title}-AWS_S3_SECRET":
+      varname => 'AWS_S3_SECRET',
+      value   => $aws_s3_secret;
   }
 }


### PR DESCRIPTION
Rummager is going to upload Elasticsearch snapshots to an Amazon Web Services
S3 bucket.

Ticket: 
https://trello.com/c/L8pivLjy/487-get-credentials-set-up-for-snapshot-restore