### PR TITLE
Rework transition manifest to be more modern

### DIFF
--- a/modules/govuk/manifests/apps/transition.pp
+++ b/modules/govuk/manifests/apps/transition.pp
@@ -1,16 +1,52 @@
-# FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
-class govuk::apps::transition( $port = '3044', $enable_procfile_worker = true ) {
+# == Class: govuk::apps::transition
+#
+# Managing mappings (eg redirects) for sites moving to GOV.UK.
+#
+# === Parameters
+#
+# [*port*]
+#   The port that transition is served on.
+#   Default: 3044
+#
+# [*enable_procfile_worker*]
+#   Whether to enable the procfile worker
+#   Default: true
+#
+# [*secret_key_base*]
+#   The key for Rails to use when signing/encrypting sessions.
+#
+class govuk::apps::transition(
+  $port = '3044',
+  $enable_procfile_worker = true,
+  $secret_key_base = undef
+) {
+  $app_name = 'transition'
+
   include govuk_postgresql::client
-  govuk::app { 'transition':
+  govuk::app { $app_name:
     app_type           => 'rack',
     port               => $port,
     vhost_ssl_only     => true,
     health_check_path  => '/',
     log_format_is_json => true,
     deny_framing       => true,
+    asset_pipeline     => true,
   }
 
-  govuk::procfile::worker {'transition':
+  govuk::procfile::worker { $app_name:
     enable_service => $enable_procfile_worker,
   }
+
+  Govuk::App::Envvar {
+    app => $app_name,
+  }
+
+  if $secret_key_base {
+    govuk::app::envvar {
+      "${title}-SECRET_KEY_BASE":
+        varname => 'SECRET_KEY_BASE',
+        value   => $secret_key_base;
+    }
+  }
+
 }


### PR DESCRIPTION
Mostly this is so we get the secret_key_base into env to match up with
how rails 4.1+ apps expect secrets to be delivered.  We also enable
asset_pipeline because it seems that other backend apps with UI (e.g.
publisher) have this.

This is required for https://github.com/alphagov/transition/pull/508 and will require deployment changes to support it (https://github.gds/gds/deployment/pull/934).