### PR TITLE
Disable travel advice publisher worker in prod.

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -46,6 +46,7 @@ govuk::apps::publicapi::backdrop_host: 'www.performance.service.gov.uk'
 govuk::apps::publisher::data_import_passive_check: true
 govuk::apps::rummager::aws_s3_bucket_name: govuk-api-elasticsearch-snapshots-production
 govuk::apps::travel_advice_publisher::enable_email_alerts: true
+govuk::apps::travel_advice_publisher::enable_procfile_worker: false
 
 govuk::deploy::actionmailer_enable_delivery: true
 

--- a/modules/govuk/manifests/apps/travel_advice_publisher.pp
+++ b/modules/govuk/manifests/apps/travel_advice_publisher.pp
@@ -86,7 +86,6 @@ class govuk::apps::travel_advice_publisher(
   }
 
   validate_bool($enable_email_alerts)
-
   if ($enable_email_alerts) {
     govuk::app::envvar {
       "${title}-SEND_EMAIL_ALERTS":
@@ -95,6 +94,7 @@ class govuk::apps::travel_advice_publisher(
     }
   }
 
+  validate_bool($enable_procfile_worker)
   govuk::procfile::worker { $app_name:
     enable_service => $enable_procfile_worker,
   }


### PR DESCRIPTION
The code isn't ready for prime time but we want to
keep testing in integration and staging.