### PR TITLE
[DO NOT MERGE] Add Rate-Limit-Token to govuk_crawler_worker

### DIFF
--- a/modules/govuk/manifests/apps/govuk_crawler_worker.pp
+++ b/modules/govuk/manifests/apps/govuk_crawler_worker.pp
@@ -32,6 +32,10 @@
 # [*root_urls*]
 #   A list of hostnames that the crawler should crawl
 #
+# [*rate_limit_token*]
+#   Sets the header "Rate-Limit-Token" which ensures that the crawler is
+#   whitelisted by the rate limiting function (receiving 429 status)
+#
 class govuk::apps::govuk_crawler_worker (
   $airbrake_api_key = '',
   $airbrake_endpoint = '',
@@ -43,6 +47,7 @@ class govuk::apps::govuk_crawler_worker (
   $mirror_root = '/mnt/crawler_worker',
   $port = '3074',
   $root_urls = [],
+  $rate_limit_token = undef,
 ) {
   validate_array($blacklist_paths, $root_urls)
 
@@ -78,6 +83,8 @@ class govuk::apps::govuk_crawler_worker (
         value => $mirror_root;
       'TTL_EXPIRE_TIME':
         value => '24h';
+      'RATE_LIMIT_TOKEN':
+        value => $rate_limit_token;
     }
 
     file { $mirror_root:


### PR DESCRIPTION
This ensures that the crawler doesn't get rate limited when hitting the
site.

This entirely depends on https://github.com/alphagov/govuk_crawler_worker/pull/107
which is highly likely to be incorrect because I was basically flapping at Go