### PR TITLE
Update banner campaign classes for redesign

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_emergency_banner.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_emergency_banner.yaml.erb
@@ -13,11 +13,11 @@
     parameters:
       - choice:
           name: CAMPAIGN_CLASS
-          description: Choose the colour of banner to deploy
+          description: Choose the type of banner to deploy
           choices:
-            - black
-            - green
-            - red
+            - notable-death
+            - national-emergency
+            - local-emergency
       - string:
           name: HEADING
           description: The title of the banner


### PR DESCRIPTION
The redesign of the emergency banner has resulted in changes to the names of the classes used in the HTML for the emergency banners.

This is reflected in changes to the options in the campaign class drop down in the Jenkins job to deploy the emergency banner.

This should be merged and deployed once both [PR 1049 in Static](https://github.com/alphagov/static/pull/1049) and [PR 230 in Govuk Developer Docs](https://github.com/alphagov/govuk-developer-docs/pull/230) have been merged and deployed.

- [x] PR 1049 in Static has been merged and deployed
- [ ] PR 230 in Govuk Developer docs has been merged and deployed 

Related [Trello](https://trello.com/c/eSfTdFEx)

After this has run and gone through the pipes, a PR should be raised in Static to remove the redundant `red`, `black` and `green` classes.

- [ ] PR has been raised in Static to remove redundant classes.