### PR TITLE
Add a newline to cron job

### DIFF
--- a/modules/govuk_ci/manifests/agent/mysql.pp
+++ b/modules/govuk_ci/manifests/agent/mysql.pp
@@ -44,7 +44,8 @@ class govuk_ci::agent::mysql {
   # so we should ensure that this runs after every boot
   file { '/etc/cron.d/run_puppet_on_boot':
     ensure  => present,
-    content => '@reboot root /usr/local/bin/govuk_puppet',
+    # Double quotes to ensure a newline otherwise cron will ignore it
+    content => "@reboot root /usr/local/bin/govuk_puppet \n",
   }
 
   ensure_packages([


### PR DESCRIPTION
Otherwise it will fail with this error:
`Feb 15 09:58:01 ci-agent-4.ci cron[1197]: (*system*run_puppet_on_boot) ERROR (Missing newline before EOF, this crontab file will be ignored)`