### PR TITLE
Don't set Elasticsearch local_proxy for AWS

### DIFF
--- a/modules/govuk/manifests/node/s_backend.pp
+++ b/modules/govuk/manifests/node/s_backend.pp
@@ -32,7 +32,9 @@ class govuk::node::s_backend inherits govuk::node::s_base {
   nginx::config::vhost::default { 'default': }
 
   # Local proxy for Rummager to access ES cluster.
-  include govuk_elasticsearch::local_proxy
+  if ! $::aws_migration {
+    include govuk_elasticsearch::local_proxy
+  }
 
   # Ensure memcached is available to backend nodes
   include collectd::plugin::memcached

--- a/modules/govuk/manifests/node/s_calculators_frontend.pp
+++ b/modules/govuk/manifests/node/s_calculators_frontend.pp
@@ -5,7 +5,9 @@ class govuk::node::s_calculators_frontend inherits govuk::node::s_base {
   include nginx
 
   # Local proxy for licence-finder to access ES cluster.
-  include govuk_elasticsearch::local_proxy
+  if ! $::aws_migration {
+    include govuk_elasticsearch::local_proxy
+  }
 
   # If we miss all the apps, throw a 500 to be caught by the cache nginx
   nginx::config::vhost::default { 'default': }

--- a/modules/govuk/manifests/node/s_search.pp
+++ b/modules/govuk/manifests/node/s_search.pp
@@ -11,5 +11,7 @@ class govuk::node::s_search inherits govuk::node::s_base {
   nginx::config::vhost::default { 'default': }
 
   # Local proxy for Rummager to access ES cluster.
-  include govuk_elasticsearch::local_proxy
+  if ! $::aws_migration {
+    include govuk_elasticsearch::local_proxy
+  }
 }


### PR DESCRIPTION
We use the class govuk_elasticsearch::local_proxy to set up an nginx vhost on the local application server which load balances request to our elasticsearch cluster.

In Amazon our cluster will sit behind an ELB, so as far as I can gather this isn't required as we can just set the applications to use the DNS name tied to the ELB.

As it currently stands, including this means that Puppet is failing to run on the machines where it is included.