### PR TITLE
Offsite postgresql backups using WAL-E

### DIFF
--- a/hieradata/class/integration/transition_postgresql_master.yaml
+++ b/hieradata/class/integration/transition_postgresql_master.yaml
@@ -1,0 +1,1 @@
+govuk_postgresql::wal_e::backup::enabled: true

--- a/hieradata/vagrant.yaml
+++ b/hieradata/vagrant.yaml
@@ -157,6 +157,8 @@ govuk_postgresql::server::snakeoil_ssl_key: |
   vxBODhF5cvyO/S2jUuvApGU4dU2KULT5Dv3/Lh/Otg==
   -----END RSA PRIVATE KEY-----
 
+govuk_postgresql::wal_e::backup::enabled: true
+
 icinga::config::enable_event_handlers: true
 icinga::nginx::enable_basic_auth: false
 

--- a/hieradata/vagrant_credentials.yaml
+++ b/hieradata/vagrant_credentials.yaml
@@ -147,6 +147,11 @@ govuk_jenkins::ssh_key::public_key: |
 
 govuk_postgresql::env_sync_user::password: 'XB4MMvdTy0nU/AeoygnPuYGAabiSihUHif3BPP0SjIM='
 
+govuk_postgresql::wal_e::backup::aws_access_key_id: '123456789'
+govuk_postgresql::wal_e::backup::aws_secret_access_key: 'thisisafakekey'
+govuk_postgresql::wal_e::backup::s3_bucket_url: 's3://foo/bar'
+govuk_postgresql::wal_e::backup::enabled: true
+
 govuk_rabbitmq::monitoring_password: monitoring
 govuk_rabbitmq::root_password: root
 

--- a/hieradata/vagrant_credentials.yaml
+++ b/hieradata/vagrant_credentials.yaml
@@ -150,7 +150,6 @@ govuk_postgresql::env_sync_user::password: 'XB4MMvdTy0nU/AeoygnPuYGAabiSihUHif3B
 govuk_postgresql::wal_e::backup::aws_access_key_id: '123456789'
 govuk_postgresql::wal_e::backup::aws_secret_access_key: 'thisisafakekey'
 govuk_postgresql::wal_e::backup::s3_bucket_url: 's3://foo/bar'
-govuk_postgresql::wal_e::backup::enabled: true
 
 govuk_rabbitmq::monitoring_password: monitoring
 govuk_rabbitmq::root_password: root

--- a/modules/govuk_postgresql/manifests/backup.pp
+++ b/modules/govuk_postgresql/manifests/backup.pp
@@ -34,4 +34,7 @@ class govuk_postgresql::backup {
         source => 'puppet:///modules/govuk_postgresql/etc/postgresql-backup-pre',
     }
 
+    # Include offsite backups to S3
+    include govuk_postgresql::wal_e::backup
+
 }

