### PR TITLE
Extract govuk::safe_to_reboot into own module

### DIFF
--- a/hieradata/class/api_elasticsearch.yaml
+++ b/hieradata/class/api_elasticsearch.yaml
@@ -1,7 +1,7 @@
 ---
 
-govuk::safe_to_reboot::can_reboot: 'careful'
-govuk::safe_to_reboot::reason: 'Reboot a single node at time and check that the cluster goes green between reboots'
+govuk_safe_to_reboot::can_reboot: 'careful'
+govuk_safe_to_reboot::reason: 'Reboot a single node at time and check that the cluster goes green between reboots'
 
 govuk_elasticsearch::version: '1.4.4'
 

--- a/hieradata/class/api_mongo.yaml
+++ b/hieradata/class/api_mongo.yaml
@@ -1,7 +1,7 @@
 ---
 
-govuk::safe_to_reboot::can_reboot: 'careful'
-govuk::safe_to_reboot::reason: 'Check for primary, reboot secondaries, step down primary, reboot primary'
+govuk_safe_to_reboot::can_reboot: 'careful'
+govuk_safe_to_reboot::reason: 'Check for primary, reboot secondaries, step down primary, reboot primary'
 
 lv:
   mongodb:

--- a/hieradata/class/api_postgresql_primary.yaml
+++ b/hieradata/class/api_postgresql_primary.yaml
@@ -1,7 +1,7 @@
 ---
 
-govuk::safe_to_reboot::can_reboot: 'no'
-govuk::safe_to_reboot::reason: 'Single point of failure for any Postgres-writing apps'
+govuk_safe_to_reboot::can_reboot: 'no'
+govuk_safe_to_reboot::reason: 'Single point of failure for any Postgres-writing apps'
 
 govuk_postgresql::server::primary::slave_addresses:
   live:

--- a/hieradata/class/api_postgresql_standby.yaml
+++ b/hieradata/class/api_postgresql_standby.yaml
@@ -1,7 +1,7 @@
 ---
 
-govuk::safe_to_reboot::can_reboot: 'careful'
-govuk::safe_to_reboot::reason: 'We take backups from this machine; rebooting during backup will cause it to fail'
+govuk_safe_to_reboot::can_reboot: 'careful'
+govuk_safe_to_reboot::reason: 'We take backups from this machine; rebooting during backup will cause it to fail'
 
 govuk_postgresql::server::standby::master_host: 'api-postgresql-primary-1.api'
 

--- a/hieradata/class/api_redis.yaml
+++ b/hieradata/class/api_redis.yaml
@@ -1,4 +1,4 @@
 ---
 
-govuk::safe_to_reboot::can_reboot: 'no'
-govuk::safe_to_reboot::reason: 'Single point of failure for applications, no clustering'
+govuk_safe_to_reboot::can_reboot: 'no'
+govuk_safe_to_reboot::reason: 'Single point of failure for applications, no clustering'

--- a/hieradata/class/asset_master.yaml
+++ b/hieradata/class/asset_master.yaml
@@ -6,8 +6,8 @@ govuk::node::s_asset_master::asset_slave_ip_ranges:
   asset_slave_2_nfs:
     from: "%{hiera('environment_ip_prefix')}.11.21"
 
-govuk::safe_to_reboot::can_reboot: 'no'
-govuk::safe_to_reboot::reason: 'Mounted by backend machines, causes attachment delivery failures'
+govuk_safe_to_reboot::can_reboot: 'no'
+govuk_safe_to_reboot::reason: 'Mounted by backend machines, causes attachment delivery failures'
 
 govuk_sudo::sudo_conf:
   deploy_assets_rsync:

--- a/hieradata/class/asset_slave.yaml
+++ b/hieradata/class/asset_slave.yaml
@@ -2,8 +2,8 @@
 
 backup::assets::archive_directory: '/mnt/uploads/.cache/duplicity/'
 
-govuk::safe_to_reboot::can_reboot: 'careful'
-govuk::safe_to_reboot::reason: 'Check that offsite sync job is not running before rebooting'
+govuk_safe_to_reboot::can_reboot: 'careful'
+govuk_safe_to_reboot::reason: 'Check that offsite sync job is not running before rebooting'
 
 lv:
   data:

--- a/hieradata/class/backend_lb.yaml
+++ b/hieradata/class/backend_lb.yaml
@@ -1,6 +1,6 @@
 ---
 
