### PR TITLE
Allow overnight reboot of elasticsearch nodes

### DIFF
--- a/hieradata/class/staging/api_elasticsearch.yaml
+++ b/hieradata/class/staging/api_elasticsearch.yaml
@@ -1,0 +1,3 @@
+---
+
+govuk::safe_to_reboot::can_reboot: 'overnight'

--- a/hieradata/class/staging/elasticsearch.yaml
+++ b/hieradata/class/staging/elasticsearch.yaml
@@ -1,0 +1,3 @@
+---
+
+govuk::safe_to_reboot::can_reboot: 'overnight'

--- a/hieradata/class/staging/logs_elasticsearch.yaml
+++ b/hieradata/class/staging/logs_elasticsearch.yaml
@@ -1,0 +1,3 @@
+---
+
+govuk::safe_to_reboot::can_reboot: 'overnight'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -408,6 +408,7 @@ govuk_sudo::sudo_conf:
 
 govuk_unattended_reboot::enabled: true
 govuk_unattended_reboot::mongodb::enabled: true
+govuk_unattended_reboot::elasticsearch::enabled: true
 
 govuk_unattended_reboot::monitoring_basic_auth:
   username: "%{hiera('http_username')}"

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -232,6 +232,7 @@ govuk_sshkeys::development_keys:
 
 govuk_unattended_reboot::enabled: false
 govuk_unattended_reboot::mongodb::enabled: false
+govuk_unattended_reboot::elasticsearch::enabled: false
 
 hosts::development::apps:
   - 'asset-manager'

--- a/modules/govuk_elasticsearch/manifests/init.pp
+++ b/modules/govuk_elasticsearch/manifests/init.pp
@@ -124,6 +124,8 @@ class govuk_elasticsearch (
     legacy_elasticsearch => versioncmp($version, '1.0.0') < 0, # version 0.x has different stats URLs etc.
   }
 
+  include govuk_unattended_reboot::elasticsearch
+
   if $open_firewall_from_all {
     @ufw::allow { "allow-elasticsearch-http-${http_port}-from-all":
       port => $http_port,

--- a/modules/govuk_unattended_reboot/files/etc/unattended-reboot/check/02_elasticsearch.py
+++ b/modules/govuk_unattended_reboot/files/etc/unattended-reboot/check/02_elasticsearch.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+import json
+import sys
+from urllib2 import urlopen
+
+
+def healthy_status():
+    """
+    Returns true if our cluster is green.
+    Raises exception for HTTP errors.
+    """
+    response = urlopen('http://localhost:9200/_cluster/health')
+    parsed = json.load(response)
+    return parsed['status'] == 'green'
+
+
+if __name__ == '__main__':
+    if not healthy_status():
+        sys.exit(1)

--- a/modules/govuk_unattended_reboot/manifests/elasticsearch.pp
+++ b/modules/govuk_unattended_reboot/manifests/elasticsearch.pp
@@ -1,0 +1,19 @@
+# == Class: govuk_unattended_reboot::elasticsearch
+#
+# Installs a script which ensures that an elasticsearch server
+# can be rebooted.
+#
+class govuk_unattended_reboot::elasticsearch {
+
+  $config_directory = '/etc/unattended-reboot'
+  $check_scripts_directory = "${config_directory}/check"
+
+  file { "${check_scripts_directory}/02_elasticsearch.py":
+    ensure  => present,
+    mode    => '0755',
+    owner   => 'root',
+    group   => 'root',
+    source  => "puppet:///modules/govuk_unattended_reboot/${check_scripts_directory}/02_elasticsearch.py",
+    require => File[$check_scripts_directory],
+  }
+}

--- a/modules/govuk_unattended_reboot/manifests/elasticsearch.pp
+++ b/modules/govuk_unattended_reboot/manifests/elasticsearch.pp
@@ -3,7 +3,14 @@
 # Installs a script which ensures that an elasticsearch server
 # can be rebooted.
 #
-class govuk_unattended_reboot::elasticsearch {
+# === Parameters
+#
+# [*enabled*]
+#   Whether to enable the check for unattended reboots.
+#
+class govuk_unattended_reboot::elasticsearch (
+  $enabled = false
+) {
 
   $config_directory = '/etc/unattended-reboot'
   $check_scripts_directory = "${config_directory}/check"

--- a/modules/govuk_unattended_reboot/manifests/mongodb.pp
+++ b/modules/govuk_unattended_reboot/manifests/mongodb.pp
@@ -6,7 +6,7 @@
 # === Parameters
 #
 # [*enabled*]
-#   Whether to enable unattended reboots.
+#   Whether to enable the check for unattended reboots.
 #
 class govuk_unattended_reboot::mongodb (
   $enabled = false


### PR DESCRIPTION
The check is the same as the fabric task, but without the disable_reallocation part.
We think it will be simpler this way, although it might take longer for the cluster
to go green again after a single node is rebooted.

The other way we could do this is to disable reallocation in the /etc/unattended_reboot check, and then add something else to renable it after the machine boots up again.

https://trello.com/c/JD2ZFRcJ/13-write-script-to-check-if-elasticsearch-logs-elasticsearch-machines-can-be-rebooted

@rboulton can you review?