### PR TITLE
Offsite postgresql backups using WAL-E

### DIFF
--- a/hieradata/class/integration/transition_postgresql_master.yaml
+++ b/hieradata/class/integration/transition_postgresql_master.yaml
@@ -1,0 +1,1 @@
+govuk_postgresql::wal_e::backup::enabled: true

--- a/hieradata/vagrant.yaml
+++ b/hieradata/vagrant.yaml
@@ -157,6 +157,7 @@ govuk_postgresql::server::snakeoil_ssl_key: |
 govuk_postgresql::wal_e::backup::aws_access_key_id: '123456789'
 govuk_postgresql::wal_e::backup::aws_secret_access_key: 'thisisafakekey'
 govuk_postgresql::wal_e::backup::s3_bucket_url: 's3://foo/bar'
+govuk_postgresql::wal_e::backup::enabled: true
 
 icinga::config::enable_event_handlers: true
 icinga::nginx::enable_basic_auth: false

--- a/hieradata/vagrant.yaml
+++ b/hieradata/vagrant.yaml
@@ -154,6 +154,10 @@ govuk_postgresql::server::snakeoil_ssl_key: |
   vxBODhF5cvyO/S2jUuvApGU4dU2KULT5Dv3/Lh/Otg==
   -----END RSA PRIVATE KEY-----
 
+govuk_postgresql::wal_e::backup::aws_access_key_id: '123456789'
+govuk_postgresql::wal_e::backup::aws_secret_access_key: 'thisisafakekey'
+govuk_postgresql::wal_e::backup::s3_bucket_url: 's3://foo/bar'
+
 icinga::config::enable_event_handlers: true
 icinga::nginx::enable_basic_auth: false
 

--- a/hieradata/vagrant_credentials.yaml
+++ b/hieradata/vagrant_credentials.yaml
@@ -147,6 +147,11 @@ govuk_jenkins::ssh_key::public_key: |
 
 govuk_postgresql::env_sync_user::password: 'XB4MMvdTy0nU/AeoygnPuYGAabiSihUHif3BPP0SjIM='
 
+govuk_postgresql::wal_e::backup::aws_access_key_id: '123456789'
+govuk_postgresql::wal_e::backup::aws_secret_access_key: 'thisisafakekey'
+govuk_postgresql::wal_e::backup::s3_bucket_url: 's3://foo/bar'
+govuk_postgresql::wal_e::backup::enabled: true
+
 govuk_rabbitmq::monitoring_password: monitoring
 govuk_rabbitmq::root_password: root
 

--- a/modules/govuk_postgresql/manifests/backup.pp
+++ b/modules/govuk_postgresql/manifests/backup.pp
@@ -34,4 +34,7 @@ class govuk_postgresql::backup {
         source => 'puppet:///modules/govuk_postgresql/etc/postgresql-backup-pre',
     }
 
+    # Include offsite backups to S3
+    include govuk_postgresql::wal_e::backup
+
 }

