### PR TITLE
Fix MySQL grant for efg_rebuild database

### DIFF
--- a/modules/govuk/manifests/apps/efg_rebuild/db.pp
+++ b/modules/govuk/manifests/apps/efg_rebuild/db.pp
@@ -18,7 +18,7 @@ class govuk::apps::efg_rebuild::db (
 
   mysql_grant { 'efg_rebuild@%/efg_production.*':
     user       => 'efg_rebuild@%',
-    table      => 'efg_rebuild.*',
+    table      => 'efg_production.*',
     privileges => 'ALL',
   }
 


### PR DESCRIPTION
The first bit of the `table` property should be the database name.