### PR TITLE
Add jenkins job to run analysis on nav links

### DIFF
--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -25,6 +25,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::email_alert_check
   - govuk_jenkins::job::gds_production_backup
   - govuk_jenkins::job::govuk_cdn_nightly_2xx_status_collection
+  - govuk_jenkins::job::govuk_navigation_link_analysis
   - govuk_jenkins::job::govuk_tagging_monitor
   - govuk_jenkins::job::launch_vms
   - govuk_jenkins::job::mirror_network_config

--- a/modules/govuk_jenkins/manifests/job/govuk_navigation_link_analysis.pp
+++ b/modules/govuk_jenkins/manifests/job/govuk_navigation_link_analysis.pp
@@ -1,0 +1,52 @@
+# == Class: govuk_jenkins::job::govuk_navigation_link_analysis
+#
+# Monthly analysis of links displayed in the new navigation pages. The output of
+# this is needed for Performance Analysts to produce reports on how the new
+# navigation is performing.
+#
+# === Parameters
+#
+# [*rate_limit_token*]
+#   Sets the header "Rate-Limit-Token" which ensures that the tagging monitor is
+#   whitelisted by the rate limiting function (receiving 429 status)
+#
+# [*private_key_id*]
+#   Specific to access the Google API.
+#
+# [*private_key*]
+#   Specific to access the Google API.
+#
+# [*client_email*]
+#   Specific to access the Google API.
+#
+# [*client_email*]
+#   Specific to access the Google API.
+#
+# [*client_id*]
+#   Specific to access the Google API.
+#
+# [*client_x509_cert_url*]
+#   Specific to access the Google API.
+#
+class govuk_jenkins::job::govuk_navigation_link_analysis (
+  $rate_limit_token = undef,
+  $private_key_id = undef,
+  $private_key = undef,
+  $client_email = undef,
+  $client_id = undef,
+  $client_x509_cert_url = undef,
+) {
+
+  file { '/var/lib/jenkins/govuk_navigation_link_analysis/govuk-tagging-monitor-2f614b9b92c2.json':
+    ensure  => present,
+    content => template('govuk_jenkins/google_api/credentials.json.erb'),
+    owner   => 'jenkins',
+    group   => 'jenkins',
+  }
+
+  file { '/etc/jenkins_jobs/jobs/govuk_navigation_link_analysis.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/govuk_navigation_link_analysis.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+}

--- a/modules/govuk_jenkins/templates/google_api/credentials.json.erb
+++ b/modules/govuk_jenkins/templates/google_api/credentials.json.erb
@@ -1,0 +1,12 @@
+{
+  "type": "service_account",
+  "project_id": "govuk-tagging-monitor",
+  "private_key_id": "<%= @private_key_id -%>",
+  "private_key": "<%= @private_key -%>",
+  "client_email": "<%= @client_email -%>",
+  "client_id": "<%= @client_id -%>",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://accounts.google.com/o/oauth2/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "<%= @client_x509_cert_url -%>"
+}

--- a/modules/govuk_jenkins/templates/jobs/govuk_navigation_link_analysis.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/govuk_navigation_link_analysis.yaml.erb
@@ -1,0 +1,31 @@
+---
+- scm:
+    name: govuk_tagging_monitor
+    scm:
+      - git:
+          url: git@github.com:alphagov/govuk-tagging-monitor.git
+          basedir: govuk-tagging-monitor
+          branches:
+            - master
+- job:
+    name: govuk_navigation_link_analysis
+    display-name: govuk-navigation-link-analysis
+    project-type: freestyle
+    description: |
+      Monthly analysis of links displayed in the new navigation pages. The output of
+      this is needed for Performance Analysts to produce reports on how the new
+      navigation is performing.
+    scm:
+      - govuk_tagging_monitor
+    logrotate:
+      numToKeep: 10
+    triggers:
+        - timed: 'H 10 1 * *'
+    builders:
+      - shell: |
+          #!/bin/bash
+          set -eu
+
+          export RATE_LIMIT_TOKEN="<%= @rate_limit_token -%>"
+          bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
+          bundle exec rake analyse:links


### PR DESCRIPTION
The new job runs a monthly analysis of links displayed in the new navigation
pages. The output of this is needed for Performance Analysts to produce reports
on how the new navigation is performing.

The rake tasks needs a credentials JSON file in the root path of the
repository, which will be built and placed in the correct place with
credentials stored in hieradata.

Trello: https://trello.com/c/1qbNKZQ8/128-create-a-script-that-outputs-a-spreadsheet-of-content-url-slugs-within-each-navigation-page

Dependencies:
- [x] https://github.digital.cabinet-office.gov.uk/gds/deployment/pull/1341