### PR TITLE
Double quote command arguments

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_emergency_banner.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_emergency_banner.yaml.erb
@@ -6,7 +6,7 @@
     description: "Deploy the emergency banner on GOV.UK."
     builders:
       # The argument to `-c` is in this case `frontend` but the value is used by both `static` and `frontend` applications
-      - shell: ssh deploy@$(govuk_node_list -c frontend --single-node) "cd /var/apps/static && govuk_setenv static bundle exec rake emergency_banner:deploy[$CAMPAIGN_CLASS,$HEADING,$SHORT_DESCRIPTION,$LINK]"
+      - shell: ssh deploy@$(govuk_node_list -c frontend --single-node) 'cd /var/apps/static && govuk_setenv static bundle exec rake emergency_banner:deploy["$CAMPAIGN_CLASS","$HEADING","$SHORT_DESCRIPTION","$LINK"]'
     wrappers:
       - ansicolor:
           colormap: xterm


### PR DESCRIPTION
The emergency_banner:deploy rake task expects arguments to be passed as
strings. The jenkins jobs don't automatically quote parameters, they
have to be explicitly quoted.