### PR TITLE
Add MySQL on ramdisk

### DIFF
--- a/modules/govuk_ci/manifests/agent/mysql.pp
+++ b/modules/govuk_ci/manifests/agent/mysql.pp
@@ -107,12 +107,14 @@ class govuk_ci::agent::mysql {
   mysql_user { 'whitehall@%':
     ensure        => 'present',
     password_hash => mysql_password('whitehall'),
+    require       => Class['::govuk_mysql::server'],
   }
 
   mysql_grant { 'whitehall@%whitehall_%.*':
     user       => 'whitehall@%',
     table      => 'whitehall_%.*',
     privileges => 'ALL',
+    require    => Class['::govuk_mysql::server'],
   }
 
   file { '/etc/mysql/conf.d/custom.cnf':


### PR DESCRIPTION
We had a performance issue with running tests with MySQL in that they were taking a substantially long time to run, and it seems to be pegged by the disk.

To stop blocking developers do their work, and because we don't care about the MySQL data in CI, a solution was to devised to run MySQL in ramdisk.

This Puppet requires an initial bootstrap in that we'll have to remove the MySQL data, and then run Puppet, but then after that it'll mount the directory on tmpfs, and then when Puppet runs the ::mysql module will create the data structure.

On boot I have added a cronjob to ensure that Puppet runs immediately so that there is a working MySQL directory ASAP.