### PR TITLE
Fix publish gem function

### DIFF
--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -282,7 +282,7 @@ def publishGem(String repository, String branch) {
     return
   } else {
     echo('Pushing tag')
-    govuk.pushTag(repository, branch, 'v' + version)
+    pushTag(repository, branch, 'v' + version)
   }
 
   def escapedVersion = version.replaceAll(/\./, /\\\\./)

--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -272,6 +272,11 @@ def publishGem(String repository, String branch) {
     returnStdout: true
   ).trim()
 
+  sshagent(['govuk-ci-ssh-key']) {
+    echo "Fetching remote tags"
+    sh("git fetch --tags")
+  }
+
   def taggedReleaseExists = sh(
     script: "git tag | grep v${version}",
     returnStatus: true


### PR DESCRIPTION
In this PR:

- Remove invalid `govuk` namespace from pushTag call;
- Fetch remote tags before checking if a tag exists.

This script has been successfully tested in `govuk_ab_testing`'s build 29 in Jenkins.