### PR TITLE
Use events to display server deploys

### DIFF
--- a/modules/grafana/templates/dashboards/deployment_dashboard_template.json.erb
+++ b/modules/grafana/templates/dashboards/deployment_dashboard_template.json.erb
@@ -88,7 +88,7 @@
         "enable": true,
         "iconColor": "rgba(255, 96, 96, 1)",
         "name": "Deploys",
-        "target": "stats.govuk.app.<%= @app_name %>.all.deploys"
+        "tags": "deploys <%= @app_name %>"
       },
       {
         "datasource": "Graphite",


### PR DESCRIPTION
Event data exists for all environments which whisper (time stream)
data does not. As a result moving to use event data means deploys
are visible in all environments.

Events are documented: http://graphite.readthedocs.io/en/latest/events.html

https://trello.com/b/T9cPzxHP/gov-uk-search-doing

Event data is recorded slightly earlier than whisper data as you can see in the below picture, however as there is less than 5sec in it I feel we should change over.

![screenshot 2017-04-18 12 19 01](https://cloud.githubusercontent.com/assets/63736/25128349/4b89a42a-2431-11e7-853e-c6fbdf6f20a5.png)
