### PR TITLE
Remove manage_config condition

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -41,7 +41,6 @@ govuk_jenkins::config::banner_string: 'Carrenza INTEGRATION'
 govuk_jenkins::config::theme_colour: '#ffbf47'
 govuk_jenkins::config::theme_text_colour: 'black'
 govuk_jenkins::config::theme_environment_name: 'Integration'
-govuk_jenkins::config::manage_config: true
 
 govuk_jenkins::config::admins:
   - aaronkeogh

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -69,7 +69,6 @@ govuk_jenkins::config::banner_string: 'Carrenza PRODUCTION'
 govuk_jenkins::config::theme_colour: '#df3034'
 govuk_jenkins::config::theme_text_colour: 'white'
 govuk_jenkins::config::theme_environment_name: 'Production'
-govuk_jenkins::config::manage_config: true
 
 govuk_jenkins::job_builder::environment: 'production'
 

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -30,7 +30,6 @@ govuk_jenkins::config::banner_string: 'Carrenza STAGING'
 govuk_jenkins::config::theme_colour: '#ffbf47'
 govuk_jenkins::config::theme_text_colour: 'black'
 govuk_jenkins::config::theme_environment_name: 'Staging'
-govuk_jenkins::config::manage_config: true
 
 govuk_elasticsearch::dump::run_es_dump_hour: '4'
 

--- a/modules/govuk_jenkins/manifests/config.pp
+++ b/modules/govuk_jenkins/manifests/config.pp
@@ -47,10 +47,6 @@
 # [*admins*]
 #   List of admins that have "admin" permissions in Jenkins.
 #
