### PR TITLE
Don't reboot while logrotate is running

### DIFF
--- a/modules/govuk_unattended_reboot/templates/etc/unattended-reboot/check/00_safety.erb
+++ b/modules/govuk_unattended_reboot/templates/etc/unattended-reboot/check/00_safety.erb
@@ -3,3 +3,8 @@
 if ! [[ "$(/usr/local/bin/govuk_setenv default /usr/bin/printenv SAFE_TO_REBOOT)" =~ ^(yes|overnight)$ ]]; then
   exit 1
 fi
+
+# Don't reboot while logrotate is running
+if /usr/bin/pgrep "logrotate" > /dev/null; then
+  exit 1
+fi


### PR DESCRIPTION
We have a theory that machines rebooting while logrotate is running causes logrotate to get confused and never rotate some logfiles, which causes the root partition to fill up, which is really annoying.