### PR TITLE
Adjust time of auto postgresql backup

### DIFF
--- a/hieradata/node/postgresql-primary-1.backend.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/postgresql-primary-1.backend.integration.publishing.service.gov.uk.yaml
@@ -1,3 +1,0 @@
----
-govuk_postgresql::backup::auto_postgresql_backup_hour: 8
-govuk_postgresql::backup::auto_postgresql_backup_minute: 15

--- a/modules/govuk_postgresql/manifests/backup.pp
+++ b/modules/govuk_postgresql/manifests/backup.pp
@@ -20,8 +20,8 @@
 #  A simple description of the check that is alerting.
 #
 class govuk_postgresql::backup (
-  $auto_postgresql_backup_hour = 7,
-  $auto_postgresql_backup_minute = 30,
+  $auto_postgresql_backup_hour = 8,
+  $auto_postgresql_backup_minute = 0,
 ) {
 
     $threshold_secs = 28 * 3600


### PR DESCRIPTION
There has been some improvement since https://github.com/alphagov/govuk-puppet/pull/4914 was merged, in that backups are not failing every day.

Bumping time by 30mins later to avoid race with env_sync

<img width="656" alt="screen shot 2017-01-18 at 09 41 23" src="https://cloud.githubusercontent.com/assets/8365097/22059057/28d2252a-dd63-11e6-850b-6d34b1255194.png">