### PR TITLE
Add mirrorS3 Fastly backend to Grafana dashboard

### DIFF
--- a/modules/grafana/templates/dashboards/edge_health.json.erb
+++ b/modules/grafana/templates/dashboards/edge_health.json.erb
@@ -545,6 +545,10 @@
             {
               "target": "stats.govuk.app.govuk-cdn-logs-monitor.logs-cdn-1.cdn_backend.error",
               "refId": "D"
+            },
+            {
+              "target": "stats.govuk.app.govuk-cdn-logs-monitor.logs-cdn-1.cdn_backend.mirrorS3",
+              "refId": "E"
             }
           ],
           "title": "Requests by CDN backend",


### PR DESCRIPTION
Update the Edge Heatlth Grafana Dashboard to include the new Fastly S3 backend