### PR TITLE
Integration data sync complete: clear Sidekiq queues before requeuing…

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
@@ -11,16 +11,16 @@
       artifactNumToKeep: 10
     builders:
        - shell: |
+           # Clear the Sidekiq queues to stop any residual 'stale' jobs running
+           for host in $(govuk_node_list -c redis); do
+              ssh deploy@${host} 'redis-cli flushall'
+           done
            # Re-register smartanswers to pick up drafts.
            ssh deploy@$(govuk_node_list -c calculators_frontend --single-node) 'cd /var/apps/smartanswers ; govuk_setenv smartanswers bundle exec rake panopticon:register'
            # Queue up any publisher scheduled editions that have been transferred across.
            ssh deploy@$(govuk_node_list -c backend --single-node) 'cd /var/apps/publisher ; govuk_setenv publisher bundle exec rake editions:requeue_scheduled_for_publishing'
            # Publish any pre-production finders from Specialist Publisher Rebuild.
            ssh deploy@$(govuk_node_list -c backend --single-node) 'cd /var/apps/specialist-publisher-rebuild ; govuk_setenv specialist-publisher-rebuild bundle exec rake publishing_api:publish_finders rummager:publish_finders'
-           # Clear the Sidekiq queues to stop any residual 'stale' jobs running
-           for host in $(govuk_node_list -c redis); do
-              ssh deploy@${host} 'redis-cli flushall'
-           done
     publishers:
         - trigger-parameterized-builds:
             <%- %w{ publishing-api collections-publisher service-manual-publisher local-links-manager }.each do |app| -%>


### PR DESCRIPTION
… things

We need to requeue scheduled publishings after the data sync, so shouldn't
clear the queues after that.