### PR TITLE
Disable Puppet service in Xenial

### DIFF
--- a/modules/puppet/manifests/init.pp
+++ b/modules/puppet/manifests/init.pp
@@ -67,10 +67,18 @@ class puppet (
     require => File[$lock_dir],
   }
 
-  service { 'puppet': # we're using cron, so we don't want the daemonized puppet agent
-    ensure   => stopped,
-    provider => base,
-    pattern  => '/usr/bin/puppet agent$',
-    require  => Class['puppet::package'],
+  if $::lsbdistcodename == 'xenial' {
+    service { 'puppet':
+      ensure  => stopped,
+      enable  => false,
+      require => Class['puppet::package'],
+    }
+  } else {
+    service { 'puppet': # we're using cron, so we don't want the daemonized puppet agent
+      ensure   => stopped,
+      provider => base,
+      pattern  => '/usr/bin/puppet agent$',
+      require  => Class['puppet::package'],
+    }
   }
 }


### PR DESCRIPTION
The Puppet agent service needs to be disabled because we run this process via cron
job. Trusty doesn't start the Puppet service by default (the Upstart service is enabled,
but the daemon options in /etc/default/puppet prevent the service from starting), but
Xenial enables the service by default.