### PR TITLE
Update to use new provisioning repo on github.com

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -596,8 +596,7 @@ govuk_ci::master::pipeline_jobs:
   govuk_message_queue_consumer: {}
   govuk_mirrorer: {}
   govuk_navigation_helpers: {}
-  govuk-provisioning:
-    source: 'github-enterprise'
+  govuk-provisioning: {}
   govuk_seed_crawler: {}
   govuk_schemas: {}
   govuk_security_audit: {}

--- a/modules/govuk_jenkins/manifests/job/network_config_deploy.pp
+++ b/modules/govuk_jenkins/manifests/job/network_config_deploy.pp
@@ -6,7 +6,7 @@
 #
 # [*environments*]
 #   An array of environments where network config can be deployed to. The
-#   possibilities are https://github.digital.cabinet-office.gov.uk/gds/govuk-provisioning/blob/master/vcloud-edge_gateway/jenkins.sh
+#   possibilities are https://github.com/alphagov/govuk-provisioning/blob/master/vcloud-edge_gateway/jenkins.sh
 #
 class govuk_jenkins::job::network_config_deploy (
   $environments = [],

--- a/modules/govuk_jenkins/templates/jobs/check_cdn_ip_ranges.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/check_cdn_ip_ranges.yaml.erb
@@ -3,7 +3,7 @@
     name: govuk-provisioning_Check_CDN_IP_Ranges
     scm:
         - git:
-            url: git@github.digital.cabinet-office.gov.uk:gds/govuk-provisioning.git
+            url: git@github.com:alphagov/govuk-provisioning.git
             branches:
               - master
             wipe-workspace: false
@@ -15,7 +15,7 @@
     description: "This job compares the IP ranges that Fastly publishes against the ranges configured in govuk-provisioning and errors if they don't match."
     properties:
         - github:
-            url: https://github.digital.cabinet-office.gov.uk/gds/govuk-provisioning/
+            url: https://github.com/alphagov/govuk-provisioning/
     scm:
       - govuk-provisioning_Check_CDN_IP_Ranges
     builders:

--- a/modules/govuk_jenkins/templates/jobs/launch_vms.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/launch_vms.yaml.erb
@@ -3,7 +3,7 @@
     name: govuk-provisioning_Launch_VMs
     scm:
         - git:
-            url: git@github.digital.cabinet-office.gov.uk:gds/govuk-provisioning.git
+            url: git@github.com:alphagov/govuk-provisioning.git
             branches:
               - master
 - job:

--- a/modules/govuk_jenkins/templates/jobs/launch_vms_dr.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/launch_vms_dr.yaml.erb
@@ -3,7 +3,7 @@
     name: govuk-provisioning_Launch_VMs_DR
     scm:
         - git:
-            url: git@github.digital.cabinet-office.gov.uk:gds/govuk-provisioning.git
+            url: git@github.com:alphagov/govuk-provisioning.git
             branches:
               - master
 - job:

--- a/modules/govuk_jenkins/templates/jobs/launch_vms_licensify.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/launch_vms_licensify.yaml.erb
@@ -3,7 +3,7 @@
     name: govuk-provisioning_Launch_VMs_Licensify
     scm:
         - git:
-            url: git@github.digital.cabinet-office.gov.uk:gds/govuk-provisioning.git
+            url: git@github.com:alphagov/govuk-provisioning.git
             branches:
               - master
 - job:

--- a/modules/govuk_jenkins/templates/jobs/network_config_deploy.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/network_config_deploy.yaml.erb
@@ -3,7 +3,7 @@
     name: govuk-provisioning_Network_Config_Deploy
     scm:
         - git:
-            url: git@github.digital.cabinet-office.gov.uk:gds/govuk-provisioning.git
+            url: git@github.com:alphagov/govuk-provisioning.git
             branches:
               - master
             wipe-workspace: false
@@ -17,7 +17,7 @@
     description: "This job configures the edge gateway in *<%= @environment -%>*. It uses the configuration in the govuk-provisioning repo."
     properties:
         - github:
-            url: https://github.digital.cabinet-office.gov.uk/gds/govuk-provisioning/
+            url: https://github.com/alphagov/govuk-provisioning/
     scm:
       - govuk-provisioning_Network_Config_Deploy
     builders:

--- a/modules/govuk_jenkins/templates/jobs/start_vapps.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/start_vapps.yaml.erb
@@ -3,7 +3,7 @@
     name: govuk-provisioning_start_vapps
     scm:
         - git:
-            url: git@github.digital.cabinet-office.gov.uk:gds/govuk-provisioning.git
+            url: git@github.com:alphagov/govuk-provisioning.git
             branches:
                 - master
             skip-tag: true

--- a/modules/govuk_jenkins/templates/jobs/start_vapps_dr.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/start_vapps_dr.yaml.erb
@@ -3,7 +3,7 @@
     name: govuk-provisioning_start_vapps_dr
     scm:
         - git:
-            url: git@github.digital.cabinet-office.gov.uk:gds/govuk-provisioning.git
+            url: git@github.com:alphagov/govuk-provisioning.git
             branches:
                 - master
             skip-tag: true

--- a/modules/govuk_jenkins/templates/jobs/stop_vapps.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/stop_vapps.yaml.erb
@@ -3,7 +3,7 @@
     name: govuk-provisioning_stop_vapps
     scm:
         - git:
-            url: git@github.digital.cabinet-office.gov.uk:gds/govuk-provisioning.git
+            url: git@github.com:alphagov/govuk-provisioning.git
             branches:
                 - master
             skip-tag: true

--- a/modules/govuk_jenkins/templates/jobs/stop_vapps_dr.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/stop_vapps_dr.yaml.erb
@@ -3,7 +3,7 @@
     name: govuk-provisioning_stop_vapps_dr
     scm:
         - git:
-            url: git@github.digital.cabinet-office.gov.uk:gds/govuk-provisioning.git
+            url: git@github.com:alphagov/govuk-provisioning.git
             branches:
                 - master
             skip-tag: true


### PR DESCRIPTION
Replaces the old GHE references.