### PR TITLE
Add deploy host aliases for jenkins master

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -995,6 +995,8 @@ hosts::production::licensify::hosts:
 hosts::production::management::hosts:
   jenkins-1:
     ip: '10.1.0.3'
+    legacy_aliases:
+      - "deploy.%{hiera('app_domain')}"
   puppetmaster-1:
     ip: '10.1.0.5'
     legacy_aliases:

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -417,6 +417,8 @@ hosts::production::frontend::hosts:
 hosts::production::management::hosts:
   jenkins-1:
     ip: '10.3.0.3'
+    legacy_aliases:
+      - "deploy.%{hiera('app_domain')}"
   puppetmaster-1:
     ip: '10.3.0.5'
     legacy_aliases:

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -375,6 +375,8 @@ hosts::production::frontend::hosts:
 hosts::production::management::hosts:
   jenkins-1:
     ip: '10.2.0.3'
+    legacy_aliases:
+      - "deploy.%{hiera('app_domain')}"
   puppetmaster-1:
     ip: '10.2.0.5'
     legacy_aliases:


### PR DESCRIPTION
CI agents need to connect with the Jenkins deploy instance using the
service name deploy.domain to avoid certificate issues. Instead of
opening access to the external facing interface we are adding an entry
to the hosts file to resolve deploy.domain with the internal IP.