### PR TITLE
Add repo arg to publishing e2e tests method

### DIFF
--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -206,7 +206,7 @@ def buildProject(Map options = [:]) {
         } else {
           testBranch = env.PUBLISHING_E2E_TESTS_BRANCH
         }
-        runPublishingE2ETests(appCommitishName, testBranch)
+        runPublishingE2ETests(appCommitishName, testBranch, repoName)
       }
     }
 
@@ -768,7 +768,7 @@ def setBuildStatus(repoName, commit, message, state) {
   ]);
 }
 
-def runPublishingE2ETests(appCommitishName, testBranch) {
+def runPublishingE2ETests(appCommitishName, testBranch, repo) {
   build(
     job: "publishing-e2e-tests/${testBranch}",
     parameters: [
@@ -777,7 +777,7 @@ def runPublishingE2ETests(appCommitishName, testBranch) {
         value: env.FULL_COMMIT_HASH],
       [$class: "StringParameterValue",
         name: "ORIGIN_REPO",
-        value: repoName],
+        value: repo],
       [$class: "StringParameterValue",
         name: "ORIGIN_COMMIT",
         value: env.FULL_COMMIT_HASH]


### PR DESCRIPTION
We need to have the ability to pass in a `repo` argument to the
`runPublishingE2ETests` method in `govuk_jenkinslib` as not all repos will be
using the whole script and won't automatically have a `repoName` variable
available to use.

https://trello.com/c/NwvQLJMs/957-run-e2e-tests-as-part-of-content-store-and-travel-advice-publisher-builds-1