### PR TITLE
moves govuk_crawler_worker rabbitmq to 'mirrorer'

### DIFF
--- a/hieradata/class/mirrorer.yaml
+++ b/hieradata/class/mirrorer.yaml
@@ -1,6 +1,8 @@
 ---
 govuk_crawler::mirror_root: '/mnt/crawler_worker'
 
+govuk::apps::govuk_crawler_worker::amqp_host: "%{hiera('govuk_crawler::amqp_host')}"
+
 govuk::node::s_base::apps:
   - govuk_crawler_worker
 

--- a/hieradata/class/rabbitmq.yaml
+++ b/hieradata/class/rabbitmq.yaml
@@ -4,7 +4,6 @@ govuk::node::s_rabbitmq::apps_using_rabbitmq:
   - backdrop_write
   - content_register
   - email_alert_service
-  - govuk_crawler_worker
   - panopticon
   - publishing_api
   - rummager

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -433,7 +433,7 @@ govuk_cdnlogs::service_port_map:
   assets: 6515
   bouncer: 6516
 
-govuk_crawler::amqp_host: 'rabbitmq-1.backend'
+govuk_crawler::amqp_host: 'localhost'
 govuk_crawler::site_root: 'https://www.gov.uk'
 
 govuk_elasticsearch::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"

--- a/modules/govuk/manifests/apps/govuk_crawler_worker.pp
+++ b/modules/govuk/manifests/apps/govuk_crawler_worker.pp
@@ -36,6 +36,7 @@ class govuk::apps::govuk_crawler_worker (
   $airbrake_api_key = '',
   $airbrake_endpoint = '',
   $airbrake_env = '',
+  $amqp_host = 'localhost',
   $amqp_pass = 'guest',
   $blacklist_paths = [],
   $enabled   = false,
@@ -58,7 +59,7 @@ class govuk::apps::govuk_crawler_worker (
       'AIRBRAKE_ENV':
         value => $airbrake_env;
       'AMQP_ADDRESS':
-        value => "amqp://govuk_crawler_worker:${amqp_pass}@rabbitmq-1:5672/";
+        value => "amqp://govuk_crawler_worker:${amqp_pass}@${amqp_host}:5672/";
       'AMQP_EXCHANGE':
         value => 'govuk_crawler_exchange';
       'AMQP_MESSAGE_QUEUE':
@@ -93,5 +94,7 @@ class govuk::apps::govuk_crawler_worker (
       command            => './govuk_crawler_worker -json',
       health_check_path  => '/healthcheck',
     }
+
+    include govuk::apps::govuk_crawler_worker::rabbitmq
   }
 }

--- a/modules/govuk/manifests/node/s_mirrorer.pp
+++ b/modules/govuk/manifests/node/s_mirrorer.pp
@@ -1,5 +1,6 @@
 # Node defintion for mirrorer-?.management boxen
 class govuk::node::s_mirrorer inherits govuk::node::s_base {
   include govuk_crawler
+  include govuk_rabbitmq
   include nginx
 }


### PR DESCRIPTION
The crawler has been known to crash the production rabbitmq.
It has beed decided to move the rabbitmq process away from
the rabbitmq cluster and to create a local rabbitmq instance
on the mirrorer app server. This will effectively make the
govuk_crawler_worker app self contained and should lighten
the load on the rabbitmq cluster