### PR TITLE
Add environment variable for Errbit to hmrc-manuals-api

### DIFF
--- a/modules/govuk/manifests/apps/hmrc_manuals_api.pp
+++ b/modules/govuk/manifests/apps/hmrc_manuals_api.pp
@@ -18,6 +18,10 @@
 #   non-whitelisted manual slugs.
 #   Default: false
 #
+# [*errbit_api_key*]
+#   Errbit API key used by airbrake
+#   Default: undef
+#
 # [*oauth_id*]
 #   Sets the OAuth ID for using GDS-SSO
 #   Default: undef
@@ -38,6 +42,7 @@
 class govuk::apps::hmrc_manuals_api(
   $port = '3071',
   $enable_procfile_worker = true,
+  $errbit_api_key = undef,
   $allow_unknown_hmrc_manual_slugs = false,
   $oauth_id = undef,
   $oauth_secret = undef,
@@ -66,6 +71,9 @@ class govuk::apps::hmrc_manuals_api(
   }
 
   govuk::app::envvar {
+    "${title}-ERRBIT_API_KEY":
+      varname => 'ERRBIT_API_KEY',
+      value   => $errbit_api_key;
     "${title}-OAUTH_ID":
       varname => 'OAUTH_ID',
       value   => $oauth_id;


### PR DESCRIPTION
Trello: https://trello.com/c/pEx2HlBB

Related to:
1. https://github.digital.cabinet-office.gov.uk/gds/alphagov-deployment/pull/1336
2. https://github.com/alphagov/hmrc-manuals-api/pull/178
3. https://github.digital.cabinet-office.gov.uk/gds/deployment/pull/1372

## Motivation

HMRC Manuals API uses config in [alphagov-deployment](https://github.digital.cabinet-office.gov.uk/gds/alphagov-deployment) to set the values for Airbrake including the `errbit_api_key`. [alphagov-deployment](https://github.digital.cabinet-office.gov.uk/gds/alphagov-deployment) is an application that has been deprecated, and all config in there should be moved to environment variables.