### PR TITLE
Add mysql performance tweaks for ci

### DIFF
--- a/hieradata/class/ci_agent.yaml
+++ b/hieradata/class/ci_agent.yaml
@@ -6,7 +6,10 @@ mongodb::server::replicaset_members:
 
 govuk_ci::agent::postgresql::mapit_role_password: 'mapit'
 postgresql::globals::version: '9.3'
-govuk_mysql::server::innodb_flush_log_at_trx_commit: 0
+
+govuk_mysql::server::innodb_flush_log_at_trx_commit: 2
+govuk_mysql::server::innodb_buffer_pool_size_proportion: 0.05
+govuk_mysql::server::query_cache_size: 0
 
 govuk_elasticsearch::minimum_master_nodes: '1'
 govuk_elasticsearch::version: '1.7.5'

--- a/modules/govuk_ci/files/mysql_custom_config
+++ b/modules/govuk_ci/files/mysql_custom_config
@@ -1,0 +1,12 @@
+# This file is managed by Puppet
+#
+# Custom MySQL configuration for CI agents only
+#
+[mysqld]
+query_cache_type = 0
+log_queries_not_using_indexes = 0
+thread_cache_size = 24
+table_definition_cache = 4096
+table_open_cache = 4096
+optimizer_search_depth = 0
+join_buffer_size = 512k

--- a/modules/govuk_ci/manifests/agent/mysql.pp
+++ b/modules/govuk_ci/manifests/agent/mysql.pp
@@ -88,4 +88,11 @@ class govuk_ci::agent::mysql {
     table      => 'whitehall_%.*',
     privileges => 'ALL',
   }
+
+  file { '/etc/mysql/conf.d/custom.cnf':
+    ensure  => present,
+    source  => 'puppet:///modules/govuk_ci/mysql_custom_config',
+    notify  => Class['::mysql::server::service'],
+    require => Class['::govuk_mysql::server'],
+  }
 }

--- a/modules/govuk_mysql/manifests/server.pp
+++ b/modules/govuk_mysql/manifests/server.pp
@@ -5,10 +5,44 @@
 #
 # === Parameters
 #
+# [*root_password*]
+#   Set the MySQL root password.
+#
+# [*tmp_table_size*]
+#   The maximum size of internal in-memory temporary tables.
+#
+# [*max_heap_table_size*]
+#   This variable sets the maximum size to which user-created MEMORY tables
+#   are permitted to grow.
+#
+# [*innodb_file_per_table*]
+#   When innodb_file_per_table is enabled (the default), InnoDB stores the data
+#   and indexes for each newly created table in a separate .ibd file instead
+#   of the system tablespace.
+#
+# [*key_buffer_size*]
+#   MyISAM variable which determines the size of the index buffers held in
+#   memory, which affects the speed of index reads.
+#
+# [*query_cache_limit*]
+#   The maximum size of an individual query that can be cached.
+#
+# [*query_cache_size*]
+#   The size of the query cache.
+#
+# [*expire_log_days*]
+#   The number of days for automatic binary log file removal.
+#
 # [*innodb_flush_log_at_trx_commit*]
 #   Controls if the filesystem flushes after every transaction commit.
 #   Do not set this to anything other than 1 (default) or 2, except in CI
 #   otherwise you risk losing data.
+#
+# [*slow_query_log*]
+#   Set to enable the slow query log.
+#
+# [*innodb_buffer_pool_size_proportion*]
+#   The proportion of machine memory used by the innodb buffer.
 #
 class govuk_mysql::server (
   $root_password=undef,


### PR DESCRIPTION
This adds performance tweaks for CI agents running MySQL. Some applications run tests (e.g. Whitehall) that are intensive, although we don't really care much about the data.

Along with adding standard config changes in Hiera, this also adds a custom configuration file to be used by MySQL as recommended by @stephenharker.