### PR TITLE
Rename Rummager indexing process

### DIFF
--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -151,7 +151,7 @@ govuk::apps::router::vhost_aliases: ["www"]
 govuk::apps::router_api::mongodb_name: 'router'
 govuk::apps::router_api::mongodb_nodes: ['localhost']
 govuk::apps::router_api::router_nodes: ['localhost:3055']
-govuk::apps::rummager::enable_procfile_worker: false
+govuk::apps::rummager::enable_procfile_worker: true
 govuk::apps::rummager::rabbitmq_hosts: ['localhost']
 govuk::apps::share_sale_publisher::enabled: true
 govuk::apps::share_sale_publisher::mongodb_nodes: ['localhost']

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -19,7 +19,6 @@ govuk::apps::errbit::errbit_email_from: 'govuk-winston+errbit-integration@digita
 govuk::apps::event_store::enabled: true
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
 govuk::apps::publicapi::backdrop_host: 'www.preview.performance.service.gov.uk'
-govuk::apps::rummager::enable_publishing_api_document_indexer: false
 govuk::apps::rummager::aws_s3_bucket_name: govuk-api-elasticsearch-snapshots-integration
 govuk::apps::smartanswers::expose_govspeak: true
 govuk::apps::specialist_publisher::publish_pre_production_finders: true

--- a/modules/govuk/manifests/apps/rummager.pp
+++ b/modules/govuk/manifests/apps/rummager.pp
@@ -17,7 +17,7 @@
 #   Whether to enable the procfile worker service.
 #   Default: true
 #
-# [*enable_publishing_api_document_indexer*]
+# [*enable_publishing_listener*]
 #   Whether to enable the procfile indexing service.
 #   Default: false
 #
@@ -54,7 +54,7 @@
 class govuk::apps::rummager(
   $port = '3009',
   $enable_procfile_worker = true,
-  $enable_publishing_api_document_indexer = false,
+  $enable_publishing_listener = false,
   $publishing_api_bearer_token = undef,
   $aws_s3_key = undef,
   $aws_s3_secret = undef,
@@ -104,16 +104,16 @@ class govuk::apps::rummager(
     enable_service => $enable_procfile_worker,
   }
 
-  $toggled_ensure = $enable_publishing_api_document_indexer ? {
+  $toggled_ensure = $enable_publishing_listener ? {
     true    => present,
     default => absent,
   }
 
-  govuk::procfile::worker { 'rummager-publishing-api-document-indexer':
+  govuk::procfile::worker { 'rummager-publishing-queue-listener':
     ensure         => $toggled_ensure,
     setenv_as      => 'rummager',
-    enable_service => $enable_publishing_api_document_indexer,
-    process_type   => 'publishing-api-document-indexer',
+    enable_service => $enable_publishing_listener,
+    process_type   => 'publishing-queue-listener',
   }
 
   Govuk::App::Envvar {

--- a/modules/govuk/manifests/apps/rummager/rabbitmq.pp
+++ b/modules/govuk/manifests/apps/rummager/rabbitmq.pp
@@ -10,15 +10,15 @@
 #
 # [*password*]
 #   The password for the RabbitMQ user (default: 'rummager')
-# [*enable_publishing_api_document_indexer*]
+# [*enable_publishing_listener*]
 #   Whether or not to configure the queue for the rummager indexer
 #
 class govuk::apps::rummager::rabbitmq (
   $password  = 'rummager',
-  $enable_publishing_api_document_indexer = false,
+  $enable_publishing_listener = true,
 ) {
 
-  $toggled_ensure = $enable_publishing_api_document_indexer ? {
+  $toggled_ensure = $enable_publishing_listener ? {
     true    => present,
     default => absent,
   }


### PR DESCRIPTION
`enable_publishing_api_document_indexer` isn't correct because we don't use the publishing-api message queue to index documents. Rather, we listen to changes and trigger re-indexes. This updates the naming to avoid confusion.

Remove `enable_publishing_api_document_indexer` from integration.yml because it duplicates the default.

Related: https://github.com/alphagov/rummager/pull/650
