### PR TITLE
Ci api_user

### DIFF
--- a/modules/govuk_jenkins/manifests/api_user.pp
+++ b/modules/govuk_jenkins/manifests/api_user.pp
@@ -1,0 +1,51 @@
+# == Define: govuk_jenkins::api_user
+#
+# Create an account within Jenkins that will subsequently be used for API
+# access. No API token will be set as it needs to be hashed against a seed
+# that it specific to that installation of Jenkins. You will need to
+# subsequently generate a token through the Jenkins UI. The contents of the
+# user config file will not be managed after initial creation to prevent
+# conflicts with the Jenkins UI.
+#
+# The name of the instance ($title) is used as the account name.
+#
+# === Parameters
+#
+# [*ensure*]
+#   Standard ensure param. Can be used to remove an existing user.
+#   Default: present
+#
+# [*users_dir*]
+#   Directory that Jenkins keeps it's user configs. The default should be
+#   fine for installations from the official packages.
+#   Default: /var/lib/jenkins/users
+#
+define govuk_jenkins::api_user(
+  $ensure = present,
+  $users_dir = '/var/lib/jenkins/users',
+) {
+  require ::govuk_jenkins
+
+  $ensure_directory = $ensure ? {
+    /^present$/ => directory,
+    default     => absent,
+  }
+
+  File {
+    owner  => 'jenkins',
+    mode   => '0640',
+  }
+
+  file { "${users_dir}/${title}":
+    ensure  => $ensure_directory,
+    recurse => true,
+    purge   => true,
+    force   => true,
+  }
+
+  file { "${users_dir}/${title}/config.xml":
+    ensure  => $ensure,
+    content => template('govuk_jenkins/api_user.xml.erb'),
+    replace => false,
+  }
+}

--- a/modules/govuk_jenkins/manifests/init.pp
+++ b/modules/govuk_jenkins/manifests/init.pp
@@ -111,6 +111,7 @@ class govuk_jenkins (
     configure_firewall => false,
     config_hash        => $config,
     manage_user        => false,
+    manage_group       => false,
     plugin_hash        => $plugins,
     require            => Class['govuk_java::set_defaults'],
   }

--- a/modules/govuk_jenkins/templates/api_user.xml.erb
+++ b/modules/govuk_jenkins/templates/api_user.xml.erb
@@ -1,0 +1,30 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<user>
+  <fullName>api_user: <%= @title -%></fullName>
+  <description>This local user has been created, but not subsequently managed, by Puppet.&#xd;
+Before first use you will need to generate an API token below.&#xd;
+That API token should then be distributed to any clients.</description>
+  <properties>
+    <jenkins.security.ApiTokenProperty>
+      <apiToken>REGENERATE_THIS_USING_THE_JENKINS_UI</apiToken>
+    </jenkins.security.ApiTokenProperty>
+    <com.cloudbees.plugins.credentials.UserCredentialsProvider_-UserCredentialsProperty plugin="credentials@1.3.1">
+      <credentials/>
+    </com.cloudbees.plugins.credentials.UserCredentialsProvider_-UserCredentialsProperty>
+    <hudson.model.MyViewsProperty>
+      <views>
+        <hudson.model.AllView>
+          <owner class="hudson.model.MyViewsProperty" reference="../../.."/>
+          <name>All</name>
+          <filterExecutors>false</filterExecutors>
+          <filterQueue>false</filterQueue>
+          <properties class="hudson.model.View$PropertyList"/>
+        </hudson.model.AllView>
+      </views>
+    </hudson.model.MyViewsProperty>
+    <hudson.search.UserSearchProperty>
+      <insensitiveSearch>false</insensitiveSearch>
+    </hudson.search.UserSearchProperty>
+    <hudson.tasks.Mailer_-UserProperty plugin="mailer@1.4"/>
+  </properties>
+</user>


### PR DESCRIPTION
The Puppet defined type that provisions users for the purpose of making api calls.

Requires updated Jenkins Puppet module. 
relates to: https://github.com/alphagov/govuk-puppet/pull/5024