### PR TITLE
Fix development VM git scripts

### DIFF
--- a/development-vm/single-update-git.sh
+++ b/development-vm/single-update-git.sh
@@ -63,7 +63,7 @@ cd "$(dirname "$0")"
 
 REPO="$1"
 
-cd "../$REPO"
+cd "../../$REPO"
 
 BRANCH=$(git symbolic-ref HEAD | sed 's|^refs/heads/||')
 

--- a/development-vm/update-git.sh
+++ b/development-vm/update-git.sh
@@ -5,7 +5,7 @@ set -e
 cd "$(dirname "$0")"
 
 find_repos () {
-  ls -d ../*/.git | cut -d/ -f2
+  ls -d ../../*/.git | cut -d/ -f3
 }
 
 # Run in parallel with 8 processes. This is primarily network-bound, so even


### PR DESCRIPTION
This commit fixes the git scripts used in the development VM to pull the latest changes from each repository. Due to the scripts now being one directory lower than before, they need to reference each repo one level higher.