### PR TITLE
Bump max_connections to postgres

### DIFF
--- a/hieradata/class/production/postgresql_primary.yaml
+++ b/hieradata/class/production/postgresql_primary.yaml
@@ -11,5 +11,3 @@ lv:
   data:
     pv: '/dev/sdd1'
     vg: 'postgresql'
-
-govuk_postgresql::server::max_connections: 200

--- a/hieradata/class/production/postgresql_standby.yaml
+++ b/hieradata/class/production/postgresql_standby.yaml
@@ -1,1 +1,0 @@
-govuk_postgresql::server::max_connections: 200

--- a/hieradata/class/staging/postgresql_primary.yaml
+++ b/hieradata/class/staging/postgresql_primary.yaml
@@ -1,1 +1,0 @@
-govuk_postgresql::server::max_connections: 120

--- a/hieradata/class/staging/postgresql_standby.yaml
+++ b/hieradata/class/staging/postgresql_standby.yaml
@@ -1,1 +1,0 @@
-govuk_postgresql::server::max_connections: 120

--- a/modules/govuk_postgresql/manifests/server.pp
+++ b/modules/govuk_postgresql/manifests/server.pp
@@ -29,7 +29,7 @@ class govuk_postgresql::server (
     $snakeoil_ssl_key,
     $listen_addresses = '*',
     $configure_env_sync_user = false,
-    $max_connections = 100,
+    $max_connections = 200,
 ) {
   if !(
     defined(Class["${name}::standalone"]) or


### PR DESCRIPTION
Bouncer and transition are seeing a lot of `PG::ConnectionBad: remaining connection slots are reserved for non-replication superuser connections` errors. It means there are no more database connections for the app to use.

https://sentry.io/govuk/app-bouncer/issues/335728174/events

This happens only on integration and staging, not production. I think this is because the `max_connections` in those environments is set to 120, while it's 200 in production.

Note that it was bumped from 100 to 120 last month: https://github.com/alphagov/govuk-puppet/pull/6128. I think that PR intended to solve the same problem.

I'm wondering if this is the correct solution, or that this is actually an application issue that should be solved there (perhaps connected to https://github.com/alphagov/bouncer/pull/143/files). Opening this to see if anyone has some more insight.