### PR TITLE
Enable password for the training VM

### DIFF
--- a/training-vm/provisioner/add_auth.sh
+++ b/training-vm/provisioner/add_auth.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-sed -i '' '/location[^\^]*{/a\
+sed -i '/location[^\^]*{/a\
 \
 \ \ \ \ auth_basic "Restricted";\
 \ \ \ \ auth_basic_user_file /etc/nginx/.htpasswd;\

--- a/training-vm/provisioner/add_auth.sh
+++ b/training-vm/provisioner/add_auth.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+sed -i '' '/location[^\^]*{/a\
+\
+\ \ \ \ auth_basic "Restricted";\
+\ \ \ \ auth_basic_user_file /etc/nginx/.htpasswd;\
+\
+' $1

--- a/training-vm/training_user_data.txt
+++ b/training-vm/training_user_data.txt
@@ -122,6 +122,7 @@ echo "[$(date '+%H:%M:%S %d-%m-%Y')] END OBTAIN LETSENCRYPT CERTIFICATES"
 echo
 
 echo "[$(date '+%H:%M:%S %d-%m-%Y')] START ADDING AUTHENTICATION TO NGINX CONFIGURATION"
-sudo find /etc/nginx/available_sites -name '*publishing.service.gov.uk' | xargs -n 1 /home/ubuntu/provisioner/add_auth.sh 
+sudo find /etc/nginx/available_sites -name '*publishing.service.gov.uk' | xargs -n 1 /home/ubuntu/provisioner/add_auth.sh
+sudo sh -c "echo -n 'betademo:N04wQhwGA777s' > /etc/nginx/.htpasswd"
 echo "[$(date '+%H:%M:%S %d-%m-%Y')] END ADDING AUTHENTICATION TO NGINX CONFIGURATION"
 echo

--- a/training-vm/training_user_data.txt
+++ b/training-vm/training_user_data.txt
@@ -122,7 +122,7 @@ echo "[$(date '+%H:%M:%S %d-%m-%Y')] END OBTAIN LETSENCRYPT CERTIFICATES"
 echo
 
 echo "[$(date '+%H:%M:%S %d-%m-%Y')] START ADDING AUTHENTICATION TO NGINX CONFIGURATION"
-sudo find /etc/nginx/sites-available -name '*publishing.service.gov.uk' | xargs -n 1 /home/ubuntu/provisioner/add_auth.sh
+sudo find /etc/nginx/sites-available -name '*publishing.service.gov.uk' | sudo xargs -n 1 /home/ubuntu/provisioner/add_auth.sh
 sudo sh -c "echo -n 'betademo:N04wQhwGA777s' > /etc/nginx/.htpasswd"
 echo "[$(date '+%H:%M:%S %d-%m-%Y')] END ADDING AUTHENTICATION TO NGINX CONFIGURATION"
 echo

--- a/training-vm/training_user_data.txt
+++ b/training-vm/training_user_data.txt
@@ -122,7 +122,7 @@ echo "[$(date '+%H:%M:%S %d-%m-%Y')] END OBTAIN LETSENCRYPT CERTIFICATES"
 echo
 
 echo "[$(date '+%H:%M:%S %d-%m-%Y')] START ADDING AUTHENTICATION TO NGINX CONFIGURATION"
-sudo find /etc/nginx/available_sites -name '*publishing.service.gov.uk' | xargs -n 1 /home/ubuntu/provisioner/add_auth.sh
+sudo find /etc/nginx/sites-available -name '*publishing.service.gov.uk' | xargs -n 1 /home/ubuntu/provisioner/add_auth.sh
 sudo sh -c "echo -n 'betademo:N04wQhwGA777s' > /etc/nginx/.htpasswd"
 echo "[$(date '+%H:%M:%S %d-%m-%Y')] END ADDING AUTHENTICATION TO NGINX CONFIGURATION"
 echo

--- a/training-vm/training_user_data.txt
+++ b/training-vm/training_user_data.txt
@@ -120,3 +120,8 @@ echo "[$(date '+%H:%M:%S %d-%m-%Y')] START OBTAIN LETSENCRYPT CERTIFICATES"
 sudo /home/ubuntu/provisioner/acme-certificates.sh
 echo "[$(date '+%H:%M:%S %d-%m-%Y')] END OBTAIN LETSENCRYPT CERTIFICATES"
 echo
+
+echo "[$(date '+%H:%M:%S %d-%m-%Y')] START ADDING AUTHENTICATION TO NGINX CONFIGURATION"
+sudo find /etc/nginx/available_sites -name '*publishing.service.gov.uk' | xargs -n 1 /home/ubuntu/provisioner/add_auth.sh 
+echo "[$(date '+%H:%M:%S %d-%m-%Y')] END ADDING AUTHENTICATION TO NGINX CONFIGURATION"
+echo


### PR DESCRIPTION
Adds very simple username/password authentication to all *publishing.service.gov.uk sites defined in /etc/nginx/available_sites.

Trello: https://trello.com/c/WtlHWxea/15-firebreak-set-up-betademo-http-auth