### PR TITLE
Extract govuk::user into its own module

### DIFF
--- a/modules/backup/manifests/client.pp
+++ b/modules/backup/manifests/client.pp
@@ -13,7 +13,7 @@ class backup::client (
   $backup_public_key = '',
 ) {
 
-  govuk::user { 'govuk-backup':
+  govuk_user { 'govuk-backup':
     fullname    => 'Backup User',
     email       => 'webops@digital.cabinet-office.gov.uk',
     ssh_key     => "ssh-rsa ${backup_public_key}",

--- a/modules/backup/manifests/server.pp
+++ b/modules/backup/manifests/server.pp
@@ -37,7 +37,7 @@ class backup::server (
     mode   => '0700',
   }
 
-  # Parent dir is provided by govuk::user in backup::client.
+  # Parent dir is provided by govuk_user in backup::client.
   file {'/home/govuk-backup/.ssh/id_rsa':
     ensure  => file,
     owner   => 'govuk-backup',

--- a/modules/backup/spec/classes/backup__offsite_spec.rb
+++ b/modules/backup/spec/classes/backup__offsite_spec.rb
@@ -80,7 +80,7 @@ describe 'backup::offsite', :type => :class do
     }
 
     it {
-      # Leaky abstraction? We need to know that govuk::user creates the
+      # Leaky abstraction? We need to know that govuk_user creates the
       # parent directory for our file.
       is_expected.to contain_file('/home/govuk-backup/.ssh').with_ensure('directory')
     }

--- a/modules/backup/spec/classes/backup__server_spec.rb
+++ b/modules/backup/spec/classes/backup__server_spec.rb
@@ -2,7 +2,7 @@ require_relative '../../../../spec_helper'
 
 describe 'backup::server', :type => :class do
   it {
-    # Leaky abstraction? We need to know that govuk::user creates the
+    # Leaky abstraction? We need to know that govuk_user creates the
     # parent directory for our file.
     is_expected.to contain_file('/home/govuk-backup/.ssh').with_ensure('directory')
   }

--- a/modules/govuk_crawler/manifests/init.pp
+++ b/modules/govuk_crawler/manifests/init.pp
@@ -98,7 +98,7 @@ class govuk_crawler(
   create_resources('sshkey', $ssh_keys)
 
   # User used to rsync crawled content to the remote mirror
-  govuk::user { $crawler_user:
+  govuk_user { $crawler_user:
     fullname => 'GOV.UK Crawler',
     email    => 'webops@digital.cabinet-office.gov.uk',
   }
@@ -107,7 +107,7 @@ class govuk_crawler(
     owner   => $crawler_user,
     mode    => '0600',
     content => $ssh_private_key,
-    require => Govuk::User[$crawler_user],
+    require => Govuk_user[$crawler_user],
   }
 
   file { $seeder_lock_path:

--- a/modules/govuk_crawler/spec/classes/govuk_crawler_spec.rb
+++ b/modules/govuk_crawler/spec/classes/govuk_crawler_spec.rb
@@ -15,7 +15,7 @@ describe 'govuk_crawler', :type => :class do
   it { is_expected.to contain_file('/foo/error') }
 
   it {
-    # Leaky abstraction? We need to know that govuk::user creates the
+    # Leaky abstraction? We need to know that govuk_user creates the
     # parent directory for our file.
     is_expected.to contain_file('/home/govuk-crawler/.ssh').with_ensure('directory')
   }

--- a/modules/govuk_user/manifests/init.pp
+++ b/modules/govuk_user/manifests/init.pp
@@ -1,4 +1,4 @@
-# == Type: govuk::user
+# == Type: govuk_user
 #
 # Set up a user with default settings for the GOV.UK stack
 #
@@ -38,7 +38,7 @@
 #   existing file being removed. The `.ssh` directory will be created for
 #   present users regardless of whether `ssh_key` is passed.
 #
-define govuk::user(
+define govuk_user(
   $ensure = present,
   $fullname = 'No Name',
   $email = 'no.name@digital.cabinet-office.gov.uk',

--- a/modules/govuk_user/spec/defines/govuk_user_spec.rb
+++ b/modules/govuk_user/spec/defines/govuk_user_spec.rb
@@ -1,6 +1,6 @@
 require_relative '../../../../spec_helper'
 
-describe 'govuk::user', :type => :define do
+describe 'govuk_user', :type => :define do
   let(:title) { 'hungrycaterpillar' }
   let(:ssh_dir) { '/home/hungrycaterpillar/.ssh' }
   let(:ssh_file) { '/home/hungrycaterpillar/.ssh/authorized_keys' }

--- a/modules/users/manifests/alexmuller.pp
+++ b/modules/users/manifests/alexmuller.pp
@@ -1,6 +1,6 @@
 # Creates the alexmuller user
 class users::alexmuller {
-  govuk::user { 'alexmuller':
+  govuk_user { 'alexmuller':
     fullname => 'Alex Muller',
     email    => 'alex.muller@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCdvvlsypohk8GO/OVu6oTpJMBf+uxhpdk6yjd7cELgD2wrLQKggMCLRzi+04WcLoU8YE/SuEd8fwiwvhi+wauRKCkCnkuHQzexA30cLqWpkjbzZzFiEp76cBevbR/btFKWAc8suxhxGQp4i90QjsAdIuEY230cpUURbGW1JRdhfF9n6nQ5HVWyZ6Q/0PqzJvB8k2GNcPGYqmPW7V3aW0FteEvf3a27K30dUkOomUJGtXiJxkAe81aovxGcLwhBFiKrof35+qGylTlgh/XMcdjxdBstUbEBxi0RzNycFGJnwacrolLnn0Zsm5dLfi0nLCXgK7yxGFI8xoJOdb4GBKvMiDtM5qHnE3grIXjjpmYZfEvY/pbXA7PBjhIs2GfS7YAPDDOWV+fME1+UQssd9dz1kzlej6+bg/9z/hHdWylN+G3cAC4pRNHhvZUUvOTVjCM18KZdRLzIO8BPADxUDLqcUznR/x8jeAMZs5L0TvBQcnZsrBnm2gplPmzhh0OYGdlgzDzDPmR2LBKyiCQCxANEW7Z4alJRjRHoq2dx9BawUWBsHFJ9JexDLE2XvkRA1vqhQSQTsWn4eM/PnUUiSxTTh2fVme9SC9rwL0NN1VB8n4CCLxOU9EMLRTvVawR2pNlDeiowDiVT1Fpe1NCUAlVkGkJP9h5/GupYt2ufXQn2ZQ== alexmuller@gds0386.local',

--- a/modules/users/manifests/alextorrance.pp
+++ b/modules/users/manifests/alextorrance.pp
@@ -1,6 +1,6 @@
 # Creates the alextorrance user
 class users::alextorrance {
-  govuk::user { 'alextorrance':
+  govuk_user { 'alextorrance':
     fullname => 'Alex Torrance',
     email    => 'alex.torrance@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC2CD/mWay9ITFDeetA/V4i73iUe8gopCq7z/PKmqQ8AiWlWfhznplMwmaXIH7hh2pXC9IZ4HN3yMwFTD6ZltlEvUE9EWAcXmXsFOrxEGNMpXlX9hSqVL19BRSs5KFi9gPz7YYObbiVYYzzycYSnojuC2NUuJNJmKMsz7kt0vEWebh6UOc3hDbIzW6UXkPzbNuxyAjSGLIDqOm9nG50SM7BQRhE/Jwcmy7ZeLUIioEunj3HNz9gt6vSBLZhGjrblkGRfYcU8BYdAu3H+3RIYDMOJonYgT/axJKlnuTOcBDaC6AGL+6JKbbkGqykLmtL3+eIpOEyPIzvylNqHNr+q3oRUelIuAH9b0mpqIjTBHe4QjO7qffPLDV29O86HOL5wzX47a6T+mWSL9J9EhbI4obOu50lwMhcAcV8MOpJe4yyCqz8YCRPuyDjhDQgzKw88SgxZVCEIwQrI0vDIrIsLYT8Zvj41/xm0EWhvVe9OVnCqzK/0nT5vIZuHH6NJe6ZEaRwxXaIqh7Sk0yIi8avOENx31weaJ7xlwkjrP6MNP6RmSNlFfXj8YKBQ4xm3175/f7XLfQqc72Soqt6frApMD9hAjS/5ZYbtNfdxWmgETg+FXGXgjf0X4wxN1RDG8FGrtRvzwUWzgQ2Vl0Aq+oG6dzvXFt7kOIi0J6JEPBSxzflKw== alex.torrance@digital.cabinet-office.gov.uk',

--- a/modules/users/manifests/andrewvos.pp
+++ b/modules/users/manifests/andrewvos.pp
@@ -1,6 +1,6 @@
 # Creates the andrewvos user
 class users::andrewvos {
-  govuk::user { 'andrewvos':
+  govuk_user { 'andrewvos':
     fullname => 'Andrew Vos',
     email    => 'andrew.vos@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDTYT3kzkFLwCFn+dKtfBU+BWpHy6kGYMlwzKJ4+jRN6upnatkZT6uhDxeg93pJn2KHpeWfmwshPM6FymCSDOjjAHYKyOY7/fg/jQk/tTJN6VIFJgBDTo2/imKxcjJBVckJBPqdvR76N0bkdzBalD3ABTPyiIhrqjqeH9YC6s3SF7jMJQV5DrlRVsiroDlOGJ0wQkIyhigeYvDYjVYEOxzEk2CubNF/A8QZW9Cee2C8zEbH3GKh+bHKOfsu5nj7jrkHjid1gA5J5IN/Icc+5VzQG6k5k/oNaQaCyZ75FYpTNpKbNklJHW+xABp54t6TnH7fFIoYeERZwICvSIit40vhrIBj3fQ/DqfcKje5FdtgtYMJ5TP8Tx+GNJv0A+DpYIvIhufi9S0uttLkJbRCQ0ylipG+GN/nKj05rXdRk+rT3mKYhC1L5XU5AEZsLiGOzJ64pSHuH5iJfac89pAJ2v7wfaBTTlsEoRgBCjSrgK3MF/IVr27XnQ7DDlrgAnocklC0keL2Gc4De9jkys1ndIVGCxxufVQRHAkPCoFaLSkxBBwNR783nDf7CZW6ZDkXPho5wkEZzeG73l65+2Mb7QY5mpfA9vdI2qMn/0bkPeshxBY6EFyjuTv8X22Jat7JJ0JXxQ0/fcqqing4fp7h4hAs2FQiKV3TMb1weFIzL2ULpw== andrew.vos@gmail.com',

--- a/modules/users/manifests/benilovj.pp
+++ b/modules/users/manifests/benilovj.pp
@@ -1,6 +1,6 @@
 # Creates the benilovj user
 class users::benilovj {
-  govuk::user { 'benilovj':
+  govuk_user { 'benilovj':
       fullname => 'Jake Benilov',
       email    => 'jake.benilov@digital.cabinet-office.gov.uk',
       ssh_key  => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDZlq/ByLPy7iB1R4KH5qocTGFk6g/U89fd9O1iyiABx99jf2ogBWjKQp9dkrS0NYMCrnFjPJZFM5Kn+Gz0/YQG2L22uWLsrMPlb8RBqPHPVurt4eFIPRCeZ+kEUNF7nK+vxsvEOnpaNzXzlYDCooB9UcwujgIsdeEPSelS4fmSi3Dg4/nSgf+HxiJYyI1CvBrQGtm9kgOFY4wpL6Y0Fnn7mTRGGvA9MXiGegHkBNIwaD8wAFvoIbt938uXXv+AWGIfCVMM8yLUag7QC10eBR0dfKSUqyChBhPpdMr6wWziaX3agwD66SGL0UyBmNvh2ZQvnr4Ur3w551VzQBZ8RbMhFRAG7nDzzheFJwtCwQ5cXts9n4jgwvuTfXH2peoh3IC5DrxvSeiJyhaIwKzwdzMBa+9t/KVt0+Wt4IpEMPxKXXmZPraaQ1Rm/9ompLXIlYYm06jnncsYJN1YTRpcz1FjRDTdIQbso7+3LK8uoHtjCVSDjPf2mk9jB7VEswSLqz8KFl4HnfgxWLV0mjdmjjsiaiT7SR7jzaAN3mMfb3BwKGkHV2IhNQe2OjwctEf2/9VZhwt73E4qbdRg1cn6OmGf7dV/+p8X9BI6dUEr0XnNfgVvG5zGSdjBmqIp/hYLyr9ly3iCv8ceKoHGF8j3X/1QwZHHTiUiJ5LJpWAT9jO2Tw== benilov@gmail.com',

--- a/modules/users/manifests/benlovell.pp
+++ b/modules/users/manifests/benlovell.pp
@@ -1,6 +1,6 @@
 # Creates the benlovell user
 class users::benlovell {
-  govuk::user { 'benlovell':
+  govuk_user { 'benlovell':
     fullname => 'Ben Lovell',
     email    => 'ben.lovell@digital.cabinet-office.gov.uk',
     ssh_key  => [

--- a/modules/users/manifests/bob.pp
+++ b/modules/users/manifests/bob.pp
@@ -1,6 +1,6 @@
 # Creates the bob user
 class users::bob {
-  govuk::user { 'bob':
+  govuk_user { 'bob':
     fullname => 'bob walker',
     email    => 'bob.walker@digital.cabinet-office.gov.uk',
     ssh_key  => [

--- a/modules/users/manifests/bradleyw.pp
+++ b/modules/users/manifests/bradleyw.pp
@@ -1,6 +1,6 @@
 # Creates the bradleyw user
 class users::bradleyw {
-  govuk::user { 'bradleyw':
+  govuk_user { 'bradleyw':
     fullname => 'Bradley Wright',
     email    => 'bradley.wright@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDTlc6MBQDXSkT5EdzxbuU1tEEwMlK8YZ/H8JSKSNlBdiCBlPj+puWDLzlFze1vSswRAgBgzct0dEFZgowcmvigDHAvfTIxJujlzpYWaztOCoYbqeuhDl2+ey8Ogwzow4oVdMrw70hLGlskbPveGiSEURqcV+6fW1ugaqPUSu3x5YOLhzuxjLEb/x0yVUOB9b+AE0crGNN57sYToPr+bJcZNl61OkVx+yaV17HQTOwt+uZ4gMX4VzHzwO3aClJ1rsSbbYtH/aZzsu8djEdSQZIMZQmbSMf4zJNl3yMN72lkbO8BZlj9zNtHh3PhxnC2YWX6iX7nEq1KMIKPCj/QK0hCccgvd/a1Y7qZqo2I+yBl+AUjTACOgoiEjCZ6IFfhcxuB8E2ZogwBquaR8R8lYKAwq6tcHj6XDMLCszuge3etlYomG7k8Nmgbxg2AgjnGsywpOiXPAmmCZaX/YsYH6y5/2NeJunXl/1d1POnezuVgIUnUONyWe+4DTFsMOhNRuexWXEX5zjJqT9mHli3KoYmQBPddoEJEN+qac7bL0y65El3aWks3Cl+m5Kk94+vf94RWrPL+9t9DOXj/RFE4VzyrvumRiDIB7guZl4XdGgwP3iKI7ajgCFUjD7AMGjLpvy7FwkXiSR6+SF61IX+MYeb6HKoMpV77AJA6dsQPD6KY5Q== bradley.wright@digital.cabinet-office.gov.uk',

--- a/modules/users/manifests/brendanbutler.pp
+++ b/modules/users/manifests/brendanbutler.pp
@@ -1,6 +1,6 @@
 # Creates brendanbutler user
 class users::brendanbutler {
-  govuk::user { 'brendanbutler':
+  govuk_user { 'brendanbutler':
     fullname => 'Brendan Butler',
     email    => 'brendan.butler@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC5GqE9ZyPi5nWLGeXzqgLL+vUYiGwePulBhCaeiIMXmDX9JVG94r4o/WgUgkOLiON+j+F4m41GMnHsWSZ8+Fd4lJHHaIuX+DtK6COsIyezIF/4963wRZFaak9Z8J1XX82Su3wY7DtBuszYZEPon8uZj3/hGTmSd4Gm5x7fVZSCAiv4QTICCw3omrJw0zIeKCQCpmmRIkyHu1HOcz3WB4hJtPDgmZ5OgPtZ58R5pC6j0wzCoAnerNlXC/+t3Z321zOF9PNgxdqDjkElJsWioB9V3/MZfVxj3u1OrYWBblv92LBExHpbZUlrw9zxEDcugq/KQFG5eva9RjeRxZK99OAlApRBfYEL8/cEnxp04ZTTfPF2RrFlkgpZ+xMZIfm59uo/zK9sLB5slOwryhx3WeU6BDAJa+Av0cU8bj8j93RKyXsnhrBZIj3zttDfD5zogX9DCbJ4xi12b4PzpMuR0FaWOVc5qqcWWBCVXZmUoF6DYpErE+jIWs1TAJynr4/BktkQQAHLf/K0VrT6JthrWRGfegqqBvwLo7AeXdcNYwbp7H/blnroBVWNZIRdjaGtVncaFLY21Xvy0gPlEbW/w+c3UqhS1dopjzg/QLRy7uSxCRLJfZOGRvY0NVPwB4rxb6tz68ZSbmgfvWnDQSLKyWyZPb1t+XB1IA9L5vd9lbgKWQ== brendan.butler@digital.cabinet-office.gov.uk',

--- a/modules/users/manifests/chrispatuzzo.pp
+++ b/modules/users/manifests/chrispatuzzo.pp
@@ -1,6 +1,6 @@
 # Creates the chrispatuzzo user
 class users::chrispatuzzo {
-  govuk::user { 'chrispatuzzo':
+  govuk_user { 'chrispatuzzo':
     fullname => 'Chris Patuzzo',
     email    => 'chris.patuzzo@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDbNxGtzthC9mxoIHswOtrRihLTCQ8I/gsNW13UYykk6wHaZAbTaienTcmDoUFc60kUUgNu5615CD9rGWTULk/ZqjAWhFWmPL/Xk8TMKLGp3S9U1pFkE3e+1kbN0uOfopA6UxJXRMvH7jM0PyKXNifnYFdIEBN2wVyGS0RhLWjOBsirM9KRVUk9aeSPSoEDUSXWJSCa9M4bdCJfTgEbeJo+IS6Pv+ndtTVrGWXMXAOT1Xi8iTY7lkQOiO1iJjRfBKWM+ibMg1M0i/FWZUl2BnMK5fasJFd2zIGfX77vEEboLFg3WWPQK+wGC7Q+8V0mGtbtJgGfN5DbpmHJ4CYsakAzzGuggEKc+HUTBYLAAAenr5SiQP7H364i4f5Ir2DdrMynS1NfjOitLctTQIW+Ovx/8RWbKHwaKZRCzJxjoz/haJ+64NyUzF5a78hTKiKDlhPUwYrp+TdiFCAcTzxSZQPtGwc8kxumHeKhQz8uqId2A3tR0MXcOdfanRvOKCRbob1ymBt1edxCQVrsR4a3Z2pTqqkBuEd3QI0gTQO8d50JQybVZ5dZqNPtBjN+U+hKD6DRlZdrnIvMlkNf1SQWJCqaXQTzdT9XCPZFWuTNCH/bdqGrMZv85UGbEpRth+Y20nPVioJ74IMPsTmTdSoyM/fgSiAdYsO9GxTpLdz9cmFmQw== chris@patuzzo.co.uk',

--- a/modules/users/manifests/christophwong.pp
+++ b/modules/users/manifests/christophwong.pp
@@ -1,6 +1,6 @@
 # Creates the christophwong user
 class users::christophwong {
-  govuk::user { 'christophwong':
+  govuk_user { 'christophwong':
     fullname => 'Christoph Wong',
     email    => 'christoph.wong@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCq/VzTGCUdz5gkYUpc8QAUu5Y0QyzIDYSgvhc4DGlFmGgWyEv0+xvKafyD5LPgOhn+8b6UDBRwKSRBtdoN370ME43k4bLZ88x3l+sYrG6sFs9PhvW9ZYbdwhV/3zciK6bo3g1lcisdtMKZ3K7fgBgSpVkMoXZN9SXO7VjUO3+qsM+GuqEI7kj6LiG+so6vP0gcwh7Gm25C14fcIPfebrk0eIw/ZM0hFUYMLRmbsaT+JFAqz+8XGOiWcmF8vrBUWaCS9lZLYHpSFRWOoyezlZZ2IMFm0SGqNY+t45Z7gSZ6lkGcrzuS5L1rDZtiaAzC3PAsJTYja80aaEdPqOOyWG7GkQKO44QOsCIH2ER9A7hBbbzyKf4nvW/DeKPIE/M9F0OOH/AUBIpyKM+ICRdw/tyONax2KUZ5zHgRBvu7RMN/1l562VA1zD1+3MhFLmKFU95h/B5cE6AwwffHuuXgxba1/wpbCzcPKIu4kEqEWEFTtFWc57FbjoBcUIhHI8+JeRwTvT20F7Ilka7ShoFIBHWRcyNWtSzE+F48PDOf98bMd17g2u0MrZq5pXZNQOlQcX1Qyo6bgv55/h0t76ZhLoFT2z/MNLNYT/sq2p+T+WMDNfKgJaebDUS1Ra9OuoL2dAxfAuRrvobr/jxh8zBfJQknUXNJzx7Z+1a0psndg8eLvQ== chwong@thoughtworks.com

--- a/modules/users/manifests/daivaughan.pp
+++ b/modules/users/manifests/daivaughan.pp
@@ -1,6 +1,6 @@
 # Creates the daivaughan user
 class users::daivaughan {
-  govuk::user { 'daivaughan':
+  govuk_user { 'daivaughan':
     fullname => 'Dai Vaughan',
     email    => 'dai.vaughan@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC2UL9m1ukdh0gZUoBOuGfNL9aZJ64gGa0Wn94a3owZxvfFHpb0cuuYb2EvyOt4tjpaKucAXRs+2nW+892p+wbwSerf26V6q8MgM0LbsDcXOkI8dqhx/HBZ9W6d3xpBdF/f1W3sKrKVvaVCZC6CrRplaPdDwPr/N9FF/qf4mRO5gCN7cP530F6uJnPj7tUKdIrkgWY8CMxhpF6uEFZTRdRJPUsKratS2k0w7woF09TqMngJuIfu+OFDJTm3VnIbn3zdgqJSWIO9RQFHOBg9SCSotNWetQfcaS4f8WJJy6/IFir0i05izy1f6PQPIxI9SbgiERp2G7UaOGtBGRePGluFxYnrZZxfRqlg41FeCeH2mKn/EKdwOSY/9gzWN4QQKKNPNaCoJxKo4QCI1225HPQgGfHH8V2fHgRf3lsgwWsnQUOWZi2KvjwTyO+qPNyj5sxVSt7o2B1l41bh7COqivc9MVvl7SqQK1VARQtoyLwxjjlG+Xgo2OfNB2OqCxn5UuSJpI6fQYhOFM3LYeSixVpK3t9WBqCi9bKEOx0lO1tzcXyES4rZDZNjyvJ3W0C6OkisMIeCArvQ+vI/d5FaUUhHeATS8C5Awe7/joq5OOn46hMDa93RW7WRrH5m5JddlraK3Pa6S1GvuTtpMZTSg32bXIK9zq+kmhhLjCQRU3yJAQ== dafydd.vaughan@digital.cabinet-office.gov.uk',

--- a/modules/users/manifests/danielroseman.pp
+++ b/modules/users/manifests/danielroseman.pp
@@ -1,6 +1,6 @@
 # Creates the danielroseman user
 class users::danielroseman {
-  govuk::user { 'danielroseman':
+  govuk_user { 'danielroseman':
     fullname => 'Daniel Roseman',
     email    => 'daniel.roseman@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDcz+lw8fLHK2IHyIOs4w29QO0zT6I98l0m5JrapSsK9ZUASS2svj7EvinMdJJ2NQQ4fqhYMD67xB2gzhug/SEpYpIicg3aUDdQEJyQulWLigH9rRFYjFv5d6jkFkRUHc4XRd31PFc6tjTgpstzPaL1uO20XlDIaU1U2+LyUplENVkVtTuNqyVPfg8qjtzHGWswr16E8ouKtfzAuTAmkuVS19cjXiflSuXD5v8vXsVzpNbyoXDjoeu443ZY8MOavZMD/7ClrZd43m/Yi154I42xJ68uM+3R4uuU6OQgcOnNhwRnyJ21jFk7ohnipVmTxB5oUjXuh0gPQSfOkCQPvddwsd/0dmfLEKidAIrwcUllI0qngSjkei0M693Wn9zJmdYoyOTpksCpEsmSpeF5ALYOXedlZfa6WuJu7SxozfuaQScJONu5TZbIS5mM/1zRVwB15cdZ+qgH1WCG9wjFWTH3CerqfnMxqpB80nxHcKD6r/FJ7tRVpHY9CaW9iAjZ97d7Hh6MTb8Jksg1F0os0c/hSOChFX/hJpmeGnQIEdu4hE7U/zt7gVxalx6446BOPdDePDcPae8ngQAutRDNI6/MtL0QAcxDUEnW2KD9QVatvwEh3kdta+EJBUOiWAjEBlpMa34509mBI1H8JKa3wAxpQ0u9tzIzsXzoxsYiUPjXkQ== daniel.roseman@digital.cabinet-office.gov.uk',

--- a/modules/users/manifests/davidbasalla.pp
+++ b/modules/users/manifests/davidbasalla.pp
@@ -1,6 +1,6 @@
 # Creates the davidbasalla user
 class users::davidbasalla {
-  govuk::user { 'davidbasalla':
+  govuk_user { 'davidbasalla':
     fullname => 'David Basalla',
     email    => 'david.basalla@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCy6pTUVjVj15Zm8NW8Dkhdf4EJS/c4ys3podB4O77uuaezx2P1qVqufmjDWBtWwzKlwJIjgNPe431isnJ5Hw4rvx1PpQ7wKYwmcLnCeYIVY9d3QmyE68pKauvjhcmdhxJ1MCqFecMmx+8KRcwC23L/RxfZO2m5lSHmwm5COT+uJgtoaeEsU8vC3lYBxZDDohllSBz26uEDoUMT1FNmtKWWdorzDzaN1hwSFe3uPF7f0A3LJQEpYxt0kkKJxTWhjYVJ2wrx0Dzipi+rZirAlBI+gybvozzvl/AwTiRzAage9JvDysjj0Hw9/GEKxs+BflWwy06EANPkklWJUsEUU6LIzVAhfFJxkPu8YVE0qAt1UHs4A4YayUslPB4e7rjI+0xmJSeA2UJnbPFkJGho1IkLKDmzARRVlWVXDYjZFOwBqgR6Vp7UagQDeFubvHdvW5zD1oRsbd0UkvzByQoHrhqUU4fQAmPYv2YGtVEvegZ1pjXbMQrucBcjhedXbUCPXD9MGktUQPwOVlgrIRxT3PHaYA9ajU865GoKlsMQfWIdm+kxUbhH7xeXlDRqwSjHUVy/hXUUUUd51lffmTZATeCDBLB0f0XffNWap2IC1U1E3xIX4Ybw3koC1elhoRdY+PvzYARSFvp29mGBTO00UnzT1O+jbhs7/BPJiERt9EUxfw== davidbasalla@gmail.com',

--- a/modules/users/manifests/davidsilva.pp
+++ b/modules/users/manifests/davidsilva.pp
@@ -1,6 +1,6 @@
 # Creates the davidsilva user
 class users::davidsilva {
-  govuk::user { 'davidsilva':
+  govuk_user { 'davidsilva':
     fullname => 'David Silva',
     email    => 'david.silva@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAADAQDBV+B+iIuNVt61wrVetNKVRC/s2bD9JNAf/1sCU0vD2wWM6JEWSm5BPIBQSSaf5X0pANSM7+TyQfvo9fIAhT8s73CqVKgXDYeVJld6pt8JIqtc6xKOJuV8bmGE6E3xU9XiONypu1z04H9Y9uR6p/jzQngWG01FY4ixsgRLf/mr0iODTl2HYhUVxb2ZnJZ/2JyK4VjlPLnk73b2WhViq6+07kZsv6bJdoB2t+Fhs8bDNLuG/eO/RxcYYJpODPURi+LEls1GzUA+yfCHbsFPMcdxlFN+ijDGX1bkTYB2nZtj3cHxn68vG9LQc9mKMz6yqeqJBDF8SgftR12kj3FJWSx7ivURJZ7h73ze4W1g6V3hqWxqEv3cZmQi8DM8IRIbWCBGiDpClNVP1opkbeOVhlJJUrv58Whby8zpsVqu0IEYQwKyLy6pV3gyYlSVbZhQnsLtzF2saFjE+eZ3nlOuKolhDt5SJalr8jNtmqSkv5rvHg8vOuDqhQ1zt8+fYcWr9KK2hxDo/J+kLM1Oztv0AF+zcxL3UX3LW3fuqjp6mjLcBW7udVTFad3U76b+j23uvgkokoze2DGNDSCjILOQykkV4hyCxb/Qqn5aYaD1tgx3TimOkIEUJMmzXmjUNrAyjhgPhUHMUGb+wRXBAXd/neqs0ZINZAubW0mp3QbWImXDx3RQKx91+xH5cso9DwF63rEIIl1GU2EFgQkI3x5Y6p26yt3qUtf5MMSBeMM80tX1cqqxzL5swvgeX9i3olyJbrAvHRZmZQ12pruQ3PjgO1GokJaCMDMZatAZLaRMG78BgtZ/6StLH5nNgBcbH64OeDCvVWt8gmjHWbcIaATymedP/0cWthAEbRMg+7wZ67Y8gE/sOilwfJ9aQviIIKQK9Pf6Nu4QurHZrFbJ33h+JCaq1JyiGXvpMShNHjUj+3GcMH5D57WgDbOmFTrAZwo+f4qdYtgSdChe4pQJiza3y7yZ/QDhBcXWRwvmfilTIvngX9uJaFlNoMpemY8XDuR4YAc= david.silva@digital.cabinet-office.gov.uk',

--- a/modules/users/manifests/davidsingleton.pp
+++ b/modules/users/manifests/davidsingleton.pp
@@ -1,6 +1,6 @@
 # Creates the davidsingleton user
 class users::davidsingleton {
-  govuk::user { 'davidsingleton':
+  govuk_user { 'davidsingleton':
     fullname => 'David Singleton',
     email    => 'david.singleton@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDT7A4xuyVp7s2aZA68boarLAn4p3+UIvQmu/Kfq7EP6JZsrnOip2+Xd2ztRkQ2mwG9AnrlMpugDfeqBzbdcxE3H+rQPFGlWen8S/5DNl0eB6ElevQ9Kv7sMGCidmIsfQGz5wi0TxyREv33Ge2iR6auoXujYzCX7eP4b7R/ieEd0Okhd8Suo6cYEwbP+UJVJCpwxSzNOce1L5FST9JG2a/QJHxw6siM7AGkSwze3SY8lN2o1Vb4WC2pdcZnBE6LwDEFQdqdWUIO5wZByoENda+GyCLb19A6tt7nhED70YtwUimpXeMS7VIkywDma0xlE2Lt+0pEQbPy5UrFxw/1Gyp83fjCof5J9FGRQWQvSjhQ07YZJTuZzYdaFf0ZEpyAhpNwNw1wp0Qckj88kD12wxssyIrzic1Q93YiJ5q/8K+bGy0+VQBSCGJOtTKKpT77WaZA8iMsgDwTct2IsHXEervkQnZqeVrS+zy9oWyHG+6Ef9UIzRw4Sl0a/mqNqnseSzpZFn7ivUdXy1gin3ZzchwMyLNHEmXdiWUQwEHw/QTlzBIzv5bJiUuH+2ipdep6GB1aVgcEINCe3hMfaEcc2LK03vOkqCJzNsMStKfUAn3SjkyCxdnCpO4DKy7NyZBvjZ9fN4a2OEekQLhWNqwa4ru6IRzQJyICZ20c2MV8pJ6AeQ== david.singleton@digital.cabinet-office.gov.uk',

--- a/modules/users/manifests/deanwilson.pp
+++ b/modules/users/manifests/deanwilson.pp
@@ -1,6 +1,6 @@
 # Creates the deanwilson user
 class users::deanwilson {
-  govuk::user { 'deanwilson':
+  govuk_user { 'deanwilson':
     fullname => 'Dean Wilson',
     email    => 'dean.wilson@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDAmm4kdSdiwYnIhn9wcuNGmTQllNNcaKALRT8z/3Q0Z+vSkqnhIA6gHWFZn7ZZ0u8Zfv5rig+lyJNPZ6e+1uwxCtLABNe8G1NPUdgqhirblBDy0uhLaeiCcwOP/oiZ/M94+LxM2aPLoA9rwR47rviXUwiJ3rjQV4IZzGDuB/p1d7ttaBra39HMkqz5K1Y+I7T9mhCuoU4Rd88NHVx4NmseUQTStdulH6sy+shARMUg2M4PoXEKcWasJUd2s7CuuWa3ZHjL7EQePM1eqgUFPQloac98f3RUVAfVb9AbPhA4t/zewOZS1sYf1kxO6lrGw1P7qbXTmHUR5eTGeW/hKkZSbz5VZeN6ZtihQ3mogzmP+bsDaiuAfF2LQWijwQI7M7xjk7NBjvFfCkmnw1MymSC26vnIrb+ITfPefgi2M+uaL6HXsQvgdEL6VT1pTewD8494UJtPARf472npBWXrMjDpier711rMY5HtSwenq6KE0DHFp1bFXZ+gUZeMzvyIynB4HmyNGZpZf41Lh8uenOy49/ouO9aHMN8lcRLEz9aPQXyjAWT+FooXRQjT+BZWZ3A5t1IJB7Mfbxsah+7wE+CHOtpydL4bDR+wGIR4dm65YegeBviMN2FlCle6CnU2baDK23LTCYJalBV8K17a9ydxvHgelf0nvabTb/f93PQhjQ== deanwilson@gds0092.local',

--- a/modules/users/manifests/elliot.pp
+++ b/modules/users/manifests/elliot.pp
@@ -1,6 +1,6 @@
 # Creates the elliot user
 class users::elliot {
-  govuk::user { 'elliot':
+  govuk_user { 'elliot':
     fullname => 'Elliot Crosby-McCullough',
     email    => 'elliot.crosby-mccullough@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDozuKT8j3aciI4z86/Vf74zsZviHQpCqLJXMCG6Cl1Pf8dOZYnDbI4hPGnpBRNrticmTPzGeXG9bsMe30x3+NMupkIZhfLQKJKmWnoLoEse8kUx8q5/eH4oHybuXYisBT2n3ORq4JUQbjDmjTJfOELCL0os8554RSMlIjzhS9U11z1NwyjCOeDSA0GzwIhEg0phc9zNpMiD8koj89alCpFiktm4EdjXmhGyQVNSffRxwwIgAc/XswL2+2AfZ6vR2xJQMMNM2y2XkIKsaCsRYOVN0UjOTuvEgg5CWrniOy+3nipcSk7YzjUv7ozGIdIaUTSVwzRtD3B9zjobQHUIOOum1fDnKaJJIQba0SwFYe2mLmPK0DN5SyfE884jsOk+Tj8KpKFcVof071GFC9e+2TdPGkFqkVUZFXhjDdV8LbJENtVKhDnv6C8Foo6Ir9RG5gzFaGRrzeKeQkgubH7DJyFAHUaeVVrzK+24ca0ef9xZvFLa0KwWR2Cv6xvS3kUuv6JSvInCW6sdfmMx18M3kqPJcn5TQljEJg5Vz7/lDORUP3/pmgv5sKYrDIWRTIbfMGCrh1S91fPWLGnOIpOjRVF9Dseb4gkax3dZ2n5lQZp0xIUXXHVT7eNKcWpCAqmxvPy4cnZCKD9WzgjT2ZP0ZhaXTob6Uy57yewTVzTaqvTlw== Elliot Crosby-McCullough',

--- a/modules/users/manifests/gemmaleigh.pp
+++ b/modules/users/manifests/gemmaleigh.pp
@@ -1,6 +1,6 @@
 # Creates the gemmaleigh user
 class users::gemmaleigh {
-  govuk::user { 'gemmaleigh':
+  govuk_user { 'gemmaleigh':
     fullname => 'Gemma Leigh',
     email    => 'gemma.leigh@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC9b/nT3QRPujygd/umKHAkfQQrxCEstLpGNRxHU35YBkakF5rOCE2NP3gTsO/Hidj/tI9jUnUQis9yvUiyex95XLbhTBhKDMStteLym+sbtds4IXhzHiNEM+C7n44nmi0f9GeLsBWQWglkQUsg1HeimFhNGJ5EnfjFfLhoZDGjKF8tc6gEmi0X8aBMxDdf6Rp4na7WW0fCWtx8Q+pASJ0qzfE9iodzIFtoUE6e+ZyeNQZBkx8E72Z0ddnX25pLhUbCWLOORUKY3VWMAEjyYPZmOC1OvADUgG6I8RfsNidvfbhmYSgyLtVlYNKVUx0TXawXelZuw2JBMa0h1qc84/hBJT7riW8WPhfR3197YRilePxZuY5H83GvhQdRK9eammyC1QUZqbC7joh15JMlBebWGyCpQ+rrDTPxboZc/XTCRvyl1MNwbvCR7cgGO9BFoxdB/PYlQFmQtTgBjzromcCQ4rz85I9Itn6rhCmuSqY7l0j0012rcKOV5B22/t+7dYGSMaT/V1bTGUhjjHrFxdqTIj6T6NEDLGC3IPZQxm8h/Ucrog1+AXJXcMiJoWXlObDRJhOAEgFCAkt0Z3cQv2aBqdKF6ZzUPRcKCOk14f6tr/R9TkMku74PzNoXZry7w9bmH6vROIywTP2FDuWKWfqYf5/rkBuOk17ST49E6lxc/w== hello@gemmaleigh.com',

--- a/modules/users/manifests/grahampengelly.pp
+++ b/modules/users/manifests/grahampengelly.pp
@@ -1,6 +1,6 @@
 # Creates the grahampengelly user
 class users::grahampengelly {
-  govuk::user { 'grahampengelly':
+  govuk_user { 'grahampengelly':
     fullname => 'Graham Pengelly',
     email    => 'graham.pengelly@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC34Rk2V47gq6xxdC+4sY6TlxDPewkMRJd8paoYeFST3Gf77Eb2enV1/3+tAdvbz4pAZNXnfXiur5OnOWVf3Cps9HMpau/PUUyAqttjJ+RCSIQ+QoaUR7cP/ZyHY7Ft6ojjnpJSN79P+Caunay479IgN/SGsTxB/h36s1Ov4dRoqeYrOnGtWCNMeIQ+EXjsPGnqM4Mw8ktd3vZWfF8wbs4LMeSJOVzb7mSXnB4eqOTFYQYoY5Js71jAOFm8H2Vjt+AforZcv84rkOpL87qtjoAukYeX+FECljLrmunG0ZGrZt4xbCXGVNywOpst5ehR1tiZlNZp78LrKIctXybtwTiX5Wp51kLqVNjupuhlO6uxIRTLr0tSnq1obSr1ZRiJNwElxNL7lGyOumcUoP+1s9KyLICWgWCTPRd5L98CggM479BAH0LlI+dsjRC9toDXGfA5xbwWnCwm+wrgs21yvpy/9AxelNPWR3Fgg2Zx8dm5en7GL/JNLgk4PudTyaql0v5TetOo3oTm6O05bl99B50aVgHNzo1WVp5R190V/Xm/GkASRkLlPfXQ0O5V+qsRciBBAkNTdwMx6kT7ULDIsnjqYWkFN2qWbuB98WMMVeoXC5jaDuTVFm7W+jizzCVOtmstRjhwCBLd9FT19l6YFoh0qPTOXSEcTacvqBXx41EwCQ== graham.pengelly@digital.cabinet-office.gov.uk',

--- a/modules/users/manifests/henryturner.pp
+++ b/modules/users/manifests/henryturner.pp
@@ -1,6 +1,6 @@
 # Creates the henryturner user
 class users::henryturner {
-  govuk::user { 'henryturner':
+  govuk_user { 'henryturner':
     fullname => 'Henry Turner',
     email    => 'henry.turner@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDEI+exhJ8u7p2SrlAemxLQMuNr5dKzWIeJcvWY+pGLQXFlpkbFjSU4o+8FAGQuOFofTgC3eBriiWUBKdC6mAcF1OjJszPgrQePAGfCvvYK/C+3Pjsw9BQUACTNHLx3ufh5qirgxRSp21hyclfhjzQUZiQEIUhoUhzqL6IuvpHMvGem3IjpKpLQlL/38wAtxZtXXFL12d9I5ys7qvUZ2jofkxxBDujQ9qXqwUPV22waT9dGAJweCHXkOcTKN+QQYNube+mg0W1fKDOolsX9WkXnCdJATqO2CpLY8MJxC2iz+08zwXiJHOYeC5fpF58RXGof4yUxhbyJJ6Bdo7sKoE9eacp9J50m+jcj5Of3Z3DOeHOFO9GfocXHPNlN948X50bDhQkyKRIuny2GFU7D/0A+/QVrQGocx/lNDo3fZCuvUpcgSUA6VHFWwqXcIRPu2CLE3VniNVIsvXoBbIIWL9RDVgEDAtmUOnX+o9n4PaWkyw87nRN4QH0HJtv97KRAIvZN1fO5PDBcOZkFa10BF1ajT9NyK9t7kfIMmWyHXKQz1gQkJ72YaU0Jjf5ZHhqQtrNHmYTX+apxnDnzqsjC17OT1BAIougZBbGHSI7a0zklNsoMhbzFJ2whTZWzvHcvEkKeiZ36fZoqA5it4FgDW54D4S/ICzp3BfiT5of/DqM6EQ== henry.turner@digital.cabinet-office.gov.uk',

--- a/modules/users/manifests/isabelllong.pp
+++ b/modules/users/manifests/isabelllong.pp
@@ -1,6 +1,6 @@
 # Creates the isabelllong user
 class users::isabelllong {
-  govuk::user { 'isabelllong':
+  govuk_user { 'isabelllong':
     fullname => 'Isabell Long',
     email    => 'isabell.long@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDUbyr7etlWC/BUYSM3Y447UHGVYULrdu8p6/kbyqPV9KF1Ncn83WuhC/sghWIKOW5famspMcLJS2Sorc+k9FyX3qmgMG/ZNRHNN7xbMfdtJSgk4U74bLsTVg00OrTOTRpt984R7m3HQ5wHWIDazZximbl4AHy9vVwLKJ8HT7jwYGja6WFdkJiqscRgoFNE/IEjqntFXZmnILw2TGD4eCypRI0Hf0R5MWhAQkp98p8ul/935+TqC1KQEZkAY89d5imhlXjSr23JFfF+XNtyHkUG+E7KN5O0tUPyVRPfGXk3WYKsMtDqkhoIkT5wokSt9gOGkTbOmhxuHQQZjZh3n07eIBKVR8GS9Vn7g+Sr125zXzJ08mWc/jekoTxMhyDlPPO7kxkU5ucALw5Xt1oST8R/0XRPJgH0cMzkoFFJZt+hUbovMPYlRiR91I76uGb898Kn5Vp0vefVccyaMDIjcoBtgIK6RPinWrzSNAAGBhXORQ2UpuQUwH+mfkjsoWI+XO8ShRKxgeOTkTTTD8+2br1lvWaurSyhybIbua8L8GazHO5GXxtqdGWDTI9C1hfPr1P8vXTecJ/Dmv/xUdFNfoiHrCSN+IG+sTr0W1rq6RvkLzFE8OkqFfF7dnqwesBOi5glkjZsRBrFfYxKFg0ebtwlAuc/u79LNpYgf6F3WpTwBw== isabelllong@GDS3533.local',

--- a/modules/users/manifests/jackscotti.pp
+++ b/modules/users/manifests/jackscotti.pp
@@ -1,6 +1,6 @@
 # Creates the jackscotti user
 class users::jackscotti {
-  govuk::user { 'jackscotti':
+  govuk_user { 'jackscotti':
     fullname => 'Jacopo Scotti',
     email    => 'jack.scotti@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDgvmRKKUOXhp8A3f8ngWawFUguwL1XkR7jm3I08KiBjqr6EPd7p/YudGT1kh++q1ko26LsCNFhnCERwbmtc1w3AT39QZeDqKUiJlb1rPaJOm0yJTwVaGABjsNsXujrjnZitrGkeqG0BeeI500LFBNOYNiFu0d7BMGgKyPXG1/mZ2yy+GQzKaqys/PksvklrFK5XZ9FDVDperpy/UwNhDp8ATb9Sh581GEpjXVqhEIyE1KCwn+tdLxQZcMVtiaNrtKcXY1ZW+CglOcZ29RVLe63rS1M2x282ZaboQ6IBznhoZn5tOd91uO7YEvNtHXRiQ0TvjCyiVHMTflR4IkGAlY53ANsDMqvN8JEqKqQCbob1RLxNpRPhbeZag4ItPr+OBRWW4weJJ2jLg2hH/2e+tDxmVBub4C+DdeweuCeqeDEmEA2c9NSaCa6IBWrvbXHo3GKkssc0nHsernrGGXW7WVAD5B7pY3+05r641HxV3vggO1FOjRiaij8lCsE/CK0jsPiyeVle7F198fCO6K7xB8dV7rWciroqKV84eSUQn9qsZ1al1Fm4M4D/JhOdDgblfYrsomHe8a9HIH9G5VcGZ6VMBtNXZfZnZwvvpqvEwleiVbLg6VNSJPcKJN7lVVKWUgVyFoBz1KN4Pd9zkTeTBSFscEZUkmy+qAvBq4lHWsjew== jack.scotti@digital.cabinet-office.gov.uk',

--- a/modules/users/manifests/jamiec.pp
+++ b/modules/users/manifests/jamiec.pp
@@ -1,6 +1,6 @@
 # Creates the jamiec user
 class users::jamiec {
-  govuk::user { 'jamiec':
+  govuk_user { 'jamiec':
     fullname => 'Jamie Cobbett',
     email    => 'jamie.cobbett@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDJHyDmfrVBot/8xcAwPLv5uHRpvRy13iNWYW0FGPol7hgcrr0CAESK+cYD7LaW9PmX9dR0X65tAhp4nZydmiBKjfcoMKOcMELxKNNoOzMnd0vDI6emG+ldD0UPZsZwMvYzfYLw7ZaFTPlK/EHZe7/zQ84PKVvtV16LKn17sP6Y9DgizcrctUSbjwmLtwBhLaAptq4wyqeJANQf9D/4jyvrTPyDGkZ40cl6XiTcTzXBPUkdTVA2r66c+sg08YgOgCBK3iysm6yKadd0xrfWKvBnin6ZAClyjJnJ35gZxpVRbczvSOmwiY8EkiCzbgFyoGIRUyUBUfifWoE8BYMK8aF8uQPvAvdkb4bkfcTiQTT3LmL8WlRqosGqmctMwyHaa/o+HNMpsGMeB0s/uVCRcnspuoJV/JHf+61UUeJP7PhwefBnMozqdJqjJSFRP1lhONUwUQR3zRh0BwkkyA+/TxYnByhLwkRiPe//O/DMlSZqW8EH59aiZUOsbkOz/WxolpgNg82WSE6fzk5WLTMuWZNRJuJOv7Bj9N142lJCCN8jowP+dnm3MDN/I8sIf1We4D/VFRoeMbbs1DBf+N9WQrpGABEKbMeKivOkTT/AYVa6dsqb3zRG0QxiJfELVDGlSE62/c5h+PaABIuvxWLERbz32TS3iCjtw383BnWKhcbAKw== jamie.cobbett@digital.cabinet-office.gov.uk',

--- a/modules/users/manifests/jennyduckett.pp
+++ b/modules/users/manifests/jennyduckett.pp
@@ -1,6 +1,6 @@
 # Creates the jennyduckett user
 class users::jennyduckett {
-  govuk::user { 'jennyduckett':
+  govuk_user { 'jennyduckett':
     fullname => 'Jenny Duckett',
     email    => 'jenny.duckett@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCtChH/aBoCbgossPnUCUUhdSNah/dBZqqbFV4zDY+kvdB4N73nt3yGiQnLRp/9aI2oHI046coN+fDaNIcaJcLLXxqavZEazP/xZab0zDez/yvxGGPeHdi1iMEGg0EpWjKKHhvONWgsGAkHLObIzrcU9+GRcyn68CeS44hHuGy4LQ6fYVsi5iCXziGpJCTND13gK2rpl1tnr72G+dJtTRA120eO/2ZM4EWQpbI1RpTcBDABIBa22SNM76lazNiVDcPG88igP9QPDlAGQSXXIz573K61M+Gtm+jGyWnD9Hj+G3u1tQ2UAC+D5Mc5p6B/cDYHUoEQgcIwm3yuTJPSJMyKy/u2dCMmvRhr7rCMBYfWt6mprQKubYw64lGVItpPswXujmSWmUqHILCMY4Daqt9jHOe/cabjEEyrtqxWPj4JjC+lUpX7aoMfHmNqVi84P/E+0z+eA5cL+4wbeeJYeHhicXOQl2Z2NcmKBU/kOEoLO1GeO1w+2GdMQQt1SpAiHflBnvKo9HcrHZVaRzWH/VPehfiQcwjiWD/lpTRnr570nM8NudgxQOtaV4vewM8VNrT88E0IL4uorO/g7FiY2d5KV/g+Gvre5zsCBWObAze8O1/h0itcJ0zzBJ+BVgvOAMUrL7V0pYjKkmsXVTIXXcL8iZXClz7Q8kmYB3Be0qKbdw== jenny.duckett@digital.cabinet-office.gov.uk',

--- a/modules/users/manifests/leelongmore.pp
+++ b/modules/users/manifests/leelongmore.pp
@@ -1,6 +1,6 @@
 # Creates the leelongmore user
 class users::leelongmore {
-  govuk::user { 'leelongmore':
+  govuk_user { 'leelongmore':
     fullname => 'Lee Longmore',
     email    => 'lee.longmore@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDdIpPIrJNN9ZfhiXeTinWB1uHFzVM18cVRBazlTg7P8+kJVReHUfrHmLRIFZGuCXSp1ZCXo4hvOZ4Xlt1kJYIiP4LVrq7w5VECUHVr8s9FyzjszHT8h7+ExiltFfgpnXjymnssQ8tKZk+31+nGNHVICx8gtTv7HHgh9MEZrufneBQOc1OzqsG71lZTqyDCqDYLW83qMR5Kr+JfRXNTn9tKbzXzbheyyw8fK/rX4uaGg/dW4bMT9WuHkzgonjFXTxVLxgCLrvj9gM6fZJCqlcARj5Cjj7uEWe9a1uqA5WdhcfxpUS4NKKckvnd+KJQzeRQ6AUBWTZyZ0grbDILt8RmF lee@turkeyred.co.uk',

--- a/modules/users/manifests/leenagupte.pp
+++ b/modules/users/manifests/leenagupte.pp
@@ -1,6 +1,6 @@
 # Creates the leenagupte user
 class users::leenagupte {
-  govuk::user { 'leenagupte':
+  govuk_user { 'leenagupte':
     fullname => 'Leena Gupte',
     email    => 'leena.gupte@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCZR0b38YB8xwcvKPW5l2OrbYh3ON/xSEu8NCtDM9aO4bqhsdDjI3rwr6VPSWtP8SaY7Kib2rx5Ocp/GnvXtMvq56zMAKh5P+cB9cn9OppSE/Gh03zXebfwW6h89qx2DpMZ/p0DDE6MuAY1Zc2ZMFSh6ySzlQejNbtVyW5JdQvdZWAnszTJhElerW3v1ZVfEIqfg5yuz1QYhVochJMgq+j1wQCrn3sQrsmN6mxowerpF1GuCQYha+G4Wvh60Yxf1B7W418cJCoOESxzmCywgPJ9DQ4aobNGy1qBGia5jTOKDW1Jfnv3IJGuXq3ej0Bxu7hC4wKSiaTlm/45JWOfJ9rEaRwRn2ic/V5aENXESAzz7VhtydCNqdNtFSkhY/iKMUPGQBuTi3t3eihZOtZum9SCeaXarQijWK5lQpV4fypS4FnYOlAuVm6jPb+1d7slPFsUm3CHRlACHTjM14ugc6MGVvjRfBiSM/7DKRfrVBWFPYMlmF2zF33LmPJzEqZYugOL8b7g/CNVGxKY1QUqH8w7p2ImDCehfcsVUYvOm8LSh81mpIK5oc2l1ITjbOc2sI6ZEDuvvDfumta+1b/wH7v7HZSO09HHhEEVqJsUDQAV1eJML2PPXR9yILZAv/hqHoYxtAimwUZPzU3OB3AhX5LGHrrYKiLlyOMqjL5ZwO6a8Q== leena.gupte@digital.cabinet-office.gov.uk',

--- a/modules/users/manifests/mathildathompson.pp
+++ b/modules/users/manifests/mathildathompson.pp
@@ -1,6 +1,6 @@
 # Creates the mattbostock user
 class users::mathildathompson {
-  govuk::user { 'mathildathompson':
+  govuk_user { 'mathildathompson':
     fullname => 'Mathilda Thompson',
     email    => 'mathilda.thompson@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCpfq8YqOdXwI58NxsbFlIIvb3xIx4Vk5V+u2mQbrsy4kqyE6M2u79rlfv4mAEldjc+ALIeuNFZ4IQ1P3dZIUaTbJ3gJIoBnVE/0kfPbcMsROfXoVmfCvvTUpy5rrRAIm+jlBWTRY/T+WIXOgk5irx+xUn/sK5wo6zbPJ7+LD3/J89TwOmF2nOVg0e7KVGhc7Km9QiNje+rhrgy4RGydKNHhSUHJ7sTQxKvd6V+F9B9PhioLnqkhCP631sAtICYMCljKR3W8xazNmkuHnrW6/DGU4Ky7wca5pTssoULyH467Tb1XJQFcYWM1mf6OehnkCncUvx/+WJ2gNIKeRrOhj7ziROelWkdGeJRAt9QdE8pxFYxs9jKQl5rIL5mIn0JXPNLHc0qxFT9yGeKEnagoPeTG813CVCLsKvLR0WH20FSUumdaZ0Ciq1qOrdARUJqYyfm4eFXbomaCykuNAsT7Yzq9OsoAxlPABYcKqaXS4nnrmeKhF8DkBK7aDSg8fGxLk1aM5IMg/a2OWw+H06/VCgD9TmS8A40raTmCs7ALCKjqp6OuYHe1qBW8+sGowu/Sxa3d/vova69ota14t+iYN4C5QgR5qzV9of/H56FJ4nFjFC108PTy8LPHqhbpXRc7zt5AjgquPN02Be4FHKm7ekUXP/xTfngsmmKJqNUNw56Zw== mthomps@thoughtworks.com',

--- a/modules/users/manifests/matmoore.pp
+++ b/modules/users/manifests/matmoore.pp
@@ -1,6 +1,6 @@
 # Creates the matmoore user
 class users::matmoore {
-  govuk::user { 'matmoore':
+  govuk_user { 'matmoore':
     fullname => 'Mat Moore',
     email    => 'mat.moore@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCgVBCjPNhjGkZK2ruZ4YPaHL+bdAA/77+/Al7ulNWZ9ZEg92vXXh7Iaj40n6STW15IF59iSdjbR8JJLgczrlthJA4gKAMOTu+u/ytq+TZsIeQniYWcXE9OYfNwQzHYPof5xIia2z/KWXwaMqqcIsQ/6IhbAzaq+3WCdinHhGFGYq0248P1Qob57xIPoCZ2mqbB3eooB5R3ipmelXFC6uJacQfjzN38wOgHfjRYwvVxAlf60VM7zpsrdkX7Tu26hNs1CCCj7IzujKu9S58AU79hWIUkMNKuqH0Qu9TBnDNanmw0x9g56W97KpyR3pSCJj4H4XrUcZZHISKnfEb+lmnFJc/zuXt3f4mK94/3BRZJuuv3gEsEVTIhM5ge6PKLTnpEpyGLjFbt4H+8+w7bQpyl2luilT93tUq3SDUSw6/lX8N9YbuoQVacnUWRrCej6r5PmVXA/D6OKrDGdTAcFfG7gKAZfUK/PV37XaXFA0muXGaG/rRb7VZAsrCer2c+EYGFH5moYi2jGAg4mfiJQDzVDYU9tG6pu+yklbsZ7OyScQFdaO/Tjsqd+ko8VTlnLWnTq7017C5L4MdmoAjKzRGI2NuYgT/HxAQ661ihfDaoKoKQ3vKZe6/ntJeUNVI8R8Imna3yxadAuYvXvPjeHxI97VX7FVHO+NYkVMtbnd4Y4w== mat.moore@digital.cabinet-office.gov.uk',

--- a/modules/users/manifests/mattbostock.pp
+++ b/modules/users/manifests/mattbostock.pp
@@ -1,6 +1,6 @@
 # Creates the mattbostock user
 class users::mattbostock {
-  govuk::user { 'mattbostock':
+  govuk_user { 'mattbostock':
     fullname => 'Matt Bostock',
     email    => 'matt.bostock@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDBc1Tcz6UiZoCnQCadVCSuJT9UXu0sf/duILN5epB2s0jL1uB8rKjT+RrpstZAr5YIN3Gm2IpTlTAxftNyDnxH5SqFYt4lLG+ibCxGffUYdJt0RCc4Atgh7VJDtLiwLbH1iaAVCipV8SevkcbT1BaBymsIPqy76XtuI46ENTbT23wW9a3F6j43M0TMzjFsTVy4dagSkkpb3V47E26jik/rcVL43lZNyaLBx/Nn/4bdGjZw6LfjyTAyE//xTvK5I6dYLFF4hH9IwC59Hs532q73YjXsEey4hf+mPjZWjirIJdyisXyK4E1LfKTqQoqOd2mMiPlK15pkDkHc1DnZTv8AZCgWNf87li2GIAsuB62bR76Umg7U49J+hFN6TSs8kLB+QJg83BBnKUb4lJj49BCGg7VP6xx7VIuG6ir/WROmN33miKpYBE8NYZb1t7W/CeglcfA3eZh+ZZAvQ8AUDh7WHvxqr0L5UQuuVCtO4pJV0OyKorLM/5TYh++CKr0Z+EZAVK3WsB+EIPbT9lNy0FrY40GAfE2Ud4uW5P20afYnd+f2TfBotRC6EHtM8guqO8JoFUqWTCgcyQyEe3f4zR5x7jseGyb/hL+dOPgfw3WNVYdLKNQx9weEjRAVhlzfDOrfOXEdPoaOYKmtWd2i4yM0/wblxOQnxI4rZbo1KWBx2Q== matt.bostock@digital.cabinet-office.gov.uk',

--- a/modules/users/manifests/matteograssotti.pp
+++ b/modules/users/manifests/matteograssotti.pp
@@ -1,6 +1,6 @@
 # Creates the matteograssotti user
 class users::matteograssotti {
-  govuk::user { 'matteograssotti':
+  govuk_user { 'matteograssotti':
     fullname => 'Matteo Grassotti',
     email    => 'matteo.grassotti@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDK1I5i8LSaOF/P1fo4z/e91AUlISLW7E0i2mHiA5L0fP6tNgL0DSnaIXfxApwLBG3fQr10qoeGd3NCoOVDskfpHufVyR383V5TKpYuzUrOy5IP4Gyx1JOE+UhQwa+NX76zqXYLETa6yc4nj0V6I+UbmxIXlNI2MT70+MCATkw94tN6g8YS+OTvZAy05WvnetFB3TmUqbZ0X89lFBY5y2HHmJCdsxRUDFrt1M1oSbfE4sWNr9wLlgAJth0Lk9J/YWiXs3+K9vtzNOUfxikvFdnHEB+AXswg7Go8FwGUDzNnMBoxFqx2GV9+O8sWn/knhKpwMx1y8chvRi+SDIFJn6OMX8WUX2HKsc3GXHrhhvGhOcKe9AtM7asPCjB52NxVm2NobkN2uSWVFjDLQJR+Z+VTcga4LgU2SxgBYmpFXNTuNRxbOM73dbEEy5zL+VBDFLYHgtNhJFk7YHCwju1dLjR8Yyy4za+Gw2Xb/1HxuWp6WNZCVfcyB/7XBTEvE2ijr3cwYBcUa5nsTrYRz5uvyEAfShKd19FQbPSeJPE/j8CSWj2S0m31k+ijfioCqJ7bhRyRnEzaVyltasYrXH2qT2x3uDMs5/NUz5RotOzTEAyDH/Oz0QQaWG6YYCVReQlEVHm0tdIXCX/JcSi9oJcl7y1rNzd6CNbi9OLwjojiQ4CA9Q== mackeyfordev',

--- a/modules/users/manifests/mobaig.pp
+++ b/modules/users/manifests/mobaig.pp
@@ -1,6 +1,6 @@
 # Creates the mobaig user
 class users::mobaig {
-  govuk::user { 'mobaig':
+  govuk_user { 'mobaig':
     fullname => 'Mo Baig',
     email    => 'mo.baig@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC9+UcAnAsFO5yrTC+kKwl3XGVJq/tRedPwir4i1D0uTgNKpd5zx1YXWCAMw4tWng+euIL7RlK0KFP0fGJelBscUViO8sv6ikY2CiXTEdhGIamKp7IBMDqFFlExuD1PoeVhf9tJU1NBaiPqXj3t1t2BX5DL0oQ8FUwlBHkZMyNQ4Brzke4cnj2fjYkWvDnslrvlCu7+TwmpnUyv5eDy3Aoj3cAIFkf9YvqNHE7G+eA0ZzDUwr3b6jkUXCUMkkq4WioKbJwNyxRfqlXFYZLQVoVMfYUAfruRpKdFJnKSSKxlDrlfLWvZE7uPi2pJSGFPV7iBbw0sbpdnTQG5060NMmxBBEHIgdWqsryo3vFkiC2of7+Hoe5z41N/VJTVLl4lrQ1oOmnopm9vGKHeO1PL7UAJabmlStoFcn9QWOaH+OEfdezjI5qZwmrKubhScPLl8fAE5mCbTjuQk+tsTxak6XdsmAUDX5Df906CdCq39IE6aAybMQr/mYQGHeawL/AnCPHzK6eUW23eSalbNmt/11IH2m9cTOpCMzbYzN+GvXiYCYfX2M7qj6dof+8U5hY7Dbng5EKXBdS7vPZ0DK/dqJKFGYqxdWLvNh6pYK2pQqmwnlyEx2dWLMqBnBxrHFNoppPery4NJkLJusX5B9/6VQf5V/50QMEBR+CyBGz+4bhfMQ== mo@mobaig.com',

--- a/modules/users/manifests/murraysteele.pp
+++ b/modules/users/manifests/murraysteele.pp
@@ -1,6 +1,6 @@
 # Creates the murraysteele user
 class users::murraysteele {
-  govuk::user { 'murraysteele':
+  govuk_user { 'murraysteele':
     fullname => 'Murray Steele',
     email    => 'murray.steele@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDLjjQ5qyX1S8aHT4109z0hzEhB1z4oTXecFVIV7haSooWJmJTV2wmrbfhoSs7zSNPKk2nAaqSAn4n4+rK7LoMlUOaWVzghXF67nS2UzWNVNiU/9TdSko4aICjp7HyEHKF3eXI36YLYxFjgug6PgOUEHqdNgVU2zMYoOu+zvB4VDf4s22ggjjHVYnetXKhWLJjB0NQH5tVzGHCd79Jn6cg3wAT1UzvhQ8YpbdNqhwdgo/q+lcsngbwYH1+BHySltqi0aJ9KuqGjKEb6+/rROhIHstIjVjFfukp4JApU1kw5fzcPH7oeP1ADEsJmEbR6V5gkNpj6pSkIunrVH+BZNGRnVtNOJcjbcWeU7g6T7z5Z91Kl9MjaZoGecdnpAFwh5z5pBR/OWjNqv+B1bTtKnWHHVi9NCEteCQ70OGlwc139rEsuUwHr6Nh7+q6t2Tn5BmiSAsPLDCuVeEtDE6WKiFZtPsEAFSzKvm9c3JanycAFeRM4Hx8issYDMGgu5HGVjqxJh6BxV/RtcfcOLs7eynHIBg3uumP8NQAjxr8BDjk+tlg5z0e2wq3dViMFDRohNI2IfKX3aycfWgLI2EY+Tj2GeQJHLxbjFRLWufJp0CwaOQ4EYvNfCOItmZvXPiKi30UYUJJRbcVZGZzM5QY+ebmgU+vjj281Km6PKKK3vMbv/w== murray.steele@digital.cabinet-office.gov.uk',

--- a/modules/users/manifests/paulbowsher.pp
+++ b/modules/users/manifests/paulbowsher.pp
@@ -1,6 +1,6 @@
 # Creates the paulbowsher user
 class users::paulbowsher {
-  govuk::user { 'paulbowsher':
+  govuk_user { 'paulbowsher':
     fullname => 'Paul Bowsher',
     email    => 'paul.bowsher@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDGc7mCKEuZH4fcqos9up5oRGa3n5Jl/xSiZ+zVKhIpgZXQ8M62QUqA1GReJ5GgZojx2BlIJAj3A7x9QxsrkGCkeS7Mc5gr+P/VHeOXJ3Lnbcijaunjf4bt4DszAQLjamGZAffceRUL+3C1jeyPfj4S79tkajXFySF/E035NK2v1qqeNjP5p72bZGlzzdFVuJ6M5j+CSw3bZqg7pk63CD0bnEClYD3LVaPOhISj2vuHSNFv6yiJGDBNYXifsOtwxj3hMR2NiOuucZozzKFcrSUzsRzu2E4Lvp2tXpSkSTK7C7dWZM+PUpmDbIZCmyqJ0btFNrrS8OditqzvD0aVtgoPyZXNVzeKX/tMcOfqi4GrvdweG6BSRCbQ7oncAMGmk4RNqvMrO1qxIlaeofb8ADcVSywoYP1Hb9sbbYCpwW/5sk2VOBYjyj50ywQr+xy1DwVEz4vVWH4fYgv4Fz2iBEYe9d1HmDEG7zPo1HSverEbUZDl7oHP5mDxJxmoyRWTOpRlfAQ51y/zZt8pg6tdVBodDCE+whCmruzJzPwWYLxsK5538Pg9r+DREQt+E5MH4D/Z7hd1ekT3ZUR4jS1XfRXGgpRml5IVJQSwqZWKrVkoSlCfyPzdwCLHSBHm6SJo2H9p7secdEc60FoSlwNGX8ISKonpdR8TU9/+LR2r6FuY6Q== paul.bowsher@gmail.com',

--- a/modules/users/manifests/paulhayes.pp
+++ b/modules/users/manifests/paulhayes.pp
@@ -1,6 +1,6 @@
 # Creates the paulhayes user
 class users::paulhayes {
-  govuk::user { 'paulhayes':
+  govuk_user { 'paulhayes':
     fullname => 'Paul Hayes',
     email    => 'paul.hayes@digital.cabinet-office.gov.uk',
     ssh_key  => [

--- a/modules/users/manifests/paulmartin.pp
+++ b/modules/users/manifests/paulmartin.pp
@@ -1,6 +1,6 @@
 # Creates the paulmartin user
 class users::paulmartin {
-  govuk::user { 'paulmartin':
+  govuk_user { 'paulmartin':
     fullname => 'Paul Martin',
     email    => 'paul.martin@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCmRLg0w+h+v/7e69My1MKdwFtwophFObBunFAeDBxz2Q06WeVPjUxjxuDSIBOD/VyRJFzN6ouxvTr+E+4pR4hk899RCfWnBzM+jWf37TZYMZ7uuA7/i3xVkad5o0gIFrvv+gdRSa5Xu2sMGt8HEgj7KONH13NXwJiKiE916Vp0ZDmVIE1qbaqlT5NA4D+WNMzgtXfekHpECnY/MLwIxdsLpOr2adsCRSR9zm6v8ycQzSTmQdrwrz28B3Cmk9E9JqVuucSq+Gnoi/Zk+nSrc3raS4PPwIXd/0wsl+d8CD7HuuwmVTE/27imjTaY0Rln8V6I/FM+6hdfBExapRCkrAd9KWC/BW10YjGjmuudqemW1khwgr75k1D3387r5nru4KJYsqb/TYbdp+M7uu7rImBnvSK52eNNyatXmgK86/pFJOJwJyPi+7XMn3EqY5wquOucsWI7RDANfMJhf/AFZzP8e6Yc/XxBdlri6ua3qCw9vA/TTi0h18O6FMz1s2nKP4+65+vjihuOJO+kl7eloIGHVEG8qW6/CBxefTKVAVxbjW2hJFlGkcb3D2g1kbQTNolG22dxRJzfDwZmsuS7vLnvlqdVEspmVczNBUod4lN59XnGa1fNECn5rlLPzhNtK0yZvtpZCMGwB/rWPADhgxXNna2CLwC2Y7C7ejcp2QSzEw==',

--- a/modules/users/manifests/richardboulton.pp
+++ b/modules/users/manifests/richardboulton.pp
@@ -1,6 +1,6 @@
 # Creates the richardboulton user
 class users::richardboulton {
-  govuk::user { 'richardboulton':
+  govuk_user { 'richardboulton':
     fullname => 'Richard Boulton',
     email    => 'richard.boulton@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCz/YV16q+dQQlXReLyS9mDVl36NlIs6iwZjbGQbLnuz1pb5GrHn8Adnvr50bHZncCtbMa0FlCpeiKGfcGCiDeQLYx1laCeNaD94OSeRYdjoVJiw6bpM7oc06YMaveMlD/z1K+XPbWx78Wx4TzezVhvO3+frVqe1w+0Z8olyLJW84c0FLlssBye6wG5dd/ZA/Vjj3dEA7qSgcRNeishedj62aVmvBYgwl95AHCH2dknmPMGmgWDdg+Rv6qR1F309XP4iwHgPCX+vllxFENZi1SQdekJw+sMTtcat10G6C9fmK6Cm6P+Xk5hcG5MzoQOB4YcC5wUCGPX0NiJxov0kvSoHDwxsjiZJG+ktGIUkmAYX/t+lbVhJbjJfU3XOkHUAe4RteqjTDKxw8LCNqIw1AHGJ9A1Ny5+JNt9cj60pKF75G5Iek2y5mrCQSxg4Bo8zloS7IaOhuU+9shT3d7BuaFkfV01FIt7WZPyNhtBACyac9+zIMd/9MFFNLlh8NLLoi/LK6IYlArfcORr4vzkMG7BNfcR1yj6NoissbffnfpzVZryfOChWPDk3lfXp5SOwEaktZYZ6gtjCXE9Soy5Kqdf/FV1TMwgzbR6egwV+PrB5Iy0+1GkNwY/4fmU89+URfTQw/HmRDrnGaPeEYCeCDZesfJVC3u9o+yKXZCoys6dpw== richardboulton@GDS0322',

--- a/modules/users/manifests/robinwhittleton.pp
+++ b/modules/users/manifests/robinwhittleton.pp
@@ -1,6 +1,6 @@
 # Creates the robinwhittleton user
 class users::robinwhittleton {
-  govuk::user { 'robinwhittleton':
+  govuk_user { 'robinwhittleton':
     fullname => 'Robin Whittleton',
     email    => 'robin.whittleton@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-rsa REPLACE ME',

--- a/modules/users/manifests/rosafox.pp
+++ b/modules/users/manifests/rosafox.pp
@@ -1,6 +1,6 @@
 # Creates rosafox user
 class users::rosafox {
-  govuk::user { 'rosafox':
+  govuk_user { 'rosafox':
     fullname => 'Rosa Fox',
     email    => 'rosa.fox@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC9D0hz7MNQL9ywlC4OfhhirQwc6dmUJE1hPan32rGq3WKVVtNCRyycB3UTu2GZ7vEBahYFx9Sxf/tbOAwuhGEgaOvGPepvslKltY9X+A92z7KneK12UyX4TTtuKZMAfCMKC6auoXyROuxPNpxFBrrmPHhySbftaxjjM5ORh1btef+GKyhbrqyFwzUq5AuylAacE3aiS8+A00FNs9aRPcnMMu6vDCFsaUKrDh4U9nIb3fa2d+mQAbuGpEw+yYN0gPmCE9x9zXN/rPXBxboTqOMnLvqPiuMebnV8Ec9/puSzYMREi+VrqMxun1/GsAh0GDvYIEPrKSYdIxQ4/Q4f23sPUF1UZBlqxdaVQFP/QH+E35woNQRF1/ulxxOflHMUPna36Cuw8aJRb4FZ+lyVF23qCNpUP1upa82aDadfcZPRMPk5nscrOFQJBO4JgTWosfofFdFEdgznuUfTi7+QFoVVRJ6SFNmeSF6Av09FQ4pkRjiNZF2LI7xgJ65ZkfNiJn/0A8w4lx9XioNNtfZunCPz3pQzgRSqZyw4SyZHZalm7MDRp1oNKrESqQy+cLPNWcogKI93YG3HckXK5hDGJOH1xWHO1jNZ99fr9da+ej0En5hRQE1xjQyFSvvZi/d5G4gabunjSzSrcfu2FYryr3CcFCJS8XOZUF7IbHu51g8c5w== rosa.fox@digital.cabinet-office.gov.uk',

--- a/modules/users/manifests/seemasatish.pp
+++ b/modules/users/manifests/seemasatish.pp
@@ -1,6 +1,6 @@
 # Creates the ssatish user
 class users::seemasatish {
-  govuk::user { 'seemasatish':
+  govuk_user { 'seemasatish':
     fullname => 'Seema Satish',
     email    => 'seema.satish@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDAWfw6NUUuU8C7c8MuLGt0hRjWN3W4ov2wjJTSGr+bAxStqEoWCpOG0ZoiXb8/idtxPd6gEDtHZSLzX0BRow9JeKA3hXQPmsK0W5JguXs6JSSIIKesQHXXjusp1GyKGiNexBbpU4PykNVx3BoNPgktGKg9Yzz+fE+5DixqVczsnEyJ/OJytsblZKyzOmPpg1bW+bao/kbDI470DrgkcE9amtGcyxc9KAvGM64CzJt49/xIRdKBObx6X6gbRpOoA4CkbU6FA4eJIHk6+3QwZFjF+Sshh2kP9dhf15eS8aHDA6kdolUeArycOVKqwnJgunjcS1EJ2L8oMZ4rpf4tOF8jtoZw58mBGsrJsZvSu7yGGYDy7z8I4V+5feOWMbGH6b5oA0VgzzhkuSA2u2VoVAmSdr5Be1YyfjhrgdiQYA5UrKO8mvF8MmNFulKdgow+M9/zzEskcK6rWBGj8kxUxqImQK2556TV2Dvz6KTSaKggfEZJI/9Y/5DaRwqvzPX3XSYzRB5zHnnFDIqqoQO2UfyLw7PxZ0xaYlRMyQn9afphT5ChrFV5IRrWNK1eghe/1t6p+Zjk7hhWN2BhTWXR553zlrzHwEyNIYuPnN2431uBkhh7ATMYuTTEULsOXjDpi1PycN5Gc6jfaG9y6sh++OZK4E7K7yGEaDHoYrj7zEFoJw== ssatish@eussatish.local',

--- a/modules/users/manifests/simonhughesdon.pp
+++ b/modules/users/manifests/simonhughesdon.pp
@@ -1,6 +1,6 @@
 # Creates the simonhughesdon user
 class users::simonhughesdon {
-  govuk::user { 'simonhughesdon':
+  govuk_user { 'simonhughesdon':
     fullname => 'Simon Hughesdon',
     email    => 'simon.hughesdon@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCqbi1IsUFv6YjnhLTHY3pDhhGpl1chm657LpUU8Y/I3/4pUmtXF4N8HGoch5Be3VZDYrhWy7m9uqu2A7vVGn3Feq4TIZn2+hZ33A715iN4LSsqR/ccuOaHazb485RKgKbycFFwZVe4bxpuxy8rhqfQ9GckhQO2BrN5ZFmZVSiQ0hxh6fkWPILfp/bxI64c7MTOXeWt0rqPXJF7MHPQv1r47OiTzggYu+dk5eGPi1PUrU0npt3R3J1+c9lj6bNLpYRN6Ko+CzrOFXwp+mhxdv/1WZnKMPYpVU2W+97eZdUk6mOw2qUvYXvugCzOeVBrkhjW1xEEfybgJ8ud6rC1a60Dz1sPLO1uwaPP+VzC2GuvPP3WSS66HouaJkcjTHwT2TsLv0T21R3rFpae8FVDS4L2fw08SjR/IOqw3ZN3OARomomJBk4sojHC5UEnzY1ZIilyUS+DD8mtXYyZABXGuTREvDHCSvW1rcEpY16JKXceY4aLRs2kYYAvJdtpo5zUhnRTPpQRF8smtR9xElFhNi2+76cX/718Hf22Yu4IsY6p+4tHeQKQMF6/kzJavTIq/g0BnA/fDFGtfj2wx5qDyMwFkieYppgX4eW6Hyxhn+tph2uN4ntvhq1+hI30mHv2bs1+tqJq5Ze97hSMBCwzKZGdJe0LyGukjP72arw2hBEYfw== simon.hughesdon@digital.cabinet-office.gov.uk',

--- a/modules/users/manifests/stevelaing.pp
+++ b/modules/users/manifests/stevelaing.pp
@@ -1,6 +1,6 @@
 # Creates the stevelaing user
 class users::stevelaing {
-  govuk::user { 'stevelaing':
+  govuk_user { 'stevelaing':
     fullname => 'Steve Laing',
     email    => 'steve.laing@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1gVqgpzk0hswuVTlB6ICy7ee66ZpXKdDJubLrZ2+k129swujlwBTPmf+asS/2aSRXhC+rrDTflYaupQiGzuZZkO9sMzKoGVr9EyHZcjUZU7jWj66rGiBi1XaF3I1ZdiJjVRdrJ1jMcAnkkPeE4jA2LMuoO5h/Xlk5tiu3h3Wm6fa8QBvvpIf6MtqisRlsNqLUIt3+7K+MCO9ZgSdb8VTO8UKlfk6G0Lby5ptKFu2yhlujeJD3vCcO41XRuzLV3Pb/rRZPPJ8LNv5D+qV+TO+s1qJj6xrNH5kn48XveebSglu/YZWG0NYnDvbH7dKyKfKenJm/UGY/AYR3ZoCkQxx1eZlEkZGRv+U8BT4gIKmdc3VQYC30AMUF/trNDrWAJIKJ7f8XiT9Zc4NGRBSJ8OH+RWzJ7Q4prW1MxViN7qOmpgYdHTfnPYndR+j4n/3qkPO4+3R1rAPDxNReoMa30mUBWyKxkifp16CmY+kk6UdrYs1lnPbDL95EHpMlDAobKoRWXHIWA+J0luhZ0RcHbJA+n8u8bJgUw3KaFKerdjzy6dxGEMVTzkgACA4f9eePtwBVMTv+vZJZGOk5V96VrrMdhzMX7xmNW0twkRyxy7SOd9fUGqGqKAEC396d67HeH7IhJuq22rRC5CNWxJpITFPpVdMjWnYEYqYQcBl2d+9JTw==',

--- a/modules/users/manifests/stuartgale.pp
+++ b/modules/users/manifests/stuartgale.pp
@@ -1,6 +1,6 @@
 # Creates the stuartgale user
 class users::stuartgale {
-  govuk::user { 'stuartgale':
+  govuk_user { 'stuartgale':
     fullname => 'Stuart Gale',
     email    => 'stuart.gale@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC3VSG/wyLEbASHpGwY4os0PNfCRBCVj/w8NsXFuNC6JDA5Ylz33xKM6QXmsW7WcEXz+apCkyvHeHZvijY2ztzoxMr0FbidNuHK28CyO99rzL8uGMqYpHgIIk9Iro9OW5uuROvXvSqAP0pdXQtMQQf9BfYD0+bGNZUsyvQ9nZtbijJHzEz7qyWpLY0mvgTc9A2uSggd0G8AsgxOHD/hJxlZdwoqrNDbSkskqD2UlDFmizzAzbAdiK3KGFO0kaEI1M5WkIBalMtMyr6TjMLpgHmHiaa2ivSWFkRNaz9LUVmN+K6izlGUEY4ANekzn6PxzJkTfXq7pfgnMHPbEdcm/2CNv/CewxgsBrCx7P8wsNwi5JzuIfG9aaTFfztMfhweHyBadtT176Uo3IJaqMM8fcAVZQuZcfcdgU6yfa+8zpWaX994pWub6nuGOkdkrS50PgwwnkhtKymcOmjiVuwtqUZ1EDJWNyOyN/u4GjrK5rrz1Mcu1vZOsz5Dy6fdlvWkyHgZ/OGrDUd5CCfOW8f4NGYNec1b/FiXITkRwxvEdamXcVG+4W0+/yYthf7gZT1cJFj1ZF/B0j09qFuKBVh8aIBXOdFNdku3cBRW1/W4cxvRKZvXvnLV50u4YHt3jOTH8tQx78nj1s9MS0SgQNEbpmpIN4n8f0sjwKKPiSusrN9mEQ== stuart.gale@digital.cabinet-office.gov.uk

--- a/modules/users/manifests/tatianasoukiassian.pp
+++ b/modules/users/manifests/tatianasoukiassian.pp
@@ -1,6 +1,6 @@
 # Creates the tatianasoukiassian user
 class users::tatianasoukiassian {
-  govuk::user { 'tatianasoukiassian':
+  govuk_user { 'tatianasoukiassian':
     fullname => 'Tatiana Soukiassian',
     email    => 'tatiana.soukiassian@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDD1oitANDo9Sn/uc0El3iFsRLb0rmHQ2rMx6TKojtfvlSUEClhxhkYZflykpAAeFiyFO3A3eo5/QoP6G2fqc+L4h70Td5tniXVC2ht2UO+UqcSEStkaEFbUCn9lD+jkD+Ta0tpXwA0lmcZtfTk2e2kpNu9ecx3bvKfe3apY9K+4g83I3971BDNK3eCjszvC4QCzr9NG9ssrg4DH+5AmMXn6mRxF0TMgmt3jbJ23i3snEJyRQK4KPy0GEOx3NFyVQACj3wv6ZN+elo3rSGOuiuwFrQKNdte/NfUkRm2Sh3GU+6vGiJfBiw2/J6OqyRORAYoCvy+73A805a/mNsH7y16+P9A+thsMusYVtr6nUP7+nm9iLo3G4t1zNIRJ6h4Z/M6Zt1nFzfvCrOgK2xTkwXPvzqXAshsjl2/ls8FU9Co7WHQmBGrHinBCadEABgXx27ruWYI4lfSL3/5w5PBoMm24m3WoFH9swo51HLVdE3r3ZxN7XP4BHVIpBpAzIxyguKHEuMHXRGwFklfsVuC9fOuap284pZvemc2FJthSvn+wUMglFGIWhyoFLGJJ5ihwgRD+uFkXt4NUf5N5BbdLGKdqRZGzuaSV9Fl65FTIpV/frmFixY1vfls6GRj4Vrtm/zU8oO3fhlRwhCKVmMjdSKjzQxu1w9kG1rP89wGOpziPw== tatiana.soukiassian@digital.cabinet-office.gov.uk',

--- a/modules/users/manifests/tijmenbrommet.pp
+++ b/modules/users/manifests/tijmenbrommet.pp
@@ -1,6 +1,6 @@
 # Creates the tijmenbrommet user
 class users::tijmenbrommet {
-  govuk::user { 'tijmenbrommet':
+  govuk_user { 'tijmenbrommet':
     fullname => 'Tijmen Brommet',
     email    => 'tijmen.brommet@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQChxDnHtmrP+8wTqONV76/sHMAVkJeyeMs/yDNl4+bumjWum9+ZqKGTS6QvvZGh/rTKg5934ncv5xPv910NmisYW6SetjT4hWMZuqtnZKdLBN2YpSyqTjIWK0kpdKMS1linkeE5/6X38Ebi3UKP63VqTsDM7o4W2v/CshoIbC5+UKt7WjtcMsrijpul1leSw8gvwCtoq6z5N3vLqECTcv5/AoH+LxWDW/TYlywGqUD4Lfa1jJGf+D5ICK+StQMQ1RBU4ICby43htus+RR+NqMyDnQLkGdrVVT+/Tc2jQrj0wz78nVvJPULiG889NvgPrjXn1s9w45DuVl7i3a4c+X8yFGg6hcgW8pHcH+2sOPC5g1Y84ZARLj6yIr1ezdr6H5vSLiUBTauYuTOP3u2F5h1MKLHdXuhUKaV4jIj42jKpCwnKnd62uHs4oOkfIz4OFbVNCNDvUdBMYbRkJd8yDYHeSzbEFElSSSxBRtwMnfX1DJ21myNtI0AGzQMP27NYkroHQGLmbbHiLeWuFly8yuEmeeustdtQBwf6qMTcJeCXtAkzgTUDFYLsu3zBCZQN9wJt/OCBPrGbwn5cutaUMmn9RGEeUgqNYxzvKEwmF+1/QINAD3PZjk3byfh0u1LRYnppvQrfsg24wh5dtlTRzPfuPxtrWdKTxkPm3gLvqdJmvw== tijmen.brommet@digital.cabinet-office.gov.uk',

--- a/modules/users/spec/classes/users_spec.rb
+++ b/modules/users/spec/classes/users_spec.rb
@@ -4,15 +4,15 @@ require 'sshkey'
 describe "users", :type => "class" do
   context 'on whitelisted node pentest user should be created' do
     let(:facts) {{ :hostname => 'foo' }}
-    let(:pre_condition) { 'class users::andre_the_giant { govuk::user { "andre_the_giant": } }' }
+    let(:pre_condition) { 'class users::andre_the_giant { govuk_user { "andre_the_giant": } }' }
 
-    it { is_expected.to contain_govuk__user('andre_the_giant') }
+    it { is_expected.to contain_govuk_user('andre_the_giant') }
   end
 
   context 'on non-whitelisted node pentest user should not be created' do
     let(:facts) {{ :hostname => 'bar' }}
 
-    it { is_expected.not_to contain_govuk__user('andre_the_giant') }
+    it { is_expected.not_to contain_govuk_user('andre_the_giant') }
   end
 end
 
@@ -43,7 +43,7 @@ username_whitelist = %w{
 user_list.each do |username|
   describe "users::#{username}", :type => "class" do
     it 'should have a username of the correct form' do
-      user = subject.call.resource('govuk::user', username)
+      user = subject.call.resource('govuk_user', username)
       expect(user).not_to be_nil
 
       unless username_whitelist.include?(username)
@@ -56,7 +56,7 @@ user_list.each do |username|
     end
 
     it 'should have a strong SSH key' do
-      user = subject.call.resource('govuk::user', username)
+      user = subject.call.resource('govuk_user', username)
       ssh_keys = user[:ssh_key]
 
       # Support for multiple SSH keys


### PR DESCRIPTION
In a bid to break up the monolithic `govuk` module.

I tested this in Vagrant.