### PR TITLE
Elasticsearch s3 Credentials

### DIFF
--- a/modules/govuk_elasticsearch/templates/awspasswd.erb
+++ b/modules/govuk_elasticsearch/templates/awspasswd.erb
@@ -1,4 +1,4 @@
-AWS_SECRET_ACCESS_KEY=<%= @aws_access_key_id %>
-AWS_ACCESS_KEY_ID=<%= @aws_secret_access_key %>
+AWS_SECRET_ACCESS_KEY=<%= @aws_secret_access_key %>
+AWS_ACCESS_KEY_ID=<%= @aws_access_key_id %>
 AWS_REGION=<%= @aws_region %>
 S3_BUCKET=<%= @s3_bucket %>


### PR DESCRIPTION
Relates to https://github.com/alphagov/govuk-puppet/pull/4925

Swapping the tags/values to the appropriate keys.  This will enable Elasticsearch to authenticate to S3
