### PR TITLE
Increase minimum SSH RSA key length to 4096 bits

### DIFF
--- a/modules/users/spec/classes/users_spec.rb
+++ b/modules/users/spec/classes/users_spec.rb
@@ -65,7 +65,7 @@ user_list.each do |username|
       ssh_keys.each do |key|
         if key != 'ssh-rsa REPLACE ME'
           key_strength = SSHKey.ssh_public_key_bits key
-          expect(key_strength).to be >= 2048, "SSH key for #{user[:name]} is only #{key_strength} bits and must be stronger"
+          expect(key_strength).to be >= 4096, "SSH key for #{user[:name]} is only #{key_strength} bits and must be stronger"
         end
       end
     end


### PR DESCRIPTION
While 2048 bits likely provides sufficient security, using 4096 bits is
good practice and may provide better protection from cryptographic
attacks.

@ikennaokpala and @leelongmore will need to replace their existing keys before this can be merged.