### PR TITLE
New ES machines running v2.4 ES for Rummager in Integration.

### DIFF
--- a/hieradata/class/rummager_elasticsearch.yaml
+++ b/hieradata/class/rummager_elasticsearch.yaml
@@ -1,0 +1,19 @@
+---
+
+govuk_safe_to_reboot::can_reboot: 'careful'
+govuk_safe_to_reboot::reason: 'Reboot a single node at time and check that the cluster goes green between reboots'
+
+govuk_elasticsearch::version: '2.4.6'
+
+lv:
+  data:
+    pv: '/dev/sdb1'
+    vg: 'elasticsearch'
+
+mount:
+  /mnt/elasticsearch:
+    disk: '/dev/mapper/elasticsearch-data'
+    govuk_lvm: 'data'
+    mountoptions: 'defaults'
+    percent_threshold_warning: 16
+    percent_threshold_critical: 11

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1026,6 +1026,12 @@ hosts::production::api::hosts:
     ip: '10.1.4.33'
   performance-mongo-4:
     ip: '10.1.12.31'
+  rummager-elasticsearch-1:
+    ip: '10.1.4.55'
+  rummager-elasticsearch-2:
+    ip: '10.1.4.56'
+  rummager-elasticsearch-3:
+    ip: '10.1.4.57'
   search-1:
     ip: '10.1.4.4'
   search-2:

--- a/modules/govuk/manifests/node/s_rummager_elasticsearch.pp
+++ b/modules/govuk/manifests/node/s_rummager_elasticsearch.pp
@@ -1,0 +1,50 @@
+# == Class: govuk::node::s_rummager_elasticsearch
+#
+# Machines for the elasticsearch cluster in the API vDC
+#
+class govuk::node::s_rummager_elasticsearch inherits govuk::node::s_base {
+  include govuk_java::openjdk7::jre
+
+  $es_heap_size = floor($::memorysize_mb / 2)
+
+  class { 'govuk_elasticsearch::dump':
+    require => Class['govuk_elasticsearch'], # required for elasticsearch user to exist
+  }
+
+  class { 'govuk_elasticsearch':
+    cluster_hosts          => ['rummager-elasticsearch-1.api:9300', 'rummager-elasticsearch-2.api:9300', 'rummager-elasticsearch-3.api:9300'],
+    cluster_name           => 'govuk-content',
+    heap_size              => "${es_heap_size}m",
+    number_of_replicas     => '1',
+    host                   => $::fqdn,
+    open_firewall_from_all => false,
+    require                => Class['govuk_java::openjdk7::jre'],
+  }
+
+  @ufw::allow { 'allow-elasticsearch-http-9200-from-search-1':
+    port    => 9200,
+    from    => getparam(Govuk_host['search-1'], 'ip'),
+    require => Govuk_host['search-1'],
+  }
+  @ufw::allow { 'allow-elasticsearch-http-9200-from-search-2':
+    port    => 9200,
+    from    => getparam(Govuk_host['search-2'], 'ip'),
+    require => Govuk_host['search-2'],
+  }
+  @ufw::allow { 'allow-elasticsearch-http-9200-from-search-3':
+    port    => 9200,
+    from    => getparam(Govuk_host['search-3'], 'ip'),
+    require => Govuk_host['search-3'],
+  }
+
+  collectd::plugin::tcpconn { 'es-9200':
+    incoming => 9200,
+    outgoing => 9200,
+  }
+  collectd::plugin::tcpconn { 'es-9300':
+    incoming => 9300,
+    outgoing => 9300,
+  }
+
+  Govuk_mount['/mnt/elasticsearch'] -> Class['govuk_elasticsearch']
+}

--- a/modules/govuk_elasticsearch/manifests/plugins.pp
+++ b/modules/govuk_elasticsearch/manifests/plugins.pp
@@ -2,7 +2,9 @@
 #
 # Install plugins on an Elasticsearch node
 #
