### PR TITLE
Bugfix transition logs passive check

### DIFF
--- a/modules/govuk_cdnlogs/manifests/transition_logs.pp
+++ b/modules/govuk_cdnlogs/manifests/transition_logs.pp
@@ -111,6 +111,8 @@ class govuk_cdnlogs::transition_logs (
     ensure => 'absent',
   }
 
+  $service_desc = 'Transition logs processing script'
+
   file { $process_script:
     ensure  => $ensure,
     owner   => $user,
@@ -129,8 +131,6 @@ class govuk_cdnlogs::transition_logs (
       path    => '/usr/lib/rbenv/shims:/usr/sbin:/usr/bin:/sbin:/bin',
       require => File[$process_script],
     }
-
-    $service_desc = 'Transition logs processing script'
 
     @@icinga::passive_check { "transition-logs-processing-script-${::hostname}":
       service_description => $service_desc,


### PR DESCRIPTION
I made the classic mistake of putting the variable that is used in a template **after** the template is created. Therefore the template is created with a blank service description, and Icinga is unable to recognise it being sent and so sends a warning.