### PR TITLE
Remove purged package reference

### DIFF
--- a/modules/govuk_rbenv/manifests/all.pp
+++ b/modules/govuk_rbenv/manifests/all.pp
@@ -20,10 +20,6 @@ class govuk_rbenv::all (
     key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
   }
 
-  rbenv::version { '1.9.3-p484':
-    ensure => absent, # FIXME: Remove this resource once purged everywhere
-  }
-
   rbenv::version { '2.1.2':
     bundler_version => '1.6.5',
   }


### PR DESCRIPTION
For whatever reason this was making my local tests fail. It's been
deployed since it was added in 586a64ff9b70ac41c11837726bd4c60ee8c77f2f
so this should be safe to remove.