### PR TITLE
Refactor: use default vhost values

### DIFF
--- a/hieradata/class/content_store.yaml
+++ b/hieradata/class/content_store.yaml
@@ -5,7 +5,6 @@ govuk::apps::content_store::mongodb_nodes:
   - 'api-mongo-1.api'
   - 'api-mongo-2.api'
   - 'api-mongo-3.api'
-govuk::apps::content_store::vhost: 'content-store'
 
 govuk::node::s_base::apps:
   - content_store

--- a/hieradata/class/email_campaign_frontend.yaml
+++ b/hieradata/class/email_campaign_frontend.yaml
@@ -1,6 +1,4 @@
 ---
-govuk::apps::email_campaign_frontend::vhost: 'email-campaign-frontend'
-
 govuk::node::s_base::apps:
   - email_campaign_frontend
 

--- a/hieradata/class/frontend.yaml
+++ b/hieradata/class/frontend.yaml
@@ -3,7 +3,6 @@
 govuk::apps::collections::vhost: 'collections'
 govuk::apps::contacts::vhost: 'contacts-frontend-old'
 govuk::apps::contacts_frontend::vhost: 'contacts-frontend'
-govuk::apps::email_alert_frontend::vhost: 'email-alert-frontend'
 
 govuk::node::s_base::apps:
   - canary_frontend

--- a/hieradata/class/frontend.yaml
+++ b/hieradata/class/frontend.yaml
@@ -1,7 +1,6 @@
 ---
 
 govuk::apps::collections::vhost: 'collections'
-govuk::apps::contacts::vhost: 'contacts-frontend-old'
 
 govuk::node::s_base::apps:
   - canary_frontend

--- a/hieradata/class/frontend.yaml
+++ b/hieradata/class/frontend.yaml
@@ -2,7 +2,6 @@
 
 govuk::apps::collections::vhost: 'collections'
 govuk::apps::contacts::vhost: 'contacts-frontend-old'
-govuk::apps::contacts_frontend::vhost: 'contacts-frontend'
 
 govuk::node::s_base::apps:
   - canary_frontend

--- a/hieradata/class/frontend.yaml
+++ b/hieradata/class/frontend.yaml
@@ -5,7 +5,6 @@ govuk::apps::contacts::vhost: 'contacts-frontend-old'
 govuk::apps::contacts_frontend::vhost: 'contacts-frontend'
 govuk::apps::email_alert_frontend::vhost: 'email-alert-frontend'
 govuk::apps::government_frontend::vhost: 'government-frontend'
-govuk::apps::manuals_frontend::vhost: 'manuals-frontend'
 
 govuk::node::s_base::apps:
   - canary_frontend

--- a/hieradata/class/frontend.yaml
+++ b/hieradata/class/frontend.yaml
@@ -4,7 +4,6 @@ govuk::apps::collections::vhost: 'collections'
 govuk::apps::contacts::vhost: 'contacts-frontend-old'
 govuk::apps::contacts_frontend::vhost: 'contacts-frontend'
 govuk::apps::email_alert_frontend::vhost: 'email-alert-frontend'
-govuk::apps::government_frontend::vhost: 'government-frontend'
 
 govuk::node::s_base::apps:
   - canary_frontend

--- a/hieradata/class/frontend.yaml
+++ b/hieradata/class/frontend.yaml
@@ -1,7 +1,4 @@
 ---
-
-govuk::apps::collections::vhost: 'collections'
-
 govuk::node::s_base::apps:
   - canary_frontend
   - collections

--- a/hieradata/class/frontend.yaml
+++ b/hieradata/class/frontend.yaml
@@ -6,7 +6,6 @@ govuk::apps::contacts_frontend::vhost: 'contacts-frontend'
 govuk::apps::email_alert_frontend::vhost: 'email-alert-frontend'
 govuk::apps::government_frontend::vhost: 'government-frontend'
 govuk::apps::manuals_frontend::vhost: 'manuals-frontend'
