### PR TITLE
Enable anonymous grafana access

### DIFF
--- a/modules/grafana/files/grafana.ini
+++ b/modules/grafana/files/grafana.ini
@@ -158,7 +158,7 @@ check_for_updates = true
 #################################### Anonymous Auth ##########################
 [auth.anonymous]
 # enable anonymous access
-;enabled = false
+enabled = true
 
 # specify organization name that should be used for unauthenticated users
 ;org_name = Main Org.


### PR DESCRIPTION
We're not using authentication for access to Grafana in any serious
way so allow anonymous access. Grafana is only accessible internally
so this makes it usable to radiator screens.