### PR TITLE
Link Deploys of EFG and EFG_TRAIN

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -22,7 +22,7 @@ deployable_applications: &deployable_applications
   - courts-api
   - courts-frontend
   - designprinciples
-  - EFG
+  - efg-training
   - email-alert-api
   - email-alert-frontend
   - email-alert-monitor

--- a/modules/govuk_jenkins/manifests/job/deploy_app.pp
+++ b/modules/govuk_jenkins/manifests/job/deploy_app.pp
@@ -24,4 +24,10 @@ class govuk_jenkins::job::deploy_app (
     content => template('govuk_jenkins/jobs/deploy_app.yaml.erb'),
     notify  => Exec['jenkins_jobs_update'],
   }
+
+  file { '/etc/jenkins_jobs/jobs/deploy_efg.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/deploy_efg.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
 }

--- a/modules/govuk_jenkins/templates/jobs/deploy_efg.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_efg.yaml.erb
@@ -1,0 +1,79 @@
+---
+- scm:
+    name: alphagov-deployment_Deploy_App
+    scm:
+        - git:
+            url: git@github.com:alphagov/govuk-app-deployment.git
+            branches:
+              - master
+            wipe-workspace: true
+
+- job:
+    name: Deploy_EFG
+    display-name: Deploy_EFG
+    project-type: freestyle
+    description: "<% if @environment != 'integration' %><a href=\"http://www.flickr.com/photos/fatty/9158066939/\">\r\n  <img src=\"https://farm3.staticflickr.com/2835/9158066939_374360ed56_n.jpg\">\r\n</a>\r\n<% end %><h2>You can monitor the application health using the <a href=\"https://grafana.<%= @app_domain %>/#/dashboard/file/application_http_error_codes.json\">4XX and 5XX status dashboard</a></h2>\r\n"
+    <%- if @auth_token -%>
+    auth-token: <%= @auth_token %>
+    <%- end -%>
+    properties:
+        - github:
+            url: https://github.com/alphagov/govuk-app-deployment
+    scm:
+      - alphagov-deployment_Deploy_App
+    builders:
+        - shell: |
+            #!/usr/bin/env bash
+            export DEPLOY_TO="<%= @environment -%>"
+            export DEPLOY_TASK="$DEPLOY_TASK"
+            export TAG="$TAG"
+            export ORGANISATION="<%= @environment -%>"
+            export CI_DEPLOY_JENKINS_API_KEY="<%= @ci_deploy_jenkins_api_key -%>"
+
+            if [ "$DEPLOY_FROM_GITHUB_ENTERPRISE" == "true" ]; then
+              export GIT_ORIGIN_PREFIX="git@github.gds:gds-production-backup"
+            fi
+
+            ./jenkins.sh
+        - trigger-parameterized-builds:
+            - project: Deploy_EFG
+              predefined-parameters: |
+                TARGET_APPLICATION=efg-training
+                TARGET_APPLICATION_GIT_REPO=$WORKSPACE/EFG
+              condition: 'UNSTABLE_OR_BETTER'
+    publishers:
+        - trigger:
+            project: Smokey
+        - trigger-parameterized-builds:
+            - project: GDS_Production_Backup, service-manual_rebuild_search_index
+              predefined-parameters: |
+                TARGET_APPLICATION=$TARGET_APPLICATION
+                TARGET_APPLICATION_GIT_REPO=$WORKSPACE/$TARGET_APPLICATION
+              condition: 'SUCCESS'
+    wrappers:
+        - ansicolor:
+            colormap: xterm
+        - build-name:
+            name: '${ENV,var="TARGET_APPLICATION"} ${ENV,var="TAG"}'
+    parameters:
+        - choice:
+            name: TARGET_APPLICATION
+            description: Application to deploy.
+            choices:
+                - EFG
+        - choice:
+            name: DEPLOY_TASK
+            description: Capistrano task to run.
+            choices:
+                - deploy
+                - deploy:migrate_and_hard_restart
+                - deploy:migrations
+                - deploy:hard_restart
+        - string:
+            name: TAG
+            description: Git tag/committish to deploy.
+            default: release
+        - bool:
+            name: DEPLOY_FROM_GITHUB_ENTERPRISE
+            default: false
+            description: Whether to deploy from GitHub Enterprise in case public GitHub is unavailable

