### PR TITLE
Add monitoring for postgres conns

### DIFF
--- a/modules/govuk_postgresql/manifests/server/primary.pp
+++ b/modules/govuk_postgresql/manifests/server/primary.pp
@@ -22,7 +22,13 @@
 #
 # [*user*]
 #   Specifies which database user name(s) the pg_hba record matches.
-
+#
+# [*max_connections*]
+#   The maximum number of connections the server can connect. It always reserves
+#   3 for superuser connections, but if it runs out it can have an impact on
+#   applications waiting for connections. Ideally applications should close
+#   their connections to the database, but this doesn't always happen.
+#   Default: 100
 class govuk_postgresql::server::primary (
   $auth_method = 'md5',
   $database = 'replication',
@@ -30,6 +36,7 @@ class govuk_postgresql::server::primary (
   $slave_password,
   $type = 'host',
   $user = 'replication',
+  $max_connections = 100,
 ) {
   include govuk_postgresql::backup
   include govuk_postgresql::server
@@ -44,6 +51,8 @@ class govuk_postgresql::server::primary (
       value => 3;
     'wal_keep_segments':
       value => 256;
+    'max_connections':
+      value => $max_connections;
   }
 
   if versioncmp($::postgresql::globals::version, '9.5') < 0 {

--- a/modules/govuk_postgresql/manifests/server/primary.pp
+++ b/modules/govuk_postgresql/manifests/server/primary.pp
@@ -76,4 +76,15 @@ class govuk_postgresql::server::primary (
 
   create_resources('postgresql::server::pg_hba_rule', $slave_addresses, $pg_hba_defaults)
 
+  $warning_conns = $max_connections * 0.8
+  $critical_conns = $max_connections * 0.9
+
+  @@icinga::check::graphite { "check_postgres_conns_used_${::hostname}":
+    target    => "${::fqdn_metrics}.postgresql-global.pg_numbackends",
+    desc      => 'postgres high connections used',
+    warning   => $warning_conns,
+    critical  => $critical_conns,
+    host_name => $::fqdn,
+  }
+
 }


### PR DESCRIPTION
PostgreSQL has a maximum number of connections that are available for applications to connect to. The default maximum is 100, but for a busy production database this may be too low.

If applications also do not properly close off their connections (and therefore persist in an 'idle' state) then this can fill up the amount of available connections.

If there are no more connections available, then it may block applications from connecting to the database.

This adds an alert to let us know when we're close to the threshold. In this instance, we should check the number using `psql`:

`SELECT state, count(*) FROM pg_stat_activity GROUP BY state;`

We could then terminate some of the older connections.