### PR TITLE
MongoDB S3 Backup Tweaks

### DIFF
--- a/modules/mongodb/templates/mongodb-backup-s3.erb
+++ b/modules/mongodb/templates/mongodb-backup-s3.erb
@@ -43,7 +43,7 @@ printf "BACKUP COMPLETED IN: ${TIME}s\n"
 
 # Compress and encrypt backup
 TIME="$(date +%s)"
-(/bin/tar cvz $BACKUP_DIR | /usr/bin/gpg -e -o $BACKUP_DIR/$BACKUP_FILE -r $KEY_FINGERPRINT)
+(/bin/tar cvz $BACKUP_DIR --exclude=lost+found | /usr/bin/gpg -e -o $BACKUP_DIR/$BACKUP_FILE -r $KEY_FINGERPRINT)
 TIME="$(($(date +%s)-TIME))"
 printf "COMPRESSION AND ENCRYPTION FINISHED IN: ${TIME}s\n"
 


### PR DESCRIPTION
What
During verification on Staging, we noticed that `tar` was outputting "permission denied" on `/var/lib/s3backup/lost+found`.
This is because `/var/lib/s3backup` is now a mount point on the root of a separate volume.
Relates to https://github.com/alphagov/govuk-puppet/pull/4689

How
Exclude the `lost+found` directory by adding the `--exclude` flag to the `tar` command.