### PR TITLE
Include CI credentials on CI agents

### DIFF
--- a/modules/govuk_ci/manifests/agent.pp
+++ b/modules/govuk_ci/manifests/agent.pp
@@ -23,6 +23,7 @@ class govuk_ci::agent(
   include ::govuk_ci::agent::mongodb
   include ::govuk_ci::agent::postgresql
   include ::govuk_ci::agent::mysql
+  include ::govuk_ci::credentials
   include ::govuk_ci::vpn
   include ::govuk_java::oracle8
   include ::govuk_jenkins::github_enterprise_cert


### PR DESCRIPTION
This is necessary to allow jobs in CI to publish to rubygems.org, PyPI
and NPM.