### PR TITLE
AWS puppetserver support

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1521,7 +1521,7 @@ postgresql_transition_standby_addresses_dr: "%{hiera('environment_ip_prefix')}.1
 postgresql::lib::devel::link_pg_config: false
 postgresql::globals::version: '9.3'
 
-puppet::master::puppetdb_version: '2.0.0-1puppetlabs1'
+puppet::puppetserver::puppetdb_version: '2.0.0-1puppetlabs1'
 
 puppet::monitoring::alert_hostname: 'alert'
 

--- a/modules/govuk/manifests/node/s_puppetmaster.pp
+++ b/modules/govuk/manifests/node/s_puppetmaster.pp
@@ -1,6 +1,11 @@
 # == Class: govuk::node::s_puppetmaster
 #
 class govuk::node::s_puppetmaster inherits govuk::node::s_base {
-  include puppet::master
   include govuk_postgresql::backup
+
+  if $::aws_migration {
+    include puppet::puppetserver
+  } else {
+    include puppet::master
+  }
 }

--- a/modules/govuk_puppetdb/manifests/config.pp
+++ b/modules/govuk_puppetdb/manifests/config.pp
@@ -22,7 +22,16 @@ class govuk_puppetdb::config {
   # config file in /etc/puppetdb/conf.d updated.
   exec { '/usr/sbin/puppetdb-ssl-setup':
     creates => $puppetdb_ssl_setup_creates,
-    require => Class['puppet::master::generate_cert'],
+  }
+
+  if $::aws_migration {
+    Exec['/usr/sbin/puppetdb-ssl-setup'] {
+      require => Class['puppet::puppetserver::generate_cert'],
+    }
+  } else {
+    Exec['/usr/sbin/puppetdb-ssl-setup'] {
+      require => Class['puppet::master::generate_cert'],
+    }
   }
 
   # Configure Puppetdb service:

--- a/modules/govuk_puppetdb/manifests/package.pp
+++ b/modules/govuk_puppetdb/manifests/package.pp
@@ -3,9 +3,23 @@ class govuk_puppetdb::package($package_ensure) {
 
   include puppet::repository
 
+  if $::aws_migration {
+    ensure_packages(['openjdk-7-jre-headless'])
+
+    Package['puppetdb'] {
+      require => [
+        Class['puppet::package'],
+        Package['openjdk-7-jre-headless'],
+      ]
+    }
+  } else {
+    Package['puppetdb'] {
+      require => Class['puppet::package'],
+    }
+  }
+
   package { 'puppetdb':
     ensure  => $package_ensure,
-    require => Class['puppet::package'],
   }
 
 }

--- a/modules/puppet/files/etc/puppet/certsigner.rb
+++ b/modules/puppet/files/etc/puppet/certsigner.rb
@@ -1,0 +1,72 @@
+#!/usr/bin/env ruby
+
+require 'etc'
+
+ENV['HOME'] = Etc.getpwuid(Process.uid).dir
+
+require 'puppet'
+require 'puppet/ssl/certificate_request'
+require 'aws-sdk-core'
+
+certname = ARGV.pop
+csr = Puppet::SSL::CertificateRequest.from_s(STDIN.read)
+
+# because we aren't loading all of puppet we don't have the full mappings
+# keeping it simple, just using their OID numbers
+# https://docs.puppetlabs.com/puppet/latest/reference/ssl_attributes_extensions.html#puppet-specific-registered-ids
+
+instance_id = csr.request_extensions.find { |a| a['oid'] == 'pp_instance_id' }['value']
+ami_id = csr.request_extensions.find { |a| a['oid'] == 'pp_image_name' }['value']
+aws_region = csr.request_extensions.find { |a| a['oid'] == '1.3.6.1.4.1.34380.1.1.18' }['value']
+
+returncode = 100
+
+ec2 = Aws::EC2::Client.new( region: aws_region )
+
+server = ec2.describe_instances({
+  instance_ids: [instance_id],
+  filters: [
+    {
+      name: 'instance-state-name',
+      values: ['running']
+    },
+  ],
+})
+
+tags = server.reservations[0].instances[0].tags
+image_id = server.reservations[0].instances[0].image_id
+
+# we are checking to see if this instance has already been signed
+signed = false
+tags.each do |tag|
+  if tag.key == 'puppet_cert_signed'
+    signed = true
+  end
+end
+
+# lets make sure we can get a positive match also, this assumes you are using
+# pp_image_name in csr_attributes.yaml
+if image_id == ami_id
+  ami_match = true
+else
+  ami_match = false
+end
+
+# the only time we can sign this cert is if this instance hasn't been given a signed
+# cert before and we match on the instance in AWS also
+if signed != true && ami_match == true
+  ec2.create_tags({
+    resources: [instance_id],
+    tags: [
+      {
+        key: 'puppet_cert_signed',
+        value: certname,
+      },
+    ],
+  })
+  returncode = 0
+else
+  returncode = 200
+end
+
+exit returncode

--- a/modules/puppet/manifests/puppetserver.pp
+++ b/modules/puppet/manifests/puppetserver.pp
@@ -1,0 +1,76 @@
+# == Class: puppet::puppetserver
+#
+# Install and configure a puppetserver.
+# Includes PuppetDB of a fixed version on the same host.
+#
+# === Parameters
+#
+# [*puppetdb_version*]
+#   Specify the version of puppetdb to be installed
+
+class puppet::puppetserver(
+  $puppetdb_version = '1.3.2-1puppetlabs1',
+) {
+  include puppet::repository
+
+  class { '::govuk_puppetdb':
+    package_ensure => $puppetdb_version,
+  }
+
+  anchor {'puppet::puppetserver::begin':
+    notify => Class['puppet::puppetserver::service'],
+  }
+  class{'puppet::puppetserver::package':
+    puppetdb_version => $puppetdb_version,
+    notify           => Class['puppet::puppetserver::service'],
+    require          => [
+      Class['puppet::package'],
+      Anchor['puppet::puppetserver::begin'],
+    ],
+  }
+  class{'puppet::puppetserver::config':
+    require => Class['puppet::puppetserver::package'],
+    notify  => Class['puppet::puppetserver::service'],
+  }
+  class { 'puppet::puppetserver::generate_cert':
+    require   => Class['puppet::puppetserver::config'],
+  }
+
+  class { 'puppet::puppetserver::firewall':
+    require => Class['puppet::puppetserver::config'],
+  }
+
+  class{'puppet::puppetserver::service':
+    subscribe => [
+      Class['puppet::package'],
+    ],
+    require   => Class['puppet::puppetserver::generate_cert'],
+  }
+
+  class { 'puppet::puppetserver::nginx':
+    require      => Class['puppet::puppetserver::generate_cert'],
+  }
+
+  file { '/etc/puppet/gpg':
+    ensure  => directory,
+    mode    => '0700',
+    recurse => true,
+    owner   => 'puppet',
+    group   => 'puppet',
+  }
+
+  anchor {'puppet::puppetserver::end':
+    subscribe =>  Class['puppet::puppetserver::service'],
+    require   =>  [
+                    Class['puppet::puppetserver::firewall'],
+                    Class['puppet::puppetserver::nginx'],
+                    File['/etc/puppet/gpg'],
+                  ],
+  }
+
+  cron::crondotdee { 'puppet_report_purge':
+    command => '/usr/bin/find /var/lib/puppet/reports/ -type f -mtime +1 -delete',
+    hour    => 6,
+    minute  => 45,
+  }
+}

--- a/modules/puppet/manifests/puppetserver/config.pp
+++ b/modules/puppet/manifests/puppetserver/config.pp
@@ -1,0 +1,47 @@
+# FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
+class puppet::puppetserver::config {
+
+  file {'/etc/puppet/puppetdb.conf':
+    content => template('puppet/etc/puppet/puppetdb.conf.erb'),
+  }
+  file {'/etc/puppet/routes.yaml':
+    source => 'puppet:///modules/puppet/etc/puppet/routes.yaml',
+  }
+  file { '/usr/local/bin/puppet_config_version':
+    ensure => present,
+    source => 'puppet:///modules/puppet/usr/local/bin/puppet_config_version',
+    mode   => '0755',
+  }
+  file { '/etc/puppet/certsigner.rb':
+    ensure => present,
+    source => 'puppet:///modules/puppet/etc/puppet/certsigner.rb',
+    mode   => '0755',
+  }
+
+  # Track checksums and reload `puppetmaster` service when they change. This
+  # is still pretty non-deterministic because it requires a `puppet agent`
+  # run on the master after deployment and then a wait for `unicornherder`
+  # to do its thing. Workarounds for the issues:
+
+  # https://tickets.puppetlabs.com/browse/PUP-1336
+  file { '/usr/share/puppet/production/current/hiera.yml':
+    ensure => undef,
+    owner  => undef,
+    group  => undef,
+    mode   => undef,
+    audit  => 'content',
+  }
+
+  # https://tickets.puppetlabs.com/browse/PUP-1033
+  file { [
+    '/var/lib/puppet/lib/puppet/type',
+    '/var/lib/puppet/lib/puppet/parser',
+    ]:
+    ensure  => undef,
+    owner   => undef,
+    group   => undef,
+    mode    => undef,
+    recurse => true,
+    audit   => 'content',
+  }
+}

--- a/modules/puppet/manifests/puppetserver/firewall.pp
+++ b/modules/puppet/manifests/puppetserver/firewall.pp
@@ -1,0 +1,6 @@
+# FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
+class puppet::puppetserver::firewall {
+  @ufw::allow { 'allow-puppetserver-from-all':
+    port => 8140,
+  }
+}

--- a/modules/puppet/manifests/puppetserver/generate_cert.pp
+++ b/modules/puppet/manifests/puppetserver/generate_cert.pp
@@ -1,0 +1,6 @@
+# FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
+class puppet::puppetserver::generate_cert {
+  exec { "/usr/bin/puppet cert generate ${::aws_instanceid}":
+    creates => "/etc/puppet/ssl/ca/signed/${::aws_instanceid}.pem",
+  }
+}

--- a/modules/puppet/manifests/puppetserver/nginx.pp
+++ b/modules/puppet/manifests/puppetserver/nginx.pp
@@ -1,0 +1,37 @@
+# == Class: puppet::puppetserver::nginx
+#
+# Install Nginx and set up configuration for a Puppetdb.
+#
+class puppet::puppetserver::nginx {
+  include ::nginx
+
+  nginx::config::site { 'puppetdb':
+    content => template('puppet/puppetdb-vhost.conf'),
+  }
+
+  $counter_basename = "${::fqdn_metrics}.nginx_logs.puppetdb"
+
+  nginx::log {
+    'puppetdb-json.event.access.log':
+      json          => true,
+      logstream     => present,
+      statsd_metric => "${counter_basename}.http_%{@fields.status}",
+      statsd_timers => [{metric => "${counter_basename}.time_request",
+                          value => '@fields.request_time'}];
+    'puppetdb-error.log':
+      logstream => present;
+  }
+
+  statsd::counter { "${counter_basename}.http_500": }
+
+  @@icinga::check::graphite { "check_nginx_5xx_puppetdb_on_${::hostname}":
+    target    => "transformNull(stats.${counter_basename}.http_5xx,0)",
+    warning   => 0.05,
+    critical  => 0.1,
+    from      => '3minutes',
+    desc      => 'puppetdb nginx high 5xx rate',
+    host_name => $::fqdn,
+    notes_url => monitoring_docs_url(nginx-5xx-rate-too-high-for-many-apps-boxes),
+  }
+
+}

--- a/modules/puppet/manifests/puppetserver/package.pp
+++ b/modules/puppet/manifests/puppetserver/package.pp
@@ -1,0 +1,64 @@
+# == Class: puppet::puppetserver::package
+#
+# Install packages for a Puppetserver.
+#
+# === Parameters
+#
+# [*puppetdb_version*]
+#   Specify the version of puppetdb-terminus to install which should match
+#   the puppetdb installation. Passed in by parent class.
+#
+# [*puppet_sentry_dsn*]
+#   This is the DSN to send puppet reports to.
+#
+class puppet::puppetserver::package(
+  $puppetdb_version = 'present',
+  $puppet_sentry_dsn = undef,
+) {
+  include ::puppet
+
+  ensure_packages(['openjdk-7-jre-headless'])
+
+  package { 'puppetserver':
+    ensure  => installed,
+    require => Package['openjdk-7-jre-headless'],
+  }
+
+  package { 'aws-sdk-core':
+    provider => system_gem,
+  }
+
+  # These gems are installed during the bootstrap, but puppetserver needs
+  # gems in the jruby path
+  package { ['hiera-eyaml-gpg', 'gpgme']:
+    ensure   => absent,
+    provider => system_gem,
+  }
+
+  package { 'puppetdb-terminus':
+    ensure  => $puppetdb_version,
+  }
+
+  exec { '/usr/bin/puppetserver gem install hiera-eyaml-gpg':
+    unless  => '/usr/bin/puppetserver gem list | /bin/grep hiera-eyaml-gpg',
+    require => Package['puppetserver'],
+  }
+
+  exec { '/usr/bin/puppetserver gem install ruby_gpg':
+    unless  => '/usr/bin/puppetserver gem list | /bin/grep ruby_gpg',
+    require => Package['puppetserver'],
+  }
+
+  exec { '/usr/bin/puppetserver gem install sentry-raven':
+    unless  => '/usr/bin/puppetserver gem list | /bin/grep sentry-raven',
+    require => Package['puppetserver'],
+  }
+
+  file_line { 'puppetserver_config_sentry':
+    ensure  => present,
+    path    => '/etc/default/puppetserver',
+    line    => inline_template("PUPPET_SENTRY_DSN=${puppet_sentry_dsn}\n"),
+    match   => '^PUPPET_SENTRY_DSN=',
+    require => Package['puppetserver'],
+  }
+}

--- a/modules/puppet/manifests/puppetserver/service.pp
+++ b/modules/puppet/manifests/puppetserver/service.pp
@@ -1,0 +1,6 @@
+# FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
+class puppet::puppetserver::service {
+  service { 'puppetserver':
+    ensure   => running,
+  }
+}

--- a/modules/puppet/spec/classes/puppet__puppetserver__package_spec.rb
+++ b/modules/puppet/spec/classes/puppet__puppetserver__package_spec.rb
@@ -1,0 +1,11 @@
+require_relative '../../../../spec_helper'
+
+describe 'puppet::puppetserver::package', :type => :class do
+  let(:params) {{
+    :puppetdb_version => '2.3.4',
+  }}
+
+  it { is_expected.to contain_package('puppetserver') }
+  it { is_expected.to contain_package('puppetdb-terminus').with_ensure('2.3.4') }
+end
+

--- a/modules/puppet/spec/classes/puppet__puppetserver_spec.rb
+++ b/modules/puppet/spec/classes/puppet__puppetserver_spec.rb
@@ -1,0 +1,22 @@
+require_relative '../../../../spec_helper'
+
+describe 'puppet::puppetserver', :type => :class do
+  # concat_basedir needed for puppetdb module (for postgresql)
+  let(:facts) {{
+    :concat_basedir => '/var/lib/puppet/concat/',
+    :id             => 'root',
+    :path           => 'concatted_file',
+  }}
+
+  it do
+    is_expected.to contain_service('puppetserver').with_ensure('running')
+  end
+
+  it { is_expected.to contain_class('govuk_puppetdb') }
+  it { is_expected.to contain_class('puppet::puppetserver::nginx') }
+
+  it do
+    is_expected.to contain_class('puppet')
+    is_expected.to contain_class('puppet::puppetserver::config')
+  end
+end

--- a/modules/puppet/templates/etc/puppet/puppet.conf.erb
+++ b/modules/puppet/templates/etc/puppet/puppet.conf.erb
@@ -12,6 +12,9 @@ parser = future
 stringify_facts = false
 strict_variables = true
 <%- end -%>
+<%- if scope.lookupvar('::aws_migration') %>
+ssldir = /etc/puppet/ssl
+<%- end -%>
 
 [master]
 reports = store,sentry
@@ -26,7 +29,13 @@ hiera_config = /usr/share/puppet/production/current/hiera.yml
 <%- if @use_puppetmaster == true -%>
 environmentpath = /usr/share/puppet/production/current/environments
 <%- end -%>
+<%- if scope.lookupvar('::aws_migration') %>
+autosign = /etc/puppet/certsigner.rb
+<%- end -%>
 
 [agent]
 report = true
 configtimeout = 600
+<%- if scope.lookupvar('::aws_migration') and scope.lookupvar('::aws_instanceid') %>
+certname = <%= scope.lookupvar('::aws_instanceid') %>
+<%- end -%>

--- a/modules/puppet/templates/puppetdb-vhost.conf
+++ b/modules/puppet/templates/puppetdb-vhost.conf
@@ -1,0 +1,13 @@
+upstream puppetmaster_puppetdb {
+    server localhost:8080;
+}
+
+server {
+    listen 80;
+    server_name puppetdb puppetdb.cluster;
+    location / {
+        proxy_pass http://puppetmaster_puppetdb;
+        proxy_redirect off;
+    }
+}
+


### PR DESCRIPTION
On AWS we are going to run the puppet master service from puppetserver
instead of Nginx + Unicorn, to help the transition to Puppet 4 and
support certificate extensions for node classification.

This requires a new puppetserver manifest and some adjustments to
install Openjdk and remove conflicting gems that are installed during
the Puppet master bootstrap. Nginx is still installed to enable access to
Puppetdb, but we should review this.