### PR TITLE
Disable theme filtering in CPM

### DIFF
--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -104,6 +104,7 @@ govuk::apps::backdrop_write::enable_procfile_worker: false
 govuk::apps::collections_publisher::enable_procfile_worker: false
 govuk::apps::contacts::extra_aliases: ['contacts-admin']
 govuk::apps::content_performance_manager::feature_auditing_allocation: true
+govuk::apps::content_performance_manager::feature_auditing_theme_filtering: true
 govuk::apps::content_store::mongodb_nodes: ['localhost']
 govuk::apps::content_store::mongodb_name: 'content_store_development'
 govuk::apps::content_tagger::enable_procfile_worker: false

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -26,6 +26,7 @@ cron::weekly_dow: 1
 cron::daily_hour: 6
 
 govuk::apps::content_performance_manager::feature_auditing_allocation: true
+govuk::apps::content_performance_manager::feature_auditing_theme_filtering: true
 govuk::apps::email_alert_api::allow_govdelivery_topic_syncing: true
 govuk::apps::errbit::errbit_email_from: 'govuk-winston+errbit-integration@digital.cabinet-office.gov.uk'
 govuk::apps::event_store::enabled: true

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -66,6 +66,8 @@ base::supported_kernel::enabled: true
 
 environment_ip_prefix: '10.3'
 
+govuk::apps::content_performance_manager::feature_auditing_allocation: false
+govuk::apps::content_performance_manager::feature_auditing_theme_filtering: false
 govuk::apps::email_alert_api::db::backend_ip_range: '10.3.3.0/24'
 govuk::apps::errbit::errbit_email_from: 'govuk-winston+errbit-production@digital.cabinet-office.gov.uk'
 govuk::apps::hmrc_manuals_api::publish_topics: false

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -10,6 +10,7 @@ cron::daily_hour: 6
 environment_ip_prefix: '10.2'
 
 govuk::apps::content_performance_manager::feature_auditing_allocation: true
+govuk::apps::content_performance_manager::feature_auditing_theme_filtering: false
 govuk::apps::email_alert_api::allow_govdelivery_topic_syncing: true
 govuk::apps::email_alert_api::db::backend_ip_range: '10.2.3.0/24'
 govuk::apps::errbit::errbit_email_from: 'govuk-winston+errbit-staging@digital.cabinet-office.gov.uk'

--- a/modules/govuk/manifests/apps/content_performance_manager.pp
+++ b/modules/govuk/manifests/apps/content_performance_manager.pp
@@ -26,6 +26,10 @@
 #   Whether the auditing allocation feature should be enabled/disabled.
 #   Default: false
 #
+# [*feature_auditing_theme_filtering*]
+#   Whether the auditing filters for themes are enabled/disabled.
+#   Default: false
+#
 # [*google_client_email*]
 #   Google authentication email
 #   Default: undef
@@ -71,6 +75,7 @@ class govuk::apps::content_performance_manager(
   $db_username = 'content_performance_manager',
   $enable_procfile_worker = true,
   $feature_auditing_allocation = false,
+  $feature_auditing_theme_filtering = false,
   $google_analytics_govuk_view_id = undef,
   $google_client_email = undef,
   $google_private_key = undef,
@@ -106,6 +111,9 @@ class govuk::apps::content_performance_manager(
     "${title}-FEATURE_AUDITING_ALLOCATION":
       varname => 'FEATURE_AUDITING_ALLOCATION',
       value   => bool2str($feature_auditing_allocation);
+    "${title}-FEATURE_AUDITING_THEME_FILTERING":
+      varname => 'FEATURE_AUDITING_THEME_FILTERING',
+      value   => bool2str($feature_auditing_theme_filtering);
     "${title}-GOOGLE_ANALYTICS_GOVUK_VIEW_ID":
       varname => 'GOOGLE_ANALYTICS_GOVUK_VIEW_ID',
       value   => $google_analytics_govuk_view_id;


### PR DESCRIPTION
Add env vars that toggle the feature in the Content Performance Manager.

See also https://github.com/alphagov/content-performance-manager/pull/296