### PR TITLE
Show the reason Puppet is disabled in Icinga

### DIFF
--- a/modules/puppet/files/usr/lib/nagios/plugins/check_puppet_agent
+++ b/modules/puppet/files/usr/lib/nagios/plugins/check_puppet_agent
@@ -1,8 +1,18 @@
 #!/usr/bin/ruby
 
+require 'json'
 require 'yaml'
 
 puppet_agent_summary_filename = "/var/lib/puppet/state/last_run_summary.yaml"
+puppet_agent_disabled_lockfile = "/var/lib/puppet/state/agent_disabled.lock"
+
+if File.file?(puppet_agent_disabled_lockfile)
+  disabled_reason = JSON.parse(File.read(puppet_agent_disabled_lockfile))['disabled_message']
+
+  puts "Puppet is disabled: #{disabled_reason}"
+  exit 1
+end
+
 begin
   summary = YAML.load_file(puppet_agent_summary_filename)
 

--- a/modules/puppet/templates/govuk_puppet
+++ b/modules/puppet/templates/govuk_puppet
@@ -8,8 +8,7 @@ fi
 
 START_TIME=`date +%s%3N`
 
-# Allow return code 2 in case -v/--detailed-exitcodes is passed.
-RBENV_VERSION=1.9.3 /usr/local/bin/govuk_setenv default puppet agent --onetime --no-daemonize "$@" || [ $? -eq 2 ]
+RBENV_VERSION=1.9.3 /usr/local/bin/govuk_setenv default puppet agent --onetime --no-daemonize "$@"
 
 TIME_TOOK=$((`date +%s%3N`-START_TIME))
 echo "<%= @fqdn_metrics %>.puppet.run_duration:${TIME_TOOK}|ms" | nc -w 1 -u localhost 8125


### PR DESCRIPTION
This commit changes the check of the Puppet agent to also check whether there's a lockfile on disk which is preventing Puppet from running.

Unfortunately this means that we need to make a fairly large change to `govuk_puppet` which allows all exit codes to let the script continue rather than just 0 or 2.