### PR TITLE
Make sure /var/lib/jenkins/workspace exists

### DIFF
--- a/modules/govuk_jenkins/manifests/init.pp
+++ b/modules/govuk_jenkins/manifests/init.pp
@@ -59,6 +59,12 @@ class govuk_jenkins (
 
   include ::govuk_python
 
+  file { "${jenkins_homedir}/workspace":
+    ensure => directory,
+    owner  => 'jenkins',
+    group  => 'jenkins',
+  }
+
   class { 'govuk_jenkins::job_builder':
     jenkins_api_user  => $jenkins_api_user,
     jenkins_api_token => $jenkins_api_token,


### PR DESCRIPTION
This directory is required but not always created. This ensures it's created before we try to populate it with jobs.