### PR TITLE
Add manuals_publisher to the list of enabled apps

### DIFF
--- a/hieradata/class/backend.yaml
+++ b/hieradata/class/backend.yaml
@@ -68,6 +68,7 @@ govuk::node::s_base::apps:
   - imminence
   - kibana
   - local_links_manager
+  - manuals_publisher
   - maslow
   - need_api
   - panopticon

--- a/hieradata/class/backend.yaml
+++ b/hieradata/class/backend.yaml
@@ -15,6 +15,12 @@ govuk::apps::contentapi::mongodb_nodes:
   - 'mongo-2.backend'
   - 'mongo-3.backend'
 
+govuk::apps::manuals_publisher::mongodb_name: 'manuals_publisher_production'
+govuk::apps::manuals_publisher::mongodb_nodes:
+  - 'mongo-1.backend'
+  - 'mongo-2.backend'
+  - 'mongo-3.backend'
+
 govuk::apps::panopticon::mongodb_name: 'govuk_content_production'
 govuk::apps::panopticon::mongodb_nodes:
   - 'mongo-1.backend'


### PR DESCRIPTION
This was missed in https://github.com/alphagov/govuk-puppet/pull/4874, we want to enable this application now.