### PR TITLE
Allow applications to set the SENTRY_DSN env var

### DIFF
--- a/modules/govuk/manifests/app.pp
+++ b/modules/govuk/manifests/app.pp
@@ -220,6 +220,9 @@
 # This parameter is used to ensure symlinks are created correctly if the app
 # name and repo name don't match
 #
+# [*sentry_dsn*]
+#   The URL used by Sentry to report exceptions
+#
 define govuk::app (
   $app_type,
   $port = 0,
@@ -250,6 +253,7 @@ define govuk::app (
   $read_timeout = 15,
   $proxy_http_version_1_1_enabled = false,
   $repo_name = undef,
+  $sentry_dsn = undef,
 ) {
 
   if ! ($app_type in ['procfile', 'rack', 'bare']) {
@@ -313,6 +317,7 @@ define govuk::app (
     asset_pipeline_prefix          => $asset_pipeline_prefix,
     depends_on_nfs                 => $depends_on_nfs,
     read_timeout                   => $read_timeout,
+    sentry_dsn                     => $sentry_dsn,
     proxy_http_version_1_1_enabled => $proxy_http_version_1_1_enabled,
   }
 

--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -6,6 +6,9 @@
 #
 # FIXME: Document all parameters
 #
+# [*sentry_dsn*]
+#   The URL used by Sentry to report exceptions
+#
 # [*nagios_memory_warning*]
 #   Memory use, in MB, at which Nagios should generate a warning.
 #
@@ -43,6 +46,7 @@ define govuk::app::config (
   $depends_on_nfs = false,
   $read_timeout = 15,
   $proxy_http_version_1_1_enabled = false,
+  $sentry_dsn = undef,
 ) {
   $ensure_directory = $ensure ? {
     'present' => 'directory',
@@ -119,6 +123,9 @@ define govuk::app::config (
       "${title}-GOVUK_STATSD_PREFIX":
         varname => 'GOVUK_STATSD_PREFIX',
         value   => "govuk.app.${title}.${::hostname}";
+      "${title}-SENTRY_DSN":
+        varname => 'SENTRY_DSN',
+        value   => $sentry_dsn;
     }
 
     if $app_type == 'rack' and $unicorn_herder_timeout != 'NOTSET' {

--- a/modules/govuk/manifests/apps/collections.pp
+++ b/modules/govuk/manifests/apps/collections.pp
@@ -17,6 +17,9 @@
 # [*secret_key_base*]
 #   The key for Rails to use when signing/encrypting sessions.
 #
+# [*sentry_dsn*]
+#   The URL used by Sentry to report exceptions
+#
 # [*nagios_memory_warning*]
 #   Memory use at which Nagios should generate a warning.
 #
@@ -28,6 +31,7 @@ class govuk::apps::collections(
   $port = '3070',
   $errbit_api_key = undef,
   $secret_key_base = undef,
+  $sentry_dsn = undef,
   $nagios_memory_warning = undef,
   $nagios_memory_critical = undef,
 ) {
@@ -41,6 +45,7 @@ class govuk::apps::collections(
     vhost                  => $vhost,
     nagios_memory_warning  => $nagios_memory_warning,
     nagios_memory_critical => $nagios_memory_critical,
+    sentry_dsn             => $sentry_dsn,
   }
 
   Govuk::App::Envvar {

--- a/modules/govuk/manifests/apps/content_tagger.pp
+++ b/modules/govuk/manifests/apps/content_tagger.pp
@@ -11,6 +11,9 @@
 # [*secret_key_base*]
 #   The key for Rails to use when signing/encrypting sessions.
 #
+# [*sentry_dsn*]
+#   The URL used by Sentry to report exceptions
+#
 # [*errbit_api_key*]
 #   Errbit API key used by airbrake
 #
@@ -51,6 +54,7 @@
 class govuk::apps::content_tagger(
   $port = '3116',
   $secret_key_base = undef,
+  $sentry_dsn = undef,
   $errbit_api_key = '',
   $db_hostname = undef,
   $db_username = 'content_tagger',
@@ -73,6 +77,7 @@ class govuk::apps::content_tagger(
     log_format_is_json => true,
     asset_pipeline     => true,
     deny_framing       => true,
+    sentry_dsn         => $sentry_dsn,
   }
 
   Govuk::App::Envvar {


### PR DESCRIPTION
The `SENTRY_DSN` env var is used by the Sentry client to report exceptions. This commit allows us to set the var for applications. To use it we'll have to pass in the `sentry_dsn` variable via hieradata into `govuk::app`. The hieradata will be set in govuk-secrets.

The DSN for collections & content-tagger are added here because we'll be testing with them first. Once the test is successful we'll add the other applications as well.

https://trello.com/c/YsgDupoW