### PR TITLE
Remove Frontend app 'ensure' parameter

### DIFF
--- a/hieradata/class/backend.yaml
+++ b/hieradata/class/backend.yaml
@@ -10,8 +10,6 @@ govuk::apps::event_store::mongodb_servers:
   - 'mongo-2.backend'
   - 'mongo-3.backend'
 
-govuk::apps::frontend::vhost_protected: true
-
 govuk::apps::contentapi::mongodb_name: 'govuk_content_production'
 govuk::apps::contentapi::mongodb_nodes:
   - 'mongo-1.backend'
@@ -60,7 +58,6 @@ govuk::node::s_base::apps:
   - email_alert_api
   - email_alert_service
   - event_store
-  - frontend
   - govuk_delivery
   - hmrc_manuals_api
   - imminence

--- a/hieradata/class/backend.yaml
+++ b/hieradata/class/backend.yaml
@@ -11,7 +11,6 @@ govuk::apps::event_store::mongodb_servers:
   - 'mongo-3.backend'
 
 govuk::apps::frontend::vhost_protected: true
-govuk::apps::frontend::ensure: 'absent'
 
 govuk::apps::contentapi::mongodb_name: 'govuk_content_production'
 govuk::apps::contentapi::mongodb_nodes:

--- a/modules/govuk/manifests/apps/frontend.pp
+++ b/modules/govuk/manifests/apps/frontend.pp
@@ -4,10 +4,6 @@
 #
 # === Parameters
 #
-# [*ensure*]
-#   Whether the app should be present or absent
-#   Default: 'present'
-#
 # [*vhost*]
 #   Virtual host used by the application.
 #   Default: 'frontend'
@@ -31,7 +27,6 @@
 #   Memory use at which Nagios should generate a critical alert.
 #
 class govuk::apps::frontend(
-  $ensure = 'present',
   $vhost = 'frontend',
   $port = '3005',
   $vhost_protected = false,
@@ -41,7 +36,6 @@ class govuk::apps::frontend(
 ) {
 
   govuk::app { 'frontend':
-    ensure                 => $ensure,
     app_type               => 'rack',
     port                   => $port,
     vhost_protected        => $vhost_protected,
@@ -59,11 +53,9 @@ class govuk::apps::frontend(
   ',
   }
 
-  if $ensure == 'present' {
-    govuk::app::envvar { "${title}-PUBLISHING_API_BEARER_TOKEN":
-      app     => 'frontend',
-      varname => 'PUBLISHING_API_BEARER_TOKEN',
-      value   => $publishing_api_bearer_token,
-    }
+  govuk::app::envvar { "${title}-PUBLISHING_API_BEARER_TOKEN":
+    app     => 'frontend',
+    varname => 'PUBLISHING_API_BEARER_TOKEN',
+    value   => $publishing_api_bearer_token,
   }
 }


### PR DESCRIPTION
Now that [5690](https://github.com/alphagov/govuk-puppet/pull/5690) and [5693](https://github.com/alphagov/govuk-puppet/pull/5693) have been deployed we can revert the Frontend class back to its previous state.

https://trello.com/c/JYT9roQm/709-turn-off-private-frontend

cc @emmabeynon 