### PR TITLE
Mongo s3 restore 5

### DIFF
--- a/hieradata/node/mongo-3.backend.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/mongo-3.backend.integration.publishing.service.gov.uk.yaml
@@ -1,0 +1,2 @@
+mongodb::backup::s3_restores: true
+


### PR DESCRIPTION
The mongodb::s3backup::restore class is gated in mongodb::backup.
To enable it we need to override the class param to true.