### PR TITLE
Make physical volumes reflect reality in integration…

### DIFF
--- a/hieradata/class/integration/postgresql_primary.yaml
+++ b/hieradata/class/integration/postgresql_primary.yaml
@@ -1,0 +1,12 @@
+---
+
+lv:
+  postgresql:
+    pv:
+      - '/dev/sda1'
+      - '/dev/sdc1'
+      - '/dev/sde1'
+    vg: 'backups'
+  data:
+    pv: '/dev/sdd1'
+    vg: 'postgresql'


### PR DESCRIPTION
udev has renamed the underlying disks. Our puppet
configuration expected specific names that didn’t
match. This changes the puppet config to match the
names of the physical volumes.

The machine still works currently because it’s
using uuids in the configuration of the logical
volumes.