### PR TITLE
Make search analytics job alerts non-critical

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/failure_passive_check.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/failure_passive_check.yaml.erb
@@ -8,7 +8,6 @@
     builders:
       - shell: |
           IPADDRESS=$(facter ipaddress)
-          NSCA_CODE=2
           printf "$IPADDRESS\t$NSCA_CHECK_DESCRIPTION\t$NSCA_CODE\t$NSCA_OUTPUT\n" | /usr/sbin/send_nsca -H alert.cluster >/dev/null
     wrappers:
         - ansicolor:
@@ -20,3 +19,11 @@
         - string:
             name: NSCA_OUTPUT
             description: 'Description for the condition of the failure'
+        - choice:
+            name: NSCA_CODE
+            description: 'Type of alert to trigger. 1=warning, 2=critical, 3=unknown.'
+            # Choices are listed out of order so that 2 (critical) is the default
+            choices:
+                - '2'
+                - '1'
+                - '3'

--- a/modules/govuk_jenkins/templates/jobs/search_fetch_analytics_data.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/search_fetch_analytics_data.yaml.erb
@@ -39,6 +39,7 @@
               predefined-parameters: |
                   NSCA_CHECK_DESCRIPTION=<%= @service_description %>
                   NSCA_OUTPUT=<%= @service_description %> failed
+                  NSCA_CODE=1
     wrappers:
         - ansicolor:
             colormap: xterm


### PR DESCRIPTION
Currently whenever a jenkins job fails, it raises a critical alert.
Allow this to be overriden so we can raise warning alerts instead.

The search-fetch-analytics job is known to be flaky, but it's fine to
leave it until the next day.

https://trello.com/c/xAUa1fQn/162-deprioritise-errors-when-search-reindex-fails