### PR TITLE
Env vars for government-frontend.

### DIFF
--- a/modules/govuk/manifests/apps/government_frontend.pp
+++ b/modules/govuk/manifests/apps/government_frontend.pp
@@ -11,14 +11,35 @@
 # [*port*]
 #   What port should the app run on?
 #
+# [*errbit_api_key*]
+#   Errbit API key used by airbrake
+#   Default: ''
+#
+# [*secret_key_base*]
+#   The key for Rails to use when signing/encrypting sessions.
+#
 class govuk::apps::government_frontend(
   $vhost = 'government-frontend',
   $port = '3090',
+  $errbit_api_key = '',
+  $secret_key_base = undef,
 ) {
   Govuk::App::Envvar {
     app => 'government-frontend',
   }
 
+  govuk::app::envvar {
+    "${title}-ERRBIT_API_KEY":
+      varname => 'ERRBIT_API_KEY',
+      value   => $errbit_api_key;
+  }
+
+  if $secret_key_base != undef {
+    govuk::app::envvar { "${title}-SECRET_KEY_BASE":
+      varname => 'SECRET_KEY_BASE',
+      value   => $secret_key_base,
+    }
+  }
   govuk::app { 'government-frontend':
     app_type              => 'rack',
     port                  => $port,


### PR DESCRIPTION
These remove the need for storing the Rails secret and Errbit API key
in the deployment repo. They will be populated from hieradata.
