### PR TITLE
[WIP] Install oracle7 similar to oracle8

### DIFF
--- a/modules/govuk/manifests/node/s_licensing_backend.pp
+++ b/modules/govuk/manifests/node/s_licensing_backend.pp
@@ -5,7 +5,9 @@
 class govuk::node::s_licensing_backend inherits govuk::node::s_base {
   include clamav
 
-  include govuk_java::oracle8
+  class { '::govuk_java::oracle':
+    version => 8,
+  }
 
   include licensify::apps::licensify_admin
   include licensify::apps::licensify_feed

--- a/modules/govuk/manifests/node/s_licensing_frontend.pp
+++ b/modules/govuk/manifests/node/s_licensing_frontend.pp
@@ -5,7 +5,9 @@
 class govuk::node::s_licensing_frontend inherits govuk::node::s_base {
   include clamav
 
-  include govuk_java::oracle8
+  class { '::govuk_java::oracle':
+    version => 8,
+  }
 
   include licensify::apps::licensify
   include licensify::apps::licensing_web_forms

--- a/modules/govuk/manifests/node/s_logging.pp
+++ b/modules/govuk/manifests/node/s_logging.pp
@@ -19,7 +19,9 @@ class govuk::node::s_logging (
       port => 514;
   }
 
-  include govuk_java::oracle7::jre
+  class { '::govuk_java::oracle':
+    version => 7,
+  }
   # TODO: this should really be done with a package.
 
   apt::source { 'logstash':
@@ -33,7 +35,7 @@ class govuk::node::s_logging (
     ensure  => installed,
     require => [
       Apt::Source['logstash'],
-      Class['govuk_java::oracle7::jre'],
+      Class['govuk_java::oracle'],
     ],
   }
 

--- a/modules/govuk_ci/manifests/agent.pp
+++ b/modules/govuk_ci/manifests/agent.pp
@@ -31,7 +31,6 @@ class govuk_ci::agent(
   include ::govuk_ci::credentials
   include ::govuk_ci::limits
   include ::govuk_ci::vpn
-  include ::govuk_java::oracle8
   include ::govuk_jenkins::github_enterprise_cert
   include ::govuk_jenkins::packages::terraform
   include ::govuk_jenkins::pipeline
@@ -39,6 +38,10 @@ class govuk_ci::agent(
   include ::govuk_rbenv::all
   include ::govuk_sysdig
   include ::govuk_testing_tools
+
+  class { '::govuk_java::oracle':
+    version => 8,
+  }
 
   # Override sudoers.d resource (managed by sudo module) to enable Jenkins user to run sudo tests
   File<|title == '/etc/sudoers.d/'|> {

--- a/modules/govuk_java/manifests/oracle.pp
+++ b/modules/govuk_java/manifests/oracle.pp
@@ -1,9 +1,11 @@
-# == Class: govuk_java::oracle8
+# == Class: govuk_java::oracle
 #
 # Installs (and removes) the oracle-java8-installer package and accepts the
 # license agreement.
 #
-class govuk_java::oracle8 {
+class govuk_java::oracle (
+  $version,
+) {
 
   include govuk_ppa
 
@@ -14,7 +16,7 @@ class govuk_java::oracle8 {
       command => '/bin/echo debconf shared/accepted-oracle-license-v1-1 seen true | /usr/bin/debconf-set-selections';
   }
 
-  package { 'oracle-java8-installer':
+  package { "oracle-java${version}-installer":
     ensure  => present,
     require => [Exec['set-licence-selected'], Exec['set-licence-seen']],
   }


### PR DESCRIPTION
Currently we install jdk7 using a tarball in an S3 bucket the location of which I can't find.

This changes it to use the install method used for oracle8 by making the class more open and passing in a parameter.

We use this class for two things:

 - Installing a really old version of logstash
 - Licensing

I'm happy to change the method simply to install logstash, which we will hopefully upgrade soon anyway.