### PR TITLE
Provide redis_host and redis_port configs for manuals_publisher

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -301,6 +301,9 @@ govuk::apps::frontend::nagios_memory_critical: 1400
 
 govuk::apps::govuk_cdn_logs_monitor::processed_data_dir: '/mnt/logs_cdn/data'
 
+govuk::apps::manuals_publisher::redis_host: "%{hiera('sidekiq_host')}"
+govuk::apps::manuals_publisher::redis_port: "%{hiera('sidekiq_port')}"
+
 govuk::apps::publisher::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::publisher::redis_port: "%{hiera('sidekiq_port')}"
 


### PR DESCRIPTION
[Manuals Publisher is currently looking for Redis on localhost](https://errbit.integration.publishing.service.gov.uk/apps/57dfff6a65786363d4270100/problems/57e9408a657863704d2f0000), this doesn't work so do what other apps do.