### PR TITLE
Make mongo config a class param.

### DIFF
--- a/modules/mongodb/manifests/config.pp
+++ b/modules/mongodb/manifests/config.pp
@@ -4,7 +4,9 @@
 #
 # === Parameters:
 #
-# [*dbpath*]
+# [*config_filename*]
+#   The config file mongo should use. This varies between mongo 2 and 3.
+#
 # [*dbpath*]
 #
 # [*development*]
@@ -23,6 +25,7 @@
 #   case it is set to 'development'.
 #
 class mongodb::config (
+  $config_filename = '/etc/mongodb.conf',
   $dbpath = '/var/lib/mongodb',
   $development,
   $oplog_size = undef,
@@ -32,7 +35,7 @@ class mongodb::config (
 
   # Class params are used in the templates below.
 
-  file { '/etc/mongodb.conf':
+  file { $config_filename:
     ensure  => present,
     content => template('mongodb/mongodb.conf'),
     owner   => 'root',

--- a/modules/mongodb/manifests/server.pp
+++ b/modules/mongodb/manifests/server.pp
@@ -32,9 +32,11 @@ class mongodb::server (
   if versioncmp($version, '3.0.0') >= 0 {
     $service_name = 'mongod'
     $package_name = 'mongodb-org'
+    $config_filename = '/etc/mongod.conf'
   } else {
     $service_name = 'mongodb'
     $package_name = 'mongodb-10gen'
+    $config_filename = '/etc/mongodb.conf'
   }
 
   validate_bool($development)
@@ -72,6 +74,7 @@ class mongodb::server (
   }
 
   class { 'mongodb::config':
+    config_filename => $config_filename,
     dbpath          => $dbpath,
     development     => $development,
     oplog_size      => $oplog_size,

--- a/modules/mongodb/spec/classes/mongodb_spec.rb
+++ b/modules/mongodb/spec/classes/mongodb_spec.rb
@@ -23,7 +23,7 @@ describe 'mongodb::server', :type => :class do
      } }
     it do
       is_expected.to contain_package('mongodb-org').with_ensure('3.2.7')
-      is_expected.to contain_file('/etc/mongodb.conf')
+      is_expected.to contain_file('/etc/mongod.conf')
       is_expected.to contain_class('mongodb::service').with_service_name('mongod')
     end
   end


### PR DESCRIPTION
There is a difference in configuration filename between mongo 2 and 3.
This change lets you specify the one you want, although they both get
populated from the same template for now.