### PR TITLE
Revert "Temporarily add a rake task to Integration data sync complete job"

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
@@ -42,11 +42,6 @@
                 RAKE_TASK=publishing:scheduled:requeue_all_jobs
             - project: run-rake-task
               predefined-parameters: |
-                TARGET_APPLICATION=whitehall
-                MACHINE_CLASS=whitehall_backend
-                RAKE_TASK=url_to_subscriber_list_criteria[/data/vhost/whitehall-admin.integration.publishing.service.gov.uk/shared/govuk-delivery-topics-20170329-with-fixed-slugs.csv,true]
-            - project: run-rake-task
-              predefined-parameters: |
                 TARGET_APPLICATION=email-alert-api
                 MACHINE_CLASS=backend
                 RAKE_TASK=sync_govdelivery_topic_mappings


### PR DESCRIPTION
Reverts alphagov/govuk-puppet#5684

This rake task has now been run in Production so we don't need it to run from here any more.