### PR TITLE
Return 200 response when purging whitehall uploads

### DIFF
--- a/modules/varnish/templates/default.vcl.erb
+++ b/modules/varnish/templates/default.vcl.erb
@@ -63,7 +63,11 @@ sub vcl_recv {
   # Don't waste our internal cache on uploaded assets (large) which are
   # typically cached for a long time at the CDN edge.
   if (req.url ~ "^/government/uploads/") {
-    return(pass);
+    if (req.request == "PURGE") {
+      error 200 "Path excluded from varnish";
+    } else {
+      return(pass);
+    }
   }
 
   # Serve stale period. This is the period for which Varnish is *allowed* to


### PR DESCRIPTION
If we send a purge request to a whitehall upload it currently gets passed through to the application server. This is because the vcl is configured to not cache whitehall uploads. 

This update stops passing a purge on to the whitehall application and having that return a 405. 

It instead returns a 200 with the reason of "Path excluded from varnish". 

Status code and reason are welcome to suggestions if someone has a better suggestion 😃 