### PR TITLE
Fix Jenkins Navigation link job cron

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/govuk_navigation_link_analysis.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/govuk_navigation_link_analysis.yaml.erb
@@ -20,7 +20,7 @@
     logrotate:
       numToKeep: 10
     triggers:
-        - timed: 'H 0 * * MON'
+        - timed: 'H 0 * * 1'
     builders:
       - shell: |
           #!/bin/bash


### PR DESCRIPTION
Jenkins crons use `0-6` (Sunday - Saturday) for the day of the week.

### Trello

https://trello.com/c/tyBA9uGn/233-change-tagging-monitor-monthly-export-to-weekly