### PR TITLE
Add publishing api overview dashboard to grafana

### DIFF
--- a/modules/grafana/manifests/dashboards.pp
+++ b/modules/grafana/manifests/dashboards.pp
@@ -35,5 +35,6 @@ class grafana::dashboards (
     "${dashboard_directory}/edge_health.json": content => template('grafana/dashboards/edge_health.json.erb');
     "${dashboard_directory}/origin_health.json": content => template('grafana/dashboards/origin_health.json.erb');
     "${dashboard_directory}/whitehall_health.json": content => template('grafana/dashboards/whitehall_health.json.erb');
+    "${dashboard_directory}/publishing_api_overview.json": content => template('grafana/dashboards/publishing_api_overview.json.erb');
   }
 }


### PR DESCRIPTION
https://trello.com/c/qPIJoZIV/728-publishing-api-metrics-making-visible

Makes the Publishing API dashboard template available to Grafana 3

@deanwilson This adds a specific dashboard to the ever growing list, as discussed this could be done with some clever puppetry, happy to make it so with some advice.