### PR TITLE
New hierachy for stackname credentials

### DIFF
--- a/hiera_aws.yml
+++ b/hiera_aws.yml
@@ -3,6 +3,7 @@
   - 'node/%{::fqdn}'
   - 'class/%{::aws_stackname}/%{::govuk_node_class}'
   - 'class/%{::govuk_node_class}'
+  - 'class/%{::aws_stackname}/%{::environment}_credentials'
   - '%{::environment}_credentials'
   - '%{::environment}'
   - 'common.%{::lsbdistcodename}'


### PR DESCRIPTION
This would allow overwriting credentials for a specific stack. This may be required for things like Jenkins, which generates tokens based upon the instance it's running on.