### PR TITLE
Licensing: Remove automongobackup 

### DIFF
--- a/hieradata/class/licensing_mongo.yaml
+++ b/hieradata/class/licensing_mongo.yaml
@@ -12,9 +12,6 @@ hosts::production::licensify::app_hostnames:
   - 'licensing-web-forms'
 
 lv:
-  mongodb:
-    pv: '/dev/sdb1'
-    vg: 'backup'
   databases:
     pv: '/dev/sdc1'
     vg: 'mongodb'
@@ -24,17 +21,13 @@ mount:
     disk: '/dev/mapper/mongodb-databases'
     govuk_lvm: 'databases'
     mountoptions: 'defaults'
-  /var/lib/automongodbbackup:
-    disk: '/dev/mapper/backup-mongodb'
-    govuk_lvm: 'mongodb'
-    mountoptions: 'defaults'
 
 mongodb::server::replicaset_members:
   'licensing-mongo-1':
   'licensing-mongo-2':
   'licensing-mongo-3':
 
-# Disable monthly backups to limit the retention of IL3 data.
-mongodb::backup::domonthly: false
+# Only s3backups will be implemented on licensing
+mongodb::backup::enabled: false
 
 mongodb::server::version: '3.2.7'

--- a/modules/govuk/manifests/node/s_licensing_mongo.pp
+++ b/modules/govuk/manifests/node/s_licensing_mongo.pp
@@ -11,5 +11,4 @@ class govuk::node::s_licensing_mongo inherits govuk::node::s_base {
   }
 
   Govuk_mount['/var/lib/mongodb'] -> Class['mongodb::server']
-  Govuk_mount['/var/lib/automongodbbackup'] -> Class['mongodb::backup']
 }

--- a/modules/mongodb/manifests/backup.pp
+++ b/modules/mongodb/manifests/backup.pp
@@ -84,19 +84,19 @@ class mongodb::backup(
   if $enabled_real {
     include logrotate
 
-    if $s3_backups {
-      include mongodb::s3backup::backup
-    }
-
-    if $s3_restores {
-      include mongodb::s3backup::restore
-    }
-
     @@icinga::passive_check { "check_automongodbbackup-${::hostname}":
       service_description => $service_desc,
       freshness_threshold => $threshold_secs,
       host_name           => $::fqdn,
     }
+  }
+
+  if $s3_backups {
+    include mongodb::s3backup::backup
+  }
+
+  if $s3_restores {
+    include mongodb::s3backup::restore
   }
 
 }


### PR DESCRIPTION
What
It's been decided that we will only implement s3 backups on the new licensing
Mongo vms running Mongodb 3.2.  We already have a PR to add separate mounts for s3backups.
This PR is to remove the `/dev/mapper/backup-mongodb` mount and the mongodb::backup class  from the Licensing mongo vms.

How
Remove the hiera config from this (puppet) repo that provisions the logical volumes/groups.
Remove the hiera config that provisions the disks in provisioning repo. (separate PR)
Remove mount resource from base class. Exclude mongodb::backup class.

It's agreed that the existing vms will be destroyed and new vms provisioned.