### PR TITLE
Serve an uncached empty gif for analytics purposes

### DIFF
--- a/modules/govuk/templates/static_extra_nginx_config.conf.erb
+++ b/modules/govuk/templates/static_extra_nginx_config.conf.erb
@@ -1,3 +1,9 @@
+location /static/a.gif {
+  expires -1;
+  add_header Last-Modified "";
+  empty_gif;
+}
+
 location /__canary__ {
   default_type application/json;
   add_header cache-control "max-age=0, no-store, no-cache";


### PR DESCRIPTION
Configure `assets-origin.domain/static/a.gif` to always serve an empty
gif that isn’t allowed to be cached. This is to be used in conjunction
with a new GOV.UK analytics tracker. Javascript will insert an image
tag on every page referencing this, with tracking data added to the
query string of the gif. This will be picked up in CDN logs.

The anti-caching might be slightly too aggressive here, but the
overhead is minimal and debugging this in production would be hard.
It’s easier to scale back the aggression once it’s live.