### PR TITLE
Use new boxes for Virtualbox in Vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,14 +8,17 @@ min_required_vagrant_version = '1.3.0'
 # Construct box name and URL from distro and version.
 def get_box(dist, version, provider)
   dist    ||= "trusty"
-  version ||= "20141112"
 
   if provider == "vmware_fusion"
+    version ||= '20141112'
     name  = "govuk_dev_#{dist}64_vmware_fusion_#{version}"
+    bucket = 'gds-boxes'
   else
+    version ||= '20160323'
     name  = "govuk_dev_#{dist}64_#{version}"
+    bucket = 'govuk-dev-boxes-test'
   end
-  url   = "http://gds-boxes.s3.amazonaws.com/#{name}.box"
+  url = "http://#{bucket}.s3.amazonaws.com/#{name}.box"
 
   return name, url
 end

--- a/development/Vagrantfile
+++ b/development/Vagrantfile
@@ -11,8 +11,8 @@ BOXES = {
   virtualbox: {
     bucket: 'govuk-dev-boxes-test',
     latest_versions: {
-      precise: '20160321',
-      trusty: '20160321',
+      precise: '20160323',
+      trusty: '20160323',
     },
   },
   vmware_fusion: {


### PR DESCRIPTION
- The boxes from 21 March did not have Puppet installed properly
- The Vagrantfile for bringing up specific nodes was not updated to use those 21 March boxes but should have been