### PR TITLE
Reload configuration rather than restart

### DIFF
--- a/modules/govuk_ci/manifests/job.pp
+++ b/modules/govuk_ci/manifests/job.pp
@@ -50,7 +50,7 @@ define govuk_ci::job (
     group   => 'jenkins',
     content => template('govuk_ci/application_build_job.xml.erb'),
     require => File[$application_directory],
-    notify  => Class['Govuk_jenkins::Safe_restart'],
+    notify  => Class['Govuk_jenkins::Reload'],
   }
 
 }

--- a/modules/govuk_jenkins/manifests/config.pp
+++ b/modules/govuk_jenkins/manifests/config.pp
@@ -109,7 +109,7 @@ class govuk_jenkins::config (
     File {
       owner  => 'jenkins',
       group  => 'jenkins',
-      notify => Class['Govuk_jenkins::Safe_restart'],
+      notify => Class['Govuk_jenkins::Reload'],
     }
 
     file {'/var/lib/jenkins/com.cloudbees.jenkins.GitHubPushTrigger.xml':

--- a/modules/govuk_jenkins/manifests/init.pp
+++ b/modules/govuk_jenkins/manifests/init.pp
@@ -74,7 +74,7 @@ class govuk_jenkins (
   }
 
   include ::govuk_jenkins::github_enterprise_cert
-  include ::govuk_jenkins::safe_restart
+  include ::govuk_jenkins::reload
 
   # Jenkins service needs to be restarted to reload the Java keystore
   Class['govuk_jenkins::github_enterprise_cert'] ~> Class['jenkins::service']

--- a/modules/govuk_jenkins/manifests/reload.pp
+++ b/modules/govuk_jenkins/manifests/reload.pp
@@ -1,7 +1,7 @@
-# == Class: Govuk_jenkins::Safe_restart
+# == Class: Govuk_jenkins::Reload
 #
-# This class will issue a "safe restart" of Jenkins, which means it will only
-# restart once all jobs have finished running.
+# This class will issue a "reload-configuration" of Jenkins, which means it will
+# reload any configuration changes made to disk.
 #
 # Note: this requires having a user enabled that has the appropriate public SSH
 # key assigned to it. This should be added manually via the UI in advance
@@ -13,7 +13,7 @@
 #   The home directory of the Jenkins install, and where to put the Jenkins CLI
 #   jar.
 #
-class govuk_jenkins::safe_restart (
+class govuk_jenkins::reload (
   $jenkins_home = '/var/lib/jenkins',
 ) {
   require ::govuk_jenkins
@@ -25,8 +25,8 @@ class govuk_jenkins::safe_restart (
     verbose     => false,
   }
 
-  exec { 'Restart Jenkins':
-    command     => "/usr/bin/java -jar ${jenkins_home}/jenkins-cli.jar -s http://localhost:8080/ -i ${jenkins_home}/.ssh/id_rsa safe-restart",
+  exec { 'Reload Jenkins configuration':
+    command     => "/usr/bin/java -jar ${jenkins_home}/jenkins-cli.jar -s http://localhost:8080/ -i ${jenkins_home}/.ssh/id_rsa reload-configuration",
     require     => Curl::Fetch['Jenkins CLI tool'],
     refreshonly => true,
   }

--- a/modules/govuk_jenkins/manifests/ssh_slave.pp
+++ b/modules/govuk_jenkins/manifests/ssh_slave.pp
@@ -54,7 +54,7 @@ define govuk_jenkins::ssh_slave (
     content => template('govuk_jenkins/ssh_slave_config.xml.erb'),
     owner   => $jenkins_user,
     group   => $jenkins_user,
-    notify  => Class['Govuk_jenkins::Safe_restart'],
+    notify  => Class['Govuk_jenkins::Reload'],
   }
 
   include icinga::client::check_jenkins_agent


### PR DESCRIPTION
In an attempt to stop interrupting jobs a class was created that issued a "safe-restart" from the jenkins-cli. Unfortunately this does not appear to work with pipeline jobs, which is problematic on our CI environment.

This changes the command to use "reload-configuration" which reloads all configuration that may have been made to disk, and should *hopefully* not interrupt any running jobs when it does it.