### PR TITLE
Reschedule autopostgresqlbackup cron integration

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -229,6 +229,7 @@ govuk::node::s_whitehall_backend::sync_mirror: true
 govuk::node::s_transition_postgresql_slave::redirector_ip_range: '10.1.5.0/24'
 govuk::node::s_transition_postgresql_standby::redirector_ip_range: "%{hiera('govuk::node::s_transition_postgresql_slave::redirector_ip_range')}"
 
+govuk_postgresql::backup::auto_postgresql_backup_hour: 10
 govuk_postgresql::server::standby::pgpassfile_enabled: true
 
 govuk_sudo::sudo_conf:


### PR DESCRIPTION
Postgresql auto-backups have been failing on Integration with errors:
`pg_dump: [archiver (db)] query failed: ERROR:  cache lookup failed for index ...`

One of the possible causes could be collision with the Copy_Data_to_Integration job that
runs between 4:30 and 9:30 am. This change reschedules the backup cron to run out of the
data recovery window.