### PR TITLE
Remove navigation monitor jobs from integration

### DIFF
--- a/hieradata/class/integration/jenkins.yaml
+++ b/hieradata/class/integration/jenkins.yaml
@@ -16,8 +16,6 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::deploy_terraform_project
   - govuk_jenkins::job::deploy_training
   - govuk_jenkins::job::govuk_cdn_nightly_2xx_status_collection
-  - govuk_jenkins::job::govuk_navigation_link_analysis
-  - govuk_jenkins::job::govuk_tagging_monitor
   - govuk_jenkins::job::launch_vms
   - govuk_jenkins::job::network_config_deploy
   - govuk_jenkins::job::passive_checks


### PR DESCRIPTION
These were added so we could get them setup properly without waiting to
see what happened in production. Now that they are working on
integration, we can remove them to avoid receiving too many alerts.