### PR TITLE
Bump nginx minor version

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1045,7 +1045,7 @@ monitoring::vpn_gateways::endpoints:
   vpn_gateway_router_dr:
     address: "%{hiera('environment_ip_prefix')}.9.1"
 
-nginx::package::version: '1.4.6-1ubuntu3.4'
+nginx::package::version: '1.4.6-1ubuntu3.5'
 
 nodejs::version: '0.10.37-1chl1~%{::lsbdistcodename}1'
 


### PR DESCRIPTION
We need to do this for two (probably related) reasons:

Puppet is failing to run on all machines that have nginx because we pin the verison "1.4.6-1ubuntu3.4" which is now unavailable:

```
lauramartin@integration-backend-1:~$ sudo apt-cache madison nginx |grep
"1.4.6-1ubuntu3.4"
lauramartin@integration-backend-1:~$
```

There has also been a vulnerability flagged by Ubuntu for that specific version of nginx which has been patched in the next minor version (1.4.6-1ubuntu3.5).