### PR TITLE
Update Grafana dashboards to 3.x format

### DIFF
--- a/modules/grafana/templates/dashboards/application_health.json.erb
+++ b/modules/grafana/templates/dashboards/application_health.json.erb
@@ -1,50 +1,46 @@
 {
+  "id": null,
   "title": "application health",
-  "services": {
-    "filter": {
-      "list": [],
-      "time": {
-        "from": "now-6h",
-        "to": "now"
-      }
-    }
-  },
+  "originalTitle": "application health",
+  "tags": [],
+  "style": "dark",
+  "timezone": "utc",
+  "editable": true,
+  "hideControls": false,
+  "sharedCrosshair": false,
   "rows": [
     {
-      "title": "one",
-      "height": "400px",
-      "editable": true,
-      "collapse": false,
       "collapsable": true,
+      "collapse": false,
+      "editable": true,
+      "height": "400px",
+      "notice": false,
       "panels": [
         {
-          "span": 4,
-          "editable": true,
-          "type": "graphite",
-          "loadingEditor": false,
-          "x-axis": true,
-          "y-axis": true,
-          "scale": 1,
-          "grid": {
-            "max": 1500,
-            "min": 0,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
+          "aliasColors": {},
           "annotate": {
             "enable": false,
+            "field": "_type",
             "query": "*",
             "size": 20,
-            "field": "_type",
             "sort": [
               "_score",
               "desc"
             ]
           },
           "auto_int": true,
-          "resolution": 100,
+          "bars": false,
+          "datasource": "Graphite",
+          "editable": true,
+          "fill": 0,
+          "grid": {
+            "min": 0,
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "interactive": true,
           "interval": "5m",
           "intervals": [
             "auto",
@@ -60,81 +56,95 @@
             "1w",
             "1y"
           ],
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "spyable": true,
-          "zoomlinks": false,
-          "options": false,
           "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
+            "avg": false,
             "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
             "total": false,
-            "avg": false
+            "values": false
           },
-          "interactive": true,
           "legend_counts": true,
-          "percentage": false,
-          "zerofill": true,
+          "lines": true,
+          "linewidth": 1,
+          "loadingEditor": false,
           "nullPointMode": "connected",
+          "options": false,
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "resolution": 100,
+          "scale": 1,
+          "span": 4,
+          "spyable": true,
+          "stack": false,
           "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "query_as_alias": true
-          },
           "targets": [
             {
-              "target": "alias(scale(averageSeries(stats.timers.backend-?_backend<%= @machine_suffix_metrics -%>.nginx_logs.contentapi_*.time_request.mean),1000),\"nginx\")"
+              "target": "alias(scale(averageSeries(stats.timers.backend-?_backend.nginx_logs.contentapi_*.time_request.mean),1000),\"nginx\")",
+              "refId": "A"
             },
             {
-              "target": "groupByNode(stats.timers.backend-?_backend<%= @machine_suffix_metrics -%>.contentapi.time_*.mean,4,\"avg\")"
+              "target": "groupByNode(stats.timers.backend-?_backend.contentapi.time_*.mean,4,\"avg\")",
+              "refId": "B"
             }
           ],
-          "aliasColors": {},
-          "aliasYAxis": {},
           "title": "contentapi resp/avg",
-          "datasource": null,
-          "renderer": "flot",
-          "y_formats": [
-            "none",
-            "none"
-          ]
+          "tooltip": {
+            "query_as_alias": true,
+            "value_type": "cumulative",
+            "shared": true,
+            "msResolution": true
+          },
+          "type": "graph",
+          "zerofill": true,
+          "zoomlinks": false,
+          "id": 1,
+          "yaxes": [
+            {
+              "show": true,
+              "max": 1500,
+              "format": "none"
+            },
+            {
+              "show": true,
+              "format": "none"
+            }
+          ],
+          "xaxis": {
+            "show": true
+          },
+          "timeFrom": null,
+          "timeShift": null,
+          "seriesOverrides": []
         },
         {
-          "span": 4,
-          "editable": true,
-          "type": "graphite",
-          "loadingEditor": false,
-          "x-axis": true,
-          "y-axis": true,
-          "scale": 1,
-          "grid": {
-            "max": 1500,
-            "min": 0,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
+          "aliasColors": {},
           "annotate": {
             "enable": false,
+            "field": "_type",
             "query": "*",
             "size": 20,
-            "field": "_type",
             "sort": [
               "_score",
               "desc"
             ]
           },
           "auto_int": true,
-          "resolution": 100,
+          "bars": false,
+          "datasource": "Graphite",
+          "editable": true,
+          "fill": 0,
+          "grid": {
+            "min": 0,
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "interactive": true,
           "interval": "5m",
           "intervals": [
             "auto",
@@ -150,81 +160,95 @@
             "1w",
             "1y"
           ],
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "spyable": true,
-          "zoomlinks": false,
-          "options": false,
           "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
+            "avg": false,
             "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
             "total": false,
-            "avg": false
+            "values": false
           },
-          "interactive": true,
           "legend_counts": true,
-          "percentage": false,
-          "zerofill": true,
+          "lines": true,
+          "linewidth": 1,
+          "loadingEditor": false,
           "nullPointMode": "connected",
+          "options": false,
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "resolution": 100,
+          "scale": 1,
+          "span": 4,
+          "spyable": true,
+          "stack": false,
           "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "query_as_alias": true
-          },
           "targets": [
             {
-              "target": "alias(scale(averageSeries(stats.timers.calculators-frontend-?_frontend<%= @machine_suffix_metrics -%>.nginx_logs.smartanswers_*.time_request.mean),1000),\"nginx\")"
+              "target": "alias(scale(averageSeries(stats.timers.calculators-frontend-?_frontend.nginx_logs.smartanswers_*.time_request.mean),1000),\"nginx\")",
+              "refId": "A"
             },
             {
-              "target": "groupByNode(stats.timers.calculators-frontend-?_frontend<%= @machine_suffix_metrics -%>.smartanswers.time_*.mean,4,\"avg\")"
+              "target": "groupByNode(stats.timers.calculators-frontend-?_frontend.smartanswers.time_*.mean,4,\"avg\")",
+              "refId": "B"
             }
           ],
-          "aliasColors": {},
-          "aliasYAxis": {},
           "title": "smartanswers resp/avg",
-          "datasource": null,
-          "renderer": "flot",
-          "y_formats": [
-            "none",
-            "none"
-          ]
+          "tooltip": {
+            "query_as_alias": true,
+            "value_type": "cumulative",
+            "shared": true,
+            "msResolution": true
+          },
+          "type": "graph",
+          "zerofill": true,
+          "zoomlinks": false,
+          "id": 2,
+          "yaxes": [
+            {
+              "show": true,
+              "max": 1500,
+              "format": "none"
+            },
+            {
+              "show": true,
+              "format": "none"
+            }
+          ],
+          "xaxis": {
+            "show": true
+          },
+          "timeFrom": null,
+          "timeShift": null,
+          "seriesOverrides": []
         },
         {
-          "span": 4,
-          "editable": true,
-          "type": "graphite",
-          "loadingEditor": false,
-          "x-axis": true,
-          "y-axis": true,
-          "scale": 1,
-          "grid": {
-            "max": 1500,
-            "min": 0,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
+          "aliasColors": {},
           "annotate": {
             "enable": false,
+            "field": "_type",
             "query": "*",
             "size": 20,
-            "field": "_type",
             "sort": [
               "_score",
               "desc"
             ]
           },
           "auto_int": true,
-          "resolution": 100,
+          "bars": false,
+          "datasource": "Graphite",
+          "editable": true,
+          "fill": 0,
+          "grid": {
+            "min": 0,
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "interactive": true,
           "interval": "5m",
           "intervals": [
             "auto",
@@ -240,91 +264,105 @@
             "1w",
             "1y"
           ],
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "spyable": true,
-          "zoomlinks": false,
-          "options": false,
           "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
+            "avg": false,
             "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
             "total": false,
-            "avg": false
+            "values": false
           },
-          "interactive": true,
           "legend_counts": true,
-          "percentage": false,
-          "zerofill": true,
+          "lines": true,
+          "linewidth": 1,
+          "loadingEditor": false,
           "nullPointMode": "connected",
+          "options": false,
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "resolution": 100,
+          "scale": 1,
+          "span": 4,
+          "spyable": true,
+          "stack": false,
           "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "query_as_alias": true
-          },
           "targets": [
             {
-              "target": "alias(scale(averageSeries(stats.timers.frontend-?_frontend<%= @machine_suffix_metrics -%>.nginx_logs.frontend_*.time_request.mean),1000),\"nginx\")"
+              "target": "alias(scale(averageSeries(stats.timers.frontend-?_frontend.nginx_logs.frontend_*.time_request.mean),1000),\"nginx\")",
+              "refId": "A"
             },
             {
-              "target": "groupByNode(stats.timers.frontend-?_frontend<%= @machine_suffix_metrics -%>.frontend.time_*.mean,4,\"avg\")"
+              "target": "groupByNode(stats.timers.frontend-?_frontend.frontend.time_*.mean,4,\"avg\")",
+              "refId": "B"
             }
           ],
-          "aliasColors": {},
-          "aliasYAxis": {},
           "title": "frontend resp/avg",
-          "datasource": null,
-          "renderer": "flot",
-          "y_formats": [
-            "none",
-            "none"
-          ]
+          "tooltip": {
+            "query_as_alias": true,
+            "value_type": "cumulative",
+            "shared": true,
+            "msResolution": true
+          },
+          "type": "graph",
+          "zerofill": true,
+          "zoomlinks": false,
+          "id": 3,
+          "yaxes": [
+            {
+              "show": true,
+              "max": 1500,
+              "format": "none"
+            },
+            {
+              "show": true,
+              "format": "none"
+            }
+          ],
+          "xaxis": {
+            "show": true
+          },
+          "timeFrom": null,
+          "timeShift": null,
+          "seriesOverrides": []
         }
       ],
-      "notice": false
+      "title": "one"
     },
     {
-      "title": "two",
-      "height": "400px",
-      "editable": true,
-      "collapse": false,
       "collapsable": true,
+      "collapse": false,
+      "editable": true,
+      "height": "400px",
+      "notice": false,
       "panels": [
         {
-          "span": 4,
-          "editable": true,
-          "type": "graphite",
-          "loadingEditor": false,
-          "x-axis": true,
-          "y-axis": true,
-          "scale": 1,
-          "grid": {
-            "max": 1500,
-            "min": 0,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
+          "aliasColors": {},
           "annotate": {
             "enable": false,
+            "field": "_type",
             "query": "*",
             "size": 20,
-            "field": "_type",
             "sort": [
               "_score",
               "desc"
             ]
           },
           "auto_int": true,
-          "resolution": 100,
+          "bars": false,
+          "datasource": "Graphite",
+          "editable": true,
+          "fill": 0,
+          "grid": {
+            "min": 0,
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "interactive": true,
           "interval": "5m",
           "intervals": [
             "auto",
@@ -340,81 +378,95 @@
             "1w",
             "1y"
           ],
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "spyable": true,
-          "zoomlinks": false,
-          "options": false,
           "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
+            "avg": false,
             "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
             "total": false,
-            "avg": false
+            "values": false
           },
-          "interactive": true,
           "legend_counts": true,
-          "percentage": false,
-          "zerofill": true,
+          "lines": true,
+          "linewidth": 1,
+          "loadingEditor": false,
           "nullPointMode": "connected",
+          "options": false,
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "resolution": 100,
+          "scale": 1,
+          "span": 4,
+          "spyable": true,
+          "stack": false,
           "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "query_as_alias": true
-          },
           "targets": [
             {
-              "target": "alias(scale(averageSeries(stats.timers.search-?_api<%= @machine_suffix_metrics -%>.nginx_logs.rummager_*.time_request.mean),1000),\"nginx\")"
+              "target": "alias(scale(averageSeries(stats.timers.search-?_api.nginx_logs.rummager_*.time_request.mean),1000),\"nginx\")",
+              "refId": "A"
             },
             {
-              "target": "groupByNode(stats.timers.search-?_api<%= @machine_suffix_metrics -%>.rummager.time_*.mean,4,\"avg\")"
+              "target": "groupByNode(stats.timers.search-?_api.rummager.time_*.mean,4,\"avg\")",
+              "refId": "B"
             }
           ],
-          "aliasColors": {},
-          "aliasYAxis": {},
           "title": "rummager resp/avg",
-          "datasource": null,
-          "renderer": "flot",
-          "y_formats": [
-            "none",
-            "none"
-          ]
+          "tooltip": {
+            "query_as_alias": true,
+            "value_type": "cumulative",
+            "shared": true,
+            "msResolution": true
+          },
+          "type": "graph",
+          "zerofill": true,
+          "zoomlinks": false,
+          "id": 4,
+          "yaxes": [
+            {
+              "show": true,
+              "max": 1500,
+              "format": "none"
+            },
+            {
+              "show": true,
+              "format": "none"
+            }
+          ],
+          "xaxis": {
+            "show": true
+          },
+          "timeFrom": null,
+          "timeShift": null,
+          "seriesOverrides": []
         },
         {
-          "span": 4,
-          "editable": true,
-          "type": "graphite",
-          "loadingEditor": false,
-          "x-axis": true,
-          "y-axis": true,
-          "scale": 1,
-          "grid": {
-            "max": 1500,
-            "min": 0,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
+          "aliasColors": {},
           "annotate": {
             "enable": false,
+            "field": "_type",
             "query": "*",
             "size": 20,
-            "field": "_type",
             "sort": [
               "_score",
               "desc"
             ]
           },
           "auto_int": true,
-          "resolution": 100,
+          "bars": false,
+          "datasource": "Graphite",
+          "editable": true,
+          "fill": 0,
+          "grid": {
+            "min": 0,
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "interactive": true,
           "interval": "5m",
           "intervals": [
             "auto",
@@ -430,78 +482,92 @@
             "1w",
             "1y"
           ],
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "spyable": true,
-          "zoomlinks": false,
-          "options": false,
           "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
+            "avg": false,
             "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
             "total": false,
-            "avg": false
+            "values": false
           },
-          "interactive": true,
           "legend_counts": true,
-          "percentage": false,
-          "zerofill": true,
+          "lines": true,
+          "linewidth": 1,
+          "loadingEditor": false,
           "nullPointMode": "connected",
+          "options": false,
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "resolution": 100,
+          "scale": 1,
+          "span": 4,
+          "spyable": true,
+          "stack": false,
           "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "query_as_alias": true
-          },
           "targets": [
             {
-              "target": "groupByNode(stats.timers.whitehall-frontend-?_frontend<%= @machine_suffix_metrics -%>.whitehall.time_*.mean,4,\"avg\")"
+              "target": "groupByNode(stats.timers.whitehall-frontend-?_frontend.whitehall.time_*.mean,4,\"avg\")",
+              "refId": "A"
             }
           ],
-          "aliasColors": {},
-          "aliasYAxis": {},
           "title": "whitehall fe resp/avg",
-          "datasource": null,
-          "renderer": "flot",
-          "y_formats": [
-            "none",
-            "none"
-          ]
+          "tooltip": {
+            "query_as_alias": true,
+            "value_type": "cumulative",
+            "shared": true,
+            "msResolution": true
+          },
+          "type": "graph",
+          "zerofill": true,
+          "zoomlinks": false,
+          "id": 5,
+          "yaxes": [
+            {
+              "show": true,
+              "max": 1500,
+              "format": "none"
+            },
+            {
+              "show": true,
+              "format": "none"
+            }
+          ],
+          "xaxis": {
+            "show": true
+          },
+          "timeFrom": null,
+          "timeShift": null,
+          "seriesOverrides": []
         },
         {
-          "span": 4,
+          "aliasColors": {},
+          "annotate": {
+            "enable": false,
+            "field": "_type",
+            "query": "*",
+            "size": 20,
+            "sort": [
+              "_score",
+              "desc"
+            ]
+          },
+          "auto_int": true,
+          "bars": false,
+          "datasource": "Graphite",
           "editable": true,
-          "type": "graphite",
-          "loadingEditor": false,
-          "x-axis": true,
-          "y-axis": true,
-          "scale": 1,
+          "fill": 10,
           "grid": {
             "max": null,
             "min": 0,
             "threshold1": null,
-            "threshold2": null,
             "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "annotate": {
-            "enable": false,
-            "query": "*",
-            "size": 20,
-            "field": "_type",
-            "sort": [
-              "_score",
-              "desc"
-            ]
-          },
-          "auto_int": true,
-          "resolution": 100,
+          "interactive": true,
           "interval": "5m",
           "intervals": [
             "auto",
@@ -517,140 +583,133 @@
             "1w",
             "1y"
           ],
-          "lines": true,
-          "fill": 10,
-          "linewidth": 0,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "spyable": true,
-          "zoomlinks": false,
-          "options": false,
           "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
+            "avg": false,
             "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
             "total": false,
-            "avg": false
+            "values": false
           },
-          "interactive": true,
           "legend_counts": true,
-          "percentage": false,
-          "zerofill": true,
+          "lines": true,
+          "linewidth": 0,
+          "loadingEditor": false,
           "nullPointMode": "connected",
+          "options": false,
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "resolution": 100,
+          "scale": 1,
+          "span": 4,
+          "spyable": true,
+          "stack": false,
           "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "query_as_alias": true
-          },
           "targets": [
             {
-              "target": "aliasSub(groupByNode(stats.*_frontend<%= @machine_suffix_metrics -%>.nginx_logs.*_<%= @app_domain_metrics -%>.http_503,3,\"sum\"),\"_.*\",\"\")"
+              "target": "aliasSub(groupByNode(stats.*_frontend.nginx_logs.*_publishing_service_gov_uk.http_503,3,\"sum\"),\"_.*\",\"\")",
+              "refId": "A"
             }
           ],
-          "aliasColors": {},
-          "aliasYAxis": {},
           "title": "fe HTTP 503/s",
-          "datasource": null,
-          "renderer": "flot",
-          "y_formats": [
-            "none",
-            "none"
-          ]
+          "tooltip": {
+            "query_as_alias": true,
+            "value_type": "cumulative",
+            "shared": true,
+            "msResolution": true
+          },
+          "type": "graph",
+          "zerofill": true,
+          "zoomlinks": false,
+          "id": 6,
+          "yaxes": [
+            {
+              "show": true,
+              "format": "none"
+            },
+            {
+              "show": true,
+              "format": "none"
+            }
+          ],
+          "xaxis": {
+            "show": true
+          },
+          "timeFrom": null,
+          "timeShift": null,
+          "seriesOverrides": []
         }
       ],
-      "notice": false
+      "title": "two"
     }
   ],
