### PR TITLE
Add enhanced ecommerce export job

### DIFF
--- a/hieradata/class/integration/jenkins.yaml
+++ b/hieradata/class/integration/jenkins.yaml
@@ -15,6 +15,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::deploy_router_data
   - govuk_jenkins::job::deploy_terraform_project
   - govuk_jenkins::job::deploy_training
+  - govuk_jenkins::job::enhanced_ecommerce
   - govuk_jenkins::job::govuk_cdn_nightly_2xx_status_collection
   - govuk_jenkins::job::launch_vms
   - govuk_jenkins::job::network_config_deploy

--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -23,6 +23,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::deploy_router_data
   - govuk_jenkins::job::deploy_terraform_project
   - govuk_jenkins::job::email_alert_check
+  - govuk_jenkins::job::enhanced_ecommerce
   - govuk_jenkins::job::gds_production_backup
   - govuk_jenkins::job::govuk_cdn_nightly_2xx_status_collection
   - govuk_jenkins::job::govuk_navigation_link_analysis

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -156,6 +156,8 @@ govuk_jenkins::job::deploy_kubernetes::gce_project_id: 'govuk-integration'
 govuk_jenkins::job::search_benchmark::cron_schedule: '30 9 * * 1-5'
 govuk_jenkins::job::search_test_spelling_suggestions::cron_schedule: '0 10 * * 1-5'
 
+govuk_jenkins::job::enhanced_ecommerce::cron_schedule: '30 9 * * 1-5'
+
 govuk_jenkins::ssh_key::public_key: 'AAAAB3NzaC1yc2EAAAADAQABAAACAQDQBl40cv64wBa1zEG3dIOwsTTcJsMybZW0nPmCLBqS9/xzv4WoW5VzvID6yrSlg5XfX1Qxq8FmFGIDaAhb1fna2Z05EAC1Jh8EnCSFK8Q6NaUGxlyYoHRD06kZI8ZdAj3Ct8Hsqa0YaWKa/vSIWKIRtboVKm6SMbNxcLwQ04AG2zP2wtnGpyDKBPZol/L3jxVExx1B2lIww0drSKNFKQzM9kijZyAmhu8ocClNl19Rv86q44v0PcDIv5hkW5bEbsavTghnLNXad2dmiSP5Se68NscumyboetuG+o0lOFbFjuHk8NaXklOWiFZxJaJXiOVLihXHVhpDcuXEzwNoOKhYEzA06vHBVXbngBuEsgns/Hgpz4we2H4y4k9w9eJ4rKNhTvrfAzcYzEsnmhbNtQMZaLbqKnWBt2+X6lKTYUBpnUWXwLMaAb5dqEqD+LGiDxcfJ4b6UctSR7+CF29gRChwv0HUO1NdiVzZ2AMrqsYp9QtCWnfNipveGZl9Rqox3JSt4u/+7+I9xw0d8bFp8xCPxan78eMu42i3jNm4qcbbXGvPU6WFP0htjZZ8S0Fq7Dss4AbADrLxwepW8n7E+PozZRjH2P7TgmZ+wQXS6aUNHdgDeYsv5070NYK33wuE2f9GNVuN35/5ImB9PuyxDNSdHIPXTABMOZk7fVQUqXLCRw=='
 
 govuk_mysql::server::slow_query_log: true

--- a/modules/govuk_jenkins/manifests/job/enhanced_ecommerce.pp
+++ b/modules/govuk_jenkins/manifests/job/enhanced_ecommerce.pp
@@ -1,0 +1,29 @@
+# == Class: govuk_jenkins::job::enhanced_ecommerce
+#
+# Create a file on disk that can be parsed by jenkins-job-builder
+#
+class govuk_jenkins::job::enhanced_ecommerce (
+  $app_domain = hiera('app_domain'),
+  $auth_username = undef,
+  $auth_password = undef,
+  $rate_limit_token = undef,
+  $cron_schedule = '0 5 * * *'
+) {
+
+  $job_name = 'enhanced_ecommerce'
+  $service_description = 'Export Enhanced Ecommerce data'
+  $job_url = "https://deploy.${app_domain}/job/enhanced_ecommerce/"
+
+  file { '/etc/jenkins_jobs/jobs/enhanced_ecommerce.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/enhanced_ecommerce.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+
+  @@icinga::passive_check { "${job_name}_${::hostname}":
+    service_description => $service_description,
+    host_name           => $::fqdn,
+    freshness_threshold => 104400,
+    action_url          => $job_url,
+  }
+}

--- a/modules/govuk_jenkins/templates/jobs/enhanced_ecommerce.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/enhanced_ecommerce.yaml.erb
@@ -1,0 +1,28 @@
+---
+
+- job:
+    name: <%= @job_name %>
+    display-name: <%= @job_name %>
+    project-type: freestyle
+    builders:
+        - shell: |
+            ssh deploy@search-1.api '
+            cd /var/apps/rummager &&
+            govuk_setenv rummager bundle exec rake analytics:create_data_import_csv EXPORT_PATH=/data/export/enhanced_ecommerce &&
+            govuk_setenv rummager bundle exec rake analytics:delete_old_files EXPORT_PATH=/data/export/enhanced_ecommerce EXPORT_FILE_LIMIT=10
+            '
+    triggers:
+        - timed: '<%= @cron_schedule %>'
+    publishers:
+        - trigger-parameterized-builds:
+            - project: Success_Passive_Check
+              condition: 'SUCCESS'
+              predefined-parameters: |
+                  NSCA_CHECK_DESCRIPTION=<%= @service_description %>
+                  NSCA_OUTPUT=<%= @service_description %> success
+            - project: Failure_Passive_Check
+              condition: 'FAILED'
+              predefined-parameters: |
+                  NSCA_CHECK_DESCRIPTION=<%= @service_description %>
+                  NSCA_OUTPUT=<%= @service_description %> failed
+


### PR DESCRIPTION
Run the ecommerce exporter on a daily basis, an additional task to upload the generated data file needs to be completed, in the meantime this file will be manually uploaded as and when needed.

The job runs two rake tasks, one for generating the file and one to delete files older than 10 days, this is to avoid filling the disk up with data files.

https://trello.com/c/RFFTzN3z/144-automate-ecommerce-csv-generation