### PR TITLE
Update developer scripts to work with their new home

### DIFF
--- a/development-vm/checkout-repos.sh
+++ b/development-vm/checkout-repos.sh
@@ -6,5 +6,5 @@ cd "$(dirname "$0")"
 
 while read repo
 do
-  git clone git@github.com:alphagov/$repo.git ../$repo
+  git clone git@github.com:alphagov/$repo.git ../../$repo
 done < "${1:-/dev/stdin}"

--- a/development-vm/single-update-git.sh
+++ b/development-vm/single-update-git.sh
@@ -2,57 +2,7 @@
 
 set -e
 
-ANSI_GREEN="\033[32m"
-ANSI_RED="\033[31m"
-ANSI_YELLOW="\033[33m"
-ANSI_RESET="\033[0m"
-ANSI_BOLD="\033[1m"
-
-truncate () {
-  local len="$1"
-  local str="$2"
-  if [ "${#str}" -gt "$len" ]; then
-    printf "$str" | awk "{ s=substr(\$0, 1, $len-3); print s \"...\"; }"
-  else
-    printf "$str"
-  fi
-}
-
-start () {
-  local repo="$1"
-  local branch="$2"
-  repo=$(truncate 25 "$repo")
-  branch=$(truncate 15 "$branch")
-  printf "${ANSI_BOLD}%-25s${ANSI_RESET} %-15s " "$repo" "$branch" >&2
-}
-
-ok () {
-  start "$REPO" "$BRANCH"
-  echo "${ANSI_GREEN}${@}${ANSI_RESET}" >&2
-}
-
-warn () {
-  start "$REPO" "$BRANCH"
-  echo "${ANSI_YELLOW}${@}${ANSI_RESET}" >&2
-}
-
-error () {
-  start "$REPO" "$BRANCH"
-  echo "${ANSI_RED}${@}${ANSI_RESET}" >&2
-}
-
-catch_errors () {
-  out=$(mktemp -t update-git.XXXXXX)
-  trap "rm -f '$out'" EXIT
-
-  if ! "$@" >"$out" 2>&1; then
-    error "FAILED, with output:"
-    cat "$out"
-    exit 1
-  fi
-
-  rm -f "$out"
-}
+. ./support_functions.sh
 
 if [ "$#" -ne "1" ]; then
   echo "Usage: $(basename "$0") <reponame>"

--- a/development-vm/single-update-pip.sh
+++ b/development-vm/single-update-pip.sh
@@ -4,10 +4,11 @@ set -e
 
 . ./support_functions.sh
 
-if [ "$#" -ne "1" ]; then
-  echo "Usage: $(basename "$0") <reponame>"
-  exit 1
-fi
+run_pip_install () {
+  $DIRECTORY/bin/pip install -qr requirements.txt
+}
+
+DIRECTORY='.venv'
 
 cd "$(dirname "$0")"
 
@@ -18,16 +19,16 @@ cd "../../$REPO"
 if [ -f lock ]; then
   warn "skipped because 'lock' file exists"
 else
+  virtualenv -q "$DIRECTORY"
   echo "Updating $REPO..."
-  outputfile=$(mktemp -t update-bundler.XXXXXX)
+  outputfile=$(mktemp -t update-pip.XXXXXX)
   trap "rm -f '$outputfile'" EXIT
 
-  if bundle install >"$outputfile" 2>&1; then
+  if $(run_pip_install) >"$outputfile" 2>&1; then
     ok "ok"
   else
-    error "failed with bundler output:"
+    error "failed with pip output:"
     cat "$outputfile"
     exit 1
   fi
 fi
-

