### PR TITLE
Jenkins Deploy Upgrade [stage 1]

### DIFF
--- a/hieradata/class/jenkins.yaml
+++ b/hieradata/class/jenkins.yaml
@@ -1,5 +1,4 @@
 ---
-
 govuk_jenkins::config:
   NAME:
     value: jenkins
@@ -32,60 +31,60 @@ govuk_jenkins::config:
 
 govuk_jenkins::plugins:
   ansicolor:
-    version: '0.3.1'
+    version: '0.4.2'
   build-name-setter:
-    version: '1.3'
+    version: '1.6.5'
   build-pipeline-plugin:
-    version: '1.4.5'
+    version: '1.5.4'
   build-with-parameters:
     version: '1.3'
   conditional-buildstep:
-    version: '1.3.3'
+    version: '1.3.5'
   copyartifact:
-    version: '1.35'
+    version: '1.38.1'
   description-setter:
-    version: '1.9'
+    version: '1.10'
   downstream-buildview:
     version: '1.9'
   envinject:
-    version: '1.91.1'
+    version: '1.93.1'
   external-monitor-job:
-    version: '1.2'
+    version: '1.7'
   git:
-    version: '2.2.6'
+    version: '3.0.0'
   git-client:
-    version: '1.10.2'
+    version: '2.3.0'
   github-api:
-    version: '1.58'
+    version: '1.79'
   github-oauth:
     version: '0.19'
   greenballs:
-    version: '1.14'
+    version: '1.15'
   jquery:
-    version: '1.7.2-1'
+    version: '1.11.2-0'
   parameterized-trigger:
-    version: '2.26'
+    version: '2.32'
   rebuild:
-    version: '1.22'
+    version: '1.25'
   role-strategy:
-    version: '2.2.0'
+    version: '2.3.2'
   run-condition:
     version: '1.0'
   simple-theme-plugin:
     version: '0.3'
   scm-api:
-    version: '0.2'
+    version: '1.3'
   show-build-parameters:
     version: '1.0'
   slack:
-    version: '1.7'
+    version: '2.0.1'
   text-finder:
     version: '1.10'
   timestamper:
-    version: '1.8.2'
+    version: '1.8.8'
   token-macro:
-    version: '1.9'
+    version: '2.0'
   versionnumber:
-    version: '1.5'
+    version: '1.8.1'
   ws-cleanup:
-    version: '0.25'
+    version: '0.32'

--- a/hieradata/vagrant.yaml
+++ b/hieradata/vagrant.yaml
@@ -203,3 +203,61 @@ mongodb::s3backup::backup::private_gpg_key: |
   -----END PGP PRIVATE KEY BLOCK-----
 
 mongodb::s3backup::backup::private_gpg_key_fingerprint: 'CB77872D51ADD27CF75BD63CB60B50E6DBE2EAFF'
+
+govuk_jenkins::plugins:
+  ansicolor:
+    version: '0.4.2'
+  build-name-setter:
+    version: '1.6.5'
+  build-pipeline-plugin:
+    version: '1.5.4'
+  build-with-parameters:
+    version: '1.3'
+  conditional-buildstep:
+    version: '1.3.5'
+  copyartifact:
+    version: '1.38.1'
+  description-setter:
+    version: '1.10'
+  downstream-buildview:
+    version: '1.9'
+  envinject:
+    version: '1.93.1'
+  external-monitor-job:
+    version: '1.7'
+  git:
+    version: '3.0.0'
+  git-client:
+    version: '2.3.0'
+  github-api:
+    version: '1.79'
+  greenballs:
+    version: '1.15'
+  jquery:
+    version: '1.11.2-0'
+  parameterized-trigger:
+    version: '2.32'
+  rebuild:
+    version: '1.25'
+  role-strategy:
+    version: '2.3.2'
+  run-condition:
+    version: '1.0'
+  simple-theme-plugin:
+    version: '0.3'
+  scm-api:
+    version: '1.3'
+  show-build-parameters:
+    version: '1.0'
+  slack:
+    version: '2.0.1'
+  text-finder:
+    version: '1.10'
+  timestamper:
+    version: '1.8.8'
+  token-macro:
+    version: '2.0'
+  versionnumber:
+    version: '1.8.1'
+  ws-cleanup:
+    version: '0.32'

--- a/modules/govuk_jenkins/manifests/init.pp
+++ b/modules/govuk_jenkins/manifests/init.pp
@@ -36,7 +36,7 @@ class govuk_jenkins (
   $plugins = {},
   $ssh_private_key = undef,
   $ssh_public_key = undef,
-  $version = '1.554.2',
+  $version = '2.19.2',
   $jenkins_api_token = '',
   $jenkins_user = 'jenkins',
   $jenkins_homedir = '/var/lib/jenkins',


### PR DESCRIPTION
Upgrading deploy Jenkins to version 2.

Plugin versions had to be modified to be compatible with upgraded Jenkins core.

plugin=github-oauth must be omitted when provisioning a vagrant instance.  This is because the plugin will cause Jenkins to not load its configuration due to the lack of an auth backend.

see: https://trello.com/c/RZCVbiHd