### PR TITLE
Recommend using Vagrant 1.7.4

### DIFF
--- a/development-vm/README.md
+++ b/development-vm/README.md
@@ -26,11 +26,10 @@ checking for other manufacturers.
   * You have [OSX GCC tools installed](https://github.com/kennethreitz/osx-gcc-installer) (or via XCode)
   * You have [VirtualBox](https://www.virtualbox.org/) installed
   * You have an account on [GitHub.com](https://github.com)
-  * You have a recent version of [Vagrant](https://www.vagrantup.com/downloads.html)
-    installed - these instructions may work with older versions, but
-    they're not officially supported
+  * You have [Vagrant 1.7.4](https://releases.hashicorp.com/vagrant/1.7.4/vagrant_1.7.4.dmg)
+    installed.
   * You have some other repositories from GDS checked out to work on -
-    these should be located alongside the `puppet` repository we're in
+    these should be located alongside the `govuk-puppet` repository we're in
     now (e.g `~/govuk/govuk-puppet:~/govuk/frontend`)
 
 ### A note on Boxen


### PR DESCRIPTION
Vagrant 1.8 doesn't work with vagrant-dns.

https://trello.com/c/S4ulV1Qr/4-vagrant-1-8-is-buggy-recommend-1-7-4