### PR TITLE
Add env vars to whitehall

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -314,6 +314,15 @@ govuk::apps::publisher::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::short_url_manager::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::short_url_manager::redis_port: "%{hiera('sidekiq_port')}"
 
+govuk::apps::whitehall::admin_db_hostname: whitehall-master.mysql
+govuk::apps::whitehall::admin_key_space_limit: '262144'
+govuk::apps::whitehall::admin_db_name: whitehall_production
+govuk::apps::whitehall::admin_db_password: "%{hiera('govuk::apps::whitehall::db::mysql_whitehall_admin')}"
+govuk::apps::whitehall::admin_db_username: whitehall
+govuk::apps::whitehall::db_hostname: whitehall-slave.mysql
+govuk::apps::whitehall::db_name: whitehall_production
+govuk::apps::whitehall::db_password: "%{hiera('govuk::apps::whitehall::db::mysql_whitehall')}"
+govuk::apps::whitehall::db_username: whitehall_fe
 govuk::apps::whitehall::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::whitehall::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::whitehall::procfile_worker_process_count: 2

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -25,6 +25,8 @@ govuk::apps::specialist_publisher::publish_pre_production_finders: true
 govuk::apps::support_api::pp_data_url: 'https://www.preview.performance.service.gov.uk'
 govuk::apps::travel_advice_publisher::enable_email_alerts: true
 govuk::apps::url_arbiter::db::backend_ip_range: '10.1.3.0/24'
+govuk::apps::whitehall::basic_auth_credentials: "%{hiera('http_username')}:%{hiera('http_password')}"
+govuk::apps::whitehall::highlight_words_to_avoid: true
 
 govuk::deploy::aws_ses_smtp_host: 'email-smtp.eu-west-1.amazonaws.com'
 govuk::deploy::config::errbit_environment_name: 'integration'

--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -6,15 +6,85 @@
 #
 # FIXME: Document all class parameters
 #
-# [*prevent_single_host*]
-#   This manifest will deliberately fail if the frontend and admin are on the
-#   same machine and this flag is not set in hiera
+# [*admin_db_hostname*]
+#   The hostname of the admin database server to use in the DATABASE_URL.
+#
+# [*admin_db_name*]
+#   The database name to use in the admin DATABASE_URL.
+#
+# [*admin_db_password*]
+#   The password for the admin database.
+#
+# [*admin_db_username*]
+#   The username to use in the admin DATABASE_URL.
+#
+# [*admin_key_space_limit*]
+#   Rack limit for how many form parameters it will parse.
+#   Default: undef
+#
+# [*basic_auth_credentials*]
+#   Basic auth credentials (necessary for LinkChecker config) used
+#   by some environments.
+#   Default: undef
+#
+# [*db_hostname*]
+#   The hostname of the database server to use in the DATABASE_URL.
+#
+# [*db_name*]
+#   The database name to use in the DATABASE_URL.
+#
+# [*db_password*]
+#   The password for the database.
+#
+# [*db_username*]
+#   The username to use in the DATABASE_URL.
+#
+# [*errbit_api_key*]
+#   Errbit API key used by airbrake
+#   Default: undef
+#
+# [*errbit_api_key*]
+#   Errbit API key used by airbrake
+#   Default: undef
+#
+# [*highlight_words_to_avoid*]
+#   Boolean to turn on active highlighting of words to avoid.
+#   Default: false
 #
 # [*nagios_memory_warning*]
 #   Memory use at which Nagios should generate a warning.
 #
 # [*nagios_memory_critical*]
 #   Memory use at which Nagios should generate a critical alert.
+#
+# [*need_api_bearer_token*]
+#   The bearer token to use when communicating with Need API.
+#   Default: undef
+#
+# [*oauth_id*]
+#   Sets the OAuth ID for using GDS-SSO
+#   Default: undef
+#
+# [*oauth_secret*]
+#   Sets the OAuth Secret Key for using GDS-SSO
+#   Default: undef
+#
+# [*panopticon_bearer_token*]
+#   The bearer token to use when communicating with Panopticon.
+#   Default: undef
+#
+# [*port*]
+#   The port where the Rails app is running.
+#   Default: 3020
+#
+# [*prevent_single_host*]
+#   This manifest will deliberately fail if the frontend and admin are on the
+#   same machine and this flag is not set in hiera
+#   Default: true
+#
+# [*publishing_api_bearer_token*]
+#   The bearer token to use when communicating with Publishing API.
+#   Default: undef
 #
 # [*redis_host*]
 #   Redis host for Sidekiq.
@@ -24,25 +94,54 @@
 #   Redis port for Sidekiq.
 #   Default: undef
 #
