### PR TITLE
Extract govuk::mount into own module

### DIFF
--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -194,7 +194,7 @@ govuk::deploy::setup_actionmailer_ses_config: false
 
 govuk_lvm::no_op: true
 
-govuk::mount::no_op: true
+govuk_mount::no_op: true
 
 govuk_elasticsearch::version: '1.4.4'
 

--- a/hieradata/vagrant.yaml
+++ b/hieradata/vagrant.yaml
@@ -36,7 +36,7 @@ govuk::deploy::config::website_root: 'http://www.dev.gov.uk'
 
 govuk_lvm::no_op: true
 
-govuk::mount::no_op: true
+govuk_mount::no_op: true
 
 govuk::node::s_api_lb::api_servers:
   - "api-1.api"

--- a/lib/puppet-lint/plugins/check_hiera.rb
+++ b/lib/puppet-lint/plugins/check_hiera.rb
@@ -28,7 +28,7 @@ PuppetLint.new_check(:hiera_explicit_lookup) do
     'app_domain',
 
     # disk noops due to defined classes not doing magical hiera lookups
-    'govuk::mount::no_op',
+    'govuk_mount::no_op',
     'govuk_lvm::no_op',
 
     # govuk::app::nginx_vhost defined type needs a global disable flag for

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -55,7 +55,7 @@ node default {
   create_resources('govuk_lvm', $lv)
   # Create mounts from hiera
   $mount = hiera('mount',{})
-  create_resources('govuk::mount', $mount)
+  create_resources('govuk_mount', $mount)
 
   # This has to be included after all other govuk_rbenv::* includes in the
   # parse order. See comments on the class for details.

--- a/modules/govuk/manifests/node/s_api_elasticsearch.pp
+++ b/modules/govuk/manifests/node/s_api_elasticsearch.pp
@@ -57,5 +57,5 @@ class govuk::node::s_api_elasticsearch inherits govuk::node::s_base {
     outgoing => 9300,
   }
 
-  Govuk::Mount['/mnt/elasticsearch'] -> Class['govuk_elasticsearch']
+  Govuk_mount['/mnt/elasticsearch'] -> Class['govuk_elasticsearch']
 }

--- a/modules/govuk/manifests/node/s_api_mongo.pp
+++ b/modules/govuk/manifests/node/s_api_mongo.pp
@@ -10,6 +10,6 @@ class govuk::node::s_api_mongo inherits govuk::node::s_base {
     outgoing => 27017,
   }
 
-  Govuk::Mount['/var/lib/mongodb'] -> Class['mongodb::server']
-  Govuk::Mount['/var/lib/automongodbbackup'] -> Class['mongodb::backup']
+  Govuk_mount['/var/lib/mongodb'] -> Class['mongodb::server']
+  Govuk_mount['/var/lib/automongodbbackup'] -> Class['mongodb::backup']
 }

--- a/modules/govuk/manifests/node/s_api_postgresql_base.pp
+++ b/modules/govuk/manifests/node/s_api_postgresql_base.pp
@@ -5,7 +5,7 @@
 class govuk::node::s_api_postgresql_base inherits govuk::node::s_base {
   include govuk::apps::stagecraft::postgresql_db
 
-  Govuk::Mount['/var/lib/postgresql'] -> Class['govuk_postgresql::server']
+  Govuk_mount['/var/lib/postgresql'] -> Class['govuk_postgresql::server']
 
   include govuk_postgresql::tuning
 }

--- a/modules/govuk/manifests/node/s_apt.pp
+++ b/modules/govuk/manifests/node/s_apt.pp
@@ -20,7 +20,7 @@ class govuk::node::s_apt (
     },
   }
 
