### PR TITLE
Add backdrop_host override for training VM

### DIFF
--- a/hieradata/class/training.yaml
+++ b/hieradata/class/training.yaml
@@ -8,6 +8,7 @@ govuk::deploy::config::website_root: 'https://www.training.publishing.service.go
 govuk::apps::authenticating_proxy::govuk_upstream_uri: 'http://government-frontend.training.publishing.service.gov.uk'
 govuk::apps::government_frontend::enable_running_in_draft_mode::content_store: 'http://draft-content-store.training.publishing.service.gov.uk'
 govuk::apps::manuals_frontend::enable_running_in_draft_mode::content_store: 'http://draft-content-store.training.publishing.service.gov.uk'
+govuk::apps::publicapi::backdrop_host: 'read.backdrop.training.publishing.service.gov.uk'
 govuk::apps::publishing_api::content_store: 'http://content-store.training.publishing.service.gov.uk'
 govuk::apps::publishing_api::draft_content_store: 'http://draft-content-store.training.publishing.service.gov.uk'
 


### PR DESCRIPTION
This commit adds an override for the `backdrop_host` in the training VM.