### PR TITLE
Enable the dfid-transition nginx host

### DIFF
--- a/modules/govuk/manifests/apps/dfid_transition.pp
+++ b/modules/govuk/manifests/apps/dfid_transition.pp
@@ -72,7 +72,7 @@ class govuk::apps::dfid_transition (
     govuk::app { $app_name:
       app_type           => 'procfile',
       port               => $port,
-      enable_nginx_vhost => false,
+      enable_nginx_vhost => true,
     }
   }
 }


### PR DESCRIPTION
We've added the Sidekiq queue-monitoring Rack app for this short
shelf-life project, this lets us see it