### PR TITLE
Remove fail2ban package

### DIFF
--- a/modules/govuk/manifests/node/s_base.pp
+++ b/modules/govuk/manifests/node/s_base.pp
@@ -103,6 +103,11 @@ class govuk::node::s_base (
     ensure => purged,
   }
 
+  # FIXME: remove once this has been deployed
+  package { 'fail2ban':
+    ensure => purged,
+  }
+
   # Remove user on first Puppet run after bootstrapping.
   user { 'ubuntu':
     ensure => absent,


### PR DESCRIPTION
fail2ban puppet class was removed in c11b00ad231e0784c64c15f56f2272d7a442a356, but we did not ensure that the package would be stopped and removed.