### PR TITLE
Add conditionals for custom nginx templates

### DIFF
--- a/modules/govuk/templates/node/s_jenkins/jenkins.conf.erb
+++ b/modules/govuk/templates/node/s_jenkins/jenkins.conf.erb
@@ -1,9 +1,14 @@
 server {
+  <%- if scope.lookupvar('::aws_migration') %>
+  listen 80;
+  <%- else %>
   listen 443 ssl;
-  server_name deploy.*;
 
   ssl_certificate     /etc/nginx/ssl/jenkins.crt;
   ssl_certificate_key /etc/nginx/ssl/jenkins.key;
+  <%- end %>
+
+  server_name deploy.*;
 
   location / {
     proxy_pass http://localhost:8080;

--- a/modules/icinga/templates/nginx.conf.erb
+++ b/modules/icinga/templates/nginx.conf.erb
@@ -1,9 +1,13 @@
 server {
   server_name nagios nagios.* icinga icinga.* alert alert.*;
 
+  <%- if scope.lookupvar('::aws_migration') %>
+  listen 80;
+  <%- else %>
   listen                    443 ssl;
   ssl_certificate           /etc/nginx/ssl/nagios.crt;
   ssl_certificate_key       /etc/nginx/ssl/nagios.key;
+  <%- end %>
   include                   /etc/nginx/ssl.conf;
 
   index index.html;


### PR DESCRIPTION
In AWS we're terminating SSL at the ELBs. This updates some custom nginx templates to ensure that the services only listen on tcp/80.