### PR TITLE
Link to new docs from Icinga panel

### DIFF
--- a/lib/tasks/lint_alert_docs.rake
+++ b/lib/tasks/lint_alert_docs.rake
@@ -1,0 +1,27 @@
+desc "Check if the monitoring_docs_url's in puppet definitions link to an existing page"
+task :lint_alert_docs do
+  checks = Dir.glob("modules/**/*.pp").map do |filename|
+    code = File.read(filename)
+    code.scan(%r[monitoring_docs_url\((.*)\)]).to_a
+  end.flatten.compact.uniq
+
+  puts "ICINGA ALERTS NOT IN DOCS"
+
+  checks.each do |check|
+    next if check == "$healthcheck_opsmanual"
+    unless File.exist?("../docs.publishing.service.gov.uk/source/manual/alerts/#{check}.html.md")
+      puts "NOT FOUND: #{check}"
+    end
+  end
+
+  puts "\n\nDOCS NOT LINKED FROM ICINGA"
+
+  Dir.glob("../docs.publishing.service.gov.uk/source/manual/alerts/*.md").each do |filename|
+    name = File.basename(filename).sub('.html.md', '')
+    next if name.end_with?('healthcheck-not-ok')
+
+    unless checks.include?(name)
+      puts "NOT FOUND: #{name}"
+    end
+  end
+end

--- a/modules/govuk/lib/puppet/parser/functions/monitoring_docs_url.rb
+++ b/modules/govuk/lib/puppet/parser/functions/monitoring_docs_url.rb
@@ -2,27 +2,17 @@ module Puppet::Parser::Functions
   newfunction(:monitoring_docs_url, :type => :rvalue, :doc => <<-EOS
 Return a URL for documentation about one of our monitoring alerts
 
-The first argument should be an anchor where the docs can be found
-
-If the optional second argument is true, the first argument should be the
-name of a page rather than a slug.
+The argument should be the filename where the docs can be found
     EOS
   ) do |args|
 
-    if args.size < 1 or args.size > 2
+    if args.size != 1
       raise(ArgumentError, "monitoring_docs_url: Wrong number of arguments " +
       "(given #{args.size})")
     end
 
     key = args[0]
-    base_path = 'https://github.gds/pages/gds/opsmanual/2nd-line'
 
-    if args[1]
-      url = "#{base_path}/alerts/#{key}.html"
-    else
-      url = "#{base_path}/nagios.html##{key}"
-    end
-
-    return url
+    return "https://docs.publishing.service.gov.uk/manual/alerts/#{key}.html"
   end
 end

--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -282,7 +282,7 @@ define govuk::app::config (
       check_command       => "check_nrpe!check_unicorn_ruby_version!${title}",
       service_description => "${title} is not running the expected ruby version",
       host_name           => $::fqdn,
-      notes_url           => monitoring_docs_url('ruby-version', true),
+      notes_url           => monitoring_docs_url(ruby-version),
     }
   }
   @@icinga::check { "check_app_${title}_upstart_up_${::hostname}":

--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -267,7 +267,7 @@ define govuk::app::config (
       check_command       => "check_nrpe!check_proc_running_with_arg!unicornherder /var/run/${title}/app.pid",
       service_description => "${title} app unicornherder not running",
       host_name           => $::fqdn,
-      notes_url           => monitoring_docs_url(app-unicornherder-running),
+      notes_url           => monitoring_docs_url(unicorn-herder),
     }
     include icinga::client::check_unicorn_workers
     @@icinga::check { "check_app_${title}_unicorn_workers_${::hostname}":

--- a/modules/govuk/manifests/node/s_asset_base.pp
+++ b/modules/govuk/manifests/node/s_asset_base.pp
@@ -209,7 +209,6 @@ class govuk::node::s_asset_base (
         service_description => 'Push attachments to S3',
         host_name           => $::fqdn,
         freshness_threshold => 100800,
-        notes_url           => monitoring_docs_url(full-attachments-sync),
       }
     }
   }

