### PR TITLE
Point /var/apps to correct app directory in development VM

### DIFF
--- a/modules/govuk/manifests/app.pp
+++ b/modules/govuk/manifests/app.pp
@@ -185,7 +185,7 @@
 # match the application's config.assets.prefix (which defaults to 'assets').
 # Should only be set if the application is being deployed to the GOV.UK frontend.
 # The value is where the pages served by the application can be found on gov.uk.
-# e.g. The whitehall app has an asset_pipeline_prefix of `government`, that means 
+# e.g. The whitehall app has an asset_pipeline_prefix of `government`, that means
 # all of the whitehall pages can be found at `gov.uk/government`.  If the value
 # is set for an app deployed to a backend server, the assets (css, images etc)
 # are copied to the wrong place and the app doesn't render correctly.
@@ -211,6 +211,14 @@
 # [*proxy_http_version_1_1_enabled*]
 #   Boolean, whether to enable HTTP/1.1 for proxying from the Nginx vhost
 #   to the app server.
+#
+#
+# [*repo_name*]
+# the name of the repository that contains this app, if it is different from
+# $title
+#
+# This parameter is used to ensure symlinks are created correctly if the app
+# name and repo name don't match
 #
 define govuk::app (
   $app_type,
@@ -241,6 +249,7 @@ define govuk::app (
   $depends_on_nfs = false,
   $read_timeout = 15,
   $proxy_http_version_1_1_enabled = false,
+  $repo_name = undef,
 ) {
 
   if ! ($app_type in ['procfile', 'rack', 'bare']) {
@@ -274,6 +283,7 @@ define govuk::app (
   govuk::app::package { $title:
     ensure     => $ensure,
     vhost_full => $vhost_full,
+    repo_name  => $repo_name,
   }
 
   govuk::app::config { $title:

--- a/modules/govuk/manifests/app/package.pp
+++ b/modules/govuk/manifests/app/package.pp
@@ -1,6 +1,7 @@
 # FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
 define govuk::app::package (
   $vhost_full,
+  $repo_name = $title,
   $ensure = 'present',
 ) {
   validate_re($ensure, '^(present|absent)$', 'Invalid ensure value')
@@ -57,7 +58,7 @@ define govuk::app::package (
   } else {
     file { "/var/apps/${title}":
       ensure => $ensure_link,
-      target => "/var/govuk/${title}";
+      target => "/var/govuk/${repo_name}";
     }
   }
 

--- a/modules/govuk/manifests/apps/contacts.pp
+++ b/modules/govuk/manifests/apps/contacts.pp
@@ -101,6 +101,7 @@ class govuk::apps::contacts(
       asset_pipeline        => true,
       asset_pipeline_prefix => 'contacts-assets',
       vhost_aliases         => $extra_aliases,
+      repo_name             => 'contacts-admin',
       nginx_extra_config    => '
         # Don\'t ask for basic auth on SSO API pages so we can sync
         # permissions.

--- a/modules/govuk/manifests/apps/contentapi.pp
+++ b/modules/govuk/manifests/apps/contentapi.pp
@@ -68,6 +68,7 @@ class govuk::apps::contentapi (
     nginx_extra_config     => 'proxy_set_header API-PREFIX $http_api_prefix;',
     nagios_memory_warning  => $nagios_memory_warning,
     nagios_memory_critical => $nagios_memory_critical,
+    repo_name              => 'govuk_content_api',
   }
 
   if $mongodb_nodes != undef {

--- a/modules/govuk/manifests/apps/designprinciples.pp
+++ b/modules/govuk/manifests/apps/designprinciples.pp
@@ -23,6 +23,7 @@ class govuk::apps::designprinciples(
     log_format_is_json    => true,
     asset_pipeline        => true,
     asset_pipeline_prefix => 'designprinciples',
+    repo_name             => 'design-principles',
   }
 
   govuk::app::envvar { "${title}-PUBLISHING_API_BEARER_TOKEN":

--- a/modules/govuk/manifests/apps/licencefinder.pp
+++ b/modules/govuk/manifests/apps/licencefinder.pp
@@ -43,6 +43,7 @@ class govuk::apps::licencefinder(
     log_format_is_json    => true,
     asset_pipeline        => true,
     asset_pipeline_prefix => 'licencefinder',
+    repo_name             => 'licence-finder',
   }
 
   if $errbit_api_key {

--- a/modules/govuk/manifests/apps/need_api.pp
+++ b/modules/govuk/manifests/apps/need_api.pp
@@ -59,6 +59,7 @@ class govuk::apps::need_api(
     vhost_ssl_only     => true,
     health_check_path  => '/healthcheck',
     log_format_is_json => true,
+    repo_name          => 'govuk_need_api',
   }
 
   govuk_logging::logstream { 'need-api-org-import-json-log':

--- a/modules/govuk/manifests/apps/router/enable_running_in_draft_mode.pp
+++ b/modules/govuk/manifests/apps/router/enable_running_in_draft_mode.pp
@@ -47,5 +47,6 @@ class govuk::apps::router::enable_running_in_draft_mode(
     port               => $port,
     enable_nginx_vhost => $enable_nginx_vhost,
     vhost_aliases      => $vhost_aliases,
+    repo_name          => 'router',
   }
 }

--- a/modules/govuk/manifests/apps/router_api/enable_running_in_draft_mode.pp
+++ b/modules/govuk/manifests/apps/router_api/enable_running_in_draft_mode.pp
@@ -44,6 +44,7 @@ class govuk::apps::router_api::enable_running_in_draft_mode(
     health_check_path  => '/healthcheck',
     log_format_is_json => true,
     vhost              => $vhost,
+    repo_name          => 'router-api',
   }
 
   Govuk::App::Envvar {

--- a/modules/govuk/manifests/apps/smartanswers.pp
+++ b/modules/govuk/manifests/apps/smartanswers.pp
@@ -56,5 +56,6 @@ class govuk::apps::smartanswers(
     asset_pipeline_prefix  => 'smartanswers',
     nagios_memory_warning  => $nagios_memory_warning,
     nagios_memory_critical => $nagios_memory_critical,
+    repo_name              => 'smart-answers',
   }
 }

--- a/modules/govuk/manifests/apps/static/enable_running_in_draft_mode.pp
+++ b/modules/govuk/manifests/apps/static/enable_running_in_draft_mode.pp
@@ -62,6 +62,7 @@ class govuk::apps::static::enable_running_in_draft_mode(
     asset_pipeline        => true,
     asset_pipeline_prefix => $app_name,
     vhost                 => $vhost,
+    repo_name             => 'static',
   }
 
   Govuk::App::Envvar {

--- a/modules/govuk/spec/defines/govuk__app__package_spec.rb
+++ b/modules/govuk/spec/defines/govuk__app__package_spec.rb
@@ -15,6 +15,7 @@ describe 'govuk::app::package', :type => :define do
     let(:params) do
       {
         :vhost_full => 'giraffe.example.com',
+        :repo_name => 'elephant',
       }
     end
 


### PR DESCRIPTION
This commit adds a `repo_name` variable to `govuk::app` and `govuk::app::package`, to be used where the app name is different from its repository name. Setting `repo_name` ensures that symlinks from `/var/apps` to `/var/govuk` in the development VM point to the correct directory.