### PR TITLE
Change '~' to 'stop' as the former is being deprecated..

### DIFF
--- a/modules/govuk/manifests/node/s_base.pp
+++ b/modules/govuk/manifests/node/s_base.pp
@@ -57,7 +57,7 @@ class govuk::node::s_base (
   }
 
   rsyslog::snippet { 'aaa-disable-remote-audispd':
-    content => ':programname, isequal, "audispd"  ~',
+    content => ':programname, isequal, "audispd"  stop',
   }
 
   rsyslog::snippet { 'aaa-local3-for-govuk-apps':

--- a/modules/govuk/templates/etc/rsyslog.d/local3-for-govuk-apps.conf.erb
+++ b/modules/govuk/templates/etc/rsyslog.d/local3-for-govuk-apps.conf.erb
@@ -3,5 +3,5 @@ $ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
 $template local3_program,"/var/log/govuk/%programname%.log"
 
 :syslogfacility-text, isequal, "local3" ?local3_program
-& ~
-# Adding & ~ makes sure log message is not passed to any further rule
+& stop
+# Adding '& stop' makes sure log message is not passed to any further rule


### PR DESCRIPTION
 in newer versions of ryslog and there are complaints in the logs about it.