### PR TITLE
Add safety flag for transition logs

### DIFF
--- a/modules/govuk_cdnlogs/manifests/transition_logs.pp
+++ b/modules/govuk_cdnlogs/manifests/transition_logs.pp
@@ -22,7 +22,8 @@ class govuk_cdnlogs::transition_logs (
   $log_dir,
   $private_ssh_key = undef,
   $user = 'logs_processor',
-  $enabled = false,
+  $enabled = true,
+  $enable_cron = false,
 ) {
   validate_bool($enabled)
 
@@ -81,13 +82,15 @@ class govuk_cdnlogs::transition_logs (
     content => template('govuk_cdnlogs/process_transition_logs.erb'),
   }
 
-  cron::crondotdee { 'process_transition_logs':
-    ensure  => $ensure,
-    command => $process_script,
-    hour    => '*',
-    minute  => '30',
-    user    => $user,
-    require => File[$process_script],
+  if $enable_cron {
+    cron::crondotdee { 'process_transition_logs':
+      ensure  => $ensure,
+      command => $process_script,
+      hour    => '*',
+      minute  => '30',
+      user    => $user,
+      require => File[$process_script],
+    }
   }
 
   # Provides /opt/mawk required by pre-transition-stats

--- a/modules/govuk_cdnlogs/spec/classes/govuk_cdnlogs__transition_log_spec.rb
+++ b/modules/govuk_cdnlogs/spec/classes/govuk_cdnlogs__transition_log_spec.rb
@@ -6,6 +6,7 @@ describe 'govuk_cdnlogs::transition_logs', :type => :class do
     :private_ssh_key  => 'my key',
     :user             => 'logs_processor',
     :enabled          => true,
+    :enable_cron      => true,
   }}
 
   context 'enabled set to true' do

--- a/modules/govuk_cdnlogs/templates/process_transition_logs.erb
+++ b/modules/govuk_cdnlogs/templates/process_transition_logs.erb
@@ -51,5 +51,6 @@ if ! git diff --cached --quiet; then
     TIMESTAMP=$(date +"%F %T")
     git commit -m 'Bouncer Fastly hits processed on '"$TIMESTAMP"
 fi
-
+<% if @enable_cron %>
 git push origin master
+<% end %>


### PR DESCRIPTION
I needed a way to safely test the function of transition logs without causing any production issues. This commit adds an "enable_cron" flag which when enabled starts the job running. Without this flag there will
be no cron job and the job won't push to master. This enables us to have Puppet create everything required in our testing environment, but without a risk of pushing anything to the upstream repository.