### PR TITLE
Mongodb backup s3 script

### DIFF
--- a/modules/mongodb/templates/mongodb-backup-s3.erb
+++ b/modules/mongodb/templates/mongodb-backup-s3.erb
@@ -37,7 +37,7 @@ printf "COMPRESSION AND ENCRYPTION FINISHED IN: ${TIME}s\n"
 
 # Upload backup to s3 bucket
 TIME="$(date +%s)"
-if [ $1 == "daily" ]; then
+if [[ $1 == "daily" ]]; then
 
     /usr/bin/envdir <%= @env_dir %>/env.d /usr/local/bin/s3cmd put $BACKUP_DIR/mongodump-* s3://$S3_BUCKET_DAILY --quiet
 else


### PR DESCRIPTION
While script was running it would log a warning "unary operator expected".

Compound commands should be wrapped in double braces or both variables should
be wrapped in quotes.