### PR TITLE
Change gof3r path to full

### DIFF
--- a/modules/govuk_mysql/spec/classes/govuk_mysql__xtrabackup_backup_spec.rb
+++ b/modules/govuk_mysql/spec/classes/govuk_mysql__xtrabackup_backup_spec.rb
@@ -18,6 +18,6 @@ describe 'govuk_mysql::xtrabackup::backup', :type => :class do
     it { is_expected.to contain_file('/etc/mysql/xtrabackup/env.d').with_ensure('directory') }
     it { is_expected.to contain_file('/etc/mysql/xtrabackup/env.d/AWS_SECRET_ACCESS_KEY').with_content(/walk-on-the-wild-side/) }
     it { is_expected.to contain_file('/etc/mysql/xtrabackup/env.d/AWS_ACCESS_KEY_ID').with_content(/lou-reed/) }
-    it { is_expected.to contain_file('/usr/local/bin/xtrabackup_s3_base').with_content(/.*innobackupex\ --extra-lsndir='\/var\/lib\/mysql\/'\ --encrypt=AES256\ --encrypt-key="thisisnotarealkey"\ --stream=xbstream\ --compress\ \.\ \|\ envdir \/etc\/mysql\/xtrabackup\/env\.d\ gof3r\ put\ --endpoint s3-eu-west-1\.amazonaws\.com\ -b\ foo\ -k\ \$\(cat \/var\/lib\/mysql\/xtrabackup_date\)\/base\.xbcrypt.*/) }
+    it { is_expected.to contain_file('/usr/local/bin/xtrabackup_s3_base').with_content(/.*innobackupex\ --extra-lsndir='\/var\/lib\/mysql\/'\ --encrypt=AES256\ --encrypt-key="thisisnotarealkey"\ --stream=xbstream\ --compress\ \.\ \|\ envdir \/etc\/mysql\/xtrabackup\/env\.d\ \/usr\/local\/bin\/gof3r\ put\ --endpoint s3-eu-west-1\.amazonaws\.com\ -b\ foo\ -k\ \$\(cat \/var\/lib\/mysql\/xtrabackup_date\)\/base\.xbcrypt.*/) }
   end
 end

--- a/modules/govuk_mysql/templates/usr/local/bin/xtrabackup_s3_base
+++ b/modules/govuk_mysql/templates/usr/local/bin/xtrabackup_s3_base
@@ -20,7 +20,7 @@ trap nagios_passive EXIT
 
 date +%Y%m%d-%H%M > /var/lib/mysql/xtrabackup_date
 
-innobackupex --extra-lsndir='/var/lib/mysql/' --encrypt=AES256 --encrypt-key="<%= @encryption_key %>" --stream=xbstream --compress . | envdir /etc/mysql/xtrabackup/env.d gof3r put --endpoint s3-<%= @aws_region -%>.amazonaws.com -b <%= @s3_bucket_name %> -k $(cat /var/lib/mysql/xtrabackup_date)/base.xbcrypt
+innobackupex --extra-lsndir='/var/lib/mysql/' --encrypt=AES256 --encrypt-key="<%= @encryption_key %>" --stream=xbstream --compress . | envdir /etc/mysql/xtrabackup/env.d /usr/local/bin/gof3r put --endpoint s3-<%= @aws_region -%>.amazonaws.com -b <%= @s3_bucket_name %> -k $(cat /var/lib/mysql/xtrabackup_date)/base.xbcrypt
 
 if [ $? == 0 ]
   then

--- a/modules/govuk_mysql/templates/usr/local/bin/xtrabackup_s3_incremental
+++ b/modules/govuk_mysql/templates/usr/local/bin/xtrabackup_s3_incremental
@@ -18,7 +18,7 @@ function nagios_passive () {
 
 trap nagios_passive EXIT
 
-innobackupex --incremental-basedir='/var/lib/mysql/' --encrypt=AES256 --encrypt-key="<%= @encryption_key %>" --stream=xbstream --compress --incremental . | envdir /etc/mysql/xtrabackup/env.d gof3r put --endpoint s3-<%= @aws_region -%>.amazonaws.com -b <%= @s3_bucket_name %> -k $(cat /var/lib/mysql/xtrabackup_date)/incremental-$(date +%Y%m%d-%H%M%S).xbcrypt
+innobackupex --incremental-basedir='/var/lib/mysql/' --encrypt=AES256 --encrypt-key="<%= @encryption_key %>" --stream=xbstream --compress --incremental . | envdir /etc/mysql/xtrabackup/env.d /usr/local/bin/gof3r put --endpoint s3-<%= @aws_region -%>.amazonaws.com -b <%= @s3_bucket_name %> -k $(cat /var/lib/mysql/xtrabackup_date)/incremental-$(date +%Y%m%d-%H%M%S).xbcrypt
 
 if [ $? == 0 ]
   then


### PR DESCRIPTION
Continuing my series of annoying little oversights, I got the following error on the cron run:

`envdir: fatal: unable to run gof3r: file does not exist`

Changed from just "gof3r" to "/usr/local/bin/gof3r" in the command.