### PR TITLE
Revert "Lowercase URLs if they are all capitals"

### DIFF
--- a/modules/router/templates/router_include.conf.erb
+++ b/modules/router/templates/router_include.conf.erb
@@ -26,19 +26,6 @@ access_log /var/log/nginx/lb-access.log timed_combined;
 access_log /var/log/nginx/lb-json.event.access.log json_event;
 error_log  /var/log/nginx/lb-error.log;
 
-# Function to lowercase a uri
-perl_set $uri_lowercase 'sub {
-        my $r = shift;
-        return lc($r->uri);
-}';
-
-# If slug contains no lowercase letters then lowercase it
-# eg www.gov.uk/GOVERNMENT/GUIDANCE -> www.gov.uk/government/guidance
-# eg WWW.GOV.UK/GOVERNMENT/GUIDANCE -> www.gov.uk/government/guidance
-location ~ ^([A-Z]|\W|\d)+$ {
-  rewrite ^(.*)$ $scheme://$host$uri_lowercase permanent;
-}
-
 location ~ ^/apply-for-a-licence/? {
   proxy_intercept_errors off;
 


### PR DESCRIPTION
Reverts alphagov/govuk-puppet#4524

Causes an nginx syntax error.