### PR TITLE
Refactor govuk jenkins class

### DIFF
--- a/hieradata/class/ci_master.yaml
+++ b/hieradata/class/ci_master.yaml
@@ -1,5 +1,5 @@
 ---
-govuk_jenkins::package::version: '2.19.2'
+govuk_jenkins::version: '2.19.2'
 
 govuk_jenkins::plugins:
     greenballs:

--- a/hieradata/class/ci_master.yaml
+++ b/hieradata/class/ci_master.yaml
@@ -1,4 +1,5 @@
 ---
+govuk_jenkins::package::version: '2.19.2'
 
 govuk_jenkins::plugins:
     greenballs:

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -526,7 +526,7 @@ govuk_crawler::site_root: 'https://www.gov.uk'
 
 govuk_elasticsearch::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
-govuk_jenkins::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_jenkins::package::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk_jenkins::github_enterprise_cert: |
     -----BEGIN CERTIFICATE-----
     MIIEdDCCA1ygAwIBAgIJAKt4YiHj0+tVMA0GCSqGSIb3DQEBBQUAMIGCMQswCQYD
@@ -554,8 +554,7 @@ govuk_jenkins::github_enterprise_cert: |
     LG8Mr4r1mOsqtUPYYjCN77EOwkRUucvIt1zNPoiD21OXzzxdOIUOUq6l/kERSfba
     LWIWJn/KXkog8bU776IixxWlO8l1TwiCUoDS9YsLIKIRCT74QE48qA==
     -----END CERTIFICATE-----
-govuk_jenkins::jenkins_home: "/var/lib/jenkins"
-govuk_jenkins::github_enterprise_cert_path: "%{hiera('govuk_jenkins::jenkins_home')}/github.gds.pem"
+govuk_jenkins::github_enterprise_cert_path: "/var/lib/jenkins/github.gds.pem"
 govuk_jenkins::github_enterprise_hostname: "github.gds"
 govuk_jenkins::config::github_api_uri: "%{hiera('govuk_jenkins::config::github_web_uri')}/api/v3"
 govuk_jenkins::config::github_web_uri: "https://%{hiera('govuk_jenkins::github_enterprise_hostname')}"

--- a/modules/govuk_ci/manifests/master.pp
+++ b/modules/govuk_ci/manifests/master.pp
@@ -5,5 +5,6 @@
 class govuk_ci::master {
 
   include ::govuk_ci::credentials
+  include ::govuk_jenkins
 
 }

--- a/modules/govuk_jenkins/manifests/config.pp
+++ b/modules/govuk_jenkins/manifests/config.pp
@@ -51,6 +51,9 @@
 #   Option to manage the Jenkins config or not. This is set so we do not
 #   overwrite configuration in live environments.
 #
