### PR TITLE
Fix ssh-key usage in gem push

### DIFF
--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -336,10 +336,14 @@ def publishGem(String repository, String branch) {
     sh("gem push ${repository}-${version}.gem")
   }
 
-  def taggedReleaseExists = sh(
-    script: "git ls-remote --exit-code --tags origin v${version}",
-    returnStatus: true
-  ) == 0
+  def taggedReleaseExists = false
+
+  sshagent(['govuk-ci-ssh-key']) {
+    taggedReleaseExists = sh(
+      script: "git ls-remote --exit-code --tags origin v${version}",
+      returnStatus: true
+    ) == 0
+  }
 
   if (taggedReleaseExists) {
     echo "Version ${version} has already been tagged on Github. Skipping publication."


### PR DESCRIPTION
This wraps the `git ls-remote` script in a block to use the correct SSH key. This prevents the script from trying to create a tag when it already exists.

https://trello.com/c/ONAhXHP8