### PR TITLE
Update ‘Deploy Puppet’ description

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_puppet.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_puppet.yaml.erb
@@ -11,7 +11,15 @@
     name: Deploy_Puppet
     display-name: Deploy Puppet
     project-type: freestyle
-    description: "<a href='http://www.flickr.com/photos/fatty/9158066939/'><img src='https://farm3.staticflickr.com/2835/9158066939_374360ed56_n.jpg'></a><p>This job deploys the puppet release branch by default. To promote something into the release branch so it can be deployed to <%= @environment -%>, see the instructions on the <a href='https://ci.dev.publishing.service.gov.uk/job/Puppet_Promote_To_Release_Ready/'>Puppet_Promote_To_Release_Ready</a> job.</p>"
+    description: |
+        <a href='http://www.flickr.com/photos/fatty/9158066939/'>
+          <img src='https://farm3.staticflickr.com/2835/9158066939_374360ed56_n.jpg'>
+        </a>
+        <p style="font-size:18px">
+          <strong>⚠️ You may need to wait up to 30 minutes before your changes will be reflected.</strong><br>
+          This job only deploys the latest Puppet code, it doesn't trigger a Puppet run.<br>
+          For more information, refer to the <a href="https://github.gds/pages/gds/opsmanual/infrastructure/howto/deploy-puppet.html#convergence">'Deploying Puppet' page in the Ops Manual</a>.
+        </p>
     <%- if @auth_token -%>
     auth-token: <%= @auth_token %>
     <%- end -%>


### PR DESCRIPTION
Remove outdated link to ‘Promote to Release’ job on the old CI instance, and add a comment about convergence.