### PR TITLE
Fix a shallow copy issue caused by a git plugin upgrade

### DIFF
--- a/modules/govuk_ci/templates/application_build_job.xml.erb
+++ b/modules/govuk_ci/templates/application_build_job.xml.erb
@@ -45,6 +45,15 @@
           <buildOriginPRHead>false</buildOriginPRHead>
           <buildForkPRMerge>false</buildForkPRMerge>
           <buildForkPRHead>false</buildForkPRHead>
+          <traits>
+            <jenkins.plugins.git.traits.RefSpecsSCMSourceTrait plugin="git@3.5.1">
+              <templates>
+                <jenkins.plugins.git.traits.RefSpecsSCMSourceTrait_-RefSpecTemplate>
+                  <value>+refs/heads/*:refs/remotes/@{remote}/*</value>
+                </jenkins.plugins.git.traits.RefSpecsSCMSourceTrait_-RefSpecTemplate>
+              </templates>
+            </jenkins.plugins.git.traits.RefSpecsSCMSourceTrait>
+          </traits>
         </source>
         <strategy class="jenkins.branch.DefaultBranchPropertyStrategy">
           <properties class="empty-list"/>


### PR DESCRIPTION
We upgraded some Jenkins plugins. This included
git. Many builds were failing because the default
behaviour changed to do shallow copies which don’t
include the master branch.

This fixes the template to add the ‘refspec’ build
option as recommended in the change log:

>Because each branch job in a multibranch project will only ever build the one specific branch, the default behaviour for a Git Branch Source is now to use a minimal refspec corresponding to just the required branch. Tags will not be checked out by default. If you have a multibranch project that requires the full set of ref-specs (for example, you might have a pipeline that will use some analysis tool on the diff with some other branch) you can restore the previous behaviour by adding the "Advanced Clone Behaviours". Note: In some cases you may also need to add the "Specify ref specs" behaviour.