### PR TITLE
Remove daily purge

### DIFF
--- a/modules/cron/manifests/crondotdee.pp
+++ b/modules/cron/manifests/crondotdee.pp
@@ -34,6 +34,11 @@
 #   Specifically set where the cron should attempt to email output to.
 #   Example would be a user or an email address, or use an empty string to
 #   suppress mailing any output.
+#
+# [*ensure*]
+#   Ensure the file is created. Set to 'absent' to remove the cron job if it is
+#   no longer required.
+#
 define cron::crondotdee (
   $command,
   $hour,
@@ -43,9 +48,10 @@ define cron::crondotdee (
   $weekday = '*',
   $user = 'root',
   $mailto = undef,
+  $ensure = 'present',
 ) {
   file { "/etc/cron.d/${title}":
-    ensure  => present,
+    ensure  => $ensure,
     content => template('cron/etc/cron.d/crondotdee.erb'),
     require => Class['cron'],
     mode    => '0644',

--- a/modules/cron/spec/defines/crondotdee_spec.rb
+++ b/modules/cron/spec/defines/crondotdee_spec.rb
@@ -32,4 +32,11 @@ describe 'cron::crondotdee' do
     it { should contain_file('/etc/cron.d/true_cron').without_content(/MAILTO/) }
   end
 
+  context 'with ensure set to absent' do
+    let(:params) { default_params.merge({
+      :ensure => 'absent',
+    })}
+
+    it { is_expected.to contain_file('/etc/cron.d/true_cron').with_ensure('absent') }
+  end
 end

--- a/modules/govuk/manifests/node/s_mirrorer.pp
+++ b/modules/govuk/manifests/node/s_mirrorer.pp
@@ -7,30 +7,20 @@
 # [*daily_queue_purge*]
 #   This purges the rabbitmq queue of all messages. Use with caution!
 #
-class govuk::node::s_mirrorer (
-  $daily_queue_purge = false,
-) inherits govuk::node::s_base {
+class govuk::node::s_mirrorer inherits govuk::node::s_base {
   include govuk_crawler
   include govuk_rabbitmq
   include nginx
 
-  if $daily_queue_purge {
-    # Create a file that only root can read so not to expose the rabbitmq root password.
-    file { '/root/purge_govuk_crawler_queue.sh':
-      ensure  => present,
-      owner   => 'root',
-      group   => 'root',
-      mode    => '0700',
-      content => "/usr/local/bin/rabbitmqadmin --username=root --password=${::govuk_rabbitmq::root_password} purge queue name=govuk_crawler_queue",
-      require => Class['govuk_rabbitmq'],
-    }
+  # FIXME: remove once deployed to Integration
+  file { '/root/purge_govuk_crawler_queue.sh':
+    ensure => 'absent',
+  }
 
-    cron::crondotdee { 'purge_govuk_crawler_queue':
-      command => '/root/purge_govuk_crawler_queue.sh',
-      hour    => 10,
-      minute  => 30,
-      mailto  => '""',
-      require => File['/root/purge_govuk_crawler_queue.sh'],
-    }
+  cron::crondotdee { 'purge_govuk_crawler_queue':
+    ensure  => 'absent',
+    hour    => 10,
+    minute  => 30,
+    command => '/root/purge_govuk_crawler_queue.sh',
   }
 }


### PR DESCRIPTION
We now sync data to a bucket for Integration so this is no longer required as the rabbitmq queue will be processed.