### PR TITLE
Publish finders after integration data sync

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
@@ -22,6 +22,8 @@
            ssh deploy@calculators-frontend-1.frontend 'cd /var/apps/smartanswers ; govuk_setenv smartanswers bundle exec rake panopticon:register'
            # Queue up any publisher scheduled editions that have been transferred across.
            ssh deploy@backend-2.backend 'cd /var/apps/publisher ; govuk_setenv publisher bundle exec rake editions:requeue_scheduled_for_publishing'
+           # Publish any pre-production finders from Specialist Publisher Rebuild.
+           ssh deploy@$(govuk_node_list -c backend | shuf -n 1) 'cd /var/apps/specialist-publisher-rebuild ; govuk_setenv specialist-publisher-rebuild bundle exec rake publishing_api:publish_finders rummager:publish_finders'
     publishers:
         - trigger-parameterized-builds:
             <%- %w{ publishing-api collections-publisher service-manual-publisher local-links-manager }.each do |app| -%>


### PR DESCRIPTION
This is necessary to publish any pre-production finders to Integration; without doing this, the prod sync wipes those out.