### PR TITLE
Add Link Checker API

### DIFF
--- a/hieradata/class/backend.yaml
+++ b/hieradata/class/backend.yaml
@@ -62,6 +62,7 @@ govuk::node::s_base::apps:
   - hmrc_manuals_api
   - imminence
   - kibana
+  - link_checker_api
   - local_links_manager
   - manuals_publisher
   - maslow

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -291,6 +291,8 @@ govuk::apps::frontend::nagios_memory_critical: 1400
 
 govuk::apps::govuk_cdn_logs_monitor::processed_data_dir: '/mnt/logs_cdn/data'
 
+govuk::apps::link_checker_api::db_hostname: "postgresql-primary-1.backend"
+
 govuk::apps::manuals_publisher::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::manuals_publisher::redis_port: "%{hiera('sidekiq_port')}"
 
@@ -958,6 +960,7 @@ hosts::production::backend::app_hostnames:
   - 'hmrc-manuals-api'
   - 'imminence'
   - 'kibana'
+  - 'link-checker-api'
   - 'local-links-manager'
   - 'maslow'
   - 'manuals-publisher'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -292,6 +292,7 @@ govuk::apps::frontend::nagios_memory_critical: 1400
 govuk::apps::govuk_cdn_logs_monitor::processed_data_dir: '/mnt/logs_cdn/data'
 
 govuk::apps::link_checker_api::db_hostname: "postgresql-primary-1.backend"
+govuk::apps::link_checker_api::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 
 govuk::apps::manuals_publisher::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::manuals_publisher::redis_port: "%{hiera('sidekiq_port')}"

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -54,6 +54,7 @@ govuk::node::s_development::apps:
   - 'info_frontend'
   - 'kibana'
   - 'licencefinder'
+  - 'link_checker_api'
   - 'local_links_manager'
   - 'manuals_frontend'
   - 'manuals_frontend::enable_running_in_draft_mode'
@@ -122,6 +123,7 @@ govuk::apps::imminence::redis_host: 'localhost'
 govuk::apps::kibana::elasticsearch_host: 'localhost'
 govuk::apps::licencefinder::mongodb_nodes: ['localhost']
 govuk::apps::manuals_frontend::enable_running_in_draft_mode::content_store: 'http://draft-content-store.dev.gov.uk'
+govuk::apps::link_checker_api::enabled: true
 govuk::apps::manuals_publisher::enable_procfile_worker: false
 govuk::apps::manuals_publisher::mongodb_nodes: ['localhost']
 govuk::apps::manuals_publisher::mongodb_name: 'manuals_publisher_development'

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -123,6 +123,7 @@ govuk::apps::imminence::redis_host: 'localhost'
 govuk::apps::kibana::elasticsearch_host: 'localhost'
 govuk::apps::licencefinder::mongodb_nodes: ['localhost']
 govuk::apps::manuals_frontend::enable_running_in_draft_mode::content_store: 'http://draft-content-store.dev.gov.uk'
+govuk::apps::link_checker_api::enable_procfile_worker: false
 govuk::apps::link_checker_api::enabled: true
 govuk::apps::manuals_publisher::enable_procfile_worker: false
 govuk::apps::manuals_publisher::mongodb_nodes: ['localhost']

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -17,6 +17,7 @@ govuk::apps::errbit::errbit_email_from: 'govuk-winston+errbit-integration@digita
 govuk::apps::event_store::enabled: true
 govuk::apps::govuk_delivery::list_title_format: 'INTEGRATION: %s'
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
+govuk::apps::link_checker_api::enabled: true
 govuk::apps::publicapi::backdrop_host: 'www.preview.performance.service.gov.uk'
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-integration'
 govuk::apps::short_url_manager::instance_name: 'integration'

--- a/hieradata/vagrant_credentials.yaml
+++ b/hieradata/vagrant_credentials.yaml
@@ -35,6 +35,8 @@ govuk::apps::content_tagger::db::password: '6bab0d694abaabc64f4b40fcd7e51'
 govuk::apps::email_alert_api::db::password: '8WB3h7RXohmTvmU7bmmDK4ppsd8BU7Ki'
 
 govuk::apps::govuk_crawler_worker::airbrake_api_key: 'lxHeeE3VknbR7nlZ51QnUfKcxd7iuIcSe25r'
+govuk::apps::link_checker_api::db::password: 'r8I6kP13TypUPiCR4izTImbaF7Li/Oh4VZFTSYR3j7A='
+govuk::apps::link_checker_api::db_password: "%{hiera('govuk::apps::link_checker_api::db::password')}"
 govuk::apps::local_links_manager::db::password: 'a192e3fcb901b069aa6c45438faecdc48b30f8a6'
 govuk::apps::local_links_manager::db_password: "%{hiera('govuk::apps::local_links_manager::db::password')}"
 govuk::apps::mapit::db_password: 'h2sBuU%M1859A0K*10VriyQwa$jGQkBKYYlAKNKh'

--- a/modules/govuk/manifests/apps/link_checker_api.pp
+++ b/modules/govuk/manifests/apps/link_checker_api.pp
@@ -20,6 +20,10 @@
 #   Whether the app is enabled.
 #   Default: false
 #
+# [*enable_procfile_worker*]
+#   Enables the sidekiq background worker.
+#   Default: true
+#
 # [*errbit_api_key*]
 #   Errbit API key for sending errors.
 #   Default: undef
