### PR TITLE
Set up GOVUK_CONTENT_SCHEMAS_PATH environment variable

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -389,6 +389,7 @@ govuk::apps::publishing_api::rabbitmq_password: "%{hiera('govuk::apps::publishin
 govuk::apps::publishing_api::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::publishing_api::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::publishing_api::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
+govuk::apps::publishing_api::govuk_content_schemas_path: '/data/apps/publishing-api/shared/govuk-content-schemas/'
 
 govuk::apps::release::db_hostname: "master.mysql"
 govuk::apps::release::db_username: "release"

--- a/modules/govuk/manifests/apps/publishing_api.pp
+++ b/modules/govuk/manifests/apps/publishing_api.pp
@@ -65,6 +65,9 @@
 #   A password to connect to RabbitMQ:
 #   https://github.com/alphagov/publishing-api/blob/master/config/rabbitmq.yml
 #
+# [*govuk_content_schemas_path*]
+#   The path for generated govuk-content-schemas
+#
 class govuk::apps::publishing_api(
   $port = '3093',
   $content_store = '',
@@ -82,6 +85,7 @@ class govuk::apps::publishing_api(
   $oauth_id = undef,
   $oauth_secret = undef,
   $rabbitmq_password = undef,
+  $govuk_content_schemas_path = '',
 ) {
   $app_name = 'publishing-api'
 
@@ -129,6 +133,9 @@ class govuk::apps::publishing_api(
     "${title}-RABBITMQ_PASSWORD":
       varname => 'RABBITMQ_PASSWORD',
       value   => $rabbitmq_password;
+    "${title}-GOVUK_CONTENT_SCHEMAS_PATH":
+      varname => 'GOVUK_CONTENT_SCHEMAS_PATH',
+      value   => $govuk_content_schemas_path;
   }
 
   govuk_logging::logstream { 'publishing_api_sidekiq_json_log':


### PR DESCRIPTION
To be used in the publishing-api for the govuk-content-schemas path.