### PR TITLE
Add Aptly rbenv-ruby repo for Xenial

### DIFF
--- a/modules/govuk/manifests/node/s_apt.pp
+++ b/modules/govuk/manifests/node/s_apt.pp
@@ -104,6 +104,9 @@ class govuk::node::s_apt (
   aptly::repo { 'jenkins-agent': }
   aptly::repo { 'locksmithctl': }
   aptly::repo { 'rbenv-ruby': }
+  aptly::repo { 'rbenv-ruby-xenial':
+    distribution => 'xenial',
+  }
   aptly::repo { 'statsd': }
   aptly::repo { 'terraform': }
 


### PR DESCRIPTION
We need to build rbenv-ruby packages for Xenial and upload them to
Aptly. We are going to have the same package version built twice,
one for each distribution. There is an email thread that explains some
of the options to implement this:

https://groups.google.com/forum/#!topic/aptly-discuss/QhgkRlR577w

This commit adds a new repo for the Xenial distribution. We could still
publish the repo under the 'rbenv-ruby' prefix if we want to have
something like 'rbenv-ruby trusty' and 'rbenv-ruby xenial' in our sources
or use a different prefix if we want to keep package names.