### PR TITLE
Add an uptime collecting service

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -245,6 +245,7 @@ monitoring::checks::enable_support_check: false
 monitoring::checks::pingdom::enable: false
 monitoring::checks::ses::region: eu-west-1
 monitoring::checks::smokey::environment: 'integration'
+monitoring::uptime_collector::environment: 'integration'
 
 postfix::smarthost:
   - 'email-smtp.eu-west-1.amazonaws.com:587'

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -600,6 +600,7 @@ monitoring::contacts::slack_username: 'Production Icinga'
 monitoring::contacts::slack_alert_url: "https://alert.%{hiera('app_domain')}/cgi-bin/icinga/status.cgi"
 monitoring::edge::enabled: true
 monitoring::pagerduty_drill::enabled: true
+monitoring::uptime_collector::environment: 'production'
 
 postfix::smarthost:
   - 'email-smtp.us-east-1.amazonaws.com:587'

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -531,6 +531,7 @@ licensify::apps::licensing_web_forms::enabled: false
 monitoring::checks::enable_support_check: false
 monitoring::checks::ses::region: eu-west-1
 monitoring::checks::smokey::environment: 'staging'
+monitoring::uptime_collector::environment: 'staging'
 
 postfix::smarthost:
   - 'email-smtp.us-east-1.amazonaws.com:587'

