### PR TITLE
Use enabled param for Elasticsearch reboot

### DIFF
--- a/modules/govuk_unattended_reboot/manifests/elasticsearch.pp
+++ b/modules/govuk_unattended_reboot/manifests/elasticsearch.pp
@@ -15,8 +15,14 @@ class govuk_unattended_reboot::elasticsearch (
   $config_directory = '/etc/unattended-reboot'
   $check_scripts_directory = "${config_directory}/check"
 
+  if ($enabled) {
+    $file_ensure = present
+  } else {
+    $file_ensure = absent
+  }
+
   file { "${check_scripts_directory}/02_elasticsearch":
-    ensure  => present,
+    ensure  => $file_ensure,
     mode    => '0755',
     owner   => 'root',
     group   => 'root',


### PR DESCRIPTION
We define this param already but we don't use it.