### PR TITLE
Revert "Blacklist DFID research outputs from the mirrors"

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -310,7 +310,6 @@ govuk::apps::govuk_crawler_worker::blacklist_paths:
   - '/api/'
   - '/apply-for-a-licence'
   - '/business-finance-support-finder'
-  - '/dfid-research-outputs/'
   - '/drug-device-alerts.atom'
   - '/drug-safety-update.atom'
   - '/foreign-travel-advice.atom'


### PR DESCRIPTION
[Trello](https://trello.com/c/PVT5Fnpd/255-truncate-over-length-dfid-urls-medium)
- This reverts commit 58436801425471857002296f138c23c2849bc19c.
- Previously, when the crawler tried to back up DFID pages with long urls, it failed because the filenames were too long for the filesystem it backed up to
- Specialist Publisher team have ensured that urls are now truncated to max 250 chars on creation of a new document. A script has been run on all environments to truncate the DFID urls that were too long. Commit [here](https://github.com/alphagov/specialist-publisher-rebuild/commit/a08962f39b54fcda46d94d91b8f1171ec4c47aff). 
- As a result, we no longer need to blacklist `/dfid-research-outputs`.