### PR TITLE
Increase nginx variables_hash_max_size and variables_hash_bucket_size values

### DIFF
--- a/modules/nginx/manifests/config.pp
+++ b/modules/nginx/manifests/config.pp
@@ -15,7 +15,7 @@
 #
 class nginx::config (
   $server_names_hash_max_size,
-  $variables_hash_max_size = 512,
+  $variables_hash_max_size = 1024,
   $denied_ip_addresses) {
 
   file { '/etc/nginx':

--- a/modules/nginx/manifests/init.pp
+++ b/modules/nginx/manifests/init.pp
@@ -11,7 +11,7 @@
 #
 class nginx (
   $server_names_hash_max_size = 512,
-  $variables_hash_max_size = 512,
+  $variables_hash_max_size = 1024,
   $denied_ip_addresses = []) {
 
   anchor { 'nginx::begin':

--- a/modules/nginx/templates/etc/nginx/nginx.conf.erb
+++ b/modules/nginx/templates/etc/nginx/nginx.conf.erb
@@ -19,7 +19,7 @@ http {
     server_names_hash_max_size <%= @server_names_hash_max_size -%>;
     server_names_hash_bucket_size 128;
     variables_hash_max_size <%= @variables_hash_max_size -%>;
-    variables_hash_bucket_size 64;
+    variables_hash_bucket_size 128;
     proxy_headers_hash_bucket_size 128;
     map_hash_bucket_size 128;
 


### PR DESCRIPTION
We've recently added a new app and this means we need a bigger hash to
store all the info.  Without this change nginx will fail to start and
issue a error to error.log as follows:

    2017/01/18 12:26:18 [emerg] 13762#0: could not build the variables_hash, you should increase either variables_hash_max_size: 512 or variables_hash_bucket_size: 64