### PR TITLE
Configure scheduled signon rake tasks via jenkins

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -113,6 +113,12 @@ govuk_jenkins::job_builder::environment: 'integration'
 
 govuk_jenkins::job::deploy_puppet::commitish: 'integration'
 
+govuk_jenkins::job::signon_cron_rake_tasks::configure_jobs: true
+govuk_jenkins::job::signon_cron_rake_tasks::rake_oauth_access_grants_delete_expired_frequency: '30 11 * * 2'
+govuk_jenkins::job::signon_cron_rake_tasks::rake_organisations_fetch_frequency: '0 11 * * *'
+govuk_jenkins::job::signon_cron_rake_tasks::rake_users_suspend_inactive_frequency: '15 11 * * *'
+govuk_jenkins::job::signon_cron_rake_tasks::rake_users_send_suspension_reminders_frequency: '45 11 * * *'
+
 govuk_jenkins::job::smokey::smokey_task: 'test:integration'
 
 govuk_jenkins::job::network_config_deploy::environments:

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -84,6 +84,12 @@ govuk_jenkins::job::network_config_deploy::environments:
 govuk_jenkins::job::performance_platform_smokey::pp_full_app_domain: "production.performance.service.gov.uk"
 govuk_jenkins::job::performance_platform_smokey::pp_app_domain: "performance.service.gov.uk"
 
+govuk_jenkins::job::signon_cron_rake_tasks::configure_jobs: true
+govuk_jenkins::job::signon_cron_rake_tasks::rake_oauth_access_grants_delete_expired_frequency: '0 12 * * 0'
+govuk_jenkins::job::signon_cron_rake_tasks::rake_organisations_fetch_frequency: '0 3 * * *'
+govuk_jenkins::job::signon_cron_rake_tasks::rake_users_suspend_inactive_frequency: '0 4 * * *'
+govuk_jenkins::job::signon_cron_rake_tasks::rake_users_send_suspension_reminders_frequency: '0 6 * * *'
+
 govuk_jenkins::ssh_key::public_key: 'AAAAB3NzaC1yc2EAAAADAQABAAACAQCfPjubgzCkZo1aTPlkgeXb1eh3IonRBRptx0qLMCjOV+e+M8uRAT/Xx3ydJYPd7sOgZDyx2xjSGb7Eefau0jSUAcMD1Xd01SXWBQPJRDfPmQLrdbM0xxOFH8nft39uo4Mz6ccZc34xrudL6q/urp732HZHYwltnNnbk9h58n1QIhemRtN3u9RrSSOILqw/F42S6Aj8lZ1v/DGgfc6F5pKyJ7TByHL1RlqwpZHbEjYYuvK0ZJJsKPlyVPbNDsX7UEYWwbpPsFs9LPvCC6epmj+7Lv25bTU8rKK8J3rNWa1FybpWS0VXbF/+mrLjtT0/vwvbwUzsjK6dSUsbEsBEn+cOqomxCYkLjMzUy1+ReYAh6+CjmzutPs1g4OjQRel2ONprhPTEsNUu+oNObnGDOUpzHK10ntAZxguA4QEUmOBBWfxuQhmJO60/b1zedCcc7MR8e9S0y4jtpXa8GBCe40+napArZTW9QXlHLWz+khkYQfO107Q+z1QaLFojdcrHlUfpqAc6DtVJQu7tsBt2vXTn0qq6mU5Eg6UY+X1l/3gWdFS3ZEvCUoGK6bLU3i50jZ1xsFogFFfvSux46S1DYW2Fk8a/2IBBdcQcL1YoM73jiAQgpU8Vs50wtk4mWhK1yBaMYmMAeL7mKFbJla7SjTAwaDdo5uezyrJlbZxqTb/Y3w=='
 
 govuk_mysql::server::innodb_buffer_pool_size_proportion: '0.5'

