### PR TITLE
Remove Jake Benilov

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -68,7 +68,6 @@ govuk_jenkins::config::admins:
   - ikennaokpala
   - isabelllong
   - jackscotti
-  - jakebenilov
   - jennyduckett
   - katiesmith
   - leelongmore
@@ -261,7 +260,6 @@ users::usernames:
   - alexmuller
   - alextorrance
   - benhyland
-  - benilovj
   - bob
   - brendanbutler
   - chrispatuzzo

--- a/modules/govuk_jenkins/templates/jobs/run_govuk_complaint_rate_report.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/run_govuk_complaint_rate_report.yaml.erb
@@ -27,7 +27,3 @@
             ./run.sh
     triggers:
         - timed: 'H 4 * * *'
-    publishers:
-        - email:
-            recipients: jake.benilov@digital.cabinet-office.gov.uk
-

--- a/modules/users/manifests/benilovj.pp
+++ b/modules/users/manifests/benilovj.pp
@@ -1,8 +1,0 @@
-# Creates the benilovj user
-class users::benilovj {
-  govuk_user { 'benilovj':
-      fullname => 'Jake Benilov',
-      email    => 'jake.benilov@digital.cabinet-office.gov.uk',
-      ssh_key  => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDZlq/ByLPy7iB1R4KH5qocTGFk6g/U89fd9O1iyiABx99jf2ogBWjKQp9dkrS0NYMCrnFjPJZFM5Kn+Gz0/YQG2L22uWLsrMPlb8RBqPHPVurt4eFIPRCeZ+kEUNF7nK+vxsvEOnpaNzXzlYDCooB9UcwujgIsdeEPSelS4fmSi3Dg4/nSgf+HxiJYyI1CvBrQGtm9kgOFY4wpL6Y0Fnn7mTRGGvA9MXiGegHkBNIwaD8wAFvoIbt938uXXv+AWGIfCVMM8yLUag7QC10eBR0dfKSUqyChBhPpdMr6wWziaX3agwD66SGL0UyBmNvh2ZQvnr4Ur3w551VzQBZ8RbMhFRAG7nDzzheFJwtCwQ5cXts9n4jgwvuTfXH2peoh3IC5DrxvSeiJyhaIwKzwdzMBa+9t/KVt0+Wt4IpEMPxKXXmZPraaQ1Rm/9ompLXIlYYm06jnncsYJN1YTRpcz1FjRDTdIQbso7+3LK8uoHtjCVSDjPf2mk9jB7VEswSLqz8KFl4HnfgxWLV0mjdmjjsiaiT7SR7jzaAN3mMfb3BwKGkHV2IhNQe2OjwctEf2/9VZhwt73E4qbdRg1cn6OmGf7dV/+p8X9BI6dUEr0XnNfgVvG5zGSdjBmqIp/hYLyr9ly3iCv8ceKoHGF8j3X/1QwZHHTiUiJ5LJpWAT9jO2Tw== benilov@gmail.com',
-    }
-}

--- a/modules/users/spec/classes/users_spec.rb
+++ b/modules/users/spec/classes/users_spec.rb
@@ -32,7 +32,6 @@ end
 # We shouldn't be adding users to this list unless their username does not
 # follow the standard form AND is their LDAP username
 username_whitelist = %w{
-  benilovj
   bob
   elliot
   jackscotti


### PR DESCRIPTION
Jake has now left GDS

Jake was the only recipient of emails about the success or failure of
the `run_govuk_complaint_rate_report` job in production. This job has
been running successfully for a while, so I’m removing the email
publisher.

@benilovj were these emails useful? Should someone else pick them up?