### PR TITLE
Change image tag on containers

### DIFF
--- a/modules/govuk_containers/manifests/app.pp
+++ b/modules/govuk_containers/manifests/app.pp
@@ -74,9 +74,4 @@ define govuk_containers::app (
     subscribe        => Class[Govuk_containers::App::Config],
   }
 
-  @@icinga::check { "${title}_process_${::hostname}":
-    check_command       => "check_nrpe!check_proc_running!${title}",
-    service_description => "${title} running",
-    host_name           => $::fqdn,
-  }
 }

--- a/modules/govuk_containers/manifests/app.pp
+++ b/modules/govuk_containers/manifests/app.pp
@@ -9,7 +9,9 @@
 #   The container image to run.
 #
 # [*image_tag*]
-#   The tag of the image to run.
+#   The image tag to run. In our deployment this should not be specified
+#   as we will explicitly tag images. However, for local development this
+#   parameter can be set.
 #
 # [*ports*]
 #   An array of local ports to map in the format of ['1234:1234'].
@@ -30,8 +32,8 @@
 #
 define govuk_containers::app (
   $image,
-  $image_tag,
   $port,
+  $image_tag = 'current',
   $envvars = [],
   $global_env_file = '/etc/global.env',
   $command = undef,
@@ -57,11 +59,6 @@ define govuk_containers::app (
     $restart_arg,
   ]
 
-  ::docker::image { $image:
-    ensure    => 'present',
-    image_tag => $image_tag,
-  }
-
   ::docker::run { $title:
     net              => 'host',
     image            => "${image}:${image_tag}",
@@ -70,7 +67,6 @@ define govuk_containers::app (
     env_file         => $global_env_file,
     command          => $command,
     extra_parameters => $extra_params,
-    require          => Docker::Image[$image],
     subscribe        => Class[Govuk_containers::App::Config],
   }
 

--- a/modules/govuk_containers/manifests/apps/release.pp
+++ b/modules/govuk_containers/manifests/apps/release.pp
@@ -4,17 +4,15 @@
 #
 class govuk_containers::apps::release (
   $image = 'govuk/release',
-  $image_tag = 'master',
   $port = '3036',
   $envvars = [],
 ) {
   validate_array($envvars)
 
   govuk_containers::app { 'release':
-    image     => $image,
-    image_tag => $image_tag,
-    port      => $port,
-    envvars   => $envvars,
+    image   => $image,
+    port    => $port,
+    envvars => $envvars,
   }
 
   govuk_containers::balancermember { 'release':

--- a/modules/govuk_containers/spec/defines/govuk_containers__app__spec.rb
+++ b/modules/govuk_containers/spec/defines/govuk_containers__app__spec.rb
@@ -6,7 +6,6 @@ describe 'govuk_containers::app', :type => :define do
   let :default_params do
     {
       :image => 'cat',
-      :image_tag => 'v1',
       :port => '1234',
       :global_env_file => '/etc/global.env',
     }
@@ -16,13 +15,9 @@ describe 'govuk_containers::app', :type => :define do
     let(:params) { default_params }
 
     it do
-      is_expected.to contain_docker__image('cat').with(
-        'ensure' => 'present',
-        'image_tag' => 'v1',
-      )
       is_expected.to contain_docker__run('bella').with(
         'net' => 'host',
-        'image' => 'cat:v1',
+        'image' => 'cat:current',
         'ports' => '1234:1234',
         'env_file' => '/etc/global.env',
         'extra_parameters' => '--restart=on-failure:3',
@@ -40,7 +35,7 @@ describe 'govuk_containers::app', :type => :define do
     it do
       is_expected.to contain_docker__run('bella').with(
         'net' => 'host',
-        'image' => 'cat:v1',
+        'image' => 'cat:current',
         'ports' => '1234:1234',
         'env_file' => '/etc/global.env',
         'env' => [ 'cheese=milk', 'wheat=bread' ],
@@ -59,7 +54,7 @@ describe 'govuk_containers::app', :type => :define do
     it do
       is_expected.to contain_docker__run('bella').with(
         'net' => 'host',
-        'image' => 'cat:v1',
+        'image' => 'cat:current',
         'ports' => '1234:1234',
         'env_file' => '/etc/global.env',
         'extra_parameters' => '--restart=no',
@@ -77,7 +72,7 @@ describe 'govuk_containers::app', :type => :define do
     it do
       is_expected.to contain_docker__run('bella').with(
         'net' => 'host',
-        'image' => 'cat:v1',
+        'image' => 'cat:current',
         'ports' => '1234:1234',
         'env_file' => '/etc/global.env',
         'extra_parameters' => '--restart=always',


### PR DESCRIPTION
The Puppet code that used the ::docker::image and ::docker::run classes did not fit into our current deployment model as it meant Puppet managed which images were running, whereas we need a job which deploys a newer image and then restarts the service.

the ::docker::run defined type is useful as it creates an init script, so we're going to have a generic "release_env" tag, and then use `docker image tag` to point this specific tag to a specific image.