### PR TITLE
Rename env var for assisted digital survey in feedback

### DIFF
--- a/modules/govuk/manifests/apps/feedback.pp
+++ b/modules/govuk/manifests/apps/feedback.pp
@@ -24,7 +24,7 @@ class govuk::apps::feedback(
   $secret_key_base = undef,
   $support_api_bearer_token = undef,
   $publishing_api_bearer_token = undef,
-  $assisted_digital_help_with_fees_google_spreadsheet_key = undef,
+  $assisted_digital_google_spreadsheet_key = undef,
   $google_client_email = undef,
   $google_private_key = undef,
 ) {
@@ -69,10 +69,10 @@ class govuk::apps::feedback(
     value   => $publishing_api_bearer_token,
   }
 
-  if $assisted_digital_help_with_fees_google_spreadsheet_key != undef {
-    govuk::app::envvar { "${title}-ASSISTED_DIGITAL_HELP_WITH_FEES_GOOGLE_SPREADSHEET_KEY":
-      varname => 'ASSISTED_DIGITAL_HELP_WITH_FEES_GOOGLE_SPREADSHEET_KEY',
-      value   => $assisted_digital_help_with_fees_google_spreadsheet_key,
+  if $assisted_digital_google_spreadsheet_key != undef {
+    govuk::app::envvar { "${title}-ASSISTED_DIGITAL_GOOGLE_SPREADSHEET_KEY":
+      varname => 'ASSISTED_DIGITAL_GOOGLE_SPREADSHEET_KEY',
+      value   => $assisted_digital_google_spreadsheet_key,
     }
   }
 


### PR DESCRIPTION
For: https://trello.com/c/kZCX6dGB/53-gov-uk-survey-assisted-digital-support-on-done-page

It was originally to be used just for assisted digital help with fees
feedback, but that is no longer the case and it'll be used for any
assisted digital feedback so we can rename the vars to reflect that.

Relies on:

* a similar change in our deployment repo: https://github.gds/gds/deployment/pull/1241
* a change in the feedback app to use this new variable instead: 