--- a/modules/govuk_postgresql/manifests/wal_e/backup.pp
+++ b/modules/govuk_postgresql/manifests/wal_e/backup.pp
@@ -1,0 +1,176 @@
+# == Class: Govuk_postgresql::Wal_e::Backup
+#
+# Creates an offsite backup of a chosen PostgreSQL database
+# to an S3 bucket using WAL-E:
+# https://github.com/wal-e/wal-e
+#
+# === Parameters:
+#
+# [*aws_access_key_id*]
+#   The AWS access ID for the user that is allowed to
+#   access the S3 bucket.
+#
+# [*aws_secret_access_key*]
+#   The AWS secret access key for the user that is allowed
+#   to access the S3 bucket.
+#
+# [*s3_bucket_url*]
+#   The unique address of the S3 bucket, in the format of:
+#   s3://bucketaddress/directory/foo
+#
+# [*aws_region*]
+#   The AWS region where the specified bucket resides.
+#   Default: eu-west-1
+#
+# [*wale_private_gpg_key*]
+#   The private GPG to import to allow encryption. If present, WAL-E will
+#   will encrypt the backups.
+#
+# [*wale_private_gpg_key_fingerprint*]
+#   The GPG key fingerprint for the above GPG key.
+#
+# [*hour*]
+#   The hour(s) the daily base backup cron job runs.
+#   Default: 6
+#
+# [*minute*]
+#   The minute(s) the daily base backup cron job runs.
+#   Default: 20
+#
+# [*db_dir*]
+#   The database directory to backup. WAL-E does hot backups
+#   so there should be no impact, and the default backups up
+#   everything.
+#   Default: /var/lib/postgresql/9.3/main
+#
+# [*enabled*]
+#   Whether or not to enable WAL-E backups to S3.
+#
+
+class govuk_postgresql::wal_e::backup (
+  $aws_access_key_id = undef,
+  $aws_secret_access_key = undef,
+  $s3_bucket_url = undef,
+  $aws_region = 'eu-west-1',
+  $wale_private_gpg_key = undef,
+  $wale_private_gpg_key_fingerprint = undef,
+  $hour = 6,
+  $minute = 20,
+  $db_dir = '/var/lib/postgresql/9.3/main',
+  $enabled = false,
+) {
+  if $enabled {
+    include govuk_postgresql::wal_e::package
+
+    # Continuous archiving to S3
+    postgresql::server::config_entry {
+      'archive_mode':
+        value => 'on';
+      'archive_command':
+        value => 'envdir /etc/wal-e/env.d /usr/local/bin/wal-e wal-push %p';
+      'archive_timeout':
+        value => '60';
+    }
+
+    file { [ '/etc/wal-e', '/etc/wal-e/env.d' ]:
+      ensure => directory,
+      owner  => 'postgres',
+      group  => 'postgres',
+      mode   => '0775',
+    }
+
+    file { '/etc/wal-e/env.d/AWS_SECRET_ACCESS_KEY':
+      content => $aws_secret_access_key,
+      owner   => 'postgres',
+      group   => 'postgres',
+      mode    => '0660',
+    }
+
+    file { '/etc/wal-e/env.d/AWS_ACCESS_KEY_ID':
+      content => $aws_access_key_id,
+      owner   => 'postgres',
+      group   => 'postgres',
+      mode    => '0660',
+    }
+
+    file { '/etc/wal-e/env.d/WALE_S3_PREFIX':
+      content => $s3_bucket_url,
+      owner   => 'postgres',
+      group   => 'postgres',
+      mode    => '0660',
+    }
+
+    file { '/etc/wal-e/env.d/AWS_REGION':
+      content => $aws_region,
+      owner   => 'postgres',
+      group   => 'postgres',
+      mode    => '0660',
+    }
+
+    if $wale_private_gpg_key and $wale_private_gpg_key_fingerprint {
+      validate_re($wale_private_gpg_key_fingerprint, '^[[:alnum:]]{40}$', 'Must supply full GPG fingerprint')
+
+      file { '/etc/wal-e/env.d/WALE_GPG_KEY_ID':
+        content => $wale_private_gpg_key_fingerprint,
+        owner   => 'postgres',
+        group   => 'postgres',
+        mode    => '0660',
+      }
+
+      file { '/var/lib/postgresql/.gnupg':
+        ensure => directory,
+        mode   => '0700',
+        owner  => 'postgres',
+        group  => 'postgres',
+      }
+
+      # This ensures that stuff can be encrypted without prompt
+      file { '/var/lib/postgresql/.gnupg/gpg.conf':
+        ensure  => present,
+        content => 'trust-model always',
+        mode    => '0600',
+        owner   => 'postgres',
+        group   => 'postgres',
+      }
+
+      file { "/var/lib/postgresql/.gnupg/${wale_private_gpg_key_fingerprint}_secret_key.asc":
+        ensure  => present,
+        mode    => '0600',
+        content => $wale_private_gpg_key,
+        owner   => 'postgres',
+        group   => 'postgres',
+      }
+
+      exec { 'import_gpg_secret_key':
+        command     => "gpg --batch --delete-secret-and-public-key ${wale_private_gpg_key_fingerprint}; gpg --allow-secret-key-import --import /var/lib/postgresql/.gnupg/${wale_private_gpg_key_fingerprint}_secret_key.asc",
+        user        => 'postgres',
+        group       => 'postgres',
+        subscribe   => File["/var/lib/postgresql/.gnupg/${wale_private_gpg_key_fingerprint}_secret_key.asc"],
+        refreshonly => true,
+      }
+    }
+
+    # Daily base backup
+    file { '/etc/cron.d/wal-e_postgres_base_backup_push_cron':
+      ensure  => present,
+      content => template('govuk_postgresql/etc/cron.d/wal-e_postgres_backup_push_cron.erb'),
+      mode    => '0775',
+    }
+
+    file { '/usr/local/bin/wal-e_postgres_base_backup_push':
+      ensure  => present,
+      content => template('govuk_postgresql/usr/local/bin/wal-e_postgres_backup_push.erb'),
+      mode    => '0775',
+      require => Class['govuk_postgresql::wal_e::package'],
+    }
+
+    $threshold_secs = 28 * 3600
+    $service_desc = 'PostgreSQL WAL-E base backup push'
+
+    @@icinga::passive_check { "check_wale_base_backup_push-${::hostname}":
+        service_description => $service_desc,
+        freshness_threshold => $threshold_secs,
+        host_name           => $::fqdn,
+      }
+  }
+}

