### PR TITLE
Pin Puppet gems to correct versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,8 @@ gem "rake"
 gem "puppet-syntax", '2.1.0'
 gem "puppet-lint"
 gem 'puppet-lint-trailing_comma-check', :require => false
-gem "puppet", "~> 3.6.0"
+gem "puppet", '3.6.2'
+gem 'facter', '1.7.5'
 gem "hiera", "1.3.4"
 gem "hiera-eyaml-gpg", :git => 'git://github.com/alphagov/hiera-eyaml-gpg.git', :branch => 'avoid_gpghome_env_var'
 gem "rspec-puppet"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,6 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (2.2.8)
     activemodel (4.1.8)
       activesupport (= 4.1.8)
       builder (~> 3.1)
@@ -25,8 +24,7 @@ GEM
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
-    facter (2.2.0)
-      CFPropertyList (~> 2.2.6)
+    facter (1.7.5)
     faraday (0.9.0)
       multipart-post (>= 1.2, < 3)
     gpgme (2.0.8)
@@ -113,12 +111,13 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  facter (= 1.7.5)
   hiera (= 1.3.4)
   hiera-eyaml-gpg!
   librarian-puppet
   parallel
   parallel_tests
-  puppet (~> 3.6.0)
+  puppet (= 3.6.2)
   puppet-lint
   puppet-lint-trailing_comma-check
   puppet-syntax (= 2.1.0)

--- a/lib/tasks/spec.rake
+++ b/lib/tasks/spec.rake
@@ -46,7 +46,7 @@ namespace :spec do
     node_classes = get_node_classes
 
     NUM_PROCESSES = [
-      Facter.value('processors')['count'],
+      Facter.value('processorcount').to_i,
       node_classes.length
     ].min
 


### PR DESCRIPTION
In `puppet::package` we install specific versions of our dependencies. We should install the same versions in development as gems.

This commit downgrades facter from 2.x to 1.x to ensure that our tests run the same code as our other environments.