### PR TITLE
Allow deploy user to restart postgres on integration and staging.

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -220,6 +220,10 @@ govuk::node::s_monitoring::offsite_backups: false
 govuk::node::s_whitehall_backend::sync_mirror: true
 govuk::node::s_transition_postgresql_slave::redirector_ip_range: '10.1.5.0/24'
 
+govuk_sudo::sudo_conf:
+  deploy_service_postgresql:
+    content: 'deploy ALL=NOPASSWD:/etc/init.d/postgresql'
+
 # FIXME: This PPA should be renamed 'integration'
 govuk_ppa::path: 'preview'
 

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -157,6 +157,10 @@ govuk::node::s_licensify_mongo::mongodb_backup_disk: '/dev/sdb1'
 govuk::node::s_monitoring::offsite_backups: false
 govuk::node::s_transition_postgresql_slave::redirector_ip_range: '10.2.5.0/24'
 
+govuk_sudo::sudo_conf:
+  deploy_service_postgresql:
+    content: 'deploy ALL=NOPASSWD:/etc/init.d/postgresql'
+
 grafana::dashboards::machine_suffix_metrics: '_staging'
 
 hosts::production::ip_api_lb: '10.2.4.254'


### PR DESCRIPTION
This is used by the data sync job to clean up
connections after swapping out the postgres data.