### PR TITLE
Configure filebeat to group apt-history log lines

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -298,6 +298,11 @@ filebeat::prospectors:
       - 'history'
     fields:
       application: 'apt'
+    multiline:
+      pattern: '^$'
+      negate: true
+      match: 'after'
+      timeout: 30
   apt-term:
     paths:
       - '/var/log/apt/term.log'


### PR DESCRIPTION
Apt's history log has the general form of:
```

Start-Date: 2017-02-20  16:48:49
Commandline: apt-get remove telnet
Remove: telnet:amd64 (0.17-36build2)
End-Date: 2017-02-20  16:48:50
```

Note the blank line used to delineate separate actions. These blocks of logs are more usefully treated as a single entry. This commit configures filebeat to send logs for apt as a single block when they have this form and do not take longer than 30s.