### PR TITLE
Remove trailing / from tariff-frontend url

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1254,4 +1254,4 @@ unattended_reboot::etcd_endpoints:
 
 unicornherder::version: '0.0.8'
 
-trade_tariff_uri: 'https://tariff-frontend-dev.cloudapps.digital/'
+trade_tariff_uri: 'https://tariff-frontend-dev.cloudapps.digital'

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -592,4 +592,4 @@ shell::shell_prompt_string: 'production'
 mongodb::s3backup::backup::s3_bucket: 'govuk-mongodb-backup-s3-production'
 mongodb::s3backup::backup::s3_bucket_daily: 'govuk-mongodb-backup-s3-daily-production'
 
-trade_tariff_uri: 'https://tariff-frontend-production.cloudapps.digital/'
+trade_tariff_uri: 'https://tariff-frontend-production.cloudapps.digital'

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -534,4 +534,4 @@ users::pentest_machines:
 mongodb::s3backup::backup::s3_bucket: 'govuk-mongodb-backup-s3-staging'
 mongodb::s3backup::backup::s3_bucket_daily: 'govuk-mongodb-backup-s3-daily-staging'
 
-trade_tariff_uri: 'https://tariff-frontend-staging.cloudapps.digital/'
+trade_tariff_uri: 'https://tariff-frontend-staging.cloudapps.digital'


### PR DESCRIPTION
The content-store adds a trailing slash, so without this change, there is an
unnecessary / in the url.