### PR TITLE
Add cache-file for s3 syncs

### DIFF
--- a/modules/govuk/templates/node/s_asset_base/copy-attachments.sh
+++ b/modules/govuk/templates/node/s_asset_base/copy-attachments.sh
@@ -41,7 +41,7 @@ for NODE in $ASSET_SLAVE_NODES; do
 done
 
 <% if @s3_bucket %>
-  if envdir /etc/govuk/aws/env.d /usr/local/bin/s3cmd --server-side-encryption sync --exclude="lost+found" --skip-existing --delete-removed "$DIRECTORY_TO_COPY/" "s3://<%= @s3_bucket -%>$DIRECTORY_TO_COPY/"; then
+  if envdir /etc/govuk/aws/env.d /usr/local/bin/s3cmd --cache-file=/tmp/s3cmd_attachments.cache --server-side-encryption sync --exclude="lost+found" --skip-existing --delete-removed "$DIRECTORY_TO_COPY/" "s3://<%= @s3_bucket -%>$DIRECTORY_TO_COPY/"; then
     logger -t copy_attachments "Attachments copied to S3 (<%= @s3_bucket -%>) successfully"
   else
     logger -t copy_attachments "Attachments errored while copying to S3 (<%= @s3_bucket -%>)"


### PR DESCRIPTION
The cache-file flag compiles a list of source MD5s for the files that have been synced to the destination. This means that any files which haven't changed are skipped in the run, but if the file has changed
then they'll be included, which should hopefully make the syncs a lot quicker.