### PR TITLE
Update ES binding

### DIFF
--- a/modules/govuk_elasticsearch/manifests/init.pp
+++ b/modules/govuk_elasticsearch/manifests/init.pp
@@ -132,6 +132,7 @@ class govuk_elasticsearch (
     'index.refresh_interval'   => $refresh_interval,
     'transport.tcp.port'       => $transport_port,
     'network.publish_host'     => $::fqdn,
+    'network.host'             => '0.0.0.0',
     'node.name'                => $::fqdn,
     'http.port'                => $http_port,
     'http.cors.enabled'        => $cors_enabled,


### PR DESCRIPTION
Allow Elasticsearch connections from all hosts. In v1.x, the default is to allow all (ref: https://www.elastic.co/guide/en/elasticsearch/reference/1.7/modules-network.html#common-network-settings).

In v2.x, the default is localhost only (ref: https://www.elastic.co/guide/en/elasticsearch/reference/2.4/modules-network.html#common-network-settings).

Add the network setting to explictly allow from all so we can create a cluster for newer versions of Elasticsearch.