### PR TITLE
Extract govuk::firewall into own module

### DIFF
--- a/modules/govuk/manifests/node/s_base.pp
+++ b/modules/govuk/manifests/node/s_base.pp
@@ -14,7 +14,7 @@ class govuk::node::s_base (
 
   include backup::client
   include base
-  include govuk::firewall
+  include govuk_firewall
   include govuk::safe_to_reboot
   include govuk_rbenv
   include govuk_unattended_reboot

--- a/modules/govuk_firewall/manifests/init.pp
+++ b/modules/govuk_firewall/manifests/init.pp
@@ -1,5 +1,5 @@
 # FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
-class govuk::firewall {
+class govuk_firewall {
 
   include ufw
 


### PR DESCRIPTION
In a bid to break up the monolithic `govuk` module.