-  "editable": true,
-  "failover": false,
-  "panel_hints": true,
-  "style": "dark",
-  "pulldowns": [
-    {
-      "type": "filtering",
-      "collapse": false,
-      "notice": false,
-      "enable": false
-    },
-    {
-      "type": "annotations",
-      "enable": true,
-      "annotations": [
-        {
-          "name": "all deploys",
-          "type": "graphite events",
-          "showLine": true,
-          "iconColor": "#C0C6BE",
-          "lineColor": "rgba(32, 230, 25, 0.592157)",
-          "iconSize": 13,
-          "enable": true,
-          "tags": "deploys"
-        },
-        {
-          "name": "all restarts",
-          "type": "graphite metric",
-          "showLine": true,
-          "iconColor": "#FF2020",
-          "lineColor": "rgba(255, 32, 32, 0.592157)",
-          "iconSize": 13,
-          "enable": true,
-          "target": "substr(stats.govuk.app.*.restarts,3,5)"
-        }
-      ]
-    }
-  ],
-  "nav": [
-    {
-      "type": "timepicker",
-      "collapse": false,
-      "notice": false,
-      "enable": true,
-      "status": "Stable",
-      "time_options": [
-        "5m",
-        "15m",
-        "1h",
-        "6h",
-        "12h",
-        "24h",
-        "2d",
-        "7d",
-        "30d"
-      ],
-      "refresh_intervals": [
-        "5s",
-        "10s",
-        "30s",
-        "1m",
-        "5m",
-        "15m",
-        "30m",
-        "1h",
-        "2h",
-        "1d"
-      ],
-      "now": true
-    }
-  ],
-  "loader": {
-    "save_gist": false,
-    "save_elasticsearch": true,
-    "save_local": true,
-    "save_default": true,
-    "save_temp": true,
-    "save_temp_ttl_enable": true,
-    "save_temp_ttl": "30d",
-    "load_gist": false,
-    "load_elasticsearch": true,
-    "load_elasticsearch_size": 20,
-    "load_local": false,
-    "hide": false
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "collapse": false,
+    "enable": true,
+    "notice": false,
+    "now": true,
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "status": "Stable",
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ],
+    "type": "timepicker"
+  },
+  "templating": {
+    "list": []
+  },
+  "annotations": {
+    "list": [
+      {
+        "enable": true,
+        "iconColor": "#C0C6BE",
+        "iconSize": 13,
+        "lineColor": "rgba(32, 230, 25, 0.592157)",
+        "name": "all deploys",
+        "showLine": true,
+        "tags": "deploys",
+        "type": "graphite events"
+      },
+      {
+        "enable": true,
+        "iconColor": "#FF2020",
+        "iconSize": 13,
+        "lineColor": "rgba(255, 32, 32, 0.592157)",
+        "name": "all restarts",
+        "showLine": true,
+        "target": "substr(stats.govuk.app.*.restarts,3,5)",
+        "type": "graphite metric"
+      }
+    ]
   },
   "refresh": "1m",
-  "tags": [],
-  "timezone": "utc"
+  "schemaVersion": 12,
+  "version": 0,
+  "links": []
 }

--- a/modules/grafana/templates/dashboards/application_http_error_codes.json.erb
+++ b/modules/grafana/templates/dashboards/application_http_error_codes.json.erb
@@ -1,244 +1,251 @@
 {
+  "id": null,
   "title": "Application 4XX and 5XX codes",
-  "services": {
-    "filter": {
-      "list": [],
-      "time": {
-        "from": "now-6h",
-        "to": "now"
-      }
-    }
-  },
+  "originalTitle": "Application 4XX and 5XX codes",
+  "tags": [],
+  "style": "dark",
+  "timezone": "utc",
+  "editable": true,
+  "hideControls": false,
+  "sharedCrosshair": false,
   "rows": [
     {
-      "title": "123",
-      "height": "600px",
-      "editable": true,
-      "collapse": false,
       "collapsable": true,
+      "collapse": false,
+      "editable": true,
+      "height": "600px",
+      "notice": false,
       "panels": [
         {
-          "span": 12,
+          "annotate": {
+            "enable": false
+          },
+          "bars": false,
+          "datasource": "Graphite",
           "editable": true,
-          "type": "graphite",
-          "loadingEditor": false,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "scale": 1,
-          "y_formats": [
-            "short",
-            "short"
-          ],
+          "fill": 0,
           "grid": {
             "max": null,
             "min": 0,
             "threshold1": null,
-            "threshold2": null,
             "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "loadingEditor": false,
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "resolution": 100,
+          "scale": 1,
+          "span": 12,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "target": "groupByNode(stats.frontend-?_frontend*.nginx_logs.*.http_4xx, 3, \"sumSeries\")",
+              "refId": "A"
+            },
+            {
+              "target": "groupByNode(stats.*-frontend-?_frontend*.nginx_logs.*.http_4xx, 3, \"sumSeries\")",
+              "refId": "B"
+            }
+          ],
+          "title": "4XX by Application",
+          "tooltip": {
+            "query_as_alias": true,
+            "value_type": "cumulative",
+            "shared": true,
+            "msResolution": true
+          },
+          "type": "graph",
+          "zerofill": true,
+          "id": 1,
+          "yaxes": [
+            {
+              "show": true,
+              "format": "short"
+            },
+            {
+              "show": true,
+              "format": "short"
+            }
+          ],
+          "xaxis": {
+            "show": true
+          },
+          "timeFrom": null,
+          "timeShift": null,
+          "aliasColors": {},
+          "seriesOverrides": []
+        }
+      ],
+      "title": "123"
+    },
+    {
+      "collapsable": true,
+      "collapse": false,
+      "editable": true,
+      "height": "600px",
+      "notice": false,
+      "panels": [
+        {
           "annotate": {
             "enable": false
           },
-          "resolution": 100,
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
           "bars": false,
-          "stack": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false
-          },
-          "percentage": false,
-          "zerofill": true,
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "query_as_alias": true
-          },
-          "targets": [
-            {
-              "target": "groupByNode(stats.frontend-?_frontend*.nginx_logs.*.http_4xx, 3, \"sumSeries\")"
-            },
-            {
-              "target": "groupByNode(stats.*-frontend-?_frontend*.nginx_logs.*.http_4xx, 3, \"sumSeries\")"
-            }
-          ],
-          "aliasYAxis": {},
-          "title": "4XX by Application"
-        }
-      ],
-      "notice": false
-    },
-    {
-      "title": "123",
-      "height": "600px",
-      "editable": true,
-      "collapse": false,
-      "collapsable": true,
-      "panels": [
-        {
-          "span": 12,
-          "editable": true,
-          "type": "graphite",
-          "loadingEditor": false,
           "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "scale": 1,
-          "y_formats": [
-            "short",
-            "short"
-          ],
+          "editable": true,
+          "fill": 0,
           "grid": {
             "max": null,
             "min": 0,
             "threshold1": null,
-            "threshold2": null,
             "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "annotate": {
-            "enable": false
-          },
-          "resolution": 100,
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
           "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
+            "avg": false,
             "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
             "total": false,
-            "avg": false
+            "values": false
           },
-          "percentage": false,
-          "zerofill": true,
+          "lines": true,
+          "linewidth": 1,
+          "loadingEditor": false,
           "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "resolution": 100,
+          "scale": 1,
+          "span": 12,
+          "stack": false,
           "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "query_as_alias": true
-          },
           "targets": [
             {
-              "target": "groupByNode(stats.frontend-?_frontend*.nginx_logs.*.http_5xx, 3, \"sumSeries\")"
+              "target": "groupByNode(stats.frontend-?_frontend*.nginx_logs.*.http_5xx, 3, \"sumSeries\")",
+              "refId": "A"
             },
             {
-              "target": "groupByNode(stats.*-frontend-?_frontend*.nginx_logs.*.http_5xx, 3, \"sumSeries\")"
+              "target": "groupByNode(stats.*-frontend-?_frontend*.nginx_logs.*.http_5xx, 3, \"sumSeries\")",
+              "refId": "B"
             }
           ],
-          "aliasYAxis": {},
-          "title": "5XX by Application"
+          "title": "5XX by Application",
+          "tooltip": {
+            "query_as_alias": true,
+            "value_type": "cumulative",
+            "shared": true,
+            "msResolution": true
+          },
+          "type": "graph",
+          "zerofill": true,
+          "id": 2,
+          "yaxes": [
+            {
+              "show": true,
+              "format": "short"
+            },
+            {
+              "show": true,
+              "format": "short"
+            }
+          ],
+          "xaxis": {
+            "show": true
+          },
+          "timeFrom": null,
+          "timeShift": null,
+          "aliasColors": {},
+          "seriesOverrides": []
         }
       ],
