### PR TITLE
Don't run SASS lint if the app doesn't have govuk_lint

### DIFF
--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -441,7 +441,7 @@ def buildProject(sassLint = true) {
       echo "WARNING: You do not have Ruby linting turned on. Please install govuk-lint and enable."
     }
 
-    if (hasAssets() && sassLint) {
+    if (hasAssets() && hasLint() && sassLint) {
       stage("Lint SASS") {
         sassLinter()
       }


### PR DESCRIPTION
This skips the SASS linting if the project doesn't have govuk_lint installed. We already do this for the ruby linting.

This is tripping up https://github.com/alphagov/email-alert-frontend/pull/31.