### PR TITLE
Allow an alternative proxy ssl port to be specified

### DIFF
--- a/modules/nginx/manifests/config/vhost/proxy.pp
+++ b/modules/nginx/manifests/config/vhost/proxy.pp
@@ -11,6 +11,10 @@
 #   Boolean whether the upstream servers are running on HTTPS/443.
 #   Default: false
 #
+# [*to_ssl_port*]
+#   String override port as an alternative to 443.
+#   Default: '443'
+#
 # [*aliases*]
 #   Other hostnames to serve the app on
 #
@@ -79,6 +83,7 @@
 define nginx::config::vhost::proxy(
   $to,
   $to_ssl = false,
+  $to_ssl_port = '443',
   $aliases = [],
   $custom_http_host = undef,
   $extra_config = '',
@@ -111,7 +116,7 @@ define nginx::config::vhost::proxy(
   $title_escaped = regsubst($title, '\.', '_', 'G')
 
   $to_port = $to_ssl ? {
-    true    => ':443',
+    true    => ":${to_ssl_port}",
     default => '',
   }
   $to_proto = $to_ssl ? {

--- a/modules/nginx/spec/defines/nginx__config__vhost__proxy_spec.rb
+++ b/modules/nginx/spec/defines/nginx__config__vhost__proxy_spec.rb
@@ -65,6 +65,18 @@ describe 'nginx::config::vhost::proxy', :type => :define do
     it { is_expected.to contain_nginx__config__site('rabbit')
       .with_content(/^\s+proxy_pass https:\/\/rabbit-proxy;$/) }
 
+    context 'with to_ssl_port "8443"' do
+      before do
+        params[:to_ssl_port] = '8443'
+      end
+
+      it 'should use the provided value' do
+        is_expected.to contain_nginx__config__site('rabbit')
+          .with_content(/server a\.internal:8443;/)
+          .with_content(/server b\.internal:8443;/)
+          .with_content(/server c\.internal:8443;/)
+      end
+    end
   end
 
   context 'with deny_framing true' do


### PR DESCRIPTION
https://trello.com/c/hCl0Jify/483-make-draft-content-store-accessible-large-3
[Secure connections to the draft content store require an alternative port to 443](https://github.com/alphagov/govuk-puppet/blob/0ec68d0244d498472e156fe3c1e096b326b25808/modules/govuk/manifests/node/s_api_lb.pp#L50).
This PR adds an additional variable to `nginx::config::vhost::proxy` which defaults to '443' but can be used to override the ssl port in the upstream proxy configuration.