### PR TITLE
Allow different remote port for proxy

### DIFF
--- a/hieradata/class/search.yaml
+++ b/hieradata/class/search.yaml
@@ -9,6 +9,7 @@ govuk_elasticsearch::rummager_local_proxy::servers:
   - 'rummager-elasticsearch-1.api'
   - 'rummager-elasticsearch-2.api'
   - 'rummager-elasticsearch-3.api'
+govuk_elasticsearch::rummager_local_proxy::remote_port: 9200
 
 govuk::node::s_base::apps:
   - rummager

--- a/modules/govuk_elasticsearch/manifests/local_proxy.pp
+++ b/modules/govuk_elasticsearch/manifests/local_proxy.pp
@@ -27,6 +27,7 @@
 class govuk_elasticsearch::local_proxy(
   $read_timeout = 60,
   $port = 9200,
+  $remote_port = undef,
   $servers,
 ) {
   # Also used within template.
@@ -34,6 +35,12 @@ class govuk_elasticsearch::local_proxy(
   $log_json   = "${vhost}-json.event.access.log"
   $log_access = "${vhost}-access.log"
   $log_error  = "${vhost}-error.log"
+
+  if($remote_port) {
+    $final_remote_port = $remote_port
+  } else {
+    $final_remote_port = $port
+  }
 
   nginx::config::site { $vhost:
     content => template('govuk_elasticsearch/nginx_local_proxy.conf.erb'),

--- a/modules/govuk_elasticsearch/manifests/rummager_local_proxy.pp
+++ b/modules/govuk_elasticsearch/manifests/rummager_local_proxy.pp
@@ -23,6 +23,7 @@
 class govuk_elasticsearch::rummager_local_proxy(
   $read_timeout = 60,
   $port = 19200,
+  $remote_port = undef,
   $servers,
 ) {
   # Also used within template.
@@ -30,6 +31,12 @@ class govuk_elasticsearch::rummager_local_proxy(
   $log_json   = "${vhost}-json.event.access.log"
   $log_access = "${vhost}-access.log"
   $log_error  = "${vhost}-error.log"
+
+  if($remote_port) {
+    $final_remote_port = $remote_port
+  } else {
+    $final_remote_port = $port
+  }
 
   nginx::config::site { $vhost:
     content => template('govuk_elasticsearch/nginx_local_proxy.conf.erb'),

--- a/modules/govuk_elasticsearch/spec/classes/govuk_elasticsearch__local_proxy_spec.rb
+++ b/modules/govuk_elasticsearch/spec/classes/govuk_elasticsearch__local_proxy_spec.rb
@@ -74,4 +74,31 @@ describe 'govuk_elasticsearch::local_proxy', :type => :class do
       is_expected.to contain_nginx__config__site(vhost_name).with_content(/^\s+listen localhost:999;$/)
     end
   end
+
+  context 'different port and remote_port' do
+    let(:params) {{
+      :read_timeout => 10,
+      :port         => 999,
+      :remote_port  => 666,
+      :servers      => [
+        'es0.example.com',
+      ]
+    }}
+
+    it 'should reference one upstream with custom port' do
+      is_expected.to contain_nginx__config__site(vhost_name).with_content(
+/^upstream #{vhost_name}-upstream {
+  server es0\.example\.com:666\s[^\n]+;
+}/
+      )
+    end
+
+    it 'should have proxy_read_timeout 10' do
+      is_expected.to contain_nginx__config__site(vhost_name).with_content(/^\s+proxy_read_timeout 10;$/)
+    end
+
+    it 'should listen on port 999' do
+      is_expected.to contain_nginx__config__site(vhost_name).with_content(/^\s+listen localhost:999;$/)
+    end
+  end
 end

--- a/modules/govuk_elasticsearch/templates/nginx_local_proxy.conf.erb
+++ b/modules/govuk_elasticsearch/templates/nginx_local_proxy.conf.erb
@@ -1,6 +1,6 @@
 upstream <%= @vhost %>-upstream {
 <%- @servers.each do |server| -%>
-  server <%= server -%>:<%= @port %> max_fails=3 fail_timeout=10s;
+  server <%= server -%>:<%= @final_remote_port %> max_fails=3 fail_timeout=10s;
 <%- end -%>
 }
 


### PR DESCRIPTION
This is require for the ES migration where we want to have two ES
instances being accessible via proxy ports from a single machine.