### PR TITLE
Ensure lock directory exists

### DIFF
--- a/modules/puppet/manifests/init.pp
+++ b/modules/puppet/manifests/init.pp
@@ -49,10 +49,17 @@ class puppet (
     $govuk_puppet_template = 'puppet/govuk_puppet_development'
   }
 
+  $lock_dir = '/var/run/lock/puppet'
+
+  file { $lock_dir:
+    ensure => directory,
+  }
+
   file { '/usr/local/bin/govuk_puppet':
     ensure  => present,
     mode    => '0755',
     content => template($govuk_puppet_template),
+    require => File[$lock_dir],
   }
 
   service { 'puppet': # we're using cron, so we don't want the daemonized puppet agent

--- a/modules/puppet/templates/govuk_puppet
+++ b/modules/puppet/templates/govuk_puppet
@@ -10,7 +10,7 @@ fi
 app_name=$(basename "$0")
 
 puppet_lock=/var/lib/puppet/state/agent_disabled.lock
-lock_dir=/var/run/lock/puppet
+lock_dir=<%= @lock_dir %>
 
 lock_name=default # TODO validate this
 lock_reason='' # default to no value to match current invocations


### PR DESCRIPTION
When 78c9abf was deployed, the govuk_puppet script failed to run on all machines.
This is because the lock directory does not exist.