### PR TITLE
Ensure business-support-finder is removed

### DIFF
--- a/hieradata/class/calculators_frontend.yaml
+++ b/hieradata/class/calculators_frontend.yaml
@@ -6,6 +6,7 @@ govuk_elasticsearch::local_proxy::servers:
   - 'api-elasticsearch-3.api'
 
 govuk::node::s_base::apps:
+  - businesssupportfinder
   - calculators
   - calendars
   - finder_frontend

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -22,6 +22,7 @@ govuk::node::s_development::apps:
   - 'backdrop_write::rabbitmq'
   - 'bouncer'
   - 'business_support_api'
+  - 'businesssupportfinder'
   - 'calculators'
   - 'calendars'
   - 'canary_backend'


### PR DESCRIPTION
In https://github.com/alphagov/govuk-puppet/pull/5652, business-support-finder was removed, but due to the removal of the entries in the hieradata files, this was never applied. This commit temporarily adds back those entries to ensure the app is removed.