### PR TITLE
Modify Elasticsearch Backup Script

### DIFF
--- a/modules/govuk_elasticsearch/templates/es-backup-s3.erb
+++ b/modules/govuk_elasticsearch/templates/es-backup-s3.erb
@@ -49,7 +49,7 @@ printf "<%= @ipaddress %>\t<%= @service_desc %>\t${NAGIOS_CODE}\t${NAGIOS_MESSAG
 trap nagios_passive EXIT
 
 
-/usr/bin/envdir <%= @env_dir %>/env.d  /usr/bin/curl --connect-timeout 10 -sS -XPUT "http://127.0.0.1:9200/_snapshot/${ES_REPO}?wait_for_completion=true&pretty" -d "$REPO_DATA"
+/usr/bin/curl --connect-timeout 10 -sS -XPUT "http://127.0.0.1:9200/_snapshot/${ES_REPO}?wait_for_completion=true&pretty" -d "$REPO_DATA"
 
 
 # indices: option allows us to specify indexes in a comma separated list rather than taking a snapshot of everything. However we can set
@@ -61,7 +61,7 @@ trap nagios_passive EXIT
 
 if [ $? -eq 0 ]; then
 
-  /usr/bin/envdir <%= @env_dir %>/env.d /usr/bin/curl --connect-timeout 10 -sS -XPUT "http://127.0.0.1:9200/_snapshot/${ES_REPO}/${ES_SNAPSHOT}?wait_for_completion=true&pretty" -d "$SNAPSHOT_DATA" &> /dev/null
+/usr/bin/curl --connect-timeout 10 -sS -XPUT "http://127.0.0.1:9200/_snapshot/${ES_REPO}/${ES_SNAPSHOT}?wait_for_completion=true&pretty" -d "$SNAPSHOT_DATA" &> /dev/null
 
 
 fi


### PR DESCRIPTION
Relates to https://github.com/alphagov/govuk-puppet/pull/4925

`envdir` command is no longer necessary now that we source the data at the start of the script.