### PR TITLE
Add new Publishing platform machines

### DIFF
--- a/hieradata/class/publishing_api.yaml
+++ b/hieradata/class/publishing_api.yaml
@@ -1,0 +1,4 @@
+---
+
+govuk::node::s_base::apps:
+  - publishing_api

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -888,6 +888,10 @@ hosts::production::backend::hosts:
     ip: '10.1.3.13'
   postgresql-standby-2:
     ip: '10.1.11.13'
+  publishing-api-1:
+    ip: '10.1.3.45'
+  publishing-api-2:
+    ip: '10.1.3.46'
   rabbitmq-1:
     ip: '10.1.3.70'
   rabbitmq-2:

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -171,6 +171,11 @@ govuk::node::s_backend_lb::performance_backend_servers:
 govuk::node::s_backend_lb::whitehall_backend_servers:
   - 'whitehall-backend-1.backend'
   - 'whitehall-backend-2.backend'
+govuk::node::s_backend_lb::publishing_api_backend_servers:
+  - 'backend-1.backend'
+  - 'backend-2.backend'
+  - 'publishing-api-1.backend'
+  - 'publishing-api-2.backend'
 govuk::node::s_backend_lb::perfplat_public_app_domain: 'preview.performance.service.gov.uk'
 govuk::node::s_bouncer::minimum_request_rate: 0.1
 govuk::node::s_cache::real_ip_header: 'X-Forwarded-For'

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -141,6 +141,13 @@ govuk::node::s_backend_lb::backend_servers:
 govuk::node::s_backend_lb::performance_backend_servers:
   - 'performance-backend-1.backend'
   - 'performance-backend-2.backend'
+govuk::node::s_backend_lb::publishing_api_backend_servers:
+  - 'backend-1.backend'
+  - 'backend-2.backend'
+  - 'backend-3.backend'
+  - 'publishing-api-1.backend'
+  - 'publishing-api-2.backend'
+  - 'publishing-api-3.backend'
 govuk::node::s_backend_lb::whitehall_backend_servers:
   - 'whitehall-backend-1.backend'
   - 'whitehall-backend-2.backend'

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -352,6 +352,12 @@ hosts::production::backend::hosts:
     ip: '10.3.3.13'
   postgresql-standby-2:
     ip: '10.3.11.13'
+  publishing-api-1:
+    ip: '10.3.3.45'
+  publishing-api-2:
+    ip: '10.3.3.46'
+  publishing-api-3:
+    ip: '10.3.3.47'
   rabbitmq-1:
     ip: '10.3.3.70'
   rabbitmq-2:

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -98,6 +98,13 @@ govuk::node::s_backend_lb::backend_servers:
 govuk::node::s_backend_lb::performance_backend_servers:
   - 'performance-backend-1.backend'
   - 'performance-backend-2.backend'
+govuk::node::s_backend_lb::publishing_api_backend_servers:
+  - 'backend-1.backend'
+  - 'backend-2.backend'
+  - 'backend-3.backend'
+  - 'publishing-api-1.backend'
+  - 'publishing-api-2.backend'
+  - 'publishing-api-3.backend'
 govuk::node::s_backend_lb::whitehall_backend_servers:
   - 'whitehall-backend-1.backend'
   - 'whitehall-backend-2.backend'

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -287,6 +287,12 @@ hosts::production::backend::hosts:
     ip: '10.2.3.13'
   postgresql-standby-2:
     ip: '10.2.11.13'
+  publishing-api-1:
+    ip: '10.2.3.45'
+  publishing-api-2:
+    ip: '10.2.3.46'
+  publishing-api-3:
+    ip: '10.2.3.47'
   rabbitmq-1:
     ip: '10.2.3.70'
   rabbitmq-2:

--- a/hieradata/vagrant.yaml
+++ b/hieradata/vagrant.yaml
@@ -70,6 +70,11 @@ govuk::node::s_backend_lb::backend_servers:
 govuk::node::s_backend_lb::whitehall_backend_servers:
   - 'whitehall-backend-1.backend'
   - 'whitehall-backend-2.backend'
+govuk::node::s_backend_lb::publishing_api_backend_servers:
+  - 'backend-1.backend'
+  - 'backend-2.backend'
+  - 'publishing-api-1.backend'
+  - 'publishing-api-2.backend'
 govuk::node::s_backend_lb::performance_backend_servers:
   - 'performance-backend-1.backend'
   - 'performance-backend-2.backend'

--- a/modules/govuk/manifests/node/s_backend_lb.pp
+++ b/modules/govuk/manifests/node/s_backend_lb.pp
@@ -16,6 +16,9 @@
 # [*whitehall_backend_servers*]
 #   An array of whitehall backend app servers
 #
+# [*publishing_api_backend_servers*]
+#   An array of publishing-api backend app servers
+#
 # [*maintenance_mode*]
 #   Whether the backend should be taken offline in nginx
 #
@@ -24,6 +27,7 @@ class govuk::node::s_backend_lb (
   $backend_servers,
   $performance_backend_servers = [],
   $whitehall_backend_servers,
+  $publishing_api_backend_servers,
   $maintenance_mode = false,
 ){
   include govuk::node::s_base
@@ -73,7 +77,6 @@ class govuk::node::s_backend_lb (
       'event-store',
       'govuk-delivery',
       'need-api',
-      'publishing-api',
       'support-api',
     ]:
       internal_only => true,
@@ -84,6 +87,11 @@ class govuk::node::s_backend_lb (
     ]:
       deny_crawlers => true,
       servers       => $whitehall_backend_servers;
+    [
+      'publishing-api',
+    ]:
+      internal_only => true,
+      servers       => $publishing_api_backend_servers;
   }
 
   loadbalancer::balance { 'errbit':

--- a/modules/govuk/manifests/node/s_publishing_api.pp
+++ b/modules/govuk/manifests/node/s_publishing_api.pp
@@ -1,0 +1,34 @@
+# == Class: govuk::node::publishing_api
+#
+# Publishing API machine definition. Publishing API machines are used for running
+# the publishing API application and workers.
+#
+class govuk::node::s_publishing_api inherits govuk::node::s_base {
+  include ::govuk_rbenv::all
+
+  limits::limits { 'root_nofile':
+    ensure     => present,
+    user       => 'root',
+    limit_type => 'nofile',
+    both       => 16384,
+  }
+
+  limits::limits { 'root_nproc':
+    ensure     => present,
+    user       => 'root',
+    limit_type => 'nproc',
+    both       => 1024,
+  }
+
+  include nginx
+
+  # If we miss all the apps, throw a 500 to be caught by the cache nginx
+  nginx::config::vhost::default { 'default': }
+
+  # Ensure memcached is available to backend nodes
+  include collectd::plugin::memcached
+  class { 'memcached':
+    max_memory => '12%',
+    listen_ip  => '127.0.0.1',
+  }
+}


### PR DESCRIPTION
These machines will be used to separate the publishing API application and move it to its own hosts.