### PR TITLE
Change DRY_RUN to ACTION

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_dns.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_dns.yaml.erb
@@ -29,8 +29,7 @@
             export GOOGLE_REGION=${GOOGLE_REGION}
             export GOOGLE_MANAGED_ZONE=${GOOGLE_MANAGED_ZONE}
             export GOOGLE_PROJECT=${GOOGLE_PROJECT}
-            export DRY_RUN=${DRY_RUN}
-            ./jenkins.sh
+            ./jenkins.sh ${ACTION}
     wrappers:
         - ansicolor:
             colormap: xterm
@@ -67,7 +66,9 @@
             name: GOOGLE_PROJECT
             description: The name of the Google Compute Engine project that contains the dns zone you want to interact with.
             default: <%= @gce_project_id %>
-        - bool:
-            name: DRY_RUN
-            default: true
-            description: When dry run is enabled, it will show a diff but will not deploy changes.
+        - choice:
+            name: ACTION
+            description: Choose whether to plan (default) or apply
+            choices:
+                - plan
+                - apply


### PR DESCRIPTION
When I added the DRY_RUN option I thought this was the difference between a `terraform plan` and a `terraform apply`. However, this was incorrect.

Instead we should pass in an argument to jenkins.sh within the repo to run the intended task.

Default is to plan.