### PR TITLE
Change drill to take place at 11:00 in the UK

### DIFF
--- a/modules/monitoring/manifests/pagerduty_drill.pp
+++ b/modules/monitoring/manifests/pagerduty_drill.pp
@@ -21,7 +21,7 @@ class monitoring::pagerduty_drill (
       ensure  => present,
       user    => 'root',
       weekday => 'wednesday',
-      hour    => 11,
+      hour    => 10,
       minute  => 0,
       command => "touch ${filename}",
     }
@@ -30,7 +30,7 @@ class monitoring::pagerduty_drill (
       ensure  => present,
       user    => 'root',
       weekday => 'wednesday',
-      hour    => 11,
+      hour    => 10,
       minute  => 15,
       command => "rm -f ${filename}",
     }


### PR DESCRIPTION
The cron configuration timings are specific to the time on the server,
and the server timezone is UTC. Currently, 11:00 in BST is 10:00 in UTC.