### PR TITLE
Allow Backend and API Elasticsearch clusters to reboot in Production overnight

### DIFF
--- a/hieradata/class/api_elasticsearch.yaml
+++ b/hieradata/class/api_elasticsearch.yaml
@@ -1,7 +1,7 @@
 ---
 
-govuk::safe_to_reboot::can_reboot: 'careful'
-govuk::safe_to_reboot::reason: 'Reboot a single node at time and check that the cluster goes green between reboots'
+govuk::safe_to_reboot::can_reboot: 'overnight'
+govuk::safe_to_reboot::reason: 'Will reboot overnight if the cluster is healthy'
 
 govuk_elasticsearch::version: '1.4.4'
 

--- a/hieradata/class/elasticsearch.yaml
+++ b/hieradata/class/elasticsearch.yaml
@@ -1,7 +1,7 @@
 ---
 
-govuk::safe_to_reboot::can_reboot: 'careful'
-govuk::safe_to_reboot::reason: 'Reboot a single node at time and check that the cluster goes green between reboots'
+govuk::safe_to_reboot::can_reboot: 'overnight'
+govuk::safe_to_reboot::reason: 'Will reboot overnight if the cluster is healthy'
 
 govuk_elasticsearch::version: '0.90.12'
 

--- a/hieradata/class/staging/api_elasticsearch.yaml
+++ b/hieradata/class/staging/api_elasticsearch.yaml
@@ -1,3 +1,0 @@
----
-
-govuk::safe_to_reboot::can_reboot: 'overnight'

--- a/hieradata/class/staging/elasticsearch.yaml
+++ b/hieradata/class/staging/elasticsearch.yaml
@@ -1,3 +1,0 @@
----
-
-govuk::safe_to_reboot::can_reboot: 'overnight'


### PR DESCRIPTION
Story: https://trello.com/c/JD2ZFRcJ/13-write-script-to-check-if-elasticsearch-logs-elasticsearch-machines-can-be-rebooted

Allow the backend and API Elasticsearch clusters to reboot in Production
unattended overnight. They will only reboot if the cluster is healthy.

I haven't enabled this for the logs Elasticsearch cluster as the shard
reallocation, which is not disabled by the unattended reboots, takes
hours and I'd rather test it further in Staging first.