### PR TITLE
Add LinkCheckerAPI to Procfile and Pinfile

### DIFF
--- a/development-vm/Pinfile
+++ b/development-vm/Pinfile
@@ -55,7 +55,9 @@ process :'contacts-admin' => [:rummager, :'publishing-api', :whitehall]
 process :'hmrc-manuals-api' => [:'publishing-api', :rummager]
 process :'manuals-frontend' => [:static, :'content-store']
 process :licencefinder => [:static, :contentapi, :'content-store']
-process :'local-links-manager'
+process :'link-checker-api' => [:'link-checker-api-sidekiq']
+process :'link-checker-api-sidekiq'
+process :'local-links-manager' => [:'link-checker-api']
 process :'manuals-publisher' => ['asset-manager', :rummager, :'publishing-api']
 process :mapit
 process :maslow => :need_api

--- a/development-vm/Procfile
+++ b/development-vm/Procfile
@@ -157,4 +157,7 @@ draft-manuals-frontend: govuk_setenv draft-manuals-frontend ./run_in.sh ../../ma
 #content-performance-manager reserve 3207 for sidekiq monitoring
 content-performance-manager:          govuk_setenv content-performance-manager ./run_in.sh ../../content-performance-manager bundle exec rails s -p 3206
 content-performance-manager-sidekiq:  govuk_setenv content-performance-manager ./run_in.sh ../../content-performance-manager bundle exec sidekiq -C ./config/sidekiq.yml
-#link-checker-api reserves port 3208
+
+# link-checker-api-sidekiq reserve port 3209 for sidekiq monitoring
+link-checker-api:                     govuk_setenv link-checker-api            ./run_in.sh ../../link-checker-api bundle exec rails s -p 3208
+link-checker-api-sidekiq:             govuk_setenv link-checker-api            ./run_in.sh ../../link-checker-api bundle exec sidekiq -C ./config/sidekiq.yml

--- a/development-vm/alphagov_repos
+++ b/development-vm/alphagov_repos
@@ -28,9 +28,10 @@ hmrc-manuals-api
 imminence
 info-frontend
 licence-finder
+link-checker-api
+local-links-manager
 manuals-frontend
 manuals-publisher
-local-links-manager
 mapit
 maslow
 metadata-api


### PR DESCRIPTION
We also add LinkCheckerAPI as a dependency to LocalLinksManager.