### PR TITLE
Clean up email campaign errbit

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -186,7 +186,6 @@ govuk::apps::email_alert_api::enabled: true
 govuk::apps::email_alert_api::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 
 govuk::apps::email_campaign_api::errbit_environment_name: "%{hiera('govuk::deploy::config::errbit_environment_name')}"
-govuk::apps::email_campaign_api::errbit_host: "https://errbit.%{hiera('app_domain')}"
 govuk::apps::email_campaign_api::mongodb_nodes:
   - 'email-campaign-mongo-1.api'
   - 'email-campaign-mongo-2.api'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -185,7 +185,6 @@ govuk::apps::efg::nagios_memory_critical: 1800
 govuk::apps::email_alert_api::enabled: true
 govuk::apps::email_alert_api::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 
-govuk::apps::email_campaign_api::errbit_environment_name: "%{hiera('govuk::deploy::config::errbit_environment_name')}"
 govuk::apps::email_campaign_api::mongodb_nodes:
   - 'email-campaign-mongo-1.api'
   - 'email-campaign-mongo-2.api'

--- a/modules/govuk/manifests/apps/email_campaign_api.pp
+++ b/modules/govuk/manifests/apps/email_campaign_api.pp
@@ -29,7 +29,6 @@ class govuk::apps::email_campaign_api(
   $enabled = true,
   $enable_procfile_worker = false,
   $errbit_api_key = undef,
-  $errbit_environment_name,
   $secret_key_base = undef,
   $gov_delivery_endpoint = undef,
   $gov_delivery_code = undef,
@@ -73,9 +72,6 @@ class govuk::apps::email_campaign_api(
       "${title}-ERRBIT_API_KEY":
           varname => 'ERRBIT_API_KEY',
           value   => $errbit_api_key;
-      "${title}-ERRBIT_ENVIRONMENT_NAME":
-          varname => 'ERRBIT_ENVIRONMENT_NAME',
-          value   => $errbit_environment_name;
       "${title}-SECRET_KEY_BASE":
           varname => 'SECRET_KEY_BASE',
           value   => $secret_key_base;

--- a/modules/govuk/manifests/apps/email_campaign_api.pp
+++ b/modules/govuk/manifests/apps/email_campaign_api.pp
@@ -30,7 +30,6 @@ class govuk::apps::email_campaign_api(
   $enable_procfile_worker = false,
   $errbit_api_key = undef,
   $errbit_environment_name,
-  $errbit_host=undef,
   $secret_key_base = undef,
   $gov_delivery_endpoint = undef,
   $gov_delivery_code = undef,
@@ -77,9 +76,6 @@ class govuk::apps::email_campaign_api(
       "${title}-ERRBIT_ENVIRONMENT_NAME":
           varname => 'ERRBIT_ENVIRONMENT_NAME',
           value   => $errbit_environment_name;
-      "${title}-ERRBIT_HOST":
-          varname => 'ERRBIT_HOST',
-          value   => $errbit_host;
       "${title}-SECRET_KEY_BASE":
           varname => 'SECRET_KEY_BASE',
           value   => $secret_key_base;


### PR DESCRIPTION
- Remove special errbit host - derived from Plek (needs https://github.gds/email-campaign/email-campaign-api/pull/23 merged)
- Remove special errbit environment name - set globally already