### PR TITLE
Lock database setup step

### DIFF
--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -449,15 +449,15 @@ def buildProject(sassLint = true) {
       echo "WARNING: You do not have SASS linting turned on. Please install govuk-lint and enable."
     }
 
-    if (hasDatabase()) {
-      stage("Set up the database") {
-        runRakeTask("db:drop db:create db:schema:load")
+    // Prevent a project's tests from running in parallel on the same node
+    lock("$repoName-$NODE_NAME-test") {
+      if (hasDatabase()) {
+        stage("Set up the database") {
+            runRakeTask("db:drop db:create db:schema:load")
+        }
       }
-    }
 
-    stage("Run tests") {
-      // Prevent a project's tests from running in parallel on the same node
-      lock("$repoName-$NODE_NAME-test") {
+      stage("Run tests") {
         runTests()
       }
     }


### PR DESCRIPTION
This prevents tests from modifying the same `_test` database on the same machine. This has happened a number of times on publishing-api:

https://ci.integration.publishing.service.gov.uk/job/publishing-api/job/deployed-to-production/296/console