### PR TITLE
Add PostgreSQL WAL-E restore script

### DIFF
--- a/hieradata/node/transition-postgresql-master-1.backend.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/transition-postgresql-master-1.backend.integration.publishing.service.gov.uk.yaml
@@ -1,2 +1,0 @@
----
-govuk::node::s_transition_postgresql_base::env_sync_enabled: true

--- a/modules/govuk/manifests/node/s_transition_postgresql_base.pp
+++ b/modules/govuk/manifests/node/s_transition_postgresql_base.pp
@@ -2,15 +2,7 @@
 #
 # Base node for s_transition_postgresql_{master,slave}
 #
-class govuk::node::s_transition_postgresql_base (
-  $env_sync_access_key_id = undef,
-  $env_sync_secret_access_key = undef,
-  $env_sync_s3_bucket_url = undef,
-  $env_sync_private_gpg_key = undef,
-  $env_sync_private_gpg_key_fingerprint = undef,
-  $env_sync_private_gpg_key_passphrase = undef,
-  $env_sync_enabled = false,
-) inherits govuk::node::s_base {
+class govuk::node::s_transition_postgresql_base inherits govuk::node::s_base {
   include govuk::apps::transition::postgresql_db
 
   Govuk_mount['/var/lib/postgresql'] -> Class['govuk_postgresql::server']
@@ -19,16 +11,5 @@ class govuk::node::s_transition_postgresql_base (
 
   postgresql::server::config_entry { 'random_page_cost':
     value => 2.5,
-  }
-
-  if $env_sync_enabled {
-    govuk_postgresql::wal_e::env_sync { $title:
-      aws_access_key_id                => $env_sync_access_key_id,
-      aws_secret_access_key            => $env_sync_secret_access_key,
-      s3_bucket_url                    => $env_sync_s3_bucket_url,
-      wale_private_gpg_key             => $env_sync_private_gpg_key,
-      wale_private_gpg_key_fingerprint => $env_sync_private_gpg_key_fingerprint,
-      wale_private_gpg_key_passphrase  => $env_sync_private_gpg_key_passphrase,
-    }
   }
 }

--- a/modules/govuk_postgresql/manifests/wal_e/backup.pp
+++ b/modules/govuk_postgresql/manifests/wal_e/backup.pp
@@ -194,4 +194,11 @@ define govuk_postgresql::wal_e::backup (
         host_name           => $::fqdn,
         notes_url           => monitoring_docs_url(postgresql-s3-backups),
       }
+
+    file { '/usr/local/bin/wal-e_restore':
+      ensure  => present,
+      content => template('govuk_postgresql/usr/local/bin/wal-e_restore.erb'),
+      mode    => '0755',
+      require => Class['govuk_postgresql::wal_e::package'],
+    }
 }

--- a/modules/govuk_postgresql/templates/usr/local/bin/wal-e_restore.erb
+++ b/modules/govuk_postgresql/templates/usr/local/bin/wal-e_restore.erb
@@ -1,0 +1,44 @@
+#!/bin/bash
+#
+# PostgreSQL Restore
+#
+# This is a wrapper script which sets up prerequisites for an encrypted WAL-E
+# backup from an Amazon S3 bucket, and moves the backup into place. It restores
+# the very latest back-up available.
+#
+export RECOVERY_FILE=<%= @datadir -%>/recovery.conf
+
+set -e
+
+# Redirect stdout and stderr to syslog
+exec 1> >(/usr/bin/logger -s -t $(basename $0)) 2>&1
+
+# Check if Puppet is enabled
+if sudo test -f /var/lib/puppet/state/agent_disabled.lock; then
+  # If it isn't then quit
+  echo "Puppet agent disabled! If Puppet cannot run then we will not be able"
+  echo "to resync passwords and things will break. Quitting"
+  exit 1
+else
+  echo "PostgreSQL environment sync starting"
+
+  # Otherwise go ahead and disable Puppet to start the sync
+  govuk_puppet --disable "Disabling Puppet to sync data (by $0)"
+
+  # Stop the PostgreSQL service
+  sudo service postgresql stop
+
+  # Start the restore process
+  sudo -iu postgres envdir /etc/wal-e/env.d /usr/local/bin/wal-e backup-fetch --blind-restore <%= @datadir -%> LATEST
+
+  # Add the recovery.conf configuration (this is renamed to recovery.done after PostgreSQL starts)
+  sudo -iu postgres sh -c "echo \"restore_command = 'envdir /etc/wal-e/env.d /usr/local/bin/wal-e wal-fetch \"%f\" \"%p\"'\" > $RECOVERY_FILE"
+
+  # Start the PostgreSQL service
+  sudo service postgresql start
+
+  # Enable and run Puppet to update passwords
+  govuk_puppet --enable && govuk_puppet
+
+  echo "PostgreSQL environment sync finished"
+fi


### PR DESCRIPTION
While writing documentation it occurred to me that we did not have a basic restore script for restores from the same environment. This commit adds the script. The script is essentially the same as the env_sync script which has been successfully tested, except that it does not contain any Production key passphrases or references to a different envdir directory than the one that should already be present on the machine that sends backups to S3. 

It also removes the env_sync details added to Integration that was used for testing restores from Production. We are currently not using this method so it should be removed until we decide to use it.