### PR TITLE
Use api-elasticsearch on all calculators-frontend environments

### DIFF
--- a/hieradata/class/calculators_frontend.yaml
+++ b/hieradata/class/calculators_frontend.yaml
@@ -1,9 +1,9 @@
 ---
 
 govuk_elasticsearch::local_proxy::servers:
-  - 'elasticsearch-1.backend'
-  - 'elasticsearch-2.backend'
-  - 'elasticsearch-3.backend'
+  - 'api-elasticsearch-1.api'
+  - 'api-elasticsearch-2.api'
+  - 'api-elasticsearch-3.api'
 
 govuk::node::s_base::apps:
   - businesssupportfinder

--- a/hieradata/class/integration/calculators_frontend.yaml
+++ b/hieradata/class/integration/calculators_frontend.yaml
@@ -1,6 +1,0 @@
----
-
-govuk_elasticsearch::local_proxy::servers:
-  - 'api-elasticsearch-1.api'
-  - 'api-elasticsearch-2.api'
-  - 'api-elasticsearch-3.api'

--- a/hieradata/class/staging/calculators_frontend.yaml
+++ b/hieradata/class/staging/calculators_frontend.yaml
@@ -1,6 +1,0 @@
----
-
-govuk_elasticsearch::local_proxy::servers:
-  - 'api-elasticsearch-1.api'
-  - 'api-elasticsearch-2.api'
-  - 'api-elasticsearch-3.api'


### PR DESCRIPTION
This finishes the work started in #4871 and continued in #4916 to make
the calculators_frontend machines use the api-elasticsearch.api cluster
instead of the elasticsearch.backend cluster.