### PR TITLE
Upgrade Puppet to 3.8.5 in integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem "rake"
 gem "puppet-syntax", '2.1.0'
 gem "puppet-lint"
 gem 'puppet-lint-trailing_comma-check', :require => false
-gem "puppet", '3.6.2'
+gem "puppet", '3.8.5'
 gem 'facter', '1.7.5'
 gem "hiera", "1.3.4"
 gem "hiera-eyaml-gpg", :git => 'git://github.com/alphagov/hiera-eyaml-gpg.git', :branch => 'avoid_gpghome_env_var'

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem "puppet-syntax", '2.1.0'
 gem "puppet-lint"
 gem 'puppet-lint-trailing_comma-check', :require => false
 gem "puppet", '3.8.5'
-gem 'facter', '1.7.5'
+gem 'facter', '2.0.2'
 gem "hiera", "1.3.4"
 gem "hiera-eyaml-gpg", :git => 'git://github.com/alphagov/hiera-eyaml-gpg.git', :branch => 'avoid_gpghome_env_var'
 gem "rspec-puppet"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,6 +10,7 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
+    CFPropertyList (2.2.8)
     activemodel (4.1.8)
       activesupport (= 4.1.8)
       builder (~> 3.1)
@@ -24,7 +25,8 @@ GEM
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
-    facter (1.7.5)
+    facter (2.0.2)
+      CFPropertyList (~> 2.2.6)
     faraday (0.9.0)
       multipart-post (>= 1.2, < 3)
     gpgme (2.0.8)
@@ -109,7 +111,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  facter (= 1.7.5)
+  facter (= 2.0.2)
   hiera (= 1.3.4)
   hiera-eyaml-gpg!
   librarian-puppet

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,7 +42,7 @@ GEM
     highline (1.6.21)
     i18n (0.6.11)
     json (1.8.1)
-    json_pure (1.8.1)
+    json_pure (1.8.3)
     librarian (0.1.2)
       highline
       thor (~> 0.15)
@@ -60,11 +60,10 @@ GEM
     parallel (0.5.19)
     parallel_tests (0.8.14)
       parallel
-    puppet (3.6.2)
+    puppet (3.8.5)
       facter (> 1.6, < 3)
       hiera (~> 1.0)
       json_pure
-      rgen (~> 0.6.5)
     puppet-lint (1.0.1)
     puppet-lint-trailing_comma-check (0.3.1)
       puppet-lint (~> 1.0)
@@ -79,7 +78,6 @@ GEM
       rake
       rspec-puppet
     rake (10.1.0)
-    rgen (0.6.6)
     rspec (3.3.0)
       rspec-core (~> 3.3.0)
       rspec-expectations (~> 3.3.0)
@@ -117,7 +115,7 @@ DEPENDENCIES
   librarian-puppet
   parallel
   parallel_tests
-  puppet (= 3.6.2)
+  puppet (= 3.8.5)
   puppet-lint
   puppet-lint-trailing_comma-check
   puppet-syntax (= 2.1.0)
@@ -126,3 +124,6 @@ DEPENDENCIES
   rspec-puppet
   sshkey (= 1.7.0)
   webmock (~> 1.20.0)
+
+BUNDLED WITH
+   1.10.5

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -291,6 +291,8 @@ postfix::smarthost:
   - 'email-smtp.eu-west-1.amazonaws.com:587'
   - 'ses-smtp-eu-west-1-prod-345515633.eu-west-1.elb.amazonaws.com:587'
 
+puppet::package::puppet_version: '3.8.5-1puppetlabs1'
+
 router::nginx::check_requests_warning: '@0.5'
 router::nginx::check_requests_critical: '@0.25'
 

--- a/hieradata/vagrant.yaml
+++ b/hieradata/vagrant.yaml
@@ -161,6 +161,8 @@ govuk_postgresql::wal_e::backup::enabled: true
 icinga::config::enable_event_handlers: true
 icinga::nginx::enable_basic_auth: false
 
+puppet::package::puppet_version: '3.8.5-1puppetlabs1'
+
 shell::shell_prompt_string: 'dev'
 
 ssh::config::allow_users:

--- a/modules/puppet/manifests/package.pp
+++ b/modules/puppet/manifests/package.pp
@@ -3,7 +3,7 @@
 # Install packages for Puppet and various fixups that we require.
 #
 class puppet::package (
-  $facter_version = '1.7.5-1puppetlabs1',
+  $facter_version = '2.0.2-1puppetlabs1',
   $hiera_version = '1.3.4-1puppetlabs1',
   $puppet_version = '3.6.2-1puppetlabs1',
 ) {


### PR DESCRIPTION
3.8.5 is a much newer release than 3.6.2 and this will help us get ready for version 4.

## Todo

- [x] Mirror this release with aptly