### PR TITLE
Don't upgrade Jenkins in Staging or Prod

### DIFF
--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -1,4 +1,6 @@
 ---
+govuk_jenkins::version: '1.554.2'
+
 govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::bouncer_cdn
   - govuk_jenkins::job::build_fpm_package

--- a/hieradata/class/staging/jenkins.yaml
+++ b/hieradata/class/staging/jenkins.yaml
@@ -1,4 +1,6 @@
 ---
+govuk_jenkins::version: '1.554.2'
+
 govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::data_sync_complete_staging
   - govuk_jenkins::job::deploy_app


### PR DESCRIPTION
We're testing in Integration, but we don't want it in Staging or Production yet, so keep the version to the same as it is currently.