### PR TITLE
Rename custom mysql_server_id fact

### DIFF
--- a/modules/govuk_mysql/lib/facter/server_id.rb
+++ b/modules/govuk_mysql/lib/facter/server_id.rb
@@ -3,7 +3,7 @@ def get_mysql_id
   Facter.value(:ipaddress).split('.').inject(0) { |total,value| (total << 8) + value.to_i }
 end
 
-Facter.add("mysql_server_id") do
+Facter.add("govuk_mysql_server_id") do
   setcode do
     get_mysql_id
   end

--- a/modules/govuk_mysql/manifests/server.pp
+++ b/modules/govuk_mysql/manifests/server.pp
@@ -82,7 +82,7 @@ class govuk_mysql::server (
     'mysqld'                           => {
       'pid-file'                       => $pidfile,
       'bind-address'                   => '0.0.0.0',
-      'server_id'                      => $::mysql_server_id,
+      'server_id'                      => $::govuk_mysql_server_id,
       'innodb_file_per_table'          => $innodb_file_per_table,
       'innodb_buffer_pool_size'        => $innodb_buffer_pool_size,
       'key_buffer_size'                => $key_buffer_size,


### PR DESCRIPTION
The latest puppetlabs-mysql module introduces a mysql_server_id fact
that conflicts with our original one. This change renames our server ID
fact so the server configuration remains the same.