### PR TITLE
Munge routes correct for training VM

### DIFF
--- a/development-vm/replication/common-args.sh
+++ b/development-vm/replication/common-args.sh
@@ -26,6 +26,7 @@ OPTIONS:
     -q       Skip MySQL import
     -e       Skip Elasticsearch import
     -t       Skip Mapit import
+    -a       Set up as training environment
 
 EOF
 }
@@ -40,6 +41,7 @@ SKIP_MAPIT=false
 SSH_CONFIG="../ssh_config"
 RENAME_DATABASES=true
 DRY_RUN=false
+TRAINING_ENVIRONMENT=false
 # By default, ignore large databases which are not useful when replicated.
 IGNORE="event_store transition backdrop support_contacts"
 
@@ -54,7 +56,7 @@ function ignored() {
   return 1
 }
 
-while getopts "hF:u:d:sri:onmpqet" OPTION
+while getopts "hF:u:d:sri:onmpqeta" OPTION
 do
   case $OPTION in
     h )
@@ -99,6 +101,9 @@ do
       ;;
     t )
       SKIP_MAPIT=true
+      ;;
+    a )
+      TRAINING_ENVIRONMENT=true
       ;;
   esac
 done

--- a/development-vm/replication/replicate-data-local.sh
+++ b/development-vm/replication/replicate-data-local.sh
@@ -18,9 +18,15 @@ $(dirname $0)/sync-mongo.sh "$@" api-mongo-1.api.integration
 $(dirname $0)/sync-mongo.sh "$@" router-backend-1.router.integration
 
 if ! ($SKIP_MONGO || $DRY_RUN); then
-  status "Munging router backend hostnames for dev VM"
-  mongo --quiet --eval 'db = db.getSiblingDB("router"); db.backends.find().forEach( function(b) { b.backend_url = b.backend_url.replace(".integration.publishing.service.gov.uk", ".dev.gov.uk").replace("https","http"); db.backends.save(b); } );'
-  mongo --quiet --eval 'db = db.getSiblingDB("draft_router"); db.backends.find().forEach( function(b) { b.backend_url = b.backend_url.replace(".integration.publishing.service.gov.uk", ".dev.gov.uk").replace("https","http"); db.backends.save(b); } );'
+  if $TRAINING_ENVIRONMENT; then
+    status "Munging router backend hostnames for training VM"
+    mongo --quiet --eval 'db = db.getSiblingDB("router"); db.backends.find().forEach( function(b) { b.backend_url = b.backend_url.replace(".integration.publishing.service.gov.uk", ".training.publishing.service.gov.uk"); db.backends.save(b); } );'
+    mongo --quiet --eval 'db = db.getSiblingDB("draft_router"); db.backends.find().forEach( function(b) { b.backend_url = b.backend_url.replace(".integration.publishing.service.gov.uk", ".training.publishing.service.gov.uk"); db.backends.save(b); } );'
+  else
+    status "Munging router backend hostnames for dev VM"
+    mongo --quiet --eval 'db = db.getSiblingDB("router"); db.backends.find().forEach( function(b) { b.backend_url = b.backend_url.replace(".integration.publishing.service.gov.uk", ".dev.gov.uk").replace("https","http"); db.backends.save(b); } );'
+    mongo --quiet --eval 'db = db.getSiblingDB("draft_router"); db.backends.find().forEach( function(b) { b.backend_url = b.backend_url.replace(".integration.publishing.service.gov.uk", ".dev.gov.uk").replace("https","http"); db.backends.save(b); } );'
+  fi
 fi
 
 $(dirname $0)/sync-postgresql.sh "$@" postgresql-primary-1.backend.integration

--- a/training-vm/provisioner/restore-backups.sh
+++ b/training-vm/provisioner/restore-backups.sh
@@ -22,6 +22,6 @@ do
 done
 
 cd /var/govuk/govuk-puppet/development-vm/replication
-./replicate-data-local.sh -s -d /var/backups -i signon -e
+./replicate-data-local.sh -s -d /var/backups -i signon -e -a
 
 ${BINDIR}/es-restore-s3.sh


### PR DESCRIPTION
This commit amends the data replication script to do the correct route munging for the training VM so that the router works as expected, by adding a new `-a` option.