### PR TITLE
Add a vdc fact to our test runs to make them pass

### DIFF
--- a/modules/govuk/spec/classes/govuk__apt_spec.rb
+++ b/modules/govuk/spec/classes/govuk__apt_spec.rb
@@ -3,6 +3,7 @@ require_relative '../../../../spec_helper'
 describe 'govuk::node::s_apt' do
   let(:facts) {{
     :concat_basedir => '/var/lib/puppet/concat/',
+    :vdc            => 'fake_vdc',
   }}
   let(:node) { 'apt-1.management.somethingsomething' }
   let(:pre_condition) { 'govuk::mount { "/root/dir": }' }

--- a/modules/govuk/spec/classes/govuk__node__s_cache_spec.rb
+++ b/modules/govuk/spec/classes/govuk__node__s_cache_spec.rb
@@ -3,7 +3,10 @@ require_relative '../../../../spec_helper'
 describe 'govuk::node::s_cache', :type => :class do
   let(:node) { 'cache-1.router.somethingsomething' }
   let(:pre_condition) { '$concat_basedir = "/tmp"' }
-  let(:facts) { { :memorysize_mb => 3953.43 } }
+  let(:facts) {{
+    :memorysize_mb => 3953.43,
+    :vdc           => 'fake_vdc',
+  }}
 
   context 'by default' do
     it 'sets the varnish upstream port to the router' do

--- a/modules/govuk/spec/classes/govuk__node__s_whitehall_backend_spec.rb
+++ b/modules/govuk/spec/classes/govuk__node__s_whitehall_backend_spec.rb
@@ -4,7 +4,8 @@ describe 'govuk::node::s_whitehall_backend', :type => :class do
   let(:node) { 'whitehall-backend-1.backend.somethingsomething' }
   let(:facts) {{
     :concat_basedir => '/var/lib/puppet/concat/',
-    :memorysize =>  '15.95 GB',
+    :memorysize     => '15.95 GB',
+    :vdc            => 'fake_vdc',
   }}
   context 'sync_mirror is true' do
     let(:params) {{ :sync_mirror => true }}


### PR DESCRIPTION
When testing under the future parser we see issues in
icinga/manifests/client.pp under
`if ($::vdc == 'licensify') or ($::vdc == 'efg') or ($::vdc =~ /^*_dr$/) {`
if the vdc is undefined.

Adding this fact doesn't fix the tests but it does move the problem along from
'Left match operand must result in a String value. Got an Undef Value.'
to Could not find template '' which is an issue from an upstream module we'll
deal with in isolation.