### PR TITLE
Disable "support app background processing" check in integration

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -260,7 +260,7 @@ mongodb::s3backup::backup::s3_bucket: 'govuk-mongodb-backup-s3-integration'
 mongodb::s3backup::backup::s3_bucket_daily: 'govuk-mongodb-backup-s3-daily-integration'
 mongodb::backup::mongo_backup_node: 'localhost'
 
-
+monitoring::checks::enable_support_check: false
 monitoring::checks::pingdom::enable: false
 monitoring::checks::ses::region: eu-west-1
 


### PR DESCRIPTION
This check requires people to send test messages through the support queues to
actually make it pass, which they don't, which leads to be being in an UNKNOWN
state for 60 days at a time. Disabling this monitoring does risk hiding an actual failure
but it's currently broken 99% of the time anyway so people just ack it and move on.

It's also currently disabled in staging.