### PR TITLE
Bugfix quotation in copy_attachments_to_slaves

### DIFF
--- a/modules/govuk/templates/node/s_asset_base/copy-attachments-to-slaves.sh.erb
+++ b/modules/govuk/templates/node/s_asset_base/copy-attachments-to-slaves.sh.erb
@@ -33,7 +33,7 @@ ASSET_SLAVE_NODES=$(/usr/local/bin/govuk_node_list -c asset_slave)
 for FILELIST in $(find $FILELIST_DIR -type f); do
   for FILENAME in $(cat $FILELIST); do
     for NODE in $ASSET_SLAVE_NODES; do
-      if /usr/bin/timeout 20 rsync -e "ssh -q" --quiet --timeout=10" ${FILENAME}" $NODE:$FILENAME; then
+      if /usr/bin/timeout 20 rsync -e "ssh -q" --quiet --timeout=10 "${FILENAME}" $NODE:$FILENAME; then
         logger -t copy_attachments_to_slaves "File ${FILENAME} copied to ${NODE}"
       else
         logger -t copy_attachments_to_slaves "File ${FILENAME} failed to copy to ${NODE}"


### PR DESCRIPTION
In 897ff22ac8a0858d1dac6189fdc27a3c4047fdf1 I mislaid a quotation which caused a problem with the rsync.