### PR TITLE
Temporary fix while we're migrating things

### DIFF
--- a/modules/base/manifests/init.pp
+++ b/modules/base/manifests/init.pp
@@ -42,5 +42,15 @@ class base {
       ensure  => 'present',
       content => template('base/motd.erb'),
     }
+
+    # FIXME this is a temporary solution to fix ongoing connect errors before
+    # we find the real resolution
+    cron::crondotdee { 'dhclient_reload':
+      command => '/usr/bin/host puppet >/dev/null || /sbin/dhclient -r; /sbin/dhclient',
+      hour    => '*',
+      minute  => '*/2',
+      user    => 'root',
+      mailto  => '""',
+    }
   }
 }


### PR DESCRIPTION
I've found pretty often that hosts are unable to do looks up for the Puppetmaster and so Puppet isn't running consistently across all machines.

The problem is that resolv.conf is being overwritten and the search domains are being lost.

Currently I don't want to dip all my time into resolving this issue, so I propose adding a cronjob which restarts things if it can't resolve the puppet host.