### PR TITLE
Slack notifications for Deploy_CDN

### DIFF
--- a/modules/govuk_jenkins/manifests/job/deploy_cdn.pp
+++ b/modules/govuk_jenkins/manifests/job/deploy_cdn.pp
@@ -2,7 +2,14 @@
 #
 # Create a file on disk that can be parsed by jenkins-job-builder
 #
-class govuk_jenkins::job::deploy_cdn {
+class govuk_jenkins::job::deploy_cdn(
+  $app_domain = hiera('app_domain'),
+) {
+
+  $slack_team_domain = 'govuk'
+  $slack_room = '2ndline'
+  $slack_build_server_url = "https://deploy.${app_domain}/"
+
   file { '/etc/jenkins_jobs/jobs/deploy_cdn.yaml':
     ensure  => present,
     content => template('govuk_jenkins/jobs/deploy_cdn.yaml.erb'),

--- a/modules/govuk_jenkins/templates/jobs/deploy_cdn.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_cdn.yaml.erb
@@ -17,12 +17,28 @@
     properties:
         - github:
             url: https://github.com/alphagov/fastly-configure/
+        - slack:
+            notify-start: false
+            notify-success: true
+            notify-aborted: true
+            notify-notbuilt: true
+            notify-unstable: false
+            notify-failure: true
+            notify-backtonormal: false
+            notify-repeatedfailure: false
+            include-test-summary: false
     scm:
       - cdn-configs_Deploy_CDN
     builders:
         - shell: |
             export ENVIRONMENT=<%= @environment %>
             ./jenkins.sh
+    publishers:
+      - slack:
+          team-domain: <%= @slack_team_domain %>
+          auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN']%>
+          build-server-url: <%= @slack_build_server_url %>
+          room: <%= @slack_room %>
     wrappers:
         - ansicolor:
             colormap: xterm


### PR DESCRIPTION
This commit adds slack notifications to the Deploy_CDN job. The changes
are similar to previous commits like 4b906fd0a42ac88426f7d53c87f70881a87ecedc.