### PR TITLE
Delete unnecessary Jenkins helper

### DIFF
--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -52,27 +52,6 @@ def initializeParameters(Map<String, String> defaultBuildParams) {
 }
 
 /**
- * Define Jenkins build parameters relating to content schema tests. These are
- * useful parameters to add to a build which can be run to test changes to the
- * content schemas, because they allow the schema build to trigger a build of
- * the project. The project build itself still needs to check for the values of
- * these parameters and handle them sensibly.
- *
- * @return array of build parameter definitions
- */
-def schemaTestParameters() {
-  return [
-    [$class: 'BooleanParameterDefinition',
-      name: 'IS_SCHEMA_TEST',
-      defaultValue: false,
-      description: 'Identifies whether this build is being triggered to test a change to the content schemas'],
-    [$class: 'StringParameterDefinition',
-      name: 'SCHEMA_BRANCH',
-      defaultValue: DEFAULT_SCHEMA_BRANCH,
-      description: 'The branch of govuk-content-schemas to test against']]
-}
-
-/**
  * Check whether the Jenkins build should be run for the current branch, either
  * because it is a regular branch build or because it is being run to test the
  * content schema.


### PR DESCRIPTION
Delete the 'schemaTestParameters' function from the Jenkinsfile helper.

This function was intended to simplify Jenkinsfiles for projects which are used as content schema tests, but it turned out not to be very useful - it hides build parameters from the Jenkinsfile, and the Jenkinsfile needs to know the parameters so that it can ensure their default values are initialized.

The function is not being used by any applications, so it is safe to delete.

It also called a constant which doesn't exist (because I extracted it out of another Jenkinsfile and didn't spot the constant), so it wouldn't have run correctly anyway!

https://trello.com/c/S4DZbsPa/285-jenkins-2-migration