### PR TITLE
Evaluate boolean build parameter correctly in Jenkins lib

### DIFF
--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -102,7 +102,7 @@ def isAllowedBranchBuild(
   String deployedBranchName = "deployed-to-production") {
 
   if (currentBranchName == deployedBranchName) {
-    if (params.IS_SCHEMA_TEST == "true") {
+    if (params.IS_SCHEMA_TEST) {
       echo "Branch is '${deployedBranchName}' and this is a schema test " +
         "build. Proceeding with build."
       return true


### PR DESCRIPTION
We recently switched from `env.IS_SCHEMA_TEST` to `params.IS_SCHEMA_TEST` to check whether a build is being run to check changes to the content schemas.

The problem is that these variables have different types: the `env` version is a string and the `params` version is a boolean. This means that `params.IS_SCHEMA_TEST == "true"` always evaluated to `false`, which means that schema tests were not being run correctly.

This is a fix for #5592.