### PR TITLE
Add non deployable pipeline jobs and support for Github Enterprise

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -564,17 +564,24 @@ govuk_cdnlogs::service_port_map:
 govuk_ci::master::pipeline_jobs:
   <<: *deployable_applications
   async_experiments: {}
+  backdrop-transactions-explorer-collector: {}
   cdn-acceptance-tests: {}
   content-register: {}
+  deployment:
+    source: 'git'
   deprecated_columns: {}
   event-store: {}
   finder-api: {}
   finding-things-migration-checker: {}
+  gapy: {}
   gds-api-adapters: {}
   gds-scala-common: {}
   gds-sso: {}
   gds_zendesk: {}
+  gem_publisher: {}
+  google-auth-bridge: {}
   govspeak: {}
+  govuk-app-deployment: {}
   govuk-diff-pages: {}
   govuk_admin_template: {}
   govuk_bad_link_finder: {}
@@ -590,17 +597,40 @@ govuk_ci::master::pipeline_jobs:
   govuk_message_queue_consumer: {}
   govuk_mirrorer: {}
   govuk_navigation_helpers: {}
+  govuk-provisioning:
+    source: 'git'
   govuk_seed_crawler: {}
   govuk_schemas_gem: {}
   govuk_security_audit: {}
   govuk_sidekiq: {}
+  govuk_template: {}
+  licensify:
+    source: 'git'
   omniauth-gds: {}
   opsmanual: {}
   optic14n: {}
+  performance-datastore: {}
+  performanceplatform-client.py: {}
+  performanceplatform-collector: {}
+  performanceplatform-documentation: {}
+  performanceplatform-govuk-stats: {}
   plek: {}
+  pp-manual:
+    source: 'git'
   pre-transition-stats: {}
   rack-logstasher: {}
+  rails_translation_manager: {}
+  router-data:
+    source: 'git'
   rummageable: {}
+  screenshot-as-a-service: {}
+  shared_mustache: {}
+  slimmer: {}
+  smartdown: {}
+  spotlight-performance: {}
+  transition-config: {}
+  ubuntu_unused_kernels:
+    repo_owner: 'gds-operations'
 
 govuk_ci::agent::swarm::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -561,7 +561,47 @@ govuk_cdnlogs::service_port_map:
   assets: 6515
   bouncer: 6516
 
-govuk_ci::master::pipeline_jobs: *deployable_applications
+govuk_ci::master::pipeline_jobs:
+  <<: *deployable_applications
+  async_experiments: {}
+  cdn-acceptance-tests: {}
+  content-register: {}
+  deprecated_columns: {}
+  event-store: {}
+  finder-api: {}
+  finding-things-migration-checker: {}
+  gds-api-adapters: {}
+  gds-scala-common: {}
+  gds-sso: {}
+  gds_zendesk: {}
+  govspeak: {}
+  govuk-diff-pages: {}
+  govuk_admin_template: {}
+  govuk_bad_link_finder: {}
+  govuk_client_url-arbiter: {}
+  govuk_content_models: {}
+  govuk-content-schema-test-helpers: {}
+  govuk-dummy_content_store: {}
+  govuk_elements: {}
+  govuk_frontend_toolkit: {}
+  govuk_frontend_toolkit_gem: {}
+  govuk_frontend_toolkit_npm: {}
+  govuk-lint: {}
+  govuk_message_queue_consumer: {}
+  govuk_mirrorer: {}
+  govuk_navigation_helpers: {}
+  govuk_seed_crawler: {}
+  govuk_schemas_gem: {}
+  govuk_security_audit: {}
+  govuk_sidekiq: {}
+  omniauth-gds: {}
+  opsmanual: {}
+  optic14n: {}
+  plek: {}
+  pre-transition-stats: {}
+  rack-logstasher: {}
+  rummageable: {}
+
 govuk_ci::agent::swarm::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 govuk_crawler::amqp_host: 'localhost'

--- a/modules/govuk_ci/manifests/job.pp
+++ b/modules/govuk_ci/manifests/job.pp
@@ -5,15 +5,29 @@
 # === Parameters
 #
 # [*app*]
-# Application name (Default: title)
+# Application name
+# Default: title
 #
 # [*repository*]
-# Repository name, it needs to match the Github repository name (Default: title)
+# Repository name. It needs to match the Github/Github Enterprise repository name
+# Default: title
+#
+# [*repo_owner*]
+# Github repository owner
+# Default: alphagov
+#
+# [*source*]
+# Type of Branch Source plugin to use in the Jenkins job. It can be 'github' or 'git' (for Github Enterprise projects)
+# Default: github
 #
 define govuk_ci::job (
   $app = $title,
   $repository = $title,
+  $repo_owner = 'alphagov',
+  $source = 'github',
 ) {
+
+  validate_re($source, '^(github|git)$', 'Invalid source value, it must be github or git')
 
   $job_config_directory = '/var/lib/jenkins/jobs'
   $application_directory = "${job_config_directory}/${app}"

--- a/modules/govuk_ci/templates/application_build_job.xml.erb
+++ b/modules/govuk_ci/templates/application_build_job.xml.erb
@@ -24,11 +24,12 @@
   <sources class="jenkins.branch.MultiBranchProject$BranchSourceList" plugin="branch-api@1.11.1">
     <data>
       <jenkins.branch.BranchSource>
+<%- if @source == 'github' -%>
         <source class="org.jenkinsci.plugins.github_branch_source.GitHubSCMSource" plugin="github-branch-source@1.10">
           <id>45dd6853-59d2-4695-80ac-4520f8a2b64f</id>
           <checkoutCredentialsId>SAME</checkoutCredentialsId>
           <scanCredentialsId>github-token-govuk-ci-username</scanCredentialsId>
-          <repoOwner>alphagov</repoOwner>
+          <repoOwner><%= @repo_owner %></repoOwner>
           <repository><%= @repository %></repository>
           <includes>*</includes>
           <excludes></excludes>
@@ -39,6 +40,16 @@
           <buildForkPRMerge>false</buildForkPRMerge>
           <buildForkPRHead>false</buildForkPRHead>
         </source>
+<%- elsif @source == 'git' -%>
+        <source class="jenkins.plugins.git.GitSCMSource" plugin="git@3.0.0">
+          <id>edb8c02e-1e3b-45c5-bd14-325d5413bbd8</id>
+          <remote>git@github.gds:gds/<%= @repository %>.git</remote>
+          <credentialsId>github-enterprise-token-govukjenkinsci-username</credentialsId>
+          <includes>*</includes>
+          <excludes></excludes>
+          <ignoreOnPushNotifications>false</ignoreOnPushNotifications>
+        </source>
+<%- end -%>
         <strategy class="jenkins.branch.DefaultBranchPropertyStrategy">
           <properties class="empty-list"/>
         </strategy>


### PR DESCRIPTION
Add support for the 'git' branch source plugin in our govuk_ci::job
template, so projects using Github Enterprise can be managed in the
same way. It requires credentials to connect with Github Enterprise
matching the ID supplied in the template.

Add Jenkins Pipeline jobs that are not part of the list of
deployable applications, but still can be managed as a standard
pipeline job