### PR TITLE
Correctly docs.publishing.service.gov.uk to S3

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -948,6 +948,7 @@ hosts::production::backend::app_hostnames:
   - 'contacts-admin'
   - 'contentapi'
   - 'content-tagger'
+  - 'docs'
   - 'draft-whitehall-frontend'
   - 'email-alert-api'
   - 'errbit'

--- a/modules/govuk/manifests/node/s_backend_lb.pp
+++ b/modules/govuk/manifests/node/s_backend_lb.pp
@@ -107,7 +107,12 @@ class govuk::node::s_backend_lb (
     to => "https://admin.${perfplat_public_app_domain}/",
   }
 
+  # Allthough there are different staging, integration and production buckets
+  # created by Terraform on S3, we do not intend to use them. To avoid confusion
+  # we proxy all domains to the production bucket.
   nginx::config::vhost::proxy { "docs.${app_domain}" :
-    to => ['govuk-developer-documentation-production.s3-website-eu-west-1.amazonaws.com'],
+    to        => ['govuk-developer-documentation-production.s3-website-eu-west-1.amazonaws.com'],
+    protected => false,
+    http_host => 'govuk-developer-documentation-production.s3-website-eu-west-1.amazonaws.com',
   }
 }

--- a/modules/nginx/manifests/config/vhost/proxy.pp
+++ b/modules/nginx/manifests/config/vhost/proxy.pp
@@ -66,6 +66,9 @@
 #   Boolean, whether to enable HTTP/1.1 for proxying from the Nginx vhost
 #   to the app server.
 #
+# [*http_host*]
+#   The HTTP `Host` header. Defaults to the HTTP host.
+#
 define nginx::config::vhost::proxy(
   $to,
   $to_ssl = false,
@@ -86,6 +89,7 @@ define nginx::config::vhost::proxy(
   $alert_5xx_warning_rate = 0.05,
   $alert_5xx_critical_rate = 0.1,
   $proxy_http_version_1_1_enabled = false,
+  $http_host = undef,
 ) {
   validate_re($ensure, '^(absent|present)$', 'Invalid ensure value')
 

--- a/modules/nginx/templates/proxy-vhost.conf
+++ b/modules/nginx/templates/proxy-vhost.conf
@@ -44,7 +44,12 @@ server {
   proxy_http_version 1.1;
 
   <%- end -%>
+  <%- if @http_host %>
+  proxy_set_header Host <%= @http_host %>;
+  <% else %>
   proxy_set_header Host $http_host;
+  <% end %>
+
   proxy_set_header X-Real-IP $remote_addr;
   proxy_set_header X-Forwarded-Server $host;
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
In https://github.com/alphagov/govuk-puppet/pull/5269 I introduced a nginx config to proxy `docs.publishing.service.gov.uk` to an S3 bucket. The configuration was wrong, which caused nginx to crash loop on the load balancers. Sad! The crash was fixed in https://github.com/alphagov/govuk-puppet/pull/5279.

This PR fixes the following:

- By default, the nginx configs puts a HTTP basic auth password on the proxy. We like the domain to be publicly accessible, so we disable this.
- To make S3 respond with the correct content, we set the `Hostname` HTTP header to the name of the bucket. If this isn't set, Amazon will try to find a bucket called `docs.publishing.service.gov.uk` and return 404.
- Add `docs` to the hostnames. This will make nginx respond on the new `docs.x` domain.

This time, I have employed a novel development technique called "testing your stuff locally" to make sure that this config actually works.

I tested it by doing the following. First, start a load balancer VM on locally with vagrant:

```
~/govuk/govuk-puppet $ vagrant up backend-lb-1.backend
```

Next, point the test domain to the running VM:

```
# /etc/hosts
10.1.3.101 docs.dev.gov.uk
```

After this, visiting the docs will do the correct thing:

http://docs.dev.gov.uk/