### PR TITLE
Add dashboard to hold graphs for publishing api queues

### DIFF
--- a/modules/grafana/files/dashboards/publishing_queues.json
+++ b/modules/grafana/files/dashboards/publishing_queues.json
@@ -1,0 +1,129 @@
+{
+  "title": "Publishing Queues",
+  "style": "dark",
+  "timezone": "utc",
+  "editable": true,
+  "hideControls": false,
+  "sharedCrosshair": false,
+  "rows": [
+    {
+      "title": "Panopticon",
+      "height": "250px",
+      "editable": true,
+      "collapse": false,
+      "panels": [
+        {
+          "title": "Panopticon Consumers",
+          "error": false,
+          "span": 10,
+          "editable": true,
+          "type": "graph",
+          "id": 1,
+          "datasource": null,
+          "renderer": "flot",
+          "x-axis": true,
+          "y-axis": true,
+          "y_formats": [
+            "short",
+            "short"
+          ],
+          "grid": {
+            "leftMax": null,
+            "rightMax": null,
+            "leftMin": 0,
+            "rightMin": null,
+            "threshold1": null,
+            "threshold2": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "lines": false,
+          "fill": 0,
+          "linewidth": 1,
+          "points": false,
+          "pointradius": 5,
+          "bars": true,
+          "stack": false,
+          "percentage": false,
+          "legend": {
+            "show": true,
+            "values": false,
+            "min": false,
+            "max": false,
+            "current": false,
+            "total": false,
+            "avg": false
+          },
+          "nullPointMode": "connected",
+          "steppedLine": false,
+          "tooltip": {
+            "value_type": "cumulative",
+            "shared": false
+          },
+          "targets": [
+            {
+              "target": "alias(consolidateBy(summarize(stats_counts.govuk.app.panopticon.panopticon.started, '1minute', 'sum'), 'max'), 'started')"
+            },
+            {
+              "target": "alias(consolidateBy(summarize(stats_counts.govuk.app.panopticon.panopticon.acked, '1minute', 'sum'), 'max'), 'acked')"
+            },
+            {
+              "target": "alias(consolidateBy(summarize(stats_counts.govuk.app.panopticon.panopticon.retried, '1minute', 'sum'), 'max'), 'retried')"
+            },
+            {
+              "target": "alias(consolidateBy(summarize(stats_counts.govuk.app.panopticon.panopticon.discarded, '1minute', 'sum'), 'max'), 'discarded')"
+            },
+            {
+              "target": "alias(consolidateBy(summarize(stats_counts.govuk.app.panopticon.panopticon.uncaught_exception, '1minute', 'sum'), 'max'), 'uncaught_exception')"
+            }
+          ],
+          "aliasColors": {},
+          "seriesOverrides": [],
+          "links": [],
+          "maxDataPoints": "",
+          "leftYAxisLabel": "msgs per min"
+        }
+      ]
+    }
+  ],
+  "nav": [
+    {
+      "type": "timepicker",
+      "collapse": false,
+      "notice": false,
+      "enable": true,
+      "status": "Stable",
+      "time_options": [
+        "5m",
+        "15m",
+        "1h",
+        "6h",
+        "12h",
+        "24h",
+        "2d",
+        "7d",
+        "30d"
+      ],
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "now": true
+    }
+  ],
+  "time": {
+    "from": "now-12h",
+    "to": "now"
+  },
+  "refresh": "30s",
+  "version": 6,
+  "hideAllLegends": false
+}


### PR DESCRIPTION
We introduce a graph for panopticon only, non-erb-templated, as a first pass.
We will tidy and add extra graphs soon, but want to merge as we go
because there is still incremental value here.

https://trello.com/c/Ipl9UVsA/578-monitor-rummager-s-current-queue-size-with-statsd-graphite-m

This graph shows all the stats that might be reported by the
govuk_message_queue_consumer gem.

It ensures that the height of the graph is always representing actual stat values,
by using summarize and consolidateBy(max) graphite functions.
See http://graphite.readthedocs.org/en/latest/functions.html
As a result, it is possible for the area under the graph to not accurately represent
the running total correctly - but this feature is not expected by dev users (i.e. us!).
The tradeoff is necessary due to the aggregation and bucketing done by statsd
and graphite, and by the possibility that there might be fewer pixels than buckets.

@jackscotti and @benhyland