### PR TITLE
Remove CI job for govuk-client-url_arbiter gem

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -575,7 +575,6 @@ govuk_ci::master::pipeline_jobs:
   govuk-diff-pages: {}
   govuk_admin_template: {}
   govuk_ab_testing: {}
-  govuk-client-url_arbiter: {}
   govuk_content_models: {}
   govuk-content-schema-test-helpers: {}
   govuk-dummy_content_store: {}


### PR DESCRIPTION
This gem is an API client for a service that has been retired. It has now been removed from all projects which depended on it and the repo has been moved to gds-attic, so it no longer needs a CI job.