### PR TITLE
Log format is JSON for service-manual-publisher

### DIFF
--- a/modules/govuk/manifests/apps/service_manual_publisher.pp
+++ b/modules/govuk/manifests/apps/service_manual_publisher.pp
@@ -59,10 +59,11 @@ class govuk::apps::service_manual_publisher(
   $app_name = 'service-manual-publisher'
 
   govuk::app { $app_name:
-    app_type          => 'rack',
-    port              => $port,
-    vhost_ssl_only    => true,
-    health_check_path => '/healthcheck',
+    app_type           => 'rack',
+    log_format_is_json => true,
+    port               => $port,
+    vhost_ssl_only     => true,
+    health_check_path  => '/healthcheck',
   }
 
   Govuk::App::Envvar {


### PR DESCRIPTION
This is needed so that logstream will read the JSON log and the request logs will appear in Kibana.