### PR TITLE
Add LTS kernel packages to Docker machines

### DIFF
--- a/modules/govuk_docker/manifests/init.pp
+++ b/modules/govuk_docker/manifests/init.pp
@@ -28,6 +28,14 @@ class govuk_docker (
     provider => pip,
   }
 
+  # Docker machines should run with the latest Xenial kernel to fix
+  # stability issues
+  $kernel_packages = [
+    'linux-generic-lts-xenial',
+    'linux-image-generic-lts-xenial',
+  ]
+  ensure_packages($kernel_packages)
+
   # We currently only have logit set up for
   if $::domain =~ /^.*\.(dev|integration\.publishing\.service)\.gov\.uk/ {
     include ::govuk_docker::logspout


### PR DESCRIPTION
We witnessed stability issues on Docker machines and improved performance by upgrading the kernel. This commit includes the packages on any machine which includes our wrapper docker class.

Machines will require a reboot for the newer kernel to take effect.