### PR TITLE
Add MySQL S3 backups everywhere

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -506,6 +506,10 @@ govuk::node::s_licensify_lb::frontend_app_servers:
   - 'licensing-frontend-1.licensify'
   - 'licensing-frontend-2.licensify'
 
+govuk::node::s_mysql_master::aws_access_key_id: "%{hiera('govuk::node::s_mysql_backup::aws_access_key_id')}"
+govuk::node::s_mysql_master::aws_secret_access_key: "%{hiera('govuk::node::s_mysql_backup::aws_secret_access_key')}"
+govuk::node::s_mysql_master::encryption_key: "${hiera('govuk::node::s_mysql_backup::encryption_key')}"
+
 govuk::node::s_transition_postgresql_slave::redirector_ip_range: 10.6.0.1/16
 govuk::node::s_transition_postgresql_standby::redirector_ip_range: "%{hiera('govuk::node::s_transition_postgresql_slave::redirector_ip_range')}"
 

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -510,6 +510,10 @@ govuk::node::s_mysql_master::aws_access_key_id: "%{hiera('govuk::node::s_mysql_b
 govuk::node::s_mysql_master::aws_secret_access_key: "%{hiera('govuk::node::s_mysql_backup::aws_secret_access_key')}"
 govuk::node::s_mysql_master::encryption_key: "${hiera('govuk::node::s_mysql_backup::encryption_key')}"
 
+govuk::node::s_whitehall_mysql_master::aws_access_key_id: "%{hiera('govuk::node::s_mysql_backup::aws_access_key_id')}"
+govuk::node::s_whitehall_mysql_master::aws_secret_access_key: "%{hiera('govuk::node::s_mysql_backup::aws_secret_access_key')}"
+govuk::node::s_whitehall_mysql_master::encryption_key: "${hiera('govuk::node::s_mysql_backup::encryption_key')}"
+
 govuk::node::s_transition_postgresql_slave::redirector_ip_range: 10.6.0.1/16
 govuk::node::s_transition_postgresql_standby::redirector_ip_range: "%{hiera('govuk::node::s_transition_postgresql_slave::redirector_ip_range')}"
 

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -216,7 +216,8 @@ govuk::node::s_logs_elasticsearch::rotate_minute: 00
 govuk::node::s_licensify_lb::enable_feed_console: true
 govuk::node::s_logging::compress_srv_logs_hour: '9'
 govuk::node::s_monitoring::offsite_backups: false
-govuk::node::s_mysql_master::s3_bucket_name: 'govuk-mysql-xtrabackups-production'
+govuk::node::s_mysql_backup::s3_bucket_name: 'govuk-mysql-xtrabackups-integration'
+govuk::node::s_mysql_master::s3_bucket_name: "%{hiera('govuk::node::s_mysql_backup::s3_bucket_name')}"
 govuk::node::s_whitehall_backend::sync_mirror: true
 
 govuk::node::s_transition_postgresql_slave::redirector_ip_range: '10.1.5.0/24'

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -218,6 +218,8 @@ govuk::node::s_logging::compress_srv_logs_hour: '9'
 govuk::node::s_monitoring::offsite_backups: false
 govuk::node::s_mysql_backup::s3_bucket_name: 'govuk-mysql-xtrabackups-integration'
 govuk::node::s_mysql_master::s3_bucket_name: "%{hiera('govuk::node::s_mysql_backup::s3_bucket_name')}"
+govuk::node::s_whitehall_mysql_backup::s3_bucket_name: 'govuk-whitehall-mysql-xtrabackups-integration'
+govuk::node::s_whitehall_mysql_master::s3_bucket_name: "%{hiera('govuk::node::s_whitehall_mysql_backup::s3_bucket_name')}"
 govuk::node::s_whitehall_backend::sync_mirror: true
 
 govuk::node::s_transition_postgresql_slave::redirector_ip_range: '10.1.5.0/24'

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -195,6 +195,8 @@ govuk::node::s_frontend_lb::whitehall_frontend_servers:
 govuk::node::s_monitoring::enable_fastly_metrics: true
 govuk::node::s_mysql_backup::s3_bucket_name: 'govuk-mysql-xtrabackups-production'
 govuk::node::s_mysql_master::s3_bucket_name: "%{hiera('govuk::node::s_mysql_backup::s3_bucket_name')}"
