### PR TITLE
Add frontend to draft-frontend

### DIFF
--- a/hieradata/class/draft_frontend.yaml
+++ b/hieradata/class/draft_frontend.yaml
@@ -3,6 +3,7 @@
 govuk::apps::collections::vhost: 'draft-collections'
 govuk::apps::contacts_frontend::vhost: 'draft-contacts-frontend'
 govuk::apps::email_alert_frontend::vhost: 'draft-email-alert-frontend'
+govuk::apps::frontend::vhost: 'draft-frontend'
 govuk::apps::government_frontend::vhost: 'draft-government-frontend'
 govuk::apps::manuals_frontend::vhost: 'draft-manuals-frontend'
 govuk::apps::multipage_frontend::vhost: 'draft-multipage-frontend'
@@ -27,6 +28,7 @@ govuk::node::s_base::apps:
  - collections
  - contacts_frontend
  - email_alert_frontend
+ - frontend
  - government_frontend
  - manuals_frontend
  - multipage_frontend

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1079,6 +1079,7 @@ hosts::production::frontend::app_hostnames:
   - 'draft-collections'
   - 'draft-contacts-frontend'
   - 'draft-email-alert-frontend'
+  - 'draft-frontend'
   - 'draft-government-frontend'
   - 'draft-manuals-frontend'
   - 'draft-multipage-frontend'

--- a/modules/govuk/manifests/apps/frontend.pp
+++ b/modules/govuk/manifests/apps/frontend.pp
@@ -4,6 +4,10 @@
 #
 # === Parameters
 #
+# [*vhost*]
+#   Virtual host used by the application.
+#   Default: 'frontend'
+#
 # [*port*]
 #   The port that the app is served on.
 #   Default: 3005
@@ -23,6 +27,7 @@
 #   Memory use at which Nagios should generate a critical alert.
 #
 class govuk::apps::frontend(
+  $vhost = 'frontend',
   $port = '3005',
   $vhost_protected = false,
   $publishing_api_bearer_token = undef,
@@ -41,6 +46,7 @@ class govuk::apps::frontend(
     asset_pipeline_prefix  => 'frontend',
     nagios_memory_warning  => $nagios_memory_warning,
     nagios_memory_critical => $nagios_memory_critical,
+    vhost                  => $vhost,
   }
 
   govuk::app::envvar { "${title}-PUBLISHING_API_BEARER_TOKEN":

--- a/modules/govuk/manifests/node/s_frontend_lb.pp
+++ b/modules/govuk/manifests/node/s_frontend_lb.pp
@@ -19,6 +19,7 @@ class govuk::node::s_frontend_lb (
       'draft-collections',
       'draft-contacts-frontend',
       'draft-email-alert-frontend',
+      'draft-frontend',
       'draft-government-frontend',
       'draft-manuals-frontend',
       'draft-multipage-frontend',


### PR DESCRIPTION
As part of migrating frontend to use the content store and the draft content store we need to deploy Frontend to draft-frontend as well.

https://trello.com/c/TOdNOEDQ/627-migrate-help-page-use-draft-stack-for-preview-2-3-3