### PR TITLE
Update release name for PostgreSQL repo

### DIFF
--- a/modules/govuk_postgresql/manifests/mirror.pp
+++ b/modules/govuk_postgresql/manifests/mirror.pp
@@ -7,7 +7,7 @@ class govuk_postgresql::mirror (
 ) {
   apt::source { 'postgresql':
     location     => "http://${apt_mirror_hostname}/postgresql",
-    release      => $::lsbdistcodename,
+    release      => "${::lsbdistcodename}-pgdg",
     architecture => $::architecture,
     key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
   }


### PR DESCRIPTION
The actual repository name is mirrored as:
http://apt.publishing.service.gov.uk/postgresql/dists/trusty-pgdg/main/binary-amd64/Packages

This updates the apt source to correctly add it.