### PR TITLE
Add GOVUK content schema jenkins deploy job.

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -93,6 +93,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::data_sync_complete_integration
   - govuk_jenkins::job::deploy_app
   - govuk_jenkins::job::deploy_cdn
+  - govuk_jenkins::job::deploy_govuk_content_schemas
   - govuk_jenkins::job::deploy_licensify
   - govuk_jenkins::job::deploy_puppet
   - govuk_jenkins::job::deploy_router_data

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -77,6 +77,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::copy_sanitised_whitehall_database
   - govuk_jenkins::job::deploy_app
   - govuk_jenkins::job::deploy_cdn
+  - govuk_jenkins::job::deploy_govuk_content_schemas
   - govuk_jenkins::job::deploy_licensify
   - govuk_jenkins::job::deploy_puppet
   - govuk_jenkins::job::deploy_router_data

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -34,6 +34,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::data_sync_complete_staging
   - govuk_jenkins::job::deploy_app
   - govuk_jenkins::job::deploy_cdn
+  - govuk_jenkins::job::deploy_govuk_content_schemas
   - govuk_jenkins::job::deploy_licensify
   - govuk_jenkins::job::deploy_puppet
   - govuk_jenkins::job::deploy_router_data

--- a/hieradata/vagrant.yaml
+++ b/hieradata/vagrant.yaml
@@ -111,6 +111,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::deploy_app
   - govuk_jenkins::job::run_rake_task
   - govuk_jenkins::job::deploy_cdn
+  - govuk_jenkins::job::deploy_govuk_content_schemas
   - govuk_jenkins::job::deploy_licensify
   - govuk_jenkins::job::deploy_puppet
   - govuk_jenkins::job::deploy_router_data

--- a/modules/govuk_jenkins/manifests/job/deploy_govuk_content_schemas.pp
+++ b/modules/govuk_jenkins/manifests/job/deploy_govuk_content_schemas.pp
@@ -1,0 +1,10 @@
+# == Class: govuk_jenkins::job::deploy_govuk_content_schemas
+#
+# Create a file on disk that can be parsed by jenkins-job-builder
+class govuk_jenkins::job::deploy_govuk_content_schemas {
+  file { '/etc/jenkins_jobs/jobs/deploy_govuk_content_schemas.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/deploy_govuk_content_schemas.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+}

--- a/modules/govuk_jenkins/templates/jobs/deploy_govuk_content_schemas.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_govuk_content_schemas.yaml.erb
@@ -1,0 +1,32 @@
+---
+- scm:
+  name: Deploy_GOVUK_Content_Schemas
+  scm:
+    - git:
+      url: https://github.com/alphagov/govuk-content-schemas.git
+      branches:
+        - ${TAG}
+
+- job:
+  name: Deploy_GOVUK_Content_Schemas
+  display-name: Deploy GOVUK content schemas
+  project-type: freestyle
+  description: "RSyncs the GOVUK content schemas to the publishing API's shared directory"
+  properties:
+    - github:
+      url: https://github.com/alphagov/govuk-content-schemas
+  scm:
+    - Deploy_GOVUK_Content_Schemas
+  builders:
+    - shell: |
+      sh -eu deploy.sh
+  wrappers:
+    - ansicolor:
+      colormap: xterm
+    - build-name:
+      name: '#${BUILD_NUMBER} ${ENV,var="TAG"}'
+  parameters:
+    - string:
+      name: TAG
+      description: Git tag/committish to deploy.
+      default: release


### PR DESCRIPTION
RSyncs the given release tag of the content schemas
to the publishing API's shared directory, which
will separately be symlinked into the application.

Programmatically replicates https://deploy.integration.publishing.service.gov.uk/job/Deploy_GOVUK_Content_Schemas/configure

https://trello.com/c/6fnMMZaX/642-1-make-govuk-content-schemas-visible-to-the-publishing-api-in-prod