### PR TITLE
Add AWS facts and AWS_DEFAULT_REGION to user profile

### DIFF
--- a/modules/govuk/lib/facter/aws.rb
+++ b/modules/govuk/lib/facter/aws.rb
@@ -46,14 +46,12 @@ if Facter.value(:aws_migration)
   ]
 
   # Loop through every fact but only add it if it's in our list
-  aws_facts.each do |key, val|
-    factname = key.downcase
-    facts.each do |fact|
-      if factname == fact
-        Facter.add("aws_#{factname}") do
-          setcode do
-            val
-          end
+  aws_facts.each do |key,val|
+  factname = key.downcase
+    if facts.include?(factname)
+      Facter.add("aws_#{factname}") do
+        setcode do
+          val
         end
       end
     end

--- a/modules/govuk/lib/facter/aws.rb
+++ b/modules/govuk/lib/facter/aws.rb
@@ -1,0 +1,61 @@
+# Produces a bunch of AWS facts specific to each instance:
+#
+# availabilityzone
+# instanceid
+# instancetype
+# imageid
+# accountid
+# region
+#
+# Fact name will be the key above prefixed with "aws_"
+#
+require 'net/http'
+require 'json'
+
+# Lazily loads all the following information into JSON object:
+#   devpayproductcodes
+#   privateip
+#   availabilityzone
+#   version
+#   instanceid
+#   billingproducts
+#   instancetype
+#   imageid
+#   accountid
+#   kernelid
+#   ramdiskid
+#   architecture
+#   pendingtime
+#   region
+#
+def aws_facts
+  uri = URI.parse("http://169.254.169.254/latest/dynamic/instance-identity/document")
+  body = Net::HTTP.get_response(uri).body
+  JSON.parse(body)
+end
+
+if Facter.value(:aws_migration)
+  # Choose the facts we think are useful
+  facts = [
+    'availabilityzone',
+    'instanceid',
+    'instancetype',
+    'imageid',
+    'accountid',
+    'region',
+  ]
+
+  # Loop through every fact but only add it if it's in our list
+  aws_facts.each do |key, val|
+    factname = key.downcase
+    facts.each do |fact|
+      if factname == fact
+        Facter.add("aws_#{factname}") do
+          setcode do
+            val
+          end
+        end
+      end
+    end
+  end
+end

--- a/modules/shell/templates/bashrc.erb
+++ b/modules/shell/templates/bashrc.erb
@@ -83,3 +83,8 @@ alias l='ls -CF'
 
 # Use xvfb for DISPLAY, so that some integration tests can run
 export DISPLAY=:99
+
+<%- if scope.lookupvar('::aws_migration') %>
+# Set AWS specific environment settings
+export AWS_DEFAULT_REGION=<%= @aws_region %>
+<%- end -%>


### PR DESCRIPTION
Add a bunch of AWS specific facts if an instance lives in Amazon.

Set the AWS_DEFAULT_REGION default profile which is useful when working with the `aws` tool.