-      "notice": false
+      "title": "123"
     }
   ],
-  "editable": true,
-  "failover": false,
-  "panel_hints": true,
-  "style": "dark",
-  "pulldowns": [
-    {
-      "type": "filtering",
-      "collapse": false,
-      "notice": false,
-      "enable": false
-    },
-    {
-      "type": "annotations",
-      "enable": true,
-      "annotations": [
-        {
-          "name": "all deploys",
-          "type": "graphite events",
-          "showLine": true,
-          "iconColor": "#C0C6BE",
-          "lineColor": "rgba(32, 230, 25, 0.592157)",
-          "iconSize": 13,
-          "enable": true,
-          "tags": "deploys"
-        },
-        {
-          "name": "all restarts",
-          "type": "graphite metric",
-          "showLine": true,
-          "iconColor": "#FF2020",
-          "lineColor": "rgba(255, 32, 32, 0.592157)",
-          "iconSize": 13,
-          "enable": true,
-          "target": "substr(stats.govuk.app.*.restarts,3,5)"
-        }
-      ]
-    }
-  ],
-  "nav": [
-    {
-      "type": "timepicker",
-      "collapse": false,
-      "notice": false,
-      "enable": true,
-      "status": "Stable",
-      "time_options": [
-        "5m",
-        "15m",
-        "1h",
-        "6h",
-        "12h",
-        "24h",
-        "2d",
-        "7d",
-        "30d"
-      ],
-      "refresh_intervals": [
-        "5s",
-        "10s",
-        "30s",
-        "1m",
-        "5m",
-        "15m",
-        "30m",
-        "1h",
-        "2h",
-        "1d"
-      ],
-      "now": true
-    }
-  ],
-  "loader": {
-    "save_gist": false,
-    "save_elasticsearch": false,
-    "save_local": true,
-    "save_default": true,
-    "save_temp": true,
-    "save_temp_ttl_enable": true,
-    "save_temp_ttl": "30d",
-    "load_gist": false,
-    "load_elasticsearch": false,
-    "load_elasticsearch_size": 20,
-    "load_local": true,
-    "hide": false
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "collapse": false,
+    "enable": true,
+    "notice": false,
+    "now": true,
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "status": "Stable",
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ],
+    "type": "timepicker"
+  },
+  "templating": {
+    "list": []
+  },
+  "annotations": {
+    "list": [
+      {
+        "enable": true,
+        "iconColor": "#C0C6BE",
+        "iconSize": 13,
+        "lineColor": "rgba(32, 230, 25, 0.592157)",
+        "name": "all deploys",
+        "showLine": true,
+        "tags": "deploys",
+        "type": "graphite events"
+      },
+      {
+        "enable": true,
+        "iconColor": "#FF2020",
+        "iconSize": 13,
+        "lineColor": "rgba(255, 32, 32, 0.592157)",
+        "name": "all restarts",
+        "showLine": true,
+        "target": "substr(stats.govuk.app.*.restarts,3,5)",
+        "type": "graphite metric"
+      }
+    ]
   },
   "refresh": "1m",
-  "tags": [],
-  "timezone": "utc"
+  "schemaVersion": 12,
+  "version": 0,
+  "links": []
 }

