### PR TITLE
Add a Crawler specific redis docker container

### DIFF
--- a/modules/govuk/manifests/apps/govuk_crawler_worker.pp
+++ b/modules/govuk/manifests/apps/govuk_crawler_worker.pp
@@ -74,7 +74,7 @@ class govuk::apps::govuk_crawler_worker (
       'HTTP_PORT':
         value => $port;
       'REDIS_ADDRESS':
-        value => 'redis-1:6379';
+        value => '127.0.0.1:6379';
       'REDIS_KEY_PREFIX':
         value => 'govuk_crawler_worker';
       'ROOT_URLS':

--- a/modules/govuk/manifests/node/s_mirrorer.pp
+++ b/modules/govuk/manifests/node/s_mirrorer.pp
@@ -12,6 +12,9 @@ class govuk::node::s_mirrorer inherits govuk::node::s_base {
   include govuk_rabbitmq
   include nginx
 
+  include ::govuk_docker
+  include ::govuk_containers::redis
+
   cron::crondotdee { 'purge_govuk_crawler_queue':
     ensure  => 'absent',
     hour    => 10,

--- a/modules/govuk_containers/manifests/redis.pp
+++ b/modules/govuk_containers/manifests/redis.pp
@@ -1,0 +1,47 @@
+# == Class: govuk_containers::redis
+#
+# Install and run a dockerised Redis server
+#
+# === Parameters
+#
+# [*image_name*]
+#   Docker image name to use for the container.
+#
+# [*image_version*]
+#   The docker image version to use.
+#
+class govuk_containers::redis(
+  $image_name = 'redis',
+  $image_version = '3.2.8-alpine',
+) {
+
+  # TODO: investigate why this is causing spec failiures and enable
+  # include ::collectd::plugin::redis
+
+  # store the state dumps here on the docker host
+  file { '/srv/redis':
+    ensure => directory,
+  }
+
+  ::docker::image { $image_name:
+    ensure    => 'present',
+    require   => Class['govuk_docker'],
+    image_tag => $image_version,
+  }
+
+  ::docker::run { 'redis':
+    net              => 'host',
+    ports            => ['6379:6379'],
+    image            => $image_name,
+    require          => [ Docker::Image[$image_name], File['/srv/redis'] ],
+    volumes          => ['/srv/redis:/data'],
+    extra_parameters => ['-P'],
+    command          => '--appendonly yes',
+  }
+
+  @@icinga::check { "check_redis_running_${::hostname}":
+    check_command       => 'check_nrpe!check_proc_running!redis',
+    service_description => 'redis running',
+    host_name           => $::fqdn,
+  }
+}

--- a/modules/govuk_containers/spec/classes/govuk_containers__redis_spec.rb
+++ b/modules/govuk_containers/spec/classes/govuk_containers__redis_spec.rb
@@ -1,0 +1,8 @@
+require_relative '../../../../spec_helper'
+
+describe 'govuk_containers::redis', :type => :class do
+  let(:pre_condition) { 'include ::govuk_docker' }
+  it { is_expected.to compile }
+
+  it { is_expected.to compile.with_all_deps }
+end


### PR DESCRIPTION
We're extracting the redis used by the crawler worker from `redis-1` to the local machine. And running it inside a container.