### PR TITLE
Bugfix Jenkins Job Builder yaml

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/whitehall_run_broken_link_checker.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/whitehall_run_broken_link_checker.yaml.erb
@@ -18,12 +18,12 @@
             recipients: govuk-ci-notifications@digital.cabinet-office.gov.uk
         - trigger-parameterized-builds:
             - project: success_passive_check
-                condition: 'success'
+                condition: 'SUCCESS'
                 predefined-parameters: |
                     NSCA_CHECK_DESCRIPTION=<%= @service_description %>
                     NSCA_OUTPUT=<%= @service_description %> successful
             - project: failure_passive_check
-                condition: 'failed'
+                condition: 'FAILED'
                 predefined-parameters: |
                     NSCA_CHECK_DESCRIPTION=<%= @service_description %>
                     NSCA_OUTPUT=<%= @service_description %> failed


### PR DESCRIPTION
Jenkins Job Builder gets upset:

```
Notice:
/Stage[main]/Govuk_jenkins::Job_builder/Exec[jenkins_jobs_update]/returns:
yaml.scanner.ScannerError: mapping values are not allowed here
Notice:
/Stage[main]/Govuk_jenkins::Job_builder/Exec[jenkins_jobs_update]/returns:
in "/etc/jenkins_jobs/jobs/whitehall_run_broken_link_checker.yaml", line
21, column 26
```

I believe it's because the condition should be in capitals.