### PR TITLE
Add aws_migration output to puppet_node_clean

### DIFF
--- a/modules/puppet/files/puppet_node_clean.sh
+++ b/modules/puppet/files/puppet_node_clean.sh
@@ -18,7 +18,9 @@ awk 'FNR==NR{ array[$0];next}
 print $1}
 ' <(aws ec2 describe-instances --filters "Name=tag:aws_stackname,Values=${STACKNAME}" --output=json | jq -r '.Reservations[] | .Instances[] | .InstanceId ') <(curl 'http://localhost:8080/v3/nodes' 2>/dev/null | grep name | awk '{print $3}' | tr -d '",') | while read NODE
 do
-  echo "[$(date '+%H:%M:%S %d-%m-%Y')] Preparing to delete: ${NODE}"
+  echo "[$(date '+%H:%M:%S %d-%m-%Y')] Preparing to delete: ${NODE}:"
+  curl http://localhost:8080/v3/nodes/${NODE}/facts/aws_migration
+  echo
   puppet node clean ${NODE}
   puppet node deactivate ${NODE}
 done


### PR DESCRIPTION
Show the value of the aws_migration fact of the instance that the
puppet_node_clean cron is going to delete from Puppetdb.