### PR TITLE
Ci exclude release related branches from automated builds

### DIFF
--- a/modules/govuk_ci/templates/application_build_job.xml.erb
+++ b/modules/govuk_ci/templates/application_build_job.xml.erb
@@ -32,7 +32,7 @@
           <repoOwner><%= @repo_owner %></repoOwner>
           <repository><%= @repository %></repository>
           <includes>*</includes>
-          <excludes></excludes>
+          <excludes>release deployed-to-* integration staging production</excludes>
           <buildOriginBranch>true</buildOriginBranch>
           <buildOriginBranchWithPR>true</buildOriginBranchWithPR>
           <buildOriginPRMerge>false</buildOriginPRMerge>
@@ -46,7 +46,7 @@
           <remote>git@github.gds:gds/<%= @repository %>.git</remote>
           <credentialsId>github-enterprise-token-govukjenkinsci-username</credentialsId>
           <includes>*</includes>
-          <excludes></excludes>
+          <excludes>release deployed-to-* integration staging production</excludes>
           <ignoreOnPushNotifications>false</ignoreOnPushNotifications>
         </source>
 <%- end -%>


### PR DESCRIPTION
The new Multibranch pipeline jobs trigger a build for changes pushed
to branches. We want to exclude builds from branches used for
deployments, such as release, staging, etc.