### PR TITLE
Run content-store when bowling info-frontend

### DIFF
--- a/development-vm/Pinfile
+++ b/development-vm/Pinfile
@@ -40,7 +40,7 @@ process :'govuk-delivery'
 process :'govuk-delivery-worker'
 process :'hmrc-manuals-api' => [:'publishing-api', :rummager]
 process :imminence => [:mapit]
-process :'info-frontend' => [:static, :'metadata-api']
+process :'info-frontend' => [:static, :'content-store', :'metadata-api']
 process :licencefinder => [:static, :'content-store', :rummager]
 process :'link-checker-api' => [:'link-checker-api-sidekiq']
 process :'link-checker-api-sidekiq'


### PR DESCRIPTION
Ever since https://github.com/alphagov/info-frontend/pull/57, 
info-frontend has relied on content-store, so we add it as a
dependency to the Pinfile for local development