### PR TITLE
Ensure content-performance-manager absent in prod

### DIFF
--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -108,7 +108,6 @@ govuk::apps::authenticating_proxy::govuk_upstream_uri: 'http://government-fronte
 govuk::apps::backdrop_write::enable_procfile_worker: false
 govuk::apps::collections_publisher::enable_procfile_worker: false
 govuk::apps::contacts::extra_aliases: ['contacts-admin']
-govuk::apps::content_performance_manager::enabled: true
 govuk::apps::content_store::mongodb_nodes: ['localhost']
 govuk::apps::content_store::mongodb_name: 'content_store_development'
 govuk::apps::content_tagger::enable_procfile_worker: false

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -12,7 +12,6 @@ base::supported_kernel::enabled: true
 cron::weekly_dow: 1
 cron::daily_hour: 6
 
-govuk::apps::content_performance_manager::enabled: true
 govuk::apps::email_alert_api::allow_govdelivery_topic_syncing: true
 govuk::apps::errbit::errbit_email_from: 'govuk-winston+errbit-integration@digital.cabinet-office.gov.uk'
 govuk::apps::event_store::enabled: true

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -38,6 +38,8 @@ base::supported_kernel::enabled: true
 
 environment_ip_prefix: '10.3'
 
+govuk::apps::content_performance_manager::ensure: 'absent'
+
 govuk::apps::efg::ssl_certtype: 'sflg'
 govuk::apps::efg::vhost_name: "www.sflg.gov.uk"
 

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -9,7 +9,6 @@ cron::daily_hour: 6
 
 environment_ip_prefix: '10.2'
 
-govuk::apps::content_performance_manager::enabled: true
 govuk::apps::email_alert_api::allow_govdelivery_topic_syncing: true
 govuk::apps::email_alert_api::db::backend_ip_range: '10.2.3.0/24'
 govuk::apps::errbit::errbit_email_from: 'govuk-winston+errbit-staging@digital.cabinet-office.gov.uk'

--- a/modules/govuk/manifests/apps/content_performance_manager.pp
+++ b/modules/govuk/manifests/apps/content_performance_manager.pp
@@ -8,8 +8,8 @@
 #   The port that it is served on.
 #   Default: 3206
 #
-# [*enabled*]
-#   Whether the application should be enabled. Can be specified for each
+# [*ensure*]
+#   Whether the application should be exist. Can be specified for each
 #   environment using deployment hieradata.
 #
 # [*secret_key_base*]
@@ -44,7 +44,7 @@
 #
 class govuk::apps::content_performance_manager(
   $port = '3206',
-  $enabled = false,
+  $ensure = 'present',
   $secret_key_base = undef,
   $publishing_api_bearer_token = undef,
   $google_analytics_govuk_view_id = undef,
@@ -57,13 +57,12 @@ class govuk::apps::content_performance_manager(
 ) {
   $app_name = 'content-performance-manager'
 
-  if $enabled {
-    govuk::app { $app_name:
-      app_type          => 'rack',
-      port              => $port,
-      health_check_path => '/',
-      asset_pipeline    => true,
-    }
+  govuk::app { $app_name:
+    ensure            => $ensure,
+    app_type          => 'rack',
+    port              => $port,
+    health_check_path => '/',
+    asset_pipeline    => true,
   }
 
   Govuk::App::Envvar {


### PR DESCRIPTION
The content-performance-manager is a new app, and is not ready to be 
deployed in production.

When the original puppet code was added for the application, the feature
flag was missing, so all of the alerts and checks were set up even though
the application does not exist.

I tried rectifying this by adding the feature flag, but this didn’t
remove the framework that was already put in place.

Setting `ensure` to absent is one of the first steps in 
[retiring an application](https://github.gds/pages/gds/opsmanual/infrastructure/howto/retiring-an-application.html). I’m hoping that this will remove all of
the alerts for content-performance-manager

I’ve removed the feature flag because the value for `ensure` can’t be set
while it exists.