### PR TITLE
Allow multiple procfile processes

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -305,6 +305,7 @@ govuk::apps::publisher::redis_port: "%{hiera('sidekiq_port')}"
 
 govuk::apps::whitehall::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::whitehall::redis_port: "%{hiera('sidekiq_port')}"
+govuk::apps::whitehall::procfile_worker_process_count: 2
 
 govuk::apps::govuk_crawler_worker::airbrake_endpoint: "https://errbit.%{hiera('app_domain')}/notifier_api/v2/notices"
 govuk::apps::govuk_crawler_worker::airbrake_env: "%{hiera('govuk::deploy::config::errbit_environment_name')}"

--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -37,6 +37,7 @@ class govuk::apps::whitehall(
   $publishing_api_bearer_token = undef,
   $redis_host = undef,
   $redis_port = undef,
+  $procfile_worker_process_count = 1,
 ) {
 
   $app_domain = hiera('app_domain')
@@ -191,6 +192,7 @@ class govuk::apps::whitehall(
     govuk::procfile::worker { 'whitehall-admin':
       setenv_as      => 'whitehall',
       enable_service => $enable_procfile_worker,
+      process_count  => $procfile_worker_process_count,
     }
 
     # FIXME: Remove this when Whitehall is using Rack 1.7

--- a/modules/govuk/manifests/procfile/worker.pp
+++ b/modules/govuk/manifests/procfile/worker.pp
@@ -60,8 +60,9 @@ define govuk::procfile::worker (
     }
 
     if $enable_service {
-      @@icinga::check { "check_app_${title}_procfile_worker_upstart_up_${::hostname}":
-        check_command       => "check_nrpe!check_upstart_status!${service_name}",
+      include icinga::client::check_procfile_workers
+      @@icinga::check { "check_app_${title}_procfile_workers_count_${::hostname}":
+        check_command       => "check_nrpe!check_procfile_workers!${service_name} ${process_count}",
         service_description => "${title} procfile worker upstart up",
         host_name           => $::fqdn,
       }

--- a/modules/govuk/spec/defines/govuk__procfile__worker_spec.rb
+++ b/modules/govuk/spec/defines/govuk__procfile__worker_spec.rb
@@ -24,9 +24,27 @@ describe 'govuk::procfile::worker', :type => :define do
     it { is_expected.to contain_service("giraffe-procfile-worker").with(:ensure => false) }
   end
 
-  context "default process_type" do
+  context "default process_count" do
     it do
       is_expected.to contain_file("/etc/init/giraffe-procfile-worker.conf").with(
+        :content => /seq 1 1/
+      )
+    end
+  end
+
+  context "process_count is 4" do
+    let(:params) { {:process_count => 4} }
+
+    it do
+      is_expected.to contain_file("/etc/init/giraffe-procfile-worker.conf").with(
+        :content => /seq 1 4/
+      )
+    end
+  end
+
+  context "default process_type" do
+    it do
+      is_expected.to contain_file("/etc/init/giraffe-procfile-worker_child.conf").with(
         :content => /govuk_run_procfile_worker worker/
       )
     end
@@ -35,7 +53,7 @@ describe 'govuk::procfile::worker', :type => :define do
   context "process_type is foo" do
     let(:params) { {:process_type => 'foo'} }
     it do
-      is_expected.to contain_file("/etc/init/giraffe-procfile-worker.conf").with(
+      is_expected.to contain_file("/etc/init/giraffe-procfile-worker_child.conf").with(
         :content => /govuk_run_procfile_worker foo/
       )
     end

--- a/modules/govuk/templates/procfile-worker.conf.erb
+++ b/modules/govuk/templates/procfile-worker.conf.erb
@@ -1,4 +1,4 @@
-description "Procfile background worker for <%= @title %>"
+description "Procfile background worker manager for <%= @title %>"
 
 start on runlevel [2345]
 stop on runlevel [!2345]
@@ -7,10 +7,23 @@ stop on runlevel [!2345]
 manual
 <%- end -%>
 
-respawn
+pre-start script
+    for inst in $(seq 1 <%= @process_count%>)
+    do
+        start <%= @service_name%>_child INDEX=$inst
+    done
+end script
 
-# If the app respawns more than 5 times in 20 seconds, it has deeper problems
-# and should be killed off.
-respawn limit 5 20
+post-stop script
+    for inst in $(initctl list | grep "^<%= @service_name%>_child " | awk '{print $2}' | tr -d ')' | tr -d '(')
+    do
+        stop <%= @service_name%>_child INDEX=$inst
+    done
 
-exec govuk_setenv <%= @setenv_as %> govuk_run_procfile_worker <%= @process_type %>
+    # For backwards compatibility, also see if this job has a running process and kill it
+    pids=$(initctl list | awk '/^<%= @service_name%> start\/running, process/ {print $4}')
+    for pid in $pids
+    do
+      kill $pid
+    done
+end script

--- a/modules/govuk/templates/procfile-worker_child.conf.erb
+++ b/modules/govuk/templates/procfile-worker_child.conf.erb
@@ -1,0 +1,11 @@
+description "Child procfile background worker for <%= @title %>"
+
+instance $INDEX
+
+respawn
+
+# If the app respawns more than 5 times in 20 seconds, it has deeper problems
+# and should be killed off.
+respawn limit 5 20
+
+exec govuk_setenv <%= @setenv_as %> govuk_run_procfile_worker <%= @process_type %>

--- a/modules/icinga/files/etc/nagios/nrpe.d/check_procfile_workers.cfg
+++ b/modules/icinga/files/etc/nagios/nrpe.d/check_procfile_workers.cfg
@@ -1,0 +1,1 @@
+command[check_procfile_workers]=/usr/lib/nagios/plugins/check_procfile_workers $ARG1$ $ARG2$

--- a/modules/icinga/files/usr/lib/nagios/plugins/check_procfile_workers
+++ b/modules/icinga/files/usr/lib/nagios/plugins/check_procfile_workers
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -eu
+SERVICE_NAME=$1
+EXPECTED_WORKERS=$2
+
+# Bail if not an integer.
+[[ $EXPECTED_WORKERS != *[!0-9]* ]] || exit_unknown
+
+set +e
+trap - ERR
+
+$(dirname $0)/check_upstart_status -j ${SERVICE_NAME}
+
+for i in $(seq 1 $EXPECTED_WORKERS);
+do
+  $(dirname $0)/check_upstart_status -j ${SERVICE_NAME}_child -i INDEX=${i}
+done

--- a/modules/icinga/files/usr/lib/nagios/plugins/check_upstart_status
+++ b/modules/icinga/files/usr/lib/nagios/plugins/check_upstart_status
@@ -42,14 +42,15 @@ my $exit_value = $ERRORS{'UNKNOWN'} ;
 
 my %options=();
 
-getopts("j:", \%options);
+getopts("i:j:", \%options);
 
-if (scalar(keys(%options))<1 )
+if ($options{'j'} eq "")
 {
   show_usage();
 }
 
 my $jobName = $options{'j'};
+my $jobInstance = $options{'i'};
 my $exit_value_human="";
 my $retval;
 my $goal;
@@ -57,6 +58,11 @@ my $state;
 
 #Run command and get result
 my $cmd = "status $jobName";
+
+if (length $jobInstance)
+{
+  $cmd = "$cmd $jobInstance";
+}
 $retval = `$cmd`;
 
 #Get return code
@@ -154,6 +160,7 @@ sub show_usage
   print "./check_upstart_status.pl -j jobName\n";
   print "\n";
   print "-j jobName\t\t The name of the upstart job you want to check\n";
+  print "-i jobInstance\t\t (optional) The instance of the job, e.g. INDEX=1\n";
   print "\n\n";
 
   exit $exit_value;

--- a/modules/icinga/manifests/client/check_procfile_workers.pp
+++ b/modules/icinga/manifests/client/check_procfile_workers.pp
@@ -1,0 +1,14 @@
+# == Class: icinga::client::check_procfile_workers
+#
+# Install a Nagios plugin that alerts when the number of procfile workers is not as expected
+#
+class icinga::client::check_procfile_workers {
+
+  @icinga::plugin { 'check_procfile_workers':
+    source  => 'puppet:///modules/icinga/usr/lib/nagios/plugins/check_procfile_workers',
+  }
+
+  @icinga::nrpe_config { 'check_procfile_workers':
+    source  => 'puppet:///modules/icinga/etc/nagios/nrpe.d/check_procfile_workers.cfg',
+  }
+}


### PR DESCRIPTION
Adds support for a `process_count` parameter to
`govuk::procfile::worker`. This uses instanced upstart jobs to allow us
to run a configurable number of procfile-defined processes.

The existing procfile upstart job becomes a parent job, which manages a
set of child jobs. The original logic is moved into the child job
configuration. When the parent job is started, it starts the requested
number of instances of the child job. When it is stopped, it stops all
child jobs. This enables us to scale processes easily with hieradata,
and makes upstart tidy up all the child jobs whether they’re configured
or not.

This maintains the ability to stop the existing job that is running
directly under what is now the parent job. On stopping the parent job
(in this instance, on the puppet run that upgrades the job layout), it
finds any parent jobs that have a process attached, and kills them.
These would have the format `foo-profile-worker start/running, process
1234` in `initctl list`.

I've added some Icinga alerts for this. Rather than alerting on the parent
job, it now alerts on the count of the child jobs similar to the unicorn process
worker check.

I've not been able to test the Icinga stuff locally, hoping to deploy the branch
to integration to test it.