### PR TITLE
Set deny_framing to false for content-tagger

### DIFF
--- a/modules/govuk/manifests/apps/content_tagger.pp
+++ b/modules/govuk/manifests/apps/content_tagger.pp
@@ -76,7 +76,7 @@ class govuk::apps::content_tagger(
     health_check_path  => '/healthcheck',
     log_format_is_json => true,
     asset_pipeline     => true,
-    deny_framing       => true,
+    deny_framing       => false,
     sentry_dsn         => $sentry_dsn,
   }
 


### PR DESCRIPTION
Content Tagger contains a proxy for easily viewing GOV.UK content in
an <iframe> when tagging it, but setting X-Frame-Options to DENY
prevents this from working.