### PR TITLE
Jenkins swarm client

### DIFF
--- a/hieradata/class/ci_agent.yaml
+++ b/hieradata/class/ci_agent.yaml
@@ -9,3 +9,5 @@ postgresql::globals::version: '9.3'
 govuk_mysql::server::innodb_flush_log_at_trx_commit: 0
 
 govuk_elasticsearch::minimum_master_nodes: '1'
+
+govuk_ci::agent::swarm::swarm_client_url: 'https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/2.2/swarm-client-2.2-jar-with-dependencies.jar'

--- a/hieradata/node/ci-agent-1.ci.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/ci-agent-1.ci.integration.publishing.service.gov.uk.yaml
@@ -1,2 +1,8 @@
 ---
+govuk_ci::agent::swarm::agent_labels:
+  - 'elasticsearch-1.7.5'
+  - 'postgresql-9.3'
+  - 'mongodb-2.4'
+  - 'ubuntu-trusty'
+
 mongodb::server::version: '2.4.9'

--- a/modules/govuk_ci/manifests/agent.pp
+++ b/modules/govuk_ci/manifests/agent.pp
@@ -10,6 +10,7 @@ class govuk_ci::agent {
   include ::govuk_ci::agent::mongodb
   include ::govuk_ci::agent::postgresql
   include ::govuk_ci::agent::mysql
+  include ::govuk_ci::agent::swarm
   include ::govuk_java::oracle8
 
   ufw::allow { 'allow-jenkins-slave-swarm-to-listen-on-ephemeral-ports':

--- a/modules/govuk_ci/manifests/agent/swarm.pp
+++ b/modules/govuk_ci/manifests/agent/swarm.pp
@@ -1,0 +1,73 @@
+# Class govuk_ci::agent::swarm
+#
+# Joins a jenkins agent machine to a jenkins master/cluster by downloading and invoking the swarm client.
+#
+# note: The jenkins master requires the swarm plugin before an agent can be assigned with this class.
+#       This class requires an associated API user to be created on the jenkins master. After the user
+#       has been created, you'll need to retrieve the user's API token. The API token is used in place of a
+#       a password to authenticate a jenkins user with the jenkins master. An API token can be
+#       found in the jenkins UI under the user's profile 'http://<JENKINS HOST>:<PORT>/user/<USERNAME>/configure'
+#
+# === Parameters
+#
+# [*swarm_user*]
+#   The that invokes the swarm client
+#
+# [*agent_labels*]
+#   The agent labels advertise what resources a particular jenkins agent has available.
+#   This is useful if you wanted to isolate a job/task to a jenkins agent to
+#   make use of any unique resouces/dependencies a particular jenkins agent may offer.
+#
+# [*discovery_addr*]
+#   The broadcast IP address of an interface.  The swarm client uses udp to discovery to
+#   discover a jenkins master on the network.
+#
+# [*agent_user_api_token*]
+#   Used to authenticate a jenkins user with the jenkisn master.  The user is defined in:
+#   'govuk_ci::master' as an 'govuk_jenkins::api_user' type.
+#
+# [*swarm_client_dest*]
+#   Path to the swarm client binary.
+#
+# [*swarm_client_url*]
+#   The download link of the swarm client binary.
+#
+class govuk_ci::agent::swarm(
+  $swarm_user           = 'jenkins',
+  $agent_labels         = [],
+  $discovery_addr       = '10.1.6.255',
+  $agent_user_api_token = undef,     # Corresponding user: 'agent_user'
+  $swarm_client_dest    = '/home/jenkins/swarm-client-2.2-jar-with-dependencies.jar',
+  $swarm_client_url     = undef,
+) {
+
+  include ::curl
+
+  validate_array($agent_labels)
+  $labels = join($agent_labels, ' ') # Convert the Hiera array to a space separated list
+
+  user { $swarm_user :
+    comment    => 'I run the jenkins swarm client',
+    managehome => true,
+    shell      => '/bin/sh',
+  }
+
+  ::curl::fetch { 'swarm_client':
+    source      => $swarm_client_url,
+    destination => $swarm_client_dest,
+    timeout     => 10,
+    verbose     => false,
+    require     => User['jenkins'],
+  }
+
+  # Upstart script to manage process
+  file {'jenkins-agent.conf':
+    ensure  => file,
+    path    => '/etc/init/jenkins-agent.conf',
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0700',
+    content => template('govuk_ci/jenkins-agent.conf.erb'),
+  }
+
+}

--- a/modules/govuk_ci/manifests/master.pp
+++ b/modules/govuk_ci/manifests/master.pp
@@ -16,6 +16,9 @@
 # [*ghe_vpn_password*]
 #   The password to authenticate against the Github Enterprise VPN
 #
+# [*agent_user*]
+#   The user account used by jenkins agents authenticate with the jenkins master
+#
 class govuk_ci::master (
   $github_client_id,
   $github_client_secret,
@@ -23,9 +26,12 @@ class govuk_ci::master (
   $ghe_vpn_password,
   $jenkins_api_token,
   $pipeline_jobs = {},
+  $agent_user = 'agent_user',
 ){
 
   include ::govuk_ci::credentials
+
+  ::govuk_jenkins::api_user { $agent_user: }
 
   class { '::govuk_jenkins':
     github_client_id     => $github_client_id,

--- a/modules/govuk_ci/spec/classes/govuk_ci_swarm_spec.rb
+++ b/modules/govuk_ci/spec/classes/govuk_ci_swarm_spec.rb
@@ -1,0 +1,16 @@
+require_relative '../../../../spec_helper'
+
+describe 'govuk_ci::agent::swarm', :type => :class do
+
+  let(:params) {{
+      :agent_labels => [
+          'earth',
+          'mars',
+          'saturn',
+      ]
+  }}
+
+  context 'The jenkins upstart configuration file' do
+    it { is_expected.to contain_file('jenkins-agent.conf').with_path('/etc/init/jenkins-agent.conf').with_content(/'earth\smars\ssaturn'/) }
+  end
+end

--- a/modules/govuk_ci/templates/jenkins-agent.conf.erb
+++ b/modules/govuk_ci/templates/jenkins-agent.conf.erb
@@ -1,0 +1,13 @@
+start on runlevel [2345]
+stop on runlevel [!2345]
+
+script
+        test -f /etc/default/locale && . /etc/default/locale || true
+        export LANG
+        exec start-stop-daemon --start -c jenkins --exec /usr/bin/java \
+                --name jenkins-agent --  -jar <%= @swarm_client_dest %> \
+                -username agent -password <%= @agent_user_api_token %> \
+                -name <%= @hostname %> -executors 2 \
+                -autoDiscoveryAddress <%= @discovery_addr %> \
+                -fsroot /home/jenkins -labels '<%= @labels %>'
+end script


### PR DESCRIPTION
This commit adds the functionality to connect a Jenkins agent to a Jenkins master with the swarm client.

The swarm client will run on Jenkins agents as an upstart service.

The discovery address is hard coded as a temporary measure until we have a fact to resolve.

At the moment if we wanted to use another version of the swarm client.  We would have to reflect the change in two places with class parameters `$swarm_client_dest` and `$swarm_client_url`.

There is one manual step where we have to retrieve the api_token for the user we're authenticating against the Jenkins master with.
To automate this would mean opening up a potential security hole.
See: [jenkins.security.ApiTokenProperty.showTokenToAdmins](https://wiki.jenkins-ci.org/display/JENKINS/Features+controlled+by+system+properties)