### PR TITLE
Exported resources should not require class

### DIFF
--- a/modules/govuk_docker/manifests/init.pp
+++ b/modules/govuk_docker/manifests/init.pp
@@ -32,7 +32,6 @@ class govuk_docker (
     check_command       => 'check_nrpe!check_proc_running!dockerd',
     service_description => 'dockerd running',
     host_name           => $::fqdn,
-    require             => Class['docker'],
   }
 
 }


### PR DESCRIPTION
This is exporting a resource to a class that does not include the docker class, so we should remove the require.