### PR TITLE
Change asset_root in production

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -306,6 +306,7 @@ govuk::apps::govuk_crawler_worker::blacklist_paths:
 govuk::apps::govuk_crawler_worker::enabled: true
 govuk::apps::govuk_crawler_worker::root_urls:
   - 'https://assets.digital.cabinet-office.gov.uk/'
+  - 'https://assets.publishing.service.gov.uk/'
   - 'https://www.gov.uk/'
 
 govuk::apps::imminence::mongodb_nodes:

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -51,7 +51,7 @@ govuk::deploy::actionmailer_enable_delivery: true
 
 govuk::deploy::aws_ses_smtp_host: 'email-smtp.us-east-1.amazonaws.com'
 govuk::deploy::config::errbit_environment_name: 'production'
-govuk::deploy::config::asset_root: 'https://assets.digital.cabinet-office.gov.uk'
+govuk::deploy::config::asset_root: 'https://assets.publishing.service.gov.uk'
 govuk::deploy::config::website_root: 'https://www.gov.uk'
 govuk::deploy::setup::ssh_keys:
   jenkins_production_carrenza: 'AAAAB3NzaC1yc2EAAAADAQABAAACAQCfPjubgzCkZo1aTPlkgeXb1eh3IonRBRptx0qLMCjOV+e+M8uRAT/Xx3ydJYPd7sOgZDyx2xjSGb7Eefau0jSUAcMD1Xd01SXWBQPJRDfPmQLrdbM0xxOFH8nft39uo4Mz6ccZc34xrudL6q/urp732HZHYwltnNnbk9h58n1QIhemRtN3u9RrSSOILqw/F42S6Aj8lZ1v/DGgfc6F5pKyJ7TByHL1RlqwpZHbEjYYuvK0ZJJsKPlyVPbNDsX7UEYWwbpPsFs9LPvCC6epmj+7Lv25bTU8rKK8J3rNWa1FybpWS0VXbF/+mrLjtT0/vwvbwUzsjK6dSUsbEsBEn+cOqomxCYkLjMzUy1+ReYAh6+CjmzutPs1g4OjQRel2ONprhPTEsNUu+oNObnGDOUpzHK10ntAZxguA4QEUmOBBWfxuQhmJO60/b1zedCcc7MR8e9S0y4jtpXa8GBCe40+napArZTW9QXlHLWz+khkYQfO107Q+z1QaLFojdcrHlUfpqAc6DtVJQu7tsBt2vXTn0qq6mU5Eg6UY+X1l/3gWdFS3ZEvCUoGK6bLU3i50jZ1xsFogFFfvSux46S1DYW2Fk8a/2IBBdcQcL1YoM73jiAQgpU8Vs50wtk4mWhK1yBaMYmMAeL7mKFbJla7SjTAwaDdo5uezyrJlbZxqTb/Y3w=='


### PR DESCRIPTION
This will change `/etc/govuk/env.d/GOVUK_ASSET_HOST` and `/etc/govuk/env.d/GOVUK_ASSET_ROOT` on every machine.

~~I don't think this will restart every application but it may do, so it requires care when deploying.~~

These 2 hostnames are served by the same backend so changing them will make no difference at all.