### PR TITLE
Add draft specialist frontend

### DIFF
--- a/development-vm/Pinfile
+++ b/development-vm/Pinfile
@@ -27,6 +27,11 @@ process :'draft-government-frontend' => [
   :'government-frontend',
   :static
 ]
+process :'draft-specialist-frontend' => [
+  :'draft-content-store',
+  :'specialist-frontend',
+  :static
+]
 process :designprinciples => :static
 process :'email-alert-api'
 process :'email-alert-frontend' => [:'content-store', :'email-alert-api', :static]

--- a/development-vm/Procfile
+++ b/development-vm/Procfile
@@ -141,6 +141,8 @@ draft-government-frontend: govuk_setenv draft-government-frontend ./run_in.sh ..
 # efg_rebuild used 3127
 # efg_training_rebuild used 3128
 
+draft-specialist-frontend: govuk_setenv draft-specialist-frontend ./run_in.sh ../../specialist-frontend bundle exec rails s -p 3130 -P tmp/pids/draft-specialist-frontend.pid
+
 # Frontend JS test runner uses port 3150
 # Router test suite uses ports 3160-3169
 # Firewall block rule on port 3170 (for testing connect timeouts)

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -81,6 +81,7 @@ govuk::node::s_development::apps:
   - 'signon'
   - 'smartanswers'
   - 'specialist_frontend'
+  - 'specialist_frontend::enable_running_in_draft_mode'
   - 'specialist_publisher'
   - 'stagecraft'
   - 'stagecraft::rabbitmq'
@@ -154,6 +155,7 @@ govuk::apps::signon::enable_procfile_worker: false
 govuk::apps::smartanswers::expose_govspeak: true
 govuk::apps::short_url_manager::mongodb_name: 'short_url_manager_development'
 govuk::apps::short_url_manager::mongodb_nodes: ['localhost']
+govuk::apps::specialist_frontend::enable_running_in_draft_mode::content_store: 'http://draft-content-store.dev.gov.uk'
 govuk::apps::specialist_publisher::enable_procfile_worker: false
 govuk::apps::specialist_publisher::publish_pre_production_finders: true
 govuk::apps::specialist_publisher::mongodb_nodes: ['localhost']

--- a/modules/govuk/manifests/apps/specialist_frontend/enable_running_in_draft_mode.pp
+++ b/modules/govuk/manifests/apps/specialist_frontend/enable_running_in_draft_mode.pp
@@ -1,13 +1,13 @@
-# == Class govuk::apps::government_frontend::enable_running_in_draft_mode
+# == Class govuk::apps::specialist_frontend::enable_running_in_draft_mode
 #
-# Enables running government-frontend to serve content pages from the draft content store
+# Enables running specialist-frontend to serve content pages from the draft content store
 #
-class govuk::apps::government_frontend::enable_running_in_draft_mode(
+class govuk::apps::specialist_frontend::enable_running_in_draft_mode(
   $content_store = '',
-  $port          = '3126',
-  $vhost         = 'draft-government-frontend',
+  $port          = '3130',
+  $vhost         = 'draft-specialist-frontend',
 ) {
-  $app_name = 'draft-government-frontend'
+  $app_name = 'draft-specialist-frontend'
 
   Govuk::App::Envvar {
     app => $app_name,


### PR DESCRIPTION
This enables the draft-specialist-frontend app to be run on the development VM. It follows the same pattern as government-frontend