### PR TITLE
Add an early short circuit for AWS hosts

### DIFF
--- a/modules/govuk/lib/puppet/parser/functions/govuk_node_class.rb
+++ b/modules/govuk/lib/puppet/parser/functions/govuk_node_class.rb
@@ -22,7 +22,8 @@ EOS
     ) unless args.size == 0
 
     # Explicit early return if in AWS.
-    return lookupvar('AWS_MIGRATION') unless lookupvar('AWS_MIGRATION').empty?
+    aws_migration = lookupvar('aws_migration')
+    return aws_migration unless (aws_migration.nil? || aws_migration.empty?)
 
     # http://docs.puppetlabs.com/puppet/3/reference/lang_variables.html#trusted-node-data
     trusted_hash = lookupvar('::trusted')

--- a/modules/govuk/lib/puppet/parser/functions/govuk_node_class.rb
+++ b/modules/govuk/lib/puppet/parser/functions/govuk_node_class.rb
@@ -21,6 +21,9 @@ EOS
       "govuk_node_class: Wrong number of arguments given #{args.size} for 0."
     ) unless args.size == 0
 
+    # Explicit early return if in AWS.
+    return lookupvar('AWS_MIGRATION') unless lookupvar('AWS_MIGRATION').empty?
+
     # http://docs.puppetlabs.com/puppet/3/reference/lang_variables.html#trusted-node-data
     trusted_hash = lookupvar('::trusted')
     raise(

--- a/modules/govuk/spec/functions/govuk_node_class_spec.rb
+++ b/modules/govuk/spec/functions/govuk_node_class_spec.rb
@@ -11,8 +11,27 @@ describe 'govuk_node_class' do
     expect { scope.function_govuk_node_class([:gruffalo]) }.to raise_error(Puppet::ParseError, /given 1 for 0/)
   end
 
+  context 'aws_migration set' do
+    it 'should return aws_migration' do
+      aws_migration_name = 'chicken'
+      expect(scope).to receive(:lookupvar).with('aws_migration').and_return(aws_migration_name)
+      expect(scope.function_govuk_node_class([])).to eq(aws_migration_name)
+    end
+
+    it 'should not return aws_migration its an empty string' do
+      aws_migration_name = 'chicken'
+      expect(scope).to receive(:lookupvar).with('aws_migration').and_return('')
+      expect(scope).to receive(:lookupvar).with('::trusted').and_return(nil)
+      expect { scope.function_govuk_node_class([]) }.to raise_error(
+        Puppet::ParseError,
+        /Unable to lookup \$::trusted/
+      )
+    end
+  end
+
   context '$::trusted not set' do
     it 'should raise an error' do
+      expect(scope).to receive(:lookupvar).with('aws_migration').and_return(nil)
       expect(scope).to receive(:lookupvar).with('::trusted').and_return(nil)
       expect { scope.function_govuk_node_class([]) }.to raise_error(
         Puppet::ParseError,
@@ -23,6 +42,7 @@ describe 'govuk_node_class' do
 
   context '$::trusted["certname"] nil' do
     it 'should raise an error' do
+      expect(scope).to receive(:lookupvar).with('aws_migration').and_return(nil)
       expect(scope).to receive(:lookupvar).with('::trusted').and_return({
         'authenticated' => false,
         'certname'      => nil,
@@ -36,6 +56,7 @@ describe 'govuk_node_class' do
 
   context '$::trusted["certname"] empty' do
     it 'should raise an error' do
+      expect(scope).to receive(:lookupvar).with('aws_migration').and_return(nil)
       expect(scope).to receive(:lookupvar).with('::trusted').and_return({
         'authenticated' => false,
         'certname'      => '',
@@ -61,6 +82,7 @@ describe 'govuk_node_class' do
       }}
 
       it {
+        expect(scope).to receive(:lookupvar).with('aws_migration').and_return(nil)
         expect(scope).to receive(:lookupvar).with('::trusted').and_return(trusted_hash)
         expect(scope.function_govuk_node_class([])).to eq(result)
       }


### PR DESCRIPTION
We will be testing some of our Puppet code in AWS and this allows us
to be explicit about the class. There is a downside in that you could
manually change an existing hosts class and read its secrets but we're
accepting that for now.