### PR TITLE
Don't link pg_config for PostgreSQL

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -959,6 +959,7 @@ postgresql_slave_addresses_dr: "%{hiera('environment_ip_prefix')}.11.13/32"
 postgresql_transition_slave_addresses_live: "%{hiera('environment_ip_prefix')}.3.61/32"
 postgresql_transition_slave_addresses_dr: "%{hiera('environment_ip_prefix')}.11.61/32"
 
+postgresql::lib::devel::link_pg_config: false
 postgresql::globals::version: '9.3'
 
 puppet::master::puppetdb_version: '2.0.0-1puppetlabs1'


### PR DESCRIPTION
On Debian systems this change is destructive. It creates a symlink on top of the `pg_config` binary which exists.

This was caused by the recent upgrade of the [Puppet PostgreSQL module from 3.4.1 to 4.1.0][1]: "Link pg_config binary into /usr/bin"

[1]: https://github.com/puppetlabs/puppetlabs-postgresql/blob/master/CHANGELOG.md#2014-09-03---supported-release-400

Subsequently [MODULES-1485][2] was opened which correctly identified that this change was very destructive on Debian systems.

[2]: https://tickets.puppetlabs.com/browse/MODULES-1485

This has caused our PostgreSQL clients (including the development VM) to stop being able to install the `pg` gem.

It can be fixed by removing the postgresql-common packages and allowing Puppet to re-run to reinstall them:

```
sudo rm /usr/bin/pg_config
sudo apt-get remove postgresql-client-9.3 postgresql-client-common
```

The change to the PostgreSQL module has been [fixed in 4.2.0][3]

[3]: https://github.com/puppetlabs/puppetlabs-postgresql/blob/master/CHANGELOG.md#2015-03-10---supported-release-420