### PR TITLE
Check existence of lock file before reboot

### DIFF
--- a/modules/govuk_unattended_reboot/manifests/init.pp
+++ b/modules/govuk_unattended_reboot/manifests/init.pp
@@ -13,6 +13,13 @@
 #   A hash containing a `username` and a `password` to access monitoring
 #   which is protected by basic authentication.
 #
+# === Variables
+#
+# [*lock_dir*]
+#   path => /etc/unattended-reboot/no-reboot/
+#   The directory in which a process places a file while in progress to
+#   prevent the host from rebooting.
+#
 class govuk_unattended_reboot (
   $enabled = false,
   $monitoring_basic_auth = {},
@@ -57,6 +64,24 @@ class govuk_unattended_reboot (
     group   => 'root',
     content => template("govuk_unattended_reboot${check_scripts_directory}/01_alerts.erb"),
     require => File['/usr/local/bin/check_icinga'],
+  }
+
+  $lock_dir = "${config_directory}/no-reboot"
+
+  file { $lock_dir:
+    ensure => directory,
+    mode   => '0777',
+    owner  => 'root',
+    group  => 'root',
+  }
+
+  file { '03_no_reboot':
+    ensure  => file,
+    path    => "${check_scripts_directory}/03_no_reboot",
+    mode    => '0755',
+    owner   => 'root',
+    group   => 'root',
+    content => template('govuk_unattended_reboot/03_no_reboot.erb'),
   }
 
   file { '/usr/local/bin/check_icinga':

--- a/modules/govuk_unattended_reboot/templates/03_no_reboot.erb
+++ b/modules/govuk_unattended_reboot/templates/03_no_reboot.erb
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+# Redirect stdout and stderr to syslog
+exec 1> >(/usr/bin/logger -s -t $(basename $0)) 2>&1
+
+LOCK_FILES=$(ls -A <%= @lock_dir %>)
+
+  # If any files exist within the lock directory. The Server will not reboot
+
+  if [[ $LOCK_FILES ]]; then
+
+    printf "REBOOT ABORTED BECAUSE THESE FILES EXIST WITHIN <%= @lock_dir %> :\n${LOCK_FILES}\n"
+
+    exit 1
+
+  else
+
+    exit 0
+
+  fi


### PR DESCRIPTION
What
Unattended reboots when invoked, interrupt backups. We do not want to reboot the host while
a backup is in progress.

How
When a backup is initiated we create a file under /etc/unattended-reboot/no-reboot.
The file should only exists for the duration of the job. While the file exists,
the machine does not reboot.

This relates to https://github.com/alphagov/govuk-puppet/pull/4670