### PR TITLE
Improve graphs of rummager queue stats

### DIFF
--- a/modules/grafana/files/dashboards/rummager_queues.json
+++ b/modules/grafana/files/dashboards/rummager_queues.json
@@ -52,8 +52,8 @@
           "leftYAxisLabel": "Messages per minute"
         },
         {
-          "id": 5,
-          "title": "Sidekiq worker activity (search indexing)",
+          "id": 2,
+          "title": "Sidekiq AmendWorker activity (search indexing)",
           "span": 6,
           "type": "graph",
           "lines": false,
@@ -62,10 +62,10 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "alias(consolidateBy(summarize(sumSeries(stats.govuk.app.rummager.workers.Indexer.*.success), '1minute', 'sum'), 'max'), 'Success')"
+              "target": "alias(consolidateBy(summarize(stats_counts.govuk.app.rummager.workers.Indexer.AmendWorker.success, '1minute', 'sum'), 'max'), 'Success')"
             },
             {
-              "target": "alias(consolidateBy(summarize(sumSeries(stats.govuk.app.rummager.workers.Indexer.*.failure), '1minute', 'sum'), 'max'), 'Failure')"
+              "target": "alias(consolidateBy(summarize(stats_counts.govuk.app.rummager.workers.Indexer.AmendWorker.failure, '1minute', 'sum'), 'max'), 'Failure')"
             }
           ],
           "aliasColors": {
@@ -75,22 +75,22 @@
           "grid": {
             "leftMin": 0
           },
-          "leftYAxisLabel": "message count"
+          "leftYAxisLabel": "Messages per minute"
         }
       ]
     },
     {
-      "height": "400px",
+      "height": "200px",
       "editable": true,
       "collapse": false,
       "panels": [
         {
-          "title": "Publishing queue consumer queue size (RabbitMQ)",
+          "title": "Publishing queue size (RabbitMQ)",
           "error": false,
           "span": 6,
           "editable": true,
           "type": "graph",
-          "id": 2,
+          "id": 3,
           "datasource": null,
           "renderer": "flot",
           "x-axis": true,
@@ -141,7 +141,7 @@
           "span": 6,
           "editable": true,
           "type": "graph",
-          "id": 2,
+          "id": 4,
           "datasource": null,
           "renderer": "flot",
           "x-axis": true,
@@ -175,11 +175,15 @@
           },
           "targets": [
             {
-              "target": "alias(consolidateBy(summarize(stats.gauges.govuk.app.rummager.workers.enqueued, '10s', 'max'), 'max'), 'Unprocessed')"
+              "target": "alias(consolidateBy(summarize(stats.gauges.govuk.app.rummager.workers.enqueued, '10s', 'max'), 'max'), 'Enqueued')"
+            },
+            {
+              "target": "alias(consolidateBy(summarize(stats.gauges.govuk.app.rummager.workers.retry_set_size, '10s', 'max'), 'max'), 'Retry Set')"
             }
           ],
           "aliasColors": {
-            "Unprocessed": "#0662D9"
+            "Enqueued": "#0662D9",
+            "Retry Set": "#BA43A9"
           },
           "leftYAxisLabel": "message count",
           "grid": {


### PR DESCRIPTION
1. Have the sidekiq activity graph display only AmendWorker activity.
This is nicer for comparing the consumer activity with sidekiq activity,
since the consumer only ever uses the AmendWorker.

2. Avoid `sumSeries()`. This function is unnecessary since we only need to
sum into buckets, not sum multiple `seriesList`s. Note that `summarize()`
is already capable of summing multiple `series`, and a `series` is not
the same as a `seriesList`. `sumSeries()` has the unfortunate side effect
of averaging `series` where the sample rates are different, which in our
case is always. It doesn't make sense to show that sideqick processed a
non-integer fraction of a message in some bucket.

3. Use `stat_counts` instead of `stats`. statsd emits values for all stats under
both top-level keys. For counter stats, `stats` contains per-second rate values,
while `stat_counts` contains bucketed integer counts, which is what we want.

4. Add 'Retry Set' to the sidekiq queue size graph - this is where jobs go to wait
for the backoff period to expire when they are retried.

We have some more detailed graphs which will be put on another dashboard,
since this one is supposed to be for a big-screen info radiator.
Unfortunately I can't add a link to the detailed view from here since Grafana
doesn't know how to link to file-based dashboards.

![screen shot 2016-06-27 at 18 31 55](https://cloud.githubusercontent.com/assets/4282030/16389560/67ef8dec-3c96-11e6-8745-4f93f54d5061.png)
