### PR TITLE
Move spec file for consistency

### DIFF
--- a/modules/govuk_etcd/spec/classes/govuk_etcd_spec.rb
+++ b/modules/govuk_etcd/spec/classes/govuk_etcd_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../../../spec_helper'
+require_relative '../../../../spec_helper'
 
 describe 'govuk_etcd', :type => :class do
   context 'When specifying a list of peers' do


### PR DESCRIPTION
Move the spec file for the etcd class to a `classes` subdirectory for
consistency with the directory schema we use for our other modules.