### PR TITLE
Add .pgpass file

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -229,6 +229,8 @@ govuk::node::s_whitehall_backend::sync_mirror: true
 
 govuk::node::s_transition_postgresql_slave::redirector_ip_range: '10.1.5.0/24'
 
+govuk_postgresql::server::standby::pgpassfile_enabled: true
+
 govuk_sudo::sudo_conf:
   deploy_service_postgresql:
     content: 'deploy ALL=NOPASSWD:/etc/init.d/postgresql'

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -153,6 +153,8 @@ govuk::node::s_monitoring::offsite_backups: false
 govuk::node::s_mysql_master::s3_bucket_name: 'govuk-mysql-xtrabackups-staging'
 govuk::node::s_transition_postgresql_slave::redirector_ip_range: '10.2.5.0/24'
 
+govuk_postgresql::server::standby::pgpassfile_enabled: true
+
 govuk_sudo::sudo_conf:
   deploy_service_postgresql:
     content: 'deploy ALL=NOPASSWD:/etc/init.d/postgresql'


### PR DESCRIPTION
I think this will be a controversial change. Essentially it means when we run
`pg_resync_slave` we won't have to enter a password. This would allow auto resync
of slaves after [running the environment sync from S3]
(https://github.com/alphagov/govuk-puppet/blob/master/modules/govuk_postgresql/manifests/wal_e/env_sync.pp).

This creates a pgpass file that reads in a password so batch that resync
data from a primary to a standby does not prompt for a password.

Ref: https://www.postgresql.org/docs/current/static/libpq-pgpass.html