### PR TITLE
Add mapit server

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -473,6 +473,8 @@ hosts::production::api::hosts:
     ip: '10.1.4.53'
   mapit-1:
     ip: '10.1.4.60'
+  mapit-2:
+    ip: '10.1.4.61'
   performance-mongo-1:
     ip: '10.1.4.31'
   performance-mongo-2:


### PR DESCRIPTION
We've built and tested one MapIt server in Integration.  The time has come to add another so that we can run them in a load balanced pair like the existing (old) servers do.

I'm planning to do the load balancer config in a separate PR once I've verified that it works OK.

The provisioning PR is here: https://github.gds/gds/govuk-provisioning/pull/520

https://trello.com/c/LrsfgWXN/30-test-the-new-version-of-mapit-in-integration