### PR TITLE
Enable rummager message queue in production

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -43,6 +43,7 @@ govuk::apps::errbit::errbit_email_from: 'govuk-winston+errbit-production@digital
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::publicapi::backdrop_host: 'www.performance.service.gov.uk'
 govuk::apps::publisher::data_import_passive_check: true
+govuk::apps::rummager::enable_publishing_api_document_indexer: true
 govuk::apps::rummager::aws_s3_bucket_name: govuk-api-elasticsearch-snapshots-production
 govuk::apps::travel_advice_publisher::enable_email_alerts: true
 

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -16,6 +16,7 @@ govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::publicapi::backdrop_host: 'www.staging.performance.service.gov.uk'
 govuk::apps::sidekiq_monitoring::enabled: true
 govuk::apps::travel_advice_publisher::enable_email_alerts: true
+govuk::apps::rummager::enable_publishing_api_document_indexer: true
 
 govuk::deploy::aws_ses_smtp_host: 'email-smtp.eu-west-1.amazonaws.com'
 govuk::deploy::config::errbit_environment_name: 'staging'


### PR DESCRIPTION
This commit enables the Rummager message queue consumer in production and staging.

Trello: https://trello.com/c/lRnxI2x5