### PR TITLE
Update relative directory path for signon

### DIFF
--- a/development-vm/replication/replicate-data-local.sh
+++ b/development-vm/replication/replicate-data-local.sh
@@ -42,8 +42,8 @@ ruby $(dirname $0)/delete_closed_indices.rb
 
 if ! $DRY_RUN; then
   status "Munging Signon db tokens for dev VM"
-  if [[ -d $(dirname $0)/../../signon ]]; then
-    cd $(dirname $0)/../../signon && bundle install && bundle exec ruby script/make_oauth_work_in_dev
+  if [[ -d $(dirname $0)/../../../signon ]]; then
+    cd $(dirname $0)/../../../signon && bundle install && bundle exec ruby script/make_oauth_work_in_dev
   fi
 fi
 


### PR DESCRIPTION
Needs to go one directory higher after moving development repo into govuk-puppet repo. I had a look through the rest of the replication scripts and this seems to be the only path that needs to be updated