### PR TITLE
Pin specific packages of wal-e dependencies

### DIFF
--- a/modules/govuk_postgresql/manifests/wal_e/package.pp
+++ b/modules/govuk_postgresql/manifests/wal_e/package.pp
@@ -20,13 +20,13 @@ class govuk_postgresql::wal_e::package {
   # pip should take care of version deps but we need to manually upgrade
   # a couple of things
 
-  $pip_deps = [
-    'requests',
-    'six',
-  ]
+  package { 'requests':
+    ensure   => '2.10.0',
+    provider => pip,
+  }
 
-  package { $pip_deps:
-    ensure   => latest,
+  package { 'six':
+    ensure   => '1.10.0',
     provider => pip,
   }
 }


### PR DESCRIPTION
We don't always want to upgrade these versions to whatever happens to be on PyPI, which is what `latest` will do.

Instead I've pinned the packages to the versions we currently have installed.