### PR TITLE
Move the `reload_service` Icinga plugin

### DIFF
--- a/modules/icinga/manifests/client.pp
+++ b/modules/icinga/manifests/client.pp
@@ -51,4 +51,9 @@ class icinga::client {
 
   Icinga::Nrpe_config <| |>
   Icinga::Plugin <| |>
+
+  icinga::plugin { 'reload_service':
+    source => 'puppet:///modules/monitoring/usr/lib/nagios/plugins/reload_service',
+  }
+
 }

--- a/modules/monitoring/manifests/event_handler/app_high_memory.pp
+++ b/modules/monitoring/manifests/event_handler/app_high_memory.pp
@@ -10,10 +10,6 @@ class monitoring::event_handler::app_high_memory () {
     require => File['/usr/local/bin/event_handlers/govuk_app_high_memory.sh'],
   }
 
-  @icinga::plugin { 'reload_service':
-    source => 'puppet:///modules/monitoring/usr/lib/nagios/plugins/reload_service',
-  }
-
   file { '/usr/local/bin/event_handlers/govuk_app_high_memory.sh':
     source => 'puppet:///modules/govuk/usr/local/bin/event_handlers/govuk_app_high_memory.sh',
     mode   => '0755',


### PR DESCRIPTION
Story: https://trello.com/c/8U5ou5rr/77-gracefully-kill-unicorn-workers-if-they-use-too-much-ram

Move the `reload_service` Icinga plugin so that it is installed on every
machine, not just the monitoring machine. Without this, Icinga is unable
to reload services using event handlers.