### PR TITLE
[DO NOT MERGE] Add a jenkins job to dump routes and content every day

### DIFF
--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -6,6 +6,8 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::build_offsite_backup
   - govuk_jenkins::job::check_cdn_ip_ranges
   - govuk_jenkins::job::check_pingdom_ip_ranges
+  - govuk_jenkins::job::check_content_store_inconsistencies
+  - govuk_jenkins::job::check_publishing_api_inconsistencies
   - govuk_jenkins::job::ci_network_config
   - govuk_jenkins::job::copy_data_to_integration
   - govuk_jenkins::job::copy_data_to_staging

--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -19,6 +19,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::deploy_puppet
   - govuk_jenkins::job::deploy_router_data
   - govuk_jenkins::job::deploy_terraform_project
+  - govuk_jenkins::job::dump_content
   - govuk_jenkins::job::dump_routes
   - govuk_jenkins::job::email_alert_check
   - govuk_jenkins::job::gds_production_backup

--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -19,6 +19,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::deploy_puppet
   - govuk_jenkins::job::deploy_router_data
   - govuk_jenkins::job::deploy_terraform_project
+  - govuk_jenkins::job::dump_routes
   - govuk_jenkins::job::email_alert_check
   - govuk_jenkins::job::gds_production_backup
   - govuk_jenkins::job::govuk_cdn_nightly_2xx_status_collection

