### PR TITLE
Set correct database password for search-admin

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -466,7 +466,7 @@ govuk::apps::rummager::redis_port: '6379'
 
 govuk::apps::search_admin::db_name: 'search_admin_production'
 govuk::apps::search_admin::db_hostname: 'master.mysql'
-govuk::apps::search_admin::db_password: "%{hiera('govuk::apps::search_admin::db::password')}"
+govuk::apps::search_admin::db_password: "%{hiera('govuk::apps::search_admin::db::mysql_search_admin')}"
 govuk::apps::search_admin::db_username: 'search_admin'
 
 govuk::apps::service_manual_publisher::http_username: "%{hiera('http_username')}"


### PR DESCRIPTION
This commit fixes the setting of the database password for search-admin in puppet, since https://github.com/alphagov/govuk-puppet/blob/master/modules/govuk/manifests/apps/search_admin/db.pp#L8 is looking for `govuk::apps::search_admin::db::mysql_search_admin`.

Trello: https://trello.com/c/tjUur3ec/462-move-search-admin-to-new-deployment-pipeline