### PR TITLE
Override Jenkins branches built for schema test repos

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -28,7 +28,8 @@ deployable_applications: &deployable_applications
     repository: 'contacts-admin'
   contacts-frontend: {}
   content-store: {}
-  content-tagger: {}
+  content-tagger:
+    branches_to_exclude: ['release', 'deployed-to-integration', 'deployed-to-staging']
   designprinciples:
     repository: 'design-principles'
   efg-training:
@@ -97,7 +98,8 @@ deployable_applications: &deployable_applications
   support-api: {}
   transition: {}
   travel-advice-publisher: {}
-  whitehall: {}
+  whitehall:
+    branches_to_exclude: ['release', 'deployed-to-integration', 'deployed-to-staging']
 
 apt_mirror_hostname: 'apt.production.alphagov.co.uk'
 


### PR DESCRIPTION
Ensure that 'deployed-to-production' is included in the Jenkins branch builds for the 'whitehall' and 'content-tagger' repos. This is not normally required, but it is necessary for these repos because the
'deployed-to-production' branch is used to test changes pushed to the govuk-content-schemas repo.

https://trello.com/c/S4DZbsPa/285-jenkins-2-migration