### PR TITLE
Add build name to job list

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_dns.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_dns.yaml.erb
@@ -19,6 +19,11 @@
             url: https://github.com/alphagov/govuk-dns/
     scm:
       - Deploy_DNS
+    wrappers:
+        - ansicolor:
+            colormap: xterm
+        - build-name:
+            name: '${ENV,var="PROVIDERS"} ${ENV,var="ACTION"}'
     builders:
         - shell: |
             export DEPLOY_ENV=<%= @environment %>


### PR DESCRIPTION
This makes it easier to see what was deployed and when.