### PR TITLE
govuk_puppet Fix

### DIFF
--- a/modules/puppet/templates/govuk_puppet
+++ b/modules/puppet/templates/govuk_puppet
@@ -168,6 +168,7 @@ if [[ " ${puppet_args} " =~ "--disable " ]]; then
   fi
 
   write_lock
+  exit 0
 fi
 
 if [[ " ${puppet_args} " =~ "--enable " ]]; then


### PR DESCRIPTION
What
Whenever a lock is created the `govuk_puppet` script would exit with the status code `1` when bash option `-e` is passed. It's not an issue when invoking the script interactively. However, invoking the script from another script would cause the latter to exit immediately, preventing the script from going any further.

How
Call to `exit` once the lock has been created.