### PR TITLE
Add respawn to jenkins-agent upstart

### DIFF
--- a/modules/govuk_ci/templates/jenkins-agent.conf.erb
+++ b/modules/govuk_ci/templates/jenkins-agent.conf.erb
@@ -1,6 +1,9 @@
 start on runlevel [2345]
 stop on runlevel [!2345]
 
+respawn
+respawn limit 5 20
+
 script
         test -f /etc/default/locale && . /etc/default/locale || true
         export LANG


### PR DESCRIPTION
We should try restarting the service if it crashes before the CI master determines that is unable to connect to it.