### PR TITLE
Add Jenkins job to update CDN edge dictionaries

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -118,6 +118,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::transition_load_site_config
   - govuk_jenkins::job::transition_load_transition_stats_hits
   - govuk_jenkins::job::trigger_data_sync_complete
+  - govuk_jenkins::job::update_cdn_dictionaries
   - govuk_jenkins::job::whitehall_rebuild_elasticsearch_index
   - govuk_jenkins::job::whitehall_run_broken_link_checker
 

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -48,6 +48,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::smokey
   - govuk_jenkins::job::smokey_deploy
   - govuk_jenkins::job::tagging_migration_check
+  - govuk_jenkins::job::update_cdn_dictionaries
 
 govuk_jenkins::job_builder::environment: 'staging'
 

--- a/hieradata/vagrant.yaml
+++ b/hieradata/vagrant.yaml
@@ -120,6 +120,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::service_manual_rebuild_search_index
   - govuk_jenkins::job::smokey
   - govuk_jenkins::job::smokey_deploy
+  - govuk_jenkins::job::update_cdn_dictionaries
 govuk_jenkins::job_builder::environment: 'dev'
 
 govuk_jenkins::job::network_config_deploy::environments:

--- a/modules/govuk_jenkins/manifests/job/update_cdn_dictionaries.pp
+++ b/modules/govuk_jenkins/manifests/job/update_cdn_dictionaries.pp
@@ -1,0 +1,11 @@
+# == Class: govuk_jenkins::job::update_cdn_dictionaries
+#
+# Create a file on disk that can be parsed by jenkins-job-builder
+#
+class govuk_jenkins::job::update_cdn_dictionaries {
+  file { '/etc/jenkins_jobs/jobs/update_cdn_dictionaries.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/update_cdn_dictionaries.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+}

--- a/modules/govuk_jenkins/templates/jobs/update_cdn_dictionaries.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/update_cdn_dictionaries.yaml.erb
@@ -1,0 +1,40 @@
+---
+- scm:
+    name: update_cdn_dictionaries
+    scm:
+        - git:
+            url: git@github.gds:gds/cdn-configs
+            branches:
+              - master
+
+- job:
+    name: Update_CDN_Dictionaries
+    display-name: Update CDN dictionaries
+    project-type: freestyle
+    properties:
+        - github:
+            url: https://github.gds/gds/cdn-configs/
+    scm:
+      - update_cdn_dictionaries
+    builders:
+        - shell: |
+            cd fastly
+            bundle install --path "${HOME}/bundles/${JOB_NAME}"
+            bundle exec ./dictionaries/configure_dictionaries ${vhost} <%= @environment %>
+    wrappers:
+        - ansicolor:
+            colormap: xterm
+        - build-name:
+            name: '#${BUILD_NUMBER} ${ENV,var="vhost"}'
+    parameters:
+        - choice:
+            name: vhost
+            choices:
+                - PLEASE CHOOSE ONE
+                - www
+        - string:
+            name: FASTLY_USER
+            default: false
+        - password:
+            name: FASTLY_PASS
+            default: false


### PR DESCRIPTION
Story: https://trello.com/c/nZvKJFFJ/21-block-ips-at-edge

We've added a script to update CDN [edge dictionaries][] at Fastly so
that we can block IP addresses at the edge without redeploying our VCL:
https://github.gds/gds/cdn-configs/pull/108

Add a Jenkins job which will update the edge dictionary using the data
in the cdn-configs repository.

[edge dictionaries]: https://www.fastly.com/blog/announcing-edge-dictionaries-make-faster-decisions-edge