### PR TITLE
AWS fix boot, ssh and nginx alerts

### DIFF
--- a/modules/icinga/files/etc/nagios/nrpe.d/check_ssh_local.cfg
+++ b/modules/icinga/files/etc/nagios/nrpe.d/check_ssh_local.cfg
@@ -1,0 +1,1 @@
+command[check_ssh_local]=/usr/lib/nagios/plugins/check_ssh localhost

--- a/modules/nginx/files/etc/nagios/nrpe.d/check_http_local.cfg
+++ b/modules/nginx/files/etc/nagios/nrpe.d/check_http_local.cfg
@@ -1,0 +1,1 @@
+command[check_http_local]=/usr/lib/nagios/plugins/check_http -I 127.0.0.1 -w $ARG2$ -c $ARG3$ -H $ARG1$


### PR DESCRIPTION
Update some common Icinga checks to work on AWS
- Remove boot partition space check, as we don't implement the same disk layout
on AWS
- Update ssh check to run locally with nrpe, as the monitoring box does not have
access on ssh to the rest of instances. Later we can update the jumpbox configuration
to run more ssh checks from there, but we might also want to remove this check
- Update Ngnix http check to run locally with nrpe, as the monitoring box does
not have http access to the rest of instances