### PR TITLE
Disable backups for exception handler in integration

### DIFF
--- a/hieradata/class/integration/exception_handler.yaml
+++ b/hieradata/class/integration/exception_handler.yaml
@@ -1,0 +1,3 @@
+---
+
+mongodb::backup::enabled: false


### PR DESCRIPTION
The file system does not have enough space to do backups.