### PR TITLE
Add a job to run DFID research outputs import

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -100,6 +100,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::deploy_puppet
   - govuk_jenkins::job::deploy_router_data
   - govuk_jenkins::job::deploy_terraform_project
+  - govuk_jenkins::job::dfid_transition_import
   - govuk_jenkins::job::govuk_cdn_nightly_2xx_status_collection
   - govuk_jenkins::job::govuk_delivery_configure_integration_catchall_feed
   - govuk_jenkins::job::launch_vms

--- a/modules/govuk_jenkins/manifests/job/dfid_transition_import.pp
+++ b/modules/govuk_jenkins/manifests/job/dfid_transition_import.pp
@@ -1,0 +1,20 @@
+# == Class: govuk_jenkins::job::dfid_transition_import
+#
+# Create a file on disk that can be parsed by jenkins-job-builder
+#
+# === Parameters
+#
+# [*publishing_api_bearer_token*]
+#   The bearer token to use when communicating with Publishing API.
+#   Default: undef
+class govuk_jenkins::job::dfid_transition_import (
+  $publishing_api_bearer_token = undef,
+) {
+
+  file {
+    '/etc/jenkins_jobs/jobs/dfid_transition_import.yaml':
+      ensure  => present,
+      content => template('govuk_jenkins/jobs/dfid_transition_import.yaml.erb'),
+      notify  => Exec['jenkins_jobs_update'];
+  }
+}

--- a/modules/govuk_jenkins/templates/jobs/dfid_transition_import.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/dfid_transition_import.yaml.erb
@@ -1,0 +1,34 @@
+---
+- scm:
+    name: dfid-transition-import
+    scm:
+        - git:
+            url: git@github.com:alphagov/dfid-transition.git
+            branches:
+              - master
+
+- job:
+    name: dfid-transition-import
+    display-name: DFID Transition Import
+    project-type: freestyle
+    description: "This job loads research outputs for the DFID specialist finder"
+    scm:
+      - dfid-transition-import
+    logrotate:
+        artifactNumToKeep: 100
+    triggers:
+        - timed: '49 * * * *' # every hour on the 49th minute
+    builders:
+        - shell: |
+            bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
+            bundle exec rake load:outputs
+    wrappers:
+        - ansicolor:
+            colormap: xterm
+        - inject-passwords:
+            global: false
+            mask-password-params: true
+            job-passwords:
+              - name: PUBLISHING_API_BEARER_TOKEN
+                password:
+                  '<%= @publishing_api_bearer_token %>'


### PR DESCRIPTION
* Scheduled on the 49th minute of every hour (selected by fair random
  dice roll)
* Uses a Publishing API bearer token
* Calls `rake load:outputs` and stuffs some DFID research outputs into
  publishing_api and rummager

Paired with @rgarner on this.
/cc @alexmuller @tuzz 