### PR TITLE
Add disk to duplicity-cache mount

### DIFF
--- a/hieradata/node/asset-slave-1.backend.publishing.service.gov.uk.yaml
+++ b/hieradata/node/asset-slave-1.backend.publishing.service.gov.uk.yaml
@@ -12,6 +12,7 @@ lv:
   cache:
     pv:
       - '/dev/sda1'
+      - '/dev/sde1'
     vg: 'duplicity'
 
 mount:


### PR DESCRIPTION
Increase the size of the duplicity cache. Since we added additional backups for S3 this runs out of space which means backups end up failing. Add another disk to increase size of the cache.