### PR TITLE
Re-add multipage-frontend to deployable apps...

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -47,6 +47,7 @@ deployable_applications: &deployable_applications
   - mapit
   - maslow
   - metadata-api
+  - multipage-frontend
   - panopticon
   - performanceplatform-admin
   - performanceplatform-big-screen-view


### PR DESCRIPTION
Multipage frontend was removed or omitted in a recent de-dupe / sanitization of deployable apps so re-add it.