### PR TITLE
Fix the release name for grafana

### DIFF
--- a/modules/grafana/manifests/repo.pp
+++ b/modules/grafana/manifests/repo.pp
@@ -10,7 +10,7 @@ class grafana::repo (
 ) {
   apt::source { 'grafana':
     location     => "http://${apt_mirror_hostname}/grafana",
-    release      => 'main',
+    release      => 'jessie',
     architecture => $::architecture,
     key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
   }


### PR DESCRIPTION
https://trello.com/c/qPIJoZIV/728-publishing-api-metrics-making-visible
According to the puppet apt module docs:

```
release: Specifies a distribution of the Apt repository.
repos: Specifies a component of the Apt repository. Valid options: a string. Default: 'main'.
```

So release should be 'jessie'