### PR TITLE
Remove reverse proxy for drug-analysis-prints

### DIFF
--- a/modules/bouncer/templates/www.mhra.gov.uk_nginx.conf.erb
+++ b/modules/bouncer/templates/www.mhra.gov.uk_nginx.conf.erb
@@ -21,12 +21,6 @@ server {
       '/home/resources/',
       '/home/websites/',
 
-      # Drug Analysis Prints content
-      # New location for Drug Analysis Prints index:
-      '/drug-analysis-prints/',
-      # Drug Analysis Prints PDFs are under here:
-      '/home/groups/public/documents/sentineldocuments/',
-
       # Summaries of Product Characteristics (SPCs) and patient information leaflets (PILs)
       '/home/groups/spcpil/documents/spcpil/', # PDFs
       '/spc-pil/', # New location for SPCs and PILs


### PR DESCRIPTION
This relates to https://govuk.zendesk.com/agent/tickets/1453127

We're removing the reverse proxy configuration for `/drug-analysis-prints/` as MHRA have a new site which they want to manage mappings for.

The PDFs under `/home/groups/public/documents/sentineldocuments/` appear to all 404 now so we're removing this now.  I've requested that MHRA add mappings for these as there are 1436 of these without mappings.