### PR TITLE
Increase memory threshold on publishing-api

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -406,6 +406,8 @@ govuk::apps::publishing_api::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::publishing_api::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::publishing_api::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 govuk::apps::publishing_api::govuk_content_schemas_path: '/data/apps/govuk-content-schemas/current'
+govuk::apps::publishing_api::nagios_memory_warning: 2500
+govuk::apps::publishing_api::nagios_memory_critical: 3000
 
 govuk::apps::release::db_hostname: "master.mysql"
 govuk::apps::release::db_username: "release"


### PR DESCRIPTION
This is currently set to 600/700MB. Since they're now on new machines we can bump the thresholds so that we won't get as many alerts.

@danielroseman 