### PR TITLE
Add statsd and locksmithctl repos

### DIFF
--- a/modules/govuk/manifests/node/s_apt.pp
+++ b/modules/govuk/manifests/node/s_apt.pp
@@ -96,7 +96,9 @@ class govuk::node::s_apt (
   aptly::repo { 'govuk-jenkins': }
   aptly::repo { 'govuk-rubygems': }
   aptly::repo { 'jenkins-agent': }
+  aptly::repo { 'locksmithctl': }
   aptly::repo { 'rbenv-ruby': }
+  aptly::repo { 'statsd': }
   aptly::repo { 'terraform': }
 
   include nginx


### PR DESCRIPTION
These are two packages which originally we had on our PPA, but for our upgrades to Xenial we are packaging using fpm and hosting on our local mirror.