### PR TITLE
Link inode alerts to the correct documentation

### DIFF
--- a/modules/govuk_mount/manifests/init.pp
+++ b/modules/govuk_mount/manifests/init.pp
@@ -67,5 +67,6 @@ define govuk_mount(
     service_description => "low available disk inodes on ${mountpoint}",
     use                 => 'govuk_high_priority',
     host_name           => $::fqdn,
+    notes_url           => monitoring_docs_url(low-available-disk-inodes),
   }
 }

--- a/modules/icinga/manifests/client/checks.pp
+++ b/modules/icinga/manifests/client/checks.pp
@@ -59,7 +59,7 @@ class icinga::client::checks (
     service_description => 'low available disk inodes on root',
     use                 => 'govuk_high_priority',
     host_name           => $::fqdn,
-    notes_url           => monitoring_docs_url(low-available-disk-space),
+    notes_url           => monitoring_docs_url(low-available-disk-inodes),
   }
 
   @@icinga::check { "check_boot_disk_space_${::hostname}":


### PR DESCRIPTION
Low inode availability is directly linkable in the opsmanual so we
should link to it directly.