### PR TITLE
Use SSH credentials to access Github from CI

### DIFF
--- a/modules/govuk_ci/templates/application_build_job.xml.erb
+++ b/modules/govuk_ci/templates/application_build_job.xml.erb
@@ -27,7 +27,7 @@
         <source class="org.jenkinsci.plugins.github_branch_source.GitHubSCMSource" plugin="github-branch-source@1.10">
           <id>45dd6853-59d2-4695-80ac-4520f8a2b64f</id>
 <%- if @source == 'github' -%>
-          <checkoutCredentialsId>SAME</checkoutCredentialsId>
+          <checkoutCredentialsId>govuk-ci-ssh-key</checkoutCredentialsId>
           <scanCredentialsId>github-token-govuk-ci-username</scanCredentialsId>
           <repoOwner><%= @repo_owner %></repoOwner>
 <%- elsif @source == 'github-enterprise' -%>


### PR DESCRIPTION
During busy parts of the day we have been hitting the Github rate
limit of 5,000 requests/hour. This causes an exception in Jenkins
and stops jobs building.

This commit changes the Multibranch Pipeline configuration to use
separate SSH credentials for checkout as to scanning. This should
mean that we are less likely to hit the rate limit.

**This assumes that the govuk-ci-ssh-key is enabled on github for the ci-user**