### PR TITLE
Add efg training rebuild

### DIFF
--- a/hieradata/class/efg_frontend.yaml
+++ b/hieradata/class/efg_frontend.yaml
@@ -4,6 +4,7 @@ govuk::node::s_base::apps:
   - efg
   - efg_rebuild
   - efg_training
+  - efg_training_rebuild
 
 govuk_safe_to_reboot::can_reboot: 'overnight'
 govuk_safe_to_reboot::reason: 'There is only one EFG frontend'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -276,6 +276,11 @@ govuk::apps::efg_training::vhost_name: "efg-training.%{hiera('app_domain')}"
 govuk::apps::efg_training::nagios_memory_warning: 1600
 govuk::apps::efg_training::nagios_memory_critical: 1800
 
+govuk::apps::efg_training_rebuild::ssl_certtype: 'wildcard_publishing'
+govuk::apps::efg_training_rebuild::vhost_name: "efg-training-rebuild.%{hiera('app_domain')}"
+govuk::apps::efg_training_rebuild::nagios_memory_warning: 1600
+govuk::apps::efg_training_rebuild::nagios_memory_critical: 1800
+
 govuk::apps::email_alert_api::enabled: true
 govuk::apps::email_alert_api::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 govuk::apps::email_alert_api::redis_host: "%{hiera('sidekiq_host')}"

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -179,6 +179,7 @@ govuk::node::s_backend_lb::perfplat_public_app_domain: 'preview.performance.serv
 govuk::node::s_backup::backup_efg: false
 govuk::node::s_backup::backup_efg_rebuild: false
 govuk::node::s_backup::backup_efg_training: false
+govuk::node::s_backup::backup_efg_training_rebuild: false
 govuk::node::s_bouncer::minimum_request_rate: 0.1
 govuk::node::s_cache::real_ip_header: 'X-Forwarded-For'
 govuk::node::s_cache::protect_cache_servers: true

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -44,6 +44,9 @@ govuk::apps::efg::vhost_name: "www.sflg.gov.uk"
 govuk::apps::efg_training::ssl_certtype: 'sflg'
 govuk::apps::efg_training::vhost_name: "training.sflg.gov.uk"
 
+govuk::apps::efg_training::ssl_certtype: 'sflg'
+govuk::apps::efg_training::vhost_name: "rebuild-training.sflg.gov.uk"
+
 govuk::apps::email_alert_api::db::backend_ip_range: '10.3.3.0/24'
 govuk::apps::errbit::errbit_email_from: 'govuk-winston+errbit-production@digital.cabinet-office.gov.uk'
 govuk::apps::hmrc_manuals_api::publish_topics: false

--- a/hieradata/vagrant_credentials.yaml
+++ b/hieradata/vagrant_credentials.yaml
@@ -33,6 +33,7 @@ govuk::apps::content_tagger::db::password: '6bab0d694abaabc64f4b40fcd7e51'
 govuk::apps::efg::db::mysql_password: '8nHudrr6uMSxH6Bfv8OxCfzK6w1Zd6bI'
 govuk::apps::efg_rebuild::db::mysql_password: 'vo9vieRooth3eeChiNeph7shaisekeed'
 govuk::apps::efg_training::db::mysql_password: 'ehau8oodoo3ieL1Bo1veinoukai1Doof'
+govuk::apps::efg_training_rebuild::db::mysql_password: 'SaePhiecohleingeeWeew2xaejoongee'
 govuk::apps::email_alert_api::db::password: '8WB3h7RXohmTvmU7bmmDK4ppsd8BU7Ki'
 
 govuk::apps::govuk_crawler_worker::airbrake_api_key: 'lxHeeE3VknbR7nlZ51QnUfKcxd7iuIcSe25r'

