### PR TITLE
Mongodb s3 Restore3

### DIFF
--- a/modules/mongodb/manifests/backup.pp
+++ b/modules/mongodb/manifests/backup.pp
@@ -13,11 +13,19 @@
 # [*domonthly*]
 #   Whether monthly backups should be enabled or disabled
 #
+# [*s3_backups*]
+#   Whether to provision machine to perform s3 backups
+#
+# [*s3_restores*]
+#   Whether to provision machine to perform s3 restores. Idealy this is class
+#   should only be applied to mongo instances acting as PRIMARY
+#
 class mongodb::backup(
   $replicaset_members,
   $enabled = true,
   $domonthly = true,
   $s3_backups = false,
+  $s3_restores = false,
 ) {
   $threshold_secs = 28 * 3600
   $service_desc = 'AutoMongoDB backup'
@@ -78,7 +86,10 @@ class mongodb::backup(
 
     if $s3_backups {
       include mongodb::s3backup::backup
-      include mongodb::s3backup::package
+    }
+
+    if $s3_restores {
+      include mongodb::s3backup::restore
     }
 
     @@icinga::passive_check { "check_automongodbbackup-${::hostname}":

--- a/modules/mongodb/manifests/s3backup/backup.pp
+++ b/modules/mongodb/manifests/s3backup/backup.pp
@@ -66,7 +66,7 @@ class mongodb::s3backup::backup(
   $user = 'govuk-backup'
 ){
 
-  include backup::client
+  include ::backup::client
 
   validate_re($private_gpg_key_fingerprint, '^[[:alnum:]]{40}$', 'Must supply full GPG fingerprint')
 
@@ -153,7 +153,7 @@ class mongodb::s3backup::backup(
     owner   => $user,
     group   => $user,
     mode    => '0755',
-    require => User[$user],
+    require => Class['mongodb::s3backup::package'],
   }
 
 

--- a/modules/mongodb/manifests/s3backup/cron.pp
+++ b/modules/mongodb/manifests/s3backup/cron.pp
@@ -10,7 +10,7 @@ class mongodb::s3backup::cron(
   $user = 'govuk-backup',
 ) {
 
-  include backup::client
+  include ::backup::client
   require mongodb::s3backup::package
   require mongodb::s3backup::backup
 

--- a/modules/mongodb/manifests/s3backup/restore.pp
+++ b/modules/mongodb/manifests/s3backup/restore.pp
@@ -44,7 +44,8 @@ class mongodb::s3backup::restore(
   $user = 'govuk-backup',
   $cron = false
 ){
-  include backup::client
+
+  include ::backup::client
 
   file { '/usr/local/bin/mongodb-restore-s3':
     ensure  => file,
@@ -52,6 +53,7 @@ class mongodb::s3backup::restore(
     mode    => '0770',
     owner   => $user,
     group   => $user,
+    require => Class[mongodb::s3backup::package],
   }
 
 }


### PR DESCRIPTION

While verifying https://github.com/alphagov/govuk-puppet/pull/4522 I noticed the s3 restore class had not been applied.  The backup class has an "if" statement that includes s3backup related classes.
I've done some slight refactoring to order s3 dependencies while including the restore class.