### PR TITLE
Mark the "original_url" field as not analysed

### DIFF
--- a/modules/govuk/files/node/s_logs_elasticsearch/logstash-template.json
+++ b/modules/govuk/files/node/s_logs_elasticsearch/logstash-template.json
@@ -81,6 +81,10 @@
             "path_exact": {
               "index": "not_analyzed",
               "type": "string"
+            },
+            "original_url": {
+              "index": "not_analyzed",
+              "type": "string"
             }
           },
           "type": "object"


### PR DESCRIPTION
The purpose of recording this is to be able to find the list of pages
which a particular app is involved in rendering, or the list of apps
involved in rendering a particular page.  If the field is
analysed we can't do this, because a facet query will instead return the
list of components of urls.