### PR TITLE
Add PP data sync job

### DIFF
--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -25,6 +25,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::mirror_network_config
   - govuk_jenkins::job::network_config_deploy
   - govuk_jenkins::job::passive_checks
+  - govuk_jenkins::job::performance_platform_data_sync
   - govuk_jenkins::job::publishing_api_archive_events
   - govuk_jenkins::job::run_rake_task
   - govuk_jenkins::job::run_whitehall_data_migrations

--- a/modules/govuk_jenkins/manifests/job/performance_platform_data_sync.pp
+++ b/modules/govuk_jenkins/manifests/job/performance_platform_data_sync.pp
@@ -1,0 +1,11 @@
+# == Class: govuk_jenkins::job::performance_platform_data_sync
+#
+# Create a file on disk that can be parsed by jenkins-job-builder
+#
+class govuk_jenkins::job::performance_platform_data_sync {
+  file { '/etc/jenkins_jobs/jobs/performance_platform_data_sync.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/performance_platform_data_sync.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+}

--- a/modules/govuk_jenkins/templates/jobs/performance_platform_data_sync.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/performance_platform_data_sync.yaml.erb
@@ -1,0 +1,37 @@
+---
+- scm:
+    name: env-sync-and-backup_Performance_Platform_Data_Sync
+    scm:
+        - git:
+            url: git@github.gds:gds/env-sync-and-backup.git
+            branches:
+              - master
+
+- job:
+    name: Performance_Platform_Data_Sync
+    display-name: Performance_Platform_Data_Sync
+    project-type: freestyle
+    description: |
+        This job copies the Performance Platform database from production to integration.
+    properties:
+        - github:
+            url: https://github.gds/gds/env-sync-and-backup/
+    scm:
+      - env-sync-and-backup_Performance_Platform_Data_Sync
+    logrotate:
+        numToKeep: 10
+    builders:
+        - shell: |
+            set -eu
+            cd "${WORKSPACE}"
+            echo "Syncing data"
+            bash sync production integration
+    wrappers:
+        - ansicolor:
+            colormap: xterm
+    parameters:
+        - choice:
+            name: JOBLIST
+            description: 'Choose the thing to sync.'
+            choices:
+                - mongo-pp


### PR DESCRIPTION
Every couple of months we're asked to set up a data sync for Performance Platform. The way this happens is by editing and submitting PRs on different repos and/or by editing the Jenkins job that syncs *all* the data on GOVUK to Integration.

This is not an ideal way of doing things. Instead, create a separate job that can be run at anytime to sync data and give power back to the developers who want to do the work.

This is just a slimmed down version of the Copy_Data_to_Integration job, with only a single option for what to sync.

/cc @leelongmore 