### PR TITLE
Add MapIt to collectd process monitoring

### DIFF
--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -193,10 +193,11 @@ define govuk::app::config (
   $title_underscore = regsubst($title, '\.', '_', 'G')
 
   # Set up monitoring
-  if $app_type in ['rack', 'bare'] {
+  if $app_type in ['rack', 'bare', 'procfile'] {
     $collectd_process_regex = $app_type ? {
       'rack' => "unicorn (master|worker\\[[0-9]+\\]).* -P ${govuk_app_run}/app\\.pid",
       'bare' => inline_template('<%= "^" + Regexp.escape(@command) + "$" -%>'),
+      'procfile' => "gunicorn .* ${govuk_app_run}/app\\.pid",
     }
     collectd::plugin::process { "app-${title_underscore}":
       ensure => $ensure,


### PR DESCRIPTION
MapIt is a procfile app but uses gunicorn. We don't have monitoring on its app
processes at the moment.

We have other procfile apps, but I'm not really worried about them at the
moment.  (They seem to be mostly licensing)

We have other gunicorn apps (specifically performance platform), but they appear
to be set up as `bare` apps rather than `procfile` ones.

A MapIt process looks like this:
`data/apps/mapit/shared/venv/bin/python ./venv/bin/gunicorn -D -p /var/run/mapit/app.pid project.wsgi:application --bind 127.0.0.1:3108 --workers 8`

There appears to be no difference between the master/worker process commands
for gunicorn (unlike the typical unicorn process).  

This config would pick up other gunicorn procfile processes should any arise.