### PR TITLE
Licence Finder's short name is licencefinder

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -43,7 +43,7 @@ deployable_applications: &deployable_applications
   - imminence
   - info-frontend
   - kibana-gds
-  - licence-finder
+  - licencefinder
   - local-links-manager
   - manuals-frontend
   - mapit


### PR DESCRIPTION
A rogue hyphen snuck in as part of 0b6a732edbe48cab1353b65f530aebe83be16989 meaing we couldn't deploy Licence Finder.