### PR TITLE
Add asset manager header to emit location of files

### DIFF
--- a/modules/govuk/manifests/apps/asset_manager.pp
+++ b/modules/govuk/manifests/apps/asset_manager.pp
@@ -89,6 +89,7 @@ class govuk::apps::asset_manager(
       # publicly as it is an internal path mapping.
       location ~ /raw/(.*) {
         internal;
+        add_header GOVUK-Asset-Manager-File-Store NFS;
         alias /var/apps/asset-manager/uploads/assets/$1;
       }
 
@@ -107,6 +108,8 @@ class govuk::apps::asset_manager(
         # $is_args: Optional ? delimiter
         # $args:    Optional querystring params
         set $download_url $1$is_args$args;
+
+        add_header GOVUK-Asset-Manager-File-Store S3;
 
         # The X-CLOUD-STORAGE-URL header contains a signed URL for the asset on
         # S3. The signature of this URL is based in part on the request headers

--- a/modules/nginx/templates/etc/nginx/nginx.conf.erb
+++ b/modules/nginx/templates/etc/nginx/nginx.conf.erb
@@ -61,6 +61,7 @@ http {
                          '"govuk_original_url": "$http_govuk_original_url", '
                          '"govuk_dependency_resolution_source_content_id": "$http_govuk_dependency_resolution_source_content_id", '
                          '"govuk_abtest_educationnavigation": "$http_govuk_abtest_educationnavigation", '
+                         '"govuk_asset_manager_file_store": "$sent_http_govuk_asset_manager_file_store", '
                          '"varnish_id": "$http_x_varnish", '
                          '"ssl_protocol": "$ssl_protocol", '
                          '"ssl_cipher": "$ssl_cipher" } }';


### PR DESCRIPTION
The addition of this informational header will allow us to see whether an individual asset-manager request was served by an asset hosted on S3 or on NFS. Writing the value of the header to the `json_event` nginx log will mean that it ends up in Kibana and we'll be able to use this to monitor the proportion of requests being served by assets hosted on S3 vs NFS. This is all related to the work we're doing to host assets on S3.

I've tested this change on the Developer VM and can confirm that the HTTP header is added as expected and that the value of the header is written to the log file.

I'm slightly uncomfortable with the header being written to nginx log files for _all_ apps but there seems to be some precedent for this in PR #5577.