--- a/modules/grafana/templates/dashboards/edge_health.json.erb
+++ b/modules/grafana/templates/dashboards/edge_health.json.erb
@@ -1,552 +1,621 @@
 {
+  "id": null,
   "title": "edge health",
-  "services": {
-    "filter": {
-      "list": [],
-      "time": {
-        "from": "now-6h",
-        "to": "now"
-      }
-    }
-  },
+  "originalTitle": "edge health",
+  "tags": [],
+  "style": "dark",
+  "timezone": "utc",
+  "editable": true,
+  "hideControls": false,
+  "sharedCrosshair": false,
   "rows": [
     {
-      "title": "one",
-      "height": "375px",
-      "editable": true,
-      "collapse": false,
       "collapsable": true,
-      "panels": [
-        {
-          "span": 4,
-          "editable": true,
-          "type": "graphite",
-          "loadingEditor": false,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "scale": 1,
-          "y_formats": [
-            "short",
-            "short"
-          ],
-          "grid": {
-            "max": null,
-            "min": 0,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "annotate": {
-            "enable": false
-          },
-          "resolution": 100,
-          "lines": true,
-          "fill": 5,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": true,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false
-          },
-          "percentage": false,
-          "zerofill": true,
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "individual",
-            "query_as_alias": true
-          },
-          "targets": [
-            {
-              "target": "monitoring-1_management<%= @machine_suffix_metrics -%>.cdn_fastly-govuk.requests-{errors,hits,miss,pass}"
-            }
-          ],
-          "aliasColors": {
-            "monitoring-1_management<%= @machine_suffix_metrics -%>.cdn_fastly-govuk.requests-errors": "#890F02"
-          },
-          "aliasYAxis": {},
-          "title": "www.gov edge cache func"
-        },
-        {
-          "span": 4,
-          "editable": true,
-          "type": "graphite",
-          "loadingEditor": false,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "scale": 1,
-          "y_formats": [
-            "short",
-            "short"
-          ],
-          "grid": {
-            "max": null,
-            "min": 0,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "annotate": {
-            "enable": false
-          },
-          "resolution": 100,
-          "lines": true,
-          "fill": 5,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": true,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false
-          },
-          "percentage": false,
-          "zerofill": true,
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "individual",
-            "query_as_alias": true
-          },
-          "targets": [
-            {
-              "target": "monitoring-1_management<%= @machine_suffix_metrics -%>.cdn_fastly-assets.requests-{errors,hits,miss,pass}"
-            }
-          ],
-          "aliasColors": {
-            "monitoring-1_management<%= @machine_suffix_metrics -%>.cdn_fastly-assets.requests-errors": "#890F02"
-          },
-          "aliasYAxis": {},
-          "title": "assets edge cache func"
-        },
-        {
-          "span": 4,
-          "editable": true,
-          "type": "graphite",
-          "loadingEditor": false,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "scale": 1,
-          "y_formats": [
-            "short",
-            "short"
-          ],
-          "grid": {
-            "max": null,
-            "min": 0,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "annotate": {
-            "enable": false
-          },
-          "resolution": 100,
-          "lines": true,
-          "fill": 5,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": true,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false
-          },
-          "percentage": false,
-          "zerofill": true,
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "individual",
-            "query_as_alias": true
-          },
-          "targets": [
-            {
-              "target": "monitoring-1_management<%= @machine_suffix_metrics -%>.cdn_fastly-redirector.requests-{errors,hits,miss,pass}"
-            }
-          ],
-          "aliasColors": {
-            "monitoring-1_management<%= @machine_suffix_metrics -%>.cdn_fastly-redirector.requests-errors": "#890F02"
-          },
-          "aliasYAxis": {},
-          "title": "bouncer/redirector edge cache func"
-        }
-      ],
-      "notice": false
-    },
-    {
-      "title": "two",
+      "collapse": false,
+      "editable": true,
       "height": "375px",
-      "editable": true,
-      "collapse": false,
-      "collapsable": true,
+      "notice": false,
       "panels": [
         {
-          "span": 4,
-          "editable": true,
-          "type": "graphite",
-          "loadingEditor": false,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "scale": 1,
-          "y_formats": [
-            "short",
-            "short"
-          ],
-          "grid": {
-            "max": null,
-            "min": 0,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          "aliasColors": {
+            "monitoring-1_management.cdn_fastly-govuk.requests-errors": "#890F02"
           },
           "annotate": {
             "enable": false
           },
-          "resolution": 100,
-          "lines": true,
-          "fill": 5,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
           "bars": false,
-          "stack": true,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false
-          },
-          "percentage": false,
-          "zerofill": true,
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "individual",
-            "query_as_alias": true
-          },
-          "targets": [
-            {
-              "target": "monitoring-1_management<%= @machine_suffix_metrics -%>.cdn_fastly-govuk.requests-status_{5,4,3,2}xx"
-            }
-          ],
-          "aliasColors": {
-            "monitoring-1_management<%= @machine_suffix_metrics -%>.cdn_fastly-govuk.requests-status_5xx": "#E24D42",
-            "monitoring-1_management<%= @machine_suffix_metrics -%>.cdn_fastly-govuk.requests-status_4xx": "#EAB839",
-            "monitoring-1_management<%= @machine_suffix_metrics -%>.cdn_fastly-govuk.requests-status_3xx": "#6ED0E0",
-            "monitoring-1_management<%= @machine_suffix_metrics -%>.cdn_fastly-govuk.requests-status_2xx": "#7EB26D"
-          },
-          "aliasYAxis": {},
-          "title": "www.gov edge status code"
-        },
-        {
-          "span": 4,
+          "datasource": "Graphite",
           "editable": true,
-          "type": "graphite",
-          "loadingEditor": false,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "scale": 1,
-          "y_formats": [
-            "short",
-            "short"
-          ],
+          "fill": 5,
           "grid": {
             "max": null,
             "min": 0,
             "threshold1": null,
-            "threshold2": null,
             "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "annotate": {
-            "enable": false
-          },
-          "resolution": 100,
-          "lines": true,
-          "fill": 5,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": true,
           "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false
-          },
-          "percentage": false,
-          "zerofill": true,
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "individual",
-            "query_as_alias": true
-          },
-          "targets": [
-            {
-              "target": "monitoring-1_management<%= @machine_suffix_metrics -%>.cdn_fastly-assets.requests-status_{5,4,3,2}xx"
-            }
-          ],
-          "aliasColors": {
-            "monitoring-1_management<%= @machine_suffix_metrics -%>.cdn_fastly-assets.requests-status_5xx": "#E24D42",
-            "monitoring-1_management<%= @machine_suffix_metrics -%>.cdn_fastly-assets.requests-status_4xx": "#EAB839",
-            "monitoring-1_management<%= @machine_suffix_metrics -%>.cdn_fastly-assets.requests-status_3xx": "#6ED0E0",
-            "monitoring-1_management<%= @machine_suffix_metrics -%>.cdn_fastly-assets.requests-status_2xx": "#7EB26D"
-          },
-          "aliasYAxis": {},
-          "title": "assets edge status code"
-        },
-        {
-          "span": 4,
-          "editable": true,
-          "type": "graphite",
-          "loadingEditor": false,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "scale": 1,
-          "y_formats": [
-            "short",
-            "short"
-          ],
-          "grid": {
-            "max": null,
-            "min": 0,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "annotate": {
-            "enable": false
-          },
-          "resolution": 100,
-          "lines": true,
-          "fill": 5,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": true,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false
-          },
-          "percentage": false,
-          "zerofill": true,
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "individual",
-            "query_as_alias": true
-          },
-          "targets": [
-            {
-              "target": "monitoring-1_management<%= @machine_suffix_metrics -%>.cdn_fastly-redirector.requests-status_{5,4,3,2}xx"
-            }
-          ],
-          "aliasColors": {
-            "monitoring-1_management<%= @machine_suffix_metrics -%>.cdn_fastly-redirector.requests-status_5xx": "#E24D42",
-            "monitoring-1_management<%= @machine_suffix_metrics -%>.cdn_fastly-redirector.requests-status_4xx": "#EAB839",
-            "monitoring-1_management<%= @machine_suffix_metrics -%>.cdn_fastly-redirector.requests-status_3xx": "#6ED0E0",
-            "monitoring-1_management<%= @machine_suffix_metrics -%>.cdn_fastly-redirector.requests-status_2xx": "#7EB26D"
-          },
-          "aliasYAxis": {},
-          "title": "redirector/bouncer edge status code"
-        }
-      ],
-      "notice": false
-    },
-    {
-      "title": "CDN backends",
-      "height": "250px",
-      "editable": true,
-      "collapse": false,
-      "panels": [
-        {
-          "title": "Requests by CDN backend",
-          "error": false,
-          "span": 12,
-          "editable": true,
-          "type": "graph",
-          "id": 7,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "short",
-            "short"
-          ],
-          "grid": {
-            "leftMax": 100,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 10,
-          "linewidth": 0,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": true,
-          "percentage": true,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
             "avg": false,
-            "alignAsTable": true
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
           },
-          "nullPointMode": "null as zero",
+          "lines": true,
+          "linewidth": 1,
+          "loadingEditor": false,
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "resolution": 100,
+          "scale": 1,
+          "span": 4,
+          "stack": true,
           "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": false
-          },
           "targets": [
             {
-              "target": "stats.govuk.app.govuk-cdn-logs-monitor.logs-cdn-1.cdn_backend.origin"
-            },
-            {
-              "target": "stats.govuk.app.govuk-cdn-logs-monitor.logs-cdn-1.cdn_backend.mirror0"
-            },
-            {
-              "target": "stats.govuk.app.govuk-cdn-logs-monitor.logs-cdn-1.cdn_backend.mirror1"
-            },
-            {
-              "target": "stats.govuk.app.govuk-cdn-logs-monitor.logs-cdn-1.cdn_backend.error"
+              "target": "monitoring-1_management.cdn_fastly-govuk.requests-{errors,hits,miss,pass}",
+              "refId": "A"
             }
           ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": [],
-          "leftYAxisLabel": "Proportion of requests"
+          "title": "www.gov edge cache func",
+          "tooltip": {
+            "query_as_alias": true,
+            "value_type": "individual",
+            "shared": true,
+            "msResolution": true
+          },
+          "type": "graph",
+          "zerofill": true,
+          "id": 8,
+          "yaxes": [
+            {
+              "show": true,
+              "format": "short"
+            },
+            {
+              "show": true,
+              "format": "short"
+            }
+          ],
+          "xaxis": {
+            "show": true
+          },
+          "timeFrom": null,
+          "timeShift": null,
+          "seriesOverrides": []
+        },
+        {
+          "aliasColors": {
+            "monitoring-1_management.cdn_fastly-assets.requests-errors": "#890F02"
+          },
+          "annotate": {
+            "enable": false
+          },
+          "bars": false,
+          "datasource": "Graphite",
+          "editable": true,
+          "fill": 5,
+          "grid": {
+            "max": null,
+            "min": 0,
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "loadingEditor": false,
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "resolution": 100,
+          "scale": 1,
+          "span": 4,
+          "stack": true,
+          "steppedLine": false,
+          "targets": [
+            {
+              "target": "monitoring-1_management.cdn_fastly-assets.requests-{errors,hits,miss,pass}",
+              "refId": "A"
+            }
+          ],
+          "title": "assets edge cache func",
+          "tooltip": {
+            "query_as_alias": true,
+            "value_type": "individual",
+            "shared": true,
+            "msResolution": true
+          },
+          "type": "graph",
+          "zerofill": true,
+          "id": 9,
+          "yaxes": [
+            {
+              "show": true,
+              "format": "short"
+            },
+            {
+              "show": true,
+              "format": "short"
+            }
+          ],
+          "xaxis": {
+            "show": true
+          },
+          "timeFrom": null,
+          "timeShift": null,
+          "seriesOverrides": []
+        },
+        {
+          "aliasColors": {
+            "monitoring-1_management.cdn_fastly-redirector.requests-errors": "#890F02"
+          },
+          "annotate": {
+            "enable": false
+          },
+          "bars": false,
+          "datasource": "Graphite",
+          "editable": true,
+          "fill": 5,
+          "grid": {
+            "max": null,
+            "min": 0,
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "loadingEditor": false,
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "resolution": 100,
+          "scale": 1,
+          "span": 4,
+          "stack": true,
+          "steppedLine": false,
+          "targets": [
+            {
+              "target": "monitoring-1_management.cdn_fastly-redirector.requests-{errors,hits,miss,pass}",
+              "refId": "A"
+            }
+          ],
+          "title": "bouncer/redirector edge cache func",
+          "tooltip": {
+            "query_as_alias": true,
+            "value_type": "individual",
+            "shared": true,
+            "msResolution": true
+          },
+          "type": "graph",
+          "zerofill": true,
+          "id": 10,
+          "yaxes": [
+            {
+              "show": true,
+              "format": "short"
+            },
+            {
+              "show": true,
+              "format": "short"
+            }
+          ],
+          "xaxis": {
+            "show": true
+          },
+          "timeFrom": null,
+          "timeShift": null,
+          "seriesOverrides": []
         }
-      ]
-    }
-  ],
-  "editable": true,
-  "failover": false,
-  "panel_hints": true,
-  "style": "dark",
-  "pulldowns": [
-    {
-      "type": "filtering",
-      "collapse": false,
-      "notice": false,
-      "enable": false
+      ],
+      "title": "one"
     },
     {
-      "type": "annotations",
-      "enable": false,
-      "annotations": []
-    }
-  ],
-  "nav": [
-    {
-      "type": "timepicker",
+      "collapsable": true,
       "collapse": false,
+      "editable": true,
+      "height": "375px",
       "notice": false,
-      "enable": true,
-      "status": "Stable",
-      "time_options": [
-        "5m",
-        "15m",
-        "1h",
-        "6h",
-        "12h",
-        "24h",
-        "2d",
-        "7d",
-        "30d"
+      "panels": [
+        {
+          "aliasColors": {
+            "monitoring-1_management.cdn_fastly-govuk.requests-status_2xx": "#7EB26D",
+            "monitoring-1_management.cdn_fastly-govuk.requests-status_3xx": "#6ED0E0",
+            "monitoring-1_management.cdn_fastly-govuk.requests-status_4xx": "#EAB839",
+            "monitoring-1_management.cdn_fastly-govuk.requests-status_5xx": "#E24D42"
+          },
+          "annotate": {
+            "enable": false
+          },
+          "bars": false,
+          "datasource": "Graphite",
+          "editable": true,
+          "fill": 5,
+          "grid": {
+            "max": null,
+            "min": 0,
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "loadingEditor": false,
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "resolution": 100,
+          "scale": 1,
+          "span": 4,
+          "stack": true,
+          "steppedLine": false,
+          "targets": [
+            {
+              "target": "monitoring-1_management.cdn_fastly-govuk.requests-status_{5,4,3,2}xx",
+              "refId": "A"
+            }
+          ],
+          "title": "www.gov edge status code",
+          "tooltip": {
+            "query_as_alias": true,
+            "value_type": "individual",
+            "shared": true,
+            "msResolution": true
+          },
+          "type": "graph",
+          "zerofill": true,
+          "id": 11,
+          "yaxes": [
+            {
+              "show": true,
+              "format": "short"
+            },
+            {
+              "show": true,
+              "format": "short"
+            }
+          ],
+          "xaxis": {
+            "show": true
+          },
+          "timeFrom": null,
+          "timeShift": null,
+          "seriesOverrides": []
+        },
+        {
+          "aliasColors": {
+            "monitoring-1_management.cdn_fastly-assets.requests-status_2xx": "#7EB26D",
+            "monitoring-1_management.cdn_fastly-assets.requests-status_3xx": "#6ED0E0",
+            "monitoring-1_management.cdn_fastly-assets.requests-status_4xx": "#EAB839",
+            "monitoring-1_management.cdn_fastly-assets.requests-status_5xx": "#E24D42"
+          },
+          "annotate": {
+            "enable": false
+          },
+          "bars": false,
+          "datasource": "Graphite",
+          "editable": true,
+          "fill": 5,
+          "grid": {
+            "max": null,
+            "min": 0,
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "loadingEditor": false,
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "resolution": 100,
+          "scale": 1,
+          "span": 4,
+          "stack": true,
+          "steppedLine": false,
+          "targets": [
+            {
+              "target": "monitoring-1_management.cdn_fastly-assets.requests-status_{5,4,3,2}xx",
+              "refId": "A"
+            }
+          ],
+          "title": "assets edge status code",
+          "tooltip": {
+            "query_as_alias": true,
+            "value_type": "individual",
+            "shared": true,
+            "msResolution": true
+          },
+          "type": "graph",
+          "zerofill": true,
+          "id": 12,
+          "yaxes": [
+            {
+              "show": true,
+              "format": "short"
+            },
+            {
+              "show": true,
+              "format": "short"
+            }
+          ],
+          "xaxis": {
+            "show": true
+          },
+          "timeFrom": null,
+          "timeShift": null,
+          "seriesOverrides": []
+        },
+        {
+          "aliasColors": {
+            "monitoring-1_management.cdn_fastly-redirector.requests-status_2xx": "#7EB26D",
+            "monitoring-1_management.cdn_fastly-redirector.requests-status_3xx": "#6ED0E0",
+            "monitoring-1_management.cdn_fastly-redirector.requests-status_4xx": "#EAB839",
+            "monitoring-1_management.cdn_fastly-redirector.requests-status_5xx": "#E24D42"
+          },
+          "annotate": {
+            "enable": false
+          },
+          "bars": false,
+          "datasource": "Graphite",
+          "editable": true,
+          "fill": 5,
+          "grid": {
+            "max": null,
+            "min": 0,
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "loadingEditor": false,
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "resolution": 100,
+          "scale": 1,
+          "span": 4,
+          "stack": true,
+          "steppedLine": false,
+          "targets": [
+            {
+              "target": "monitoring-1_management.cdn_fastly-redirector.requests-status_{5,4,3,2}xx",
+              "refId": "A"
+            }
+          ],
+          "title": "redirector/bouncer edge status code",
+          "tooltip": {
+            "query_as_alias": true,
+            "value_type": "individual",
+            "shared": true,
+            "msResolution": true
+          },
+          "type": "graph",
+          "zerofill": true,
+          "id": 13,
+          "yaxes": [
+            {
+              "show": true,
+              "format": "short"
+            },
+            {
+              "show": true,
+              "format": "short"
+            }
+          ],
+          "xaxis": {
+            "show": true
+          },
+          "timeFrom": null,
+          "timeShift": null,
+          "seriesOverrides": []
+        }
       ],
-      "refresh_intervals": [
-        "5s",
-        "10s",
-        "30s",
-        "1m",
-        "5m",
-        "15m",
-        "30m",
-        "1h",
-        "2h",
-        "1d"
+      "title": "two"
+    },
+    {
+      "collapse": false,
+      "editable": true,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "Graphite",
+          "editable": true,
+          "error": false,
+          "fill": 10,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "id": 7,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 0,
+          "links": [],
+          "nullPointMode": "null as zero",
+          "percentage": true,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 12,
+          "stack": true,
+          "steppedLine": false,
+          "targets": [
+            {
+              "target": "stats.govuk.app.govuk-cdn-logs-monitor.logs-cdn-1.cdn_backend.origin",
+              "refId": "A"
+            },
+            {
+              "target": "stats.govuk.app.govuk-cdn-logs-monitor.logs-cdn-1.cdn_backend.mirror0",
+              "refId": "B"
+            },
+            {
+              "target": "stats.govuk.app.govuk-cdn-logs-monitor.logs-cdn-1.cdn_backend.mirror1",
+              "refId": "C"
+            },
+            {
+              "target": "stats.govuk.app.govuk-cdn-logs-monitor.logs-cdn-1.cdn_backend.error",
+              "refId": "D"
+            }
+          ],
+          "title": "Requests by CDN backend",
+          "tooltip": {
+            "shared": false,
+            "value_type": "cumulative",
+            "msResolution": true
+          },
+          "type": "graph",
+          "yaxes": [
+            {
+              "show": true,
+              "min": 0,
+              "max": 100,
+              "format": "short",
+              "label": "Proportion of requests"
+            },
+            {
+              "show": true,
+              "min": null,
+              "max": null,
+              "format": "short"
+            }
+          ],
+          "xaxis": {
+            "show": true
+          },
+          "timeFrom": null,
+          "timeShift": null
+        }
       ],
-      "now": true
+      "title": "CDN backends"
     }
   ],
-  "loader": {
-    "save_gist": false,
-    "save_elasticsearch": false,
-    "save_local": true,
-    "save_default": true,
-    "save_temp": true,
-    "save_temp_ttl_enable": true,
-    "save_temp_ttl": "30d",
-    "load_gist": false,
-    "load_elasticsearch": false,
-    "load_elasticsearch_size": 20,
-    "load_local": true,
-    "hide": false
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "collapse": false,
+    "enable": true,
+    "notice": false,
+    "now": true,
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "status": "Stable",
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ],
+    "type": "timepicker"
+  },
+  "templating": {
+    "list": []
+  },
+  "annotations": {
+    "list": []
   },
   "refresh": "1m",
-  "tags": [],
-  "timezone": "utc"
+  "schemaVersion": 12,
+  "version": 0,
+  "links": []
 }

--- a/modules/grafana/templates/dashboards/origin_health.json.erb
+++ b/modules/grafana/templates/dashboards/origin_health.json.erb
@@ -1,50 +1,47 @@
 {
+  "id": null,
   "title": "origin health",
-  "services": {
-    "filter": {
-      "list": [],
-      "time": {
-        "from": "now-6h",
-        "to": "now"
-      }
-    }
-  },
+  "originalTitle": "origin health",
+  "tags": [],
+  "style": "dark",
+  "timezone": "utc",
+  "editable": true,
+  "hideControls": false,
+  "sharedCrosshair": false,
   "rows": [
     {
-      "title": "one",
-      "height": "400px",
-      "editable": true,
-      "collapse": false,
       "collapsable": true,
+      "collapse": false,
+      "editable": true,
+      "height": "400px",
+      "notice": false,
       "panels": [
         {
-          "span": 4,
-          "editable": true,
-          "type": "graphite",
-          "loadingEditor": false,
-          "x-axis": true,
-          "y-axis": true,
-          "scale": 1,
-          "grid": {
-            "max": null,
-            "min": 0,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
+          "aliasColors": {},
           "annotate": {
             "enable": false,
+            "field": "_type",
             "query": "*",
             "size": 20,
-            "field": "_type",
             "sort": [
               "_score",
               "desc"
             ]
           },
           "auto_int": true,
-          "resolution": 100,
+          "bars": false,
+          "datasource": "Graphite",
+          "editable": true,
+          "fill": 10,
+          "grid": {
+            "max": null,
+            "min": 0,
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "interactive": true,
           "interval": "5m",
           "intervals": [
             "auto",
@@ -60,165 +57,91 @@
             "1w",
             "1y"
           ],
-          "lines": true,
-          "fill": 10,
-          "linewidth": 0,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": true,
-          "spyable": true,
-          "zoomlinks": false,
-          "options": false,
           "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
+            "avg": false,
             "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
             "total": false,
-            "avg": false
+            "values": false
           },
-          "interactive": true,
           "legend_counts": true,
-          "percentage": false,
-          "zerofill": true,
+          "lines": true,
+          "linewidth": 0,
+          "loadingEditor": false,
           "nullPointMode": "connected",
+          "options": false,
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "resolution": 100,
+          "scale": 1,
+          "span": 4,
+          "spyable": true,
+          "stack": true,
           "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "query_as_alias": true
-          },
           "targets": [
             {
-              "target": "aliasSub(stats.cache-*_router<%= @machine_suffix_metrics -%>.nginx_logs.www-origin.http_5xx,\".*(cache-\\d+).*\", \"\\1\")"
+              "target": "aliasSub(stats.cache-*_router.nginx_logs.www-origin.http_5xx,\".*(cache-\\d+).*\", \"\\1\")",
+              "refId": "A"
             }
           ],
-          "aliasColors": {},
-          "aliasYAxis": {},
           "title": "HTTP 5xx/s",
-          "datasource": null,
-          "renderer": "flot",
-          "y_formats": [
-            "none",
-            "none"
-          ]
+          "tooltip": {
+            "query_as_alias": true,
+            "value_type": "cumulative",
+            "shared": true,
+            "msResolution": true
+          },
+          "type": "graph",
+          "zerofill": true,
+          "zoomlinks": false,
+          "id": 1,
+          "yaxes": [
+            {
+              "show": true,
+              "format": "none"
+            },
+            {
+              "show": true,
+              "format": "none"
+            }
+          ],
+          "xaxis": {
+            "show": true
+          },
+          "timeFrom": null,
+          "timeShift": null,
+          "seriesOverrides": []
         },
         {
-          "span": 4,
-          "editable": true,
-          "type": "graphite",
-          "loadingEditor": false,
-          "x-axis": true,
-          "y-axis": true,
-          "scale": 1,
-          "grid": {
-            "max": null,
-            "min": 0,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
+          "aliasColors": {},
           "annotate": {
             "enable": false,
+            "field": "_type",
             "query": "*",
             "size": 20,
-            "field": "_type",
             "sort": [
               "_score",
               "desc"
             ]
           },
           "auto_int": true,
-          "resolution": 100,
-          "interval": "5m",
-          "intervals": [
-            "auto",
-            "1s",
-            "1m",
-            "5m",
-            "10m",
-            "30m",
-            "1h",
-            "3h",
-            "12h",
-            "1d",
-            "1w",
-            "1y"
-          ],
-          "lines": true,
+          "bars": false,
+          "datasource": "Graphite",
+          "editable": true,
           "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": true,
-          "spyable": true,
-          "zoomlinks": false,
-          "options": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false
-          },
-          "interactive": true,
-          "legend_counts": true,
-          "percentage": false,
-          "zerofill": true,
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "query_as_alias": true
-          },
-          "targets": [
-            {
-              "target": "aliasSub(movingMedian(cache-*_router<%= @machine_suffix_metrics -%>.nginx.nginx_requests, '1min'),\".*(cache-\\d+).*\", \"\\1\")"
-            }
-          ],
-          "aliasColors": {},
-          "aliasYAxis": {},
-          "title": "HTTP total/s",
-          "datasource": null,
-          "renderer": "flot",
-          "y_formats": [
-            "none",
-            "none"
-          ]
-        },
-        {
-          "span": 4,
-          "editable": true,
-          "type": "graphite",
-          "loadingEditor": false,
-          "x-axis": true,
-          "y-axis": true,
-          "scale": 1,
           "grid": {
             "max": null,
             "min": 0,
             "threshold1": null,
-            "threshold2": null,
             "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "annotate": {
-            "enable": false,
-            "query": "*",
-            "size": 20,
-            "field": "_type",
-            "sort": [
-              "_score",
-              "desc"
-            ]
-          },
-          "auto_int": true,
-          "resolution": 100,
+          "interactive": true,
           "interval": "5m",
           "intervals": [
             "auto",
@@ -234,94 +157,212 @@
             "1w",
             "1y"
           ],
-          "lines": true,
-          "fill": 10,
-          "linewidth": 0,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "spyable": true,
-          "zoomlinks": false,
-          "options": false,
           "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
+            "avg": false,
             "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
             "total": false,
-            "avg": false
+            "values": false
           },
-          "interactive": true,
           "legend_counts": true,
-          "percentage": false,
-          "zerofill": true,
+          "lines": true,
+          "linewidth": 1,
+          "loadingEditor": false,
           "nullPointMode": "connected",
+          "options": false,
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "resolution": 100,
+          "scale": 1,
+          "span": 4,
+          "spyable": true,
+          "stack": true,
           "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "query_as_alias": true
-          },
           "targets": [
             {
-              "target": "alias(movingAverage(asPercent(divideSeries(stats.cache-1_router<%= @machine_suffix_metrics -%>.nginx_logs.www-origin.http_5xx,sum(stats.cache-1_router<%= @machine_suffix_metrics -%>.nginx_logs.www-origin.http_*xx)),1), '1min'),\"cache-1\")"
-            },
-            {
-              "target": "alias(movingAverage(asPercent(divideSeries(stats.cache-2_router<%= @machine_suffix_metrics -%>.nginx_logs.www-origin.http_5xx,sum(stats.cache-2_router<%= @machine_suffix_metrics -%>.nginx_logs.www-origin.http_*xx)),1), '1min'),\"cache-2\")"
-            },
-            {
-              "target": "alias(movingAverage(asPercent(divideSeries(stats.cache-3_router<%= @machine_suffix_metrics -%>.nginx_logs.www-origin.http_5xx,sum(stats.cache-3_router<%= @machine_suffix_metrics -%>.nginx_logs.www-origin.http_*xx)),1), '1min'),\"cache-3\")"
+              "target": "aliasSub(movingMedian(cache-*_router.nginx.nginx_requests, '1min'),\".*(cache-\\d+).*\", \"\\1\")",
+              "refId": "A"
             }
           ],
+          "title": "HTTP total/s",
+          "tooltip": {
+            "query_as_alias": true,
+            "value_type": "cumulative",
+            "shared": true,
+            "msResolution": true
+          },
+          "type": "graph",
+          "zerofill": true,
+          "zoomlinks": false,
+          "id": 2,
+          "yaxes": [
+            {
+              "show": true,
+              "format": "none"
+            },
+            {
+              "show": true,
+              "format": "none"
+            }
+          ],
+          "xaxis": {
+            "show": true
+          },
+          "timeFrom": null,
+          "timeShift": null,
+          "seriesOverrides": []
+        },
+        {
           "aliasColors": {},
-          "aliasYAxis": {},
-          "title": "HTTP error/pc",
-          "datasource": null,
+          "annotate": {
+            "enable": false,
+            "field": "_type",
+            "query": "*",
+            "size": 20,
+            "sort": [
+              "_score",
+              "desc"
+            ]
+          },
+          "auto_int": true,
+          "bars": false,
+          "datasource": "Graphite",
+          "editable": true,
+          "fill": 10,
+          "grid": {
+            "max": null,
+            "min": 0,
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "interactive": true,
+          "interval": "5m",
+          "intervals": [
+            "auto",
+            "1s",
+            "1m",
+            "5m",
+            "10m",
+            "30m",
+            "1h",
+            "3h",
+            "12h",
+            "1d",
+            "1w",
+            "1y"
+          ],
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "legend_counts": true,
+          "lines": true,
+          "linewidth": 0,
+          "loadingEditor": false,
+          "nullPointMode": "connected",
+          "options": false,
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
           "renderer": "flot",
-          "y_formats": [
-            "none",
-            "none"
-          ]
+          "resolution": 100,
+          "scale": 1,
+          "span": 4,
+          "spyable": true,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "target": "alias(movingAverage(asPercent(divideSeries(stats.cache-1_router.nginx_logs.www-origin.http_5xx,sum(stats.cache-1_router.nginx_logs.www-origin.http_*xx)),1), '1min'),\"cache-1\")",
+              "refId": "A",
+              "textEditor": true
+            },
+            {
+              "target": "alias(movingAverage(asPercent(divideSeries(stats.cache-2_router.nginx_logs.www-origin.http_5xx,sum(stats.cache-2_router.nginx_logs.www-origin.http_*xx)),1), '1min'),\"cache-2\")",
+              "refId": "B",
+              "textEditor": true
+            },
+            {
+              "target": "alias(movingAverage(asPercent(divideSeries(stats.cache-3_router.nginx_logs.www-origin.http_5xx,sum(stats.cache-3_router.nginx_logs.www-origin.http_*xx)),1), '1min'),\"cache-3\")",
+              "refId": "C",
+              "textEditor": true
+            }
+          ],
+          "title": "HTTP error/pc",
+          "tooltip": {
+            "query_as_alias": true,
+            "value_type": "cumulative",
+            "shared": true,
+            "msResolution": true
+          },
+          "type": "graph",
+          "zerofill": true,
+          "zoomlinks": false,
+          "id": 3,
+          "yaxes": [
+            {
+              "show": true,
+              "format": "none"
+            },
+            {
+              "show": true,
+              "format": "none"
+            }
+          ],
+          "xaxis": {
+            "show": true
+          },
+          "timeFrom": null,
+          "timeShift": null,
+          "seriesOverrides": []
         }
       ],
