### PR TITLE
Add ordering for govuk_puppet script

### DIFF
--- a/modules/puppet/manifests/init.pp
+++ b/modules/puppet/manifests/init.pp
@@ -44,6 +44,7 @@ class puppet (
     ensure  => present,
     mode    => '0755',
     content => template($govuk_puppet_template),
+    require => File['/var/run/lock/puppet'],
   }
 
   file { '/var/run/lock/puppet':


### PR DESCRIPTION
The script requires the lock directory to be present; if it's not present then the script bombs out:

```
lauramartin@integration-api-1:~$ govuk_puppet --test
/usr/local/bin/govuk_puppet: line 84: cd: /var/run/lock/puppet: No such
file or directory
Unable to access locks directory: '/var/run/lock/puppet'
```

At some point the new script was created but the directory wasn't. I'm not really sure how but this would stop that (and ordering is good).