### PR TITLE
Add fake backend-3 to hieradata

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -731,6 +731,10 @@ hosts::production::backend::hosts:
     ip: '10.1.3.2'
   backend-2:
     ip: '10.1.3.3'
+  # FIXME: This machine doesn't exist, but this host entry
+  # is depended upon by s_api_elasticsearch. We should fix that.
+  backend-3:
+    ip: '10.1.3.4'
   backend-lb-1:
     ip: '10.1.3.101'
   backend-lb-2:


### PR DESCRIPTION
This is similar to what we do with the calculators-frontend-3 and search-3 machines in integration. I don't like it but I don't have a better suggestion right now.