### PR TITLE
Add database credentials to Collections Publisher module

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -239,6 +239,7 @@ govuk::apps::bouncer::nagios_memory_critical: 1500
 govuk::apps::collections::nagios_memory_warning: 900
 govuk::apps::collections::nagios_memory_critical: 1000
 
+govuk::apps::collections_publisher::db_hostname: "mysql-master-1.backend"
 govuk::apps::collections_publisher::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::collections_publisher::redis_port: "%{hiera('sidekiq_port')}"
 

--- a/hieradata/vagrant_credentials.yaml
+++ b/hieradata/vagrant_credentials.yaml
@@ -26,6 +26,7 @@ collectd::plugin::postgresql::password: 'password'
 govuk::apps::authenticating_proxy::errbit_api_key: '1234567812345678'
 govuk::apps::bouncer::postgresql_role::password: 'sKnvsmsAEeviNNl3Ded90NzxoT7eFI6Qd1cOVmaA'
 govuk::apps::collections_publisher::db::mysql_password: 'BeDrefCoopdevAynhagmimUmdicuvKas'
+govuk::apps::collections_publisher::db_password: "%{hiera('govuk::apps::collections_publisher::db::mysql_password')}"
 govuk::apps::contacts::db::mysql_contacts_frontend: 'DfM7oUW8Hsn9g23WZW3Hvv4wmr69deQX'
 govuk::apps::contacts::db::mysql_contacts_admin: 'DO7910Lz5ohJukmnvC6GrN3e4jtUP82l'
 govuk::apps::content_performance_manager::db_password: "%{hiera('govuk::apps::content_performance_manager::db::password')}"


### PR DESCRIPTION
This adds database credentials to the Collections Publisher module so that they can be configured as environmental variables and not (as they are currently) as a deployed configuration file.

See https://12factor.net/config and https://trello.com/c/hjzBXsqL