### PR TITLE
Update jenkins-cli script

### DIFF
--- a/modules/govuk_jenkins/manifests/cli.pp
+++ b/modules/govuk_jenkins/manifests/cli.pp
@@ -16,8 +16,16 @@
 #   The home directory of the Jenkins install, and where to put the
 #   Jenkins CLI jar.
 #
+# [*jenkins_api_user*]
+#   The user used to authenticate with the Jenkins API.
+
+# [*jenkins_api_token*]
+#   The token used to authenticate with the Jenkins API.
+#
 class govuk_jenkins::cli (
   $jenkins_home = '/var/lib/jenkins',
+  $jenkins_api_user = 'deploy',
+  $jenkins_api_token = '',
 ) {
   require ::govuk_jenkins
 

--- a/modules/govuk_jenkins/manifests/init.pp
+++ b/modules/govuk_jenkins/manifests/init.pp
@@ -26,6 +26,18 @@
 # [*version*]
 #   Specify the version of Jenkins
 #
+# [*jenkins_api_user*]
+#   An API user that authenticates with the Jenkins API.
+#
+# [*jenkins_api_token*]
+#   A token to authenticate with the Jenkins API.
+#
+# [*jenkins_user*]
+#   User that runs the Jenkins service.
+#
+# [*jenkins_homedir*]
+#   Directory that Jenkins is installed into.
+#
 # [*environment_variables*]
 #   A hash of environment variables that should be set for all Jenkins jobs.
 #
@@ -37,6 +49,7 @@ class govuk_jenkins (
   $ssh_private_key = undef,
   $ssh_public_key = undef,
   $version = '1.554.2',
+  $jenkins_api_user = 'deploy',
   $jenkins_api_token = '',
   $jenkins_user = 'jenkins',
   $jenkins_homedir = '/var/lib/jenkins',
@@ -47,6 +60,12 @@ class govuk_jenkins (
   include ::govuk_python
 
   class { 'govuk_jenkins::job_builder':
+    jenkins_api_user  => $jenkins_api_user,
+    jenkins_api_token => $jenkins_api_token,
+  }
+
+  class { 'govuk_jenkins::cli':
+    jenkins_api_user  => $jenkins_api_user,
     jenkins_api_token => $jenkins_api_token,
   }
 
@@ -73,7 +92,6 @@ class govuk_jenkins (
     home_dir     => $jenkins_homedir,
   }
 
-  include ::govuk_jenkins::cli
   include ::govuk_jenkins::github_enterprise_cert
   include ::govuk_jenkins::reload
 

--- a/modules/govuk_jenkins/manifests/job_builder.pp
+++ b/modules/govuk_jenkins/manifests/job_builder.pp
@@ -11,7 +11,7 @@
 # [*environment*]
 #   Specify the environment ({production,staging,integration}). Required by some jobs.
 #
-# [*jenkins_user*]
+# [*jenkins_api_user*]
 #   A username of a user on Jenkins who has permission to create and modify jobs
 #
 # [*jenkins_api_token*]
@@ -34,7 +34,7 @@
 class govuk_jenkins::job_builder (
   $app_domain = hiera('app_domain'),
   $environment = 'development',
-  $jenkins_user = 'deploy',
+  $jenkins_api_user = 'deploy',
   $jenkins_api_token = '',
   $jenkins_url = 'http://localhost:8080/',
   $jobs = [],

--- a/modules/govuk_jenkins/templates/jenkins-cli.erb
+++ b/modules/govuk_jenkins/templates/jenkins-cli.erb
@@ -5,4 +5,4 @@ if [ "$EUID" -ne 0 ]
   exit 1
 fi
 
-/usr/bin/java -jar <%= @jenkins_home %>/jenkins-cli.jar -s http://localhost:8080/ -i <%= @jenkins_home %>/.ssh/id_rsa $1
+/usr/bin/java -jar <%= @jenkins_home %>/jenkins-cli.jar -s http://localhost:8080/ -http -auth <%= @jenkins_api_user %>:<%= @jenkins_api_token %> $1


### PR DESCRIPTION
The latest version of jenkins-cli.jar changed the way in which SSH identity files are used, which caused the following error to be thrown:

`ERROR: anonymous is missing the Overall/Administer permission`

Instead of using the SSH identity option which now explicitly requires enabling an SSH server in Jenkins itself, auth using the API user and token that we already use for Jenkins Job Builder.