### PR TITLE
Move out search analytics script to own repo

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/search_fetch_analytics_data.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/search_fetch_analytics_data.yaml.erb
@@ -24,17 +24,7 @@
       - search-analytics_search-fetch-analytics-data
     builders:
         - shell: |
-            if [ \! -d ENV ]; then virtualenv ENV; fi
-            . ENV/bin/activate
-            pip install -r requirements.txt
-            rm -f page-traffic.dump
-            PYTHONPATH=. python scripts/fetch.py page-traffic.dump 14
-            ssh deploy@search-1.api '(cd /var/apps/rummager; govuk_setenv rummager bundle exec ./bin/bulk_load page-traffic)' < page-traffic.dump
-            ssh deploy@search-1.api '(cd /var/apps/rummager; RUMMAGER_INDEX=mainstream govuk_setenv rummager bundle exec rake rummager:migrate_index)'
-            ssh deploy@search-1.api '(cd /var/apps/rummager; RUMMAGER_INDEX=detailed govuk_setenv rummager bundle exec rake rummager:migrate_index)'
-            ssh deploy@search-1.api '(cd /var/apps/rummager; RUMMAGER_INDEX=government govuk_setenv rummager bundle exec rake rummager:migrate_index)'
-            ssh deploy@search-1.api '(cd /var/apps/rummager; RUMMAGER_INDEX=service-manual govuk_setenv rummager bundle exec rake rummager:migrate_index)'
-            ssh deploy@search-1.api '(cd /var/apps/rummager; RUMMAGER_INDEX=all govuk_setenv rummager bundle exec rake rummager:clean)'
+          ./nightly-run.sh
     triggers:
         - timed: '5 4 * * *'
     publishers:


### PR DESCRIPTION
This script is easier changeable if it lives in the search-analytics
repo.

Added here: https://github.com/alphagov/search-analytics/pull/7

https://trello.com/c/kAm186hM