### PR TITLE
Bouncer Gor bugfix

### DIFF
--- a/modules/govuk_bouncer/manifests/gor.pp
+++ b/modules/govuk_bouncer/manifests/gor.pp
@@ -28,7 +28,7 @@ class govuk_bouncer::gor (
 
   class { 'govuk_gor':
     args    => {
-      '-input-raw'          => ':80',
+      '-input-raw'          => ':3049',
       '-output-http'        => $gor_targets,
       '-http-allow-method'  => [
         'GET', 'HEAD', 'OPTIONS',

--- a/modules/govuk_bouncer/spec/classes/govuk_bouncer__gor_spec.rb
+++ b/modules/govuk_bouncer/spec/classes/govuk_bouncer__gor_spec.rb
@@ -3,7 +3,7 @@ require_relative '../../../../spec_helper'
 describe 'govuk_bouncer::gor', :type => :class do
   let(:ip_address) { '127.0.0.1' }
   let(:args_default) {{
-    '-input-raw'          => ':80',
+    '-input-raw'          => ':3049',
     '-http-allow-method' => %w{GET HEAD OPTIONS},
     '-http-original-host' => '',
   }}


### PR DESCRIPTION
After upgrading to the new version of Gor, bouncer stopped replaying traffic. It seems that listening on the nginx port does not replay traffic, but to do so on the unicorn port works as expected. I have not deduced why this is yet.

In the screen shot below, Puppet is deployed at roughly 14:40 and the machines update themselves to the new version. Traffic significantly falls off (the remaining traffic is for healthchecks and automated tests). At about 15:50 I change the port it's listening on a single bouncer machine, and a small amount of traffic starts to re-appear. At 16:30 I enable this across all machines, leaving it enabled with Puppet disabled.

![screen shot 2016-07-22 at 17 45 55](https://cloud.githubusercontent.com/assets/5610276/17064411/43382cfa-5034-11e6-8a60-324e78a8b825.png)
