### PR TITLE
Extract govuk::sshkeys into own module

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -272,7 +272,7 @@ govuk::node::s_transition_postgresql_slave::redirector_ip_range: 10.6.0.1/16
 
 govuk::ppa::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
-govuk::sshkeys::deployment_keys:
+govuk_sshkeys::deployment_keys:
   github.com:
     key: 'AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=='
   github.gds:

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -207,7 +207,7 @@ govuk_postgresql::server::snakeoil_ssl_key: key
 
 govuk::ppa::path: preview
 
-govuk::sshkeys::development_keys:
+govuk_sshkeys::development_keys:
   jumpbox.integration.publishing.service.gov.uk:
     key: "AAAAB3NzaC1yc2EAAAADAQABAAABAQDLRdHg/Ae3XZy2f7o2PMJIDQznrE7FjWyzC1MIvL1dDDKhcG+ht+IH05w3eUCuMQVj8t5Wihpp/oB8Fm/+d15xJQtW3oIggE34KMADYN3M00anaod+GhdKubOnFQRF/wtX0/CPdt/isuWdGweudKSwse4rV4U7aaTD+sb1co8tIGfpQNtnI1nEg0rjSe4DSw1FT9gzmkrISj3yECcA0OMvAFlxorRY4WzWajCW2tfxGRdBA7jpzMTpMy1nmuj6YXcvmpzkegu1IioxH5H6YosBxOd2i7gq89YDEMkWRM/8u+hMF77jV9kO+4zbKDo95UUyH87TKSlG1iU4A/8MLMT7"
     host_aliases: "31.210.245.102"

--- a/modules/base/manifests/init.pp
+++ b/modules/base/manifests/init.pp
@@ -15,8 +15,8 @@ class base {
   include govuk::deploy
   include govuk::envsys
   include govuk_scripts
-  include govuk::sshkeys
   include govuk_apt::unused_kernels
+  include govuk_sshkeys
   include govuk_sudo
   include logrotate
   include motd

--- a/modules/govuk_sshkeys/manifests/init.pp
+++ b/modules/govuk_sshkeys/manifests/init.pp
@@ -1,4 +1,4 @@
-# == Class: govuk::sshkeys
+# == Class: govuk_sshkeys
 #
 # Add predefined SSH host keys to a machine. These keys are intended to be for
 # hosts that a machine will almost always have to connect to.
@@ -13,7 +13,7 @@
 #   allow the data replication script to work without prompting to connect
 #   to hosts.
 #
-class govuk::sshkeys (
+class govuk_sshkeys (
   $deployment_keys = {},
   $development_keys = {},
 ) {


### PR DESCRIPTION
In a bid to break up the monolithic `govuk` module.