### PR TITLE
Add Plek service uris for Draft Frontend

### DIFF
--- a/modules/govuk/manifests/node/s_draft_frontend.pp
+++ b/modules/govuk/manifests/node/s_draft_frontend.pp
@@ -13,5 +13,9 @@ class govuk::node::s_draft_frontend() inherits govuk::node::s_base {
   govuk_envvar {
     'PLEK_HOSTNAME_PREFIX': value => 'draft-';
     'PLEK_SERVICE_ERRBIT_URI': value => "https://errbit.${app_domain}";
+    'PLEK_SERVICE_IMMINENCE_URI': value => "https://imminence.${app_domain}";
+    'PLEK_SERVICE_LOCAL_LINKS_MANAGER_URI': value => "https://local-links-manager.${app_domain}";
+    'PLEK_SERVICE_MAPIT_URI': value  => "https://mapit.${app_domain}";
+    'PLEK_SERVICE_SEARCH_URI': value => "https://search.${app_domain}";
   }
 }


### PR DESCRIPTION
In the draft stack draft-frontend needs to make api calls to both Mapit and Local Links Manager neither of which are available with `draft` prepended to their uri.

We now set them directly based on the app_domain with and so Plek will return the necessary uri.