### PR TITLE
CI Next Build Number Plugin

### DIFF
--- a/hieradata/class/ci_master.yaml
+++ b/hieradata/class/ci_master.yaml
@@ -103,6 +103,8 @@ govuk_jenkins::plugins:
       version: "1.1.1"
     monitoring:
       version: "1.62.0"
+    next-build-number:
+      version: "1.4"
     nodelabelparameter:
       version: "1.7.2"
     parameterized-trigger:


### PR DESCRIPTION
This plugin is required to preserve the history sequence of builds