### PR TITLE
Make dfid-transition a Rack app

### DIFF
--- a/modules/govuk/manifests/apps/dfid_transition.pp
+++ b/modules/govuk/manifests/apps/dfid_transition.pp
@@ -70,7 +70,7 @@ class govuk::apps::dfid_transition (
     }
 
     govuk::app { $app_name:
-      app_type           => 'procfile',
+      app_type           => 'rack',
       port               => $port,
       enable_nginx_vhost => true,
     }


### PR DESCRIPTION
Was `procfile`, but the sidekiq monitor's a `rack` app – no sense leaving it to the Procfile when it ought to be run by a unicorn.