### PR TITLE
Fix quoting in deploy Jenkins job

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
@@ -24,7 +24,7 @@
     builders:
         - shell: |
             ./jenkins.sh
-            export DEPLOY_TO=<%= @environment -%>
+            export DEPLOY_TO="<%= @environment -%>"
             export DEPLOY_TASK="$DEPLOY_TASK"
             export TAG="$TAG"
             export ORGANISATION="<%= @environment -%>"


### PR DESCRIPTION
Without the double quotes, the bash script appears in Jenkins as:

    export DEPLOY_TO=staging            export DEPLOY_TASK="$DEPLOY_TASK"

This is because the trailing newline is removed if the quotes are not
present.