### PR TITLE
Add more disk space

### DIFF
--- a/hieradata/class/graphite.yaml
+++ b/hieradata/class/graphite.yaml
@@ -12,6 +12,7 @@ lv:
       - /dev/sdb1
       - /dev/sdc1
       - /dev/sdd1
+      - /dev/sde1
     vg: graphite
 
 mount:

--- a/hieradata/class/postgresql_primary.yaml
+++ b/hieradata/class/postgresql_primary.yaml
@@ -18,6 +18,7 @@ lv:
       - '/dev/sdd1'
       - '/dev/sde1'
       - '/dev/sdf1'
+      - '/dev/sdg1'
     vg: 'backups'
   data:
     pv: '/dev/sdc1'


### PR DESCRIPTION
We need more disk on both postgresql_primary and graphite for backups. We've done some remedial action on backup-1 to take the graphite backups, but we still need enough space to compress the backups in the first place.