### PR TITLE
`/etc/cron.d` isn't a managed resource so require the cron class intead

### DIFF
--- a/modules/cron/manifests/crondotdee.pp
+++ b/modules/cron/manifests/crondotdee.pp
@@ -47,7 +47,7 @@ define cron::crondotdee (
   file { "/etc/cron.d/${title}":
     ensure  => present,
     content => template('cron/etc/cron.d/crondotdee.erb'),
-    require => File['/etc/cron.d'],
+    require => Class['cron'],
     mode    => '0644',
     owner   => 'root',
     group   => 'root',

--- a/modules/cron/manifests/init.pp
+++ b/modules/cron/manifests/init.pp
@@ -30,8 +30,13 @@ class cron (
     purge => true,
   }
 
+  package { 'cron':
+    ensure => 'installed',
+  }
+
   service { 'cron':
-    ensure => running,
+    ensure  => running,
+    require => Package['cron'],
   }
 
   # set the timings of the scheduled tasks at different times


### PR DESCRIPTION
We should also ensure our cron package is installed if we're going
to manage the service.