### PR TITLE
Elasticsearch index backup

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -39,6 +39,10 @@ govuk_cdnlogs::monitoring_enabled: false
 govuk_crawler::seed_enable: true
 
 govuk_elasticsearch::dump::run_es_dump_hour: '9'
+govuk_elasticsearch::backup::s3_bucket: 'kibana-dashboards'
+govuk_elasticsearch::backup::es_repo: 'kibana-dashboards'
+govuk_elasticsearch::backup::es_indices:
+  - kibana_int
 
 govuk_jenkins::config::banner_colour_background: '#ffbf47'
 govuk_jenkins::config::banner_colour_text: 'black'

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -39,10 +39,6 @@ govuk_cdnlogs::monitoring_enabled: false
 govuk_crawler::seed_enable: true
 
 govuk_elasticsearch::dump::run_es_dump_hour: '9'
-govuk_elasticsearch::backup::s3_bucket: 'kibana-dashboards'
-govuk_elasticsearch::backup::es_repo: 'kibana-dashboards'
-govuk_elasticsearch::backup::es_indices:
-  - kibana_int
 
 govuk_jenkins::config::banner_colour_background: '#ffbf47'
 govuk_jenkins::config::banner_colour_text: 'black'

--- a/hieradata/node/elasticsearch-1.backend.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/elasticsearch-1.backend.integration.publishing.service.gov.uk.yaml
@@ -1,2 +1,6 @@
 ---
-govuk_elasticsearch::backup::housekeeping_enabled: true
+govuk_elasticsearch::backup::enabled: true
+govuk_elasticsearch::backup::s3_bucket: 'elasticsearch'
+govuk_elasticsearch::backup::es_repo: 'snapshots'
+govuk_elasticsearch::backup::es_indices:
+  - kibana_int

--- a/hieradata/node/elasticsearch-1.backend.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/elasticsearch-1.backend.integration.publishing.service.gov.uk.yaml
@@ -1,0 +1,2 @@
+---
+govuk_elasticsearch::backup::housekeeping_enabled: true

--- a/hieradata/node/logs-elasticsearch-1.management.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/logs-elasticsearch-1.management.integration.publishing.service.gov.uk.yaml
@@ -1,2 +1,6 @@
 ---
-govuk_elasticsearch::backup::housekeeping_enabled: true
+govuk_elasticsearch::backup::enabled: true
+govuk_elasticsearch::backup::s3_bucket: 'logs-elasticsearch'
+govuk_elasticsearch::backup::es_repo: 'snapshots'
+govuk_elasticsearch::backup::es_indices:
+  - kibana_int

--- a/hieradata/node/logs-elasticsearch-1.management.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/logs-elasticsearch-1.management.integration.publishing.service.gov.uk.yaml
@@ -1,0 +1,2 @@
+---
+govuk_elasticsearch::backup::housekeeping_enabled: true

