### PR TITLE
Include the govuk index in the training vm

### DIFF
--- a/training-vm/provisioner/es-restore-s3.sh
+++ b/training-vm/provisioner/es-restore-s3.sh
@@ -6,7 +6,7 @@ set -e
 exec 1> >(/usr/bin/logger -s -t $(basename $0)) 2>&1
 
 ES_REPO=snapshots
-ES_INDICES="detailed","government","mainstream","metasearch","page-traffic","service-manual"
+ES_INDICES="detailed","government","mainstream","metasearch","page-traffic","service-manual","govuk"
 
 # PARAMETERS FOR ELASTICSEARCH SNAPSHOT REPOSITORY
 REPO_DATA=$(cat <<EOD
@@ -38,4 +38,3 @@ EOD
 LATEST_SNAPSHOT=$(/usr/bin/curl --connect-timeout 10 -sS -XGET "127.0.0.1:9200/_snapshot/${ES_REPO}/_all?pretty" | /usr/bin/jq --raw-output ".snapshots[].snapshot" |tail -1)
 
 curl -XPOST "localhost:9200/_snapshot/${ES_REPO}/${LATEST_SNAPSHOT}/_restore" -d $"${RESTORE_DATA}"
-


### PR DESCRIPTION
AFAIK this script isn't operational yet, but when it is, it should include the new `govuk` index which will eventually replace `government`, `mainstream` and `detailed`.

All other environments replicate data from the search indexes using `es_dump`, which already backs up all the indexes.

Trello: https://trello.com/c/NgQ9q987/242-make-sure-new-index-is-backed-up-and-replicated-across-environments