### PR TITLE
Enable travel advice email alerts

### DIFF
--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -180,6 +180,7 @@ govuk::apps::support::enable_procfile_worker: false
 govuk::apps::support_api::enable_procfile_worker: false
 govuk::apps::tariff_api::enable_procfile_worker: false
 govuk::apps::transition::enable_procfile_worker: false
+govuk::apps::travel_advice_publisher::enable_email_alerts: true
 govuk::apps::whitehall::configure_admin: true
 govuk::apps::whitehall::configure_frontend: true
 govuk::apps::whitehall::enable_procfile_worker: false

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -26,6 +26,7 @@ govuk::apps::share_sale_publisher::enabled: true
 govuk::apps::smartanswers::expose_govspeak: true
 govuk::apps::specialist_publisher::publish_pre_production_finders: true
 govuk::apps::sidekiq_monitoring::enabled: true
+govuk::apps::travel_advice_publisher::enable_email_alerts: true
 govuk::apps::url_arbiter::db::backend_ip_range: '10.1.3.0/24'
 
 govuk::deploy::aws_ses_smtp_host: 'email-smtp.eu-west-1.amazonaws.com'

--- a/modules/govuk/manifests/apps/travel_advice_publisher.pp
+++ b/modules/govuk/manifests/apps/travel_advice_publisher.pp
@@ -8,6 +8,10 @@
 #   The port that publishing API is served on.
 #   Default: 3078
 #
+# [*enable_email_alerts*]
+#   Send email alerts via the email-alert-api
+#   Default: false
+#
 # [*mongodb_name*]
 #   The Mongo database to be used.
 #
@@ -23,6 +27,7 @@
 #
 class govuk::apps::travel_advice_publisher(
   $port = '3035',
+  $enable_email_alerts = false,
   $mongodb_name = undef,
   $mongodb_nodes = undef,
   $secret_key_base = undef,
@@ -58,5 +63,15 @@ class govuk::apps::travel_advice_publisher(
     "${title}-SECRET_KEY_BASE":
       varname => 'SECRET_KEY_BASE',
       value   => $secret_key_base;
+  }
+
+  validate_bool($enable_email_alerts)
+
+  if ($enable_email_alerts) {
+    govuk::app::envvar {
+      "${title}-SEND_EMAIL_ALERTS":
+        varname => 'SEND_EMAIL_ALERTS',
+        value   => '1';
+    }
   }
 }


### PR DESCRIPTION
Enable email alerts in integration and development.

https://github.com/alphagov/travel-advice-publisher/blob/cd0fdf68fa00c66b841e9a8ee263f20a69df62b0/config/environments/production.rb#L71 shows the use of the feature flag.