### PR TITLE
[Don't merge] Revert removal of homepage no-cache rules

### DIFF
--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -115,6 +115,7 @@ govuk::apps::email_alert_api::enable_procfile_worker: false
 govuk::apps::email_alert_service::rabbitmq_hosts: ['localhost']
 govuk::apps::event_store::enabled: true
 govuk::apps::event_store::mongodb_servers: ['localhost']
+govuk::apps::frontend::enable_homepage_nocache_location: false
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
 govuk::apps::hmrc_manuals_api::enable_procfile_worker: false
 govuk::apps::government_frontend::enable_running_in_draft_mode::content_store: 'http://draft-content-store.dev.gov.uk'

--- a/modules/govuk/manifests/apps/frontend.pp
+++ b/modules/govuk/manifests/apps/frontend.pp
@@ -8,6 +8,10 @@
 #   The port that the app is served on.
 #   Default: 3005
 #
+# [*enable_homepage_nocache_location*]
+#   Adds nginx configuration to never cache the homepage/no-cache location.
+#   Default: true
+#
 # [*vhost_protected*]
 #   Should this vhost be protected with HTTP Basic auth?
 #   Default: undef
@@ -24,11 +28,24 @@
 #
 class govuk::apps::frontend(
   $port = '3005',
+  $enable_homepage_nocache_location = true,
   $vhost_protected = false,
   $publishing_api_bearer_token = undef,
   $nagios_memory_warning = undef,
   $nagios_memory_critical = undef,
 ) {
+
+  validate_bool($enable_homepage_nocache_location)
+
+  if ($enable_homepage_nocache_location) {
+    $nginx_extra_config = '
+  location ^~ /frontend/homepage/no-cache/ {
+    expires epoch;
+  }
+'
+  } else {
+    $nginx_extra_config = ''
+  }
 
   govuk::app { 'frontend':
     app_type               => 'rack',


### PR DESCRIPTION
Revert "Revert no-cache rule for front-end homepage"
This reverts commit 9213f54c855b753931239a3f0fa87b237bb65db8.

We're running the Javascript detection experiment again. This reinstates
no caching rules for the tracking images.

Merge required prior to https://github.com/alphagov/frontend/pull/1115.