### PR TITLE
Amend the mongodb_name this got lost in translation

### DIFF
--- a/hieradata/class/backend.yaml
+++ b/hieradata/class/backend.yaml
@@ -15,7 +15,7 @@ govuk::apps::contentapi::mongodb_nodes:
   - 'mongo-2.backend'
   - 'mongo-3.backend'
 
-govuk::apps::manuals_publisher::mongodb_name: 'manuals_publisher_production'
+govuk::apps::manuals_publisher::mongodb_name: 'govuk_content_production'
 govuk::apps::manuals_publisher::mongodb_nodes:
   - 'mongo-1.backend'
   - 'mongo-2.backend'


### PR DESCRIPTION
https://github.gds/gds/alphagov-deployment/blob/master/specialist-publisher/to_upload/mongoid.yml#L2
Manuals Publisher should use the same collection as Specialist Publisher v1 did.