### PR TITLE
Raise the collections alert threshold for memory

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -267,6 +267,9 @@ govuk::apps::bouncer::db_hostname: "transition-postgresql-slave-1.backend"
 govuk::apps::bouncer::nagios_memory_warning: 1400
 govuk::apps::bouncer::nagios_memory_critical: 1500
 
+govuk::apps::collections::nagios_memory_warning: 900
+govuk::apps::collections::nagios_memory_critical: 1000
+
 govuk::apps::collections_publisher::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::collections_publisher::redis_port: "%{hiera('sidekiq_port')}"
 


### PR DESCRIPTION
The collections app appears to settle at just under 800MB at the moment, giving us constant warnings.

https://graphite.staging.publishing.service.gov.uk/render/?width=1000&height=600&colorList=red,orange,blue,green,purple,brown&target=alias(dashed(constantLine(800000000)),%22critical%22)&target=alias(dashed(constantLine(700000000)),%22warning%22)&target=frontend-1_frontend_staging.processes-app-collections.ps_rss&target=frontend-2_frontend_staging.processes-app-collections.ps_rss&target=frontend-3_frontend_staging.processes-app-collections.ps_rss&from=-30d