### PR TITLE
Fix virus scan wait time alert being UNKNOWN

### DIFF
--- a/modules/govuk/manifests/node/s_asset_master.pp
+++ b/modules/govuk/manifests/node/s_asset_master.pp
@@ -92,7 +92,7 @@ class govuk::node::s_asset_master (
   }
 
   @@icinga::check::graphite { "check_uploads_scan_waiting_time_${::hostname}":
-    target    => 'stats.timers.govuk.app.asset-master.scan-queue.upper_90',
+    target    => 'transformNull(stats.timers.govuk.app.asset-master.scan-queue.upper_90, 0)',
     warning   => 1200,
     critical  => 2400,
     desc      => 'Waiting time to pass virus scan',


### PR DESCRIPTION
When there’s no data for the virus scan queue time, the alert goes into
an UNKNOWN state due to a lack of data points. As this is a latency
graph, the correct value for no data points should be 0. Wrapping the
metric in `transformNull` converts null to 0.