### PR TITLE
Contain icinga classes in config

### DIFF
--- a/modules/icinga/manifests/config.pp
+++ b/modules/icinga/manifests/config.pp
@@ -22,8 +22,8 @@ class icinga::config (
   validate_bool($enable_event_handlers)
 
   include govuk_htpasswd
-  include icinga::config::pingdom
-  include icinga::config::smokey
+  contain icinga::config::pingdom
+  contain icinga::config::smokey
 
   $app_domain = hiera('app_domain','dev.gov.uk')
 


### PR DESCRIPTION
Update icinga::config to contain classes that require the packages. The
package-config dependency is already managed in the init.pp manifest, but
if we use include inside config, it doesn't ensure the package will be
present by the time the classes are implemented.