### PR TITLE
Explicitly set the `value` of an govuk_envvar to undef

### DIFF
--- a/modules/govuk_envvar/manifests/init.pp
+++ b/modules/govuk_envvar/manifests/init.pp
@@ -8,7 +8,7 @@
 # need to restart an application before it picks up a changed environment
 # variable.
 
-define govuk_envvar ($value, $envdir = '/etc/govuk/env.d', $varname = $title) {
+define govuk_envvar ($value = undef, $envdir = '/etc/govuk/env.d', $varname = $title) {
 
   file { "${envdir}/${varname}":
     content => $value,


### PR DESCRIPTION
We currently default to undef so we might as well be explicit.
This also allows tests to pass under `strict`