### PR TITLE
Postgres futureparser specs

### DIFF
--- a/modules/govuk_postgresql/spec/classes/govuk_postgresql__env_sync_user_spec.rb
+++ b/modules/govuk_postgresql/spec/classes/govuk_postgresql__env_sync_user_spec.rb
@@ -38,7 +38,7 @@ describe 'govuk_postgresql::env_sync_user', :type => :class do
   context 'no password provided' do
     it {
       is_expected.to raise_error(
-        Puppet::Error, /^Must pass password to/
+        Puppet::Error, /Must pass password to/
       )
     }
   end

--- a/modules/govuk_postgresql/spec/classes/govuk_postgresql__server__standby_spec.rb
+++ b/modules/govuk_postgresql/spec/classes/govuk_postgresql__server__standby_spec.rb
@@ -13,7 +13,9 @@ describe 'govuk_postgresql::server::standby', :type => :class do
   let(:pg_resync_slave) { '/usr/local/bin/pg_resync_slave' }
 
   let(:facts) {{
-    :concat_basedir => '/tmp/concat',
+    :concat_basedir         => '/tmp/concat',
+    :operatingsystem        => 'Ubuntu',
+    :operatingsystemrelease => '14.04',
   }}
   let(:params) {{
     :master_host     => param_host,

--- a/modules/govuk_postgresql/spec/classes/govuk_postgresql__server_spec.rb
+++ b/modules/govuk_postgresql/spec/classes/govuk_postgresql__server_spec.rb
@@ -50,7 +50,7 @@ describe 'govuk_postgresql::server', :type => :class do
     context 'no sub-classes are loaded' do
       it {
         is_expected.to raise_error(
-          Puppet::Error, /^Class govuk_postgresql::server cannot be used directly/
+          Puppet::Error, /Class govuk_postgresql::server cannot be used directly/
         )
       }
     end

--- a/modules/govuk_postgresql/spec/classes/govuk_postgresql__server_spec.rb
+++ b/modules/govuk_postgresql/spec/classes/govuk_postgresql__server_spec.rb
@@ -24,7 +24,7 @@ describe 'govuk_postgresql::server', :type => :class do
               address     => '0.0.0.0/0',
               auth_method => 'md5',
               database    => 'replication',
-              type        => 'host',
+              'type'      => 'host',
               user        => 'replication',
             }
           }


### PR DESCRIPTION
These spec changes make the postgres module a lot more future parser friendly and allow most of the specs to now pass under Puppet 3.8 on OSX.