### PR TITLE
Mongodb s3 Restore 8

### DIFF
--- a/modules/mongodb/templates/mongodb-restore-s3.erb
+++ b/modules/mongodb/templates/mongodb-restore-s3.erb
@@ -14,7 +14,7 @@ cd $BACKUP_DIR
 TIME="$(date +%s)"
 
 # Download and decrypt backup
-  /usr/bin/envdir <%= @env_dir %>/env.d /usr/local/bin/s3cmd get --force `/usr/local/bin/s3cmd ls s3://${S3_BUCKET}/mongodump* | \
+/usr/bin/envdir <%= @env_dir %>/env.d /usr/local/bin/s3cmd get --force `/usr/bin/envdir <%= @env_dir %>/env.d /usr/local/bin/s3cmd ls s3://${S3_BUCKET}/mongodump* | \
   tail -1 | /usr/bin/awk '{print $4}'`| /usr/bin/awk '{print $4}' | /usr/bin/tr -d "'" | \
   /usr/bin/xargs /usr/bin/gpg --yes --quiet --output mongodump.tar.gz --decrypt && /bin/tar xzf mongodump.tar.gz
 
@@ -29,7 +29,7 @@ TIME="$(date +%s)"
   /usr/bin/mongorestore var/ > /dev/null
 
 # Tidy up
-  /bin/rm -rf var/ mongodump*
+  /bin/rm -rf mongodump*
 
 TIME="$(($(date +%s)-TIME))"
 /usr/bin/printf "RESTORE COMPLETED IN: ${TIME}s\n"


### PR DESCRIPTION
prefixing 's3cmd' sub-command with 'envdir'.

While verifying the restore script an error occurred stating that there was no '.s3cfg' file.
When invoking s3cmd it performs a lookup for aws auth tokens by checking for cmd-line arguments, env-variables and it's own config '.s3cfg'.
This occured while executing a sub-command that was not prefixed with the envdir command which is how we pass env-varibles.

Removed 'var/' sub-directory as this does not get created outside my testing environment.

This has been tested on a host running MongoDB in integration.