### PR TITLE
Update nginx Pin Version

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1109,7 +1109,7 @@ monitoring::vpn_gateways::endpoints:
   vpn_gateway_router_dr:
     address: "%{hiera('environment_ip_prefix')}.9.1"
 
-nginx::package::version: '1.4.6-1ubuntu3.6'
+nginx::package::version: '1.4.6-1ubuntu3.7'
 
 nodejs::version: '0.10.37-1chl1~%{::lsbdistcodename}1'
 


### PR DESCRIPTION
relates to https://github.com/alphagov/govuk-puppet/pull/4990

Wrong package version is causing puppet run warnings.
`aptitude show nginx` displays the correct package version.