### PR TITLE
Make the `govuk_rabbitmq` specs work under strict variables

### DIFF
--- a/modules/govuk_rabbitmq/spec/defines/govuk_rabbitmq__consumer_spec.rb
+++ b/modules/govuk_rabbitmq/spec/defines/govuk_rabbitmq__consumer_spec.rb
@@ -3,6 +3,10 @@ require_relative '../../../../spec_helper'
 describe 'govuk_rabbitmq::consumer', :type => :define do
   let(:title) { 'a_user' }
 
+  let(:facts) {{
+    staging_http_get: 'curl',
+  }}
+
   context 'minimum info' do
     let(:params) {{
       :amqp_pass => 'super_secret',


### PR DESCRIPTION
If a `staging_http_get` fact is not passed then all 8 spec tests will fail with

    Puppet::Error:
       Undefined variable "::staging_http_get"; Undefined variable "staging_http_get"

The value provided in the spec is the same as on our running systems.