### PR TITLE
Change internal grafana alias

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1178,6 +1178,7 @@ hosts::production::management::hosts:
     ip: '10.1.0.20'
     legacy_aliases:
       - 'monitoring'
+      - "grafana.%{hiera('app_domain')}"
     service_aliases:
       - 'alert'
       - 'monitoring'
@@ -1185,7 +1186,6 @@ hosts::production::management::hosts:
     ip: '10.1.0.22'
     legacy_aliases:
       - "graphite.%{hiera('app_domain')}"
-      - "grafana.%{hiera('app_domain')}"
     service_aliases:
       - 'graphite'
   logs-cdn-1:

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -474,6 +474,7 @@ hosts::production::management::hosts:
     ip: '10.3.0.20'
     legacy_aliases:
       - 'monitoring'
+      - "grafana.%{hiera('app_domain')}"
     service_aliases:
       - 'alert'
       - 'monitoring'
@@ -481,7 +482,6 @@ hosts::production::management::hosts:
     ip: '10.3.0.22'
     legacy_aliases:
       - "graphite.%{hiera('app_domain')}"
-      - "grafana.%{hiera('app_domain')}"
     service_aliases:
       - 'graphite'
   logs-cdn-1:

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -409,6 +409,7 @@ hosts::production::management::hosts:
     ip: '10.2.0.20'
     legacy_aliases:
       - 'monitoring'
+      - "grafana.%{hiera('app_domain')}"
     service_aliases:
       - 'alert'
       - 'monitoring'
@@ -416,7 +417,6 @@ hosts::production::management::hosts:
     ip: '10.2.0.22'
     legacy_aliases:
       - "graphite.%{hiera('app_domain')}"
-      - "grafana.%{hiera('app_domain')}"
     service_aliases:
       - 'graphite'
   logs-cdn-1:


### PR DESCRIPTION
The SSL grafana vhost is actually served from monitoring-1 rather than graphite-1.