### PR TITLE
Fix CI Groovy pushTag function to update release branch

### DIFF
--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -14,10 +14,12 @@
 def pushTag(String repository, String branch, String tag) {
 
   if (branch == 'master'){
-    echo "Tagging alphagov/${repository} master branch -> ${tag}"
     sshagent(['govuk-ci-ssh-key']) {
       sh("git tag -a ${tag} -m 'Jenkinsfile tagging with ${tag}'")
+      echo "Tagging alphagov/${repository} master branch -> ${tag}"
       sh("git push git@github.com:alphagov/${repository}.git ${tag}")
+      echo "Updating alphagov/${repository} release branch"
+      sh("git push git@github.com:alphagov/${repository}.git HEAD:release")
     }
   } else {
     echo "No tagging on branch"


### PR DESCRIPTION
In our CI pipeline we need to update the release branch of
each repository every time we push a release tag. This is
needed for automated deployments, so the release branch
always contains a version of the code that has passed all
the tests.