### PR TITLE
Add Mapit dependency to CI agents

### DIFF
--- a/modules/govuk_ci/manifests/agent.pp
+++ b/modules/govuk_ci/manifests/agent.pp
@@ -50,4 +50,8 @@ class govuk_ci::agent(
   service { 'jenkins-agent':
     ensure => 'stopped',
   }
+
+  package { 'libgdal-dev': # needed for mapit
+    ensure => installed,
+  }
 }


### PR DESCRIPTION
In order to get Mapit running on the new Jenkins infrastructure, we need to install the `libgdal-dev` package on Jenkins' agents.