### PR TITLE
Proxy 20% of asset-manager requests to S3 in production

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -68,6 +68,7 @@ environment_ip_prefix: '10.3'
 
 govuk::apps::asset_manager::aws_s3_bucket_name: 'govuk-assets-production'
 govuk::apps::asset_manager::aws_region: 'eu-west-1'
+govuk::apps::asset_manager::proxy_percentage_of_asset_requests_to_s3_via_nginx: '20'
 govuk::apps::content_performance_manager::feature_auditing_allocation: false
 govuk::apps::content_performance_manager::feature_auditing_theme_filtering: false
 govuk::apps::email_alert_api::db::backend_ip_range: '10.3.3.0/24'


### PR DESCRIPTION
Enabling the proxying-to-S3 functionality for 20% of asset-manager requests will allow us to keep an eye on the app/server performance before rolling it out further.