### PR TITLE
Use new github private repo for govuk-dns-config

### DIFF
--- a/modules/govuk_ci/manifests/master.pp
+++ b/modules/govuk_ci/manifests/master.pp
@@ -43,9 +43,7 @@ class govuk_ci::master (
 
   # Manually add jobs that we do not want to included in the 'Deploy App' job
   govuk_ci::job { 'govuk-dns': }
-  govuk_ci::job { 'govuk-dns-config':
-    source => 'github-enterprise',
-  }
+  govuk_ci::job { 'govuk-dns-config': }
 
   # Add pipeline jobs from applications hash in Hieradata
   create_resources(govuk_ci::job, $pipeline_jobs)

--- a/modules/govuk_jenkins/templates/jobs/validate_published_dns.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/validate_published_dns.yaml.erb
@@ -3,14 +3,14 @@
     name: Validate_published_dns
     display-name: Validate_published_dns
     project-type: freestyle
-    description: "<p>Check that the published DNS records match those in the <a href='https://github.digital.cabinet-office.gov.uk/govuk-dns-config'>govuk-dns-config repo</a> YAML file.</p>"
+    description: "<p>Check that the published DNS records match those in the <a href='https://github.com/alphagov/govuk-dns-config'>govuk-dns-config repo</a> YAML file.</p>"
     logrotate:
         numToKeep: 30
     builders:
         - shell: |
             set -e
             rm -rf govuk-dns-config
-            git clone --branch master --depth 1 git@github.digital.cabinet-office.gov.uk:gds/govuk-dns-config.git
+            git clone --branch master --depth 1 git@github.com:alphagov/govuk-dns-config.git
             cd govuk-dns-config
             bundle install --path "${HOME}/bundles/${JOB_NAME}"
             bundle exec rake validate_dns


### PR DESCRIPTION
As part of the migration from GHE move govuk-dns-config to a github private repo