### PR TITLE
Set the backend ip range for each environment

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -278,6 +278,7 @@ govuk::apps::contentapi::nagios_memory_warning: 3800
 govuk::apps::contentapi::nagios_memory_critical: 4000
 
 govuk::apps::content_performance_manager::db_hostname: "postgresql-primary-1.backend"
+govuk::apps::content_performance_manager::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 
 govuk::apps::content_store::nagios_memory_warning: 2300
 govuk::apps::content_store::nagios_memory_critical: 2500

--- a/modules/govuk/manifests/apps/content_performance_manager/db.pp
+++ b/modules/govuk/manifests/apps/content_performance_manager/db.pp
@@ -10,7 +10,7 @@
 #
 class govuk::apps::content_performance_manager::db (
   $password,
-  $backend_ip_range = '10.3.0.0/16',
+  $backend_ip_range = undef,
 ) {
   govuk_postgresql::db { 'content_performance_manager_production':
     user                    => 'content_performance_manager',


### PR DESCRIPTION
The backend ip range is used to determine which database host the app tries to
connect to.

This needs to be a different value for each environment.

Set the default to undef so that it picks it up from hieradata.