### PR TITLE
Fix missing Grafana dashboard panels which track workers

### DIFF
--- a/modules/grafana/templates/dashboards/deployment_dashboard_template.json.erb
+++ b/modules/grafana/templates/dashboards/deployment_dashboard_template.json.erb
@@ -54,7 +54,7 @@
         <%= scope.function_template(["grafana/dashboards/deployment_panels/_recent_500_count.json.erb"]) %>,
         <%= scope.function_template(["grafana/dashboards/deployment_panels/_period_500_count.json.erb"]) %>,
         <%= scope.function_template(["grafana/dashboards/deployment_panels/_links.json.erb"]) %>
-        <% unless @has_workers %>
+        <% if @has_workers %>
         ,
         <%= scope.function_template(["grafana/dashboards/deployment_panels/_worker_failures.json.erb"]) %>,
         <%= scope.function_template(["grafana/dashboards/deployment_panels/_worker_successes.json.erb"]) %>


### PR DESCRIPTION
Ensure that these panels are added to the dashboard if the application has workers, and are skipped if not.

The logic for this was inverted recently and this `unless` should have been changed at the same time.

https://trello.com/c/vJodL9Cc/36-generate-dashboard-from-a-template-in-puppet