### PR TITLE
Add access for postgresql standbys to S3

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -214,7 +214,8 @@ govuk::node::s_licensify_mongo::licensify_mongo_encrypted: false
 govuk::node::s_logging::compress_srv_logs_hour: '9'
 govuk::node::s_monitoring::offsite_backups: false
 govuk::node::s_whitehall_backend::sync_mirror: true
-govuk::node::s_transition_postgresql_master::env_sync_enabled: true
+
+govuk::node::s_transition_postgresql_base::env_sync_enabled: true
 govuk::node::s_transition_postgresql_slave::redirector_ip_range: '10.1.5.0/24'
 
 govuk_sudo::sudo_conf:

--- a/modules/govuk/manifests/node/s_transition_postgresql_base.pp
+++ b/modules/govuk/manifests/node/s_transition_postgresql_base.pp
@@ -2,7 +2,15 @@
 #
 # Base node for s_transition_postgresql_{master,slave}
 #
-class govuk::node::s_transition_postgresql_base inherits govuk::node::s_base {
+class govuk::node::s_transition_postgresql_base (
+  $env_sync_access_key_id = undef,
+  $env_sync_secret_access_key = undef,
+  $env_sync_s3_bucket_url = undef,
+  $env_sync_private_gpg_key = undef,
+  $env_sync_private_gpg_key_fingerprint = undef,
+  $env_sync_private_gpg_key_passphrase = undef,
+  $env_sync_enabled = false,
+) inherits govuk::node::s_base {
   include govuk::apps::transition::postgresql_db
 
   Govuk_mount['/var/lib/postgresql'] -> Class['govuk_postgresql::server']
@@ -11,5 +19,16 @@ class govuk::node::s_transition_postgresql_base inherits govuk::node::s_base {
 
   postgresql::server::config_entry { 'random_page_cost':
     value => 2.5,
+  }
+
+  if $env_sync_enabled {
+    govuk_postgresql::wal_e::env_sync { $title:
+      aws_access_key_id                => $env_sync_access_key_id,
+      aws_secret_access_key            => $env_sync_secret_access_key,
+      s3_bucket_url                    => $env_sync_s3_bucket_url,
+      wale_private_gpg_key             => $env_sync_private_gpg_key,
+      wale_private_gpg_key_fingerprint => $env_sync_private_gpg_key_fingerprint,
+      wale_private_gpg_key_passphrase  => $env_sync_private_gpg_key_passphrase,
+    }
   }
 }

--- a/modules/govuk/manifests/node/s_transition_postgresql_master.pp
+++ b/modules/govuk/manifests/node/s_transition_postgresql_master.pp
@@ -15,13 +15,6 @@ class govuk::node::s_transition_postgresql_master (
   $s3_bucket_url,
   $wale_private_gpg_key,
   $wale_private_gpg_key_fingerprint,
-  $env_sync_access_key_id = undef,
-  $env_sync_secret_access_key = undef,
-  $env_sync_s3_bucket_url = undef,
-  $env_sync_private_gpg_key = undef,
-  $env_sync_private_gpg_key_fingerprint = undef,
-  $env_sync_private_gpg_key_passphrase = undef,
-  $env_sync_enabled = false,
 ) inherits govuk::node::s_transition_postgresql_base {
   class { 'govuk_postgresql::server::primary':
     slave_password => $slave_password,
@@ -35,16 +28,6 @@ class govuk::node::s_transition_postgresql_master (
     wale_private_gpg_key_fingerprint => $wale_private_gpg_key_fingerprint,
   }
 
-  if $env_sync_enabled {
-    govuk_postgresql::wal_e::env_sync { $title:
-      aws_access_key_id                => $env_sync_access_key_id,
-      aws_secret_access_key            => $env_sync_secret_access_key,
-      s3_bucket_url                    => $env_sync_s3_bucket_url,
-      wale_private_gpg_key             => $env_sync_private_gpg_key,
-      wale_private_gpg_key_fingerprint => $env_sync_private_gpg_key_fingerprint,
-      wale_private_gpg_key_passphrase  => $env_sync_private_gpg_key_passphrase,
-    }
-  }
 
   include govuk::apps::bouncer::postgresql_role
 }


### PR DESCRIPTION
We are able to successfully restore the data from the Production S3 bucket to the PostgreSQL master, but when we do this the slaves get extremely unhappy. We would like to test pulling all the data from S3
onto the slaves as well, and while keeping hold of some files and configuration, try to restore replication at the same time as the master so we don't need to do a full resync.

This change is mainly for testing purposes, but would also be kept if we went along with this approach in the future.