### PR TITLE
Create a READ ONLY role on Publishing API database

### DIFF
--- a/modules/govuk/manifests/apps/publishing_api/postgresql_role.pp
+++ b/modules/govuk/manifests/apps/publishing_api/postgresql_role.pp
@@ -1,0 +1,21 @@
+# == Class: govuk::apps::publishing_api::postgresql_role
+#
+# Creates a `migration_checker` role in publishing-api PostgreSQL database
+# with READ ONLY privileges
+class govuk::apps::publishing_api::postgresql_role ( $password = '' ) {
+  $role = 'migration_checker'
+  $db   = 'publishing_api_production'
+
+  postgresql::server::role { $role:
+    password_hash => postgresql_password($role, $password),
+  }
+
+  # Allows SELECT from any column, or the specific columns listed,
+  # of the specified table and also allows the use of COPY
+  postgresql::server::database_grant { "${role} can query ${db}":
+    privilege => 'SELECT',
+    db        => $db,
+    role      => $role,
+    require   => [Postgresql::Server::Role[$role],
+  }
+}


### PR DESCRIPTION
The intention of this role is to allow the creation of a user that will be assigned this role, with the sole purpose of being used in [Finding Things Migration Checker](https://github.com/alphagov/finding-things-migration-checker)

**Please let me know what I missed**, I'm not used to Puppet at all, thank you.

For more information please [read here](https://trello.com/c/DYFgXNYr/621-automate-link-checker-tool#)