### PR TITLE
Rename smokey-nagios to smokey-loop

### DIFF
--- a/modules/monitoring/files/etc/init/smokey-loop.conf
+++ b/modules/monitoring/files/etc/init/smokey-loop.conf
@@ -6,4 +6,4 @@ description "Smokey loop outputs JSON which is consumed by monitoring"
 start on runlevel [2345] and stopped $UPSTART_JOB
 respawn
 
-exec /opt/smokey/cron_json.sh /tmp/smokey.json
+exec /opt/smokey/tests_json_output.sh /tmp/smokey.json

--- a/modules/monitoring/files/etc/init/smokey-loop.conf
+++ b/modules/monitoring/files/etc/init/smokey-loop.conf
@@ -1,4 +1,4 @@
-description "Smokey loop outputs JSON which is consumed by Nagios"
+description "Smokey loop outputs JSON which is consumed by monitoring"
 
 # Run in a continuous loop. `respawn` catches non-zero exit codes. Whereas
 # `and stopped` catches normal exits. The default `respawn limit` will


### PR DESCRIPTION
This confuses everyone who comes across it (including me). The fact that smokey runs in a loop is hardly anything to do with the fact it's consumed by Icinga (not Nagios).