### PR TITLE
Build Content API docs from production

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/govuk_content_api_docs.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/govuk_content_api_docs.yaml.erb
@@ -29,7 +29,7 @@
 
           rm -rf content-store
 
-          git clone https://github.com/alphagov/content-store.git
+          git clone -b deployed-to-production https://github.com/alphagov/content-store.git
 
           cd govuk-content-api-docs
 


### PR DESCRIPTION
Currently it builds from master, but it would be better for the
documentation to represent production.