### PR TITLE
Create Pipeline jobs in CI from Hieradata

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -3,83 +3,96 @@ HIERA_SAFETY_CHECK: true
 
 app_domain: 'dev.gov.uk'
 
+# If the repository name is the same as the application name
+# we don't need to explicitly declare the repository, but we
+# need to add an empty hash
 deployable_applications: &deployable_applications
-  - asset-manager
-  - authenticating-proxy
-  - backdrop-read
-  - backdrop-write
-  - bouncer
-  - business-support-api
-  - businesssupportfinder
-  - calculators
-  - calendars
-  - collections
-  - collections-publisher
-  - contacts
-  - contacts-frontend
-  - content-store
-  - content-tagger
-  - courts-api
-  - courts-frontend
-  - designprinciples
-  - efg-training
-  - efg-training-rebuild
-  - email-alert-api
-  - email-alert-frontend
-  - email-alert-monitor
-  - email-alert-service
-  - errbit
-  - feedback
-  - finder-frontend
-  - frontend
-  - government-frontend
-  - govuk-delivery
-  - govuk-cdn-logs-monitor
-  - govuk_content_api
-  - govuk-content-schemas
-  - govuk_crawler_worker
-  - govuk_need_api
-  - hmrc-manuals-api
-  - imminence
-  - info-frontend
-  - kibana
-  - licencefinder
-  - local-links-manager
-  - manuals-frontend
-  - manuals-publisher
-  - mapit
-  - maslow
-  - metadata-api
-  - multipage-frontend
-  - panopticon
-  - performanceplatform-admin
-  - performanceplatform-big-screen-view
-  - policy-publisher
-  - publisher
-  - publishing-api
-  - release
-  - router
-  - router-api
-  - rummager
-  - search-admin
-  - service-manual-frontend
-  - service-manual-publisher
-  - share-sale-publisher
-  - short-url-manager
-  - sidekiq-monitoring
-  - signonotron2
-  - smartanswers
-  - smokey
-  - specialist-frontend
-  - specialist-publisher
-  - spotlight
-  - stagecraft
-  - static
-  - support
-  - support-api
-  - transition
-  - travel-advice-publisher
-  - whitehall
+  asset-manager: {}
+  authenticating-proxy: {}
+  backdrop-read:
+    repository: 'backdrop'
+  backdrop-write:
+    repository: 'backdrop'
+  bouncer: {}
+  business-support-api: {}
+  businesssupportfinder:
+    repository: 'business-support-finder'
+  calculators: {}
+  calendars: {}
+  collections: {}
+  collections-publisher: {}
+  contacts:
+    repository: 'contacts-admin'
+  contacts-frontend: {}
+  content-store: {}
+  content-tagger: {}
+  courts-api: {}
+  courts-frontend: {}
+  designprinciples:
+    repository: 'design-principles'
+  efg-training:
+    repository: 'EFG'
+  efg-training-rebuild:
+    repository: 'EFG'
+  email-alert-api: {}
+  email-alert-frontend: {}
+  email-alert-monitor: {}
+  email-alert-service: {}
+  errbit: {}
+  feedback: {}
+  finder-frontend: {}
+  frontend: {}
+  government-frontend: {}
+  govuk-delivery: {}
+  govuk-cdn-logs-monitor: {}
+  govuk_content_api: {}
+  govuk-content-schemas: {}
+  govuk_crawler_worker: {}
+  govuk_need_api: {}
+  hmrc-manuals-api: {}
+  imminence: {}
+  info-frontend: {}
+  kibana:
+    repository: 'kibana-gds'
+  licencefinder:
+    repository: 'licence-finder'
+  local-links-manager: {}
+  manuals-frontend: {}
+  manuals-publisher: {}
+  mapit: {}
+  maslow: {}
+  metadata-api: {}
+  multipage-frontend: {}
+  panopticon: {}
+  performanceplatform-admin: {}
+  performanceplatform-big-screen-view: {}
+  policy-publisher: {}
+  publisher: {}
+  publishing-api: {}
+  release: {}
+  router: {}
+  router-api: {}
+  rummager: {}
+  search-admin: {}
+  service-manual-frontend: {}
+  service-manual-publisher: {}
+  share-sale-publisher: {}
+  short-url-manager: {}
+  sidekiq-monitoring: {}
+  signonotron2: {}
+  smartanswers:
+    repository: 'smart-answers'
+  smokey: {}
+  specialist-frontend: {}
+  specialist-publisher: {}
+  spotlight: {}
+  stagecraft: {}
+  static: {}
+  support: {}
+  support-api: {}
+  transition: {}
+  travel-advice-publisher: {}
+  whitehall: {}
 
 apt_mirror_hostname: 'apt.production.alphagov.co.uk'
 
