### PR TITLE
Add the source on the actual server

### DIFF
--- a/modules/govuk_mysql/manifests/xtrabackup/packages.pp
+++ b/modules/govuk_mysql/manifests/xtrabackup/packages.pp
@@ -24,6 +24,13 @@ class govuk_mysql::xtrabackup::packages (
     mode    => '0600',
   }
 
+  apt::source { 'percona':
+    location     => "https://${apt_mirror_hostname}/percona",
+    release      => $::lsbdistcodename,
+    architecture => $::architecture,
+    key          => '1C4CBDCDCD2EFD2A',
+  }
+
   package { 'qpress':
     ensure => present,
   }


### PR DESCRIPTION
The aptly mirror had been added but the source hadn't been added on the
servers to be able to find the package.