### PR TITLE
Improve parameter name in Jenkins deployment helper

### DIFF
--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -155,15 +155,17 @@ def pushTag(String repository, String branch, String tag) {
 /**
  * Method to deploy an application on the Integration environment
  *
- * @param repository Github repository
+ * @param application ID of the application, which should match the ID
+          configured in puppet and which is usually the same as the repository
+          name
  * @param branch Branch name
  * @param tag Tag to deploy
  * @param deployTask Deploy task (deploy, deploy:migrations or deploy:setup)
  */
-def deployIntegration(String repository, String branch, String tag, String deployTask) {
+def deployIntegration(String application, String branch, String tag, String deployTask) {
 
   if (branch == 'master') {
-    build job: 'integration-app-deploy', parameters: [string(name: 'TARGET_APPLICATION', value: repository), string(name: 'TAG', value: tag), string(name: 'DEPLOY_TASK', value: deployTask)]
+    build job: 'integration-app-deploy', parameters: [string(name: 'TARGET_APPLICATION', value: application), string(name: 'TAG', value: tag), string(name: 'DEPLOY_TASK', value: deployTask)]
   }
 
 }


### PR DESCRIPTION
The integration deployment function in the pipeline helper takes an application parameter - this needs to be the application ID configured in puppet, not the repository. These are usually the same thing, but in some applications they are different (e.g. business-support-finder vs businesssupportfinder).

This change makes it clearer that the application ID is what's required.

I'm not totally sure on the terminology here, so if there's a better name then "application ID", then let me know and I'll update it.

https://trello.com/c/S4DZbsPa/285-jenkins-2-migration