### PR TITLE
Override Jenkins branches built for schema test repos

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -37,8 +37,10 @@ deployable_applications: &deployable_applications
   efg-training-rebuild:
     repository: 'EFG'
   email-alert-api: {}
-  email-alert-frontend: {}
-  email-alert-service: {}
+  email-alert-frontend:
+    branches_to_exclude: ['release', 'deployed-to-integration', 'deployed-to-staging']
+  email-alert-service:
+    branches_to_exclude: ['release', 'deployed-to-integration', 'deployed-to-staging']
   errbit: {}
   feedback: {}
   finder-frontend:


### PR DESCRIPTION
By default, all of the deployment branches are excluded from Jenkins build, because it normally doesn't make sense to build them. However, we sometimes do want to build deployed-to-production to test a project against changes to the content schemas.

This overrides the excluded branches for email-alert-service and email-alert-frontend so that most of the release and deployment branches are still excluded, but deployed-to-production can be built for schema tests.

https://trello.com/c/S4DZbsPa/285-jenkins-2-migration