### PR TITLE
Install Amazon AWS Elasticsearch plugin

### DIFF
--- a/modules/govuk/manifests/node/s_api_elasticsearch.pp
+++ b/modules/govuk/manifests/node/s_api_elasticsearch.pp
@@ -43,6 +43,11 @@ class govuk::node::s_api_elasticsearch inherits govuk::node::s_base {
     instances  => $::fqdn,
   }
 
+  elasticsearch::plugin { 'elasticsearch/elasticsearch-cloud-aws/2.4.2':
+    module_dir => 'cloud-aws',
+    instances  => $::fqdn,
+  }
+
   collectd::plugin::tcpconn { 'es-9200':
     incoming => 9200,
     outgoing => 9200,


### PR DESCRIPTION
Snapshot-restore is an elasticsearch feature which allows regular incremental
snapshots of the indexes to be taken, and stored in amazon S3.  We would like
to use this for disaster recovery, and also to make it easier to sync indexes
between environments and development machines.

Ticket:
https://trello.com/c/YAJY2zIl/359-implement-snapshot-restore-to-backup-elasticsearch-indexes

cc: @rboulton 