### PR TITLE
Add content/need api bearer tokens to metadata api

### DIFF
--- a/modules/govuk/manifests/apps/metadata_api.pp
+++ b/modules/govuk/manifests/apps/metadata_api.pp
@@ -1,10 +1,29 @@
 # == Class: govuk::apps::metadata_api
 #
+# HTTP application that acts as an easy way to get metadata about given URLs on GOV.UK.
+#
+# === Parameters
+#
+# [*content_api_bearer_token*]
+#   The bearer token to use when communicating with the content API.
+#   Default: undef
+#
+# [*enabled*]
+#   Whether the app is enabled.
+#   Default: false
+#
+# [*need_api_bearer_token*]
+#   The bearer token to use when communicating with the need API.
+#   Default: undef
+#
+# [*port*]
+#   The port that publishing API is served on.
+#   Default: 3064
+#
 class govuk::apps::metadata_api (
-  # Whether or not this application should be enabled.
+  $content_api_bearer_token = undef,
   $enabled = false,
-
-  # The default port that the application will start on.
+  $need_api_bearer_token = undef,
   $port = '3087',
 ) {
   $app_name = 'metadata-api'
@@ -15,6 +34,12 @@ class govuk::apps::metadata_api (
 
   govuk::app::envvar {
     'HTTP_PORT': value => $port;
+    "${title}-CONTENT_API_BEARER_TOKEN":
+    varname => 'CONTENT_API_BEARER_TOKEN',
+    value   => $content_api_bearer_token;
+    "${title}-NEED_API_BEARER_TOKEN":
+    varname => 'NEED_API_BEARER_TOKEN',
+    value   => $need_api_bearer_token;
   }
 
   govuk::app { $app_name:


### PR DESCRIPTION
Part of https://trello.com/c/BrKRdn4f/495-rebuild-gov-uk-app-deployment-pipeline

Moving this app to govuk-app-deployment, this provides some additional env vars.

Depends on https://github.gds/gds/deployment/pull/1152