### PR TITLE
Add elasticsearch-2.4 repository

### DIFF
--- a/modules/govuk/manifests/node/s_apt.pp
+++ b/modules/govuk/manifests/node/s_apt.pp
@@ -70,6 +70,10 @@ class govuk::node::s_apt (
       location => 'http://packages.elastic.co/elasticsearch/1.7/debian',
       release  => 'stable',
       key      => '46095ACC8548582C1A2699A9D27D666CD88E42B4';
+    'elasticsearch-2.4':
+      location => 'http://packages.elastic.co/elasticsearch/2.4/debian',
+      release  => 'stable',
+      key      => '46095ACC8548582C1A2699A9D27D666CD88E42B4';
     'grafana':
       location => 'https://packagecloud.io/grafana/stable/debian',
       release  => 'jessie',


### PR DESCRIPTION
This is required for the new rummager-elasticsearch machines.

Ref: https://www.elastic.co/guide/en/elasticsearch/reference/2.4/setup-repositories.html