### PR TITLE
Set process and file limits for Jenkins user

### DIFF
--- a/modules/govuk_ci/manifests/agent.pp
+++ b/modules/govuk_ci/manifests/agent.pp
@@ -31,6 +31,7 @@ class govuk_ci::agent(
   include ::govuk_ci::agent::postgresql
   include ::govuk_ci::agent::mysql
   include ::govuk_ci::credentials
+  include ::govuk_ci::limits
   include ::govuk_ci::vpn
   include ::govuk_java::oracle8
   include ::govuk_jenkins::github_enterprise_cert

--- a/modules/govuk_ci/manifests/limits.pp
+++ b/modules/govuk_ci/manifests/limits.pp
@@ -1,0 +1,19 @@
+# == Class: Govuk_ci::Limits
+#
+# Set process and file limits for the Jenkins user
+#
+class govuk_ci::limits {
+  limits::limits { 'jenkins_nofile':
+    ensure     => present,
+    user       => 'jenkins',
+    limit_type => 'nofile',
+    both       => 8192,
+  }
+
+  limits::limits { 'jenkins_nproc':
+    ensure     => present,
+    user       => 'jenkins',
+    limit_type => 'nproc',
+    both       => 30654,
+  }
+}

--- a/modules/govuk_ci/manifests/master.pp
+++ b/modules/govuk_ci/manifests/master.pp
@@ -28,6 +28,7 @@ class govuk_ci::master (
   validate_hash($environment_variables)
 
   include ::govuk_ci::credentials
+  include ::govuk_ci::limits
   include ::govuk_ci::vpn
 
   # After these users have been created, you'll have to retrieve the API token from the UI


### PR DESCRIPTION
We keep seeing the following error when we run many jobs at once:

```
Caused by: java.lang.OutOfMemoryError: unable to create new native thread
      at java.lang.Thread.start0(Native Method)
      at java.lang.Thread.start(Thread.java:714)
      at java.util.concurrent.ThreadPoolExecutor.addWorker(ThreadPoolExecutor.java:949)
      at java.util.concurrent.ThreadPoolExecutor.execute(ThreadPoolExecutor.java:1371)
```

[This article](https://support.cloudbees.com/hc/en-us/articles/204231510-Memory-problem-unable-to-create-new-native-thread-) suggests that the process and file limits need to be raised.

This commit creates a new class that creates these limits using the saz/limits module. The values are based upon the CloudBees KB article.