--- a/modules/grafana/files/dashboards/application_uptime.json
+++ b/modules/grafana/files/dashboards/application_uptime.json
@@ -1,0 +1,97 @@
+{
+  "id": null,
+  "title": "Application Uptime",
+  "tags": [],
+  "style": "dark",
+  "timezone": "browser",
+  "editable": true,
+  "hideControls": false,
+  "sharedCrosshair": false,
+  "rows": [
+    {
+      "collapse": false,
+      "editable": true,
+      "height": "650px",
+      "panels": [
+        {
+          "columns": [],
+          "datasource": "Graphite",
+          "editable": true,
+          "error": false,
+          "fontSize": "100%",
+          "id": 4,
+          "isNew": true,
+          "links": [],
+          "pageSize": null,
+          "scroll": true,
+          "showHeader": true,
+          "sort": {
+            "col": 0,
+            "desc": true
+          },
+          "span": 12,
+          "styles": [
+            {
+              "dateFormat": "YYYY-MM-DD",
+              "pattern": "Time",
+              "type": "date"
+            },
+            {
+              "colorMode": "cell",
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "decimals": 2,
+              "pattern": "/.*/",
+              "thresholds": ["0.9931", "1"],
+              "type": "number",
+              "unit": "percentunit"
+            }
+          ],
+          "targets": [
+            {
+              "hide": false,
+              "refId": "A",
+              "target": "aliasByNode(summarize(stats.gauges.uptime.*, '1d', 'avg'), 3)",
+              "textEditor": false
+            }
+          ],
+          "title": "Uptimes",
+          "transform": "timeseries_to_columns",
+          "type": "table"
+        }
+      ],
+      "title": "Uptimes"
+    }
+  ],
+  "time": {
+    "from": "now-6M",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "templating": {
+    "list": []
+  },
+  "annotations": {
+    "list": []
+  },
+  "schemaVersion": 12,
+  "version": 1,
+  "links": [],
+  "gnetId": null
+}

--- a/modules/monitoring/files/usr/local/bin/govuk_uptime_collector
+++ b/modules/monitoring/files/usr/local/bin/govuk_uptime_collector
@@ -1,0 +1,71 @@
+#!/usr/bin/env ruby
+
+# Usage: govuk_uptime_collector <environment> <service ...>
+
+require "csv"
+require "fileutils"
+require "net/http"
+require "time"
+require "statsd"
+
+class Collector
+  def initialize(service_name, environment)
+    @statsd = Statsd.new("127.0.0.1")
+    @service_name = service_name
+    @environment = environment
+  end
+
+  def call
+    while true
+      send_to_statsd(check_service_up)
+      sleep 5
+    end
+  end
+
+private
+
+  attr_reader :statsd, :service_name, :environment
+
+  def healthcheck_uri
+    @healthcheck_uri ||= begin
+      prefix = environment == "production" ? "#{service_name}" : "#{service_name}.#{environment}"
+      URI("https://#{prefix}.publishing.service.gov.uk/healthcheck")
+    end
+  end
+
+  def check_service_up
+    http = Net::HTTP.new(healthcheck_uri.host, healthcheck_uri.port)
+    http.use_ssl = true
+    http.read_timeout = 20
+
+    request = Net::HTTP::Head.new(healthcheck_uri.request_uri)
+    res = http.request(request)
+
+    status_code = res.code.to_i
+    (200..299).include?(res.code.to_i)
+  end
+
+  def statsd_key
+    @statsd_key ||= "uptime.#{service_name}"
+  end
+
+  def send_to_statsd(status)
+    statsd.gauge(statsd_key, status ? 1 : 0)
+  end
+end
+
+def main
+  threads = []
+
+  environment = ARGV[0]
+
+  ARGV[1..-1].each do |service_name|
+    threads << Thread.new do
+      Collector.new(service_name, environment).call
+    end
+  end
+
+  threads.each(&:join)
+end
+
+main

--- a/modules/monitoring/manifests/init.pp
+++ b/modules/monitoring/manifests/init.pp
@@ -19,6 +19,7 @@ class monitoring {
   include monitoring::edge
   include monitoring::event_handlers
   include monitoring::pagerduty_drill
+  include monitoring::uptime_collector
 
   if ! $::aws_migration {
     include monitoring::vpn_gateways

--- a/modules/monitoring/manifests/uptime_collector.pp
+++ b/modules/monitoring/manifests/uptime_collector.pp
@@ -1,0 +1,36 @@
+# == Class: monitoring::uptime_collector
+#
+# Set up the uptime monitoring tool.
+#
+# === Parameters
+#
+# [*environment*]
+#   The environment the uptime collecting is running in. For example:
+#     production, integration or staging.
+#
+class monitoring::uptime_collector (
+  $environment = '',
+) {
+  file { '/usr/local/bin/govuk_uptime_collector':
+    source => 'puppet:///modules/monitoring/usr/local/bin/govuk_uptime_collector',
+    mode   => '0755',
+    notify => Service['govuk-uptime-collector'],
+  }
+
+  file { '/etc/init/govuk-uptime-collector.conf':
+    content => template('monitoring/govuk-uptime-collector.conf.erb'),
+    notify  => Service['govuk-uptime-collector'],
+  }
+
+  service { 'govuk-uptime-collector':
+    ensure => running,
+    enable => true,
+  }
+
+  @@icinga::check { 'check_uptime_collector_running':
+    check_command       => 'check_nrpe!check_proc_running_with_arg!ruby /usr/local/bin/govuk_uptime_collector',
+    service_description => 'govuk_uptime_collector not running',
+    host_name           => $::fqdn,
+    notes_url           => monitoring_docs_url(uptime-metrics),
+  }
+}

--- a/modules/monitoring/templates/govuk-uptime-collector.conf.erb
+++ b/modules/monitoring/templates/govuk-uptime-collector.conf.erb
@@ -1,0 +1,9 @@
+description "govuk-uptime-collector"
+
+start on runlevel [2345]
+respawn
+
+env RBENV_VERSION=2.3
+env PATH=/usr/lib/rbenv/shims:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+exec govuk_uptime_collector <%= @environment %> publishing-api content-store


### PR DESCRIPTION
This sends the uptime data it collects to statsd which allows it
to be viewed in Graphite.

We decided to go down the route of a service rather than taking
advantage of the Icinga checks because we wanted to have control
over when the /healthcheck endpoint will be polled.

[Trello Card](https://trello.com/c/zveUxj8x/943-spike-uptime-and-availability-metrics-timebox-3-days)