### PR TITLE
Set envvar for hmrc-manuals-api log request body

### DIFF
--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -112,6 +112,7 @@ govuk::apps::email_alert_service::rabbitmq_hosts: ['localhost']
 govuk::apps::event_store::enabled: true
 govuk::apps::event_store::mongodb_servers: ['localhost']
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
+govuk::apps::hmrc_manuals_api::log_request_body: false
 govuk::apps::hmrc_manuals_api::enable_procfile_worker: false
 govuk::apps::government_frontend::enable_running_in_draft_mode::content_store: 'http://draft-content-store.dev.gov.uk'
 govuk::apps::govuk_cdn_logs_monitor::enabled: false

--- a/modules/govuk/manifests/apps/hmrc_manuals_api.pp
+++ b/modules/govuk/manifests/apps/hmrc_manuals_api.pp
@@ -18,6 +18,9 @@
 #   non-whitelisted manual slugs.
 #   Default: false
 #
+# [*log_request_body*]
+#   Feature flag to log the body of the HTTP request
+#
 # [*publish_topics*]
 #   Feature flag to allow publishing of manual topics to the Publishing
 #   API and Rummager.
@@ -31,6 +34,7 @@ class govuk::apps::hmrc_manuals_api(
   $port = '3071',
   $enable_procfile_worker = true,
   $allow_unknown_hmrc_manual_slugs = false,
+  $log_request_body = true,
   $publish_topics = true,
   $publishing_api_bearer_token = undef,
 ) {
@@ -43,6 +47,14 @@ class govuk::apps::hmrc_manuals_api(
     govuk::app::envvar {
       "${title}-ALLOW_UNKNOWN_HMRC_MANUAL_SLUGS":
         varname => 'ALLOW_UNKNOWN_HMRC_MANUAL_SLUGS',
+        value   => '1';
+    }
+  }
+
+  if $log_request_body {
+    govuk::app::envvar {
+      "${title}-LOG_REQUEST_BODY":
+        varname => 'LOG_REQUEST_BODY',
         value   => '1';
     }
   }


### PR DESCRIPTION
We need to configure this using an environment variable rather than config from GitHub Enterprise.