### PR TITLE
Template config file for Jenkins 2

### DIFF
--- a/modules/govuk_jenkins/manifests/config.pp
+++ b/modules/govuk_jenkins/manifests/config.pp
@@ -197,8 +197,13 @@ class govuk_jenkins::config (
       content => template('govuk_jenkins/config/jenkins.model.JenkinsLocationConfiguration.xml.erb'),
     }
 
+    # FIXME: Remove once all Jenkinses are upgraded to at least 2.0.0
     if versioncmp($version, '2.0.0') == 1 {
       $csrf_version = true
+      $jenkins_2 = true
+      $markup_formatter_version = '1.5'
+    } else {
+      $markup_formatter_version = '1.3'
     }
 
     file { '/var/lib/jenkins/config.xml':

--- a/modules/govuk_jenkins/templates/config/config.xml.erb
+++ b/modules/govuk_jenkins/templates/config/config.xml.erb
@@ -14,8 +14,13 @@
     <roleMap type="globalRoles">
       <role name="Anonymouse" pattern=".*">
         <permissions>
+          <%- if @jenkins_2 -%>
+          <permission>hudson.model.Item.Discover</permission>
+          <permission>hudson.model.Hudson.Read</permission>
+          <%- else -%>
           <permission>hudson.model.Hudson.Read</permission>
           <permission>hudson.model.Item.Discover</permission>
+          <%- end -%>
         </permissions>
         <assignedSIDs>
           <sid>anonymous</sid>
@@ -23,6 +28,26 @@
       </role>
       <role name="admin" pattern=".*">
         <permissions>
+          <%- if @jenkins_2 -%>
+          <permission>hudson.scm.SCM.Tag</permission>
+          <permission>hudson.model.View.Delete</permission>
+          <permission>hudson.model.Item.Read</permission>
+          <permission>hudson.model.Hudson.Administer</permission>
+          <permission>hudson.model.Item.Configure</permission>
+          <permission>hudson.model.Item.Workspace</permission>
+          <permission>hudson.model.Hudson.RunScripts</permission>
+          <permission>hudson.model.View.Create</permission>
+          <permission>hudson.model.View.Read</permission>
+          <permission>hudson.model.Run.Delete</permission>
+          <permission>hudson.model.Item.Discover</permission>
+          <permission>hudson.model.Item.Create</permission>
+          <permission>hudson.model.Item.Build</permission>
+          <permission>hudson.model.Item.Cancel</permission>
+          <permission>hudson.model.Hudson.Read</permission>
+          <permission>hudson.model.Item.Delete</permission>
+          <permission>hudson.model.Run.Update</permission>
+          <permission>hudson.model.View.Configure</permission>
+          <%- else -%>
           <permission>hudson.model.Hudson.Administer</permission>
           <permission>hudson.model.Hudson.Read</permission>
           <permission>hudson.model.Hudson.RunScripts</permission>
@@ -41,11 +66,12 @@
           <permission>hudson.model.View.Delete</permission>
           <permission>hudson.model.View.Read</permission>
           <permission>hudson.scm.SCM.Tag</permission>
+          <%- end -%>
         </permissions>
         <assignedSIDs>
-          <% @admins.each do |a| -%>
-          !<sid><%= a %></sid>
-          <% end -%>
+          <%- @admins.each do |a| -%>
+          <%- if not @jenkins_2 -%>!<%- end -%><sid><%= a %></sid>
+          <%- end -%>
         </assignedSIDs>
       </role>
       <%- if @create_agent_role -%>
@@ -73,8 +99,13 @@
       </role>
       <role name="read_only" pattern=".*">
         <permissions>
+          <%- if @jenkins_2 -%>
+          <permission>hudson.model.Item.Read</permission>
+          <permission>hudson.model.Hudson.Read</permission>
+          <%- else -%>
           <permission>hudson.model.Hudson.Read</permission>
           <permission>hudson.model.Item.Read</permission>
+          <%- end -%>
         </permissions>
         <assignedSIDs/>
       </role>
@@ -87,6 +118,9 @@
     <githubApiUri><%= @github_api_uri -%></githubApiUri>
     <clientID><%= @github_client_id -%></clientID>
     <clientSecret><%= @github_client_secret -%></clientSecret>
+    <%- if @jenkins_2 -%>
+    <oauthScopes>read:org,user:email</oauthScopes>
+    <%- end -%>
   </securityRealm>
   <disableRememberMe>false</disableRememberMe>
   <projectNamingStrategy class="jenkins.model.ProjectNamingStrategy$PatternProjectNamingStrategy">
@@ -97,14 +131,16 @@
   <workspaceDir>${JENKINS_HOME}/workspace/${ITEM_FULLNAME}</workspaceDir>
   <buildsDir>${ITEM_ROOTDIR}/builds</buildsDir>
   <systemMessage>&lt;h2 style=&quot;background-color: <%= @banner_colour_background -%>; color: <%= @banner_colour_text -%>; padding: 0.5em;&quot;&gt;<%= @banner_string -%>&lt;/h2&gt;</systemMessage>
-  <markupFormatter class="hudson.markup.RawHtmlMarkupFormatter" plugin="antisamy-markup-formatter@1.3">
+  <markupFormatter class="hudson.markup.RawHtmlMarkupFormatter" plugin="antisamy-markup-formatter@<%= @markup_formatter_version -%>">
     <disableSyntaxHighlighting>false</disableSyntaxHighlighting>
   </markupFormatter>
   <jdks/>
   <viewsTabBar class="hudson.views.DefaultViewsTabBar"/>
   <myViewsTabBar class="hudson.views.DefaultMyViewsTabBar"/>
   <clouds/>
+  <%- if not @jenkins_2 -%>
   <slaves/>
+  <%- end -%>
   <quietPeriod>5</quietPeriod>
   <scmCheckoutRetryCount>0</scmCheckoutRetryCount>
   <views>
@@ -145,11 +181,11 @@
   <primaryView>All</primaryView>
   <slaveAgentPort><%= @agent_tcp_port %></slaveAgentPort>
   <label></label>
- <% if @csrf_version -%>
+  <%- if @csrf_version -%>
   <crumbIssuer class="hudson.security.csrf.DefaultCrumbIssuer">
     <excludeClientIPFromCrumb>false</excludeClientIPFromCrumb>
   </crumbIssuer>
- <% end -%>
+  <%- end -%>
   <nodeProperties/>
   <globalNodeProperties>
     <hudson.slaves.EnvironmentVariablesNodeProperty>


### PR DESCRIPTION
Jenkins 2 is super picky about its config file. Jenkins 2 will decide to modify its config file when it starts so that it's formatted the way it wants it to be. Puppet will then revert that change and cause Jenkins to restart.

Here are some of the highlights of this ridiculousness:

- In Jenkins 2, things are sorted in some arbitrary way which is different to Jenkins 1. Don't try and sort things the old way. I could get on board with this except that it's less alphabetical than the sort order we were using in Jenkins 1.
- Jenkins 1 will add an exclamation mark before the XML for user IDs. Jenkins 2 will remove that exclamation mark.
- If Jenkins 2 decides that it needs to rewrite your perfectly fine config file, it will write out a POSIX-incompatible file because it doesn't have trailing newline character.

I am sick of XML and I am sick of using Jenkins and I feel awful for littering an XML template with conditionals but what are you going to do ¯\\\_(ツ)\_/¯.