### PR TITLE
Enable sync to S3 in staging

### DIFF
--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -29,6 +29,7 @@ govuk::deploy::setup::ssh_keys:
 
 govuk_cdnlogs::monitoring_enabled: false
 
+govuk_crawler::seed_enable: true
 govuk_crawler::sync_enable: true
 govuk_crawler::targets:
   - 's3://govuk-mirror-staging'

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -29,6 +29,10 @@ govuk::deploy::setup::ssh_keys:
 
 govuk_cdnlogs::monitoring_enabled: false
 
+govuk_crawler::sync_enable: true
+govuk_crawler::targets:
+  - 's3://govuk-mirror-staging'
+
 govuk_jenkins::config::banner_colour_background: '#ffbf47'
 govuk_jenkins::config::banner_colour_text: 'black'
 govuk_jenkins::config::banner_string: 'Carrenza STAGING'


### PR DESCRIPTION
In order to test using S3 for mirroring we want to use staging for failover tests. To do this we need to provision the staging S3 mirror buckets with the mirrors. This enables the sync cron job in staging.

It also enables the crawler-seed job in order to bring Staging more in line with Production