### PR TITLE
asset-slave-1 rebooted and rearranged its disks

### DIFF
--- a/hieradata/node/asset-slave-1.backend.publishing.service.gov.uk.yaml
+++ b/hieradata/node/asset-slave-1.backend.publishing.service.gov.uk.yaml
@@ -6,12 +6,12 @@ backup::assets::archive_directory: '/mnt/duplicity-cache'
 lv:
   data:
     pv:
-      - '/dev/sdb1'
       - '/dev/sdc1'
+      - '/dev/sdd1'
     vg: 'uploads'
   cache:
     pv:
-      - '/dev/sdd1'
+      - '/dev/sda1'
     vg: 'duplicity'
 
 mount:
@@ -25,5 +25,5 @@ mount:
     disk: '/dev/mapper/duplicity-cache'
     govuk_lvm: 'cache'
     mountoptions: 'defaults'
-    percent_threshold_warning: 10 
+    percent_threshold_warning: 10
     percent_threshold_critical: 2


### PR DESCRIPTION
Now pv is trying to move its volume groups around. This
commit updates the expected disk layout.

```
paulbowsher@production-asset-slave-1:~$ sudo fdisk -l 2>/dev/null | grep 'Disk /dev/sd'
Disk /dev/sda: 48.3 GB, 48318382080 bytes
Disk /dev/sdb: 53.7 GB, 53687091200 bytes
Disk /dev/sdd: 274.9 GB, 274877906944 bytes
Disk /dev/sdc: 549.8 GB, 549755813888 bytes
```
