### PR TITLE
Update list of upstream servers

### DIFF
--- a/modules/govuk/manifests/apps/publicapi.pp
+++ b/modules/govuk/manifests/apps/publicapi.pp
@@ -7,7 +7,6 @@ class govuk::apps::publicapi (
 
   $app_domain = hiera('app_domain')
 
-  $privateapi = "contentapi.${app_domain}"
   $whitehallapi = "whitehall-frontend.${app_domain}"
   $rummager_api = "search.${app_domain}"
   $content_store_api = "content-store.${app_domain}"
@@ -24,7 +23,7 @@ class govuk::apps::publicapi (
   $full_domain = "${app_name}.${app_domain}"
 
   nginx::config::vhost::proxy { $full_domain:
-    to               => [$privateapi],
+    to               => [$whitehallapi, $rummager_api, $content_store_api],
     to_ssl           => $privateapi_ssl,
     protected        => false,
     ssl_only         => false,


### PR DESCRIPTION
### Background

`publicapi` is an nginx vhost that proxies requests to the content store, search, whitehall and content api. Since the content api is being retired, we no longer should have it mentioned here. The issue is that the only upstream server being listed here was the content api server.

### Changes

- remove the `contentapi` upstream;
- add all other relevant upstream servers to the list.

This has been tested on integration, after puppet ran on both lb boxes.

Trello: https://trello.com/c/2MF97xce/154-retire-content-api