### PR TITLE
Enable event handlers in all environments

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -283,7 +283,6 @@ hosts::production::licensify_hosts:
     ip: '31.210.245.117'
 
 icinga::client::check_cputype::cputype: 'amd'
-icinga::config::enable_event_handlers: true
 
 licensify::apps::licensing_web_forms::enabled: true
 

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -573,8 +573,6 @@ hosts::production::router::hosts:
     legacy_aliases:
       - "draft-router-api.%{hiera('app_domain')}"
 
-icinga::config::enable_event_handlers: true
-
 #Do not enable this without speaking to Brad first
 licensify::apps::licensing_web_forms::enabled: false
 

--- a/hieradata/vagrant.yaml
+++ b/hieradata/vagrant.yaml
@@ -160,8 +160,6 @@ govuk_postgresql::server::snakeoil_ssl_key: |
 
 govuk_postgresql::wal_e::backup::enabled: true
 
-icinga::config::enable_event_handlers: true
-
 shell::shell_prompt_string: 'dev'
 
 ssh::config::allow_users:

--- a/modules/icinga/manifests/config.pp
+++ b/modules/icinga/manifests/config.pp
@@ -14,7 +14,7 @@
 #   Password for $http_username
 #
 class icinga::config (
-  $enable_event_handlers = false,
+  $enable_event_handlers = true,
   $http_username = '',
   $http_password = '',
 ) {


### PR DESCRIPTION
Restarting services which use to much memory by 'hand' is tedious.
Change the default value of enable_event_handlers to true so that all
our environments will restart apps which are above their memory
thresholds.