### PR TITLE
Ensure the procfile::worker is absent when the application is.

### DIFF
--- a/modules/govuk/manifests/apps/publishing_api.pp
+++ b/modules/govuk/manifests/apps/publishing_api.pp
@@ -124,6 +124,7 @@ class govuk::apps::publishing_api(
   }
 
   govuk::procfile::worker {'publishing-api':
+    ensure         => $ensure,
     enable_service => $enable_procfile_worker,
   }
 


### PR DESCRIPTION
Otherwise you remove the app but leave the sidekick processes running