### PR TITLE
Rate limit contact/govuk urls for POST requests only

### DIFF
--- a/modules/router/templates/rate-limiting.conf.erb
+++ b/modules/router/templates/rate-limiting.conf.erb
@@ -7,9 +7,21 @@ map $http_Rate_Limit_Token $limit_req {
 }
 
 limit_req_zone $limit_req zone=rate:30m rate=10r/s;
-limit_req_zone $limit_req zone=contact:5m rate=6r/m;
 limit_req_zone $limit_req zone=performance:5m rate=5r/s;
 limit_conn_zone $limit_req zone=connections:10m;
+
+# Create another rate limiting zone that only limits POST requests
+# this allows us to limit restful routes where we use one url with
+# GET to render a form and with POST to submit it
+map "$http_Rate_Limit_Token:$request_method" $post_limit_req {
+  <%- @rate_limit_tokens.each do |token| -%>
+    <%= token -%>:POST "";
+  <%- end -%>
+  ~:POST$          $binary_remote_addr;
+  default    "";
+}
+
+limit_req_zone $post_limit_req zone=contact:5m rate=6r/m;
 
 # Return 429 (Too Many Requests) instead of the default 503.
 limit_req_status 429;

--- a/modules/router/templates/router_include.conf.erb
+++ b/modules/router/templates/router_include.conf.erb
@@ -51,7 +51,9 @@ location ~ ^/performance/ {
   proxy_pass http://varnish;
 }
 
-location ~ ^/contact/govuk/(service-feedback|problem_reports)$ {
+# This list of URLS should be kept in sync with the POST-able routes in the
+# feedback application
+location ~ ^/contact/govuk/(|service-feedback|problem_reports|foi|page_improvements|email-survey-signup)$ {
   limit_req zone=contact burst=4 nodelay;
   proxy_pass http://varnish;
 }


### PR DESCRIPTION
For: https://trello.com/c/vNJvbs2g/119-simple-ip-rate-limiting-for-named-contact-requests-to-reduce-spam

We were rate limiting /contact/govuk/service-feedback and
/contact/govuk/problem_reports already, but for all requests.  The problem
is that /contact/govuk and /contact/govuk/foi are both restful and so we
want to allow the GET requests through, but limit the POST requests that
actually submit.  To do this we introduce a new map that toggles on both
the Rate-Limit-Token header and request method.  This map sets up a
variable that is blank for anything that isn't a POST request, and also
blank for a POST request that has a correct Rate-Limit-Token header.  All
other requests have the binary version of the remote address as the value.

This variable is then used in the "contact" `limit_req_zone` to decide which
requests to rate limit.  It'll let all blank values through, but rate limit
any others to 6 requests per minute (with a 5Mb cache).  Note that the limit
zone is unchanged, apart from the variable used as the key.

We then add all POST requests for the feedback app to the existing location
that uses this `limit_req_zone`.  We'll need to keep this in sync with any
new POST endpoints in the feedback app.