### PR TITLE
Create CI job for govuk_document_types

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -681,6 +681,7 @@ govuk_ci::master::pipeline_jobs:
   govuk_content_models: {}
   govuk-content-schema-test-helpers: {}
   govuk-dummy_content_store: {}
+  govuk_document_types: {}
   govuk_elements: {}
   govuk_frontend_toolkit: {}
   govuk_frontend_toolkit_gem: {}


### PR DESCRIPTION
This is a new gem and needs testing:

https://github.com/alphagov/govuk_document_types

https://trello.com/c/07lAcDtC