### PR TITLE
Add the unicorn_port param to the package.pp file.

### DIFF
--- a/modules/puppet/manifests/master.pp
+++ b/modules/puppet/manifests/master.pp
@@ -34,6 +34,7 @@ class puppet::master(
       Class['unicornherder'],
       Anchor['puppet::master::begin'],
     ],
+    unicorn_port     => $unicorn_port,
   }
   class{'puppet::master::config':
     unicorn_port => $unicorn_port,

--- a/modules/puppet/manifests/master/package.pp
+++ b/modules/puppet/manifests/master/package.pp
@@ -4,13 +4,21 @@
 #
 # === Parameters
 #
+# [*hiera_eyaml_gpg_version*]
+#  Specify the version of hiera_eyaml_gpg to install.
+#
 # [*puppetdb_version*]
 #   Specify the version of puppetdb-terminus to install which should match
 #   the puppetdb installation. Passed in by parent class.
 #
+# [*unicorn_port*]
+#   Specify the port on which unicorn (and hence the puppetmaster) should
+#   listen.
+#
 class puppet::master::package(
   $hiera_eyaml_gpg_version = 'latest',
   $puppetdb_version = 'present',
+  $unicorn_port = '9090',
 ) {
   include ::puppet
 


### PR DESCRIPTION
The unicorn_port setting is used in package.pp ->
puppet/etc/init/puppetmaster.conf.erb and so needs to be
plumbed in. The test fails under futuer parser without this change.