### PR TITLE
Increase logspout restarts to 16

### DIFF
--- a/modules/govuk_docker/manifests/logspout.pp
+++ b/modules/govuk_docker/manifests/logspout.pp
@@ -42,7 +42,7 @@ class govuk_docker::logspout (
     env              => [$tag_env],
     volumes          => ['/var/run/docker.sock:/var/run/docker.sock'],
     command          => "logstash+tls://${endpoint}",
-    extra_parameters => ['--restart=on-failure:3'],
+    extra_parameters => ['--restart=on-failure:16'],
   }
 
   @@icinga::check { "check_logspout_running_${::hostname}":


### PR DESCRIPTION
The logspout container (used for sending docker logs to logit.io) will
stop if its TCP connection breaks. Currently docker will only attempt to
restart the container 3 times. This increases the retry count to 16
which should reduce alerts on this.