### PR TITLE
Fix protected locations for nginx

### DIFF
--- a/modules/nginx/templates/proxy-vhost.conf
+++ b/modules/nginx/templates/proxy-vhost.conf
@@ -61,19 +61,11 @@ server {
 
   <%- end -%>
   location / {
-    <%- if @enable_basic_auth && @protected -%>
-      <%- if @protected_location != "/" -%>
-        location <%= @protected_location %> {
-      <%- end -%>
-
-          deny all;
-          auth_basic            "Enter the GOV.UK username/password (not your personal username/password)";
-          auth_basic_user_file  /etc/govuk.htpasswd;
-          satisfy any;
-
-      <%- if @protected_location != "/" -%>
-        }
-      <%- end -%>
+    <%- if @enable_basic_auth && @protected && @protected_location == "/" -%>
+    deny all;
+    auth_basic            "Enter the GOV.UK username/password (not your personal username/password)";
+    auth_basic_user_file  /etc/govuk.htpasswd;
+    satisfy any;
     <%- end -%>
 
     <%- if @single_page_app -%>
@@ -82,6 +74,21 @@ server {
     try_files $uri/index.html $uri.html $uri @app;
     <%- end -%>
   }
+
+  <%- if @enable_basic_auth && @protected && @protected_location != "/" -%>
+  location <%= @protected_location %> {
+    deny all;
+    auth_basic            "Enter the GOV.UK username/password (not your personal username/password)";
+    auth_basic_user_file  /etc/govuk.htpasswd;
+    satisfy any;
+
+    <%- if @single_page_app -%>
+    try_files $uri/index.html $uri.html $uri <%= @single_page_app %>;
+    <% else %>
+    try_files $uri/index.html $uri.html $uri @app;
+    <%- end -%>
+  }
+  <%- end -%>
 
   <%- @hidden_paths.each do |hidden_path| -%>
   location <%= hidden_path %> {


### PR DESCRIPTION
Nested location blocks don't work as I expect. This commit introduces more code but is more explicit about what's going on.

In the `location /` block, if basic auth is enabled and the protected location is `/` then set it up.

If basic auth is enabled and the location isn't `/`, create a new block (which nginx will match to if it's there because the prefix URL is longer).