### PR TITLE
Delete old artifacts for job

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/check_content_consistency.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/check_content_consistency.yaml.erb
@@ -18,6 +18,7 @@
       - check-content-consistency
     logrotate:
       numToKeep: 10
+      artifactDaysToKeep: 3
     triggers:
         - timed: 'H 11 * * *'
     builders:


### PR DESCRIPTION
The Check Content Consistency job keeps lots of artefacts which are quite large in size and it's eating disk. We only need to keep the last fews, so delete anything older than 3 days.

[Trello Card](https://trello.com/c/jkdsdLDp/1027-1-delete-old-consistency-checker-results)