-  Govuk::Mount[$root_dir] -> Class['aptly']
+  Govuk_mount[$root_dir] -> Class['aptly']
 
   file { $root_dir:
     ensure  => directory,

--- a/modules/govuk/manifests/node/s_asset_base.pp
+++ b/modules/govuk/manifests/node/s_asset_base.pp
@@ -39,7 +39,7 @@ class govuk::node::s_asset_base (
     require => [
       Group['assets'],
       User['assets'],
-      Govuk::Mount['/mnt/uploads']
+      Govuk_mount['/mnt/uploads']
     ],
   }
 

--- a/modules/govuk/manifests/node/s_backup.pp
+++ b/modules/govuk/manifests/node/s_backup.pp
@@ -30,7 +30,7 @@ class govuk::node::s_backup (
   validate_bool($backup_licensify)
 
   class {'backup::server':
-    require => Govuk::Mount['/data/backups'],
+    require => Govuk_mount['/data/backups'],
   }
 
   # To accommodate futzing around with databases, we install a MySQL server

--- a/modules/govuk/manifests/node/s_calculators_frontend.pp
+++ b/modules/govuk/manifests/node/s_calculators_frontend.pp
@@ -19,6 +19,6 @@ class govuk::node::s_calculators_frontend inherits govuk::node::s_base {
     notes_url => monitoring_docs_url(nginx-high-conn-writing-upstream-indicator-check),
   }
 
-  Govuk::Mount['/data/vhost'] -> Class['govuk::apps::calculators']
+  Govuk_mount['/data/vhost'] -> Class['govuk::apps::calculators']
 
 }

--- a/modules/govuk/manifests/node/s_efg_mysql_master.pp
+++ b/modules/govuk/manifests/node/s_efg_mysql_master.pp
@@ -14,5 +14,5 @@ class govuk::node::s_efg_mysql_master inherits govuk::node::s_base {
     require => Class['govuk_mysql::server'],
   }
 
-  Govuk::Mount['/var/lib/mysql'] -> Class['govuk_mysql::server']
+  Govuk_mount['/var/lib/mysql'] -> Class['govuk_mysql::server']
 }

--- a/modules/govuk/manifests/node/s_elasticsearch.pp
+++ b/modules/govuk/manifests/node/s_elasticsearch.pp
@@ -37,5 +37,5 @@ class govuk::node::s_elasticsearch inherits govuk::node::s_base {
     outgoing => 9300,
   }
 
-  Govuk::Mount['/mnt/elasticsearch'] -> Class['govuk_elasticsearch']
+  Govuk_mount['/mnt/elasticsearch'] -> Class['govuk_elasticsearch']
 }

--- a/modules/govuk/manifests/node/s_email_campaign_mongo.pp
+++ b/modules/govuk/manifests/node/s_email_campaign_mongo.pp
@@ -10,6 +10,6 @@ class govuk::node::s_email_campaign_mongo inherits govuk::node::s_base {
     outgoing => 27017,
   }
 
-  Govuk::Mount['/var/lib/mongodb'] -> Class['mongodb::server']
-  Govuk::Mount['/var/lib/automongodbbackup'] -> Class['mongodb::backup']
+  Govuk_mount['/var/lib/mongodb'] -> Class['mongodb::server']
+  Govuk_mount['/var/lib/automongodbbackup'] -> Class['mongodb::backup']
 }

--- a/modules/govuk/manifests/node/s_exception_handler.pp
+++ b/modules/govuk/manifests/node/s_exception_handler.pp
@@ -7,6 +7,6 @@ class govuk::node::s_exception_handler inherits govuk::node::s_base {
   include govuk::node::s_app_server
   include nginx
 
-  Govuk::Mount['/var/lib/mongodb'] -> Class['mongodb::server']
-  Govuk::Mount['/var/lib/automongodbbackup'] -> Class['mongodb::backup']
+  Govuk_mount['/var/lib/mongodb'] -> Class['mongodb::server']
+  Govuk_mount['/var/lib/automongodbbackup'] -> Class['mongodb::backup']
 }

--- a/modules/govuk/manifests/node/s_graphite.pp
+++ b/modules/govuk/manifests/node/s_graphite.pp
@@ -24,7 +24,7 @@ class govuk::node::s_graphite (
     storage_aggregation_source => 'puppet:///modules/govuk/node/s_graphite/storage-aggregation.conf',
     storage_schemas_source     => 'puppet:///modules/govuk/node/s_graphite/storage-schemas.conf',
     carbon_source              => 'puppet:///modules/govuk/node/s_graphite/carbon.conf',
-    require                    => Govuk::Mount[$graphite_path],
+    require                    => Govuk_mount[$graphite_path],
   }
 
   # FIXME: Remove this patch when Graphite is upgraded past 0.9.13

