### PR TITLE
Don't install extensions if we're using RDS.

### DIFF
--- a/modules/govuk_postgresql/manifests/db.pp
+++ b/modules/govuk_postgresql/manifests/db.pp
@@ -119,7 +119,7 @@ define govuk_postgresql::db (
         tag      => 'govuk_postgresql::server::not_slave',
     }
 
-    if ! $::aws_migration {
+    if ! $rds {
       validate_array($extensions)
       if (!empty($extensions)) {
           $temp_extensions = prefix($extensions,"${db_name}:")


### PR DESCRIPTION
But don't always restrict them in AWS. Mapit for example needs them