### PR TITLE
Add new wildcard_publishing certificate type

### DIFF
--- a/hieradata/development_credentials.yaml
+++ b/hieradata/development_credentials.yaml
@@ -47,7 +47,7 @@ sflg_key: |
 # This encrypted password was generated with `mkpasswd --method=sha-512` and a password of 'password'
 users::root_password_encrypted: '$6$gwBpG15Z0dCJ$.8BBgOp4zu6vOwxckV1RiQ73hz440NKY4TC/ViUELkDMhvfDfHyIiFg2guwKcmjsxd4AZLDz7Va3IUK4WCDn31'
 
-wildcard_alphagov_crt: |
+wildcard_publishing_certificate: |
     -----BEGIN CERTIFICATE-----
     MIID7TCCAtWgAwIBAgIJAMVuKOcew/ZlMA0GCSqGSIb3DQEBBQUAMFcxCzAJBgNV
     BAYTAkdCMSkwJwYDVQQKEyBHT1YuVUsgRGV2ZWxvcG1lbnQgKHNlbGYtc2lnbmVk
@@ -73,7 +73,7 @@ wildcard_alphagov_crt: |
     kQ==
     -----END CERTIFICATE-----
 
-wildcard_alphagov_key: |
+wildcard_publishing_key: |
     -----BEGIN RSA PRIVATE KEY-----
     MIIEpQIBAAKCAQEAtzWdoTKnLLE7rPf7xvFMdiQOc88BStmaXgpLQNi35KKCu2um
     ybPOlYoz+uSnrOinXS3v8iauhv1DZq5YbC3w5HcN+jJRFj6kGyZwI87qHS7pBKw3

--- a/hieradata/vagrant_credentials.yaml
+++ b/hieradata/vagrant_credentials.yaml
@@ -220,7 +220,7 @@ sflg_key: |
 # This encrypted password was generated with `mkpasswd --method=sha-512` and a password of 'password'
 users::root_password_encrypted: '$6$gwBpG15Z0dCJ$.8BBgOp4zu6vOwxckV1RiQ73hz440NKY4TC/ViUELkDMhvfDfHyIiFg2guwKcmjsxd4AZLDz7Va3IUK4WCDn31'
 
-wildcard_alphagov_crt: |
+wildcard_publishing_certificate: |
     -----BEGIN CERTIFICATE-----
     MIID7TCCAtWgAwIBAgIJAMVuKOcew/ZlMA0GCSqGSIb3DQEBBQUAMFcxCzAJBgNV
     BAYTAkdCMSkwJwYDVQQKEyBHT1YuVUsgRGV2ZWxvcG1lbnQgKHNlbGYtc2lnbmVk
@@ -246,7 +246,7 @@ wildcard_alphagov_crt: |
     kQ==
     -----END CERTIFICATE-----
 
-wildcard_alphagov_key: |
+wildcard_publishing_key: |
     -----BEGIN RSA PRIVATE KEY-----
     MIIEpQIBAAKCAQEAtzWdoTKnLLE7rPf7xvFMdiQOc88BStmaXgpLQNi35KKCu2um
     ybPOlYoz+uSnrOinXS3v8iauhv1DZq5YbC3w5HcN+jJRFj6kGyZwI87qHS7pBKw3

--- a/lib/puppet-lint/plugins/check_hiera.rb
+++ b/lib/puppet-lint/plugins/check_hiera.rb
@@ -47,8 +47,8 @@ PuppetLint.new_check(:hiera_explicit_lookup) do
     'nginx_enable_ssl',
     'sflg_certificate',
     'sflg_key',
-    'wildcard_alphagov_crt',
-    'wildcard_alphagov_key',
+    'wildcard_publishing_certificate',
+    'wildcard_publishing_key',
     'www_crt',
     'www_key',
   ]

