### PR TITLE
Poke the deployment dashboards

### DIFF
--- a/modules/grafana/templates/dashboards/deployment_dashboard_template.json.erb
+++ b/modules/grafana/templates/dashboards/deployment_dashboard_template.json.erb
@@ -50,8 +50,8 @@
     <% end %>
   ],
   "time": {
-    "from": "now/d",
-    "to": "now/d"
+    "from": "now-1h",
+    "to": "now"
   },
   "timepicker": {
     "refresh_intervals": [
@@ -99,7 +99,7 @@
       }
     ]
   },
-  "refresh": "1m",
+  "refresh": "5s",
   "schemaVersion": 12,
   "version": 31,
   "links": [],


### PR DESCRIPTION
As an impatient deployer of things
I want to get fast feedback on the things that I deploy
So that I can take the appropriate action more promptly

I loooove these deployment dashboards, but I always find myself tweaking the
time and refresh intervals.  I haven't got time for a 1 minute refresh rate
when I'm deploying.

Also, I want more focus on the time around my deploy.  Having "today" as the
timescale means that we could be displaying between 9.5 hours and 17 hours of
metrics, most of which is fairly irrelevant to the user.  I usually tweak it to
be the last 30 mins, but 1 hour is also OK.