### PR TITLE
Extra disk for s3backups

### DIFF
--- a/hieradata/class/api_mongo.yaml
+++ b/hieradata/class/api_mongo.yaml
@@ -12,6 +12,9 @@ lv:
   data:
     pv: '/dev/sdc1'
     vg: 'mongodb'
+  s3backups:
+    pv: '/dev/sde1'
+    vg: 'mongo'
 
 mount:
   /var/lib/mongodb:
@@ -21,6 +24,10 @@ mount:
   /var/lib/automongodbbackup:
     disk: '/dev/mapper/backup-mongodb'
     govuk_lvm: 'mongodb'
+    mountoptions: 'defaults'
+  /var/lib/s3backup:
+    disk: '/dev/mapper/mongo-s3backups'
+    govuk_lvm: 's3backups'
     mountoptions: 'defaults'
 
 mongodb::server::replicaset_members:

--- a/hieradata/class/email_campaign_mongo.yaml
+++ b/hieradata/class/email_campaign_mongo.yaml
@@ -11,6 +11,9 @@ lv:
   data:
     pv: '/dev/sdc1'
     vg: 'mongodb'
+  s3backups:
+    pv: '/dev/sdd1'
+    vg: 'mongo'
 
 mount:
   /var/lib/mongodb:
@@ -20,6 +23,10 @@ mount:
   /var/lib/automongodbbackup:
     disk: '/dev/mapper/backup-mongodb'
     govuk_lvm: 'mongodb'
+    mountoptions: 'defaults'
+  /var/lib/s3backup:
+    disk: '/dev/mapper/mongo-s3backups'
+    govuk_lvm: 's3backups'
     mountoptions: 'defaults'
 
 mongodb::server::replicaset_members:

--- a/hieradata/class/exception_handler.yaml
+++ b/hieradata/class/exception_handler.yaml
@@ -12,6 +12,9 @@ lv:
   data:
     pv: '/dev/sdc1'
     vg: 'mongodb'
+  s3backups:
+    pv: '/dev/sde1'
+    vg: 'mongo'
 
 mount:
   /var/lib/mongodb:
@@ -21,6 +24,10 @@ mount:
   /var/lib/automongodbbackup:
     disk: '/dev/mapper/backup-mongodb'
     govuk_lvm: 'mongodb'
+    mountoptions: 'defaults'
+  /var/lib/s3backup:
+    disk: '/dev/mapper/mongo-s3backups'
+    govuk_lvm: 's3backups'
     mountoptions: 'defaults'
 
 mongodb::server::replicaset_members:

--- a/hieradata/class/integration/licensify_mongo.yaml
+++ b/hieradata/class/integration/licensify_mongo.yaml
@@ -4,9 +4,16 @@ lv:
   mongodb:
     pv: '/dev/sdb1'
     vg: 'backup'
+  s3backups:
+    pv: '/dev/sdc1'
+    vg: 'mongo'
 
 mount:
   /var/lib/automongodbbackup:
     disk: '/dev/mapper/backup-mongodb'
     govuk_lvm: 'mongodb'
+    mountoptions: 'defaults'
+  /var/lib/s3backup:
+    disk: '/dev/mapper/mongo-s3backups'
+    govuk_lvm: 's3backups'
     mountoptions: 'defaults'

--- a/hieradata/class/licensify_mongo.yaml
+++ b/hieradata/class/licensify_mongo.yaml
@@ -18,6 +18,9 @@ lv:
   encrypted:
     pv: '/dev/sdc1'
     vg: 'mongodb'
+  s3backups:
+    pv: '/dev/sdd1'
+    vg: 'mongo'
 
 mount:
   /mnt/encrypted:
@@ -27,6 +30,10 @@ mount:
   /var/lib/automongodbbackup:
     disk: '/dev/mapper/backup-mongodb'
     govuk_lvm: 'mongodb'
+    mountoptions: 'defaults'
+  /var/lib/s3backup:
+    disk: '/dev/mapper/mongo-s3backups'
+    govuk_lvm: 's3backups'
     mountoptions: 'defaults'
 
 mongodb::server::replicaset_members:

--- a/hieradata/class/mongo.yaml
+++ b/hieradata/class/mongo.yaml
@@ -12,6 +12,9 @@ lv:
   data:
     pv: '/dev/sdc1'
     vg: 'mongodb'
+  s3backups:
+    pv: '/dev/sde1'
+    vg: 'mongo'
 
 mount:
   /var/lib/mongodb:
@@ -21,6 +24,10 @@ mount:
   /var/lib/automongodbbackup:
     disk: '/dev/mapper/backup-mongodb'
     govuk_lvm: 'mongodb'
+    mountoptions: 'defaults'
+  /var/lib/s3backup:
+    disk: '/dev/mapper/mongo-s3backups'
+    govuk_lvm: 's3backups'
     mountoptions: 'defaults'
 
 mongodb::server::oplog_size: 7168 # 7 * 1024

