### PR TITLE
Upgrade deploy to v2

### DIFF
--- a/hieradata/class/ci_master.yaml
+++ b/hieradata/class/ci_master.yaml
@@ -74,8 +74,6 @@ govuk_jenkins::config::views:
 govuk_jenkins::config::create_agent_role: true
 govuk_jenkins::config::executors: '0'
 
-govuk_jenkins::version: '2.46.2'
-
 govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::integration_deploy
 

--- a/hieradata/class/jenkins.yaml
+++ b/hieradata/class/jenkins.yaml
@@ -30,6 +30,10 @@ govuk_jenkins::config:
       --ajp13Port=-1
       --sessionTimeout=1440
 
+# FIXME: During the upgrade this stopped deploys being triggered from CI. When
+# the resolution has been configured remove this.
+govuk_jenkins::config::csrf_version: false
+
 govuk_jenkins::plugins:
   ansicolor:
     version: '0.5.0'

--- a/hieradata/class/jenkins.yaml
+++ b/hieradata/class/jenkins.yaml
@@ -32,66 +32,148 @@ govuk_jenkins::config:
 
 govuk_jenkins::plugins:
   ansicolor:
-    version: '0.3.1'
+    version: '0.5.0'
+  ant:
+    version: '1.5'
+  antisamy-markup-formatter:
+    version: '1.5'
+  bouncycastle-api:
+    version: '2.16.1'
   build-name-setter:
-    version: '1.3'
+    version: '1.6.7'
   build-pipeline-plugin:
-    version: '1.4.5'
+    version: '1.5.7.1'
   build-with-parameters:
-    version: '1.3'
+    version: '1.4'
   conditional-buildstep:
-    version: '1.3.3'
+    version: '1.3.6'
   copyartifact:
     version: '1.35'
   credentials-binding:
-    version: '1.2'
+    version: '1.12'
+  cvs:
+    version: '2.13'
   description-setter:
-    version: '1.9'
+    version: '1.10'
+  display-url-api:
+    version: '2.0'
   downstream-buildview:
     version: '1.9'
+  durable-task:
+    version: '1.14'
   envinject:
     version: '1.91.1'
   external-monitor-job:
-    version: '1.2'
-  git:
-    version: '2.2.6'
+    version: '1.7'
   git-client:
     version: '1.10.2'
+  git:
+    version: '2.2.6'
   github-api:
-    version: '1.58'
+    version: '1.86'
   github-oauth:
     version: '0.19'
+  google-oauth-plugin:
+    version: '0.5'
+  gradle:
+    version: '1.27.1'
   greenballs:
-    version: '1.14'
-  jquery:
-    version: '1.7.2-1'
-  parameterized-scheduler:
-    version: '0.2'
-  parameterized-trigger:
+    version: '1.15'
+  groovy-postbuild:
+    version: '2.2'
+  icon-shim:
+    version: '2.0.3'
+  instant-messaging:
+    version: '1.33'
+  ircbot:
     version: '2.26'
+  jackson2-api:
+    version: '2.7.3'
+  javadoc:
+    version: '1.4'
+  jquery:
+    version: '1.11.2-0'
+  junit:
+    version: '1.20'
+  ldap:
+    version: '1.16'
+  mailer:
+    version: '1.20'
+  mapdb-api:
+    version: '1.0.9.0'
+  matrix-auth:
+    version: '1.7'
+  matrix-project:
+    version: '1.11'
+  maven-plugin:
+    version: '2.17'
+  nodelabelparameter:
+    version: '1.7.2'
+  oauth-credentials:
+    version: '0.3'
+  pam-auth:
+    version: '1.3'
+  parameterized-scheduler:
+    version: '0.4'
+  parameterized-trigger:
+    version: '2.35.1'
   plain-credentials:
-    version: '1.0'
+    version: '1.4'
+  rake:
+    version: '1.8.0'
   rebuild:
-    version: '1.22'
+    version: '1.25'
+  resource-disposer:
+    version: '0.6'
   role-strategy:
-    version: '2.2.0'
+    version: '2.5.1'
   run-condition:
