### PR TITLE
Fix script to run tagging migration verifier

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/tagging_migration_check.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/tagging_migration_check.yaml.erb
@@ -21,7 +21,7 @@
     builders:
         - shell: |
             bundle install --path "${HOME}/bundles/${JOB_NAME}"
-            bin/verify_migrated_apps
+            bundle exec bin/verify_migrated_apps
     publishers:
       - trigger-parameterized-builds:
         - project: Success_Passive_Check


### PR DESCRIPTION
Since we now have a dependency on http, we need to bundle and _also_ run it with `bundle exec`. As opposed to https://github.com/alphagov/govuk-puppet/pull/4098, I've now actually tried this change in jenkins first, so I'm pretty sure this actually works.

Trello: https://trello.com/c/q5jUopvT