--- a/modules/govuk_postgresql/manifests/wal_e/backup.pp
+++ b/modules/govuk_postgresql/manifests/wal_e/backup.pp
@@ -1,0 +1,94 @@
+# == Class: Govuk_postgresql::Wal_e::Backup
+#
+# Creates an offsite backup of a chosen PostgreSQL database
+# to an S3 bucket using WAL-E:
+# https://github.com/wal-e/wal-e
+#
+# === Parameters:
+#
+# [*aws_access_key_id*]
+#   The AWS access ID for the user that is allowed to
+#   access the S3 bucket.
+#
+# [*aws_secret_access_key*]
+#   The AWS secret access key for the user that is allowed
+#   to access the S3 bucket.
+#
+# [*s3_bucket_url*]
+#   The unique address of the S3 bucket, in the format of:
+#   s3://bucketaddress/directory/foo
+#
+# [*hour*]
+#   The hour(s) the cron job runs.
+#   Default: 6
+#
+# [*minute*]
+#   The minute(s) the cron job runs.
+#   Default: 20
+#
+# [*db_dir*]
+#   The database directory to backup. WAL-E does hot backups
+#   so there should be no impact, and the default backups up
+#   everything.
+#   Default: /var/lib/postgresql/9.3/main
+#
+# [*enabled*]
+#   Whether or not to enable WAL-E backups to S3.
+#
+class govuk_postgresql::wal_e::backup (
+  $aws_access_key_id = undef,
+  $aws_secret_access_key = undef,
+  $s3_bucket_url = undef,
+  $hour = 6,
+  $minute = 20,
+  $db_dir = '/var/lib/postgresql/9.3/main',
+  $enabled = false,
+) {
+  if $enabled {
+    include govuk_postgresql::wal_e::package
+
+    # Continuous archiving to S3
+    postgresql::server::config_entry {
+      'archive_mode':
+        value => 'on';
+      'archive_command':
+        value => 'envdir /etc/govuk/env.d /usr/local/bin/wal-e wal-push %p';
+      'archive_timeout':
+        value => '60';
+    }
+
+    govuk::envvar { 'AWS_SECRET_ACCESS_KEY':
+      value => $aws_secret_access_key,
+    }
+
+    govuk::envvar { 'AWS_ACCESS_KEY_ID':
+      value => $aws_access_key_id,
+    }
+
+    govuk::envvar { 'WALE_S3_PREFIX':
+      value => $s3_bucket_url,
+    }
+
+    # Daily base backup
+    file { '/etc/cron.d/wal-e_postgres_backup_push_cron':
+      ensure  => present,
+      content => template('govuk_postgresql/etc/cron.d/wal-e_postgres_backup_push_cron.erb'),
+      mode    => '0775',
+    }
+    file { '/usr/local/bin/wal-e_postgres_backup_push':
+      ensure  => present,
+      content => template('govuk_postgresql/usr/local/bin/wal-e_postgres_backup_push.erb'),
+      mode    => '0775',
+      require => Class['govuk_postgresql::wal_e::package'],
+    }
+
+    $threshold_secs = 28 * 3600
+    $service_desc = 'PostgreSQL WAL-E backup push'
+
+    @@icinga::passive_check { "check_wale_backup_push-${::hostname}":
+        service_description => $service_desc,
+        freshness_threshold => $threshold_secs,
+        host_name           => $::fqdn,
+      }
+  }
+}

--- a/modules/govuk_postgresql/manifests/wal_e/package.pp
+++ b/modules/govuk_postgresql/manifests/wal_e/package.pp
@@ -1,0 +1,32 @@
+# == Class: Govuk_postgresql::Wal_e::Package
+#
+# This class installs the WAL-E package and dependencies
+#
+class govuk_postgresql::wal_e::package {
+  package { 'wal-e':
+    ensure   => present,
+    provider => pip,
+    require  => Class['govuk_postgresql::server'],
+  }
+
+  $dependencies = [
+    'lzop',
+  ]
+
+  package { $dependencies:
+    ensure => present,
+  }
+
+  # pip should take care of version deps but we need to manually upgrade
+  # a couple of things
+
+  $pip_deps = [
+    'requests',
+    'six',
+  ]
+
+  package { $pip_deps:
+    ensure   => latest,
+    provider => pip,
+  }
+}

--- a/modules/govuk_postgresql/templates/etc/cron.d/wal-e_postgres_backup_push_cron.erb
+++ b/modules/govuk_postgresql/templates/etc/cron.d/wal-e_postgres_backup_push_cron.erb
@@ -1,0 +1,2 @@
+MAILTO='root'
+<%= @minute %> <%= @hour %> * * * postgres /usr/local/bin/wal-e_postgres_backup_push

--- a/modules/govuk_postgresql/templates/usr/local/bin/wal-e_postgres_backup_push.erb
+++ b/modules/govuk_postgresql/templates/usr/local/bin/wal-e_postgres_backup_push.erb
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+
+# The default Icinga passive alert assumes that the script failed
+NAGIOS_CODE=2
+NAGIOS_MESSAGE="CRITICAL: PostgreSQL WAL-E backup push to S3 failed"
+
+# Triggered whenever this script exits, successful or otherwise. The values
+# of CODE/MESSAGE will be taken from that point in time.
+function nagios_passive () {
+  printf "<%= @ipaddress %>\t<%= @service_desc %>\t${NAGIOS_CODE}\t${NAGIOS_MESSAGE}\n" | /usr/sbin/send_nsca -H alert.cluster >/dev/null
+}
+
+trap nagios_passive EXIT
+
+envdir /etc/govuk/env.d /usr/local/bin/wal-e backup-push <%= @db_dir %>
+
+if [ $STATUS -eq 0 ]; then
+  NAGIOS_CODE=0
+  NAGIOS_MESSAGE="OK: PostgreSQL WAL-E backup push to S3 succeeded"
+fi
+
+exit $STATUS


### PR DESCRIPTION
This change would implement daily base backups and continuous archiving of [WAL segments](http://www.postgresql.org/docs/9.3/static/wal-intro.html) for the Bouncer application in Integration.

It has a couple of dependencies in that it requires a user and subsequent ID, KEY and S3 bucket to be created.
