### PR TITLE
Extract govuk::envvar to own module

### DIFF
--- a/modules/govuk/manifests/app/envvar.pp
+++ b/modules/govuk/manifests/app/envvar.pp
@@ -3,7 +3,7 @@
 # Defines an app-specific environment variable to be exported when the app is
 # run using govuk_spinup or govuk_setenv.
 #
-# Unlike govuk::envvar, the dependency between the govuk::app::envvar and the
+# Unlike govuk_envvar, the dependency between the govuk::app::envvar and the
 # application is explicitly encoded, so changing a govuk::app::envvar should
 # automatically restart the relevant application.
 

--- a/modules/govuk/manifests/deploy/config.pp
+++ b/modules/govuk/manifests/deploy/config.pp
@@ -78,7 +78,7 @@ class govuk::deploy::config(
 
   $app_domain = hiera('app_domain')
 
-  govuk::envvar {
+  govuk_envvar {
     'GOVUK_ENV': value => $govuk_env;
     'NODE_ENV': value => $govuk_env;
     'RACK_ENV':  value => $govuk_env;

--- a/modules/govuk/manifests/node/s_draft_cache.pp
+++ b/modules/govuk/manifests/node/s_draft_cache.pp
@@ -8,7 +8,7 @@
 class govuk::node::s_draft_cache() {
   include govuk::node::s_cache
 
-  govuk::envvar { 'PLEK_HOSTNAME_PREFIX':
+  govuk_envvar { 'PLEK_HOSTNAME_PREFIX':
     value => 'draft-',
   }
 }

--- a/modules/govuk/manifests/node/s_draft_content_store.pp
+++ b/modules/govuk/manifests/node/s_draft_content_store.pp
@@ -9,7 +9,7 @@
 class govuk::node::s_draft_content_store() inherits govuk::node::s_base {
   include govuk::node::s_content_store
 
-  govuk::envvar { 'PLEK_HOSTNAME_PREFIX':
+  govuk_envvar { 'PLEK_HOSTNAME_PREFIX':
     value => 'draft-',
   }
 }

--- a/modules/govuk/manifests/node/s_draft_email_campaign_frontend.pp
+++ b/modules/govuk/manifests/node/s_draft_email_campaign_frontend.pp
@@ -8,7 +8,7 @@
 class govuk::node::s_draft_email_campaign_frontend() inherits govuk::node::s_base {
   include govuk::node::s_email_campaign_frontend
 
-  govuk::envvar { 'PLEK_HOSTNAME_PREFIX':
+  govuk_envvar { 'PLEK_HOSTNAME_PREFIX':
     value => 'draft-',
   }
 }

--- a/modules/govuk/manifests/node/s_draft_frontend.pp
+++ b/modules/govuk/manifests/node/s_draft_frontend.pp
@@ -8,7 +8,7 @@
 class govuk::node::s_draft_frontend() inherits govuk::node::s_base {
   include govuk::node::s_frontend
 
-  govuk::envvar { 'PLEK_HOSTNAME_PREFIX':
+  govuk_envvar { 'PLEK_HOSTNAME_PREFIX':
     value => 'draft-',
   }
 }

--- a/modules/govuk/manifests/safe_to_reboot/careful.pp
+++ b/modules/govuk/manifests/safe_to_reboot/careful.pp
@@ -6,10 +6,10 @@
 class govuk::safe_to_reboot::careful (
   $reason,
 ) {
-  govuk::envvar { 'SAFE_TO_REBOOT':
+  govuk_envvar { 'SAFE_TO_REBOOT':
     value => 'careful',
   }
-  govuk::envvar { 'SAFE_TO_REBOOT_REASON':
+  govuk_envvar { 'SAFE_TO_REBOOT_REASON':
     value => $reason,
   }
 }

--- a/modules/govuk/manifests/safe_to_reboot/no.pp
+++ b/modules/govuk/manifests/safe_to_reboot/no.pp
@@ -6,10 +6,10 @@
 class govuk::safe_to_reboot::no (
   $reason,
 ) {
-  govuk::envvar { 'SAFE_TO_REBOOT':
+  govuk_envvar { 'SAFE_TO_REBOOT':
     value => 'no',
   }
-  govuk::envvar { 'SAFE_TO_REBOOT_REASON':
+  govuk_envvar { 'SAFE_TO_REBOOT_REASON':
     value => $reason,
   }
 }

--- a/modules/govuk/manifests/safe_to_reboot/overnight.pp
+++ b/modules/govuk/manifests/safe_to_reboot/overnight.pp
@@ -6,10 +6,10 @@
 class govuk::safe_to_reboot::overnight (
   $reason,
 ) {
-  govuk::envvar { 'SAFE_TO_REBOOT':
+  govuk_envvar { 'SAFE_TO_REBOOT':
     value => 'overnight',
   }
-  govuk::envvar { 'SAFE_TO_REBOOT_REASON':
+  govuk_envvar { 'SAFE_TO_REBOOT_REASON':
     value => $reason,
   }
 }

--- a/modules/govuk/manifests/safe_to_reboot/yes.pp
+++ b/modules/govuk/manifests/safe_to_reboot/yes.pp
@@ -6,10 +6,10 @@
 class govuk::safe_to_reboot::yes (
   $reason,
 ) {
-  govuk::envvar { 'SAFE_TO_REBOOT':
+  govuk_envvar { 'SAFE_TO_REBOOT':
     value => 'yes',
   }
-  govuk::envvar { 'SAFE_TO_REBOOT_REASON':
+  govuk_envvar { 'SAFE_TO_REBOOT_REASON':
     value => $reason,
   }
 }

--- a/modules/govuk_envvar/manifests/init.pp
+++ b/modules/govuk_envvar/manifests/init.pp
@@ -1,14 +1,14 @@
-# govuk::envvar
+# govuk_envvar
 #
 # Defines a global GOV.UK environment variable, which will be exported for all
 # applications when using govuk_spinup or govuk_setenv.
 #
 # NB: most applications will alter their behaviour on the basis of the value
-# of govuk::envvars, but there is no explicit dependency encoded here. You may
+# of govuk_envvars, but there is no explicit dependency encoded here. You may
 # need to restart an application before it picks up a changed environment
 # variable.
 
-define govuk::envvar ($value, $envdir = '/etc/govuk/env.d', $varname = $title) {
+define govuk_envvar ($value, $envdir = '/etc/govuk/env.d', $varname = $title) {
 
   file { "${envdir}/${varname}":
     content => $value,


### PR DESCRIPTION
In a bid to break up the monolithic `govuk` module.