-      "notice": false
+      "title": "one"
     },
     {
-      "title": "two",
-      "height": "400px",
-      "editable": true,
-      "collapse": false,
       "collapsable": true,
+      "collapse": false,
+      "editable": true,
+      "height": "400px",
+      "notice": false,
       "panels": [
         {
-          "span": 4,
-          "editable": true,
-          "type": "graphite",
-          "loadingEditor": false,
-          "x-axis": true,
-          "y-axis": true,
-          "scale": 1,
-          "grid": {
-            "max": null,
-            "min": 0,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
+          "aliasColors": {},
           "annotate": {
             "enable": false,
+            "field": "_type",
             "query": "*",
             "size": 20,
-            "field": "_type",
             "sort": [
               "_score",
               "desc"
             ]
           },
           "auto_int": true,
-          "resolution": 100,
+          "bars": false,
+          "datasource": "Graphite",
+          "editable": true,
+          "fill": 0,
+          "grid": {
+            "max": null,
+            "min": 0,
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "interactive": true,
           "interval": "5m",
           "intervals": [
             "auto",
@@ -337,165 +378,91 @@
             "1w",
             "1y"
           ],
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "spyable": true,
-          "zoomlinks": false,
-          "options": false,
           "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
+            "avg": false,
             "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
             "total": false,
-            "avg": false
+            "values": false
           },
-          "interactive": true,
           "legend_counts": true,
-          "percentage": false,
-          "zerofill": true,
+          "lines": true,
+          "linewidth": 1,
+          "loadingEditor": false,
           "nullPointMode": "connected",
+          "options": false,
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "resolution": 100,
+          "scale": 1,
+          "span": 4,
+          "spyable": true,
+          "stack": false,
           "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "query_as_alias": true
-          },
           "targets": [
             {
-              "target": "aliasSub(stats.timers.cache-*_router<%= @machine_suffix_metrics -%>.nginx_logs.www-origin.time_request.mean,\".*(cache-\\d+).*\", \"\\1\")"
+              "target": "aliasSub(stats.timers.cache-*_router.nginx_logs.www-origin.time_request.mean,\".*(cache-\\d+).*\", \"\\1\")",
+              "refId": "A"
             }
           ],
-          "aliasColors": {},
-          "aliasYAxis": {},
           "title": "Cache resp/avg",
-          "datasource": null,
-          "renderer": "flot",
-          "y_formats": [
-            "none",
-            "none"
-          ]
+          "tooltip": {
+            "query_as_alias": true,
+            "value_type": "cumulative",
+            "shared": true,
+            "msResolution": true
+          },
+          "type": "graph",
+          "zerofill": true,
+          "zoomlinks": false,
+          "id": 4,
+          "yaxes": [
+            {
+              "show": true,
+              "format": "none"
+            },
+            {
+              "show": true,
+              "format": "none"
+            }
+          ],
+          "xaxis": {
+            "show": true
+          },
+          "timeFrom": null,
+          "timeShift": null,
+          "seriesOverrides": []
         },
         {
-          "span": 4,
-          "editable": true,
-          "type": "graphite",
-          "loadingEditor": false,
-          "x-axis": true,
-          "y-axis": true,
-          "scale": 1,
-          "grid": {
-            "max": null,
-            "min": 0,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
+          "aliasColors": {},
           "annotate": {
             "enable": false,
+            "field": "_type",
             "query": "*",
             "size": 20,
-            "field": "_type",
             "sort": [
               "_score",
               "desc"
             ]
           },
           "auto_int": true,
-          "resolution": 100,
-          "interval": "5m",
-          "intervals": [
-            "auto",
-            "1s",
-            "1m",
-            "5m",
-            "10m",
-            "30m",
-            "1h",
-            "3h",
-            "12h",
-            "1d",
-            "1w",
-            "1y"
-          ],
-          "lines": true,
+          "bars": false,
+          "datasource": "Graphite",
+          "editable": true,
           "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "spyable": true,
-          "zoomlinks": false,
-          "options": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false
-          },
-          "interactive": true,
-          "legend_counts": true,
-          "percentage": false,
-          "zerofill": true,
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "query_as_alias": true
-          },
-          "targets": [
-            {
-              "target": "aliasByNode(highestMax(*.nginx.nginx_connections-writing,6),0)"
-            }
-          ],
-          "aliasColors": {},
-          "aliasYAxis": {},
-          "title": "Nginx cnx writing/top6",
-          "datasource": null,
-          "renderer": "flot",
-          "y_formats": [
-            "none",
-            "none"
-          ]
-        },
-        {
-          "span": 4,
-          "editable": true,
-          "type": "graphite",
-          "loadingEditor": false,
-          "x-axis": true,
-          "y-axis": true,
-          "scale": 1,
           "grid": {
             "max": null,
             "min": 0,
             "threshold1": null,
-            "threshold2": null,
             "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "annotate": {
-            "enable": false,
-            "query": "*",
-            "size": 20,
-            "field": "_type",
-            "sort": [
-              "_score",
-              "desc"
-            ]
-          },
-          "auto_int": true,
-          "resolution": 100,
+          "interactive": true,
           "interval": "5m",
           "intervals": [
             "auto",
@@ -511,140 +478,233 @@
             "1w",
             "1y"
           ],
-          "lines": true,
-          "fill": 10,
-          "linewidth": 0,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "spyable": true,
-          "zoomlinks": false,
-          "options": false,
           "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
+            "avg": false,
             "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
             "total": false,
-            "avg": false
+            "values": false
           },
-          "interactive": true,
           "legend_counts": true,
-          "percentage": false,
-          "zerofill": true,
+          "lines": true,
+          "linewidth": 1,
+          "loadingEditor": false,
           "nullPointMode": "connected",
+          "options": false,
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "resolution": 100,
+          "scale": 1,
+          "span": 4,
+          "spyable": true,
+          "stack": false,
           "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "query_as_alias": true
-          },
           "targets": [
             {
-              "target": "maximumAbove(aliasSub(groupByNode(stats.*_frontend<%= @machine_suffix_metrics -%>.nginx_logs.*_<%= @app_domain_metrics -%>.http_500,3,\"sum\"),\"_.*\",\"\"),0)"
+              "target": "aliasByNode(highestMax(*.nginx.nginx_connections-writing,6),0)",
+              "refId": "A"
             }
           ],
