### PR TITLE
Increase number of parallel runners for "Copy data to Integration"

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
@@ -19,7 +19,7 @@
             url: https://github.com/alphagov/env-sync-and-backup/
         - inject:
             properties-content: |
-              PARALLEL_JOBS=2
+              PARALLEL_JOBS=3
         - slack:
             notify-start: false
             notify-success: true


### PR DESCRIPTION
With the addition of the Elasticsearch 2.4 copy task we now have 13
tasks to run each night and use two runners is resulting in the
process being completed after standard start time. This will hopefully
help reduce the amount of time this process task to run.