### PR TITLE
Add timeout command for MySQL S3 backups

### DIFF
--- a/modules/govuk_mysql/manifests/xtrabackup/backup.pp
+++ b/modules/govuk_mysql/manifests/xtrabackup/backup.pp
@@ -94,14 +94,14 @@ define govuk_mysql::xtrabackup::backup (
   }
 
   cron::crondotdee { 'xtrabackup_s3_base':
-    command => '/usr/bin/setlock -N /var/run/mysql_xtrabackup /usr/local/bin/xtrabackup_s3_base',
+    command => '/usr/bin/timeout 1h /usr/bin/setlock -N /var/run/mysql_xtrabackup /usr/local/bin/xtrabackup_s3_base',
     hour    => $base_backup_cron_hour,
     minute  => $base_backup_cron_minute,
     mailto  => $mailto,
   }
 
   cron::crondotdee { 'xtrabackup_s3_incremental':
-    command => '/usr/bin/setlock -n /var/run/mysql_xtrabackup /usr/local/bin/xtrabackup_s3_incremental',
+    command => '/usr/bin/timeout 30m /usr/bin/setlock -n /var/run/mysql_xtrabackup /usr/local/bin/xtrabackup_s3_incremental',
     hour    => '*',
     minute  => $incremental_backup_cron_minute,
     mailto  => $mailto,


### PR DESCRIPTION
This issue was raised because there was an unusual situation where gof3r was unable to reach the S3 bucket, and while gof3r threw an error, because of the pipe structure the streaming backup continued to stream the backup without finishing because it had no valid endpoint (as far as I can gather).

It would be safer to explicitly set a timeout value for both the incremental and base backup pushes. If they don't complete in the given time it's likely that they have run into an error.