### PR TITLE
Revert "Upgrade gor to 0.14.1"

### DIFF
--- a/modules/govuk_bouncer/manifests/gor.pp
+++ b/modules/govuk_bouncer/manifests/gor.pp
@@ -30,10 +30,9 @@ class govuk_bouncer::gor (
     args   => {
       '-input-raw'          => ':80',
       '-output-http'        => $gor_targets,
-      '-http-allow-method'  => [
+      '-output-http-method' => [
         'GET', 'HEAD', 'OPTIONS',
       ],
-      '-http-original-host' => '',
     },
     enable => $gor_enable,
   }

--- a/modules/govuk_bouncer/spec/classes/govuk_bouncer__gor_spec.rb
+++ b/modules/govuk_bouncer/spec/classes/govuk_bouncer__gor_spec.rb
@@ -4,8 +4,7 @@ describe 'govuk_bouncer::gor', :type => :class do
   let(:ip_address) { '127.0.0.1' }
   let(:args_default) {{
     '-input-raw'          => ':80',
-    '-http-allow-method'  => %w{GET HEAD OPTIONS},
-    '-http-original-host' => '',
+    '-output-http-method' => %w{GET HEAD OPTIONS},
   }}
 
   context 'default (disabled)' do

--- a/modules/govuk_gor/manifests/init.pp
+++ b/modules/govuk_gor/manifests/init.pp
@@ -20,7 +20,7 @@ class govuk_gor(
   $apt_mirror_hostname = '',
   $args = {},
   $enable = false,
-  $version = '0.14.1',
+  $version = '0.9.4',
 ) {
 
   apt::source { 'gor':
@@ -28,6 +28,8 @@ class govuk_gor(
     key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
     architecture => $::architecture,
   }
+
+  include govuk_ppa
 
   validate_bool($enable)
 
@@ -45,12 +47,6 @@ class govuk_gor(
     $gor_service_ensure = stopped
     $nagios_ensure      = absent
     $logstream_ensure   = absent
-  }
-
-  # FIXME: Remove once deployed to production
-  # The old version of gor was installed to `/usr/bin` but the new version is in `/usr/local/bin`
-  file { '/usr/bin/gor':
-    ensure => absent,
   }
 
   class { '::gor':

--- a/modules/router/manifests/gor.pp
+++ b/modules/router/manifests/gor.pp
@@ -32,12 +32,11 @@ class router::gor (
 
   class { 'govuk_gor':
     args   => {
-      '-input-raw'          => ':7999',
+      '-input-raw'          => 'localhost:7999',
       '-output-http'        => prefix(keys($replay_targets), 'https://'),
-      '-http-allow-method'  => [
+      '-output-http-method' => [
         'GET', 'HEAD', 'OPTIONS',
       ],
-      '-http-original-host' => '',
     },
     enable => $enabled,
   }

--- a/modules/router/spec/classes/router__gor_spec.rb
+++ b/modules/router/spec/classes/router__gor_spec.rb
@@ -5,9 +5,8 @@ describe 'router::gor', :type => :class do
     :replay_targets => replay_targets,
   }}
   let(:args_default) {{
-    '-input-raw'          => ':7999',
-    '-http-allow-method'  => %w{GET HEAD OPTIONS},
-    '-http-original-host' => '',
+    '-input-raw'          => 'localhost:7999',
+    '-output-http-method' => %w{GET HEAD OPTIONS},
   }}
 
   context 'no targets defined (disabled)' do


### PR DESCRIPTION
This reverts commit 91dab2869a96cf383022d76e551fbe289f9a5ab0.

The new version of gor crashes repeatedly in production. We need to do some investigation to figure out what's going on.