### PR TITLE
Add env vars for panopticon.

### DIFF
--- a/hieradata/class/backend.yaml
+++ b/hieradata/class/backend.yaml
@@ -15,6 +15,12 @@ govuk::apps::contentapi::mongodb_nodes:
   - 'mongo-2.backend'
   - 'mongo-3.backend'
 
+govuk::apps::panopticon::mongodb_name: 'govuk_content_production'
+govuk::apps::panopticon::mongodb_nodes:
+  - 'mongo-1.backend'
+  - 'mongo-2.backend'
+  - 'mongo-3.backend'
+
 govuk::apps::publisher::mongodb_name: 'govuk_content_production'
 govuk::apps::publisher::mongodb_nodes:
   - 'mongo-1.backend'

--- a/modules/govuk/manifests/apps/panopticon.pp
+++ b/modules/govuk/manifests/apps/panopticon.pp
@@ -29,6 +29,15 @@
 #   The bearer token to use when communicating with Publishing API.
 #   Default: undef
 #
+# [*secret_key_base*]
+#   The key for Rails to use when signing/encrypting sessions.
+#
+# [*mongodb_name*]
+#   The Mongo database to be used.
+#
+# [*mongodb_nodes*]
+#   Array of hostnames for the mongo cluster to use.
+#
 class govuk::apps::panopticon(
   $port = '3003',
   $rabbitmq_hosts = ['localhost'],
@@ -36,6 +45,9 @@ class govuk::apps::panopticon(
   $rabbitmq_password = 'panopticon',
   $enable_procfile_worker = true,
   $publishing_api_bearer_token = undef,
+  $secret_key_base = undef,
+  $mongodb_name = undef,
+  $mongodb_nodes = undef,
 ) {
   govuk::app { 'panopticon':
     app_type           => 'rack',
@@ -51,9 +63,20 @@ class govuk::apps::panopticon(
     app => 'panopticon',
   }
 
-  govuk::app::envvar { "${title}-PUBLISHING_API_BEARER_TOKEN":
-    varname => 'PUBLISHING_API_BEARER_TOKEN',
-    value   => $publishing_api_bearer_token,
+  govuk::app::envvar {
+    "${title}-PUBLISHING_API_BEARER_TOKEN":
+      varname => 'PUBLISHING_API_BEARER_TOKEN',
+      value   => $publishing_api_bearer_token;
+    "${title}-SECRET_KEY_BASE":
+      varname => 'SECRET_KEY_BASE',
+      value   => $secret_key_base;
+  }
+
+  if $mongodb_nodes != undef {
+    govuk::app::envvar::mongodb_uri { 'panopticon':
+      hosts    => $mongodb_nodes,
+      database => $mongodb_name,
+    }
   }
 
   govuk::app::envvar::rabbitmq { 'panopticon':


### PR DESCRIPTION
This adds MONGODB_URI and SECRET_KEY_BASE, which are required in the
upgrade to the latest versions of Mongoid/govuk_content_models. The
latter will be populated by the deployment hieradata.