### PR TITLE
Create s_licensing_mongo class

### DIFF
--- a/hieradata/class/licensing_mongo.yaml
+++ b/hieradata/class/licensing_mongo.yaml
@@ -36,3 +36,6 @@ mongodb::server::replicaset_members:
 
 # Disable monthly backups to limit the retention of IL3 data.
 mongodb::backup::domonthly: false
+
+mongodb::server::package_name: 'mongodb-org'
+mongodb::server::version: '3.2.7'

--- a/hieradata/class/licensing_mongo.yaml
+++ b/hieradata/class/licensing_mongo.yaml
@@ -1,0 +1,38 @@
+---
+
+govuk_safe_to_reboot::can_reboot: 'overnight'
+govuk_safe_to_reboot::reason: 'Secondaries will reboot overnight if cluster is healthy'
+
+hosts::production::external_licensify: false
+
+hosts::production::licensify::app_hostnames:
+  - 'licensify'
+  - 'uploadlicence'
+  - 'licensify-admin'
+  - 'licensing-web-forms'
+
+lv:
+  mongodb:
+    pv: '/dev/sdb1'
+    vg: 'backup'
+  databases:
+    pv: '/dev/sdc1'
+    vg: 'mongodb'
+
+mount:
+  /var/lib/mongodb:
+    disk: '/dev/mapper/mongodb-databases'
+    govuk_lvm: 'databases'
+    mountoptions: 'defaults'
+  /var/lib/automongodbbackup:
+    disk: '/dev/mapper/backup-mongodb'
+    govuk_lvm: 'mongodb'
+    mountoptions: 'defaults'
+
+mongodb::server::replicaset_members:
+  'licensing-mongo-1':
+  'licensing-mongo-2':
+  'licensing-mongo-3':
+
+# Disable monthly backups to limit the retention of IL3 data.
+mongodb::backup::domonthly: false

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -880,6 +880,12 @@ hosts::production::licensify::hosts:
     ip: '10.5.0.14'
   licensing-backend-2:
     ip: '10.5.0.15'
+  licensing-mongo-1:
+    ip: '10.5.0.16'
+  licensing-mongo-2:
+    ip: '10.5.0.17'
+  licensing-mongo-3:
+    ip: '10.5.0.18'
 
 hosts::production::management::hosts:
   jenkins-1:

--- a/modules/govuk/manifests/node/s_licensing_mongo.pp
+++ b/modules/govuk/manifests/node/s_licensing_mongo.pp
@@ -1,0 +1,15 @@
+# == Class: govuk::node::s_licensing_mongo
+#
+# mongo node
+#
+class govuk::node::s_licensing_mongo inherits govuk::node::s_base {
+  include mongodb::server
+
+  collectd::plugin::tcpconn { 'mongo':
+    incoming => 27017,
+    outgoing => 27017,
+  }
+
+  Govuk_mount['/var/lib/mongodb'] -> Class['mongodb::server']
+  Govuk_mount['/var/lib/automongodbbackup'] -> Class['mongodb::backup']
+}

--- a/modules/mongodb/manifests/repository.pp
+++ b/modules/mongodb/manifests/repository.pp
@@ -25,6 +25,15 @@ class mongodb::repository(
       architecture => $::architecture,
       key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
     }
+
+    apt::source { 'mongodb3.2':
+      location     => "http://${apt_mirror_hostname}/mongodb3.2",
+      release      => 'trusty-mongodb-org-3.2',
+      repos        => 'multiverse',
+      architecture => $::architecture,
+      key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+    }
+
   } else {
     apt::source { 'mongodb':
       location => 'http://downloads-distro.mongodb.org/repo/ubuntu-upstart',


### PR DESCRIPTION
The new Licensing MongoDB servers are now just ordinary MongoDB nodes
because they no longer have encrypted drives. We're bringing up fresh
machines so we're creating a fresh class for them.