### PR TITLE
Trigger Sanitize_publishing_API_data project without params

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
@@ -22,6 +22,8 @@
            # Update govuk-delivery's database for this environment.
            ssh deploy@$(govuk_node_list -c backend --single-node) 'cd /var/apps/govuk-delivery ; govuk_setenv govuk-delivery ./venv/bin/python scripts/update_data_after_sync.py'
     publishers:
+        - trigger:
+            - project: Sanitize_publishing_API_data
         - trigger-parameterized-builds:
             <%- %w{ publishing-api collections-publisher service-manual-publisher local-links-manager email-alert-api transition link-checker-api content-performance-manager }.each do |app| -%>
             - project: Deploy_App
@@ -29,7 +31,6 @@
                 TARGET_APPLICATION=<%= app %>
                 DEPLOY_TASK=app:migrate_and_hard_restart
             <%- end -%>
-            - project: Sanitize_publishing_API_data
             - project: run-rake-task
               predefined-parameters: |
                 TARGET_APPLICATION=whitehall


### PR DESCRIPTION
https://trello.com/c/mHsl3Y6M/948-filter-access-limited-data-when-syncing-from-production-to-integration
This project doesn't need or accept params so trigger it without them.