### PR TITLE
Prompt for username, then password

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_cdn.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_cdn.yaml.erb
@@ -38,9 +38,9 @@
                 - performanceplatform
                 - performanceplatform_admin
                 - performanceplatform_stagecraft
-        - password:
-            name: FASTLY_PASS
-            default: false
         - string:
             name: FASTLY_USER
+            default: false
+        - password:
+            name: FASTLY_PASS
             default: false


### PR DESCRIPTION
Story: https://trello.com/c/nZvKJFFJ/21-block-ips-at-edge

Prompt for the Fastly password after the username, consistent with
convention used by most login forms on the Internet.