### PR TITLE
Fix bugs in the govuk_containers specs

### DIFF
--- a/modules/govuk_containers/spec/classes/govuk_containers__frontend__haproxy.rb
+++ b/modules/govuk_containers/spec/classes/govuk_containers__frontend__haproxy.rb
@@ -1,8 +1,0 @@
-require_relative '../../../../spec_helper'
-
-describe 'govuk_containers::frontend::haproxy', :type => :class do
-
-  it { is_expected.to compile }
-
-  it { is_expected.to compile.with_all_deps }
-end

--- a/modules/govuk_containers/spec/classes/govuk_containers__frontend__haproxy_spec.rb
+++ b/modules/govuk_containers/spec/classes/govuk_containers__frontend__haproxy_spec.rb
@@ -1,0 +1,13 @@
+require_relative '../../../../spec_helper'
+
+describe 'govuk_containers::frontend::haproxy', :type => :class do
+  let(:pre_condition) {'include ::govuk_docker'}
+  let(:params) { {
+      :backend_mappings                => [ { "release.dev.gov.uk" => "release" } ],
+      :wildcard_publishing_certificate => "foo",
+      :wildcard_publishing_key         => "bar",
+    }}
+  it { is_expected.to compile }
+
+  it { is_expected.to compile.with_all_deps }
+end

--- a/modules/govuk_containers/spec/classes/govuk_containers__gemstash_spec.rb
+++ b/modules/govuk_containers/spec/classes/govuk_containers__gemstash_spec.rb
@@ -1,7 +1,7 @@
 require_relative '../../../../spec_helper'
 
 describe 'govuk_containers::gemstash', :type => :class do
-
+  let(:pre_condition) { 'include ::govuk_docker' }
   it { is_expected.to compile }
 
   it { is_expected.to compile.with_all_deps }


### PR DESCRIPTION
The govuk_containers module specs weren't running due to lack of the
'_spec' suffix. This updates the names so they are part of the test
suite and fixes a couple of bugs.