### PR TITLE
Jenkins job updates

### DIFF
--- a/modules/govuk_jenkins/templates/config/config.xml.erb
+++ b/modules/govuk_jenkins/templates/config/config.xml.erb
@@ -167,6 +167,10 @@
           <string><%= name -%></string>
           <string><%= value -%></string>
           <%- end -%>
+          <%- if @aws_migration -%>
+          <string>STACKNAME</string>
+          <string><%- @aws_stackname -%></string>
+          <%- end -%>
         </tree-map>
       </envVars>
     </hudson.slaves.EnvironmentVariablesNodeProperty>

--- a/modules/govuk_jenkins/templates/jobs/deploy_puppet.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_puppet.yaml.erb
@@ -45,8 +45,12 @@
     scm:
       - deployment_Deploy_Puppet
     builders:
-        - shell: |
+           - shell: |
+           <%- if @aws_migration -%>
+           sh -eu puppet_aws/deploy.sh
+           <%- else -%>
            sh -eu puppet/deploy.sh
+           <%- end -%>
     publishers:
         - trigger:
             project: Smokey

--- a/modules/govuk_jenkins/templates/jobs/deploy_puppet.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_puppet.yaml.erb
@@ -50,6 +50,7 @@
     publishers:
         - trigger:
             project: Smokey
+        <%- unless @aws_migration -%>
         - trigger-parameterized-builds:
             - project: GDS_Production_Backup
               predefined-parameters: TARGET_APPLICATION_GIT_REPO=$WORKSPACE/puppet
@@ -59,6 +60,7 @@
             auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN']%>
             build-server-url: <%= @slack_build_server_url %>
             room: <%= @slack_room %>
+        <%- end -%>
     wrappers:
         - ansicolor:
             colormap: xterm


### PR DESCRIPTION
This PR does two things:

 - Adds a global environment variable for Jenkins instances in AWS
 - Updates the Puppet deployment job to be compatible with AWS 

This is related to: https://github.com/alphagov/govuk-secrets/pull/2