### PR TITLE
Add blue ocean plugin

### DIFF
--- a/hieradata/class/ci_master.yaml
+++ b/hieradata/class/ci_master.yaml
@@ -37,6 +37,36 @@ govuk_jenkins::plugins:
       version: "0.4.2"
     antisamy-markup-formatter:
       version: "1.5"
+    blueocean:
+      version: "1.0.0-b18"
+    blueocean-autofavorite:
+      version: "0.5"
+    blueocean-commons:
+      version: "1.0.0-b18"
+    blueocean-config:
+      version: "1.0.0-b18"
+    blueocean-dashboard:
+      version: "1.0.0-b18"
+    blueocean-display-url:
+      version: "1.3"
+    blueocean-git-pipeline:
+      version: "1.0.0-b18"
+    blueocean-github-pipeline:
+      version: "1.0.0-b18"
+    blueocean-i18n:
+      version: "1.0.0-b18"
+    blueocean-jwt:
+      version: "1.0.0-b18"
+    blueocean-personalization:
+      version: "1.0.0-b18"
+    blueocean-pipeline-api-impl:
+      version: "1.0.0-b18"
+    blueocean-rest:
+      version: "1.0.0-b18"
+    blueocean-rest-impl:
+      version: "1.0.0-b18"
+    blueocean-web:
+      version: "1.0.0-b18"
     bouncycastle-api:
       version: "2.16.0"
     brakeman:


### PR DESCRIPTION
We should add the plugin incase people want to try it. Enabling currently does mean that you are unable to configure jobs in the UI, so would need to use classic mode, but it specifically plays nicely with pipeline jobs, which are the majority of jobs used on CI.

https://jenkins.io/projects/blueocean/
https://wiki.jenkins-ci.org/display/JENKINS/Blue+Ocean+Plugin