### PR TITLE
Sync govdelivery topics in integration after data sync.

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
@@ -48,5 +48,10 @@
                 TARGET_APPLICATION=whitehall
                 MACHINE_CLASS=whitehall_backend
                 RAKE_TASK=publishing:scheduled:requeue_all_jobs
+            - project: run-rake-task
+              predefined-parameters: |
+                TARGET_APPLICATION=email-alert-api
+                MACHINE_CLASS=backend
+                RAKE_TASK=sync_govdelivery_topic_mappings
         - email:
             recipients: govuk-ci-notifications@digital.cabinet-office.gov.uk


### PR DESCRIPTION
This will ensure that the topic IDs in our system
match the ones in govdelivery, making signoff and
QA much easier for people working with email.