### PR TITLE
Exclude deployed to int branch for Navigation Helpers

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -55,6 +55,8 @@ deployable_applications: &deployable_applications
   govuk_content_api: {}
   govuk-content-schemas: {}
   govuk_crawler_worker: {}
+  govuk_navigation_helpers:
+    branches_to_exclude: ['release', 'deployed-to-integration', 'deployed-to-staging']
   govuk_need_api: {}
   hmrc-manuals-api: {}
   imminence: {}


### PR DESCRIPTION
This change is part of migrating `govuk_navigation_helpers` to Jenkins 2. The corresponding `Jenkinsfile` change is here: https://github.com/alphagov/govuk_navigation_helpers/pull/20