### PR TITLE
Add wildcards to make the Graphite queries work in all environments

### DIFF
--- a/modules/grafana/templates/dashboards/application_health.json.erb
+++ b/modules/grafana/templates/dashboards/application_health.json.erb
@@ -83,11 +83,11 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "alias(scale(averageSeries(stats.timers.backend-?_backend.nginx_logs.contentapi_*.time_request.mean),1000),\"nginx\")",
+              "target": "alias(scale(averageSeries(stats.timers.backend-?_backend*.nginx_logs.contentapi_*.time_request.mean),1000),\"nginx\")",
               "refId": "A"
             },
             {
-              "target": "groupByNode(stats.timers.backend-?_backend.contentapi.time_*.mean,4,\"avg\")",
+              "target": "groupByNode(stats.timers.backend-?_backend*.contentapi.time_*.mean,4,\"avg\")",
               "refId": "B"
             }
           ],
@@ -187,11 +187,11 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "alias(scale(averageSeries(stats.timers.calculators-frontend-?_frontend.nginx_logs.smartanswers_*.time_request.mean),1000),\"nginx\")",
+              "target": "alias(scale(averageSeries(stats.timers.calculators-frontend-?_frontend*.nginx_logs.smartanswers_*.time_request.mean),1000),\"nginx\")",
               "refId": "A"
             },
             {
-              "target": "groupByNode(stats.timers.calculators-frontend-?_frontend.smartanswers.time_*.mean,4,\"avg\")",
+              "target": "groupByNode(stats.timers.calculators-frontend-?_frontend*.smartanswers.time_*.mean,4,\"avg\")",
               "refId": "B"
             }
           ],
@@ -291,11 +291,11 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "alias(scale(averageSeries(stats.timers.frontend-?_frontend.nginx_logs.frontend_*.time_request.mean),1000),\"nginx\")",
+              "target": "alias(scale(averageSeries(stats.timers.frontend-?_frontend*.nginx_logs.frontend_*.time_request.mean),1000),\"nginx\")",
               "refId": "A"
             },
             {
-              "target": "groupByNode(stats.timers.frontend-?_frontend.frontend.time_*.mean,4,\"avg\")",
+              "target": "groupByNode(stats.timers.frontend-?_frontend.frontend*.time_*.mean,4,\"avg\")",
               "refId": "B"
             }
           ],
@@ -509,7 +509,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "groupByNode(stats.timers.whitehall-frontend-?_frontend.whitehall.time_*.mean,4,\"avg\")",
+              "target": "groupByNode(stats.timers.whitehall-frontend-?_frontend*.whitehall.time_*.mean,4,\"avg\")",
               "refId": "A"
             }
           ],
@@ -610,7 +610,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "aliasSub(groupByNode(stats.*_frontend.nginx_logs.*_publishing_service_gov_uk.http_503,3,\"sum\"),\"_.*\",\"\")",
+              "target": "aliasSub(groupByNode(stats.*_frontend*.nginx_logs.*_publishing_service_gov_uk.http_503,3,\"sum\"),\"_.*\",\"\")",
               "refId": "A"
             }
           ],

--- a/modules/grafana/templates/dashboards/publishing_api_overview.json.erb
+++ b/modules/grafana/templates/dashboards/publishing_api_overview.json.erb
@@ -695,11 +695,11 @@
           "targets": [
             {
               "refId": "A",
-              "target": "backend-1_backend.processes-app-publishing-api.ps_rss"
+              "target": "backend-1_backend*.processes-app-publishing-api.ps_rss"
             },
             {
               "refId": "B",
-              "target": "backend-2_backend.processes-app-publishing-api.ps_rss"
+              "target": "backend-2_backend*.processes-app-publishing-api.ps_rss"
             }
           ],
           "timeFrom": null,
@@ -792,7 +792,7 @@
                 }
               ],
               "refId": "A",
-              "target": "postgresql-primary-?_backend.postgresql-publishing_api_production.pg_db_size",
+              "target": "postgresql-primary-?_backend*.postgresql-publishing_api_production.pg_db_size",
               "timeField": "@timestamp"
             }
           ],

--- a/modules/grafana/templates/dashboards/whitehall_health.json.erb
+++ b/modules/grafana/templates/dashboards/whitehall_health.json.erb
@@ -57,7 +57,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "groupByNode(stats.whitehall-frontend-?_frontend.nginx_logs.whitehall-frontend_publishing_service_gov_uk.http_5xx,4,\"sumSeries\")",
+              "target": "groupByNode(stats.whitehall-frontend-?_frontend.nginx_logs.whitehall-frontend_*publishing_service_gov_uk.http_5xx,4,\"sumSeries\")",
               "refId": "A"
             }
           ],
@@ -129,7 +129,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "groupByNode(stats.whitehall-backend-?_backend.nginx_logs.whitehall-admin_publishing_service_gov_uk.http_5xx,4,\"sumSeries\")",
+              "target": "groupByNode(stats.whitehall-backend-?_backend*.nginx_logs.whitehall-admin_publishing_service_gov_uk.http_5xx,4,\"sumSeries\")",
               "refId": "A"
             }
           ],
@@ -283,11 +283,11 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "groupByNode(whitehall-backend-*_backend.nginx.nginx_connections-writing,-1,\"sum\")",
+              "target": "groupByNode(whitehall-backend-*_backend*.nginx.nginx_connections-writing,-1,\"sum\")",
               "refId": "A"
             },
             {
-              "target": "groupByNode(whitehall-backend-*_backend.nginx.nginx_requests,-1,\"sum\")",
+              "target": "groupByNode(whitehall-backend-*_backend*.nginx.nginx_requests,-1,\"sum\")",
               "refId": "B"
             }
           ],
@@ -367,15 +367,15 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "alias(sumSeries(whitehall-mysql-master-1_backend.cpu-*.cpu-user),\"Master CPU Usage\")",
+              "target": "alias(sumSeries(whitehall-mysql-master-1_backend*.cpu-*.cpu-user),\"Master CPU Usage\")",
               "refId": "A"
             },
             {
-              "target": "alias(sumSeries(whitehall-mysql-slave-1_backend.cpu-*.cpu-user),\"Slave-1 CPU Usage\")",
+              "target": "alias(sumSeries(whitehall-mysql-slave-1_backend*.cpu-*.cpu-user),\"Slave-1 CPU Usage\")",
               "refId": "B"
             },
             {
-              "target": "alias(sumSeries(whitehall-mysql-slave-2_backend.cpu-*.cpu-user),\"Slave-2 CPU Usage\")",
+              "target": "alias(sumSeries(whitehall-mysql-slave-2_backend*.cpu-*.cpu-user),\"Slave-2 CPU Usage\")",
               "refId": "C"
             }
           ],
@@ -445,7 +445,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "aliasSub(groupByNode({elasticsearch,support}-?_backend.cpu-*.cpu-user,0,\"sumSeries\"),\"_backend\",\"\")",
+              "target": "aliasSub(groupByNode({elasticsearch,support}-?_backend*.cpu-*.cpu-user,0,\"sumSeries\"),\"_backend\",\"\")",
               "refId": "A"
             }
           ],


### PR DESCRIPTION
These changes will make the dashboards work in staging and integration, while
making them still work in production. The names of the metrics in Graphite
differ between the environments, so this commit adds wildcards in the
appropriate places.