### PR TITLE
Remove graphite checks for the EFG we don't use

### DIFF
--- a/modules/govuk/manifests/apps/efg_rebuild.pp
+++ b/modules/govuk/manifests/apps/efg_rebuild.pp
@@ -93,14 +93,6 @@ class govuk::apps::efg_rebuild (
     ssl_only     => true,
   }
 
-  @@icinga::check::graphite { "check_efg_rebuild_login_failures_${::hostname}":
-    target    => "sumSeries(stats.govuk.app.${app_name}.*.logins.failure)",
-    warning   => 10,
-    critical  => 15,
-    desc      => 'EFG login failures',
-    host_name => $::fqdn,
-  }
-
   ramdisk { 'efg_rebuild_sqlite':
     ensure => present,
     path   => '/var/efg-rebuild-data',

--- a/modules/govuk/manifests/apps/efg_training_rebuild.pp
+++ b/modules/govuk/manifests/apps/efg_training_rebuild.pp
@@ -92,14 +92,6 @@ class govuk::apps::efg_training_rebuild (
     ssl_only     => true,
   }
 
-  @@icinga::check::graphite { "check_efg_training_rebuild_login_failures_${::hostname}":
-    target    => "sumSeries(stats.govuk.app.${app_name}.*.logins.failure)",
-    warning   => 10,
-    critical  => 15,
-    desc      => 'EFG_TRAINING login failures',
-    host_name => $::fqdn,
-  }
-
   ramdisk { 'efg_training_rebuild_sqlite':
     ensure => present,
     path   => '/var/efg-training-rebuild-data',


### PR DESCRIPTION
These are causing false positives in icinga. / @alexmuller 