### PR TITLE
Update app deployment job

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
@@ -6,7 +6,7 @@
             url: git@github.gds:gds/alphagov-deployment.git
             branches:
               - <%= @alphagov_deployment_branch %>
-            wipe-workspace: false
+            wipe-workspace: true
 
 - job:
     name: Deploy_App
@@ -29,15 +29,22 @@
             export TAG="$TAG"
             export ORGANISATION="<%= @environment -%>"
             export CI_DEPLOY_JENKINS_API_KEY="<%= @ci_deploy_jenkins_api_key -%>"
-            mkdir -p "$WORKSPACE/$TARGET_APPLICATION/"
-            cd "$WORKSPACE/$TARGET_APPLICATION/"
+            cd "$WORKSPACE/"
             logger -p INFO -t jenkins "DEPLOYMENT: ${JOB_NAME} ${BUILD_NUMBER} ${TARGET_APPLICATION} ${TAG} (${BUILD_URL})"
-            if [ -e "deploy.sh" ]; then
-              echo "---> Found deploy.sh, running 'sh -e deploy.sh'" >&2
-              exec sh -e deploy.sh
+            if [ -d "$TARGET_APPLICATION" ]; then
+              cd "$TARGET_APPLICATION/"
+              if [ -e "deploy.sh" ]; then
+                echo "---> Found deploy.sh, running 'sh -e deploy.sh'" >&2
+                exec sh -e deploy.sh
+              else
+                echo "---> No deploy.sh found, running 'bundle exec cap \"${DEPLOY_TASK}\"'" >&2
+                exec bundle exec cap "$DEPLOY_TASK"
+              fi
             else
-              echo "---> No deploy.sh found, running 'bundle exec cap \"${DEPLOY_TASK}\"'" >&2
-              exec bundle exec cap "$DEPLOY_TASK"
+              git clone "git@github.com:alphagov/${TARGET_APPLICATION}.git"
+              cd "$TARGET_APPLICATION/"
+              git checkout $TAG
+              BUNDLE_GEMFILE=${WORKSPACE}/Gemfile bundle exec cap "$DEPLOY_TASK"
             fi
     publishers:
         - trigger:


### PR DESCRIPTION
This change allows us to use Capistrano recipes which are in the app
repo (in public). This is good because it means more people can access
stuff and see how it works.

- We need to wipe the workspace because we're making clones inside clones
  (it only takes about a minute longer)
- For existing apps the process should be exactly the same
- For apps that aren't defined in alphagov-deployment, this change will
  use the Capistrano recipe from the app repo
- We have to remove the Gemfile so that it uses the bundler bundle from
  the main alphagov-deployment (not the app's bundle)