### PR TITLE
Add future parser

### DIFF
--- a/modules/puppet/manifests/init.pp
+++ b/modules/puppet/manifests/init.pp
@@ -8,11 +8,16 @@
 #   Whether this environment should be controlled by a master
 #   or should run from a local catalog.
 #
+# [*future_parser*]
+#   Boolean, whether or not to use Puppet's future parser to
+#   help upgrade to Puppet 4.
+#
 class puppet (
-    $use_puppetmaster = true
+    $future_parser = false,
+    $use_puppetmaster = true,
   ) {
 
-  # Be absolutely certain we have a bool as strings are weird
+  validate_bool($future_parser)
   validate_bool($use_puppetmaster)
 
   include puppet::cronjob

--- a/modules/puppet/templates/etc/puppet/puppet.conf.erb
+++ b/modules/puppet/templates/etc/puppet/puppet.conf.erb
@@ -7,6 +7,11 @@ environment = <%= scope.lookupvar("::environment") %>
 <%- if @use_puppetmaster == false -%>
 environmentpath = /var/govuk/govuk-puppet/environments
 <%- end -%>
+<%- if @future_parser == true -%>
+parser = future
+stringify_facts = false
+strict_variables = true
+<%- end -%>
 
 [master]
 reports = store


### PR DESCRIPTION
**We need a controlled merge of this for testing purposes.**

This enables to help test the upgrade to Puppet 4.

The `future_parser` config is only required on the puppetmaster, but it doesn't hurt to have it on the client config.

The `stringify_facts` config fixes any problems we have with how data types are evaluated in Puppet 4.

The `strict_variables` config is set to help us debug issues easier 
because Puppet 4 has a stricter checking for undefined variables.
