### PR TITLE
Don't call people for a machine being down

### DIFF
--- a/modules/icinga/files/etc/icinga/conf.d/generic-host_nagios2.cfg
+++ b/modules/icinga/files/etc/icinga/conf.d/generic-host_nagios2.cfg
@@ -14,7 +14,7 @@ define host {
   notification_interval           0
   notification_period             24x7
   notification_options            d,r
-  contact_groups                  urgent-priority
+  contact_groups                  high-priority
   register                        0       ; DONT REGISTER THIS DEFINITION - ITS NOT A REAL HOST, JUST A TEMPLATE!
 }
 


### PR DESCRIPTION
Since we mostly have clusters of machines a machine being down shouldn't be enough to call someone out of hours.
The effects of machines being down should be what calls people.
