### PR TITLE
Ensure `libpq-dev` is present for signon backends

### DIFF
--- a/modules/govuk/manifests/apps/signon.pp
+++ b/modules/govuk/manifests/apps/signon.pp
@@ -68,4 +68,6 @@ class govuk::apps::signon(
       value   => $redis_url,
     }
   }
+
+  include govuk_postgresql::client #installs libpq-dev package needed for pg gem
 }


### PR DESCRIPTION
Since signon now supports either mysql or postgresql database adapters
we'll need to ensure `libpq-dev` is around so the `pg` gem can find the
necessary headers.