### PR TITLE
Disable workers in development

### DIFF
--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -115,7 +115,7 @@ govuk::apps::contacts::extra_aliases: ['contacts-frontend-old', 'contacts-admin'
 govuk::apps::content_store::mongodb_nodes: ['localhost']
 govuk::apps::content_store::mongodb_name: 'content_store_development'
 govuk::apps::dfid_transition::enable_procfile_worker: false
-govuk::apps::content_tagger::enable_procfile_worker: true
+govuk::apps::content_tagger::enable_procfile_worker: false
 govuk::apps::email_alert_api::enable_procfile_worker: false
 govuk::apps::email_campaign_api::mongodb_name: 'email_campaign_api_development'
 govuk::apps::email_campaign_api::mongodb_nodes: ['localhost']
@@ -155,10 +155,10 @@ govuk::apps::router::vhost_aliases: ["www"]
 govuk::apps::router_api::mongodb_name: 'router'
 govuk::apps::router_api::mongodb_nodes: ['localhost']
 govuk::apps::router_api::router_nodes: ['localhost:3055']
-govuk::apps::rummager::enable_procfile_worker: true
+govuk::apps::rummager::enable_procfile_worker: false
 govuk::apps::rummager::rabbitmq_hosts: ['localhost']
-govuk::apps::rummager::enable_publishing_listener: true
-govuk::apps::rummager::rabbitmq::enable_publishing_listener: true
+govuk::apps::rummager::enable_publishing_listener: false
+govuk::apps::rummager::rabbitmq::enable_publishing_listener: false
 govuk::apps::rummager::redis_host: 'localhost'
 govuk::apps::share_sale_publisher::enabled: true
 govuk::apps::share_sale_publisher::mongodb_nodes: ['localhost']


### PR DESCRIPTION
Workers should be run manually using `bowl` in development

/cc @alphagov/team-gov-uk-finding-things 