### PR TITLE
Nginx limit rate alert on www and assets

### DIFF
--- a/modules/router/manifests/assets_origin.pp
+++ b/modules/router/manifests/assets_origin.pp
@@ -54,4 +54,18 @@ class router::assets_origin(
     "${vhost_name}-error.log":
       logstream => present;
   }
+
+  $graphite_429_target = "transformNull(stats.${::fqdn_metrics}.nginx_logs.assets-origin.http_429,0)"
+
+  @@icinga::check::graphite { "check_nginx_429_assets_on_${::hostname}":
+    target              => $graphite_429_target,
+    warning             => 2,
+    critical            => 4,
+    use                 => 'govuk_urgent_priority',
+    from                => '3minutes',
+    desc                => '429 rate for assets-origin (too many requests) [in office hours]',
+    host_name           => $::fqdn,
+    notes_url           => monitoring_docs_url(nginx-429-too-many-requests),
+    notification_period => 'inoffice',
+  }
 }

--- a/modules/router/manifests/nginx.pp
+++ b/modules/router/manifests/nginx.pp
@@ -164,4 +164,18 @@ class router::nginx (
     notes_url           => monitoring_docs_url(nginx-requests-too-low),
     notification_period => 'inoffice',
   }
+
+  $graphite_429_target = "transformNull(stats.${::fqdn_metrics}.nginx_logs.www-origin.http_429,0)"
+
+  @@icinga::check::graphite { "check_nginx_429_www_on_${::hostname}":
+    target              => $graphite_429_target,
+    warning             => 2,
+    critical            => 4,
+    use                 => 'govuk_urgent_priority',
+    from                => '3minutes',
+    desc                => '429 rate for www-origin (too many requests) [in office hours]',
+    host_name           => $::fqdn,
+    notes_url           => monitoring_docs_url(nginx-429-too-many-requests),
+    notification_period => 'inoffice',
+  }
 }


### PR DESCRIPTION
At the moment we monitor limit rate errors (HTTP 429) on the cache services
(www.govuk.uk and assets) only in Grafana. This change creates a Icinga alert,
similar to 5xx errors, to monitor on HTTP response code 429 during office
hours.

We should monitor the alert to check that the limits and metric window are
correct before enabling out of office hours.

Documentation in https://github.com/alphagov/govuk-developer-docs/pull/422