### PR TITLE
Disable client unique ID

### DIFF
--- a/modules/govuk_ci/templates/jenkins-agent.conf.erb
+++ b/modules/govuk_ci/templates/jenkins-agent.conf.erb
@@ -9,5 +9,6 @@ script
                 -username jenkins_agent -password <%= @agent_user_api_token %> \
                 -name <%= @hostname %> -executors <%= @executors %> \
                 -master https://<%= @ci_master %>/ \
-                -fsroot <%= @fsroot %> -labels '<%= @labels %>'
+                -fsroot <%= @fsroot %> -labels '<%= @labels %>' \
+                -disableClientsUniqueId
 end script


### PR DESCRIPTION
When the agents register with the Jenkins master they register themselves with a unique ID. We do not need this function enabled, and it makes it harder to pin specific jobs to specific agents for testing purposes.