### PR TITLE
Ensure ~/.bundle/cache exists for users

### DIFF
--- a/modules/govuk_bundler/manifests/config.pp
+++ b/modules/govuk_bundler/manifests/config.pp
@@ -22,6 +22,12 @@ define govuk_bundler::config(
     group  => 'root',
   }
 
+  file { "${user_home}/.bundle/cache":
+    ensure => 'directory',
+    owner  => 'deploy',
+    group  => 'deploy',
+  }
+
   file { "${user_home}/.bundle/config":
     ensure  => 'present',
     owner   => 'root',


### PR DESCRIPTION
When bundler attempts to install gems during deployment, it tries to
create a cache in `/home/deploy/.bundle` and is unable to. The reason
for this is that `/home/deploy/.bundle` belongs to the `root` user.

The error is:

```
There was an error while trying to write to
/home/deploy/.bundle/cache/compact_index/rubygems.org.443.29b0360b937aa4d161703e6160654e47/info.
It is likely that you need to grant write permissions for that path.
```

This could be a bug in `bundler`, but I'm not yet sure. I've opened an
issue with them and I will follow up.

One thing I noticed is that the deployment works if that `cache`
directory is present. I've manually created it for bouncer-1.redirector
and the deployment stopped failing there:

https://deploy.staging.publishing.service.gov.uk/job/Deploy_App/3837/console

This commit makes sure the `cache` directory is present and has the
right permissions. This will allow us to deploy `bouncer`.