### PR TITLE
Set `$GOPATH` in the dev VM environment

### DIFF
--- a/modules/golang/files/etc/profile.d/gopath.sh
+++ b/modules/golang/files/etc/profile.d/gopath.sh
@@ -1,0 +1,1 @@
+export GOPATH=/var/govuk/gopath

--- a/modules/golang/manifests/init.pp
+++ b/modules/golang/manifests/init.pp
@@ -19,4 +19,11 @@ class golang {
 
   # Ensure that scm tools used by `go get` are present.
   ensure_packages(['bzr', 'git', 'mercurial'])
+
+  if $::domain == 'development'{
+    file { '/etc/profile.d/gopath.sh':
+      ensure => present,
+      source => 'puppet:///modules/golang/etc/profile.d/gopath.sh',
+    }
+  }
 }

--- a/modules/golang/spec/classes/golang_spec.rb
+++ b/modules/golang/spec/classes/golang_spec.rb
@@ -1,0 +1,19 @@
+require_relative '../../../../spec_helper'
+
+describe 'golang', :type => :class do
+  let(:file_path) { '/etc/profile.d/gopath.sh' }
+  let(:go_path){ 'export GOPATH=/var/govuk/gopath' }
+
+  context 'in development' do
+    let(:facts) {{domain: 'development'}}
+    it {
+      is_expected.to contain_file(file_path).
+        with_source('puppet:///modules/golang/etc/profile.d/gopath.sh')
+    }
+  end
+
+  context 'not in development' do
+    let(:facts) {{}}
+    it { is_expected.not_to contain_file(file_path) }
+  end
+end


### PR DESCRIPTION
This is part of the work underway to upgrade metadata-api to the latest go version.

Currently the dev VM has no `$GOPATH` which requires the apps try and build one within their own directory. This seems increasingly fragile with the most recent >1.6 versions of go.

This commit sets the `$GOPATH` to `/var/govuk/gopath` which will require our go apps to be located at
`/var/govuk/gopath/src/github.com/alphagov/<reponame>` at which point all will be well in the world.

I've opened another [PR](https://github.gds/gds/development/pull/319) to update the `Procfile` (currently just for metadata-api)

[Trello](https://trello.com/c/TGGWiuRB/399-upgrade-metadata-api-to-newest-go-version-large)