### PR TITLE
Raise thresholds of alert

### DIFF
--- a/modules/govuk/manifests/node/s_asset_slave.pp
+++ b/modules/govuk/manifests/node/s_asset_slave.pp
@@ -53,8 +53,8 @@ class govuk::node::s_asset_slave (
 
   @@icinga::check::graphite { "asset_master_and_slave_disk_space_similar_from_${::hostname}":
     target    => "movingMedian(absolute(transformNull(diffSeries(${slave_metric},${master_metric}),0)),10)",
-    critical  => to_bytes('256 MB'),
-    warning   => to_bytes('128 MB'),
+    critical  => to_bytes('512 MB'),
+    warning   => to_bytes('384 MB'),
     desc      => 'Asset master and slave are using about the same amount of disk space',
     host_name => $::fqdn,
   }


### PR DESCRIPTION
This was added in ee785db742cf2ebbdd917b8393b18f3a6180b7c9 because the master and slave went out of sync. This has been refactored since then (https://github.com/alphagov/govuk-puppet/pull/3813) and believe it is more stable.

On a day to day basis the master and slaves go out of sync because there are some things which are specifically not synced in real time, such as `carrierwave-tmp/`. Each morning a full sync is run across the base directory, but the alert will throw up errors during the day because the threshold is low. Rather than hack anything about it, we can just expect a certain amount of variant and panic if it goes over half a gig; considering the directory is >500GB this isn't really that much.