### PR TITLE
Set fixed TCP port for Jenkins agent

### DIFF
--- a/hieradata/class/ci_master.yaml
+++ b/hieradata/class/ci_master.yaml
@@ -11,6 +11,7 @@ govuk_jenkins::config::views:
     - 'govuk-puppet'
     - 'integration-puppet-deploy'
 
+govuk_jenkins::config::agent_tcp_port: '54322'
 govuk_jenkins::config::create_agent_role: true
 govuk_jenkins::config::executors: '0'
 

--- a/modules/govuk_jenkins/manifests/config.pp
+++ b/modules/govuk_jenkins/manifests/config.pp
@@ -70,6 +70,11 @@
 # [*executors*]
 #   The number of executors a master can allocate to running jobs
 #
+# [*agent_tcp_port*]
+#   When set to anything other than 0, it specifies the TCP port that the
+#   Jenkins master connects to the Jenkins agent with (when using the JNLP
+#   agent). Default is '0', which enables setting a random port number.
+#
 class govuk_jenkins::config (
   $url_prefix = 'deploy',
   $app_domain = hiera('app_domain'),
@@ -91,6 +96,7 @@ class govuk_jenkins::config (
   $create_agent_role = false,
   $jenkins_agent_user = 'jenkins_agent',
   $executors = '4',
+  $agent_tcp_port = '0',
 ) {
 
   $url = "${url_prefix}.${app_domain}"

--- a/modules/govuk_jenkins/templates/config/config.xml.erb
+++ b/modules/govuk_jenkins/templates/config/config.xml.erb
@@ -143,7 +143,7 @@
     <%- end -%>
   </views>
   <primaryView>All</primaryView>
-  <slaveAgentPort>0</slaveAgentPort>
+  <slaveAgentPort><%= @agent_tcp_port %></slaveAgentPort>
   <label></label>
   <nodeProperties/>
   <globalNodeProperties>


### PR DESCRIPTION
This config setting allows you to set a fixed TCP port for connecting to Jenkins agents rather than using a random port number. Fixing this allows us to be more secure.

'0' is default and assigns a random number, as we do not need to set this on Jenkins deployment machines.

Related to: https://github.com/alphagov/govuk-puppet/pull/5202