### PR TITLE
Enable Content Audit allocation

### DIFF
--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -103,6 +103,7 @@ govuk::apps::authenticating_proxy::govuk_upstream_uri: 'http://government-fronte
 govuk::apps::backdrop_write::enable_procfile_worker: false
 govuk::apps::collections_publisher::enable_procfile_worker: false
 govuk::apps::contacts::extra_aliases: ['contacts-admin']
+govuk::apps::content_performance_manager::feature_auditing_allocation: true
 govuk::apps::content_store::mongodb_nodes: ['localhost']
 govuk::apps::content_store::mongodb_name: 'content_store_development'
 govuk::apps::content_tagger::enable_procfile_worker: false

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -25,6 +25,7 @@ base::supported_kernel::enabled: true
 cron::weekly_dow: 1
 cron::daily_hour: 6
 
+govuk::apps::content_performance_manager::feature_auditing_allocation: true
 govuk::apps::email_alert_api::allow_govdelivery_topic_syncing: true
 govuk::apps::errbit::errbit_email_from: 'govuk-winston+errbit-integration@digital.cabinet-office.gov.uk'
 govuk::apps::event_store::enabled: true

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -9,6 +9,7 @@ cron::daily_hour: 6
 
 environment_ip_prefix: '10.2'
 
+govuk::apps::content_performance_manager::feature_auditing_allocation: true
 govuk::apps::email_alert_api::allow_govdelivery_topic_syncing: true
 govuk::apps::email_alert_api::db::backend_ip_range: '10.2.3.0/24'
 govuk::apps::errbit::errbit_email_from: 'govuk-winston+errbit-staging@digital.cabinet-office.gov.uk'

--- a/modules/govuk/manifests/apps/content_performance_manager.pp
+++ b/modules/govuk/manifests/apps/content_performance_manager.pp
@@ -22,6 +22,10 @@
 #   The view id of GOV.UK in Google Analytics
 #   Default: undef
 #
+# [*feature_auditing_allocation*]
+#   Whether the auditing allocation feature should be enabled/disabled.
+#   Default: false
+#
 # [*google_client_email*]
 #   Google authentication email
 #   Default: undef
@@ -63,6 +67,7 @@ class govuk::apps::content_performance_manager(
   $db_password = undef,
   $db_username = 'content_performance_manager',
   $enable_procfile_worker = true,
+  $feature_auditing_allocation = false,
   $google_analytics_govuk_view_id = undef,
   $google_client_email = undef,
   $google_private_key = undef,
@@ -93,6 +98,9 @@ class govuk::apps::content_performance_manager(
   }
 
   govuk::app::envvar {
+    "${title}-FEATURE_AUDITING_ALLOCATION":
+      varname => 'FEATURE_AUDITING_ALLOCATION',
+      value   => bool2str($feature_auditing_allocation);
     "${title}-GOOGLE_ANALYTICS_GOVUK_VIEW_ID":
       varname => 'GOOGLE_ANALYTICS_GOVUK_VIEW_ID',
       value   => $google_analytics_govuk_view_id;


### PR DESCRIPTION
Adds an environmental variable to enable content audit allocation in dev, integration and staging.