### PR TITLE
Limit time range of ElasticSearch-based data on deployment dashboard

### DIFF
--- a/modules/grafana/templates/dashboards/deployment_panels/_errors_by_controller_action.json.erb
+++ b/modules/grafana/templates/dashboards/deployment_panels/_errors_by_controller_action.json.erb
@@ -84,7 +84,7 @@
       "timeField": "@timestamp"
     }
   ],
-  "timeFrom": null,
+  "timeFrom": "6h",
   "timeShift": null,
   "title": "Top 10 Error Count by Controller and Action",
   "tooltip": {

--- a/modules/grafana/templates/dashboards/deployment_panels/_response_times_by_controller.json.erb
+++ b/modules/grafana/templates/dashboards/deployment_panels/_response_times_by_controller.json.erb
@@ -78,7 +78,7 @@
       "timeField": "@timestamp"
     }
   ],
-  "timeFrom": null,
+  "timeFrom": "6h",
   "timeShift": null,
   "title": "90th Percentile Response Time by Controller",
   "tooltip": {


### PR DESCRIPTION
Set the maximum time range to 6 hours for the graphs of 5xx responses and slow response times broken down by Rails controller. This should still be a useful range to look at when doing a deployment, since you're mostly interested in looking at recent data.

The queries which populate these graphs are very slow over long time ranges, and this has caused problems where changing the time range on one dashboard causes other dashboards to lose data because their queries were blocked by the slow one.

Restricting the time range of these graphs should make it safe for developers to change the time range of the whole dashboard.

Limiting the time range doesn't prevent you from zooming in on a shorter time period; it just prevents you from zooming out. And the longer-range data is still available in Kibana if someone does need to look at it.

https://trello.com/c/XUBo6FxV/45-restrict-date-range-of-kibana-queries