### PR TITLE
Add search benchmarking jenkins jobs to production

### DIFF
--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -33,7 +33,9 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::remove_emergency_banner
   - govuk_jenkins::job::run_rake_task
   - govuk_jenkins::job::run_whitehall_data_migrations
+  - govuk_jenkins::job::search_benchmark
   - govuk_jenkins::job::search_fetch_analytics_data
+  - govuk_jenkins::job::search_test_spelling_suggestions
   - govuk_jenkins::job::signon_cron_rake_tasks
   - govuk_jenkins::job::smokey
   - govuk_jenkins::job::smokey_deploy


### PR DESCRIPTION
These are have been running daily in Integration so we now need them to run in prod.

https://trello.com/c/TXeHcOnY/53-revive-the-search-healthcheck