### PR TITLE
Upgrade ImageMagick to 8:6.7.7.10-6ubuntu3.3

### DIFF
--- a/modules/imagemagick/manifests/init.pp
+++ b/modules/imagemagick/manifests/init.pp
@@ -4,7 +4,7 @@
 #
 class imagemagick {
   package { 'imagemagick':
-    ensure => '8:6.7.7.10-6ubuntu3.2',
+    ensure => '8:6.7.7.10-6ubuntu3.3',
   }
 
   file { '/etc/ImageMagick/policy.xml':


### PR DESCRIPTION
This commit upgrades ImageMagick to the latest version.

Currently, some boxes fail to run puppet with:

```
Error: Could not update: Execution of '/usr/bin/apt-get -q -y -o DPkg::Options::=--force-confold --force-yes install imagemagick=8:6.7.7.10-6ubuntu3.2' returned 100: Reading package lists...
Building dependency tree...
Reading state information...
E: Version '8:6.7.7.10-6ubuntu3.2' for 'imagemagick' was not found
```

Further information:
https://launchpad.net/ubuntu/+source/imagemagick/8:6.7.7.10-6ubuntu3.3