### PR TITLE
Add pipeline class

### DIFF
--- a/modules/govuk_jenkins/manifests/init.pp
+++ b/modules/govuk_jenkins/manifests/init.pp
@@ -107,20 +107,4 @@ class govuk_jenkins (
   include govuk_mysql::libdev
   include mysql::client
 
-  # Add common functions for Jenkinsfile used by Pipeline jobs
-  file { '/var/lib/jenkins/groovy_scripts':
-    ensure  => directory,
-    owner   => 'jenkins',
-    group   => 'jenkins',
-    require => Class['govuk_jenkins::package'],
-  }
-
-  file { '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy':
-    ensure  => file,
-    owner   => 'jenkins',
-    group   => 'jenkins',
-    source  => 'puppet:///modules/govuk_jenkins/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy',
-    require => File['/var/lib/jenkins/groovy_scripts'],
-  }
-
 }

--- a/modules/govuk_jenkins/manifests/package.pp
+++ b/modules/govuk_jenkins/manifests/package.pp
@@ -57,4 +57,8 @@ class govuk_jenkins::package (
     require            => Class['govuk_java::set_defaults'],
   }
 
+  class { 'govuk_jenkins::pipeline':
+    require => Class['jenkins'],
+  }
+
 }

--- a/modules/govuk_jenkins/manifests/pipeline.pp
+++ b/modules/govuk_jenkins/manifests/pipeline.pp
@@ -1,0 +1,31 @@
+# == Class: Govuk_jenkins::Pipeline
+#
+# Create dependencies for creating Jenkins pipelines
+#
+# === Parameters:
+#
+# [*user*]
+#   The user which owns Jenkins directories
+#
+# [*group*]
+#   The group which owns Jenkins directories
+#
+class govuk_jenkins::pipeline (
+  $user  = 'jenkins',
+  $group = 'jenkins',
+) {
+  file { '/var/lib/jenkins/groovy_scripts':
+    ensure  => directory,
+    owner   => $user,
+    group   => $group,
+    require => File['/var/lib/jenkins'],
+  }
+
+  file { '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy':
+    ensure  => file,
+    owner   => $user,
+    group   => $group,
+    source  => 'puppet:///modules/govuk_jenkins/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy',
+    require => File['/var/lib/jenkins/groovy_scripts'],
+  }
+}


### PR DESCRIPTION
We need to include the groovy directory and scripts on the agents for running pipeline jobs. This splits the creation of the directory and scripts out from the main class so we don't install Jenkins on the agents, but still pull in the groovy scripts.