### PR TITLE
CI Bundle Cleanup

### DIFF
--- a/modules/govuk_ci/manifests/agent.pp
+++ b/modules/govuk_ci/manifests/agent.pp
@@ -54,4 +54,10 @@ class govuk_ci::agent(
   package { 'libgdal-dev': # needed for mapit
     ensure => installed,
   }
+
+  cron::crondotdee { 'clean_up_bundles':
+    command => 'find /var/lib/jenkins/bundles/* -maxdepth 1 -type d -mtime +1 -exec rm -rf {} \;',
+    hour    => 7,
+    minute  => 45,
+  }
 }


### PR DESCRIPTION
Jenkins Bundle directories take up a lot of disk space. Currently a bundle directory gets created for every project/branch that gets built.
These directories then remain there afterwards.
Consequence of this is that the first build of the day may take slightly longer depending.