### PR TITLE
Use new deployment repo for post-deploy repo backup job

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/gds_production_backup.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/gds_production_backup.yaml.erb
@@ -1,9 +1,9 @@
 ---
 - scm:
-    name: alphagov-deployment_GDS_Production_Backup
+    name: govuk-app-deployment_GDS_Production_Backup
     scm:
         - git:
-            url: git@github.gds:gds/alphagov-deployment.git
+            url: git@github.com:alphagov/govuk-app-deployment.git
             branches:
               - release
 
@@ -16,7 +16,7 @@
         After a production deployment, this job pushes the state of the deployed repository to the
         <a href="https://github.gds/gds-production-backup/">gds-production-backup organisation in GitHub Enterprise</a>.
     scm:
-      - alphagov-deployment_GDS_Production_Backup
+      - govuk-app-deployment_GDS_Production_Backup
     builders:
         - shell: |
             sh sync_to_ghe.sh


### PR DESCRIPTION
All of the shared deployment code from `alphagov-deployment`, including the
`sync_to_ghe.sh` script which this job uses, is [already in the new repo](https://github.com/alphagov/govuk-app-deployment/blob/master/sync_to_ghe.sh).

The [`Deploy_App` job uses the new repo already](https://github.com/alphagov/govuk-puppet/pull/4350) so we should update this job too
for consistency. This change brings us nearer to getting all deployment code
out of `alphagov-deployment`.