### PR TITLE
Ensure rsync cron resources are purged

### DIFF
--- a/modules/govuk/manifests/node/s_asset_master.pp
+++ b/modules/govuk/manifests/node/s_asset_master.pp
@@ -59,6 +59,16 @@ class govuk::node::s_asset_master (
     require => $cron_requires,
   }
 
+  # FIXME: Remove once purged from production
+  cron { 'rsync-clean':
+    ensure => absent,
+    user   => 'assets',
+  }
+  cron { 'rsync-clean-draft':
+    ensure => absent,
+    user   => 'assets',
+  }
+
   @@icinga::passive_check { "check_process_attachments_${::hostname}":
     service_description => 'Process attachments last run',
     host_name           => $::fqdn,


### PR DESCRIPTION
These were removed in 1e13c72ea04979305716767b37cc86f5e6898dd4 but I didn't specify the user so the resources were never actually purged from production.