### PR TITLE
Enable service-manual-frontend in staging and production

### DIFF
--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -152,7 +152,6 @@ govuk::apps::router_api::mongodb_nodes: ['localhost']
 govuk::apps::router_api::router_nodes: ['localhost:3055']
 govuk::apps::rummager::enable_procfile_worker: false
 govuk::apps::rummager::rabbitmq_hosts: ['localhost']
-govuk::apps::service_manual_frontend::enabled: true
 govuk::apps::share_sale_publisher::enabled: true
 govuk::apps::share_sale_publisher::mongodb_nodes: ['localhost']
 govuk::apps::share_sale_publisher::mongodb_name: 'share_sale_publisher_development'

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -22,7 +22,6 @@ govuk::apps::local_links_manager::enabled: true
 govuk::apps::publicapi::backdrop_host: 'www.preview.performance.service.gov.uk'
 govuk::apps::rummager::enable_publishing_api_document_indexer: false
 govuk::apps::rummager::aws_s3_bucket_name: govuk-api-elasticsearch-snapshots-integration
-govuk::apps::service_manual_frontend::enabled: true
 govuk::apps::smartanswers::expose_govspeak: true
 govuk::apps::specialist_publisher::publish_pre_production_finders: true
 govuk::apps::specialist_publisher_rebuild::enabled: true

--- a/modules/govuk/manifests/apps/service_manual_frontend.pp
+++ b/modules/govuk/manifests/apps/service_manual_frontend.pp
@@ -27,7 +27,7 @@
 class govuk::apps::service_manual_frontend(
   $vhost = 'service-manual-frontend',
   $port = 3122,
-  $enabled = false,
+  $enabled = true,
   $errbit_api_key = undef,
   $secret_key_base = undef,
 ) {


### PR DESCRIPTION
Because we now want service-manual-frontend enabled in all environments we are enabling by default and removing the environment specific config.