### PR TITLE
Add env var for Appsignal trial

### DIFF
--- a/modules/govuk/manifests/deploy/config.pp
+++ b/modules/govuk/manifests/deploy/config.pp
@@ -19,11 +19,16 @@
 # [*website_root*]
 #   The location that the website is served from, including protocol.
 #
+# [*appsignal_api_key*]
+#   Appsignal API key (https://appsignal.com/gov-dot-uk). For evaluation on
+#   integration.
+#
 class govuk::deploy::config(
   $asset_root,
   $errbit_environment_name = '',
   $govuk_env = 'production',
   $website_root,
+  $appsignal_api_key = undef,
 ){
 
   limits::limits { 'deploy_nofile':
@@ -85,6 +90,7 @@ class govuk::deploy::config(
     'RAILS_ENV': value => $govuk_env;
 
     'ERRBIT_ENVIRONMENT_NAME': value   => $errbit_environment_name;
+    'APPSIGNAL_API_KEY': value         => $appsignal_api_key;
     'GOVUK_APP_DOMAIN': value          => $app_domain;
     'GOVUK_ASSET_HOST': value          => $asset_root;
     'GOVUK_ASSET_ROOT': value          => $asset_root;


### PR DESCRIPTION
We're evaluating Appsignal as an alternative to Errbit. This adds a env var that will be accessible to all applications. This works because Appsignal uses one API key per account (as opposed to app and environment for Errbit).

We'll only configure this in integration for our trial (https://github.gds/gds/deployment/pull/1215). If we decide to go with another option we'll remove this.

cc @alexmuller @carvil 

https://trello.com/c/J3kDeZD7