### PR TITLE
Remove metadata-api as dependency of info-frontend

### DIFF
--- a/development-vm/Pinfile
+++ b/development-vm/Pinfile
@@ -39,7 +39,7 @@ process :'govuk-delivery'
 process :'govuk-delivery-worker'
 process :'hmrc-manuals-api' => [:'publishing-api', :rummager]
 process :imminence => [:mapit]
-process :'info-frontend' => [:static, :'content-store', :'metadata-api']
+process :'info-frontend' => [:static, :'content-store']
 process :licencefinder => [:static, :'content-store', :rummager]
 process :'link-checker-api' => [:'link-checker-api-sidekiq']
 process :'link-checker-api-sidekiq'


### PR DESCRIPTION
For: https://trello.com/c/9JNitfXS/173-spike-info-pages

In https://github.com/alphagov/info-frontend/pull/71 we changed 
info-frontend to get performance results directly from the performance
platform instead of talking to metadata-api.  This was the last
thing that info-frontend needed from metadata-api and so it is no
longer a dependency - you can run info-frontend without metadata-api.