### PR TITLE
Install the libpq-dev package on the new extracted publishing_api nodes

### DIFF
--- a/modules/govuk/manifests/apps/publishing_api.pp
+++ b/modules/govuk/manifests/apps/publishing_api.pp
@@ -105,6 +105,8 @@ class govuk::apps::publishing_api(
 ) {
   $app_name = 'publishing-api'
 
+  include govuk_postgresql::client #installs libpq-dev package needed for pg gem
+
   govuk::app { $app_name:
     app_type          => 'rack',
     port              => $port,


### PR DESCRIPTION
Publishing_api has always has these installed implicitly, we're adding them
as an explicit requirement now the application lives on its own.