### PR TITLE
Add Plek draft prefixes

### DIFF
--- a/modules/govuk/manifests/apps/content_store/enable_running_in_draft_mode.pp
+++ b/modules/govuk/manifests/apps/content_store/enable_running_in_draft_mode.pp
@@ -47,6 +47,9 @@ class govuk::apps::content_store::enable_running_in_draft_mode() {
     "${title}-PORT":
       varname => 'PORT',
       value   => $draft_content_store_port;
+    "${title}-PLEK_HOSTNAME_PREFIX":
+      varname => 'PLEK_HOSTNAME_PREFIX',
+      value   => 'draft-';
   }
 
   govuk::app::envvar::mongodb_uri { $app_name:

--- a/modules/govuk/manifests/apps/government_frontend/enable_running_in_draft_mode.pp
+++ b/modules/govuk/manifests/apps/government_frontend/enable_running_in_draft_mode.pp
@@ -28,5 +28,8 @@ class govuk::apps::government_frontend::enable_running_in_draft_mode(
     "${title}-PLEK_SERVICE_CONTENT_STORE_URI":
       varname => 'PLEK_SERVICE_CONTENT_STORE_URI',
       value   => $content_store;
+    "${title}-PLEK_HOSTNAME_PREFIX":
+      varname => 'PLEK_HOSTNAME_PREFIX',
+      value   => 'draft-';
   }
 }

--- a/modules/govuk/manifests/apps/manuals_frontend/enable_running_in_draft_mode.pp
+++ b/modules/govuk/manifests/apps/manuals_frontend/enable_running_in_draft_mode.pp
@@ -28,5 +28,8 @@ class govuk::apps::manuals_frontend::enable_running_in_draft_mode(
     "${title}-PLEK_SERVICE_CONTENT_STORE_URI":
       varname => 'PLEK_SERVICE_CONTENT_STORE_URI',
       value   => $content_store;
+    "${title}-PLEK_HOSTNAME_PREFIX":
+      varname => 'PLEK_HOSTNAME_PREFIX',
+      value   => 'draft-';
   }
 }

--- a/modules/govuk/manifests/apps/specialist_frontend/enable_running_in_draft_mode.pp
+++ b/modules/govuk/manifests/apps/specialist_frontend/enable_running_in_draft_mode.pp
@@ -28,5 +28,8 @@ class govuk::apps::specialist_frontend::enable_running_in_draft_mode(
     "${title}-PLEK_SERVICE_CONTENT_STORE_URI":
       varname => 'PLEK_SERVICE_CONTENT_STORE_URI',
       value   => $content_store;
+    "${title}-PLEK_HOSTNAME_PREFIX":
+      varname => 'PLEK_HOSTNAME_PREFIX',
+      value   => 'draft-';
   }
 }


### PR DESCRIPTION
This commit adds env vars for draft-content-store, draft-government-frontend, draft-manuals-frontend and draft-specialist-frontend to direct Plek to prefix all requested hostnames with “draft-“ to ensure they point to the draft versions of the respective apps.