### PR TITLE
Ensure Jenkins discards old builds.

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/bouncer_cdn.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/bouncer_cdn.yaml.erb
@@ -18,7 +18,7 @@
     scm:
         - cdn-configs_Bouncer_CDN
     logrotate:
-        artifactNumToKeep: 20
+        numToKeep: 20
     builders:
         - shell: |
             cd fastly

--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
@@ -33,7 +33,7 @@
     scm:
       - env-sync-and-backup_Copy_Data_to_Integration
     logrotate:
-        artifactNumToKeep: 10
+        numToKeep: 10
     triggers:
         - timed: 'H 4 * * 1-5'
     builders:

--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_staging.yaml.erb
@@ -22,7 +22,7 @@
     scm:
       - env-sync-and-backup_Copy_Data_to_Staging
     logrotate:
-        artifactNumToKeep: 10
+        numToKeep: 10
     triggers:
         - timed: 'H 1 * * *'
     builders:

--- a/modules/govuk_jenkins/templates/jobs/copy_licensify_data_to_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_licensify_data_to_staging.yaml.erb
@@ -21,7 +21,7 @@
     scm:
       - env-sync-and-backup_Copy_Licensify_Data_to_Staging
     logrotate:
-        artifactNumToKeep: 10
+        numToKeep: 10
     triggers:
         - timed: 'H 1 * * *'
     builders:

--- a/modules/govuk_jenkins/templates/jobs/copy_sanitised_whitehall_database.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_sanitised_whitehall_database.yaml.erb
@@ -20,7 +20,7 @@
     scm:
       - env-sync-and-backup_copy_sanitised_whitehall_database
     logrotate:
-        artifactNumToKeep: 10
+        numToKeep: 10
     triggers:
         - timed: '15 5 * * 1-5'
     builders:

--- a/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
@@ -8,7 +8,7 @@
     auth-token: <%= @auth_token %>
     <%- end -%>
     logrotate:
-      artifactNumToKeep: 10
+      numToKeep: 10
     builders:
        - shell: |
            # Clear the Sidekiq queues to stop any residual 'stale' jobs running

--- a/modules/govuk_jenkins/templates/jobs/data_sync_complete_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/data_sync_complete_staging.yaml.erb
@@ -8,7 +8,7 @@
     auth-token: <%= @auth_token %>
     <%- end -%>
     logrotate:
-      artifactNumToKeep: 10
+      numToKeep: 10
     builders:
        - shell: |
            <%- if @signon_domains_to_migrate -%>

--- a/modules/govuk_jenkins/templates/jobs/deploy_router_data.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_router_data.yaml.erb
@@ -12,7 +12,7 @@
     display-name: deploy_router_data
     project-type: freestyle
     logrotate:
-      artifactNumToKeep: 20
+      numToKeep: 20
     scm:
       - router-data_deploy_router_data
     builders:

--- a/modules/govuk_jenkins/templates/jobs/drug_email_alert_check.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/drug_email_alert_check.yaml.erb
@@ -15,7 +15,7 @@
     scm:
       - email-alert-check
     logrotate:
-        artifactNumToKeep: 100
+        numToKeep: 100
     triggers:
         - timed: '21 * * * *' # every hour on the 21st minute
     builders:

--- a/modules/govuk_jenkins/templates/jobs/govuk_cdn_nightly_2xx_status_collection.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/govuk_cdn_nightly_2xx_status_collection.yaml.erb
@@ -26,6 +26,6 @@
             govuk_setenv govuk-cdn-logs-monitor bundle exec ruby scripts/process_completed_logs.rb
           '
     logrotate:
-      artifactNumToKeep: 14
+      numToKeep: 14
     triggers:
       - timed: 'H 7 * * *'

--- a/modules/govuk_jenkins/templates/jobs/govuk_delivery_configure_integration_catchall_feed.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/govuk_delivery_configure_integration_catchall_feed.yaml.erb
@@ -8,7 +8,7 @@
     auth-token: <%= @auth_token %>
     <%- end -%>
     logrotate:
