### PR TITLE
Fix Wal-e catalog error

### DIFF
--- a/modules/govuk_postgresql/manifests/wal_e/env_sync.pp
+++ b/modules/govuk_postgresql/manifests/wal_e/env_sync.pp
@@ -38,7 +38,8 @@ define govuk_postgresql::wal_e::env_sync (
   $wale_private_gpg_key_passphrase,
   $aws_region = 'eu-west-1',
 ) {
-
+    include govuk_postgresql::wal_e::package
+    
     $env_sync_envdir = '/etc/wal-e/env_sync/env.d'
     $datadir = $postgresql::params::datadir
 


### PR DESCRIPTION
- `wal-e_env_sync` script requires the `govuk_postgresql::wal_e::package` in order to run a `wal-e` command