### PR TITLE
Remove hstore extension from email-alert-api's db definition

### DIFF
--- a/modules/govuk/manifests/apps/email_alert_api/db.pp
+++ b/modules/govuk/manifests/apps/email_alert_api/db.pp
@@ -19,7 +19,6 @@ class govuk::apps::email_alert_api::db (
   govuk_postgresql::db { 'email-alert-api_production':
     user                    => 'email-alert-api',
     password                => $password,
-    extensions              => ['hstore'],
     allow_auth_from_backend => true,
     backend_ip_range        => $backend_ip_range,
   }


### PR DESCRIPTION
We've finished migrating the app to use json columns instead of hstore to
store the main matching criteria for email subscription lists.

This change isn't enough to actually disable the extension in the database (we
don't support `ensure => absent` in our puppet module for this) so we'll devops
it in each environment (`DROP EXTENSION hstore;`).

We've done similar things before: 3b8fc618febac824edf24aae719d5c2709ce8434

Part of https://trello.com/c/a2KUeoSD/69-finish-or-revert-email-alert-api-migration