### PR TITLE
Remove https_redirect parameter

### DIFF
--- a/modules/govuk/manifests/node/s_api_lb.pp
+++ b/modules/govuk/manifests/node/s_api_lb.pp
@@ -45,10 +45,9 @@ class govuk::node::s_api_lb (
     [
       'draft-content-store',
     ]:
-      servers        => $draft_content_store_servers,
-      internal_only  => true,
-      https_port     => 8443,
-      https_redirect => true,
+      servers       => $draft_content_store_servers,
+      internal_only => true,
+      https_port    => 8443,
   }
   @ufw::allow { 'allow-https-8443-from-any':
     port => 8443,
@@ -69,8 +68,7 @@ class govuk::node::s_api_lb (
       # cluster running in backend VDC.
       'search',
     ]:
-      servers        => $search_servers,
-      https_redirect => false, # Necessary for the router to fetch sitemaps.
-      internal_only  => true;
+      servers       => $search_servers,
+      internal_only => true;
   }
 }

--- a/modules/govuk/manifests/node/s_backend_lb.pp
+++ b/modules/govuk/manifests/node/s_backend_lb.pp
@@ -98,9 +98,8 @@ class govuk::node::s_backend_lb (
 
   if !empty($performance_backend_servers) {
     loadbalancer::balance { 'performanceplatform-admin':
-      servers        => $performance_backend_servers,
-      internal_only  => false,
-      https_redirect => true,
+      servers       => $performance_backend_servers,
+      internal_only => false,
     }
   }
 

--- a/modules/govuk/manifests/node/s_frontend_lb.pp
+++ b/modules/govuk/manifests/node/s_frontend_lb.pp
@@ -11,8 +11,7 @@ class govuk::node::s_frontend_lb (
   include loadbalancer
 
   Loadbalancer::Balance {
-    https_redirect => false, # Varnish/Router can't speak HTTPS.
-    internal_only  => true,
+    internal_only => true,
   }
 
   loadbalancer::balance {

--- a/modules/govuk/manifests/node/s_licensify_lb.pp
+++ b/modules/govuk/manifests/node/s_licensify_lb.pp
@@ -40,9 +40,8 @@ class govuk::node::s_licensify_lb (
 
     # Licensing web forms
     'licensing-web-forms':
-      https_redirect => true,
-      servers        => $frontend_app_servers,
-      internal_only  => true;
+      servers       => $frontend_app_servers,
+      internal_only => true;
 
   }
   if ($enable_feed_console) {

--- a/modules/loadbalancer/manifests/balance.pp
+++ b/modules/loadbalancer/manifests/balance.pp
@@ -23,10 +23,6 @@
 #   Port to listen on for HTTPS.
 #   Default: 443
 #
-# [*https_redirect*]
-#   Boolean, whether requests on port 80 should be redirected to HTTPS.
-#   Default: true
-#
 # [*internal_only*]
 #   Limit access to the loadbalanced service to internal IP address only.
 #   Default: false
@@ -47,7 +43,6 @@ define loadbalancer::balance(
     $deny_crawlers = false,
     $error_on_http = false,
     $https_port = 443,
-    $https_redirect = true,
     $internal_only = false,
     $vhost = $title,
     $read_timeout = 15,

--- a/modules/loadbalancer/spec/defines/loadbalancer__balance_spec.rb
+++ b/modules/loadbalancer/spec/defines/loadbalancer__balance_spec.rb
@@ -69,10 +69,9 @@ describe 'loadbalancer::balance', :type => :define do
     end
 
     context 'HTTP and HTTPS behaviour' do
-      describe 'error_on_http is true, https_redirect is true' do
+      describe 'error_on_http is true' do
         let(:params) { default_params.merge({
           :error_on_http => true,
-          :https_redirect => true,
         })}
 
         it 'should serve errors for HTTP' do
@@ -81,39 +80,14 @@ describe 'loadbalancer::balance', :type => :define do
         end
       end
 
-      describe 'error_on_http is true, https_redirect is false' do
-        let(:params) { default_params.merge({
-          :error_on_http => true,
-          :https_redirect => false,
-        })}
-
-        it 'should serve errors for HTTP' do
-          is_expected.to contain_nginx__config__site('giraffe.environment.example.com')
-            .with_content(/listen 80;\n\s+return 426/)
-        end
-      end
-
-      describe 'error_on_http is false, https_redirect is true' do
+      describe 'error_on_http is false' do
         let(:params) { default_params.merge({
           :error_on_http => false,
-          :https_redirect => true,
         })}
 
         it 'should redirect from HTTP to HTTPS' do
           is_expected.to contain_nginx__config__site('giraffe.environment.example.com')
             .with_content(/listen 80;\n\s+rewrite \^\/\(\.\*\) https/)
-        end
-      end
-
-      describe 'error_on_http is false, https_redirect is false' do
-        let(:params) { default_params.merge({
-          :error_on_http => false,
-          :https_redirect => false,
-        })}
-
-        it 'should serve the loadbalanced app over HTTP and HTTPS' do
-          is_expected.to contain_nginx__config__site('giraffe.environment.example.com')
-            .with_content(/listen\s+80;\n\s+listen\s+443 ssl;/)
         end
       end
     end

--- a/modules/loadbalancer/templates/nginx_balance.conf.erb
+++ b/modules/loadbalancer/templates/nginx_balance.conf.erb
@@ -10,7 +10,7 @@ server {
   listen 80;
   return 426 "Request cannot be completed using a plaintext HTTP connection. Retry over HTTPS.\n";
 }
-<%- elsif @https_redirect -%>
+<%- else -%>
 server {
   server_name <%= @vhost_real %> ;
   listen 80;
@@ -41,9 +41,6 @@ perl_set $govuk_request_id '
 server {
   server_name <%= @vhost_real %> ;
 
-  <%- if @https_redirect == false and @error_on_http == false -%>
-  listen              80;
-  <%- end -%>
   listen              <%= @https_port %> ssl;
   ssl_certificate     /etc/nginx/ssl/<%= @vhost_real %>.crt;
   ssl_certificate_key /etc/nginx/ssl/<%= @vhost_real %>.key;


### PR DESCRIPTION
All the traffic we send to the loadbalancers is over port 443 now, so we don't need an option to redirect from 80 to 443. We just always do it.