### PR TITLE
Add a “training” environment indicator

### DIFF
--- a/training-vm/provisioner/alphagov_user_facing_apps
+++ b/training-vm/provisioner/alphagov_user_facing_apps
@@ -1,0 +1,16 @@
+collections-publisher
+contacts
+content-tagger
+imminence
+local-links-manager
+manuals-publisher
+maslow
+policy-publisher
+publisher
+service-manual-publisher
+short-url-manager
+signon
+specialist-publisher
+support
+travel-advice-publisher
+whitehall

--- a/training-vm/provisioner/govuk-admin-template-environment-indicators.sh
+++ b/training-vm/provisioner/govuk-admin-template-environment-indicators.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+cd "$(dirname "$0")"
+
+# Copy `govuk_admin_template_environment_indicators.rb` to the
+# `config/initializers` folder for each app.
+
+while read app
+do
+  cp govuk_admin_template_environment_indicators.rb /var/apps/$app/config/initializers
+done < "${1:-/dev/stdin}"

--- a/training-vm/provisioner/govuk_admin_template_environment_indicators.rb
+++ b/training-vm/provisioner/govuk_admin_template_environment_indicators.rb
@@ -1,0 +1,2 @@
+GovukAdminTemplate.environment_style = 'development'
+GovukAdminTemplate.environment_label = 'Training'

--- a/training-vm/training_user_data.txt
+++ b/training-vm/training_user_data.txt
@@ -101,6 +101,11 @@ sudo /var/govuk/govuk-puppet/development-vm/update-bundler.sh
 echo "[$(date '+%H:%M:%S %d-%m-%Y')] END UPDATE BUNDLER"
 echo
 
+echo "[$(date '+%H:%M:%S %d-%m-%Y')] START ADD ENVIRONMENT INDICATORS"
+sudo -i -u deploy /home/ubuntu/provisioner/govuk-admin-template-environment-indicators.sh < /home/ubuntu/provisioner/alphagov_user_facing_apps
+echo "[$(date '+%H:%M:%S %d-%m-%Y')] END ADD ENVIRONMENT INDICATORS"
+echo
+
 echo "[$(date '+%H:%M:%S %d-%m-%Y')] START PREPARE SIGNON TRAINING ENVIRONMENT"
 sudo /var/govuk/signon/script/prepare_training_environment --really-setup-training-environment
 echo "[$(date '+%H:%M:%S %d-%m-%Y')] END PREPARE SIGNON TRAINING ENVIRONMENT"


### PR DESCRIPTION
This commit adds a “training” environment indicator to all user-facing apps in the training VM.

<img width="1262" alt="screen shot 2017-07-06 at 11 08 21" src="https://user-images.githubusercontent.com/444232/27906448-78aaebf6-623b-11e7-9d62-0f43d6569896.png">