### PR TITLE
Use shallow clone of deployment repo

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_puppet.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_puppet.yaml.erb
@@ -4,6 +4,12 @@
     scm:
         - git:
             url: git@github.gds:gds/deployment.git
+            per-build-tag: false
+            refspec: +refs/heads/master:refs/remotes/origin/master
+            shallow-clone: true
+            wipe-workspace: false
+            clean:
+              before: true
             branches:
               - master
 


### PR DESCRIPTION
Cloning the full history of the deployment repo takes a long time due
to the large changes to GPGed files. We only need master, so only clone
that.

Shallow Clone doesn’t appear to be compatible with wipe-workspace as it
forces a `git fetch` without specifying a `depth`, so replace it with
cleaning the workspace before checkout.