### PR TITLE
Add opsmanual notes for elasticsearch check

### DIFF
--- a/modules/govuk/manifests/node/s_logs_elasticsearch.pp
+++ b/modules/govuk/manifests/node/s_logs_elasticsearch.pp
@@ -91,6 +91,7 @@ class govuk::node::s_logs_elasticsearch(
     warning   => '0.000001:',
     desc      => 'elasticsearch not receiving syslog from logstash',
     host_name => $::fqdn,
+    notes_url => monitoring_docs_url(elasticsearch-not-receiving-syslog-from-logstash-check),
   }
 
   Govuk_mount['/mnt/elasticsearch'] -> Class['govuk_elasticsearch']


### PR DESCRIPTION
Adds a link to instructions in the opsmanual for restarting `logstash`