### PR TITLE
Use integration as the branch name.

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -123,7 +123,7 @@ govuk_jenkins::job_builder::jobs:
 govuk_jenkins::job_builder::environment: 'integration'
 
 govuk_jenkins::job::deploy_licensify::alphagov_deployment_branch: 'master'
-govuk_jenkins::job::deploy_puppet::commitish: 'preview'
+govuk_jenkins::job::deploy_puppet::commitish: 'integration'
 
 govuk_jenkins::job::network_config_deploy::environments:
   - 'carrenza-integration'


### PR DESCRIPTION
We no longer run a preview environment so update the name to suit.
The other part of this change, the jenkins job branch push, has been made
in the correct place.