### PR TITLE
Enable new nav pages on integration

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -28,6 +28,7 @@ govuk::apps::travel_advice_publisher::show_historical_edition_link: true
 govuk::apps::url_arbiter::db::backend_ip_range: '10.1.3.0/24'
 govuk::apps::whitehall::basic_auth_credentials: "%{hiera('http_username')}:%{hiera('http_password')}"
 govuk::apps::whitehall::highlight_words_to_avoid: true
+govuk::apps::collections::enable_new_navigation: "yes"
 
 govuk::deploy::aws_ses_smtp_host: 'email-smtp.eu-west-1.amazonaws.com'
 govuk::deploy::config::errbit_environment_name: 'integration'

--- a/modules/govuk/manifests/apps/collections.pp
+++ b/modules/govuk/manifests/apps/collections.pp
@@ -17,11 +17,15 @@
 # [*secret_key_base*]
 #   The key for Rails to use when signing/encrypting sessions.
 #
+# [*enable_new_navigation*]
+#   Should we show the new navigation pages?
+#
 class govuk::apps::collections(
   $vhost = 'collections',
   $port = '3070',
   $errbit_api_key = undef,
   $secret_key_base = undef,
+  $enable_new_navigation = undef
 ) {
   govuk::app { 'collections':
     app_type              => 'rack',
@@ -44,5 +48,8 @@ class govuk::apps::collections(
     "${title}-SECRET_KEY_BASE":
         varname => 'SECRET_KEY_BASE',
         value   => $secret_key_base;
+    "${title}-ENABLE_NEW_NAVIGATION":
+        varname => 'ENABLE_NEW_NAVIGATION',
+        value   => $enable_new_navigation;
   }
 }


### PR DESCRIPTION
We will be releasing the new GOV.UK navigation pages soon. These pages
live in `collections` and in the meantime we would like to have them
available on integration. In order to do so, we have hidden the nav
pages behind a feature flag.

This commit adds an environment variable to collections on integration
so that we can show those new pages on only this environment.