### PR TITLE
Backup Elasticsearch indices

### DIFF
--- a/hieradata/node/elasticsearch-1.backend.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/elasticsearch-1.backend.integration.publishing.service.gov.uk.yaml
@@ -1,0 +1,6 @@
+---
+govuk_elasticsearch::backup_enabled: true
+govuk_elasticsearch::backup::s3_bucket: 'elasticsearch'
+govuk_elasticsearch::backup::es_repo: 'snapshots'
+govuk_elasticsearch::backup::es_indices:
+  - kibana_int

--- a/hieradata/node/logs-elasticsearch-1.management.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/logs-elasticsearch-1.management.integration.publishing.service.gov.uk.yaml
@@ -1,0 +1,6 @@
+---
+govuk_elasticsearch::backup_enabled: true
+govuk_elasticsearch::backup::s3_bucket: 'logs-elasticsearch'
+govuk_elasticsearch::backup::es_repo: 'snapshots'
+govuk_elasticsearch::backup::es_indices:
+  - kibana_int

--- a/modules/govuk_elasticsearch/manifests/backup.pp
+++ b/modules/govuk_elasticsearch/manifests/backup.pp
@@ -1,0 +1,114 @@
+# == Class: govuk_elasticsearch::backup
+#
+# GOV.UK specific class to backup elasticsearch indexes.
+#
+# === Parameters
+#
+# [*aws_access_key_id*]
+#   AWS key to authenticate requests
+#
+# [*aws_secret_access_key*]
+#   AWS key to authenticate requests
+#
+# [*aws_region*]
+#   AWS region for the S3 bucket
+#
+# [*env_dir*]
+#   Defines directory for the environment
+#   variables
+#
+# [*s3_bucket*]
+#   Defines the AWS S3 bucket where the backups
+#   will be uploaded. It should be created by the
+#   user
+#
+# [*user*]
+#   Defines the system user that will be created
+#   to run the backups
+#
+# [*es_repos*]
+#   The repositories within elasticsearch
+#   where backups will be stored
+#
+# [*es_indices*]
+#   Elaticsearch indexes
+#
+# === Variables
+#
+# [*json_es_indices*]
+#   Formatted indexes to be backed up when script is invoked
+#
+class govuk_elasticsearch::backup(
+  $aws_access_key_id = undef,
+  $aws_secret_access_key = undef,
+  $aws_region = 'eu-west-1',
+  $s3_bucket = undef,
+  $env_dir = '/etc/es_s3backup',
+  $user = 'govuk-backup',
+  $es_repo = undef,
+  $es_indices = []
+){
+
+
+    $threshold_secs = 28 * 3600
+    $service_desc = 'Elasticsearch-Index_Backup'
+    $json_es_indices = join(regsubst($es_indices, '(.*)', '"\1"'), ',')
+
+    include ::backup::client
+#   FIXME This include will cause tests to fail until the PR for housekeeping is merged
+    #include govuk_elasticsearch::housekeeping
+
+
+    # push env files
+    file { [$env_dir,"${env_dir}/env.d"]:
+      ensure => directory,
+      owner  => $user,
+      group  => $user,
+      mode   => '0750',
+    }
+
+    file { "${env_dir}/env.d/AWS_SECRET_ACCESS_KEY":
+      content => $aws_secret_access_key,
+      owner   => $user,
+      group   => $user,
+      mode    => '0640',
+    }
+
+    file { "${env_dir}/env.d/AWS_ACCESS_KEY_ID":
+      content => $aws_access_key_id,
+      owner   => $user,
+      group   => $user,
+      mode    => '0640',
+    }
+
+    file { "${env_dir}/env.d/AWS_REGION":
+      content => $aws_region,
+      owner   => $user,
+      group   => $user,
+      mode    => '0640',
+    }
+
+    @@icinga::passive_check { "check_esindexbackup-${::hostname}":
+      service_description => $service_desc,
+      freshness_threshold => $threshold_secs,
+      host_name           => $::fqdn,
+    }
+
+    file { 'es-backup-s3':
+      path    => '/usr/local/bin/es-backup-s3',
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0755',
+      content => template('govuk_elasticsearch/es-backup-s3.erb'),
+    }
+
+
+    cron { 's3-elasticsearch-indexes':
+      ensure  => present,
+      command => '/usr/local/bin/es-backup-s3',
+      user    => $user,
+      hour    => 0,
+      minute  => 0,
+    }
+
+}

--- a/modules/govuk_elasticsearch/manifests/init.pp
+++ b/modules/govuk_elasticsearch/manifests/init.pp
@@ -22,6 +22,9 @@
 #   specific machines.
 #   Default: true
 #
