### PR TITLE
Restart Jenkins nightly

### DIFF
--- a/modules/govuk_ci/manifests/master.pp
+++ b/modules/govuk_ci/manifests/master.pp
@@ -76,4 +76,12 @@ class govuk_ci::master (
     minute  => 45,
   }
 
+  # Restart Jenkins nightly: using the govuk_jenkins::reload class means that Jenkins goes for long
+  # periods without a restart, which seems to cause some issues with the service.
+  cron::crondotdee { 'restart_jenkins_service':
+    command => '/usr/sbin/service jenkins restart',
+    hour    => 0,
+    minute  => 0,
+  }
+
 }


### PR DESCRIPTION
Since I implemented the govuk_jenkins::reload class we've seen some odd behaviour which is resolved by restarting the Jenkins service. Going for long periods doesn't play well with Jenkins so restart it each night as the bell tolls midnight.