### PR TITLE
Update input raw argument for Gor

### DIFF
--- a/modules/router/manifests/gor.pp
+++ b/modules/router/manifests/gor.pp
@@ -32,7 +32,7 @@ class router::gor (
 
   class { 'govuk_gor':
     args   => {
-      '-input-raw'          => 'localhost:7999',
+      '-input-raw'          => '127.0.0.1:7999',
       '-output-http'        => prefix(keys($replay_targets), 'https://'),
       '-output-http-method' => [
         'GET', 'HEAD', 'OPTIONS',

--- a/modules/router/spec/classes/router__gor_spec.rb
+++ b/modules/router/spec/classes/router__gor_spec.rb
@@ -5,7 +5,7 @@ describe 'router::gor', :type => :class do
     :replay_targets => replay_targets,
   }}
   let(:args_default) {{
-    '-input-raw'          => 'localhost:7999',
+    '-input-raw'          => '127.0.0.1:7999',
     '-output-http-method' => %w{GET HEAD OPTIONS},
   }}
 


### PR DESCRIPTION
When testing version 0.14.1 on Staging I discovered that it didn't like
using the interface name "localhost" and threw the following error in
the upstart logs:

```
2016/07/19 17:54:16 Can't find interfaces with addr: localhost. Provide
available IP for intercepting traffic
```

I don't think it hurts to explicitly use the loopback address and this
resolved the error when testing on the host itself.