### PR TITLE
Permit GovDelivery topic overwriting in staging and integration.

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -11,6 +11,7 @@ base::supported_kernel::enabled: true
 cron::weekly_dow: 1
 cron::daily_hour: 6
 
+govuk::apps::email_alert_api::allow_govdelivery_topic_syncing: true
 govuk::apps::email_campaign_api::mongodb_nodes:
   - 'api-mongo-1.api'
   - 'api-mongo-2.api'

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -9,6 +9,7 @@ cron::daily_hour: 6
 
 environment_ip_prefix: '10.2'
 
+govuk::apps::email_alert_api::allow_govdelivery_topic_syncing: true
 govuk::apps::email_alert_api::db::backend_ip_range: '10.2.3.0/24'
 govuk::apps::errbit::errbit_email_from: 'govuk-winston+errbit-staging@digital.cabinet-office.gov.uk'
 govuk::apps::hmrc_manuals_api::publish_topics: false

--- a/modules/govuk/manifests/apps/email_alert_api.pp
+++ b/modules/govuk/manifests/apps/email_alert_api.pp
@@ -24,6 +24,12 @@
 #   Redis port for Sidekiq.
 #   Default: undef
 #
+# [*allow_govdelivery_topic_syncing*]
+#   If set to `true`, allows the running of a script which deletes all topics
+#   in GovDelivery and replaces them with copies from the email alert API database.
+#   Must only be configured to `true` in staging or integration, never production.
+#   Default: false
+#
 class govuk::apps::email_alert_api(
   $port = '3088',
   $enabled = false,
@@ -36,6 +42,7 @@ class govuk::apps::email_alert_api(
   $sidekiq_queue_latency_warning = '30',
   $redis_host = undef,
   $redis_port = undef,
+  $allow_govdelivery_topic_syncing = false,
 ) {
 
   if $enabled {
@@ -102,6 +109,13 @@ class govuk::apps::email_alert_api(
     govuk::app::envvar { "${title}-SIDEKIQ_QUEUE_LATENCY_WARNING_THRESHOLD":
       varname => 'SIDEKIQ_QUEUE_LATENCY_WARNING',
       value   => $sidekiq_queue_latency_warning;
+    }
+
+    if $allow_govdelivery_topic_syncing {
+      govuk::app::envvar { "${title}-ALLOW_GOVDELIVERY_SYNC":
+        varname => 'ALLOW_GOVDELIVERY_SYNC',
+        value   => 'allow';
+      }
     }
   }
 }


### PR DESCRIPTION
Allows us to keep the integration/staging account
of GovDelivery in sync with production, making QA
easier.

See https://github.com/alphagov/email-alert-api/blob/master/lib/tasks/data_hygiene.rake#L23-L29
and https://trello.com/c/PTDavZWZ/1-sync-integration-and-staging-topic-ids