### PR TITLE
Make draft-email-campaign-frontend available

### DIFF
--- a/hieradata/class/draft_email_campaign_frontend.yaml
+++ b/hieradata/class/draft_email_campaign_frontend.yaml
@@ -1,4 +1,5 @@
 ---
+govuk::apps::email_campaign_frontend::vhost: 'draft-email-campaign-frontend'
 
 govuk::node::s_base::apps:
   - email_campaign_frontend

--- a/hieradata/class/email_campaign_frontend.yaml
+++ b/hieradata/class/email_campaign_frontend.yaml
@@ -1,4 +1,5 @@
 ---
+govuk::apps::email_campaign_frontend::vhost: 'email-campaign-frontend'
 
 govuk::node::s_base::apps:
   - email_campaign_frontend

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -768,6 +768,7 @@ hosts::production::frontend::app_hostnames:
   - 'draft-collections'
   - 'draft-contacts-frontend'
   - 'draft-email-alert-frontend'
+  - 'draft-email-campaign-frontend'
   - 'draft-government-frontend'
   - 'draft-manuals-frontend'
   - 'draft-specialist-frontend'

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -101,6 +101,7 @@ govuk::node::s_development::apps:
 govuk_app_enable_capistrano_layout: false
 govuk_app_enable_services: false
 
+govuk::apps::email_campaign_frontend::vhost: 'email-campaign-frontend'
 govuk::apps::asset_manager::enable_delayed_job_worker: false
 govuk::apps::asset_manager::mongodb_name: 'govuk_assets_development'
 govuk::apps::asset_manager::mongodb_nodes: ['localhost']

--- a/modules/govuk/manifests/apps/email_campaign_frontend.pp
+++ b/modules/govuk/manifests/apps/email_campaign_frontend.pp
@@ -6,6 +6,9 @@
 #
 # FIXME: Document all class parameters
 #
+# [*vhost*]
+#   Virtual host used by the application.
+#
 # [*nagios_memory_warning*]
 #   Memory use at which Nagios should generate a warning.
 #
@@ -13,6 +16,7 @@
 #   Memory use at which Nagios should generate a critical alert.
 #
 class govuk::apps::email_campaign_frontend(
+  $vhost,
   $port = 3109,
   $enabled = true,
   $errbit_api_key = undef,
@@ -33,6 +37,7 @@ class govuk::apps::email_campaign_frontend(
       asset_pipeline_prefix  => 'email-campaign-frontend',
       nagios_memory_warning  => $nagios_memory_warning,
       nagios_memory_critical => $nagios_memory_critical,
+      vhost                  => $vhost,
     }
 
     Govuk::App::Envvar {


### PR DESCRIPTION
This vhost wasn't set, which means nothing is listening to this vhost.

@bradwright @mattbostock and I looked at the previous PR and this seems to fix the tests. Opened as a new PR in case it's wrong.