### PR TITLE
Replace publishing-e2e-docker with publishing-e2e-tests

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -739,7 +739,7 @@ govuk_ci::master::pipeline_jobs:
   pp-manual:
     source: 'github-enterprise'
   pre-transition-stats: {}
-  publishing-e2e-docker: {}
+  publishing-e2e-tests: {}
   rack-logstasher: {}
   rails_translation_manager: {}
   router-data:


### PR DESCRIPTION
This has been added so that we can trigger jenkins builds for https://github.com/alphagov/publishing-e2e-tests

It will eventually replace https://ci.integration.publishing.service.gov.uk/job/publishing-platform-docker/ which does not seem to be listed in this file. 

Note this is also a repo that needs docker in CI, not sure if I have to set anything up extra for that?

/cc @deanwilson @afda16 