### PR TITLE
Transition PostgreSQL amend Standby IP Suffix

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1167,8 +1167,8 @@ postgresql_slave_addresses_live: "%{hiera('environment_ip_prefix')}.3.13/32"
 postgresql_slave_addresses_dr: "%{hiera('environment_ip_prefix')}.11.13/32"
 postgresql_transition_slave_addresses_live: "%{hiera('environment_ip_prefix')}.3.61/32"
 postgresql_transition_slave_addresses_dr: "%{hiera('environment_ip_prefix')}.11.61/32"
-postgresql_transition_standby_addresses_live: "%{hiera('environment_ip_prefix')}.3.61/32"
-postgresql_transition_standby_addresses_dr: "%{hiera('environment_ip_prefix')}.11.61/32"
+postgresql_transition_standby_addresses_live: "%{hiera('environment_ip_prefix')}.3.161/32"
+postgresql_transition_standby_addresses_dr: "%{hiera('environment_ip_prefix')}.11.161/32"
 
 postgresql::lib::devel::link_pg_config: false
 postgresql::globals::version: '9.3'


### PR DESCRIPTION
What
There are alerts for the two new Transition PostgreSQL standby hosts
missing data.  At present we cannot sync the hosts until we modify the pg_hba.conf with the correct ipaddress.

How
Add correct IP host suffix to hiera.