### PR TITLE
Add brute-force option to pg_resync_slave

### DIFF
--- a/modules/govuk_postgresql/templates/usr/local/bin/pg_resync_slave.erb
+++ b/modules/govuk_postgresql/templates/usr/local/bin/pg_resync_slave.erb
@@ -12,6 +12,12 @@ FILES_TO_KEEP="
   ${DATADIR}/server.key
 "
 
+BRUTE=0
+
+if [ $1 == '--brute-force' ]; then
+  BRUTE=1
+fi
+
 if [ -z ${DATADIR} ]; then
   echo "DATADIR variable is empty"
   exit 1
@@ -37,7 +43,12 @@ done
 
 # Delay deletion and move instead of copy so that the service is down for
 # the minimal amount of time possible.
-sudo -u <%= @pg_user %> mv ${DATADIR} ${DATADIR_DELETE}
+if [ $BRUTE == 1 ]; then
+  sudo -u <%= @pg_user %> rm -rf ${DATADIR}
+else
+  sudo -u <%= @pg_user %> mv ${DATADIR} ${DATADIR_DELETE}
+fi
+
 sudo -u <%= @pg_user %> mv ${SYNCDIR} ${DATADIR}
 
 # Copy replication config, in case it's a new machine or the details have


### PR DESCRIPTION
This script fixes replication on a Postgres slave. It works very well,
other than it copies the data directory before restoring, which means we
need to have two full copies of the data directory on disk for the
restore. If the database is large, and we're tight on disk space, then
we can add a brute force option to delete the data directory and then do
the restore.