### PR TITLE
Match only the analytics endpoint

### DIFF
--- a/modules/govuk/templates/static_extra_nginx_config.conf.erb
+++ b/modules/govuk/templates/static_extra_nginx_config.conf.erb
@@ -1,4 +1,4 @@
-location /static/a {
+location = /static/a {
   expires -1;
   add_header Last-Modified "";
 


### PR DESCRIPTION
Stop being greedy and matching e.g. `/static/application.css` and
returning an empty response