### PR TITLE
Escape quotes

### DIFF
--- a/modules/icinga/files/usr/lib/nagios/plugins/check_jenkins_agent
+++ b/modules/icinga/files/usr/lib/nagios/plugins/check_jenkins_agent
@@ -12,8 +12,8 @@ then
 fi
 
 if /usr/bin/curl -sk 'https://localhost:443/computer/api/json' \
-   | /usr/bin/jq '.computer[] | select(.displayName=="${1}")' \
-   | /usr/bin/jq '{offline}' \
+   | /usr/bin/jq ".computer[] | select(.displayName==\"${1}\")" \
+   | /usr/bin/jq "{offline}" \
    | /bin/grep -q "false"
 then
   echo "OK: Jenkins agent is online"


### PR DESCRIPTION
Without escaping the quotes of the ARGV, the hostname does not get passed in which means the check reports that host as offline. Ideally it would be better to have it fail if jq errors but this will fix it for now.