### PR TITLE
Expose HTTP_USERNAME and HTTP_PASSWORD to service-manual-publisher

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -351,6 +351,9 @@ govuk::apps::publishing_api::db::backend_ip_range: "%{hiera('environment_ip_pref
 govuk::apps::rummager::nagios_memory_warning: 4600
 govuk::apps::rummager::nagios_memory_critical: 4900
 
+govuk::apps::service_manual_publisher::http_username: "%{hiera('http_username')}"
+govuk::apps::service_manual_publisher::http_password: "%{hiera('http_password')}"
+
 govuk::apps::service_manual_publisher::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 
 govuk::apps::signon::redis_url: "redis://redis-1.backend:6379/0"

--- a/modules/govuk/manifests/apps/service_manual_publisher.pp
+++ b/modules/govuk/manifests/apps/service_manual_publisher.pp
@@ -40,6 +40,14 @@
 #   The bearer token to use when communicating with Asset Manager.
 #   Default: undef
 #
+# [*http_username*]
+#   The http basic auth username when running on integration.
+#   Default: undef
+#
+# [*http_password*]
+#   The http basic auth password when running on integration.
+#   Default: undef
+#
 class govuk::apps::service_manual_publisher(
   $db_hostname = 'postgresql-primary-1.backend',
   $db_name = 'service-manual-publisher_production',
@@ -52,6 +60,8 @@ class govuk::apps::service_manual_publisher(
   $secret_key_base = undef,
   $publishing_api_bearer_token = undef,
   $asset_manager_bearer_token = undef,
+  $http_username = undef,
+  $http_password = undef,
 ) {
 
   include govuk_postgresql::client #installs libpq-dev package needed for pg gem
@@ -86,6 +96,12 @@ class govuk::apps::service_manual_publisher(
     "${title}-ASSET_MANAGER_BEARER_TOKEN":
       varname => 'ASSET_MANAGER_BEARER_TOKEN',
       value   => $asset_manager_bearer_token;
+    "${title}-HTTP_USERNAME":
+      varname => 'HTTP_USERNAME',
+      value   => $http_username;
+    "${title}-HTTP_PASSWORD":
+      varname => 'HTTP_PASSWORD',
+      value   => $http_password;
   }
 
   if $secret_key_base != undef {


### PR DESCRIPTION
This is so that we can hit www-origin servers from inside the app, with the
correct http basic auth:
https://github.com/alphagov/service-manual-publisher/pull/175