### PR TITLE
Upgrade nginx package

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -880,7 +880,7 @@ monitoring::vpn_gateways::endpoints:
   vpn_gateway_router_dr:
     address: "%{hiera('environment_ip_prefix')}.9.1"
 
-nginx::package::version: '1.4.6-1ubuntu3.1'
+nginx::package::version: '1.4.6-1ubuntu3.4'
 
 nodejs::version: '0.10.37-1chl1~%{::lsbdistcodename}1'
 


### PR DESCRIPTION
This package was installed automatically by unattended-upgrades last night to patch CVEs CVE-2016-0742, CVE-2016-0746, CVE-2016-0747.

Puppet is failing to run correctly because it can't find the old version to install (and we wouldn't want it to anyway).

Paired with @MatMoore on this.