### PR TITLE
Fix the task that archives publishing-api events

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/publishing_api_archive_events.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/publishing_api_archive_events.yaml.erb
@@ -4,14 +4,9 @@
     display-name: Publishing_API_Archive_Events
     project-type: freestyle
     description: "This job periodically archives publishing API events to S3"
+    builders:
+      - shell: ssh deploy@$(govuk_node_list -c publishing_api --single-node) "cd /var/apps/publishing-api && govuk_setenv publishing-api bundle exec rake events:export_to_s3"
     logrotate:
       numToKeep: 10
-    publishers:
-        - trigger-parameterized-builds:
-          - project: run-rake-task
-            predefined-parameters: |
-              TARGET_APPLICATION=publishing-api
-              MACHINE_CLASS=publishing_api
-              RAKE_TASK=events:export_to_s3
     triggers:
         - timed: 'H 5 * * 0'

--- a/modules/govuk_jenkins/templates/jobs/publishing_api_archive_events.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/publishing_api_archive_events.yaml.erb
@@ -11,7 +11,7 @@
           - project: run-rake-task
             predefined-parameters: |
               TARGET_APPLICATION=publishing-api
-              MACHINE_CLASS=backend
+              MACHINE_CLASS=publishing_api
               RAKE_TASK=events:export_to_s3
     triggers:
         - timed: 'H 5 * * 0'

--- a/modules/govuk_jenkins/templates/jobs/publishing_api_archive_events.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/publishing_api_archive_events.yaml.erb
@@ -10,3 +10,7 @@
       numToKeep: 10
     triggers:
         - timed: 'H 5 * * 0'
+    publishers:
+        - email:
+            recipients: 2nd-line-support@digital.cabinet-office.gov.uk
+            send-to-individuals: true


### PR DESCRIPTION
The publishing-api was moved to its own machines recently, so this task
stopped working. The first failure was here:

https://deploy.publishing.service.gov.uk/job/run-rake-task/1162/

@kevindew 