### PR TITLE
Extract govuk::python into own module

### DIFF
--- a/modules/govuk/manifests/apps/govuk_delivery.pp
+++ b/modules/govuk/manifests/apps/govuk_delivery.pp
@@ -5,7 +5,7 @@ class govuk::apps::govuk_delivery(
   $enable_procfile_worker = true,
 ) {
   if $enabled {
-    include govuk::python
+    include govuk_python
 
     govuk::app { 'govuk-delivery':
       app_type           => 'procfile',

--- a/modules/govuk/manifests/deploy.pp
+++ b/modules/govuk/manifests/deploy.pp
@@ -7,7 +7,7 @@ class govuk::deploy (
     $aws_ses_smtp_password = 'UNSET',
 ){
   include govuk_logging
-  include govuk::python
+  include govuk_python
   include harden
   include unicornherder
 

--- a/modules/govuk/manifests/node/s_development.pp
+++ b/modules/govuk/manifests/node/s_development.pp
@@ -27,7 +27,7 @@ class govuk::node::s_development (
   include redis
   include tmpreaper
 
-  include govuk::python
+  include govuk_python
   include govuk::testing_tools
 
   include govuk_rbenv::all

--- a/modules/govuk_jenkins/manifests/init.pp
+++ b/modules/govuk_jenkins/manifests/init.pp
@@ -28,7 +28,7 @@ class govuk_jenkins (
 ) {
   validate_hash($config, $plugins)
 
-  include govuk::python
+  include govuk_python
   include govuk_jenkins::job_builder
   include govuk_jenkins::ssh_key
   include govuk_jenkins::config

--- a/modules/govuk_python/manifests/init.pp
+++ b/modules/govuk_python/manifests/init.pp
@@ -1,5 +1,5 @@
 # FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
-class govuk::python {
+class govuk_python {
 
   class { '::python':
     pip        => 'present',


### PR DESCRIPTION
To help break up the monolithic `govuk` module.