### PR TITLE
Keep Bouncer CDN logs for 30 days only

### DIFF
--- a/modules/govuk_cdnlogs/spec/classes/govuk_cdnlogs_spec.rb
+++ b/modules/govuk_cdnlogs/spec/classes/govuk_cdnlogs_spec.rb
@@ -117,7 +117,7 @@ ruleset\(name="cdn-giraffe"\) \{
         it 'should rotate the elephant logs hourly' do
           is_expected.to contain_file('/etc/logrotate.cdn_logs_hourly.conf')
             .with_content(%r{^/tmp/logs/cdn-elephant\.log$})
-            .with_content(/rotate 8760/)
+            .with_content(/rotate 720/)
         end
       end
     end

--- a/modules/govuk_cdnlogs/templates/etc/logrotate.cdn_logs_hourly.conf.erb
+++ b/modules/govuk_cdnlogs/templates/etc/logrotate.cdn_logs_hourly.conf.erb
@@ -4,7 +4,7 @@
 -%>
 
 {
-  rotate 8760
+  rotate 720
   dateext
   dateformat -%Y%m%d-%s
   compress


### PR DESCRIPTION
These logs are rotated hourly, so 30 * 24 = 720 hours.

We changed our policy to retain other CDN logs for 30 days only in
edfe535 and this change makes the configuration for Bouncer the same in
that respect.