### PR TITLE
Update properties for Terraform Jenkins job

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_terraform_project.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_terraform_project.yaml.erb
@@ -17,8 +17,7 @@
             url: https://github.com/alphagov/govuk-terraform-provisioning/
         - inject:
             properties-content: |
-              DEPLOY_ENV=${ENVIRONMENT}
-              PROJECT_NAME=${PROJECT_NAME}
+              DEPLOY_ENV=<%= @environment %>
     scm:
         - govuk-terraform-provisioning_Deploy_Terraform_Project
     builders:


### PR DESCRIPTION
- `ENVIRONMENT` isn't set as an environment variable
- `PROJECT_NAME` doesn't need to be set because it is already