### PR TITLE
Hardcode ci-master-1 location

### DIFF
--- a/modules/govuk_ci/manifests/agent/swarm.pp
+++ b/modules/govuk_ci/manifests/agent/swarm.pp
@@ -46,7 +46,7 @@
 class govuk_ci::agent::swarm(
   $swarm_user           = 'jenkins',
   $agent_labels         = [],
-  $discovery_addr       = '10.1.6.255',
+  $ci_master            = 'ci-master-1',
   $agent_user_api_token = undef,     # Corresponding user: 'jenkins_agent'
   $swarm_client_package = 'jenkins-agent',
   $swarm_client_dest    = '/usr/local/bin/jenkins-agent',

--- a/modules/govuk_ci/templates/jenkins-agent.conf.erb
+++ b/modules/govuk_ci/templates/jenkins-agent.conf.erb
@@ -8,6 +8,6 @@ script
                 --name jenkins-agent --  -jar <%= @swarm_client_dest %> \
                 -username jenkins_agent -password <%= @agent_user_api_token %> \
                 -name <%= @hostname %> -executors 2 \
-                -autoDiscoveryAddress <%= @discovery_addr %> \
+                -master https://<%= @ci_master %>/ \
                 -fsroot /home/jenkins -labels '<%= @labels %>'
 end script


### PR DESCRIPTION
Instead of doing a discovery for a Jenkins master we hardcode the hostname and IP address of it in our codebase, so we may as well hardcode it here, too.