### PR TITLE
Add Elasticsearch URI to licencefinder

### DIFF
--- a/modules/govuk/manifests/apps/licencefinder.pp
+++ b/modules/govuk/manifests/apps/licencefinder.pp
@@ -81,4 +81,12 @@ class govuk::apps::licencefinder(
     varname => 'PUBLISHING_API_BEARER_TOKEN',
     value   => $publishing_api_bearer_token,
   }
+
+  if $::aws_migration {
+    govuk::app::envvar { "${title}-ELASTICSEARCH_URI":
+      app     => $app_name,
+      varname => 'ELASTICSEARCH_URI',
+      value   => 'http://elasticsearch:9200',
+    }
+  }
 }


### PR DESCRIPTION
As per the change here:

https://github.com/alphagov/licence-finder/commit/84bd22f519f670d1efb8d49ca052428ececdff5f