### PR TITLE
Don't set description for Puppet deployment

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_puppet.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_puppet.yaml.erb
@@ -34,8 +34,6 @@
         - shell: |
            sh -eu puppet/deploy.sh
     publishers:
-        - description-setter:
-            regexp: 'Deployed ([^ ]+) \(resolved'
         - trigger:
             project: Smokey
         - trigger-parameterized-builds:


### PR DESCRIPTION
This was done when we had a more complex process for deploying Puppet involving pushing the release branch. It's easier now so we don't need this.