### PR TITLE
Mongodb 3.2 config file

### DIFF
--- a/modules/mongodb/manifests/config.pp
+++ b/modules/mongodb/manifests/config.pp
@@ -8,6 +8,7 @@
 #   The config file mongo should use. This varies between mongo 2 and 3.
 #
 # [*dbpath*]
+#   Path to database on filesystem
 #
 # [*development*]
 #   Disable journalling and enable query profiling.
@@ -24,8 +25,12 @@
 #   'production' unless $development is true, in which
 #   case it is set to 'development'.
 #
+# [*template_name*]
+#   The name of the template that will be used as the config file.
+#
 class mongodb::config (
-  $config_filename = '/etc/mongodb.conf',
+  $config_filename,
+  $template_name,
   $dbpath = '/var/lib/mongodb',
   $development,
   $oplog_size = undef,
@@ -33,13 +38,14 @@ class mongodb::config (
 ) {
   validate_bool($development)
 
-  # Class params are used in the templates below.
 
-  file { $config_filename:
-    ensure  => present,
-    content => template('mongodb/mongodb.conf'),
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0644',
-  }
+  # Class params are used in the templates below.
+    file { $config_filename:
+      ensure  => present,
+      content => template("mongodb/${template_name}"),
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
+    }
+
 }

--- a/modules/mongodb/manifests/server.pp
+++ b/modules/mongodb/manifests/server.pp
@@ -5,8 +5,20 @@
 # === Parameters:
 #
 # [*version*]
+#   Version of mongodb. Should resolve to 2.6
+#
 # [*package_name*]
+#   The name of the mongo install
+#
 # [*dbpath*]
+#   Path to database on filesystem
+#
+# [*config_filename*]
+#   Name and path of the main configuration file
+#
+# [*template_name*]
+#   The name of the template that will be used as the config file.
+#
 # [*oplog_size*]
 #   Defines size of the oplog in megabytes.
 #   If undefined, we use MongoDB's default.
@@ -33,10 +45,12 @@ class mongodb::server (
     $service_name = 'mongod'
     $package_name = 'mongodb-org'
     $config_filename = '/etc/mongod.conf'
+    $template_name = 'mongod.conf.erb'
   } else {
     $service_name = 'mongodb'
     $package_name = 'mongodb-10gen'
     $config_filename = '/etc/mongodb.conf'
+    $template_name = 'mongodb.conf'
   }
 
   validate_bool($development)
@@ -79,6 +93,7 @@ class mongodb::server (
     development     => $development,
     oplog_size      => $oplog_size,
     replicaset_name => $replicaset_name,
+    template_name   => $template_name,
     require         => Class['mongodb::package'],
     notify          => Class['mongodb::service'];
   }

--- a/modules/mongodb/spec/classes/mongodb__config_spec.rb
+++ b/modules/mongodb/spec/classes/mongodb__config_spec.rb
@@ -6,6 +6,8 @@ describe 'mongodb::config', :type => :class do
       let(:params) {{
         :development => false,
         :replicaset_name  => 'production',
+        :config_filename => '/etc/mongodb.conf',
+        :template_name => 'mongodb.conf'
       }}
 
       it { is_expected.to contain_file('/etc/mongodb.conf').with_content(/^replSet = production$/) }
@@ -18,6 +20,8 @@ describe 'mongodb::config', :type => :class do
       let(:params) {{
         :development      => true,
         :replicaset_name  => 'development',
+        :config_filename => '/etc/mongodb.conf',
+        :template_name => 'mongodb.conf'
       }}
 
       it { is_expected.to contain_file('/etc/mongodb.conf').with_content(/replSet = development$/) }
@@ -25,4 +29,36 @@ describe 'mongodb::config', :type => :class do
       it { is_expected.to contain_file('/etc/mongodb.conf').with_content(/noprealloc|journal|nojournal/) }
     end
   end
+
+  describe 'mongod.conf' do
+    context 'defaults' do
+      let(:params) {{
+          :development => false,
+          :replicaset_name  => 'production',
+          :config_filename => '/etc/mongod.conf',
+          :oplog_size => '7168 # 7 * 1024',
+          :template_name => 'mongod.conf.erb'
+      }}
+
+      it { is_expected.to contain_file('/etc/mongod.conf').with_content(/^replication:\n\s\soplogSizeMB:\s7168 # 7 \* 1024\n\s\sreplSetName:\sproduction/) }
+      it { is_expected.to contain_file('/etc/mongod.conf').with_content(/\s\sprofile: 1/) }
+      it { is_expected.to contain_file('/etc/mongod.conf').with_content(/\s\sjournal:\n\s\s\s\senabled: true/) }
+    end
+
+    context 'development => true' do
+      let(:params) {{
+          :development => true,
+          :replicaset_name  => 'development',
+          :config_filename => '/etc/mongod.conf',
+          :oplog_size => '7168 # 7 * 1024',
+          :template_name => 'mongod.conf.erb'
+      }}
+
+      it { is_expected.to contain_file('/etc/mongod.conf').with_content(/^replication:\n\s\soplogSizeMB:\n\s\sreplSetName:\sdevelopment/) }
+      it { is_expected.to contain_file('/etc/mongod.conf').with_content(/\s\sprofile: 2/) }
+      it { is_expected.to contain_file('/etc/mongod.conf').with_content(/\s\sjournal:\n\s\s\s\senabled: false/) }
+    end
+
+  end
+
 end

--- a/modules/mongodb/templates/mongod.conf.erb
+++ b/modules/mongodb/templates/mongod.conf.erb
@@ -1,0 +1,51 @@
+# mongod.conf
+
+# for documentation of all options, see:
+#   http://docs.mongodb.org/manual/reference/configuration-options/
+
+# Where and how to store data.
+storage:
+# Omit trailing slash
+  dbPath: <%= @dbPath %>
+
+if <%= @development -%>
+  journal:
+    enabled: false
+
+# Query profiling level. Capture data regarding performance.
+  profile: 2
+
+# replicaset options
+replication:
+  oplogSizeMB:
+  replSetName: <%= @replicaset_name %>
+
+   <%= @else -%>
+
+  journal:
+    enabled: true
+
+# Query profiling level. Capture data regarding performance.
+  profile: 1
+
+# replicaset options
+replication:
+  oplogSizeMB: <%= @oplog_size %>
+  replSetName: <%= @replicaset_name %>
+
+
+
+  <%= @end -%>
+
+# where to write logging data.
+systemLog:
+  destination: file
+  logAppend: true
+  path: /var/log/mongodb/mongod.log
+
+# network interfaces
+net:
+  port: 27017
+  bindIp: 127.0.0.1
+
+


### PR DESCRIPTION
Mongodb's config file format has changed since version 2.6 and will fail to start with without
the correct configuration file.
The parameters are mostly the same between versions so we are using puppet
'versioncmp' method as the conditional argument to apply the right file for
the version.
We added a 2nd template for mongodb version 3.2