### PR TITLE
Update Smokey email notification settings

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/smokey.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/smokey.yaml.erb
@@ -32,7 +32,9 @@
           room: <%= @slack_room %>
       - email-ext:
           recipients: govuk-ci-notifications@digital.cabinet-office.gov.uk
+          attach-build-log: true
           failure: true
+          fixed: true
           presend-script: |
             import hudson.tasks.Mailer
 


### PR DESCRIPTION
Prior to moving to the `email-ext` plugin, Smokey email notifications
used to:

- Notify users when the build was fixed. This allows users to track
  whether the build has been fixed, especially if they do not have
  access to the staging or production environments for Jenkins.
- View the log of the failed build. This gives a quick insight to the
  reason for failure, and is again useful for users without staging or
  production access.

This change updates our `email-ext` configuration to restore this
behaviour.