### PR TITLE
Use shallow clone for content schemas in consistency task

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/check_content_store.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/check_content_store.yaml.erb
@@ -19,4 +19,4 @@
 
           CONTENT_STORE=$(govuk_node_list --single-node -c content_store)
 
-          ssh deploy@$CONTENT_STORE "rm -rf /tmp/govuk-content-schemas; git clone https://github.com/alphagov/govuk-content-schemas.git /tmp/govuk-content-schemas && cd /var/apps/content-store && GOVUK_CONTENT_SCHEMAS_PATH=/tmp/govuk-content-schemas govuk_setenv content-store bundle exec rake validate_content_against_schema"
+          ssh deploy@$CONTENT_STORE "rm -rf /tmp/govuk-content-schemas; git clone https://github.com/alphagov/govuk-content-schemas.git /tmp/govuk-content-schemas --depth=1 && cd /var/apps/content-store && GOVUK_CONTENT_SCHEMAS_PATH=/tmp/govuk-content-schemas govuk_setenv content-store bundle exec rake validate_content_against_schema"


### PR DESCRIPTION
This makes cloning the repo a lot faster, because it has a lot of history.

cc @thomasleese 

https://trello.com/c/FesP8XSc