### PR TITLE
Do the housekeeping before notifying nagios

### DIFF
--- a/modules/mongodb/templates/mongodb-backup-s3.erb
+++ b/modules/mongodb/templates/mongodb-backup-s3.erb
@@ -29,8 +29,8 @@ function housekeeping() {
 }
 
 function exit_trap() {
-  nagios_passive
   housekeeping
+  nagios_passive
 }
 
 trap exit_trap EXIT


### PR DESCRIPTION
Notifying nagios can fail, and if it does, this causes the housekeeping
function not to run, causing other problems with the disk space.

Running the housekeeping function before notifying nagios will ensure
that this always runs, regardless of issues with nagios.