### PR TITLE
Enable Travel Advice email alerts everywhere

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -43,6 +43,7 @@ govuk::apps::errbit::errbit_email_from: 'govuk-winston+errbit-production@digital
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::publicapi::backdrop_host: 'www.performance.service.gov.uk'
 govuk::apps::publisher::data_import_passive_check: true
+govuk::apps::travel_advice_publisher::enable_email_alerts: true
 
 govuk::deploy::actionmailer_enable_delivery: true
 

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -15,6 +15,7 @@ govuk::apps::errbit::errbit_email_from: 'govuk-winston+errbit-staging@digital.ca
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::publicapi::backdrop_host: 'www.staging.performance.service.gov.uk'
 govuk::apps::sidekiq_monitoring::enabled: true
+govuk::apps::travel_advice_publisher::enable_email_alerts: true
 
 govuk::deploy::aws_ses_smtp_host: 'email-smtp.eu-west-1.amazonaws.com'
 govuk::deploy::config::errbit_environment_name: 'staging'


### PR DESCRIPTION
NOT TO BE MERGED UNTIL SAFELY DEPLOYED

To be followed up by a PR to remove the conditionals everywhere once we've deployed and tested the change.