### PR TITLE
Make some small fixes to the training VM scripts

### DIFF
--- a/training-vm/provisioner/acme-certificates.sh
+++ b/training-vm/provisioner/acme-certificates.sh
@@ -12,11 +12,11 @@ NGINX_CONF_DIR="/etc/nginx"
 LETSENCRYPT_DIR="/etc/letsencrypt"
 
 # Add repository and install certbot
-sudo apt-get update
-sudo apt-get install software-properties-common
+sudo apt-get update -qq
+sudo apt-get -y install software-properties-common
 sudo add-apt-repository -y ppa:certbot/certbot
-sudo apt-get update
-sudo apt-get install certbot
+sudo apt-get update -qq
+sudo apt-get -y install certbot
 
 # Certbot starts up its own webserver to perform the ACME protocol,
 # so free up ports 80 and 443 by stopping nginx

--- a/training-vm/training_user_data.txt
+++ b/training-vm/training_user_data.txt
@@ -80,14 +80,19 @@ else
 fi
 
 echo "[$(date '+%H:%M:%S %d-%m-%Y')] START CHECKOUT REPOSITORIES"
-sudo -i -u deploy mkdir -p /var/govuk
-sudo -i -u deploy DEPLOYED_TO_PRODUCTION=true /home/ubuntu/provisioner/checkout-repos.sh -d /var/govuk /home/ubuntu/provisioner/alphagov_repos
+sudo mkdir -p /var/govuk
+sudo DEPLOYED_TO_PRODUCTION=true /home/ubuntu/provisioner/checkout-repos.sh -d /var/govuk /home/ubuntu/provisioner/alphagov_repos
 echo "[$(date '+%H:%M:%S %d-%m-%Y')] END CHECKOUT REPOSITORIES"
 echo
 
 echo "[$(date '+%H:%M:%S %d-%m-%Y')] START PUPPET-APPLY"
 sudo NO_GIT_PULL=1 /var/govuk/govuk-puppet/tools/puppet-apply-dev
 echo "[$(date '+%H:%M:%S %d-%m-%Y')] END PUPPET-APPLY"
+echo
+
+echo "[$(date '+%H:%M:%S %d-%m-%Y')] START CHANGE REPOSITORY OWNER"
+sudo chown -R deploy:deploy /var/govuk
+echo "[$(date '+%H:%M:%S %d-%m-%Y')] END CHANGE REPOSITORY OWNER"
 echo
 
 echo "[$(date '+%H:%M:%S %d-%m-%Y')] START RESTORE DATABASES"


### PR DESCRIPTION
This commit:

* Adds the appropriate flags to `acme-certificates.sh` to ensure `apt-get` doesn’t wait for input
* Changes the repository checkout step to use the `root` user and then change ownership after puppet has run and created the `deploy` user