### PR TITLE
Add mongo-pp to Integration data sync

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
@@ -90,6 +90,7 @@
                 - mongo-exceptions
                 - mongo-licensify
                 - mongo-normal
+                - mongo-pp
                 - mongo-router
                 - mysql-efg
                 - mysql-normal


### PR DESCRIPTION
This is now being run as part of `all` jobs and it is failing. The current error is:

```
2017-02-01T05:27:33Z: [mongo-pp] Sourcing config files
2017-02-01T05:27:33Z: [mongo-pp] Synchronising Performance Platform Mongo Databases to integration
2017-02-01T05:27:33Z: [mongo-pp] Dumping from all databases on performance-mongo-3.api
2017-02-01T05:29:12Z: [mongo-pp] assertion: 14035 couldn't write to file: errno:28 No space left on device
2017-02-01T05:29:12Z: [mongo-pp] Deleting dump from source performance-mongo-3.api
2017-02-01T05:29:12Z: [mongo-pp] Deleting dump from dest performance-mongo-2
2017-02-01T05:29:12Z: [mongo-pp] JOB FAILURE
```

By adding it to the list of choices we will be able to trigger that specific data sync job again and check what's going wrong.