### PR TITLE
Change default host to ipaddress_eth0 fact

### DIFF
--- a/modules/icinga/manifests/host.pp
+++ b/modules/icinga/manifests/host.pp
@@ -33,7 +33,7 @@
 #
 define icinga::host (
   $hostalias  = $::fqdn,
-  $address    = $::ipaddress,
+  $address    = $::ipaddress_eth0,
   $use        = 'generic-host',
   $host_name  = $::fqdn,
   $display_name = $::fqdn_short,


### PR DESCRIPTION
In a recent commit (8e9f59a34e7c3f698f8acc752edd8fadd7f9d8d2) we added Docker to a new machine.

Icinga reported this machine down despite it being up, available and accessible.

We discovered that the facter fact that sets the ipaddress for the Icinga host config takes the first ipv4 address reported in `ifconfig`: https://github.com/puppetlabs/facter/blob/3bdb78459193d16b58324abfd8a882e533cac42f/lib/facter/ipaddress.rb#L27-L44

The Docker interface that gets configured as part of the package appears first in `ifconfig` as it's named "docker0"; we're assuming that maybe `ifconfig` lists the interfaces in alphabetical order:

```
$ ifconfig
docker0   Link encap:Ethernet  HWaddr 02:42:4a:a4:28:6f
          inet addr:172.17.0.1  Bcast:0.0.0.0  Mask:255.255.0.0
          inet6 addr: fe80::42:4aff:fea4:286f/64 Scope:Link
          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
          RX packets:12191 errors:0 dropped:0 overruns:0 frame:0
          TX packets:12652 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:0
          RX bytes:286583616 (286.5 MB)  TX bytes:1511639 (1.5 MB)

eth0      Link encap:Ethernet  HWaddr 00:50:56:01:1c:e5
          inet addr:10.1.0.80  Bcast:10.1.0.255  Mask:255.255.255.0
          inet6 addr: fe80::250:56ff:fe01:1ce5/64 Scope:Link
          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
          RX packets:1847900 errors:0 dropped:1023 overruns:0 frame:0
          TX packets:919213 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:1000
          RX bytes:562780282 (562.7 MB)  TX bytes:789367635 (789.3 MB)
```

Our default interface for the machine will most likely be eth0, so we should set the default host address to this interface specifically:

```
$ facter ipaddress
172.17.0.1
$ facter ipaddress_eth0
10.1.0.80
```