### PR TITLE
Add testing tools to CI agents

### DIFF
--- a/modules/govuk_ci/manifests/agent.pp
+++ b/modules/govuk_ci/manifests/agent.pp
@@ -30,6 +30,7 @@ class govuk_ci::agent(
   include ::govuk_jenkins::pipeline
   include ::govuk_rbenv::all
   include ::golang
+  include ::govuk_testing_tools
 
   # Override sudoers.d resource (managed by sudo module) to enable Jenkins user to run sudo tests
   File<|title == '/etc/sudoers.d/'|> {


### PR DESCRIPTION
Ensure that phantomJS and qmake are installed on Jenkins executors so
that they can be used by tests for Ruby projects.

qmake is required to install Capybara.