### PR TITLE
Fix the dependency resolution header name

### DIFF
--- a/modules/nginx/templates/etc/nginx/nginx.conf.erb
+++ b/modules/nginx/templates/etc/nginx/nginx.conf.erb
@@ -54,7 +54,7 @@ http {
                          '"http_user_agent": "$http_user_agent", '
                          '"govuk_request_id": "$http_govuk_request_id", '
                          '"govuk_original_url": "$http_govuk_original_url", '
-                         '"govuk_publishing_api_dependency_resolution_source_content_id": "$http_govuk_publishing_api_dependency_resolution_source_content_id", '
+                         '"govuk_dependency_resolution_source_content_id": "$http_govuk_dependency_resolution_source_content_id", '
                          '"varnish_id": "$http_x_varnish" } }';
 
     access_log  /var/log/nginx/access.log timed_combined;


### PR DESCRIPTION
Turns out I wrote the previous patch from memory, and got the header
name wrong. This time I have double checked.