### PR TITLE
Add some additional ordering to stop puppet warning.

### DIFF
--- a/modules/govuk_postgresql/manifests/wal_e/backup.pp
+++ b/modules/govuk_postgresql/manifests/wal_e/backup.pp
@@ -122,10 +122,11 @@ define govuk_postgresql::wal_e::backup (
       }
 
       file { '/var/lib/postgresql/.gnupg':
-        ensure => directory,
-        mode   => '0700',
-        owner  => 'postgres',
-        group  => 'postgres',
+        ensure  => directory,
+        mode    => '0700',
+        owner   => 'postgres',
+        group   => 'postgres',
+        require => Class['govuk_postgresql::server'],
       }
 
       # This ensures that stuff can be encrypted without prompt

--- a/modules/govuk_postgresql/manifests/wal_e/package.pp
+++ b/modules/govuk_postgresql/manifests/wal_e/package.pp
@@ -5,16 +5,16 @@
 class govuk_postgresql::wal_e::package {
 
   file { '/etc/wal-e':
-    ensure => directory,
-    owner  => 'postgres',
-    group  => 'postgres',
-    mode   => '0775',
+    ensure  => directory,
+    owner   => 'postgres',
+    group   => 'postgres',
+    mode    => '0775',
+    require => Class['govuk_postgresql::server'],
   }
 
   package { 'wal-e':
     ensure   => present,
     provider => pip,
-    require  => [ Class['govuk_postgresql::server'], File['/etc/wal-e'] ],
   }
 
   $dependencies = [


### PR DESCRIPTION
We were previously trying to set the owner to a user that had
not yet been created. This re-ordering fixes that.