### PR TITLE
Add link to high memory page from alert

### DIFF
--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -218,6 +218,7 @@ define govuk::app::config (
       desc          => "high memory for ${title} app",
       host_name     => $::fqdn,
       event_handler => "govuk_app_high_memory!${title}",
+      notes_url     => monitoring_docs_url(high-memory-for-application),
     }
   }
 


### PR DESCRIPTION
This links the "high memory for x" alert to the new page in the docs (https://github.com/alphagov/govuk-developer-docs/pull/225). 