### PR TITLE
Add single-step build for most projects

### DIFF
--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -451,7 +451,10 @@ def buildProject(sassLint = true) {
     }
 
     stage("Run tests") {
-      runTests()
+      // Prevent a project's tests from running in parallel on the same node
+      lock("$repoName-$NODE_NAME-test") {
+        runTests()
+      }
     }
 
     if (hasAssets()) {

--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -463,17 +463,19 @@ def buildProject(sassLint = true) {
       }
     }
 
-    if (isGem()) {
-      stage("Publish Gem to Rubygems") {
-        publishGem(repoName, env.BRANCH_NAME)
-      }
-    } else {
-      stage("Push release tag") {
-        pushTag(repoName, env.BRANCH_NAME, 'release_' + env.BUILD_NUMBER)
-      }
+    if (env.BRANCH_NAME == "master") {
+      if (isGem()) {
+        stage("Publish Gem to Rubygems") {
+          publishGem(repoName, env.BRANCH_NAME)
+        }
+      } else {
+        stage("Push release tag") {
+          pushTag(repoName, env.BRANCH_NAME, 'release_' + env.BUILD_NUMBER)
+        }
 
-      stage("Deploy to integration") {
-        deployIntegration(repoName, env.BRANCH_NAME, 'release', 'deploy')
+        stage("Deploy to integration") {
+          deployIntegration(repoName, env.BRANCH_NAME, 'release', 'deploy')
+        }
       }
     }
 

--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -394,11 +394,6 @@ def buildProject(sassLint = true) {
   ])
 
   try {
-    initializeParameters([
-      'IS_SCHEMA_TEST': 'false',
-      'SCHEMA_BRANCH': 'deployed-to-production',
-    ])
-
     if (!isAllowedBranchBuild(env.BRANCH_NAME)) {
       return
     }
@@ -421,7 +416,7 @@ def buildProject(sassLint = true) {
     }
 
     stage("Set up content schema dependency") {
-      contentSchemaDependency(env.SCHEMA_BRANCH)
+      contentSchemaDependency(params.SCHEMA_BRANCH)
       setEnvar("GOVUK_CONTENT_SCHEMAS_PATH", "tmp/govuk-content-schemas")
     }
 

--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -367,4 +367,158 @@ def withStatsdTiming(key, fn) {
   sh 'echo "ci.' + project_name + '.' + key + ':' + runtime + '|ms" | nc -w 1 -u localhost 8125'
 }
 
+/**
+ * Build the project
+ * @param sassLint Whether or not to run the SASS linter
+ */
+def buildProject(sassLint = true) {
+  repoName = JOB_NAME.split('/')[0]
+
+  properties([
+    buildDiscarder(
+      logRotator(
+        numToKeepStr: '50')
+      ),
+    [$class: 'RebuildSettings', autoRebuild: false, rebuildDisabled: false],
+    [$class: 'ParametersDefinitionProperty',
+      parameterDefinitions: [
+        [$class: 'BooleanParameterDefinition',
+          name: 'IS_SCHEMA_TEST',
+          defaultValue: false,
+          description: 'Identifies whether this build is being triggered to test a change to the content schemas'],
+        [$class: 'StringParameterDefinition',
+          name: 'SCHEMA_BRANCH',
+          defaultValue: 'deployed-to-production',
+          description: 'The branch of govuk-content-schemas to test against']]
+    ],
+  ])
+
+  try {
+    initializeParameters([
+      'IS_SCHEMA_TEST': 'false',
+      'SCHEMA_BRANCH': 'deployed-to-production',
+    ])
+
+    if (!isAllowedBranchBuild(env.BRANCH_NAME)) {
+      return
+    }
+
+    stage("Checkout") {
+      checkoutFromGitHubWithSSH(repoName)
+    }
+
+    stage("Clean up workspace") {
+      cleanupGit()
+    }
+
+    stage("Merge master") {
+      mergeMasterBranch()
+    }
+
+    stage("Configure environment") {
+      setEnvar("RAILS_ENV", "test")
+      setEnvar("RACK_ENV", "test")
+    }
+
+    stage("Set up content schema dependency") {
+      contentSchemaDependency(env.SCHEMA_BRANCH)
+      setEnvar("GOVUK_CONTENT_SCHEMAS_PATH", "tmp/govuk-content-schemas")
+    }
+
+    stage("bundle install") {
+      if (isGem()) {
+        bundleGem()
+      } else {
+        bundleApp()
+      }
+    }
+
+    if (hasLint()) {
+      stage("Lint Ruby") {
+        rubyLinter()
+      }
+    } else {
+      echo "WARNING: You do not have Ruby linting turned on. Please install govuk-lint and enable."
+    }
+
+    if (hasAssets() && sassLint) {
+      stage("Lint SASS") {
+        sassLinter()
+      }
+    } else {
+      echo "WARNING: You do not have SASS linting turned on. Please install govuk-lint and enable."
+    }
+
+    if (hasDatabase()) {
+      stage("Set up the database") {
+        runRakeTask("db:drop db:create db:schema:load")
+      }
+    }
+
+    stage("Run tests") {
+      runTests()
+    }
+
+    if (hasAssets()) {
+      stage("Precompile assets") {
+        precompileAssets()
+      }
+    }
+
+    if (isGem()) {
+      stage("Publish Gem to Rubygems") {
+        publishGem(repoName, env.BRANCH_NAME)
+      }
+    } else {
+      stage("Push release tag") {
+        pushTag(repoName, env.BRANCH_NAME, 'release_' + env.BUILD_NUMBER)
+      }
+
+      stage("Deploy to integration") {
+        deployIntegration(repoName, env.BRANCH_NAME, 'release', 'deploy')
+      }
+    }
+
+  } catch (e) {
+    currentBuild.result = "FAILED"
+    step([$class: 'Mailer',
+          notifyEveryUnstableBuild: true,
+          recipients: 'govuk-ci-notifications@digital.cabinet-office.gov.uk',
+          sendToIndividuals: true])
+    throw e
+  }
+}
+
+/**
+ * Does this project use Rails-style assets?
+ */
+def hasAssets() {
+  sh(script: "test -d app/assets", returnStatus: true) == 0
+}
+
+/**
+ * Does this project use GOV.UK lint?
+ */
+def hasLint() {
+  sh(script: "grep 'govuk-lint' Gemfile.lock", returnStatus: true) == 0
+}
+
+/**
+ * Is this a Ruby gem?
+ *
+ * Determined by checking the presence of a `.gemspec` file
+ */
+def isGem() {
+  sh(script: "ls | grep gemspec", returnStatus: true) == 0
+}
+
+/**
+ * Does this project use a Rails-style database?
+ *
+ * Determined by checking the presence of a `database.yml` file
+ */
+def hasDatabase() {
+  sh(script: "test -e config/database.yml", returnStatus: true) == 0
+}
+
 return this;

--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -457,7 +457,7 @@ def buildProject(sassLint = true) {
       }
     }
 
-    if (hasAssets()) {
+    if (hasAssets() && !params.IS_SCHEMA_TEST) {
       stage("Precompile assets") {
         precompileAssets()
       }

--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -430,7 +430,7 @@ def buildProject(sassLint = true) {
 
     if (hasLint()) {
       stage("Lint Ruby") {
-        rubyLinter()
+        rubyLinter("app lib spec test")
       }
     } else {
       echo "WARNING: You do not have Ruby linting turned on. Please install govuk-lint and enable."


### PR DESCRIPTION
This adds functionality to perform the build process with a minimal Jenkinsfile. In most cases the following will be sufficient:

```groovy
#!/usr/bin/env groovy
node {
  def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
  govuk.buildProject()
}
```

It's been tested with:

- content-tagger (Rails app with database)
- collections & finder-frontend (Rails apps without database)
- rummager (Sinatra app)
- email-alert-service (non-web app)
- govuk_ab_testing (a Ruby gem)

The script uses some simple heuristics to determine how to build/test/release the project.

It's intended to fix a number of specific problems and make it easier to iterate on the build process.

- @36degrees discovered that some downstream schema testing projects aren't correctly checking out the correct branch, which causes them to tests against the `deployed-to-production` branch of the schemas, not against the branch they should be testing against
(https://trello.com/c/iZMj1jz9).
- The [throttling configuration][throttle] in some apps is wrong, causing slow builds.
- @mcgoooo discovered that the [contacts-admin tests][contacts] weren't being run because `RAILS_ENV` wasn't set.
- `checkout scm` often runs into trouble with rate limiting, but it's hard to change all the Jenkinsfiles (https://trello.com/c/amd0k0xe)

### SASS linting

The only thing we can't infer from the code is whether or not the project is supposed to run SASS linting. If you aren't ready to run this linter yet, you can disable it explicitly:

```groovy
#!/usr/bin/env groovy
node {
  def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
  govuk.buildProject(false)
}
```

### Trade-offs

- We have to clone the schemas for all projects. This is acceptable because most projects use the schemas, but it will slow down non-schema tests with a few seconds.
- It's easy to break CI for all projects by messing up this script. If that happens often we should be looking to add groovy unit tests or do some kind of integration test.
- Some projects will have to be updated to respond correctly to `bundle exec rake (default)`, which should run the tests. This is acceptable because it improves consistency across projects.
- It's not possible to specify the linting directories so [some projects](man) will have less linting. 

[throttle]: https://github.com/alphagov/content-tagger/blob/5fefdace31953b2582780f1932dc5198463a0f9c/Jenkinsfile#L15-L22
[contacts]: alphagov/contacts-admin#265
[man]: https://github.com/alphagov/manuals-publisher/blob/3cd802d065ad21e063f28311dd522c54455c5c78/Jenkinsfile#L70

https://trello.com/c/iDWjE1Vz
