### PR TITLE
Ignore last updated flags for Hiera eYAML GPG

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ REVISION
 /development/Vagrantfile.localconfig
 /gpg/random_seed
 nodes.local.yaml
+gpg_recipients/.*last_updated


### PR DESCRIPTION
As of gds/deployment@e1d5763a, the Rake task to modify credentials
encrypted using Hiera eYAML GPG now automatically imports GPG keys.

So that the Rake task only imports GPG keys when necessary, it now
creates a file on disk whose last-modified time it uses to know when GPG
keys were last imported.

Since we store the GPG recipients for the `vagrant` environment in this
repository, we need to ignore these files here also.