### PR TITLE
Bugfix Service Description

### DIFF
--- a/modules/govuk_postgresql/manifests/wal_e/backup.pp
+++ b/modules/govuk_postgresql/manifests/wal_e/backup.pp
@@ -165,10 +165,10 @@ class govuk_postgresql::wal_e::backup (
     }
 
     $threshold_secs = 28 * 3600
-    $service_desc = 'PostgreSQL WAL-E base backup push'
+    $service_desc_wale = 'PostgreSQL WAL-E base backup push'
 
     @@icinga::passive_check { "check_wale_base_backup_push-${::hostname}":
-        service_description => $service_desc,
+        service_description => $service_desc_wale,
         freshness_threshold => $threshold_secs,
         host_name           => $::fqdn,
       }

--- a/modules/govuk_postgresql/templates/usr/local/bin/wal-e_postgres_backup_push.erb
+++ b/modules/govuk_postgresql/templates/usr/local/bin/wal-e_postgres_backup_push.erb
@@ -12,7 +12,7 @@ NAGIOS_MESSAGE="CRITICAL: PostgreSQL WAL-E backup push to S3 failed"
 # Triggered whenever this script exits, successful or otherwise. The values
 # of CODE/MESSAGE will be taken from that point in time.
 function nagios_passive () {
-  printf "<%= @ipaddress %>\t<%= @service_desc %>\t${NAGIOS_CODE}\t${NAGIOS_MESSAGE}\n" | /usr/sbin/send_nsca -H alert.cluster >/dev/null
+  printf "<%= @ipaddress %>\t<%= @service_desc_wale %>\t${NAGIOS_CODE}\t${NAGIOS_MESSAGE}\n" | /usr/sbin/send_nsca -H alert.cluster >/dev/null
 }
 
 trap nagios_passive EXIT


### PR DESCRIPTION
For some reason Puppet created the passive check details as having the incorrect service description ("AutoPostgreSQL backup"). This may be because the class and parameter both share the same name. I assumed this wouldn't cause a problem, but I've made it unique to test and ensure this fixes it.