### PR TITLE
Add ElasticSearch machines to AWS

### DIFF
--- a/hieradata_aws/class/api_elasticsearch.yaml
+++ b/hieradata_aws/class/api_elasticsearch.yaml
@@ -1,0 +1,19 @@
+---
+
+govuk_safe_to_reboot::can_reboot: 'careful'
+govuk_safe_to_reboot::reason: 'Reboot a single node at time and check that the cluster goes green between reboots'
+
+govuk_elasticsearch::version: '1.7.5'
+
+lv:
+  data:
+    pv: '/dev/xvdf'
+    vg: 'elasticsearch'
+
+mount:
+  /mnt/elasticsearch:
+    disk: '/dev/mapper/elasticsearch-data'
+    govuk_lvm: 'data'
+    mountoptions: 'defaults'
+    percent_threshold_warning: 16
+    percent_threshold_critical: 11

--- a/modules/govuk/manifests/node/s_api_elasticsearch.pp
+++ b/modules/govuk/manifests/node/s_api_elasticsearch.pp
@@ -7,6 +7,10 @@ class govuk::node::s_api_elasticsearch inherits govuk::node::s_base {
 
   $es_heap_size = floor($::memorysize_mb / 2)
 
+  if $::aws_migration {
+    $aws_cluster_name = "elasticsearch-${::aws_stackname}"
+  }
+
   class { 'govuk_elasticsearch::dump':
     require => Class['govuk_elasticsearch'], # required for elasticsearch user to exist
   }
@@ -19,57 +23,60 @@ class govuk::node::s_api_elasticsearch inherits govuk::node::s_base {
     host                   => $::fqdn,
     open_firewall_from_all => false,
     require                => Class['govuk_java::openjdk7::jre'],
+    aws_cluster_name       => $aws_cluster_name,
   }
 
-  @ufw::allow { 'allow-elasticsearch-http-9200-from-search-1':
-    port    => 9200,
-    from    => getparam(Govuk_host['search-1'], 'ip'),
-    require => Govuk_host['search-1'],
-  }
-  @ufw::allow { 'allow-elasticsearch-http-9200-from-search-2':
-    port    => 9200,
-    from    => getparam(Govuk_host['search-2'], 'ip'),
-    require => Govuk_host['search-2'],
-  }
-  @ufw::allow { 'allow-elasticsearch-http-9200-from-search-3':
-    port    => 9200,
-    from    => getparam(Govuk_host['search-3'], 'ip'),
-    require => Govuk_host['search-3'],
-  }
+  unless $::aws_migration {
+    @ufw::allow { 'allow-elasticsearch-http-9200-from-search-1':
+      port    => 9200,
+      from    => getparam(Govuk_host['search-1'], 'ip'),
+      require => Govuk_host['search-1'],
+    }
+    @ufw::allow { 'allow-elasticsearch-http-9200-from-search-2':
+      port    => 9200,
+      from    => getparam(Govuk_host['search-2'], 'ip'),
+      require => Govuk_host['search-2'],
+    }
+    @ufw::allow { 'allow-elasticsearch-http-9200-from-search-3':
+      port    => 9200,
+      from    => getparam(Govuk_host['search-3'], 'ip'),
+      require => Govuk_host['search-3'],
+    }
 
-  @ufw::allow { 'allow-elasticsearch-http-9200-from-calculators-frontend-1':
-    port    => 9200,
-    from    => getparam(Govuk_host['calculators-frontend-1'], 'ip'),
-    require => Govuk_host['calculators-frontend-1'],
-  }
-  @ufw::allow { 'allow-elasticsearch-http-9200-from-calculators-frontend-2':
-    port    => 9200,
-    from    => getparam(Govuk_host['calculators-frontend-2'], 'ip'),
-    require => Govuk_host['calculators-frontend-2'],
-  }
-  @ufw::allow { 'allow-elasticsearch-http-9200-from-calculators-frontend-3':
-    port    => 9200,
-    from    => getparam(Govuk_host['calculators-frontend-3'], 'ip'),
-    require => Govuk_host['calculators-frontend-3'],
-  }
+    @ufw::allow { 'allow-elasticsearch-http-9200-from-calculators-frontend-1':
+      port    => 9200,
+      from    => getparam(Govuk_host['calculators-frontend-1'], 'ip'),
+      require => Govuk_host['calculators-frontend-1'],
+    }
+    @ufw::allow { 'allow-elasticsearch-http-9200-from-calculators-frontend-2':
+      port    => 9200,
+      from    => getparam(Govuk_host['calculators-frontend-2'], 'ip'),
+      require => Govuk_host['calculators-frontend-2'],
+    }
+    @ufw::allow { 'allow-elasticsearch-http-9200-from-calculators-frontend-3':
+      port    => 9200,
+      from    => getparam(Govuk_host['calculators-frontend-3'], 'ip'),
+      require => Govuk_host['calculators-frontend-3'],
+    }
 
-  # FIXME: Remove these firewall rules by moving the need-api app from the backend
-  # machines to the API machines. The MongoDB database will need to move too.
-  # There are more firewall rules in govuk-provisioning that can also be removed.
-  @ufw::allow { 'allow-elasticsearch-http-9200-from-backend-1':
-    port    => 9200,
-    from    => getparam(Govuk_host['backend-1'], 'ip'),
-    require => Govuk_host['backend-1'],
-  }
-  @ufw::allow { 'allow-elasticsearch-http-9200-from-backend-2':
-    port    => 9200,
-    from    => getparam(Govuk_host['backend-2'], 'ip'),
-    require => Govuk_host['backend-2'],
-  }
-  @ufw::allow { 'allow-elasticsearch-http-9200-from-backend-3':
-    port    => 9200,
-    from    => getparam(Govuk_host['backend-3'], 'ip'),
-    require => Govuk_host['backend-3'],
+    # FIXME: Remove these firewall rules by moving the need-api app from the backend
+    # machines to the API machines. The MongoDB database will need to move too.
+    # There are more firewall rules in govuk-provisioning that can also be removed.
+    @ufw::allow { 'allow-elasticsearch-http-9200-from-backend-1':
+      port    => 9200,
+      from    => getparam(Govuk_host['backend-1'], 'ip'),
+      require => Govuk_host['backend-1'],
+    }
+    @ufw::allow { 'allow-elasticsearch-http-9200-from-backend-2':
+      port    => 9200,
+      from    => getparam(Govuk_host['backend-2'], 'ip'),
+      require => Govuk_host['backend-2'],
+    }
+    @ufw::allow { 'allow-elasticsearch-http-9200-from-backend-3':
+      port    => 9200,
+      from    => getparam(Govuk_host['backend-3'], 'ip'),
+      require => Govuk_host['backend-3'],
+    }
   }
 
   collectd::plugin::tcpconn { 'es-9200':


### PR DESCRIPTION
- Ignore firewall rules for Carrenza if we're on AWS, as that's all done
  through security groups in Terraform.