+# [*version*]
+#   Specify the version of Jenkins
+#
 class govuk_jenkins::config (
   $app_domain = hiera('app_domain'),
   $banner_colour_background = 'black',
@@ -66,6 +69,7 @@ class govuk_jenkins::config (
   $github_client_secret,
   $admins = [],
   $manage_config = false,
+  $version = $govuk_jenkins::version,
 ) {
 
   validate_array($admins)

--- a/modules/govuk_jenkins/manifests/init.pp
+++ b/modules/govuk_jenkins/manifests/init.pp
@@ -5,11 +5,11 @@
 #
 # === Parameters:
 #
-# [*apt_mirror_hostname*]
-#   Hostname to use for the APT mirror.
-#
 # [*github_enterprise_cert*]
 #   PEM certificate for GitHub Enterprise.
+#
+# [*github_enterprise_hostname*]
+#   The hostname of Github Enterprise
 #
 # [*config*]
 #   A hash of Jenkins config options to set
@@ -17,40 +17,35 @@
 # [*plugins*]
 #   A hash of Jenkins plugins that should be installed
 #
+# [*ssh_private_key*]
+#   The SSH private key of the Jenkins user
+#
+# [*ssh_public_key*]
+#   The SSH public key of the Jenkins user
+#
 class govuk_jenkins (
-  $apt_mirror_hostname,
   $github_enterprise_cert,
   $github_enterprise_hostname,
-  $jenkins_home,
   $github_enterprise_cert_path,
   $config = {},
   $plugins = {},
+  $ssh_private_key = undef,
+  $ssh_public_key = undef,
 ) {
   validate_hash($config, $plugins)
 
-  include govuk_python
-  include govuk_jenkins::job_builder
-  include govuk_jenkins::ssh_key
-  include govuk_jenkins::config
+  include ::govuk_python
+  include ::govuk_jenkins::config
+  include ::govuk_jenkins::job_builder
 
-  user { 'jenkins':
-    ensure     => present,
-    home       => $jenkins_home,
-    managehome => true,
-    shell      => '/bin/bash',
+  class { 'govuk_jenkins::user':
+    private_key => $ssh_private_key,
+    public_key  => $ssh_public_key,
   }
 
-  include govuk_java::openjdk7::jdk
-  include govuk_java::openjdk7::jre
-
-  class { 'govuk_java::set_defaults':
-    jdk     => 'openjdk7',
-    jre     => 'openjdk7',
-    require => [
-                  Class['govuk_java::openjdk7::jdk'],
-                  Class['govuk_java::openjdk7::jre'],
-                ],
-    notify  => Class['jenkins::service'],
+  class { 'govuk_jenkins::package':
+    config  => $config,
+    plugins => $plugins,
   }
 
   # In addition to the keystore below, this path is also referenced by the
@@ -88,38 +83,6 @@ class govuk_jenkins (
 
   # Runtime dependency of: https://github.com/alphagov/search-analytics
   include libffi
-
-  file { "${jenkins_home}/.gitconfig":
-    source  => 'puppet:///modules/govuk_jenkins/dot-gitconfig',
-    owner   => jenkins,
-    group   => jenkins,
-    mode    => '0644',
-    require => User['jenkins'],
-  }
-
-  apt::source { 'govuk-jenkins':
-    location     => "http://${apt_mirror_hostname}/govuk-jenkins",
-    release      => 'stable',
-    architecture => $::architecture,
-    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
-  }
-
-  class { 'jenkins':
-    version            => '1.554.2',
-    repo               => false,
-    install_java       => false,
-    configure_firewall => false,
-    config_hash        => $config,
-    manage_user        => false,
-    manage_group       => false,
-    plugin_hash        => $plugins,
-    require            => Class['govuk_java::set_defaults'],
-  }
-
-  file { '/etc/default/jenkins':
-    ensure => file,
-    notify => Class['jenkins::service'],
-  }
 
   include govuk_mysql::libdev
   include mysql::client

--- a/modules/govuk_jenkins/manifests/init.pp
+++ b/modules/govuk_jenkins/manifests/init.pp
@@ -23,6 +23,9 @@
 # [*ssh_public_key*]
 #   The SSH public key of the Jenkins user
 #
+# [*version*]
+#   Specify the version of Jenkins
+#
 class govuk_jenkins (
   $github_enterprise_cert,
   $github_enterprise_hostname,
@@ -31,6 +34,7 @@ class govuk_jenkins (
   $plugins = {},
   $ssh_private_key = undef,
   $ssh_public_key = undef,
+  $version = '1.554.2',
 ) {
   validate_hash($config, $plugins)
 

--- a/modules/govuk_jenkins/manifests/package.pp
+++ b/modules/govuk_jenkins/manifests/package.pp
@@ -57,8 +57,4 @@ class govuk_jenkins::package (
     require            => Class['govuk_java::set_defaults'],
   }
 
-  file { '/etc/default/jenkins':
-    ensure => file,
-    notify => Class['jenkins::service'],
-  }
 }

--- a/modules/govuk_jenkins/manifests/package.pp
+++ b/modules/govuk_jenkins/manifests/package.pp
@@ -19,7 +19,7 @@
 #
 class govuk_jenkins::package (
   $apt_mirror_hostname,
-  $version = '1.554.2',
+  $version = $govuk_jenkins::version,
   $config  = {},
   $plugins = {},
   ) {

--- a/modules/govuk_jenkins/manifests/package.pp
+++ b/modules/govuk_jenkins/manifests/package.pp
@@ -1,0 +1,64 @@
+# == Class: govuk_jenkins::package
+#
+# Install the Jenkins package and dependencies
+#
+# === Parameters:
+#
+# [*apt_mirror_hostname*]
+#   The hostname for the apt mirror to add to enable fetching specific
+#   packages
+#
+# [*version*]
+#   Specify the version of Jenkins you wish to install
+#
+# [*config*]
+#   A hash of configuration options
+#
+# [*plugins*]
+#   A hash of plugins to enable
+#
+class govuk_jenkins::package (
+  $apt_mirror_hostname,
+  $version = '1.554.2',
+  $config  = {},
+  $plugins = {},
+  ) {
+  validate_hash($config, $plugins)
+
+  include govuk_java::openjdk7::jdk
+  include govuk_java::openjdk7::jre
+
+  apt::source { 'govuk-jenkins':
+    location     => "http://${apt_mirror_hostname}/govuk-jenkins",
+    release      => 'stable',
+    architecture => $::architecture,
+    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+  }
+
+  class { 'govuk_java::set_defaults':
+    jdk     => 'openjdk7',
+    jre     => 'openjdk7',
+    require => [
+                  Class['govuk_java::openjdk7::jdk'],
+                  Class['govuk_java::openjdk7::jre'],
+                ],
+    notify  => Class['jenkins::service'],
+  }
+
+  class { 'jenkins':
+    version            => $version,
+    repo               => false,
+    install_java       => false,
+    configure_firewall => false,
+    config_hash        => $config,
+    manage_user        => false,
+    manage_group       => false,
+    plugin_hash        => $plugins,
+    require            => Class['govuk_java::set_defaults'],
+  }
+
+  file { '/etc/default/jenkins':
+    ensure => file,
+    notify => Class['jenkins::service'],
+  }
+}

--- a/modules/govuk_jenkins/manifests/ssh_key.pp
+++ b/modules/govuk_jenkins/manifests/ssh_key.pp
@@ -1,6 +1,6 @@
 # == Class: govuk_jenkins::ssh_key
 #
-# Sets up an SSH key pair for the jenkins user.
+# Sets up an SSH key pair for the specified user.
 #
 # === Parameters:
 #
@@ -10,11 +10,18 @@
 # [*public_key*]
 #   The public key that matches `$private_key`.
 #
+# [*jenkins_user*]
+#   Name of the Jenkins user
+#
+# [*home_dir*]
+#   Home directory of the Jenkins user
+#
 class govuk_jenkins::ssh_key (
-  $private_key = undef,
-  $public_key = undef,
+  $private_key  = undef,
+  $public_key   = undef,
+  $jenkins_user = 'jenkins',
+  $home_dir     = '/var/lib/jenkins',
 ) {
-  $home_dir = '/var/lib/jenkins'
   $ssh_dir = "${home_dir}/.ssh"
   $private_key_filename = "${ssh_dir}/id_rsa"
   $public_key_filename = "${ssh_dir}/id_rsa.pub"
@@ -22,35 +29,35 @@ class govuk_jenkins::ssh_key (
   file { $ssh_dir:
     ensure => directory,
     mode   => '0600',
-    owner  => 'jenkins',
-    group  => 'jenkins',
+    owner  => $jenkins_user,
+    group  => $jenkins_user,
   }
 
   if $private_key and $public_key {
     file { $public_key_filename:
       content => "ssh-rsa ${public_key}",
       mode    => '0644',
-      owner   => 'jenkins',
-      group   => 'jenkins',
-      require => User['jenkins'],
+      owner   => $jenkins_user,
+      group   => $jenkins_user,
+      require => User[$jenkins_user],
     }
 
     file { $private_key_filename:
       content => $private_key,
       mode    => '0600',
-      owner   => 'jenkins',
-      group   => 'jenkins',
+      owner   => $jenkins_user,
+      group   => $jenkins_user,
       require => User['jenkins'],
     }
   } else {
     exec { 'Creating key pair for jenkins':
-      command => "ssh-keygen -t rsa -C 'Provided by Puppet for jenkins' -N '' -f ${private_key_filename}",
+      command => "ssh-keygen -t rsa -C 'Provided by Puppet for ${jenkins_user}' -N '' -f ${private_key_filename}",
       creates => $private_key_filename,
       require => [
-        User['jenkins'],
+        User[$jenkins_user],
         File[$ssh_dir],
       ],
-      user    => 'jenkins',
+      user    => $jenkins_user,
     }
   }
 
@@ -61,8 +68,8 @@ class govuk_jenkins::ssh_key (
   file { "${home_dir}/.profile":
     ensure  => file,
     source  => 'puppet:///modules/govuk_jenkins/dot-profile',
-    owner   => jenkins,
-    group   => jenkins,
+    owner   => $jenkins_user,
+    group   => $jenkins_user,
     mode    => '0700',
     notify  => Class['jenkins::service'],
     require => Package['keychain'],

--- a/modules/govuk_jenkins/manifests/user.pp
+++ b/modules/govuk_jenkins/manifests/user.pp
@@ -1,0 +1,41 @@
+# == Class: govuk_jenkins::user
+#
+# Configure the Jenkins user and home directory
+#
+# === Parameters:
+#
+# [*home_directory*]
+#   The home directory of the user
+#
+# [*username*]
+#   The username you wish to use
+#
+class govuk_jenkins::user (
+  $home_directory = '/var/lib/jenkins',
+  $username       = 'jenkins',
+  $private_key    = undef,
+  $public_key     = undef,
+) {
+  user { $username:
+    ensure     => present,
+    home       => $home_directory,
+    managehome => true,
+    shell      => '/bin/bash',
+  }
+
+  class { 'govuk_jenkins::ssh_key':
+    private_key  => $private_key,
+    public_key   => $public_key,
+    jenkins_user => $username,
+    home_dir     => $home_directory,
+  }
+
+  file { "${home_directory}/.gitconfig":
+    source  => 'puppet:///modules/govuk_jenkins/dot-gitconfig',
+    owner   => $username,
+    group   => $username,
+    mode    => '0644',
+    require => User[$username],
+  }
+
+}

--- a/modules/govuk_jenkins/spec/classes/jenkins__config_spec.rb
+++ b/modules/govuk_jenkins/spec/classes/jenkins__config_spec.rb
@@ -2,13 +2,6 @@ require_relative '../../../../spec_helper'
 
 describe 'govuk_jenkins::config', :type => :class do
   describe 'manage config' do
-    let(:hiera_data) {{
-      'govuk_jenkins::config::github_api_uri' => 'foo',
-      'govuk_jenkins::config::github_client_id' => 'bar',
-      'govuk_jenkins::config::github_client_secret' => 'baz',
-      'govuk_jenkins::config::github_web_uri' => 'bobble',
-    }}
-
     context 'false (default)' do
       let (:params) {{
         :manage_config => false,
@@ -22,7 +15,7 @@ describe 'govuk_jenkins::config', :type => :class do
         :manage_config => true,
       }}
 
-      it { is_expected.to contain_file('/var/lib/jenkins/config.xml') }
+      it { is_expected.to contain_file('/var/lib/jenkins/config.xml').with_content(/<githubWebUri>wibble/) }
     end
   end
 end

--- a/modules/govuk_jenkins/spec/classes/jenkins__package_spec.rb
+++ b/modules/govuk_jenkins/spec/classes/jenkins__package_spec.rb
@@ -1,0 +1,14 @@
+require_relative '../../../../spec_helper'
+
+describe 'govuk_jenkins::package', :type => :class do
+  let(:params) {{
+    :apt_mirror_hostname => 'apt.example.com',
+    :version             => '1.554.2',
+  }}
+  it { is_expected.to contain_class('jenkins').with(
+    'version'            => '1.554.2',
+    'repo'               => 'false',
+    'install_java'       => 'false',
+    'configure_firewall' => 'false',
+  ) }
+end

--- a/modules/govuk_jenkins/spec/classes/jenkins__user_spec.rb
+++ b/modules/govuk_jenkins/spec/classes/jenkins__user_spec.rb
@@ -1,0 +1,12 @@
+require_relative '../../../../spec_helper'
+
+describe 'govuk_jenkins::user', :type => :class do
+
+  let(:params) {{
+    :home_directory => '/var/lib/jenkins',
+    :username => 'jenkins',
+  }}
+
+  it { is_expected.to contain_user('jenkins') }
+  it { is_expected.to contain_class('govuk_jenkins::ssh_key') }
+end

--- a/modules/govuk_jenkins/spec/classes/jenkins_spec.rb
+++ b/modules/govuk_jenkins/spec/classes/jenkins_spec.rb
@@ -4,16 +4,14 @@ describe 'govuk_jenkins', :type => :class do
   let(:ssh_dir) { '/var/lib/jenkins/.ssh' }
 
   let(:params) {{
-    :apt_mirror_hostname => 'apt.example.com',
     :github_enterprise_cert => 'certcertcert',
     :github_enterprise_cert_path => 'wobble',
     :github_enterprise_hostname => 'dibble',
-    :jenkins_home => 'bibble',
   }}
 
-  it { is_expected.to contain_class('govuk_jenkins::ssh_key') }
-  it { is_expected.to contain_class('govuk_jenkins::config') }
-  it { is_expected.to contain_file(ssh_dir).with_ensure('directory') }
+  it { is_expected.to contain_file('wobble').with_content(/certcertcert/) }
 
-  it { is_expected.to contain_user('jenkins').with_ensure('present') }
+  it { is_expected.to contain_class('govuk_jenkins::config') }
+  it { is_expected.to contain_class('govuk_jenkins::user') }
+  it { is_expected.to contain_class('govuk_jenkins::package') }
 end

--- a/modules/govuk_jenkins/templates/config/config.xml.erb
+++ b/modules/govuk_jenkins/templates/config/config.xml.erb
@@ -6,7 +6,7 @@
     <string>OldData</string>
     <string>jenkins.security.RekeySecretAdminMonitor</string>
   </disabledAdministrativeMonitors>
-  <version>1.554.2</version>
+  <version><%= @version %></version>
   <numExecutors>4</numExecutors>
   <mode>NORMAL</mode>
   <useSecurity>true</useSecurity>

--- a/spec/fixtures/hieradata/common.yaml
+++ b/spec/fixtures/hieradata/common.yaml
@@ -15,6 +15,8 @@ govuk_app_enable_services: false
 
 govuk_cdnlogs::monitoring_enabled: false
 
+govuk_jenkins::package::apt_mirror_hostname: 'apt.example.com'
+
 govuk_jenkins::config::github_api_uri: foo
 govuk_jenkins::config::github_client_id: bar
 govuk_jenkins::config::github_client_secret: baz


### PR DESCRIPTION
This refactors the govuk_jenkins class and breaks it out to make it more defined. It's main purpose is to be able to be able to set the Jenkins version easier for different machines.

It also makes it clear to be able to call that class with different config, plugins and SSH key pairs depending on what you need for a machine:

```
class { 'govuk_jenkins':
  private_key => 'foo',
  public_key  => 'bar',
  config      => $my_config,
  plugins     => $my_plugins,
}
```