### PR TITLE
Add clamav to ci agents

### DIFF
--- a/modules/govuk_ci/manifests/agent.pp
+++ b/modules/govuk_ci/manifests/agent.pp
@@ -18,6 +18,7 @@ class govuk_ci::agent(
   $master_ssh_key = undef,
   $elasticsearch_enabled = true,
 ) {
+  include ::clamav
   include ::govuk_ci::agent::redis
   if $docker_enabled {
     include ::govuk_ci::agent::docker


### PR DESCRIPTION
The asset-manager test suite performs an antivirus run against a virus definition and needs the `govuk_clamscan` binary to be present for this. So add the clamav module which handles setting up this executable.