### PR TITLE
Add common functions library for Jenkinsfile

### DIFF
--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -26,4 +26,23 @@ def pushTag(String repository, String branch, String tag) {
 
 }
 
+/**
+ * Method to deploy an application on the Integration environment
+ *
+ * @param repository Github repository
+ * @param branch Branch name
+ * @param tag Tag to deploy
+ * @param deployTask Deploy task (deploy, deploy:migrations or deploy:setup)
+ */
+def deployIntegration(String repository, String branch, String tag, String deployTask) {
+
+  if (branch == 'master'){
+    // Deploy on Integration
+    stage("Deploy on Integration") {
+      build job: 'integration-deploy', parameters: [string(name: 'TARGET_APPLICATION', value: repository), string(name: 'TAG', value: tag), string(name: 'DEPLOY_TASK', value: deployTask)]
+    }
+  }
+
+}
+
 return this;

--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -1,0 +1,29 @@
+#!/usr/bin/env groovy
+
+/*
+ * Common functions for GOVUK Jenkinsfiles
+ */
+
+/**
+ * Push tags to Github repository
+ *
+ * @param repository Github repository
+ * @param branch Branch name
+ * @param tag Tag name
+ */
+def pushTag(String repository, String branch, String tag) {
+
+  if (branch == 'master'){
+    echo "Tagging alphagov/${repository} master branch -> ${tag}"
+    // Uncomment to enable
+//    sshagent(['govuk-ci-ssh-key']) {
+//      sh("git tag -a ${tag} -m 'Jenkinsfile tagging with ${tag}'")
+//      sh("git push git@github.com:alphagov/${repository}.git ${tag}")
+//    }
+  } else {
+    echo "No tagging on branch"
+  }
+
+}
+
+return this;

--- a/modules/govuk_jenkins/manifests/init.pp
+++ b/modules/govuk_jenkins/manifests/init.pp
@@ -106,4 +106,21 @@ class govuk_jenkins (
 
   include govuk_mysql::libdev
   include mysql::client
+
+  # Add common functions for Jenkinsfile used by Pipeline jobs
+  file { '/var/lib/jenkins/groovy_scripts':
+    ensure  => directory,
+    owner   => 'jenkins',
+    group   => 'jenkins',
+    require => Class['govuk_jenkins::package'],
+  }
+
+  file { '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy':
+    ensure  => file,
+    owner   => 'jenkins',
+    group   => 'jenkins',
+    source  => 'puppet:///modules/govuk_jenkins/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy',
+    require => File['/var/lib/jenkins/groovy_scripts'],
+  }
+
 }


### PR DESCRIPTION
New multibranch pipeline jobs can share functions provided by this
library in the Jenkinsfile. For instance:

```
def jenkinsLib = load "/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy"
jenkinsLib.myfunction()
```