### PR TITLE
Add Local Links Manager service interactions importer Jenkins job

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -86,6 +86,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::gds_production_backup
   - govuk_jenkins::job::govuk_cdn_nightly_2xx_status_collection
   - govuk_jenkins::job::launch_vms
+  - govuk_jenkins::job::local_links_manager_import_service_interactions
   - govuk_jenkins::job::mirror_network_config
   - govuk_jenkins::job::network_config_deploy
   - govuk_jenkins::job::passive_checks

--- a/modules/govuk_jenkins/manifests/job/local_links_manager_import_service_interactions.pp
+++ b/modules/govuk_jenkins/manifests/job/local_links_manager_import_service_interactions.pp
@@ -1,0 +1,25 @@
+# == Class: govuk_jenkins::job::local_links_manager_import_service_interactions
+#
+# Import services and interactions and the mapped service interactions into local-links-manager
+#
+class govuk_jenkins::job::local_links_manager_import_service_interactions (
+  $app_domain = hiera('app_domain'),
+) {
+
+  $check_name = 'local-links-manager-import-service-interactions'
+  $service_description = 'Import services and interactions into local-links-manager'
+  $job_url = "https://deploy.${app_domain}/job/local-links-manager-import-service-interactions/"
+
+  file { '/etc/jenkins_jobs/jobs/local_links_manager_import_service_interactions.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/local_links_manager_import_service_interactions.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+
+  @@icinga::passive_check { "${check_name}_${::hostname}":
+    service_description => $service_description,
+    host_name           => $::fqdn,
+    freshness_threshold => 1224000,
+    action_url          => $job_url,
+  }
+}

--- a/modules/govuk_jenkins/templates/jobs/local_links_manager_import_service_interactions.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/local_links_manager_import_service_interactions.yaml.erb
@@ -1,0 +1,27 @@
+---
+- job:
+    name: Local_Links_Manager_Import_Service_Interactions
+    display-name: Local_Links_Manager_Import_Service_Interactions
+    project-type: freestyle
+    description: |
+      Runs the rake task to import all services and interactions into Local Links Manager on the 1st of each month
+    logrotate:
+      artifactNumToKeep: 10
+    triggers:
+        - timed: '0 0 1 * *'
+    builders:
+        - shell: |
+            ssh deploy@backend-1.backend.production "cd /var/apps/local-links-manager && govuk_setenv local-links-manager bundle exec rake import:service_interactions:import_all"
+            echo "Local Links Manager services and interactions importer has run"
+    publishers:
+        - trigger-parameterized-builds:
+            - project: Success_Passive_Check
+              condition: 'SUCCESS'
+              predefined-parameters: |
+                  NSCA_CHECK_DESCRIPTION=<%= @service_description %>
+                  NSCA_OUTPUT=<%= @service_description %> success
+            - project: Failure_Passive_Check
+              condition: 'FAILED'
+              predefined-parameters: |
+                  NSCA_CHECK_DESCRIPTION=<%= @service_description %>
+                  NSCA_OUTPUT=<%= @service_description %> failed


### PR DESCRIPTION
- Local Links Manager requires all the services and interactions for each local authority to be imported at regular intervals from the [Local Government Association](standards.esd.org.uk) site. The import script is already part of the [local-links-manager repo](https://github.com/alphagov/local-links-manager). This commit adds a Jenkins job to run the rake task on the first day of each month.

[Trello card](https://trello.com/c/r8yv6gjk/368-import-all-services-and-interactions-into-local-links-manager-3)