### PR TITLE
Run relevant smokey tests in integration

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -134,6 +134,8 @@ govuk_jenkins::job_builder::environment: 'integration'
 
 govuk_jenkins::job::deploy_puppet::commitish: 'integration'
 
+govuk_jenkins::job::smokey::smokey_task: 'test:integration'
+
 govuk_jenkins::job::network_config_deploy::environments:
   - 'carrenza-integration'
   - 'carrenza-integration-dr'

--- a/modules/govuk_jenkins/manifests/job/smokey.pp
+++ b/modules/govuk_jenkins/manifests/job/smokey.pp
@@ -28,6 +28,9 @@
 # [*smokey_rate_limit_token*]
 #   Token to pass as an HTTP header to bypass rate limiting
 #
+# [*smokey_task*]
+#   The rake task to run for the tests
+#
 class govuk_jenkins::job::smokey (
   $auth_username = undef,
   $auth_password = undef,
@@ -37,6 +40,7 @@ class govuk_jenkins::job::smokey (
   $signon_password = undef,
   $smokey_bearer_token = undef,
   $smokey_rate_limit_token = undef,
+  $smokey_task = 'test:production',
 ) {
   file { '/etc/jenkins_jobs/jobs/smokey.yaml':
     ensure  => present,

--- a/modules/govuk_jenkins/templates/jobs/smokey.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/smokey.yaml.erb
@@ -27,6 +27,7 @@
             export SIGNON_PASSWORD='<%= @signon_password %>'
             export BEARER_TOKEN=<%= @smokey_bearer_token %>
             export RATE_LIMIT_TOKEN=<%= @smokey_rate_limit_token %>
+            export MYTASK=<%= @smokey_task %>
             set -x
             ./jenkins.sh
     wrappers:


### PR DESCRIPTION
Smokey was configured long ago to exclude tests tagged with `@notintegration` when you run `rake test:integration`.

But currently we still run `rake test:production` on integration CI, which has a bunch of test failures
(https://deploy.integration.publishing.service.gov.uk/job/Smokey/11051).

This commit makes sure we actually run the subset of tests on integration. This will get us closer to getting smokey green there, which would be useful for development.