### PR TITLE
nodejs on CI

### DIFF
--- a/modules/govuk_ci/manifests/agent/nodejs.pp
+++ b/modules/govuk_ci/manifests/agent/nodejs.pp
@@ -1,0 +1,15 @@
+# Class govuk_ci::agent::nodejs
+#
+# Installs nodejs and nodejs specific tools
+#
+class govuk_ci::agent::nodejs {
+
+  # uglifier requires a JavaScript runtime
+  # alphagov/spotlight requires a decent version of Node (0.10+) and grunt-cli
+
+  package { 'grunt-cli':
+    ensure   => '0.1.9',
+    provider => 'npm',
+    require  => Class['::nodejs'],
+  }
+}


### PR DESCRIPTION
uglifier requires a JavaScript runtime
alphagov/spotlight requires a decent version of Node (0.10+) and grunt-cli