### PR TITLE
Update docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,8 +17,8 @@ You can propose changes using a pull request.
 3. Commit your work (we like [commits that explain your thought process][commits])
 4. Open a pull request
 5. If you have write access, you can merge your own pull request once somebody
-   has reviewed it and given you a thumbs up 👍. If you don't have access, we'll
-   merge the pull request for you once it's ready.
+   has approved it. If you don't have access, we'll merge the pull request for
+   you once it's ready.
 
 [forking]: https://help.github.com/articles/fork-a-repo/
 [commits]: https://github.com/alphagov/styleguides/blob/master/git.md


### PR DESCRIPTION
## update CONTRIBUTING language around approvals

I guess this was written before github supported reviews and we
approved PRs using a thumbs-up emoji.  Now that we use github reviews
directly, this document could be tweaked slightly.

## remove docs around govuk_jenkins::config::admins

This is no longer needed, as of 01f6578.
