### PR TITLE
CI Jenkins api_user

### DIFF
--- a/modules/govuk_ci/manifests/master.pp
+++ b/modules/govuk_ci/manifests/master.pp
@@ -28,7 +28,7 @@ class govuk_ci::master (
   include ::govuk_ci::credentials
 
   # After these users have been created, you'll have to retrieve the API token from the UI
-  ::govuk_jenkins::api_user { 'jenkins_agent': }
+  govuk_jenkins::api_user { 'jenkins_agent': }
 
   class { '::govuk_jenkins':
     github_client_id     => $github_client_id,


### PR DESCRIPTION
Removing absolute path from defined type.  Defining the absolute path on a defined type
prevents it from being applied.