### PR TITLE
Specialist publisher rebuild: pre_production finder config

### DIFF
--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -162,6 +162,7 @@ govuk::apps::specialist_publisher::publish_pre_production_finders: true
 govuk::apps::specialist_publisher_rebuild::enabled: true
 govuk::apps::specialist_publisher_rebuild::mongodb_name: 'specialist_publisher_rebuild_production'
 govuk::apps::specialist_publisher_rebuild::mongodb_nodes: ['localhost']
+govuk::apps::specialist_publisher_rebuild::publish_pre_production_finders: true
 govuk::apps::stagecraft::worker::enabled: true
 govuk::apps::stagecraft::beat::enabled: true
 govuk::apps::stagecraft::celerycam::enabled: true

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -24,6 +24,7 @@ govuk::apps::rummager::aws_s3_bucket_name: govuk-api-elasticsearch-snapshots-int
 govuk::apps::smartanswers::expose_govspeak: true
 govuk::apps::specialist_publisher::publish_pre_production_finders: true
 govuk::apps::specialist_publisher_rebuild::enabled: true
+govuk::apps::specialist_publisher_rebuild::publish_pre_production_finders: true
 govuk::apps::travel_advice_publisher::enable_email_alerts: true
 govuk::apps::url_arbiter::db::backend_ip_range: '10.1.3.0/24'
 

--- a/modules/govuk/manifests/apps/specialist_publisher_rebuild.pp
+++ b/modules/govuk/manifests/apps/specialist_publisher_rebuild.pp
@@ -39,6 +39,10 @@
 #   Sets the OAuth Secret Key for using GDS-SSO
 #   Default: undef
 #
+# [*publish_pre_production_finders*]
+#   Whether to enable publishing of pre-production finders
+#   Default: false
+#
 # [*publishing_api_bearer_token*]
 #   The bearer token to use when communicating with Publishing API.
 #   Default: undef
@@ -59,6 +63,7 @@ class govuk::apps::specialist_publisher_rebuild(
   $mongodb_name,
   $oauth_id = undef,
   $oauth_secret = undef,
+  $publish_pre_production_finders = undef,
   $publishing_api_bearer_token = undef,
   $secret_key_base = undef,
 ) {
@@ -101,6 +106,14 @@ class govuk::apps::specialist_publisher_rebuild(
       "${title}-PUBLISHING_API_BEARER_TOKEN":
         varname => 'PUBLISHING_API_BEARER_TOKEN',
         value   => $publishing_api_bearer_token;
+    }
+
+    if $publish_pre_production_finders {
+      govuk::app::envvar {
+        "${title}-PUBLISH_PRE_PRODUCTION_FINDERS":
+          varname => 'PUBLISH_PRE_PRODUCTION_FINDERS',
+          value => '1';
+      }
     }
 
     if $secret_key_base != undef {


### PR DESCRIPTION
Specialist Publisher Rebuild has [an environment variable](https://github.com/alphagov/specialist-publisher-rebuild/blob/master/config/initializers/publish_pre_production_finders_feature_flag.rb#L1) that controls
whether pre-production finders are published or not. This setting
is switched on for development and integration, and off by default.

This mimicks the behaviour in Specialist Publisher V1.