### PR TITLE
Check Publishing API validity in production

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -125,7 +125,6 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::network_config_deploy
   - govuk_jenkins::job::passive_checks
   - govuk_jenkins::job::performance_platform_smokey
-  - govuk_jenkins::job::publishing_api_check_validity
   - govuk_jenkins::job::run_rake_task
   - govuk_jenkins::job::run_whitehall_data_migrations
   - govuk_jenkins::job::sanitize_publishing_api_data

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -90,6 +90,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::network_config_deploy
   - govuk_jenkins::job::passive_checks
   - govuk_jenkins::job::performance_platform_smokey
+  - govuk_jenkins::job::publishing_api_check_validity
   - govuk_jenkins::job::run_rake_task
   - govuk_jenkins::job::run_whitehall_data_migrations
   - govuk_jenkins::job::search_fetch_analytics_data


### PR DESCRIPTION
This changes the Jenkins task `publishing_api_check_validity` to run only in the production environment.