### PR TITLE
Make need-api use new Elasticsearch in integration

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -16,6 +16,7 @@ govuk::apps::errbit::errbit_email_from: 'govuk-winston+errbit-integration@digita
 govuk::apps::event_store::enabled: true
 govuk::apps::govuk_delivery::list_title_format: 'INTEGRATION: %s'
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
+govuk::apps::need_api::elasticsearch_hosts: 'api-elasticsearch-1.api:9200'
 govuk::apps::publicapi::backdrop_host: 'www.preview.performance.service.gov.uk'
 
 govuk::apps::smartanswers::expose_govspeak: true

--- a/modules/govuk/manifests/node/s_api_elasticsearch.pp
+++ b/modules/govuk/manifests/node/s_api_elasticsearch.pp
@@ -53,6 +53,25 @@ class govuk::node::s_api_elasticsearch inherits govuk::node::s_base {
     require => Govuk_host['calculators-frontend-3'],
   }
 
+  # FIXME: Remove these firewall rules by moving the need-api app from the backend
+  # machines to the API machines. The MongoDB database will need to move too.
+  # There are more firewall rules in govuk-provisioning that can also be removed.
+  @ufw::allow { 'allow-elasticsearch-http-9200-from-backend-1':
+    port    => 9200,
+    from    => getparam(Govuk_host['backend-1'], 'ip'),
+    require => Govuk_host['backend-1'],
+  }
+  @ufw::allow { 'allow-elasticsearch-http-9200-from-backend-2':
+    port    => 9200,
+    from    => getparam(Govuk_host['backend-2'], 'ip'),
+    require => Govuk_host['backend-2'],
+  }
+  @ufw::allow { 'allow-elasticsearch-http-9200-from-backend-3':
+    port    => 9200,
+    from    => getparam(Govuk_host['backend-3'], 'ip'),
+    require => Govuk_host['backend-3'],
+  }
+
   collectd::plugin::tcpconn { 'es-9200':
     incoming => 9200,
     outgoing => 9200,


### PR DESCRIPTION
# FIXME: Add firewall rules for need-api new Elasticsearch

We want to switch off the old Elasticsearch machine. This means that
we need to move need-api to the Elasticsearch in the API vDC.

Ideally we would do this by moving need-api to the API vDC:

- Deploy need-api to API machines
- Migrate database and repoint loadbalancers (simultaneously)

But that's a lot more work than just adding these firewall rules for now.

# Make need-api use new Elasticsearch in integration

The data will need to be reindexed on the new Elasticsearch once this
change is deployed.