### PR TITLE
Run unattended-upgrades on the dev VM as part of the puppet run

### DIFF
--- a/modules/govuk/manifests/node/s_development.pp
+++ b/modules/govuk/manifests/node/s_development.pp
@@ -151,4 +151,14 @@ class govuk::node::s_development (
     'vegeta':         ensure => installed; # vegeta is used by the router test suite
     'mawk-1.3.4':     ensure => installed; # Provides /opt/mawk required by pre-transition-stats
   }
+
+  exec { 'unattended_upgrades':
+    command => '/usr/bin/unattended-upgrades',
+    require => Notify['unattended_upgrades'],
+  }
+
+  notify { 'unattended_upgrades':
+    message  => 'Updating apt packages',
+  }
+
 }


### PR DESCRIPTION
When we run govuk_puppet on a dev VM we expect that it will update all
the managed software on the machine, however for package updates it
relies on unattended-upgrades to actually perform the updates.  These
are set to run at some small hour in the morning, but most dev VMs are
not powered on at this time, so the updates don't actually run.

We noticed this when postgres 9.3.14 came out which introduced a breaking
change to the `\connect` line in sql dumps.  The servers were upgraded
but most dev VMs weren't and so replicating data generated on the servers
running 9.3.14 would silently fail when run on the dev VMs running 9.3.12.

See https://github.gds/gds/development/pull/334 for some extra context on the change.

I fully expect that this isn't the correct way to invoke the run, or that some other approach would be better.  Please chip in with better ideas.