### PR TITLE
Setup Elasticsearch 2.4 to run on CI agent 3

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -664,7 +664,7 @@ govuk_ci::master::ci_agents:
     labels: 'mongodb-2.4 docker ci-agent-2 elasticsearch terraform'
   ci-agent-3:
     agent_hostname: 'ci-agent-3.ci'
-    labels: 'mongodb-2.4 docker ci-agent-3 elasticsearch terraform'
+    labels: 'mongodb-2.4 docker ci-agent-3 elasticsearch-2.4 terraform'
   ci-agent-4:
     agent_hostname: 'ci-agent-4.ci'
     labels: 'mongodb-3.2 docker ci-agent-4 elasticsearch terraform'

--- a/hieradata/node/ci-agent-3.ci.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/ci-agent-3.ci.integration.publishing.service.gov.uk.yaml
@@ -1,2 +1,3 @@
 ---
+govuk_elasticsearch::version: '2.4.6'
 mongodb::server::version: '2.4.9'


### PR DESCRIPTION
This adds testing support to facilitate the upgrade.

https://trello.com/c/7UxzIqNo/205-update-es-version-for-ci