### PR TITLE
Make smokey run `test:staging` on staging

### DIFF
--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -44,6 +44,8 @@ govuk_jenkins::job::network_config_deploy::environments:
   - 'carrenza-staging-dr'
   - 'skyscape-staging'
 
+govuk_jenkins::job::smokey::smokey_task: 'test:staging'
+
 govuk_jenkins::job::data_sync_complete_staging::signon_domains_to_migrate:
   -
     old: publishing.service.gov.uk


### PR DESCRIPTION
We now have a couple of tests that can never work on staging (the A/B testing that relies on Fastly). This makes smokey run the `test:staging` rake task, which excludes any tests that are tagged with `@notstaging`.