### PR TITLE
Remove linebreaks in dashboard JSON config file

### DIFF
--- a/modules/grafana/templates/dashboards/deployment_panels/_links.json.erb
+++ b/modules/grafana/templates/dashboards/deployment_panels/_links.json.erb
@@ -1,10 +1,5 @@
 {
-  "content": "<ul style=\"font-size: 20px;\">\n
-      <li><a target=\"_blank\" href=\"https://errbit.<%= @app_domain %>/\">Errbit</a></li>\n
-      <li><a target=\"_blank\" href=\"https://alert.<%= @app_domain %>/\">Icinga</a></li>\n
-      <li><a target=\"_blank\" href=\"https://docs.publishing.service.gov.uk/apps/<%= @docs_name %>.html\"><%= @app_name %> documentation</a></li>\n
-      <li><a target=\"_blank\" href=\"https://govuk.zendesk.com/agent/filters/135081425\">Dashboard feedback</a></li>\n
-    </ul>\n",
+  "content": "<ul style=\"font-size: 20px;\">\n<li><a target=\"_blank\" href=\"https://errbit.<%= @app_domain %>/\">Errbit</a></li>\n<li><a target=\"_blank\" href=\"https://alert.<%= @app_domain %>/\">Icinga</a></li>\n<li><a target=\"_blank\" href=\"https://docs.publishing.service.gov.uk/apps/<%= @docs_name %>.html\"><%= @app_name %> documentation</a></li>\n<li><a target=\"_blank\" href=\"https://govuk.zendesk.com/agent/filters/135081425\">Dashboard feedback</a></li>\n</ul>\n",
   "editable": true,
   "error": false,
   "id": 12,


### PR DESCRIPTION
Remove linebreaks from links panel in deployment dashboards because these make the generated JSON invalid.