### PR TITLE
If we're in AWS don't do a dynamic lookup

### DIFF
--- a/modules/govuk_logging/templates/logstream.erb
+++ b/modules/govuk_logging/templates/logstream.erb
@@ -34,7 +34,11 @@ if @json.to_s == 'true'
 end
 -%>
 script
+    <%- if scope.lookupvar('::aws_migration') %>
+    REDIS_SERVERS=logs-redis
+    <%- else -%>
     REDIS_SERVERS=$(govuk_node_list -c logs_redis | xargs -IHOST echo redis://HOST | paste -sd ',')
+    <%- end -%>
     if [ -z "$REDIS_SERVERS" ]; then
         echo "No redis servers found from govuk_node_list"
         exit 1


### PR DESCRIPTION
Only use node_list in the old environments