### PR TITLE
Fix name of Kibana app

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -42,7 +42,7 @@ deployable_applications: &deployable_applications
   - hmrc-manuals-api
   - imminence
   - info-frontend
-  - kibana-gds
+  - kibana
   - licencefinder
   - local-links-manager
   - manuals-frontend


### PR DESCRIPTION
We deploy this app as kibana but the repo is called kibana-gds which is where the confusion comes from.