-          "aliasColors": {},
-          "aliasYAxis": {},
-          "title": "HTTP 5xx/app",
-          "datasource": null,
-          "renderer": "flot",
-          "y_formats": [
-            "none",
-            "none"
-          ]
-        }
-      ],
-      "notice": false
-    }
-  ],
-  "editable": true,
-  "failover": false,
-  "panel_hints": true,
-  "style": "dark",
-  "pulldowns": [
-    {
-      "type": "filtering",
-      "collapse": false,
-      "notice": false,
-      "enable": false
-    },
-    {
-      "type": "annotations",
-      "enable": true,
-      "annotations": [
-        {
-          "name": "all deploys",
-          "type": "graphite events",
-          "showLine": true,
-          "iconColor": "#C0C6BE",
-          "lineColor": "rgba(32, 230, 25, 0.592157)",
-          "iconSize": 13,
-          "enable": true,
-          "tags": "deploys"
+          "title": "Nginx cnx writing/top6",
+          "tooltip": {
+            "query_as_alias": true,
+            "value_type": "cumulative",
+            "shared": true,
+            "msResolution": true
+          },
+          "type": "graph",
+          "zerofill": true,
+          "zoomlinks": false,
+          "id": 5,
+          "yaxes": [
+            {
+              "show": true,
+              "format": "none"
+            },
+            {
+              "show": true,
+              "format": "none"
+            }
+          ],
+          "xaxis": {
+            "show": true
+          },
+          "timeFrom": null,
+          "timeShift": null,
+          "seriesOverrides": []
         },
         {
-          "name": "all restarts",
-          "type": "graphite metric",
-          "showLine": true,
-          "iconColor": "#FF2020",
-          "lineColor": "rgba(255, 32, 32, 0.592157)",
-          "iconSize": 13,
-          "enable": true,
-          "target": "substr(stats.govuk.app.*.restarts,3,5)"
+          "aliasColors": {},
+          "annotate": {
+            "enable": false,
+            "field": "_type",
+            "query": "*",
+            "size": 20,
+            "sort": [
+              "_score",
+              "desc"
+            ]
+          },
+          "auto_int": true,
+          "bars": false,
+          "datasource": "Graphite",
+          "editable": true,
+          "fill": 10,
+          "grid": {
+            "max": null,
+            "min": 0,
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "interactive": true,
+          "interval": "5m",
+          "intervals": [
+            "auto",
+            "1s",
+            "1m",
+            "5m",
+            "10m",
+            "30m",
+            "1h",
+            "3h",
+            "12h",
+            "1d",
+            "1w",
+            "1y"
+          ],
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "legend_counts": true,
+          "lines": true,
+          "linewidth": 0,
+          "loadingEditor": false,
+          "nullPointMode": "connected",
+          "options": false,
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "resolution": 100,
+          "scale": 1,
+          "span": 4,
+          "spyable": true,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "target": "maximumAbove(aliasSub(groupByNode(stats.*_frontend.nginx_logs.*_publishing_service_gov_uk.http_500,3,\"sum\"),\"_.*\",\"\"),0)",
+              "refId": "A"
+            }
+          ],
+          "title": "HTTP 5xx/app",
+          "tooltip": {
+            "query_as_alias": true,
+            "value_type": "cumulative",
+            "shared": true,
+            "msResolution": true
+          },
+          "type": "graph",
+          "zerofill": true,
+          "zoomlinks": false,
+          "id": 6,
+          "yaxes": [
+            {
+              "show": true,
+              "format": "none"
+            },
+            {
+              "show": true,
+              "format": "none"
+            }
+          ],
+          "xaxis": {
+            "show": true
+          },
+          "timeFrom": null,
+          "timeShift": null,
+          "seriesOverrides": []
         }
-      ]
+      ],
+      "title": "two"
     }
   ],
-  "nav": [
-    {
-      "type": "timepicker",
-      "collapse": false,
-      "notice": false,
-      "enable": true,
-      "status": "Stable",
-      "time_options": [
-        "5m",
-        "15m",
-        "1h",
-        "6h",
-        "12h",
-        "24h",
-        "2d",
-        "7d",
-        "30d"
-      ],
-      "refresh_intervals": [
-        "5s",
-        "10s",
-        "30s",
-        "1m",
-        "5m",
-        "15m",
-        "30m",
-        "1h",
-        "2h",
-        "1d"
-      ],
-      "now": true
-    }
-  ],
-  "loader": {
-    "save_gist": false,
-    "save_elasticsearch": false,
-    "save_local": true,
-    "save_default": true,
-    "save_temp": true,
-    "save_temp_ttl_enable": true,
-    "save_temp_ttl": "30d",
-    "load_gist": false,
-    "load_elasticsearch": false,
-    "load_elasticsearch_size": 20,
-    "load_local": true,
-    "hide": false
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "collapse": false,
+    "enable": true,
+    "notice": false,
+    "now": true,
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "status": "Stable",
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ],
+    "type": "timepicker"
+  },
+  "templating": {
+    "list": []
+  },
+  "annotations": {
+    "list": [
+      {
+        "enable": true,
+        "iconColor": "#C0C6BE",
+        "iconSize": 13,
+        "lineColor": "rgba(32, 230, 25, 0.592157)",
+        "name": "all deploys",
+        "showLine": true,
+        "tags": "deploys",
+        "type": "graphite events"
+      },
+      {
+        "enable": true,
+        "iconColor": "#FF2020",
+        "iconSize": 13,
+        "lineColor": "rgba(255, 32, 32, 0.592157)",
+        "name": "all restarts",
+        "showLine": true,
+        "target": "substr(stats.govuk.app.*.restarts,3,5)",
+        "type": "graphite metric"
+      }
+    ]
   },
   "refresh": "1m",
-  "tags": [],
-  "timezone": "utc"
+  "schemaVersion": 12,
+  "version": 0,
+  "links": []
 }

--- a/modules/grafana/templates/dashboards/publishing_api_overview.json.erb
+++ b/modules/grafana/templates/dashboards/publishing_api_overview.json.erb
@@ -248,7 +248,7 @@
         },
         {
           "aliasColors": {},
-          "bars": false,
+          "bars": true,
           "datasource": "Elasticsearch",
           "editable": true,
           "error": false,
@@ -272,7 +272,7 @@
             "total": false,
             "values": true
           },
-          "lines": true,
+          "lines": false,
           "linewidth": 2,
           "links": [],
           "nullPointMode": "connected",
