### PR TITLE
AWS add puppet node clean cron job

### DIFF
--- a/modules/puppet/files/puppet_node_clean.sh
+++ b/modules/puppet/files/puppet_node_clean.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+export AWS_DEFAULT_REGION=$(facter -p aws_region)
+if [[ -z $AWS_DEFAULT_REGION ]] ; then
+  echo "Error: aws_region is null"
+  exit
+fi
+
+STACKNAME=$(facter -p aws_stackname)
+if [[ -z ${STACKNAME} ]] ; then
+  echo "Error: stackname is null"
+  exit
+fi
+
+# Do we need "Name=tag:puppet_cert_signed,Values=*" ?
+awk 'FNR==NR{ array[$0];next}
+{ if ( $1 in array ) next
+print $1}
+' <(aws ec2 describe-instances --filters "Name=tag:aws_stackname,Values=${STACKNAME}" --output=json | jq -r '.Reservations[] | .Instances[] | .InstanceId ') <(curl 'http://localhost:8080/v3/nodes' 2>/dev/null | grep name | awk '{print $3}' | tr -d '",') | while read NODE
+do
+  echo "[$(date '+%H:%M:%S %d-%m-%Y')] Preparing to delete: ${NODE}"
+  puppet node clean ${NODE}
+  puppet node deactivate ${NODE}
+done
+

--- a/modules/puppet/manifests/puppetserver.pp
+++ b/modules/puppet/manifests/puppetserver.pp
@@ -73,4 +73,20 @@ class puppet::puppetserver(
     hour    => 6,
     minute  => 45,
   }
+
+  file { '/usr/local/bin/puppet_node_clean.sh':
+    ensure => present,
+    mode   => '0750',
+    owner  => 'root',
+    group  => 'root',
+    source => 'puppet:///modules/puppet/puppet_node_clean.sh',
+  }
+
+  cron::crondotdee { 'puppet_node_clean':
+    command => '/usr/local/bin/puppet_node_clean.sh',
+    hour    => '*',
+    minute  => '*/5',
+    require => File['/usr/local/bin/puppet_node_clean.sh'],
+  }
+
 }


### PR DESCRIPTION
Add a cron job to remove nodes from Puppetdb that no longer exist on the
AWS environment. We should refactor the AutoScalingGroups to use queue
notifications, but for now this will help preventing errors on monitoring
and cache servers related with duplicated stored resources that are using
`$::fqdn` as resource key.