### PR TITLE
Use etcd on docker-management-1 for reboots

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1171,6 +1171,8 @@ hosts::production::management::hosts:
       - 'apt'
   docker-management-1:
     ip: '10.1.0.80'
+    service_aliases:
+      - 'etcd'
   jumpbox-1:
     ip: '10.1.0.100'
   mirrorer-1:

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -256,6 +256,9 @@ router::nginx::check_requests_critical: '@0.25'
 
 shell::shell_prompt_string: 'integration'
 
+unattended_reboot::etcd_endpoints:
+ - "http://etcd.cluster:2379"
+
 users::usernames:
   - alecgibson
   - alexmuller


### PR DESCRIPTION
We created a container for etcd in 8e9f59a34e7c3f698f8acc752edd8fadd7f9d8d2. The main advantage is that it enables us to easily upgrade to the latest version of etcd, and also remove a bunch of surrounding etcd code used to manage the current etcd machine.

This adds a service alias that will become "etcd.cluster", and update the cluster endpoint to use for unattended reboots in Integration only.

Integration is a little tricky to test as the machines are shut down every night, but we could potentially change the times machines are rebooted.