### PR TITLE
Fix override in Jenkins Deploy_DNS template

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_dns.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_dns.yaml.erb
@@ -32,9 +32,6 @@
         - shell: |
             export DEPLOY_ENV=<%= @environment %>
             ./jenkins.sh ${ACTION}
-    wrappers:
-        - ansicolor:
-            colormap: xterm
     parameters:
         - choice:
             name: PROVIDERS


### PR DESCRIPTION
The second 'wrappers' key is overriding the previous one, so the credentials-binding
and build name extensions aren't applied