### PR TITLE
Temporarily prevent application restarts

### DIFF
--- a/modules/govuk/manifests/app.pp
+++ b/modules/govuk/manifests/app.pp
@@ -343,7 +343,8 @@ define govuk::app (
 
   govuk::app::service { $title:
     ensure    => $ensure,
-    subscribe => Class['govuk::deploy'],
+    # FIXME: Uncomment once deployed
+    #subscribe => Class['govuk::deploy'],
   }
 
   $logstream_ensure = $ensure ? {


### PR DESCRIPTION
...while we deploy the changes in fc8532d8. Having all the applications
restart at once is too disruptive.

Once this is deployed, this line can be uncommented again.