### PR TITLE
Update Imagemagic to latest security patch

### DIFF
--- a/modules/imagemagick/manifests/init.pp
+++ b/modules/imagemagick/manifests/init.pp
@@ -4,7 +4,7 @@
 #
 class imagemagick {
   package { 'imagemagick':
-    ensure => '8:6.7.7.10-6ubuntu3.3',
+    ensure => '8:6.7.7.10-6ubuntu3.4',
   }
 
   file { '/etc/ImageMagick/policy.xml':


### PR DESCRIPTION
Imagemagic has been upgraded upstream to apply a new security patch.
More info:
https://www.ubuntu.com/usn/usn-3142-2/