### PR TITLE
Add transition logs

### DIFF
--- a/modules/govuk_cdnlogs/files/logs_processor_config
+++ b/modules/govuk_cdnlogs/files/logs_processor_config
@@ -1,0 +1,3 @@
+compression: gzip
+pattern: "cdn-bouncer.log-*.gz"
+format: redirector

--- a/modules/govuk_cdnlogs/files/logs_processor_gitconfig
+++ b/modules/govuk_cdnlogs/files/logs_processor_gitconfig
@@ -1,0 +1,3 @@
+[user]
+    email = govuk-ci@users.noreply.github.com
+    name = Logs Processor

--- a/modules/govuk_cdnlogs/manifests/init.pp
+++ b/modules/govuk_cdnlogs/manifests/init.pp
@@ -118,4 +118,7 @@ class govuk_cdnlogs (
     }
   }
 
+  class { '::govuk_cdnlogs::transition_logs':
+    log_dir => $log_dir,
+  }
 }

--- a/modules/govuk_cdnlogs/manifests/transition_logs.pp
+++ b/modules/govuk_cdnlogs/manifests/transition_logs.pp
@@ -1,0 +1,97 @@
+# == Class: govuk_cdnlogs::transition_logs
+#
+# Processes transition logs and pushes them to git repositories to be used
+# by the transition app
+#
+# === Parameters:
+#
+# [*log_dir*]
+#   Where the CDN logs are stored.
+#
+# [*private_ssh_key*]
+#   The private SSH key used to authenticate with Github. The public part of
+#   the key should be added to the Github repositories.
+#
+# [*user*]
+#   The user that processes the logs and pushes them to Github.
+#
+# [*enabled*]
+#   Enable this only in environments that require running the job.
+#
+class govuk_cdnlogs::transition_logs (
+  $log_dir,
+  $private_ssh_key = undef,
+  $user = 'logs_processor',
+  $enabled = false,
+) {
+  validate_bool($enabled)
+
+  $ensure_dir = $enabled ? {
+    true  => 'directory',
+    false => 'absent',
+  }
+
+  $ensure = $enabled ? {
+    true => 'present',
+    false => 'absent',
+  }
+
+  govuk_user { $user:
+    ensure   => $ensure,
+    fullname => 'Logs Processor',
+  }
+
+
+  if $private_ssh_key {
+    $ssh_dir = "/home/${user}/.ssh"
+
+    file { "${ssh_dir}/id_rsa":
+      ensure  => $ensure,
+      owner   => $user,
+      group   => $user,
+      mode    => '0600',
+      content => $private_ssh_key,
+      require => File[$ssh_dir],
+    }
+  }
+
+  file { "/home/${user}/.gitconfig":
+    ensure  => $ensure,
+    owner   => $user,
+    group   => $user,
+    mode    => '0644',
+    source  => 'puppet:///modules/govuk_cdnlogs/logs_processor_gitconfig',
+    require => Govuk_user[$user],
+  }
+
+  file { "${log_dir}/config.yml":
+    ensure => $ensure,
+    owner  => $user,
+    group  => $user,
+    source => 'puppet:///modules/govuk_cdnlogs/logs_processor_config',
+  }
+
+  $process_script = '/usr/local/bin/process_transition_logs.sh'
+
+  file { $process_script:
+    ensure  => $ensure,
+    owner   => $user,
+    group   => $user,
+    mode    => '0755',
+    content => template('govuk_cdnlogs/process_transition_logs.erb'),
+  }
+
+  cron::crondotdee { 'process_transition_logs':
+    ensure  => $ensure,
+    command => $process_script,
+    hour    => '*',
+    minute  => '30',
+    user    => $user,
+    require => File[$process_script],
+  }
+
+  # Provides /opt/mawk required by pre-transition-stats
+  package { 'mawk-1.3.4':
+    ensure => installed,
+  }
+}