--- a/modules/govuk_postgresql/manifests/wal_e/package.pp
+++ b/modules/govuk_postgresql/manifests/wal_e/package.pp
@@ -1,0 +1,32 @@
+# == Class: Govuk_postgresql::Wal_e::Package
+#
+# This class installs the WAL-E package and dependencies
+#
+class govuk_postgresql::wal_e::package {
+  package { 'wal-e':
+    ensure   => present,
+    provider => pip,
+    require  => Class['govuk_postgresql::server'],
+  }
+
+  $dependencies = [
+    'lzop',
+  ]
+
+  package { $dependencies:
+    ensure => present,
+  }
+
+  # pip should take care of version deps but we need to manually upgrade
+  # a couple of things
+
+  $pip_deps = [
+    'requests',
+    'six',
+  ]
+
+  package { $pip_deps:
+    ensure   => latest,
+    provider => pip,
+  }
+}

--- a/modules/govuk_postgresql/spec/classes/govuk_postgresql__wale_backup_spec.rb
+++ b/modules/govuk_postgresql/spec/classes/govuk_postgresql__wale_backup_spec.rb
@@ -1,0 +1,39 @@
+require_relative '../../../../spec_helper'
+
+describe 'govuk_postgresql::wal_e::backup', :type => :class do
+  let(:default_params) {{
+    :aws_access_key_id     => 'tom-jones',
+    :aws_secret_access_key => 'its-not-unusual',
+    :s3_bucket_url         => 's3://foo/bar',
+    :aws_region            => 'eu-west-1',
+  }}
+
+  context 'WAL-E backups enabled' do
+    let(:params) { default_params.merge({
+      :enabled                => true,
+    })}
+
+    it { is_expected.to contain_file('/etc/wal-e/').with_ensure('directory') }
+    it { is_expected.to contain_file('/etc/wal-e/env.d').with_ensure('directory') }
+    it { is_expected.to contain_file('/etc/wal-e/env.d/AWS_SECRET_ACCESS_KEY').with_content(/its-not-unusual/) }
+    it { is_expected.to contain_file('/etc/wal-e/env.d/AWS_ACCESS_KEY_ID').with_content(/tom-jones/) }
+    it { is_expected.to contain_file('/etc/wal-e/env.d/WALE_S3_PREFIX').with_content(/s3:\/\/foo\/bar/) }
+    it { is_expected.to contain_file('/etc/wal-e/env.d/AWS_REGION').with_content(/eu-west-1/) }
+  end
+
+  context 'WAL-E backups enabled and GPG key is defined' do
+    let(:params) { default_params.merge({
+      :enabled                          => true,
+      :wale_private_gpg_key             => 'i-key-therefore-i-am',
+      :wale_private_gpg_key_fingerprint => 'ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMN',
+    })}
+
+    it { is_expected.to contain_file('/etc/wal-e/env.d/WALE_GPG_KEY_ID').with_content(/ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMN/) }
+    it { is_expected.to contain_file('/var/lib/postgresql/.gnupg').with_ensure('directory') }
+    it { is_expected.to contain_file('/var/lib/postgresql/.gnupg/gpg.conf').with_content(/trust-model\ always/) }
+    it { is_expected.to contain_file('/var/lib/postgresql/.gnupg/ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMN_secret_key.asc').with_content('i-key-therefore-i-am') }
+    it { is_expected.to contain_exec('import_gpg_secret_key')
+         .with_refreshonly(true)
+    }
+  end
+end

