### PR TITLE
Add govuk beat

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -540,6 +540,8 @@ govuk::apps::transition::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::travel_advice_publisher::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::travel_advice_publisher::redis_port: "%{hiera('sidekiq_port')}"
 
+govuk_beat::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+
 govuk::deploy::config::asset_root: "https://%{hiera('router::assets_origin::vhost_name')}"
 govuk::deploy::config::website_root: "https://www-origin.%{hiera('app_domain')}"
 

--- a/modules/filebeat/manifests/config.pp
+++ b/modules/filebeat/manifests/config.pp
@@ -1,0 +1,28 @@
+#
+class filebeat::config {
+
+  $filebeat_config = delete_undef_values({
+    'beat_name' => $::fqdn,
+    'output'    => $filebeat::outputs,
+  })
+
+  file {'/etc/filebeat/filebeat.yml':
+    ensure  => file,
+    content => template('filebeat/filebeat.yml.erb'),
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    notify  => Service['filebeat'],
+    require => File['/etc/filebeat/conf.d'],
+  }
+
+  file {'/etc/filebeat/conf.d':
+    ensure  => directory,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0755',
+    recurse => $filebeat::purge_conf_dir,
+    purge   => $filebeat::purge_conf_dir,
+  }
+
+}

--- a/modules/filebeat/manifests/init.pp
+++ b/modules/filebeat/manifests/init.pp
@@ -1,0 +1,50 @@
+# == Class: filebeat
+#
+# Based on https://github.com/pcfens/puppet-filebeat
+#
+# == Parameters
+#
+# [*package_ensure*]
+#   The ensure parameter for the filebeat package 
+#   Default: present
+#
+# [*service_ensure*]
+#   The ensure parameter on the filebeat service
+#   Default: running
+#
+# [*service_enable*]
+#   The enable parameter on the filebeat service
+#   Default: true
+#
+# [*purge_conf_dir*]
+#   Should files in the prospector configuration directory not managed by puppet be automatically purged
+#   Default: true
+#
+# [*outputs*]
+#   (Hash) Will be converted to YAML for the required outputs section of the configuration 
+#
+# [*prospectors*]
+#   (Hash) Prospectors that will be created
+#
+class filebeat (
+  $package_ensure       = present,
+  $service_ensure       = running,
+  $service_enable       = true,
+  $purge_conf_dir       = true,
+  $outputs              = {},
+  $prospectors          = {},
+) {
+
+  anchor { 'filebeat::begin': } ->
+  class { '::filebeat::install': } ->
+  class { '::filebeat::config': } ->
+  class { '::filebeat::service': } ->
+  anchor { 'filebeat::end': }
+
+  $prospectors_final = hiera_hash('filebeat::prospectors', $prospectors)
+
+  if !empty($prospectors_final) {
+    create_resources('filebeat::prospector', $prospectors_final)
+  }
+
+}

--- a/modules/filebeat/manifests/install.pp
+++ b/modules/filebeat/manifests/install.pp
@@ -1,0 +1,8 @@
+#
+class filebeat::install {
+
+  package {'filebeat':
+    ensure => $filebeat::package_ensure,
+  }
+
+}

--- a/modules/filebeat/manifests/prospector.pp
+++ b/modules/filebeat/manifests/prospector.pp
@@ -1,0 +1,52 @@
+# Define: filebeat::prospector
+#
+# Based on https://github.com/pcfens/puppet-filebeat/blob/master/manifests/prospector.pp
+define filebeat::prospector (
+  $ensure                = present,
+  $paths                 = [],
+  $exclude_files         = [],
+  $encoding              = 'plain',
+  $input_type            = 'log',
+  $fields                = {},
+  $fields_under_root     = false,
+  $ignore_older          = undef,
+  $close_older           = undef,
+  $doc_type              = 'log',
+  $scan_frequency        = '10s',
+  $harvester_buffer_size = 16384,
+  $tail_files            = false,
+  $backoff               = '1s',
+  $max_backoff           = '10s',
+  $backoff_factor        = 2,
+  $close_inactive        = '5m',
+  $close_renamed         = false,
+  $close_removed         = true,
+  $close_eof             = false,
+  $clean_inactive        = 0,
+  $clean_removed         = true,
+  $close_timeout         = 0,
+  $force_close_files     = false,
+  $include_lines         = [],
+  $exclude_lines         = [],
+  $max_bytes             = '10485760',
+  $multiline             = {},
+  $json                  = {},
+  $tags                  = [],
+  $symlinks              = false,
+) {
+
+  validate_hash($fields, $multiline, $json)
+  validate_array($paths, $exclude_files, $include_lines, $exclude_lines, $tags)
+  validate_bool($tail_files, $close_renamed, $close_removed, $close_eof, $clean_removed, $symlinks)
+
+  file { "filebeat-${name}":
+    ensure  => $ensure,
+    path    => "/etc/filebeat/conf.d/${name}.yml",
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    content => template('filebeat/prospector.yml.erb'),
+    notify  => Service['filebeat'],
+  }
+
+}