--- a/modules/govuk_jenkins/manifests/job/check_content_store_inconsistencies.pp
+++ b/modules/govuk_jenkins/manifests/job/check_content_store_inconsistencies.pp
@@ -1,0 +1,14 @@
+# == Class: govuk_jenkins::job::check_content_store_inconsistencies
+#
+# Create a jenkins job to check for inconsistencies between the content-store and the router-api
+#
+#
+# === Parameters:
+#
+class govuk_jenkins::job::check_content_store_inconsistencies {
+  file { '/etc/jenkins_jobs/jobs/check_content_store_inconsistencies.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/check_content_store_inconsistencies.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+}

--- a/modules/govuk_jenkins/manifests/job/check_publishing_api_inconsistencies.pp
+++ b/modules/govuk_jenkins/manifests/job/check_publishing_api_inconsistencies.pp
@@ -1,0 +1,14 @@
+# == Class: govuk_jenkins::job::check_publishing_api_inconsistencies
+#
+# Create a jenkins job to check for inconsistencies between the content-store and the router-api
+#
+#
+# === Parameters:
+#
+class govuk_jenkins::job::check_publishing_api_inconsistencies {
+  file { '/etc/jenkins_jobs/jobs/check_publishing_api_inconsistencies.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/check_publishing_api_inconsistencies.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+}

--- a/modules/govuk_jenkins/manifests/job/dump_content.pp
+++ b/modules/govuk_jenkins/manifests/job/dump_content.pp
@@ -1,0 +1,14 @@
+# == Class: govuk_jenkins::job::dump_content
+#
+# Create a jenkins job to dump the content from the content-store
+#
+#
+# === Parameters:
+#
+class govuk_jenkins::job::dump_content {
+  file { '/etc/jenkins_jobs/jobs/dump_content.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/dump_content.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+}

--- a/modules/govuk_jenkins/manifests/job/dump_routes.pp
+++ b/modules/govuk_jenkins/manifests/job/dump_routes.pp
@@ -1,0 +1,14 @@
+# == Class: govuk_jenkins::job::dump_routes
+#
+# Create a jenkins job to dump the routes from the router-api
+#
+#
+# === Parameters:
+#
+class govuk_jenkins::job::dump_routes {
+  file { '/etc/jenkins_jobs/jobs/dump_routes.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/dump_routes.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+}

--- a/modules/govuk_jenkins/templates/jobs/check_content_store_inconsistencies.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/check_content_store_inconsistencies.yaml.erb
@@ -1,0 +1,38 @@
+---
+- scm:
+    name: router-data
+    scm:
+      - git:
+         url: https://github.gds/gds/router-data
+         branches:
+          - origin/master
+
+- job:
+  name: Check_Content_Store_Inconsistencies
+  display-name: Check_Content_Store_Inconsistencies
+  project-type: freestyle
+  description: >
+    This job checks for inconsistencies between the content store and the router-api.
+  logrotate:
+    numToKeep: 10
+  scm:
+    - router-data
+  builders:
+    - copyartifact:
+      project: run-rake-task
+      filter: *.csv.gz
+  publishers:
+    - trigger-parameterized-builds:
+      - project: run-rake-task
+        predefined-parameters: |
+          TARGET_APPLICATION=content-store
+          MACHINE_CLASS=content_store
+          RAKE_TASK=check_content_consistency[routes.csv.gz,router-data]
+    - trigger-parameterized-builds:
+      - project: run-rake-task
+        predefined-parameters: |
+          TARGET_APPLICATION=content-store
+          MACHINE_CLASS=draft_content_store
+          RAKE_TASK=check_content_consistency[draft-routes.csv.gz,router-data]
+  triggers:
+    - timed: 'H 5 * * *'

--- a/modules/govuk_jenkins/templates/jobs/check_publishing_api_inconsistencies.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/check_publishing_api_inconsistencies.yaml.erb
@@ -1,0 +1,28 @@
+---
+- job:
+  name: Check_Publishing_API_Inconsistencies
+  display-name: Check_Publishing_API_Inconsistencies
+  project-type: freestyle
+  description: >
+    This job checks for inconsistencies between the publishing-api and the content-store.
+  logrotate:
+    numToKeep: 10
+  builders:
+    - copyartifact:
+      project: run-rake-task
+      filter: *.csv.gz
+  publishers:
+    - trigger-parameterized-builds:
+      - project: run-rake-task
+        predefined-parameters: |
+          TARGET_APPLICATION=publishing-api
+          MACHINE_CLASS=backend
+          RAKE_TASK=check_content_consistency[live,content.csv.gz]
+    - trigger-parameterized-builds:
+      - project: run-rake-task
+        predefined-parameters: |
+          TARGET_APPLICATION=publishing-api
+          MACHINE_CLASS=backend
+          RAKE_TASK=check_content_consistency[draft,draft-content.csv.gz]
+  triggers:
+    - timed: 'H 5 * * *'

--- a/modules/govuk_jenkins/templates/jobs/dump_content.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/dump_content.yaml.erb
@@ -1,0 +1,27 @@
+---
+- job:
+  name: Dump_Content
+  display-name: Dump_Content
+  project-type: freestyle
+  description: >
+    This job dumps content from the content-store and stores it in an artifact.
+  logrotate:
+    numToKeep: 10
+  publishers:
+    - trigger-parameterized-builds:
+      - project: run-rake-task
+        predefined-parameters: |
+          TARGET_APPLICATION=content-store
+          MACHINE_CLASS=content_store
+          RAKE_TASK=dump_content[content.csv.gz]
+    - trigger-parameterized-builds:
+      - project: run-rake-task
+        predefined-parameters: |
+          TARGET_APPLICATION=content-store
+          MACHINE_CLASS=draft_content_store
+          RAKE_TASK=dump_routes[draft-content.csv.gz]
+    - archive:
+        artifacts: '*.csv.gz'
+        latest-only: true
+  triggers:
+    - timed: 'H 5 * * *'

--- a/modules/govuk_jenkins/templates/jobs/dump_routes.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/dump_routes.yaml.erb
@@ -1,0 +1,27 @@
+---
+- job:
+  name: Dump_Routes
+  display-name: Dump_Routes
+  project-type: freestyle
+  description: >
+    This job dumps the routes from the router-api and stores it in an artifact.
+  logrotate:
+    numToKeep: 10
+  publishers:
+    - trigger-parameterized-builds:
+      - project: run-rake-task
+        predefined-parameters: |
+          TARGET_APPLICATION=router-api
+          MACHINE_CLASS=router_backend
+          RAKE_TASK=dump_routes[routes.csv.gz]
+    - trigger-parameterized-builds:
+      - project: run-rake-task
+        predefined-parameters: |
+          TARGET_APPLICATION=router-api
+          MACHINE_CLASS=draft_cache
+          RAKE_TASK=dump_routes[draft-routes.csv.gz]
+    - archive:
+        artifacts: '*.csv.gz'
+        latest-only: true
+  triggers:
+    - timed: 'H 5 * * *'


### PR DESCRIPTION
The routes dump artefact will be used in a separate job which checks for consistency between the content store and the router-api.