### PR TITLE
Removing rabbit permissions requires a user

### DIFF
--- a/modules/govuk_rabbitmq/manifests/consumer.pp
+++ b/modules/govuk_rabbitmq/manifests/consumer.pp
@@ -63,9 +63,6 @@ define govuk_rabbitmq::consumer (
       read_permission      => "^(amq\\.gen.*|${amqp_queue}|${amqp_exchange})$",
     }
   } else {
-    rabbitmq_user_permissions { "${amqp_user}@/":
-      ensure => absent,
-    } ->
     rabbitmq_user { $amqp_user:
       ensure   => absent,
     }


### PR DESCRIPTION
Under the hood, puppet runs `rabbitmqctl clear_permissions` for absent
permissions. This is super unhelpful because if the user doesn't exist,
rabbitmqctl returns an error and the puppet fails.

It's sufficient to just remove the user, as this also removes the
permissions.

This corrects an issue with https://github.com/alphagov/govuk-puppet/pull/4306 which is preventing from the puppet from running on integration.