### PR TITLE
Refactor config for draft apps

### DIFF
--- a/modules/govuk/manifests/apps/content_store/enable_running_in_draft_mode.pp
+++ b/modules/govuk/manifests/apps/content_store/enable_running_in_draft_mode.pp
@@ -10,9 +10,12 @@
 # 3. is served via a different nginx vhost: draft-content-store.dev.gov.uk
 # 4. prepends [DRAFT] to rails application log entries
 #
-class govuk::apps::content_store::enable_running_in_draft_mode() {
+class govuk::apps::content_store::enable_running_in_draft_mode(
+  $default_ttl = '1800',
+) {
   $draft_content_store_port = 3100
   $app_name = 'draft-content-store'
+  $parent_app_name = 'content-store'
   $app_domain = hiera('app_domain')
 
   govuk::app::nginx_vhost { $app_name:
@@ -35,21 +38,42 @@ class govuk::apps::content_store::enable_running_in_draft_mode() {
   }
 
   govuk::app::envvar {
-    "${title}-GOVUK_APP_NAME":
-      varname => 'GOVUK_APP_NAME',
-      value   => $app_name;
-    "${title}-GOVUK_APP_LOGROOT":
-      varname => 'GOVUK_APP_LOGROOT',
-      value   => "/var/log/${app_name}";
+    "${title}-DEFAULT_TTL":
+      varname => 'DEFAULT_TTL',
+      value   => $default_ttl;
     "${title}-DRAFT":
       varname => 'DRAFT',
       value   => '1';
-    "${title}-PORT":
-      varname => 'PORT',
-      value   => $draft_content_store_port;
+    "${title}-GOVUK_APP_LOGROOT":
+      varname => 'GOVUK_APP_LOGROOT',
+      value   => "/var/log/${app_name}";
+    "${title}-GOVUK_APP_NAME":
+      varname => 'GOVUK_APP_NAME',
+      value   => $app_name;
+    "${title}-GOVUK_APP_ROOT":
+      varname => 'GOVUK_APP_ROOT',
+      value   => "/var/apps/${parent_app_name}";
+    "${title}-GOVUK_APP_RUN":
+      varname => 'GOVUK_APP_RUN',
+      value   => "/var/run/${app_name}";
+    "${title}-GOVUK_APP_TYPE":
+      varname => 'GOVUK_APP_TYPE',
+      value   => 'rack';
+    "${title}-GOVUK_GROUP":
+      varname => 'GOVUK_GROUP',
+      value   => 'deploy';
+    "${title}-GOVUK_STATSD_PREFIX":
+      varname => 'GOVUK_STATSD_PREFIX',
+      value   => "govuk.app.${app_name}.development";
+    "${title}-GOVUK_USER":
+      varname => 'GOVUK_USER',
+      value   => 'deploy';
     "${title}-PLEK_HOSTNAME_PREFIX":
       varname => 'PLEK_HOSTNAME_PREFIX',
       value   => 'draft-';
+    "${title}-PORT":
+      varname => 'PORT',
+      value   => $draft_content_store_port;
   }
 
   govuk::app::envvar::mongodb_uri { $app_name:

--- a/modules/govuk/manifests/apps/government_frontend/enable_running_in_draft_mode.pp
+++ b/modules/govuk/manifests/apps/government_frontend/enable_running_in_draft_mode.pp
@@ -1,35 +1,73 @@
 # == Class govuk::apps::government_frontend::enable_running_in_draft_mode
 #
-# Enables running government-frontend to serve content pages from the draft content store
+# Enables running government-frontend for serving draft content.
+#
+# Intended to be used only in development.
+# In draft mode government-frontend:
+#
+# 1. runs on a different port: 3126
+# 2. is served via a different nginx vhost: draft-government-frontend.dev.gov.uk
 #
 class govuk::apps::government_frontend::enable_running_in_draft_mode(
   $content_store = '',
-  $port          = '3126',
-  $vhost         = 'draft-government-frontend',
 ) {
+  $draft_government_frontend_port = 3126
   $app_name = 'draft-government-frontend'
+  $parent_app_name = 'government-frontend'
+  $app_domain = hiera('app_domain')
 
-  Govuk::App::Envvar {
-    app => $app_name,
+  govuk::app::nginx_vhost { $app_name:
+    vhost    => "${app_name}.${app_domain}",
+    app_port => $draft_government_frontend_port,
   }
 
-  govuk::app { $app_name:
-    app_type              => 'rack',
-    port                  => $port,
-    vhost_ssl_only        => true,
-    health_check_path     => '/healthcheck',
-    legacy_logging        => false,
-    asset_pipeline        => true,
-    asset_pipeline_prefix => $app_name,
-    vhost                 => $vhost,
+  # Necessary because we're not creating a govuk::app instance for this.
+  file { ["/etc/govuk/${app_name}", "/etc/govuk/${app_name}/env.d"]:
+    ensure  => directory,
+    purge   => true,
+    recurse => true,
+    force   => true,
+  }
+
+  Govuk::App::Envvar {
+    app            => $app_name,
+    notify_service => false,
+    require        => File["/etc/govuk/${app_name}/env.d"],
   }
 
   govuk::app::envvar {
-    "${title}-PLEK_SERVICE_CONTENT_STORE_URI":
-      varname => 'PLEK_SERVICE_CONTENT_STORE_URI',
-      value   => $content_store;
+    "${title}-GOVUK_APP_LOGROOT":
+      varname => 'GOVUK_APP_LOGROOT',
+      value   => "/var/log/${app_name}";
+    "${title}-GOVUK_APP_NAME":
+      varname => 'GOVUK_APP_NAME',
+      value   => $app_name;
+    "${title}-GOVUK_APP_ROOT":
+      varname => 'GOVUK_APP_ROOT',
+      value   => "/var/apps/${parent_app_name}";
+    "${title}-GOVUK_APP_RUN":
+      varname => 'GOVUK_APP_RUN',
+      value   => "/var/run/${app_name}";
+    "${title}-GOVUK_APP_TYPE":
+      varname => 'GOVUK_APP_TYPE',
+      value   => 'rack';
+    "${title}-GOVUK_GROUP":
+      varname => 'GOVUK_GROUP',
+      value   => 'deploy';
+    "${title}-GOVUK_STATSD_PREFIX":
+      varname => 'GOVUK_STATSD_PREFIX',
+      value   => "govuk.app.${app_name}.development";
+    "${title}-GOVUK_USER":
+      varname => 'GOVUK_USER',
+      value   => 'deploy';
     "${title}-PLEK_HOSTNAME_PREFIX":
       varname => 'PLEK_HOSTNAME_PREFIX',
       value   => 'draft-';
+    "${title}-PLEK_SERVICE_CONTENT_STORE_URI":
+      varname => 'PLEK_SERVICE_CONTENT_STORE_URI',
+      value   => $content_store;
+    "${title}-PORT":
+      varname => 'PORT',
+      value   => $draft_government_frontend_port;
   }
 }

--- a/modules/govuk/manifests/apps/manuals_frontend/enable_running_in_draft_mode.pp
+++ b/modules/govuk/manifests/apps/manuals_frontend/enable_running_in_draft_mode.pp
@@ -1,35 +1,73 @@
 # == Class govuk::apps::manuals_frontend::enable_running_in_draft_mode
 #
-# Enables running manuals-frontend to serve content pages from the draft content store
+# Enables running manuals-frontend for serving draft content.
+#
+# Intended to be used only in development.
+# In draft mode manuals-frontend:
+#
+# 1. runs on a different port: 3131
+# 2. is served via a different nginx vhost: draft-manuals-frontend.dev.gov.uk
 #
 class govuk::apps::manuals_frontend::enable_running_in_draft_mode(
   $content_store = '',
-  $port          = '3131',
-  $vhost         = 'draft-manuals-frontend',
 ) {
+  $draft_manuals_frontend_port = 3131
   $app_name = 'draft-manuals-frontend'
+  $parent_app_name = 'manuals-frontend'
+  $app_domain = hiera('app_domain')
 
-  Govuk::App::Envvar {
-    app => $app_name,
+  govuk::app::nginx_vhost { $app_name:
+    vhost    => "${app_name}.${app_domain}",
+    app_port => $draft_manuals_frontend_port,
   }
 
-  govuk::app { $app_name:
-    app_type              => 'rack',
-    port                  => $port,
-    vhost_ssl_only        => true,
-    health_check_path     => '/healthcheck',
-    legacy_logging        => false,
-    asset_pipeline        => true,
-    asset_pipeline_prefix => $app_name,
-    vhost                 => $vhost,
+  # Necessary because we're not creating a govuk::app instance for this.
+  file { ["/etc/govuk/${app_name}", "/etc/govuk/${app_name}/env.d"]:
+    ensure  => directory,
+    purge   => true,
+    recurse => true,
+    force   => true,
+  }
+
+  Govuk::App::Envvar {
+    app            => $app_name,
+    notify_service => false,
+    require        => File["/etc/govuk/${app_name}/env.d"],
   }
 
   govuk::app::envvar {
-    "${title}-PLEK_SERVICE_CONTENT_STORE_URI":
-      varname => 'PLEK_SERVICE_CONTENT_STORE_URI',
-      value   => $content_store;
+    "${title}-GOVUK_APP_LOGROOT":
+      varname => 'GOVUK_APP_LOGROOT',
+      value   => "/var/log/${app_name}";
+    "${title}-GOVUK_APP_NAME":
+      varname => 'GOVUK_APP_NAME',
+      value   => $app_name;
+    "${title}-GOVUK_APP_ROOT":
+      varname => 'GOVUK_APP_ROOT',
+      value   => "/var/apps/${parent_app_name}";
+    "${title}-GOVUK_APP_RUN":
+      varname => 'GOVUK_APP_RUN',
+      value   => "/var/run/${app_name}";
+    "${title}-GOVUK_APP_TYPE":
+      varname => 'GOVUK_APP_TYPE',
+      value   => 'rack';
+    "${title}-GOVUK_GROUP":
+      varname => 'GOVUK_GROUP',
+      value   => 'deploy';
+    "${title}-GOVUK_STATSD_PREFIX":
+      varname => 'GOVUK_STATSD_PREFIX',
+      value   => "govuk.app.${app_name}.development";
+    "${title}-GOVUK_USER":
+      varname => 'GOVUK_USER',
+      value   => 'deploy';
     "${title}-PLEK_HOSTNAME_PREFIX":
       varname => 'PLEK_HOSTNAME_PREFIX',
       value   => 'draft-';
+    "${title}-PLEK_SERVICE_CONTENT_STORE_URI":
+      varname => 'PLEK_SERVICE_CONTENT_STORE_URI',
+      value   => $content_store;
+    "${title}-PORT":
+      varname => 'PORT',
+      value   => $draft_manuals_frontend_port;
   }
 }

--- a/modules/govuk/manifests/apps/specialist_frontend/enable_running_in_draft_mode.pp
+++ b/modules/govuk/manifests/apps/specialist_frontend/enable_running_in_draft_mode.pp
@@ -1,35 +1,73 @@
 # == Class govuk::apps::specialist_frontend::enable_running_in_draft_mode
 #
-# Enables running specialist-frontend to serve content pages from the draft content store
+# Enables running specialist-frontend for serving draft content.
+#
+# Intended to be used only in development.
+# In draft mode specialist-frontend:
+#
+# 1. runs on a different port: 3130
+# 2. is served via a different nginx vhost: draft-specialist-frontend.dev.gov.uk
 #
 class govuk::apps::specialist_frontend::enable_running_in_draft_mode(
   $content_store = '',
-  $port          = '3130',
-  $vhost         = 'draft-specialist-frontend',
 ) {
+  $draft_specialist_frontend_port = 3130
   $app_name = 'draft-specialist-frontend'
+  $parent_app_name = 'specialist-frontend'
+  $app_domain = hiera('app_domain')
 
-  Govuk::App::Envvar {
-    app => $app_name,
+  govuk::app::nginx_vhost { $app_name:
+    vhost    => "${app_name}.${app_domain}",
+    app_port => $draft_specialist_frontend_port,
   }
 
-  govuk::app { $app_name:
-    app_type              => 'rack',
-    port                  => $port,
-    vhost_ssl_only        => true,
-    health_check_path     => '/healthcheck',
-    legacy_logging        => false,
-    asset_pipeline        => true,
-    asset_pipeline_prefix => $app_name,
-    vhost                 => $vhost,
+  # Necessary because we're not creating a govuk::app instance for this.
+  file { ["/etc/govuk/${app_name}", "/etc/govuk/${app_name}/env.d"]:
+    ensure  => directory,
+    purge   => true,
+    recurse => true,
+    force   => true,
+  }
+
+  Govuk::App::Envvar {
+    app            => $app_name,
+    notify_service => false,
+    require        => File["/etc/govuk/${app_name}/env.d"],
   }
 
   govuk::app::envvar {
-    "${title}-PLEK_SERVICE_CONTENT_STORE_URI":
-      varname => 'PLEK_SERVICE_CONTENT_STORE_URI',
-      value   => $content_store;
+    "${title}-GOVUK_APP_LOGROOT":
+      varname => 'GOVUK_APP_LOGROOT',
+      value   => "/var/log/${app_name}";
+    "${title}-GOVUK_APP_NAME":
+      varname => 'GOVUK_APP_NAME',
+      value   => $app_name;
+    "${title}-GOVUK_APP_ROOT":
+      varname => 'GOVUK_APP_ROOT',
+      value   => "/var/apps/${parent_app_name}";
+    "${title}-GOVUK_APP_RUN":
+      varname => 'GOVUK_APP_RUN',
+      value   => "/var/run/${app_name}";
+    "${title}-GOVUK_APP_TYPE":
+      varname => 'GOVUK_APP_TYPE',
+      value   => 'rack';
+    "${title}-GOVUK_GROUP":
+      varname => 'GOVUK_GROUP',
+      value   => 'deploy';
+    "${title}-GOVUK_STATSD_PREFIX":
+      varname => 'GOVUK_STATSD_PREFIX',
+      value   => "govuk.app.${app_name}.development";
+    "${title}-GOVUK_USER":
+      varname => 'GOVUK_USER',
+      value   => 'deploy';
     "${title}-PLEK_HOSTNAME_PREFIX":
       varname => 'PLEK_HOSTNAME_PREFIX',
       value   => 'draft-';
+    "${title}-PLEK_SERVICE_CONTENT_STORE_URI":
+      varname => 'PLEK_SERVICE_CONTENT_STORE_URI',
+      value   => $content_store;
+    "${title}-PORT":
+      varname => 'PORT',
+      value   => $draft_specialist_frontend_port;
   }
 }


### PR DESCRIPTION
This commit changes the puppet config for the draft apps to match what happens with `draft-content-store`, as well as be able to set a different `GOVUK_APP_ROOT`. This allows the apps to be run using unicorn, which otherwise tries to look in the wrong directories for the apps.