### PR TITLE
Update integration asset slave disks

### DIFF
--- a/hieradata/node/asset-slave-1.backend.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/asset-slave-1.backend.integration.publishing.service.gov.uk.yaml
@@ -2,10 +2,10 @@
 lv:
   data:
     pv:
-      - '/dev/sdb1'
       - '/dev/sdc1'
+      - '/dev/sdd1'
     vg: 'uploads'
   cache:
     pv:
-      - '/dev/sdd1'
+      - '/dev/sda1'
     vg: 'duplicity'


### PR DESCRIPTION
Upon reboot the disks changed their labels so that the Puppet is incorrect for managing the LVM volumes. You can find the correct arrangement by running `pvscan`:

```
lauramartin@integration-asset-slave-1:~$ sudo pvs
  PV         VG        Fmt  Attr PSize   PFree
  /dev/sda1  duplicity lvm2 a--   45.00g    0
  /dev/sdb2  os        lvm2 a--   49.52g    0
  /dev/sdc1  uploads   lvm2 a--  512.00g    0
  /dev/sdd1  uploads   lvm2 a--  256.00g    0
```

This now matches what is in Staging, so I wouldn't be surprised if Production also switches to this eventually.

Story: https://trello.com/c/PnbfxIRf/582-lvm-error-for-asset-slave-1backendintegration