### PR TITLE
Configure GitHub branch source plugin in CI to work with GitHub Enterprise

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -641,7 +641,7 @@ govuk_crawler::site_root: 'https://www.gov.uk'
 govuk_elasticsearch::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 govuk_jenkins::package::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
-govuk_jenkins::github_enterprise_cert: |
+govuk_jenkins::github_enterprise_cert::certificate: |
     -----BEGIN CERTIFICATE-----
     MIIEdDCCA1ygAwIBAgIJAKt4YiHj0+tVMA0GCSqGSIb3DQEBBQUAMIGCMQswCQYD
     VQQGEwJHQjEPMA0GA1UECBMGTG9uZG9uMQ8wDQYDVQQHEwZMb25kb24xFzAVBgNV
@@ -668,10 +668,10 @@ govuk_jenkins::github_enterprise_cert: |
     LG8Mr4r1mOsqtUPYYjCN77EOwkRUucvIt1zNPoiD21OXzzxdOIUOUq6l/kERSfba
     LWIWJn/KXkog8bU776IixxWlO8l1TwiCUoDS9YsLIKIRCT74QE48qA==
     -----END CERTIFICATE-----
-govuk_jenkins::github_enterprise_cert_path: "/var/lib/jenkins/github.gds.pem"
-govuk_jenkins::github_enterprise_hostname: "github.gds"
+govuk_jenkins::github_enterprise_cert::certificate_path: "/var/lib/jenkins/github.gds.pem"
+govuk_jenkins::github_enterprise_cert::github_enterprise_hostname: "github.gds"
 govuk_jenkins::config::github_api_uri: "%{hiera('govuk_jenkins::config::github_web_uri')}/api/v3"
-govuk_jenkins::config::github_web_uri: "https://%{hiera('govuk_jenkins::github_enterprise_hostname')}"
+govuk_jenkins::config::github_web_uri: "https://%{hiera('govuk_jenkins::github_enterprise_cert::github_enterprise_hostname')}"
 govuk_jenkins::job::deploy_app::app_domain: "%{hiera('app_domain')}"
 
 govuk_jenkins::job::smokey::auth_username: "%{hiera('http_username')}"

