### PR TITLE
Store POST traffic to rummager servers using GOR

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -64,6 +64,8 @@ govuk_crawler::targets:
 
 govuk_elasticsearch::dump::run_es_dump_hour: '9'
 
+govuk_search::gor::enabled: true
+
 govuk_jenkins::config::banner_colour_background: '#ffbf47'
 govuk_jenkins::config::banner_colour_text: 'black'
 govuk_jenkins::config::banner_string: 'Carrenza INTEGRATION'

--- a/modules/govuk/manifests/node/s_search.pp
+++ b/modules/govuk/manifests/node/s_search.pp
@@ -4,6 +4,7 @@
 #
 class govuk::node::s_search inherits govuk::node::s_base {
   include govuk::node::s_app_server
+  include govuk_search::gor
 
   include nginx
 

--- a/modules/govuk_search/manifests/gor.pp
+++ b/modules/govuk_search/manifests/gor.pp
@@ -1,0 +1,55 @@
+# == Class: govuk_search::gor
+#
+# Dump POST traffic to file so that it can be replayed. This means we have a simple
+# way to recover from failure as we can restore the last backup and then replay the
+# traffic (POST requests are for data insert/update only)
+#
+# Traffic can then be replayed by follow the guide at:
+# https://github.com/buger/goreplay/wiki/Capturing-and-replaying-traffic
+#
+# === Parameters
+#
+# [*enabled*]
+#   Boolean to determine if Search traffic will be saved; defaults to false.
+#
+# [*output_path*]
+#   File location for files to be saved to.
+#
+class govuk_search::gor (
+  $output_path = '/var/log/gor_dump',
+  $enabled = false
+) {
+
+  validate_bool($enabled)
+
+  if($enabled) {
+    validate_re($output_path, '^/.*')
+
+    file { $output_path:
+      ensure => 'directory',
+      owner  => root,
+      group  => root,
+      mode   => '0755',
+    }
+
+    @logrotate::conf { "govuk-${title}":
+      ensure  => $enabled,
+      matches => "${output_path}/*.log",
+    }
+
+    $output_file = "${output_path}/%Y%m%d.log"
+
+    class { 'govuk_gor':
+      args    => {
+        '-input-raw'          => ':3009',
+        '-output-file'        => $output_file,
+        '-http-allow-method'  => ['POST', 'DELETE'],
+        '-http-original-host' => '',
+      },
+      envvars => {
+        'GODEBUG' => 'netdns=go',
+      },
+      enable  => $enabled,
+    }
+  }
+}

--- a/modules/govuk_search/spec/classes/govuk_search__gor_spec.rb
+++ b/modules/govuk_search/spec/classes/govuk_search__gor_spec.rb
@@ -1,0 +1,71 @@
+require_relative '../../../../spec_helper'
+
+describe 'govuk_search::gor', :type => :class do
+  let(:args_default) {{
+    '-input-raw'          => ':3009',
+    '-http-allow-method' => %w{POST DELETE},
+    '-http-original-host' => '',
+  }}
+
+  context 'default (disabled)' do
+    let(:params) {{ }}
+
+    it {
+      is_expected.not_to contain_class('govuk_gor').with({
+        :enable => false,
+      })
+    }
+  end
+
+  context '#enabled' do
+    let(:output_path) { '/output/path' }
+    let(:params) {{
+      :enabled => true,
+      :output_path => output_path,
+    }}
+
+    it {
+      is_expected.to contain_class('govuk_gor').with(
+        :enable => true,
+        :args           => args_default.merge({
+          '-output-file' => "#{output_path}/%Y%m%d.log",
+        }),
+        :envvars => {
+          'GODEBUG' => 'netdns=go',
+        }
+      )
+    }
+
+
+    it {
+      is_expected.to contain_file(output_path).with(
+        :ensure   => 'directory',
+        :owner    => 'root',
+        :group    => 'root',
+        :mode     => '0755',
+      )
+    }
+  end
+
+  context 'enabled but missing output path' do
+    let(:params) {{
+      :enabled => true,
+      :output_path => nil
+    }}
+
+    it {
+      is_expected.to raise_error(Puppet::Error, /does not match "\^\/\.\*" at/)
+    }
+  end
+
+  context 'enabled but output path is invalid' do
+    let(:params) {{
+      :enabled => true,
+      :output_path => 'invalid/path'
+    }}
+
+    it {
+      is_expected.to raise_error(Puppet::Error, /does not match "\^\/\.\*" at/)
+    }
+  end
+end


### PR DESCRIPTION
This provides a simplified restore strategy as we can reload the index
from backup and then re-run the POST traffic. The big advantage here is
that we will not need to try and resend the changes from the individual
publishing apps.

https://trello.com/c/8AWCdA1Z/204-investigate-gor-traffic-replay