### PR TITLE
Don't filebucket a copy of a removed application.

### DIFF
--- a/modules/govuk/manifests/app/package.pp
+++ b/modules/govuk/manifests/app/package.pp
@@ -45,6 +45,7 @@ define govuk::app::package (
     }
     file { "/data/vhost/${vhost_full}":
       ensure => $ensure_directory,
+      backup => false,
       owner  => 'deploy',
       group  => 'deploy',
       force  => true,


### PR DESCRIPTION
By default our puppet code creates a backup of applications that
are being removed in to a filebucket. This is a massive collection
of files that we already have in other places so we're no longer
going to also maintain a filebucket based version.