### PR TITLE
Change permissions, add exclusions and cleanup for graphite data.

### DIFF
--- a/modules/govuk/files/usr/local/bin/govuk_backup_graphite_whisper_files
+++ b/modules/govuk/files/usr/local/bin/govuk_backup_graphite_whisper_files
@@ -20,6 +20,11 @@ BACKUP_FILE_NAME="${BACKUP_FILE_ROOT_NAME}-${TIMESTAMP}.${BACKUP_FILE_NAME_EXTEN
 
 TAR_COMMAND="ionice -c 3 nice tar"
 
+# Exclude some directories that are huge and we don't care about.
+TAR_OPTIONS="--use-compress-program pigz -c --exclude=stats/timers/pp/apps/spotlight/dashboards --exclude=stats_counts/govuk/app/govuk-cdn-logs-monitor/logs-cdn-1/status --exclude=stats/govuk/app/govuk-cdn-logs-monitor/logs-cdn-1"
+
+BACKUP_USER="govuk-backup:govuk-backup"
+
 # Create the backup directory if it's not there but only if the storage directory exists
 if [ -d ${GRAPHITE_STORAGE_DIRECTORY} ]
 then
@@ -33,4 +38,7 @@ fi
 find ${BACKUP_DIRECTORY} -type f -name "*.${BACKUP_FILE_NAME_EXTENSION}" -mtime ${DAYS_TO_KEEP} | xargs -xi rm {}
 
 # Backup Whisper files
-${TAR_COMMAND} -acf ${BACKUP_DIRECTORY}/${BACKUP_FILE_NAME} ${GRAPHITE_WHISPER_DIRECTORY}
+${TAR_COMMAND} ${TAR_OPTIONS} -f ${BACKUP_DIRECTORY}/${BACKUP_FILE_NAME} ${GRAPHITE_WHISPER_DIRECTORY}
+
+# Set permissions on the backup file
+chown ${BACKUP_USER} ${BACKUP_DIRECTORY}/${BACKUP_FILE_NAME}

--- a/modules/govuk/files/usr/local/bin/govuk_delete_ephemeral_interface_data
+++ b/modules/govuk/files/usr/local/bin/govuk_delete_ephemeral_interface_data
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Expunge unneeded ephemeral interface data from the ci-agent-* boxes.
+
+for i in 1 2 3 4 5
+do
+  find /opt/graphite/storage/whisper/ci-agent-${i}_ci_integration -type d -name "interface-br*" | xargs -xi rm -rf {}
+  find /opt/graphite/storage/whisper/ci-agent-${i}_ci_integration -type d -name "interface-veth*" | xargs -xi rm -rf {}
+done

--- a/modules/govuk/manifests/node/s_graphite.pp
+++ b/modules/govuk/manifests/node/s_graphite.pp
@@ -95,10 +95,20 @@ class govuk::node::s_graphite (
     mode   => '0755',
   }
 
+  file { '/usr/local/bin/govuk_delete_ephemeral_interface_data':
+    ensure => present,
+    source => 'puppet:///modules/govuk/usr/local/bin/govuk_delete_ephemeral_interface_data',
+    mode   => '0755',
+  }
+
+  package { 'pigz':
+    ensure => installed,
+  }
+
   file { '/opt/graphite/storage/backups':
     ensure => 'directory',
-    owner  => 'root',
-    group  => 'root',
+    owner  => 'govuk-backup',
+    group  => 'govuk-backup',
     mode   => '0770',
   }
 
@@ -106,6 +116,12 @@ class govuk::node::s_graphite (
     command => '/usr/local/bin/govuk_backup_graphite_whisper_files',
     hour    => 23,
     minute  => 45,
+  }
+
+  cron::crondotdee { 'delete_ephemeral_interface_data_from_ci_agents':
+    command => '/usr/local/bin/govuk_delete_ephemeral_interface_data',
+    hour    => 23,
+    minute  => 30,
   }
 
   if ! $::aws_migration {


### PR DESCRIPTION
A few changes. Delete ephemeral graphite interface data from the CI agents. Tweak permissions on the Graphite backup directory so that govuk-backup can read them. Use pigz to multi-thread compress the data. And exclude some large directories from being backed up that we don't care about (PP mostly).