### PR TITLE
Extract govuk::host into own module

### DIFF
--- a/modules/govuk/manifests/node/s_api_elasticsearch.pp
+++ b/modules/govuk/manifests/node/s_api_elasticsearch.pp
@@ -24,18 +24,18 @@ class govuk::node::s_api_elasticsearch inherits govuk::node::s_base {
 
   @ufw::allow { 'allow-elasticsearch-http-9200-from-search-1':
     port    => 9200,
-    from    => getparam(Govuk::Host['search-1'], 'ip'),
-    require => Govuk::Host['search-1'],
+    from    => getparam(Govuk_host['search-1'], 'ip'),
+    require => Govuk_host['search-1'],
   }
   @ufw::allow { 'allow-elasticsearch-http-9200-from-search-2':
     port    => 9200,
-    from    => getparam(Govuk::Host['search-2'], 'ip'),
-    require => Govuk::Host['search-2'],
+    from    => getparam(Govuk_host['search-2'], 'ip'),
+    require => Govuk_host['search-2'],
   }
   @ufw::allow { 'allow-elasticsearch-http-9200-from-search-3':
     port    => 9200,
-    from    => getparam(Govuk::Host['search-3'], 'ip'),
-    require => Govuk::Host['search-3'],
+    from    => getparam(Govuk_host['search-3'], 'ip'),
+    require => Govuk_host['search-3'],
   }
 
   elasticsearch::plugin { 'mobz/elasticsearch-head':

--- a/modules/govuk_elasticsearch/manifests/firewall_transport_rule.pp
+++ b/modules/govuk_elasticsearch/manifests/firewall_transport_rule.pp
@@ -1,7 +1,7 @@
 # == Define: govuk_elasticsearch::firewall_transport_rule
 #
 # Create a firewall allow rule for a given host:port.  This looks up the ip for
-# the host by finding the corresponding govuk::host instance, and creates a
+# the host by finding the corresponding govuk_host instance, and creates a
 # corresponding UFW allow rule for the given port (or 9300 if unspecified).
 #
 define govuk_elasticsearch::firewall_transport_rule {
@@ -15,9 +15,9 @@ define govuk_elasticsearch::firewall_transport_rule {
 
   if $hostname != 'localhost' {
 
-    $ip = getparam(Govuk::Host[$hostname], 'ip')
+    $ip = getparam(Govuk_host[$hostname], 'ip')
     if $ip == '' {
-      fail("Could not find govuk::host instance for ${hostname}")
+      fail("Could not find govuk_host instance for ${hostname}")
     }
 
     $port_real = $hostport ? {

--- a/modules/govuk_elasticsearch/spec/classes/govuk_elasticsearch_spec.rb
+++ b/modules/govuk_elasticsearch/spec/classes/govuk_elasticsearch_spec.rb
@@ -124,11 +124,11 @@ describe 'govuk_elasticsearch', :type => :class do
       # Realise the virtual resources so they get added to the catalogue
       Ufw::Allow <| |>
 
-      govuk::host { 'test-1':
+      govuk_host { 'test-1':
         ip  => '10.0.0.1',
         vdc => 'foo',
       }
-      govuk::host { 'test-2':
+      govuk_host { 'test-2':
         ip  => '10.0.0.2',
         vdc => 'foo',
       }

--- a/modules/govuk_elasticsearch/spec/defines/govuk_elasticsearch__firewall_transport_rule_spec.rb
+++ b/modules/govuk_elasticsearch/spec/defines/govuk_elasticsearch__firewall_transport_rule_spec.rb
@@ -11,7 +11,7 @@ describe 'govuk_elasticsearch::firewall_transport_rule', :type => :define do
       # Realise the virtual resources so they get added to the catalogue
       Ufw::Allow <| |>
 
-      govuk::host { 'giraffe':
+      govuk_host { 'giraffe':
         ip  => '10.0.0.1',
         vdc => 'test',
       }
@@ -53,7 +53,7 @@ describe 'govuk_elasticsearch::firewall_transport_rule', :type => :define do
 
       expect {
         subject.call
-      }.to raise_error(Puppet::Error, /Could not find govuk::host instance for non-existent/)
+      }.to raise_error(Puppet::Error, /Could not find govuk_host instance for non-existent/)
     end
 
     it "should error if given garbage input" do

--- a/modules/govuk_host/manifests/init.pp
+++ b/modules/govuk_host/manifests/init.pp
@@ -1,4 +1,4 @@
-# == Type: govuk::host
+# == Type: govuk_host
 #
 # Make defining a host that abides to GOV.UK convention easier. The
 # resource's title should be the host unqualified name (e.g. `jumpbox-1`).
@@ -20,7 +20,7 @@
 # [*service_aliases*]
 #   An array of service names aliased to this host.
 #
-define govuk::host(
+define govuk_host(
   $vdc,
   $ip,
   $ensure = present,

--- a/modules/govuk_host/spec/defines/govuk_host_spec.rb
+++ b/modules/govuk_host/spec/defines/govuk_host_spec.rb
@@ -1,6 +1,6 @@
 require_relative '../../../../spec_helper'
 
-describe 'govuk::host', :type => :define do
+describe 'govuk_host', :type => :define do
   let(:title) { 'giraffe' }
   let(:params) { { :ip => '1.2.3.4', :vdc => 'foobar' } }
 

--- a/modules/hosts/manifests/production.pp
+++ b/modules/hosts/manifests/production.pp
@@ -74,17 +74,17 @@ class hosts::production (
   }
 
   #efg vdc machines
-  govuk::host { 'efg-mysql-master-1':
+  govuk_host { 'efg-mysql-master-1':
     ip             => '10.4.0.10',
     vdc            => 'efg',
     legacy_aliases => ['efg.master.mysql'],
   }
 
-  govuk::host { 'efg-frontend-1':
+  govuk_host { 'efg-frontend-1':
     ip  => '10.4.0.2',
     vdc => 'efg',
   }
-  govuk::host { 'efg-mysql-slave-1':
+  govuk_host { 'efg-mysql-slave-1':
     ip             => '10.4.0.11',
     vdc            => 'efg',
     legacy_aliases => ['efg.slave.mysql'],

--- a/modules/hosts/manifests/production/api.pp
+++ b/modules/hosts/manifests/production/api.pp
@@ -8,7 +8,7 @@
 #   Domain to be used in vhost aliases
 #
 # [*hosts*]
-#   Hosts used to create govuk::host resources (hostfile entries).
+#   Hosts used to create govuk_host resources (hostfile entries).
 #
 # [*app_hostnames*]
 #   Application names
@@ -34,19 +34,19 @@ class hosts::production::api (
   $api_aliases = regsubst($app_hostnames, '$', ".${app_domain}")
   $draft_api_aliases = regsubst($draft_app_hostnames, '$', ".${app_domain}")
 
-  govuk::host { 'api-internal-lb':
+  govuk_host { 'api-internal-lb':
     ip             => $internal_lb_ip,
     legacy_aliases => $api_aliases,
   }
 
-  govuk::host { 'draft-api-internal-lb':
+  govuk_host { 'draft-api-internal-lb':
     ip             => $draft_internal_lb_ip,
     legacy_aliases => $draft_api_aliases,
   }
 
-  Govuk::Host {
+  Govuk_host {
     vdc => 'api',
   }
 
-  create_resources('govuk::host', $hosts)
+  create_resources('govuk_host', $hosts)
 }

--- a/modules/hosts/manifests/production/backend.pp
+++ b/modules/hosts/manifests/production/backend.pp
@@ -12,7 +12,7 @@
 #   Default: false
 #
 # [*hosts*]
-#   Hosts used to create govuk::host resources (hostfile entries).
+#   Hosts used to create govuk_host resources (hostfile entries).
 #
 # [*app_hostnames*]
 #   Application names
@@ -28,7 +28,7 @@ class hosts::production::backend (
   $internal_lb_ip,
 ) {
 
-  Govuk::Host {
+  Govuk_host {
     vdc => 'backend',
   }
 
@@ -36,7 +36,7 @@ class hosts::production::backend (
 
   $backend_aliases = regsubst($app_hostnames, '$', ".${app_domain}")
 
-  govuk::host { 'backend-internal-lb':
+  govuk_host { 'backend-internal-lb':
     ip             => $internal_lb_ip,
     legacy_aliases => $backend_aliases,
   }
@@ -48,5 +48,5 @@ class hosts::production::backend (
     }
   }
 
-  create_resources('govuk::host', $hosts)
+  create_resources('govuk_host', $hosts)
 }

--- a/modules/hosts/manifests/production/frontend.pp
+++ b/modules/hosts/manifests/production/frontend.pp
@@ -8,7 +8,7 @@
 #   Domain to be used in vhost aliases
 #
 # [*hosts*]
-#   Hosts used to create govuk::host resources (hostfile entries).
+#   Hosts used to create govuk_host resources (hostfile entries).
 #
 # [*app_hostnames*]
 #   Application names
@@ -23,16 +23,16 @@ class hosts::production::frontend (
   $internal_lb_ip,
 ) {
 
-  Govuk::Host {
+  Govuk_host {
     vdc => 'frontend',
   }
 
   $frontend_aliases = regsubst($app_hostnames, '$', ".${app_domain}")
 
-  govuk::host { 'frontend-internal-lb':
+  govuk_host { 'frontend-internal-lb':
     ip             => $internal_lb_ip,
     legacy_aliases => $frontend_aliases,
   }
 
-  create_resources('govuk::host', $hosts)
+  create_resources('govuk_host', $hosts)
 }

--- a/modules/hosts/manifests/production/licensify.pp
+++ b/modules/hosts/manifests/production/licensify.pp
@@ -8,7 +8,7 @@
 #   Domain to be used in vhost aliases
 #
 # [*hosts*]
-#   Hosts used to create govuk::host resources (hostfile entries).
+#   Hosts used to create govuk_host resources (hostfile entries).
 #
 # [*app_hostnames*]
 #   Application names
@@ -23,16 +23,16 @@ class hosts::production::licensify (
   $internal_lb_ip,
 ) {
 
-  Govuk::Host {
+  Govuk_host {
     vdc => 'licensify',
   }
 
   $licensify_aliases = regsubst($app_hostnames, '$', ".${app_domain}")
 
-  govuk::host { 'licensify-internal-lb':
+  govuk_host { 'licensify-internal-lb':
     ip             => $internal_lb_ip,
     legacy_aliases => $licensify_aliases,
   }
 
-  create_resources('govuk::host', $hosts)
+  create_resources('govuk_host', $hosts)
 }

--- a/modules/hosts/manifests/production/management.pp
+++ b/modules/hosts/manifests/production/management.pp
@@ -5,16 +5,16 @@
 # === Parameters:
 #
 # [*hosts*]
-#   Hosts used to create govuk::host resources (hostfile entries).
+#   Hosts used to create govuk_host resources (hostfile entries).
 #
 class hosts::production::management (
   $hosts = {},
 ) {
 
-  Govuk::Host {
+  Govuk_host {
     vdc => 'management',
   }
 
-  create_resources('govuk::host', $hosts)
+  create_resources('govuk_host', $hosts)
 
 }

--- a/modules/hosts/manifests/production/redirector.pp
+++ b/modules/hosts/manifests/production/redirector.pp
@@ -8,20 +8,20 @@
 #   The IP address of the bouncer vse load-balancer
 #
 # [*hosts*]
-#   Hosts used to create govuk::host resources (hostfile entries).
+#   Hosts used to create govuk_host resources (hostfile entries).
 #
 class hosts::production::redirector (
   $hosts = {},
   $ip_bouncer,
 ) {
 
-  Govuk::Host {
+  Govuk_host {
     vdc => 'redirector',
   }
 
-  govuk::host { 'bouncer-vse-lb':
+  govuk_host { 'bouncer-vse-lb':
     ip  => $ip_bouncer,
   }
 
-  create_resources('govuk::host', $hosts)
+  create_resources('govuk_host', $hosts)
 }

--- a/modules/hosts/manifests/production/router.pp
+++ b/modules/hosts/manifests/production/router.pp
@@ -5,15 +5,15 @@
 # === Parameters:
 #
 # [*hosts*]
-#   Hosts used to create govuk::host resources (hostfile entries).
+#   Hosts used to create govuk_host resources (hostfile entries).
 #
 class hosts::production::router (
   $hosts = {},
 ) {
 
-  Govuk::Host {
+  Govuk_host {
     vdc => 'router',
   }
 
-  create_resources('govuk::host', $hosts)
+  create_resources('govuk_host', $hosts)
 }

--- a/modules/hosts/manifests/purge.pp
+++ b/modules/hosts/manifests/purge.pp
@@ -2,7 +2,7 @@
 #
 # Purge unmanaged /etc/hosts entries.
 #
-# This will abort the catalog if a govuk::host resource doesn't exist for
+# This will abort the catalog if a govuk_host resource doesn't exist for
 # the machine's `$::hostname` so as to prevent it breaking local `hostname`
 # resolution.
 #
@@ -11,8 +11,8 @@
 # `ensure => absent`.
 #
 class hosts::purge {
-  if !defined(Govuk::Host[$::hostname]) {
-    fail("Unable to find Govuk::Host[${::hostname}]. Aborting so as not to break hostname(1)")
+  if !defined(Govuk_host[$::hostname]) {
+    fail("Unable to find Govuk_host[${::hostname}]. Aborting so as not to break hostname(1)")
   }
 
   resources { 'host':

--- a/modules/hosts/spec/classes/hosts_spec.rb
+++ b/modules/hosts/spec/classes/hosts_spec.rb
@@ -5,7 +5,7 @@ describe 'hosts', :type => :class do
     let(:node) { 'jumpbox-1' }
 
     it 'should purge unmanaged hosts entries' do
-      is_expected.to contain_govuk__host('jumpbox-1')
+      is_expected.to contain_govuk_host('jumpbox-1')
       is_expected.to contain_resources('host').with_purge('true')
     end
   end
@@ -14,7 +14,7 @@ describe 'hosts', :type => :class do
     let(:node) { 'foo-bar-wibble' }
 
     it 'should abort catalog so as not to purge hosts entry for self' do
-      is_expected.to raise_error(Puppet::Error, /Unable to find Govuk::Host\[foo-bar-wibble\]/)
+      is_expected.to raise_error(Puppet::Error, /Unable to find Govuk_host\[foo-bar-wibble\]/)
     end
   end
 end


### PR DESCRIPTION
In a bid to break up the monolithic `govuk` module.