### PR TITLE
Add configuration for new local-links-manager app

### DIFF
--- a/hieradata/class/backend.yaml
+++ b/hieradata/class/backend.yaml
@@ -44,6 +44,7 @@ govuk::node::s_base::apps:
   - hmrc_manuals_api
   - imminence
   - kibana
+  - local_links_manager
   - maslow
   - need_api
   - panopticon

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -43,6 +43,7 @@ deployable_applications: &deployable_applications
   - info-frontend
   - kibana-gds
   - licence-finder
+  - local-links-manager
   - manuals-frontend
   - mapit
   - maslow
@@ -717,6 +718,7 @@ hosts::production::backend::app_hostnames:
   - 'hmrc-manuals-api'
   - 'imminence'
   - 'kibana'
+  - 'local-links-manager'
   - 'mapit'
   - 'maslow'
   - 'need-api'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -316,6 +316,10 @@ govuk::apps::imminence::nagios_memory_warning: 1200
 govuk::apps::imminence::nagios_memory_critical: 1400
 
 govuk::apps::info_frontend::enabled: true
+
+govuk::apps::local_links_manager::db_hostname: "postgresql-primary-1.backend"
+govuk::apps::local_links_manager::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
+
 govuk::apps::mapit::enabled: true
 govuk::apps::metadata_api::enabled: true
 

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -128,6 +128,7 @@ govuk::apps::govuk_cdn_logs_monitor::enabled: false
 govuk::apps::govuk_delivery::enable_procfile_worker: false
 govuk::apps::imminence::enable_procfile_worker: false
 govuk::apps::licencefinder::mongodb_nodes: ['localhost']
+govuk::apps::local_links_manager::enabled: true
 govuk::apps::multipage_frontend::enabled: true
 govuk::apps::need_api::mongodb_name: 'govuk_needs_development'
 govuk::apps::need_api::mongodb_nodes: ['localhost']
@@ -263,6 +264,7 @@ hosts::development::apps:
   - 'info-frontend'
   - 'kibana'
   - 'licencefinder'
+  - 'local-links-manager'
   - 'manuals-frontend'
   - 'mapit'
   - 'multipage-frontend'

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -244,6 +244,7 @@ hosts::production::backend::app_hostnames:
   - 'hmrc-manuals-api'
   - 'imminence'
   - 'kibana'
+  - 'local-links-manager'
   - 'maslow'
   - 'need-api'
   - 'panopticon'

--- a/hieradata/vagrant_credentials.yaml
+++ b/hieradata/vagrant_credentials.yaml
@@ -36,6 +36,8 @@ govuk::apps::efg::db::mysql_efg_il0: 'zUdCRCXYDHhwKYvFGj6MXnFPgAaBS7WC'
 govuk::apps::email_alert_api::db::password: '8WB3h7RXohmTvmU7bmmDK4ppsd8BU7Ki'
 
 govuk::apps::govuk_crawler_worker::airbrake_api_key: 'lxHeeE3VknbR7nlZ51QnUfKcxd7iuIcSe25r'
+govuk::apps::local_links_manager::db::password: 'a192e3fcb901b069aa6c45438faecdc48b30f8a6'
+govuk::apps::local_links_manager::db_password: "%{hiera('govuk::apps::local_links_manager::db::password')}"
 govuk::apps::mapit::db_password: 'h2sBuU%M1859A0K*10VriyQwa$jGQkBKYYlAKNKh'
 govuk::apps::maslow::secret_key_base: 'a06f64da7e2fa4289722d21a8cbc9fdbc26510be9be2a48803d6dc95459a1a176f70425e6fb6597549b0b951b6a0cca5abe2f0155929e912ad251064eea267c8'
 govuk::apps::maslow::multipage_frontend: 'a9ae01769cad10a2d790d3a7ba01bc80958b5b7ffc77183fd18d8c2563f3b0a89364caf41c8a7564bee867fb39a979c2cf37ea164aaad79ea79a46b3e228ed98'

--- a/modules/govuk/manifests/apps/local_links_manager.pp
+++ b/modules/govuk/manifests/apps/local_links_manager.pp
@@ -12,7 +12,7 @@
 #
 # [*errbit_api_key*]
 #   Errbit API key used by airbrake
-#   Default: ''
+#   Default: undef
 #
 # [*secret_key_base*]
 #   Used to set the app ENV var SECRET_KEY_BASE which is used to configure
@@ -20,14 +20,34 @@
 #   start.
 #   Default: undef
 #
