### PR TITLE
Cope with structure.sql when resetting a Jenkins test db

### DIFF
--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -165,7 +165,7 @@ def buildProject(Map options = [:]) {
     lock("$repoName-$NODE_NAME-test") {
       if (hasDatabase()) {
         stage("Set up the database") {
-            runRakeTask("db:drop db:create db:schema:load")
+            runRakeTask("db:reset")
         }
       }
 


### PR DESCRIPTION
Some rails apps use structure.sql instead of schema.rb to describe their
database.  The task for loading this is not `db:schema:load` but
`db:structure:load`.  Happily rails provides `db:reset` which not only
makes sure to run the correct schema vs. structure task but also does
the drop and create steps too.  It also runs `db:seed` which may or
may not be a problem for our test databases, however there aren't that
many of our apps that have things in their `db/seeds.rb` so we'll try
it out and see.

Encountered while [upgrading support-api to rails 5](https://github.com/alphagov/support-api/pull/109).