### PR TITLE
Jenkins agent_user

### DIFF
--- a/modules/govuk_ci/manifests/master.pp
+++ b/modules/govuk_ci/manifests/master.pp
@@ -27,6 +27,9 @@ class govuk_ci::master (
 
   include ::govuk_ci::credentials
 
+  # After these users have been created, you'll have to retrieve the API token from the UI
+  ::govuk_jenkins::api_user { 'jenkins_agent': }
+
   class { '::govuk_jenkins':
     github_client_id     => $github_client_id,
     github_client_secret => $github_client_secret,


### PR DESCRIPTION
This user is required for Jenkins agents to authenticate with Jenkins master

relates to https://github.com/alphagov/govuk-puppet/pull/5128