### PR TITLE
Bugfix Elasticsearch 2.4 install

### DIFF
--- a/modules/govuk_elasticsearch/manifests/init.pp
+++ b/modules/govuk_elasticsearch/manifests/init.pp
@@ -75,9 +75,9 @@ class govuk_elasticsearch (
 
   # The repository for version 2 is called "elasticsearch-2.x" for all minor versions
   if $manage_repo {
-    if $version =~ /^2./ {
+    if versioncmp($version, '2') >= 0 {
       $repo_version = '2.x'
-    } else {
+    } elsif versioncmp($version, '2') < 0 {
       $repo_version = regsubst($version, '\.\d+$', '') # 1.4.2 becomes 1.4 etc.
     }
 

--- a/modules/govuk_elasticsearch/manifests/plugins.pp
+++ b/modules/govuk_elasticsearch/manifests/plugins.pp
@@ -6,17 +6,6 @@ class govuk_elasticsearch::plugins (
   $elasticsearch_version = $::govuk_elasticsearch::version,
 ){
 
-  elasticsearch::plugin { 'mobz/elasticsearch-head':
-    module_dir => 'head',
-    instances  => $::fqdn,
-  }
-
-  elasticsearch::plugin { 'elasticsearch-migration':
-    module_dir => 'migration',
-    url        => 'https://github.com/elastic/elasticsearch-migration/releases/download/v1.19/elasticsearch-migration-1.19.zip',
-    instances  => $::fqdn,
-  }
-
   if versioncmp($elasticsearch_version, '2.0') < 0 {
     # If version is older than 2.0.0, then install an older plugin
     case $elasticsearch_version {
@@ -30,6 +19,18 @@ class govuk_elasticsearch::plugins (
       module_dir => 'cloud-aws',
       instances  => $::fqdn,
     }
+
+    elasticsearch::plugin { 'mobz/elasticsearch-head':
+      module_dir => 'head',
+      instances  => $::fqdn,
+    }
+
+    elasticsearch::plugin { 'elasticsearch-migration':
+      module_dir => 'migration',
+      url        => 'https://github.com/elastic/elasticsearch-migration/releases/download/v1.19/elasticsearch-migration-1.19.zip',
+      instances  => $::fqdn,
+    }
+
   }
   # If the version is 2.4, then install the plugin the 2.4 way
   elsif versioncmp($elasticsearch_version, '2.4') == 0 {


### PR DESCRIPTION
  - the versioncmp function works rather than the regex (which didn't
  work as expected)

  - only install plugins for the older versions of elasticsearch. The
  Puppet module we're using for Elasticsearch is too old to install
  plugins on ES >2, so we can either fork the module, or install plugins
  manually until we've upgraded the old versions of Elasticsearch we're
  running.

@dwhenry because we're using such an old version of the Puppet Elasticsearch module, the plugin install resource doesn't work for 2.4, which means you'll have to install plugins manually (or we'll have to fork the Puppet module).