### PR TITLE
Add check for www.gov.uk DNS record

### DIFF
--- a/modules/monitoring/files/etc/nagios3/conf.d/check_dig_google.cfg
+++ b/modules/monitoring/files/etc/nagios3/conf.d/check_dig_google.cfg
@@ -1,0 +1,4 @@
+define command {
+  command_name check_dig_google
+  command_line /usr/lib/nagios/plugins/check_dig -H 8.8.8.8 -l '$ARG1$' $ARG2$
+}

--- a/modules/monitoring/manifests/checks.pp
+++ b/modules/monitoring/manifests/checks.pp
@@ -90,6 +90,19 @@ class monitoring::checks (
   }
   # END ssl certificate checks
 
+  # START DNS checks
+  icinga::check_config { 'check_dig_google':
+    source  => 'puppet:///modules/monitoring/etc/nagios3/conf.d/check_dig_google.cfg',
+  }
+
+  icinga::check { 'check_www_gov_uk_dns':
+    check_command       => 'check_dig_google!www.gov.uk!-a www-cdn.production.govuk.service.gov.uk --timeout 10 -w 2 -c 3 -T CNAME',
+    host_name           => $::fqdn,
+    service_description => 'check www.gov.uk DNS record',
+    require             => Icinga::Check_config['check_dig_google'],
+  }
+  # END DNS checks
+
   # START signon
   icinga::check::graphite { 'check_signon_queue_sizes':
     # Check signon background worker average queue sizes over a 5 min period


### PR DESCRIPTION
Add new Icinga check for www.gov.uk DNS record on monitoring servers