### PR TITLE
[do not merge] updated to replace manuals publisher deploy with specialist publisher

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,6 +126,3 @@ DEPENDENCIES
   rspec-puppet
   sshkey (= 1.7.0)
   webmock (~> 1.20.0)
-
-BUNDLED WITH
-   1.11.2

--- a/hieradata/class/backend.yaml
+++ b/hieradata/class/backend.yaml
@@ -33,7 +33,7 @@ govuk::apps::share_sale_publisher::mongodb_nodes:
   - 'mongo-2.backend'
   - 'mongo-3.backend'
 
-govuk::apps::specialist_publisher::mongodb_name: 'specialist_publisher_production'
+govuk::apps::specialist_publisher::mongodb_name: 'govuk_content_production'
 govuk::apps::specialist_publisher::mongodb_nodes:
   - 'mongo-1.backend'
   - 'mongo-2.backend'

--- a/hieradata/class/backend.yaml
+++ b/hieradata/class/backend.yaml
@@ -33,6 +33,12 @@ govuk::apps::share_sale_publisher::mongodb_nodes:
   - 'mongo-2.backend'
   - 'mongo-3.backend'
 
+govuk::apps::specialist_publisher::mongodb_name: 'specialist_publisher_production'
+govuk::apps::specialist_publisher::mongodb_nodes:
+  - 'mongo-1.backend'
+  - 'mongo-2.backend'
+  - 'mongo-3.backend'
+
 govuk::apps::specialist_publisher_rebuild::mongodb_name: 'govuk_content_production'
 govuk::apps::specialist_publisher_rebuild::mongodb_nodes:
   - 'mongo-1.backend'

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -163,6 +163,8 @@ govuk::apps::signon::enable_procfile_worker: false
 govuk::apps::smartanswers::expose_govspeak: true
 govuk::apps::specialist_publisher::enable_procfile_worker: false
 govuk::apps::specialist_publisher::publish_pre_production_finders: true
+govuk::apps::specialist_publisher::mongodb_nodes: ['localhost']
+govuk::apps::specialist_publisher::mongodb_name: 'specialist_publisher_development'
 govuk::apps::specialist_publisher_rebuild::enable_procfile_worker: false
 govuk::apps::specialist_publisher_rebuild::mongodb_name: 'specialist_publisher_rebuild_production'
 govuk::apps::specialist_publisher_rebuild::mongodb_nodes: ['localhost']

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -164,9 +164,9 @@ govuk::apps::smartanswers::expose_govspeak: true
 govuk::apps::specialist_publisher::enable_procfile_worker: false
 govuk::apps::specialist_publisher::publish_pre_production_finders: true
 govuk::apps::specialist_publisher::mongodb_nodes: ['localhost']
-govuk::apps::specialist_publisher::mongodb_name: 'specialist_publisher_development'
+govuk::apps::specialist_publisher::mongodb_name: 'govuk_content_development'
 govuk::apps::specialist_publisher_rebuild::enable_procfile_worker: false
-govuk::apps::specialist_publisher_rebuild::mongodb_name: 'specialist_publisher_rebuild_production'
+govuk::apps::specialist_publisher_rebuild::mongodb_name: 'govuk_content_development'
 govuk::apps::specialist_publisher_rebuild::mongodb_nodes: ['localhost']
 govuk::apps::specialist_publisher_rebuild::publish_pre_production_finders: true
 govuk::apps::stagecraft::worker::enabled: true

--- a/modules/govuk/manifests/apps/specialist_publisher.pp
+++ b/modules/govuk/manifests/apps/specialist_publisher.pp
@@ -6,7 +6,7 @@
 #
 # [*port*]
 #   The port that publishing API is served on.
-#   Default: 3123
+#   Default: 3064
 #
 # [*custom_http_host*]
 #   This setting allows the default HTTP Host header to be overridden.
