### PR TITLE
Make govuk-cdn-logs-monitor deployable

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -36,6 +36,7 @@ deployable_applications: &deployable_applications
   - frontend
   - government-frontend
   - govuk-delivery
+  - govuk-cdn-logs-monitor
   - govuk_content_api
   - govuk_crawler_worker
   - govuk_need_api


### PR DESCRIPTION
- Added govuk-cdn-logs-monitor to deployable apps list