### PR TITLE
Turn on rummager message queue listener in development

### DIFF
--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -153,6 +153,8 @@ govuk::apps::router_api::mongodb_nodes: ['localhost']
 govuk::apps::router_api::router_nodes: ['localhost:3055']
 govuk::apps::rummager::enable_procfile_worker: true
 govuk::apps::rummager::rabbitmq_hosts: ['localhost']
+govuk::apps::rummager::enable_publishing_listener: true
+govuk::apps::rummager::rabbitmq::enable_publishing_listener: true
 govuk::apps::share_sale_publisher::enabled: true
 govuk::apps::share_sale_publisher::mongodb_nodes: ['localhost']
 govuk::apps::share_sale_publisher::mongodb_name: 'share_sale_publisher_development'


### PR DESCRIPTION
Enabling the publishing listener tells puppet to create a RabbitMQ user
and queue for rummager. Without this it won't be possible to start
rummager after we've merged
https://github.gds/gds/development/pull/324.