### PR TITLE
These classes are not used on the same nodes so use normal packages

### DIFF
--- a/modules/govuk/manifests/node/s_asset_master.pp
+++ b/modules/govuk/manifests/node/s_asset_master.pp
@@ -40,7 +40,10 @@ class govuk::node::s_asset_master (
 
   if $s3_bucket {
 
-    ensure_packages( { 's3cmd' => { provider => 'pip' } } )
+    package { 's3cmd':
+      ensure   => 'present',
+      provider => 'pip',
+    }
 
     file { '/home/assets/.s3cfg':
       ensure  => present,

--- a/modules/govuk_jenkins/manifests/init.pp
+++ b/modules/govuk_jenkins/manifests/init.pp
@@ -81,7 +81,10 @@ class govuk_jenkins (
     provider => system_gem,
   }
 
-  ensure_packages( { 's3cmd' => { provider => 'pip' } } )
+  package { 's3cmd':
+    ensure   => 'present',
+    provider => 'pip',
+  }
 
   # Runtime dependency of: https://github.com/alphagov/search-analytics
   include libffi


### PR DESCRIPTION
We seem to have hit an issue with stdlib so we're reverting this change
out. 4.12.0 didn't work with it on Puppet 3 but it does on puppet 4.3