### PR TITLE
Add Lockable Resources Plugin to Jenkins

### DIFF
--- a/hieradata/class/ci_master.yaml
+++ b/hieradata/class/ci_master.yaml
@@ -99,6 +99,8 @@ govuk_jenkins::plugins:
       version: "1.11.2-0"
     junit:
       version: "1.19"
+    lockable-resources:
+      version: "1.11.1"
     mailer:
       version: "1.18"
     mapdb-api:


### PR DESCRIPTION
Add the latest version of the Lockable Resources Plugin: https://wiki.jenkins-ci.org/display/JENKINS/Lockable+Resources+Plugin

This plugin should give us more control over parallel builds of the same project, which will reduce the time spent waiting for builds to run. This is especially important for downstream schema tests, which currently often sit in a long queue before running.

Most projects currently use the Throttle Concurrent Builds plugin to control parallel jobs, but this has some problems:
 - The `maxConcurrentPerNode` setting is currently [incompatible with pipeline jobs](https://issues.jenkins-ci.org/browse/JENKINS-40303), so if no other throttling is added then Jenkins may try to run parallel builds of the same project on the same node. Some of these builds will fail, e.g. when one build modifies the gems being used by a different build.
 - If `limitOneJobWithMatchingParams` is used, it causes all the downstream schema tests to block while any other schema test is running. Slow builds like whitehall cause a long backlog of every other schema test build.

The Lockable Resources Plugin is really designed to prevent multiple builds from sharing individual resources like external machines, but the general consensus is that it should also be used in place of Throttle Concurrent Builds when running pipeline jobs:
- http://stackoverflow.com/questions/36454130/how-do-i-prevent-two-pipeline-jenkins-jobs-of-the-same-type-to-run-in-parallel-o
- https://issues.jenkins-ci.org/browse/JENKINS-31801

Trello: https://trello.com/c/zS6xM6Kl/18-whitehall-jobs-block-other-jobs