### PR TITLE
Add libqt-webkit to deployment jenkins boxes

### DIFF
--- a/modules/govuk/manifests/node/s_jenkins.pp
+++ b/modules/govuk/manifests/node/s_jenkins.pp
@@ -26,6 +26,11 @@ class govuk::node::s_jenkins (
   include govuk_ghe_vpn
   include govuk_rbenv::all
 
+  # To run smokey tests
+  package { 'libqtwebkit-dev':
+    ensure => present,
+  }
+
   class { 'govuk_jenkins':
     github_client_id      => $github_client_id,
     github_client_secret  => $github_client_secret,


### PR DESCRIPTION
This adds libqt-webkit package to the deployment jenkins boxes. This will enable jenkins to run [smokey tests with javascript enabled](https://github.com/alphagov/smokey/pull/221).

The same is done in [ci-puppet](https://github.com/alphagov/ci-puppet/blob/0e51d53779a72df813c63273d0f8e2bd5b3c858f/modules/ci_environment/manifests/jenkins_job_support.pp#L25).

https://trello.com/c/WIunrfiT/322-investigate-turning-on-javascript-in-smokey