### PR TITLE
Restart carbon-aggregator service every 5 minutes in Staging

### DIFF
--- a/modules/govuk/manifests/node/s_graphite.pp
+++ b/modules/govuk/manifests/node/s_graphite.pp
@@ -89,4 +89,13 @@ class govuk::node::s_graphite (
 
   include collectd::server
   include grafana
+
+  if $::domain =~ /^.*\.staging\.publishing\.service\.gov\.uk/ {
+    cron { 'carbon-aggregator-restart':
+      command => '/usr/sbin/service carbon-aggregator restart',
+      user    => 'root',
+      minute  => '*/5',
+    }
+  }
+
 }


### PR DESCRIPTION
Carbon-aggregator connections in Staging seem to be filled up from clients on
the licensify VPN, and the errors in the log file are filling the disk.

This is probably caused by network problems that are being investigated
with Carrenza, for now we can configure this cron job to restart the daemon
every 5 minutes.