### PR TITLE
Temporarily add a rake task to Integration data sync complete job

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
@@ -40,6 +40,11 @@
                 RAKE_TASK=publishing:scheduled:requeue_all_jobs
             - project: run-rake-task
               predefined-parameters: |
+                TARGET_APPLICATION=whitehall
+                MACHINE_CLASS=whitehall_backend
+                RAKE_TASK=url_to_subscriber_list_criteria[/data/vhost/whitehall-admin.integration.publishing.service.gov.uk/shared/govuk-delivery-topics-20170329-with-fixed-slugs.csv,true]
+            - project: run-rake-task
+              predefined-parameters: |
                 TARGET_APPLICATION=email-alert-api
                 MACHINE_CLASS=backend
                 RAKE_TASK=sync_govdelivery_topic_mappings


### PR DESCRIPTION
Until this rake task has been run in Production, we want it to run on
Integration each day before the email-alert-api `sync_govdelivery_topic_mappings`
one. This will save us several hours of deleting and recreating the same data
in GovDelivery each day.

I've put the CSV file at this path on both whitehall backends in Integration,
and will delete them once we're finished with this.