### PR TITLE
Remove additional Stage in Jenkins library method

### DIFF
--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -163,10 +163,7 @@ def pushTag(String repository, String branch, String tag) {
 def deployIntegration(String repository, String branch, String tag, String deployTask) {
 
   if (branch == 'master') {
-    // Deploy on Integration
-    stage('Deploy on Integration') {
-      build job: 'integration-app-deploy', parameters: [string(name: 'TARGET_APPLICATION', value: repository), string(name: 'TAG', value: tag), string(name: 'DEPLOY_TASK', value: deployTask)]
-    }
+    build job: 'integration-app-deploy', parameters: [string(name: 'TARGET_APPLICATION', value: repository), string(name: 'TAG', value: tag), string(name: 'DEPLOY_TASK', value: deployTask)]
   }
 
 }


### PR DESCRIPTION
It seems like a convention is emerging that the Jenkinsfile in an
individual project is responsible for defining the pipeline stages.

Some projects that use the `deployIntegration()` library method are showing multiple 'deploy to
integration' stages, as this defined a stage internally in addition to the stage that is defined in the project's own Jenkinsfile.

Not a big deal if people don't want this change to go through, but it
will improve the pipeline view for a few projects.

[Example](https://ci.integration.publishing.service.gov.uk/job/local-links-manager/job/master/)

<img width="1082" alt="screen shot 2016-12-22 at 12 27 28" src="https://cloud.githubusercontent.com/assets/608867/21426697/32e49140-c848-11e6-92f3-4782cb1cb4d2.png">
