### PR TITLE
Sync Whitehall attachments to S3

### DIFF
--- a/modules/govuk/manifests/node/s_asset_base.pp
+++ b/modules/govuk/manifests/node/s_asset_base.pp
@@ -71,16 +71,6 @@ class govuk::node::s_asset_base (
     require   => Package['nfs-kernel-server'],
   }
 
-  file { '/usr/local/bin/copy-attachments.sh':
-    source => 'puppet:///modules/govuk/node/s_asset_base/copy-attachments.sh',
-    mode   => '0755',
-  }
-
-  file { '/usr/local/bin/process-uploaded-attachments.sh':
-    content => template('govuk/node/s_asset_base/process-uploaded-attachments.sh'),
-    mode    => '0755',
-  }
-
   file { '/usr/local/bin/virus_scan.sh':
     source => 'puppet:///modules/govuk/node/s_asset_base/virus_scan.sh',
     mode   => '0755',

--- a/modules/govuk/templates/node/s_asset_base/copy-attachments.sh
+++ b/modules/govuk/templates/node/s_asset_base/copy-attachments.sh
@@ -27,3 +27,11 @@ for NODE in $ASSET_SLAVE_NODES; do
     logger -t copy_attachments "Attachments errored while copying to $NODE"
   fi
 done
+
+<% if @s3_bucket %>
+  if envdir /etc/govuk/aws/env.d /usr/local/bin/s3cmd --server-side-encryption sync --skip-existing --deleted-removed "$DIRECTORY_TO_COPY/" "s3://<%= @s3_bucket -%>$DIRECTORY_TO_COPY/"; then
+    logger -t process_uploaded_attachment "Attachments copied to S3 (<%= @s3_bucket -%>) successfully"
+  else
+    logger -t process_uploaded_attachment "Attachments errored while copying to S3 (<%= @s3_bucket -%>)"
+  fi
+<% end %>

--- a/modules/govuk/templates/node/s_asset_base/process-uploaded-attachments.sh
+++ b/modules/govuk/templates/node/s_asset_base/process-uploaded-attachments.sh
@@ -41,6 +41,13 @@ while IFS= read -r -d '' FILE
           logger -t process_uploaded_attachment "File $FILE failed to copy to $NODE"
         fi
       done
+      <% if @s3_bucket %>
+        if envdir /etc/govuk/aws/env.d /usr/local/bin/s3cmd --server-side-encryption put "$FILE_PATH" "s3://<%= @s3_bucket -%>$CLEAN_DIR/"; then
+          logger -t process_uploaded_attachment "File $FILE copied to S3 (<%= @s3_bucket -%>)"
+        else
+          logger -t process_uploaded_attachment "File $FILE failed to copy to S3 (<%= @s3_bucket -%>)"
+        fi
+      <% end %>
       rm "$FILE"
     else
       rsync --remove-source-files --relative "$FILE_PATH" "$INFECTED_DIR"

--- a/modules/govuk/templates/node/s_asset_base/s3cfg
+++ b/modules/govuk/templates/node/s_asset_base/s3cfg
@@ -1,0 +1,3 @@
+[default]
+bucket_location = eu-west-1
+use_https = True


### PR DESCRIPTION
This adds functionality to also backup Whitehall attachments to S3 by adding `s3cmd` to the loop in which attachments are copied over to the asset-slaves if they are detected as being free from viruses.

It is uploaded to S3 in the same directory structure as to the asset-slaves to help with consistency and make it easier to restore the directory structure if required. The nightly sync which also happens (to
ensure that the master and slaves are in sync is also updated.

The process which creates the `process-uploaded-attachments.sh` and `copy-attachments.sh` scripts are moved to asset-master only due to the way that they had to incorporate s3_bucket credentials.