### PR TITLE
Enable rummager publishing listener in development

### DIFF
--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -155,8 +155,8 @@ govuk::apps::router_api::mongodb_nodes: ['localhost']
 govuk::apps::router_api::router_nodes: ['localhost:3055']
 govuk::apps::rummager::enable_procfile_worker: false
 govuk::apps::rummager::rabbitmq_hosts: ['localhost']
-govuk::apps::rummager::enable_publishing_listener: false
-govuk::apps::rummager::rabbitmq::enable_publishing_listener: false
+govuk::apps::rummager::enable_publishing_listener: true
+govuk::apps::rummager::rabbitmq::enable_publishing_listener: true
 govuk::apps::rummager::redis_host: 'localhost'
 govuk::apps::share_sale_publisher::enabled: true
 govuk::apps::share_sale_publisher::mongodb_nodes: ['localhost']


### PR DESCRIPTION
This enables the creation of the permissions and queues in RabbitMQ.
If we enable these, we should also enable the listener in order to
not let the queue back up with unprocessed messages.

/cc @tijmenb 