### PR TITLE
Bump the Ubuntu nginx package version

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1454,7 +1454,7 @@ monitoring::vpn_gateways::endpoints:
 # FIXME: this has been added to avoid a bug until we move to v3 of the module
 mysql::client::package_ensure: 'present'
 
-nginx::package::version: '1.4.6-1ubuntu3.7'
+nginx::package::version: '1.4.6-1ubuntu3.8'
 
 nodejs::version: '0.10.37-1chl1~%{::lsbdistcodename}1'
 

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1461,7 +1461,7 @@ monitoring::vpn_gateways::endpoints:
 # FIXME: this has been added to avoid a bug until we move to v3 of the module
 mysql::client::package_ensure: 'present'
 
-nginx::package::version: '1.4.6-1ubuntu3.7'
+nginx::package::version: '1.4.6-1ubuntu3.8'
 
 nodejs::version: '0.10.37-1chl1~%{::lsbdistcodename}1'
 


### PR DESCRIPTION
A security update was released bumping version 3.7 to 3.8:
https://launchpad.net/ubuntu/+source/nginx/1.4.6-1ubuntu3.8

The correct package to use can be found by running `aptitude show nginx`.

This version bump brings us up to the correct version.