### PR TITLE
Add govuk_tagging_monitor job to production

### DIFF
--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -25,6 +25,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::email_alert_check
   - govuk_jenkins::job::gds_production_backup
   - govuk_jenkins::job::govuk_cdn_nightly_2xx_status_collection
+  - govuk_jenkins::job::govuk_tagging_monitor
   - govuk_jenkins::job::launch_vms
   - govuk_jenkins::job::mirror_network_config
   - govuk_jenkins::job::network_config_deploy


### PR DESCRIPTION
This commit adds the `govuk_tagging_monitor` job to the production
manifest file for Jenkins. This makes sure the job will only run in
production, which is the expected behaviour for this monitoring tool.

Trello: https://trello.com/c/NyNRDc78/148-add-govuk-tagging-monitor-tasks-to-puppet