### PR TITLE
Enable Gor in Bouncer Staging

### DIFF
--- a/hieradata/node/bouncer-1.redirector.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/bouncer-1.redirector.staging.publishing.service.gov.uk.yaml
@@ -1,0 +1,9 @@
+---
+
+govuk_bouncer::gor::enabled: true
+govuk_bouncer::gor::ip_address: '31.210.245.101'
+
+govuk_gor::version: '0.14.1'
+govuk_gor::binary_path: '/usr/local/bin/gor'
+govuk_gor::envvars:
+  GODEBUG: 'netdns=go'


### PR DESCRIPTION
Upgrading Gor broke traffic replay for Bouncer previously, so we should
enable it in Staging replaying to Integration to see if we can spot
these problems before any upgrades in Production.