### PR TITLE
Make upstream apps aware of secure status

### DIFF
--- a/modules/loadbalancer/templates/nginx_balance.conf.erb
+++ b/modules/loadbalancer/templates/nginx_balance.conf.erb
@@ -25,6 +25,7 @@ server {
   proxy_set_header X-Real-IP $remote_addr;
   proxy_set_header X-Forwarded-Server $host;
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  proxy_set_header X-Forwarded-Proto $scheme;
   proxy_redirect off;
 
   proxy_connect_timeout 1s;


### PR DESCRIPTION
Sends the `X-Forwarded-Proto` header to unicorn et al so that apps can
make decisions based on whether a page is being served over http or
https.

Will allow us to set `config.force_ssl` in Signon.

/cc @alexmuller @mattbostock 