### PR TITLE
You need to run `vagrant reload` on host change

### DIFF
--- a/development-vm/README.md
+++ b/development-vm/README.md
@@ -78,8 +78,8 @@ and that's it. Now you can get to work!
 * If you have < 8GB of RAM on your host machine, you will need to reduce the
   RAM available to the VM. You can also add extra RAM if you require more.
   You can do both of these things in a `Vagrantfile.localconfig` file in this
-  directory, which is automatically read by Vagrant (don't forget to re-run
-  `vagrant up`!):
+  directory, which is automatically read by Vagrant (don't forget to run
+  `vagrant reload`!):
 
         $ cat ./Vagrantfile.localconfig
         config.vm.provider :virtualbox do |vm|


### PR DESCRIPTION
Updates ‘Developing on GDS Virtual Machines’ documentation to explain that `vagrant reload` should be run when making changes to the memory or CPU configuration of the host machine.