### PR TITLE
Set special Sentry environment name for AWS

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -719,7 +719,7 @@ govuk_containers::app::config::global_envvars:
   - "RACK_ENV=production"
   - "RAILS_ENV=production"
   - "ERRBIT_ENVIRONMENT_NAME=%{hiera('govuk::deploy::config::errbit_environment_name')}"
-  - "SENTRY_CURRENT_ENV=%{hiera('govuk::deploy::config::errbit_environment_name')}"
+  - "SENTRY_CURRENT_ENV=%{hiera('govuk::deploy::config::errbit_environment_name')}-%{hiera('stackname')}-aws"
   - "GOVUK_APP_DOMAIN=%{hiera('app_domain')}"
   - "GOVUK_ASSET_HOST=%{hiera('govuk::deploy::config::asset_root')}"
   - "GOVUK_ASSET_ROOT=%{hiera('govuk::deploy::config::asset_root')}"


### PR DESCRIPTION
On AWS, the Sentry environment will be either `integration-blue-aws` or `integration-green-aws`.