### PR TITLE
Set disk layout for asset-slave-1 in integration

### DIFF
--- a/hieradata/node/asset-slave-1.backend.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/asset-slave-1.backend.integration.publishing.service.gov.uk.yaml
@@ -1,0 +1,11 @@
+---
+lv:
+  data:
+    pv:
+      - '/dev/sdc1'
+      - '/dev/sdd1'
+    vg: 'uploads'
+  cache:
+    pv:
+      - '/dev/sda1'
+    vg: 'duplicity'


### PR DESCRIPTION
Not gonna lie, I'm a bit bored of these PRs now.

The disk layout has changed recently, so pv is trying
to make the wrong disks members of the volume groups.