--- a/modules/govuk/manifests/apps/efg_training_rebuild.pp
+++ b/modules/govuk/manifests/apps/efg_training_rebuild.pp
@@ -1,0 +1,112 @@
+# == Class: govuk::apps::efg_training_rebuild
+#
+# Set up the EFG_TRAINING rebuild app
+#
+# === Parameters
+#
+# [*port*]
+#   Port the app runs on
+#
+# [*vhost_name*]
+#   External domain name that EFG_TRAINING should be available on
+#
+# [*ssl_certtype*]
+#   Which certificate EFG_TRAINING should use in each environment
+#
+# [*devise_pepper*]
+#   The key used to encrypt passwords for Devise, passed in as an environment variable
+#
+# [*devise_secret_key*]
+#   The secret_key setting for Devise, passed in as an environment variable
+#
+# [*exception_recipients*]
+#   App config: a string containing comma-separated email addresses that will
+#   receive exception notifications
+#
+# [*lender_support_email*]
+#   App config: an email address for support requests
+#
+# [*nagios_memory_warning*]
+#   Memory use at which Nagios should generate a warning.
+#
+# [*nagios_memory_critical*]
+#   Memory use at which Nagios should generate a critical alert.
+#
+# [*secret_token*]
+#   The secret token Rails uses to encrypt cookies and stuff like that.
+#
+class govuk::apps::efg_training_rebuild (
+  $port = '3128',
+  $ssl_certtype,
+  $vhost_name,
+  $devise_pepper = undef,
+  $devise_secret_key = undef,
+  $exception_recipients = undef,
+  $lender_support_email = undef,
+  $nagios_memory_warning = undef,
+  $nagios_memory_critical = undef,
+  $secret_token = undef,
+) {
+  validate_string($vhost_name)
+
+  $app_name = 'efg-training-rebuild'
+
+  govuk::app { $app_name:
+    app_type               => 'rack',
+    port                   => $port,
+    enable_nginx_vhost     => false,
+    health_check_path      => '/healthcheck',
+    nagios_memory_warning  => $nagios_memory_warning,
+    nagios_memory_critical => $nagios_memory_critical,
+  }
+
+  Govuk::App::Envvar {
+    app => $app_name,
+  }
+
+  govuk::app::envvar {
+    "${title}-EFG_HOST":
+      varname => 'EFG_HOST',
+      value   => $vhost_name;
+    "${title}-DEVISE_PEPPER":
+      varname => 'DEVISE_PEPPER',
+      value   => $devise_pepper;
+    "${title}-DEVISE_SECRET_KEY":
+      varname => 'DEVISE_SECRET_KEY',
+      value   => $devise_secret_key;
+    "${title}-EXCEPTION_RECIPIENTS":
+      varname => 'EXCEPTION_RECIPIENTS',
+      value   => $exception_recipients;
+    "${title}-LENDER_SUPPORT_EMAIL":
+      varname => 'LENDER_SUPPORT_EMAIL',
+      value   => $lender_support_email;
+    "${title}-SECRET_TOKEN":
+      varname => 'SECRET_TOKEN',
+      value   => $secret_token;
+  }
+
+  nginx::config::vhost::proxy { $vhost_name:
+    to           => ["localhost:${port}"],
+    protected    => false,
+    ssl_certtype => $ssl_certtype,
+    ssl_only     => true,
+  }
+
+  @@icinga::check::graphite { "check_efg_training_rebuild_login_failures_${::hostname}":
+    target    => "sumSeries(stats.govuk.app.${app_name}.*.logins.failure)",
+    warning   => 10,
+    critical  => 15,
+    desc      => 'EFG_TRAINING login failures',
+    host_name => $::fqdn,
+  }
+
+  ramdisk { 'efg_training_rebuild_sqlite':
+    ensure => present,
+    path   => '/var/efg-training-rebuild-data',
+    atboot => true,
+    size   => '512M',
+    mode   => '0733',
+    owner  => 'deploy',
+    group  => 'deploy',
+  }
+}

--- a/modules/govuk/manifests/apps/efg_training_rebuild/db.pp
+++ b/modules/govuk/manifests/apps/efg_training_rebuild/db.pp
@@ -1,0 +1,31 @@
+# == Class: Govuk::Apps::Efg_training_rebuild::Db
+#
+# Create the EFG Training rebuild application database
+#
+# === Parameters
+#
+# [*mysql_password*]
+#   The MySQL password for the 'efg_training' database
+#
+class govuk::apps::efg_training_rebuild::db (
+  $mysql_password = '',
+){
+
+  mysql_user { 'efg_training_rebuild@%':
+    ensure        => 'present',
+    password_hash => mysql_password($mysql_password),
+  }
+
+  mysql_grant { 'efg_training_rebuild@%/efg_training_production.*':
+    user       => 'efg_training_rebuild@%',
+    table      => 'efg_training_production.*',
+    privileges => 'ALL',
+  }
+
+  mysql_grant { 'efg@%/efg_training_il0.*':
+      user       => 'efg@%',
+      table      => 'efg_training_il0.*',
+      privileges => 'ALL',
+  }
+
+}

