### PR TITLE
Add exec to init MySQL on initial mount

### DIFF
--- a/modules/govuk_ci/manifests/agent/mysql.pp
+++ b/modules/govuk_ci/manifests/agent/mysql.pp
@@ -11,7 +11,6 @@ class govuk_ci::agent::mysql {
     ensure  => directory,
     owner   => 'mysql',
     group   => 'mysql',
-    before  => Mount['/var/lib/mysql'],
     require => User['mysql'],
   }
 

--- a/modules/govuk_ci/manifests/agent/mysql.pp
+++ b/modules/govuk_ci/manifests/agent/mysql.pp
@@ -19,6 +19,12 @@ class govuk_ci::agent::mysql {
     shell  => '/bin/false',
   }
 
+  exec { 'mysql_install_db':
+    command => '/usr/bin/mysql_install_db',
+    unless  => '/usr/bin/test -d /var/lib/mysql/mysql',
+    require => [Mount['/var/lib/mysql'], Package['mysql-server']],
+  }
+
   # Mount the MySQL datadir in ramdisk, and make sure this is completed before
   # the MySQL class runs. When the MySQL class runs it recreates the datadir
   # as usual
@@ -31,6 +37,7 @@ class govuk_ci::agent::mysql {
     atboot   => true,
     before   => Class['::govuk_mysql::server'],
     require  => File['/var/lib/mysql'],
+    notify   => Exec['mysql_install_db'],
   }
 
   # On boot, the server will not have a working MySQL install until Puppet runs,


### PR DESCRIPTION
The MySQL puppet module requires MySQL to be running before any changes can be made. MySQL will not run until the datadir has been correctly initiated, which it won't be if the directory has just been mounted on a ramdisk.

This creates an exec which runs mysql_install_db which initiates that directory, but only after it's been mounted and that the package exists. The mount notifies the exec itself, and if the `mysql` database already exists, it won't run (as it assumes it's already been initiated with the meta tables).