### PR TITLE
[DO NOT MERGE] Jenkins Roles

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -55,6 +55,13 @@ govuk_jenkins::config::theme_text_colour: 'black'
 govuk_jenkins::config::theme_environment_name: 'Integration'
 
 govuk_jenkins::config::admins:
+  - anafernandez
+  - deanwilson
+  - lauramartin
+  - mikaelallison
+  - samcook
+
+govuk_jenkins::config:devs:
   - aaronkeogh
   - alecgibson
   - alexmuller

--- a/modules/govuk_jenkins/manifests/config.pp
+++ b/modules/govuk_jenkins/manifests/config.pp
@@ -53,6 +53,9 @@
 # [*admins*]
 #   List of admins that have "admin" permissions in Jenkins.
 #
+# [*devs*]
+#   List of users that have "developer" permissions in Jenkins.
+#
 # [*manage_config*]
 #   Boolean option to manage the Jenkins configuration directory.
 #
@@ -97,11 +100,13 @@ class govuk_jenkins::config (
   $jenkins_agent_user = 'jenkins_agent',
   $executors = '4',
   $agent_tcp_port = '0',
+  $devs = [],
 ) {
 
   $url = "${url_prefix}.${app_domain}"
 
   validate_array($admins)
+  validate_array($devs)
   validate_hash($views)
 
   if $manage_config {

--- a/modules/govuk_jenkins/templates/config/config.xml.erb
+++ b/modules/govuk_jenkins/templates/config/config.xml.erb
@@ -110,8 +110,56 @@
         <assignedSIDs/>
       </role>
     </roleMap>
-    <roleMap type="slaveRoles"/>
-    <roleMap type="projectRoles"/>
+    <roleMap type="projectRoles">
+      <role name="Devs" pattern="(?!)Deploy_DNS*">
+        <permissions>
+          <%- if @jenkins_2 -%>
+          <permission>hudson.scm.SCM.Tag</permission>
+          <permission>hudson.model.View.Delete</permission>
+          <permission>hudson.model.Item.Read</permission>
+          <permission>hudson.model.Hudson.Administer</permission>
+          <permission>hudson.model.Item.Configure</permission>
+          <permission>hudson.model.Item.Workspace</permission>
+          <permission>hudson.model.Hudson.RunScripts</permission>
+          <permission>hudson.model.View.Create</permission>
+          <permission>hudson.model.View.Read</permission>
+          <permission>hudson.model.Run.Delete</permission>
+          <permission>hudson.model.Item.Discover</permission>
+          <permission>hudson.model.Item.Create</permission>
+          <permission>hudson.model.Item.Build</permission>
+          <permission>hudson.model.Item.Cancel</permission>
+          <permission>hudson.model.Hudson.Read</permission>
+          <permission>hudson.model.Item.Delete</permission>
+          <permission>hudson.model.Run.Update</permission>
+          <permission>hudson.model.View.Configure</permission>
+          <%- else -%>
+          <permission>hudson.model.Hudson.Administer</permission>
+          <permission>hudson.model.Hudson.Read</permission>
+          <permission>hudson.model.Hudson.RunScripts</permission>
+          <permission>hudson.model.Item.Build</permission>
+          <permission>hudson.model.Item.Cancel</permission>
+          <permission>hudson.model.Item.Configure</permission>
+          <permission>hudson.model.Item.Create</permission>
+          <permission>hudson.model.Item.Delete</permission>
+          <permission>hudson.model.Item.Discover</permission>
+          <permission>hudson.model.Item.Read</permission>
+          <permission>hudson.model.Item.Workspace</permission>
+          <permission>hudson.model.Run.Delete</permission>
+          <permission>hudson.model.Run.Update</permission>
+          <permission>hudson.model.View.Configure</permission>
+          <permission>hudson.model.View.Create</permission>
+          <permission>hudson.model.View.Delete</permission>
+          <permission>hudson.model.View.Read</permission>
+          <permission>hudson.scm.SCM.Tag</permission>
+          <%- end -%>
+        </permissions>
+        <assignedSIDs>
+          <%- @devs.each do |a| -%>
+          <%- if not @jenkins_2 -%>!<%- end -%><sid><%= a %></sid>
+          <%- end -%>
+        </assignedSIDs>
+      </role>
+    </roleMap>
   </authorizationStrategy>
   <securityRealm class="org.jenkinsci.plugins.GithubSecurityRealm">
     <githubWebUri><%= @github_web_uri -%></githubWebUri>


### PR DESCRIPTION
We've introduced some deploy jobs that we'd prefer to be restricted to specified, authenticated users.  At present all interactive users hold the `admin` role.

This PR specifies a `dev` role with the same access as the previous admin role.  Except that the `devs` is restricted from building jobs that name matches the `Deploy_DNS` pattern and it's variants.

Relates to: https://github.com/alphagov/govuk-puppet/tree/gce-jenkins

See: https://trello.com/c/88BhiP5e