### PR TITLE
Add script to resync environment

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -214,6 +214,7 @@ govuk::node::s_licensify_mongo::licensify_mongo_encrypted: false
 govuk::node::s_logging::compress_srv_logs_hour: '9'
 govuk::node::s_monitoring::offsite_backups: false
 govuk::node::s_whitehall_backend::sync_mirror: true
+govuk::node::s_transition_postgresql_master::env_sync_enabled: true
 govuk::node::s_transition_postgresql_slave::redirector_ip_range: '10.1.5.0/24'
 
 govuk_sudo::sudo_conf:

--- a/modules/backup/manifests/assets.pp
+++ b/modules/backup/manifests/assets.pp
@@ -63,7 +63,7 @@ class backup::assets(
       content => $backup_private_gpg_key,
     }
 
-    exec { 'import_gpg_secret_key':
+    exec { "import_gpg_secret_key_${::hostname}":
       command     => "gpg --batch --delete-secret-and-public-key ${backup_private_gpg_key_fingerprint}; gpg --allow-secret-key-import --import /root/.gnupg/${backup_private_gpg_key_fingerprint}_secret_key.asc",
       user        => 'root',
       group       => 'root',

--- a/modules/govuk/manifests/node/s_transition_postgresql_master.pp
+++ b/modules/govuk/manifests/node/s_transition_postgresql_master.pp
@@ -15,6 +15,13 @@ class govuk::node::s_transition_postgresql_master (
   $s3_bucket_url,
   $wale_private_gpg_key,
   $wale_private_gpg_key_fingerprint,
+  $env_sync_access_key_id = undef,
+  $env_sync_secret_access_key = undef,
+  $env_sync_s3_bucket_url = undef,
+  $env_sync_private_gpg_key = undef,
+  $env_sync_private_gpg_key_fingerprint = undef,
+  $env_sync_private_gpg_key_passphrase = undef,
+  $env_sync_enabled = false,
 ) inherits govuk::node::s_transition_postgresql_base {
   class { 'govuk_postgresql::server::primary':
     slave_password => $slave_password,
@@ -26,6 +33,17 @@ class govuk::node::s_transition_postgresql_master (
     s3_bucket_url                    => $s3_bucket_url,
     wale_private_gpg_key             => $wale_private_gpg_key,
     wale_private_gpg_key_fingerprint => $wale_private_gpg_key_fingerprint,
+  }
+
+  if $env_sync_enabled {
+    govuk_postgresql::wal_e::env_sync { $title:
+      aws_access_key_id                => $env_sync_access_key_id,
+      aws_secret_access_key            => $env_sync_secret_access_key,
+      s3_bucket_url                    => $env_sync_s3_bucket_url,
+      wale_private_gpg_key             => $env_sync_private_gpg_key,
+      wale_private_gpg_key_fingerprint => $env_sync_private_gpg_key_fingerprint,
+      wale_private_gpg_key_passphrase  => $env_sync_private_gpg_key_passphrase,
+    }
   }
 
   include govuk::apps::bouncer::postgresql_role

--- a/modules/govuk_postgresql/manifests/wal_e/backup.pp
+++ b/modules/govuk_postgresql/manifests/wal_e/backup.pp
@@ -143,7 +143,7 @@ define govuk_postgresql::wal_e::backup (
         group   => 'postgres',
       }
 
-      exec { 'import_gpg_secret_key':
+      exec { "import_gpg_secret_key_${::hostname}":
         command     => "gpg --batch --delete-secret-and-public-key ${wale_private_gpg_key_fingerprint}; gpg --allow-secret-key-import --import /var/lib/postgresql/.gnupg/${wale_private_gpg_key_fingerprint}_secret_key.asc",
         user        => 'postgres',
         group       => 'postgres',

--- a/modules/govuk_postgresql/manifests/wal_e/backup.pp
+++ b/modules/govuk_postgresql/manifests/wal_e/backup.pp
@@ -60,7 +60,7 @@ define govuk_postgresql::wal_e::backup (
   $archive_timeout = '300',
   $hour = 6,
   $minute = 20,
-  $db_dir = $postgresql::globals::datadir,
+  $db_dir = $postgresql::params::datadir,
 ) {
     include govuk_postgresql::wal_e::package
 

--- a/modules/govuk_postgresql/manifests/wal_e/backup.pp
+++ b/modules/govuk_postgresql/manifests/wal_e/backup.pp
@@ -60,7 +60,7 @@ define govuk_postgresql::wal_e::backup (
   $archive_timeout = '300',
   $hour = 6,
   $minute = 20,
-  $db_dir = '/var/lib/postgresql/9.3/main',
+  $db_dir = $postgresql::globals::datadir,
 ) {
     include govuk_postgresql::wal_e::package
 

--- a/modules/govuk_postgresql/manifests/wal_e/env_sync.pp
+++ b/modules/govuk_postgresql/manifests/wal_e/env_sync.pp
@@ -1,0 +1,104 @@
+# == Define: Govuk_postgresql::Wal_e::Env_sync
+#
+# Syncs the database from a specific location from a different environment,
+# for example the Production data from an S3 bucket into a Staging environment.
+#
+# === Parameters:
+#
+# [*aws_access_key_id*]
+#   This is the access key to use to access the bucket that you wish to restore
+#   from.
+#
+# [*aws_secret_access_key*]
+#   This is the secret access key associated with the above.
+#
+# [*s3_bucket_url*]
+#   This is the bucket URL for the bucket you wish to restore from. Format is
+#   's3://bucket/'
+#
+# [*wale_private_gpg_key*]
+#   The private key is required to decrypt the backups.
+#
+# [*wale_private_gpg_key_fingerprint*]
+#   The fingerprint is required to specify the private key.
+#
+# [*wale_private_gpg_key_passphrase*]
+#   The passphrase for the private key. This is not ideal as it is passed in
+#   when decrypting the backups, but is required to do a batch job.
+#
+# [*aws_region*]
+#   The region where the bucket is located.
+#
+define govuk_postgresql::wal_e::env_sync (
+  $aws_access_key_id,
+  $aws_secret_access_key,
+  $s3_bucket_url,
+  $wale_private_gpg_key,
+  $wale_private_gpg_key_fingerprint,
+  $wale_private_gpg_key_passphrase,
+  $aws_region = 'eu-west-1',
+) {
+
+    $env_sync_envdir = '/etc/wal-e/env.d/env_sync'
+
+    file { $env_sync_envdir:
+      ensure  => directory,
+      owner   => 'postgres',
+      group   => 'postgres',
+      mode    => '0775',
+      require => Package['wal-e'],
+    }
+
+    file { "${env_sync_envdir}/AWS_SECRET_ACCESS_KEY":
+      content => $aws_secret_access_key,
+      owner   => 'postgres',
+      group   => 'postgres',
+      mode    => '0640',
+    }
+
+    file { "${env_sync_envdir}/AWS_ACCESS_KEY_ID":
+      content => $aws_access_key_id,
+      owner   => 'postgres',
+      group   => 'postgres',
+      mode    => '0640',
+    }
+
+    file { "${env_sync_envdir}/WALE_S3_PREFIX":
+      content => $s3_bucket_url,
+      owner   => 'postgres',
+      group   => 'postgres',
+      mode    => '0640',
+    }
+
+    file { "${env_sync_envdir}/AWS_REGION":
+      content => $aws_region,
+      owner   => 'postgres',
+      group   => 'postgres',
+      mode    => '0640',
+    }
+
+    file { "/var/lib/postgresql/.gnupg/${wale_private_gpg_key_fingerprint}_secret_key.asc":
+      ensure  => present,
+      mode    => '0600',
+      content => $wale_private_gpg_key,
+      owner   => 'postgres',
+      group   => 'postgres',
+    }
+
+    exec { 'import_gpg_secret_key':
+      command     => "gpg --batch --delete-secret-and-public-key ${wale_private_gpg_key_fingerprint}; gpg --allow-secret-key-import --import /var/lib/postgresql/.gnupg/${wale_private_gpg_key_fingerprint}_secret_key.asc",
+      user        => 'postgres',
+      group       => 'postgres',
+      subscribe   => File["/var/lib/postgresql/.gnupg/${wale_private_gpg_key_fingerprint}_secret_key.asc"],
+      refreshonly => true,
+    }
+
+    $datadir = $postgresql::globals::datadir
+
+    file { '/usr/local/bin/wal-e_env_sync':
+      ensure  => present,
+      content => template('govuk_postgresql/usr/local/bin/wal-e_env_sync'),
+      require => Class['govuk_postgresql::wal_e::backup'],
+    }
+
+}

--- a/modules/govuk_postgresql/manifests/wal_e/env_sync.pp
+++ b/modules/govuk_postgresql/manifests/wal_e/env_sync.pp
@@ -85,7 +85,7 @@ define govuk_postgresql::wal_e::env_sync (
       group   => 'postgres',
     }
 
-    exec { 'import_gpg_secret_key':
+    exec { "import_gpg_secret_key_${::hostname}":
       command     => "gpg --batch --delete-secret-and-public-key ${wale_private_gpg_key_fingerprint}; gpg --allow-secret-key-import --import /var/lib/postgresql/.gnupg/${wale_private_gpg_key_fingerprint}_secret_key.asc",
       user        => 'postgres',
       group       => 'postgres',

--- a/modules/govuk_postgresql/templates/usr/local/bin/wal-e_env_sync
+++ b/modules/govuk_postgresql/templates/usr/local/bin/wal-e_env_sync
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# PostgreSQL WAL-E Environment Sync
+#
+# This is a wrapper script which sets up prerequisites for an encrypted WAL-E
+# backup from an Amazon S3 bucket, and moves the backup into place. It restores
+# the very latest back-up available.
+#
+export RECOVERY_FILE=<%= @datadir -%>/recovery.conf
+
+set -e
+
+# Redirect stdout and stderr to syslog
+exec 1> >(/usr/bin/logger -s -t $(basename $0)) 2>&1
+
+# Stop the PostgreSQL service
+sudo service postgresql stop
+
+# Push the passphrase to a file so we can decrypt without prompt
+sudo echo "passphrase <%= @wale_private_gpg_key_passphrase %>" >> /var/lib/postgresql/.gnupg/gpg.conf
+
+# Start the restore process
+sudo -iu postgres envdir <%= @env_sync_envdir %> /usr/local/bin/wal-e backup-fetch --blind-restore /var/lib/postgresql/9.3/main LATEST
+
+# Remove the GPG stuff
+sudo sed '/passphrase/d' /var/lib/postgresql/.gnupg/gpg.conf || exit 1
+
+# Add the recovery.conf configuration (this is renamed to recovery.done after PostgreSQL starts)
+sudo -iu postgres echo "restore_command = \'envdir /etc/wal-e/env.d /usr/local/bin/wal-e wal-fetch \"%f\" \"%p\"\'" > $RECOVERY_FILE
+
+# Start the PostgreSQL service
+sudo service postgresql start

--- a/modules/govuk_postgresql/templates/usr/local/bin/wal-e_env_sync
+++ b/modules/govuk_postgresql/templates/usr/local/bin/wal-e_env_sync
@@ -17,13 +17,13 @@ exec 1> >(/usr/bin/logger -s -t $(basename $0)) 2>&1
 sudo service postgresql stop
 
 # Push the passphrase to a file so we can decrypt without prompt
-sudo echo "passphrase <%= @wale_private_gpg_key_passphrase %>" >> /var/lib/postgresql/.gnupg/gpg.conf
+sudo -iu postgres envdir <%= @env_sync_envdir %> sh -c  'echo "passphrase $GPG_PASSPHRASE" >> /var/lib/postgresql/.gnupg/gpg.conf'
 
 # Start the restore process
-sudo -iu postgres envdir <%= @env_sync_envdir %> /usr/local/bin/wal-e backup-fetch --blind-restore /var/lib/postgresql/9.3/main LATEST
+sudo -iu postgres envdir <%= @env_sync_envdir %> /usr/local/bin/wal-e backup-fetch --blind-restore <%= @datadir -%> LATEST
 
 # Remove the GPG stuff
-sudo sed '/passphrase/d' /var/lib/postgresql/.gnupg/gpg.conf || exit 1
+sudo sed -i '/passphrase/d' /var/lib/postgresql/.gnupg/gpg.conf || exit 1
 
 # Add the recovery.conf configuration (this is renamed to recovery.done after PostgreSQL starts)
 sudo -iu postgres echo "restore_command = \'envdir /etc/wal-e/env.d /usr/local/bin/wal-e wal-fetch \"%f\" \"%p\"\'" > $RECOVERY_FILE

--- a/modules/mongodb/manifests/s3backup/backup.pp
+++ b/modules/mongodb/manifests/s3backup/backup.pp
@@ -146,7 +146,7 @@ class mongodb::s3backup::backup(
   }
 
   # import key
-  exec { 'import_gpg_secret_key':
+  exec { "import_gpg_secret_key_${::hostname}":
     command     => "gpg --batch --delete-secret-and-public-key ${private_gpg_key_fingerprint}; gpg --allow-secret-key-import --import /home/${user}/.gnupg/${private_gpg_key_fingerprint}_secret_key.asc",
     user        => $user,
     group       => $user,

--- a/modules/mongodb/spec/classes/mongodb__s3backup__backup_spec.rb
+++ b/modules/mongodb/spec/classes/mongodb__s3backup__backup_spec.rb
@@ -14,6 +14,8 @@ describe 'mongodb::s3backup::backup', :type => :class do
     :user                        => 'foo-user'
   }}
 
+  let(:facts) {{ :hostname => 'mongo-server-1' }}
+
   context 'mongodb s3backups with AWS defined' do
 
     it { is_expected.to contain_file('/etc/foo/').with_ensure('directory') }
@@ -28,7 +30,7 @@ describe 'mongodb::s3backup::backup', :type => :class do
     it { is_expected.to contain_file('/home/foo-user/.gnupg').with_ensure('directory') }
     it { is_expected.to contain_file('/home/foo-user/.gnupg/gpg.conf').with_content(/trust-model\ always/) }
     it { is_expected.to contain_file('/home/foo-user/.gnupg/CB77872D51ADD27CF75BD63CB60B50E6DBE2EAFF_secret_key.asc').with_content('test-key-content') }
-    it { is_expected.to contain_exec('import_gpg_secret_key')
+    it { is_expected.to contain_exec("import_gpg_secret_key_mongo-server-1")
          .with_refreshonly(true)
     }
   end


### PR DESCRIPTION
This adds a defined type to create a wrapper script to allow syncing from an S3 bucket from another environment to the current server. It uses WAL-E backups which first pulls a base backup from the latest available backup, adds in the required options for recovery and starts the PostgreSQL server which will start up the recovery process.

I've left it simply as a script for now to keep it open about how we wish to schedule the job. Comments welcome on how we wish to do the process overall!

Ticket: https://trello.com/c/wLbRNufD/60-automate-restoration-of-bouncer-wal-e-backups-to-staging-and-integration