### PR TITLE
Enable email_campaign_api procfile worker

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -11,7 +11,6 @@ base::supported_kernel::enabled: true
 cron::weekly_dow: 1
 cron::daily_hour: 6
 
-govuk::apps::email_campaign_api::enable_procfile_worker: true
 govuk::apps::email_campaign_api::mongodb_nodes:
   - 'api-mongo-1.api'
   - 'api-mongo-2.api'

--- a/modules/govuk/manifests/apps/email_campaign_api.pp
+++ b/modules/govuk/manifests/apps/email_campaign_api.pp
@@ -27,7 +27,7 @@
 class govuk::apps::email_campaign_api(
   $port = 3110,
   $enabled = true,
-  $enable_procfile_worker = false,
+  $enable_procfile_worker = true,
   $errbit_api_key = undef,
   $secret_key_base = undef,
   $gov_delivery_endpoint = undef,


### PR DESCRIPTION
This should now be enabled everywhere.

Without this the worker keeps getting killed in production:

```(/Stage[main]/Govuk::Apps::Email_campaign_api/Govuk::Procfile::Worker[email-campaign-api]/Service[email-campaign-api-procfile-worker]/ensure) ensure changed 'running' to 'stopped'```