### PR TITLE
adds Elasticsearch index snapshots to S3

### DIFF
--- a/hieradata/class/vagrant/logs_elasticsearch.yaml
+++ b/hieradata/class/vagrant/logs_elasticsearch.yaml
@@ -1,0 +1,9 @@
+---
+# should set to real values
+govuk_elasticsearch::aws_access_key: 'ABCDEFGHIJKLMNOPQRST'
+govuk_elasticsearch::aws_secret_key: 'n4AQffsnBJ5rcQK9DBn5eYHVuDqhT5DVCYa7ZU9tt'
+
+govuk_elasticsearch::snapshot_backups:
+   'kibana-int':
+     s3_bucket: 'govuk-elasticsearch-vagrant'
+     s3_path: 'test'

--- a/modules/govuk/manifests/node/s_logs_elasticsearch.pp
+++ b/modules/govuk/manifests/node/s_logs_elasticsearch.pp
@@ -35,6 +35,24 @@ class govuk::node::s_logs_elasticsearch(
     ],
   }
 
+  case $govuk_elasticsearch::version {
+    /^0.9/: { $cloud_aws_version = '1.16.0' }
+    /^1.0/: { $cloud_aws_version = '2.0.0' }
+    /^1.1/: { $cloud_aws_version = '2.1.1' }
+    /^1.2/: { $cloud_aws_version = '2.2.0' }
+    /^1.3/: { $cloud_aws_version = '2.3.0' }
+    /^1.4/: { $cloud_aws_version = '2.4.2' }
+    /^1.5/: { $cloud_aws_version = '2.5.1' }
+    /^1.6/: { $cloud_aws_version = '2.6.1' }
+    /^1.7/: { $cloud_aws_version = '2.7.1' }
+    default: { fail('Plugin version must match elasticsearch version, see README at https://github.com/elastic/elasticsearch-cloud-aws') }
+  }
+
+  elasticsearch::plugin { "elasticsearch/elasticsearch-cloud-aws/${cloud_aws_version}":
+    module_dir => 'cloud-aws',
+    instances  => $::fqdn,
+  }
+
   elasticsearch::plugin { 'mobz/elasticsearch-head':
     module_dir => 'head',
     instances  => $::fqdn,

--- a/modules/govuk_elasticsearch/manifests/snapshot.pp
+++ b/modules/govuk_elasticsearch/manifests/snapshot.pp
@@ -1,0 +1,61 @@
+# define govuk_elasticsearch::snapshot
+#
+# [*s3_bucket]
+#   The S3 bucket where the snapshots will be stored
+#
+# [*s3_region]
+#   The AWS region for the S3 bucket. Defaults to eu-west-1.
+#
+# [*s3_path]
+#   The folder path within the S3 bucket where the snapshots
+#   will be stored
+#
+# [*index]
+#   The ES index to backup
+#
+# [*http_port]
+#   The port that ES runs on
+#
+# [*title*]
+#   The $title or $name of the hiera hash should be the index name
+#
+# Hiera example:
+# --------------
+# govuk_elasticsearch::snapshot::indices:
+#   kibana-int:
+#     s3_bucket: 'jonauman-test2'
+#     s3_path: 'elasticsearch'
+
+define govuk_elasticsearch::snapshot (
+  $s3_bucket = undef,
+  $s3_region = 'eu-west',
+  $s3_path = undef,
+  $index = $title,
+  $http_port = 9200,
+  ){
+
+  File {
+    mode => '0755',
+  }
+
+  file { "/usr/local/bin/elasticsearch-create-repo-${index}":
+    ensure  => present,
+    content => template('govuk_elasticsearch/create_repo.sh.erb'),
+  }
+
+  file { "/usr/local/bin/elasticsearch-backup-${index}":
+    ensure  => present,
+    content => template('govuk_elasticsearch/backup_index.sh.erb'),
+  }
+
+  exec { "/usr/local/bin/elasticsearch-create-repo-${index}":
+    require => File["/usr/local/bin/elasticsearch-create-repo-${index}"],
+  }
+
+  cron { "elasticsearch-backup-${index}":
+    command => "/usr/local/bin/elasticsearch-backup-${index}",
+    special => daily,
+    require => File["/usr/local/bin/elasticsearch-backup-${index}"],
+  }
+
+}

--- a/modules/govuk_elasticsearch/templates/backup_index.sh.erb
+++ b/modules/govuk_elasticsearch/templates/backup_index.sh.erb
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+repo=<%= @s3_bucket %>
+timestamp=$(date +%Y-%m-%dt%H:%M:%S)
+snapshot=${timestamp}-<%= @title %>
+
+curl --fail -XPUT "http://localhost:<%= @http_port %>/_snapshot/${repo}/${snapshot}?wait_for_completion=true" -d '{
+  "indices": "<%= @title %>",
+  "ignore_unavailable": "true",
+  "include_global_state": false
+}'

--- a/modules/govuk_elasticsearch/templates/create_repo.sh.erb
+++ b/modules/govuk_elasticsearch/templates/create_repo.sh.erb
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+repo=<%= @s3_bucket %>
+
+curl --fail -XPUT "http://localhost:<%= @http_port %>/_snapshot/$repo" -d '{
+  "type": "s3",
+  "settings": {
+    "bucket": "<%= @s3_bucket %>",
+    "region": "<%= @s3_region %>"<% if @s3_path %>,
+    "base_path": "<%= @s3_path %>"
+<% end -%>
+  }
+}'


### PR DESCRIPTION
This commit adds the ES plugin to AWS which allows us to snapshot
individual indices to an S3 bucket. S3 credentials can be passed
a variety of ways, but adding them to elasticsearch.yml provides
the simplest solution. Passing the creds as environment variables
requires changes to ES user and the ES init.d script and overrides
to the vendor module, and only works if these requirements are met.