### PR TITLE
Revert "Upgrade elasticsearch for logs on integration"

### DIFF
--- a/hieradata/class/integration/logs_elasticsearch.yaml
+++ b/hieradata/class/integration/logs_elasticsearch.yaml
@@ -1,3 +1,3 @@
 ---
 
-govuk_elasticsearch::version: '1.7.5'
+govuk_elasticsearch::version: '1.5.2'


### PR DESCRIPTION
Reverts alphagov/govuk-puppet#4840

We did the upgrade which went smoothly, but the redis river stoppped consuming data from redis and it's not clear how to fix it, so we're downgrading for now.  We may have to use a different redis river plugin, or, as rivers are deprecated change our approach entirely. 

Note that downgrading may mean we can no longer read the indexes but as it's integration we'll be able to delete all the data and start again.