### PR TITLE
Test pushing docker images to GCR

### DIFF
--- a/hieradata/class/ci_master.yaml
+++ b/hieradata/class/ci_master.yaml
@@ -87,6 +87,10 @@ govuk_jenkins::plugins:
       version: "0.27"
     git-server:
       version: "1.7"
+    google-oauth-plugin:
+      version: '0.5'
+    google-container-registry-auth:
+      version: '0.3'
     gradle:
       version: "1.26"
     greenballs:

--- a/hieradata/class/jenkins.yaml
+++ b/hieradata/class/jenkins.yaml
@@ -61,6 +61,10 @@ govuk_jenkins::plugins:
     version: '1.58'
   github-oauth:
     version: '0.19'
+  google-oauth-plugin:
+    version: '0.5'
+  google-container-registry-auth:
+    version: '0.3'
   greenballs:
     version: '1.14'
   jquery:

--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -198,6 +198,10 @@ def buildProject(Map options = [:]) {
     if (hasDockerfile()) {
       stage("Push Docker image") {
         pushDockerImage(repoName, env.BRANCH_NAME)
+        docker.withRegistry('https://gcr.io', 'gcr:govuk-test') {
+          img = docker.Image('govuk/repoName').tag('gcr.io/govuk-test/jenkins-test')
+          img.push('latest')
+        }
       }
     }
 


### PR DESCRIPTION
Temporary PR as using this with replay causes a "RejectedAccessException" error which I believe to be because it's being invoked from a replay build. This will be used to test whether this is actually the case.