### PR TITLE
Add short url manager env vars

### DIFF
--- a/hieradata/class/backend.yaml
+++ b/hieradata/class/backend.yaml
@@ -37,6 +37,12 @@ govuk::apps::publisher::mongodb_nodes:
   - 'mongo-2.backend'
   - 'mongo-3.backend'
 
+govuk::apps::short_url_manager::mongodb_name: 'short_url_manager_production'
+govuk::apps::short_url_manager::mongodb_nodes:
+  - 'mongo-1.backend'
+  - 'mongo-2.backend'
+  - 'mongo-3.backend'
+
 govuk::apps::specialist_publisher::mongodb_name: 'govuk_content_production'
 govuk::apps::specialist_publisher::mongodb_nodes:
   - 'mongo-1.backend'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -298,6 +298,9 @@ govuk::apps::manuals_publisher::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::publisher::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::publisher::redis_port: "%{hiera('sidekiq_port')}"
 
+govuk::apps::short_url_manager::redis_host: "%{hiera('sidekiq_host')}"
+govuk::apps::short_url_manager::redis_port: "%{hiera('sidekiq_port')}"
+
 govuk::apps::whitehall::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::whitehall::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::whitehall::procfile_worker_process_count: 2

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -156,6 +156,8 @@ govuk::apps::rummager::rabbitmq::enable_publishing_listener: true
 govuk::apps::rummager::redis_host: 'localhost'
 govuk::apps::signon::enable_procfile_worker: false
 govuk::apps::smartanswers::expose_govspeak: true
+govuk::apps::short_url_manager::mongodb_name: 'short_url_manager_development'
+govuk::apps::short_url_manager::mongodb_nodes: ['localhost']
 govuk::apps::specialist_publisher::enable_procfile_worker: false
 govuk::apps::specialist_publisher::publish_pre_production_finders: true
 govuk::apps::specialist_publisher::mongodb_nodes: ['localhost']

--- a/modules/govuk/manifests/apps/short_url_manager.pp
+++ b/modules/govuk/manifests/apps/short_url_manager.pp
@@ -4,19 +4,51 @@
 #
 # === Parameters
 #
-# [*port*]
-#   The port that publishing API is served on.
-#   Default: 3078
+# [*errbit_api_key*]
+#   Errbit API key for sending errors.
+#   Default: undef
+#
+# [*mongodb_nodes_string*]
+#   List of mongo hostnames and ports.
+#   Default: undef
+#
+# [*oauth_id*]
+#   Sets the OAuth ID for using GDS-SSO
+#   Default: undef
+#
+# [*oauth_secret*]
+#   Sets the OAuth Secret Key for using GDS-SSO
+#   Default: undef
 #
 # [*publishing_api_bearer_token*]
 #   The bearer token to use when communicating with Publishing API.
 #   Default: undef
 #
+# [*port*]
+#   The port that publishing API is served on.
+#   Default: 3078
+#
+# [*redis_host*]
+#   Redis host for sidekiq.
+#
+# [*redis_port*]
+#   Redis port for sidekiq.
+#   Default: 6379
+#
 class govuk::apps::short_url_manager(
-  $port = '3076',
+  $errbit_api_key = undef,
+  $mongodb_nodes_string = undef,
+  $oauth_id = undef,
+  $oauth_secret = undef,
   $publishing_api_bearer_token = undef,
+  $port = '3076',
+  $redis_host = undef,
+  $redis_port = '6379',
 ) {
-  govuk::app { 'short-url-manager':
+
+  $app_name = 'short-url-manager'
+
+  govuk::app { $app_name:
     app_type           => 'rack',
     port               => $port,
     vhost_ssl_only     => true,
@@ -24,9 +56,28 @@ class govuk::apps::short_url_manager(
     log_format_is_json => true,
   }
 
-  govuk::app::envvar { "${title}-PUBLISHING_API_BEARER_TOKEN":
-    app     => 'short-url-manager',
-    varname => 'PUBLISHING_API_BEARER_TOKEN',
-    value   => $publishing_api_bearer_token,
+  govuk::app::envvar {
+    "${title}-ERRBIT_API_KEY":
+      varname => 'ERRBIT_API_KEY',
+      value   => $errbit_api_key;
+    "${title}-MONGODB_NODES":
+      varname => 'MONGODB_NODES',
+      value   => $mongodb_nodes_string;
+    "${title}-OAUTH_ID":
+      varname => 'OAUTH_ID',
+      value   => $oauth_id;
+    "${title}-OAUTH_SECRET":
+      varname => 'OAUTH_SECRET',
+      value   => $oauth_secret;
+    "${title}-PUBLISHING_API_BEARER_TOKEN":
+      app     => 'short-url-manager',
+      varname => 'PUBLISHING_API_BEARER_TOKEN',
+      value   => $publishing_api_bearer_token;
+  }
+
+  govuk::app::envvar::redis { $app_name:
+    host      => $redis_host,
+    port      => $redis_port,
+    namespace => $app_name,
   }
 }


### PR DESCRIPTION
Part of https://trello.com/c/BrKRdn4f/495-rebuild-gov-uk-app-deployment-pipeline

Adds more env vars for short-url-manager to help move it to govuk-app-deployment

Depends on https://github.gds/gds/deployment/pull/1154