--- a/modules/govuk_jenkins/manifests/job/deploy_app.pp
+++ b/modules/govuk_jenkins/manifests/job/deploy_app.pp
@@ -30,4 +30,10 @@ class govuk_jenkins::job::deploy_app (
     content => template('govuk_jenkins/jobs/deploy_efg.yaml.erb'),
     notify  => Exec['jenkins_jobs_update'],
   }
+
+  file { '/etc/jenkins_jobs/jobs/deploy_efg_rebuild.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/deploy_efg_rebuild.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
 }

--- a/modules/govuk_jenkins/templates/jobs/deploy_efg_rebuild.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_efg_rebuild.yaml.erb
@@ -1,0 +1,75 @@
+---
+- scm:
+    name: alphagov-deployment_Deploy_EFG_Rebuild
+    scm:
+        - git:
+            url: git@github.com:alphagov/govuk-app-deployment.git
+            branches:
+              - master
+            wipe-workspace: true
+
+- job:
+    name: Deploy_EFG_Rebuild
+    display-name: Deploy_EFG_Rebuild
+    project-type: freestyle
+    description: "This job will also trigger a deploy of efg-training"
+    properties:
+        - github:
+            url: https://github.com/alphagov/govuk-app-deployment
+        - inject:
+            properties-content: |
+              TARGET_APPLICATION=efg_rebuild
+    scm:
+      - alphagov-deployment_Deploy_EFG_Rebuild
+    builders:
+        - shell: |
+            #!/usr/bin/env bash
+            export DEPLOY_TO="<%= @environment -%>"
+            export DEPLOY_TASK="$DEPLOY_TASK"
+            export TAG="$TAG"
+            export ORGANISATION="<%= @environment -%>"
+            export CI_DEPLOY_JENKINS_API_KEY="<%= @ci_deploy_jenkins_api_key -%>"
+
+            if [ "$DEPLOY_FROM_GITHUB_ENTERPRISE" == "true" ]; then
+              export GIT_ORIGIN_PREFIX="git@github.gds:gds-production-backup"
+            fi
+
+            ./jenkins.sh
+    publishers:
+        - trigger:
+            project: Smokey
+        - trigger-parameterized-builds:
+            - project: Deploy_App
+              predefined-parameters: |
+                TARGET_APPLICATION=efg-training-rebuild
+                DEPLOY_TASK=deploy
+                TAG=$TAG
+                DEPLOY_FROM_GITHUB_ENTERPRISE=false
+              condition: 'SUCCESS'
+            - project: GDS_Production_Backup, service-manual_rebuild_search_index
+              predefined-parameters: |
+                TARGET_APPLICATION=$TARGET_APPLICATION
+                TARGET_APPLICATION_GIT_REPO=$WORKSPACE/$TARGET_APPLICATION
+              condition: 'UNSTABLE_OR_BETTER'
+    wrappers:
+        - ansicolor:
+            colormap: xterm
+        - build-name:
+            name: '${ENV,var="TARGET_APPLICATION"} ${ENV,var="TAG"}'
+    parameters:
+        - choice:
+            name: DEPLOY_TASK
+            description: Capistrano task to run.
+            choices:
+                - deploy
+                - deploy:migrate_and_hard_restart
+                - deploy:migrations
+                - deploy:hard_restart
+        - string:
+            name: TAG
+            description: Git tag/committish to deploy.
+            default: release
+        - bool:
+            name: DEPLOY_FROM_GITHUB_ENTERPRISE
+            default: false
+            description: Whether to deploy from GitHub Enterprise in case public GitHub is unavailable


### PR DESCRIPTION
This adds the EFG training rebuild application.

The current setup is to just use the _current_ efg training database, which matches how the efg training app is going to work. Not sure if this is how we wish to implement it.

Also adds the Jenkins job to deploy it.

https://trello.com/c/DmTxeazb/238-run-a-rebuild-copy-of-the-efg-training-app