### PR TITLE
Update plugins

### DIFF
--- a/hieradata/class/ci_master.yaml
+++ b/hieradata/class/ci_master.yaml
@@ -77,69 +77,69 @@ govuk_jenkins::plugins:
     ace-editor:
       version: "1.1"
     analysis-core:
-      version: "1.86"
+      version: "1.92"
     ansicolor:
-      version: "0.5.0"
+      version: "0.5.1"
     antisamy-markup-formatter:
       version: "1.5"
     authentication-tokens:
       version: "1.3"
     bouncycastle-api:
-      version: "2.16.1"
+      version: "2.16.2"
     brakeman:
-      version: "0.11"
+      version: "0.12"
     branch-api:
-      version: "2.0.9"
+      version: "2.0.11"
     build-name-setter:
-      version: "1.6.5"
+      version: "1.6.7"
     build-pipeline-plugin:
-      version: "1.5.6"
+      version: "1.5.7.1"
     cloudbees-folder:
-      version: "6.0.4"
+      version: "6.1.2"
     cobertura:
-      version: "1.10"
+      version: "1.11"
     conditional-buildstep:
-      version: "1.3.5"
+      version: "1.3.6"
     copyartifact:
       version: "1.38.1"
     credentials-binding:
-      version: "1.11"
+      version: "1.13"
     description-setter:
       version: "1.10"
     display-url-api:
       version: "2.0"
     docker-commons:
-      version: "1.6"
+      version: "1.8"
     docker-workflow:
-      version: "1.10"
+      version: "1.12"
     durable-task:
-      version: "1.13"
+      version: "1.14"
     envinject:
-      version: "2.0"
+      version: "2.1.3"
     findbugs:
-      version: "4.70"
+      version: "4.71"
     git-client:
-      version: "2.4.5"
+      version: "2.5.0"
     git:
-      version: "3.3.0"
+      version: "3.5.1"
     github-api:
-      version: "1.85"
+      version: "1.86"
     github-branch-source:
-      version: "2.0.5"
+      version: "2.2.3"
     github:
-      version: "1.27.0"
+      version: "1.28.0"
     github-oauth:
       version: "0.27"
     git-server:
       version: "1.7"
     gradle:
-      version: "1.26"
+      version: "1.27.1"
     greenballs:
       version: "1.15"
     handlebars:
       version: "1.1.1"
     htmlpublisher:
-      version: "1.13"
+      version: "1.14"
     icon-shim:
       version: "2.0.3"
     javadoc:
@@ -151,7 +151,7 @@ govuk_jenkins::plugins:
     jquery:
       version: "1.11.2-0"
     junit:
-      version: "1.20"
+      version: "1.21"
     lockable-resources:
       version: "2.0"
     mailer:
@@ -159,45 +159,45 @@ govuk_jenkins::plugins:
     mapdb-api:
       version: "1.0.9.0"
     matrix-auth:
-      version: "1.5"
+      version: "1.7"
     matrix-project:
-      version: "1.10"
+      version: "1.11"
     maven-plugin:
-      version: "2.15.1"
+      version: "2.17"
     momentjs:
       version: "1.1.1"
     monitoring:
-      version: "1.65.1"
+      version: "1.68.1"
     next-build-number:
       version: "1.4"
     nodelabelparameter:
       version: "1.7.2"
     parameterized-trigger:
-      version: "2.33"
+      version: "2.35.1"
     pipeline-build-step:
-      version: "2.5"
+      version: "2.5.1"
     pipeline-graph-analysis:
-      version: "1.3"
+      version: "1.5"
     pipeline-input-step:
-      version: "2.7"
+      version: "2.8"
     pipeline-milestone-step:
       version: "1.3.1"
     pipeline-model-api:
-      version: "1.1.4"
+      version: "1.1.9"
     pipeline-model-declarative-agent:
       version: "1.1.1"
     pipeline-model-definition:
       version: "1.1.4"
     pipeline-model-extensions:
-      version: "1.1.4"
+      version: "1.1.9"
     pipeline-rest-api:
-      version: "2.6"
+      version: "2.8"
     pipeline-stage-step:
       version: "2.2"
     pipeline-stage-tags-metadata:
-      version: "1.1.4"
+      version: "1.1.9"
     pipeline-stage-view:
-      version: "2.6"
+      version: "2.8"
     plain-credentials:
       version: "1.4"
     rake:
@@ -205,9 +205,9 @@ govuk_jenkins::plugins:
     rebuild:
       version: "1.25"
     resource-disposer:
-      version: "0.6"
+      version: "0.7"
     role-strategy:
-      version: "2.4.0"
+      version: "2.5.1"
     ruby:
       version: "1.2"
     rubyMetrics:
@@ -217,9 +217,9 @@ govuk_jenkins::plugins:
     saferestart:
       version: "0.3"
     scm-api:
-      version: "2.1.1"
+      version: "2.2.0"
     script-security:
