### PR TITLE
Temporary workaround for Jenkins vhost config

### DIFF
--- a/modules/govuk/manifests/node/s_ci_master.pp
+++ b/modules/govuk/manifests/node/s_ci_master.pp
@@ -18,7 +18,7 @@ class govuk::node::s_ci_master inherits govuk::node::s_base {
   }
 
   nginx::config::site { 'jenkins':
-    content => template('govuk/node/s_jenkins/jenkins.conf.erb'),
+    content => template('govuk/node/s_ci_master/jenkins.conf.erb'),
     require => Nginx::Config::Ssl['jenkins'],
   }
 }

--- a/modules/govuk/templates/node/s_ci_master/jenkins.conf.erb
+++ b/modules/govuk/templates/node/s_ci_master/jenkins.conf.erb
@@ -1,0 +1,22 @@
+server {
+  listen 443 ssl;
+
+  ssl_certificate     /etc/nginx/ssl/jenkins.crt;
+  ssl_certificate_key /etc/nginx/ssl/jenkins.key;
+
+  location / {
+    proxy_pass http://localhost:8080;
+
+    include /etc/nginx/add-sts.conf;
+
+    location /api/json {
+      proxy_pass http://localhost:8080;
+
+      add_header "Access-Control-Allow-Origin" "*";
+      add_header "Access-Control-Allow-Methods" "GET, POST, OPTIONS";
+      add_header "Access-Control-Allow-Headers" "origin, authorization, cookie, accept";
+      add_header "Access-Control-Allow-Credentials" "true";
+    }
+
+  }
+}


### PR DESCRIPTION
This is a very quick temporary workaround for the default Jenkins template so it isn't tied to "deploy.*" servername, which we have removed.