### PR TITLE
Rabbitmq for new ci agents

### DIFF
--- a/modules/govuk_ci/manifests/agent.pp
+++ b/modules/govuk_ci/manifests/agent.pp
@@ -5,5 +5,6 @@
 class govuk_ci::agent {
 
   include ::govuk_ci::agent::redis
+  include ::govuk_ci::agent::rabbitmq
 
 }

--- a/modules/govuk_ci/manifests/agent/rabbitmq.pp
+++ b/modules/govuk_ci/manifests/agent/rabbitmq.pp
@@ -1,0 +1,7 @@
+# == Class: govuk_ci::agent::rabbitmq
+#
+# Installs and configures rabbitmq-server
+#
+class govuk_ci::agent::rabbitmq {
+  include ::govuk_rabbitmq
+}


### PR DESCRIPTION
The new ci agents require rabbitmq.
This includes the base rabbitmq class which offers the same config as found in [ci-puppet](https://github.com/alphagov/ci-puppet/tree/master/modules/gds_rabbitmq/manifests).
The base class also sets up monitoring and logging.  We have decided to fix as we go, should the firewall or any other config cause issues with builds.