-      version: "1.27"
+      version: "1.31"
     sitemonitor:
       version: "0.5"
     slack:
@@ -229,15 +229,15 @@ govuk_jenkins::plugins:
     ssh-credentials:
       version: "1.13"
     ssh-slaves:
-      version: "1.17"
+      version: "1.20"
     structs:
-      version: "1.6"
+      version: "1.10"
     swarm:
       version: "3.4"
     text-finder:
       version: "1.10"
     throttle-concurrents:
-      version: "1.9.0"
+      version: "2.0.1"
     token-macro:
       version: "2.1"
     versionnumber:
@@ -245,32 +245,32 @@ govuk_jenkins::plugins:
     violations:
       version: "0.7.11"
     warnings:
-      version: "4.62"
+      version: "4.63"
     windows-slaves:
       version: "1.3.1"
     workflow-aggregator:
       version: "2.5"
     workflow-api:
-      version: "2.13"
+      version: "2.20"
     workflow-basic-steps:
-      version: "2.4"
+      version: "2.6"
     workflow-cps-global-lib:
       version: "2.8"
     workflow-cps:
-      version: "2.30"
+      version: "2.39"
     workflow-durable-task-step:
-      version: "2.11"
+      version: "2.13"
     workflow-job:
-      version: "2.10"
+      version: "2.11.2"
     workflow-multibranch:
-      version: "2.14"
+      version: "2.16"
     workflow-scm-step:
-      version: "2.4"
+      version: "2.5"
     workflow-step-api:
-      version: "2.9"
+      version: "2.12"
     workflow-support:
       version: "2.14"
     ws-cleanup:
-      version: "0.33"
+      version: "0.34"
 
 icinga::client::check_cputype::cputype: 'intel'

--- a/hieradata/class/jenkins.yaml
+++ b/hieradata/class/jenkins.yaml
@@ -40,15 +40,15 @@ govuk_jenkins::plugins:
   ace-editor:
     version: '1.1'
   ansicolor:
-    version: '0.5.0'
+    version: '0.5.1'
   ant:
-    version: '1.5'
+    version: '1.6'
   antisamy-markup-formatter:
     version: '1.5'
   bouncycastle-api:
-    version: '2.16.1'
+    version: '2.16.2'
   branch-api:
-    version: '2.0.10'
+    version: '2.0.11'
   build-name-setter:
     version: '1.6.7'
   build-pipeline-plugin:
@@ -56,13 +56,13 @@ govuk_jenkins::plugins:
   build-with-parameters:
     version: '1.4'
   cloudbees-folder:
-    version: '6.0.4'
+    version: '6.1.2'
   conditional-buildstep:
     version: '1.3.6'
   copyartifact:
     version: '1.38.1'
   credentials-binding:
-    version: '1.12'
+    version: '1.13'
   cvs:
     version: '2.13'
   description-setter:
@@ -80,15 +80,15 @@ govuk_jenkins::plugins:
   external-monitor-job:
     version: '1.7'
   git-client:
-    version: '2.4.6'
+    version: '2.5.0'
   git:
-    version: '3.3.2'
+    version: '3.5.1'
   github-api:
     version: '1.86'
   github-branch-source:
-    version: '2.0.8'
+    version: '2.2.3'
   github:
-    version: '1.27.0'
+    version: '1.28.0'
   github-oauth:
     version: '0.27'
   google-oauth-plugin:
@@ -114,7 +114,7 @@ govuk_jenkins::plugins:
   jquery:
     version: '1.11.2-0'
   junit:
-    version: '1.20'
+    version: '1.21'
   ldap:
     version: '1.16'
   mailer:
@@ -134,7 +134,7 @@ govuk_jenkins::plugins:
   pam-auth:
     version: '1.3'
   parameterized-scheduler:
-    version: '0.4'
+    version: '0.5'
   parameterized-trigger:
     version: '2.35.1'
   plain-credentials:
@@ -144,7 +144,7 @@ govuk_jenkins::plugins:
   rebuild:
     version: '1.25'
   resource-disposer:
-    version: '0.6'
+    version: '0.7'
   role-strategy:
     version: '2.5.1'
   run-condition:
@@ -152,23 +152,23 @@ govuk_jenkins::plugins:
   sbt:
     version: '1.5'
   scm-api:
-    version: '2.1.1'
+    version: '2.2.0'
   scm-sync-configuration:
     version: '0.0.10'
   script-security:
-    version: '1.29.1'
+    version: '1.31'
   show-build-parameters:
     version: '1.0'
   simple-theme-plugin:
     version: '0.3'
   slack:
-    version: '1.7'
+    version: '2.2'
   ssh-credentials:
     version: '1.13'
   ssh-slaves:
     version: '1.20'
   structs:
-    version: '1.9'
+    version: '1.10'
   subversion:
     version: '2.9'
   text-finder:
