### PR TITLE
Update crawler dependencies

### DIFF
--- a/modules/govuk_crawler/manifests/init.pp
+++ b/modules/govuk_crawler/manifests/init.pp
@@ -122,15 +122,6 @@ class govuk_crawler(
     owner  => $crawler_user,
   }
 
-  # TODO: Can be removed when dependency in govuk_seed_crawler has gone:
-  #       https://github.com/alphagov/govuk_seed_crawler/blob/v1.0.0/lib/govuk_seed_crawler/indexer.rb#L12
-  package { 'govuk_mirrorer':
-      ensure   => '1.3.2',
-      provider => system_gem,
-      notify   => Package['govuk_seed_crawler'],
-  }
-  # END TODO
-
   package { 'govuk_seed_crawler':
         ensure   => '1.0.0',
         provider => system_gem,

--- a/modules/govuk_crawler/manifests/init.pp
+++ b/modules/govuk_crawler/manifests/init.pp
@@ -123,7 +123,7 @@ class govuk_crawler(
   }
 
   package { 'govuk_seed_crawler':
-        ensure   => '1.0.0',
+        ensure   => '2.0.0',
         provider => system_gem,
   }
 


### PR DESCRIPTION
This will make `govuk_seed_crawler` use the sitemap instead of contentapi. See https://github.com/alphagov/govuk_seed_crawler/pull/3

cc @alexmuller 