### PR TITLE
Add jenkins jobs to run search benchmarks

### DIFF
--- a/hieradata/class/integration/jenkins.yaml
+++ b/hieradata/class/integration/jenkins.yaml
@@ -20,6 +20,8 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::run_rake_task
   - govuk_jenkins::job::run_whitehall_data_migrations
   - govuk_jenkins::job::sanitize_publishing_api_data
+  - govuk_jenkins::job::search_benchmark
+  - govuk_jenkins::job::search_test_spelling_suggestions
   - govuk_jenkins::job::signon_cron_rake_tasks
   - govuk_jenkins::job::smokey
   - govuk_jenkins::job::smokey_deploy

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -721,6 +721,12 @@ govuk_jenkins::config::github_api_uri: "%{hiera('govuk_jenkins::config::github_w
 govuk_jenkins::config::github_web_uri: "https://%{hiera('govuk_jenkins::github_enterprise_cert::github_enterprise_hostname')}"
 govuk_jenkins::job::deploy_app::app_domain: "%{hiera('app_domain')}"
 
+govuk_jenkins::job::search_benchmark::auth_username: "%{hiera('http_username')}"
+govuk_jenkins::job::search_benchmark::auth_password: "%{hiera('http_password')}"
+
+govuk_jenkins::job::search_test_spelling_suggestions::auth_username: "%{hiera('http_username')}"
+govuk_jenkins::job::search_test_spelling_suggestions::auth_password: "%{hiera('http_password')}"
+
 govuk_jenkins::job::smokey::auth_username: "%{hiera('http_username')}"
 govuk_jenkins::job::smokey::auth_password: "%{hiera('http_password')}"
 govuk_jenkins::job::smokey::smokey_bearer_token: "%{hiera('smokey_bearer_token')}"

