### PR TITLE
Licensing s3 mount 2

### DIFF
--- a/modules/govuk/manifests/node/s_licensing_mongo.pp
+++ b/modules/govuk/manifests/node/s_licensing_mongo.pp
@@ -11,4 +11,5 @@ class govuk::node::s_licensing_mongo inherits govuk::node::s_base {
   }
 
   Govuk_mount['/var/lib/mongodb'] -> Class['mongodb::server']
+  Govuk_mount['/var/lib/s3backup'] -> Class['mongodb::backup']
 }


### PR DESCRIPTION
This change was left behind in a previous PR https://github.com/alphagov/govuk-puppet/pull/4689 and is required to mount /var/lib/s3backup to the newly provisioned disk.