### PR TITLE
Record Sidekiq stats with collectd

### DIFF
--- a/modules/govuk/manifests/procfile/worker.pp
+++ b/modules/govuk/manifests/procfile/worker.pp
@@ -39,6 +39,12 @@ define govuk::procfile::worker (
   include govuk::procfile
 
   $service_name = "${title}-procfile-worker"
+  $title_underscore = regsubst($title, '\.', '_', 'G')
+
+  collectd::plugin::process { "app-worker-${title_underscore}":
+    ensure => $ensure,
+    regex  => "sidekiq .* ${title}.*\\.gov\\.uk",
+  }
 
   if $ensure == present {
     file { "/etc/init/${service_name}.conf":


### PR DESCRIPTION
In order to help diagnose excessive memory usage of worker tasks,
this change collects Sidekiq process data with collectd, for monitoring
in Graphite.

![worker-rss-usage](https://user-images.githubusercontent.com/12036746/29063672-7e7d9c98-7c1e-11e7-8bb2-d587d8679b23.png)
