### PR TITLE
Remove contacts-frontend-old

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -879,7 +879,6 @@ hosts::production::frontend::app_hostnames:
   - 'canary-frontend'
   - 'collections'
   - 'contacts-frontend'
-  - 'contacts-frontend-old'
   - 'designprinciples'
   - 'draft-collections'
   - 'draft-contacts-frontend'
@@ -1178,7 +1177,6 @@ router::assets_origin::asset_routes:
   '/calculators/': "calculators"
   '/calendars/': "calendars"
   '/collections/': "collections"
-  '/contacts-assets/': "contacts-frontend-old"
   '/contacts-frontend/': "contacts-frontend"
   '/designprinciples/': "designprinciples"
   '/email-alert-frontend/': "email-alert-frontend"

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -107,7 +107,7 @@ govuk::apps::authenticating_proxy::mongodb_nodes: ['localhost']
 govuk::apps::authenticating_proxy::govuk_upstream_uri: 'http://government-frontend.dev.gov.uk'
 govuk::apps::backdrop_write::enable_procfile_worker: false
 govuk::apps::collections_publisher::enable_procfile_worker: false
-govuk::apps::contacts::extra_aliases: ['contacts-frontend-old', 'contacts-admin']
+govuk::apps::contacts::extra_aliases: ['contacts-admin']
 govuk::apps::content_store::mongodb_nodes: ['localhost']
 govuk::apps::content_store::mongodb_name: 'content_store_development'
 govuk::apps::content_tagger::enable_procfile_worker: false
@@ -240,7 +240,6 @@ hosts::development::apps:
   - 'collections-publisher'
   - 'contacts-admin'
   - 'contacts-frontend'
-  - 'contacts-frontend-old'
   - 'contentapi'
   - 'content-store'
   - 'content-tagger'

--- a/modules/govuk/manifests/apps/contacts.pp
+++ b/modules/govuk/manifests/apps/contacts.pp
@@ -23,7 +23,7 @@
 #
 # [*vhost*]
 #   Virtual host for this application.
-#   Default: contacts-frontend-old
+#   Default: contacts-admin
 #
 # [*oauth_id*]
 #   Sets the OAuth ID for using GDS-SSO
@@ -83,7 +83,7 @@ class govuk::apps::contacts(
   $oauth_id = undef,
   $oauth_secret = undef,
   $secret_key_base = undef,
-  $vhost = 'contacts-frontend-old',
+  $vhost = 'contacts-admin',
   $port = '3051',
   $vhost_protected = undef,
   $extra_aliases = [],

--- a/modules/govuk/manifests/node/s_frontend_lb.pp
+++ b/modules/govuk/manifests/node/s_frontend_lb.pp
@@ -33,7 +33,6 @@ class govuk::node::s_frontend_lb (
       'canary-frontend',
       'collections',
       'contacts-frontend',
-      'contacts-frontend-old',
       'designprinciples',
       'email-alert-frontend',
       'feedback',


### PR DESCRIPTION
This commit removes the contacts-frontend-old app since the page it renders has been moved to finder-frontend by https://github.com/alphagov/contacts-admin/pull/249. This app is actually part of the larger contacts-admin app which remains as the admin interface.

Trello: https://trello.com/c/wD10DEXt/260-migrate-the-hmrc-contacts-page-to-a-finder