### PR TITLE
Rename govuk_config to govuk_app_config

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -592,7 +592,7 @@ govuk_ci::master::pipeline_jobs:
   govuk-diff-pages: {}
   govuk_admin_template: {}
   govuk_ab_testing: {}
-  govuk_config: {}
+  govuk_app_config: {}
   govuk-content-schema-test-helpers: {}
   govuk-dummy_content_store: {}
   govuk-developer-docs: {}

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -631,7 +631,7 @@ govuk_ci::master::pipeline_jobs:
   govuk-diff-pages: {}
   govuk_admin_template: {}
   govuk_ab_testing: {}
-  govuk_config: {}
+  govuk_app_config: {}
   govuk-content-schema-test-helpers: {}
   govuk-dummy_content_store: {}
   govuk-developer-docs: {}


### PR DESCRIPTION
This makes it clearer what the gem is for.