+    version: '1.0'
+  sbt:
+    version: '1.5'
+  scm-api:
+    version: '2.1.1'
+  scm-sync-configuration:
+    version: '0.0.10'
+  script-security:
+    version: '1.29.1'
+  show-build-parameters:
     version: '1.0'
   simple-theme-plugin:
     version: '0.3'
-  scm-api:
-    version: '0.2'
-  show-build-parameters:
-    version: '1.0'
   slack:
-    version: '1.7'
+    version: '2.2'
+  ssh-credentials:
+    version: '1.13'
+  ssh-slaves:
+    version: '1.20'
+  structs:
+    version: '1.9'
+  subversion:
+    version: '2.9'
   text-finder:
     version: '1.10'
   timestamper:
-    version: '1.8.2'
+    version: '1.8.8'
   token-macro:
-    version: '1.9'
+    version: '2.1'
+  translation:
+    version: '1.15'
   versionnumber:
-    version: '1.5'
+    version: '1.8.1'
+  windows-slaves:
+    version: '1.3.1'
+  workflow-api:
+    version: '2.18'
+  workflow-durable-task-step:
+    version: '2.12'
+  workflow-job:
+    version: '2.11.1'
+  workflow-scm-step:
+    version: '2.5'
+  workflow-step-api:
+    version: '2.12'
+  workflow-support:
+    version: '2.14'
   ws-cleanup:
-    version: '0.25'
+    version: '0.33'

--- a/hieradata/class/jenkins.yaml
+++ b/hieradata/class/jenkins.yaml
@@ -35,6 +35,8 @@ govuk_jenkins::config:
 govuk_jenkins::config::csrf_version: false
 
 govuk_jenkins::plugins:
+  ace-editor:
+    version: '1.1'
   ansicolor:
     version: '0.5.0'
   ant:
@@ -43,16 +45,20 @@ govuk_jenkins::plugins:
     version: '1.5'
   bouncycastle-api:
     version: '2.16.1'
+  branch-api:
+    version: '2.0.10'
   build-name-setter:
     version: '1.6.7'
   build-pipeline-plugin:
     version: '1.5.7.1'
   build-with-parameters:
     version: '1.4'
+  cloudbees-folder:
+    version: '6.0.4'
   conditional-buildstep:
     version: '1.3.6'
   copyartifact:
-    version: '1.35'
+    version: '1.38.1'
   credentials-binding:
     version: '1.12'
   cvs:
@@ -65,18 +71,24 @@ govuk_jenkins::plugins:
     version: '1.9'
   durable-task:
     version: '1.14'
+  envinject-api:
+    version: '1.2'
   envinject:
-    version: '1.91.1'
+    version: '2.1.3'
   external-monitor-job:
     version: '1.7'
   git-client:
-    version: '1.10.2'
+    version: '2.4.6'
   git:
-    version: '2.2.6'
+    version: '3.3.2'
   github-api:
     version: '1.86'
+  github-branch-source:
+    version: '2.0.8'
+  github:
+    version: '1.27.0'
   github-oauth:
-    version: '0.19'
+    version: '0.27'
   google-oauth-plugin:
     version: '0.5'
   gradle:
@@ -84,17 +96,19 @@ govuk_jenkins::plugins:
   greenballs:
     version: '1.15'
   groovy-postbuild:
-    version: '2.2'
+    version: '2.3.1'
   icon-shim:
     version: '2.0.3'
   instant-messaging:
-    version: '1.33'
+    version: '1.35'
   ircbot:
-    version: '2.26'
+    version: '2.27'
   jackson2-api:
     version: '2.7.3'
   javadoc:
     version: '1.4'
+  jquery-detached:
+    version: '1.2.1'
   jquery:
     version: '1.11.2-0'
   junit:
@@ -146,7 +160,7 @@ govuk_jenkins::plugins:
   simple-theme-plugin:
     version: '0.3'
   slack:
-    version: '2.2'
+    version: '1.7'
   ssh-credentials:
     version: '1.13'
   ssh-slaves:
