### PR TITLE
Rspec test fixes

### DIFF
--- a/modules/govuk_cdnlogs/spec/classes/govuk_cdnlogs_spec.rb
+++ b/modules/govuk_cdnlogs/spec/classes/govuk_cdnlogs_spec.rb
@@ -8,6 +8,11 @@ describe 'govuk_cdnlogs', :type => :class do
     :service_port_map => { 'elephant' => 123 },
   }}
 
+  let(:facts) {{
+    :ipaddress_eth0 => '10.10.10.10',
+  }}
+
+
   context 'all params' do
     let(:params) { default_params }
 

--- a/modules/govuk_elasticsearch/spec/classes/govuk_elasticsearch_spec.rb
+++ b/modules/govuk_elasticsearch/spec/classes/govuk_elasticsearch_spec.rb
@@ -2,8 +2,9 @@ require_relative '../../../../spec_helper'
 
 describe 'govuk_elasticsearch', :type => :class do
   let(:facts) {{
-    :fqdn   => 'test.example.com',
-    :kernel => 'Linux',
+    :fqdn        => 'test.example.com',
+    :kernel      => 'Linux',
+    :rubyversion => '1.9.3',
   }}
 
   describe '#version' do

--- a/modules/govuk_elasticsearch/spec/defines/govuk_elasticsearch__firewall_transport_rule_spec.rb
+++ b/modules/govuk_elasticsearch/spec/defines/govuk_elasticsearch__firewall_transport_rule_spec.rb
@@ -5,6 +5,9 @@ describe 'govuk_elasticsearch::firewall_transport_rule', :type => :define do
   context "with a bare hostname" do
     let(:title) { @title }
     let(:params) {{}}
