### PR TITLE
Enable signon jenkins rake tasks

### DIFF
--- a/hieradata/class/integration/jenkins.yaml
+++ b/hieradata/class/integration/jenkins.yaml
@@ -18,6 +18,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::run_whitehall_data_migrations
   - govuk_jenkins::job::sanitize_publishing_api_data
   - govuk_jenkins::job::service_manual_rebuild_search_index
+  - govuk_jenkins::job::signon_cron_rake_tasks
   - govuk_jenkins::job::smokey
   - govuk_jenkins::job::smokey_deploy
   - govuk_jenkins::job::tagging_sync_check

--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -31,6 +31,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::run_whitehall_data_migrations
   - govuk_jenkins::job::search_fetch_analytics_data
   - govuk_jenkins::job::service_manual_rebuild_search_index
+  - govuk_jenkins::job::signon_cron_rake_tasks
   - govuk_jenkins::job::smokey
   - govuk_jenkins::job::smokey_deploy
   - govuk_jenkins::job::transition_load_all_data


### PR DESCRIPTION
Part of https://trello.com/c/BrKRdn4f/495-rebuild-gov-uk-app-deployment-pipeline

Missed in https://github.com/alphagov/govuk-puppet/pull/5191

These are only needed in integration and production.