### PR TITLE
Reduce the nodes and shards used in the cluster

### DIFF
--- a/hieradata/class/elasticsearch.yaml
+++ b/hieradata/class/elasticsearch.yaml
@@ -3,6 +3,8 @@
 govuk_safe_to_reboot::can_reboot: 'careful'
 govuk_safe_to_reboot::reason: 'Reboot a single node at time and check that the cluster goes green between reboots'
 
+govuk_elasticsearch::minimum_master_nodes: '1'
+govuk_elasticsearch::number_of_replicas: '0'
 govuk_elasticsearch::version: '0.90.12'
 
 lv:


### PR DESCRIPTION
They are numbers but the class uses strings to represent them so
I'm doing the same here.

We are reducing the size of the ES cluster, this ensures a machine holds all its own data.