### PR TITLE
Add specialist-publisher-rebuild app for development

### DIFF
--- a/hieradata/class/backend.yaml
+++ b/hieradata/class/backend.yaml
@@ -27,6 +27,12 @@ govuk::apps::share_sale_publisher::mongodb_nodes:
   - 'mongo-2.backend'
   - 'mongo-3.backend'
 
+govuk::apps::specialist_publisher_rebuild::mongodb_name: 'specialist_publisher_rebuild_production'
+govuk::apps::specialist_publisher_rebuild::mongodb_nodes:
+  - 'mongo-1.backend'
+  - 'mongo-2.backend'
+  - 'mongo-3.backend'
+
 govuk::apps::travel_advice_publisher::mongodb_name: 'govuk_content_production'
 govuk::apps::travel_advice_publisher::mongodb_nodes:
   - 'mongo-1.backend'
@@ -65,6 +71,7 @@ govuk::node::s_base::apps:
   - sidekiq_monitoring
   - signon
   - specialist_publisher
+  - specialist_publisher_rebuild
   - support
   - support_api
   - tariff_admin

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -71,6 +71,7 @@ deployable_applications: &deployable_applications
   - smokey
   - specialist-frontend
   - specialist-publisher
+  - specialist-publisher-rebuild
   - spotlight
   - stagecraft
   - static
@@ -750,6 +751,7 @@ hosts::production::backend::app_hostnames:
   - 'short-url-manager'
   - 'signon'
   - 'specialist-publisher'
+  - 'specialist-publisher-rebuild'
   - 'support'
   - 'support-api'
   - 'tariff-admin'

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -87,6 +87,7 @@ govuk::node::s_development::apps:
   - 'smartanswers'
   - 'specialist_frontend'
   - 'specialist_publisher'
+  - 'specialist_publisher_rebuild'
   - 'stagecraft'
   - 'stagecraft::rabbitmq'
   - 'static'
@@ -164,6 +165,9 @@ govuk::apps::signon::redis_url: redis://localhost:6379/0
 govuk::apps::smartanswers::expose_govspeak: true
 govuk::apps::specialist_publisher::enable_procfile_worker: false
 govuk::apps::specialist_publisher::publish_pre_production_finders: true
+govuk::apps::specialist_publisher_rebuild::enabled: true
+govuk::apps::specialist_publisher_rebuild::mongodb_name: 'specialist_publisher_rebuild_production'
+govuk::apps::specialist_publisher_rebuild::mongodb_nodes: ['localhost']
 govuk::apps::stagecraft::worker::enabled: true
 govuk::apps::stagecraft::beat::enabled: true
 govuk::apps::stagecraft::celerycam::enabled: true
@@ -296,6 +300,7 @@ hosts::development::apps:
   - 'smartanswers'
   - 'specialist-frontend'
   - 'specialist-publisher'
+  - 'specialist-publisher-rebuild'
   - 'spotlight'
   - 'stagecraft'
   - 'static'

