### PR TITLE
Add a separate step for plain bundle install

### DIFF
--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -166,11 +166,19 @@ def setupDb() {
 }
 
 /**
- * Bundles all the gems
+ * Bundles all the gems in deployment mode
  */
 def bundleApp() {
   echo 'Bundling'
   sh("bundle install --path ${JENKINS_HOME}/bundles/${JOB_NAME} --deployment --without development")
+}
+
+/**
+ * Bundles all the gems
+ */
+def bundleGem() {
+  echo 'Bundling'
+  sh("bundle install --path ${JENKINS_HOME}/bundles/${JOB_NAME} --without development")
 }
 
 /**


### PR DESCRIPTION
The existing `deployApp` includes the `--deployment` flag, which tells bundler to respect a `Gemfile.lock` file, to ensure that the exact same versions are used from dev to live. 

This isn't appropriate for building a gem. In this case we just a do a regular bundle install.

For use in https://github.com/alphagov/govuk_taxonomy_helpers/pull/2

cc @suzannehamilton