### PR TITLE
Set nullPointMode to null for Processes

### DIFF
--- a/modules/grafana/templates/dashboards/deployment_panels/_processor_count.json.erb
+++ b/modules/grafana/templates/dashboards/deployment_panels/_processor_count.json.erb
@@ -25,7 +25,7 @@
   "lines": true,
   "linewidth": 1,
   "links": [],
-  "nullPointMode": "null as zero",
+  "nullPointMode": "null",
   "percentage": false,
   "pointradius": 5,
   "points": false,


### PR DESCRIPTION
With "null as zero", you can't tell the difference between 0
processes, and no data yet, whereas with "null", you just see the
available data.