### PR TITLE
Change dfid-transition app_type from `rack` to `procfile`

### DIFF
--- a/modules/govuk/manifests/apps/dfid_transition.pp
+++ b/modules/govuk/manifests/apps/dfid_transition.pp
@@ -70,7 +70,7 @@ class govuk::apps::dfid_transition (
     }
 
     govuk::app { $app_name:
-      app_type           => 'rack',
+      app_type           => 'procfile',
       port               => $port,
       enable_nginx_vhost => true,
     }


### PR DESCRIPTION
This means it won't start unicorns serving port 3124, so leaving the way
open for the "proper" channel of sidekiq-monitoring. Now we've added
this app on 3124 to sidekiq-monitoring's Procfile, sidekiq-monitoring is
attempting to rackup this app and causing a port collision, breaking
monitoring for other apps.

Let's be nicer than that.