### PR TITLE
Change how all apps deploy

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -121,7 +121,6 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::whitehall_update_integration_data
 govuk_jenkins::job_builder::environment: 'integration'
 
-govuk_jenkins::job::deploy_app::alphagov_deployment_branch: 'master'
 govuk_jenkins::job::deploy_licensify::alphagov_deployment_branch: 'master'
 govuk_jenkins::job::deploy_puppet::commitish: 'preview'
 

--- a/modules/govuk_jenkins/manifests/job/deploy_app.pp
+++ b/modules/govuk_jenkins/manifests/job/deploy_app.pp
@@ -4,10 +4,6 @@
 #
 # === Parameters
 #
-# [*alphagov_deployment_branch*]
-#   The branch of the `alphagov-deployment` repository to use to
-#   deploy applications
-#
 # [*app_domain*]
 #   The hostname where applications are served from
 #
@@ -18,7 +14,6 @@
 #   API key to download build artefacts from CI servers
 #
 class govuk_jenkins::job::deploy_app (
-  $alphagov_deployment_branch = 'release',
   $app_domain = undef,
   $auth_token = undef,
   $ci_deploy_jenkins_api_key = undef,

--- a/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
@@ -3,10 +3,10 @@
     name: alphagov-deployment_Deploy_App
     scm:
         - git:
-            url: git@github.gds:gds/alphagov-deployment.git
+            url: git@github.com:alphagov/govuk-app-deployment.git
             branches:
-              - <%= @alphagov_deployment_branch %>
-            wipe-workspace: false
+              - master
+            wipe-workspace: true
 
 - job:
     name: Deploy_App
@@ -18,27 +18,17 @@
     <%- end -%>
     properties:
         - github:
-            url: https://github.gds/gds/alphagov-deployment/
+            url: https://github.com/alphagov/govuk-app-deployment
     scm:
       - alphagov-deployment_Deploy_App
     builders:
         - shell: |
-            ./jenkins.sh
             export DEPLOY_TO="<%= @environment -%>"
             export DEPLOY_TASK="$DEPLOY_TASK"
             export TAG="$TAG"
             export ORGANISATION="<%= @environment -%>"
             export CI_DEPLOY_JENKINS_API_KEY="<%= @ci_deploy_jenkins_api_key -%>"
-            mkdir -p "$WORKSPACE/$TARGET_APPLICATION/"
-            cd "$WORKSPACE/$TARGET_APPLICATION/"
-            logger -p INFO -t jenkins "DEPLOYMENT: ${JOB_NAME} ${BUILD_NUMBER} ${TARGET_APPLICATION} ${TAG} (${BUILD_URL})"
-            if [ -e "deploy.sh" ]; then
-              echo "---> Found deploy.sh, running 'sh -e deploy.sh'" >&2
-              exec sh -e deploy.sh
-            else
-              echo "---> No deploy.sh found, running 'bundle exec cap \"${DEPLOY_TASK}\"'" >&2
-              exec bundle exec cap "$DEPLOY_TASK"
-            fi
+            ./jenkins.sh
     publishers:
         - trigger:
             project: Smokey


### PR DESCRIPTION
**This cannot be merged until all the apps have been migrated to work this way.**

- This is so everyone is able to see how all the Capistrano config works
for each app.
- This is using the new [public
  repo](https://github.com/alphagov/govuk-app-deployment).
- The Capistrano recipes will all be the above public repo.
- The secrets will remain in alphagov-deployment.
- Also we are now using the master branch of govuk-app-deployment

@alexmuller @brenetic @emmabeynon @klssmith