### PR TITLE
removes paging alerts for third party hosts

### DIFF
--- a/modules/icinga/files/etc/icinga/conf.d/third-party-host.cfg
+++ b/modules/icinga/files/etc/icinga/conf.d/third-party-host.cfg
@@ -1,0 +1,20 @@
+# Generic host definition template - This is NOT a real host, just a template!
+
+define host {
+  name                            third-party-host    ; The name of this host template
+  notifications_enabled           1       ; Host notifications are enabled
+  event_handler_enabled           1       ; Host event handler is enabled
+  flap_detection_enabled          1       ; Flap detection is enabled
+  failure_prediction_enabled      1       ; Failure prediction is enabled
+  process_perf_data               1       ; Process performance data
+  retain_status_information       1       ; Retain status information across program restarts
+  retain_nonstatus_information    1       ; Retain non-status information across program restarts
+  check_command                   check-host-alive
+  max_check_attempts              10
+  notification_interval           0
+  notification_period             24x7
+  notification_options            d,r
+  contact_groups                  high-priority
+  register                        0       ; DONT REGISTER THIS DEFINITION - ITS NOT A REAL HOST, JUST A TEMPLATE!
+}
+

--- a/modules/monitoring/manifests/network_checks.pp
+++ b/modules/monitoring/manifests/network_checks.pp
@@ -1,4 +1,4 @@
-# == Class: monitoring::network_checks
+# == Define: monitoring::network_checks
 #
 # Create a host with specified IP address and name, and include a basic ping
 # check.
@@ -17,6 +17,7 @@ define monitoring::network_checks (
       address             => $address,
       display_name        => $title,
       notification_period => 'inoffice',
+      use                 => 'third-party-host',
     }
 
     icinga::check { "check_ping_${title}":


### PR DESCRIPTION
We don't want to be paged when there are issues contacting third
party hosts like the VPN. Whereas the service alerts do not page
us, the host alerts currently do as that is the default for the
'generic-host' template

overrides #4296