### PR TITLE
Only require 1 elasticsearch master node on the dev vm

### DIFF
--- a/modules/govuk/manifests/node/s_development.pp
+++ b/modules/govuk/manifests/node/s_development.pp
@@ -47,11 +47,12 @@ class govuk::node::s_development (
   }
 
   class { 'govuk_elasticsearch':
-    cluster_name       => 'govuk-development',
-    heap_size          => '1024m',
-    number_of_shards   => '1',
-    number_of_replicas => '0',
-    require            => Class['govuk_java::set_defaults'],
+    cluster_name         => 'govuk-development',
+    heap_size            => '1024m',
+    number_of_shards     => '1',
+    number_of_replicas   => '0',
+    minimum_master_nodes => '1',
+    require              => Class['govuk_java::set_defaults'],
   }
 
   include nginx


### PR DESCRIPTION
In 1cfda1339ca819fdeb80f8c027173e565c6e38dd we changed the default for
`minimum_master_nodes` to be 2.  This makes sense everywhere except on the
dev vm where we still want it to be 1.  If it remains as 2 then the dev
vm cluster is unhealthy and reports:

   {"error":"MasterNotDiscoveredException[waited for [30s]]","status":503}

for `curl -XGET 'localhost:9200/_cluster/health?pretty'`.  This in turn
means we cannot run replication scripts.  Setting it to 1 makes things
work again.