### PR TITLE
Add Jenkins jobs to deploy and remove the emergency banner

### DIFF
--- a/hieradata/class/integration/jenkins.yaml
+++ b/hieradata/class/integration/jenkins.yaml
@@ -4,6 +4,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::deploy_app
   - govuk_jenkins::job::deploy_cdn
   - govuk_jenkins::job::deploy_dns
+  - govuk_jenkins::job::deploy_emergency_banner
   - govuk_jenkins::job::deploy_lambda_app
   - govuk_jenkins::job::deploy_licensify
   - govuk_jenkins::job::deploy_puppet
@@ -13,6 +14,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::launch_vms
   - govuk_jenkins::job::network_config_deploy
   - govuk_jenkins::job::passive_checks
+  - govuk_jenkins::job::remove_emergency_banner
   - govuk_jenkins::job::run_rake_task
   - govuk_jenkins::job::run_whitehall_data_migrations
   - govuk_jenkins::job::sanitize_publishing_api_data

--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -14,6 +14,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::deploy_app
   - govuk_jenkins::job::deploy_cdn
   - govuk_jenkins::job::deploy_dns
+  - govuk_jenkins::job::deploy_emergency_banner
   - govuk_jenkins::job::deploy_lambda_app
   - govuk_jenkins::job::deploy_licensify
   - govuk_jenkins::job::deploy_puppet
@@ -28,6 +29,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::passive_checks
   - govuk_jenkins::job::performance_platform_data_sync
   - govuk_jenkins::job::publishing_api_archive_events
+  - govuk_jenkins::job::remove_emergency_banner
   - govuk_jenkins::job::run_rake_task
   - govuk_jenkins::job::run_whitehall_data_migrations
   - govuk_jenkins::job::search_fetch_analytics_data

--- a/hieradata/class/staging/jenkins.yaml
+++ b/hieradata/class/staging/jenkins.yaml
@@ -4,6 +4,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::deploy_app
   - govuk_jenkins::job::deploy_cdn
   - govuk_jenkins::job::deploy_dns
+  - govuk_jenkins::job::deploy_emergency_banner
   - govuk_jenkins::job::deploy_lambda_app
   - govuk_jenkins::job::deploy_licensify
   - govuk_jenkins::job::deploy_puppet
@@ -13,6 +14,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::launch_vms
   - govuk_jenkins::job::network_config_deploy
   - govuk_jenkins::job::passive_checks
+  - govuk_jenkins::job::remove_emergency_banner
   - govuk_jenkins::job::run_rake_task
   - govuk_jenkins::job::run_whitehall_data_migrations
   - govuk_jenkins::job::smokey

--- a/modules/govuk_jenkins/manifests/job/deploy_emergency_banner.pp
+++ b/modules/govuk_jenkins/manifests/job/deploy_emergency_banner.pp
@@ -1,0 +1,12 @@
+# == Class: govuk_jenkins::job::deploy_emergency_banner
+#
+# Create a file on disk that can be parsed by jenkins-job-builder
+#
+class govuk_jenkins::job::deploy_emergency_banner {
+
+  file { '/etc/jenkins_jobs/jobs/deploy_emergency_banner.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/deploy_emergency_banner.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+}

--- a/modules/govuk_jenkins/manifests/job/remove_emergency_banner.pp
+++ b/modules/govuk_jenkins/manifests/job/remove_emergency_banner.pp
@@ -1,0 +1,12 @@
+# == Class: govuk_jenkins::job::remove_emergency_banner
+#
+# Create a file on disk that can be parsed by jenkins-job-builder
+#
+class govuk_jenkins::job::remove_emergency_banner {
+
+  file { '/etc/jenkins_jobs/jobs/remove_emergency_banner.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/remove_emergency_banner.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+}

--- a/modules/govuk_jenkins/templates/jobs/deploy_emergency_banner.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_emergency_banner.yaml.erb
@@ -1,0 +1,29 @@
+---
+- job:
+    name: deploy-emergency-banner
+    display-name: Deploy the emergency banner
+    project-type: freestyle
+    description: "Deploy the emergency banner on GOV.UK."
+    builders:
+      # The argument to `-c` is in this case `frontend` but the value is used by both `static` and `frontend` applications
+      - shell: ssh deploy@$(govuk_node_list -c frontend --single-node) "cd /var/apps/static && govuk_setenv static bundle exec rake emergency_banner:deploy[$CAMPAIGN_CLASS,$HEADING,$SHORT_DESCRIPTION,$LINK]"
+    wrappers:
+      - ansicolor:
+          colormap: xterm
+    parameters:
+      - choice:
+          name: CAMPAIGN_CLASS
+          description: Choose the colour of banner to deploy
+          choices:
+            - black
+            - green
+            - red
+      - string:
+          name: HEADING
+          description: The title of the banner
+      - string:
+          name: SHORT_DESCRIPTION
+          description: The text that appears under the title
+      - string:
+          name: LINK
+          description: The more information link

--- a/modules/govuk_jenkins/templates/jobs/remove_emergency_banner.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/remove_emergency_banner.yaml.erb
@@ -1,0 +1,12 @@
+---
+- job:
+    name: remove-emergency-banner
+    display-name: Remove the emergency banner
+    project-type: freestyle
+    description: "Remove the emergency banner from GOV.UK."
+    builders:
+      # The argument to `-c` is in this case `frontend` but the value is used by both `static` and `frontend` applications
+      - shell: ssh deploy@$(govuk_node_list -c frontend --single-node) "cd /var/apps/static && govuk_setenv static bundle exec rake emergency_banner:remove"
+    wrappers:
+      - ansicolor:
+          colormap: xterm


### PR DESCRIPTION
Trello card: https://trello.com/c/HXTUIqJk

## Motivation 

The way the emergency banner is deployed is changing. Rather than using a fabric script to add content to some partials in Frontend and Static, we will populate a hash in Redis with values needed for the emergency banner.

The same Redis values will be used by both Frontend and Static to determine whether the emergency banner should be displayed, and what it's content should be.

There are two rake tasks in Static to add and remove values to this hash.

This PR allows these Rake tasks to be run from Jenkins.