### PR TITLE
Add note to update packages

### DIFF
--- a/development-vm/README.md
+++ b/development-vm/README.md
@@ -211,6 +211,12 @@ GOV.UK have an apt repository at http://apt.publishing.service.gov.uk/ This is n
 2. [Connect to the Aviation House VPN](https://github.com/jabley/homedir/commit/2682f094024524cb7e31ca447694bdf81b1239a2)
 3. `vagrant provision` should now be able to download packages when running apt
 
+You may also need to run `sudo apt-get update` if you get errors that look something like:
+
+```
+E: Unable to locate package rbenv-ruby-2.4.0
+E: Couldn't find any package by regex 'rbenv-ruby-2.4.0'
+```
 
 ### Errors running `govuk_puppet` on VM
 

--- a/tools/puppet-apply-dev
+++ b/tools/puppet-apply-dev
@@ -78,4 +78,5 @@ for dir in `ls vendor/modules`; do
 done
 
 info "running puppet"
+info "***If you see: E: Unable to locate package... errors, run sudo apt-get update***"
 exec /var/govuk/govuk-puppet/tools/puppet-apply "$@"


### PR DESCRIPTION
When running `govuk_puppet` to update the development-vm, sometimes there are errors when installing system packages where these packages can't be found. It may simply require getting the latest package list.