### PR TITLE
Revert "Add publishing api content item count to collectd..."

### DIFF
--- a/modules/collectd/templates/etc/collectd/conf.d/postgresql.conf.erb
+++ b/modules/collectd/templates/etc/collectd/conf.d/postgresql.conf.erb
@@ -37,16 +37,6 @@ LoadPlugin postgresql
     </Result>
   </Query>
 
-  <Query publishing_api_content_item_count>
-    Statement "SELECT count(*) AS count \
-               FROM content_items;"
-
-    <Result>
-      Type counter
-      ValuesFrom "count"
-    </Result>
-  </Query>
-
   <Database postgres>
     Instance "global"
     Host "localhost"
@@ -65,13 +55,5 @@ LoadPlugin postgresql
     SSLMode "prefer"
     # By not specifying a specific query, we pull in the defaults
     # which are specific to the `postgres` database
-  </Database>
-
-  <Database publishing_api_production>
-    Host "localhost"
-    User "<%= @user %>"
-    Password "<%= @password %>"
-    SSLMode "prefer"
-    Query publishing_api_content_item_count
   </Database>
 </Plugin>


### PR DESCRIPTION
Reverts alphagov/govuk-puppet#4607

I've been trying to work out where all the collectd data has gone for publishing_api_production db. See: https://graphite.publishing.service.gov.uk/render/?width=586&height=308&_salt=1502099938.681&target=postgresql-primary-1_backend.postgresql-publishing_api_production.pg_db_size&from=00%3A00_20160612&until=23%3A59_20160826

This change seems to correlate with the timing of this. So I'm planning to revert it to try resume the data.