### PR TITLE
Use SSH key and wipe workspace

### DIFF
--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -13,6 +13,19 @@ def cleanupGit() {
 }
 
 /**
+ * Checkout repo using SSH key
+ */
+def checkoutFromGitHubWithSSH(String repository, String org = 'alphagov', String url = 'github.com') {
+  checkout([$class: 'GitSCM',
+    branches: scm.branches,
+    userRemoteConfigs: [[
+      credentialsId: 'govuk-ci-ssh-key',
+      url: "git@${url}:${org}/${repository}.git"
+    ]]
+  ])
+}
+
+/**
  * Try to merge master into the current branch
  *
  * This will abort if it doesn't exit cleanly (ie there are conflicts), and


### PR DESCRIPTION
Using the SSH key helps with git rate limits, and wipe the workspace to help ongoing maintenance.

As a note, the `scm.branches` must be specified as otherwise it checks out master.