### PR TITLE
Fix docs nginx config

### DIFF
--- a/modules/govuk/manifests/node/s_backend_lb.pp
+++ b/modules/govuk/manifests/node/s_backend_lb.pp
@@ -108,6 +108,6 @@ class govuk::node::s_backend_lb (
   }
 
   nginx::config::vhost::proxy { "docs.${app_domain}" :
-    to => ['http://govuk-developer-documentation-production.s3-website-eu-west-1.amazonaws.com/'],
+    to => ['govuk-developer-documentation-production.s3-website-eu-west-1.amazonaws.com'],
   }
 }


### PR DESCRIPTION
nginx on backend load balancers in integration was failing to start.  When
testing the config it claimed: `[emerg] invalid host in upstream "http://govuk-developer-documentation-production.s3-website-eu-west-1.amazonaws.com/"
in /etc/nginx/sites-enabled/docs.integration.publishing.service.gov.uk:2`.

Looking at the config on backend-lb-1 it seemed that including the scheme on
this line would result in a URL with two schemes being generated.  Removing
the scheme and trailing '/' allowed nginx to start once more.

@deanwilson 