-govuk::safe_to_reboot::can_reboot: 'careful'
-govuk::safe_to_reboot::reason: 'NAT rule points directly at backend-lb-1 for backend services. Need to switch this before rebooting to backend-2'
+govuk_safe_to_reboot::can_reboot: 'careful'
+govuk_safe_to_reboot::reason: 'NAT rule points directly at backend-lb-1 for backend services. Need to switch this before rebooting to backend-2'
 
 nginx::logging::days_to_keep: '45'

--- a/hieradata/class/efg_frontend.yaml
+++ b/hieradata/class/efg_frontend.yaml
@@ -3,8 +3,8 @@
 govuk::node::s_base::apps:
   - efg
 
-govuk::safe_to_reboot::can_reboot: 'overnight'
-govuk::safe_to_reboot::reason: 'There is only one EFG frontend'
+govuk_safe_to_reboot::can_reboot: 'overnight'
+govuk_safe_to_reboot::reason: 'There is only one EFG frontend'
 
 lv:
   data:

--- a/hieradata/class/efg_mysql_master.yaml
+++ b/hieradata/class/efg_mysql_master.yaml
@@ -1,7 +1,7 @@
 ---
 
-govuk::safe_to_reboot::can_reboot: 'overnight'
-govuk::safe_to_reboot::reason: 'Single master database, applications not resilient'
+govuk_safe_to_reboot::can_reboot: 'overnight'
+govuk_safe_to_reboot::reason: 'Single master database, applications not resilient'
 
 lv:
   data:

--- a/hieradata/class/elasticsearch.yaml
+++ b/hieradata/class/elasticsearch.yaml
@@ -1,7 +1,7 @@
 ---
 
-govuk::safe_to_reboot::can_reboot: 'careful'
-govuk::safe_to_reboot::reason: 'Reboot a single node at time and check that the cluster goes green between reboots'
+govuk_safe_to_reboot::can_reboot: 'careful'
+govuk_safe_to_reboot::reason: 'Reboot a single node at time and check that the cluster goes green between reboots'
 
 govuk_elasticsearch::version: '0.90.12'
 

--- a/hieradata/class/email_campaign_mongo.yaml
+++ b/hieradata/class/email_campaign_mongo.yaml
@@ -1,7 +1,7 @@
 ---
 
-govuk::safe_to_reboot::can_reboot: 'careful'
-govuk::safe_to_reboot::reason: 'Check for primary, reboot secondaries, step down primary, reboot primary'
+govuk_safe_to_reboot::can_reboot: 'careful'
+govuk_safe_to_reboot::reason: 'Check for primary, reboot secondaries, step down primary, reboot primary'
 
 lv:
   mongodb:

--- a/hieradata/class/graphite.yaml
+++ b/hieradata/class/graphite.yaml
@@ -1,7 +1,7 @@
 ---
 
-govuk::safe_to_reboot::can_reboot: 'careful'
-govuk::safe_to_reboot::reason: 'We lose stats and some alerting when this machine is down'
+govuk_safe_to_reboot::can_reboot: 'careful'
+govuk_safe_to_reboot::reason: 'We lose stats and some alerting when this machine is down'
 
 icinga::client::checks::disk_time_warn: 280 # milliseconds
 icinga::client::checks::disk_time_critical: 400 # milliseconds

--- a/hieradata/class/jumpbox.yaml
+++ b/hieradata/class/jumpbox.yaml
@@ -1,4 +1,4 @@
 ---
 
-govuk::safe_to_reboot::can_reboot: 'careful'
-govuk::safe_to_reboot::reason: 'Warn connected users before rebooting'
+govuk_safe_to_reboot::can_reboot: 'careful'
+govuk_safe_to_reboot::reason: 'Warn connected users before rebooting'

--- a/hieradata/class/licensify_mongo.yaml
+++ b/hieradata/class/licensify_mongo.yaml
@@ -1,7 +1,7 @@
 ---
 
-govuk::safe_to_reboot::can_reboot: 'careful'
-govuk::safe_to_reboot::reason: 'Has an encrypted partition that must be mounted manually after reboot'
+govuk_safe_to_reboot::can_reboot: 'careful'
+govuk_safe_to_reboot::reason: 'Has an encrypted partition that must be mounted manually after reboot'
 
 hosts::production::external_licensify: false
 

--- a/hieradata/class/logs_elasticsearch.yaml
+++ b/hieradata/class/logs_elasticsearch.yaml
@@ -1,7 +1,7 @@
 ---
 
