### PR TITLE
Get content-performance-manager ready for prod deploy

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -38,8 +38,6 @@ base::supported_kernel::enabled: true
 
 environment_ip_prefix: '10.3'
 
-govuk::apps::content_performance_manager::ensure: 'absent'
-
 govuk::apps::efg::ssl_certtype: 'sflg'
 govuk::apps::efg::vhost_name: "www.sflg.gov.uk"
 

--- a/modules/govuk/manifests/apps/content_performance_manager.pp
+++ b/modules/govuk/manifests/apps/content_performance_manager.pp
@@ -8,10 +8,6 @@
 #   The port that it is served on.
 #   Default: 3206
 #
-# [*ensure*]
-#   Whether the application should be exist. Can be specified for each
-#   environment using deployment hieradata.
-#
 # [*secret_key_base*]
 #   The key for Rails to use when signing/encrypting sessions.
 #
@@ -44,7 +40,6 @@
 #
 class govuk::apps::content_performance_manager(
   $port = '3206',
-  $ensure = 'present',
   $secret_key_base = undef,
   $publishing_api_bearer_token = undef,
   $google_analytics_govuk_view_id = undef,
@@ -58,45 +53,42 @@ class govuk::apps::content_performance_manager(
   $app_name = 'content-performance-manager'
 
   govuk::app { $app_name:
-    ensure            => $ensure,
     app_type          => 'rack',
     port              => $port,
     health_check_path => '/',
     asset_pipeline    => true,
   }
 
-  if $ensure == 'present' {
-    Govuk::App::Envvar {
-      app    => $app_name,
-    }
+  Govuk::App::Envvar {
+    app    => $app_name,
+  }
 
-    govuk::app::envvar {
-      "${title}-GOOGLE_ANALYTICS_GOVUK_VIEW_ID":
-        varname => 'GOOGLE_ANALYTICS_GOVUK_VIEW_ID',
-        value   => $google_analytics_govuk_view_id;
-      "${title}-GOOGLE_PRIVATE_KEY":
-        varname => 'GOOGLE_PRIVATE_KEY',
-        value   => $google_private_key;
-      "${title}-GOOGLE_CLIENT_EMAIL":
-        varname => 'GOOGLE_CLIENT_EMAIL',
-        value   => $google_client_email;
-    }
+  govuk::app::envvar {
+    "${title}-GOOGLE_ANALYTICS_GOVUK_VIEW_ID":
+      varname => 'GOOGLE_ANALYTICS_GOVUK_VIEW_ID',
+      value   => $google_analytics_govuk_view_id;
+    "${title}-GOOGLE_PRIVATE_KEY":
+      varname => 'GOOGLE_PRIVATE_KEY',
+      value   => $google_private_key;
+    "${title}-GOOGLE_CLIENT_EMAIL":
+      varname => 'GOOGLE_CLIENT_EMAIL',
+      value   => $google_client_email;
+  }
 
-    if $secret_key_base != undef {
-      govuk::app::envvar { "${title}-SECRET_KEY_BASE":
-        varname => 'SECRET_KEY_BASE',
-        value   => $secret_key_base,
-      }
+  if $secret_key_base != undef {
+    govuk::app::envvar { "${title}-SECRET_KEY_BASE":
+      varname => 'SECRET_KEY_BASE',
+      value   => $secret_key_base,
     }
+  }
 
-    if $::govuk_node_class != 'development' {
-      govuk::app::envvar::database_url { $app_name:
-        type     => 'postgresql',
-        username => $db_username,
-        password => $db_password,
-        host     => $db_hostname,
-        database => $db_name,
-      }
+  if $::govuk_node_class != 'development' {
+    govuk::app::envvar::database_url { $app_name:
+      type     => 'postgresql',
+      username => $db_username,
+      password => $db_password,
+      host     => $db_hostname,
+      database => $db_name,
     }
   }
 }

--- a/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
@@ -21,7 +21,7 @@
            ssh deploy@$(govuk_node_list -c backend --single-node) 'cd /var/apps/specialist-publisher ; govuk_setenv specialist-publisher bundle exec rake publishing_api:publish_finders rummager:publish_finders'
     publishers:
         - trigger-parameterized-builds:
-            <%- %w{ publishing-api collections-publisher service-manual-publisher local-links-manager content-performance-manager }.each do |app| -%>
+            <%- %w{ publishing-api collections-publisher service-manual-publisher local-links-manager }.each do |app| -%>
             - project: Deploy_App
               predefined-parameters: |
                 TARGET_APPLICATION=<%= app %>
@@ -47,10 +47,5 @@
                 TARGET_APPLICATION=email-alert-api
                 MACHINE_CLASS=backend
                 RAKE_TASK=sync_govdelivery_topic_mappings
-            - project: run-rake-task
-              predefined-parameters: |
-                TARGET_APPLICATION=content-performance-manager
-                MACHINE_CLASS=backend
-                RAKE_TASK=import:all_organisations
         - email:
             recipients: govuk-ci-notifications@digital.cabinet-office.gov.uk

--- a/modules/govuk_jenkins/templates/jobs/data_sync_complete_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/data_sync_complete_staging.yaml.erb
@@ -23,10 +23,6 @@
            ssh deploy@$(govuk_node_list -c backend --single-node) 'cd /var/apps/publisher ; govuk_setenv publisher bundle exec rake editions:requeue_scheduled_for_publishing'
     publishers:
         - trigger-parameterized-builds:
-            - project: Deploy_App
-              predefined-parameters: |
-                TARGET_APPLICATION=content-performance-manager
-                DEPLOY_TASK=app:migrate_and_hard_restart
             - project: run-rake-task
               predefined-parameters: |
                 TARGET_APPLICATION=router-api
@@ -37,10 +33,5 @@
                 TARGET_APPLICATION=email-alert-api
                 MACHINE_CLASS=backend
                 RAKE_TASK=sync_govdelivery_topic_mappings
-            - project: run-rake-task
-              predefined-parameters: |
-                TARGET_APPLICATION=content-performance-manager
-                MACHINE_CLASS=backend
-                RAKE_TASK=import:all_organisations
         - email:
             recipients: govuk-ci-notifications@digital.cabinet-office.gov.uk


### PR DESCRIPTION
Trello ticket: https://trello.com/c/OW9lB2U1/145-deploy-to-production

## Motivation

We are ready for content-performance-manager to be deployed to production.
To get the application ready, I'm removing the flag that "ensures" that the application is not deployed in production, and the rake tasks the run the migrations in staging and integration every morning.