### PR TITLE
Increase disk space on mirrorer-1

### DIFF
--- a/hieradata/class/mirrorer.yaml
+++ b/hieradata/class/mirrorer.yaml
@@ -11,7 +11,9 @@ icinga::client::checks::disk_time_critical: 250 # milliseconds
 
 lv:
   worker:
-    pv: '/dev/sdb1'
+    pv:
+      - '/dev/sdb1'
+      - '/dev/sdc1'
     vg: 'crawler'
 
 mount:


### PR DESCRIPTION
The size of the site we're pulling is now becoming sufficiently large that we need to increase the default size of the crawler mount (50GB). This commit adds a new disk to increase the size of this mount.