-      artifactNumToKeep: 10
+      numToKeep: 10
     builders:
        - shell: |
            ssh deploy@backend-1.backend 'cd /var/apps/govuk-delivery && ./venv/bin/python scripts/activate_integration_catchall_topic_mapping.py'

--- a/modules/govuk_jenkins/templates/jobs/publishing_api_archive_events.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/publishing_api_archive_events.yaml.erb
@@ -5,7 +5,7 @@
     project-type: freestyle
     description: "This job periodically archives publishing API events to S3"
     logrotate:
-      artifactNumToKeep: 10
+      numToKeep: 10
     publishers:
         - trigger-parameterized-builds:
           - project: run-rake-task

--- a/modules/govuk_jenkins/templates/jobs/publishing_api_check_validity.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/publishing_api_check_validity.yaml.erb
@@ -5,7 +5,7 @@
     project-type: freestyle
     description: "This job checks the data within the Publishing API for any invalid data"
     logrotate:
-      artifactNumToKeep: 10
+      numToKeep: 10
     publishers:
         - trigger-parameterized-builds:
           - project: run-rake-task

--- a/modules/govuk_jenkins/templates/jobs/sanitize_publishing_api_data.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/sanitize_publishing_api_data.yaml.erb
@@ -8,7 +8,7 @@
     auth-token: <%= @auth_token %>
     <%- end -%>
     logrotate:
-      artifactNumToKeep: 10
+      numToKeep: 10
     builders:
        - shell: |
            ssh deploy@backend-1.backend 'cd /var/apps/publishing-api && sudo -u deploy govuk_setenv publishing-api bundle exec rake sanitize_data'

--- a/modules/govuk_jenkins/templates/jobs/service_manual_rebuild_search_index.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/service_manual_rebuild_search_index.yaml.erb
@@ -7,7 +7,7 @@
       <p><strong>NB</strong> this isn't atomic - the index will be empty for a short while
       (a few seconds, if all goes well). Traffic on this manual is low enough that this isn't a big problem.</p>"
     logrotate:
-      artifactNumToKeep: 3
+      numToKeep: 3
     builders:
         - shell: |
             if [ "$TARGET_APPLICATION" = "designprinciples" ]; then

--- a/modules/govuk_jenkins/templates/jobs/signon_cron_rake_tasks.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/signon_cron_rake_tasks.yaml.erb
@@ -16,7 +16,7 @@
     triggers:
       - timed: <%= @rake_oauth_access_grants_delete_expired_frequency %>
     logrotate:
-        artifactNumToKeep: 10
+        numToKeep: 10
 - job:
     name: signon_rake_organisations_fetch
     display-name: signon_rake_organisations_fetch
@@ -34,7 +34,7 @@
     triggers:
       - timed: <%= @rake_organisations_fetch_frequency %>
     logrotate:
-        artifactNumToKeep: 10
+        numToKeep: 10
 - job:
     name: signon_rake_users_suspend_inactive
     display-name: signon_rake_users_suspend_inactive
@@ -52,7 +52,7 @@
     triggers:
       - timed: <%= @rake_users_suspend_inactive_frequency %>
         logrotate:
-            artifactNumToKeep: 10
+            numToKeep: 10
 - job:
     name: signon_rake_users_send_suspension_reminders
     display-name: signon_rake_users_send_suspension_reminders
@@ -70,4 +70,4 @@
     triggers:
       - timed: <%= @rake_users_send_suspension_reminders_frequency %>
         logrotate:
-            artifactNumToKeep: 10
+            numToKeep: 10

--- a/modules/govuk_jenkins/templates/jobs/tagging_sync_check.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/tagging_sync_check.yaml.erb
@@ -16,11 +16,11 @@
       See https://github.com/alphagov/finding-things-migration-checker
 
       Only runs the "MissingLinks" check. This check verifies that tags from
-      publishing-api are synced correctly with the search index. 
+      publishing-api are synced correctly with the search index.
     scm:
       - tagging-sync-check
     logrotate:
