### PR TITLE
Remove ci-agent-6

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -666,9 +666,6 @@ govuk_ci::master::ci_agents:
   ci-agent-5:
     agent_hostname: 'ci-agent-5.ci'
     labels: 'mongodb-3.2 ci-agent-5 elasticsearch'
-  ci-agent-6:
-    agent_hostname: 'ci-agent-6.ci'
-    labels: 'ci-agent-6 xenial'
 
 govuk_ci::master::credentials_id: 'jenkins-ssh-slave'
 


### PR DESCRIPTION
This machine does not currently exist and so the generated monitoring
for it is marking the checks as critical. We'll remove it from puppet for now until
we can build the host too.