### PR TITLE
Add post data sync tasks for content-performance-manger

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
@@ -21,7 +21,7 @@
            ssh deploy@$(govuk_node_list -c backend --single-node) 'cd /var/apps/specialist-publisher ; govuk_setenv specialist-publisher bundle exec rake publishing_api:publish_finders rummager:publish_finders'
     publishers:
         - trigger-parameterized-builds:
-            <%- %w{ publishing-api collections-publisher service-manual-publisher local-links-manager }.each do |app| -%>
+            <%- %w{ publishing-api collections-publisher service-manual-publisher local-links-manager content-performance-manager }.each do |app| -%>
             - project: Deploy_App
               predefined-parameters: |
                 TARGET_APPLICATION=<%= app %>
@@ -47,5 +47,10 @@
                 TARGET_APPLICATION=email-alert-api
                 MACHINE_CLASS=backend
                 RAKE_TASK=sync_govdelivery_topic_mappings
+            - project: run-rake-task
+              predefined-parameters: |
+                TARGET_APPLICATION=content-performance-manager
+                MACHINE_CLASS=backend
+                RAKE_TASK=import:all_organisations
         - email:
             recipients: govuk-ci-notifications@digital.cabinet-office.gov.uk

--- a/modules/govuk_jenkins/templates/jobs/data_sync_complete_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/data_sync_complete_staging.yaml.erb
@@ -23,6 +23,10 @@
            ssh deploy@$(govuk_node_list -c backend --single-node) 'cd /var/apps/publisher ; govuk_setenv publisher bundle exec rake editions:requeue_scheduled_for_publishing'
     publishers:
         - trigger-parameterized-builds:
+            - project: Deploy_App
+              predefined-parameters: |
+                TARGET_APPLICATION=content-performance-manager
+                DEPLOY_TASK=app:migrate_and_hard_restart
             - project: run-rake-task
               predefined-parameters: |
                 TARGET_APPLICATION=router-api
@@ -33,5 +37,10 @@
                 TARGET_APPLICATION=email-alert-api
                 MACHINE_CLASS=backend
                 RAKE_TASK=sync_govdelivery_topic_mappings
+            - project: run-rake-task
+              predefined-parameters: |
+                TARGET_APPLICATION=content-performance-manager
+                MACHINE_CLASS=backend
+                RAKE_TASK=import:all_organisations
         - email:
             recipients: govuk-ci-notifications@digital.cabinet-office.gov.uk


### PR DESCRIPTION
content-performance-manager is not deployed in production. This means
that every time the data sync jobs to staging and integration run, their
databases are copied over with a blank database that does not have any
tables.

These post sync jobs, re-deploy the app and run migrations and 
populate the databases with minimal data.

When the application is finally deployed to production, these jobs will
be removed.