--- a/modules/filebeat/manifests/service.pp
+++ b/modules/filebeat/manifests/service.pp
@@ -1,0 +1,9 @@
+#
+class filebeat::service {
+
+  service { 'filebeat':
+    ensure => $filebeat::service_ensure,
+    enable => $filebeat::service_enable,
+  }
+
+}

--- a/modules/filebeat/spec/classes/filebeat_spec.rb
+++ b/modules/filebeat/spec/classes/filebeat_spec.rb
@@ -1,0 +1,8 @@
+require_relative '../../../../spec_helper'
+
+describe 'filebeat', :type => :class do
+
+  it { is_expected.to compile }
+  it { is_expected.to compile.with_all_deps }
+
+end

--- a/modules/filebeat/templates/filebeat.yml.erb
+++ b/modules/filebeat/templates/filebeat.yml.erb
@@ -1,0 +1,137 @@
+###################### Filebeat Configuration Example #########################
+
+# This file is an example configuration file highlighting only the most common
+# options. The filebeat.full.yml file from the same directory contains all the
+# supported options with more comments. You can use it as a reference.
+#
+# You can find the full configuration reference here:
+# https://www.elastic.co/guide/en/beats/filebeat/index.html
+
+#================================ General =====================================
+
+# The name of the shipper that publishes the network data. It can be used to group
+# all the transactions sent by a single shipper in the web interface.
+name: <%= @filebeat_config['beat_name'] %>
+
+# The tags of the shipper are included in their own field with each
+# transaction published.
+#tags: ["service-X", "web-tier"]
+
+# Optional fields that you can specify to add additional information to the
+# output.
+#fields:
+#  env: staging
+
+#================================= Paths ======================================
+
+# The home path for the filebeat installation. This is the default base path
+# for all other path settings and for miscellaneous files that come with the
+# distribution (for example, the sample dashboards).
+# If not set by a CLI flag or in the configuration file, the default for the
+# home path is the location of the binary.
+#path.home:
+
+# The configuration path for the filebeat installation. This is the default
+# base path for configuration files, including the main YAML configuration file
+# and the Elasticsearch template file. If not set by a CLI flag or in the
+# configuration file, the default for the configuration path is the home path.
+path.config: /etc/filebeat/conf.d
+
+# The data path for the filebeat installation. This is the default base path
+# for all the files in which filebeat needs to store its data. If not set by a
+# CLI flag or in the configuration file, the default for the data path is a data
+# subdirectory inside the home path.
+#path.data: ${path.home}/data
+
+# The logs path for a filebeat installation. This is the default location for
+# the Beat's log files. If not set by a CLI flag or in the configuration file,
+# the default for the logs path is a logs subdirectory inside the home path.
+#path.logs: ${path.home}/logs
+
+#================================ Outputs =====================================
+
+# Configure what outputs to use when sending the data collected by the beat.
+# Multiple outputs may be used.
+
+<%- if @filebeat_config['output']['logstash'] != nil -%>
+#----------------------------- Logstash output --------------------------------
+output.logstash:
+  <%- if @filebeat_config['output']['logstash']['enabled'] != nil -%>
+  enabled: <%= @filebeat_config['output']['logstash']['enabled'] %>
+  <%- end -%>
+  hosts:
+  <%- @filebeat_config['output']['logstash']['hosts'].each do |host| -%>
+    - <%= host %>
+  <%- end -%>
+  <%- if @filebeat_config['output']['logstash']['worker'] != nil -%>
+  worker: <%= @filebeat_config['output']['logstash']['worker'] %>
+  <%- end -%>
+  <%- if @filebeat_config['output']['logstash']['compression_level'] != nil -%>
+  compression_level: <%= @filebeat_config['output']['logstash']['compression_level'] %>
+  <%- end -%>
+  <%- if @filebeat_config['output']['logstash']['loadbalance'] != nil -%>
+  loadbalance: <%= @filebeat_config['output']['logstash']['loadbalance'] %>
+  <%- end -%>
+  <%- if @filebeat_config['output']['logstash']['pipelining'] != nil -%>
+  pipelining: <%= @filebeat_config['output']['logstash']['pipelining'] %>
+  <%- end -%>
+  <%- if @filebeat_config['output']['logstash']['index'] != nil -%>
+  index: <%= @filebeat_config['output']['logstash']['index'] %>
+  <%- end -%>
+  <%- if @filebeat_config['output']['logstash']['proxy_url'] != nil -%>
+  proxy_url: <%= @filebeat_config['output']['logstash']['proxy_url'] %>
+  <%- end -%>
+  <%- if @filebeat_config['output']['logstash']['proxy_use_local_resolver'] != nil -%>
+  proxy_use_local_resolver: <%= @filebeat_config['output']['logstash']['proxy_use_local_resolver'] %>
+  <%- end -%>
+  <%- if @filebeat_config['output']['logstash']['ssl'] != nil -%>
+  ssl:
+    <%- if @filebeat_config['output']['logstash']['ssl']['enabled'] == false -%>
+    enabled: false
+    <%- else -%>
+    enabled: true
+    <%- end -%>
+    <%- if @filebeat_config['output']['logstash']['ssl']['verification_mode'] != nil -%>
+    verification_mode: <%= @filebeat_config['output']['logstash']['ssl']['verification_mode'] %>
+    <%- end -%>
+    <%- if @filebeat_config['output']['logstash']['ssl']['certificate_authorities'] != nil -%>
+    certificate_authorities:
+    <%- @filebeat_config['output']['logstash']['ssl']['certificate_authorities'].each do |ca| -%>
+      - <%= ca %>
+    <%- end -%>
+    <%- end -%>
+    <%- if @filebeat_config['output']['logstash']['ssl']['certificate'] != nil -%>
+    certificate: "<%= @filebeat_config['output']['logstash']['ssl']['certificate'] %>"
+    <%- end -%>
+    <%- if @filebeat_config['output']['logstash']['ssl']['key'] != nil -%>
+    key: "<%= @filebeat_config['output']['logstash']['ssl']['key'] %>"
+    <%- end -%>
+    <%- if @filebeat_config['output']['logstash']['ssl']['key_passphrase'] != nil -%>
+    key_passphrase: '<%= @filebeat_config['output']['logstash']['ssl']['key_passphrase'] %>'
+    <%- end -%>
+    <%- if @filebeat_config['output']['logstash']['ssl']['cipher_suites'] != nil -%>
+    cipher_suites:
+    <%- @filebeat_config['output']['logstash']['ssl']['cipher_suites'].each do |cipher_suite| -%>
+      - <%= cipher_suite %>
+    <%- end -%>
+    <%- end -%>
+    <%- if @filebeat_config['output']['logstash']['ssl']['curve_types'] != nil -%>
+    curve_types:
+    <%- @filebeat_config['output']['logstash']['ssl']['curve_types'].each do |curve_type| -%>
+      - <%= curve_type %>
+    <%- end -%>
+    <%- end -%>
+  <%- end -%>
+<%- end -%>
+
+#================================ Logging =====================================
+
+# Sets log level. The default log level is info.
+# Available log levels are: critical, error, warning, info, debug
+#logging.level: debug
+
+# At debug level, you can selectively enable logging only for some components.
+# To enable all selectors use ["*"]. Examples of other selectors are "beat",
+# "publish", "service".
+#logging.selectors: ["*"]
+

