### PR TITLE
Fix broken build when facter specs run first

### DIFF
--- a/modules/govuk/spec/facter/fqdn_metrics_spec.rb
+++ b/modules/govuk/spec/facter/fqdn_metrics_spec.rb
@@ -2,7 +2,7 @@
 dir = File.expand_path('../../', File.dirname(__FILE__))
 $LOAD_PATH.unshift File.join(dir, 'lib')
 
-# We don't need rspec-puppet from spec_helper. Just facter.
+require_relative '../../../../spec_helper'
 require 'facter'
 
 describe 'fqdn_metrics' do

--- a/modules/govuk/spec/facter/fqdn_short_spec.rb
+++ b/modules/govuk/spec/facter/fqdn_short_spec.rb
@@ -2,7 +2,7 @@
 dir = File.expand_path('../../', File.dirname(__FILE__))
 $LOAD_PATH.unshift File.join(dir, 'lib')
 
-# We don't need rspec-puppet from spec_helper. Just facter.
+require_relative '../../../../spec_helper'
 require 'facter'
 
 describe 'fqdn_short' do

--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -1,4 +1,3 @@
-require 'csv'
 require 'rspec-puppet'
 require 'puppet'
 require 'puppetlabs_spec_helper/module_spec_helper'


### PR DESCRIPTION
Fix a race condition where the Rspec would error if the facter spec
tests ran before our other spec tests.

These spec tests for facter previously didn't require `spec_helper`
because they don't use `rspec-puppet`.

However, Rspec will error if we define example groups before configuring
the [Rspec mock framework][]. If the tests are parallelised in such a
way as to trigger this behaviour, Rspec aborts with the following error:

    Randomized with seed 31992
    : RSpec's mock_framework configuration option must be configured before any example groups are defined, but you have already defined a group. (RSpec::Core::Configuration::MustBeConfiguredBeforeExampleGroupsError)
            from /home/travis/build/alphagov/govuk-puppet/vendor/bundle/ruby/1.9.1/gems/rspec-core-3.3.2/lib/rspec/core/configuration.rb:582:in `mock_with'
            from /home/travis/build/alphagov/govuk-puppet/vendor/bundle/ruby/1.9.1/gems/puppetlabs_spec_helper-1.0.1/lib/puppetlabs_spec_helper/puppet_spec_helper.rb:122:in `block in <top (required)>'
            from /home/travis/build/alphagov/govuk-puppet/vendor/bundle/ruby/1.9.1/gems/rspec-core-3.3.2/lib/rspec/core.rb:97:in `configure'
            from /home/travis/build/alphagov/govuk-puppet/vendor/bundle/ruby/1.9.1/gems/puppetlabs_spec_helper-1.0.1/lib/puppetlabs_spec_helper/puppet_spec_helper.rb:120:in `<top (required)>'
            from /home/travis/build/alphagov/govuk-puppet/vendor/bundle/ruby/1.9.1/gems/puppetlabs_spec_helper-1.0.1/lib/puppetlabs_spec_helper/module_spec_helper.rb:2:in `require'
            from /home/travis/build/alphagov/govuk-puppet/vendor/bundle/ruby/1.9.1/gems/puppetlabs_spec_helper-1.0.1/lib/puppetlabs_spec_helper/module_spec_helper.rb:2:in `<top (required)>'
            from /home/travis/build/alphagov/govuk-puppet/spec_helper.rb:4:in `require'
            from /home/travis/build/alphagov/govuk-puppet/spec_helper.rb:4:in `<top (required)>'
            from /home/travis/build/alphagov/govuk-puppet/modules/loadbalancer/spec/defines/loadbalancer__balance_spec.rb:1:in `require_relative'
            from /home/travis/build/alphagov/govuk-puppet/modules/loadbalancer/spec/defines/loadbalancer__balance_spec.rb:1:in `<top (required)>'
            from /home/travis/build/alphagov/govuk-puppet/vendor/bundle/ruby/1.9.1/gems/rspec-core-3.3.2/lib/rspec/core/configuration.rb:1327:in `load'
            from /home/travis/build/alphagov/govuk-puppet/vendor/bundle/ruby/1.9.1/gems/rspec-core-3.3.2/lib/rspec/core/configuration.rb:1327:in `block in load_spec_files'
            from /home/travis/build/alphagov/govuk-puppet/vendor/bundle/ruby/1.9.1/gems/rspec-core-3.3.2/lib/rspec/core/configuration.rb:1325:in `each'
            from /home/travis/build/alphagov/govuk-puppet/vendor/bundle/ruby/1.9.1/gems/rspec-core-3.3.2/lib/rspec/core/configuration.rb:1325:in `load_spec_files'
            from /home/travis/build/alphagov/govuk-puppet/vendor/bundle/ruby/1.9.1/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:102:in `setup'
            from /home/travis/build/alphagov/govuk-puppet/vendor/bundle/ruby/1.9.1/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:88:in `run'
            from /home/travis/build/alphagov/govuk-puppet/vendor/bundle/ruby/1.9.1/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:73:in `run'
            from /home/travis/build/alphagov/govuk-puppet/vendor/bundle/ruby/1.9.1/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:41:in `invoke'
            from /home/travis/build/alphagov/govuk-puppet/vendor/bundle/ruby/1.9.1/gems/rspec-core-3.3.2/exe/rspec:4:in `<top (required)>'
            from /home/travis/build/alphagov/govuk-puppet/vendor/bundle/ruby/1.9.1/bin/rspec:23:in `load'
            from /home/travis/build/alphagov/govuk-puppet/vendor/bundle/ruby/1.9.1/bin/rspec:23:in `<main>'

I was able to reproduce this by running a facter spec test first:

    bundle exec rspec modules/govuk/spec/facter/fqdn_metrics_spec.rb modules/loadbalancer/spec/defines/loadbalancer__balance_spec.rb

https://travis-ci.org/alphagov/govuk-puppet/builds/111979282

[Rspec mock framework]: https://github.com/alphagov/govuk-puppet/blob/5bec25cf2c7c8e38c0d8a49719afbc7f6575e7c7/spec_helper.rb#L9

* * *

Also, remove an unused `require`.