### PR TITLE
Add asset_bom_removal-rails gem to jenkins

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -568,6 +568,7 @@ govuk_cdnlogs::service_port_map:
 
 govuk_ci::master::pipeline_jobs:
   <<: *deployable_applications
+  asset_bom_removal-rails: {}
   async_experiments: {}
   backdrop-transactions-explorer-collector: {}
   cdn-acceptance-tests: {}


### PR DESCRIPTION
We've created a new gem called [`asset_bom_removal-rails`](https://github.com/alphagov/asset_bom_removal-rails) and want to add it to CI.  The gem hooks into rails asset-pipeline to remove the BOM from compiled CSS files to avoid a bug in firefox (< 52) when calculating SRI checksums.