### PR TITLE
Revert Licensing backups Everywhere

### DIFF
--- a/hieradata/node/licensing-mongo-2.licensify.publishing.service.gov.uk.yaml
+++ b/hieradata/node/licensing-mongo-2.licensify.publishing.service.gov.uk.yaml
@@ -1,1 +1,0 @@
-mongodb::backup::s3_backups: true

--- a/hieradata/node/licensing-mongo-2.licensify.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/licensing-mongo-2.licensify.staging.publishing.service.gov.uk.yaml
@@ -1,1 +1,0 @@
-mongodb::backup::s3_backups: true


### PR DESCRIPTION
This relates to https://github.com/alphagov/govuk-puppet/pull/4847

The credentials required for s3 backups were not present beyond integration.  To prevent failures in monitoring,
I am reverting the above mentioned PR until the crendentials have been deployed.