### PR TITLE
Enable elasticsearch 1.7 on production

### DIFF
--- a/hieradata/class/api_elasticsearch.yaml
+++ b/hieradata/class/api_elasticsearch.yaml
@@ -3,7 +3,7 @@
 govuk_safe_to_reboot::can_reboot: 'careful'
 govuk_safe_to_reboot::reason: 'Reboot a single node at time and check that the cluster goes green between reboots'
 
-govuk_elasticsearch::version: '1.4.4'
+govuk_elasticsearch::version: '1.7.5'
 
 lv:
   data:

--- a/hieradata/class/integration/api_elasticsearch.yaml
+++ b/hieradata/class/integration/api_elasticsearch.yaml
@@ -1,3 +1,1 @@
 ---
-
-govuk_elasticsearch::version: '1.7.5'

--- a/hieradata/class/staging/api_elasticsearch.yaml
+++ b/hieradata/class/staging/api_elasticsearch.yaml
@@ -1,4 +1,3 @@
 ---
 
 govuk_safe_to_reboot::can_reboot: 'overnight'
-govuk_elasticsearch::version: '1.7.5'


### PR DESCRIPTION
See https://trello.com/c/EYXNHkyr/524-upgrade-elasticsearch-to-1-7-5-m

Puppet has been temporarily disabled on api-elasticsearch hosts as we need to do a rolling deploy.