### PR TITLE
Clear integration redis after data sync

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
@@ -24,6 +24,10 @@
            ssh deploy@$(govuk_node_list -c backend --single-node) 'cd /var/apps/publisher ; govuk_setenv publisher bundle exec rake editions:requeue_scheduled_for_publishing'
            # Publish any pre-production finders from Specialist Publisher Rebuild.
            ssh deploy@$(govuk_node_list -c backend --single-node) 'cd /var/apps/specialist-publisher-rebuild ; govuk_setenv specialist-publisher-rebuild bundle exec rake publishing_api:publish_finders rummager:publish_finders'
+           # Clear the Sidekiq queues to stop any residual 'stale' jobs running
+           for host in $(govuk_node_list -c redis); do
+              ssh deploy@${host} 'redis-cli flushall'
+           done
     publishers:
         - trigger-parameterized-builds:
             <%- %w{ publishing-api collections-publisher service-manual-publisher local-links-manager }.each do |app| -%>


### PR DESCRIPTION
This PR runs `flushall` on `redis-1` and `redis-2` in the integration environment following the completion of the data sync job.

Redis is predominantly used for Sidekiq queues. When running large republishings on integration it is possible that there will be residual jobs left in Redis when integration is switched off overnight. These
jobs will run when the environment comes back on the following morning but will be running over different data than they were created against possibly causing inconsistencies.

Both Redis hosts are included as they run independently and aren't clustered. This PR doesn't include `api-redis-1`, `logs-redis-1` or `logs-redis-2` as they don't seem to be involved in the publishing pipeline.

An alternative approach would be to clear the Sidekiq queues explicitly via Sidekiq rather than just flushing Redis but I've used this approach as I think the same issue could affect any of the apps using Sidekiq and losing anything else stored in Redis on integration shouldn't be an issue.