-govuk::safe_to_reboot::can_reboot: 'careful'
-govuk::safe_to_reboot::reason: 'Reboot a single node at time and check that the cluster goes green between reboots'
+govuk_safe_to_reboot::can_reboot: 'careful'
+govuk_safe_to_reboot::reason: 'Reboot a single node at time and check that the cluster goes green between reboots'
 
 govuk_elasticsearch::version: '1.4.4'
 

--- a/hieradata/class/logs_redis.yaml
+++ b/hieradata/class/logs_redis.yaml
@@ -1,4 +1,4 @@
 ---
 
-govuk::safe_to_reboot::can_reboot: 'careful'
-govuk::safe_to_reboot::reason: 'Check queue is empty first with: redis-cli llen logs '
+govuk_safe_to_reboot::can_reboot: 'careful'
+govuk_safe_to_reboot::reason: 'Check queue is empty first with: redis-cli llen logs '

--- a/hieradata/class/mongo.yaml
+++ b/hieradata/class/mongo.yaml
@@ -1,7 +1,7 @@
 ---
 
-govuk::safe_to_reboot::can_reboot: 'careful'
-govuk::safe_to_reboot::reason: 'Check for primary, reboot secondaries, step down primary, reboot primary'
+govuk_safe_to_reboot::can_reboot: 'careful'
+govuk_safe_to_reboot::reason: 'Check for primary, reboot secondaries, step down primary, reboot primary'
 
 lv:
   mongodb:

--- a/hieradata/class/monitoring.yaml
+++ b/hieradata/class/monitoring.yaml
@@ -1,4 +1,4 @@
 ---
 
-govuk::safe_to_reboot::can_reboot: 'overnight'
-govuk::safe_to_reboot::reason: 'We lose alerting while this is down'
+govuk_safe_to_reboot::can_reboot: 'overnight'
+govuk_safe_to_reboot::reason: 'We lose alerting while this is down'

--- a/hieradata/class/mysql_master.yaml
+++ b/hieradata/class/mysql_master.yaml
@@ -1,7 +1,7 @@
 ---
 
-govuk::safe_to_reboot::can_reboot: 'no'
-govuk::safe_to_reboot::reason: 'Single master database, applications not resilient'
+govuk_safe_to_reboot::can_reboot: 'no'
+govuk_safe_to_reboot::reason: 'Single master database, applications not resilient'
 
 govuk_mysql::server::key_buffer_size: '1024M'
 govuk_mysql::server::query_cache_limit: '4M'

--- a/hieradata/class/mysql_slave.yaml
+++ b/hieradata/class/mysql_slave.yaml
@@ -1,7 +1,7 @@
 ---
 
-govuk::safe_to_reboot::can_reboot: 'careful'
-govuk::safe_to_reboot::reason: 'Applications normally read from slave-1 and should be switched before rebooting slave-1'
+govuk_safe_to_reboot::can_reboot: 'careful'
+govuk_safe_to_reboot::reason: 'Applications normally read from slave-1 and should be switched before rebooting slave-1'
 
 lv:
   data:

--- a/hieradata/class/performance_mongo.yaml
+++ b/hieradata/class/performance_mongo.yaml
@@ -1,7 +1,7 @@
 ---
 
-govuk::safe_to_reboot::can_reboot: 'careful'
-govuk::safe_to_reboot::reason: 'Check for primary, reboot secondaries, step down primary, reboot primary'
+govuk_safe_to_reboot::can_reboot: 'careful'
+govuk_safe_to_reboot::reason: 'Check for primary, reboot secondaries, step down primary, reboot primary'
 
 lv:
   mongodb:

--- a/hieradata/class/postgresql_primary.yaml
+++ b/hieradata/class/postgresql_primary.yaml
@@ -1,7 +1,7 @@
 ---
 
-govuk::safe_to_reboot::can_reboot: 'no'
-govuk::safe_to_reboot::reason: 'Single point of failure for any Postgres-writing apps'
+govuk_safe_to_reboot::can_reboot: 'no'
+govuk_safe_to_reboot::reason: 'Single point of failure for any Postgres-writing apps'
 
 govuk_postgresql::server::primary::slave_addresses:
   live:

--- a/hieradata/class/postgresql_standby.yaml
+++ b/hieradata/class/postgresql_standby.yaml
@@ -1,7 +1,7 @@
 ---
 
