### PR TITLE
Enable deployed-to-production build for schema tests

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -72,7 +72,8 @@ deployable_applications: &deployable_applications
   performanceplatform-big-screen-view: {}
   policy-publisher:
     branches_to_exclude: ['release', 'deployed-to-integration', 'deployed-to-staging']
-  publisher: {}
+  publisher:
+    branches_to_exclude: ['release', 'deployed-to-integration', 'deployed-to-staging']
   publishing-api: {}
   release: {}
   router: {}


### PR DESCRIPTION
Trello: https://trello.com/c/UCcCp13D/576-move-publisher-to-new-ci-infrastructure-1

In the context of moving Publisher to the new CI, we want to remove the build from the govuk_content_schemas downstream builds on Jenkins 1.

This overrides the excluded branches for publisher, so that the
deployed-to-production can be built for schema tests.