### PR TITLE
Use file/directory_ensure for unattended reboots

### DIFF
--- a/modules/govuk_unattended_reboot/manifests/init.pp
+++ b/modules/govuk_unattended_reboot/manifests/init.pp
@@ -69,14 +69,14 @@ class govuk_unattended_reboot (
   $lock_dir = "${config_directory}/no-reboot"
 
   file { $lock_dir:
-    ensure => directory,
+    ensure => $directory_ensure,
     mode   => '0777',
     owner  => 'root',
     group  => 'root',
   }
 
   file { '03_no_reboot':
-    ensure  => file,
+    ensure  => $file_ensure,
     path    => "${check_scripts_directory}/03_no_reboot",
     mode    => '0755',
     owner   => 'root',


### PR DESCRIPTION
We defined these at the top of the file to match whether the class is enabled or not. Puppet will fail in cases where the `config_directory` doesn't exist (eg new development VMs).

/cc @h-lame @jennyd 