### PR TITLE
Update manuals publisher port to 3205

### DIFF
--- a/modules/govuk/manifests/apps/manuals_publisher.pp
+++ b/modules/govuk/manifests/apps/manuals_publisher.pp
@@ -51,7 +51,7 @@
 #   Default: 6379
 #
 class govuk::apps::manuals_publisher(
-  $port = 3064,
+  $port = 3205,
   $asset_manager_bearer_token = undef,
   $email_alert_api_bearer_token = undef,
   $enable_procfile_worker = true,


### PR DESCRIPTION
Manuals Publisher is a new application despite being a re-purposed Specialist Publisher so it needs a new port number so that it doesn't conflict with existing Specialist Publisher app(s).
https://github.gds/gds/development/pull/342