### PR TITLE
Bugfix `/performance` rate limiting

### DIFF
--- a/modules/router/templates/router_include.conf.erb
+++ b/modules/router/templates/router_include.conf.erb
@@ -41,7 +41,7 @@ location ~ ^/apply-for-a-licence/assets/ {
   proxy_pass http://varnish;
 }
 
-location /performance/ {
+location ~ ^/performance/ {
   limit_req zone=performance burst=10 nodelay;
   proxy_pass http://varnish;
 }


### PR DESCRIPTION
Proving once again that I have no idea how Nginx location blocks work.