### PR TITLE
Rename Amazon AWS ENV variables

### DIFF
--- a/modules/govuk/manifests/apps/rummager.pp
+++ b/modules/govuk/manifests/apps/rummager.pp
@@ -116,11 +116,11 @@ class govuk::apps::rummager(
     "${title}-PUBLISHING_API_BEARER_TOKEN":
       varname => 'PUBLISHING_API_BEARER_TOKEN',
       value   => $publishing_api_bearer_token;
-    "${title}-AWS_S3_KEY":
-      varname => 'AWS_S3_KEY',
+    "${title}-AWS_ACCESS_KEY_ID":
+      varname => 'AWS_ACCESS_KEY_ID',
       value   => $aws_s3_key;
-    "${title}-AWS_S3_SECRET":
-      varname => 'AWS_S3_SECRET',
+    "${title}-AWS_SECRET_ACCESS_KEY":
+      varname => 'AWS_SECRET_ACCESS_KEY',
       value   => $aws_s3_secret;
   }
 }


### PR DESCRIPTION
So that they ease the configuration process.
With these names will be picked up automatically by the
AWS client.

https://github.com/aws/aws-sdk-ruby#configuration

Part of:
https://trello.com/c/YAJY2zIl/359-implement-snapshot-restore-to-backup-elasticsearch-indexes

Pairing with @jackscotti 