### PR TITLE
Update Filebeat to use only Logit on SSL

### DIFF
--- a/modules/govuk_beat/manifests/init.pp
+++ b/modules/govuk_beat/manifests/init.pp
@@ -28,10 +28,14 @@ class govuk_beat (
 
   $filebeat_outputs = {
     logstash => {
-      hosts   => $hosts,
       enabled => true,
+      hosts   => $hosts,
+      ssl     => {
+        enabled => true,
+      },
     },
   }
+
   # Configure Filebeat. The outputs parameter needs a default value for
   # the process to start
   class { '::filebeat' :


### PR DESCRIPTION
Update govuk_beat configuration to use SSL and install the Logit
intermediate certificate.