### PR TITLE
Ensure mongo service name is correct

### DIFF
--- a/hieradata/class/licensing_mongo.yaml
+++ b/hieradata/class/licensing_mongo.yaml
@@ -37,5 +37,4 @@ mongodb::server::replicaset_members:
 # Disable monthly backups to limit the retention of IL3 data.
 mongodb::backup::domonthly: false
 
-mongodb::server::package_name: 'mongodb-org'
 mongodb::server::version: '3.2.7'

--- a/modules/mongodb/manifests/server.pp
+++ b/modules/mongodb/manifests/server.pp
@@ -23,12 +23,20 @@
 #
 class mongodb::server (
   $version,
-  $package_name = 'mongodb-10gen',
   $dbpath = '/var/lib/mongodb',
   $oplog_size = undef,
   $replicaset_members = {},
   $development = false,
 ) {
+
+  if versioncmp($version, '3.0.0') >= 0 {
+    $service_name = 'mongod'
+    $package_name = 'mongodb-org'
+  } else {
+    $service_name = 'mongodb'
+    $package_name = 'mongodb-10gen'
+  }
+
   validate_bool($development)
   validate_hash($replicaset_members)
   if empty($replicaset_members) {
@@ -87,7 +95,8 @@ class mongodb::server (
   }
 
   class { 'mongodb::service':
-    require => Class['mongodb::logging'],
+    service_name => $service_name,
+    require      => Class['mongodb::logging'],
   }
 
   class { 'mongodb::monitoring':

--- a/modules/mongodb/manifests/service.pp
+++ b/modules/mongodb/manifests/service.pp
@@ -1,7 +1,18 @@
-# FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
-class mongodb::service {
+# == Class: Mongodb::Service
+#
+# Manages the MongoDB service
+#
+# === Parameters
+#
+# [*service_name*]
+# Name of the MongoDB service. In 2.x, this is 'mongodb', and in 3.x this is
+# 'mongod'.
+#
+class mongodb::service (
+  $service_name = 'mongodb',
+) {
 
-  service { 'mongodb':
+  service { $service_name:
     ensure     => running,
     hasrestart => true,
     hasstatus  => true,

--- a/modules/mongodb/spec/classes/mongodb_spec.rb
+++ b/modules/mongodb/spec/classes/mongodb_spec.rb
@@ -16,23 +16,21 @@ describe 'mongodb::server', :type => :class do
     end
   end
 
-  describe "overriding the package name" do
+  describe "with package version > 3" do
     let(:params) { {
-      'version' => '2.0.7',
-      'package_name' => 'mongodb20-10gen',
+      'version' => '3.2.7',
       'replicaset_members' => {'mongo-box-1' => {}},
-    } }
-
+     } }
     it do
-      is_expected.to contain_package('mongodb20-10gen').with_ensure('2.0.7')
+      is_expected.to contain_package('mongodb-org').with_ensure('3.2.7')
       is_expected.to contain_file('/etc/mongodb.conf')
+      is_expected.to contain_class('mongodb::service').with_service_name('mongod')
     end
   end
 
   describe "not setting the replica set members" do
     let(:params) { {
       'version' => '2.0.7',
-      'package_name' => 'mongodb20-10gen',
     } }
 
     it do
@@ -43,7 +41,6 @@ describe 'mongodb::server', :type => :class do
   describe "replica set can have one member" do
     let(:params) { {
       'version' => '2.0.7',
-      'package_name' => 'mongodb20-10gen',
       'replicaset_members' => {'mongo-box-1' => {}},
     } }
 
@@ -56,7 +53,6 @@ describe 'mongodb::server', :type => :class do
   describe "setting three replica set members" do
     let(:params) { {
       'version' => '2.0.7',
-      'package_name' => 'mongodb20-10gen',
       'replicaset_members' => {
         'mongo-box-1' => {},
         'mongo-box-2' => {},
@@ -79,7 +75,6 @@ describe 'mongodb::server', :type => :class do
     let(:params) {{
       'version' => '2.0.7',
       'oplog_size' => '1234',
-      'package_name' => 'mongodb20-10gen',
       'replicaset_members' => {'mongo-box-1' => {}},
     }}
 


### PR DESCRIPTION
In later versions of MongoDB (3.x), and in the package we're installing
from specifically, the upstart service name has changed to 'mongod' from
'mongodb'. This causes a few problems in Puppet for dependencies, so as
a plaster before we upgrade fully to mongo 3 just specify the service
name.