### PR TITLE
Add nginx-extras

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1488,6 +1488,7 @@ monitoring::vpn_gateways::endpoints:
 # FIXME: this has been added to avoid a bug until we move to v3 of the module
 mysql::client::package_ensure: 'present'
 
+nginx::package::nginx_package: 'nginx-extras'
 nginx::package::version: '1.4.6-1ubuntu3.8'
 
 nodejs::version: '0.10.37-1chl1~%{::lsbdistcodename}1'


### PR DESCRIPTION
We require nginx-extras on the loadbalancers to do the additional
headers for tracing.

Adding the nginx-extras package everywhere doesn't hurt, and it means we
don't have a bunch of extra hieradata files to maintain.