--- a/modules/govuk_ci/manifests/agent.pp
+++ b/modules/govuk_ci/manifests/agent.pp
@@ -13,6 +13,7 @@ class govuk_ci::agent {
   include ::govuk_ci::agent::swarm
   include ::govuk_ci::vpn
   include ::govuk_java::oracle8
+  include ::govuk_jenkins::github_enterprise_cert
   include ::govuk_rbenv::all
   include ::golang
 

--- a/modules/govuk_ci/templates/application_build_job.xml.erb
+++ b/modules/govuk_ci/templates/application_build_job.xml.erb
@@ -24,12 +24,18 @@
   <sources class="jenkins.branch.MultiBranchProject$BranchSourceList" plugin="branch-api@1.11.1">
     <data>
       <jenkins.branch.BranchSource>
-<%- if @source == 'github' -%>
         <source class="org.jenkinsci.plugins.github_branch_source.GitHubSCMSource" plugin="github-branch-source@1.10">
           <id>45dd6853-59d2-4695-80ac-4520f8a2b64f</id>
+<%- if @source == 'github' -%>
           <checkoutCredentialsId>SAME</checkoutCredentialsId>
           <scanCredentialsId>github-token-govuk-ci-username</scanCredentialsId>
           <repoOwner><%= @repo_owner %></repoOwner>
+<%- elsif @source == 'git' -%>
+          <apiUri>https://github.gds/api/v3/</apiUri>
+          <checkoutCredentialsId>SAME</checkoutCredentialsId>
+          <scanCredentialsId>github-enterprise-token-govukjenkinsci-username</scanCredentialsId>
+          <repoOwner>gds</repoOwner>
+<%- end -%>
           <repository><%= @repository %></repository>
           <includes>*</includes>
           <excludes>release deployed-to-* integration staging production</excludes>
@@ -40,16 +46,6 @@
           <buildForkPRMerge>false</buildForkPRMerge>
           <buildForkPRHead>false</buildForkPRHead>
         </source>
-<%- elsif @source == 'git' -%>
-        <source class="jenkins.plugins.git.GitSCMSource" plugin="git@3.0.0">
-          <id>edb8c02e-1e3b-45c5-bd14-325d5413bbd8</id>
-          <remote>git@github.gds:gds/<%= @repository %>.git</remote>
-          <credentialsId>govuk-ci-ssh-key</credentialsId>
-          <includes>*</includes>
-          <excludes>release deployed-to-* integration staging production</excludes>
-          <ignoreOnPushNotifications>false</ignoreOnPushNotifications>
-        </source>
-<%- end -%>
         <strategy class="jenkins.branch.DefaultBranchPropertyStrategy">
           <properties class="empty-list"/>
         </strategy>

--- a/modules/govuk_jenkins/manifests/github_enterprise_cert.pp
+++ b/modules/govuk_jenkins/manifests/github_enterprise_cert.pp
@@ -1,0 +1,51 @@
+# == Class: govuk_jenkins::github_enterprise_cert
+#
+# Add GDS GitHub Enterprise certificate to Jenkins machines. The certificate
+# is added to the Java keystore and the OS certificate store. The Jenkins
+# process needs to be restarted to reload changes on the Java keystore, that
+# dependency is not managed in this class.
+# 
+#
+# === Parameters:
+#
+# [*certificate*]
+#   PEM certificate for GitHub Enterprise.
+#
+# [*certificate_path*]
+#   Path to GitHub Enterprise certificate for java_ks
+#
+# [*github_enterprise_hostname*]
+#   The hostname of Github Enterprise
+#
+class govuk_jenkins::github_enterprise_cert (
+  $certificate,
+  $certificate_path,
+  $github_enterprise_hostname,
+) {
+
+  # In addition to the keystore below, in the Deploy Jenkins instances the certificate path is also
+  # referenced by the `GITHUB_GDS_CA_BUNDLE` environment variable in Jenkins, which is used by
+  # ghtools during GitHub.com -> GitHub Enterprise repo backups.
+  file { [ $certificate_path, '/usr/local/share/ca-certificates/github_enterprise.crt']:
+    ensure  => file,
+    content => $certificate,
+  }
+
+  # Add the certificate to the default Java keystore 
+  java_ks { "${github_enterprise_hostname}:cacerts":
+    ensure       => latest,
+    certificate  => $certificate_path,
+    target       => '/usr/lib/jvm/java-7-openjdk-amd64/jre/lib/security/cacerts',
+    password     => 'changeit',
+    trustcacerts => true,
+    require      => Class['govuk_java::openjdk7::jre'],
+  }
+
+  # Rebuild /etc/ssl/certs when /usr/local/share/ca-certificates/filename is updated
+  exec { 'update-ca-certificates':
+    path        => ['/usr/bin', '/usr/sbin', '/bin'],
+    subscribe   => File['/usr/local/share/ca-certificates/github_enterprise.crt'],
+    refreshonly => true,
+  }
+
+}

--- a/modules/govuk_jenkins/spec/classes/jenkins__github_enterprise_cert_spec.rb
+++ b/modules/govuk_jenkins/spec/classes/jenkins__github_enterprise_cert_spec.rb
@@ -1,0 +1,13 @@
+require_relative '../../../../spec_helper'
+
+describe 'govuk_jenkins::github_enterprise_cert', :type => :class do
+
+  let(:params) {{
+    :certificate => 'certcertcert',
+    :certificate_path => 'wobble',
+    :github_enterprise_hostname => 'dibble',
+  }}
+
+  it { is_expected.to contain_file('wobble').with_content(/certcertcert/) }
+
+end

--- a/modules/govuk_jenkins/spec/classes/jenkins_spec.rb
+++ b/modules/govuk_jenkins/spec/classes/jenkins_spec.rb
@@ -3,14 +3,6 @@ require_relative '../../../../spec_helper'
 describe 'govuk_jenkins', :type => :class do
   let(:ssh_dir) { '/var/lib/jenkins/.ssh' }
 
-  let(:params) {{
-    :github_enterprise_cert => 'certcertcert',
-    :github_enterprise_cert_path => 'wobble',
-    :github_enterprise_hostname => 'dibble',
-  }}
-
-  it { is_expected.to contain_file('wobble').with_content(/certcertcert/) }
-
   it { is_expected.to contain_class('govuk_jenkins::config') }
   it { is_expected.to contain_class('govuk_jenkins::user') }
   it { is_expected.to contain_class('govuk_jenkins::package') }

--- a/spec/fixtures/hieradata/common.yaml
+++ b/spec/fixtures/hieradata/common.yaml
@@ -21,6 +21,9 @@ govuk_jenkins::config::github_api_uri: foo
 govuk_jenkins::github_client_id: bar
 govuk_jenkins::github_client_secret: baz
 govuk_jenkins::config::github_web_uri: wibble
+govuk_jenkins::github_enterprise_cert::certificate: 'certcertcert'
+govuk_jenkins::github_enterprise_cert::certificate_path: 'wobble'
+govuk_jenkins::github_enterprise_cert::github_enterprise_hostname: 'dibble'
 
 govuk_postgresql::server::snakeoil_ssl_certificate: certificate
 govuk_postgresql::server::snakeoil_ssl_key: key


### PR DESCRIPTION
In the new CI Jenkins we want to manage GitHub Enterprise repositories
with the GitHub branch source plugin, same as we do with the GitHub
projects. This plugin provides better integration to update the status
of the build and we can configure all projects in the same way. The
GitHub Enterprise token credentials need to exist in Jenkins, and the
server needs to be added to the Global configuration.

When we use the GitHub branch source plugin for GitHub Enterprise, in addition
to adding the server certificate to the Java keystore, we also need to add it
to the machine certificate store. This is implemented with a new Puppet class
that manages the original code for the Java keystore and the new resources
for the OS certificate store.