### PR TITLE
Replicate mirrors to S3

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -41,6 +41,9 @@ govuk::deploy::setup::ssh_keys:
 govuk_cdnlogs::monitoring_enabled: false
 
 govuk_crawler::seed_enable: true
+govuk_crawler::sync_enable: true
+govuk_crawler::targets:
+  - 's3://govuk-mirror-integration'
 
 govuk_elasticsearch::dump::run_es_dump_hour: '9'
 

--- a/modules/govuk_crawler/manifests/config.pp
+++ b/modules/govuk_crawler/manifests/config.pp
@@ -1,0 +1,40 @@
+# == Class: govuk_crawler::config
+#
+# Class for configuring the AWS keys used to upload crawler results to S3.
+#
+# [*aws_access_key*] access key for AWS
+# [*aws_secret_key*] secret for chosen AWS key
+#
+# Will be set using environment variables, see:
+# http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-environment
+#
+
+class govuk_crawler::config (
+  $aws_access_key = undef,
+  $aws_secret_key = undef,
+) {
+  $env_name = 's3_sync_mirror'
+
+  file { ["/etc/govuk/${env_name}", "/etc/govuk/${env_name}/env.d"]:
+    ensure  => 'directory',
+    purge   => true,
+    recurse => true,
+    force   => true,
+    mode    => '0755',
+  }
+
+  File {
+    owner   => $govuk_crawler::crawler_user,
+    group   => $govuk_crawler::crawler_user,
+    mode    => '0600',
+    ensure  => present,
+  }
+
+  file { "/etc/govuk/${env_name}/env.d/AWS_SECRET_ACCESS_KEY":
+    content => $aws_secret_key,
+  }
+
+  file { "/etc/govuk/${env_name}/env.d/AWS_ACCESS_KEY_ID":
+    content => $aws_access_key,
+  }
+}

--- a/modules/govuk_crawler/manifests/init.pp
+++ b/modules/govuk_crawler/manifests/init.pp
@@ -79,6 +79,8 @@ class govuk_crawler(
   $sync_enable = false,
   $targets = [],
 ) {
+  include govuk_crawler::config
+
   validate_array($targets)
   validate_hash($ssh_keys)
 
@@ -125,6 +127,12 @@ class govuk_crawler(
   package { 'govuk_seed_crawler':
         ensure   => '2.0.0',
         provider => system_gem,
+  }
+
+  # Needed to copy to AWS S3
+  package { 'awscli':
+        ensure   => present,
+        provider => pip,
   }
 
   $sync_service_desc = 'Mirror sync'
@@ -191,7 +199,7 @@ class govuk_crawler(
     minute      => '0',
     environment => 'MAILTO=""',
     command     => "/usr/bin/setlock -n ${sync_lock_path} ${sync_script_path}",
-    require     => [File[$sync_error_dir], File[$sync_script_path], File[$sync_lock_path], Package['daemontools']],
+    require     => [File[$sync_error_dir], File[$sync_script_path], File[$sync_lock_path], Package['daemontools'], Package['awscli'], Class['govuk_crawler::config']],
   }
 
   file { $sync_error_dir:

--- a/modules/govuk_crawler/templates/govuk_sync_mirror.erb
+++ b/modules/govuk_crawler/templates/govuk_sync_mirror.erb
@@ -51,7 +51,14 @@ EXITCODE=0
 for TARGET in ${TARGETS}; do
   log "user.info" "Started uploading to ${TARGET}"
 
-  if rsync -az --exclude 'lost+found' ${MIRROR_ROOT}/. ${TARGET}:/srv/mirror_data; then
+  # Toggle the command: whether we will use rsync of the s3 sync.
+  if [[ $TARGET = s3://* ]]; then
+    CMD="govuk_setenv s3_sync_mirror aws s3 sync ${MIRROR_ROOT}/. ${TARGET}"
+  else
+    CMD="rsync -az --exclude 'lost+found' ${MIRROR_ROOT}/. ${TARGET}:/srv/mirror_data"
+  fi
+
+  if eval $CMD; then
     log "user.info" "Finished uploading to mirror ${TARGET}"
   else
     EXITCODE=1


### PR DESCRIPTION
We want to serve mirrors from S3 rather than from VMs.

This commit adds S3 as a target for the cron job that copies to our
mirrors. To achieve this the AWS secret & access keys are set by
`govuk_setenv` and the copy itself done using the AWS command line
tool.

DO NOT DEPLOY WITHOUT https://github.com/alphagov/govuk-terraform-provisioning/pull/94