### PR TITLE
Remove backup for licensing mongo

### DIFF
--- a/modules/govuk/manifests/node/s_backup.pp
+++ b/modules/govuk/manifests/node/s_backup.pp
@@ -50,12 +50,6 @@ class govuk::node::s_backup (
     }
   }
 
-  backup::directory {'backup_mongodb_backups_licensify_mongo':
-    directory => '/var/lib/automongodbbackup/',
-    fq_dn     => "licensing-mongo-1.licensify.${app_domain}",
-    priority  => '002',
-  }
-
   if $backup_email_campaign {
     backup::directory {'backup_mongodb_backups_email_campaign_mongo':
       directory => '/var/lib/automongodbbackup/',


### PR DESCRIPTION
In commit 0e3cc049da5097d039881f7ff560cd92e4e825cb, we disabled the auto mongo db
backup for licensing, but were still trying to collect a backup that does not
exist.