### PR TITLE
Remove /buiness-finance-support-finder from robots.txt

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1591,9 +1591,6 @@ router::nginx::robotstxt: |
   # We only allow indexing of the licence-finder landing page
   Disallow: /licence-finder/
   Allow: /licence-finder
-  # We only allow indexing of the finance finder landing page
-  Disallow: /business-finance-support-finder/*
-  Allow: /business-finance-support-finder
   Disallow: /apply-for-a-licence/
   # Don't allow indexing of user needs pages
   Disallow: /info/*

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1557,9 +1557,6 @@ router::nginx::robotstxt: |
   # We only allow indexing of the licence-finder landing page
   Disallow: /licence-finder/
   Allow: /licence-finder
-  # We only allow indexing of the finance finder landing page
-  Disallow: /business-finance-support-finder/*
-  Allow: /business-finance-support-finder
   Disallow: /apply-for-a-licence/
   # Don't allow indexing of user needs pages
   Disallow: /info/*


### PR DESCRIPTION
This commit removes the `robots.txt` rules for `/buiness-finance-support-finder`. This old finder has been replaced by the `/business-finance-support` finder, which doesn’t have any pages under it that need to be excluded from search engines.