### PR TITLE
Add wildcard for nagios sudoers rule

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -346,7 +346,7 @@ govuk_sudo::sudo_conf:
   deploy_service_varnish:
     content: 'deploy ALL=NOPASSWD:/etc/init.d/varnish'
   icinga_init_ctl:
-    content: 'nagios ALL=NOPASSWD:/sbin/initctl reload'
+    content: 'nagios ALL=NOPASSWD:/sbin/initctl reload *'
   ubuntu:
     content: 'ubuntu ALL=(ALL) NOPASSWD:ALL'
 


### PR DESCRIPTION
In 0ac9c6a42cd3d56a732e064ebed218d2419cfbb8 we made this rule more restrictive, but it turns out that if you pass in one command-line argument to the sudoers file you need a wildcard to allow all arguments under that.