### PR TITLE
Change host alerting priority

### DIFF
--- a/hieradata/class/api_postgresql_primary.yaml
+++ b/hieradata/class/api_postgresql_primary.yaml
@@ -9,6 +9,8 @@ govuk_postgresql::server::primary::slave_addresses:
   dr:
     address: "%{hiera('postgresql_api_slave_addresses_dr')}"
 
+icinga::client::contact_groups: 'urgent-priority'
+
 lv:
   postgresql:
     pv: '/dev/sdb1'

--- a/hieradata/class/api_redis.yaml
+++ b/hieradata/class/api_redis.yaml
@@ -2,3 +2,6 @@
 
 govuk_safe_to_reboot::can_reboot: 'no'
 govuk_safe_to_reboot::reason: 'Single point of failure for applications, no clustering'
+
+icinga::client::contact_groups: 'urgent-priority'
+

--- a/hieradata/class/asset_master.yaml
+++ b/hieradata/class/asset_master.yaml
@@ -15,6 +15,8 @@ govuk_sudo::sudo_conf:
   deploy_assets_rsync:
     content: 'deploy ALL=(assets) NOPASSWD:/usr/bin/rsync --server -vlogDtprze.iLs --delete --ignore-errors . /mnt/uploads'
 
+icinga::client::contact_groups: 'urgent-priority'
+
 lv:
   data:
     pv:

--- a/hieradata/class/mysql_master.yaml
+++ b/hieradata/class/mysql_master.yaml
@@ -9,6 +9,8 @@ govuk_mysql::server::query_cache_size: '256M'
 govuk_mysql::server::tmp_table_size: '512M'
 govuk_mysql::server::max_heap_table_size: '512M'
 
+icinga::client::contact_groups: 'urgent-priority'
+
 lv:
   data:
     pv: '/dev/sdb1'

--- a/hieradata/class/postgresql_primary.yaml
+++ b/hieradata/class/postgresql_primary.yaml
@@ -9,6 +9,8 @@ govuk_postgresql::server::primary::slave_addresses:
   dr:
     address: "%{hiera('postgresql_slave_addresses_dr')}"
 
+icinga::client::contact_groups: 'urgent-priority'
+
 lv:
   postgresql:
     pv:

--- a/hieradata/class/postgresql_standby.yaml
+++ b/hieradata/class/postgresql_standby.yaml
@@ -5,6 +5,8 @@ govuk_safe_to_reboot::reason: 'Apps point directly to this machine for reading.'
 
 govuk_postgresql::server::standby::master_host: 'postgresql-primary-1.backend'
 
+icinga::client::contact_groups: 'urgent-priority'
+
 lv:
   postgresql:
     pv: '/dev/sdb1'

--- a/hieradata/class/redis.yaml
+++ b/hieradata/class/redis.yaml
@@ -2,3 +2,6 @@
 
 govuk_safe_to_reboot::can_reboot: 'no'
 govuk_safe_to_reboot::reason: 'Single point of failure for applications, no clustering'
+
+icinga::client::contact_groups: 'urgent-priority'
+

--- a/hieradata/class/transition_postgresql_master.yaml
+++ b/hieradata/class/transition_postgresql_master.yaml
@@ -3,6 +3,8 @@
 govuk_safe_to_reboot::can_reboot: 'no'
 govuk_safe_to_reboot::reason: 'Single point of failure for Transition application'
 
+icinga::client::contact_groups: 'urgent-priority'
+
 lv:
   data:
     pv: '/dev/sdb1'

--- a/hieradata/class/transition_postgresql_primary.yaml
+++ b/hieradata/class/transition_postgresql_primary.yaml
@@ -4,6 +4,8 @@ postgresql::globals::version: '9.5'
 govuk_safe_to_reboot::can_reboot: 'no'
 govuk_safe_to_reboot::reason: 'Single point of failure for Transition application'
 
+icinga::client::contact_groups: 'urgent-priority'
+
 lv:
   data:
     pv: '/dev/sdb1'

--- a/hieradata/class/transition_postgresql_slave.yaml
+++ b/hieradata/class/transition_postgresql_slave.yaml
@@ -2,6 +2,8 @@
 govuk_safe_to_reboot::can_reboot: 'no'
 govuk_safe_to_reboot::reason: 'Single point of failure for Bouncer application'
 
+icinga::client::contact_groups: 'urgent-priority'
+
 lv:
   postgresql:
     pv: '/dev/sdb1'

--- a/hieradata/class/transition_postgresql_standby.yaml
+++ b/hieradata/class/transition_postgresql_standby.yaml
@@ -4,6 +4,8 @@ postgresql::globals::version: '9.5'
 govuk_safe_to_reboot::can_reboot: 'no'
 govuk_safe_to_reboot::reason: 'Single point of failure for Bouncer application'
 
