### PR TITLE
Add the default docker networking

### DIFF
--- a/modules/govuk_containers/manifests/app.pp
+++ b/modules/govuk_containers/manifests/app.pp
@@ -63,6 +63,7 @@ define govuk_containers::app (
   }
 
   ::docker::run { $title:
+    net              => 'host',
     image            => "${image}:${image_tag}",
     ports            => [$exposed_port],
     env              => $envvars,

--- a/modules/govuk_containers/spec/defines/govuk_containers__app__spec.rb
+++ b/modules/govuk_containers/spec/defines/govuk_containers__app__spec.rb
@@ -21,6 +21,7 @@ describe 'govuk_containers::app', :type => :define do
         'image_tag' => 'v1',
       )
       is_expected.to contain_docker__run('bella').with(
+        'net' => 'host',
         'image' => 'cat:v1',
         'ports' => '1234:1234',
         'env_file' => '/etc/global.env',
@@ -38,6 +39,7 @@ describe 'govuk_containers::app', :type => :define do
 
     it do
       is_expected.to contain_docker__run('bella').with(
+        'net' => 'host',
         'image' => 'cat:v1',
         'ports' => '1234:1234',
         'env_file' => '/etc/global.env',
@@ -56,6 +58,7 @@ describe 'govuk_containers::app', :type => :define do
 
     it do
       is_expected.to contain_docker__run('bella').with(
+        'net' => 'host',
         'image' => 'cat:v1',
         'ports' => '1234:1234',
         'env_file' => '/etc/global.env',
@@ -73,6 +76,7 @@ describe 'govuk_containers::app', :type => :define do
 
     it do
       is_expected.to contain_docker__run('bella').with(
+        'net' => 'host',
         'image' => 'cat:v1',
         'ports' => '1234:1234',
         'env_file' => '/etc/global.env',


### PR DESCRIPTION
Add the default networking for docker apps as "host" rather than the default "bridge" networking for now. This simplifies things as it uses the host for networking, so it can connect to other external hosts without additional configuration.