### PR TITLE
Create directory structure for Whitehall in AWS

### DIFF
--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -360,7 +360,9 @@ class govuk::apps::whitehall(
       }
     }
 
-    if $::govuk_node_class =~ /^(development|training)$/ {
+    # FIXME: this should be removed after AWS testing has been completed and
+    # assets is up and running
+    if $::govuk_node_class =~ /^(development|training)$/ or $::aws_migration {
       # Create the directory structure for whitehall assets in development
       $asset_directories = [
         '/data/uploads/whitehall',


### PR DESCRIPTION
We're not moving over assets yet, but not creating the directory structure means Whitehall deploys fail and we can't test the functionality of it even a little bit.