### PR TITLE
CI Elasticsearch Label

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -751,19 +751,19 @@ govuk_ci::master::ci_agents:
   ci-agent-1:
     agent_hostname: 'ci-agent-1.ci'
     description: 'Build agent with docker'
-    labels: 'mongodb-2.4 docker ci-agent-1'
+    labels: 'mongodb-2.4 docker ci-agent-1 elasticsearch'
   ci-agent-2:
     agent_hostname: 'ci-agent-2.ci'
-    labels: 'mongodb-2.4 ci-agent-2'
+    labels: 'mongodb-2.4 ci-agent-2 elasticsearch'
   ci-agent-3:
     agent_hostname: 'ci-agent-3.ci'
-    labels: 'mongodb-2.4 ci-agent-3'
+    labels: 'mongodb-2.4 ci-agent-3 elasticsearch'
   ci-agent-4:
     agent_hostname: 'ci-agent-4.ci'
-    labels: 'mongodb-3.2 ci-agent-4'
+    labels: 'mongodb-3.2 ci-agent-4 elasticsearch'
   ci-agent-5:
     agent_hostname: 'ci-agent-5.ci'
-    labels: 'mongodb-3.2 ci-agent-5'
+    labels: 'mongodb-3.2 ci-agent-5 elasticsearch'
 govuk_ci::master::credentials_id: 'jenkins-ssh-slave'
 
 govuk_ci::agent::master_ssh_key: "%{hiera('govuk_jenkins::ssh_key::public_key')}"


### PR DESCRIPTION
We're now introducing an agent which does not offer elasticsearch. The implications to this are that jobs will have to explicitly define a label if it requires elasticsearch.  Otherwise, the job may be executed on an agent without it's requirements.