### PR TITLE
Remove reboot checks for Integration

### DIFF
--- a/modules/monitoring/manifests/checks.pp
+++ b/modules/monitoring/manifests/checks.pp
@@ -23,9 +23,12 @@ class monitoring::checks (
   include monitoring::checks::ses
   include monitoring::checks::sidekiq
   include monitoring::checks::smokey
-  include monitoring::checks::reboots
 
   $app_domain = hiera('app_domain')
+
+  if $app_domain != 'integration.publishing.service.gov.uk' {
+    include monitoring::checks::reboots
+  }
 
   include icinga::plugin::check_http_timeout_noncrit
 


### PR DESCRIPTION
Servers in Integration get rebooted every night regardless of patches so
we shouldn't alert on it (in my opinion).