### PR TITLE
Use full paths in S3 mirror cron job.

### DIFF
--- a/modules/govuk_crawler/templates/govuk_sync_mirror.erb
+++ b/modules/govuk_crawler/templates/govuk_sync_mirror.erb
@@ -53,7 +53,7 @@ for TARGET in ${TARGETS}; do
 
   # Toggle the command: whether we will use rsync of the s3 sync.
   if [[ $TARGET = s3://* ]]; then
-    CMD="govuk_setenv s3_sync_mirror aws s3 sync ${MIRROR_ROOT}/. ${TARGET}"
+    CMD="/usr/local/bin/govuk_setenv s3_sync_mirror /usr/local/bin/aws s3 sync ${MIRROR_ROOT}/. ${TARGET}"
   else
     CMD="rsync -az --exclude 'lost+found' ${MIRROR_ROOT}/. ${TARGET}:/srv/mirror_data"
   fi


### PR DESCRIPTION
The S3 mirror-synchronisation cron job was failing because it could
not find the programs. This uses the full paths which fixes the
problem.