### PR TITLE
Add log file to puppet_node_clean cron

### DIFF
--- a/modules/puppet/manifests/puppetserver.pp
+++ b/modules/puppet/manifests/puppetserver.pp
@@ -83,7 +83,7 @@ class puppet::puppetserver(
   }
 
   cron::crondotdee { 'puppet_node_clean':
-    command => '/usr/local/bin/puppet_node_clean.sh',
+    command => '/usr/local/bin/puppet_node_clean.sh >> /var/log/govuk/puppet_node_clean.log 2>&1',
     hour    => '*',
     minute  => '*/5',
     require => File['/usr/local/bin/puppet_node_clean.sh'],


### PR DESCRIPTION
The cron job is sending the output to the mail service, but this
is not configured properly on AWS yet. This change sends the
puppet_node_clean output to a log file, that is going to be rotated
by the default govuk-logs logrotate configuration.