### PR TITLE
Rearrange disk ordering on asset-slave-1.integration

### DIFF
--- a/hieradata/node/asset-slave-1.backend.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/asset-slave-1.backend.integration.publishing.service.gov.uk.yaml
@@ -2,10 +2,10 @@
 lv:
   data:
     pv:
+      - '/dev/sdb1'
       - '/dev/sdc1'
-      - '/dev/sdd1'
     vg: 'uploads'
   cache:
     pv:
-      - '/dev/sda1'
+      - '/dev/sdd1'
     vg: 'duplicity'


### PR DESCRIPTION
After rebooting, the disks are now in a different order and Puppet is failing. In the short term, this will fix Puppet.
What would be better is to uniquely identify the underlying 'disk' and assign the PVs to those but I'm not sure this is possible in a VMware environment