### PR TITLE
Clean up panopticon-related configuration

### DIFF
--- a/modules/govuk/manifests/apps/collections_publisher.pp
+++ b/modules/govuk/manifests/apps/collections_publisher.pp
@@ -5,10 +5,6 @@
 #
 # === Parameters
 #
-# [*panopticon_bearer_token*]
-#   The bearer token to use when communicating with Panopticon.
-#   Default: example
-#
 # [*port*]
 #   The port that publishing API is served on.
 #   Default: 3078
@@ -42,7 +38,6 @@
 #   Default: undef
 #
 class govuk::apps::collections_publisher(
-  $panopticon_bearer_token = 'example',
   $port = '3078',
   $secret_key_base = undef,
   $errbit_api_key = undef,
@@ -90,9 +85,6 @@ class govuk::apps::collections_publisher(
     "${title}-OAUTH_SECRET":
       varname => 'OAUTH_SECRET',
       value   => $oauth_secret;
-    "${title}-PANOPTICON_BEARER_TOKEN":
-      varname => 'PANOPTICON_BEARER_TOKEN',
-      value   => $panopticon_bearer_token;
     "${title}-PUBLISHING_API_BEARER_TOKEN":
       varname => 'PUBLISHING_API_BEARER_TOKEN',
       value   => $publishing_api_bearer_token;

--- a/modules/govuk/manifests/apps/travel_advice_publisher.pp
+++ b/modules/govuk/manifests/apps/travel_advice_publisher.pp
@@ -32,10 +32,6 @@
 # [*oauth_secret*]
 #   Sets the OAuth Secret Key
 #
-# [*panopticon_bearer_token*]
-#   The bearer token to use when communicating with Panopticon.
-#   Default: undef
-#
 # [*port*]
 #   The port that publishing API is served on.
 #   Default: 3035
@@ -67,7 +63,6 @@ class govuk::apps::travel_advice_publisher(
   $mongodb_nodes = undef,
   $oauth_id = undef,
   $oauth_secret = undef,
-  $panopticon_bearer_token = undef,
   $port = '3035',
   $publishing_api_bearer_token = undef,
   $redis_host = undef,
@@ -116,9 +111,6 @@ class govuk::apps::travel_advice_publisher(
     "${title}-OAUTH_SECRET":
       varname => 'OAUTH_SECRET',
       value   => $oauth_secret;
-    "${title}-PANOPTICON_BEARER_TOKEN":
-      varname => 'PANOPTICON_BEARER_TOKEN',
-      value   => $panopticon_bearer_token;
     "${title}-PUBLISHING_API_BEARER_TOKEN":
       varname => 'PUBLISHING_API_BEARER_TOKEN',
       value   => $publishing_api_bearer_token;

--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -69,10 +69,6 @@
 #   Sets the OAuth Secret Key for using GDS-SSO
 #   Default: undef
 #
-# [*panopticon_bearer_token*]
-#   The bearer token to use when communicating with Panopticon.
-#   Default: undef
-#
 # [*port*]
 #   The port where the Rails app is running.
 #   Default: 3020
@@ -120,7 +116,6 @@ class govuk::apps::whitehall(
   $oauth_id = undef,
   $oauth_secret = undef,
   $port = '3020',
-  $panopticon_bearer_token = undef,
   $prevent_single_host = true,
   $procfile_worker_process_count = 1,
   $publishing_api_bearer_token = undef,
@@ -337,9 +332,6 @@ class govuk::apps::whitehall(
       "${title}-OAUTH_SECRET":
         varname => 'OAUTH_SECRET',
         value   => $oauth_secret;
-      "${title}-PANOPTICON_BEARER_TOKEN":
-        varname => 'PANOPTICON_BEARER_TOKEN',
-        value   => $panopticon_bearer_token;
     }
 
     if $::govuk_node_class != 'development' {

--- a/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
@@ -15,8 +15,6 @@
            for host in $(govuk_node_list -c redis); do
               ssh deploy@${host} 'redis-cli flushall'
            done
-           # Re-register smartanswers to pick up drafts.
-           ssh deploy@$(govuk_node_list -c calculators_frontend --single-node) 'cd /var/apps/smartanswers ; govuk_setenv smartanswers bundle exec rake panopticon:register'
            # Queue up any publisher scheduled editions that have been transferred across.
            ssh deploy@$(govuk_node_list -c backend --single-node) 'cd /var/apps/publisher ; govuk_setenv publisher bundle exec rake editions:requeue_scheduled_for_publishing'
            # Publish any pre-production finders from Specialist Publisher.


### PR DESCRIPTION
Publisher is now the only application that depends on panopticon. This cleans up a number of configs. A similar thing has been done in https://github.gds/gds/alphagov-deployment/pull/1300.

PR for gds/deployment to remove the settings from hieradata: https://github.gds/gds/deployment/pull/1205

https://trello.com/c/7u8M6zrg

