### PR TITLE
Duplicate cronjob

### DIFF
--- a/modules/mongodb/manifests/s3backup/cron.pp
+++ b/modules/mongodb/manifests/s3backup/cron.pp
@@ -30,6 +30,7 @@ class mongodb::s3backup::cron(
 # FIXME Please remove this resource one merged
   cron { 'mongodb-s3backup':
     ensure => absent,
+    user   => $user,
   }
 
 }


### PR DESCRIPTION
Duplicate cronjob. Removing cronjob 'mongodb-s3backup' from govuk-backup's crontab.