### PR TITLE
Adds assets-origin (the asset root) to /etc/hosts

### DIFF
--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -233,6 +233,7 @@ govuk_unattended_reboot::mongodb::enabled: false
 govuk_unattended_reboot::elasticsearch::enabled: false
 
 hosts::development::apps:
+  - 'assets-origin'
   - 'asset-manager'
   - 'bouncer'
   - 'backdrop-write'


### PR DESCRIPTION
When testing government-frontend and trying to run internal tests
the assets root does not resolve properly on the development vm

Service Manual team also encountered the same and used a work around https://github.com/alphagov/service-manual-frontend/pull/37/files#diff-04c6e90faac2675aa89e2176d2eec7d8R41

I'm not sure if adding this to apps does anything else than just add it to hosts, so not sure if this is the right place?