### PR TITLE
Add wkhtmltopdf to whitehall backends

### DIFF
--- a/modules/govuk/manifests/node/s_development.pp
+++ b/modules/govuk/manifests/node/s_development.pp
@@ -27,6 +27,7 @@ class govuk::node::s_development (
   include nodejs
   include redis
   include tmpreaper
+  include wkhtmltopdf
 
   include govuk_python
   include govuk_testing_tools

--- a/modules/govuk/manifests/node/s_whitehall_backend.pp
+++ b/modules/govuk/manifests/node/s_whitehall_backend.pp
@@ -8,6 +8,9 @@ class govuk::node::s_whitehall_backend (
 
   include imagemagick
 
+  # Package required in order to use PDFKit
+  include wkhtmltopdf
+
   # If we miss all the apps, throw a 500 to be caught by the cache nginx
   nginx::config::vhost::default { 'default': }
 

--- a/modules/wkhtmltopdf/manifests/init.pp
+++ b/modules/wkhtmltopdf/manifests/init.pp
@@ -1,0 +1,9 @@
+# == Class: wkhtmltopdf
+#
+# Installs the wkhtmltopdf package.
+#
+class wkhtmltopdf {
+  package { 'wkhtmltopdf':
+    ensure => 'present',
+  }
+}

--- a/modules/wkhtmltopdf/spec/classes/wkhtmltopdf_spec.rb
+++ b/modules/wkhtmltopdf/spec/classes/wkhtmltopdf_spec.rb
@@ -1,0 +1,10 @@
+require_relative '../../../../spec_helper'
+
+describe 'wkhtmltopdf', :type => :class do
+
+  it { is_expected.to compile }
+
+  it { is_expected.to compile.with_all_deps }
+
+  it { is_expected.to contain_class('wkhtmltopdf') }
+end


### PR DESCRIPTION
Blitz related, trello: https://trello.com/c/6ZBdzhk8/18-add-https-github-com-wkhtmltopdf-wkhtmltopdf-to-all-whitehall-backend-servers