### PR TITLE
Add sidekiq and redis config to travel advice publisher

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -396,6 +396,8 @@ govuk::apps::tariff_api::nagios_memory_critical: 2000
 
 govuk::apps::transition::postgresql_db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 
+govuk::apps::travel_advice_publisher::redis_host: 'redis-1.backend'
+
 govuk::deploy::config::asset_root: "https://%{hiera('router::assets_origin::vhost_name')}"
 govuk::deploy::config::website_root: "https://www-origin.%{hiera('app_domain')}"
 

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -170,6 +170,7 @@ govuk::apps::support_api::enable_procfile_worker: false
 govuk::apps::tariff_api::enable_procfile_worker: false
 govuk::apps::transition::enable_procfile_worker: false
 govuk::apps::travel_advice_publisher::enable_email_alerts: true
+govuk::apps::travel_advice_publisher::redis_host: 'localhost'
 govuk::apps::whitehall::configure_admin: true
 govuk::apps::whitehall::configure_frontend: true
 govuk::apps::whitehall::enable_procfile_worker: false

--- a/modules/govuk/manifests/apps/travel_advice_publisher.pp
+++ b/modules/govuk/manifests/apps/travel_advice_publisher.pp
@@ -25,6 +25,17 @@
 #   The bearer token to use when communicating with Publishing API.
 #   Default: undef
 #
+# [*redis_host*]
+#   Redis host for sidekiq.
+#
+# [*redis_port*]
+#   Redis port for sidekiq.
+#   Default: 6379
+#
+# [*enable_procfile_worker*]
+#   Enables the sidekiq background worker.
+#   Default: true
+#
 class govuk::apps::travel_advice_publisher(
   $port = '3035',
   $enable_email_alerts = false,
@@ -32,6 +43,9 @@ class govuk::apps::travel_advice_publisher(
   $mongodb_nodes = undef,
   $secret_key_base = undef,
   $publishing_api_bearer_token = undef,
+  $redis_host = undef,
+  $redis_port = '6379',
+  $enable_procfile_worker = true,
 ) {
   $app_name = 'travel-advice-publisher'
 
@@ -63,6 +77,12 @@ class govuk::apps::travel_advice_publisher(
     "${title}-SECRET_KEY_BASE":
       varname => 'SECRET_KEY_BASE',
       value   => $secret_key_base;
+    "${title}-REDIS_HOST":
+      varname => 'REDIS_HOST',
+      value   => $redis_host;
+    "${title}-REDIS_PORT":
+      varname => 'REDIS_PORT',
+      value   => $redis_port;
   }
 
   validate_bool($enable_email_alerts)


### PR DESCRIPTION
https://trello.com/c/ABfCJwT7/648-travel-advice-publisher-send-content-on-a-queue-rather-than-synchronously

This code by @steventux makes our publishing API calls async to provide additional resilience to publishing actions.