### PR TITLE
Update branch exclusion list for service manual applications

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -81,8 +81,10 @@ deployable_applications: &deployable_applications
   rummager:
     branches_to_exclude: ['release', 'deployed-to-integration', 'deployed-to-staging']
   search-admin: {}
-  service-manual-frontend: {}
-  service-manual-publisher: {}
+  service-manual-frontend:
+    branches_to_exclude: ['release', 'deployed-to-integration', 'deployed-to-staging']
+  service-manual-publisher:
+    branches_to_exclude: ['release', 'deployed-to-integration', 'deployed-to-staging']
   short-url-manager: {}
   sidekiq-monitoring: {}
   signon: {}


### PR DESCRIPTION
We want to ensure that deployed-to-production is a build that Jenkins
runs, so that we can run govuk-content-schemas tests against the service
manual applications (service-manual-frontend and
service-manual-publisher).

For background, see [here](https://github.gds/gds/opsmanual/pull/862/files?short_path=db37eb8#diff-db37eb8a3f2b8b7408aa69b7a0435c61).

Related: alphagov/service-manual-frontend#100 & alphagov/service-manual-publisher#379