### PR TITLE
Vagrant CI Master ssh key

### DIFF
--- a/hieradata/vagrant_credentials.yaml
+++ b/hieradata/vagrant_credentials.yaml
@@ -127,6 +127,8 @@ govuk_ci::master::github_client_id: 'bellathecat'
 govuk_ci::master::github_client_secret: 'sheisfurry'
 govuk_ci::master::jenkins_api_token: 'thisisatoken'
 
+govuk_ci::agent::master_ssh_key: 'key'
+
 govuk_ci::vpn::ghe_vpn_username: 'bella'
 govuk_ci::vpn::ghe_vpn_password: 'furrysocks'
 


### PR DESCRIPTION
Puppet requires that a correctly formatted string be set for a param belonging to ssh_authorized_key type.

Works around this error when provisioning a ci agent in vagrant:
```
Error: Parameter key failed on Ssh_authorized_key[ci-master-1.ci]: Key must not contain whitespace: In other environments, this should be replaced with a real public key
```