### PR TITLE
First draft at managing apps as containers

### DIFF
--- a/hieradata/vagrant.yaml
+++ b/hieradata/vagrant.yaml
@@ -31,8 +31,17 @@ govuk::apps::stagecraft::celerycam::enabled: true
 
 # An example configuration for env vars
 govuk_containers::apps::release::envvars:
-  DATABASE: 'password'
-  BLUE: 'green'
+  - "GOVUK_ENV=production"
+  - "NODE_ENV=production"
+  - "RACK_ENV=production"
+  - "RAILS_ENV=production"
+  - "ERRBIT_ENVIRONMENT_NAME=%{hiera('govuk::deploy::config::errbit_environment_name')}"
+  - "GOVUK_APP_DOMAIN=%{hiera('app_domain')}"
+  - "GOVUK_ASSET_HOST=%{hiera('govuk::deploy::config::asset_root')}"
+  - "GOVUK_ASSET_ROOT=%{hiera('govuk::deploy::config::asset_root')}"
+  - "GOVUK_WEBSITE_ROOT=%{hiera('govuk::deploy::config::website_root')}"
+  - "DATABASE=password"
+  - "BLUE=green"
 
 govuk::deploy::aws_ses_smtp_host: 'email-smtp.aws.example.com'
 govuk::deploy::config::errbit_environment_name: 'vagrant'

--- a/hieradata/vagrant.yaml
+++ b/hieradata/vagrant.yaml
@@ -29,6 +29,11 @@ govuk::apps::stagecraft::worker::enabled: true
 govuk::apps::stagecraft::beat::enabled: true
 govuk::apps::stagecraft::celerycam::enabled: true
 
+# An example configuration for env vars
+govuk_containers::apps::release::envvars:
+  DATABASE: 'password'
+  BLUE: 'green'
+
 govuk::deploy::aws_ses_smtp_host: 'email-smtp.aws.example.com'
 govuk::deploy::config::errbit_environment_name: 'vagrant'
 govuk::deploy::config::asset_root: 'http://static.dev.gov.uk'

--- a/modules/govuk/manifests/node/s_docker_backend.pp
+++ b/modules/govuk/manifests/node/s_docker_backend.pp
@@ -4,4 +4,6 @@ class govuk::node::s_docker_backend {
 
   include ::govuk::node::s_base
 
+  include ::govuk_containers::apps::release
+
 }

--- a/modules/govuk_containers/manifests/app.pp
+++ b/modules/govuk_containers/manifests/app.pp
@@ -1,0 +1,73 @@
+# == Class: Govuk_containers::App
+#
+# A defined type which pulls and runs a container with the defined environment
+# variables.
+#
+# === Parameters:
+#
+# [*image*]
+#   The container image to run.
+#
+# [*image_tag*]
+#   The tag of the image to run.
+#
+# [*ports*]
+#   An array of local ports to map in the format of ['1234:1234'].
+#
+# [*envvars*]
+#   A hash of environment variables to start the container with.
+#
+# [*command*]
+#   A command to start the container with.
+#
+# [*extra_params*]
+#   An array of extra paramaters to set.
+#   Default is to always try restarting the app.
+#
+define govuk_containers::app (
+  $image,
+  $image_tag,
+  $port,
+  $envvars = {},
+  $command = undef,
+  $restart_attempts = 3,
+) {
+  require ::govuk_docker
+
+  validate_hash($envvars) # These are converted to an array in the upstream module
+  validate_re($restart_attempts, [ 'never', 'always', '^\d$' ])
+
+  $exposed_port = "${port}:${port}"
+
+  case $restart_attempts {
+    'never':  { $restart_arg = '--restart=no' }
+    'always': { $restart_arg = '--restart=always' }
+    /\d/:   { $restart_arg = "--restart=on-failure:${restart_attempts}" }
+    default: { $restart_arg = "--restart=on-failure:${restart_attempts}" }
+  }
+
+  # Add any extra parameters as an array
+  $extra_params = [
+    $restart_arg,
+  ]
+
+  ::docker::image { $image:
+    ensure    => 'present',
+    image_tag => $image_tag,
+  }
+
+  ::docker::run { $title:
+    image            => "${image}:${image_tag}",
+    ports            => [$exposed_port],
+    env              => $envvars,
+    command          => $command,
+    extra_parameters => $extra_params,
+    require          => Docker::Image[$image],
+  }
+
+  @@icinga::check { "${title}_process_${::hostname}":
+    check_command       => "check_nrpe!check_proc_running!${title}",
+    service_description => "${title} running",
+    host_name           => $::fqdn,
+  }
+}

--- a/modules/govuk_containers/manifests/app.pp
+++ b/modules/govuk_containers/manifests/app.pp
@@ -15,7 +15,7 @@
 #   An array of local ports to map in the format of ['1234:1234'].
 #
 # [*envvars*]
-#   A hash of environment variables to start the container with.
+#   An array of environment variables to start the container with.
 #
 # [*command*]
 #   A command to start the container with.
