### PR TITLE
Fixes for rebuilding service manual search index

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
@@ -34,7 +34,9 @@
             project: Smokey
         - trigger-parameterized-builds:
             - project: GDS_Production_Backup, service-manual_rebuild_search_index
-              predefined-parameters: TARGET_APPLICATION_GIT_REPO=$WORKSPACE/$TARGET_APPLICATION
+              predefined-parameters: |
+                TARGET_APPLICATION=$TARGET_APPLICATION
+                TARGET_APPLICATION_GIT_REPO=$WORKSPACE/$TARGET_APPLICATION
               condition: 'UNSTABLE_OR_BETTER'
     wrappers:
         - ansicolor:

--- a/modules/govuk_jenkins/templates/jobs/service_manual_rebuild_search_index.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/service_manual_rebuild_search_index.yaml.erb
@@ -11,8 +11,8 @@
     builders:
         - shell: |
             if [ "$TARGET_APPLICATION" = "designprinciples" ]; then
-            ssh deploy@search-1.api.<%= @environment -%> 'cd /var/apps/rummager && RUMMAGER_INDEX=service-manual govuk_setenv rummager bundle exec rake rummager:switch_to_empty_index '
-            ssh deploy@frontend-1.frontend.<%= @environment -%> 'cd /var/apps/designprinciples && govuk_setenv designprinciples bundle exec rake rummager:index'
+            ssh deploy@search-1.api 'cd /var/apps/rummager && RUMMAGER_INDEX=service-manual govuk_setenv rummager bundle exec rake rummager:switch_to_empty_index '
+            ssh deploy@frontend-1.frontend 'cd /var/apps/designprinciples && govuk_setenv designprinciples bundle exec rake rummager:index'
             else
               echo "Not building '$TARGET_APPLICATION'"
             fi


### PR DESCRIPTION
After deploying designprincples we want to purge the service-manual search index and rebuild it so old pages no longer exist in search. It probably once worked but something changed at some point.