### PR TITLE
Prepare to remove sp rebuild apps

### DIFF
--- a/modules/govuk/manifests/apps/specialist_publisher_rebuild.pp
+++ b/modules/govuk/manifests/apps/specialist_publisher_rebuild.pp
@@ -94,6 +94,7 @@ class govuk::apps::specialist_publisher_rebuild(
 
   if $enabled {
     govuk::app { $app_name:
+      ensure             => absent,
       app_type           => 'rack',
       port               => $port,
       custom_http_host   => "specialist-publisher.${app_domain}",
@@ -103,10 +104,12 @@ class govuk::apps::specialist_publisher_rebuild(
     }
 
     govuk::procfile::worker {'specialist-publisher-rebuild':
+      ensure         => absent,
       enable_service => $enable_procfile_worker,
     }
 
     govuk_logging::logstream { 'specialist-publisher-rebuild_sidekiq_json_log':
+      ensure  => absent,
       logfile => '/var/apps/specialist-publisher-rebuild/log/sidekiq.json.log',
       fields  => {'application' => 'specialist-publisher-rebuild'},
       json    => true,

--- a/modules/govuk/manifests/apps/specialist_publisher_rebuild_standalone.pp
+++ b/modules/govuk/manifests/apps/specialist_publisher_rebuild_standalone.pp
@@ -93,6 +93,7 @@ class govuk::apps::specialist_publisher_rebuild_standalone(
 
   if $enabled {
     govuk::app { $app_name:
+      ensure             => absent,
       app_type           => 'rack',
       port               => $port,
       health_check_path  => '/healthcheck',
@@ -101,10 +102,12 @@ class govuk::apps::specialist_publisher_rebuild_standalone(
     }
 
     govuk::procfile::worker {'specialist-publisher-rebuild-standalone':
+      ensure         => absent,
       enable_service => $enable_procfile_worker,
     }
 
     govuk_logging::logstream { 'specialist-publisher-rebuild-standalone_sidekiq_json_log':
+      ensure  => absent,
       logfile => '/var/apps/specialist-publisher-rebuild-standalone/log/sidekiq.json.log',
       fields  => {'application' => 'specialist-publisher-rebuild-standalone'},
       json    => true,

--- a/modules/govuk/manifests/node/s_backend_lb.pp
+++ b/modules/govuk/manifests/node/s_backend_lb.pp
@@ -61,7 +61,6 @@ class govuk::node::s_backend_lb (
       'share-sale-publisher',
       'signon',
       'specialist-publisher',
-      'specialist-publisher-rebuild-standalone',
       'short-url-manager',
       'support',
       'travel-advice-publisher',
@@ -77,7 +76,6 @@ class govuk::node::s_backend_lb (
       'govuk-delivery',
       'need-api',
       'publishing-api',
-      'specialist-publisher-rebuild',
       'support-api',
     ]:
       https_redirect => false, # FIXME: Remove for #51136581


### PR DESCRIPTION
Mark specialist-publisher-rebuild and standalone as absent.
Please shout if more puppet config can be removed in this PR.