### PR TITLE
Drop trade tariff configuration

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1528,8 +1528,6 @@ router::assets_origin::asset_routes:
   '/spotlight/': "spotlight"
   '/stagecraft/': "stagecraft"
 
-router::assets_origin::trade_tariff_host: "%{hiera('trade_tariff_hostname')}"
-
 router::assets_origin::vhost_aliases:
   - 'assets.digital.cabinet-office.gov.uk'
   - 'assets.publishing.service.gov.uk'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -261,7 +261,6 @@ govuk::apps::content_performance_manager::redis_port: "%{hiera('sidekiq_port')}"
 
 govuk::apps::content_store::nagios_memory_warning: 2300
 govuk::apps::content_store::nagios_memory_critical: 2500
-govuk::apps::content_store::trade_tariff_uri: "https://%{hiera('trade_tariff_hostname')}"
 
 govuk::apps::content_tagger::db_hostname: "postgresql-primary-1.backend"
 govuk::apps::content_tagger::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1426,8 +1426,6 @@ monitoring::checks::smokey::features:
     feature: smartanswers
   check_static_mirrors:
     feature: mirror
-  check_tariff:
-    feature: tariff
   check_whitehall:
     feature: whitehall
   check_draft_environment:

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1569,8 +1569,6 @@ ssh::config::allow_users_enable: true
 statsd::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk_unattended_reboot::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
-trade_tariff_hostname: 'tariff-frontend-dev.cloudapps.digital'
-
 unattended_reboot::cron_env_vars:
   - 'MAILTO=""'
 unattended_reboot::cron_hour: '0-5'

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -604,5 +604,3 @@ shell::shell_prompt_string: 'production'
 
 mongodb::s3backup::backup::s3_bucket: 'govuk-mongodb-backup-s3-production'
 mongodb::s3backup::backup::s3_bucket_daily: 'govuk-mongodb-backup-s3-daily-production'
-
-trade_tariff_hostname: 'tariff-frontend-production.cloudapps.digital'

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -541,5 +541,3 @@ users::pentest_machines:
 
 mongodb::s3backup::backup::s3_bucket: 'govuk-mongodb-backup-s3-staging'
 mongodb::s3backup::backup::s3_bucket_daily: 'govuk-mongodb-backup-s3-daily-staging'
-
-trade_tariff_hostname: 'tariff-frontend-staging.cloudapps.digital'

--- a/modules/govuk/manifests/apps/content_store.pp
+++ b/modules/govuk/manifests/apps/content_store.pp
@@ -38,9 +38,6 @@
 # [*secret_key_base*]
 #   The key for Rails to use when signing/encrypting sessions.
 #
-# [*trade_tariff_uri*]
-#   A URI where Trade Tariff is available on the internet.
-#
 class govuk::apps::content_store(
   $port = '3068',
   $mongodb_nodes,
@@ -52,7 +49,6 @@ class govuk::apps::content_store(
   $nagios_memory_critical = undef,
   $errbit_api_key = '',
   $secret_key_base = undef,
-  $trade_tariff_uri = '',
 ) {
   $app_name = 'content-store'
 
@@ -93,8 +89,5 @@ class govuk::apps::content_store(
     "${title}-ERRBIT_API_KEY":
       varname => 'ERRBIT_API_KEY',
       value   => $errbit_api_key;
-    "${title}-PLEK_SERVICE_TARIFF_URI":
-      varname => 'PLEK_SERVICE_TARIFF_URI',
-      value   =>  $trade_tariff_uri;
   }
 }

--- a/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
@@ -32,11 +32,6 @@
             - project: Sanitize_publishing_API_data
             - project: run-rake-task
               predefined-parameters: |
-                TARGET_APPLICATION=router-api
-                MACHINE_CLASS=router_backend
-                RAKE_TASK=backend:modify_url[tariff,https://tariff-frontend-dev.cloudapps.digital/]
-            - project: run-rake-task
-              predefined-parameters: |
                 TARGET_APPLICATION=whitehall
                 MACHINE_CLASS=whitehall_backend
                 RAKE_TASK=publishing:scheduled:requeue_all_jobs

--- a/modules/govuk_jenkins/templates/jobs/data_sync_complete_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/data_sync_complete_staging.yaml.erb
@@ -27,11 +27,6 @@
         - trigger-parameterized-builds:
             - project: run-rake-task
               predefined-parameters: |
-                TARGET_APPLICATION=router-api
-                MACHINE_CLASS=router_backend
-                RAKE_TASK=backend:modify_url[tariff,https://tariff-frontend-staging.cloudapps.digital/]
-            - project: run-rake-task
-              predefined-parameters: |
                 TARGET_APPLICATION=email-alert-api
                 MACHINE_CLASS=backend
                 RAKE_TASK=sync_govdelivery_topic_mappings

--- a/modules/router/manifests/assets_origin.pp
+++ b/modules/router/manifests/assets_origin.pp
@@ -11,9 +11,6 @@
 #   Uses the Nginx realip module (http://nginx.org/en/docs/http/ngx_http_realip_module.html)
 #   to change the client IP address to the one in the specified HTTP header.
 #
-# [*trade_tariff_host*]
-#   The hostname where trade tariff is available on the internet to proxy to for assets.
-#
 # [*vhost_aliases*]
 #   Array of other vhosts that assets should be served on at origin
 #
@@ -23,7 +20,6 @@
 class router::assets_origin(
   $asset_routes = {},
   $real_ip_header = '',
-  $trade_tariff_host = undef,
   $vhost_aliases = [],
   $vhost_name,
 ) {

--- a/modules/router/templates/assets_origin.conf.erb
+++ b/modules/router/templates/assets_origin.conf.erb
@@ -46,14 +46,6 @@ server {
 
   <%- end -%>
 
-  <%- if @trade_tariff_host -%>
-  location /tariff/ {
-    set $trade_tariff_backend "https://<%= @trade_tariff_host %>";
-    proxy_set_header Host <%= @trade_tariff_host %>;
-    proxy_pass $trade_tariff_backend;
-  }
-  <%- end -%>
-
   location / {
     proxy_set_header Host static.<%= @app_domain %>;
     proxy_pass <%= @enable_ssl ? 'https' : 'http' %>://static.<%= @app_domain %>;


### PR DESCRIPTION
Trade tariff is now hosted on an external service domain, and no traffic should be being routed through the GOV.UK origin. The transaction page at https://www.gov.uk/trade-tariff has been updated to use the new domain, and all the routes in the router have been changed to redirects to redirect to the new domain.

These commits remove the related puppet configuration that supported the previous setup of routing trade tariff requests through GOV.UK.