### PR TITLE
Proxy 100% of asset-manager-requests to S3 in production

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -68,7 +68,7 @@ environment_ip_prefix: '10.3'
 
 govuk::apps::asset_manager::aws_s3_bucket_name: 'govuk-assets-production'
 govuk::apps::asset_manager::aws_region: 'eu-west-1'
-govuk::apps::asset_manager::proxy_percentage_of_asset_requests_to_s3_via_nginx: '20'
+govuk::apps::asset_manager::proxy_percentage_of_asset_requests_to_s3_via_nginx: '100'
 govuk::apps::content_performance_manager::feature_auditing_allocation: false
 govuk::apps::content_performance_manager::feature_auditing_theme_filtering: false
 govuk::apps::email_alert_api::db::backend_ip_range: '10.3.3.0/24'


### PR DESCRIPTION
We've been proxying 20% of requests to S3 since Thu 7 Sep. We're
confident that everything is working as expected and that the change
hasn't had any negative effects (see
https://github.com/alphagov/asset-manager/issues/153 for more info) so
we're now ramping up to 100%.