### PR TITLE
Bugfix for MySQL backups to S3

### DIFF
--- a/modules/govuk_mysql/templates/usr/local/bin/xtrabackup_s3_base.erb
+++ b/modules/govuk_mysql/templates/usr/local/bin/xtrabackup_s3_base.erb
@@ -25,10 +25,10 @@ date +%Y%m%d-%H%M%S > /var/lib/mysql/xtrabackup_date
 innobackupex --extra-lsndir='/var/lib/mysql/' --encrypt=AES256 --encrypt-key="<%= @encryption_key %>" --stream=xbstream --compress . | envdir /etc/mysql/xtrabackup/env.d /usr/local/bin/gof3r put --endpoint s3-<%= @aws_region -%>.amazonaws.com -b <%= @s3_bucket_name %> -k latest/$TMPNAME
 
 # If a previous backup exists then move it to an archive directory
-envdir /etc/mysql/xtrabackup/env.d /usr/local/bin/s3cmd mv --recursive s3://<%= @s3_bucket_name %>/latest/base.xbcrypt s3://<%= @s3_bucket_name %>/$(cat /var/lib/mysql/xtrabackup_date)/base.xbcrypt || echo "No previous backup found for archiving"
+envdir /etc/mysql/xtrabackup/env.d /usr/local/bin/s3cmd mv s3://<%= @s3_bucket_name %>/latest/base.xbcrypt s3://<%= @s3_bucket_name %>/$(cat /var/lib/mysql/xtrabackup_date)/base.xbcrypt || echo "No previous backup found for archiving"
 
 # Rename the temporary backup to a name used by the restore method
-envdir /etc/mysql/xtrabackup/env.d /usr/local/bin/s3cmd mv --recursive s3://<%= @s3_bucket_name %>/latest/$TMPNAME s3://<%= @s3_bucket_name %>/latest/base.xbcrypt
+envdir /etc/mysql/xtrabackup/env.d /usr/local/bin/s3cmd mv s3://<%= @s3_bucket_name %>/latest/$TMPNAME s3://<%= @s3_bucket_name %>/latest/base.xbcrypt
 
 if [ $? == 0 ]
   then


### PR DESCRIPTION
This commit follows on from e00e8265b8cb0a35ff2e24b123a5428131717b20. This has a failure condition where when it moves the temporary filename to be named "base.xbcrypt", it actually just moves the temporary filename into a directory named "base.xbcrypt". This means that we haven't lost any data, but when we come to restore it would be called a file we don't expect (we call it s3://<bucket>/latest/base.xbcrypt so when we restore we can easily find the latest backup). This seems to happen because of the recursive option being set, and since this option does not seem to be needed for any of the incremental backup tasks, I think we can safely remove this from the base backup task and ensure the condition described above no longer occurs. This removes the `--recursive` flag from the `s3cmd mv` command.

**Note**: I've put a fix in place in Production and disabled Puppet on the machine where this occurs. It's currently breaking and causing files to pile up when they should be archived.