### PR TITLE
Email users upstream of a failing Smokey build

### DIFF
--- a/hieradata/class/jenkins.yaml
+++ b/hieradata/class/jenkins.yaml
@@ -29,6 +29,11 @@ govuk_jenkins::config:
       --httpPort=$HTTP_PORT
       --ajp13Port=-1
       --sessionTimeout=1440
+  JAVA_ARGS:
+    value: >-
+      -Djava.awt.headless=true
+      -Djenkins.install.runSetupWizard=false
+      -Dhudson.tasks.MailSender.SEND_TO_USERS_WITHOUT_READ=true
 
 # FIXME: During the upgrade this stopped deploys being triggered from CI. When
 # the resolution has been configured remove this.
@@ -73,6 +78,8 @@ govuk_jenkins::plugins:
     version: '1.9'
   durable-task:
     version: '1.14'
+  email-ext:
+    version: '2.58'
   envinject-api:
     version: '1.2'
   envinject:

--- a/modules/govuk_jenkins/templates/jobs/smokey.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/smokey.yaml.erb
@@ -30,9 +30,33 @@
           auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN']%>
           build-server-url: <%= @slack_build_server_url %>
           room: <%= @slack_room %>
-      - email:
+      - email-ext:
           recipients: govuk-ci-notifications@digital.cabinet-office.gov.uk
-          send-to-individuals: true
+          failure: true
+          presend-script: |
+            import hudson.tasks.Mailer
+
+            def upstreamCause = build.getCause(Cause.UpstreamCause)
+
+            if (upstreamCause != null) {
+              def upstreamCauses = upstreamCause.getUpstreamCauses()
+              upstreamCauses.each() { cause ->
+                if (cause instanceof Cause.UserIdCause) {
+                  def user = User.get(cause.getUserId())
+                  def userEmail = user.getProperty(Mailer.UserProperty.class).getAddress()
+
+                  if (userEmail.endsWith("@digital.cabinet-office.gov.uk")) {
+                    logger.println("Upstream user being emailed: " + userEmail)
+                    msg.addRecipient(javax.mail.Message.RecipientType.TO, new javax.mail.internet.InternetAddress(userEmail))
+                  }
+                }
+              }
+            }
+          send-to:
+            - recipients
+            - developers
+            - culprits
+
     builders:
         - shell: |
             set +x


### PR DESCRIPTION
Prior to this change, Smokey would only notify a distribution list on
failure. If people aren’t watching that list, they will not be notified
of failures.

This change still notifies the distribution list, but on top of that it
tries to work out who kicked off the job upstream of Smokey causing it
to fail, and emails them.

In other words, if someone kicks off one of:
- Deploy App
- Deploy Puppet
- Deploy Licensify
- Network Config Deploy

...and then Smokey fails, then they will be notified by email, if that
email can be inferred.

Additionally, if changes were made to Smokey, and then it fails, then
the “culprits” who broke the build will also be notified.

In order to achieve this behaviour, we need to use the Jenkins
[`email-ext`](https://wiki.jenkins.io/display/JENKINS/Email-ext+plugin) plugin.

This plugin offers far more customisation than the plainer `mailer`
plugin, and - importantly - allows us to email addresses that are
unknown to Jenkins. After Jenkins’ security advisory
[`SECURITY-372`](https://jenkins.io/security/advisory/2017-03-20/), it was not possible to email addresses not associated with Jenkins users.

However, since we authenticate via Github, Jenkins does not actually
consider our email addresses to be associated with our projects.
`Email-ext` allows us to overcome this by running Jenkins with the
`-Dhudson.tasks.MailSender.SEND_TO_USERS_WITHOUT_READ=true` `JAVA_ARG`,
which is also added in this change.