### PR TITLE
Add REDIS support to Content Performance Manager

### DIFF
--- a/modules/govuk/manifests/apps/content_performance_manager.pp
+++ b/modules/govuk/manifests/apps/content_performance_manager.pp
@@ -38,6 +38,14 @@
 #   The bearer token to use when communicating with Publishing API.
 #   Default: undef
 #
+# [*redis_host*]
+#   Redis host for Sidekiq.
+#   Default: undef
+#
+# [*redis_port*]
+#   Redis port for Sidekiq.
+#   Default: undef
+#
 # [*secret_key_base*]
 #   The key for Rails to use when signing/encrypting sessions.
 #
@@ -51,6 +59,8 @@ class govuk::apps::content_performance_manager(
   $google_private_key = undef,
   $port = '3206',
   $publishing_api_bearer_token = undef,
+  $redis_host = undef,
+  $redis_port = undef,
   $secret_key_base = undef,
 ) {
   $app_name = 'content-performance-manager'
@@ -79,6 +89,11 @@ class govuk::apps::content_performance_manager(
     "${title}-PUBLISHING_API_BEARER_TOKEN":
       varname => 'PUBLISHING_API_BEARER_TOKEN',
       value   => $publishing_api_bearer_token;
+  }
+
+  govuk::app::envvar::redis { $app_name:
+    host => $redis_host,
+    port => $redis_port,
   }
 
   if $secret_key_base != undef {

--- a/modules/govuk/manifests/apps/content_performance_manager.pp
+++ b/modules/govuk/manifests/apps/content_performance_manager.pp
@@ -4,55 +4,54 @@
 #
 # === Parameters
 #
-# [*port*]
-#   The port that it is served on.
-#   Default: 3206
+# [*db_hostname*]
+#   The hostname of the database server to use in the DATABASE_URL.
+#   Default: undef
 #
-# [*secret_key_base*]
-#   The key for Rails to use when signing/encrypting sessions.
+# [*db_name*]
+#   The database name to use in the DATABASE_URL.
+#
+# [*db_password*]
+#   The password for the database.
+#   Default: undef
+#
+# [*db_username*]
+#   The username to use in the DATABASE_URL.
 #
 # [*google_analytics_govuk_view_id*]
 #   The view id of GOV.UK in Google Analytics
-#   Default: undef
-#
-# [*google_private_key*]
-#   Google authentication private key
 #   Default: undef
 #
 # [*google_client_email*]
 #   Google authentication email
 #   Default: undef
 #
-#
-# [*db_hostname*]
-#   The hostname of the database server to use in the DATABASE_URL.
+# [*google_private_key*]
+#   Google authentication private key
 #   Default: undef
 #
-# [*db_username*]
-#   The username to use in the DATABASE_URL.
-#
-# [*db_password*]
-#   The password for the database.
-#   Default: undef
-#
-# [*db_name*]
-#   The database name to use in the DATABASE_URL.
+# [*port*]
+#   The port that it is served on.
+#   Default: 3206
 #
 # [*publishing_api_bearer_token*]
 #   The bearer token to use when communicating with Publishing API.
 #   Default: undef
 #
+# [*secret_key_base*]
+#   The key for Rails to use when signing/encrypting sessions.
+#
 class govuk::apps::content_performance_manager(
-  $port = '3206',
-  $secret_key_base = undef,
-  $publishing_api_bearer_token = undef,
-  $google_analytics_govuk_view_id = undef,
-  $google_private_key = undef,
-  $google_client_email = undef,
   $db_hostname = undef,
-  $db_username = 'content_performance_manager',
-  $db_password = undef,
   $db_name = 'content_performance_manager_production',
+  $db_password = undef,
+  $db_username = 'content_performance_manager',
+  $google_analytics_govuk_view_id = undef,
+  $google_client_email = undef,
+  $google_private_key = undef,
+  $port = '3206',
+  $publishing_api_bearer_token = undef,
+  $secret_key_base = undef,
 ) {
   $app_name = 'content-performance-manager'
 


### PR DESCRIPTION
Content Performance Manager is using Sidekiq to run jobs in the background; we
are using [govuk_sidekiq](https://github.com/alphagov/govuk_sidekiq) gem which requires to setup two environment variables: 
`REDIS_HOST` and `REDIS_PORT`

We have also configured [Sidekiq monitoring](https://github.com/alphagov/sidekiq-monitoring/pull/27) and [reserved the port 3207 for it](https://github.gds/gds/development/pull/385)

This is the [updated to the development environment (VM)](https://github.gds/gds/development/pull/384)



