### PR TITLE
Don't phone for travel advice when GitHub is down

### DIFF
--- a/hieradata/class/jenkins.yaml
+++ b/hieradata/class/jenkins.yaml
@@ -91,6 +91,8 @@ govuk_jenkins::plugins:
     version: '0.0.8'
   show-build-parameters:
     version: '1.0'
+  text-finder:
+    version: '1.10'
   timestamper:
     version: '1.8.2'
   token-macro:

--- a/modules/govuk_jenkins/templates/jobs/travel_advice_email_alert_check.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/travel_advice_email_alert_check.yaml.erb
@@ -23,6 +23,10 @@
             bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
             bundle exec rake run_travel_alerts
     publishers:
+      - text-finder:
+          regexp: "Could not read from remote repository"
+          also-check-console-output: true
+          unstable-if-found: true
       - trigger-parameterized-builds:
         - project: Success_Passive_Check
           condition: 'SUCCESS'


### PR DESCRIPTION
If GitHub is unavailable the travel advice check will fail which will notify PagerDuty.

Instead we use the TextFinder Jenkins plugin to check for output that indicates GitHub is down, and use that to mark the build as unstable.

/cc @boffbowsh 