### PR TITLE
Fix monitoring user in development

### DIFF
--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -199,7 +199,6 @@ govuk_elasticsearch::version: '1.4.4'
 
 govuk_mysql::server::slow_query_log: true
 
-govuk_postgresql::monitoring::user: username
 govuk_postgresql::monitoring::password: password
 govuk_postgresql::server::configure_env_sync_user: false
 govuk_postgresql::server::snakeoil_ssl_certificate: certificate

--- a/hieradata/vagrant.yaml
+++ b/hieradata/vagrant.yaml
@@ -126,7 +126,6 @@ govuk_jenkins::job_builder::environment: 'dev'
 govuk_jenkins::job::network_config_deploy::environments:
   - foo
 
-govuk_postgresql::monitoring::user: nagios
 govuk_postgresql::monitoring::password: password
 
 govuk_postgresql::server::snakeoil_ssl_certificate: |

--- a/modules/govuk_postgresql/manifests/monitoring.pp
+++ b/modules/govuk_postgresql/manifests/monitoring.pp
@@ -4,16 +4,15 @@
 #
 # === Parameters
 #
-# [*user*]
-#   Username of a monitoring account to create in PostgreSQL
-#
 # [*password*]
 #   The password that you'd like to set for $user
 #
 class govuk_postgresql::monitoring (
-  $user,
   $password,
 ) {
+
+  # This user is granted access to databases in the `govuk_postgresql::monitoring::db` defined type.
+  $user = 'nagios'
 
   package { 'check-postgres':
     ensure => installed,

--- a/spec/fixtures/hieradata/common.yaml
+++ b/spec/fixtures/hieradata/common.yaml
@@ -23,7 +23,6 @@ govuk_jenkins::config::github_web_uri: wibble
 govuk_postgresql::server::snakeoil_ssl_certificate: certificate
 govuk_postgresql::server::snakeoil_ssl_key: key
 
-govuk_postgresql::monitoring::user: username
 govuk_postgresql::monitoring::password: password
 
 hosts::production::backend::hosts:


### PR DESCRIPTION
The monitoring user in development is set incorrectly. There's no point in parameterising this username because it can't be changed at the moment; it's used in a defined type.