### PR TITLE
Add Redis config for Frontend

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -288,6 +288,8 @@ govuk::apps::finder_frontend::nagios_memory_critical: 2500
 
 govuk::apps::frontend::nagios_memory_warning: 1200
 govuk::apps::frontend::nagios_memory_critical: 1400
+govuk::apps::frontend::redis_host: "%{hiera('sidekiq_host')}"
+govuk::apps::frontend::redis_port: "%{hiera('sidekiq_port')}"
 
 govuk::apps::govuk_cdn_logs_monitor::processed_data_dir: '/mnt/logs_cdn/data'
 

--- a/modules/govuk/manifests/apps/frontend.pp
+++ b/modules/govuk/manifests/apps/frontend.pp
@@ -26,6 +26,14 @@
 # [*nagios_memory_critical*]
 #   Memory use at which Nagios should generate a critical alert.
 #
+# [*redis_host*]
+#   Redis host for Sidekiq.
+#   Default: undef
+#
+# [*redis_port*]
+#   Redis port for Sidekiq.
+#   Default: undef
+#
 class govuk::apps::frontend(
   $vhost = 'frontend',
   $port = '3005',
@@ -33,6 +41,8 @@ class govuk::apps::frontend(
   $publishing_api_bearer_token = undef,
   $nagios_memory_warning = undef,
   $nagios_memory_critical = undef,
+  $redis_host = undef,
+  $redis_port = undef,
 ) {
 
   govuk::app { 'frontend':
@@ -51,6 +61,11 @@ class govuk::apps::frontend(
     expires epoch;
   }
   ',
+  }
+
+  govuk::app::envvar::redis { 'frontend':
+    host => $redis_host,
+    port => $redis_port,
   }
 
   govuk::app::envvar { "${title}-PUBLISHING_API_BEARER_TOKEN":


### PR DESCRIPTION
Related to 2378fff8f76675b75f4760ddaa3f4198d34b65cb

The new emergency banner implementation uses Redis. This exposes the env
vars needed for Frontend to access Redis. Although most of the code to
display the emergency banner is being moved into Static, Frontend still
needs to selectively display the promo banner if there is no emergency
banner to display. Checking for the keys in Redis will allow Frontend to
achieve this.

[Trello card](https://trello.com/c/3eq0AeHA/30-consolidate-emergency-banner-templates-in-static-and-frontend)
