### PR TITLE
Only use one etcd node.

### DIFF
--- a/hieradata/class/etcd.yaml
+++ b/hieradata/class/etcd.yaml
@@ -2,8 +2,6 @@
 
 govuk_etcd::peers:
   - "etcd-1.management:7001"
-  - "etcd-2.management:7001"
-  - "etcd-3.management:7001"
 
 etcd::manage_log_dir: false
 etcd::manage_service_file: false

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1152,7 +1152,5 @@ unattended_reboot::cron_env_vars:
 unattended_reboot::cron_hour: '0-5'
 unattended_reboot::etcd_endpoints:
   - "http://etcd-1.management:4001"
-  - "http://etcd-2.management:4001"
-  - "http://etcd-3.management:4001"
 
 unicornherder::version: '0.0.8'


### PR DESCRIPTION
We've decided that we're going to run locksmithctl, the only thing
that uses our etcd cluster, against a single node in each environment
and trade lower resilience for cost savings.

By convention we'll continue to run etcd on the etcd-1 node in each
environment.