### PR TITLE
Remove Email Campaign Smokey checks

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1104,8 +1104,6 @@ monitoring::checks::smokey::features:
     feature: contacts
   check_efg:
     feature: efg
-  check_email_campaign:
-    feature: email_campaign
   check_frontend:
     feature: frontend
   check_licencefinder:


### PR DESCRIPTION
These are no longer required as the Lloyds share sale has been cancelled, the pages have been redirected to a press release, and the backing services themselves will be decommissioned in the very near future.