### PR TITLE
Add support for user expiry

### DIFF
--- a/modules/govuk/manifests/user.pp
+++ b/modules/govuk/manifests/user.pp
@@ -24,6 +24,11 @@
 # [*shell*]
 #   The user's login shell. Default: "/bin/bash"
 #
+# [*expiry*]
+#   The expiry date for this user. Must be provided in a zero-padded YYYY-MM-DD
+#   format - e.g. 2010-02-19. If you want to make sure the user account never
+#   expires, you can pass the special value `absent` (this is the default).
+#
 # [*ssh_key*]
 #   The user's SSH public key as a string or array thereof, e.g.
 #
@@ -40,6 +45,7 @@ define govuk::user(
   $groups = ['admin', 'deploy', 'adm' ],
   $purgegroups = false,
   $shell = '/bin/bash',
+  $expiry = absent,
   $ssh_key = undef
 ) {
 
@@ -71,6 +77,7 @@ define govuk::user(
   user { $title:
     ensure     => $ensure,
     comment    => "${fullname} <${email}>",
+    expiry     => $expiry,
     home       => $home,
     managehome => true,
     groups     => $groups,

--- a/modules/govuk/manifests/user.pp
+++ b/modules/govuk/manifests/user.pp
@@ -74,6 +74,8 @@ define govuk::user(
     $membership = 'minimum'
   }
 
+  validate_re($expiry, '^(absent|\d{4}-\d{2}-\d{2})$')
+
   user { $title:
     ensure     => $ensure,
     comment    => "${fullname} <${email}>",


### PR DESCRIPTION
After comments on #1402, adds support for user expiry so we can set a
user's expiry date when we learn their leaving date, rather than having
to push a release out on the day.

Credit goes to @philandstuff who originally raised this as #1487. I've added some validation for the date format.