### PR TITLE
PostgreSQL Backup User

### DIFF
--- a/modules/govuk_postgresql/templates/usr/local/bin/autopostgresqlbackup.erb
+++ b/modules/govuk_postgresql/templates/usr/local/bin/autopostgresqlbackup.erb
@@ -346,9 +346,9 @@ dbdump () {
   for db in $1 ; do
     if [ -n "$SU_USERNAME" ]; then
       if [ "$db" = "$GLOBALS_OBJECTS" ]; then
-        su $SU_USERNAME -c "pg_dumpall $PGHOST --globals-only" >> $2
+        su - $SU_USERNAME -c "pg_dumpall $PGHOST --globals-only" >> $2
       else
-        su $SU_USERNAME -c "pg_dump $PGHOST $OPT $db" >> $2
+        su - $SU_USERNAME -c "pg_dump $PGHOST $OPT $db" >> $2
       fi
     else
       if [ "$db" = "$GLOBALS_OBJECTS" ]; then
@@ -419,7 +419,7 @@ fi
 # If backing up all DBs on the server
 if [ "$DBNAMES" = "all" ]; then
   if [ -n "$SU_USERNAME" ]; then
-    DBNAMES="$(su $SU_USERNAME -c "LANG=C psql -U $USERNAME $PGHOST -l -A -F: | sed -ne '/:/ { /Name:Owner/d; /template0/d; s/:.*$//; p }'")"
+    DBNAMES="$(su - $SU_USERNAME -c "LANG=C psql -U $USERNAME $PGHOST -l -A -F: | sed -ne '/:/ { /Name:Owner/d; /template0/d; s/:.*$//; p }'")"
   else
     DBNAMES="`LANG=C psql -U $USERNAME $PGHOST -l -A -F: | sed -ne "/:/ { /Name:Owner/d; /template0/d; s/:.*$//; p }"`"
   fi


### PR DESCRIPTION
Script exits with error `could not change directory to "/root": Permission denied`

This script runs as `root` so when using the command 'substitute user' or su to run a command we should use the target user's environment.
In this case `postgres`.