### PR TITLE
Add X-Frame-Options header when proxying requests to S3

### DIFF
--- a/modules/govuk/manifests/apps/asset_manager.pp
+++ b/modules/govuk/manifests/apps/asset_manager.pp
@@ -76,6 +76,8 @@ class govuk::apps::asset_manager(
       app => $app_name,
     }
 
+    $deny_framing = true
+
     $nginx_extra_config = inline_template('
       client_max_body_size 500m;
 
@@ -164,7 +166,7 @@ class govuk::apps::asset_manager(
       health_check_path  => '/healthcheck',
       vhost_aliases      => ['private-asset-manager'],
       log_format_is_json => true,
-      deny_framing       => true,
+      deny_framing       => $deny_framing,
       depends_on_nfs     => true,
       nginx_extra_config => $nginx_extra_config,
     }

--- a/modules/govuk/manifests/apps/asset_manager.pp
+++ b/modules/govuk/manifests/apps/asset_manager.pp
@@ -140,6 +140,14 @@ class govuk::apps::asset_manager(
         add_header Last-Modified $last_modified_from_rails;
         add_header Content-Type $content_type_from_rails;
 
+        # Avoid the asset being embedded in other pages[1]
+        # This header is already set in the outer virtual host config but the
+        # presence of additional `add_header` calls in this `location` block
+        # mean that the value from the outer block is not being inherited[2].
+        # [1]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
+        # [2]: http://nginx.org/en/docs/http/ngx_http_headers_module.html#add_header
+        add_header X-Frame-Options DENY;
+
         # Remove S3 HTTP headers listed in:
         # http://docs.aws.amazon.com/AmazonS3/latest/API/RESTCommonResponseHeaders.html
         # This keeps this HTTP response as similar as possible to the response

--- a/modules/govuk/manifests/apps/asset_manager.pp
+++ b/modules/govuk/manifests/apps/asset_manager.pp
@@ -76,7 +76,7 @@ class govuk::apps::asset_manager(
       app => $app_name,
     }
 
-    $nginx_extra_config = '
+    $nginx_extra_config = inline_template('
       client_max_body_size 500m;
 
       proxy_set_header X-Sendfile-Type X-Accel-Redirect;
@@ -154,7 +154,7 @@ class govuk::apps::asset_manager(
         # Download the file and send it to client
         proxy_pass $download_url;
       }
-    '
+    ')
 
     govuk::app { $app_name:
       app_type           => 'rack',

--- a/modules/govuk/manifests/apps/asset_manager.pp
+++ b/modules/govuk/manifests/apps/asset_manager.pp
@@ -132,6 +132,7 @@ class govuk::apps::asset_manager(
         add_header Last-Modified $last_modified_from_rails;
         add_header Content-Type $content_type_from_rails;
 
+        <%- if @deny_framing -%>
         # Avoid the asset being embedded in other pages[1]
         # This header is already set in the outer virtual host config but the
         # presence of additional `add_header` calls in this `location` block
@@ -139,6 +140,7 @@ class govuk::apps::asset_manager(
         # [1]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
         # [2]: http://nginx.org/en/docs/http/ngx_http_headers_module.html#add_header
         add_header X-Frame-Options DENY;
+        <%- end -%>
 
         # Remove S3 HTTP headers listed in:
         # http://docs.aws.amazon.com/AmazonS3/latest/API/RESTCommonResponseHeaders.html

--- a/modules/govuk/manifests/apps/asset_manager.pp
+++ b/modules/govuk/manifests/apps/asset_manager.pp
@@ -76,17 +76,7 @@ class govuk::apps::asset_manager(
       app => $app_name,
     }
 
-    govuk::app { $app_name:
-      app_type           => 'rack',
-      port               => $port,
-      sentry_dsn         => $sentry_dsn,
-      vhost_ssl_only     => true,
-      health_check_path  => '/healthcheck',
-      vhost_aliases      => ['private-asset-manager'],
-      log_format_is_json => true,
-      deny_framing       => true,
-      depends_on_nfs     => true,
-      nginx_extra_config => '
+    $nginx_extra_config = '
       client_max_body_size 500m;
 
       proxy_set_header X-Sendfile-Type X-Accel-Redirect;
@@ -164,7 +154,19 @@ class govuk::apps::asset_manager(
         # Download the file and send it to client
         proxy_pass $download_url;
       }
-      ',
+    '
+
+    govuk::app { $app_name:
+      app_type           => 'rack',
+      port               => $port,
+      sentry_dsn         => $sentry_dsn,
+      vhost_ssl_only     => true,
+      health_check_path  => '/healthcheck',
+      vhost_aliases      => ['private-asset-manager'],
+      log_format_is_json => true,
+      deny_framing       => true,
+      depends_on_nfs     => true,
+      nginx_extra_config => $nginx_extra_config,
     }
 
     govuk::app::envvar {


### PR DESCRIPTION
This ensures that we're sending the `X-Frame-Options` header with a value of `DENY` if `$deny_framing` is set to `true`; irrespective of whether we serve the asset file from the filesystem or from S3.

This address [issue 166 in asset-manager][1].

[1]: https://github.com/alphagov/asset-manager/issues/166