### PR TITLE
Add https vhost for AWS Grafana

### DIFF
--- a/modules/grafana/manifests/init.pp
+++ b/modules/grafana/manifests/init.pp
@@ -25,8 +25,19 @@ class grafana {
     require => Package['grafana'],
   }
 
-  nginx::config::site { 'grafana':
-    source => 'puppet:///modules/grafana/vhost.conf',
+  if $::aws_migration {
+    nginx::config::vhost::proxy { 'grafana':
+      to           => ['localhost:3204'],
+      root         => '/usr/share/grafana',
+      aliases      => ['grafana.*'],
+      protected    => false,
+      ssl_only     => true,
+      ssl_certtype => 'wildcard_publishing',
+    }
+  } else {
+    nginx::config::site { 'grafana':
+      source => 'puppet:///modules/grafana/vhost.conf',
+    }
   }
 
 }


### PR DESCRIPTION
Our VCloud infrastructure proxies graphite/grafana HTTPS requests from the
monitoring to the graphite box. On AWS we are accessing directly the
Nginx service on graphite via loadbalancer, so the Grafana site needs to be
updated to use HTTPS. The Graphite Nginx site config is already using HTTPS.