### PR TITLE
Training environment update checkout-repos

### DIFF
--- a/training-vm/provisioner/checkout-repos.sh
+++ b/training-vm/provisioner/checkout-repos.sh
@@ -28,5 +28,10 @@ fi
 
 while read repo
 do
-  git clone $branch https://github.com/alphagov/$repo.git $repo
+  if [[ -z $(git ls-remote --heads https://github.com/alphagov/$repo.git $branch) ]]
+  then
+    git clone https://github.com/alphagov/$repo.git $repo
+  else
+    git clone $branch https://github.com/alphagov/$repo.git $repo
+  fi
 done < "${1:-/dev/stdin}"


### PR DESCRIPTION
When we are checking out the repositories during the Training
provisioning, use the master branch if the specified one does
not exist