-govuk::safe_to_reboot::can_reboot: 'no'
-govuk::safe_to_reboot::reason: 'Apps point directly to this machine for reading.'
+govuk_safe_to_reboot::can_reboot: 'no'
+govuk_safe_to_reboot::reason: 'Apps point directly to this machine for reading.'
 
 govuk_postgresql::server::standby::master_host: 'postgresql-primary-1.backend'
 

--- a/hieradata/class/rabbitmq.yaml
+++ b/hieradata/class/rabbitmq.yaml
@@ -10,8 +10,8 @@ govuk::node::s_rabbitmq::apps_using_rabbitmq:
   - rummager
   - stagecraft
 
-govuk::safe_to_reboot::can_reboot: 'careful'
-govuk::safe_to_reboot::reason: 'rabbitmq-1 is a single point of failure for content-store, apps not resilient'
+govuk_safe_to_reboot::can_reboot: 'careful'
+govuk_safe_to_reboot::reason: 'rabbitmq-1 is a single point of failure for content-store, apps not resilient'
 
 lv:
   data:

--- a/hieradata/class/redis.yaml
+++ b/hieradata/class/redis.yaml
@@ -1,4 +1,4 @@
 ---
 
-govuk::safe_to_reboot::can_reboot: 'no'
-govuk::safe_to_reboot::reason: 'Single point of failure for applications, no clustering'
+govuk_safe_to_reboot::can_reboot: 'no'
+govuk_safe_to_reboot::reason: 'Single point of failure for applications, no clustering'

--- a/hieradata/class/router_backend.yaml
+++ b/hieradata/class/router_backend.yaml
@@ -14,8 +14,8 @@ govuk::apps::router_api::vhost: 'router-api'
 govuk::node::s_base::apps:
   - router_api
 
-govuk::safe_to_reboot::can_reboot: 'careful'
-govuk::safe_to_reboot::reason: 'Check for primary, reboot secondaries, step down primary, reboot primary'
+govuk_safe_to_reboot::can_reboot: 'careful'
+govuk_safe_to_reboot::reason: 'Check for primary, reboot secondaries, step down primary, reboot primary'
 
 lv:
   mongodb:

--- a/hieradata/class/staging/api_elasticsearch.yaml
+++ b/hieradata/class/staging/api_elasticsearch.yaml
@@ -1,3 +1,3 @@
 ---
 
-govuk::safe_to_reboot::can_reboot: 'overnight'
+govuk_safe_to_reboot::can_reboot: 'overnight'

--- a/hieradata/class/staging/api_mongo.yaml
+++ b/hieradata/class/staging/api_mongo.yaml
@@ -1,3 +1,3 @@
 ---
 
-govuk::safe_to_reboot::can_reboot: 'overnight'
+govuk_safe_to_reboot::can_reboot: 'overnight'

--- a/hieradata/class/staging/elasticsearch.yaml
+++ b/hieradata/class/staging/elasticsearch.yaml
@@ -1,3 +1,3 @@
 ---
 
-govuk::safe_to_reboot::can_reboot: 'overnight'
+govuk_safe_to_reboot::can_reboot: 'overnight'

--- a/hieradata/class/staging/email_campaign_mongo.yaml
+++ b/hieradata/class/staging/email_campaign_mongo.yaml
@@ -1,3 +1,3 @@
 ---
 
-govuk::safe_to_reboot::can_reboot: 'overnight'
+govuk_safe_to_reboot::can_reboot: 'overnight'

--- a/hieradata/class/staging/logs_elasticsearch.yaml
+++ b/hieradata/class/staging/logs_elasticsearch.yaml
@@ -1,3 +1,3 @@
 ---
 
-govuk::safe_to_reboot::can_reboot: 'overnight'
+govuk_safe_to_reboot::can_reboot: 'overnight'

--- a/hieradata/class/staging/mongo.yaml
+++ b/hieradata/class/staging/mongo.yaml
@@ -1,3 +1,3 @@
 ---
 
-govuk::safe_to_reboot::can_reboot: 'overnight'
+govuk_safe_to_reboot::can_reboot: 'overnight'

--- a/hieradata/class/staging/performance_mongo.yaml
+++ b/hieradata/class/staging/performance_mongo.yaml
@@ -1,4 +1,4 @@
 ---
 
-govuk::safe_to_reboot::can_reboot: 'overnight'
+govuk_safe_to_reboot::can_reboot: 'overnight'
 

--- a/hieradata/class/staging/router_backend.yaml
+++ b/hieradata/class/staging/router_backend.yaml
@@ -1,3 +1,3 @@
 ---
 
-govuk::safe_to_reboot::can_reboot: 'overnight'
+govuk_safe_to_reboot::can_reboot: 'overnight'

