### PR TITLE
Change unified_search to search

### DIFF
--- a/modules/govuk/manifests/apps/rummager.pp
+++ b/modules/govuk/manifests/apps/rummager.pp
@@ -69,7 +69,7 @@ class govuk::apps::rummager(
   govuk::app { 'rummager':
     app_type               => 'rack',
     port                   => $port,
-    health_check_path      => '/unified_search?q=search_healthcheck',
+    health_check_path      => '/search?q=search_healthcheck',
 
     # support search as an alias for ease of migration from old
     # cluster running in backend VDC.

--- a/modules/govuk/templates/publicapi_nginx_extra_config.erb
+++ b/modules/govuk/templates/publicapi_nginx_extra_config.erb
@@ -27,7 +27,7 @@
   location ~ ^/api/search.json {
     expires 30m;
 
-    rewrite ^/api/search.json(.*) /unified_search.json$1 break;
+    rewrite ^/api/search.json(.*) /search.json$1 break;
 
     proxy_set_header Host <%= @rummager_api %>;
     proxy_set_header API-PREFIX api;


### PR DESCRIPTION
This commit changes the nginx config to point all external requests for `/api/search.json` to the rummager endpoint `/search.json` rather than `/unified_search.json`. This provides consistency between the internal and external APIs in terms of naming.

See https://github.com/alphagov/rummager/pull/694 for the equivalent changes to rummager.

Trello: https://trello.com/c/cj8UX2jX