### PR TITLE
Add Nginx proxy entry for docs.content-api.publishing...

### DIFF
--- a/modules/govuk/manifests/node/s_backend_lb.pp
+++ b/modules/govuk/manifests/node/s_backend_lb.pp
@@ -127,4 +127,8 @@ class govuk::node::s_backend_lb (
     protected => false,
     http_host => 'govuk-developer-documentation-production.s3-website-eu-west-1.amazonaws.com',
   }
+
+  nginx::config::vhost::proxy { "content-api.${app_domain}" :
+    to => ['alphagov.github.io/govuk-content-api-docs'],
+  }
 }


### PR DESCRIPTION
This will be hosted by GitHub Pages, the DNS entry will come later.

[Trello Card](https://trello.com/c/09DCw1RQ/1080-2-create-api-documentation-domain)