### PR TITLE
Licensing s3 mounts 3

### DIFF
--- a/hieradata/class/licensing_mongo.yaml
+++ b/hieradata/class/licensing_mongo.yaml
@@ -15,9 +15,10 @@ lv:
   databases:
     pv: '/dev/sdc1'
     vg: 'mongodb'
-  s3backup:
+  s3backups:
     pv: '/dev/sdb1'
-    vg: 's3backup'
+    vg: 'mongo'
+
 
 mount:
   /var/lib/mongodb:
@@ -25,8 +26,8 @@ mount:
     govuk_lvm: 'databases'
     mountoptions: 'defaults'
   /var/lib/s3backup:
-    disk: '/dev/mapper/mongodb-s3backup'
-    govuk_lvm: 's3backup'
+    disk: '/dev/mapper/mongo-s3backups'
+    govuk_lvm: 's3backups'
     mountoptions: 'defaults'
 
 mongodb::server::replicaset_members:


### PR DESCRIPTION
We want the mapping for the s3 mount to be `/dev/mapper/mongo-s3backups`. My previous PR contained incorrect disk mappings. 
This has been corrected to provision `/dev/mapper/'volume_group'-'logical_volume'` as stated before.