### PR TITLE
Bugfix S3 offsite backups

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -171,8 +171,8 @@ backup::offsite::jobs:
       - '/data/backups/*/var/lib/autopostgresqlbackup/latest.tbz2'
       - '/data/backups/archived'
     bucket: 'govuk-offsite-backups'
-    aws_access_key_id: "%hiera('backup::offsite::job::aws_access_key_id')"
-    aws_secret_access_key: "%hiera('backup::offsite::job::aws_secret_access_key')"
+    aws_access_key_id: "%{hiera('backup::offsite::job::aws_access_key_id')}"
+    aws_secret_access_key: "%{hiera('backup::offsite::job::aws_secret_access_key')}"
     hour: 8,
     minute: 13,
     gpg_key_id: *offsite_gpg_key


### PR DESCRIPTION
The keys were missing curly braces which caused the backup script to incorrectly export the required values:

`export AWS_ACCESS_KEY_ID='%hiera('backup::offsite::job::aws_access_key_id')'`
`export AWS_SECRET_ACCESS_KEY='%hiera('backup::offsite::job::aws_secret_access_key')'`