### PR TITLE
Add Jenkins agent role

### DIFF
--- a/hieradata/class/ci_master.yaml
+++ b/hieradata/class/ci_master.yaml
@@ -11,6 +11,8 @@ govuk_jenkins::config::views:
     - 'govuk-puppet'
     - 'integration-puppet-deploy'
 
+govuk_jenkins::config::create_agent_role: true
+
 govuk_jenkins::version: '2.19.2'
 
 govuk_jenkins::job_builder::jobs:

--- a/modules/govuk_jenkins/manifests/config.pp
+++ b/modules/govuk_jenkins/manifests/config.pp
@@ -59,6 +59,14 @@
 # [*version*]
 #   Specify the version of Jenkins
 #
+# [*create_agent_role*]
+#   If enabled, this creates a role and assigns an "agent" user to that role
+#   so that it may connect to the master
+#
+# [*jenkins_agent_user*]
+#   The username of the Jenkins "agent" user used to authenticate against
+#   the master
+#
 class govuk_jenkins::config (
   $url_prefix = 'deploy',
   $app_domain = hiera('app_domain'),
@@ -77,6 +85,8 @@ class govuk_jenkins::config (
   $admins = [],
   $manage_config = true,
   $version = $govuk_jenkins::version,
+  $create_agent_role = false,
+  $jenkins_agent_user = 'jenkins_agent',
 ) {
 
   $url = "${url_prefix}.${app_domain}"

--- a/modules/govuk_jenkins/templates/config/config.xml.erb
+++ b/modules/govuk_jenkins/templates/config/config.xml.erb
@@ -48,6 +48,20 @@
           <% end -%>
         </assignedSIDs>
       </role>
+      <%- if @create_agent_role -%>
+      <role name="agent" pattern=".*">
+        <permissions>
+          <permission>hudson.model.Computer.Delete</permission>
+          <permission>hudson.model.Computer.Disconnect</permission>
+          <permission>hudson.model.Computer.Connect</permission>
+          <permission>hudson.model.Computer.Create</permission>
+          <permission>hudson.model.Computer.Configure</permission>
+        </permissions>
+        <assignedSIDs>
+          <sid><%= @jenkins_agent_user %></sid>
+        </assignedSIDs>
+      </role>
+      <%- end -%>
       <role name="github" pattern=".*">
         <permissions>
           <permission>hudson.model.Item.Read</permission>


### PR DESCRIPTION
This role is required to give the agent user appropriate permissions to connect to the CI master and become a fully fledged agent.