### PR TITLE
Fix Jenkins in AWS

### DIFF
--- a/modules/govuk/templates/node/s_jenkins/jenkins.conf.erb
+++ b/modules/govuk/templates/node/s_jenkins/jenkins.conf.erb
@@ -1,6 +1,7 @@
 server {
   <%- if scope.lookupvar('::aws_migration') %>
   listen 80;
+  proxy_set_header Host $http_host;
   <%- else %>
   listen 443 ssl;
 


### PR DESCRIPTION
Nginx was trying to do some odd redirects when we removed the configuration for HTTPS. Some pages failed to load, and after a bit of trial and error I discovered this as the fix.