-        artifactNumToKeep: 100
+        numToKeep: 100
     builders:
         - shell: |
             bundle install --path "${HOME}/bundles/${JOB_NAME}"

--- a/modules/govuk_jenkins/templates/jobs/transition_load_all_data.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/transition_load_all_data.yaml.erb
@@ -5,7 +5,7 @@
     project-type: freestyle
     description: "<p>Loads mapping data and statistics into Transition/Bouncer.</p>"
     logrotate:
-      artifactNumToKeep: 30
+      numToKeep: 30
     builders:
         - shell: |
             rm -rf data

--- a/modules/govuk_jenkins/templates/jobs/transition_load_site_config.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/transition_load_site_config.yaml.erb
@@ -15,7 +15,7 @@
     scm:
       - transition-config_Transition_load_site_config
     logrotate:
-      artifactNumToKeep: 30
+      numToKeep: 30
     builders:
         - shell: |
             rsync --delete -avz -e ssh ./ deploy@backend-1.backend:/var/apps/transition/data/transition-config

--- a/modules/govuk_jenkins/templates/jobs/transition_load_transition_stats_hits.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/transition_load_transition_stats_hits.yaml.erb
@@ -5,7 +5,7 @@
     project-type: freestyle
     description: "<p>Loads hits data from our CDN logs into Transition soon after they are processed.</p>"
     logrotate:
-      artifactNumToKeep: 20
+      numToKeep: 20
     properties:
         - github:
             url: https://github.com/alphagov/transition-stats/

--- a/modules/govuk_jenkins/templates/jobs/transition_run_database_migrations.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/transition_run_database_migrations.yaml.erb
@@ -10,7 +10,7 @@
     auth-token: <%= @auth_token %>
     <%- end -%>
     logrotate:
-      artifactNumToKeep: 10
+      numToKeep: 10
     builders:
        - shell: |
            ssh deploy@backend-1.backend.production "cd /var/apps/transition && govuk_setenv transition bundle exec rake db:migrate"

--- a/modules/govuk_jenkins/templates/jobs/travel_advice_email_alert_check.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/travel_advice_email_alert_check.yaml.erb
@@ -15,7 +15,7 @@
     scm:
       - travel-advice-email-alert-check
     logrotate:
-        artifactNumToKeep: 100
+        numToKeep: 100
     triggers:
         - timed: '*/15 * * * *' # every 15 minutes
     builders:

--- a/modules/govuk_jenkins/templates/jobs/trigger_data_sync_complete.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/trigger_data_sync_complete.yaml.erb
@@ -5,7 +5,7 @@
     project-type: freestyle
     description: "This job triggers the Data_Sync_Complete jobs on a remote Jenkins machine"
     logrotate:
-        artifactNumToKeep: 10
+        numToKeep: 10
     builders:
         - shell: |
             echo "Triggering post-sync job on $HOSTNAME"

--- a/modules/govuk_jenkins/templates/jobs/whitehall_run_broken_link_checker.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/whitehall_run_broken_link_checker.yaml.erb
@@ -28,5 +28,5 @@
                   NSCA_CHECK_DESCRIPTION=<%= @service_description %>
                   NSCA_OUTPUT=<%= @service_description %> failed
     logrotate:
-        artifactNumToKeep: 10
+        numToKeep: 10
 

--- a/modules/govuk_jenkins/templates/jobs/whitehall_update_integration_data.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/whitehall_update_integration_data.yaml.erb
@@ -15,7 +15,7 @@
     scm:
       - env-sync-and-backup_<%= @job_slug %>
     logrotate:
-        artifactNumToKeep: 10
+        numToKeep: 10
     builders:
         - shell: |
             export WHITEHALL_MYSQL_PASSWORD="<%= @whitehall_mysql_password -%>"


### PR DESCRIPTION
Not that many of our jobs actually create artefacts, so by using
artifactNumToKeep it means that one dark day our Jenkins machine will
run out of disk space.

Well my friends, that day has come as prophesied.