### PR TITLE
Revert "Add brute-force option to pg_resync_slave"

### DIFF
--- a/modules/govuk_postgresql/templates/usr/local/bin/pg_resync_slave.erb
+++ b/modules/govuk_postgresql/templates/usr/local/bin/pg_resync_slave.erb
@@ -12,12 +12,6 @@ FILES_TO_KEEP="
   ${DATADIR}/server.key
 "
 
-BRUTE=0
-
-if [ $1 == '--brute-force' ]; then
-  BRUTE=1
-fi
-
 if [ -z ${DATADIR} ]; then
   echo "DATADIR variable is empty"
   exit 1
@@ -43,12 +37,7 @@ done
 
 # Delay deletion and move instead of copy so that the service is down for
 # the minimal amount of time possible.
-if [ $BRUTE == 1 ]; then
-  sudo -u <%= @pg_user %> rm -rf ${DATADIR}
-else
-  sudo -u <%= @pg_user %> mv ${DATADIR} ${DATADIR_DELETE}
-fi
-
+sudo -u <%= @pg_user %> mv ${DATADIR} ${DATADIR_DELETE}
 sudo -u <%= @pg_user %> mv ${SYNCDIR} ${DATADIR}
 
 # Copy replication config, in case it's a new machine or the details have


### PR DESCRIPTION
This reverts commit 4956a81ecc5a8437d8b5872c93eae96d56cbab55.

This did not work like I was expecting and I don't want it to be
deployed out. Needs more testing.