### PR TITLE
Remove env-sync user from AWS

### DIFF
--- a/modules/govuk/manifests/node/s_db_admin.pp
+++ b/modules/govuk/manifests/node/s_db_admin.pp
@@ -59,9 +59,6 @@ class govuk::node::s_db_admin(
   # Ensure the client class is installed
   class { '::govuk_postgresql::client': } ->
 
-  # We want to grab the env-sync user
-  class { '::govuk_postgresql::env_sync_user': } ->
-
   # include all PostgreSQL classes that create databases and users
   class { '::govuk::apps::content_performance_manager::db': } ->
   class { '::govuk::apps::content_tagger::db': } ->

--- a/modules/govuk_postgresql/manifests/env_sync_user.pp
+++ b/modules/govuk_postgresql/manifests/env_sync_user.pp
@@ -10,25 +10,17 @@
 class govuk_postgresql::env_sync_user (
   $password
 ) {
-
-  if $::aws_migration {
-    $rds = true
-  }
-
   @postgresql::server::role { 'env-sync':
     superuser     => true,
     password_hash => postgresql_password('env-sync', $password),
     tag           => 'govuk_postgresql::server::not_slave',
-    rds           => $rds,
   }
 
-  if ! $rds {
-    postgresql::server::pg_hba_rule { 'local access as env-sync user':
-      type        => 'local',
-      database    => 'all',
-      user        => 'env-sync',
-      auth_method => 'md5',
-      order       => '001', # necessary to ensure this is before the 'local all all ident' rule.
-    }
+  postgresql::server::pg_hba_rule { 'local access as env-sync user':
+    type        => 'local',
+    database    => 'all',
+    user        => 'env-sync',
+    auth_method => 'md5',
+    order       => '001', # necessary to ensure this is before the 'local all all ident' rule.
   }
 }


### PR DESCRIPTION
Rather that try to construct a suitable superuser account for the
env-sync user in AWS we'll just use the main superuser account.