@@ -47,6 +51,7 @@ class govuk::apps::link_checker_api (
   $db_password = undef,
   $db_name = 'link_checker_api_production',
   $enabled = false,
+  $enable_procfile_worker = true,
   $errbit_api_key = undef,
   $port = 3208,
   $redis_host = undef,
@@ -68,6 +73,10 @@ class govuk::apps::link_checker_api (
 
     Govuk::App::Envvar {
       app => $app_name,
+    }
+
+    govuk::procfile::worker { $app_name:
+      enable_service => $enable_procfile_worker,
     }
 
     govuk::app::envvar::redis { $app_name:

--- a/modules/govuk/manifests/apps/link_checker_api.pp
+++ b/modules/govuk/manifests/apps/link_checker_api.pp
@@ -1,0 +1,100 @@
+# == Class: govuk::apps::link_checker_api
+#
+# App details at: https://github.com/alphagov/link-checker-api
+#
+# === Parameters
+#
+# [*db_hostname*]
+#   The hostname of the database server to use in the DATABASE_URL.
+#
+# [*db_username*]
+#   The username to use in the DATABASE_URL.
+#
+# [*db_password*]
+#   The password for the database.
+#
+# [*db_name*]
+#   The database name to use in the DATABASE_URL.
+#
+# [*enabled*]
+#   Whether the app is enabled.
+#   Default: false
+#
+# [*errbit_api_key*]
+#   Errbit API key for sending errors.
+#   Default: undef
+#
+# [*port*]
+#   The port that it is served on.
+#   Default: 3208
+#
+# [*redis_host*]
+#   Redis host for sidekiq.
+#
+# [*redis_port*]
+#   Redis port for sidekiq.
+#   Default: 6379
+#
+# [*secret_token*]
+#   Used to set the app ENV var SECRET_TOKEN which is used to configure
+#   rails 4.x signed cookie mechanism. If unset the app will be unable to
+#   start.
+#   Default: undef
+#
+class govuk::apps::link_checker_api (
+  $db_hostname = undef,
+  $db_username = 'link_checker_api',
+  $db_password = undef,
+  $db_name = 'link_checker_api_production',
+  $enabled = false,
+  $errbit_api_key = undef,
+  $port = 3208,
+  $redis_host = undef,
+  $redis_port = undef,
+  $secret_token = undef,
+) {
+  $app_name = 'link-checker-api'
+
+  if $enabled {
+
+    include govuk_postgresql::client #installs libpq-dev package needed for pg gem
+
+    govuk::app { $app_name:
+      app_type          => 'rack',
+      port              => $port,
+      vhost_ssl_only    => true,
+      health_check_path => '/healthcheck',
+    }
+
+    Govuk::App::Envvar {
+      app => $app_name,
+    }
+
+    govuk::app::envvar::redis { $app_name:
+      host => $redis_host,
+      port => $redis_port,
+    }
+
+    govuk::app::envvar { "${title}-ERRBIT_API_KEY":
+      varname => 'ERRBIT_API_KEY',
+      value   => $errbit_api_key;
+    }
+
+    if $secret_token != undef {
+      govuk::app::envvar { "${title}-SECRET_TOKEN":
+        varname => 'SECRET_TOKEN',
+        value   => $secret_token,
+      }
+    }
+
+    if $::govuk_node_class != 'development' {
+      govuk::app::envvar::database_url { $app_name:
+        type     => 'postgresql',
+        username => $db_username,
+        password => $db_password,
+        host     => $db_hostname,
+        database => $db_name,
+      }
+    }
+  }
+}

--- a/modules/govuk/manifests/apps/link_checker_api/db.pp
+++ b/modules/govuk/manifests/apps/link_checker_api/db.pp
@@ -1,0 +1,21 @@
+# == Class: govuk::apps::link_checker_api::db
+#
+# === Parameters
+#
+# [*password*]
+#   The DB instance password.
+#
+# [*backend_ip_range*]
+#   Backend IP addresses to allow access to the database.
+#
+class govuk::apps::link_checker_api::db (
+  $password,
+  $backend_ip_range = undef,
+) {
+  govuk_postgresql::db { 'link_checker_api_production':
+    user                    => 'link_checker_api',
+    password                => $password,
+    allow_auth_from_backend => true,
+    backend_ip_range        => $backend_ip_range,
+  }
+}

--- a/modules/govuk/manifests/node/s_backend_lb.pp
+++ b/modules/govuk/manifests/node/s_backend_lb.pp
@@ -53,6 +53,7 @@ class govuk::node::s_backend_lb (
       'content-performance-manager',
       'content-tagger',
       'imminence',
+      'link-checker-api',
       'local-links-manager',
       'manuals-publisher',
       'maslow',

--- a/modules/govuk/manifests/node/s_postgresql_base.pp
+++ b/modules/govuk/manifests/node/s_postgresql_base.pp
@@ -6,6 +6,7 @@ class govuk::node::s_postgresql_base inherits govuk::node::s_base {
   include govuk::apps::content_performance_manager::db
   include govuk::apps::content_tagger::db
   include govuk::apps::email_alert_api::db
+  include govuk::apps::link_checker_api::db
   include govuk::apps::local_links_manager::db
   include govuk::apps::policy_publisher::db
   include govuk::apps::publishing_api::db


### PR DESCRIPTION
Adds the Link Checker API application to development and integration environments.

Depends on https://github.gds/gds/deployment/pull/1277

See also https://github.com/alphagov/govuk-app-deployment/pull/120