### PR TITLE
Use an old version of Node on precise

### DIFF
--- a/hieradata/common.precise.yaml
+++ b/hieradata/common.precise.yaml
@@ -7,6 +7,8 @@ duplicity::packages::version: '0.6.18-0ubuntu3.5'
 
 nginx::package::version: '1.4.4-1~precise0'
 
+nodejs::version: '0.10.37-1chl1~precise1'
+
 postgresql::globals::version: '9.1'
 
 puppet::master::puppetdb_version: '1.3.2-1puppetlabs1'


### PR DESCRIPTION
The new version introduced in #6314 isn't available in precise.