### PR TITLE
More plugin dependencies

### DIFF
--- a/hieradata/class/ci_master.yaml
+++ b/hieradata/class/ci_master.yaml
@@ -116,3 +116,13 @@ govuk_jenkins::plugins:
         version: "1.24"
     plain-credentials:
         version: "1.1"
+    bouncycastle-api:
+        version: "2.16.0"
+    windows-slaves:
+        version: "1.2"
+    matrix-auth:
+        version: "1.4"
+    antisamy-markup-formatter:
+        version: "1.5"
+    icon-shim:
+        version: "2.0.3"


### PR DESCRIPTION
This enables us to properly run the Role Based Strategy Authorization Plugin which fails silently if the dependencies are not installed.