### PR TITLE
Add short-url-manager and imminence to training VM

### DIFF
--- a/training-vm/provisioner/alphagov_apps
+++ b/training-vm/provisioner/alphagov_apps
@@ -16,6 +16,7 @@ feedback
 finder-frontend
 frontend
 government-frontend
+imminence
 info-frontend
 licencefinder
 local-links-manager
@@ -31,6 +32,7 @@ router
 rummager
 service-manual-frontend
 service-manual-publisher
+short-url-manager
 signon
 smartanswers
 specialist-publisher

--- a/training-vm/provisioner/alphagov_repos
+++ b/training-vm/provisioner/alphagov_repos
@@ -38,6 +38,7 @@ router-api
 rummager
 service-manual-frontend
 service-manual-publisher
+short-url-manager
 signon
 slimmer
 smart-answers


### PR DESCRIPTION
This commit adds `short-url-manager` and `imminence` to the training VM.