--- a/modules/govuk/manifests/node/s_licensify_mongo.pp
+++ b/modules/govuk/manifests/node/s_licensify_mongo.pp
@@ -20,7 +20,7 @@ class govuk::node::s_licensify_mongo (
   if $licensify_mongo_encrypted {
     include ecryptfs
     motd::snippet {'01-encrypted-licensify': }
-    Govuk::Mount['/mnt/encrypted'] -> Class['mongodb::server']
+    Govuk_mount['/mnt/encrypted'] -> Class['mongodb::server']
 
     # Actual low disk space would get caught by the /mnt/encrypted check however this will catch it not being mounted.
     # Only check if MongoDB's data is on an encrypted filesystem; otherwise /var/lib/mongodb is not used as a mountpoint.
@@ -33,5 +33,5 @@ class govuk::node::s_licensify_mongo (
     }
   }
 
-  Govuk::Mount['/var/lib/automongodbbackup'] -> Class['mongodb::backup']
+  Govuk_mount['/var/lib/automongodbbackup'] -> Class['mongodb::backup']
 }

--- a/modules/govuk/manifests/node/s_logging.pp
+++ b/modules/govuk/manifests/node/s_logging.pp
@@ -9,7 +9,7 @@ class govuk::node::s_logging (
   # we want this to be a syslog server which also forwards to logstash
   class { 'rsyslog::server':
     custom_config => 'govuk/etc/rsyslog.d/server-logstash.conf.erb',
-    require       => Govuk::Mount['/srv'],
+    require       => Govuk_mount['/srv'],
   }
 
   # we want all the other machines to be able to send syslog on 514/tcp to this machine
@@ -44,7 +44,7 @@ class govuk::node::s_logging (
     initfile    => 'puppet:///modules/govuk/node/s_logging/logstash.init.Debian',
     require     => [
       Curl::Fetch['logstash-monolithic'],
-      Govuk::Mount['/srv']
+      Govuk_mount['/srv']
     ],
   }
 

--- a/modules/govuk/manifests/node/s_logs_elasticsearch.pp
+++ b/modules/govuk/manifests/node/s_logs_elasticsearch.pp
@@ -31,7 +31,7 @@ class govuk::node::s_logs_elasticsearch(
     disable_gc_alerts    => true,
     require              => [
       Class['govuk_java::openjdk7::jre'],
-      Govuk::Mount['/mnt/elasticsearch']
+      Govuk_mount['/mnt/elasticsearch']
     ],
   }
 
@@ -103,5 +103,5 @@ class govuk::node::s_logs_elasticsearch(
     host_name => $::fqdn,
   }
 
-  Govuk::Mount['/mnt/elasticsearch'] -> Class['govuk_elasticsearch']
+  Govuk_mount['/mnt/elasticsearch'] -> Class['govuk_elasticsearch']
 }

