### PR TITLE
Only restart apps on critical high memory alerts

### DIFF
--- a/modules/monitoring/files/usr/local/bin/event_handlers/govuk_app_high_memory.sh
+++ b/modules/monitoring/files/usr/local/bin/event_handlers/govuk_app_high_memory.sh
@@ -13,7 +13,7 @@ case "${SERVICESTATE}" in
   OK)
     # Service just came back up, so don't do anything
     ;;
-  WARNING|CRITICAL)
+  CRITICAL)
     case "${SERVICESTATETYPE}" in
       SOFT)
         ;;


### PR DESCRIPTION
Applications should only be restarted when a `CRITICAL` service state is encountered by the high memory event handler.