### PR TITLE
Add ssh slaves to CI

### DIFF
--- a/hieradata/class/ci_agent.yaml
+++ b/hieradata/class/ci_agent.yaml
@@ -5,9 +5,6 @@ mongodb::server::replicaset_members:
   "%{::hostname}":
 
 govuk_ci::agent::postgresql::mapit_role_password: 'mapit'
-govuk_ci::agent::swarm::agent_labels:
-  - 'mongodb-3.2'
-
 postgresql::globals::version: '9.3'
 govuk_mysql::server::innodb_flush_log_at_trx_commit: 0
 

--- a/hieradata/class/ci_master.yaml
+++ b/hieradata/class/ci_master.yaml
@@ -153,6 +153,8 @@ govuk_jenkins::plugins:
       version: "1.13"
     ssh-credentials:
       version: "1.12"
+    ssh-slaves:
+      version: "1.11"
     structs:
       version: "1.5"
     subversion:

--- a/hieradata/class/ci_master.yaml
+++ b/hieradata/class/ci_master.yaml
@@ -11,7 +11,6 @@ govuk_jenkins::config::views:
     - 'govuk-puppet'
     - 'integration-puppet-deploy'
 
-govuk_jenkins::config::agent_tcp_port: '54322'
 govuk_jenkins::config::create_agent_role: true
 govuk_jenkins::config::executors: '0'
 

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -635,6 +635,26 @@ govuk_ci::master::pipeline_jobs:
   ubuntu_unused_kernels:
     repo_owner: 'gds-operations'
 
+govuk_ci::master::ci_agents:
+  ci-agent-1:
+    agent_hostname: 'ci-agent-1.ci'
+    description: 'Build agent with docker'
+    labels: 'mongodb-2.4 docker'
+  ci-agent-2:
+    agent_hostname: 'ci-agent-2.ci'
+    labels: 'mongodb-2.4'
+  ci-agent-3:
+    agent_hostname: 'ci-agent-3.ci'
+    labels: 'mongodb-2.4'
+  ci-agent-4:
+    agent_hostname: 'ci-agent-4.ci'
+    labels: 'mongodb-3.2'
+  ci-agent-5:
+    agent_hostname: 'ci-agent-5.ci'
+    labels: 'mongodb-3.2'
+govuk_ci::master::credentials_id: 'jenkins-ssh-slave'
+
+govuk_ci::agent::master_ssh_key: "%{hiera('govuk_jenkins::ssh_key::public_key')}"
 govuk_ci::agent::swarm::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 govuk_crawler::amqp_host: 'localhost'

--- a/hieradata/node/ci-agent-1.ci.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/ci-agent-1.ci.integration.publishing.service.gov.uk.yaml
@@ -1,8 +1,4 @@
 ---
-govuk_ci::agent::swarm::agent_labels:
-  - 'mongodb-2.4'
-  - 'docker'
-
 mongodb::server::version: '2.4.9'
 
 govuk_ci::agent::docker_enabled: true

--- a/hieradata/node/ci-agent-2.ci.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/ci-agent-2.ci.integration.publishing.service.gov.uk.yaml
@@ -1,5 +1,2 @@
 ---
-govuk_ci::agent::swarm::agent_labels:
-  - 'mongodb-2.4'
-
 mongodb::server::version: '2.4.9'

--- a/hieradata/node/ci-agent-3.ci.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/ci-agent-3.ci.integration.publishing.service.gov.uk.yaml
@@ -1,5 +1,2 @@
 ---
-govuk_ci::agent::swarm::agent_labels:
-  - 'mongodb-2.4'
-
 mongodb::server::version: '2.4.9'

