### PR TITLE
Add tests for collectd plugins

### DIFF
--- a/modules/collectd/files/usr/lib/collectd/python/mongodb.py
+++ b/modules/collectd/files/usr/lib/collectd/python/mongodb.py
@@ -1,5 +1,6 @@
 #
 # Plugin to collectd statistics from MongoDB
+# Source https://github.com/sebest/collectd-mongodb
 #
 
 import collectd

--- a/modules/collectd/manifests/plugin/cdn_fastly.pp
+++ b/modules/collectd/manifests/plugin/cdn_fastly.pp
@@ -14,7 +14,7 @@
 #   A hash of services. In the format:
 #   `{ 'friendly_name' => 'service_id', }`
 #
-class collectd::plugin::cdn_fastly(
+class collectd::plugin::cdn_fastly (
   $username,
   $password,
   $services,

--- a/modules/collectd/spec/classes/collectd__package_spec.rb
+++ b/modules/collectd/spec/classes/collectd__package_spec.rb
@@ -1,7 +1,6 @@
 require_relative '../../../../spec_helper'
 
 describe 'collectd::package', :type => :class do
-
   it { is_expected.to contain_package('collectd-core').with_ensure('5.4.0-3ubuntu2') }
 
   it { is_expected.to contain_package('libyajl2') }

--- a/modules/collectd/spec/classes/collectd__plugin__cdn_fastly_spec.rb
+++ b/modules/collectd/spec/classes/collectd__plugin__cdn_fastly_spec.rb
@@ -1,0 +1,45 @@
+require_relative '../../../../spec_helper'
+
+describe "collectd::plugin::cdn_fastly", :type => :class do
+  let(:pre_condition) { 'Collectd::Plugin <||>' }
+  let(:params) {{
+    :username => 'Patrica',
+    :password => 'drowssap',
+    :services => {
+      'test' => 1,
+      'another_val' => 'some string',
+    },
+  }}
+
+  it 'Includes the correct resources' do
+    is_expected.to contain_package('collectd-cdn')
+    is_expected.to contain_class('Collectd::Plugin::Python')
+  end
+
+  it 'Correctly sets the Service attributes' do
+    is_expected.to contain_collectd__plugin("cdn_fastly").with_content(<<-EOS
+<LoadPlugin python>
+  Globals true
+</LoadPlugin>
+
+<Plugin python>
+  Import "collectd_cdn.fastly"
+
+  <Module "collectd_cdn.fastly">
+    ApiUser "Patrica"
+    ApiPass "drowssap"
+
+    <Service>
+      Name "test"
+      Id "1"
+    </Service>
+    <Service>
+      Name "another_val"
+      Id "some string"
+    </Service>
+  </Module>
+</Plugin>
+EOS
+    )
+  end
+end

--- a/modules/collectd/spec/classes/collectd__plugin__elasticsearch_spec.rb
+++ b/modules/collectd/spec/classes/collectd__plugin__elasticsearch_spec.rb
@@ -1,0 +1,29 @@
+require_relative '../../../../spec_helper'
+
+describe "collectd::plugin::elasticsearch", :type => :class do
+  let(:pre_condition) { 'Collectd::Plugin <||>' }
+  let(:params){ {
+    :es_port => 4242,
+    :log_index_type_count => {
+      'test_index' => ['type_1',]
+    }
+  } }
+
+  it 'Includes the correct resources' do
+    is_expected.to contain_class('Collectd::Plugin::Elasticsearch')
+    is_expected.to contain_class('Collectd::Plugin::Curl_json')
+    is_expected.to contain_collectd__Plugin('curl_json')
+  end
+
+  it 'Sets the URL correctly' do
+    is_expected.to contain_collectd__plugin("elasticsearch").with_content(/<URL "http:\/\/127\.0\.0\.1:4242\/_nodes\/_local\/stats\/indices,http,jvm,process,transport">/)
+  end
+
+  it 'Sets the standard metrics' do
+    is_expected.to contain_collectd__plugin("elasticsearch").with_content(/<Key "nodes\/\*\/indices\/docs\/count">\n[\s]*Type "gauge"\n[\s]*Instance "indices\.docs\.count"\n/)
+  end
+
+  it 'Sets index specific metrics' do
+    is_expected.to contain_collectd__plugin("elasticsearch").with_content(/<URL "http:\/\/127\.0\.0\.1:4242\/test_index\/type_1\/_count">\n[\s]*Instance "elasticsearch"\n[\s]*<Key "count">\n[\s]*Type "gauge"\n[\s]*Instance "test_index_type_1_count"/)
+  end
+end

--- a/modules/collectd/spec/classes/collectd__plugin__etcd_spec.rb
+++ b/modules/collectd/spec/classes/collectd__plugin__etcd_spec.rb
@@ -1,0 +1,17 @@
+require_relative '../../../../spec_helper'
+
+describe "collectd::plugin::etcd", :type => :class do
+  let(:pre_condition) { 'Collectd::Plugin <||>' }
+  let(:node) { 'test.example.com' }
+
+  it 'Should create the correct resources' do
+    is_expected.to contain_collectd__plugin('curl_json')
+    # Test all the URLs interpolate correctly and that the looped keys are present
+    is_expected.to contain_collectd__plugin('etcd').with_content(/<URL "http:\/\/test.example.com:2380\/v2\/admin\/config">\n[ ]*Instance "etcd_config"/)
+    is_expected.to contain_collectd__plugin('etcd').with_content(/<Key "activeSize">\n[ ]*Type "gauge"\n[ ]*<\/Key>/)
+    is_expected.to contain_collectd__plugin('etcd').with_content(/<URL "http:\/\/test.example.com:2379\/v2\/stats\/store">\n[ ]*Instance "etcd_store"/)
+    is_expected.to contain_collectd__plugin('etcd').with_content(/<Key "compareAndSwapFail">\n[ ]*Type "counter"\n[ ]*<\/Key>/)
+    is_expected.to contain_collectd__plugin('etcd').with_content(/<URL "test.example.com:2379\/v2\/stats\/self">\n[ ]*Instance "etcd_self"/)
+    is_expected.to contain_collectd__plugin('etcd').with_content(/<Key "recvAppendRequestCnt">\n[ ]*Type "counter"\n[ ]*<\/Key>/)
+  end
+end

--- a/modules/collectd/spec/classes/collectd__plugin__python_spec.rb
+++ b/modules/collectd/spec/classes/collectd__plugin__python_spec.rb
@@ -1,0 +1,12 @@
+require_relative '../../../../spec_helper'
+
+describe "collectd::plugin::python", :type => :class do
+  let(:pre_condition) { 'File <||> Collectd::Plugin <||>' }
+
+  it 'Includes the correct resources' do
+    is_expected.to contain_file('/usr/lib/collectd/python').with_ensure('directory')
+    is_expected.to contain_file('/usr/lib/collectd/python/__init__.py').with_content('')
+    is_expected.to contain_file('/etc/collectd/conf.d/00-python.conf')
+    is_expected.to contain_collectd__plugin('00-python')
+  end
+end


### PR DESCRIPTION
This adds tests for the Fastly CDN, Python, Elasticsearch and Etcd
collectd plugins. These plugins all contain some amount of logic
(e.g. conditionals or loops).