### PR TITLE
Point lbs to container "release" in Integration

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -191,6 +191,9 @@ govuk::node::s_backend_lb::publishing_api_backend_servers:
   - 'backend-2.backend'
   - 'publishing-api-1.backend'
   - 'publishing-api-2.backend'
+govuk::node::s_backend_lb::docker_backend_servers:
+  - 'docker-backend-1.backend'
+  - 'docker-backend-2.backend'
 govuk::node::s_backend_lb::perfplat_public_app_domain: 'preview.performance.service.gov.uk'
 govuk::node::s_backup::offsite_backups: true
 govuk::node::s_bouncer::minimum_request_rate: 0.1

--- a/hieradata/vagrant.yaml
+++ b/hieradata/vagrant.yaml
@@ -80,6 +80,9 @@ govuk::node::s_backend_lb::publishing_api_backend_servers:
 govuk::node::s_backend_lb::performance_backend_servers:
   - 'performance-backend-1.backend'
   - 'performance-backend-2.backend'
+govuk::node::s_backend_lb::docker_backend_servers:
+  - 'docker-backend-1.backend'
+  - 'docker-backend-2.backend'
 
 govuk::node::s_cache::real_ip_header: 'X-Forwarded-For'
 

--- a/modules/govuk/manifests/node/s_backend_lb.pp
+++ b/modules/govuk/manifests/node/s_backend_lb.pp
@@ -10,6 +10,9 @@
 # [*backend_servers*]
 #   An array of backend app servers
 #
+# [*docker_backend_servers*]
+#   An array of Docker backend app servers
+#
 # [*performance_backend_servers*]
 #   An array of Performance Platform backend app servers
 #
@@ -25,6 +28,7 @@
 class govuk::node::s_backend_lb (
   $perfplat_public_app_domain = 'performance.service.gov.uk',
   $backend_servers,
+  $docker_backend_servers = [],
   $performance_backend_servers = [],
   $whitehall_backend_servers,
   $publishing_api_backend_servers,
@@ -59,7 +63,6 @@ class govuk::node::s_backend_lb (
       'maslow',
       'policy-publisher',
       'publisher',
-      'release',
       'search-admin',
       'service-manual-publisher',
       'signon',
@@ -109,6 +112,19 @@ class govuk::node::s_backend_lb (
       servers       => $performance_backend_servers,
       internal_only => false,
     }
+  }
+
+  if !empty($docker_backend_servers) {
+    $_backend_servers = $docker_backend_servers
+  } else {
+    $_backend_servers = $backend_servers
+  }
+
+  loadbalancer::balance {
+    [
+      'release',
+    ]:
+      servers => $_backend_servers;
   }
 
   nginx::config::vhost::redirect { "backdrop-admin.${app_domain}" :


### PR DESCRIPTION
Point the loadbalancers to the container version of the "release" app in Integration only. This adds a conditional which will allow this only if the servers are specifically listed in hieradata.