### PR TITLE
Move the docker build step until after linting.

### DIFF
--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -128,12 +128,6 @@ def buildProject(options = [:]) {
       }
     }
 
-    if (hasDockerfile()) {
-      stage("Build Docker image") {
-        buildDockerImage(repoName, env.BRANCH_NAME)
-      }
-    }
-
     if (hasLint()) {
       stage("Lint Ruby") {
         rubyLinter("app lib spec test")
@@ -148,6 +142,12 @@ def buildProject(options = [:]) {
       }
     } else {
       echo "WARNING: You do not have SASS linting turned on. Please install govuk-lint and enable."
+    }
+
+    if (hasDockerfile()) {
+      stage("Build Docker image") {
+        buildDockerImage(repoName, env.BRANCH_NAME)
+      }
     }
 
     if (hasTestOptions && options.beforeTest) {

--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -34,6 +34,23 @@
  * }
  * ```
  *
+ * If you need to run tests using a command other than the default rake task
+ * you can do this by specifying the `overrideTestTask` option:
+ *
+ * ```groovy
+ * #!/usr/bin/env groovy
+ *
+ * node {
+ *   def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
+ *
+ *   govuk.buildProject(overrideTestTask: {
+ *     stage("Run custom tests") {
+ *       govuk.runRakeTask("super-special-tests")
+ *     }
+ *   })
+ * }
+ *```
+ *
  * @param options Map of build options:
  *        - sassLint Whether or not to run the SASS linter. Default: true
  *        - extraRubyVersions Ruby versions to run the tests against in


### PR DESCRIPTION
For most docker images the build step is quiet slow. It's a waste to
build the image if the entire build will fail anyway because of linting
errors.