### PR TITLE
Update gemstash server

### DIFF
--- a/modules/govuk/manifests/node/s_apt.pp
+++ b/modules/govuk/manifests/node/s_apt.pp
@@ -123,4 +123,8 @@ class govuk::node::s_apt (
     content => template('govuk/node/s_apt/vhost.conf.erb'),
   }
 
+  # Manage our local Gemstash mirror. Deployed via a docker container
+  include ::govuk_docker
+  include ::govuk_containers::gemstash
+
 }

--- a/modules/govuk_containers/files/gemstash/Dockerfile
+++ b/modules/govuk_containers/files/gemstash/Dockerfile
@@ -1,7 +1,11 @@
 FROM alpine:3.3
-MAINTAINER  govuk-role-platform-accounts-members@digital.cabinet-office.gov.uk
+LABEL maintainer="govuk-role-platform-accounts-members@digital.cabinet-office.gov.uk" \
+      description="Runs a Gemstash server on top of Alpine" \
+      version="0.1.0"
 
-RUN apk add --no-cache --virtual .ruby-builddeps \
+RUN apk update \
+    # Things we need in order to build ruby
+    && apk add --no-cache --virtual .ruby-builddeps \
         autoconf \
         bison \
         bzip2 \
@@ -16,33 +20,33 @@ RUN apk add --no-cache --virtual .ruby-builddeps \
         libxml2-dev \
         libxslt-dev \
         linux-headers \
-        ncurses-dev \
         make \
+        ncurses-dev \
         openssl \
         openssl-dev \
         procps \
         readline-dev \
         ruby \
         tar \
+        xz \
         yaml-dev \
         zlib-dev \
-        xz \
-    &&\
-    apk add --no-cache --virtual .ruby-rundeps \
+    # Things we need to run the container
+    && apk add --no-cache --virtual .ruby-rundeps \
+        curl \
         ruby \
         ruby-dev \
         sqlite-dev \
-        curl \
-    ruby-io-console \
-    ruby-json \
-    &&\
-    gem install --no-ri --no-rdoc gemstash \
-    &&\
-    apk del .ruby-builddeps
+        ruby-io-console \
+        ruby-json \
+    # Get gemstash
+    && gem install --no-ri --no-rdoc gemstash \
+    # Clean up build dependencies
+    && apk del .ruby-builddeps
 
 EXPOSE 9292
 
-HEALTHCHECK --interval=15s --timeout=3s \
-  CMD curl -f http://localhost:9292/ || exit 1
+HEALTHCHECK --interval=15s --timeout=3s\
+        CMD curl -f http://localhost:9292/ || exit 1
 
-CMD ["/usr/bin/gemstash", "start", "--no-daemonize"]
+CMD ["gemstash", "start", "--no-daemonize"]

--- a/modules/govuk_containers/files/gemstash/README.MD
+++ b/modules/govuk_containers/files/gemstash/README.MD
@@ -38,9 +38,36 @@ $ sudo docker ps -a
 CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS                    PORTS               NAMES
 86b133245e54        25897c36b312        "/usr/bin/gemstash..."   28 minutes ago      Up 28 minutes (healthy)                       gemstash
 ```
-will append the health-check response to the 'STATUS' column. To extract just the health you can use `inspect` and a parsing tool like [jq](https://stedolan.github.io/jq/):
+will append the health-check response to the 'STATUS' column. To extract just the health you can use `inspect`:
 ```bash
-$ sudo docker inspect gemstash | jq '.[].State.Health.Status'
+$ sudo docker inspect --format='{{json .State.Health.Status}}' gemstash
 "healthy"
 ```
+
+
+## Setting up Auto-build
+
+<!-- FIXME: this should be moved but we don't currently have a better location -->
+This image is automatically built on [Docker Hub](hub.docker.com). This is done using their [Automated Build process](https://docs.docker.com/docker-hub/builds/#create-an-automated-build).
+
+You'll need a Docker Hub account, to be part of the [GOV.UK](https://hub.docker.com/u/govuk/) organization and to have linked your github account using the recommended 'Public and Private' method.
+
+The main steps are:
+
+1. Click 'Create' (top right corner) then 'Create Automated Build'
+2. Click 'Create Auto-build Github' (the next page may take some time to load)
+3. Select the repository that contains the DockerFile (for example 'govuk-puppet')
+4. Set the namespace, name, visibility and a description:
+    * Namespace: `govuk`
+    * Name: what ever you like (this uses `gemstash-alpine`)
+        - The name and namespace determine the path used to pull the image created, in this case it's `govuk/gemstash-alpine`
+        - You can have multiple DockerFiles in a repository by differentiating them by namespace/name and location
+    * Visibility: whether the image is public or private.
+5. You then should click the 'Click here to customize' link.
+    * This will allow you to configure build tags and triggers.
+    * By default the master branch is built and tagged 'latest'
+6. You should specify where in the repository the DockerFile is in the "DockerFile Location" field.
+    * *Remember*: you should only have one DockerFile per directory (and everything in that directory is passed to the build process unless explicitly [ignored](https://docs.docker.com/engine/reference/builder/#dockerignore-file))
+7. Set up any further build properties. For example how to name other branch or tag builds.
+8. Click 'Create'
 

--- a/modules/govuk_containers/manifests/gemstash.pp
+++ b/modules/govuk_containers/manifests/gemstash.pp
@@ -1,0 +1,43 @@
+# == Class: govuk_containers::gemstash
+#
+# Install and run a dockerised Gemstash server
+#
+# === Parameters
+#
+# [*gemstash_image*]
+#   Docker image name to use for the gemstash container.
+#
+# [*gemstash_image_version*]
+#   The docker image version use.
+#
+class govuk_containers::gemstash(
+  $gemstash_image = 'govuk/gemstash-alpine',
+  # TODO publish a specific version and use that here
+  $gemstash_image_version = 'latest',
+) {
+
+  file { '/var/lib/gemstash':
+    ensure => directory,
+  }
+
+  ::docker::image { $gemstash_image:
+    ensure    => 'present',
+    require   => Class['govuk_docker'],
+    image_tag => $gemstash_image_version,
+  }
+
+  ::docker::run { 'gemstash':
+    net              => 'host',
+    ports            => ['9292:9292'],
+    image            => $gemstash_image,
+    require          => Docker::Image[$gemstash_image],
+    volumes          => ['/var/lib/gemstash', '/root/.gemstash'],
+    extra_parameters => ['-P'],
+  }
+
+  @@icinga::check { "check_gemstash_running_${::hostname}":
+    check_command       => 'check_nrpe!check_proc_running!gemstash',
+    service_description => 'gemstash running',
+    host_name           => $::fqdn,
+  }
+}

--- a/modules/govuk_containers/spec/classes/govuk_containers__gemstash.rb
+++ b/modules/govuk_containers/spec/classes/govuk_containers__gemstash.rb
@@ -1,0 +1,8 @@
+require_relative '../../../../spec_helper'
+
+describe 'govuk_containers::gemstash', :type => :class do
+
+  it { is_expected.to compile }
+
+  it { is_expected.to compile.with_all_deps }
+end


### PR DESCRIPTION
Extract the gemstash server side work from @SamLR original branch and add some monitoring / specs.

This adds Gemstash as a container to our infrastructure and deploys it on the `apt` nodes. This will be used by our internal machines for faster, less externally dependent deploys. The client config will follow in a separate PR.