### PR TITLE
Rename link-checker to link-checker-api

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -50,7 +50,7 @@ deployable_applications: &deployable_applications
     repository: 'kibana-gds'
   licencefinder:
     repository: 'licence-finder'
-  link-checker: {}
+  link-checker-api: {}
   local-links-manager: {}
   manuals-frontend: {}
   manuals-publisher: {}


### PR DESCRIPTION
Continuing our theme of renaming our service every day of the blitz today we are adopting the naming of link-checker-api. Hopefully this is the last one 😃