### PR TITLE
Notify slack when smokey is back to normal

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/smokey.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/smokey.yaml.erb
@@ -21,7 +21,7 @@
           notify-notbuilt: true
           notify-unstable: false
           notify-failure: true
-          notify-backtonormal: false
+          notify-backtonormal: true
           notify-repeatedfailure: false
           include-test-summary: false
     publishers:


### PR DESCRIPTION
I think it's useful to know when Smokey is green again. This change
makes sure we get a sack notification when that happens.