### PR TITLE
Prepare for api-elasticsearch upgrade to 1.7

### DIFF
--- a/hieradata/class/staging/api_elasticsearch.yaml
+++ b/hieradata/class/staging/api_elasticsearch.yaml
@@ -1,3 +1,4 @@
 ---
 
 govuk_safe_to_reboot::can_reboot: 'overnight'
+govuk_elasticsearch::version: '1.7.5'


### PR DESCRIPTION
Please check puppet is disabled on api-elasticsearch hosts before merging, as we need to do a rolling deploy.