### PR TITLE
Upgrade logs-elasticsearch to 1.5.2 in integration

### DIFF
--- a/hieradata/class/integration/logs_elasticsearch.yaml
+++ b/hieradata/class/integration/logs_elasticsearch.yaml
@@ -1,0 +1,3 @@
+---
+
+govuk_elasticsearch::version: '1.5.2'

--- a/modules/backup/manifests/offsite/job.pp
+++ b/modules/backup/manifests/offsite/job.pp
@@ -1,4 +1,4 @@
-# == Define: backup::assets::job
+# == Define: backup::offsite::job
 #
 # Setup and monitor a duplicity job for offsite backups.
 #

--- a/modules/govuk/manifests/node/s_apt.pp
+++ b/modules/govuk/manifests/node/s_apt.pp
@@ -62,6 +62,10 @@ class govuk::node::s_apt (
       location => 'http://packages.elasticsearch.org/elasticsearch/1.4/debian',
       release  => 'stable',
       key      => 'D88E42B4';
+    'elasticsearch-1.5':
+      location => 'http://packages.elastic.co/elasticsearch/1.5/debian',
+      release  => 'stable',
+      key      => '46095ACC8548582C1A2699A9D27D666CD88E42B4';
     'rabbitmq':
       location => 'http://www.rabbitmq.com/debian',
       release  => 'testing',


### PR DESCRIPTION
Our logs-elasticsearch cluster is running a version of Elasticsearch which is quite old. I'd like to try upgrading to 1.5.2 first because I don't have much experience with Elasticsearch.

[Upgrading instructions](https://www.elastic.co/guide/en/elasticsearch/reference/current/setup-upgrade.html)

[Breaking changes doc](https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes.html) (there are no breaking changes from 1.4 to 1.5).

## Todo

- [ ] Mirror this release with aptly for integration