### PR TITLE
Include unattended reboot on dev but disable it

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -115,6 +115,7 @@ base::packages::packages:
   - 'tcpdump'
   - 'tmux'
   - 'tree'
+  - 'update-notifier-common'
   - 'unzip'
   - 'vim-nox'
   - 'xz-utils'
@@ -351,6 +352,8 @@ govuk_sudo::sudo_conf:
     content: 'ubuntu ALL=(ALL) NOPASSWD:ALL'
 
 govuk_unattended_reboot::enabled: true
+govuk_unattended_reboot::mongodb::enabled: true
+
 govuk_unattended_reboot::monitoring_basic_auth:
   username: "%{hiera('http_username')}"
   password: "%{hiera('http_password')}"

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -230,6 +230,9 @@ govuk::sshkeys::development_keys:
   whitehall-mysql-backup-1.backend.integration:
     key: "AAAAB3NzaC1yc2EAAAADAQABAAABAQCvYDHGv5HGn+0UkNySdJKIEfj+dhLA7bE7+jnantWsit7EdzEupG1AffmZxL4fOnKubwclA/ZkeC8/HtTp3ZsM9rmBsyYQLlY3ZRotcPxwLadLHtXGjq71nKbikFafjA1f7NVa0yRqFuHHrcQyzAsfmN1QWP/IaSwUWRI72XlSs+QTuX0NPlhLkJ548ltIXxwUgT/EdXCVA3ZrIrt6KddeKQ5enxB0qqCqoMt4iHIDadSXcfFoT7Y9xSeDZ+vURHll2knuNY2wKncytq3XcYMYey2Ke44CQjRL4GfasoS6DYUqCR2QSzKhWm83zXiYIP0uP4RMpjjwlJFJn/hQtWuX"
 
+govuk_unattended_reboot::enabled: false
+govuk_unattended_reboot::mongodb::enabled: false
+
 hosts::development::apps:
   - 'asset-manager'
   - 'bouncer'

--- a/modules/base/manifests/init.pp
+++ b/modules/base/manifests/init.pp
@@ -18,6 +18,7 @@ class base {
   include govuk::sshkeys
   include govuk_apt::unused_kernels
   include govuk_sudo
+  include govuk_unattended_reboot
   include logrotate
   include motd
   include ntp

--- a/modules/govuk/manifests/node/s_base.pp
+++ b/modules/govuk/manifests/node/s_base.pp
@@ -17,7 +17,6 @@ class govuk::node::s_base (
   include govuk::firewall
   include govuk::safe_to_reboot
   include govuk_rbenv
-  include govuk_unattended_reboot
   include grub2
   include harden
   include hosts

--- a/modules/govuk_unattended_reboot/manifests/mongodb.pp
+++ b/modules/govuk_unattended_reboot/manifests/mongodb.pp
@@ -3,13 +3,26 @@
 # Installs a script which ensures that a MongoDB server
 # can be rebooted.
 #
-class govuk_unattended_reboot::mongodb {
+# === Parameters
+#
+# [*enabled*]
+#   Whether to enable unattended reboots.
+#
+class govuk_unattended_reboot::mongodb (
+  $enabled = false
+) {
 
   $config_directory = '/etc/unattended-reboot'
   $check_scripts_directory = "${config_directory}/check"
 
+  if ($enabled) {
+    $file_ensure = present
+  } else {
+    $file_ensure = absent
+  }
+
   file { "${check_scripts_directory}/02_mongodb.py":
-    ensure  => present,
+    ensure  => $file_ensure,
     mode    => '0755',
     owner   => 'root',
     group   => 'root',

--- a/modules/monitoring/manifests/client.pp
+++ b/modules/monitoring/manifests/client.pp
@@ -8,15 +8,6 @@ class monitoring::client {
   include collectd
   include collectd::plugin::tcp
 
-  # Provides:
-  # - `notify-reboot-required` which is referenced in the `postinst`
-  #   of some packages in order to request that the system be rebooted at a
-  #   convenient time. Required by the `check_reboot_required` alert, but
-  #   still beneficial to have on nodes that aren't monitored by Nagios.
-  # - `apt-check` which is called by the `check_apt_security_updates` alert.
-  #   More reliable than the builtin Nagios plugin.
-  package {'update-notifier-common': }
-
   package {'gds-nagios-plugins':
     ensure   => '1.4.0',
     provider => 'pip',


### PR DESCRIPTION
There is an assumed dependency between unattended_reboot::mongo on unattended_reboot. Previously puppet was not running on development as we only included the mongo one from there. We include this automatically wherever we use mongo. 

This PR solves this by including unattended_reboot everywhere and disabling both classes on development.

update-notifier-common is now required everywhere, not just for monitoring clients.