### PR TITLE
Tidy the copy data to AWS jenkins job

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/copy_data_from_integration_to_aws.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_from_integration_to_aws.yaml.erb
@@ -23,12 +23,12 @@
               PARALLEL_JOBS=2
         - slack:
             # TODO: re-enable notifications
-            notify-start: false
-            notify-success: false
+            notify-start: true
+            notify-success: true
             notify-aborted: false
             notify-notbuilt: false
             notify-unstable: false
-            notify-failure: false
+            notify-failure: true
             notify-backtonormal: false
             notify-repeatedfailure: false
             include-test-summary: false
@@ -37,7 +37,7 @@
     logrotate:
         numToKeep: 10
     triggers:
-        - timed: 'H 4 * * 1-5'
+        - timed: 'H 7 * * 1-5'
     builders:
         - shell: |
             set -eu
@@ -84,12 +84,9 @@
                 - elasticsearch-api
                 - elasticsearch-rummager
                 - mongo-api
-                - mongo-exceptions
-                - mongo-licensify
                 - mongo-normal
                 - mongo-router
                 - mysql-normal
                 - mysql-whitehall
                 - postgresql-api
                 - postgresql-backend
-                - postgresql-transition


### PR DESCRIPTION
This makes a few tweaks to the job:

* it re-enables slack notifications
* it sets the timer to run at 7am (when integration should be up)
* it removes jobs for databases we're not currently migrating