### PR TITLE
Add pingdom jenkins checker

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -78,6 +78,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::build_fpm_package
   - govuk_jenkins::job::build_offsite_backup
   - govuk_jenkins::job::check_cdn_ip_ranges
+  - govuk_jenkins::job::check_pingdom_ip_ranges
   - govuk_jenkins::job::ci_network_config
   - govuk_jenkins::job::copy_data_to_integration
   - govuk_jenkins::job::copy_data_to_staging

--- a/modules/govuk_jenkins/manifests/job/check_pingdom_ip_ranges.pp
+++ b/modules/govuk_jenkins/manifests/job/check_pingdom_ip_ranges.pp
@@ -1,0 +1,12 @@
+# == Class: govuk_jenkins::job::check_pingdom_ip_ranges
+#
+# Create a jenkins-job-builder config file for checking that Pingdom
+# IP ranges are configured correctly.
+#
+class govuk_jenkins::job::check_pingdom_ip_ranges {
+  file { '/etc/jenkins_jobs/jobs/check_pingdom_ip_ranges.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/check_pingdom_ip_ranges.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+}

--- a/modules/govuk_jenkins/templates/jobs/check_pingdom_ip_ranges.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/check_pingdom_ip_ranges.yaml.erb
@@ -1,0 +1,28 @@
+---
+- scm:
+    name: govuk-provisioning_Check_Pingdom_IP_Ranges
+    scm:
+        - git:
+            url: git@github.gds:gds/govuk_mirror-deployment.git
+            branches:
+              - master
+            wipe-workspace: false
+
+- job:
+    name: Check_Pingdom_IP_Ranges
+    display-name: Check_Pingdom_IP_Ranges
+    project-type: freestyle
+    description: "This job compares the IP ranges that Pingdom publishes against the ranges configured in govuk-provisioning and errors if they don't match."
+    properties:
+        - github:
+            url: https://github.gds/gds/govuk_mirror-deployment/
+    scm:
+      - govuk-provisioning_Check_Pingdom_IP_Ranges
+    builders:
+        - shell: |
+            ruby tools/pingdom_ips.rb
+    publishers:
+        - email:
+            recipients: 2nd-line-support@digital.cabinet-office.gov.uk
+    triggers:
+        - timed: 'H 3 * * *'


### PR DESCRIPTION
This adds a jenkins job that will check our locally configured pingdom ip ranges against the authoritative upstream source and fail if any differences are found.