### PR TITLE
Rate limit paths under /performance

### DIFF
--- a/modules/router/templates/rate-limiting.conf.erb
+++ b/modules/router/templates/rate-limiting.conf.erb
@@ -8,6 +8,7 @@ map $http_Rate_Limit_Token $limit_req {
 
 limit_req_zone $limit_req zone=rate:30m rate=10r/s;
 limit_req_zone $limit_req zone=contact:5m rate=6r/m;
+limit_req_zone $limit_req zone=performance:5m rate=5r/s;
 limit_conn_zone $limit_req zone=connections:10m;
 
 # Return 429 (Too Many Requests) instead of the default 503.

--- a/modules/router/templates/router_include.conf.erb
+++ b/modules/router/templates/router_include.conf.erb
@@ -41,8 +41,8 @@ location ~ ^/apply-for-a-licence/assets/ {
   proxy_pass http://varnish;
 }
 
-location ~ ^/performance/.+\.(json|png)$ {
-  limit_req zone=rate burst=25 nodelay;
+location /performance/ {
+  limit_req zone=performance burst=10 nodelay;
   proxy_pass http://varnish;
 }
 


### PR DESCRIPTION
Set up a new Nginx request limit zone for the Performance Platform and apply that zone to the whole `/performance` location block.

We're doing this because the Performance Platform frontend is sometimes quite slow to serve responses and we'd rather not phone on-call. Serving a 429 rate limit response is better.