### PR TITLE
Set redis env variables for signon

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -382,6 +382,8 @@ govuk::apps::service_manual_publisher::db::backend_ip_range: "%{hiera('environme
 govuk::apps::share_sale_publisher::enabled: true
 
 govuk::apps::signon::redis_url: "redis://redis-1.backend:6379/0"
+govuk::apps::signon::redis_host: 'redis-1.backend'
+govuk::apps::signon::redis_port: '6379'
 govuk::apps::signon::nagios_memory_warning: 900
 govuk::apps::signon::nagios_memory_critical: 1000
 

--- a/modules/govuk/manifests/apps/signon.pp
+++ b/modules/govuk/manifests/apps/signon.pp
@@ -29,6 +29,8 @@ class govuk::apps::signon(
   $enable_procfile_worker = true,
   $devise_secret_key = undef,
   $redis_url = undef,
+  $redis_host = 'redis-1.backend',
+  $redis_port = '6379',
   $nagios_memory_warning = undef,
   $nagios_memory_critical = undef,
 ) {
@@ -63,9 +65,18 @@ class govuk::apps::signon(
   }
 
   if $redis_url != undef {
-    govuk::app::envvar { "${title}-REDIS_URL":
-      varname => 'REDIS_URL',
-      value   => $redis_url,
+    govuk::app::envvar {
+      "${title}-REDIS_URL":
+        varname => 'REDIS_URL',
+        value   => $redis_url;
+      "${title}-REDIS_HOST":
+        app     => $app_name,
+        varname => 'REDIS_HOST',
+        value   => $redis_host;
+      "${title}-REDIS_PORT":
+        app     => $app_name,
+        varname => 'REDIS_PORT',
+        value   => $redis_port;
     }
   }
 


### PR DESCRIPTION
Define environment constants for signon, in order to initialize the
govuk_sidekiq gem properly.