### PR TITLE
Elasticsearch needs a larger heapsize for rummager

### DIFF
--- a/modules/govuk/manifests/node/s_development.pp
+++ b/modules/govuk/manifests/node/s_development.pp
@@ -46,7 +46,7 @@ class govuk::node::s_development (
 
   class { 'govuk_elasticsearch':
     cluster_name       => 'govuk-development',
-    heap_size          => '256m',
+    heap_size          => '1024m',
     number_of_shards   => '1',
     number_of_replicas => '0',
     require            => Class['govuk_java::set_defaults'],


### PR DESCRIPTION
Increase to 1gb heap size for development.

With 256mb it can't handle the rummager integration tests.

I spoke to @rboulton about this and he suggested trying this. If it starts impacting performance of other apps on the dev VM we can revisit it.