### PR TITLE
Fix TravisCI bundler version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ env:
   - PUPPET_RSPEC_STRICT_VARIABLES=1
   - PUPPET_RSPEC_FUTURE_PARSER=0
   - PUPPET_RSPEC_FUTURE_PARSER=1
+before_install:
+  # Travis bundler versions are quite out of date and can cause install errors
+  # see: https://github.com/rubygems/rubygems/issues/1419
+  - gem update bundler
 install:
   - bundle install --jobs=3 --retry=3 --deployment --path=${BUNDLE_PATH:-vendor/bundle}
   - bundle exec rake librarian:install


### PR DESCRIPTION
The TravisCI version of bundler is out of date, which can cause some problems
install dependencies. Updating bundler as part of the install setup is the
fix recommended by Travis (See travis-ci/travis-ci#3531)

More info: https://github.com/rubygems/rubygems/issues/1419