### PR TITLE
Update ETCD Image

### DIFF
--- a/modules/govuk/manifests/node/s_docker_management.pp
+++ b/modules/govuk/manifests/node/s_docker_management.pp
@@ -6,7 +6,7 @@ class govuk::node::s_docker_management inherits govuk::node::s_base {
   include ::govuk_containers::docker_security_bench
 
   $etcd_image = 'quay.io/coreos/etcd'
-  $etcd_image_version = 'v3.0.13'
+  $etcd_image_version = 'v3.1.3'
 
   ::docker::image { $etcd_image:
     ensure    => 'present',


### PR DESCRIPTION
Current image marked as vunerable by vendor.  Ideally the version should be set to latest, which would allow auto-patching but that should be discussed.

See: https://quay.io/repository/coreos/etcd/image/4d3a6160f8b0a2962dccdd11e677e1a03258b4b4a1aa8f629066cf0fd0e2ab2b?tab=vulnerabilities

See: https://trello.com/c/gZ2cXr3g