### PR TITLE
CI agents require Oracle java 8

### DIFF
--- a/modules/govuk_ci/manifests/agent.pp
+++ b/modules/govuk_ci/manifests/agent.pp
@@ -10,5 +10,6 @@ class govuk_ci::agent {
   include ::govuk_ci::agent::mongodb
   include ::govuk_ci::agent::postgresql
   include ::govuk_ci::agent::mysql
+  include ::govuk_java::oracle8
 
 }


### PR DESCRIPTION
This is to run tests for licensing.