### PR TITLE
Alert on-call people for travel advice email problems

### DIFF
--- a/modules/govuk_jenkins/manifests/job/email_alert_check.pp
+++ b/modules/govuk_jenkins/manifests/job/email_alert_check.pp
@@ -54,6 +54,7 @@ class govuk_jenkins::job::email_alert_check (
       action_url          => $drug_job_url,
       notes_url           => monitoring_docs_url(email-alerts);
     "${travel_advice_check_name}_${::hostname}":
+      use                 => 'govuk_urgent_priority',
       service_description => $travel_advice_service_description,
       host_name           => $::fqdn,
       freshness_threshold => 5400, # 90 minutes


### PR DESCRIPTION
The icinga check verifies that travel advice emails have been sent to some test-email accounts.

This commit ups the priority to alert an on-call person. Previously this had the default "high_priority" priority which doesn't escalate to pagerduty.