### PR TITLE
Make jenkins run links import daily for local links manager

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -87,6 +87,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::govuk_cdn_nightly_2xx_status_collection
   - govuk_jenkins::job::launch_vms
   - govuk_jenkins::job::local_links_manager_import_service_interactions
+  - govuk_jenkins::job::local_links_manager_import_links
   - govuk_jenkins::job::mirror_network_config
   - govuk_jenkins::job::network_config_deploy
   - govuk_jenkins::job::passive_checks

--- a/modules/govuk_jenkins/manifests/job/local_links_manager_import_links.pp
+++ b/modules/govuk_jenkins/manifests/job/local_links_manager_import_links.pp
@@ -1,0 +1,25 @@
+# == Class: govuk_jenkins::job::local_links_manager_import_links
+#
+# Import links to service interactions for local authorities into local-links-manager
+#
+class govuk_jenkins::job::local_links_manager_import_links (
+  $app_domain = hiera('app_domain'),
+) {
+
+  $check_name = 'local-links-manager-import-links'
+  $service_description = 'Import links to service interactions for local authorities into local-links-manager'
+  $job_url = "https://deploy.${app_domain}/job/local-links-manager-import-links/"
+
+  file { '/etc/jenkins_jobs/jobs/local_links_manager_import_links.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/local_links_manager_import_links.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+
+  @@icinga::passive_check { "${check_name}_${::hostname}":
+    service_description => $service_description,
+    host_name           => $::fqdn,
+    freshness_threshold => (25 * 60 * 60), # 25 hrs (e.g. just over a day)
+    action_url          => $job_url,
+  }
+}

--- a/modules/govuk_jenkins/templates/jobs/local_links_manager_import_links.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/local_links_manager_import_links.yaml.erb
@@ -1,0 +1,27 @@
+---
+- job:
+    name: Local_Links_Manager_Import_Links
+    display-name: Local_Links_Manager_Import_Links
+    project-type: freestyle
+    description: |
+      Runs the rake task to import all links to service interactions for local authorities into Local Links Manager every day
+    logrotate:
+      artifactNumToKeep: 10
+    triggers:
+        - timed: 'H 5 * * *'
+    builders:
+        - shell: |
+            ssh deploy@backend-1.backend.production "cd /var/apps/local-links-manager && govuk_setenv local-links-manager bundle exec rake import:links:import_all"
+            echo "Local Links Manager links importer has run"
+    publishers:
+        - trigger-parameterized-builds:
+            - project: Success_Passive_Check
+              condition: 'SUCCESS'
+              predefined-parameters: |
+                  NSCA_CHECK_DESCRIPTION=<%= @service_description %>
+                  NSCA_OUTPUT=<%= @service_description %> success
+            - project: Failure_Passive_Check
+              condition: 'FAILED'
+              predefined-parameters: |
+                  NSCA_CHECK_DESCRIPTION=<%= @service_description %>
+                  NSCA_OUTPUT=<%= @service_description %> failed

--- a/modules/govuk_jenkins/templates/jobs/local_links_manager_import_links.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/local_links_manager_import_links.yaml.erb
@@ -10,9 +10,13 @@
     triggers:
         - timed: 'H 5 * * *'
     builders:
-        - shell: |
-            ssh deploy@backend-1.backend.production "cd /var/apps/local-links-manager && govuk_setenv local-links-manager bundle exec rake import:links:import_all"
-            echo "Local Links Manager links importer has run"
+        - trigger-builds:
+            - project: run-rake-task
+              block: true
+              predefined-parameters: |
+                  TARGET_APPLICATION=local-links-manager
+                  MACHINE_CLASS=backend
+                  RAKE_TASK=import:links:import_all
     publishers:
         - trigger-parameterized-builds:
             - project: Success_Passive_Check

--- a/modules/govuk_jenkins/templates/jobs/local_links_manager_import_service_interactions.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/local_links_manager_import_service_interactions.yaml.erb
@@ -10,9 +10,13 @@
     triggers:
         - timed: '0 0 1 * *'
     builders:
-        - shell: |
-            ssh deploy@backend-1.backend.production "cd /var/apps/local-links-manager && govuk_setenv local-links-manager bundle exec rake import:service_interactions:import_all"
-            echo "Local Links Manager services and interactions importer has run"
+        - trigger-builds:
+            - project: run-rake-task
+              block: true
+              predefined-parameters: |
+                  TARGET_APPLICATION=local-links-manager
+                  MACHINE_CLASS=backend
+                  RAKE_TASK=import:service_interactions:import_all
     publishers:
         - trigger-parameterized-builds:
             - project: Success_Passive_Check


### PR DESCRIPTION
Local Links Manager needs to import all the links that each local
authority provides to services and interactions.  These links are a csv
dataset provided on local.directgov.uk and we should import it daily.  The
import script is already part of the [local-links-manager
repo](https://github.com/alphagov/local-links-manager) and this commit
adds a jenkins job to run that import script configured to run at 5am (ish)
every day.

For: https://trello.com/c/Q0fMMggq/370-import-local-links-into-local-links-manager-5

The script we run is in https://github.com/alphagov/local-links-manager/pull/15 which is due for a deploy today.