### PR TITLE
Jenkins jobs for ci

### DIFF
--- a/hieradata/class/ci_master.yaml
+++ b/hieradata/class/ci_master.yaml
@@ -1,4 +1,7 @@
 ---
+# FIXME: This should be set to true once this Jenkins instance is set up.
+govuk_jenkins::config::manage_config: false
+
 govuk_jenkins::version: '2.19.2'
 
 govuk_jenkins::plugins:

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -41,7 +41,6 @@ govuk_jenkins::config::banner_string: 'Carrenza INTEGRATION'
 govuk_jenkins::config::theme_colour: '#ffbf47'
 govuk_jenkins::config::theme_text_colour: 'black'
 govuk_jenkins::config::theme_environment_name: 'Integration'
-govuk_jenkins::config::manage_config: true
 
 govuk_jenkins::config::admins:
   - aaronkeogh

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -69,7 +69,6 @@ govuk_jenkins::config::banner_string: 'Carrenza PRODUCTION'
 govuk_jenkins::config::theme_colour: '#df3034'
 govuk_jenkins::config::theme_text_colour: 'white'
 govuk_jenkins::config::theme_environment_name: 'Production'
-govuk_jenkins::config::manage_config: true
 
 govuk_jenkins::job_builder::environment: 'production'
 

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -30,7 +30,6 @@ govuk_jenkins::config::banner_string: 'Carrenza STAGING'
 govuk_jenkins::config::theme_colour: '#ffbf47'
 govuk_jenkins::config::theme_text_colour: 'black'
 govuk_jenkins::config::theme_environment_name: 'Staging'
-govuk_jenkins::config::manage_config: true
 
 govuk_elasticsearch::dump::run_es_dump_hour: '4'
 

--- a/modules/govuk/manifests/apps/local_links_manager.pp
+++ b/modules/govuk/manifests/apps/local_links_manager.pp
@@ -133,5 +133,8 @@ class govuk::apps::local_links_manager(
         database => $db_name,
       }
     }
+
+    @@govuk_ci::job { 'local-links-manager': }
+
   }
 }

--- a/modules/govuk_ci/manifests/job.pp
+++ b/modules/govuk_ci/manifests/job.pp
@@ -1,0 +1,33 @@
+# == Define: govuk_ci::job
+#
+# Create a Jenkins multibranch Pipeline job for GOV.UK CI
+#
+# === Parameters
+#
+# [*app*]
+# Application name (Default: title)
+#
+# [*repository*]
+# Repository name, it needs to match the Github repository name (Default: title)
+#
+define govuk_ci::job (
+  $app = $title,
+  $repository = $title,
+) {
+
+  $job_config_directory = '/var/lib/jenkins/jobs'
+  $application_directory = "${job_config_directory}/${app}"
+
+  file { [ $job_config_directory, $application_directory ]:
+    ensure => directory,
+    owner  => 'jenkins',
+    group  => 'jenkins',
+  }
+
+  file { "${application_directory}/config.xml":
+    ensure  => present,
+    content => template('govuk_ci/application_build_job.xml.erb'),
+    require => File[$application_directory],
+  }
+
+}

--- a/modules/govuk_ci/manifests/master.pp
+++ b/modules/govuk_ci/manifests/master.pp
@@ -37,6 +37,9 @@ class govuk_ci::master (
     password => $ghe_vpn_password,
   }
 
+  # Collect exported jobs
+  Govuk_ci::Job <<| |>>
+
   ufw::allow {'jenkins-slave-to-jenkins-master-on-tcp':
     port  => '32768:65535',
     proto => 'tcp',

--- a/modules/govuk_ci/templates/application_build_job.xml.erb
+++ b/modules/govuk_ci/templates/application_build_job.xml.erb
@@ -1,0 +1,52 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject plugin="workflow-multibranch@2.9.2">
+  <actions/>
+  <description></description>
+  <properties/>
+  <views>
+    <hudson.model.AllView>
+      <owner class="org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject" reference="../../.."/>
+      <name>All</name>
+      <filterExecutors>false</filterExecutors>
+      <filterQueue>false</filterQueue>
+      <properties class="hudson.model.View$PropertyList"/>
+    </hudson.model.AllView>
+  </views>
+  <viewsTabBar class="hudson.views.DefaultViewsTabBar"/>
+  <healthMetrics/>
+  <icon class="com.cloudbees.hudson.plugins.folder.icons.StockFolderIcon" plugin="cloudbees-folder@5.13"/>
+  <orphanedItemStrategy class="com.cloudbees.hudson.plugins.folder.computed.DefaultOrphanedItemStrategy" plugin="cloudbees-folder@5.13">
+    <pruneDeadBranches>true</pruneDeadBranches>
+    <daysToKeep>0</daysToKeep>
+    <numToKeep>50</numToKeep>
+  </orphanedItemStrategy>
+  <triggers/>
+  <sources class="jenkins.branch.MultiBranchProject$BranchSourceList" plugin="branch-api@1.11.1">
+    <data>
+      <jenkins.branch.BranchSource>
+        <source class="org.jenkinsci.plugins.github_branch_source.GitHubSCMSource" plugin="github-branch-source@1.10">
+          <id>45dd6853-59d2-4695-80ac-4520f8a2b64f</id>
+          <checkoutCredentialsId>SAME</checkoutCredentialsId>
+          <scanCredentialsId>github-token-govuk-ci-username</scanCredentialsId>
+          <repoOwner>alphagov</repoOwner>
+          <repository><%= @repository %></repository>
+          <includes>*</includes>
+          <excludes></excludes>
+          <buildOriginBranch>true</buildOriginBranch>
+          <buildOriginBranchWithPR>true</buildOriginBranchWithPR>
+          <buildOriginPRMerge>true</buildOriginPRMerge>
+          <buildOriginPRHead>false</buildOriginPRHead>
+          <buildForkPRMerge>false</buildForkPRMerge>
+          <buildForkPRHead>false</buildForkPRHead>
+        </source>
+        <strategy class="jenkins.branch.DefaultBranchPropertyStrategy">
+          <properties class="empty-list"/>
+        </strategy>
+      </jenkins.branch.BranchSource>
+    </data>
+    <owner class="org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject" reference="../.."/>
+  </sources>
+  <factory class="org.jenkinsci.plugins.workflow.multibranch.WorkflowBranchProjectFactory">
+    <owner class="org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject" reference="../.."/>
+  </factory>
+</org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject>

--- a/modules/govuk_jenkins/manifests/config.pp
+++ b/modules/govuk_jenkins/manifests/config.pp
@@ -48,8 +48,7 @@
 #   List of admins that have "admin" permissions in Jenkins.
 #
 # [*manage_config*]
-#   Option to manage the Jenkins config or not. This is set so we do not
-#   overwrite configuration in live environments.
+#   Boolean option to manage the Jenkins configuration directory.
 #
 # [*version*]
 #   Specify the version of Jenkins
@@ -68,7 +67,7 @@ class govuk_jenkins::config (
   $github_client_id,
   $github_client_secret,
   $admins = [],
-  $manage_config = false,
+  $manage_config = true,
   $version = $govuk_jenkins::version,
 ) {
 


### PR DESCRIPTION
Add new define to create Pipeline jobs as exported resources from the application manifests. The jobs are collected in the govuk_ci class. The govuk_ci::master::jobs class should be removed if we follow this approach.

Change govuk_jenkins::config::manage_config default value to true.