### PR TITLE
Fix a test that fails in development

### DIFF
--- a/modules/golang/spec/classes/golang_spec.rb
+++ b/modules/golang/spec/classes/golang_spec.rb
@@ -13,7 +13,7 @@ describe 'golang', :type => :class do
   end
 
   context 'not in development' do
-    let(:facts) {{}}
+    let(:facts) {{domain: 'somethingelse'}}
     it { is_expected.not_to contain_file(file_path) }
   end
 end


### PR DESCRIPTION
This domain for the test is development when run on the
dev vm so that test's context is wrong. Instead, set it
to something that's definitely not development.