### PR TITLE
Suppress output of Google credentials

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_dns.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_dns.yaml.erb
@@ -27,7 +27,9 @@
     builders:
         - shell: |
             export DEPLOY_ENV=<%= @environment %>
+            set +x
             export GOOGLE_CREDENTIALS="`cat <%= @credentials_file_path %>`"
+            set -x
             ./jenkins.sh ${ACTION}
     wrappers:
         - ansicolor:


### PR DESCRIPTION
This ensures that the credentials are not visible in the Jenkins job output.