### PR TITLE
Reboot Mongo clusters unattended in Production

### DIFF
--- a/hieradata/class/api_mongo.yaml
+++ b/hieradata/class/api_mongo.yaml
@@ -1,7 +1,7 @@
 ---
 
-govuk_safe_to_reboot::can_reboot: 'careful'
-govuk_safe_to_reboot::reason: 'Check for primary, reboot secondaries, step down primary, reboot primary'
+govuk_safe_to_reboot::can_reboot: 'overnight'
+govuk_safe_to_reboot::reason: 'Secondaries will reboot overnight if cluster is healthy'
 
 lv:
   mongodb:

--- a/hieradata/class/email_campaign_mongo.yaml
+++ b/hieradata/class/email_campaign_mongo.yaml
@@ -1,7 +1,7 @@
 ---
 
-govuk_safe_to_reboot::can_reboot: 'careful'
-govuk_safe_to_reboot::reason: 'Check for primary, reboot secondaries, step down primary, reboot primary'
+govuk_safe_to_reboot::can_reboot: 'overnight'
+govuk_safe_to_reboot::reason: 'Secondaries will reboot overnight if cluster is healthy'
 
 lv:
   mongodb:

--- a/hieradata/class/mongo.yaml
+++ b/hieradata/class/mongo.yaml
@@ -1,7 +1,7 @@
 ---
 
-govuk_safe_to_reboot::can_reboot: 'careful'
-govuk_safe_to_reboot::reason: 'Check for primary, reboot secondaries, step down primary, reboot primary'
+govuk_safe_to_reboot::can_reboot: 'overnight'
+govuk_safe_to_reboot::reason: 'Secondaries will reboot overnight if cluster is healthy'
 
 lv:
   mongodb:

--- a/hieradata/class/performance_mongo.yaml
+++ b/hieradata/class/performance_mongo.yaml
@@ -1,7 +1,7 @@
 ---
 
-govuk_safe_to_reboot::can_reboot: 'careful'
-govuk_safe_to_reboot::reason: 'Check for primary, reboot secondaries, step down primary, reboot primary'
+govuk_safe_to_reboot::can_reboot: 'overnight'
+govuk_safe_to_reboot::reason: 'Secondaries will reboot overnight if cluster is healthy'
 
 lv:
   mongodb:

--- a/hieradata/class/staging/api_mongo.yaml
+++ b/hieradata/class/staging/api_mongo.yaml
@@ -1,3 +1,0 @@
----
-
-govuk_safe_to_reboot::can_reboot: 'overnight'

--- a/hieradata/class/staging/email_campaign_mongo.yaml
+++ b/hieradata/class/staging/email_campaign_mongo.yaml
@@ -1,3 +1,0 @@
----
-
-govuk_safe_to_reboot::can_reboot: 'overnight'

--- a/hieradata/class/staging/mongo.yaml
+++ b/hieradata/class/staging/mongo.yaml
@@ -1,3 +1,0 @@
----
-
-govuk_safe_to_reboot::can_reboot: 'overnight'

--- a/hieradata/class/staging/performance_mongo.yaml
+++ b/hieradata/class/staging/performance_mongo.yaml
@@ -1,4 +1,0 @@
----
-
-govuk_safe_to_reboot::can_reboot: 'overnight'
-


### PR DESCRIPTION
Story: https://trello.com/c/WRgYW2Zi/14-write-script-to-check-if-mongo-api-mongo-machines-can-be-rebooted

Enable unattended server reboots for MongoDB secondaries in Production.