### PR TITLE
route update for spr - drug safety

### DIFF
--- a/modules/govuk/manifests/node/s_backend_lb.pp
+++ b/modules/govuk/manifests/node/s_backend_lb.pp
@@ -97,7 +97,12 @@ class govuk::node::s_backend_lb (
         '/vehicle-recalls-and-faults-alerts' => {
           'app' => 'specialist-publisher-rebuild',
         },
-
+        '/drug-safety-updates'               => {
+          'app' => 'specialist-publisher-rebuild',
+        },
+        '/medical-safety-alerts'             => {
+          'app' => 'specialist-publisher-rebuild',
+        },
       },
       servers        => $backend_servers;
     [


### PR DESCRIPTION
- Routes have been updated to use specialist publisher rebuild for
drug safety updates

We're waiting on QA ([ticket](https://trello.com/c/sNDhnPlI/234-medical-safety-alerts-qa-ahead-of-go-live-small)) then this can be merged. We expect this to happen in the next 2 - 3 days.