### PR TITLE
Update node

### DIFF
--- a/hieradata/class/performance_backend.yaml
+++ b/hieradata/class/performance_backend.yaml
@@ -1,4 +1,6 @@
 ---
 
+nodejs::version: '0.10.37-1chl1~%{::lsbdistcodename}1'
+
 govuk::node::s_base::apps:
   - performanceplatform_admin

--- a/hieradata/class/performance_frontend.yaml
+++ b/hieradata/class/performance_frontend.yaml
@@ -1,5 +1,7 @@
 ---
 
+nodejs::version: '0.10.37-1chl1~%{::lsbdistcodename}1'
+
 govuk::node::s_base::apps:
   - performanceplatform_big_screen_view
   - spotlight

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1510,7 +1510,8 @@ mysql::client::package_ensure: 'present'
 
 nginx::package::version: '1.4.6-1ubuntu3.8'
 
-nodejs::version: '0.10.37-1chl1~%{::lsbdistcodename}1'
+nodejs::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+nodejs::version: '6.11.2-1nodesource1~%{::lsbdistcodename}1'
 
 ntp::server_list:
   - 'ntp.ubuntu.com'

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1058,7 +1058,8 @@ mysql::client::package_ensure: 'present'
 nginx::package::nginx_package: 'nginx-extras'
 nginx::package::version: '1.4.6-1ubuntu3.8'
 
-nodejs::version: '0.10.37-1chl1~%{::lsbdistcodename}1'
+nodejs::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+nodejs::version: '6.11.2-1nodesource1~%{::lsbdistcodename}1'
 
 ntp::server_list:
   - 'ntp.ubuntu.com'

--- a/modules/nodejs/manifests/init.pp
+++ b/modules/nodejs/manifests/init.pp
@@ -9,7 +9,7 @@
 #   Default: `undef`
 #
 class nodejs(
-  $version = undef
+  $version = undef,
 ) {
 
   if $version == undef {
@@ -18,7 +18,10 @@ class nodejs(
     $ensure = $version
   }
 
+  class { '::nodejs::repo': }
+
   package { 'nodejs':
     ensure  => $ensure,
+    require => Class['Nodejs::Repo'],
   }
 }

--- a/modules/nodejs/manifests/repo.pp
+++ b/modules/nodejs/manifests/repo.pp
@@ -1,0 +1,20 @@
+# == Class: nodejs::repo
+#
+# Use our own mirror of the nodejs repo. Should be used with `manage_repo`
+# disable of the upstream module.
+#
+# === Parameters
+#
+# [*apt_mirror_hostname*]
+#   Hostname to use for the APT mirror.
+#
+class nodejs::repo(
+  $apt_mirror_hostname = undef,
+) {
+  apt::source { 'nodejs':
+    location     => "http://${apt_mirror_hostname}/nodejs",
+    release      => $::lsbdistcodename,
+    architecture => $::architecture,
+    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+  }
+}


### PR DESCRIPTION
Update the version of node available on most of the machines, but leave the performance platform on the older version as they are still dependant on it.

Closes https://github.com/alphagov/govuk-puppet/issues/5942

[Trello Card](https://trello.com/c/YPhTen16/1041-2-automate-the-building-of-documentation) [Trello Card](https://trello.com/c/M8uRSjYq/113-spike-npm-integration-into-static-2)