### PR TITLE
Show Jenkins CPM jobs in Staging

### DIFF
--- a/hieradata/class/staging/jenkins.yaml
+++ b/hieradata/class/staging/jenkins.yaml
@@ -1,6 +1,7 @@
 ---
 govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::check_content_consistency
+  - govuk_jenkins::job::content_performance_manager
   - govuk_jenkins::job::data_sync_complete_staging
   - govuk_jenkins::job::deploy_app
   - govuk_jenkins::job::deploy_cdn


### PR DESCRIPTION
Jobs are currently displayed in Production and Integration. 
We also need them to be listed in staging so we can properly
 tests the updates to our processes.