### PR TITLE
[Discuss] Don't restart applications by default after env change

### DIFF
--- a/modules/govuk/manifests/app/envvar.pp
+++ b/modules/govuk/manifests/app/envvar.pp
@@ -20,7 +20,7 @@ define govuk::app::envvar (
   $ensure  = 'present',
   $envdir  = "/etc/govuk/${app}/env.d",
   $varname = $title,
-  $notify_service  = true,
+  $notify_service  = false,
 ) {
   validate_string($value)
 

--- a/modules/govuk/manifests/apps/content_store/enable_running_in_draft_mode.pp
+++ b/modules/govuk/manifests/apps/content_store/enable_running_in_draft_mode.pp
@@ -33,7 +33,6 @@ class govuk::apps::content_store::enable_running_in_draft_mode(
 
   Govuk::App::Envvar {
     app            => $app_name,
-    notify_service => false,
     require        => File["/etc/govuk/${app_name}/env.d"],
   }
 

--- a/modules/govuk/manifests/apps/government_frontend/enable_running_in_draft_mode.pp
+++ b/modules/govuk/manifests/apps/government_frontend/enable_running_in_draft_mode.pp
@@ -31,7 +31,6 @@ class govuk::apps::government_frontend::enable_running_in_draft_mode(
 
   Govuk::App::Envvar {
     app            => $app_name,
-    notify_service => false,
     require        => File["/etc/govuk/${app_name}/env.d"],
   }
 

--- a/modules/govuk/manifests/apps/manuals_frontend/enable_running_in_draft_mode.pp
+++ b/modules/govuk/manifests/apps/manuals_frontend/enable_running_in_draft_mode.pp
@@ -31,7 +31,6 @@ class govuk::apps::manuals_frontend::enable_running_in_draft_mode(
 
   Govuk::App::Envvar {
     app            => $app_name,
-    notify_service => false,
     require        => File["/etc/govuk/${app_name}/env.d"],
   }
 

--- a/modules/govuk/manifests/apps/performanceplatform_big_screen_view.pp
+++ b/modules/govuk/manifests/apps/performanceplatform_big_screen_view.pp
@@ -45,7 +45,6 @@ class govuk::apps::performanceplatform_big_screen_view (
       app            => $app_name,
       varname        => 'PUBLISHING_API_BEARER_TOKEN',
       value          => $publishing_api_bearer_token,
-      notify_service => false,
     }
   }
 }


### PR DESCRIPTION
Following a discussion in https://trello.com/c/PCkKYHnp, this changes the default behaviour to not restart applications when en environment variable changes. 

Applications would have to redeploy for the env variable to take effect. This is a better option than always restarting because redeploying is zero-downtime, while mass-restarting can cause errors to be served to users.

@surminus @danielroseman @SamLR @boffbowsh thoughts?