### PR TITLE
Proxy docs.publishing.service.gov.uk to docs S3 bucket

### DIFF
--- a/modules/govuk/manifests/node/s_backend_lb.pp
+++ b/modules/govuk/manifests/node/s_backend_lb.pp
@@ -106,4 +106,8 @@ class govuk::node::s_backend_lb (
   nginx::config::vhost::redirect { "backdrop-admin.${app_domain}" :
     to => "https://admin.${perfplat_public_app_domain}/",
   }
+
+  nginx::config::vhost::proxy { "docs.${app_domain}" :
+    to => ['http://govuk-developer-documentation-production.s3-website-eu-west-1.amazonaws.com/'],
+  }
 }


### PR DESCRIPTION
This makes the URL docs.publishing.service.gov.uk proxy through to the docs S3 bucket, which has been created by https://github.com/alphagov/govuk-terraform-provisioning/pull/85.

The DNS will be set up later.

@alexmuller helped set this up.

https://trello.com/c/sOqubT5e