### PR TITLE
Remove now unused MONGODB_NODES env var for manuals-publisher

### DIFF
--- a/modules/govuk/manifests/apps/manuals_publisher.pp
+++ b/modules/govuk/manifests/apps/manuals_publisher.pp
@@ -93,30 +93,6 @@ class govuk::apps::manuals_publisher(
     port => $redis_port,
   }
 
-  # FIXME: This templated list of mongodb nodes is a temporary measure to allow
-  # us to run manuals publisher on earlier ruby versions as ruby 2.1 cannot
-  # parse the comma delimited MONGODB_URI var.
-  # Either MONGODB_URI or MONGODB_NODES should be removed from this module once
-  # we have resolved ruby version issues.
-  # Please talk to Steve Laing for more information.
-  # The first line shouldn't be indented, but the other lines need to be so
-  # that they line up with the YAML file they're inserted into.  For example
-  # given yaml like:
-  # nodes:
-  #   - <%= ENV['MONGODB_NODES'] %>
-  # we want:
-  # nodes:
-  #   - - first_node
-  #     - second_node
-  # which means the first_node line needs no indent, but second_node line
-  # needs a 4 char indent (in the real file the indent is 6 chars as nodes
-  # is itself indented).
-  $mongodb_nodes_template = '<%
-    first_node, *other_nodes = @mongodb_nodes
-    yaml_version = (["- #{first_node}:27017"] + other_nodes.map { |node| "      - #{node}:27017" }).join("\n")
-    %><%= yaml_version %>'
-  $mongodb_nodes_string = inline_template($mongodb_nodes_template)
-
   govuk::app::envvar {
     "${title}-ASSET_MANAGER_BEARER_TOKEN":
       varname => 'ASSET_MANAGER_BEARER_TOKEN',
@@ -127,9 +103,6 @@ class govuk::apps::manuals_publisher(
     "${title}-EMAIL_ALERT_API_BEARER_TOKEN":
       varname => 'EMAIL_ALERT_API_BEARER_TOKEN',
       value   => $email_alert_api_bearer_token;
-    "${title}-MONGODB_NODES":
-      varname => 'MONGODB_NODES',
-      value   => $mongodb_nodes_string;
     "${title}-OAUTH_ID":
       varname => 'OAUTH_ID',
       value   => $oauth_id;


### PR DESCRIPTION
We switched manuals-publisher to use `MONGODB_URI` in [this PR][1]. This change was deployed to production at approx 11:50 on 31 Mar 2017. So it should now be safe to remove the `MONGODB_NODES` env var.

In order to ensure I didn't miss anything, I created this commit by reverting the following two commits and squashing into one:

* [Write MONGODB_NODES for manuals-publisher correctly][1]
* [Provide a list of mongodb hosts for manuals-publisher][2]

[1]: https://github.com/alphagov/manuals-publisher/pull/936
[2]: https://github.com/alphagov/govuk-puppet/commit/06acc5ce08e11bee1d05d11e47c6afacb073a7f0
[3]: https://github.com/alphagov/govuk-puppet/commit/0d03bfd5c6e5e875906c9b1a9f44969f6dd2c330