### PR TITLE
Add `service_template` param to passive checks

### DIFF
--- a/modules/icinga/manifests/passive_check.pp
+++ b/modules/icinga/manifests/passive_check.pp
@@ -32,12 +32,16 @@
 #   and why the alert might exist. Should link to a section of the
 #   "opsmanual". This will be included in the Nagios UI and email alerts.
 #
+# [*service_template*]
+#   Which parent Icinga service to inherit from
+#
 define icinga::passive_check (
   $service_description,
   $host_name,
   $freshness_threshold = '',
   $action_url          = undef,
-  $notes_url           = undef
+  $notes_url           = undef,
+  $service_template = 'govuk_regular_service',
 ){
 
   validate_re($service_description, '^(\w|\s|\-|/|\[|\]|:|\.)*$', "Icinga check \"${service_description}\" contains invalid characters")

--- a/modules/icinga/templates/passive_service.erb
+++ b/modules/icinga/templates/passive_service.erb
@@ -1,5 +1,5 @@
 define service {
-  use                       govuk_regular_service
+  use                       <%= @service_template %>
   host_name                 <%= @host_name %>
   service_description       <%= @service_description %>
   active_checks_enabled     0


### PR DESCRIPTION
We want to make some passive checks more important than just regular service.