### PR TITLE
Add an explicit architecture.

### DIFF
--- a/modules/govuk_gor/manifests/init.pp
+++ b/modules/govuk_gor/manifests/init.pp
@@ -24,8 +24,9 @@ class govuk_gor(
 ) {
 
   apt::source { 'gor':
-    location => "http://${apt_mirror_hostname}/gor",
-    key      => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+    location     => "http://${apt_mirror_hostname}/gor",
+    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+    architecture => $::architecture,
   }
 
   validate_bool($enable)


### PR DESCRIPTION
We only mirror the 64bit version and without this apt updates
will complain and break on the lack of i386 files.