### PR TITLE
Add redis-rivers for AWS

### DIFF
--- a/modules/govuk/templates/node/s_logs_elasticsearch/redis_river_aws.json.erb
+++ b/modules/govuk/templates/node/s_logs_elasticsearch/redis_river_aws.json.erb
@@ -1,0 +1,14 @@
+{
+  "type": "redis",
+  "redis": {
+    "mode": "list",
+    "host": "logs-redis",
+    "port": 6379,
+    "key": "logs",
+    "database": 0
+  },
+  "index": {
+    "bulk_timeout": 5,
+    "bulk_size": 100
+  }
+}


### PR DESCRIPTION
This isn't working because we traditionally exported the redis river resource from the redis instances. Now we use elasticache this isn't possible, so we must call the defined type directly.