### PR TITLE
Add option to pass in different env vars

### DIFF
--- a/modules/govuk/manifests/node/s_jenkins.pp
+++ b/modules/govuk/manifests/node/s_jenkins.pp
@@ -1,9 +1,37 @@
-# FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
-class govuk::node::s_jenkins inherits govuk::node::s_base {
+# == Class: Govuk::Node::S_jenkins
+#
+# Sets up the deployment Jenkins standalone instance
+#
+# === Parameters:
+#
+# [*github_client_id*]
+#   The Github client ID is used as the user to authenticate against Github.
+#
+# [*github_client_secret*]
+#   The Github client secret is used to authenticate against Github.
+#
+# [*jenkins_api_token*]
+#   The API token for Jenkins user.
+#
+# [*environment_variables*]
+#   A hash of environment variables that should be set for all Jenkins jobs.
+#
+class govuk::node::s_jenkins (
+  $github_client_id = undef,
+  $github_client_secret = undef,
+  $jenkins_api_token = undef,
+  $environment_variables = {},
+) inherits govuk::node::s_base {
   include nginx
-  include govuk_jenkins
   include govuk_ghe_vpn
   include govuk_rbenv::all
+
+  class { 'govuk_jenkins':
+    github_client_id      => $github_client_id,
+    github_client_secret  => $github_client_secret,
+    jenkins_api_token     => $jenkins_api_token,
+    environment_variables => $environment_variables,
+  }
 
   # Close connection if vhost not known
   nginx::config::vhost::default { 'default':

--- a/modules/govuk_ci/manifests/master.pp
+++ b/modules/govuk_ci/manifests/master.pp
@@ -16,6 +16,9 @@
 # [*ghe_vpn_password*]
 #   The password to authenticate against the Github Enterprise VPN
 #
+# [*environment_variables*]
+#   A hash of environment variables that should be set for all Jenkins jobs.
+#
 class govuk_ci::master (
   $github_client_id,
   $github_client_secret,
@@ -23,6 +26,7 @@ class govuk_ci::master (
   $ghe_vpn_password,
   $jenkins_api_token,
   $pipeline_jobs = {},
+  $environment_variables = {},
 ){
 
   include ::govuk_ci::credentials
@@ -31,9 +35,10 @@ class govuk_ci::master (
   govuk_jenkins::api_user { 'jenkins_agent': }
 
   class { '::govuk_jenkins':
-    github_client_id     => $github_client_id,
-    github_client_secret => $github_client_secret,
-    jenkins_api_token    => $jenkins_api_token,
+    github_client_id      => $github_client_id,
+    github_client_secret  => $github_client_secret,
+    jenkins_api_token     => $jenkins_api_token,
+    environment_variables => $environment_variables,
   }
 
   class { 'govuk_ghe_vpn':

--- a/modules/govuk_jenkins/manifests/init.pp
+++ b/modules/govuk_jenkins/manifests/init.pp
@@ -32,6 +32,9 @@
 # [*version*]
 #   Specify the version of Jenkins
 #
+# [*environment_variables*]
+#   A hash of environment variables that should be set for all Jenkins jobs.
+#
 class govuk_jenkins (
   $github_enterprise_cert,
   $github_enterprise_hostname,
@@ -46,6 +49,7 @@ class govuk_jenkins (
   $jenkins_api_token = '',
   $jenkins_user = 'jenkins',
   $jenkins_homedir = '/var/lib/jenkins',
+  $environment_variables = {},
 ) {
   validate_hash($config, $plugins)
 
@@ -56,8 +60,9 @@ class govuk_jenkins (
   }
 
   class { 'govuk_jenkins::config':
-    github_client_id     => $github_client_id,
-    github_client_secret => $github_client_secret,
+    github_client_id      => $github_client_id,
+    github_client_secret  => $github_client_secret,
+    environment_variables => $environment_variables,
   }
 
   class { 'govuk_jenkins::package':


### PR DESCRIPTION
If we need to move away from the default set environment variables which are set elsewhere, we need to be able to break them out and specify them by class as we are unable to differentiate by specific node class where
we set our secrets in hieradata.

This allows us to set a different PATH for the CI cluster.