### PR TITLE
Remove metadata api

### DIFF
--- a/development-vm/Pinfile
+++ b/development-vm/Pinfile
@@ -48,7 +48,6 @@ process :'manuals-frontend' => [:static, :'content-store']
 process :'manuals-publisher' => ['asset-manager', :rummager, :'publishing-api']
 process :mapit
 process :maslow => :need_api
-process :'metadata-api' => [:need_api]
 process :need_api
 process :'performanceplatform-admin' => [:stagecraft]
 process :'policy-publisher' => [:'publishing-api', :rummager]

--- a/development-vm/Procfile
+++ b/development-vm/Procfile
@@ -89,8 +89,6 @@ service-manual:        govuk_setenv service-manual        ./run_in.sh ../../gove
 # collections-api used port3084
 info-frontend:         govuk_setenv info-frontend         ./run_in.sh ../../info-frontend bundle exec rails server -p 3085
 # sidekiq-monitoring for transition uses port 3086
-# metadata-api uses port 3087
-metadata-api:          govuk_setenv metadata-api          ./run_go.sh metadata-api          make run
 email-alert-api:       govuk_setenv email-alert-api       ./run_in.sh ../../email-alert-api bundle exec foreman start
 email-alert-service:   govuk_setenv email-alert-service   ./run_in.sh ../../email-alert-service bundle exec bin/email_alert_service
 # sidekiq-monitoring for email-alert-api uses port 3089

--- a/development-vm/alphagov_repos
+++ b/development-vm/alphagov_repos
@@ -30,7 +30,6 @@ manuals-frontend
 manuals-publisher
 mapit
 maslow
-metadata-api
 policy-publisher
 publisher
 publishing-api

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -372,7 +372,6 @@ govuk::apps::local_links_manager::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::local_links_manager::redis_port: "%{hiera('sidekiq_port')}"
 
 govuk::apps::mapit::enabled: true
-govuk::apps::metadata_api::enabled: true
 
 govuk::apps::need_api::elasticsearch_hosts: 'api-elasticsearch-1.api:9200'
 

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -926,10 +926,6 @@ grafana::dashboards::deployment_applications:
     # Very low usage
     show_controller_errors: false
     show_slow_requests: false
-  metadata-api:
-    # status instead of @fields.status, missing duration, controller
-    show_controller_errors: false
-    show_slow_requests: false
   publisher:
     has_workers: true
   publishing-api:

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1052,7 +1052,6 @@ hosts::production::api::app_hostnames:
   - 'backdrop-write'
   - 'content-store'
   - 'mapit'
-  - 'metadata-api'
   - 'rummager'
   - 'search'
   - 'stagecraft'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -53,7 +53,6 @@ deployable_applications: &deployable_applications
   manuals-publisher: {}
   mapit: {}
   maslow: {}
-  metadata-api: {}
   performanceplatform-admin: {}
   performanceplatform-big-screen-view: {}
   policy-publisher: {}

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -289,7 +289,6 @@ hosts::development::apps:
   - 'manuals-publisher'
   - 'mapit'
   - 'maslow'
-  - 'metadata-api'
   - 'need-api'
   - 'performanceplatform-admin'
   - 'policy-publisher'

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -938,10 +938,6 @@ grafana::dashboards::deployment_applications:
     # Very low usage
     show_controller_errors: false
     show_slow_requests: false
-  metadata-api:
-    # status instead of @fields.status, missing duration, controller
-    show_controller_errors: false
-    show_slow_requests: false
   publisher:
     has_workers: true
   publishing-api:

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -383,7 +383,6 @@ govuk::apps::local_links_manager::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::local_links_manager::redis_port: "%{hiera('sidekiq_port')}"
 
 govuk::apps::mapit::enabled: true
-govuk::apps::metadata_api::enabled: true
 
 govuk::apps::need_api::elasticsearch_hosts: 'elasticsearch:9200'
 

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -60,7 +60,6 @@ deployable_applications: &deployable_applications
   manuals-publisher: {}
   mapit: {}
   maslow: {}
-  metadata-api: {}
   performanceplatform-admin: {}
   performanceplatform-big-screen-view: {}
   policy-publisher: {}

--- a/modules/govuk/manifests/node/s_api_lb.pp
+++ b/modules/govuk/manifests/node/s_api_lb.pp
@@ -17,7 +17,6 @@ class govuk::node::s_api_lb (
   loadbalancer::balance {
     [
       'backdrop-read',
-      'metadata-api',
       'stagecraft',
     ]:
       servers       => $api_servers,

--- a/modules/grafana/files/dashboards/processes.json
+++ b/modules/grafana/files/dashboards/processes.json
@@ -1342,11 +1342,6 @@
             "selected": false
           },
           {
-            "text": "processes-app-metadata-api",
-            "value": "processes-app-metadata-api",
-            "selected": false
-          },
-          {
             "text": "processes-app-need-api",
             "value": "processes-app-need-api",
             "selected": false

--- a/training-vm/provisioner/alphagov_apps
+++ b/training-vm/provisioner/alphagov_apps
@@ -23,7 +23,6 @@ local-links-manager
 manuals-frontend
 manuals-publisher
 maslow
-metadata-api
 need-api
 policy-publisher
 publisher

--- a/training-vm/provisioner/alphagov_repos
+++ b/training-vm/provisioner/alphagov_repos
@@ -29,7 +29,6 @@ manuals-frontend
 manuals-publisher
 mapit
 maslow
-metadata-api
 policy-publisher
 publisher
 publishing-api


### PR DESCRIPTION
For: https://trello.com/c/pKthUgvD/199-retire-metadata-api

This removes the metadata-api application. 

The last part of removing metadata-api config is done here: https://github.com/alphagov/govuk-puppet/pull/6412, which will be merged after this current PR is deployed and tested. 