### PR TITLE
Disallow remote connections to mongo on exception-handler

### DIFF
--- a/hieradata/class/exception_handler.yaml
+++ b/hieradata/class/exception_handler.yaml
@@ -23,5 +23,7 @@ mount:
     govuk_lvm: 'mongodb'
     mountoptions: 'defaults'
 
+mongodb::firewall::enable_firewall_rules: false
+
 mongodb::server::replicaset_members:
   'exception-handler-1':

--- a/modules/mongodb/manifests/firewall.pp
+++ b/modules/mongodb/manifests/firewall.pp
@@ -2,11 +2,15 @@
 #
 # Allow network traffic through firewall for mongodb
 #
-class mongodb::firewall {
-  @ufw::allow { 'allow-mongod-27017-from-all':
-    port => 27017,
-  }
-  @ufw::allow { 'allow-mongod-28017-from-all':
-    port => 28017,
+class mongodb::firewall (
+  $enable_firewall_rules = true,
+) {
+  if $enable_firewall_rules {
+    @ufw::allow { 'allow-mongod-27017-from-all':
+      port => 27017,
+    }
+    @ufw::allow { 'allow-mongod-28017-from-all':
+      port => 28017,
+    }
   }
 }


### PR DESCRIPTION
Current firewall rules allow remote connections to mongo on all servers. This commit adds the option to remove these firewall rules from certain servers, and configures exception-handler to disallow such connections. All connections to mongo on exception-handler are from localhost.