### PR TITLE
Remove unicode character from description

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_puppet.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_puppet.yaml.erb
@@ -16,7 +16,7 @@
           <img src='https://farm3.staticflickr.com/2835/9158066939_374360ed56_n.jpg'>
         </a>
         <p style="font-size:18px">
-          <strong>⚠️ You may need to wait up to 30 minutes before your changes will be reflected.</strong><br>
+          <strong>You may need to wait up to 30 minutes before your changes will be reflected.</strong><br>
           This job only deploys the latest Puppet code, it doesn't trigger a Puppet run.<br>
           For more information, refer to the <a href="https://github.gds/pages/gds/opsmanual/infrastructure/howto/deploy-puppet.html#convergence">'Deploying Puppet' page in the Ops Manual</a>.
         </p>


### PR DESCRIPTION
Jenkins Job builder doesn't like the unicode:

`UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 295: ordinal not in range(128)`

/cc @36degrees 