### PR TITLE
Remove publishing API on the backends from the LBs

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -187,8 +187,6 @@ govuk::node::s_backend_lb::whitehall_backend_servers:
   - 'whitehall-backend-1.backend'
   - 'whitehall-backend-2.backend'
 govuk::node::s_backend_lb::publishing_api_backend_servers:
-  - 'backend-1.backend'
-  - 'backend-2.backend'
   - 'publishing-api-1.backend'
   - 'publishing-api-2.backend'
 govuk::node::s_backend_lb::docker_backend_servers:

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -142,9 +142,6 @@ govuk::node::s_backend_lb::performance_backend_servers:
   - 'performance-backend-1.backend'
   - 'performance-backend-2.backend'
 govuk::node::s_backend_lb::publishing_api_backend_servers:
-  - 'backend-1.backend'
-  - 'backend-2.backend'
-  - 'backend-3.backend'
   - 'publishing-api-1.backend'
   - 'publishing-api-2.backend'
   - 'publishing-api-3.backend'

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -99,9 +99,6 @@ govuk::node::s_backend_lb::performance_backend_servers:
   - 'performance-backend-1.backend'
   - 'performance-backend-2.backend'
 govuk::node::s_backend_lb::publishing_api_backend_servers:
-  - 'backend-1.backend'
-  - 'backend-2.backend'
-  - 'backend-3.backend'
   - 'publishing-api-1.backend'
   - 'publishing-api-2.backend'
   - 'publishing-api-3.backend'

--- a/hieradata/vagrant.yaml
+++ b/hieradata/vagrant.yaml
@@ -73,8 +73,6 @@ govuk::node::s_backend_lb::whitehall_backend_servers:
   - 'whitehall-backend-1.backend'
   - 'whitehall-backend-2.backend'
 govuk::node::s_backend_lb::publishing_api_backend_servers:
-  - 'backend-1.backend'
-  - 'backend-2.backend'
   - 'publishing-api-1.backend'
   - 'publishing-api-2.backend'
 govuk::node::s_backend_lb::performance_backend_servers:


### PR DESCRIPTION
We want to decomission the publishing api application on the backend
machines as they now have dedicated hosts. This first step stops traffic
being sent to those machines. A follow up PR will remove the apps from them.