### PR TITLE
Fix the links on the 2nd line health Grafana dashboard

### DIFF
--- a/modules/grafana/templates/dashboards/2ndline_health.json.erb
+++ b/modules/grafana/templates/dashboards/2ndline_health.json.erb
@@ -35,7 +35,7 @@
               "name": "Drilldown dashboard",
               "title": "Edge health",
               "type": "absolute",
-              "url": "/#/dashboard/file/edge_health.json"
+              "url": "/dashboard/file/edge_health.json"
             }
           ],
           "maxDataPoints": 100,
@@ -101,7 +101,7 @@
               "name": "Drilldown dashboard",
               "title": "Edge health",
               "type": "absolute",
-              "url": "/#/dashboard/file/edge_health.json"
+              "url": "/dashboard/file/edge_health.json"
             }
           ],
           "maxDataPoints": 100,
@@ -168,7 +168,7 @@
               "name": "Drilldown dashboard",
               "title": "Edge health",
               "type": "absolute",
-              "url": "/#/dashboard/file/edge_health.json"
+              "url": "/dashboard/file/edge_health.json"
             }
           ],
           "maxDataPoints": 100,
@@ -246,7 +246,7 @@
               "name": "Drilldown dashboard",
               "title": "Origin health",
               "type": "absolute",
-              "url": "/#/dashboard/file/origin_health.json"
+              "url": "/dashboard/file/origin_health.json"
             }
           ],
           "maxDataPoints": 100,
@@ -312,7 +312,7 @@
               "name": "Drilldown dashboard",
               "title": "Origin health",
               "type": "absolute",
-              "url": "/#/dashboard/file/origin_health.json"
+              "url": "/dashboard/file/origin_health.json"
             }
           ],
           "maxDataPoints": 100,
@@ -379,7 +379,7 @@
               "name": "Drilldown dashboard",
               "title": "Origin health",
               "type": "absolute",
-              "url": "/#/dashboard/file/origin_health.json"
+              "url": "/dashboard/file/origin_health.json"
             }
           ],
           "maxDataPoints": 100,
@@ -446,7 +446,7 @@
               "name": "Drilldown dashboard",
               "title": "Origin health",
               "type": "absolute",
-              "url": "/#/dashboard/file/origin_health.json"
+              "url": "/dashboard/file/origin_health.json"
             }
           ],
           "maxDataPoints": 100,


### PR DESCRIPTION
These were broken with a Grafana update.