### PR TITLE
Fix require for govuk_ci::credentials

### DIFF
--- a/modules/govuk_ci/manifests/credentials.pp
+++ b/modules/govuk_ci/manifests/credentials.pp
@@ -44,7 +44,7 @@ class govuk_ci::credentials (
     owner   => $jenkins_user,
     group   => $jenkins_user,
     mode    => '0600',
-    require => Class['::govuk_jenkins'],
+    require => Class['::govuk_jenkins::user'],
   }
 
   file {'jenkins_dotgem_dir':


### PR DESCRIPTION
The agent machines need credentials, but they don't include the whole govuk_jenkins class - only the user part of it.

/cc @cbaines 