### PR TITLE
This commit adds the script /usr/local/bin/{mongodb-restore-s3,mongod…

### DIFF
--- a/modules/mongodb/manifests/s3backup/restore.pp
+++ b/modules/mongodb/manifests/s3backup/restore.pp
@@ -1,0 +1,64 @@
+# == Class: mongodb::s3backup::restore
+#
+# Restore a MongoDB backup to a server from s3
+#
+# === Parameters:
+#
+# [*aws_access_key_id*]
+#
+# [*aws_secret_access_key*]
+#
+# [*aws_region*]
+#   AWS region for the S3 bucket
+#
+# [*backup_dir*]
+#   Defines the directory to restore the backups
+#
+# [*cron*]
+#   Defines whether to enable the cron job. Value
+#   should be true or false
+#
+# [*private_gpg_key*]
+#   Defines the ascii exported private gpg to
+#   use for encrypting backups. This key should
+#   be created by the user and encrypted with eyaml
+#
+# [*private_gpg_key_fingerprint*]
+#   Defines the fingerprint of the gpg private
+#   key to encrypt the backups. The fingerprint
+#   should be 40 characters without spaces
+#
+# [*s3_bucket*]
+#   Defines the AWS S3 bucket where the backups
+#   will be uploaded. It should be created by the
+#   user
+#
+class mongodb::s3backup::restore(
+  $aws_access_key_id = undef,
+  $aws_secret_access_key = undef,
+  $s3_bucket  = 'govuk-mongodb-backup-s3',
+  $backup_dir = '/var/lib/s3backup',
+){
+  include backup::client
+  $backup_user = 'govuk-backup'
+
+  File {
+    owner => $backup_user,
+    group => $backup_user,
+    mode  => '0660',
+  }
+
+  file { '/usr/local/bin/mongodb-restore-s3':
+    ensure  => file,
+    content => template('mongodb/mongodb-restore-s3.sh.erb'),
+    mode    => '0750',
+    require => User[$backup_user],
+  }
+
+  file { '/usr/local/bin/mongodb-restore-s3-wrapper':
+    ensure  => file,
+    content => template('mongodb/mongodb-restore-s3-wrapper.erb'),
+    mode    => '0755',
+    require => User[$backup_user],
+  }
+}

--- a/modules/mongodb/templates/mongodb-backup-s3.sh.erb
+++ b/modules/mongodb/templates/mongodb-backup-s3.sh.erb
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+
+BACKUP_NODE=<%= @backup_node %>
+BACKUP_DIR=<%= @backup_dir %>
+BACKUP_FILE=mongodump-<%= @fqdn %>.$(date +%F_%T).tar.gz.gpg
+KEY_FINGERPRINT=<%= @private_gpg_key_fingerprint %>
+S3_BUCKET=<%= @s3_bucket %>
+
+
+exec 1> >(/usr/bin/logger -s -t $(basename $0)) 2>&1
+
+function time_taken {
+  TIME="$(date +%s%N)"
+  $@
+  TIME="$(($(date +%s%N)-TIME))"
+  SECS="$((TIME/1000000000))"
+  MILLISECS="$((TIME/100000000))"
+  printf " FINISHED IN: %02d:%02d:%02d.%02d\n" "$((SECS/3600%24))" "$((SECS/60%60))" "$((SECS%60))" "${MILLISECS}"
+
+}
+
+echo "................STARTING BACKUP..................."
+
+
+time_taken mongodump -h $BACKUP_NODE -o $BACKUP_DIR
+
+
+
+echo "................COMPRESSING AND ENCRYPTING................."
+
+
+time_taken `tar cvz $BACKUP_DIR | gpg -e -o $BACKUP_DIR/$BACKUP_FILE -r $KEY_FINGERPRINT`
+
+
+export AWS_ACCESS_KEY_ID=<%= @aws_access_key_id %>
+export AWS_SECRET_ACCESS_KEY=<%= @ws_secret_access_key %>
+
+echo "................UPLOADING TO S3.................."
+
+time_taken s3cmd put $BACKUP_DIR/mongodump-* s3://$S3_BUCKET
+
+rm -f $BACKUP_DIR/mongodump-*
+
+

--- a/modules/mongodb/templates/mongodb-restore-s3-wrapper.erb
+++ b/modules/mongodb/templates/mongodb-restore-s3-wrapper.erb
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -e
+
+# Redirect stdout and stderr to syslog
+exec 1> >(/usr/bin/logger -s -t $(basename $0)) 2>&1
+
+# The default Icinga passive alert assumes that the script failed
+NAGIOS_CODE=2
+NAGIOS_MESSAGE="CRITICAL: Mongodb backup push to S3 failed"
+
+# Triggered whenever this script exits, successful or otherwise. The values
+# of CODE/MESSAGE will be taken from that point in time.
+function nagios_passive () {
+printf "<%= @ipaddress %>\t<%= @service_desc %>\t${NAGIOS_CODE}\t${NAGIOS_MESSAGE}\n" | /usr/sbin/send_nsca -H alert.cluster >/dev/null
+}
+
+trap nagios_passive EXIT
+
+/usr/local/bin/mongodb-restore-s3
+
+if [ $? == 0 ]
+then
+STATUS=0
+else
+STATUS=1
+fi
+
+if [ $STATUS -eq 0 ]; then
+NAGIOS_CODE=0
+NAGIOS_MESSAGE="OK: Mongodb backup push to S3 succeeded"
+fi
+
+exit $STATUS

--- a/modules/mongodb/templates/mongodb-restore-s3.sh.erb
+++ b/modules/mongodb/templates/mongodb-restore-s3.sh.erb
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+S3_BUCKET=<%= @s3_bucket %>
+BACKUP_DIR=<%= @backup_dir %>
+
+function time_taken {
+  TIME="$(date +%s%N)"
+  $@
+  TIME="$(($(date +%s%N)-TIME))"
+  SECS="$((TIME/1000000000))"
+  MILLISECS="$((TIME/100000000))"
+  printf " FINISHED IN: %02d:%02d:%02d.%02d\n" "$((SECS/3600%24))" "$((SECS/60%60))" "$((SECS%60))" "${MILLISECS}"
+
+}
+
+cd $BACKUP_DIR
+
+export AWS_ACCESS_KEY_ID=<%= @aws_access_key_id %>
+export AWS_SECRET_ACCESS_KEY=<%= @ws_secret_access_key %>
+
+echo "................FETCHING LATEST BACKUP...................."
+
+time_taken $(s3cmd get --force `s3cmd ls s3://${s3_bucket}/mongodump* | tail -1 | awk '{print $4}'`| \
+awk '{print $4}' | tr -d "'" | \
+xargs gpg --yes --output mongodump.tar.gz --decrypt && tar xzf mongodump.tar.gz)
+
+echo "................RESTORING BACKUP..........................."
+
+time_taken mongorestore var/
+
+
+rm -rf var/ mongo*


### PR DESCRIPTION
…b-restore-s3-wrapper}. All the script does is downloads the most recent backup, decrypts it, uncompresses it and restores the backup into mongo. We're able to get the latest backup with the script because amazon s3 stores files in alphabetical,chronological order. Note: this only works when the filenames are timestamped in 'yyyy-mm-dd' format.