### PR TITLE
Add detailed graphs for rummager queue stats

### DIFF
--- a/modules/grafana/files/dashboards/detailed_rummager_queues.json
+++ b/modules/grafana/files/dashboards/detailed_rummager_queues.json
@@ -1,0 +1,149 @@
+{
+  "id": null,
+  "title": "Rummager search indexing dashboard - details",
+  "tags": [],
+  "style": "dark",
+  "timezone": "utc",
+  "editable": true,
+  "hideControls": false,
+  "sharedCrosshair": false,
+  "rows": [
+    {
+      "height": "400px",
+      "editable": true,
+      "collapse": false,
+      "panels": [
+        {
+          "id": 1,
+          "title": "Message processor status counts",
+          "span": 4,
+          "type": "graph",
+          "bars": true,
+          "lines": false,
+          "nullPointMode": "null as zero",
+          "steppedLine": false,
+          "tooltip": {
+            "value_type": "individual",
+            "shared": false
+          },
+          "targets": [
+            {
+              "target": "alias(consolidateBy(summarize(stats_counts.govuk.app.rummager.message_queue.indexer.accepted, '1minute', 'sum'), 'max'), 'Accepted')"
+            },
+            {
+              "target": "alias(consolidateBy(summarize(stats_counts.govuk.app.rummager.message_queue.indexer.rejected, '1minute', 'sum'), 'max'), 'Ignored')"
+            }
+          ],
+          "aliasColors": {
+            "Accepted": "#00C200",
+            "Ignored": "#FF9900"
+          },
+          "leftYAxisLabel": "Messages per minute",
+          "grid": {
+            "leftMin": 0
+          }
+        },
+        {
+          "id": 2,
+          "title": "Sidekiq BulkIndexWorker activity (search indexing)",
+          "span": 4,
+          "type": "graph",
+          "bars": true,
+          "lines": false,
+          "nullPointMode": "null as zero",
+          "steppedLine": false,
+          "tooltip": {
+            "value_type": "individual",
+            "shared": false
+          },
+          "targets": [
+            {
+              "target": "alias(consolidateBy(summarize(stats_counts.govuk.app.rummager.workers.Indexer.BulkIndexWorker.success, '1minute', 'sum'), 'max'), 'Success')"
+            },
+            {
+              "target": "alias(consolidateBy(summarize(stats_counts.govuk.app.rummager.workers.Indexer.BulkIndexWorker.failure, '1minute', 'sum'), 'max'), 'Failure')"
+            }
+          ],
+          "aliasColors": {
+            "Success": "#00C200",
+            "Failure": "#EE0000"
+          },
+          "grid": {
+            "leftMin": 0
+          },
+          "leftYAxisLabel": "Messages per minute"
+        },
+        {
+          "id": 3,
+          "title": "Sidekiq DeleteWorker activity (search indexing)",
+          "span": 4,
+          "type": "graph",
+          "bars": true,
+          "lines": false,
+          "nullPointMode": "null as zero",
+          "steppedLine": false,
+          "tooltip": {
+            "value_type": "individual",
+            "shared": false
+          },
+          "targets": [
+            {
+              "target": "alias(consolidateBy(summarize(stats_counts.govuk.app.rummager.workers.Indexer.DeleteWorker.success, '1minute', 'sum'), 'max'), 'Success')"
+            },
+            {
+              "target": "alias(consolidateBy(summarize(stats_counts.govuk.app.rummager.workers.Indexer.DeleteWorker.failure, '1minute', 'sum'), 'max'), 'Failure')"
+            }
+          ],
+          "aliasColors": {
+            "Success": "#00C200",
+            "Failure": "#EE0000"
+          },
+          "grid": {
+            "leftMin": 0
+          },
+          "leftYAxisLabel": "Messages per minute"
+        }
+      ]
+    }
+  ],
+  "nav": [
+    {
+      "type": "timepicker",
+      "collapse": false,
+      "notice": false,
+      "enable": true,
+      "status": "Stable",
+      "time_options": [
+        "5m",
+        "15m",
+        "1h",
+        "6h",
+        "12h",
+        "24h",
+        "2d",
+        "7d",
+        "30d"
+      ],
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "now": true
+    }
+  ],
+  "time": {
+    "from": "now-2h",
+    "to": "now"
+  },
+  "refresh": "5s",
+  "version": 6,
+  "hideAllLegends": false
+}


### PR DESCRIPTION
![screen shot 2016-06-27 at 18 45 14](https://cloud.githubusercontent.com/assets/4282030/16389856/dc481a00-3c97-11e6-8acc-5a7cf5bb09b0.png)

Since we don't want to clutter the information radiator with
too many graphs, additional details can go here.