### PR TITLE
Fix Jenkins job directory declaration

### DIFF
--- a/modules/govuk_ci/manifests/job.pp
+++ b/modules/govuk_ci/manifests/job.pp
@@ -18,7 +18,7 @@ define govuk_ci::job (
   $job_config_directory = '/var/lib/jenkins/jobs'
   $application_directory = "${job_config_directory}/${app}"
 
-  file { [ $job_config_directory, $application_directory ]:
+  file { $application_directory :
     ensure => directory,
     owner  => 'jenkins',
     group  => 'jenkins',


### PR DESCRIPTION
Puppet fails to run on CI because the Jenkins job directory is
declared in govuk_ci::job, and this code executes for each new
job that we create.