### PR TITLE
Use the eth0 address to avoid docker details escaping

### DIFF
--- a/modules/icinga/manifests/client.pp
+++ b/modules/icinga/manifests/client.pp
@@ -56,7 +56,7 @@ class icinga::client (
 
   if $::aws_migration {
     # If it's in AWS, display the Puppet role and the IP address of the instance.
-    $display_name = "${::aws_migration} (${::ipaddress})"
+    $display_name = "${::aws_migration} (${::ipaddress_eth0})"
   } else {
     $display_name = $::fqdn_short
   }


### PR DESCRIPTION
Otherwise we see 172 addresses in our dashboards