### PR TITLE
Hide data sync related alerts in the morning

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -150,6 +150,8 @@ govuk::node::s_api_lb::search_servers:
 
 govuk::node::s_asset_master::copy_attachments_hour: 11
 
+govuk::node::s_asset_slave::notification_period: 'inoffice_afternoon'
+
 govuk::node::s_backend_lb::backend_servers:
   - 'backend-1.backend'
   - 'backend-2.backend'

--- a/modules/govuk/manifests/node/s_asset_slave.pp
+++ b/modules/govuk/manifests/node/s_asset_slave.pp
@@ -9,6 +9,7 @@
 #
 class govuk::node::s_asset_slave (
   $offsite_backups = false,
+  $notification_period = '24x7',
 ) inherits govuk::node::s_asset_base {
 
   validate_bool($offsite_backups)
@@ -52,11 +53,12 @@ class govuk::node::s_asset_slave (
   $slave_metric = "${::fqdn_metrics}.${graphite_mnt_uploads_metric}"
 
   @@icinga::check::graphite { "asset_master_and_slave_disk_space_similar_from_${::hostname}":
-    target    => "movingMedian(absolute(transformNull(diffSeries(${slave_metric},${master_metric}),0)),10)",
-    critical  => to_bytes('512 MB'),
-    warning   => to_bytes('384 MB'),
-    desc      => 'Asset master and slave are using about the same amount of disk space',
-    host_name => $::fqdn,
-    notes_url => monitoring_docs_url(asset-master-slave-disk-space-comparison),
+    target              => "movingMedian(absolute(transformNull(diffSeries(${slave_metric},${master_metric}),0)),10)",
+    critical            => to_bytes('512 MB'),
+    warning             => to_bytes('384 MB'),
+    desc                => 'Asset master and slave are using about the same amount of disk space',
+    host_name           => $::fqdn,
+    notes_url           => monitoring_docs_url(asset-master-slave-disk-space-comparison),
+    notification_period => $notification_period,
   }
 }

--- a/modules/monitoring/manifests/contacts.pp
+++ b/modules/monitoring/manifests/contacts.pp
@@ -51,11 +51,14 @@ class monitoring::contacts (
 
   $midnight_day_start = '00:00'
   $office_day_start = '09:30'
+  $midday = '12:00'
   $office_day_end = '17:30'
   $midnight_day_end = '24:00'
 
   $all_day = "${midnight_day_start}-${midnight_day_end}"
   $office_day = "${office_day_start}-${office_day_end}"
+  $office_day_morning = "${office_day_start}-${midday}"
+  $office_day_afternoon = "${midday}-${office_day_end}"
   $oncall_early_day = "${midnight_day_start}-${office_day_start}"
   $oncall_late_day = "${office_day_end}-${midnight_day_end}"
 
@@ -77,6 +80,15 @@ class monitoring::contacts (
     wed              => $office_day,
     thu              => $office_day,
     fri              => $office_day,
+  }
+
+  icinga::timeperiod { 'inoffice_afternoon':
+    timeperiod_alias => '2nd line in-office hours, afternoon',
+    mon              => $office_day_afternoon,
+    tue              => $office_day_afternoon,
+    wed              => $office_day_afternoon,
+    thu              => $office_day_afternoon,
+    fri              => $office_day_afternoon,
   }
 
   icinga::timeperiod { 'oncall':


### PR DESCRIPTION
In integration, the data sync in the morning copies data to the asset
master, but the sync between the asset-master and the slaves usually
does not finish until midday. This means that there are always alerts in
integration in the morning before the sync to the slaves has had a
chance to run.

We tried, but didn't manage, to get the asset-master to sync to the slaves - 
we ran into difficulties getting access from Jenkins to the assets user on the 
asset-master. 

Paired with @cbaines 