### PR TITLE
Uninstall unused Ruby 2.1.6 and 2.1.7

### DIFF
--- a/modules/govuk_rbenv/manifests/all.pp
+++ b/modules/govuk_rbenv/manifests/all.pp
@@ -32,10 +32,10 @@ class govuk_rbenv::all (
     bundler_version => '1.8.3',
   }
   rbenv::version { '2.1.6':
-    bundler_version => '1.9.4',
+    ensure => absent, # FIXME: Tidy up once deployed
   }
   rbenv::version { '2.1.7':
-    bundler_version => '1.10.6',
+    ensure => absent, # FIXME: Tidy up once deployed
   }
   rbenv::version { '2.1.8':
     bundler_version => '1.10.6',


### PR DESCRIPTION
These versions are not in use. Verified with:

```
fab production puppet_class:govuk_rbenv::all rbenv.version_in_use:2.1.6
fab production puppet_class:govuk_rbenv::all rbenv.version_in_use:2.1.7
```