### PR TITLE
Remove old cron file for postgresql backup

### DIFF
--- a/modules/govuk_postgresql/manifests/backup.pp
+++ b/modules/govuk_postgresql/manifests/backup.pp
@@ -27,6 +27,11 @@ class govuk_postgresql::backup (
     $threshold_secs = 28 * 3600
     $service_desc = 'AutoPostgreSQL backup'
 
+    #FIXME Remove once this has been deployed.
+    file {'/etc/cron.daily/autopostgresqlbackup':
+        ensure => absent,
+    }
+
     file {'/usr/local/bin/autopostgresqlbackup':
         mode    => '0755',
         content => template('govuk_postgresql/usr/local/bin/autopostgresqlbackup.erb'),


### PR DESCRIPTION
The location of the cron file was changed in commit
5c022b12162c63cec6c549286c3b54287c863c14, but the original file was not removed.

This meant that the postgresql backup is running twice every morning and causing
the machine to constantly run out of disk space.