### PR TITLE
Mongodb s3 backup 3

### DIFF
--- a/modules/mongodb/manifests/s3backup/cron.pp
+++ b/modules/mongodb/manifests/s3backup/cron.pp
@@ -14,23 +14,23 @@ class mongodb::s3backup::cron(
   require mongodb::s3backup::package
   require mongodb::s3backup::backup
 
+  # Here we use setlock to prevent the jobs from running asynchronously
   cron { 'mongodb-s3backup-realtime':
-    command => '/usr/bin/setlock -n /var/lock/mongodb-s3backup /usr/local/bin/mongodb-backup-s3',
+    command => '/usr/bin/setlock -n /etc/unattended-reboot/no-reboot/mongodb-s3backup /usr/local/bin/mongodb-backup-s3',
     user    => $user,
     minute  => '*/15',
   }
 
   cron { 'mongodb-s3-night-backup':
-    command => '/usr/bin/setlock /var/lock/mongodb-s3backup /usr/local/bin/mongodb-backup-s3 daily',
+    command => '/usr/bin/setlock /etc/unattended-reboot/no-reboot/mongodb-s3backup /usr/local/bin/mongodb-backup-s3 daily',
     user    => $user,
     hour    => '0',
     minute  => '0',
   }
 
-# FIXME Please remove this resource one merged
-  cron { 'mongodb-s3backup':
+  # FIXME Please remove resource once merged
+  file { '/var/lock/mongodb-s3backup':
     ensure => absent,
-    user   => $user,
   }
 
 }

--- a/modules/mongodb/templates/mongodb-backup-s3.erb
+++ b/modules/mongodb/templates/mongodb-backup-s3.erb
@@ -11,6 +11,7 @@ NAGIOS_MESSAGE="CRITICAL: Mongodb backup push to S3 failed"
 BACKUP_NODE=<%= @backup_node %>
 BACKUP_DIR=<%= @backup_dir %>
 BACKUP_FILE=mongodump-<%= @fqdn %>.$(date +%F_%T).tar.gz.gpg
+LOCK_FILE=/etc/unattended-reboot/no-reboot/mongodb-s3backup
 KEY_FINGERPRINT=<%= @private_gpg_key_fingerprint %>
 S3_BUCKET=<%= @s3_bucket %>/<%= @fqdn %>/
 S3_BUCKET_DAILY=<%= @s3_bucket_daily %>/<%= @fqdn %>/
@@ -21,9 +22,10 @@ function nagios_passive () {
 printf "<%= @ipaddress %>\t<%= @service_desc %>\t${NAGIOS_CODE}\t${NAGIOS_MESSAGE}\n" | /usr/sbin/send_nsca -H alert.cluster >/dev/null
 }
 
-# Remove any tarballs created as a result of running this script regardless of the exit status
+# Remove any tarballs and/or locks created as a result of running this script regardless of the exit status
 function housekeeping() {
   /bin/rm -f $BACKUP_DIR/mongodump-*
+  /bin/rm -f $LOCK_FILE
 }
 
 function exit_trap() {


### PR DESCRIPTION
What
This realtes to https://github.com/alphagov/govuk-puppet/pull/4721
The directory in which we touch a file to not only prevent the cronjobs from running asynchronously, but to also prevent the host from being rebooted while a cronjob is in progress has been modified.
Remove FIXME comment and relating cron resource.

How
Modified cron resource to touch file in the no-reboot directory.
Added comment explaining cron resource command.
Added clean up action for touched file to the s3 backup script for when the scripts exits.
Removed FIXME comment and relating cron resource.