+govuk::node::s_whitehall_mysql_backup::s3_bucket_name: 'govuk-whitehall-mysql-xtrabackups-production'
+govuk::node::s_whitehall_mysql_master::s3_bucket_name: "%{hiera('govuk::node::s_whitehall_mysql_backup::s3_bucket_name')}"
 govuk::node::s_transition_postgresql_slave::redirector_ip_range: '10.3.5.0/24'
 govuk::node::s_transition_postgresql_standby::redirector_ip_range: "%{hiera('govuk::node::s_transition_postgresql_slave::redirector_ip_range')}"
 

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -194,6 +194,7 @@ govuk::node::s_frontend_lb::whitehall_frontend_servers:
   - 'whitehall-frontend-7.frontend'
 govuk::node::s_monitoring::enable_fastly_metrics: true
 govuk::node::s_mysql_backup::s3_bucket_name: 'govuk-mysql-xtrabackups-production'
+govuk::node::s_mysql_master::s3_bucket_name: "%{hiera('govuk::node::s_mysql_backup::s3_bucket_name')}"
 govuk::node::s_transition_postgresql_slave::redirector_ip_range: '10.3.5.0/24'
 govuk::node::s_transition_postgresql_standby::redirector_ip_range: "%{hiera('govuk::node::s_transition_postgresql_slave::redirector_ip_range')}"
 

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -151,6 +151,8 @@ govuk::node::s_frontend_lb::whitehall_frontend_servers:
 govuk::node::s_monitoring::offsite_backups: false
 govuk::node::s_mysql_backup::s3_bucket_name: 'govuk-mysql-xtrabackups-staging'
 govuk::node::s_mysql_master::s3_bucket_name: "%{hiera('govuk::node::s_mysql_backup::s3_bucket_name')}"
+govuk::node::s_whitehall_mysql_backup::s3_bucket_name: 'govuk-whitehall-mysql-xtrabackups-staging'
+govuk::node::s_whitehall_mysql_master::s3_bucket_name: "%{hiera('govuk::node::s_whitehall_mysql_backup::s3_bucket_name')}"
 govuk::node::s_transition_postgresql_slave::redirector_ip_range: '10.2.5.0/24'
 govuk::node::s_transition_postgresql_standby::redirector_ip_range: "%{hiera('govuk::node::s_transition_postgresql_slave::redirector_ip_range')}"
 

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -149,7 +149,8 @@ govuk::node::s_frontend_lb::whitehall_frontend_servers:
   - 'whitehall-frontend-6.frontend'
   - 'whitehall-frontend-7.frontend'
 govuk::node::s_monitoring::offsite_backups: false
-govuk::node::s_mysql_master::s3_bucket_name: 'govuk-mysql-xtrabackups-production'
+govuk::node::s_mysql_backup::s3_bucket_name: 'govuk-mysql-xtrabackups-staging'
+govuk::node::s_mysql_master::s3_bucket_name: "%{hiera('govuk::node::s_mysql_backup::s3_bucket_name')}"
 govuk::node::s_transition_postgresql_slave::redirector_ip_range: '10.2.5.0/24'
 govuk::node::s_transition_postgresql_standby::redirector_ip_range: "%{hiera('govuk::node::s_transition_postgresql_slave::redirector_ip_range')}"
 

