### PR TITLE
Fix CI Opsmanual job source to use Git Enterprise

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -607,7 +607,8 @@ govuk_ci::master::pipeline_jobs:
   licensify:
     source: 'git'
   omniauth-gds: {}
-  opsmanual: {}
+  opsmanual:
+    source: 'git'
   optic14n: {}
   performance-datastore: {}
   performanceplatform-client.py: {}


### PR DESCRIPTION
Update the configuration of the Opsmanual job in CI to use
Git Enterprise instead of GitHub.