### PR TITLE
Do not restart Mysql on config change

### DIFF
--- a/modules/govuk_mysql/manifests/server.pp
+++ b/modules/govuk_mysql/manifests/server.pp
@@ -114,7 +114,7 @@ class govuk_mysql::server (
     root_password    => $root_password,
     override_options => $mysql_config,
     purge_conf_dir   => true,
-    restart          => true,
+    restart          => false,
   }
 
   class { 'mysql::server::account_security': }


### PR DESCRIPTION
The latest puppetlabs-mysql upgrade is going to introduce some
minor changes in the Mysql configuration. This change updates our
govuk_mysql module to not restart the servicemif the configuration
is updated, so we can deploy the previous changes on Production.

After deploying Puppet on Production, we can revert this change if
we want to restore the previous behaviour.