### PR TITLE
Add config for Redis to hmrc-manuals-api

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -285,6 +285,9 @@ govuk::apps::government-frontend::nagios_memory_critical: 1000
 
 govuk::apps::govuk_cdn_logs_monitor::processed_data_dir: '/mnt/logs_cdn/data'
 
+govuk::apps::hmrc_manuals_api::redis_host: "%{hiera('sidekiq_host')}"
+govuk::apps::hmrc_manuals_api::redis_port: "%{hiera('sidekiq_port')}"
+
 govuk::apps::link_checker_api::db_hostname: "postgresql-primary-1.backend"
 govuk::apps::link_checker_api::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 govuk::apps::link_checker_api::redis_host: "%{hiera('sidekiq_host')}"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -288,6 +288,9 @@ govuk::apps::government-frontend::nagios_memory_critical: 1000
 
 govuk::apps::govuk_cdn_logs_monitor::processed_data_dir: '/mnt/logs_cdn/data'
 
+govuk::apps::hmrc_manuals_api::redis_host: "%{hiera('sidekiq_host')}"
+govuk::apps::hmrc_manuals_api::redis_port: "%{hiera('sidekiq_port')}"
+
 govuk::apps::link_checker_api::db_hostname: "postgresql-primary-1.backend"
 govuk::apps::link_checker_api::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 govuk::apps::link_checker_api::redis_host: "%{hiera('sidekiq_host')}"

--- a/modules/govuk/manifests/apps/hmrc_manuals_api.pp
+++ b/modules/govuk/manifests/apps/hmrc_manuals_api.pp
@@ -39,6 +39,13 @@
 #   The bearer token to use when communicating with Publishing API.
 #   Default: undef
 #
+# [*redis_host*]
+#   Redis host for sidekiq.
+#
+# [*redis_port*]
+#   Redis port for sidekiq.
+#   Default: undef
+#
 class govuk::apps::hmrc_manuals_api(
   $port = '3071',
   $enable_procfile_worker = true,
@@ -48,6 +55,8 @@ class govuk::apps::hmrc_manuals_api(
   $oauth_secret = undef,
   $publish_topics = true,
   $publishing_api_bearer_token = undef,
+  $redis_host = undef,
+  $redis_port = undef,
 ) {
 
   Govuk::App::Envvar {
@@ -68,6 +77,11 @@ class govuk::apps::hmrc_manuals_api(
         varname => 'PUBLISH_TOPICS',
         value   => '1';
     }
+  }
+
+  govuk::app::envvar::redis { 'hmrc-manuals-api':
+    host => $redis_host,
+    port => $redis_port,
   }
 
   govuk::app::envvar {


### PR DESCRIPTION
Trello: https://trello.com/c/jpPE9GXd

Related to:
1. https://github.com/alphagov/hmrc-manuals-api/pull/179
2. https://github.digital.cabinet-office.gov.uk/gds/alphagov-deployment/pull/1337

## Motivation

Unlike most other GOV.UK applications, HMRC Manuals API uses config in [alphagov-deployment](https://github.digital.cabinet-office.gov.uk/gds/alphagov-deployment) to set the values for Redis. 

[alphagov-deployment](https://github.digital.cabinet-office.gov.uk/gds/alphagov-deployment) is an application that has been deprecated, and all config in there should be moved to environment variables.