### PR TITLE
Ensure users dir is created

### DIFF
--- a/modules/govuk_jenkins/manifests/api_user.pp
+++ b/modules/govuk_jenkins/manifests/api_user.pp
@@ -41,11 +41,13 @@ define govuk_jenkins::api_user(
     recurse => true,
     purge   => true,
     force   => true,
+    require => File[$users_dir],
   }
 
   file { "${users_dir}/${title}/config.xml":
     ensure  => $ensure,
     content => template('govuk_jenkins/api_user.xml.erb'),
     replace => false,
+    require => File["${users_dir}/${title}"],
   }
 }

--- a/modules/govuk_jenkins/manifests/init.pp
+++ b/modules/govuk_jenkins/manifests/init.pp
@@ -130,4 +130,12 @@ class govuk_jenkins (
     require => Class['govuk_jenkins::user'],
   }
 
+  file { "${jenkins_homedir}/users":
+    ensure  => directory,
+    owner   => $jenkins_user,
+    group   => $jenkins_user,
+    mode    => '0775',
+    require => Class['govuk_jenkins::user'],
+  }
+
 }


### PR DESCRIPTION
This directory is required to create api_users. We want to create an api_user when we initially run Puppet on a Jenkins instance, so ensure the directory exists.