### PR TITLE
Add CI job for govuk-dns

### DIFF
--- a/modules/govuk_ci/manifests/master.pp
+++ b/modules/govuk_ci/manifests/master.pp
@@ -43,6 +43,7 @@ class govuk_ci::master (
 
   # Manually add jobs that we do not want to included in the 'Deploy App' job
   govuk_ci::job { 'govuk-puppet': }
+  govuk_ci::job { 'govuk-dns': }
   govuk_ci::job { 'govuk-dns-config':
     source => 'github-enterprise',
   }


### PR DESCRIPTION
Related: https://github.com/alphagov/govuk-dns/pull/20

Story: https://trello.com/c/im16e5ue/447-create-a-way-to-sufficiently-test-the-deployment-of-dns-dns