### PR TITLE
Add per-project configuration for branches which are excluded by Jenkins

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -20,7 +20,8 @@ deployable_applications: &deployable_applications
   calculators: {}
   calendars: {}
   collections: {}
-  collections-publisher: {}
+  collections-publisher:
+    branches_to_exclude: ['release', 'deployed-to-integration', 'deployed-to-staging']
   contacts:
     repository: 'contacts-admin'
   contacts-frontend: {}

--- a/modules/govuk_ci/manifests/job.pp
+++ b/modules/govuk_ci/manifests/job.pp
@@ -20,11 +20,17 @@
 # Type of Branch Source plugin to use in the Jenkins job. It can be 'github' or 'git' (for Github Enterprise projects)
 # Default: github
 #
+# [*branches_to_exclude*]
+# Array of branches which should _not_ be built by the CI server, for example because they are labels for releases
+# rather than development work. '*' may be used as a wildcard.
+# Default: release deployed-to-* integration staging production
+#
 define govuk_ci::job (
   $app = $title,
   $repository = $title,
   $repo_owner = 'alphagov',
   $source = 'github',
+  $branches_to_exclude = ['release', 'deployed-to-*', 'integration', 'staging', 'production'],
 ) {
 
   validate_re($source, '^(github|git)$', 'Invalid source value, it must be github or git')

--- a/modules/govuk_ci/templates/application_build_job.xml.erb
+++ b/modules/govuk_ci/templates/application_build_job.xml.erb
@@ -38,7 +38,7 @@
 <%- end -%>
           <repository><%= @repository %></repository>
           <includes>*</includes>
-          <excludes>release deployed-to-* integration staging production</excludes>
+          <excludes><%= @branches_to_exclude.join(' ') =></excludes>
           <buildOriginBranch>true</buildOriginBranch>
           <buildOriginBranchWithPR>true</buildOriginBranchWithPR>
           <buildOriginPRMerge>false</buildOriginPRMerge>
@@ -57,4 +57,3 @@
     <owner class="org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject" reference="../.."/>
   </factory>
 </org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject>
-

--- a/modules/govuk_ci/templates/application_build_job.xml.erb
+++ b/modules/govuk_ci/templates/application_build_job.xml.erb
@@ -38,7 +38,7 @@
 <%- end -%>
           <repository><%= @repository %></repository>
           <includes>*</includes>
-          <excludes><%= @branches_to_exclude.join(' ') =></excludes>
+          <excludes><%= @branches_to_exclude.join(' ') %></excludes>
           <buildOriginBranch>true</buildOriginBranch>
           <buildOriginBranchWithPR>true</buildOriginBranchWithPR>
           <buildOriginPRMerge>false</buildOriginPRMerge>


### PR DESCRIPTION
By default, Jenkins does not build branches which represent releases, e.g. 'release' or 'deployed-to-production'. This makes sense for most projects, but it is sometimes useful to be able to trigger builds of release branches, such as for projects which are used as downstream tests of other projects like the content schemas.

This is the solution that Ana and I discussed - it avoids having to create a completely separate Puppet config for the schema tests. In a separate commit, I've also configured the first of the downstream builds to override the defaults so that deployed-to-production is a valid Jenkins branch build.

Marked as DO NOT MERGE until I've updated collections-publisher to handle 'deployed-to-production' builds (alphagov/collections-publisher#231).

@afda16 and @tijmenb - would you mind taking a look at this?