### PR TITLE
Prevent accidental activation of rummager worker.

### DIFF
--- a/modules/govuk/manifests/apps/rummager.pp
+++ b/modules/govuk/manifests/apps/rummager.pp
@@ -104,7 +104,13 @@ class govuk::apps::rummager(
     enable_service => $enable_procfile_worker,
   }
 
+  $toggled_ensure = $enable_publishing_api_document_indexer ? {
+    true    => present,
+    default => absent,
+  }
+
   govuk::procfile::worker { 'rummager-publishing-api-document-indexer':
+    ensure         => $toggled_ensure,
     setenv_as      => 'rummager',
     enable_service => $enable_publishing_api_document_indexer,
     process_type   => 'publishing-api-document-indexer',

--- a/modules/govuk/manifests/apps/rummager/rabbitmq.pp
+++ b/modules/govuk/manifests/apps/rummager/rabbitmq.pp
@@ -10,12 +10,21 @@
 #
 # [*password*]
 #   The password for the RabbitMQ user (default: 'rummager')
+# [*enable_publishing_api_document_indexer*]
+#   Whether or not to configure the queue for the rummager indexer
 #
 class govuk::apps::rummager::rabbitmq (
   $password  = 'rummager',
+  $enable_publishing_api_document_indexer = false,
 ) {
 
+  $toggled_ensure = $enable_publishing_api_document_indexer ? {
+    true    => present,
+    default => absent,
+  }
+
   govuk_rabbitmq::consumer { 'rummager':
+    ensure        => $toggled_ensure,
     amqp_pass     => $password,
     amqp_exchange => 'published_documents',
     amqp_queue    => 'rummager_to_be_indexed',


### PR DESCRIPTION
Recently the capistrano deployment job ran a task which erroneously enabled
the rummager indexer worker process. This should not be possible, and
could possibly have led to production issues (we got away with it this time).

Tie the presence of the upstart conf file for the worker to the feature flag -
when the flag is off the file is missing so it is not possible to accidentally
start the worker.

 Also tie the appropriate rabbitmq queue config to the same feature.

 @matmoore and @benhyland

See https://trello.com/c/hUWLNllj/583-fix-rogue-message-queue-worker-on-production