### PR TITLE
[DO NOT MERGE] Add docker to dev vm

### DIFF
--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -200,6 +200,12 @@ govuk_mount::no_op: true
 
 govuk::deploy::setup::gemstash_server: 'https://rubygems.org'
 
+govuk_containers::apps::release::running: false
+govuk_containers::apps::release::enable_haproxy: false
+
+govuk_containers::apps::release::envvars:
+  - "DATABASE_URL=mysql2://release:release@mysql.cluster/release_development"
+
 govuk_containers::app::config::global_envvars:
   - "GOVUK_ENV=development"
   - "NODE_ENV=development"

--- a/modules/govuk/manifests/node/s_development.pp
+++ b/modules/govuk/manifests/node/s_development.pp
@@ -12,6 +12,8 @@ class govuk::node::s_development (
 ) {
   include base
 
+  include ::govuk_containers::apps::release
+
   include assets::user
   include clamav::run_fake_virus_scan
   include golang

--- a/modules/govuk_containers/manifests/app.pp
+++ b/modules/govuk_containers/manifests/app.pp
@@ -28,6 +28,10 @@
 #   An array of extra paramaters to set.
 #   Default is to always try restarting the app.
 #
+# [*running*]
+#   Puppet will ensure the running state of the container.
+#   Default: true
+#
 define govuk_containers::app (
   $image,
   $image_tag,
@@ -36,12 +40,14 @@ define govuk_containers::app (
   $global_env_file = '/etc/global.env',
   $command = undef,
   $restart_attempts = 3,
+  $running = true,
 ) {
   require ::govuk_docker
   require ::govuk_containers::app::config
 
   validate_array($envvars)
   validate_re($restart_attempts, [ 'never', 'always', '^\d$' ])
+  validate_bool($running)
 
   $exposed_port = "${port}:${port}"
 
@@ -68,6 +74,7 @@ define govuk_containers::app (
     ports            => [$exposed_port],
     env              => $envvars,
     env_file         => $global_env_file,
+    running          => $running,
     command          => $command,
     extra_parameters => $extra_params,
     require          => Docker::Image[$image],

--- a/modules/govuk_containers/manifests/apps/release.pp
+++ b/modules/govuk_containers/manifests/apps/release.pp
@@ -7,6 +7,8 @@ class govuk_containers::apps::release (
   $image_tag = 'master',
   $port = '3036',
   $envvars = [],
+  $running = true,
+  $enable_haproxy = true,
 ) {
   validate_array($envvars)
 
@@ -15,10 +17,12 @@ class govuk_containers::apps::release (
     image_tag => $image_tag,
     port      => $port,
     envvars   => $envvars,
+    running   => $running,
   }
 
-  govuk_containers::balancermember { 'release':
-    port => $port,
+  if $enable_haproxy {
+    govuk_containers::balancermember { 'release':
+      port => $port,
+    }
   }
-
 }

--- a/modules/govuk_containers/spec/defines/govuk_containers__app__spec.rb
+++ b/modules/govuk_containers/spec/defines/govuk_containers__app__spec.rb
@@ -8,6 +8,7 @@ describe 'govuk_containers::app', :type => :define do
       :image => 'cat',
       :image_tag => 'v1',
       :port => '1234',
+      :running => true,
       :global_env_file => '/etc/global.env',
     }
   end
@@ -25,6 +26,7 @@ describe 'govuk_containers::app', :type => :define do
         'image' => 'cat:v1',
         'ports' => '1234:1234',
         'env_file' => '/etc/global.env',
+        'running' => true,
         'extra_parameters' => '--restart=on-failure:3',
       )
     end
@@ -44,6 +46,7 @@ describe 'govuk_containers::app', :type => :define do
         'ports' => '1234:1234',
         'env_file' => '/etc/global.env',
         'env' => [ 'cheese=milk', 'wheat=bread' ],
+        'running' => true,
         'extra_parameters' => '--restart=on-failure:3',
       )
     end
@@ -62,6 +65,7 @@ describe 'govuk_containers::app', :type => :define do
         'image' => 'cat:v1',
         'ports' => '1234:1234',
         'env_file' => '/etc/global.env',
+        'running' => true,
         'extra_parameters' => '--restart=no',
       )
     end
@@ -80,6 +84,7 @@ describe 'govuk_containers::app', :type => :define do
         'image' => 'cat:v1',
         'ports' => '1234:1234',
         'env_file' => '/etc/global.env',
+        'running' => true,
         'extra_parameters' => '--restart=always',
       )
     end


### PR DESCRIPTION
I've added a "do not merge" flag because I do not want to cause problems for any developers on the development-vm. This is mostly for myself so I can check the container with it's dependencies itself. Ideally I think I'd prefer to go down the road of [docker-compose](https://github.com/alphagov/release/compare/docker-compose) but I faffed a bit due to my lack of rails understanding.

This adds a couple of parameters so that the container and init file will be created on the development VM. This allows us to test locally with a database and the current nginx configuration as haproxy conflicts with nginx bindings.