### PR TITLE
Add AB Testing Gem to Pipeline

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -627,6 +627,7 @@ govuk_ci::master::pipeline_jobs:
   govuk-app-deployment: {}
   govuk-diff-pages: {}
   govuk_admin_template: {}
+  govuk_ab_testing: {}
   govuk_bad_link_finder: {}
   govuk_client_url-arbiter: {}
   govuk_content_models: {}


### PR DESCRIPTION
This change is to add the [AB Testing Gem](https://github.com/alphagov/govuk_ab_testing) to our Jenkins build pipeline.

Trello: https://trello.com/c/tclzOZ7Z/382-release-govuk-ab-testing-to-rubygems