### PR TITLE
Add slack plugin to Jenkins

### DIFF
--- a/hieradata/class/jenkins.yaml
+++ b/hieradata/class/jenkins.yaml
@@ -91,6 +91,8 @@ govuk_jenkins::plugins:
     version: '0.0.8'
   show-build-parameters:
     version: '1.0'
+  slack:
+    version: '1.7'
   text-finder:
     version: '1.10'
   timestamper:


### PR DESCRIPTION
We would like to receive some notifications on slack regarding some builds. For
example, when the "Copy Data to <environment>" builds fail, we would like to
have visibility on it.

The Jenkins' slack plugin will allow us to do this and it is more configurable than using a simple webhook.

More details here: https://wiki.jenkins-ci.org/display/JENKINS/Slack+Plugin

**Note**: The latest version of the slack plugin is `2.0.1`, which needs core to be `1.609.2`. Currently our jenkins version is [1.554.2](https://github.com/alphagov/govuk-puppet/blob/master/modules/govuk_jenkins/manifests/init.pp#L108), therefore I had to use slack version `1.7` to make sure it's compatible.