### PR TITLE
Rename rake task to import:all_content_items in CPM

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -104,7 +104,7 @@ govuk_jenkins::job::network_config_deploy::environments:
   - 'carrenza-production-dr'
   - 'skyscape-production'
 
-govuk_jenkins::job::content_performance_manager::rake_import_all_inventory_frequency: '0 2 * * *'
+govuk_jenkins::job::content_performance_manager::rake_import_all_content_items_frequency: '0 2 * * *'
 govuk_jenkins::job::content_performance_manager::rake_import_all_ga_metrics_frequency: '0 7 * * *'
 
 govuk_jenkins::job::signon_cron_rake_tasks::configure_jobs: true

--- a/modules/govuk_jenkins/manifests/job/content_performance_manager.pp
+++ b/modules/govuk_jenkins/manifests/job/content_performance_manager.pp
@@ -1,20 +1,20 @@
 # == Class: govuk_jenkins::job::content_performance_manager
 #
 # Create a jenkins job to periodically run rake for the following tasks:
-# - import:all_inventory
+# - import:all_content_items
 #
 # === Parameters:
 #
-# [*rake_import_all_inventory_frequency *]
-#   The cron timings for the import:all_inventory rake task
+# [*rake_import_all_content_items_frequency *]
+#   The cron timings for the import:all_content_items rake task
 #   Default: undef
 #
 # [*rake_import_all_ga_metrics_frequency *]
-#   The cron timings for the import:all_inventory rake task
+#   The cron timings for the import:all_content_items rake task
 #   Default: undef
 #
 class govuk_jenkins::job::content_performance_manager (
-  $rake_import_all_inventory_frequency = undef,
+  $rake_import_all_content_items_frequency = undef,
   $rake_import_all_ga_metrics_frequency = undef,
 ) {
   file { '/etc/jenkins_jobs/jobs/content_performance_manager.yaml':

--- a/modules/govuk_jenkins/templates/jobs/content_performance_manager.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/content_performance_manager.yaml.erb
@@ -1,20 +1,20 @@
 ---
 - job:
-    name: content_performance_manager_import_all_inventory
+    name: content_performance_manager_import_all_content_items
     display-name: Content Performance Manager - import inventory
     project-type: freestyle
-    description: "<p>Run the import:all_inventory rake task.</p>"
+    description: "<p>Run the import:all_content_items rake task.</p>"
     builders:
-      - shell: ssh deploy@$(govuk_node_list -c backend --single-node) "cd /var/apps/content-performance-manager && govuk_setenv content-performance-manager bundle exec rake import:all_inventory"
+      - shell: ssh deploy@$(govuk_node_list -c backend --single-node) "cd /var/apps/content-performance-manager && govuk_setenv content-performance-manager bundle exec rake import:all_content_items"
     wrappers:
       - ansicolor:
           colormap: xterm
     publishers:
       - email:
           recipients: govuk-ci-notifications@digital.cabinet-office.gov.uk
-  <% if @rake_import_all_inventory_frequency %>
+  <% if @rake_import_all_content_items_frequency %>
     triggers:
-      - timed: <%= @rake_import_all_inventory_frequency %>
+      - timed: <%= @rake_import_all_content_items_frequency %>
   <% end %>
     logrotate:
         numToKeep: 10


### PR DESCRIPTION
We no longer use the name `all_inventory` to load all the content items
from PublishingAPI. We prefer the name `all_content_items` as it 
clearly describe what it does.