### PR TITLE
Add vCloud Tools repository

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -645,6 +645,8 @@ govuk_ci::master::pipeline_jobs:
     repo_owner: 'gds-operations'
   vcloud-net_launcher:
     repo_owner: 'gds-operations'
+  vcloud-tools:
+    repo_owner: 'gds-operations'
   vcloud-tools-tester:
     repo_owner: 'gds-operations'
   vcloud-walker:


### PR DESCRIPTION
There is a repository that publishes all the tools as a single gem. Add this to CI so we may publish the newer changes in this gem.