### PR TITLE
Increase Postgres Primary disk space

### DIFF
--- a/hieradata/class/integration/postgresql_primary.yaml
+++ b/hieradata/class/integration/postgresql_primary.yaml
@@ -7,6 +7,7 @@ lv:
       - '/dev/sdc1'
       - '/dev/sde1'
       - '/dev/sdf1'
+      - '/dev/sdg1'
     vg: 'backups'
   data:
     pv: '/dev/sdd1'

--- a/hieradata/class/production/postgresql_primary.yaml
+++ b/hieradata/class/production/postgresql_primary.yaml
@@ -6,7 +6,7 @@ lv:
       - '/dev/sde1'
       - '/dev/sdf1'
       - '/dev/sdg1'
-
+      - '/dev/sdh1'
     vg: 'backups'
   data:
     pv: '/dev/sdd1'


### PR DESCRIPTION
Postgres Primary is running out of space when performing backups in the
production environment since there is not enough disk space available
for the uncompressed backups.

At current time we have a 126G partition on integration and production
and a 156G one on staging. So this commit only adds extra drives to the
integration and production environments.