### PR TITLE
Enable MapIt in staging

### DIFF
--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -13,6 +13,7 @@ govuk::apps::content_register::db::backend_ip_range: '10.2.3.0/24'
 govuk::apps::email_alert_api::db::backend_ip_range: '10.2.3.0/24'
 govuk::apps::errbit::errbit_email_from: 'govuk-winston+errbit-staging@digital.cabinet-office.gov.uk'
 govuk::apps::hmrc_manuals_api::publish_topics: false
+govuk::apps::mapit::enabled: true
 govuk::apps::publicapi::backdrop_host: 'www.staging.performance.service.gov.uk'
 govuk::apps::sidekiq_monitoring::enabled: true
 govuk::apps::travel_advice_publisher::enable_email_alerts: true


### PR DESCRIPTION
New MapIt is currently enabled in integration, however it requires extra
configuration to be able to work in staging.