### PR TITLE
Fix hyphens in efg-rebuild app name

### DIFF
--- a/modules/govuk/manifests/apps/efg_rebuild.pp
+++ b/modules/govuk/manifests/apps/efg_rebuild.pp
@@ -50,7 +50,7 @@ class govuk::apps::efg_rebuild (
 ) {
   validate_string($vhost_name)
 
-  $app_name = 'efg_rebuild'
+  $app_name = 'efg-rebuild'
 
   govuk::app { $app_name:
     app_type               => 'rack',

--- a/modules/govuk_jenkins/templates/jobs/deploy_efg_rebuild.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_efg_rebuild.yaml.erb
@@ -18,7 +18,7 @@
             url: https://github.com/alphagov/govuk-app-deployment
         - inject:
             properties-content: |
-              TARGET_APPLICATION=efg_rebuild
+              TARGET_APPLICATION=efg-rebuild
     scm:
       - alphagov-deployment_Deploy_EFG_Rebuild
     builders:


### PR DESCRIPTION
The app name should have hyphens - the only thing with underscores should be the Puppet class.