### PR TITLE
Add PATH on Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,6 +12,9 @@ node {
 
     stage("Build") {
 
+      // Explicitly set the path for the Jenkins swarm service on the agent
+      env.PATH = "/usr/lib/rbenv/shims:/usr/lib/rbenv/shims:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
       sh "${WORKSPACE}/jenkins.sh"
       if (env.BRANCH_NAME != 'master'){
         if (fileExists('build/puppet-lint-errors')) {


### PR DESCRIPTION
When trying to run builds on the new Jenkins agents using the swarm client, we were receiving the following error:

```
jenkins.sh: bundle: not found
```

We need to explicitly set the path so it is able to run bundler. This could be passed in a different way in the future but for now set it on the Jenkinsfile.

This didn't occur on the Jenkins master because we believe environmental variables are set by Jenkins itself.