### PR TITLE
Include EFG rebuild apps

### DIFF
--- a/modules/govuk/manifests/apps/efg/db.pp
+++ b/modules/govuk/manifests/apps/efg/db.pp
@@ -26,9 +26,9 @@ class govuk::apps::efg::db (
     collate => 'utf8_general_ci',
   }
   mysql_grant { 'efg@%/efg_il0.*':
-      user       => 'efg@%',
-      table      => 'efg_il0.*',
-      privileges => 'ALL',
+    user       => 'efg@%',
+    table      => 'efg_il0.*',
+    privileges => 'ALL',
   }
 
 }

--- a/modules/govuk/manifests/apps/efg_rebuild/db.pp
+++ b/modules/govuk/manifests/apps/efg_rebuild/db.pp
@@ -22,10 +22,10 @@ class govuk::apps::efg_rebuild::db (
     privileges => 'ALL',
   }
 
-  mysql_grant { 'efg_rebuild@%/efg_rebuild_il0.*':
-      user       => 'efg_rebuild@%',
-      table      => 'efg_rebuild_il0.*',
-      privileges => 'ALL',
+  mysql_grant { 'efg_rebuild@%/efg_il0.*':
+    user       => 'efg_rebuild@%',
+    table      => 'efg_il0.*',
+    privileges => 'ALL',
   }
 
 }

--- a/modules/govuk/manifests/apps/efg_training/db.pp
+++ b/modules/govuk/manifests/apps/efg_training/db.pp
@@ -25,10 +25,10 @@ class govuk::apps::efg_training::db (
     charset => 'utf8',
     collate => 'utf8_general_ci',
   }
-  mysql_grant { 'efg@%/efg_training_il0.*':
-      user       => 'efg@%',
-      table      => 'efg_training_il0.*',
-      privileges => 'ALL',
+  mysql_grant { 'efg_training@%/efg_training_il0.*':
+    user       => 'efg_training@%',
+    table      => 'efg_training_il0.*',
+    privileges => 'ALL',
   }
 
 }

--- a/modules/govuk/manifests/apps/efg_training_rebuild/db.pp
+++ b/modules/govuk/manifests/apps/efg_training_rebuild/db.pp
@@ -22,10 +22,10 @@ class govuk::apps::efg_training_rebuild::db (
     privileges => 'ALL',
   }
 
-  mysql_grant { 'efg@%/efg_training_il0.*':
-      user       => 'efg@%',
-      table      => 'efg_training_il0.*',
-      privileges => 'ALL',
+  mysql_grant { 'efg_training_rebuild@%/efg_training_il0.*':
+    user       => 'efg_training_rebuild@%',
+    table      => 'efg_training_il0.*',
+    privileges => 'ALL',
   }
 
 }

--- a/modules/govuk/manifests/node/s_efg_mysql_master.pp
+++ b/modules/govuk/manifests/node/s_efg_mysql_master.pp
@@ -26,7 +26,15 @@ class govuk::node::s_efg_mysql_master (
     require => Class['govuk_mysql::server'],
   }
 
+  class {'govuk::apps::efg_rebuild::db':
+    require => Class['govuk_mysql::server'],
+  }
+
   class {'govuk::apps::efg_training::db':
+    require => Class['govuk_mysql::server'],
+  }
+
+  class {'govuk::apps::efg_training_rebuild::db':
     require => Class['govuk_mysql::server'],
   }
 


### PR DESCRIPTION
We (I) forgot to include these classes when creating the applications which meant the users weren't created on the database, which meant we were unable to deploy the app.