### PR TITLE
Monitor /srv/backup-cdn-logs on offsite backup box

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -32,6 +32,7 @@ backup::offsite::enable: true
 
 backup::offsite::monitoring::offsite_fqdn: *offsite_host
 backup::offsite::monitoring::offsite_hostname: 'backup0.provider0'
+backup::offsite::monitoring::monitor_cdn_logs_disk: true
 
 base::supported_kernel::enabled: true
 

--- a/hieradata/vagrant.yaml
+++ b/hieradata/vagrant.yaml
@@ -5,6 +5,7 @@ app_domain: 'dev.gov.uk'
 
 backup::offsite::monitoring::offsite_fqdn: backup.gov.uk
 backup::offsite::monitoring::offsite_hostname: backup0.provider0
+backup::offsite::monitoring::monitor_cdn_logs_disk: true
 
 assets::ssh_authorized_key::key: 'AAAAB3NzaC1yc2EAAAADAQABAAAAYQDCIfGHdqJj9IMkdwXtieDW15ZnR9GAqcnUwjQOMvySEst54705ekxcKwjRFTaYmawlifQTOgFDPkMwp72s2Zd+0ZiR7lfSzBQctbCptS/SgTNNltvplVt8nUbz9H0jLy8='
 assets::ssh_private_key::key: |

--- a/modules/backup/manifests/offsite/monitoring.pp
+++ b/modules/backup/manifests/offsite/monitoring.pp
@@ -10,10 +10,15 @@
 # [*offsite_hostname*]
 #   Descriptive hostname for use in Icinga check - eg "backup0.provider0"
 #
+# [*monitor_cdn_logs_disk*]
+#   If true, monitor disk space on /srv/backup-cdn-logs
+#
 class backup::offsite::monitoring(
   $offsite_fqdn,
   $offsite_hostname,
+  $monitor_cdn_logs_disk = false,
 ){
+  validate_bool($monitor_cdn_logs_disk)
 
   icinga::host { $offsite_fqdn:
     hostalias => $offsite_fqdn,
@@ -46,6 +51,15 @@ class backup::offsite::monitoring(
     service_description => 'low available disk space /srv/backup-logs',
     use                 => 'govuk_high_priority',
     host_name           => $offsite_fqdn,
+  }
+
+  if $monitor_cdn_logs_disk {
+    icinga::check { "check_disk_backup-cdn-logs_${offsite_hostname}":
+      check_command       => 'check_nrpe_1arg!check_disk_backup-cdn-logs',
+      service_description => 'low available disk space /srv/backup-cdn-logs',
+      use                 => 'govuk_high_priority',
+      host_name           => $offsite_fqdn,
+    }
   }
 
   icinga::check { "check_ssh_${offsite_hostname}":


### PR DESCRIPTION
__Story: https://trello.com/c/xbsYTau0/33-back-up-processed-cdn-logs__

Monitor the disk used to backup processed CDN logs on the provider0
(Skyscape) offsite backup machine.