### PR TITLE
Add monitoring for archiving

### DIFF
--- a/modules/govuk_postgresql/templates/usr/local/bin/wal-e_postgres_archiving_wrapper.erb
+++ b/modules/govuk_postgresql/templates/usr/local/bin/wal-e_postgres_archiving_wrapper.erb
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -e
+
+# Redirect stdout and stderr to syslog
+exec 1> >(/usr/bin/logger -s -t $(basename $0)) 2>&1
+
+# The default Icinga passive alert assumes that the script failed
+NAGIOS_CODE=2
+NAGIOS_MESSAGE="CRITICAL: PostgreSQL WAL-E archiving to S3 failed"
+
+# Triggered whenever this script exits, successful or otherwise. The values
+# of CODE/MESSAGE will be taken from that point in time.
+function nagios_passive () {
+  printf "<%= @ipaddress %>\t<%= @service_desc_wale_archiving %>\t${NAGIOS_CODE}\t${NAGIOS_MESSAGE}\n" | /usr/sbin/send_nsca -H alert.cluster >/dev/null
+}
+
+trap nagios_passive EXIT
+
+envdir /etc/wal-e/env.d /usr/local/bin/wal-e wal-push %p
+
+if [ $? == 0 ]
+  then
+    STATUS=0
+  else
+    STATUS=1
+fi
+
+if [ $STATUS -eq 0 ]; then
+  NAGIOS_CODE=0
+  NAGIOS_MESSAGE="OK: PostgreSQL WAL-E archiving to S3 succeeded"
+fi
+
+exit $STATUS


### PR DESCRIPTION
When we use WAL-E for backups we switch on the WAL continuous archiving option
(http://www.postgresql.org/docs/9.3/static/continuous-archiving.html). Everytime a WAL segment is archived ends up in S3, and the archive timeout option is set to 60 seconds, which means we will push something to S3 every 60 seconds.

This adds a wrapper around the command which includes a passive check set to a threshold of 15 minutes. If a WAL segment hasn't been archived for over 15 minutes then we'll be alerted (this might be a problem overnight in Integration when the machines turn off).

I've gone for this option for ease of use, though it may be better to gather metrics somehow on how far behind the archiving is, but ideally we just need to know if there's been a problem with the archiving process which this PR achieves. There might also be questions about how often we want to archive WAL segments, and if we want to make it less frequent than every minute (which could potentially save on disk and bandwidth charges to S3)?