--- a/modules/govuk/manifests/node/s_asset_master.pp
+++ b/modules/govuk/manifests/node/s_asset_master.pp
@@ -89,7 +89,6 @@ class govuk::node::s_asset_master (
     service_description => 'Full attachments sync',
     host_name           => $::fqdn,
     freshness_threshold => 100800,
-    notes_url           => monitoring_docs_url(full-attachments-sync),
   }
 
   @@icinga::check::graphite { "check_uploads_scan_waiting_time_${::hostname}":

--- a/modules/govuk/manifests/node/s_asset_master.pp
+++ b/modules/govuk/manifests/node/s_asset_master.pp
@@ -98,7 +98,7 @@ class govuk::node::s_asset_master (
     critical  => 2400,
     desc      => 'Waiting time to pass virus scan',
     host_name => $::fqdn,
-    notes_url => monitoring_docs_url('virus-scanning', true),
+    notes_url => monitoring_docs_url(virus-scanning),
   }
 
   cron { 'virus-scan-clean':

--- a/modules/govuk/manifests/node/s_logs_elasticsearch.pp
+++ b/modules/govuk/manifests/node/s_logs_elasticsearch.pp
@@ -108,7 +108,7 @@ class govuk::node::s_logs_elasticsearch(
     warning   => '0.000001:',
     desc      => 'elasticsearch not receiving syslog from logstash',
     host_name => $::fqdn,
-    notes_url => monitoring_docs_url(elasticsearch-not-receiving-syslog-from-logstash-check),
+    notes_url => monitoring_docs_url(elasticsearch-not-receiving-syslog),
   }
 
   Govuk_mount['/mnt/elasticsearch'] -> Class['govuk_elasticsearch']

--- a/modules/govuk/manifests/node/s_logs_redis.pp
+++ b/modules/govuk/manifests/node/s_logs_redis.pp
@@ -7,7 +7,7 @@ class govuk::node::s_logs_redis inherits govuk::node::s_redis_base {
     warning   => 10000,
     critical  => 30000,
     desc      => 'redis list length for logs',
-    notes_url => monitoring_docs_url('redis', true),
+    notes_url => monitoring_docs_url(redis),
     host_name => $::fqdn,
   }
 

--- a/modules/govuk/manifests/node/s_redis_base.pp
+++ b/modules/govuk/manifests/node/s_redis_base.pp
@@ -22,7 +22,7 @@ class govuk::node::s_redis_base {
     warning   => to_bytes("${redis_mem_warn}M"),
     critical  => to_bytes("${redis_mem_crit}M"),
     desc      => 'redis memory usage',
-    notes_url => monitoring_docs_url('redis', true),
+    notes_url => monitoring_docs_url(redis),
     host_name => $::fqdn,
   }
 
@@ -31,7 +31,7 @@ class govuk::node::s_redis_base {
     warning   => 1000,
     critical  => 2000,
     desc      => 'redis connected clients',
-    notes_url => monitoring_docs_url('redis', true),
+    notes_url => monitoring_docs_url(redis),
     host_name => $::fqdn,
   }
 

--- a/modules/govuk/spec/functions/monitoring_docs_url_spec.rb
+++ b/modules/govuk/spec/functions/monitoring_docs_url_spec.rb
@@ -12,12 +12,7 @@ describe 'monitoring_docs_url' do
   end
 
   it 'should return a URL with the correct anchor' do
-    broken_thing_url = 'https://github.gds/pages/gds/opsmanual/2nd-line/nagios.html#broken-thing'
+    broken_thing_url = 'https://docs.publishing.service.gov.uk/manual/alerts/broken-thing.html'
     expect(scope.function_monitoring_docs_url(['broken-thing'])).to eq(broken_thing_url)
-  end
-
-  it 'should return a new-style URL with optional second param' do
-    broken_thing_url = 'https://github.gds/pages/gds/opsmanual/2nd-line/alerts/broken-thing.html'
-    expect(scope.function_monitoring_docs_url(['broken-thing', true])).to eq(broken_thing_url)
   end
 end

--- a/modules/govuk_ghe_vpn/manifests/init.pp
+++ b/modules/govuk_ghe_vpn/manifests/init.pp
@@ -49,7 +49,7 @@ class govuk_ghe_vpn (
 
   @@icinga::check { "check_ghe_connection_on_${::hostname}":
     check_command       => 'check_nrpe_1arg!check_ghe_responding',
-    notes_url           => monitoring_docs_url('github-enterprise-connectivity', true),
+    notes_url           => monitoring_docs_url(github-enterprise-connectivity),
     service_description => 'Connection to GitHub Enterprise over HTTPS',
     host_name           => $::fqdn,
   }

--- a/modules/govuk_gor/manifests/init.pp
+++ b/modules/govuk_gor/manifests/init.pp
@@ -76,6 +76,6 @@ class govuk_gor(
     check_command       => 'check_nrpe!check_proc_running!gor',
     host_name           => $::fqdn,
     service_description => 'gor running',
-    notes_url           => monitoring_docs_url('gor', true),
+    notes_url           => monitoring_docs_url(gor),
   }
 }

--- a/modules/govuk_jenkins/manifests/job/copy_data_to_integration.pp
+++ b/modules/govuk_jenkins/manifests/job/copy_data_to_integration.pp
@@ -31,6 +31,6 @@ class govuk_jenkins::job::copy_data_to_integration (
     host_name           => $::fqdn,
     freshness_threshold => 115200,
     action_url          => $job_url,
-    notes_url           => monitoring_docs_url('data-sync', true),
+    notes_url           => monitoring_docs_url(data-sync),
   }
 }

--- a/modules/govuk_jenkins/manifests/job/copy_data_to_staging.pp
+++ b/modules/govuk_jenkins/manifests/job/copy_data_to_staging.pp
@@ -31,6 +31,6 @@ class govuk_jenkins::job::copy_data_to_staging (
     host_name           => $::fqdn,
     freshness_threshold => 115200,
     action_url          => $job_url,
-    notes_url           => monitoring_docs_url('data-sync', true),
+    notes_url           => monitoring_docs_url(data-sync),
   }
 }

