### PR TITLE
Update health check path for licence-finder

### DIFF
--- a/modules/govuk/manifests/apps/licencefinder.pp
+++ b/modules/govuk/manifests/apps/licencefinder.pp
@@ -39,7 +39,7 @@ class govuk::apps::licencefinder(
   govuk::app { $app_name:
     app_type              => 'rack',
     port                  => $port,
-    health_check_path     => '/licence-finder',
+    health_check_path     => '/licence-finder/sectors',
     log_format_is_json    => true,
     asset_pipeline        => true,
     asset_pipeline_prefix => 'licencefinder',


### PR DESCRIPTION
The licence finder start page is becoming a transaction start page served by frontend.

* Check a page that will continue to be served by licence-finder

(similar to https://github.com/alphagov/govuk-puppet/pull/6028)

Part of: https://trello.com/c/zboJadd9/409-3-republish-licence-finder-start-page-as-a-transaction-page-and-remove-hardcoded-version

@binaryberry 