### PR TITLE
Remove modified_paths.

### DIFF
--- a/modules/loadbalancer/manifests/balance.pp
+++ b/modules/loadbalancer/manifests/balance.pp
@@ -47,7 +47,6 @@ define loadbalancer::balance(
     $vhost = $title,
     $read_timeout = 15,
     $maintenance_mode = false,
-    $modified_paths = {},
 ) {
 
   $vhost_suffix = hiera('app_domain')

--- a/modules/loadbalancer/templates/nginx_balance.conf.erb
+++ b/modules/loadbalancer/templates/nginx_balance.conf.erb
@@ -83,13 +83,6 @@ server {
   }
   <%- end -%>
 
-  <% @modified_paths.each do |path, config| %>
-  location <%= path %> {
-    proxy_set_header Host <%= config['app'] %>.<%= @vhost_suffix %>;
-    proxy_pass https://<%= @vhost %>-upstream;
-  }
-  <% end %>
-
   location / {
     <%- if @internal_only -%>
     # Only accept connnections from internal machines

--- a/modules/loadbalancer/templates/nginx_balance_no_ssl.conf.erb
+++ b/modules/loadbalancer/templates/nginx_balance_no_ssl.conf.erb
@@ -66,13 +66,6 @@ server {
   }
   <%- end -%>
 
-  <% @modified_paths.each do |path, config| %>
-  location <%= path %> {
-    proxy_set_header Host <%= config['app'] %>.<%= @vhost_suffix %>;
-    proxy_pass https://<%= @vhost %>-upstream;
-  }
-  <% end %>
-
   location / {
     <%- if @internal_only -%>
     # Only accept connnections from internal machines


### PR DESCRIPTION
This was used in the past by specilist publisher only, which no longer
uses it.