### PR TITLE
Add include for safe_restart class

### DIFF
--- a/modules/govuk_jenkins/manifests/init.pp
+++ b/modules/govuk_jenkins/manifests/init.pp
@@ -74,6 +74,7 @@ class govuk_jenkins (
   }
 
   include ::govuk_jenkins::github_enterprise_cert
+  include ::govuk_jenkins::safe_restart
 
   # Jenkins service needs to be restarted to reload the Java keystore
   Class['govuk_jenkins::github_enterprise_cert'] ~> Class['jenkins::service']


### PR DESCRIPTION
This wasn't included anywhere, so the Notify was complaining that the class wasn't in the catalog.