### PR TITLE
Enable Jenkins user to run sudo tests on CI

### DIFF
--- a/modules/govuk_ci/manifests/agent.pp
+++ b/modules/govuk_ci/manifests/agent.pp
@@ -18,4 +18,9 @@ class govuk_ci::agent {
     ip    => 'any',
   }
 
+  # Override sudoers.d resource (managed by sudo module) to enable Jenkins user to run sudo tests
+  File<|title == '/etc/sudoers.d/'|> {
+    mode => '0555',
+  }
+
 }

--- a/modules/govuk_ci/manifests/master.pp
+++ b/modules/govuk_ci/manifests/master.pp
@@ -56,4 +56,9 @@ class govuk_ci::master (
     ip    => 'any',
   }
 
+  # Override sudoers.d resource (managed by sudo module) to enable Jenkins user to run sudo tests
+  File<|title == '/etc/sudoers.d/'|> {
+    mode => '0555',
+  }
+
 }


### PR DESCRIPTION
The sudoers.d directory is managed by the sudo module, by default
the Jenkins user can't read the directory so Rake tests are failing
on the new CI boxes.

In this commit we override the resource in the master and agent
classes, eventually we can remove the override from the master.