### PR TITLE
Update hieradata_aws domains to match new schema; Elasticsearch AWS config

### DIFF
--- a/hieradata_aws/class/logs_elasticsearch.yaml
+++ b/hieradata_aws/class/logs_elasticsearch.yaml
@@ -1,0 +1,24 @@
+---
+
+govuk_safe_to_reboot::can_reboot: 'careful'
+govuk_safe_to_reboot::reason: 'Reboot a single node at time and check that the cluster goes green between reboots'
+
+govuk_elasticsearch::version: '1.4.4'
+govuk_elasticsearch::open_firewall_from_all: true
+
+icinga::client::checks::disk_time_warn: 200 # milliseconds
+icinga::client::checks::disk_time_critical: 300 # milliseconds
+
+lv:
+  data:
+    pv:
+        - '/dev/xvdf'
+    vg: 'elasticsearch'
+
+mount:
+  /mnt/elasticsearch:
+    disk: '/dev/mapper/elasticsearch-data'
+    govuk_lvm: 'data'
+    mountoptions: 'defaults'
+    percent_threshold_warning: 16
+    percent_threshold_critical: 11

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -2,7 +2,7 @@
 HIERA_SAFETY_CHECK: true
 
 stackname: "%{::aws_stackname}"
-app_domain: "%{::aws_stackname}.internal"
+app_domain: "%{::aws_stackname}.govuk.internal"
 
 # If the repository name is the same as the application name
 # we don't need to explicitly declare the repository, but we

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -1,6 +1,8 @@
 ---
 _: &offsite_gpg_key 'DA204134165653A8D32526FCDBAB06CD60D07A2C'
 
+app_domain: "%{::aws_stackname}.integration.govuk.internal"
+
 backup::mysql::rotation_daily: '2'
 backup::mysql::rotation_weekly: '6'
 backup::mysql::rotation_monthly: '28'


### PR DESCRIPTION
We've decided to use <stackname>.<environment>.govuk.internal for
internal domains.

Add pending elasticsearch configuration for AWS