### PR TITLE
Add freshclam cron to CI

### DIFF
--- a/modules/clamav/manifests/cron_freshclam.pp
+++ b/modules/clamav/manifests/cron_freshclam.pp
@@ -1,0 +1,12 @@
+# == Class: clamav::cron_freshclam
+#
+# Update virus database via cron, when the freshclam service is not enabled
+#
+class clamav::cron_freshclam {
+  cron::crondotdee { 'freshclam':
+    command => '/usr/bin/freshclam --quiet',
+    hour    => '*',
+    minute  => '0',
+    user    => 'root',
+  }
+}

--- a/modules/govuk_ci/manifests/agent.pp
+++ b/modules/govuk_ci/manifests/agent.pp
@@ -16,6 +16,7 @@ class govuk_ci::agent(
   $gemstash_server = 'http://gemstash.cluster',
 ) {
   include ::clamav
+  include ::clamav::cron_freshclam
   include ::govuk_ci::agent::redis
   include ::govuk_ci::agent::docker
   if $elasticsearch_enabled {


### PR DESCRIPTION
The CI agents are not running clamav and freshclam as a service,
so the virus databases are not being updated and that's triggering
a Nagios alert.

This change adds a cron to update the virus databases that gets included
in the CI manifest.