### PR TITLE
Add publishing_api class to AWS

### DIFF
--- a/hieradata_aws/class/publishing_api.yaml
+++ b/hieradata_aws/class/publishing_api.yaml
@@ -1,0 +1,4 @@
+---
+
+govuk::node::s_base::apps:
+  - publishing_api


### PR DESCRIPTION
This ensures everything required to run publishing API is installed on the instances.