### PR TITLE
Fix bundle command for email alert check

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/email_alert_check.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/email_alert_check.yaml.erb
@@ -20,7 +20,7 @@
         - timed: '21 * * * *' # every hour on the 21st minute
     builders:
         - shell: |
-            bundle install
+            bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
             bundle exec rake run
     publishers:
       - trigger-parameterized-builds:


### PR DESCRIPTION
Running `bundle install` doesn't seem to work, because it tries to install the gem to a location it doesn't have permission to. Setting the path fixes this.

This is used by all [other jenkins jobs](https://github.com/alphagov/govuk-puppet/blob/321d0449b2e582252c080649c93650d2d1146a2f/modules/govuk_jenkins/templates/jobs/deploy_router_data.yaml.erb#L20) that run `bundle install`.

Trello: https://trello.com/c/GGGYpRXd