### PR TITLE
Remove ci-agent-6

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1068,8 +1068,6 @@ hosts::production::ci::hosts:
     ip: '10.1.6.24'
   ci-agent-5:
     ip: '10.1.6.25'
-  ci-agent-6:
-    ip: '10.1.6.26'
 
 hosts::production::frontend::hosts:
   calculators-frontend-1:


### PR DESCRIPTION
Whenever I run a fab task across the ci-agents it complains that it can't connect to ci-agent-6. It doesn't exist, so remove the host entry.