### PR TITLE
Configure environment for Sidekiq monitoring

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -247,8 +247,8 @@ govuk::apps::bouncer::db_hostname: "transition-postgresql-slave-1.backend"
 govuk::apps::bouncer::nagios_memory_warning: 1400
 govuk::apps::bouncer::nagios_memory_critical: 1500
 
-govuk::apps::collections_publisher::redis_host: 'redis-1.backend'
-govuk::apps::collections_publisher::redis_port: '6379'
+govuk::apps::collections_publisher::redis_host: "%{hiera('sidekiq::host')}"
+govuk::apps::collections_publisher::redis_port: "%{hiera('sidekiq::port')}"
 
 govuk::apps::contentapi::nagios_memory_warning: 3800
 govuk::apps::contentapi::nagios_memory_critical: 4000
@@ -259,6 +259,8 @@ govuk::apps::content_store::nagios_memory_critical: 1300
 govuk::apps::content_tagger::db_hostname: "postgresql-primary-1.backend"
 govuk::apps::content_tagger::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 govuk::apps::content_tagger::enable_procfile_worker: true
+govuk::apps::content_tagger::redis_host: "%{hiera('sidekiq::host')}"
+govuk::apps::content_tagger::redis_port: "%{hiera('sidekiq::port')}"
 
 govuk::apps::efg::vhost_name: "www.sflg.gov.uk"
 govuk::apps::efg::nagios_memory_warning: 1600
@@ -294,14 +296,14 @@ govuk::apps::govuk_cdn_logs_monitor::processed_data_dir: '/mnt/logs_cdn/data'
 
 govuk::apps::dfid_transition::enabled: true
 govuk::apps::dfid_transition::enable_procfile_worker: true
-govuk::apps::dfid_transition::redis_host: 'redis-1.backend'
-govuk::apps::dfid_transition::redis_port: '6379'
+govuk::apps::dfid_transition::redis_host: "%{hiera('sidekiq::host')}"
+govuk::apps::dfid_transition::redis_port: "%{hiera('sidekiq::port')}"
 
-govuk::apps::publisher::redis_host: 'redis-1.backend'
-govuk::apps::publisher::redis_port: '6379'
+govuk::apps::publisher::redis_host: "%{hiera('sidekiq::host')}"
+govuk::apps::publisher::redis_port: "%{hiera('sidekiq::port')}"
 
-govuk::apps::whitehall::redis_host: 'redis-1.backend'
-govuk::apps::whitehall::redis_port: '6379'
+govuk::apps::whitehall::redis_host: "%{hiera('sidekiq::host')}"
+govuk::apps::whitehall::redis_port: "%{hiera('sidekiq::port')}"
 
 govuk::apps::govuk_crawler_worker::airbrake_endpoint: "https://errbit.%{hiera('app_domain')}/notifier_api/v2/notices"
 govuk::apps::govuk_crawler_worker::airbrake_env: "%{hiera('govuk::deploy::config::errbit_environment_name')}"
@@ -340,7 +342,8 @@ govuk::apps::kibana::signon_root: "https://signon.%{hiera('app_domain')}"
 
 govuk::apps::local_links_manager::db_hostname: "postgresql-primary-1.backend"
 govuk::apps::local_links_manager::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
-govuk::apps::local_links_manager::redis_host: 'redis-1.backend'
+govuk::apps::local_links_manager::redis_host: "%{hiera('sidekiq::host')}"
+govuk::apps::local_links_manager::redis_port: "%{hiera('sidekiq::port')}"
 
 govuk::apps::mapit::enabled: true
 govuk::apps::metadata_api::enabled: true
@@ -373,7 +376,8 @@ govuk::apps::policy_publisher::db::backend_ip_range: "%{hiera('environment_ip_pr
 govuk::apps::publishing_api::content_store: "https://content-store.%{hiera('app_domain')}"
 govuk::apps::publishing_api::db_hostname: "postgresql-primary-1.backend"
 govuk::apps::publishing_api::draft_content_store: "https://draft-content-store.%{hiera('app_domain')}"
-govuk::apps::publishing_api::redis_host: 'redis-1.backend'
+govuk::apps::publishing_api::redis_host: "%{hiera('sidekiq::host')}"
+govuk::apps::publishing_api::redis_port: "%{hiera('sidekiq::port')}"
 govuk::apps::publishing_api::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 
 govuk::apps::rummager::nagios_memory_warning: 4600
@@ -389,8 +393,8 @@ govuk::apps::service_manual_publisher::db::backend_ip_range: "%{hiera('environme
 govuk::apps::share_sale_publisher::enabled: true
 
 govuk::apps::signon::redis_url: "redis://redis-1.backend:6379/0"
-govuk::apps::signon::redis_host: 'redis-1.backend'
-govuk::apps::signon::redis_port: '6379'
+govuk::apps::signon::redis_host: "%{hiera('sidekiq::host')}"
+govuk::apps::signon::redis_port: "%{hiera('sidekiq::port')}"
 govuk::apps::signon::nagios_memory_warning: 900
 govuk::apps::signon::nagios_memory_critical: 1000
 
@@ -403,8 +407,10 @@ govuk::apps::specialist_publisher::nagios_memory_warning: 1100
 govuk::apps::specialist_publisher::nagios_memory_critical: 1200
 
 govuk::apps::specialist_publisher_rebuild::enabled: true
-govuk::apps::specialist_publisher_rebuild::redis_host: 'redis-1.backend'
-govuk::apps::specialist_publisher_rebuild_standalone::redis_host: 'redis-1.backend'
+govuk::apps::specialist_publisher_rebuild::redis_host: "%{hiera('sidekiq::host')}"
+govuk::apps::specialist_publisher_rebuild::redis_port: "%{hiera('sidekiq::port')}"
+govuk::apps::specialist_publisher_rebuild_standalone::redis_host: "%{hiera('sidekiq::host')}"
+govuk::apps::specialist_publisher_rebuild_standalone::redis_port: "%{hiera('sidekiq::port')}"
 
 govuk::apps::spotlight::enabled: true
 govuk::apps::spotlight::alert_5xx_warning_rate: 0.2
@@ -431,7 +437,8 @@ govuk::apps::tariff_api::nagios_memory_critical: 2000
 
 govuk::apps::transition::postgresql_db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 
-govuk::apps::travel_advice_publisher::redis_host: 'redis-1.backend'
+govuk::apps::travel_advice_publisher::redis_host: "%{hiera('sidekiq::host')}"
+govuk::apps::travel_advice_publisher::redis_port: "%{hiera('sidekiq::port')}"
 
 govuk::deploy::config::asset_root: "https://%{hiera('router::assets_origin::vhost_name')}"
 govuk::deploy::config::website_root: "https://www-origin.%{hiera('app_domain')}"
@@ -1207,6 +1214,9 @@ router::nginx::robotstxt: |
   # whether or not it supports crawl-delay.
   User-agent: deepcrawl
   Disallow: /
+
+sidekiq::host: 'redis-1.backend'
+sidekiq::port: '6379'
 
 ssh::config::allow_users_enable: true
 

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -268,11 +268,15 @@ govuk::apps::efg::nagios_memory_critical: 1800
 
 govuk::apps::email_alert_api::enabled: true
 govuk::apps::email_alert_api::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
+govuk::apps::email_alert_api::redis_host: "%{hiera('sidekiq::host')}"
+govuk::apps::email_alert_api::redis_port: "%{hiera('sidekiq::port')}"
 
 govuk::apps::email_campaign_api::mongodb_nodes:
   - 'email-campaign-mongo-1.api'
   - 'email-campaign-mongo-2.api'
   - 'email-campaign-mongo-3.api'
+govuk::apps::email_campaign_api::redis_host: 'api-redis-1.api'
+govuk::apps::email_campaign_api::redis_port: '6379'
 
 govuk::apps::email_alert_service::rabbitmq_hosts:
   - rabbitmq-1.backend
@@ -333,6 +337,8 @@ govuk::apps::imminence::mongodb_nodes:
   - 'mongo-1.backend'
   - 'mongo-2.backend'
   - 'mongo-3.backend'
+govuk::apps::imminence::redis_host: 'redis-2.backend'
+govuk::apps::imminence::redis_port: '6379'
 govuk::apps::imminence::nagios_memory_warning: 1200
 govuk::apps::imminence::nagios_memory_critical: 1400
 
@@ -384,6 +390,8 @@ govuk::apps::rummager::nagios_memory_warning: 4600
 govuk::apps::rummager::nagios_memory_critical: 4900
 govuk::apps::rummager::enable_publishing_listener: true
 govuk::apps::rummager::rabbitmq::enable_publishing_listener: true
+govuk::apps::rummager::redis_host: 'api-redis-1.api'
+govuk::apps::rummager::redis_port: '6379'
 
 govuk::apps::service_manual_publisher::http_username: "%{hiera('http_username')}"
 govuk::apps::service_manual_publisher::http_password: "%{hiera('http_password')}"
@@ -391,6 +399,29 @@ govuk::apps::service_manual_publisher::http_password: "%{hiera('http_password')}
 govuk::apps::service_manual_publisher::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 
 govuk::apps::share_sale_publisher::enabled: true
