### PR TITLE
Set higher memory warning levels for publishing api...

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -353,6 +353,8 @@ govuk::apps::publishing_api::db_hostname: "postgresql-primary-1.backend"
 govuk::apps::publishing_api::draft_content_store: "https://draft-content-store.%{hiera('app_domain')}"
 govuk::apps::publishing_api::redis_host: 'redis-1.backend'
 govuk::apps::publishing_api::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
+govuk::apps::publishing_api::nagios_memory_warning: 1400
+govuk::apps::publishing_api::nagios_memory_critical: 1600
 
 govuk::apps::rummager::nagios_memory_warning: 4600
 govuk::apps::rummager::nagios_memory_critical: 4900


### PR DESCRIPTION
Previously, it was just using the defaults which are
700 / 800 MB. Publishing API is taking on more and more
content and so it probably makes sense to up this a bit.

Here is a graph of the last two weeks of memory usage:
https://graphite.publishing.service.gov.uk/render/?width=1400&height=800&colorList=red,orange,blue,green,purple,brown&target=alias(dashed(constantLine(800000000)),%22critical%22)&target=alias(dashed(constantLine(700000000)),%22warning%22)&target=backend-*_backend.processes-app-publishing-api.ps_rss&from=-14d