### PR TITLE
Pass the original request URL in a special header

### DIFF
--- a/modules/nginx/templates/etc/nginx/nginx.conf.erb
+++ b/modules/nginx/templates/etc/nginx/nginx.conf.erb
@@ -53,6 +53,7 @@ http {
                          '"http_referrer": "$http_referer", '
                          '"http_user_agent": "$http_user_agent", '
                          '"govuk_request_id": "$http_govuk_request_id", '
+                         '"govuk_original_url": "$http_govuk_original_url", '
                          '"varnish_id": "$http_x_varnish" } }';
 
     access_log  /var/log/nginx/access.log timed_combined;

--- a/modules/varnish/templates/default.vcl.erb
+++ b/modules/varnish/templates/default.vcl.erb
@@ -18,6 +18,8 @@ acl purge_acl {
 sub vcl_recv {
   unset req.http.GOVUK-Request-Id;
   set req.http.GOVUK-Request-Id = server.identity + "-" + req.xid;
+  unset req.http.GOVUK-Original-Url;
+  set req.http.GOVUK-Original-Url = req.url;
 
   set req.backend = upstream;
 


### PR DESCRIPTION
We want to be able to identify which pages depend on each of our apps,
so that we can ensure that architectural changes which aren't intended
to make any front-end visible changes do indeed work as expected.

Theoretically, this information is captured in the `govuk_request_id`
tag, which is set by varnish, and then passed through by
`gds_api_adapters` when one app calls another.  This information is all
in elasticsearch and accessible through Kibana, but to work out which
original URL caused a request we would need to perform a join in
elasticsearch between the log entry for the original request and the
internal request. Elasticsearch does have some limited support for
joins, but it is resource intensive to do and would require some
remodelling (ensuring that all entries with the same request_id get
routed to the same shard, etc).

Instead it's much easier to pass the original URL through to subsequent
calls in a special header, just like the request-id is sent.  This PR
makes varnish set the GOVUK-Original-Url header, and makes nginx log the
header to logstash.  Additional PRs will be required to make GDS API
adapters pass the header along to subsequent requests (updating its
railtie settings so that it works for all rails apps), and also to
configure non-rails apps to pass the header along.  All apps will need
to be bumped, too, but this can happen gradually - we'll start to get
useful information by just bumping a few.