### PR TITLE
Move PARALLEL_JOBS env var to correct place

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
@@ -17,6 +17,9 @@
     properties:
         - github:
             url: https://github.gds/gds/env-sync-and-backup/
+        - inject:
+            properties-content: |
+              PARALLEL_JOBS=2
     scm:
       - env-sync-and-backup_Copy_Data_to_Integration
     logrotate:
@@ -60,8 +63,6 @@
     wrappers:
         - ansicolor:
             colormap: xterm
-        - inject:
-            script-content: PARALLEL_JOBS=2
     parameters:
         - choice:
             name: JOBLIST

--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_staging.yaml.erb
@@ -16,6 +16,9 @@
     properties:
         - github:
             url: https://github.gds/gds/env-sync-and-backup/
+        - inject:
+            properties-content: |
+              PARALLEL_JOBS=2
     scm:
       - env-sync-and-backup_Copy_Data_to_Staging
     logrotate:
@@ -73,8 +76,6 @@
     wrappers:
         - ansicolor:
             colormap: xterm
-        - inject:
-            script-content: PARALLEL_JOBS=2
     parameters:
         - choice:
             name: JOBLIST

--- a/modules/govuk_jenkins/templates/jobs/copy_licensify_data_to_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_licensify_data_to_staging.yaml.erb
@@ -15,6 +15,9 @@
     properties:
         - github:
             url: https://github.gds/gds/env-sync-and-backup/
+        - inject:
+            properties-content: |
+              PARALLEL_JOBS=2
     scm:
       - env-sync-and-backup_Copy_Licensify_Data_to_Staging
     logrotate:
@@ -58,8 +61,6 @@
     wrappers:
         - ansicolor:
             colormap: xterm
-        - inject:
-            script-content: PARALLEL_JOBS=2
     parameters:
         - choice:
             name: JOBLIST


### PR DESCRIPTION
The `PARALLEL_JOBS` environment variable in the data sync Jenkins job
was in the wrong place.

Fixing this will allow our Integration sync job to complete before
office hours by running the sync jobs in parallel; currently it has been
overrunning until after 9:30am. It has been taking 1.5 hours longer
since the `mongo-pp` job was added in alphagov/govuk-puppet#3665.

According to the contextual help in Jenkins, `script-content` is used as
follows (note the last line):

    Execute a script file aimed at setting an environment such as creating folders, copying files, and so on.
    Give the script file content.
    You can use the above properties variables.
    However, adding or overriding environment variables in the script doesn't have any impacts in the build job.

So that this variable is taken into account by the build job, move it to
`properties-content`, which is the correct place to set environment
variables for the build.