### PR TITLE
Change to using s3cmd rather than awscli

### DIFF
--- a/modules/govuk_crawler/manifests/init.pp
+++ b/modules/govuk_crawler/manifests/init.pp
@@ -129,8 +129,12 @@ class govuk_crawler(
         provider => system_gem,
   }
 
-  # Needed to copy to AWS S3
+  # FIXME: remove this once this has run in production
   package { 'awscli':
+        ensure   => absent,
+  }
+  # Needed to copy to AWS S3
+  package { 's3cmd':
         ensure   => present,
         provider => pip,
   }

--- a/modules/govuk_crawler/templates/govuk_sync_mirror.erb
+++ b/modules/govuk_crawler/templates/govuk_sync_mirror.erb
@@ -53,7 +53,7 @@ for TARGET in ${TARGETS}; do
 
   # Toggle the command: whether we will use rsync of the s3 sync.
   if [[ $TARGET = s3://* ]]; then
-    CMD="/usr/local/bin/govuk_setenv s3_sync_mirror /usr/local/bin/aws s3 sync ${MIRROR_ROOT}/. ${TARGET}"
+    CMD="/usr/local/bin/govuk_setenv s3_sync_mirror /usr/local/bin/s3cmd sync --cache-file=/tmp/s3cmd_mirror_sync.cache --exclude=\"lost+found\" ${MIRROR_ROOT}/. ${TARGET}"
   else
     CMD="rsync -az --exclude 'lost+found' ${MIRROR_ROOT}/. ${TARGET}:/srv/mirror_data"
   fi


### PR DESCRIPTION
The `aws s3 sync` command does not complete. This tries using the alternate `s3cmd sync` which will hopefully succeed.

This is awaiting the successful completion of a manual run on `mirrorer-1.integration`.