### PR TITLE
Make estimated disk space for the VM more realistic

### DIFF
--- a/development-vm/README.md
+++ b/development-vm/README.md
@@ -9,7 +9,7 @@ Follow the steps on this page to get your GDS development environment running wi
 
 It will take you roughly one day to do everything in this guide from start to finish. There are lots of things to download, and loads of installers need to do their thing.
 
-> You'll need up to 50GB of free space on your hard-drive to run the whole of GOV.UK.
+> You'll need up to 100GB of free space on your hard-drive to run the whole of GOV.UK.
 
 **Developing outside the VM**
 


### PR DESCRIPTION
Once you build the VM and replicate all the data you're eating closer
to 70GB for the VM and 30GB for the replication backup.  You can delete
the backup to reclaim that 30GB, but you still need to have that much
spare so that you can run another replication later when things get
out of date.

The VM is configured to grow up to 100GB so it's possible that you'll
actually need closer to 130GB free space on your host drive, but 100GB
seems more realistic.