### PR TITLE
Revert "Stop GOVUK-Request-Id from being overwritten."

### DIFF
--- a/modules/loadbalancer/templates/nginx_balance.conf.erb
+++ b/modules/loadbalancer/templates/nginx_balance.conf.erb
@@ -40,13 +40,7 @@ server {
   proxy_set_header X-Forwarded-Server $host;
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   proxy_set_header X-Forwarded-Proto $scheme;
-
-  # Set GOVUK-Request-Id if not already set
-  map $upstream_http_govuk_request_id $govuk_request_id {
-   '' $pid-$msec-$remote_addr-$request_length;
-  }
-  add_header GOVUK-Request-Id $govuk_request_id;
-
+  proxy_set_header GOVUK-Request-Id $pid-$msec-$remote_addr-$request_length;
   proxy_redirect off;
 
   proxy_connect_timeout 1s;


### PR DESCRIPTION
Reverts alphagov/govuk-puppet#4356

Doesn't work, causes more trouble than it's worth anyway.  Another fix will come later.