### PR TITLE
Disable plaintext HTTP for Errbit and Kibana

### DIFF
--- a/modules/govuk/manifests/node/s_backend_lb.pp
+++ b/modules/govuk/manifests/node/s_backend_lb.pp
@@ -88,13 +88,11 @@ class govuk::node::s_backend_lb (
   }
 
   loadbalancer::balance { 'errbit':
-    servers    => $errbit_servers,
-    https_only => false, # FIXME: Remove for #51136581
+    servers => $errbit_servers,
   }
 
   loadbalancer::balance { 'kibana':
     read_timeout => 5,
-    https_only   => false, # FIXME: Remove for #51136581
   }
 
   loadbalancer::balance { 'mapit':

--- a/modules/govuk/manifests/node/s_backend_lb.pp
+++ b/modules/govuk/manifests/node/s_backend_lb.pp
@@ -1,4 +1,27 @@
-# FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
+# == Class: govuk::node::s_backend_lb
+#
+# Sets up a backend loadbalancer
+#
+# === Parameters
+#
+# [*perfplat_public_app_domain*]
+#   The public application domain for the Performance Platform
+#
+# [*backend_servers*]
+#   An array of backend app servers
+#
+# [*mapit_servers*]
+#   An array of mapit servers
+#
+# [*performance_backend_servers*]
+#   An array of Performance Platform backend app servers
+#
+# [*whitehall_backend_servers*]
+#   An array of whitehall backend app servers
+#
+# [*maintenance_mode*]
+#   Whether the backend should be taken offline in nginx
+#
 class govuk::node::s_backend_lb (
   $perfplat_public_app_domain = 'performance.service.gov.uk',
   $backend_servers,


### PR DESCRIPTION
I don't think there's any reason for these services to listen on port 80.

Both the HTTP and HTTPS requests log to the same place so I don't think there's any way to see if anything is using port 80 right now.

Tests failed on Travis but Jenkins is fine.