### PR TITLE
Mentions default password for Vagrant

### DIFF
--- a/development-vm/README.md
+++ b/development-vm/README.md
@@ -93,6 +93,9 @@ and that's it. Now you can get to work!
 
 * To re-run Puppet, just SSH into your VM and run `govuk_puppet`.
 
+* If for example you want to install ZSH, your default root password is `vagrant`.
+  (https://www.vagrantup.com/docs/boxes/base.html#root-password-quot-vagrant-quot)
+
 ## Troubleshooting
 
 ### Errors loading the Vagrantfile


### PR DESCRIPTION
After setting up my VM for the first time it took me a while to figure out the default password (which is ‘vagrant’).

I was attempting to install oh-my-zsh and was running into a `chsh: PAM authentication failed` error because I didn’t know my default password. So I think it would be useful to mention in the documentation that “Oh, by the way, this is your default password....” 

I did find it by googling so it’s not like it’s secret information.