### PR TITLE
Jenkins move gitconfig to user class

### DIFF
--- a/modules/govuk_jenkins/manifests/init.pp
+++ b/modules/govuk_jenkins/manifests/init.pp
@@ -82,14 +82,6 @@ class govuk_jenkins (
     home_dir     => $jenkins_homedir,
   }
 
-  file { "${jenkins_homedir}/.gitconfig":
-    source  => 'puppet:///modules/govuk_jenkins/dot-gitconfig',
-    owner   => $jenkins_user,
-    group   => $jenkins_user,
-    mode    => '0644',
-    require => Class['govuk_jenkins::user'],
-  }
-
   # In addition to the keystore below, this path is also referenced by the
   # `GITHUB_GDS_CA_BUNDLE` environment variable in Jenkins which is used by
   # ghtools during GitHub.com -> GitHub Enterprise repo backups.

--- a/modules/govuk_jenkins/manifests/user.pp
+++ b/modules/govuk_jenkins/manifests/user.pp
@@ -21,4 +21,12 @@ class govuk_jenkins::user (
     shell      => '/bin/bash',
   }
 
+  file { "${home_directory}/.gitconfig":
+    source  => 'puppet:///modules/govuk_jenkins/dot-gitconfig',
+    owner   => $username,
+    group   => $username,
+    mode    => '0644',
+    require => User[$username],
+  }
+
 }


### PR DESCRIPTION
The Jenkins user Git configuration needs to be applied on all the
CI nodes. The main govuk_jenkins class is only applied on the
master node, not the agents, so we move the gitconfig file to the
user class that is applied everywhere.