### PR TITLE
Move s3 asset sync to slave

### DIFF
--- a/hieradata/class/asset_master.yaml
+++ b/hieradata/class/asset_master.yaml
@@ -6,6 +6,8 @@ govuk::node::s_asset_master::asset_slave_ip_ranges:
   asset_slave_2_nfs:
     from: "%{hiera('environment_ip_prefix')}.11.21"
 
+govuk::node::s_asset_base::s3_bucket: 's3://govuk-attachments-production'
+
 govuk_safe_to_reboot::can_reboot: 'no'
 govuk_safe_to_reboot::reason: 'Mounted by backend machines, causes attachment delivery failures'
 

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -161,7 +161,6 @@ govuk::node::s_api_lb::search_servers:
   - "search-2.api"
 
 govuk::node::s_asset_master::copy_attachments_hour: 11
-govuk::node::s_asset_master::s3_env_sync_enabled: true
 
 govuk::node::s_backend_lb::backend_servers:
   - 'backend-1.backend'

--- a/hieradata/node/asset-master-1.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/asset-master-1.integration.publishing.service.gov.uk.yaml
@@ -1,0 +1,1 @@
+govuk::node::s_asset_base::s3_env_sync_enabled: true

--- a/hieradata/node/asset-master-1.publishing.service.gov.uk.yaml
+++ b/hieradata/node/asset-master-1.publishing.service.gov.uk.yaml
@@ -1,0 +1,1 @@
+govuk::node::s_asset_base::process_uploaded_attachments_to_s3: true

--- a/hieradata/node/asset-master-1.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/asset-master-1.staging.publishing.service.gov.uk.yaml
@@ -1,0 +1,1 @@
+govuk::node::s_asset_base::s3_env_sync_enabled: true

--- a/hieradata/node/asset-slave-2.backend.publishing.service.gov.uk.yaml
+++ b/hieradata/node/asset-slave-2.backend.publishing.service.gov.uk.yaml
@@ -1,1 +1,3 @@
 icinga::client::check_cputype::cputype: 'amd'
+govuk::node::s_asset_base::push_attachments_to_s3: true
+govuk::node::s_asset_base::s3_bucket: 's3://govuk-attachments-production'

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -95,7 +95,6 @@ govuk::node::s_api_lb::search_servers:
   - "search-3.api"
 
 govuk::node::s_asset_master::copy_attachments_hour: 7
-govuk::node::s_asset_master::s3_env_sync_enabled: true
 
 govuk::node::s_backend_lb::backend_servers:
   - 'backend-1.backend'

--- a/modules/govuk/manifests/node/s_asset_master.pp
+++ b/modules/govuk/manifests/node/s_asset_master.pp
@@ -11,28 +11,9 @@
 # [*asset_slave_ip_ranges*]
 #   A hash of IP addresses that the asset slave machines run on.
 #
