### PR TITLE
Manage config and create views CI

### DIFF
--- a/hieradata/class/ci_master.yaml
+++ b/hieradata/class/ci_master.yaml
@@ -1,6 +1,14 @@
 ---
-# FIXME: This should be set to true once this Jenkins instance is set up.
-govuk_jenkins::config::manage_config: false
+govuk_jenkins::config::banner_colour_background: '#009ACD'
+govuk_jenkins::config::banner_colour_text: 'black'
+govuk_jenkins::config::banner_string: 'Carrenza CI'
+govuk_jenkins::config::theme_colour: '#009ACD'
+govuk_jenkins::config::theme_text_colour: 'black'
+govuk_jenkins::config::theme_environment_name: 'CI'
+govuk_jenkins::config::views:
+  GOVUK_Infrastructure:
+    - 'govuk-puppet'
+    - 'integration-puppet-deploy'
 
 govuk_jenkins::version: '2.19.2'
 

--- a/modules/govuk_jenkins/manifests/config.pp
+++ b/modules/govuk_jenkins/manifests/config.pp
@@ -44,6 +44,9 @@
 # [*theme_environiment_name*]
 #   The environment name that is shown in Jenkins.
 #
+# [*views*]
+#   Create a "list view" which contains specified jobs.
+#
 # [*admins*]
 #   List of admins that have "admin" permissions in Jenkins.
 #
@@ -62,6 +65,7 @@ class govuk_jenkins::config (
   $theme_colour = '#222',
   $theme_text_colour = 'white',
   $theme_environment_name = 'Jenkins',
+  $views = {},
   $github_web_uri,
   $github_api_uri,
   $github_client_id,
@@ -72,6 +76,7 @@ class govuk_jenkins::config (
 ) {
 
   validate_array($admins)
+  validate_hash($views)
 
   if $manage_config {
 

--- a/modules/govuk_jenkins/templates/config/config.xml.erb
+++ b/modules/govuk_jenkins/templates/config/config.xml.erb
@@ -101,6 +101,32 @@
       <filterQueue>false</filterQueue>
       <properties class="hudson.model.View$PropertyList"/>
     </hudson.model.AllView>
+    <%- @views.each do |key, value| -%>
+    <listView>
+      <owner class="hudson" reference="../../.."/>
+      <name><%= key %></name>
+      <filterExecutors>false</filterExecutors>
+      <filterQueue>false</filterQueue>
+      <properties class="hudson.model.View$PropertyList"/>
+      <jobNames>
+        <comparator class="hudson.util.CaseInsensitiveComparator"/>
+    <%- value.each do |app| -%>
+        <string><%= app %></string>
+    <%- end -%>
+      </jobNames>
+      <jobFilters/>
+      <columns>
+        <hudson.views.StatusColumn/>
+        <hudson.views.WeatherColumn/>
+        <hudson.views.JobColumn/>
+        <hudson.views.LastSuccessColumn/>
+        <hudson.views.LastFailureColumn/>
+        <hudson.views.LastDurationColumn/>
+        <hudson.views.BuildButtonColumn/>
+      </columns>
+      <recurse>false</recurse>
+    </listView>
+    <%- end -%>
   </views>
   <primaryView>All</primaryView>
   <slaveAgentPort>0</slaveAgentPort>


### PR DESCRIPTION
On the current CI Jenkins there are lots of views to help manage the number of jobs in that environment.

This creates an easy way to manage these views now we create all the jobs someway or another in Puppet. 

It also means we're now managing the configuration for CI Jenkins.