### PR TITLE
Update rbenv Ruby and Bundler versions

### DIFF
--- a/modules/govuk_rbenv/manifests/all.pp
+++ b/modules/govuk_rbenv/manifests/all.pp
@@ -29,8 +29,11 @@ class govuk_rbenv::all (
   rbenv::version { '2.1.8':
     bundler_version => '1.14.5',
   }
+  rbenv::version { '2.1.10':
+    bundler_version => '1.14.5',
+  }
   rbenv::alias { '2.1':
-    to_version => '2.1.8',
+    to_version => '2.1.10',
   }
 
   rbenv::version { '2.2.2':
@@ -42,8 +45,11 @@ class govuk_rbenv::all (
   rbenv::version { '2.2.4':
     bundler_version => '1.14.5',
   }
+  rbenv::version { '2.2.7':
+    bundler_version => '1.14.5',
+  }
   rbenv::alias { '2.2':
-    to_version => '2.2.4',
+    to_version => '2.2.7',
   }
 
   rbenv::version { '2.3.0':
@@ -52,14 +58,20 @@ class govuk_rbenv::all (
   rbenv::version { '2.3.1':
     bundler_version => '1.14.5',
   }
+  rbenv::version { '2.3.4':
+    bundler_version => '1.14.5',
+  }
   rbenv::alias { '2.3':
-    to_version => '2.3.1',
+    to_version => '2.3.4',
   }
 
   rbenv::version { '2.4.0':
     bundler_version => '1.14.5',
   }
+  rbenv::version { '2.4.1':
+    bundler_version => '1.14.5',
+  }
   rbenv::alias { '2.4':
-    to_version => '2.4.0',
+    to_version => '2.4.1',
   }
 }

--- a/modules/govuk_rbenv/manifests/all.pp
+++ b/modules/govuk_rbenv/manifests/all.pp
@@ -21,55 +21,55 @@ class govuk_rbenv::all (
   }
 
   rbenv::version { '2.1.4':
-    bundler_version => '1.14.5',
+    bundler_version => '1.15.1',
   }
   rbenv::version { '2.1.5':
-    bundler_version => '1.14.5',
+    bundler_version => '1.15.1',
   }
   rbenv::version { '2.1.8':
-    bundler_version => '1.14.5',
+    bundler_version => '1.15.1',
   }
   rbenv::version { '2.1.10':
-    bundler_version => '1.14.5',
+    bundler_version => '1.15.1',
   }
   rbenv::alias { '2.1':
     to_version => '2.1.10',
   }
 
   rbenv::version { '2.2.2':
-    bundler_version => '1.14.5',
+    bundler_version => '1.15.1',
   }
   rbenv::version { '2.2.3':
-    bundler_version => '1.14.5',
+    bundler_version => '1.15.1',
   }
   rbenv::version { '2.2.4':
-    bundler_version => '1.14.5',
+    bundler_version => '1.15.1',
   }
   rbenv::version { '2.2.7':
-    bundler_version => '1.14.5',
+    bundler_version => '1.15.1',
   }
   rbenv::alias { '2.2':
     to_version => '2.2.7',
   }
 
   rbenv::version { '2.3.0':
-    bundler_version => '1.15.0',
+    bundler_version => '1.15.1',
   }
   rbenv::version { '2.3.1':
-    bundler_version => '1.14.5',
+    bundler_version => '1.15.1',
   }
   rbenv::version { '2.3.4':
-    bundler_version => '1.14.5',
+    bundler_version => '1.15.1',
   }
   rbenv::alias { '2.3':
     to_version => '2.3.4',
   }
 
   rbenv::version { '2.4.0':
-    bundler_version => '1.14.5',
+    bundler_version => '1.15.1',
   }
   rbenv::version { '2.4.1':
-    bundler_version => '1.14.5',
+    bundler_version => '1.15.1',
   }
   rbenv::alias { '2.4':
     to_version => '2.4.1',


### PR DESCRIPTION
* Add missing versions of Ruby to rbenv list
* Update rbenv aliases to appropriate Ruby version
* Upgrade bundler version to latest version (v1.15.1) across the board (mostly from v1.14.5)

I've tried to explain why I think it should be safe to make these changes in the relevant commit notes, but I'm willing to be persuaded the changes should be made in smaller increments.