### PR TITLE
Add Errbit API key for rummager and specialist-frontend

### DIFF
--- a/modules/govuk/manifests/apps/rummager.pp
+++ b/modules/govuk/manifests/apps/rummager.pp
@@ -21,6 +21,10 @@
 #   Whether to enable the procfile indexing service.
 #   Default: false
 #
+# [*errbit_api_key*]
+#   Errbit API key used by Airbrake
+#   Default: undef
+#
 # [*publishing_api_bearer_token*]
 #   The bearer token to use when communicating with Publishing API.
 #   Default: undef
@@ -55,6 +59,7 @@ class govuk::apps::rummager(
   $port = '3009',
   $enable_procfile_worker = true,
   $enable_publishing_listener = false,
+  $errbit_api_key = undef,
   $publishing_api_bearer_token = undef,
   $rabbitmq_hosts = ['localhost'],
   $rabbitmq_user = 'rummager',
@@ -124,6 +129,9 @@ class govuk::apps::rummager(
   }
 
   govuk::app::envvar {
+    "${title}-ERRBIT_API_KEY":
+      varname => 'ERRBIT_API_KEY',
+      value   => $errbit_api_key;
     "${title}-PUBLISHING_API_BEARER_TOKEN":
       varname => 'PUBLISHING_API_BEARER_TOKEN',
       value   => $publishing_api_bearer_token;

--- a/modules/govuk/manifests/apps/specialist_frontend.pp
+++ b/modules/govuk/manifests/apps/specialist_frontend.pp
@@ -15,6 +15,9 @@
 # [*enabled*]
 #   Whether the app is enabled in this environment.
 #
+# [*errbit_api_key*]
+#   Errbit API key used by Airbrake
+#
 # [*nagios_memory_warning*]
 #   Memory use at which Nagios should generate a warning.
 #
@@ -25,12 +28,15 @@ class govuk::apps::specialist_frontend(
   $vhost = 'specialist-frontend',
   $port = '3065',
   $enabled = false,
+  $errbit_api_key = undef,
   $nagios_memory_warning = undef,
   $nagios_memory_critical = undef,
 ) {
 
+  $app_name = 'specialist-frontend'
+
   if $enabled {
-    govuk::app { 'specialist-frontend':
+    govuk::app { $app_name:
       app_type               => 'rack',
       port                   => $port,
       vhost_aliases          => ['private-specialist-frontend'],
@@ -40,6 +46,16 @@ class govuk::apps::specialist_frontend(
       vhost                  => $vhost,
       nagios_memory_warning  => $nagios_memory_warning,
       nagios_memory_critical => $nagios_memory_critical,
+    }
+
+    Govuk::App::Envvar {
+      app => $app_name,
+    }
+
+    govuk::app::envvar {
+      "${title}-ERRBIT_API_KEY":
+        varname => 'ERRBIT_API_KEY',
+        value   => $errbit_api_key;
     }
   }
 }


### PR DESCRIPTION
These apps were missing this and are having the configuration file
replaced at deploy time.