### PR TITLE
Fix dfid-transition-import jenkins job

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/dfid_transition_import.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/dfid_transition_import.yaml.erb
@@ -24,8 +24,9 @@
             bundle exec rake load:outputs
     properties:
         - inject:
-            properties-content: REDIS_HOST=<%= @redis_host %>
-            properties-content: REDIS_PORT=<%= @redis_port %>
+            properties-content: |
+              REDIS_HOST=<%= @redis_host %>
+              REDIS_PORT=<%= @redis_port %>
     wrappers:
         - ansicolor:
             colormap: xterm


### PR DESCRIPTION
Only the last line of properties-content was considered; needed a YAML
block. Without it we only got REDIS_PORT and connection errors happened
due to REDIS_HOST defaulting to 127.0.0.1