### PR TITLE
Do not set Nginx package version in Xenial

### DIFF
--- a/hieradata/common.xenial.yaml
+++ b/hieradata/common.xenial.yaml
@@ -6,6 +6,8 @@ govuk_ppa::repo_ensure: 'absent'
 
 govuk_unattended_reboot::manage_repo_class: true
 
+nginx::package::version: 'present'
+
 nodejs::version: '4.2.6~dfsg-1ubuntu4.1'
 
 puppet::package::facter_version: '2.4.6-1'


### PR DESCRIPTION
Trusty and Precise machines are forcing Nginx version in the common yaml file. For
Xenial we can initially set it to 'present' to use the upstream version (1.10 at this
point)