-# [*s3_bucket*]
-#   The URL of an S3 bucket. This can be used to either push backups or
-#   sync from an environment. Format should be the full URL:
-#   e.g s3://foo-bucket/
-#
-# [*aws_access_key_id*]
-#   The AWS key ID for the bucket you are accessing.
-#
-# [*aws_secret_access_key*]
-#   The secret part of the keypair.
-#
-# [*s3_env_sync_enabled*]
-#   When this is enabled, it will pull down and apply backups from the
-#   specified bucket, and will not push any of it's own backups.
-#
 class govuk::node::s_asset_master (
   $copy_attachments_hour = 4,
   $asset_slave_ip_ranges = {},
-  $s3_bucket = undef,
-  $aws_access_key_id = undef,
-  $aws_secret_access_key = undef,
-  $s3_env_sync_enabled = false,
 ) inherits govuk::node::s_asset_base {
 
   include assets::ssh_private_key
@@ -42,60 +23,6 @@ class govuk::node::s_asset_master (
   file { '/var/run/virus_scan':
     ensure => directory,
     owner  => 'assets',
-  }
-
-  file { '/usr/local/bin/process-uploaded-attachments.sh':
-    content => template('govuk/node/s_asset_base/process-uploaded-attachments.sh.erb'),
-    mode    => '0755',
-  }
-
-  file { '/usr/local/bin/copy-attachments.sh':
-    content => template('govuk/node/s_asset_base/copy-attachments.sh.erb'),
-    mode    => '0755',
-  }
-
-  if $s3_bucket {
-
-    package { 's3cmd':
-      ensure   => 'present',
-      provider => 'pip',
-    }
-
-    file { '/home/assets/.s3cfg':
-      ensure  => present,
-      content => template('govuk/node/s_asset_base/s3cfg.erb'),
-      owner   => 'assets',
-      group   => 'assets',
-    }
-
-    file {
-    [ '/etc/govuk/aws', '/etc/govuk/aws/env.d']:
-      ensure  => directory,
-      owner   => 'assets',
-      group   => 'assets',
-      mode    => '0750';
-    '/etc/govuk/aws/env.d/AWS_ACCESS_KEY_ID':
-      ensure  => present,
-      content => $aws_access_key_id,
-      owner   => 'assets',
-      group   => 'assets',
-      mode    => '0640';
-    '/etc/govuk/aws/env.d/AWS_SECRET_ACCESS_KEY':
-      ensure  => present,
-      content => $aws_secret_access_key,
-      owner   => 'assets',
-      group   => 'assets',
-      mode    => '0640';
-    }
-
-    if $s3_env_sync_enabled {
-      file { '/usr/local/bin/attachments-s3-env-sync.sh':
-        ensure  => present,
-        mode    => '0755',
-        content => template('govuk/node/s_asset_base/attachments-s3-env-sync.sh.erb'),
-      }
-    }
-
   }
 
   # daemontools provides setlock

--- a/modules/govuk/templates/node/s_asset_base/copy-attachments.sh.erb
+++ b/modules/govuk/templates/node/s_asset_base/copy-attachments.sh.erb
@@ -40,14 +40,6 @@ for NODE in $ASSET_SLAVE_NODES; do
   fi
 done
 
-<% if @s3_bucket && !@s3_env_sync_enabled %>
-  if envdir /etc/govuk/aws/env.d /usr/local/bin/s3cmd --cache-file=/tmp/s3cmd_attachments.cache --server-side-encryption sync --exclude="lost+found" --skip-existing --delete-removed "$DIRECTORY_TO_COPY/" "s3://<%= @s3_bucket -%>$DIRECTORY_TO_COPY/"; then
-    logger -t copy_attachments "Attachments copied to S3 (<%= @s3_bucket -%>) successfully"
-  else
-    logger -t copy_attachments "Attachments errored while copying to S3 (<%= @s3_bucket -%>)"
-  fi
-<% end %>
-
 if [ $? == 0 ]
   then
     STATUS=0

--- a/modules/govuk/templates/node/s_asset_base/process-uploaded-attachments.sh.erb
+++ b/modules/govuk/templates/node/s_asset_base/process-uploaded-attachments.sh.erb
@@ -41,7 +41,7 @@ while IFS= read -r -d '' FILE
           logger -t process_uploaded_attachment "File $FILE failed to copy to $NODE"
         fi
       done
-      <% if @s3_bucket && !@s3_env_sync_enabled %>
+      <% if @s3_bucket && @process_uploaded_attachments_to_s3 %>
         if envdir /etc/govuk/aws/env.d /usr/local/bin/s3cmd --server-side-encryption put "$FILE_PATH" "s3://<%= @s3_bucket -%>$CLEAN_DIR/$FILE_PATH"; then
           logger -t process_uploaded_attachment "File $FILE copied to S3 (<%= @s3_bucket -%>)"
         else

--- a/modules/govuk/templates/node/s_asset_base/push-attachments-to-s3.sh.erb
+++ b/modules/govuk/templates/node/s_asset_base/push-attachments-to-s3.sh.erb
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+exec 1> >(logger -s -t $(basename $0)) 2>&1
+
+set -e
+
+export DIRECTORY_TO_COPY=$1
+
+set -u
+
+# The default Icinga passive alert assumes that the script failed
+NAGIOS_CODE=2
+NAGIOS_MESSAGE="CRITICAL: Push attachments to S3 failed"
+
+# Triggered whenever this script exits, successful or otherwise. The values
+# of CODE/MESSAGE will be taken from that point in time.
+function nagios_passive () {
+  printf "<%= @ipaddress %>\tPush attachments to S3\t${NAGIOS_CODE}\t${NAGIOS_MESSAGE}\n" | /usr/sbin/send_nsca -H alert.cluster >/dev/null
+}
+
+trap nagios_passive EXIT
+
+usage() {
+  echo "USAGE: $0 <directory_to_copy>"
+  echo
+  echo "Copies attachments in <directory_to_copy> to an S3 bucket"
+  echo
+  exit 1
+}
+
+if [ ! "$DIRECTORY_TO_COPY" ]; then
+ usage
+fi
+
+if envdir /etc/govuk/aws/env.d /usr/local/bin/s3cmd --cache-file=/tmp/s3cmd_attachments.cache --server-side-encryption sync --exclude="lost+found" --skip-existing --delete-removed "$DIRECTORY_TO_COPY/" "s3://<%= @s3_bucket -%>$DIRECTORY_TO_COPY/"; then
+  echo "Attachments copied to S3 (<%= @s3_bucket -%>) successfully"
+else
+  echo "Attachments errored while copying to S3 (<%= @s3_bucket -%>)"
+fi
+
+if [ $? == 0 ]
+  then
+    STATUS=0
+  else
+    STATUS=1
+fi
+
+if [ $STATUS -eq 0 ]; then
+  NAGIOS_CODE=0
+  NAGIOS_MESSAGE="Push attachments to S3 succeeded"
+fi
+
+exit $STATUS


### PR DESCRIPTION
The asset master in Production was set up to do a full sync of attachments to an S3 bucket. Unfortunately this caused the machine to run out of memory and OOM killer to kill the process before it had completed checking all the files on the source machine (completed about 40% before it ran OOM). We made the decision to move this process to an asset slave instead where we can upgrade memory, perform maintenance and will have less of an impact overall than the asset master.

However, because there will now be two machines sharing AWS credentials it made sense to move the logic to s_asset_base, set enabling parameters and specifically pick nodes to run the required function on. By default we should have nothing that copies to S3 until we specifically enable it
in the node specific hieradata. Once enabled it should pick up the same credentials so we don't have to repeat them in our secrets store.