-govuk::apps::multipage_frontend::vhost: 'multipage-frontend'
 
 govuk::node::s_base::apps:
   - canary_frontend

--- a/hieradata/class/frontend.yaml
+++ b/hieradata/class/frontend.yaml
@@ -8,7 +8,6 @@ govuk::apps::government_frontend::vhost: 'government-frontend'
 govuk::apps::manuals_frontend::vhost: 'manuals-frontend'
 govuk::apps::multipage_frontend::vhost: 'multipage-frontend'
 govuk::apps::specialist_frontend::vhost: 'specialist-frontend'
-govuk::apps::static::vhost: 'static'
 
 govuk::node::s_base::apps:
   - canary_frontend

--- a/hieradata/class/frontend.yaml
+++ b/hieradata/class/frontend.yaml
@@ -7,7 +7,6 @@ govuk::apps::email_alert_frontend::vhost: 'email-alert-frontend'
 govuk::apps::government_frontend::vhost: 'government-frontend'
 govuk::apps::manuals_frontend::vhost: 'manuals-frontend'
 govuk::apps::multipage_frontend::vhost: 'multipage-frontend'
-govuk::apps::specialist_frontend::vhost: 'specialist-frontend'
 
 govuk::node::s_base::apps:
   - canary_frontend

--- a/hieradata/class/router_backend.yaml
+++ b/hieradata/class/router_backend.yaml
@@ -9,7 +9,6 @@ govuk::apps::router_api::router_nodes:
   - 'cache-1.router:3055'
   - 'cache-2.router:3055'
   - 'cache-3.router:3055'
-govuk::apps::router_api::vhost: 'router-api'
 
 govuk::node::s_base::apps:
   - router_api

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -153,7 +153,6 @@ govuk::apps::router::vhost_aliases: ["www"]
 govuk::apps::router_api::mongodb_name: 'router'
 govuk::apps::router_api::mongodb_nodes: ['localhost']
 govuk::apps::router_api::router_nodes: ['localhost:3055']
-govuk::apps::router_api::vhost: 'router-api'
 govuk::apps::rummager::enable_procfile_worker: false
 govuk::apps::rummager::rabbitmq_hosts: ['localhost']
 govuk::apps::share_sale_publisher::enabled: true

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -109,7 +109,6 @@ govuk::apps::authenticating_proxy::mongodb_name: 'authenticating_proxy_developme
 govuk::apps::authenticating_proxy::mongodb_nodes: ['localhost']
 govuk::apps::authenticating_proxy::govuk_upstream_uri: 'http://government-frontend.dev.gov.uk'
 govuk::apps::backdrop_write::enable_procfile_worker: false
-govuk::apps::collections::vhost: 'collections'
 govuk::apps::collections_publisher::enable_procfile_worker: false
 govuk::apps::contacts::extra_aliases: ['contacts-frontend-old', 'contacts-admin']
 govuk::apps::content_register::enable_procfile_worker: false

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -120,7 +120,6 @@ govuk::apps::content_store::mongodb_nodes: ['localhost']
 govuk::apps::content_store::mongodb_name: 'content_store_development'
 govuk::apps::content_store::vhost: 'content-store'
 govuk::apps::email_alert_api::enable_procfile_worker: false
-govuk::apps::email_alert_frontend::vhost: 'email-alert-frontend'
 govuk::apps::email_campaign_api::mongodb_name: 'email_campaign_api_development'
 govuk::apps::email_campaign_api::mongodb_nodes: ['localhost']
 govuk::apps::email_alert_service::rabbitmq_hosts: ['localhost']

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -101,7 +101,6 @@ govuk::node::s_development::apps:
 govuk_app_enable_capistrano_layout: false
 govuk_app_enable_services: false
 
