### PR TITLE
Update lockable-resources-jenkins plugin

### DIFF
--- a/hieradata/class/ci_master.yaml
+++ b/hieradata/class/ci_master.yaml
@@ -100,7 +100,7 @@ govuk_jenkins::plugins:
     junit:
       version: "1.19"
     lockable-resources:
-      version: "1.11.1"
+      version: "1.11.2"
     mailer:
       version: "1.18"
     mapdb-api:


### PR DESCRIPTION
This might fix the bundle install deadlocks that we've seen today
because the 1.11.2 release fixes a resource lock issue:

https://wiki.jenkins-ci.org/display/JENKINS/Lockable+Resources+Plugin

https://issues.jenkins-ci.org/browse/JENKINS-40368