### PR TITLE
Add auth for Github OAuth plugin and VPN

### DIFF
--- a/hieradata/vagrant_credentials.yaml
+++ b/hieradata/vagrant_credentials.yaml
@@ -123,6 +123,11 @@ govuk_ci::credentials::pypi_username: 'pipyusername'
 govuk_ci::credentials::pypi_test_password: 'passwordtest'
 govuk_ci::credentials::pypi_live_password: 'passwordlive'
 
+govuk_ci::master::github_client_id: 'bellathecat'
+govuk_ci::master::github_client_secret: 'sheisfurry'
+govuk_ci::master::ghe_vpn_username: 'bella'
+govuk_ci::master::ghe_vpn_password: 'furrysocks'
+
 govuk::deploy::aws_ses_smtp_username: 'a_username'
 govuk::deploy::aws_ses_smtp_password: 'a_password'
 
@@ -163,8 +168,8 @@ govuk::node::s_transition_postgresql_master::wale_private_gpg_key_fingerprint: '
 govuk_jenkins::config::environment_variables:
   ORGANISATION: development
 
-govuk_jenkins::config::github_client_id: client_id
-govuk_jenkins::config::github_client_secret: client_secret
+govuk_jenkins::github_client_id: client_id
+govuk_jenkins::github_client_secret: client_secret
 govuk_jenkins::job_builder::jenkins_api_token: jenkins_api_token
 govuk_jenkins::job::deploy_app::auth_token: remote_deployment_token
 govuk_jenkins::job::deploy_puppet::auth_token: remote_deployment_token

--- a/modules/govuk/manifests/node/s_ci_master.pp
+++ b/modules/govuk/manifests/node/s_ci_master.pp
@@ -4,7 +4,6 @@
 #
 class govuk::node::s_ci_master inherits govuk::node::s_base {
   include ::nginx
-  include ::govuk_ghe_vpn
   include ::govuk_rbenv::all
   include ::govuk_ci::master
 

--- a/modules/govuk_ci/manifests/master.pp
+++ b/modules/govuk_ci/manifests/master.pp
@@ -2,9 +2,37 @@
 #
 # Class to manage continuous deployment master
 #
-class govuk_ci::master {
+# === Parameters:
+#
+# [*github_client_id*]
+#   The Github client ID is used as the user to authenticate against Github.
+#
+# [*github_client_secret*]
+#   The Github client secret is used to authenticate against Github.
+#
+# [*ghe_vpn_username*]
+#   The username used to connect to the Github Enterprise VPN
+#
+# [*ghe_vpn_password*]
+#   The password to authenticate against the Github Enterprise VPN
+#
+class govuk_ci::master (
+  $github_client_id,
+  $github_client_secret,
+  $ghe_vpn_username,
+  $ghe_vpn_password,
+){
 
   include ::govuk_ci::credentials
-  include ::govuk_jenkins
+
+  class { '::govuk_jenkins':
+    github_client_id     => $github_client_id,
+    github_client_secret => $github_client_secret,
+  }
+
+  class { 'govuk_ghe_vpn':
+    username => $ghe_vpn_username,
+    password => $ghe_vpn_password,
+  }
 
 }

--- a/modules/govuk_jenkins/manifests/init.pp
+++ b/modules/govuk_jenkins/manifests/init.pp
@@ -11,6 +11,12 @@
 # [*github_enterprise_hostname*]
 #   The hostname of Github Enterprise
 #
+# [*github_client_id*]
+#   The Github client ID is used as the user to authenticate against Github.
+#
+# [*github_client_secret*]
+#   The Github client secret is used to authenticate against Github.
+#
 # [*config*]
 #   A hash of Jenkins config options to set
 #
@@ -30,6 +36,8 @@ class govuk_jenkins (
   $github_enterprise_cert,
   $github_enterprise_hostname,
   $github_enterprise_cert_path,
+  $github_client_id,
+  $github_client_secret,
   $config = {},
   $plugins = {},
   $ssh_private_key = undef,
@@ -39,8 +47,12 @@ class govuk_jenkins (
   validate_hash($config, $plugins)
 
   include ::govuk_python
-  include ::govuk_jenkins::config
   include ::govuk_jenkins::job_builder
+
+  class { 'govuk_jenkins::config':
+    github_client_id     => $github_client_id,
+    github_client_secret => $github_client_secret,
+  }
 
   class { 'govuk_jenkins::user':
     private_key => $ssh_private_key,

--- a/modules/govuk_jenkins/spec/classes/jenkins__config_spec.rb
+++ b/modules/govuk_jenkins/spec/classes/jenkins__config_spec.rb
@@ -1,19 +1,24 @@
 require_relative '../../../../spec_helper'
 
 describe 'govuk_jenkins::config', :type => :class do
+  let(:default_params) {{
+    :github_client_id     => 'bar',
+    :github_client_secret => 'baz',
+  }}
+
   describe 'manage config' do
     context 'false (default)' do
-      let (:params) {{
+      let (:params) { default_params.merge({
         :manage_config => false,
-      }}
+      })}
 
       it { is_expected.not_to contain_file('/var/lib/jenkins/config.xml') }
     end
 
     context 'true' do
-      let (:params) {{
+      let (:params) { default_params.merge({
         :manage_config => true,
-      }}
+      })}
 
       it { is_expected.to contain_file('/var/lib/jenkins/config.xml').with_content(/<githubWebUri>wibble/) }
     end

--- a/spec/fixtures/hieradata/common.yaml
+++ b/spec/fixtures/hieradata/common.yaml
@@ -18,8 +18,8 @@ govuk_cdnlogs::monitoring_enabled: false
 govuk_jenkins::package::apt_mirror_hostname: 'apt.example.com'
 
 govuk_jenkins::config::github_api_uri: foo
-govuk_jenkins::config::github_client_id: bar
-govuk_jenkins::config::github_client_secret: baz
+govuk_jenkins::github_client_id: bar
+govuk_jenkins::github_client_secret: baz
 govuk_jenkins::config::github_web_uri: wibble
 
 govuk_postgresql::server::snakeoil_ssl_certificate: certificate


### PR DESCRIPTION
This explicitly calls the relevant classes to set the auth secrets required to first authenticate with the Github Enterprise VPN, then to authenticate with Github Enterprise itself.

We pass in parameters and call the classes themselves because when passing in secrets in encrypted hiera we can only specify per environment, and not by class or node specific hieradate. Adding parameters to this class allows us to set different credentials to the default Integration credentials.