### PR TITLE
Remove www-origin-staging from nginx

### DIFF
--- a/modules/router/templates/base.conf.erb
+++ b/modules/router/templates/base.conf.erb
@@ -21,8 +21,7 @@ server {
 }
 
 server {
-  # www-origin-staging.<appdomain> is necessary as a target for Gor from Production
-  server_name         www.<%= @app_domain %> www-origin.<%= @app_domain %> draft-origin.<%= @app_domain %> www-origin-staging.<%= @app_domain %>;
+  server_name         www.<%= @app_domain %> www-origin.<%= @app_domain %> draft-origin.<%= @app_domain %>;
   listen              443 ssl;
   ssl_certificate     /etc/nginx/ssl/www.<%= @app_domain %>.crt;
   ssl_certificate_key /etc/nginx/ssl/www.<%= @app_domain %>.key;


### PR DESCRIPTION
Gor doesn't send traffic to this hostname anymore so it's completely unused. There's no need to keep it in our nginx config.