### PR TITLE
PostgreSQL Backup Lock File

### DIFF
--- a/modules/govuk_postgresql/files/etc/postgresql-backup-post
+++ b/modules/govuk_postgresql/files/etc/postgresql-backup-post
@@ -14,3 +14,10 @@ chmod u=wr,go=r latest.tbz2
 
 # Log the time we finished
 logger -t autopostgresqlbackup autopostgresqlbackup finished
+
+# Remove lock file after backup has finished regardless of the status
+function remove_lock {
+  /bin/rm -f /etc/unattended-reboot/no-reboot/autopostgresqlbackup.lock
+}
+
+trap remove_lock EXIT

--- a/modules/govuk_postgresql/files/etc/postgresql-backup-pre
+++ b/modules/govuk_postgresql/files/etc/postgresql-backup-pre
@@ -1,4 +1,8 @@
 #!/bin/bash
 
+
 # Log the time we started
 logger -t autopostgresqlbackup autopostgresqlbackup started
+
+#Prevent host from rebooting while backup is in progress...
+/usr/bin/touch /etc/unattended-reboot/no-reboot/autopostgresqlbackup.lock


### PR DESCRIPTION
What
Think I've noticed a recurring event where the autopostgresql backup gets interrupted by
unattended reboot.

How
Create lock file to defer unattended reboot while a backup is in progress and remove the
lock when finished. Regardless of status.