### PR TITLE
Add sidekiq-monitoring route for imminence to nginx

### DIFF
--- a/modules/govuk/templates/sidekiq_monitoring_nginx_config.conf.erb
+++ b/modules/govuk/templates/sidekiq_monitoring_nginx_config.conf.erb
@@ -46,6 +46,10 @@ server {
     proxy_pass http://localhost:3117;
   }
 
+  location /imminence {
+    proxy_pass http://localhost:3120;
+  }
+
   root /data/vhost/<%= @full_domain %>/current/public;
 
 }


### PR DESCRIPTION
For: https://trello.com/c/A5bWfOlG/317-add-imminence-to-sidekiq-monitoring-app-3

Port comes from https://github.gds/gds/development/pull/299