### PR TITLE
Run tagging migration in production & staging

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -58,7 +58,6 @@ govuk::apps::content_register::db::backend_ip_range: '10.3.3.0/24'
 govuk::apps::email_alert_api::db::backend_ip_range: '10.3.3.0/24'
 govuk::apps::errbit::errbit_email_from: 'govuk-winston+errbit-production@digital.cabinet-office.gov.uk'
 govuk::apps::hmrc_manuals_api::publish_topics: false
-govuk::apps::panopticon::enable_procfile_worker: false
 govuk::apps::publicapi::backdrop_host: 'www.performance.service.gov.uk'
 govuk::apps::publisher::data_import_passive_check: true
 

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -13,7 +13,6 @@ govuk::apps::content_register::db::backend_ip_range: '10.2.3.0/24'
 govuk::apps::email_alert_api::db::backend_ip_range: '10.2.3.0/24'
 govuk::apps::errbit::errbit_email_from: 'govuk-winston+errbit-staging@digital.cabinet-office.gov.uk'
 govuk::apps::hmrc_manuals_api::publish_topics: false
-govuk::apps::panopticon::enable_procfile_worker: false
 govuk::apps::publicapi::backdrop_host: 'www.staging.performance.service.gov.uk'
 govuk::apps::sidekiq_monitoring::enabled: true
 


### PR DESCRIPTION
Panopticons procfileworker is not turned on currently in production and staging (but by default is in integration). The procfile worker starts the message queue consumer which copies tags from publishing-api to the contentapi.