### PR TITLE
Disable Rails 5 DB environment check

### DIFF
--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -109,6 +109,7 @@ def buildProject(options = [:]) {
     }
 
     stage("Configure environment") {
+      setEnvar("DISABLE_DATABASE_ENVIRONMENT_CHECK", "1")
       setEnvar("RAILS_ENV", "test")
       setEnvar("RACK_ENV", "test")
       setEnvar("DISPLAY", ":99")


### PR DESCRIPTION
In ActiveRecord on Rails 5 before being able to drop databases you need
to run `rake db:environment:set` otherwise you can't run `db:drop` etc.

Unfortunately the `db:environment:set` command requires the DB to exist
which is a pain on CI. Setting this environment variable removes the
need.