--- a/modules/govuk_jenkins/manifests/job/signon_cron_rake_tasks.pp
+++ b/modules/govuk_jenkins/manifests/job/signon_cron_rake_tasks.pp
@@ -1,0 +1,45 @@
+# == Class: govuk_jenkins::job::signon_cron_rake_tasks
+#
+# Create a jenkins job to periodically run rake for the following tasks:
+# - oauth_access_grants:delete_expired
+# - organisations:fetch
+# - users:suspend_inactive
+# - users:send_suspension_reminders
+#
+# === Parameters:
+#
+# [*configure_jobs*]
+#   Whether we should configure these jenkins jobs
+#   Default: false
+#
+# [*rake_oauth_access_grants_delete_expired_frequency*]
+#   The cron timings for the oauth_access_grants:delete_expired rake task
+#   Default: undef
+#
+# [*rake_organisations_fetch_frequency*]
+#   The cron timings for the organisations:fetch rake task
+#   Default: undef
+#
+# [*rake_users_suspend_inactive_frequency*]
+#   The cron timings for the users:suspend_inactive rake task
+#   Default: undef
+#
+# [*rake_users_send_suspension_reminders_frequency*]
+#   The cron timings for the users:send_suspension_reminders rake task
+#   Default: undef
+#
+class govuk_jenkins::job::signon_cron_rake_tasks (
+  $configure_jobs = false,
+  $rake_oauth_access_grants_delete_expired_frequency = undef,
+  $rake_organisations_fetch_frequency = undef,
+  $rake_users_suspend_inactive_frequency = undef,
+  $rake_users_send_suspension_reminders_frequency = undef,
+) {
+  if $configure_jobs {
+    file { '/etc/jenkins_jobs/jobs/signon_cron_rake_tasks.yaml':
+      ensure  => present,
+      content => template('govuk_jenkins/jobs/signon_cron_rake_tasks.yaml.erb'),
+      notify  => Exec['jenkins_jobs_update'],
+    }
+  }
+}

--- a/modules/govuk_jenkins/templates/jobs/signon_cron_rake_tasks.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/signon_cron_rake_tasks.yaml.erb
@@ -1,0 +1,73 @@
+---
+- job:
+    name: signon_rake_oauth_access_grants_delete_expired
+    display-name: signon_rake_oauth_access_grants_delete_expired
+    project-type: freestyle
+    description: "<p>Regularly run the oauth_access_grants:delete_expired rake task for Signonotron2.</p>"
+    publishers:
+        - trigger-parameterized-builds:
+            - project: run-rake-task
+              predefined-parameters: |
+                TARGET_APPLICATION=signon
+                MACHINE_CLASS=backend
+                RAKE_TASK=oauth_access_grants:delete_expired
+        - email:
+            recipients: govuk-ci-notifications@digital.cabinet-office.gov.uk
+    triggers:
+      - timed: <%= @rake_oauth_access_grants_delete_expired_frequency %>
+    logrotate:
+        artifactNumToKeep: 10
+- job:
+    name: signon_rake_organisations_fetch
+    display-name: signon_rake_organisations_fetch
+    project-type: freestyle
+    description: "<p>Regularly run the organisations:fetch rake task for Signonotron2.</p>"
+    publishers:
+        - trigger-parameterized-builds:
+            - project: run-rake-task
+              predefined-parameters: |
+                TARGET_APPLICATION=signon
+                MACHINE_CLASS=backend
+                RAKE_TASK=organisations:fetch
+        - email:
+            recipients: govuk-ci-notifications@digital.cabinet-office.gov.uk
+    triggers:
+      - timed: <%= @rake_organisations_fetch_frequency %>
+    logrotate:
+        artifactNumToKeep: 10
+- job:
+    name: signon_rake_users_suspend_inactive
+    display-name: signon_rake_users_suspend_inactive
+    project-type: freestyle
+    description: "<p>Regularly run the users:suspend_inactive rake task for Signonotron2.</p>"
+    publishers:
+        - trigger-parameterized-builds:
+            - project: run-rake-task
+              predefined-parameters: |
+                TARGET_APPLICATION=signon
+                MACHINE_CLASS=backend
+                RAKE_TASK=users:suspend_inactive
+        - email:
+            recipients: govuk-ci-notifications@digital.cabinet-office.gov.uk
+    triggers:
+      - timed: <%= @rake_users_suspend_inactive_frequency %>
+        logrotate:
+            artifactNumToKeep: 10
+- job:
+    name: signon_rake_users_send_suspension_reminders
+    display-name: signon_rake_users_send_suspension_reminders
+    project-type: freestyle
+    description: "<p>Regularly run the users:send_suspension_reminders rake task for Signonotron2.</p>"
+    publishers:
+        - trigger-parameterized-builds:
+            - project: run-rake-task
+              predefined-parameters: |
+                TARGET_APPLICATION=signon
+                MACHINE_CLASS=backend
+                RAKE_TASK=users:send_suspension_reminders
+        - email:
+            recipients: govuk-ci-notifications@digital.cabinet-office.gov.uk
+    triggers:
+      - timed: <%= @rake_users_send_suspension_reminders_frequency %>
+        logrotate:
+            artifactNumToKeep: 10


### PR DESCRIPTION
Part of https://trello.com/c/BrKRdn4f/495-rebuild-gov-uk-app-deployment-pipeline

Signon performs several rake tasks at regular intervals in order to
clean up certain user account specific data and fetch organisational
data. Previously this was done via the 'whenever' gem and the appropriate
cron configuration was passed from alphagov-deployment, this is going
away so we'll configure these tasks via jenkins per environment.

I'm not sure whether multiple jobs can be configured like this, given the structure of the jobs yaml file it's implied they are just an array of jobs.