### PR TITLE
Override Jenkins branches built for schema test repos

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -17,9 +17,11 @@ deployable_applications: &deployable_applications
   business-support-api: {}
   businesssupportfinder:
     repository: 'business-support-finder'
+    branches_to_exclude: ['release', 'deployed-to-integration', 'deployed-to-staging']
   calculators: {}
   calendars: {}
-  collections: {}
+  collections:
+    branches_to_exclude: ['release', 'deployed-to-integration', 'deployed-to-staging']
   collections-publisher:
     branches_to_exclude: ['release', 'deployed-to-integration', 'deployed-to-staging']
   contacts:
@@ -38,7 +40,8 @@ deployable_applications: &deployable_applications
   email-alert-service: {}
   errbit: {}
   feedback: {}
-  finder-frontend: {}
+  finder-frontend:
+    branches_to_exclude: ['release', 'deployed-to-integration', 'deployed-to-staging']
   frontend: {}
   government-frontend: {}
   govuk-delivery: {}
@@ -64,13 +67,15 @@ deployable_applications: &deployable_applications
   panopticon: {}
   performanceplatform-admin: {}
   performanceplatform-big-screen-view: {}
-  policy-publisher: {}
+  policy-publisher:
+    branches_to_exclude: ['release', 'deployed-to-integration', 'deployed-to-staging']
   publisher: {}
   publishing-api: {}
   release: {}
   router: {}
   router-api: {}
-  rummager: {}
+  rummager:
+    branches_to_exclude: ['release', 'deployed-to-integration', 'deployed-to-staging']
   search-admin: {}
   service-manual-frontend: {}
   service-manual-publisher: {}
@@ -83,7 +88,8 @@ deployable_applications: &deployable_applications
     repository: 'smart-answers'
   smokey: {}
   specialist-frontend: {}
-  specialist-publisher: {}
+  specialist-publisher:
+    branches_to_exclude: ['release', 'deployed-to-integration', 'deployed-to-staging']
   spotlight: {}
   stagecraft: {}
   static: {}


### PR DESCRIPTION
Ensure that 'deployed-to-production' is included in the Jenkins branch builds. This is not normally required, but it is necessary for these repos because the 'deployed-to-production' branch is used to test changes pushed to the govuk-content-schemas repo.

This is just a sub-set of the repos which are built to test the content schemas. Others will be configured in a similar way once their Jenkinsfiles handle builds of deployed-to-production correctly.

https://trello.com/c/S4DZbsPa/285-jenkins-2-migration