### PR TITLE
Run scripts as deploy user for training VM

### DIFF
--- a/training-vm/training_user_data.txt
+++ b/training-vm/training_user_data.txt
@@ -80,8 +80,8 @@ else
 fi
 
 echo "[$(date '+%H:%M:%S %d-%m-%Y')] START CHECKOUT REPOSITORIES"
-sudo mkdir -p /var/govuk
-sudo DEPLOYED_TO_PRODUCTION=true /home/ubuntu/provisioner/checkout-repos.sh -d /var/govuk /home/ubuntu/provisioner/alphagov_repos
+sudo -i -u deploy mkdir -p /var/govuk
+sudo -i -u deploy DEPLOYED_TO_PRODUCTION=true /home/ubuntu/provisioner/checkout-repos.sh -d /var/govuk /home/ubuntu/provisioner/alphagov_repos
 echo "[$(date '+%H:%M:%S %d-%m-%Y')] END CHECKOUT REPOSITORIES"
 echo
 
@@ -97,12 +97,12 @@ echo "[$(date '+%H:%M:%S %d-%m-%Y')] END RESTORE DATABASES"
 echo
 
 echo "[$(date '+%H:%M:%S %d-%m-%Y')] START UPDATE BUNDLER"
-sudo /var/govuk/govuk-puppet/development-vm/update-bundler.sh
+sudo -i -u deploy /var/govuk/govuk-puppet/development-vm/update-bundler.sh
 echo "[$(date '+%H:%M:%S %d-%m-%Y')] END UPDATE BUNDLER"
 echo
 
 echo "[$(date '+%H:%M:%S %d-%m-%Y')] START PREPARE SIGNON TRAINING ENVIRONMENT"
-sudo /var/govuk/signon/script/prepare_training_environment --really-setup-training-environment
+sudo -i -u deploy /var/govuk/signon/script/prepare_training_environment --really-setup-training-environment
 echo "[$(date '+%H:%M:%S %d-%m-%Y')] END PREPARE SIGNON TRAINING ENVIRONMENT"
 echo
 


### PR DESCRIPTION
This commit changes the user data to run shell scripts as the `deploy` user otherwise apps don’t have access to their home directories.