### PR TITLE
Cdn logrotate rotate

### DIFF
--- a/modules/govuk_cdnlogs/spec/classes/govuk_cdnlogs_spec.rb
+++ b/modules/govuk_cdnlogs/spec/classes/govuk_cdnlogs_spec.rb
@@ -117,7 +117,7 @@ ruleset\(name="cdn-giraffe"\) \{
         it 'should rotate the elephant logs hourly' do
           is_expected.to contain_file('/etc/logrotate.cdn_logs_hourly.conf')
             .with_content(%r{^/tmp/logs/cdn-elephant\.log$})
-            .with_content(/rotate 720/)
+            .with_content(/maxage 30/)
         end
       end
     end

--- a/modules/govuk_cdnlogs/templates/etc/logrotate.cdn_logs_hourly.conf.erb
+++ b/modules/govuk_cdnlogs/templates/etc/logrotate.cdn_logs_hourly.conf.erb
@@ -4,7 +4,7 @@
 -%>
 
 {
-  rotate 720
+  maxage 30
   dateext
   dateformat -%Y%m%d-%s
   compress


### PR DESCRIPTION
What
Logrotate never removes CDN's log files. It appears that logrotate compresses CDN's log files but due to what I think is a config error.  They never get removed.  The result is log files building up and causing alerts for disk space.

How
Modify logrotate to remove the logs after 30 days.  The previous attempt to amend this was done in error by setting the `rotate` file count to 720.
Please see https://linuxconfig.org/logrotate-8-manual-page for more info.