### PR TITLE
Add env vars for travel-advice-publisher.

### DIFF
--- a/hieradata/class/backend.yaml
+++ b/hieradata/class/backend.yaml
@@ -15,6 +15,12 @@ govuk::apps::share_sale_publisher::mongodb_nodes:
   - 'mongo-2.backend'
   - 'mongo-3.backend'
 
+govuk::apps::travel_advice_publisher::mongodb_name: 'govuk_content_production'
+govuk::apps::travel_advice_publisher::mongodb_nodes:
+  - 'mongo-1.backend'
+  - 'mongo-2.backend'
+  - 'mongo-3.backend'
+
 govuk::node::s_base::apps:
   - asset_manager
   - business_support_api

--- a/modules/govuk/manifests/apps/travel_advice_publisher.pp
+++ b/modules/govuk/manifests/apps/travel_advice_publisher.pp
@@ -8,15 +8,29 @@
 #   The port that publishing API is served on.
 #   Default: 3078
 #
+# [*mongodb_name*]
+#   The Mongo database to be used.
+#
+# [*mongodb_nodes*]
+#   Array of hostnames for the mongo cluster to use.
+#
+# [*secret_key_base*]
+#   The key for Rails to use when signing/encrypting sessions.
+#
 # [*publishing_api_bearer_token*]
 #   The bearer token to use when communicating with Publishing API.
 #   Default: undef
 #
 class govuk::apps::travel_advice_publisher(
   $port = '3035',
+  $mongodb_name = undef,
+  $mongodb_nodes = undef,
+  $secret_key_base = undef,
   $publishing_api_bearer_token = undef,
 ) {
-  govuk::app { 'travel-advice-publisher':
+  $app_name = 'travel-advice-publisher'
+
+  govuk::app { $app_name:
     app_type           => 'rack',
     port               => $port,
     vhost_ssl_only     => true,
@@ -26,9 +40,23 @@ class govuk::apps::travel_advice_publisher(
     deny_framing       => true,
   }
 
-  govuk::app::envvar { "${title}-PUBLISHING_API_BEARER_TOKEN":
-    app     => 'travel-advice-publisher',
-    varname => 'PUBLISHING_API_BEARER_TOKEN',
-    value   => $publishing_api_bearer_token,
+  Govuk::App::Envvar {
+    app     => $app_name,
+  }
+
+  if $mongodb_nodes != undef {
+    govuk::app::envvar::mongodb_uri { $app_name:
+      hosts    => $mongodb_nodes,
+      database => $mongodb_name,
+    }
+  }
+
+  govuk::app::envvar {
+    "${title}-PUBLISHING_API_BEARER_TOKEN":
+      varname => 'PUBLISHING_API_BEARER_TOKEN',
+      value   => $publishing_api_bearer_token;
+    "${title}-SECRET_KEY_BASE":
+      varname => 'SECRET_KEY_BASE',
+      value   => $secret_key_base;
   }
 }


### PR DESCRIPTION
This defines MONGODB_URI, using the existing mongodb_uri class with data
supplied in backend hieradata, and SECRET_KEY_BASE, which uses data in the
deployment hieradata.