### PR TITLE
Add explicit require on the install package.

### DIFF
--- a/modules/collectd/manifests/plugin/file_handles.pp
+++ b/modules/collectd/manifests/plugin/file_handles.pp
@@ -12,6 +12,7 @@ class collectd::plugin::file_handles(
     group   => 'root',
     content => file('collectd/usr/lib/collectd/file_handles.sh'),
     tag     => 'collectd::plugin',
+    require => Class['collectd::package'],
   }
 
   @collectd::plugin { 'file_handles':


### PR DESCRIPTION
We're seeing puppet ordering errors on new host spinups as the directory this plugin installs
to doesn't exist until after the collect-core package has been installed. This change ensures that directory exists before
the plugin is deployed.