### PR TITLE
[DO NOT MERGE] split puppet module for setting up RabbitMQ consumers

### DIFF
--- a/modules/govuk/manifests/apps/rummager/rabbitmq.pp
+++ b/modules/govuk/manifests/apps/rummager/rabbitmq.pp
@@ -62,14 +62,4 @@ class govuk::apps::rummager::rabbitmq (
     routing_key   => '*.*',
     durable       => true
   }
-
-  # Additional queue for reindexing.
-  # We use a longer binding key so the durable queue can use wildcard matching.
-  govuk_rabbitmq::queue_with_binding { 'govuk_index_transient':
-    amqp_pass     => $password,
-    amqp_exchange => 'published_documents',
-    amqp_queue    => 'govuk_index_transient',
-    routing_key   => '*.requeue.bulk',
-    durable       => true
-  }
 }

--- a/modules/govuk_rabbitmq/manifests/queue_with_binding.pp
+++ b/modules/govuk_rabbitmq/manifests/queue_with_binding.pp
@@ -1,0 +1,72 @@
+# == Define: govuk_rabbitmq::consumer
+#
+# Creates a RabbitMQ queue, binds it to an exchange, and monitors it.
+# Users should be set up separately: when doing so, you need to include
+# read/write/configure permissions for the queue.
+#
+# === Modifying queues and bindings
+#
+# The provider for the rabbitmq_binding resource identifies instances without reference to the routing key.
+# This makes it rather awkward to add or change bindings on any queue which already has a binding, because the
+# provider will think the binding already exists even if the routing keys differ, and will assume
+# that no work needs doing.
+# At present the workaround for changing a binding is to create a new queue for the new binding. Then switch the
+# consumers over to the new queue, and remove the old queue.
+# Another side effect of this problem is you can't define more than one binding for a queue.
+# This may be fixed by https://github.com/voxpupuli/puppet-rabbitmq/pull/504
+#
+# govuk_rabbitmq::remove_queues and govuk_rabbitmq::remove_bindings can be used
+# to ensure old queues and bindings are cleaned up.
+#
+# === Parameters
+#
+# [*amqp_pass*]
+#   The RabbitMQ password for the $title user.
+#
+# [*amqp_exchange*]
+#   The RabbitMQ exchange to configure permissions for.
+#
+# [*amqp_queue*]
+#   The RabbitMQ queue to create and configure permissions for.
+#
+# [*routing_key*]
+#   The routing key to create a binding for on the RabbitMQ queue.
+#
+# [*durable*]
+#   Queues can be durable or transient. Durable queues survive broker restart, transient queues do not.
+#   (default: true)
+#
+define govuk_rabbitmq::queue_with_binding (
+  $amqp_pass,
+  $amqp_exchange,
+  $amqp_queue,
+  $routing_key,
+  $durable = true
+) {
+  validate_re($routing_key, '^.+$', '$routing_key must be non-empty')
+  $amqp_user = $title
+
+  rabbitmq_queue { "${amqp_queue}@/":
+    ensure      => present,
+    user        => 'root',
+    password    => $::govuk_rabbitmq::root_password,
+    durable     => $durable,
+    auto_delete => false,
+    arguments   => {},
+  } ->
+  rabbitmq_binding { "binding_${routing_key}_${amqp_exchange}@${amqp_queue}@/":
+    ensure           => present,
+    name             => "${amqp_exchange}@${amqp_queue}@/",
+    user             => 'root',
+    password         => $::govuk_rabbitmq::root_password,
+    destination_type => 'queue',
+    routing_key      => $routing_key,
+    arguments        => {},
+  }
+
+  govuk_rabbitmq::monitor_consumers {"${title}_${amqp_queue}_consumer_monitoring":
+    ensure            => $ensure,
+    rabbitmq_hostname => 'localhost',
+    rabbitmq_queue    => $amqp_queue,
+  }
+}


### PR DESCRIPTION
As part of https://trello.com/c/5d4Qkt31/244-bulk-requeue-content-by-format, I'm looking at adding a separate queue to route requeued messages into, when we want to bulk-reindex content in search.

My reasoning for adding this is so that requeued messages won't get in the way of normal publishing. With a separate queue we can be less strict about persistence and easily purge messages if we don't want to wait for them to be processed. My plan is to make the new queue [transient](http://rubybunny.info/articles/durability.html) (non-durable).

Currently in puppet the `govuk_rabbitmq::consumer` class sets up the users and queues at the same time. This gets really messy when there are multiple queues per user, so I attempted to extract out the queue setup into its own thing.

On reflection I'm thinking this is a bit overkill for my immediate problem, so I'm going to first try having the consumer declare its own transient queue instead.

But I'd still like a review of this PR as some of the changes could still be merged, and I'd like someone to sanity check my approach.

The changes:

1. Remove amqp_queue_2, routing_key_2 in favour of explicitly creating a separate queue with `govuk_rabbitmq::queue_with_binding`

2. Rename `govuk_index` to `govuk_index_durable` - in contrast to the new queue which should be transient

3. Introduce extra parameters for the user permissions, so we can decouple the user/queue setup. This is the most awkward part of the PR since if it's wrong stuff will break. It also feels more complicated than it needs to be (see questions below).

4. Route messages with two words in (`*.*`) to `govuk_index_durable` instead of routing everything. My intention is to make the requeued messages use a longer routing key that doesn't match this pattern. An alternative would be to set up multiple bindings for the same queue (one for each of major, minor, links, unpublish), but this is not yet possible with the puppet module we're using.

## Questions
 I've attempted to preserve existing permissions for now, but I'm not sure the the defaults are optimal, and this adds complexity to the class.

1. Are there any downsides to granting full read permission to all consumers? This would mean consumers could read any exchange/queue/binding, but our messages are not sensitive.
2. Do consumers still need configure permissions by default? If puppet is supposed to declare the queues, then it seems like the consumers don't need to be doing that any more?
3. Do consumers need write permission at all?

Trello: https://trello.com/c/FFLNonSI/247-make-rummager-process-requeued-messages