### PR TITLE
Downgrade Grafana to 3.1.1

### DIFF
--- a/modules/grafana/manifests/init.pp
+++ b/modules/grafana/manifests/init.pp
@@ -7,7 +7,7 @@ class grafana {
   include grafana::dashboards
 
   package { 'grafana':
-    ensure  => latest,
+    ensure  => '3.1.1',
     require => Class['grafana::repo'],
   }
 


### PR DESCRIPTION
The recent upgrade of Grafana to 4.1.2 broke the elasticsearch source and therefore all the corresponding dashboards. We are downgrading it to get those working again.

https://trello.com/c/cAdp6QBA/16-restore-kibana-data-in-grafana

cc @MatMoore @deanwilson 