--- a/development-vm/support_functions.sh
+++ b/development-vm/support_functions.sh
@@ -1,0 +1,52 @@
+
+ANSI_GREEN="\033[32m"
+ANSI_RED="\033[31m"
+ANSI_YELLOW="\033[33m"
+ANSI_RESET="\033[0m"
+ANSI_BOLD="\033[1m"
+
+truncate () {
+  local len="$1"
+  local str="$2"
+  if [ "${#str}" -gt "$len" ]; then
+    printf "$str" | awk "{ s=substr(\$0, 1, $len-3); print s \"...\"; }"
+  else
+    printf "$str"
+  fi
+}
+
+catch_errors () {
+  out=$(mktemp -t update-git.XXXXXX)
+  trap "rm -f '$out'" EXIT
+
+  if ! "$@" >"$out" 2>&1; then
+    error "FAILED, with output:"
+    cat "$out"
+    exit 1
+  fi
+
+  rm -f "$out"
+}
+
+start () {
+  local repo="$1"
+  local branch="$2"
+  repo=$(truncate 25 "$repo")
+  branch=$(truncate 15 "$branch")
+  printf "${ANSI_BOLD}%-25s${ANSI_RESET} %-15s " "$repo" "$branch" >&2
+}
+
+ok () {
+  start "$REPO" "$BRANCH"
+  echo "${ANSI_GREEN}${@}${ANSI_RESET}" >&2
+}
+
+warn () {
+  start "$REPO" "$BRANCH"
+  echo "${ANSI_YELLOW}${@}${ANSI_RESET}" >&2
+}
+
+error () {
+  start "$REPO" "$BRANCH"
+  echo "${ANSI_RED}${@}${ANSI_RESET}" >&2
+}

--- a/development-vm/update-bundler.sh
+++ b/development-vm/update-bundler.sh
@@ -7,7 +7,7 @@ set -e
 cd "$(dirname "$0")"
 
 find_repos () {
-  ls -d ../*/Gemfile | cut -d/ -f2
+  ls -d ../../*/Gemfile | cut -d/ -f3
 }
 
 

--- a/development-vm/update-pip.sh
+++ b/development-vm/update-pip.sh
@@ -3,71 +3,8 @@
 set -e
 cd "$(dirname "$0")"
 
-ANSI_GREEN="\033[32m"
-ANSI_RED="\033[31m"
-ANSI_YELLOW="\033[33m"
-ANSI_RESET="\033[0m"
-ANSI_BOLD="\033[1m"
-
-ok () {
-  start "$REPO"
-  echo "${ANSI_GREEN}${@}${ANSI_RESET}" >&2
-}
-
-error () {
-  start "$REPO"
-  echo "${ANSI_RED}${@}${ANSI_RESET}" >&2
-}
-
-warn () {
-  start "$REPO"
-  echo "${ANSI_YELLOW}${@}${ANSI_RESET}" >&2
-}
-
-start () {
-  local repo="$1"
-  repo=$(truncate 25 "$repo")
-  printf "${ANSI_BOLD}%-25s${ANSI_RESET} " "$repo" >&2
-}
-
-truncate () {
-  local len="$1"
-  local str="$2"
-  if [ "${#str}" -gt "$len" ]; then
-    printf "$str" | awk "{ s=substr(\$0, 1, $len-3); print s \"...\"; }"
-  else
-    printf "$str"
-  fi
-}
-
-DIRECTORY='.venv'
-
 find_pip_repos () {
-  ls -d ../*/requirements.txt | cut -d/ -f2
+  ls -d ../../*/requirements.txt | cut -d/ -f3
 }
 
-run_pip_install () {
-  $DIRECTORY/bin/pip install -qr requirements.txt
-}
-
-for REPO in $(find_pip_repos)
-do
-  cd "../$REPO"
-
-  if [ -f lock ]; then
-    warn "skipped because 'lock' file exists"
-  else
-    virtualenv -q "$DIRECTORY"
-    echo "Updating $REPO..."
-    outputfile=$(mktemp -t update-pip.XXXXXX)
-    trap "rm -f '$outputfile'" EXIT
-
-    if $(run_pip_install) >"$outputfile" 2>&1; then
-      ok "ok"
-    else
-      error "failed with pip output:"
-      cat "$outputfile"
-      exit 1
-    fi
-  fi
-done
+find_pip_repos | xargs -n1 ./single-update-pip.sh


### PR DESCRIPTION
The scripts moved over from the development repo (RIP) needed to know
about their new file paths relative to the app root in the dev vm.