### PR TITLE
Add Haproxy profile for Docker machines

### DIFF
--- a/hieradata/vagrant.yaml
+++ b/hieradata/vagrant.yaml
@@ -43,6 +43,11 @@ govuk_containers::apps::release::envvars:
   - "DATABASE=password"
   - "BLUE=green"
 
+govuk_containers::frontend::haproxy::backend_mappings:
+  - "release.%{hiera('app_domain')}": "release"
+govuk_containers::frontend::haproxy::wildcard_publishing_certificate: "%{hiera('wildcard_publishing_certificate')}"
+govuk_containers::frontend::haproxy::wildcard_publishing_key: "%{hiera('wildcard_publishing_key')}"
+
 govuk::deploy::aws_ses_smtp_host: 'email-smtp.aws.example.com'
 govuk::deploy::config::errbit_environment_name: 'vagrant'
 govuk::deploy::config::asset_root: 'http://static.dev.gov.uk'

--- a/modules/govuk/manifests/node/s_docker_backend.pp
+++ b/modules/govuk/manifests/node/s_docker_backend.pp
@@ -4,6 +4,7 @@ class govuk::node::s_docker_backend {
 
   include ::govuk::node::s_base
 
+  include ::govuk_containers::frontend::haproxy
   include ::govuk_containers::apps::release
 
 }

--- a/modules/govuk_containers/manifests/apps/release.pp
+++ b/modules/govuk_containers/manifests/apps/release.pp
@@ -16,4 +16,9 @@ class govuk_containers::apps::release (
     port      => $port,
     envvars   => $envvars,
   }
+
+  govuk_containers::balancermember { 'release':
+    port => $port,
+  }
+
 }

--- a/modules/govuk_containers/manifests/balancermember.pp
+++ b/modules/govuk_containers/manifests/balancermember.pp
@@ -1,0 +1,42 @@
+# == Define: Govuk_containers::Balancermember
+#
+# A defined type which creates a Haproxy backend with a balancermember
+# for the container application
+#
+# === Parameters:
+#
+# [*port*]
+#   Container listening port.
+#
+# [*ipaddress*]
+#   Container listening ipaddress
+#
+# [*options*]
+#   Haproxy backend server options
+#   Default: 'check'
+#
+define govuk_containers::balancermember (
+  $port,
+  $ipaddress = $::ipaddress_lo,
+  $options = 'check',
+) {
+
+  haproxy::backend { $name:
+    mode    => 'http',
+    options => {
+      'option'  => [
+        'httplog',
+      ],
+      'balance' => 'roundrobin',
+    },
+  }
+
+  haproxy::balancermember { $name:
+    listening_service => $name,
+    server_names      => $name,
+    ipaddresses       => $ipaddress,
+    ports             => $port,
+    options           => $options,
+  }
+
+}

--- a/modules/govuk_containers/manifests/frontend/haproxy.pp
+++ b/modules/govuk_containers/manifests/frontend/haproxy.pp
@@ -1,0 +1,67 @@
+# == Class: Govuk_containers::Frontend::Haproxy
+#
+# Manage Haproxy frontend for container boxes
+#
+# === Parameters:
+#
+# [*backend_mappings*]
+#   Array of hashes with domain to backend mapping information to configure Haproxy
+#   frontend. The backend needs to match the name of the relevant haproxy::backend
+#   resource in govuk_containers::balancermember: 
+#
+#   [ { "release.dev.gov.uk" => "release" } ]
+#
+# [*wildcard_publishing_certificate*]
+#   Wildcard publishing certificate
+#
+# [*wildcard_publishing_key*]
+#   Wildcard publishing key
+#
+class govuk_containers::frontend::haproxy (
+  $backend_mappings,
+  $wildcard_publishing_certificate,
+  $wildcard_publishing_key,
+) {
+
+  include ::haproxy
+
+  apt::pin { 'haproxy':
+    packages => 'haproxy',
+    release  => 'trusty-backports',
+    priority => 1001, # 1001 will cause a downgrade if necessary
+  }
+
+  file { [ '/etc/haproxy/ssl' ]:
+    ensure  => 'directory',
+    require => File['/etc/haproxy'],
+  }
+
+  file { '/etc/haproxy/ssl/publishing.pem':
+    ensure  => 'present',
+    owner   => haproxy,
+    mode    => '0640',
+    content => inline_template("${wildcard_publishing_certificate}${wildcard_publishing_key}"),
+    require => File['/etc/haproxy/ssl'],
+  }
+
+  haproxy::frontend { $::hostname:
+    mode    => 'http',
+    bind    => {
+      "${::ipaddress_eth0}:443" => ['ssl', 'crt', '/etc/haproxy/ssl/publishing.pem'],
+    },
+    options => {
+      'timeout client' => '30s',
+      'option'         => [
+        'httplog',
+        'accept-invalid-http-request',
+      ],
+      'use_backend'    => '%[req.hdr(host),lower,map(/etc/haproxy/domains-to-backends.map,bk_default)]',
+    },
+  }
+
+  haproxy::mapfile { 'domains-to-backends':
+    ensure   => 'present',
+    mappings => $backend_mappings,
+  }
+
+}

--- a/modules/govuk_containers/spec/classes/govuk_containers__frontend__haproxy.rb
+++ b/modules/govuk_containers/spec/classes/govuk_containers__frontend__haproxy.rb
@@ -1,0 +1,8 @@
+require_relative '../../../../spec_helper'
+
+describe 'govuk_containers::frontend::haproxy', :type => :class do
+
+  it { is_expected.to compile }
+
+  it { is_expected.to compile.with_all_deps }
+end


### PR DESCRIPTION
- Add classes and defines to manage Haproxy in the docker backend
profile.

- Override upstream global options that expects rsyslog listening
on eth0, and add rsyslog snippet to capture Haproxy logs