### PR TITLE
Specify an explicit $HOME for nagios scripts that use bundler

### DIFF
--- a/modules/icinga/files/usr/lib/nagios/plugins/check_unicorn_workers
+++ b/modules/icinga/files/usr/lib/nagios/plugins/check_unicorn_workers
@@ -19,7 +19,7 @@ fi
 
 cd /var/apps/${APPLICATION}/
 EXPECTED_WORKERS=$(env -i /usr/local/bin/govuk_setenv ${APPLICATION} \
-    env GOVUK_APP_LOGROOT=/tmp bundle exec ruby \
+    env HOME=/tmp GOVUK_APP_LOGROOT=/tmp bundle exec ruby \
     -e 'require "unicorn"; puts Unicorn::Configurator.new(:config_file => "'${CONFIG_FILE}'")[:worker_processes]' \
     2>/dev/null)
 


### PR DESCRIPTION
In bundler 1.14.0 a feature was added to fallback to a /tmp dir if the user's
home dir is not writable (see: https://github.com/bundler/bundler/pull/4951/).
As part of this feature bundler outputs a warning that it is doing this.  When
our check_uricorn_workers script is run by the nagios user it runs a ruby script
via bundler using an empty environment which means it has no $HOME env var set.
This triggers the warning, which unfortunately goes to stdout and interferes
with our script which expects the output to be a number and treats anything else
as an error state.

If we specify a HOME var when running the ruby script we avoid the problem.  We
follow the example for setting GOVUK_APP_LOGROOT to /tmp and do the same as this
will be globally writable, and hopefully we don't actually have to write
anything to run the short ruby script.