### PR TITLE
Add link_text to deploy emergency banner task

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_emergency_banner.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_emergency_banner.yaml.erb
@@ -6,7 +6,7 @@
     description: "Deploy the emergency banner on GOV.UK."
     builders:
       # The argument to `-c` is in this case `frontend` but the value is used by both `static` and `frontend` applications
-      - shell: ssh deploy@$(govuk_node_list -c frontend --single-node) "cd /var/apps/static && govuk_setenv static bundle exec rake emergency_banner:deploy[\"$CAMPAIGN_CLASS\",\"$HEADING\",\"$SHORT_DESCRIPTION\",\"$LINK\"]"
+      - shell: ssh deploy@$(govuk_node_list -c frontend --single-node) "cd /var/apps/static && govuk_setenv static bundle exec rake emergency_banner:deploy[\"$CAMPAIGN_CLASS\",\"$HEADING\",\"$SHORT_DESCRIPTION\",\"$LINK\",\"$LINK_TEXT\"]"
     wrappers:
       - ansicolor:
           colormap: xterm
@@ -27,3 +27,6 @@
       - string:
           name: LINK
           description: The more information link
+      - string:
+          name: LINK_TEXT
+          description: The anchor text for the more information link


### PR DESCRIPTION
Update the Jenkins task that deploys the emergency banner.

* Create a new parameter called `LINK_TEXT`
* Update the call to the rake task in [Static](https://github.com/alphagov/static) to include the new `LINK_TEXT` parameter

This should be released in conjunction with:

- [ ] [PR 1106 in Static](https://github.com/alphagov/static/pull/1106)
- [ ] [PR 352 in GOV.UK Developer Docs](https://github.com/alphagov/govuk-developer-docs/pull/352)

[Trello](https://trello.com/c/ZPkk7hnk/58-add-new-field-for-link-text)