### PR TITLE
Add missing Rabbitmq configuration for Rummager

### DIFF
--- a/hieradata/class/rabbitmq.yaml
+++ b/hieradata/class/rabbitmq.yaml
@@ -7,6 +7,7 @@ govuk::node::s_rabbitmq::apps_using_rabbitmq:
   - govuk_crawler_worker
   - panopticon
   - publishing_api
+  - rummager
   - stagecraft
 
 govuk::safe_to_reboot::can_reboot: 'careful'

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -77,6 +77,7 @@ govuk::node::s_development::apps:
   - 'router'
   - 'router_api'
   - 'rummager'
+  - 'rummager::rabbitmq'
   - 'search_admin'
   - 'service_manual_publisher'
   - 'share_sale_publisher'

--- a/modules/govuk/manifests/apps/rummager/rabbitmq.pp
+++ b/modules/govuk/manifests/apps/rummager/rabbitmq.pp
@@ -1,0 +1,23 @@
+# == Class: govuk::apps::rummager::rabbitmq
+#
+# Permissions for rummager to read messages from
+# the publishing API's AMQP exchange.
+#
+# This sets up the user, and permits read/write/configure
+# to the queue, and read-only to the exchange.
+#
+# === Parameters
+#
+# [*password*]
+#   The password for the RabbitMQ user (default: 'rummager')
+#
+class govuk::apps::rummager::rabbitmq (
+  $password  = 'rummager',
+) {
+
+  govuk_rabbitmq::consumer { 'rummager':
+    amqp_pass     => $password,
+    amqp_exchange => 'published_documents',
+    amqp_queue    => 'rummager_to_be_indexed',
+  }
+}


### PR DESCRIPTION
The following changes were missing/in the wrong place in order for RabbitMQ and Rummager to work together.