### PR TITLE
Simplify consumer class by removing exchanges

### DIFF
--- a/modules/govuk/manifests/apps/email_alert_service/rabbitmq_test_permissions.pp
+++ b/modules/govuk/manifests/apps/email_alert_service/rabbitmq_test_permissions.pp
@@ -31,11 +31,16 @@ class govuk::apps::email_alert_service::rabbitmq_test_permissions (
   $amqp_queue = 'email_alert_service_published_documents_test_queue',
 ) {
 
+  govuk_rabbitmq::exchange { "${amqp_exchange}@/":
+    ensure => present,
+    type   => 'topic',
+  } ->
+  
   govuk_rabbitmq::consumer { $amqp_user:
     amqp_pass        => $amqp_pass,
     amqp_exchange    => $amqp_exchange,
     amqp_queue       => $amqp_queue,
     routing_key      => '*.major.#',
-    is_test_exchange => true,
+    write_permission => "^(amq\\.gen.*|${amqp_queue}|${amqp_exchange})\$",
   }
 }

--- a/modules/govuk_rabbitmq/spec/defines/govuk_rabbitmq__consumer_spec.rb
+++ b/modules/govuk_rabbitmq/spec/defines/govuk_rabbitmq__consumer_spec.rb
@@ -127,37 +127,4 @@ describe 'govuk_rabbitmq::consumer', :type => :define do
 
     it { is_expected.not_to contain_govuk_rabbitmq__exchange }
   end
-
-  context 'for a test exchange' do
-    let(:params) {{
-      :amqp_pass => 'super_secret',
-      :amqp_exchange => 'an_exchange',
-      :amqp_queue => 'a_queue',
-      :routing_key => 'some routing key',
-      :is_test_exchange => true,
-    }}
-
-    it { is_expected.to contain_govuk_rabbitmq__exchange('an_exchange@/').with_type('topic') }
-
-    it {
-      is_expected.to contain_rabbitmq_user_permissions('a_user@/').with(
-        :configure_permission => '^(amq\.gen.*|a_queue)$',
-        :write_permission => '^(amq\.gen.*|a_queue|an_exchange)$',
-        :read_permission => '^(amq\.gen.*|a_queue|an_exchange)$',
-      )
-    }
-  end
-
-  context 'creating the test exchange with a non-default type' do
-    let(:params) {{
-      :amqp_pass => 'super_secret',
-      :amqp_exchange => 'an_exchange',
-      :amqp_queue => 'a_queue',
-      :routing_key => 'some routing key',
-      :is_test_exchange => true,
-      :exchange_type => 'direct',
-    }}
-
-    it { is_expected.to contain_govuk_rabbitmq__exchange('an_exchange@/').with_type('direct') }
-  end
 end


### PR DESCRIPTION
RabbitMQ exchanges are only relevant to the publisher of the messages, so its a
bit weird for the consumer stuff to create these.

They're only used in one place for creating test infrastructure.

Simplifying the consumer makes it easier to change the search infrastructure.
At the moment this is difficult because there is a lot of logic for
constructing permission strings.

The ultimate goal is to separate queue creation so we can set up multiple
queues per consumer.

Trello: https://trello.com/c/k2L67c4a/272-cleanup-puppet-module-for-declaring-message-queue-consumers