### PR TITLE
Use dedicated disk for Duplicity cache

### DIFF
--- a/hieradata/class/asset_slave.yaml
+++ b/hieradata/class/asset_slave.yaml
@@ -1,6 +1,6 @@
 ---
 
-backup::assets::archive_directory: '/mnt/uploads/.cache/duplicity/'
+backup::assets::archive_directory: '/mnt/duplicity-cache'
 
 govuk_safe_to_reboot::can_reboot: 'careful'
 govuk_safe_to_reboot::reason: 'Check that offsite sync job is not running before rebooting'
@@ -8,9 +8,13 @@ govuk_safe_to_reboot::reason: 'Check that offsite sync job is not running before
 lv:
   data:
     pv:
-        - '/dev/sdb1'
-        - '/dev/sdc1'
+      - '/dev/sdb1'
+      - '/dev/sdc1'
     vg: 'uploads'
+  cache:
+    pv:
+      - '/dev/sdd1'
+    vg: 'duplicity'
 
 mount:
   /mnt/uploads:
@@ -18,4 +22,10 @@ mount:
     govuk_lvm: 'data'
     mountoptions: 'defaults'
     percent_threshold_warning: 5
+    percent_threshold_critical: 2
+  /mnt/duplicity-cache:
+    disk: '/dev/mapper/duplicity-cache'
+    govuk_lvm: 'cache'
+    mountoptions: 'defaults'
+    percent_threshold_warning: 10 
     percent_threshold_critical: 2


### PR DESCRIPTION
Story: https://trello.com/c/S8B99y46/120-asset-slave-backups-no-longer-working

__Depends on: https://github.gds/gds/govuk-provisioning/pull/526__

Move the Duplicity cache onto its own disk, which will allow us to
monitor the disk space used by assets synced from the asset master
without the size of the cache directory interfering.

We perform offsite backups using Duplicity on the asset-slave-1
machines. Duplicity maintains a cache which is uses to know what is
already backed up when performing incremental backups. Otherwise, it
would have to retrieve the backups from the remote and decrypt them.

We recently started rsyncing /mnt/uploads from the asset-master-1 to
the asset-slaves and added an Icinga check (ee785db7) to ensure that the
free space on each machine corresponds (to confirm that the sync is
working correctly). Since the Duplicity cache directory exists on the
asset-slave but not the asset-master, this Icinga check is raising false
alarms.