### PR TITLE
Fix Travel Advice Publisher Sidekiq Monitoring

### DIFF
--- a/modules/govuk/templates/sidekiq_monitoring_nginx_config.conf.erb
+++ b/modules/govuk/templates/sidekiq_monitoring_nginx_config.conf.erb
@@ -30,6 +30,10 @@ server {
     proxy_pass http://localhost:3086;
   }
 
+  location /travel-advice-publisher {
+    proxy_pass http://localhost:3203;
+  }
+
   location /dfid-transition {
     proxy_pass http://localhost:3124;
   }


### PR DESCRIPTION
Adds missing location to the Nginx config.

Port is defined in https://github.com/alphagov/sidekiq-monitoring/blob/master/Procfile#L11