### PR TITLE
Begin basic node class for s_db_admin

### DIFF
--- a/modules/govuk/manifests/node/s_db_admin.pp
+++ b/modules/govuk/manifests/node/s_db_admin.pp
@@ -2,10 +2,40 @@
 #
 # This machine class is used to administer RDS instances.
 #
-class govuk::node::s_db_admin {
+# === Parameters
+#
+# [*mysql_db_host*]
+#  The database hostname
+#
+# [*mysql_db_password*]
+#  The database password
+#
+# [*mysql_db_user*]
+#  The database user to connect to the remote database as
+#
+class govuk::node::s_db_admin(
+  $mysql_db_host     = undef,
+  $mysql_db_password = undef,
+  $mysql_db_user     = undef,
+) {
   include ::govuk::node::s_base
 
+  file { '/root/.my.cnf':
+    ensure  => 'present',
+    owner   => 'root',
+    group   => 'root',
+    content => template('govuk/node/s_db_admin/.my.cnf.erb'),
+  } ->
+  # include all the MySQL database classes that add users
+  class { '::govuk::apps::collections_publisher::db': } ->
+  class { '::govuk::apps::contacts::db': } ->
+  class { '::govuk::apps::release::db': } ->
+  class { '::govuk::apps::search_admin::db': } ->
+  class { '::govuk::apps::signon::db': } ->
+  class { '::govuk::apps::whitehall::db': }
+
   $packages = [
+    # should this be include govuk_postgresql::client
     'postgresql-client-9.3',
     'mysql-client-5.5',
   ]

--- a/modules/govuk/manifests/node/s_db_admin.pp
+++ b/modules/govuk/manifests/node/s_db_admin.pp
@@ -1,0 +1,16 @@
+# == Class: Govuk_Node::S_db_admin
+#
+# This machine class is used to administer RDS instances.
+#
+class govuk::node::s_db_admin {
+  include ::govuk::node::s_base
+
+  $packages = [
+    'postgresql-client-9.3',
+    'mysql-client-5.5',
+  ]
+
+  package { $packages:
+    ensure =>  present,
+  }
+}

--- a/modules/govuk/templates/node/s_db_admin/.my.cnf.erb
+++ b/modules/govuk/templates/node/s_db_admin/.my.cnf.erb
@@ -1,0 +1,4 @@
+[client]
+host=<%= @mysql_db_host %>
+password=<%= @mysql_db_password %>
+user=<%= @mysql_db_user %>

--- a/modules/hosts/manifests/purge.pp
+++ b/modules/hosts/manifests/purge.pp
@@ -11,8 +11,17 @@
 # `ensure => absent`.
 #
 class hosts::purge {
-  if !defined(Govuk_host[$::hostname]) {
-    fail("Unable to find Govuk_host[${::hostname}]. Aborting so as not to break hostname(1)")
+
+  # Specifically for hosts that exist as a node class but do not use the Govuk_host defined type
+  # eg hosts that are only present in AWS
+  $whitelist = [
+    'db-admin-1',
+  ]
+
+  if ! ($::hostname in $whitelist) {
+    if !defined(Govuk_host[$::hostname]) {
+      fail("Unable to find Govuk_host[${::hostname}]. Aborting so as not to break hostname(1)")
+    }
   }
 
   resources { 'host':


### PR DESCRIPTION
We're looking to provision our databases in RDS rather than provision EC2 machines with databases on them.

To create, administer and backup databases using Puppet, we need something to use that can do this in our current Puppet estate.

For now just install packages to used to work with our current versions MySQL and PostgreSQL.