### PR TITLE
Update Jenkins auth to use Github

### DIFF
--- a/hieradata/class/ci_master.yaml
+++ b/hieradata/class/ci_master.yaml
@@ -20,16 +20,12 @@ jenkins_admin_permission_list: &jenkins_admin_permission_list
   - 'hudson.model.View.Read'
   - 'hudson.scm.SCM.Tag'
 
-govuk_jenkins::config::manage_permissions_github_teams: true
 govuk_jenkins::config::user_permissions:
   -
     user: 'ci_alphagov'
     permissions: *jenkins_admin_permission_list
   -
-    user: 'gds*GOV.UK non-security-cleared-devs'
-    permissions: *jenkins_admin_permission_list
-  -
-    user: 'gds*GOV.UK security-cleared staff'
+    user: 'alphagov*GOV.UK'
     permissions: *jenkins_admin_permission_list
   -
     user: 'anonymous'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -743,8 +743,8 @@ govuk_jenkins::github_enterprise_cert::certificate: |
     -----END CERTIFICATE-----
 govuk_jenkins::github_enterprise_cert::certificate_path: "/var/lib/jenkins/github.digital.cabinet-office.gov.uk.pem"
 govuk_jenkins::github_enterprise_cert::github_enterprise_hostname: "github.digital.cabinet-office.gov.uk"
-govuk_jenkins::config::github_api_uri: "%{hiera('govuk_jenkins::config::github_web_uri')}/api/v3"
-govuk_jenkins::config::github_web_uri: "https://%{hiera('govuk_jenkins::github_enterprise_cert::github_enterprise_hostname')}"
+govuk_jenkins::config::github_api_uri: "https://api.github.com"
+govuk_jenkins::config::github_web_uri: "https://github.com"
 govuk_jenkins::job::deploy_app::app_domain: "%{hiera('app_domain')}"
 
 govuk_jenkins::job::search_benchmark::auth_username: "%{hiera('http_username')}"
@@ -766,6 +766,44 @@ govuk_jenkins::job::integration_deploy::applications: *deployable_applications
 
 govuk_jenkins::job::deploy_lambda_app::lambda_apps:
   - 'email_alert_notifications'
+
+jenkins_admin_permission_list: &jenkins_admin_permission_list
+  - 'hudson.model.Hudson.Administer'
+  - 'hudson.model.Hudson.Read'
+  - 'hudson.model.Hudson.RunScripts'
+  - 'hudson.model.Item.Build'
+  - 'hudson.model.Item.Cancel'
+  - 'hudson.model.Item.Configure'
+  - 'hudson.model.Item.Create'
+  - 'hudson.model.Item.Delete'
+  - 'hudson.model.Item.Discover'
+  - 'hudson.model.Item.Read'
+  - 'hudson.model.Item.Workspace'
+  - 'hudson.model.Run.Delete'
+  - 'hudson.model.Run.Update'
+  - 'hudson.model.View.Configure'
+  - 'hudson.model.View.Create'
+  - 'hudson.model.View.Delete'
+  - 'hudson.model.View.Read'
+  - 'hudson.scm.SCM.Tag'
+
+govuk_jenkins::config::user_permissions:
+  -
+    user: 'ci_alphagov'
+    permissions: *jenkins_admin_permission_list
+  -
+    user: 'alphagov*GOV.UK Production'
+    permissions: *jenkins_admin_permission_list
+  -
+    user: 'anonymous'
+    permissions:
+      - 'hudson.model.Hudson.Read'
+      - 'hudson.model.Item.Discover'
+  -
+    user: 'github'
+    permissions:
+      - 'hudson.model.Item.Build'
+      - 'hudson.model.Item.Read'
 
 govuk_mysql::server::expire_log_days: 3
 govuk_mysql::server::monitoring::master::plaintext_mysql_password: "%{hiera('mysql_nagios')}"

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -67,75 +67,43 @@ govuk_jenkins::config::theme_colour: '#ffbf47'
 govuk_jenkins::config::theme_text_colour: 'black'
 govuk_jenkins::config::theme_environment_name: 'Integration'
 
