### PR TITLE
Fix configuration of Content API docs domain

### DIFF
--- a/modules/govuk/manifests/node/s_backend_lb.pp
+++ b/modules/govuk/manifests/node/s_backend_lb.pp
@@ -129,6 +129,7 @@ class govuk::node::s_backend_lb (
   }
 
   nginx::config::vhost::proxy { "content-api.${app_domain}" :
-    to => ['alphagov.github.io/govuk-content-api-docs'],
+    to        => ['alphagov.github.io'],
+    protected => false,
   }
 }


### PR DESCRIPTION
[Trello Card](https://trello.com/c/09DCw1RQ/1080-2-create-api-documentation-domain)