### PR TITLE
Revert "Remove this partial work until we're ready to focus on it"

### DIFF
--- a/modules/govuk/manifests/node/s_apt.pp
+++ b/modules/govuk/manifests/node/s_apt.pp
@@ -81,6 +81,10 @@ class govuk::node::s_apt (
       location => 'http://downloads-distro.mongodb.org/repo/ubuntu-upstart',
       release  => 'dist',
       key      => '7F0CEB10';
+    'mongodb3.2':
+      location => 'https://repo.mongodb.org/apt/ubuntu',
+      release  => 'trusty/mongodb-org/3.2',
+      key      => 'EA312927';
     'jenkins':
       location => 'http://pkg.jenkins-ci.org/debian-stable',
       release  => 'binary/', # Trailing slash is significant.


### PR DESCRIPTION
This reverts commit c57e764bcce06f57a11d0c04337032e70aed98b6, which was actually a revert of 51de76f67c9b8ebb8372e1d1bb670412a7cc6c22. 

We can try adding this again because aptly has now been upgraded (manually but also by [removing the pinning](https://github.com/alphagov/govuk-puppet/pull/4551/commits/dc29c37e998201a21324170e1c4c75fd8bb6aa3f)) which _should_ fix the error it was throwing when trying to add this package.