### PR TITLE
Access Jenkins build parameters with `params.FOO` instead of `env.FOO`

### DIFF
--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -95,7 +95,7 @@ def isAllowedBranchBuild(
   String deployedBranchName = "deployed-to-production") {
 
   if (currentBranchName == deployedBranchName) {
-    if (env.IS_SCHEMA_TEST == "true") {
+    if (params.IS_SCHEMA_TEST == "true") {
       echo "Branch is '${deployedBranchName}' and this is a schema test " +
         "build. Proceeding with build."
       return true


### PR DESCRIPTION
There are three ways of accessing build parameters in Jenkins pipelines: `env.FOO`, `FOO` and `params.FOO`. But the first two versions don't work on the very first build of a branch (see [JENKINS-40574](https://issues.jenkins-ci.org/browse/JENKINS-40574)).

We have been using `env.FOO` and working around the problem by calling the `initializeParameters` function, but it's simpler to use `params.FOO` instead.

We should be able to delete `initializeParameters` once we've updated every other project to using `params` rather than `env` for build parameters. It's fine to leave other environment variables as `env.FOO`.