### PR TITLE
Fix router script for training VM

### DIFF
--- a/training-vm/provisioner/make-router.sh
+++ b/training-vm/provisioner/make-router.sh
@@ -8,4 +8,5 @@ ln -s "$org_path/router" /var/govuk/router
 
 # Build `router` and `draft-router`
 cd "$org_path/router"
-make
+GOPATH=/var/govuk/gopath make
+GOPATH=/var/govuk/gopath BINARY=draft-router make


### PR DESCRIPTION
This commit changes the router build script in the training VM to correctly build the router with the `GOPATH` environment variable. It also adds a similar command to build a draft-router.