### PR TITLE
Fix deploy job

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -6,6 +6,8 @@ app_domain: 'dev.gov.uk'
 deployable_applications: &deployable_applications
   - asset-manager
   - authenticating-proxy
+  - backdrop-read
+  - backdrop-write
   - bouncer
   - business-support-api
   - businesssupportfinder
@@ -26,11 +28,14 @@ deployable_applications: &deployable_applications
   - email-alert-frontend
   - email-alert-monitor
   - email-alert-service
+  - email-campaign-api
+  - email-campaign-frontend
   - errbit
   - feedback
   - finder-frontend
   - frontend
   - government-frontend
+  - govuk-delivery
   - govuk_content_api
   - govuk_need_api
   - hmrc-manuals-api
@@ -39,16 +44,23 @@ deployable_applications: &deployable_applications
   - kibana-gds
   - licence-finder
   - manuals-frontend
+  - mapit
   - maslow
+  - metadata-api
   - panopticon
+  - performanceplatform-admin
+  - performanceplatform-big-screen-view
   - policy-publisher
   - publisher
   - publishing-api
   - recommended-links
   - release
+  - router
   - router-api
   - rummager
   - search-admin
+  - service-manual-publisher
+  - share-sale-publisher
   - short-url-manager
   - sidekiq-monitoring
   - signonotron2
@@ -56,6 +68,8 @@ deployable_applications: &deployable_applications
   - smokey
   - specialist-frontend
   - specialist-publisher
+  - spotlight
+  - stagecraft
   - static
   - support
   - support-api

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -64,7 +64,6 @@ deployable_applications: &deployable_applications
   - trade-tariff-frontend
   - transition
   - travel-advice-publisher
-  - url-arbiter
   - whitehall
 
 apt_mirror_hostname: 'apt.production.alphagov.co.uk'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -8,19 +8,19 @@ deployable_applications: &deployable_applications
   - authenticating-proxy
   - bouncer
   - business-support-api
-  - business-support-finder
+  - businesssupportfinder
   - calculators
   - calendars
   - collections
   - collections-publisher
-  - contacts-admin
+  - contacts
   - contacts-frontend
   - content-register
   - content-store
   - content-tagger
   - courts-api
   - courts-frontend
-  - design-principles
+  - designprinciples
   - EFG
   - email-alert-api
   - email-alert-frontend
@@ -52,7 +52,7 @@ deployable_applications: &deployable_applications
   - short-url-manager
   - sidekiq-monitoring
   - signonotron2
-  - smart-answers
+  - smartanswers
   - smokey
   - specialist-frontend
   - specialist-publisher


### PR DESCRIPTION
Several deploys have failed as a result of the downstream CI process handing off an invalid app name to the deploy Jenkins.

The reason for this is that the app names need to exist *and* match the Capistrano deploy names we use.

Fix this by either repairing broken names or adding missing ones.