### PR TITLE
Add publishing api content item count to collectd...

### DIFF
--- a/modules/collectd/templates/etc/collectd/conf.d/postgresql.conf.erb
+++ b/modules/collectd/templates/etc/collectd/conf.d/postgresql.conf.erb
@@ -37,6 +37,16 @@ LoadPlugin postgresql
     </Result>
   </Query>
 
+  <Query publishing_api_content_item_count>
+    Statement "SELECT count(*) AS count \
+               FROM content_items;"
+
+    <Result>
+      Type counter
+      ValuesFrom "count"
+    </Result>
+  </Query>
+
   <Database postgres>
     Instance "global"
     Host "localhost"
@@ -55,5 +65,13 @@ LoadPlugin postgresql
     SSLMode "prefer"
     # By not specifying a specific query, we pull in the defaults
     # which are specific to the `postgres` database
+  </Database>
+
+  <Database publishing_api_production>
+    Host "localhost"
+    User "<%= @user %>"
+    Password "<%= @password %>"
+    SSLMode "prefer"
+    Query publishing_api_content_item_count
   </Database>
 </Plugin>


### PR DESCRIPTION
https://trello.com/c/qPIJoZIV/728-publishing-api-metrics-making-visible

We'd like to have a collectd count to highlight content growth in the publishing api, so add a query and database config to handle this.

/cc @boffbowsh I think this addresses your earlier comment on https://github.com/alphagov/govuk-puppet/pull/4603, I couldn't revive that PR because of the force push.