### PR TITLE
Enable email notifications for the Jenkins Smokey job

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/smokey.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/smokey.yaml.erb
@@ -30,6 +30,9 @@
           auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN']%>
           build-server-url: <%= @slack_build_server_url %>
           room: <%= @slack_room %>
+      - email:
+          recipients: govuk-ci-notifications@digital.cabinet-office.gov.uk
+          send-to-individuals: true
     builders:
         - shell: |
             set +x


### PR DESCRIPTION
I'd like to know as soon as possible if a change we've deployed means
that an associated Smokey test fails.

This is the same as the change I made for the Deploy App Jenkins job in
4cc88440d4fc49d1f495c813d1ad5fa95c80800b.

Prior to this change the only notification mechanism was Slack. This was
disabled in integration (the Slack auth token is set to `disabled for
environment` in /etc/jenkins_jobs/jobs/smokey.yaml on CI) meaning that
we'd only see failures by looking at the Jenkins interface. Although it
was enabled in staging and production, the Slack notification only
includes a link to the failure which I'm not able to view because I
don't have access to those Jenkins instances.

I've copied the email configuration from the deploy_app.yaml.erb file as
I know we've received email notifications from that job in Jenkins.

I haven't added a test for this change as we don't appear to have added
tests for similar changes in the past.