--- a/modules/govuk/manifests/node/s_mapit.pp
+++ b/modules/govuk/manifests/node/s_mapit.pp
@@ -4,7 +4,7 @@ class govuk::node::s_mapit inherits govuk::node::s_base {
 
   include nginx
 
-  Govuk::Mount['/var/lib/postgresql']
+  Govuk_mount['/var/lib/postgresql']
   ->
   class { 'govuk_postgresql::server::standalone': }
 

--- a/modules/govuk/manifests/node/s_mapit_server.pp
+++ b/modules/govuk/manifests/node/s_mapit_server.pp
@@ -15,7 +15,7 @@ class govuk::node::s_mapit_server (
 
   include mapit
 
-  Govuk::Mount['/var/lib/postgresql']
+  Govuk_mount['/var/lib/postgresql']
   ->
   class { 'govuk_postgresql::server::standalone': }
   postgresql::server::config_entry { 'standard_conforming_strings':

--- a/modules/govuk/manifests/node/s_mongo.pp
+++ b/modules/govuk/manifests/node/s_mongo.pp
@@ -10,6 +10,6 @@ class govuk::node::s_mongo inherits govuk::node::s_base {
     outgoing => 27017,
   }
 
-  Govuk::Mount['/var/lib/mongodb'] -> Class['mongodb::server']
-  Govuk::Mount['/var/lib/automongodbbackup'] -> Class['mongodb::backup']
+  Govuk_mount['/var/lib/mongodb'] -> Class['mongodb::server']
+  Govuk_mount['/var/lib/automongodbbackup'] -> Class['mongodb::backup']
 }

--- a/modules/govuk/manifests/node/s_mysql_backup.pp
+++ b/modules/govuk/manifests/node/s_mysql_backup.pp
@@ -4,7 +4,7 @@ class govuk::node::s_mysql_backup inherits govuk::node::s_base {
 
   class { 'backup::mysql':
     mysql_dump_password => $root_password,
-    require             => Govuk::Mount['/var/lib/automysqlbackup'],
+    require             => Govuk_mount['/var/lib/automysqlbackup'],
   }
 
   class { 'govuk_mysql::server':
@@ -17,5 +17,5 @@ class govuk::node::s_mysql_backup inherits govuk::node::s_base {
     outgoing => 3306,
   }
 
-  Govuk::Mount['/var/lib/mysql'] -> Class['govuk_mysql::server']
+  Govuk_mount['/var/lib/mysql'] -> Class['govuk_mysql::server']
 }

--- a/modules/govuk/manifests/node/s_mysql_master.pp
+++ b/modules/govuk/manifests/node/s_mysql_master.pp
@@ -26,5 +26,5 @@ class govuk::node::s_mysql_master () inherits govuk::node::s_base {
     outgoing => 3306,
   }
 
-  Govuk::Mount['/var/lib/mysql'] -> Class['govuk_mysql::server']
+  Govuk_mount['/var/lib/mysql'] -> Class['govuk_mysql::server']
 }

--- a/modules/govuk/manifests/node/s_mysql_slave.pp
+++ b/modules/govuk/manifests/node/s_mysql_slave.pp
@@ -14,5 +14,5 @@ class govuk::node::s_mysql_slave inherits govuk::node::s_base {
     outgoing => 3306,
   }
 
-  Govuk::Mount['/var/lib/mysql'] -> Class['govuk_mysql::server']
+  Govuk_mount['/var/lib/mysql'] -> Class['govuk_mysql::server']
 }

--- a/modules/govuk/manifests/node/s_performance_mongo.pp
+++ b/modules/govuk/manifests/node/s_performance_mongo.pp
@@ -11,6 +11,6 @@ class govuk::node::s_performance_mongo inherits govuk::node::s_base {
     outgoing => 27017,
   }
 
-  Govuk::Mount['/var/lib/mongodb'] -> Class['mongodb::server']
-  Govuk::Mount['/var/lib/automongodbbackup'] -> Class['mongodb::backup']
+  Govuk_mount['/var/lib/mongodb'] -> Class['mongodb::server']
+  Govuk_mount['/var/lib/automongodbbackup'] -> Class['mongodb::backup']
 }

--- a/modules/govuk/manifests/node/s_postgresql_base.pp
+++ b/modules/govuk/manifests/node/s_postgresql_base.pp
@@ -11,5 +11,5 @@ class govuk::node::s_postgresql_base inherits govuk::node::s_base {
   include govuk::apps::service_manual_publisher::db
   include govuk::apps::support_api::db
 
-  Govuk::Mount['/var/lib/postgresql'] -> Class['govuk_postgresql::server']
+  Govuk_mount['/var/lib/postgresql'] -> Class['govuk_postgresql::server']
 }

