### PR TITLE
Modify user logins service description

### DIFF
--- a/modules/icinga/manifests/client/checks.pp
+++ b/modules/icinga/manifests/client/checks.pp
@@ -71,7 +71,7 @@ class icinga::client::checks (
 
   @@icinga::check { "check_users_${::hostname}":
     check_command       => 'check_nrpe_1arg!check_users',
-    service_description => 'high user logins',
+    service_description => 'high number of ssh sessions',
     host_name           => $::fqdn,
   }
 


### PR DESCRIPTION
Making the service description more explicit.  Check is counting the number of TTYs

```
mikaelallison@integration-backend-1:~$ w
 11:43:04 up  8:06,  8 users,  load average: 0.40, 0.61, 0.52
USER     TTY      FROM             LOGIN@   IDLE   JCPU   PCPU WHAT
tomgladh pts/11   jumpbox-1.manage 10:36    2:17  16.48s  0.00s /bin/sh /usr/lo
tomgladh pts/238  jumpbox-1.manage 10:44    2:33   7.92s  0.00s /bin/sh /usr/lo
thomasle pts/174  jumpbox-1.manage 10:58   44:04   0.01s  0.01s -bash
carlosma pts/241  jumpbox-1.manage 10:59   43:50   0.01s  0.01s -bash
tomgladh pts/242  jumpbox-1.manage 11:11   31:41   0.00s  0.00s -bash
leenagup pts/243  jumpbox-1.manage 11:26    9:32   0.03s  0.03s -bash
matteogr pts/244  jumpbox-1.manage 11:34    4:52   0.07s  0.07s -bash
mikaelal pts/240  jumpbox-1.manage 11:42    0.00s  0.01s  0.01s w
```