### PR TITLE
Add calendars as dependency to publisher

### DIFF
--- a/development-vm/Pinfile
+++ b/development-vm/Pinfile
@@ -57,7 +57,7 @@ process :'multipage-frontend' => [:static, :'content-store']
 process :need_api
 process :'performanceplatform-admin' => [:stagecraft]
 process :'policy-publisher' => [:'publishing-api', :rummager]
-process :publisher => [:'publishing-api', 'publisher-worker'] # for some requests also uses: mapit
+process :publisher => [:'publishing-api', 'publisher-worker', :calendars] # for some requests also uses: mapit
 process :'publishing-api' => [:'content-store', :'draft-content-store', :'router-api', :'draft-router-api', :'publishing-api-worker']
 process :'publishing-api-worker' => [:'content-store', :'router-api']
 process :release


### PR DESCRIPTION
The default message for the fact-check email in publisher needs to know how to
calculate working days and it does so by reading one of the bank holidays json
files hosted by the calendars app.  This seems like a small dependency, but the
default message for the fact-check email is rendered on every visit to the
email edit form.  If calendars isn't running then we break publisher which
would probably be painful in dev.

For: https://trello.com/c/VSg9iWPO/156-factcheck-email-include-the-date-in-email

See also: 

* https://github.com/alphagov/publisher/pull/621 - introduces the dependency on calendars to publisher
* https://github.com/alphagov/gds-api-adapters/pull/702 - introduces the new api adapter for calendars

This probably shouldn't be merged until the above PRs are.