### PR TITLE
Set higher disk time threshold

### DIFF
--- a/hieradata/class/mongo.yaml
+++ b/hieradata/class/mongo.yaml
@@ -3,6 +3,8 @@
 govuk_safe_to_reboot::can_reboot: 'overnight'
 govuk_safe_to_reboot::reason: 'Secondaries will reboot overnight if cluster is healthy'
 
+icinga::client::checks::disk_time_window_minutes: 10
+
 lv:
   mongodb:
     pv:

--- a/modules/icinga/manifests/client/checks.pp
+++ b/modules/icinga/manifests/client/checks.pp
@@ -12,6 +12,7 @@
 class icinga::client::checks (
   $disk_time_warn = 100,
   $disk_time_critical = 200,
+  $disk_time_window_minutes = 5,
 ) {
 
   include icinga::client::check_cputype
@@ -111,7 +112,6 @@ class icinga::client::checks (
   # This will not alert on short spikes in I/O unless they are very large.
   # Instead, it is intended to alert on persistent high I/O.
 
-  $disk_time_window_minutes = 5
   $disk_time_window_points = ($disk_time_window_minutes * 60) / 10
 
   @@icinga::check::graphite { "check_disk_time_${::hostname}":


### PR DESCRIPTION
Set a higher disk time threshold for mongo machines that take regular backups so it's less likely we will be alerted on them. We would still be alerted on a sustained spike of disk usage of over 10 minutes.
