### PR TITLE
Add tagging monitor to list of deployable apps

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -42,6 +42,7 @@ deployable_applications: &deployable_applications
   govuk_content_api: {}
   govuk-content-schemas: {}
   govuk_crawler_worker: {}
+  govuk-tagging-monitor: {}
   govuk_need_api: {}
   hmrc-manuals-api: {}
   imminence: {}


### PR DESCRIPTION
Adding it to this list allows us to run its rake tasks on Jenkins.