### PR TITLE
Make postfix class comply with the future parser

### DIFF
--- a/modules/postfix/manifests/init.pp
+++ b/modules/postfix/manifests/init.pp
@@ -23,9 +23,9 @@
 #   Pass to authenticate all relayed mail with.
 #
 class postfix (
-  $smarthost = '',
-  $smarthost_user = '',
-  $smarthost_pass = '',
+  $smarthost = undef,
+  $smarthost_user = undef,
+  $smarthost_pass = undef,
   $rewrite_mail_domain = 'localhost',
   $rewrite_mail_list = 'noemail'
 ) {


### PR DESCRIPTION
In the future parser, an empty string is truthy. We're using this for a boolean comparison in `postfix::config` so really what we want to default to undefined.