@@ -28,13 +28,13 @@ define govuk_containers::app (
   $image,
   $image_tag,
   $port,
-  $envvars = {},
+  $envvars = [],
   $command = undef,
   $restart_attempts = 3,
 ) {
   require ::govuk_docker
 
-  validate_hash($envvars) # These are converted to an array in the upstream module
+  validate_array($envvars)
   validate_re($restart_attempts, [ 'never', 'always', '^\d$' ])
 
   $exposed_port = "${port}:${port}"

--- a/modules/govuk_containers/manifests/apps/release.pp
+++ b/modules/govuk_containers/manifests/apps/release.pp
@@ -1,0 +1,19 @@
+# == Class: Govuk_containers::Apps::Release
+#
+# Runs the release app.
+#
+class govuk_containers::apps::release (
+  $image = 'govuk/release',
+  $image_tag = 'release_243',
+  $port = '3036',
+  $envvars = {},
+) {
+  validate_hash($envvars)
+
+  govuk_containers::app { 'release':
+    image     => $image,
+    image_tag => $image_tag,
+    port      => $port,
+    envvars   => $envvars,
+  }
+}

--- a/modules/govuk_containers/manifests/apps/release.pp
+++ b/modules/govuk_containers/manifests/apps/release.pp
@@ -6,9 +6,9 @@ class govuk_containers::apps::release (
   $image = 'govuk/release',
   $image_tag = 'release_243',
   $port = '3036',
-  $envvars = {},
+  $envvars = [],
 ) {
-  validate_hash($envvars)
+  validate_array($envvars)
 
   govuk_containers::app { 'release':
     image     => $image,

--- a/modules/govuk_containers/spec/defines/govuk_containers__app__spec.rb
+++ b/modules/govuk_containers/spec/defines/govuk_containers__app__spec.rb
@@ -1,0 +1,88 @@
+require_relative '../../../../spec_helper'
+
+describe 'govuk_containers::app', :type => :define do
+  let(:title) { 'bella' }
+
+  let :default_params do
+    {
+      :image => 'cat',
+      :image_tag => 'v1',
+      :port => '1234',
+    }
+  end
+
+  context 'with minimum params' do
+    let(:params) { default_params }
+
+    it do
+      is_expected.to contain_docker__image('cat').with(
+        'ensure' => 'present',
+        'image_tag' => 'v1',
+      )
+      is_expected.to contain_docker__run('bella').with(
+        'image' => 'cat:v1',
+        'ports' => '1234:1234',
+        'extra_parameters' => '--restart=on-failure:3',
+      )
+    end
+  end
+
+  context 'setting environment variables' do
+    let(:params) do
+      {
+        :envvars => { 'cheese' => 'milk', 'wheat' => 'bread' },
+      }.merge(default_params)
+    end
+
+    it do
+      is_expected.to contain_docker__run('bella').with(
+        'image' => 'cat:v1',
+        'ports' => '1234:1234',
+        'env' => {"cheese"=>"milk", "wheat"=>"bread"},
+        'extra_parameters' => '--restart=on-failure:3',
+      )
+    end
+  end
+
+  context 'setting restart_attempts to "never"' do
+    let(:params) do
+      {
+        :restart_attempts => 'never',
+      }.merge(default_params)
+    end
+
+    it do
+      is_expected.to contain_docker__run('bella').with(
+        'image' => 'cat:v1',
+        'ports' => '1234:1234',
+        'extra_parameters' => '--restart=no',
+      )
+    end
+  end
+
+  context 'setting restart_attempts to "always"' do
+    let(:params) do
+      {
+        :restart_attempts => 'always',
+      }.merge(default_params)
+    end
+
+    it do
+      is_expected.to contain_docker__run('bella').with(
+        'image' => 'cat:v1',
+        'ports' => '1234:1234',
+        'extra_parameters' => '--restart=always',
+      )
+    end
+  end
+
+  context 'setting restart_attempts to something other than "always", "never" or a number' do
+    let(:params) do
+      {
+        :restart_attempts => 'foo',
+      }.merge(default_params)
+    end
+
+    it { is_expected.to raise_error(Puppet::Error, /validate_re/) }
+  end
+end

--- a/modules/govuk_containers/spec/defines/govuk_containers__app__spec.rb
+++ b/modules/govuk_containers/spec/defines/govuk_containers__app__spec.rb
@@ -30,7 +30,7 @@ describe 'govuk_containers::app', :type => :define do
   context 'setting environment variables' do
     let(:params) do
       {
-        :envvars => { 'cheese' => 'milk', 'wheat' => 'bread' },
+        :envvars => [ 'cheese=milk', 'wheat=bread' ],
       }.merge(default_params)
     end
 
@@ -38,7 +38,7 @@ describe 'govuk_containers::app', :type => :define do
       is_expected.to contain_docker__run('bella').with(
         'image' => 'cat:v1',
         'ports' => '1234:1234',
-        'env' => {"cheese"=>"milk", "wheat"=>"bread"},
+        'env' => [ 'cheese=milk', 'wheat=bread' ],
         'extra_parameters' => '--restart=on-failure:3',
       )
     end


### PR DESCRIPTION
This commit adds a defined type to pull and run a specified container.

It's function is meant to be the beginning of a construction similar to the govuk::app class, but does the minimum neccessary to pull an image with the given tag, and run that image.

It allows adding environment variables using encrypted hieradata. These will be placed in an init upstart script for the time-being before we use proper secret management in docker.

We're using the [release](https://hub.docker.com/r/govuk/release/) app for testing our processes.