### PR TITLE
Bugfix MySQL restore stuff

### DIFF
--- a/modules/govuk_mysql/manifests/xtrabackup/restore.pp
+++ b/modules/govuk_mysql/manifests/xtrabackup/restore.pp
@@ -12,6 +12,8 @@ define govuk_mysql::xtrabackup::restore (
 ) {
   $env_sync_envdir = '/etc/mysql/xtrabackup/env_sync/env.d'
 
+  include govuk_mysql::xtrabackup::packages
+
   file {[
         '/etc/mysql/xtrabackup',
         '/etc/mysql/xtrabackup/env_sync',


### PR DESCRIPTION
My restore stuff foolishly assumed that we would have the packages
already installed from backups, but actually in MySQL we backup from the
slave but restore to a master, so the packages class wasn't already
included and there was a require which threw this error:

``` Error: Could not retrieve catalog from remote server: Error 400 on
SERVER: Invalid relationship: File[/usr/local/bin/xtrabackup_s3_restore]
{ require => Class[Govuk_mysql::Xtrabackup::Packages] }, because
Class[Govuk_mysql::Xtrabackup::Packages] doesn't seem to be in the
catalog ```

This just includes it if it's not installed already.