### PR TITLE
Mongo restore s3 bucket path

### DIFF
--- a/modules/mongodb/templates/mongodb-restore-s3.erb
+++ b/modules/mongodb/templates/mongodb-restore-s3.erb
@@ -5,7 +5,7 @@ set -e
 # Redirect stdout and stderr to syslog
 exec 1> >(/usr/bin/logger -s -t $(basename $0)) 2>&1
 
-S3_BUCKET=<%= @s3_bucket %>
+S3_BUCKET=<%= @s3_bucket %>/<%= @fqdn %>
 BACKUP_DIR=<%= @backup_dir %>
 
 cd $BACKUP_DIR


### PR DESCRIPTION
Path in S3 bucket where backups will be downloaded from.
The paths for backups will vary by fully qualified hostname inside the S3 bucket.
This commit makes use of the ruby tag 'fqdn' to restore a backup for the machine
that invoked the restore.