### PR TITLE
Add build parameter initialization to Jenkins helper functions

### DIFF
--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -35,6 +35,23 @@ def setEnvar(String key, String value) {
 }
 
 /**
+ * Ensure that the build parameters are set to their default values if they are
+ * missing. This fixes an issue where the parameters are missing on the very
+ * first pipeline build of a new branch (JENKINS-40574). They are set correctly
+ * on every subsequent build, whether it is triggered automatically by a branch
+ * push or manually by a Jenkins user.
+ *
+ * @param defaultBuildParams map of build parameter names to default values
+ */
+def initializeParameters(Map<String, String> defaultBuildParams) {
+  for (param in defaultBuildParams) {
+    if (env."${param.key}" == null) {
+      setEnvar(param.key, param.value)
+    }
+  }
+}
+
+/**
  * Sets the current git commit in the env. Used by the linter
  */
 def setEnvGitCommit() {


### PR DESCRIPTION
Extract a function from finder-frontend to ensure that Jenkins build parameters are set the first time that a new branch is built. There seems to be an issue with build parameters not being picked up in the first build of a pipeline project ([JENKINS-40574](https://issues.jenkins-ci.org/browse/JENKINS-40574)), and this is a workaround.

https://trello.com/c/S4DZbsPa/285-jenkins-2-migration