### PR TITLE
Remove error log output

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -735,7 +735,6 @@ govuk_containers::apps::router::envvars:
   - "ROUTER_APIADDR=:3055"
   - "ROUTER_MONGO_DB=router"
   - "ROUTER_MONGO_URL=router-backend-1,router-backend-2,router-backend-3"
-  - "ROUTER_ERROR_LOG=/var/log/router/errors.json.log"
   - "ROUTER_BACKEND_HEADER_TIMEOUT=20s"
 
 govuk_containers::frontend::haproxy::backend_mappings:


### PR DESCRIPTION
By default a container will log to syslog (as per our govuk_docker class). The env var in this case is related to inside the container, so remove. The default for the app is to error to STDERR.

If we want to take this to Production we may want to change this to go to a specific file.