### PR TITLE
Add golang 1.6.2

### DIFF
--- a/modules/golang/manifests/init.pp
+++ b/modules/golang/manifests/init.pp
@@ -10,7 +10,7 @@ class golang {
     global_version => '1.5.3',
     require        => Class['govuk_ppa'],
   }
-  goenv::version { ['1.3.3', '1.4.2', '1.4.3', '1.5.1', '1.5.3']: }
+  goenv::version { ['1.3.3', '1.4.2', '1.4.3', '1.5.1', '1.5.3', '1.6.2']: }
 
   package { ['golang-gom', 'godep']:
     ensure  => latest,


### PR DESCRIPTION
This commit makes the latest version of Go (currently 1.6.2) available within the dev VM to support work to upgrade metadata-api.