### PR TITLE
Add Slack properties and publisher to jobs

### DIFF
--- a/modules/govuk_jenkins/manifests/job/copy_data_to_integration.pp
+++ b/modules/govuk_jenkins/manifests/job/copy_data_to_integration.pp
@@ -16,6 +16,10 @@ class govuk_jenkins::job::copy_data_to_integration (
   $service_description = 'Copy Data to Integration'
   $job_url = "https://deploy.${app_domain}/job/copy_data_to_integration"
 
+  $slack_team_domain = 'govuk'
+  $slack_room = '2ndline'
+  $slack_build_server_url = "https://deploy.${app_domain}/"
+
   file { '/etc/jenkins_jobs/jobs/copy_data_to_integration.yaml':
     ensure  => present,
     content => template('govuk_jenkins/jobs/copy_data_to_integration.yaml.erb'),

--- a/modules/govuk_jenkins/manifests/job/deploy_puppet.pp
+++ b/modules/govuk_jenkins/manifests/job/deploy_puppet.pp
@@ -13,7 +13,12 @@
 class govuk_jenkins::job::deploy_puppet (
   $auth_token = undef,
   $commitish   = 'release',
+  $app_domain = hiera('app_domain')
 ) {
+  $slack_team_domain = 'govuk'
+  $slack_room = '2ndline'
+  $slack_build_server_url = "https://deploy.${app_domain}/"
+
   file { '/etc/jenkins_jobs/jobs/deploy_puppet.yaml':
     ensure  => present,
     content => template('govuk_jenkins/jobs/deploy_puppet.yaml.erb'),

--- a/modules/govuk_jenkins/manifests/job/smokey.pp
+++ b/modules/govuk_jenkins/manifests/job/smokey.pp
@@ -41,7 +41,12 @@ class govuk_jenkins::job::smokey (
   $smokey_bearer_token = undef,
   $smokey_rate_limit_token = undef,
   $smokey_task = 'test:production',
+  $app_domain = hiera('app_domain')
 ) {
+  $slack_team_domain = 'govuk'
+  $slack_room = '2ndline'
+  $slack_build_server_url = "https://deploy.${app_domain}/"
+
   file { '/etc/jenkins_jobs/jobs/smokey.yaml':
     ensure  => present,
     content => template('govuk_jenkins/jobs/smokey.yaml.erb'),

--- a/modules/govuk_jenkins/manifests/job_builder.pp
+++ b/modules/govuk_jenkins/manifests/job_builder.pp
@@ -43,7 +43,7 @@ class govuk_jenkins::job_builder (
   validate_array($jobs)
 
   package { 'jenkins-job-builder':
-    ensure   => '1.3.0',
+    ensure   => '1.6.1',
     provider => pip,
   }
 

--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
@@ -20,6 +20,16 @@
         - inject:
             properties-content: |
               PARALLEL_JOBS=2
+        - slack:
+            notify-start: false
+            notify-success: true
+            notify-aborted: true
+            notify-notbuilt: true
+            notify-unstable: false
+            notify-failure: true
+            notify-backtonormal: false
+            notify-repeatedfailure: false
+            include-test-summary: false
     scm:
       - env-sync-and-backup_Copy_Data_to_Integration
     logrotate:
@@ -60,6 +70,11 @@
             HOSTNAME=deploy.integration.publishing.service.gov.uk
             API_KEY=<%= @ci_alphagov_api_key %>
             AUTH_TOKEN=<%= @auth_token %>
+      - slack:
+          team-domain: <%= @slack_team_domain %>
+          auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN']%>
+          build-server-url: <%= @slack_build_server_url %>
+          room: <%= @slack_room %>
     wrappers:
         - ansicolor:
             colormap: xterm

--- a/modules/govuk_jenkins/templates/jobs/deploy_puppet.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_puppet.yaml.erb
@@ -18,6 +18,16 @@
     properties:
         - github:
             url: https://github.gds/gds/deployment/
+        - slack:
+            notify-start: false
+            notify-success: true
+            notify-aborted: true
+            notify-notbuilt: true
+            notify-unstable: false
+            notify-failure: true
+            notify-backtonormal: false
+            notify-repeatedfailure: false
+            include-test-summary: false
     scm:
       - deployment_Deploy_Puppet
     builders:
@@ -32,6 +42,11 @@
             - project: GDS_Production_Backup
               predefined-parameters: TARGET_APPLICATION_GIT_REPO=$WORKSPACE/puppet
               condition: 'UNSTABLE_OR_BETTER'
+        - slack:
+            team-domain: <%= @slack_team_domain %>
+            auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN']%>
+            build-server-url: <%= @slack_build_server_url %>
+            room: <%= @slack_room %>
     wrappers:
         - ansicolor:
             colormap: xterm

--- a/modules/govuk_jenkins/templates/jobs/smokey.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/smokey.yaml.erb
@@ -13,6 +13,23 @@
     project-type: freestyle
     scm:
       - smokey_Smokey
+    properties:
+      - slack:
+          notify-start: false
+          notify-success: false
+          notify-aborted: true
+          notify-notbuilt: true
+          notify-unstable: false
+          notify-failure: true
+          notify-backtonormal: false
+          notify-repeatedfailure: false
+          include-test-summary: false
+    publishers:
+      - slack:
+          team-domain: <%= @slack_team_domain %>
+          auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN']%>
+          build-server-url: <%= @slack_build_server_url %>
+          room: <%= @slack_room %>
     builders:
         - shell: |
             set +x


### PR DESCRIPTION
This commit adds the slack configuration to the following jobs:
- Copy Data To Integration;
- Smokey;
- Deploy Puppet.

This will alert us on some of the statuses on those jobs (more details on which alerts can be seen in the individual commits).

Requires:
- [x] https://github.gds/gds/deployment/pull/1172 to be merged;
- [x] https://github.gds/gds/deployment/pull/1177 to be merged;
- [x] testing in integration.

Original PR is [here](https://github.com/alphagov/govuk-puppet/pull/4909) for reference.