### PR TITLE
Remove “enable_admin_routes” for contacts

### DIFF
--- a/hieradata/class/backend.yaml
+++ b/hieradata/class/backend.yaml
@@ -1,7 +1,6 @@
 ---
 
 govuk::apps::contacts::vhost: contacts-admin
-govuk::apps::contacts::enable_admin_routes: 'enabled'
 govuk::apps::contacts::db_hostname: 'mysql-master-1.backend'
 govuk::apps::contacts::db_username: 'contacts'
 govuk::apps::contacts::db_password: "%{hiera('govuk::apps::contacts::db::mysql_contacts_admin')}"

--- a/modules/govuk/manifests/apps/contacts.pp
+++ b/modules/govuk/manifests/apps/contacts.pp
@@ -8,9 +8,6 @@
 #   Whether the app is enabled.
 #   Default: true
 #
-# [*enable_admin_routes]
-#   Enables /admin route for the app running on backend servers only
-#
 # [*errbit_api_key*]
 #   Errbit API key used by airbrake
 #   Default: undef
@@ -78,7 +75,6 @@ class govuk::apps::contacts(
   $db_username = undef,
   $db_password = undef,
   $enabled = true,
-  $enable_admin_routes = undef,
   $errbit_api_key = undef,
   $oauth_id = undef,
   $oauth_secret = undef,
@@ -125,9 +121,6 @@ class govuk::apps::contacts(
     }
 
     govuk::app::envvar {
-      "${title}-ENABLE_ADMIN_ROUTES":
-      varname => 'ENABLE_ADMIN_ROUTES',
-      value   => $enable_admin_routes;
       "${title}-ERRBIT_API_KEY":
         varname => 'ERRBIT_API_KEY',
         value   => $errbit_api_key;


### PR DESCRIPTION
Now that contacts-admin is a purely admin app with no frontend code, and only deployed to backend servers, we no longer need the ability to disable the admin routes on frontend servers.

Removed from contacts-admin by https://github.com/alphagov/contacts-admin/pull/253.