### PR TITLE
Change the healthcheck endpoint for Content API

### DIFF
--- a/modules/govuk/manifests/apps/contentapi.pp
+++ b/modules/govuk/manifests/apps/contentapi.pp
@@ -63,7 +63,7 @@ class govuk::apps::contentapi (
   govuk::app { 'contentapi':
     app_type               => 'rack',
     port                   => $port,
-    health_check_path      => '/vat-rates.json',
+    health_check_path      => '/healthcheck',
     log_format_is_json     => true,
     nginx_extra_config     => 'proxy_set_header API-PREFIX $http_api_prefix;',
     nagios_memory_warning  => $nagios_memory_warning,


### PR DESCRIPTION
The endpoint `/vat-rates.json` no longer exists, so we need to change
the healthcheck endpoint for now until we turn this app off.

Trello: https://trello.com/c/2MF97xce/154-retire-content-api