### PR TITLE
Revert "CI Bundle Cleanup"

### DIFF
--- a/modules/govuk_ci/manifests/agent.pp
+++ b/modules/govuk_ci/manifests/agent.pp
@@ -63,10 +63,4 @@ class govuk_ci::agent(
   package { 'libgdal-dev': # needed for mapit
     ensure => installed,
   }
-
-  cron::crondotdee { 'clean_up_bundles':
-    command => 'find /var/lib/jenkins/bundles/* -maxdepth 1 -type d -mtime +1 -exec rm -rf {} \;',
-    hour    => 7,
-    minute  => 45,
-  }
 }


### PR DESCRIPTION
This reverts commit b6c576310a4658af2fa8c1e1604ed86e81e01681.

Clearing the bundle directories every day is no longer necessary because all gems are being installed into the same directory (#5604) rather than into a separate directory for each branch of a project.

cc @tijmenb @surminus 