### PR TITLE
Jenkins job to archive Publishing API events to S3

### DIFF
--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -26,6 +26,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::passive_checks
   - govuk_jenkins::job::performance_platform_smokey
   - govuk_jenkins::job::publishing_api_check_validity
+  - govuk_jenkins::job::publishing_api_archive_events
   - govuk_jenkins::job::run_rake_task
   - govuk_jenkins::job::run_whitehall_data_migrations
   - govuk_jenkins::job::search_fetch_analytics_data

--- a/modules/govuk_jenkins/manifests/job/publishing_api_archive_events.pp
+++ b/modules/govuk_jenkins/manifests/job/publishing_api_archive_events.pp
@@ -1,0 +1,14 @@
+# == Class: govuk_jenkins::job::publishing_api_archive_events
+#
+# Create a jenkins job to periodically archive publishing API events
+#
+#
+# === Parameters:
+#
+class govuk_jenkins::job::publishing_api_archive_events {
+  file { '/etc/jenkins_jobs/jobs/publishing_api_archive_events.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/publishing_api_archive_events.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+}

--- a/modules/govuk_jenkins/templates/jobs/publishing_api_archive_events.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/publishing_api_archive_events.yaml.erb
@@ -1,0 +1,17 @@
+---
+- job:
+    name: Publishing_API_Archive_Events
+    display-name: Publishing_API_Archive_Events
+    project-type: freestyle
+    description: "This job periodically archives publishing API events to S3"
+    logrotate:
+      artifactNumToKeep: 10
+    publishers:
+        - trigger-parameterized-builds:
+          - project: run-rake-task
+            predefined-parameters: |
+              TARGET_APPLICATION=publishing-api
+              MACHINE_CLASS=backend
+              RAKE_TASK=events:export_to_s3
+    triggers:
+        - timed: 'H 5 * * 0'


### PR DESCRIPTION
This sets up a Jenkins job to run every Sunday at ~5am to run a Publishing API
rake task which archives events to S3.

Depends on https://github.com/alphagov/publishing-api/pull/614 running first