### PR TITLE
Fix scm name in govuk tagging monitor job

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/govuk_tagging_monitor.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/govuk_tagging_monitor.yaml.erb
@@ -15,7 +15,7 @@
       This job checks new navigation pages against a set of rules. This makes
       sure we don't have invalid navigation pages being shown to users.
     scm:
-      - govuk-tagging-monitor
+      - govuk_tagging_monitor
     logrotate:
       numToKeep: 10
     triggers:


### PR DESCRIPTION
This will fix the following puppet error:

```
(/Stage[main]/Govuk_jenkins::Job_builder/Exec[jenkins_jobs_update]/returns)
jenkins_jobs.errors.JenkinsJobsException: Unknown entry point or macro
'govuk-tagging-monitor' for component type: 'scm'.
```
The `scm` field needs to match the `name` field above.

Details: https://kibana.publishing.service.gov.uk/kibana/#/dashboard/file/default.json?query=@fields.syslog_program:'puppet-agent'%20AND%20@source_host:jenkins-1*&from=4h

Trello: https://trello.com/c/NyNRDc78/148-add-govuk-tagging-monitor-tasks-to-puppet