### PR TITLE
Add golang v1.6.3 to the dev VM

### DIFF
--- a/modules/golang/manifests/init.pp
+++ b/modules/golang/manifests/init.pp
@@ -7,11 +7,11 @@ class golang {
   include govuk_ppa
 
   class { 'goenv':
-    global_version => '1.5.3',
+    global_version => '1.6.3',
     require        => Class['govuk_ppa'],
   }
-  goenv::version { ['1.3.3', '1.4.2', '1.4.3', '1.5.1', '1.5.3', '1.6.2']: }
 
+  goenv::version { ['1.3.3', '1.4.2', '1.4.3', '1.5.1', '1.5.3', '1.6.2', '1.6.3']: }
   package { ['golang-gom', 'godep']:
     ensure  => latest,
     require => Class['govuk_ppa'],


### PR DESCRIPTION
This commit installs 1.6.3 onto the dev vm and also changes the `global_version` to 1.6.3 as this is the latest patched version and apps are using `.go-version` anyway.

govuk_crawler_worker 1.5.3
router 1.5.3 (we're upgrading it to 1.6.3 at the moment)
metadata-api 1.6.2

We can probably drop some of the older versions now too.

cc/ @timblair 