### PR TITLE
Scheduled rake tasks should be an array of hashes

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -21,7 +21,7 @@ govuk::apps::publicapi::backdrop_host: 'www.preview.performance.service.gov.uk'
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-integration'
 
 govuk::apps::signon::instance_name: 'integration'
-govuk::apps::signon::scheduled_rake_tasks: |
+govuk::apps::signon::scheduled_rake_tasks:
   - frequency: 'tuesday'
     time: '11:30am'
     task: 'oauth_access_grants:delete_expired'

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -50,7 +50,7 @@ govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::local_links_manager::local_links_manager_passive_checks: true
 govuk::apps::publicapi::backdrop_host: 'www.performance.service.gov.uk'
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-production'
-govuk::apps::signon::scheduled_rake_tasks: |
+govuk::apps::signon::scheduled_rake_tasks:
   - frequency: 'sunday'
     time: '12am'
     task: 'oauth_access_grants:delete_expired'


### PR DESCRIPTION
Part of https://trello.com/c/BrKRdn4f/495-rebuild-gov-uk-app-deployment-pipeline

These tasks are parsed as JSON by an application initializer,
they need to be serialised as JSON in the puppet app module,
which means that they need to be passed to the module as an
array of hashes.