### PR TITLE
Add dashboards for most deployable apps.

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -755,8 +755,10 @@ grafana::dashboards::deployment_applications:
   contacts-frontend: {}
   content-performance-manager: {}
   content-store: {}
-  content-tagger: {}
-  email-alert-api: {}
+  content-tagger:
+    has_workers: true
+  email-alert-api:
+    has_workers: true
   email-alert-frontend: {}
   feedback: {}
   finder-frontend: {}
@@ -765,7 +767,8 @@ grafana::dashboards::deployment_applications:
   govuk_content_api: {}
   govuk_need_api: {}
   hmrc-manuals-api: {}
-  imminence: {}
+  imminence:
+    has_workers: true
   info-frontend: {}
   licencefinder: {}
   link-checker-api: {}
@@ -777,26 +780,33 @@ grafana::dashboards::deployment_applications:
   metadata-api: {}
   multipage-frontend: {}
   policy-publisher: {}
-  publisher: {}
-  publishing-api: {}
+  publisher:
+    has_workers: true
+  publishing-api:
+    has_workers: true
   release: {}
   router-api: {}
-  rummager: {}
+  rummager:
+    has_workers: true
   search-admin: {}
   service-manual-frontend: {}
   service-manual-publisher: {}
   short-url-manager: {}
-  signon: {}
+  signon:
+    has_workers: true
   smartanswers: {}
   specialist-frontend: {}
-  specialist-publisher:
-    has_workers: false
+  specialist-publisher: {}
   static: {}
   support: {}
   support-api: {}
-  transition: {}
-  travel-advice-publisher: {}
-  whitehall: {}
+  transition:
+    has_workers: true
+  travel-advice-publisher:
+    has_workers: true
+  whitehall:
+    has_workers: true
+
 
 grub2::recordfail_timeout: 5
 

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -744,10 +744,59 @@ grafana::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 grafana::dashboards::app_domain: "%{hiera('app_domain')}"
 grafana::dashboards::machine_suffix_metrics: ''
 grafana::dashboards::deployment_applications:
-  whitehall: {}
+  asset-manager: {}
+  authenticating-proxy: {}
+  business-support-api: {}
+  calculators: {}
+  calendars: {}
+  collections: {}
+  collections-publisher: {}
+  contacts: {}
+  contacts-frontend: {}
+  content-performance-manager: {}
+  content-store: {}
+  content-tagger: {}
+  email-alert-api: {}
+  email-alert-frontend: {}
+  feedback: {}
+  finder-frontend: {}
+  frontend: {}
+  government-frontend: {}
+  govuk_content_api: {}
+  govuk_need_api: {}
+  hmrc-manuals-api: {}
+  imminence: {}
+  info-frontend: {}
+  licencefinder: {}
+  link-checker-api: {}
+  local-links-manager: {}
+  manuals-frontend: {}
+  manuals-publisher: {}
+  mapit: {}
+  maslow: {}
+  metadata-api: {}
+  multipage-frontend: {}
+  policy-publisher: {}
   publisher: {}
+  publishing-api: {}
+  release: {}
+  router-api: {}
+  rummager: {}
+  search-admin: {}
+  service-manual-frontend: {}
+  service-manual-publisher: {}
+  short-url-manager: {}
+  signon: {}
+  smartanswers: {}
+  specialist-frontend: {}
   specialist-publisher:
     has_workers: false
+  static: {}
+  support: {}
+  support-api: {}
+  transition: {}
+  travel-advice-publisher: {}
+  whitehall: {}
 
 grub2::recordfail_timeout: 5
 

--- a/modules/grafana/manifests/dashboards/deployment_dashboard.pp
+++ b/modules/grafana/manifests/dashboards/deployment_dashboard.pp
@@ -21,7 +21,7 @@ define grafana::dashboards::deployment_dashboard (
   $app_name = $title,
   $dashboard_directory = undef,
   $app_domain = undef,
-  $has_workers = true,
+  $has_workers = false,
 ) {
   if $has_workers {
     $worker_row = [['worker_failures', 'worker_successes']]


### PR DESCRIPTION
We have excluded the following deployable apps from this list:
    
* backdrop-read
* backdrop-write
* bouncer
* designprinciples
* email-alert-service
* errbit
* govuk-deliver
* govuk-cdn-logs-monitor
* govuk-content-schemas
* govuk_crawler_worker
* kibana
* performanceplatform-admin
* performanceplatform-big-screen-view
* router
* sidekiq-monitoring
* smokey
* spotlight
* stagecraft
    
We decided to focus on apps that speak HTTP and are part of GOV.UK
publishing.

https://trello.com/c/vJodL9Cc/36-generate-dashboard-from-a-template-in-puppet

Mobbed with @dwhenry and @MatMoore 