### PR TITLE
Check for `null` User Email

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/smokey.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/smokey.yaml.erb
@@ -47,7 +47,7 @@
                   def user = User.get(cause.getUserId())
                   def userEmail = user.getProperty(Mailer.UserProperty.class).getAddress()
 
-                  if (userEmail.endsWith("@digital.cabinet-office.gov.uk")) {
+                  if (userEmail != null && userEmail.endsWith("@digital.cabinet-office.gov.uk")) {
                     logger.println("Upstream user being emailed: " + userEmail)
                     msg.addRecipient(javax.mail.Message.RecipientType.TO, new javax.mail.internet.InternetAddress(userEmail))
                   }


### PR DESCRIPTION
Some user emails can apparently be `null`, which causes a Java error
when trying to send them an email.

This change checks for `null` before trying to send them an email.