### PR TITLE
Revert "Use the puppet from $PATH"

### DIFF
--- a/tools/puppet-apply
+++ b/tools/puppet-apply
@@ -9,7 +9,7 @@ sed -e "s;^  :datadir: .*$;  :datadir: '/var/govuk/govuk-puppet/hieradata';g" /v
 # Filter warnings about 'storeconfigs' not being set
 exec sudo \
   RBENV_VERSION=1.9.3 \
-  puppet apply /var/govuk/govuk-puppet/manifests/site.pp \
+  /usr/bin/puppet apply /var/govuk/govuk-puppet/manifests/site.pp \
   --trusted_node_data \
   --environment ${ENVIRONMENT:-development} \
   --modulepath /var/govuk/govuk-puppet/modules:/var/govuk/govuk-puppet/vendor/modules \


### PR DESCRIPTION
Reverts alphagov/govuk-puppet#4247

Breaks the puppet run for the dev vm with the error
"Error: Could not find a suitable provider for augeas"