### PR TITLE
Update library methods to work with Rails < 5

### DIFF
--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -88,6 +88,7 @@ def contentSchemaDependency(String schemaGitCommit = 'deployed-to-production') {
     dir("tmp/govuk-content-schemas") {
       sh("git checkout ${schemaGitCommit}")
     }
+    env."GOVUK_CONTENT_SCHEMAS_PATH" = "tmp/govuk-content-schemas"
   }
 }
 
@@ -96,7 +97,7 @@ def contentSchemaDependency(String schemaGitCommit = 'deployed-to-production') {
  */
 def setupDb() {
   echo 'Setting up database'
-  sh('bundle exec rails db:drop db:create db:environment:set db:schema:load')
+  sh('RAILS_ENV=test bundle exec rake db:drop db:create db:environment:set db:schema:load')
 }
 
 /**
@@ -115,7 +116,7 @@ def bundleApp() {
  */
 def runTests(String test_task = 'default') {
   echo 'Running tests'
-  sh("bundle exec rails ${test_task}")
+  sh("bundle exec rake ${test_task}")
 }
 
 /**


### PR DESCRIPTION
A few tweaks to ensure that the same library functions will work for the
majority of rails apps.