### PR TITLE
Use an env var to toggle if `strict_variables` testing is enabled

### DIFF
--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -16,6 +16,8 @@ RSpec.configure do |c|
 
   c.order = 'rand'
 
+  c.strict_variables = ENV['PUPPET_RSPEC_STRICT_VARIABLES'] == '1'
+
   possible_releases = {
     'precise' => '12.04',
     'trusty'  => '14.04',


### PR DESCRIPTION
Puppet 4 has added language improvements that will detect and raise
errors on undefined variable usage. In order to test under the same
conditions in Puppet 3 you need to set `strict_variables` to true.

As we plan to one day move to puppet 4 having our code run cleanly under
this setting would be a nice thing to have. This change makes it easier to
test in either mode while parts of our code base are non-compliant.