### PR TITLE
Add zonefile parameter

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_dns.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_dns.yaml.erb
@@ -43,6 +43,10 @@
                 - gce
                 - route53
         - string:
+            name: ZONEFILE
+            default: publishing.service.gov.uk.yaml
+            description: Set the zonefile to deploy
+        - string:
             name: AWS_ACCESS_KEY_ID
             default: false
             description: This is required for all providers


### PR DESCRIPTION
I removed the default export [here](https://github.com/alphagov/govuk-dns/pull/21/commits/ab16bdbc750a52b9d71cbc1feba12fbcbc33084c) and added it to the validate_dns job [here](6cc108d19681045f6e06ac10dd8c6a6c84bc4c5c), but forgot to add it to the job that deploys the DNS zone itself.