### PR TITLE
Proxy assets for trade tariff

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -256,6 +256,7 @@ govuk::apps::contentapi::nagios_memory_critical: 4000
 
 govuk::apps::content_store::nagios_memory_warning: 2300
 govuk::apps::content_store::nagios_memory_critical: 2500
+govuk::apps::content_store::trade_tariff_uri: "https://%{hiera('trade_tariff_hostname')}"
 
 govuk::apps::content_tagger::db_hostname: "postgresql-primary-1.backend"
 govuk::apps::content_tagger::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
@@ -1374,6 +1375,8 @@ sidekiq_port: '6379'
 
 ssh::config::allow_users_enable: true
 
+trade_tariff_hostname: 'tariff-frontend-dev.cloudapps.digital'
+
 unattended_reboot::cron_env_vars:
   - 'MAILTO=""'
 unattended_reboot::cron_hour: '0-5'
@@ -1388,5 +1391,3 @@ unattended_upgrades::origins:
  - "%{::lsbdistid} %{::lsbdistcodename}-security"
 
 unicornherder::version: '0.0.8'
-
-trade_tariff_uri: 'https://tariff-frontend-dev.cloudapps.digital'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1337,6 +1337,8 @@ router::assets_origin::asset_routes:
   '/spotlight/': "spotlight"
   '/stagecraft/': "stagecraft"
 
+router::assets_origin::trade_tariff_host: "%{hiera('trade_tariff_hostname')}"
+
 router::assets_origin::vhost_aliases:
   - 'assets.digital.cabinet-office.gov.uk'
   - 'assets.publishing.service.gov.uk'

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -565,4 +565,4 @@ shell::shell_prompt_string: 'production'
 mongodb::s3backup::backup::s3_bucket: 'govuk-mongodb-backup-s3-production'
 mongodb::s3backup::backup::s3_bucket_daily: 'govuk-mongodb-backup-s3-daily-production'
 
-trade_tariff_uri: 'https://tariff-frontend-production.cloudapps.digital'
+trade_tariff_hostname: 'tariff-frontend-production.cloudapps.digital'

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -519,4 +519,4 @@ users::pentest_machines:
 mongodb::s3backup::backup::s3_bucket: 'govuk-mongodb-backup-s3-staging'
 mongodb::s3backup::backup::s3_bucket_daily: 'govuk-mongodb-backup-s3-daily-staging'
 
-trade_tariff_uri: 'https://tariff-frontend-staging.cloudapps.digital'
+trade_tariff_hostname: 'tariff-frontend-staging.cloudapps.digital'

--- a/lib/puppet-lint/plugins/check_hiera.rb
+++ b/lib/puppet-lint/plugins/check_hiera.rb
@@ -47,7 +47,6 @@ PuppetLint.new_check(:hiera_explicit_lookup) do
     'nginx_enable_ssl',
     'sflg_certificate',
     'sflg_key',
-    'trade_tariff_uri',
     'wildcard_publishing_certificate',
     'wildcard_publishing_key',
     'www_crt',

--- a/modules/govuk/manifests/apps/content_store.pp
+++ b/modules/govuk/manifests/apps/content_store.pp
@@ -38,6 +38,9 @@
 # [*secret_key_base*]
 #   The key for Rails to use when signing/encrypting sessions.
 #
+# [*trade_tariff_uri*]
+#   A URI where Trade Tariff is available on the internet.
+#
 class govuk::apps::content_store(
   $port = '3068',
   $mongodb_nodes,
@@ -49,6 +52,7 @@ class govuk::apps::content_store(
   $nagios_memory_critical = undef,
   $errbit_api_key = '',
   $secret_key_base = undef,
+  $trade_tariff_uri = '',
 ) {
   $app_name = 'content-store'
 
@@ -78,8 +82,6 @@ class govuk::apps::content_store(
       value   => $secret_key_base;
     }
   }
-
-  $trade_tariff_uri = hiera('trade_tariff_uri')
 
   govuk::app::envvar {
     "${title}-DEFAULT_TTL":

--- a/modules/router/manifests/assets_origin.pp
+++ b/modules/router/manifests/assets_origin.pp
@@ -11,6 +11,9 @@
 #   Uses the Nginx realip module (http://nginx.org/en/docs/http/ngx_http_realip_module.html)
 #   to change the client IP address to the one in the specified HTTP header.
 #
+# [*trade_tariff_host*]
+#   The hostname where trade tariff is available on the internet to proxy to for assets.
+#
 # [*vhost_aliases*]
 #   Array of other vhosts that assets should be served on at origin
 #
@@ -20,6 +23,7 @@
 class router::assets_origin(
   $asset_routes = {},
   $real_ip_header = '',
+  $trade_tariff_host = undef,
   $vhost_aliases = [],
   $vhost_name,
 ) {

--- a/modules/router/templates/assets_origin.conf.erb
+++ b/modules/router/templates/assets_origin.conf.erb
@@ -45,6 +45,14 @@ server {
   }
 
   <%- end -%>
+
+  <%- if @trade_tariff_host -%>
+  location /tariff/ {
+    proxy_set_header Host <%= @trade_tariff_host %>;
+    proxy_pass https://<%= @trade_tariff_host %>;
+  }
+  <%- end -%>
+
   location / {
     proxy_set_header Host static.<%= @app_domain %>;
     proxy_pass <%= @enable_ssl ? 'https' : 'http' %>://static.<%= @app_domain %>;


### PR DESCRIPTION
While trade tariff is still available on GOV.UK (but hosted on the PaaS) we should make the assets available on our assets domain.

This matches the behaviour we had before it moved to the PaaS.