### PR TITLE
Enable password configuration in Puppetdb Postgres

### DIFF
--- a/modules/govuk_puppetdb/manifests/config.pp
+++ b/modules/govuk_puppetdb/manifests/config.pp
@@ -1,7 +1,7 @@
 # FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
-class govuk_puppetdb::config {
-
-  $puppetdb_postgres_password = ''
+class govuk_puppetdb::config (
+  $puppetdb_postgres_password = '',
+){
 
   # We are currently leaving puppetdb-1.x on the Precise machines and
   # installing puppetdb-2.x on the new Trusty Puppetmasters on AWS


### PR DESCRIPTION
The Puppetdb user to connect with PortgreSQL is using a password with empty
string. Make this a variable so we can change this setting if we need to.

This is required after this upgrade, empty passwords are not allowed:
https://www.postgresql.org/docs/9.6/static/release-9-3-18.html