### PR TITLE
Revert no-cache rule for front-end homepage

### DIFF
--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -123,7 +123,6 @@ govuk::apps::email_campaign_api::mongodb_nodes: ['localhost']
 govuk::apps::email_alert_service::rabbitmq_hosts: ['localhost']
 govuk::apps::event_store::enabled: true
 govuk::apps::event_store::mongodb_servers: ['localhost']
-govuk::apps::frontend::enable_homepage_nocache_location: false
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
 govuk::apps::hmrc_manuals_api::enable_procfile_worker: false
 govuk::apps::govuk_cdn_logs_monitor::enabled: false

--- a/modules/govuk/manifests/apps/frontend.pp
+++ b/modules/govuk/manifests/apps/frontend.pp
@@ -8,10 +8,6 @@
 #   The port that the app is served on.
 #   Default: 3005
 #
-# [*enable_homepage_nocache_location*]
-#   Adds nginx configuration to never cache the homepage/no-cache location.
-#   Default: true
-#
 # [*vhost_protected*]
 #   Should this vhost be protected with HTTP Basic auth?
 #   Default: undef
@@ -28,23 +24,12 @@
 #
 class govuk::apps::frontend(
   $port = '3005',
-  $enable_homepage_nocache_location = true,
   $vhost_protected = false,
   $publishing_api_bearer_token = undef,
   $nagios_memory_warning = undef,
   $nagios_memory_critical = undef,
 ) {
-  validate_bool($enable_homepage_nocache_location)
-
-  if ($enable_homepage_nocache_location) {
-    $nginx_extra_config = '
-  location ^~ /frontend/homepage/no-cache/ {
-    expires epoch;
-  }
-'
-  } else {
-    $nginx_extra_config = ''
-  }
+  $nginx_extra_config = ''
 
   govuk::app { 'frontend':
     app_type               => 'rack',

--- a/modules/govuk/manifests/apps/frontend.pp
+++ b/modules/govuk/manifests/apps/frontend.pp
@@ -29,7 +29,6 @@ class govuk::apps::frontend(
   $nagios_memory_warning = undef,
   $nagios_memory_critical = undef,
 ) {
-  $nginx_extra_config = ''
 
   govuk::app { 'frontend':
     app_type               => 'rack',
@@ -40,7 +39,6 @@ class govuk::apps::frontend(
     log_format_is_json     => true,
     asset_pipeline         => true,
     asset_pipeline_prefix  => 'frontend',
-    nginx_extra_config     => $nginx_extra_config,
     nagios_memory_warning  => $nagios_memory_warning,
     nagios_memory_critical => $nagios_memory_critical,
   }


### PR DESCRIPTION
The code to remove non-js tracking has been removed in:
https://github.com/alphagov/frontend/pull/944

Also remove the corresponding parts added in:
https://github.gds/gds/puppet/pull/978
https://github.com/alphagov/govuk-puppet/commit/003254aad44ce391b595220f707ccba7367c1adf
https://github.com/alphagov/govuk-puppet/commit/e10bc998cc9229308c321f00cc6a0129b846582e