### PR TITLE
Rework attachment syncs

### DIFF
--- a/modules/govuk/manifests/node/s_asset_base.pp
+++ b/modules/govuk/manifests/node/s_asset_base.pp
@@ -134,6 +134,11 @@ class govuk::node::s_asset_base (
     mode    => '0755',
   }
 
+  file { '/usr/local/bin/copy-attachments-to-slaves.sh':
+    content => template('govuk/node/s_asset_base/copy-attachments-to-slaves.sh.erb'),
+    mode    => '0755',
+  }
+
   file { '/usr/local/bin/copy-attachments.sh':
     content => template('govuk/node/s_asset_base/copy-attachments.sh.erb'),
     mode    => '0755',

--- a/modules/govuk/templates/node/s_asset_base/copy-attachments-to-slaves.sh.erb
+++ b/modules/govuk/templates/node/s_asset_base/copy-attachments-to-slaves.sh.erb
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+set -eu
+
+FILELIST_DIR=$1
+
+# The default Icinga passive alert assumes that the script failed
+NAGIOS_CODE=2
+NAGIOS_MESSAGE="CRITICAL: Copy attachments to asset slaves failed"
+
+# Triggered whenever this script exits, successful or otherwise. The values
+# of CODE/MESSAGE will be taken from that point in time.
+function nagios_passive () {
+  printf "<%= @ipaddress %>\tCopy attachments to asset slaves\t${NAGIOS_CODE}\t${NAGIOS_MESSAGE}\n" | /usr/sbin/send_nsca -H alert.cluster >/dev/null
+}
+
+trap nagios_passive EXIT
+
+usage() {
+  echo "USAGE: $0 <filelist_dir>"
+  echo
+  echo "Copies files in all filelists within <filelist_dir> to each asset slave"
+  echo
+  exit 1
+}
+
+if [ ! "${FILELIST_DIR}" ]; then
+  usage
+fi
+
+ASSET_SLAVE_NODES=$(/usr/local/bin/govuk_node_list -c asset_slave)
+
+for FILELIST in $(ls $FILELIST_DIR); do
+  for FILENAME in $(cat $FILELIST); do
+    for NODE in $ASSET_SLAVE_NODES; do
+      if /usr/bin/timeout 20 rsync -e "ssh -q" --quiet --timeout=10 --relative "${FILENAME}" $NODE:$FILENAME; then
+        logger -t copy_attachments_to_slaves "File ${FILENAME} copied to ${NODE}"
+      else
+        logger -t copy_attachments_to_slaves "File ${FILENAME} failed to copy to ${NODE}"
+      fi
+    done
+    <% if @s3_bucket && @process_uploaded_attachments_to_s3 %>
+      if envdir /etc/govuk/aws/env.d /usr/local/bin/s3cmd --server-side-encryption put "$FILENAME" "s3://<%= @s3_bucket -%>${FILENAME}"; then
+        logger -t copy_attachments_to_slaves "File ${FILENAME} copied to S3 (<%= @s3_bucket -%>)"
+      else
+        logger -t copy_attachments_to_slaves "File ${FILENAME} failed to copy to S3 (<%= @s3_bucket -%>)"
+      fi
+    <% end %>
+  done
+  rm -f $FILELIST
+done
+
+if [ $? == 0 ]
+  NAGIOS_CODE=0
+  NAGIOS_MESSAGE="Copying attachments to asset slaves succeeded"
+fi
+
+exit $NAGIOS_CODE

--- a/modules/govuk/templates/node/s_asset_base/process-uploaded-attachments.sh.erb
+++ b/modules/govuk/templates/node/s_asset_base/process-uploaded-attachments.sh.erb
@@ -1,29 +1,30 @@
 #!/bin/bash
 
-set -e
+set -eu
 
 INCOMING_DIR=$1
 CLEAN_DIR=$2
 INFECTED_DIR=$3
-
-set -u
+TMP_DIR=$4
 
 usage() {
-  echo "USAGE: $0 <incoming_directory> <clean_directory> <infected_directory>"
+  echo "USAGE: $0 <incoming_directory> <clean_directory> <infected_directory> <tmp_dir>"
   echo
   echo "Processes attachments in <incoming_directory> by:"
   echo "  - Running a virus scan on each attachment"
   echo "  - If the file is clean, moving it to a directory of clean files"
-  echo "  - Copying it to one or more other machines"
+  echo "  - Create a file list of outstanding files in <tmp_dir> to sync to asset slaves"
   echo
   exit 1
 }
 
-if [ $# -lt 3 ]; then
+if [ $# -lt 4 ]; then
  usage
 fi
 
-ASSET_SLAVE_NODES=$(/usr/local/bin/govuk_node_list -c asset_slave)
+mkdir -p $TMP_DIR
+
+TMP_FILE=$(mktemp /tmp/attachment_sync_list_XXXXXX)
 
 cd "$INCOMING_DIR"
 
@@ -34,25 +35,14 @@ while IFS= read -r -d '' FILE
     FILE_PATH=${FILE#$INCOMING_DIR/}
     if /usr/local/bin/virus-scan-file.sh "$FILE"; then
       rsync --relative "$FILE_PATH" "$CLEAN_DIR"
-      for NODE in $ASSET_SLAVE_NODES; do
-        if /usr/bin/timeout 120 rsync -e "ssh -q" --quiet --timeout=10 --relative "$FILE_PATH" $NODE:$CLEAN_DIR; then
-          logger -t process_uploaded_attachment "File $FILE copied to $NODE"
-        else
-          logger -t process_uploaded_attachment "File $FILE failed to copy to $NODE"
-        fi
-      done
-      <% if @s3_bucket && @process_uploaded_attachments_to_s3 %>
-        if envdir /etc/govuk/aws/env.d /usr/local/bin/s3cmd --server-side-encryption put "$FILE_PATH" "s3://<%= @s3_bucket -%>$CLEAN_DIR/$FILE_PATH"; then
-          logger -t process_uploaded_attachment "File $FILE copied to S3 (<%= @s3_bucket -%>)"
-        else
-          logger -t process_uploaded_attachment "File $FILE failed to copy to S3 (<%= @s3_bucket -%>)"
-        fi
-      <% end %>
+      echo "${CLEAN_DIR}/${FILE_PATH}" >> $TMP_FILE
       rm "$FILE"
     else
       rsync --remove-source-files --relative "$FILE_PATH" "$INFECTED_DIR"
     fi
 done < <(find "$INCOMING_DIR" -type f -print0)
+
+mv $TMP_FILE $TMP_DIR/
 
 CODE=0
 OUTPUT="Last run status processing $INCOMING_DIR"


### PR DESCRIPTION
When the work was completed to add in the DR asset slave in the attachment syncs it caused a condition that can have a significant impact on the user.

If there is any sort of networking issue to the DR node, then the processing of each attachment can increase from ~10 seconds to over 2 minutes (due to the 2 minute timeout that is set). There should be no dependency on rsyncing the files across to both asset slaves before moving onto processing the next attachment on the asset master. The most important aspect of this process is to
scan the file, and move it on disk on the asset master so that the user is then able to access the file.

This commit looks to separate the processing and syncing processes. Instead of including the rsync within the loop, put the file that still needs to be synced into file. We create a list of files into one file
for each "processing-attachments" loop.

A separate process then goes through all the filelist files and attempts to sync each file onto both slaves (and an S3 bucket if set). The timeout has been reduced to 20 seconds because I don't think we will often have a file which should take longer than 20 seconds to copy. When each file
in a filelist has been copied, the filelist is removed and it moves onto the next one.

There is also a catch-all task that runs every morning to ensure the asset master and slaves are all in sync.