### PR TITLE
Change back to default checkout mode

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ node {
 
   try {
     stage("Checkout") {
-      govuk.checkoutFromGitHubWithSSH(REPOSITORY)
+      checkout scm
     }
 
     stage("Bundle install") {


### PR DESCRIPTION
I recently changed the checkout mode to use an SSH method. Unfortunately I've started to see occasional errors since this has been changed and Googling seems to suggest it's something to do with git and SSH.

I prefer not to disrupt work and will try to do some testing to see if we can work around it, but using standard https is fine for now.

```
Receiving objects:  53% (66672/125795), 14.24 MiB | 6.82 MiB/s
Receiving objects:  54% (67930/125795), 14.24 MiB | 6.82 MiB/s
Receiving objects:  55% (69188/125795), 14.24 MiB | 6.82 MiB/s
Receiving objects:  56% (70446/125795), 14.24 MiB | 6.82 MiB/s
Receiving objects:  57% (71704/125795), 14.24 MiB | 6.82 MiB/s
Receiving objects:  58% (72962/125795), 18.23 MiB | 7.04 MiB/s
Receiving objects:  59% (74220/125795), 18.23 MiB | 7.04 MiB/s
Receiving objects:  60% (75477/125795), 18.23 MiB | 7.04 MiB/s
Receiving objects:  61% (76735/125795), 18.23 MiB | 7.04 MiB/s
Receiving objects:  62% (77993/125795), 18.23 MiB | 7.04 MiB/s
Receiving objects:  63% (79251/125795), 18.23 MiB | 7.04 MiB/s
Receiving objects:  64% (80509/125795), 18.23 MiB | 7.04 MiB/s
Receiving objects:  65% (81767/125795), 18.23 MiB | 7.04 MiB/s
Receiving objects:  66% (83025/125795), 18.23 MiB | 7.04 MiB/s
Receiving objects:  67% (84283/125795), 18.23 MiB | 7.04 MiB/s
Receiving objects:  68% (85541/125795), 18.23 MiB | 7.04 MiB/s
Receiving objects:  69% (86799/125795), 18.23 MiB | 7.04 MiB/s
Receiving objects:  70% (88057/125795), 18.23 MiB | 7.04 MiB/s
Receiving objects:  71% (89315/125795), 18.23 MiB | 7.04 MiB/s
Receiving objects:  71% (90075/125795), 18.23 MiB | 7.04 MiB/s
Receiving objects:  72% (90573/125795), 18.23 MiB | 7.04 MiB/s
Corrupted MAC on input.
Disconnecting: Packet corrupt
fatal: The remote end hung up unexpectedly
fatal: early EOF
fatal: index-pack failed

	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.launchCommandIn(CliGitAPIImpl.java:1745)
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.launchCommandWithCredentials(CliGitAPIImpl.java:1489)
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.access$300(CliGitAPIImpl.java:64)
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl$1.execute(CliGitAPIImpl.java:315)
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl$2.execute(CliGitAPIImpl.java:512)
	at hudson.plugins.git.GitSCM.retrieveChanges(GitSCM.java:1042)
	at hudson.plugins.git.GitSCM.checkout(GitSCM.java:1082)
	at org.jenkinsci.plugins.workflow.steps.scm.SCMStep.checkout(SCMStep.java:109)
	at org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition.create(CpsScmFlowDefinition.java:108)
	at org.jenkinsci.plugins.workflow.multibranch.SCMBinder.create(SCMBinder.java:85)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun.run(WorkflowRun.java:215)
	at hudson.model.ResourceController.execute(ResourceController.java:98)
	at hudson.model.Executor.run(Executor.java:404)
```