### PR TITLE
Indicate that commas must be escaped in emergency banner task

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_emergency_banner.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_emergency_banner.yaml.erb
@@ -20,13 +20,13 @@
             - local-emergency
       - string:
           name: HEADING
-          description: The title of the banner
+          description: The title of the banner. Commas must be escaped, eg One\, two
       - string:
           name: SHORT_DESCRIPTION
-          description: The text that appears under the title
+          description: The text that appears under the title. Commas must be escaped, eg One\, two
       - string:
           name: LINK
           description: The more information link
       - string:
           name: LINK_TEXT
-          description: The anchor text for the more information link
+          description: The anchor text for the more information link. Commas must be escaped, eg One\, two


### PR DESCRIPTION
Rake arguments need to escape commas as commas are used to split arguments, even when quoted.

More details: https://github.com/alphagov/static/issues/1109