### PR TITLE
Add CSV mime type to nginx

### DIFF
--- a/modules/nginx/files/etc/nginx/mime.types
+++ b/modules/nginx/files/etc/nginx/mime.types
@@ -7,6 +7,7 @@ types {
 	application/x-javascript		js;
 	application/atom+xml			atom;
 
+	text/csv				csv;
 	text/mathml				mml;
 	text/plain				txt;
 	text/vnd.sun.j2me.app-descriptor	jad;


### PR DESCRIPTION
Local-links-manager generates and serves static CSVs.  In testing on Integration, we noticed that the CSVs were served with a `Content-Type` of `text/plain` where they should have been `text/csv`.

https://tools.ietf.org/html/rfc4180#page-4