### PR TITLE
Allow the memory usage to be set for this applications nagios checks

### DIFF
--- a/modules/govuk/manifests/apps/collections.pp
+++ b/modules/govuk/manifests/apps/collections.pp
@@ -17,20 +17,30 @@
 # [*secret_key_base*]
 #   The key for Rails to use when signing/encrypting sessions.
 #
+# [*nagios_memory_warning*]
+#   Memory use at which Nagios should generate a warning.
+#
+# [*nagios_memory_critical*]
+#   Memory use at which Nagios should generate a critical alert.
+#
 class govuk::apps::collections(
   $vhost = 'collections',
   $port = '3070',
   $errbit_api_key = undef,
   $secret_key_base = undef,
+  $nagios_memory_warning = undef,
+  $nagios_memory_critical = undef,
 ) {
   govuk::app { 'collections':
-    app_type              => 'rack',
-    port                  => $port,
-    health_check_path     => '/topic/oil-and-gas',
-    log_format_is_json    => true,
-    asset_pipeline        => true,
-    asset_pipeline_prefix => 'collections',
-    vhost                 => $vhost,
+    app_type               => 'rack',
+    port                   => $port,
+    health_check_path      => '/topic/oil-and-gas',
+    log_format_is_json     => true,
+    asset_pipeline         => true,
+    asset_pipeline_prefix  => 'collections',
+    vhost                  => $vhost,
+    nagios_memory_warning  => $nagios_memory_warning,
+    nagios_memory_critical => $nagios_memory_critical,
   }
 
   Govuk::App::Envvar {


### PR DESCRIPTION
The limit was raised in https://github.com/alphagov/govuk-puppet/pull/5581/commits/987b34b3da3f904b21f081975ea90ba0e0baca6e
but the class doesn't know how to process the values. Adding these params
will allow the new values to be used.