### PR TITLE
Always deploy Licensify using deployment master

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -137,7 +137,6 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::whitehall_update_integration_data
 govuk_jenkins::job_builder::environment: 'integration'
 
-govuk_jenkins::job::deploy_licensify::alphagov_deployment_branch: 'master'
 govuk_jenkins::job::deploy_puppet::commitish: 'integration'
 
 govuk_jenkins::job::network_config_deploy::environments:

--- a/modules/govuk_jenkins/manifests/job/deploy_licensify.pp
+++ b/modules/govuk_jenkins/manifests/job/deploy_licensify.pp
@@ -4,15 +4,10 @@
 #
 # === Parameters
 #
-# [*alphagov_deployment_branch*]
-#   The branch of the `alphagov-deployment` repository to use to
-#   deploy applications
-#
 # [*ci_new_jenkins_api_key*]
 #   API key to download build artefacts from CI servers
 #
 class govuk_jenkins::job::deploy_licensify (
-  $alphagov_deployment_branch = 'release',
   $ci_new_jenkins_api_key = undef,
 ) {
   file { '/etc/jenkins_jobs/jobs/deploy_licensify.yaml':

--- a/modules/govuk_jenkins/templates/jobs/deploy_licensify.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_licensify.yaml.erb
@@ -5,7 +5,7 @@
         - git:
             url: git@github.gds:gds/alphagov-deployment.git
             branches:
-              - <%= @alphagov_deployment_branch %>
+              - master
             wipe-workspace: false
 
 - job:


### PR DESCRIPTION
This mirrors the way all of our other apps are deployed.