### PR TITLE
[Do Not Merge] Update field for emergency banner campaign class

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_emergency_banner.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_emergency_banner.yaml.erb
@@ -15,9 +15,9 @@
           name: CAMPAIGN_CLASS
           description: Choose the colour of banner to deploy
           choices:
-            - black
-            - green
-            - red
+            - notable-death
+            - national-emergency
+            - local-emergency
       - string:
           name: HEADING
           description: The title of the banner


### PR DESCRIPTION
This PR should be merged and deployed when we are ready to deploy the corresponding PR in Static: https://github.com/alphagov/static/pull/1001

The front end redesign of the emergency banner changes the campaign_class to use semantic class names instead of class names reflecting the colours. 

Change the deploy emergency banner Jenkins job's parameters to reflect these changes.

Related [Trello card](https://trello.com/c/3pKoTsFM/49-review-the-frontend-code-and-markup)