### PR TITLE
Update project to string rather than choice

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -482,18 +482,6 @@ govuk_jenkins::job::smokey::signon_password: "%{hiera('smokey_signon_password')}
 govuk_jenkins::job::run_rake_task::applications: *deployable_applications
 govuk_jenkins::job::deploy_app::applications: *deployable_applications
 
-govuk_jenkins::job::deploy_terraform_project::projects:
-  - base_aws_infrastructure
-  - dev_vm
-  - elasticsearch_snapshots
-  - mongodb-backup-s3
-  - mysql_xtrabackups
-  - packer_ami_builder
-  - uktt_data
-  - wal-e_backups_api-postgresql
-  - wal-e_backups_postgresql
-  - wal-e_backups_transition-postgresql
-
 govuk_mysql::server::expire_log_days: 3
 govuk_mysql::server::monitoring::master::plaintext_mysql_password: "%{hiera('mysql_nagios')}"
 govuk_mysql::server::monitoring::slave::plaintext_mysql_password: "%{hiera('mysql_nagios')}"

--- a/modules/govuk_jenkins/manifests/job/deploy_terraform_project.pp
+++ b/modules/govuk_jenkins/manifests/job/deploy_terraform_project.pp
@@ -12,10 +12,7 @@
 class govuk_jenkins::job::deploy_terraform_project (
   $apt_mirror_hostname = '',
   $aws_account_id = '',
-  $projects = [],
 ) {
-  validate_array($projects)
-
   file { '/etc/jenkins_jobs/jobs/deploy_terraform_project.yaml':
     ensure  => present,
     content => template('govuk_jenkins/jobs/deploy_terraform_project.yaml.erb'),

--- a/modules/govuk_jenkins/templates/jobs/deploy_terraform_project.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_terraform_project.yaml.erb
@@ -11,7 +11,9 @@
     display-name: Deploy_Terraform_Project
     project-type: freestyle
     description: |
-      Deploy a specific Terraform project in <%= @environment -%>.
+        Deploy a specific Terraform project in <%= @environment -%>.
+        Projects currently available can be found in Github: https://github.com/alphagov/govuk-terraform-provisioning/tree/master/projects
+
     properties:
         - github:
             url: https://github.com/alphagov/govuk-terraform-provisioning/
@@ -41,7 +43,7 @@
             choices:
                 - plan
                 - apply
-        - choice:
+        - string:
             name: PROJECT_NAME
             description: Name of the project you wish to deploy
-            choices: <%= ['-- Choose a project'] + @projects %>
+            default: false


### PR DESCRIPTION
With the amount of projects rapidly expanding it's a pain to have to add them to hieradata for the sake of a dropdown choice. Dynamically generating the projects in Jenkins is probably possible but isn't worth
the effort. Let's just get the user to type in the project instead, and if it's mistyped it'll just fail anyway.