### PR TITLE
[DO NOT MERGE] Make merge test stricter in Jenkins build setup

### DIFF
--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -19,7 +19,7 @@ def cleanupGit() {
  */
 def mergeMasterBranch() {
   echo 'Attempting merge of master branch'
-  sh('git merge --no-commit origin/master || git merge --abort')
+  sh('git merge --no-commit --no-ff origin/master || git merge --abort')
 }
 
 /**


### PR DESCRIPTION
Many Jenkins builds call the `mergeMasterBranch()` helper near the start of the build. This alerts us (and GitHub) to branches which cannot be cleanly merged with master. It uses the `--no-commit` flag to just check whether a merge would be valid, without actually performing the merge.

This works fine in the mainstream use-case, which is to test dev branches which have yet to be merged. However, it doesn't do the right thing for content schema tests, where we are running builds on the `deployed-to-production` branch. Unlike a dev branch, this branch is _behind_ `master`. So the merge being tested in this case is a fast-forward merge. Git doesn't apply the `--no-commit` behaviour for fast-forward merges, so it actually performs the merge! This means that we end up building the `master` branch rather than `deployed-to-production`.

The consequence of this is that the content schema tests were not strict enough: they were unintentionally running against the `master` version of the downstream repos, not `deployed-to-production`, which is the branch that we really care about breaking.

The fix is to add another flag, `--no-ff`, to prevent fast-forward merges as well as regular merges.

Trello: https://trello.com/c/S4DZbsPa/285-jenkins-2-migration