### PR TITLE
Couple of changes to help clear up alerts

### DIFF
--- a/hieradata/class/backend.yaml
+++ b/hieradata/class/backend.yaml
@@ -69,7 +69,6 @@ govuk::node::s_base::apps:
   - need_api
   - policy_publisher
   - publisher
-  - publishing_api
   - release
   - search_admin
   - service_manual_publisher

--- a/hieradata_aws/class/backend.yaml
+++ b/hieradata_aws/class/backend.yaml
@@ -64,7 +64,6 @@ govuk::node::s_base::apps:
   - local_links_manager
   - manuals_publisher
   - maslow
-  - need_api
   - policy_publisher
   - publisher
   - release

--- a/hieradata_aws/class/backend.yaml
+++ b/hieradata_aws/class/backend.yaml
@@ -67,7 +67,6 @@ govuk::node::s_base::apps:
   - need_api
   - policy_publisher
   - publisher
-  - publishing_api
   - release
   - search_admin
   - service_manual_publisher

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -385,15 +385,6 @@ govuk::apps::local_links_manager::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::mapit::enabled: true
 govuk::apps::metadata_api::enabled: true
 
-govuk::apps::need_api::elasticsearch_hosts: 'elasticsearch:9200'
-
-govuk::apps::need_api::mongodb_nodes:
-  - 'mongo-1'
-  - 'mongo-2'
-  - 'mongo-3'
-
-govuk::apps::need_api::redis_host: "%{hiera('sidekiq_host')}"
-
 govuk::apps::rummager::rabbitmq_hosts:
   - rabbitmq-1
   - rabbitmq-2


### PR DESCRIPTION
Need API is being retired, and publishing-api should only run on the publishing-api
instances.

Note that the change to publishing-api also affects the current infrastructure, but
I do not believe that it is required to run on the backend machines.