### PR TITLE
Export the zendesk client username to all environments

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -314,6 +314,8 @@ govuk::apps::publisher::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::short_url_manager::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::short_url_manager::redis_port: "%{hiera('sidekiq_port')}"
 
+govuk::apps::support_api::zendesk_client_username: 'zd-api-govt@digital.cabinet-office.gov.uk/token'
+
 govuk::apps::whitehall::admin_db_hostname: whitehall-master.mysql
 govuk::apps::whitehall::admin_key_space_limit: '262144'
 govuk::apps::whitehall::admin_db_name: whitehall_production

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -52,7 +52,6 @@ govuk::apps::publicapi::backdrop_host: 'www.performance.service.gov.uk'
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-production'
 govuk::apps::support_api::pp_data_url: 'https://www.performance.service.gov.uk'
 govuk::apps::support_api::zendesk_anonymous_ticket_email: 'zd-api-public@digital.cabinet-office.gov.uk'
-govuk::apps::support_api::zendesk_client_username: 'zd-api-govt@digital.cabinet-office.gov.uk/token'
 govuk::apps::travel_advice_publisher::enable_email_alerts: true
 
 govuk::deploy::actionmailer_enable_delivery: true


### PR DESCRIPTION
This is currently missing from integration and staging, [it should be present in all environments](https://github.gds/gds/alphagov-deployment/pull/1295/commits/26c959585a81077db4949d8fa295102604ebd640#diff-8a844458b8b7915263827443e9c1ca88L6).