### PR TITLE
[WIP] Remove apt mirror hostname

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -106,8 +106,6 @@ deployable_applications: &deployable_applications
   whitehall:
     branches_to_exclude: ['release', 'deployed-to-integration', 'deployed-to-staging']
 
-apt_mirror_hostname: 'apt.production.alphagov.co.uk'
-
 apt::apt_update_frequency: 'daily'
 apt::purge_preferences_d: true
 apt::purge_sources_list: true
@@ -554,18 +552,12 @@ govuk::apps::travel_advice_publisher::redis_port: "%{hiera('sidekiq_port')}"
 
 govuk_apt::local_mirror_alias::address: '10.3.0.75'
 
-govuk_beat::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
-
 govuk::deploy::config::asset_root: "https://%{hiera('router::assets_origin::vhost_name')}"
 govuk::deploy::config::website_root: "https://www-origin.%{hiera('app_domain')}"
 
 govuk_ghe_vpn::openconnect_version: '6.00-0~21~ubuntu14.04.1'
 
-govuk_gor::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
-
 govuk_htpasswd::http_username: "%{hiera('http_username')}"
-
-govuk_jenkins::job::deploy_terraform_project::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 govuk::node::s_api_redis::allowed_api_ip_range: "%{hiera('environment_ip_prefix')}.4.0/24"
 govuk::node::s_api_redis::allowed_backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
@@ -593,9 +585,6 @@ govuk::node::s_whitehall_mysql_master::encryption_key: "${hiera('govuk::node::s_
 
 govuk::node::s_transition_postgresql_slave::redirector_ip_range: 10.6.0.1/16
 govuk::node::s_transition_postgresql_standby::redirector_ip_range: "%{hiera('govuk::node::s_transition_postgresql_slave::redirector_ip_range')}"
-
-govuk_postgresql::mirror::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
-govuk_ppa::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 govuk_sshkeys::deployment_keys:
   github.com:
@@ -698,14 +687,10 @@ govuk_ci::master::ci_agents:
 govuk_ci::master::credentials_id: 'jenkins-ssh-slave'
 
 govuk_ci::agent::master_ssh_key: "%{hiera('govuk_jenkins::ssh_key::public_key')}"
-govuk_ci::agent::swarm::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 govuk_crawler::amqp_host: 'localhost'
 govuk_crawler::site_root: 'https://www.gov.uk'
 
-govuk_elasticsearch::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
-
-govuk_jenkins::package::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk_jenkins::github_enterprise_cert::certificate: |
     -----BEGIN CERTIFICATE-----
     MIIEdDCCA1ygAwIBAgIJAKt4YiHj0+tVMA0GCSqGSIb3DQEBBQUAMIGCMQswCQYD
@@ -756,13 +741,8 @@ govuk_jenkins::job::deploy_lambda_app::lambda_apps:
 govuk_mysql::server::expire_log_days: 3
 govuk_mysql::server::monitoring::master::plaintext_mysql_password: "%{hiera('mysql_nagios')}"
 govuk_mysql::server::monitoring::slave::plaintext_mysql_password: "%{hiera('mysql_nagios')}"
-govuk_mysql::xtrabackup::packages::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 govuk_postgresql::server::configure_env_sync_user: true
-
-govuk_rabbitmq::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
-
-govuk_rbenv::all::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 govuk_sudo::sudo_conf:
   deploy_init_ctl:
@@ -784,7 +764,6 @@ govuk_unattended_reboot::monitoring_basic_auth:
   username: "%{hiera('http_username')}"
   password: "%{hiera('http_password')}"
 
-grafana::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 grafana::dashboards::app_domain: "%{hiera('app_domain')}"
 grafana::dashboards::machine_suffix_metrics: ''
 
@@ -1271,7 +1250,6 @@ limits::entries:
     limit_type: 'nofile'
     hard: 2048
 
-mongodb::repository::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 mongodb::server::version: '2.4.9'
 
 monitoring::checks::http_username: "%{hiera('http_username')}"
@@ -1357,8 +1335,6 @@ postgresql::lib::devel::link_pg_config: false
 postgresql::globals::version: '9.3'
 
 puppet::master::puppetdb_version: '2.0.0-1puppetlabs1'