-# [*manage_config*]
-#   Option to manage the Jenkins config or not. This is set so we do not
-#   overwrite configuration in live environments.
-#
 class govuk_jenkins::config (
   $app_domain = hiera('app_domain'),
   $banner_colour_background = 'black',
@@ -65,118 +61,114 @@ class govuk_jenkins::config (
   $github_client_id,
   $github_client_secret,
   $admins = [],
-  $manage_config = false,
 ) {
 
   validate_array($admins)
 
-  if $manage_config {
+  File {
+    owner  => 'jenkins',
+    group  => 'jenkins',
+    notify => Service['jenkins'],
+  }
 
-    File {
-      owner  => 'jenkins',
-      group  => 'jenkins',
-      notify => Service['jenkins'],
-    }
+  file {'/var/lib/jenkins/com.cloudbees.jenkins.GitHubPushTrigger.xml':
+    ensure => file,
+    source => 'puppet:///modules/govuk_jenkins/var/lib/jenkins/com.cloudbees.jenkins.GitHubPushTrigger.xml',
+  }
 
-    file {'/var/lib/jenkins/com.cloudbees.jenkins.GitHubPushTrigger.xml':
-      ensure => file,
-      source => 'puppet:///modules/govuk_jenkins/var/lib/jenkins/com.cloudbees.jenkins.GitHubPushTrigger.xml',
-    }
+  file {'/var/lib/jenkins/com.sonyericsson.rebuild.RebuildDescriptor.xml':
+    ensure => file,
+    source => 'puppet:///modules/govuk_jenkins/var/lib/jenkins/com.sonyericsson.rebuild.RebuildDescriptor.xml',
+  }
 
-    file {'/var/lib/jenkins/com.sonyericsson.rebuild.RebuildDescriptor.xml':
-      ensure => file,
-      source => 'puppet:///modules/govuk_jenkins/var/lib/jenkins/com.sonyericsson.rebuild.RebuildDescriptor.xml',
-    }
+  file {'/var/lib/jenkins/envInject.xml':
+    ensure => file,
+    source => 'puppet:///modules/govuk_jenkins/var/lib/jenkins/envInject.xml',
+  }
 
-    file {'/var/lib/jenkins/envInject.xml':
-      ensure => file,
-      source => 'puppet:///modules/govuk_jenkins/var/lib/jenkins/envInject.xml',
-    }
+  file {'/var/lib/jenkins/hudson.model.UpdateCenter.xml':
+    ensure => file,
+    source => 'puppet:///modules/govuk_jenkins/var/lib/jenkins/hudson.model.UpdateCenter.xml',
+  }
 
-    file {'/var/lib/jenkins/hudson.model.UpdateCenter.xml':
-      ensure => file,
-      source => 'puppet:///modules/govuk_jenkins/var/lib/jenkins/hudson.model.UpdateCenter.xml',
-    }
+  file {'/var/lib/jenkins/hudson.plugins.ansicolor.AnsiColorBuildWrapper.xml':
+    ensure => file,
+    source => 'puppet:///modules/govuk_jenkins/var/lib/jenkins/hudson.plugins.ansicolor.AnsiColorBuildWrapper.xml',
+  }
 
-    file {'/var/lib/jenkins/hudson.plugins.ansicolor.AnsiColorBuildWrapper.xml':
-      ensure => file,
-      source => 'puppet:///modules/govuk_jenkins/var/lib/jenkins/hudson.plugins.ansicolor.AnsiColorBuildWrapper.xml',
-    }
+  file {'/var/lib/jenkins/hudson.plugins.git.GitTool.xml':
+    ensure => file,
+    source => 'puppet:///modules/govuk_jenkins/var/lib/jenkins/hudson.plugins.git.GitTool.xml',
+  }
 
-    file {'/var/lib/jenkins/hudson.plugins.git.GitTool.xml':
-      ensure => file,
-      source => 'puppet:///modules/govuk_jenkins/var/lib/jenkins/hudson.plugins.git.GitTool.xml',
-    }
+  file {'/var/lib/jenkins/hudson.plugins.sitemonitor.SiteMonitorRecorder.xml':
+    ensure => file,
+    source => 'puppet:///modules/govuk_jenkins/var/lib/jenkins/hudson.plugins.sitemonitor.SiteMonitorRecorder.xml',
+  }
 
-    file {'/var/lib/jenkins/hudson.plugins.sitemonitor.SiteMonitorRecorder.xml':
-      ensure => file,
-      source => 'puppet:///modules/govuk_jenkins/var/lib/jenkins/hudson.plugins.sitemonitor.SiteMonitorRecorder.xml',
-    }
+  file {'/var/lib/jenkins/hudson.tasks.Shell.xml':
+    ensure => file,
+    source => 'puppet:///modules/govuk_jenkins/var/lib/jenkins/hudson.tasks.Shell.xml',
+  }
 
-    file {'/var/lib/jenkins/hudson.tasks.Shell.xml':
-      ensure => file,
-      source => 'puppet:///modules/govuk_jenkins/var/lib/jenkins/hudson.tasks.Shell.xml',
-    }
+  file {'/var/lib/jenkins/jenkins.model.ArtifactManagerConfiguration.xml':
+    ensure => file,
+    source => 'puppet:///modules/govuk_jenkins/var/lib/jenkins/jenkins.model.ArtifactManagerConfiguration.xml',
+  }
 
-    file {'/var/lib/jenkins/jenkins.model.ArtifactManagerConfiguration.xml':
-      ensure => file,
-      source => 'puppet:///modules/govuk_jenkins/var/lib/jenkins/jenkins.model.ArtifactManagerConfiguration.xml',
-    }
+  file {'/var/lib/jenkins/jenkins.model.DownloadSettings.xml':
+    ensure => file,
+    source => 'puppet:///modules/govuk_jenkins/var/lib/jenkins/jenkins.model.DownloadSettings.xml',
+  }
 
-    file {'/var/lib/jenkins/jenkins.model.DownloadSettings.xml':
-      ensure => file,
-      source => 'puppet:///modules/govuk_jenkins/var/lib/jenkins/jenkins.model.DownloadSettings.xml',
-    }
+  file {'/var/lib/jenkins/jenkins.mvn.GlobalMavenConfig.xml':
+    ensure => file,
+    source => 'puppet:///modules/govuk_jenkins/var/lib/jenkins/jenkins.mvn.GlobalMavenConfig.xml',
+  }
 
-    file {'/var/lib/jenkins/jenkins.mvn.GlobalMavenConfig.xml':
-      ensure => file,
-      source => 'puppet:///modules/govuk_jenkins/var/lib/jenkins/jenkins.mvn.GlobalMavenConfig.xml',
-    }
+  file {'/var/lib/jenkins/jenkins.security.QueueItemAuthenticatorConfiguration.xml':
+    ensure => file,
+    source => 'puppet:///modules/govuk_jenkins/var/lib/jenkins/jenkins.security.QueueItemAuthenticatorConfiguration.xml',
+  }
 
-    file {'/var/lib/jenkins/jenkins.security.QueueItemAuthenticatorConfiguration.xml':
-      ensure => file,
-      source => 'puppet:///modules/govuk_jenkins/var/lib/jenkins/jenkins.security.QueueItemAuthenticatorConfiguration.xml',
-    }
+  file {'/var/lib/jenkins/org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder.xml':
+    ensure => file,
+    source => 'puppet:///modules/govuk_jenkins/var/lib/jenkins/org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder.xml',
+  }
 
-    file {'/var/lib/jenkins/org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder.xml':
-      ensure => file,
-      source => 'puppet:///modules/govuk_jenkins/var/lib/jenkins/org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder.xml',
-    }
+  file {'/var/lib/jenkins/org.jenkinsci.plugins.gitclient.JGitTool.xml':
+    ensure => file,
+    source => 'puppet:///modules/govuk_jenkins/var/lib/jenkins/org.jenkinsci.plugins.gitclient.JGitTool.xml',
+  }
 
-    file {'/var/lib/jenkins/org.jenkinsci.plugins.gitclient.JGitTool.xml':
-      ensure => file,
-      source => 'puppet:///modules/govuk_jenkins/var/lib/jenkins/org.jenkinsci.plugins.gitclient.JGitTool.xml',
-    }
+  file {'/var/lib/jenkins/org.jvnet.hudson.plugins.SSHBuildWrapper.xml':
+    ensure => file,
+    source => 'puppet:///modules/govuk_jenkins/var/lib/jenkins/org.jvnet.hudson.plugins.SSHBuildWrapper.xml',
+  }
 
-    file {'/var/lib/jenkins/org.jvnet.hudson.plugins.SSHBuildWrapper.xml':
-      ensure => file,
-      source => 'puppet:///modules/govuk_jenkins/var/lib/jenkins/org.jvnet.hudson.plugins.SSHBuildWrapper.xml',
-    }
+  file { '/var/lib/jenkins/org.codefirst.SimpleThemeDecorator.xml':
+    ensure => present,
+    source => 'puppet:///modules/govuk_jenkins/var/lib/jenkins/org.codefirst.SimpleThemeDecorator.xml',
+  }
 
-    file { '/var/lib/jenkins/org.codefirst.SimpleThemeDecorator.xml':
-      ensure => present,
-      source => 'puppet:///modules/govuk_jenkins/var/lib/jenkins/org.codefirst.SimpleThemeDecorator.xml',
-    }
+  file { '/var/lib/jenkins/jenkins.model.JenkinsLocationConfiguration.xml':
+    ensure  => present,
+    content => template('govuk_jenkins/config/jenkins.model.JenkinsLocationConfiguration.xml.erb'),
+  }
 
-    file { '/var/lib/jenkins/jenkins.model.JenkinsLocationConfiguration.xml':
-      ensure  => present,
-      content => template('govuk_jenkins/config/jenkins.model.JenkinsLocationConfiguration.xml.erb'),
-    }
+  file { '/var/lib/jenkins/config.xml':
+    ensure  => present,
+    content => template('govuk_jenkins/config/config.xml.erb'),
+    require => File['/var/lib/jenkins'],
+  }
 
-    file { '/var/lib/jenkins/config.xml':
-      ensure  => present,
-      content => template('govuk_jenkins/config/config.xml.erb'),
-      require => File['/var/lib/jenkins'],
-    }
+  file { '/var/lib/jenkins/userContent/header-crown.png':
+    ensure => present,
+    source => 'puppet:///modules/govuk_jenkins/userContent/header-crown.png',
+  }
 
-    file { '/var/lib/jenkins/userContent/header-crown.png':
-      ensure => present,
-      source => 'puppet:///modules/govuk_jenkins/userContent/header-crown.png',
-    }
-
-    file { '/var/lib/jenkins/userContent/govuk.css':
-      ensure  => present,
-      content => template('govuk_jenkins/userContent/govuk.css.erb'),
-    }
+  file { '/var/lib/jenkins/userContent/govuk.css':
+    ensure  => present,
+    content => template('govuk_jenkins/userContent/govuk.css.erb'),
   }
 }


### PR DESCRIPTION
This is set to "true" everywhere, so I don't think it's needed. It was originally added so we could test the changes in Integration only, but was never removed when it was set everywhere.

This also recently caused a condition where the changes weren't tested in Vagrant because the default was "false", and when a test was deployed to Integration there were unexpected results.