### PR TITLE
Support old rails in govuk_app_console

### DIFF
--- a/modules/govuk_scripts/files/usr/local/bin/govuk_app_console
+++ b/modules/govuk_scripts/files/usr/local/bin/govuk_app_console
@@ -18,6 +18,8 @@ cd /var/apps/$1
 
 if [ -f bin/rails ]; then
   sudo -u deploy govuk_setenv $1 bundle exec ./bin/rails console
+elif [ -f script/rails ]; then
+  sudo -u deploy govuk_setenv $1 bundle exec ./script/rails console
 elif [ -f console ]; then
   sudo -u deploy govuk_setenv $1 bundle exec ./console
 else


### PR DESCRIPTION
Before rails switched to the more standard `bin`
directory for storing the `rails` executable it
used the directory `script`, but it works the same.