### PR TITLE
Mongodb s3 backups 1

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -258,7 +258,6 @@ licensify::apps::licensing_web_forms::enabled: true
 
 mongodb::s3backup::backup::s3_bucket: 'govuk-mongodb-backup-s3-integration'
 mongodb::s3backup::backup::s3_bucket_daily: 'govuk-mongodb-backup-s3-daily-integration'
-mongodb::backup::s3_backups: true
 mongodb::backup::mongo_backup_node: 'localhost'
 
 

--- a/hieradata/node/api-mongo-2.api.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/api-mongo-2.api.integration.publishing.service.gov.uk.yaml
@@ -1,0 +1,1 @@
+mongodb::backup::s3_backups: true

--- a/hieradata/node/exception-handler-1.backend.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/exception-handler-1.backend.integration.publishing.service.gov.uk.yaml
@@ -1,0 +1,1 @@
+mongodb::backup::s3_backups: true

--- a/hieradata/node/licensify-mongo-2.licensify.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/licensify-mongo-2.licensify.integration.publishing.service.gov.uk.yaml
@@ -1,0 +1,1 @@
+mongodb::backup::s3_backups: true

--- a/hieradata/node/licensing-mongo-2.licensify.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/licensing-mongo-2.licensify.integration.publishing.service.gov.uk.yaml
@@ -1,0 +1,1 @@
+mongodb::backup::s3_backups: true

--- a/hieradata/node/mongo-2.backend.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/mongo-2.backend.integration.publishing.service.gov.uk.yaml
@@ -1,0 +1,1 @@
+mongodb::backup::s3_backups: true

--- a/hieradata/node/performance-mongo-2.api.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/performance-mongo-2.api.integration.publishing.service.gov.uk.yaml
@@ -1,0 +1,1 @@
+mongodb::backup::s3_backups: true

--- a/hieradata/node/router-backend-2.router.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/router-backend-2.router.integration.publishing.service.gov.uk.yaml
@@ -1,0 +1,1 @@
+mongodb::backup::s3_backups: true

--- a/modules/mongodb/templates/mongodb-backup-s3.erb
+++ b/modules/mongodb/templates/mongodb-backup-s3.erb
@@ -12,8 +12,8 @@ BACKUP_NODE=<%= @backup_node %>
 BACKUP_DIR=<%= @backup_dir %>
 BACKUP_FILE=mongodump-<%= @fqdn %>.$(date +%F_%T).tar.gz.gpg
 KEY_FINGERPRINT=<%= @private_gpg_key_fingerprint %>
-S3_BUCKET=<%= @s3_bucket %>/<%= @fqdn %>
-S3_BUCKET_DAILY=<%= @s3_bucket_daily %>/<%= @fqdn %>
+S3_BUCKET=<%= @s3_bucket %>/<%= @fqdn %>/
+S3_BUCKET_DAILY=<%= @s3_bucket_daily %>/<%= @fqdn %>/
 
 # Triggered whenever this script exits, successful or otherwise. The values
 # of CODE/MESSAGE will be taken from that point in time.
@@ -22,6 +22,13 @@ printf "<%= @ipaddress %>\t<%= @service_desc %>\t${NAGIOS_CODE}\t${NAGIOS_MESSAG
 }
 
 trap nagios_passive EXIT
+
+# Remove any tarballs created as a result of running this script regardless of the exit status
+function housekeeping() {
+  /bin/rm -f $BACKUP_DIR/mongodump-*
+}
+
+trap housekeeping EXIT
 
 # Backup mongodb
 TIME="$(date +%s)"
@@ -46,8 +53,6 @@ fi
 TIME="$(($(date +%s)-TIME))"
 printf "BACKUP UPLOADED IN: ${TIME}s\n"
 
-# Tidy up
-/bin/rm -f $BACKUP_DIR/mongodump-*
 
 if [ $? == 0 ]; then
   STATUS=0


### PR DESCRIPTION
What
Inconsistent errors while performing s3 backups due to trailing slashes not being present at the end of bucket URLs.
As a result of of the errors, the script never gets to a point where it can cleanup the tarball(s) it
creates causing the host to run low on disk space.
s3 backups are gated in the base backup class but are currently deployed and performed on every provisioned host with mongodb in integration.

How
Add trailing slash to bucket directories/URLs as manual tests show the script works with or without trailing slash.
Implement trap in bash script which calls a function that performs housekeeping regardless of the exit status.
Removed gated boolean value from common integration data. Applied the value in node specific files in hiera.