-govuk::apps::email_campaign_frontend::vhost: 'email-campaign-frontend'
 govuk::apps::asset_manager::enable_delayed_job_worker: false
 govuk::apps::asset_manager::mongodb_name: 'govuk_assets_development'
 govuk::apps::asset_manager::mongodb_nodes: ['localhost']

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -136,7 +136,6 @@ govuk::apps::imminence::enable_procfile_worker: false
 govuk::apps::licencefinder::mongodb_nodes: ['localhost']
 govuk::apps::manuals_frontend::vhost: 'manuals-frontend'
 govuk::apps::mapit::enabled: true
-govuk::apps::multipage_frontend::vhost: 'multipage-frontend'
 govuk::apps::multipage_frontend::enabled: true
 govuk::apps::need_api::mongodb_name: 'govuk_needs_development'
 govuk::apps::need_api::mongodb_nodes: ['localhost']

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -134,7 +134,6 @@ govuk::apps::govuk_cdn_logs_monitor::enabled: false
 govuk::apps::govuk_delivery::enable_procfile_worker: false
 govuk::apps::imminence::enable_procfile_worker: false
 govuk::apps::licencefinder::mongodb_nodes: ['localhost']
-govuk::apps::manuals_frontend::vhost: 'manuals-frontend'
 govuk::apps::mapit::enabled: true
 govuk::apps::multipage_frontend::enabled: true
 govuk::apps::need_api::mongodb_name: 'govuk_needs_development'

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -115,7 +115,6 @@ govuk::apps::content_register::rabbitmq::configure_test_details: true
 govuk::apps::content_register::rabbitmq_hosts: ['localhost']
 govuk::apps::content_store::mongodb_nodes: ['localhost']
 govuk::apps::content_store::mongodb_name: 'content_store_development'
-govuk::apps::content_store::vhost: 'content-store'
 govuk::apps::email_alert_api::enable_procfile_worker: false
 govuk::apps::email_campaign_api::mongodb_name: 'email_campaign_api_development'
 govuk::apps::email_campaign_api::mongodb_nodes: ['localhost']

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -112,7 +112,6 @@ govuk::apps::backdrop_write::enable_procfile_worker: false
 govuk::apps::collections::vhost: 'collections'
 govuk::apps::collections_publisher::enable_procfile_worker: false
 govuk::apps::contacts::extra_aliases: ['contacts-frontend-old', 'contacts-admin']
-govuk::apps::contacts_frontend::vhost: 'contacts-frontend'
 govuk::apps::content_register::enable_procfile_worker: false
 govuk::apps::content_register::rabbitmq::configure_test_details: true
 govuk::apps::content_register::rabbitmq_hosts: ['localhost']

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -176,7 +176,6 @@ govuk::apps::specialist_publisher::publish_pre_production_finders: true
 govuk::apps::stagecraft::worker::enabled: true
 govuk::apps::stagecraft::beat::enabled: true
 govuk::apps::stagecraft::celerycam::enabled: true
-govuk::apps::static::vhost: 'static'
 govuk::apps::support::enable_procfile_worker: false
 govuk::apps::support_api::enable_procfile_worker: false
 govuk::apps::tariff_api::enable_procfile_worker: false

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -129,7 +129,6 @@ govuk::apps::event_store::mongodb_servers: ['localhost']
 govuk::apps::frontend::enable_homepage_nocache_location: false
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
 govuk::apps::hmrc_manuals_api::enable_procfile_worker: false
-govuk::apps::government_frontend::vhost: 'government-frontend'
 govuk::apps::govuk_cdn_logs_monitor::enabled: false
 govuk::apps::govuk_delivery::enable_procfile_worker: false
 govuk::apps::imminence::enable_procfile_worker: false

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -170,7 +170,6 @@ govuk::apps::share_sale_publisher::mongodb_name: 'share_sale_publisher_developme
 govuk::apps::signon::enable_procfile_worker: false
 govuk::apps::signon::redis_url: redis://localhost:6379/0
 govuk::apps::smartanswers::expose_govspeak: true
