### PR TITLE
Fix the EducationNavigation header name

### DIFF
--- a/modules/nginx/templates/etc/nginx/nginx.conf.erb
+++ b/modules/nginx/templates/etc/nginx/nginx.conf.erb
@@ -56,7 +56,7 @@ http {
                          '"govuk_request_id": "$http_govuk_request_id", '
                          '"govuk_original_url": "$http_govuk_original_url", '
                          '"govuk_dependency_resolution_source_content_id": "$http_govuk_dependency_resolution_source_content_id", '
-                         '"govuk_educationnavigation": "$http_govuk_educationnavigation", '
+                         '"govuk_abtest_educationnavigation": "$http_govuk_abtest_educationnavigation", '
                          '"varnish_id": "$http_x_varnish", '
                          '"ssl_protocol": "$ssl_protocol", '
                          '"ssl_cipher": "$ssl_cipher" } }';


### PR DESCRIPTION
The header is called `GOVUK-ABTest-EducationNavigation`. This commit
makes sure we pick up the correct value from nginx and pass it on to
kibana.

Trello: https://trello.com/c/1bELZexu/489-make-sure-we-report-the-a-b-test-version-in-the-logs