### PR TITLE
Add govuk-aws repo to CI

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -583,6 +583,7 @@ govuk_ci::master::pipeline_jobs:
   google-auth-bridge: {}
   govspeak: {}
   govuk-app-deployment: {}
+  govuk-aws: {}
   govuk-diff-pages: {}
   govuk_admin_template: {}
   govuk_ab_testing: {}


### PR DESCRIPTION
Good practice and helps us if we want to run any tests in the future.