### PR TITLE
Upgrade typesdb for collectd server

### DIFF
--- a/modules/collectd/files/usr/share/collectd/types.db.rabbitmq
+++ b/modules/collectd/files/usr/share/collectd/types.db.rabbitmq
@@ -47,3 +47,7 @@ deliver_get_details     value:GAUGE:0:U
 redeliver               value:GAUGE:0:U
 redeliver_details       value:GAUGE:0:U
 return                  value:GAUGE:0:U
+
+messages                value:GAUGE:0:U
+messages_ready          value:GAUGE:0:U
+messages_unacknowledged value:GAUGE:0:U


### PR DESCRIPTION
We need the new types for the collectd on the graphite box to
understand the new stats from https://github.com/alphagov/govuk-puppet/pull/4373