### PR TITLE
Allow deploy user to use docker image cmd

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -754,6 +754,8 @@ govuk_rabbitmq::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk_rbenv::all::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 govuk_sudo::sudo_conf:
+  deploy_docker_image:
+    content: 'deploy ALL=NOPASSWD:/usr/bin/docker image *'
   deploy_init_ctl:
     content: 'deploy ALL=NOPASSWD:/sbin/initctl'
   deploy_service_nginx:


### PR DESCRIPTION
For deployments the "deploy" user will need to use the following commands:

`docker image pull <image>`

`docker image tag <source> <target>`

We should allow all commands under `docker image` to allow us flexibility in our image deployment.