@@ -184,20 +184,20 @@ govuk_jenkins::plugins:
   windows-slaves:
     version: '1.3.1'
   workflow-api:
-    version: '2.18'
+    version: '2.20'
   workflow-cps:
-    version: '2.36.1'
+    version: '2.39'
   workflow-durable-task-step:
-    version: '2.12'
+    version: '2.13'
   workflow-job:
-    version: '2.11.1'
+    version: '2.11.2'
   workflow-multibranch:
     version: '2.16'
   workflow-scm-step:
-    version: '2.5'
+    version: '2.12'
   workflow-step-api:
     version: '2.12'
   workflow-support:
     version: '2.14'
   ws-cleanup:
-    version: '0.33'
+    version: '0.34'

--- a/hieradata_aws/class/jenkins.yaml
+++ b/hieradata_aws/class/jenkins.yaml
@@ -51,15 +51,15 @@ govuk_jenkins::plugins:
   ace-editor:
     version: '1.1'
   ansicolor:
-    version: '0.5.0'
+    version: '0.5.1'
   ant:
-    version: '1.5'
+    version: '1.6'
   antisamy-markup-formatter:
     version: '1.5'
   bouncycastle-api:
-    version: '2.16.1'
+    version: '2.16.2'
   branch-api:
-    version: '2.0.10'
+    version: '2.0.11'
   build-name-setter:
     version: '1.6.7'
   build-pipeline-plugin:
@@ -67,13 +67,13 @@ govuk_jenkins::plugins:
   build-with-parameters:
     version: '1.4'
   cloudbees-folder:
-    version: '6.0.4'
+    version: '6.1.2'
   conditional-buildstep:
     version: '1.3.6'
   copyartifact:
     version: '1.38.1'
   credentials-binding:
-    version: '1.12'
+    version: '1.13'
   cvs:
     version: '2.13'
   description-setter:
@@ -91,15 +91,15 @@ govuk_jenkins::plugins:
   external-monitor-job:
     version: '1.7'
   git-client:
-    version: '2.4.6'
+    version: '2.5.0'
   git:
-    version: '3.3.2'
+    version: '3.5.1'
   github-api:
     version: '1.86'
   github-branch-source:
-    version: '2.0.8'
+    version: '2.2.3'
   github:
-    version: '1.27.0'
+    version: '1.28.0'
   github-oauth:
     version: '0.27'
   google-oauth-plugin:
@@ -125,7 +125,7 @@ govuk_jenkins::plugins:
   jquery:
     version: '1.11.2-0'
   junit:
-    version: '1.20'
+    version: '1.21'
   ldap:
     version: '1.16'
   mailer:
@@ -145,7 +145,7 @@ govuk_jenkins::plugins:
   pam-auth:
     version: '1.3'
   parameterized-scheduler:
-    version: '0.4'
+    version: '0.5'
   parameterized-trigger:
     version: '2.35.1'
   plain-credentials:
@@ -155,7 +155,7 @@ govuk_jenkins::plugins:
   rebuild:
     version: '1.25'
   resource-disposer:
-    version: '0.6'
+    version: '0.7'
   role-strategy:
     version: '2.5.1'
   run-condition:
@@ -163,23 +163,23 @@ govuk_jenkins::plugins:
   sbt:
     version: '1.5'
   scm-api:
-    version: '2.1.1'
+    version: '2.2.0'
   scm-sync-configuration:
     version: '0.0.10'
   script-security:
-    version: '1.29.1'
+    version: '1.31'
   show-build-parameters:
     version: '1.0'
   simple-theme-plugin:
     version: '0.3'
   slack:
-    version: '1.7'
+    version: '2.2'
   ssh-credentials:
     version: '1.13'
   ssh-slaves:
     version: '1.20'
   structs:
-    version: '1.9'
+    version: '1.10'
   subversion:
     version: '2.9'
   text-finder:
@@ -195,20 +195,20 @@ govuk_jenkins::plugins:
   windows-slaves:
     version: '1.3.1'
   workflow-api:
-    version: '2.18'
+    version: '2.20'
   workflow-cps:
-    version: '2.36.1'
+    version: '2.39'
   workflow-durable-task-step:
-    version: '2.12'
+    version: '2.13'
   workflow-job:
-    version: '2.11.1'
+    version: '2.11.2'
   workflow-multibranch:
     version: '2.16'
   workflow-scm-step:
-    version: '2.5'
+    version: '2.12'
   workflow-step-api:
     version: '2.12'
   workflow-support:
     version: '2.14'
   ws-cleanup:
-    version: '0.33'
+    version: '0.34'


### PR DESCRIPTION
This updates the plugins for CI & deploy to the latest versions.

It should be deployed alongside [this PR on govuk-secrets](https://github.com/alphagov/govuk-secrets/pull/21) which fixes a problem caused by the upgrade and the use of the `$PATH` environment variable in Jenkins' PATH