### PR TITLE
Add ImageMagick to CI agents

### DIFF
--- a/modules/govuk_testing_tools/manifests/init.pp
+++ b/modules/govuk_testing_tools/manifests/init.pp
@@ -1,4 +1,7 @@
-# FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
+# == Class: govuk_testing_tools
+#
+# Installs packages required by testing environments such as CI agents
+#
 class govuk_testing_tools {
   include imagemagick
   include phantomjs

--- a/modules/govuk_testing_tools/manifests/init.pp
+++ b/modules/govuk_testing_tools/manifests/init.pp
@@ -1,5 +1,6 @@
 # FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
 class govuk_testing_tools {
+  include imagemagick
   include phantomjs
   include ::xvfb
 


### PR DESCRIPTION
ImageMagick is used by some projects' integration tests, e.g. whitehall, so it needs to be installed on Jenkins as part of the testing tools.