### PR TITLE
Deploy router-data from GitHub

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_router_data.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_router_data.yaml.erb
@@ -3,7 +3,7 @@
     name: router-data_deploy_router_data
     scm:
         - git:
-            url: git@github.digital.cabinet-office.gov.uk:gds/router-data.git
+            url: git@github.com:alphagov/router-data.git
             branches:
               - $TAG
 


### PR DESCRIPTION
Rather than GitHub enterprise. This repository is in the process of
being deprecated, but in the mean time, move it to GitHub, and off of
GitHub Enterprise.