### PR TITLE
Override publishing-api branches built by Jenkins

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -80,7 +80,8 @@ deployable_applications: &deployable_applications
     branches_to_exclude: ['release', 'deployed-to-integration', 'deployed-to-staging']
   publisher:
     branches_to_exclude: ['release', 'deployed-to-integration', 'deployed-to-staging']
-  publishing-api: {}
+  publishing-api:
+    branches_to_exclude: ['release', 'deployed-to-integration', 'deployed-to-staging']
   release: {}
   router: {}
   router-api: {}


### PR DESCRIPTION
By default, Jenkins builds exclude all deployed-to-* branches. This overrides that setting for publishing-api so that the deployed-to-production branch is no longer excluded, and can be built to test changes to the content schemas.