### PR TITLE
Enable local-links-manager in Staging and Production

### DIFF
--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -130,7 +130,6 @@ govuk::apps::govuk_cdn_logs_monitor::enabled: false
 govuk::apps::govuk_delivery::enable_procfile_worker: false
 govuk::apps::imminence::enable_procfile_worker: false
 govuk::apps::licencefinder::mongodb_nodes: ['localhost']
-govuk::apps::local_links_manager::enabled: true
 govuk::apps::multipage_frontend::enabled: true
 govuk::apps::need_api::mongodb_name: 'govuk_needs_development'
 govuk::apps::need_api::mongodb_nodes: ['localhost']

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -18,7 +18,6 @@ govuk::apps::email_campaign_api::mongodb_nodes:
 govuk::apps::errbit::errbit_email_from: 'govuk-winston+errbit-integration@digital.cabinet-office.gov.uk'
 govuk::apps::event_store::enabled: true
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
-govuk::apps::local_links_manager::enabled: true
 govuk::apps::publicapi::backdrop_host: 'www.preview.performance.service.gov.uk'
 govuk::apps::rummager::enable_publishing_api_document_indexer: false
 govuk::apps::rummager::aws_s3_bucket_name: govuk-api-elasticsearch-snapshots-integration

--- a/modules/govuk/manifests/apps/local_links_manager.pp
+++ b/modules/govuk/manifests/apps/local_links_manager.pp
@@ -9,6 +9,7 @@
 #
 # [*enabled*]
 #   Should the app exist?
+#   Default: true
 #
 # [*errbit_api_key*]
 #   Errbit API key used by airbrake
@@ -44,7 +45,7 @@
 #
 class govuk::apps::local_links_manager(
   $port = 3121,
-  $enabled = false,
+  $enabled = true,
   $errbit_api_key = undef,
   $secret_key_base = undef,
   $oauth_id = undef,


### PR DESCRIPTION
- Set $enabled to be true by default
- Removed $enabled being set from development and integration yamls

[Trello card](https://trello.com/c/XnLuP22b/371-deploy-local-links-manager-to-staging-and-production-2)