### PR TITLE
Add slack notifications to Copy data to Staging

### DIFF
--- a/modules/govuk_jenkins/manifests/job/copy_data_to_staging.pp
+++ b/modules/govuk_jenkins/manifests/job/copy_data_to_staging.pp
@@ -16,6 +16,10 @@ class govuk_jenkins::job::copy_data_to_staging (
   $service_description = 'Copy Data to Staging'
   $job_url = "https://deploy.${app_domain}/job/copy_data_to_staging/"
 
+  $slack_team_domain = 'govuk'
+  $slack_room = '2ndline'
+  $slack_build_server_url = "https://deploy.${app_domain}/"
+
   file { '/etc/jenkins_jobs/jobs/copy_data_to_staging.yaml':
     ensure  => present,
     content => template('govuk_jenkins/jobs/copy_data_to_staging.yaml.erb'),

--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_staging.yaml.erb
@@ -19,6 +19,16 @@
         - inject:
             properties-content: |
               PARALLEL_JOBS=2
+        - slack:
+            notify-start: false
+            notify-success: true
+            notify-aborted: true
+            notify-notbuilt: true
+            notify-unstable: false
+            notify-failure: true
+            notify-backtonormal: false
+            notify-repeatedfailure: false
+            include-test-summary: false
     scm:
       - env-sync-and-backup_Copy_Data_to_Staging
     logrotate:
@@ -73,6 +83,11 @@
             HOSTNAME=deploy.staging.publishing.service.gov.uk
             API_KEY=<%= @ci_alphagov_api_key %>
             AUTH_TOKEN=<%= @auth_token %>
+      - slack:
+          team-domain: <%= @slack_team_domain %>
+          auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN']%>
+          build-server-url: <%= @slack_build_server_url %>
+          room: <%= @slack_room %>
     wrappers:
         - ansicolor:
             colormap: xterm


### PR DESCRIPTION
This was copied from 9097731d89bb9d8720e5b4914c402900c18628bd

When live, this will notify us of the status of that job. We will still see the icinga alert, but for those not on 2nd line it could be useful to see it in slack too.