### PR TITLE
Use clamd to scan files

### DIFF
--- a/modules/govuk/files/node/s_asset_base/virus-scan-file.sh
+++ b/modules/govuk/files/node/s_asset_base/virus-scan-file.sh
@@ -29,7 +29,7 @@ fi
 logger -t virus_scan "Starting scan on $FILENAME"
 
 set +e
-clamscan --quiet $FILENAME
+clamdscan --fdpass --quiet $FILENAME
 EXITCODE=$?
 set -e
 


### PR DESCRIPTION
Currently, for every file we scan for viruses, we boot a new instance
of `clamscan`. This means it has to load the entire virus definition
database each time, and each file takes a minimum of 11 seconds to scan.

`clamd` is a server version of `clamscan`. It keeps the definition
database in memory and has the file passed to it from `clamdscan`,
which acts similarly to `clamscan`. We’ve tried this approach before
but we didn’t use `--fdpass`. This made things fail as `clamd` couldn’t
access the files we were trying to scan. Specifying `--fdpass` passes
the file descriptor from `clamdscan` (which does have access) to
`clamd`.

This should bring the per file scan time down from ~11-14 seconds to
~1-2 seconds.

I've devopsed this on Integration and it works:

Before:
```
Jul 12 14:59:38 asset-master-1.backend virus_scan: Starting scan on /mnt/uploads/whitehall/incoming/system/uploads/image_data/file/65156/s465_UKCN_large_logo_final.jpg
Jul 12 14:59:53 asset-master-1.backend virus_scan: File /mnt/uploads/whitehall/incoming/system/uploads/image_data/file/65156/s465_UKCN_large_logo_final.jpg clean; took 15 seconds
```

After:
```
Jul 12 16:06:04 asset-master-1.backend virus_scan: Starting scan on /mnt/uploads/whitehall/incoming/system/uploads/attachment_data/file/627237/PR_10579A__A.pdf
Jul 12 16:06:06 asset-master-1.backend virus_scan: File /mnt/uploads/whitehall/incoming/system/uploads/attachment_data/file/627237/PR_10579A__A.pdf clean; took 2 seconds
```