### PR TITLE
[DO NOT MERGE] Add Slack properties and publisher details

### DIFF
--- a/modules/govuk_jenkins/manifests/job/copy_data_to_integration.pp
+++ b/modules/govuk_jenkins/manifests/job/copy_data_to_integration.pp
@@ -10,11 +10,16 @@ class govuk_jenkins::job::copy_data_to_integration (
   $ci_alphagov_api_key = undef,
   $auth_token = undef,
   $app_domain = hiera('app_domain'),
+  $slack_auth_token = undef,
 ) {
 
   $check_name = 'copy_data_to_integration'
   $service_description = 'Copy Data to Integration'
   $job_url = "https://deploy.${app_domain}/job/copy_data_to_integration"
+
+  $slack_team_domain = 'govuk'
+  $slack_room = '2ndline'
+  $slack_build_server_url = "https://deploy.${app_domain}/"
 
   file { '/etc/jenkins_jobs/jobs/copy_data_to_integration.yaml':
     ensure  => present,

--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
@@ -20,6 +20,16 @@
         - inject:
             properties-content: |
               PARALLEL_JOBS=2
+        - slack:
+          notify-start: false
+          notify-success: true
+          notify-aborted: true
+          notify-notbuilt: true
+          notify-unstable: false
+          notify-failure: true
+          notify-backtonormal: false
+          notify-repeatedfailure: false
+          include-test-summary: false
     scm:
       - env-sync-and-backup_Copy_Data_to_Integration
     logrotate:
@@ -60,6 +70,11 @@
             HOSTNAME=deploy.integration.publishing.service.gov.uk
             API_KEY=<%= @ci_alphagov_api_key %>
             AUTH_TOKEN=<%= @auth_token %>
+      - slack:
+        team-domain: <%= @slack_team_domain %>
+        auth-token: <%= @slack_auth_token %>
+        build-server-url: <%= @slack_build_server_url %>
+        room: <%= @slack_room %>
     wrappers:
         - ansicolor:
             colormap: xterm


### PR DESCRIPTION
This commit adds the slack configuration to the "Copy Data To Integration" job.

Before this can be merged, we need to:
- [ ] Add the Slack Access Token to hieradata in gds/deployment
- [ ] Test this against a local Jenkins.
