### PR TITLE
Sort list of machines requiring reboots

### DIFF
--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_reboots_required
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_reboots_required
@@ -29,14 +29,14 @@ else
   if unsafe_machines.length > 0
     puts "\n"
     puts 'These hosts need to be rebooted manually:'
-    unsafe_machines.each do |hostname|
+    unsafe_machines.sort.each do |hostname|
       puts "- #{hostname}"
     end
   end
   if safe_machines.length > 0
     puts "\n"
     puts 'These hosts should reboot overnight:'
-    safe_machines.each do |hostname|
+    safe_machines.sort.each do |hostname|
       puts "- #{hostname}"
     end
   end


### PR DESCRIPTION
Currently, this is seemingly random.  It's much easier to work through a list
if it's ordered.