### PR TITLE
Add publicapi to cache instead of frontend-lb

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -522,6 +522,7 @@ govuk_ci::agent::gcloud::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 govuk::deploy::config::asset_root: "https://%{hiera('router::assets_origin::vhost_name')}"
 govuk::deploy::config::website_root: "https://www-origin.%{hiera('app_domain')}"
+govuk::deploy::config::app_domain: "%{hiera('app_domain')}"
 
 govuk_ghe_vpn::openconnect_version: '6.00-0~21~ubuntu14.04.1'
 

--- a/hieradata_aws/class/cache.yaml
+++ b/hieradata_aws/class/cache.yaml
@@ -7,3 +7,5 @@ govuk::apps::authenticating_proxy::mongodb_nodes:
 govuk::node::s_base::apps:
   - publicapi
   - public_event_store
+
+govuk::deploy::config::app_domain: "%{hiera('app_domain_internal')}"

--- a/hieradata_aws/class/cache.yaml
+++ b/hieradata_aws/class/cache.yaml
@@ -3,3 +3,7 @@ govuk::apps::authenticating_proxy::mongodb_nodes:
   - 'router-backend-1'
   - 'router-backend-2'
   - 'router-backend-3'
+
+govuk::node::s_base::apps:
+  - publicapi
+  - public_event_store

--- a/hieradata_aws/class/calculators_frontend.yaml
+++ b/hieradata_aws/class/calculators_frontend.yaml
@@ -6,3 +6,5 @@ govuk::node::s_base::apps:
   - finder_frontend
   - licencefinder
   - smartanswers
+
+govuk::deploy::config::app_domain: "%{hiera('app_domain_internal')}"

--- a/hieradata_aws/class/frontend.yaml
+++ b/hieradata_aws/class/frontend.yaml
@@ -15,3 +15,5 @@ govuk::node::s_base::apps:
 govuk::apps::contacts::db_hostname: 'mysql-slave-1'
 govuk::apps::contacts::db_username: 'contacts_fe'
 govuk::apps::contacts::db_password: "%{hiera('govuk::apps::contacts::db::mysql_contacts_frontend')}"
+
+govuk::deploy::config::app_domain: "%{hiera('app_domain_internal')}"

--- a/hieradata_aws/class/frontend_lb.yaml
+++ b/hieradata_aws/class/frontend_lb.yaml
@@ -1,5 +1,0 @@
----
-
-govuk::node::s_base::apps:
-  - publicapi
-  - public_event_store

--- a/hieradata_aws/class/whitehall_frontend.yaml
+++ b/hieradata_aws/class/whitehall_frontend.yaml
@@ -11,3 +11,5 @@ govuk::node::s_base::apps:
 
 govuk_safe_to_reboot::can_reboot: 'overnight'
 govuk_safe_to_reboot::reason: 'Whitehall application is slow to start, recommend rebooting a single node at a time'
+
+govuk::deploy::config::app_domain: "%{hiera('app_domain_internal')}"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1095,8 +1095,6 @@ router::assets_origin::asset_routes:
   '/licencefinder/': "licencefinder"
   '/service-manual-frontend/': "service-manual-frontend"
   '/smartanswers/': "smartanswers"
-  '/spotlight/': "spotlight"
-  '/stagecraft/': "stagecraft"
 
 router::assets_origin::vhost_aliases:
   - 'assets.digital.cabinet-office.gov.uk'

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -529,6 +529,7 @@ govuk_ci::agent::gcloud::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 govuk::deploy::config::asset_root: "https://%{hiera('router::assets_origin::vhost_name')}"
 govuk::deploy::config::website_root: "https://www-origin.%{hiera('app_domain')}"
+govuk::deploy::config::app_domain: "%{hiera('app_domain')}"
 govuk::deploy::setup::gemstash_server: 'http://gemstash'
 
 govuk_ghe_vpn::openconnect_version: '6.00-0~21~ubuntu14.04.1'

--- a/modules/govuk/manifests/deploy/config.pp
+++ b/modules/govuk/manifests/deploy/config.pp
@@ -19,11 +19,15 @@
 # [*website_root*]
 #   The location that the website is served from, including protocol.
 #
+# [*app_domain*]
+#   The app domain for the environment eg dev.gov.uk
+#
 class govuk::deploy::config(
   $asset_root,
   $errbit_environment_name = '',
   $govuk_env = 'production',
   $website_root,
+  $app_domain,
 ){
 
   limits::limits { 'deploy_nofile':
@@ -75,8 +79,6 @@ class govuk::deploy::config(
     force   => true,
     require => File['/etc/govuk'],
   }
-
-  $app_domain = hiera('app_domain')
 
   govuk_envvar {
     'GOVUK_ENV': value => $govuk_env;

--- a/modules/router/manifests/assets_origin.pp
+++ b/modules/router/manifests/assets_origin.pp
@@ -25,12 +25,13 @@ class router::assets_origin(
 ) {
   validate_array($vhost_aliases)
 
-  $app_domain = hiera('app_domain')
   $enable_ssl = hiera('nginx_enable_ssl', true)
 
   if $::aws_migration {
+    $app_domain = hiera('app_domain_internal')
     $upstream_ssl = true
   } else {
+    $app_domain = hiera('app_domain')
     $upstream_ssl = $enable_ssl
   }
 

--- a/modules/router/manifests/errorpage.pp
+++ b/modules/router/manifests/errorpage.pp
@@ -1,6 +1,12 @@
 # FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
 define router::errorpage () {
 
+  if $::aws_migration {
+    $app_domain = hiera('app_domain_internal')
+  } else {
+    $app_domain = hiera('app_domain')
+  }
+
   # Only triggers every 6h or if the file doesn't exist.
   $filename = "/usr/share/nginx/www/${title}.html"
 
@@ -10,7 +16,6 @@ define router::errorpage () {
     $cmd = "aws --region eu-west-1 s3 cp ${s3_url} ${filename}"
 
   } else {
-    $app_domain = hiera('app_domain')
     $static_url = "https://static.${app_domain}/templates/${title}.html.erb"
     $cmd = "curl --connect-timeout 1 -sf ${static_url} -o ${filename}"
   }

--- a/spec/fixtures/hieradata/common.yaml
+++ b/spec/fixtures/hieradata/common.yaml
@@ -13,6 +13,7 @@ govuk_ci::agent::gcloud::apt_mirror_hostname: 'apt.example.com'
 
 govuk::deploy::config::asset_root: 'http://assets.example.com'
 govuk::deploy::config::website_root: 'http://www.example.com'
+govuk::deploy::config::app_domain: 'foo.example.com'
 
 govuk_mount::no_op: false
 


### PR DESCRIPTION
In an attempt to completely remove frontend-lb, add publicapi application to cache instances instead.

The plan is to update the DNS record to point at the cache elb, so it will automatically forward requests to itself, and then nginx will pick up requests with the host header and forward requests to the relevant machines.

https://trello.com/c/O7RiQxH2/714-remove-aws-frontend-lb-machines