### PR TITLE
Add a feature flag to content-performance-manager

### DIFF
--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -108,6 +108,7 @@ govuk::apps::authenticating_proxy::govuk_upstream_uri: 'http://government-fronte
 govuk::apps::backdrop_write::enable_procfile_worker: false
 govuk::apps::collections_publisher::enable_procfile_worker: false
 govuk::apps::contacts::extra_aliases: ['contacts-admin']
+govuk::apps::content_performance_manager::enabled: true
 govuk::apps::content_store::mongodb_nodes: ['localhost']
 govuk::apps::content_store::mongodb_name: 'content_store_development'
 govuk::apps::content_tagger::enable_procfile_worker: false

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -12,6 +12,7 @@ base::supported_kernel::enabled: true
 cron::weekly_dow: 1
 cron::daily_hour: 6
 
+govuk::apps::content_performance_manager::enabled: true
 govuk::apps::email_alert_api::allow_govdelivery_topic_syncing: true
 govuk::apps::errbit::errbit_email_from: 'govuk-winston+errbit-integration@digital.cabinet-office.gov.uk'
 govuk::apps::event_store::enabled: true

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -9,6 +9,7 @@ cron::daily_hour: 6
 
 environment_ip_prefix: '10.2'
 
+govuk::apps::content_performance_manager::enabled: true
 govuk::apps::email_alert_api::allow_govdelivery_topic_syncing: true
 govuk::apps::email_alert_api::db::backend_ip_range: '10.2.3.0/24'
 govuk::apps::errbit::errbit_email_from: 'govuk-winston+errbit-staging@digital.cabinet-office.gov.uk'

--- a/modules/govuk/manifests/apps/content_performance_manager.pp
+++ b/modules/govuk/manifests/apps/content_performance_manager.pp
@@ -8,6 +8,10 @@
 #   The port that it is served on.
 #   Default: 3206
 #
+# [*enabled*]
+#   Whether the application should be enabled. Can be specified for each
+#   environment using deployment hieradata.
+#
 # [*secret_key_base*]
 #   The key for Rails to use when signing/encrypting sessions.
 #
@@ -40,6 +44,7 @@
 #
 class govuk::apps::content_performance_manager(
   $port = '3206',
+  $enabled = false,
   $secret_key_base = undef,
   $publishing_api_bearer_token = undef,
   $google_analytics_govuk_view_id = undef,
@@ -52,11 +57,13 @@ class govuk::apps::content_performance_manager(
 ) {
   $app_name = 'content-performance-manager'
 
-  govuk::app { $app_name:
-    app_type          => 'rack',
-    port              => $port,
-    health_check_path => '/',
-    asset_pipeline    => true,
+  if $enabled {
+    govuk::app { $app_name:
+      app_type          => 'rack',
+      port              => $port,
+      health_check_path => '/',
+      asset_pipeline    => true,
+    }
   }
 
   Govuk::App::Envvar {


### PR DESCRIPTION
Content Performance Manager has been deployed to staging and
integration, but it is not ready to be deployed to production.

The app has already been added to puppet though, and was throwing errors
in production.

Added a feature flag to fix the error, as per the docs:
https://github.com/alphagov/govuk-puppet/blob/master/docs/adding-a-new-app.md#feature-flags