+
+govuk::apps::sidekiq_monitoring::dfid_transition_redis_host: "%{hiera('govuk::apps::dfid_transition::redis_host')}"
+govuk::apps::sidekiq_monitoring::dfid_transition_redis_port: "%{hiera('govuk::apps::dfid_transition::redis_port')}"
+govuk::apps::sidekiq_monitoring::email_alert_api_redis_host: "%{hiera('govuk::apps::email_alert_api::redis_host')}"
+govuk::apps::sidekiq_monitoring::email_alert_api_redis_port: "%{hiera('govuk::apps::email_alert_api::redis_port')}"
+govuk::apps::sidekiq_monitoring::email_campaign_api_redis_host: "%{hiera('govuk::apps::email_campaign_api::redis_host')}"
+govuk::apps::sidekiq_monitoring::email_campaign_api_redis_port: "%{hiera('govuk::apps::email_campaign_api::redis_port')}"
+govuk::apps::sidekiq_monitoring::imminence_redis_host: "%{hiera('govuk::apps::imminence::redis_host')}"
+govuk::apps::sidekiq_monitoring::imminence_redis_port: "%{hiera('govuk::apps::imminence::redis_port')}"
+govuk::apps::sidekiq_monitoring::publisher_redis_host: "%{hiera('govuk::apps::publisher::redis_host')}"
+govuk::apps::sidekiq_monitoring::publisher_redis_port: "%{hiera('govuk::apps::publisher::redis_port')}"
+govuk::apps::sidekiq_monitoring::publishing_api_redis_host: "%{hiera('govuk::apps::publishing_api::redis_host')}"
+govuk::apps::sidekiq_monitoring::publishing_api_redis_port: "%{hiera('govuk::apps::publishing_api::redis_port')}"
+govuk::apps::sidekiq_monitoring::rummager_redis_host: "%{hiera('govuk::apps::rummager::redis_host')}"
+govuk::apps::sidekiq_monitoring::rummager_redis_port: "%{hiera('govuk::apps::rummager::redis_port')}"
+govuk::apps::sidekiq_monitoring::signon_redis_host: "%{hiera('govuk::apps::signon::redis_host')}"
+govuk::apps::sidekiq_monitoring::signon_redis_port: "%{hiera('govuk::apps::signon::redis_port')}"
+govuk::apps::sidekiq_monitoring::travel_advice_publisher_redis_host: "%{hiera('govuk::apps::travel_advice_publisher::redis_host')}"
+govuk::apps::sidekiq_monitoring::travel_advice_publisher_redis_port: "%{hiera('govuk::apps::travel_advice_publisher::redis_port')}"
+govuk::apps::sidekiq_monitoring::transition_redis_host: "%{hiera('govuk::apps::transition::redis_host')}"
+govuk::apps::sidekiq_monitoring::transition_redis_port: "%{hiera('govuk::apps::transition::redis_port')}"
+govuk::apps::sidekiq_monitoring::whitehall_redis_host: "%{hiera('govuk::apps::whitehall::redis_host')}"
+govuk::apps::sidekiq_monitoring::whitehall_redis_port: "%{hiera('govuk::apps::whitehall::redis_port')}"
 
 govuk::apps::signon::redis_url: "redis://redis-1.backend:6379/0"
 govuk::apps::signon::redis_host: "%{hiera('sidekiq::host')}"
@@ -436,6 +467,8 @@ govuk::apps::tariff_api::nagios_memory_warning: 1800
 govuk::apps::tariff_api::nagios_memory_critical: 2000
 
 govuk::apps::transition::postgresql_db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
+govuk::apps::transition::redis_host: "%{hiera('sidekiq::host')}"
+govuk::apps::transition::redis_port: "%{hiera('sidekiq::port')}"
 
 govuk::apps::travel_advice_publisher::redis_host: "%{hiera('sidekiq::host')}"
 govuk::apps::travel_advice_publisher::redis_port: "%{hiera('sidekiq::port')}"

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -247,8 +247,8 @@ govuk::apps::bouncer::db_hostname: "transition-postgresql-slave-1.backend"
 govuk::apps::bouncer::nagios_memory_warning: 1400
 govuk::apps::bouncer::nagios_memory_critical: 1500
 
-govuk::apps::collections_publisher::redis_host: "%{hiera('sidekiq::host')}"
-govuk::apps::collections_publisher::redis_port: "%{hiera('sidekiq::port')}"
+govuk::apps::collections_publisher::redis_host: "%{hiera('sidekiq_host')}"
+govuk::apps::collections_publisher::redis_port: "%{hiera('sidekiq_port')}"
 
 govuk::apps::contentapi::nagios_memory_warning: 3800
 govuk::apps::contentapi::nagios_memory_critical: 4000
@@ -259,8 +259,8 @@ govuk::apps::content_store::nagios_memory_critical: 1300
 govuk::apps::content_tagger::db_hostname: "postgresql-primary-1.backend"
 govuk::apps::content_tagger::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 govuk::apps::content_tagger::enable_procfile_worker: true
-govuk::apps::content_tagger::redis_host: "%{hiera('sidekiq::host')}"
-govuk::apps::content_tagger::redis_port: "%{hiera('sidekiq::port')}"
+govuk::apps::content_tagger::redis_host: "%{hiera('sidekiq_host')}"
+govuk::apps::content_tagger::redis_port: "%{hiera('sidekiq_port')}"
 
 govuk::apps::efg::vhost_name: "www.sflg.gov.uk"
 govuk::apps::efg::nagios_memory_warning: 1600
@@ -268,8 +268,8 @@ govuk::apps::efg::nagios_memory_critical: 1800
 
 govuk::apps::email_alert_api::enabled: true
 govuk::apps::email_alert_api::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
-govuk::apps::email_alert_api::redis_host: "%{hiera('sidekiq::host')}"
-govuk::apps::email_alert_api::redis_port: "%{hiera('sidekiq::port')}"
+govuk::apps::email_alert_api::redis_host: "%{hiera('sidekiq_host')}"
+govuk::apps::email_alert_api::redis_port: "%{hiera('sidekiq_port')}"
 
 govuk::apps::email_campaign_api::mongodb_nodes:
   - 'email-campaign-mongo-1.api'
@@ -300,14 +300,14 @@ govuk::apps::govuk_cdn_logs_monitor::processed_data_dir: '/mnt/logs_cdn/data'
 
 govuk::apps::dfid_transition::enabled: true
 govuk::apps::dfid_transition::enable_procfile_worker: true
-govuk::apps::dfid_transition::redis_host: "%{hiera('sidekiq::host')}"
-govuk::apps::dfid_transition::redis_port: "%{hiera('sidekiq::port')}"
+govuk::apps::dfid_transition::redis_host: "%{hiera('sidekiq_host')}"
+govuk::apps::dfid_transition::redis_port: "%{hiera('sidekiq_port')}"
 
-govuk::apps::publisher::redis_host: "%{hiera('sidekiq::host')}"
-govuk::apps::publisher::redis_port: "%{hiera('sidekiq::port')}"
+govuk::apps::publisher::redis_host: "%{hiera('sidekiq_host')}"
+govuk::apps::publisher::redis_port: "%{hiera('sidekiq_port')}"
 
-govuk::apps::whitehall::redis_host: "%{hiera('sidekiq::host')}"
-govuk::apps::whitehall::redis_port: "%{hiera('sidekiq::port')}"
+govuk::apps::whitehall::redis_host: "%{hiera('sidekiq_host')}"
+govuk::apps::whitehall::redis_port: "%{hiera('sidekiq_port')}"
 
 govuk::apps::govuk_crawler_worker::airbrake_endpoint: "https://errbit.%{hiera('app_domain')}/notifier_api/v2/notices"
 govuk::apps::govuk_crawler_worker::airbrake_env: "%{hiera('govuk::deploy::config::errbit_environment_name')}"
@@ -348,8 +348,8 @@ govuk::apps::kibana::signon_root: "https://signon.%{hiera('app_domain')}"
 
 govuk::apps::local_links_manager::db_hostname: "postgresql-primary-1.backend"
 govuk::apps::local_links_manager::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
-govuk::apps::local_links_manager::redis_host: "%{hiera('sidekiq::host')}"
-govuk::apps::local_links_manager::redis_port: "%{hiera('sidekiq::port')}"
+govuk::apps::local_links_manager::redis_host: "%{hiera('sidekiq_host')}"
+govuk::apps::local_links_manager::redis_port: "%{hiera('sidekiq_port')}"
 
 govuk::apps::mapit::enabled: true
 govuk::apps::metadata_api::enabled: true
@@ -382,8 +382,8 @@ govuk::apps::policy_publisher::db::backend_ip_range: "%{hiera('environment_ip_pr
 govuk::apps::publishing_api::content_store: "https://content-store.%{hiera('app_domain')}"
 govuk::apps::publishing_api::db_hostname: "postgresql-primary-1.backend"
 govuk::apps::publishing_api::draft_content_store: "https://draft-content-store.%{hiera('app_domain')}"
-govuk::apps::publishing_api::redis_host: "%{hiera('sidekiq::host')}"
-govuk::apps::publishing_api::redis_port: "%{hiera('sidekiq::port')}"
+govuk::apps::publishing_api::redis_host: "%{hiera('sidekiq_host')}"
+govuk::apps::publishing_api::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::publishing_api::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 
 govuk::apps::rummager::nagios_memory_warning: 4600
