### PR TITLE
newer vcloud has username in the form of email addresses

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/launch_vms.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/launch_vms.yaml.erb
@@ -31,7 +31,7 @@
     parameters:
         - string:
             name: USERNAME
-            description: your vcloud username. probably in the form of 12.3.45a6b7
+            description: your vcloud username. This should be an email address.
             default: false
         - string:
             name: CONFIG_GLOB

--- a/modules/govuk_jenkins/templates/jobs/launch_vms_dr.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/launch_vms_dr.yaml.erb
@@ -31,7 +31,7 @@
     parameters:
         - string:
             name: USERNAME
-            description: your vcloud username
+            description: your vcloud username. This should be an email address
             default: false
         - string:
             name: CONFIG_GLOB


### PR DESCRIPTION
Our older provider does not.