### PR TITLE
Fix Slack channel for search benchmarking

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/benchmark_search.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/benchmark_search.yaml.erb
@@ -40,9 +40,7 @@
                   NSCA_OUTPUT=<%= @service_description %> failed
         - slack:
             team-domain: <%= @slack_team_domain %>
-            auth-token: <%= @environment_variables['SEARCH_TEAM_SLACK_AUTH_TOKEN']%>
             build-server-url: <%= @slack_build_server_url %>
-            room: <%= @slack_room %>
     properties:
         - inject:
             properties-content: |
@@ -57,6 +55,8 @@
             notify-backtonormal: false
             notify-repeatedfailure: false
             include-test-summary: false
+            room: '#<%= @slack_room %>'
+            token: <%= @environment_variables['SEARCH_TEAM_SLACK_AUTH_TOKEN']%>
     wrappers:
         - ansicolor:
             colormap: xterm


### PR DESCRIPTION
Reconfigure Jenkins for the search benchmark checks so that the results are posted to the #search-team Slack channel rather than the default channel, #2ndline.

The old config was copied from other Jenkins jobs. It's hard to tell whether the config works in those jobs because they all post to the 2ndline channel, which I think is the Jenkins default.

In any case, I've tested this new configuration by updating the Jenkins job manually and inspecting the config file.