### PR TITLE
Extract govuk::gor into its own module

### DIFF
--- a/modules/govuk_bouncer/manifests/gor.pp
+++ b/modules/govuk_bouncer/manifests/gor.pp
@@ -26,7 +26,7 @@ class govuk_bouncer::gor (
     $gor_targets        = []
   }
 
-  class { 'govuk::gor':
+  class { 'govuk_gor':
     args   => {
       '-input-raw'          => ':80',
       '-output-http'        => $gor_targets,

--- a/modules/govuk_bouncer/spec/classes/govuk_bouncer__gor_spec.rb
+++ b/modules/govuk_bouncer/spec/classes/govuk_bouncer__gor_spec.rb
@@ -11,7 +11,7 @@ describe 'govuk_bouncer::gor', :type => :class do
     let(:params) {{ }}
 
     it {
-      is_expected.to contain_class('govuk::gor').with({
+      is_expected.to contain_class('govuk_gor').with({
         :enable => false,
       })
     }
@@ -24,7 +24,7 @@ describe 'govuk_bouncer::gor', :type => :class do
     }}
 
     it {
-      is_expected.to contain_class('govuk::gor').with(
+      is_expected.to contain_class('govuk_gor').with(
         :enable => true,
         :args           => args_default.merge({
           '-output-http' => ["http://#{ip_address}"],
@@ -40,7 +40,7 @@ describe 'govuk_bouncer::gor', :type => :class do
     }}
 
     it {
-      is_expected.to contain_class('govuk::gor').with(
+      is_expected.to contain_class('govuk_gor').with(
         :enable => false,
       )
     }
@@ -52,7 +52,7 @@ describe 'govuk_bouncer::gor', :type => :class do
     }}
 
     it {
-      is_expected.to contain_class('govuk::gor').with(
+      is_expected.to contain_class('govuk_gor').with(
         :enable => false,
       )
     }

--- a/modules/govuk_gor/manifests/init.pp
+++ b/modules/govuk_gor/manifests/init.pp
@@ -1,4 +1,4 @@
-# == Class: govuk::gor
+# == Class: govuk_gor
 #
 # Setup gor traffic replay for GOV.UK
 #
@@ -13,7 +13,7 @@
 # [*version*]
 #   Which version of the Go package to install; defaults to latest
 #
-class govuk::gor(
+class govuk_gor(
   $args = {},
   $enable = false,
   $version = 'latest',

--- a/modules/govuk_gor/spec/classes/govuk_gor_spec.rb
+++ b/modules/govuk_gor/spec/classes/govuk_gor_spec.rb
@@ -1,6 +1,6 @@
 require_relative '../../../../spec_helper'
 
-describe 'govuk::gor', :type => :class do
+describe 'govuk_gor', :type => :class do
   let(:args_default) {{
     '-input-raw'          => 'localhost:7999',
     '-output-http-method' => %w{GET HEAD OPTIONS},

--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_staging.yaml.erb
@@ -38,7 +38,7 @@
             set +e
 
             echo "Disabling Gor traffic replay"
-            for box in $(govuk_node_list -C 'govuk::gor'); do
+            for box in $(govuk_node_list -C 'govuk_gor'); do
               ssh deploy@${box} 'echo "true" > /etc/govuk/env.d/FACTER_data_sync_in_progress; sudo initctl stop gor';
             done
 
@@ -47,7 +47,7 @@
             EXITCODE=$?
 
             echo "Re-enabling Gor traffic replay"
-            for box in $(govuk_node_list -C 'govuk::gor'); do
+            for box in $(govuk_node_list -C 'govuk_gor'); do
               ssh deploy@${box} 'echo "" > /etc/govuk/env.d/FACTER_data_sync_in_progress; sudo initctl start gor';
             done
 

--- a/modules/govuk_jenkins/templates/jobs/copy_licensify_data_to_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_licensify_data_to_staging.yaml.erb
@@ -29,7 +29,7 @@
             set +e
 
             echo "Disabling Gor traffic replay"
-            for box in $(govuk_node_list -C 'govuk::gor'); do
+            for box in $(govuk_node_list -C 'govuk_gor'); do
               ssh deploy@${box} 'echo "true" > /etc/govuk/env.d/FACTER_data_sync_in_progress; sudo initctl stop gor';
             done
 
@@ -38,7 +38,7 @@
             EXITCODE=$?
 
             echo "Re-enabling Gor traffic replay"
-            for box in $(govuk_node_list -C 'govuk::gor'); do
+            for box in $(govuk_node_list -C 'govuk_gor'); do
               ssh deploy@${box} 'echo "" > /etc/govuk/env.d/FACTER_data_sync_in_progress; sudo initctl start gor';
             done
 

--- a/modules/router/manifests/gor.pp
+++ b/modules/router/manifests/gor.pp
@@ -24,13 +24,13 @@ class router::gor (
   # once for *every* request/goroutine, and can be quite overwhelming.
   $host_defaults = {
     'ensure'  => $gor_hosts_ensure,
-    'notify'  => 'Class[Govuk::Gor]',
+    'notify'  => 'Class[Govuk_gor]',
     'comment' => 'Used by Gor. See comments in router::gor.',
   }
 
   create_resources('host', $replay_targets, $host_defaults)
 
-  class { 'govuk::gor':
+  class { 'govuk_gor':
     args   => {
       '-input-raw'          => 'localhost:7999',
       '-output-http'        => prefix(keys($replay_targets), 'https://'),

--- a/modules/router/spec/classes/router__gor_spec.rb
+++ b/modules/router/spec/classes/router__gor_spec.rb
@@ -12,7 +12,7 @@ describe 'router::gor', :type => :class do
   context 'no targets defined (disabled)' do
     let(:replay_targets) {{}}
 
-    it { is_expected.to contain_class('govuk::gor').with({ :enable => false, }) }
+    it { is_expected.to contain_class('govuk_gor').with({ :enable => false, }) }
   end
 
   context 'a target defined (enabled)' do
@@ -24,7 +24,7 @@ describe 'router::gor', :type => :class do
     it { is_expected.to contain_host(target_host).with_ensure('present') }
 
     it {
-      is_expected.to contain_class('govuk::gor').with(
+      is_expected.to contain_class('govuk_gor').with(
         :enable => true,
         :args   => args_default.merge({
           '-output-http' => ["https://#{target_host}"],
@@ -42,7 +42,7 @@ describe 'router::gor', :type => :class do
     }}
 
     it {
-      is_expected.to contain_class('govuk::gor').with(
+      is_expected.to contain_class('govuk_gor').with(
         :enable => true,
         :args   => args_default.merge({
           '-output-http' => ["https://#{target_host_a}", "https://#{target_host_b}"],


### PR DESCRIPTION
To help break up the monolithic `govuk` module.