### PR TITLE
Restart Jenkins for new pipeline jobs

### DIFF
--- a/modules/govuk_ci/manifests/job.pp
+++ b/modules/govuk_ci/manifests/job.pp
@@ -50,6 +50,7 @@ define govuk_ci::job (
     group   => 'jenkins',
     content => template('govuk_ci/application_build_job.xml.erb'),
     require => File[$application_directory],
+    notify  => Class['Govuk_jenkins::Safe_restart'],
   }
 
 }


### PR DESCRIPTION
A new job was added to the list of deployable apps, but this didn't appear. A restart was required, so add the notify so this is automated in the future.