### PR TITLE
Raise memory warning and critical limits for content-store

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -252,8 +252,8 @@ govuk::apps::contacts::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::contentapi::nagios_memory_warning: 3800
 govuk::apps::contentapi::nagios_memory_critical: 4000
 
-govuk::apps::content_store::nagios_memory_warning: 1200
-govuk::apps::content_store::nagios_memory_critical: 1300
+govuk::apps::content_store::nagios_memory_warning: 2300
+govuk::apps::content_store::nagios_memory_critical: 2500
 
 govuk::apps::content_tagger::db_hostname: "postgresql-primary-1.backend"
 govuk::apps::content_tagger::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"


### PR DESCRIPTION
A recent acknowledgement of content-store-3 memory alerts allowed the app
to keep running until memory usage appeared to stabilise ~2.1GB. This suggests
that the application needs this amount and will garbage collect and not
continue to consume more.

![screenshot from 2016-10-19 11 52 38](https://cloud.githubusercontent.com/assets/93511/19516153/94b077c8-95f2-11e6-9409-533a0641ff9b.png)

[Link to graphite for this data](https://graphite.publishing.service.gov.uk/render/?width=1000&height=600&colorList=red,orange,blue,green,purple,brown&target=alias(dashed(constantLine(1300000000)),%22critical%22)&target=alias(dashed(constantLine(1200000000)),%22warning%22)&target=content-store-3_api.processes-app-content-store.ps_rss&from=20161017&until=20161020)
