### PR TITLE
Add delayed_job worker to cpm

### DIFF
--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -104,6 +104,7 @@ govuk::apps::authenticating_proxy::govuk_upstream_uri: 'http://government-fronte
 govuk::apps::backdrop_write::enable_procfile_worker: false
 govuk::apps::collections_publisher::enable_procfile_worker: false
 govuk::apps::contacts::extra_aliases: ['contacts-admin']
+govuk::apps::content_performance_manager::enable_delayed_job_worker: false
 govuk::apps::content_store::mongodb_nodes: ['localhost']
 govuk::apps::content_store::mongodb_name: 'content_store_development'
 govuk::apps::content_tagger::enable_procfile_worker: false

--- a/modules/govuk/manifests/apps/content_performance_manager.pp
+++ b/modules/govuk/manifests/apps/content_performance_manager.pp
@@ -23,6 +23,9 @@
 #   Google authentication email
 #   Default: undef
 #
+# [*enable_delayed_job_worker*]
+#   Whether or not to enable the background worker for Delayed Job.
+#   Boolean value.
 #
 # [*db_hostname*]
 #   The hostname of the database server to use in the DATABASE_URL.
@@ -50,6 +53,7 @@ class govuk::apps::content_performance_manager(
   $google_private_key = undef,
   $google_client_email = undef,
   $db_hostname = undef,
+  $enable_delayed_job_worker = true,
   $db_username = 'content_performance_manager',
   $db_password = undef,
   $db_name = 'content_performance_manager_production',
@@ -97,5 +101,9 @@ class govuk::apps::content_performance_manager(
       host     => $db_hostname,
       database => $db_name,
     }
+  }
+
+  govuk::delayed_job::worker { 'content-performance-manager':
+    enable_service => $enable_delayed_job_worker,
   }
 }


### PR DESCRIPTION
The Content Performance Manager app needs delayed_job to start as a worker. Adding this call to the delayed_job service worker that's already defined in our puppet manifests.