### PR TITLE
Fix invalid Jenkins job config

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
@@ -23,7 +23,7 @@
            ssh deploy@$(govuk_node_list -c backend --single-node) 'cd /var/apps/govuk-delivery ; govuk_setenv govuk-delivery ./venv/bin/python scripts/update_data_after_sync.py'
     publishers:
         - trigger:
-            - project: Sanitize_publishing_API_data
+            project: Sanitize_publishing_API_data
         - trigger-parameterized-builds:
             <%- %w{ publishing-api collections-publisher service-manual-publisher local-links-manager email-alert-api transition link-checker-api content-performance-manager }.each do |app| -%>
             - project: Deploy_App


### PR DESCRIPTION
Attempts to update the Jenkins jobs fails with the output

```
childProjects.text = data['project']
TypeError: list indices must be integers, not str
```

It looks like because it’s only a single value it should just be a hash rather than an array of hashes - other trigger definitions in the other config files do not have this leading dash either.

YAML is hard.