### PR TITLE
Properly wrap jenkins-cli

### DIFF
--- a/modules/govuk_jenkins/templates/jenkins-cli.erb
+++ b/modules/govuk_jenkins/templates/jenkins-cli.erb
@@ -5,4 +5,4 @@ if [ "$EUID" -ne 0 ]
   exit 1
 fi
 
-/usr/bin/java -jar <%= @jenkins_home %>/jenkins-cli.jar -s http://localhost:8080/ -http -auth <%= @jenkins_api_user %>:<%= @jenkins_api_token %> $1
+/usr/bin/java -jar <%= @jenkins_home %>/jenkins-cli.jar -s http://localhost:8080/ -http -auth <%= @jenkins_api_user %>:<%= @jenkins_api_token %> "$@"


### PR DESCRIPTION
I noticed the tool didn't work when trying to use it to deploy an app. This ensures all arguments are passed through correctly.