### PR TITLE
Install liblzma-dev as a package on all machines in AWS

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -143,6 +143,7 @@ base::packages::packages:
   - 'libsqlite3-dev'
   - 'libxml2-dev'
   - 'libxslt1-dev'
+  - 'liblzma-dev'
   - 'logtail'
   - 'mailutils'
   - 'man-db'


### PR DESCRIPTION
- We tried to deploy an app that depended on Nokogiri in the Gemfile,
  and compiling Nokogiri failed with errors like: `** ar: tree.o: No
  such file or directory`. The Nokogiri troubleshooting instructions
  suggest installing this package amongst others
  (http://www.nokogiri.org/tutorials/installing_nokogiri.html#ubuntu___debian),
  but this was the only one not installed on the machine Imminence was
  trying to deploy to. After installing with `apt-get`, the deploy
  succeeded, hence adding it to Puppet now.