### PR TITLE
Add environment variables for rummager S3 bucket

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -21,6 +21,7 @@ govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
 govuk::apps::mapit::enabled: true
 govuk::apps::publicapi::backdrop_host: 'www.preview.performance.service.gov.uk'
 govuk::apps::rummager::enable_publishing_api_document_indexer: true
+govuk::apps::rummager::aws_s3_bucket_name: govuk-api-elasticsearch-snapshots-integration
 govuk::apps::share_sale_publisher::enabled: true
 govuk::apps::smartanswers::expose_govspeak: true
 govuk::apps::specialist_publisher::publish_pre_production_finders: true

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -43,6 +43,7 @@ govuk::apps::errbit::errbit_email_from: 'govuk-winston+errbit-production@digital
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::publicapi::backdrop_host: 'www.performance.service.gov.uk'
 govuk::apps::publisher::data_import_passive_check: true
+govuk::apps::rummager::aws_s3_bucket_name: govuk-api-elasticsearch-snapshots-production
 govuk::apps::travel_advice_publisher::enable_email_alerts: true
 
 govuk::deploy::actionmailer_enable_delivery: true

--- a/modules/govuk/manifests/apps/rummager.pp
+++ b/modules/govuk/manifests/apps/rummager.pp
@@ -58,6 +58,8 @@ class govuk::apps::rummager(
   $publishing_api_bearer_token = undef,
   $aws_s3_key = undef,
   $aws_s3_secret = undef,
+  $aws_s3_bucket_name = undef,
+  $aws_s3_bucket_region = 'eu-west-1',
   $rabbitmq_hosts = ['localhost'],
   $rabbitmq_user = 'rummager',
   $rabbitmq_password = 'rummager',
@@ -122,5 +124,11 @@ class govuk::apps::rummager(
     "${title}-AWS_SECRET_ACCESS_KEY":
       varname => 'AWS_SECRET_ACCESS_KEY',
       value   => $aws_s3_secret;
+    "${title}-AWS_BUCKET_NAME":
+      varname => 'AWS_BUCKET_NAME',
+      value   => $aws_s3_bucket_name;
+    "${title}-AWS_BUCKET_REGION":
+      varname => 'AWS_BUCKET_REGION',
+      value   => $aws_s3_bucket_region;
   }
 }


### PR DESCRIPTION
Bucket name and region are defined per environment so we would prefer to
pass them to rummager rather than put them in config files.