### PR TITLE
Add govuk-rubygems repo

### DIFF
--- a/modules/govuk/manifests/node/s_apt.pp
+++ b/modules/govuk/manifests/node/s_apt.pp
@@ -94,6 +94,7 @@ class govuk::node::s_apt (
   aptly::repo { 'gof3r': }
   aptly::repo { 'gor': }
   aptly::repo { 'govuk-jenkins': }
+  aptly::repo { 'govuk-rubygems': }
   aptly::repo { 'jenkins-agent': }
   aptly::repo { 'rbenv-ruby': }
   aptly::repo { 'terraform': }


### PR DESCRIPTION
We're creating some homemade debian packages from gems. We will store them in this repo.

These are the packages created by fpm in https://github.com/alphagov/packager/