### PR TITLE
Jenkins swarm client

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -542,6 +542,7 @@ govuk_cdnlogs::service_port_map:
   bouncer: 6516
 
 govuk_ci::master::pipeline_jobs: *deployable_applications
+govuk_ci::agent::swarm::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 govuk_crawler::amqp_host: 'localhost'
 govuk_crawler::site_root: 'https://www.gov.uk'

--- a/hieradata/node/ci-agent-1.ci.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/ci-agent-1.ci.integration.publishing.service.gov.uk.yaml
@@ -1,2 +1,8 @@
 ---
+govuk_ci::agent::swarm::agent_labels:
+  - 'elasticsearch-1.7.5'
+  - 'postgresql-9.3'
+  - 'mongodb-2.4'
+  - 'ubuntu-trusty'
+
 mongodb::server::version: '2.4.9'

--- a/modules/govuk/manifests/node/s_apt.pp
+++ b/modules/govuk/manifests/node/s_apt.pp
@@ -98,6 +98,7 @@ class govuk::node::s_apt (
   aptly::repo { 'gof3r': }
   aptly::repo { 'gor': }
   aptly::repo { 'govuk-jenkins': }
+  aptly::repo { 'jenkins-agent': }
   aptly::repo { 'rbenv-ruby': }
   aptly::repo { 'terraform': }
 

--- a/modules/govuk_ci/manifests/agent.pp
+++ b/modules/govuk_ci/manifests/agent.pp
@@ -10,6 +10,7 @@ class govuk_ci::agent {
   include ::govuk_ci::agent::mongodb
   include ::govuk_ci::agent::postgresql
   include ::govuk_ci::agent::mysql
+  include ::govuk_ci::agent::swarm
   include ::govuk_java::oracle8
 
   ufw::allow { 'allow-jenkins-slave-swarm-to-listen-on-ephemeral-ports':

--- a/modules/govuk_ci/manifests/agent/swarm.pp
+++ b/modules/govuk_ci/manifests/agent/swarm.pp
@@ -1,0 +1,94 @@
+# Class govuk_ci::agent::swarm
+#
+# Joins a jenkins agent machine to a jenkins master/cluster by downloading and invoking the swarm client.
+#
+# note: The jenkins master requires the swarm plugin before an agent can be assigned with this class.
+#       This class requires an associated API user to be created on the jenkins master. After the user
+#       has been created, you'll need to retrieve the user's API token. The API token is used in place of a
+#       a password to authenticate a jenkins user with the jenkins master. An API token can be
+#       found in the jenkins UI under the user's profile 'http://<JENKINS HOST>:<PORT>/user/<USERNAME>/configure'
+#
+# === Parameters
+#
+# [*swarm_user*]
+#   The user that invokes the swarm client
+#
+# [*agent_labels*]
+#   The agent labels advertise what resources a particular jenkins agent has available.
+#   This is useful if you wanted to isolate a job/task to a jenkins agent to
+#   make use of any unique resouces/dependencies a particular jenkins agent may offer.
+#
+# [*discovery_addr*]
+#   The broadcast IP address of an interface.  The swarm client uses udp to discovery to
+#   discover a jenkins master on the network.
+#
+# [*agent_user_api_token*]
+#   Used to authenticate a jenkins user with the jenkisn master.  The user is defined in:
+#   'govuk_ci::master' as an 'govuk_jenkins::api_user' type.
+#
+#   By default, in newer versions of Jenkins you will be unable to view another
+#   users token. To get past this, temporarily set the following as an argument under
+#   JAVA_ARGS in the init.d script and restart the Jenkins service:
+#
+#   "-Djenkins.security.ApiTokenProperty.showTokenToAdmins=true"
+#
+#   Ref: https://wiki.jenkins-ci.org/display/JENKINS/Features+controlled+by+system+properties
+#
+# [*swarm_client_package*]
+#   The name of the package in our ppa (aptly repo). It also represents the name of the ppa.
+#
+# [*swarm_client_dest*]
+#   Path to the swarm client binary.
+#
+# [*apt_mirror_hostname*]
+#   The base url of the ppa. The value can be found in hiera
+#
+class govuk_ci::agent::swarm(
+  $swarm_user           = 'jenkins',
+  $agent_labels         = [],
+  $discovery_addr       = '10.1.6.255',
+  $agent_user_api_token = undef,     # Corresponding user: 'jenkins_agent'
+  $swarm_client_package = 'jenkins-agent',
+  $swarm_client_dest    = '/usr/local/bin/jenkins-agent',
+  $apt_mirror_hostname  = undef,
+) {
+
+  validate_array($agent_labels)
+  $labels = join($agent_labels, ' ') # Convert the Hiera array to a space separated list
+
+  user { $swarm_user :
+    comment    => 'I run the jenkins swarm client',
+    managehome => true,
+    shell      => '/bin/sh',
+  }
+
+  # The apt source which hosts the package
+  apt::source { $swarm_client_package :
+    location => "http://${apt_mirror_hostname}/${$swarm_client_package}",
+    release  => $::lsbdistcodename,
+    key      => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+  }
+
+  package { $swarm_client_package :
+    ensure  => '2.2',
+    require => Apt::Source[$swarm_client_package],
+  }
+
+  # Upstart script to manage process
+  file {'jenkins-agent.conf':
+    ensure  => file,
+    path    => '/etc/init/jenkins-agent.conf',
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0700',
+    content => template('govuk_ci/jenkins-agent.conf.erb'),
+    require => Package[$swarm_client_package],
+  }
+
+  service { $swarm_client_package :
+    ensure   => running,
+    provider => upstart,
+    require  => File['jenkins-agent.conf'],
+  }
+
+}

--- a/modules/govuk_ci/spec/classes/govuk_ci_swarm_spec.rb
+++ b/modules/govuk_ci/spec/classes/govuk_ci_swarm_spec.rb
@@ -1,0 +1,16 @@
+require_relative '../../../../spec_helper'
+
+describe 'govuk_ci::agent::swarm', :type => :class do
+
+  let(:params) {{
+      :agent_labels => [
+          'earth',
+          'mars',
+          'saturn',
+      ]
+  }}
+
+  context 'The jenkins upstart configuration file' do
+    it { is_expected.to contain_file('jenkins-agent.conf').with_path('/etc/init/jenkins-agent.conf').with_content(/'earth\smars\ssaturn'/) }
+  end
+end

--- a/modules/govuk_ci/templates/jenkins-agent.conf.erb
+++ b/modules/govuk_ci/templates/jenkins-agent.conf.erb
@@ -1,0 +1,13 @@
+start on runlevel [2345]
+stop on runlevel [!2345]
+
+script
+        test -f /etc/default/locale && . /etc/default/locale || true
+        export LANG
+        exec start-stop-daemon --start -c jenkins --exec /usr/bin/java \
+                --name jenkins-agent --  -jar <%= @swarm_client_dest %> \
+                -username jenkins_agent -password <%= @agent_user_api_token %> \
+                -name <%= @hostname %> -executors 2 \
+                -autoDiscoveryAddress <%= @discovery_addr %> \
+                -fsroot /home/jenkins -labels '<%= @labels %>'
+end script


### PR DESCRIPTION
This commit adds the functionality to connect a Jenkins agent to a Jenkins master with the swarm client.

The swarm client will run on Jenkins agents as an upstart service.

The discovery address is hard coded as a temporary measure until we have a fact to resolve.

At the moment if we wanted to use another version of the swarm client.  We would have to reflect the change in two places with class parameters `$swarm_client_dest` and `$swarm_client_url`.

There is one manual step where we have to retrieve the api_token for the user we're authenticating against the Jenkins master with.
To automate this would mean opening up a potential security hole.
See: [jenkins.security.ApiTokenProperty.showTokenToAdmins](https://wiki.jenkins-ci.org/display/JENKINS/Features+controlled+by+system+properties)

Requires: https://github.com/alphagov/govuk-puppet/pull/5131, https://github.com/alphagov/packager/pull/121