### PR TITLE
Update nav monitoring jenkins jobs

### DIFF
--- a/modules/govuk_jenkins/manifests/job/govuk_navigation_link_analysis.pp
+++ b/modules/govuk_jenkins/manifests/job/govuk_navigation_link_analysis.pp
@@ -37,7 +37,7 @@ class govuk_jenkins::job::govuk_navigation_link_analysis (
   $client_x509_cert_url = undef,
 ) {
 
-  file { '/var/lib/jenkins/govuk_navigation_link_analysis/govuk-tagging-monitor-2f614b9b92c2.json':
+  file { '/var/lib/jenkins/workspace/govuk_navigation_link_analysis/govuk-tagging-monitor-2f614b9b92c2.json':
     ensure  => present,
     content => template('govuk_jenkins/google_api/credentials.json.erb'),
     owner   => 'jenkins',

--- a/modules/govuk_jenkins/templates/jobs/govuk_navigation_link_analysis.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/govuk_navigation_link_analysis.yaml.erb
@@ -26,6 +26,8 @@
           #!/bin/bash
           set -eu
 
+          cd govuk-tagging-monitor
+          cp ../govuk-tagging-monitor-2f614b9b92c2.json .
           export RATE_LIMIT_TOKEN="<%= @rate_limit_token -%>"
           bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
           bundle exec rake analyse:links

--- a/modules/govuk_jenkins/templates/jobs/govuk_tagging_monitor.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/govuk_tagging_monitor.yaml.erb
@@ -25,6 +25,7 @@
           #!/bin/bash
           set -eu
 
+          cd govuk-tagging-monitor
           export RATE_LIMIT_TOKEN="<%= @rate_limit_token -%>"
           bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
           bundle exec rake run


### PR DESCRIPTION
Since the job name is different than the repo name, we need to `cd` into
the directory before we can run bundler. Furthermore, we need to copy
over the credentials file for google analytics into the repository after
it's cloned in order for the rake tasks to work as expected.

This commit fixes the following issue in the tagging monitor job:

```
rbenv: bundle: command not found

The `bundle' command exists in these Ruby versions:
```

Source:
https://deploy.integration.publishing.service.gov.uk/job/govuk_tagging_monitor/17/console

It also fixes the location of the JSON file (by adding it to the workspace directory), which will fix the following error:

```
Could not set 'present' on ensure: No such file or directory -
/var/lib/jenkins/govuk_navigation_link_analysis/govuk-tagging-monitor-2f614b9b92c2.json
```

When the file is available, the following error in the job itself will be fixed too:

```
Errno::ENOENT: No such file or directory @ rb_sysopen - govuk-tagging-monitor-2f614b9b92c2.json
```

Source:
https://deploy.integration.publishing.service.gov.uk/job/govuk_navigation_link_analysis/1/console

Trello: https://trello.com/c/NyNRDc78/148-add-govuk-tagging-monitor-tasks-to-puppet