### PR TITLE
Add Jenkins job for tagging sync check

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -115,6 +115,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::smokey
   - govuk_jenkins::job::smokey_deploy
   - govuk_jenkins::job::tagging_migration_check
+  - govuk_jenkins::job::tagging_sync_check
   - govuk_jenkins::job::transition_load_site_config
   - govuk_jenkins::job::transition_load_transition_stats_hits
   - govuk_jenkins::job::transition_run_database_migrations

--- a/modules/govuk_jenkins/manifests/job/tagging_sync_check.pp
+++ b/modules/govuk_jenkins/manifests/job/tagging_sync_check.pp
@@ -1,0 +1,18 @@
+# == Class: govuk_jenkins::job::tagging_sync_check
+#
+# Create a file on disk that can be parsed by jenkins-job-builder.
+#
+class govuk_jenkins::job::tagging_sync_check (
+  $app_domain = hiera('app_domain'),
+) {
+
+  $check_name = 'tagging_sync_check'
+  $service_description = 'Tagging migration check'
+  $job_url = "https://deploy.${app_domain}/job/tagging-sync-check/"
+
+  file { '/etc/jenkins_jobs/jobs/tagging_sync_check.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/tagging_sync_check.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+}

--- a/modules/govuk_jenkins/templates/jobs/tagging_sync_check.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/tagging_sync_check.yaml.erb
@@ -1,0 +1,27 @@
+---
+- scm:
+    name: tagging-sync-check
+    scm:
+        - git:
+            url: git@github.com:alphagov/finding-things-migration-checker.git
+            branches:
+              - master
+
+- job:
+    name: tagging-sync-check
+    display-name: Tagging sync check
+    project-type: freestyle
+    description: "This job checks if taggings are in sync between Rummager and Publishing API. See https://github.com/alphagov/finding-things-migration-checker"
+    scm:
+      - tagging-sync-check
+    logrotate:
+        artifactNumToKeep: 100
+    builders:
+        - shell: |
+            bin/run_automated_checks
+    wrappers:
+        - ansicolor:
+            colormap: xterm
+    publishers:
+        - archive:
+            artifacts: '*.csv'


### PR DESCRIPTION
The tagging sync check, or migration checker, is used to monitor differences between publishing-api and rummager.

This Jenkins job will only be available in integration.

https://trello.com/c/InnHPkm5/645-add-jenkins-job-for-tagging-migration-checker