### PR TITLE
Add draft manuals frontend

### DIFF
--- a/development-vm/Pinfile
+++ b/development-vm/Pinfile
@@ -27,6 +27,11 @@ process :'draft-government-frontend' => [
   :'government-frontend',
   :static
 ]
+process :'draft-manuals-frontend' => [
+  :'draft-content-store',
+  :'manuals-frontend',
+  :static
+]
 process :'draft-specialist-frontend' => [
   :'draft-content-store',
   :'specialist-frontend',

--- a/development-vm/Procfile
+++ b/development-vm/Procfile
@@ -142,6 +142,7 @@ draft-government-frontend: govuk_setenv draft-government-frontend ./run_in.sh ..
 # efg_training_rebuild used 3128
 
 draft-specialist-frontend: govuk_setenv draft-specialist-frontend ./run_in.sh ../../specialist-frontend bundle exec rails s -p 3130 -P tmp/pids/draft-specialist-frontend.pid
+draft-manuals-frontend: govuk_setenv draft-manuals-frontend ./run_in.sh ../../manuals-frontend bundle exec rails s -p 3131 -P tmp/pids/draft-manuals-frontend.pid
 
 # Frontend JS test runner uses port 3150
 # Router test suite uses ports 3160-3169

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -56,6 +56,7 @@ govuk::node::s_development::apps:
   - 'licencefinder'
   - 'local_links_manager'
   - 'manuals_frontend'
+  - 'manuals_frontend::enable_running_in_draft_mode'
   - 'manuals_publisher'
   - 'mapit'
   - 'maslow'
@@ -120,6 +121,7 @@ govuk::apps::imminence::enable_procfile_worker: false
 govuk::apps::imminence::redis_host: 'localhost'
 govuk::apps::kibana::elasticsearch_host: 'localhost'
 govuk::apps::licencefinder::mongodb_nodes: ['localhost']
+govuk::apps::manuals_frontend::enable_running_in_draft_mode::content_store: 'http://draft-content-store.dev.gov.uk'
 govuk::apps::manuals_publisher::enable_procfile_worker: false
 govuk::apps::manuals_publisher::mongodb_nodes: ['localhost']
 govuk::apps::manuals_publisher::mongodb_name: 'manuals_publisher_development'

--- a/modules/govuk/manifests/apps/manuals_frontend/enable_running_in_draft_mode.pp
+++ b/modules/govuk/manifests/apps/manuals_frontend/enable_running_in_draft_mode.pp
@@ -1,0 +1,32 @@
+# == Class govuk::apps::manuals_frontend::enable_running_in_draft_mode
+#
+# Enables running manuals-frontend to serve content pages from the draft content store
+#
+class govuk::apps::manuals_frontend::enable_running_in_draft_mode(
+  $content_store = '',
+  $port          = '3131',
+  $vhost         = 'draft-manuals-frontend',
+) {
+  $app_name = 'draft-manuals-frontend'
+
+  Govuk::App::Envvar {
+    app => $app_name,
+  }
+
+  govuk::app { $app_name:
+    app_type              => 'rack',
+    port                  => $port,
+    vhost_ssl_only        => true,
+    health_check_path     => '/healthcheck',
+    legacy_logging        => false,
+    asset_pipeline        => true,
+    asset_pipeline_prefix => $app_name,
+    vhost                 => $vhost,
+  }
+
+  govuk::app::envvar {
+    "${title}-PLEK_SERVICE_CONTENT_STORE_URI":
+      varname => 'PLEK_SERVICE_CONTENT_STORE_URI',
+      value   => $content_store;
+  }
+}


### PR DESCRIPTION
This enables the draft-manuals-frontend app to be run on the development VM, follows the same pattern as government-frontend and specialist-frontend