### PR TITLE
Automatically restart apps at memory warning

### DIFF
--- a/modules/monitoring/files/usr/local/bin/event_handlers/govuk_app_high_memory.sh
+++ b/modules/monitoring/files/usr/local/bin/event_handlers/govuk_app_high_memory.sh
@@ -19,6 +19,7 @@ case "${SERVICESTATE}" in
         ;;
       HARD)
         logger --tag govuk_icinga_event_handler "Restarting app ${APPNAME} on ${HOSTADDRESS} because it's using too much memory"
+        echo -n "govuk.app.${APPNAME}.memory_restarts:1|c" > /dev/udp/localhost/8125
         /usr/lib/nagios/plugins/check_nrpe -H ${HOSTADDRESS} -c reload_service -a ${APPNAME}
         ;;
     esac

--- a/modules/monitoring/files/usr/local/bin/event_handlers/govuk_app_high_memory.sh
+++ b/modules/monitoring/files/usr/local/bin/event_handlers/govuk_app_high_memory.sh
@@ -13,7 +13,7 @@ case "${SERVICESTATE}" in
   OK)
     # Service just came back up, so don't do anything
     ;;
-  CRITICAL)
+  WARNING)
     case "${SERVICESTATETYPE}" in
       SOFT)
         ;;


### PR DESCRIPTION
This used to be restarted at Critical, but this still leaves noise on
Icinga. The suggestion from Stephen Harker was to instead restart at
Warning level, then if it gets to Critical it’s something for us to
actually worry about and action.