### PR TITLE
Remove duplicate `govuk::apps::efg_training` config

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -44,9 +44,6 @@ govuk::apps::efg::vhost_name: "www.sflg.gov.uk"
 govuk::apps::efg_training::ssl_certtype: 'sflg'
 govuk::apps::efg_training::vhost_name: "training.sflg.gov.uk"
 
-govuk::apps::efg_training::ssl_certtype: 'sflg'
-govuk::apps::efg_training::vhost_name: "rebuild-training.sflg.gov.uk"
-
 govuk::apps::email_alert_api::db::backend_ip_range: '10.3.3.0/24'
 govuk::apps::errbit::errbit_email_from: 'govuk-winston+errbit-production@digital.cabinet-office.gov.uk'
 govuk::apps::hmrc_manuals_api::publish_topics: false


### PR DESCRIPTION
This duplicates the values immediately above it - I think these were meant to be set with the key `govuk::apps::efg_training_rebuild` but as we don't need to override these values in production it's easier to remove them.

This means the hostname for the rebuild will be `efg-training-rebuild.publishing.service.gov.uk`.