### PR TITLE
Restrict boto timeout/retry settings

### DIFF
--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_quota
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_quota
@@ -24,6 +24,18 @@ if args.secret_key is None:
     print "UNKNOWN: You have not supplied an AWS secret key"
     sys.exit(3)
 
+# By default boto is very patient - failed requests can be retried 5 times, and
+# the http socket timeout is a minute.
+#
+# The check itself times out sooner than that so we want to shorten this so
+# that it can be handled by the plugin itself.
+#
+if not boto.config.has_section('Boto'):
+    boto.config.add_section('Boto')
+
+boto.config.set('Boto', 'http_socket_timeout', '5')
+boto.config.set('Boto', 'num_retries', '2')
+
 try:
     conn = boto.ses.connect_to_region(
         args.region,


### PR DESCRIPTION
This should change CRITICAL alerts to UNKNOWNs when we have issues
talking to AWS.

We use boto for SES in the check_aws_quote icinga plugin.

By default boto is very patient - failed requests can be retried 5
times, and the http socket timeout is a minute.

The check itself times out at a minute so we want to shorten this so
that it can be handled by the plugin itself. We already have a catch all
exception handler that reports the result as UNKNOWN.

I couldn't find documentation anywhere on how to configure the Boto
library without a configuration file, so I've cribbed this code from the
wal-e tool:
https://github.com/wal-e/wal-e/blob/98b81d0080a772fe26f4bb0e70bed04f9ecdb490/wal_e/blobstore/s3/s3_util.py#L17-L25

Story: https://trello.com/c/WYsEieXt/12-improve-amazon-web-services-aws-simple-email-service-ses-quota-alert