### PR TITLE
Check existence of lock file before reboot

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -537,6 +537,8 @@ govuk_sudo::sudo_conf:
 govuk_unattended_reboot::enabled: true
 govuk_unattended_reboot::mongodb::enabled: true
 govuk_unattended_reboot::elasticsearch::enabled: true
+govuk_unattended_reboot::lock_files:
+  - '/var/lock/mongodb-s3backup'
 
 govuk_unattended_reboot::monitoring_basic_auth:
   username: "%{hiera('http_username')}"

--- a/modules/govuk_unattended_reboot/manifests/init.pp
+++ b/modules/govuk_unattended_reboot/manifests/init.pp
@@ -13,10 +13,21 @@
 #   A hash containing a `username` and a `password` to access monitoring
 #   which is protected by basic authentication.
 #
+# [*lock_files*]
+#   An array of lock files owned by jobs that are in progress.
+#   Add full path of the lock file to hiera.
+#
+# === Variables
+#
+# [check_lockfiles*]
+#   Formatted array of lockfiles. Wrapped in doubles quotes and space separated.
+#
 class govuk_unattended_reboot (
   $enabled = false,
   $monitoring_basic_auth = {},
+  $lock_files = []
 ) {
+
 
   validate_bool($enabled)
   validate_hash($monitoring_basic_auth)
@@ -31,6 +42,7 @@ class govuk_unattended_reboot (
 
   $config_directory = '/etc/unattended-reboot'
   $check_scripts_directory = "${config_directory}/check"
+  $check_lockfiles = join(regsubst($lock_files,'(.*)','"\1"'), ' ')
 
   $node_class_search_phrase = regsubst($::govuk_node_class, '_', '-')
   $icinga_url = "https://alert.cluster/cgi-bin/icinga/status.cgi?search_string=%5E${node_class_search_phrase}-[0-9]&allunhandledproblems&jsonoutput"
@@ -65,6 +77,16 @@ class govuk_unattended_reboot (
     owner  => 'root',
     group  => 'root',
     source => 'puppet:///modules/govuk_unattended_reboot/usr/local/bin/check_icinga.rb',
+  }
+
+  # This script will check for the existence of any lock files relating to backups in progress as not to interrupt them
+
+  file { "${check_scripts_directory}/03_backups":
+    ensure  => $file_ensure,
+    mode    => '0755',
+    owner   => 'root',
+    group   => 'root',
+    content => template("govuk_unattended_reboot${check_scripts_directory}/backups.erb"),
   }
 
   class { '::unattended_reboot':

--- a/modules/govuk_unattended_reboot/spec/classes/govuk_unattended_reboot_spec.rb
+++ b/modules/govuk_unattended_reboot/spec/classes/govuk_unattended_reboot_spec.rb
@@ -18,6 +18,7 @@ describe 'govuk_unattended_reboot', :type => :class do
     it { is_expected.to contain_file("#{check_scripts_directory}").with_ensure('directory') }
     it { is_expected.to contain_file("#{check_scripts_directory}/00_safety").with_ensure('present') }
     it { is_expected.to contain_file("#{check_scripts_directory}/01_alerts").with_ensure('present') }
+    it { is_expected.to contain_file("#{check_scripts_directory}/03_backups").with_ensure('present') }
 
     it "correctly formats the node class when querying Icinga" do
       is_expected.to contain_file('/etc/unattended-reboot/check/01_alerts').with_content(/status.cgi\?search_string=%5Echocolate-factory-\[0-9\]&/)
@@ -35,5 +36,23 @@ describe 'govuk_unattended_reboot', :type => :class do
     it { is_expected.to contain_file("#{check_scripts_directory}").with_ensure('absent') }
     it { is_expected.to contain_file("#{check_scripts_directory}/00_safety").with_ensure('absent') }
     it { is_expected.to contain_file("#{check_scripts_directory}/01_alerts").with_ensure('absent') }
+    it { is_expected.to contain_file("#{check_scripts_directory}/03_backups").with_ensure('absent') }
+  end
+
+  describe 'Lock file array' do
+    let(:params) {{
+      :enabled    => true,
+      :lock_files => [
+          '/var/lock/alvin',
+          '/var/lock/simon',
+          '/var/lock/theodore'
+      ]
+    }}
+
+    context 'It should contain a correctly formatted bash array' do
+      it { is_expected.to contain_file("#{check_scripts_directory}/03_backups").with_content(/"\/var\/lock\/alvin"\s"\/var\/lock\/simon"\s"\/var\/lock\/theodore"/) }
+
+    end
+
   end
 end

--- a/modules/govuk_unattended_reboot/templates/etc/unattended-reboot/check/backups.erb
+++ b/modules/govuk_unattended_reboot/templates/etc/unattended-reboot/check/backups.erb
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+LOCK_FILES=(<%= @check_lockfiles %>)
+
+# If any lock files above are present. The  machine will not reboot.
+
+  for i in ${LOCK_FILES[@]}; do
+
+    if [[ -f ${i} ]]; then
+
+      exit 1
+
+    fi
+
+  done

--- a/modules/mongodb/templates/mongodb-backup-s3.erb
+++ b/modules/mongodb/templates/mongodb-backup-s3.erb
@@ -14,6 +14,7 @@ BACKUP_FILE=mongodump-<%= @fqdn %>.$(date +%F_%T).tar.gz.gpg
 KEY_FINGERPRINT=<%= @private_gpg_key_fingerprint %>
 S3_BUCKET=<%= @s3_bucket %>/<%= @fqdn %>
 S3_BUCKET_DAILY=<%= @s3_bucket_daily %>/<%= @fqdn %>
+LOCKFILE=/var/lock/mongodb-s3backup
 
 # Triggered whenever this script exits, successful or otherwise. The values
 # of CODE/MESSAGE will be taken from that point in time.
@@ -55,9 +56,14 @@ else
   STATUS=1
 fi
 
+# Remove lock file
+if [ -f $LOCKFILE ]; then
+  rm -f $LOCKFILE
+fi
+
 if [ $STATUS -eq 0 ]; then
-NAGIOS_CODE=0
-NAGIOS_MESSAGE="OK: Mongodb backup push to S3 succeeded"
+  NAGIOS_CODE=0
+  NAGIOS_MESSAGE="OK: Mongodb backup push to S3 succeeded"
 fi
 
 exit $STATUS


### PR DESCRIPTION
What
Unattended reboots when invoked, interrupt backups. We don't want to reboot while
a backup is in progress.

How
While running backups we create a lock file under /var/lock.
The lock file only exists for the lifetime of the backup job.  While the lock file exists,
the machine doesn't get rebooted.