### PR TITLE
Fix Grafana dashboard dir dependency

### DIFF
--- a/modules/grafana/manifests/init.pp
+++ b/modules/grafana/manifests/init.pp
@@ -11,6 +11,8 @@ class grafana {
     require => Class['grafana::repo'],
   }
 
+  Package['grafana'] -> Class['grafana::dashboards']
+
   service { 'grafana-server':
     ensure  => 'running',
     enable  => true,


### PR DESCRIPTION
The `/etc/grafana/dashboard` directory created in grafana::dashboards
needs `/etc/grafana` to exist. `/etc/grafana` is created by the
grafana package, so we are adding a dependency to make sure new
installations run without errors.