### PR TITLE
Deploy Licensing Backups Everywhere

### DIFF
--- a/hieradata/node/licensing-mongo-2.licensify.publishing.service.gov.uk.yaml
+++ b/hieradata/node/licensing-mongo-2.licensify.publishing.service.gov.uk.yaml
@@ -1,0 +1,1 @@
+mongodb::backup::s3_backups: true

--- a/hieradata/node/licensing-mongo-2.licensify.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/licensing-mongo-2.licensify.staging.publishing.service.gov.uk.yaml
@@ -1,0 +1,1 @@
+mongodb::backup::s3_backups: true


### PR DESCRIPTION
S3 backups are gated in the mongodb::backup class.  To enable s3 backups, we need to set the condition to true in the
node classifier.  This allows for deploying to specific nodes.