### PR TITLE
Fix rummager grafana dashboards

### DIFF
--- a/modules/grafana/files/dashboards/detailed_rummager_queues.json
+++ b/modules/grafana/files/dashboards/detailed_rummager_queues.json
@@ -1,6 +1,7 @@
 {
   "id": null,
   "title": "Rummager search indexing dashboard - details",
+  "originalTitle": "Rummager search indexing dashboard - details",
   "tags": [],
   "style": "dark",
   "timezone": "utc",
@@ -9,141 +10,267 @@
   "sharedCrosshair": false,
   "rows": [
     {
-      "height": "400px",
-      "editable": true,
       "collapse": false,
+      "editable": true,
+      "height": "400px",
       "panels": [
         {
-          "id": 1,
-          "title": "Message processor status counts",
-          "span": 4,
-          "type": "graph",
-          "bars": true,
-          "lines": false,
-          "nullPointMode": "null as zero",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "individual",
-            "shared": false
-          },
-          "targets": [
-            {
-              "target": "alias(consolidateBy(summarize(stats_counts.govuk.app.rummager.message_queue.indexer.accepted, '1minute', 'sum'), 'max'), 'Accepted')"
-            },
-            {
-              "target": "alias(consolidateBy(summarize(stats_counts.govuk.app.rummager.message_queue.indexer.rejected, '1minute', 'sum'), 'max'), 'Ignored')"
-            }
-          ],
           "aliasColors": {
             "Accepted": "#00C200",
             "Ignored": "#FF9900"
           },
-          "leftYAxisLabel": "Messages per minute",
+          "bars": true,
           "grid": {
-            "leftMin": 0
-          }
+            "threshold1": null,
+            "threshold2": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "id": 1,
+          "lines": false,
+          "nullPointMode": "null as zero",
+          "span": 4,
+          "steppedLine": false,
+          "targets": [
+            {
+              "target": "alias(consolidateBy(summarize(stats_counts.govuk.app.rummager.message_queue.indexer.accepted, '1minute', 'sum'), 'max'), 'Accepted')",
+              "refId": "A"
+            },
+            {
+              "target": "alias(consolidateBy(summarize(stats_counts.govuk.app.rummager.message_queue.indexer.rejected, '1minute', 'sum'), 'max'), 'Ignored')",
+              "refId": "B"
+            }
+          ],
+          "title": "Message processor status counts",
+          "tooltip": {
+            "shared": false,
+            "value_type": "individual",
+            "msResolution": true
+          },
+          "type": "graph",
+          "yaxes": [
+            {
+              "show": true,
+              "min": 0,
+              "format": "short",
+              "label": "Messages per minute"
+            },
+            {
+              "show": true,
+              "format": "short"
+            }
+          ],
+          "xaxis": {
+            "show": true
+          },
+          "datasource": "Graphite",
+          "renderer": "flot",
+          "fill": 1,
+          "linewidth": 2,
+          "points": false,
+          "pointradius": 5,
+          "stack": false,
+          "percentage": false,
+          "legend": {
+            "show": true,
+            "values": false,
+            "min": false,
+            "max": false,
+            "current": false,
+            "total": false,
+            "avg": false
+          },
+          "timeFrom": null,
+          "timeShift": null,
+          "seriesOverrides": []
         },
         {
+          "aliasColors": {
+            "Failure": "#EE0000",
+            "Success": "#00C200"
+          },
+          "bars": true,
+          "grid": {
+            "threshold1": null,
+            "threshold2": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
           "id": 2,
-          "title": "Sidekiq BulkIndexWorker activity (search indexing)",
-          "span": 4,
-          "type": "graph",
-          "bars": true,
           "lines": false,
           "nullPointMode": "null as zero",
+          "span": 4,
           "steppedLine": false,
-          "tooltip": {
-            "value_type": "individual",
-            "shared": false
-          },
           "targets": [
             {
-              "target": "alias(consolidateBy(summarize(stats_counts.govuk.app.rummager.workers.Indexer.BulkIndexWorker.success, '1minute', 'sum'), 'max'), 'Success')"
+              "target": "alias(consolidateBy(summarize(stats_counts.govuk.app.rummager.workers.Indexer.BulkIndexWorker.success, '1minute', 'sum'), 'max'), 'Success')",
+              "refId": "A"
             },
             {
-              "target": "alias(consolidateBy(summarize(stats_counts.govuk.app.rummager.workers.Indexer.BulkIndexWorker.failure, '1minute', 'sum'), 'max'), 'Failure')"
+              "target": "alias(consolidateBy(summarize(stats_counts.govuk.app.rummager.workers.Indexer.BulkIndexWorker.failure, '1minute', 'sum'), 'max'), 'Failure')",
+              "refId": "B"
             }
           ],
-          "aliasColors": {
-            "Success": "#00C200",
-            "Failure": "#EE0000"
+          "title": "Sidekiq BulkIndexWorker activity (search indexing)",
+          "tooltip": {
+            "shared": false,
+            "value_type": "individual",
+            "msResolution": true
           },
-          "grid": {
-            "leftMin": 0
+          "type": "graph",
+          "yaxes": [
+            {
+              "show": true,
+              "min": 0,
+              "format": "short",
+              "label": "Messages per minute"
+            },
+            {
+              "show": true,
+              "format": "short"
+            }
+          ],
+          "xaxis": {
+            "show": true
           },
-          "leftYAxisLabel": "Messages per minute"
+          "datasource": "Graphite",
+          "renderer": "flot",
+          "fill": 1,
+          "linewidth": 2,
+          "points": false,
+          "pointradius": 5,
+          "stack": false,
+          "percentage": false,
+          "legend": {
+            "show": true,
+            "values": false,
+            "min": false,
+            "max": false,
+            "current": false,
+            "total": false,
+            "avg": false
+          },
+          "timeFrom": null,
+          "timeShift": null,
+          "seriesOverrides": []
         },
         {
-          "id": 3,
-          "title": "Sidekiq DeleteWorker activity (search indexing)",
-          "span": 4,
-          "type": "graph",
+          "aliasColors": {
+            "Failure": "#EE0000",
+            "Success": "#00C200"
+          },
           "bars": true,
+          "grid": {
+            "threshold1": null,
+            "threshold2": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "id": 3,
           "lines": false,
           "nullPointMode": "null as zero",
+          "span": 4,
           "steppedLine": false,
-          "tooltip": {
-            "value_type": "individual",
-            "shared": false
-          },
           "targets": [
             {
-              "target": "alias(consolidateBy(summarize(stats_counts.govuk.app.rummager.workers.Indexer.DeleteWorker.success, '1minute', 'sum'), 'max'), 'Success')"
+              "target": "alias(consolidateBy(summarize(stats_counts.govuk.app.rummager.workers.Indexer.DeleteWorker.success, '1minute', 'sum'), 'max'), 'Success')",
+              "refId": "A"
             },
             {
-              "target": "alias(consolidateBy(summarize(stats_counts.govuk.app.rummager.workers.Indexer.DeleteWorker.failure, '1minute', 'sum'), 'max'), 'Failure')"
+              "target": "alias(consolidateBy(summarize(stats_counts.govuk.app.rummager.workers.Indexer.DeleteWorker.failure, '1minute', 'sum'), 'max'), 'Failure')",
+              "refId": "B"
             }
           ],
-          "aliasColors": {
-            "Success": "#00C200",
-            "Failure": "#EE0000"
+          "title": "Sidekiq DeleteWorker activity (search indexing)",
+          "tooltip": {
+            "shared": false,
+            "value_type": "individual",
+            "msResolution": true
           },
-          "grid": {
-            "leftMin": 0
+          "type": "graph",
+          "yaxes": [
+            {
+              "show": true,
+              "min": 0,
+              "format": "short",
+              "label": "Messages per minute"
+            },
+            {
+              "show": true,
+              "format": "short"
+            }
+          ],
+          "xaxis": {
+            "show": true
           },
-          "leftYAxisLabel": "Messages per minute"
+          "datasource": "Graphite",
+          "renderer": "flot",
+          "fill": 1,
+          "linewidth": 2,
+          "points": false,
+          "pointradius": 5,
+          "stack": false,
+          "percentage": false,
+          "legend": {
+            "show": true,
+            "values": false,
+            "min": false,
+            "max": false,
+            "current": false,
+            "total": false,
+            "avg": false
+          },
+          "timeFrom": null,
+          "timeShift": null,
+          "seriesOverrides": []
         }
-      ]
-    }
-  ],
-  "nav": [
-    {
-      "type": "timepicker",
-      "collapse": false,
-      "notice": false,
-      "enable": true,
-      "status": "Stable",
-      "time_options": [
-        "5m",
-        "15m",
-        "1h",
-        "6h",
-        "12h",
-        "24h",
-        "2d",
-        "7d",
-        "30d"
       ],
-      "refresh_intervals": [
-        "5s",
-        "10s",
-        "30s",
-        "1m",
-        "5m",
-        "15m",
-        "30m",
-        "1h",
-        "2h",
-        "1d"
-      ],
-      "now": true
+      "title": "Row"
     }
   ],
   "time": {
     "from": "now-2h",
     "to": "now"
   },
+  "timepicker": {
+    "collapse": false,
+    "enable": true,
+    "notice": false,
+    "now": true,
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "status": "Stable",
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ],
+    "type": "timepicker"
+  },
+  "templating": {
+    "list": []
+  },
+  "annotations": {
+    "list": []
+  },
   "refresh": "5s",
-  "version": 6,
-  "hideAllLegends": false
+  "schemaVersion": 12,
+  "version": 0,
+  "links": []
 }

--- a/modules/grafana/files/dashboards/rummager_queues.json
+++ b/modules/grafana/files/dashboards/rummager_queues.json
@@ -1,6 +1,7 @@
 {
   "id": null,
   "title": "Rummager search indexing dashboard",
+  "originalTitle": "Rummager search indexing dashboard",
   "tags": [],
   "style": "dark",
   "timezone": "utc",
@@ -9,228 +10,354 @@
   "sharedCrosshair": false,
   "rows": [
     {
+      "collapse": false,
+      "editable": true,
       "height": "400px",
-      "editable": true,
-      "collapse": false,
       "panels": [
         {
-          "id": 1,
-          "title": "Publishing queue consumer activity (RabbitMQ)",
-          "span": 6,
-          "type": "graph",
-          "bars": true,
-          "lines": false,
-          "nullPointMode": "null as zero",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "individual",
-            "shared": false
-          },
-          "targets": [
-            {
-              "target": "alias(consolidateBy(summarize(stats_counts.govuk.app.rummager.rummager_to_be_indexed.uncaught_exception, '1minute', 'sum'), 'max'), 'Error')"
-            },
-            {
-              "target": "alias(consolidateBy(summarize(stats_counts.govuk.app.rummager.rummager_to_be_indexed.discarded, '1minute', 'sum'), 'max'), 'Discarded')"
-            },
-            {
-              "target": "alias(consolidateBy(summarize(stats_counts.govuk.app.rummager.rummager_to_be_indexed.retried, '1minute', 'sum'), 'max'), 'Retried')"
-            },
-            {
-              "target": "alias(consolidateBy(summarize(stats_counts.govuk.app.rummager.rummager_to_be_indexed.acked, '1minute', 'sum'), 'max'), 'Success')"
-            }
-          ],
           "aliasColors": {
-            "Success": "#00C200",
-            "Retried": "#FF9900",
             "Discarded": "#FF7100",
-            "Error": "#EE0000"
+            "Error": "#EE0000",
+            "Retried": "#FF9900",
+            "Success": "#00C200"
           },
-          "grid": {
-            "leftMin": 0
-          },
-          "leftYAxisLabel": "Messages per minute"
-        },
-        {
-          "id": 2,
-          "title": "Sidekiq AmendWorker activity (search indexing)",
-          "span": 6,
-          "type": "graph",
-          "lines": false,
           "bars": true,
+          "grid": {
+            "threshold1": null,
+            "threshold2": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "id": 1,
+          "lines": false,
           "nullPointMode": "null as zero",
+          "span": 6,
           "steppedLine": false,
           "targets": [
             {
-              "target": "alias(consolidateBy(summarize(stats_counts.govuk.app.rummager.workers.Indexer.AmendWorker.success, '1minute', 'sum'), 'max'), 'Success')"
+              "target": "alias(consolidateBy(summarize(stats_counts.govuk.app.rummager.rummager_to_be_indexed.uncaught_exception, '1minute', 'sum'), 'max'), 'Error')",
+              "refId": "A"
             },
             {
-              "target": "alias(consolidateBy(summarize(stats_counts.govuk.app.rummager.workers.Indexer.AmendWorker.failure, '1minute', 'sum'), 'max'), 'Failure')"
+              "target": "alias(consolidateBy(summarize(stats_counts.govuk.app.rummager.rummager_to_be_indexed.discarded, '1minute', 'sum'), 'max'), 'Discarded')",
+              "refId": "B"
+            },
+            {
+              "target": "alias(consolidateBy(summarize(stats_counts.govuk.app.rummager.rummager_to_be_indexed.retried, '1minute', 'sum'), 'max'), 'Retried')",
+              "refId": "C"
+            },
+            {
+              "target": "alias(consolidateBy(summarize(stats_counts.govuk.app.rummager.rummager_to_be_indexed.acked, '1minute', 'sum'), 'max'), 'Success')",
+              "refId": "D"
             }
           ],
-          "aliasColors": {
-            "Success": "#00C200",
-            "Failure": "#EE0000"
+          "title": "Publishing queue consumer activity (RabbitMQ)",
+          "tooltip": {
+            "shared": false,
+            "value_type": "individual",
+            "msResolution": true
           },
-          "grid": {
-            "leftMin": 0
-          },
-          "leftYAxisLabel": "Messages per minute"
-        }
-      ]
-    },
-    {
-      "height": "200px",
-      "editable": true,
-      "collapse": false,
-      "panels": [
-        {
-          "title": "Publishing queue size (RabbitMQ)",
-          "error": false,
-          "span": 6,
-          "editable": true,
           "type": "graph",
-          "id": 3,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "short",
-            "short"
+          "yaxes": [
+            {
+              "show": true,
+              "min": 0,
+              "format": "short",
+              "label": "Messages per minute"
+            },
+            {
+              "show": true,
+              "format": "short"
+            }
           ],
-          "lines": true,
-          "fill": 0,
-          "linewidth": 3,
+          "xaxis": {
+            "show": true
+          },
+          "datasource": "Graphite",
+          "renderer": "flot",
+          "fill": 1,
+          "linewidth": 2,
           "points": false,
           "pointradius": 5,
-          "bars": false,
           "stack": false,
           "percentage": false,
           "legend": {
             "show": true,
             "values": false,
             "min": false,
-            "max": true,
-            "current": true,
+            "max": false,
+            "current": false,
             "total": false,
             "avg": false
           },
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": false
+          "timeFrom": null,
+          "timeShift": null,
+          "seriesOverrides": []
+        },
+        {
+          "aliasColors": {
+            "Failure": "#EE0000",
+            "Success": "#00C200"
           },
+          "bars": true,
+          "grid": {
+            "threshold1": null,
+            "threshold2": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "id": 2,
+          "lines": false,
+          "nullPointMode": "null as zero",
+          "span": 6,
+          "steppedLine": false,
           "targets": [
             {
-              "target": "alias(consolidateBy(summarize(rabbitmq_%2F.queues-rummager_to_be_indexed.messages_ready, '10s', 'max'), 'max'), 'Unprocessed')"
+              "target": "alias(consolidateBy(summarize(stats_counts.govuk.app.rummager.workers.Indexer.AmendWorker.success, '1minute', 'sum'), 'max'), 'Success')",
+              "refId": "A"
+            },
+            {
+              "target": "alias(consolidateBy(summarize(stats_counts.govuk.app.rummager.workers.Indexer.AmendWorker.failure, '1minute', 'sum'), 'max'), 'Failure')",
+              "refId": "B"
             }
           ],
+          "title": "Sidekiq AmendWorker activity (search indexing)",
+          "type": "graph",
+          "yaxes": [
+            {
+              "show": true,
+              "min": 0,
+              "format": "short",
+              "label": "Messages per minute"
+            },
+            {
+              "show": true,
+              "format": "short"
+            }
+          ],
+          "xaxis": {
+            "show": true
+          },
+          "datasource": "Graphite",
+          "renderer": "flot",
+          "fill": 1,
+          "linewidth": 2,
+          "points": false,
+          "pointradius": 5,
+          "stack": false,
+          "percentage": false,
+          "legend": {
+            "show": true,
+            "values": false,
+            "min": false,
+            "max": false,
+            "current": false,
+            "total": false,
+            "avg": false
+          },
+          "tooltip": {
+            "value_type": "cumulative",
+            "shared": true,
+            "msResolution": true
+          },
+          "timeFrom": null,
+          "timeShift": null,
+          "seriesOverrides": []
+        }
+      ],
+      "title": "Row"
+    },
+    {
+      "collapse": false,
+      "editable": true,
+      "height": "200px",
+      "panels": [
+        {
           "aliasColors": {
             "Unprocessed": "#0662D9"
           },
-          "leftYAxisLabel": "message count",
-          "grid": {
-            "leftMin": 0
-          }
-        },
-        {
-          "title": "Sidekiq queue size",
-          "error": false,
-          "span": 6,
-          "editable": true,
-          "type": "graph",
-          "id": 4,
-          "datasource": null,
-          "renderer": "flot",
-          "x-axis": true,
-          "y-axis": true,
-          "y_formats": [
-            "short",
-            "short"
-          ],
-          "lines": true,
-          "fill": 0,
-          "linewidth": 3,
-          "points": false,
-          "pointradius": 5,
           "bars": false,
-          "stack": false,
-          "percentage": false,
+          "datasource": "Graphite",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {
+            "threshold1": null,
+            "threshold2": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "id": 3,
           "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": true,
+            "avg": false,
             "current": true,
+            "max": true,
+            "min": false,
+            "show": true,
             "total": false,
-            "avg": false
+            "values": false
           },
+          "lines": true,
+          "linewidth": 3,
           "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "span": 6,
+          "stack": false,
           "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": false
-          },
           "targets": [
             {
-              "target": "alias(consolidateBy(summarize(stats.gauges.govuk.app.rummager.workers.enqueued, '10s', 'max'), 'max'), 'Enqueued')"
-            },
-            {
-              "target": "alias(consolidateBy(summarize(stats.gauges.govuk.app.rummager.workers.retry_set_size, '10s', 'max'), 'max'), 'Retry Set')"
+              "target": "alias(consolidateBy(summarize(rabbitmq_%2F.queues-rummager_to_be_indexed.messages_ready, '10s', 'max'), 'max'), 'Unprocessed')",
+              "refId": "A"
             }
           ],
+          "title": "Publishing queue size (RabbitMQ)",
+          "tooltip": {
+            "shared": false,
+            "value_type": "cumulative",
+            "msResolution": true
+          },
+          "type": "graph",
+          "yaxes": [
+            {
+              "show": true,
+              "min": 0,
+              "format": "short",
+              "label": "message count"
+            },
+            {
+              "show": true,
+              "format": "short"
+            }
+          ],
+          "xaxis": {
+            "show": true
+          },
+          "timeFrom": null,
+          "timeShift": null,
+          "seriesOverrides": []
+        },
+        {
           "aliasColors": {
             "Enqueued": "#0662D9",
             "Retry Set": "#BA43A9"
           },
-          "leftYAxisLabel": "message count",
+          "bars": false,
+          "datasource": "Graphite",
+          "editable": true,
+          "error": false,
+          "fill": 0,
           "grid": {
-            "leftMin": 0
-          }
+            "threshold1": null,
+            "threshold2": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "id": 4,
+          "legend": {
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 3,
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "target": "alias(consolidateBy(summarize(stats.gauges.govuk.app.rummager.workers.enqueued, '10s', 'max'), 'max'), 'Enqueued')",
+              "refId": "A"
+            },
+            {
+              "target": "alias(consolidateBy(summarize(stats.gauges.govuk.app.rummager.workers.retry_set_size, '10s', 'max'), 'max'), 'Retry Set')",
+              "refId": "B"
+            }
+          ],
+          "title": "Sidekiq queue size",
+          "tooltip": {
+            "shared": false,
+            "value_type": "cumulative",
+            "msResolution": true
+          },
+          "type": "graph",
+          "yaxes": [
+            {
+              "show": true,
+              "min": 0,
+              "format": "short",
+              "label": "message count"
+            },
+            {
+              "show": true,
+              "format": "short"
+            }
+          ],
+          "xaxis": {
+            "show": true
+          },
+          "timeFrom": null,
+          "timeShift": null,
+          "seriesOverrides": []
         }
-      ]
-    }
-  ],
-  "nav": [
-    {
-      "type": "timepicker",
-      "collapse": false,
-      "notice": false,
-      "enable": true,
-      "status": "Stable",
-      "time_options": [
-        "5m",
-        "15m",
-        "1h",
-        "6h",
-        "12h",
-        "24h",
-        "2d",
-        "7d",
-        "30d"
       ],
-      "refresh_intervals": [
-        "5s",
-        "10s",
-        "30s",
-        "1m",
-        "5m",
-        "15m",
-        "30m",
-        "1h",
-        "2h",
-        "1d"
-      ],
-      "now": true
+      "title": "Row"
     }
   ],
   "time": {
     "from": "now-2h",
     "to": "now"
   },
+  "timepicker": {
+    "collapse": false,
+    "enable": true,
+    "notice": false,
+    "now": true,
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "status": "Stable",
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ],
+    "type": "timepicker"
+  },
+  "templating": {
+    "list": []
+  },
+  "annotations": {
+    "list": []
+  },
   "refresh": "5s",
-  "version": 6,
-  "hideAllLegends": false
+  "schemaVersion": 12,
+  "version": 0,
+  "links": []
 }


### PR DESCRIPTION
Grafana dashboards for Rummager are throwing javascript errors due to the upgrade from 1.9.x to 3.x
_something something y axis_

To fix I have added the expected properties locally, this made the dashboards visible, then updated the data sources and exported again. This _seems_ to make the dashboards appear properly again, see screenshots.

![screenshot from 2016-08-03 14 11 22](https://cloud.githubusercontent.com/assets/93511/17366686/658a3844-5984-11e6-9f92-e84dda35230b.png)
![screenshot from 2016-08-03 14 12 50](https://cloud.githubusercontent.com/assets/93511/17366685/6588cff4-5984-11e6-99df-06a83f13eeb0.png)

cc @tijmenb 