### PR TITLE
ci-agent-6 on Xenial

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -769,6 +769,10 @@ govuk_ci::master::ci_agents:
   ci-agent-5:
     agent_hostname: 'ci-agent-5.ci'
     labels: 'mongodb-3.2 ci-agent-5 elasticsearch'
+  ci-agent-6:
+    agent_hostname: 'ci-agent-6.ci'
+    labels: 'ci-agent-6 xenial'
+
 govuk_ci::master::credentials_id: 'jenkins-ssh-slave'
 
 govuk_ci::agent::master_ssh_key: "%{hiera('govuk_jenkins::ssh_key::public_key')}"
@@ -1115,6 +1119,8 @@ hosts::production::ci::hosts:
     ip: '10.1.6.24'
   ci-agent-5:
     ip: '10.1.6.25'
+  ci-agent-6:
+    ip: '10.1.6.26'
 
 hosts::production::frontend::hosts:
   calculators-frontend-1:

--- a/hieradata/node/ci-agent-6.ci.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/ci-agent-6.ci.integration.publishing.service.gov.uk.yaml
@@ -1,0 +1,3 @@
+---
+
+govuk_ci::agent::elasticsearch_enabled: false

--- a/modules/govuk_ci/manifests/agent.pp
+++ b/modules/govuk_ci/manifests/agent.pp
@@ -10,16 +10,22 @@
 # [*master_ssh_key*]
 #   The public SSH key of the CI master to enable SSH based agent builds
 #
+# [*elasticsearch_enabled*]
+#   Boolean.  Allows the exclusion of the elasticsearch class.
+#
 class govuk_ci::agent(
   $docker_enabled = false,
   $master_ssh_key = undef,
+  $elasticsearch_enabled = true,
 ) {
   include ::govuk_ci::agent::redis
   if $docker_enabled {
     include ::govuk_ci::agent::docker
   }
+  if $elasticsearch_enabled {
+    include ::govuk_ci::agent::elasticsearch
+  }
   include ::govuk_ci::agent::rabbitmq
-  include ::govuk_ci::agent::elasticsearch
   include ::govuk_ci::agent::mongodb
   include ::govuk_ci::agent::postgresql
   include ::govuk_ci::agent::mysql


### PR DESCRIPTION
We require an agent running on Xenial.
We've decided to defer provisioning elasticsearch, due to the complexity involved with jumping multiple major versions.

https://trello.com/c/VWChaAZu