### PR TITLE
Add servicegovuk to Deploy_CDN Jenkins job

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_cdn.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_cdn.yaml.erb
@@ -37,6 +37,7 @@
                 - assets
                 - apt
                 - tldredirect
+                - servicegovuk
                 - performanceplatform
                 - performanceplatform_admin
                 - performanceplatform_stagecraft


### PR DESCRIPTION
In govuk-cdn-config we added a new Fastly template to manage
service.gov.uk. This change updates the Jenkins job to include
the new service to the options list.