### PR TITLE
Get Letsencrypt certificates for training vm and install them

### DIFF
--- a/training-vm/provisioner/acme_certificates.sh
+++ b/training-vm/provisioner/acme_certificates.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+MAIN_SITE="www.training.publishing.service.gov.uk"
+SITE_LIST="`ls /etc/nginx/sites-enabled | grep training.publishing.service.gov.uk`"$'\n'"${MAIN_SITE}"
+CS_SITE_LIST=`printf "${SITE_LIST}" | paste -s -d, -`
+EMAIL="govuk-dev@digital.cabinet-office.gov.uk"
+NGINX_CONF_DIR="/etc/nginx"
+LETSENCRYPT_DIR="/etc/letsencrypt"
+
+#Certbot starts up its own webserver to perform the ACME protocol
+sudo service nginx stop
+
+#Add repository and install certbot
+sudo apt-get update
+sudo apt-get install software-properties-common
+sudo add-apt-repository -y ppa:certbot/certbot
+sudo apt-get update
+sudo apt-get install certbot
+
+sudo certbot certonly --staging --cert-name ${MAIN_SITE} -m ${EMAIL} -n -d ${CS_SITE_LIST} --agree-tos --standalone
+
+rm -f ${NGINX_CONF_DIR}/ssl/*
+
+while read -r LINE; do
+    sudo ln -sf ${LETSENCRYPT_DIR}/live/${MAIN_SITE}/fullchain.pem ${NGINX_CONF_DIR}/ssl/${LINE}.crt
+    sudo ln -sf ${LETSENCRYPT_DIR}/live/${MAIN_SITE}/privkey.pem ${NGINX_CONF_DIR}/ssl/${LINE}.key
+done <<< "$SITE_LIST"
+
+sudo service nginx start

--- a/training-vm/training_user_data.txt
+++ b/training-vm/training_user_data.txt
@@ -110,3 +110,8 @@ echo "[$(date '+%H:%M:%S %d-%m-%Y')] START RUN UPSTART APPS"
 sudo /home/ubuntu/provisioner/start-training-environment.sh < /home/ubuntu/provisioner/alphagov_apps
 echo "[$(date '+%H:%M:%S %d-%m-%Y')] END RUN UPSTART APPS"
 echo
+
+echo "[$(date '+%H:%M:%S %d-%m-%Y')] START OBTAIN LETSENCRYPT CERTIFICATES"
+sudo /home/ubuntu/provisioner/acme_certificates.sh
+echo "[$(date '+%H:%M:%S %d-%m-%Y')] END OBTAIN LETSENCRYPT CERTIFICATES"
+echo


### PR DESCRIPTION
This PR adds a script to the training VM to get certificates from the letsencrypt site (https://letsencrypt.org/). 

The official client (https://certbot.eff.org) is used in 'standalone' mode, so the challenge is served by Certbot starting and stopping a webserver.

The certificates are placed in its default directory, /etc/letsencrypt and links are added to /etc/nginx/ssl

The --staging option in line 20 of acme_certificates.sh file needs to be removed at a later date to use the 'real' CA instead of the staging CA.

Trello: https://trello.com/c/TqW7DXfx/11-firebreak-get-ssl-working