### PR TITLE
Create compressed archives of Graphite data to backup.

### DIFF
--- a/hieradata/class/backup.yaml
+++ b/hieradata/class/backup.yaml
@@ -44,7 +44,7 @@ govuk::node::s_backup::directories:
     fq_dn: transition-postgresql-master-1.backend.%{hiera('app_domain')}
     priority: '001'
   backup_graphite_storage_whisper_graphite-1:
-    directory: /opt/graphite/storage/whisper
+    directory: /opt/graphite/storage/backups
     fq_dn: graphite-1.management.%{hiera('app_domain')}
     priority: '004'
   processed_cdn_logs:

--- a/modules/govuk/files/usr/local/bin/govuk_backup_graphite_whisper_files
+++ b/modules/govuk/files/usr/local/bin/govuk_backup_graphite_whisper_files
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+TIMESTAMP=`date +%Y-%m-%d_%Hh%Mm.%A`
+
+GRAPHITE_STORAGE_DIRECTORY="/opt/graphite/storage"
+GRAPHITE_WHISPER_DIRECTORY_NAME="whisper"
+
+GRAPHITE_WHISPER_DIRECTORY="${GRAPHITE_STORAGE_DIRECTORY}/${GRAPHITE_WHISPER_DIRECTORY_NAME}"
+
+BACKUP_DIRECTORY_NAME="backups"
+
+BACKUP_DIRECTORY=${GRAPHITE_STORAGE_DIRECTORY}/${BACKUP_DIRECTORY_NAME}
+
+BACKUP_FILE_ROOT_NAME=${GRAPHITE_WHISPER_DIRECTORY_NAME}
+BACKUP_FILE_NAME="${BACKUP_FILE_ROOT_NAME}-${TIMESTAMP}.tgz"
+
+
+TAR_COMMAND="ionice -c 3 nice tar"
+
+# Create the backup directory if it's not there but only if the storage directory exists
+if [ -d ${GRAPHITE_STORAGE_DIRECTORY} ]
+then
+  mkdir -p ${BACKUP_DIRECTORY}
+else
+  echo "Can't create backup directory"
+  exit 1
+fi
+
+# Remove any backups older than 7 days
+find ${BACKUP_DIRECTORY} -type f -name "*.tar.gz" -mtime +7 | xargs -xi rm {}
+
+# Backup Whisper files
+${TAR_COMMAND} -acf ${BACKUP_DIRECTORY}/${BACKUP_FILE_NAME} ${GRAPHITE_WHISPER_DIRECTORY}

--- a/modules/govuk/manifests/node/s_graphite.pp
+++ b/modules/govuk/manifests/node/s_graphite.pp
@@ -87,6 +87,27 @@ class govuk::node::s_graphite (
     extra_config => $cors_headers,
   }
 
+  ## Make compressed archives of Whisper data to backup off-box rather than
+  ## backing up the raw files
+  file { '/usr/local/bin/govuk_backup_graphite_whisper_files':
+    ensure => present,
+    source => 'puppet:///modules/govuk/usr/local/bin/govuk_backup_graphite_whisper_files',
+    mode   => '0755',
+  }
+
+  file { '/opt/graphite/storage/backups':
+    ensure => 'directory',
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0770',
+  }
+
+  cron::crondotdee { 'create_compressed_archive_of_whisper_data':
+    command => '/usr/local/bin/govuk_backup_graphite_whisper_files',
+    hour    => 23,
+    minute  => 45,
+  }
+
   if ! $::aws_migration {
     include collectd::server
   }


### PR DESCRIPTION
Currently, the backups of graphite-1 to backup-1 and then to s3 are of the raw Whisper data files. This will create daily compressed archives on graphite-1 and backup-1 will back those up instead which should save a lot of space on backup-1 and in s3.