### PR TITLE
Revert removal of homepage no-cache rules

### DIFF
--- a/modules/govuk/manifests/apps/frontend.pp
+++ b/modules/govuk/manifests/apps/frontend.pp
@@ -47,6 +47,11 @@ class govuk::apps::frontend(
     nagios_memory_warning  => $nagios_memory_warning,
     nagios_memory_critical => $nagios_memory_critical,
     vhost                  => $vhost,
+    nginx_extra_config     => '
+  location ^~ /frontend/homepage/no-cache/ {
+    expires epoch;
+  }
+  ',
   }
 
   govuk::app::envvar { "${title}-PUBLISHING_API_BEARER_TOKEN":


### PR DESCRIPTION
This re-opens https://github.com/alphagov/govuk-puppet/pull/5441 and add in configuration used originally in puppet for the original experiment.

And is part of running the no-js experiment again https://gds.blog.gov.uk/2013/10/21/how-many-people-are-missing-out-on-javascript-enhancement/