### PR TITLE
Tweak Puppet run

### DIFF
--- a/modules/puppet/files/usr/lib/nagios/plugins/check_puppet_agent
+++ b/modules/puppet/files/usr/lib/nagios/plugins/check_puppet_agent
@@ -3,6 +3,8 @@
 require 'json'
 require 'yaml'
 
+WARNING = 1
+
 puppet_agent_summary_filename = "/var/lib/puppet/state/last_run_summary.yaml"
 puppet_agent_disabled_lockfile = "/var/lib/puppet/state/agent_disabled.lock"
 
@@ -11,6 +13,13 @@ if File.file?(puppet_agent_disabled_lockfile)
 
   puts "Puppet is disabled: #{disabled_reason}"
   exit 1
+end
+
+hours_since_last_run = (Time.now - File.mtime(puppet_agent_summary_filename)) / 3600
+
+if hours_since_last_run > 2
+  puts "Puppet has not run in #{hours_since_last_run.to_i} hours"
+  exit WARNING
 end
 
 begin

--- a/modules/puppet/templates/govuk_puppet
+++ b/modules/puppet/templates/govuk_puppet
@@ -8,10 +8,11 @@ fi
 
 START_TIME=`date +%s%3N`
 
+set +e
 RBENV_VERSION=1.9.3 /usr/local/bin/govuk_setenv default puppet agent --onetime --no-daemonize "$@"
+set -e
 
 TIME_TOOK=$((`date +%s%3N`-START_TIME))
 echo "<%= @fqdn_metrics %>.puppet.run_duration:${TIME_TOOK}|ms" | nc -w 1 -u localhost 8125
 
-# We should only reach here if a last_run_summary was written.
 /usr/local/bin/puppet_passive_check_update >/dev/null


### PR DESCRIPTION
In 73b49aa205b7226900ab90510cc2a6616edef865 I tried to get Icinga to
show the reason Puppet is disabled, but I had to remove the check
for exit code 2 on the Puppet run.

Puppet runs can have all kind of exit codes (especially when run with
`--detailed-exitcodes`) so we should probably let every exit code
through and catch problems as part of the script that checks the
run.

I've added an additional check that the run is recent enough.