### PR TITLE
Remove annotations from server uptime dashboard

### DIFF
--- a/modules/grafana/files/dashboards/server_uptime.json
+++ b/modules/grafana/files/dashboards/server_uptime.json
@@ -149,32 +149,6 @@
       "collapse": false,
       "notice": false,
       "enable": false
-    },
-    {
-      "type": "annotations",
-      "enable": true,
-      "annotations": [
-        {
-          "name": "all deploys",
-          "type": "graphite events",
-          "showLine": true,
-          "iconColor": "#C0C6BE",
-          "lineColor": "rgba(32, 230, 25, 0.592157)",
-          "iconSize": 13,
-          "enable": true,
-          "tags": "deploys"
-        },
-        {
-          "name": "all restarts",
-          "type": "graphite metric",
-          "showLine": true,
-          "iconColor": "#FF2020",
-          "lineColor": "rgba(255, 32, 32, 0.592157)",
-          "iconSize": 13,
-          "enable": true,
-          "target": "substr(stats.govuk.app.*.restarts,3,5)"
-        }
-      ]
     }
   ],
   "nav": [


### PR DESCRIPTION
The annotations, which showed when deploys and application restarts
happen, made it more difficult to interpret the server uptime graphs.

Remove them.