### PR TITLE
Add jq to CI machines

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ variable `classes` for the rake task, e.g.
 
     $ bundle exec rake spec:nodes classes=frontend,backend
 
+#### Test Hieradata
+
+During spec tests `spec/fixtures/hiera/hiera.yaml` is used to configure hieradata which *only* uses `spec/fixtures/hieradata/common.yaml` for its values (i.e. nothing from `hieradata/`).
+
+During node tests the hieradata uses the `vagrant` and `development` environments. The `development` environment should only be used if a value in `ENV['classes']` matches the regexp `/^(development|training)$/` (i.e. in normal operation it will use `vagrant`). This can mean that settings in `common.yaml` will be overwritten in accordance with hiera's `:hierarchy`.
+
 ### Test Coverage
 
 Each test suite's results are followed by a summary of how many resources that suite covers, how many the tests touch and the coverage as a percentage. e.g.

--- a/hieradata/class/ci_agent.yaml
+++ b/hieradata/class/ci_agent.yaml
@@ -13,6 +13,11 @@ govuk_mysql::server::innodb_flush_log_at_trx_commit: 2
 govuk_mysql::server::innodb_buffer_pool_size_proportion: 0.05
 govuk_mysql::server::query_cache_size: 0
 
+# On all environments ES-backups are disabled except for vagrant.
+# The vagrant env is used for testing. By explicitly disabling we can
+# overwrite that behaviour here without breaking tests & making
+# clear expected behaviour.
+govuk_elasticsearch::backup_enabled: false
 govuk_elasticsearch::minimum_master_nodes: '1'
 govuk_elasticsearch::version: '1.7.5'
 govuk_elasticsearch::number_of_replicas: '0'

--- a/modules/govuk_ci/manifests/agent.pp
+++ b/modules/govuk_ci/manifests/agent.pp
@@ -56,6 +56,9 @@ class govuk_ci::agent(
   package { 'libgdal-dev': # needed for mapit
     ensure => installed,
   }
+  package { 'jq':
+    ensure => installed,
+  }
 
   govuk_bundler::config {'jenkins-bundler':
     server    => $gemstash_server,


### PR DESCRIPTION
jq is often used for JSON linting and parsing. As such it's useful to
have on CI machines where these are common tasks (also we want to use it
to lint JSON in the govuk-aws repo).