### PR TITLE
Upgrade Gor to 0.14.1

### DIFF
--- a/hieradata/node/bouncer-1.redirector.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/bouncer-1.redirector.staging.publishing.service.gov.uk.yaml
@@ -2,8 +2,3 @@
 
 govuk_bouncer::gor::enabled: true
 govuk_bouncer::gor::ip_address: '31.210.245.101'
-
-govuk_gor::version: '0.14.1'
-govuk_gor::binary_path: '/usr/local/bin/gor'
-govuk_gor::envvars:
-  GODEBUG: 'netdns=go'

--- a/hieradata/node/cache-1.router.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/cache-1.router.staging.publishing.service.gov.uk.yaml
@@ -6,8 +6,3 @@
 router::gor::replay_targets:
   'www-origin.integration.publishing.service.gov.uk':
     ip: '31.210.245.98'
-
-govuk_gor::version: '0.14.1'
-govuk_gor::binary_path: '/usr/local/bin/gor'
-govuk_gor::envvars:
-  GODEBUG: 'netdns=go'

--- a/modules/govuk_bouncer/manifests/gor.pp
+++ b/modules/govuk_bouncer/manifests/gor.pp
@@ -27,13 +27,17 @@ class govuk_bouncer::gor (
   }
 
   class { 'govuk_gor':
-    args   => {
+    args    => {
       '-input-raw'          => ':80',
       '-output-http'        => $gor_targets,
-      '-output-http-method' => [
+      '-http-allow-method'  => [
         'GET', 'HEAD', 'OPTIONS',
       ],
+      '-http-original-host' => '',
     },
-    enable => $gor_enable,
+    envvars => {
+      'GODEBUG' => 'netdns=go',
+    },
+    enable  => $gor_enable,
   }
 }

--- a/modules/govuk_bouncer/spec/classes/govuk_bouncer__gor_spec.rb
+++ b/modules/govuk_bouncer/spec/classes/govuk_bouncer__gor_spec.rb
@@ -4,7 +4,8 @@ describe 'govuk_bouncer::gor', :type => :class do
   let(:ip_address) { '127.0.0.1' }
   let(:args_default) {{
     '-input-raw'          => ':80',
-    '-output-http-method' => %w{GET HEAD OPTIONS},
+    '-http-allow-method' => %w{GET HEAD OPTIONS},
+    '-http-original-host' => '',
   }}
 
   context 'default (disabled)' do
@@ -29,6 +30,9 @@ describe 'govuk_bouncer::gor', :type => :class do
         :args           => args_default.merge({
           '-output-http' => ["http://#{ip_address}"],
         }),
+        :envvars => {
+          'GODEBUG' => 'netdns=go',
+        }
       )
     }
   end

--- a/modules/govuk_gor/manifests/init.pp
+++ b/modules/govuk_gor/manifests/init.pp
@@ -26,8 +26,8 @@ class govuk_gor(
   $apt_mirror_hostname = '',
   $args = {},
   $enable = false,
-  $version = '0.9.4~ppa1',
-  $binary_path = '/usr/bin/gor',
+  $version = '0.14.1',
+  $binary_path = '/usr/local/bin/gor',
   $envvars = {},
 ) {
 

--- a/modules/router/manifests/gor.pp
+++ b/modules/router/manifests/gor.pp
@@ -31,13 +31,17 @@ class router::gor (
   create_resources('host', $replay_targets, $host_defaults)
 
   class { 'govuk_gor':
-    args   => {
+    args    => {
       '-input-raw'          => '127.0.0.1:7999',
       '-output-http'        => prefix(keys($replay_targets), 'https://'),
-      '-output-http-method' => [
+      '-http-allow-method'  => [
         'GET', 'HEAD', 'OPTIONS',
       ],
+      '-http-original-host' => '',
     },
-    enable => $enabled,
+    envvars => {
+      'GODEBUG' => 'netdns=go',
+    },
+    enable  => $enabled,
   }
 }

--- a/modules/router/spec/classes/router__gor_spec.rb
+++ b/modules/router/spec/classes/router__gor_spec.rb
@@ -6,7 +6,8 @@ describe 'router::gor', :type => :class do
   }}
   let(:args_default) {{
     '-input-raw'          => '127.0.0.1:7999',
-    '-output-http-method' => %w{GET HEAD OPTIONS},
+    '-http-allow-method' => %w{GET HEAD OPTIONS},
+    '-http-original-host' => '',
   }}
 
   context 'no targets defined (disabled)' do
@@ -29,6 +30,9 @@ describe 'router::gor', :type => :class do
         :args   => args_default.merge({
           '-output-http' => ["https://#{target_host}"],
         }),
+        :envvars => {
+          'GODEBUG' => 'netdns=go',
+        }
       )
     }
   end


### PR DESCRIPTION
This was reverted in e454b9a0442e7e5079137de270954da86112dd9e, but now
after some testing I think it is ready to try again.

This will fully upgrade Gor for both the cache servers and bouncer, and
also update some options that the new version of Gor requires, along
with adding the '-http-original-host' setting which keeps the original
Host header in place (required for bouncer).

It also keeps Gor running in Staging on cache-1 and bouncer-1 which
replays traffic to Integration.