### PR TITLE
Disable browser download in Jenkins

### DIFF
--- a/modules/govuk_jenkins/files/var/lib/jenkins/jenkins.model.DownloadSettings.xml
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/jenkins.model.DownloadSettings.xml
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <jenkins.model.DownloadSettings>
-  <useBrowser>true</useBrowser>
+  <useBrowser>false</useBrowser>
 </jenkins.model.DownloadSettings>


### PR DESCRIPTION
This is strongly discouraged by the new version of Jenkins we use:

> You currently are using browser-based download to retrieve metadata for Jenkins
> plugins and tools. This has reliability issues and is not considered fully secure.

And:

> this can be used to at least see new metadata when Jenkins cannot access the Internet

We don't need it.