### PR TITLE
Update elasticsearch to 1.7.5

### DIFF
--- a/hieradata/class/integration/api_elasticsearch.yaml
+++ b/hieradata/class/integration/api_elasticsearch.yaml
@@ -1,0 +1,3 @@
+---
+
+govuk_elasticsearch::version: '1.7.5'

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -186,7 +186,7 @@ govuk_lvm::no_op: true
 
 govuk_mount::no_op: true
 
-govuk_elasticsearch::version: '1.4.4'
+govuk_elasticsearch::version: '1.7.5'
 
 govuk_logging::logstream::disabled: true
 


### PR DESCRIPTION
Only update integration for now.

We'd like to do some review of the search results before deploying to staging and production.

See https://trello.com/c/EYXNHkyr/524-upgrade-elasticsearch-to-1-7-5-m for the deploy steps.

I've disabled puppet on the api-elasticsearch machines so will do the upgrade once this is merged.