### PR TITLE
Allow checking out deployed-to-production branch

### DIFF
--- a/development-vm/checkout-repos.sh
+++ b/development-vm/checkout-repos.sh
@@ -2,9 +2,18 @@
 
 cd "$(dirname "$0")"
 
-# Takes either a file of repo names, or from stdin
+# Takes either a file of repo names, or from stdin.
+# If the DEPLOYED_TO_PRODUCTION environment variable
+# is set then the "deployed-to-production" branch is
+# checked out rather than "master".
+
+if [ "${DEPLOYED_TO_PRODUCTION}" == "true" ]; then
+  branch="-b deployed-to-production"
+else
+  branch=""
+fi
 
 while read repo
 do
-  git clone git@github.com:alphagov/$repo.git ../../$repo
+  git clone $branch git@github.com:alphagov/$repo.git ../../$repo
 done < "${1:-/dev/stdin}"


### PR DESCRIPTION
This commit adds functionality to `checkout-repos.sh` for the development VM to allow the `deployed-to-production` branch to be checked out rather than the default `master`. This means that a known-working version of the app can be pulled for testing.