@@ -315,7 +315,7 @@
               "hide": false,
               "metrics": [
                 {
-                  "field": "request_time",
+                  "field": "@fields.duration",
                   "id": "3",
                   "meta": {},
                   "settings": {},
@@ -354,7 +354,7 @@
               "dsType": "elasticsearch",
               "metrics": [
                 {
-                  "field": "request_time",
+                  "field": "@fields.duration",
                   "id": "3",
                   "meta": {},
                   "settings": {},
@@ -393,7 +393,7 @@
               "dsType": "elasticsearch",
               "metrics": [
                 {
-                  "field": "request_time",
+                  "field": "@fields.duration",
                   "id": "3",
                   "meta": {},
                   "settings": {},
@@ -432,7 +432,7 @@
               "dsType": "elasticsearch",
               "metrics": [
                 {
-                  "field": "request_time",
+                  "field": "@fields.duration",
                   "id": "3",
                   "meta": {},
                   "settings": {},
@@ -471,7 +471,7 @@
               "dsType": "elasticsearch",
               "metrics": [
                 {
-                  "field": "request_time",
+                  "field": "@fields.duration",
                   "id": "3",
                   "meta": {},
                   "settings": {},
@@ -497,7 +497,7 @@
           },
           "yaxes": [
             {
-              "format": "s",
+              "format": "ms",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -665,7 +665,7 @@
           ],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Publishing API db size",
+          "title": "Publishing API Postgresql Metrics",
           "tooltip": {
             "msResolution": true,
             "shared": true,
@@ -735,6 +735,6 @@
   },
   "refresh": false,
   "schemaVersion": 12,
-  "version": 25,
+  "version": 0,
   "links": []
 }

--- a/modules/grafana/templates/dashboards/vpn_diagnostics.json.erb
+++ b/modules/grafana/templates/dashboards/vpn_diagnostics.json.erb
@@ -10,404 +10,468 @@
   "sharedCrosshair": false,
   "rows": [
     {
-      "title": "New row",
-      "height": "250px",
-      "editable": true,
       "collapse": false,
+      "editable": true,
+      "height": "250px",
       "panels": [
         {
-          "title": "DR Redirector VPN State",
-          "error": false,
-          "span": 12,
+          "aliasColors": {},
+          "bars": true,
+          "datasource": "Graphite",
           "editable": true,
-          "type": "graph",
+          "error": false,
+          "fill": 10,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
           "id": 1,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "none",
-            "short"
-          ],
-          "grid": {
-            "leftMax": 0.5,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
           },
           "lines": false,
-          "fill": 10,
           "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": true,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": false,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false
-          },
+          "links": [],
           "nullPointMode": "null as zero",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 12,
+          "stack": false,
           "steppedLine": true,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": false
-          },
           "targets": [
             {
-              "target": "bouncer-4_redirector<%= @machine_suffix_metrics -%>.processes.*",
-              "hide": false
+              "hide": false,
+              "target": "bouncer-4_redirector.processes.*",
+              "refId": "A"
             }
           ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": []
+          "title": "DR Redirector VPN State",
+          "tooltip": {
+            "shared": false,
+            "value_type": "cumulative",
+            "msResolution": true
+          },
+          "type": "graph",
+          "yaxes": [
+            {
+              "show": true,
+              "min": 0,
+              "max": 0.5,
+              "format": "none"
+            },
+            {
+              "show": true,
+              "min": null,
+              "max": null,
+              "format": "short"
+            }
+          ],
+          "xaxis": {
+            "show": true
+          },
+          "timeFrom": null,
+          "timeShift": null
         },
         {
-          "title": "DR API VPN State",
-          "error": false,
-          "span": 12,
+          "aliasColors": {},
+          "bars": true,
+          "datasource": null,
           "editable": true,
-          "type": "graph",
+          "error": false,
+          "fill": 10,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
           "id": 4,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "none",
-            "short"
-          ],
-          "grid": {
-            "leftMax": 0.5,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
           },
           "lines": false,
-          "fill": 10,
           "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": true,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": false,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false
-          },
+          "links": [],
           "nullPointMode": "null as zero",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 12,
+          "stack": false,
           "steppedLine": true,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": false
-          },
           "targets": [
             {
-              "target": "api-mongo-4_api<%= @machine_suffix_metrics -%>.processes.*",
-              "hide": false
+              "hide": false,
+              "target": "api-mongo-4_api.processes.*",
+              "refId": "A"
             }
           ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": []
+          "title": "DR API VPN State",
+          "tooltip": {
+            "shared": false,
+            "value_type": "cumulative",
+            "msResolution": true
+          },
+          "type": "graph",
+          "yaxes": [
+            {
+              "show": true,
+              "min": 0,
+              "max": 0.5,
+              "format": "none"
+            },
+            {
+              "show": true,
+              "min": null,
+              "max": null,
+              "format": "short"
+            }
+          ],
+          "xaxis": {
+            "show": true
+          },
+          "timeFrom": null,
+          "timeShift": null
         },
         {
-          "title": "DR Backend VPN State",
-          "error": false,
-          "span": 12,
+          "aliasColors": {},
+          "bars": true,
+          "datasource": null,
           "editable": true,
-          "type": "graph",
+          "error": false,
+          "fill": 10,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
           "id": 5,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "none",
-            "short"
-          ],
-          "grid": {
-            "leftMax": 0.5,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
           },
           "lines": false,
-          "fill": 10,
           "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": true,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": false,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false
-          },
+          "links": [],
           "nullPointMode": "null as zero",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 12,
+          "stack": false,
           "steppedLine": true,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": false
-          },
           "targets": [
             {
-              "target": "postgresql-standby-2_backend<%= @machine_suffix_metrics -%>.processes.*",
-              "hide": false
+              "hide": false,
+              "target": "postgresql-standby-2_backend.processes.*",
+              "refId": "A"
             }
           ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": []
+          "title": "DR Backend VPN State",
+          "tooltip": {
+            "shared": false,
+            "value_type": "cumulative",
+            "msResolution": true
+          },
+          "type": "graph",
+          "yaxes": [
+            {
+              "show": true,
+              "min": 0,
+              "max": 0.5,
+              "format": "none"
+            },
+            {
+              "show": true,
+              "min": null,
+              "max": null,
+              "format": "short"
+            }
+          ],
+          "xaxis": {
+            "show": true
+          },
+          "timeFrom": null,
+          "timeShift": null
         },
         {
-          "title": "DR Router VPN State",
-          "error": false,
-          "span": 12,
-          "editable": true,
-          "type": "graph",
-          "id": 6,
+          "aliasColors": {},
+          "bars": true,
           "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "none",
-            "short"
-          ],
+          "editable": true,
+          "error": false,
+          "fill": 10,
           "grid": {
-            "leftMax": 0.5,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
             "threshold1": null,
-            "threshold2": null,
             "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "lines": false,
-          "fill": 10,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": true,
-          "stack": false,
-          "percentage": false,
+          "id": 6,
           "legend": {
-            "show": false,
-            "values": false,
-            "min": false,
-            "max": false,
+            "avg": false,
             "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
             "total": false,
-            "avg": false
+            "values": false
           },
+          "lines": false,
+          "linewidth": 1,
+          "links": [],
           "nullPointMode": "null as zero",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 12,
+          "stack": false,
           "steppedLine": true,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": false
-          },
           "targets": [
             {
-              "target": "router-backend-4_router<%= @machine_suffix_metrics -%>.processes.*",
-              "hide": false
+              "hide": false,
+              "target": "router-backend-4_router.processes.*",
+              "refId": "A"
             }
           ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": []
+          "title": "DR Router VPN State",
+          "tooltip": {
+            "shared": false,
+            "value_type": "cumulative",
+            "msResolution": true
+          },
+          "type": "graph",
+          "yaxes": [
+            {
+              "show": true,
+              "min": 0,
+              "max": 0.5,
+              "format": "none"
+            },
+            {
+              "show": true,
+              "min": null,
+              "max": null,
+              "format": "short"
+            }
+          ],
+          "xaxis": {
+            "show": true
+          },
+          "timeFrom": null,
+          "timeShift": null
         }
-      ]
+      ],
+      "title": "New row"
     },
     {
-      "title": "New row",
-      "height": "250px",
-      "editable": true,
       "collapse": false,
+      "editable": true,
+      "height": "250px",
       "panels": [
         {
-          "title": "Skyscape Licensify VPN State",
-          "error": false,
-          "span": 12,
-          "editable": true,
-          "type": "graph",
-          "id": 2,
+          "aliasColors": {},
+          "bars": true,
           "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "short",
-            "short"
-          ],
+          "editable": true,
+          "error": false,
+          "fill": 0,
           "grid": {
-            "leftMax": 0.5,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
             "threshold1": null,
-            "threshold2": null,
             "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "lines": false,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": true,
-          "stack": false,
-          "percentage": false,
+          "id": 2,
           "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
+            "avg": false,
             "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
             "total": false,
-            "avg": false
+            "values": false
           },
+          "lines": false,
+          "linewidth": 1,
+          "links": [],
           "nullPointMode": "null as zero",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 12,
+          "stack": false,
           "steppedLine": true,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": false
-          },
           "targets": [
             {
-              "target": "licensify-frontend-1_licensify<%= @machine_suffix_metrics -%>.processes.*"
+              "target": "licensify-frontend-1_licensify.processes.*",
+              "refId": "A"
             }
           ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": []
+          "title": "Skyscape Licensify VPN State",
+          "tooltip": {
+            "shared": false,
+            "value_type": "cumulative",
+            "msResolution": true
+          },
+          "type": "graph",
+          "yaxes": [
+            {
+              "show": true,
+              "min": 0,
+              "max": 0.5,
+              "format": "short"
+            },
+            {
+              "show": true,
+              "min": null,
+              "max": null,
+              "format": "short"
+            }
+          ],
+          "xaxis": {
+            "show": true
+          },
+          "timeFrom": null,
+          "timeShift": null
         },
         {
-          "title": "Skyscape EFG VPN State",
-          "error": false,
-          "span": 12,
-          "editable": true,
-          "type": "graph",
-          "id": 7,
+          "aliasColors": {},
+          "bars": true,
           "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "short",
-            "short"
-          ],
+          "editable": true,
+          "error": false,
+          "fill": 0,
           "grid": {
-            "leftMax": 0.5,
-            "rightMax": null,
-            "leftMin": 0,
-            "rightMin": null,
             "threshold1": null,
-            "threshold2": null,
             "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "lines": false,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": true,
-          "stack": false,
-          "percentage": false,
+          "id": 7,
           "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
+            "avg": false,
             "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
             "total": false,
-            "avg": false
+            "values": false
           },
+          "lines": false,
+          "linewidth": 1,
+          "links": [],
           "nullPointMode": "null as zero",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 12,
+          "stack": false,
           "steppedLine": true,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": false
-          },
           "targets": [
             {
-              "target": "efg-mysql-master-1_efg<%= @machine_suffix_metrics -%>.processes.*"
+              "target": "efg-mysql-master-1_efg.processes.*",
+              "refId": "A"
             }
           ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": []
+          "title": "Skyscape EFG VPN State",
+          "tooltip": {
+            "shared": false,
+            "value_type": "cumulative",
+            "msResolution": true
+          },
+          "type": "graph",
+          "yaxes": [
+            {
+              "show": true,
+              "min": 0,
+              "max": 0.5,
+              "format": "short"
+            },
+            {
+              "show": true,
+              "min": null,
+              "max": null,
+              "format": "short"
+            }
+          ],
+          "xaxis": {
+            "show": true
+          },
+          "timeFrom": null,
+          "timeShift": null
         }
-      ]
-    }
-  ],
-  "nav": [
-    {
-      "type": "timepicker",
-      "collapse": false,
-      "notice": false,
-      "enable": true,
-      "status": "Stable",
-      "time_options": [
-        "5m",
-        "15m",
-        "1h",
-        "6h",
-        "12h",
-        "24h",
-        "2d",
-        "7d",
-        "30d"
       ],
-      "refresh_intervals": [
-        "5s",
-        "10s",
-        "30s",
-        "1m",
-        "5m",
-        "15m",
-        "30m",
-        "1h",
-        "2h",
-        "1d"
-      ],
-      "now": true
+      "title": "New row"
     }
   ],
   "time": {
     "from": "now-7d",
     "to": "now"
+  },
+  "timepicker": {
+    "collapse": false,
+    "enable": true,
+    "notice": false,
+    "now": true,
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "status": "Stable",
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ],
+    "type": "timepicker"
   },
   "templating": {
     "list": []
@@ -416,6 +480,7 @@
     "list": []
   },
   "refresh": false,
-  "version": 6,
-  "hideAllLegends": false
+  "schemaVersion": 12,
+  "version": 0,
+  "links": []
 }

