### PR TITLE
Make sure env vars are only created if app is present

### DIFF
--- a/modules/govuk/manifests/apps/content_performance_manager.pp
+++ b/modules/govuk/manifests/apps/content_performance_manager.pp
@@ -65,36 +65,38 @@ class govuk::apps::content_performance_manager(
     asset_pipeline    => true,
   }
 
-  Govuk::App::Envvar {
-    app    => $app_name,
-  }
-
-  govuk::app::envvar {
-    "${title}-GOOGLE_ANALYTICS_GOVUK_VIEW_ID":
-      varname => 'GOOGLE_ANALYTICS_GOVUK_VIEW_ID',
-      value   => $google_analytics_govuk_view_id;
-    "${title}-GOOGLE_PRIVATE_KEY":
-      varname => 'GOOGLE_PRIVATE_KEY',
-      value   => $google_private_key;
-    "${title}-GOOGLE_CLIENT_EMAIL":
-      varname => 'GOOGLE_CLIENT_EMAIL',
-      value   => $google_client_email;
-  }
-
-  if $secret_key_base != undef {
-    govuk::app::envvar { "${title}-SECRET_KEY_BASE":
-      varname => 'SECRET_KEY_BASE',
-      value   => $secret_key_base,
+  if $ensure == 'present' {
+    Govuk::App::Envvar {
+      app    => $app_name,
     }
-  }
 
-  if $::govuk_node_class != 'development' {
-    govuk::app::envvar::database_url { $app_name:
-      type     => 'postgresql',
-      username => $db_username,
-      password => $db_password,
-      host     => $db_hostname,
-      database => $db_name,
+    govuk::app::envvar {
+      "${title}-GOOGLE_ANALYTICS_GOVUK_VIEW_ID":
+        varname => 'GOOGLE_ANALYTICS_GOVUK_VIEW_ID',
+        value   => $google_analytics_govuk_view_id;
+      "${title}-GOOGLE_PRIVATE_KEY":
+        varname => 'GOOGLE_PRIVATE_KEY',
+        value   => $google_private_key;
+      "${title}-GOOGLE_CLIENT_EMAIL":
+        varname => 'GOOGLE_CLIENT_EMAIL',
+        value   => $google_client_email;
+    }
+
+    if $secret_key_base != undef {
+      govuk::app::envvar { "${title}-SECRET_KEY_BASE":
+        varname => 'SECRET_KEY_BASE',
+        value   => $secret_key_base,
+      }
+    }
+
+    if $::govuk_node_class != 'development' {
+      govuk::app::envvar::database_url { $app_name:
+        type     => 'postgresql',
+        username => $db_username,
+        password => $db_password,
+        host     => $db_hostname,
+        database => $db_name,
+      }
     }
   }
 }


### PR DESCRIPTION
Puppet won’t allow you to create environment variables for an app that
does not have any records (i.e. is ‘absent’)

The last run of puppet threw errors for content-performance-manager,
because the manifest was trying to create environment variables for an
application framework that doesn’t exist:

```
[backend-3.backend] out: Error: Could not set 'present' on ensure: No such file or directory - /etc/govuk/content-performance-manager/env.d/GOOGLE_PRIVATE_KEY20170130-4949-gakref.lock at 36:/usr/share/puppet/production/current/modules/govuk/manifests/app/envvar.pp
[backend-3.backend] out: Error: Could not set 'present' on ensure: No such file or directory - /etc/govuk/content-performance-manager/env.d/GOOGLE_PRIVATE_KEY20170130-4949-gakref.lock at 36:/usr/share/puppet/production/current/modules/govuk/manifests/app/envvar.pp
```

Wrapped the creation of the environment variables in a conditional to fix
this.