### PR TITLE
Add ELASTICSEARCH_URI for rummager

### DIFF
--- a/modules/govuk/manifests/apps/rummager.pp
+++ b/modules/govuk/manifests/apps/rummager.pp
@@ -158,4 +158,11 @@ class govuk::apps::rummager(
       varname => 'PUBLISHING_API_BEARER_TOKEN',
       value   => $publishing_api_bearer_token;
   }
+
+  if $::aws_migration {
+    govuk::app::envvar { "${title}-ELASTICSEARCH_URI":
+      varname => 'ELASTICSEARCH_URI',
+      value   => 'http://elasticsearch:9200',
+    }
+  }
 }

--- a/modules/govuk/manifests/node/s_api_elasticsearch.pp
+++ b/modules/govuk/manifests/node/s_api_elasticsearch.pp
@@ -26,7 +26,14 @@ class govuk::node::s_api_elasticsearch inherits govuk::node::s_base {
     aws_cluster_name       => $aws_cluster_name,
   }
 
-  unless $::aws_migration {
+  if $::aws_migration {
+
+    @ufw::allow { 'allow-elasticsearch-http-9200':
+      port => 9200,
+    }
+
+  } else {
+
     @ufw::allow { 'allow-elasticsearch-http-9200-from-search-1':
       port    => 9200,
       from    => getparam(Govuk_host['search-1'], 'ip'),


### PR DESCRIPTION
Without setting this, it defaults to localhost (as per https://github.com/alphagov/rummager/blob/cbfe9ac6fbc1e3b55f37c57e948d71f02214afea/elasticsearch.yml).

In the old world, we used a local_proxy to the load balancing. In the new world, we use ELBs and a DNS name.

Also open up firewall rules.