### PR TITLE
Add local Gemstash servername

### DIFF
--- a/modules/govuk/templates/node/s_apt/gemstash_cluster_vhost.conf.erb
+++ b/modules/govuk/templates/node/s_apt/gemstash_cluster_vhost.conf.erb
@@ -2,7 +2,7 @@ server {
   # This serves:
   #   - `gemstash.cluster` internally.
   #   - `gemstash.APP_DOMAIN` externally.
-  server_name gemstash.*;
+  server_name gemstash gemstash.*;
   listen 80;
 
   access_log /var/log/nginx/gemstash-access.log timed_combined;


### PR DESCRIPTION
On AWS, the gemstash service is requested using the short service name, instead
of '.cluster'. This change adds the extra service name to the Nginx vhost configuration.