### PR TITLE
Add Draft Government Frontend to Development VM

### DIFF
--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -51,6 +51,7 @@ govuk::node::s_development::apps:
   - 'finder_frontend'
   - 'frontend'
   - 'government_frontend'
+  - 'government_frontend::enable_running_in_draft_mode'
   - 'govuk_delivery'
   - 'hmrc_manuals_api'
   - 'imminence'
@@ -123,6 +124,7 @@ govuk::apps::event_store::enabled: true
 govuk::apps::event_store::mongodb_servers: ['localhost']
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
 govuk::apps::hmrc_manuals_api::enable_procfile_worker: false
+govuk::apps::government_frontend::enable_running_in_draft_mode::content_store: 'http://draft-content-store.dev.gov.uk'
 govuk::apps::govuk_cdn_logs_monitor::enabled: false
 govuk::apps::govuk_delivery::enable_procfile_worker: false
 govuk::apps::imminence::enable_procfile_worker: false

--- a/modules/govuk/manifests/apps/government_frontend/enable_running_in_draft_mode.pp
+++ b/modules/govuk/manifests/apps/government_frontend/enable_running_in_draft_mode.pp
@@ -1,0 +1,30 @@
+# == Class govuk::apps::government_frontend::enable_running_in_draft_mode
+#
+# Enables running government-frontend to serve content pages from the draft content store
+#
+class govuk::apps::government_frontend::enable_running_in_draft_mode(
+  $content_store = '',
+  $port          = '3126',
+  $vhost         = 'draft-government-frontend',
+) {
+  $app_name = 'draft-government-frontend'
+
+  Govuk::App::Envvar {
+    app => $app_name,
+  }
+
+  govuk::app { $app_name:
+    app_type              => 'rack',
+    port                  => $port,
+    vhost_ssl_only        => true,
+    health_check_path     => '/healthcheck',
+    legacy_logging        => false,
+    asset_pipeline        => true,
+    asset_pipeline_prefix => $app_name,
+    vhost                 => $vhost,
+  }
+
+  govuk::app::envvar { 'PLEK_SERVICE_CONTENT_STORE_URI':
+    value => $content_store;
+  }
+}


### PR DESCRIPTION
Migrated formats no longer use Whitehall for rendering, instead they use Government Frontend. 

This adds Government Frontend to the Development VM so that we can verify draft content correctly renders.

[See Trelllo](https://trello.com/c/AbHcPmNH)