### PR TITLE
Adjust high watermark threshold

### DIFF
--- a/hieradata/class/mirrorer.yaml
+++ b/hieradata/class/mirrorer.yaml
@@ -19,3 +19,6 @@ mount:
     disk: '/dev/mapper/crawler-worker'
     govuk_lvm: 'worker'
     mountoptions: 'defaults'
+
+rabbitmq::config_variables:
+  'vm_memory_high_watermark': '0.5'


### PR DESCRIPTION
The threshold appears to be set too low for the rabbitmq runtime.  This causes the Nagios checks to raise alerts in Icinga (false positives) for integration.

What the threshold should be set to, is debatable. We are currently using the default value of 40% of resident memory for the mirrorer vms.
See: https://www.rabbitmq.com/memory.html

Alternatively, we could increase the memory of the VM to same as in production.

Rabbitmq consistently occupies currently set threshold for the high watermark

Affects: https://github.gds/gds/opsmanual/pull/868