### PR TITLE
Fix annotations in Grafana applications errors dashboard

### DIFF
--- a/modules/grafana/templates/dashboards/application_http_error_codes.json.erb
+++ b/modules/grafana/templates/dashboards/application_http_error_codes.json.erb
@@ -230,6 +230,8 @@
         "name": "all deploys",
         "showLine": true,
         "tags": "deploys",
+        "datasource": "Graphite",
+        "target": "stats.govuk.app.*.all.deploys",
         "type": "graphite events"
       },
       {
@@ -239,6 +241,7 @@
         "lineColor": "rgba(255, 32, 32, 0.592157)",
         "name": "all restarts",
         "showLine": true,
+        "datasource": "Graphite",
         "target": "substr(stats.govuk.app.*.restarts,3,5)",
         "type": "graphite metric"
       }


### PR DESCRIPTION
The data type and target were missing for this dashboard and causing UI errors.