### PR TITLE
Jenkins redis 

### DIFF
--- a/modules/govuk/manifests/node/s_ci_agent.pp
+++ b/modules/govuk/manifests/node/s_ci_agent.pp
@@ -4,4 +4,6 @@
 #
 class govuk::node::s_ci_agent inherits govuk::node::s_base {
 
+  include ::govuk_ci::agent
+
 }

--- a/modules/govuk_ci/manifests/agent.pp
+++ b/modules/govuk_ci/manifests/agent.pp
@@ -1,0 +1,9 @@
+# == Class: govuk_ci::agent
+#
+# Class to manage continuous deployment agents
+#
+class govuk_ci::agent {
+
+  include ::govuk_ci::agent::redis
+
+}

--- a/modules/govuk_ci/manifests/agent/redis.pp
+++ b/modules/govuk_ci/manifests/agent/redis.pp
@@ -1,0 +1,18 @@
+# == Class: govuk_ci::agent::redis
+#
+# Installs and configures redis-server
+#
+# === Parameters
+#
+# [*conf_maxmemory*]
+#   Sets the config option "maxmemory" for redis
+#
+class govuk_ci::agent::redis(
+  $conf_maxmemory = '256mb',
+) {
+
+  class {'::redis':
+    conf_maxmemory => $conf_maxmemory,
+  }
+
+}

--- a/modules/govuk_ci/manifests/init.pp
+++ b/modules/govuk_ci/manifests/init.pp
@@ -1,6 +1,7 @@
 # == Class: govuk_ci
 #
 # Class to manage continuous deployment services
+#
 class govuk_ci {
 
 }


### PR DESCRIPTION
The new ci agents, that are intended to replace ci.dev, require redis. This code uses the redis already existing in the govuk repo rather than bringing the version from ci-puppet over