### PR TITLE
Add pulling error pages for cache-1 from s3 as fallback

### DIFF
--- a/modules/router/manifests/errorpage.pp
+++ b/modules/router/manifests/errorpage.pp
@@ -1,12 +1,22 @@
 # FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
 define router::errorpage () {
 
-  $app_domain = hiera('app_domain')
+  # Only triggers every 6h or if the file doesn't exist.
   $filename = "/usr/share/nginx/www/${title}.html"
 
-  # Only triggers every 6h or if the file doesn't exist.
+  if $::aws_migration {
+    $s3_artefact_bucket = "govuk-${::aws_environment}-artefact"
+    $s3_url = "s3://${s3_artefact_bucket}/templates/${title}.html.erb"
+    $cmd = "aws --region eu-west-1 s3 cp ${s3_url} ${filename}"
+
+  } else {
+    $app_domain = hiera('app_domain')
+    $static_url = "https://static.${app_domain}/templates/${title}.html.erb"
+    $cmd = "curl --connect-timeout 1 -sf ${static_url} -o ${filename}"
+  }
+
   exec { "update_error_page_${title}":
-    command => "curl --connect-timeout 1 -sf https://static.${app_domain}/templates/${title}.html.erb -o ${filename}",
+    command => $cmd,
     unless  => "find ${filename} -mmin -360 -print 2>/dev/null | grep -Eqs '^${filename}$'",
     user    => 'deploy',
     group   => 'deploy',


### PR DESCRIPTION
Currently in order to deploy a cache-n box the static app has to be
reachable, this is not always the case. To break this dependency add a
fallback of pulling from an s3 bucket.