### PR TITLE
Add timestamper plugin

### DIFF
--- a/hieradata/class/jenkins.yaml
+++ b/hieradata/class/jenkins.yaml
@@ -91,6 +91,8 @@ govuk_jenkins::plugins:
     version: '0.0.8'
   show-build-parameters:
     version: '1.0'
+  timestamper:
+    version: '1.8.2'
   token-macro:
     version: '1.9'
   versionnumber:


### PR DESCRIPTION
This plugin add timestamps to console output.
It is useful for longer running or multi-step jobs, especially
when they are not doing what they are supposed to.

See https://wiki.jenkins-ci.org/display/JENKINS/Timestamper