### PR TITLE
Revert "Add tagging monitor to list of deployable apps"

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -42,7 +42,6 @@ deployable_applications: &deployable_applications
   govuk_content_api: {}
   govuk-content-schemas: {}
   govuk_crawler_worker: {}
-  govuk-tagging-monitor: {}
   govuk_need_api: {}
   hmrc-manuals-api: {}
   imminence: {}


### PR DESCRIPTION
This reverts commit 8c4c36bf911cdc7a45ec9f903d42f294997379da.

The tagging monitor isn't a deployable app that runs, so we don't actually need this.