### PR TITLE
Update healthcheck path for calculators app

### DIFF
--- a/modules/govuk/manifests/apps/calculators.pp
+++ b/modules/govuk/manifests/apps/calculators.pp
@@ -19,7 +19,7 @@ class govuk::apps::calculators(
   govuk::app { 'calculators':
     app_type              => 'rack',
     port                  => $port,
-    health_check_path     => '/child-benefit-tax-calculator',
+    health_check_path     => '/child-benefit-tax-calculator/main',
     log_format_is_json    => true,
     asset_pipeline        => true,
     asset_pipeline_prefix => 'calculators',


### PR DESCRIPTION
This commit updates the healthcheck path for the calculators app by appending `/main` to the path to match the changes made in https://github.com/alphagov/calculators/pull/188.