@@ -424,8 +424,8 @@ govuk::apps::sidekiq_monitoring::whitehall_redis_host: "%{hiera('govuk::apps::wh
 govuk::apps::sidekiq_monitoring::whitehall_redis_port: "%{hiera('govuk::apps::whitehall::redis_port')}"
 
 govuk::apps::signon::redis_url: "redis://redis-1.backend:6379/0"
-govuk::apps::signon::redis_host: "%{hiera('sidekiq::host')}"
-govuk::apps::signon::redis_port: "%{hiera('sidekiq::port')}"
+govuk::apps::signon::redis_host: "%{hiera('sidekiq_host')}"
+govuk::apps::signon::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::signon::nagios_memory_warning: 900
 govuk::apps::signon::nagios_memory_critical: 1000
 
@@ -438,10 +438,10 @@ govuk::apps::specialist_publisher::nagios_memory_warning: 1100
 govuk::apps::specialist_publisher::nagios_memory_critical: 1200
 
 govuk::apps::specialist_publisher_rebuild::enabled: true
-govuk::apps::specialist_publisher_rebuild::redis_host: "%{hiera('sidekiq::host')}"
-govuk::apps::specialist_publisher_rebuild::redis_port: "%{hiera('sidekiq::port')}"
-govuk::apps::specialist_publisher_rebuild_standalone::redis_host: "%{hiera('sidekiq::host')}"
-govuk::apps::specialist_publisher_rebuild_standalone::redis_port: "%{hiera('sidekiq::port')}"
+govuk::apps::specialist_publisher_rebuild::redis_host: "%{hiera('sidekiq_host')}"
+govuk::apps::specialist_publisher_rebuild::redis_port: "%{hiera('sidekiq_port')}"
+govuk::apps::specialist_publisher_rebuild_standalone::redis_host: "%{hiera('sidekiq_host')}"
+govuk::apps::specialist_publisher_rebuild_standalone::redis_port: "%{hiera('sidekiq_port')}"
 
 govuk::apps::spotlight::enabled: true
 govuk::apps::spotlight::alert_5xx_warning_rate: 0.2
@@ -467,11 +467,11 @@ govuk::apps::tariff_api::nagios_memory_warning: 1800
 govuk::apps::tariff_api::nagios_memory_critical: 2000
 
 govuk::apps::transition::postgresql_db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
-govuk::apps::transition::redis_host: "%{hiera('sidekiq::host')}"
-govuk::apps::transition::redis_port: "%{hiera('sidekiq::port')}"
+govuk::apps::transition::redis_host: "%{hiera('sidekiq_host')}"
+govuk::apps::transition::redis_port: "%{hiera('sidekiq_port')}"
 
-govuk::apps::travel_advice_publisher::redis_host: "%{hiera('sidekiq::host')}"
-govuk::apps::travel_advice_publisher::redis_port: "%{hiera('sidekiq::port')}"
+govuk::apps::travel_advice_publisher::redis_host: "%{hiera('sidekiq_host')}"
+govuk::apps::travel_advice_publisher::redis_port: "%{hiera('sidekiq_port')}"
 
 govuk::deploy::config::asset_root: "https://%{hiera('router::assets_origin::vhost_name')}"
 govuk::deploy::config::website_root: "https://www-origin.%{hiera('app_domain')}"
@@ -1248,8 +1248,8 @@ router::nginx::robotstxt: |
   User-agent: deepcrawl
   Disallow: /
 
-sidekiq::host: 'redis-1.backend'
-sidekiq::port: '6379'
+sidekiq_host: 'redis-1.backend'
+sidekiq_port: '6379'
 
 ssh::config::allow_users_enable: true
 

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -111,12 +111,10 @@ govuk::apps::authenticating_proxy::mongodb_nodes: ['localhost']
 govuk::apps::authenticating_proxy::govuk_upstream_uri: 'http://government-frontend.dev.gov.uk'
 govuk::apps::backdrop_write::enable_procfile_worker: false
 govuk::apps::collections_publisher::enable_procfile_worker: false
-govuk::apps::collections_publisher::redis_host: 'localhost'
 govuk::apps::contacts::extra_aliases: ['contacts-frontend-old', 'contacts-admin']
 govuk::apps::content_store::mongodb_nodes: ['localhost']
 govuk::apps::content_store::mongodb_name: 'content_store_development'
 govuk::apps::dfid_transition::enable_procfile_worker: false
-govuk::apps::content_tagger::redis_host: 'localhost'
 govuk::apps::content_tagger::enable_procfile_worker: true
 govuk::apps::email_alert_api::enable_procfile_worker: false
 govuk::apps::email_campaign_api::mongodb_name: 'email_campaign_api_development'
@@ -132,7 +130,6 @@ govuk::apps::govuk_delivery::enable_procfile_worker: false
 govuk::apps::imminence::enable_procfile_worker: false
 govuk::apps::kibana::elasticsearch_host: 'localhost'
 govuk::apps::licencefinder::mongodb_nodes: ['localhost']
-govuk::apps::local_links_manager:redis_host: 'localhost'
 govuk::apps::multipage_frontend::enabled: true
 govuk::apps::need_api::mongodb_name: 'govuk_needs_development'
 govuk::apps::need_api::mongodb_nodes: ['localhost']
@@ -147,7 +144,6 @@ govuk::apps::publishing_api::content_store: 'http://content-store.dev.gov.uk'
 govuk::apps::publishing_api::draft_content_store: 'http://draft-content-store.dev.gov.uk'
 govuk::apps::publishing_api::enable_procfile_worker: false
 govuk::apps::publishing_api::rabbitmq::configure_test_exchange: true
-govuk::apps::publishing_api::redis_host: 'localhost'
 govuk::apps::publishing_api::suppress_draft_store_502_error: '1'
 govuk::apps::router::error_log: STDERR
 govuk::apps::router::enable_nginx_vhost: true
@@ -165,7 +161,6 @@ govuk::apps::share_sale_publisher::enabled: true
 govuk::apps::share_sale_publisher::mongodb_nodes: ['localhost']
 govuk::apps::share_sale_publisher::mongodb_name: 'share_sale_publisher_development'
 govuk::apps::signon::enable_procfile_worker: false
-govuk::apps::signon::redis_url: redis://localhost:6379/0
 govuk::apps::smartanswers::expose_govspeak: true
 govuk::apps::specialist_publisher::enable_procfile_worker: false
 govuk::apps::specialist_publisher::publish_pre_production_finders: true
@@ -173,8 +168,6 @@ govuk::apps::specialist_publisher_rebuild::enable_procfile_worker: false
 govuk::apps::specialist_publisher_rebuild::mongodb_name: 'specialist_publisher_rebuild_production'
 govuk::apps::specialist_publisher_rebuild::mongodb_nodes: ['localhost']
 govuk::apps::specialist_publisher_rebuild::publish_pre_production_finders: true
-govuk::apps::specialist_publisher_rebuild::redis_host: 'localhost'
-govuk::apps::specialist_publisher_rebuild_standalone::redis_host: 'localhost'
 govuk::apps::stagecraft::worker::enabled: true
 govuk::apps::stagecraft::beat::enabled: true
 govuk::apps::stagecraft::celerycam::enabled: true
@@ -183,7 +176,6 @@ govuk::apps::support_api::enable_procfile_worker: false
 govuk::apps::tariff_api::enable_procfile_worker: false
 govuk::apps::transition::enable_procfile_worker: false
 govuk::apps::travel_advice_publisher::enable_email_alerts: true
-govuk::apps::travel_advice_publisher::redis_host: 'localhost'
 govuk::apps::travel_advice_publisher::enable_procfile_worker: false
 govuk::apps::whitehall::configure_admin: true
 govuk::apps::whitehall::configure_frontend: true
@@ -354,6 +346,8 @@ puppet::use_puppetmaster: false
 puppet::cronjob::enabled: false
 
 shell::shell_prompt_string: 'dev'
+
+sidekiq::host: 'localhost'
 
 ssh::config::allow_x11_forwarding: true
 

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -120,6 +120,7 @@ govuk::apps::email_alert_api::enable_procfile_worker: false
 govuk::apps::email_campaign_api::mongodb_name: 'email_campaign_api_development'
 govuk::apps::email_campaign_api::mongodb_nodes: ['localhost']
 govuk::apps::email_campaign_api::enable_procfile_worker: false
+govuk::apps::email_campaign_api::redis_host: 'localhost'
 govuk::apps::email_alert_service::rabbitmq_hosts: ['localhost']
 govuk::apps::event_store::enabled: true
 govuk::apps::event_store::mongodb_servers: ['localhost']
@@ -128,6 +129,7 @@ govuk::apps::hmrc_manuals_api::enable_procfile_worker: false
 govuk::apps::govuk_cdn_logs_monitor::enabled: false
 govuk::apps::govuk_delivery::enable_procfile_worker: false
 govuk::apps::imminence::enable_procfile_worker: false
