### PR TITLE
Add publishing-api bearer token to sync check

### DIFF
--- a/modules/govuk_jenkins/manifests/job/tagging_sync_check.pp
+++ b/modules/govuk_jenkins/manifests/job/tagging_sync_check.pp
@@ -2,8 +2,17 @@
 #
 # Create a file on disk that can be parsed by jenkins-job-builder.
 #
+# === Parameters
+#
+# [*app_domain*]
+#   The app_domain.
+#
+# [*publishing_api_bearer_token*]
+#   A valid Publishing API bearer token belonging to a API user
+#
 class govuk_jenkins::job::tagging_sync_check (
   $app_domain = hiera('app_domain'),
+  $publishing_api_bearer_token = undef,
 ) {
 
   $check_name = 'tagging_sync_check'

--- a/modules/govuk_jenkins/templates/jobs/tagging_sync_check.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/tagging_sync_check.yaml.erb
@@ -19,7 +19,7 @@
     builders:
         - shell: |
             bundle install --path "${HOME}/bundles/${JOB_NAME}"
-            bin/run_automated_checks
+            PUBLISHING_API_BEARER_TOKEN=<%= @publishing_api_bearer_token %> bin/run_automated_checks
     wrappers:
         - ansicolor:
             colormap: xterm


### PR DESCRIPTION
The sync check needs `PUBLISHING_API_BEARER_TOKEN` set so that it can communicate with the publishing-api.

A corresponding change in the encrypted hieradata: https://github.gds/gds/deployment/pull/1012