--- a/modules/govuk_cdnlogs/spec/classes/govuk_cdnlogs__transition_log_spec.rb
+++ b/modules/govuk_cdnlogs/spec/classes/govuk_cdnlogs__transition_log_spec.rb
@@ -1,0 +1,46 @@
+require_relative '../../../../spec_helper'
+
+describe 'govuk_cdnlogs::transition_logs', :type => :class do
+  let(:default_params) {{
+    :log_dir          => '/tmp/logs',
+    :private_ssh_key  => 'my key',
+    :user             => 'logs_processor',
+    :enabled          => true,
+  }}
+
+  context 'enabled set to true' do
+    let(:params) { default_params }
+
+    describe 'user' do
+      it { is_expected.to contain_govuk_user('logs_processor').with({
+        :ensure   => 'present',
+        :fullname => 'Logs Processor',
+      })}
+    end
+
+    describe 'SSH key' do
+      it { is_expected.to contain_file('/home/logs_processor/.ssh/id_rsa').with_content('my key') }
+    end
+
+    describe 'git config' do
+      it { is_expected.to contain_file('/home/logs_processor/.gitconfig') }
+    end
+
+    describe 'log processing config.yml' do
+      it { is_expected.to contain_file('/tmp/logs/config.yml') }
+    end
+
+    describe 'processing script' do
+      it { is_expected.to contain_file('/usr/local/bin/process_transition_logs.sh')
+           .with_content(/LOGS_DIR='\/tmp\/logs'/)}
+    end
+
+    describe 'cron job' do
+      it { is_expected.to contain_cron__crondotdee('process_transition_logs').with({
+        :ensure  => 'present',
+        :command => '/usr/local/bin/process_transition_logs.sh',
+        :user    => 'logs_processor',
+      }) }
+    end
+  end
+end

--- a/modules/govuk_cdnlogs/templates/process_transition_logs.erb
+++ b/modules/govuk_cdnlogs/templates/process_transition_logs.erb
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# This script expects that the user running it is able to pull and push to the
+# two repositories used here.
+
+set -e
+
+# Ensure we're working from the user directory
+cd /home/<%= @user %>
+
+BUNDLE_DIR='/home/<%= @user -%>/bundle'
+if [ ! -d "$BUNDLE_DIR" ]; then
+    mkdir "$BUNDLE_DIR"
+fi
+
+# clone repos
+for REPO in transition-stats pre-transition-stats
+do
+    if [ -d "./$REPO" ]; then
+        cd "$REPO"
+        if [ -n "$(git status --porcelain)" ]; then
+            echo "git status in $REPO was unclean"
+            exit 1
+        fi
+        git checkout master
+        git fetch
+        git pull origin master
+        cd ..
+    else
+        git clone "git@github.com-$REPO:alphagov/$REPO.git"
+    fi
+done
+
+# process logs
+LOGS_DIR='<%= @log_dir -%>'
+
+(cd pre-transition-stats &&
+    bundle install --path "$BUNDLE_DIR" &&
+    bundle exec bin/hits update "$LOGS_DIR" --output-dir '../transition-stats/hits')
+
+# move into transition-stats to commit and push to master
+cd transition-stats
+
+# we will probably have untracked files as well as changes in tracked files if
+# anything has been processed, so git add first before checking cached diff
+git add hits/
+
+# check the exit code from `git diff --cached`: 0 if no changes, 1 if there is a diff
+# --quiet implies --exit-code as well as suppressing output
+if ! git diff --cached --quiet; then
+    TIMESTAMP=$(date +"%F %T")
+    git commit -m 'Bouncer Fastly hits processed on '"$TIMESTAMP"
+fi
+
+git push origin master


### PR DESCRIPTION
This commit adds a new class which enables running the code to push transition logs to the appropriate Github repositories.The code for doing this currently exists as it's own machine in UKCloud. This is the last machine that is still in UKCloud, and is not monitored.

The original code exists [here](https://github.com/alphagov/ci-puppet/blob/master/modules/ci_environment/manifests/transition_logs.pp)

---
How transition logs work:

  - Our CDN pushes logs for bouncer to a machine
  - These logs get rotated hourly by logrotate
  - A cronjob runs each hour that pulls two repositories from Github
  - Within one repository is a rake task that creates statistics based
  upon the logs
  - When the stats are compiled, they are committed to a git repo and
  pushed to master
  - Transition application then reads in the latest statistics
---

The Govuk_cdnlogs class already takes care of most of the work for the
actual logs, so this commit needs to provide user and scripts to run the
process.

The SSH private key will be added separately and to each Github repo.
Previously there was a different key for each repository, but this time
round I think it is OK to use the same key to authenticate with Github.