--- a/modules/govuk_jenkins/manifests/job/search_fetch_analytics_data.pp
+++ b/modules/govuk_jenkins/manifests/job/search_fetch_analytics_data.pp
@@ -22,5 +22,6 @@ class govuk_jenkins::job::search_fetch_analytics_data (
     host_name           => $::fqdn,
     freshness_threshold => 104400,
     action_url          => $job_url,
+    notes_url           => monitoring_docs_url(fetch-analytics-data-for-search-failed),
   }
 }

--- a/modules/govuk_postgresql/manifests/server/standby.pp
+++ b/modules/govuk_postgresql/manifests/server/standby.pp
@@ -81,6 +81,6 @@ class govuk_postgresql::server::standby (
     critical  => to_bytes('16 MB'),
     args      => '--droplast 1',
     host_name => $::fqdn,
-    notes_url => monitoring_docs_url(replication-on-the-postgres-slave-is-too-far-behind-master-value-in-bytes),
+    notes_url => monitoring_docs_url(postgresql-replication-too-far-behind),
   }
 }

--- a/modules/govuk_rabbitmq/manifests/monitor_consumers.pp
+++ b/modules/govuk_rabbitmq/manifests/monitor_consumers.pp
@@ -35,7 +35,7 @@ define govuk_rabbitmq::monitor_consumers (
       check_command       => "check_nrpe!check_rabbitmq_consumers!${rabbitmq_hostname} ${rabbitmq_admin_port} ${rabbitmq_queue} ${rabbitmq_user}",
       service_description => "Check that there is at least one non-idle consumer for rabbitmq queue ${rabbitmq_queue}",
       host_name           => $::fqdn,
-      notes_url           => monitoring_docs_url(check-for-non-idle-consumers),
+      notes_url           => monitoring_docs_url(rabbitmq-no-consumers-listening),
     }
   }
 }

--- a/modules/govuk_rabbitmq/manifests/monitoring.pp
+++ b/modules/govuk_rabbitmq/manifests/monitoring.pp
@@ -28,6 +28,6 @@ class govuk_rabbitmq::monitoring (
     check_command       => 'check_nrpe_1arg!check_rabbitmq_watermark',
     service_description => 'RabbitMQ high watermark has been exceeded',
     host_name           => $::fqdn,
-    notes_url           => monitoring_docs_url(rabbitmq-high-watermark-has-been-exceeded),
+    notes_url           => monitoring_docs_url(rabbitmq-high-watermark),
   }
 }

--- a/modules/monitoring/manifests/edge.pp
+++ b/modules/monitoring/manifests/edge.pp
@@ -20,7 +20,7 @@ class monitoring::edge (
       critical  => 0.1,
       host_name => $::fqdn,
       from      => '30minutes',
-      notes_url => monitoring_docs_url('fastly-error-rate', true),
+      notes_url => monitoring_docs_url(fastly-error-rate),
     }
   }
 

--- a/modules/monitoring/manifests/network_checks.pp
+++ b/modules/monitoring/manifests/network_checks.pp
@@ -26,5 +26,6 @@ define monitoring::network_checks (
       use                 => 'govuk_high_priority',
       service_description => 'unable to ping',
       host_name           => $title,
+      notes_url           => monitoring_docs_url(vpn-down),
     }
 }

--- a/modules/monitoring/manifests/pagerduty_drill.pp
+++ b/modules/monitoring/manifests/pagerduty_drill.pp
@@ -40,7 +40,7 @@ class monitoring::pagerduty_drill (
       use                 => 'govuk_urgent_priority',
       service_description => 'PagerDuty test drill in progress',
       host_name           => $::fqdn,
-      notes_url           => monitoring_docs_url(pagerduty-dry-run),
+      notes_url           => monitoring_docs_url(pagerduty-drill),
     }
   }
 }


### PR DESCRIPTION
This changes the URLs for the "alert" pages linked from Icinga. They now go to the new developer docs. Because we have an alert per page we can simplify the URL creation a bit.

To make sure that we're linking correctly, there's a `lint_alert_docs` rake task that checks that:

- All values `monitoring_docs_url` exist on [the developer docs](https://docs.publishing.service.gov.uk/manual.html)
- Everything in [/source/manual/alerts](https://github.com/alphagov/govuk-developer-docs/tree/master/source/manual/alerts) is linked _to_ from Icinga

Todo:

- [x] https://github.com/alphagov/govuk-developer-docs/pull/118 needs to be merged first

https://trello.com/c/wWWH6YGr