### PR TITLE
Downgrade Git branch source plugin

### DIFF
--- a/hieradata/class/ci_master.yaml
+++ b/hieradata/class/ci_master.yaml
@@ -125,7 +125,7 @@ govuk_jenkins::plugins:
     github-api:
       version: "1.86"
     github-branch-source:
-      version: "2.2.3"
+      version: "2.0.5"
     github:
       version: "1.28.0"
     github-oauth:


### PR DESCRIPTION
Upgrading this broke things; webhooks weren't being received, and branches weren't being built.

Downgrading as a quick fix.

Ref: https://wiki.jenkins.io/display/JENKINS/GitHub+Branch+Source+Plugin