-class govuk_elasticsearch::plugins {
+class govuk_elasticsearch::plugins (
+  $elasticsearch_version = $::govuk_elasticsearch::version,
+){
 
   elasticsearch::plugin { 'mobz/elasticsearch-head':
     module_dir => 'head',
@@ -15,16 +17,38 @@ class govuk_elasticsearch::plugins {
     instances  => $::fqdn,
   }
 
-  case $govuk_elasticsearch::version {
-    /^1.4/:  { $cloud_aws_version = '2.4.2' }
-    /^1.5/:  { $cloud_aws_version = '2.5.1' }
-    /^1.7/:  { $cloud_aws_version = '2.7.1' }
-    default: { fail('Not able to select a version for cloud-aws, see https://github.com/elastic/elasticsearch-cloud-aws') }
-  }
+  if versioncmp($elasticsearch_version, '2.0') < 0 {
+    # If version is older than 2.0.0, then install an older plugin
+    case $elasticsearch_version {
+      /^1.4/:  { $cloud_aws_version = '2.4.2' }
+      /^1.5/:  { $cloud_aws_version = '2.5.1' }
+      /^1.7/:  { $cloud_aws_version = '2.7.1' }
+      default: { fail('Not able to select a version for cloud-aws, see https://github.com/elastic/elasticsearch-cloud-aws') }
+    }
 
-  elasticsearch::plugin { "elasticsearch/elasticsearch-cloud-aws/${cloud_aws_version}":
-    module_dir => 'cloud-aws',
-    instances  => $::fqdn,
+    elasticsearch::plugin { "elasticsearch/elasticsearch-cloud-aws/${cloud_aws_version}":
+      module_dir => 'cloud-aws',
+      instances  => $::fqdn,
+    }
   }
+  # If the version is 2.4, then install the plugin the 2.4 way
+  elsif versioncmp($elasticsearch_version, '2.4') == 0 {
+    elasticsearch::plugin { 'cloud-aws':
+      module_dir => 'cloud-aws',
+      instances  => $::fqdn,
+    }
+  }
+  # If the version is 5.0 or newer, then install the two plugins it got split into:
+  # https://www.elastic.co/guide/en/elasticsearch/plugins/5.0/cloud-aws.html
+  elsif versioncmp($elasticsearch_version, '5.0') >= 0 {
+    elasticsearch::plugin { 'discovery-ec2':
+      module_dir => 'discovery-ec2',
+      instances  => $::fqdn,
+    }
 
+    elasticsearch::plugin { 'repository-s3':
+      module_dir => 'repository-s3',
+      instances  => $::fqdn,
+    }
+  }
 }

--- a/modules/govuk_elasticsearch/spec/classes/govuk_elasticsearch__plugins_spec.rb
+++ b/modules/govuk_elasticsearch/spec/classes/govuk_elasticsearch__plugins_spec.rb
@@ -1,0 +1,42 @@
+require_relative '../../../../spec_helper'
+
+describe 'govuk_elasticsearch::plugins', :type => :class do
+
+  context 'Elasticsearch version 1.4.4 should install cloud-aws plugin 2.4.2' do
+    let(:params) {{
+      :elasticsearch_version => '1.4.4',
+    }}
+    it { is_expected.to contain_elasticsearch__plugin('elasticsearch/elasticsearch-cloud-aws/2.4.2') }
+  end
+
+
+  context 'Elasticsearch version 1.5.2 should install cloud-aws plugin 2.5.1' do
+    let(:params) {{
+      :elasticsearch_version => '1.5.2',
+    }}
+    it { is_expected.to contain_elasticsearch__plugin('elasticsearch/elasticsearch-cloud-aws/2.5.1') }
+  end
+
+  context 'Elasticsearch version 1.7.5 should install cloud-aws plugin 2.7.1' do
+    let(:params) {{
+      :elasticsearch_version => '1.7.5',
+    }}
+    it { is_expected.to contain_elasticsearch__plugin('elasticsearch/elasticsearch-cloud-aws/2.7.1') }
+  end
+
+  context 'Elasticsearch version 2.4.6 should install cloud-aws plugin' do
+    let(:params) {{
+      :elasticsearch_version => '2.4',
+    }}
+    it { is_expected.to contain_elasticsearch__plugin('cloud-aws') }
+  end
+
+  context 'Elasticsearch version 5.x.x should install the discovery-ec2 and repository-s3 plugins' do
+    let(:params) {{
+      :elasticsearch_version => '5.1.0',
+    }}
+    it { is_expected.to contain_elasticsearch__plugin('discovery-ec2') }
+    it { is_expected.to contain_elasticsearch__plugin('repository-s3') }
+  end
+
+end


### PR DESCRIPTION
A new ES cluster in Integration running v2.4.6 which will be used by the search team to migrate from the old ES machines api-elasticsearch-1/2/3
Named: rummager-elasticsearch-1/2/3