### PR TITLE
Override mysql_id function in custom fact

### DIFF
--- a/modules/govuk_mysql/lib/facter/server_id.rb
+++ b/modules/govuk_mysql/lib/facter/server_id.rb
@@ -1,10 +1,10 @@
 # Converts IP address to integer for MySQL server id
-def get_mysql_id
+def get_govuk_mysql_id
   Facter.value(:ipaddress).split('.').inject(0) { |total,value| (total << 8) + value.to_i }
 end
 
 Facter.add("govuk_mysql_server_id") do
   setcode do
-    get_mysql_id
+    get_govuk_mysql_id
   end
 end


### PR DESCRIPTION
Do not use same function name as upstream mysql_server_id fact.