### PR TITLE
Remove the line continuation character

### DIFF
--- a/modules/mongodb/manifests/s3backup/cron.pp
+++ b/modules/mongodb/manifests/s3backup/cron.pp
@@ -17,15 +17,13 @@ class mongodb::s3backup::cron(
   require mongodb::s3backup::backup
 
   cron { 'mongodb-s3backup':
-    command => '/usr/bin/setlock -n /var/lock/mongodb-s3backup \
-    /usr/local/bin/mongodb-backup-s3',
+    command => '/usr/bin/setlock -n /var/lock/mongodb-s3backup /usr/local/bin/mongodb-backup-s3',
     user    => $user,
     minute  => '*/15',
   }
 
   cron { 'mongodb-s3-night-backup':
-    command => '/usr/bin/setlock /var/lock/mongodb-s3backup \
-    /usr/local/bin/mongodb-backup-s3 daily',
+    command => '/usr/bin/setlock /var/lock/mongodb-s3backup /usr/local/bin/mongodb-backup-s3 daily',
     user    => $user,
     hour    => '0',
     minute  => '0',


### PR DESCRIPTION
Puppet doesn't like resources declared in this way. It throws a
```
"-":6: bad minute
errors in crontab file, can't install.

Error.
```