### PR TITLE
Run licensify data sync daily instead of weekly.

### DIFF
--- a/modules/govuk_jenkins/manifests/job/copy_licensify_data_to_staging.pp
+++ b/modules/govuk_jenkins/manifests/job/copy_licensify_data_to_staging.pp
@@ -19,7 +19,7 @@ class govuk_jenkins::job::copy_licensify_data_to_staging (
   @@icinga::passive_check { "${check_name}_${::hostname}":
     service_description => $service_description,
     host_name           => $::fqdn,
-    freshness_threshold => 612000,
+    freshness_threshold => 115200,
     action_url          => $job_url,
   }
 }

--- a/modules/govuk_jenkins/templates/jobs/copy_licensify_data_to_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_licensify_data_to_staging.yaml.erb
@@ -23,7 +23,7 @@
     logrotate:
         artifactNumToKeep: 10
     triggers:
-        - timed: 'H 1 * * 6'
+        - timed: 'H 1 * * *'
     builders:
         - shell: |
             set +x


### PR DESCRIPTION
We're doing some work to improve these apps and
having more up to date data will help that process.