### PR TITLE
[DO NOT MERGE] Routing change for SPR CMA case deploy

### DIFF
--- a/modules/govuk/manifests/node/s_backend_lb.pp
+++ b/modules/govuk/manifests/node/s_backend_lb.pp
@@ -61,6 +61,9 @@ class govuk::node::s_backend_lb (
         '/maib-reports'        => {
           'app' => 'specialist-publisher-rebuild',
         },
+        '/cma-cases'           => {
+          'app' => 'specialist-publisher-rebuild',
+        },
       },
       servers        => $backend_servers;
     [


### PR DESCRIPTION
changed routing so that CMA cases are handled by specialist publisher
rebuild, rather than specialist publisher v1