### PR TITLE
Add asset-manager option to allow us to rollout the S3 proxy

### DIFF
--- a/modules/govuk/manifests/apps/asset_manager.pp
+++ b/modules/govuk/manifests/apps/asset_manager.pp
@@ -35,6 +35,9 @@
 #   AWS access key for a user with permission to write to the S3 bucket
 # [*aws_secret_access_key*]
 #   AWS secret key for a user with permission to write to the S3 bucket
+# [*proxy_percentage_of_asset_requests_to_s3_via_nginx*]
+#   Value between 0 and 100 controlling the percentage of traffic that should
+#   be served by proxying the asset from S3
 #
 class govuk::apps::asset_manager(
   $enabled = true,
@@ -51,6 +54,7 @@ class govuk::apps::asset_manager(
   $aws_region = undef,
   $aws_access_key_id = undef,
   $aws_secret_access_key = undef,
+  $proxy_percentage_of_asset_requests_to_s3_via_nginx = '0'
 ) {
 
   $app_name = 'asset-manager'
@@ -178,6 +182,14 @@ class govuk::apps::asset_manager(
       "${title}-AWS_SECRET_KEY":
         varname => 'AWS_SECRET_KEY',
         value   => $aws_secret_access_key;
+    }
+
+    # Write the environment variable to configure the percentage of requests
+    # that should be served by proxying the request to S3 via nginx
+    govuk::app::envvar {
+      "${title}-PROXY_PERCENTAGE_OF_ASSET_REQUESTS_TO_S3_VIA_NGINX":
+        varname => 'PROXY_PERCENTAGE_OF_ASSET_REQUESTS_TO_S3_VIA_NGINX',
+        value   => $proxy_percentage_of_asset_requests_to_s3_via_nginx;
     }
   }
 }


### PR DESCRIPTION
We're working toward moving our assets from NFS to S3. In the short
term we're going to respond to requests for assets by having nginx
proxy the request to S3.

This configuration option and associated environment variable allows us
to incrementally rollout the change so that we can keep an eye on the
performance of the servers as we do so.

The value defaults to '0' in all cases. Once we're ready to start
rolling it out we can set
`govuk::apps::asset_manager::proxy_percentage_of_asset_requests_to_s3_via_nginx:`
to a value between '0' and '100' in the environment-specific heriadata
files.

I've manually tested this change in the developer VM. After applying the
change I see that all requests to the asset-manager continue to be
served by nginx + Sendfile. After updating the
`proxy_percentage_of_asset_requests_to_s3_via_nginx` option to 100 I see
that all requests to the asset-manager are served by nginx + proxy to
S3. I'm currently able to tell the difference between Sendfile + S3 by
looking at the value of the Etag in the response headers.