### PR TITLE
Remove SCM sync plugin from Jenkins

### DIFF
--- a/hieradata/class/ci_master.yaml
+++ b/hieradata/class/ci_master.yaml
@@ -149,8 +149,6 @@ govuk_jenkins::plugins:
       version: "1.0"
     scm-api:
       version: "1.3"
-    scm-sync-configuration:
-      version: "0.0.10"
     script-security:
       version: "1.24"
     sitemonitor:
@@ -165,8 +163,6 @@ govuk_jenkins::plugins:
       version: "1.11"
     structs:
       version: "1.5"
-    subversion:
-      version: "2.7.1"
     swarm:
       version: "2.2"
     text-finder:

--- a/hieradata/class/jenkins.yaml
+++ b/hieradata/class/jenkins.yaml
@@ -75,8 +75,6 @@ govuk_jenkins::plugins:
     version: '0.3'
   scm-api:
     version: '0.2'
-  scm-sync-configuration:
-    version: '0.0.8'
   show-build-parameters:
     version: '1.0'
   slack:


### PR DESCRIPTION
We used this originally before our Jenkins was managed using code. Now that our Jenkins is managed with Puppet we have no need to sync its configuration to a git repo.

This means we can get rid of the subversion plugin because scm-sync is the only thing that needs it:

```
alexmuller@integration-ci-master-1:/var/lib/jenkins/plugins$ ack-grep subversion | grep Dependencies
scm-sync-configuration/META-INF/MANIFEST.MF:23:Plugin-Dependencies: subversion:2.5.7
parameterized-trigger/META-INF/MANIFEST.MF:19:Plugin-Dependencies: subversion:2.5.7;resolution:=optional,matrix-proj
```