### PR TITLE
Update crawler S3 sync command to avoid re-uploads

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -42,7 +42,7 @@ govuk_cdnlogs::monitoring_enabled: false
 govuk_crawler::seed_enable: true
 govuk_crawler::sync_enable: true
 govuk_crawler::targets:
-  - 's3://govuk-mirror-integration'
+  - 's3://govuk-mirror-integration/'
 
 govuk_elasticsearch::dump::run_es_dump_hour: '9'
 

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -32,7 +32,7 @@ govuk_cdnlogs::monitoring_enabled: false
 govuk_crawler::seed_enable: true
 govuk_crawler::sync_enable: true
 govuk_crawler::targets:
-  - 's3://govuk-mirror-staging'
+  - 's3://govuk-mirror-staging/'
 
 govuk_jenkins::config::banner_colour_background: '#ffbf47'
 govuk_jenkins::config::banner_colour_text: 'black'

--- a/modules/govuk_crawler/templates/govuk_sync_mirror.erb
+++ b/modules/govuk_crawler/templates/govuk_sync_mirror.erb
@@ -53,7 +53,9 @@ for TARGET in ${TARGETS}; do
 
   # Toggle the command: whether we will use rsync of the s3 sync.
   if [[ $TARGET = s3://* ]]; then
-    CMD="/usr/local/bin/govuk_setenv s3_sync_mirror /usr/local/bin/s3cmd sync --cache-file=/tmp/s3cmd_mirror_sync.cache --exclude=\"lost+found\" ${MIRROR_ROOT}/. ${TARGET}"
+    # With s3cmd sync, target needs to end with /
+    if [[ ! $(echo ${TARGET} | egrep '/$') ]] ; then TARGET="${TARGET}/" ; fi
+    CMD="/usr/local/bin/govuk_setenv s3_sync_mirror /usr/local/bin/s3cmd sync --cache-file=/tmp/s3cmd_mirror_sync.cache --exclude=\"lost+found\" ${MIRROR_ROOT}/ ${TARGET}"
   else
     CMD="rsync -az --exclude 'lost+found' ${MIRROR_ROOT}/. ${TARGET}:/srv/mirror_data"
   fi


### PR DESCRIPTION
When syncing the website mirror files to S3, s3cmd is not detecting the
remote files so it's re-uploading all the files every time it runs.

s3cmd is quite specific about the declaration of the origin and target
directories, this change removes the dot at the end of the origin
directory so the files in the remote dir can be detected. With this change
we also need to force the target directory to end with /

More info:
https://github.com/s3tools/s3cmd/issues/745
https://github.com/s3tools/s3cmd/issues/660