### PR TITLE
Remove basic auth for monitoring

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -194,7 +194,6 @@ govuk::node::s_frontend_lb::whitehall_frontend_servers:
   - 'whitehall-frontend-5.frontend'
   - 'whitehall-frontend-6.frontend'
   - 'whitehall-frontend-7.frontend'
-govuk::node::s_graphite::enable_basic_auth: false
 govuk::node::s_licensify_lb::licensify_backend_servers:
   - 'licensify-backend-1.licensify'
   - 'licensify-backend-2.licensify'
@@ -596,8 +595,6 @@ hosts::production::router::hosts:
     ip: '10.3.1.252'
     legacy_aliases:
       - "draft-router-api.%{hiera('app_domain')}"
-
-icinga::nginx::enable_basic_auth: false
 
 #Do not enable this without speaking to Brad first
 licensify::apps::licensing_web_forms::enabled: false

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -145,7 +145,6 @@ govuk::node::s_frontend_lb::whitehall_frontend_servers:
   - 'whitehall-frontend-5.frontend'
   - 'whitehall-frontend-6.frontend'
   - 'whitehall-frontend-7.frontend'
-govuk::node::s_graphite::enable_basic_auth: false
 govuk::node::s_licensify_lb::licensify_backend_servers:
   - 'licensify-backend-1.licensify'
   - 'licensify-backend-2.licensify'
@@ -526,7 +525,6 @@ hosts::production::router::hosts:
       - "draft-router-api.%{hiera('app_domain')}"
 
 icinga::config::enable_event_handlers: true
-icinga::nginx::enable_basic_auth: false
 
 #Do not enable this without speaking to Brad first
 licensify::apps::licensing_web_forms::enabled: false

--- a/hieradata/vagrant.yaml
+++ b/hieradata/vagrant.yaml
@@ -100,7 +100,6 @@ govuk::node::s_frontend_lb::performance_frontend_servers:
   - 'performance-frontend-2.frontend'
 govuk::node::s_frontend_lb::performance_frontend_apps:
   - 'spotlight'
-govuk::node::s_graphite::enable_basic_auth: false
 govuk::node::s_licensify_mongo::licensify_mongo_encrypted: true
 govuk::node::s_licensify_mongo::mongodb_backup_disk: '/dev/sdb1'
 
@@ -162,7 +161,6 @@ govuk_postgresql::server::snakeoil_ssl_key: |
 govuk_postgresql::wal_e::backup::enabled: true
 
 icinga::config::enable_event_handlers: true
-icinga::nginx::enable_basic_auth: false
 
 shell::shell_prompt_string: 'dev'
 

--- a/modules/govuk/manifests/node/s_graphite.pp
+++ b/modules/govuk/manifests/node/s_graphite.pp
@@ -4,18 +4,12 @@
 #
 # === Parameters:
 #
-# [*enable_basic_auth*]
-#   Boolean. Whether basic auth should be enabled or disabled.
-#
 # [*graphite_path*]
 #   Path to the installation of Graphite.
 #
 class govuk::node::s_graphite (
-  $enable_basic_auth = true,
   $graphite_path = '/opt/graphite',
 ) inherits govuk::node::s_base {
-  validate_bool($enable_basic_auth)
-
   class { 'graphite':
     version                    => '0.9.13',
     port                       => '33333',
@@ -102,7 +96,7 @@ class govuk::node::s_graphite (
     to           => ['localhost:33333'],
     root         => "${graphite_path}/webapp",
     aliases      => ['graphite.*'],
-    protected    => $enable_basic_auth,
+    protected    => false,
     extra_config => $cors_headers,
   }
 

--- a/modules/icinga/manifests/nginx.pp
+++ b/modules/icinga/manifests/nginx.pp
@@ -2,16 +2,7 @@
 #
 # Sets up nginx for Icinga
 #
-# === Parameters:
-#
-# [*enable_basic_auth*]
-#   Boolean. Whether basic auth should be enabled or disabled.
-#
-class icinga::nginx (
-  $enable_basic_auth = true,
-) {
-  validate_bool($enable_basic_auth)
-
+class icinga::nginx {
   include ::nginx
 
   nginx::config::ssl { 'nagios':

--- a/modules/icinga/templates/nginx.conf.erb
+++ b/modules/icinga/templates/nginx.conf.erb
@@ -12,10 +12,7 @@ server {
   access_log /var/log/nginx/nagios-access.log timed_combined;
   access_log /var/log/nginx/nagios-json.event.access.log json_event;
   error_log /var/log/nginx/nagios-error.log;
-<%- if @enable_basic_auth -%>
-  auth_basic "Nagios Restricted Access";
-  auth_basic_user_file /etc/govuk.htpasswd;
-<%- end -%>
+
   location /stylesheets {
     alias /etc/icinga/stylesheets;
   }


### PR DESCRIPTION
Graphite and Icinga both have basic authentication enabled in integration but they are also restricted to only be available from the GDS office, so there's no need for this basic auth at all.