### PR TITLE
Set asset-manager S3 bucket and region in hieradata

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -25,6 +25,8 @@ base::supported_kernel::enabled: true
 cron::weekly_dow: 1
 cron::daily_hour: 6
 
+govuk::apps::asset_manager::aws_s3_bucket_name: 'govuk-assets-integration'
+govuk::apps::asset_manager::aws_region: 'eu-west-1'
 govuk::apps::content_performance_manager::feature_auditing_allocation: true
 govuk::apps::content_performance_manager::feature_auditing_theme_filtering: true
 govuk::apps::email_alert_api::allow_govdelivery_topic_syncing: true

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -66,6 +66,8 @@ base::supported_kernel::enabled: true
 
 environment_ip_prefix: '10.3'
 
+govuk::apps::asset_manager::aws_s3_bucket_name: 'govuk-assets-production'
+govuk::apps::asset_manager::aws_region: 'eu-west-1'
 govuk::apps::content_performance_manager::feature_auditing_allocation: false
 govuk::apps::content_performance_manager::feature_auditing_theme_filtering: false
 govuk::apps::email_alert_api::db::backend_ip_range: '10.3.3.0/24'

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -9,6 +9,8 @@ cron::daily_hour: 6
 
 environment_ip_prefix: '10.2'
 
+govuk::apps::asset_manager::aws_s3_bucket_name: 'govuk-assets-staging'
+govuk::apps::asset_manager::aws_region: 'eu-west-1'
 govuk::apps::content_performance_manager::feature_auditing_allocation: true
 govuk::apps::content_performance_manager::feature_auditing_theme_filtering: false
 govuk::apps::email_alert_api::allow_govdelivery_topic_syncing: true


### PR DESCRIPTION
These options are currently set in the govuk-secrets repo but that seems
like overkill given that I don't think they're particularly sensitive.
Storing them in these files will make it easier for people that don't
have access to govuk-secrets to change them if necessary.

The hiera.yml configuration file suggests that <environment>_credentials
hieradata will take priority over <environment> hieradata. I think
that's fine as it'll mean the apps continue to read from the values set
in govuk-secrets until we can get them removed from there.