### PR TITLE
Add prefix URL to Jenkins

### DIFF
--- a/hieradata/class/ci_master.yaml
+++ b/hieradata/class/ci_master.yaml
@@ -1,4 +1,5 @@
 ---
+govuk_jenkins::config::url_prefix: 'ci'
 govuk_jenkins::config::banner_colour_background: '#009ACD'
 govuk_jenkins::config::banner_colour_text: 'black'
 govuk_jenkins::config::banner_string: 'Carrenza CI'

--- a/modules/govuk_jenkins/manifests/config.pp
+++ b/modules/govuk_jenkins/manifests/config.pp
@@ -7,9 +7,12 @@
 #
 # == Parameters:
 #
+# [*url_prefix*]
+#   The prefix used on the URL to access the Jenkins instance. Default is 'deploy',
+#   which would create "https://deploy.${app_domain}"
+#
 # [*app_domain*]
-#   The full domain for this environment. This is specifically used
-#   within Location Configuration template.
+#   The domain name applied to the Jenkins instance URL
 #
 # [*banner_colour_background*]
 #   The background colour of the banner to display in the Jenkins web interface.
@@ -57,6 +60,7 @@
 #   Specify the version of Jenkins
 #
 class govuk_jenkins::config (
+  $url_prefix = 'deploy',
   $app_domain = hiera('app_domain'),
   $banner_colour_background = 'black',
   $banner_colour_text = 'white',
@@ -74,6 +78,8 @@ class govuk_jenkins::config (
   $manage_config = true,
   $version = $govuk_jenkins::version,
 ) {
+
+  $url = "${url_prefix}.${app_domain}"
 
   validate_array($admins)
   validate_hash($views)

--- a/modules/govuk_jenkins/templates/config/jenkins.model.JenkinsLocationConfiguration.xml.erb
+++ b/modules/govuk_jenkins/templates/config/jenkins.model.JenkinsLocationConfiguration.xml.erb
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <jenkins.model.JenkinsLocationConfiguration>
   <adminAddress>webops@digital.cabinet-office.gov.uk</adminAddress>
-  <jenkinsUrl>https://deploy.<%= @app_domain -%>/</jenkinsUrl>
+  <jenkinsUrl>https://<%= @url -%>/</jenkinsUrl>
 </jenkins.model.JenkinsLocationConfiguration>


### PR DESCRIPTION
Adding this allows us to create a different URL that is the default for that Jenkins instance, a requirement that has come about by running two masters in the same environment.

Keeping 'app_domain' as a parameter will allow us to override the default down the line if we decide to apply a different domain name to the CI instance.