### PR TITLE
Configure Sentry for email-alert-monitoring

### DIFF
--- a/modules/govuk_jenkins/manifests/job/email_alert_check.pp
+++ b/modules/govuk_jenkins/manifests/job/email_alert_check.pp
@@ -28,7 +28,6 @@ class govuk_jenkins::job::email_alert_check (
   $google_client_secret = undef,
   $emails_that_should_receive_drug_alerts = undef,
   $emails_that_should_receive_travel_advice_alerts = undef,
-  $errbit_api_key = undef,
   $app_domain = hiera('app_domain'),
   $sentry_dsn = undef,
 ) {

--- a/modules/govuk_jenkins/templates/jobs/drug_email_alert_check.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/drug_email_alert_check.yaml.erb
@@ -53,6 +53,6 @@
               - name: EMAILS_THAT_SHOULD_RECEIVE_DRUG_ALERTS
                 password:
                   '<%= @emails_that_should_receive_drug_alerts %>'
-              - name: ERRBIT_API_KEY
+              - name: SENTRY_DSN
                 password:
-                  '<%= @errbit_api_key %>'
+                  '<%= @sentry_dsn %>'

--- a/modules/govuk_jenkins/templates/jobs/travel_advice_email_alert_check.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/travel_advice_email_alert_check.yaml.erb
@@ -65,6 +65,6 @@
               - name: EMAILS_THAT_SHOULD_RECEIVE_TRAVEL_ADVICE_ALERTS
                 password:
                   '<%= @emails_that_should_receive_travel_advice_alerts %>'
-              - name: ERRBIT_API_KEY
+              - name: SENTRY_DSN
                 password:
-                  '<%= @errbit_api_key %>'
+                  '<%= @sentry_dsn %>'


### PR DESCRIPTION
This commit adds the `SENTRY_DSN` environment variable to the two email alert monitoring jobs in Jenkins.