### PR TITLE
Delays the cron process `es_dump` from 3am to 4am in staging

### DIFF
--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -29,6 +29,8 @@ govuk_jenkins::config::banner_colour_text: 'black'
 govuk_jenkins::config::banner_string: 'Carrenza STAGING'
 govuk_jenkins::config::manage_config: true
 
+govuk_elasticsearch::dump::run_es_dump_hour: '4'
+
 govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::data_sync_complete_staging
   - govuk_jenkins::job::deploy_app


### PR DESCRIPTION
Supersedes https://github.com/alphagov/govuk-puppet/pull/4958. See https://github.com/alphagov/govuk-puppet/pull/4958#issuecomment-254186829

We are having intermittent failures in the [process that copies data 
from production to staging][1]. The process usually fails when importing
`/tmp/es_dump_production/government.zip` See executions 437, 478, 475

We have not been able to identify the cause of this issue, but as 
we have another process that runs daily at 03:00, we want to explore __in 
staging__ if increasing the gap between them fixes the issue.

[1]: https://deploy.publishing.service.gov.uk/job/copy_data_to_staging/