### PR TITLE
Only reload configuration on Jenkins 2

### DIFF
--- a/modules/govuk_jenkins/manifests/config.pp
+++ b/modules/govuk_jenkins/manifests/config.pp
@@ -109,7 +109,17 @@ class govuk_jenkins::config (
     File {
       owner  => 'jenkins',
       group  => 'jenkins',
-      notify => Class['Govuk_jenkins::Reload'],
+    }
+
+    # FIXME: Remove once all Jenkinses are upgraded to at least 2.0.0
+    if versioncmp($version, '2.0.0') == 1 {
+      File {
+        notify => Class['Govuk_jenkins::Reload'],
+      }
+    } else {
+      File {
+        notify => Service['jenkins'],
+      }
     }
 
     file {'/var/lib/jenkins/com.cloudbees.jenkins.GitHubPushTrigger.xml':


### PR DESCRIPTION
To use the reload-configuration CLI command you require "credentials" to be added in the Jenkins GUI. In Jenkins 2, you're able to create a set of credentials that has an SSH key for "system scope", but in Jenkins 1 this option isn't available.

This commit adds a conditional that only allows reload on Jenkins 2. The other classes that use the govuk_jenkins::reload class are only Jenkins 2, so this just fixes Jenkins 1 machines (which generally weren't affected by service restarts as badly as our CI machines).