### PR TITLE
Provide a list of mongodb hosts for manuals-publisher

### DIFF
--- a/modules/govuk/manifests/apps/manuals_publisher.pp
+++ b/modules/govuk/manifests/apps/manuals_publisher.pp
@@ -93,6 +93,15 @@ class govuk::apps::manuals_publisher(
     port => $redis_port,
   }
 
+  # FIXME: This templated list of mongodb nodes is a temporary measure to allow
+  # us to run manuals publisher on earlier ruby versions as ruby 2.1 cannot
+  # parse the comma delimited MONGODB_URI var.
+  # Either MONGODB_URI or MONGODB_NODES should be removed from this module once
+  # we have resolved ruby version issues.
+  # Please talk to Steve Laing for more information.
+  $mongodb_nodes_template = '<%= @mongodb_nodes.map { |node| "- #{node}:27017" }.join("\n") %>'
+  $mongodb_nodes_string = inline_template($mongodb_nodes_template)
+
   govuk::app::envvar {
     "${title}-ASSET_MANAGER_BEARER_TOKEN":
       varname => 'ASSET_MANAGER_BEARER_TOKEN',
@@ -103,6 +112,9 @@ class govuk::apps::manuals_publisher(
     "${title}-EMAIL_ALERT_API_BEARER_TOKEN":
       varname => 'EMAIL_ALERT_API_BEARER_TOKEN',
       value   => $email_alert_api_bearer_token;
+    "${title}-MONGODB_NODES":
+      varname => 'MONGODB_NODES',
+      value   => $mongodb_nodes_string;
     "${title}-OAUTH_ID":
       varname => 'OAUTH_ID',
       value   => $oauth_id;


### PR DESCRIPTION
[Ruby 2.1.* cannot parse the comma delimited list of mongodb uris](https://deploy.integration.publishing.service.gov.uk/job/Deploy_App/6932/console) and we would like to be able to eliminate recent ruby-version upgrades from problems we're seeing on Manuals Publisher by
reverting to ruby 2.1.2 as this is the version the codebase is known to run happily on.

Provide [a list of mongodb host:port strings](https://github.gds/gds/alphagov-deployment/blob/master/specialist-publisher/to_upload/mongoid.yml#L7) in an ENV var that can be used by older ruby versions to configure mongo.

This is pretty ugly in using an inline template to achieve the correct format, so if there's an easier way please tell me. 
