### PR TITLE
Fix database url env var for whitehall

### DIFF
--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -188,7 +188,7 @@ class govuk::apps::whitehall(
 
     if $::govuk_node_class != 'development' {
       govuk::app::envvar::database_url { $app_name:
-        type     => 'mysql',
+        type     => 'mysql2',
         username => $db_username,
         password => $db_password,
         host     => $db_hostname,
@@ -344,7 +344,7 @@ class govuk::apps::whitehall(
 
     if $::govuk_node_class != 'development' {
       govuk::app::envvar::database_url { $app_name:
-        type     => 'mysql',
+        type     => 'mysql2',
         username => $admin_db_username,
         password => $admin_db_password,
         host     => $admin_db_hostname,


### PR DESCRIPTION
The type should be the name of the adapter gem that will be used, not just
the name of the database.  In this case mysql2, not mysql.

From #5136

/cc @steventux 