### PR TITLE
AWS remove graphite vhost from monitoring

### DIFF
--- a/modules/govuk/manifests/node/s_monitoring.pp
+++ b/modules/govuk/manifests/node/s_monitoring.pp
@@ -25,13 +25,15 @@ class govuk::node::s_monitoring (
     include collectd::plugin::cdn_fastly
   }
 
-  nginx::config::vhost::proxy { 'graphite':
-    to           => ['graphite.cluster'],
-    aliases      => ['graphite.*', 'grafana', 'grafana.*'],
-    ssl_only     => true,
-    ssl_certtype => 'wildcard_publishing',
-    protected    => false,
-    root         => '/dev/null',
+  if ! $::aws_migration {
+    nginx::config::vhost::proxy { 'graphite':
+      to           => ['graphite.cluster'],
+      aliases      => ['graphite.*', 'grafana', 'grafana.*'],
+      ssl_only     => true,
+      ssl_certtype => 'wildcard_publishing',
+      protected    => false,
+      root         => '/dev/null',
+    }
   }
 
   limits::limits { 'nagios_nofile':


### PR DESCRIPTION
On AWS we don't need to reuse public IPs, and the graphite vhost
is preventing Nginx from starting on the monitoring box because
it cannot resolve the servername.