### PR TITLE
Add govuk index worker to Rummager and RabbitMQ

### DIFF
--- a/development-vm/Pinfile
+++ b/development-vm/Pinfile
@@ -59,9 +59,10 @@ process :'publishing-api-worker' => [:'content-store', :'router-api']
 process :release
 process :router
 process :'router-api'
-process :rummager => [:'publishing-api-read', :'rummager-sidekiq', :'rummager-publishing-listener']
+process :rummager => [:'publishing-api-read', :'rummager-sidekiq', :'rummager-publishing-listener', :'rummager-govuk-index-listener']
 process :'rummager-sidekiq'
 process :'rummager-publishing-listener'
+process :'rummager-govuk-index-listener'
 process :screenshot_as_a_service
 process :'search-admin' => [:rummager]
 process :'service-manual-frontend' => [:'content-store', :static]

--- a/development-vm/Procfile
+++ b/development-vm/Procfile
@@ -8,6 +8,7 @@ frontend:              govuk_setenv frontend              ./run_in.sh ../../fron
 rummager:              govuk_setenv rummager              ./run_in.sh ../../rummager       bundle exec mr-sparkle --force-polling -- -p 3009
 rummager-sidekiq:      govuk_setenv rummager              ./run_in.sh ../../rummager       bundle exec sidekiq -C ./config/sidekiq.yml
 rummager-publishing-listener: govuk_setenv rummager       ./run_in.sh ../../rummager       bundle exec rake message_queue:listen_to_publishing_queue
+rummager-govuk-index-listener: govuk_setenv rummager      ./run_in.sh ../../rummager       bundle exec rake message_queue:insert_data_into_govuk
 smartanswers:          govuk_setenv smartanswers          ./run_in.sh ../../smart-answers  bundle exec rails server -p 3010
 calendars:             govuk_setenv calendars             ./run_in.sh ../../calendars      bundle exec rails server -p 3011
 static:                govuk_setenv static                ./run_in.sh ../../static         bundle exec rails server -p 3013

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -417,6 +417,7 @@ govuk::apps::rummager::nagios_memory_warning: 4600
 govuk::apps::rummager::nagios_memory_critical: 4900
 govuk::apps::rummager::enable_publishing_listener: true
 govuk::apps::rummager::rabbitmq::enable_publishing_listener: true
+govuk::apps::rummager::rabbitmq_user: 'rummager'
 govuk::apps::rummager::redis_host: 'api-redis-1.api'
 govuk::apps::rummager::redis_port: '6379'
 

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -160,7 +160,10 @@ govuk::apps::router_api::enable_running_in_draft_mode::router_nodes: ['localhost
 govuk::apps::rummager::enable_procfile_worker: false
 govuk::apps::rummager::rabbitmq_hosts: ['localhost']
 govuk::apps::rummager::enable_publishing_listener: true
+govuk::apps::rummager::enable_govuk_index_listener: true
 govuk::apps::rummager::rabbitmq::enable_publishing_listener: true
+govuk::apps::rummager::rabbitmq::enable_govuk_index_listener: true
+govuk::apps::rummager::rabbitmq_user: 'rummager-v2'
 govuk::apps::rummager::redis_host: 'localhost'
 govuk::apps::signon::enable_procfile_worker: false
 govuk::apps::smartanswers::expose_govspeak: true

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -33,6 +33,9 @@ govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
 govuk::apps::publicapi::backdrop_host: 'www.preview.performance.service.gov.uk'
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-integration'
 govuk::apps::publishing_api::content_api_prototype: true
+govuk::apps::rummager::enable_govuk_index_listener: true
+govuk::apps::rummager::rabbitmq::enable_govuk_index_listener: true
+govuk::apps::rummager::rabbitmq_user: 'rummager-v2'
 govuk::apps::short_url_manager::instance_name: 'integration'
 govuk::apps::signon::instance_name: 'integration'
 govuk::apps::smartanswers::expose_govspeak: true

--- a/modules/govuk/manifests/apps/rummager/rabbitmq.pp
+++ b/modules/govuk/manifests/apps/rummager/rabbitmq.pp
@@ -13,8 +13,12 @@
 # [*enable_publishing_listener*]
 #   Whether or not to configure the queue for the rummager indexer
 #
+# [*enable_govuk_index_listener*]
+#   Whether or not to configure the queue for the rummager govuk indexer
+#
 class govuk::apps::rummager::rabbitmq (
   $password  = 'rummager',
+  $enable_govuk_index_listener = false,
   $enable_publishing_listener = false,
 ) {
 
@@ -23,11 +27,29 @@ class govuk::apps::rummager::rabbitmq (
     default => absent,
   }
 
+  $toggled_govuk_index_listener = $enable_govuk_index_listener ? {
+    true    => present,
+    default => absent,
+  }
+
+  # match everything on queue 2 while we test
+  govuk_rabbitmq::consumer { 'rummager-v2':
+    ensure        => $toggled_ensure,
+    amqp_pass     => $password,
+    amqp_exchange => 'published_documents',
+    amqp_queue    => 'rummager_to_be_indexed',
+    routing_key   => '*.links',
+    amqp_queue_2  => 'rummager_govuk_index',
+    routing_key_2 => '#',
+  }
+
+  # deprecated - we will remove this user once we have migrated to the new user
   govuk_rabbitmq::consumer { 'rummager':
     ensure        => $toggled_ensure,
     amqp_pass     => $password,
     amqp_exchange => 'published_documents',
     amqp_queue    => 'rummager_to_be_indexed',
     routing_key   => '*.links',
+    create_queue  => false,
   }
 }

--- a/modules/govuk_rabbitmq/spec/defines/govuk_rabbitmq__consumer_spec.rb
+++ b/modules/govuk_rabbitmq/spec/defines/govuk_rabbitmq__consumer_spec.rb
@@ -7,6 +7,92 @@ describe 'govuk_rabbitmq::consumer', :type => :define do
     staging_http_get: 'curl',
   }}
 
