### PR TITLE
Fix directory which is declared twice

### DIFF
--- a/modules/mongodb/manifests/s3backup/backup.pp
+++ b/modules/mongodb/manifests/s3backup/backup.pp
@@ -104,13 +104,6 @@ class mongodb::s3backup::backup(
     mode    => '0640',
   }
 
-  file { '/var/lib/s3backup':
-    ensure => directory,
-    owner  => $user,
-    group  => $user,
-    mode   => '0775',
-  }
-
   # push script
   file { '/usr/local/bin/mongodb-backup-s3':
     ensure  => present,


### PR DESCRIPTION
I think this got muddled up in a rebase. It's causing Puppet to throw an
error and consequently causing new Mongo machines to fail when I create
them.