### PR TITLE
Only enable the env_sync on selected machines.

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -224,7 +224,6 @@ govuk::node::s_monitoring::offsite_backups: false
 govuk::node::s_mysql_master::s3_bucket_name: 'govuk-mysql-xtrabackups-integration'
 govuk::node::s_whitehall_backend::sync_mirror: true
 
-govuk::node::s_transition_postgresql_base::env_sync_enabled: true
 govuk::node::s_transition_postgresql_slave::redirector_ip_range: '10.1.5.0/24'
 
 govuk_sudo::sudo_conf:

--- a/hieradata/node/transition-postgresql-master-1.backend.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/transition-postgresql-master-1.backend.integration.publishing.service.gov.uk.yaml
@@ -1,0 +1,2 @@
+---
+govuk::node::s_transition_postgresql_base::env_sync_enabled: true


### PR DESCRIPTION
This shouldn't be deployed everywhere and in this specific case
we're only testing in integration on the transition master.