--- a/hieradata/class/transition_postgresql_master.yaml
+++ b/hieradata/class/transition_postgresql_master.yaml
@@ -1,7 +1,7 @@
 ---
 
-govuk::safe_to_reboot::can_reboot: 'no'
-govuk::safe_to_reboot::reason: 'Single point of failure for Transition application'
+govuk_safe_to_reboot::can_reboot: 'no'
+govuk_safe_to_reboot::reason: 'Single point of failure for Transition application'
 
 lv:
   data:

--- a/hieradata/class/transition_postgresql_slave.yaml
+++ b/hieradata/class/transition_postgresql_slave.yaml
@@ -1,6 +1,6 @@
 ---
-govuk::safe_to_reboot::can_reboot: 'no'
-govuk::safe_to_reboot::reason: 'Single point of failure for Bouncer application'
+govuk_safe_to_reboot::can_reboot: 'no'
+govuk_safe_to_reboot::reason: 'Single point of failure for Bouncer application'
 
 lv:
   postgresql:

--- a/hieradata/class/whitehall_frontend.yaml
+++ b/hieradata/class/whitehall_frontend.yaml
@@ -3,8 +3,8 @@
 govuk::apps::whitehall::nagios_memory_warning: 10737
 govuk::apps::whitehall::nagios_memory_critical: 12884
 
-govuk::safe_to_reboot::can_reboot: 'overnight'
-govuk::safe_to_reboot::reason: 'Whitehall application is slow to start, recommend rebooting a single node at a time'
+govuk_safe_to_reboot::can_reboot: 'overnight'
+govuk_safe_to_reboot::reason: 'Whitehall application is slow to start, recommend rebooting a single node at a time'
 
 lv:
   data:

--- a/hieradata/class/whitehall_mysql_master.yaml
+++ b/hieradata/class/whitehall_mysql_master.yaml
@@ -2,8 +2,8 @@
 
 govuk::node::s_whitehall_mysql_master::whitehall_fe_password: "%{hiera('mysql_whitehall_frontend')}"
 
-govuk::safe_to_reboot::can_reboot: 'no'
-govuk::safe_to_reboot::reason: 'Single master database, applications not resilient'
+govuk_safe_to_reboot::can_reboot: 'no'
+govuk_safe_to_reboot::reason: 'Single master database, applications not resilient'
 
 lv:
   data:

--- a/hieradata/class/whitehall_mysql_slave.yaml
+++ b/hieradata/class/whitehall_mysql_slave.yaml
@@ -1,7 +1,7 @@
 ---
 
-govuk::safe_to_reboot::can_reboot: 'careful'
-govuk::safe_to_reboot::reason: 'Whitehall normally reads from slave-1 and should be switched before rebooting slave-1'
+govuk_safe_to_reboot::can_reboot: 'careful'
+govuk_safe_to_reboot::reason: 'Whitehall normally reads from slave-1 and should be switched before rebooting slave-1'
 
 lv:
   data:

