### PR TITLE
Disable full asset sync to s3

### DIFF
--- a/modules/govuk/templates/node/s_asset_base/copy-attachments.sh.erb
+++ b/modules/govuk/templates/node/s_asset_base/copy-attachments.sh.erb
@@ -40,14 +40,6 @@ for NODE in $ASSET_SLAVE_NODES; do
   fi
 done
 
-<% if @s3_bucket && !@s3_env_sync_enabled %>
-  if envdir /etc/govuk/aws/env.d /usr/local/bin/s3cmd --cache-file=/tmp/s3cmd_attachments.cache --server-side-encryption sync --exclude="lost+found" --skip-existing --delete-removed "$DIRECTORY_TO_COPY/" "s3://<%= @s3_bucket -%>$DIRECTORY_TO_COPY/"; then
-    logger -t copy_attachments "Attachments copied to S3 (<%= @s3_bucket -%>) successfully"
-  else
-    logger -t copy_attachments "Attachments errored while copying to S3 (<%= @s3_bucket -%>)"
-  fi
-<% end %>
-
 if [ $? == 0 ]
   then
     STATUS=0


### PR DESCRIPTION
There is a larger change proposed in e194f1847a866c8e0d32ddc6a417d62b61456b3f but in the meantime we need to ensure that the full asset sync doesn't run so the asset master doesn't
run out of memory again.