### PR TITLE
Enable new tagging tool in whitehall

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -95,6 +95,7 @@ govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-eve
 govuk::apps::support_api::pp_data_url: 'https://www.performance.service.gov.uk'
 govuk::apps::support_api::zendesk_anonymous_ticket_email: 'zd-api-public@digital.cabinet-office.gov.uk'
 govuk::apps::travel_advice_publisher::enable_email_alerts: true
+govuk::apps::whitehall::enable_tagging_to_new_taxonomy: "yes"
 
 govuk::deploy::actionmailer_enable_delivery: true
 

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -19,6 +19,7 @@ govuk::apps::short_url_manager::instance_name: 'staging'
 govuk::apps::signon::instance_name: 'staging'
 govuk::apps::support_api::pp_data_url: 'https://www.staging.performance.service.gov.uk'
 govuk::apps::travel_advice_publisher::enable_email_alerts: true
+govuk::apps::whitehall::enable_tagging_to_new_taxonomy: "yes"
 
 govuk::deploy::aws_ses_smtp_host: 'email-smtp.eu-west-1.amazonaws.com'
 govuk::deploy::config::errbit_environment_name: 'staging'


### PR DESCRIPTION
We're almost ready to deploy this.

Before we switch it on:
- [x] https://github.com/alphagov/whitehall/pull/3053
- [x] https://github.com/alphagov/whitehall/pull/3060
- [x] https://github.com/alphagov/whitehall/pull/3064
- [ ] Get ready to send out comms (talk with Chris Pugh or Sam Dub to do this)

There is also https://trello.com/c/pbtbMZer/469-add-event-tracking-to-checkboxes-on-topic-tagging-page (in progress) but we can deploy without this.

https://trello.com/c/dQYsqpiU/406-epic-education-publishers-can-tag-content-to-the-new-taxonomy