--- a/modules/govuk_postgresql/templates/etc/cron.d/wal-e_postgres_backup_push_cron.erb
+++ b/modules/govuk_postgresql/templates/etc/cron.d/wal-e_postgres_backup_push_cron.erb
@@ -1,0 +1,2 @@
+MAILTO='root'
+<%= @minute %> <%= @hour %> * * * postgres /usr/local/bin/wal-e_postgres_backup_push

--- a/modules/govuk_postgresql/templates/etc/cron.d/wal-e_postgres_backup_push_cron.erb
+++ b/modules/govuk_postgresql/templates/etc/cron.d/wal-e_postgres_backup_push_cron.erb
@@ -1,2 +1,2 @@
-MAILTO='root'
+MAILTO=""
 <%= @minute %> <%= @hour %> * * * postgres /usr/local/bin/wal-e_postgres_backup_push

--- a/modules/govuk_postgresql/templates/usr/local/bin/wal-e_postgres_backup_push.erb
+++ b/modules/govuk_postgresql/templates/usr/local/bin/wal-e_postgres_backup_push.erb
@@ -2,6 +2,9 @@
 
 set -e
 
+# Redirect stdout and stderr to syslog
+exec 1> >(/usr/bin/logger -s -t $(basename $0)) 2>&1
+
 # The default Icinga passive alert assumes that the script failed
 NAGIOS_CODE=2
 NAGIOS_MESSAGE="CRITICAL: PostgreSQL WAL-E backup push to S3 failed"

--- a/modules/govuk_postgresql/templates/usr/local/bin/wal-e_postgres_backup_push.erb
+++ b/modules/govuk_postgresql/templates/usr/local/bin/wal-e_postgres_backup_push.erb
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -e
+
+# The default Icinga passive alert assumes that the script failed
+NAGIOS_CODE=2
+NAGIOS_MESSAGE="CRITICAL: PostgreSQL WAL-E backup push to S3 failed"
+
+# Triggered whenever this script exits, successful or otherwise. The values
+# of CODE/MESSAGE will be taken from that point in time.
+function nagios_passive () {
+  printf "<%= @ipaddress %>\t<%= @service_desc %>\t${NAGIOS_CODE}\t${NAGIOS_MESSAGE}\n" | /usr/sbin/send_nsca -H alert.cluster >/dev/null
+}
+
+trap nagios_passive EXIT
+
+envdir /etc/wal-e/env.d /usr/local/bin/wal-e backup-push <%= @db_dir %>
+
+if [ $? == 0 ]
+  then
+    STATUS=0
+  else
+    STATUS=1
+fi
+
+if [ $STATUS -eq 0 ]; then
+  NAGIOS_CODE=0
+  NAGIOS_MESSAGE="OK: PostgreSQL WAL-E backup push to S3 succeeded"
+fi
+
+exit $STATUS


### PR DESCRIPTION
This PR strives to allow encrypted offsite backups to an S3 bucket, along with continuous archiving that also helps us with DR purposes.

Story: https://trello.com/c/sozQLBHM/42-spike-end-to-end-backup-procedure-for-bouncer

WAL-E: https://github.com/wal-e/wal-e

I have successfully tested this in Vagrant. The bucket in Integration has been deployed [from this change](https://github.com/alphagov/govuk-terraform-provisioning/pull/26).

Would love to hear some critical opinion on this!