### PR TITLE
Fix creation of wal-e env sync directory

### DIFF
--- a/modules/govuk_postgresql/manifests/wal_e/env_sync.pp
+++ b/modules/govuk_postgresql/manifests/wal_e/env_sync.pp
@@ -42,7 +42,7 @@ define govuk_postgresql::wal_e::env_sync (
     $env_sync_envdir = '/etc/wal-e/env_sync/env.d'
     $datadir = $postgresql::params::datadir
 
-    file { [ '/etc/wal-e/env_sync', $env_sync_envdir ]:
+    file { [ '/etc/wal-e', '/etc/wal-e/env_sync', $env_sync_envdir ]:
       ensure  => directory,
       owner   => 'postgres',
       group   => 'postgres',


### PR DESCRIPTION
The parent directory doesn't exist so Puppet refuses to run.