### PR TITLE
Add service-manual-frontend to development hierdata

### DIFF
--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -80,6 +80,7 @@ govuk::node::s_development::apps:
   - 'rummager'
   - 'rummager::rabbitmq'
   - 'search_admin'
+  - 'service_manual_frontend'
   - 'service_manual_publisher'
   - 'share_sale_publisher'
   - 'short_url_manager'
@@ -156,6 +157,7 @@ govuk::apps::router_api::mongodb_nodes: ['localhost']
 govuk::apps::router_api::router_nodes: ['localhost:3055']
 govuk::apps::rummager::enable_procfile_worker: false
 govuk::apps::rummager::rabbitmq_hosts: ['localhost']
+govuk::apps::service_manual_frontend::enabled: true
 govuk::apps::share_sale_publisher::enabled: true
 govuk::apps::share_sale_publisher::mongodb_nodes: ['localhost']
 govuk::apps::share_sale_publisher::mongodb_name: 'share_sale_publisher_development'


### PR DESCRIPTION
Required in order to run service-manual-frontend in the development VM.