-govuk_jenkins::config::admins:
-  - aaronkeogh
-  - alecgibson
-  - alextorrance
-  - anafernandez
-  - andrewgarner
-  - andrienricketts
-  - andydriver
-  - andysellick
-  - anikahenke
-  - bevanloon
-  - bobwalker
-  - brendanbutler
-  - carlosvilhena
-  - chrislowis
-  - chrispatuzzo
-  - christopherbaines
-  - chrisroos
-  - ci_alphagov
-  - danielroseman
-  - davidbasalla
-  - davidhenry
-  - davidsilva
-  - deanwilson
-  - deborahchua
-  - elenatanasoiu
-  - emmabeynon
-  - georgekoetsier
-  - grahampengelly
-  - gregorambrozic
-  - ikennaokpala
-  - isabelllong
-  - jamesrobinson
-  - jamesmead
-  - jennyduckett
-  - jonathanhallam
-  - joskoetsier
-  - kanemorgan
-  - katiesmith
-  - kelvingan
-  - kevindew
-  - lauramartin
-  - leelongmore
-  - leenagupte
-  - matmoore
-  - matteograssotti
-  - murraysteele
-  - nickcolley
-  - oliverbyford
-  - pablomanrubia
-  - paulbowsher
-  - paulhayes
-  - peterhartshorn
-  - richardboulton
-  - rosafox
-  - rubenarakelyan
-  - samcook
-  - simonhughesdon
-  - stephenharker
-  - stevelaing
-  - suzannehamilton
-  - tatianastantonian
-  - theodorvararu
-  - thomasleese
-  - thomasnatt
-  - tijmenbrommet
-  - timblair
-  - tomgladhill
-  - vanitabarrett
+jenkins_admin_permission_list: &jenkins_admin_permission_list
+  - 'hudson.model.Hudson.Administer'
+  - 'hudson.model.Hudson.Read'
+  - 'hudson.model.Hudson.RunScripts'
+  - 'hudson.model.Item.Build'
+  - 'hudson.model.Item.Cancel'
+  - 'hudson.model.Item.Configure'
+  - 'hudson.model.Item.Create'
+  - 'hudson.model.Item.Delete'
+  - 'hudson.model.Item.Discover'
+  - 'hudson.model.Item.Read'
+  - 'hudson.model.Item.Workspace'
+  - 'hudson.model.Run.Delete'
+  - 'hudson.model.Run.Update'
+  - 'hudson.model.View.Configure'
+  - 'hudson.model.View.Create'
+  - 'hudson.model.View.Delete'
+  - 'hudson.model.View.Read'
+  - 'hudson.scm.SCM.Tag'
+
+govuk_jenkins::config::user_permissions:
+  -
+    user: 'ci_alphagov'
+    permissions: *jenkins_admin_permission_list
+  -
+    user: 'alphagov*GOV.UK'
+    permissions: *jenkins_admin_permission_list
+  -
+    user: 'anonymous'
+    permissions:
+      - 'hudson.model.Hudson.Read'
+      - 'hudson.model.Item.Discover'
+  -
+    user: 'github'
+    permissions:
+      - 'hudson.model.Item.Build'
+      - 'hudson.model.Item.Read'
 
 govuk_jenkins::job_builder::environment: 'integration'
 

--- a/modules/govuk_jenkins/manifests/config.pp
+++ b/modules/govuk_jenkins/manifests/config.pp
@@ -105,7 +105,7 @@ class govuk_jenkins::config (
   $github_client_secret,
   $admins = [],
   $user_permissions = [],
-  $manage_permissions_github_teams = false,
+  $manage_permissions_github_teams = true,
   $manage_config = true,
   $version = $govuk_jenkins::version,
   $create_agent_role = false,


### PR DESCRIPTION
We're running out of seats, both in the office and Github Enterprise. This means there is a push to get us to start auth'ing in Github instead.

Standing on the shoulders of @alexmuller, it's trivial to update this.

 - By default, we allow permissions to a new Github team called "GOV.UK
 Production"
 - Allow more open access to the "GOV.UK" team in both Integration and
 CI
 - Ensure CI has a slightly different set of permissions to allow for
 the "jenkins_agent" user
 - Set the default authorization strategy to use the auth matrix rather
 than a list of admins
 - Remove the list of admins

Story: https://trello.com/c/BHByyOoh/644-get-jenkins-to-authenticate-in-githubcom-rather-than-github-enterprise