### PR TITLE
Upgrade Openconnect to 6.00 (all environments)

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -467,6 +467,8 @@ govuk::apps::travel_advice_publisher::redis_port: "%{hiera('sidekiq_port')}"
 govuk::deploy::config::asset_root: "https://%{hiera('router::assets_origin::vhost_name')}"
 govuk::deploy::config::website_root: "https://www-origin.%{hiera('app_domain')}"
 
+govuk_ghe_vpn::openconnect_version: '6.00-0~21~ubuntu14.04.1'
+
 govuk_gor::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 govuk_htpasswd::http_username: "%{hiera('http_username')}"

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -35,8 +35,6 @@ govuk_crawler::seed_enable: true
 
 govuk_elasticsearch::dump::run_es_dump_hour: '9'
 
-govuk_ghe_vpn::openconnect_version: '6.00-0~21~ubuntu14.04.1'
-
 govuk_jenkins::config::banner_colour_background: '#ffbf47'
 govuk_jenkins::config::banner_colour_text: 'black'
 govuk_jenkins::config::banner_string: 'Carrenza INTEGRATION'


### PR DESCRIPTION
Upgrade Openconnect package to 6.00 on all the environments, to support disaster recovery office VPN.