### PR TITLE
Move assets s3 sync

### DIFF
--- a/modules/govuk/manifests/node/s_asset_base.pp
+++ b/modules/govuk/manifests/node/s_asset_base.pp
@@ -193,11 +193,6 @@ class govuk::node::s_asset_base (
         mode    => '0755',
       }
 
-      # FIXME: remove after this has been deployed
-      file { '/etc/cron.daily/push_attachments_to_s3':
-        ensure => absent,
-      }
-
       cron { 'push_attachments_to_s3':
         command => '/usr/bin/setlock -n /var/run/virus_scan/push-attachments.lock /usr/local/bin/push_attachments_to_s3.sh /mnt/uploads',
         user    => 'assets',

--- a/modules/govuk/manifests/node/s_asset_base.pp
+++ b/modules/govuk/manifests/node/s_asset_base.pp
@@ -196,7 +196,7 @@ class govuk::node::s_asset_base (
       cron { 'push_attachments_to_s3':
         command => '/usr/bin/setlock -n /var/run/virus_scan/push-attachments.lock /usr/local/bin/push_attachments_to_s3.sh /mnt/uploads',
         user    => 'assets',
-        hour    => 6,
+        hour    => 21,
         minute  => 0,
       }
 


### PR DESCRIPTION
The S3 attachment sync causes the machine to run extremely low on memory, which *may* have caused problems with the asset-master to connect to it. The asset-master virus scanning process copies each file it scans to each slave, and if it's unable to connect it will eventually time out, but it will also cause files to backup in processing if there are a lot of them.

This makes it less likely that we will see an impact of this during the daytime when there are more files being uploaded for processing.