### PR TITLE
New frontend service-manual-frontend

### DIFF
--- a/hieradata/class/draft_frontend.yaml
+++ b/hieradata/class/draft_frontend.yaml
@@ -6,6 +6,7 @@ govuk::apps::email_alert_frontend::vhost: 'draft-email-alert-frontend'
 govuk::apps::government_frontend::vhost: 'draft-government-frontend'
 govuk::apps::manuals_frontend::vhost: 'draft-manuals-frontend'
 govuk::apps::multipage_frontend::vhost: 'draft-multipage-frontend'
+govuk::apps::service_manual_frontend::vhost: 'draft-service-manual-frontend'
 govuk::apps::specialist_frontend::vhost: 'draft-specialist-frontend'
 
 govuk::apps::static::draft_environment: true
@@ -29,5 +30,6 @@ govuk::node::s_base::apps:
  - government_frontend
  - manuals_frontend
  - multipage_frontend
+ - service_manual_frontend
  - specialist_frontend
  - static

--- a/hieradata/class/frontend.yaml
+++ b/hieradata/class/frontend.yaml
@@ -12,6 +12,7 @@ govuk::node::s_base::apps:
   - info_frontend
   - manuals_frontend
   - multipage_frontend
+  - service_manual_frontend
   - specialist_frontend
   - static
 

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -62,6 +62,7 @@ deployable_applications: &deployable_applications
   - router-api
   - rummager
   - search-admin
+  - service-manual-frontend
   - service-manual-publisher
   - share-sale-publisher
   - short-url-manager
@@ -817,6 +818,7 @@ hosts::production::frontend::app_hostnames:
   - 'draft-email-campaign-frontend'
   - 'draft-government-frontend'
   - 'draft-manuals-frontend'
+  - 'draft-service-manual-frontend'
   - 'draft-specialist-frontend'
   - 'draft-static'
   - 'email-campaign-frontend'
@@ -833,6 +835,7 @@ hosts::production::frontend::app_hostnames:
   - 'publicapi'
   - 'public-event-store'
   - 'service-manual'
+  - 'service-manual-frontend'
   - 'smartanswers'
   - 'spotlight'
   - 'specialist-frontend'
@@ -1127,6 +1130,7 @@ router::assets_origin::asset_routes:
   '/manuals-frontend/': "manuals-frontend"
   '/multipage-frontend/': "multipage-frontend"
   '/licencefinder/': "licencefinder"
+  '/service-manual-frontend/': "service-manual-frontend"
   '/smartanswers/': "smartanswers"
   '/specialist-frontend/': "specialist-frontend"
   '/spotlight/': "spotlight"

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -293,6 +293,7 @@ hosts::development::apps:
   - 'search'
   - 'search-admin'
   - 'service-manual'
+  - 'service-manual-frontend'
   - 'service-manual-publisher'
   - 'share-sale-publisher'
   - 'short-url-manager'

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -22,6 +22,7 @@ govuk::apps::local_links_manager::enabled: true
 govuk::apps::publicapi::backdrop_host: 'www.preview.performance.service.gov.uk'
 govuk::apps::rummager::enable_publishing_api_document_indexer: false
 govuk::apps::rummager::aws_s3_bucket_name: govuk-api-elasticsearch-snapshots-integration
+govuk::apps::service_manual_frontend::enabled: true
 govuk::apps::smartanswers::expose_govspeak: true
 govuk::apps::specialist_publisher::publish_pre_production_finders: true
 govuk::apps::specialist_publisher_rebuild::enabled: true

--- a/modules/govuk/manifests/apps/service_manual_frontend.pp
+++ b/modules/govuk/manifests/apps/service_manual_frontend.pp
@@ -11,10 +11,25 @@
 # [*port*]
 #   What port should the app run on?
 #