--- a/modules/govuk/manifests/apps/specialist_publisher_rebuild.pp
+++ b/modules/govuk/manifests/apps/specialist_publisher_rebuild.pp
@@ -1,0 +1,113 @@
+# == Class: govuk::apps::specialist_publisher_rebuild
+#
+# A rebuild of specialist-publisher, a publishing app for specialist documents and manuals.
+#
+# === Parameters
+#
+# [*port*]
+#   The port that publishing API is served on.
+#   Default: 3123
+#
+# [*asset_manager_bearer_token*]
+#   The bearer token to use when communicating with Asset Manager.
+#   Default: undef
+#
+# [*errbit_api_key*]
+#   Errbit API key for sending errors.
+#   Default: undef
+#
+# [*enabled*]
+#   A flag to toggle the app's existence on different environments.
+#   Default: false
+#
+# [*email_alert_api_bearer_token*]
+#   The bearer token to use when communicating with Email Alert API.
+#   Default: undef
+#
+# [*mongodb_nodes*]
+#   Array of hostnames for the mongo cluster to use.
+#
+# [*mongodb_name*]
+#   The mongo database to be used. Overriden in development
+#   to be 'content_store_development'.
+#
+# [*oauth_id*]
+#   Sets the OAuth ID for using GDS-SSO
+#   Default: undef
+#
+# [*oauth_secret*]
+#   Sets the OAuth Secret Key for using GDS-SSO
+#   Default: undef
+#
+# [*publishing_api_bearer_token*]
+#   The bearer token to use when communicating with Publishing API.
+#   Default: undef
+#
+# [*secret_key_base*]
+#   Used to set the app ENV var SECRET_KEY_BASE which is used to configure
+#   rails 4.x signed cookie mechanism. If unset the app will be unable to
+#   start.
+#   Default: undef
+#
+class govuk::apps::specialist_publisher_rebuild(
+  $port = 3123,
+  $asset_manager_bearer_token = undef,
+  $errbit_api_key = undef,
+  $email_alert_api_bearer_token = undef,
+  $enabled = false,
+  $mongodb_nodes,
+  $mongodb_name,
+  $oauth_id = undef,
+  $oauth_secret = undef,
+  $publishing_api_bearer_token = undef,
+  $secret_key_base = undef,
+) {
+  $app_name = 'specialist-publisher-rebuild'
+
+  if $enabled {
+    govuk::app { $app_name:
+      app_type           => 'rack',
+      port               => $port,
+      health_check_path  => '/healthcheck',
+      log_format_is_json => true,
+      asset_pipeline     => true,
+    }
+
+    Govuk::App::Envvar {
+      app => $app_name,
+    }
+
+    govuk::app::envvar::mongodb_uri { $app_name:
+      hosts    => $mongodb_nodes,
+      database => $mongodb_name,
+    }
+
+    govuk::app::envvar {
+      "${title}-ASSET_MANAGER_BEARER_TOKEN":
+        varname => 'ASSET_MANAGER_BEARER_TOKEN',
+        value   => $asset_manager_bearer_token;
+      "${title}-ERRBIT_API_KEY":
+        varname => 'ERRBIT_API_KEY',
+        value   => $errbit_api_key;
+      "${title}-EMAIL_ALERT_API_BEARER_TOKEN":
+        varname => 'EMAIL_ALERT_API_BEARER_TOKEN',
+        value   => $email_alert_api_bearer_token;
+      "${title}-OAUTH_ID":
+        varname => 'OAUTH_ID',
+        value   => $oauth_id;
+      "${title}-OAUTH_SECRET":
+        varname => 'OAUTH_SECRET',
+        value   => $oauth_secret;
+      "${title}-PUBLISHING_API_BEARER_TOKEN":
+        varname => 'PUBLISHING_API_BEARER_TOKEN',
+        value   => $publishing_api_bearer_token;
+    }
+
+    if $secret_key_base != undef {
+      govuk::app::envvar { "${title}-SECRET_KEY_BASE":
+        varname => 'SECRET_KEY_BASE',
+        value   => $secret_key_base,
+      }
+    }
+  }
+}

--- a/modules/govuk/manifests/node/s_backend_lb.pp
+++ b/modules/govuk/manifests/node/s_backend_lb.pp
@@ -65,6 +65,7 @@ class govuk::node::s_backend_lb (
       'share-sale-publisher',
       'signon',
       'specialist-publisher',
+      'specialist-publisher-rebuild',
       'short-url-manager',
       'support',
       'tariff-admin',


### PR DESCRIPTION
This is the first commit for setting up specialist-publisher-rebuild to
run on development.
Compared with specialist-publisher we have dropped the env vars for
nagios configs, preproduction finders, and sidekiq procfile workers
because the phase-2 rebuild doesn't yet use those configs.

Integration and further environments will come later.

cc: @benilovj @brenetic 