### PR TITLE
Update owner permissions

### DIFF
--- a/modules/govuk_cdnlogs/manifests/init.pp
+++ b/modules/govuk_cdnlogs/manifests/init.pp
@@ -121,6 +121,8 @@ class govuk_cdnlogs (
   # The scripts used by transition logs need to be able to write to the directory.
   file { $log_dir:
     ensure => directory,
+    owner  => 'root',
+    group  => 'deploy',
     mode   => '0775',
   }
 


### PR DESCRIPTION
I also needed to update the group permissions after 5ac368aeef10581160d1240293baebfe44b371e5, as it needs to be writeable by anyone in the "deploy" group for the script to correctly `touch` files after successfully processing the data.