### PR TITLE
Update ssh_config guidance

### DIFF
--- a/development-vm/README.md
+++ b/development-vm/README.md
@@ -117,42 +117,11 @@ Your pull request from earlier will hopefully have been merged by now. It's time
 
 > If you're not in the office right now, you'll need to be connected to the Aviation House VPN for SSH access to Integration.
 
-While the applications are available directly via the public internet, SSH access to the environment is via a ‘jumpbox’. You’ll need to configure your machine to use this jumpbox, using this example SSH config file:
-
-```
-Host *
-  UseRoaming no
-
-Host *.integration
-    IdentityFile ~/.ssh/alphagov
-    User $USERNAME
-
-# Integration
-# -------
-Host jumpbox.integration.publishing.service.gov.uk
-  ProxyCommand none
-
-Host *.integration.publishing.service.gov.uk
-  ProxyCommand ssh -e none %r@jumpbox.integration.publishing.service.gov.uk -W %h:%p
-
-Host jumpbox-1.management.integration
-  Hostname jumpbox.integration.publishing.service.gov.uk
-  ProxyCommand none
-
-Host jumpbox-2.management.integration
-  Hostname jumpbox.integration.publishing.service.gov.uk
-  Port     1022
-  ProxyCommand none
-
-Host *.integration
-  ProxyCommand ssh -e none %r@jumpbox-1.management.integration -W $(echo %h | sed 's/\.integration$//'):%p
-```
-
-Copy that into the `~/.ssh/config` file on your mac, substituting your username for `$USERNAME`. You should then be able to ssh into any box in the Integration environment directly. Test that it works, by running:
+While the applications are available directly via the public internet, SSH access to remote environments is via a ‘jumpbox’. You’ll need to configure your machine to use this jumpbox using the [example SSH config file](https://github.com/alphagov/govuk-puppet/blob/master/development-vm/ssh_config). Copy the file into the `~/.ssh/config` file on your host machine. You should then be able to ssh into any box in the Integration environment directly. Test that it works, by running:
 
     mac$ ssh backend-1.backend.integration
 
-Next, create an ssh config file inside the VM with the same contents. You can choose whether to import your `alphagov` keypair to the VM or to use the built in key-forwarding. If you choose the latter, then remove the `IdentityFile` declaration. Test that you can reach Integration from your VM:
+Next, create an ssh config file inside the VM with the same contents. You can choose whether to import your `alphagov` keypair to the VM or to use the built in key-forwarding. Test that you can reach Integration from your VM:
 
     dev$ ssh backend-1.backend.integration
 


### PR DESCRIPTION
This commit updates the guidance on setting up and using `ssh_config` to point to the file in this repository rather than reiterating its contents (which is prone to becoming out-of-date).