### PR TITLE
Remove deleted Elasticsearch nodes from cluster

### DIFF
--- a/modules/govuk/manifests/node/s_elasticsearch.pp
+++ b/modules/govuk/manifests/node/s_elasticsearch.pp
@@ -17,7 +17,7 @@ class govuk::node::s_elasticsearch inherits govuk::node::s_base {
   }
 
   class { 'govuk_elasticsearch':
-    cluster_hosts          => ['elasticsearch-1.backend:9300', 'elasticsearch-2.backend:9300', 'elasticsearch-3.backend:9300'],
+    cluster_hosts          => ['elasticsearch-1.backend:9300'],
     cluster_name           => 'govuk-production',
     heap_size              => "${es_heap_size}m",
     host                   => $::fqdn,


### PR DESCRIPTION
This is used when monitoring the cluster and needs to reflect the machines that exist.
