### PR TITLE
Use private env-sync-and-backup repo

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
@@ -3,7 +3,7 @@
     name: env-sync-and-backup_Copy_Data_to_Integration
     scm:
         - git:
-            url: git@github.digital.cabinet-office.gov.uk:gds/env-sync-and-backup.git
+            url: git@github.com:alphagov/env-sync-and-backup.git
             branches:
               - master
 
@@ -16,7 +16,7 @@
         to keep the integration environment up to date. The signon database isn't copied.
     properties:
         - github:
-            url: https://github.digital.cabinet-office.gov.uk/gds/env-sync-and-backup/
+            url: https://github.com/alphagov/env-sync-and-backup/
         - inject:
             properties-content: |
               PARALLEL_JOBS=2

--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_staging.yaml.erb
@@ -3,7 +3,7 @@
     name: env-sync-and-backup_Copy_Data_to_Staging
     scm:
         - git:
-            url: git@github.digital.cabinet-office.gov.uk:gds/env-sync-and-backup.git
+            url: git@github.com:alphagov/env-sync-and-backup.git
             branches:
               - master
 
@@ -15,7 +15,7 @@
       their databases copied because several have sensitive data."
     properties:
         - github:
-            url: https://github.digital.cabinet-office.gov.uk/gds/env-sync-and-backup/
+            url: https://github.com/alphagov/env-sync-and-backup/
         - inject:
             properties-content: |
               PARALLEL_JOBS=2

--- a/modules/govuk_jenkins/templates/jobs/copy_licensify_data_to_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_licensify_data_to_staging.yaml.erb
@@ -3,7 +3,7 @@
     name: env-sync-and-backup_Copy_Licensify_Data_to_Staging
     scm:
         - git:
-            url: git@github.digital.cabinet-office.gov.uk:gds/env-sync-and-backup.git
+            url: git@github.com:alphagov/env-sync-and-backup.git
             branches:
               - master
 
@@ -14,7 +14,7 @@
     description: "This job currently copies Licensify MongoDB databases from production to staging"
     properties:
         - github:
-            url: https://github.digital.cabinet-office.gov.uk/gds/env-sync-and-backup/
+            url: https://github.com/alphagov/env-sync-and-backup/
         - inject:
             properties-content: |
               PARALLEL_JOBS=2

--- a/modules/govuk_jenkins/templates/jobs/copy_sanitised_whitehall_database.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_sanitised_whitehall_database.yaml.erb
@@ -3,7 +3,7 @@
     name: env-sync-and-backup_copy_sanitised_whitehall_database
     scm:
         - git:
-            url: git@github.digital.cabinet-office.gov.uk:gds/env-sync-and-backup.git
+            url: git@github.com:alphagov/env-sync-and-backup.git
             branches:
               - master
 
@@ -16,7 +16,7 @@
         to other environments periodically to keep them up to date.
     properties:
         - github:
-            url: https://github.digital.cabinet-office.gov.uk/gds/env-sync-and-backup/
+            url: https://github.com/alphagov/env-sync-and-backup/
     scm:
       - env-sync-and-backup_copy_sanitised_whitehall_database
     logrotate:

--- a/modules/govuk_jenkins/templates/jobs/performance_platform_data_sync.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/performance_platform_data_sync.yaml.erb
@@ -3,7 +3,7 @@
     name: env-sync-and-backup_Performance_Platform_Data_Sync
     scm:
         - git:
-            url: git@github.digital.cabinet-office.gov.uk:gds/env-sync-and-backup.git
+            url: git@github.com:alphagov/env-sync-and-backup.git
             branches:
               - master
 
@@ -15,7 +15,7 @@
         This job copies the Performance Platform database from production to integration.
     properties:
         - github:
-            url: https://github.digital.cabinet-office.gov.uk/gds/env-sync-and-backup/
+            url: https://github.com/alphagov/env-sync-and-backup/
     scm:
       - env-sync-and-backup_Performance_Platform_Data_Sync
     logrotate:

--- a/modules/govuk_jenkins/templates/jobs/whitehall_update_integration_data.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/whitehall_update_integration_data.yaml.erb
@@ -3,7 +3,7 @@
     name: env-sync-and-backup_<%= @job_slug %>
     scm:
         - git:
-            url: git@github.digital.cabinet-office.gov.uk:gds/env-sync-and-backup.git
+            url: git@github.com:alphagov/env-sync-and-backup.git
             branches:
               - master
 


### PR DESCRIPTION
The env-sync-and-backup repository is now in github (rather than GHE).
This updates links to use its new location: https://github.com/alphagov/env-sync-and-backup