### PR TITLE
Allow multiple procfile processes

### DIFF
--- a/modules/govuk/spec/defines/govuk__procfile__worker_spec.rb
+++ b/modules/govuk/spec/defines/govuk__procfile__worker_spec.rb
@@ -24,9 +24,27 @@ describe 'govuk::procfile::worker', :type => :define do
     it { is_expected.to contain_service("giraffe-procfile-worker").with(:ensure => false) }
   end
 
-  context "default process_type" do
+  context "default process_count" do
     it do
       is_expected.to contain_file("/etc/init/giraffe-procfile-worker.conf").with(
+        :content => /seq 1 1/
+      )
+    end
+  end
+
+  context "process_count is 4" do
+    let(:params) { {:process_count => 4} }
+
+    it do
+      is_expected.to contain_file("/etc/init/giraffe-procfile-worker.conf").with(
+        :content => /seq 1 4/
+      )
+    end
+  end
+
+  context "default process_type" do
+    it do
+      is_expected.to contain_file("/etc/init/giraffe-procfile-worker_child.conf").with(
         :content => /govuk_run_procfile_worker worker/
       )
     end
@@ -35,7 +53,7 @@ describe 'govuk::procfile::worker', :type => :define do
   context "process_type is foo" do
     let(:params) { {:process_type => 'foo'} }
     it do
-      is_expected.to contain_file("/etc/init/giraffe-procfile-worker.conf").with(
+      is_expected.to contain_file("/etc/init/giraffe-procfile-worker_child.conf").with(
         :content => /govuk_run_procfile_worker foo/
       )
     end

--- a/modules/govuk/templates/procfile-worker.conf.erb
+++ b/modules/govuk/templates/procfile-worker.conf.erb
@@ -1,4 +1,4 @@
-description "Procfile background worker for <%= @title %>"
+description "Procfile background worker manager for <%= @title %>"
 
 start on runlevel [2345]
 stop on runlevel [!2345]
@@ -7,10 +7,23 @@ stop on runlevel [!2345]
 manual
 <%- end -%>
 
-respawn
+pre-start script
+    for inst in $(seq 1 <%= @process_count%>)
+    do
+        start <%= @service_name%>_child INDEX=$inst
+    done
+end script
 
-# If the app respawns more than 5 times in 20 seconds, it has deeper problems
-# and should be killed off.
-respawn limit 5 20
+post-stop script
+    for inst in $(initctl list | grep "^<%= @service_name%>_child " | awk '{print $2}' | tr -d ')' | tr -d '(')
+    do
+        stop <%= @service_name%>_child INDEX=$inst
+    done
 
-exec govuk_setenv <%= @setenv_as %> govuk_run_procfile_worker <%= @process_type %>
+    # For backwards compatibility, also see if this job has a running process and kill it
+    pids=$(initctl list | awk '/^<%= @service_name%> start\/running, process/ {print $4}')
+    for pid in $pids
+    do
+      kill $pid
+    done
+end script

--- a/modules/govuk/templates/procfile-worker_child.conf.erb
+++ b/modules/govuk/templates/procfile-worker_child.conf.erb
@@ -1,0 +1,11 @@
+description "Child procfile background worker for <%= @title %>"
+
+instance $INDEX
+
+respawn
+
+# If the app respawns more than 5 times in 20 seconds, it has deeper problems
+# and should be killed off.
+respawn limit 5 20
+
+exec govuk_setenv <%= @setenv_as %> govuk_run_procfile_worker <%= @process_type %>


### PR DESCRIPTION
Adds support for a `process_count` parameter to
`govuk::procfile::worker`. This uses instanced upstart jobs to allow us
to run a configurable number of procfile-defined processes.

The existing procfile upstart job becomes a parent job, which manages a
set of child jobs. The original logic is moved into the child job
configuration. When the parent job is started, it starts the requested
number of instances of the child job. When it is stopped, it stops all
child jobs. This enables us to scale processes easily with hieradata,
and makes upstart tidy up all the child jobs whether they’re configured
or not.

This maintains the ability to stop the existing job that is running
directly under what is now the parent job. On stopping the parent job
(in this instance, on the puppet run that upgrades the job layout), it
finds any parent jobs that have a process attached and kills them.
These would have the format `foo-profile-worker start/running, process
1234` in `initctl list`.

