### PR TITLE
Decrease amount of indices to keep

### DIFF
--- a/modules/govuk/manifests/node/s_logs_elasticsearch.pp
+++ b/modules/govuk/manifests/node/s_logs_elasticsearch.pp
@@ -1,4 +1,18 @@
-# FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
+# == Class: Govuk::Node::S_logs_elasticsearch
+#
+#  Node class for the logs_elasticsearch machines.
+#
+# === Parameters:
+#
+# [*rotate_hour*]
+#   The hour to rotate elasticsearch indices.
+#
+# [*rotate_minute*]
+#   The minute to rotate elasticsearch indices.
+#
+# [*indices_days_to_keep*]
+#   The number of elasticsearch indices to keep in days.
+#
 class govuk::node::s_logs_elasticsearch(
   $rotate_hour = 00,
   $rotate_minute = 01,

--- a/modules/govuk/manifests/node/s_logs_elasticsearch.pp
+++ b/modules/govuk/manifests/node/s_logs_elasticsearch.pp
@@ -2,6 +2,7 @@
 class govuk::node::s_logs_elasticsearch(
   $rotate_hour = 00,
   $rotate_minute = 01,
+  $indices_days_to_keep = 13,
 ) inherits govuk::node::s_base {
 
   $es_heap_size = floor($::memorysize_mb / 2)

--- a/modules/govuk/templates/usr/local/bin/es-rotate-passive-check.erb
+++ b/modules/govuk/templates/usr/local/bin/es-rotate-passive-check.erb
@@ -4,7 +4,7 @@
 exec 1> >(/usr/bin/logger -s -t $(basename $0)) 2>&1
 
 #FIXME: 2014-01-12 - Ideally this should be 21 days - need to fix logstasher gem first
-ARGS='--delete-old --delete-maxage 15 --optimize-old --optimize-maxage 1 logs'
+ARGS='--delete-old --delete-maxage <%= @indices_days_to_keep %> --optimize-old --optimize-maxage 1 logs'
 CMD="/usr/local/bin/es-rotate"
 
 function send_to_monitoring() {


### PR DESCRIPTION
We have a lot of data, too much for our current elasticsearch setup. To keep it ticking over while we reconfigure our elasticsearch stuff we can decrease the number of days that we keep our logs for, from 15 down to 13.

This also turns it to a parameter in a manifest from being hardcoded in the template because it's easier to find within the s_logs_elasticsearch manifest itself.