### PR TITLE
Wrap upstream mysql::db

### DIFF
--- a/modules/govuk/manifests/apps/collections_publisher/db.pp
+++ b/modules/govuk/manifests/apps/collections_publisher/db.pp
@@ -2,7 +2,7 @@
 class govuk::apps::collections_publisher::db(
   $mysql_password,
 ) {
-  mysql::db {'collections_publisher_production':
+  govuk_mysql::db {'collections_publisher_production':
     user     => 'collections_pub',
     host     => '%',
     password => $mysql_password,

--- a/modules/govuk/manifests/apps/contacts/db.pp
+++ b/modules/govuk/manifests/apps/contacts/db.pp
@@ -12,7 +12,7 @@ class govuk::apps::contacts::db (
   $mysql_contacts_admin = '',
   $mysql_contacts_frontend =  '',
 ){
-  mysql::db { 'contacts_production':
+  govuk_mysql::db { 'contacts_production':
     user     => 'contacts',
     host     => '%',
     password => $mysql_contacts_admin,

--- a/modules/govuk/manifests/apps/release/db.pp
+++ b/modules/govuk/manifests/apps/release/db.pp
@@ -3,7 +3,7 @@ class govuk::apps::release::db (
   $mysql_release = '',
 ){
 
-  mysql::db {'release_production':
+  govuk_mysql::db {'release_production':
     user     => 'release',
     host     => '%',
     password => $mysql_release,

--- a/modules/govuk/manifests/apps/search_admin/db.pp
+++ b/modules/govuk/manifests/apps/search_admin/db.pp
@@ -2,7 +2,7 @@
 class govuk::apps::search_admin::db(
   $mysql_search_admin,
 ) {
-  mysql::db {'search_admin_production':
+  govuk_mysql::db {'search_admin_production':
     user     => 'search_admin',
     host     => '%',
     password => $mysql_search_admin,

--- a/modules/govuk/manifests/apps/signon/db.pp
+++ b/modules/govuk/manifests/apps/signon/db.pp
@@ -3,7 +3,7 @@ class govuk::apps::signon::db (
   $mysql_signonotron = '',
 ){
 
-  mysql::db {'signon_production':
+  govuk_mysql::db {'signon_production':
     user     => 'signon',
     host     => '%',
     password => $mysql_signonotron,

--- a/modules/govuk/manifests/apps/whitehall/db.pp
+++ b/modules/govuk/manifests/apps/whitehall/db.pp
@@ -2,7 +2,7 @@
 class govuk::apps::whitehall::db (
   $mysql_whitehall_admin = '',
 ){
-  mysql::db { 'whitehall_production':
+  govuk_mysql::db { 'whitehall_production':
     user     => 'whitehall',
     host     => '%',
     password => $mysql_whitehall_admin,

--- a/modules/govuk/manifests/node/s_db_admin.pp
+++ b/modules/govuk/manifests/node/s_db_admin.pp
@@ -34,13 +34,6 @@ class govuk::node::s_db_admin(
   class { '::govuk::apps::signon::db': } ->
   class { '::govuk::apps::whitehall::db': }
 
-  $packages = [
-    # should this be include govuk_postgresql::client
-    'postgresql-client-9.3',
-    'mysql-client-5.5',
-  ]
+  include ::govuk_postgresql::client
 
-  package { $packages:
-    ensure =>  present,
-  }
 }

--- a/modules/govuk_mysql/manifests/db.pp
+++ b/modules/govuk_mysql/manifests/db.pp
@@ -1,0 +1,96 @@
+# == Class: Govuk_mysql::Db
+#
+# This defined type is a direct copy from the upstream MySQL Puppet module,
+# save for the fact it does not explictly require the mysql::server class. This
+# is so we can transparently manage remote MySQL servers without having to install
+# a MySQL server on our admin instance.
+#
+#
+define govuk_mysql::db (
+  $user,
+  $password,
+  $charset     = 'utf8',
+  $collate     = 'utf8_general_ci',
+  $host        = 'localhost',
+  $grant       = 'ALL',
+  $sql         = '',
+  $enforce_sql = false,
+  $ensure      = 'present'
+) {
+  #input validation
+  validate_re($ensure, '^(present|absent)$',
+  "${ensure} is not supported for ensure. Allowed values are 'present' and 'absent'.")
+  $table = "${name}.*"
+
+  include '::mysql::client'
+
+  if $::aws_migration {
+    mysql_database { $name:
+      ensure   => $ensure,
+      charset  => $charset,
+      collate  => $collate,
+      provider => 'mysql',
+      require  => Class['mysql::client'],
+      before   => Mysql_user["${user}@${host}"],
+    }
+  } else {
+    mysql_database { $name:
+      ensure   => $ensure,
+      charset  => $charset,
+      collate  => $collate,
+      provider => 'mysql',
+      require  => [ Class['mysql::server'], Class['mysql::client'] ],
+      before   => Mysql_user["${user}@${host}"],
+    }
+  }
+
+  if $::aws_migration {
+    $user_resource = {
+      ensure        => $ensure,
+      password_hash => mysql_password($password),
+      provider      => 'mysql',
+    }
+  } else {
+    $user_resource = {
+      ensure        => $ensure,
+      password_hash => mysql_password($password),
+      provider      => 'mysql',
+      require       => Class['mysql::server'],
+    }
+  }
+
+  ensure_resource('mysql_user', "${user}@${host}", $user_resource)
+
+  if $ensure == 'present' {
+    if $::aws_migration {
+      mysql_grant { "${user}@${host}/${table}":
+        privileges => $grant,
+        provider   => 'mysql',
+        user       => "${user}@${host}",
+        table      => $table,
+        require    => Mysql_user["${user}@${host}"],
+      }
+    } else {
+      mysql_grant { "${user}@${host}/${table}":
+        privileges => $grant,
+        provider   => 'mysql',
+        user       => "${user}@${host}",
+        table      => $table,
+        require    => [ Mysql_user["${user}@${host}"], Class['mysql::server'] ],
+      }
+    }
+
+    $refresh = ! $enforce_sql
+
+    if $sql {
+      exec{ "${name}-import":
+        command     => "/usr/bin/mysql ${name} < ${sql}",
+        logoutput   => true,
+        environment => "HOME=${::root_home}",
+        refreshonly => $refresh,
+        require     => Mysql_grant["${user}@${host}/${table}"],
+        subscribe   => Mysql_database[$name],
+      }
+    }
+  }
+}

--- a/modules/govuk_mysql/spec/defines/govuk_mysql__db_spec.rb
+++ b/modules/govuk_mysql/spec/defines/govuk_mysql__db_spec.rb
@@ -1,0 +1,45 @@
+require_relative '../../../../spec_helper'
+
+describe 'mysql::db', :type => :define do
+  let(:facts) {{ :osfamily => 'RedHat' }}
+  let(:title) { 'test_db' }
+
+  let(:params) {
+    { 'user'     => 'testuser',
+      'password' => 'testpass',
+    }
+  }
+
+  it 'should not notify the import sql exec if no sql script was provided' do
+    should contain_mysql_database('test_db').without_notify
+  end
+
+  it 'should subscribe to database if sql script is given' do
+    params.merge!({'sql' => 'test_sql'})
+    should contain_exec('test_db-import').with_subscribe('Mysql_database[test_db]')
+  end
+
+  it 'should only import sql script on creation if not enforcing' do
+    params.merge!({'sql' => 'test_sql', 'enforce_sql' => false})
+    should contain_exec('test_db-import').with_refreshonly(true)
+  end
+
+  it 'should import sql script on creation if enforcing' do
+    params.merge!({'sql' => 'test_sql', 'enforce_sql' => true})
+    should contain_exec('test_db-import').with_refreshonly(false)
+  end
+
+  it 'should not create database and database user' do
+    params.merge!({'ensure' => 'absent', 'host' => 'localhost'})
+    should contain_mysql_database('test_db').with_ensure('absent')
+    should contain_mysql_user('testuser@localhost').with_ensure('absent')
+  end
+
+  it 'should create with an appropriate collate and charset' do
+    params.merge!({'charset' => 'utf8', 'collate' => 'utf8_danish_ci'})
+    should contain_mysql_database('test_db').with({
+      'charset' => 'utf8',
+      'collate' => 'utf8_danish_ci',
+    })
+  end
+end


### PR DESCRIPTION
In AWS we wish to use RDS to manage our databases. The current upstream MySQL module does not allow managing a remote database with the current defined types as it always requires the mysql::server class, which installs and sets up a MySQL server.

This is an attempt to copy the current code (and tests), except with added conditionals related to AWS which means resources do not require setting up the server.