### PR TITLE
Exclude bouncer 4XXs from Edge health graph

### DIFF
--- a/modules/grafana/templates/dashboards/2ndline_health.json.erb
+++ b/modules/grafana/templates/dashboards/2ndline_health.json.erb
@@ -121,7 +121,7 @@
           "targets": [
             {
               "hide": false,
-              "target": "timeShift(movingAverage(asPercent(divideSeries(sumSeries(monitoring-1_management.cdn_fastly-{assets,govuk,redirector}.requests-status_4xx), sumSeries(monitoring-1_management.cdn_fastly-{assets,govuk,redirector}.requests-status_?xx)),1), '1min'), '-15min')",
+              "target": "timeShift(movingAverage(asPercent(divideSeries(sumSeries(monitoring-1_management.cdn_fastly-{assets,govuk}.requests-status_4xx), sumSeries(monitoring-1_management.cdn_fastly-{assets,govuk}.requests-status_?xx)),1), '1min'), '-15min')",
               "refId": "A",
               "textEditor": true
             }


### PR DESCRIPTION
We care less about Bouncer 4XXs, they're mostly noise against
origin 4XXs which are more likely to be real errors.

/cc @jennyd @tijmenb 