### PR TITLE
Reduce varnish storage size

### DIFF
--- a/modules/govuk/manifests/node/s_cache.pp
+++ b/modules/govuk/manifests/node/s_cache.pp
@@ -57,8 +57,8 @@ class govuk::node::s_cache (
     real_ip_header  => $real_ip_header,
   }
 
-  # Set the varnish storage size to 75% of memory - 1024
-  $varnish_storage_size_pre = floor($::memorysize_mb / 4 * 3 - 1024)
+  # The storage size for the cache, excluding per object and static overheads
+  $varnish_storage_size_pre = floor($::memorysize_mb * 0.70 - 1024)
 
   # Ensure that there's some varnish storage in small environments (eg, vagrant).
   if $varnish_storage_size_pre < 100 {


### PR DESCRIPTION
As noted in the documentation:

> It is important to keep in mind that the size you specify with the -s
argument is the size for the actual cache. Varnish has an overhead on
top of this for keeping track of the cache, so the actual memory
footprint of Varnish will exceed what the ‘-s’ argument specifies if the
cache is full. The current estimate (subject to change on individual
Varnish-versions) is that about 1kB of overhead needed for each object.
For 1 million objects, that means 1GB extra memory usage.
- https://www.varnish-software.com/book/3/Tuning.html#storage-backends

Our previous calculation subtracted 1GB to account for this, which
allows 11GB for storage. This seems reasonable, given that we see
around 500k objects. However in practice varnish is still using most
of the memory on the machine, so we want to lower the limit a bit more.

https://trello.com/c/rz5YIUef/81-varnish-using-lots-of-ram-in-staging-cache-n-router-staging