### PR TITLE
PostgreSQL Backup Logs

### DIFF
--- a/modules/govuk_postgresql/templates/usr/local/bin/autopostgresqlbackup.erb
+++ b/modules/govuk_postgresql/templates/usr/local/bin/autopostgresqlbackup.erb
@@ -637,9 +637,8 @@ if [ -s "$LOGERR" ]
     STATUS=0
 fi
 
-# Clean up Logfile
-rm -f "$LOGFILE"
-rm -f "$LOGERR"
+# Clean up Logfiles older than two weeks
+/usr/bin/find $BACKUPDIR -iname *.log -mtime +14 -type f -delete
 
 if [ $STATUS -eq 0 ]; then
   NAGIOS_CODE=0


### PR DESCRIPTION
If the script must remove it's logs. It would be handy to keep them around for a while for debugging purposes.

Remove autopostgresql backup logs that are older than 2 weeks