### PR TITLE
Disable rummager worker on integration

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -20,7 +20,7 @@ govuk::apps::event_store::enabled: true
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
 govuk::apps::local_links_manager::enabled: true
 govuk::apps::publicapi::backdrop_host: 'www.preview.performance.service.gov.uk'
-govuk::apps::rummager::enable_publishing_api_document_indexer: true
+govuk::apps::rummager::enable_publishing_api_document_indexer: false
 govuk::apps::rummager::aws_s3_bucket_name: govuk-api-elasticsearch-snapshots-integration
 govuk::apps::smartanswers::expose_govspeak: true
 govuk::apps::specialist_publisher::publish_pre_production_finders: true


### PR DESCRIPTION
This is not being actively tested at the moment and is causing a lot
of timeouts. We'll disable for the time being to simplify testing the elasticsearch
upgrade.