### PR TITLE
Use api-elasticsearch for calculators-frontend in staging

### DIFF
--- a/hieradata/class/staging/calculators_frontend.yaml
+++ b/hieradata/class/staging/calculators_frontend.yaml
@@ -1,0 +1,6 @@
+---
+
+govuk_elasticsearch::local_proxy::servers:
+  - 'api-elasticsearch-1.api'
+  - 'api-elasticsearch-2.api'
+  - 'api-elasticsearch-3.api'


### PR DESCRIPTION
As a follow up to #4871 we make staging calculators-frontend machines
use the new api-elasticsearch cluster.  We want to run this for a few
days to check it's ok before moving production to the new cluster.