### PR TITLE
MongoDB S3 Restore 6

### DIFF
--- a/modules/mongodb/manifests/s3backup/restore.pp
+++ b/modules/mongodb/manifests/s3backup/restore.pp
@@ -46,6 +46,7 @@ class mongodb::s3backup::restore(
 ){
 
   include ::backup::client
+  contain ::mongodb::s3backup::package
 
   file { '/usr/local/bin/mongodb-restore-s3':
     ensure  => file,
@@ -53,7 +54,7 @@ class mongodb::s3backup::restore(
     mode    => '0770',
     owner   => $user,
     group   => $user,
-    require => Class[mongodb::s3backup::package],
+    require => Class['::mongodb::s3backup::package'],
   }
 
 }


### PR DESCRIPTION
Lack of attention on my part.  The auto loader could not resolve the dependency and therefore could not load the class 'Package' and require the needed resource.

For future reference. Puppet master would throw the following error:

----
Aug 23 13:26:14 puppetmaster-1 puppet-master[1542]: Invalid relationship: File[/usr/local/bin/mongodb-restore-s3] { require => Class[Mongodb::S3backup::Package] }, because Class[Mongodb::S3backup::Package] doesn't seem to be in the catalog
----
Aug 23 13:26:15 puppetmaster-1 puppet-master[1545]: (Scope(Class[main])) Could not look up qualified variable '::govuk_node_class';
----