### PR TITLE
Add pre transition stats key

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -88,8 +88,6 @@ govuk::deploy::setup::ssh_keys:
 govuk_bouncer::gor::enabled: true
 govuk_bouncer::gor::ip_address: '195.225.216.149'
 
-govuk_cdnlogs::transition_logs::enable_cron: true
-
 govuk_jenkins::config::banner_colour_background: '#df3034'
 govuk_jenkins::config::banner_colour_text: 'white'
 govuk_jenkins::config::banner_string: 'Carrenza PRODUCTION'

--- a/modules/govuk_cdnlogs/files/logs_processor_ssh_config
+++ b/modules/govuk_cdnlogs/files/logs_processor_ssh_config
@@ -1,0 +1,7 @@
+Host github.com-transition-stats
+    HostName github.com
+    IdentityFile ~/.ssh/transition_stats_rsa
+
+Host github.com-pre-transition-stats
+    HostName github.com
+    IdentityFile ~/.ssh/pre_transition_stats_rsa

--- a/modules/govuk_cdnlogs/manifests/transition_logs.pp
+++ b/modules/govuk_cdnlogs/manifests/transition_logs.pp
@@ -20,7 +20,8 @@
 #
 class govuk_cdnlogs::transition_logs (
   $log_dir,
-  $private_ssh_key = undef,
+  $transition_stats_private_ssh_key = undef,
+  $pre_transition_stats_private_ssh_key = undef,
   $user = 'logs_processor',
   $enabled = true,
   $enable_cron = false,
@@ -43,16 +44,34 @@ class govuk_cdnlogs::transition_logs (
   }
 
 
-  if $private_ssh_key {
+  if $transition_stats_private_ssh_key and $pre_transition_stats_private_ssh_key {
     $ssh_dir = "/home/${user}/.ssh"
 
-    file { "${ssh_dir}/id_rsa":
+    file { "${ssh_dir}/transition_stats_rsa":
       ensure  => $ensure,
       owner   => $user,
       group   => $user,
       mode    => '0600',
-      content => $private_ssh_key,
+      content => $transition_stats_private_ssh_key,
       require => File[$ssh_dir],
+    }
+
+    file { "${ssh_dir}/pre_transition_stats_rsa":
+      ensure  => $ensure,
+      owner   => $user,
+      group   => $user,
+      mode    => '0600',
+      content => $pre_transition_stats_private_ssh_key,
+      require => File[$ssh_dir],
+    }
+
+    file {"${ssh_dir}/config":
+        ensure  => $ensure,
+        owner   => $user,
+        group   => $user,
+        mode    => '0644',
+        source  => 'puppet:///modules/govuk_cdnlogs/logs_processor_ssh_config',
+        require => Govuk_user[$user],
     }
   }
 

--- a/modules/govuk_cdnlogs/spec/classes/govuk_cdnlogs__transition_log_spec.rb
+++ b/modules/govuk_cdnlogs/spec/classes/govuk_cdnlogs__transition_log_spec.rb
@@ -3,7 +3,8 @@ require_relative '../../../../spec_helper'
 describe 'govuk_cdnlogs::transition_logs', :type => :class do
   let(:default_params) {{
     :log_dir          => '/tmp/logs',
-    :private_ssh_key  => 'my key',
+    :transition_stats_private_ssh_key  => 'transition stats key',
+    :pre_transition_stats_private_ssh_key  => 'pre transition stats key',
     :user             => 'logs_processor',
     :enabled          => true,
     :enable_cron      => true,
@@ -19,8 +20,13 @@ describe 'govuk_cdnlogs::transition_logs', :type => :class do
       })}
     end
 
-    describe 'SSH key' do
-      it { is_expected.to contain_file('/home/logs_processor/.ssh/id_rsa').with_content('my key') }
+    describe 'SSH deploy keys' do
+      it { is_expected.to contain_file('/home/logs_processor/.ssh/transition_stats_rsa').with_content('transition stats key') }
+      it { is_expected.to contain_file('/home/logs_processor/.ssh/pre_transition_stats_rsa').with_content('pre transition stats key') }
+    end
+
+    describe 'ssh config' do
+      it { is_expected.to contain_file('/home/logs_processor/.ssh/config') }
     end
 
     describe 'git config' do


### PR DESCRIPTION
You can only use a deploy key once on Github, which means that a second one needs to be added. This was the behaviour of the original Puppet code, but I incorrectly thought it wasn't required.

The script would not have worked without adding the SSH config either as when it clones the repo for the first time it references the host in that config.

Rather than keeping Puppet disabled on logs-cdn-1, revert the cron job commit and make sure the SSH keys get added correctly to the server and the Github repos. Specifically enable the cron job
again for the migration in the future.

Story: https://trello.com/c/6aRbVzOa/558-organise-migration-for-transition-logs