### PR TITLE
Remove Specialist Publisher from post-data sync run

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
@@ -29,10 +29,6 @@
                 TARGET_APPLICATION=<%= app %>
                 DEPLOY_TASK=deploy:migrate_and_hard_restart
             <%- end -%>
-            - project: Deploy_App
-              predefined-parameters: |
-                TARGET_APPLICATION=specialist-publisher
-                DEPLOY_TASK=deploy:migrations
             <%- %w{ govuk_delivery_configure_integration_catchall_feed transition_run_database_migrations }.each do |job| -%>
             - project: <%= job %>
               condition: 'SUCCESS'


### PR DESCRIPTION
We're not going to be writing any more migrations for
the old specialist publisher so this can go.