### PR TITLE
Define redis url for whitehall

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -287,6 +287,9 @@ govuk::apps::frontend::nagios_memory_critical: 1400
 
 govuk::apps::govuk_cdn_logs_monitor::processed_data_dir: '/mnt/logs_cdn/data'
 
+govuk::apps::whitehall::redis_host: 'redis-1.backend'
+govuk::apps::whitehall::redis_port: '6379'
+
 govuk::apps::govuk_crawler_worker::airbrake_endpoint: "https://errbit.%{hiera('app_domain')}/notifier_api/v2/notices"
 govuk::apps::govuk_crawler_worker::airbrake_env: "%{hiera('govuk::deploy::config::errbit_environment_name')}"
 # FIXME: The API can be crawled when https://github.com/alphagov/govuk_crawler_worker/issues/97 is fixed.

--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -27,6 +27,8 @@ class govuk::apps::whitehall(
   $prevent_single_host = true,
   $enable_procfile_worker = true,
   $publishing_api_bearer_token = undef,
+  $redis_host = 'redis-1.backend',
+  $redis_port = '6379',
 ) {
 
   $app_domain = hiera('app_domain')


### PR DESCRIPTION
https://trello.com/c/JQREOuvh/424-use-sidekiq-gem

Define environment constants for whitehall, in order to configure the
govuk_sidekiq gem properly.