### PR TITLE
Icinga client override host ipaddress in Xenial

### DIFF
--- a/hieradata/common.xenial.yaml
+++ b/hieradata/common.xenial.yaml
@@ -6,6 +6,8 @@ govuk_ppa::repo_ensure: 'absent'
 
 govuk_unattended_reboot::manage_repo_class: true
 
+icinga::client::host_ipaddress: "%{::ipaddress}"
+
 nginx::package::version: 'present'
 
 nodejs::version: '4.2.6~dfsg-1ubuntu4.1'

--- a/modules/icinga/manifests/client.pp
+++ b/modules/icinga/manifests/client.pp
@@ -6,9 +6,13 @@
 # 
 # [*contact_groups*]
 #   Sets the contact groups for host. Defaults to high priority.  
-# 
+#
+# [*host_ipaddress*]
+#   Sets the ipaddress in the Icinga host check. Defaults to facter ipaddress_eth0
+#
 class icinga::client (
-  $contact_groups = 'high-priority'
+  $contact_groups = 'high-priority',
+  $host_ipaddress = $::ipaddress_eth0,
 )
 {
 
@@ -52,7 +56,7 @@ class icinga::client (
 
   @@icinga::host { $::fqdn:
     hostalias      => $::fqdn,
-    address        => $::ipaddress_eth0,
+    address        => $host_ipaddress,
     display_name   => $::fqdn_short,
     parents        => $parents,
     contact_groups => $contact_groups,


### PR DESCRIPTION
The Icinga host declaration is using ipaddress_eth0, but Xenial
boxes don't create that interface. This change allows to override
the ipaddress in the icinga::client class and sets the value to
the ipaddress facter in Hieradata for Xenial boxes.