### PR TITLE
Fix JNLP CI agents firewall rule

### DIFF
--- a/modules/govuk_ci/manifests/agent.pp
+++ b/modules/govuk_ci/manifests/agent.pp
@@ -25,7 +25,8 @@ class govuk_ci::agent {
   ufw::allow { 'allow-jenkins-master-to-connect-via-jnlp':
     port  => '54322',
     proto => 'tcp',
-    ip    => '10.1.6.10',
+    ip    => 'any',
+    from  => '10.1.6.10',
   }
 
   # Override sudoers.d resource (managed by sudo module) to enable Jenkins user to run sudo tests


### PR DESCRIPTION
Fix previously added rule, use 'from' instead of 'ip'