### PR TITLE
Add deployment job for Lambda apps

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -483,6 +483,9 @@ govuk_jenkins::job::smokey::signon_password: "%{hiera('smokey_signon_password')}
 govuk_jenkins::job::run_rake_task::applications: *deployable_applications
 govuk_jenkins::job::deploy_app::applications: *deployable_applications
 
+govuk_jenkins::job::deploy_lambda_app::lambda_apps:
+  - 'email_alert_notifications'
+
 govuk_mysql::server::expire_log_days: 3
 govuk_mysql::server::monitoring::master::plaintext_mysql_password: "%{hiera('mysql_nagios')}"
 govuk_mysql::server::monitoring::slave::plaintext_mysql_password: "%{hiera('mysql_nagios')}"

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -95,6 +95,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::deploy_app
   - govuk_jenkins::job::deploy_cdn
   - govuk_jenkins::job::deploy_govuk_content_schemas
+  - govuk_jenkins::job::deploy_lambda_app
   - govuk_jenkins::job::deploy_licensify
   - govuk_jenkins::job::deploy_puppet
   - govuk_jenkins::job::deploy_router_data

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -78,6 +78,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::deploy_app
   - govuk_jenkins::job::deploy_cdn
   - govuk_jenkins::job::deploy_govuk_content_schemas
+  - govuk_jenkins::job::deploy_lambda_app
   - govuk_jenkins::job::deploy_licensify
   - govuk_jenkins::job::deploy_puppet
   - govuk_jenkins::job::deploy_router_data

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -33,6 +33,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::deploy_app
   - govuk_jenkins::job::deploy_cdn
   - govuk_jenkins::job::deploy_govuk_content_schemas
+  - govuk_jenkins::job::deploy_lambda_app
   - govuk_jenkins::job::deploy_licensify
   - govuk_jenkins::job::deploy_puppet
   - govuk_jenkins::job::deploy_router_data

--- a/modules/govuk_jenkins/manifests/job/deploy_lambda_app.pp
+++ b/modules/govuk_jenkins/manifests/job/deploy_lambda_app.pp
@@ -1,0 +1,15 @@
+# == Class: govuk_jenkins::job::deploy_lambda_app
+#
+# Create a file on disk that can be parsed by jenkins-job-builder
+#
+class govuk_jenkins::job::deploy_lambda_app (
+  $lambda_apps = [],
+) {
+  validate_array($lambda_apps)
+
+  file { '/etc/jenkins_jobs/jobs/deploy_lambda_app.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/deploy_lambda_app.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+}

--- a/modules/govuk_jenkins/templates/jobs/deploy_lambda_app.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_lambda_app.yaml.erb
@@ -1,0 +1,54 @@
+---
+- scm:
+    name: govuk-lambda-app-deployment_Deploy_Lambda_App
+    scm:
+        - git:
+            url: git@github.com:alphagov/govuk-lambda-app-deployment.git
+            branches:
+              - master
+            wipe-workspace: true
+
+- job:
+    name: Deploy_Lambda_App
+    display-name: Deploy_Lambda_App
+    project-type: freestyle
+    description: "This job uploads an AWS Lambda app to an S3 bucket and kicks off the relevant Terraform job"
+    properties:
+        - github:
+            url: https://github.com/alphagov/govuk-lambda-app-deployment
+        - inject:
+            properties-content: |
+              ENVIRONMENT=<%= @environment %>
+    scm:
+      - govuk-lambda-app-deployment_Deploy_Lambda_App
+    builders:
+      - shell: |
+          cd $TARGET_APPLICATION
+          source ./jenkins.sh # this job should create the source ready for uploading to an S3 bucket
+          s3cmd sync $FILE_TO_UPLOAD s3://govuk-lambda-applications-$ENVIRONMENT/${TARGET_APPLICATION}/
+    publishers:
+        - trigger-parameterized-builds:
+            - project: Deploy_Terraform_Project
+              predefined-parameters: |
+                AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+                AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+                ACTION=apply
+                PROJECT_NAME=${TARGET_APPLICATION}
+              condition: 'UNSTABLE_OR_BETTER'
+    wrappers:
+        - ansicolor:
+            colormap: xterm
+    parameters:
+        - choice:
+            name: TARGET_APPLICATION
+            description: Lambda application to deploy.
+            choices: <%= ['-- Choose an app'] + @lambda_apps %>
+    parameters:
+        - string:
+            name: AWS_ACCESS_KEY_ID
+            description: Your AWS access key ID
+            default: false
+        - password:
+            name: AWS_SECRET_ACCESS_KEY
+            description: Your AWS secret access key
+            default: false


### PR DESCRIPTION
The idea behind it is to grab the source from a new repository specifically for holding lambda
app info, push the content to an S3 bucket specifically created for Lambda apps, and trigger a build of a Terraform job which is designed to deploy the Lambda function in Amazon.

I think there's still a fair bit of work to do, including adding in pulling the object version of the uploaded object into the S3 bucket ([related](https://github.com/alphagov/govuk-terraform-provisioning/pull/46/commits/2d35845d8433661e03732c7cc21edb32cde4f1fc)). 

Another question is if we want to allow automatic deploys without passing in AWS credentials. 