### PR TITLE
Pin WAL-E version

### DIFF
--- a/modules/govuk_postgresql/manifests/wal_e/package.pp
+++ b/modules/govuk_postgresql/manifests/wal_e/package.pp
@@ -13,7 +13,7 @@ class govuk_postgresql::wal_e::package {
   }
 
   package { 'wal-e':
-    ensure   => present,
+    ensure   => '0.9.2',
     provider => pip,
   }
 


### PR DESCRIPTION
This needs to be pinned to a 0.9.x version as 1.x versions require python 3.4. I don't believe we should install another version of python for this package only.