### PR TITLE
Set event_log_aws_bucketname for each environment

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -18,6 +18,7 @@ govuk::apps::govuk_delivery::list_title_format: 'INTEGRATION: %s'
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
 govuk::apps::need_api::elasticsearch_hosts: 'api-elasticsearch-1.api:9200'
 govuk::apps::publicapi::backdrop_host: 'www.preview.performance.service.gov.uk'
+govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-integration'
 
 govuk::apps::smartanswers::expose_govspeak: true
 govuk::apps::specialist_publisher::publish_pre_production_finders: true

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -49,6 +49,7 @@ govuk::apps::errbit::errbit_email_from: 'govuk-winston+errbit-production@digital
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::local_links_manager::local_links_manager_passive_checks: true
 govuk::apps::publicapi::backdrop_host: 'www.performance.service.gov.uk'
+govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-production'
 govuk::apps::support_api::pp_data_url: 'https://www.performance.service.gov.uk'
 govuk::apps::support_api::zendesk_anonymous_ticket_email: 'zd-api-public@digital.cabinet-office.gov.uk'
 govuk::apps::support_api::zendesk_client_username: 'zd-api-govt@digital.cabinet-office.gov.uk/token'

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -14,6 +14,7 @@ govuk::apps::email_alert_api::db::backend_ip_range: '10.2.3.0/24'
 govuk::apps::errbit::errbit_email_from: 'govuk-winston+errbit-staging@digital.cabinet-office.gov.uk'
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::publicapi::backdrop_host: 'www.staging.performance.service.gov.uk'
+govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-staging'
 govuk::apps::support_api::pp_data_url: 'https://www.staging.performance.service.gov.uk'
 govuk::apps::travel_advice_publisher::enable_email_alerts: true
 


### PR DESCRIPTION
Needed to access s3 bucket for publishing API event archiving.
Set up in https://github.com/alphagov/govuk-terraform-provisioning/pull/79/files