### PR TITLE
Add LVM override for Production

### DIFF
--- a/hieradata/class/production/postgresql_primary.yaml
+++ b/hieradata/class/production/postgresql_primary.yaml
@@ -1,0 +1,11 @@
+lv:
+  postgresql:
+    pv:
+      - '/dev/sda1'
+      - '/dev/sdc1'
+      - '/dev/sde1'
+      - '/dev/sdf1'
+    vg: 'backups'
+  data:
+    pv: '/dev/sdd1'
+    vg: 'postgresql'


### PR DESCRIPTION
postgresql-primary-1 in Production was rebooted for maintenance. When it came back up, devices in LVM were different to how Puppet was it expecting it to be:

```
lauramartin@production-postgresql-primary-1:~$ sudo pvs
  PV         VG         Fmt  Attr PSize  PFree
  /dev/sda1  backups    lvm2 a--  32.00g    0
  /dev/sdb2  os         lvm2 a--  49.52g    0
  /dev/sdc1  backups    lvm2 a--  16.00g    0
  /dev/sdd1  postgresql lvm2 a--  64.00g    0
  /dev/sde1  backups    lvm2 a--  16.00g    0
  /dev/sdf1  backups    lvm2 a--  64.00g    0
```

This is probably because the device names have been assigned different labels. The sizing looks correct, and everything is mounted correctly, so things are running OK, but Puppet fails to run because of these errors.

Due to the sensitivity of this machine, add an override in Puppet which prevents these errors so that future updates can be correctly applied.

The last time the server was rebooted before this was 379 days ago.