### PR TITLE
Aws fixes 1

### DIFF
--- a/modules/base/manifests/init.pp
+++ b/modules/base/manifests/init.pp
@@ -21,7 +21,11 @@ class base {
   include logrotate
   include ntp
   include puppet
-  include resolvconf
+
+  if ! $::aws_migration {
+    include resolvconf
+  }
+
   include screen
   include shell
   include ssh

--- a/modules/govuk_puppetdb/files/config.ini
+++ b/modules/govuk_puppetdb/files/config.ini
@@ -1,0 +1,14 @@
+[global]
+
+# Store mq/db data in a custom directory
+vardir = /var/lib/puppetdb
+
+# Use an external log4j config file
+logging-config = /etc/puppetdb/logback.xml
+
+# Maximum number of results that a resource query may return
+resource-query-limit = 20000
+
+[command-processing]
+# How many command-processing threads to use, defaults to (CPUs / 2)
+# threads = 4

--- a/modules/govuk_puppetdb/manifests/init.pp
+++ b/modules/govuk_puppetdb/manifests/init.pp
@@ -25,8 +25,9 @@ class govuk_puppetdb($package_ensure) {
   }
 
   class { 'govuk_puppetdb::config':
-    require => Class['govuk_puppetdb::package'],
-    notify  => Class['govuk_puppetdb::service'];
+    package_ensure => $package_ensure,
+    require        => Class['govuk_puppetdb::package'],
+    notify         => Class['govuk_puppetdb::service'];
   }
 
   class { 'govuk_puppetdb::firewall':


### PR DESCRIPTION
On AWS, use internal DNS already configured in the image, and do not
add Internet DNS servers managed by the resolvconf module

On AWS, Puppetmaster is Trusty. Update Puppetdb version to the latest
in the series 2.x and update the current govuk_puppetdb module to
work with this version:
- Do not manage service script
- Do not exec puppetdb-setup-ssl, the keystore file is not in use by this version and apt should take care of that step 
- Update the name and configuration of the Puppetdb configuration
file to match the changes in version 2