### PR TITLE
Clean up Jenkins pipeline workspace

### DIFF
--- a/modules/govuk_ci/manifests/master.pp
+++ b/modules/govuk_ci/manifests/master.pp
@@ -70,4 +70,10 @@ class govuk_ci::master (
     'credentials_id' => $credentials_id,
   })
 
+  cron::crondotdee { 'Clean up pipeline workspace':
+    command => 'find /var/lib/jenkins/workspace/*@script -maxdepth 0 -type d -mtime +1 -exec rm -rf {} \;',
+    hour    => 7,
+    minute  => 45,
+  }
+
 }


### PR DESCRIPTION
Using pipeline builds means that Jenkins has to pull the repo which contains the Jenkinsfile. Sometimes this means pulling repos that contain lots of files, and it pulls the repo each time but never cleans itself up. We had an alert in Icinga related to the number of available inodes was low rather than disk usage, which suggested it was a problem with the number of files it was pulling.

This adds a cron job to just clean up everything in the workspace. It should not impact because a repo is pulled everytime a job is started to grab the Jenkinsfile. We could entirely clean it up each morning, but I have added the "-mtime" flag to ensure that workspaces aren't being wiped out while jobs are running.

Note: I haven't been able to find the "proper" way of doing this, so this is a workaround. It would be better if we could define this step in the Jenkinsfile itself.