### PR TITLE
Add Statsd metrics to virus scan cron job

### DIFF
--- a/modules/govuk/templates/node/s_asset_base/process-uploaded-attachments.sh.erb
+++ b/modules/govuk/templates/node/s_asset_base/process-uploaded-attachments.sh.erb
@@ -31,6 +31,9 @@ cd "$INCOMING_DIR"
 while IFS= read -r -d '' FILE
   do
     logger -t process_uploaded_attachment "Processing uploaded file $FILE"
+    # Send metric to Statsd
+    WAITING_TIME=$(expr $(date +%s) - $(stat -c %Y $FILE))
+    echo "govuk.app.asset-master.scan-queue:${WAITING_TIME}|ms" | nc -w 1 -u localhost 8125
     # This parameter substition strips "$INCOMING_DIR/" from the beginning of $FILE.
     FILE_PATH=${FILE#$INCOMING_DIR/}
     if /usr/local/bin/virus-scan-file.sh "$FILE"; then


### PR DESCRIPTION
Add metrics to visualise number of documents processed and waiting time
to be scanned. Metrics should appear in Graphite under the prefix
'stats.timers.govuk.app.asset-master.scan-queue.'

Times are reported in seconds, number of documents processed should appear
in .count