### PR TITLE
Disable icinga alert for disabled rummager worker

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,6 +126,3 @@ DEPENDENCIES
   rspec-puppet
   sshkey (= 1.7.0)
   webmock (~> 1.20.0)
-
-BUNDLED WITH
-   1.10.5

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -44,6 +44,11 @@ govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::publicapi::backdrop_host: 'www.performance.service.gov.uk'
 govuk::apps::publisher::data_import_passive_check: true
 govuk::apps::rummager::aws_s3_bucket_name: govuk-api-elasticsearch-snapshots-production
+
+# Disable icinga alert and rabbitmq setup for the publishing api document indexer
+govuk::apps::rummager::rabbitmq::ensure: false
+govuk::apps::rummager::enable_publishing_api_document_indexer: false
+
 govuk::apps::travel_advice_publisher::enable_email_alerts: true
 
 govuk::deploy::actionmailer_enable_delivery: true

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -14,6 +14,11 @@ govuk::apps::email_alert_api::db::backend_ip_range: '10.2.3.0/24'
 govuk::apps::errbit::errbit_email_from: 'govuk-winston+errbit-staging@digital.cabinet-office.gov.uk'
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::publicapi::backdrop_host: 'www.staging.performance.service.gov.uk'
+
+# Disable icinga alert and rabbitmq setup for the publishing api document indexer
+govuk::apps::rummager::rabbitmq::ensure: false
+govuk::apps::rummager::enable_publishing_api_document_indexer: false
+
 govuk::apps::sidekiq_monitoring::enabled: true
 govuk::apps::travel_advice_publisher::enable_email_alerts: true
 

--- a/modules/govuk/manifests/apps/rummager/rabbitmq.pp
+++ b/modules/govuk/manifests/apps/rummager/rabbitmq.pp
@@ -11,11 +11,17 @@
 # [*password*]
 #   The password for the RabbitMQ user (default: 'rummager')
 #
+# [*ensure*]
+#   Determines whether to create or delete the consumer.
+#   (default: present)
+#
 class govuk::apps::rummager::rabbitmq (
   $password  = 'rummager',
+  $ensure    = 'present',
 ) {
 
   govuk_rabbitmq::consumer { 'rummager':
+    ensure        => $ensure,
     amqp_pass     => $password,
     amqp_exchange => 'published_documents',
     amqp_queue    => 'rummager_to_be_indexed',


### PR DESCRIPTION
We've disabled the worker on production and staging, so its
not useful to have the alert still present.