### PR TITLE
Blacklist DFID research outputs from the mirrors

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -316,6 +316,7 @@ govuk::apps::govuk_crawler_worker::blacklist_paths:
   - '/api/'
   - '/apply-for-a-licence'
   - '/business-finance-support-finder'
+  - '/dfid-research-outputs/'
   - '/drug-device-alerts.atom'
   - '/drug-safety-update.atom'
   - '/foreign-travel-advice.atom'


### PR DESCRIPTION
URLs under this path have filenames which are too long, which causes errors in the crawler worker when writing to disk.

Blacklist this path temporarily until the publisher has been fixed to limit URLs to 255 characters.

@tuzz: Please would you add something to the story in your backlog to revert this change once the fix is complete?