### PR TITLE
[WIP] Add Mapit to api load balancer

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -148,6 +148,8 @@ govuk::node::s_api_lb::draft_content_store_servers:
 govuk::node::s_api_lb::email_campaign_api_servers:
   - "email-campaign-api-1.api"
   - "email-campaign-api-2.api"
+govuk::node::s_api_lb::mapit_servers:
+  - "mapit-1.api"
 govuk::node::s_api_lb::search_servers:
   - "search-1.api"
   - "search-2.api"

--- a/modules/govuk/manifests/node/s_api_lb.pp
+++ b/modules/govuk/manifests/node/s_api_lb.pp
@@ -4,6 +4,7 @@ class govuk::node::s_api_lb (
   $content_store_servers,
   $draft_content_store_servers,
   $email_campaign_api_servers,
+  $mapit_servers,
   $search_servers,
 ) {
   include govuk::node::s_base
@@ -58,6 +59,12 @@ class govuk::node::s_api_lb (
   loadbalancer::balance { 'email-campaign-api':
     servers       => $email_campaign_api_servers,
     internal_only => true,
+  }
+
+  loadbalancer::balance { 'mapit':
+    servers       => $mapit_servers,
+    internal_only => true,
+    https_only    => false, # FIXME: Remove for #51136581
   }
 
   loadbalancer::balance {


### PR DESCRIPTION
This is to enable us to use the new version of Mapit (initially for testing
 with dependant apps in Integration).

This part sets up the configuration so that both versions are available.

When ready, we'll change the config so that the Mapit URL points at the new
version. We'll then be able to test before switching it back.

https://trello.com/c/LrsfgWXN/30-test-the-new-version-of-mapit-in-integration