### PR TITLE
Remove Frontend app from backend machines

### DIFF
--- a/hieradata/class/backend.yaml
+++ b/hieradata/class/backend.yaml
@@ -11,6 +11,7 @@ govuk::apps::event_store::mongodb_servers:
   - 'mongo-3.backend'
 
 govuk::apps::frontend::vhost_protected: true
+govuk::apps::frontend::ensure: 'absent'
 
 govuk::apps::contentapi::mongodb_name: 'govuk_content_production'
 govuk::apps::contentapi::mongodb_nodes:

--- a/modules/govuk/manifests/apps/frontend.pp
+++ b/modules/govuk/manifests/apps/frontend.pp
@@ -4,6 +4,10 @@
 #
 # === Parameters
 #
+# [*ensure*]
+#   Whether the app should be present or absent
+#   Default: 'present'
+#
 # [*vhost*]
 #   Virtual host used by the application.
 #   Default: 'frontend'
@@ -27,6 +31,7 @@
 #   Memory use at which Nagios should generate a critical alert.
 #
 class govuk::apps::frontend(
+  $ensure = 'present',
   $vhost = 'frontend',
   $port = '3005',
   $vhost_protected = false,
@@ -36,6 +41,7 @@ class govuk::apps::frontend(
 ) {
 
   govuk::app { 'frontend':
+    ensure                 => $ensure,
     app_type               => 'rack',
     port                   => $port,
     vhost_protected        => $vhost_protected,


### PR DESCRIPTION
We no longer use private-frontend and therefore need to remove it from any backend machines that it was previously deployed to.

https://trello.com/c/JYT9roQm/709-turn-off-private-frontend

cc @emmabeynon 