### PR TITLE
Disable the slack trigger for Copy To AWS

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/copy_data_from_integration_to_aws.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_from_integration_to_aws.yaml.erb
@@ -21,17 +21,17 @@
         - inject:
             properties-content: |
               PARALLEL_JOBS=2
-        - slack:
-            # TODO: re-enable notifications
-            notify-start: true
-            notify-success: true
-            notify-aborted: false
-            notify-notbuilt: false
-            notify-unstable: false
-            notify-failure: true
-            notify-backtonormal: false
-            notify-repeatedfailure: false
-            include-test-summary: false
+        # TODO: re-enable notifications
+        # - slack:
+        #     notify-start: true
+        #     notify-success: true
+        #     notify-aborted: false
+        #     notify-notbuilt: false
+        #     notify-unstable: false
+        #     notify-failure: true
+        #     notify-backtonormal: false
+        #     notify-repeatedfailure: false
+        #     include-test-summary: false
     scm:
       - env-sync-and-backup_Copy_Data_from_Integration_to_AWS
     logrotate:
@@ -66,11 +66,11 @@
           predefined-parameters: |
             NSCA_CHECK_DESCRIPTION=<%= @service_description %>
             NSCA_OUTPUT=<%= @service_description %> failed
-      - slack:
-          team-domain: <%= @slack_team_domain %>
-          auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN']%>
-          build-server-url: <%= @slack_build_server_url %>
-          room: <%= @slack_room %>
+      # - slack:
+      #     team-domain: <%= @slack_team_domain %>
+      #     auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN']%>
+      #     build-server-url: <%= @slack_build_server_url %>
+      #     room: <%= @slack_room %>
     wrappers:
         - ansicolor:
             colormap: xterm


### PR DESCRIPTION
The 'Copy from integration to AWS' task has the slack notify trigger set
on it. Unfortunately this relies upon the 'SECOND_LINE_SLACK_AUTH_TOKEN'
being set which it isn't in integration. This disables the trigger.