### PR TITLE
Run travel advice monitoring more frequently

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/travel_advice_email_alert_check.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/travel_advice_email_alert_check.yaml.erb
@@ -17,7 +17,7 @@
     logrotate:
         artifactNumToKeep: 100
     triggers:
-        - timed: '21 * * * *' # every hour on the 21st minute
+        - timed: '*/15 * * * *' # every 15 minutes
     builders:
         - shell: |
             bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment


### PR DESCRIPTION
This should run every 15 minutes.