### PR TITLE
Add Aptly logstash repo

### DIFF
--- a/modules/govuk/manifests/node/s_apt.pp
+++ b/modules/govuk/manifests/node/s_apt.pp
@@ -118,6 +118,7 @@ class govuk::node::s_apt (
   aptly::repo { 'govuk-rubygems': }
   aptly::repo { 'jenkins-agent': }
   aptly::repo { 'locksmithctl': }
+  aptly::repo { 'logstash': }
   aptly::repo { 'rbenv-ruby': }
   aptly::repo { 'rbenv-ruby-xenial':
     distribution => 'xenial',


### PR DESCRIPTION
At the moment we are downloding a very old version of logstash from a site that
has an expired certificate, so the download is failing on new installations.

We are going to package the Logstash jar and upload to an internal repository until
we upgrade to the latest version. This change creates the Aptly repository to store
the package.