### PR TITLE
Add Google Cloud Aptly mirror

### DIFF
--- a/modules/govuk/manifests/node/s_apt.pp
+++ b/modules/govuk/manifests/node/s_apt.pp
@@ -102,6 +102,11 @@ class govuk::node::s_apt (
       location => 'http://ppa.launchpad.net/duplicity-team/ppa/ubuntu',
       release  => 'trusty',
       key      => 'AF953139C1DF9EF3476DE1D58F571BB27A86F4A2';
+    'google-cloud-sdk-trusty':
+      location => 'https://packages.cloud.google.com/apt',
+      repos    => ['main'],
+      release  => 'trusty',
+      key      => 'A7317B0F';
   }
 
   aptly::repo { 'elastic-beats': }


### PR DESCRIPTION
Add Google Cloud mirror to install gcloud in our Jenkins instances
https://cloud.google.com/sdk/docs/#deb