### PR TITLE
Fix dependency issue

### DIFF
--- a/modules/govuk_ci/manifests/agent/mysql.pp
+++ b/modules/govuk_ci/manifests/agent/mysql.pp
@@ -82,7 +82,6 @@ class govuk_ci::agent::mysql {
   file { '/etc/mysql/conf.d/custom.cnf':
     ensure  => present,
     source  => 'puppet:///modules/govuk_ci/mysql_custom_config',
-    notify  => Class['::mysql::server::service'],
     require => Class['::govuk_mysql::server'],
   }
 }


### PR DESCRIPTION
This change caused a dependency cycle:

```
(Anchor[govuk_mysql::server::end] => Class[Govuk_mysql::Server] =>
File[/etc/mysql/conf.d/custom.cnf] => Class[Mysql::Server::Service] =>
Service[mysqld] => Class[Mysql::Server::Service] =>
Class[Mysql::Server::Root_password] =>
Class[Mysql::Server::Root_password] => Class[Mysql::Server::Providers]
=> Class[Mysql::Server::Providers] => Anchor[mysql::server::end] =>
Class[Mysql::Server] => Anchor[govuk_mysql::server::end])
```

MySQL might need a manual restart the first time to apply these changes.