### PR TITLE
Add paragraph about signon data

### DIFF
--- a/development-vm/README-dev.md
+++ b/development-vm/README-dev.md
@@ -139,6 +139,8 @@ Those databases include:
 - Licensify
 - Signon
 
+However, the dump includes the Signon database from integration.
+
 Mapit's database will be downloaded in the Mapit repo and therefore will be not be in the backups folder.
 
 To get production data on to your local vm you will need to either have access


### PR DESCRIPTION
This commit adds a paragraph about signon data, to make clear that while it isn't synced from production, it is nevertheless available in the data dump.