### PR TITLE
This aaset prefix seems superfluous

### DIFF
--- a/modules/govuk/manifests/apps/content_performance_manager.pp
+++ b/modules/govuk/manifests/apps/content_performance_manager.pp
@@ -53,11 +53,10 @@ class govuk::apps::content_performance_manager(
   $app_name = 'content-performance-manager'
 
   govuk::app { $app_name:
-    app_type              => 'rack',
-    port                  => $port,
-    health_check_path     => '/',
-    asset_pipeline        => true,
-    asset_pipeline_prefix => 'content-performance-manager',
+    app_type          => 'rack',
+    port              => $port,
+    health_check_path => '/',
+    asset_pipeline    => true,
   }
 
   Govuk::App::Envvar {


### PR DESCRIPTION
This prefix seems superfluous. Assets are normally placed under an `assets` directory in the project root.