### PR TITLE
Create defined crondotdee

### DIFF
--- a/modules/cron/manifests/crondotdee.pp
+++ b/modules/cron/manifests/crondotdee.pp
@@ -1,0 +1,53 @@
+# == Define: Cron::Crondotdee
+#
+# Create a file in /etc/cron.d rather than in cron.daily or a shared crontab.
+# Default behaviour is to set a command, minute and hour and to run as root.
+#
+# Note: set hour/minute/day/month/weekday as a string rather than an integer as
+# they could potentially contain non-integer values, so keep it consisent.
+#
+# === Parameters:
+#
+# [*command*]
+#   The command to schedule. Required.
+#
+# [*hour*]
+#   The hour(s) to run. Default is 09:00.
+#
+# [*minute*]
+#   The minute(s) to run. Default is on the hour.
+#
+# [*day*]
+#   The day to run. Default is everyday.
+#
+# [*month*]
+#   The month to run. Default is every month.
+#
+# [*weekday*]
+#   The weekday to run. Default is every weekday.
+#
+# [*user*]
+#   Which user to run as. This can be used if you wish to run a script without
+#   invoking "sudo -u $user". Default is root, as per the standard cron job.
+#
+# [*mailto*]
+#   Specifically set where the cron should attempt to email output to.
+#   Example would be a user or an email address, or use an empty string to
+#   suppress mailing any output.
+define cron::crondotdee (
+  $command,
+  $hour = '9',
+  $minute = '0',
+  $day = '*',
+  $month = '*',
+  $weekday = '*',
+  $user = 'root',
+  $mailto = undef,
+) {
+  file { "/etc/cron.d/${title}":
+    ensure  => present,
+    content => template('cron/etc/cron.d/crondotdee.erb'),
+    require => File['/etc/cron.d'],
+  }
+}
+

--- a/modules/cron/manifests/crondotdee.pp
+++ b/modules/cron/manifests/crondotdee.pp
@@ -4,7 +4,7 @@
 # Default behaviour is to set a command, minute and hour and to run as root.
 #
 # Note: set hour/minute/day/month/weekday as a string rather than an integer as
-# they could potentially contain non-integer values, so keep it consisent.
+# they could potentially contain non-integer values, so keep it consistent.
 #
 # === Parameters:
 #
@@ -12,10 +12,10 @@
 #   The command to schedule. Required.
 #
 # [*hour*]
-#   The hour(s) to run. Default is 09:00.
+#   The hour(s) to run.
 #
 # [*minute*]
-#   The minute(s) to run. Default is on the hour.
+#   The minute(s) to run.
 #
 # [*day*]
 #   The day to run. Default is everyday.
@@ -36,8 +36,8 @@
 #   suppress mailing any output.
 define cron::crondotdee (
   $command,
-  $hour = '9',
-  $minute = '0',
+  $hour,
+  $minute,
   $day = '*',
   $month = '*',
   $weekday = '*',
@@ -48,6 +48,9 @@ define cron::crondotdee (
     ensure  => present,
     content => template('cron/etc/cron.d/crondotdee.erb'),
     require => File['/etc/cron.d'],
+    mode    => '0644',
+    owner   => 'root',
+    group   => 'root',
   }
 }
 

--- a/modules/cron/templates/etc/cron.d/crondotdee.erb
+++ b/modules/cron/templates/etc/cron.d/crondotdee.erb
@@ -1,0 +1,4 @@
+<% if @mailto %>
+MAILTO=<%= @mailto %>
+<% end %>
+<%= @minute %> <%= @hour %> <%= @day %> <%= @month %> <%= @weekday %> <%= @user %> <%= @command %>

--- a/modules/rkhunter/manifests/monitoring.pp
+++ b/modules/rkhunter/manifests/monitoring.pp
@@ -44,11 +44,20 @@ class rkhunter::monitoring {
   }
 
   # Script to run rkhunter as a passive check
-  file { '/etc/cron.daily/rkhunter-passive-check':
+  file { '/usr/local/bin/rkhunter-passive-check':
     ensure  => present,
     mode    => '0755',
     content => template('rkhunter/rkhunter-passive-check.erb'),
   }
+
+  # Run it twice a day to stop superfluous alerting
+  cron::crondotdee { 'rkhunter-passive-check':
+    command => '/usr/local/bin/rkhunter-passive-check',
+    hour    => '6,14',
+    minute  => '0',
+    mailto  => '',
+  }
+
   @@icinga::passive_check { "check_rkhunter_${::hostname}":
     service_description => 'rkhunter warnings',
     host_name           => $::fqdn,


### PR DESCRIPTION
This creates a way to add stuff to `/etc/cron.d` which can be a preference from `/etc/cron.daily` and a shared crontab. In this example we'll add rkhunter as it tends to alert throughout the day when the cron.daily job doesn't run for whatever reason.