### PR TITLE
Add support-api env vars

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -458,6 +458,12 @@ govuk::apps::stagecraft::beat::enabled: true
 govuk::apps::stagecraft::celerycam::enabled: true
 govuk::apps::stagecraft::postgresql_db::api_ip_range: "%{hiera('environment_ip_prefix')}.4.0/24"
 
+govuk::apps::support_api::db_name: 'support_contacts_production'
+govuk::apps::support_api::db_hostname: 'postgresql-primary-1.backend'
+govuk::apps::support_api::db_password: "%{hiera('govuk::apps::support_api::db::password')}"
+govuk::apps::support_api::db_username: 'support_contacts'
+govuk::apps::support_api::redis_host: "%{hiera('sidekiq_host')}"
+govuk::apps::support_api::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::support_api::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 
 govuk::apps::transition::postgresql_db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -20,6 +20,7 @@ govuk::apps::publicapi::backdrop_host: 'www.preview.performance.service.gov.uk'
 
 govuk::apps::smartanswers::expose_govspeak: true
 govuk::apps::specialist_publisher::publish_pre_production_finders: true
+govuk::apps::support_api::pp_data_url: 'https://www.preview.performance.service.gov.uk'
 govuk::apps::travel_advice_publisher::enable_email_alerts: true
 govuk::apps::url_arbiter::db::backend_ip_range: '10.1.3.0/24'
 

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -49,6 +49,9 @@ govuk::apps::errbit::errbit_email_from: 'govuk-winston+errbit-production@digital
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::local_links_manager::local_links_manager_passive_checks: true
 govuk::apps::publicapi::backdrop_host: 'www.performance.service.gov.uk'
+govuk::apps::support_api::pp_data_url: 'https://www.performance.service.gov.uk'
+govuk::apps::support_api::zendesk_anonymous_ticket_email: 'zd-api-public@digital.cabinet-office.gov.uk'
+govuk::apps::support_api::zendesk_client_username: 'zd-api-govt@digital.cabinet-office.gov.uk/token'
 govuk::apps::travel_advice_publisher::enable_email_alerts: true
 
 govuk::deploy::actionmailer_enable_delivery: true

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -14,6 +14,7 @@ govuk::apps::email_alert_api::db::backend_ip_range: '10.2.3.0/24'
 govuk::apps::errbit::errbit_email_from: 'govuk-winston+errbit-staging@digital.cabinet-office.gov.uk'
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::publicapi::backdrop_host: 'www.staging.performance.service.gov.uk'
+govuk::apps::support_api::pp_data_url: 'https://www.staging.performance.service.gov.uk'
 govuk::apps::travel_advice_publisher::enable_email_alerts: true
 
 govuk::deploy::aws_ses_smtp_host: 'email-smtp.eu-west-1.amazonaws.com'

--- a/modules/govuk/manifests/apps/support_api.pp
+++ b/modules/govuk/manifests/apps/support_api.pp
@@ -7,24 +7,111 @@
 #
 # === Parameters
 #
-# [*port*]
-#   The port where the Rails app is running.
-#   Default: 3075
+# [*db_hostname*]
+#   The hostname of the database server to use in the DATABASE_URL.
+#
+# [*db_name*]
+#   The database name to use in the DATABASE_URL.
+#
+# [*db_password*]
+#   The password for the database.
+#
+# [*db_username*]
+#   The username to use in the DATABASE_URL.
 #
 # [*enable_procfile_worker*]
 #   Whether the Upstart-based background worker process is configured or not.
 #   Default: true
 #