--- a/modules/govuk/manifests/node/s_mysql_backup.pp
+++ b/modules/govuk/manifests/node/s_mysql_backup.pp
@@ -1,4 +1,21 @@
-# FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
+# == Class: Govuk::Node::S_mysql_backup
+#
+#  Set up a GOV.UK MySQL Backup machine
+#
+# === Parameters:
+#
+#  [*aws_access_key_id*]
+#    AWS access key ID for the S3 bucket
+#
+#  [*aws_secret_access_key*]
+#    AWS secret key for the S3 bucket
+#
+#  [*s3_bucket_name*]
+#    Name of the S3 bucket
+#
+#  [*encryption_key*]
+#    Encryption key that encrypts the backup for S3
+#
 class govuk::node::s_mysql_backup (
   $aws_access_key_id = undef,
   $aws_secret_access_key = undef,
@@ -24,7 +41,7 @@ class govuk::node::s_mysql_backup (
 
   Govuk_mount['/var/lib/mysql'] -> Class['govuk_mysql::server']
 
-  if $s3_bucket_name {
+  if $s3_bucket_name and $aws_access_key_id and $aws_secret_access_key {
     govuk_mysql::xtrabackup::backup { $::hostname:
       aws_access_key_id     => $aws_access_key_id,
       aws_secret_access_key => $aws_secret_access_key,

--- a/modules/govuk/manifests/node/s_mysql_master.pp
+++ b/modules/govuk/manifests/node/s_mysql_master.pp
@@ -1,4 +1,21 @@
-# Configure a MySQL Master server for GOV.UK
+# == Class: Govuk::Node::S_mysql_master
+#
+#  Set up a GOV.UK MySQL Master machine
+#
+# === Parameters:
+#
+#  [*aws_access_key_id*]
+#    AWS access key ID for the S3 bucket
+#
+#  [*aws_secret_access_key*]
+#    AWS secret key for the S3 bucket
+#
+#  [*s3_bucket_name*]
+#    Name of the S3 bucket
+#
+#  [*encryption_key*]
+#    Encryption key that decrypts the backup
+#
 class govuk::node::s_mysql_master (
   $aws_access_key_id = undef,
   $aws_secret_access_key = undef,
@@ -33,7 +50,7 @@ class govuk::node::s_mysql_master (
 
   Govuk_mount['/var/lib/mysql'] -> Class['govuk_mysql::server']
 
-  if $s3_bucket_name {
+  if $s3_bucket_name and $aws_access_key_id and $aws_secret_access_key {
     govuk_mysql::xtrabackup::restore { $::hostname:
       aws_access_key_id     => $aws_access_key_id,
       aws_secret_access_key => $aws_secret_access_key,

--- a/modules/govuk/manifests/node/s_whitehall_mysql_backup.pp
+++ b/modules/govuk/manifests/node/s_whitehall_mysql_backup.pp
@@ -1,7 +1,38 @@
-# FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
-class govuk::node::s_whitehall_mysql_backup inherits govuk::node::s_whitehall_mysql_slave {
+# == Class: Govuk::Node::S_whitehall_mysql_backup
+#
+#  Set up a GOV.UK Whitehall MySQL Backup machine
+#
+# === Parameters:
+#
+#  [*aws_access_key_id*]
+#    AWS access key ID for the S3 bucket
+#
+#  [*aws_secret_access_key*]
+#    AWS secret key for the S3 bucket
+#
+#  [*s3_bucket_name*]
+#    Name of the S3 bucket
+#
+#  [*encryption_key*]
+#    Encryption key that encrypts the backup for S3
+#
+class govuk::node::s_whitehall_mysql_backup (
+  $aws_access_key_id = undef,
+  $aws_secret_access_key = undef,
+  $s3_bucket_name = undef,
+  $encryption_key = undef,
+) inherits govuk::node::s_whitehall_mysql_slave {
   class { 'backup::mysql':
     mysql_dump_password => hiera('mysql_root',''),
     require             => Govuk_mount['/var/lib/automysqlbackup'],
+  }
+
+  if $s3_bucket_name and $aws_access_key_id and $aws_secret_access_key {
+    govuk_mysql::xtrabackup::backup { $::hostname:
+      aws_access_key_id     => $aws_access_key_id,
+      aws_secret_access_key => $aws_secret_access_key,
+      s3_bucket_name        => $s3_bucket_name,
+      encryption_key        => $encryption_key,
+    }
   }
 }

--- a/modules/govuk/manifests/node/s_whitehall_mysql_master.pp
+++ b/modules/govuk/manifests/node/s_whitehall_mysql_master.pp
@@ -4,11 +4,27 @@
 #
 # === Parameters
 #
-# [*whitehall_fe_password*]
-#   Password for a MySQL account called `whitehall_fe`.
+#  [*whitehall_fe_password*]
+#    Password for a MySQL account called `whitehall_fe`.
+#
+#  [*aws_access_key_id*]
+#    AWS access key ID for the S3 bucket
+#
+#  [*aws_secret_access_key*]
+#    AWS secret key for the S3 bucket
+#
+#  [*s3_bucket_name*]
+#    Name of the S3 bucket
+#
+#  [*encryption_key*]
+#    Encryption key that decrypts the backup
 #
 class govuk::node::s_whitehall_mysql_master (
   $whitehall_fe_password = '',
+  $aws_access_key_id = undef,
+  $aws_secret_access_key = undef,
+  $s3_bucket_name = undef,
+  $encryption_key = undef,
 ) inherits govuk::node::s_base {
   $replica_password = hiera('mysql_replica_password', '')
   $root_password = hiera('mysql_root', '')
@@ -36,4 +52,13 @@ class govuk::node::s_whitehall_mysql_master (
   }
 
   Govuk_mount['/var/lib/mysql'] -> Class['govuk_mysql::server']
+
+  if $s3_bucket_name and $aws_access_key_id and $aws_secret_access_key {
+    govuk_mysql::xtrabackup::restore { $::hostname:
+      aws_access_key_id     => $aws_access_key_id,
+      aws_secret_access_key => $aws_secret_access_key,
+      s3_bucket_name        => $s3_bucket_name,
+      encryption_key        => $encryption_key,
+    }
+  }
 }


### PR DESCRIPTION
This adds all the configuration which sets up MySQL S3 backups in all environments, on both Whitehall MySQL backup and MySQL backup machines. It also adds the restore scripts the appropriate masters.

The majority of this work had already been completed but we have changed focus so we are no longer doing an automated restore from Production to Staging/Integration, but should still provide the tools to allow restoring from backups for the appropriate environments.

Ref: [Trello story](https://trello.com/c/AsknJrSt/102-script-to-restore-s3-mysql-backups)