### PR TITLE
Create Jenkins job for terraform deployments

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -471,6 +471,13 @@ govuk_jenkins::job::smokey::signon_password: "%{hiera('smokey_signon_password')}
 govuk_jenkins::job::run_rake_task::applications: *deployable_applications
 govuk_jenkins::job::deploy_app::applications: *deployable_applications
 
+govuk_jenkins::job::deploy_terraform_project::projects:
+  - base_aws_infrastructure
+  - dev_vm
+  - elasticsearch_snapshots
+  - uktt_data
+  - wal-e_backups
+
 govuk_mysql::server::expire_log_days: 3
 govuk_mysql::server::monitoring::master::plaintext_mysql_password: "%{hiera('mysql_nagios')}"
 govuk_mysql::server::monitoring::slave::plaintext_mysql_password: "%{hiera('mysql_nagios')}"

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -95,6 +95,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::deploy_licensify
   - govuk_jenkins::job::deploy_puppet
   - govuk_jenkins::job::deploy_router_data
+  - govuk_jenkins::job::deploy_terraform_project
   - govuk_jenkins::job::govuk_cdn_nightly_2xx_status_collection
   - govuk_jenkins::job::govuk_delivery_configure_integration_catchall_feed
   - govuk_jenkins::job::launch_vms

--- a/hieradata/vagrant.yaml
+++ b/hieradata/vagrant.yaml
@@ -113,6 +113,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::deploy_licensify
   - govuk_jenkins::job::deploy_puppet
   - govuk_jenkins::job::deploy_router_data
+  - govuk_jenkins::job::deploy_terraform_project
   - govuk_jenkins::job::govuk_cdn_nightly_2xx_status_collection
   - govuk_jenkins::job::launch_vms
   - govuk_jenkins::job::network_config_deploy

--- a/modules/govuk_jenkins/manifests/job/deploy_terraform_project.pp
+++ b/modules/govuk_jenkins/manifests/job/deploy_terraform_project.pp
@@ -1,0 +1,17 @@
+# == Class: govuk_jenkins::job::deploy_terraform_project
+#
+# [*projects*]
+#   An array that contains the list of projects currently configured to deploy
+#
+class govuk_jenkins::job::deploy_terraform_project (
+  $projects = [],
+) {
+  validate_array($projects)
+
+  file { '/etc/jenkins_jobs/jobs/deploy_terraform_project.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/deploy_terraform_project.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+
+}

--- a/modules/govuk_jenkins/templates/jobs/deploy_terraform_project.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_terraform_project.yaml.erb
@@ -1,0 +1,47 @@
+---
+- scm:
+    name: govuk-terraform-provisioning_Deploy_Terraform_Project
+    scm:
+        - git:
+            url: git@github.com:alphagov/govuk-terraform-provisioning.git
+            branches:
+                - master
+- job:
+    name: Deploy_Terraform_Project
+    display-name: Deploy_Terraform_Project
+    project-type: freestyle
+    description: |
+      Deploy a specific Terraform project in <%= @environment -%>.
+    properties:
+        - github:
+            url: https://github.com/alphagov/govuk-terraform-provisioning/
+        - inject:
+            properties-content: |
+              DEPLOY_ENV=${ENVIRONMENT}
+              PROJECT_NAME=${PROJECT_NAME}
+    scm:
+        - govuk-terraform-provisioning_Deploy_Terraform_Project
+    builders:
+        - shell: |
+            bundle install --path "${HOME}/bundles/${JOB_NAME}"
+            bundle exec rake ${ACTION}
+
+    parameters:
+        - string:
+            name: AWS_ACCESS_KEY_ID
+            description: Your AWS access key ID
+            default: false
+        - password:
+            name: AWS_SECRET_ACCESS_KEY
+            description: Your AWS secret access key
+            default: false
+        - choice:
+            name: ACTION
+            description: Choose whether to plan (default) or apply
+            choices:
+                - plan
+                - apply
+        - choice:
+            name: PROJECT_NAME
+            description: Name of the project you wish to deploy
+            choices: <%= ['-- Choose a project'] + @projects %>


### PR DESCRIPTION
We require a Jenkins job so we can keep track of deployments for Terraform. This commit adds the job manifest and template, and also adds in the hieradata required, including the list of projects available to
deploy.

Story: https://trello.com/c/FOG8jmb5/53-create-jenkins-job-to-deploy-aws-configuration