### PR TITLE
Add resolver to nginx config in AWS

### DIFF
--- a/modules/nginx/manifests/config.pp
+++ b/modules/nginx/manifests/config.pp
@@ -13,10 +13,16 @@
 # [*denied_ip_addresses*]
 #   An array of IP addresses that Nginx should prevent from accessing this machine.
 #
+# [*stack_network_prefix*]
+#   This is only used in AWS. This adds a resolver so that nginx refreshes resolved addresses
+#   from DNS if an upstream lookup fails. This is the prefix address defined for a VPC.
+#
 class nginx::config (
   $server_names_hash_max_size,
   $variables_hash_max_size = 1024,
-  $denied_ip_addresses) {
+  $denied_ip_addresses,
+  $stack_network_prefix = '10.1.0',
+) {
 
   file { '/etc/nginx':
     ensure  => directory,

--- a/modules/nginx/templates/etc/nginx/nginx.conf.erb
+++ b/modules/nginx/templates/etc/nginx/nginx.conf.erb
@@ -10,6 +10,10 @@ events {
 }
 
 http {
+    <%- if scope.lookupvar('::aws_migration') %>
+    resolver <%= @stack_network_prefix -%>.2;
+    <%- end %>
+
     include       /etc/nginx/mime.types;
     include       /etc/nginx/blockips.conf;
 


### PR DESCRIPTION
On startup, nginx does DNS lookups for upstream hosts and caches the result. In AWS, when ELBs scale up or down, they are liable to change endpoints. We use DNS to reach the appropriate endpoints, but unless we restart nginx then upstream requests will timeout.

By adding a resolver directive, it means that if the upstream request times out, it will do a DNS search:

https://nginx.org/en/docs/http/ngx_http_core_module.html#resolver

The resolver value is for the VPC nameserver, which is always the same in a VPC based upon the network range:

http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_DHCP_Options.html#AmazonDNS