### PR TITLE
Add conditional for elasticsearch repos

### DIFF
--- a/modules/govuk_elasticsearch/manifests/init.pp
+++ b/modules/govuk_elasticsearch/manifests/init.pp
@@ -73,8 +73,14 @@ class govuk_elasticsearch (
   $http_port = '9200'
   $transport_port = '9300'
 
+  # The repository for version 2 is called "elasticsearch-2.x" for all minor versions
   if $manage_repo {
-    $repo_version = regsubst($version, '\.\d+$', '') # 1.4.2 becomes 1.4 etc.
+    if $version =~ /^2./ {
+      $repo_version = '2.x'
+    } else {
+      $repo_version = regsubst($version, '\.\d+$', '') # 1.4.2 becomes 1.4 etc.
+    }
+
     class { 'govuk_elasticsearch::repo':
       repo_version => $repo_version,
     }

--- a/modules/govuk_elasticsearch/spec/classes/govuk_elasticsearch_spec.rb
+++ b/modules/govuk_elasticsearch/spec/classes/govuk_elasticsearch_spec.rb
@@ -37,6 +37,11 @@ describe 'govuk_elasticsearch', :type => :class do
         is_expected.to contain_class('govuk_elasticsearch::repo').with_repo_version('1.4')
       end
 
+      it "should handle the repo for 2.4.x" do
+        params[:version] = '2.4.3'
+        is_expected.to contain_class('govuk_elasticsearch::repo').with_repo_version('2.x')
+      end
+
       it { is_expected.to contain_class('elasticsearch').with_manage_repo(false) }
     end
 


### PR DESCRIPTION
The repo that gets added to apt for Elasticsearch v2.x is literally
called "elasticsearch-2.x", so we need to add a conditional so that any
version of Elasticsearch v2 will use that repository name in apt
sources.