### PR TITLE
Expose secrets added to hieradata from alphagov-deployment

### DIFF
--- a/modules/govuk/manifests/apps/calculators.pp
+++ b/modules/govuk/manifests/apps/calculators.pp
@@ -12,9 +12,17 @@
 #   The bearer token to use when communicating with Publishing API.
 #   Default: undef
 #
+# [*errbit_api_key*]
+#   Errbit API key used by airbrake
+#
+# [*secret_key_base*]
+#   The key for Rails to use when signing/encrypting sessions.
+#
 class govuk::apps::calculators(
   $port = '3047',
   $publishing_api_bearer_token = undef,
+  $errbit_api_key = undef,
+  $secret_key_base = undef,
 ) {
   govuk::app { 'calculators':
     app_type              => 'rack',
@@ -25,9 +33,19 @@ class govuk::apps::calculators(
     asset_pipeline_prefix => 'calculators',
   }
 
-  govuk::app::envvar { "${title}-PUBLISHING_API_BEARER_TOKEN":
-    app     => 'calculators',
-    varname => 'PUBLISHING_API_BEARER_TOKEN',
-    value   => $publishing_api_bearer_token,
+  Govuk::App::Envvar {
+    app => 'calculators',
+  }
+
+  govuk::app::envvar {
+    "${title}-PUBLISHING_API_BEARER_TOKEN":
+        varname => 'PUBLISHING_API_BEARER_TOKEN',
+        value   => $publishing_api_bearer_token;
+    "${title}-ERRBIT_API_KEY":
+        varname => 'ERRBIT_API_KEY',
+        value   => $errbit_api_key;
+    "${title}-SECRET_KEY_BASE":
+        varname => 'SECRET_KEY_BASE',
+        value   => $secret_key_base;
   }
 }

--- a/modules/govuk/manifests/apps/calendars.pp
+++ b/modules/govuk/manifests/apps/calendars.pp
@@ -16,10 +16,14 @@
 #   The bearer token to use when communicating with Publishing API.
 #   Default: undef
 #
+# [*errbit_api_key*]
+#   Errbit API key used by airbrake
+#
 class govuk::apps::calendars(
   $port = '3011',
   $secret_key_base = undef,
   $publishing_api_bearer_token = undef,
+  $errbit_api_key = undef,
 ) {
   $app_name = 'calendars'
 
@@ -36,9 +40,13 @@ class govuk::apps::calendars(
     app => $app_name,
   }
 
-  govuk::app::envvar { "${title}-PUBLISHING_API_BEARER_TOKEN":
-    varname => 'PUBLISHING_API_BEARER_TOKEN',
-    value   => $publishing_api_bearer_token,
+  govuk::app::envvar {
+    "${title}-PUBLISHING_API_BEARER_TOKEN":
+        varname => 'PUBLISHING_API_BEARER_TOKEN',
+        value   => $publishing_api_bearer_token;
+    "${title}-ERRBIT_API_KEY":
+        varname => 'ERRBIT_API_KEY',
+        value   => $errbit_api_key;
   }
 
   if $secret_key_base {

--- a/modules/govuk/manifests/apps/email_alert_api.pp
+++ b/modules/govuk/manifests/apps/email_alert_api.pp
@@ -30,6 +30,28 @@
 #   Must only be configured to `true` in staging or integration, never production.
 #   Default: false
 #
+# [*govdelivery_username*]
+#   Username used to authenticate with govdelivery API
+#
+# [*govdelivery_password*]
+#   Password used to authenticate with govdelivery API
+#
+# [*govdelivery_account_code*]
+#   Identifier for GOV.UK within the govdelivery service
+#
+# [*govdelivery_hostname*]
+#   Hostname for the govdelivery API (changes depending on environment)
+#
+# [*govdelivery_signup_form*]
+#   URL to the public govdelivery page users are redirected to to enter their
+#   email and subscribe (URL should include a %s to provide a topic ID)
+#
+# [*errbit_api_key*]
+#   Errbit API key used by airbrake
+#
+# [*secret_key_base*]
+#   The key for Rails to use when signing/encrypting sessions.
+#
 class govuk::apps::email_alert_api(
   $port = '3088',
   $enabled = false,
@@ -43,6 +65,13 @@ class govuk::apps::email_alert_api(
   $redis_host = undef,
   $redis_port = undef,
   $allow_govdelivery_topic_syncing = false,
+  $govdelivery_username = undef,
+  $govdelivery_password = undef,
+  $govdelivery_account_code = undef,
+  $govdelivery_hostname = undef,
+  $govdelivery_signup_form = undef,
+  $errbit_api_key = undef,
+  $secret_key_base = undef,
 ) {
 
   if $enabled {
@@ -81,34 +110,46 @@ class govuk::apps::email_alert_api(
       port => $redis_port,
     }
 
-    govuk::app::envvar { "${title}-SIDEKIQ_RETRY_CRITICAL_THRESHOLD":
-      varname => 'SIDEKIQ_RETRY_SIZE_CRITICAL',
-      value   => $sidekiq_retry_critical;
-    }
-
-    govuk::app::envvar { "${title}-SIDEKIQ_RETRY_WARNING_THRESHOLD":
-      varname => 'SIDEKIQ_RETRY_SIZE_WARNING',
-      value   => $sidekiq_retry_warning;
-    }
-
-    govuk::app::envvar { "${title}-SIDEKIQ_QUEUE_SIZE_CRITICAL_THRESHOLD":
-      varname => 'SIDEKIQ_QUEUE_SIZE_CRITICAL',
-      value   => $sidekiq_queue_size_critical;
-    }
-
-    govuk::app::envvar { "${title}-SIDEKIQ_QUEUE_SIZE_WARNING_THRESHOLD":
-      varname => 'SIDEKIQ_QUEUE_SIZE_WARNING',
-      value   => $sidekiq_queue_size_warning;
-    }
-
-    govuk::app::envvar { "${title}-SIDEKIQ_QUEUE_LATENCY_CRITICAL_THRESHOLD":
-      varname => 'SIDEKIQ_QUEUE_LATENCY_CRITICAL',
-      value   => $sidekiq_queue_latency_critical;
-    }
-
-    govuk::app::envvar { "${title}-SIDEKIQ_QUEUE_LATENCY_WARNING_THRESHOLD":
-      varname => 'SIDEKIQ_QUEUE_LATENCY_WARNING',
-      value   => $sidekiq_queue_latency_warning;
+    govuk::app::envvar {
+      "${title}-SIDEKIQ_RETRY_CRITICAL_THRESHOLD":
+          varname => 'SIDEKIQ_RETRY_SIZE_CRITICAL',
+          value   => $sidekiq_retry_critical;
+      "${title}-SIDEKIQ_RETRY_WARNING_THRESHOLD":
+          varname => 'SIDEKIQ_RETRY_SIZE_WARNING',
+          value   => $sidekiq_retry_warning;
+      "${title}-SIDEKIQ_QUEUE_SIZE_CRITICAL_THRESHOLD":
+          varname => 'SIDEKIQ_QUEUE_SIZE_CRITICAL',
+          value   => $sidekiq_queue_size_critical;
+      "${title}-SIDEKIQ_QUEUE_SIZE_WARNING_THRESHOLD":
+          varname => 'SIDEKIQ_QUEUE_SIZE_WARNING',
+          value   => $sidekiq_queue_size_warning;
+      "${title}-SIDEKIQ_QUEUE_LATENCY_CRITICAL_THRESHOLD":
+          varname => 'SIDEKIQ_QUEUE_LATENCY_CRITICAL',
+          value   => $sidekiq_queue_latency_critical;
+      "${title}-SIDEKIQ_QUEUE_LATENCY_WARNING_THRESHOLD":
+          varname => 'SIDEKIQ_QUEUE_LATENCY_WARNING',
+          value   => $sidekiq_queue_latency_warning;
+      "${title}-GOVDELIVERY_USERNAME":
+          varname => 'GOVDELIVERY_USERNAME',
+          value   => $govdelivery_username;
+      "${title}-GOVDELIVERY_PASSWORD":
+          varname => 'GOVDELIVERY_PASSWORD',
+          value   => $govdelivery_password;
+      "${title}-GOVDELIVERY_ACCOUNT_CODE":
+          varname => 'GOVDELIVERY_ACCOUNT_CODE',
+          value   => $govdelivery_account_code;
+      "${title}-GOVDELIVERY_HOSTNAME":
+          varname => 'GOVDELIVERY_HOSTNAME',
+          value   => $govdelivery_hostname;
+      "${title}-GOVDELIVERY_SIGNUP_FORM":
+          varname => 'GOVDELIVERY_SIGNUP_FORM',
+          value   => $govdelivery_signup_form;
+      "${title}-ERRBIT_API_KEY":
+          varname => 'ERRBIT_API_KEY',
+          value   => $errbit_api_key;
+      "${title}-SECRET_KEY_BASE":
+          varname => 'SECRET_KEY_BASE',
+          value   => $secret_key_base;
     }
 
     if $allow_govdelivery_topic_syncing {

--- a/modules/govuk/manifests/apps/email_alert_frontend.pp
+++ b/modules/govuk/manifests/apps/email_alert_frontend.pp
@@ -15,9 +15,17 @@
 # [*port*]
 #   What port should the app run on?
 #
+# [*errbit_api_key*]
+#   Errbit API key used by airbrake
+#
+# [*secret_key_base*]
+#   The key for Rails to use when signing/encrypting sessions.
+#
 class govuk::apps::email_alert_frontend(
   $vhost = 'email-alert-frontend',
   $port = '3099',
+  $errbit_api_key = undef,
+  $secret_key_base = undef,
 ) {
   govuk::app { 'email-alert-frontend':
     app_type              => 'rack',
@@ -25,5 +33,18 @@ class govuk::apps::email_alert_frontend(
     asset_pipeline        => true,
     asset_pipeline_prefix => 'email-alert-frontend',
     vhost                 => $vhost,
+  }
+
+  Govuk::App::Envvar {
+    app => 'email-alert-frontend',
+  }
+
+  govuk::app::envvar {
+    "${title}-ERRBIT_API_KEY":
+        varname => 'ERRBIT_API_KEY',
+        value   => $errbit_api_key;
+    "${title}-SECRET_KEY_BASE":
+        varname => 'SECRET_KEY_BASE',
+        value   => $secret_key_base;
   }
 }

--- a/modules/govuk/manifests/apps/email_alert_service.pp
+++ b/modules/govuk/manifests/apps/email_alert_service.pp
@@ -21,10 +21,14 @@
 #   RabbitMQ password.
 #   Default: email_alert_service
 #
+# [*errbit_api_key*]
+#   Errbit API key used by airbrake
+#
 class govuk::apps::email_alert_service(
   $rabbitmq_hosts = ['localhost'],
   $rabbitmq_user = 'email_alert_service',
   $rabbitmq_password = 'email_alert_service',
+  $errbit_api_key = undef,
 ) {
   govuk::app { 'email-alert-service':
     app_type           => 'bare',
@@ -40,5 +44,11 @@ class govuk::apps::email_alert_service(
     hosts    => $rabbitmq_hosts,
     user     => $rabbitmq_user,
     password => $rabbitmq_password,
+  }
+
+  govuk::app::envvar {
+    "${title}-ERRBIT_API_KEY":
+        varname => 'ERRBIT_API_KEY',
+        value   => $errbit_api_key;
   }
 }

--- a/modules/govuk/manifests/apps/errbit.pp
+++ b/modules/govuk/manifests/apps/errbit.pp
@@ -17,12 +17,20 @@
 # [*nagios_memory_critical*]
 #   Memory use at which Nagios should generate a critical alert.
 #
+# [*oauth_id*]
+#   The application's OAuth ID from Signon
+#
+# [*oauth_secret*]
+#   The application's OAuth Secret from Signon
+#
 class govuk::apps::errbit(
   $port = '3029',
   $errbit_email_from = 'errbit@example.com',
   $errbit_secret_key_base = 'f258ed69266dc8ad0ca79363c3d2f945c388a9c5920fc9a1ae99a98fbb619f135001c6434849b625884a9405a60cd3d50fc3e3b07ecd38cbed7406a4fccdb59c', # This is the default in the errbit/errbit repo
   $nagios_memory_warning = undef,
   $nagios_memory_critical = undef,
+  $oauth_id = undef,
+  $oauth_secret = undef,
 ) {
   govuk::app { 'errbit':
     app_type               => 'rack',
@@ -48,5 +56,9 @@ class govuk::apps::errbit(
       value => "errbit.${app_domain}";
     'SECRET_KEY_BASE':
       value => $errbit_secret_key_base;
+    'OAUTH_ID':
+      value => $oauth_id;
+    'OAUTH_SECRET':
+      value => $oauth_secret;
   }
 }

--- a/modules/govuk/manifests/apps/finder_frontend.pp
+++ b/modules/govuk/manifests/apps/finder_frontend.pp
@@ -12,11 +12,19 @@
 # [*nagios_memory_critical*]
 #   Memory use at which Nagios should generate a critical alert.
 #
+# [*errbit_api_key*]
+#   Errbit API key used by airbrake
+#
+# [*secret_key_base*]
+#   The key for Rails to use when signing/encrypting sessions.
+#
 class govuk::apps::finder_frontend(
   $port = '3062',
   $enabled = false,
   $nagios_memory_warning = undef,
   $nagios_memory_critical = undef,
+  $errbit_api_key = undef,
+  $secret_key_base = undef,
 ) {
 
   if $enabled {
@@ -30,5 +38,18 @@ class govuk::apps::finder_frontend(
       nagios_memory_warning  => $nagios_memory_warning,
       nagios_memory_critical => $nagios_memory_critical,
     }
+  }
+
+  Govuk::App::Envvar {
+    app => 'finder-frontend',
+  }
+
+  govuk::app::envvar {
+    "${title}-ERRBIT_API_KEY":
+        varname => 'ERRBIT_API_KEY',
+        value   => $errbit_api_key;
+    "${title}-SECRET_KEY_BASE":
+        varname => 'SECRET_KEY_BASE',
+        value   => $secret_key_base;
   }
 }

--- a/modules/govuk/manifests/apps/frontend.pp
+++ b/modules/govuk/manifests/apps/frontend.pp
@@ -34,6 +34,9 @@
 #   Redis port for Sidekiq.
 #   Default: undef
 #
+# [*errbit_api_key*]
+#   Errbit API key used by airbrake
+#
 class govuk::apps::frontend(
   $vhost = 'frontend',
   $port = '3005',
@@ -43,6 +46,7 @@ class govuk::apps::frontend(
   $nagios_memory_critical = undef,
   $redis_host = undef,
   $redis_port = undef,
+  $errbit_api_key = undef,
 ) {
 
   govuk::app { 'frontend':
@@ -68,9 +72,16 @@ class govuk::apps::frontend(
     port => $redis_port,
   }
 
-  govuk::app::envvar { "${title}-PUBLISHING_API_BEARER_TOKEN":
-    app     => 'frontend',
-    varname => 'PUBLISHING_API_BEARER_TOKEN',
-    value   => $publishing_api_bearer_token,
+  Govuk::App::Envvar {
+    app => 'frontend',
+  }
+
+  govuk::app::envvar {
+    "${title}-PUBLISHING_API_BEARER_TOKEN":
+        varname => 'PUBLISHING_API_BEARER_TOKEN',
+        value   => $publishing_api_bearer_token;
+    "${title}-ERRBIT_API_KEY":
+        varname => 'ERRBIT_API_KEY',
+        value   => $errbit_api_key;
   }
 }

--- a/modules/govuk/manifests/apps/mapit.pp
+++ b/modules/govuk/manifests/apps/mapit.pp
@@ -11,10 +11,14 @@
 # [*db_password*]
 #   The password for the mapit postgresql role
 #
+# [*django_secret_key*]
+#   The key for Django to use when signing/encrypting sessions.
+#
 class govuk::apps::mapit (
   $enabled = false,
   $port    = '3108',
   $db_password,
+  $django_secret_key = undef,
 ) {
   if $enabled {
     govuk::app { 'mapit':
@@ -47,5 +51,15 @@ class govuk::apps::mapit (
       ]:
       ensure => present,
     }
+  }
+
+  Govuk::App::Envvar {
+    app => 'mapit',
+  }
+
+  govuk::app::envvar {
+    "${title}-DJANGO_SECRET_KEY":
+        varname => 'DJANGO_SECRET_KEY',
+        value   => $django_secret_key;
   }
 }

--- a/modules/govuk/manifests/apps/maslow.pp
+++ b/modules/govuk/manifests/apps/maslow.pp
@@ -19,12 +19,24 @@
 # [*secret_key_base*]
 #   The key for Rails to use when signing/encrypting sessions.
 #
+# [*errbit_api_key*]
+#   Errbit API key used by airbrake
+#
+# [*oauth_id*]
+#   The application's OAuth ID from Signon
+#
+# [*oauth_secret*]
+#   The application's OAuth Secret from Signon
+#
 class govuk::apps::maslow(
   $port = '3053',
   $mongodb_nodes,
   $mongodb_name,
   $publishing_api_bearer_token = undef,
   $secret_key_base = undef,
+  $errbit_api_key = undef,
+  $oauth_id = undef,
+  $oauth_secret = undef,
 ) {
   $app_name = 'maslow'
 
@@ -47,14 +59,19 @@ class govuk::apps::maslow(
 
   govuk::app::envvar {
     "${title}-PUBLISHING_API_BEARER_TOKEN":
-    varname => 'PUBLISHING_API_BEARER_TOKEN',
-    value   => $publishing_api_bearer_token;
-  }
-
-  if $secret_key_base != undef {
-    govuk::app::envvar { "${title}-SECRET_KEY_BASE":
+      varname => 'PUBLISHING_API_BEARER_TOKEN',
+      value   => $publishing_api_bearer_token;
+    "${title}-OAUTH_ID":
+      varname => 'OAUTH_ID',
+      value   => $oauth_id;
+    "${title}-OAUTH_SECRET":
+      varname => 'OAUTH_SECRET',
+      value   => $oauth_secret;
+    "${title}-ERRBIT_API_KEY":
+        varname => 'ERRBIT_API_KEY',
+        value   => $errbit_api_key;
+    "${title}-SECRET_KEY_BASE":
       varname => 'SECRET_KEY_BASE',
-      value   => $secret_key_base,
-    }
+      value   => $secret_key_base;
   }
 }

--- a/modules/govuk/manifests/apps/publisher.pp
+++ b/modules/govuk/manifests/apps/publisher.pp
@@ -20,6 +20,10 @@
 #   The bearer token to use when communicating with Need API.
 #   Default: undef
 #
+# [*asset_manager_bearer_token*]
+#   The bearer token to use when communicating with Need API.
+#   Default: undef
+#
 # [*secret_key_base*]
 #   The key for Rails to use when signing/encrypting sessions.
 #
@@ -41,11 +45,27 @@
 #   The secret used to encode JWT authentication tokens. This value needs to be
 #   shared with authenticating-proxy which decodes the tokens.
 #
+# [*errbit_api_key*]
+#   Errbit API key used by airbrake
+#
+# [*oauth_id*]
+#   The application's OAuth ID from Signon
+#
+# [*oauth_secret*]
+#   The application's OAuth Secret from Signon
+#
+# [*fact_check_username*]
+#   The username to use for Basic Auth for fact check
+#
+# [*fact_check_password*]
+#   The password to use for Basic Auth for fact check
+#
 class govuk::apps::publisher(
     $port = '3000',
     $enable_procfile_worker = true,
     $publishing_api_bearer_token = undef,
     $need_api_bearer_token = undef,
+    $asset_manager_bearer_token = undef,
     $secret_key_base = undef,
     $mongodb_name = undef,
     $mongodb_nodes = undef,
@@ -53,6 +73,11 @@ class govuk::apps::publisher(
     $redis_port = undef,
     $jwt_auth_secret = undef,
     $alert_hostname = 'alert.cluster',
+    $errbit_api_key = undef,
+    $oauth_id = undef,
+    $oauth_secret = undef,
+    $fact_check_username = undef,
+    $fact_check_password = undef,
   ) {
 
   govuk::app { 'publisher':
@@ -107,22 +132,40 @@ class govuk::apps::publisher(
     port => $redis_port,
   }
 
+  Govuk::App::Envvar {
+    app => 'publisher',
+  }
+
   govuk::app::envvar {
     "${title}-PUBLISHING_API_BEARER_TOKEN":
-      app     => 'publisher',
       varname => 'PUBLISHING_API_BEARER_TOKEN',
       value   => $publishing_api_bearer_token;
     "${title}-NEED_API_BEARER_TOKEN":
-      app     => 'publisher',
       varname => 'NEED_API_BEARER_TOKEN',
       value   => $need_api_bearer_token;
+    "${title}-ASSET_MANAGER_BEARER_TOKEN":
+      varname => 'ASSET_MANAGER_BEARER_TOKEN',
+      value   => $asset_manager_bearer_token;
     "${title}-JWT_AUTH_SECRET":
-      app     => 'publisher',
       varname => 'JWT_AUTH_SECRET',
       value   => $jwt_auth_secret;
     "${title}-SECRET_KEY_BASE":
-      app     => 'publisher',
       varname => 'SECRET_KEY_BASE',
       value   => $secret_key_base;
+    "${title}-OAUTH_ID":
+      varname => 'OAUTH_ID',
+      value   => $oauth_id;
+    "${title}-OAUTH_SECRET":
+      varname => 'OAUTH_SECRET',
+      value   => $oauth_secret;
+    "${title}-ERRBIT_API_KEY":
+      varname => 'ERRBIT_API_KEY',
+      value   => $errbit_api_key;
+    "${title}-FACT_CHECK_USERNAME":
+      varname => 'FACT_CHECK_USERNAME',
+      value   => $fact_check_username;
+    "${title}-FACT_CHECK_PASSWORD":
+      varname => 'FACT_CHECK_PASSWORD',
+      value   => $fact_check_password;
   }
 }

--- a/modules/govuk/manifests/apps/router_api.pp
+++ b/modules/govuk/manifests/apps/router_api.pp
@@ -25,6 +25,9 @@
 # [*secret_key_base*]
 #   The key for Rails to use when signing/encrypting sessions.
 #
+# [*errbit_api_key*]
+#   Errbit API key used by airbrake
+#
 class govuk::apps::router_api(
   $port = '3056',
   $mongodb_name,
@@ -32,6 +35,7 @@ class govuk::apps::router_api(
   $router_nodes,
   $vhost = 'router-api',
   $secret_key_base = undef,
+  $errbit_api_key = undef,
 ) {
   $app_name = 'router-api'
 
@@ -50,11 +54,13 @@ class govuk::apps::router_api(
     app            => $app_name,
   }
 
-  if $secret_key_base != undef {
-    govuk::app::envvar { "${title}-SECRET_KEY_BASE":
+  govuk::app::envvar {
+    "${title}-SECRET_KEY_BASE":
       varname => 'SECRET_KEY_BASE',
-      value   => $secret_key_base,
-    }
+      value   => $secret_key_base;
+    "${title}-ERRBIT_API_KEY":
+        varname => 'ERRBIT_API_KEY',
+        value   => $errbit_api_key;
   }
 
   govuk::app::envvar::mongodb_uri { $app_name:

--- a/modules/govuk/manifests/apps/smartanswers.pp
+++ b/modules/govuk/manifests/apps/smartanswers.pp
@@ -23,12 +23,20 @@
 # [*nagios_memory_critical*]
 #   Memory use at which Nagios should generate a critical alert.
 #
+# [*errbit_api_key*]
+#   Errbit API key used by airbrake
+#
+# [*secret_key_base*]
+#   The key for Rails to use when signing/encrypting sessions.
+#
 class govuk::apps::smartanswers(
   $port = '3010',
   $expose_govspeak = false,
   $publishing_api_bearer_token = undef,
   $nagios_memory_warning = undef,
   $nagios_memory_critical = undef,
+  $errbit_api_key = undef,
+  $secret_key_base = undef,
 ) {
   Govuk::App::Envvar {
     app => 'smartanswers',
@@ -42,9 +50,16 @@ class govuk::apps::smartanswers(
     }
   }
 
-  govuk::app::envvar { "${title}-PUBLISHING_API_BEARER_TOKEN":
-    varname => 'PUBLISHING_API_BEARER_TOKEN',
-    value   => $publishing_api_bearer_token,
+  govuk::app::envvar {
+    "${title}-PUBLISHING_API_BEARER_TOKEN":
+      varname => 'PUBLISHING_API_BEARER_TOKEN',
+      value   => $publishing_api_bearer_token;
+    "${title}-ERRBIT_API_KEY":
+      varname => 'ERRBIT_API_KEY',
+      value   => $errbit_api_key;
+    "${title}-SECRET_KEY_BASE":
+      varname => 'SECRET_KEY_BASE',
+      value   => $secret_key_base;
   }
 
   govuk::app { 'smartanswers':

--- a/modules/govuk/manifests/apps/transition.pp
+++ b/modules/govuk/manifests/apps/transition.pp
@@ -29,6 +29,24 @@
 # [*secret_key_base*]
 #   The key for Rails to use when signing/encrypting sessions.
 #
+# [*basic_auth_username*]
+#   The username to use for Basic Auth
+#
+# [*basic_auth_password*]
+#   The password to use for Basic Auth
+#
+# [*errbit_api_key*]
+#   Errbit API key used by airbrake
+#
+# [*ga_auth_provider_x509_cert_url*]
+# [*ga_auth_uri*]
+# [*ga_client_email*]
+# [*ga_client_id*]
+# [*ga_client_x509_cert_url*]
+# [*ga_key_p12_b64*]
+# [*ga_token_uri*]
+#   Authentication credentials for Google Analytics
+#
 class govuk::apps::transition(
   $port = '3044',
   $enable_procfile_worker = true,
@@ -36,7 +54,17 @@ class govuk::apps::transition(
   $oauth_secret = undef,
   $redis_host = undef,
   $redis_port = undef,
-  $secret_key_base = undef
+  $secret_key_base = undef,
+  $basic_auth_username = undef,
+  $basic_auth_password = undef,
+  $errbit_api_key = undef,
+  $ga_auth_provider_x509_cert_url = undef,
+  $ga_auth_uri = undef,
+  $ga_client_email = undef,
+  $ga_client_id = undef,
+  $ga_client_x509_cert_url = undef,
+  $ga_key_p12_b64 = undef,
+  $ga_token_uri = undef,
 ) {
   $app_name = 'transition'
 
@@ -75,7 +103,36 @@ class govuk::apps::transition(
       "${title}-SECRET_KEY_BASE":
         varname => 'SECRET_KEY_BASE',
         value   => $secret_key_base;
+      "${title}-BASIC_AUTH_USERNAME":
+        varname => 'BASIC_AUTH_USERNAME',
+        value   => $basic_auth_username;
+      "${title}-BASIC_AUTH_PASSWORD":
+        varname => 'BASIC_AUTH_PASSWORD',
+        value   => $basic_auth_password;
+      "${title}-ERRBIT_API_KEY":
+        varname => 'ERRBIT_API_KEY',
+        value   => $errbit_api_key;
+      "${title}-GA_AUTH_PROVIDER_X509_CERT_URL":
+        varname => 'GA_AUTH_PROVIDER_X509_CERT_URL',
+        value   => $ga_auth_provider_x509_cert_url;
+      "${title}-GA_AUTH_URI":
+        varname => 'GA_AUTH_URI',
+        value   => $ga_auth_uri;
+      "${title}-GA_CLIENT_EMAIL":
+        varname => 'GA_CLIENT_EMAIL',
+        value   => $ga_client_email;
+      "${title}-GA_CLIENT_ID":
+        varname => 'GA_CLIENT_ID',
+        value   => $ga_client_id;
+      "${title}-GA_CLIENT_X509_CERT_URL":
+        varname => 'GA_CLIENT_X509_CERT_URL',
+        value   => $ga_client_x509_cert_url;
+      "${title}-GA_KEY_P12_B64":
+        varname => 'GA_KEY_P12_B64',
+        value   => $ga_key_p12_b64;
+      "${title}-GA_TOKEN_URI":
+        varname => 'GA_TOKEN_URI',
+        value   => $ga_token_uri;
     }
   }
-
 }


### PR DESCRIPTION
These new environment variables were originally deployment secrets in
alphagov-deployment and are now exposed via hieradata.