### PR TITLE
Pin version of duplicity

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -201,7 +201,7 @@ collectd::plugin::tcp::metrics:
   - 'ActiveOpens'
   - 'PassiveOpens'
 
-duplicity::packages::version: '0.6.23-1ubuntu4.1'
+duplicity::packages::version: '0.7.11-0ubuntu0ppa1263~ubuntu14.04.1'
 
 environment_ip_prefix: '10.1'
 


### PR DESCRIPTION
A newer version of duplicity was recently made available via another PPA, so pin the version to this.