### PR TITLE
Add draft-router and draft-router-api

### DIFF
--- a/development-vm/Pinfile
+++ b/development-vm/Pinfile
@@ -32,6 +32,8 @@ process :'draft-manuals-frontend' => [
   :'manuals-frontend',
   :static
 ]
+process :'draft-router'
+process :'draft-router-api'
 process :'draft-specialist-frontend' => [
   :'draft-content-store',
   :'specialist-frontend',
@@ -68,7 +70,7 @@ process :need_api
 process :'performanceplatform-admin' => [:stagecraft]
 process :'policy-publisher' => [:'publishing-api', :rummager]
 process :publisher => [:'publishing-api', 'publisher-worker'] # for some requests also uses: mapit
-process :'publishing-api' => [:'content-store', :'draft-content-store', :'router-api', :'publishing-api-worker' ]
+process :'publishing-api' => [:'content-store', :'draft-content-store', :'router-api', :'draft-router-api', :'publishing-api-worker' ]
 process :'publishing-api-worker' => [:'content-store', :'router-api']
 process :release
 process :router

--- a/development-vm/Procfile
+++ b/development-vm/Procfile
@@ -144,6 +144,9 @@ draft-government-frontend: govuk_setenv draft-government-frontend ./run_in.sh ..
 draft-specialist-frontend: govuk_setenv draft-specialist-frontend ./run_in.sh ../../specialist-frontend bundle exec rails s -p 3130 -P tmp/pids/draft-specialist-frontend.pid
 draft-manuals-frontend: govuk_setenv draft-manuals-frontend ./run_in.sh ../../manuals-frontend bundle exec rails s -p 3131 -P tmp/pids/draft-manuals-frontend.pid
 draft-static:              govuk_setenv draft-static              ./run_in.sh ../../static              bundle exec rails s -p 3132 -P tmp/pids/draft-static.pid
+# draft-router uses 3133 and 3134
+draft-router:                govuk_setenv draft-router                env BINARY=/var/govuk/gopath/src/github.com/alphagov/router/draft_router ./run_go.sh router            make run
+draft-router-api:            govuk_setenv draft-router-api            ./run_in.sh ../../router-api     bundle exec rails s -p 3135 -P tmp/pids/draft-router-api.pid
 
 # Frontend JS test runner uses port 3150
 # Router test suite uses ports 3160-3169

--- a/development-vm/replication/replicate-data-local.sh
+++ b/development-vm/replication/replicate-data-local.sh
@@ -20,6 +20,7 @@ $(dirname $0)/sync-mongo.sh "$@" router-backend-1.router.integration
 if ! $SKIP_MONGO && ! $DRY_RUN; then
   status "Munging router backend hostnames for dev VM"
   mongo --quiet --eval 'db = db.getSiblingDB("router"); db.backends.find().forEach( function(b) { b.backend_url = b.backend_url.replace(".integration.publishing.service.gov.uk", ".dev.gov.uk").replace("https","http"); db.backends.save(b); } );'
+  mongo --quiet --eval 'db = db.getSiblingDB("draft_router"); db.backends.find().forEach( function(b) { b.backend_url = b.backend_url.replace(".integration.publishing.service.gov.uk", ".dev.gov.uk").replace("https","http"); db.backends.save(b); } );'
 fi
 
 $(dirname $0)/sync-postgresql.sh "$@" postgresql-primary-1.backend.integration

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -73,7 +73,9 @@ govuk::node::s_development::apps:
   - 'publishing_api::rabbitmq'
   - 'release'
   - 'router'
+  - 'router::enable_running_in_draft_mode'
   - 'router_api'
+  - 'router_api::enable_running_in_draft_mode'
   - 'rummager'
   - 'rummager::rabbitmq'
   - 'search_admin'
@@ -149,9 +151,17 @@ govuk::apps::router::enable_nginx_vhost: true
 govuk::apps::router::mongodb_name: "%{hiera('govuk::apps::router_api::mongodb_name')}"
 govuk::apps::router::mongodb_nodes: ['localhost']
 govuk::apps::router::vhost_aliases: ["www"]
+govuk::apps::router::enable_running_in_draft_mode::error_log: STDERR
+govuk::apps::router::enable_running_in_draft_mode::enable_nginx_vhost: true
+govuk::apps::router::enable_running_in_draft_mode::mongodb_name: "draft_router"
+govuk::apps::router::enable_running_in_draft_mode::mongodb_nodes: ['localhost']
+govuk::apps::router::enable_running_in_draft_mode::vhost_aliases: ["draft-origin"]
 govuk::apps::router_api::mongodb_name: 'router'
 govuk::apps::router_api::mongodb_nodes: ['localhost']
 govuk::apps::router_api::router_nodes: ['localhost:3055']
+govuk::apps::router_api::enable_running_in_draft_mode::mongodb_name: 'draft_router'
+govuk::apps::router_api::enable_running_in_draft_mode::mongodb_nodes: ['localhost']
+govuk::apps::router_api::enable_running_in_draft_mode::router_nodes: ['localhost:3134']
 govuk::apps::rummager::enable_procfile_worker: false
 govuk::apps::rummager::rabbitmq_hosts: ['localhost']
 govuk::apps::rummager::enable_publishing_listener: true
@@ -250,6 +260,8 @@ hosts::development::apps:
   - 'draft-content-store'
   - 'draft-government-frontend'
   - 'draft-manuals-frontend'
+  - 'draft-router-api'
+  - 'draft-router'
   - 'draft-specialist-frontend'
   - 'draft-static'
   - 'draft-whitehall-frontend'

--- a/hieradata/vagrant_credentials.yaml
+++ b/hieradata/vagrant_credentials.yaml
@@ -49,6 +49,7 @@ govuk::apps::publishing_api::db_password: "%{hiera('govuk::apps::publishing_api:
 govuk::apps::publishing_api::db::password: 'jgt8923jg8923jg289jg2389fj2389fj3289j'
 govuk::apps::release::db::mysql_release: 'AlxLdicrdDEx20Yekkn4AXGAG2ksIQU1'
 govuk::apps::router_api::secret_key_base: '05ddf7c150a3c850705c86b270895d92a71779cdee752077c8d76d89fb657b018043e918bfc5abe8b914c1094158d9ffbb2264aa1301da5d2e6dde0995afd65d'
+govuk::apps::router_api::enable_running_in_draft_mode::secret_key_base: '05ddf7c150a3c850705c86b270895d92a71779cdee752077c8d76d89fb657b018043e918bfc5abe8b914c1094158d9ffbb2264aa1301da5d2e6dde0995afd65d'
 govuk::apps::search_admin::db::mysql_search_admin: 'KrafvoginjuxwycjiwegFaicsyecvi'
 govuk::apps::service_manual_publisher::db_password: "%{hiera('govuk::apps::service_manual_publisher::db::password')}"
 govuk::apps::service_manual_publisher::db::password: '3H3lpsZenSZAdI3zQGCAcdYEUTbcECvMtZ4VoK3v'

--- a/modules/govuk/manifests/apps/router/enable_running_in_draft_mode.pp
+++ b/modules/govuk/manifests/apps/router/enable_running_in_draft_mode.pp
@@ -1,0 +1,51 @@
+# == Class govuk::apps::router::enable_running_in_draft_mode
+#
+# Enables running router to serve content pages from the draft content store
+#
+class govuk::apps::router::enable_running_in_draft_mode(
+  $port = '3133',
+  $api_port = 3134,
+  $api_healthcheck = '/healthcheck',
+  $error_log = '/var/log/router/errors.json.log',
+  $mongodb_name,
+  $mongodb_nodes,
+
+  # These are only overridden in the dev VM to allow draft-origin.dev.gov.uk to go through the router.
+  $enable_nginx_vhost = false,
+  $vhost_aliases = [],
+) {
+  $app_name = 'draft-router'
+
+  Govuk::App::Envvar {
+    app => 'draft-router',
+  }
+
+  govuk::app::envvar {
+    "${title}-ROUTER_PUBADDR":
+      value   => "localhost:${port}",
+      varname => 'ROUTER_PUBADDR';
+    "${title}-ROUTER_APIADDR":
+      value   => ":${api_port}",
+      varname => 'ROUTER_APIADDR';
+    "${title}-ROUTER_MONGO_DB":
+      value   => $mongodb_name,
+      varname => 'ROUTER_MONGO_DB';
+    "${title}-ROUTER_MONGO_URL":
+      value   => join($mongodb_nodes, ','),
+      varname => 'ROUTER_MONGO_URL';
+    "${title}-ROUTER_ERROR_LOG":
+      value   => $error_log,
+      varname => 'ROUTER_ERROR_LOG';
+    "${title}-ROUTER_BACKEND_HEADER_TIMEOUT":
+      value   => '20s',
+      varname => 'ROUTER_BACKEND_HEADER_TIMEOUT';
+  }
+
+  govuk::app { 'draft-router':
+    app_type           => 'bare',
+    command            => './router',
+    port               => $port,
+    enable_nginx_vhost => $enable_nginx_vhost,
+    vhost_aliases      => $vhost_aliases,
+  }
+}

--- a/modules/govuk/manifests/apps/router_api/enable_running_in_draft_mode.pp
+++ b/modules/govuk/manifests/apps/router_api/enable_running_in_draft_mode.pp
@@ -1,0 +1,71 @@
+# == Class govuk::apps::router_api::enable_running_in_draft_mode
+#
+# Enables running router-api to serve content pages from the draft content store
+#
+# === Parameters
+#
+# [*port*]
+#   The port that draft-router-api listens on.
+#   Default: 3135
+#
+# [*mongodb_name*]
+#   The Mongo database to be used.
+#
+# [*mongodb_nodes*]
+#   Array of hostnames for the mongo cluster to use.
+#
+# [*router_nodes*]
+#   Array of hostname:port pairs for the router instances.  These will be used
+#   when reloading routes in the router.
+#
+# [*vhost*]
+#   Virtual host to be used by the application.
+#   Default: draft-router-api
+#
+# [*secret_key_base*]
+#   The key for Rails to use when signing/encrypting sessions.
+#
+class govuk::apps::router_api::enable_running_in_draft_mode(
+  $port = '3135',
+  $mongodb_name,
+  $mongodb_nodes,
+  $router_nodes,
+  $vhost = 'draft-router-api',
+  $secret_key_base = undef,
+) {
+  $app_name = 'draft-router-api'
+
+  validate_array($router_nodes)
+
+  govuk::app { $app_name:
+    app_type           => 'rack',
+    port               => $port,
+    vhost_ssl_only     => true,
+    health_check_path  => '/healthcheck',
+    log_format_is_json => true,
+    vhost              => $vhost,
+  }
+
+  Govuk::App::Envvar {
+    app            => $app_name,
+  }
+
+  if $secret_key_base != undef {
+    govuk::app::envvar { "${title}-SECRET_KEY_BASE":
+      varname => 'SECRET_KEY_BASE',
+      value   => $secret_key_base,
+    }
+  }
+
+  govuk::app::envvar::mongodb_uri { $app_name:
+    hosts    => $mongodb_nodes,
+    database => $mongodb_name,
+  }
+
+  if $router_nodes != [] {
+    govuk::app::envvar { "${title}-ROUTER_NODES":
+      varname => 'ROUTER_NODES',
+      value   => join($router_nodes, ','),
+    }
+  }
+}


### PR DESCRIPTION
This commit adds draft versions of router and router-api to the development VM. It follows the same pattern as other draft apps (e.g. government-frontend). This completes the draft stack in the development VM. It also updates the replication script to replace backend routes for draft-router with dev.gov.uk ones.