### PR TITLE
Update Jenkins Job Builder template

### DIFF
--- a/modules/govuk_jenkins/templates/jenkins_jobs.ini.erb
+++ b/modules/govuk_jenkins/templates/jenkins_jobs.ini.erb
@@ -1,5 +1,5 @@
 [jenkins]
-user=<%= @jenkins_user %>
+user=<%= @jenkins_api_user %>
 password=<%= @jenkins_api_token %>
 url=<%= @jenkins_url %>
 


### PR DESCRIPTION
The template used the incorrect variable that was being set in a different class. It should use the variable that gets passed into the Govuk_jenkins::Job_builder class.