### PR TITLE
Add a healthcheck endpoint that we can use to test routing

### DIFF
--- a/modules/govuk/manifests/node/s_backend_lb.pp
+++ b/modules/govuk/manifests/node/s_backend_lb.pp
@@ -46,7 +46,10 @@ class govuk::node::s_backend_lb (
       'specialist-publisher',
     ]:
       modified_paths => {
-        '/sp-rebuild/assets' => {
+        '/sp-rebuild/assets'   => {
+          'app' => 'specialist-publisher-rebuild',
+        },
+        '/rebuild-healthcheck' => {
           'app' => 'specialist-publisher-rebuild',
         },
       },


### PR DESCRIPTION
The specialist publisher (v1) app routes specific endpoints
to the v2 app. This rule lets us test that routing works.

Part of: https://trello.com/c/h2N84bHb/122-per-format-path-to-live-large