### PR TITLE
Add all our built rubies to the monitoring host

### DIFF
--- a/modules/govuk/manifests/node/s_monitoring.pp
+++ b/modules/govuk/manifests/node/s_monitoring.pp
@@ -17,6 +17,7 @@ class govuk::node::s_monitoring (
 
   validate_bool($enable_fastly_metrics, $offsite_backups)
 
+  include govuk_rbenv::all
   include monitoring
 
   if $enable_fastly_metrics {


### PR DESCRIPTION
Smokey needs newer rubies and developers assume we have the
latest and greatest inline with the versions applications use.
This should suffice until we agree and merge the refactored
hieradata/application approach.