### PR TITLE
Small changes for transition logs

### DIFF
--- a/modules/cron/manifests/crondotdee.pp
+++ b/modules/cron/manifests/crondotdee.pp
@@ -35,6 +35,10 @@
 #   Example would be a user or an email address, or use an empty string to
 #   suppress mailing any output.
 #
+# [*path*]
+#   Set an environment path to load for the cron job
+#   eg '/usr/bin:/usr/local/bin'
+#
 # [*ensure*]
 #   Ensure the file is created. Set to 'absent' to remove the cron job if it is
 #   no longer required.
@@ -48,6 +52,7 @@ define cron::crondotdee (
   $weekday = '*',
   $user = 'root',
   $mailto = undef,
+  $path = undef,
   $ensure = 'present',
 ) {
   file { "/etc/cron.d/${title}":

--- a/modules/cron/templates/etc/cron.d/crondotdee.erb
+++ b/modules/cron/templates/etc/cron.d/crondotdee.erb
@@ -1,4 +1,8 @@
+# This file is managed by Puppet
 <% unless @mailto.nil? || @mailto.empty? %>
 MAILTO=<%= @mailto %>
+<% end %>
+<% unless @path.nil? || @path.empty? %>
+PATH=<%= @path %>
 <% end %>
 <%= @minute %> <%= @hour %> <%= @day %> <%= @month %> <%= @weekday %> <%= @user %> <%= @command %>

--- a/modules/govuk_cdnlogs/manifests/init.pp
+++ b/modules/govuk_cdnlogs/manifests/init.pp
@@ -118,6 +118,12 @@ class govuk_cdnlogs (
     }
   }
 
+  # The scripts used by transition logs need to be able to write to the directory.
+  file { $log_dir:
+    ensure => directory,
+    mode   => '0775',
+  }
+
   class { '::govuk_cdnlogs::transition_logs':
     log_dir => $log_dir,
   }

--- a/modules/govuk_cdnlogs/manifests/transition_logs.pp
+++ b/modules/govuk_cdnlogs/manifests/transition_logs.pp
@@ -108,6 +108,7 @@ class govuk_cdnlogs::transition_logs (
       hour    => '*',
       minute  => '30',
       user    => $user,
+      path    => '/usr/lib/rbenv/shims:/usr/sbin:/usr/bin:/sbin:/bin',
       require => File[$process_script],
     }
   }

--- a/modules/govuk_cdnlogs/templates/etc/logrotate.cdn_logs_hourly.conf.erb
+++ b/modules/govuk_cdnlogs/templates/etc/logrotate.cdn_logs_hourly.conf.erb
@@ -4,6 +4,7 @@
 -%>
 
 {
+  su root deploy
   rotate 720
   dateext
   dateformat -%Y%m%d-%s

--- a/modules/govuk_cdnlogs/templates/etc/logrotate.d/cdnlogs.erb
+++ b/modules/govuk_cdnlogs/templates/etc/logrotate.d/cdnlogs.erb
@@ -9,6 +9,7 @@ to_rotate_daily.map { |name| "#{ @log_dir }/cdn-#{ name }.log" }.join("\n")
 -%>
 
 {
+  su root deploy
   rotate 30
   daily
   dateext

--- a/modules/govuk_jenkins/templates/jobs/transition_load_transition_stats_hits.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/transition_load_transition_stats_hits.yaml.erb
@@ -17,4 +17,4 @@
             mkdir data
             git clone --depth 1 git@github.com:alphagov/transition-stats.git data/transition-stats
             rsync --delete -avz -e ssh data/transition-stats deploy@backend-1.backend:/var/apps/transition/data
-            ssh deploy@backend-1.backend "cd /var/apps/transition && govuk_setenv transition bundle exec rake import:hits[data/transition-stats/hits/cdn_*]"
+            ssh deploy@backend-1.backend "cd /var/apps/transition && govuk_setenv transition bundle exec rake import:hits[data/transition-stats/hits/logs_cdn_*]"


### PR DESCRIPTION
This has a couple of changes to finish off the transition logs migration:

 - directory permissions: there was a race condition where logrotate is required  to process the logs on an hourly basis, but refused to do that with insecure permissions, and the script required these insecure permissions to `touch` a file in the directory after it had finished processing.
 - update Jenkins job to load the right data