### PR TITLE
Make duplicity config specific to asset-slave-1

### DIFF
--- a/hieradata/class/asset_slave.yaml
+++ b/hieradata/class/asset_slave.yaml
@@ -1,7 +1,5 @@
 ---
 
-backup::assets::archive_directory: '/mnt/duplicity-cache'
-
 govuk_safe_to_reboot::can_reboot: 'careful'
 govuk_safe_to_reboot::reason: 'Check that offsite sync job is not running before rebooting'
 
@@ -11,10 +9,6 @@ lv:
       - '/dev/sdb1'
       - '/dev/sdc1'
     vg: 'uploads'
-  cache:
-    pv:
-      - '/dev/sdd1'
-    vg: 'duplicity'
 
 mount:
   /mnt/uploads:
@@ -22,10 +16,4 @@ mount:
     govuk_lvm: 'data'
     mountoptions: 'defaults'
     percent_threshold_warning: 5
-    percent_threshold_critical: 2
-  /mnt/duplicity-cache:
-    disk: '/dev/mapper/duplicity-cache'
-    govuk_lvm: 'cache'
-    mountoptions: 'defaults'
-    percent_threshold_warning: 10 
     percent_threshold_critical: 2

--- a/hieradata/node/asset-slave-1.backend.publishing.service.gov.uk.yaml
+++ b/hieradata/node/asset-slave-1.backend.publishing.service.gov.uk.yaml
@@ -1,1 +1,29 @@
+---
+
 govuk::node::s_asset_slave::offsite_backups: true
+backup::assets::archive_directory: '/mnt/duplicity-cache'
+
+lv:
+  data:
+    pv:
+      - '/dev/sdb1'
+      - '/dev/sdc1'
+    vg: 'uploads'
+  cache:
+    pv:
+      - '/dev/sdd1'
+    vg: 'duplicity'
+
+mount:
+  /mnt/uploads:
+    disk: '/dev/mapper/uploads-data'
+    govuk_lvm: 'data'
+    mountoptions: 'defaults'
+    percent_threshold_warning: 5
+    percent_threshold_critical: 2
+  /mnt/duplicity-cache:
+    disk: '/dev/mapper/duplicity-cache'
+    govuk_lvm: 'cache'
+    mountoptions: 'defaults'
+    percent_threshold_warning: 10 
+    percent_threshold_critical: 2


### PR DESCRIPTION
__Story: https://trello.com/c/S8B99y46/120-asset-slave-backups-no-longer-working__

Make the configuration for Duplicity's cache directory specific to the
`asset-slave-1` machine.

When I added this config, I accidentally applied it to all machines of
the `asset_slave` type. We only run offsite backups with Duplicity on
`asset-slave-1`, so make the configuration for the Duplicity cache
specific to that machine.