### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ unknown classes or functions such as:
 - `Could not find class apt for …`
 - `Puppet::Parser::AST::Resource failed with error ArgumentError: Invalid resource type apt::source …`
 
+It may affect errors relating to classes you have not modified when running spec tests after a rebase.
+
 This should also fix errors while trying to run `govuk_puppet`, of the form:
 
 - `chown: changing ownership of '/home/vagrant/.puppet/[…]': Operation not permitted`


### PR DESCRIPTION
I thought this might be helpful for others who have seen errors while running tests against puppet

for code they have not touched.

` 1) govuk::node::s_cache by default configures varnish to strip cookies
     Failure/Error: is_expected.to contain_file('/etc/varnish/default.vcl').
     Puppet::Error:
       Invalid parameter preserve_fqdn on Class[Rsyslog] at
       /Users/USER/govuk/govuk-puppet/modules/govuk/manifests/node/s_base.pp:35
       on node cache-1.router.somethingsomething
`

I found that if i've had a long running live branch which I may have rebased and in that time updated
my master branch. I get spec errors on code that I have not touched.  This is due to either missing or
outdated modules managed by librarian.  This does not occur on Jenkins or Travis because a new environment
is spawned each time a test is run.