### PR TITLE
Add a Plex service URI for Licensify for draft frontend

### DIFF
--- a/modules/govuk/manifests/node/s_draft_frontend.pp
+++ b/modules/govuk/manifests/node/s_draft_frontend.pp
@@ -14,6 +14,7 @@ class govuk::node::s_draft_frontend() inherits govuk::node::s_base {
     'PLEK_HOSTNAME_PREFIX': value => 'draft-';
     'PLEK_SERVICE_ERRBIT_URI': value => "https://errbit.${app_domain}";
     'PLEK_SERVICE_IMMINENCE_URI': value => "https://imminence.${app_domain}";
+    'PLEK_SERVICE_LICENSIFY_URI': value => "https://licensify.${app_domain}";
     'PLEK_SERVICE_LOCAL_LINKS_MANAGER_URI': value => "https://local-links-manager.${app_domain}";
     'PLEK_SERVICE_MAPIT_URI': value  => "https://mapit.${app_domain}";
     'PLEK_SERVICE_SEARCH_URI': value => "https://search.${app_domain}";


### PR DESCRIPTION
- In the same vein as PR 5476. Frontend talks to Licensify to get licence details.