### PR TITLE
Remove unneeded join

### DIFF
--- a/modules/icinga/files/usr/lib/nagios/plugins/check_rabbitmq_watermark
+++ b/modules/icinga/files/usr/lib/nagios/plugins/check_rabbitmq_watermark
@@ -157,7 +157,7 @@ for my $check (@checks) {
     }
 }
 
-my($code, $message) = $p->check_messages(join_all=>', ');
+my($code, $message) = $p->check_messages();
 $p->nagios_exit(
     return_code => $code,
     message => $message


### PR DESCRIPTION
The nagios plugin library check_messages method returns a
collection of all errors and, if none are present, returns all the 'OKs'.
The explicit join seems to be forcing all messages to be collected and joined.
This causes the alert to show all checks, including the passing ones, as failing
if *any* of the checks fail.