--- a/modules/govuk/manifests/node/s_router_backend.pp
+++ b/modules/govuk/manifests/node/s_router_backend.pp
@@ -12,6 +12,6 @@ class govuk::node::s_router_backend inherits govuk::node::s_base {
   # If we miss all the apps, throw a 500 to be caught by the cache nginx
   nginx::config::vhost::default { 'default': }
 
-  Govuk::Mount['/var/lib/mongodb'] -> Class['mongodb::server']
-  Govuk::Mount['/var/lib/automongodbbackup'] -> Class['mongodb::backup']
+  Govuk_mount['/var/lib/mongodb'] -> Class['mongodb::server']
+  Govuk_mount['/var/lib/automongodbbackup'] -> Class['mongodb::backup']
 }

--- a/modules/govuk/manifests/node/s_transition_postgresql_base.pp
+++ b/modules/govuk/manifests/node/s_transition_postgresql_base.pp
@@ -5,7 +5,7 @@
 class govuk::node::s_transition_postgresql_base inherits govuk::node::s_base {
   include govuk::apps::transition::postgresql_db
 
-  Govuk::Mount['/var/lib/postgresql'] -> Class['govuk_postgresql::server']
+  Govuk_mount['/var/lib/postgresql'] -> Class['govuk_postgresql::server']
 
   include govuk_postgresql::tuning
 

--- a/modules/govuk/manifests/node/s_whitehall_mysql_backup.pp
+++ b/modules/govuk/manifests/node/s_whitehall_mysql_backup.pp
@@ -2,6 +2,6 @@
 class govuk::node::s_whitehall_mysql_backup inherits govuk::node::s_whitehall_mysql_slave {
   class { 'backup::mysql':
     mysql_dump_password => hiera('mysql_root',''),
-    require             => Govuk::Mount['/var/lib/automysqlbackup'],
+    require             => Govuk_mount['/var/lib/automysqlbackup'],
   }
 }

--- a/modules/govuk/manifests/node/s_whitehall_mysql_master.pp
+++ b/modules/govuk/manifests/node/s_whitehall_mysql_master.pp
@@ -35,5 +35,5 @@ class govuk::node::s_whitehall_mysql_master (
     outgoing => 3306,
   }
 
-  Govuk::Mount['/var/lib/mysql'] -> Class['govuk_mysql::server']
+  Govuk_mount['/var/lib/mysql'] -> Class['govuk_mysql::server']
 }

--- a/modules/govuk/manifests/node/s_whitehall_mysql_slave.pp
+++ b/modules/govuk/manifests/node/s_whitehall_mysql_slave.pp
@@ -15,5 +15,5 @@ class govuk::node::s_whitehall_mysql_slave inherits govuk::node::s_base {
     outgoing => 3306,
   }
 
-  Govuk::Mount['/var/lib/mysql'] -> Class['govuk_mysql::server']
+  Govuk_mount['/var/lib/mysql'] -> Class['govuk_mysql::server']
 }

--- a/modules/govuk/spec/classes/govuk__apt_spec.rb
+++ b/modules/govuk/spec/classes/govuk__apt_spec.rb
@@ -6,7 +6,7 @@ describe 'govuk::node::s_apt' do
     :vdc            => 'fake_vdc',
   }}
   let(:node) { 'apt-1.management.somethingsomething' }
-  let(:pre_condition) { 'govuk::mount { "/root/dir": }' }
+  let(:pre_condition) { 'govuk_mount { "/root/dir": }' }
 
   describe 'real_ip_header' do
     context 'when not specified' do

--- a/modules/govuk/spec/classes/govuk_nodes_spec_optional.rb
+++ b/modules/govuk/spec/classes/govuk_nodes_spec_optional.rb
@@ -40,7 +40,7 @@ $govuk_node_class = "#{class_name}"
 $lv = hiera('lv',{})
 create_resources('govuk_lvm', $lv)
 $mount = hiera('mount',{})
-create_resources('govuk::mount', $mount)
+create_resources('govuk_mount', $mount)
       EOT
     }
 

--- a/modules/govuk/spec/fixtures/hiera/hiera.yaml
+++ b/modules/govuk/spec/fixtures/hiera/hiera.yaml
@@ -1,7 +1,0 @@
----
-:backends:
-  - yaml
-:yaml:
-  :datadir: 'modules/govuk/spec/fixtures/hieradata'
-:hierarchy:
-  - 'common'

