### PR TITLE
Add virus scan speed alert and Grafana dashboard

### DIFF
--- a/modules/govuk/manifests/node/s_asset_master.pp
+++ b/modules/govuk/manifests/node/s_asset_master.pp
@@ -92,6 +92,14 @@ class govuk::node::s_asset_master (
     notes_url           => monitoring_docs_url(full-attachments-sync),
   }
 
+  @@icinga::check::graphite { "check_uploads_scan_waiting_time_${::hostname}":
+    target    => 'stats.timers.govuk.app.asset-master.scan-queue.upper_90',
+    warning   => 1200,
+    critical  => 2400,
+    desc      => 'Waiting time to pass virus scan',
+    host_name => $::fqdn,
+  }
+
   cron { 'virus-scan-clean':
     user    => 'assets',
     hour    => '*',

--- a/modules/grafana/files/dashboards/asset_master_virus_scan_speed.json
+++ b/modules/grafana/files/dashboards/asset_master_virus_scan_speed.json
@@ -1,0 +1,206 @@
+{
+  "id": 8,
+  "title": "Asset Master virus scan speed",
+  "originalTitle": "Asset Master virus scan speed",
+  "tags": [],
+  "style": "dark",
+  "timezone": "browser",
+  "editable": true,
+  "hideControls": false,
+  "sharedCrosshair": false,
+  "rows": [
+    {
+      "collapse": false,
+      "editable": true,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "Graphite",
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "id": 1,
+          "isNew": true,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "refId": "A",
+              "target": "alias(summarize(stats.timers.govuk.app.asset-master.scan-queue.count, '10m', 'sum', false), 'documents')"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Number of documents",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "show": true
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "Graphite",
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "id": 2,
+          "isNew": true,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "refId": "A",
+              "target": "aliasByNode(stats.timers.govuk.app.asset-master.scan-queue.upper_90, 5)"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "90th Percentile of waiting time",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "show": true
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "title": "Row"
+    }
+  ],
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "templating": {
+    "list": []
+  },
+  "annotations": {
+    "list": []
+  },
+  "refresh": false,
+  "schemaVersion": 12,
+  "version": 1,
+  "links": []
+}


### PR DESCRIPTION
Add an Icinga check to alert when the waiting time in the asset-master queue
to scan documents is longer than 20 minutes (warn) and 40 minutes (critical).
We might need to adjust these values when we start analyzing the new metrics.

Add initial Grafana dashboard to visualise number of documents and time since
the document was uploaded until it's ready to be scanned.