### PR TITLE
Create CLI class

### DIFF
--- a/modules/govuk_jenkins/manifests/cli.pp
+++ b/modules/govuk_jenkins/manifests/cli.pp
@@ -1,0 +1,36 @@
+# == Class: Govuk_jenkins::Cli
+#
+# Adds the pre-reqs and command for easily running the
+# jenkins-cli.
+#
+# Currently only supported on Jenkins 2 as the required credentials
+# using an SSH key is not possible on Jenkins 1.
+#
+# This should have a user enabled that has the appropriate public SSH
+# key assigned to it. Add this manually via the UI in advance
+# otherwise the tool will fail.
+#
+# === Parameters:
+#
+# [*jenkins_home*]
+#   The home directory of the Jenkins install, and where to put the
+#   Jenkins CLI jar.
+#
+class govuk_jenkins::cli (
+  $jenkins_home = '/var/lib/jenkins',
+) {
+  require ::govuk_jenkins
+
+  curl::fetch { 'Jenkins CLI tool':
+    source      => 'http://localhost:8080/jnlpJars/jenkins-cli.jar',
+    destination => "${jenkins_home}/jenkins-cli.jar",
+    timeout     => 0,
+    verbose     => false,
+  }
+
+  file { '/usr/local/bin/jenkins-cli':
+    mode    => '0755',
+    content => template('govuk_jenkins/jenkins-cli.erb'),
+    require => Curl::Fetch['Jenkins CLI tool'],
+  }
+}

--- a/modules/govuk_jenkins/manifests/init.pp
+++ b/modules/govuk_jenkins/manifests/init.pp
@@ -73,6 +73,7 @@ class govuk_jenkins (
     home_dir     => $jenkins_homedir,
   }
 
+  include ::govuk_jenkins::cli
   include ::govuk_jenkins::github_enterprise_cert
   include ::govuk_jenkins::reload
 

--- a/modules/govuk_jenkins/manifests/reload.pp
+++ b/modules/govuk_jenkins/manifests/reload.pp
@@ -3,31 +3,11 @@
 # This class will issue a "reload-configuration" of Jenkins, which means it will
 # reload any configuration changes made to disk.
 #
-# Note: this requires having a user enabled that has the appropriate public SSH
-# key assigned to it. This should be added manually via the UI in advance
-# otherwise the command will fail.
-#
-# === Parameters:
-#
-# [*jenkins_home*]
-#   The home directory of the Jenkins install, and where to put the Jenkins CLI
-#   jar.
-#
-class govuk_jenkins::reload (
-  $jenkins_home = '/var/lib/jenkins',
-) {
-  require ::govuk_jenkins
-
-  curl::fetch { 'Jenkins CLI tool':
-    source      => 'http://localhost:8080/jnlpJars/jenkins-cli.jar',
-    destination => "${jenkins_home}/jenkins-cli.jar",
-    timeout     => 0,
-    verbose     => false,
-  }
+class govuk_jenkins::reload {
+  require ::govuk_jenkins::cli
 
   exec { 'Reload Jenkins configuration':
-    command     => "/usr/bin/java -jar ${jenkins_home}/jenkins-cli.jar -s http://localhost:8080/ -i ${jenkins_home}/.ssh/id_rsa reload-configuration",
-    require     => Curl::Fetch['Jenkins CLI tool'],
+    command     => '/usr/local/bin/jenkins-cli reload-configuration',
     refreshonly => true,
   }
 }

--- a/modules/govuk_jenkins/templates/jenkins-cli.erb
+++ b/modules/govuk_jenkins/templates/jenkins-cli.erb
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+if [ "$EUID" -ne 0 ]
+  then echo "Please run as root"
+  exit 1
+fi
+
+/usr/bin/java -jar <%= @jenkins_home %>/jenkins-cli.jar -s http://localhost:8080/ -i <%= @jenkins_home %>/.ssh/id_rsa $1


### PR DESCRIPTION
This commit creates a CLI class that can be called by a user when they want to interact with Jenkins using jenkins-cli.jar. It was already invoked by the reload-configuration class, so I have moved the pre-reqs into it's own class and created a very basic script which can be invoked.