### PR TITLE
Lowercase URLs if they are all capitals

### DIFF
--- a/modules/router/templates/base.conf.erb
+++ b/modules/router/templates/base.conf.erb
@@ -2,6 +2,12 @@ upstream varnish {
   server localhost:7999;
 }
 
+# Function to lowercase a uri
+perl_set $uri_lowercase 'sub {
+  my $r = shift;
+  return lc($r->uri);
+}';
+
 server {
   server_name www.gov.uk www.<%= @app_domain %> www-origin.<%= @app_domain %>;
   listen 80;

--- a/modules/router/templates/router_include.conf.erb
+++ b/modules/router/templates/router_include.conf.erb
@@ -26,6 +26,13 @@ access_log /var/log/nginx/lb-access.log timed_combined;
 access_log /var/log/nginx/lb-json.event.access.log json_event;
 error_log  /var/log/nginx/lb-error.log;
 
+# If slug contains no lowercase letters then lowercase it
+# eg www.gov.uk/GOVERNMENT/GUIDANCE -> www.gov.uk/government/guidance
+# eg WWW.GOV.UK/GOVERNMENT/GUIDANCE -> www.gov.uk/government/guidance
+location ~ ^\/[A-Z]+[A-Z\W\d]+$ {
+  rewrite ^(.*)$ $scheme://$host$uri_lowercase permanent;
+}
+
 location ~ ^/apply-for-a-licence/? {
   proxy_intercept_errors off;
 


### PR DESCRIPTION
Currently we serve 404s to users that have inadvertently entered a URL with CAPSLOCK on. This commit downcases URLs that contain no lowercase letters but ignores urls where the case is mixed.

This should reduce 404s received by users.

So...

```
HTTPS://WWW.GOV.UK/BROWSE/BENEFITS -> https://www.gov.uk/browse/benefits
https://www.gov.uk/BROWSE/BENEFITS -> https://www.gov.uk/browse/benefits
https://www.gov.uk/browse/Benefits -> https://www.gov.uk/browse/Benefits (ignored)
```

[Trello](https://trello.com/c/CDpTRF1e/408-404s-caused-by-capitalisation-medium)

This is the latest in a long line of failed previous attempts at this that have caused issues when deployed to staging (namely redirect loops for certain URLs). 

The regex in this PR has been [tested against some of the 'problem' URLs](https://regex101.com/r/xW7iF8/3) encountered so far.

I've marked this 'do not merge' as we'll deploy master, merge this and then deploy this to staging on its own for testing.