### PR TITLE
Renice disk I/O for MongoDB Backups

### DIFF
--- a/modules/mongodb/manifests/s3backup/cron.pp
+++ b/modules/mongodb/manifests/s3backup/cron.pp
@@ -20,14 +20,14 @@ class mongodb::s3backup::cron(
 
   # Here we use setlock to prevent the jobs from running asynchronously
   cron { 'mongodb-s3backup-realtime':
-    command => '/usr/bin/setlock -n /etc/unattended-reboot/no-reboot/mongodb-s3backup /usr/local/bin/mongodb-backup-s3',
+    command => '/usr/bin/ionice -c 2 -n 6 /usr/bin/setlock -n /etc/unattended-reboot/no-reboot/mongodb-s3backup /usr/local/bin/mongodb-backup-s3',
     user    => $user,
     hour    => $realtime_hour,
     minute  => $realtime_minute,
   }
 
   cron { 'mongodb-s3-night-backup':
-    command => '/usr/bin/setlock /etc/unattended-reboot/no-reboot/mongodb-s3backup /usr/local/bin/mongodb-backup-s3 daily',
+    command => '/usr/bin/ionice -c 2 -n 6 /usr/bin/setlock /etc/unattended-reboot/no-reboot/mongodb-s3backup /usr/local/bin/mongodb-backup-s3 daily',
     user    => $user,
     hour    => $daily_hour,
     minute  => $daily_minute,


### PR DESCRIPTION
What
Since deploying Mongo s3 backups to staging and production, 2nd line have reported alerts for
breaching disk ops thresholds.  The complete backup process consists of:
- Dumping databases to disk
- Archiving data
- Encrypting data
- Uploading data
This is a resource intensive process and may require some performance tuning.

How
Prefix cron  commands `ionice`.  Specify the scheduling class flag of `2` and a priority of `6`.
The changes lower the priority of the backup jobs in terms of disk ops.

Many thanks to Dean Wilson 💯 