### PR TITLE
Increase api-mongo-2 disk time window

### DIFF
--- a/hieradata/class/api_mongo.yaml
+++ b/hieradata/class/api_mongo.yaml
@@ -38,4 +38,4 @@ mongodb::server::replicaset_members:
     hidden: true
     priority: 0
 
-icinga::client::checks::disk_time_window_minutes: 7
+icinga::client::checks::disk_time_window_minutes: 10


### PR DESCRIPTION
api-mongo-2 runs 15 minutely backups that routinely alert for high disk time. The disk time window is set to 10 minutes in the base mongo class and then reduced to 7 (to try and fix this problem) in api_mongo.

This commit resets to 10 minutes just for api-mongo-2.