### PR TITLE
Do not update plugins in Staging/Prod

### DIFF
--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -1,6 +1,66 @@
 ---
 govuk_jenkins::version: '1.554.2'
 
+govuk_jenkins::plugins:
+  ansicolor:
+    version: '0.3.1'
+  build-name-setter:
+    version: '1.3'
+  build-pipeline-plugin:
+    version: '1.4.5'
+  build-with-parameters:
+    version: '1.3'
+  conditional-buildstep:
+    version: '1.3.3'
+  copyartifact:
+    version: '1.35'
+  description-setter:
+    version: '1.9'
+  downstream-buildview:
+    version: '1.9'
+  envinject:
+    version: '1.91.1'
+  external-monitor-job:
+    version: '1.2'
+  git:
+    version: '2.2.6'
+  git-client:
+    version: '1.10.2'
+  github-api:
+    version: '1.58'
+  github-oauth:
+    version: '0.19'
+  greenballs:
+    version: '1.14'
+  jquery:
+    version: '1.7.2-1'
+  parameterized-trigger:
+    version: '2.26'
+  rebuild:
+    version: '1.22'
+  role-strategy:
+    version: '2.2.0'
+  run-condition:
+    version: '1.0'
+  simple-theme-plugin:
+    version: '0.3'
+  scm-api:
+    version: '0.2'
+  show-build-parameters:
+    version: '1.0'
+  slack:
+    version: '1.7'
+  text-finder:
+    version: '1.10'
+  timestamper:
+    version: '1.8.2'
+  token-macro:
+    version: '1.9'
+  versionnumber:
+    version: '1.5'
+  ws-cleanup:
+    version: '0.25'
+
 govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::bouncer_cdn
   - govuk_jenkins::job::build_fpm_package

--- a/hieradata/class/staging/jenkins.yaml
+++ b/hieradata/class/staging/jenkins.yaml
@@ -1,6 +1,66 @@
 ---
 govuk_jenkins::version: '1.554.2'
 
+govuk_jenkins::plugins:
+  ansicolor:
+    version: '0.3.1'
+  build-name-setter:
+    version: '1.3'
+  build-pipeline-plugin:
+    version: '1.4.5'
+  build-with-parameters:
+    version: '1.3'
+  conditional-buildstep:
+    version: '1.3.3'
+  copyartifact:
+    version: '1.35'
+  description-setter:
+    version: '1.9'
+  downstream-buildview:
+    version: '1.9'
+  envinject:
+    version: '1.91.1'
+  external-monitor-job:
+    version: '1.2'
+  git:
+    version: '2.2.6'
+  git-client:
+    version: '1.10.2'
+  github-api:
+    version: '1.58'
+  github-oauth:
+    version: '0.19'
+  greenballs:
+    version: '1.14'
+  jquery:
+    version: '1.7.2-1'
+  parameterized-trigger:
+    version: '2.26'
+  rebuild:
+    version: '1.22'
+  role-strategy:
+    version: '2.2.0'
+  run-condition:
+    version: '1.0'
+  simple-theme-plugin:
+    version: '0.3'
+  scm-api:
+    version: '0.2'
+  show-build-parameters:
+    version: '1.0'
+  slack:
+    version: '1.7'
+  text-finder:
+    version: '1.10'
+  timestamper:
+    version: '1.8.2'
+  token-macro:
+    version: '1.9'
+  versionnumber:
+    version: '1.5'
+  ws-cleanup:
+    version: '0.25'
+
 govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::data_sync_complete_staging
   - govuk_jenkins::job::deploy_app


### PR DESCRIPTION
As per the previous commit (168da3a56ea95c1b79cd4c33b491f64ebc592ad9), we also do not want to force the update of plugins.

Add into each separate environment based class hieradata so they can be removed when we come round to upgrading in these environments.