### PR TITLE
Change rabbitmq monitoring user tag to 'monitoring'

### DIFF
--- a/modules/govuk_rabbitmq/manifests/init.pp
+++ b/modules/govuk_rabbitmq/manifests/init.pp
@@ -29,11 +29,9 @@ class govuk_rabbitmq (
     write_permission     => '.*',
   }
 
-  # FIXME: Consider using a normal user with a "monitoring" user tag.  Not
-  # configurable from puppet using the current puppetlabs/rabbitmq (4.0).
-  # Added here: https://github.com/puppetlabs/puppetlabs-rabbitmq/pull/193
   rabbitmq_user { $monitoring_user:
-    admin    => true,
+    admin    => false,
+    tags     => [ 'monitoring' ],
     password => $monitoring_password,
   }
 


### PR DESCRIPTION
Tag change to 'monitoring' from 'administrator'.

See the discussion of permissions at https://www.rabbitmq.com/management.html
This should have no production impact since noone should be using the monitoring
user to view users or permissions, close connections, or create vhosts.

**Merge only after https://github.com/alphagov/govuk-puppet/pull/4315 is merged, since we need to update the puppetlabs/rabbitmq module for this to work.**

See https://trello.com/c/eP2CdnrC/590-fix-rabbitmq-queue-binding