### PR TITLE
Add 'freshold' check for local-links-manager

### DIFF
--- a/modules/govuk/manifests/apps/local_links_manager.pp
+++ b/modules/govuk/manifests/apps/local_links_manager.pp
@@ -123,6 +123,12 @@ class govuk::apps::local_links_manager(
         host_name           => $::fqdn,
         freshness_threshold => (25 * 60 * 60), # 25 hrs (e.g. just over a day)
       }
+
+      @@icinga::passive_check { "local-links-manager-check-homepage-urls_${::hostname}":
+        service_description => 'Check for blank homepage urls in local-links-manager',
+        host_name           => $::fqdn,
+        freshness_threshold => (25 * 60 * 60), # 25 hrs (e.g. just over a day)
+      }
     }
 
     if $::govuk_node_class != 'development' {


### PR DESCRIPTION
We've added a scheduled import of local authority homepage URLs to local links manager.  As part of this, we're checking that none of them have been set to empty strings.  When local links manager goes live, we will then be the source of this information, and so the import (and this freshness threshold check) can be removed.

The corresponding `service_description` in local links manager is [here](https://github.com/alphagov/local-links-manager/blob/fae155d62faac4573c68ca9402c1d322f70dee68/lib/tasks/import/local_authorities.rake#L20)

This should not be merged before https://github.com/alphagov/local-links-manager/pull/34 to avoid premature alerts.