--- a/modules/filebeat/templates/prospector.yml.erb
+++ b/modules/filebeat/templates/prospector.yml.erb
@@ -1,0 +1,178 @@
+---
+filebeat:
+  prospectors:
+    - input_type: <%= @input_type %>
+      paths:
+        <%- @paths.each do |log_path| -%>
+        - <%= log_path %>
+        <%- end -%>
+      <%- if @encoding -%>
+      encoding: <%= @encoding %>
+      <%- end -%>
+      <%- if @include_lines.length > 0 -%>
+      include_lines:
+        <%- @include_lines.each do |include_line| -%>
+        - '<%= include_line %>'
+        <%- end -%>
+      <%- end -%>
+      <%- if @exclude_lines.length > 0 -%>
+      exclude_lines:
+        <%- @exclude_lines.each do |exclude_line| -%>
+        - '<%= exclude_line %>'
+        <%- end -%>
+      <%- end -%>
+      <%- if @exclude_files.length > 0 -%>
+      exclude_files:
+        <%- @exclude_files.each do |exclude_file| -%>
+        - <%= exclude_file %>
+        <%- end -%>
+      <%- end -%>
+      <%- if @fields.length > 0 -%>
+      fields:
+        <%- @fields.each_pair do |k, v| -%>
+        <%= k %>: <%= v %>
+        <%- end -%>
+      <%- end -%>
+      fields_under_root: <%= @fields_under_root %>
+      <%- if @tags.length > 0 -%>
+      tags:
+        <%- @tags.each do |tag| -%>
+        - <%= tag %>
+        <%- end -%>
+      <%- end -%>
+      <%- if @ignore_older -%>
+      ignore_older: <%= @ignore_older %>
+      <%- end -%>
+      <%- if @doc_type -%>
+      document_type: <%= @doc_type %>
+      <%- end -%>
+      <%- if @scan_frequency -%>
+      scan_frequency: <%= @scan_frequency %>
+      <%- end -%>
+      <%- if @harvester_buffer_size -%>
+      harvester_buffer_size: <%= @harvester_buffer_size %>
+      <%- end -%>
+      <%- if @max_bytes -%>
+      max_bytes: <%= @max_bytes %>
+      <%- end -%>
+      <%- if @symlinks -%>
+      symlinks: <%= @symlinks %>
+      <%- end -%>
+      <%- if @close_older -%>
+      close_older: <%= @close_older %>
+      <%- end -%>
+      <%- if @force_close_files -%>
+      force_close_files: <%= @force_close_files %>
+      <%- end -%>
+
+      <%- if @json.length > 0 -%>
+      ### JSON configuration
+      json:
+          # Decode JSON options. Enable this if your logs are structured in JSON.
+          # JSON key on which to apply the line filtering and multiline settings. This key
+          # must be top level and its value must be string, otherwise it is ignored. If
+          # no text key is defined, the line filtering and multiline features cannot be used.
+          <%- if @json['message_key'] -%>
+          message_key: '<%= @json['message_key'] %>'
+          <%- end -%>
+
+          # By default, the decoded JSON is placed under a "json" key in the output document.
+          # If you enable this setting, the keys are copied top level in the output document.
+          <%- if @json['keys_under_root'] -%>
+          keys_under_root: <%= @json['keys_under_root'] %>
+          <%- end -%>
+
+          # If keys_under_root and this setting are enabled, then the values from the decoded
+          # JSON object overwrite the fields that Filebeat normally adds (type, source, offset, etc.)
+          # in case of conflicts.
+          <%- if @json['overwrite_keys'] -%>
+          overwrite_keys: <%= @json['overwrite_keys'] %>
+          <%- end -%>
+
+          # If this setting is enabled, Filebeat adds a "json_error" key in case of JSON
+          # unmarshaling errors or when a text key is defined in the configuration but cannot
+          # be used.
+          <%- if @json['add_error_key'] -%>
+          add_error_key: <%= @json['add_error_key'] %>
+          <%- end -%>
+      <%- end -%>
+
+      <%- if @multiline.length > 0 -%>
+      multiline:
+        <%- if @multiline['pattern'] -%>
+        pattern: '<%= @multiline['pattern'] %>'
+        <%- end -%>
+        <%- if @multiline['negate'] -%>
+        negate: <%= @multiline['negate'] %>
+        <%- end -%>
+        <%- if @multiline['match'] -%>
+        match: <%= @multiline['match'] %>
+        <%- end -%>
+        <%- if @multiline['max_lines'] -%>
+        max_lines: <%= @multiline['max_lines'] %>
+        <%- end -%>
+        <%- if @multiline['timeout'] -%>
+        timeout: <%= @multiline['timeout'] %>
+        <%- end -%>
+      <%- end -%>
+      tail_files: <%= @tail_files %>
+
+      # Experimental: If symlinks is enabled, symlinks are opened and harvested. The harvester is openening the
+      # original for harvesting but will report the symlink name as source.
+      #symlinks: false
+
+      <%- if @backoff -%>
+      backoff: <%= @backoff %>
+      <%- end -%>
+      <%- if @max_backoff -%>
+      max_backoff: <%= @max_backoff %>
+      <%- end -%>
+      <%- if @backoff_factor -%>
+      backoff_factor: <%= @backoff_factor %>
+      <%- end -%>
+
+      # Experimental: Max number of harvesters that are started in parallel.
+      # Default is 0 which means unlimited
+      #harvester_limit: 0
+
+      ### Harvester closing options
+
+      # Close inactive closes the file handler after the predefined period.
+      # The period starts when the last line of the file was, not the file ModTime.
+      # Time strings like 2h (2 hours), 5m (5 minutes) can be used.
+      <%- if @close_inactive -%>
+      close_inactive: <%= @close_inactive %>
+      <%- end -%>      
+
+      # Close renamed closes a file handler when the file is renamed or rotated.
+      # Note: Potential data loss. Make sure to read and understand the docs for this option.
+      close_renamed: <%= @close_renamed %>
+
+      # When enabling this option, a file handler is closed immediately in case a file can't be found
+      # any more. In case the file shows up again later, harvesting will continue at the last known position
+      # after scan_frequency.
+      close_removed: <%= @close_removed %>
+
+      # Closes the file handler as soon as the harvesters reaches the end of the file.
+      # By default this option is disabled.
+      # Note: Potential data loss. Make sure to read and understand the docs for this option.
+      close_eof: <%= @close_eof %>
+
+      ### State options
+
+      # Files for the modification data is older then clean_inactive the state from the registry is removed
+      # By default this is disabled.
+      <%- if @clean_inactive -%>
+      clean_inactive: <%= @clean_inactive %>
+      <%- end -%>
+
+      # Removes the state for file which cannot be found on disk anymore immediately
+      clean_removed: <%= @clean_removed %>
+
+      # Close timeout closes the harvester after the predefined time.
+      # This is independent if the harvester did finish reading the file or not.
+      # By default this option is disabled.
+      # Note: Potential data loss. Make sure to read and understand the docs for this option.
+      <%- if @close_timeout -%>
+      close_timeout: <%= @close_timeout %>
+      <%- end -%>

