### PR TITLE
Add support app env vars

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -460,6 +460,11 @@ govuk::apps::stagecraft::beat::enabled: true
 govuk::apps::stagecraft::celerycam::enabled: true
 govuk::apps::stagecraft::postgresql_db::api_ip_range: "%{hiera('environment_ip_prefix')}.4.0/24"
 
+govuk::apps::support::redis_host: "%{hiera('sidekiq_host')}"
+govuk::apps::support::redis_port: "%{hiera('sidekiq_port')}"
+govuk::apps::support::zendesk_anonymous_ticket_email: 'zd-api-public@digital.cabinet-office.gov.uk'
+govuk::apps::support::zendesk_client_username: 'zd-api-govt@digital.cabinet-office.gov.uk/token'
+
 govuk::apps::support_api::db_name: 'support_contacts_production'
 govuk::apps::support_api::db_hostname: 'postgresql-primary-1.backend'
 govuk::apps::support_api::db_password: "%{hiera('govuk::apps::support_api::db::password')}"

--- a/modules/govuk/manifests/apps/support.pp
+++ b/modules/govuk/manifests/apps/support.pp
@@ -1,7 +1,69 @@
-# FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
-class govuk::apps::support($port = '3031', $enable_procfile_worker = true) {
+# == Class: govuk::apps::support
+#
+# Provides forms that create Zendesk tickets from requests
+# coming from government agencies.
+#
+# === Parameters
+#
+# [*emergency_contact_details*]
+#   Emergency phone numbers and other contact details presented in this app.
+#
+# [*enable_procfile_worker*]
+#   Enables the sidekiq background worker.
+#   Default: true
+#
+# [*errbit_api_key*]
+#   Errbit API key used by airbrake
+#   Default: ''
+#
+# [*oauth_id*]
+#   Sets the OAuth ID
+#
+# [*oauth_secret*]
+#   Sets the OAuth Secret Key
+#
+# [*port*]
+#   The port that publishing API is served on.
+#   Default: 3093
+#
+# [*redis_host*]
+#   Redis host for Sidekiq.
+#   Default: undef
+#
+# [*redis_port*]
+#   Redis port for Sidekiq.
+#   Default: undef
+#
+# [*secret_key_base*]
+#   The key for Rails to use when signing/encrypting sessions.
+#
+# [*zendesk_anonymous_ticket_email*]
+#   Email address used for anonymous zendesk tickets.
+#
+# [*zendesk_client_password*]
+#   Password for connection to GDS zendesk client.
+#
+# [*zendesk_client_username*]
+#   Username for connection to GDS zendesk client.
+#
+class govuk::apps::support(
+  $emergency_contact_details = undef,
+  $errbit_api_key = undef,
+  $enable_procfile_worker = true,
+  $oauth_id = undef,
+  $oauth_secret = undef,
+  $port = '3031',
+  $redis_host = undef,
+  $redis_port = undef,
+  $secret_key_base = undef,
+  $zendesk_anonymous_ticket_email = undef,
+  $zendesk_client_password = undef,
+  $zendesk_client_username = undef,
+) {
 
-  govuk::app { 'support':
+  $app_name = 'support'
+
+  govuk::app { $app_name:
     app_type           => 'rack',
     port               => $port,
     vhost_ssl_only     => true,
@@ -23,7 +85,50 @@ class govuk::apps::support($port = '3031', $enable_procfile_worker = true) {
     asset_pipeline     => true,
   }
 
-  govuk::procfile::worker { 'support':
+  govuk::procfile::worker { $app_name:
     enable_service => $enable_procfile_worker,
+  }
+
+  Govuk::App::Envvar {
+    app => $app_name,
+  }
+
+  govuk::app::envvar::redis { $app_name:
+    host => $redis_host,
+    port => $redis_port,
+  }
+
+  $emergency_contact_details_json = inline_template(
+    '<%= @emergency_contact_details.to_json unless @emergency_contact_details.nil? %>')
+
+  govuk::app::envvar {
+    "${title}-EMERGENCY_CONTACT_DETAILS":
+      varname => 'EMERGENCY_CONTACT_DETAILS',
+      value   => $emergency_contact_details_json;
+    "${title}-ERRBIT_API_KEY":
+      varname => 'ERRBIT_API_KEY',
+      value   => $errbit_api_key;
+    "${title}-OAUTH_ID":
+      varname => 'OAUTH_ID',
+      value   => $oauth_id;
+    "${title}-OAUTH_SECRET":
+      varname => 'OAUTH_SECRET',
+      value   => $oauth_secret;
+    "${title}-ZENDESK_ANONYMOUS_TICKET_EMAIL":
+      varname => 'ZENDESK_ANONYMOUS_TICKET_EMAIL',
+      value   => $zendesk_anonymous_ticket_email;
+    "${title}-ZENDESK_CLIENT_PASSWORD":
+      varname => 'ZENDESK_CLIENT_PASSWORD',
+      value   => $zendesk_client_password;
+    "${title}-ZENDESK_CLIENT_USERNAME":
+      varname => 'ZENDESK_CLIENT_USERNAME',
+      value   => $zendesk_client_username;
+  }
+
+  if $secret_key_base != undef {
+    govuk::app::envvar { "${title}-SECRET_KEY_BASE":
+      varname => 'SECRET_KEY_BASE',
+      value   => $secret_key_base,
+    }
   }
 }


### PR DESCRIPTION
Part of https://trello.com/c/BrKRdn4f/495-rebuild-gov-uk-app-deployment-pipeline

Support is moving to the new deployment pipeline,
so configure the necessary environment variables for this app.
The emergency contact details are stored as an env var as JSON.

Depends on https://github.gds/gds/deployment/pull/1158