### PR TITLE
Ensure that MySQL is stopped before Puppet runs

### DIFF
--- a/modules/govuk_ci/manifests/agent/mysql.pp
+++ b/modules/govuk_ci/manifests/agent/mysql.pp
@@ -45,7 +45,7 @@ class govuk_ci::agent::mysql {
   file { '/etc/cron.d/run_puppet_on_boot':
     ensure  => present,
     # Double quotes to ensure a newline otherwise cron will ignore it
-    content => "@reboot root /usr/local/bin/govuk_puppet \n",
+    content => "@reboot root /usr/sbin/service mysql stop; rm -rf /var/lib/mysql && /usr/local/bin/govuk_puppet \n",
   }
 
   ensure_packages([


### PR DESCRIPTION
Unfortunately because the upstream module manages the MySQL service there's no good way of disabling it to start on boot. If it does try to start on boot, it will likely fail because the `/var/lib/mysql` dir won't have been initilised, however it will still place some ibdata stuff inside of it.

We do not want anything shadow mounted, so using the on-boot cron job, stop the mysql service (if it's already stopped then the exit code will be 1 thus the break), delete the directory and run puppet. Puppet will then create the directory, mount in tmpfs and do everything else.