### PR TITLE
Bugfix archiving command

### DIFF
--- a/modules/govuk_postgresql/manifests/wal_e/backup.pp
+++ b/modules/govuk_postgresql/manifests/wal_e/backup.pp
@@ -67,7 +67,7 @@ class govuk_postgresql::wal_e::backup (
       'archive_mode':
         value => 'on';
       'archive_command':
-        value => '/usr/local/bin/wal-e_postgres_archiving_wrapper';
+        value => '/usr/local/bin/wal-e_postgres_archiving_wrapper %p';
       'archive_timeout':
         value => '60';
     }

--- a/modules/govuk_postgresql/templates/usr/local/bin/wal-e_postgres_archiving_wrapper.erb
+++ b/modules/govuk_postgresql/templates/usr/local/bin/wal-e_postgres_archiving_wrapper.erb
@@ -17,7 +17,7 @@ function nagios_passive () {
 
 trap nagios_passive EXIT
 
-envdir /etc/wal-e/env.d /usr/local/bin/wal-e wal-push %p
+envdir /etc/wal-e/env.d /usr/local/bin/wal-e wal-push $1
 
 if [ $? == 0 ]
   then


### PR DESCRIPTION
The `%p` variable must be passed into the wrapper script as an argument because it's defined within the postgres config itself.