### PR TITLE
Include DB for content_performance_manager

### DIFF
--- a/modules/govuk/manifests/node/s_postgresql_base.pp
+++ b/modules/govuk/manifests/node/s_postgresql_base.pp
@@ -3,6 +3,7 @@
 # Base node for s_postgresql_{master,slave}
 #
 class govuk::node::s_postgresql_base inherits govuk::node::s_base {
+  include govuk::apps::content_performance_manager::db
   include govuk::apps::content_tagger::db
   include govuk::apps::email_alert_api::db
   include govuk::apps::local_links_manager::db


### PR DESCRIPTION
Without this included it was causing Puppet errors because hiera lookups were incomplete (also, we need the database created).