### PR TITLE
Add staging override for graphite

### DIFF
--- a/hieradata/class/staging/graphite.yaml
+++ b/hieradata/class/staging/graphite.yaml
@@ -1,0 +1,9 @@
+---
+
+lv:
+  data:
+    pv:
+      - /dev/sdb1
+      - /dev/sdc1
+      - /dev/sdd1
+    vg: graphite


### PR DESCRIPTION
The graphite in Staging isn't using as much disk as in Production, so don't waste money with an extra disk.