### PR TITLE
Fix processes panel title on deployment dashboards

### DIFF
--- a/modules/grafana/templates/dashboards/deployment_panels/_processor_count.json.erb
+++ b/modules/grafana/templates/dashboards/deployment_panels/_processor_count.json.erb
@@ -61,7 +61,7 @@
   "thresholds": [],
   "timeFrom": null,
   "timeShift": null,
-  "title": "Processes - Last Hour",
+  "title": "Processes",
   "tooltip": {
     "msResolution": false,
     "shared": true,


### PR DESCRIPTION
Remove the 'Last Hour' label from the process count in the Grafana deployment dashboards. The panel used to be restricted to the last hour, but now it inherits the time period from the dashboard settings. The dashboard shows the last hour by default anyway.