--- a/modules/govuk_elasticsearch/manifests/backup.pp
+++ b/modules/govuk_elasticsearch/manifests/backup.pp
@@ -40,14 +40,14 @@ class govuk_elasticsearch::backup(
   $env_dir = '/etc/es_s3backup',
   $user = backup::client::govuk-backup,
   $es_repo = undef,
-  $enabled = fasle,
+  $housekeeping_enabled = fasle,
   $es_indices = [
     join(regsubst($govuk_elasticsearch::backup::es_indices, '.*', '"\1"'), ',')]
   ){
 
   include backup::client
 
-  if $enabled {
+  if $housekeeping_enabled {
     include govuk_elasticsearch::housekeeping
   }
 

--- a/modules/govuk_elasticsearch/manifests/backup.pp
+++ b/modules/govuk_elasticsearch/manifests/backup.pp
@@ -1,0 +1,92 @@
+# == Class: govuk_elasticsearch::backup
+#
+# GOV.UK specific class to backup elasticsearch indexes.
+#
+# === Parameters
+#
+# [*aws_access_key_id*]
+#
+# [*aws_secret_access_key*]
+#
+# [*aws_region*]
+#   AWS region for the S3 bucket
+#
+# [*env_dir*]
+#   Defines directory for the environment
+#   variables
+#
+# [*s3_bucket*]
+#   Defines the AWS S3 bucket where the backups
+#   will be uploaded. It should be created by the
+#   user
+#
+# [*user*]
+#   Defines the system user that will be created
+#   to run the backups
+#
+# [*es_repo*]
+#   The repository within elasticsearch
+#   where backups will be stored
+#
+# [*es_indices*]
+#   Elaticsearch indexes
+#
+class govuk_elasticsearch::backup(
+  $aws_access_key_id = undef,
+  $aws_secret_access_key = undef,
+  $aws_region = 'eu-west-1',
+  $s3_bucket = undef,
+  $cron = true,
+  $env_dir = '/etc/es_s3backup',
+  $user = backup::client::govuk-backup,
+  $es_repo = undef,
+  $es_indices = [
+    join(regsubst($govuk_elasticsearch::backup::es_indices, '.*', '"\1"'), ',')]
+  ){
+
+  include backup::client
+
+  # push env files
+  file { [$env_dir,"${env_dir}/env.d"]:
+    ensure => directory,
+    owner  => $user,
+    group  => $user,
+    mode   => '0770',
+  }
+
+  file { "${env_dir}/env.d/AWS_SECRET_ACCESS_KEY":
+    content => $aws_secret_access_key,
+    owner   => $user,
+    group   => $user,
+    mode    => '0640',
+  }
+
+  file { "${env_dir}/env.d/AWS_ACCESS_KEY_ID":
+    content => $aws_access_key_id,
+    owner   => $user,
+    group   => $user,
+    mode    => '0640',
+  }
+
+  file { "${env_dir}/env.d/AWS_REGION":
+    content => $aws_region,
+    owner   => $user,
+    group   => $user,
+    mode    => '0640',
+  }
+
+  file { 'es-backup-s3':
+    path    => '/usr/local/bin',
+    owner   => $user,
+    group   => $user,
+    mode    => '0550',
+    content => template('govuk_elasticsearch/es-backup-s3.erb'),
+  }
+
+  cron { 's3-elasticsearch-indexes':
+    command => '/usr/local/bin/es-backup-s3',
+    user    => $user,
+    hour    => 0,
+  }
+
+}

--- a/modules/govuk_elasticsearch/manifests/backup.pp
+++ b/modules/govuk_elasticsearch/manifests/backup.pp
@@ -40,11 +40,16 @@ class govuk_elasticsearch::backup(
   $env_dir = '/etc/es_s3backup',
   $user = backup::client::govuk-backup,
   $es_repo = undef,
+  $enabled = fasle,
   $es_indices = [
     join(regsubst($govuk_elasticsearch::backup::es_indices, '.*', '"\1"'), ',')]
   ){
 
   include backup::client
+
+  if $enabled {
+    include govuk_elasticsearch::housekeeping
+  }
 
   # push env files
   file { [$env_dir,"${env_dir}/env.d"]:

--- a/modules/govuk_elasticsearch/manifests/backup.pp
+++ b/modules/govuk_elasticsearch/manifests/backup.pp
@@ -5,8 +5,10 @@
 # === Parameters
 #
 # [*aws_access_key_id*]
+#   AWS key to authenticate requests
 #
 # [*aws_secret_access_key*]
+#   AWS key to authenticate requests
 #
 # [*aws_region*]
 #   AWS region for the S3 bucket
@@ -31,6 +33,9 @@
 # [*es_indices*]
 #   Elaticsearch indexes
 #
+# [*enabled*]
+#   Determines whether this job will be scheduled
+#
 class govuk_elasticsearch::backup(
   $aws_access_key_id = undef,
   $aws_secret_access_key = undef,
@@ -38,60 +43,70 @@ class govuk_elasticsearch::backup(
   $s3_bucket = undef,
   $cron = true,
   $env_dir = '/etc/es_s3backup',
-  $user = backup::client::govuk-backup,
+  $user = 'govuk-backup',
   $es_repo = undef,
-  $housekeeping_enabled = fasle,
+  $enabled = false,
   $es_indices = [
     join(regsubst($govuk_elasticsearch::backup::es_indices, '.*', '"\1"'), ',')]
   ){
 
   include backup::client
+  include govuk_elasticsearch::housekeeping
 
-  if $housekeeping_enabled {
-    include govuk_elasticsearch::housekeeping
-  }
 
-  # push env files
-  file { [$env_dir,"${env_dir}/env.d"]:
-    ensure => directory,
-    owner  => $user,
-    group  => $user,
-    mode   => '0770',
-  }
+    # push env files
+    file { [$env_dir,"${env_dir}/env.d"]:
+      ensure => directory,
+      owner  => $user,
+      group  => $user,
+      mode   => '0770',
+    }
 
-  file { "${env_dir}/env.d/AWS_SECRET_ACCESS_KEY":
-    content => $aws_secret_access_key,
-    owner   => $user,
-    group   => $user,
-    mode    => '0640',
-  }
+    file { "${env_dir}/env.d/AWS_SECRET_ACCESS_KEY":
+      content => $aws_secret_access_key,
+      owner   => $user,
+      group   => $user,
+      mode    => '0640',
+    }
 
-  file { "${env_dir}/env.d/AWS_ACCESS_KEY_ID":
-    content => $aws_access_key_id,
-    owner   => $user,
-    group   => $user,
-    mode    => '0640',
-  }
+    file { "${env_dir}/env.d/AWS_ACCESS_KEY_ID":
+      content => $aws_access_key_id,
+      owner   => $user,
+      group   => $user,
+      mode    => '0640',
+    }
 
-  file { "${env_dir}/env.d/AWS_REGION":
-    content => $aws_region,
-    owner   => $user,
-    group   => $user,
-    mode    => '0640',
-  }
+    file { "${env_dir}/env.d/AWS_REGION":
+      content => $aws_region,
+      owner   => $user,
+      group   => $user,
+      mode    => '0640',
+    }
 
-  file { 'es-backup-s3':
-    path    => '/usr/local/bin',
-    owner   => $user,
-    group   => $user,
-    mode    => '0550',
-    content => template('govuk_elasticsearch/es-backup-s3.erb'),
-  }
+    file { 'es-backup-s3':
+      path    => '/usr/local/bin',
+      owner   => $user,
+      group   => $user,
+      mode    => '0550',
+      content => template('govuk_elasticsearch/es-backup-s3.erb'),
+    }
 
-  cron { 's3-elasticsearch-indexes':
-    command => '/usr/local/bin/es-backup-s3',
-    user    => $user,
-    hour    => 0,
-  }
+  # Remove cron job if backup is not enabled
+    if $enabled {
 
+      cron { 's3-elasticsearch-indexes':
+        ensure  => present,
+        command => '/usr/local/bin/es-backup-s3',
+        user    => $user,
+        hour    => 0,
+        minute  => 0,
+      }
+    }
+    else {
+
+      cron { 's3-elasticsearch-indexes':
+        ensure  => absent,
+      }
+    }
 }
+

--- a/modules/govuk_elasticsearch/spec/classes/govuk_elasticsearch_spec.rb
+++ b/modules/govuk_elasticsearch/spec/classes/govuk_elasticsearch_spec.rb
@@ -23,11 +23,11 @@ describe 'govuk_elasticsearch', :type => :class do
 
   describe '#manage_repo' do
     let(:params) {{
-      :version => '1.7.0',
+      :version => '1.4.3',
     }}
 
     context 'true (default)' do
-      it { is_expected.to contain_class('govuk_elasticsearch::repo').with_repo_version('1.7') }
+      it { is_expected.to contain_class('govuk_elasticsearch::repo').with_repo_version('1.4') }
 
       it "should handle the repo for 0.90.x" do
         params[:version] = '0.90.3'
@@ -115,7 +115,7 @@ describe 'govuk_elasticsearch', :type => :class do
 
   describe "setting transport firewall rules" do
     let(:params) {{
-      :version => '1.7.0',
+      :version => '1.4.3',
       :open_firewall_from_all => false,
     }}
 
@@ -175,7 +175,7 @@ describe 'govuk_elasticsearch', :type => :class do
 
   describe "disabling default http 9200 firewall rule" do
     let(:params) {{
-      :version => '1.7.0',
+      :version => '1.4.3',
     }}
 
     let(:pre_condition) {

--- a/modules/govuk_elasticsearch/templates/es-backup-s3.erb
+++ b/modules/govuk_elasticsearch/templates/es-backup-s3.erb
@@ -5,6 +5,9 @@ set -e
 # Redirect stdout and stderr to syslog
 exec 1> >(/usr/bin/logger -s -t $(basename $0)) 2>&1
 
+# The default Icinga passive alert assumes that the script failed
+NAGIOS_CODE=2
+NAGIOS_MESSAGE="CRITICAL: Elasticsearch backup push to S3 failed"
 S3_BUCKET=<%= @s3_bucket %>
 ES_REPO=<%= @es_repo %>
 ES_INDICES=<%= @es_indices %>
@@ -12,6 +15,14 @@ ES_SNAPSHOT=snapshot_$(date +%d_%m_%y)
 AWS_REGION=<%= @aws_region %>
 AWS_ACCESS_KEY_ID=<%= @aws_access_key_id %>
 AWS_SECRET_ACCESS_KEY=<%= @aws_secret_access_key %>
+
+# Triggered whenever this script exits, successful or otherwise. The values
+# of CODE/MESSAGE will be taken from that point in time.
+function nagios_passive () {
+printf "<%= @ipaddress %>\t<%= @service_desc %>\t${NAGIOS_CODE}\t${NAGIOS_MESSAGE}\n" | /usr/sbin/send_nsca -H alert.cluster >/dev/null
+}
+
+trap nagios_passive EXIT
 
 /usr/bin/envdir <%= @env_dir %>/env.d  /usr/bin/curl --connect-timeout 10 -sS -XPUT "http://127.0.0.1:9200/_snapshot/"${ES_REPO}"?wait_for_completion=true&pretty" -d '{
   "type": "s3",
@@ -25,10 +36,8 @@ AWS_SECRET_ACCESS_KEY=<%= @aws_secret_access_key %>
   }'
 
 
-# indices: option allows us to specify indexes in a comma separated list rather than snap-shooting everything. However we can set
+# indices: option allows us to specify indexes in a comma separated list rather than snap shotting everything. However we can set
 # the $ES_REPO variable to '_all' to snapshot all indices.
-#
-# ignore_unavailable: option when true will cause indices that do not exist to be ignored during snapshot
 #
 # include_global_state: option will prevent the cluster global state from being stored as part of the snapshot.
 # The entire snapshot will fail if one or more indices participating in the snapshot don’t have all primary shards available
@@ -36,15 +45,7 @@ AWS_SECRET_ACCESS_KEY=<%= @aws_secret_access_key %>
 if [ $? -eq 0 ]; then
 
   /usr/bin/envdir <%= @env_dir %>/env.d /usr/bin/curl --connect-timeout 10 -sS -XPUT "http://127.0.0.1:9200/_snapshot/"${ES_REPO}"/"${ES_SNAPSHOT}"?wait_for_completion=true&pretty" -d '{
-    "type": "s3",
-    "settings": {
-      "bucket": "'"${S3_BUCKET}"'",
-      "region": "'"${AWS_REGION}"'",
-      "access_key": "'"${AWS_ACCESS_KEY_ID}"'",
-      "secret_key": "'"${AWS_SECRET_ACCESS_KEY}"'"
-    },
     "indices": "'"${ES_INDICES}"'",
-    "ignore_unavailable": "true",
     "include_global_state": "false",
     "compress": "true",
     "server_side_encryption": "true"
@@ -53,3 +54,18 @@ if [ $? -eq 0 ]; then
 else
   echo "Snapshot Failed"
 fi
+
+
+if [ $? == 0 ]
+then
+STATUS=0
+else
+STATUS=1
+fi
+
+if [ $STATUS -eq 0 ]; then
+NAGIOS_CODE=0
+NAGIOS_MESSAGE="OK: Elasticsearch backup push to S3 succeeded"
+fi
+
+exit $STATUS

--- a/modules/govuk_elasticsearch/templates/es-backup-s3.erb
+++ b/modules/govuk_elasticsearch/templates/es-backup-s3.erb
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+set -e
+
+# Redirect stdout and stderr to syslog
+exec 1> >(/usr/bin/logger -s -t $(basename $0)) 2>&1
+
+S3_BUCKET=<%= @s3_bucket %>
+ES_REPO=<%= @es_repo %>
+ES_INDICES=<%= @es_indices %>
+ES_SNAPSHOT=snapshot_$(date +%d_%m_%y)
+AWS_REGION=<%= @aws_region %>
+AWS_ACCESS_KEY_ID=<%= @aws_access_key_id %>
+AWS_SECRET_ACCESS_KEY=<%= @aws_secret_access_key %>
+
+/usr/bin/envdir <%= @env_dir %>/env.d  /usr/bin/curl --connect-timeout 10 -sS -XPUT "http://127.0.0.1:9200/_snapshot/"${ES_REPO}"?wait_for_completion=true&pretty" -d '{
+  "type": "s3",
+  "settings": {
+  "bucket": "'"${S3_BUCKET}"'",
+  "region": "'"${AWS_REGION}"'",
+  "access_key": "'"${AWS_ACCESS_KEY_ID}"'",
+  "secret_key": "'"${AWS_SECRET_ACCESS_KEY}"'"
+  },
+  "compress": "true"
+  }'
+
+
+# indices: option allows us to specify indexes in a comma separated list rather than snap-shooting everything. However we can set
+# the $ES_REPO variable to '_all' to snapshot all indices.
+#
+# ignore_unavailable: option when true will cause indices that do not exist to be ignored during snapshot
+#
+# include_global_state: option will prevent the cluster global state from being stored as part of the snapshot.
+# The entire snapshot will fail if one or more indices participating in the snapshot don’t have all primary shards available
+
+if [ $? -eq 0 ]; then
+
+  /usr/bin/envdir <%= @env_dir %>/env.d /usr/bin/curl --connect-timeout 10 -sS -XPUT "http://127.0.0.1:9200/_snapshot/"${ES_REPO}"/"${ES_SNAPSHOT}"?wait_for_completion=true&pretty" -d '{
+    "type": "s3",
+    "settings": {
+      "bucket": "'"${S3_BUCKET}"'",
+      "region": "'"${AWS_REGION}"'",
+      "access_key": "'"${AWS_ACCESS_KEY_ID}"'",
+      "secret_key": "'"${AWS_SECRET_ACCESS_KEY}"'"
+    },
+    "indices": "'"${ES_INDICES}"'",
+    "ignore_unavailable": "true",
+    "include_global_state": "false",
+    "compress": "true",
+    "server_side_encryption": "true"
+    }' &> /dev/null
+
+else
+  echo "Snapshot Failed"
+fi


### PR DESCRIPTION
The script backs up and uploads the specified indices.  At the moment I have the named the elasticsearch repo to kibana-dashboards but we could name it something more generic in case we wanted to use this script to backup other indexes on other hosts in future. The fact that a specified index may not exist will not cause the command to fail and it should just continue.