### PR TITLE
Remove dependency on `/usr/share/nginx`

### DIFF
--- a/modules/loadbalancer/manifests/balance.pp
+++ b/modules/loadbalancer/manifests/balance.pp
@@ -89,7 +89,6 @@ define loadbalancer::balance(
     file { '/usr/share/nginx/html/maintenance.html':
       ensure  => present,
       content => template('loadbalancer/usr/share/nginx/html/maintenance_page.erb'),
-      require => File['/usr/share/nginx'],
     }
   }
 }


### PR DESCRIPTION
This is only in the catalog on the router machines so it will need some more work to add a dependency for this resource.