--- a/hieradata/class/performance_mongo.yaml
+++ b/hieradata/class/performance_mongo.yaml
@@ -10,6 +10,9 @@ lv:
   data:
     pv: '/dev/sdc1'
     vg: 'mongodb'
+  s3backups:
+    pv: '/dev/sdd1'
+    vg: 'mongo'
 
 mount:
   /var/lib/mongodb:
@@ -19,6 +22,10 @@ mount:
   /var/lib/automongodbbackup:
     disk: '/dev/mapper/backup-mongodb'
     govuk_lvm: 'mongodb'
+    mountoptions: 'defaults'
+  /var/lib/s3backup:
+    disk: '/dev/mapper/mongo-s3backups'
+    govuk_lvm: 's3backups'
     mountoptions: 'defaults'
 
 mongodb::server::oplog_size: 7168 # 7 * 1024

--- a/hieradata/class/router_backend.yaml
+++ b/hieradata/class/router_backend.yaml
@@ -23,6 +23,9 @@ lv:
   data:
     pv: '/dev/sdc1'
     vg: 'mongodb'
+  s3backups:
+    pv: '/dev/sdd1'
+    vg: 'mongo'
 
 mount:
   /var/lib/mongodb:
@@ -32,6 +35,10 @@ mount:
   /var/lib/automongodbbackup:
     disk: '/dev/mapper/backup-mongodb'
     govuk_lvm: 'mongodb'
+    mountoptions: 'defaults'
+  /var/lib/s3backup:
+    disk: '/dev/mapper/mongo-s3backups'
+    govuk_lvm: 's3backups'
     mountoptions: 'defaults'
 
 mongodb::server::replicaset_members:

--- a/modules/govuk/manifests/node/s_api_mongo.pp
+++ b/modules/govuk/manifests/node/s_api_mongo.pp
@@ -12,4 +12,5 @@ class govuk::node::s_api_mongo inherits govuk::node::s_base {
 
   Govuk_mount['/var/lib/mongodb'] -> Class['mongodb::server']
   Govuk_mount['/var/lib/automongodbbackup'] -> Class['mongodb::backup']
+  Govuk_mount['/var/lib/s3backup'] -> Class['mongodb::backup']
 }

--- a/modules/govuk/manifests/node/s_email_campaign_mongo.pp
+++ b/modules/govuk/manifests/node/s_email_campaign_mongo.pp
@@ -12,4 +12,5 @@ class govuk::node::s_email_campaign_mongo inherits govuk::node::s_base {
 
   Govuk_mount['/var/lib/mongodb'] -> Class['mongodb::server']
   Govuk_mount['/var/lib/automongodbbackup'] -> Class['mongodb::backup']
+  Govuk_mount['/var/lib/s3backup'] -> Class['mongodb::backup']
 }

--- a/modules/govuk/manifests/node/s_exception_handler.pp
+++ b/modules/govuk/manifests/node/s_exception_handler.pp
@@ -9,4 +9,5 @@ class govuk::node::s_exception_handler inherits govuk::node::s_base {
 
   Govuk_mount['/var/lib/mongodb'] -> Class['mongodb::server']
   Govuk_mount['/var/lib/automongodbbackup'] -> Class['mongodb::backup']
+  Govuk_mount['/var/lib/s3backup'] -> Class['mongodb::backup']
 }

--- a/modules/govuk/manifests/node/s_licensify_mongo.pp
+++ b/modules/govuk/manifests/node/s_licensify_mongo.pp
@@ -34,4 +34,5 @@ class govuk::node::s_licensify_mongo (
   }
 
   Govuk_mount['/var/lib/automongodbbackup'] -> Class['mongodb::backup']
+  Govuk_mount['/var/lib/s3backup'] -> Class['mongodb::backup']
 }

--- a/modules/govuk/manifests/node/s_mongo.pp
+++ b/modules/govuk/manifests/node/s_mongo.pp
@@ -12,4 +12,6 @@ class govuk::node::s_mongo inherits govuk::node::s_base {
 
   Govuk_mount['/var/lib/mongodb'] -> Class['mongodb::server']
   Govuk_mount['/var/lib/automongodbbackup'] -> Class['mongodb::backup']
+  Govuk_mount['/var/lib/s3backup'] -> Class['mongodb::backup']
+
 }

--- a/modules/govuk/manifests/node/s_router_backend.pp
+++ b/modules/govuk/manifests/node/s_router_backend.pp
@@ -14,4 +14,5 @@ class govuk::node::s_router_backend inherits govuk::node::s_base {
 
   Govuk_mount['/var/lib/mongodb'] -> Class['mongodb::server']
   Govuk_mount['/var/lib/automongodbbackup'] -> Class['mongodb::backup']
+  Govuk_mount['/var/lib/s3backup'] -> Class['mongodb::backup']
 }


### PR DESCRIPTION
What
It has been agreed that backups should be temporarily stored on separate partitions as
to not cause any issues for other services should the backup process somehow use
up all it's disk space.

How
Create separate mounts for backups.  Here I have added Logical Volume Manager
config for Mongodb instances performing s3backups.