### PR TITLE
Allow static/deployed-to-production to be built

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -98,7 +98,8 @@ deployable_applications: &deployable_applications
     branches_to_exclude: ['release', 'deployed-to-integration', 'deployed-to-staging']
   spotlight: {}
   stagecraft: {}
-  static: {}
+  static:
+    branches_to_exclude: ['release', 'deployed-to-integration', 'deployed-to-staging']
   support: {}
   support-api: {}
   transition: {}


### PR DESCRIPTION
By default, Jenkins does not build this branch, but we need to build it to run the schema tests.

As per the instructions in the opsmanual (https://github.gds/pages/gds/opsmanual/infrastructure/testing/application-testing.html)