### PR TITLE
Bugfix removing interims

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -292,7 +292,6 @@ users::usernames:
   - brendanbutler
   - carlosvilhena
   - carolinegreen
-  - chriscarter
   - chrislowis
   - chrisroos
   - christopherbaines
@@ -325,11 +324,9 @@ users::usernames:
   - matteograssotti
   - mobaig
   - murraysteele
-  - neilvanbeinum
   - nickcolley
   - oliverbyford
   - pablomanrubia
-  - paulastepinska
   - paulbowsher
   - paulhayes
   - richardboulton


### PR DESCRIPTION
These contractors were removed in 579a500570adc1880a441207998f62c77245d3e1, but not removed from all references in Puppet. Their user class was deleted, but still referenced in the, which caused Puppet to get upset.