### PR TITLE
Safely restart jenkins service

### DIFF
--- a/hieradata/class/ci_master.yaml
+++ b/hieradata/class/ci_master.yaml
@@ -147,6 +147,8 @@ govuk_jenkins::plugins:
       version: "1.6.4"
     run-condition:
       version: "1.0"
+    safe-restart:
+      version: "0.3"
     scm-api:
       version: "1.3"
     scm-sync-configuration:

--- a/modules/govuk_jenkins/manifests/config.pp
+++ b/modules/govuk_jenkins/manifests/config.pp
@@ -109,7 +109,7 @@ class govuk_jenkins::config (
     File {
       owner  => 'jenkins',
       group  => 'jenkins',
-      notify => Service['jenkins'],
+      notify => Class['Govuk_jenkins::Safe_restart'],
     }
 
     file {'/var/lib/jenkins/com.cloudbees.jenkins.GitHubPushTrigger.xml':

--- a/modules/govuk_jenkins/manifests/safe_restart.pp
+++ b/modules/govuk_jenkins/manifests/safe_restart.pp
@@ -1,0 +1,33 @@
+# == Class: Govuk_jenkins::Safe_restart
+#
+# This class will issue a "safe restart" of Jenkins, which means it will only
+# restart once all jobs have finished running.
+#
+# Note: this requires having a user enabled that has the appropriate public SSH
+# key assigned to it. This should be added manually via the UI in advance
+# otherwise the command will fail.
+#
+# === Parameters:
+#
+# [*jenkins_home*]
+#   The home directory of the Jenkins install, and where to put the Jenkins CLI
+#   jar.
+#
+class govuk_jenkins::safe_restart (
+  $jenkins_home = '/var/lib/jenkins',
+) {
+  require ::govuk_jenkins
+
+  curl::fetch { 'Jenkins CLI tool':
+    source      => 'http://localhost:8080/nlpJars/jenkins-cli.jar',
+    destination => "${jenkins_home}/jenkins-cli.jar",
+    timeout     => 0,
+    verbose     => false,
+  }
+
+  exec { 'Restart Jenkins':
+    command     => "/usr/bin/java -jar ${jenkins_home}/jenkins-cli.jar -s http://localhost:8080/ -i ${jenkins_home}/.ssh/id_rsa safe-restart",
+    require     => Curl::Fetch['Jenkins CLI tool'],
+    refreshonly => true,
+  }
+}

--- a/modules/govuk_jenkins/manifests/ssh_slave.pp
+++ b/modules/govuk_jenkins/manifests/ssh_slave.pp
@@ -54,7 +54,7 @@ define govuk_jenkins::ssh_slave (
     content => template('govuk_jenkins/ssh_slave_config.xml.erb'),
     owner   => $jenkins_user,
     group   => $jenkins_user,
-    notify  => Service['jenkins'],
+    notify  => Class['Govuk_jenkins::Safe_restart'],
   }
 
   include icinga::client::check_jenkins_agent


### PR DESCRIPTION
When we manage files on disk, we have to restart the Jenkins service if we make a change. Doing a service refresh does not take into account if any builds may be happening and will cause them to fail.

This commit adds a class which pulls the jenkins-cli.jar and issues a safe restart. Use this class to notify rather than the service itself.