### PR TITLE
Update the analytics endpoint to match the Fastly configuration

### DIFF
--- a/modules/govuk/templates/static_extra_nginx_config.conf.erb
+++ b/modules/govuk/templates/static_extra_nginx_config.conf.erb
@@ -1,7 +1,9 @@
-location /static/a.gif {
+location /static/a {
   expires -1;
   add_header Last-Modified "";
-  empty_gif;
+
+  default_type text/plain;
+  return 200 '';
 }
 
 location /__canary__ {


### PR DESCRIPTION
For environments that don’t use Fastly (dev/integration/staging) we
still need an endpoint for the analytics to hit.

This endpoint won’t be used in production, it’s masked by Fastly config.