### PR TITLE
Run proper bundle install before running tagging sync check

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/tagging_sync_check.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/tagging_sync_check.yaml.erb
@@ -18,6 +18,7 @@
         artifactNumToKeep: 100
     builders:
         - shell: |
+            bundle install --path "${HOME}/bundles/${JOB_NAME}"
             bin/run_automated_checks
     wrappers:
         - ansicolor:


### PR DESCRIPTION
This was previously done with `bin/run_automated_checks`, but that
didn't account for the fact that jenkins can't install gems to the
default directory. This caused the jenkins job to fail:

https://deploy.integration.publishing.service.gov.uk/job/tagging-sync-check/1/console

https://trello.com/c/InnHPkm5/645-add-jenkins-job-for-tagging-migration-checker