### PR TITLE
Turn on slow query logging for Whitehall MySQL slaves

### DIFF
--- a/modules/govuk/manifests/node/s_whitehall_mysql_slave.pp
+++ b/modules/govuk/manifests/node/s_whitehall_mysql_slave.pp
@@ -7,6 +7,9 @@ class govuk::node::s_whitehall_mysql_slave inherits govuk::node::s_base {
     tmp_table_size        => '256M',
     max_heap_table_size   => '256M',
     innodb_file_per_table => true,
+    # FIXME
+    # Slow query log is turned ON for a short period of analysis.
+    slow_query_log        => true,
   }
   include govuk_mysql::server::slave
 


### PR DESCRIPTION
We've seen some load spikes on whitehall-mysql-slave-1 and some
subsequent slow whitehall-frontend responses, 5xx spikes so turn on slow query log as part of
ongoing analysis.