### PR TITLE
Escape string parameters in deploy emergency banner job

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_emergency_banner.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_emergency_banner.yaml.erb
@@ -6,7 +6,7 @@
     description: "Deploy the emergency banner on GOV.UK."
     builders:
       # The argument to `-c` is in this case `frontend` but the value is used by both `static` and `frontend` applications
-      - shell: ssh deploy@$(govuk_node_list -c frontend --single-node) 'cd /var/apps/static && govuk_setenv static bundle exec rake emergency_banner:deploy["$CAMPAIGN_CLASS","$HEADING","$SHORT_DESCRIPTION","$LINK"]'
+      - shell: ssh deploy@$(govuk_node_list -c frontend --single-node) 'cd /var/apps/static && govuk_setenv static bundle exec rake emergency_banner:deploy[\"$CAMPAIGN_CLASS\",\"$HEADING\",\"$SHORT_DESCRIPTION\",\"$LINK\"]'
     wrappers:
       - ansicolor:
           colormap: xterm


### PR DESCRIPTION
The parameters in the "Deploy emergency banner" job need to passed to
the rake task as quoted strings.

If the double quotes are not escaped, the parameters are passed to the rake
task as empty strings.