### PR TITLE
Add a default variable for ipaddress_eth0

### DIFF
--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -40,5 +40,6 @@ RSpec.configure do |c|
     :fqdn_metrics            => 'fakehost-1_management',
     :puppetversion           => '3.8.6',
     :kernel                  => 'Linux',
+    :ipaddress_eth0         => '127.0.0.1',
   }
 end


### PR DESCRIPTION
A number of our puppet classes had their use of the `ipaddress` fact
changed to `ipaddress_eth0` when we introduced docker because facter was detecting `docker0` and using
the IP address that returned. In order for our tests to run under `strict_variables` we need to provide
a default for `ipaddress_eth0` too. I've picked 127.0.0.1 as it's a valid ipaddress and no
other significent reason.