### PR TITLE
Remove Jenkins aptly mirror

### DIFF
--- a/modules/govuk/manifests/node/s_apt.pp
+++ b/modules/govuk/manifests/node/s_apt.pp
@@ -85,10 +85,6 @@ class govuk::node::s_apt (
       location => 'https://repo.mongodb.org/apt/ubuntu',
       release  => 'trusty/mongodb-org/3.2',
       key      => 'EA312927';
-    'jenkins':
-      location => 'http://pkg.jenkins-ci.org/debian-stable',
-      release  => 'binary/', # Trailing slash is significant.
-      key      => 'D50582E6';
     'percona':
       location => 'http://repo.percona.com/apt',
       release  => 'trusty',

--- a/modules/govuk_jenkins/manifests/init.pp
+++ b/modules/govuk_jenkins/manifests/init.pp
@@ -97,8 +97,8 @@ class govuk_jenkins (
     require => User['jenkins'],
   }
 
-  apt::source { 'jenkins':
-    location     => "http://${apt_mirror_hostname}/jenkins",
+  apt::source { 'govuk-jenkins':
+    location     => "http://${apt_mirror_hostname}/govuk-jenkins",
     release      => 'binary',
     architecture => $::architecture,
     key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',


### PR DESCRIPTION
Another winning example of why detailed commit messages are a good thing.

This was made redundant in 82e14c3bdee127c5c2e97049e08e2f76e5437624, so it should be removed.