### PR TITLE
Use healthcheck as compound word for consistency

### DIFF
--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -251,7 +251,7 @@ define govuk::app::config (
     if $json_health_check {
       include icinga::client::check_json_healthcheck
 
-      $healthcheck_desc      = "${title} app health check not ok"
+      $healthcheck_desc      = "${title} app healthcheck not ok"
       $healthcheck_opsmanual = regsubst($healthcheck_desc, ' ', '-', 'G')
 
       @@icinga::check { "check_app_${title}_healthcheck_on_${::hostname}":


### PR DESCRIPTION
This is the specialised instance of the "app healthcheck failed" alert
and thus should be consistent in terminology with it.

As for whether we should use "healthcheck" or "health check" across the
board, that's a tough one to solve - inconsistencies are rife.