### PR TITLE
Remove share-sale-publisher from development VM

### DIFF
--- a/development-vm/Pinfile
+++ b/development-vm/Pinfile
@@ -66,7 +66,6 @@ process :screenshot_as_a_service
 process :'search-admin' => [:rummager]
 process :'service-manual-frontend' => [:'content-store', :static]
 process :'service-manual-publisher' => [:'publishing-api', :rummager]
-process :'share-sale-publisher' => ['asset-manager', :'publishing-api']
 process :'short-url-manager' => [:'publishing-api']
 process :signon
 process :smartanswers => [:static, :'content-store', :imminence]

--- a/development-vm/Procfile
+++ b/development-vm/Procfile
@@ -123,7 +123,7 @@ content-tagger:        govuk_setenv content-tagger        ./run_in.sh ../../cont
 content-tagger-sidekiq: govuk_setenv content-tagger       ./run_in.sh ../../content-tagger bundle exec sidekiq -C ./config/sidekiq.yml
 # sidekiq-monitoring for email-campaign-api uses port 3117
 # multipage-frontend used port 3118
-share-sale-publisher:  govuk_setenv share-sale-publisher  ./run_in.sh ../../share-sale-publisher bundle exec rails server -p 3119
+# share-sale-publisher used port 3119
 # sidekiq-monitoring for imminence uses port 3120
 local-links-manager:   govuk_setenv local-links-manager   ./run_in.sh ../../local-links-manager bundle exec rails server -p 3121
 service-manual-frontend: govuk_setenv service-manual-frontend ./run_in.sh ../../service-manual-frontend bundle exec rails server -p 3122


### PR DESCRIPTION
This commit removes `share-sale-publisher` from the development VM.

This app no longer exists.