### PR TITLE
Remove unused dir for processed CDN logs

### DIFF
--- a/modules/govuk/manifests/apps/govuk_cdn_logs_monitor.pp
+++ b/modules/govuk/manifests/apps/govuk_cdn_logs_monitor.pp
@@ -23,6 +23,14 @@ class govuk::apps::govuk_cdn_logs_monitor (
   $cdn_log_dir = '/mnt/logs_cdn',
   $processed_data_dir,
 ) {
+
+  # FIXME: Remove once purged
+  file { '/mnt/logs_cdn_processed':
+    ensure  => absent,
+    force   => true,
+    recurse => true,
+  }
+
   if $enabled {
     file { $processed_data_dir:
       ensure => directory,


### PR DESCRIPTION
We stopped using this directory as of 1ec6a44 and I've confirmed that
there's no data in this directory in Production. Remove it so as to
avoid confusion.