### PR TITLE
Change notes_url in alerts to docs about onsite backups

### DIFF
--- a/modules/backup/manifests/directory.pp
+++ b/modules/backup/manifests/directory.pp
@@ -42,6 +42,6 @@ define backup::directory (
       host_name           => $::fqdn,
       freshness_threshold => $threshold_secs,
       action_url          => 'https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/#!searchin/machine.email.carrenza/backup-1$20run-parts$20$2Fetc$2Fbackup$2Fdaily%7Csort:date',
-      notes_url           => monitoring_docs_url(offsite-backups),
+      notes_url           => monitoring_docs_url(onsite-backups),
     }
 }


### PR DESCRIPTION
Change notes_url to point to new section in the opsmanual about onsite backups.

See comments in PR: https://github.gds/gds/opsmanual/pull/786