### PR TITLE
Rename 'name' to 'named' to avoid puppet 4 errors.

### DIFF
--- a/modules/postfix/manifests/config.pp
+++ b/modules/postfix/manifests/config.pp
@@ -20,11 +20,11 @@ class postfix::config(
 
   if $smarthost {
 
-    postfix::postmapfile { 'outbound_rewrites':     name => 'outbound_rewrites' }
-    postfix::postmapfile { 'local_remote_rewrites': name => 'local_remote_rewrites' }
+    postfix::postmapfile { 'outbound_rewrites':     named => 'outbound_rewrites' }
+    postfix::postmapfile { 'local_remote_rewrites': named => 'local_remote_rewrites' }
 
     if ($smarthost_user and $smarthost_pass) {
-      postfix::postmapfile { 'sasl_passwd': name => 'sasl_passwd' }
+      postfix::postmapfile { 'sasl_passwd': named => 'sasl_passwd' }
     }
   }
 

--- a/modules/postfix/manifests/postmapfile.pp
+++ b/modules/postfix/manifests/postmapfile.pp
@@ -1,17 +1,17 @@
 # FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
-define postfix::postmapfile($name) {
-        exec { "postmap_${name}":
-                command     => "/usr/sbin/postmap /etc/postfix/${name}",
+define postfix::postmapfile($named) {
+        exec { "postmap_${named}":
+                command     => "/usr/sbin/postmap /etc/postfix/${named}",
                 refreshonly => true,
                 require     => [
-                            File["/etc/postfix/${name}"],
+                            File["/etc/postfix/${named}"],
                             Package['postfix']],
         }
-        file { "/etc/postfix/${name}":
+        file { "/etc/postfix/${named}":
                 ensure  => present,
                 mode    => '0644',
-                content => template("postfix/etc/postfix/${name}.erb"),
-                notify  => Exec["postmap_${name}"],
+                content => template("postfix/etc/postfix/${named}.erb"),
+                notify  => Exec["postmap_${named}"],
         }
 }
 


### PR DESCRIPTION
In puppet 4/future parser this code will cause
"The parameter $name redefines a built in parameter in the 'define'
expression" to be logged and rspec tests to fail.