### PR TITLE
Setup a local proxy for the ES 2.4 instance on rummager boxes

### DIFF
--- a/hieradata/class/search.yaml
+++ b/hieradata/class/search.yaml
@@ -5,6 +5,11 @@ govuk_elasticsearch::local_proxy::servers:
   - 'api-elasticsearch-2.api'
   - 'api-elasticsearch-3.api'
 
+govuk_elasticsearch::rummager_local_proxy::servers:
+  - 'rummager-elasticsearch-1.api'
+  - 'rummager-elasticsearch-2.api'
+  - 'rummager-elasticsearch-3.api'
+
 govuk::node::s_base::apps:
   - rummager
 

--- a/modules/govuk/manifests/node/s_search.pp
+++ b/modules/govuk/manifests/node/s_search.pp
@@ -13,5 +13,6 @@ class govuk::node::s_search inherits govuk::node::s_base {
   # Local proxy for Rummager to access ES cluster.
   if ! $::aws_migration {
     include govuk_elasticsearch::local_proxy
+    include govuk_elasticsearch::rummager_local_proxy
   }
 }

--- a/modules/govuk_elasticsearch/manifests/local_proxy.pp
+++ b/modules/govuk_elasticsearch/manifests/local_proxy.pp
@@ -27,7 +27,7 @@
 class govuk_elasticsearch::local_proxy(
   $read_timeout = 60,
   $port = 9200,
-  $servers
+  $servers,
 ) {
   # Also used within template.
   $vhost      = 'elasticsearch-local-proxy'

--- a/modules/govuk_elasticsearch/manifests/rummager_local_proxy.pp
+++ b/modules/govuk_elasticsearch/manifests/rummager_local_proxy.pp
@@ -1,0 +1,45 @@
+# == Class: govuk_elasticsearch::rummager_local_proxy
+#
+# This is a direct copy of the govuk_elasticsearch::local_proxy
+# class and has been added here to support the migration to
+# Elasticsearch 2.4. The only difference being the proxy port
+# which has been changed to 19200.
+#
+# This class should be removed once we are fully migrated.
+#
+# === Parameters:
+#
+# [*port*]
+#   Port to bind on loopback and of the remote Elasticsearch servers.
+#   Default: 19200
+#
+# [*read_timeout*]
+#   Nginx `proxy_read_timeout` value.
+#   Default: 60
+#
+# [*servers*]
+#   Array of servers to load balance requests to.
+#
+class govuk_elasticsearch::rummager_local_proxy(
+  $read_timeout = 60,
+  $port = 19200,
+  $servers,
+) {
+  # Also used within template.
+  $vhost      = 'rummager-elasticsearch-local-proxy'
+  $log_json   = "${vhost}-json.event.access.log"
+  $log_access = "${vhost}-access.log"
+  $log_error  = "${vhost}-error.log"
+
+  nginx::config::site { $vhost:
+    content => template('govuk_elasticsearch/nginx_local_proxy.conf.erb'),
+  }
+
+  nginx::log {
+    $log_json:
+      json      => true,
+      logstream => present;
+    $log_error:
+      logstream => present;
+  }
+}


### PR DESCRIPTION
This is a temporary implementation while we are migrating.  Once the migration
is completed we should update port 9200 to point to the new cluster, we can
then revert the change in rummager so that it connects oin port 9200 again.

Once this is complete we can delete the proxy on 19200

https://trello.com/c/Ew3bOzy5/229-setup-rummager-to-work-with-es-24-on-integration