### PR TITLE
Reschedule Licensing realtime backup

### DIFF
--- a/hieradata/node/licensing-mongo-2.licensify.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/licensing-mongo-2.licensify.integration.publishing.service.gov.uk.yaml
@@ -1,1 +1,3 @@
 mongodb::backup::s3_backups: true
+mongodb::s3backup::cron::realtime_hour: '*/6'
+mongodb::s3backup::cron::realtime_minute: '0'

--- a/hieradata/node/licensing-mongo-2.licensify.publishing.service.gov.uk.yaml
+++ b/hieradata/node/licensing-mongo-2.licensify.publishing.service.gov.uk.yaml
@@ -1,1 +1,3 @@
 mongodb::backup::s3_backups: true
+mongodb::s3backup::cron::realtime_hour: '*/6'
+mongodb::s3backup::cron::realtime_minute: '0'

--- a/hieradata/node/licensing-mongo-2.licensify.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/licensing-mongo-2.licensify.staging.publishing.service.gov.uk.yaml
@@ -1,1 +1,3 @@
 mongodb::backup::s3_backups: true
+mongodb::s3backup::cron::realtime_hour: '*/6'
+mongodb::s3backup::cron::realtime_minute: '0'

--- a/modules/mongodb/manifests/s3backup/cron.pp
+++ b/modules/mongodb/manifests/s3backup/cron.pp
@@ -8,6 +8,10 @@
 #
 class mongodb::s3backup::cron(
   $user = 'govuk-backup',
+  $realtime_hour = '*',
+  $realtime_minute = '*/15',
+  $daily_hour = 0,
+  $daily_minute = 0,
 ) {
 
   include ::backup::client
@@ -18,14 +22,15 @@ class mongodb::s3backup::cron(
   cron { 'mongodb-s3backup-realtime':
     command => '/usr/bin/setlock -n /etc/unattended-reboot/no-reboot/mongodb-s3backup /usr/local/bin/mongodb-backup-s3',
     user    => $user,
-    minute  => '*/15',
+    hour    => $realtime_hour,
+    minute  => $realtime_minute,
   }
 
   cron { 'mongodb-s3-night-backup':
     command => '/usr/bin/setlock /etc/unattended-reboot/no-reboot/mongodb-s3backup /usr/local/bin/mongodb-backup-s3 daily',
     user    => $user,
-    hour    => '0',
-    minute  => '0',
+    hour    => $daily_hour,
+    minute  => $daily_minute,
   }
 
   # FIXME Please remove resource once merged


### PR DESCRIPTION
Do not merge yet so we can monitor how other machines perform with the every 15 minute backup schedule.

The dataset for Licensing mongo machines is large and isn't as vital as some of our other services. It causes high disk time when it runs, so paramaterise the cron times and specifically set them within hieradata.