### PR TITLE
Remove dead script

### DIFF
--- a/modules/icinga/files/usr/lib/nagios/plugins/check_json_healthcheck.py
+++ b/modules/icinga/files/usr/lib/nagios/plugins/check_json_healthcheck.py
@@ -1,1 +1,0 @@
-check_json_healthcheck

--- a/modules/icinga/manifests/client/check_json_healthcheck.pp
+++ b/modules/icinga/manifests/client/check_json_healthcheck.pp
@@ -1,4 +1,4 @@
-# == Class: icinga::client::check_unicorn_workers
+# == Class: icinga::client::check_json_healthcheck
 #
 # Install a Nagios plugin that alerts when an app's health check reports a
 # problem


### PR DESCRIPTION
`modules/icinga/files/usr/lib/nagios/plugins/check_json_healthcheck` does exist and is in use so `modules/icinga/files/usr/lib/nagios/plugins/check_json_healthcheck.py` can be removed.