### PR TITLE
Remove private-frontend

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -959,7 +959,6 @@ hosts::production::backend::app_hostnames:
   - 'need-api'
   - 'performanceplatform-admin'
   - 'policy-publisher'
-  - 'private-frontend'
   - 'publisher'
   - 'publishing-api'
   - 'search-admin'

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -266,7 +266,6 @@ hosts::development::apps:
   - 'need-api'
   - 'performanceplatform-admin'
   - 'policy-publisher'
-  - 'private-frontend'
   - 'publicapi'
   - 'public-event-store'
   - 'publisher'

--- a/modules/govuk/manifests/apps/frontend.pp
+++ b/modules/govuk/manifests/apps/frontend.pp
@@ -38,7 +38,6 @@ class govuk::apps::frontend(
   govuk::app { 'frontend':
     app_type               => 'rack',
     port                   => $port,
-    vhost_aliases          => ['private-frontend'],
     vhost_protected        => $vhost_protected,
     health_check_path      => '/',
     log_format_is_json     => true,

--- a/modules/govuk/manifests/node/s_backend_lb.pp
+++ b/modules/govuk/manifests/node/s_backend_lb.pp
@@ -53,7 +53,6 @@ class govuk::node::s_backend_lb (
       'manuals-publisher',
       'maslow',
       'policy-publisher',
-      'private-frontend',
       'publisher',
       'release',
       'search-admin',


### PR DESCRIPTION
Private-frontend is being turned off, so we remove it from Puppet.

[Trello](https://trello.com/c/JYT9roQm/709-turn-off-private-frontend)