### PR TITLE
Add dfid-transition hostname

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -759,6 +759,7 @@ hosts::production::backend::app_hostnames:
   - 'collections-publisher'
   - 'contacts-admin'
   - 'contentapi'
+  - 'dfid-transition'
   - 'email-alert-api'
   - 'errbit'
   - 'event-store'


### PR DESCRIPTION
Add dfid-transition as a hostname so we can see
the Sidekiq queue monitor at
https://dfid-transition.integration.publishing.service.gov.uk/