### PR TITLE
Run docker_security_bench once a week via cron.

### DIFF
--- a/modules/govuk/manifests/node/s_docker_management.pp
+++ b/modules/govuk/manifests/node/s_docker_management.pp
@@ -3,6 +3,7 @@
 class govuk::node::s_docker_management inherits govuk::node::s_base {
 
   include ::docker
+  include ::govuk_containers::docker_security_bench
 
   $etcd_image = 'quay.io/coreos/etcd'
   $etcd_image_version = 'v3.0.13'

--- a/modules/govuk_containers/manifests/docker_security_bench.pp
+++ b/modules/govuk_containers/manifests/docker_security_bench.pp
@@ -1,0 +1,24 @@
+# == Class: govuk_containers::docker_security_bench
+#
+#  Add a cronjob to periodically run the docker_security_bench container and send its
+#  results to the central cron information store.
+#
+#  This should be a non-persistent container.
+#
+class govuk_containers::docker_security_bench {
+
+  $cron_command = "/usr/bin/docker run -it --net host --pid host --cap-add audit_control \
+         -v /var/lib:/var/lib \
+         -v /var/run/docker.sock:/var/run/docker.sock \
+         -v /usr/lib/systemd:/usr/lib/systemd \
+         -v /etc:/etc \
+         --label docker_bench_security     docker/docker-bench-security"
+
+  cron::crondotdee { 'docker_security_bench':
+    command => $cron_command,
+    hour    => 6,
+    minute  => 45,
+    weekday => 0,
+  }
+
+}


### PR DESCRIPTION
`docker_security_bench` is a container provided by docker to
check your installation and running containers against a number of simple
security criteria. We will run it periodically to ensure we don't
make any of those mistakes.