### PR TITLE
Include all testing tools on deploy jenkins

### DIFF
--- a/modules/govuk/manifests/node/s_jenkins.pp
+++ b/modules/govuk/manifests/node/s_jenkins.pp
@@ -25,11 +25,7 @@ class govuk::node::s_jenkins (
   include nginx
   include govuk_ghe_vpn
   include govuk_rbenv::all
-
-  # To run smokey tests
-  package { 'libqtwebkit-dev':
-    ensure => present,
-  }
+  include ::govuk_testing_tools
 
   class { 'govuk_jenkins':
     github_client_id      => $github_client_id,

--- a/modules/govuk_jenkins/manifests/init.pp
+++ b/modules/govuk_jenkins/manifests/init.pp
@@ -83,11 +83,6 @@ class govuk_jenkins (
     provider => pip,
   }
 
-  package { 'brakeman':
-    ensure   => 'installed',
-    provider => system_gem,
-  }
-
   package { 's3cmd':
     ensure   => 'present',
     provider => 'pip',


### PR DESCRIPTION
In https://github.com/alphagov/govuk-puppet/pull/5351 we added libqt to the jenkins machines. It turns out that https://github.com/alphagov/smokey/pull/221 also needs a thing called `xvfb` to allow webkit to use X.

Instead of also adding xvfb, we just pull in the `govuk_testing_tools` module, which has all the necessary dependencies for testing.

https://trello.com/c/WIunrfiT