### PR TITLE
[WIP] Measure unprocessed whitehall uploads

### DIFF
--- a/modules/collectd/spec/defines/collectd__plugin__file_count_spec.rb
+++ b/modules/collectd/spec/defines/collectd__plugin__file_count_spec.rb
@@ -9,9 +9,9 @@ describe "collectd::plugin::file_count", :type => :define do
 
   it {
     is_expected.to contain_collectd__plugin("file count: #{title}").with_content(<<-EOS
+LoadPlugin "filecount"
 <Plugin "filecount">
   <Directory "#{directory}">
-    Instance "#{directory}"
   </Directory>
 </Plugin>
 EOS

--- a/modules/collectd/templates/etc/collectd/conf.d/file_count.conf.erb
+++ b/modules/collectd/templates/etc/collectd/conf.d/file_count.conf.erb
@@ -1,5 +1,5 @@
+LoadPlugin "filecount"
 <Plugin "filecount">
   <Directory "<%= @directory %>">
-    Instance "<%= @directory %>"
   </Directory>
 </Plugin>

--- a/modules/govuk/manifests/node/s_asset_master.pp
+++ b/modules/govuk/manifests/node/s_asset_master.pp
@@ -14,6 +14,8 @@
 class govuk::node::s_asset_master (
   $copy_attachments_hour = 4,
   $asset_slave_ip_ranges = {},
+  $incoming_uploads_count_warning = 100,
+  $incoming_uploads_count_critical = 1000
 ) inherits govuk::node::s_asset_base {
 
   include assets::ssh_private_key
@@ -29,6 +31,8 @@ class govuk::node::s_asset_master (
     File['/var/run/virus_scan'],
     Package['daemontools'],
   ]
+
+  $incoming_directory = '/mnt/uploads/whitehall/incoming'
 
   cron { 'process-incoming-files':
     user    => 'assets',
@@ -64,6 +68,11 @@ class govuk::node::s_asset_master (
     user   => 'assets',
   }
 
+  collectd::plugin::file_count {
+    'whitehall_incoming':
+      directory => $incoming_directory;
+  }
+
   @@icinga::passive_check { "check_process_attachments_${::hostname}":
     service_description => 'Process attachments last run',
     host_name           => $::fqdn,
@@ -76,6 +85,14 @@ class govuk::node::s_asset_master (
     host_name           => $::fqdn,
     freshness_threshold => 100800,
     notes_url           => monitoring_docs_url(full-attachments-sync),
+  }
+
+  @@icinga::check::graphite { "check_whitehall_incoming_uploads_count-${::hostname}":
+    target    => "${::fqdn_metrics}.filecount-mnt_uploads_whitehall_incoming.files",
+    desc      => 'Whitehall incoming uploads count',
+    warning   => $incoming_uploads_count_warning,
+    critical  => $incoming_uploads_count_critical,
+    host_name => $::fqdn,
   }
 
   cron { 'virus-scan-clean':


### PR DESCRIPTION
Measure the number of unprocessed whitehall uploads and alert if it gets too high.

We looked into also tracking the number of infected/cleared files, but these subdirectories contained a lot of files and nested subdirectories and the collectd plugin seems to hang while recursing through them. Because of this, we decided to start with just the unprocessed files.

I think the icinga alert still needs testing on integration, and the thresholds need to be set based on what's normal.

with @davidbasalla and @andrewgarner 