### PR TITLE
Fix GOVUK_CONTENT_SCHEMAS_PATH for Publishing API

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -377,7 +377,7 @@ govuk::apps::publishing_api::rabbitmq_password: "%{hiera('govuk::apps::publishin
 govuk::apps::publishing_api::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::publishing_api::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::publishing_api::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
-govuk::apps::publishing_api::govuk_content_schemas_path: '/data/apps/publishing-api/shared/govuk-content-schemas/'
+govuk::apps::publishing_api::govuk_content_schemas_path: '/data/apps/govuk-content-schemas/current'
 
 govuk::apps::release::db_hostname: "master.mysql"
 govuk::apps::release::db_username: "release"


### PR DESCRIPTION
The previous value was based upon changes that were planned for the
GovukSchemas gem, but instead of doing this, the plan is now to deploy
govuk-content-schemas as an app, and therefore this configuration value
needs changing.

This is linked to https://github.com/alphagov/govuk-app-deployment/pull/63 but the value is not used currently, so they can be merged independently. 