+# [*errbit_api_key*]
+#   Errbit API key used by airbrake
+#   Default: undef
+#
+# [*port*]
+#   The port where the Rails app is running.
+#   Default: 3075
+#
+# [*pp_data_bearer_token*]
+#   Bearer token used to connect to Performance Platform.
+#
+# [*pp_data_url*]
+#   Environment specific URL for the Performance Platform.
+#
+# [*redis_host*]
+#   Redis host for Sidekiq.
+#   Default: undef
+#
+# [*redis_port*]
+#   Redis port for Sidekiq.
+#   Default: undef
+#
+# [*secret_key_base*]
+#   The key for Rails to use when signing/encrypting sessions.
+#
+# [*zendesk_anonymous_ticket_email*]
+#   Email address used for anonymous zendesk tickets.
+#
+# [*zendesk_client_password*]
+#   Password for connection to GDS zendesk client.
+#
+# [*zendesk_client_username*]
+#   Username for connection to GDS zendesk client.
+#
 class govuk::apps::support_api(
+  $db_hostname = undef,
+  $db_name = undef,
+  $db_password = undef,
+  $db_username = undef,
+  $enable_procfile_worker = true,
+  $errbit_api_key = undef,
   $port = '3075',
-  $enable_procfile_worker = true
+  $pp_data_url = undef,
+  $pp_data_bearer_token = undef,
+  $redis_host = undef,
+  $redis_port = undef,
+  $secret_key_base = undef,
+  $zendesk_anonymous_ticket_email = undef,
+  $zendesk_client_password = undef,
+  $zendesk_client_username = undef,
 ) {
-  govuk::app { 'support-api':
+  $app_name = 'support-api'
+
+  govuk::app { $app_name:
     app_type           => 'rack',
     port               => $port,
     vhost_ssl_only     => true,
     health_check_path  => '/healthcheck',
     log_format_is_json => true,
+  }
+
+  Govuk::App::Envvar {
+    app => $app_name,
+  }
+
+  govuk::app::envvar {
+    "${title}-ERRBIT_API_KEY":
+      varname => 'ERRBIT_API_KEY',
+      value   => $errbit_api_key;
+    "${title}-PP_DATA_BEARER_TOKEN":
+      varname => 'PP_DATA_BEARER_TOKEN',
+      value   => $pp_data_bearer_token;
+    "${title}-PP_DATA_URL":
+      varname => 'PP_DATA_URL',
+      value   => $pp_data_url;
+    "${title}-ZENDESK_ANONYMOUS_TICKET_EMAIL":
+      varname => 'ZENDESK_ANONYMOUS_TICKET_EMAIL',
+      value   => $zendesk_anonymous_ticket_email;
+    "${title}-ZENDESK_CLIENT_PASSWORD":
+      varname => 'ZENDESK_CLIENT_PASSWORD',
+      value   => $zendesk_client_password;
+    "${title}-ZENDESK_CLIENT_USERNAME":
+      varname => 'ZENDESK_CLIENT_USERNAME',
+      value   => $zendesk_client_username;
+  }
+
+  govuk::app::envvar::redis { $app_name:
+    host => $redis_host,
+    port => $redis_port,
   }
 
   file { ['/data/uploads/support-api', '/data/uploads/support-api/csvs']:
@@ -34,8 +121,25 @@ class govuk::apps::support_api(
     group  => 'assets',
   }
 
-  govuk::procfile::worker { 'support-api':
+  govuk::procfile::worker { $app_name:
     enable_service => $enable_procfile_worker,
+  }
+
+  if $secret_key_base != undef {
+    govuk::app::envvar { "${title}-SECRET_KEY_BASE":
+      varname => 'SECRET_KEY_BASE',
+      value   => $secret_key_base,
+    }
+  }
+
+  if $::govuk_node_class != 'development' {
+    govuk::app::envvar::database_url { $app_name:
+      type     => 'postgresql',
+      username => $db_username,
+      password => $db_password,
+      host     => $db_hostname,
+      database => $db_name,
+    }
   }
 
   include govuk_postgresql::client #installs libpq-dev package needed for pg gem


### PR DESCRIPTION
Part of https://trello.com/c/BrKRdn4f/495-rebuild-gov-uk-app-deployment-pipeline

Moves Support API configuration into environment variables.  

Depends on https://github.gds/gds/deployment/pull/1156