### PR TITLE
Jenkins s3 plugin

### DIFF
--- a/hieradata/class/ci_master.yaml
+++ b/hieradata/class/ci_master.yaml
@@ -37,6 +37,8 @@ govuk_jenkins::plugins:
       version: "0.4.2"
     antisamy-markup-formatter:
       version: "1.5"
+    aws-java-sdk:
+      version: "1.11.68"
     bouncycastle-api:
       version: "2.16.0"
     brakeman:
@@ -89,6 +91,8 @@ govuk_jenkins::plugins:
       version: "1.1.1"
     icon-shim:
       version: "2.0.3"
+    jackson2-api:
+      version: "2.7.3"
     javadoc:
       version: "1.4"
     jenkinswalldisplay:
@@ -147,6 +151,8 @@ govuk_jenkins::plugins:
       version: "1.6.4"
     run-condition:
       version: "1.0"
+    s3:
+      version: "0.10.10"
     scm-api:
       version: "1.3"
     scm-sync-configuration:


### PR DESCRIPTION
Allows for storing, publishing and pulling artefacts backed by s3.

reference: https://wiki.jenkins-ci.org/display/JENKINS/Jackson2+API+Plugin