### PR TITLE
Run the integration Graphite backup scripts during the day.

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -191,6 +191,7 @@ govuk::node::s_frontend_lb::performance_frontend_apps:
 govuk::node::s_frontend_lb::whitehall_frontend_servers:
   - 'whitehall-frontend-1.frontend'
   - 'whitehall-frontend-2.frontend'
+govuk::node::s_graphite::graphite_backup_hour: 12
 govuk::node::s_logs_elasticsearch::rotate_hour: 06
 govuk::node::s_logs_elasticsearch::rotate_minute: 00
 govuk::node::s_licensify_lb::enable_feed_console: true

--- a/modules/govuk/manifests/node/s_graphite.pp
+++ b/modules/govuk/manifests/node/s_graphite.pp
@@ -6,6 +6,7 @@
 #
 # [*graphite_path*]
 #   Path to the installation of Graphite.
+#
 # [*graphite_backup_hour*]
 #   Hour of the day to run the backup crons.
 #

--- a/modules/govuk/manifests/node/s_graphite.pp
+++ b/modules/govuk/manifests/node/s_graphite.pp
@@ -9,6 +9,7 @@
 #
 class govuk::node::s_graphite (
   $graphite_path = '/opt/graphite',
+  $graphite_backup_hour = '23',
 ) inherits govuk::node::s_base {
   class { 'graphite':
     version                    => '0.9.13',
@@ -114,13 +115,13 @@ class govuk::node::s_graphite (
 
   cron::crondotdee { 'create_compressed_archive_of_whisper_data':
     command => '/usr/local/bin/govuk_backup_graphite_whisper_files',
-    hour    => 23,
+    hour    => $graphite_backup_hour,
     minute  => 45,
   }
 
   cron::crondotdee { 'delete_ephemeral_interface_data_from_ci_agents':
     command => '/usr/local/bin/govuk_delete_ephemeral_interface_data',
-    hour    => 23,
+    hour    => $graphite_backup_hour,
     minute  => 30,
   }
 

--- a/modules/govuk/manifests/node/s_graphite.pp
+++ b/modules/govuk/manifests/node/s_graphite.pp
@@ -6,10 +6,12 @@
 #
 # [*graphite_path*]
 #   Path to the installation of Graphite.
+# [*graphite_backup_hour*]
+#   Hour of the day to run the backup crons.
 #
 class govuk::node::s_graphite (
   $graphite_path = '/opt/graphite',
-  $graphite_backup_hour = '23',
+  $graphite_backup_hour = 23,
 ) inherits govuk::node::s_base {
   class { 'graphite':
     version                    => '0.9.13',


### PR DESCRIPTION
The default is to run them overnight but integration is switched off then so nothing happens. This fixes that and runs them during the day instead.