### PR TITLE
Set the `package_ensure` parameter on `mysql::client`

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1311,6 +1311,9 @@ monitoring::vpn_gateways::endpoints:
   vpn_gateway_router_dr:
     address: "%{hiera('environment_ip_prefix')}.9.1"
 
+# FIXME: this has been added to avoid a bug until we move to v3 of the module
+mysql::client::package_ensure: 'present'
+
 nginx::package::version: '1.4.6-1ubuntu3.7'
 
 nodejs::version: '0.10.37-1chl1~%{::lsbdistcodename}1'

--- a/spec/fixtures/hieradata/common.yaml
+++ b/spec/fixtures/hieradata/common.yaml
@@ -47,6 +47,9 @@ hosts::production::management::hosts:
 
 mongodb::s3backup::backup::private_gpg_key_fingerprint: 'CB77872D51ADD27CF75BD63CB60B50E6DBE2EAFF'
 
+# FIXME: this has been added to avoid a bug until we move to v3 of the module
+mysql::client::package_ensure: 'present'
+
 # if this is true then it conflicts with govuk_rabbit apt management
 rabbitmq::manage_repos: false
 


### PR DESCRIPTION
Our vendored version of the mysql module has a bug that is
addressed in
https://github.com/puppetlabs/puppetlabs-mysql/commit/18df1d08e5c326b1ad91b300864b30e6087d9ec4
it attempts to use a value that `params` does not define.

We have two main options for working around this (as we don't have time to
do a module upgrade at this point).

1: fork the upstream and apply the one change to fix the bug
2: explicitly set the param using hiera

Option 1 adds another module to our collection of forks and moves us
slightly further away from upstream. We'd rather not incur this cost.

Option 2 Adds hiera config that we shouldn't technically need but allows
us to retain our current code.

This PR takes options 2 and ensures the setting is present in both tests
and our running config