### PR TITLE
Configure VPN on all CI machines

### DIFF
--- a/hieradata/vagrant_credentials.yaml
+++ b/hieradata/vagrant_credentials.yaml
@@ -125,9 +125,10 @@ govuk_ci::credentials::pypi_live_password: 'passwordlive'
 
 govuk_ci::master::github_client_id: 'bellathecat'
 govuk_ci::master::github_client_secret: 'sheisfurry'
-govuk_ci::master::ghe_vpn_username: 'bella'
-govuk_ci::master::ghe_vpn_password: 'furrysocks'
 govuk_ci::master::jenkins_api_token: 'thisisatoken'
+
+govuk_ci::vpn::ghe_vpn_username: 'bella'
+govuk_ci::vpn::ghe_vpn_password: 'furrysocks'
 
 govuk::deploy::aws_ses_smtp_username: 'a_username'
 govuk::deploy::aws_ses_smtp_password: 'a_password'

--- a/modules/govuk_ci/manifests/agent.pp
+++ b/modules/govuk_ci/manifests/agent.pp
@@ -11,6 +11,7 @@ class govuk_ci::agent {
   include ::govuk_ci::agent::postgresql
   include ::govuk_ci::agent::mysql
   include ::govuk_ci::agent::swarm
+  include ::govuk_ci::vpn
   include ::govuk_java::oracle8
   include ::govuk_rbenv::all
   include ::golang

--- a/modules/govuk_ci/manifests/master.pp
+++ b/modules/govuk_ci/manifests/master.pp
@@ -10,26 +10,19 @@
 # [*github_client_secret*]
 #   The Github client secret is used to authenticate against Github.
 #
-# [*ghe_vpn_username*]
-#   The username used to connect to the Github Enterprise VPN
-#
-# [*ghe_vpn_password*]
-#   The password to authenticate against the Github Enterprise VPN
-#
 # [*environment_variables*]
 #   A hash of environment variables that should be set for all Jenkins jobs.
 #
 class govuk_ci::master (
   $github_client_id,
   $github_client_secret,
-  $ghe_vpn_username,
-  $ghe_vpn_password,
   $jenkins_api_token,
   $pipeline_jobs = {},
   $environment_variables = {},
 ){
 
   include ::govuk_ci::credentials
+  include ::govuk_ci::vpn
 
   # After these users have been created, you'll have to retrieve the API token from the UI
   govuk_jenkins::api_user { 'jenkins_agent': }
@@ -39,11 +32,6 @@ class govuk_ci::master (
     github_client_secret  => $github_client_secret,
     jenkins_api_token     => $jenkins_api_token,
     environment_variables => $environment_variables,
-  }
-
-  class { 'govuk_ghe_vpn':
-    username => $ghe_vpn_username,
-    password => $ghe_vpn_password,
   }
 
   # Add govuk-puppet job

--- a/modules/govuk_ci/manifests/vpn.pp
+++ b/modules/govuk_ci/manifests/vpn.pp
@@ -1,0 +1,24 @@
+# == Class: govuk_ci::vpn
+#
+# Configure VPN on CI machines.
+#
+# === Parameters:
+#
+# [*ghe_vpn_username*]
+#   The username used to connect to the Github Enterprise VPN
+#
+# [*ghe_vpn_password*]
+#   The password to authenticate against the Github Enterprise VPN
+#
+class govuk_ci::vpn (
+  $ghe_vpn_username,
+  $ghe_vpn_password,
+) {
+
+  class { 'govuk_ghe_vpn':
+    username => $ghe_vpn_username,
+    password => $ghe_vpn_password,
+  }
+
+}
+


### PR DESCRIPTION
Jenkins agents need access to Github Enterprise via VPN. Update
the CI modules to include the Openconnect configuration on all
the CI machines (master and agents).