### PR TITLE
Change the pre_condition class to govuk_postgresql::server::standalone

### DIFF
--- a/modules/govuk_postgresql/spec/defines/govuk_postgresql__db_spec.rb
+++ b/modules/govuk_postgresql/spec/defines/govuk_postgresql__db_spec.rb
@@ -6,7 +6,7 @@ describe 'govuk_postgresql::db', :type => :define do
         :concat_basedir => '/tmp/concat',
     }}
     let(:pre_condition) { <<-EOS
-      include govuk_postgresql::server::not_slave
+      include govuk_postgresql::server::standalone
       EOS
     }
 


### PR DESCRIPTION
While trying to upgrade the concat module we noticed that 2 of the 5 specs
that call `$postgresql::server::pg_hba_rule` were failing. After a lot of manual
experiments we've proven that the `postgresql::server` class must be included and resolved
in the catalog before our tests will pass.

This is currently also done in the other 3 test cases in the
`modules/govuk_postgresql/spec/classes/govuk_postgresql__env_sync_user_spec.rb`
pre_condition.

govuk_postgresql::server::not_slave itself does not actually do anything, it just collects
resources so I think it should be `govuk_postgresql::server::standalone` both to match the
current working tests and it logically makes sense that the variables have to exist before you use them.