### PR TITLE
Add licensify and router-data deployment jobs to CI

### DIFF
--- a/modules/govuk_jenkins/manifests/job/integration_deploy.pp
+++ b/modules/govuk_jenkins/manifests/job/integration_deploy.pp
@@ -29,4 +29,16 @@ class govuk_jenkins::job::integration_deploy (
     content => template('govuk_jenkins/jobs/integration_puppet_deploy.yaml.erb'),
     notify  => Exec['jenkins_jobs_update'],
   }
+
+  file { '/etc/jenkins_jobs/jobs/integration_licensify_deploy.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/integration_licensify_deploy.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+
+  file { '/etc/jenkins_jobs/jobs/integration_router_data_deploy.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/integration_router_data_deploy.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
 }

--- a/modules/govuk_jenkins/templates/jobs/integration_licensify_deploy.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/integration_licensify_deploy.yaml.erb
@@ -1,0 +1,19 @@
+---
+- job:
+    name: integration-licensify-deploy
+    display-name: integration-licensify-deploy
+    project-type: freestyle
+    description: "Kicks off a Licensify deploy in the Integration environment"
+    builders:
+      - shell: |
+          JSON="{\"parameter\": [{\"name\": \"BETA_PAYMENT_ACCOUNTS\", \"value\": \"false\"}, {\"name\": \"artefact_number\", \"value\": \"$artefact_number\"}, {\"name\": \"app_version\", \"value\": \"$appVersion\"}, {\"name\": \"CI_JOB_NAME\", \"value\": \"Licensify\"}, {\"name\": \"ARTIFACT_PATH\", \"value\": \"target/universal\"}], \"\": \"\"}"
+
+          # Deploy to integration environment
+          echo curl -f -XPOST https://<%= @jenkins_integration_api_user %>:<%= @jenkins_integration_api_password %>@deploy.integration.publishing.service.gov.uk/job/Licensify_Deploy/build --data-urlencode json="$JSON"
+    wrappers:
+        - ansicolor:
+            colormap: xterm
+    publishers:
+        - email:
+            recipients: govuk-ci-notifications@digital.cabinet-office.gov.uk
+            send-to-individuals: false

--- a/modules/govuk_jenkins/templates/jobs/integration_router_data_deploy.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/integration_router_data_deploy.yaml.erb
@@ -1,0 +1,24 @@
+---
+- job:
+    name: integration-router-data-deploy
+    display-name: integration-router-data-deploy
+    project-type: freestyle
+    description: "Kicks off a router-data deploy in the Integration environment"
+    builders:
+      - shell: |
+          JSON="{\"parameter\": [{\"name\": \"TAG\", \"value\": \"$TAG\"}], \"\": \"\"}"
+
+          # Deploy to integration environment
+          echo curl -f -XPOST https://<%= @jenkins_integration_api_user %>:<%= @jenkins_integration_api_password %>@deploy.integration.publishing.service.gov.uk/job/deploy_router_data/build --data-urlencode json="$JSON"
+    wrappers:
+        - ansicolor:
+            colormap: xterm
+    parameters:
+        - string:
+            name: TAG
+            description: 'Git tag/committish to deploy.'
+            default: 'release'
+    publishers:
+        - email:
+            recipients: govuk-ci-notifications@digital.cabinet-office.gov.uk
+            send-to-individuals: true


### PR DESCRIPTION
Licensify and router-data trigger specific jobs to deploy
the application on Integration. This commit adds the extra
jobs but we might want to investigate if this can be done
with integration-app-deploy instead.