### PR TITLE
AWS add calculators_frontend Hieradata

### DIFF
--- a/hieradata_aws/class/calculators_frontend.yaml
+++ b/hieradata_aws/class/calculators_frontend.yaml
@@ -1,0 +1,8 @@
+---
+
+govuk::node::s_base::apps:
+  - calculators
+  - calendars
+  - finder_frontend
+  - licencefinder
+  - smartanswers


### PR DESCRIPTION
Add custom configuration for calculators_frontend on AWS to remove
disk configuration.