### PR TITLE
Add a script to startup the training environment apps

### DIFF
--- a/development-vm/run_training_environment.sh
+++ b/development-vm/run_training_environment.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Start all apps that are required in the training environment along with
+# setting the relevant environment variables to use real signon, display
+# images from production where they don't exist locally, and use the local
+# MailHog SMTP port to capture emails.
+
+GDS_SSO_STRATEGY=real SHOW_PRODUCTION_IMAGES=true SMTP_PORT=1025 bowl calculators calendars collections collections-publisher contacts-admin contacts-frontend content-tagger designprinciples email-alert-frontend feedback finder-frontend frontend government-frontend draft-government-frontend info-frontend licencefinder local-links-manager manuals-frontend draft-manuals-frontend manuals-publisher maslow policy-publisher publisher router draft-router service-manual-frontend service-manual-publisher signon smartanswers specialist-frontend draft-specialist-frontend specialist-publisher travel_advice_publisher whitehall


### PR DESCRIPTION
This commit adds a script that uses `bowl` to startup all the apps required for the training environment, along with setting the relevent environment variables. This can be used when testing the training environment locally to easily start everything.