### PR TITLE
[WIP] Add templating of Google credentials file

### DIFF
--- a/modules/govuk_jenkins/manifests/job/deploy_dns.pp
+++ b/modules/govuk_jenkins/manifests/job/deploy_dns.pp
@@ -11,16 +11,47 @@
 #   ID of the route53 DNS zone to upload to
 #
 # [*dyn_customer_name*]
-#    Customer account to use for Dyn (not to be confused with the Dyn user name)
+#   Customer account to use for Dyn (not to be confused with the Dyn user name)
+#
+# [*gce_zone_id*]
+#   The zone ID to deploy to
+#
+# [*gce_project_id*]
+#   The ID or name of the project
+#
+# [*gce_private_key*]
+#   The private key of the credentials to authenticate with
+#
+# [*gce_client_name*]
+#   The client name for the credentials you're using to authenticate
+#
+# [*gce_credentials*]
+#   Location of the Google credentials file.
+#
+# [*gce_region*]
+#   The region of the zone you're deploying to.
 #
 class govuk_jenkins::job::deploy_dns (
     $dyn_zone_id,
     $route53_zone_id,
     $dyn_customer_name,
+    $gce_zone_id,
+    $gce_project_id,
+    $gce_private_key,
+    $gce_client_name,
+    $gce_credentials = '/var/lib/jenkins/gce_credentials.json',
+    $gce_region= 'europe-west1-d',
 ) {
   file { '/etc/jenkins_jobs/jobs/deploy_dns.yaml':
     ensure  => present,
     content => template('govuk_jenkins/jobs/deploy_dns.yaml.erb'),
     notify  => Exec['jenkins_jobs_update'],
+  }
+
+  file { $gce_credentials:
+    ensure  => present,
+    owner   => 'jenkins',
+    group   => 'jenkins',
+    content => template('govuk_jenkins/gce_credentials.json.erb'),
   }
 }

--- a/modules/govuk_jenkins/templates/gce_credentials.json.erb
+++ b/modules/govuk_jenkins/templates/gce_credentials.json.erb
@@ -1,0 +1,12 @@
+{
+  "type": "service_account",
+  "project_id": "<%= @gce_project_id %>",
+  "private_key_id": "<%= ENV['GOOGLE_PRIVATE_KEY_ID'] %>",
+  "private_key": "<%= @gce_private_key %>",
+  "client_email": "<%= @gce_client_name -%>@<%= @gce_project_id -%>.iam.gserviceaccount.com",
+  "client_id": "<%= ENV['GOOGLE_CLIENT_ID'] %>",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://accounts.google.com/o/oauth2/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/<%= @gce_client_name -%>%40<%= @gce_project_id -%>.iam.gserviceaccount.com"
+}

--- a/modules/govuk_jenkins/templates/jobs/deploy_dns.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_dns.yaml.erb
@@ -25,6 +25,9 @@
             export DYN_ZONE_ID='<%= @dyn_zone_id %>'
             export ROUTE53_ZONE_ID='<%= @route53_zone_id %>'
             export DYN_CUSTOMER_NAME='<%= @dyn_customer_name %>'
+            export GCE_ZONE_ID='<%= @gce_zone_id %>'
+            export GCE_CREDENTIALS='<%= @gce_credentials %>'
+            export GCE_REGION='<%= @gce_region %>'
             ./jenkins.sh
     wrappers:
         - ansicolor:
@@ -36,12 +39,19 @@
                 - PICK ONE
                 - all
                 - dyn
+                - gce
                 - route53
         - string:
             name: AWS_ACCESS_KEY_ID
             default: false
         - password:
             name: AWS_SECRET_ACCESS_KEY
+            default: false
+        - string:
+            name: GOOGLE_CLIENT_ID
+            default: false
+        - password:
+            name: GOOGLE_PRIVATE_KEY_ID
             default: false
         - string:
             name: DYN_USERNAME


### PR DESCRIPTION
Google Cloud does things differently in that you must have a credentials file to be able to authenticate with their API. This causes a problem as while we can provide a file to use for authentication, we want to ensure that when people run the Jenkins job they are passing in some form of authentication, because otherwise they could potentially cause serious impact in deployment of DNS.

This looks to template this credentials file, in which we can store most of the secrets of the file in encrypted hiera, but also prompt for a couple of parts of the file in the Jenkins job itself, and pass these in as environment variables. These secrets can be stored in our password store to use.