### PR TITLE
Use ETag & Last-Modified from Asset Manager when proxying to S3

### DIFF
--- a/modules/govuk/manifests/apps/asset_manager.pp
+++ b/modules/govuk/manifests/apps/asset_manager.pp
@@ -96,6 +96,11 @@ class govuk::apps::asset_manager(
         alias /var/apps/asset-manager/uploads/assets/$1;
       }
 
+      # Store values from Rails response headers for use in the
+      # cloud-storage-proxy location block below.
+      set $etag_from_rails $upstream_http_etag;
+      set $last_modified_from_rails $upstream_http_last_modified;
+
       location ~ /cloud-storage-proxy/(.*) {
         # Prevent requests to this location from outside nginx
         internal;
@@ -116,6 +121,12 @@ class govuk::apps::asset_manager(
         #
         # [1] http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_set_header
         proxy_set_header Host $proxy_host;
+
+        # Set response headers based on values stored from Rails response headers.
+        # This is so that we can keep these response headers the same as when Nginx
+        # serves the files from NFS to avoid unnecessary cache invalidation.
+        add_header ETag $etag_from_rails;
+        add_header Last-Modified $last_modified_from_rails;
 
         # Remove S3 HTTP headers listed in:
         # http://docs.aws.amazon.com/AmazonS3/latest/API/RESTCommonResponseHeaders.html


### PR DESCRIPTION
This is a follow-up to [the PR in which we made it possible to configure the Asset Manager to proxy asset requests to S3 via Nginx][1]. Since then we've merged [an Asset Manager PR which allows us to divert a percentage of asset request traffic to be proxied to S3][2]. We plan to roll this out gradually while carefully monitoring the load on and performance of the production stack.

Unfortunately Nginx and S3 use different algorithms to generate an ETag response header and, since the S3 copy of each asset has a different last modified time, the Last-Modified response header values are different too. So in order to avoid unnecessary cache invalidation and hence confound our monitoring of load & performance, we've made [a change to the Asset Manager Rails app to generate Nginx-esque ETag & Last-Modified response headers][3].

The changes to the Asset Manager Nginx config in this commit store the response header values from Rails and then add them to the response from S3 before the response is sent back to the user thus avoiding the unnecessary cache invalidation mentioned above.

Note that this is only an intermediate step; eventually we're planning to *redirect* asset requests to S3 and at that point we won't have control over these response headers. However, at that stage the load & performance concerns will transfer to S3, which is much less of a concern.

[1]: https://github.com/alphagov/govuk-puppet/pull/6280
[2]: https://github.com/alphagov/asset-manager/pull/152
[3]: https://github.com/alphagov/asset-manager/pull/157