### PR TITLE
Remove service-manual-publisher DISABLE_PUBLISHING feature flag

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -61,7 +61,6 @@ govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::panopticon::enable_procfile_worker: false
 govuk::apps::publicapi::backdrop_host: 'www.performance.service.gov.uk'
 govuk::apps::publisher::data_import_passive_check: true
-govuk::apps::service_manual_publisher::disable_publishing: true
 
 govuk::deploy::actionmailer_enable_delivery: true
 

--- a/modules/govuk/manifests/apps/service_manual_publisher.pp
+++ b/modules/govuk/manifests/apps/service_manual_publisher.pp
@@ -32,9 +32,6 @@
 # [*secret_key_base*]
 #   The key for Rails to use when signing/encrypting sessions.
 #
-# [*disable_publishing*]
-#   Disable publishing actions for documents.
-#
 # [*publishing_api_bearer_token*]
 #   The bearer token to use when communicating with Publishing API.
 #   Default: undef
@@ -53,7 +50,6 @@ class govuk::apps::service_manual_publisher(
   $oauth_secret = '',
   $port = 3111,
   $secret_key_base = undef,
-  $disable_publishing = false,
   $publishing_api_bearer_token = undef,
   $asset_manager_bearer_token = undef,
 ) {
@@ -89,14 +85,6 @@ class govuk::apps::service_manual_publisher(
     "${title}-ASSET_MANAGER_BEARER_TOKEN":
       varname => 'ASSET_MANAGER_BEARER_TOKEN',
       value   => $asset_manager_bearer_token;
-  }
-
-  if $disable_publishing {
-    govuk::app::envvar {
-      "${title}-DISABLE_PUBLISHING":
-        varname => 'DISABLE_PUBLISHING',
-        value   => '1';
-    }
   }
 
   if $secret_key_base != undef {


### PR DESCRIPTION
We're planning on going live with our guide content, so this feature
flag needs to be removed.

Related: https://github.com/alphagov/service-manual-publisher/pull/149

https://trello.com/c/3VCkqD3P/166-allow-publishing-guides-in-production

This was originally introduced here: https://github.com/alphagov/govuk-puppet/commit/42a45d8211a2a4f12f57d909ec260c2dd1196c1c