### PR TITLE
Remove non GOV.UK pipeline jobs

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -591,10 +591,6 @@ govuk_ci::master::pipeline_jobs:
   govuk-dummy_content_store: {}
   govuk-developer-docs: {}
   govuk_document_types: {}
-  govuk_elements: {}
-  govuk_frontend_toolkit: {}
-  govuk_frontend_toolkit_gem: {}
-  govuk_frontend_toolkit_npm: {}
   govuk-guix: {}
   govuk-lint: {}
   govuk_message_queue_consumer: {}
@@ -608,7 +604,6 @@ govuk_ci::master::pipeline_jobs:
   govuk_sidekiq: {}
   govuk-tagging-monitor: {}
   govuk_taxonomy_helpers: {}
-  govuk_template: {}
   govuk-user-reviewer: {}
   licensify:
     source: 'github-enterprise'


### PR DESCRIPTION
These have all moved to Travis and are no longer run on GOV.UK’s CI.

I _suspect_ the various performance platform jobs could also be removed, but I'm not confident enough to actually make that change right now.