### PR TITLE
Add Access-Control-Allow-Origin header for Icinga

### DIFF
--- a/modules/icinga/templates/nginx.conf.erb
+++ b/modules/icinga/templates/nginx.conf.erb
@@ -25,6 +25,8 @@ server {
     root /usr/lib/cgi-bin/icinga;
     rewrite ^/cgi-bin/icinga/(.*)$ /$1;
 
+    add_header Access-Control-Allow-Origin *;
+
     include /etc/nginx/fastcgi_params;
 
     fastcgi_param AUTH_USER $remote_user;


### PR DESCRIPTION
This commit adds a `Access-Control-Allow-Origin` CORS header to all `.cgi` files for Icinga. This will allow the JSON output of these files to be read by other services, such as a proposed client-side implementation of Blinken.