### PR TITLE
Ensure that scripts with file extensions are run

### DIFF
--- a/modules/cron/templates/etc/crontab.erb
+++ b/modules/cron/templates/etc/crontab.erb
@@ -8,8 +8,8 @@ SHELL=/bin/sh
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 
 # m h dom mon dow user  command
-<%= @hourly_min %> *    * * *   root    cd / && run-parts --report /etc/cron.hourly
-<%= @daily_min %> <%= @daily_hour %>    * * *   root    test -x /usr/sbin/anacron || ( cd / && run-parts --report /etc/cron.daily )
-<%= @weekly_min %> 6    * * <%= @weekly_dow %>   root    test -x /usr/sbin/anacron || ( cd / && run-parts --report /etc/cron.weekly )
-<%= @monthly_min %> 6    1 * *   root    test -x /usr/sbin/anacron || ( cd / && run-parts --report /etc/cron.monthly )
+<%= @hourly_min %> *    * * *   root    cd / && run-parts --report --regex '.*' /etc/cron.hourly
+<%= @daily_min %> <%= @daily_hour %>    * * *   root    test -x /usr/sbin/anacron || ( cd / && run-parts --report --regex '.*' /etc/cron.daily )
+<%= @weekly_min %> 6    * * <%= @weekly_dow %>   root    test -x /usr/sbin/anacron || ( cd / && run-parts --report --regex '.*' /etc/cron.weekly )
+<%= @monthly_min %> 6    1 * *   root    test -x /usr/sbin/anacron || ( cd / && run-parts --report --regex '.*' /etc/cron.monthly )
 #


### PR DESCRIPTION
I'm raising this for discussion.

The current behaviour is surprising and explains why jobs like [`prune-whisper-files.sh`](https://github.com/alphagov/govuk-puppet/blob/f47cec44a1577c7b31577ef69554ab2ebf02074e/modules/govuk/templates/node/s_graphite/prune-whisper-files.sh.erb) are not running.

We could fix the issue by renaming the scripts that have file extensions, however it's likely that someone else might hit the same issue in future and it go unreported for a long time.

On the other hand, it's also surprising behaviour if we modify the default way that `cron.daily` jobs are run.

My feeling is that adding the regex is the most pragmatic solution.

* * *

Scripts with file extensions are not currently being executed by
cron.daily because `run-parts`, which is used to run `cron.daily` jobs,
is not executing scripts with file extensions (e.g. `.sh`):

http://manpages.ubuntu.com/manpages/trusty/man8/run-parts.8.html

> If neither the --lsbsysinit option nor the --regex option is given
> then the names must consist entirely of ASCII upper- and lower-case
> letters, ASCII digits, ASCII underscores, and ASCII minus-hyphens.

Passing a regex to run-parts means that it will execute all executable
scripts in `/etc/cron.daily`.

Ubuntu bug: https://bugs.launchpad.net/ubuntu/+source/debianutils/+bug/38022

The upstream Debian bug has been archived:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=472585