### PR TITLE
Fix adapter name for whitehall database configs

### DIFF
--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -188,7 +188,7 @@ class govuk::apps::whitehall(
 
     if $::govuk_node_class != 'development' {
       govuk::app::envvar::database_url { $app_name:
-        type     => 'mysql',
+        type     => 'mysql2',
         username => $db_username,
         password => $db_password,
         host     => $db_hostname,
@@ -344,7 +344,7 @@ class govuk::apps::whitehall(
 
     if $::govuk_node_class != 'development' {
       govuk::app::envvar::database_url { $app_name:
-        type     => 'mysql',
+        type     => 'mysql2',
         username => $admin_db_username,
         password => $admin_db_password,
         host     => $admin_db_hostname,


### PR DESCRIPTION
Provide the correct adapter name to the database config class. Whitehall uses the `mysql2` gem.