### PR TITLE
Increase number of parallel runners for "Copy data to Staging"

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_staging.yaml.erb
@@ -18,7 +18,7 @@
             url: https://github.com/alphagov/env-sync-and-backup/
         - inject:
             properties-content: |
-              PARALLEL_JOBS=2
+              PARALLEL_JOBS=3
         - slack:
             notify-start: false
             notify-success: true


### PR DESCRIPTION
This helped reduce the run time for the Integration job so is
now being rolled out to staging.