### PR TITLE
Remove rummageable

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -642,7 +642,6 @@ govuk_ci::master::pipeline_jobs:
   rails_translation_manager: {}
   router-data:
     source: 'github-enterprise'
-  rummageable: {}
   screenshot-as-a-service: {}
   shared_mustache: {}
   slimmer: {}


### PR DESCRIPTION
As of https://github.com/alphagov/whitehall/pull/2960, the rummageable gem is no longer used by any app and will be archived. This commit removes it from the list of deployable applications.

Merge after https://github.com/alphagov/whitehall/pull/2960.

Trello: https://trello.com/c/g9OGDm4q/257-remove-rummageable-from-a-number-of-repositories-so-it-can-be-archived