### PR TITLE
Removing cronjob after it was replaced in a previous PR

### DIFF
--- a/modules/mongodb/manifests/s3backup/cron.pp
+++ b/modules/mongodb/manifests/s3backup/cron.pp
@@ -27,4 +27,9 @@ class mongodb::s3backup::cron(
     minute  => '0',
   }
 
+# FIXME Please remove this resource one merged
+  cron { 'mongodb-s3backup':
+    ensure => absent,
+  }
+
 }


### PR DESCRIPTION
I renamed this cron job in another PR which has been merged.  Although there are no errors caused by having two of the same cronjob. It's best to remove.