### PR TITLE
Use default elasticsearch heapsize

### DIFF
--- a/hieradata/class/ci_agent.yaml
+++ b/hieradata/class/ci_agent.yaml
@@ -11,6 +11,5 @@ govuk_ci::agent::swarm::agent_labels:
 postgresql::globals::version: '9.3'
 govuk_mysql::server::innodb_flush_log_at_trx_commit: 0
 
-govuk_elasticsearch::heap_size: '64m'
 govuk_elasticsearch::minimum_master_nodes: '1'
 govuk_elasticsearch::version: '1.7.5'


### PR DESCRIPTION
The tiny heapsize is causing elasticsearch to throw Java OutOfMemory errors when trying to run tests:

```
[2016-12-05 12:23:17,498][DEBUG][action.admin.indices.create]
[ci-agent-1.ci.integration.publishing.service.gov.uk]
[page-traffic_test-2016-12-05t12:22:37z-f71d6755-4de1-4421-a9ae-49e309f9fb88] failed to create
java.lang.OutOfMemoryError: Java heap space
```

The agents have plenty of memory available, so let's use the default heap size used by govuk_elasticsearch class (512MB).