### PR TITLE
Hide error/slow responses graphs if data is missing

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -750,36 +750,85 @@ grafana::dashboards::machine_suffix_metrics: ''
 grafana::dashboards::deployment_applications:
   asset-manager: {}
   business-support-api: {}
-  calculators: {}
+  calculators:
+    # Status, duration, controller missing @fields. prefix
+    show_controller_errors: false
+    show_slow_requests: false
   calendars: {}
   collections: {}
-  collections-publisher: {}
-  contacts-frontend: {}
-  content-performance-manager: {}
+  collections-publisher:
+    # Low usage
+    show_controller_errors: false
+    show_slow_requests: false
+  contacts-frontend:
+    # Missing data in kibana
+    show_controller_errors: false
+    show_slow_requests: false
+  content-performance-manager:
+    # Missing duration, status, controller fields
+    show_controller_errors: false
+    show_slow_requests: false
   content-store: {}
   content-tagger:
     has_workers: true
   email-alert-api:
     has_workers: true
-  email-alert-frontend: {}
+  email-alert-frontend:
+    # Missing duration, status, controller fields
+    show_controller_errors: false
+    show_slow_requests: false
   feedback: {}
   finder-frontend: {}
-  frontend: {}
+  frontend:
+    # Status, duration, controller missing @fields. prefix
+    show_controller_errors: false
+    show_slow_requests: false
   government-frontend: {}
-  hmrc-manuals-api: {}
+  hmrc-manuals-api:
+    # Missing @fields.status
+    show_controller_errors: false
   imminence:
+    # Missing @fields.status
+    show_controller_errors: false
     has_workers: true
   info-frontend: {}
   licencefinder:
+    # Status, duration, controller missing @fields. prefix
+    show_controller_errors: false
+    show_slow_requests: false
     docs_name: 'licence-finder'
-  link-checker-api: {}
-  local-links-manager: {}
-  manuals-frontend: {}
-  manuals-publisher: {}
-  mapit: {}
-  maslow: {}
-  metadata-api: {}
-  multipage-frontend: {}
+  link-checker-api:
+    # Missing kibana logs with this name
+    show_controller_errors: false
+    show_slow_requests: false
+  local-links-manager:
+    # Missing status, duration, controller
+    show_controller_errors: false
+    show_slow_requests: false
+  manuals-frontend:
+    # Missing status, duration, controller
+    show_controller_errors: false
+    show_slow_requests: false
+  manuals-publisher:
+    # Very low usage
+    show_controller_errors: false
+    show_slow_requests: false
+  mapit:
+    # No data in kibana
+    show_controller_errors: false
+    show_slow_requests: false
+  maslow:
+    # Very low usage
+    show_controller_errors: false
+    show_slow_requests: false
+  metadata-api:
+    # status instead of @fields.status, missing duration, controller
+    show_controller_errors: false
+    show_slow_requests: false
+  multipage-frontend:
+    # No data in kibana
+    show_controller_errors: false
+    show_slow_requests: false
   publisher:
     has_workers: true
   publishing-api:
@@ -787,10 +836,19 @@ grafana::dashboards::deployment_applications:
   release: {}
   router-api: {}
   rummager:
+    # @fields.controller is blank and rummager is a sinatra app
+    show_controller_errors: false
+    show_slow_requests: false
     has_workers: true
-  search-admin: {}
+  search-admin:
+    # No data in kibana
+    show_controller_errors: false
+    show_slow_requests: false
   service-manual-frontend: {}
-  service-manual-publisher: {}
+  service-manual-publisher:
+    # Status, duration, controller missing @fields. prefix
+    show_controller_errors: false
+    show_slow_requests: false
   short-url-manager: {}
   signon:
     has_workers: true
@@ -802,6 +860,9 @@ grafana::dashboards::deployment_applications:
   support: {}
   support-api: {}
   transition:
+    # Status, duration, controller missing @fields.prefix
+    show_controller_errors: false
+    show_slow_requests: false
     has_workers: true
   travel-advice-publisher:
     has_workers: true

--- a/modules/grafana/manifests/dashboards/deployment_dashboard.pp
+++ b/modules/grafana/manifests/dashboards/deployment_dashboard.pp
@@ -32,11 +32,29 @@ define grafana::dashboards::deployment_dashboard (
   $has_workers = false,
   $error_threshold = 20,
   $warning_threshold = 10,
+  $show_controller_errors = true,
+  $show_slow_requests = true
 ) {
   if $has_workers {
     $worker_row = [['worker_failures', 'worker_successes']]
   } else {
     $worker_row = []
+  }
+
+  if $show_controller_errors {
+    $errors_by_controller_row = [
+      ['errors_by_controller_action']
+    ]
+  } else {
+    $errors_by_controller_row = []
+  }
+
+  if $show_slow_requests {
+    $duration_by_controller_row = [
+      ['response_times_by_controller']
+    ]
+  } else {
+    $duration_by_controller_row = []
   }
 
   $panel_partials = concat(
@@ -45,10 +63,8 @@ define grafana::dashboards::deployment_dashboard (
       ['error_counts_table', 'links']
     ],
     $worker_row,
-    [
-      ['errors_by_controller_action'],
-      ['response_times_by_controller']
-    ]
+    $errors_by_controller_row,
+    $duration_by_controller_row
   )
 
   file {


### PR DESCRIPTION
The graphs at the bottom of the deployment dashboard come from
elasticsearch. For a lot of dashboards, these are empty because the
events aren't logged in a consistent way.

For apps where the data is not available, hide these panels. Also hide
them for low usage apps where there won't be enough events to see
trends.

In the case of the error graph, the graph itself is only useful when
there are errors and you want to break it down by controller, so we
might want to change how we present this for apps that don't error all
the time. A series is only drawn on the graph if there is an event so
the graph is just blank if everything is fine, which is confusing.

https://trello.com/c/lVNtP9A4/47-hide-errors-by-controller-and-slow-responses-by-controller-graphs-on-dashboards-where-they-have-no-data