### PR TITLE
Uninstall Ruby 2.1.2

### DIFF
--- a/modules/govuk_rbenv/manifests/all.pp
+++ b/modules/govuk_rbenv/manifests/all.pp
@@ -21,7 +21,7 @@ class govuk_rbenv::all (
   }
 
   rbenv::version { '2.1.2':
-    bundler_version => '1.14.5',
+    ensure => absent # FIXME: Tidy up once deployed
   }
   rbenv::version { '2.1.4':
     bundler_version => '1.14.5',


### PR DESCRIPTION
The last app to use this version was manuals-publisher which was recently
upgraded to 2.2.4 (see: https://github.com/alphagov/manuals-publisher/pull/806).

This was verified with:

    fab production puppet_class:govuk_rbenv::all rbenv.version_in_use:2.1.2
    fab staging puppet_class:govuk_rbenv::all rbenv.version_in_use:2.1.2
    fab integration puppet_class:govuk_rbenv::all rbenv.version_in_use:2.1.2

All of which reported back a clean slate.