### PR TITLE
WAL-E env sync bugfixes

### DIFF
--- a/modules/govuk_postgresql/manifests/wal_e/env_sync.pp
+++ b/modules/govuk_postgresql/manifests/wal_e/env_sync.pp
@@ -85,6 +85,13 @@ define govuk_postgresql::wal_e::env_sync (
       mode    => '0640',
     }
 
+    file { "${env_sync_envdir}/WALE_GPG_KEY_ID":
+      content => $wale_private_gpg_key_fingerprint,
+      owner   => 'postgres',
+      group   => 'postgres',
+      mode    => '0640',
+    }
+
     file { "/var/lib/postgresql/.gnupg/${wale_private_gpg_key_fingerprint}_secret_key.asc":
       ensure  => present,
       mode    => '0600',

--- a/modules/govuk_postgresql/templates/usr/local/bin/wal-e_env_sync
+++ b/modules/govuk_postgresql/templates/usr/local/bin/wal-e_env_sync
@@ -13,20 +13,35 @@ set -e
 # Redirect stdout and stderr to syslog
 exec 1> >(/usr/bin/logger -s -t $(basename $0)) 2>&1
 
-# Stop the PostgreSQL service
-sudo service postgresql stop
+# Check if Puppet is enabled
+if sudo test -f /var/lib/puppet/state/agent_disabled.lock; then
+  # If it isn't then quit
+  echo "Puppet agent disabled! If Puppet cannot run then we will not be able"
+  echo "to resync passwords and things will break. Quitting"
+  exit 1
+else
+  echo "PostgreSQL environment sync starting"
 
-# Push the passphrase to a file so we can decrypt without prompt
-sudo -iu postgres envdir <%= @env_sync_envdir %> sh -c  'echo "passphrase $GPG_PASSPHRASE" >> /var/lib/postgresql/.gnupg/gpg.conf'
+  # Otherwise go ahead and disable Puppet to start the sync
+  govuk_puppet --disable "Disabling Puppet to sync data (by $0)"
 
-# Start the restore process
-sudo -iu postgres envdir <%= @env_sync_envdir %> /usr/local/bin/wal-e backup-fetch --blind-restore <%= @datadir -%> LATEST
+  # Stop the PostgreSQL service
+  sudo service postgresql stop
 
-# Remove the GPG stuff
-sudo sed -i '/passphrase/d' /var/lib/postgresql/.gnupg/gpg.conf || exit 1
+  # Push the passphrase to a file so we can decrypt without prompt
+  sudo envdir <%= @env_sync_envdir %> sh -c  'echo passphrase $GPG_PASSPHRASE >> /var/lib/postgresql/.gnupg/gpg.conf'
 
-# Add the recovery.conf configuration (this is renamed to recovery.done after PostgreSQL starts)
-sudo -iu postgres echo "restore_command = \'envdir /etc/wal-e/env.d /usr/local/bin/wal-e wal-fetch \"%f\" \"%p\"\'" > $RECOVERY_FILE
+  # Start the restore process
+  sudo -iu postgres envdir <%= @env_sync_envdir %> /usr/local/bin/wal-e backup-fetch --blind-restore <%= @datadir -%> LATEST
 
-# Start the PostgreSQL service
-sudo service postgresql start
+  # Add the recovery.conf configuration (this is renamed to recovery.done after PostgreSQL starts)
+  sudo -iu postgres echo "restore_command = 'envdir <%= @env_sync_envdir %> /usr/local/bin/wal-e wal-fetch \"%f\" \"%p\"'" > $RECOVERY_FILE
+
+  # Start the PostgreSQL service
+  sudo service postgresql start
+
+  # Enable and run Puppet to update passwords
+  govuk_puppet --enable && govuk_puppet
+
+  echo "PostgreSQL environment sync finished"
+fi


### PR DESCRIPTION
In testing we found a few bugs which meant that this didn't work off the bat.

One addition is to disable and then re-enable and re-run Puppet: because we're restoring from a Production DB the passwords get updated, so running Puppet ensures the passwords are correct. It will also ensure that the gpg.conf file is updated and will remove the added passphrase.