### PR TITLE
Update Vagrant sync directory to work with Xenial builds

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -67,7 +67,7 @@ Vagrant.configure("2") do |config|
       end
 
       # These can't be NFS because OSX won't export overlapping paths.
-      c.vm.synced_folder "gpg", "/etc/puppet/gpg", :owner => 'puppet', :group => 'puppet'
+      c.vm.synced_folder "gpg", "/etc/puppet/gpg", :owner => 'puppet', :group => 'puppet', type: "rsync"
       # Additional shared folders for Puppet Master nodes.
       if node_name =~ /^puppetmaster/
         c.vm.synced_folder ".", "/usr/share/puppet/production/current"


### PR DESCRIPTION
Xenial builds are failing to execute 'puppet-apply', showing a GPG decryption related error.

The installation process is adding the package 'gnupg-agent', that is not present in Ubuntu Trusty,
and is a dependency for the other GPG tools. This package starts a gpg-agent process when the command
'gpg' is invoked, which creates a socket file in the gnugp home directory. In our Vagrant machines,
this directory is '/etc/puppet/gpg', that is synced with the directory 'gpg/' in this repository.

With Virtualbox, synced directories are using 'vboxsf' file system by default, and it looks like it's not
working with the gpg-agent behaviour. The proposed fix in this commit updates the default sync behaviour
in the Vagrantfile to use 'rsync' instead. The directory will be synced when we boot the machine on the
root partition instead of using a separate 'vboxsf' one.