### PR TITLE
Add HTTP basic auth to training environment

### DIFF
--- a/hieradata/development_credentials.yaml
+++ b/hieradata/development_credentials.yaml
@@ -13,7 +13,7 @@ govuk_rabbitmq::root_password: root
 govuk::apps::mapit::db_password: 'mapit'
 
 govuk_htpasswd::http_users:
-  betademo: 'password'
+  betademo: '$2y$05$a6oye5LFUMqBK/h6F/UFV.bhQllgJSJ7vLZDNsj5h0vELCmewYaI.'
   govuk:  '$2y$05$a6oye5LFUMqBK/h6F/UFV.bhQllgJSJ7vLZDNsj5h0vELCmewYaI.'
 
 icinga::plugin::check_rabbitmq_consumers::monitoring_password: "%{hiera('govuk_rabbitmq::monitoring_password')}"

--- a/modules/govuk/manifests/app/nginx_vhost.pp
+++ b/modules/govuk/manifests/app/nginx_vhost.pp
@@ -94,11 +94,19 @@ define govuk::app::nginx_vhost (
     $nginx_extra_config_real = $nginx_extra_config
   }
 
+  # Force HTTP basic auth for the training environment, since it doesn't have
+  # the cache servers which do this in the integration environment
+  if $::govuk_node_class == 'training' {
+    $really_protected = true
+  } else {
+    $really_protected = $protected
+  }
+
   nginx::config::vhost::proxy { $vhost:
     ensure                         => $ensure,
     to                             => ["localhost:${app_port}"],
     aliases                        => $aliases,
-    protected                      => $protected,
+    protected                      => $really_protected,
     protected_location             => $protected_location,
     ssl_only                       => $ssl_only,
     extra_config                   => $nginx_extra_config_real,


### PR DESCRIPTION
This commit adds HTTP basic auth to the training environment. This mimics the integration environment and stops search engines from indexing content or users accidentally visiting and mistaking it with production.