### PR TITLE
Change group and owner of bundler related files

### DIFF
--- a/modules/govuk/manifests/deploy/setup.pp
+++ b/modules/govuk/manifests/deploy/setup.pp
@@ -104,5 +104,6 @@ class govuk::deploy::setup (
     server    => $gemstash_server,
     require   => User['deploy'],
     user_home => '/home/deploy',
+    username  => 'deploy',
   }
 }

--- a/modules/govuk_bundler/manifests/config.pp
+++ b/modules/govuk_bundler/manifests/config.pp
@@ -6,7 +6,8 @@
 #
 # [*user_home*]
 #   The home directory of the user to add the config to.
-#   Default: /home/deploy
+# [*username*]
+#   The name of the user where we will add the directories to.
 #
 # [*server*]
 #   The gemstash server to use
@@ -14,24 +15,25 @@
 #
 define govuk_bundler::config(
   $user_home,
+  $username,
   $server = 'http://gemstash.cluster',
 ) {
   file { "${user_home}/.bundle":
     ensure => 'directory',
-    owner  => 'root',
-    group  => 'root',
+    owner  => $username,
+    group  => $username,
   }
 
   file { "${user_home}/.bundle/cache":
     ensure => 'directory',
-    owner  => 'deploy',
-    group  => 'deploy',
+    owner  => $username,
+    group  => $username,
   }
 
   file { "${user_home}/.bundle/config":
     ensure  => 'present',
-    owner   => 'root',
-    group   => 'root',
+    owner   => $username,
+    group   => $username,
     mode    => '0644',
     content => template('govuk_bundler/bundle_config.erb'),
   }

--- a/modules/govuk_bundler/spec/defines/govuk_bundler__config_spec.rb
+++ b/modules/govuk_bundler/spec/defines/govuk_bundler__config_spec.rb
@@ -2,20 +2,47 @@ require_relative '../../../../spec_helper'
 
 describe 'govuk_bundler::config', :type => :define do
   let(:title) { 'bundler-test' }
-  let(:params) {{ :user_home => '/home/deploy' }}
+  let(:params) do
+    {
+      user_home: '/home/deploy',
+      username: 'deploy-user',
+    }
+  end
 
   it { is_expected.to compile }
 
   it { is_expected.to compile.with_all_deps }
 
-  it { is_expected.to contain_file('/home/deploy/.bundle').with_ensure('directory') }
+  it {
+    is_expected.to contain_file('/home/deploy/.bundle').with(
+      ensure: 'directory',
+      owner: 'deploy-user',
+      group: 'deploy-user',
+    )
+  }
 
-  it { is_expected.to contain_file('/home/deploy/.bundle/config').with_content(/BUNDLE_MIRROR__HTTPS:\/\/RUBYGEMS\.ORG: http:\/\/gemstash\.cluster\//) }
+  it {
+    is_expected.to contain_file('/home/deploy/.bundle/cache').with(
+      ensure: 'directory',
+      owner: 'deploy-user',
+      group: 'deploy-user',
+    )
+  }
+
+  it {
+    is_expected.to contain_file('/home/deploy/.bundle/config').with(
+      content: /BUNDLE_MIRROR__HTTPS:\/\/RUBYGEMS\.ORG: http:\/\/gemstash\.cluster\//,
+      owner: 'deploy-user',
+      group: 'deploy-user',
+      mode: '0644',
+    )
+  }
 
   context 'with non-default params' do
     let(:params) { {
       :user_home => '/why/not/here',
-      :server => 'http://www.example.com:4224',
+      :username  => 'user',
+      :server    => 'http://www.example.com:4224',
     } }
     it { is_expected.to contain_file('/why/not/here/.bundle/config').with_content(/BUNDLE_MIRROR__HTTPS:\/\/RUBYGEMS\.ORG: http:\/\/www\.example\.com:4224\//) }
   end

--- a/modules/govuk_ci/manifests/agent.pp
+++ b/modules/govuk_ci/manifests/agent.pp
@@ -59,6 +59,7 @@ class govuk_ci::agent(
 
   govuk_bundler::config {'jenkins-bundler':
     server    => $gemstash_server,
+    username  => 'jenkins',
     user_home => '/var/lib/jenkins',
   }
 }


### PR DESCRIPTION
This commit makes sure it's the user that owns all bundler related
directory and files in `/home/<user>`. This means bundler will have
the right permissions to create files as needed.

This is a follow up from trying to deploy `bouncer`.