### PR TITLE
Bugfix offsite backups to s3

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -34,6 +34,7 @@ backup::assets::jobs:
     minute: 20
     user: 'root'
     gpg_key_id: *offsite_gpg_key
+    pre_command: "export PASSPHRASE=%{hiera('backup::assets::backup_private_gpg_key_passphrase')}"
   'asset-manager-s3':
     sources: '/mnt/uploads/asset-manager'
     destination: 's3://s3-eu-west-1.amazonaws.com/govuk-offsite-backups-production/asset-manager/'
@@ -43,6 +44,7 @@ backup::assets::jobs:
     minute: 13
     user: 'root'
     gpg_key_id: *offsite_gpg_key
+    pre_command: "export PASSPHRASE=%{hiera('backup::assets::backup_private_gpg_key_passphrase')}"
 
 
 backup::offsite::dest_host: *offsite_host

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -27,7 +27,7 @@ backup::assets::jobs:
     pre_command: "export PASSPHRASE=%{hiera('backup::assets::backup_private_gpg_key_passphrase')}"
   'assets-whitehall-s3':
     sources: '/mnt/uploads/whitehall'
-    bucket: 'govuk-offsite-backups-production'
+    destination: 's3://s3-eu-west-1.amazonaws.com/govuk-offsite-backups-production/assets-whitehall/'
     aws_access_key_id: "%{hiera('backup::offsite::job::aws_access_key_id')}"
     aws_secret_access_key: "%{hiera('backup::offsite::job::aws_secret_access_key')}"
     hour: 4
@@ -36,7 +36,7 @@ backup::assets::jobs:
     gpg_key_id: *offsite_gpg_key
   'asset-manager-s3':
     sources: '/mnt/uploads/asset-manager'
-    bucket: 'govuk-offsite-backups-production'
+    destination: 's3://s3-eu-west-1.amazonaws.com/govuk-offsite-backups-production/asset-manager/'
     aws_access_key_id: "%{hiera('backup::offsite::job::aws_access_key_id')}"
     aws_secret_access_key: "%{hiera('backup::offsite::job::aws_secret_access_key')}"
     hour: 4
@@ -65,7 +65,7 @@ backup::offsite::jobs:
       - '/data/backups/*/var/lib/automysqlbackup/latest.tbz2'
       - '/data/backups/*/var/lib/autopostgresqlbackup/latest.tbz2'
       - '/data/backups/archived'
-    bucket: 'govuk-offsite-backups-production'
+    destination: 's3://s3-eu-west-1.amazonaws.com/govuk-offsite-backups-production/govuk-datastores/'
     aws_access_key_id: "%{hiera('backup::offsite::job::aws_access_key_id')}"
     aws_secret_access_key: "%{hiera('backup::offsite::job::aws_secret_access_key')}"
     hour: 8,


### PR DESCRIPTION
When enabling backups for S3 I found that the backup process was being inconsistent:

 - backups were being taken as full backups each time  - backups were not being tidied up and were leaving orphans and  incomplete sets behind

When trying to run `duplicity collection-status` against these backups it failed because it didn't work with the URL that was defined in the original job:

s3+http://govuk-offsite-backups-production/

Changing this to use the fully defined bucket name allowed me to cleanup and check the status of a backup. In the actual job, just having the defined "s3://foo" still successfully took a backup as the boto backend was still used.