### PR TITLE
Add a mongo 3.2 ubuntu mirror via aptly

### DIFF
--- a/modules/govuk/manifests/node/s_apt.pp
+++ b/modules/govuk/manifests/node/s_apt.pp
@@ -78,6 +78,10 @@ class govuk::node::s_apt (
       location => 'http://downloads-distro.mongodb.org/repo/ubuntu-upstart',
       release  => 'dist',
       key      => '7F0CEB10';
+    'mongodb3.2':
+      location => 'https://repo.mongodb.org/apt/ubuntu',
+      release  => 'trusty/mongodb-org/3.2',
+      key      => 'EA312927';
     'jenkins':
       location => 'http://pkg.jenkins-ci.org/debian-stable',
       release  => 'binary/', # Trailing slash is significant.


### PR DESCRIPTION
We need this for the licensify upgrade work