### PR TITLE
Add DR nodes to the allowed list of reboots

### DIFF
--- a/hieradata/node/api-mongo-4.api.publishing.service.gov.uk.yaml
+++ b/hieradata/node/api-mongo-4.api.publishing.service.gov.uk.yaml
@@ -1,1 +1,3 @@
 icinga::client::check_cputype::cputype: 'amd'
+govuk_safe_to_reboot::can_reboot: 'overnight'
+govuk_safe_to_reboot::reason: 'DR node: only used in the event of a disaster'

--- a/hieradata/node/api-mongo-4.api.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/api-mongo-4.api.staging.publishing.service.gov.uk.yaml
@@ -1,1 +1,3 @@
 icinga::client::check_cputype::cputype: 'amd'
+govuk_safe_to_reboot::can_reboot: 'overnight'
+govuk_safe_to_reboot::reason: 'DR node: only used in the event of a disaster'

--- a/hieradata/node/api-postgresql-standby-2.api.publishing.service.gov.uk.yaml
+++ b/hieradata/node/api-postgresql-standby-2.api.publishing.service.gov.uk.yaml
@@ -1,1 +1,3 @@
 icinga::client::check_cputype::cputype: 'amd'
+govuk_safe_to_reboot::can_reboot: 'overnight'
+govuk_safe_to_reboot::reason: 'DR node: only used in the event of a disaster'

--- a/hieradata/node/api-postgresql-standby-2.api.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/api-postgresql-standby-2.api.staging.publishing.service.gov.uk.yaml
@@ -1,1 +1,3 @@
 icinga::client::check_cputype::cputype: 'amd'
+govuk_safe_to_reboot::can_reboot: 'overnight'
+govuk_safe_to_reboot::reason: 'DR node: only used in the event of a disaster'

--- a/hieradata/node/asset-slave-2.backend.publishing.service.gov.uk.yaml
+++ b/hieradata/node/asset-slave-2.backend.publishing.service.gov.uk.yaml
@@ -1,3 +1,5 @@
 icinga::client::check_cputype::cputype: 'amd'
 govuk::node::s_asset_base::push_attachments_to_s3: true
 govuk::node::s_asset_base::s3_bucket: 'govuk-attachments-production'
+govuk_safe_to_reboot::can_reboot: 'overnight'
+govuk_safe_to_reboot::reason: 'DR node: only used in the event of a disaster'

--- a/hieradata/node/asset-slave-2.backend.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/asset-slave-2.backend.staging.publishing.service.gov.uk.yaml
@@ -1,1 +1,3 @@
 icinga::client::check_cputype::cputype: 'amd'
+govuk_safe_to_reboot::can_reboot: 'overnight'
+govuk_safe_to_reboot::reason: 'DR node: only used in the event of a disaster'

--- a/hieradata/node/mysql-slave-3.backend.publishing.service.gov.uk.yaml
+++ b/hieradata/node/mysql-slave-3.backend.publishing.service.gov.uk.yaml
@@ -1,1 +1,3 @@
 icinga::client::check_cputype::cputype: 'amd'
+govuk_safe_to_reboot::can_reboot: 'overnight'
+govuk_safe_to_reboot::reason: 'DR node: only used in the event of a disaster'

--- a/hieradata/node/mysql-slave-3.backend.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/mysql-slave-3.backend.staging.publishing.service.gov.uk.yaml
@@ -1,1 +1,3 @@
 icinga::client::check_cputype::cputype: 'amd'
+govuk_safe_to_reboot::can_reboot: 'overnight'
+govuk_safe_to_reboot::reason: 'DR node: only used in the event of a disaster'

--- a/hieradata/node/postgresql-standby-2.backend.publishing.service.gov.uk.yaml
+++ b/hieradata/node/postgresql-standby-2.backend.publishing.service.gov.uk.yaml
@@ -1,1 +1,3 @@
 icinga::client::check_cputype::cputype: 'amd'
+govuk_safe_to_reboot::can_reboot: 'overnight'
+govuk_safe_to_reboot::reason: 'DR node: only used in the event of a disaster'

--- a/hieradata/node/postgresql-standby-2.backend.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/postgresql-standby-2.backend.staging.publishing.service.gov.uk.yaml
@@ -1,1 +1,3 @@
 icinga::client::check_cputype::cputype: 'amd'
+govuk_safe_to_reboot::can_reboot: 'overnight'
+govuk_safe_to_reboot::reason: 'DR node: only used in the event of a disaster'

--- a/hieradata/node/transition-postgresql-slave-2.backend.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/transition-postgresql-slave-2.backend.integration.publishing.service.gov.uk.yaml
@@ -1,3 +1,5 @@
 ---
 
 govuk::node::s_transition_postgresql_slave::redirector_ip_range: '10.1.13.0/24'
+govuk_safe_to_reboot::can_reboot: 'overnight'
+govuk_safe_to_reboot::reason: 'DR node: only used in the event of a disaster'

--- a/hieradata/node/transition-postgresql-slave-2.backend.publishing.service.gov.uk.yaml
+++ b/hieradata/node/transition-postgresql-slave-2.backend.publishing.service.gov.uk.yaml
@@ -3,3 +3,5 @@
 govuk::node::s_transition_postgresql_slave::redirector_ip_range: '10.3.13.0/24'
 
 icinga::client::check_cputype::cputype: 'amd'
+govuk_safe_to_reboot::can_reboot: 'overnight'
+govuk_safe_to_reboot::reason: 'DR node: only used in the event of a disaster'

--- a/hieradata/node/transition-postgresql-slave-2.backend.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/transition-postgresql-slave-2.backend.staging.publishing.service.gov.uk.yaml
@@ -3,3 +3,5 @@
 govuk::node::s_transition_postgresql_slave::redirector_ip_range: '10.2.13.0/24'
 
 icinga::client::check_cputype::cputype: 'amd'
+govuk_safe_to_reboot::can_reboot: 'overnight'
+govuk_safe_to_reboot::reason: 'DR node: only used in the event of a disaster'

--- a/hieradata/node/whitehall-mysql-slave-3.backend.publishing.service.gov.uk.yaml
+++ b/hieradata/node/whitehall-mysql-slave-3.backend.publishing.service.gov.uk.yaml
@@ -1,1 +1,3 @@
 icinga::client::check_cputype::cputype: 'amd'
+govuk_safe_to_reboot::can_reboot: 'overnight'
+govuk_safe_to_reboot::reason: 'DR node: only used in the event of a disaster'

--- a/hieradata/node/whitehall-mysql-slave-3.backend.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/whitehall-mysql-slave-3.backend.staging.publishing.service.gov.uk.yaml
@@ -1,1 +1,3 @@
 icinga::client::check_cputype::cputype: 'amd'
+govuk_safe_to_reboot::can_reboot: 'overnight'
+govuk_safe_to_reboot::reason: 'DR node: only used in the event of a disaster'


### PR DESCRIPTION
The DR nodes are safe to reboot at anytime, so we should allow automatic reboots overnight.