### PR TITLE
Fix Puppet 3.8.5 in development

### DIFF
--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -334,6 +334,7 @@ postgresql_api_slave_addresses_live: '127.0.0.1/32'
 postgresql_slave_addresses_live: '127.0.0.1/32'
 postgresql_transition_slave_addresses_live: '127.0.0.1/32'
 
+puppet::package::puppet_version: '3.8.5-1puppetlabs1'
 puppet::use_puppetmaster: false
 
 shell::shell_prompt_string: 'dev'


### PR DESCRIPTION
For the development VM, the Puppet package has to be upgraded _before_ the gem.

The correct process is:

- Ensure you only have the Puppet gem for 3.6.2 installed. You can do that by running ``sudo RBENV_VERSION=1.9.3 gem uninstall puppet`` and then provisioning with this commit.
- Provision with this commit to upgrade the Puppet package to 3.8
- At this point, Puppet will now not provision (I believe because the package and the gem are out of sync) - the gem now needs to be upgraded to 3.8 and the old 3.6.2 gem needs to be removed.

We will upgrade the gem in this repo soon.

/cc @jennyd @benlovell @issyl0 