### PR TITLE
Add `fast_finish` to our travis options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ script:
   - bundle exec rake lint
   - bundle exec rake all_but_lint
 matrix:
+  fast_finish: true
   allow_failures:
     - env: PUPPET_RSPEC_STRICT_VARIABLES=1
     - env: PUPPET_RSPEC_FUTURE_PARSER=1


### PR DESCRIPTION
From https://blog.travis-ci.com/2013-11-27-fast-finishing-builds/

"Travis CI will mark your build as finished as soon as one of two
conditions are met: The only remaining jobs are allowed to fail, or a
job has already failed. "

This will speed our builds up in a number of cases as we have multiple
options that are allowed to fail.