### PR TITLE
AWS govuk_node_class prevent spoofing

### DIFF
--- a/modules/govuk/lib/puppet/parser/functions/govuk_node_class.rb
+++ b/modules/govuk/lib/puppet/parser/functions/govuk_node_class.rb
@@ -1,18 +1,22 @@
 module Puppet::Parser::Functions
   newfunction(:govuk_node_class, :type => :rvalue, :doc => <<EOS
 Return the name to construct a `govuk::node::s_` class based on the variable
-`$::trusted['certname']`. Requires `trusted_node_data` to be enabled. Takes
-no arguments.
+`$::trusted['extensions']['1.3.6.1.4.1.34380.1.1.13']` or `$::trusted['certname']`
+if the first one is null. Requires `trusted_node_data` to be enabled. Takes no
+arguments.
 
-For `puppet agent` this fact will be the FQDN on the certificate signed by
-the master. It cannot be spoofed to obtain the catalog/class of another node.
+For `puppet agent` on VCLoud, this fact will be the FQDN on the certificate signed by
+the master. On AWS, this will be the value of the '1.3.6.1.4.1.34380.1.1.13'
+extension of the certificate. It cannot be spoofed to obtain the catalog/class of
+another node.
 
-For `puppet apply` the fact will just be the machine's FQDN. It will always
-be spoofable because there is no SSL involved.
+For `puppet apply` on VCloud, the fact will just be the machine's FQDN. It will always
+be spoofable because there is no SSL involved. On AWS, the fact will be the value
+of the fact 'aws_migration', if it's present and not null.
 
-It does so by taking the first part (the unqualified hostname), stripping
-any numeric suffixes, and replacing hyphens (valid for DNS) with underscores
-(valid for Puppet class names).
+When the class is extracted from the certname, it does so by taking the first part
+(the unqualified hostname), stripping any numeric suffixes, and replacing hyphens
+(valid for DNS) with underscores (valid for Puppet class names).
 EOS
   ) do |args|
 
@@ -21,10 +25,6 @@ EOS
       "govuk_node_class: Wrong number of arguments given #{args.size} for 0."
     ) unless args.size == 0
 
-    # Explicit early return if in AWS.
-    aws_migration = lookupvar('aws_migration')
-    return aws_migration unless (aws_migration.nil? || aws_migration.empty?)
-
     # http://docs.puppetlabs.com/puppet/3/reference/lang_variables.html#trusted-node-data
     trusted_hash = lookupvar('::trusted')
     raise(
@@ -32,16 +32,32 @@ EOS
       "govuk_node_class: Unable to lookup $::trusted - is trusted_node_data enabled?"
     ) if trusted_hash.nil? or trusted_hash.empty?
 
+    pp_role = trusted_hash['extensions']['1.3.6.1.4.1.34380.1.1.13']
     certname = trusted_hash['certname']
-    raise(
-      Puppet::ParseError,
-      "govuk_node_class: Unable to lookup $::trusted['certname']"
-    ) if certname.nil? or certname.empty?
+    authenticated = trusted_hash['authenticated']
+    aws_migration = lookupvar('::aws_migration')
 
-    hostname = certname.split('.').first
-    class_name = hostname.gsub(/-\d+$/, '')
-    class_name.gsub!('-', '_')
+    # Puppet apply on AWS
+    if authenticated == "local"
+      return aws_migration unless (aws_migration.nil? || aws_migration.empty?)
+    end
 
-    class_name
+    # Puppet agent
+    if (pp_role.nil? || pp_role.empty?)
+      raise(
+        Puppet::ParseError,
+        "govuk_node_class: Unable to lookup $::trusted['certname']"
+      ) if certname.nil? or certname.empty?
+
+      hostname = certname.split('.').first
+      class_name = hostname.gsub(/-\d+$/, '')
+      class_name.gsub!('-', '_')
+ 
+      return class_name
+    else
+      # From Puppet 4.1, use 'pp_role' extension name instead of the OID
+      # https://docs.puppet.com/puppet/4.1/ssl_attributes_extensions.html
+      return pp_role
+    end 
   end
 end


### PR DESCRIPTION
Update `govuk_node_class()` to obtain the class_name on AWS from the
`$::trusted` hash variable instead of the `$::aws_migration` fact in
order to prevent spoofing.

On AWS environments, the certificate request has been updated to
include the following extensions, that will appear in the `$::trusted['extensions']`
hash when we run `puppet agent` on the clients:
 - pp_instance_id: AWS instance Id
 - pp_image_name: AWS image name
 - 1.3.6.1.4.1.34380.1.1.13: Instance role, populated at provisioning
time with the value of the `aws_migration` tag. This OID should resolve
to `pp_role` in Puppet 4.1
 - 1.3.6.1.4.1.34380.1.1.18: AWS instance region. This OID should resolve
to `pp_region` in Puppet 4.3

When we run `puppet agent`, `govuk_node_class()` will return the content of
`$::trusted['extensions']['1.3.6.1.4.1.34380.1.1.13']` if it's not empty or null.
Otherwise the previous `$::trusted['certname']` is used to extract the class_name.

When we run `puppet apply --trusted_node_data`, `govuk_node_class()` will return the
value of the fact `$::aws_migration` if it's not empty or null. Otherwise
`$::trusted['certname']` will be used.