### PR TITLE
Fix Icinga hostname for offsite backup machine

### DIFF
--- a/modules/backup/manifests/offsite/monitoring.pp
+++ b/modules/backup/manifests/offsite/monitoring.pp
@@ -16,8 +16,9 @@ class backup::offsite::monitoring(
 ){
 
   icinga::host { $offsite_fqdn:
-    hostalias => $offsite_fqdn,
-    address   => $offsite_fqdn,
+    hostalias    => $offsite_fqdn,
+    address      => $offsite_fqdn,
+    display_name => $offsite_hostname,
   }
 
   icinga::check { "check_disk_${offsite_hostname}":


### PR DESCRIPTION
Without this change, the Icinga hostname was defaulting to the `fqdn`
facter fact, which made alerts for the offsite backup machine appear as
`monitoring-1.management`.