### PR TITLE
Revert "Bump max_connections to postgres"

### DIFF
--- a/hieradata/class/production/postgresql_primary.yaml
+++ b/hieradata/class/production/postgresql_primary.yaml
@@ -11,3 +11,5 @@ lv:
   data:
     pv: '/dev/sdd1'
     vg: 'postgresql'
+
+govuk_postgresql::server::max_connections: 200

--- a/hieradata/class/production/postgresql_standby.yaml
+++ b/hieradata/class/production/postgresql_standby.yaml
@@ -1,0 +1,1 @@
+govuk_postgresql::server::max_connections: 200

--- a/hieradata/class/staging/postgresql_primary.yaml
+++ b/hieradata/class/staging/postgresql_primary.yaml
@@ -1,0 +1,1 @@
+govuk_postgresql::server::max_connections: 120

--- a/hieradata/class/staging/postgresql_standby.yaml
+++ b/hieradata/class/staging/postgresql_standby.yaml
@@ -1,0 +1,1 @@
+govuk_postgresql::server::max_connections: 120

--- a/modules/govuk_postgresql/manifests/server.pp
+++ b/modules/govuk_postgresql/manifests/server.pp
@@ -29,7 +29,7 @@ class govuk_postgresql::server (
     $snakeoil_ssl_key,
     $listen_addresses = '*',
     $configure_env_sync_user = false,
-    $max_connections = 200,
+    $max_connections = 100,
 ) {
   if !(
     defined(Class["${name}::standalone"]) or


### PR DESCRIPTION
Reverts alphagov/govuk-puppet#6356. 

Yesterday on integration, this change caused postgres to crash (I think) because the standby had less connections configured than master. I'm assuming that this was because puppet had run on standby first, then master.
 
@36degrees posted this in slack:

```
2017-09-05 15:31:16 UTC FATAL:  hot standby is not possible because max_connections = 100 is a lower setting than on the master server (its value was 200)
```

I'm reverting this change to make sure we don't accidently change connection limits on production.