### PR TITLE
Lowercase all capital urls

### DIFF
--- a/modules/router/templates/base.conf.erb
+++ b/modules/router/templates/base.conf.erb
@@ -2,6 +2,12 @@ upstream varnish {
   server localhost:7999;
 }
 
+# Function to lowercase a uri
+perl_set $uri_lowercase 'sub {
+  my $r = shift;
+  return lc($r->uri);
+}';
+
 server {
   server_name www.gov.uk www.<%= @app_domain %> www-origin.<%= @app_domain %>;
   listen 80;

--- a/modules/router/templates/router_include.conf.erb
+++ b/modules/router/templates/router_include.conf.erb
@@ -26,6 +26,12 @@ access_log /var/log/nginx/lb-access.log timed_combined;
 access_log /var/log/nginx/lb-json.event.access.log json_event;
 error_log  /var/log/nginx/lb-error.log;
 
+# explicitly match 'space' only urls to avoid
+# the downcase location causing a redirect loop for https://www.gov.uk/ / /
+location ~ /[\s\/]+$ {
+  rewrite ^(.*)$ $scheme://$host;
+}
+
 # If slug contains no lowercase letters then lowercase it
 # eg www.gov.uk/GOVERNMENT/GUIDANCE -> www.gov.uk/government/guidance
 # eg WWW.GOV.UK/GOVERNMENT/GUIDANCE -> www.gov.uk/government/guidance

--- a/modules/router/templates/router_include.conf.erb
+++ b/modules/router/templates/router_include.conf.erb
@@ -26,6 +26,13 @@ access_log /var/log/nginx/lb-access.log timed_combined;
 access_log /var/log/nginx/lb-json.event.access.log json_event;
 error_log  /var/log/nginx/lb-error.log;
 
+# If slug contains no lowercase letters then lowercase it
+# eg www.gov.uk/GOVERNMENT/GUIDANCE -> www.gov.uk/government/guidance
+# eg WWW.GOV.UK/GOVERNMENT/GUIDANCE -> www.gov.uk/government/guidance
+location ~ /[A-Z\W\d]+$ {
+  rewrite ^(.*)$ $scheme://$host$uri_lowercase permanent;
+}
+
 location ~ ^/apply-for-a-licence/? {
   proxy_intercept_errors off;
 


### PR DESCRIPTION
Currently we serve 404s to users that have inadvertently entered a URL with CAPSLOCK on. This commit downcases URLs that contain no lowercase letters but ignores urls where the case is mixed.

This should reduce 404s received by users.

So...

```
HTTPS://WWW.GOV.UK/BROWSE/BENEFITS -> https://www.gov.uk/browse/benefits
https://www.gov.uk/BROWSE/BENEFITS -> https://www.gov.uk/browse/benefits
https://www.gov.uk/browse/Benefits -> https://www.gov.uk/browse/Benefits (ignored)
```

[Trello](https://trello.com/c/CDpTRF1e/408-404s-caused-by-capitalisation-medium)

The previous attempt at this matched `/` and caused a redirect loop. The regex used in this PR fixes that but introduces a new redirect loop at `/ / / /`. This isn't a valid URL and so probably doesn't matter but I've added a second commit with a possible 'fix' for this using a location that matches that url to redirect to root. I've included it for discussion as I've yet to come up with a better solution if we agree that this is a problem.
