### PR TITLE
Enable tagging documents to new taxonomy on integration

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -29,6 +29,7 @@ govuk::apps::url_arbiter::db::backend_ip_range: '10.1.3.0/24'
 govuk::apps::whitehall::basic_auth_credentials: "%{hiera('http_username')}:%{hiera('http_password')}"
 govuk::apps::whitehall::highlight_words_to_avoid: true
 govuk::apps::collections::enable_new_navigation: "yes"
+govuk::apps::whitehall::enable_tagging_to_new_taxonomy: "yes"
 
 govuk::deploy::aws_ses_smtp_host: 'email-smtp.eu-west-1.amazonaws.com'
 govuk::deploy::config::errbit_environment_name: 'integration'

--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -124,6 +124,7 @@ class govuk::apps::whitehall(
   $secret_key_base = undef,
   $vhost = 'whitehall',
   $vhost_protected,
+  $enable_tagging_to_new_taxonomy = undef
 ) {
 
   $app_name = 'whitehall'
@@ -363,6 +364,9 @@ class govuk::apps::whitehall(
     "${title}-UNICORN_WORKER_PROCESSES":
       varname => 'UNICORN_WORKER_PROCESSES',
       value   => $unicorn_worker_processes;
+    "${title}-ENABLE_TAGGING_TO_NEW_TAXONOMY":
+      varname => 'ENABLE_TAGGING_TO_NEW_TAXONOMY',
+      value   => $enable_tagging_to_new_taxonomy;
   }
 
   if $basic_auth_credentials != undef {


### PR DESCRIPTION
We will be releasing a new page on Whitehall to allow Education documents to be tagged to the new taxonomy.
In the meantime we would like to test them under integration environment.
To allow us to do that we have hidden the page behind a feature flag, so it only shows while on integration.

This commit adds an environment variable to whitehall on integration so that we can show the page only under this environment.


Trello: https://trello.com/c/miTSiYfk/409-create-tagging-interface-for-new-taxonomy-in-whitehall