### PR TITLE
Add alert links for Gor, data sync, Ruby version

### DIFF
--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -291,6 +291,7 @@ define govuk::app::config (
       check_command       => "check_nrpe!check_unicorn_ruby_version!${title}",
       service_description => "${title} is not running the expected ruby version",
       host_name           => $::fqdn,
+      notes_url           => monitoring_docs_url('ruby-version', true),
     }
   }
   @@icinga::check { "check_app_${title}_upstart_up_${::hostname}":

--- a/modules/govuk_gor/manifests/init.pp
+++ b/modules/govuk_gor/manifests/init.pp
@@ -76,5 +76,6 @@ class govuk_gor(
     check_command       => 'check_nrpe!check_proc_running!gor',
     host_name           => $::fqdn,
     service_description => 'gor running',
+    notes_url           => monitoring_docs_url('gor', true),
   }
 }

--- a/modules/govuk_jenkins/manifests/job/copy_data_to_integration.pp
+++ b/modules/govuk_jenkins/manifests/job/copy_data_to_integration.pp
@@ -27,5 +27,6 @@ class govuk_jenkins::job::copy_data_to_integration (
     host_name           => $::fqdn,
     freshness_threshold => 115200,
     action_url          => $job_url,
+    notes_url           => monitoring_docs_url('data-sync', true),
   }
 }

--- a/modules/govuk_jenkins/manifests/job/copy_data_to_staging.pp
+++ b/modules/govuk_jenkins/manifests/job/copy_data_to_staging.pp
@@ -27,5 +27,6 @@ class govuk_jenkins::job::copy_data_to_staging (
     host_name           => $::fqdn,
     freshness_threshold => 115200,
     action_url          => $job_url,
+    notes_url           => monitoring_docs_url('data-sync', true),
   }
 }


### PR DESCRIPTION
These already exist:

- https://github.gds/pages/gds/opsmanual/2nd-line/alerts/gor.html
- https://github.gds/pages/gds/opsmanual/2nd-line/alerts/data-sync.html
- https://github.gds/pages/gds/opsmanual/2nd-line/alerts/ruby-version.html