### PR TITLE
Add router_nodes_file for router-api

### DIFF
--- a/hieradata_aws/class/draft_cache.yaml
+++ b/hieradata_aws/class/draft_cache.yaml
@@ -10,9 +10,9 @@ govuk::apps::router_api::mongodb_nodes:
   - 'router-backend-1'
   - 'router-backend-2'
   - 'router-backend-3'
-govuk::apps::router_api::router_nodes:
-  - 'draft-cache-1:3055'
-  - 'draft-cache-2:3055'
+
+govuk::apps::router_api::router_nodes_class: 'draft_cache'
+
 govuk::apps::router_api::vhost: 'draft-router-api'
 
 govuk::node::s_base::apps:

--- a/hieradata_aws/class/router_backend.yaml
+++ b/hieradata_aws/class/router_backend.yaml
@@ -5,10 +5,8 @@ govuk::apps::router_api::mongodb_nodes:
   - 'router-backend-1'
   - 'router-backend-2'
   - 'router-backend-3'
-govuk::apps::router_api::router_nodes:
-  - 'cache-1:3055'
-  - 'cache-2:3055'
-  - 'cache-3:3055'
+
+govuk::apps::router_api::router_nodes_class: 'cache'
 
 govuk::node::s_base::apps:
   - router_api


### PR DESCRIPTION
One of the functions of router-api is to send a reload routes request to the router.

Traditionally this has been achieved by hardcoding the hostnames of the router nodes, which hasn't been a problem because we set hostnames of all our machines.

In a dynamic environment this is more problematic because we don't know when machines will be respun and what hostname they'll use.

This adds a basic function that writes out the current nodes to a file, which router-api will then address when it reloads the routes.

Ref: https://github.com/alphagov/router-api/commit/27637862590867f315eea74d0722da827c48fed7

Ideally in the future this kind of function should be solved using a key/value store which is more in tune with dynamic environments, but this solves the problem for the short term.