### PR TITLE
Update Elasticsearch aptly config

### DIFF
--- a/modules/govuk/manifests/node/s_apt.pp
+++ b/modules/govuk/manifests/node/s_apt.pp
@@ -70,8 +70,8 @@ class govuk::node::s_apt (
       location => 'http://packages.elastic.co/elasticsearch/1.7/debian',
       release  => 'stable',
       key      => '46095ACC8548582C1A2699A9D27D666CD88E42B4';
-    'elasticsearch-2.4':
-      location => 'http://packages.elastic.co/elasticsearch/2.4/debian',
+    'elasticsearch-2.x':
+      location => 'http://packages.elastic.co/elasticsearch/2.x/debian',
       release  => 'stable',
       key      => '46095ACC8548582C1A2699A9D27D666CD88E42B4';
     'grafana':


### PR DESCRIPTION
When it said to use "2.x" I didn't take it seriously, but that's
actually what you have to use.