### PR TITLE
Update govuk-delivery

### DIFF
--- a/development-vm/Procfile
+++ b/development-vm/Procfile
@@ -40,8 +40,8 @@ asset-manager:         govuk_setenv asset-manager         ./run_in.sh ../../asse
 asset-manager-worker:  govuk_setenv asset-manager         ./run_in.sh ../../asset-manager  bundle exec rake jobs:work
 # limelight used port 3040
 # transaction_wrappers used port 3041
-govuk-delivery:        govuk_setenv govuk-delivery        ./run_in.sh ../../govuk_delivery ./startup.sh # govuk-delivery uses port 3042
-govuk-delivery-worker: govuk_setenv govuk-delivery        ./run_in.sh ../../govuk_delivery ./venv/bin/celery worker -A service
+govuk-delivery:        govuk_setenv govuk-delivery        ./run_in.sh ../../govuk-delivery ./startup.sh # govuk-delivery uses port 3042
+govuk-delivery-worker: govuk_setenv govuk-delivery        ./run_in.sh ../../govuk-delivery ./venv/bin/celery worker -A service
 # tariff_demo_api uses port 3043 in integration only
 transition:            govuk_setenv transition            ./run_in.sh ../../transition     bundle exec rails server -p 3044
 # tariff_demo uses port 3045 in integration only

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -33,9 +33,7 @@ deployable_applications: &deployable_applications
   finder-frontend: {}
   frontend: {}
   government-frontend: {}
-  govuk-delivery:
-    repository: 'govuk_delivery'
-    source: 'github-enterprise'
+  govuk-delivery: {}
   govuk-cdn-logs-monitor: {}
   govuk-content-schemas: {}
   govuk_crawler_worker: {}


### PR DESCRIPTION
`govuk-delivery` has been moved to GitHub.com

Trello: https://trello.com/c/zLOC11AV/23-move-govuk-delivery-from-github-enterprise-to-public-github