### PR TITLE
Update Specialist Publisher application env

### DIFF
--- a/hieradata/class/backend.yaml
+++ b/hieradata/class/backend.yaml
@@ -43,6 +43,12 @@ govuk::apps::share_sale_publisher::mongodb_nodes:
   - 'mongo-2.backend'
   - 'mongo-3.backend'
 
+govuk::apps::specialist_publisher::mongodb_name: 'govuk_content_production'
+govuk::apps::specialist_publisher::mongodb_nodes:
+  - 'mongo-1.backend'
+  - 'mongo-2.backend'
+  - 'mongo-3.backend'
+
 govuk::apps::specialist_publisher_rebuild::mongodb_name: 'govuk_content_production'
 govuk::apps::specialist_publisher_rebuild::mongodb_nodes:
   - 'mongo-1.backend'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -442,6 +442,8 @@ govuk::apps::specialist_frontend::nagios_memory_critical: 2200
 govuk::apps::specialist_publisher::enabled: true
 govuk::apps::specialist_publisher::nagios_memory_warning: 1100
 govuk::apps::specialist_publisher::nagios_memory_critical: 1200
+govuk::apps::specialist_publisher::redis_host: "%{hiera('sidekiq_host')}"
+govuk::apps::specialist_publisher::redis_port: "%{hiera('sidekiq_port')}"
 
 govuk::apps::specialist_publisher_rebuild::enabled: true
 govuk::apps::specialist_publisher_rebuild::redis_host: "%{hiera('sidekiq_host')}"

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -167,8 +167,10 @@ govuk::apps::signon::enable_procfile_worker: false
 govuk::apps::smartanswers::expose_govspeak: true
 govuk::apps::specialist_publisher::enable_procfile_worker: false
 govuk::apps::specialist_publisher::publish_pre_production_finders: true
+govuk::apps::specialist_publisher::mongodb_nodes: ['localhost']
+govuk::apps::specialist_publisher::mongodb_name: 'govuk_content_development'
 govuk::apps::specialist_publisher_rebuild::enable_procfile_worker: false
-govuk::apps::specialist_publisher_rebuild::mongodb_name: 'specialist_publisher_rebuild_production'
+govuk::apps::specialist_publisher_rebuild::mongodb_name: 'govuk_content_development'
 govuk::apps::specialist_publisher_rebuild::mongodb_nodes: ['localhost']
 govuk::apps::specialist_publisher_rebuild::publish_pre_production_finders: true
 govuk::apps::stagecraft::worker::enabled: true

