### PR TITLE
Add a branch exclusion list for smart-answers, calendars and calculators

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -18,8 +18,10 @@ deployable_applications: &deployable_applications
   businesssupportfinder:
     repository: 'business-support-finder'
     branches_to_exclude: ['release', 'deployed-to-integration', 'deployed-to-staging']
-  calculators: {}
-  calendars: {}
+  calculators:
+    branches_to_exclude: ['release', 'deployed-to-integration', 'deployed-to-staging']
+  calendars:
+    branches_to_exclude: ['release', 'deployed-to-integration', 'deployed-to-staging']
   collections:
     branches_to_exclude: ['release', 'deployed-to-integration', 'deployed-to-staging']
   collections-publisher:
@@ -92,6 +94,7 @@ deployable_applications: &deployable_applications
   signon: {}
   smartanswers:
     repository: 'smart-answers'
+    branches_to_exclude: ['release', 'deployed-to-integration', 'deployed-to-staging']
   smokey: {}
   specialist-frontend: {}
   specialist-publisher:


### PR DESCRIPTION
[Trello card](https://trello.com/c/58ZBYYGL/564-add-applications-to-downstream-content-schema-test)

The following apps:

- smart-answers
- calendars
- calculators

The aforementioned apps need to build govuk-content-schemas. In the
Jenkinsfile for the branch of govuk-content-schemas being built has been
set to `deployed-to-production`, but by default Jenkins does not build this
branch, so this setting is being overriden here.
commit b6175671539ba7d70f593e015805277bce5c9319