### PR TITLE
Update notes_url link

### DIFF
--- a/modules/govuk_rabbitmq/manifests/monitoring.pp
+++ b/modules/govuk_rabbitmq/manifests/monitoring.pp
@@ -28,6 +28,6 @@ class govuk_rabbitmq::monitoring (
     check_command       => 'check_nrpe_1arg!check_rabbitmq_watermark',
     service_description => 'RabbitMQ high watermark has been exceeded',
     host_name           => $::fqdn,
-    notes_url           => monitoring_docs_url(check-rabbitmq-watermark),
+    notes_url           => monitoring_docs_url(rabbitmq-high-watermark-has-been-exceeded),
   }
 }


### PR DESCRIPTION
This didn't match the opsmanual which meant it didn't take you straight
to the documentation.