### PR TITLE
Remove absent rbenv version

### DIFF
--- a/modules/govuk_rbenv/manifests/all.pp
+++ b/modules/govuk_rbenv/manifests/all.pp
@@ -20,9 +20,6 @@ class govuk_rbenv::all (
     key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
   }
 
-  rbenv::version { '2.1.2':
-    ensure => absent # FIXME: Tidy up once deployed
-  }
   rbenv::version { '2.1.4':
     bundler_version => '1.14.5',
   }


### PR DESCRIPTION
When running tests locally on OSX we found that we kept running into this puppet-rspec failure:

```
Failure/Error: it { is_expected.to compile }
       error during compilation: Parameter ensure failed on Package[rbenv-ruby-2.1.2]: Provider must have features 'purgeable' to set 'ensure' to 'purged'
```

This seems to be because OSX package provider is not able to delete packages and it causes problems with the upstream module, although there are questions because we explicitly set the ::operatingsystem and ::osfamily facts in `spec_helper.rb` and we don't have issues with other packages.

This change should now be deployed, so we should entirely remove it.