### PR TITLE
Enable sass linting by default, as had been expected

### DIFF
--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -146,7 +146,7 @@ def buildProject(Map options = [:]) {
       echo "WARNING: You do not have Ruby linting turned on. Please install govuk-lint and enable."
     }
 
-    if (hasAssets() && hasLint() && options.sassLint) {
+    if (hasAssets() && hasLint() && options.sassLint != false) {
       stage("Lint SASS") {
         sassLinter()
       }


### PR DESCRIPTION
Reviewers: I don't know groovy and I am unsure how to test this. Help would be much appreciated.

The docs say that the sass linter is on by default:
https://github.com/alphagov/govuk-puppet/blob/f28348c1a9bc8fa5edd95e646df4bbd87f05e116/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy#L55

That's not the case though.
* If `options.sassLint` is omitted then checking `options.sassLint` is null and falsy.
* The default state was therefore no sass linting
* Explicitly check that it has been set to false so that if the option is not provided sassLint runs

I think this may have broken here:
https://github.com/alphagov/govuk-puppet/pull/5828