### PR TITLE
Fix ruby versions and permissions in training VM

### DIFF
--- a/training-vm/provisioner/install-rubies.sh
+++ b/training-vm/provisioner/install-rubies.sh
@@ -4,9 +4,12 @@
 cd ~
 git clone https://github.com/rbenv/ruby-build.git
 cd ruby-build
-./install.sh
+sudo -i -u root ./install.sh
 
 # Install all ruby versions that are currently used by our apps
 for ruby in /var/govuk/*/.ruby-version; do
   rbenv install "$(cat $ruby)" -s
 done
+
+# Automatically initialise rbenv
+echo 'if which rbenv > /dev/null; then eval "$(rbenv init -)"; fi' > /home/deploy/.bash_profile

--- a/training-vm/training_user_data.txt
+++ b/training-vm/training_user_data.txt
@@ -101,7 +101,7 @@ echo "[$(date '+%H:%M:%S %d-%m-%Y')] END CHANGE REPOSITORY OWNER"
 echo
 
 echo "[$(date '+%H:%M:%S %d-%m-%Y')] START INSTALL RUBIES"
-sudo /home/ubuntu/provisioner/install-rubies.sh
+sudo -i -u deploy /home/ubuntu/provisioner/install-rubies.sh
 echo "[$(date '+%H:%M:%S %d-%m-%Y')] END INSTALL RUBIES"
 echo
 
@@ -112,7 +112,7 @@ echo "[$(date '+%H:%M:%S %d-%m-%Y')] END RESTORE DATABASES"
 echo
 
 echo "[$(date '+%H:%M:%S %d-%m-%Y')] START UPDATE BUNDLER"
-sudo /var/govuk/govuk-puppet/development-vm/update-bundler.sh
+sudo -i -u deploy /var/govuk/govuk-puppet/development-vm/update-bundler.sh
 echo "[$(date '+%H:%M:%S %d-%m-%Y')] END UPDATE BUNDLER"
 echo
 
@@ -123,6 +123,7 @@ echo "[$(date '+%H:%M:%S %d-%m-%Y')] END ADD HTTP BASIC AUTHENTICATION TO NGINX 
 echo
 
 echo "[$(date '+%H:%M:%S %d-%m-%Y')] START PREPARE SIGNON TRAINING ENVIRONMENT"
+cd /var/govuk/signon
 sudo /var/govuk/signon/script/prepare_training_environment --really-setup-training-environment
 echo "[$(date '+%H:%M:%S %d-%m-%Y')] END PREPARE SIGNON TRAINING ENVIRONMENT"
 echo


### PR DESCRIPTION
This commit makes a number of small tweaks to the training VM setup script:

* Run the ruby installation and bundler scripts under the deploy user
* Install ruby under the root user
* Add code to initialise rbenv for the deploy user so it works correctly
* Navigate to the `/var/govuk/signon` folder before running the setup script so that relative paths in there work correctly