### PR TITLE
Don't create app.pid automatically for unicornherder procfile apps

### DIFF
--- a/modules/govuk/files/usr/local/bin/govuk_spinup
+++ b/modules/govuk/files/usr/local/bin/govuk_spinup
@@ -57,7 +57,10 @@ case "$GOVUK_APP_TYPE" in
   procfile)
     status "Spawning 'web' task from Procfile"
     CMD=$(<Procfile grep '^web:' | cut -d':' -f2-)
-    MAKE_PIDFILE="--make-pidfile"
+
+    if [ ${GOVUK_MAKE_PIDFILE:-UNSET} != "UNSET" ]; then
+      MAKE_PIDFILE="--make-pidfile"
+    fi
     ;;
 
   bare)

--- a/modules/govuk/manifests/app.pp
+++ b/modules/govuk/manifests/app.pp
@@ -37,6 +37,18 @@
 # `GOVUK_APP_CMD` which is used by `govuk_spinup`.
 #
 #
+# [*create-pidfile*]
+# Determines whether a pidfile is created when a `procfile` app is started
+#
+# By default procfile apps will create pid files (via the --make-pid switch
+# in govuk_spinup).
+# If the create-pidfile value is set to false, then a pid file will not be
+# created.  This is appropriate when using unicornherder with gunicorn.
+# The value defaults to 'NOTSET' (as opposed to true) to try to flag up that
+# this doesn't apply to all app types. (eg Rack apps don't create pid files
+# by default)
+#
+#
 # [*logstream*]
 # choose whether or not to create a log tailing upstart job
 #
@@ -236,6 +248,7 @@ define govuk::app (
   $app_type,
   $port = 'NOTSET',
   $command = undef,
+  $create_pidfile = 'NOTSET',
   $logstream = present,
   $legacy_logging = true,
   $log_format_is_json = false,
@@ -298,6 +311,7 @@ define govuk::app (
     require                   => Govuk::App::Package[$title],
     app_type                  => $app_type,
     command                   => $command,
+    create_pidfile            => $create_pidfile,
     domain                    => $app_domain,
     port                      => $port,
     vhost_aliases             => $vhost_aliases,

--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -18,6 +18,7 @@ define govuk::app::config (
   $port,
   $vhost_full,
   $command = 'NOTSET',
+  $create_pidfile = 'NOTSET',
   $vhost_aliases = [],
   $vhost_protected = false,
   $vhost_ssl_only = false,
@@ -133,6 +134,13 @@ define govuk::app::config (
       govuk::app::envvar { "${title}-UNICORN_HERDER_TIMEOUT":
         varname => 'UNICORN_HERDER_TIMEOUT',
         value   => $unicorn_herder_timeout;
+      }
+    }
+
+    if $app_type == 'procfile' and $create_pidfile {
+      govuk::app::envvar { "${title}-GOVUK_MAKE_PIDFILE":
+        varname => 'GOVUK_MAKE_PIDFILE',
+        value   => '--make-pid';
       }
     }
 

--- a/modules/govuk/manifests/apps/mapit.pp
+++ b/modules/govuk/manifests/apps/mapit.pp
@@ -19,6 +19,7 @@ class govuk::apps::mapit (
   if $enabled {
     govuk::app { 'mapit':
       app_type           => 'procfile',
+      create_pidfile     => false,
       port               => $port,
       vhost_ssl_only     => true,
       health_check_path  => '/',


### PR DESCRIPTION
As part of deploying a new version of Mapit, we want to use Unicorn Herder to
help us with zero-downtime deploys.

We were experiencing problems with this, as the pid file was being created by
the Unicorn Herder process (running as the super user), which meant that the
gunicorn processes couldn't access it (as they run under the app user).

We know that other applications use the 'procfile' app type which has
'--make-pid' defined, however we want to skip this for procfile apps that use 
unicornherder so that the first gunicorn process creates it.

If there's a more appropriate way of tackling this, please let me know!

(This in conjunction with @brenetic )

https://trello.com/c/d82WTfeq/314-get-mapit-working-with-unicorn-herder-3-time-boxed-1-day