### PR TITLE
Add a new parameter to control if the application is present or not

### DIFF
--- a/hieradata/class/backend.yaml
+++ b/hieradata/class/backend.yaml
@@ -28,6 +28,8 @@ govuk::apps::publisher::mongodb_nodes:
   - 'mongo-2.backend'
   - 'mongo-3.backend'
 
+govuk::apps::publishing_api::ensure: 'absent'
+
 govuk::apps::short_url_manager::mongodb_name: 'short_url_manager_production'
 govuk::apps::short_url_manager::mongodb_nodes:
   - 'mongo-1.backend'

--- a/modules/govuk/manifests/apps/publishing_api.pp
+++ b/modules/govuk/manifests/apps/publishing_api.pp
@@ -5,6 +5,9 @@
 #
 # === Parameters
 #
+# [*ensure*]
+#   Allow govuk app to be removed.
+#
 # [*port*]
 #   The port that publishing API is served on.
 #   Default: 3093
@@ -81,6 +84,7 @@
 #  The secret key that grants access to event_log_aws_bucketname for event_log_aws_username
 #
 class govuk::apps::publishing_api(
+  $ensure = 'present',
   $port = '3093',
   $content_store = '',
   $draft_content_store = '',
@@ -105,9 +109,12 @@ class govuk::apps::publishing_api(
 ) {
   $app_name = 'publishing-api'
 
+  validate_re($ensure, '^(present|absent)$', 'Invalid ensure value')
+
   include govuk_postgresql::client #installs libpq-dev package needed for pg gem
 
   govuk::app { $app_name:
+    ensure            => $ensure,
     app_type          => 'rack',
     port              => $port,
     vhost_ssl_only    => true,


### PR DESCRIPTION
We don't want to run the publishing api application on the backend
hosts.