### PR TITLE
Add new MapIt servers to staging and production

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -131,7 +131,9 @@ govuk::node::s_api_lb::email_campaign_api_servers:
   - "email-campaign-api-1.api"
   - "email-campaign-api-2.api"
   - "email-campaign-api-3.api"
-govuk::node::s_api_lb::mapit_servers: [] # doesn't exist in production yet
+govuk::node::s_api_lb::mapit_servers:
+  - "mapit-1.api"
+  - "mapit-2.api"
 govuk::node::s_api_lb::search_servers:
   - "search-1.api"
   - "search-2.api"
@@ -287,6 +289,10 @@ hosts::production::api::hosts:
     ip: '10.3.4.54'
   email-campaign-mongo-3:
     ip: '10.3.4.55'
+  mapit-1:
+    ip: '10.3.4.60'
+  mapit-2:
+    ip: '10.3.4.61'
   performance-mongo-1:
     ip: '10.3.4.31'
   performance-mongo-2:

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -85,7 +85,9 @@ govuk::node::s_api_lb::email_campaign_api_servers:
   - "email-campaign-api-1.api"
   - "email-campaign-api-2.api"
   - "email-campaign-api-3.api"
-govuk::node::s_api_lb::mapit_servers: [] # doesn't exist in staging yet
+govuk::node::s_api_lb::mapit_servers:
+  - "mapit-1.api"
+  - "mapit-2.api"
 govuk::node::s_api_lb::search_servers:
   - "search-1.api"
   - "search-2.api"
@@ -220,6 +222,10 @@ hosts::production::api::hosts:
     ip: '10.2.4.54'
   email-campaign-mongo-3:
     ip: '10.2.4.55'
+  mapit-1:
+    ip: '10.2.4.60'
+  mapit-2:
+    ip: '10.2.4.61'
   performance-mongo-1:
     ip: '10.2.4.31'
   performance-mongo-2:


### PR DESCRIPTION
We're currently running with out of date MapIt data on production. We've recently built new MapIt servers in integration which have up to date software, data and the ability to import new data when it is released.

This is the next stage, which is to add the new machines to staging and production.  

When they've been tested and we're happy, we'll raise another PR to point mapit at the api load balancer (it's happily running against the old servers at present.)

[Trello card](https://trello.com/c/b3XBoEPI/29-get-new-mapit-running-in-staging-and-production-5)

Related PRs

- https://github.gds/gds/alphagov-deployment/pull/1149
- https://github.gds/gds/govuk-provisioning/pull/522
