### PR TITLE
Create cron job for email-alert-api to update subscribers

### DIFF
--- a/modules/govuk_jenkins/manifests/job/email_alert_rake_tasks.pp
+++ b/modules/govuk_jenkins/manifests/job/email_alert_rake_tasks.pp
@@ -1,0 +1,11 @@
+# == Class: govuk_jenkins::job::email_alert_rake_tasks
+#
+# Create a Jenkins job
+#
+class govuk_jenkins::job::email_alert_rake_tasks  {
+  file { '/etc/jenkins_jobs/jobs/email_alert_rake_tasks.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/email_alert_rake_tasks.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+}

--- a/modules/govuk_jenkins/templates/jobs/email_alert_rake_tasks.yml.erb
+++ b/modules/govuk_jenkins/templates/jobs/email_alert_rake_tasks.yml.erb
@@ -1,0 +1,21 @@
+---
+- job:
+    name: email-alert-api-schedule-subscriber-count-update
+    display-name: "email-alert-api: update subscriber counts"
+    project-type: freestyle
+    description: "<p>Regularly run the schedule_update_subscriber_counts rake task for email-alert-api.</p>"
+    builders:
+        - trigger-builds:
+            - project: run-rake-task
+              block: true
+              predefined-parameters: |
+                TARGET_APPLICATION=email-alert-api
+                MACHINE_CLASS=backend
+                RAKE_TASK=schedule_update_subscriber_counts
+    publishers:
+        - email:
+            recipients: govuk-ci-notifications@digital.cabinet-office.gov.uk
+    triggers:
+      - timed: "30 2 * * *"
+    logrotate:
+        numToKeep: 10


### PR DESCRIPTION
This adds a cron job that every night updates the subscriber count (https://github.com/alphagov/email-alert-api/pull/166). I've copied this pattern from signon_cron_rake_tasks.yaml.

https://trello.com/c/YwfSmNQX