### PR TITLE
Add basic auth for performance endpoints in integration

### DIFF
--- a/modules/router/templates/fragments/_basic_auth.erb
+++ b/modules/router/templates/fragments/_basic_auth.erb
@@ -1,0 +1,8 @@
+  <%- if @vhost_protected -%>
+
+      deny all;
+      auth_basic            "Enter the GOV.UK username/password (not your personal username/password)";
+      auth_basic_user_file  /etc/govuk.htpasswd;
+      satisfy any;
+
+  <%- end -%>

--- a/modules/router/templates/router_include.conf.erb
+++ b/modules/router/templates/router_include.conf.erb
@@ -47,6 +47,8 @@ location ~ ^/apply-for-a-licence/assets/ {
 }
 
 location ~ ^/performance/ {
+  <%= scope.function_template(['router/fragments/_basic_auth.erb']) -%>
+
   limit_req zone=performance burst=10 nodelay;
   proxy_pass http://varnish;
 }
@@ -59,14 +61,7 @@ location ~ ^/contact/govuk/(|service-feedback|problem_reports|foi|page_improveme
 }
 
 location / {
-  <%- if @vhost_protected -%>
-
-      deny all;
-      auth_basic            "Enter the GOV.UK username/password (not your personal username/password)";
-      auth_basic_user_file  /etc/govuk.htpasswd;
-      satisfy any;
-
-  <%- end -%>
+  <%= scope.function_template(['router/fragments/_basic_auth.erb']) -%>
 
   # HTML verification for DWP YouTube channel
   location = /dla-ending/google6db9c061ce178960.html {


### PR DESCRIPTION
Current `https://www-origin.integration.publishing.service.gov.uk/performance/`
requires basic auth but
`https://www-origin.integration.publishing.service.gov.uk/performance/about`
does not.