### PR TITLE
Add ci.integration.publishing.service.gov.uk alias

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1028,6 +1028,8 @@ hosts::production::backend::app_hostnames:
 hosts::production::ci::hosts:
   ci-master-1:
     ip: '10.1.6.10'
+    legacy_aliases:
+    - "ci.%{hiera('app_domain')}"
   ci-agent-1:
     ip: '10.1.6.21'
   ci-agent-2:


### PR DESCRIPTION
Deploy jobs from the Integration Jenkins pull artefacts from the CI machine, but currently use the FQDN. As this currently resolves a public address, NAT routing won't allow this behaviour, so add an alias so machines can speak to it internally using this address.