### PR TITLE
Tweak bouncer minimum request rate for DR nodes

### DIFF
--- a/hieradata/node/bouncer-4.redirector.publishing.service.gov.uk.yaml
+++ b/hieradata/node/bouncer-4.redirector.publishing.service.gov.uk.yaml
@@ -1,3 +1,5 @@
 govuk::apps::bouncer::db_hostname: "transition-postgresql-slave-2.backend"
 
+govuk::node::s_bouncer::minimum_request_rate: 2
+
 icinga::client::check_cputype::cputype: 'amd'

--- a/hieradata/node/bouncer-4.redirector.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/bouncer-4.redirector.staging.publishing.service.gov.uk.yaml
@@ -1,3 +1,5 @@
 govuk::apps::bouncer::db_hostname: "transition-postgresql-slave-2.backend"
 
+govuk::node::s_bouncer::minimum_request_rate: 2
+
 icinga::client::check_cputype::cputype: 'amd'

--- a/hieradata/node/bouncer-5.redirector.publishing.service.gov.uk.yaml
+++ b/hieradata/node/bouncer-5.redirector.publishing.service.gov.uk.yaml
@@ -1,3 +1,5 @@
 govuk::apps::bouncer::db_hostname: "transition-postgresql-slave-2.backend"
 
+govuk::node::s_bouncer::minimum_request_rate: 2
+
 icinga::client::check_cputype::cputype: 'amd'

--- a/hieradata/node/bouncer-5.redirector.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/bouncer-5.redirector.staging.publishing.service.gov.uk.yaml
@@ -1,3 +1,5 @@
 govuk::apps::bouncer::db_hostname: "transition-postgresql-slave-2.backend"
 
+govuk::node::s_bouncer::minimum_request_rate: 2
+
 icinga::client::check_cputype::cputype: 'amd'

--- a/hieradata/node/bouncer-6.redirector.publishing.service.gov.uk.yaml
+++ b/hieradata/node/bouncer-6.redirector.publishing.service.gov.uk.yaml
@@ -1,3 +1,5 @@
 govuk::apps::bouncer::db_hostname: "transition-postgresql-slave-2.backend"
 
+govuk::node::s_bouncer::minimum_request_rate: 2
+
 icinga::client::check_cputype::cputype: 'amd'

--- a/hieradata/node/bouncer-6.redirector.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/bouncer-6.redirector.staging.publishing.service.gov.uk.yaml
@@ -1,3 +1,5 @@
 govuk::apps::bouncer::db_hostname: "transition-postgresql-slave-2.backend"
 
+govuk::node::s_bouncer::minimum_request_rate: 2
+
 icinga::client::check_cputype::cputype: 'amd'


### PR DESCRIPTION
Our disaster recovery nodes don't normally receive very much traffic.