### PR TITLE
Integration data sync: don't re-register info-frontend routes

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
@@ -22,8 +22,6 @@
            ssh deploy@calculators-frontend-1.frontend 'cd /var/apps/smartanswers ; govuk_setenv smartanswers bundle exec rake panopticon:register'
            # Queue up any publisher scheduled editions that have been transferred across.
            ssh deploy@backend-2.backend 'cd /var/apps/publisher ; govuk_setenv publisher bundle exec rake editions:requeue_scheduled_for_publishing'
-           # Re-register routes for info-frontend as it's not in production yet.
-           ssh deploy@frontend-1.frontend 'cd /var/apps/info-frontend ; govuk_setenv info-frontend bundle exec rake router:register'
     publishers:
         - trigger-parameterized-builds:
             <%- %w{ publishing-api collections-publisher service-manual-publisher local-links-manager }.each do |app| -%>


### PR DESCRIPTION
'info-frontend' has long since been deploy to Production, so this step
should no longer be necessary.

/cc @gpeng @boffbowsh 