### PR TITLE
Revert "Turn on slow query logging for Whitehall MySQL slaves"

### DIFF
--- a/modules/govuk/manifests/node/s_whitehall_mysql_slave.pp
+++ b/modules/govuk/manifests/node/s_whitehall_mysql_slave.pp
@@ -7,9 +7,6 @@ class govuk::node::s_whitehall_mysql_slave inherits govuk::node::s_base {
     tmp_table_size        => '256M',
     max_heap_table_size   => '256M',
     innodb_file_per_table => true,
-    # FIXME
-    # Slow query log is turned ON for a short period of analysis.
-    slow_query_log        => true,
   }
   include govuk_mysql::server::slave
 


### PR DESCRIPTION
This reverts commit c740b3fbe407e3d7d0d673d07840067eeb990113.

Once we've captured enough information in the slow query log we should turn it off again.