### PR TITLE
Remove mongo-pp from Integration data sync

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
@@ -76,7 +76,6 @@
                 - mongo-exceptions
                 - mongo-licensify
                 - mongo-normal
-                - mongo-pp
                 - mongo-router
                 - mysql-efg
                 - mysql-normal


### PR DESCRIPTION
This can be reverted when Performance Platform are ready to enable data syncs
again.

/cc @leelongmore