### PR TITLE
Elasticsearch snapshot housekeeping

### DIFF
--- a/modules/govuk_elasticsearch/manifests/housekeeping.pp
+++ b/modules/govuk_elasticsearch/manifests/housekeeping.pp
@@ -1,0 +1,58 @@
+# == Class: govuk_elasticsearch::housekeeping
+#
+#  Delete old snapshots from elasticsearch
+#
+#
+# === Parameters:
+#
+# [*es_repos*]
+#   The local elasticsearch repositories where snapshots are stored
+#
+# [*es_snapshot_limit*]
+#   The number of snapshots we want to keep
+#
+# [*user*]
+#   User that invokes backup
+#
+# === Variables
+#
+# [*$repositories*]
+#   A string array of Elasticsearch repositories
+#
+class govuk_elasticsearch::housekeeping(
+  $es_repos,
+  $es_snapshot_limit = 5,
+  $user = 'govuk-backup',
+  ) {
+
+  if $es_repos == undef {
+    fail('No Elasticsearch repositories were set')
+  } else {
+    # Validates a maximum and minimum string length
+    validate_slength($es_repos, 120, 3)
+    $repositories = join(regsubst($es_repos,'(.*)','"\1"'), ' ')
+  }
+
+    # This is a CLI JSON processor which allows us to "awk" the data on the fly
+    package { 'jq':
+      ensure => installed,
+    }
+
+    file { 'es-prune-snapshots':
+      ensure  => file,
+      path    => '/usr/local/bin/es-prune-snapshots',
+      content => template('govuk_elasticsearch/es-prune-snapshots.erb'),
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0755',
+    }
+
+    cron { 'elasticsearch-remove-old-snapshots':
+      ensure  => present,
+      command => '/usr/local/bin/es-prune-snapshots',
+      user    => $user,
+      weekday => 3,
+      hour    => 4,
+      minute  => 0,
+    }
+}

--- a/modules/govuk_elasticsearch/spec/classes/govuk_elasticsearch_housekeeping_spec.rb
+++ b/modules/govuk_elasticsearch/spec/classes/govuk_elasticsearch_housekeeping_spec.rb
@@ -1,0 +1,19 @@
+require_relative '../../../../spec_helper'
+
+  describe 'govuk_elasticsearch::housekeeping', :type => :class do
+
+    let(:params) {{
+        :es_repos => [
+            'kibana-lint',
+            'kibana-mint',
+            'kibana_tint'
+        ]
+    }}
+
+    context 'Checking what repositories variable expands like' do
+
+      it { is_expected.to contain_file('es-prune-snapshots').with_path('/usr/local/bin/es-prune-snapshots').with_content(/"kibana-lint"\s"kibana-mint"\s"kibana_tint"/) }
+    end
+
+
+  end

--- a/modules/govuk_elasticsearch/templates/es-prune-snapshots.erb
+++ b/modules/govuk_elasticsearch/templates/es-prune-snapshots.erb
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+# Redirect stdout and stderr to syslog
+exec 1> >(/usr/bin/logger -s -t $(basename $0)) 2>&1
+
+ES_REPOS=(<%= @repositories %>)
+LIMIT=<%= @es_snapshot_limit %>
+
+for i in ${ES_REPOS[@]}; do
+  # This gets snapshots for the repo but leaves behind 'n' youngest snapshots, 'n' being the LIMIT set above
+  SNAPSHOTS=$(/usr/bin/curl --connect-timeout 10 -sS -XGET "127.0.0.1:9200/_snapshot/${ES_REPOS[$i]}/_all" | /usr/bin/jq --raw-output ".snapshots[:-${LIMIT}][].snapshot")
+
+  for SNAPSHOT in $SNAPSHOTS; do
+    /usr/bin/curl --connect-timeout 10 -s -XDELETE "127.0.0.1:9200/_snapshot/${ES_REPOS}/${SNAPSHOT}?pretty"
+  done
+done
+


### PR DESCRIPTION
This commit adds a shell script to remove old snapshots from the local repository in elasticsearch.  Doing this will hopefully prevent degraded performance as a result of having a backup solution.