### PR TITLE
Set environment variables for Stagecraft creds

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -455,6 +455,8 @@ govuk::apps::smartanswers::nagios_memory_warning: 4000
 govuk::apps::smartanswers::nagios_memory_critical: 4500
 
 govuk::apps::stagecraft::enabled: true
+govuk::apps::stagecraft::database_password: "%{hiera('govuk::apps::stagecraft::postgresql_db::password')}"
+govuk::apps::stagecraft::message_queue_password: "%{hiera('govuk::apps::stagecraft::rabbitmq::amqp_pass')}"
 govuk::apps::stagecraft::worker::enabled: true
 govuk::apps::stagecraft::beat::enabled: true
 govuk::apps::stagecraft::celerycam::enabled: true

--- a/modules/govuk/manifests/apps/stagecraft.pp
+++ b/modules/govuk/manifests/apps/stagecraft.pp
@@ -7,16 +7,26 @@
 # [*enabled*]
 #   Should the app exist?
 #
+# [*database_password*]
+#   The password for the app to connect to its database
+#
+# [*message_queue_password*]
+#   The password for the app to connect to its message queue
+#
 class govuk::apps::stagecraft (
   $enabled = false,
+  $database_password = undef,
+  $message_queue_password = undef,
 ) {
+  $app_name = 'stagecraft'
+
   if $enabled {
 
     include libffi
 
     $port = '3103'
 
-    govuk::app { 'stagecraft':
+    govuk::app { $app_name:
       app_type           => 'bare',
       port               => 3103,
       command            => "./venv/bin/gunicorn stagecraft.wsgi:application --bind 127.0.0.1:${port} --workers 4",
@@ -28,6 +38,19 @@ class govuk::apps::stagecraft (
       logfile => '/var/apps/stagecraft/log/collectors.json.log',
       fields  => {'application' => 'performanceplatform-collectors'},
       json    => true,
+    }
+
+    Govuk::App::Envvar {
+      app => $app_name,
+    }
+
+    govuk::app::envvar {
+      "${title}-DATABASE_PASSWORD":
+        varname => 'DATABASE_PASSWORD',
+        value   => $database_password;
+      "${title}-MESSAGE_QUEUE_PASSWORD":
+        varname => 'MESSAGE_QUEUE_PASSWORD',
+        value   => $message_queue_password;
     }
   }
 }


### PR DESCRIPTION
These creds are already defined in the deployment repo so we can make use of them with hiera lookups.