### PR TITLE
Add container app monitoring

### DIFF
--- a/modules/govuk_containers/manifests/app.pp
+++ b/modules/govuk_containers/manifests/app.pp
@@ -8,13 +8,17 @@
 # [*image*]
 #   The container image to run.
 #
+# [*port*]
+#   An array of local ports to map in the format of ['1234:1234'].
+#
+# [*ensure*]
+#   Whether to ensure the frameworking for the app to exist.
+#   Default: present
+#
 # [*image_tag*]
 #   The image tag to run. In our deployment this should not be specified
 #   as we will explicitly tag images. However, for local development this
 #   parameter can be set.
-#
-# [*ports*]
-#   An array of local ports to map in the format of ['1234:1234'].
 #
 # [*envvars*]
 #   An array of environment variables to start the container with.
@@ -26,9 +30,16 @@
 # [*command*]
 #   A command to start the container with.
 #
-# [*extra_params*]
-#   An array of extra paramaters to set.
-#   Default is to always try restarting the app.
+# [*restart_attempts*]
+#   Amount of times to attempt restarting the container if it's detected
+#   as unhealthy.
+#   Default is to always try restarting the app a maximum of 3 times.
+#
+# [*healthcheck_path*]
+#   The path where the healthcheck for the application resides.
+#
+# [*json_healthcheck*]
+#   Whether the healthcheck is JSON format.
 #
 define govuk_containers::app (
   $image,

--- a/modules/govuk_containers/manifests/app.pp
+++ b/modules/govuk_containers/manifests/app.pp
@@ -33,6 +33,7 @@
 define govuk_containers::app (
   $image,
   $port,
+  $ensure = 'present',
   $image_tag = 'current',
   $envvars = [],
   $global_env_file = '/etc/global.env',
@@ -60,6 +61,7 @@ define govuk_containers::app (
   ]
 
   ::docker::run { $title:
+    ensure           => $ensure,
     net              => 'host',
     image            => "${image}:${image_tag}",
     ports            => [$exposed_port],

--- a/modules/govuk_containers/manifests/apps/release.pp
+++ b/modules/govuk_containers/manifests/apps/release.pp
@@ -6,13 +6,15 @@ class govuk_containers::apps::release (
   $image = 'govuk/release',
   $port = '3036',
   $envvars = [],
+  $healthcheck_path = '/',
 ) {
   validate_array($envvars)
 
   govuk_containers::app { 'release':
-    image   => $image,
-    port    => $port,
-    envvars => $envvars,
+    image            => $image,
+    port             => $port,
+    envvars          => $envvars,
+    healthcheck_path => $healthcheck_path,
   }
 
   govuk_containers::balancermember { 'release':

--- a/modules/govuk_containers/spec/defines/govuk_containers__app__spec.rb
+++ b/modules/govuk_containers/spec/defines/govuk_containers__app__spec.rb
@@ -89,4 +89,15 @@ describe 'govuk_containers::app', :type => :define do
 
     it { is_expected.to raise_error(Puppet::Error, /validate_re/) }
   end
+
+  context 'setting healthcheck_path and enable json_healthcheck includes check_json_healthcheck class' do
+    let(:params) do
+      {
+        :healthcheck_path => '/foo',
+        :json_healthcheck => true,
+      }.merge(default_params)
+    end
+
+    it { is_expected.to contain_class('icinga::client::check_json_healthcheck') }
+  end
 end


### PR DESCRIPTION
This adds the basic app healthcheck which is pinched off the current app healthchecks we use in Icinga.