### PR TITLE
Add timestamps to tagging-sync-check build

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/tagging_sync_check.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/tagging_sync_check.yaml.erb
@@ -23,6 +23,7 @@
     wrappers:
         - ansicolor:
             colormap: xterm
+        - timestamps
     publishers:
         - archive:
             artifacts: '*.csv'


### PR DESCRIPTION
A day may come when this sort of thing is templated into all jobs.
But it is not this day.

See https://github.com/alphagov/govuk-puppet/pull/4472