### PR TITLE
Remove load balancer config for specialist document paths

### DIFF
--- a/modules/govuk/manifests/node/s_backend_lb.pp
+++ b/modules/govuk/manifests/node/s_backend_lb.pp
@@ -43,69 +43,6 @@ class govuk::node::s_backend_lb (
       error_on_http => true,
       servers       => $backend_servers;
     [
-      'specialist-publisher',
-    ]:
-      modified_paths => {
-        '/sp-rebuild/assets'                    => {
-          'app' => 'specialist-publisher-rebuild',
-        },
-        '/rebuild-healthcheck'                  => {
-          'app' => 'specialist-publisher-rebuild',
-        },
-        '/preview'                              => {
-          'app' => 'specialist-publisher-rebuild',
-        },
-        '/raib-reports'                         => {
-          'app' => 'specialist-publisher-rebuild',
-        },
-        '/maib-reports'                         => {
-          'app' => 'specialist-publisher-rebuild',
-        },
-        '/dfid-research-outputs'                => {
-          'app' => 'specialist-publisher-rebuild',
-        },
-        '/aaib-reports'                         => {
-          'app' => 'specialist-publisher-rebuild',
-        },
-        '/cma-cases'                            => {
-          'app' => 'specialist-publisher-rebuild',
-        },
-        '/international-development-funds'      => {
-          'app' => 'specialist-publisher-rebuild',
-        },
-        '/countryside-stewardship-grants'       => {
-          'app' => 'specialist-publisher-rebuild',
-        },
-        '/esi-funds'                            => {
-          'app' => 'specialist-publisher-rebuild',
-        },
-        '/tax-tribunal-decisions'               => {
-          'app' => 'specialist-publisher-rebuild',
-        },
-        '/utaac-decisions'                      => {
-          'app' => 'specialist-publisher-rebuild',
-        },
-        '/employment-tribunal-decisions'        => {
-          'app' => 'specialist-publisher-rebuild',
-        },
-        '/employment-appeal-tribunal-decisions' => {
-          'app' => 'specialist-publisher-rebuild',
-        },
-        '/asylum-support-decisions'             => {
-          'app' => 'specialist-publisher-rebuild',
-        },
-        '/vehicle-recalls-and-faults-alerts'    => {
-          'app' => 'specialist-publisher-rebuild',
-        },
-        '/drug-safety-updates'                  => {
-          'app' => 'specialist-publisher-rebuild',
-        },
-        '/medical-safety-alerts'                => {
-          'app' => 'specialist-publisher-rebuild',
-        },
-      },
-      servers        => $backend_servers;
-    [
       'business-support-api',
       'collections-publisher',
       'contacts-admin',
@@ -123,6 +60,7 @@ class govuk::node::s_backend_lb (
       'service-manual-publisher',
       'share-sale-publisher',
       'signon',
+      'specialist-publiser',
       'specialist-publisher-rebuild-standalone',
       'short-url-manager',
       'support',


### PR DESCRIPTION
Cleanup from https://trello.com/c/m9ZWAIbQ/284-rename-the-specialist-publisher-v1-to-manuals-publisher-large 

Specialist Publisher is now running the v2 rebuild code for specialist documents,
Manuals Publisher manages manuals content.
We no longer need to direct traffic for specialist document routes to a different
application as we've repurposed Specialist Publisher, so remove this config.