### PR TITLE
Fix pv for asset-slave-1 in staging

### DIFF
--- a/hieradata/node/asset-slave-1.backend.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/asset-slave-1.backend.staging.publishing.service.gov.uk.yaml
@@ -1,0 +1,11 @@
+---
+lv:
+  data:
+    pv:
+      - '/dev/sdc1'
+      - '/dev/sdd1'
+    vg: 'uploads'
+  cache:
+    pv:
+      - '/dev/sda1'
+    vg: 'duplicity'


### PR DESCRIPTION
asset-slave-1 in staging has a different disk layout to production
so puppet is failing when running pv create.

Production:

```
Disk /dev/sda: 53.7 GB, 53687091200 bytes
Disk /dev/sdb: 549.8 GB, 549755813888 bytes
Disk /dev/sdc: 274.9 GB, 274877906944 bytes
Disk /dev/sdd: 48.3 GB, 48318382080 bytes
```

Staging:

```
Disk /dev/sda: 48.3 GB, 48318382080 bytes
Disk /dev/sdb: 53.7 GB, 53687091200 bytes
Disk /dev/sdc: 549.8 GB, 549755813888 bytes
Disk /dev/sdd: 274.9 GB, 274877906944 bytes
```

The error:

```
Execution of '/sbin/pvcreate /dev/sdb1' returned 5: Can't open /dev/sdb1 exclusively.  Mounted filesystem?
```

This is failing as `/dev/sdb1` is used for `/boot`