### PR TITLE
Reduce number of elasticsearch replicas

### DIFF
--- a/hieradata/class/ci_agent.yaml
+++ b/hieradata/class/ci_agent.yaml
@@ -14,3 +14,4 @@ govuk_mysql::server::innodb_flush_log_at_trx_commit: 0
 govuk_elasticsearch::heap_size: '64m'
 govuk_elasticsearch::minimum_master_nodes: '1'
 govuk_elasticsearch::version: '1.7.5'
+govuk_elasticsearch::number_of_replicas: '0'


### PR DESCRIPTION
On a single node elasticsearch cluster we do not want any replicas set. This matches the behaviour on legacy CI, and without this setting the elasticsearch clusters are going "red" status when importing data due to unassigned shards.