### PR TITLE
Use passwords for DNS deploy Jenkins job

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_dns.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_dns.yaml.erb
@@ -40,13 +40,13 @@
         - string:
             name: AWS_ACCESS_KEY_ID
             default: false
-        - string:
+        - password:
             name: AWS_SECRET_ACCESS_KEY
             default: false
         - string:
             name: DYN_USERNAME
             default: false
-        - string:
+        - password:
             name: DYN_PASSWORD
             default: false
 


### PR DESCRIPTION
Using passwords instead of strings means that Jenkins doesn't display these values in the interface.