### PR TITLE
Dynamically lookup trade tariff hostname

### DIFF
--- a/modules/router/templates/assets_origin.conf.erb
+++ b/modules/router/templates/assets_origin.conf.erb
@@ -48,8 +48,9 @@ server {
 
   <%- if @trade_tariff_host -%>
   location /tariff/ {
+    set $trade_tariff_backend "https://<%= @trade_tariff_host %>";
     proxy_set_header Host <%= @trade_tariff_host %>;
-    proxy_pass https://<%= @trade_tariff_host %>;
+    proxy_pass $trade_tariff_backend;
   }
   <%- end -%>
 


### PR DESCRIPTION
It turns out that nginx looks up the hostname of a proxy_pass only when it starts up, which means that if nginx hasn't restarted for a while and Amazon changes the location of an ELB, we'll send requests to the wrong place.

We've seen this before in ef64dda2105e7a055248d9dd9a7151315fe8acfe.