### PR TITLE
Obey flags when deleting old Elasticsearch indexes during Dev VM replication

### DIFF
--- a/development-vm/replication/replicate-data-local.sh
+++ b/development-vm/replication/replicate-data-local.sh
@@ -38,8 +38,10 @@ fi
 
 $(dirname $0)/sync-elasticsearch.sh "$@" api-elasticsearch-1.api.integration
 
-status "Deleting old elasticsearch indexes"
-ruby $(dirname $0)/delete_closed_indices.rb
+if ! $SKIP_ELASTIC && ! $DRY_RUN; then
+  status "Deleting old elasticsearch indexes"
+  ruby $(dirname $0)/delete_closed_indices.rb
+fi
 
 if ! $DRY_RUN; then
   status "Munging Signon db tokens for dev VM"


### PR DESCRIPTION
We shouldn't attempt to delete old Elasticsearch indexes if we are performing a replication dry run or have signalled we want to skip Elasticsearch replication.