### PR TITLE
Correct indentation in jenkins job yaml

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/whitehall_run_broken_link_checker.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/whitehall_run_broken_link_checker.yaml.erb
@@ -18,15 +18,15 @@
             recipients: govuk-ci-notifications@digital.cabinet-office.gov.uk
         - trigger-parameterized-builds:
             - project: success_passive_check
-                condition: 'SUCCESS'
-                predefined-parameters: |
-                    NSCA_CHECK_DESCRIPTION=<%= @service_description %>
-                    NSCA_OUTPUT=<%= @service_description %> successful
+              condition: 'SUCCESS'
+              predefined-parameters: |
+                  NSCA_CHECK_DESCRIPTION=<%= @service_description %>
+                  NSCA_OUTPUT=<%= @service_description %> successful
             - project: failure_passive_check
-                condition: 'FAILED'
-                predefined-parameters: |
-                    NSCA_CHECK_DESCRIPTION=<%= @service_description %>
-                    NSCA_OUTPUT=<%= @service_description %> failed
+              condition: 'FAILED'
+              predefined-parameters: |
+                  NSCA_CHECK_DESCRIPTION=<%= @service_description %>
+                  NSCA_OUTPUT=<%= @service_description %> failed
     logrotate:
         artifactNumToKeep: 10
 


### PR DESCRIPTION
Currently puppet can't apply this configuration because the yaml parser
throws an exception:

     yaml.scanner.ScannerError: mapping values are not allowed here