### PR TITLE
Add firewall rule for licence-finder Elasticsearch

### DIFF
--- a/modules/govuk/manifests/node/s_api_elasticsearch.pp
+++ b/modules/govuk/manifests/node/s_api_elasticsearch.pp
@@ -37,6 +37,22 @@ class govuk::node::s_api_elasticsearch inherits govuk::node::s_base {
     require => Govuk_host['search-3'],
   }
 
+  @ufw::allow { 'allow-elasticsearch-http-9200-from-calculators-frontend-1':
+    port    => 9200,
+    from    => getparam(Govuk_host['calculators-frontend-1'], 'ip'),
+    require => Govuk_host['calculators-frontend-1'],
+  }
+  @ufw::allow { 'allow-elasticsearch-http-9200-from-calculators-frontend-2':
+    port    => 9200,
+    from    => getparam(Govuk_host['calculators-frontend-2'], 'ip'),
+    require => Govuk_host['calculators-frontend-2'],
+  }
+  @ufw::allow { 'allow-elasticsearch-http-9200-from-calculators-frontend-3':
+    port    => 9200,
+    from    => getparam(Govuk_host['calculators-frontend-3'], 'ip'),
+    require => Govuk_host['calculators-frontend-3'],
+  }
+
   collectd::plugin::tcpconn { 'es-9200':
     incoming => 9200,
     outgoing => 9200,

--- a/modules/govuk/manifests/node/s_development.pp
+++ b/modules/govuk/manifests/node/s_development.pp
@@ -47,12 +47,13 @@ class govuk::node::s_development (
   }
 
   class { 'govuk_elasticsearch':
-    cluster_name         => 'govuk-development',
-    heap_size            => '1024m',
-    number_of_shards     => '1',
-    number_of_replicas   => '0',
-    minimum_master_nodes => '1',
-    require              => Class['govuk_java::set_defaults'],
+    cluster_name           => 'govuk-development',
+    heap_size              => '1024m',
+    number_of_shards       => '1',
+    number_of_replicas     => '0',
+    minimum_master_nodes   => '1',
+    open_firewall_from_all => true,
+    require                => Class['govuk_java::set_defaults'],
   }
 
   include nginx

--- a/modules/govuk/manifests/node/s_elasticsearch.pp
+++ b/modules/govuk/manifests/node/s_elasticsearch.pp
@@ -17,12 +17,13 @@ class govuk::node::s_elasticsearch inherits govuk::node::s_base {
   }
 
   class { 'govuk_elasticsearch':
-    cluster_hosts      => ['elasticsearch-1.backend:9300', 'elasticsearch-2.backend:9300', 'elasticsearch-3.backend:9300'],
-    cluster_name       => 'govuk-production',
-    heap_size          => "${es_heap_size}m",
-    number_of_replicas => '1',
-    host               => $::fqdn,
-    require            => [Class['govuk_java::oracle7::jre'],Class['govuk_java::set_defaults']],
+    cluster_hosts          => ['elasticsearch-1.backend:9300', 'elasticsearch-2.backend:9300', 'elasticsearch-3.backend:9300'],
+    cluster_name           => 'govuk-production',
+    heap_size              => "${es_heap_size}m",
+    number_of_replicas     => '1',
+    host                   => $::fqdn,
+    open_firewall_from_all => true,
+    require                => [Class['govuk_java::oracle7::jre'],Class['govuk_java::set_defaults']],
   }
 
   collectd::plugin::tcpconn { 'es-9200':

--- a/modules/govuk/manifests/node/s_logs_elasticsearch.pp
+++ b/modules/govuk/manifests/node/s_logs_elasticsearch.pp
@@ -30,16 +30,17 @@ class govuk::node::s_logs_elasticsearch(
   ]
 
   class { 'govuk_elasticsearch':
-    cluster_hosts        => regsubst($cluster_hostnames, '^.*$', '\0.management:9300'),
-    cluster_name         => 'logging',
-    heap_size            => "${es_heap_size}m",
-    number_of_replicas   => '1',
-    host                 => $::fqdn,
-    log_index_type_count => {
+    cluster_hosts          => regsubst($cluster_hostnames, '^.*$', '\0.management:9300'),
+    cluster_name           => 'logging',
+    heap_size              => "${es_heap_size}m",
+    number_of_replicas     => '1',
+    host                   => $::fqdn,
+    log_index_type_count   => {
       'logs-current' => ['syslog'],
     },
-    disable_gc_alerts    => true,
-    require              => [
+    disable_gc_alerts      => true,
+    open_firewall_from_all => true,
+    require                => [
       Class['govuk_java::openjdk7::jre'],
       Govuk_mount['/mnt/elasticsearch']
     ],

--- a/modules/govuk_elasticsearch/manifests/init.pp
+++ b/modules/govuk_elasticsearch/manifests/init.pp
@@ -20,7 +20,6 @@
 #   Whether to add a firewall allow rule allowing all access to port 9200 (the
 #   main http port). Typically set to false to allow restricting access to
 #   specific machines.
-#   Default: true
 #
 # [*backup_enabled*]
 #   Boolean. Whether backup class will be included.
@@ -38,7 +37,7 @@ class govuk_elasticsearch (
   $log_index_type_count = {},
   $disable_gc_alerts = false,
   $manage_repo = true,
-  $open_firewall_from_all = true,
+  $open_firewall_from_all = false,
   $backup_enabled = false
 ) {
 

--- a/modules/govuk_elasticsearch/spec/classes/govuk_elasticsearch_spec.rb
+++ b/modules/govuk_elasticsearch/spec/classes/govuk_elasticsearch_spec.rb
@@ -173,7 +173,7 @@ describe 'govuk_elasticsearch', :type => :class do
     end
   end
 
-  describe "disabling default http 9200 firewall rule" do
+  describe "firewall rules" do
     let(:params) {{
       :version => '1.7.0',
     }}
@@ -183,14 +183,14 @@ describe 'govuk_elasticsearch', :type => :class do
       "Ufw::Allow <| |>"
     }
 
-    it "should create the firewall by default" do
-      expect(subject).to contain_ufw__allow('allow-elasticsearch-http-9200-from-all')
+    it "should be closed by default" do
+      expect(subject).to have_ufw__allow_resource_count(0)
     end
 
-    it "should not create it when requested" do
-      params[:open_firewall_from_all] = false
+    it "should be open when requested" do
+      params[:open_firewall_from_all] = true
 
-      expect(subject).to have_ufw__allow_resource_count(0)
+      expect(subject).to contain_ufw__allow('allow-elasticsearch-http-9200-from-all')
     end
   end
 


### PR DESCRIPTION
licence-finder needs to use Elasticsearch to display licence search results. We want to move it from the old Elasticsearch to the new one so that we can switch the old one off.

/cc @h-lame 