--- a/modules/grafana/templates/dashboards/whitehall_health.json.erb
+++ b/modules/grafana/templates/dashboards/whitehall_health.json.erb
@@ -1,490 +1,549 @@
 {
+  "id": null,
   "title": "whitehall",
-  "services": {
-    "filter": {
-      "list": [],
-      "time": {
-        "from": "now-6h",
-        "to": "now"
-      }
-    }
-  },
+  "originalTitle": "whitehall",
+  "tags": [],
+  "style": "dark",
+  "timezone": "utc",
+  "editable": true,
+  "hideControls": false,
+  "sharedCrosshair": false,
   "rows": [
     {
-      "title": "HTTP Status Codes",
+      "collapsable": true,
+      "collapse": false,
+      "editable": true,
+      "height": "300px",
+      "notice": false,
       "panels": [
         {
-          "span": 6,
+          "aliasColors": {},
+          "annotate": {
+            "enable": false
+          },
+          "bars": false,
+          "datasource": "Graphite",
           "editable": true,
-          "type": "graphite",
-          "loadingEditor": false,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "scale": 1,
-          "y_formats": [
-            "short",
-            "short"
-          ],
+          "fill": 0,
           "grid": {
             "max": null,
             "min": 0,
             "threshold1": null,
-            "threshold2": null,
             "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "annotate": {
-            "enable": false
-          },
-          "resolution": 100,
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
           "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
+            "avg": false,
             "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
             "total": false,
-            "avg": false
+            "values": false
           },
-          "percentage": false,
-          "zerofill": true,
+          "lines": true,
+          "linewidth": 1,
+          "loadingEditor": false,
           "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "resolution": 100,
+          "scale": 1,
+          "span": 6,
+          "stack": false,
           "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "query_as_alias": true
-          },
           "targets": [
             {
-              "target": "groupByNode(stats.whitehall-frontend-?_frontend<%= @machine_suffix_metrics -%>.nginx_logs.whitehall-frontend_<%= @app_domain_metrics -%>.http_5xx,4,\"sumSeries\")"
+              "target": "groupByNode(stats.whitehall-frontend-?_frontend.nginx_logs.whitehall-frontend_publishing_service_gov_uk.http_5xx,4,\"sumSeries\")",
+              "refId": "A"
             }
           ],
-          "aliasColors": {},
-          "aliasYAxis": {},
-          "title": "Frontend 5xx Errors"
+          "title": "Frontend 5xx Errors",
+          "tooltip": {
+            "query_as_alias": true,
+            "value_type": "cumulative",
+            "shared": true,
+            "msResolution": true
+          },
+          "type": "graph",
+          "zerofill": true,
+          "id": 1,
+          "yaxes": [
+            {
+              "show": true,
+              "format": "short"
+            },
+            {
+              "show": true,
+              "format": "short"
+            }
+          ],
+          "xaxis": {
+            "show": true
+          },
+          "timeFrom": null,
+          "timeShift": null,
+          "seriesOverrides": []
         },
         {
-          "span": 6,
+          "aliasColors": {},
+          "annotate": {
+            "enable": false
+          },
+          "bars": false,
+          "datasource": "Graphite",
           "editable": true,
-          "type": "graphite",
-          "loadingEditor": false,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "scale": 1,
-          "y_formats": [
-            "short",
-            "short"
-          ],
+          "fill": 0,
           "grid": {
             "max": null,
             "min": 0,
             "threshold1": null,
-            "threshold2": null,
             "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "loadingEditor": false,
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "resolution": 100,
+          "scale": 1,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "target": "groupByNode(stats.whitehall-backend-?_backend.nginx_logs.whitehall-admin_publishing_service_gov_uk.http_5xx,4,\"sumSeries\")",
+              "refId": "A"
+            }
+          ],
+          "title": "Backend 5xx Errors",
+          "tooltip": {
+            "query_as_alias": true,
+            "value_type": "cumulative",
+            "shared": true,
+            "msResolution": true
+          },
+          "type": "graph",
+          "zerofill": true,
+          "id": 2,
+          "yaxes": [
+            {
+              "show": true,
+              "format": "short"
+            },
+            {
+              "show": true,
+              "format": "short"
+            }
+          ],
+          "xaxis": {
+            "show": true
+          },
+          "timeFrom": null,
+          "timeShift": null,
+          "seriesOverrides": []
+        }
+      ],
+      "title": "HTTP Status Codes"
+    },
+    {
+      "collapsable": true,
+      "collapse": false,
+      "editable": true,
+      "height": "300px",
+      "notice": false,
+      "panels": [
+        {
+          "aliasColors": {},
           "annotate": {
             "enable": false
           },
-          "resolution": 100,
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
           "bars": false,
-          "stack": false,
+          "datasource": "Graphite",
+          "fill": 0,
+          "grid": {
+            "max": null,
+            "min": 0,
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
           "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
+            "avg": false,
             "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
             "total": false,
-            "avg": false
+            "values": false
           },
-          "percentage": false,
-          "zerofill": true,
+          "lines": true,
+          "linewidth": 1,
           "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "resolution": 100,
+          "scale": 1,
+          "span": 6,
+          "stack": false,
           "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "query_as_alias": true
-          },
           "targets": [
             {
-              "target": "groupByNode(stats.whitehall-backend-?_backend<%= @machine_suffix_metrics -%>.nginx_logs.whitehall-admin_<%= @app_domain_metrics -%>.http_5xx,4,\"sumSeries\")"
+              "target": "groupByNode(whitehall-frontend-*_frontend.nginx.nginx_connections-writing,-1,\"sum\")",
+              "refId": "A"
+            },
+            {
+              "target": "groupByNode(whitehall-frontend-*_frontend.nginx.nginx_requests,-1,\"sum\")",
+              "refId": "B"
             }
           ],
-          "aliasColors": {},
-          "aliasYAxis": {},
-          "title": "Backend 5xx Errors"
-        }
-      ],
-      "height": "80",
-      "collapse": false,
-      "collapsable": true,
-      "editable": true,
-      "notice": false
-    },
-    {
-      "title": "NginX Status",
-      "panels": [
-        {
-          "type": "graphite",
-          "span": 6,
           "title": "Frontend Nginx Connections",
-          "targets": [
+          "tooltip": {
+            "query_as_alias": true,
+            "value_type": "cumulative",
+            "shared": true,
+            "msResolution": true
+          },
+          "type": "graph",
+          "zerofill": true,
+          "id": 3,
+          "yaxes": [
             {
-              "target": "groupByNode(whitehall-frontend-*_frontend<%= @machine_suffix_metrics -%>.nginx.nginx_connections-writing,-1,\"sum\")"
+              "show": true,
+              "format": "short"
             },
             {
-              "target": "groupByNode(whitehall-frontend-*_frontend<%= @machine_suffix_metrics -%>.nginx.nginx_requests,-1,\"sum\")"
+              "show": true,
+              "format": "short"
             }
           ],
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "scale": 1,
-          "y_formats": [
-            "short",
-            "short"
-          ],
-          "grid": {
-            "max": null,
-            "min": 0,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          "xaxis": {
+            "show": true
           },
-          "annotate": {
-            "enable": false
-          },
-          "resolution": 100,
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false
-          },
-          "percentage": false,
-          "zerofill": true,
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "query_as_alias": true
-          },
-          "aliasColors": {},
-          "aliasYAxis": {}
+          "timeFrom": null,
+          "timeShift": null,
+          "seriesOverrides": []
         },
         {
-          "type": "graphite",
-          "span": 6,
-          "title": "Backend Nginx Connections",
-          "targets": [
-            {
-              "target": "groupByNode(whitehall-backend-*_backend<%= @machine_suffix_metrics -%>.nginx.nginx_connections-writing,-1,\"sum\")"
-            },
-            {
-              "target": "groupByNode(whitehall-backend-*_backend<%= @machine_suffix_metrics -%>.nginx.nginx_requests,-1,\"sum\")"
-            }
-          ],
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "scale": 1,
-          "y_formats": [
-            "short",
-            "short"
-          ],
+          "aliasColors": {},
+          "annotate": {
+            "enable": false
+          },
+          "bars": false,
+          "datasource": "Graphite",
+          "fill": 0,
           "grid": {
             "max": null,
             "min": 0,
             "threshold1": null,
-            "threshold2": null,
             "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "annotate": {
-            "enable": false
-          },
-          "resolution": 100,
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
           "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
+            "avg": false,
             "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
             "total": false,
-            "avg": false
+            "values": false
           },
-          "percentage": false,
-          "zerofill": true,
+          "lines": true,
+          "linewidth": 1,
           "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "resolution": 100,
+          "scale": 1,
+          "span": 6,
+          "stack": false,
           "steppedLine": false,
+          "targets": [
+            {
+              "target": "groupByNode(whitehall-backend-*_backend.nginx.nginx_connections-writing,-1,\"sum\")",
+              "refId": "A"
+            },
+            {
+              "target": "groupByNode(whitehall-backend-*_backend.nginx.nginx_requests,-1,\"sum\")",
+              "refId": "B"
+            }
+          ],
+          "title": "Backend Nginx Connections",
           "tooltip": {
+            "query_as_alias": true,
             "value_type": "cumulative",
-            "query_as_alias": true
+            "shared": true,
+            "msResolution": true
           },
-          "aliasColors": {},
-          "aliasYAxis": {}
+          "type": "graph",
+          "zerofill": true,
+          "id": 4,
+          "yaxes": [
+            {
+              "show": true,
+              "format": "short"
+            },
+            {
+              "show": true,
+              "format": "short"
+            }
+          ],
+          "xaxis": {
+            "show": true
+          },
+          "timeFrom": null,
+          "timeShift": null,
+          "seriesOverrides": []
         }
       ],
-      "height": "80",
-      "collapse": false,
-      "collapsable": true,
-      "editable": true,
-      "notice": false
+      "title": "NginX Status"
     },
     {
-      "title": "ES & MySQL CPU",
+      "collapsable": true,
+      "collapse": false,
+      "editable": true,
+      "height": "300px",
+      "notice": false,
       "panels": [
         {
-          "type": "graphite",
+          "aliasColors": {},
+          "annotate": {
+            "enable": false
+          },
+          "bars": false,
+          "datasource": "Graphite",
+          "fill": 0,
+          "grid": {
+            "max": null,
+            "min": 0,
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "resolution": 100,
+          "scale": 1,
           "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "target": "alias(sumSeries(whitehall-mysql-master-1_backend.cpu-*.cpu-user),\"Master CPU Usage\")",
+              "refId": "A"
+            },
+            {
+              "target": "alias(sumSeries(whitehall-mysql-slave-1_backend.cpu-*.cpu-user),\"Slave-1 CPU Usage\")",
+              "refId": "B"
+            },
+            {
+              "target": "alias(sumSeries(whitehall-mysql-slave-2_backend.cpu-*.cpu-user),\"Slave-2 CPU Usage\")",
+              "refId": "C"
+            }
+          ],
           "title": "MySQL CPU Usage",
-          "targets": [
+          "tooltip": {
+            "query_as_alias": true,
+            "value_type": "cumulative",
+            "shared": true,
+            "msResolution": true
+          },
+          "type": "graph",
+          "zerofill": true,
+          "id": 5,
+          "yaxes": [
             {
-              "target": "alias(sumSeries(whitehall-mysql-master-1_backend<%= @machine_suffix_metrics -%>.cpu-*.cpu-user),\"Master CPU Usage\")"
+              "show": true,
+              "format": "short"
             },
             {
-              "target": "alias(sumSeries(whitehall-mysql-slave-1_backend<%= @machine_suffix_metrics -%>.cpu-*.cpu-user),\"Slave-1 CPU Usage\")"
-            },
-            {
-              "target": "alias(sumSeries(whitehall-mysql-slave-2_backend<%= @machine_suffix_metrics -%>.cpu-*.cpu-user),\"Slave-2 CPU Usage\")"
+              "show": true,
+              "format": "short"
             }
           ],
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "scale": 1,
-          "y_formats": [
-            "short",
-            "short"
-          ],
+          "xaxis": {
+            "show": true
+          },
+          "timeFrom": null,
+          "timeShift": null,
+          "seriesOverrides": []
+        },
+        {
+          "aliasColors": {},
+          "annotate": {
+            "enable": false
+          },
+          "bars": false,
+          "datasource": "Graphite",
+          "fill": 0,
           "grid": {
             "max": null,
             "min": 0,
             "threshold1": null,
-            "threshold2": null,
             "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "annotate": {
-            "enable": false
-          },
-          "resolution": 100,
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
           "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
+            "avg": false,
             "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
             "total": false,
-            "avg": false
+            "values": false
           },
-          "percentage": false,
-          "zerofill": true,
+          "lines": true,
+          "linewidth": 1,
           "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "query_as_alias": true
-          },
-          "aliasColors": {},
-          "aliasYAxis": {}
-        },
-        {
-          "type": "graphite",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "resolution": 100,
+          "scale": 1,
           "span": 6,
-          "title": "ElasticSearch CPU Usage",
+          "stack": false,
+          "steppedLine": false,
           "targets": [
             {
-              "target": "aliasSub(groupByNode({elasticsearch,support}-?_backend<%= @machine_suffix_metrics -%>.cpu-*.cpu-user,0,\"sumSeries\"),\"_backend<%= @machine_suffix_metrics -%>\",\"\")"
+              "target": "aliasSub(groupByNode({elasticsearch,support}-?_backend.cpu-*.cpu-user,0,\"sumSeries\"),\"_backend\",\"\")",
+              "refId": "A"
             }
           ],
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "scale": 1,
-          "y_formats": [
-            "short",
-            "short"
-          ],
-          "grid": {
-            "max": null,
-            "min": 0,
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "annotate": {
-            "enable": false
-          },
-          "resolution": 100,
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false
-          },
-          "percentage": false,
-          "zerofill": true,
-          "nullPointMode": "connected",
-          "steppedLine": false,
+          "title": "ElasticSearch CPU Usage",
           "tooltip": {
+            "query_as_alias": true,
             "value_type": "cumulative",
-            "query_as_alias": true
+            "shared": true,
+            "msResolution": true
           },
-          "aliasColors": {},
-          "aliasYAxis": {}
+          "type": "graph",
+          "zerofill": true,
+          "id": 6,
+          "yaxes": [
+            {
+              "show": true,
+              "format": "short"
+            },
+            {
+              "show": true,
+              "format": "short"
+            }
+          ],
+          "xaxis": {
+            "show": true
+          },
+          "timeFrom": null,
+          "timeShift": null,
+          "seriesOverrides": []
         }
       ],
-      "height": "80",
-      "collapse": false,
-      "collapsable": true,
-      "editable": true,
-      "notice": false
+      "title": "ES & MySQL CPU"
     }
   ],
-  "editable": true,
-  "failover": false,
-  "panel_hints": true,
-  "style": "dark",
-  "pulldowns": [
-    {
-      "type": "filtering",
-      "collapse": false,
-      "notice": false,
-      "enable": false
-    },
-    {
-      "type": "annotations",
-      "enable": true,
-      "annotations": [
-        {
-          "name": "whitehall deploys",
-          "type": "graphite events",
-          "showLine": true,
-          "iconColor": "#C0C6BE",
-          "lineColor": "rgba(32, 230, 25, 0.592157)",
-          "iconSize": 13,
-          "enable": true,
-          "tags": "whitehall"
-        },
-        {
-          "name": "whitehall restarts",
-          "type": "graphite metric",
-          "showLine": true,
-          "iconColor": "#FF2020",
-          "lineColor": "rgba(255, 32, 32, 0.592157)",
-          "iconSize": 13,
-          "enable": true,
-          "target": "substr(stats.govuk.app.whitehall.restarts,3,5)"
-        }
-      ]
-    }
-  ],
-  "nav": [
-    {
-      "type": "timepicker",
-      "collapse": false,
-      "notice": false,
-      "enable": true,
-      "status": "Stable",
-      "time_options": [
-        "5m",
-        "15m",
-        "1h",
-        "6h",
-        "12h",
-        "24h",
-        "2d",
-        "7d",
-        "30d"
-      ],
-      "refresh_intervals": [
-        "5s",
-        "10s",
-        "30s",
-        "1m",
-        "5m",
-        "15m",
-        "30m",
-        "1h",
-        "2h",
-        "1d"
-      ],
-      "now": true
-    }
-  ],
-  "loader": {
-    "save_gist": false,
-    "save_elasticsearch": false,
-    "save_local": true,
-    "save_default": true,
-    "save_temp": true,
-    "save_temp_ttl_enable": true,
-    "save_temp_ttl": "30d",
-    "load_gist": false,
-    "load_elasticsearch": false,
-    "load_elasticsearch_size": 20,
-    "load_local": true,
-    "hide": false
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "collapse": false,
+    "enable": true,
+    "notice": false,
+    "now": true,
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "status": "Stable",
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ],
+    "type": "timepicker"
+  },
+  "templating": {
+    "list": []
+  },
+  "annotations": {
+    "list": [
+      {
+        "enable": true,
+        "iconColor": "#C0C6BE",
+        "iconSize": 13,
+        "lineColor": "rgba(32, 230, 25, 0.592157)",
+        "name": "whitehall deploys",
+        "showLine": true,
+        "tags": "whitehall",
+        "type": "graphite events"
+      },
+      {
+        "enable": true,
+        "iconColor": "#FF2020",
+        "iconSize": 13,
+        "lineColor": "rgba(255, 32, 32, 0.592157)",
+        "name": "whitehall restarts",
+        "showLine": true,
+        "target": "substr(stats.govuk.app.whitehall.restarts,3,5)",
+        "type": "graphite metric"
+      }
+    ]
   },
   "refresh": "1m",
-  "tags": [],
-  "timezone": "utc"
+  "schemaVersion": 12,
+  "version": 0,
+  "links": []
 }


### PR DESCRIPTION
Update existing Grafana dashboards to use 3.x Graphite data source.
These are exports from Grafana 3, with the added Graphite data source so the diffs might be a bit confusing.