### PR TITLE
Explicitly use the eth0 ipaddress

### DIFF
--- a/modules/govuk/templates/notify_passive_check.erb
+++ b/modules/govuk/templates/notify_passive_check.erb
@@ -6,7 +6,7 @@ NAGIOS_CODE=$2
 NAGIOS_MESSAGE=$3
 
 if [ -n "$SERVICE_DESC" ] && [ -n "$NAGIOS_CODE" ] && [ -n "$NAGIOS_MESSAGE" ]; then
-  printf "<%= @ipaddress %>\t$SERVICE_DESC\t$NAGIOS_CODE\t$NAGIOS_MESSAGE\n" | /usr/sbin/send_nsca -H alert.cluster >/dev/null
+  printf "<%= @ipaddress_eth0 %>\t$SERVICE_DESC\t$NAGIOS_CODE\t$NAGIOS_MESSAGE\n" | /usr/sbin/send_nsca -H alert.cluster >/dev/null
 else
   logger "Failed to submit passive check. Insufficient parameters: SERVICE_DESC=$SERVICE_DESC NAGIOS_CODE=$NAGIOS_CODE NAGIOS_MESSAGE=$NAGIOS_MESSAGE"
   exit 1

--- a/modules/govuk_crawler/templates/govuk_sync_mirror.erb
+++ b/modules/govuk_crawler/templates/govuk_sync_mirror.erb
@@ -17,7 +17,7 @@ function log() {
 
 function nagios_passive() {
   log "user.info" "$NAGIOS_MESSAGE Exit code was $?"
-  printf "<%= @ipaddress %>\t<%= @sync_service_desc %>\t${NAGIOS_CODE}\t${NAGIOS_MESSAGE}\n" | /usr/sbin/send_nsca -H alert.cluster >/dev/null
+  printf "<%= @ipaddress_eth0 %>\t<%= @sync_service_desc %>\t${NAGIOS_CODE}\t${NAGIOS_MESSAGE}\n" | /usr/sbin/send_nsca -H alert.cluster >/dev/null
 }
 trap nagios_passive EXIT
 

--- a/modules/govuk_crawler/templates/seed-crawler-wrapper.erb
+++ b/modules/govuk_crawler/templates/seed-crawler-wrapper.erb
@@ -13,7 +13,7 @@ function send_nsca {
         CODE=3
         OUTPUT="UNKNOWN: seed-crawler-wrapper exited before setting OUTPUT - this should never happen"
     fi
-    printf "<%= @ipaddress %>\t<%= @seed_service_desc %>\t$CODE\t$OUTPUT\n" | /usr/sbin/send_nsca -H alert.cluster >/dev/null
+    printf "<%= @ipaddress_eth0 %>\t<%= @seed_service_desc %>\t$CODE\t$OUTPUT\n" | /usr/sbin/send_nsca -H alert.cluster >/dev/null
     exit $?
 }
 trap send_nsca EXIT


### PR DESCRIPTION
We now have some docker hosts in our clusters and those
are causing the address associated with docker0 to be put in the
ipaddress fact. To work around this we explicitly use the eth0 fact.
Until we move to systemd based stuff.