--- a/modules/govuk_beat/manifests/init.pp
+++ b/modules/govuk_beat/manifests/init.pp
@@ -1,0 +1,35 @@
+# == Class: govuk_beat
+#
+# Wrapper for the upstream 'filebeat' module. 
+#
+# === Examples
+#
+# To add a Filebeat prospector, update the Hiera key 'govuk_beat::filebeat_prospectors'. Hiera
+# will merge prospector declarations down the Hiera hierarchy
+#
+# filebeat::prospectors:
+#   syslog:
+#     paths:
+#       - '/var/log/syslog'
+#
+# === Parameters:
+#
+# [*filebeat_outputs*]
+#   Configure what outputs to use when sending the data collected by the beat
+#
+#   Default: Logstash on localhost
+#
+class govuk_beat (
+  $filebeat_outputs = { logstash => { enabled => true, hosts => ['127.0.0.1:5566'], }, },
+){
+
+  class { '::govuk_beat::repo': }
+
+  # Configure Filebeat. The outputs parameter needs a default value for
+  # the process to start
+  class { '::filebeat' :
+    outputs => $filebeat_outputs,
+    require => Class['govuk_beat::repo'],
+  }
+
+}

--- a/modules/govuk_beat/manifests/repo.pp
+++ b/modules/govuk_beat/manifests/repo.pp
@@ -1,0 +1,21 @@
+# == Class: govuk_beat::repo
+#
+# Use our own mirror of the beat repo. Should be used with `manage_repo`
+# disable of the upstream module.
+#
+#
+# === Parameters
+#
+# [*apt_mirror_hostname*]
+#   Hostname to use for the APT mirror.
+#
+class govuk_beat::repo(
+  $apt_mirror_hostname = undef,
+) {
+  apt::source { 'elastic-beats':
+    location     => "http://${apt_mirror_hostname}/elastic-beats",
+    release      => 'stable',
+    architecture => $::architecture,
+    key          => '',
+  }
+}

--- a/modules/govuk_beat/spec/classes/govuk_beat_spec.rb
+++ b/modules/govuk_beat/spec/classes/govuk_beat_spec.rb
@@ -1,0 +1,9 @@
+require_relative '../../../../spec_helper'
+
+describe 'govuk_beat', :type => :class do
+
+  it { is_expected.to compile }
+  it { is_expected.to compile.with_all_deps }
+  it { is_expected.to contain_class('govuk_beat::repo') }
+
+end


### PR DESCRIPTION
- Add pcfens-filebeat to Puppetfile
- Add new govuk_beat Puppet module to configure Filebeat for Logstash:
  - Override the 'govuk_beat::filebeat_outputs' parameter in Hiera with the Logstash information for the environment
  - Add 'filebeat::prospectors' to Hiera to configure the files that we want to send to Logstash
  - Include the 'govuk_beat' class to the environment or node configuration