### PR TITLE
Enable email notifications for the Jenkins Deploy App

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
@@ -44,6 +44,9 @@
                 TARGET_APPLICATION=$TARGET_APPLICATION
                 TARGET_APPLICATION_GIT_REPO=$WORKSPACE/$TARGET_APPLICATION
               condition: 'UNSTABLE_OR_BETTER'
+        - email:
+            recipients: govuk-ci-notifications@digital.cabinet-office.gov.uk
+            send-to-individuals: true
     wrappers:
         - ansicolor:
             colormap: xterm


### PR DESCRIPTION
I want to be notified as soon as possible if any of my changes mean that
an app can't be deployed to integration.

A recent change to manuals-publisher caused the deployment to
integration to fail. We only became aware of this problem when we tried
to deploy to production and were informed by 2ndline. We (Go Free Range)
recall having a similar problem when working on smart-answers.

NOTE. Although my use case is for deployments to integration the change
in this commit will mean that we're notified of deployment failures for
all environments.

I've looked through the history of this file to see whether we've
previously removed these notifications (i.e. whether this commit is
reverting a previous commit) but that doesn't seem to be the case.

I copied the email configuration from the
integration_app_deployment.yaml.erb file as I know I've seen email
notifications from that Job in Jenkins.

I haven't added a test for this change as we don't appear to have added
tests for similar changes in the past.