### PR TITLE
Add memcached meta and entity store urls for contentapi

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -238,6 +238,8 @@ govuk::apps::collections_publisher::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::contacts::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::contacts::redis_port: "%{hiera('sidekiq_port')}"
 
+govuk::apps::contentapi::memcached_entitystore_url: "memcached://localhost:11211/contentapi-entity"
+govuk::apps::contentapi::memcached_metastore_url: "memcached://localhost:11211/contentapi-meta"
 govuk::apps::contentapi::nagios_memory_warning: 3800
 govuk::apps::contentapi::nagios_memory_critical: 4000
 

--- a/modules/govuk/manifests/apps/contentapi.pp
+++ b/modules/govuk/manifests/apps/contentapi.pp
@@ -14,6 +14,12 @@
 # [*errbit_api_key*]
 #   Errbit API key used by airbrake
 #
+# [*memcached_entitystore_url*]
+#   Memcached url for entitystore
+#
+# [*memcached_metastore_url*]
+#   Memcached url for metastore
+#
 # [*mongodb_name*]
 #   The Mongo database to be used.
 #
@@ -42,6 +48,8 @@ class govuk::apps::contentapi (
   $port = '3022',
   $asset_manager_bearer_token = undef,
   $errbit_api_key = undef,
+  $memcached_entitystore_url = undef,
+  $memcached_metastore_url = undef,
   $mongodb_name = undef,
   $mongodb_nodes = undef,
   $nagios_memory_warning = undef,
@@ -77,6 +85,12 @@ class govuk::apps::contentapi (
     "${title}-ERRBIT_API_KEY":
       varname => 'ERRBIT_API_KEY',
       value   => $errbit_api_key;
+    "${title}-MEMCACHED_ENTITYSTORE":
+      varname => 'MEMCACHED_ENTITYSTORE',
+      value   => $memcached_entitystore_url;
+    "${title}-MEMCACHED_METASTORE":
+      varname => 'MEMCACHED_METASTORE',
+      value   => $memcached_metastore_url;
     "${title}-OAUTH_ID":
       varname => 'OAUTH_ID',
       value   => $oauth_id;


### PR DESCRIPTION
Part of https://trello.com/c/BrKRdn4f/495-rebuild-gov-uk-app-deployment-pipeline
These are moving out of alphagov-deployment config files, so they need to be turned into env vars.