+# [*db_hostname*]
+#   The hostname of the database server to use in the DATABASE_URL.
+#   Default: undef
+#
+# [*db_username*]
+#   The username to use in the DATABASE_URL.
+#
+# [*db_password*]
+#   The password for the database.
+#   Default: undef
+#
+# [*db_name*]
+#   The database name to use in the DATABASE_URL.
+#
 class govuk::apps::local_links_manager(
   $port = 3121,
   $enabled = false,
   $errbit_api_key = undef,
   $secret_key_base = undef,
+  $db_hostname = undef,
+  $db_username = 'local_links_manager',
+  $db_password = undef,
+  $db_name = 'local-links-manager_production',
 ) {
+  $app_name = 'local-links-manager'
+
   if $enabled {
-    govuk::app { 'local-links-manager':
+    govuk::app { $app_name:
       app_type          => 'rack',
       port              => $port,
       vhost_ssl_only    => true,
@@ -36,7 +56,7 @@ class govuk::apps::local_links_manager(
   }
 
   Govuk::App::Envvar {
-    app    => 'local-links-manager',
+    app    => $app_name,
   }
 
   govuk::app::envvar {
@@ -46,5 +66,15 @@ class govuk::apps::local_links_manager(
     "${title}-SECRET_KEY_BASE":
       varname => 'SECRET_KEY_BASE',
       value   => $secret_key_base;
+  }
+
+  if $::govuk_node_class != 'development' {
+    govuk::app::envvar::database_url { $app_name:
+      type     => 'postgresql',
+      username => $db_username,
+      password => $db_password,
+      host     => $db_hostname,
+      database => $db_name,
+    }
   }
 }

--- a/modules/govuk/manifests/apps/local_links_manager.pp
+++ b/modules/govuk/manifests/apps/local_links_manager.pp
@@ -1,0 +1,50 @@
+# Class: govuk::apps::local_links_manager
+#
+# App to manage the local links within GOV.UK so that
+# they can be used for local transactions.
+# https://github.com/alphagov/local-links-manager
+#
+# [*port*]
+#   What port should the app run on?
+#
+# [*enabled*]
+#   Should the app exist?
+#
+# [*errbit_api_key*]
+#   Errbit API key used by airbrake
+#   Default: ''
+#
+# [*secret_key_base*]
+#   Used to set the app ENV var SECRET_KEY_BASE which is used to configure
+#   rails 4.x signed cookie mechanism. If unset the app will be unable to
+#   start.
+#   Default: undef
+#
+class govuk::apps::local_links_manager(
+  $port = 3121,
+  $enabled = false,
+  $errbit_api_key = undef,
+  $secret_key_base = undef,
+) {
+  if $enabled {
+    govuk::app { 'local-links-manager':
+      app_type          => 'rack',
+      port              => $port,
+      vhost_ssl_only    => true,
+      health_check_path => '/healthcheck',
+    }
+  }
+
+  Govuk::App::Envvar {
+    app    => 'local-links-manager',
+  }
+
+  govuk::app::envvar {
+    "${title}-ERRBIT_API_KEY":
+      varname => 'ERRBIT_API_KEY',
+      value   => $errbit_api_key;
+    "${title}-SECRET_KEY_BASE":
+      varname => 'SECRET_KEY_BASE',
+      value   => $secret_key_base;
+  }
+}

--- a/modules/govuk/manifests/apps/local_links_manager/db.pp
+++ b/modules/govuk/manifests/apps/local_links_manager/db.pp
@@ -1,0 +1,25 @@
+# == Class: govuk::apps::local_links_manager::db
+#
+# Postgresql to store content for the Local Links Manager app
+#
+# https://github.com/alphagov/local-links-manager
+#
+# === Parameters
+#
+# [*password*]
+#   The DB user password.
+#
+# [*backend_ip_range*]
+#   Backend IP addresses to allow access to the database.
+#
+class govuk::apps::local_links_manager::db (
+  $password,
+  $backend_ip_range = '10.3.0.0/16',
+) {
+  govuk_postgresql::db { 'local-links-manager_production':
+    user                    => 'local_links_manager',
+    password                => $password,
+    allow_auth_from_backend => true,
+    backend_ip_range        => $backend_ip_range,
+  }
+}

--- a/modules/govuk/manifests/node/s_backend_lb.pp
+++ b/modules/govuk/manifests/node/s_backend_lb.pp
@@ -79,6 +79,7 @@ class govuk::node::s_backend_lb (
       'event-store',
       'govuk-delivery',
       'need-api',
+      'local-links-manager',
       'publishing-api',
       'support-api',
       'tariff-api',

--- a/modules/govuk/manifests/node/s_postgresql_base.pp
+++ b/modules/govuk/manifests/node/s_postgresql_base.pp
@@ -6,6 +6,7 @@ class govuk::node::s_postgresql_base inherits govuk::node::s_base {
   include govuk::apps::content_register::db
   include govuk::apps::content_tagger::db
   include govuk::apps::email_alert_api::db
+  include govuk::apps::local_links_manager::db
   include govuk::apps::policy_publisher::db
   include govuk::apps::publishing_api::db
   include govuk::apps::service_manual_publisher::db

--- a/modules/govuk/spec/classes/govuk_nodes_spec_optional.rb
+++ b/modules/govuk/spec/classes/govuk_nodes_spec_optional.rb
@@ -35,12 +35,12 @@ ENV.fetch('classes').split(",").each do |class_name|
 
     # Pull in some required bits from top-level site.pp
     let(:pre_condition) { <<-EOT
-$govuk_node_class = "#{class_name}"
+      $govuk_node_class = "#{class_name}"
 
-$lv = hiera('lv',{})
-create_resources('govuk_lvm', $lv)
-$mount = hiera('mount',{})
-create_resources('govuk_mount', $mount)
+      $lv = hiera('lv',{})
+      create_resources('govuk_lvm', $lv)
+      $mount = hiera('mount',{})
+      create_resources('govuk_mount', $mount)
       EOT
     }
 


### PR DESCRIPTION
- Add puppet configuration for new local-links-manager app to help manage the local links within GOV.UK so that they can be used for local transactions.
- Add postgresql configuration for the local_links_manager app.

These are all base settings and will no doubt change as the app increments.

Relies on these PR's:
https://github.gds/gds/deployment/pull/929
https://github.gds/gds/deployment/pull/937

[Trello card](https://trello.com/c/cAioCrSk/316-get-a-new-local-links-manager-app-up-and-running-3)