### PR TITLE
Remove explictly pinned version for aptly

### DIFF
--- a/modules/govuk/manifests/node/s_apt.pp
+++ b/modules/govuk/manifests/node/s_apt.pp
@@ -13,8 +13,7 @@ class govuk::node::s_apt (
   # `apt::source` resources will need to specify an `architecture` param to
   # select only "amd64" or "binary".
   class { 'aptly':
-    package_ensure => '0.6',
-    config         => {
+    config => {
       'rootDir'       => $root_dir,
       'architectures' => [$::architecture],
     },


### PR DESCRIPTION
We need some of the newer bug fixes so we're going to remove the pin
for testing in integration. Originally pinned in
c62115d364b7e9a3cedd39f6ed47ac54a6674d79