+# [*backup_enabled*]
+#   Boolean. Whether backup class will be included.
+#
 class govuk_elasticsearch (
   $version,
   $cluster_hosts = ['localhost'],
@@ -36,6 +39,7 @@ class govuk_elasticsearch (
   $disable_gc_alerts = false,
   $manage_repo = true,
   $open_firewall_from_all = true,
+  $backup_enabled = false
 ) {
 
   validate_re($version, '^\d+\.\d+\.\d+$', 'govuk_elasticsearch::version must be in the form x.y.z')
@@ -142,5 +146,8 @@ class govuk_elasticsearch (
   include govuk_elasticsearch::estools
   include govuk_elasticsearch::plugins
 
+  if $backup_enabled {
+    include govuk_elasticsearch::backup
+  }
   anchor { 'govuk_elasticsearch::end': }
 }

--- a/modules/govuk_elasticsearch/spec/classes/govuk_elasticsearch_backup_spec.rb
+++ b/modules/govuk_elasticsearch/spec/classes/govuk_elasticsearch_backup_spec.rb
@@ -1,0 +1,19 @@
+require_relative '../../../../spec_helper'
+
+  describe 'govuk_elasticsearch::backup', :type => :class do
+
+    let(:params){{
+        :es_indices => [
+            'cagney',
+            'lacey'
+        ]
+    }}
+
+    context 'Check file' do
+
+      it { is_expected.to contain_file('es-backup-s3').with_content(/"cagney","lacey"/) }
+
+    end
+
+
+  end

--- a/modules/govuk_elasticsearch/templates/es-backup-s3.erb
+++ b/modules/govuk_elasticsearch/templates/es-backup-s3.erb
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+set -e
+
+# Redirect stdout and stderr to syslog
+exec 1> >(/usr/bin/logger -s -t $(basename $0)) 2>&1
+
+# The default Icinga passive alert assumes that the script failed
+NAGIOS_CODE=2
+NAGIOS_MESSAGE="CRITICAL: Elasticsearch index backup push to S3 failed"
+S3_BUCKET=<%= @s3_bucket %>
+ES_REPO=<%= @es_repo %>
+ES_INDICES=<%= @json_es_indices %>
+ES_SNAPSHOT=snapshot_$(date +%d_%m_%y)
+AWS_REGION=<%= @aws_region %>
+AWS_ACCESS_KEY_ID=<%= @aws_access_key_id %>
+AWS_SECRET_ACCESS_KEY=<%= @aws_secret_access_key %>
+
+# PARAMETERS FOR ELASTICSEARCH SNAPSHOT REPOSITORY
+REPO_DATA=$(cat <<EOD
+{
+  "type": "s3",
+  "settings": {
+  "bucket": "${S3_BUCKET}",
+  "region": "${AWS_REGION}",
+  "access_key": "${AWS_ACCESS_KEY_ID}",
+  "secret_key": "${AWS_SECRET_ACCESS_KEY}"
+},
+  "compress": "true"
+}
+EOD
+)
+
+# PARAMETERS FOR ELASTICSEARCH SNAPSHOT
+SNAPSHOT_DATA=$(cat <<EOD
+{
+  "indices": "${ES_INDICES}",
+  "include_global_state": "false",
+  "compress": "true",
+  "server_side_encryption": "true"
+}
+EOD
+)
+
+# Triggered whenever this script exits, successful or otherwise. The values
+# of CODE/MESSAGE will be taken from that point in time.
+function nagios_passive () {
+printf "<%= @ipaddress %>\t<%= @service_desc %>\t${NAGIOS_CODE}\t${NAGIOS_MESSAGE}\n" | /usr/sbin/send_nsca -H alert.cluster >/dev/null
+}
+
+trap nagios_passive EXIT
+
+
+/usr/bin/envdir <%= @env_dir %>/env.d  /usr/bin/curl --connect-timeout 10 -sS -XPUT "http://127.0.0.1:9200/_snapshot/${ES_REPO}?wait_for_completion=true&pretty" -d "$REPO_DATA"
+
+
+# indices: option allows us to specify indexes in a comma separated list rather than taking a snapshot of everything. However we can set
+# the $ES_REPO variable to '_all' to snapshot all indices.
+#
+# include_global_state: option will prevent the cluster global state from being stored as part of the snapshot.
+# The entire snapshot will fail if one or more indices participating in the snapshot don’t have all primary shards available
+
+
+if [ $? -eq 0 ]; then
+
+  /usr/bin/envdir <%= @env_dir %>/env.d /usr/bin/curl --connect-timeout 10 -sS -XPUT "http://127.0.0.1:9200/_snapshot/${ES_REPO}/${ES_SNAPSHOT}?wait_for_completion=true&pretty" -d "$SNAPSHOT_DATA" &> /dev/null
+
+
+fi
+
+
+if [ $? == 0 ]
+  then
+    STATUS=0
+  else
+    STATUS=1
+fi
+
+if [ $STATUS -eq 0 ]; then
+  NAGIOS_CODE=0
+  NAGIOS_MESSAGE="OK: Elasticsearch backup push to S3 succeeded"
+fi
+
+exit $STATUS


### PR DESCRIPTION
Please merge this after https://github.com/alphagov/govuk-puppet/pull/4517
This is due to the 'Include' in the backup class causing the spec to fail when it cannot find the housekeeping class.


This refers o this PR https://github.com/alphagov/govuk-puppet/pull/4500
From coments on the last PR I have wrppped the entire class in a 'if'
to restrict to one node in the cluster.