--- a/modules/govuk_lvm/manifests/init.pp
+++ b/modules/govuk_lvm/manifests/init.pp
@@ -14,7 +14,7 @@
 # === Example
 #
 # To create a logical volume called test on volume group example using /dev/sdb1 as the physical volume.
-# This would be available as /dev/mapper/example-test for mounting by govuk::mount
+# This would be available as /dev/mapper/example-test for mounting by govuk_mount
 #
 #   govuk_lvm { 'test':
 #     pv => '/dev/sdb1',

--- a/modules/govuk_lvm/spec/defines/govuk_lvm_spec.rb
+++ b/modules/govuk_lvm/spec/defines/govuk_lvm_spec.rb
@@ -66,7 +66,7 @@ describe 'govuk_lvm', :type => :define do
       :vg    => 'orange',
     }}
     let(:hiera_data) {{
-      :'govuk::mount::no_op' => true,
+      :'govuk_mount::no_op' => true,
     }}
 
     it { is_expected.not_to contain_ext4mount('purple') }

--- a/modules/govuk_mount/manifests/init.pp
+++ b/modules/govuk_mount/manifests/init.pp
@@ -1,4 +1,4 @@
-# == Define: govuk::mount
+# == Define: govuk_mount
 #
 # Wrapper for `Ext4mount[]` which will automatically setup new monitoring checks
 # for free space and inodes.
@@ -23,7 +23,7 @@
 # as `undef` here so that upstream defaults are respected, except for
 # `mountpoint` which needs to default to `$title`.
 #
-define govuk::mount(
+define govuk_mount(
   $percent_threshold_warning = 10,
   $percent_threshold_critical = 5,
   $govuk_lvm = undef,
@@ -37,7 +37,7 @@ define govuk::mount(
   $mountpoint_graphite = regsubst($mountpoint, '/', '-', 'G')
   $graphite_target = "${::fqdn_metrics}.df${mountpoint_graphite}.df_complex-free"
 
-  unless hiera(govuk::mount::no_op, false) {
+  unless hiera(govuk_mount::no_op, false) {
     if $govuk_lvm != undef {
       Govuk_lvm[$govuk_lvm] -> Ext4mount[$title]
     }

--- a/modules/govuk_mount/spec/defines/govuk_mount_spec.rb
+++ b/modules/govuk_mount/spec/defines/govuk_mount_spec.rb
@@ -1,7 +1,7 @@
 require_relative '../../../../spec_helper'
 
 # FIXME: We're unable to test the Nagios exported resources.
-describe 'govuk::mount', :type => :define do
+describe 'govuk_mount', :type => :define do
   let(:title) { '/mnt/gruffalo' }
 
   context 'param defaults (undef)' do

--- a/modules/govuk_mount/spec/fixtures/hiera/hiera.yaml
+++ b/modules/govuk_mount/spec/fixtures/hiera/hiera.yaml
@@ -1,0 +1,7 @@
+---
+:backends:
+  - yaml
+:yaml:
+  :datadir: 'modules/govuk_mount/spec/fixtures/hieradata'
+:hierarchy:
+  - 'common'

--- a/modules/govuk_mount/spec/fixtures/hieradata/common.yaml
+++ b/modules/govuk_mount/spec/fixtures/hieradata/common.yaml
@@ -1,3 +1,3 @@
 app_domain: 'environment.example.com'
 
-govuk::mount::no_op: true
+govuk_mount::no_op: true

--- a/spec/fixtures/hieradata/common.yaml
+++ b/spec/fixtures/hieradata/common.yaml
@@ -9,7 +9,7 @@ govuk::apps::authenticating_proxy::mongodb_nodes: ['localhost']
 govuk::deploy::config::asset_root: 'http://assets.example.com'
 govuk::deploy::config::website_root: 'http://www.example.com'
 
-govuk::mount::no_op: false
+govuk_mount::no_op: false
 
 govuk_app_enable_services: false
 


### PR DESCRIPTION
In a bid to break up the monolithic `govuk` module.