### PR TITLE
Improve ClamAV freshness monitoring

### DIFF
--- a/modules/clamav/files/usr/local/bin/check_clamav_definitions
+++ b/modules/clamav/files/usr/local/bin/check_clamav_definitions
@@ -1,26 +1,15 @@
-#!/bin/bash
+#!/usr/bin/env ruby
 
-set -euo pipefail
+clamscan_version = `/usr/bin/clamscan --version`.strip
+clamscan_dns = `/usr/bin/dig +short -t txt current.cvd.clamav.net`.gsub('"', '').strip
 
-if [[ $# -ne 2 ]]
-then
-  echo "Usage: check_clamav_definitions [warning] [critical]"
-  exit 1
-fi
+current_version = clamscan_version.split('/', 3)[1].to_i
+latest_version = clamscan_dns.split(':', 8)[2].to_i
 
-WARNING_THRESHOLD=$1
-CRITICAL_THRESHOLD=$2
+versions_behind = latest_version - current_version
 
-if [ -f "/var/lib/clamav/daily.cld" ]
-then
-  CLAM_FILE="/var/lib/clamav/daily.cld"
-elif [ -f "/var/lib/clamav/daily.cvd" ]
-then
-  CLAM_FILE="/var/lib/clamav/daily.cvd"
-else
-  echo "Neither daily.cld nor daily.cvd exist, so exiting with critical."
-  exit 2
-fi
-
-/usr/lib/nagios/plugins/check_file_age -f "${CLAM_FILE}" \
-  -w${WARNING_THRESHOLD} -c${CRITICAL_THRESHOLD}
+if versions_behind < 0
+  raise 'Error parsing ClamAV definition versions'
+elsif versions_behind > 2
+  raise 'ClamAV database is out-of-date'
+end

--- a/modules/clamav/manifests/monitoring.pp
+++ b/modules/clamav/manifests/monitoring.pp
@@ -7,9 +7,6 @@
 # There are other definition files but this is a good canary.
 #
 class clamav::monitoring {
-  # Convert days to seconds.
-  $warning_age = 2 * (24 * 60 * 60)
-
   file { '/usr/local/bin/check_clamav_definitions':
     ensure => present,
     source => 'puppet:///modules/clamav/usr/local/bin/check_clamav_definitions',
@@ -24,7 +21,7 @@ class clamav::monitoring {
   }
 
   @@icinga::check { "check_clamav_definitions_${::hostname}":
-    check_command       => "check_nrpe!check_clamav_definitions!${warning_age} 0",
+    check_command       => 'check_nrpe_1arg!check_clamav_definitions',
     service_description => 'clamav definitions out of date',
     host_name           => $::fqdn,
     notes_url           => monitoring_docs_url(clamav-definitions-out-of-date),


### PR DESCRIPTION
Instead of monitoring the age of the file (which is frequently broken for example because the file isn't updated) we should check the value that ClamAV publish over DNS and make sure it isn't too out-of-date.

Being a version behind should be ok.