### PR TITLE
Allow uploading of artefacts to S3 from CI

### DIFF
--- a/modules/govuk_ci/manifests/agent.pp
+++ b/modules/govuk_ci/manifests/agent.pp
@@ -60,6 +60,11 @@ class govuk_ci::agent(
     ensure => installed,
   }
 
+  package { 's3cmd':
+    ensure   => 'present',
+    provider => 'pip',
+  }
+
   govuk_bundler::config {'jenkins-bundler':
     server    => $gemstash_server,
     username  => 'jenkins',


### PR DESCRIPTION
This adds a simple command to upload an artefact to a bucket and
installs s3cmd on ci-agents.