### PR TITLE
Update Build strategy in Jenkins multibranch pipeline jobs

### DIFF
--- a/modules/govuk_ci/templates/application_build_job.xml.erb
+++ b/modules/govuk_ci/templates/application_build_job.xml.erb
@@ -34,7 +34,7 @@
           <excludes></excludes>
           <buildOriginBranch>true</buildOriginBranch>
           <buildOriginBranchWithPR>true</buildOriginBranchWithPR>
-          <buildOriginPRMerge>true</buildOriginPRMerge>
+          <buildOriginPRMerge>false</buildOriginPRMerge>
           <buildOriginPRHead>false</buildOriginPRHead>
           <buildForkPRMerge>false</buildForkPRMerge>
           <buildForkPRHead>false</buildForkPRHead>


### PR DESCRIPTION
Update the configuration of the Jenkins multibranch pipeline jobs
to avoid building PRs. This is disabled by default and after
seeing the behaviour we don't think we need a PR build on top of
the default branch build. For more information check the Github
Branch Source plugin documentation:

https://go.cloudbees.com/docs/cloudbees-documentation/cje-user-guide/index.html