### PR TITLE
Further bugfix for Whitehall attachments

### DIFF
--- a/modules/govuk/templates/node/s_asset_base/copy-attachments.sh
+++ b/modules/govuk/templates/node/s_asset_base/copy-attachments.sh
@@ -33,7 +33,7 @@ fi
 ASSET_SLAVE_NODES=$(/usr/local/bin/govuk_node_list -c asset_slave)
 
 for NODE in $ASSET_SLAVE_NODES; do
-  if rsync -aqe "ssh -q" --delete "$DIRECTORY_TO_COPY/" $NODE:$DIRECTORY_TO_COPY; then
+  if rsync -aqe "ssh -q" --exclude "lost+found" --delete "$DIRECTORY_TO_COPY/" $NODE:$DIRECTORY_TO_COPY; then
     logger -t copy_attachments "Attachments copied to $NODE successfully"
   else
     logger -t copy_attachments "Attachments errored while copying to $NODE"
@@ -41,7 +41,7 @@ for NODE in $ASSET_SLAVE_NODES; do
 done
 
 <% if @s3_bucket %>
-  if envdir /etc/govuk/aws/env.d /usr/local/bin/s3cmd --server-side-encryption sync --skip-existing --delete-removed "$DIRECTORY_TO_COPY/" "s3://<%= @s3_bucket -%>$DIRECTORY_TO_COPY/"; then
+  if envdir /etc/govuk/aws/env.d /usr/local/bin/s3cmd --server-side-encryption sync --exclude="lost+found" --skip-existing --delete-removed "$DIRECTORY_TO_COPY/" "s3://<%= @s3_bucket -%>$DIRECTORY_TO_COPY/"; then
     logger -t copy_attachments "Attachments copied to S3 (<%= @s3_bucket -%>) successfully"
   else
     logger -t copy_attachments "Attachments errored while copying to S3 (<%= @s3_bucket -%>)"


### PR DESCRIPTION
We should exclude "lost+found" because it throws an error when it does an rsync due to permissions, and it shouldn't ever be synced.