### PR TITLE
Stop forwarding /api/incoming-links to content-store

### DIFF
--- a/modules/govuk/templates/publicapi_nginx_extra_config.erb
+++ b/modules/govuk/templates/publicapi_nginx_extra_config.erb
@@ -34,7 +34,7 @@
     proxy_pass <%= @privateapi_protocol %>://<%= @rummager_api %>;
   }
 
-  location ~ ^/api/(content|incoming-links)/ {
+  location ~ ^/api/content/ {
     limit_except GET {
       deny all;
     }


### PR DESCRIPTION
This endpoint was exposed to allow us to use it from prototypes hosted on Heroku. The functionality was removed in https://github.com/alphagov/content-store/pull/244 so we no longer need this.