### PR TITLE
Remove old notes url for licence finder smokey check

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1420,7 +1420,6 @@ monitoring::checks::smokey::features:
     feature: frontend
   check_licencefinder:
     feature: licencefinder
-    notes_url: "https://github.digital.cabinet-office.gov.uk/pages/gds/opsmanual/2nd-line/nagios.html#licencefinder-smokey-checks"
   check_licensing:
     feature: licensing
   check_publishing:


### PR DESCRIPTION
Presumably we used to have a special page for when the licence finder smokey checks failed. We don't have that anymore (even before the move to the developer docs), so remove the special notes link.