### PR TITLE
Proxy requests for grafana

### DIFF
--- a/modules/grafana/files/grafana.ini
+++ b/modules/grafana/files/grafana.ini
@@ -30,7 +30,7 @@
 ;http_addr =
 
 # The http port  to use
-;http_port = 3000
+http_port = 3204
 
 # The public facing domain name used to access grafana from a browser
 ;domain = localhost

--- a/modules/grafana/files/vhost.conf
+++ b/modules/grafana/files/vhost.conf
@@ -1,3 +1,7 @@
+upstream grafana.gov.uk-proxy {
+  server localhost:3204;
+}
+
 server {
   server_name grafana.*;
   root /usr/share/grafana;
@@ -8,5 +12,11 @@ server {
 
   location /app/dashboards/ {
     alias /etc/grafana/dashboards/;
+
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header Host $http_host;
+    proxy_redirect off;
+
+    proxy_pass http://grafana.gov.uk-proxy;
   }
 }


### PR DESCRIPTION
https://trello.com/c/qPIJoZIV/728-publishing-api-metrics-making-visible

Grafana 3 is a service with a web UI configured to use port 3204.
Configure nginx vhost to proxy requests to localhost on this port.