### PR TITLE
Delete mostly-empty deployment dashboards

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -749,14 +749,11 @@ grafana::dashboards::app_domain: "%{hiera('app_domain')}"
 grafana::dashboards::machine_suffix_metrics: ''
 grafana::dashboards::deployment_applications:
   asset-manager: {}
-  authenticating-proxy: {}
   business-support-api: {}
   calculators: {}
   calendars: {}
   collections: {}
   collections-publisher: {}
-  contacts:
-    docs_name: 'contacts-admin'
   contacts-frontend: {}
   content-performance-manager: {}
   content-store: {}
@@ -769,8 +766,6 @@ grafana::dashboards::deployment_applications:
   finder-frontend: {}
   frontend: {}
   government-frontend: {}
-  govuk_content_api: {}
-  govuk_need_api: {}
   hmrc-manuals-api: {}
   imminence:
     has_workers: true
@@ -785,7 +780,6 @@ grafana::dashboards::deployment_applications:
   maslow: {}
   metadata-api: {}
   multipage-frontend: {}
-  policy-publisher: {}
   publisher:
     has_workers: true
   publishing-api:


### PR DESCRIPTION
Delete dashboards which are missing most of the data or are not reporting it correctly. This errs on the side of deleting rather than keeping dashboards to avoid confusing developers with missing data while the dashboards are still so new. Any dashboards that we fix can easily be re-added later.

 - `authenticating-proxy` does not seem to report 5xx responses or error data in the same way as other Rails apps
 - `contacts` conflates admin and frontend data, and does not report Errbit errors correctly
 - `govuk_content_api` is deprecated
 - `govuk_need_api` reports graphite data as `need_api`, so it does not appear on the dashboard, which expects the data to match the app name
 - `policy-publisher` is not reporting 5xx data correctly

https://trello.com/c/6xMip5AS/46-delete-dashboards-which-are-completely-broken-empty