### PR TITLE
Postgresql backup alerted as failed

### DIFF
--- a/modules/govuk_postgresql/templates/usr/local/bin/autopostgresqlbackup.erb
+++ b/modules/govuk_postgresql/templates/usr/local/bin/autopostgresqlbackup.erb
@@ -638,7 +638,7 @@ if [ -s "$LOGERR" ]
 fi
 
 # Clean up Logfiles older than two weeks
-/usr/bin/find $BACKUPDIR -iname *.log -mtime +14 -type f -delete
+/usr/bin/find $BACKUPDIR -iname "*.log" -mtime +14 -type f -delete
 
 if [ $STATUS -eq 0 ]; then
   NAGIOS_CODE=0


### PR DESCRIPTION
Postgresql backup alerted as failed when the command to clear old logs failed.

Error:
```
find: paths must precede expression: ERROR_LOG.........
Usage: find [-H] [-L] [-P] [-Olevel] [-Dhelp|tree|search|stat|rates|opt|exec] [path...] [expression]
```
Wrapping glob expression in quotes allows bash/find to process the list of files