### PR TITLE
Elasticsearch s3 Params

### DIFF
--- a/hieradata/node/api-elasticsearch-1.api.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/api-elasticsearch-1.api.integration.publishing.service.gov.uk.yaml
@@ -1,0 +1,4 @@
+---
+govuk_elasticsearch::backup_enabled: true
+govuk_elasticsearch::backup::s3_bucket: 'govuk-api-elasticsearch'
+govuk_elasticsearch::backup::es_repo: 'snapshots'

--- a/hieradata/node/elasticsearch-1.backend.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/elasticsearch-1.backend.integration.publishing.service.gov.uk.yaml
@@ -1,6 +1,0 @@
----
-govuk_elasticsearch::backup_enabled: true
-govuk_elasticsearch::backup::s3_bucket: 'elasticsearch'
-govuk_elasticsearch::backup::es_repo: 'snapshots'
-govuk_elasticsearch::backup::es_indices:
-  - kibana_int

--- a/hieradata/node/logs-elasticsearch-1.management.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/logs-elasticsearch-1.management.integration.publishing.service.gov.uk.yaml
@@ -1,6 +1,6 @@
 ---
 govuk_elasticsearch::backup_enabled: true
-govuk_elasticsearch::backup::s3_bucket: 'logs-elasticsearch'
+govuk_elasticsearch::backup::s3_bucket: 'govuk-logs-elasticsearch'
 govuk_elasticsearch::backup::es_repo: 'snapshots'
 govuk_elasticsearch::backup::es_indices:
   - kibana_int


### PR DESCRIPTION
What
Clarified what indices we want to backup on which elasticsearch clusters.
Cluster                          Indices
`logs-elasticsearch `  `kibana_int`
`api-elasticsearch`      all

How
Remove hiera node yaml for cluster: `elasticsearch`.
Create hiera node yaml for cluster: `api-elasticsearch`.
Amend the name of the s3 bucket for logs-elasticserach.

Elasticsearch's default behaviour when no indices are specified is to snapshot all indices.
On the api cluster we have to backup all indices which is why we've left it as an empty array.

Relates to https://github.com/alphagov/govuk-puppet/pull/4637