### PR TITLE
Create whitehall asset directory structure in dev VM

### DIFF
--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -318,7 +318,7 @@ class govuk::apps::whitehall(
           value   => '0';
     }
 
-    # Protocal relative URL so assets in admin are on the same domain but work
+    # Protocol relative URL so assets in admin are on the same domain but work
     # in production and development. (This is needed for IE8)
     govuk::app::envvar {
       "${title}-GOVUK_ASSET_ROOT":
@@ -346,6 +346,68 @@ class govuk::apps::whitehall(
         password => $admin_db_password,
         host     => $admin_db_hostname,
         database => $admin_db_name,
+      }
+    }
+
+    if $::govuk_node_class == 'development' {
+      # Create the directory structure for whitehall assets in development
+      $asset_directories = [
+        '/data/uploads/whitehall',
+        '/data/uploads/whitehall/attachment-cache',
+        '/data/uploads/whitehall/bulk-upload-zip-file-tmp',
+        '/data/uploads/whitehall/carrierwave-tmp',
+        '/data/uploads/whitehall/clean',
+        '/data/uploads/whitehall/draft-clean',
+        '/data/uploads/whitehall/draft-incoming',
+        '/data/uploads/whitehall/draft-infected',
+        '/data/uploads/whitehall/fatality_notices',
+        '/data/uploads/whitehall/incoming',
+        '/data/uploads/whitehall/infected',
+      ]
+
+      file { $asset_directories:
+        ensure => directory,
+        mode   => '0775',
+        owner  => 'assets',
+        group  => 'assets',
+      }
+
+      # Symlink directories in the whitehall app root to the assets directories
+      # Use `force` since some of these are created on git checkout.
+      file { '/var/govuk/whitehall/attachment-cache':
+        ensure => symlink,
+        target => '/data/uploads/whitehall/attachment-cache',
+        force  => true,
+      }
+
+      file { '/var/govuk/whitehall/bulk-upload-zip-file-tmp':
+        ensure => symlink,
+        target => '/data/uploads/whitehall/bulk-upload-zip-file-tmp',
+        force  => true,
+      }
+
+      file { '/var/govuk/whitehall/carrierwave-tmp':
+        ensure => symlink,
+        target => '/data/uploads/whitehall/carrierwave-tmp',
+        force  => true,
+      }
+
+      file { '/var/govuk/whitehall/clean-uploads':
+        ensure => symlink,
+        target => '/data/uploads/whitehall/clean',
+        force  => true,
+      }
+
+      file { '/var/govuk/whitehall/incoming-uploads':
+        ensure => symlink,
+        target => '/data/uploads/whitehall/incoming',
+        force  => true,
+      }
+
+      file { '/var/govuk/whitehall/infected-uploads':
+        ensure => symlink,
+        target => '/data/uploads/whitehall/infected',
+        force  => true,
       }
     }
   }


### PR DESCRIPTION
This commit creates the whitehall asset directory structure in the development VM. This allows locally-uploaded assets to be served correctly.