### PR TITLE
Frontend only add envvar when ensure is present

### DIFF
--- a/modules/govuk/manifests/apps/frontend.pp
+++ b/modules/govuk/manifests/apps/frontend.pp
@@ -59,9 +59,11 @@ class govuk::apps::frontend(
   ',
   }
 
-  govuk::app::envvar { "${title}-PUBLISHING_API_BEARER_TOKEN":
-    app     => 'frontend',
-    varname => 'PUBLISHING_API_BEARER_TOKEN',
-    value   => $publishing_api_bearer_token,
+  if $ensure == 'present' {
+    govuk::app::envvar { "${title}-PUBLISHING_API_BEARER_TOKEN":
+      app     => 'frontend',
+      varname => 'PUBLISHING_API_BEARER_TOKEN',
+      value   => $publishing_api_bearer_token,
+    }
   }
 }


### PR DESCRIPTION
Prevent errors during frotend-private decommissioning that
is using ensure = absent