### PR TITLE
Add router script to training VM

### DIFF
--- a/training-vm/provisioner/make-router.sh
+++ b/training-vm/provisioner/make-router.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Move `router` to $GOPATH
+org_path="/var/govuk/gopath/src/github.com/alphagov"
+mkdir -p $org_path
+mv /var/govuk/router $org_path
+ln -s "$org_path/router" /var/govuk/router
+
+# Build `router` and `draft-router`
+cd "$org_path/router"
+make

--- a/training-vm/training_user_data.txt
+++ b/training-vm/training_user_data.txt
@@ -134,6 +134,11 @@ echo "1025" | sudo tee /etc/govuk/env.d/SMTP_PORT > /dev/null
 echo "[$(date '+%H:%M:%S %d-%m-%Y')] END SET ENVIRONMENT VARIABLES FOR ALL APPS"
 echo
 
+echo "[$(date '+%H:%M:%S %d-%m-%Y')] START BUILD ROUTER"
+sudo -i -u deploy /home/ubuntu/provisioner/make-router.sh
+echo "[$(date '+%H:%M:%S %d-%m-%Y')] END BUILD ROUTER"
+echo
+
 echo "[$(date '+%H:%M:%S %d-%m-%Y')] START RUN UPSTART APPS"
 sudo /home/ubuntu/provisioner/start-training-environment.sh < /home/ubuntu/provisioner/alphagov_apps
 echo "[$(date '+%H:%M:%S %d-%m-%Y')] END RUN UPSTART APPS"


### PR DESCRIPTION
This commit adds a script to move the router to the gopath and build it, so it can be run by upstart.