### PR TITLE
Use the master branch. Not the release one.

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/gds_production_backup.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/gds_production_backup.yaml.erb
@@ -5,7 +5,7 @@
         - git:
             url: git@github.com:alphagov/govuk-app-deployment.git
             branches:
-              - release
+              - master
 
 - job:
     name: GDS_Production_Backup


### PR DESCRIPTION
@alexmuller this fixes the GDS Production Backup job.