### PR TITLE
Clean up jenkins jobs on new CI

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -567,12 +567,10 @@ govuk_ci::master::pipeline_jobs:
   async_experiments: {}
   backdrop-transactions-explorer-collector: {}
   cdn-acceptance-tests: {}
-  content-register: {}
   deployment:
     source: 'git'
   deprecated_columns: {}
   event-store: {}
-  finder-api: {}
   gapy: {}
   gds-api-adapters: {}
   gds-scala-common: {}
@@ -628,7 +626,6 @@ govuk_ci::master::pipeline_jobs:
   screenshot-as-a-service: {}
   shared_mustache: {}
   slimmer: {}
-  smartdown: {}
   spotlight-performance: {}
   transition-config: {}
   ubuntu_unused_kernels:


### PR DESCRIPTION
These repos all have been decommissioned:

https://github.com/gds-attic/content-register
https://github.com/gds-attic/finder-api
https://github.com/gds-attic/smartdown