@@ -527,6 +540,8 @@ govuk_cdnlogs::service_port_map:
   govuk: 6514
   assets: 6515
   bouncer: 6516
+
+govuk_ci::master::pipeline_jobs: *deployable_applications
 
 govuk_crawler::amqp_host: 'localhost'
 govuk_crawler::site_root: 'https://www.gov.uk'

--- a/modules/govuk/manifests/apps/local_links_manager.pp
+++ b/modules/govuk/manifests/apps/local_links_manager.pp
@@ -134,7 +134,5 @@ class govuk::apps::local_links_manager(
       }
     }
 
-    @@govuk_ci::job { 'local-links-manager': }
-
   }
 }

--- a/modules/govuk_ci/manifests/master.pp
+++ b/modules/govuk_ci/manifests/master.pp
@@ -22,6 +22,7 @@ class govuk_ci::master (
   $ghe_vpn_username,
   $ghe_vpn_password,
   $jenkins_api_token,
+  $pipeline_jobs = {},
 ){
 
   include ::govuk_ci::credentials
@@ -40,8 +41,8 @@ class govuk_ci::master (
   # Add govuk-puppet job
   govuk_ci::job { 'govuk-puppet': }
 
-  # Collect exported jobs
-  Govuk_ci::Job <<| |>>
+  # Add pipeline jobs from applications hash in Hieradata
+  create_resources(govuk_ci::job, $pipeline_jobs)
 
   ufw::allow {'jenkins-slave-to-jenkins-master-on-tcp':
     port  => '32768:65535',

--- a/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
@@ -53,7 +53,7 @@
         - choice:
             name: TARGET_APPLICATION
             description: Application to deploy.
-            choices: <%= ['-- Choose an app'] + @applications %>
+            choices: <%= ['-- Choose an app'] + @applications.keys %>
         - choice:
             name: DEPLOY_TASK
             description: |

--- a/modules/govuk_jenkins/templates/jobs/integration_app_deploy.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/integration_app_deploy.yaml.erb
@@ -17,7 +17,7 @@
         - choice:
             name: TARGET_APPLICATION
             description: 'Application to deploy'
-            choices: <%= ['-- Choose an app'] + @applications %>
+            choices: <%= ['-- Choose an app'] + @applications.keys %>
         - string:
             name: TAG
             description: 'Git tag/committish to deploy.'

--- a/modules/govuk_jenkins/templates/jobs/run_rake_task.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/run_rake_task.yaml.erb
@@ -13,7 +13,7 @@
       - choice:
           name: TARGET_APPLICATION
           description: Choose the application to run the rake task in
-          choices: <%= ['-- Choose an app'] + @applications %>
+          choices: <%= ['-- Choose an app'] + @applications.keys %>
       - choice:
           name: MACHINE_CLASS
           description: Choose the machine class this app is running on


### PR DESCRIPTION
Update the CI implementation to generate the Pipeline jobs
from the applications parameter in Hieradata instead of exported
resources. We need to convert the applications parameter to hash
to work with the govuk_ci master class.