### PR TITLE
Define imagemagick policies

### DIFF
--- a/modules/imagemagick/files/etc/ImageMagick/policy.xml
+++ b/modules/imagemagick/files/etc/ImageMagick/policy.xml
@@ -45,6 +45,11 @@
   exceeds policy maximum so memory limit is 1GB).
 -->
 <policymap>
+  <policy domain="coder" rights="none" pattern="EPHEMERAL" />
+  <policy domain="coder" rights="none" pattern="URL" />
+  <policy domain="coder" rights="none" pattern="HTTPS" />
+  <policy domain="coder" rights="none" pattern="MVG" />
+  <policy domain="coder" rights="none" pattern="MSL" />
   <!-- <policy domain="system" name="precision" value="6"/> -->
   <!-- <policy domain="resource" name="temporary-path" value="/tmp"/> -->
   <!-- <policy domain="resource" name="memory" value="2GiB"/> -->

--- a/modules/imagemagick/files/etc/ImageMagick/policy.xml
+++ b/modules/imagemagick/files/etc/ImageMagick/policy.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policymap [
+<!ELEMENT policymap (policy)+>
+<!ELEMENT policy (#PCDATA)>
+<!ATTLIST policy domain (delegate|coder|filter|path|resource) #IMPLIED>
+<!ATTLIST policy name CDATA #IMPLIED>
+<!ATTLIST policy rights CDATA #IMPLIED>
+<!ATTLIST policy pattern CDATA #IMPLIED>
+<!ATTLIST policy value CDATA #IMPLIED>
+]>
+<!--
+  Configure ImageMagick policies.
+
+  Domains include system, delegate, coder, filter, path, or resource.
+
+  Rights include none, read, write, and execute.  Use | to combine them,
+  for example: "read | write" to permit read from, or write to, a path.
+
+  Use a glob expression as a pattern.
+
+  Suppose we do not want users to process MPEG video images:
+
+    <policy domain="delegate" rights="none" pattern="mpeg:decode" />
+
+  Here we do not want users reading images from HTTP:
+
+    <policy domain="coder" rights="none" pattern="HTTP" />
+
+  Lets prevent users from executing any image filters:
+
+    <policy domain="filter" rights="none" pattern="*" />
+
+  The /repository file system is restricted to read only.  We use a glob
+  expression to match all paths that start with /repository:
+
+    <policy domain="path" rights="read" pattern="/repository/*" />
+
+  Any large image is cached to disk rather than memory:
+
+    <policy domain="resource" name="area" value="1GB"/>
+
+  Define arguments for the memory, map, area, and disk resources with
+  SI prefixes (.e.g 100MB).  In addition, resource policies are maximums for
+  each instance of ImageMagick (e.g. policy memory limit 1GB, -limit 2GB
+  exceeds policy maximum so memory limit is 1GB).
+-->
+<policymap>
+  <!-- <policy domain="system" name="precision" value="6"/> -->
+  <!-- <policy domain="resource" name="temporary-path" value="/tmp"/> -->
+  <!-- <policy domain="resource" name="memory" value="2GiB"/> -->
+  <!-- <policy domain="resource" name="map" value="4GiB"/> -->
+  <!-- <policy domain="resource" name="area" value="1GB"/> -->
+  <!-- <policy domain="resource" name="disk" value="16EB"/> -->
+  <!-- <policy domain="resource" name="file" value="768"/> -->
+  <!-- <policy domain="resource" name="thread" value="4"/> -->
+  <!-- <policy domain="resource" name="throttle" value="0"/> -->
+  <!-- <policy domain="resource" name="time" value="3600"/> -->
+</policymap>

--- a/modules/imagemagick/manifests/init.pp
+++ b/modules/imagemagick/manifests/init.pp
@@ -4,6 +4,12 @@
 #
 class imagemagick {
   package { 'imagemagick':
-    ensure => installed,
+    ensure => '8:6.7.7.10-6ubuntu3',
+  }
+
+  file { '/etc/ImageMagick/policy.xml':
+    ensure  => 'present',
+    source  => 'puppet:///modules/imagemagick/etc/ImageMagick/policy.xml',
+    require => Package['imagemagick'],
   }
 }


### PR DESCRIPTION
We use imagemagick to convert images in whitehall and backend publishers.

- Put existing ImageMagick policy file into puppet
-  Disable potentially dangerous imagemagick features