-
-puppet::repository::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 rabbitmq::delete_guest_user: true
 rabbitmq::config_stomp: true
@@ -1452,9 +1428,6 @@ sidekiq_host: 'redis-1.backend'
 sidekiq_port: '6379'
 
 ssh::config::allow_users_enable: true
-
-statsd::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
-govuk_unattended_reboot::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 trade_tariff_hostname: 'tariff-frontend-dev.cloudapps.digital'
 

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -552,6 +552,8 @@ govuk::apps::transition::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::travel_advice_publisher::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::travel_advice_publisher::redis_port: "%{hiera('sidekiq_port')}"
 
+govuk_apt::local_mirror_alias::address: '10.3.0.75'
+
 govuk_beat::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 govuk::deploy::config::asset_root: "https://%{hiera('router::assets_origin::vhost_name')}"

--- a/modules/base/manifests/init.pp
+++ b/modules/base/manifests/init.pp
@@ -12,6 +12,7 @@ class base {
   include curl
   include gcc
   include govuk::deploy
+  include govuk_apt::local_mirror_alias
   include govuk_apt::unused_kernels
   include govuk_apt::package_blacklist
   include govuk_envsys

--- a/modules/govuk_apt/manifests/local_mirror_alias.pp
+++ b/modules/govuk_apt/manifests/local_mirror_alias.pp
@@ -1,0 +1,19 @@
+# == Class: govuk_apt::local_mirror_alias
+#
+# Installs a host entry that points to the local apt mirror
+#
+# === Parameters
+#
+# [*address*]
+#   The IP address of the apt mirror. Will be aliased to `hostname`
+#
+class govuk_apt::local_mirror_alias (
+  $address  = undef,
+) {
+
+  host { 'apt_mirror.cluster':
+    ip      => $address,
+    comment => 'Alias to the production apt mirror',
+  }
+
+}

--- a/modules/govuk_apt/spec/classes/govuk_apt__local_mirror_alias_spec.rb
+++ b/modules/govuk_apt/spec/classes/govuk_apt__local_mirror_alias_spec.rb
@@ -1,0 +1,9 @@
+require_relative '../../../../spec_helper'
+
+describe 'govuk_apt::local_mirror_alias', :type => :class do
+
+  it { is_expected.to compile }
+
+  it { is_expected.to compile.with_all_deps }
+
+end

--- a/modules/govuk_beat/manifests/repo.pp
+++ b/modules/govuk_beat/manifests/repo.pp
@@ -3,17 +3,9 @@
 # Use our own mirror of the beat repo. Should be used with `manage_repo`
 # disable of the upstream module.
 #
-#
-# === Parameters
-#
-# [*apt_mirror_hostname*]
-#   Hostname to use for the APT mirror.
-#
-class govuk_beat::repo(
-  $apt_mirror_hostname = undef,
-) {
+class govuk_beat::repo {
   apt::source { 'elastic-beats':
-    location     => "http://${apt_mirror_hostname}/elastic-beats",
+    location     => 'http://apt_mirror.cluster/elastic-beats',
     release      => 'stable',
     architecture => $::architecture,
     key          => '',

--- a/modules/govuk_ci/manifests/agent/swarm.pp
+++ b/modules/govuk_ci/manifests/agent/swarm.pp
@@ -41,9 +41,6 @@
 # [*swarm_client_dest*]
 #   Path to the swarm client binary.
 #
-# [*apt_mirror_hostname*]
-#   The base url of the ppa. The value can be found in hiera
-#
 # [*executors*]
 #   The number of executors an agent can allocate to running jobs
 #
@@ -53,7 +50,6 @@ class govuk_ci::agent::swarm(
   $agent_user_api_token = undef,     # Corresponding user: 'jenkins_agent'
   $swarm_client_package = 'jenkins-agent',
   $swarm_client_dest    = '/usr/local/bin/jenkins-agent',
-  $apt_mirror_hostname  = undef,
   $executors            = '4',
 ) {
 
@@ -68,7 +64,7 @@ class govuk_ci::agent::swarm(
 
   # The apt source which hosts the package
   apt::source { $swarm_client_package :
-    location     => "http://${apt_mirror_hostname}/${$swarm_client_package}",
+    location     => "http://apt_mirror.cluster/${$swarm_client_package}",
     release      => 'trusty',
     architecture => $::architecture,
     key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',

--- a/modules/govuk_elasticsearch/manifests/repo.pp
+++ b/modules/govuk_elasticsearch/manifests/repo.pp
@@ -10,18 +10,14 @@
 #
 # === Parameters
 #
-# [*apt_mirror_hostname*]
-#   Hostname to use for the APT mirror.
-#
 # [*repo_version*]
 #   The Version series to add the repo for (1.4 etc...)
 #
 class govuk_elasticsearch::repo(
-  $apt_mirror_hostname = undef,
   $repo_version,
 ) {
   apt::source { "elasticsearch-${repo_version}":
-    location     => "http://${apt_mirror_hostname}/elasticsearch-${repo_version}",
+    location     => "http://apt_mirror.cluster/elasticsearch-${repo_version}",
     release      => 'stable',
     architecture => $::architecture,
     key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',

--- a/modules/govuk_gor/manifests/init.pp
+++ b/modules/govuk_gor/manifests/init.pp
@@ -4,9 +4,6 @@
 #
 # === Parameters
 #
-# [*apt_mirror_hostname*]
-#   Hostname of the APT mirror to install Gor from
-#
 # [*args*]
 #   Command-line arguments to pass to Gor executable, defaults to an empty hash
 #
@@ -23,7 +20,6 @@
 #   Set any environment variables that will be loaded into the Gor service.
 #
 class govuk_gor(
-  $apt_mirror_hostname = '',
   $args = {},
   $enable = false,
   $version = '0.14.1',
@@ -32,7 +28,7 @@ class govuk_gor(
 ) {
 
   apt::source { 'gor':
-    location     => "http://${apt_mirror_hostname}/gor",
+    location     => 'http://apt_mirror.cluster/gor',
     key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
     architecture => $::architecture,
   }

--- a/modules/govuk_jenkins/manifests/job/deploy_terraform_project.pp
+++ b/modules/govuk_jenkins/manifests/job/deploy_terraform_project.pp
@@ -1,8 +1,5 @@
 # == Class: govuk_jenkins::job::deploy_terraform_project
 #
-# [*apt_mirror_hostname*]
-#   The hostname of an APT mirror
-#
 # [*aws_account_id*]
 #   The account ID for Amazon Web Services, required by our Terraform code
 #
@@ -10,7 +7,6 @@
 #   An array that contains the list of projects currently configured to deploy
 #
 class govuk_jenkins::job::deploy_terraform_project (
-  $apt_mirror_hostname = '',
   $aws_account_id = '',
 ) {
   file { '/etc/jenkins_jobs/jobs/deploy_terraform_project.yaml':
@@ -20,7 +16,7 @@ class govuk_jenkins::job::deploy_terraform_project (
   }
 
   apt::source { 'terraform':
-    location     => "http://${apt_mirror_hostname}/terraform",
+    location     => 'http://apt_mirror.cluster/terraform',
     release      => $::lsbdistcodename,
     architecture => $::architecture,
     key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',

--- a/modules/govuk_jenkins/manifests/package.pp
+++ b/modules/govuk_jenkins/manifests/package.pp
@@ -4,10 +4,6 @@
 #
 # === Parameters:
 #
-# [*apt_mirror_hostname*]
-#   The hostname for the apt mirror to add to enable fetching specific
-#   packages
-#
 # [*version*]
 #   Specify the version of Jenkins you wish to install
 #
@@ -18,7 +14,6 @@
 #   A hash of plugins to enable
 #
 class govuk_jenkins::package (
-  $apt_mirror_hostname,
   $version = $govuk_jenkins::version,
   $config  = {},
   $plugins = {},
@@ -29,7 +24,7 @@ class govuk_jenkins::package (
   include govuk_java::openjdk7::jre
 
   apt::source { 'govuk-jenkins':
-    location     => "http://${apt_mirror_hostname}/govuk-jenkins",
+    location     => 'http://apt_mirror.cluster/govuk-jenkins',
     release      => 'stable',
     architecture => $::architecture,
     key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',

--- a/modules/govuk_jenkins/spec/classes/jenkins__package_spec.rb
+++ b/modules/govuk_jenkins/spec/classes/jenkins__package_spec.rb
@@ -2,7 +2,6 @@ require_relative '../../../../spec_helper'
 
 describe 'govuk_jenkins::package', :type => :class do
   let(:params) {{
-    :apt_mirror_hostname => 'apt.example.com',
     :version             => '1.554.2',
   }}
 

--- a/modules/govuk_mysql/manifests/xtrabackup/packages.pp
+++ b/modules/govuk_mysql/manifests/xtrabackup/packages.pp
@@ -1,13 +1,7 @@
 # == Class: Govuk_mysql::Xtrabackup::Packages
 #
-# === Parameters
-#
-# [*apt_mirror_hostname*]
-#   The hostname of an APT mirror
-#
-class govuk_mysql::xtrabackup::packages (
-  $apt_mirror_hostname  = '',
-) {
+class govuk_mysql::xtrabackup::packages {
+
   package { 'xtrabackup':
     ensure  => present,
     require => Class[Mysql::Server],
@@ -25,7 +19,7 @@ class govuk_mysql::xtrabackup::packages (
   }
 
   apt::source { 'percona':
-    location     => "http://${apt_mirror_hostname}/percona",
+    location     => 'http://apt_mirror.cluster/percona',
     release      => $::lsbdistcodename,
     architecture => $::architecture,
     key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
@@ -36,7 +30,7 @@ class govuk_mysql::xtrabackup::packages (
   }
 
   apt::source { 'gof3r':
-    location     => "http://${apt_mirror_hostname}/gof3r",
+    location     => 'http://apt_mirror.cluster/gof3r',
     release      => $::lsbdistcodename,
     architecture => $::architecture,
     key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',

--- a/modules/govuk_postgresql/manifests/mirror.pp
+++ b/modules/govuk_postgresql/manifests/mirror.pp
@@ -2,12 +2,10 @@
 #
 # Add the apt source for the PostgreSQL aptly mirror
 #
-class govuk_postgresql::mirror (
-  $apt_mirror_hostname = undef,
-) {
+class govuk_postgresql::mirror {
   if $::lsbdistcodename == 'trusty' {
     apt::source { 'postgresql':
-      location     => "http://${apt_mirror_hostname}/postgresql",
+      location     => 'http://apt_mirror.cluster/postgresql',
       release      => "${::lsbdistcodename}-pgdg",
       architecture => $::architecture,
       key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',

--- a/modules/govuk_ppa/manifests/init.pp
+++ b/modules/govuk_ppa/manifests/init.pp
@@ -2,10 +2,6 @@
 #
 # === Parameters
 #
-# [*apt_mirror_hostname*]
-#   Hostname to use for the APT mirror when setting up our PPA.
-#   Defaults to undefined because `$use_mirror` can be disabled.
-#
 # [*path*]
 #   Path that constitutes the last part of the repository. This can be used
 #   to present a different snapshot to an environment, e.g. `integration`
@@ -22,7 +18,6 @@
 #   Default: true
 #
 class govuk_ppa (
-  $apt_mirror_hostname = undef,
   $path = 'production',
   $repo_ensure = 'present',
   $use_mirror = true,
@@ -34,7 +29,7 @@ class govuk_ppa (
   if $use_mirror {
     apt::source { 'govuk-ppa':
       ensure       => $repo_ensure,
-      location     => "http://${apt_mirror_hostname}/govuk/ppa/${path}",
+      location     => "http://apt_mirror.cluster/govuk/ppa/${path}",
       architecture => $::architecture,
       key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
     }

--- a/modules/govuk_ppa/spec/classes/govuk_ppa_spec.rb
+++ b/modules/govuk_ppa/spec/classes/govuk_ppa_spec.rb
@@ -8,20 +8,16 @@ describe 'govuk_ppa', :type => :class do
   }}
   describe '#path' do
     context 'production (default)' do
-      let(:params) {{
-        :apt_mirror_hostname => 'apt.example.com',
-      }}
 
-      it { is_expected.to contain_apt__source('govuk-ppa').with_location('http://apt.example.com/govuk/ppa/production') }
+      it { is_expected.to contain_apt__source('govuk-ppa').with_location('http://apt_mirror.cluster/govuk/ppa/production') }
     end
 
     context 'another environment' do
       let(:params) {{
-        :apt_mirror_hostname => 'apt.example.com',
         :path => 'another-environment',
       }}
 
-      it { is_expected.to contain_apt__source('govuk-ppa').with_location('http://apt.example.com/govuk/ppa/another-environment') }
+      it { is_expected.to contain_apt__source('govuk-ppa').with_location('http://apt_mirror.cluster/govuk/ppa/another-environment') }
     end
   end
 

--- a/modules/govuk_rabbitmq/manifests/repo.pp
+++ b/modules/govuk_rabbitmq/manifests/repo.pp
@@ -1,15 +1,8 @@
 # == Class: govuk_rabbitmq::repo
 #
-# === Parameters:
-#
-# [*apt_mirror_hostname*]
-#   Hostname to use for the APT mirror.
-#
-class govuk_rabbitmq::repo (
-  $apt_mirror_hostname,
-) {
+class govuk_rabbitmq::repo {
   apt::source { 'rabbitmq':
-    location     => "http://${apt_mirror_hostname}/rabbitmq",
+    location     => 'http://apt_mirror.cluster/rabbitmq',
     release      => 'testing',
     architecture => $::architecture,
     key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',

--- a/modules/govuk_rbenv/manifests/all.pp
+++ b/modules/govuk_rbenv/manifests/all.pp
@@ -3,18 +3,11 @@
 # Installs rbenv and the full set of rubies.  This is provides the set of
 # rubies that are needed to run our ruby apps.
 #
-# === Parameters
-#
-# [*apt_mirror_hostname*]
-#   Hostname of the APT mirror to install packages from
-#
-class govuk_rbenv::all (
-  $apt_mirror_hostname = undef,
-) {
+class govuk_rbenv::all {
   include govuk_rbenv
 
   apt::source { 'rbenv-ruby':
-    location     => "http://${apt_mirror_hostname}/rbenv-ruby",
+    location     => 'http://apt_mirror.cluster/rbenv-ruby',
     release      => $::lsbdistcodename,
     architecture => $::architecture,
     key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',

--- a/modules/govuk_unattended_reboot/manifests/repo.pp
+++ b/modules/govuk_unattended_reboot/manifests/repo.pp
@@ -2,16 +2,9 @@
 #
 # Use our own repo for locksmith package
 #
-# === Parameters
-#
-# [*apt_mirror_hostname*]
-#   Hostname to use for the APT mirror.
-#
-class govuk_unattended_reboot::repo(
-  $apt_mirror_hostname = undef,
-) {
+class govuk_unattended_reboot::repo {
   apt::source { 'locksmithctl':
-    location     => "http://${apt_mirror_hostname}/locksmithctl",
+    location     => 'http://apt_mirror.cluster/locksmithctl',
     release      => $::lsbdistcodename,
     architecture => $::architecture,
     key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',

--- a/modules/grafana/manifests/repo.pp
+++ b/modules/grafana/manifests/repo.pp
@@ -1,15 +1,8 @@
 # == Class: grafana::repo
 #
-# === Parameters:
-#
-# [*apt_mirror_hostname*]
-#   Hostname to use for the APT mirror.
-#
-class grafana::repo (
-  $apt_mirror_hostname,
-) {
+class grafana::repo {
   apt::source { 'grafana':
-    location     => "http://${apt_mirror_hostname}/grafana",
+    location     => 'http://apt_mirror.cluster/grafana',
     release      => 'jessie',
     architecture => $::architecture,
     key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',

--- a/modules/mongodb/manifests/repository.pp
+++ b/modules/mongodb/manifests/repository.pp
@@ -4,22 +4,17 @@
 #
 # === Parameters
 #
-# [*apt_mirror_hostname*]
-#   Hostname to use for the APT mirror.
-#   Defaults to undefined because `$use_mirror` can be disabled.
-#
 # [*use_mirror*]
 #   Whether to use our mirror of the repo.
 #   Default: true
 #
 class mongodb::repository(
-  $apt_mirror_hostname = undef,
   $use_mirror = true,
 ) {
   validate_bool($use_mirror)
   if $use_mirror {
     apt::source { 'mongodb':
-      location     => "http://${apt_mirror_hostname}/mongodb",
+      location     => 'http://apt_mirror.cluster/mongodb',
       release      => 'dist',
       repos        => '10gen',
       architecture => $::architecture,
@@ -27,7 +22,7 @@ class mongodb::repository(
     }
 
     apt::source { 'mongodb3.2':
-      location     => "http://${apt_mirror_hostname}/mongodb3.2",
+      location     => 'http://apt_mirror.cluster/mongodb3.2',
       release      => 'trusty-mongodb-org-3.2',
       repos        => 'multiverse',
       architecture => $::architecture,

--- a/modules/puppet/manifests/repository.pp
+++ b/modules/puppet/manifests/repository.pp
@@ -4,10 +4,6 @@
 #
 # === Parameters
 #
-# [*apt_mirror_hostname*]
-#   Hostname to use for the APT mirror.
-#   Defaults to undefined because `$use_mirror` can be disabled.
-#
 # [*use_mirror*]
 #   Whether to use our own mirror of the PuppetLabs repo. You may want to
 #   temporarily disable this if you're bringing up a new production
@@ -15,7 +11,6 @@
 #   Default: true
 #
 class puppet::repository(
-  $apt_mirror_hostname = undef,
   $use_mirror = true,
 ) {
   # This is installed by bootstrapping. `apt::source` takes its place.
@@ -26,7 +21,7 @@ class puppet::repository(
   validate_bool($use_mirror)
   if $use_mirror {
     apt::source { 'puppetlabs':
-      location     => "http://${apt_mirror_hostname}/puppetlabs-${::lsbdistcodename}",
+      location     => "http://apt_mirror.cluster/puppetlabs-${::lsbdistcodename}",
       release      => $::lsbdistcodename,
       architecture => $::architecture,
       key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',

--- a/modules/statsd/manifests/repo.pp
+++ b/modules/statsd/manifests/repo.pp
@@ -2,16 +2,9 @@
 #
 # Use our own Statsd repo
 #
-# === Parameters
-#
-# [*apt_mirror_hostname*]
-#   Hostname to use for the APT mirror.
-#
-class statsd::repo(
-  $apt_mirror_hostname = undef,
-) {
+class statsd::repo {
   apt::source { 'statsd':
-    location     => "http://${apt_mirror_hostname}/statsd",
+    location     => 'http://apt_mirror.cluster/statsd',
     release      => $::lsbdistcodename,
     architecture => $::architecture,
     key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',

--- a/spec/fixtures/hieradata/common.yaml
+++ b/spec/fixtures/hieradata/common.yaml
@@ -15,8 +15,6 @@ govuk_app_enable_services: false
 
 govuk_cdnlogs::monitoring_enabled: false
 
-govuk_jenkins::package::apt_mirror_hostname: 'apt.example.com'
-
 govuk_jenkins::config::github_api_uri: foo
 govuk_jenkins::github_client_id: bar
 govuk_jenkins::github_client_secret: baz
@@ -32,7 +30,6 @@ govuk_postgresql::monitoring::password: password
 
 govuk_rabbitmq::monitoring_password: 'rabbit_monitor'
 govuk_rabbitmq::root_password: 'rabbit_root'
-govuk_rabbitmq::repo::apt_mirror_hostname: 'rabbit_repo'
 
 hosts::production::backend::hosts:
   whitehall-backend-1:


### PR DESCRIPTION
We currently have an apt-mirror configured in our base hieraconfig and then alias that to a class specific value for every puppet class that uses it. This value is the same throughout our infrastructure so instead we'll create a static host entry and use that in all the classes.

This removes the need for all the aliases and class params.