### PR TITLE
Disable licensing smokey test in integration.

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -253,6 +253,10 @@ mongodb::backup::mongo_backup_node: 'localhost'
 monitoring::checks::enable_support_check: false
 monitoring::checks::pingdom::enable: false
 monitoring::checks::ses::region: eu-west-1
+monitoring::checks::smokey::features:
+  check_licensing:
+    feature: licensing
+    enabled: false
 
 postfix::smarthost:
   - 'email-smtp.eu-west-1.amazonaws.com:587'

--- a/modules/icinga/manifests/check_feature.pp
+++ b/modules/icinga/manifests/check_feature.pp
@@ -1,24 +1,42 @@
-# FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
-define icinga::check_feature ($feature, $notes_url = undef) {
-  icinga::check_feature_w_prio { "check_feature_${feature}_urgent":
-    feature   => $feature,
-    prio      => 'urgent',
-    notes_url => $notes_url,
-  }
-  icinga::check_feature_w_prio { "check_feature_${feature}_high":
-    feature   => $feature,
-    prio      => 'high',
-    notes_url => $notes_url,
-  }
-  icinga::check_feature_w_prio { "check_feature_${feature}_normal":
-    feature   => $feature,
-    prio      => 'normal',
-    notes_url => $notes_url,
-  }
-  icinga::check_feature_w_prio { "check_feature_${feature}_low":
-    feature   => $feature,
-    prio      => 'low',
-    notes_url => $notes_url,
+# == Define: icinga::check_feature
+#
+# Create the configuration for a new Icinga `check_feature`.
+#
+# === Parameters
+#
+# [*feature*]
+#   Name of the feature to be created.
+#
+# [*notes_url*]
+#   URL to show in Icinga for further information about this check
+#   Default: undef
+#
+# [*enabled*]
+#   Can be used to disable checks/alerts for a given environment.
+#   Default: true
+#
+define icinga::check_feature ($feature, $notes_url = undef, $enabled = true) {
+  if $enabled {
+    icinga::check_feature_w_prio { "check_feature_${feature}_urgent":
+      feature   => $feature,
+      prio      => 'urgent',
+      notes_url => $notes_url,
+    }
+    icinga::check_feature_w_prio { "check_feature_${feature}_high":
+      feature   => $feature,
+      prio      => 'high',
+      notes_url => $notes_url,
+    }
+    icinga::check_feature_w_prio { "check_feature_${feature}_normal":
+      feature   => $feature,
+      prio      => 'normal',
+      notes_url => $notes_url,
+    }
+    icinga::check_feature_w_prio { "check_feature_${feature}_low":
+      feature   => $feature,
+      prio      => 'low',
+      notes_url => $notes_url,
+    }
   }
 }
 

--- a/modules/monitoring/spec/classes/monitoring__checks__smokey_spec.rb
+++ b/modules/monitoring/spec/classes/monitoring__checks__smokey_spec.rb
@@ -1,0 +1,25 @@
+require_relative '../../../../spec_helper'
+
+describe 'monitoring::checks::smokey', :type => :class do
+  let(:pre_condition) {
+    'icinga::host { "dummy.host": }'
+  }
+  let(:facts) {{
+    :fqdn       => "dummy.host",
+    :cache_bust => Time.now,
+    :ipaddress  => '10.10.10.10',
+    :fqdn_short => 'fakehost-1.management',
+  }}
+
+  context 'with disabled features' do
+    let(:params) {{
+      "features" => {
+        "check_foo" => { "feature" => "foo" },
+        "check_bar" => { "feature" => "bar", "enabled" => false },
+      }
+    }}
+
+    it { is_expected.to contain_icinga__check("check_feature_foo_urgent_checker") }
+    it { is_expected.not_to contain_icinga__check("check_feature_bar_urgent_checker") }
+  end
+end


### PR DESCRIPTION
Licensing does not contain the correct data in integration, so the
tests have been disabled in smokey itself (in alphagov/smokey#205) by using the @notintegration
tag. However, the monitoring check does not respect that tag, so the
failing tests were being run by Icincga anyway.

This change introduces an "enabled" flag in the icinga::check_feature
defined type, defaulting to true, and overrides the check_licensing
hash in integration hieradata to set it to false for that one feature.