### PR TITLE
Add aptly mirror for elasticsearch 1.7

### DIFF
--- a/modules/govuk/manifests/node/s_apt.pp
+++ b/modules/govuk/manifests/node/s_apt.pp
@@ -66,6 +66,10 @@ class govuk::node::s_apt (
       location => 'http://packages.elastic.co/elasticsearch/1.5/debian',
       release  => 'stable',
       key      => '46095ACC8548582C1A2699A9D27D666CD88E42B4';
+    'elasticsearch-1.7':
+      location => 'http://packages.elastic.co/elasticsearch/1.7/debian',
+      release  => 'stable',
+      key      => '46095ACC8548582C1A2699A9D27D666CD88E42B4';
     'rabbitmq':
       location => 'http://www.rabbitmq.com/debian',
       release  => 'testing',


### PR DESCRIPTION
This creates an aptly mirror so we can start testing 1.7. We plan to update api elasticsearch to this soon.

The key is the fingerprint documented at https://www.elastic.co/guide/en/elasticsearch/reference/1.7/setup-repositories.html