### PR TITLE
Add govuk-puppet as a deployable app

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -41,6 +41,7 @@ deployable_applications: &deployable_applications
   govuk-content-schemas: {}
   govuk_crawler_worker: {}
   govuk_need_api: {}
+  govuk-puppet: {}
   hmrc-manuals-api: {}
   imminence: {}
   info-frontend: {}

--- a/modules/govuk_ci/manifests/master.pp
+++ b/modules/govuk_ci/manifests/master.pp
@@ -42,7 +42,6 @@ class govuk_ci::master (
   }
 
   # Manually add jobs that we do not want to included in the 'Deploy App' job
-  govuk_ci::job { 'govuk-puppet': }
   govuk_ci::job { 'govuk-dns': }
   govuk_ci::job { 'govuk-dns-config':
     source => 'github-enterprise',


### PR DESCRIPTION
Rather than have it's own special job, deploy Puppet from the Deploy App Jenkins job. This adds it to the list of apps that we can deploy using it.

Related: 
https://github.digital.cabinet-office.gov.uk/gds/deployment/pull/1329
https://github.com/alphagov/govuk-app-deployment/pull/148

Story: https://trello.com/c/nsFatflf/542-move-puppet-deployment-to-govuk-app-deployment
