### PR TITLE
Add a Jenkins task to publish govuk-content-api-docs

### DIFF
--- a/hieradata/class/integration/jenkins.yaml
+++ b/hieradata/class/integration/jenkins.yaml
@@ -19,6 +19,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::deploy_training
   - govuk_jenkins::job::enhanced_ecommerce
   - govuk_jenkins::job::govuk_cdn_nightly_2xx_status_collection
+  - govuk_jenkins::job::govuk_content_api_docs
   - govuk_jenkins::job::launch_vms
   - govuk_jenkins::job::network_config_deploy
   - govuk_jenkins::job::passive_checks

--- a/modules/govuk_jenkins/manifests/job/govuk_content_api_docs.pp
+++ b/modules/govuk_jenkins/manifests/job/govuk_content_api_docs.pp
@@ -1,0 +1,11 @@
+# == Class: govuk_jenkins::job::govuk_content_api_docs
+#
+# Create a file on disk that can be parsed by jenkins-job-builder
+#
+class govuk_jenkins::job::govuk_content_api_docs {
+  file { '/etc/jenkins_jobs/jobs/govuk_content_api_docs.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/govuk_content_api_docs.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+}

--- a/modules/govuk_jenkins/templates/jobs/govuk_content_api_docs.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/govuk_content_api_docs.yaml.erb
@@ -1,0 +1,41 @@
+---
+- scm:
+    name: govuk-content-api-docs
+    scm:
+      - git:
+          url: git@github.com:alphagov/govuk-content-api-docs.git
+          basedir: govuk-content-api-docs
+          branches:
+            - master
+- job:
+    name: govuk-content-api-docs
+    display-name: Publish GOV.UK Content API Docs
+    project-type: freestyle
+    description: |
+      Builds and publishes the govuk-content-api-docs.
+    scm:
+      - govuk-content-api-docs
+    logrotate:
+      numToKeep: 10
+      artifactDaysToKeep: 3
+    triggers:
+      - timed: 'H * * * *'
+    builders:
+      - shell: |
+          #!/bin/bash
+          set -eu
+
+          cd "${WORKSPACE}"
+
+          rm -rf content-store
+
+          git clone https://github.com/alphagov/content-store.git
+
+          cd govuk-content-api-docs
+
+          export BUNDLE_PATH="${HOME}/bundles/${JOB_NAME}"
+          make publish API_SPEC=../content-store/openapi.yaml
+
+          cd ..
+
+          rm -rf content-store


### PR DESCRIPTION
This will run every hour.

Work in progress as the final job will run on production.

[Trello Card](https://trello.com/c/YPhTen16/61-automate-the-building-of-documentation)