### PR TITLE
Add Puppet for Asset Master in AWS

### DIFF
--- a/modules/assets/manifests/init.pp
+++ b/modules/assets/manifests/init.pp
@@ -34,9 +34,16 @@ class assets (
   if $mount_asset_master {
     $app_domain = hiera('app_domain')
 
+    if $::aws_migration {
+      $app_domain_internal = hiera('app_domain_internal')
+      $mount_point = "assets.${app_domain_internal}:/"
+    } else {
+      $mount_point = "asset-master.${app_domain}:/mnt/uploads"
+    }
+
     mount { '/data/uploads':
       ensure   => 'mounted',
-      device   => "asset-master.${app_domain}:/mnt/uploads",
+      device   => $mount_point,
       fstype   => 'nfs',
       options  => 'rw,soft',
       remounts => false,

--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -360,9 +360,7 @@ class govuk::apps::whitehall(
       }
     }
 
-    # FIXME: this should be removed after AWS testing has been completed and
-    # assets is up and running
-    if $::govuk_node_class =~ /^(development|training)$/ or $::aws_migration {
+    if $::govuk_node_class =~ /^(development|training)$/ {
       # Create the directory structure for whitehall assets in development
       $asset_directories = [
         '/data/uploads/whitehall',

--- a/modules/govuk/manifests/node/s_asset_base.pp
+++ b/modules/govuk/manifests/node/s_asset_base.pp
@@ -45,8 +45,26 @@ class govuk::node::s_asset_base (
   include assets::user
   include clamav
 
+  if $::aws_migration {
+    $app_domain_internal = hiera('app_domain_internal')
+    $mount_point = "assets.${app_domain_internal}:/"
+
+    package { 'nfs-common':
+      ensure => 'present',
+    }
+
+    mount { '/mnt/uploads':
+      ensure   => 'mounted',
+      device   => $mount_point,
+      fstype   => 'nfs',
+      options  => 'rw,soft',
+      remounts => false,
+      atboot   => true,
+      require  => [File['/mnt/uploads'], Package['nfs-common']],
+    }
+  }
+
   $directories = [
-    '/mnt/uploads',
     '/mnt/uploads/whitehall',
     '/mnt/uploads/whitehall/attachment-cache',
     '/mnt/uploads/whitehall/bulk-upload-zip-file-tmp',
@@ -60,45 +78,87 @@ class govuk::node::s_asset_base (
     '/mnt/uploads/whitehall/infected',
   ]
 
-  file { $directories:
-    ensure  => directory,
-    owner   => 'assets',
-    group   => 'assets',
-    mode    => '0775',
-    purge   => false,
-    require => [
-      Group['assets'],
-      User['assets'],
-      Govuk_mount['/mnt/uploads']
-    ],
-  }
+  if $::aws_migration {
+    # Ensure that /mnt/uploads dir is created before mounting to EFS, and
+    # the rest of the directories are created after mounting to the EFS share
+    file { '/mnt/uploads':
+      ensure  => directory,
+      owner   => 'assets',
+      group   => 'assets',
+      mode    => '0775',
+      purge   => false,
+      require => [
+        Group['assets'],
+        User['assets'],
+      ],
+    }
 
-  file { '/etc/exports':
-    ensure  => present,
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0644',
-    content => '/mnt/uploads     10.0.0.0/8(rw,fsid=0,insecure,no_subtree_check,async,all_squash,anonuid=2900,anongid=2900)',
-    require => File['/mnt/uploads'],
-    notify  => Service['nfs-kernel-server'],
-  }
+    file { $directories:
+      ensure  => directory,
+      owner   => 'assets',
+      group   => 'assets',
+      mode    => '0775',
+      purge   => false,
+      require => [
+        Group['assets'],
+        User['assets'],
+        Mount['/mnt/uploads'],
+      ],
+    }
+  } else {
+    file { '/mnt/uploads':
+      ensure  => directory,
+      owner   => 'assets',
+      group   => 'assets',
+      mode    => '0775',
+      purge   => false,
+      require => [
+        Group['assets'],
+        User['assets'],
+        Govuk_mount['/mnt/uploads']
+      ],
+    }
 
-  ufw::allow { 'Allow all access from backend machines':
-    from => $firewall_allow_ip_range,
-  }
+    file { $directories:
+      ensure  => directory,
+      owner   => 'assets',
+      group   => 'assets',
+      mode    => '0775',
+      purge   => false,
+      require => [
+        Group['assets'],
+        User['assets'],
+        Govuk_mount['/mnt/uploads']
+      ],
+    }
 
-  package { 'nfs-kernel-server':
-    ensure => installed,
-  }
+    file { '/etc/exports':
+      ensure  => present,
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
+      content => '/mnt/uploads     10.0.0.0/8(rw,fsid=0,insecure,no_subtree_check,async,all_squash,anonuid=2900,anongid=2900)',
+      require => File['/mnt/uploads'],
+      notify  => Service['nfs-kernel-server'],
+    }
 
-  service { 'nfs-kernel-server':
-    ensure    => running,
-    hasstatus => true,
-    require   => Package['nfs-kernel-server'],
-  }
+    ufw::allow { 'Allow all access from backend machines':
+      from => $firewall_allow_ip_range,
+    }
 
-  collectd::plugin { 'nfs':
-    require   => Package['nfs-kernel-server'],
+    package { 'nfs-kernel-server':
+      ensure => installed,
+    }
+
+    service { 'nfs-kernel-server':
+      ensure    => running,
+      hasstatus => true,
+      require   => Package['nfs-kernel-server'],
+    }
+
+    collectd::plugin { 'nfs':
+      require   => Package['nfs-kernel-server'],
+    }
   }
 
   file { '/usr/local/bin/virus_scan.sh':

--- a/modules/govuk/manifests/node/s_asset_base.pp
+++ b/modules/govuk/manifests/node/s_asset_base.pp
@@ -205,6 +205,11 @@ class govuk::node::s_asset_base (
     mode    => '0755',
   }
 
+  file { '/var/run/virus_scan':
+    ensure => directory,
+    owner  => 'assets',
+  }
+
   if $s3_bucket {
 
     package { 's3cmd':
@@ -237,11 +242,6 @@ class govuk::node::s_asset_base (
       owner   => 'assets',
       group   => 'assets',
       mode    => '0640';
-    }
-
-    file { '/var/run/virus_scan':
-      ensure => directory,
-      owner  => 'assets',
     }
 
     if $s3_env_sync_enabled {


### PR DESCRIPTION
In AWS we're making use of EFS.

Traditionally we created a large disk on the asset-master and then exported that to our backend machines.

In AWS we're creating an EFS disk, and mounting it onto each server that requires it. Asset master can do all the virus scan stuff it needs to do, and the backend machines can access and upload to the same EFS mount as required.

https://trello.com/c/YGAQ2KDD/732-aws-migration-asset-master-asset-slave