### PR TITLE
Cron job for creating snapshots & jenkins job for pruning old snapshots

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,6 +126,3 @@ DEPENDENCIES
   rspec-puppet
   sshkey (= 1.7.0)
   webmock (~> 1.20.0)
-
-BUNDLED WITH
-   1.10.5

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -21,6 +21,7 @@ govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
 govuk::apps::publicapi::backdrop_host: 'www.preview.performance.service.gov.uk'
 govuk::apps::rummager::enable_publishing_api_document_indexer: true
 govuk::apps::rummager::aws_s3_bucket_name: govuk-api-elasticsearch-snapshots-integration
+govuk::apps::rummager::snapshot::snapshot_enable: true
 govuk::apps::smartanswers::expose_govspeak: true
 govuk::apps::specialist_publisher::publish_pre_production_finders: true
 govuk::apps::sidekiq_monitoring::enabled: true

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -103,6 +103,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::network_config_deploy
   - govuk_jenkins::job::passive_checks
   - govuk_jenkins::job::performance_platform_smokey
+  - govuk_jenkins::job::prune_elasticsearch_snapshots
   - govuk_jenkins::job::run_rake_task
   - govuk_jenkins::job::run_whitehall_data_migrations
   - govuk_jenkins::job::sanitize_publishing_api_data

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -88,6 +88,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::network_config_deploy
   - govuk_jenkins::job::passive_checks
   - govuk_jenkins::job::performance_platform_smokey
+  - govuk_jenkins::job::prune_elasticsearch_snapshots
   - govuk_jenkins::job::run_govuk_complaint_rate_report
   - govuk_jenkins::job::run_rake_task
   - govuk_jenkins::job::run_whitehall_data_migrations

--- a/modules/govuk/manifests/apps/rummager/snapshot.pp
+++ b/modules/govuk/manifests/apps/rummager/snapshot.pp
@@ -1,0 +1,53 @@
+# == Class: govuk::apps::rummager::snapshot
+#
+# Run a script every 5 minutes to create repository (idempotent)
+# and take a search index snapshot.
+#
+# === Parameters
+#
+# [*snapshot_enable*]
+#   Whether to enable the cron job that takes search index snapshot
+#   Default: false
+#
+# [*snapshot_user*]
+#   User that runs the cron job
+#   Default: deploy
+#
+# [*snapshot_service_desc*]
+#   Service name to report to icinga
+#   Default: rummager-snapshot
+#
+
+class govuk::apps::rummager::snapshot (
+  $snapshot_enable = false,
+  $snapshot_user = 'deploy',
+  $snapshot_service_desc = 'rummager-snapshot',
+) {
+
+  $snapshot_ensure = $snapshot_enable ? {
+    true    => present,
+    default => absent,
+  }
+
+  file { '/etc/cron.d/snapshot':
+    ensure  => $snapshot_ensure,
+    mode    => '0755',
+    content => template('govuk/etc/cron.d/snapshot.erb'),
+  }
+
+  file { '/usr/local/bin/rummager-snapshot':
+    ensure  => $snapshot_ensure,
+    mode    => '0755',
+    content => template('govuk/usr/local/bin/rummager-snapshot.erb'),
+  }
+
+  $threshold_secs = 15 * 60
+
+  if $snapshot_enable {
+    @@icinga::passive_check { "check_rummager_snapshot_${::hostname}":
+      service_description => $snapshot_service_desc,
+      host_name           => $::fqdn,
+      freshness_threshold => $threshold_secs,
+    }
+  }
+}

