### PR TITLE
Docker cleanup cron task

### DIFF
--- a/modules/govuk_ci/manifests/agent/docker.pp
+++ b/modules/govuk_ci/manifests/agent/docker.pp
@@ -10,4 +10,15 @@ class govuk_ci::agent::docker {
 
   include ::docker::compose
 
+  cron::crondotdee { 'remove_docker_dangling_images' :
+    hour    => 10,
+    minute  => 0,
+    command => 'docker rmi $(docker images --filter "dangling=true" -q --no-trunc)',
+  }
+
+  cron::crondotdee { 'remove_docker_dangling_volumes' :
+    hour    => 10,
+    minute  => 2,
+    command => 'docker volume rm $(docker volume ls -qf dangling=true)',
+  }
 }


### PR DESCRIPTION
This runs the commands listed in the opsmanual to clean up docker space
that is built up from dangling images.

A more thorough alternative to this could be to look at something like:
https://github.com/meltwater/docker-cleanup