### PR TITLE
Ignore the /var/lib/ureadahead/debugfs mount

### DIFF
--- a/modules/icinga/files/etc/nagios/nrpe.cfg
+++ b/modules/icinga/files/etc/nagios/nrpe.cfg
@@ -192,7 +192,7 @@ connection_timeout=300
 command[check_users]=/usr/lib/nagios/plugins/check_users -w 5 -c 10
 #command[check_load]=/usr/lib/nagios/plugins/check_load -w 15,10,5 -c 30,25,20
 # fallback check if individual ones havent been set up.
-command[check_disk]=/usr/lib/nagios/plugins/check_disk -w 6% -c 3% -W 6% -K 3%
+command[check_disk]=/usr/lib/nagios/plugins/check_disk -w 6% -c 3% -W 6% -K 3% -x /var/lib/ureadahead/debugfs/tracing
 command[check_zombie_procs]=/usr/lib/nagios/plugins/check_procs -w 5 -c 10 -s Z
 command[check_total_procs]=/usr/lib/nagios/plugins/check_procs -w 1200 -c 1500
 command[check_puppet_agent]=/usr/lib/nagios/plugins/check_puppet_agent


### PR DESCRIPTION
We're hitting a bug where `/var/lib/ureadahead/debugfs` is being added to the mount
structure at somepoint in the boot and then being removed. This is causing

`DISK CRITICAL - /var/lib/ureadahead/debugfs/tracing is not accessible: No such file or directory`

as mountall adds everything it finds, but doesn't remove it when it goes away. We don't use the
tracing functionality and we're not in a position to test removing ureadahead so for now
we'll ignore the partition and allow the check to function as it used to.