+govuk::apps::imminence::redis_host: 'localhost'
 govuk::apps::kibana::elasticsearch_host: 'localhost'
 govuk::apps::licencefinder::mongodb_nodes: ['localhost']
 govuk::apps::multipage_frontend::enabled: true
@@ -157,6 +159,7 @@ govuk::apps::rummager::enable_procfile_worker: true
 govuk::apps::rummager::rabbitmq_hosts: ['localhost']
 govuk::apps::rummager::enable_publishing_listener: true
 govuk::apps::rummager::rabbitmq::enable_publishing_listener: true
+govuk::apps::rummager::redis_host: 'localhost'
 govuk::apps::share_sale_publisher::enabled: true
 govuk::apps::share_sale_publisher::mongodb_nodes: ['localhost']
 govuk::apps::share_sale_publisher::mongodb_name: 'share_sale_publisher_development'

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -350,7 +350,7 @@ puppet::cronjob::enabled: false
 
 shell::shell_prompt_string: 'dev'
 
-sidekiq::host: 'localhost'
+sidekiq_host: 'localhost'
 
 ssh::config::allow_x11_forwarding: true
 

--- a/modules/govuk/manifests/app.pp
+++ b/modules/govuk/manifests/app.pp
@@ -239,6 +239,9 @@
 # [*ensure*]
 # allow govuk app to be removed.
 #
+# [*hasrestart*]
+# specify if the app init script has a restart command
+# Default: false
 #
 # [*depends_on_nfs*]
 # Start the application after mounted filesystems. Some applications
