### PR TITLE
Fix the memory used metrics to work on all environments

### DIFF
--- a/modules/grafana/templates/dashboards/publishing_api_overview.json.erb
+++ b/modules/grafana/templates/dashboards/publishing_api_overview.json.erb
@@ -874,11 +874,11 @@
           "targets": [
             {
               "refId": "A",
-              "target": "redis-1_backend.memory.memory-used"
+              "target": "redis-1_backend*.memory.memory-used"
             },
             {
               "refId": "B",
-              "target": "redis-2_backend.memory.memory-used"
+              "target": "redis-2_backend*.memory.memory-used"
             }
           ],
           "timeFrom": null,


### PR DESCRIPTION
Suffixes (e.g. _integration) are used on staging and integration, so add a
wildcard to handle this.