### PR TITLE
Add environment variables for assisted digital survey to feedback

### DIFF
--- a/modules/govuk/manifests/app/envvar.pp
+++ b/modules/govuk/manifests/app/envvar.pp
@@ -6,6 +6,11 @@
 # Unlike govuk_envvar, the dependency between the govuk::app::envvar and the
 # application is explicitly encoded, so changing a govuk::app::envvar should
 # automatically restart the relevant application.
+#
+# We use envdir to read the files we place in env.d and this only reads the
+# first line of the file.  To deliver multiline values we have to convert
+# newlines into null characters.  Envdir will then do the reverse when it
+# reads the value out of the file and makes it available in the environment.
 
 define govuk::app::envvar (
   # Name of the application with which this env var is associated
@@ -18,16 +23,21 @@ define govuk::app::envvar (
 ) {
   validate_string($value)
 
+  $nulls_for_newlines_value = inline_template('<%= @value.encode(
+    @value.encoding,
+    universal_newline: true
+  ).gsub(/\n/,"\0") unless @value.nil? %>')
+
   if $notify_service {
     file { "${envdir}/${varname}":
       ensure  => present,
-      content => $value,
+      content => $nulls_for_newlines_value,
       notify  => Govuk::App::Service[$app],
     }
   } else {
     file { "${envdir}/${varname}":
       ensure  => present,
-      content => $value,
+      content => $nulls_for_newlines_value,
     }
   }
 }

--- a/modules/govuk/manifests/apps/feedback.pp
+++ b/modules/govuk/manifests/apps/feedback.pp
@@ -24,6 +24,9 @@ class govuk::apps::feedback(
   $secret_key_base = undef,
   $support_api_bearer_token = undef,
   $publishing_api_bearer_token = undef,
+  $assisted_digital_help_with_fees_google_spreadsheet_key = undef,
+  $google_client_email = undef,
+  $google_private_key = undef,
 ) {
   $app_name = 'feedback'
 
@@ -64,5 +67,26 @@ class govuk::apps::feedback(
   govuk::app::envvar { "${title}-PUBLISHING_API_BEARER_TOKEN":
     varname => 'PUBLISHING_API_BEARER_TOKEN',
     value   => $publishing_api_bearer_token,
+  }
+
+  if $assisted_digital_help_with_fees_google_spreadsheet_key != undef {
+    govuk::app::envvar { "${title}-ASSISTED_DIGITAL_HELP_WITH_FEES_GOOGLE_SPREADSHEET_KEY":
+      varname => 'ASSISTED_DIGITAL_HELP_WITH_FEES_GOOGLE_SPREADSHEET_KEY',
+      value   => $assisted_digital_help_with_fees_google_spreadsheet_key,
+    }
+  }
+
+  if $google_client_email != undef {
+    govuk::app::envvar { "${title}-GOOGLE_CLIENT_EMAIL":
+      varname => 'GOOGLE_CLIENT_EMAIL',
+      value   => $google_client_email,
+    }
+  }
+
+  if $google_private_key != undef {
+    govuk::app::envvar { "${title}-GOOGLE_PRIVATE_KEY":
+      varname => 'GOOGLE_PRIVATE_KEY',
+      value   => $google_private_key,
+    }
   }
 }

--- a/modules/govuk/spec/defines/govuk__app__envvar_spec.rb
+++ b/modules/govuk/spec/defines/govuk__app__envvar_spec.rb
@@ -1,0 +1,59 @@
+require_relative '../../../../spec_helper'
+
+describe 'govuk::app::envvar', :type => :define do
+  let(:title) { "robert-burns" }
+
+  context 'with a value that has no newlines' do
+    let(:params) {
+      {
+        :app => 'burns',
+        :varname => 'GOVUK_POET_FULL_NAME',
+        :value => 'Robert Burns'
+      }
+    }
+
+    it "writes the value to disk" do
+      is_expected.to contain_file('/etc/govuk/burns/env.d/GOVUK_POET_FULL_NAME')
+                       .with_content('Robert Burns')
+    end
+  end
+
+  context 'with a value that has newlines' do
+    let(:params) {
+      {
+        :app => 'burns',
+        :varname => 'GOVUK_TO_A_MOUSE',
+        :value => to_a_mouse
+      }
+    }
+
+    shared_examples_for 'a multiline env var' do
+      it "writes the value to disk with null characters instead of newlines" do
+        is_expected.to contain_file('/etc/govuk/burns/env.d/GOVUK_TO_A_MOUSE')
+                         .with_content("Wee, sleekit, cowran, tim'rous beastie,\0O, what a panic's in thy breastie!\0Thou need na start awa sae hasty,\0Wi' bickering brattle!\0I wad be laith to rin an' chase thee,\0Wi' murd'ring pattle!\0")
+      end
+    end
+
+    context 'that are normalized' do
+      let(:to_a_mouse) {
+        "Wee, sleekit, cowran, tim'rous beastie,
+O, what a panic's in thy breastie!
+Thou need na start awa sae hasty,
+Wi' bickering brattle!
+I wad be laith to rin an' chase thee,
+Wi' murd'ring pattle!
+"
+      }
+
+      it_behaves_like 'a multiline env var'
+    end
+
+    context 'that are excitingly diverse' do
+      let(:to_a_mouse) {
+        "Wee, sleekit, cowran, tim'rous beastie,\r\nO, what a panic's in thy breastie!\rThou need na start awa sae hasty,\nWi' bickering brattle!\nI wad be laith to rin an' chase thee,\r\nWi' murd'ring pattle!\r"
+      }
+
+      it_behaves_like 'a multiline env var'
+    end
+  end
+end


### PR DESCRIPTION
These will hold the key of the spreadsheet to write survey results to and
the email and private key credentials of the service account to use to
perform the write.  Each environment will have their own values for this
and it'll come from the encrypted puppet hieradata.

To provide config for https://github.com/alphagov/feedback/pull/179/ (which is in service of https://trello.com/c/kZCX6dGB/53-assisted-digital-support-on-done-page-survey)