### PR TITLE
Allow disabling of database rename on replication

### DIFF
--- a/development-vm/replication/common-args.sh
+++ b/development-vm/replication/common-args.sh
@@ -17,8 +17,9 @@ OPTIONS:
     -u user  SSH user to log in as (overrides SSH config)
     -d dir   Use named directory to store and load backups
     -s       Skip downloading the backups (use with -d to load old backups)
-    -r       Reset ignore list. This overrides any default ignores.
+    -r       Reset ignore list. This overrides any default ignores
     -i       Databases to ignore. Can be used multiple times, or as a quoted space-delimited list
+    -o       Don't rename databases (*_production to *_development)
     -n       Don't actually import anything (dry run)
     -m       Skip MongoDB import
     -p       Skip PostgreSQL import
@@ -37,6 +38,7 @@ SKIP_MYSQL=false
 SKIP_ELASTIC=false
 SKIP_MAPIT=false
 SSH_CONFIG="../ssh_config"
+RENAME_DATABASES=true
 DRY_RUN=false
 # By default, ignore large databases which are not useful when replicated.
 IGNORE="event_store transition backdrop support_contacts"
@@ -52,7 +54,7 @@ function ignored() {
   return 1
 }
 
-while getopts "hF:u:d:sri:nmpqet" OPTION
+while getopts "hF:u:d:sri:onmpqet" OPTION
 do
   case $OPTION in
     h )
@@ -76,6 +78,9 @@ do
       ;;
     i )
       IGNORE="$IGNORE $OPTARG"
+      ;;
+    o )
+      RENAME_DATABASES=false
       ;;
     n )
       DRY_RUN=true

--- a/development-vm/replication/sync-mongo.sh
+++ b/development-vm/replication/sync-mongo.sh
@@ -56,7 +56,12 @@ else
 fi
 
 echo "Mapping database names for a development VM"
-NAME_MUNGE_COMMAND="sed -f $(dirname $0)/mappings/names.sed"
+
+if $RENAME_DATABASES; then
+  NAME_MUNGE_COMMAND="sed -f $(dirname $0)/mappings/names.sed"
+else
+  NAME_MUNGE_COMMAND="cat"
+fi
 
 for dir in $(find $MONGO_DIR -mindepth 2 -maxdepth 2 -type d | grep -v '*'); do
   if $DRY_RUN; then

--- a/development-vm/replication/sync-mysql.sh
+++ b/development-vm/replication/sync-mysql.sh
@@ -56,7 +56,12 @@ else
 fi
 
 echo "Mapping database names for a development VM"
-NAME_MUNGE_COMMAND="sed -f $(dirname $0)/mappings/names.sed"
+
+if $RENAME_DATABASES; then
+  NAME_MUNGE_COMMAND="sed -f $(dirname $0)/mappings/names.sed"
+else
+  NAME_MUNGE_COMMAND="cat"
+fi
 
 if which pv >/dev/null 2>&1; then
   PV_COMMAND="pv"
@@ -78,7 +83,9 @@ for file in $(find $MYSQL_DIR -name 'daily*production*.sql.bz2'); do
     done
 
     TEMP_SED_SCRIPT=$(mktemp)
-    awk '{print "/^CREATE DATABASE/,+10",$0}' $(dirname $0)/mappings/names.sed > ${TEMP_SED_SCRIPT}
+    if $RENAME_DATABASES; then
+      awk '{print "/^CREATE DATABASE/,+10",$0}' $(dirname $0)/mappings/names.sed > ${TEMP_SED_SCRIPT}
+    fi
     if [[ -f $(dirname $0)/mappings/dbs/${PROD_DB_NAME}.sed ]] ; then
       cat $(dirname $0)/mappings/dbs/${PROD_DB_NAME}.sed >> ${TEMP_SED_SCRIPT}
     fi

--- a/development-vm/replication/sync-postgresql.sh
+++ b/development-vm/replication/sync-postgresql.sh
@@ -55,7 +55,11 @@ else
   touch $POSTGRESQL_DIR/.extracted
 fi
 
-NAME_MUNGE_COMMAND="sed -f $(dirname $0)/mappings/names.sed"
+if $RENAME_DATABASES; then
+  NAME_MUNGE_COMMAND="sed -f $(dirname $0)/mappings/names.sed"
+else
+  NAME_MUNGE_COMMAND="cat"
+fi
 
 if which pv >/dev/null 2>&1; then
   PV_COMMAND="pv"


### PR DESCRIPTION
This commit allows passing the `-o` argument to the development VM replication script to prevent the database names being renamed from `*_production` to `*_development`.

This can be used when running apps with `RAILS_ENV=production` so that the apps find their databases.

This will be used when setting up the training environment since that will be running as a production environment.