### PR TITLE
Increase memory alert levels for content store

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -252,8 +252,8 @@ govuk::apps::content_register::rabbitmq_hosts:
   - rabbitmq-2.backend
   - rabbitmq-3.backend
 
-govuk::apps::content_store::nagios_memory_warning: 800
-govuk::apps::content_store::nagios_memory_critical: 900
+govuk::apps::content_store::nagios_memory_warning: 900
+govuk::apps::content_store::nagios_memory_critical: 1000
 
 govuk::apps::content_tagger::db_hostname: "postgresql-primary-1.backend"
 govuk::apps::content_tagger::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"


### PR DESCRIPTION
The last two weeks of memory usage:

![screen shot 2016-04-04 at 10 19 13](https://cloud.githubusercontent.com/assets/892251/14243686/d6793e46-fa4e-11e5-90cc-45b9e7ae7944.png)

It looks like it increased some time around March 10th. I have [added a ticket](https://trello.com/c/eFdamRxD/662-investigate-why-content-store-memory-usage-has-spiked) to the Publishing Platform team's backlog. Until then, this gives content store a bit more breathing room.

The last 1 month of memory usage:

![screen shot 2016-04-04 at 10 26 48](https://cloud.githubusercontent.com/assets/892251/14243864/ce96abc2-fa4f-11e5-86d3-881f17568036.png)

