### PR TITLE
Default `enable_publishing_listener` to false

### DIFF
--- a/modules/govuk/manifests/apps/rummager/rabbitmq.pp
+++ b/modules/govuk/manifests/apps/rummager/rabbitmq.pp
@@ -15,7 +15,7 @@
 #
 class govuk::apps::rummager::rabbitmq (
   $password  = 'rummager',
-  $enable_publishing_listener = true,
+  $enable_publishing_listener = false,
 ) {
 
   $toggled_ensure = $enable_publishing_listener ? {


### PR DESCRIPTION
This was mistakenly committed in https://github.com/alphagov/govuk-puppet/commit/efd8d3eb1ca62cc25904b55a47da052a8c0dd78f.