### PR TITLE
Fix virus scan for asset manager tests

### DIFF
--- a/hieradata/class/ci_agent.yaml
+++ b/hieradata/class/ci_agent.yaml
@@ -4,6 +4,8 @@ mongodb::server::development: true
 mongodb::server::replicaset_members:
   "%{::hostname}":
 
+clamav::use_service: false
+
 govuk_ci::agent::postgresql::mapit_role_password: 'mapit'
 postgresql::globals::version: '9.3'
 


### PR DESCRIPTION
`clamav` was added in to CI in https://github.com/alphagov/govuk-puppet/pull/5566 to make the asset manager tests run. This commit adds a piece of configuration that will make `govuk_clamscan` point at the non-daemonised version of clamscan. The daemon version is run by the `clamav` user and won't be able to scan the files uploaded by asset manager's integration tests, causing test failures.

The original code comes from https://github.com/alphagov/ci-puppet/blob/0e51d53779a72df813c63273d0f8e2bd5b3c858f/modules/ci_environment/manifests/jenkins_job_support.pp#L86-L93.

Intends to fix https://github.com/alphagov/asset-manager/pull/61.