### PR TITLE
Log a publishing api related header from NGinx

### DIFF
--- a/modules/nginx/templates/etc/nginx/nginx.conf.erb
+++ b/modules/nginx/templates/etc/nginx/nginx.conf.erb
@@ -54,6 +54,7 @@ http {
                          '"http_user_agent": "$http_user_agent", '
                          '"govuk_request_id": "$http_govuk_request_id", '
                          '"govuk_original_url": "$http_govuk_original_url", '
+                         '"govuk_publishing_api_dependency_resolution_source_content_id": "$http_govuk_publishing_api_dependency_resolution_source_content_id", '
                          '"varnish_id": "$http_x_varnish" } }';
 
     access_log  /var/log/nginx/access.log timed_combined;


### PR DESCRIPTION
This HTTP header is useful for request tracing as it allows identifying
what requests have been caused by dependency resolution, and the value
is the content id of the item on which dependency resolution took place.