### PR TITLE
Add logstash filter for logrus logging

### DIFF
--- a/modules/govuk/manifests/node/s_logging.pp
+++ b/modules/govuk/manifests/node/s_logging.pp
@@ -78,6 +78,11 @@ class govuk::node::s_logging (
                 'MMM  d HH:mm:ss' ],
     order => '13',
   }
+  logstash::filter::mutate { 'logrus-msg-field':
+    rename => {
+      'msg' => '@message',
+    },
+  }
   logstash::filter::mutate {'syslog-1':
     type         => 'syslog',
     order        => '14',


### PR DESCRIPTION
Apps that use Go's [logrus][1] (all of our Go apps) output a `msg` field which contains the log message. Logstash/Kibana uses an `@message` field.

This commit adds a rename filter to Logstash so that we have more consistent naming of that field.

[1]: https://github.com/Sirupsen/logrus

I haven't tested this in Vagrant (yet).