### PR TITLE
Enable caching of vendor/{bundle,modules} on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 rvm:
   - 1.9.3
 install:
-  - bundle install
+  - bundle install --jobs=3 --retry=3 --deployment --path=${BUNDLE_PATH:-vendor/bundle}
   - bundle exec rake librarian:install
 script:
   - bundle exec rake lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: ruby
 sudo: false
+cache:
+  directories:
+    - vendor/bundle
+    - vendor/modules
 rvm:
   - 1.9.3
 install:


### PR DESCRIPTION
To speed up travis runs.

Also changes the bundle install command to match the one used by travis normally