### PR TITLE
Ensure CI machines use Intel CPU arch

### DIFF
--- a/hieradata/class/ci_agent.yaml
+++ b/hieradata/class/ci_agent.yaml
@@ -14,3 +14,5 @@ govuk_mysql::server::innodb_flush_log_at_trx_commit: 0
 govuk_elasticsearch::minimum_master_nodes: '1'
 govuk_elasticsearch::version: '1.7.5'
 govuk_elasticsearch::number_of_replicas: '0'
+
+icinga::client::check_cputype::cputype: 'intel'

--- a/hieradata/class/ci_master.yaml
+++ b/hieradata/class/ci_master.yaml
@@ -197,3 +197,5 @@ govuk_jenkins::plugins:
       version: "2.11"
     ws-cleanup:
       version: "0.32"
+
+icinga::client::check_cputype::cputype: 'intel'


### PR DESCRIPTION
**Merge after the machines have been migrated to new CPU architecture.**

CI machines do CPU heavy work when running tests. We should ensure these are using the underlying Intel CPU architecture rather than AMD as it is more performant. The default for Integration is AMD, so we specifically need to set the CI machines as 'intel'.