### PR TITLE
Local links manager link checker job

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -89,6 +89,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::launch_vms
   - govuk_jenkins::job::local_links_manager_import_service_interactions
   - govuk_jenkins::job::local_links_manager_import_links
+  - govuk_jenkins::job::local_links_manager_check_links
   - govuk_jenkins::job::mirror_network_config
   - govuk_jenkins::job::network_config_deploy
   - govuk_jenkins::job::passive_checks

--- a/modules/govuk_jenkins/manifests/job/local_links_manager_check_links.pp
+++ b/modules/govuk_jenkins/manifests/job/local_links_manager_check_links.pp
@@ -1,0 +1,25 @@
+# == Class: govuk_jenkins::job::local_links_manager_check_links
+#
+# Checks the status of links that have been imported into Local Links Manager
+#
+class govuk_jenkins::job::local_links_manager_check_links (
+  $app_domain = hiera('app_domain'),
+) {
+
+  $check_name = 'local-links-manager-check-links'
+  $service_description = 'Checks the status of links that have been imported into Local Links Manager'
+  $job_url = "https://deploy.${app_domain}/job/local-links-manager-check-links/"
+
+  file { '/etc/jenkins_jobs/jobs/local_links_manager_check_links.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/local_links_manager_check_links.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+
+  @@icinga::passive_check { "${check_name}_${::hostname}":
+    service_description => $service_description,
+    host_name           => $::fqdn,
+    freshness_threshold => (25 * 60 * 60), # 25 hrs (e.g. just over a day)
+    action_url          => $job_url,
+  }
+}

--- a/modules/govuk_jenkins/templates/jobs/local_links_manager_check_links.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/local_links_manager_check_links.yaml.erb
@@ -1,0 +1,31 @@
+---
+- job:
+    name: Local_Links_Manager_Check_Links
+    display-name: Local_Links_Manager_Check_Links
+    project-type: freestyle
+    description: |
+      Runs the rake task to check the status of links in Local Links Manager every day
+    logrotate:
+      artifactNumToKeep: 10
+    triggers:
+        - timed: 'H 2 * * *'
+    builders:
+        - trigger-builds:
+            - project: run-rake-task
+              block: true
+              predefined-parameters: |
+                  TARGET_APPLICATION=local-links-manager
+                  MACHINE_CLASS=backend
+                  RAKE_TASK=check-links
+    publishers:
+        - trigger-parameterized-builds:
+            - project: Success_Passive_Check
+              condition: 'SUCCESS'
+              predefined-parameters: |
+                  NSCA_CHECK_DESCRIPTION=<%= @service_description %>
+                  NSCA_OUTPUT=<%= @service_description %> success
+            - project: Failure_Passive_Check
+              condition: 'FAILED'
+              predefined-parameters: |
+                  NSCA_CHECK_DESCRIPTION=<%= @service_description %>
+                  NSCA_OUTPUT=<%= @service_description %> failed

--- a/modules/govuk_jenkins/templates/jobs/local_links_manager_import_links.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/local_links_manager_import_links.yaml.erb
@@ -8,7 +8,7 @@
     logrotate:
       artifactNumToKeep: 10
     triggers:
-        - timed: 'H 5 * * *'
+        - timed: 'H 1 * * *'
     builders:
         - trigger-builds:
             - project: run-rake-task


### PR DESCRIPTION
- Add link checker jenkins job for Local Links Manager. The link checker rake task should run daily after the importing of the links in order to check their status

- Change time that links are imported into Local Links Manager. The link checker rake task takes 19 hours approximately. This changes the importing of the links to run at 1am instead of 5am so that the link
checker task can begin an hour later.

[Trello card](https://trello.com/c/KBT9RC9q/406-check-the-status-code-of-links)