### PR TITLE
Correctly parse graphite minimum thresholds

### DIFF
--- a/modules/icinga/manifests/check/graphite.pp
+++ b/modules/icinga/manifests/check/graphite.pp
@@ -88,12 +88,14 @@ define icinga::check::graphite(
   $graph_height = 600
 
   # Only display lines when threshold is an integer or float.
+  # The '@' symbol indicates to icinga that the threshold is a minimum so we
+  # allow that and capture the numbers for display in graphite.
   $warn_line = $warning ? {
-    /^[0-9.]+$/ => "&target=alias(dashed(constantLine(${warning})),%22warning%22)",
+    /^@?([0-9.]+)$/ => "&target=alias(dashed(constantLine(${1})),%22warning%22)",
     default    => '',
   }
   $crit_line = $critical ? {
-    /^[0-9.]+$/ => "&target=alias(dashed(constantLine(${critical})),%22critical%22)",
+    /^@?([0-9.]+)$/ => "&target=alias(dashed(constantLine(${1})),%22critical%22)",
     default    => '',
   }
 

--- a/modules/icinga/spec/defines/icinga__check__graphite_spec.rb
+++ b/modules/icinga/spec/defines/icinga__check__graphite_spec.rb
@@ -103,6 +103,12 @@ describe 'icinga::check::graphite', :type => :define do
         :check_command => 'check_graphite_metric_args!sumSeries(zoo.*.deer)!@30!@40!-F 23minutes --droplast 1',
       )
     end
+
+    it 'should contain a warning line and critical line' do
+      is_expected.to contain_icinga__check('count_inverse_deer').with(
+        :action_url    => /^https:\/\/graphite\.environment\.example\.com\/render\/\?width=\d+&height=\d+&colorList=[a-z,]+&target=alias\(dashed\(constantLine\(40\)\),%22critical%22\)&target=alias\(dashed\(constantLine\(30\)\),%22warning%22\)&target=sumSeries\(zoo\.\*\.deer\)$/,
+      )
+    end
   end
 
   context 'when ensure is passed' do
@@ -139,7 +145,7 @@ describe 'icinga::check::graphite', :type => :define do
 
       it { is_expected.to raise_error(Puppet::Error, /Invalid ensure value/) }
     end
-    
+
     context 'ensure => true' do
       let(:title) { 'count_nothing' }
       let(:params) {{


### PR DESCRIPTION
Graphite can be configured to treat a number as a minimum by
prepending the value with a '@', these values should still be
displayed as a line in charts. This changes the selector regex to
allow strings to start with a '@' whilst still correctly setting
the value of the constantLine.