### PR TITLE
Enable cron job for transition logs

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -88,6 +88,8 @@ govuk::deploy::setup::ssh_keys:
 govuk_bouncer::gor::enabled: true
 govuk_bouncer::gor::ip_address: '195.225.216.149'
 
+govuk_cdnlogs::transition_logs::enable_cron: true
+
 govuk_jenkins::config::banner_colour_background: '#df3034'
 govuk_jenkins::config::banner_colour_text: 'white'
 govuk_jenkins::config::banner_string: 'Carrenza PRODUCTION'


### PR DESCRIPTION
This is the last step in the migration of transition logs.