### PR TITLE
Never show negative numbers in rummager dashboard

### DIFF
--- a/modules/grafana/files/dashboards/rummager_queues.json
+++ b/modules/grafana/files/dashboards/rummager_queues.json
@@ -130,7 +130,10 @@
           "aliasColors": {
             "Unprocessed": "#0662D9"
           },
-          "leftYAxisLabel": "message count"
+          "leftYAxisLabel": "message count",
+          "grid": {
+            "leftMin": 0
+          }
         },
         {
           "title": "Sidekiq queue size",
@@ -178,7 +181,10 @@
           "aliasColors": {
             "Unprocessed": "#0662D9"
           },
-          "leftYAxisLabel": "message count"
+          "leftYAxisLabel": "message count",
+          "grid": {
+            "leftMin": 0
+          }
         }
       ]
     }


### PR DESCRIPTION
When there are no values, the graphs currently display the zero-line in the middle of the graph. This moves the 0 to the bottom of the graph, since we'll never report negative values anyway.