### PR TITLE
Fix setup db wrong environment error

### DIFF
--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -157,7 +157,7 @@ def contentSchemaDependency(String schemaGitCommit = 'deployed-to-production') {
  */
 def setupDb() {
   echo 'Setting up database'
-  sh('RAILS_ENV=test bundle exec rake db:drop db:create db:environment:set db:schema:load')
+  sh('RAILS_ENV=test bundle exec rake db:environment:set db:drop db:create db:schema:load')
 }
 
 /**


### PR DESCRIPTION
Jenkins throws an error if the database is created before the environment has been set.

See:

![screen shot 2017-02-03 at 16 08 28](https://cloud.githubusercontent.com/assets/5793815/22598526/a4bd2ffc-ea2b-11e6-8f37-129a87d8f5f9.png)


This has been fixed in application Jenkins files, but running a rake task that does the equivalent of this fix.

See [commit](https://github.com/alphagov/content-performance-manager/pull/61/commits/7525878448e251ccc496ef040cbb7b6a7b7e2ef3)