### PR TITLE
Allow jumpboxes to reboot unattended overnight

### DIFF
--- a/hieradata/class/jumpbox.yaml
+++ b/hieradata/class/jumpbox.yaml
@@ -1,4 +1,4 @@
 ---
 
-govuk::safe_to_reboot::can_reboot: 'careful'
-govuk::safe_to_reboot::reason: 'Warn connected users before rebooting'
+govuk::safe_to_reboot::can_reboot: 'overnight'
+govuk::safe_to_reboot::reason: 'Will only reboot if no users are connected'

--- a/modules/govuk/manifests/node/s_jumpbox.pp
+++ b/modules/govuk/manifests/node/s_jumpbox.pp
@@ -1,4 +1,7 @@
-# FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
+# == Class: govuk::node::s_jumpbox
+#
+# Configures an SSH jumpbox, also known as a bastion host
+#
 class govuk::node::s_jumpbox inherits govuk::node::s_base {
-
+  include govuk_unattended_reboot::jumpbox
 }

--- a/modules/govuk_unattended_reboot/files/etc/unattended-reboot/check/02_jumpbox
+++ b/modules/govuk_unattended_reboot/files/etc/unattended-reboot/check/02_jumpbox
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# Ensure no users are logged in
+[[ $(/usr/bin/w --no-header | /usr/bin/wc -l) -eq 0 ]]

--- a/modules/govuk_unattended_reboot/manifests/jumpbox.pp
+++ b/modules/govuk_unattended_reboot/manifests/jumpbox.pp
@@ -1,0 +1,18 @@
+# == Class: govuk_unattended_reboot::jumpbox
+#
+# Installs a script which ensures that a jumpbox server
+# can be rebooted.
+#
+class govuk_unattended_reboot::jumpbox (){
+  $config_directory = '/etc/unattended-reboot'
+  $check_scripts_directory = "${config_directory}/check"
+
+  file { "${check_scripts_directory}/02_jumpbox":
+    ensure  => 'present',
+    mode    => '0755',
+    owner   => 'root',
+    group   => 'root',
+    source  => "puppet:///modules/govuk_unattended_reboot/${check_scripts_directory}/02_jumpbox",
+    require => File[$check_scripts_directory],
+  }
+}


### PR DESCRIPTION
The reason we had not previously allowed the jumpboxes to reboot
overnight was to avoid exacerbating an incident if someone was
investigating an issue out of hours (the time when the unattended
reboots occur) and was logged off mid-incident because the jumpbox was
rebooted.

This script checks if there are any users logged on so that the jumpbox
can reboot overnight.

Note that there's still the potential that the jumpbox never returns
from the reboot, or that it's still rebooting when someone needs to log
in, however I think that that scenario is rare enough that it's not
something we should worry about. We also have a second jumpbox.

* * *

I plan to refactor the way we're installing the check scripts to use a defined type rather than a new class for each check script but I'll do that in a later PR.