### PR TITLE
Refactor Jenkins user class

### DIFF
--- a/modules/govuk_jenkins/manifests/pipeline.pp
+++ b/modules/govuk_jenkins/manifests/pipeline.pp
@@ -18,7 +18,7 @@ class govuk_jenkins::pipeline (
     ensure  => directory,
     owner   => $user,
     group   => $group,
-    require => File['/var/lib/jenkins'],
+    require => Class['govuk_jenkins::user'],
   }
 
   file { '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy':

--- a/modules/govuk_jenkins/manifests/user.pp
+++ b/modules/govuk_jenkins/manifests/user.pp
@@ -13,8 +13,6 @@
 class govuk_jenkins::user (
   $home_directory = '/var/lib/jenkins',
   $username       = 'jenkins',
-  $private_key    = undef,
-  $public_key     = undef,
 ) {
   user { $username:
     ensure     => present,
@@ -22,20 +20,4 @@ class govuk_jenkins::user (
     managehome => true,
     shell      => '/bin/bash',
   }
-
-  class { 'govuk_jenkins::ssh_key':
-    private_key  => $private_key,
-    public_key   => $public_key,
-    jenkins_user => $username,
-    home_dir     => $home_directory,
-  }
-
-  file { "${home_directory}/.gitconfig":
-    source  => 'puppet:///modules/govuk_jenkins/dot-gitconfig',
-    owner   => $username,
-    group   => $username,
-    mode    => '0644',
-    require => User[$username],
-  }
-
 }

--- a/modules/govuk_jenkins/spec/classes/jenkins__user_spec.rb
+++ b/modules/govuk_jenkins/spec/classes/jenkins__user_spec.rb
@@ -8,5 +8,4 @@ describe 'govuk_jenkins::user', :type => :class do
   }}
 
   it { is_expected.to contain_user('jenkins') }
-  it { is_expected.to contain_class('govuk_jenkins::ssh_key') }
 end

--- a/modules/govuk_jenkins/spec/classes/jenkins_spec.rb
+++ b/modules/govuk_jenkins/spec/classes/jenkins_spec.rb
@@ -14,4 +14,5 @@ describe 'govuk_jenkins', :type => :class do
   it { is_expected.to contain_class('govuk_jenkins::config') }
   it { is_expected.to contain_class('govuk_jenkins::user') }
   it { is_expected.to contain_class('govuk_jenkins::package') }
+  it { is_expected.to contain_class('govuk_jenkins::ssh_key')  }
 end


### PR DESCRIPTION
We need to include the user class on Jenkins agent machines, which require the user and home directory created but do not need SSH keys or gitconfig.

Since these two things are only needed on the master, move this into the main class and just keep the user creation in it's own class to be included elsewhere. Explicitly call in the jenkins_user and
jenkins_homedir parameters in the main class as these are used in several places, so if we wanted to overwrite these on the master there would be less changes.

Further, ensure the govuk_jenkins::pipeline class requires on the govuk_jenkins::user class rather than a file resource.