### PR TITLE
Add monitoring for jenkins agents

### DIFF
--- a/modules/govuk_jenkins/manifests/ssh_slave.pp
+++ b/modules/govuk_jenkins/manifests/ssh_slave.pp
@@ -57,4 +57,11 @@ define govuk_jenkins::ssh_slave (
     notify  => Service['jenkins'],
   }
 
+  include icinga::client::check_jenkins_agent
+  @@icinga::check { "check_jenkins_agent_status_${agent_name}":
+    check_command       => "check_nrpe!check_jenkins_agent!${agent_name}",
+    service_description => "${title} is not connected to the Jenkins master",
+    host_name           => $::fqdn,
+  }
+
 }

--- a/modules/icinga/files/etc/nagios/nrpe.d/check_jenkins_agent.cfg
+++ b/modules/icinga/files/etc/nagios/nrpe.d/check_jenkins_agent.cfg
@@ -1,0 +1,1 @@
+command[check_jenkins_agent]=/usr/lib/nagios/plugins/check_jenkins_agent $ARG1$

--- a/modules/icinga/files/usr/lib/nagios/plugins/check_jenkins_agent
+++ b/modules/icinga/files/usr/lib/nagios/plugins/check_jenkins_agent
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# Desc : Plugin to check status of Jenkins agents. Should be run
+# on the master.
+
+PROGNAME=$(basename "$0")
+
+if [ -z "$1" ]
+then
+  echo -e "Use : $PROGNAME <Jenkins agent hostname> -- Ex : $PROGNAME ci-agent-1 \n "
+  exit 3
+fi
+
+if /usr/bin/curl -sk 'https://localhost:443/computer/api/json' \
+   | /usr/bin/jq '.computer[] | select(.displayName=="${1}")' \
+   | /usr/bin/jq '{offline}' \
+   | /bin/grep -q "false"
+then
+  echo "OK: Jenkins agent is online"
+  exit 0
+else
+  echo "Critical: Jenkins agent is offline"
+  exit 2
+fi

--- a/modules/icinga/manifests/client/check_jenkins_agent.pp
+++ b/modules/icinga/manifests/client/check_jenkins_agent.pp
@@ -1,0 +1,16 @@
+# == Class: Icinga::Client::Check_jenkins_agent
+#
+# Checks the online/offline status of a Jenkins agent by calling the
+# API from the master.
+#
+class icinga::client::check_jenkins_agent {
+  ensure_packages('jq', {'ensure' => 'present'})
+
+  @icinga::plugin { 'check_jenkins_agent':
+    source  => 'puppet:///modules/icinga/usr/lib/nagios/plugins/check_jenkins_agent',
+  }
+
+  @icinga::nrpe_config { 'check_jenkins_agent':
+    source => 'puppet:///modules/icinga/etc/nagios/nrpe.d/check_jenkins_agent.cfg',
+  }
+}


### PR DESCRIPTION
We've had occasions where Jenkins agents have lost their connection to the Jenkins master, even when the processes and server seems to be OK. This hopefully allows us to monitor the agent status from the perspective of the master. 