### PR TITLE
Make Nginx proxy with HTTP/1.1 for Licensing

### DIFF
--- a/modules/govuk/manifests/app.pp
+++ b/modules/govuk/manifests/app.pp
@@ -253,6 +253,10 @@
 # Configure the amount of time the nginx proxy vhost will wait for the
 # backing app before it sends the client a 504. It defaults to 15 seconds.
 #
+# [*proxy_http_version_1_1_enabled*]
+#   Boolean, whether to enable HTTP/1.1 for proxying from the Nginx vhost
+#   to the app server.
+#
 define govuk::app (
   $app_type,
   $port = 0,
@@ -288,6 +292,7 @@ define govuk::app (
   $hasrestart = false,
   $depends_on_nfs = false,
   $read_timeout = 15,
+  $proxy_http_version_1_1_enabled = false,
 ) {
 
   if ! ($app_type in ['procfile', 'rack', 'bare']) {
@@ -324,39 +329,40 @@ define govuk::app (
   }
 
   govuk::app::config { $title:
-    ensure                    => $ensure,
-    require                   => Govuk::App::Package[$title],
-    app_type                  => $app_type,
-    command                   => $command,
-    create_pidfile            => $create_pidfile,
-    domain                    => $app_domain,
-    port                      => $port,
-    custom_http_host          => $custom_http_host,
-    vhost_aliases             => $vhost_aliases,
-    vhost_full                => $vhost_full,
-    vhost_protected           => $vhost_protected,
-    vhost_ssl_only            => $vhost_ssl_only,
-    nginx_extra_config        => $nginx_extra_config,
-    nginx_extra_app_config    => $nginx_extra_app_config,
-    health_check_path         => $health_check_path,
-    expose_health_check       => $expose_health_check,
-    json_health_check         => $json_health_check,
-    intercept_errors          => $intercept_errors,
-    deny_framing              => $deny_framing,
-    enable_nginx_vhost        => $enable_nginx_vhost,
-    logstream                 => $logstream,
-    nagios_cpu_warning        => $nagios_cpu_warning,
-    nagios_cpu_critical       => $nagios_cpu_critical,
-    nagios_memory_warning     => $nagios_memory_warning,
-    nagios_memory_critical    => $nagios_memory_critical,
-    alert_5xx_warning_rate    => $alert_5xx_warning_rate,
-    alert_5xx_critical_rate   => $alert_5xx_critical_rate,
-    unicorn_herder_timeout    => $unicorn_herder_timeout,
-    upstart_post_start_script => $upstart_post_start_script,
-    asset_pipeline            => $asset_pipeline,
-    asset_pipeline_prefix     => $asset_pipeline_prefix,
-    depends_on_nfs            => $depends_on_nfs,
-    read_timeout              => $read_timeout,
+    ensure                         => $ensure,
+    require                        => Govuk::App::Package[$title],
+    app_type                       => $app_type,
+    command                        => $command,
+    create_pidfile                 => $create_pidfile,
+    domain                         => $app_domain,
+    port                           => $port,
+    custom_http_host               => $custom_http_host,
+    vhost_aliases                  => $vhost_aliases,
+    vhost_full                     => $vhost_full,
+    vhost_protected                => $vhost_protected,
+    vhost_ssl_only                 => $vhost_ssl_only,
+    nginx_extra_config             => $nginx_extra_config,
+    nginx_extra_app_config         => $nginx_extra_app_config,
+    health_check_path              => $health_check_path,
+    expose_health_check            => $expose_health_check,
+    json_health_check              => $json_health_check,
+    intercept_errors               => $intercept_errors,
+    deny_framing                   => $deny_framing,
+    enable_nginx_vhost             => $enable_nginx_vhost,
+    logstream                      => $logstream,
+    nagios_cpu_warning             => $nagios_cpu_warning,
+    nagios_cpu_critical            => $nagios_cpu_critical,
+    nagios_memory_warning          => $nagios_memory_warning,
+    nagios_memory_critical         => $nagios_memory_critical,
+    alert_5xx_warning_rate         => $alert_5xx_warning_rate,
+    alert_5xx_critical_rate        => $alert_5xx_critical_rate,
+    unicorn_herder_timeout         => $unicorn_herder_timeout,
+    upstart_post_start_script      => $upstart_post_start_script,
+    asset_pipeline                 => $asset_pipeline,
+    asset_pipeline_prefix          => $asset_pipeline_prefix,
+    depends_on_nfs                 => $depends_on_nfs,
+    read_timeout                   => $read_timeout,
+    proxy_http_version_1_1_enabled => $proxy_http_version_1_1_enabled,
   }
 
   govuk::app::service { $title:

--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -12,6 +12,10 @@
 # [*nagios_memory_critical*]
 #   Memory use, in MB, at which Nagios should generate a critical alert.
 #
+# [*proxy_http_version_1_1_enabled*]
+#   Boolean, whether to enable HTTP/1.1 for proxying from the Nginx vhost
+#   to the app server.
+#
 define govuk::app::config (
   $app_type,
   $domain,
@@ -45,6 +49,7 @@ define govuk::app::config (
   $ensure = 'present',
   $depends_on_nfs = false,
   $read_timeout = 15,
+  $proxy_http_version_1_1_enabled = false,
 ) {
   $ensure_directory = $ensure ? {
     'present' => 'directory',
@@ -175,24 +180,25 @@ define govuk::app::config (
 
     # Expose this application from nginx
     govuk::app::nginx_vhost { $title:
-      ensure                  => $ensure,
-      vhost                   => $vhost_full,
-      aliases                 => $vhost_aliases_real,
-      protected               => $vhost_protected,
-      custom_http_host        => $custom_http_host,
-      app_port                => $port,
-      ssl_only                => $vhost_ssl_only,
-      nginx_extra_config      => $nginx_extra_config,
-      nginx_extra_app_config  => $nginx_extra_app_config,
-      intercept_errors        => $intercept_errors,
-      deny_framing            => $deny_framing,
-      logstream               => $logstream,
-      asset_pipeline          => $asset_pipeline,
-      asset_pipeline_prefix   => $asset_pipeline_prefix,
-      hidden_paths            => $hidden_paths,
-      read_timeout            => $read_timeout,
-      alert_5xx_warning_rate  => $alert_5xx_warning_rate,
-      alert_5xx_critical_rate => $alert_5xx_critical_rate,
+      ensure                         => $ensure,
+      vhost                          => $vhost_full,
+      aliases                        => $vhost_aliases_real,
+      protected                      => $vhost_protected,
+      custom_http_host               => $custom_http_host,
+      app_port                       => $port,
+      ssl_only                       => $vhost_ssl_only,
+      nginx_extra_config             => $nginx_extra_config,
+      nginx_extra_app_config         => $nginx_extra_app_config,
+      intercept_errors               => $intercept_errors,
+      deny_framing                   => $deny_framing,
+      logstream                      => $logstream,
+      asset_pipeline                 => $asset_pipeline,
+      asset_pipeline_prefix          => $asset_pipeline_prefix,
+      hidden_paths                   => $hidden_paths,
+      read_timeout                   => $read_timeout,
+      alert_5xx_warning_rate         => $alert_5xx_warning_rate,
+      alert_5xx_critical_rate        => $alert_5xx_critical_rate,
+      proxy_http_version_1_1_enabled => $proxy_http_version_1_1_enabled,
     }
   }
   $title_underscore = regsubst($title, '\.', '_', 'G')

--- a/modules/govuk/manifests/app/nginx_vhost.pp
+++ b/modules/govuk/manifests/app/nginx_vhost.pp
@@ -71,6 +71,10 @@
 # [*alert_5xx_critical_rate*]
 #   The error percentage that triggers a critical alert
 #
+# [*proxy_http_version_1_1_enabled*]
+#   Boolean, whether to enable HTTP/1.1 for proxying from the Nginx vhost
+#   to the app server.
+#
 define govuk::app::nginx_vhost (
   $vhost,
   $app_port,
@@ -93,6 +97,7 @@ define govuk::app::nginx_vhost (
   $ensure = 'present',
   $alert_5xx_warning_rate = 0.05,
   $alert_5xx_critical_rate = 0.1,
+  $proxy_http_version_1_1_enabled = false,
 ) {
 
   # added to whitelist in lib/puppet-lint/plugins/check_hiera.rb
@@ -110,23 +115,24 @@ define govuk::app::nginx_vhost (
   }
 
   nginx::config::vhost::proxy { $vhost:
-    ensure                  => $ensure,
-    to                      => ["localhost:${app_port}"],
-    aliases                 => $aliases,
-    protected               => $protected,
-    protected_location      => $protected_location,
-    ssl_only                => $ssl_only,
-    logstream               => $logstream,
-    extra_config            => $nginx_extra_config_real,
-    extra_app_config        => $nginx_extra_app_config,
-    intercept_errors        => $intercept_errors,
-    deny_framing            => $deny_framing,
-    custom_http_host        => $custom_http_host,
-    is_default_vhost        => $is_default_vhost,
-    hidden_paths            => $hidden_paths,
-    single_page_app         => $single_page_app,
-    read_timeout            => $read_timeout,
-    alert_5xx_warning_rate  => $alert_5xx_warning_rate,
-    alert_5xx_critical_rate => $alert_5xx_critical_rate,
+    ensure                         => $ensure,
+    to                             => ["localhost:${app_port}"],
+    aliases                        => $aliases,
+    protected                      => $protected,
+    protected_location             => $protected_location,
+    ssl_only                       => $ssl_only,
+    logstream                      => $logstream,
+    extra_config                   => $nginx_extra_config_real,
+    extra_app_config               => $nginx_extra_app_config,
+    intercept_errors               => $intercept_errors,
+    deny_framing                   => $deny_framing,
+    custom_http_host               => $custom_http_host,
+    is_default_vhost               => $is_default_vhost,
+    hidden_paths                   => $hidden_paths,
+    single_page_app                => $single_page_app,
+    read_timeout                   => $read_timeout,
+    alert_5xx_warning_rate         => $alert_5xx_warning_rate,
+    alert_5xx_critical_rate        => $alert_5xx_critical_rate,
+    proxy_http_version_1_1_enabled => $proxy_http_version_1_1_enabled,
   }
 }

--- a/modules/licensify/manifests/apps/licensify.pp
+++ b/modules/licensify/manifests/apps/licensify.pp
@@ -8,11 +8,12 @@ class licensify::apps::licensify (
 ) inherits licensify::apps::base {
 
   govuk::app { 'licensify':
-    app_type           => 'procfile',
-    port               => $port,
-    nginx_extra_config => template('licensify/nginx_extra'),
-    health_check_path  => '/api/licences',
-    require            => File['/etc/licensing'],
+    app_type                       => 'procfile',
+    port                           => $port,
+    nginx_extra_config             => template('licensify/nginx_extra'),
+    health_check_path              => '/api/licences',
+    require                        => File['/etc/licensing'],
+    proxy_http_version_1_1_enabled => true,
   }
 
   licensify::apps::envvars { 'licensify':

--- a/modules/licensify/manifests/apps/licensify_admin.pp
+++ b/modules/licensify/manifests/apps/licensify_admin.pp
@@ -8,10 +8,11 @@ class licensify::apps::licensify_admin(
 ) inherits licensify::apps::base {
 
   govuk::app { 'licensify-admin':
-    app_type          => 'procfile',
-    port              => $port,
-    health_check_path => '/login',
-    require           => File['/etc/licensing'],
+    app_type                       => 'procfile',
+    port                           => $port,
+    health_check_path              => '/login',
+    require                        => File['/etc/licensing'],
+    proxy_http_version_1_1_enabled => true,
   }
 
   licensify::apps::envvars { 'licensify-admin':

--- a/modules/licensify/manifests/apps/licensify_feed.pp
+++ b/modules/licensify/manifests/apps/licensify_feed.pp
@@ -8,10 +8,11 @@ class licensify::apps::licensify_feed(
 ) inherits licensify::apps::base {
 
   govuk::app { 'licensify-feed':
-    app_type        => 'procfile',
-    port            => $port,
-    vhost_protected => true,
-    require         => File['/etc/licensing'],
+    app_type                       => 'procfile',
+    port                           => $port,
+    vhost_protected                => true,
+    require                        => File['/etc/licensing'],
+    proxy_http_version_1_1_enabled => true,
   }
 
   licensify::apps::envvars { 'licensify-feed':

--- a/modules/nginx/manifests/config/vhost/proxy.pp
+++ b/modules/nginx/manifests/config/vhost/proxy.pp
@@ -75,6 +75,10 @@
 # [*alert_5xx_critical_rate*]
 #   The error percentage that triggers a critical alert
 #
+# [*proxy_http_version_1_1_enabled*]
+#   Boolean, whether to enable HTTP/1.1 for proxying from the Nginx vhost
+#   to the app server.
+#
 define nginx::config::vhost::proxy(
   $to,
   $to_ssl = false,
@@ -97,6 +101,7 @@ define nginx::config::vhost::proxy(
   $ensure = 'present',
   $alert_5xx_warning_rate = 0.05,
   $alert_5xx_critical_rate = 0.1,
+  $proxy_http_version_1_1_enabled = false,
 ) {
   validate_re($ensure, '^(absent|present)$', 'Invalid ensure value')
 

--- a/modules/nginx/templates/proxy-vhost.conf
+++ b/modules/nginx/templates/proxy-vhost.conf
@@ -40,6 +40,10 @@ server {
   listen 80<%= $is_default_vhost ? " default_server" : "" %>;
   <%- end -%>
 
+  <%- if proxy_http_version_1_1_enabled == true -%>
+  proxy_http_version 1.1;
+
+  <%- end -%>
   proxy_set_header Host <%= @custom_http_host || '$http_host' %>;
   proxy_set_header X-Real-IP $remote_addr;
   proxy_set_header X-Forwarded-Server $host;


### PR DESCRIPTION
This commit adds a feature flag so that Nginx on the app servers can proxy to the Licensing app on localhost using HTTP/1.1.

Nginx docs:

> By default, version 1.0 is used. Version 1.1 is recommended for use with keepalive connections and NTLM authentication.

http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_http_version

Licensing has been upgraded to a new version of Scala/Play which is picky about which HTTP version it needs (because it uses chunked responses for file downloads).