### PR TITLE
Increase max connections

### DIFF
--- a/hieradata/node/postgresql-primary-1.backend.publishing.service.gov.uk.yaml
+++ b/hieradata/node/postgresql-primary-1.backend.publishing.service.gov.uk.yaml
@@ -1,0 +1,1 @@
+govuk_postgresql::server::primary::max_connections: 200


### PR DESCRIPTION
Increase the maximum number of allowed connections in postgresql-primary-1 in Production. We're increasing the amount of memory on the machine to increase capacity, so we should also double the
allowed number of connections.