### PR TITLE
Adjust setting of envars in Groovy scripts

### DIFF
--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -31,7 +31,7 @@ def mergeMasterBranch() {
  */
 def setEnvar(String key, String value) {
   echo 'Setting environment variable'
-  sh("export ${key}=${value}")
+  env."${key}" = value
 }
 
 /**


### PR DESCRIPTION
This was previously only setting an envar for the specific bash shell being called and not the global shell where the Jenkins job is running.

cc @surminus @afda16 