### PR TITLE
Add scripts to avoid nfs permissions errors on VM

### DIFF
--- a/development-vm/refresh-nfs-cache-on-host.sh
+++ b/development-vm/refresh-nfs-cache-on-host.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+echo "Refreshing host disk cache to fix NFS permissions"
+ls -laR ../../ > /dev/null

--- a/development-vm/refresh-nfs-cache-on-vm.sh
+++ b/development-vm/refresh-nfs-cache-on-vm.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+echo "Refreshing host disk cache to fix NFS permissions"
+find /var/govuk -type d \
+	-exec touch '{}'/.touch ';' \
+	-exec rm -f '{}'/.touch ';' \
+	2>/dev/null

--- a/development-vm/vagrant-up.sh
+++ b/development-vm/vagrant-up.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+./refresh-nfs-cache-on-host.sh
+vagrant up


### PR DESCRIPTION
On macOS 10.12 Sierra it seems that nfs has some issues which means that
the dev VM will get permissions errors because the macOS disk cache is out
of date.  (See: https://github.com/mitchellh/vagrant/issues/8061).

We've written up some help in [the developer docs manual](https://docs.publishing.service.gov.uk/manual/troubleshooting-vagrant.html#permission-denied-errors-on-synced-folders) but we can be more
useful by adding script versions of the advice that you can run.

* `refresh-nfs-cache-on-host.sh` - this script runs on your host and walks
  `../../` to refresh the cache
* `refresh-nfs-cache-on-vm.sh` - this script does something similar on the
  vm, walking `/var/govuk/` instead
* `vagrant-up.sh` - this script runs `refresh-nfs-cache-on-host.sh` and
  then runs `vagrant up` to start the vm

Aside: if this is merged, I'll update the docs mentioned too.