### PR TITLE
Add nightly job to validate published DNS records

### DIFF
--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -39,5 +39,6 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::transition_load_transition_stats_hits
   - govuk_jenkins::job::trigger_data_sync_complete
   - govuk_jenkins::job::update_cdn_dictionaries
+  - govuk_jenkins::job::validate_published_dns
   - govuk_jenkins::job::whitehall_rebuild_elasticsearch_index
   - govuk_jenkins::job::whitehall_run_broken_link_checker

--- a/modules/govuk_jenkins/manifests/job/validate_published_dns.pp
+++ b/modules/govuk_jenkins/manifests/job/validate_published_dns.pp
@@ -1,0 +1,11 @@
+# == Class: govuk_jenkins::job::validate_published_dns
+#
+# Create a file on disk that can be parsed by jenkins-job-builder
+#
+class govuk_jenkins::job::validate_published_dns {
+  file { '/etc/jenkins_jobs/jobs/validate_published_dns.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/validate_published_dns.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+}

--- a/modules/govuk_jenkins/templates/jobs/validate_published_dns.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/validate_published_dns.yaml.erb
@@ -1,0 +1,24 @@
+---
+- job:
+    name: Validate_published_dns
+    display-name: Validate_published_dns
+    project-type: freestyle
+    description: "<p>Check that the published DNS records match those in the <a href='https://github.gds/govuk-dns-config'>govuk-dns-config repo</a> YAML file.</p>"
+    logrotate:
+        numToKeep: 30
+    builders:
+        - shell: |
+            set -e
+            rm -rf govuk-dns-config
+            git clone --branch master --depth 1 git@github.gds:gds/govuk-dns-config.git
+            cd govuk-dns-config
+            bundle install
+            bundle exec rake validate_dns
+    wrappers:
+        - ansicolor:
+            colormap: xterm
+    publishers:
+        - email:
+            recipients: 2nd-line-support@digital.cabinet-office.gov.uk
+    triggers:
+        - timed: '@midnight'


### PR DESCRIPTION
We want to make sure that the published DNS records match those saved
in the govuk-dns-config repository. To do this every night we will run
the validate_dns rake task which will match the YAML file data to
what is currently available in production.

This commit adds a validate_published_dns task to Jenkins and
configures it to run every night between midnight and 0259.