### PR TITLE
Fix replication logic

### DIFF
--- a/development-vm/replication/replicate-data-local.sh
+++ b/development-vm/replication/replicate-data-local.sh
@@ -17,7 +17,7 @@ $(dirname $0)/sync-mongo.sh "$@" mongo-1.backend.integration
 $(dirname $0)/sync-mongo.sh "$@" api-mongo-1.api.integration
 $(dirname $0)/sync-mongo.sh "$@" router-backend-1.router.integration
 
-if ! $SKIP_MONGO && ! $DRY_RUN; then
+if ! ($SKIP_MONGO || $DRY_RUN); then
   status "Munging router backend hostnames for dev VM"
   mongo --quiet --eval 'db = db.getSiblingDB("router"); db.backends.find().forEach( function(b) { b.backend_url = b.backend_url.replace(".integration.publishing.service.gov.uk", ".dev.gov.uk").replace("https","http"); db.backends.save(b); } );'
   mongo --quiet --eval 'db = db.getSiblingDB("draft_router"); db.backends.find().forEach( function(b) { b.backend_url = b.backend_url.replace(".integration.publishing.service.gov.uk", ".dev.gov.uk").replace("https","http"); db.backends.save(b); } );'
@@ -38,7 +38,7 @@ fi
 
 $(dirname $0)/sync-elasticsearch.sh "$@" api-elasticsearch-1.api.integration
 
-if ! $SKIP_ELASTIC && ! $DRY_RUN; then
+if ! ($SKIP_ELASTIC || $DRY_RUN); then
   status "Deleting old elasticsearch indexes"
   ruby $(dirname $0)/delete_closed_indices.rb
 fi


### PR DESCRIPTION
The $DRY_RUN, $SKIP_MONGO and $SKIP_ELASTIC arguments of the dev vm replication script were not having the expected effect due to an error in the logic.

This commit fixes the logic to ensure that the mongo munging and elasticsearch index deletion are not run when they should be skipped or during a dry run.