### PR TITLE
Delay cron process to dump elastic search indexes

### DIFF
--- a/modules/govuk_elasticsearch/manifests/dump.pp
+++ b/modules/govuk_elasticsearch/manifests/dump.pp
@@ -1,6 +1,6 @@
 # FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
 class govuk_elasticsearch::dump (
-  $run_es_dump_hour = '3',
+  $run_es_dump_hour = '4',
 ) {
   package { 'es_dump_restore':
     ensure   => '2.0.0',


### PR DESCRIPTION
Delays the execution of the cron process `es_dump` from 3am to 4am

We are having intermittent failures in the [process that copies data 
from production to staging][1]. The process usually fails when importing
`/tmp/es_dump_production/government.zip` See executions 437, 478, 475

We have not been able to identify the cause of this issue, but as 
we have another process that runs daily at 03:00, we want to explore if
increasing the gap between them prevent the timeout from happening.

[1]: https://deploy.publishing.service.gov.uk/job/copy_data_to_staging/