### PR TITLE
[DO NOT MERGE] Use govuk_node_list to get a list of servers

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -203,9 +203,6 @@ govuk::node::s_frontend_lb::performance_frontend_servers:
 govuk::node::s_frontend_lb::performance_frontend_apps:
   - 'spotlight'
   - 'performanceplatform-big-screen-view'
-govuk::node::s_frontend_lb::whitehall_frontend_servers:
-  - 'whitehall-frontend-1.frontend'
-  - 'whitehall-frontend-2.frontend'
 govuk::node::s_logs_elasticsearch::rotate_hour: 06
 govuk::node::s_logs_elasticsearch::rotate_minute: 00
 govuk::node::s_licensify_backend::java8: true

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -182,14 +182,6 @@ govuk::node::s_frontend_lb::performance_frontend_servers:
 govuk::node::s_frontend_lb::performance_frontend_apps:
   - 'spotlight'
   - 'performanceplatform-big-screen-view'
-govuk::node::s_frontend_lb::whitehall_frontend_servers:
-  - 'whitehall-frontend-1.frontend'
-  - 'whitehall-frontend-2.frontend'
-  - 'whitehall-frontend-3.frontend'
-  - 'whitehall-frontend-4.frontend'
-  - 'whitehall-frontend-5.frontend'
-  - 'whitehall-frontend-6.frontend'
-  - 'whitehall-frontend-7.frontend'
 govuk::node::s_licensify_lb::licensify_backend_servers:
   - 'licensify-backend-1.licensify'
   - 'licensify-backend-2.licensify'

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -139,14 +139,6 @@ govuk::node::s_frontend_lb::performance_frontend_servers:
 govuk::node::s_frontend_lb::performance_frontend_apps:
   - 'spotlight'
   - 'performanceplatform-big-screen-view'
-govuk::node::s_frontend_lb::whitehall_frontend_servers:
-  - 'whitehall-frontend-1.frontend'
-  - 'whitehall-frontend-2.frontend'
-  - 'whitehall-frontend-3.frontend'
-  - 'whitehall-frontend-4.frontend'
-  - 'whitehall-frontend-5.frontend'
-  - 'whitehall-frontend-6.frontend'
-  - 'whitehall-frontend-7.frontend'
 govuk::node::s_licensify_lb::licensify_backend_servers:
   - 'licensify-backend-1.licensify'
   - 'licensify-backend-2.licensify'

--- a/hieradata/vagrant.yaml
+++ b/hieradata/vagrant.yaml
@@ -83,9 +83,6 @@ govuk::node::s_frontend_lb::email_campaign_frontend_servers:
 govuk::node::s_frontend_lb::frontend_servers:
   - 'frontend-1.frontend'
   - 'frontend-2.frontend'
-govuk::node::s_frontend_lb::whitehall_frontend_servers:
-  - 'whitehall-frontend-1.frontend'
-  - 'whitehall-frontend-2.frontend'
 govuk::node::s_licensify_lb::licensify_backend_servers:
   - 'licensify-backend-1.licensify'
   - 'licensify-backend-2.licensify'

--- a/modules/govuk/manifests/node/s_frontend_lb.pp
+++ b/modules/govuk/manifests/node/s_frontend_lb.pp
@@ -5,11 +5,12 @@ class govuk::node::s_frontend_lb (
   $draft_frontend_servers,
   $email_campaign_frontend_servers,
   $frontend_servers,
-  $whitehall_frontend_servers,
   $hide_frontend_apps = true,
   $performance_frontend_apps = [],
   $performance_frontend_servers = [],
 ){
+  $whitehall_frontend_servers = split(generate('/usr/local/bin/govuk_node_list', '-c', 'whitehall_frontend'), '\n')
+
   include govuk::node::s_base
   include loadbalancer
 


### PR DESCRIPTION
This avoids us having to specify all of our machines. It does increase the dependency on PuppetDB though (especially in the case of Vagrant) but I think the trade-off is worth it.

Opening for comment: I'd like some opinions on whether this is a good idea or not.