### PR TITLE
Remove erroneous "minus" character from ERB

### DIFF
--- a/modules/logrotate/templates/logrotate.conf.erb
+++ b/modules/logrotate/templates/logrotate.conf.erb
@@ -1,6 +1,6 @@
 <%= @matches %> {
   <%- if @user && @group -%>
-  su <%= @user -%> <%= @group -%>
+  su <%= @user -%> <%= @group %>
   <%- end -%>
   daily
   missingok


### PR DESCRIPTION
This caused the logrotate configuration to incorrectly format like:

```
su deploy deploy daily
missingok
```

This fixes it. :person_frowning: 