### PR TITLE
Include all dependencies for gems in jenkins builds

### DIFF
--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -178,7 +178,7 @@ def bundleApp() {
  */
 def bundleGem() {
   echo 'Bundling'
-  sh("bundle install --path ${JENKINS_HOME}/bundles/${JOB_NAME} --without development")
+  sh("bundle install --path ${JENKINS_HOME}/bundles/${JOB_NAME}")
 }
 
 /**


### PR DESCRIPTION
I added this step in https://github.com/alphagov/govuk-puppet/pull/5502

I thought it was still useful to filter out development dependencies, but this
actually filters out things like govuk_lint which we need for CI.