### PR TITLE
Add EducationNavigation header to the logs

### DIFF
--- a/modules/nginx/templates/etc/nginx/nginx.conf.erb
+++ b/modules/nginx/templates/etc/nginx/nginx.conf.erb
@@ -56,6 +56,7 @@ http {
                          '"govuk_request_id": "$http_govuk_request_id", '
                          '"govuk_original_url": "$http_govuk_original_url", '
                          '"govuk_dependency_resolution_source_content_id": "$http_govuk_dependency_resolution_source_content_id", '
+                         '"govuk_educationnavigation": "$http_govuk_educationnavigation", '
                          '"varnish_id": "$http_x_varnish", '
                          '"ssl_protocol": "$ssl_protocol", '
                          '"ssl_cipher": "$ssl_cipher" } }';


### PR DESCRIPTION
We would like to see what variant users are on from the logs. This
commit adds the `HTTP_GOVUK_EDUCATIONNAVIGATION` header to the nginx log
format so we can see it.

Trello: https://trello.com/c/1bELZexu/489-make-sure-we-report-the-a-b-test-version-in-the-logs