### PR TITLE
Improve validation for app memory threshold

### DIFF
--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -55,24 +55,16 @@ define govuk::app::config (
     'absent'  => 'absent',
   }
 
+  # Check memory thresholds are approximately right
+  validate_integer($nagios_memory_warning, 12000, 100)
+  validate_integer($nagios_memory_critical, 14000, 200)
+
   # Use the International System of Units (SI) value of 1 million bytes in a MB
   # as it makes it simpler to evaluate memory usage when looking at our
   # metrics, which record memory usage in bytes
   $si_megabyte = 1000000
   $nagios_memory_warning_real = $nagios_memory_warning * $si_megabyte
   $nagios_memory_critical_real = $nagios_memory_critical * $si_megabyte
-
-  # Check memory thresholds are sane
-  # i.e. 10MB or more but less than 100GB, i.e. between 8-11 digits long
-  # FIXME: Lower max memory threshold to 10GB once Whitehall thresholds are lowered to a sane level
-  #
-  # Tell Puppet Lint to ignore double quoted string as `validate_re` does
-  # not except a Fixnum type so we convert it to a string.
-  #
-  # lint:ignore:only_variable_string
-  validate_re("${nagios_memory_warning_real}", '^\d{8,11}$', '$nagios_memory_warning_real must be specified in MB')
-  validate_re("${nagios_memory_critical_real}", '^\d{8,11}$', '$nagios_memory_warning_real must be specified in MB')
-  # lint:endignore
 
   # Ensure config dir exists
   file { "/etc/govuk/${title}":

--- a/modules/govuk/spec/defines/govuk__app__config_spec.rb
+++ b/modules/govuk/spec/defines/govuk__app__config_spec.rb
@@ -269,7 +269,7 @@ describe 'govuk::app::config', :type => :define do
       })}
 
       it 'raises an error' do
-        is_expected.to raise_error(Puppet::Error, /nagios_memory_warning_real must be specified in MB/)
+        is_expected.to raise_error(Puppet::Error, /Expected 1 to be greater or equal to 100/)
       end
     end
 
@@ -280,7 +280,7 @@ describe 'govuk::app::config', :type => :define do
       })}
 
       it 'raises an error' do
-        is_expected.to raise_error(Puppet::Error, /nagios_memory_warning_real must be specified in MB/)
+        is_expected.to raise_error(Puppet::Error, /Expected 111000 to be smaller or equal to 12000/)
       end
     end
   end


### PR DESCRIPTION
Use `validate_integer` instead of validating a regex because it's much easier to figure out what's going on.