### PR TITLE
Upgrade ImageMagick to 8:6.7.7.10-6ubuntu3.1

### DIFF
--- a/modules/imagemagick/manifests/init.pp
+++ b/modules/imagemagick/manifests/init.pp
@@ -4,7 +4,7 @@
 #
 class imagemagick {
   package { 'imagemagick':
-    ensure => '8:6.7.7.10-6ubuntu3',
+    ensure => '8:6.7.7.10-6ubuntu3.1',
   }
 
   file { '/etc/ImageMagick/policy.xml':


### PR DESCRIPTION
This is the version that fixes ImageTragick security vulnerabilities including CVE-2016-3714.

It is installed automatically by unattended-upgrades but Puppet keeps downgrading it.