### PR TITLE
Fix content schema checkout in Jenkinsfile helper

### DIFF
--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -85,8 +85,9 @@ def contentSchemaDependency(String schemaGitCommit = 'deployed-to-production') {
     echo 'Cloning govuk-content-schemas'
     sh('rm -rf tmp/govuk-content-schemas')
     sh('git clone git@github.com:alphagov/govuk-content-schemas.git tmp/govuk-content-schemas')
-    sh('cd tmp/govuk-content-schemas')
-    sh("git checkout ${schemaGitCommit}")
+    dir("tmp/govuk-content-schemas") {
+      sh("git checkout ${schemaGitCommit}")
+    }
   }
 }
 


### PR DESCRIPTION
Calling 'cd' from a Jenkins pipeline script doesn't change the working directory for the subsequent commands. This is fixed by using a 'dir' block, which executes every step inside the block in the given directory.