### PR TITLE
Remove default Route53 Zone Id

### DIFF
--- a/modules/govuk_jenkins/manifests/job/deploy_dns.pp
+++ b/modules/govuk_jenkins/manifests/job/deploy_dns.pp
@@ -20,15 +20,12 @@
 # [*gce_credential_id*]
 #   Jenkins credential ID that stores the Gcloud account.
 #
-# [*route53_zone_id*]
-#   ID of the route53 DNS zone to upload to
 #
 class govuk_jenkins::job::deploy_dns (
   $dyn_customer_name = undef,
   $dyn_zone_id = undef,
   $gce_project_id = undef,
   $gce_credential_id = undef,
-  $route53_zone_id = undef,
 ) {
 
   contain '::govuk_jenkins::packages::terraform'

--- a/modules/govuk_jenkins/templates/jobs/deploy_dns.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_dns.yaml.erb
@@ -54,7 +54,7 @@
             description: This is required for all providers
         - string:
             name: ROUTE53_ZONE_ID
-            default: <%= @route53_zone_id %>
+            description: Which AWS Route53 zone to deploy to
         - string:
             name: GOOGLE_REGION
             description: See available zones https://cloud.google.com/compute/images/zones_diagram.svg


### PR DESCRIPTION
Providing a default made sense when we only managed a single zone but
now that we manage multile zones using this system it risks over-writing
values.