### PR TITLE
Add Mapit to api load balancer

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -143,11 +143,13 @@ govuk::node::s_api_lb::content_store_servers:
   - "content-store-1.api"
   - "content-store-2.api"
 govuk::node::s_api_lb::draft_content_store_servers:
-- "draft-content-store-1.api"
-- "draft-content-store-2.api"
+  - "draft-content-store-1.api"
+  - "draft-content-store-2.api"
 govuk::node::s_api_lb::email_campaign_api_servers:
   - "email-campaign-api-1.api"
   - "email-campaign-api-2.api"
+govuk::node::s_api_lb::mapit_servers:
+  - "mapit-1.api"
 govuk::node::s_api_lb::search_servers:
   - "search-1.api"
   - "search-2.api"

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -143,12 +143,13 @@ govuk::node::s_api_lb::content_store_servers:
   - "content-store-2.api"
   - "content-store-3.api"
 govuk::node::s_api_lb::draft_content_store_servers:
-- "draft-content-store-1.api"
-- "draft-content-store-2.api"
+  - "draft-content-store-1.api"
+  - "draft-content-store-2.api"
 govuk::node::s_api_lb::email_campaign_api_servers:
   - "email-campaign-api-1.api"
   - "email-campaign-api-2.api"
   - "email-campaign-api-3.api"
+govuk::node::s_api_lb::mapit_servers: [] # doesn't exist in production yet
 govuk::node::s_api_lb::search_servers:
   - "search-1.api"
   - "search-2.api"

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -79,12 +79,13 @@ govuk::node::s_api_lb::content_store_servers:
   - "content-store-2.api"
   - "content-store-3.api"
 govuk::node::s_api_lb::draft_content_store_servers:
-- "draft-content-store-1.api"
-- "draft-content-store-2.api"
+  - "draft-content-store-1.api"
+  - "draft-content-store-2.api"
 govuk::node::s_api_lb::email_campaign_api_servers:
   - "email-campaign-api-1.api"
   - "email-campaign-api-2.api"
   - "email-campaign-api-3.api"
+govuk::node::s_api_lb::mapit_servers: [] # doesn't exist in staging yet
 govuk::node::s_api_lb::search_servers:
   - "search-1.api"
   - "search-2.api"

--- a/hieradata/vagrant.yaml
+++ b/hieradata/vagrant.yaml
@@ -45,11 +45,13 @@ govuk::node::s_api_lb::content_store_servers:
   - "content-store-1.api"
   - "content-store-2.api"
 govuk::node::s_api_lb::draft_content_store_servers:
-- "draft-content-store-1.api"
-- "draft-content-store-2.api"
+  - "draft-content-store-1.api"
+  - "draft-content-store-2.api"
 govuk::node::s_api_lb::email_campaign_api_servers:
   - "email-campaign-api-1.api"
   - "email-campaign-api-2.api"
+govuk::node::s_api_lb::mapit_servers:
+  - "mapit-1.api"
 govuk::node::s_api_lb::search_servers:
   - "search-1.api"
   - "search-2.api"

--- a/modules/govuk/manifests/node/s_api_lb.pp
+++ b/modules/govuk/manifests/node/s_api_lb.pp
@@ -4,6 +4,7 @@ class govuk::node::s_api_lb (
   $content_store_servers,
   $draft_content_store_servers,
   $email_campaign_api_servers,
+  $mapit_servers,
   $search_servers,
 ) {
   include govuk::node::s_base
@@ -58,6 +59,14 @@ class govuk::node::s_api_lb (
   loadbalancer::balance { 'email-campaign-api':
     servers       => $email_campaign_api_servers,
     internal_only => true,
+  }
+
+  if !empty($mapit_servers) {
+    loadbalancer::balance { 'mapit':
+      servers       => $mapit_servers,
+      internal_only => true,
+      https_only    => false, # FIXME: Remove for #51136581
+    }
   }
 
   loadbalancer::balance {


### PR DESCRIPTION
This is to enable us to use the new version of Mapit (initially for testing
with dependant apps in Integration).

This part sets up the configuration so that both versions are available (ie
via the backend or api loadbalancers).  The new Mapit server type is not
available in staging or production yet.

https://trello.com/c/LrsfgWXN/30-test-the-new-version-of-mapit-in-integration