### PR TITLE
Use api-elasticsearch for calculators-frontend in integration

### DIFF
--- a/hieradata/class/integration/calculators_frontend.yaml
+++ b/hieradata/class/integration/calculators_frontend.yaml
@@ -1,0 +1,6 @@
+---
+
+govuk_elasticsearch::local_proxy::servers:
+  - 'api-elasticsearch-1.api'
+  - 'api-elasticsearch-2.api'
+  - 'api-elasticsearch-3.api'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -855,6 +855,10 @@ hosts::production::frontend::hosts:
     ip: '10.1.2.11'
   calculators-frontend-2:
     ip: '10.1.2.12'
+  # FIXME: This machine doesn't exist, but this host entry
+  # is depended upon by s_api_elasticsearch. We should fix that.
+  calculators-frontend-3:
+    ip: '10.1.2.13'
   frontend-1:
     ip: '10.1.2.2'
   frontend-2:


### PR DESCRIPTION
For: https://trello.com/c/vaecOj9d/493-upgrade-rails-on-licence-finder-2

This is step one towards us getting rid of the 0.90 cluster.

The only deployed app that actually uses elasticsearch directly on
calculators-frontend is licencefinder and it can create it's index from
nothing so we can easily point the servers at a new cluster and create
the data again.

Tariff is still listed as an app for these machines, and it uses
elasticsearch, but it's since been deployed to the PaaS so we can ignore it.