### PR TITLE
Escape commas for Emergency Banner Deploy task

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_emergency_banner.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_emergency_banner.yaml.erb
@@ -5,8 +5,23 @@
     project-type: freestyle
     description: "Deploy the emergency banner on GOV.UK."
     builders:
-      # The argument to `-c` is in this case `frontend` but the value is used by both `static` and `frontend` applications
-      - shell: ssh deploy@$(govuk_node_list -c frontend --single-node) "cd /var/apps/static && govuk_setenv static bundle exec rake emergency_banner:deploy[\"$CAMPAIGN_CLASS\",\"$HEADING\",\"$SHORT_DESCRIPTION\",\"$LINK\",\"$LINK_TEXT\"]"
+      # The argument to `-c` is in this case `frontend` but the value is used by both `static` and `frontend` applications.
+      # Rake does not handle commas in its arguments very well, so we have to escape them with a backslash. Since we're
+      # running the whole query inside quotes, we also need to escape quote marks.
+      - shell: |
+          #!/usr/bin/env bash
+
+          function escapeRakeArg {
+            echo $@ | sed 's/\([,"]\)/\\\1/g'
+          }
+
+          CAMPAIGN_CLASS=$(escapeRakeArg $CAMPAIGN_CLASS)
+          HEADING=$(escapeRakeArg $HEADING)
+          SHORT_DESCRIPTION=$(escapeRakeArg $SHORT_DESCRIPTION)
+          LINK=$(escapeRakeArg $LINK)
+          LINK_TEXT=$(escapeRakeArg $LINK_TEXT)
+
+          ssh deploy@$(govuk_node_list -c frontend --single-node) "cd /var/apps/static && govuk_setenv static bundle exec rake \"emergency_banner:deploy[$CAMPAIGN_CLASS,$HEADING,$SHORT_DESCRIPTION,$LINK,$LINK_TEXT]\""
     wrappers:
       - ansicolor:
           colormap: xterm
@@ -20,13 +35,13 @@
             - local-emergency
       - string:
           name: HEADING
-          description: The title of the banner. Commas must be escaped, eg One\, two
+          description: The title of the banner
       - string:
           name: SHORT_DESCRIPTION
-          description: The text that appears under the title. Commas must be escaped, eg One\, two
+          description: The text that appears under the title
       - string:
           name: LINK
           description: The more information link
       - string:
           name: LINK_TEXT
-          description: The anchor text for the more information link. Commas must be escaped, eg One\, two
+          description: The anchor text for the more information link


### PR DESCRIPTION
Rake is not very good at handling arguments with commas in. It has
surprising behaviour, such as:

`rake test[‘foo, bar’]` will give you two arguments: `foo` and `bar`.

If you escape the comma, then they are provided as a single argument
with a comma: `foo, bar`.

This change escapes the commas in the provided arguments, in order
to reduce human error when manually escaping. Since the command is
executed inside speech marks, this change also escapes quotes.

The new task has been tested with arguments whose commas and
quotes were not manually escaped:

![banner-deploy-quotes-commas](https://user-images.githubusercontent.com/12036746/29917803-f87a702e-8e3a-11e7-995f-f0abd608489b.png)
