### PR TITLE
Fix a problem with double / locations and basic auth

### DIFF
--- a/modules/nginx/templates/proxy-vhost.conf
+++ b/modules/nginx/templates/proxy-vhost.conf
@@ -62,13 +62,18 @@ server {
   <%- end -%>
   location / {
     <%- if @enable_basic_auth && @protected -%>
-      location <%= @protected_location %> {
-        deny all;
-        auth_basic            "Enter the GOV.UK username/password (not your personal username/password)";
-        auth_basic_user_file  /etc/govuk.htpasswd;
-        satisfy any;
-      }
+      <%- if @protected_location != "/" -%>
+        location <%= @protected_location %> {
+      <%- end -%>
 
+          deny all;
+          auth_basic            "Enter the GOV.UK username/password (not your personal username/password)";
+          auth_basic_user_file  /etc/govuk.htpasswd;
+          satisfy any;
+
+      <%- if @protected_location != "/" -%>
+        }
+      <%- end -%>
     <%- end -%>
 
     <%- if @single_page_app -%>


### PR DESCRIPTION
This change probably needs a test. Currently, puppet is disabled on production because the Nginx configuration is broken, so we should get this merged and shipped fairly quickly.