### PR TITLE
PostgreSQL Backup Time

### DIFF
--- a/hieradata/node/postgresql-primary-1.backend.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/postgresql-primary-1.backend.integration.publishing.service.gov.uk.yaml
@@ -1,0 +1,3 @@
+---
+govuk_postgresql::backup::auto_postgresql_backup_hour: 8
+govuk_postgresql::backup::auto_postgresql_backup_minute: 15


### PR DESCRIPTION
Backup fails due to the database not being available.
ERROR: [psql: FATAL:  the database system is shutting down, pg_dumpall: could not connect to database "template1": FATAL:  the database system is shutting down]

The dataset on this cluster is large so running the backup later will give the environment sync more time to complete.

Testing theory in integration.
