### PR TITLE
Add govuk_publishing_components to jenkins

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -597,6 +597,7 @@ govuk_ci::master::pipeline_jobs:
   govuk_mirrorer: {}
   govuk_navigation_helpers: {}
   govuk-provisioning: {}
+  govuk_publishing_components: {}
   govuk_seed_crawler: {}
   govuk_schemas: {}
   govuk_security_audit: {}


### PR DESCRIPTION
`govuk_publishing_components` is a gem for documenting components across our frontend applications.

https://github.com/alphagov/govuk_publishing_components
https://trello.com/c/SD6M3IUF/