### PR TITLE
Jenkins puppet-lint check workaround

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,8 +14,7 @@ node {
 
       sh "${WORKSPACE}/jenkins.sh"
       if (env.BRANCH_NAME != 'master'){
-        File file = new File("${WORKSPACE}/build/puppet-lint")
-        if (file.exists() && file.length() > 0) {
+        if (fileExists 'build/puppet-lint-errors') {
           step([$class: 'GitHubCommitStatusSetter',
                 statusResultSource: [$class: 'ConditionalStatusResultSource', 
                                      results: [[$class: 'BetterThanOrEqualBuildResult', 

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -14,6 +14,10 @@ mkdir -p build
 set +e
 # don't fail build if rake lint fails; it stops jenkins from parsing the results
 bundle exec rake lint >build/puppet-lint
+if [[ -s build/puppet-lint ]]
+then
+  touch build/puppet-lint-errors
+fi
 set -e
 
 exit $RESULT


### PR DESCRIPTION
The new Jenkins Pipeline job needs to check if puppet-lint showed
any message to publish the right commit status. We can try creating
an empty file that we check in Jenkinsfile with the fileExists
function.