### PR TITLE
Allow Sass linting dirs to be passed as args

### DIFF
--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -124,9 +124,9 @@ def rubyLinter(String dirs = 'app spec lib') {
 /**
  * Runs the SASS linter
  */
-def sassLinter() {
+def sassLinter(String dirs = 'app/assets/stylesheets') {
   echo 'Running SASS linter'
-  sh('bundle exec govuk-lint-sass app/assets/stylesheets')
+  sh("bundle exec govuk-lint-sass ${dirs}")
 }
 
 /**


### PR DESCRIPTION
In the static repo we want to lint a different directory to `app/assets/stylesheets`, so making the directory an argument with the current default specified as a default value will allow us to use the provided function whilst overriding the directories we want to lint.