### PR TITLE
Bundle install before running migration check

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/tagging_migration_check.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/tagging_migration_check.yaml.erb
@@ -20,6 +20,7 @@
         - timed: '0 * * * *' # every hour
     builders:
         - shell: |
+            bundle install --path "${HOME}/bundles/${JOB_NAME}"
             bin/verify_migrated_apps
     publishers:
       - trigger-parameterized-builds:


### PR DESCRIPTION
https://github.com/alphagov/tagging-migration-verifier/pull/8 will make the script rely on installed gems. This commit makes sure that we run `bundle install` on each run.

Trello: https://trello.com/c/q5jUopvT