### PR TITLE
Remove feature flag to tag documents to taxonomy

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -29,7 +29,6 @@ govuk::apps::travel_advice_publisher::show_historical_edition_link: true
 govuk::apps::url_arbiter::db::backend_ip_range: '10.1.3.0/24'
 govuk::apps::whitehall::basic_auth_credentials: "%{hiera('http_username')}:%{hiera('http_password')}"
 govuk::apps::whitehall::highlight_words_to_avoid: true
-govuk::apps::whitehall::enable_tagging_to_new_taxonomy: "yes"
 
 govuk::deploy::aws_ses_smtp_host: 'email-smtp.eu-west-1.amazonaws.com'
 govuk::deploy::config::errbit_environment_name: 'integration'

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -75,7 +75,6 @@ govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-eve
 govuk::apps::support_api::pp_data_url: 'https://www.performance.service.gov.uk'
 govuk::apps::support_api::zendesk_anonymous_ticket_email: 'zd-api-public@digital.cabinet-office.gov.uk'
 govuk::apps::travel_advice_publisher::enable_email_alerts: true
-govuk::apps::whitehall::enable_tagging_to_new_taxonomy: "yes"
 
 govuk::deploy::actionmailer_enable_delivery: true
 

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -19,7 +19,6 @@ govuk::apps::short_url_manager::instance_name: 'staging'
 govuk::apps::signon::instance_name: 'staging'
 govuk::apps::support_api::pp_data_url: 'https://www.staging.performance.service.gov.uk'
 govuk::apps::travel_advice_publisher::enable_email_alerts: true
-govuk::apps::whitehall::enable_tagging_to_new_taxonomy: "yes"
 
 govuk::deploy::aws_ses_smtp_host: 'email-smtp.eu-west-1.amazonaws.com'
 govuk::deploy::config::errbit_environment_name: 'staging'

--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -128,7 +128,6 @@ class govuk::apps::whitehall(
   $secret_key_base = undef,
   $vhost = 'whitehall',
   $vhost_protected,
-  $enable_tagging_to_new_taxonomy = undef,
   $jwt_auth_secret = undef,
 ) {
 
@@ -369,9 +368,6 @@ class govuk::apps::whitehall(
     "${title}-UNICORN_WORKER_PROCESSES":
       varname => 'UNICORN_WORKER_PROCESSES',
       value   => $unicorn_worker_processes;
-    "${title}-ENABLE_TAGGING_TO_NEW_TAXONOMY":
-      varname => 'ENABLE_TAGGING_TO_NEW_TAXONOMY',
-      value   => $enable_tagging_to_new_taxonomy;
   }
 
   if $basic_auth_credentials != undef {


### PR DESCRIPTION
This commit reverts https://github.com/alphagov/govuk-puppet/pull/5361
We no longer need this feature flag.

Depends on https://github.com/alphagov/whitehall/pull/3138 before it gets merged.

Trello:
https://trello.com/c/dBDSxqtJ/497-make-tagging-to-taxons-mandatory-with-special-cases-for-parenting-and-corporate-information