### PR TITLE
Define icinga checks for every rabbitmq consumer

### DIFF
--- a/modules/govuk/manifests/apps/content_register.pp
+++ b/modules/govuk/manifests/apps/content_register.pp
@@ -51,7 +51,4 @@ class govuk::apps::content_register(
   govuk::procfile::worker {'content-register':
     enable_service => $enable_procfile_worker,
   }
-  govuk_rabbitmq::monitor_consumers {'content-register_rabbitmq-consumers':
-    rabbitmq_queue => 'content_register',
-  }
 }

--- a/modules/govuk/manifests/apps/email_alert_service.pp
+++ b/modules/govuk/manifests/apps/email_alert_service.pp
@@ -31,9 +31,6 @@ class govuk::apps::email_alert_service(
     enable_nginx_vhost => false,
     command            => './bin/email_alert_service',
   }
-  govuk_rabbitmq::monitor_consumers {'email-alert-service_rabbitmq-consumers':
-    rabbitmq_queue     => 'email_alert_service',
-  }
 
   Govuk::App::Envvar {
     app => 'email-alert-service',

--- a/modules/govuk/manifests/apps/rummager.pp
+++ b/modules/govuk/manifests/apps/rummager.pp
@@ -98,10 +98,6 @@ class govuk::apps::rummager(
     process_type   => 'publishing-api-document-indexer',
   }
 
-  govuk_rabbitmq::monitor_consumers {'rummager-publishing-api-document-indexer':
-    rabbitmq_queue => 'rummager_to_be_indexed',
-  }
-
   Govuk::App::Envvar {
     app            => 'rummager',
   }

--- a/modules/govuk_rabbitmq/manifests/consumer.pp
+++ b/modules/govuk_rabbitmq/manifests/consumer.pp
@@ -70,4 +70,9 @@ define govuk_rabbitmq::consumer (
       ensure   => absent,
     }
   }
+
+  govuk_rabbitmq::monitor_consumers {"${title}_consumer_monitoring":
+    rabbitmq_hostname => 'localhost',
+    rabbitmq_queue    => $amqp_queue,
+  }
 }


### PR DESCRIPTION
Currently we define these checks in the app modules for a few consumers,
meaning they get run from the backend, and make requests against the
first rabbitmq node.

We get duplicate checks when services are clustered, and we don't have
checks defined for all consumers.

This changes the check to run on the rabbitmq nodes, against localhost,
and we define it in the same place we create service users, so the checks
are extended to every consumer.

There is still some duplicated checks because clustered nodes will return
the same result, but its easier to keep the configuration the same for
all of them.