### PR TITLE
Update authorization strategy for AWS Jenkins

### DIFF
--- a/hieradata_aws/class/jenkins.yaml
+++ b/hieradata_aws/class/jenkins.yaml
@@ -1,4 +1,43 @@
 ---
+jenkins_admin_permission_list: &jenkins_admin_permission_list
+  - 'hudson.model.Hudson.Administer'
+  - 'hudson.model.Hudson.Read'
+  - 'hudson.model.Hudson.RunScripts'
+  - 'hudson.model.Item.Build'
+  - 'hudson.model.Item.Cancel'
+  - 'hudson.model.Item.Configure'
+  - 'hudson.model.Item.Create'
+  - 'hudson.model.Item.Delete'
+  - 'hudson.model.Item.Discover'
+  - 'hudson.model.Item.Read'
+  - 'hudson.model.Item.Workspace'
+  - 'hudson.model.Run.Delete'
+  - 'hudson.model.Run.Update'
+  - 'hudson.model.View.Configure'
+  - 'hudson.model.View.Create'
+  - 'hudson.model.View.Delete'
+  - 'hudson.model.View.Read'
+  - 'hudson.scm.SCM.Tag'
+
+govuk_jenkins::config::manage_permissions_github_teams: true
+govuk_jenkins::config::user_permissions:
+  -
+    user: 'ci_alphagov'
+    permissions: *jenkins_admin_permission_list
+  -
+    user: 'alphagov*GOV.UK'
+    permissions: *jenkins_admin_permission_list
+  -
+    user: 'anonymous'
+    permissions:
+      - 'hudson.model.Hudson.Read'
+      - 'hudson.model.Item.Discover'
+  -
+    user: 'github'
+    permissions:
+      - 'hudson.model.Item.Build'
+      - 'hudson.model.Item.Read'
+
 govuk_jenkins::config::banner_string: 'AWS Deploy'
 
 govuk_jenkins::plugins:

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -744,8 +744,8 @@ govuk_jenkins::github_enterprise_cert::certificate: |
     -----END CERTIFICATE-----
 govuk_jenkins::github_enterprise_cert::certificate_path: "/var/lib/jenkins/github.digital.cabinet-office.gov.uk.pem"
 govuk_jenkins::github_enterprise_cert::github_enterprise_hostname: "github.digital.cabinet-office.gov.uk"
-govuk_jenkins::config::github_api_uri: "%{hiera('govuk_jenkins::config::github_web_uri')}/api/v3"
-govuk_jenkins::config::github_web_uri: "https://%{hiera('govuk_jenkins::github_enterprise_cert::github_enterprise_hostname')}"
+govuk_jenkins::config::github_api_uri: "https://api.github.com"
+govuk_jenkins::config::github_web_uri: "https://github.com"
 govuk_jenkins::job::deploy_app::app_domain: "%{hiera('app_domain')}"
 
 govuk_jenkins::job::search_benchmark::auth_username: "%{hiera('http_username')}"


### PR DESCRIPTION
Use github.com to authenticate into Jenkins in AWS.