### PR TITLE
Adding govuk_tagging_monitor job

### DIFF
--- a/modules/govuk_jenkins/manifests/job/govuk_tagging_monitor.pp
+++ b/modules/govuk_jenkins/manifests/job/govuk_tagging_monitor.pp
@@ -1,0 +1,23 @@
+# == Class: govuk_jenkins::job::govuk_tagging_monitor
+#
+# Monitor GOV.UK navigation pages to find invalid pages that we shouldn't
+# display to users. It also raises alerts when navigation pages exceed the
+# number of allowed links, so a content designer can act on those. The ruby
+# script handles slack notifications.
+#
+# === Parameters
+#
+# [*rate_limit_token*]
+#   Sets the header "Rate-Limit-Token" which ensures that the tagging monitor is
+#   whitelisted by the rate limiting function (receiving 429 status)
+#
+class govuk_jenkins::job::govuk_tagging_monitor (
+  $rate_limit_token = undef,
+) {
+
+  file { '/etc/jenkins_jobs/jobs/govuk_tagging_monitor.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/govuk_tagging_monitor.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+}

--- a/modules/govuk_jenkins/templates/jobs/govuk_tagging_monitor.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/govuk_tagging_monitor.yaml.erb
@@ -1,0 +1,30 @@
+---
+- scm:
+    name: govuk_tagging_monitor
+    scm:
+      - git:
+          url: git@github.com:alphagov/govuk-tagging-monitor.git
+          basedir: govuk-tagging-monitor
+          branches:
+            - master
+- job:
+    name: govuk_tagging_monitor
+    display-name: GOV.UK Tagging Monitor
+    project-type: freestyle
+    description: |
+      This job checks new navigation pages against a set of rules. This makes
+      sure we don't have invalid navigation pages being shown to users.
+    scm:
+      - govuk-tagging-monitor
+    logrotate:
+      numToKeep: 10
+    triggers:
+        - timed: 'H * * * *'
+    builders:
+      - shell: |
+          #!/bin/bash
+          set -eu
+
+          export RATE_LIMIT_TOKEN="<%= @rate_limit_token -%>"
+          bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
+          bundle exec rake run


### PR DESCRIPTION
This job already exists in Jenkins, but not in code. This commit moves
the job configuration into puppet.

The existing job is here: https://deploy.publishing.service.gov.uk/job/govuk-tagging-monitor/

Trello: https://trello.com/c/NyNRDc78/148-add-govuk-tagging-monitor-tasks-to-puppet