+# [*secret_key_base*]
+#   The key for Rails to use when signing/encrypting sessions.
+#   Default: undef
+#
 class govuk::apps::whitehall(
-  $vhost = 'whitehall',
-  $port = '3020',
+  $admin_db_name = undef,
+  $admin_db_hostname = undef,
+  $admin_db_password = undef,
+  $admin_db_username = undef,
+  $admin_key_space_limit = undef,
+  $basic_auth_credentials = undef,
   $configure_frontend = false,
   $configure_admin = false,
-  $vhost_protected,
+  $db_name = undef,
+  $db_hostname = undef,
+  $db_password = undef,
+  $db_username = undef,
+  $enable_procfile_worker = true,
+  $errbit_api_key = undef,
+  $highlight_words_to_avoid = false,
   $nagios_memory_warning = undef,
   $nagios_memory_critical = undef,
+  $need_api_bearer_token = undef,
+  $oauth_id = undef,
+  $oauth_secret = undef,
+  $port = '3020',
+  $panopticon_bearer_token = undef,
   $prevent_single_host = true,
-  $enable_procfile_worker = true,
+  $procfile_worker_process_count = 1,
   $publishing_api_bearer_token = undef,
   $redis_host = undef,
   $redis_port = undef,
-  $procfile_worker_process_count = 1,
+  $secret_key_base = undef,
+  $vhost = 'whitehall',
+  $vhost_protected,
 ) {
 
+  $app_name = 'whitehall'
   $app_domain = hiera('app_domain')
 
   $health_check_path = '/healthcheck'
+
+  # The number of worker processes differs for frontend vs. backend configs.
+  if $configure_frontend {
+    $unicorn_worker_processes = 8
+  } else {
+    $unicorn_worker_processes = 4
+  }
 
   validate_bool($prevent_single_host)
   if $prevent_single_host {
@@ -51,7 +150,7 @@ class govuk::apps::whitehall(
     }
   }
 
-  govuk::app { 'whitehall':
+  govuk::app { $app_name:
     app_type               => 'rack',
     vhost                  => $vhost,
     port                   => $port,
@@ -65,6 +164,10 @@ class govuk::apps::whitehall(
     nagios_memory_critical => $nagios_memory_critical,
     unicorn_herder_timeout => 45,
     require                => Package['unzip'],
+  }
+
+  Govuk::App::Envvar {
+    app => $app_name,
   }
 
   if $configure_frontend == true {
@@ -81,6 +184,16 @@ class govuk::apps::whitehall(
         proxy_pass https://whitehall-admin.${app_domain};
       }
       ",
+    }
+
+    if $::govuk_node_class != 'development' {
+      govuk::app::envvar::database_url { $app_name:
+        type     => 'mysql',
+        username => $db_username,
+        password => $db_password,
+        host     => $db_hostname,
+        database => $db_name,
+      }
     }
   }
 
@@ -192,7 +305,7 @@ class govuk::apps::whitehall(
     }
 
     govuk::procfile::worker { 'whitehall-admin':
-      setenv_as      => 'whitehall',
+      setenv_as      => $app_name,
       enable_service => $enable_procfile_worker,
       process_count  => $procfile_worker_process_count,
     }
@@ -200,7 +313,7 @@ class govuk::apps::whitehall(
     # FIXME: Remove this when Whitehall is using Rack 1.7
     govuk::app::envvar {
       "${title}-RACK_MULTIPART_PART_LIMIT":
-          app     => 'whitehall',
+          app     =>  $app_name,
           varname => 'RACK_MULTIPART_PART_LIMIT',
           value   => '0';
     }
@@ -209,9 +322,34 @@ class govuk::apps::whitehall(
     # in production and development. (This is needed for IE8)
     govuk::app::envvar {
       "${title}-GOVUK_ASSET_ROOT":
-        app     => 'whitehall',
+        app     => $app_name,
         varname => 'GOVUK_ASSET_ROOT',
         value   => "//whitehall-admin.${app_domain}";
+      "${title}-HIGHLIGHT_WORDS_TO_AVOID":
+        varname => 'HIGHLIGHT_WORDS_TO_AVOID',
+        value   => bool2str($highlight_words_to_avoid);
+      "${title}-KEY_SPACE_LIMIT":
+        varname => 'KEY_SPACE_LIMIT',
+        value   => $admin_key_space_limit;
+      "${title}-OAUTH_ID":
+        varname => 'OAUTH_ID',
+        value   => $oauth_id;
+      "${title}-OAUTH_SECRET":
+        varname => 'OAUTH_SECRET',
+        value   => $oauth_secret;
+      "${title}-PANOPTICON_BEARER_TOKEN":
+        varname => 'PANOPTICON_BEARER_TOKEN',
+        value   => $panopticon_bearer_token;
+    }
+
+    if $::govuk_node_class != 'development' {
+      govuk::app::envvar::database_url { $app_name:
+        type     => 'mysql',
+        username => $admin_db_username,
+        password => $admin_db_password,
+        host     => $admin_db_hostname,
+        database => $admin_db_name,
+      }
     }
   }
 
@@ -221,9 +359,32 @@ class govuk::apps::whitehall(
   }
 
   govuk::app::envvar {
+    "${title}-ERRBIT_API_KEY":
+      varname => 'ERRBIT_API_KEY',
+      value   => $errbit_api_key;
+    "${title}-NEED_API_BEARER_TOKEN":
+      varname => 'NEED_API_BEARER_TOKEN',
+      value   => $need_api_bearer_token;
     "${title}-PUBLISHING_API_BEARER_TOKEN":
-      app     => 'whitehall',
       varname => 'PUBLISHING_API_BEARER_TOKEN',
       value   => $publishing_api_bearer_token;
+    "${title}-UNICORN_WORKER_PROCESSES":
+      varname => 'UNICORN_WORKER_PROCESSES',
+      value   => $unicorn_worker_processes;
+  }
+
+  if $basic_auth_credentials != undef {
+    govuk::app::envvar {
+      "${title}-BASIC_AUTH_CREDENTIALS":
+        varname => 'BASIC_AUTH_CREDENTIALS',
+        value   => $basic_auth_credentials;
+    }
+  }
+
+  if $secret_key_base != undef {
+    govuk::app::envvar { "${title}-SECRET_KEY_BASE":
+      varname => 'SECRET_KEY_BASE',
+      value   => $secret_key_base,
+    }
   }
 }


### PR DESCRIPTION
Part of https://trello.com/c/BrKRdn4f/495-rebuild-gov-uk-app-deployment-pipeline

Moving Whitehall to newer deployment pipeline, so adds database url config for admin and frontend versions of this application plus redis, panopticon, need API and some secret key base values.

Depends on https://github.gds/gds/deployment/pull/1161