### PR TITLE
Allow `draft-whitehall-frontend.$app_domain` to serve whitehall assets

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -833,6 +833,7 @@ hosts::production::backend::app_hostnames:
   - 'contacts-admin'
   - 'contentapi'
   - 'content-tagger'
+  - 'draft-whitehall-frontend'
   - 'email-alert-api'
   - 'errbit'
   - 'event-store'

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -243,6 +243,7 @@ hosts::development::apps:
   - 'content-tagger'
   - 'designprinciples'
   - 'draft-content-store'
+  - 'draft-whitehall-frontend'
   - 'efg'
   - 'efg_rebuild'
   - 'efg_training'

--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -177,6 +177,10 @@ class govuk::apps::whitehall(
     ',
     }
 
+    nginx::config::vhost::static { "draft-whitehall-frontend.${app_domain}":
+      locations => {'/government/uploads' => '/data/uploads/whitehall/clean'},
+    }
+
     govuk_logging::logstream { 'whitehall_scheduled_publishing_json_log':
       logfile => '/var/apps/whitehall/log/production_scheduled_publishing.json.log',
       fields  => {'application' => 'whitehall'},

--- a/modules/govuk/manifests/node/s_backend_lb.pp
+++ b/modules/govuk/manifests/node/s_backend_lb.pp
@@ -81,7 +81,10 @@ class govuk::node::s_backend_lb (
       https_redirect => false, # FIXME: Remove for #51136581
       internal_only  => true,
       servers        => $backend_servers;
-    'whitehall-admin':
+    [
+      'whitehall-admin',
+      'draft-whitehall-frontend',
+    ]:
       deny_crawlers => true,
       servers       => $whitehall_backend_servers;
   }

--- a/modules/nginx/manifests/config/vhost/static.pp
+++ b/modules/nginx/manifests/config/vhost/static.pp
@@ -1,0 +1,82 @@
+# == Define: nginx::config::vhost::static
+#
+# Simple Nginx vhost which serves static content from disk
+#
+# === Parameters
+#
+# [*aliases*]
+#   Other hostnames to serve the app on
+#
+# [*locations*]
+#   A Hash mapping http paths to filesystem paths
+#   eg. {'/foo' => '/data/uploads/foo'}
+#
+# [*extra_config*]
+#   A string containing additional nginx config
+#
+# [*deny_framing*]
+#   Boolean, whether nginx should instruct browsers to not allow framing the page
+#
+# [*logstream*]
+#   Whether nginx logs should be shipped to the logging box
+#
+# [*is_default_vhost*]
+#   Boolean, whether to set `default_server` in nginx
+#
+# [*ssl_certtype*]
+#   Type of certificate from the predefined list in `nginx::config::ssl`.
+#   Default: 'wildcard_publishing'
+#
+# [*ensure*]
+#   Whether to create the nginx vhost, present/absent
+#
+define nginx::config::vhost::static(
+  $aliases = [],
+  $locations = {},
+  $extra_config = '',
+  $deny_framing = false,
+  $logstream = present,
+  $is_default_vhost = false,
+  $ssl_certtype = 'wildcard_publishing',
+  $ensure = 'present',
+) {
+  validate_re($ensure, '^(absent|present)$', 'Invalid ensure value')
+
+  $static_vhost_template = 'nginx/static-vhost.conf'
+  $logpath = '/var/log/nginx'
+  $access_log = "${name}-access.log"
+  $json_access_log = "${name}-json.event.access.log"
+  $error_log = "${name}-error.log"
+  $title_escaped = regsubst($title, '\.', '_', 'G')
+
+  # Whether to enable SSL. Used by template.
+  $enable_ssl = hiera('nginx_enable_ssl', true)
+
+  nginx::config::ssl { $name:
+    certtype => $ssl_certtype,
+  }
+  nginx::config::site { $name:
+    ensure  => $ensure,
+    content => template($static_vhost_template),
+  }
+
+  $counter_basename = "${::fqdn_metrics}.nginx_logs.${title_escaped}"
+
+  $logstream_ensure = $ensure ? {
+    'present' => $logstream,
+    default   => $ensure,
+  }
+
+  nginx::log {
+    $json_access_log:
+      json          => true,
+      logpath       => $logpath,
+      logstream     => $logstream_ensure,
+      statsd_metric => "${counter_basename}.http_%{@fields.status}",
+      statsd_timers => [{metric => "${counter_basename}.time_request",
+                          value => '@fields.request_time'}];
+    $error_log:
+      logpath   => $logpath,
+      logstream => $logstream_ensure;
+  }
+}

--- a/modules/nginx/templates/static-vhost.conf
+++ b/modules/nginx/templates/static-vhost.conf
@@ -1,0 +1,51 @@
+<% if @enable_ssl -%>
+server {
+  server_name <%= @name %> <%= @aliases.join(" ") unless @aliases.empty? %>;
+  listen 80<%= $is_default_vhost ? " default_server" : "" %>;
+  rewrite ^/(.*) https://$host/$1 permanent;
+}
+<% end -%>
+
+<%
+  # @enable_ssl is used (for now) in the development environment to forcibly
+  # disable SSL for these vhosts. TODO: roll out the *.dev.alphagov.co.uk SSL
+  # certificate and get development behaving like everything else...
+
+  ports = if !@enable_ssl
+            [80]
+          else
+            [443]
+          end
+%>
+
+<%- ports.each do |port| -%>
+server {
+  server_name <%= @name %> <%= @aliases.join(" ") unless @aliases.empty? %>;
+
+  <%- if port == 443 -%>
+  listen              443 ssl<%= $is_default_vhost ? " default_server" : "" %>;
+  ssl_certificate     /etc/nginx/ssl/<%= @name %>.crt;
+  ssl_certificate_key /etc/nginx/ssl/<%= @name %>.key;
+  include             /etc/nginx/ssl.conf;
+  <%- end -%>
+  <%- if port == 80 -%>
+  listen 80<%= $is_default_vhost ? " default_server" : "" %>;
+  <%- end -%>
+
+  access_log <%= @logpath %>/<%= @access_log %> timed_combined;
+  access_log <%= @logpath %>/<%= @json_access_log %> json_event;
+  error_log <%= @logpath %>/<%= @error_log %>;
+
+  <%- if @deny_framing -%>
+  add_header X-Frame-Options DENY;
+  <%- end -%>
+
+  <%- @locations.each do |http_path, filesystem_path| -%>
+  location <%= http_path%> {
+    alias <%= filesystem_path%>;
+  }
+  <%- end -%>
+
+  <%= @extra_config %>
+}
+<% end -%>


### PR DESCRIPTION
In production, the GOV.UK router expects anything under /government to
be served by `whitehall-frontend` unless a more specific route exists.
This includes assets such as uploaded PDFs. This is fine in the live
stack for immigrated content as the Whitehall Rails app will serve the
asset through nginx once it’s performed its own authorisation checks.

For migrated content such as detailed guides, content is previewed
using the draft stack. In this case, the router sends all requests for
/government to `draft-whitehall-frontend`. Before this change, this
would be an invalid vhost in production. This change will create the
vhost and simply serve the files from disk. We make a whitehall-backend
machine serve it as it has access to the NFS mount already. This is a
temporary solution until Whitehall’s asset management system is rebuilt
or ported to use asset-manager.

We don’t need to provide any additional authorisation checking for
these requests as `draft-origin` (the user’s only path to this
endpoint) is protected by `authenticating-proxy`.

/cc @alexmuller 

Todo: 
- [x] Test in integration before merging