### PR TITLE
Make port use an integer value, not implicit string conversion

### DIFF
--- a/modules/govuk/manifests/app.pp
+++ b/modules/govuk/manifests/app.pp
@@ -269,14 +269,20 @@ define govuk::app (
   if ! ($app_type in ['procfile', 'rack', 'bare']) {
     fail 'Invalid argument $app_type to govuk::app! Must be one of "procfile", "rack", or "bare"'
   }
+
   if ($app_type in ['procfile', 'rack']) and ($port == 0) {
     fail 'Must pass port when $app_type is "procfile" or "rack"'
   }
+
   if ($app_type == 'bare') and !($command) {
     fail 'Invalid $command parameter'
   }
+
+  if ($app_type in ['procfile', 'rack']) {
+    validate_integer($port, 65535, 1025)
+  }
+
   validate_re($ensure, '^(present|absent)$', 'Invalid ensure value')
-  validate_integer($port, 65535, 1025)
 
   $vhost_real = $vhost ? {
     undef    => $title,

--- a/modules/govuk/manifests/app.pp
+++ b/modules/govuk/manifests/app.pp
@@ -234,7 +234,7 @@
 #
 define govuk::app (
   $app_type,
-  $port = 'NOTSET',
+  $port = 0,
   $command = undef,
   $logstream = present,
   $legacy_logging = true,
@@ -269,14 +269,14 @@ define govuk::app (
   if ! ($app_type in ['procfile', 'rack', 'bare']) {
     fail 'Invalid argument $app_type to govuk::app! Must be one of "procfile", "rack", or "bare"'
   }
-  if ($app_type in ['procfile', 'rack']) and ($port == 'NOTSET') {
+  if ($app_type in ['procfile', 'rack']) and ($port == 0) {
     fail 'Must pass port when $app_type is "procfile" or "rack"'
   }
   if ($app_type == 'bare') and !($command) {
     fail 'Invalid $command parameter'
   }
   validate_re($ensure, '^(present|absent)$', 'Invalid ensure value')
-  validate_string($port)
+  validate_integer($port, 65535, 1025)
 
   $vhost_real = $vhost ? {
     undef    => $title,


### PR DESCRIPTION
This is an early step to support future/parser puppet 4. Our rspec
tests currently specify (correctly) that port is an int. Our manifest
should reflect that choice of type.

We also shouldn't be running our apps on priviledged ports so we set
the lowest allowed port to be 1025.

This will require apps using strings to be converted over to ints
when we start to run puppet 4. Those will be done in a seperate PR.