### PR TITLE
Explicitly specify service URLs for auth-proxy.

### DIFF
--- a/modules/govuk/manifests/apps/authenticating_proxy.pp
+++ b/modules/govuk/manifests/apps/authenticating_proxy.pp
@@ -95,4 +95,16 @@ class govuk::apps::authenticating_proxy(
       value   => $secret_key_base,
     }
   }
+
+  $app_domain = hiera('app_domain')
+  govuk::app::envvar {
+    "${title}-PLEK_SERVICE_SIGNON_URI":
+      app     => $app_name,
+      varname => 'PLEK_SERVICE_SIGNON_URI',
+      value   => "https://signon.${app_domain}";
+    "${title}-PLEK_SERVICE_ERRBIT_URI":
+      app     => $app_name,
+      varname => 'PLEK_SERVICE_ERRBIT_URI',
+      value   => "https://errbit.${app_domain}";
+  }
 }


### PR DESCRIPTION
Plek now automatically inserts a "draft-" prefix for all service URLs
when called on the draft-cache machines because they have the
PLEK_HOSTNAME_PREFIX env var set. It's not possible to override that
with an empty value, so instead set the two service domains that
authenticating-proxy actually cares about - errbit and signon -
explicitly.