### PR TITLE
Remove Rummager AWS credentials

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -20,8 +20,6 @@ govuk::apps::event_store::enabled: true
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
 govuk::apps::publicapi::backdrop_host: 'www.preview.performance.service.gov.uk'
 
-govuk::apps::rummager::aws_s3_bucket_name: govuk-api-elasticsearch-snapshots-integration
-
 govuk::apps::smartanswers::expose_govspeak: true
 govuk::apps::specialist_publisher::publish_pre_production_finders: true
 govuk::apps::specialist_publisher_rebuild::publish_pre_production_finders: true

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -43,7 +43,6 @@ govuk::apps::errbit::errbit_email_from: 'govuk-winston+errbit-production@digital
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::local_links_manager::local_links_manager_passive_checks: true
 govuk::apps::publicapi::backdrop_host: 'www.performance.service.gov.uk'
-govuk::apps::rummager::aws_s3_bucket_name: govuk-api-elasticsearch-snapshots-production
 govuk::apps::travel_advice_publisher::enable_email_alerts: true
 
 govuk::deploy::actionmailer_enable_delivery: true

--- a/modules/govuk/manifests/apps/rummager.pp
+++ b/modules/govuk/manifests/apps/rummager.pp
@@ -25,14 +25,6 @@
 #   The bearer token to use when communicating with Publishing API.
 #   Default: undef
 #
-# [*aws_s3_key*]
-#   AWS access key for uploading API search index snapshots
-#   Default: undef
-#
-# [*aws_s3_secret*]
-#   AWS access secret for uploading API search index snapshots
-#   Default: undef
-#
 # [*rabbitmq_hosts*]
 #   RabbitMQ hosts to connect to.
 #   Default: localhost
@@ -64,10 +56,6 @@ class govuk::apps::rummager(
   $enable_procfile_worker = true,
   $enable_publishing_listener = false,
   $publishing_api_bearer_token = undef,
-  $aws_s3_key = undef,
-  $aws_s3_secret = undef,
-  $aws_s3_bucket_name = undef,
-  $aws_s3_bucket_region = 'eu-west-1',
   $rabbitmq_hosts = ['localhost'],
   $rabbitmq_user = 'rummager',
   $rabbitmq_password = 'rummager',
@@ -139,17 +127,5 @@ class govuk::apps::rummager(
     "${title}-PUBLISHING_API_BEARER_TOKEN":
       varname => 'PUBLISHING_API_BEARER_TOKEN',
       value   => $publishing_api_bearer_token;
-    "${title}-AWS_ACCESS_KEY_ID":
-      varname => 'AWS_ACCESS_KEY_ID',
-      value   => $aws_s3_key;
-    "${title}-AWS_SECRET_ACCESS_KEY":
-      varname => 'AWS_SECRET_ACCESS_KEY',
-      value   => $aws_s3_secret;
-    "${title}-AWS_BUCKET_NAME":
-      varname => 'AWS_BUCKET_NAME',
-      value   => $aws_s3_bucket_name;
-    "${title}-AWS_BUCKET_REGION":
-      varname => 'AWS_BUCKET_REGION',
-      value   => $aws_s3_bucket_region;
   }
 }


### PR DESCRIPTION
https://github.com/alphagov/rummager/pull/690 removed snapshotting functionality from Rummager that was replaced by more generic functionality in govuk-puppet. This commit removes the credentials used by the previous functionality.

Trello: https://trello.com/c/hHfwtyyR/26-cleanup-remove-redundant-snapshotting-code-from-rummager