### PR TITLE
Add a way to blacklist packages

### DIFF
--- a/modules/base/manifests/init.pp
+++ b/modules/base/manifests/init.pp
@@ -13,6 +13,7 @@ class base {
   include gcc
   include govuk::deploy
   include govuk_apt::unused_kernels
+  include govuk_apt::package_blacklist
   include govuk_envsys
   include govuk_scripts
   include govuk_sshkeys

--- a/modules/govuk_apt/manifests/package_blacklist.pp
+++ b/modules/govuk_apt/manifests/package_blacklist.pp
@@ -1,0 +1,13 @@
+# == Class: Govuk_apt::Package_blacklist
+#
+# Blacklists specific packages from being able to be installed on the system.
+# This means, if a user tries to install a package using apt, the package
+# specified will appear as unavailable for installation.
+#
+class govuk_apt::package_blacklist {
+  apt::pin { 'blacklist_systemd':
+    packages => 'systemd',
+    priority => '-1',
+    origin   => '""',
+  }
+}


### PR DESCRIPTION
We currently blacklist packages for unattended_upgrades. However, when we bring up a new machine, Puppet will install packages from fresh, and some packages may install other packages we do not want installed. This change makes it impossible to install the specified packages whatsoever.

An example of this is systemd, which affects the way the system behaves which we may not want to do yet. A newer version of postgresql installs systemd which caused some problems. We want to block this from happening.