### PR TITLE
Extract govuk::lvm to own module

### DIFF
--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -190,7 +190,7 @@ govuk::deploy::config::errbit_environment_name: 'development'
 govuk::deploy::config::govuk_env: 'development'
 govuk::deploy::setup_actionmailer_ses_config: false
 
-govuk::lvm::no_op: true
+govuk_lvm::no_op: true
 
 govuk::mount::no_op: true
 

--- a/hieradata/vagrant.yaml
+++ b/hieradata/vagrant.yaml
@@ -34,7 +34,7 @@ govuk::deploy::config::errbit_environment_name: 'vagrant'
 govuk::deploy::config::asset_root: 'http://static.dev.gov.uk'
 govuk::deploy::config::website_root: 'http://www.dev.gov.uk'
 
-govuk::lvm::no_op: true
+govuk_lvm::no_op: true
 
 govuk::mount::no_op: true
 

--- a/lib/puppet-lint/plugins/check_hiera.rb
+++ b/lib/puppet-lint/plugins/check_hiera.rb
@@ -29,7 +29,7 @@ PuppetLint.new_check(:hiera_explicit_lookup) do
 
     # disk noops due to defined classes not doing magical hiera lookups
     'govuk::mount::no_op',
-    'govuk::lvm::no_op',
+    'govuk_lvm::no_op',
 
     # govuk::app::nginx_vhost defined type needs a global disable flag for
     # asset pipeline on dev vm

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -52,7 +52,7 @@ node default {
 
   # Create logical volumes from hiera
   $lv = hiera('lv',{})
-  create_resources('govuk::lvm', $lv)
+  create_resources('govuk_lvm', $lv)
   # Create mounts from hiera
   $mount = hiera('mount',{})
   create_resources('govuk::mount', $mount)

--- a/modules/govuk/manifests/mount.pp
+++ b/modules/govuk/manifests/mount.pp
@@ -16,7 +16,7 @@
 #   Default: 5
 #
 # [*govuk_lvm*]
-#   If you're using govuk::lvm to create a logical volume pass the title so
+#   If you're using govuk_lvm to create a logical volume pass the title so
 #   that it gets run before the ext4mount.
 #
 # See the ext4mount module/define for all other parameters. They are defined
@@ -39,7 +39,7 @@ define govuk::mount(
 
   unless hiera(govuk::mount::no_op, false) {
     if $govuk_lvm != undef {
-      Govuk::Lvm[$govuk_lvm] -> Ext4mount[$title]
+      Govuk_lvm[$govuk_lvm] -> Ext4mount[$title]
     }
 
     ext4mount { $title:

--- a/modules/govuk/spec/classes/govuk_nodes_spec_optional.rb
+++ b/modules/govuk/spec/classes/govuk_nodes_spec_optional.rb
@@ -38,7 +38,7 @@ ENV.fetch('classes').split(",").each do |class_name|
 $govuk_node_class = "#{class_name}"
 
 $lv = hiera('lv',{})
-create_resources('govuk::lvm', $lv)
+create_resources('govuk_lvm', $lv)
 $mount = hiera('mount',{})
 create_resources('govuk::mount', $mount)
       EOT

--- a/modules/govuk/spec/defines/govuk__mount_spec.rb
+++ b/modules/govuk/spec/defines/govuk__mount_spec.rb
@@ -25,7 +25,7 @@ describe 'govuk::mount', :type => :define do
 
   context 'custom params' do
     let(:title) { 'gruffalo' }
-    let(:pre_condition) { 'govuk::lvm{"elephant": pv => "/dev/africa", vg => "serengeti"}' }
+    let(:pre_condition) { 'govuk_lvm{"elephant": pv => "/dev/africa", vg => "serengeti"}' }
     let(:params) {{
       :disk         => '/dev/mouse',
       :mountoptions => 'snake=1',
@@ -33,7 +33,7 @@ describe 'govuk::mount', :type => :define do
       :govuk_lvm    => 'elephant',
     }}
 
-    it { is_expected.to contain_govuk__lvm('elephant').that_comes_before('Ext4mount[gruffalo]') }
+    it { is_expected.to contain_govuk_lvm('elephant').that_comes_before('Ext4mount[gruffalo]') }
 
     it { is_expected.to contain_tune_ext('/dev/mouse').that_requires('Ext4mount[gruffalo]') }
 

--- a/modules/govuk_lvm/manifests/init.pp
+++ b/modules/govuk_lvm/manifests/init.pp
@@ -1,4 +1,4 @@
-# == Define: govuk::lvm
+# == Define: govuk_lvm
 #
 # Module to wrap lvm::volume so we dont try to do it on vagrant machines.
 # the title of the resource will be the logical volume name.
@@ -16,19 +16,19 @@
 # To create a logical volume called test on volume group example using /dev/sdb1 as the physical volume.
 # This would be available as /dev/mapper/example-test for mounting by govuk::mount
 #
-#   govuk::lvm { 'test':
+#   govuk_lvm { 'test':
 #     pv => '/dev/sdb1',
 #     vg => 'example',
 #   }
 #
-define govuk::lvm(
+define govuk_lvm(
   # lvm::volume[] options (@dcarley longs for **kwargs)
   $pv,
   $vg,
   $ensure = present,
   $fstype = 'ext4',
   ) {
-  unless hiera(govuk::lvm::no_op, false) {
+  unless hiera(govuk_lvm::no_op, false) {
 
     $filesystem = "/dev/${vg}/${title}"
 

--- a/modules/govuk_lvm/spec/defines/govuk_lvm_spec.rb
+++ b/modules/govuk_lvm/spec/defines/govuk_lvm_spec.rb
@@ -1,6 +1,6 @@
 require_relative '../../../../spec_helper'
 
-describe 'govuk::lvm', :type => :define do
+describe 'govuk_lvm', :type => :define do
   let(:title) { 'purple' }
 
   context 'with no params' do


### PR DESCRIPTION
In a bid to break up the monolithic `govuk` module.