### PR TITLE
Add FASTLY_OTP environment variable to deploy job

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_cdn.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_cdn.yaml.erb
@@ -47,3 +47,7 @@
         - password:
             name: FASTLY_PASS
             default: false
+        - string:
+            name: FASTLY_OTP
+            description: A six digit two-factor authentication code
+            default: false


### PR DESCRIPTION
When deploying the CDN we want to use 2 factor authentication.

Until the change is made in the CDN deployment code this variable will be unused and it won't matter if it's set or not.