### PR TITLE
Specialist publisher Rebuild: tweak flag default

### DIFF
--- a/modules/govuk/manifests/apps/specialist_publisher_rebuild.pp
+++ b/modules/govuk/manifests/apps/specialist_publisher_rebuild.pp
@@ -63,7 +63,7 @@ class govuk::apps::specialist_publisher_rebuild(
   $mongodb_name,
   $oauth_id = undef,
   $oauth_secret = undef,
-  $publish_pre_production_finders = undef,
+  $publish_pre_production_finders = false,
   $publishing_api_bearer_token = undef,
   $secret_key_base = undef,
 ) {


### PR DESCRIPTION
Change the 'publish_pre_production_finders' to default to 'false',
rather than 'undef', so it's exactly the same as in Specialist Publisher v1.

/cc @deanwilson 