### PR TITLE
Set DISPLAY env variable for tests

### DIFF
--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -417,6 +417,7 @@ def buildProject(sassLint = true) {
     stage("Configure environment") {
       setEnvar("RAILS_ENV", "test")
       setEnvar("RACK_ENV", "test")
+      setEnvar("DISPLAY", ":99")
     }
 
     stage("Set up content schema dependency") {


### PR DESCRIPTION
This will allow capybara-webkit to run without using `xvfb-run -a` first.

Will allow us to port https://github.com/alphagov/specialist-publisher/pull/1017 to the new jenkins.

https://trello.com/c/iDWjE1Vz