### PR TITLE
Jenkins firewall rules for CI Master

### DIFF
--- a/modules/govuk_ci/manifests/master.pp
+++ b/modules/govuk_ci/manifests/master.pp
@@ -7,4 +7,16 @@ class govuk_ci::master {
   include ::govuk_ci::credentials
   include ::govuk_jenkins
 
+  ufw::allow {'jenkins-slave-to-jenkins-master-on-tcp':
+    port  => '32768:65535',
+    proto => 'tcp',
+    ip    => 'any',
+  }
+
+  ufw::allow {'jenkins-slave-to-jenkins-master-on-udp':
+    port  => '33848',
+    proto => 'udp',
+    ip    => 'any',
+  }
+
 }


### PR DESCRIPTION
Allows network access for specified services on the jenkins master.