### PR TITLE
Jenkins CDN jobs: Don't delete .git directory

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_cdn.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_cdn.yaml.erb
@@ -6,6 +6,9 @@
             url: git@github.gds:gds/cdn-configs
             branches:
               - master
+            wipe-workspace: false
+            clean:
+                after: true
 
 - job:
     name: Deploy_CDN

--- a/modules/govuk_jenkins/templates/jobs/update_cdn_dictionaries.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/update_cdn_dictionaries.yaml.erb
@@ -6,6 +6,9 @@
             url: git@github.gds:gds/cdn-configs
             branches:
               - master
+            wipe-workspace: false
+            clean:
+                after: true
 
 - job:
     name: Update_CDN_Dictionaries


### PR DESCRIPTION
Story: https://trello.com/c/nZvKJFFJ/21-block-ips-at-edge

Configure the Jenkins GIT plugin not to delete the `.git` directory on
every build so that deploying the CDN configs or updating the CDN
dictionaries complete faster.

`wipe-workspace` is set to true by default. Instead, run `git-clean`
after `git-clone` to ensure that the workspace is clean.

See:
http://docs.openstack.org/infra/jenkins-job-builder/scm.html?highlight=force%20clone#scm.git