### PR TITLE
Purge mirrorer rabbitmq purge daily

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -196,6 +196,7 @@ govuk::node::s_logs_elasticsearch::rotate_hour: 06
 govuk::node::s_logs_elasticsearch::rotate_minute: 00
 govuk::node::s_licensify_lb::enable_feed_console: true
 govuk::node::s_logging::compress_srv_logs_hour: '9'
+govuk::node::s_mirrorer::daily_queue_purge: true
 govuk::node::s_monitoring::offsite_backups: false
 govuk::node::s_mysql_backup::s3_bucket_name: 'govuk-mysql-xtrabackups-integration'
 govuk::node::s_mysql_master::s3_bucket_name: "%{hiera('govuk::node::s_mysql_backup::s3_bucket_name')}"

--- a/modules/govuk/manifests/node/s_mirrorer.pp
+++ b/modules/govuk/manifests/node/s_mirrorer.pp
@@ -1,6 +1,36 @@
-# Node defintion for mirrorer-?.management boxen
-class govuk::node::s_mirrorer inherits govuk::node::s_base {
+# == Class: Govuk::Node::S_mirrorer
+#
+#  Node definition for mirrorer boxes
+#
+# === Parameters:
+#
+# [*daily_queue_purge*]
+#   This purges the rabbitmq queue of all messages. Use with caution!
+#
+class govuk::node::s_mirrorer (
+  $daily_queue_purge = false,
+) inherits govuk::node::s_base {
   include govuk_crawler
   include govuk_rabbitmq
   include nginx
+
+  if $daily_queue_purge {
+    # Create a file that only root can read so not to expose the rabbitmq root password.
+    file { '/root/purge_govuk_crawler_queue.sh':
+      ensure  => present,
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0700',
+      content => "/usr/local/bin/rabbitmqadmin --username=root --password=${::govuk_rabbitmq::root_password} purge queue name=govuk_crawler_queue",
+      require => Class['govuk_rabbitmq'],
+    }
+
+    cron::crondotdee { 'purge_govuk_crawler_queue':
+      command => '/root/purge_govuk_crawler_queue.sh',
+      hour    => 10,
+      minute  => 30,
+      mailto  => '""',
+      require => File['/root/purge_govuk_crawler_queue.sh'],
+    }
+  }
 }


### PR DESCRIPTION
We run govuk_crawler_worker to test the functionality, and it adds messages to rabbitmq but these are never processed because we do not have mirrors in Integration.

This adds a function that purges the queue everyday so avoid get alerts related to rabbitmq memory because the queue has too many messages.