### PR TITLE
Add extra disk for performance mongo data

### DIFF
--- a/hieradata/class/performance_mongo.yaml
+++ b/hieradata/class/performance_mongo.yaml
@@ -8,7 +8,9 @@ lv:
     pv: '/dev/sdb1'
     vg: 'backup'
   data:
-    pv: '/dev/sdc1'
+    pv:
+      - '/dev/sdc1'
+      - '/dev/sde1'
     vg: 'mongodb'
   s3backups:
     pv: '/dev/sdd1'


### PR DESCRIPTION
This is very close to capacity, 90%, and will continue to rise.

Performance are anticipating moving to PAAS in October 2017 so hopefully
this will only be needed for a short period of time.