### PR TITLE
Fix name of `govuk_schemas` gem

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -693,7 +693,7 @@ govuk_ci::master::pipeline_jobs:
   govuk-provisioning:
     source: 'github-enterprise'
   govuk_seed_crawler: {}
-  govuk_schemas_gem: {}
+  govuk_schemas: {}
   govuk_security_audit: {}
   govuk_sidekiq: {}
   govuk_taxonomy_helpers: {}

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -676,7 +676,6 @@ govuk_ci::master::pipeline_jobs:
   govuk-diff-pages: {}
   govuk_admin_template: {}
   govuk_ab_testing: {}
-  govuk_bad_link_finder: {}
   govuk_client_url-arbiter: {}
   govuk_content_models: {}
   govuk-content-schema-test-helpers: {}


### PR DESCRIPTION
This repo has been renamed.