### PR TITLE
Ports to strings

### DIFF
--- a/modules/govuk/manifests/app/envvar/redis.pp
+++ b/modules/govuk/manifests/app/envvar/redis.pp
@@ -22,7 +22,7 @@ define govuk::app::envvar::redis (
   $app    = undef,
   $prefix = undef,
   $host   = '127.0.0.1',
-  $port   = 6379,
+  $port   = '6379',
 ) {
 
   Govuk::App::Envvar {

--- a/modules/govuk/spec/defines/govuk__app__config_spec.rb
+++ b/modules/govuk/spec/defines/govuk__app__config_spec.rb
@@ -15,7 +15,7 @@ describe 'govuk::app::config', :type => :define do
     context 'with good params' do
       let(:params) do
         {
-          :port => 8000,
+          :port => '8000',
           :app_type => 'rack',
           :domain => 'foo.bar.baz',
           :vhost_full => 'giraffe.foo.bar.baz',
@@ -48,7 +48,7 @@ describe 'govuk::app::config', :type => :define do
     context 'with aliases' do
       let(:params) do
         {
-          :port => 8000,
+          :port => '8000',
           :app_type => 'rack',
           :vhost_aliases => ['foo','bar'],
           :domain => 'example.com',
@@ -62,7 +62,7 @@ describe 'govuk::app::config', :type => :define do
     context 'without vhost' do
       let(:params) do
         {
-          :port => 8000,
+          :port => '8000',
           :app_type => 'rack',
           :domain => 'example.com',
           :vhost_full => 'giraffe.example.com',
@@ -76,25 +76,25 @@ describe 'govuk::app::config', :type => :define do
     context 'with unicorn_herder_timeout and app_type rack' do
       let(:params) do
         {
-          :port => 8000,
+          :port => '8000',
           :app_type => 'rack',
           :domain => 'example.com',
           :vhost_full => 'giraffe.example.com',
-          :unicorn_herder_timeout => 60
+          :unicorn_herder_timeout => '60'
         }
       end
 
       it do
         is_expected.to contain_govuk__app__envvar('giraffe-UNICORN_HERDER_TIMEOUT').with(
           :varname => 'UNICORN_HERDER_TIMEOUT',
-          :value   => 60
+          :value   => '60'
         )
       end
     end
 
     context 'with app_type => bare, command => ./launch_zoo' do
       let(:params) {{
-        :port => 123,
+        :port => '123',
         :app_type => 'bare',
         :domain => 'example.com',
         :vhost_full => 'giraffe.example.com',
@@ -118,7 +118,7 @@ describe 'govuk::app::config', :type => :define do
     context 'with asset_pipeline => true' do
       let(:params) do
         {
-          :port => 8000,
+          :port => '8000',
           :app_type => 'rack',
           :vhost_full => 'giraffe.example.com',
           :domain => 'example.com',
@@ -134,7 +134,7 @@ describe 'govuk::app::config', :type => :define do
     context 'with asset_pipeline => true, asset_pipeline_prefix => "giraffe_assets"' do
       let(:params) do
         {
-          :port => 8000,
+          :port => '8000',
           :app_type => 'rack',
           :vhost_full => 'giraffe.example.com',
           :domain => 'example.com',
@@ -151,7 +151,7 @@ describe 'govuk::app::config', :type => :define do
     context 'with asset_pipeline enabled and nginx_extra_config' do
       let(:params) do
         {
-          :port => 8000,
+          :port => '8000',
           :app_type => 'rack',
           :vhost_full => 'giraffe.example.com',
           :domain => 'example.com',
@@ -167,7 +167,7 @@ describe 'govuk::app::config', :type => :define do
 
     context 'when govuk_app_enable_services is false' do
       let(:params) {{
-        :port => 8000,
+        :port => '8000',
         :app_type => 'rack',
         :domain => 'foo.bar.baz',
         :vhost_full => 'giraffe.foo.bar.baz',
@@ -188,7 +188,7 @@ describe 'govuk::app::config', :type => :define do
     context 'with good params' do
       let(:params) do
         {
-          :port => 8000,
+          :port => '8000',
           :app_type => 'rack',
           :domain => 'foo.bar.baz',
           :vhost_full => 'big.giraffe.foo.bar.baz',
@@ -209,7 +209,7 @@ describe 'govuk::app::config', :type => :define do
   context 'when setting memory alert thresholds' do
     let(:title) { 'giraffe' }
     let(:default_params) {{
-      :port => 8000,
+      :port => '8000',
       :app_type => 'rack',
       :domain => 'foo.bar.baz',
       :vhost_full => 'giraffe.foo.bar.baz',

--- a/modules/govuk/spec/defines/govuk__app__envvar__redis_spec.rb
+++ b/modules/govuk/spec/defines/govuk__app__envvar__redis_spec.rb
@@ -30,7 +30,7 @@ describe 'govuk::app::envvar::redis', :type => :define do
 
   context 'with some good parameters' do
     let(:host) { 'redis.backend' }
-    let(:port) { 1234 }
+    let(:port) { '1234' }
     let(:params) { { host: host, port: port } }
 
     it 'sets the Redis host' do

--- a/modules/govuk/spec/defines/govuk__app__spec.rb
+++ b/modules/govuk/spec/defines/govuk__app__spec.rb
@@ -14,7 +14,7 @@ describe 'govuk::app', :type => :define do
   context 'with good params' do
     let(:params) do
       {
-        :port => 8000,
+        :port => '8000',
         :app_type => 'rack',
       }
     end
@@ -49,7 +49,7 @@ describe 'govuk::app', :type => :define do
     let(:params) do
       {
         :app_type => 'rack',
-        :port => 8000,
+        :port => '8000',
         :health_check_path => '/healthcheck',
         :expose_health_check => false,
       }
@@ -113,7 +113,7 @@ describe 'govuk::app', :type => :define do
   describe "logging" do
     let(:params) {{
       :app_type => 'rack',
-      :port => 8000,
+      :port => '8000',
     }}
 
     context "a 12-factor app" do


### PR DESCRIPTION
Convert numeric ports to strings to allow tests to pass on puppet 4. This is required as `envvar` uses validate_string on the value passed in.