### PR TITLE
Don't attempt to run search tests when integration is off

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -153,6 +153,9 @@ govuk_jenkins::job::network_config_deploy::environments:
 govuk_jenkins::job::deploy_dns::gce_project_id: 'govuk-integration'
 govuk_jenkins::job::deploy_kubernetes::gce_project_id: 'govuk-integration'
 
+govuk_jenkins::job::search_benchmark::cron_schedule: '30 9 * * 1-5'
+govuk_jenkins::job::search_test_spelling_suggestions::cron_schedule: '0 10 * * 1-5'
+
 govuk_jenkins::ssh_key::public_key: 'AAAAB3NzaC1yc2EAAAADAQABAAACAQDQBl40cv64wBa1zEG3dIOwsTTcJsMybZW0nPmCLBqS9/xzv4WoW5VzvID6yrSlg5XfX1Qxq8FmFGIDaAhb1fna2Z05EAC1Jh8EnCSFK8Q6NaUGxlyYoHRD06kZI8ZdAj3Ct8Hsqa0YaWKa/vSIWKIRtboVKm6SMbNxcLwQ04AG2zP2wtnGpyDKBPZol/L3jxVExx1B2lIww0drSKNFKQzM9kijZyAmhu8ocClNl19Rv86q44v0PcDIv5hkW5bEbsavTghnLNXad2dmiSP5Se68NscumyboetuG+o0lOFbFjuHk8NaXklOWiFZxJaJXiOVLihXHVhpDcuXEzwNoOKhYEzA06vHBVXbngBuEsgns/Hgpz4we2H4y4k9w9eJ4rKNhTvrfAzcYzEsnmhbNtQMZaLbqKnWBt2+X6lKTYUBpnUWXwLMaAb5dqEqD+LGiDxcfJ4b6UctSR7+CF29gRChwv0HUO1NdiVzZ2AMrqsYp9QtCWnfNipveGZl9Rqox3JSt4u/+7+I9xw0d8bFp8xCPxan78eMu42i3jNm4qcbbXGvPU6WFP0htjZZ8S0Fq7Dss4AbADrLxwepW8n7E+PozZRjH2P7TgmZ+wQXS6aUNHdgDeYsv5070NYK33wuE2f9GNVuN35/5ImB9PuyxDNSdHIPXTABMOZk7fVQUqXLCRw=='
 
 govuk_mysql::server::slow_query_log: true

--- a/modules/govuk_jenkins/manifests/job/search_benchmark.pp
+++ b/modules/govuk_jenkins/manifests/job/search_benchmark.pp
@@ -6,14 +6,14 @@ class govuk_jenkins::job::search_benchmark (
   $app_domain = hiera('app_domain'),
   $auth_username = undef,
   $auth_password = undef,
-  $rate_limit_token = undef
+  $rate_limit_token = undef,
+  $cron_schedule = '30 4 * * *'
 ) {
 
   $test_type = 'results'
   $job_name = 'search_benchmark'
   $service_description = 'Benchmark search queries'
   $job_url = "https://deploy.${app_domain}/job/search_benchmark/"
-  $cron_schedule = '30 4 * * *'
 
   file { '/etc/jenkins_jobs/jobs/search_benchmark.yaml':
     ensure  => present,

--- a/modules/govuk_jenkins/manifests/job/search_test_spelling_suggestions.pp
+++ b/modules/govuk_jenkins/manifests/job/search_test_spelling_suggestions.pp
@@ -6,14 +6,14 @@ class govuk_jenkins::job::search_test_spelling_suggestions (
   $app_domain = hiera('app_domain'),
   $auth_username = undef,
   $auth_password = undef,
-  $rate_limit_token = undef
+  $rate_limit_token = undef,
+  $cron_schedule = '0 5 * * *'
 ) {
 
   $test_type = 'suggestions'
   $job_name = 'search_test_spelling_suggestions'
   $service_description = 'Check for spelling suggestions'
   $job_url = "https://deploy.${app_domain}/job/search_test_spelling_suggestions/"
-  $cron_schedule = '0 5 * * *'
 
   file { '/etc/jenkins_jobs/jobs/search_test_spelling.yaml':
     ensure  => present,


### PR DESCRIPTION
Integration is generally not available when these tests run, so they
always fail. Allow configuration per environment and move the
integration schedule to a safer time