+    let(:facts) {{
+      :ipaddress_eth0 => '10.10.10.10',
+    }}
 
     let(:pre_condition) {
       <<-EOT

--- a/modules/govuk_postgresql/spec/classes/govuk_postgresql__env_sync_user_spec.rb
+++ b/modules/govuk_postgresql/spec/classes/govuk_postgresql__env_sync_user_spec.rb
@@ -3,6 +3,8 @@ require_relative '../../../../spec_helper'
 describe 'govuk_postgresql::env_sync_user', :type => :class do
   let(:facts) {{
     :concat_basedir => '/tmp/concat',
+    :id             => 'fake_id',
+    :kernel         => 'Linux',
   }}
   let(:pre_condition) { <<-EOS
     include govuk_postgresql::server::standalone

--- a/modules/govuk_postgresql/spec/classes/govuk_postgresql__server__standby_spec.rb
+++ b/modules/govuk_postgresql/spec/classes/govuk_postgresql__server__standby_spec.rb
@@ -16,6 +16,8 @@ describe 'govuk_postgresql::server::standby', :type => :class do
     :concat_basedir         => '/tmp/concat',
     :operatingsystem        => 'Ubuntu',
     :operatingsystemrelease => '14.04',
+    :id                     => 'fake_id',
+    :kernel                 => 'Linux',
   }}
   let(:params) {{
     :master_host     => param_host,

--- a/modules/govuk_postgresql/spec/classes/govuk_postgresql__server_spec.rb
+++ b/modules/govuk_postgresql/spec/classes/govuk_postgresql__server_spec.rb
@@ -3,6 +3,8 @@ require_relative '../../../../spec_helper'
 describe 'govuk_postgresql::server', :type => :class do
   let(:facts) {{
     :concat_basedir => '/tmp/concat',
+    :id             => 'fake_id',
+    :kernel         => 'Linux',
   }}
 
   describe 'prevent direct use' do

--- a/modules/icinga/spec/defines/icinga__check__graphite_spec.rb
+++ b/modules/icinga/spec/defines/icinga__check__graphite_spec.rb
@@ -2,7 +2,12 @@ require_relative '../../../../spec_helper'
 
 describe 'icinga::check::graphite', :type => :define do
 
-  let(:facts) {{ :fqdn => 'warden.zoo.tld' }}
+  let(:facts) {{
+    :fqdn       => 'warden.zoo.tld',
+    :fqdn_short => 'warden.zoo',
+    :ipaddress  => '10.10.10.10',
+  }}
+
   let(:pre_condition) { 'icinga::host { "warden.zoo.tld": }' }
 
   context 'when required params are passed' do

--- a/modules/icinga/spec/defines/icinga__check_feature_spec.rb
+++ b/modules/icinga/spec/defines/icinga__check_feature_spec.rb
@@ -4,8 +4,10 @@ describe 'icinga::check_feature', :type => :define do
   let(:title) { 'check_test_feature' }
   let(:pre_condition) {  'icinga::host{"test_host.blah.blah":}' }
   let(:facts) {{
-    "hostname"    => "test_host",
-    "fqdn"        => "test_host.blah.blah"
+    "hostname"   => "test_host",
+    "fqdn"       => "test_host.blah.blah",
+    "ipaddress"  => '10.10.10.10',
+    "fqdn_short" => 'fakehost-1.management',
   }}
   let(:params) {{
     "feature"   => "test_feature"

--- a/modules/icinga/spec/defines/icinga__check_passive_spec.rb
+++ b/modules/icinga/spec/defines/icinga__check_passive_spec.rb
@@ -4,7 +4,8 @@ describe 'icinga::passive_check', :type => :define do
   let(:title) { 'check_giraffes' }
   let(:file_path) { '/etc/icinga/conf.d/icinga_host_warden.zoo.tld/check_giraffes.cfg' }
   let(:facts) {{
-    :fqdn => 'warden.zoo.tld',
+    :fqdn      => 'warden.zoo.tld',
+    :ipaddress => '10.10.10.10',
   }}
   let(:pre_condition) {
     "icinga::host { 'warden.zoo.tld': }"

--- a/modules/icinga/spec/defines/icinga__check_spec.rb
+++ b/modules/icinga/spec/defines/icinga__check_spec.rb
@@ -10,6 +10,10 @@ describe 'icinga::check', :type => :define do
     :host_name           => "bruce-forsyth",
     :service_description => "to see you nice",
   }}
+  let(:facts) {{
+    :ipaddress  => '10.10.10.10',
+    :fqdn_short => 'fakehost-1.management',
+  }}
 
   context "validating service description" do
     context "when service description is valid" do

--- a/modules/icinga/spec/defines/icinga__host_spec.rb
+++ b/modules/icinga/spec/defines/icinga__host_spec.rb
@@ -3,6 +3,11 @@ require_relative '../../../../spec_helper'
 describe 'icinga::host', :type => :define do
   let(:title) { 'bruce-forsyth' }
 
+  let(:facts) {{
+    :ipaddress  => '10.10.10.10',
+    :fqdn_short => 'fakehost-1.management',
+  }}
+
   it { is_expected.to contain_file('/etc/icinga/conf.d/icinga_host_bruce-forsyth.cfg') }
   it { is_expected.to contain_file('/etc/icinga/conf.d/icinga_host_bruce-forsyth.cfg').without_content(/parents/) }
 

--- a/modules/icinga/spec/defines/icinga__passive_check_spec.rb
+++ b/modules/icinga/spec/defines/icinga__passive_check_spec.rb
@@ -14,6 +14,7 @@ end
 # icinga::passive_check should create file using right template (we'll check for some known content)
 describe 'icinga::passive_check', :type => :define do
   let(:title) { 'heartbeat' }
+  let(:facts) {{ 'ipaddress' => '10.10.10.10' }}
   let(:pre_condition) {  'icinga::host{"bruce-forsyth":}' }
   let(:params) {{
     "host_name" => "bruce-forsyth",

--- a/modules/monitoring/spec/classes/monitoring__checks__mirror_spec.rb
+++ b/modules/monitoring/spec/classes/monitoring__checks__mirror_spec.rb
@@ -7,6 +7,8 @@ describe 'monitoring::checks::mirror', :type => :class do
   let(:facts) {{
     :fqdn       => "dummy.host",
     :cache_bust => Time.now,
+    :ipaddress  => '10.10.10.10',
+    :fqdn_short => 'fakehost-1.management',
   }}
 
   context 'checks enabled with hiera' do

--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -35,6 +35,7 @@ RSpec.configure do |c|
     :operatingsystemrelease  => possible_releases[dist_preferred],
     :lsbdistid               => 'Debian',
     :lsbdistcodename         => dist_preferred.capitalize,
+    :lsbmajdistrelease       => 14,
     :architecture            => 'amd64',
   }
 end

--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -37,5 +37,6 @@ RSpec.configure do |c|
     :lsbdistcodename         => dist_preferred.capitalize,
     :lsbmajdistrelease       => 14,
     :architecture            => 'amd64',
+    :fqdn_metrics            => 'fakehost-1_management',
   }
 end

--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -35,5 +35,6 @@ RSpec.configure do |c|
     :operatingsystemrelease  => possible_releases[dist_preferred],
     :lsbdistid               => 'Debian',
     :lsbdistcodename         => dist_preferred.capitalize,
+    :architecture            => 'amd64',
   }
 end


### PR DESCRIPTION
We'd like to run our specs under `strict_variables` as part of the puppet 4 migration. These fixes allow more modules to pass those tests.