### PR TITLE
Add relative back in, but do it from /

### DIFF
--- a/modules/govuk/templates/node/s_asset_base/copy-attachments-to-slaves.sh.erb
+++ b/modules/govuk/templates/node/s_asset_base/copy-attachments-to-slaves.sh.erb
@@ -33,7 +33,7 @@ ASSET_SLAVE_NODES=$(/usr/local/bin/govuk_node_list -c asset_slave)
 for FILELIST in $(find $FILELIST_DIR -type f); do
   for FILENAME in $(cat $FILELIST); do
     for NODE in $ASSET_SLAVE_NODES; do
-      if /usr/bin/timeout 20 rsync -e "ssh -q" --quiet --timeout=10 "${FILENAME}" $NODE:$FILENAME; then
+      if /usr/bin/timeout 20 rsync -e "ssh -q" --quiet --timeout=10 --relative "${FILENAME}" $NODE:/; then
         logger -t copy_attachments_to_slaves "File ${FILENAME} copied to ${NODE}"
       else
         logger -t copy_attachments_to_slaves "File ${FILENAME} failed to copy to ${NODE}"


### PR DESCRIPTION
**This is currently set in Production with Puppet disabled as an emergency measure**

The `--relative` flag was removed because it caused incorrect pathnames. However, this flag has a very handy function of creating the remote directory structure. This is something which is not performed by default.

We set the `--relative` flag back in to ensure files are copied, but set the path to `/` so that they are copied to the correct location.