### PR TITLE
Give docker it's own mount

### DIFF
--- a/hieradata/class/ci_agent.yaml
+++ b/hieradata/class/ci_agent.yaml
@@ -21,9 +21,16 @@ lv:
   data:
     pv: '/dev/sdb1'
     vg: 'jenkins'
+  docker:
+    pv: '/dev/sdc1'
+    vg: 'data'
 
 mount:
   /var/lib/jenkins:
     disk: '/dev/mapper/jenkins-data'
     govuk_lvm: 'data'
+    mountoptions: 'defaults'
+  /var/lib/docker:
+    disk: '/dev/mapper/data-docker'
+    govuk_lvm: 'docker'
     mountoptions: 'defaults'

--- a/modules/govuk_ci/manifests/agent/docker.pp
+++ b/modules/govuk_ci/manifests/agent/docker.pp
@@ -3,6 +3,9 @@
 # Installs and configures Docker and Docker Compose
 class govuk_ci::agent::docker {
 
+  # Mount docker on it's own disk
+  Govuk_mount['/var/lib/docker'] ->
+
   # Jenkins user needs to be able to build and manage containers
   class { '::docker':
     docker_users => ['jenkins'],


### PR DESCRIPTION
Docker keeps filling the root filesystem with data. We should ensure that it doesn't interupt the system by giving it's own disk and mount.