### PR TITLE
Include the standard postgres tuning

### DIFF
--- a/modules/govuk/manifests/node/s_postgresql_base.pp
+++ b/modules/govuk/manifests/node/s_postgresql_base.pp
@@ -11,5 +11,7 @@ class govuk::node::s_postgresql_base inherits govuk::node::s_base {
   include govuk::apps::service_manual_publisher::db
   include govuk::apps::support_api::db
 
+  include govuk_postgresql::tuning
+
   Govuk_mount['/var/lib/postgresql'] -> Class['govuk_postgresql::server']
 }


### PR DESCRIPTION
This class sets the effective_cache_size and shared_buffers to values
recommended by the postgres documentation.

Some of our postgres servers include this already but not this one,
which is used by the publishing api database.