### PR TITLE
Set imagemagick to present, not a specific version.

### DIFF
--- a/modules/imagemagick/manifests/init.pp
+++ b/modules/imagemagick/manifests/init.pp
@@ -4,7 +4,7 @@
 #
 class imagemagick {
   package { 'imagemagick':
-    ensure => '8:6.7.7.10-6ubuntu3.5',
+    ensure => 'present',
   }
 
   file { '/etc/ImageMagick/policy.xml':


### PR DESCRIPTION
Our unattended security patches currently bump the version when an upstream
security release is made and then our puppet, which has an explicit version, fails
to apply until the version number is changed in this code. Moving to 'present' will
stop puppet complaining in this way