### PR TITLE
Add the 'Deploy DNS' job to Jenkins

### DIFF
--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -12,6 +12,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::copy_sanitised_whitehall_database
   - govuk_jenkins::job::deploy_app
   - govuk_jenkins::job::deploy_cdn
+  - govuk_jenkins::job::deploy_dns
   - govuk_jenkins::job::deploy_lambda_app
   - govuk_jenkins::job::deploy_licensify
   - govuk_jenkins::job::deploy_puppet

--- a/modules/govuk_jenkins/manifests/job/deploy_dns.pp
+++ b/modules/govuk_jenkins/manifests/job/deploy_dns.pp
@@ -1,0 +1,26 @@
+# == Class: govuk_jenkins::job::deploy_dns
+#
+# Create the Jenkins job to deploy DNS records.
+#
+# === Parameters
+#
+# [*dyn_zone_id*]
+#   ID of the Dyn DNS zone to upload the DNS records to.
+#
+# [*route53_zone_id*]
+#   ID of the route53 DNS zone to upload to
+#
+# [*dyn_customer_name*]
+#    Customer account to use for Dyn (not to be confused with the Dyn user name)
+#
+class govuk_jenkins::job::deploy_dns (
+    $dyn_zone_id,
+    $route53_zone_id,
+    $dyn_customer_name,
+) {
+  file { '/etc/jenkins_jobs/jobs/deploy_dns.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/deploy_dns.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+}

--- a/modules/govuk_jenkins/templates/jobs/deploy_dns.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_dns.yaml.erb
@@ -1,0 +1,52 @@
+---
+- scm:
+    name: Deploy_DNS
+    scm:
+        - git:
+            url: git@github.com:alphagov/govuk-dns.git
+            branches:
+              - master
+            wipe-workspace: true
+            clean:
+                after: true
+
+- job:
+    name: Deploy_DNS
+    display-name: Deploy_DNS
+    project-type: freestyle
+    properties:
+        - github:
+            url: https://github.com/alphagov/govuk-dns/
+    scm:
+      - Deploy_DNS
+    builders:
+        - shell: |
+            export DEPLOY_ENV=<%= @environment %>
+            export DYN_ZONE_ID='<%= @dyn_zone_id %>'
+            export ROUTE53_ZONE_ID='<%= @route53_zone_id %>'
+            export DYN_CUSTOMER_NAME='<%= @dyn_customer_name %>'
+            ./jenkins.sh
+    wrappers:
+        - ansicolor:
+            colormap: xterm
+    parameters:
+        - choice:
+            name: PROVIDERS
+            choices:
+                - PICK ONE
+                - all
+                - dyn
+                - route53
+        - string:
+            name: AWS_ACCESS_KEY_ID
+            default: false
+        - string:
+            name: AWS_SECRET_ACCESS_KEY
+            default: false
+        - string:
+            name: DYN_USERNAME
+            default: false
+        - string:
+            name: DYN_PASSWORD
+            default: false
+


### PR DESCRIPTION
This adds the deploy dns task to jenkins but only for the production environment
as Dyn currently only has a production account.