### PR TITLE
Backup processed CDN logs

### DIFF
--- a/hieradata/class/backup.yaml
+++ b/hieradata/class/backup.yaml
@@ -47,6 +47,10 @@ govuk::node::s_backup::directories:
     directory: /opt/graphite/storage/whisper
     fq_dn: graphite-1.management.%{hiera('app_domain')}
     priority: '004'
+  processed_cdn_logs:
+    directory: "%{hiera('govuk::apps::govuk_cdn_logs_monitor::processed_data_dir')}"
+    fq_dn: "logs-cdn-1.management.%{hiera('app_domain')}"
+    priority: '003'
 
 icinga::client::checks::disk_time_warn: 750 # milliseconds
 icinga::client::checks::disk_time_critical: 1000 # milliseconds

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -182,6 +182,8 @@ govuk::apps::email_alert_service::rabbitmq_hosts:
 
 govuk::apps::finder_frontend::enabled: true
 
+govuk::apps::govuk_cdn_logs_monitor::processed_data_dir: '/mnt/logs_cdn/data'
+
 govuk::apps::govuk_crawler_worker::airbrake_endpoint: "https://errbit.%{hiera('app_domain')}/notifier_api/v2/notices"
 govuk::apps::govuk_crawler_worker::airbrake_env: "%{hiera('govuk::deploy::config::errbit_environment_name')}"
 # FIXME: The API can be crawled when https://github.com/alphagov/govuk_crawler_worker/issues/97 is fixed.

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -79,6 +79,12 @@ backup::offsite::jobs:
     hour: 8,
     minute: 13,
     # No encryption because of size and sensitivity
+  'govuk-cdn-logs':
+    sources: "/data/backups/logs-cdn-1.management.%{hiera('app_domain')}/*"
+    destination: "rsync://%{hiera('backup::offsite::dest_host')}//srv/backup-cdn-logs/"
+    hour: 7,
+    minute: 12,
+    # CDN logs are backed up unencrypted because they don't contain any sensitive information
 
 base::packages::gems:
   ruby-shadow:

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -29,24 +29,7 @@ backup::assets::jobs:
 backup::offsite::dest_host: *offsite_host
 backup::offsite::dest_host_key: *offsite_ssh_host_key
 backup::offsite::enable: true
-backup::offsite::jobs:
-  'govuk-datastores':
-    sources:
-      - '/data/backups/*/var/lib/automongodbbackup/latest'
-      - '/data/backups/*/var/lib/automysqlbackup/latest.tbz2'
-      - '/data/backups/*/var/lib/autopostgresqlbackup/latest.tbz2'
-      - '/data/backups/archived'
-    destination: "rsync://%{hiera('backup::offsite::dest_host')}//srv/backup-data/"
-    hour: 8,
-    minute: 13,
-    gpg_key_id: *offsite_gpg_key
-  'govuk-graphite':
-    sources: '/data/backups/*/opt/graphite/storage/whisper'
-    destination: "rsync://%{hiera('backup::offsite::dest_host')}//srv/backup-graphite/"
-    weekday: 6
-    hour: 8,
-    minute: 13,
-    # No encryption because of size and sensitivity
+
 backup::offsite::monitoring::offsite_fqdn: *offsite_host
 backup::offsite::monitoring::offsite_hostname: 'backup0.provider0'
 

--- a/modules/govuk/manifests/apps/govuk_cdn_logs_monitor.pp
+++ b/modules/govuk/manifests/apps/govuk_cdn_logs_monitor.pp
@@ -17,12 +17,11 @@
 #
 # [*processed_data_dir*]
 #   Directory that processed data from the logs is stored in
-#   Default: processed
 #
 class govuk::apps::govuk_cdn_logs_monitor (
   $enabled = true,
   $cdn_log_dir = '/mnt/logs_cdn',
-  $processed_data_dir = '/mnt/logs_cdn/data',
+  $processed_data_dir,
 ) {
   if $enabled {
     file { $processed_data_dir:


### PR DESCRIPTION
We're going to start deleting historical raw CDN logs, which means the processed files will be the only data we retain. We should back them up.

I've forced the `processed_data_dir` parameter to be in hieradata so that I can do a hiera lookup in `backup.yaml` and avoid some duplication.

https://trello.com/c/xbsYTau0/33-back-up-processed-cdn-logs