### PR TITLE
Stop GOVUK-Request-Id from being overwritten.

### DIFF
--- a/modules/loadbalancer/templates/nginx_balance.conf.erb
+++ b/modules/loadbalancer/templates/nginx_balance.conf.erb
@@ -40,7 +40,13 @@ server {
   proxy_set_header X-Forwarded-Server $host;
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   proxy_set_header X-Forwarded-Proto $scheme;
-  proxy_set_header GOVUK-Request-Id $pid-$msec-$remote_addr-$request_length;
+
+  # Set GOVUK-Request-Id if not already set
+  map $upstream_http_govuk_request_id $govuk_request_id {
+   '' $pid-$msec-$remote_addr-$request_length;
+  }
+  add_header GOVUK-Request-Id $govuk_request_id;
+
   proxy_redirect off;
 
   proxy_connect_timeout 1s;


### PR DESCRIPTION
Requests from backend apps to backend apps go back
through the relevant load balancers and so get their
ID reset.

This alternate method should only set the variable
if it is not already set.  For prior art see
https://github.com/alphagov/govuk-puppet/blob/ef5f4bc4f9ff011ce592098dd7f9f4c71e4648d8/modules/nginx/files/map-sts.conf