### PR TITLE
Remove the old cronjob

### DIFF
--- a/modules/rkhunter/manifests/monitoring.pp
+++ b/modules/rkhunter/manifests/monitoring.pp
@@ -65,4 +65,9 @@ class rkhunter::monitoring {
     notes_url           => monitoring_docs_url(rkhunter-warnings),
     require             => File['/etc/cron.d/rkhunter-passive-check'],
   }
+
+  # FIXME: remove once the file has gone from all hosts.
+  file { '/etc/cron.daily/rkhunter-passive-check':
+    ensure => 'absent',
+  }
 }


### PR DESCRIPTION
We now run this from cron.d. Once this file is absent everywhere
we'll remove this puppet resource.