### PR TITLE
AWS Rabbitmq configuration

### DIFF
--- a/hieradata_aws/class/rabbitmq.yaml
+++ b/hieradata_aws/class/rabbitmq.yaml
@@ -1,0 +1,23 @@
+---
+
+govuk::node::s_rabbitmq::apps_using_rabbitmq:
+  - backdrop_write
+  - email_alert_service
+  - publishing_api
+  - rummager
+  - stagecraft
+
+govuk_safe_to_reboot::can_reboot: 'careful'
+govuk_safe_to_reboot::reason: 'rabbitmq-1 is a single point of failure for content-store, apps not resilient'
+
+rabbitmq::config_kernel_variables:
+  'inet_dist_listen_min': '9100'
+  'inet_dist_listen_max': '9105'
+rabbitmq::config_variables:
+  'vm_memory_high_watermark': '0.8'
+  'cluster_partition_handling': 'pause_minority'
+rabbitmq::config_additional_variables:
+  'autocluster': '[ {autocluster_log_level, debug}, {backend, aws}, {aws_autoscaling, true}, {aws_ec2_region, "eu-west-1"} ]'
+rabbitmq::cluster_node_type: 'disc'
+rabbitmq::erlang_cookie: 'EOKOWXQREETZSHFNTPEY'
+rabbitmq::wipe_db_on_cookie_change: true

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1495,8 +1495,6 @@ puppet::repository::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 rabbitmq::delete_guest_user: true
 rabbitmq::config_stomp: true
 # Always use our mirror because they only provide the latest package.
-rabbitmq::package_ensure: '3.4.3-1'
-rabbitmq::manage_repos: false
 
 rcs::fsckfix: 'YES'
 rcs::tmptime: '7'


### PR DESCRIPTION
Add Rabbitmq configuration for AWS:
- Override hieradata settings to install latest package and use autocluster
- Install autocluster plugin