### PR TITLE
Specify the interface to use for the ip address.

### DIFF
--- a/modules/puppet/templates/puppet_passive_check_update
+++ b/modules/puppet/templates/puppet_passive_check_update
@@ -1,5 +1,5 @@
 #!/bin/bash
 OUTPUT=`/usr/lib/nagios/plugins/check_puppet_agent`
 CODE=$?
-printf "<%= @ipaddress %>\tpuppet last run errors\t$CODE\t$OUTPUT\n" | /usr/sbin/send_nsca -H alert.cluster
+printf "<%= @ipaddress_eth0 %>\tpuppet last run errors\t$CODE\t$OUTPUT\n" | /usr/sbin/send_nsca -H alert.cluster
 exit $?


### PR DESCRIPTION
This currently breaks on hosts with a `docker0` interface as
that comes first and appears in the `ipaddress` fact. By explicitly picking
eth0, the address icinga knows about, the puppet run alerts should stop.