### PR TITLE
Remove elasticsearch-backend from the data sync joblist

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
@@ -86,7 +86,6 @@
                 - all
                 - assets
                 - elasticsearch-api
-                - elasticsearch-backend
                 - mongo-api
                 - mongo-exceptions
                 - mongo-licensify

--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_staging.yaml.erb
@@ -84,7 +84,6 @@
                 - all
                 - assets
                 - elasticsearch-api
-                - elasticsearch-backend
                 - mongo-api
                 - mongo-exceptions
                 - mongo-licensify


### PR DESCRIPTION
Data syncs are failing `[elasticsearch-backend] JOB FAILURE`
This node has been removed, there's no point attempting to sync with it.

/cc @deanwilson @surminus