### PR TITLE
Ensure lock directory exists

### DIFF
--- a/modules/puppet/templates/govuk_puppet
+++ b/modules/puppet/templates/govuk_puppet
@@ -69,6 +69,9 @@ exit 0
 
 ###############################
 
+# Ensure the lock directory exists
+test -d $lock_dir || mkdir -p $lock_dir
+
 write_lock() {
   local lock_file="${lock_dir}/${lock_name}.lock"
   local time_stamp=$(date +%Y%m%d-%H%M%S)


### PR DESCRIPTION
When 78c9abf57e65b4cb136c31e877f6fb84e99215ff was deployed, the govuk_puppet script failed to run on all machines. This is because the lock directory does not exist. Add logic in the script to ensure the directory exists.

I chose to add the logic within the script rather than Puppet to avoid having to manually update all machines that already have the newest version of the script.