### PR TITLE
Make integration work one hour earlier

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
@@ -22,7 +22,7 @@
     logrotate:
         artifactNumToKeep: 10
     triggers:
-        - timed: 'H 5 * * 1-5'
+        - timed: 'H 4 * * 1-5'
     builders:
         - shell: |
             set -eu

--- a/modules/govuk_jenkins/templates/jobs/start_vapps.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/start_vapps.yaml.erb
@@ -39,4 +39,4 @@
             cd tools/start_stop_vapps/
             ./run.sh ./start_stop_all_vapps.rb start
     triggers:
-        - timed: '30 4 * * 1-5'
+        - timed: '30 3 * * 1-5'


### PR DESCRIPTION
The content team are using integration for training and they need to have it working in the morning.

Specialist publisher currently has an issue where the database is in an inconsistent state in integration between the times when:

- The database is upgraded
- The data sync complete job is run

@stephaniekd has agreed to having integration switched on a little bit earlier.