### PR TITLE
Update Jenkins job to validate DNS

### DIFF
--- a/hieradata/class/integration/jenkins.yaml
+++ b/hieradata/class/integration/jenkins.yaml
@@ -22,5 +22,6 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::smokey_deploy
   - govuk_jenkins::job::transition_load_site_config
   - govuk_jenkins::job::transition_load_transition_stats_hits
+  - govuk_jenkins::job::validate_published_dns
   - govuk_jenkins::job::vapps
   - govuk_jenkins::job::whitehall_update_integration_data

--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -61,6 +61,7 @@ govuk_jenkins::plugins:
   ws-cleanup:
     version: '0.25'
 
+govuk_jenkins::job::validate_published_dns::run_daily: true
 govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::bouncer_cdn
   - govuk_jenkins::job::build_fpm_package

--- a/hieradata/class/staging/jenkins.yaml
+++ b/hieradata/class/staging/jenkins.yaml
@@ -80,3 +80,4 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::smokey
   - govuk_jenkins::job::smokey_deploy
   - govuk_jenkins::job::update_cdn_dictionaries
+  - govuk_jenkins::job::validate_published_dns

--- a/modules/govuk_jenkins/manifests/job/validate_published_dns.pp
+++ b/modules/govuk_jenkins/manifests/job/validate_published_dns.pp
@@ -2,7 +2,13 @@
 #
 # Create a file on disk that can be parsed by jenkins-job-builder
 #
-class govuk_jenkins::job::validate_published_dns {
+# === Parameters:
+#  [*run_daily*]
+#    Set to true to run this task every night and email on failures.
+#
+class govuk_jenkins::job::validate_published_dns (
+  $run_daily = false,
+){
   file { '/etc/jenkins_jobs/jobs/validate_published_dns.yaml':
     ensure  => present,
     content => template('govuk_jenkins/jobs/validate_published_dns.yaml.erb'),

--- a/modules/govuk_jenkins/templates/jobs/validate_published_dns.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/validate_published_dns.yaml.erb
@@ -17,8 +17,19 @@
     wrappers:
         - ansicolor:
             colormap: xterm
+    parameters:
+        - string:
+            name: CUSTOM_NS
+            default: false
+            description: Specify a custom nameserver to query
+        - string:
+            name: ZONEFILE
+            default: publishing.service.gov.uk.yaml
+            description: Set the zonefile to test
+    <% if @run_daily %>
     publishers:
         - email:
             recipients: 2nd-line-support@digital.cabinet-office.gov.uk
     triggers:
         - timed: '@midnight'
+    <% end %>


### PR DESCRIPTION
This commit updates the Jenkins job that validates DNS. It adds the job to all environments, with a parameter to enable/disable the nightly task run.

It also adds a parameters to:
  * allow the querying of a custom nameserver
  * set the zonefile to query

Related: https://github.com/alphagov/govuk-dns/pull/21
Story: https://trello.com/c/im16e5ue/447-create-a-way-to-sufficiently-test-the-deployment-of-dns-dns