--- a/modules/govuk/manifests/node/s_jenkins.pp
+++ b/modules/govuk/manifests/node/s_jenkins.pp
@@ -12,7 +12,7 @@ class govuk::node::s_jenkins inherits govuk::node::s_base {
   }
 
   nginx::config::ssl { 'jenkins':
-    certtype => 'wildcard_alphagov',
+    certtype => 'wildcard_publishing',
   }
 
   nginx::config::site { 'jenkins':

--- a/modules/govuk/manifests/node/s_monitoring.pp
+++ b/modules/govuk/manifests/node/s_monitoring.pp
@@ -28,7 +28,7 @@ class govuk::node::s_monitoring (
     to           => ['graphite.cluster'],
     aliases      => ['graphite.*', 'grafana', 'grafana.*'],
     ssl_only     => true,
-    ssl_certtype => 'wildcard_alphagov',
+    ssl_certtype => 'wildcard_publishing',
     protected    => false,
     root         => '/dev/null',
   }

--- a/modules/icinga/manifests/nginx.pp
+++ b/modules/icinga/manifests/nginx.pp
@@ -6,7 +6,7 @@ class icinga::nginx {
   include ::nginx
 
   nginx::config::ssl { 'nagios':
-    certtype => 'wildcard_alphagov',
+    certtype => 'wildcard_publishing',
   }
 
   nginx::config::site { 'nagios':

--- a/modules/licensify/manifests/apps/licensify.pp
+++ b/modules/licensify/manifests/apps/licensify.pp
@@ -26,7 +26,7 @@ class licensify::apps::licensify (
   $vhost_escaped = regsubst($vhost_name, '\.', '_', 'G')
   $counter_basename = "${::fqdn_metrics}.nginx_logs.${vhost_escaped}"
 
-  nginx::config::ssl { $vhost_name: certtype => 'wildcard_alphagov' }
+  nginx::config::ssl { $vhost_name: certtype => 'wildcard_publishing' }
   nginx::config::site { $vhost_name: content => template('licensify/licensify-upload-vhost.conf') }
   nginx::log {
     "${vhost_name}-json.event.access.log":

--- a/modules/loadbalancer/manifests/balance.pp
+++ b/modules/loadbalancer/manifests/balance.pp
@@ -64,7 +64,7 @@ define loadbalancer::balance(
   $vhost_real = "${vhost}.${vhost_suffix}"
 
   nginx::config::ssl { $vhost_real:
-    certtype => 'wildcard_alphagov',
+    certtype => 'wildcard_publishing',
   }
 
   nginx::config::site { $vhost_real:

--- a/modules/nginx/manifests/config/ssl.pp
+++ b/modules/nginx/manifests/config/ssl.pp
@@ -9,8 +9,9 @@
 #   Mandatory key used to lookup value from hiera. It performs no other
 #   magic. Permitted values:
 #
+#     - sflg
+#     - wildcard_publishing
 #     - www
-#     - wildcard_alphagov
 #
 define nginx::config::ssl( $certtype, $ensure = 'present' ) {
   case $certtype {
@@ -18,9 +19,9 @@ define nginx::config::ssl( $certtype, $ensure = 'present' ) {
         $cert = hiera('sflg_certificate', '')
         $key = hiera('sflg_key', '')
     }
-    'wildcard_alphagov': {
-        $cert = hiera('wildcard_alphagov_crt', '')
-        $key = hiera('wildcard_alphagov_key', '')
+    'wildcard_publishing': {
+        $cert = hiera('wildcard_publishing_certificate', '')
+        $key = hiera('wildcard_publishing_key', '')
     }
     'www': {
         $cert = hiera('www_crt', '')

--- a/modules/nginx/manifests/config/vhost/default.pp
+++ b/modules/nginx/manifests/config/vhost/default.pp
@@ -17,13 +17,13 @@
 #
 # [*ssl_certtype*]
 #   Type of SSL cert passed to nginx::config::ssl
-#   Default: wildcard_alphagov
+#   Default: wildcard_publishing
 #
 define nginx::config::vhost::default(
   $extra_config = '',
   $status = '500',
   $status_message = "'{\"error\": \"Fell through to default vhost\"}\\n'",
-  $ssl_certtype = 'wildcard_alphagov',
+  $ssl_certtype = 'wildcard_publishing',
 ) {
 
   # Whether to enable SSL. Used by template.

--- a/modules/nginx/manifests/config/vhost/proxy.pp
+++ b/modules/nginx/manifests/config/vhost/proxy.pp
@@ -53,7 +53,7 @@
 #
 # [*ssl_certtype*]
 #   Type of certificate from the predefined list in `nginx::config::ssl`.
-#   Default: 'wildcard_alphagov'
+#   Default: 'wildcard_publishing'
 #
 # [*hidden_paths*]
 #   Array of paths that nginx will force to return an error
@@ -90,7 +90,7 @@ define nginx::config::vhost::proxy(
   $ssl_only = false,
   $logstream = present,
   $is_default_vhost = false,
-  $ssl_certtype = 'wildcard_alphagov',
+  $ssl_certtype = 'wildcard_publishing',
   $hidden_paths = [],
   $single_page_app = false,
   $read_timeout = 15,

--- a/modules/nginx/manifests/config/vhost/redirect.pp
+++ b/modules/nginx/manifests/config/vhost/redirect.pp
@@ -13,9 +13,9 @@
 #
 # [*certtype*]
 #   The "type" of cert to use. See `nginx::config::ssl`.
-#   Default: wildcard_alphagov
+#   Default: wildcard_publishing
 #
-define nginx::config::vhost::redirect($to, $certtype = 'wildcard_alphagov') {
+define nginx::config::vhost::redirect($to, $certtype = 'wildcard_publishing') {
   nginx::config::site { $name:
     content => template('nginx/redirect-vhost.conf'),
   }

--- a/modules/nginx/spec/defines/nginx__config__vhost__proxy_spec.rb
+++ b/modules/nginx/spec/defines/nginx__config__vhost__proxy_spec.rb
@@ -111,7 +111,7 @@ describe 'nginx::config::vhost::proxy', :type => :define do
     end
   end
 
-  context 'with ssl_certtype wildcard_alphagov' do
+  context 'with ssl_certtype wildcard_publishing' do
     let(:params) do
       {
         :to => ['a.internal'],
@@ -119,7 +119,7 @@ describe 'nginx::config::vhost::proxy', :type => :define do
     end
 
     it {
-      is_expected.to contain_nginx__config__ssl('rabbit').with_certtype('wildcard_alphagov')
+      is_expected.to contain_nginx__config__ssl('rabbit').with_certtype('wildcard_publishing')
     }
   end
 

--- a/modules/nginx/spec/defines/nginx__config__vhost__redirect_spec.rb
+++ b/modules/nginx/spec/defines/nginx__config__vhost__redirect_spec.rb
@@ -15,7 +15,7 @@ describe 'nginx::config::vhost::redirect', :type => :define do
       :content => /^\s+rewrite \^\/\(\.\*\)\ https:\/\/mouse\.example\.com\/\$1 permanent;$/
     )}
     it { is_expected.to contain_nginx__config__ssl('gruffalo.example.com').with(
-      :certtype => 'wildcard_alphagov'
+      :certtype => 'wildcard_publishing'
     )}
   end
 end

--- a/modules/router/manifests/assets_origin.pp
+++ b/modules/router/manifests/assets_origin.pp
@@ -35,7 +35,7 @@ class router::assets_origin(
   }
 
   nginx::config::ssl { $vhost_name:
-    certtype => 'wildcard_alphagov',
+    certtype => 'wildcard_publishing',
   }
 
   nginx::log {

--- a/modules/router/manifests/nginx.pp
+++ b/modules/router/manifests/nginx.pp
@@ -64,7 +64,7 @@ class router::nginx (
   $app_domain = hiera('app_domain')
 
   nginx::config::ssl { "www.${app_domain}":
-    certtype => 'wildcard_alphagov',
+    certtype => 'wildcard_publishing',
   }
 
   nginx::config::ssl { 'www.gov.uk':


### PR DESCRIPTION
wildcard_alphagov is no longer accurate because we're not using the alphagov domain anymore.