### PR TITLE
Add PLEK updates for internal, and internal alias in nginx

### DIFF
--- a/lib/puppet-lint/plugins/check_hiera.rb
+++ b/lib/puppet-lint/plugins/check_hiera.rb
@@ -27,6 +27,9 @@ PuppetLint.new_check(:hiera_explicit_lookup) do
     # Legacy, used everywhere.
     'app_domain',
 
+    # Used in AWS, will be used everywhere eventually ;)
+    'app_domain_internal',
+
     # disk noops due to defined classes not doing magical hiera lookups
     'govuk_mount::no_op',
     'govuk_lvm::no_op',

--- a/modules/govuk/manifests/apps/content_store.pp
+++ b/modules/govuk/manifests/apps/content_store.pp
@@ -84,6 +84,15 @@ class govuk::apps::content_store(
     }
   }
 
+  if $::aws_migration {
+    $app_domain_internal = hiera('app_domain_internal')
+
+    govuk::app::envvar { "${title}-PLEK_SERVICE_ROUTER_API_URI":
+      varname => 'PLEK_SERVICE_ROUTER_API_URI',
+      value   => "https://router-api.${app_domain_internal}",
+    }
+  }
+
   govuk::app::envvar {
     "${title}-DEFAULT_TTL":
       varname => 'DEFAULT_TTL',

--- a/modules/nginx/manifests/config/vhost/proxy.pp
+++ b/modules/nginx/manifests/config/vhost/proxy.pp
@@ -114,6 +114,15 @@ define nginx::config::vhost::proxy(
   # Whether to enable SSL. Used by template.
   $enable_ssl = hiera('nginx_enable_ssl', true)
 
+  if $::aws_migration {
+    # We want to add the internal version of the domain everywhere in AWS,
+    # but when this defined type is called the external domain name is appended.
+    # We want the plain app name, which we can then add in the template.
+    $app_name = regsubst($name, '^(.*?)\.', '')
+    $app_domain_internal = hiera('app_domain_internal')
+    $name_internal = "${app_name}.${app_domain_internal}"
+  }
+
   nginx::config::ssl { $name:
     certtype => $ssl_certtype,
   }

--- a/modules/nginx/templates/proxy-vhost.conf
+++ b/modules/nginx/templates/proxy-vhost.conf
@@ -28,7 +28,11 @@ server {
 
 <%- ports.each do |port| -%>
 server {
+  <%- if scope.lookupvar('::aws_migration') %>
+  server_name <%= @name %> <%= @name_internal %> <%= @aliases.join(" ") unless @aliases.empty? %>;
+  <%- else %>
   server_name <%= @name %> <%= @aliases.join(" ") unless @aliases.empty? %>;
+  <%- end %>
 
   <%- if port == 443 -%>
   listen              443 ssl<%= $is_default_vhost ? " default_server" : "" %>;


### PR DESCRIPTION
This adds a PLEK override in AWS for router-api as we wish this to be an internal service only, and in AWS we split the idea of internal and external by using different DNS records.

This means that we also need the internal DNS records to exist in the nginx config as well as the external to ensure that vhost proxying works.