### PR TITLE
Add CDN backend graph to edge health dashboard

### DIFF
--- a/modules/grafana/templates/dashboards/edge_health.json.erb
+++ b/modules/grafana/templates/dashboards/edge_health.json.erb
@@ -404,6 +404,82 @@
         }
       ],
       "notice": false
+    },
+    {
+      "title": "CDN backends",
+      "height": "250px",
+      "editable": true,
+      "collapse": false,
+      "panels": [
+        {
+          "title": "Requests by CDN backend",
+          "error": false,
+          "span": 12,
+          "editable": true,
+          "type": "graph",
+          "id": 7,
+          "datasource": null,
+          "renderer": "flot",
+          "x-axis": true,
+          "y-axis": true,
+          "y_formats": [
+            "short",
+            "short"
+          ],
+          "grid": {
+            "leftMax": 100,
+            "rightMax": null,
+            "leftMin": 0,
+            "rightMin": null,
+            "threshold1": null,
+            "threshold2": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "lines": true,
+          "fill": 10,
+          "linewidth": 0,
+          "points": false,
+          "pointradius": 5,
+          "bars": false,
+          "stack": true,
+          "percentage": true,
+          "legend": {
+            "show": true,
+            "values": false,
+            "min": false,
+            "max": false,
+            "current": false,
+            "total": false,
+            "avg": false,
+            "alignAsTable": true
+          },
+          "nullPointMode": "null as zero",
+          "steppedLine": false,
+          "tooltip": {
+            "value_type": "cumulative",
+            "shared": false
+          },
+          "targets": [
+            {
+              "target": "stats.govuk.app.govuk-cdn-logs-monitor.logs-cdn-1.cdn_backend.origin"
+            },
+            {
+              "target": "stats.govuk.app.govuk-cdn-logs-monitor.logs-cdn-1.cdn_backend.mirror0"
+            },
+            {
+              "target": "stats.govuk.app.govuk-cdn-logs-monitor.logs-cdn-1.cdn_backend.mirror1"
+            },
+            {
+              "target": "stats.govuk.app.govuk-cdn-logs-monitor.logs-cdn-1.cdn_backend.error"
+            }
+          ],
+          "aliasColors": {},
+          "seriesOverrides": [],
+          "links": [],
+          "leftYAxisLabel": "Proportion of requests"
+        }
+      ]
     }
   ],
   "editable": true,


### PR DESCRIPTION
To show where requests are being served from.