### PR TITLE
Remove NPM credentials from CI

### DIFF
--- a/hieradata/vagrant_credentials.yaml
+++ b/hieradata/vagrant_credentials.yaml
@@ -118,8 +118,6 @@ govuk_cdnlogs::server_crt: |
   SWxT6CtXBLz/pX7S1nkT58Anunp3H2jdt0P4llBxsA==
   -----END CERTIFICATE-----
 
-govuk_ci::credentials::npm_auth: 'foo'
-govuk_ci::credentials::npm_email: 'foo@bar.com'
 govuk_ci::credentials::rubygems_api_key: 'rubygemskey'
 govuk_ci::credentials::pypi_username: 'pipyusername'
 govuk_ci::credentials::pypi_test_password: 'passwordtest'

--- a/modules/govuk_ci/manifests/credentials.pp
+++ b/modules/govuk_ci/manifests/credentials.pp
@@ -4,12 +4,6 @@
 #
 # === Parameters:
 #
-# [*npm_auth*]
-#   Auth code for npm
-#
-# [*npm_email*]
-#   Email for npn
-#
 # [*rubygems_api_key*]
 #   API key to authenticate with Rubygems
 #
@@ -29,8 +23,6 @@
 #   The user that has access to these credentials
 #
 class govuk_ci::credentials (
-  $npm_auth,
-  $npm_email,
   $rubygems_api_key,
   $pypi_username,
   $pypi_test_password,
@@ -60,10 +52,6 @@ class govuk_ci::credentials (
 
   file {"${jenkins_home}/.pypirc":
     content => template('govuk_ci/pypirc.erb'),
-  }
-
-  file { "${jenkins_home}/.npmrc":
-    content => template('govuk_ci/npmrc.erb'),
   }
 }
 

--- a/modules/govuk_ci/manifests/credentials.pp
+++ b/modules/govuk_ci/manifests/credentials.pp
@@ -53,5 +53,9 @@ class govuk_ci::credentials (
   file {"${jenkins_home}/.pypirc":
     content => template('govuk_ci/pypirc.erb'),
   }
-}
 
+  # FIXME: Remove this once the npmrc file has been removed from all nodes
+  file {"${jenkins_home}/.npmrc":
+    ensure => 'absent',
+  }
+}

--- a/modules/govuk_ci/templates/npmrc.erb
+++ b/modules/govuk_ci/templates/npmrc.erb
@@ -1,2 +1,0 @@
-_auth = <%= @npm_auth %>
-email = <%= @npm_email %>


### PR DESCRIPTION
My Puppet-foo is pretty weak, hope I've done this correctly.

All of the packages currently published under alphagov on the NPM registry either belong to the Service Manual, Patterns & Tools team (govuk-elements-sass, govuk_frontend_toolkit, govuk_template_ejs, govuk_template_jinja, govuk_template_mustache) or the Performance Platform (performanceplatform-client.js).

They have all been migrated to Travis and are now managed by their teams as part of the Services Programme, so there is no longer any reason for Jenkins to know the npm credentials.