### PR TITLE
Fix default content schema branch in Jenkins config

### DIFF
--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -78,15 +78,15 @@ def precompileAssets() {
 }
 
 /**
- * Clone govuk-content-schemas depedency for contract tests
+ * Clone govuk-content-schemas dependency for contract tests
  */
-def contentSchemaDependency(String schemaGitCommit) {
+def contentSchemaDependency(String schemaGitCommit = 'deployed-to-production') {
   sshagent(['govuk-ci-ssh-key']) {
     echo 'Cloning govuk-content-schemas'
     sh('rm -rf tmp/govuk-content-schemas')
     sh('git clone git@github.com:alphagov/govuk-content-schemas.git tmp/govuk-content-schemas')
     sh('cd tmp/govuk-content-schemas')
-    sh("git checkout ${schemaGitCommit}:-deployed-to-production")
+    sh("git checkout ${schemaGitCommit}")
   }
 }
 


### PR DESCRIPTION
The content schema checkout step takes a git branch, with the default value of 'deployed-to-production'. In the old shell script, the default was inserted using shell parameter expansion. In the new Groovy script, I think the default should be inserted using a default method argument.

The implementation before this commit gave the error "Unimplemented pathspec magic" because the ":-" characters were being passed to git rather than being processed by the build script.

Note that this changes the signature of the base Jenkinsfile, but I think we might be the first people to use the `contentSchemaDependency` step - I've just added it to a branch of collections-publisher, and I couldn't find any references to it in other repos.