### PR TITLE
Disable rummager message queue in production

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -43,7 +43,6 @@ govuk::apps::errbit::errbit_email_from: 'govuk-winston+errbit-production@digital
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::publicapi::backdrop_host: 'www.performance.service.gov.uk'
 govuk::apps::publisher::data_import_passive_check: true
-govuk::apps::rummager::enable_publishing_api_document_indexer: true
 govuk::apps::rummager::aws_s3_bucket_name: govuk-api-elasticsearch-snapshots-production
 govuk::apps::travel_advice_publisher::enable_email_alerts: true
 

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -17,7 +17,6 @@ govuk::apps::mapit::enabled: true
 govuk::apps::publicapi::backdrop_host: 'www.staging.performance.service.gov.uk'
 govuk::apps::sidekiq_monitoring::enabled: true
 govuk::apps::travel_advice_publisher::enable_email_alerts: true
-govuk::apps::rummager::enable_publishing_api_document_indexer: true
 
 govuk::deploy::aws_ses_smtp_host: 'email-smtp.eu-west-1.amazonaws.com'
 govuk::deploy::config::errbit_environment_name: 'staging'


### PR DESCRIPTION
This PR reverts alphagov/govuk-puppet#4206.

We are experiencing difficulties on production with the message queue consumer. It seems the indexing of the messages is generating too much load on elasticsearch, causing other (more important) processes to error as well.

We'd like to disable the indexing until we've replicated the issue on integration, established a root cause and have proper monitoring in place.