### PR TITLE
Run fake virus scan in development VM

### DIFF
--- a/modules/clamav/manifests/run_fake_virus_scan.pp
+++ b/modules/clamav/manifests/run_fake_virus_scan.pp
@@ -1,0 +1,14 @@
+# == Class: clamav::run_fake_virus_scan
+#
+# Copy uploaded files from the `uploads` folder to the `clean` folder.
+# This simulates running a virus scan without the overhead of running
+# `clamav` and is used for the development VM. Runs once a minute.
+#
+class clamav::run_fake_virus_scan {
+  cron::crondotdee { 'run_fake_virus_scan':
+    command => 'cd /var/apps/whitehall ; /usr/local/bin/govuk_setenv whitehall bundle exec rake development:fake_virus_scan > /dev/null',
+    hour    => '*',
+    minute  => '*',
+    user    => 'vagrant',
+  }
+}

--- a/modules/govuk/manifests/node/s_development.pp
+++ b/modules/govuk/manifests/node/s_development.pp
@@ -13,6 +13,7 @@ class govuk::node::s_development (
   include base
 
   include assets::user
+  include clamav::run_fake_virus_scan
   include golang
   include govuk_apt::disable_pipelining
   include govuk_mysql::libdev


### PR DESCRIPTION
This commit adds a cron job for the development VM to run a fake virus scan every minute. The fake scan just copies files from the `upload` folder to the `clean` folder to simulate a virus scan.

This allows users of the development VM to do things like publishing documents with attachments in whitehall without having to run the rake task manually each time.