### PR TITLE
CI update credentials plugins

### DIFF
--- a/hieradata/class/ci_master.yaml
+++ b/hieradata/class/ci_master.yaml
@@ -47,6 +47,8 @@ govuk_jenkins::plugins:
       version: "1.3.5"
     copyartifact:
       version: "1.38.1"
+    credentials-binding:
+      version: "1.10"
     description-setter:
       version: "1.10"
     display-url-api:
@@ -122,7 +124,7 @@ govuk_jenkins::plugins:
     pipeline-stage-view:
       version: "2.2"
     plain-credentials:
-      version: "1.1"
+      version: "1.3"
     rake:
       version: "1.8.0"
     rebuild:


### PR DESCRIPTION
In order to use withCredentials function in our Jenkinsfiles, to access
credential parameters within the pipeline stages, we need to install
the credentials-binding plugin, that requires a newer version of
plain-credentials.