### PR TITLE
Update Smokey deploy job for AWS

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/smokey_deploy.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/smokey_deploy.yaml.erb
@@ -18,7 +18,11 @@
       - smokey_Smokey_Deploy
     builders:
         - shell: |
+            <%- if scope.lookupvar('::aws_migration') %>
+            export DEPLOY_TO=$(govuk_node_list -c monitoring)
+            <%- else %>
             export DEPLOY_TO=monitoring-1
+            <%- end %>
             sh -x deploy.sh
     triggers:
         - timed: 'H 9 * * *'


### PR DESCRIPTION
In AWS we need to find the monitoring box to deploy to as the hostname is not hardcoded.