### PR TITLE
Add read-only publishing-api as dependency

### DIFF
--- a/development-vm/Pinfile
+++ b/development-vm/Pinfile
@@ -15,7 +15,7 @@ process :'collections-publisher' => [:'publishing-api', :rummager, :'collections
 process :'collections-publisher-worker'
 process :'contacts-admin' => [:rummager, :'publishing-api', :whitehall]
 process :contentapi => [:imminence, 'asset-manager']
-process :'content-performance-manager' => [:'publishing-api', :'content-performance-manager-sidekiq']
+process :'content-performance-manager' => [:'publishing-api-read', :'content-performance-manager-sidekiq']
 process :'content-store'
 # Example usage: bowl [your-app] dummy-content-store --without content-store
 process :'dummy-content-store'
@@ -54,12 +54,13 @@ process :need_api
 process :'performanceplatform-admin' => [:stagecraft]
 process :'policy-publisher' => [:'publishing-api', :rummager]
 process :publisher => [:'publishing-api', 'publisher-worker', :calendars] # for some requests also uses: mapit
-process :'publishing-api' => [:'content-store', :'draft-content-store', :'router-api', :'draft-router-api', :'publishing-api-worker']
+process :'publishing-api-read' => [:'publishing-api-web']
+process :'publishing-api' => [:'publishing-api-web', :'content-store', :'draft-content-store', :'router-api', :'draft-router-api', :'publishing-api-worker']
 process :'publishing-api-worker' => [:'content-store', :'router-api']
 process :release
 process :router
 process :'router-api'
-process :rummager => [:'publishing-api', :'rummager-sidekiq', :'rummager-publishing-listener']
+process :rummager => [:'publishing-api-read', :'rummager-sidekiq', :'rummager-publishing-listener']
 process :'rummager-sidekiq'
 process :'rummager-publishing-listener'
 process :screenshot_as_a_service

--- a/development-vm/Procfile
+++ b/development-vm/Procfile
@@ -95,7 +95,7 @@ email-alert-service:   govuk_setenv email-alert-service   ./run_in.sh ../../emai
 government-frontend:   govuk_setenv government-frontend   ./run_in.sh ../../government-frontend bundle exec rails server -p 3090
 # sidekiq-monitoring for rummager uses port 3091
 # courts-api used port 3092
-publishing-api:        govuk_setenv publishing-api        ./run_in.sh ../../publishing-api bundle exec rails server -p 3093
+publishing-api-web:    govuk_setenv publishing-api        ./run_in.sh ../../publishing-api bundle exec rails server -p 3093
 publishing-api-worker: govuk_setenv publishing-api        ./run_in.sh ../../publishing-api bundle exec sidekiq -C ./config/sidekiq.yml
 # email-alert-monitor used port 3094
 # courts-frontend used port 3095
@@ -149,7 +149,7 @@ draft-router-api:            govuk_setenv draft-router-api            ./run_in.s
 # grafana has reserved port 3204
 # manuals-publisher has reserved port 3205
 # sidekiq-monitoring for content-performance-manager uses port 3207
-content-performance-manager:          govuk_setenv content-performance-manager ./run_in.sh ../../content-performance-manager bundle exec rails server -p 3206
+content-performance-manager:      govuk_setenv content-performance-manager ./run_in.sh ../../content-performance-manager bundle exec rails server -p 3206
 content-performance-manager-sidekiq:  govuk_setenv content-performance-manager ./run_in.sh ../../content-performance-manager bundle exec sidekiq -C ./config/sidekiq.yml
 # sidekiq-monitoring for link-checker-api-sidekiq uses port 3209
 link-checker-api:                     govuk_setenv link-checker-api            ./run_in.sh ../../link-checker-api bundle exec rails server -p 3208


### PR DESCRIPTION
Rummager and content performance manager only use publishing-api to read data. This adds a `publishing-api-read` process, which only starts the web frontend. This means the applications lose content-store, draft-content-store, router-api, draft-router-api and publishing-api-worker as dependencies. This translates into less dependencies for frontends like finder-frontend as well, since they also rely on rummager.

## Before

```
$ bowl content-performance-manager --output-only
content-store
draft-content-store
router-api
draft-router-api
publishing-api-worker
publishing-api
content-performance-manager-sidekiq
content-performance-manager
```

## After

```
vagrant@development:~/govuk/govuk-puppet/development-vm$ bowl content-performance-manager --output-only
publishing-api-web
publishing-api-read
content-performance-manager-sidekiq
content-performance-manager
```