### PR TITLE
Fix mongodb s3 backup Cron

### DIFF
--- a/modules/mongodb/manifests/s3backup/backup.pp
+++ b/modules/mongodb/manifests/s3backup/backup.pp
@@ -1,4 +1,3 @@
-# FIXME  Once deployed please remove user and file references that ensure absent
 # == Class: mongodb::s3backup::backup
 #
 # Backup a MongoDB server to AWS S3
@@ -6,8 +5,10 @@
 # === Parameters:
 #
 # [*aws_access_key_id*]
+#   AWS access key
 #
 # [*aws_secret_access_key*]
+#   AWS secret access key
 #
 # [*aws_region*]
 #   AWS region for the S3 bucket
@@ -42,6 +43,10 @@
 #   will be uploaded. It should be created by the
 #   user
 #
+# [*s3_bucket_daily*]
+#   Defines the AWS S3 bucket where the backups
+#   will be uploaded on a daily basis
+#
 # [*user*]
 #   Defines the system user that will be created
 #   to run the backups
@@ -65,9 +70,6 @@ class mongodb::s3backup::backup(
 
   validate_re($private_gpg_key_fingerprint, '^[[:alnum:]]{40}$', 'Must supply full GPG fingerprint')
 
-  user { 'govuk-backups':
-    ensure => absent,
-  }
 
   file { $backup_dir:
     ensure => directory,
@@ -114,9 +116,6 @@ class mongodb::s3backup::backup(
     require => User[$user],
   }
 
-  file { '/usr/local/bin/mongodb-backup-s3-wrapper':
-    ensure => absent,
-  }
 
   # push gpg key
   file { "/home/${user}/.gnupg":

--- a/modules/mongodb/manifests/s3backup/cron.pp
+++ b/modules/mongodb/manifests/s3backup/cron.pp
@@ -1,3 +1,5 @@
+# FIXME Remove lines 34 to 37 after this has been deployed
+#
 # == Class: mongodb::s3backup::cron
 #
 # Runs a backup of MongoDB to Amazon S3 as a cron job.
@@ -5,8 +7,6 @@
 # [*user*]
 #   The user to run the cronjob as.
 #
-# [*backup_dir*]
-#   The directory where backups are managed
 #
 class mongodb::s3backup::cron(
   $user = 'govuk-backup',
@@ -16,19 +16,21 @@ class mongodb::s3backup::cron(
   require mongodb::s3backup::package
   require mongodb::s3backup::backup
 
-  cron { 'mongodb-s3backup':
-    command => '/usr/bin/setlock -n /var/lock/mongodb-s3backup \
-    /usr/local/bin/mongodb-backup-s3',
+  cron { 'mongodb-s3backup-realtime':
+    command => '/usr/bin/setlock -n /var/lock/mongodb-s3backup /usr/local/bin/mongodb-backup-s3',
     user    => $user,
     minute  => '*/15',
   }
 
   cron { 'mongodb-s3-night-backup':
-    command => '/usr/bin/setlock /var/lock/mongodb-s3backup \
-    /usr/local/bin/mongodb-backup-s3 daily',
+    command => '/usr/bin/setlock /var/lock/mongodb-s3backup /usr/local/bin/mongodb-backup-s3 daily',
     user    => $user,
     hour    => '0',
     minute  => '0',
   }
 
+  cron { 'mongodb-s3backup':
+    ensure => absent,
+    user   => root,
+  }
 }

--- a/modules/mongodb/templates/mongodb-backup-s3.erb
+++ b/modules/mongodb/templates/mongodb-backup-s3.erb
@@ -49,6 +49,11 @@ printf "BACKUP UPLOADED IN: ${TIME}s\n"
 # Tidy up
 /bin/rm -f $BACKUP_DIR/mongodump-*
 
+if [ $? == 0 ]; then
+  STATUS=0
+else
+  STATUS=1
+fi
 
 if [ $STATUS -eq 0 ]; then
 NAGIOS_CODE=0


### PR DESCRIPTION
Two things:

Puppet fails to create cron job due to line continuation in command.
Deleting backup job from root's crontab


- Created a cron resource and marked it as absent to remove previously managed jobs.
- Removed backslash for two of the cron jobs as these were causing things to fail.
- Added conditional for $STATUS variable to the backup script.

Removing absent resource declarations and FIXME message in backup.pp.