### PR TITLE
Disable workers in development

### DIFF
--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -115,7 +115,7 @@ govuk::apps::contacts::extra_aliases: ['contacts-frontend-old', 'contacts-admin'
 govuk::apps::content_store::mongodb_nodes: ['localhost']
 govuk::apps::content_store::mongodb_name: 'content_store_development'
 govuk::apps::dfid_transition::enable_procfile_worker: false
-govuk::apps::content_tagger::enable_procfile_worker: true
+govuk::apps::content_tagger::enable_procfile_worker: false
 govuk::apps::email_alert_api::enable_procfile_worker: false
 govuk::apps::email_campaign_api::mongodb_name: 'email_campaign_api_development'
 govuk::apps::email_campaign_api::mongodb_nodes: ['localhost']
@@ -155,10 +155,10 @@ govuk::apps::router::vhost_aliases: ["www"]
 govuk::apps::router_api::mongodb_name: 'router'
 govuk::apps::router_api::mongodb_nodes: ['localhost']
 govuk::apps::router_api::router_nodes: ['localhost:3055']
-govuk::apps::rummager::enable_procfile_worker: true
+govuk::apps::rummager::enable_procfile_worker: false
 govuk::apps::rummager::rabbitmq_hosts: ['localhost']
-govuk::apps::rummager::enable_publishing_listener: true
-govuk::apps::rummager::rabbitmq::enable_publishing_listener: true
+govuk::apps::rummager::enable_publishing_listener: false
+govuk::apps::rummager::rabbitmq::enable_publishing_listener: false
 govuk::apps::rummager::redis_host: 'localhost'
 govuk::apps::share_sale_publisher::enabled: true
 govuk::apps::share_sale_publisher::mongodb_nodes: ['localhost']

--- a/modules/govuk/manifests/procfile/fleet.pp
+++ b/modules/govuk/manifests/procfile/fleet.pp
@@ -1,0 +1,67 @@
+# == Define: govuk::procfile::fleet
+#
+# Creates an upstart entry for a worker as defined by the application's Procfile.
+#
+# === Parameters
+#
+# [*enable_service*]
+#   Whether or not to start the service.  Always false if $ensure is 'absent'.
+#   Default: true
+#
+# [*ensure*]
+#   Whether to create or remove the configuration file.
+#   Default: present
+#
+# [*process_type*]
+#   The type of process to spawn, defined in the application's Procfile.
+#   This variable is used by the govuk/procfile-worker.conf.erb template.
+#   Default: 'worker'
+#
+# [*setenv_as*]
+#   The application name to use when calling `govuk_setenv`.
+#   This variable is used by the govuk/procfile-worker.conf.erb template.
+#   Default: $title
+#
+define govuk::procfile::worker (
+  $enable_service = true,
+  $ensure = present,
+  $process_type = 'worker',
+  $setenv_as = $title,
+) {
+  validate_re($ensure, '^(present|absent)$', '$ensure must be "present" or "absent"')
+
+  include govuk::procfile
+
+  $service_name = "${title}-procfile-worker"
+
+  if $ensure == present {
+    file { "/etc/init/${service_name}.conf":
+      ensure    => present,
+      content   => template('govuk/procfile-worker.conf.erb'),
+      notify    => Service[$service_name],
+      subscribe => Class['Govuk::Procfile'],
+    }
+
+    service { $service_name:
+      ensure => $enable_service,
+    }
+
+    if $enable_service {
+      @@icinga::check { "check_app_${title}_procfile_worker_upstart_up_${::hostname}":
+        check_command       => "check_nrpe!check_upstart_status!${service_name}",
+        service_description => "${title} procfile worker upstart up",
+        host_name           => $::fqdn,
+      }
+    }
+  } else {
+    exec { "stop_service_${service_name}":
+      command => "service ${service_name} stop",
+      onlyif  => "service ${service_name} status | grep running",
+    }
+
+    file { "/etc/init/${service_name}.conf":
+      ensure  => absent,
+      require => Exec["stop_service_${service_name}"],
+    }
+  }
+}


### PR DESCRIPTION
Workers should be run manually using `bowl` in development

/cc @tijmenb I guess?