### PR TITLE
Add env vars for Signon to Transition

### DIFF
--- a/modules/govuk/manifests/apps/transition.pp
+++ b/modules/govuk/manifests/apps/transition.pp
@@ -12,12 +12,20 @@
 #   Whether to enable the procfile worker
 #   Default: true
 #
+# [*oauth_id*]
+#   The Signon OAuth identifier for this app
+#
+# [*oauth_secret*]
+#   The Signon OAuth secret for this app
+#
 # [*secret_key_base*]
 #   The key for Rails to use when signing/encrypting sessions.
 #
 class govuk::apps::transition(
   $port = '3044',
   $enable_procfile_worker = true,
+  $oauth_id = undef,
+  $oauth_secret = undef,
   $secret_key_base = undef
 ) {
   $app_name = 'transition'
@@ -43,6 +51,12 @@ class govuk::apps::transition(
 
   if $secret_key_base {
     govuk::app::envvar {
+      "${title}-OAUTH_ID":
+        varname => 'OAUTH_ID',
+        value   => $oauth_id;
+      "${title}-OAUTH_SECRET":
+        varname => 'OAUTH_SECRET',
+        value   => $oauth_secret;
       "${title}-SECRET_KEY_BASE":
         varname => 'SECRET_KEY_BASE',
         value   => $secret_key_base;


### PR DESCRIPTION
These aren't going to be used yet, the file is still overwritten on deployment.