+  context 'multiple queues' do
+    let(:params) {{
+      :amqp_pass => 'super_secret',
+      :amqp_exchange => 'an_exchange',
+      :amqp_queue => 'a_queue',
+      :routing_key => 'some routing key',
+      :amqp_queue_2 => 'a_second_queue',
+      :routing_key_2 => 'another routing key',
+    }}
+
+    it { is_expected.to contain_rabbitmq_user('a_user').with_password('super_secret') }
+
+    it {
+      is_expected.to contain_rabbitmq_queue('a_queue@/').with(
+          :durable     => true,
+          :auto_delete => false,
+      )
+      is_expected.to contain_rabbitmq_queue('a_second_queue@/').with(
+          :durable     => true,
+          :auto_delete => false,
+      )
+    }
+
+    it {
+      is_expected.to contain_rabbitmq_binding('binding_some routing key_an_exchange@a_queue@/').with(
+          :destination_type => 'queue',
+          :routing_key      => 'some routing key',
+      )
+      is_expected.to contain_rabbitmq_binding('binding_another routing key_an_exchange@a_second_queue@/').with(
+          :destination_type => 'queue',
+          :routing_key      => 'another routing key',
+      )
+    }
+
+    context 'when create_queue is false' do
+      let(:params) {{
+        :amqp_pass => 'super_secret',
+        :amqp_exchange => 'an_exchange',
+        :amqp_queue => 'a_queue',
+        :routing_key => 'some routing key',
+        :amqp_queue_2 => 'a_second_queue',
+        :routing_key_2 => 'another routing key',
+        :create_queue => false
+      }}
+
+      it {
+        is_expected.not_to contain_rabbitmq_queue('a_queue@/')
+        is_expected.not_to contain_rabbitmq_queue('a_second_queue@/')
+      }
+    end
+
+    it {
+      is_expected.to contain_rabbitmq_user_permissions('a_user@/').with(
+        :configure_permission => '^(amq\.gen.*|a_queue|a_second_queue)$',
+        :write_permission => '^(amq\.gen.*|a_queue|a_second_queue)$',
+        :read_permission => '^(amq\.gen.*|a_queue|a_second_queue|an_exchange)$',
+      )
+    }
+
+    it { is_expected.not_to contain_govuk_rabbitmq__exchange }
+  end
+
+  context 'missing routing key' do
+    let(:params) {{
+      :amqp_pass => 'super_secret',
+      :amqp_exchange => 'an_exchange',
+      :amqp_queue => 'a_queue',
+      :routing_key => '',
+      }}
+
+      it { is_expected.to raise_error(Puppet::Error, /\$routing_key must be non-empty/) }
+  end
+
+  context 'missing routing key for optional queue' do
+    let(:params) {{
+      :amqp_pass => 'super_secret',
+      :amqp_exchange => 'an_exchange',
+      :amqp_queue => 'a_queue',
+      :routing_key => 'some routing key',
+      :amqp_queue_2 => 'a_second_queue',
+      :routing_key_2 => '',
+      }}
+
+      it { is_expected.to raise_error(Puppet::Error, /\$routing_key_2 must be non-empty/) }
+  end
+
   context 'minimum info' do
     let(:params) {{
       :amqp_pass => 'super_secret',


### PR DESCRIPTION
We are creating a new govuk index for Elasticsearch. This eventually will consume
messages from the publishing api for all publishing events.

Once all the content has been migrated to this new index this will
replace the publishing-queue-listener which only consumes updates to links.

For now we are just listening for major publishing events while we test
things.

https://trello.com/c/dmBzBVLG/160-insert-data-into-govuk-index-from-rabbitmq-message

Mobbed with @binaryberry @suzannehamilton @dwhenry @Rosa-Fox 