### PR TITLE
Allow mongodb secondaries to be rebooted overnight

### DIFF
--- a/hieradata/class/staging/api_mongo.yaml
+++ b/hieradata/class/staging/api_mongo.yaml
@@ -1,0 +1,3 @@
+---
+
+govuk::safe_to_reboot::can_reboot: 'overnight'

--- a/hieradata/class/staging/email_campaign_mongo.yaml
+++ b/hieradata/class/staging/email_campaign_mongo.yaml
@@ -1,0 +1,3 @@
+---
+
+govuk::safe_to_reboot::can_reboot: 'overnight'

--- a/hieradata/class/staging/mongo.yaml
+++ b/hieradata/class/staging/mongo.yaml
@@ -1,0 +1,3 @@
+---
+
+govuk::safe_to_reboot::can_reboot: 'overnight'

--- a/hieradata/class/staging/performance_mongo.yaml
+++ b/hieradata/class/staging/performance_mongo.yaml
@@ -1,0 +1,4 @@
+---
+
+govuk::safe_to_reboot::can_reboot: 'overnight'
+

--- a/hieradata/class/staging/router_backend.yaml
+++ b/hieradata/class/staging/router_backend.yaml
@@ -1,0 +1,3 @@
+---
+
+govuk::safe_to_reboot::can_reboot: 'overnight'

--- a/modules/govuk_unattended_reboot/files/etc/unattended-reboot/check/02_mongodb.py
+++ b/modules/govuk_unattended_reboot/files/etc/unattended-reboot/check/02_mongodb.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+import json
+import re
+import sys
+from subprocess import check_output
+
+
+def node_health(health_code):
+    return "OK" if health_code == 1 else "ERROR"
+
+
+def mongo_command(command):
+    return ['mongo', '--quiet', '--eval', command]
+
+
+def strip_dates(raw_output):
+    """
+    mongodb returns invalid JSON.
+    """
+    stripped_isodates = re.sub(r'ISODate\((.*?)\)', r'\1', raw_output)
+    return re.sub(r'Timestamp\((.*?)\)', r'"\1"', stripped_isodates)
+
+
+def run_mongo_command(command):
+    """
+    Parse the json output of a mongo command. Errors if return code is non-zero.
+    """
+    response = strip_dates(check_output(mongo_command('printjson(%s)' % command)))
+    return json.loads(response)
+
+
+def get_cluster_status():
+    status = run_mongo_command('rs.status()')
+    parsed_statuses = []
+
+    for member_status in status['members']:
+        parsed_status = {
+            'health': node_health(member_status['health']),
+            'state': member_status['stateStr'],
+        }
+        parsed_statuses.append(parsed_status)
+
+    return parsed_statuses
+
+
+def cluster_is_ok(member_statuses):
+    health_ok = all(s['health'] == 'OK' for s in member_statuses)
+    state_ok = all(s['state'] in ['PRIMARY', 'SECONDARY']
+                   for s in member_statuses)
+    one_primary = len([s for s in member_statuses
+                       if s['state'] == 'PRIMARY']) == 1
+
+    return health_ok and state_ok and one_primary
+
+
+def i_am_primary():
+    return run_mongo_command('db.isMaster().primary === db.isMaster().me')
+
+
+if __name__ == '__main__':
+    member_statuses = get_cluster_status()
+    if cluster_is_ok(member_statuses) and not i_am_primary():
+        sys.exit(0)
+    else:
+        sys.exit(1)

--- a/modules/govuk_unattended_reboot/manifests/mongodb.pp
+++ b/modules/govuk_unattended_reboot/manifests/mongodb.pp
@@ -1,0 +1,19 @@
+# == Class: govuk_unattended_reboot::mongodb
+#
+# Installs a script which ensures that a MongoDB server
+# can be rebooted.
+#
+class govuk_unattended_reboot::mongodb {
+
+  $config_directory = '/etc/unattended-reboot'
+  $check_scripts_directory = "${config_directory}/check"
+
+  file { "${check_scripts_directory}/02_mongodb.py":
+    ensure  => present,
+    mode    => '0755',
+    owner   => 'root',
+    group   => 'root',
+    source  => "puppet:///modules/govuk_unattended_reboot/${check_scripts_directory}/02_mongodb.py",
+    require => File[$check_scripts_directory],
+  }
+}

--- a/modules/mongodb/manifests/server.pp
+++ b/modules/mongodb/manifests/server.pp
@@ -41,6 +41,7 @@ class mongodb::server (
     }
   }
 
+  include govuk_unattended_reboot::mongodb
   include mongodb::repository
 
   if $development {


### PR DESCRIPTION
For now we don't allow the primaries, but the process is to
first step the primary down to secondary before rebooting.

The status check here is the same as the safe_reboot fabric command.

This replaces this PR, which was part reverted due to the status check not being complete https://github.com/alphagov/govuk-puppet/pull/3877

Paired with @alexmuller 