### PR TITLE
Enable SSL for the training VM

### DIFF
--- a/hieradata/class/training.yaml
+++ b/hieradata/class/training.yaml
@@ -2,6 +2,8 @@
 
 app_domain: 'training.publishing.service.gov.uk'
 
+nginx_enable_ssl: true
+
 govuk::deploy::config::asset_root: 'https://assets-origin.training.publishing.service.gov.uk'
 govuk::deploy::config::website_root: 'https://www.training.publishing.service.gov.uk'
 


### PR DESCRIPTION
This commit enables SSL for the training VM since it is hosted on the `publishing.service.gov.uk` subdomain which enforces HTTPS.