### PR TITLE
Rework max connections

### DIFF
--- a/hieradata/class/production/postgresql_primary.yaml
+++ b/hieradata/class/production/postgresql_primary.yaml
@@ -9,3 +9,5 @@ lv:
   data:
     pv: '/dev/sdd1'
     vg: 'postgresql'
+
+govuk_postgresql::server::max_connections: 200

--- a/hieradata/class/production/postgresql_standby.yaml
+++ b/hieradata/class/production/postgresql_standby.yaml
@@ -1,0 +1,1 @@
+govuk_postgresql::server::max_connections: 200

--- a/hieradata/node/postgresql-primary-1.backend.publishing.service.gov.uk.yaml
+++ b/hieradata/node/postgresql-primary-1.backend.publishing.service.gov.uk.yaml
@@ -1,1 +1,0 @@
-govuk_postgresql::server::primary::max_connections: 200

--- a/modules/govuk_postgresql/manifests/server/primary.pp
+++ b/modules/govuk_postgresql/manifests/server/primary.pp
@@ -23,12 +23,6 @@
 # [*user*]
 #   Specifies which database user name(s) the pg_hba record matches.
 #
-# [*max_connections*]
-#   The maximum number of connections the server can connect. It always reserves
-#   3 for superuser connections, but if it runs out it can have an impact on
-#   applications waiting for connections. Ideally applications should close
-#   their connections to the database, but this doesn't always happen.
-#   Default: 100
 class govuk_postgresql::server::primary (
   $auth_method = 'md5',
   $database = 'replication',
@@ -36,7 +30,6 @@ class govuk_postgresql::server::primary (
   $slave_password,
   $type = 'host',
   $user = 'replication',
-  $max_connections = 100,
 ) {
   include govuk_postgresql::backup
   include govuk_postgresql::server
@@ -51,8 +44,6 @@ class govuk_postgresql::server::primary (
       value => 3;
     'wal_keep_segments':
       value => 256;
-    'max_connections':
-      value => $max_connections;
   }
 
   if versioncmp($::postgresql::globals::version, '9.5') < 0 {
@@ -75,16 +66,5 @@ class govuk_postgresql::server::primary (
   }
 
   create_resources('postgresql::server::pg_hba_rule', $slave_addresses, $pg_hba_defaults)
-
-  $warning_conns = $max_connections * 0.8
-  $critical_conns = $max_connections * 0.9
-
-  @@icinga::check::graphite { "check_postgres_conns_used_${::hostname}":
-    target    => "${::fqdn_metrics}.postgresql-global.pg_numbackends",
-    desc      => 'postgres high connections used',
-    warning   => $warning_conns,
-    critical  => $critical_conns,
-    host_name => $::fqdn,
-  }
 
 }


### PR DESCRIPTION
This setting needs to be applied to both the primary and the standbys, otherwise the standby machines will refuse to start.

This commit shuffles the setting around in the class so it can be included.