### PR TITLE
Use search team slack auth token

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/benchmark_search.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/benchmark_search.yaml.erb
@@ -40,7 +40,7 @@
                   NSCA_OUTPUT=<%= @service_description %> failed
         - slack:
             team-domain: <%= @slack_team_domain %>
-            auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN']%>
+            auth-token: <%= @environment_variables['SEARCH_TEAM_SLACK_AUTH_TOKEN']%>
             build-server-url: <%= @slack_build_server_url %>
             room: <%= @slack_room %>
     properties:


### PR DESCRIPTION
Notifications for the search benchmarking jenkins job need to be sent to the search-team channel which needs its' own authentication token.

- [x] Merge after: https://github.gds/gds/deployment/pull/1312

https://trello.com/c/TXeHcOnY/53-revive-the-search-healthcheck