### PR TITLE
Enable integration-app-deploy in CI

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/integration_app_deploy.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/integration_app_deploy.yaml.erb
@@ -9,7 +9,7 @@
           JSON="{\"parameter\": [{\"name\": \"TARGET_APPLICATION\", \"value\": \"$TARGET_APPLICATION\"}, {\"name\": \"TAG\", \"value\": \"$TAG\"}, {\"name\": \"DEPLOY_TASK\", \"value\": \"$DEPLOY_TASK\"}], \"\": \"\"}"
 
           # Deploy to integration environment
-          echo curl -f -XPOST https://<%= @jenkins_integration_api_user %>:<%= @jenkins_integration_api_password %>@deploy.integration.publishing.service.gov.uk/job/Deploy_App/build --data-urlencode json="$JSON"
+          curl -f -XPOST https://<%= @jenkins_integration_api_user %>:<%= @jenkins_integration_api_password %>@deploy.integration.publishing.service.gov.uk/job/Deploy_App/build --data-urlencode json="$JSON"
     wrappers:
         - ansicolor:
             colormap: xterm


### PR DESCRIPTION
Enable the action in the integration-app-deploy CI job to trigger
the deploy build on Integration.