### PR TITLE
Remove enforcing options

### DIFF
--- a/modules/puppet/templates/govuk_puppet
+++ b/modules/puppet/templates/govuk_puppet
@@ -85,11 +85,6 @@ cd "$GOVUK_STATE_DIR" || { echo "Unable to access locks directory: '$GOVUK_STATE
 
 OPTION=${1:-}
 
-if  [ -z "$OPTION" ]
-then
-	OPTION=help #Show usage if no command line arguments are present
-fi
-
 case "$OPTION" in
 
 --disable)


### PR DESCRIPTION
The cronjobs run `govuk_puppet` without any arguments, which means automatic runs of puppet are not currently working.

This removes the conditional to enforce this. It isn't required.