### PR TITLE
Make RAIB live for Specialist Publisher Rebuild

### DIFF
--- a/modules/govuk/manifests/node/s_backend_lb.pp
+++ b/modules/govuk/manifests/node/s_backend_lb.pp
@@ -55,6 +55,9 @@ class govuk::node::s_backend_lb (
         '/preview'             => {
           'app' => 'specialist-publisher-rebuild',
         },
+        '/raib-reports'        => {
+          'app' => 'specialist-publisher-rebuild',
+        },
       },
       servers => $backend_servers;
     [


### PR DESCRIPTION
This routes requests to /raib-reports to the rebuilt
application rather than being handled by the existing
V1 application.