### PR TITLE
Add dfid-transition worker

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -22,6 +22,7 @@ deployable_applications: &deployable_applications
   - courts-api
   - courts-frontend
   - designprinciples
+  - dfid-transition
   - EFG
   - email-alert-api
   - email-alert-frontend
@@ -289,6 +290,10 @@ govuk::apps::frontend::nagios_memory_warning: 1200
 govuk::apps::frontend::nagios_memory_critical: 1400
 
 govuk::apps::govuk_cdn_logs_monitor::processed_data_dir: '/mnt/logs_cdn/data'
+
+govuk::apps::dfid_transition::redis_host: 'redis-1.backend'
+govuk::apps::dfid_transition::redis_port: '6379'
+govuk::apps::dfid_transition::enable_procfile_worker: false
 
 govuk::apps::publisher::redis_host: 'redis-1.backend'
 govuk::apps::publisher::redis_port: '6379'

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -36,6 +36,7 @@ govuk::node::s_development::apps:
   - 'content_tagger'
   - 'contentapi'
   - 'designprinciples'
+  - 'dfid_transition'
   - 'efg'
   - 'email_alert_api'
   - 'email_alert_frontend'

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -23,6 +23,7 @@ govuk::apps::publicapi::backdrop_host: 'www.preview.performance.service.gov.uk'
 govuk::apps::rummager::aws_s3_bucket_name: govuk-api-elasticsearch-snapshots-integration
 
 govuk::apps::smartanswers::expose_govspeak: true
+govuk::apps::dfid_transition::enable_procfile_worker: true
 govuk::apps::specialist_publisher::publish_pre_production_finders: true
 govuk::apps::specialist_publisher_rebuild::publish_pre_production_finders: true
 govuk::apps::specialist_publisher_rebuild_standalone::enabled: true

--- a/modules/govuk/manifests/apps/dfid_transition.pp
+++ b/modules/govuk/manifests/apps/dfid_transition.pp
@@ -1,0 +1,78 @@
+# == Class: govuk::apps::dfid_transition
+#
+# Helps in managing the DFID research outputs import by allowing
+# us to enqueue transition operations (such as downloading the
+# outputs' PDFs). This 'app' has a shelf life which expires
+# when dfid-transition does.
+#
+# Read more: https://github.com/alphagov/dfid-transition
+#
+# === Parameters
+#
+# [*port*]
+#   Not used.
+#   Default: 9999
+#
+# [*enabled*]
+#   Whether the app should exist
+#   Default: false
+#
+# [*enabled_procfile_worker*]
+#   Whether the procfile worker is enabled
+#
+# [*asset_manager_bearer_token*]
+#   The bearer token to use when communicating with Asset Manager.
+#   Default: undef
+#
+# [*publishing_api_bearer_token*]
+#   The bearer token to use when communicating with Publishing API.
+#   Default: undef
+#
+# [*redis_host*]
+#   Redis host for sidekiq and AttachmentIndex.
+#
+# [*redis_port*]
+#   Redis port for sidekiq and AttachmentIndex.
+#   Default: 6379
+class govuk::apps::dfid_transition (
+  $port = 9999,
+  $enabled = true,
+  $enable_procfile_worker = undef,
+  $asset_manager_bearer_token = undef,
+  $publishing_api_bearer_token = undef,
+  $redis_host = undef,
+  $redis_port = undef,
+) {
+  $app_name = 'dfid-transition'
+
+  if $enabled {
+    Govuk::App::Envvar {
+      app => $app_name,
+    }
+
+    govuk::procfile::worker {$app_name:
+      enable_service => $enable_procfile_worker,
+    }
+
+    govuk::app::envvar {
+      "${title}-ASSET_MANAGER_BEARER_TOKEN":
+        varname => 'ASSET_MANAGER_BEARER_TOKEN',
+        value   => $asset_manager_bearer_token;
+      "${title}-PUBLISHING_API_BEARER_TOKEN":
+        varname => 'PUBLISHING_API_BEARER_TOKEN',
+        value   => $publishing_api_bearer_token;
+      "${title}-REDIS_HOST":
+        varname => 'REDIS_HOST',
+        value   => $redis_host;
+      "${title}-REDIS_PORT":
+        varname => 'REDIS_PORT',
+        value   => $redis_port;
+    }
+
+    govuk::app { $app_name:
+      app_type           => 'procfile',
+      port               => $port,
+      enable_nginx_vhost => false,
+    }
+  }
+}

--- a/modules/govuk/manifests/apps/dfid_transition.pp
+++ b/modules/govuk/manifests/apps/dfid_transition.pp
@@ -35,7 +35,7 @@
 #   Redis port for sidekiq and AttachmentIndex.
 #   Default: 6379
 class govuk::apps::dfid_transition (
-  $port = 9999,
+  $port = 3124,
   $enabled = true,
   $enable_procfile_worker = undef,
   $asset_manager_bearer_token = undef,


### PR DESCRIPTION
[dfid-transition](http://github.com/alphagov/dfid-transition) is a repo containing nothing but rake tasks and sidekiq workers. This PR is for the setup of those workers across environments.

The procfile worker for sidekiq is currently enabled only in integration.

This PR did have a Jenkins job for `load:attachments` but we can just as easily SSH into a backend and run those manually (since we need the ability to use ad-hoc environmental params like `SPARQL_ENDPOINT`.

## Outstanding issue

We're only interested in getting the sidekiq workers running and addressable via `service stop|start`. It looks like an `app` type of `'procfile'` works best here, but we need a port, which I've ended up setting to a rather unsatisfactory 9999 and combining with `enable_nginx_vhost => false`. Dean suggested we might need to use a port registry of which I am blissfully unaware (even if we don't use the port)

