### PR TITLE
Update assets routing in AWS

### DIFF
--- a/modules/router/manifests/assets_origin.pp
+++ b/modules/router/manifests/assets_origin.pp
@@ -28,6 +28,12 @@ class router::assets_origin(
   $app_domain = hiera('app_domain')
   $enable_ssl = hiera('nginx_enable_ssl', true)
 
+  if $::aws_migration {
+    $upstream_ssl = true
+  } else {
+    $upstream_ssl = $enable_ssl
+  }
+
   # suspect we want `protected => false` here
   # once appropriate firewalling is in place?
   nginx::config::site { $vhost_name:

--- a/modules/router/templates/assets_origin.conf.erb
+++ b/modules/router/templates/assets_origin.conf.erb
@@ -41,13 +41,13 @@ server {
   <%- @asset_routes.each do |alias_path, vhost_name| -%>
   location <%= alias_path %> {
     proxy_set_header Host <%= vhost_name %>.<%= @app_domain %>;
-    proxy_pass <%= @enable_ssl ? 'https' : 'http' %>://<%= vhost_name %>.<%= @app_domain %>;
+    proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://<%= vhost_name %>.<%= @app_domain %>;
   }
 
   <%- end -%>
 
   location / {
     proxy_set_header Host static.<%= @app_domain %>;
-    proxy_pass <%= @enable_ssl ? 'https' : 'http' %>://static.<%= @app_domain %>;
+    proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://static.<%= @app_domain %>;
   }
 }


### PR DESCRIPTION
In AWS we're terminating SSL on the ELBs. We disable SSL on the nginx config, and the router template for assets had some logic which meant if SSL is disabled, then it would also set the upstream path to HTTP rather than the required HTTPS.

This adds a full conditional block for that ensures that all upstream paths are set to HTTPS in AWS.