### PR TITLE
Add vcloud-tools to CI

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -638,6 +638,12 @@ govuk_ci::master::pipeline_jobs:
   transition-config: {}
   ubuntu_unused_kernels:
     repo_owner: 'gds-operations'
+  vcloud-core: {}
+  vcloud-edge_gateway: {}
+  vcloud-launcher: {}
+  vcloud-net_launcher: {}
+  vcloud-tools-tester: {}
+  vcloud-walker: {}
 
 govuk_ci::master::ci_agents:
   ci-agent-1:


### PR DESCRIPTION
It looks as if we're going to have to do some work to fix some critical bugs in the vcloud-tools universe. Adding this to CI will allow us to run tests and publish gems when we release new versions.