### PR TITLE
The vendored jenkins modules expect the `jenkins_plugins` fact

### DIFF
--- a/modules/govuk_jenkins/spec/classes/jenkins_spec.rb
+++ b/modules/govuk_jenkins/spec/classes/jenkins_spec.rb
@@ -3,6 +3,10 @@ require_relative '../../../../spec_helper'
 describe 'govuk_jenkins', :type => :class do
   let(:ssh_dir) { '/var/lib/jenkins/.ssh' }
 
+  let(:facts) {{
+    :jenkins_plugins => 'fake_plugin 1.0'
+  }}
+
   it { is_expected.to contain_class('govuk_jenkins::config') }
   it { is_expected.to contain_class('govuk_jenkins::user') }
   it { is_expected.to contain_class('govuk_jenkins::package') }


### PR DESCRIPTION
Without this fact defined the tests will fail under `strict_variables`
testing.