--- a/modules/govuk/manifests/apps/specialist_publisher.pp
+++ b/modules/govuk/manifests/apps/specialist_publisher.pp
@@ -92,8 +92,10 @@ class govuk::apps::specialist_publisher(
   $secret_token = undef,
 ) {
 
+  $app_name = 'specialist-publisher'
+
   if $enabled {
-    govuk::app { 'specialist-publisher':
+    govuk::app { $app_name:
       app_type               => 'rack',
       port                   => $port,
       health_check_path      => '/healthcheck',
@@ -106,14 +108,14 @@ client_max_body_size 500m;
       asset_pipeline         => true,
     }
 
-    govuk_logging::logstream { 'specialist-publisher_sidekiq_json_log':
-      logfile => '/var/apps/specialist-publisher/log/sidekiq.json.log',
-      fields  => {'application' => 'specialist-publisher'},
+    govuk_logging::logstream { "${app_name}_sidekiq_json_log":
+      logfile => "/var/apps/${app_name}/log/sidekiq.json.log",
+      fields  => {'application' => $app_name},
       json    => true,
     }
 
     Govuk::App::Envvar {
-      app => 'specialist-publisher',
+      app => $app_name,
     }
 
     govuk::app::envvar::mongodb_uri { $app_name:
@@ -134,7 +136,7 @@ client_max_body_size 500m;
       }
     }
 
-    govuk::procfile::worker { 'specialist-publisher':
+    govuk::procfile::worker { $app_name:
       enable_service => $enable_procfile_worker,
     }
 

--- a/modules/govuk/manifests/apps/specialist_publisher.pp
+++ b/modules/govuk/manifests/apps/specialist_publisher.pp
@@ -1,12 +1,20 @@
 # == Class: govuk::apps::specialist_publisher
 #
-# Publishing App for specialist documents and manuals.
+# Publishing App for specialist documents and finders.
 #
 # === Parameters
 #
 # [*port*]
 #   The port that publishing API is served on.
 #   Default: 3064
+#
+# [*asset_manager_bearer_token*]
+#   The bearer token to use when communicating with Asset Manager.
+#   Default: undef
+#
+# [*errbit_api_key*]
+#   Errbit API key for sending errors.
+#   Default: undef
 #
 # [*enabled*]
 #   Whether the app is enabled.
@@ -16,6 +24,22 @@
 #   Whether to enable the procfile worker
 #   Default: true
 
+#
+# [*mongodb_nodes*]
+#   Array of hostnames for the mongo cluster to use.
+#
+# [*mongodb_name*]
+#   The mongo database to be used. Overriden in development
+#   to be 'content_store_development'.
+#
+# [*oauth_id*]
+#   Sets the OAuth ID for using GDS-SSO
+#   Default: undef
+#
+# [*oauth_secret*]
+#   Sets the OAuth Secret Key for using GDS-SSO
+#   Default: undef
+#
 # [*publish_pre_production_finders*]
 #   Whether to enable publishing of pre-production finders
 #   Default: false
@@ -34,32 +58,72 @@
 # [*nagios_memory_critical*]
 #   Memory use at which Nagios should generate a critical alert.
 #
+# [*redis_host*]
+#   Redis host for sidekiq.
+#
+# [*redis_port*]
+#   Redis port for sidekiq.
+#   Default: 6379
+#
+# [*secret_token*]
+#   Used to set the app ENV var SECRET_TOKEN which is used to configure
+#   rails 4.x signed cookie mechanism. If unset the app will be unable to
+#   start. SECRET_TOKEN is used rather than SECRET_KEY_BASE so that
+#   specialist publisher can share signed cookies with version 1.
+#   Default: undef
+#
 class govuk::apps::specialist_publisher(
   $port = '3064',
+  $asset_manager_bearer_token = undef,
+  $errbit_api_key = undef,
   $enabled = false,
   $enable_procfile_worker = true,
+  $mongodb_nodes,
+  $mongodb_name,
+  $oauth_id = undef,
+  $oauth_secret = undef,
   $publish_pre_production_finders = false,
   $publishing_api_bearer_token = undef,
   $email_alert_api_bearer_token = undef,
   $nagios_memory_warning = undef,
   $nagios_memory_critical = undef,
+  $redis_host = undef,
+  $redis_port = undef,
+  $secret_token = undef,
 ) {
 
   if $enabled {
     govuk::app { 'specialist-publisher':
       app_type               => 'rack',
       port                   => $port,
-      health_check_path      => '/specialist-documents',
+      health_check_path      => '/healthcheck',
       log_format_is_json     => true,
       nginx_extra_config     => '
 client_max_body_size 500m;
 ',
       nagios_memory_warning  => $nagios_memory_warning,
       nagios_memory_critical => $nagios_memory_critical,
+      asset_pipeline         => true,
+    }
+
+    govuk_logging::logstream { 'specialist-publisher_sidekiq_json_log':
+      logfile => '/var/apps/specialist-publisher/log/sidekiq.json.log',
+      fields  => {'application' => 'specialist-publisher'},
+      json    => true,
     }
 
     Govuk::App::Envvar {
       app => 'specialist-publisher',
+    }
+
+    govuk::app::envvar::mongodb_uri { $app_name:
+      hosts    => $mongodb_nodes,
+      database => $mongodb_name,
+    }
+
+    govuk::app::envvar::redis { $app_name:
+      host => $redis_host,
+      port => $redis_port,
     }
 
     if $publish_pre_production_finders {
@@ -75,12 +139,31 @@ client_max_body_size 500m;
     }
 
     govuk::app::envvar {
+      "${title}-ASSET_MANAGER_BEARER_TOKEN":
+      varname => 'ASSET_MANAGER_BEARER_TOKEN',
+      value   => $asset_manager_bearer_token;
+      "${title}-ERRBIT_API_KEY":
+      varname => 'ERRBIT_API_KEY',
+      value   => $errbit_api_key;
+      "${title}-OAUTH_ID":
+      varname => 'OAUTH_ID',
+      value   => $oauth_id;
+      "${title}-OAUTH_SECRET":
+      varname => 'OAUTH_SECRET',
+      value   => $oauth_secret;
       "${title}-PUBLISHING_API_BEARER_TOKEN":
       varname => 'PUBLISHING_API_BEARER_TOKEN',
       value   => $publishing_api_bearer_token;
       "${title}-EMAIL_ALERT_API_BEARER_TOKEN":
       varname => 'EMAIL_ALERT_API_BEARER_TOKEN',
       value   => $email_alert_api_bearer_token;
+    }
+
+    if $secret_token != undef {
+      govuk::app::envvar { "${title}-SECRET_TOKEN":
+        varname => 'SECRET_TOKEN',
+        value   => $secret_token,
+      }
     }
   }
 }


### PR DESCRIPTION
Specialist Publisher will use the codebase from Specialist Publisher Rebuild very shortly, so ensure that the same environment is created for both applications to ease deployment.

This means the same ENV variables should be made available and any config from alphagov-deployment should be added to the environment where relevant.

Secrets here https://github.gds/gds/deployment/pull/1103 (this has now been merged)