### PR TITLE
Don't phone for travel advice when GitHub errors

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/travel_advice_email_alert_check.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/travel_advice_email_alert_check.yaml.erb
@@ -27,6 +27,10 @@
           regexp: "Could not read from remote repository"
           also-check-console-output: true
           unstable-if-found: true
+      - text-finder:
+          regexp: "The remote end hung up unexpectedly"
+          also-check-console-output: true
+          unstable-if-found: true
       - trigger-parameterized-builds:
         - project: Success_Passive_Check
           condition: 'SUCCESS'


### PR DESCRIPTION
https://github.com/alphagov/govuk-puppet/commit/06ec702fe0a560102f8bdf9195304975368f463c introduced a condition to make sure that we don't wake people up when GitHub is down and the repo can't be checked out. But a GitHub outage last night manifested itself with a [different error][error]:

```
remote: Compressing objects: 100% (14/14), done.
fatal: The remote end hung up unexpectedly
fatal: protocol error: bad pack header
```

This commit should make Jenkins also ignore those errors.

@sihugh :sleeping: 

[error]:
https://deploy.publishing.service.gov.uk/job/travel-advice-email-alert-check/38681/console