### PR TITLE
Improve number formatting in worker counts in deployment dashboard

### DIFF
--- a/modules/grafana/templates/dashboards/deployment_panels/_worker_failures.json.erb
+++ b/modules/grafana/templates/dashboards/deployment_panels/_worker_failures.json.erb
@@ -38,14 +38,14 @@
         "rgba(245, 54, 54, 0.9)"
       ],
       "dateFormat": "YYYY-MM-DD HH:mm:ss",
-      "decimals": 2,
+      "decimals": 0,
       "pattern": "/.*/",
       "thresholds": [
         "1",
         "1"
       ],
       "type": "number",
-      "unit": "short"
+      "unit": "none"
     }
   ],
   "targets": [

--- a/modules/grafana/templates/dashboards/deployment_panels/_worker_successes.json.erb
+++ b/modules/grafana/templates/dashboards/deployment_panels/_worker_successes.json.erb
@@ -38,14 +38,14 @@
         "rgba(50, 172, 45, 0.97)"
       ],
       "dateFormat": "YYYY-MM-DD HH:mm:ss",
-      "decimals": 2,
+      "decimals": 0,
       "pattern": "/.*/",
       "thresholds": [
         "0",
         "0"
       ],
       "type": "number",
-      "unit": "short"
+      "unit": "none"
     }
   ],
   "targets": [


### PR DESCRIPTION
Mobbed with @MatMoore, @dwhenry, @suzannehamilton 

https://trello.com/c/ujC05759/35-round-numbers-for-error-counts