### PR TITLE
Don't analyse `fields.govuk_original_url` in logs

### DIFF
--- a/modules/govuk/files/node/s_logs_elasticsearch/logstash-template.json
+++ b/modules/govuk/files/node/s_logs_elasticsearch/logstash-template.json
@@ -82,7 +82,7 @@
               "index": "not_analyzed",
               "type": "string"
             },
-            "original_url": {
+            "govuk_original_url": {
               "index": "not_analyzed",
               "type": "string"
             }


### PR DESCRIPTION
https://github.com/alphagov/govuk-puppet/pull/4135 was meant to mark this field as not analysed, but used an incorrect field name. The correct one is `govuk_original_url`.

From the original PR:

> The purpose of recording this is to be able to find the list of pages which a particular app is involved in rendering, or the list of apps involved in rendering a particular page. If the field is analysed we
can't do this, because a facet query will instead return the list of components of urls.

After this is deployed, [our Kibana dashboard](https://kibana.publishing.service.gov.uk/kibana/#/dashboard/elasticsearch/Top%20URLs%20for%20rummager) will start showing URLs in the `Top URLs for App` list instead of fragments of the URLs.
 
Trello: https://trello.com/c/JVZPH4S9

@rboulton 