### PR TITLE
Link Checker API env vars

### DIFF
--- a/modules/govuk/manifests/apps/link_checker_api.pp
+++ b/modules/govuk/manifests/apps/link_checker_api.pp
@@ -28,6 +28,11 @@
 #   Errbit API key for sending errors.
 #   Default: undef
 #
+# [*google_api_key*]
+#   A Google API Key which will be used for Google Safebrowing checks. If
+#   uset these checks won't be performed
+#   Default: undef
+#
 # [*port*]
 #   The port that it is served on.
 #   Default: 3208
@@ -53,6 +58,7 @@ class govuk::apps::link_checker_api (
   $enabled = false,
   $enable_procfile_worker = true,
   $errbit_api_key = undef,
+  $google_api_key = undef,
   $port = 3208,
   $redis_host = undef,
   $redis_port = undef,
@@ -89,6 +95,12 @@ class govuk::apps::link_checker_api (
       value   => $errbit_api_key;
     }
 
+    if $google_api_key != undef {
+      govuk::app::envvar { "${title}-GOOGLE_API_KEY":
+        varname => 'GOOGLE_API_KEY',
+        value   => $google_api_key,
+      }
+    }
     if $secret_key_base != undef {
       govuk::app::envvar { "${title}-SECRET_KEY_BASE":
         varname => 'SECRET_KEY_BASE',

--- a/modules/govuk/manifests/apps/link_checker_api.pp
+++ b/modules/govuk/manifests/apps/link_checker_api.pp
@@ -39,9 +39,9 @@
 #   Redis port for sidekiq.
 #   Default: 6379
 #
-# [*secret_token*]
-#   Used to set the app ENV var SECRET_TOKEN which is used to configure
-#   rails 4.x signed cookie mechanism. If unset the app will be unable to
+# [*secret_key_base*]
+#   Used to set the app ENV var SECRET_KEY_BASE which is used to configure
+#   rails 4.1+ signed cookie mechanism. If unset the app will be unable to
 #   start.
 #   Default: undef
 #
@@ -56,7 +56,7 @@ class govuk::apps::link_checker_api (
   $port = 3208,
   $redis_host = undef,
   $redis_port = undef,
-  $secret_token = undef,
+  $secret_key_base = undef,
 ) {
   $app_name = 'link-checker-api'
 
@@ -89,10 +89,10 @@ class govuk::apps::link_checker_api (
       value   => $errbit_api_key;
     }
 
-    if $secret_token != undef {
-      govuk::app::envvar { "${title}-SECRET_TOKEN":
-        varname => 'SECRET_TOKEN',
-        value   => $secret_token,
+    if $secret_key_base != undef {
+      govuk::app::envvar { "${title}-SECRET_KEY_BASE":
+        varname => 'SECRET_KEY_BASE',
+        value   => $secret_key_base,
       }
     }
 


### PR DESCRIPTION
This changes SECRET_TOKEN to be SECRET_KEY_BASE as SECRET_TOKEN is a legacy variable

Also introduces a GOOGLE_API_KEY env var