### PR TITLE
Upgrade Bundler version to 1.15.0 on ruby 2.3.0

### DIFF
--- a/modules/govuk_rbenv/manifests/all.pp
+++ b/modules/govuk_rbenv/manifests/all.pp
@@ -47,7 +47,7 @@ class govuk_rbenv::all (
   }
 
   rbenv::version { '2.3.0':
-    bundler_version => '1.14.5',
+    bundler_version => '1.15.0',
   }
   rbenv::version { '2.3.1':
     bundler_version => '1.14.5',


### PR DESCRIPTION
This is an attempt to fix the deployment of `bouncer`. At the moment, we
see the following error:

```
There was an error while trying to write to
/home/deploy/.bundle/cache/compact_index/rubygems.org.443.29b0360b937aa4d161703e6160654e47/info.
It is likely that you need to grant write permissions for that path.
There was an error while trying to write to
```

Further discussion in: https://github.com/bundler/bundler/issues/5691

If this works, we should roll-out the latest version of bundler to the
rest of the rubies.