### PR TITLE
Restrict RabbitMQ queue binding for rummager

### DIFF
--- a/modules/govuk/manifests/apps/rummager/rabbitmq.pp
+++ b/modules/govuk/manifests/apps/rummager/rabbitmq.pp
@@ -40,7 +40,7 @@ class govuk::apps::rummager::rabbitmq (
     amqp_queue    => 'rummager_to_be_indexed',
     routing_key   => '*.links',
     amqp_queue_2  => 'rummager_govuk_index',
-    routing_key_2 => '#',
+    routing_key_2 => '*.*',
   }
 
   # deprecated - we will remove this user once we have migrated to the new user


### PR DESCRIPTION
In RabbitMQ binding keys, the wildcard `#` matches any number of dot separated words, whereas the pattern `*.*` ensures it's two words.

This allows us to keep subscribing to `schema.major`, `schema.minor`, `schema.links`, `schema.unpublish`, while not getting reindexing messages (https://github.com/alphagov/publishing-api/pull/1009)

I'm going to set up a separate queue to handle these messages.

Note that the puppet module for rabbitmq is not smart enough to update bindings for an existing queue when the binding key changes, so this will need to be manually changed after deployment.

I also looked at splitting the queue/binding stuff out of the consumer class, to make it easier to define multiple queues per Rabbit user without loads of params like `amqp_queue_2`, and `routing_key_2`. It turns out this refactor isn't necessary to update the routing, so I've raised https://github.com/alphagov/govuk-puppet/pull/6330 separately.

Trello: https://trello.com/c/FFLNonSI/247-make-rummager-process-requeued-messages