### PR TITLE
Remove --quiet option

### DIFF
--- a/modules/mongodb/templates/mongodb-backup-s3.erb
+++ b/modules/mongodb/templates/mongodb-backup-s3.erb
@@ -24,7 +24,7 @@ trap nagios_passive EXIT
 
 # Backup mongodb
 TIME="$(date +%s)"
-/usr/bin/mongodump -h $BACKUP_NODE -o $BACKUP_DIR --quiet
+/usr/bin/mongodump -h $BACKUP_NODE -o $BACKUP_DIR
 TIME="$(($(date +%s)-TIME))"
 printf "BACKUP COMPLETED IN: ${TIME}s\n"
 


### PR DESCRIPTION
Our version of the mongo command doesn't support this so remove it from the
script.