--- a/modules/govuk_jenkins/manifests/job/search_benchmark.pp
+++ b/modules/govuk_jenkins/manifests/job/search_benchmark.pp
@@ -5,7 +5,8 @@
 class govuk_jenkins::job::search_benchmark (
   $app_domain = hiera('app_domain'),
   $auth_username = undef,
-  $auth_password = undef
+  $auth_password = undef,
+  $rate_limit_token = undef
 ) {
 
   $test_type = 'results'

--- a/modules/govuk_jenkins/manifests/job/search_benchmark.pp
+++ b/modules/govuk_jenkins/manifests/job/search_benchmark.pp
@@ -1,0 +1,30 @@
+# == Class: govuk_jenkins::job::search_benchmark
+#
+# Create a file on disk that can be parsed by jenkins-job-builder
+#
+class govuk_jenkins::job::search_benchmark (
+  $app_domain = hiera('app_domain'),
+  $auth_username = undef,
+  $auth_password = undef
+) {
+
+  $test_type = 'results'
+  $job_name = 'search_benchmark'
+  $service_description = 'Benchmark search queries from https://docs.google.com/spreadsheets/d/1JjSoy68vscNjrvQm8b9hHt0nbZgFxk8lrcTdqV08iHk'
+  $job_url = "https://deploy.${app_domain}/job/search_benchmark/"
+  $cron_schedule = '30 4 * * *'
+
+  file { '/etc/jenkins_jobs/jobs/search_benchmark.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/benchmark_search.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+
+  @@icinga::passive_check { "${job_name}_${::hostname}":
+    service_description => $service_description,
+    host_name           => $::fqdn,
+    freshness_threshold => 104400,
+    action_url          => $job_url,
+    notes_url           => monitoring_docs_url(search-healthcheck),
+  }
+}

--- a/modules/govuk_jenkins/manifests/job/search_benchmark.pp
+++ b/modules/govuk_jenkins/manifests/job/search_benchmark.pp
@@ -14,6 +14,10 @@ class govuk_jenkins::job::search_benchmark (
   $job_url = "https://deploy.${app_domain}/job/search_benchmark/"
   $cron_schedule = '30 4 * * *'
 
+  $slack_team_domain = 'govuk'
+  $slack_room = 'search-team'
+  $slack_build_server_url = "https://deploy.${app_domain}/"
+
   file { '/etc/jenkins_jobs/jobs/search_benchmark.yaml':
     ensure  => present,
     content => template('govuk_jenkins/jobs/benchmark_search.yaml.erb'),

--- a/modules/govuk_jenkins/manifests/job/search_test_spelling_suggestions.pp
+++ b/modules/govuk_jenkins/manifests/job/search_test_spelling_suggestions.pp
@@ -14,6 +14,10 @@ class govuk_jenkins::job::search_test_spelling_suggestions (
   $job_url = "https://deploy.${app_domain}/job/search_test_spelling_suggestions/"
   $cron_schedule = '0 5 * * *'
 
+  $slack_team_domain = 'govuk'
+  $slack_room = 'search-team'
+  $slack_build_server_url = "https://deploy.${app_domain}/"
+
   file { '/etc/jenkins_jobs/jobs/search_test_spelling.yaml':
     ensure  => present,
     content => template('govuk_jenkins/jobs/benchmark_search.yaml.erb'),

--- a/modules/govuk_jenkins/manifests/job/search_test_spelling_suggestions.pp
+++ b/modules/govuk_jenkins/manifests/job/search_test_spelling_suggestions.pp
@@ -1,0 +1,30 @@
+# == Class: govuk_jenkins::job::search_test_spelling_suggestions
+#
+# Create a file on disk that can be parsed by jenkins-job-builder
+#
+class govuk_jenkins::job::search_test_spelling_suggestions (
+  $app_domain = hiera('app_domain'),
+  $auth_username = undef,
+  $auth_password = undef
+) {
+
+  $test_type = 'suggestions'
+  $job_name = 'search_test_spelling_suggestions'
+  $service_description = 'Check for spelling suggestions (see https://docs.google.com/spreadsheets/d/1JjSoy68vscNjrvQm8b9hHt0nbZgFxk8lrcTdqV08iHk)'
+  $job_url = "https://deploy.${app_domain}/job/search_test_spelling_suggestions/"
+  $cron_schedule = '0 5 * * *'
+
+  file { '/etc/jenkins_jobs/jobs/search_test_spelling.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/benchmark_search.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+
+  @@icinga::passive_check { "${job_name}_${::hostname}":
+    service_description => $service_description,
+    host_name           => $::fqdn,
+    freshness_threshold => 104400,
+    action_url          => $job_url,
+    notes_url           => monitoring_docs_url(search-healthcheck),
+  }
+}

--- a/modules/govuk_jenkins/manifests/job/search_test_spelling_suggestions.pp
+++ b/modules/govuk_jenkins/manifests/job/search_test_spelling_suggestions.pp
@@ -5,7 +5,8 @@
 class govuk_jenkins::job::search_test_spelling_suggestions (
   $app_domain = hiera('app_domain'),
   $auth_username = undef,
-  $auth_password = undef
+  $auth_password = undef,
+  $rate_limit_token = undef
 ) {
 
   $test_type = 'suggestions'

--- a/modules/govuk_jenkins/templates/jobs/benchmark_search.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/benchmark_search.yaml.erb
@@ -1,0 +1,53 @@
+---
+- scm:
+    name: rummager_<%= @job_name %>
+    scm:
+        - git:
+            url: git@github.com:alphagov/rummager.git
+            branches:
+              - master
+
+- job:
+    name: <%= @job_name %>
+    display-name: <%= @job_name %>
+    project-type: freestyle
+    description: |
+      <p><%= @service_description %></p>
+      <p>More information:</p>
+      <ul>
+        <li><a href='https://github.com/alphagov/rummager/blob/master/docs/health-check.md'>Healthcheck docs on Github</a></li>
+      </ul>
+    scm:
+        - rummager_<%= @job_name %>
+    builders:
+        - shell: |
+            bundle install --path "${HOME}/bundles/${JOB_NAME}";
+            bundle exec bin/health_check --download
+            bundle exec bin/health_check --json=https://www-origin.<%= @app_domain %>/api/search.json --type=<%= @test_type %> --auth="$AUTH_USERNAME:$AUTH_PASSWORD"
+    triggers:
+        - timed: '<%= @cron_schedule %>'
+    publishers:
+        - trigger-parameterized-builds:
+            - project: Success_Passive_Check
+              condition: 'SUCCESS'
+              predefined-parameters: |
+                  NSCA_CHECK_DESCRIPTION=<%= @service_description %>
+                  NSCA_OUTPUT=<%= @service_description %> success
+            - project: Failure_Passive_Check
+              condition: 'FAILED'
+              predefined-parameters: |
+                  NSCA_CHECK_DESCRIPTION=<%= @service_description %>
+                  NSCA_OUTPUT=<%= @service_description %> failed
+    properties:
+        - inject:
+            properties-content: |
+              AUTH_USERNAME=<%= @auth_username %>
+    wrappers:
+        - ansicolor:
+            colormap: xterm
+        - inject-passwords:
+            global: false
+            mask-password-params: true
+            job-passwords:
+                - name: AUTH_PASSWORD
+                  password: '<%= @auth_password %>'

--- a/modules/govuk_jenkins/templates/jobs/benchmark_search.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/benchmark_search.yaml.erb
@@ -38,10 +38,25 @@
               predefined-parameters: |
                   NSCA_CHECK_DESCRIPTION=<%= @service_description %>
                   NSCA_OUTPUT=<%= @service_description %> failed
+        - slack:
+            team-domain: <%= @slack_team_domain %>
+            auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN']%>
+            build-server-url: <%= @slack_build_server_url %>
+            room: <%= @slack_room %>
     properties:
         - inject:
             properties-content: |
               AUTH_USERNAME=<%= @auth_username %>
+        - slack:
+            notify-start: false
+            notify-success: true
+            notify-aborted: true
+            notify-notbuilt: true
+            notify-unstable: true
+            notify-failure: true
+            notify-backtonormal: false
+            notify-repeatedfailure: false
+            include-test-summary: false
     wrappers:
         - ansicolor:
             colormap: xterm

--- a/modules/govuk_jenkins/templates/jobs/benchmark_search.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/benchmark_search.yaml.erb
@@ -23,7 +23,7 @@
         - shell: |
             bundle install --path "${HOME}/bundles/${JOB_NAME}";
             bundle exec bin/health_check --download
-            bundle exec bin/health_check --json=https://www-origin.<%= @app_domain %>/api/search.json --type=<%= @test_type %> --auth="$AUTH_USERNAME:$AUTH_PASSWORD"
+            bundle exec bin/health_check --json=https://www-origin.<%= @app_domain %>/api/search.json --type=<%= @test_type %> --auth="$AUTH_USERNAME:$AUTH_PASSWORD" --rate_limit_token=$RATE_LIMIT_TOKEN
     triggers:
         - timed: '<%= @cron_schedule %>'
     publishers:
@@ -66,3 +66,5 @@
             job-passwords:
                 - name: AUTH_PASSWORD
                   password: '<%= @auth_password %>'
+                - name: RATE_LIMIT_TOKEN
+                  password: '<%= @rate_limit_token %>'


### PR DESCRIPTION
These tests run the rummager healthcheck, which benchmarks search
against a set of judgements. One job checks for the presence/absense of
particular documents in query results, and the other tests that the "did
you mean" returns suitable suggestions for misspelled queries.

These used to run on the old CI server, which we replaced. These take a
long time to run, so we're using the deploy jenkins and running them
nightly instead of incorporating it into the rummager CI pipeline.

We'd like to test this on integration before rolling it out to production.

Before rolling it out to production we'll create an alert page in the developer docs for these jobs (at the moment the notes url is is a dead link).

Paired with @brenetic 
Trello: https://trello.com/c/TXeHcOnY/53-revive-the-search-healthcheck