### PR TITLE
Add architecture to apt source

### DIFF
--- a/modules/govuk_ci/manifests/agent/swarm.pp
+++ b/modules/govuk_ci/manifests/agent/swarm.pp
@@ -64,9 +64,10 @@ class govuk_ci::agent::swarm(
 
   # The apt source which hosts the package
   apt::source { $swarm_client_package :
-    location => "http://${apt_mirror_hostname}/${$swarm_client_package}",
-    release  => $::lsbdistcodename,
-    key      => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+    location     => "http://${apt_mirror_hostname}/${$swarm_client_package}",
+    release      => 'trusty',
+    architecture => $::architecture,
+    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
   }
 
   package { $swarm_client_package :


### PR DESCRIPTION
This error was appearing when trying to run an apt-get update:

```
W: Failed to fetch
http://apt.production.alphagov.co.uk/jenkins-agent/dists/trusty/InRelease
Unable to find expected entry 'main/binary-i386/Packages' in Release
file (Wrong sources.list entry or malformed file)

E: Some index files failed to download. They have been ignored, or old
ones used instead.
```

We don't care about i386 architecture, so we should specify amd64.