-govuk::apps::specialist_frontend::vhost: 'specialist-frontend'
 govuk::apps::specialist_publisher::enable_procfile_worker: false
 govuk::apps::specialist_publisher::publish_pre_production_finders: true
 govuk::apps::stagecraft::worker::enabled: true

--- a/modules/govuk/manifests/apps/collections.pp
+++ b/modules/govuk/manifests/apps/collections.pp
@@ -6,12 +6,13 @@
 #
 # [*vhost*]
 #   Virtual host used by the application.
+#   Default: collections
 #
 # [*port*]
 #   What port should the app run on?
 #
 class govuk::apps::collections(
-  $vhost,
+  $vhost = 'collections',
   $port = '3070',
 ) {
   govuk::app { 'collections':

--- a/modules/govuk/manifests/apps/contacts.pp
+++ b/modules/govuk/manifests/apps/contacts.pp
@@ -10,7 +10,7 @@
 #
 # [*vhost*]
 #   Virtual host for this application.
-#   Default: contacts
+#   Default: contacts-frontend-old
 #
 # [*port*]
 #   The port that the app is served on.
@@ -30,7 +30,7 @@
 #
 class govuk::apps::contacts(
   $enabled = true,
-  $vhost = 'contacts',
+  $vhost = 'contacts-frontend-old',
   $port = '3051',
   $vhost_protected = undef,
   $extra_aliases = [],

--- a/modules/govuk/manifests/apps/contacts_frontend.pp
+++ b/modules/govuk/manifests/apps/contacts_frontend.pp
@@ -1,6 +1,6 @@
 # FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
 class govuk::apps::contacts_frontend (
-  $vhost,
+  $vhost = 'contacts-frontend',
   $port = '3074',
 ) {
   govuk::app { 'contacts-frontend':

--- a/modules/govuk/manifests/apps/content_store.pp
+++ b/modules/govuk/manifests/apps/content_store.pp
@@ -16,6 +16,7 @@
 #
 # [*vhost*]
 #   Virtual host for this application.
+#   Default: content-store
 #
 # [*default_ttl*]
 #   The default cache timeout in seconds.
@@ -34,7 +35,7 @@ class govuk::apps::content_store(
   $port = '3068',
   $mongodb_nodes,
   $mongodb_name,
-  $vhost,
+  $vhost = 'content-store',
   $default_ttl = '1800',
   $publishing_api_bearer_token = undef,
   $nagios_memory_warning = undef,

--- a/modules/govuk/manifests/apps/email_alert_frontend.pp
+++ b/modules/govuk/manifests/apps/email_alert_frontend.pp
@@ -10,12 +10,13 @@
 #
 # [*vhost*]
 #   Virtual host used by the application.
+#   Default: 'email-alert-frontend'
 #
 # [*port*]
 #   What port should the app run on?
 #
 class govuk::apps::email_alert_frontend(
-  $vhost,
+  $vhost = 'email-alert-frontend',
   $port = '3099',
 ) {
   govuk::app { 'email-alert-frontend':

--- a/modules/govuk/manifests/apps/email_campaign_frontend.pp
+++ b/modules/govuk/manifests/apps/email_campaign_frontend.pp
@@ -8,6 +8,7 @@
 #
 # [*vhost*]
 #   Virtual host used by the application.
+#   Default: email-campaign-frontend
 #
 # [*nagios_memory_warning*]
 #   Memory use at which Nagios should generate a warning.
@@ -16,7 +17,7 @@
 #   Memory use at which Nagios should generate a critical alert.
 #
 class govuk::apps::email_campaign_frontend(
-  $vhost,
+  $vhost = 'email-campaign-frontend',
   $port = 3109,
   $enabled = true,
   $errbit_api_key = undef,

--- a/modules/govuk/manifests/apps/government_frontend.pp
+++ b/modules/govuk/manifests/apps/government_frontend.pp
@@ -6,12 +6,13 @@
 #
 # [*vhost*]
 #   Virtual host used by the application.
+#   Default: 'government-frontend'
 #
 # [*port*]
 #   What port should the app run on?
 #
 class govuk::apps::government_frontend(
-  $vhost,
+  $vhost = 'government-frontend',
   $port = '3090',
 ) {
   Govuk::App::Envvar {

--- a/modules/govuk/manifests/apps/manuals_frontend.pp
+++ b/modules/govuk/manifests/apps/manuals_frontend.pp
@@ -4,6 +4,10 @@
 #
 # === Parameters
 #
+# [*vhost*]
+#   Virtual host used by the application.
+#   Default: 'manuals-frontend'
+#
 # [*port*]
 #   The port that the app is served on.
 #   Default: 3072
@@ -13,7 +17,7 @@
 #   Default: undef
 #
 class govuk::apps::manuals_frontend(
-  $vhost,
+  $vhost = 'manuals-frontend',
   $port = '3072',
   $publishing_api_bearer_token = undef,
 ) {

--- a/modules/govuk/manifests/apps/multipage_frontend.pp
+++ b/modules/govuk/manifests/apps/multipage_frontend.pp
@@ -3,6 +3,7 @@
 #
 # [*vhost*]
 #   Virtual host used by the application.
+#   Default: 'multipage-frontend'
 #
 # [*port*]
 #   What port should the app run on?
@@ -18,7 +19,7 @@
 #   Default: undef
 #
 class govuk::apps::multipage_frontend(
-  $vhost,
+  $vhost = 'multipage-frontend',
   $port = '3118',
   $errbit_api_key = undef,
   $secret_key_base = undef,

--- a/modules/govuk/manifests/apps/router_api.pp
+++ b/modules/govuk/manifests/apps/router_api.pp
@@ -20,6 +20,7 @@
 #
 # [*vhost*]
 #   Virtual host to be used by the application.
+#   Default: router-api
 #
 # [*secret_key_base*]
 #   The key for Rails to use when signing/encrypting sessions.
@@ -29,7 +30,7 @@ class govuk::apps::router_api(
   $mongodb_name,
   $mongodb_nodes,
   $router_nodes,
-  $vhost,
+  $vhost = 'router-api',
   $secret_key_base = undef,
 ) {
   $app_name = 'router-api'

--- a/modules/govuk/manifests/apps/specialist_frontend.pp
+++ b/modules/govuk/manifests/apps/specialist_frontend.pp
@@ -7,6 +7,7 @@
 #
 # [*vhost*]
 #   Virtual host used by the application.
+#   Default: specialist-frontend
 #
 # [*port*]
 #   What port should the app run on?
@@ -21,7 +22,7 @@
 #   Memory use at which Nagios should generate a critical alert.
 #
 class govuk::apps::specialist_frontend(
-  $vhost,
+  $vhost = 'specialist-frontend',
   $port = '3065',
   $enabled = false,
   $nagios_memory_warning = undef,

--- a/modules/govuk/manifests/apps/static.pp
+++ b/modules/govuk/manifests/apps/static.pp
@@ -6,7 +6,8 @@
 #
 # [*vhost*]
 #   Virtual host used by the application.
-
+#   Default: static
+#
 # [*port*]
 #   The port that the app is served on.
 #   Default: 3013
@@ -30,7 +31,7 @@
 #   Default: undef
 #
 class govuk::apps::static(
-  $vhost,
+  $vhost = 'static',
   $port = '3013',
   $errbit_api_key = undef,
   $draft_environment = false,


### PR DESCRIPTION
These were previously duplicated across config files, when they really only diverged from a standard value in the draft environments.

The only slightly weird refactor is the `contacts` one - more details in that commit message.

This follows up #4169