### PR TITLE
Add `content-tagger` to backend

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -759,6 +759,7 @@ hosts::production::backend::app_hostnames:
   - 'collections-publisher'
   - 'contacts-admin'
   - 'contentapi'
+  - 'content-tagger'
   - 'dfid-transition'
   - 'email-alert-api'
   - 'errbit'


### PR DESCRIPTION
This commit adds `content-tagger` to the `hosts::production::backend::app_hostnames:` in
hierdata/common.yaml. Signon has started timing out when trying to update users on the Content Tagger app. This appears to be caused by a missing entry in `/etc/hosts`. DevOps-ing this fixed the issue.