### PR TITLE
Fix mongo monitoring

### DIFF
--- a/modules/mongodb/manifests/monitoring.pp
+++ b/modules/mongodb/manifests/monitoring.pp
@@ -58,7 +58,7 @@ class mongodb::monitoring ($dbpath = '/var/lib/mongodb') {
 
   @@icinga::check { "check_mongod_replset_state_${::hostname}":
     check_command       => 'check_nrpe!check_mongodb!replset_state',
-    service_description => 'monogod replset state',
+    service_description => 'mongod replset state',
     host_name           => $::fqdn,
   }
 }

--- a/modules/mongodb/templates/mongod.conf.erb
+++ b/modules/mongodb/templates/mongod.conf.erb
@@ -27,9 +27,3 @@ systemLog:
   destination: file
   logAppend: true
   path: /var/log/mongodb/mongod.log
-
-# network interfaces
-net:
-  port: 27017
-  bindIp: 127.0.0.1
-


### PR DESCRIPTION
When bringing up new Mongo instances with the config file the replicaset wasn't being configured correctly, and it appeared that mongo did not seem to know how to connect to the instance on it's own machine:

```
lauramartin@integration-licensing-mongo-1:~$ mongo --host
licensing-mongo-1
MongoDB shell version: 3.2.7
connecting to: licensing-mongo-1:27017/test
2016-07-21T11:04:54.824+0000 W NETWORK  [thread1] Failed to connect to
127.0.1.1:27017, reason: errno:111 Connection refused
2016-07-21T11:04:54.824+0000 E QUERY    [thread1] Error: couldn't
connect to server licensing-mongo-1:27017, connection attempt failed :
connect@src/mongo/shell/mongo.js:231:14
@(connect):1:6

exception: connect failed
```

This turned out to be because we bound our IP on a specific IP, and we had an entry in the hosts file which wasn't on that IP:

```
lauramartin@integration-licensing-mongo-1:~$ grep licensing-mongo-1
/etc/hosts
127.0.1.1
licensing-mongo-1.licensify.integration.publishing.service.gov.uk
licensing-mongo-1
10.5.0.16
licensing-mongo-1.licensify.integration.publishing.service.gov.uk
licensing-mongo-1.licensify licensing-mongo-1
```

```
lauramartin@integration-licensing-mongo-1:~$ sudo netstat -pan |grep 27017
tcp        0      0 127.0.0.1:27017         0.0.0.0:*
LISTEN      -
```

The problem would be solved by either adding further entries in the hosts file, or removing the explicit bind in the mongod.conf file. This is something we do not do for the current mongodb configuration, so I think it made more sense to just remove it.

When removed it just binds to 0.0.0.0:

```
lauramartin@integration-licensing-mongo-1:~$ sudo netstat -pan |grep
mongod
tcp        0      0 0.0.0.0:27017           0.0.0.0:*
LISTEN      29164/mongod
```

We are now able to connect to itself:

```
lauramartin@integration-licensing-mongo-1:~$ mongo --host
licensing-mongo-1
MongoDB shell version: 3.2.7
connecting to: licensing-mongo-1:27017/test
Server has startup warnings:
2016-07-21T11:14:49.316+0000 I CONTROL  [initandlisten]
2016-07-21T11:14:49.316+0000 I CONTROL  [initandlisten] ** WARNING:
/sys/kernel/mm/transparent_hugepage/enabled is 'always'.
2016-07-21T11:14:49.316+0000 I CONTROL  [initandlisten] **        We
suggest setting it to 'never'
2016-07-21T11:14:49.316+0000 I CONTROL  [initandlisten]
2016-07-21T11:14:49.316+0000 I CONTROL  [initandlisten] ** WARNING:
/sys/kernel/mm/transparent_hugepage/defrag is 'always'.
2016-07-21T11:14:49.316+0000 I CONTROL  [initandlisten] **        We
suggest setting it to 'never'
2016-07-21T11:14:49.316+0000 I CONTROL  [initandlisten]
>
```

As a side note we need to fix those warnings.