### PR TITLE
Update repo configuration for Xenial Builds

### DIFF
--- a/hieradata/common.xenial.yaml
+++ b/hieradata/common.xenial.yaml
@@ -2,8 +2,14 @@
 
 collectd::package::collectd_version: '5.5.1-1build2'
 
+govuk_ppa::repo_ensure: 'absent'
+
+govuk_unattended_reboot::manage_repo_class: true
+
 nodejs::version: '4.2.6~dfsg-1ubuntu4.1'
 
 puppet::package::facter_version: '2.4.6-1'
 puppet::package::hiera_version: '2.0.0-2'
 puppet::package::puppet_version: '3.8.5-2'
+
+statsd::manage_repo_class: true

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -110,6 +110,10 @@ apt::apt_update_frequency: 'daily'
 apt::purge_preferences_d: true
 apt::purge_sources_list: true
 apt::purge_sources_list_d: true
+apt::purge:
+  preferences.d: true
+  sources.list: true
+  sources.list.d: true
 apt::sources:
   ubuntu:
     location: 'http://gb.archive.ubuntu.com/ubuntu/'
@@ -1426,6 +1430,9 @@ sidekiq_host: 'redis-1.backend'
 sidekiq_port: '6379'
 
 ssh::config::allow_users_enable: true
+
+statsd::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_unattended_reboot::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 trade_tariff_hostname: 'tariff-frontend-dev.cloudapps.digital'
 

--- a/modules/govuk_ppa/manifests/init.pp
+++ b/modules/govuk_ppa/manifests/init.pp
@@ -11,6 +11,10 @@
 #   to present a different snapshot to an environment, e.g. `integration`
 #   Default: `production`
 #
+# [*repo_ensure*]
+#   Apt resource ensure attribute
+#   Default: `present`
+#
 # [*use_mirror*]
 #   Whether to use our snapshotted mirror of the PPA. Things may break if
 #   you disable this, because package versions may have changed and PPAs
@@ -20,18 +24,24 @@
 class govuk_ppa (
   $apt_mirror_hostname = undef,
   $path = 'production',
+  $repo_ensure = 'present',
   $use_mirror = true,
 ) {
   include ::apt
 
+  validate_re($repo_ensure, '^(present|absent)$', 'Invalid repo_ensure value')
   validate_bool($use_mirror)
   if $use_mirror {
     apt::source { 'govuk-ppa':
+      ensure       => $repo_ensure,
       location     => "http://${apt_mirror_hostname}/govuk/ppa/${path}",
       architecture => $::architecture,
       key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
     }
   } else {
-    apt::ppa { 'ppa:gds/govuk': }
+    apt::ppa { 'ppa:gds/govuk':
+      ensure => $repo_ensure,
+    }
   }
+
 }

--- a/modules/govuk_unattended_reboot/manifests/init.pp
+++ b/modules/govuk_unattended_reboot/manifests/init.pp
@@ -9,6 +9,10 @@
 #   Whether to enable unattended reboots.
 #   Default: false
 #
+# [*manage_repo_class*]
+#   Whether to use a separate repository to install Locksmith
+#   Default: false (use 'govuk_ppa' repository)
+#
 # [*monitoring_basic_auth*]
 #   A hash containing a `username` and a `password` to access monitoring
 #   which is protected by basic authentication.
@@ -22,10 +26,12 @@
 #
 class govuk_unattended_reboot (
   $enabled = false,
+  $manage_repo_class = false,
   $monitoring_basic_auth = {},
 ) {
 
   validate_bool($enabled)
+  validate_bool($manage_repo_class)
   validate_hash($monitoring_basic_auth)
 
   if ($enabled) {
@@ -41,6 +47,10 @@ class govuk_unattended_reboot (
 
   $node_class_search_phrase = regsubst($::govuk_node_class, '_', '-')
   $icinga_url = "https://alert.cluster/cgi-bin/icinga/status.cgi?search_string=%5E${node_class_search_phrase}-[0-9]&allunhandledproblems&jsonoutput"
+
+  if $manage_repo_class {
+    include govuk_unattended_reboot::repo
+  }
 
   file { [ $config_directory, $check_scripts_directory ]:
     ensure => $directory_ensure,

--- a/modules/govuk_unattended_reboot/manifests/repo.pp
+++ b/modules/govuk_unattended_reboot/manifests/repo.pp
@@ -1,0 +1,19 @@
+# == Class: govuk_unattended_reboot::repo
+#
+# Use our own repo for locksmith package
+#
+# === Parameters
+#
+# [*apt_mirror_hostname*]
+#   Hostname to use for the APT mirror.
+#
+class govuk_unattended_reboot::repo(
+  $apt_mirror_hostname = undef,
+) {
+  apt::source { 'locksmithctl':
+    location     => "http://${apt_mirror_hostname}/locksmithctl",
+    release      => $::lsbdistcodename,
+    architecture => $::architecture,
+    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+  }
+}

--- a/modules/statsd/manifests/init.pp
+++ b/modules/statsd/manifests/init.pp
@@ -2,11 +2,29 @@
 #
 # This class installs and sets-up statsd
 #
+# === Parameters
+#
+# [*graphite_hostname*]
+#   Graphite hostname
+#
+# [*manage_repo_class*]
+#   Whether to use a separate repository to install Statsd
+#   Default: false (use 'govuk_ppa' repository)
+#
 class statsd(
-  $graphite_hostname
+  $graphite_hostname,
+  $manage_repo_class = false,
 ) {
-  include govuk_ppa
+
+  validate_bool($manage_repo_class)
+
   include nodejs
+
+  if $manage_repo_class {
+    include statsd::repo
+  } else {
+    include govuk_ppa
+  }
 
   package { 'statsd':
     ensure  => 'latest',

--- a/modules/statsd/manifests/repo.pp
+++ b/modules/statsd/manifests/repo.pp
@@ -1,0 +1,19 @@
+# == Class: statsd::repo
+#
+# Use our own Statsd repo
+#
+# === Parameters
+#
+# [*apt_mirror_hostname*]
+#   Hostname to use for the APT mirror.
+#
+class statsd::repo(
+  $apt_mirror_hostname = undef,
+) {
+  apt::source { 'statsd':
+    location     => "http://${apt_mirror_hostname}/statsd",
+    release      => $::lsbdistcodename,
+    architecture => $::architecture,
+    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+  }
+}


### PR DESCRIPTION
Repository changes for Xenial builds:
- Ensure Apt source lists are purged by Puppet by updating the Hiera key
introduced in puppetlabs/apt v2.0.0:
https://forge.puppet.com/puppetlabs/apt/changelog#apt
- 'govuk_ppa' doesn't need to be installed
- Statsd uses own repository, instead of 'govuk_ppa'
- Locksmith uses own repository, instead of 'govuk_ppa'