### PR TITLE
Add notes about viewing another users token

### DIFF
--- a/modules/govuk_jenkins/manifests/job_builder.pp
+++ b/modules/govuk_jenkins/manifests/job_builder.pp
@@ -15,7 +15,15 @@
 #   A username of a user on Jenkins who has permission to create and modify jobs
 #
 # [*jenkins_api_token*]
-#   The API token for $jenkins_user
+#   The API token for $jenkins_user.
+#
+#   By default, in newer versions of Jenkins you will be unable to view another
+#   users token. To get past this, temporarily set the following as an argument under
+#   JAVA_ARGS in the init script and restart the Jenkins service:
+#
+#   "-Djenkins.security.ApiTokenProperty.showTokenToAdmins=true"
+#
+#   Ref: https://wiki.jenkins-ci.org/display/JENKINS/Features+controlled+by+system+properties
 #
 # [*jenkins_url*]
 #   The URL to access Jenkins


### PR DESCRIPTION
We came across an issue where we automatically added the user which is used by Jenkins job builder to authenticate and create jobs, but were not able to view the users token. To view the token of a user you must login as that user, but since we do authentication with Github OAuth,
this makes it tricky. This was not an issue on older versions of Jenkins, but was a security feature that was later introduced.

In lieu of an obvious place to add this documentation, I thought I would help someone in the future by mentioning in this specific class in case it crops up again.