### PR TITLE
Fix navigation & tagging checks

### DIFF
--- a/hieradata/class/integration/jenkins.yaml
+++ b/hieradata/class/integration/jenkins.yaml
@@ -16,6 +16,8 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::deploy_terraform_project
   - govuk_jenkins::job::deploy_training
   - govuk_jenkins::job::govuk_cdn_nightly_2xx_status_collection
+  - govuk_jenkins::job::govuk_navigation_link_analysis
+  - govuk_jenkins::job::govuk_tagging_monitor
   - govuk_jenkins::job::launch_vms
   - govuk_jenkins::job::network_config_deploy
   - govuk_jenkins::job::passive_checks

--- a/modules/govuk_jenkins/templates/jobs/govuk_navigation_link_analysis.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/govuk_navigation_link_analysis.yaml.erb
@@ -1,6 +1,6 @@
 ---
 - scm:
-    name: govuk_tagging_monitor
+    name: govuk_tagging_monitor_for_nav
     scm:
       - git:
           url: git@github.com:alphagov/govuk-tagging-monitor.git
@@ -16,7 +16,7 @@
       this is needed for Performance Analysts to produce reports on how the new
       navigation is performing.
     scm:
-      - govuk_tagging_monitor
+      - govuk_tagging_monitor_for_nav
     logrotate:
       numToKeep: 10
     triggers:

--- a/modules/govuk_jenkins/templates/jobs/govuk_tagging_monitor.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/govuk_tagging_monitor.yaml.erb
@@ -1,6 +1,6 @@
 ---
 - scm:
-    name: govuk_tagging_monitor
+    name: govuk_tagging_monitor_repo_for_monitor
     scm:
       - git:
           url: git@github.com:alphagov/govuk-tagging-monitor.git
@@ -15,7 +15,7 @@
       This job checks new navigation pages against a set of rules. This makes
       sure we don't have invalid navigation pages being shown to users.
     scm:
-      - govuk_tagging_monitor
+      - govuk_tagging_monitor_repo_for_monitor
     logrotate:
       numToKeep: 10
     triggers:


### PR DESCRIPTION
It looks like Jenkins is complaining about duplicate `scm` values across jobs:

```
Notice:
/Stage[main]/Govuk_jenkins::Job_builder/Exec[jenkins_jobs_update]/return
s: INFO:root:Updating jobs in ['/etc/jenkins_jobs/jobs/'] ([])
Notice:
/Stage[main]/Govuk_jenkins::Job_builder/Exec[jenkins_jobs_update]/return
s: ERROR:jenkins_jobs.parser:Duplicate entry found in
'/etc/jenkins_jobs/jobs/govuk_navigation_link_analysis.yaml:
'govuk_tagging_monitor' already defined
Notice:
/Stage[main]/Govuk_jenkins::Job_builder/Exec[jenkins_jobs_update]/return
s: Traceback (most recent call last):
```