### PR TITLE
Fix training environment domain name

### DIFF
--- a/hieradata/class/training.yaml
+++ b/hieradata/class/training.yaml
@@ -1,3 +1,17 @@
+---
+
+app_domain: 'training.publishing.service.gov.uk'
+
+govuk::deploy::config::asset_root: 'https://assets-origin.training.publishing.service.gov.uk'
+govuk::deploy::config::website_root: 'https://www.training.publishing.service.gov.uk'
+
+govuk::apps::authenticating_proxy::govuk_upstream_uri: 'http://government-frontend.training.publishing.service.gov.uk'
+govuk::apps::government_frontend::enable_running_in_draft_mode::content_store: 'http://draft-content-store.training.publishing.service.gov.uk'
+govuk::apps::manuals_frontend::enable_running_in_draft_mode::content_store: 'http://draft-content-store.training.publishing.service.gov.uk'
+govuk::apps::publishing_api::content_store: 'http://content-store.training.publishing.service.gov.uk'
+govuk::apps::publishing_api::draft_content_store: 'http://draft-content-store.training.publishing.service.gov.uk'
+govuk::apps::specialist_frontend::enable_running_in_draft_mode::content_store: 'http://draft-content-store.training.publishing.service.gov.uk'
+
 users::usernames:
   - alecgibson
   - alexmuller
@@ -66,5 +80,3 @@ users::usernames:
   - tijmenbrommet
   - timblair
   - tomgladhill
-
-

--- a/training-vm/training_user_data.txt
+++ b/training-vm/training_user_data.txt
@@ -4,9 +4,9 @@ echo "[$(date '+%H:%M:%S %d-%m-%Y')] START POST-INSTALL"
 # Source DISTRIB_ env vars
 . /etc/lsb-release
 
-sudo sed -i '1 i\127.0.0.1 training.dev.gov.uk training' /etc/hosts
+sudo sed -i '1 i\127.0.0.1 training.publishing.service.gov.uk training' /etc/hosts
 sudo hostname training
-sudo domainname dev.gov.uk
+sudo domainname publishing.service.gov.uk
 sudo echo "training" > /etc/hostname
 
 # Know when this box was created


### PR DESCRIPTION
This commit changes the training environment domain name to `training.publishing.service.gov.uk` to match the DNS entries.