### PR TITLE
Monitor api_mongo disk time over 7 minute windows

### DIFF
--- a/hieradata/class/api_mongo.yaml
+++ b/hieradata/class/api_mongo.yaml
@@ -37,3 +37,5 @@ mongodb::server::replicaset_members:
   'api-mongo-4':
     hidden: true
     priority: 0
+
+icinga::client::checks::disk_time_window_minutes: 7

--- a/modules/icinga/manifests/client/checks.pp
+++ b/modules/icinga/manifests/client/checks.pp
@@ -9,6 +9,10 @@
 # [*disk_time_critical*]
 #   The disk time in milliseconds that will cause a critical state.
 #
+# [*disk_time_window_minutes*]
+#   The duration in minutes to include in the moving average window
+#   for disk time checks.
+#
 class icinga::client::checks (
   $disk_time_warn = 100,
   $disk_time_critical = 200,


### PR DESCRIPTION
api-mongo-2 (currently, may change?) does large backup jobs every 5
minutes, which show as large spikes on disk time and frequently trigger
our alerting. Taking the 50th percentile over a 7 minute window should
smooth the spikes out enough to not trigger the alert, but still warn
us if there’s a more consistent problem.

Before:
![graphite publishing service gov](https://cloud.githubusercontent.com/assets/18276/22777083/0646cde6-eeaa-11e6-9a02-69ce5b5028bb.png)

After:
![graphite publishing service gov-1](https://cloud.githubusercontent.com/assets/18276/22777090/0a18ed8c-eeaa-11e6-95ee-4ac52769a5d2.png)
