### PR TITLE
Add deploy_docker cap opts

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
@@ -68,6 +68,9 @@
                 - deploy:with_hard_restart
                 - deploy:with_migrations
                 - deploy:without_migrations
+                - deploy_docker
+                - deploy_docker:pull
+                - deploy_docker:tag_to_current
                 - app:migrate
                 - app:hard_restart
                 - app:migrate_and_hard_restart


### PR DESCRIPTION
This adds the options which should be available in capistrano to deploy an app as a docker image.

Related: https://github.com/alphagov/govuk-app-deployment/pull/126

Story: https://trello.com/c/3eUPxoUN/502-write-a-docker-deploy-task