@@ -282,6 +285,7 @@ define govuk::app (
   $asset_pipeline = false,
   $asset_pipeline_prefix = 'assets',
   $ensure = 'present',
+  $hasrestart = false,
   $depends_on_nfs = false,
   $read_timeout = 15,
 ) {
@@ -356,8 +360,9 @@ define govuk::app (
   }
 
   govuk::app::service { $title:
-    ensure    => $ensure,
-    subscribe => Class['govuk::deploy'],
+    ensure     => $ensure,
+    hasrestart => $hasrestart,
+    subscribe  => Class['govuk::deploy'],
   }
 
   $logstream_ensure = $ensure ? {

--- a/modules/govuk/manifests/app/envvar/redis.pp
+++ b/modules/govuk/manifests/app/envvar/redis.pp
@@ -4,6 +4,9 @@
 #
 # === Parameters
 #
+# [*prefix*]
+#   An optional prefix for the env vars.
+#
 # [*host*]
 #   The Redis host.
 #   Default: "127.0.0.1"
@@ -13,23 +16,28 @@
 #   Default: 6379
 #
 define govuk::app::envvar::redis (
-  $host = '127.0.0.1',
-  $port = 6379,
+  $prefix = undef,
+  $host   = '127.0.0.1',
+  $port   = 6379,
 ) {
 
   Govuk::App::Envvar {
     app => $title,
   }
 
+  $host_key = join(delete_undef_values([$prefix, 'redis', 'host']), '_')
+  $port_key = join(delete_undef_values([$prefix, 'redis', 'port']), '_')
+  $url_key  = join(delete_undef_values([$prefix, 'redis', 'url']), '_')
+
   govuk::app::envvar {
-    "${title}-redis_host":
-      varname => 'REDIS_HOST',
+    "${title}-${host_key}":
+      varname => upcase($host_key),
       value   => $host;
-    "${title}-redis_port":
-      varname => 'REDIS_PORT',
+    "${title}-${port_key}":
+      varname => upcase($port_key),
       value   => $port;
-    "${title}-redis_url":
-      varname => 'REDIS_URL',
+    "${title}-${url_key}":
+      varname => upcase($url_key),
       value   => "redis://${host}:${port}";
   }
 }

--- a/modules/govuk/manifests/app/envvar/redis.pp
+++ b/modules/govuk/manifests/app/envvar/redis.pp
@@ -28,5 +28,8 @@ define govuk::app::envvar::redis (
     "${title}-redis_port":
       varname => 'REDIS_PORT',
       value   => $port;
+    "${title}-redis_url":
+      varname => 'REDIS_URL',
+      value   => "redis://${host}:${port}";
   }
 }

--- a/modules/govuk/manifests/app/envvar/redis.pp
+++ b/modules/govuk/manifests/app/envvar/redis.pp
@@ -1,0 +1,32 @@
+# == Define: govuk::app::envvar::redis
+#
+# Defines Redis env vars for an app.
+#
+# === Parameters
+#
+# [*host*]
+#   The Redis host.
+#   Default: "127.0.0.1"
+#
+# [*port*]
+#   The Redis port.
+#   Default: 6379
+#
+define govuk::app::envvar::redis (
+  $host = '127.0.0.1',
+  $port = 6379,
+) {
+
+  Govuk::App::Envvar {
+    app => $title,
+  }
+
+  govuk::app::envvar {
+    "${title}-redis_host":
+      varname => 'REDIS_HOST',
+      value   => $host;
+    "${title}-redis_port":
+      varname => 'REDIS_PORT',
+      value   => $port;
+  }
+}

--- a/modules/govuk/manifests/app/envvar/redis.pp
+++ b/modules/govuk/manifests/app/envvar/redis.pp
@@ -4,6 +4,9 @@
 #
 # === Parameters
 #
+# [*app*]
+#   An optional GOV.UK app that the env vars are for.
+#
 # [*prefix*]
 #   An optional prefix for the env vars.
 #
@@ -16,13 +19,14 @@
 #   Default: 6379
 #
 define govuk::app::envvar::redis (
+  $app    = undef,
   $prefix = undef,
   $host   = '127.0.0.1',
   $port   = 6379,
 ) {
 
   Govuk::App::Envvar {
-    app => $title,
+    app => pick($app, $title),
   }
 
   $host_key = join(delete_undef_values([$prefix, 'redis', 'host']), '_')

--- a/modules/govuk/manifests/app/service.pp
+++ b/modules/govuk/manifests/app/service.pp
@@ -1,6 +1,7 @@
 # FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
 define govuk::app::service (
   $ensure = 'present',
+  $hasrestart = false,
 ) {
 
   $enable_service = hiera('govuk_app_enable_services', true)
@@ -16,7 +17,8 @@ define govuk::app::service (
     }
   } else {
     service { $title:
-      provider => 'upstart',
+      provider   => 'upstart',
+      hasrestart => $hasrestart,
     }
     if $enable_service {
       Service[$title] {

--- a/modules/govuk/manifests/apps/collections_publisher.pp
+++ b/modules/govuk/manifests/apps/collections_publisher.pp
@@ -34,11 +34,12 @@
 #   Default: undef
 #
 # [*redis_host*]
-#   Redis host for sidekiq.
+#   Redis host for Sidekiq.
+#   Default: undef
 #
 # [*redis_port*]
-#   Redis port for sidekiq.
-#   Default: 6379
+#   Redis port for Sidekiq.
+#   Default: undef
 #
 class govuk::apps::collections_publisher(
   $panopticon_bearer_token = 'example',
@@ -49,7 +50,7 @@ class govuk::apps::collections_publisher(
   $oauth_secret = undef,
   $enable_procfile_worker = true,
   $publishing_api_bearer_token = undef,
-  $redis_host = 'redis-1.backend',
+  $redis_host = undef,
   $redis_port = undef,
 ) {
 

--- a/modules/govuk/manifests/apps/collections_publisher.pp
+++ b/modules/govuk/manifests/apps/collections_publisher.pp
@@ -50,7 +50,7 @@ class govuk::apps::collections_publisher(
   $enable_procfile_worker = true,
   $publishing_api_bearer_token = undef,
   $redis_host = 'redis-1.backend',
-  $redis_port = '6379',
+  $redis_port = undef,
 ) {
 
   govuk::app { 'collections-publisher':
@@ -65,6 +65,11 @@ class govuk::apps::collections_publisher(
 
   Govuk::App::Envvar {
     app =>  'collections-publisher',
+  }
+
+  govuk::app::envvar::redis { 'collections-publisher':
+    host => $redis_host,
+    port => $redis_port,
   }
 
   if $secret_key_base {
@@ -90,12 +95,6 @@ class govuk::apps::collections_publisher(
     "${title}-PUBLISHING_API_BEARER_TOKEN":
       varname => 'PUBLISHING_API_BEARER_TOKEN',
       value   => $publishing_api_bearer_token;
-    "${title}-REDIS_HOST":
-      varname => 'REDIS_HOST',
-      value   => $redis_host;
-    "${title}-REDIS_PORT":
-      varname => 'REDIS_PORT',
-      value   => $redis_port;
   }
 
   govuk::procfile::worker {'collections-publisher':

--- a/modules/govuk/manifests/apps/content_tagger.pp
+++ b/modules/govuk/manifests/apps/content_tagger.pp
@@ -78,6 +78,11 @@ class govuk::apps::content_tagger(
     app => $app_name,
   }
 
+  govuk::app::envvar::redis { $app_name:
+    host => $redis_host,
+    port => $redis_port,
+  }
+
   if $secret_key_base {
     govuk::app::envvar { "${title}-SECRET_KEY_BASE":
       varname => 'SECRET_KEY_BASE',
@@ -98,12 +103,6 @@ class govuk::apps::content_tagger(
     "${title}-PUBLISHING_API_BEARER_TOKEN":
       varname => 'PUBLISHING_API_BEARER_TOKEN',
       value   => $publishing_api_bearer_token;
-    "${title}-REDIS_HOST":
-      varname => 'REDIS_HOST',
-      value   => $redis_host;
-    "${title}-REDIS_PORT":
-      varname => 'REDIS_PORT',
-      value   => $redis_port;
   }
 
   if $::govuk_node_class != 'development' {

--- a/modules/govuk/manifests/apps/content_tagger.pp
+++ b/modules/govuk/manifests/apps/content_tagger.pp
@@ -37,11 +37,12 @@
 #   Default: undef
 #
 # [*redis_host*]
-#   Redis host for sidekiq.
+#   Redis host for Sidekiq.
+#   Default: undef
 #
 # [*redis_port*]
-#   Redis port for sidekiq.
-#   Default: 6379
+#   Redis port for Sidekiq.
+#   Default: undef
 #
 # [*enable_procfile_worker*]
 #   Whether to enable the procfile worker
@@ -58,8 +59,8 @@ class govuk::apps::content_tagger(
   $oauth_id = '',
   $oauth_secret = '',
   $publishing_api_bearer_token = undef,
-  $redis_host = 'redis-1.backend',
-  $redis_port = '6379',
+  $redis_host = undef,
+  $redis_port = undef,
   $enable_procfile_worker = true,
 ) {
   $app_name = 'content-tagger'

--- a/modules/govuk/manifests/apps/dfid_transition.pp
+++ b/modules/govuk/manifests/apps/dfid_transition.pp
@@ -29,11 +29,13 @@
 #   Default: undef
 #
 # [*redis_host*]
-#   Redis host for sidekiq and AttachmentIndex.
+#   Redis host for Sidekiq and AttachmentIndex.
+#   Default: undef
 #
 # [*redis_port*]
-#   Redis port for sidekiq and AttachmentIndex.
-#   Default: 6379
+#   Redis port for Sidekiq and AttachmentIndex.
+#   Default: undef
+#
 class govuk::apps::dfid_transition (
   $port = 3124,
   $enabled = false,

--- a/modules/govuk/manifests/apps/dfid_transition.pp
+++ b/modules/govuk/manifests/apps/dfid_transition.pp
@@ -54,6 +54,11 @@ class govuk::apps::dfid_transition (
       enable_service => $enable_procfile_worker,
     }
 
+    govuk::app::envvar::redis { $app_name:
+      host => $redis_host,
+      port => $redis_port,
+    }
+
     govuk::app::envvar {
       "${title}-ASSET_MANAGER_BEARER_TOKEN":
         varname => 'ASSET_MANAGER_BEARER_TOKEN',
@@ -61,12 +66,6 @@ class govuk::apps::dfid_transition (
       "${title}-PUBLISHING_API_BEARER_TOKEN":
         varname => 'PUBLISHING_API_BEARER_TOKEN',
         value   => $publishing_api_bearer_token;
-      "${title}-REDIS_HOST":
-        varname => 'REDIS_HOST',
-        value   => $redis_host;
-      "${title}-REDIS_PORT":
-        varname => 'REDIS_PORT',
-        value   => $redis_port;
     }
 
     govuk::app { $app_name:

--- a/modules/govuk/manifests/apps/email_alert_api.pp
+++ b/modules/govuk/manifests/apps/email_alert_api.pp
@@ -16,6 +16,14 @@
 #   Should the Foreman-based background worker be enabled by default. Set in
 #   hiera.
 #
+# [*redis_host*]
+#   Redis host for Sidekiq.
+#   Default: undef
+#
+# [*redis_port*]
+#   Redis port for Sidekiq.
+#   Default: undef
+#
 class govuk::apps::email_alert_api(
   $port = '3088',
   $enabled = false,
@@ -26,6 +34,8 @@ class govuk::apps::email_alert_api(
   $sidekiq_queue_size_warning = '2',
   $sidekiq_queue_latency_critical = '60',
   $sidekiq_queue_latency_warning = '30',
+  $redis_host = undef,
+  $redis_port = undef,
 ) {
 
   if $enabled {
@@ -57,6 +67,11 @@ class govuk::apps::email_alert_api(
 
     Govuk::App::Envvar {
       app => 'email-alert-api',
+    }
+
+    govuk::app::envvar::redis { 'email-alert-api':
+      host => $redis_host,
+      port => $redis_port,
     }
 
     govuk::app::envvar { "${title}-SIDEKIQ_RETRY_CRITICAL_THRESHOLD":

--- a/modules/govuk/manifests/apps/email_campaign_api.pp
+++ b/modules/govuk/manifests/apps/email_campaign_api.pp
@@ -35,7 +35,7 @@ class govuk::apps::email_campaign_api(
   $gov_delivery_username = undef,
   $gov_delivery_password = undef,
   $redis_host='api-redis-1.api',
-  $redis_port='6379',
+  $redis_port= undef,
   $mongodb_nodes,
   $mongodb_name = 'email_campaign_api',
 ) {
@@ -68,6 +68,11 @@ class govuk::apps::email_campaign_api(
       json    => true,
     }
 
+    govuk::app::envvar::redis { $app_name:
+      host => $redis_host,
+      port => $redis_port,
+    }
+
     govuk::app::envvar {
       "${title}-ERRBIT_API_KEY":
           varname => 'ERRBIT_API_KEY',
@@ -87,12 +92,6 @@ class govuk::apps::email_campaign_api(
       "${title}-GOV_DELIVERY_PASSWORD":
           varname => 'GOV_DELIVERY_PASSWORD',
           value   => $gov_delivery_password;
-      "${title}-REDIS_HOST":
-          varname => 'REDIS_HOST',
-          value   => $redis_host;
-      "${title}-REDIS_PORT":
-          varname => 'REDIS_PORT',
-          value   => $redis_port;
     }
   }
 }

--- a/modules/govuk/manifests/apps/imminence.pp
+++ b/modules/govuk/manifests/apps/imminence.pp
@@ -20,6 +20,14 @@
 # [*mongodb_name*]
 #   The name of the MongoDB database to use
 #
+# [*redis_host*]
+#   Redis host for Sidekiq.
+#   Default: undef
+#
+# [*redis_port*]
+#   Redis port for Sidekiq.
+#   Default: undef
+#
 # [*secret_key_base*]
 #   The key for Rails to use when signing/encrypting sessions.
 #
@@ -34,9 +42,12 @@ class govuk::apps::imminence(
   $enable_procfile_worker = true,
   $mongodb_nodes = undef,
   $mongodb_name = 'imminence_production',
+  $redis_host = undef,
+  $redis_port = undef,
   $secret_key_base = undef,
   $nagios_memory_warning = undef,
   $nagios_memory_critical = undef,
+
 ) {
 
   $app_name = 'imminence'
@@ -54,6 +65,11 @@ class govuk::apps::imminence(
     asset_pipeline         => true,
     nagios_memory_warning  => $nagios_memory_warning,
     nagios_memory_critical => $nagios_memory_critical,
+  }
+
+  govuk::app::envvar::redis { $app_name:
+    host => $redis_host,
+    port => $redis_port,
   }
 
   if $secret_key_base {

--- a/modules/govuk/manifests/apps/local_links_manager.pp
+++ b/modules/govuk/manifests/apps/local_links_manager.pp
@@ -67,7 +67,7 @@ class govuk::apps::local_links_manager(
   $db_password = undef,
   $db_name = 'local-links-manager_production',
   $redis_host = undef,
-  $redis_port = '6379',
+  $redis_port = undef,
   $local_links_manager_passive_checks = false,
 ) {
   $app_name = 'local-links-manager'
@@ -84,6 +84,11 @@ class govuk::apps::local_links_manager(
       app    => $app_name,
     }
 
+    govuk::app::envvar::redis { $app_name:
+      host => $redis_host,
+      port => $redis_port,
+    }
+
     govuk::app::envvar {
       "${title}-ERRBIT_API_KEY":
         varname => 'ERRBIT_API_KEY',
@@ -97,12 +102,6 @@ class govuk::apps::local_links_manager(
       "${title}-OAUTH_SECRET":
         varname => 'OAUTH_SECRET',
         value   => $oauth_secret;
-      "${title}-REDIS_HOST":
-        varname => 'REDIS_HOST',
-        value   => $redis_host;
-      "${title}-REDIS_PORT":
-        varname => 'REDIS_PORT',
-        value   => $redis_port;
     }
 
     if $local_links_manager_passive_checks {

--- a/modules/govuk/manifests/apps/local_links_manager.pp
+++ b/modules/govuk/manifests/apps/local_links_manager.pp
@@ -44,12 +44,12 @@
 #   Default: undef
 #
 # [*redis_host*]
-#   Sets the host environment variable for a Redis connection
+#   Redis host for Sidekiq.
 #   Default: undef
 #
 # [*redis_port*]
-#   Sets the port number environment variable for a Redis connection
-#   Default: 6379
+#   Redis port for Sidekiq.
+#   Default: undef
 #
 # [*local_links_manager_passive_checks*]
 #   Enables the passive checks in Icinga for the local links manager cron jobs

--- a/modules/govuk/manifests/apps/publisher.pp
+++ b/modules/govuk/manifests/apps/publisher.pp
@@ -25,6 +25,14 @@
 # [*mongodb_nodes*]
 #   Array of hostnames for the mongo cluster to use.
 #
+# [*redis_host*]
+#   Redis host for Sidekiq.
+#   Default: undef
+#
+# [*redis_port*]
+#   Redis port for Sidekiq.
+#   Default: undef
+#
 class govuk::apps::publisher(
     $port = '3000',
     $enable_procfile_worker = true,
@@ -32,7 +40,7 @@ class govuk::apps::publisher(
     $secret_key_base = undef,
     $mongodb_name = undef,
     $mongodb_nodes = undef,
-    $redis_host = 'redis-1.backend',
+    $redis_host = undef,
     $redis_port = undef,
   ) {
 

--- a/modules/govuk/manifests/apps/publisher.pp
+++ b/modules/govuk/manifests/apps/publisher.pp
@@ -33,7 +33,7 @@ class govuk::apps::publisher(
     $mongodb_name = undef,
     $mongodb_nodes = undef,
     $redis_host = 'redis-1.backend',
-    $redis_port = '6379',
+    $redis_port = undef,
   ) {
 
   govuk::app { 'publisher':
@@ -83,6 +83,11 @@ class govuk::apps::publisher(
     }
   }
 
+  govuk::app::envvar::redis { 'publisher':
+    host => $redis_host,
+    port => $redis_port,
+  }
+
   govuk::app::envvar {
     "${title}-PUBLISHING_API_BEARER_TOKEN":
       app     => 'publisher',
@@ -92,13 +97,5 @@ class govuk::apps::publisher(
       app     => 'publisher',
       varname => 'SECRET_KEY_BASE',
       value   => $secret_key_base;
-    "${title}-REDIS_HOST":
-      app     => 'publisher',
-      varname => 'REDIS_HOST',
-      value   => $redis_host;
-    "${title}-REDIS_PORT":
-      app     => 'publisher',
-      varname => 'REDIS_PORT',
-      value   => $redis_port;
   }
 }

--- a/modules/govuk/manifests/apps/publishing_api.pp
+++ b/modules/govuk/manifests/apps/publishing_api.pp
@@ -72,7 +72,7 @@ class govuk::apps::publishing_api(
   $db_password = undef,
   $db_name = 'publishing_api_production',
   $redis_host = undef,
-  $redis_port = '6379',
+  $redis_port = undef,
   $enable_procfile_worker = true,
   $oauth_id = undef,
   $oauth_secret = undef,
@@ -96,6 +96,11 @@ class govuk::apps::publishing_api(
     app => $app_name,
   }
 
+  govuk::app::envvar::redis { $app_name:
+    host => $redis_host,
+    port => $redis_port,
+  }
+
   govuk::app::envvar {
     "${title}-CONTENT_STORE":
       varname => 'CONTENT_STORE',
@@ -109,12 +114,6 @@ class govuk::apps::publishing_api(
     "${title}-ERRBIT_API_KEY":
       varname => 'ERRBIT_API_KEY',
       value   => $errbit_api_key;
-    "${title}-REDIS_HOST":
-      varname => 'REDIS_HOST',
-      value   => $redis_host;
-    "${title}-REDIS_PORT":
-      varname => 'REDIS_PORT',
-      value   => $redis_port;
     "${title}-OAUTH_ID":
       varname => 'OAUTH_ID',
       value   => $oauth_id;

--- a/modules/govuk/manifests/apps/publishing_api.pp
+++ b/modules/govuk/manifests/apps/publishing_api.pp
@@ -44,11 +44,12 @@
 #   The database name to use in the DATABASE_URL.
 #
 # [*redis_host*]
-#   Redis host for sidekiq.
+#   Redis host for Sidekiq.
+#   Default: undef
 #
 # [*redis_port*]
-#   Redis port for sidekiq.
-#   Default: 6379
+#   Redis port for Sidekiq.
+#   Default: undef
 #
 # [*enable_procfile_worker*]
 #   Enables the sidekiq background worker.

--- a/modules/govuk/manifests/apps/rummager.pp
+++ b/modules/govuk/manifests/apps/rummager.pp
@@ -45,6 +45,14 @@
 #   RabbitMQ password.
 #   Default: rummager
 #
+# [*redis_host*]
+#   Redis host for Sidekiq.
+#   Default: undef
+#
+# [*redis_port*]
+#   Redis port for Sidekiq.
+#   Default: undef
+#
 # [*nagios_memory_warning*]
 #   Memory use at which Nagios should generate a warning.
 #
@@ -63,6 +71,8 @@ class govuk::apps::rummager(
   $rabbitmq_hosts = ['localhost'],
   $rabbitmq_user = 'rummager',
   $rabbitmq_password = 'rummager',
+  $redis_host = undef,
+  $redis_port = undef,
   $nagios_memory_warning = undef,
   $nagios_memory_critical = undef,
 ) {
@@ -98,6 +108,11 @@ class govuk::apps::rummager(
     hosts    => $rabbitmq_hosts,
     user     => $rabbitmq_user,
     password => $rabbitmq_password,
+  }
+
+  govuk::app::envvar::redis { 'rummager':
+    host => $redis_host,
+    port => $redis_port,
   }
 
   govuk::procfile::worker { 'rummager':

--- a/modules/govuk/manifests/apps/sidekiq_monitoring.pp
+++ b/modules/govuk/manifests/apps/sidekiq_monitoring.pp
@@ -128,6 +128,7 @@ class govuk::apps::sidekiq_monitoring (
     app_type           => 'bare',
     command            => 'bundle exec foreman start',
     enable_nginx_vhost => false,
+    hasrestart         => true,
   }
 
   govuk::app::envvar::redis {

--- a/modules/govuk/manifests/apps/sidekiq_monitoring.pp
+++ b/modules/govuk/manifests/apps/sidekiq_monitoring.pp
@@ -1,13 +1,190 @@
-# FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
-class govuk::apps::sidekiq_monitoring () {
+# == Class: govuk::apps::sidekiq_monitoring
+#
+# App to monitor Sidekiq for multiple GOV.UK apps.
+#
+# === Parameters
+#
+# [*dfid_transition_redis_host*]
+#   Redis host for DFID Transition Sidekiq.
+#   Default: undef
+#
+# [*dfid_transition_redis_port*]
+#   Redis port for DFID Transition Sidekiq.
+#   Default: undef
+#
+# [*email_alert_api_redis_host*]
+#   Redis host for Email Alert API Sidekiq.
+#   Default: undef
+#
+# [*email_alert_api_redis_port*]
+#   Redis port for Email Alert API Sidekiq.
+#   Default: undef
+#
+# [*email_campaign_api_redis_host*]
+#   Redis host for Email Campaign API Sidekiq.
+#   Default: undef
+#
+# [*email_campaign_api_redis_port*]
+#   Redis port for Email Campaign API Sidekiq.
+#   Default: undef
+#
+# [*imminence_redis_host*]
+#   Redis host for Imminence Sidekiq.
+#   Default: undef
+#
+# [*imminence_redis_port*]
+#   Redis port for Imminence Sidekiq.
+#   Default: undef
+#
+# [*publisher_redis_host*]
+#   Redis host for Publisher Sidekiq.
+#   Default: undef
+#
+# [*publisher_redis_port*]
+#   Redis port for Publisher Sidekiq.
+#   Default: undef
+#
+# [*publishing_api_redis_host*]
+#   Redis host for Publishing API Sidekiq.
+#   Default: undef
+#
+# [*publishing_api_redis_port*]
+#   Redis port for Publishing API Sidekiq.
+#   Default: undef
+#
+# [*rummager_redis_host*]
+#   Redis host for Rummager Sidekiq.
+#   Default: undef
+#
+# [*rummager_redis_port*]
+#   Redis port for Rummager Sidekiq.
+#   Default: undef
+#
+# [*signon_redis_host*]
+#   Redis host for Signon Sidekiq.
+#   Default: undef
+#
+# [*signon_redis_port*]
+#   Redis port for Signon Sidekiq.
+#   Default: undef
+#
+# [*travel_advice_publisher_redis_host*]
+#   Redis host for Travel Advice Publisher Sidekiq.
+#   Default: undef
+#
+# [*travel_advice_publisher_redis_port*]
+#   Redis port for Travel Advice Publisher Sidekiq.
+#   Default: undef
+#
+# [*transition_redis_host*]
+#   Redis host for Transition Sidekiq.
+#   Default: undef
+#
+# [*transition_redis_port*]
+#   Redis port for Transition Sidekiq.
+#   Default: undef
+#
+# [*whitehall_redis_host*]
+#   Redis host for Whitehall Sidekiq.
+#   Default: undef
+#
+# [*whitehall_redis_port*]
+#   Redis port for Whitehall Sidekiq.
+#   Default: undef
+#
+class govuk::apps::sidekiq_monitoring (
+  $dfid_transition_redis_host = undef,
+  $dfid_transition_redis_port = undef,
+  $email_alert_api_redis_host = undef,
+  $email_alert_api_redis_port = undef,
+  $email_campaign_api_redis_host = undef,
+  $email_campaign_api_redis_port = undef,
+  $imminence_redis_host = undef,
+  $imminence_redis_port = undef,
+  $publisher_redis_host = undef,
+  $publisher_redis_port = undef,
+  $publishing_api_redis_host = undef,
+  $publishing_api_redis_port = undef,
+  $rummager_redis_host = undef,
+  $rummager_redis_port = undef,
+  $signon_redis_host = undef,
+  $signon_redis_port = undef,
+  $travel_advice_publisher_redis_host = undef,
+  $travel_advice_publisher_redis_port = undef,
+  $transition_redis_host = undef,
+  $transition_redis_port = undef,
+  $whitehall_redis_host = undef,
+  $whitehall_redis_port = undef,
+) {
   $app_name = 'sidekiq-monitoring'
   $app_domain = hiera('app_domain')
   $full_domain = "${app_name}.${app_domain}"
+
+  Govuk::App::Envvar::Redis {
+    app => $app_name,
+  }
 
   govuk::app { $app_name:
     app_type           => 'bare',
     command            => 'bundle exec foreman start',
     enable_nginx_vhost => false,
+  }
+
+  govuk::app::envvar::redis {
+    "${app_name}_dfid_transition":
+      prefix => 'dfid_transition',
+      host   => $dfid_transition_redis_host,
+      port   => $dfid_transition_redis_port;
+
+    "${app_name}_email_alert_api":
+      prefix => 'email_alert_api',
+      host   => $email_alert_api_redis_host,
+      port   => $email_alert_api_redis_port;
+
+    "${app_name}_email_campaign_api":
+      prefix => 'email_campaign_api',
+      host   => $email_campaign_api_redis_host,
+      port   => $email_campaign_api_redis_port;
+
+    "${app_name}_imminence":
+      prefix => 'imminence',
+      host   => $imminence_redis_host,
+      port   => $imminence_redis_port;
+
+    "${app_name}_publisher":
+      prefix => 'publisher',
+      host   => $publisher_redis_host,
+      port   => $publisher_redis_port;
+
+    "${app_name}_publishing_api":
+      prefix => 'publishing_api',
+      host   => $publishing_api_redis_host,
+      port   => $publishing_api_redis_port;
+
+    "${app_name}_rummager":
+      prefix => 'rummager',
+      host   => $rummager_redis_host,
+      port   => $rummager_redis_port;
+
+    "${app_name}_signon":
+      prefix => 'signon',
+      host   => $signon_redis_host,
+      port   => $signon_redis_port;
+
+    "${app_name}_transition":
+      prefix => 'transition',
+      host   => $transition_redis_host,
+      port   => $transition_redis_port;
+
+    "${app_name}_travel_advice_publisher":
+      prefix => 'travel_advice_publisher',
+      host   => $travel_advice_publisher_redis_host,
+      port   => $travel_advice_publisher_redis_port;
+
+    "${app_name}_whitehall":
+      prefix => 'whitehall',
+      host   => $whitehall_redis_host,
+      port   => $whitehall_redis_port;
   }
 
   nginx::config::site { $full_domain:

--- a/modules/govuk/manifests/apps/signon.pp
+++ b/modules/govuk/manifests/apps/signon.pp
@@ -24,14 +24,22 @@
 # [*nagios_memory_critical*]
 #   Memory use at which Nagios should generate a critical alert.
 #
+# [*redis_host*]
+#   Redis host for Sidekiq.
+#   Default: undef
+#
+# [*redis_port*]
+#   Redis port for Sidekiq.
+#   Default: undef
+#
 class govuk::apps::signon(
   $port = '3016',
   $enable_procfile_worker = true,
   $devise_secret_key = undef,
-  $redis_host = 'redis-1.backend',
-  $redis_port = undef,
   $nagios_memory_warning = undef,
   $nagios_memory_critical = undef,
+  $redis_host = undef,
+  $redis_port = undef,
 ) {
   $app_name = 'signon'
 

--- a/modules/govuk/manifests/apps/signon.pp
+++ b/modules/govuk/manifests/apps/signon.pp
@@ -28,9 +28,8 @@ class govuk::apps::signon(
   $port = '3016',
   $enable_procfile_worker = true,
   $devise_secret_key = undef,
-  $redis_url = undef,
   $redis_host = 'redis-1.backend',
-  $redis_port = '6379',
+  $redis_port = undef,
   $nagios_memory_warning = undef,
   $nagios_memory_critical = undef,
 ) {
@@ -64,20 +63,9 @@ class govuk::apps::signon(
     }
   }
 
-  if $redis_url != undef {
-    govuk::app::envvar {
-      "${title}-REDIS_URL":
-        varname => 'REDIS_URL',
-        value   => $redis_url;
-      "${title}-REDIS_HOST":
-        app     => $app_name,
-        varname => 'REDIS_HOST',
-        value   => $redis_host;
-      "${title}-REDIS_PORT":
-        app     => $app_name,
-        varname => 'REDIS_PORT',
-        value   => $redis_port;
-    }
+  govuk::app::envvar::redis { $app_name:
+    host => $redis_host,
+    port => $redis_port,
   }
 
   include govuk_postgresql::client #installs libpq-dev package needed for pg gem

--- a/modules/govuk/manifests/apps/specialist_publisher_rebuild.pp
+++ b/modules/govuk/manifests/apps/specialist_publisher_rebuild.pp
@@ -85,7 +85,7 @@ class govuk::apps::specialist_publisher_rebuild(
   $publish_pre_production_finders = false,
   $publishing_api_bearer_token = undef,
   $redis_host = undef,
-  $redis_port = '6379',
+  $redis_port = undef,
   $enable_procfile_worker = true,
   $secret_token = undef,
 ) {
@@ -121,6 +121,11 @@ class govuk::apps::specialist_publisher_rebuild(
       database => $mongodb_name,
     }
 
+    govuk::app::envvar::redis { $app_name:
+      host => $redis_host,
+      port => $redis_port,
+    }
+
     govuk::app::envvar {
       "${title}-ASSET_MANAGER_BEARER_TOKEN":
         varname => 'ASSET_MANAGER_BEARER_TOKEN',
@@ -140,12 +145,6 @@ class govuk::apps::specialist_publisher_rebuild(
       "${title}-PUBLISHING_API_BEARER_TOKEN":
         varname => 'PUBLISHING_API_BEARER_TOKEN',
         value   => $publishing_api_bearer_token;
-      "${title}-REDIS_HOST":
-        varname => 'REDIS_HOST',
-        value   => $redis_host;
-      "${title}-REDIS_PORT":
-        varname => 'REDIS_PORT',
-        value   => $redis_port;
     }
 
     if $publish_pre_production_finders {

--- a/modules/govuk/manifests/apps/specialist_publisher_rebuild_standalone.pp
+++ b/modules/govuk/manifests/apps/specialist_publisher_rebuild_standalone.pp
@@ -85,7 +85,7 @@ class govuk::apps::specialist_publisher_rebuild_standalone(
   $publish_pre_production_finders = false,
   $publishing_api_bearer_token = undef,
   $redis_host = undef,
-  $redis_port = '6379',
+  $redis_port = undef,
   $enable_procfile_worker = true,
   $secret_token = undef,
 ) {
@@ -119,6 +119,11 @@ class govuk::apps::specialist_publisher_rebuild_standalone(
       database => $mongodb_name,
     }
 
+    govuk::app::envvar::redis { $app_name:
+      host => $redis_host,
+      port => $redis_port,
+    }
+
     govuk::app::envvar {
       "${title}-ASSET_MANAGER_BEARER_TOKEN":
         varname => 'ASSET_MANAGER_BEARER_TOKEN',
@@ -138,12 +143,6 @@ class govuk::apps::specialist_publisher_rebuild_standalone(
       "${title}-PUBLISHING_API_BEARER_TOKEN":
         varname => 'PUBLISHING_API_BEARER_TOKEN',
         value   => $publishing_api_bearer_token;
-      "${title}-REDIS_HOST":
-        varname => 'REDIS_HOST',
-        value   => $redis_host;
-      "${title}-REDIS_PORT":
-        varname => 'REDIS_PORT',
-        value   => $redis_port;
     }
 
     if $publish_pre_production_finders {

--- a/modules/govuk/manifests/apps/transition.pp
+++ b/modules/govuk/manifests/apps/transition.pp
@@ -18,6 +18,14 @@
 # [*oauth_secret*]
 #   The Signon OAuth secret for this app
 #
+# [*redis_host*]
+#   Redis host for Sidekiq.
+#   Default: undef
+#
+# [*redis_port*]
+#   Redis port for Sidekiq.
+#   Default: undef
+#
 # [*secret_key_base*]
 #   The key for Rails to use when signing/encrypting sessions.
 #
@@ -26,6 +34,8 @@ class govuk::apps::transition(
   $enable_procfile_worker = true,
   $oauth_id = undef,
   $oauth_secret = undef,
+  $redis_host = undef,
+  $redis_port = undef,
   $secret_key_base = undef
 ) {
   $app_name = 'transition'
@@ -47,6 +57,11 @@ class govuk::apps::transition(
 
   Govuk::App::Envvar {
     app => $app_name,
+  }
+
+  govuk::app::envvar::redis { $app_name:
+    host => $redis_host,
+    port => $redis_port,
   }
 
   if $secret_key_base {

--- a/modules/govuk/manifests/apps/travel_advice_publisher.pp
+++ b/modules/govuk/manifests/apps/travel_advice_publisher.pp
@@ -26,11 +26,12 @@
 #   Default: undef
 #
 # [*redis_host*]
-#   Redis host for sidekiq.
+#   Redis host for Sidekiq.
+#   Default: undef
 #
 # [*redis_port*]
-#   Redis port for sidekiq.
-#   Default: 6379
+#   Redis port for Sidekiq.
+#   Default: undef
 #
 # [*enable_procfile_worker*]
 #   Enables the sidekiq background worker.

--- a/modules/govuk/manifests/apps/travel_advice_publisher.pp
+++ b/modules/govuk/manifests/apps/travel_advice_publisher.pp
@@ -44,7 +44,7 @@ class govuk::apps::travel_advice_publisher(
   $secret_key_base = undef,
   $publishing_api_bearer_token = undef,
   $redis_host = undef,
-  $redis_port = '6379',
+  $redis_port = undef,
   $enable_procfile_worker = true,
 ) {
   $app_name = 'travel-advice-publisher'
@@ -70,6 +70,11 @@ class govuk::apps::travel_advice_publisher(
     }
   }
 
+  govuk::app::envvar::redis { $app_name:
+    host => $redis_host,
+    port => $redis_port,
+  }
+
   govuk::app::envvar {
     "${title}-PUBLISHING_API_BEARER_TOKEN":
       varname => 'PUBLISHING_API_BEARER_TOKEN',
@@ -77,12 +82,6 @@ class govuk::apps::travel_advice_publisher(
     "${title}-SECRET_KEY_BASE":
       varname => 'SECRET_KEY_BASE',
       value   => $secret_key_base;
-    "${title}-REDIS_HOST":
-      varname => 'REDIS_HOST',
-      value   => $redis_host;
-    "${title}-REDIS_PORT":
-      varname => 'REDIS_PORT',
-      value   => $redis_port;
   }
 
   validate_bool($enable_email_alerts)

--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -16,6 +16,14 @@
 # [*nagios_memory_critical*]
 #   Memory use at which Nagios should generate a critical alert.
 #
+# [*redis_host*]
+#   Redis host for Sidekiq.
+#   Default: undef
+#
+# [*redis_port*]
+#   Redis port for Sidekiq.
+#   Default: undef
+#
 class govuk::apps::whitehall(
   $vhost = 'whitehall',
   $port = '3020',
@@ -27,7 +35,7 @@ class govuk::apps::whitehall(
   $prevent_single_host = true,
   $enable_procfile_worker = true,
   $publishing_api_bearer_token = undef,
-  $redis_host = 'redis-1.backend',
+  $redis_host = undef,
   $redis_port = undef,
 ) {
 

--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -28,7 +28,7 @@ class govuk::apps::whitehall(
   $enable_procfile_worker = true,
   $publishing_api_bearer_token = undef,
   $redis_host = 'redis-1.backend',
-  $redis_port = '6379',
+  $redis_port = undef,
 ) {
 
   $app_domain = hiera('app_domain')
@@ -203,18 +203,15 @@ class govuk::apps::whitehall(
     }
   }
 
+  govuk::app::envvar::redis { 'whitehall':
+    host => $redis_host,
+    port => $redis_port,
+  }
+
   govuk::app::envvar {
     "${title}-PUBLISHING_API_BEARER_TOKEN":
       app     => 'whitehall',
       varname => 'PUBLISHING_API_BEARER_TOKEN',
       value   => $publishing_api_bearer_token;
-    "${title}-REDIS_HOST":
-      app     => 'whitehall',
-      varname => 'REDIS_HOST',
-      value   => $redis_host;
-    "${title}-REDIS_PORT":
-      app     => 'whitehall',
-      varname => 'REDIS_PORT',
-      value   => $redis_port;
   }
 }

--- a/modules/govuk/spec/defines/govuk__app__envvar__redis_spec.rb
+++ b/modules/govuk/spec/defines/govuk__app__envvar__redis_spec.rb
@@ -1,0 +1,43 @@
+require_relative '../../../../spec_helper'
+
+describe 'govuk::app::envvar::redis', :type => :define do
+  let(:title) { 'giraffe' }
+
+  context 'with empty parameters' do
+    let(:params) { {} }
+
+    it 'sets the Redis host to 127.0.0.1 by default' do
+      is_expected.to contain_govuk__app__envvar("#{title}-redis_host")
+                       .with_app(title)
+                       .with_varname('REDIS_HOST')
+                       .with_value('127.0.0.1')
+    end
+
+    it 'sets the Redis port to 6379 by default' do
+      is_expected.to contain_govuk__app__envvar("#{title}-redis_port")
+                       .with_app(title)
+                       .with_varname('REDIS_PORT')
+                       .with_value('6379')
+    end
+  end
+
+  context 'with some good parameters' do
+    let(:host) { 'redis.backend' }
+    let(:port) { 1234 }
+    let(:params) { { host: host, port: port } }
+
+    it 'sets the Redis host' do
+      is_expected.to contain_govuk__app__envvar("#{title}-redis_host")
+                       .with_app(title)
+                       .with_varname('REDIS_HOST')
+                       .with_value(host)
+    end
+
+    it 'sets the Redis port' do
+      is_expected.to contain_govuk__app__envvar("#{title}-redis_port")
+                       .with_app(title)
+                       .with_varname('REDIS_PORT')
+                       .with_value(port)
+    end
+  end
+end

--- a/modules/govuk/spec/defines/govuk__app__envvar__redis_spec.rb
+++ b/modules/govuk/spec/defines/govuk__app__envvar__redis_spec.rb
@@ -54,4 +54,26 @@ describe 'govuk::app::envvar::redis', :type => :define do
                        .with_value('redis://redis.backend:1234')
     end
   end
+
+  context 'white a prefix' do
+    let(:params) { { prefix: 'zoo' } }
+
+    it 'adds a prefix to the host variable' do
+      is_expected.to contain_govuk__app__envvar("#{title}-zoo_redis_host")
+                       .with_app(title)
+                       .with_varname('ZOO_REDIS_HOST')
+    end
+
+    it 'adds a prefix to the port variable' do
+      is_expected.to contain_govuk__app__envvar("#{title}-zoo_redis_port")
+                       .with_app(title)
+                       .with_varname('ZOO_REDIS_PORT')
+    end
+
+    it 'adds a prefix to the url variable' do
+      is_expected.to contain_govuk__app__envvar("#{title}-zoo_redis_url")
+                       .with_app(title)
+                       .with_varname('ZOO_REDIS_URL')
+    end
+  end
 end

--- a/modules/govuk/spec/defines/govuk__app__envvar__redis_spec.rb
+++ b/modules/govuk/spec/defines/govuk__app__envvar__redis_spec.rb
@@ -55,6 +55,26 @@ describe 'govuk::app::envvar::redis', :type => :define do
     end
   end
 
+  context 'with a specific app' do
+    let(:app) { 'enclosure' }
+    let(:params) { { app: app } }
+
+    it 'uses that app when setting the host variable' do
+      is_expected.to contain_govuk__app__envvar("#{title}-redis_host")
+                       .with_app(app)
+    end
+
+    it 'uses that app when setting the port variable' do
+      is_expected.to contain_govuk__app__envvar("#{title}-redis_port")
+                       .with_app(app)
+    end
+
+    it 'uses that app when setting the url variable' do
+      is_expected.to contain_govuk__app__envvar("#{title}-redis_url")
+                       .with_app(app)
+    end
+  end
+
   context 'white a prefix' do
     let(:params) { { prefix: 'zoo' } }
 

--- a/modules/govuk/spec/defines/govuk__app__envvar__redis_spec.rb
+++ b/modules/govuk/spec/defines/govuk__app__envvar__redis_spec.rb
@@ -19,6 +19,13 @@ describe 'govuk::app::envvar::redis', :type => :define do
                        .with_varname('REDIS_PORT')
                        .with_value('6379')
     end
+
+    it 'sets a Redis URL with the default values' do
+      is_expected.to contain_govuk__app__envvar("#{title}-redis_url")
+                       .with_app(title)
+                       .with_varname('REDIS_URL')
+                       .with_value('redis://127.0.0.1:6379')
+    end
   end
 
   context 'with some good parameters' do
@@ -38,6 +45,13 @@ describe 'govuk::app::envvar::redis', :type => :define do
                        .with_app(title)
                        .with_varname('REDIS_PORT')
                        .with_value(port)
+    end
+
+    it 'sets a Redis URL' do
+      is_expected.to contain_govuk__app__envvar("#{title}-redis_url")
+                       .with_app(title)
+                       .with_varname('REDIS_URL')
+                       .with_value('redis://redis.backend:1234')
     end
   end
 end


### PR DESCRIPTION
Ensures that the Redis config for all applications that use Sidekiq is stored in the environment.

The configuration is then made available to the Sidekiq monitoring application so that we can ensure the monitoring tools point to the same Redis configuration as the application.

Ticket: https://trello.com/c/Qa02qGyb/460-fix-sidekiq-monitoring-medium