### PR TITLE
Move GOVUK-Request-Id from varnish to nginx.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,6 +126,3 @@ DEPENDENCIES
   rspec-puppet
   sshkey (= 1.7.0)
   webmock (~> 1.20.0)
-
-BUNDLED WITH
-   1.10.5

--- a/modules/loadbalancer/templates/nginx_balance.conf.erb
+++ b/modules/loadbalancer/templates/nginx_balance.conf.erb
@@ -40,6 +40,7 @@ server {
   proxy_set_header X-Forwarded-Server $host;
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   proxy_set_header X-Forwarded-Proto $scheme;
+  proxy_set_header GOVUK-Request-Id $pid-$msec-$remote_addr-$request_length;
   proxy_redirect off;
 
   proxy_connect_timeout 1s;

--- a/modules/varnish/templates/default.vcl.erb
+++ b/modules/varnish/templates/default.vcl.erb
@@ -17,7 +17,6 @@ acl purge_acl {
 
 sub vcl_recv {
   unset req.http.GOVUK-Request-Id;
-  set req.http.GOVUK-Request-Id = server.identity + "-" + req.xid;
   unset req.http.GOVUK-Original-Url;
   set req.http.GOVUK-Original-Url = req.url;
 


### PR DESCRIPTION
DO NOT MERGE YET

This gives us tracing in our admin systems.

If we find that we need tracing back between varnish
and the router on our frontend systems we can add
a "GOVUK-Cache-Request-Id" or similar.

If anyone has any changes they'd like to make to the "unique enough" ID, please let me know.

I've confirmed via vagrant that `backend-lb-1` and `backend-1` will build and boot nginx happily, but had trouble trying to form convincing requests for it.