### PR TITLE
[WIP] Test internal Plek routing

### DIFF
--- a/modules/govuk/manifests/deploy/config.pp
+++ b/modules/govuk/manifests/deploy/config.pp
@@ -76,7 +76,12 @@ class govuk::deploy::config(
     require => File['/etc/govuk'],
   }
 
-  $app_domain = hiera('app_domain')
+  # In AWS we want to route things using the internal DNS name
+  if $::aws_migration {
+    $app_domain = hiera('app_domain_internal')
+  } else {
+    $app_domain = hiera('app_domain')
+  }
 
   govuk_envvar {
     'GOVUK_ENV': value => $govuk_env;


### PR DESCRIPTION
In AWS we wish to route things internally using DNS records.

Applications use Plek to find services, and quite often we find that things fail because they're requesting the external name. Internal services should have internal service records and internal ELBs, so we want to test setting the Plek root domain to the internal domain name and see what breaks.