### PR TITLE
Add global environment variables

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -230,6 +230,17 @@ filebeat::prospectors:
     fields:
       application: 'rkhunter'
 
+govuk_containers::app::config::global_envvars:
+  - "GOVUK_ENV=production"
+  - "NODE_ENV=production"
+  - "RACK_ENV=production"
+  - "RAILS_ENV=production"
+  - "ERRBIT_ENVIRONMENT_NAME=%{hiera('govuk::deploy::config::errbit_environment_name')}"
+  - "GOVUK_APP_DOMAIN=%{hiera('app_domain')}"
+  - "GOVUK_ASSET_HOST=%{hiera('govuk::deploy::config::asset_root')}"
+  - "GOVUK_ASSET_ROOT=%{hiera('govuk::deploy::config::asset_root')}"
+  - "GOVUK_WEBSITE_ROOT=%{hiera('govuk::deploy::config::website_root')}"
+
 govuk::apps::asset_manager::mongodb_nodes:
   - 'mongo-1.backend'
   - 'mongo-2.backend'

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -198,6 +198,17 @@ govuk_lvm::no_op: true
 
 govuk_mount::no_op: true
 
+govuk_containers::app::config::global_envvars:
+  - "GOVUK_ENV=development"
+  - "NODE_ENV=development"
+  - "RACK_ENV=development"
+  - "RAILS_ENV=development"
+  - "ERRBIT_ENVIRONMENT_NAME=%{hiera('govuk::deploy::config::errbit_environment_name')}"
+  - "GOVUK_APP_DOMAIN=%{hiera('app_domain')}"
+  - "GOVUK_ASSET_HOST=%{hiera('govuk::deploy::config::asset_root')}"
+  - "GOVUK_ASSET_ROOT=%{hiera('govuk::deploy::config::asset_root')}"
+  - "GOVUK_WEBSITE_ROOT=%{hiera('govuk::deploy::config::website_root')}"
+
 govuk_elasticsearch::version: '1.7.5'
 
 govuk_logging::logstream::disabled: true

--- a/hieradata/vagrant.yaml
+++ b/hieradata/vagrant.yaml
@@ -29,20 +29,6 @@ govuk::apps::stagecraft::worker::enabled: true
 govuk::apps::stagecraft::beat::enabled: true
 govuk::apps::stagecraft::celerycam::enabled: true
 
-# An example configuration for env vars
-govuk_containers::apps::release::envvars:
-  - "GOVUK_ENV=production"
-  - "NODE_ENV=production"
-  - "RACK_ENV=production"
-  - "RAILS_ENV=production"
-  - "ERRBIT_ENVIRONMENT_NAME=%{hiera('govuk::deploy::config::errbit_environment_name')}"
-  - "GOVUK_APP_DOMAIN=%{hiera('app_domain')}"
-  - "GOVUK_ASSET_HOST=%{hiera('govuk::deploy::config::asset_root')}"
-  - "GOVUK_ASSET_ROOT=%{hiera('govuk::deploy::config::asset_root')}"
-  - "GOVUK_WEBSITE_ROOT=%{hiera('govuk::deploy::config::website_root')}"
-  - "DATABASE=password"
-  - "BLUE=green"
-
 govuk_containers::frontend::haproxy::backend_mappings:
   - "release.%{hiera('app_domain')}": "release"
 govuk_containers::frontend::haproxy::wildcard_publishing_certificate: "%{hiera('wildcard_publishing_certificate')}"

--- a/modules/govuk_containers/manifests/app/config.pp
+++ b/modules/govuk_containers/manifests/app/config.pp
@@ -1,0 +1,15 @@
+# == Class: Govuk_containers::App::Config
+#
+# Basic configuration for apps running in containers
+#
+class govuk_containers::app::config (
+  $global_envvars = [],
+  $global_env_file = '/etc/global.env',
+) {
+
+  file { $global_env_file:
+    ensure  => 'present',
+    content => template('govuk_containers/global.env.erb'),
+  }
+
+}

