### PR TITLE
Ensure GPG key is re-imported when changed

### DIFF
--- a/modules/backup/manifests/assets.pp
+++ b/modules/backup/manifests/assets.pp
@@ -50,6 +50,8 @@ class backup::assets(
   }
 
   if $backup_private_gpg_key and $backup_private_gpg_key_fingerprint {
+    validate_re($backup_private_gpg_key_fingerprint, '^[[:alnum:]]{40}$', 'Must supply full GPG fingerprint')
+
     file { '/root/.gnupg':
       ensure => directory,
       mode   => '0700',
@@ -62,8 +64,7 @@ class backup::assets(
     }
 
     exec { 'import_gpg_secret_key':
-      command     => "gpg --allow-secret-key-import --import /root/.gnupg/${backup_private_gpg_key_fingerprint}_secret_key.asc",
-      unless      => "gpg --list-secret-keys | grep -Eqs ${backup_private_gpg_key_fingerprint}",
+      command     => "gpg --batch --delete-secret-and-public-key ${backup_private_gpg_key_fingerprint}; gpg --allow-secret-key-import --import /root/.gnupg/${backup_private_gpg_key_fingerprint}_secret_key.asc",
       user        => 'root',
       group       => 'root',
       subscribe   => File["/root/.gnupg/${backup_private_gpg_key_fingerprint}_secret_key.asc"],


### PR DESCRIPTION
Story: https://trello.com/c/S8B99y46/120-asset-slave-backups-no-longer-working

Currently, if we change the GPG private key in Hiera data, the new key
is not imported.

This change ensures that the old key is deleted to allow the new key to
be imported.

Since `refreshonly` is set to `true`, this command should only run when
the private key file is changed and so I have removed the `unless`
option as it's unnecessary.

The GPG fingerprint must now be a full fingerprint for the `gpg --batch
--delete-secret-key` to work; it errors if I try to supply a full
fingerprint.

When deploying this, I'll need to:

- [x] Raise a corresponding PR in the deployment repo to change the
  GPG fingerprint to be full-length

- [ ] Remove the old secret key files using Fabric
  i.e. `/root/.gnupg/<SHORTFINGERPRINT>_secret_key.asc`