+icinga::client::contact_groups: 'urgent-priority'
+
 lv:
   postgresql:
     pv: '/dev/sdb1'

--- a/hieradata/class/whitehall_mysql_master.yaml
+++ b/hieradata/class/whitehall_mysql_master.yaml
@@ -5,6 +5,8 @@ govuk::node::s_whitehall_mysql_master::whitehall_fe_password: "%{hiera('mysql_wh
 govuk_safe_to_reboot::can_reboot: 'no'
 govuk_safe_to_reboot::reason: 'Single master database, applications not resilient'
 
+icinga::client::contact_groups: 'urgent-priority'
+
 lv:
   data:
     pv: '/dev/sdb1'

--- a/modules/icinga/files/etc/icinga/conf.d/generic-host_nagios2.cfg
+++ b/modules/icinga/files/etc/icinga/conf.d/generic-host_nagios2.cfg
@@ -14,7 +14,7 @@ define host {
   notification_interval           0
   notification_period             24x7
   notification_options            d,r
-  contact_groups                  urgent-priority
+  contact_groups                  high-priority
   register                        0       ; DONT REGISTER THIS DEFINITION - ITS NOT A REAL HOST, JUST A TEMPLATE!
 }
 

--- a/modules/icinga/manifests/client.pp
+++ b/modules/icinga/manifests/client.pp
@@ -2,7 +2,15 @@
 #
 # Sets up a host in Icinga that checks can be associated with.
 #
-class icinga::client {
+# === Parameters
+# 
+# [*contact_groups*]
+#   Sets the contact groups for host. Defaults to high priority.  
+# 
+class icinga::client (
+  $contact_groups = 'high-priority'
+)
+{
 
   anchor { 'icinga::client::begin':
     before => Class['icinga::client::package'],
@@ -43,10 +51,11 @@ class icinga::client {
   }
 
   @@icinga::host { $::fqdn:
-    hostalias    => $::fqdn,
-    address      => $::ipaddress_eth0,
-    display_name => $::fqdn_short,
-    parents      => $parents,
+    hostalias      => $::fqdn,
+    address        => $::ipaddress_eth0,
+    display_name   => $::fqdn_short,
+    parents        => $parents,
+    contact_groups => $contact_groups,
   }
 
   Icinga::Nrpe_config <| |>

--- a/modules/icinga/manifests/host.pp
+++ b/modules/icinga/manifests/host.pp
@@ -31,6 +31,9 @@
 #    The icinga::timeperiod for when Icinga will send out notifications
 #    if this host is unavailable.
 #
+#  [*contact_groups*]
+#    Set the contact groups for the host.
+
 define icinga::host (
   $hostalias  = $::fqdn,
   $address    = $::ipaddress_eth0,
@@ -39,6 +42,7 @@ define icinga::host (
   $display_name = $::fqdn_short,
   $parents = undef,
   $notification_period = '24x7',
+  $contact_groups = 'high-priority',
 ) {
 
   file {"/etc/icinga/conf.d/icinga_host_${title}":

--- a/modules/icinga/spec/defines/icinga__host_spec.rb
+++ b/modules/icinga/spec/defines/icinga__host_spec.rb
@@ -12,6 +12,14 @@ describe 'icinga::host', :type => :define do
   it { is_expected.to contain_file('/etc/icinga/conf.d/icinga_host_bruce-forsyth.cfg').without_content(/parents/) }
 
   it { is_expected.to contain_file('/etc/icinga/conf.d/icinga_host_bruce-forsyth.cfg').with_content(/notification_period\s+24x7/) }
+  it { is_expected.to contain_file('/etc/icinga/conf.d/icinga_host_bruce-forsyth.cfg').with_content(/contact_groups\s+high-priority/) }
+
+  context 'Contact group set' do
+    let(:params) {{
+      'contact_groups' => 'urgent-priority'
+    }}
+    it { is_expected.to contain_file('/etc/icinga/conf.d/icinga_host_bruce-forsyth.cfg').with_content(/contact_groups\s+urgent-priority/) }
+    end
 
   context 'Host parents required' do
     let(:params) {{

--- a/modules/icinga/templates/host.erb
+++ b/modules/icinga/templates/host.erb
@@ -6,6 +6,7 @@ define host {
         host_name            <%= @hostalias %>
         hostgroups           all
         notification_period  <%= @notification_period %>
+        contact_groups       <%= @contact_groups %>
         <%- if @parents -%>
         parents              <%= @parents %>
         <%- end -%>


### PR DESCRIPTION
We want to be alerted when single points of failure go down. Set the contact groups for a host. Defaults to high-priority.

Needs some 👀 on these changes please.