### PR TITLE
Add CI job for govuk-developer-docs

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -578,6 +578,7 @@ govuk_ci::master::pipeline_jobs:
   govuk_content_models: {}
   govuk-content-schema-test-helpers: {}
   govuk-dummy_content_store: {}
+  govuk-developer-docs: {}
   govuk_document_types: {}
   govuk_elements: {}
   govuk_frontend_toolkit: {}


### PR DESCRIPTION
In light of the recent token issues, I'd prefer to run the tests for this on our own machines instead of CircleCI.