### PR TITLE
fetch hiera-eyaml via https not git.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'puppet-lint-trailing_comma-check', '0.3.2', :require => false
 gem "puppet", '3.8.5'
 gem 'facter', '2.0.2'
 gem "hiera", "1.3.4"
-gem "hiera-eyaml-gpg", :git => 'git://github.com/alphagov/hiera-eyaml-gpg.git', :branch => 'avoid_gpghome_env_var'
+gem "hiera-eyaml-gpg", :git => 'https://github.com/alphagov/hiera-eyaml-gpg.git', :branch => 'avoid_gpghome_env_var'
 gem "rspec-puppet"
 # FIXME: There is some confusion about who should require who.
 # https://github.com/rodjek/rspec-puppet/issues/56

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/alphagov/hiera-eyaml-gpg.git
+  remote: https://github.com/alphagov/hiera-eyaml-gpg.git
   revision: b10d8a890a4aff78b90e4662fe1e2d5b1690937b
   branch: avoid_gpghome_env_var
   specs:


### PR DESCRIPTION
We should pull this over a more trusted protocol that
encrypts the data in transit.