### PR TITLE
Run content-tagger migrations after data sync

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
@@ -23,7 +23,7 @@
            ssh deploy@$(govuk_node_list -c backend --single-node) 'cd /var/apps/govuk-delivery ; govuk_setenv govuk-delivery ./venv/bin/python scripts/update_data_after_sync.py'
     publishers:
         - trigger-parameterized-builds:
-            <%- %w{ publishing-api collections-publisher service-manual-publisher local-links-manager email-alert-api transition link-checker-api content-performance-manager }.each do |app| -%>
+            <%- %w{ publishing-api collections-publisher service-manual-publisher local-links-manager email-alert-api transition link-checker-api content-performance-manager content-tagger }.each do |app| -%>
             - project: Deploy_App
               predefined-parameters: |
                 TARGET_APPLICATION=<%= app %>


### PR DESCRIPTION
Because the data sync will blot out any changes to the database.

@koetsier @whoojemaflip @cbaines 