### PR TITLE
Remove govuk_content_models

### DIFF
--- a/development-vm/alphagov_repos
+++ b/development-vm/alphagov_repos
@@ -19,7 +19,6 @@ government-frontend
 govuk-content-schema-test-helpers
 govuk-content-schemas
 govuk-puppet
-govuk_content_models
 govuk_need_api
 hmrc-manuals-api
 imminence

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -588,7 +588,6 @@ govuk_ci::master::pipeline_jobs:
   govuk-diff-pages: {}
   govuk_admin_template: {}
   govuk_ab_testing: {}
-  govuk_content_models: {}
   govuk-content-schema-test-helpers: {}
   govuk-dummy_content_store: {}
   govuk-developer-docs: {}

--- a/training-vm/provisioner/alphagov_repos
+++ b/training-vm/provisioner/alphagov_repos
@@ -19,7 +19,6 @@ government-frontend
 govuk-content-schema-test-helpers
 govuk-content-schemas
 govuk-puppet
-govuk_content_models
 govuk_need_api
 hmrc-manuals-api
 imminence


### PR DESCRIPTION
The `govuk_content_models` gem is no longer needed, and is being
retired.

### Trello

https://trello.com/c/9Ho9O9Yo/219-epic-retire-govukcontentmodels