### PR TITLE
Add fix for mysql_grant statement in CI

### DIFF
--- a/modules/govuk_ci/manifests/agent/mysql.pp
+++ b/modules/govuk_ci/manifests/agent/mysql.pp
@@ -97,7 +97,7 @@ class govuk_ci::agent::mysql {
     require       => Class['::govuk_mysql::server'],
   }
 
-  mysql_grant { 'whitehall@%whitehall_%.*':
+  mysql_grant { 'whitehall@%/whitehall_%.*':
     user       => 'whitehall@%',
     table      => 'whitehall_%.*',
     privileges => 'ALL',


### PR DESCRIPTION
This was failing since we upgraded the MySQL Puppet module. The user and
table needs to be seperated with a slash.