### PR TITLE
AWS Elasticsearch do not firewall hosts

### DIFF
--- a/modules/govuk_elasticsearch/manifests/init.pp
+++ b/modules/govuk_elasticsearch/manifests/init.pp
@@ -152,7 +152,9 @@ class govuk_elasticsearch (
     }
   }
 
-  govuk_elasticsearch::firewall_transport_rule { $cluster_hosts: }
+  if ! $::aws_migration {
+    govuk_elasticsearch::firewall_transport_rule { $cluster_hosts: }
+  }
 
   include govuk_elasticsearch::estools
   include govuk_elasticsearch::plugins


### PR DESCRIPTION
Do not apply firewall rules to ES cluster hosts on AWS