### PR TITLE
Change broken link report email

### DIFF
--- a/modules/govuk_jenkins/manifests/job/whitehall_run_broken_link_checker.pp
+++ b/modules/govuk_jenkins/manifests/job/whitehall_run_broken_link_checker.pp
@@ -3,9 +3,22 @@
 # Create a file on disk that can be parsed by jenkins-job-builder
 #
 class govuk_jenkins::job::whitehall_run_broken_link_checker {
+  $app_domain = hiera('app_domain')
+
+  $service_description = 'Runs a rake task on Whitehall that generates a broken link report'
+  $job_slug = 'whitehall_run_broken_link_checker'
+  $job_url = "https://deploy.${app_domain}/job/${job_slug}"
+
   file { '/etc/jenkins_jobs/jobs/whitehall_run_broken_link_checker.yaml':
     ensure  => present,
     content => template('govuk_jenkins/jobs/whitehall_run_broken_link_checker.yaml.erb'),
     notify  => Exec['jenkins_jobs_update'],
+  }
+
+  @@icinga::passive_check { "${job_slug}_${::hostname}":
+    service_description => $service_description,
+    host_name           => $::fqdn,
+    freshness_threshold => 32 * 86400,
+    action_url          => $job_url,
   }
 }

--- a/modules/govuk_jenkins/templates/jobs/whitehall_run_broken_link_checker.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/whitehall_run_broken_link_checker.yaml.erb
@@ -6,7 +6,7 @@
     description: "<p>Triggers the broken link checker rake task on whitehall-backend-1.</p>"
     builders:
         - shell: |
-            ssh deploy@whitehall-backend-1.backend 'cd /var/apps/whitehall; govuk_setenv whitehall nohup bundle exec rake generate_broken_link_reports[/tmp/bad_link_reports,departments-policy-content@digital.cabinet-office.gov.uk]'
+            ssh deploy@whitehall-backend-1.backend 'cd /var/apps/whitehall; govuk_setenv whitehall nohup bundle exec rake generate_broken_link_reports[/tmp/bad_link_reports,second-line-content@digital.cabinet-office.gov.uk]'
             echo "Broken link checker run"
     triggers:
         - timed: '0 2 1 * *'

--- a/modules/govuk_jenkins/templates/jobs/whitehall_run_broken_link_checker.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/whitehall_run_broken_link_checker.yaml.erb
@@ -16,6 +16,17 @@
     publishers:
         - email:
             recipients: govuk-ci-notifications@digital.cabinet-office.gov.uk
+        - trigger-parameterized-builds:
+            - project: success_passive_check
+                condition: 'success'
+                predefined-parameters: |
+                    NSCA_CHECK_DESCRIPTION=<%= @service_description %>
+                    NSCA_OUTPUT=<%= @service_description %> successful
+            - project: failure_passive_check
+                condition: 'failed'
+                predefined-parameters: |
+                    NSCA_CHECK_DESCRIPTION=<%= @service_description %>
+                    NSCA_OUTPUT=<%= @service_description %> failed
     logrotate:
-      artifactNumToKeep: 10
+        artifactNumToKeep: 10
 


### PR DESCRIPTION
This PR updates the Jenkins job that calls the Whitehall broken link report rake task to pass an updated email address parameter as per [Trello](https://trello.com/c/RCdWcC28/429-broken-links-report-for-publishers-medium)

It also adds an Icinga passive check for success/failure of the job. I'm not familiar with how Icinga is set up here so have just followed how the other jobs seem to hook into it. Any suggestions/corrections would be graciously received... 