### PR TITLE
Make search benchmark alerts non-critical

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/benchmark_search.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/benchmark_search.yaml.erb
@@ -38,6 +38,7 @@
               predefined-parameters: |
                   NSCA_CHECK_DESCRIPTION=<%= @service_description %>
                   NSCA_OUTPUT=<%= @service_description %> failed
+                  NSCA_CODE=1
     properties:
         - inject:
             properties-content: |


### PR DESCRIPTION
Downgrade the alert level from the default value of 2 (critical) to 1 (warning).

Search benchmark failures do not need to be investigated urgently. They just report on the current state of search results, and there are other services which monitor the availability of search which will alert us to more serious problems.

https://trello.com/c/vtGDAiVi/305-review-icinga-alert-thresholds