### PR TITLE
Fix deprecation warning in vhost

### DIFF
--- a/modules/nginx/templates/proxy-vhost.conf
+++ b/modules/nginx/templates/proxy-vhost.conf
@@ -40,7 +40,7 @@ server {
   listen 80<%= $is_default_vhost ? " default_server" : "" %>;
   <%- end -%>
 
-  <%- if proxy_http_version_1_1_enabled == true -%>
+  <%- if @proxy_http_version_1_1_enabled == true -%>
   proxy_http_version 1.1;
 
   <%- end -%>


### PR DESCRIPTION
Running `govuk_puppet` on the VM currently gives this deprecation warning:

```
Warning: Variable access via 'proxy_http_version_1_1_enabled' is deprecated. Use '@proxy_http_version_1_1_enabled' instead. 

template[/var/govuk/govuk-puppet/modules/nginx/templates/proxy-vhost.conf]:43
```

This commit fixes that.