### PR TITLE
Crontab files should not have spaces in their names

### DIFF
--- a/modules/govuk_ci/manifests/master.pp
+++ b/modules/govuk_ci/manifests/master.pp
@@ -70,7 +70,7 @@ class govuk_ci::master (
     'credentials_id' => $credentials_id,
   })
 
-  cron::crondotdee { 'Clean up pipeline workspace':
+  cron::crondotdee { 'clean_up_pipeline_workspace':
     command => 'find /var/lib/jenkins/workspace/*@script -maxdepth 0 -type d -mtime +1 -exec rm -rf {} \;',
     hour    => 7,
     minute  => 45,


### PR DESCRIPTION
The "Clean up pipeline workspace" cronjob does not seem to have been
running. This is likely because it has spaces in its name so this
replaces them with underscores.