### PR TITLE
Add ssh-proxy command to jumpboxes in AWS

### DIFF
--- a/modules/govuk/files/node/s_jumpbox/ssh-proxy
+++ b/modules/govuk/files/node/s_jumpbox/ssh-proxy
@@ -1,0 +1,6 @@
+#!/bin/bash
+STACKNAME=$1
+PUPPET_ROLE=$2
+HOST=$(aws ec2 describe-instances --region eu-west-1 --filters "Name=tag:aws_migration,Values=${PUPPET_ROLE}" "Name=tag:aws_stackname,Values=${STACKNAME}" --output=json | jq -r '.Reservations[] | .Instances[] | .NetworkInterfaces[] | .PrivateIpAddress' | head -n1 )
+USER=$(whoami)
+ssh -t $USER@$HOST

--- a/modules/govuk/manifests/node/s_jumpbox.pp
+++ b/modules/govuk/manifests/node/s_jumpbox.pp
@@ -1,4 +1,12 @@
 # FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
 class govuk::node::s_jumpbox inherits govuk::node::s_base {
 
+  if $::aws_migration {
+    file { '/usr/local/bin/ssh-proxy':
+      ensure => 'present',
+      mode   => '0775',
+      source => 'puppet:///modules/govuk/node/s_jumpbox/ssh-proxy',
+    }
+  }
+
 }


### PR DESCRIPTION
The usage would be:

`ssh-proxy delana jenkins`

This looks up the instance IP address using tags so you can jump straight to it from the jumpbox. It includes the stackname so that it's a generic script that can be called from a client machine on different stacks.