### PR TITLE
Specify the user the cronjobs run as.

### DIFF
--- a/modules/mongodb/manifests/backup.pp
+++ b/modules/mongodb/manifests/backup.pp
@@ -103,7 +103,7 @@ class mongodb::backup(
 
       cron { $jobs :
         ensure => absent,
-        user   => $::backup::client::user,
+        user   => 'govuk-backup',
       }
   }
 


### PR DESCRIPTION
The `$::backup::client::user` variable doesn't exist and we use `govuk-backup`
everywhere so we'll use the literal value here.