### PR TITLE
Set environment variables for training VM apps

### DIFF
--- a/training-vm/provisioner/start-training-environment.sh
+++ b/training-vm/provisioner/start-training-environment.sh
@@ -2,15 +2,8 @@
 
 cd "$(dirname "$0")"
 
-# Start all apps that are required in the training environment along with
-# setting the relevant environment variables to use real signon, display
-# images from production where they don't exist locally, and use the local
-# MailHog SMTP port to capture emails. Takes either a file of app names,
-# or from stdin.
-
-export GDS_SSO_STRATEGY=real
-export SHOW_PRODUCTION_IMAGES=true
-export SMTP_PORT=1025
+# Start all apps that are required in the training environment.
+# Takes either a file of app names, or from stdin.
 
 while read app
 do

--- a/training-vm/provisioner/stop-training-environment.sh
+++ b/training-vm/provisioner/stop-training-environment.sh
@@ -5,10 +5,6 @@ cd "$(dirname "$0")"
 # Stop all apps that are required in the training environment. Takes either a
 # file of app names, or from stdin.
 
-unset GDS_SSO_STRATEGY
-unset SHOW_PRODUCTION_IMAGES
-unset SMTP_PORT
-
 while read app
 do
   sudo service $app stop

--- a/training-vm/training_user_data.txt
+++ b/training-vm/training_user_data.txt
@@ -127,6 +127,13 @@ sudo -i -u deploy /var/govuk/signon/script/prepare_training_environment --really
 echo "[$(date '+%H:%M:%S %d-%m-%Y')] END PREPARE SIGNON TRAINING ENVIRONMENT"
 echo
 
+echo "[$(date '+%H:%M:%S %d-%m-%Y')] START SET ENVIRONMENT VARIABLES FOR ALL APPS"
+echo "real" | sudo tee /etc/govuk/env.d/GDS_SSO_STRATEGY > /dev/null
+echo "true" | sudo tee /etc/govuk/env.d/SHOW_PRODUCTION_IMAGES > /dev/null
+echo "1025" | sudo tee /etc/govuk/env.d/SMTP_PORT > /dev/null
+echo "[$(date '+%H:%M:%S %d-%m-%Y')] END SET ENVIRONMENT VARIABLES FOR ALL APPS"
+echo
+
 echo "[$(date '+%H:%M:%S %d-%m-%Y')] START RUN UPSTART APPS"
 sudo /home/ubuntu/provisioner/start-training-environment.sh < /home/ubuntu/provisioner/alphagov_apps
 echo "[$(date '+%H:%M:%S %d-%m-%Y')] END RUN UPSTART APPS"


### PR DESCRIPTION
This commit sets some global environment variables for all apps in the training VM. The variables enable the use of signon for authentication, displaying images from production where they don’t exist in the VM, and sending emails to the local Mailhog instance.