### PR TITLE
Enable future parser in integration only

### DIFF
--- a/hieradata/class/jumpbox.yaml
+++ b/hieradata/class/jumpbox.yaml
@@ -2,5 +2,3 @@
 
 govuk_safe_to_reboot::can_reboot: 'careful'
 govuk_safe_to_reboot::reason: 'Warn connected users before rebooting'
-
-puppet::future_parser: true

--- a/hieradata/class/puppetmaster.yaml
+++ b/hieradata/class/puppetmaster.yaml
@@ -1,5 +1,3 @@
 ---
 
 govuk_postgresql::server::listen_addresses: localhost
-
-puppet::future_parser: true

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -266,6 +266,8 @@ postfix::smarthost:
   - 'email-smtp.eu-west-1.amazonaws.com:587'
   - 'ses-smtp-eu-west-1-prod-345515633.eu-west-1.elb.amazonaws.com:587'
 
+puppet::future_parser: true
+
 router::nginx::check_requests_warning: '@0.5'
 router::nginx::check_requests_critical: '@0.25'
 


### PR DESCRIPTION
I assumed this was agent config so I set it on 2 machines - apparently it's master config so there's no way to roll it out machine-by-machine.

Also enable it only in integration because we want to test it a bit.