### PR TITLE
Remove “contacts” as a frontend app

### DIFF
--- a/hieradata/class/frontend.yaml
+++ b/hieradata/class/frontend.yaml
@@ -2,7 +2,6 @@
 govuk::node::s_base::apps:
   - canary_frontend
   - collections
-  - contacts
   - contacts_frontend
   - designprinciples
   - email_alert_frontend


### PR DESCRIPTION
“contacts” (aka “contacts-admin”) is now purely a backend app (as of https://github.com/alphagov/contacts-admin/pull/250) and so it is removed here.

Trello: https://trello.com/c/wD10DEXt/260-migrate-the-hmrc-contacts-page-to-a-finder