### PR TITLE
Point unattended_reboot to the docker host

### DIFF
--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -427,6 +427,8 @@ hosts::production::management::hosts:
       - 'apt'
   docker-management-1:
     ip: '10.2.0.80'
+    service_aliases:
+      - 'etcd'
   jumpbox-1:
     ip: '10.2.0.100'
   mirrorer-1:
@@ -521,3 +523,6 @@ mongodb::s3backup::backup::s3_bucket: 'govuk-mongodb-backup-s3-staging'
 mongodb::s3backup::backup::s3_bucket_daily: 'govuk-mongodb-backup-s3-daily-staging'
 
 trade_tariff_hostname: 'tariff-frontend-staging.cloudapps.digital'
+
+unattended_reboot::etcd_endpoints:
+ - "http://etcd.cluster:2379"


### PR DESCRIPTION
We're now running etcd under docker to avoid the complexity of another
additional machine. This change adds a host alias of `etcd.cluster` that
points to the docker host and then configures the locksmith client to
use it.