### PR TITLE
Set `key_content` to undef on resource removal

### DIFF
--- a/modules/govuk_user/manifests/init.pp
+++ b/modules/govuk_user/manifests/init.pp
@@ -65,6 +65,7 @@ define govuk_user(
   } else {
     $dir_ensure = undef
     $key_ensure = absent
+    $key_content = undef
   }
 
   validate_bool($purgegroups)


### PR DESCRIPTION
We try to assert the `key_content` even when we're removing the resources, which
causes undefined value errors as we only assign it a value when ensuring resources
exist. This change adds a default of `undef` that is only used when removing.