### PR TITLE
Puppetdb use aws_migration fact for Puppetdb-2 config

### DIFF
--- a/modules/govuk_puppetdb/manifests/init.pp
+++ b/modules/govuk_puppetdb/manifests/init.pp
@@ -25,9 +25,8 @@ class govuk_puppetdb($package_ensure) {
   }
 
   class { 'govuk_puppetdb::config':
-    package_ensure => $package_ensure,
-    require        => Class['govuk_puppetdb::package'],
-    notify         => Class['govuk_puppetdb::service'];
+    require => Class['govuk_puppetdb::package'],
+    notify  => Class['govuk_puppetdb::service'];
   }
 
   class { 'govuk_puppetdb::firewall':


### PR DESCRIPTION
Replace package version evaluation with the aws_migration custom fact to
configure Puppetdb on AWS. Later it will be easier to find all the code
exceptions we've done for AWS.