### PR TITLE
Add Local Links Manager export links passive check

### DIFF
--- a/modules/govuk/manifests/apps/local_links_manager.pp
+++ b/modules/govuk/manifests/apps/local_links_manager.pp
@@ -128,6 +128,12 @@ class govuk::apps::local_links_manager(
         host_name           => $::fqdn,
         freshness_threshold => (25 * 60 * 60), # 25 hrs (e.g. just over a day)
       }
+
+      @@icinga::passive_check { "local-links-manager-export-links_${::hostname}":
+        service_description => 'Export links to CSV from local-links-manager',
+        host_name           => $::fqdn,
+        freshness_threshold => (25 * 60 * 60), # 25 hrs (e.g. just over a day)
+      }
     }
 
     if $::govuk_node_class != 'development' {


### PR DESCRIPTION
- We are adding a scheduled task which exports all the local authority
  links for services to a CSV. This adds a passive check for Icinga
  so we are alerted if it does not run once a day.

[Related PR](https://github.com/alphagov/local-links-manager/pull/55)
[Trello card](https://trello.com/c/dFFQRlsp/448-generate-local-links-csv-3)