### PR TITLE
Enable api-elasticsearch to S3 in production

### DIFF
--- a/hieradata/node/api-elasticsearch-1.api.publishing.service.gov.uk.yaml
+++ b/hieradata/node/api-elasticsearch-1.api.publishing.service.gov.uk.yaml
@@ -1,0 +1,4 @@
+---
+govuk_elasticsearch::backup_enabled: true
+govuk_elasticsearch::backup::s3_bucket: 'govuk-api-elasticsearch-production'
+govuk_elasticsearch::backup::es_repo: 'snapshots'


### PR DESCRIPTION
The credentials for this bucket are already in the deployment repo but the backup hasn't been enabled yet.