### PR TITLE
Remove the icinga checks for importing data in publisher

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -43,7 +43,6 @@ govuk::apps::errbit::errbit_email_from: 'govuk-winston+errbit-production@digital
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::local_links_manager::local_links_manager_passive_checks: true
 govuk::apps::publicapi::backdrop_host: 'www.performance.service.gov.uk'
-govuk::apps::publisher::data_import_passive_check: true
 govuk::apps::rummager::aws_s3_bucket_name: govuk-api-elasticsearch-snapshots-production
 govuk::apps::travel_advice_publisher::enable_email_alerts: true
 

--- a/modules/govuk/manifests/apps/publisher.pp
+++ b/modules/govuk/manifests/apps/publisher.pp
@@ -8,11 +8,6 @@
 #   The port which the app runs on.
 #   Default: 3000
 #
-# [*data_import_passive_check*]
-#   Boolean, whether we should be monitoring publisher's local
-#   authority data import
-#   Default: false
-#
 # [*enable_procfile_worker*]
 #   Boolean, whether the procfile worker should be enabled
 #   Default: true
@@ -32,7 +27,6 @@
 #
 class govuk::apps::publisher(
     $port = '3000',
-    $data_import_passive_check = false,
     $enable_procfile_worker = true,
     $publishing_api_bearer_token = undef,
     $secret_key_base = undef,
@@ -65,8 +59,6 @@ class govuk::apps::publisher(
     }',
   }
 
-  $service_desc = 'publisher local authority data importer error'
-
   file { '/usr/local/bin/local_authority_import_check':
     ensure  => present,
     mode    => '0755',
@@ -78,14 +70,6 @@ class govuk::apps::publisher(
     mode   => '0775',
     owner  => 'assets',
     group  => 'assets',
-  }
-
-  if $data_import_passive_check {
-    @@icinga::passive_check { "check-local-authority-data-importer-${::hostname}":
-      service_description => $service_desc,
-      host_name           => $::fqdn,
-      freshness_threshold => 28 * (60 * 60),
-    }
   }
 
   govuk::procfile::worker {'publisher':


### PR DESCRIPTION
For: https://trello.com/c/opAHOMr4/443-4-of-4-delete-old-ldg-import-into-publisher-and-related-code-3

We've removed these imports so the icinga checks don't need to be created
anymore.

For extra context see:

* https://github.com/alphagov/publisher/pull/493
* https://github.com/alphagov/govuk_content_models/pull/389
* https://github.com/alphagov/govuk_content_api/pull/251