### PR TITLE
Adjust Backup management time

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -5,6 +5,7 @@ backup::mysql::rotation_daily: '2'
 backup::mysql::rotation_weekly: '6'
 backup::mysql::rotation_monthly: '28'
 backup::server::backup_hour: 8
+backup::server::backup_minute: 30
 
 base::supported_kernel::enabled: true
 

--- a/modules/backup/manifests/server.pp
+++ b/modules/backup/manifests/server.pp
@@ -17,6 +17,7 @@
 class backup::server (
   $backup_private_key = '',
   $backup_hour = 7,
+  $backup_minute = 0,
 ) {
 
   include backup::client
@@ -50,7 +51,7 @@ class backup::server (
     command => 'run-parts /etc/backup',
     user    => 'govuk-backup',
     hour    => $backup_hour,
-    minute  => '0',
+    minute  => $backup_minute,
   }
 
   Backup::Directory   <<||>> { }


### PR DESCRIPTION
relates to: https://github.com/alphagov/govuk-puppet/pull/5363

This job needs to be invoked after the backups, giving the backups sufficient time to complete.