### PR TITLE
Install Elasticsearch migration plugin

### DIFF
--- a/modules/govuk_elasticsearch/manifests/plugins.pp
+++ b/modules/govuk_elasticsearch/manifests/plugins.pp
@@ -9,6 +9,12 @@ class govuk_elasticsearch::plugins {
     instances  => $::fqdn,
   }
 
+  elasticsearch::plugin { 'elasticsearch-migration':
+    module_dir => 'migration',
+    url        => 'https://github.com/elastic/elasticsearch-migration/releases/download/v1.19/elasticsearch-migration-1.19.zip',
+    instances  => $::fqdn,
+  }
+
   case $govuk_elasticsearch::version {
     /^1.4/:  { $cloud_aws_version = '2.4.2' }
     /^1.5/:  { $cloud_aws_version = '2.5.1' }


### PR DESCRIPTION
Add plugin to pre-emptively check for issues in upgrading Elasticsearch from version 1.x to 2.x.

https://trello.com/c/FJUYuFv7/82-deploy-elasticsearch-migration-plugin

I've added a note to Trello to remind us to remove the plugin when we actually upgrade Elasticsearch to 2.x