### PR TITLE
Make govuk-content-schemas a deployable app

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -36,6 +36,7 @@ deployable_applications: &deployable_applications
   - govuk-delivery
   - govuk-cdn-logs-monitor
   - govuk_content_api
+  - govuk-content-schemas
   - govuk_crawler_worker
   - govuk_need_api
   - hmrc-manuals-api


### PR DESCRIPTION
Update to match the changes in govuk-app-deployment, otherwise it does
not appear in the Deploy App job in Jenkins.