### PR TITLE
Revert "Update bucket to destination"

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -27,7 +27,7 @@ backup::assets::jobs:
     pre_command: "export PASSPHRASE=%{hiera('backup::assets::backup_private_gpg_key_passphrase')}"
   'assets-whitehall-s3':
     sources: '/mnt/uploads/whitehall'
-    destination: 's3://s3-eu-west-1.amazonaws.com/govuk-offsite-backups-production/assets-whitehall/'
+    bucket: 'govuk-offsite-backups-production'
     aws_access_key_id: "%{hiera('backup::offsite::job::aws_access_key_id')}"
     aws_secret_access_key: "%{hiera('backup::offsite::job::aws_secret_access_key')}"
     hour: 4
@@ -37,7 +37,7 @@ backup::assets::jobs:
     pre_command: "export PASSPHRASE=%{hiera('backup::assets::backup_private_gpg_key_passphrase')}"
   'asset-manager-s3':
     sources: '/mnt/uploads/asset-manager'
-    destination: 's3://s3-eu-west-1.amazonaws.com/govuk-offsite-backups-production/asset-manager/'
+    bucket: 'govuk-offsite-backups-production'
     aws_access_key_id: "%{hiera('backup::offsite::job::aws_access_key_id')}"
     aws_secret_access_key: "%{hiera('backup::offsite::job::aws_secret_access_key')}"
     hour: 4
@@ -67,7 +67,7 @@ backup::offsite::jobs:
       - '/data/backups/*/var/lib/automysqlbackup/latest.tbz2'
       - '/data/backups/*/var/lib/autopostgresqlbackup/latest.tbz2'
       - '/data/backups/archived'
-    destination: 's3://s3-eu-west-1.amazonaws.com/govuk-offsite-backups-production/govuk-datastores/'
+    bucket: 'govuk-offsite-backups-production'
     aws_access_key_id: "%{hiera('backup::offsite::job::aws_access_key_id')}"
     aws_secret_access_key: "%{hiera('backup::offsite::job::aws_secret_access_key')}"
     hour: 8,


### PR DESCRIPTION
This reverts commit 52f48dad5f8f31aab809b9acd2c79ebaea98dbc5.

I'm not convinced this is the fix, so would prefer to revert this for now. I want to test having a bucket without versioning or lifecycling enabled before updating the destination in this way.