### PR TITLE
Enable https_redirect for some loadbalancers

### DIFF
--- a/modules/govuk/manifests/node/s_backend_lb.pp
+++ b/modules/govuk/manifests/node/s_backend_lb.pp
@@ -78,9 +78,8 @@ class govuk::node::s_backend_lb (
       'publishing-api',
       'support-api',
     ]:
-      https_redirect => false, # FIXME: Remove for #51136581
-      internal_only  => true,
-      servers        => $backend_servers;
+      internal_only => true,
+      servers       => $backend_servers;
     [
       'whitehall-admin',
       'draft-whitehall-frontend',

--- a/modules/govuk/manifests/node/s_licensify_lb.pp
+++ b/modules/govuk/manifests/node/s_licensify_lb.pp
@@ -25,9 +25,8 @@ class govuk::node::s_licensify_lb (
   loadbalancer::balance {
     # Licensify frontend
     'licensify':
-      https_redirect => false,
-      servers        => $frontend_app_servers,
-      internal_only  => true;
+      servers       => $frontend_app_servers,
+      internal_only => true;
 
     # Licensify upload pdf public endpoint
     'uploadlicence':

--- a/modules/loadbalancer/manifests/balance.pp
+++ b/modules/loadbalancer/manifests/balance.pp
@@ -94,13 +94,6 @@ define loadbalancer::balance(
     }
   }
 
-  # FIXME: Remove once this file has been purged from all machines
-  if ! defined(File['/usr/share/nginx/html/maintenance.html']) {
-    file { '/usr/share/nginx/html/maintenance.html':
-      ensure => absent,
-    }
-  }
-
   if $maintenance_mode {
     include loadbalancer::maintenance
   }


### PR DESCRIPTION
In Kibana:

```
@source_host:backend-lb-* AND @fields.server_port:80 AND NOT @fields.application:json.event.access
@source_host:api-lb-* AND @fields.server_port:80 AND NOT @fields.application:json.event.access AND NOT @fields.application:rummager.publishing.service.gov.uk-json.event.access
```

There are no requests to the backend loadbalancer on port 80, so we can definitely redirect port 80 to 443 rather than responding on port 80.

Same thing for licensify on the API loadbalancer.