--- a/modules/govuk_ci/manifests/agent.pp
+++ b/modules/govuk_ci/manifests/agent.pp
@@ -31,20 +31,6 @@ class govuk_ci::agent(
   include ::govuk_rbenv::all
   include ::golang
 
-  ufw::allow { 'allow-jenkins-slave-swarm-to-listen-on-ephemeral-ports':
-    port  => '32768:65535',
-    proto => 'udp',
-    ip    => 'any',
-  }
-
-  # Fixed TCP port for JNLP agents
-  ufw::allow { 'allow-jenkins-master-to-connect-via-jnlp':
-    port  => '54322',
-    proto => 'tcp',
-    ip    => 'any',
-    from  => '10.1.6.10',
-  }
-
   # Override sudoers.d resource (managed by sudo module) to enable Jenkins user to run sudo tests
   File<|title == '/etc/sudoers.d/'|> {
     mode => '0555',
@@ -58,4 +44,8 @@ class govuk_ci::agent(
     require => Class['::govuk_jenkins::user'],
   }
 
+  # FIXME: set the package to absent when/if the agents are connecting over SSH
+  service { 'jenkins-agent':
+    ensure => 'stopped',
+  }
 }

--- a/modules/govuk_ci/manifests/agent.pp
+++ b/modules/govuk_ci/manifests/agent.pp
@@ -2,10 +2,18 @@
 #
 # Class to manage continuous deployment agents
 #
+# === Parameters:
+#
+# [*docker_enabled*]
+#   Set to true to install the Docker service on this agent
+#
+# [*master_ssh_key*]
+#   The public SSH key of the CI master to enable SSH based agent builds
+#
 class govuk_ci::agent(
   $docker_enabled = false,
+  $master_ssh_key = undef,
 ) {
-
   include ::govuk_ci::agent::redis
   if $docker_enabled {
     include ::govuk_ci::agent::docker
@@ -15,10 +23,11 @@ class govuk_ci::agent(
   include ::govuk_ci::agent::mongodb
   include ::govuk_ci::agent::postgresql
   include ::govuk_ci::agent::mysql
-  include ::govuk_ci::agent::swarm
   include ::govuk_ci::vpn
   include ::govuk_java::oracle8
   include ::govuk_jenkins::github_enterprise_cert
+  include ::govuk_jenkins::user
+  include ::govuk_jenkins::pipeline
   include ::govuk_rbenv::all
   include ::golang
 
@@ -39,6 +48,14 @@ class govuk_ci::agent(
   # Override sudoers.d resource (managed by sudo module) to enable Jenkins user to run sudo tests
   File<|title == '/etc/sudoers.d/'|> {
     mode => '0555',
+  }
+
+  ssh_authorized_key { 'ci-master-1.ci':
+    ensure  => present,
+    user    => 'jenkins',
+    type    => 'ssh-rsa',
+    key     => $master_ssh_key,
+    require => Class['::govuk_jenkins::user'],
   }
 
 }

--- a/modules/govuk_ci/manifests/master.pp
+++ b/modules/govuk_ci/manifests/master.pp
@@ -19,7 +19,13 @@ class govuk_ci::master (
   $jenkins_api_token,
   $pipeline_jobs = {},
   $environment_variables = {},
+  $ci_agents = {},
+  $credentials_id,
 ){
+
+  validate_hash($ci_agents)
+  validate_hash($pipeline_jobs)
+  validate_hash($environment_variables)
 
   include ::govuk_ci::credentials
   include ::govuk_ci::vpn
@@ -56,5 +62,9 @@ class govuk_ci::master (
   File<|title == '/etc/sudoers.d/'|> {
     mode => '0555',
   }
+
+  create_resources('::govuk_jenkins::ssh_slave', $ci_agents, {
+    'credentials_id' => $credentials_id,
+  })
 
 }

--- a/modules/govuk_jenkins/manifests/init.pp
+++ b/modules/govuk_jenkins/manifests/init.pp
@@ -99,4 +99,14 @@ class govuk_jenkins (
   include govuk_mysql::libdev
   include mysql::client
 
+  # This is required to create Jenkins SSH slaves, but it cannot be declared
+  # in the defined type itself
+  file { "${jenkins_homedir}/nodes":
+    ensure  => directory,
+    owner   => $jenkins_user,
+    group   => $jenkins_user,
+    mode    => '0775',
+    require => Class['govuk_jenkins::user'],
+  }
+
 }

--- a/modules/govuk_jenkins/manifests/ssh_slave.pp
+++ b/modules/govuk_jenkins/manifests/ssh_slave.pp
@@ -1,0 +1,60 @@
+# == Define: Govuk_jenkins::Ssh_slave
+#
+# Create an SSH slave that the Jenkins master can use to build jobs
+#
+# === Parameters:
+#
+# [*agent_hostname*]
+#   The hostname of the agent that the master connects to.
+#
+# [*credentials_id*]
+#   This is a uniquely generated ID that is created when you create a set of
+#   credentials. The ID is linked to the specific Jenkins instance, so must
+#   be created manually before being added to this defined type.
+#
+# [*description*]
+#   Describe what the agent is used for.
+#
+# [*executors*]
+#   Set how many jobs the instance can build at any one time.
+#
+# [*ssh_port*]
+#   Set the SSH port that the master connects to.
+#
+# [*jenkins_home*]
+#   Home directory of the Jenkins user, which also sets the root directory of
+#   where builds take place.
+#
+# [*jenkins_user*]
+#   The user which the master connects to the agent over SSH as.
+#
+define govuk_jenkins::ssh_slave (
+  $agent_hostname,
+  $credentials_id,
+  $labels = undef,
+  $description = 'Generic build agent',
+  $executors = 4,
+  $ssh_port = 22,
+  $jenkins_home = '/var/lib/jenkins',
+  $jenkins_user = 'jenkins',
+) {
+
+  $agent_name = $title
+
+  file { "${jenkins_home}/nodes/${agent_name}":
+    ensure  => directory,
+    owner   => $jenkins_user,
+    group   => $jenkins_user,
+    mode    => '0775',
+    require => File["${jenkins_home}/nodes"],
+  }
+
+  file { "${jenkins_home}/nodes/${agent_name}/config.xml":
+    ensure  => present,
+    content => template('govuk_jenkins/ssh_slave_config.xml.erb'),
+    owner   => $jenkins_user,
+    group   => $jenkins_user,
+    notify  => Service['jenkins'],
+  }
+
+}

--- a/modules/govuk_jenkins/spec/defines/govuk_jenkins__ssh_slave_spec.rb
+++ b/modules/govuk_jenkins/spec/defines/govuk_jenkins__ssh_slave_spec.rb
@@ -1,0 +1,19 @@
+require_relative '../../../../spec_helper'
+
+describe 'govuk_jenkins::ssh_slave', :type => :define do
+
+  let(:title) { 'jenkins-agent-1' }
+
+  let (:default_params) {{
+    :agent_hostname => 'jenkins-agent.domain',
+    :credentials_id => 'catsarethebest',
+    :labels         => 'mongo docker postgres'
+  }}
+
+  context 'with default settings' do
+    let(:params) { default_params }
+    it { should contain_file('/var/lib/jenkins/nodes/jenkins-agent-1/config.xml').with_content(/<label>mongo docker postgres/) }
+    it { should contain_file('/var/lib/jenkins/nodes/jenkins-agent-1/config.xml').with_content(/<name>jenkins-agent-1/) }
+    it { should contain_file('/var/lib/jenkins/nodes/jenkins-agent-1/config.xml').with_content(/<credentialsId>catsarethebest/) }
+  end
+end

--- a/modules/govuk_jenkins/templates/ssh_slave_config.xml.erb
+++ b/modules/govuk_jenkins/templates/ssh_slave_config.xml.erb
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<slave>
+  <name><%= @agent_name %></name>
+  <description><%= @description %></description>
+  <remoteFS><%= @jenkins_home %></remoteFS>
+  <numExecutors><%= @executors %></numExecutors>
+  <mode>NORMAL</mode>
+  <retentionStrategy class="hudson.slaves.RetentionStrategy$Always"/>
+  <launcher class="hudson.plugins.sshslaves.SSHLauncher" plugin="ssh-slaves@1.12">
+    <host><%= @agent_hostname %></host>
+    <port><%= @ssh_port %></port>
+    <credentialsId><%= @credentials_id %></credentialsId>
+    <maxNumRetries>0</maxNumRetries>
+    <retryWaitTime>0</retryWaitTime>
+  </launcher>
+  <label><%= @labels %></label>
+  <nodeProperties/>
+</slave>
+


### PR DESCRIPTION
See commits for detail. This is a PR to replace the current Jenkins swarm plugin with the SSH slave plugin instead as we are seeing stability issues with the swarm protocol.