### PR TITLE
Update Jenkins deploy app tasks for reduced ambiguity

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
@@ -27,7 +27,7 @@
             - project: Deploy_App
               predefined-parameters: |
                 TARGET_APPLICATION=<%= app %>
-                DEPLOY_TASK=deploy:migrate_and_hard_restart
+                DEPLOY_TASK=app:migrate_and_hard_restart
             <%- end -%>
             <%- %w{ govuk_delivery_configure_integration_catchall_feed transition_run_database_migrations }.each do |job| -%>
             - project: <%= job %>

--- a/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
@@ -56,12 +56,18 @@
             choices: <%= ['-- Choose an app'] + @applications %>
         - choice:
             name: DEPLOY_TASK
-            description: Capistrano task to run (also available as $DEPLOY_TASK in deploy.sh)
+            description: |
+              Capistrano task to run (also available as $DEPLOY_TASK in deploy.sh)<br>
+              <code>deploy</code> will typically include migrations, however this is dependent on the project configuration.<br>
+              <code>hard_restart</code> tasks are generally used for when a ruby version changes, and tend to only be configured for ruby projects.
             choices:
                 - deploy
-                - deploy:migrate_and_hard_restart
-                - deploy:migrations
-                - deploy:hard_restart
+                - deploy:with_hard_restart
+                - deploy:with_migrations
+                - deploy:without_migrations
+                - app:migrate
+                - app:hard_restart
+                - app:migrate_and_hard_restart
         - string:
             name: TAG
             description: Git tag/committish to deploy.


### PR DESCRIPTION
Currently users of Jenkins are often confused by the task names in the deploy namespace and expect them to perform a deploy as well as the associated restart or migrate task.

This change updates the commands in favour of renamed ones that are easier to understand with updated description to aid people in picking their task.

The list of tasks to select are:

- deploy
- deploy:with_hard_restart
- deploy:with_migrations
- deploy:without_migrations
- app:migrate
- app:hard_restart
- app:migrate_and_hard_restart

