### PR TITLE
Add recovery options

### DIFF
--- a/modules/govuk_postgresql/manifests/wal_e/backup.pp
+++ b/modules/govuk_postgresql/manifests/wal_e/backup.pp
@@ -56,11 +56,12 @@ class govuk_postgresql::wal_e::backup (
   $wale_private_gpg_key_fingerprint = undef,
   $hour = 6,
   $minute = 20,
-  $db_dir = '/var/lib/postgresql/9.3/main',
+  $db_dir = $postgresql::globals::datadir,
   $enabled = false,
 ) {
   if $enabled {
     include govuk_postgresql::wal_e::package
+    include govuk_postgresql::wal_e::recovery
 
     # Continuous archiving to S3
     postgresql::server::config_entry {

--- a/modules/govuk_postgresql/manifests/wal_e/recovery.pp
+++ b/modules/govuk_postgresql/manifests/wal_e/recovery.pp
@@ -1,0 +1,15 @@
+# == Class: Govuk_postgresql::Wal_e::Recovery
+#
+# Creates prerequisites to restore data.
+#
+class govuk_postgresql::wal_e::recovery {
+  $datadir = $postgresql::globals::datadir,
+
+  file { "${datadir}/recovery.conf":
+    ensure  => present,
+    content => 'restore_command = \'envdir /etc/wal-e/env.d /usr/local/bin/wal-e wal-fetch "%f" "%p"\'',
+    owner   => 'postgres',
+    group   => 'postgres',
+    mode    => '0644',
+  }
+}


### PR DESCRIPTION
This just creates the required recovery.conf file in the PostgreSQL config directory. It also updates a couple of parameters to use globally set parameters by the main postgresql class because I did not want to hardcode version numbers.