### PR TITLE
Run link analysis task every Monday

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/govuk_navigation_link_analysis.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/govuk_navigation_link_analysis.yaml.erb
@@ -20,7 +20,7 @@
     logrotate:
       numToKeep: 10
     triggers:
-        - timed: 'H 10 1 * *'
+        - timed: 'H 0 * * MON'
     builders:
       - shell: |
           #!/bin/bash


### PR DESCRIPTION
This change updates the link analysis task to run weekly, every Monday at roughly midnight, instead of monthly.

### Trello

https://trello.com/c/tyBA9uGn/233-change-tagging-monitor-monthly-export-to-weekly