+# [*enabled*]
+#   Is the app enabled
+#
+# [*errbit_api_key*]
+#   Errbit API key used by airbrake
+#   Default: ''
+#
+# [*secret_key_base*]
+#   Used to set the app ENV var SECRET_KEY_BASE which is used to configure
+#   rails 4.x signed cookie mechanism. If unset the app will be unable to
+#   start.
+#   Default: undef
+#
 class govuk::apps::service_manual_frontend(
   $vhost = 'service-manual-frontend',
   $port = 3122,
   $enabled = false,
+  $errbit_api_key = undef,
+  $secret_key_base = undef,
 ) {
   if $enabled {
     Govuk::App::Envvar {
@@ -30,6 +45,15 @@ class govuk::apps::service_manual_frontend(
       asset_pipeline        => true,
       asset_pipeline_prefix => 'service-manual-frontend',
       vhost                 => $vhost,
+    }
+
+    govuk::app::envvar {
+      "${title}-ERRBIT_API_KEY":
+        varname => 'ERRBIT_API_KEY',
+        value   => $errbit_api_key;
+      "${title}-SECRET_KEY_BASE":
+        varname => 'SECRET_KEY_BASE',
+        value   => $secret_key_base;
     }
   }
 }

--- a/modules/govuk/manifests/apps/service_manual_frontend.pp
+++ b/modules/govuk/manifests/apps/service_manual_frontend.pp
@@ -13,7 +13,7 @@
 #
 class govuk::apps::service_manual_frontend(
   $vhost = 'service-manual-frontend',
-  $port = '3090',
+  $port = 3122,
 ) {
   Govuk::App::Envvar {
     app => 'service-manual-frontend',

--- a/modules/govuk/manifests/apps/service_manual_frontend.pp
+++ b/modules/govuk/manifests/apps/service_manual_frontend.pp
@@ -1,0 +1,32 @@
+# == Class: govuk::apps::service_manual_frontend
+#
+# Service Manual Frontend is an app to serve content pages for the service manual from the content store
+#
+# === Parameters
+#
+# [*vhost*]
+#   Virtual host used by the application.
+#   Default: 'service-manual-frontend'
+#
+# [*port*]
+#   What port should the app run on?
+#
+class govuk::apps::service_manual_frontend(
+  $vhost = 'service-manual-frontend',
+  $port = '3090',
+) {
+  Govuk::App::Envvar {
+    app => 'service-manual-frontend',
+  }
+
+  govuk::app { 'service-manual-frontend':
+    app_type              => 'rack',
+    port                  => $port,
+    vhost_ssl_only        => true,
+    health_check_path     => '/healthcheck',
+    legacy_logging        => false,
+    asset_pipeline        => true,
+    asset_pipeline_prefix => 'service-manual-frontend',
+    vhost                 => $vhost,
+  }
+}

--- a/modules/govuk/manifests/apps/service_manual_frontend.pp
+++ b/modules/govuk/manifests/apps/service_manual_frontend.pp
@@ -14,19 +14,22 @@
 class govuk::apps::service_manual_frontend(
   $vhost = 'service-manual-frontend',
   $port = 3122,
+  $enabled = false,
 ) {
-  Govuk::App::Envvar {
-    app => 'service-manual-frontend',
-  }
+  if $enabled {
+    Govuk::App::Envvar {
+      app => 'service-manual-frontend',
+    }
 
-  govuk::app { 'service-manual-frontend':
-    app_type              => 'rack',
-    port                  => $port,
-    vhost_ssl_only        => true,
-    health_check_path     => '/healthcheck',
-    legacy_logging        => false,
-    asset_pipeline        => true,
-    asset_pipeline_prefix => 'service-manual-frontend',
-    vhost                 => $vhost,
+    govuk::app { 'service-manual-frontend':
+      app_type              => 'rack',
+      port                  => $port,
+      vhost_ssl_only        => true,
+      health_check_path     => '/healthcheck',
+      legacy_logging        => false,
+      asset_pipeline        => true,
+      asset_pipeline_prefix => 'service-manual-frontend',
+      vhost                 => $vhost,
+    }
   }
 }

--- a/modules/govuk/manifests/node/s_frontend_lb.pp
+++ b/modules/govuk/manifests/node/s_frontend_lb.pp
@@ -26,6 +26,7 @@ class govuk::node::s_frontend_lb (
       'draft-government-frontend',
       'draft-manuals-frontend',
       'draft-multipage-frontend',
+      'draft-service-manual-frontend',
       'draft-specialist-frontend',
       'draft-static',
     ]:
@@ -44,6 +45,7 @@ class govuk::node::s_frontend_lb (
       'manuals-frontend',
       'multipage-frontend',
       'service-manual',
+      'service-manual-frontend',
       'specialist-frontend',
       'static',
     ]:


### PR DESCRIPTION
We are adding a new frontend, service-manual-frontend, which mimics government-frontend.

https://github.com/alphagov/service-manual-frontend is a fork of government-frontend and we are in the process of stripping out the non-service manual related stuff.