--- a/modules/govuk_containers/spec/classes/govuk_containers__app__config_spec.rb
+++ b/modules/govuk_containers/spec/classes/govuk_containers__app__config_spec.rb
@@ -1,0 +1,15 @@
+require_relative '../../../../spec_helper'
+
+describe 'govuk_containers::app::config', :type => :class do
+  context "default paramaters" do
+    let(:params) do
+      {
+        :global_envvars => [ 'MICHAEL=JACKSON', 'JOHNNY=CASH' ],
+        :global_env_file => '/the/file/goes/here',
+      }
+      it do
+        is_expected.to contain_file('/the/file/goes/here').with_content(/# Managed by Puppet\nMICHAEL=JACKSON\nJOHNNY=CASH/)
+      end
+    end
+  end
+end

--- a/modules/govuk_containers/spec/defines/govuk_containers__app__spec.rb
+++ b/modules/govuk_containers/spec/defines/govuk_containers__app__spec.rb
@@ -8,6 +8,7 @@ describe 'govuk_containers::app', :type => :define do
       :image => 'cat',
       :image_tag => 'v1',
       :port => '1234',
+      :global_env_file => '/etc/global.env',
     }
   end
 
@@ -22,6 +23,7 @@ describe 'govuk_containers::app', :type => :define do
       is_expected.to contain_docker__run('bella').with(
         'image' => 'cat:v1',
         'ports' => '1234:1234',
+        'env_file' => '/etc/global.env',
         'extra_parameters' => '--restart=on-failure:3',
       )
     end
@@ -38,6 +40,7 @@ describe 'govuk_containers::app', :type => :define do
       is_expected.to contain_docker__run('bella').with(
         'image' => 'cat:v1',
         'ports' => '1234:1234',
+        'env_file' => '/etc/global.env',
         'env' => [ 'cheese=milk', 'wheat=bread' ],
         'extra_parameters' => '--restart=on-failure:3',
       )
@@ -55,6 +58,7 @@ describe 'govuk_containers::app', :type => :define do
       is_expected.to contain_docker__run('bella').with(
         'image' => 'cat:v1',
         'ports' => '1234:1234',
+        'env_file' => '/etc/global.env',
         'extra_parameters' => '--restart=no',
       )
     end
@@ -71,6 +75,7 @@ describe 'govuk_containers::app', :type => :define do
       is_expected.to contain_docker__run('bella').with(
         'image' => 'cat:v1',
         'ports' => '1234:1234',
+        'env_file' => '/etc/global.env',
         'extra_parameters' => '--restart=always',
       )
     end

--- a/modules/govuk_containers/templates/global.env.erb
+++ b/modules/govuk_containers/templates/global.env.erb
@@ -1,0 +1,4 @@
+# Managed by Puppet
+<% @global_envvars.each do |env| %>
+<%= env -%>
+<% end %>


### PR DESCRIPTION
This commit creates an "env_file" which is used by each container that is started using the govuk_containers::app defined type. It separates the management of app specific env vars and global env vars rather than trying to merge arrays of both into the same variable.

On testing they seem to correctly get loaded (using `docker inspect` to check):

  ```
  vagrant@docker-backend-1:~$ sudo docker inspect release |grep -A10 Env
            "Env": [
                "GOVUK_ENV=development",
                "NODE_ENV=development",
                "RACK_ENV=development",
                "RAILS_ENV=development",
                "ERRBIT_ENVIRONMENT_NAME=vagrant",
                "GOVUK_APP_DOMAIN=dev.gov.uk",
                "GOVUK_ASSET_HOST=http://static.dev.gov.uk",
                "GOVUK_ASSET_ROOT=http://static.dev.gov.uk",
                "GOVUK_WEBSITE_ROOT=http://www.dev.gov.uk",
                "FOO=BAR",
  ```