### PR TITLE
Use the ipaddress_eth0 fact

### DIFF
--- a/modules/rkhunter/templates/rkhunter-passive-check.erb
+++ b/modules/rkhunter/templates/rkhunter-passive-check.erb
@@ -9,5 +9,5 @@ fi
 if [ $CODE -gt 0 ]; then
   CODE=1
 fi
-printf "<%= @ipaddress %>\trkhunter warnings\t$CODE\t$OUTPUT\n" | /usr/sbin/send_nsca -H alert.cluster >/dev/null
+printf "<%= @ipaddress_eth0 %>\trkhunter warnings\t$CODE\t$OUTPUT\n" | /usr/sbin/send_nsca -H alert.cluster >/dev/null
 exit $?


### PR DESCRIPTION
Docker machines are returning the docker interface ip, not the eth0 one,
which does not match the address icinga expects so the check remains
"unfresh"