### PR TITLE
Change pushTag to not try and update a branch

### DIFF
--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -235,8 +235,6 @@ def pushTag(String repository, String branch, String tag) {
       sh("git tag -a ${tag} -m 'Jenkinsfile tagging with ${tag}'")
       echo "Tagging alphagov/${repository} master branch -> ${tag}"
       sh("git push git@github.com:alphagov/${repository}.git ${tag}")
-      echo "Updating alphagov/${repository} release branch"
-      sh("git push git@github.com:alphagov/${repository}.git HEAD:release")
     }
   } else {
     echo 'No tagging on branch'


### PR DESCRIPTION
This is breaking publishGem, as the repositories containing gems do
not usually have release branches.