### PR TITLE
Bugfix mysql backups

### DIFF
--- a/modules/govuk_mysql/templates/usr/local/bin/xtrabackup_s3_base.erb
+++ b/modules/govuk_mysql/templates/usr/local/bin/xtrabackup_s3_base.erb
@@ -19,7 +19,7 @@ function nagios_passive () {
 trap nagios_passive EXIT
 
 # Set a new backup date
-date +%Y%m%d-%H%M > /var/lib/mysql/xtrabackup_date
+date +%Y%m%d-%H%M%S > /var/lib/mysql/xtrabackup_date
 
 # Copy the latest backup into a temporary filename
 innobackupex --extra-lsndir='/var/lib/mysql/' --encrypt=AES256 --encrypt-key="<%= @encryption_key %>" --stream=xbstream --compress . | envdir /etc/mysql/xtrabackup/env.d /usr/local/bin/gof3r put --endpoint s3-<%= @aws_region -%>.amazonaws.com -b <%= @s3_bucket_name %> -k latest/$TMPNAME

--- a/modules/govuk_mysql/templates/usr/local/bin/xtrabackup_s3_base.erb
+++ b/modules/govuk_mysql/templates/usr/local/bin/xtrabackup_s3_base.erb
@@ -32,7 +32,7 @@ innobackupex --extra-lsndir='/var/lib/mysql/' --encrypt=AES256 --encrypt-key="<%
 
 # If a previous backup exists then move it to an archive directory
 if $BACKUPEXIST; then
-  envdir /etc/mysql/xtrabackup/env.d /usr/local/bin/s3cmd mv --recursive s3://<%= @s3_bucket_name %>/latest/base.xbcrypt s3://<%= @s3_bucket_name %>/$(cat /var/lib/mysql/xtrabackup_date)/base.xbcrypt
+  envdir /etc/mysql/xtrabackup/env.d /usr/local/bin/s3cmd mv --recursive s3://<%= @s3_bucket_name %>/latest/base.xbcrypt s3://<%= @s3_bucket_name %>/$(cat /var/lib/mysql/xtrabackup_date)/base.xbcrypt || echo "No previous backup found for archiving"
 fi
 
 # Rename the temporary backup to a name used by the restore method

--- a/modules/govuk_mysql/templates/usr/local/bin/xtrabackup_s3_base.erb
+++ b/modules/govuk_mysql/templates/usr/local/bin/xtrabackup_s3_base.erb
@@ -18,12 +18,6 @@ function nagios_passive () {
 
 trap nagios_passive EXIT
 
-# Mark if a backup has already been taken
-BACKUPEXIST=false
-if [ -e /var/lib/mysql/xtrabackup_date ]; then
-  BACKUPEXIST=true
-fi
-
 # Set a new backup date
 date +%Y%m%d-%H%M > /var/lib/mysql/xtrabackup_date
 
@@ -31,9 +25,7 @@ date +%Y%m%d-%H%M > /var/lib/mysql/xtrabackup_date
 innobackupex --extra-lsndir='/var/lib/mysql/' --encrypt=AES256 --encrypt-key="<%= @encryption_key %>" --stream=xbstream --compress . | envdir /etc/mysql/xtrabackup/env.d /usr/local/bin/gof3r put --endpoint s3-<%= @aws_region -%>.amazonaws.com -b <%= @s3_bucket_name %> -k latest/$TMPNAME
 
 # If a previous backup exists then move it to an archive directory
-if $BACKUPEXIST; then
-  envdir /etc/mysql/xtrabackup/env.d /usr/local/bin/s3cmd mv --recursive s3://<%= @s3_bucket_name %>/latest/base.xbcrypt s3://<%= @s3_bucket_name %>/$(cat /var/lib/mysql/xtrabackup_date)/base.xbcrypt || echo "No previous backup found for archiving"
-fi
+envdir /etc/mysql/xtrabackup/env.d /usr/local/bin/s3cmd mv --recursive s3://<%= @s3_bucket_name %>/latest/base.xbcrypt s3://<%= @s3_bucket_name %>/$(cat /var/lib/mysql/xtrabackup_date)/base.xbcrypt || echo "No previous backup found for archiving"
 
 # Rename the temporary backup to a name used by the restore method
 envdir /etc/mysql/xtrabackup/env.d /usr/local/bin/s3cmd mv --recursive s3://<%= @s3_bucket_name %>/latest/$TMPNAME s3://<%= @s3_bucket_name %>/latest/base.xbcrypt

--- a/modules/govuk_mysql/templates/usr/local/bin/xtrabackup_s3_incremental.erb
+++ b/modules/govuk_mysql/templates/usr/local/bin/xtrabackup_s3_incremental.erb
@@ -18,22 +18,19 @@ function nagios_passive () {
 
 trap nagios_passive EXIT
 
-# Mark if a backup has already been taken
-BACKUPEXIST=false
+# Mark if a base backup has ever been taken
 if [ -e /var/lib/mysql/xtrabackup_date ]; then
-  BACKUPEXIST=true
-fi
 
-# Copy the latest incremental backup into a temporary filename
-innobackupex --incremental-basedir='/var/lib/mysql/' --encrypt=AES256 --encrypt-key="<%= @encryption_key %>" --stream=xbstream --compress --incremental . | envdir /etc/mysql/xtrabackup/env.d /usr/local/bin/gof3r put --endpoint s3-<%= @aws_region -%>.amazonaws.com -b <%= @s3_bucket_name %> -k latest/$TMPNAME
+  # Copy the latest incremental backup into a temporary filename
+  innobackupex --incremental-basedir='/var/lib/mysql/' --encrypt=AES256 --encrypt-key="<%= @encryption_key %>" --stream=xbstream --compress --incremental . | envdir /etc/mysql/xtrabackup/env.d /usr/local/bin/gof3r put --endpoint s3-<%= @aws_region -%>.amazonaws.com -b <%= @s3_bucket_name %> -k latest/$TMPNAME
 
-# If a previous backup exists then move it to an archive directory
-if $BACKUPEXIST; then
+  # If a previous backup exists then move it to an archive directory
   envdir /etc/mysql/xtrabackup/env.d /usr/local/bin/s3cmd mv s3://<%= @s3_bucket_name %>/latest/incremental.xbcrypt s3://<%= @s3_bucket_name %>/$(cat /var/lib/mysql/xtrabackup_date)/incremental-$(date +%Y%m%d-%H%M).xbcrypt || echo "No previous backup found for archiving"
-fi
 
-# Rename the temporary backup to a name used by the restore method
-envdir /etc/mysql/xtrabackup/env.d /usr/local/bin/s3cmd mv s3://<%= @s3_bucket_name %>/latest/$TMPNAME s3://<%= @s3_bucket_name %>/latest/incremental.xbcrypt
+  # Rename the temporary backup to a name used by the restore method
+  envdir /etc/mysql/xtrabackup/env.d /usr/local/bin/s3cmd mv s3://<%= @s3_bucket_name %>/latest/$TMPNAME s3://<%= @s3_bucket_name %>/latest/incremental.xbcrypt
+
+fi
 
 if [ $? == 0 ]
   then

--- a/modules/govuk_mysql/templates/usr/local/bin/xtrabackup_s3_incremental.erb
+++ b/modules/govuk_mysql/templates/usr/local/bin/xtrabackup_s3_incremental.erb
@@ -29,7 +29,7 @@ innobackupex --incremental-basedir='/var/lib/mysql/' --encrypt=AES256 --encrypt-
 
 # If a previous backup exists then move it to an archive directory
 if $BACKUPEXIST; then
-  envdir /etc/mysql/xtrabackup/env.d /usr/local/bin/s3cmd mv s3://<%= @s3_bucket_name %>/latest/incremental.xbcrypt s3://<%= @s3_bucket_name %>/$(cat /var/lib/mysql/xtrabackup_date)/incremental-$(date +%Y%m%d-%H%M).xbcrypt
+  envdir /etc/mysql/xtrabackup/env.d /usr/local/bin/s3cmd mv s3://<%= @s3_bucket_name %>/latest/incremental.xbcrypt s3://<%= @s3_bucket_name %>/$(cat /var/lib/mysql/xtrabackup_date)/incremental-$(date +%Y%m%d-%H%M).xbcrypt || echo "No previous backup found for archiving"
 fi
 
 # Rename the temporary backup to a name used by the restore method


### PR DESCRIPTION
This PR adds various bugfixes to the MySQL S3 backup scripts.

It ensures the script doesn't bomb out if there is no file for archiving, fixing incorrect logic for checking if a backup already exists. 

Detail within commit messages.