### PR TITLE
Set postgres max_connections to 120 in staging

### DIFF
--- a/hieradata/class/staging/postgresql_primary.yaml
+++ b/hieradata/class/staging/postgresql_primary.yaml
@@ -1,0 +1,1 @@
+govuk_postgresql::server::max_connections: 120

--- a/hieradata/class/staging/postgresql_standby.yaml
+++ b/hieradata/class/staging/postgresql_standby.yaml
@@ -1,0 +1,1 @@
+govuk_postgresql::server::max_connections: 120


### PR DESCRIPTION
- We were seeing alerts for "postgres high connections used", at
  84/100. In production, max_connections is set to 200, but that
  requires more memory, so up it to 120 in staging to see if it helps
  without needing a memory upgrade.