### PR TITLE
Set the repo location for govuk-delivery

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -48,7 +48,9 @@ deployable_applications: &deployable_applications
     branches_to_exclude: ['release', 'deployed-to-integration', 'deployed-to-staging']
   frontend: {}
   government-frontend: {}
-  govuk-delivery: {}
+  govuk-delivery:
+    repository: 'govuk_delivery'
+    source: 'github-enterprise'
   govuk-cdn-logs-monitor: {}
   govuk_content_api: {}
   govuk-content-schemas: {}


### PR DESCRIPTION
This should make the CI job work properly, and probably also make the app
deployable from the right place.

This is part of getting govuk-delivery up to date so that we can work on it (in CI, dev and integration): https://trello.com/c/LVqjfAwa/94-get-govuk-delivery-working-on-dev-vm-and-ci