### PR TITLE
Fix how params are passed to the rake task

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_emergency_banner.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_emergency_banner.yaml.erb
@@ -6,7 +6,7 @@
     description: "Deploy the emergency banner on GOV.UK."
     builders:
       # The argument to `-c` is in this case `frontend` but the value is used by both `static` and `frontend` applications
-      - shell: ssh deploy@$(govuk_node_list -c frontend --single-node) 'cd /var/apps/static && govuk_setenv static bundle exec rake emergency_banner:deploy[\"$CAMPAIGN_CLASS\",\"$HEADING\",\"$SHORT_DESCRIPTION\",\"$LINK\"]'
+      - shell: ssh deploy@$(govuk_node_list -c frontend --single-node) "cd /var/apps/static && govuk_setenv static bundle exec rake emergency_banner:deploy['"$CAMPAIGN_CLASS"','"$HEADING"','"$SHORT_DESCRIPTION"','"$LINK"']"
     wrappers:
       - ansicolor:
           colormap: xterm


### PR DESCRIPTION
The "Deploy emergency banner" should pass quoted string parameters
to the `emergency_banner:deploy` rake task.

This final attempt of wrapping quotes in quotes, which has been tested
by manually updating the config in Jenkins, seems to work.