### PR TITLE
Ensure link for docker app

### DIFF
--- a/modules/govuk_containers/manifests/app.pp
+++ b/modules/govuk_containers/manifests/app.pp
@@ -86,6 +86,12 @@ define govuk_containers::app (
     require          => Class[Govuk_docker],
   }
 
+  # Provide a symlink to the docker job using the plain app name
+  file { "/etc/init.d/${title}":
+    ensure => 'link',
+    target => "/etc/init.d/docker-${title}",
+  }
+
   if $healthcheck_path {
     @@icinga::check { "check_app_${title}_up_on_${::hostname}":
       ensure              => $ensure,


### PR DESCRIPTION
Add a symlink from `/etc/init.d/docker-app` to `/etc/init.d/app`. This is ensure that managing the service is consistent with the rest of our apps.