### PR TITLE
Install rack gem properly

### DIFF
--- a/modules/puppet/manifests/master/config.pp
+++ b/modules/puppet/manifests/master/config.pp
@@ -2,7 +2,7 @@
 class puppet::master::config ($unicorn_port = '9090') {
 
   file { '/etc/puppet/config.ru':
-    require => Exec['install rack 1.0.1'],
+    require => Package['rack'],
     source  => 'puppet:///modules/puppet/etc/puppet/config.ru',
   }
 

--- a/modules/puppet/manifests/master/package.pp
+++ b/modules/puppet/manifests/master/package.pp
@@ -30,9 +30,9 @@ class puppet::master::package(
     provider => system_gem,
   }
 
-  exec {'install rack 1.0.1':
-    command => 'gem install rack --no-rdoc --no-ri --version 1.0.1',
-    unless  => 'gem list | grep "rack.*1.0.1"',
+  package { 'rack':
+    ensure   => '1.0.1',
+    provider => system_gem,
   }
 
   package { 'puppetdb-terminus':


### PR DESCRIPTION
We install it this way from 2012 when we used to have 2 versions running: fc22056fd8637ca11b1b2a66c43aac5bbb980c69.