### PR TITLE
Revert "Temporary fix while we're migrating things"

### DIFF
--- a/modules/base/manifests/init.pp
+++ b/modules/base/manifests/init.pp
@@ -42,15 +42,5 @@ class base {
       ensure  => 'present',
       content => template('base/motd.erb'),
     }
-
-    # FIXME this is a temporary solution to fix ongoing connect errors before
-    # we find the real resolution
-    cron::crondotdee { 'dhclient_reload':
-      command => '/usr/bin/host puppet >/dev/null || /sbin/dhclient -r; /sbin/dhclient',
-      hour    => '*',
-      minute  => '*/2',
-      user    => 'root',
-      mailto  => '""',
-    }
   }
 }


### PR DESCRIPTION
This reverts commit b29354e7de000ef5c3e3c3c69cf9ab8ee550e65f.

This is killing stuff by causing instances to run out of memory. A
proper resolution needs to be put into place.

```
lauramartin@ec2-integration-delana-jenkins-ip-10-1-6-175:~$ ps aux |grep dhclient |wc -l
1428
```