### PR TITLE
Remove duplicated host header

### DIFF
--- a/modules/router/templates/base.conf.erb
+++ b/modules/router/templates/base.conf.erb
@@ -27,7 +27,6 @@ server {
   include             /etc/nginx/ssl.conf;
   <%- else %>
   listen 80;
-  proxy_set_header Host $http_host;
   <%- end %>
 
   include             /etc/nginx/router_include.conf;
@@ -42,7 +41,6 @@ server {
   include             /etc/nginx/ssl.conf;
   <%- else %>
   listen 80;
-  proxy_set_header Host $http_host;
   <%- end %>
 
   include             /etc/nginx/router_include.conf;


### PR DESCRIPTION
I added the extra host header in 63cab0a72c693dd4af5e95c3a895de915c27aa04, because I copied what I did in 6537884645b5257fae6751573ba6d9d20cffe839, which was incorrect.

This caused varnish to throw the following error because the header was being duplicated:
`Error        c Duplicated Host header`