### PR TITLE
Elasticsearch minimum matser nodes

### DIFF
--- a/hieradata/class/ci_agent.yaml
+++ b/hieradata/class/ci_agent.yaml
@@ -7,3 +7,5 @@ mongodb::server::replicaset_members:
 govuk_ci::agent::postgresql::mapit_role_password: 'mapit'
 postgresql::globals::version: '9.3'
 govuk_mysql::server::innodb_flush_log_at_trx_commit: 0
+
+govuk_elasticsearch::minimum_master_nodes: '1'

--- a/hieradata/vagrant.yaml
+++ b/hieradata/vagrant.yaml
@@ -43,6 +43,7 @@ govuk_elasticsearch::backup::es_indices:
 govuk_elasticsearch::backup::aws_access_key_id: 'foo'
 govuk_elasticsearch::backup::aws_secret_access_key: 'bar'
 
+govuk_elasticsearch::minimum_master_nodes: '1'
 
 govuk_lvm::no_op: true
 


### PR DESCRIPTION
Overriding minimum master nodes parameter so we can provision healthy clusters with 1 node.

This only affects CI and Vagrant where a one node cluster is the most likely use case.

See: https://trello.com/c/b6Yaupro