### PR TITLE
Run router as container in AWS

### DIFF
--- a/hieradata_aws/class/cache.yaml
+++ b/hieradata_aws/class/cache.yaml
@@ -1,0 +1,5 @@
+---
+govuk::apps::authenticating_proxy::mongodb_nodes:
+  - 'router-backend-1'
+  - 'router-backend-2'
+  - 'router-backend-3'

--- a/hieradata_aws/class/draft_cache.yaml
+++ b/hieradata_aws/class/draft_cache.yaml
@@ -1,0 +1,24 @@
+---
+
+govuk::apps::authenticating_proxy::mongodb_nodes:
+  - 'router-backend-1'
+  - 'router-backend-2'
+  - 'router-backend-3'
+
+govuk::apps::router_api::mongodb_name: 'draft_router'
+govuk::apps::router_api::mongodb_nodes:
+  - 'router-backend-1'
+  - 'router-backend-2'
+  - 'router-backend-3'
+govuk::apps::router_api::router_nodes:
+  - 'draft-cache-1:3055'
+  - 'draft-cache-2:3055'
+govuk::apps::router_api::vhost: 'draft-router-api'
+
+govuk::node::s_base::apps:
+  - router_api
+
+govuk::node::s_cache::enable_authenticating_proxy: true
+
+router::nginx::check_requests_warning: '@0'
+router::nginx::check_requests_critical: '@0'

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -719,6 +719,14 @@ govuk_containers::apps::release::envvars:
   - "DATABASE_URL=mysql2://%{hiera('govuk::apps::release::db_username')}:%{hiera('govuk::apps::release::db_password')}@%{hiera('govuk::apps::release::db_hostname')}/release_production"
   - "RAILS_SERVE_STATIC_FILES=true"
 
+govuk_containers::apps::router::envvars:
+  - "ROUTER_PUBADDR=localhost:3054"
+  - "ROUTER_APIADDR=:3055"
+  - "ROUTER_MONGO_DB=router"
+  - "ROUTER_MONGO_URL=router-backend-1,router-backend-2,router-backend-3"
+  - "ROUTER_ERROR_LOG=/var/log/router/errors.json.log"
+  - "ROUTER_BACKEND_HEADER_TIMEOUT=20s"
+
 govuk_containers::frontend::haproxy::backend_mappings:
   - "release.%{hiera('app_domain')}": "release"
 govuk_containers::frontend::haproxy::wildcard_publishing_certificate: "%{hiera('wildcard_publishing_certificate')}"

--- a/modules/govuk/manifests/node/s_cache.pp
+++ b/modules/govuk/manifests/node/s_cache.pp
@@ -40,6 +40,10 @@ class govuk::node::s_cache (
   include govuk_htpasswd
   include router::gor
 
+  if $::aws_migration {
+    include ::govuk_containers::apps::router
+  }
+
   class { 'nginx':
     denied_ip_addresses     => $denied_ip_addresses,
     variables_hash_max_size => '768',

--- a/modules/govuk_containers/manifests/apps/router.pp
+++ b/modules/govuk_containers/manifests/apps/router.pp
@@ -1,0 +1,20 @@
+# == Class: Govuk_containers::Apps::Router
+#
+# Runs the router app.
+#
+class govuk_containers::apps::router (
+  $image = 'govuk/router',
+  $port = '3054',
+  $envvars = [],
+  $healthcheck_path = '/healthcheck',
+) {
+  validate_array($envvars)
+
+  govuk_containers::app { 'router':
+    image            => $image,
+    port             => $port,
+    envvars          => $envvars,
+    healthcheck_path => $healthcheck_path,
+  }
+
+}


### PR DESCRIPTION
Router is pretty integral to running the frontend apps. In AWS, we do not have access to our CI environment, so we need to make a bunch of changes to allow us to push artefacts to S3.

We already have router in docker hub and it gets pushed there automatically. There aren't too many changes and it actually removes a bit of code, so run router as a container in AWS.