### PR TITLE
Update integration asset slave disks

### DIFF
--- a/hieradata/node/asset-slave-1.backend.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/asset-slave-1.backend.integration.publishing.service.gov.uk.yaml
@@ -2,10 +2,10 @@
 lv:
   data:
     pv:
+      - '/dev/sdb1'
       - '/dev/sdc1'
-      - '/dev/sdd1'
     vg: 'uploads'
   cache:
     pv:
-      - '/dev/sda1'
+      - '/dev/sdd1'
     vg: 'duplicity'


### PR DESCRIPTION
After reboot the disks changed their labels, so Puppet is incorrect for
managing the LVM volumes.

We should check how to change the configuration to use UUIDs.