### PR TITLE
Mysql xtrabackup restore

### DIFF
--- a/modules/govuk_mysql/templates/usr/local/bin/xtrabackup_s3_restore.erb
+++ b/modules/govuk_mysql/templates/usr/local/bin/xtrabackup_s3_restore.erb
@@ -31,11 +31,19 @@ else
     rm -rf $dir/*
   done
 
-  # Pull the latest backups from S3
-  envdir <%= @env_sync_envdir %> gof3r get --endpoint s3-<%= @aws_region -%>.amazonaws.com -b <%= @s3_bucket_name %> -k latest/base.xbcrypt | xbcrypt --encrypt-algo=AES256 --decrypt --encrypt-key="<%= @encryption_key %>" | xbstream -x -C $BASE_DIR
+  # Pull, then decrypt the latest backups from S3
+  cd $BASE_DIR && envdir <%= @env_sync_envdir %> gof3r get --endpoint s3-<%= @aws_region -%>.amazonaws.com -b <%= @s3_bucket_name %> -k latest/base.xbcrypt | xbstream -x -C $BASE_DIR
 
-  envdir <%= @env_sync_envdir %> gof3r get --endpoint s3-<%= @aws_region -%>.amazonaws.com -b <%= @s3_bucket_name %> -k latest/incremental.xbcrypt | xbcrypt --encrypt-algo=AES256 --decrypt --encrypt-key="<%= @encryption_key %>" | xbstream -x -C $INCR_DIR
+  for i in `find . -iname "*\.xbcrypt"`; do
+    xbcrypt --encrypt-algo=AES256 --decrypt --encrypt-key="<%= @encryption_key %>" < $i > $(dirname $i)/$(basename $i .xbcrypt) && rm $i
+  done
 
+  cd $INCR_DIR && envdir <%= @env_sync_envdir %> gof3r get --endpoint s3-<%= @aws_region -%>.amazonaws.com -b <%= @s3_bucket_name %> -k latest/incremental.xbcrypt | xbstream -x -C $INCR_DIR
+
+  for i in `find . -iname "*\.xbcrypt"`; do
+    xbcrypt --encrypt-algo=AES256 --decrypt --encrypt-key="<%= @encryption_key %>" < $i > $(dirname $i)/$(basename $i .xbcrypt) && rm $i
+  done
+  
   # Decompress the backups
   for dir in "$BASE_DIR" "$INCR_DIR"; do
     innobackupex --decompress $dir

--- a/modules/govuk_mysql/templates/usr/local/bin/xtrabackup_s3_restore.erb
+++ b/modules/govuk_mysql/templates/usr/local/bin/xtrabackup_s3_restore.erb
@@ -5,9 +5,10 @@ exec 1> >(/usr/bin/logger -s -t $(basename $0)) 2>&1
 
 set -e
 
-DATE=$(date +%s)
-BASE_DIR=/tmp/mysql/basedir/$DATE/
-INCR_DIR=/tmp/mysql/incremental/$DATE/
+DATE=$(date +%F)
+CURRENT_RESTORE=/tmp/mysql/$DATE
+BASE_DIR=$CURRENT_RESTORE/basedir
+INCR_DIR=$CURRENT_RESTORE/incremental
 
 echo "Starting MySQL environment sync"
 
@@ -21,8 +22,13 @@ else
   govuk_puppet --disable "MySQL environment sync (by $0)"
 
   # Create directories to restore into
-  for dir in "$BASE_DIR" "$INCR_DIR"; do
+  if [[ ! -d "CURRENT_RESTORE" && ! -d "$BASE_DIR" && ! -d "$INCR_DIR" ]]; then
+    for dir in "$BASE_DIR" "$INCR_DIR"; do
     mkdir -p $dir
+    done
+  else
+    for dir in "$BASE_DIR" "$INCR_DIR"; do
+    rm -rf $dir/*
   done
 
   # Pull the latest backups from S3

--- a/modules/govuk_mysql/templates/usr/local/bin/xtrabackup_s3_restore.erb
+++ b/modules/govuk_mysql/templates/usr/local/bin/xtrabackup_s3_restore.erb
@@ -5,7 +5,7 @@ exec 1> >(/usr/bin/logger -s -t $(basename $0)) 2>&1
 
 set -e
 
-DATE=$(date +%F)
+DATE=$(/bin/date +%F)
 CURRENT_RESTORE=/tmp/mysql/$DATE
 BASE_DIR=$CURRENT_RESTORE/basedir
 INCR_DIR=$CURRENT_RESTORE/incremental
@@ -19,42 +19,42 @@ if test -f /var/lib/puppet/state/agent_disabled.lock; then
   exit 1
 else
 
-  govuk_puppet --disable "MySQL environment sync (by $0)"
+  /usr/local/bin/govuk_puppet --disable "MySQL environment sync (by $0)"
 
   # Create directories to restore into
-  if [[ ! -d "CURRENT_RESTORE" && ! -d "$BASE_DIR" && ! -d "$INCR_DIR" ]]; then
+  if [[ ! -d "$CURRENT_RESTORE" && ! -d "$BASE_DIR" && ! -d "$INCR_DIR" ]]; then
     for dir in "$BASE_DIR" "$INCR_DIR"; do
-    mkdir -p $dir
+      /bin/mkdir -p $dir
     done
   else
     for dir in "$BASE_DIR" "$INCR_DIR"; do
-    rm -rf $dir/*
-  done
-
+      /bin/rm -rf $dir/*
+    done
+  fi
   # Pull, then decrypt the latest backups from S3
-  cd $BASE_DIR && envdir <%= @env_sync_envdir %> gof3r get --endpoint s3-<%= @aws_region -%>.amazonaws.com -b <%= @s3_bucket_name %> -k latest/base.xbcrypt | xbstream -x -C $BASE_DIR
+  cd $BASE_DIR && /usr/bin/envdir <%= @env_sync_envdir %> /usr/local/bin/gof3r get --endpoint s3-<%= @aws_region -%>.amazonaws.com -b <%= @s3_bucket_name %> -k latest/base.xbcrypt | /usr/bin/xbstream -x -C $BASE_DIR
 
-  for i in `find . -iname "*\.xbcrypt"`; do
-    xbcrypt --encrypt-algo=AES256 --decrypt --encrypt-key="<%= @encryption_key %>" < $i > $(dirname $i)/$(basename $i .xbcrypt) && rm $i
+  for i in `/usr/bin/find . -iname "*\.xbcrypt"`; do
+    /usr/bin/xbcrypt --encrypt-algo=AES256 --decrypt --encrypt-key="<%= @encryption_key %>" < $i > $(/usr/bin/dirname $i)/$(/usr/bin/basename $i .xbcrypt) && /bin/rm $i
   done
 
-  cd $INCR_DIR && envdir <%= @env_sync_envdir %> gof3r get --endpoint s3-<%= @aws_region -%>.amazonaws.com -b <%= @s3_bucket_name %> -k latest/incremental.xbcrypt | xbstream -x -C $INCR_DIR
+  cd $INCR_DIR && /usr/bin/envdir <%= @env_sync_envdir %> /usr/local/bin/gof3r get --endpoint s3-<%= @aws_region -%>.amazonaws.com -b <%= @s3_bucket_name %> -k latest/incremental.xbcrypt | /usr/bin/xbstream -x -C $INCR_DIR
 
-  for i in `find . -iname "*\.xbcrypt"`; do
-    xbcrypt --encrypt-algo=AES256 --decrypt --encrypt-key="<%= @encryption_key %>" < $i > $(dirname $i)/$(basename $i .xbcrypt) && rm $i
+  for i in `/usr/bin/find . -iname "*\.xbcrypt"`; do
+    /usr/bin/xbcrypt --encrypt-algo=AES256 --decrypt --encrypt-key="<%= @encryption_key %>" < $i > $(/usr/bin/dirname $i)/$(/usr/bin/basename $i .xbcrypt) && /bin/rm $i
   done
-  
+
   # Decompress the backups
   for dir in "$BASE_DIR" "$INCR_DIR"; do
-    innobackupex --decompress $dir
+    /usr/bin/innobackupex --decompress $dir --parallel=4   # "GO FAST....." Use four threads if available 
   done
 
   # Prepare the data and apply the logs
-  innobackupex --apply-log --redo-only $BASE_DIR
-  innobackupex --apply-log $BASE_DIR --incremental-dir=$INCR_DIR
+  /usr/bin/innobackupex --apply-log --redo-only $BASE_DIR
+  /usr/bin/innobackupex --apply-log $BASE_DIR --incremental-dir=$INCR_DIR
 
   # Stop the service before we copy the data across
-  service mysql stop
+  /usr/sbin/service mysql stop
 
   # Ensure that it's definitely not running before we move data directories
   if /bin/pidof mysqld; then
@@ -66,27 +66,28 @@ else
   # the directory is a mount point so we need to copy
   echo "Backing up current dir"
   TEMPDIR=mysql-$(date '+%s')
-  cp -R /var/lib/mysql /var/lib/$TEMPDIR
+  /bin/cp -R /var/lib/mysql /var/lib/$TEMPDIR
 
   # Remove contents of the datadir
-  rm -rf /var/lib/mysql/*
+  /bin/rm -rf /var/lib/mysql/*
 
   # Copy the restored data
-  innobackupex --copy-back $BASE_DIR
+  /usr/bin/innobackupex --copy-back $BASE_DIR
 
   # Update to correct permissions
   echo "Correcting permissions"
-  chown -R mysql:mysql /var/lib/mysql
+  /bin/chown -R mysql:mysql /var/lib/mysql
 
   # Start the service
-  service mysql start
+  /usr/sbin/service mysql start
 
   # Clean up
   echo "Cleaning up"
-  rm -rf /var/lib/$TEMPDIR $BASE_DIR $INCR_DIR
+  /bin/rm -rf /var/lib/$TEMPDIR $BASE_DIR $INCR_DIR
 
   # Re-enable Puppet and run it to ensure passwords are updated
-  govuk_puppet --enable && govuk_puppet
+  /usr/local/bin/govuk_puppet --enable && /usr/local/bin/govuk_puppet
 
   echo "MySQL environment sync completely successfully"
 fi
+

--- a/modules/govuk_mysql/templates/usr/local/bin/xtrabackup_s3_restore.erb
+++ b/modules/govuk_mysql/templates/usr/local/bin/xtrabackup_s3_restore.erb
@@ -12,17 +12,10 @@ INCR_DIR=$CURRENT_RESTORE/incremental
 
 echo "Starting MySQL environment sync"
 
-# Check to see if Puppet is disabled, and skip the environment sync if it is
-# as we dumbly assume the server is under maintenance
-if test -f /var/lib/puppet/state/agent_disabled.lock; then
-  echo "Puppet is already disabled! Skipping environment sync and quitting"
-  exit 1
-else
+  /usr/local/bin/govuk_puppet -n mysql_restore -r "MySQL environment sync (by $0)" --disable
 
-  /usr/local/bin/govuk_puppet --disable "MySQL environment sync (by $0)"
-
-  # Create directories to restore into
-  if [[ ! -d "$CURRENT_RESTORE" && ! -d "$BASE_DIR" && ! -d "$INCR_DIR" ]]; then
+  # Create directories to restore into OR Purge {$BASE_DIR,$INCR_DIR} if they already exist
+  if [[ ! -d "$CURRENT_RESTORE"; ! -d "$BASE_DIR"; ! -d "$INCR_DIR" ]]; then
     for dir in "$BASE_DIR" "$INCR_DIR"; do
       /bin/mkdir -p $dir
     done
@@ -31,6 +24,7 @@ else
       /bin/rm -rf $dir/*
     done
   fi
+
   # Pull, then decrypt the latest backups from S3
   cd $BASE_DIR && /usr/bin/envdir <%= @env_sync_envdir %> /usr/local/bin/gof3r get --endpoint s3-<%= @aws_region -%>.amazonaws.com -b <%= @s3_bucket_name %> -k latest/base.xbcrypt | /usr/bin/xbstream -x -C $BASE_DIR
 
@@ -86,8 +80,6 @@ else
   /bin/rm -rf /var/lib/$TEMPDIR $BASE_DIR $INCR_DIR
 
   # Re-enable Puppet and run it to ensure passwords are updated
-  /usr/local/bin/govuk_puppet --enable && /usr/local/bin/govuk_puppet
+  /usr/local/bin/govuk_puppet -n mysql_restore --enable && /usr/local/bin/govuk_puppet
 
   echo "MySQL environment sync completely successfully"
-fi
-


### PR DESCRIPTION
See Trello: https://trello.com/c/AsknJrSt

What 
Initially, to address comments made in Trello card.  Running the script in Integration produced different errors not relating to previous comments made in Trello.
Breakages in script:
- Streamed data from `gof3r` to `xbcrypt` failed due to wrong data chunk size.  reference: https://github.com/mdkent/percona-xtrabackup/blob/master/src/xbstream_read.c
- `xbcrypt` is incapable of handling multiple chunks of streamed data

Refactoring to make use of newly added features to `govuk_puppet`.

How
Streamed data from `gof3r` must first go through `xbstream -x` when piping to `xbcrypt`.  This is due to `xbcrypt` not handling multiple chunks of data that well.  
We changed the process to decrypt the data after it had been saved to disk. We then have `xbcrypt` iterate over each file.  
We now change  directory to perform operations. 

We modified the temporary directory structure for clarity.

Added flag `--parallel` to `innobackupex` to improve the performance of the process.

Govuk Puppet:
- Remove conditional that checks for the existence of a lock.  The `govuk_puppet` script now allows for multiple locks to exist.
- Rewrite (`govuk_puppet`) disable command to be more explicit.
