### PR TITLE
Prepare to retire Dfid transition, ensure absent

### DIFF
--- a/modules/govuk/manifests/apps/dfid_transition.pp
+++ b/modules/govuk/manifests/apps/dfid_transition.pp
@@ -71,6 +71,7 @@ class govuk::apps::dfid_transition (
     }
 
     govuk::app { $app_name:
+      ensure             => absent,
       app_type           => 'procfile',
       port               => $port,
       enable_nginx_vhost => true,

--- a/modules/govuk/manifests/node/s_backend_lb.pp
+++ b/modules/govuk/manifests/node/s_backend_lb.pp
@@ -86,7 +86,6 @@ class govuk::node::s_backend_lb (
       'collections-publisher',
       'contacts-admin',
       'content-tagger',
-      'dfid-transition',
       'imminence',
       'local-links-manager',
       'maslow',

--- a/modules/govuk/templates/sidekiq_monitoring_nginx_config.conf.erb
+++ b/modules/govuk/templates/sidekiq_monitoring_nginx_config.conf.erb
@@ -34,10 +34,6 @@ server {
     proxy_pass http://localhost:3203;
   }
 
-  location /dfid-transition {
-    proxy_pass http://localhost:3124;
-  }
-
   location /email-alert-api {
     proxy_pass http://localhost:3089;
   }


### PR DESCRIPTION
https://trello.com/c/Ke4GpYqS/249-tear-down-dfid-transition-smediumish

Initial work for dfid-transition tool removal.

- Ensure absent on dfid-transition app module
- Remove from loadbalancer
- Remove sidekiq monitoring config