### PR TITLE
Add a way to blacklist packages

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -512,6 +512,9 @@ govuk::apps::travel_advice_publisher::redis_port: "%{hiera('sidekiq_port')}"
 govuk::deploy::config::asset_root: "https://%{hiera('router::assets_origin::vhost_name')}"
 govuk::deploy::config::website_root: "https://www-origin.%{hiera('app_domain')}"
 
+govuk_apt::package_blacklist:
+  - 'systemd'
+
 govuk_ghe_vpn::openconnect_version: '6.00-0~21~ubuntu14.04.1'
 
 govuk_gor::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"

--- a/modules/base/manifests/init.pp
+++ b/modules/base/manifests/init.pp
@@ -13,6 +13,7 @@ class base {
   include gcc
   include govuk::deploy
   include govuk_apt::unused_kernels
+  include govuk_apt::package_blacklist
   include govuk_envsys
   include govuk_scripts
   include govuk_sshkeys

--- a/modules/govuk_apt/manifests/package_blacklist.pp
+++ b/modules/govuk_apt/manifests/package_blacklist.pp
@@ -1,0 +1,20 @@
+# == Class: Govuk_apt::Package_blacklist
+#
+# Blacklists specific packages from being able to be installed on the system.
+# This will mean that even if a user tries to install a package use apt, the
+# package specified will simply appear as unavailable for install.
+#
+# === Parameters:
+#
+#  [*packages*]
+#    An array of packages that you wish to blacklist.
+#
+class govuk_apt::package_blacklist (
+  $packages = [],
+) {
+  validate_array($packages)
+
+  file { '/etc/apt/preferences':
+    content => template('govuk_apt/preferences.erb'),
+  }
+}

--- a/modules/govuk_apt/templates/preferences.erb
+++ b/modules/govuk_apt/templates/preferences.erb
@@ -1,0 +1,5 @@
+<%= @packages.each do |package| -%>
+Package: <%= package %>
+Pin: origin ""
+Pin-Priority: -1
+<%= end -%>


### PR DESCRIPTION
We currently blacklist packages for unattended_upgrades, however when we bring up a machine Puppet will install packages, and some may install packages we do not want installed. This change makes it impossible to install the specified packages whatsoever.

An example of this is systemd, which affects the way the system behaves which we may not want to do yet. A newer version of postgresql installs systemd despite it not being a dependency which caused some problems.