### PR TITLE
Add secret for encoding/decoding JWT tokens.

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -258,6 +258,7 @@ govuk::apps::asset_manager::mongodb_nodes:
   - 'mongo-1.backend'
   - 'mongo-2.backend'
   - 'mongo-3.backend'
+govuk::apps::authenticating_proxy::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
 govuk::apps::backdrop_read::enabled: true
 govuk::apps::backdrop_write::enabled: true
 
@@ -331,6 +332,7 @@ govuk::apps::govuk_cdn_logs_monitor::processed_data_dir: '/mnt/logs_cdn/data'
 govuk::apps::manuals_publisher::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::manuals_publisher::redis_port: "%{hiera('sidekiq_port')}"
 
+govuk::apps::publisher::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
 govuk::apps::publisher::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::publisher::redis_port: "%{hiera('sidekiq_port')}"
 
@@ -348,6 +350,7 @@ govuk::apps::whitehall::db_hostname: whitehall-slave.mysql
 govuk::apps::whitehall::db_name: whitehall_production
 govuk::apps::whitehall::db_password: "%{hiera('govuk::apps::whitehall::db::mysql_whitehall')}"
 govuk::apps::whitehall::db_username: whitehall_fe
+govuk::apps::whitehall::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
 govuk::apps::whitehall::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::whitehall::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::whitehall::procfile_worker_process_count: 2

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -319,6 +319,7 @@ hosts::development::services:
   - support
   - whitehall
 
+jwt_auth_secret: '010b3c3d6419a68932c6c8e85d45da40ec161592e0e34c5357a9f510a3ccc52bfec5aebba03041b36e9bbf4299445b4f096ec7be6aef68393d3fd8321eb2628a'
 memcached::max_memory: 64
 memcached::listen_ip: '127.0.0.1'
 

--- a/modules/govuk/manifests/apps/authenticating_proxy.pp
+++ b/modules/govuk/manifests/apps/authenticating_proxy.pp
@@ -16,19 +16,29 @@
 #   The port that it is served on.
 #   Default: 3107
 #
+# [*errbit_api_key*]
+#   Errbit API key used by airbrake
+#   Default: ''
+#
 # [*govuk_upstream_uri*]
 #   The URI of the upstream service that we proxy to.
 #   Default: undef
 #
-# [*errbit_api_key*]
-#   Errbit API key used by airbrake
-#   Default: ''
+# [*oauth_id*]
+#   Sets the OAuth ID
+#
+# [*oauth_secret*]
+#   Sets the OAuth Secret Key
 #
 # [*secret_key_base*]
 #   Used to set the app ENV var SECRET_KEY_BASE which is used to configure
 #   rails 4.x signed cookie mechanism. If unset the app will be unable to
 #   start.
 #   Default: undef
+#
+# [*jwt_auth_secret*]
+#   The secret used to decode JWT authentication tokens. This value needs to be
+#   shared with the publishing apps that generate the encoded tokens.
 #
 class govuk::apps::authenticating_proxy(
   $mongodb_nodes,
@@ -39,6 +49,7 @@ class govuk::apps::authenticating_proxy(
   $oauth_id = undef,
   $oauth_secret = undef,
   $secret_key_base = undef,
+  $jwt_auth_secret = undef,
 ) {
   $app_name = 'authenticating-proxy'
 
@@ -93,6 +104,14 @@ class govuk::apps::authenticating_proxy(
       app     => $app_name,
       varname => 'SECRET_KEY_BASE',
       value   => $secret_key_base,
+    }
+  }
+
+  if $jwt_auth_secret != undef {
+    govuk::app::envvar { "${title}-JWT_AUTH_SECRET":
+      app     => $app_name,
+      varname => 'JWT_AUTH_SECRET',
+      value   => $jwt_auth_secret,
     }
   }
 

--- a/modules/govuk/manifests/apps/publisher.pp
+++ b/modules/govuk/manifests/apps/publisher.pp
@@ -37,6 +37,10 @@
 #   Redis port for Sidekiq.
 #   Default: undef
 #
+# [*jwt_auth_secret*]
+#   The secret used to encode JWT authentication tokens. This value needs to be
+#   shared with authenticating-proxy which decodes the tokens.
+#
 class govuk::apps::publisher(
     $port = '3000',
     $enable_procfile_worker = true,
@@ -47,6 +51,7 @@ class govuk::apps::publisher(
     $mongodb_nodes = undef,
     $redis_host = undef,
     $redis_port = undef,
+    $jwt_auth_secret = undef,
   ) {
 
   govuk::app { 'publisher':
@@ -110,6 +115,10 @@ class govuk::apps::publisher(
       app     => 'publisher',
       varname => 'NEED_API_BEARER_TOKEN',
       value   => $need_api_bearer_token;
+    "${title}-JWT_AUTH_SECRET":
+      app     => 'publisher',
+      varname => 'JWT_AUTH_SECRET',
+      value   => $jwt_auth_secret;
     "${title}-SECRET_KEY_BASE":
       app     => 'publisher',
       varname => 'SECRET_KEY_BASE',

--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -94,6 +94,10 @@
 #   The key for Rails to use when signing/encrypting sessions.
 #   Default: undef
 #
+# [*jwt_auth_secret*]
+#   The secret used to encode JWT authentication tokens. This value needs to be
+#   shared with authenticating-proxy which decodes the tokens.
+#
 class govuk::apps::whitehall(
   $admin_db_name = undef,
   $admin_db_hostname = undef,
@@ -124,7 +128,8 @@ class govuk::apps::whitehall(
   $secret_key_base = undef,
   $vhost = 'whitehall',
   $vhost_protected,
-  $enable_tagging_to_new_taxonomy = undef
+  $enable_tagging_to_new_taxonomy = undef,
+  $jwt_auth_secret = undef,
 ) {
 
   $app_name = 'whitehall'
@@ -381,6 +386,13 @@ class govuk::apps::whitehall(
     govuk::app::envvar { "${title}-SECRET_KEY_BASE":
       varname => 'SECRET_KEY_BASE',
       value   => $secret_key_base,
+    }
+  }
+
+  if $jwt_auth_secret != undef {
+    govuk::app::envvar { "${title}-JWT_AUTH_SECRET":
+      varname => 'JWT_AUTH_SECRET',
+      value   => $jwt_auth_secret,
     }
   }
 }


### PR DESCRIPTION
This value needs to be shared between the publishing apps generating
the encoded tokens and authenticating-proxy which decodes them. It is
therefore defined in a single place in the hieradata and the apps use
explicit hiera() calls to reference it.