### PR TITLE
Update hostalias in AWS

### DIFF
--- a/modules/icinga/manifests/client.pp
+++ b/modules/icinga/manifests/client.pp
@@ -57,12 +57,14 @@ class icinga::client (
   if $::aws_migration {
     # If it's in AWS, display the Puppet role and the IP address of the instance.
     $display_name = "${::aws_migration} (${::ipaddress})"
+    $hostalias    = "${::aws_migration}-${::fqdn}"
   } else {
     $display_name = $::fqdn_short
+    $hostalias    = $::fqdn
   }
 
   @@icinga::host { $::fqdn:
-    hostalias      => $::fqdn,
+    hostalias      => $hostalias,
     address        => $host_ipaddress,
     display_name   => $display_name,
     parents        => $parents,

--- a/modules/icinga/manifests/client.pp
+++ b/modules/icinga/manifests/client.pp
@@ -63,10 +63,13 @@ class icinga::client (
     $hostalias    = $::fqdn
   }
 
-  @@icinga::host { $::fqdn:
+  $host_name = $::fqdn
+
+  @@icinga::host { $host_name:
     hostalias      => $hostalias,
     address        => $host_ipaddress,
     display_name   => $display_name,
+    host_name      => $host_name,
     parents        => $parents,
     contact_groups => $contact_groups,
   }

--- a/modules/icinga/templates/host.erb
+++ b/modules/icinga/templates/host.erb
@@ -3,7 +3,7 @@ define host {
         alias                <%= @hostalias %>
         address              <%= @address %>
         display_name         <%= @display_name %>
-        host_name            <%= @hostalias %>
+        host_name            <%= @host_name %>
         hostgroups           all
         notification_period  <%= @notification_period %>
         contact_groups       <%= @contact_groups %>


### PR DESCRIPTION
We updated the display_name so that the hosts looked friendlier in AWS (rather than just using the Amazon set hostname), but unfortunately Icinga does the annoying thing of sorting by hostname rather than the display_name.

I'm hoping updating the alias will mean that they get properly sorted into order, because otherwise it's very hard to parse the list to see what has come up.