--- a/modules/govuk/manifests/node/s_base.pp
+++ b/modules/govuk/manifests/node/s_base.pp
@@ -15,7 +15,7 @@ class govuk::node::s_base (
   include backup::client
   include base
   include govuk_firewall
-  include govuk::safe_to_reboot
+  include govuk_safe_to_reboot
   include govuk_rbenv
   include grub2
   include harden

--- a/modules/govuk_safe_to_reboot/manifests/careful.pp
+++ b/modules/govuk_safe_to_reboot/manifests/careful.pp
@@ -3,11 +3,11 @@
 #  [*reason*]
 #  Why is this machine flagged as this rebootability
 #
-class govuk::safe_to_reboot::no (
+class govuk_safe_to_reboot::careful (
   $reason,
 ) {
   govuk_envvar { 'SAFE_TO_REBOOT':
-    value => 'no',
+    value => 'careful',
   }
   govuk_envvar { 'SAFE_TO_REBOOT_REASON':
     value => $reason,

--- a/modules/govuk_safe_to_reboot/manifests/init.pp
+++ b/modules/govuk_safe_to_reboot/manifests/init.pp
@@ -6,7 +6,7 @@
 # known to puppetdb who instantiate that class. Thus to get a list of
 # machines that are safe to reboot we can do:
 #
-#    govuk_node_list -C 'govuk::safe_to_reboot::yes'
+#    govuk_node_list -C 'govuk_safe_to_reboot::yes'
 #
 # [*can_reboot*]
 #   Can this machine be rebooted with impunity? ['yes', 'no', 'careful']
@@ -16,11 +16,11 @@
 #   What is the reasoning for the above state
 #   Default: ''
 #
-class govuk::safe_to_reboot (
+class govuk_safe_to_reboot (
   $can_reboot = 'yes',
   $reason = ''
 ) {
-  $reboot_class = "govuk::safe_to_reboot::${can_reboot}"
+  $reboot_class = "govuk_safe_to_reboot::${can_reboot}"
 
   case $can_reboot {
     'no', 'careful': {
@@ -41,7 +41,7 @@ class govuk::safe_to_reboot (
             $real_reason = 'Not flagged specifically so assuming safe to reboot'
           }
     default: {
-            fail("Invalid value for govuk::safe_to_reboot::can_reboot: ${can_reboot}")
+            fail("Invalid value for govuk_safe_to_reboot::can_reboot: ${can_reboot}")
           }
     }
 

--- a/modules/govuk_safe_to_reboot/manifests/no.pp
+++ b/modules/govuk_safe_to_reboot/manifests/no.pp
@@ -3,11 +3,11 @@
 #  [*reason*]
 #  Why is this machine flagged as this rebootability
 #
-class govuk::safe_to_reboot::yes (
+class govuk_safe_to_reboot::no (
   $reason,
 ) {
   govuk_envvar { 'SAFE_TO_REBOOT':
-    value => 'yes',
+    value => 'no',
   }
   govuk_envvar { 'SAFE_TO_REBOOT_REASON':
     value => $reason,

--- a/modules/govuk_safe_to_reboot/manifests/overnight.pp
+++ b/modules/govuk_safe_to_reboot/manifests/overnight.pp
@@ -3,7 +3,7 @@
 #  [*reason*]
 #  Why is this machine flagged as this rebootability
 #
-class govuk::safe_to_reboot::overnight (
+class govuk_safe_to_reboot::overnight (
   $reason,
 ) {
   govuk_envvar { 'SAFE_TO_REBOOT':

--- a/modules/govuk_safe_to_reboot/manifests/yes.pp
+++ b/modules/govuk_safe_to_reboot/manifests/yes.pp
@@ -3,11 +3,11 @@
 #  [*reason*]
 #  Why is this machine flagged as this rebootability
 #
-class govuk::safe_to_reboot::careful (
+class govuk_safe_to_reboot::yes (
   $reason,
 ) {
   govuk_envvar { 'SAFE_TO_REBOOT':
-    value => 'careful',
+    value => 'yes',
   }
   govuk_envvar { 'SAFE_TO_REBOOT_REASON':
     value => $reason,

--- a/modules/govuk_safe_to_reboot/spec/classes/govuk_safe_to_reboot_spec.rb
+++ b/modules/govuk_safe_to_reboot/spec/classes/govuk_safe_to_reboot_spec.rb
@@ -1,10 +1,10 @@
 require_relative '../../../../spec_helper'
 
-describe 'govuk::safe_to_reboot', :type => :class do
+describe 'govuk_safe_to_reboot', :type => :class do
     context '#yes' do
       let(:params) {{ }}
 
-      it { is_expected.to contain_class('govuk::safe_to_reboot::yes').with_reason('Not flagged specifically so assuming safe to reboot') }
+      it { is_expected.to contain_class('govuk_safe_to_reboot::yes').with_reason('Not flagged specifically so assuming safe to reboot') }
     end
 
     context '#no with blank reason' do
@@ -24,7 +24,7 @@ describe 'govuk::safe_to_reboot', :type => :class do
         :reason     => 'bad things will happen'
       }}
 
-      it { is_expected.to contain_class('govuk::safe_to_reboot::careful').with_reason('bad things will happen') }
+      it { is_expected.to contain_class('govuk_safe_to_reboot::careful').with_reason('bad things will happen') }
     end
 
     context '#invalid flag' do
@@ -33,7 +33,7 @@ describe 'govuk::safe_to_reboot', :type => :class do
         :reason     => 'bad things will happen'
       }}
       it 'should fail to compile' do
-        is_expected.to raise_error(Puppet::Error, /Invalid value for govuk::safe_to_reboot::can_reboot: never/)
+        is_expected.to raise_error(Puppet::Error, /Invalid value for govuk_safe_to_reboot::can_reboot: never/)
       end
     end
 end


### PR DESCRIPTION
In a bid to break up the monolithic `govuk` module.