### PR TITLE
Use latest bundler for all rbenv rubies

### DIFF
--- a/modules/govuk_rbenv/manifests/all.pp
+++ b/modules/govuk_rbenv/manifests/all.pp
@@ -21,46 +21,46 @@ class govuk_rbenv::all (
   }
 
   rbenv::version { '2.1.2':
-    bundler_version => '1.6.5',
+    bundler_version => '1.14.5',
   }
   rbenv::version { '2.1.4':
-    bundler_version => '1.7.4',
+    bundler_version => '1.14.5',
   }
   rbenv::version { '2.1.5':
-    bundler_version => '1.8.3',
+    bundler_version => '1.14.5',
   }
   rbenv::version { '2.1.8':
-    bundler_version => '1.10.6',
+    bundler_version => '1.14.5',
   }
   rbenv::alias { '2.1':
     to_version => '2.1.8',
   }
 
   rbenv::version { '2.2.2':
-    bundler_version => '1.9.4',
+    bundler_version => '1.14.5',
   }
   rbenv::version { '2.2.3':
-    bundler_version => '1.10.6',
+    bundler_version => '1.14.5',
   }
   rbenv::version { '2.2.4':
-    bundler_version => '1.10.6',
+    bundler_version => '1.14.5',
   }
   rbenv::alias { '2.2':
     to_version => '2.2.4',
   }
 
   rbenv::version { '2.3.0':
-    bundler_version => '1.11.2',
+    bundler_version => '1.14.5',
   }
   rbenv::version { '2.3.1':
-    bundler_version => '1.11.2',
+    bundler_version => '1.14.5',
   }
   rbenv::alias { '2.3':
     to_version => '2.3.1',
   }
 
   rbenv::version { '2.4.0':
-    bundler_version => '1.13.7',
+    bundler_version => '1.14.5',
   }
   rbenv::alias { '2.4':
     to_version => '2.4.0',


### PR DESCRIPTION
Keeping our bundler versions up to date and consistent across rubies
gives us access to bug fixes, speed improvements, and new features.

This change also specifically addresses the Gemfile.lock fluctuations
that occur around the inclusion/removal of the RUBY VERSION stamp. This
behaviour was introduced in bundler 1.12. Any developer using 1.12 and
above (because they manually updated their bundler version on the VM,
let's say) will generate lock files that include the version stamp. A
developer running < 1.12 will generate lock files without it. This leads
to additional noise and confusion in pull requests when developers
running different versions end up reversing each other's changes.