### PR TITLE
Enable govuk_index listeners in production

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -416,8 +416,10 @@ govuk::apps::release::github_username: "govuk-ci"
 govuk::apps::rummager::nagios_memory_warning: 4600
 govuk::apps::rummager::nagios_memory_critical: 4900
 govuk::apps::rummager::enable_publishing_listener: true
+govuk::apps::rummager::enable_govuk_index_listener: true
 govuk::apps::rummager::rabbitmq::enable_publishing_listener: true
-govuk::apps::rummager::rabbitmq_user: 'rummager'
+govuk::apps::rummager::rabbitmq::enable_govuk_index_listener: true
+govuk::apps::rummager::rabbitmq_user: 'rummager-v2'
 govuk::apps::rummager::redis_host: 'api-redis-1.api'
 govuk::apps::rummager::redis_port: '6379'
 

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -159,11 +159,6 @@ govuk::apps::router_api::enable_running_in_draft_mode::mongodb_nodes: ['localhos
 govuk::apps::router_api::enable_running_in_draft_mode::router_nodes: ['localhost:3134']
 govuk::apps::rummager::enable_procfile_worker: false
 govuk::apps::rummager::rabbitmq_hosts: ['localhost']
-govuk::apps::rummager::enable_publishing_listener: true
-govuk::apps::rummager::enable_govuk_index_listener: true
-govuk::apps::rummager::rabbitmq::enable_publishing_listener: true
-govuk::apps::rummager::rabbitmq::enable_govuk_index_listener: true
-govuk::apps::rummager::rabbitmq_user: 'rummager-v2'
 govuk::apps::rummager::redis_host: 'localhost'
 govuk::apps::signon::enable_procfile_worker: false
 govuk::apps::smartanswers::expose_govspeak: true

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -33,9 +33,6 @@ govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
 govuk::apps::publicapi::backdrop_host: 'www.preview.performance.service.gov.uk'
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-integration'
 govuk::apps::publishing_api::content_api_prototype: true
-govuk::apps::rummager::enable_govuk_index_listener: true
-govuk::apps::rummager::rabbitmq::enable_govuk_index_listener: true
-govuk::apps::rummager::rabbitmq_user: 'rummager-v2'
 govuk::apps::short_url_manager::instance_name: 'integration'
 govuk::apps::signon::instance_name: 'integration'
 govuk::apps::smartanswers::expose_govspeak: true


### PR DESCRIPTION
We have tested this in Integration and are happy to proceed to prod.

https://trello.com/c/dmBzBVLG/160-insert-data-into-govuk-index-from-rabbitmq-message