### PR TITLE
Add libmysqlclient-dev package to CI agents

### DIFF
--- a/modules/govuk_ci/manifests/agent/mysql.pp
+++ b/modules/govuk_ci/manifests/agent/mysql.pp
@@ -5,6 +5,10 @@
 class govuk_ci::agent::mysql {
   contain ::govuk_mysql::server
 
+  ensure_packages([
+    'libmysqlclient-dev',
+  ])
+
   mysql::db {
     'collections_publisher_test':
       user     => 'collections_pub',


### PR DESCRIPTION
CI agents which run MySQL tests need to have this package installed.