### PR TITLE
Remove reference to sanitize_publishing_api_data

### DIFF
--- a/hieradata/class/integration/jenkins.yaml
+++ b/hieradata/class/integration/jenkins.yaml
@@ -23,7 +23,6 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::remove_emergency_banner
   - govuk_jenkins::job::run_rake_task
   - govuk_jenkins::job::run_whitehall_data_migrations
-  - govuk_jenkins::job::sanitize_publishing_api_data
   - govuk_jenkins::job::search_benchmark
   - govuk_jenkins::job::search_test_spelling_suggestions
   - govuk_jenkins::job::signon_cron_rake_tasks


### PR DESCRIPTION
This class was removed in 4a7deef8840ef6841ecbd5d8a76ade5a34116c25, but it's still being referenced in hiera which causes Puppet to fail.