### PR TITLE
Increase disk on logs-elasticsearch

### DIFF
--- a/hieradata/class/integration/logs_elasticsearch.yaml
+++ b/hieradata/class/integration/logs_elasticsearch.yaml
@@ -1,3 +1,17 @@
 ---
 
 govuk_elasticsearch::version: '1.5.2'
+
+lv:
+  data:
+    pv:
+        - '/dev/sdb1'
+    vg: 'elasticsearch'
+
+mount:
+  /mnt/elasticsearch:
+    disk: '/dev/mapper/elasticsearch-data'
+    govuk_lvm: 'data'
+    mountoptions: 'defaults'
+    percent_threshold_warning: 16
+    percent_threshold_critical: 11

--- a/hieradata/class/logs_elasticsearch.yaml
+++ b/hieradata/class/logs_elasticsearch.yaml
@@ -13,6 +13,7 @@ lv:
     pv:
         - '/dev/sdb1'
         - '/dev/sdc1'
+        - '/dev/sdd1'
     vg: 'elasticsearch'
 
 mount:


### PR DESCRIPTION
Add extra disk for logs-elasticsearch machines in Staging and Production.

Integration barely uses up it's current disk, so this can be reduced to a single disk to help offset the costs slightly.