### PR TITLE
Write MONGODB_NODES for manuals-publisher correctly

### DIFF
--- a/modules/govuk/manifests/apps/manuals_publisher.pp
+++ b/modules/govuk/manifests/apps/manuals_publisher.pp
@@ -99,7 +99,22 @@ class govuk::apps::manuals_publisher(
   # Either MONGODB_URI or MONGODB_NODES should be removed from this module once
   # we have resolved ruby version issues.
   # Please talk to Steve Laing for more information.
-  $mongodb_nodes_template = '<%= @mongodb_nodes.map { |node| "- #{node}:27017" }.join("\n") %>'
+  # The first line shouldn't be indented, but the other lines need to be so
+  # that they line up with the YAML file they're inserted into.  For example
+  # given yaml like:
+  # nodes:
+  #   - <%= ENV['MONGODB_NODES'] %>
+  # we want:
+  # nodes:
+  #   - - first_node
+  #     - second_node
+  # which means the first_node line needs no indent, but second_node line
+  # needs a 4 char indent (in the real file the indent is 6 chars as nodes
+  # is itself indented).
+  $mongodb_nodes_template = '<%
+    first_node, *other_nodes = @mongodb_nodes
+    yaml_version = (["- #{first_node}:27017"] + other_nodes.map { |node| "      - #{node}:27017" }).join("\n")
+    %><%= yaml_version %>'
   $mongodb_nodes_string = inline_template($mongodb_nodes_template)
 
   govuk::app::envvar {


### PR DESCRIPTION
This value is expected to be slotted into a YAML file as an array.  The key
the value belongs to is nested and so the lines need to be indented correctly
or the resulting YAML file will be invalid.  Given some YAML as follows:

    production:
      hosts:
        - <%= ENV['MONGODB_NODES'] %>

If we don't add indentation to the lines after the first one what we end up
with is:

    production:
      hosts:
        - - first_node:27017
    - second_node:27017
    - and-so-on

This is not valid YAML and so the app will refuse to load the mongoid config
and ultimately refuse to run.  By tweaking the env var value to indent those
lines and correctly format the YAML as follows:

    production:
      hosts:
        - - first_node:27017
          - second_node:27017
          - and-so-on

And the app will boot again.

The bug in the formatting of this env var value was exposed by commit
336343d5198a62e76ab1da5515a6e40cbaf9fc0b where we introduced support
for multiline env vars.  Prior to this commit this value was ultimately treated
as a single line value.  The single line version of the value fits into the
YAML file correctly as the first line doesn't need indenting, so the problem
never arose.  Although it did mean that the app only ever communicated with
one of the expected mongo nodes.