@@ -73,7 +73,7 @@
 #   Default: undef
 #
 class govuk::apps::specialist_publisher(
-  $port = 3123,
+  $port = 3064,
   $asset_manager_bearer_token = undef,
   $errbit_api_key = undef,
   $email_alert_api_bearer_token = undef,

--- a/modules/govuk/manifests/apps/specialist_publisher.pp
+++ b/modules/govuk/manifests/apps/specialist_publisher.pp
@@ -1,21 +1,51 @@
-# == Class: govuk::apps::specialist_publisher
+# == Class: govuk::apps::specialist_publisher_rebuild
 #
-# Publishing App for specialist documents and manuals.
+# A rebuild of specialist-publisher, a publishing app for specialist documents and manuals.
 #
 # === Parameters
 #
 # [*port*]
 #   The port that publishing API is served on.
-#   Default: 3064
+#   Default: 3123
+#
+# [*custom_http_host*]
+#   This setting allows the default HTTP Host header to be overridden.
+#
+#   An example of where this is useful is if requests are handled by different
+#   backend applications but use the same hostname.
+#   Default: undef
+#
+# [*asset_manager_bearer_token*]
+#   The bearer token to use when communicating with Asset Manager.
+#   Default: undef
+#
+# [*errbit_api_key*]
+#   Errbit API key for sending errors.
+#   Default: undef
 #
 # [*enabled*]
-#   Whether the app is enabled.
+#   A flag to toggle the app's existence on different environments.
 #   Default: false
 #
-# [*enable_procfile_worker*]
-#   Whether to enable the procfile worker
-#   Default: true
-
+# [*email_alert_api_bearer_token*]
+#   The bearer token to use when communicating with Email Alert API.
+#   Default: undef
+#
+# [*mongodb_nodes*]
+#   Array of hostnames for the mongo cluster to use.
+#
+# [*mongodb_name*]
+#   The mongo database to be used. Overriden in development
+#   to be 'content_store_development'.
+#
+# [*oauth_id*]
+#   Sets the OAuth ID for using GDS-SSO
+#   Default: undef
+#
+# [*oauth_secret*]
+#   Sets the OAuth Secret Key for using GDS-SSO
+#   Default: undef
+#
 # [*publish_pre_production_finders*]
 #   Whether to enable publishing of pre-production finders
 #   Default: false
@@ -24,42 +54,96 @@
 #   The bearer token to use when communicating with Publishing API.
 #   Default: undef
 #
-# [*email_alert_api_bearer_token*]
-#   The bearer token to use when communicating with Email Alert API.
+# [*redis_host*]
+#   Redis host for sidekiq.
+#
+# [*redis_port*]
+#   Redis port for sidekiq.
+#   Default: 6379
+#
+# [*enable_procfile_worker*]
+#   Enables the sidekiq background worker.
+#   Default: true
+#
+# [*secret_token*]
+#   Used to set the app ENV var SECRET_TOKEN which is used to configure
+#   rails 4.x signed cookie mechanism. If unset the app will be unable to
+#   start. SECRET_TOKEN is used rather than SECRET_KEY_BASE so that
+#   specialist publisher rebuild can share signed cookies with version 1.
 #   Default: undef
 #
-# [*nagios_memory_warning*]
-#   Memory use at which Nagios should generate a warning.
-#
-# [*nagios_memory_critical*]
-#   Memory use at which Nagios should generate a critical alert.
-#
 class govuk::apps::specialist_publisher(
-  $port = '3064',
+  $port = 3123,
+  $asset_manager_bearer_token = undef,
+  $errbit_api_key = undef,
+  $email_alert_api_bearer_token = undef,
   $enabled = false,
-  $enable_procfile_worker = true,
+  $mongodb_nodes,
+  $mongodb_name,
+  $oauth_id = undef,
+  $oauth_secret = undef,
   $publish_pre_production_finders = false,
   $publishing_api_bearer_token = undef,
-  $email_alert_api_bearer_token = undef,
-  $nagios_memory_warning = undef,
-  $nagios_memory_critical = undef,
+  $redis_host = undef,
+  $redis_port = undef,
+  $enable_procfile_worker = true,
+  $secret_token = undef,
 ) {
+  $app_name = 'specialist-publisher'
+  $app_domain = hiera('app_domain')
 
   if $enabled {
-    govuk::app { 'specialist-publisher':
-      app_type               => 'rack',
-      port                   => $port,
-      health_check_path      => '/specialist-documents',
-      log_format_is_json     => true,
-      nginx_extra_config     => '
-client_max_body_size 500m;
-',
-      nagios_memory_warning  => $nagios_memory_warning,
-      nagios_memory_critical => $nagios_memory_critical,
+    govuk::app { $app_name:
+      app_type           => 'rack',
+      port               => $port,
+      health_check_path  => '/healthcheck',
+      log_format_is_json => true,
+      asset_pipeline     => true,
+    }
+
+    govuk::procfile::worker {'specialist-publisher':
+      enable_service => $enable_procfile_worker,
+    }
+
+    govuk_logging::logstream { 'specialist-publisher_sidekiq_json_log':
+      logfile => '/var/apps/specialist-publisher/log/sidekiq.json.log',
+      fields  => {'application' => 'specialist-publisher'},
+      json    => true,
     }
 
     Govuk::App::Envvar {
-      app => 'specialist-publisher',
+      app => $app_name,
+    }
+
+    govuk::app::envvar::mongodb_uri { $app_name:
+      hosts    => $mongodb_nodes,
+      database => $mongodb_name,
+    }
+
+    govuk::app::envvar::redis { $app_name:
+      host => $redis_host,
+      port => $redis_port,
+    }
+
+    govuk::app::envvar {
+      "${title}-ASSET_MANAGER_BEARER_TOKEN":
+        varname => 'ASSET_MANAGER_BEARER_TOKEN',
+        value   => $asset_manager_bearer_token;
+      "${title}-ERRBIT_API_KEY":
+        varname => 'ERRBIT_API_KEY',
+        value   => $errbit_api_key;
+      "${title}-EMAIL_ALERT_API_BEARER_TOKEN":
+        varname => 'EMAIL_ALERT_API_BEARER_TOKEN',
+        value   => $email_alert_api_bearer_token;
+      "${title}-OAUTH_ID":
+        varname => 'OAUTH_ID',
+        value   => $oauth_id;
+      "${title}-OAUTH_SECRET":
+        varname => 'OAUTH_SECRET',
+        value   => $oauth_secret;
+      "${title}-PUBLISHING_API_BEARER_TOKEN":
+        varname => 'PUBLISHING_API_BEARER_TOKEN',
+        value   => $publishing_api_bearer_token;
     }
 
     if $publish_pre_production_finders {
@@ -70,17 +154,11 @@ client_max_body_size 500m;
       }
     }
 
-    govuk::procfile::worker { 'specialist-publisher':
-      enable_service => $enable_procfile_worker,
-    }
-
-    govuk::app::envvar {
-      "${title}-PUBLISHING_API_BEARER_TOKEN":
-      varname => 'PUBLISHING_API_BEARER_TOKEN',
-      value   => $publishing_api_bearer_token;
-      "${title}-EMAIL_ALERT_API_BEARER_TOKEN":
-      varname => 'EMAIL_ALERT_API_BEARER_TOKEN',
-      value   => $email_alert_api_bearer_token;
+    if $secret_token != undef {
+      govuk::app::envvar { "${title}-SECRET_TOKEN":
+        varname => 'SECRET_TOKEN',
+        value   => $secret_token,
+      }
     }
   }
 }

--- a/modules/govuk/manifests/node/s_backend_lb.pp
+++ b/modules/govuk/manifests/node/s_backend_lb.pp
@@ -43,6 +43,69 @@ class govuk::node::s_backend_lb (
       error_on_http => true,
       servers       => $backend_servers;
     [
+      'specialist-publisher',
+    ]:
+      modified_paths => {
+        '/sp-rebuild/assets'                    => {
+          'app' => 'specialist-publisher-rebuild',
+        },
+        '/rebuild-healthcheck'                  => {
+          'app' => 'specialist-publisher-rebuild',
+        },
+        '/preview'                              => {
+          'app' => 'specialist-publisher-rebuild',
+        },
+        '/raib-reports'                         => {
+          'app' => 'specialist-publisher-rebuild',
+        },
+        '/maib-reports'                         => {
+          'app' => 'specialist-publisher-rebuild',
+        },
+        '/dfid-research-outputs'                => {
+          'app' => 'specialist-publisher-rebuild',
+        },
+        '/aaib-reports'                         => {
+          'app' => 'specialist-publisher-rebuild',
+        },
+        '/cma-cases'                            => {
+          'app' => 'specialist-publisher-rebuild',
+        },
+        '/international-development-funds'      => {
+          'app' => 'specialist-publisher-rebuild',
+        },
+        '/countryside-stewardship-grants'       => {
+          'app' => 'specialist-publisher-rebuild',
+        },
+        '/esi-funds'                            => {
+          'app' => 'specialist-publisher-rebuild',
+        },
+        '/tax-tribunal-decisions'               => {
+          'app' => 'specialist-publisher-rebuild',
+        },
+        '/utaac-decisions'                      => {
+          'app' => 'specialist-publisher-rebuild',
+        },
+        '/employment-tribunal-decisions'        => {
+          'app' => 'specialist-publisher-rebuild',
+        },
+        '/employment-appeal-tribunal-decisions' => {
+          'app' => 'specialist-publisher-rebuild',
+        },
+        '/asylum-support-decisions'             => {
+          'app' => 'specialist-publisher-rebuild',
+        },
+        '/vehicle-recalls-and-faults-alerts'    => {
+          'app' => 'specialist-publisher-rebuild',
+        },
+        '/drug-safety-updates'                  => {
+          'app' => 'specialist-publisher-rebuild',
+        },
+        '/medical-safety-alerts'                => {
+          'app' => 'specialist-publisher-rebuild',
+        },
+      },
+      servers        => $backend_servers;
+    [
       'business-support-api',
       'collections-publisher',
       'contacts-admin',
@@ -59,7 +122,6 @@ class govuk::node::s_backend_lb (
       'service-manual-publisher',
       'share-sale-publisher',
       'signon',
-      'specialist-publisher',
       'specialist-publisher-rebuild-standalone',
       'short-url-manager',
       'support',

--- a/modules/govuk/manifests/node/s_backend_lb.pp
+++ b/modules/govuk/manifests/node/s_backend_lb.pp
@@ -43,69 +43,6 @@ class govuk::node::s_backend_lb (
       error_on_http => true,
       servers       => $backend_servers;
     [
-      'specialist-publisher',
-    ]:
-      modified_paths => {
-        '/sp-rebuild/assets'                    => {
-          'app' => 'specialist-publisher-rebuild',
-        },
-        '/rebuild-healthcheck'                  => {
-          'app' => 'specialist-publisher-rebuild',
-        },
-        '/preview'                              => {
-          'app' => 'specialist-publisher-rebuild',
-        },
-        '/raib-reports'                         => {
-          'app' => 'specialist-publisher-rebuild',
-        },
-        '/maib-reports'                         => {
-          'app' => 'specialist-publisher-rebuild',
-        },
-        '/dfid-research-outputs'                => {
-          'app' => 'specialist-publisher-rebuild',
-        },
-        '/aaib-reports'                         => {
-          'app' => 'specialist-publisher-rebuild',
-        },
-        '/cma-cases'                            => {
-          'app' => 'specialist-publisher-rebuild',
-        },
-        '/international-development-funds'      => {
-          'app' => 'specialist-publisher-rebuild',
-        },
-        '/countryside-stewardship-grants'       => {
-          'app' => 'specialist-publisher-rebuild',
-        },
-        '/esi-funds'                            => {
-          'app' => 'specialist-publisher-rebuild',
-        },
-        '/tax-tribunal-decisions'               => {
-          'app' => 'specialist-publisher-rebuild',
-        },
-        '/utaac-decisions'                      => {
-          'app' => 'specialist-publisher-rebuild',
-        },
-        '/employment-tribunal-decisions'        => {
-          'app' => 'specialist-publisher-rebuild',
-        },
-        '/employment-appeal-tribunal-decisions' => {
-          'app' => 'specialist-publisher-rebuild',
-        },
-        '/asylum-support-decisions'             => {
-          'app' => 'specialist-publisher-rebuild',
-        },
-        '/vehicle-recalls-and-faults-alerts'    => {
-          'app' => 'specialist-publisher-rebuild',
-        },
-        '/drug-safety-updates'                  => {
-          'app' => 'specialist-publisher-rebuild',
-        },
-        '/medical-safety-alerts'                => {
-          'app' => 'specialist-publisher-rebuild',
-        },
-      },
-      servers        => $backend_servers;
-    [
       'business-support-api',
       'collections-publisher',
       'contacts-admin',
@@ -122,6 +59,7 @@ class govuk::node::s_backend_lb (
       'service-manual-publisher',
       'share-sale-publisher',
       'signon',
+      'specialist-publisher',
       'specialist-publisher-rebuild-standalone',
       'short-url-manager',
       'support',


### PR DESCRIPTION
specialist publisher deployment has been using a combination of manuals publisher (previously
called specialist publisher) and specialist publisher rebuild. This deployment should work alongside [this pull request](https://github.com/alphagov/govuk-app-deployment/pull/49) 
to replace this with a single deployment of specialist publisher rebuild, living at the address previously
occupied by manuals publisher. It also removes the custom routing to enable the combined deployment previously utilised.