### PR TITLE
Only match the bash shebang line if it's the first line.

### DIFF
--- a/lib/tasks/bash_syntax.rake
+++ b/lib/tasks/bash_syntax.rake
@@ -25,7 +25,7 @@ task :bash_syntax do
   templates = templates.exclude(*PuppetSyntax.exclude_paths)
 
   templates.each do |erb_file|
-    next unless File.open(erb_file).read() =~ BASH_HEADER
+    next unless File.open(erb_file).gets =~ BASH_HEADER
 
     begin
       erb = ERB.new(File.read(erb_file), nil, '-')


### PR DESCRIPTION
Without this change anything that contains the string, such as jenkins jobs,
with embedded shell are validated as bash scripts.