### PR TITLE
Only enable postgresql mirror for trusty

### DIFF
--- a/modules/govuk_postgresql/manifests/mirror.pp
+++ b/modules/govuk_postgresql/manifests/mirror.pp
@@ -5,10 +5,12 @@
 class govuk_postgresql::mirror (
   $apt_mirror_hostname = undef,
 ) {
-  apt::source { 'postgresql':
-    location     => "http://${apt_mirror_hostname}/postgresql",
-    release      => "${::lsbdistcodename}-pgdg",
-    architecture => $::architecture,
-    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+  if $::lsbdistcodename == 'trusty' {
+    apt::source { 'postgresql':
+      location     => "http://${apt_mirror_hostname}/postgresql",
+      release      => "${::lsbdistcodename}-pgdg",
+      architecture => $::architecture,
+      key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+    }
   }
 }


### PR DESCRIPTION
We don't need the mirror on precise machines, and *if* we add Xenial machines in the future the version of PostgreSQL we need the mirror for is available by default, so only enable it for trusty machines.