### PR TITLE
Add app_domain_internal and graphite_hostname

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -988,7 +988,7 @@ icinga::client::config::allowed_hosts: "10.0.0.0/8"
 icinga::config::http_username: "%{hiera('http_username')}"
 icinga::config::http_password: "%{hiera('http_password')}"
 
-icinga::config::graphite_hostname: 'graphite'
+icinga::config::graphite_hostname: "graphite.%{hiera('app_domain_internal')}"
 icinga::config::smokey::http_username: "%{hiera('http_username')}"
 icinga::config::smokey::http_password: "%{hiera('http_password')}"
 icinga::config::smokey::smokey_signon_email: "%{hiera('smokey_signon_email')}"

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -2,6 +2,7 @@
 _: &offsite_gpg_key 'DA204134165653A8D32526FCDBAB06CD60D07A2C'
 
 app_domain: "%{::aws_stackname}.integration.govuk.digital"
+app_domain_internal: "%{::aws_stackname}.integration.govuk-internal.digital"
 
 backup::mysql::rotation_daily: '2'
 backup::mysql::rotation_weekly: '6'


### PR DESCRIPTION
In AWS we do checks for graphite using SSL (terminated at an ELB). Update the hostname to use the internal domain, which we also add as a base hiera value.