### PR TITLE
Add new mount point for Jenkins data

### DIFF
--- a/hieradata/class/ci_agent.yaml
+++ b/hieradata/class/ci_agent.yaml
@@ -13,3 +13,14 @@ govuk_elasticsearch::version: '1.7.5'
 govuk_elasticsearch::number_of_replicas: '0'
 
 icinga::client::check_cputype::cputype: 'intel'
+
+lv:
+  data:
+    pv: '/dev/sdb1'
+    vg: 'jenkins'
+
+mount:
+  /var/lib/jenkins:
+    disk: '/dev/mapper/jenkins-data'
+    govuk_lvm: 'data'
+    mountoptions: 'defaults'


### PR DESCRIPTION
This assigns a dedicated disk to /var/lib/jenkins for Jenkins builds. Original disk size will be 128GB.