### PR TITLE
Ensure Brakeman is installed on CI agents

### DIFF
--- a/modules/govuk_testing_tools/manifests/init.pp
+++ b/modules/govuk_testing_tools/manifests/init.pp
@@ -10,4 +10,8 @@ class govuk_testing_tools {
     ensure => installed;
   }
 
+  package { 'brakeman':
+    ensure   => 'installed',
+    provider => system_gem,
+  }
 }


### PR DESCRIPTION
Brakeman is a Rails security scanner. It was installed on the old Jenkins executors, and it should be installed on Jenkins 2 executors to allow us to migrate builds like panopticon to Jenkins 2.

I've included this with the other testing packages, but I can move it if there's a more suitable location.