### PR TITLE
Remove Metadata API

### DIFF
--- a/modules/govuk/manifests/apps/metadata_api.pp
+++ b/modules/govuk/manifests/apps/metadata_api.pp
@@ -24,7 +24,8 @@ class govuk::apps::metadata_api (
   $app_name = 'metadata-api'
 
   Govuk::App::Envvar {
-    app => $app_name,
+    ensure => 'absent',
+    app    => $app_name,
   }
 
   govuk::app::envvar {
@@ -35,6 +36,7 @@ class govuk::apps::metadata_api (
   }
 
   govuk::app { $app_name:
+    ensure             => 'absent',
     app_type           => 'bare',
     log_format_is_json => true,
     port               => $port,


### PR DESCRIPTION
Metadata API is no longer in use on GOV.UK. This removes it from our
servers. A future commit will remove references to the app from Puppet.