### PR TITLE
Jenkins job to check Publishing API validity

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -123,6 +123,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::network_config_deploy
   - govuk_jenkins::job::passive_checks
   - govuk_jenkins::job::performance_platform_smokey
+  - govuk_jenkins::job::publishing_api_check_validity
   - govuk_jenkins::job::run_rake_task
   - govuk_jenkins::job::run_whitehall_data_migrations
   - govuk_jenkins::job::sanitize_publishing_api_data

--- a/modules/govuk_jenkins/manifests/job/publishing_api_check_validity.pp
+++ b/modules/govuk_jenkins/manifests/job/publishing_api_check_validity.pp
@@ -1,0 +1,14 @@
+# == Class: govuk_jenkins::job::publishing_api_check_validity
+#
+# Create a jenkins job to check the validity of data within the Publishing API
+#
+#
+# === Parameters:
+#
+class govuk_jenkins::job::publishing_api_check_validity {
+  file { '/etc/jenkins_jobs/jobs/publishing_api_check_validity.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/publishing_api_check_validity.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+}

--- a/modules/govuk_jenkins/templates/jobs/publishing_api_check_validity.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/publishing_api_check_validity.yaml.erb
@@ -1,0 +1,17 @@
+---
+- job:
+    name: Publishing_API_Check_Validity
+    display-name: Publishing_API_Check_Validity
+    project-type: freestyle
+    description: "This job checks the data within the Publishing API for any invalid data"
+    logrotate:
+      artifactNumToKeep: 10
+    publishers:
+        - trigger-parameterized-builds:
+          - project: run-rake-task
+            predefined-parameters: |
+              TARGET_APPLICATION=publishing-api
+              MACHINE_CLASS=backend
+              RAKE_TASK=duplicate_content_items:all
+    triggers:
+        - timed: 'H 5 * * *'


### PR DESCRIPTION
This is a Jenkins job that should _hopefully_ fire off the run rake task build each day for the Publishing API.

I confess I worked out the syntax for the yaml file based off the other files and am unsure if it has any problems not having a `builders` attribute like all the other ones in the directory have.