### PR TITLE
Suggest upgrading Vagrant on hostname provisioning error

### DIFF
--- a/development-vm/README.md
+++ b/development-vm/README.md
@@ -232,4 +232,4 @@ Default: Setting hostname...
     from /opt/vagrant/embedded/gems/gems/vagrant-1.8.1/plugins/communicators/ssh/communicator.rb:222:in `call’
 ```
 
-Try `sudo vim`ing (or `sudo nano`, whichever you prefer) into that file and removing the offending `return` line.
+Updating to the latest version (v1.8.5+) might resolve this error. If not, try `sudo vim`ing (or `sudo nano`, whichever you prefer) into that file and removing the offending `return` line.


### PR DESCRIPTION
I was seeing the error in `change_host_name.rb` listed in the README when running Vagrant 1.8.1, and upgrading to 1.8.5 fixed it. Upgrading Vagrant seems like a better solution than editing random gem files, so let's suggest that as the first thing to try.