### PR TITLE
Allow cross-origin requests for search & content-store APIs

### DIFF
--- a/modules/govuk/templates/publicapi_nginx_extra_config.erb
+++ b/modules/govuk/templates/publicapi_nginx_extra_config.erb
@@ -29,6 +29,7 @@
 
     rewrite ^/api/search.json(.*) /search.json$1 break;
 
+    add_header Access-Control-Allow-Origin *;
     proxy_set_header Host <%= @rummager_api %>;
     proxy_set_header API-PREFIX api;
     proxy_pass <%= @privateapi_protocol %>://<%= @rummager_api %>;
@@ -41,6 +42,7 @@
 
     expires 30m;
 
+    add_header Access-Control-Allow-Origin *;
     proxy_set_header Host <%= @content_store_api %>;
     proxy_pass <%= @privateapi_protocol %>://<%= @content_store_api %>;
   }


### PR DESCRIPTION
This allows cross origin requests for two of our public apis, rummager and content-store.

The reason I'd like to allow this is that this will enable us to experiment with API preview tools like Swagger. Preview tools like Swagger UI (http://petstore.swagger.io/ for example) are served from a different domain.

Since the APIs only respond to GET requests I think there is no security risk. But to be sure, I'd like the opinion of @alexmuller, @timblair, @boffbowsh or @tomnatt.

Precedent in this PR: https://github.com/alphagov/calendars/pull/114