### PR TITLE
Add later version of terraform to CI machines

### DIFF
--- a/hieradata/class/jenkins.yaml
+++ b/hieradata/class/jenkins.yaml
@@ -34,6 +34,8 @@ govuk_jenkins::config:
 # the resolution has been configured remove this.
 govuk_jenkins::config::csrf_version: false
 
+govuk_jenkins::packages::terraform::version: '0.8.1'
+
 govuk_jenkins::plugins:
   ace-editor:
     version: '1.1'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -655,19 +655,19 @@ govuk_ci::master::pipeline_jobs:
 govuk_ci::master::ci_agents:
   ci-agent-1:
     agent_hostname: 'ci-agent-1.ci'
-    labels: 'mongodb-2.4 docker ci-agent-1 elasticsearch'
+    labels: 'mongodb-2.4 docker ci-agent-1 elasticsearch terraform-0.8.1'
   ci-agent-2:
     agent_hostname: 'ci-agent-2.ci'
-    labels: 'mongodb-2.4 docker ci-agent-2 elasticsearch'
+    labels: 'mongodb-2.4 docker ci-agent-2 elasticsearch terraform'
   ci-agent-3:
     agent_hostname: 'ci-agent-3.ci'
-    labels: 'mongodb-2.4 docker ci-agent-3 elasticsearch'
+    labels: 'mongodb-2.4 docker ci-agent-3 elasticsearch terraform'
   ci-agent-4:
     agent_hostname: 'ci-agent-4.ci'
-    labels: 'mongodb-3.2 docker ci-agent-4 elasticsearch'
+    labels: 'mongodb-3.2 docker ci-agent-4 elasticsearch terraform'
   ci-agent-5:
     agent_hostname: 'ci-agent-5.ci'
-    labels: 'mongodb-3.2 docker ci-agent-5 elasticsearch'
+    labels: 'mongodb-3.2 docker ci-agent-5 elasticsearch terraform'
 
 govuk_ci::master::credentials_id: 'jenkins-ssh-slave'
 

--- a/hieradata/node/ci-agent-1.ci.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/ci-agent-1.ci.integration.publishing.service.gov.uk.yaml
@@ -1,2 +1,4 @@
 ---
 mongodb::server::version: '2.4.9'
+
+govuk_jenkins::packages::terraform::version: '0.8.1'

--- a/modules/govuk_jenkins/manifests/packages/terraform.pp
+++ b/modules/govuk_jenkins/manifests/packages/terraform.pp
@@ -9,6 +9,7 @@
 #
 class govuk_jenkins::packages::terraform (
   $apt_mirror_hostname = undef,
+  $version = '0.9.10',
 ){
 
   apt::source { 'terraform':
@@ -19,7 +20,7 @@ class govuk_jenkins::packages::terraform (
   }
 
   package { 'terraform':
-    ensure  => '0.8.1',
+    ensure  => $version,
     require => Apt::Source['terraform'],
   }
 


### PR DESCRIPTION
Currently we use an old version of terraform for a few things in our stack:

 - Deploying govuk-dns on Deploy Jenkins
 - Testing govuk-dns on CI
 - Deploying code in govuk-terraform-provisioning on Deploy Jenkins

We're currently migrating the GOV.UK stack to AWS, and use a much later version of Terraform to do this (0.9.10). We should be testing the code we're writing, and so we should add a later version of Terraform on a couple of CI agents to allow this.

Depends on https://github.com/alphagov/packager/pull/133