### PR TITLE
Add redis location to dfid_transition_import

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -294,6 +294,8 @@ govuk::apps::govuk_cdn_logs_monitor::processed_data_dir: '/mnt/logs_cdn/data'
 govuk::apps::dfid_transition::redis_host: 'redis-1.backend'
 govuk::apps::dfid_transition::redis_port: '6379'
 govuk::apps::dfid_transition::enable_procfile_worker: false
+govuk_jenkins::job::dfid_transition_import::redis_host: 'redis-1.backend'
+govuk_jenkins::job::dfid_transition_import::redis_port: '6379'
 
 govuk::apps::publisher::redis_host: 'redis-1.backend'
 govuk::apps::publisher::redis_port: '6379'

--- a/modules/govuk_jenkins/manifests/job/dfid_transition_import.pp
+++ b/modules/govuk_jenkins/manifests/job/dfid_transition_import.pp
@@ -14,6 +14,8 @@
 class govuk_jenkins::job::dfid_transition_import (
   $publishing_api_bearer_token = undef,
   $asset_manager_bearer_token = undef,
+  $redis_host = undef,
+  $redis_port = 6379
 ) {
 
   file {

--- a/modules/govuk_jenkins/templates/jobs/dfid_transition_import.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/dfid_transition_import.yaml.erb
@@ -25,6 +25,9 @@
     wrappers:
         - ansicolor:
             colormap: xterm
+        - inject:
+            properties-content: REDIS_HOST=<%= @redis_host %>
+            properties-content: REDIS_PORT=<%= @redis_port %>
         - inject-passwords:
             global: false
             mask-password-params: true


### PR DESCRIPTION
The rake `load:outputs` job now relies on the `AttachmentIndex`, which is
backed by redis. Without it, the hourly import – which is used to
semi-rapidly iterate and communicate changes in user experience to DFID
– will not work.