### PR TITLE
Override default postgresql max_connections for Puppetdb

### DIFF
--- a/hieradata/class/puppetmaster.yaml
+++ b/hieradata/class/puppetmaster.yaml
@@ -1,3 +1,4 @@
 ---
 
 govuk_postgresql::server::listen_addresses: localhost
+govuk_postgresql::server::max_connections: 100


### PR DESCRIPTION
Override the default 200 max_connections Postgres parameter
in Puppetdb to match the VM resources. Set parameter with previous
value (100)