### PR TITLE
Proxy 50% of asset-manager requests to S3

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -27,6 +27,7 @@ cron::daily_hour: 6
 
 govuk::apps::asset_manager::aws_s3_bucket_name: 'govuk-assets-integration'
 govuk::apps::asset_manager::aws_region: 'eu-west-1'
+govuk::apps::asset_manager::proxy_percentage_of_asset_requests_to_s3_via_nginx: '50'
 govuk::apps::content_performance_manager::feature_auditing_allocation: true
 govuk::apps::content_performance_manager::feature_auditing_theme_filtering: true
 govuk::apps::email_alert_api::allow_govdelivery_topic_syncing: true


### PR DESCRIPTION
We've uploaded all assets to S3 in integration. Setting this option to
50% will allow us to test that asset requests are being served by both
NFS and S3 before we roll this out in production.

I've tested this by setting the same option in development.yaml, running
`govuk_puppet` and checking that
/etc/govuk/asset-manager/env.d/PROXY_PERCENTAGE_OF_ASSET_REQUESTS_TO_S3_VIA_NGINX
contains '50'.