### PR TITLE
Remove s3 Backup lvm config from Exception Handler

### DIFF
--- a/hieradata/class/exception_handler.yaml
+++ b/hieradata/class/exception_handler.yaml
@@ -12,9 +12,6 @@ lv:
   data:
     pv: '/dev/sdc1'
     vg: 'mongodb'
-  s3backups:
-    pv: '/dev/sde1'
-    vg: 'mongo'
 
 mount:
   /var/lib/mongodb:
@@ -24,10 +21,6 @@ mount:
   /var/lib/automongodbbackup:
     disk: '/dev/mapper/backup-mongodb'
     govuk_lvm: 'mongodb'
-    mountoptions: 'defaults'
-  /var/lib/s3backup:
-    disk: '/dev/mapper/mongo-s3backups'
-    govuk_lvm: 's3backups'
     mountoptions: 'defaults'
 
 mongodb::server::replicaset_members:

--- a/hieradata/node/exception-handler-1.backend.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/exception-handler-1.backend.integration.publishing.service.gov.uk.yaml
@@ -1,1 +1,0 @@
-mongodb::backup::s3_backups: true

--- a/modules/govuk/manifests/node/s_exception_handler.pp
+++ b/modules/govuk/manifests/node/s_exception_handler.pp
@@ -9,5 +9,4 @@ class govuk::node::s_exception_handler inherits govuk::node::s_base {
 
   Govuk_mount['/var/lib/mongodb'] -> Class['mongodb::server']
   Govuk_mount['/var/lib/automongodbbackup'] -> Class['mongodb::backup']
-  Govuk_mount['/var/lib/s3backup'] -> Class['mongodb::backup']
 }


### PR DESCRIPTION
Exception Handler's data does not need to be backed up. The lvm config was added in error.

also 

Removed the gating to allow s3 backups for the exception handler.

relates to: https://github.gds/gds/govuk-provisioning/pull/564