### PR TITLE
Upgrade puppetdb to 2.0.0

### DIFF
--- a/hieradata/common.precise.yaml
+++ b/hieradata/common.precise.yaml
@@ -9,6 +9,4 @@ nginx::package::version: '1.4.4-1~precise0'
 
 postgresql::globals::version: '9.1'
 
-puppet::master::puppetdb_version: '1.3.2-1puppetlabs1'
-
 resolvconf::options: []

--- a/modules/puppetdb/manifests/package.pp
+++ b/modules/puppetdb/manifests/package.pp
@@ -8,4 +8,12 @@ class puppetdb::package($package_ensure) {
     require => Class['puppet::package'],
   }
 
+  # FIXME: Remove once deployed to production
+  package { 'openjdk-6-jre-headless':
+    ensure => 'absent',
+  }
+  package { 'openjdk-6-jre-lib':
+    ensure => 'absent',
+  }
+
 }

--- a/modules/puppetdb/templates/upstart.conf.erb
+++ b/modules/puppetdb/templates/upstart.conf.erb
@@ -19,7 +19,8 @@ script
                          -- \
                          <%= @java_args %> \
                          -XX:OnOutOfMemoryError="kill -9 %p" \
-                         -jar /usr/share/puppetdb/puppetdb.jar \
+                         -cp /usr/share/puppetdb/puppetdb.jar \
+                         clojure.main -m com.puppetlabs.puppetdb.core \
                          services -c /etc/puppetdb/conf.d \
                          >> /var/log/puppetdb/upstart.out.log \
                          2>> /var/log/puppetdb/upstart.err.log


### PR DESCRIPTION
This commit upgrades puppetdb on precise machines to 2.0.0.

2.0.0 requires a newer version of the JDK than 6. 6 seems to be provided by the old puppetdb package so I've uninstalled it and manually installed 7.

I've also modified the upstart file to allow puppetdb to start - the change I've made here is similar to the change the package made to its own init file (which we purge).