--- a/modules/govuk_jenkins/templates/jobs/deploy_efg.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_efg.yaml.erb
@@ -1,6 +1,6 @@
 ---
 - scm:
-    name: alphagov-deployment_Deploy_App
+    name: alphagov-deployment_Deploy_EFG
     scm:
         - git:
             url: git@github.com:alphagov/govuk-app-deployment.git
@@ -12,15 +12,15 @@
     name: Deploy_EFG
     display-name: Deploy_EFG
     project-type: freestyle
-    description: "<% if @environment != 'integration' %><a href=\"http://www.flickr.com/photos/fatty/9158066939/\">\r\n  <img src=\"https://farm3.staticflickr.com/2835/9158066939_374360ed56_n.jpg\">\r\n</a>\r\n<% end %><h2>You can monitor the application health using the <a href=\"https://grafana.<%= @app_domain %>/#/dashboard/file/application_http_error_codes.json\">4XX and 5XX status dashboard</a></h2>\r\n"
-    <%- if @auth_token -%>
-    auth-token: <%= @auth_token %>
-    <%- end -%>
+    description: "This job will also trigger a deploy of efg-training"
     properties:
         - github:
             url: https://github.com/alphagov/govuk-app-deployment
+        - inject:
+            properties-content: |
+              TARGET_APPLICATION=efg
     scm:
-      - alphagov-deployment_Deploy_App
+      - alphagov-deployment_Deploy_EFG
     builders:
         - shell: |
             #!/usr/bin/env bash
@@ -35,32 +35,28 @@
             fi
 
             ./jenkins.sh
-        - trigger-parameterized-builds:
-            - project: Deploy_EFG
-              predefined-parameters: |
-                TARGET_APPLICATION=efg-training
-                TARGET_APPLICATION_GIT_REPO=$WORKSPACE/EFG
-              condition: 'UNSTABLE_OR_BETTER'
     publishers:
         - trigger:
             project: Smokey
         - trigger-parameterized-builds:
+            - project: Deploy_App
+              predefined-parameters: |
+                TARGET_APPLICATION=efg-training
+                DEPLOY_TASK=deploy
+                TAG=$TAG
+                DEPLOY_FROM_GITHUB_ENTERPRISE=false
+              condition: 'SUCCESS'
             - project: GDS_Production_Backup, service-manual_rebuild_search_index
               predefined-parameters: |
                 TARGET_APPLICATION=$TARGET_APPLICATION
                 TARGET_APPLICATION_GIT_REPO=$WORKSPACE/$TARGET_APPLICATION
-              condition: 'SUCCESS'
+              condition: 'UNSTABLE_OR_BETTER'
     wrappers:
         - ansicolor:
             colormap: xterm
         - build-name:
             name: '${ENV,var="TARGET_APPLICATION"} ${ENV,var="TAG"}'
     parameters:
-        - choice:
-            name: TARGET_APPLICATION
-            description: Application to deploy.
-            choices:
-                - EFG
         - choice:
             name: DEPLOY_TASK
             description: Capistrano task to run.


### PR DESCRIPTION
Part of the EFG road map.
What
The stipulation on the deployment of the newly hosted EFG app is that EFG_Training must be deployed every time EFG (prod) is deployed.  Doing this within
the current 'Deploy_App' Jenkins job would prove quite complicated so we opted for a separate deploy job in Jenkins.

How
Created a new job template specifically for EFG/EFG_Training.
Statically set choice parameters as opposed to a generated list from a rake task.
Defined new post build task 'Trigger-Parameterized-Build'.  This will trigger the same Jenkins job it's defined in with the `TARGET_APPLICATION`parameter set to 'EFG_TRAINING'.