### PR TITLE
Add full version number for Grafana 3.1.1

### DIFF
--- a/modules/grafana/manifests/init.pp
+++ b/modules/grafana/manifests/init.pp
@@ -7,7 +7,7 @@ class grafana {
   include grafana::dashboards
 
   package { 'grafana':
-    ensure  => '3.1.1',
+    ensure  => '3.1.1-1470047149',
     require => Class['grafana::repo'],
   }
 


### PR DESCRIPTION
The apt command can't find a version called "3.1.1", even though the
cache contains all the versions we expect.

I'm assuming we need to add the postfix to the version numbers.

This is the output of `apt-cache policy grafana` on integration:

    grafana:
      Installed: 4.1.2-1486989747
      Candidate: 4.1.2-1486989747
      Version table:
     *** 4.1.2-1486989747 0
            500 http://apt.production.alphagov.co.uk/grafana/
    jessie/main
      amd64 Packages
            100 /var/lib/dpkg/status
      [...]
         3.1.1-1470047149 0
            500 http://apt.production.alphagov.co.uk/grafana/
    jessie/main
      amd64 Packages
      [...]