### PR TITLE
Added /preview endpoint to the list of routes directed to SPv2

### DIFF
--- a/modules/govuk/manifests/node/s_backend_lb.pp
+++ b/modules/govuk/manifests/node/s_backend_lb.pp
@@ -52,6 +52,9 @@ class govuk::node::s_backend_lb (
         '/rebuild-healthcheck' => {
           'app' => 'specialist-publisher-rebuild',
         },
+        '/preview'             => {
+          'app' => 'specialist-publisher-rebuild',
+        },
       },
       servers => $backend_servers;
     [


### PR DESCRIPTION
This is due to it being required for handling of govspeak preview rendering,
This is to solve the issue discovered in RAIB deploy test, where preview buttons did not function

[Trello Card](https://trello.com/c/mpODxjaj/169-raib-go-live-govspeak-style-not-being-displayed-in-either-preview-or-live-site)