### PR TITLE
Elasticsearch Repo Housekeeping

### DIFF
--- a/modules/govuk_elasticsearch/manifests/backup.pp
+++ b/modules/govuk_elasticsearch/manifests/backup.pp
@@ -55,8 +55,7 @@ class govuk_elasticsearch::backup(
     $json_es_indices = join(regsubst($es_indices, '(.*)', '"\1"'), ',')
 
     include ::backup::client
-#   FIXME This include will cause tests to fail until the PR for housekeeping is merged
-    #include govuk_elasticsearch::housekeeping
+    include govuk_elasticsearch::housekeeping
 
 
     # push env files

--- a/modules/govuk_elasticsearch/manifests/housekeeping.pp
+++ b/modules/govuk_elasticsearch/manifests/housekeeping.pp
@@ -5,8 +5,9 @@
 #
 # === Parameters:
 #
-# [*es_repos*]
-#   The local elasticsearch repositories where snapshots are stored
+# [*es_repo*]
+#   The local elasticsearch repositories where snapshots are stored.
+#   This could be either a single element or an aray.
 #
 # [*es_snapshot_limit*]
 #   The number of snapshots we want to keep
@@ -20,17 +21,17 @@
 #   A string array of Elasticsearch repositories
 #
 class govuk_elasticsearch::housekeeping(
-  $es_repos,
+  $es_repo = [],
   $es_snapshot_limit = 5,
   $user = 'govuk-backup',
   ) {
 
-  if $es_repos == undef {
+  if $es_repo == undef {
     fail('No Elasticsearch repositories were set')
   } else {
     # Validates a maximum and minimum string length
-    validate_slength($es_repos, 120, 3)
-    $repositories = join(regsubst($es_repos,'(.*)','"\1"'), ' ')
+    validate_slength($es_repo, 120, 3)
+    $repositories = join(regsubst($es_repo,'(.*)','"\1"'), ' ')
   }
 
     # This is a CLI JSON processor which allows us to "awk" the data on the fly

--- a/modules/govuk_elasticsearch/spec/classes/govuk_elasticsearch_housekeeping_spec.rb
+++ b/modules/govuk_elasticsearch/spec/classes/govuk_elasticsearch_housekeeping_spec.rb
@@ -3,7 +3,7 @@ require_relative '../../../../spec_helper'
   describe 'govuk_elasticsearch::housekeeping', :type => :class do
 
     let(:params) {{
-        :es_repos => [
+        :es_repo => [
             'kibana-lint',
             'kibana-mint',
             'kibana_tint'


### PR DESCRIPTION
Removing FIXME comment to include housekeeping class when applying backup class.
Modified class params names.