--- a/modules/govuk/manifests/apps/rummager/snapshot.pp
+++ b/modules/govuk/manifests/apps/rummager/snapshot.pp
@@ -24,10 +24,17 @@ class govuk::apps::rummager::snapshot (
   $snapshot_service_desc = 'rummager-snapshot',
   $pruning_service_desc = 'rummager-pruning',
 ) {
+  $snapshot_lock_path = '/var/run/elasticsearch-snapshot.lock'
 
   $snapshot_ensure = $snapshot_enable ? {
     true    => present,
     default => absent,
+  }
+
+  file { $snapshot_lock_path:
+    ensure => present,
+    mode   => '0700',
+    owner  => $snapshot_user,
   }
 
   file { '/etc/cron.d/snapshot':

--- a/modules/govuk/manifests/apps/rummager/snapshot.pp
+++ b/modules/govuk/manifests/apps/rummager/snapshot.pp
@@ -22,6 +22,7 @@ class govuk::apps::rummager::snapshot (
   $snapshot_enable = false,
   $snapshot_user = 'deploy',
   $snapshot_service_desc = 'rummager-snapshot',
+  $pruning_service_desc = 'rummager-pruning',
 ) {
 
   $snapshot_ensure = $snapshot_enable ? {

--- a/modules/govuk/manifests/node/s_search.pp
+++ b/modules/govuk/manifests/node/s_search.pp
@@ -12,4 +12,10 @@ class govuk::node::s_search inherits govuk::node::s_base {
 
   # Local proxy for Rummager to access ES cluster.
   include govuk_elasticsearch::local_proxy
+
+  # Run a script every 5 minutes to create repository (idempotent)
+  # and take a search index snapshot.
+  if $::hostname == 'search-1' {
+    include govuk::apps::rummager::snapshot
+  }
 }

--- a/modules/govuk/templates/etc/cron.d/snapshot.erb
+++ b/modules/govuk/templates/etc/cron.d/snapshot.erb
@@ -1,1 +1,1 @@
-*/10 0-4,6-23 * * * <%= @snapshot_user %> /usr/local/bin/rummager-snapshot
+*/10 * * * * <%= @snapshot_user %> /usr/local/bin/rummager-snapshot

--- a/modules/govuk/templates/etc/cron.d/snapshot.erb
+++ b/modules/govuk/templates/etc/cron.d/snapshot.erb
@@ -1,0 +1,1 @@
+*/10 0-4,6-23 * * * <%= @snapshot_user %> /usr/local/bin/rummager-snapshot

--- a/modules/govuk/templates/usr/local/bin/rummager-snapshot.erb
+++ b/modules/govuk/templates/usr/local/bin/rummager-snapshot.erb
@@ -19,11 +19,14 @@ function send_nsca {
 trap send_nsca EXIT
 
 cd /var/apps/rummager
-OUTPUT=`RUMMAGER_INDEX=all /usr/local/bin/govuk_setenv rummager bundle exec rake rummager:snapshot:run`
+
+# "setlock -nx" forces the snapshot to be skipped if we cannot acquire the lock
+# "bundle exec keep-file-descriptors" is required for setlock to detect the lock is still in use
+OUTPUT=$(RUMMAGER_INDEX=all setlock -nx <%= snapshot_lock_path %> /usr/local/bin/govuk_setenv rummager bundle exec --keep-file-descriptors rake rummager:snapshot:run 2>&1)
 
 CODE=$?
 if [ "$OUTPUT" == "" ]; then
-  OUTPUT="rummager-snapshot script exited with no output"
+  OUTPUT="rummager-snapshot script exited with no output or couldn't acquire a lock"
 fi
 # Force everything that isn't OK to be a WARNING
 if [ $CODE -gt 0 ]; then

--- a/modules/govuk/templates/usr/local/bin/rummager-snapshot.erb
+++ b/modules/govuk/templates/usr/local/bin/rummager-snapshot.erb
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -u
+
+function send_nsca {
+    # unusual ${var+x} construct explained: http://stackoverflow.com/a/13864829
+    if [ -z ${CODE+x} ]; then
+        CODE=3
+        OUTPUT="UNKNOWN: rummager-snapshot script exited before seeder returned an exit code"
+    fi
+    # unusual ${var+x} construct explained: http://stackoverflow.com/a/13864829
+    if [ -z ${OUTPUT+x} ]; then
+        CODE=3
+        OUTPUT="UNKNOWN: rummager-snapshot exited before setting OUTPUT - this should never happen"
+    fi
+    printf "<%= @ipaddress %>\t<%= @snapshot_service_desc %>\t$CODE\t$OUTPUT\n" | /usr/sbin/send_nsca -H alert.cluster >/dev/null
+    exit $?
+}
+trap send_nsca EXIT
+
+cd /var/apps/rummager
+OUTPUT=`RUMMAGER_INDEX=all /usr/local/bin/govuk_setenv rummager bundle exec rake rummager:snapshot:run`
+
+CODE=$?
+if [ "$OUTPUT" == "" ]; then
+  OUTPUT="rummager-snapshot script exited with no output"
+fi
+# Force everything that isn't OK to be a WARNING
+if [ $CODE -gt 0 ]; then
+  CODE=1
+fi
+
+logger -p local3.info -t rummager-snapshot "$OUTPUT"

--- a/modules/govuk_jenkins/manifests/job/prune_elasticsearch_snapshots.pp
+++ b/modules/govuk_jenkins/manifests/job/prune_elasticsearch_snapshots.pp
@@ -1,0 +1,26 @@
+# == Class: govuk_jenkins::job::prune_elasticsearch_snapshots
+#
+# Delete old Elasticsearch snapshots
+#
+class govuk_jenkins::job::prune_elasticsearch_snapshots (
+    $app_domain = hiera('app_domain'),
+) {
+
+  $check_name = 'prune_elasticsearch_snapshots'
+  $service_description = 'Prune Elasticsearch snapshots'
+  $job_url = "https://deploy.${app_domain}/job/prune_elasticsearch_snapshots"
+
+  file { '/etc/jenkins_jobs/jobs/prune_elasticsearch_snapshots.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/prune_elasticsearch_snapshots.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+
+  $threshold_secs = 25 * 60 * 60
+
+  @@icinga::passive_check { "${check_name}_${::hostname}":
+    service_description => $service_description,
+    host_name           => $::fqdn,
+    freshness_threshold => $threshold_secs,
+  }
+}

--- a/modules/govuk_jenkins/manifests/job/prune_elasticsearch_snapshots.pp
+++ b/modules/govuk_jenkins/manifests/job/prune_elasticsearch_snapshots.pp
@@ -9,6 +9,7 @@ class govuk_jenkins::job::prune_elasticsearch_snapshots (
   $check_name = 'prune_elasticsearch_snapshots'
   $service_description = 'Prune Elasticsearch snapshots'
   $job_url = "https://deploy.${app_domain}/job/prune_elasticsearch_snapshots"
+  $snapshot_lock_path = '/var/run/elasticsearch-snapshot.lock'
 
   file { '/etc/jenkins_jobs/jobs/prune_elasticsearch_snapshots.yaml':
     ensure  => present,

--- a/modules/govuk_jenkins/templates/jobs/prune_elasticsearch_snapshots.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/prune_elasticsearch_snapshots.yaml.erb
@@ -1,0 +1,27 @@
+---
+- job:
+    name: prune-elasticsearch-snapshots
+    display-name: prune-elasticsearch-snapshots
+    project-type: freestyle
+    description: "<p>Delete old Elasticsearch snapshots</p>
+      <p>This is run to delete old (7 days) Elasticsearch snapshots.</p>"
+    builders:
+        - shell: |
+            ssh deploy@search-1.api '(cd /var/apps/rummager; RUMMAGER_INDEX=all govuk_setenv rummager bundle exec rake rummager:snapshot:clean)'
+    triggers:
+        - timed: '5 4 * * *' # 4:05
+    publishers:
+        - trigger-parameterized-builds:
+            - project: Success_Passive_Check
+              condition: 'SUCCESS'
+              predefined-parameters: |
+                  NSCA_CHECK_DESCRIPTION=<%= @service_description %>
+                  NSCA_OUTPUT=<%= @service_description %> success
+            - project: Failure_Passive_Check
+              condition: 'FAILED'
+              predefined-parameters: |
+                  NSCA_CHECK_DESCRIPTION=<%= @service_description %>
+                  NSCA_OUTPUT=<%= @service_description %> failed
+    wrappers:
+        - ansicolor:
+            colormap: xterm

--- a/modules/govuk_jenkins/templates/jobs/prune_elasticsearch_snapshots.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/prune_elasticsearch_snapshots.yaml.erb
@@ -7,7 +7,9 @@
       <p>This is run to delete old (7 days) Elasticsearch snapshots.</p>"
     builders:
         - shell: |
-            ssh deploy@search-1.api '(cd /var/apps/rummager; RUMMAGER_INDEX=all govuk_setenv rummager bundle exec rake rummager:snapshot:clean)'
+            # "setlock -N" blocks until the lock can be acquired
+            # "bundle exec keep-file-descriptors" is required for setlock to detect the lock is still in use
+            ssh deploy@search-1.api '(cd /var/apps/rummager; RUMMAGER_INDEX=all setlock -N <%= snapshot_lock_path %> govuk_setenv rummager bundle exec --keep-file-descriptors rake rummager:snapshot:clean)'
     triggers:
         - timed: '5 4 * * *' # 4:05
     publishers:


### PR DESCRIPTION
https://trello.com/c/YAJY2zIl/359-implement-snapshot-restore-to-backup-elasticsearch-indexes

Only enabled on integration for the time being. I'd like to leave this running there for a few days and make sure its stable.

The frequency of the snapshotting is still open to discussion. It's currently every 10m. I don't think the frequency of snapshots will affect the storage used but it could influence the time other snapshot operations take to complete. The plan is to prune old snapshots overnight, but I'm not sure how long this will take to run yet. There is some discussion of the issue here: http://grokbase.com/t/gg/elasticsearch/14b7wv8a6p/what-is-the-best-practice-for-periodic-snapshotting-with-awc-cloud-s3