@@ -169,10 +183,14 @@ govuk_jenkins::plugins:
     version: '1.3.1'
   workflow-api:
     version: '2.18'
+  workflow-cps:
+    version: '2.36.1'
   workflow-durable-task-step:
     version: '2.12'
   workflow-job:
     version: '2.11.1'
+  workflow-multibranch:
+    version: '2.16'
   workflow-scm-step:
     version: '2.5'
   workflow-step-api:

--- a/modules/govuk_jenkins/manifests/config.pp
+++ b/modules/govuk_jenkins/manifests/config.pp
@@ -80,6 +80,14 @@
 #   Jenkins master connects to the Jenkins agent with (when using the JNLP
 #   agent). Default is '0', which enables setting a random port number.
 #
+# [*csrf_version*]
+#   Whether to enable Cross-Site Request Forgery protection. In the later
+#   versions of Jenkins this should be enabled by default.
+#
+# [*markup_formatter_version*]
+#   Related to the markup formatter plugin:
+#   https://wiki.jenkins.io/display/JENKINS/OWASP+Markup+Formatter+Plugin
+#
 class govuk_jenkins::config (
   $url_prefix = 'deploy',
   $app_domain = hiera('app_domain'),
@@ -103,6 +111,8 @@ class govuk_jenkins::config (
   $create_agent_role = false,
   $executors = '4',
   $agent_tcp_port = '0',
+  $csrf_version = true,
+  $markup_formatter_version = '1.5',
 ) {
 
   $url = "${url_prefix}.${app_domain}"

--- a/modules/govuk_jenkins/manifests/config.pp
+++ b/modules/govuk_jenkins/manifests/config.pp
@@ -118,15 +118,8 @@ class govuk_jenkins::config (
       group  => 'jenkins',
     }
 
-    # FIXME: Remove once all Jenkinses are upgraded to at least 2.0.0
-    if versioncmp($version, '2.0.0') == 1 {
-      File {
-        notify => Class['Govuk_jenkins::Reload'],
-      }
-    } else {
-      File {
-        notify => Service['jenkins'],
-      }
+    File {
+      notify => Class['Govuk_jenkins::Reload'],
     }
 
     file {'/var/lib/jenkins/com.cloudbees.jenkins.GitHubPushTrigger.xml':
@@ -212,15 +205,6 @@ class govuk_jenkins::config (
     file { '/var/lib/jenkins/jenkins.model.JenkinsLocationConfiguration.xml':
       ensure  => present,
       content => template('govuk_jenkins/config/jenkins.model.JenkinsLocationConfiguration.xml.erb'),
-    }
-
-    # FIXME: Remove once all Jenkinses are upgraded to at least 2.0.0
-    if versioncmp($version, '2.0.0') == 1 {
-      $csrf_version = true
-      $jenkins_2 = true
-      $markup_formatter_version = '1.5'
-    } else {
-      $markup_formatter_version = '1.3'
     }
 
     file { '/var/lib/jenkins/config.xml':

--- a/modules/govuk_jenkins/manifests/init.pp
+++ b/modules/govuk_jenkins/manifests/init.pp
@@ -48,7 +48,7 @@ class govuk_jenkins (
   $plugins = {},
   $ssh_private_key = undef,
   $ssh_public_key = undef,
-  $version = '1.554.2',
+  $version = '2.46.2',
   $jenkins_api_user = 'deploy',
   $jenkins_api_token = '',
   $jenkins_user = 'jenkins',

--- a/modules/govuk_jenkins/templates/config/config.xml.erb
+++ b/modules/govuk_jenkins/templates/config/config.xml.erb
@@ -23,13 +23,8 @@
     <roleMap type="globalRoles">
       <role name="Anonymouse" pattern=".*">
         <permissions>
-          <%- if @jenkins_2 -%>
           <permission>hudson.model.Item.Discover</permission>
           <permission>hudson.model.Hudson.Read</permission>
-          <%- else -%>
-          <permission>hudson.model.Hudson.Read</permission>
-          <permission>hudson.model.Item.Discover</permission>
-          <%- end -%>
         </permissions>
         <assignedSIDs>
           <sid>anonymous</sid>
@@ -37,7 +32,6 @@
       </role>
       <role name="admin" pattern=".*">
         <permissions>
-          <%- if @jenkins_2 -%>
           <permission>hudson.scm.SCM.Tag</permission>
           <permission>hudson.model.View.Delete</permission>
           <permission>hudson.model.Item.Read</permission>
@@ -56,30 +50,10 @@
           <permission>hudson.model.Item.Delete</permission>
           <permission>hudson.model.Run.Update</permission>
           <permission>hudson.model.View.Configure</permission>
-          <%- else -%>
-          <permission>hudson.model.Hudson.Administer</permission>
-          <permission>hudson.model.Hudson.Read</permission>
-          <permission>hudson.model.Hudson.RunScripts</permission>
-          <permission>hudson.model.Item.Build</permission>
-          <permission>hudson.model.Item.Cancel</permission>
-          <permission>hudson.model.Item.Configure</permission>
-          <permission>hudson.model.Item.Create</permission>
-          <permission>hudson.model.Item.Delete</permission>
-          <permission>hudson.model.Item.Discover</permission>
-          <permission>hudson.model.Item.Read</permission>
-          <permission>hudson.model.Item.Workspace</permission>
-          <permission>hudson.model.Run.Delete</permission>
-          <permission>hudson.model.Run.Update</permission>
-          <permission>hudson.model.View.Configure</permission>
-          <permission>hudson.model.View.Create</permission>
-          <permission>hudson.model.View.Delete</permission>
-          <permission>hudson.model.View.Read</permission>
-          <permission>hudson.scm.SCM.Tag</permission>
-          <%- end -%>
         </permissions>
         <assignedSIDs>
           <%- @admins.each do |a| -%>
-          <%- if not @jenkins_2 -%>!<%- end -%><sid><%= a %></sid>
+          <sid><%= a %></sid>
           <%- end -%>
         </assignedSIDs>
       </role>
@@ -116,9 +90,7 @@
     <githubApiUri><%= @github_api_uri -%></githubApiUri>
     <clientID><%= @github_client_id -%></clientID>
     <clientSecret><%= @github_client_secret -%></clientSecret>
-    <%- if @jenkins_2 -%>
     <oauthScopes>read:org,user:email</oauthScopes>
-    <%- end -%>
   </securityRealm>
   <disableRememberMe>false</disableRememberMe>
   <projectNamingStrategy class="jenkins.model.ProjectNamingStrategy$PatternProjectNamingStrategy">
@@ -136,9 +108,6 @@
   <viewsTabBar class="hudson.views.DefaultViewsTabBar"/>
   <myViewsTabBar class="hudson.views.DefaultMyViewsTabBar"/>
   <clouds/>
-  <%- if not @jenkins_2 -%>
-  <slaves/>
-  <%- end -%>
   <quietPeriod>5</quietPeriod>
   <scmCheckoutRetryCount>0</scmCheckoutRetryCount>
   <views>


### PR DESCRIPTION
This branch is used to upgrade Jenkins v1 to v2 in place. The upgrade steps are as follows:

 - Lock Puppet on `jenkins-1`
 - Make a backup of working `/var/lib/jenkins` directory, excl. `bundles` and `workspace`
 - Moved `/var/lib/jenkins/config.xml` out the way
 - Manually moved the 2.46.2 version of Jenkins to `/usr/share/jenkins/jenkins.war`
 - Moved the current `/var/lib/jenkins/config.xml` out of the way
 - `sudo service jenkins restart`
 - When Jenkins has come back up with no security set, log in and update all the plugins. When it has rebooted, you may have to update plugins one further time.
 - To deploy Puppet, you will need to set the `ORGANISATION` global env
 - Deploy this branch of Puppet - I also had some warnings over the Slack plugin, but that can be removed temporarily from the configuration if required
 - Take backup of working `config.xml`
 - Run Puppet on `jenkins-1` and check changes seem sane
 - Attempt login to Jenkins

