### PR TITLE
Add Jenkins user to docker group in CI

### DIFF
--- a/modules/govuk_ci/manifests/agent/docker.pp
+++ b/modules/govuk_ci/manifests/agent/docker.pp
@@ -2,6 +2,12 @@
 #
 # Installs and configures Docker and Docker Compose
 class govuk_ci::agent::docker {
-  include ::docker
+
+  # Jenkins user needs to be able to build and manage containers
+  class { '::docker':
+    docker_users => ['jenkins'],
+  }
+
   include ::docker::compose
+
 }


### PR DESCRIPTION
The Jenkins user needs to be able to build and manage containers
on the docker agents, so it needs to belong to the docker group.