### PR TITLE
Only try to ensure permissions if present

### DIFF
--- a/modules/govuk_user/manifests/init.pp
+++ b/modules/govuk_user/manifests/init.pp
@@ -87,12 +87,16 @@ define govuk_user(
     membership => $membership,
     require    => Class['shell'],
     shell      => $shell,
-  } ->
-  file { $home:
-    ensure => directory,
-    owner  => $title,
-    group  => $title,
-    mode   => '0750',
+  }
+
+  if ($ensure == present) {
+    file { $home:
+      ensure  => directory,
+      owner   => $title,
+      group   => $title,
+      mode    => '0750',
+      require => User[$title],
+    }
   }
 
   # FIXME: Manage group?


### PR DESCRIPTION
If a user leaves then we can set their user to "absent" in the govuk_user defined type.

This will remove the user, but we don't want to delete their home directory for $reasons. This will only try to set permissions on their home directory if a user is present, but will still remove their SSH key directory.