### PR TITLE
Add timestamps to the deploy puppet job as it's very slow

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_puppet.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_puppet.yaml.erb
@@ -37,6 +37,7 @@
             colormap: xterm
         - build-name:
             name: '#${BUILD_NUMBER} ${ENV,var="TAG"}'
+        - timestamps:
     parameters:
         - string:
             name: TAG


### PR DESCRIPTION
This will add per-command timestamps.