### PR TITLE
Stop search benchmark jobs from notifying Slack

### DIFF
--- a/modules/govuk_jenkins/manifests/job/search_benchmark.pp
+++ b/modules/govuk_jenkins/manifests/job/search_benchmark.pp
@@ -15,10 +15,6 @@ class govuk_jenkins::job::search_benchmark (
   $job_url = "https://deploy.${app_domain}/job/search_benchmark/"
   $cron_schedule = '30 4 * * *'
 
-  $slack_team_domain = 'govuk'
-  $slack_room = 'search-team'
-  $slack_build_server_url = "https://deploy.${app_domain}/"
-
   file { '/etc/jenkins_jobs/jobs/search_benchmark.yaml':
     ensure  => present,
     content => template('govuk_jenkins/jobs/benchmark_search.yaml.erb'),

--- a/modules/govuk_jenkins/manifests/job/search_test_spelling_suggestions.pp
+++ b/modules/govuk_jenkins/manifests/job/search_test_spelling_suggestions.pp
@@ -15,10 +15,6 @@ class govuk_jenkins::job::search_test_spelling_suggestions (
   $job_url = "https://deploy.${app_domain}/job/search_test_spelling_suggestions/"
   $cron_schedule = '0 5 * * *'
 
-  $slack_team_domain = 'govuk'
-  $slack_room = 'search-team'
-  $slack_build_server_url = "https://deploy.${app_domain}/"
-
   file { '/etc/jenkins_jobs/jobs/search_test_spelling.yaml':
     ensure  => present,
     content => template('govuk_jenkins/jobs/benchmark_search.yaml.erb'),

--- a/modules/govuk_jenkins/templates/jobs/benchmark_search.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/benchmark_search.yaml.erb
@@ -38,25 +38,10 @@
               predefined-parameters: |
                   NSCA_CHECK_DESCRIPTION=<%= @service_description %>
                   NSCA_OUTPUT=<%= @service_description %> failed
-        - slack:
-            team-domain: <%= @slack_team_domain %>
-            build-server-url: <%= @slack_build_server_url %>
-            room: '#<%= @slack_room %>'
-            auth-token: <%= @environment_variables['SEARCH_TEAM_SLACK_AUTH_TOKEN']%>
     properties:
         - inject:
             properties-content: |
               AUTH_USERNAME=<%= @auth_username %>
-        - slack:
-            notify-start: false
-            notify-success: true
-            notify-aborted: true
-            notify-notbuilt: true
-            notify-unstable: true
-            notify-failure: true
-            notify-backtonormal: false
-            notify-repeatedfailure: false
-            include-test-summary: false
     wrappers:
         - ansicolor:
             colormap: xterm


### PR DESCRIPTION
Ideally these Jenkins jobs would notify the #search-team Slack channel, but they actually spam the #2ndline channel and we haven't been able to work out how to configure the Jenkins Job Builder to send the notification to the right place.

We are planning to change how the search benchmark runs anyway, so the simplest solution for now is to just switch off the Slack notifications. They will still notify Icinga if they fail completely.