### PR TITLE
Jenkins CI Plugins

### DIFF
--- a/hieradata/class/ci_master.yaml
+++ b/hieradata/class/ci_master.yaml
@@ -1,0 +1,81 @@
+---
+
+govuk_jenkins::plugins:
+    greenballs:
+        version: "1.15"
+    monitoring:
+        version: "1.62.0"
+    swarm:
+        version: "2.2"
+    role-strategy:
+        version: "2.3.2"
+    github-api:
+        version: "1.79"
+    scm-sync-configuration:
+        version: "0.0.10"
+    git:
+        version: "3.0.0"
+    git-client:
+        version: "2.1.0"
+    ssh-credentials:
+        version: "1.12"
+    findbugs:
+        version: "4.65"
+    gradle:
+        version: "1.25"
+    copyartifact:
+        version: "1.38.1"
+    envinject:
+        version: "1.93.1"
+    brakeman:
+        version: "0.8"
+    build-name-setter:
+        version: "1.6.5"
+    cobertura:
+        version: "1.9.8"
+    conditional-buildstep:
+        version: "1.3.5"
+    jenkinswalldisplay:
+        version: "0.6.33"
+    parameterized-trigger:
+        version: "2.32"
+    run-condition:
+        version: "1.0"
+    sitemonitor:
+        version: "0.5"
+    analysis-core:
+        version: "1.79"
+    versionnumber:
+        version: "1.8.1"
+    warnings:
+        version: "4.6"
+    ws-cleanup:
+        version: "0.32"
+    ruby:
+        version: "1.2"
+    rake:
+        version: "1.8.0"
+    text-finder:
+        version: "1.10"
+    throttle-concurrents:
+        version: "1.9.0"
+    violations:
+        version: "0.7.11"
+    mailer:
+        version: "1.8"
+    rubyMetrics:
+        version: "1.6.4"
+    description-setter:
+        version: "1.10"
+    github:
+        version: "1.22.4"
+    ansicolor:
+        version: "0.4.2"
+    build-pipeline-plugin:
+        version: "1.5.4"
+    github-oauth:
+        version: "0.24"
+    rebuild:
+        version: "1.25"
+    slack:
+        version: "2.0.1"

--- a/modules/govuk_ci/manifests/master.pp
+++ b/modules/govuk_ci/manifests/master.pp
@@ -5,4 +5,3 @@
 class govuk_ci::master {
 
 }
-


### PR DESCRIPTION
The plugins being used in our current CI environment.
Plugins extend the features of Jenkins.  They're primarily used for job support.