### PR TITLE
Sum sidekiq worker activity for rummager graph

### DIFF
--- a/modules/grafana/files/dashboards/rummager_queues.json
+++ b/modules/grafana/files/dashboards/rummager_queues.json
@@ -62,10 +62,10 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "alias(consolidateBy(summarize(sumSeries(stats.govuk.app.rummager.workers.Indexer.*.success), '1minute', 'max'), 'max'), 'Success')"
+              "target": "alias(consolidateBy(summarize(sumSeries(stats.govuk.app.rummager.workers.Indexer.*.success), '1minute', 'sum'), 'max'), 'Success')"
             },
             {
-              "target": "alias(consolidateBy(summarize(sumSeries(stats.govuk.app.rummager.workers.Indexer.*.failure), '1minute', 'max'), 'max'), 'Failure')"
+              "target": "alias(consolidateBy(summarize(sumSeries(stats.govuk.app.rummager.workers.Indexer.*.failure), '1minute', 'sum'), 'max'), 'Failure')"
             }
           ],
           "aliasColors": {


### PR DESCRIPTION
We were looking at the maximum number of messages processed
in any 1min bucket of samples - what we want to see is the sum
of messages processed in each bucket.

@benhyland @davidslv