### PR TITLE
Add Jenkins token for job builder

### DIFF
--- a/hieradata/vagrant_credentials.yaml
+++ b/hieradata/vagrant_credentials.yaml
@@ -127,6 +127,7 @@ govuk_ci::master::github_client_id: 'bellathecat'
 govuk_ci::master::github_client_secret: 'sheisfurry'
 govuk_ci::master::ghe_vpn_username: 'bella'
 govuk_ci::master::ghe_vpn_password: 'furrysocks'
+govuk_ci::master::jenkins_api_token: 'thisisatoken'
 
 govuk::deploy::aws_ses_smtp_username: 'a_username'
 govuk::deploy::aws_ses_smtp_password: 'a_password'

--- a/modules/govuk_ci/manifests/master.pp
+++ b/modules/govuk_ci/manifests/master.pp
@@ -21,6 +21,7 @@ class govuk_ci::master (
   $github_client_secret,
   $ghe_vpn_username,
   $ghe_vpn_password,
+  $jenkins_api_token,
 ){
 
   include ::govuk_ci::credentials
@@ -28,6 +29,7 @@ class govuk_ci::master (
   class { '::govuk_jenkins':
     github_client_id     => $github_client_id,
     github_client_secret => $github_client_secret,
+    jenkins_api_token    => $jenkins_api_token,
   }
 
   class { 'govuk_ghe_vpn':

--- a/modules/govuk_jenkins/manifests/init.pp
+++ b/modules/govuk_jenkins/manifests/init.pp
@@ -43,11 +43,15 @@ class govuk_jenkins (
   $ssh_private_key = undef,
   $ssh_public_key = undef,
   $version = '1.554.2',
+  $jenkins_api_token = '',
 ) {
   validate_hash($config, $plugins)
 
   include ::govuk_python
-  include ::govuk_jenkins::job_builder
+
+  class { 'govuk_jenkins::job_builder':
+    jenkins_api_token => $jenkins_api_token,
+  }
 
   class { 'govuk_jenkins::config':
     github_client_id     => $github_client_id,


### PR DESCRIPTION
Since we have a second instance of Jenkins we need to be able to pass in a different API token which is used by Jenkins job builder to manage jobs. We are unable to differentiate between different classes in the encrypted hieradata, so we need to split out how we call the class and
call it specifically in the govuk_ci::master class.