### PR TITLE
Add AWS Jenkins config

### DIFF
--- a/hieradata_aws/class/jenkins.yaml
+++ b/hieradata_aws/class/jenkins.yaml
@@ -1,0 +1,68 @@
+---
+govuk_jenkins::config::banner_string: 'AWS Deploy'
+
+govuk_jenkins::plugins:
+  ansicolor:
+    version: '0.3.1'
+  build-name-setter:
+    version: '1.3'
+  build-pipeline-plugin:
+    version: '1.4.5'
+  build-with-parameters:
+    version: '1.3'
+  conditional-buildstep:
+    version: '1.3.3'
+  copyartifact:
+    version: '1.35'
+  credentials-binding:
+    version: '1.2'
+  description-setter:
+    version: '1.9'
+  downstream-buildview:
+    version: '1.9'
+  envinject:
+    version: '1.91.1'
+  external-monitor-job:
+    version: '1.2'
+  git:
+    version: '2.2.6'
+  git-client:
+    version: '1.10.2'
+  github-api:
+    version: '1.58'
+  github-oauth:
+    version: '0.19'
+  greenballs:
+    version: '1.14'
+  jquery:
+    version: '1.7.2-1'
+  parameterized-scheduler:
+    version: '0.2'
+  parameterized-trigger:
+    version: '2.26'
+  plain-credentials:
+    version: '1.0'
+  rebuild:
+    version: '1.22'
+  role-strategy:
+    version: '2.2.0'
+  run-condition:
+    version: '1.0'
+  simple-theme-plugin:
+    version: '0.3'
+  scm-api:
+    version: '0.2'
+  show-build-parameters:
+    version: '1.0'
+  slack:
+    version: '1.7'
+  text-finder:
+    version: '1.10'
+  timestamper:
+    version: '1.8.2'
+  token-macro:
+    version: '1.9'
+  versionnumber:
+    version: '1.5'
+  ws-cleanup:
+    version: '0.25'


### PR DESCRIPTION
This is a slightly trimmed down version of the standard Jenkins config which specifies which version of plugins to install.

The config [here](https://github.com/alphagov/govuk-puppet/blob/02939f0941cd97c411705c1a166f1c144865259c/hieradata/class/jenkins.yaml#L3-L31) isn't present for ci_master, and I can't see any reason why we may want to specify the options in it, so I am omitting it.