### PR TITLE
[DO NOT MERGE] Increase max_result_window for ES 2.4

### DIFF
--- a/modules/govuk_elasticsearch/manifests/init.pp
+++ b/modules/govuk_elasticsearch/manifests/init.pp
@@ -147,7 +147,8 @@ class govuk_elasticsearch (
     # https://www.elastic.co/guide/en/elasticsearch/reference/2.0/modules-scripting.html
     $instance_config_real = merge($instance_config, {
       'action.destructive_requires_name' => true,
-      'script.engine.groovy.inline.search' => true
+      'script.engine.groovy.inline.search' => true,
+      'index.max_result_window' => 1_000_000 # This will potentially create memory issues however is required until ES 5 when search_after is introduced
     })
   } else {
     # 1.4.3 introduced this setting and set it to false by default


### PR DESCRIPTION
This seeting was introduced to help limit memory costs for a single request,
however it would break a number of our FE pages which allow deep pagination.
The suggested alternative of search_after is not avaiable until we upgrade to
ES 5.