### PR TITLE
Remove  s3 Backup lvm Config

### DIFF
--- a/hieradata/class/licensify_mongo.yaml
+++ b/hieradata/class/licensify_mongo.yaml
@@ -18,10 +18,6 @@ lv:
   encrypted:
     pv: '/dev/sdc1'
     vg: 'mongodb'
-  s3backups:
-    pv: '/dev/sdd1'
-    vg: 'mongo'
-
 mount:
   /mnt/encrypted:
     disk: '/dev/mapper/mongodb-encrypted'
@@ -30,10 +26,6 @@ mount:
   /var/lib/automongodbbackup:
     disk: '/dev/mapper/backup-mongodb'
     govuk_lvm: 'mongodb'
-    mountoptions: 'defaults'
-  /var/lib/s3backup:
-    disk: '/dev/mapper/mongo-s3backups'
-    govuk_lvm: 's3backups'
     mountoptions: 'defaults'
 
 mongodb::server::replicaset_members:

--- a/modules/govuk/manifests/node/s_licensify_mongo.pp
+++ b/modules/govuk/manifests/node/s_licensify_mongo.pp
@@ -34,5 +34,4 @@ class govuk::node::s_licensify_mongo (
   }
 
   Govuk_mount['/var/lib/automongodbbackup'] -> Class['mongodb::backup']
-  Govuk_mount['/var/lib/s3backup'] -> Class['mongodb::backup']
 }


### PR DESCRIPTION
Licensify data does not need to be backed up to s3.  This config was added in error.