### PR TITLE
Routing changes for deploy

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,6 +126,3 @@ DEPENDENCIES
   rspec-puppet
   sshkey (= 1.7.0)
   webmock (~> 1.20.0)
-
-BUNDLED WITH
-   1.11.2

--- a/modules/govuk/manifests/node/s_backend_lb.pp
+++ b/modules/govuk/manifests/node/s_backend_lb.pp
@@ -46,39 +46,58 @@ class govuk::node::s_backend_lb (
       'specialist-publisher',
     ]:
       modified_paths => {
-        '/sp-rebuild/assets'               => {
+        '/sp-rebuild/assets'                 => {
           'app' => 'specialist-publisher-rebuild',
         },
-        '/rebuild-healthcheck'             => {
+        '/rebuild-healthcheck'               => {
           'app' => 'specialist-publisher-rebuild',
         },
-        '/preview'                         => {
+        '/preview'                           => {
           'app' => 'specialist-publisher-rebuild',
         },
-        '/raib-reports'                    => {
+        '/raib-reports'                      => {
           'app' => 'specialist-publisher-rebuild',
         },
-        '/maib-reports'                    => {
+        '/maib-reports'                      => {
           'app' => 'specialist-publisher-rebuild',
         },
-        '/dfid-research-outputs'           => {
+        '/dfid-research-outputs'             => {
           'app' => 'specialist-publisher-rebuild',
         },
-        '/aaib-reports'                    => {
+        '/aaib-reports'                      => {
           'app' => 'specialist-publisher-rebuild',
         },
-        '/cma-cases'                       => {
+        '/cma-cases'                         => {
           'app' => 'specialist-publisher-rebuild',
         },
-        '/international-development-funds' => {
+        '/international-development-funds'   => {
           'app' => 'specialist-publisher-rebuild',
         },
-        '/countryside-stewardship-grants'  => {
+        '/countryside-stewardship-grants'    => {
           'app' => 'specialist-publisher-rebuild',
         },
-        '/esi-funds'                       => {
+        '/esi-funds'                         => {
           'app' => 'specialist-publisher-rebuild',
         },
+        '/tax-tribunal-decisions'            => {
+          'app' => 'specialist-publisher-rebuild',
+        },
+        '/utaac-decisions'                   => {
+          'app' => 'specialist-publisher-rebuild',
+        },
+        '/et-decisions'                      => {
+          'app' => 'specialist-publisher-rebuild',
+        },
+        '/eat-decisions'                     => {
+          'app' => 'specialist-publisher-rebuild',
+        },
+        '/asylum-support-decisions'          => {
+          'app' => 'specialist-publisher-rebuild',
+        },
+        '/vehicle-recalls-and-faults-alerts' => {
+          'app' => 'specialist-publisher-rebuild',
+        },
+
       },
       servers        => $backend_servers;
     [


### PR DESCRIPTION
Added routing to make pre prod finders be handled by specialist publisher rebuild instead of specialist publisher