### PR TITLE
Avoid installing Ruby 2.3.1 on non-`trusty` machines.

### DIFF
--- a/modules/govuk_rbenv/manifests/all.pp
+++ b/modules/govuk_rbenv/manifests/all.pp
@@ -60,10 +60,16 @@ class govuk_rbenv::all (
   rbenv::version { '2.3.0':
     bundler_version => '1.11.2',
   }
-  rbenv::version { '2.3.1':
-    bundler_version => '1.11.2',
-  }
-  rbenv::alias { '2.3':
-    to_version => '2.3.1',
+  if $::lsbdistcodename == 'trusty' {
+    rbenv::version { '2.3.1':
+      bundler_version => '1.11.2',
+    }
+    rbenv::alias { '2.3':
+      to_version => '2.3.1',
+    }
+  } else {
+    rbenv::alias { '2.3':
+      to_version => '2.3.0',
+    }
   }
 }


### PR DESCRIPTION
This package is not available for `precise`
machines and the only Ruby code we have running on
them is EFG which currently uses 2.1.4.