### PR TITLE
Remove config overrides for rummager CI builds

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -79,8 +79,7 @@ deployable_applications: &deployable_applications
   release: {}
   router: {}
   router-api: {}
-  rummager:
-    branches_to_exclude: ['release', 'deployed-to-integration', 'deployed-to-staging']
+  rummager: {}
   search-admin: {}
   service-manual-frontend: {}
   service-manual-publisher: {}


### PR DESCRIPTION
Delete the configuration which specifies which rummager branches are built by Jenkins, so that the default config is used. This change means that the rummager `deployed-to-production` branch will no longer be built by Jenkins.

The default config includes all `deployed-to-X` branches. We had wanted to override this so that Jenkins would build the `deployed-to-production` branch so that rummager's production code could be tested against content schema changes, but rummager doesn't actually depend directly on the content schemas, so this was unnecessary.