### PR TITLE
Allow deployed-to-production branch to be built for short-url-manager

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -91,7 +91,8 @@ deployable_applications: &deployable_applications
     branches_to_exclude: ['release', 'deployed-to-integration', 'deployed-to-staging']
   service-manual-publisher:
     branches_to_exclude: ['release', 'deployed-to-integration', 'deployed-to-staging']
-  short-url-manager: {}
+  short-url-manager:
+    branches_to_exclude: ['release', 'deployed-to-integration', 'deployed-to-staging']
   sidekiq-monitoring: {}
   signon: {}
   smartanswers:


### PR DESCRIPTION
This is to allow it to be used as part of the content schemas build.  A follow on to: https://github.com/alphagov/govuk-content-schemas/pull/549