### PR TITLE
Add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+# Contributing guidelines for GOV.UK's Puppet repository
+
+## Pull requests
+
+You can propose changes using a pull request.
+
+1. [Fork the repository][forking] (if you don't have access to push new branches)
+2. Create a feature branch to work on (`git checkout -b my-new-feature`)
+3. Commit your work (we like [commits that explain your thought process][commits])
+4. Open a pull request
+5. If you have write access, you can merge your own pull request once somebody
+   has reviewed it and given you a thumbs up 👍. If you don't have access, we'll
+   merge the pull request for you once it's ready.
+
+[forking]: https://help.github.com/articles/fork-a-repo/
+[commits]: https://github.com/alphagov/styleguides/blob/master/git.md


### PR DESCRIPTION
@rboulton pointed out that the Infrastructure team has not been good at communicating that we've moved to a self-merge approach for Puppet pull requests.

@deanwilson suggested that we do it because Puppet is a repo which has lots of people touching it, and it's nice to be able to control when your changes are merged (and therefore deployed).

This file seems like the best way to document that.