### PR TITLE
Add instance_name envvar to short_url_manager

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -18,7 +18,7 @@ govuk::apps::govuk_delivery::list_title_format: 'INTEGRATION: %s'
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
 govuk::apps::publicapi::backdrop_host: 'www.preview.performance.service.gov.uk'
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-integration'
-
+govuk::apps::short_url_manager::instance_name: 'integration'
 govuk::apps::signon::instance_name: 'integration'
 govuk::apps::smartanswers::expose_govspeak: true
 govuk::apps::specialist_publisher::publish_pre_production_finders: true

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -15,8 +15,9 @@ govuk::apps::errbit::errbit_email_from: 'govuk-winston+errbit-staging@digital.ca
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::publicapi::backdrop_host: 'www.staging.performance.service.gov.uk'
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-staging'
-govuk::apps::support_api::pp_data_url: 'https://www.staging.performance.service.gov.uk'
+govuk::apps::short_url_manager::instance_name: 'staging'
 govuk::apps::signon::instance_name: 'staging'
+govuk::apps::support_api::pp_data_url: 'https://www.staging.performance.service.gov.uk'
 govuk::apps::travel_advice_publisher::enable_email_alerts: true
 
 govuk::deploy::aws_ses_smtp_host: 'email-smtp.eu-west-1.amazonaws.com'

--- a/modules/govuk/manifests/apps/short_url_manager.pp
+++ b/modules/govuk/manifests/apps/short_url_manager.pp
@@ -8,6 +8,10 @@
 #   Errbit API key for sending errors.
 #   Default: undef
 #
+# [*instance_name*]
+#   Environment specific name used when sending emails.
+#   Default: undef
+#
 # [*mongodb_name*]
 #   The mongo database to be used.
 #
@@ -46,6 +50,7 @@
 #
 class govuk::apps::short_url_manager(
   $errbit_api_key = undef,
+  $instance_name = undef,
   $mongodb_name = undef,
   $mongodb_nodes = undef,
   $oauth_id = undef,
@@ -100,6 +105,13 @@ class govuk::apps::short_url_manager(
     govuk::app::envvar { "${title}-SECRET_KEY_BASE":
       varname => 'SECRET_KEY_BASE',
       value   => $secret_key_base,
+    }
+  }
+
+  if $instance_name != undef {
+    govuk::app::envvar { "${title}-INSTANCE_NAME":
+      varname => 'INSTANCE_NAME',
+      value   => $instance_name,
     }
   }
 }


### PR DESCRIPTION
This is used when sending emails to help indicate to the recipients which
deployed environment the email came from, and thus if they should act on
it swiftly or not.  We follow the pattern established by signon to do this.

For: https://trello.com/c/SAcBmzf3/85-include-indication-of-which-environment-sent-the-email-in-short-url-manager

Also see: https://github.com/alphagov/short-url-manager/pull/70 which uses this env var.