### PR TITLE
Mark specialist-publisher-rebuild as internal only

### DIFF
--- a/modules/govuk/manifests/node/s_backend_lb.pp
+++ b/modules/govuk/manifests/node/s_backend_lb.pp
@@ -68,7 +68,6 @@ class govuk::node::s_backend_lb (
       'service-manual-publisher',
       'share-sale-publisher',
       'signon',
-      'specialist-publisher-rebuild',
       'specialist-publisher-rebuild-standalone',
       'short-url-manager',
       'support',
@@ -86,6 +85,7 @@ class govuk::node::s_backend_lb (
       'govuk-delivery',
       'need-api',
       'publishing-api',
+      'specialist-publisher-rebuild',
       'support-api',
       'tariff-api',
     ]:


### PR DESCRIPTION
This app will be available to the public, but initially,
its requests will be proxied through from version 1.

Fixes: https://github.com/alphagov/govuk-puppet/issues/4389

specialist-publisher-rebuild-standalone is left as is, because that is a
separate integration-only instance for development uses only and will be
accessed directly.