### PR TITLE
Fix name of `govuk-client-url_arbiter` project in hieradata

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -574,7 +574,7 @@ govuk_ci::master::pipeline_jobs:
   govuk-diff-pages: {}
   govuk_admin_template: {}
   govuk_ab_testing: {}
-  govuk_client_url-arbiter: {}
+  govuk-client-url_arbiter: {}
   govuk_content_models: {}
   govuk-content-schema-test-helpers: {}
   govuk-dummy_content_store: {}


### PR DESCRIPTION
Update project name to match repo and gem name to fix Jenkins build.