### PR TITLE
Add signon to alphagov_repos

### DIFF
--- a/development-vm/alphagov_repos
+++ b/development-vm/alphagov_repos
@@ -42,6 +42,7 @@ router-api
 rummager
 service-manual-frontend
 service-manual-publisher
+signon
 slimmer
 smart-answers
 specialist-frontend


### PR DESCRIPTION
This commit adds `signon` to `alphagov_repos` so that it is downloaded if a user wants to checkout a representative set of GOV.UK apps in the development VM.