### PR TITLE
Add memcached to frontend machines

### DIFF
--- a/modules/govuk/manifests/node/s_calculators_frontend.pp
+++ b/modules/govuk/manifests/node/s_calculators_frontend.pp
@@ -21,4 +21,9 @@ class govuk::node::s_calculators_frontend inherits govuk::node::s_base {
 
   Govuk_mount['/data/vhost'] -> Class['govuk::apps::calculators']
 
+  include collectd::plugin::memcached
+  class { 'memcached':
+    max_memory => '12%',
+    listen_ip  => '127.0.0.1',
+  }
 }

--- a/modules/govuk/manifests/node/s_frontend.pp
+++ b/modules/govuk/manifests/node/s_frontend.pp
@@ -20,4 +20,10 @@ class govuk::node::s_frontend inherits govuk::node::s_base {
     host_name => $::fqdn,
     notes_url => monitoring_docs_url(nginx-high-conn-writing-upstream-indicator-check),
   }
+
+  include collectd::plugin::memcached
+  class { 'memcached':
+    max_memory => '12%',
+    listen_ip  => '127.0.0.1',
+  }
 }


### PR DESCRIPTION
This adds memcached to the frontend machines. I've copied the config from the other machines with memcached (whitehall, mapit, backend nodes).

We'll use this mainly to cache HTTP responses, first from slimmer (https://github.com/alphagov/slimmer/pull/184) and hopefully later from gds-api-adapters.

cc @boffbowsh 

https://trello.com/c/D9HmkJwI