### PR TITLE
Add env vars for contentapi.

### DIFF
--- a/hieradata/class/backend.yaml
+++ b/hieradata/class/backend.yaml
@@ -9,6 +9,12 @@ govuk::apps::event_store::mongodb_servers:
 
 govuk::apps::frontend::vhost_protected: true
 
+govuk::apps::contentapi::mongodb_name: 'govuk_content_production'
+govuk::apps::contentapi::mongodb_nodes:
+  - 'mongo-1.backend'
+  - 'mongo-2.backend'
+  - 'mongo-3.backend'
+
 govuk::apps::publisher::mongodb_name: 'govuk_content_production'
 govuk::apps::publisher::mongodb_nodes:
   - 'mongo-1.backend'

--- a/modules/govuk/manifests/apps/contentapi.pp
+++ b/modules/govuk/manifests/apps/contentapi.pp
@@ -18,11 +18,23 @@
 # [*nagios_memory_critical*]
 #   Memory use at which Nagios should generate a critical alert.
 #
+# [*secret_key_base*]
+#   The key for Rails to use when signing/encrypting sessions.
+#
+# [*mongodb_name*]
+#   The Mongo database to be used.
+#
+# [*mongodb_nodes*]
+#   Array of hostnames for the mongo cluster to use.
+#
 class govuk::apps::contentapi (
   $port = '3022',
   $publishing_api_bearer_token = undef,
   $nagios_memory_warning = undef,
   $nagios_memory_critical = undef,
+  $secret_key_base = undef,
+  $mongodb_name = undef,
+  $mongodb_nodes = undef,
 ) {
 
   govuk::app { 'contentapi':
@@ -35,9 +47,21 @@ class govuk::apps::contentapi (
     nagios_memory_critical => $nagios_memory_critical,
   }
 
-  govuk::app::envvar { "${title}-PUBLISHING_API_BEARER_TOKEN":
-    app     => 'contentapi',
-    varname => 'PUBLISHING_API_BEARER_TOKEN',
-    value   => $publishing_api_bearer_token,
+  if $mongodb_nodes != undef {
+    govuk::app::envvar::mongodb_uri { 'contentapi':
+      hosts    => $mongodb_nodes,
+      database => $mongodb_name,
+    }
+  }
+
+  govuk::app::envvar {
+    "${title}-PUBLISHING_API_BEARER_TOKEN":
+      app     => 'contentapi',
+      varname => 'PUBLISHING_API_BEARER_TOKEN',
+      value   => $publishing_api_bearer_token;
+    "${title}-SECRET_KEY_BASE":
+      app     => 'contentapi',
+      varname => 'SECRET_KEY_BASE',
+      value   => $secret_key_base;
   }
 }


### PR DESCRIPTION
This adds MONGODB_URI and SECRET_KEY_BASE, which are required in the upgrade to the latest versions of Mongoid/govuk_content_models. The latter will be populated by the deployment hieradata.