### PR TITLE
Add timeout to processing command

### DIFF
--- a/modules/govuk/templates/node/s_asset_base/process-uploaded-attachments.sh.erb
+++ b/modules/govuk/templates/node/s_asset_base/process-uploaded-attachments.sh.erb
@@ -35,7 +35,7 @@ while IFS= read -r -d '' FILE
     if /usr/local/bin/virus-scan-file.sh "$FILE"; then
       rsync --relative "$FILE_PATH" "$CLEAN_DIR"
       for NODE in $ASSET_SLAVE_NODES; do
-        if rsync -e "ssh -q" --quiet --timeout=10 --relative "$FILE_PATH" $NODE:$CLEAN_DIR; then
+        if /usr/bin/timeout 120 rsync -e "ssh -q" --quiet --timeout=10 --relative "$FILE_PATH" $NODE:$CLEAN_DIR; then
           logger -t process_uploaded_attachment "File $FILE copied to $NODE"
         else
           logger -t process_uploaded_attachment "File $FILE failed to copy to $NODE"


### PR DESCRIPTION
There might be an issue where it stalls for whatever reason; despite
there being an rsync timeout, this only relates to being able to connect
via SSH to the node. We've seen an issue where SSH was able to connect
on the port but not establish a connection, causing timeouts and forcing
the number of queued items in the incoming queue to back up. This
ensures that we process the items in a timely manner, even if they're
not copied an asset slave.

As an assurance we do a full sync every morning of the assets to ensure
the master and slaves are in sync.