### PR TITLE
Xtrabackup Script shell-init error 

### DIFF
--- a/modules/govuk_mysql/templates/usr/local/bin/xtrabackup_s3_restore.erb
+++ b/modules/govuk_mysql/templates/usr/local/bin/xtrabackup_s3_restore.erb
@@ -70,7 +70,7 @@ INCR_DIR=$CURRENT_RESTORE/incremental
 
   # Clean up
   echo "Cleaning up"
-  /bin/rm -rf $TEMP_DIR $BASE_DIR $INCR_DIR
+  cd $CURRENT_RESTORE && /bin/rm -rf $TEMP_DIR $BASE_DIR $INCR_DIR
 
   # Re-enable Puppet and run it to ensure passwords are updated
   /usr/local/bin/govuk_puppet -n mysql_restore --enable && /usr/local/bin/govuk_puppet


### PR DESCRIPTION
Bash will complain if the current working directory no longer exists.
```
xtrabackup_s3_restore: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
xtrabackup_s3_restore: sh: 0: getcwd() failed: No such file or directory
```
We change to a directory that persists.