### PR TITLE
Give rabbitmq monitoring access to the stagecraft and backdrop_write vhosts

### DIFF
--- a/modules/govuk/manifests/apps/backdrop_write/rabbitmq.pp
+++ b/modules/govuk/manifests/apps/backdrop_write/rabbitmq.pp
@@ -38,4 +38,7 @@ class govuk::apps::backdrop_write::rabbitmq (
     write_permission     => '.*',
   }
 
+  rabbitmq_user_permissions { "${govuk_rabbitmq::monitoring_user}@/${amqp_vhost}":
+    read_permission      => '.*',
+  }
 }

--- a/modules/govuk/manifests/apps/stagecraft/rabbitmq.pp
+++ b/modules/govuk/manifests/apps/stagecraft/rabbitmq.pp
@@ -38,4 +38,7 @@ class govuk::apps::stagecraft::rabbitmq (
     write_permission     => '.*',
   }
 
+  rabbitmq_user_permissions { "${govuk_rabbitmq::monitoring_user}@/${amqp_vhost}":
+    read_permission      => '.*',
+  }
 }


### PR DESCRIPTION
We need this so that our new collectd stats gathering plugin (https://github.com/alphagov/govuk-puppet/pull/4304) will work on all queues.

@benhyland and @matmoore

Trello: https://trello.com/c/Ipl9UVsA