### PR TITLE
Add an nginx filebeat prospector

### DIFF
--- a/modules/nginx/manifests/log.pp
+++ b/modules/nginx/manifests/log.pp
@@ -11,14 +11,36 @@ define nginx::log (
   # Log name should not be absolute. Use $logpath.
   validate_re($title, '^[^/]')
 
+  $path = "${logpath}/${name}"
+  $tags = ['nginx']
+  $fields = {'application' => $logname}
+
   govuk_logging::logstream { $name:
     ensure        => $logstream,
-    logfile       => "${logpath}/${name}",
-    tags          => ['nginx'],
-    fields        => {'application' => $logname},
+    logfile       => $path,
+    tags          => $tags,
+    fields        => $fields,
     json          => $json,
     statsd_metric => $statsd_metric,
     statsd_timers => $statsd_timers,
   }
 
+  if $::domain =~ /^.*\.(dev|integration\.publishing\.service)\.gov\.uk/ {
+    # filebeat should automatically infer whether a log is in JSON or not
+    # but if it should be we want to log JSON parsing errors.
+    if $json {
+      $json_hash = {add_error_key => true}
+    } else {
+      $json_hash = {}
+    }
+
+    # TODO replace statsd shipping.
+    filebeat::prospector { $name:
+      ensure => $logstream,
+      paths  => [$path],
+      json   => $json_hash,
+      tags   => $tags,
+      fields => $fields,
+    }
+  }
 }


### PR DESCRIPTION
We want to move to using filebeat for pushing our nginx logs. This creates a prospector along side the existing logship configuration for nginx.

An alternative method to achieve this would be to add the prospector to the hieradata for each class which uses nginx. This has the advantage of removing the ugly if statement on line 28 that only enables filebeat in integration but does increase repetition.