### PR TITLE
Ensure backup offsite jobs use newer gpg key

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -25,10 +25,52 @@ backup::assets::jobs:
     user: 'root'
     gpg_key_id: *offsite_gpg_key
     pre_command: "export PASSPHRASE=%{hiera('backup::assets::backup_private_gpg_key_passphrase')}"
+  'assets-whitehall-s3':
+    sources: '/mnt/uploads/whitehall'
+    bucket: 'govuk-offsite-backups-production'
+    aws_access_key_id: "%{hiera('backup::offsite::job::aws_access_key_id')}"
+    aws_secret_access_key: "%{hiera('backup::offsite::job::aws_secret_access_key')}"
+    hour: 4
+    minute: 20
+    user: 'root'
+    gpg_key_id: *offsite_gpg_key
+  'asset-manager-s3':
+    sources: '/mnt/uploads/asset-manager'
+    bucket: 'govuk-offsite-backups-production'
+    aws_access_key_id: "%{hiera('backup::offsite::job::aws_access_key_id')}"
+    aws_secret_access_key: "%{hiera('backup::offsite::job::aws_secret_access_key')}"
+    hour: 4
+    minute: 13
+    user: 'root'
+    gpg_key_id: *offsite_gpg_key
+
 
 backup::offsite::dest_host: *offsite_host
 backup::offsite::dest_host_key: *offsite_ssh_host_key
 backup::offsite::enable: true
+backup::offsite::jobs:
+  'govuk-datastores':
+    sources:
+      - '/data/backups/*/var/lib/automongodbbackup/latest'
+      - '/data/backups/*/var/lib/automysqlbackup/latest.tbz2'
+      - '/data/backups/*/var/lib/autopostgresqlbackup/latest.tbz2'
+      - '/data/backups/archived'
+    destination: "rsync://%{hiera('backup::offsite::dest_host')}//srv/backup-data/"
+    hour: 8,
+    minute: 13,
+    gpg_key_id: *offsite_gpg_key
+  'govuk-datastores-s3':
+    sources:
+      - '/data/backups/*/var/lib/automongodbbackup/latest'
+      - '/data/backups/*/var/lib/automysqlbackup/latest.tbz2'
+      - '/data/backups/*/var/lib/autopostgresqlbackup/latest.tbz2'
+      - '/data/backups/archived'
+    bucket: 'govuk-offsite-backups-production'
+    aws_access_key_id: "%{hiera('backup::offsite::job::aws_access_key_id')}"
+    aws_secret_access_key: "%{hiera('backup::offsite::job::aws_secret_access_key')}"
+    hour: 8,
+    minute: 13,
+    gpg_key_id: *offsite_gpg_key
 
 backup::offsite::monitoring::offsite_fqdn: *offsite_host
 backup::offsite::monitoring::offsite_hostname: 'backup0.provider0'


### PR DESCRIPTION
When the GPG key was rotated in 7d4208b3b3 I only updated it in `production.yaml` and not `common.yaml`. This was misleading as the hiera that creates the job uses the key defined in the hiera, which means that offsite backups have been using the older key, although assets have been using the newer one.

This is problematic because we rotated the passphrase and secret key in our secret hiera, so if we wanted to unencrypt our non-assets offsite backups we'd need to delve back into the history of that repo to find the right key.

In the future we should refactor the way we include the offsite backup job hiera. The reason we have the data in both sets of hiera is because the defined type has required parameters, so the production ones should be the real ones, and the ones in common shouldn't matter.