### PR TITLE
Add latency monitoring for Sidekiq

### DIFF
--- a/modules/monitoring/manifests/checks.pp
+++ b/modules/monitoring/manifests/checks.pp
@@ -21,6 +21,7 @@ class monitoring::checks (
   include monitoring::checks::mirror
   include monitoring::checks::pingdom
   include monitoring::checks::ses
+  include monitoring::checks::sidekiq
   include monitoring::checks::smokey
   include monitoring::checks::reboots
 

--- a/modules/monitoring/manifests/checks/sidekiq.pp
+++ b/modules/monitoring/manifests/checks/sidekiq.pp
@@ -1,0 +1,20 @@
+# == Class: monitoring::checks::sidekiq
+#
+# Nagios alerts for sidekiq queue latency
+#
+#
+class monitoring::checks::sidekiq {
+
+  $graphite_target = 'stats.gauges.govuk.app.rummager.workers.queues.default.latency'
+
+  icinga::check::graphite { 'check_rummager_queue_latency':
+    target              => $graphite_target,
+    warning             => 0.3,
+    critical            => 0.6,
+    use                 => 'govuk_normal_priority',
+    from                => '3minutes',
+    host_name           => $::fqdn,
+    desc                => 'check rummager queue latency [in office hours]',
+    notification_period => 'inoffice',
+  }
+}


### PR DESCRIPTION
Add an icinga check for a single (not per-host) metric on the monitoring box for the stats.gauges.govuk.app.rummager.workers.queues.default.latency metric.