### PR TITLE
Separate permission logic, queues, test exchange creation from RabbitMQ consumer class

### DIFF
--- a/modules/govuk/manifests/apps/email_alert_service/rabbitmq.pp
+++ b/modules/govuk/manifests/apps/email_alert_service/rabbitmq.pp
@@ -29,9 +29,12 @@ class govuk::apps::email_alert_service::rabbitmq (
 ) {
 
   govuk_rabbitmq::consumer { $amqp_user:
-    amqp_pass     => $amqp_pass,
-    amqp_exchange => $amqp_exchange,
-    amqp_queue    => $amqp_queue,
-    routing_key   => '*.major.#',
+    amqp_pass            => $amqp_pass,
+    amqp_exchange        => $amqp_exchange,
+    amqp_queue           => $amqp_queue,
+    routing_key          => '*.major.#',
+    read_permission      => "^(amq\\.gen.*|${amqp_queue}|${amqp_exchange})\$",
+    write_permission     => "^(amq\\.gen.*|${amqp_queue})\$",
+    configure_permission => "^(amq\\.gen.*|${amqp_queue})\$",
   }
 }

--- a/modules/govuk/manifests/apps/email_alert_service/rabbitmq.pp
+++ b/modules/govuk/manifests/apps/email_alert_service/rabbitmq.pp
@@ -28,11 +28,15 @@ class govuk::apps::email_alert_service::rabbitmq (
   $amqp_queue = 'email_alert_service',
 ) {
 
+  govuk_rabbitmq::queue_with_binding { $amqp_queue:
+    amqp_exchange => $amqp_exchange,
+    amqp_queue    => $amqp_queue,
+    routing_key   => '*.major.#',
+    durable       => true,
+  } ->
+
   govuk_rabbitmq::consumer { $amqp_user:
     amqp_pass            => $amqp_pass,
-    amqp_exchange        => $amqp_exchange,
-    amqp_queue           => $amqp_queue,
-    routing_key          => '*.major.#',
     read_permission      => "^(amq\\.gen.*|${amqp_queue}|${amqp_exchange})\$",
     write_permission     => "^(amq\\.gen.*|${amqp_queue})\$",
     configure_permission => "^(amq\\.gen.*|${amqp_queue})\$",

--- a/modules/govuk/manifests/apps/email_alert_service/rabbitmq_test_permissions.pp
+++ b/modules/govuk/manifests/apps/email_alert_service/rabbitmq_test_permissions.pp
@@ -31,11 +31,16 @@ class govuk::apps::email_alert_service::rabbitmq_test_permissions (
   $amqp_queue = 'email_alert_service_published_documents_test_queue',
 ) {
 
+  govuk_rabbitmq::exchange { "${amqp_exchange}@/":
+    ensure => present,
+    type   => 'topic',
+  } ->
+  
   govuk_rabbitmq::consumer { $amqp_user:
     amqp_pass        => $amqp_pass,
     amqp_exchange    => $amqp_exchange,
     amqp_queue       => $amqp_queue,
     routing_key      => '*.major.#',
-    is_test_exchange => true,
+    write_permission => "^(amq\\.gen.*|${amqp_queue}|${amqp_exchange})\$",
   }
 }

--- a/modules/govuk/manifests/apps/email_alert_service/rabbitmq_test_permissions.pp
+++ b/modules/govuk/manifests/apps/email_alert_service/rabbitmq_test_permissions.pp
@@ -36,11 +36,15 @@ class govuk::apps::email_alert_service::rabbitmq_test_permissions (
     type   => 'topic',
   } ->
 
+  govuk_rabbitmq::queue_with_binding { $amqp_queue:
+    amqp_exchange => $amqp_exchange,
+    amqp_queue    => $amqp_queue,
+    routing_key   => '*.major.#',
+    durable       => true,
+  } ->
+
   govuk_rabbitmq::consumer { $amqp_user:
     amqp_pass            => $amqp_pass,
-    amqp_exchange        => $amqp_exchange,
-    amqp_queue           => $amqp_queue,
-    routing_key          => '*.major.#',
     read_permission      => "^(amq\\.gen.*|${amqp_queue}|${amqp_exchange})\$",
     write_permission     => "^(amq\\.gen.*|${amqp_queue}|${amqp_exchange})\$",
     configure_permission => "^(amq\\.gen.*|${amqp_queue})\$",

--- a/modules/govuk/manifests/apps/email_alert_service/rabbitmq_test_permissions.pp
+++ b/modules/govuk/manifests/apps/email_alert_service/rabbitmq_test_permissions.pp
@@ -35,12 +35,14 @@ class govuk::apps::email_alert_service::rabbitmq_test_permissions (
     ensure => present,
     type   => 'topic',
   } ->
-  
+
   govuk_rabbitmq::consumer { $amqp_user:
-    amqp_pass        => $amqp_pass,
-    amqp_exchange    => $amqp_exchange,
-    amqp_queue       => $amqp_queue,
-    routing_key      => '*.major.#',
-    write_permission => "^(amq\\.gen.*|${amqp_queue}|${amqp_exchange})\$",
+    amqp_pass            => $amqp_pass,
+    amqp_exchange        => $amqp_exchange,
+    amqp_queue           => $amqp_queue,
+    routing_key          => '*.major.#',
+    read_permission      => "^(amq\\.gen.*|${amqp_queue}|${amqp_exchange})\$",
+    write_permission     => "^(amq\\.gen.*|${amqp_queue}|${amqp_exchange})\$",
+    configure_permission => "^(amq\\.gen.*|${amqp_queue})\$",
   }
 }

--- a/modules/govuk/manifests/apps/rummager/rabbitmq.pp
+++ b/modules/govuk/manifests/apps/rummager/rabbitmq.pp
@@ -22,6 +22,8 @@ class govuk::apps::rummager::rabbitmq (
   $enable_publishing_listener = false,
 ) {
 
+  $amqp_exchange = 'published_documents'
+
   $toggled_ensure = $enable_publishing_listener ? {
     true    => present,
     default => absent,
@@ -34,22 +36,28 @@ class govuk::apps::rummager::rabbitmq (
 
   # match everything on queue 2 while we test
   govuk_rabbitmq::consumer { 'rummager-v2':
-    ensure        => $toggled_ensure,
-    amqp_pass     => $password,
-    amqp_exchange => 'published_documents',
-    amqp_queue    => 'rummager_to_be_indexed',
-    routing_key   => '*.links',
-    amqp_queue_2  => 'rummager_govuk_index',
-    routing_key_2 => '*.*',
+    ensure               => $toggled_ensure,
+    amqp_pass            => $password,
+    amqp_exchange        => $amqp_exchange,
+    amqp_queue           => 'rummager_to_be_indexed',
+    routing_key          => '*.links',
+    amqp_queue_2         => 'rummager_govuk_index',
+    routing_key_2        => '*.*',
+    read_permission      => "^(amq\\.gen.*|rummager_to_be_indexed|rummager_govuk_index|${amqp_exchange})\$",
+    write_permission     => "^(amq\\.gen.*|rummager_to_be_indexed|rummager_govuk_index)\$",
+    configure_permission => "^(amq\\.gen.*|rummager_to_be_indexed|rummager_govuk_index)\$",
   }
 
   # deprecated - we will remove this user once we have migrated to the new user
   govuk_rabbitmq::consumer { 'rummager':
-    ensure        => $toggled_ensure,
-    amqp_pass     => $password,
-    amqp_exchange => 'published_documents',
-    amqp_queue    => 'rummager_to_be_indexed',
-    routing_key   => '*.links',
-    create_queue  => false,
+    ensure               => $toggled_ensure,
+    amqp_pass            => $password,
+    amqp_exchange        => $amqp_exchange,
+    amqp_queue           => 'rummager_to_be_indexed',
+    routing_key          => '*.links',
+    create_queue         => false,
+    read_permission      => "^(amq\\.gen.*|rummager_to_be_indexed|${amqp_exchange})\$",
+    write_permission     => "^(amq\\.gen.*|rummager_to_be_indexed)\$",
+    configure_permission => "^(amq\\.gen.*|rummager_to_be_indexed)\$",
   }
 }

--- a/modules/govuk/manifests/apps/rummager/rabbitmq.pp
+++ b/modules/govuk/manifests/apps/rummager/rabbitmq.pp
@@ -29,33 +29,33 @@ class govuk::apps::rummager::rabbitmq (
     default => absent,
   }
 
-  $toggled_govuk_index_listener = $enable_govuk_index_listener ? {
-    true    => present,
-    default => absent,
-  }
+  govuk_rabbitmq::queue_with_binding { 'rummager_to_be_indexed':
+    amqp_exchange => $amqp_exchange,
+    amqp_queue    => 'rummager_to_be_indexed',
+    routing_key   => '*.links',
+    durable       => true,
+  } ->
+
+  govuk_rabbitmq::queue_with_binding { 'rummager_govuk_index':
+    amqp_exchange => $amqp_exchange,
+    amqp_queue    => 'rummager_govuk_index',
+    routing_key   => '*.*',
+    durable       => true,
+  } ->
 
   # match everything on queue 2 while we test
   govuk_rabbitmq::consumer { 'rummager-v2':
     ensure               => $toggled_ensure,
     amqp_pass            => $password,
-    amqp_exchange        => $amqp_exchange,
-    amqp_queue           => 'rummager_to_be_indexed',
-    routing_key          => '*.links',
-    amqp_queue_2         => 'rummager_govuk_index',
-    routing_key_2        => '*.*',
     read_permission      => "^(amq\\.gen.*|rummager_to_be_indexed|rummager_govuk_index|${amqp_exchange})\$",
     write_permission     => "^(amq\\.gen.*|rummager_to_be_indexed|rummager_govuk_index)\$",
     configure_permission => "^(amq\\.gen.*|rummager_to_be_indexed|rummager_govuk_index)\$",
-  }
+  } ->
 
   # deprecated - we will remove this user once we have migrated to the new user
   govuk_rabbitmq::consumer { 'rummager':
     ensure               => $toggled_ensure,
     amqp_pass            => $password,
-    amqp_exchange        => $amqp_exchange,
-    amqp_queue           => 'rummager_to_be_indexed',
-    routing_key          => '*.links',
-    create_queue         => false,
     read_permission      => "^(amq\\.gen.*|rummager_to_be_indexed|${amqp_exchange})\$",
     write_permission     => "^(amq\\.gen.*|rummager_to_be_indexed)\$",
     configure_permission => "^(amq\\.gen.*|rummager_to_be_indexed)\$",

--- a/modules/govuk_rabbitmq/manifests/consumer.pp
+++ b/modules/govuk_rabbitmq/manifests/consumer.pp
@@ -50,9 +50,11 @@ define govuk_rabbitmq::consumer (
   $amqp_exchange,
   $amqp_queue,
   $routing_key,
+  $write_permission,
+  $read_permission,
+  $configure_permission,
   $amqp_queue_2 = undef,
   $routing_key_2 = undef,
-  $write_permission = undef,
   $ensure = present,
   $create_queue = true,
 ) {
@@ -72,12 +74,6 @@ define govuk_rabbitmq::consumer (
 
   include ::govuk_rabbitmq
 
-  if $write_permission == undef {
-    $user_write_permission = "^(amq\\.gen.*|${amqp_queue_names})\$"
-  } else {
-    $user_write_permission = $write_permission
-  }
-
   if $ensure == present {
     rabbitmq_user { $amqp_user:
       ensure   => present,
@@ -85,9 +81,9 @@ define govuk_rabbitmq::consumer (
     } ->
     rabbitmq_user_permissions { "${amqp_user}@/":
       ensure               => present,
-      configure_permission => "^(amq\\.gen.*|${amqp_queue_names})\$",
-      write_permission     => $user_write_permission,
-      read_permission      => "^(amq\\.gen.*|${amqp_queue_names}|${amqp_exchange})\$",
+      read_permission      => $read_permission,
+      write_permission     => $write_permission,
+      configure_permission => $configure_permission,
     }
 
     if $create_queue {

--- a/modules/govuk_rabbitmq/manifests/consumer.pp
+++ b/modules/govuk_rabbitmq/manifests/consumer.pp
@@ -1,74 +1,33 @@
 # == Define: govuk_rabbitmq::consumer
 #
-# Creates a rabbitmq user with permissions typical for a consuming application.
-# This gives read permissions on the exchange, and read/write/configure
-# permissions on the queue.
-#
-# === Queue and Binding management
-#
-# '$ensure => absent' will remove the specified user, but will not affect queues and bindings.
-# To remove these, refer to govuk_rabbitmq::remove_queues and govuk_rabbitmq::remove_bindings.
-#
-# The provider for the rabbitmq_binding resource identifies instances without reference to the routing key.
-# This makes it rather awkward to add or change bindings on any queue which already has a binding, because the
-# provider will think the binding already exists even if the routing keys differ, and will assume
-# that no work needs doing.
-# At present the workaround for changing a binding is to create a new queue for the new binding. Then switch the
-# consumers over to the new queue, and remove the old queue.
-# We don't anticipate any use cases that require multiple bindings on a single queue.
+# Creates a rabbitmq user with specified permissions.
 #
 # === Parameters
 #
 # [*amqp_pass*]
 #   The RabbitMQ password for the $title user.
 #
-# [*amqp_exchange*]
-#   The RabbitMQ exchange to configure permissions for.
+# [*read_permission*]
+#   The read permission for the $title user.
 #
-# [*amqp_queue*]
-#   The RabbitMQ queue to create and configure permissions for.
+# [*write_permission*]
+#   The write permission for the $title user.
 #
-# [*routing_key*]
-#   The routing key to create a binding for on the RabbitMQ queue.
-#
-# [*amqp_queue_2*]
-#   Optional second RabbitMQ queue name.
-#
-# [*routing_key_2*]
-#   Optional second routing key.
+# [*configure_permission*]
+#   The configure permission for the $title user.
 #
 # [*ensure*]
 #   Determines whether to create or delete the consumer.
 #   (default: present)
 #
-# [*create_queue*]
-#   Can be used to skip queue creation, which is required if a queue is declared multiple times for different users.
-#   (default: true)
-#
 define govuk_rabbitmq::consumer (
   $amqp_pass,
-  $amqp_exchange,
-  $amqp_queue,
-  $routing_key,
   $write_permission,
   $read_permission,
   $configure_permission,
-  $amqp_queue_2 = undef,
-  $routing_key_2 = undef,
   $ensure = present,
-  $create_queue = true,
 ) {
   validate_re($ensure, '^(present|absent)$', '$ensure must be "present" or "absent"')
-  validate_re($routing_key, '^.+$', '$routing_key must be non-empty')
-  if $amqp_queue_2 {
-    validate_re($routing_key_2, '^.+$', '$routing_key_2 must be non-empty when amqp_queue_2 is set')
-  }
-
-  if $amqp_queue_2 {
-    $amqp_queue_names = "${amqp_queue}|${amqp_queue_2}"
-  } else {
-    $amqp_queue_names = $amqp_queue
-  }
 
   $amqp_user = $title
 
@@ -85,65 +44,9 @@ define govuk_rabbitmq::consumer (
       write_permission     => $write_permission,
       configure_permission => $configure_permission,
     }
-
-    if $create_queue {
-      rabbitmq_queue { "${amqp_queue}@/":
-        ensure      => present,
-        user        => 'root',
-        password    => $::govuk_rabbitmq::root_password,
-        durable     => true,
-        auto_delete => false,
-        arguments   => {},
-      } ->
-      rabbitmq_binding { "binding_${routing_key}_${amqp_exchange}@${amqp_queue}@/":
-        ensure           => present,
-        name             => "${amqp_exchange}@${amqp_queue}@/",
-        user             => 'root',
-        password         => $::govuk_rabbitmq::root_password,
-        destination_type => 'queue',
-        routing_key      => $routing_key,
-        arguments        => {},
-      }
-
-      if $amqp_queue_2 {
-        rabbitmq_queue { "${amqp_queue_2}@/":
-          ensure      => present,
-          user        => 'root',
-          password    => $::govuk_rabbitmq::root_password,
-          durable     => true,
-          auto_delete => false,
-          arguments   => {},
-        } ->
-        rabbitmq_binding { "binding_${routing_key_2}_${amqp_exchange}@${amqp_queue_2}@/":
-          ensure           => present,
-          name             => "${amqp_exchange}@${amqp_queue_2}@/",
-          user             => 'root',
-          password         => $::govuk_rabbitmq::root_password,
-          destination_type => 'queue',
-          routing_key      => $routing_key_2,
-          arguments        => {},
-        }
-      }
-    }
   } else {
     rabbitmq_user { $amqp_user:
       ensure   => absent,
-    }
-  }
-
-  if $create_queue {
-    govuk_rabbitmq::monitor_consumers {"${title}_${amqp_queue}_consumer_monitoring":
-      ensure            => $ensure,
-      rabbitmq_hostname => 'localhost',
-      rabbitmq_queue    => $amqp_queue,
-    }
-
-    if $amqp_queue_2 {
-      govuk_rabbitmq::monitor_consumers {"${title}_${amqp_queue_2}_consumer_monitoring":
-        ensure            => $ensure,
-        rabbitmq_hostname => 'localhost',
-        rabbitmq_queue    => $amqp_queue_2,
-      }
     }
   }
 }

--- a/modules/govuk_rabbitmq/manifests/queue_with_binding.pp
+++ b/modules/govuk_rabbitmq/manifests/queue_with_binding.pp
@@ -1,0 +1,68 @@
+# == Define: govuk_rabbitmq::queue_with_binding
+#
+# Creates a RabbitMQ queue, binds it to an exchange, and monitors it.
+# Users should be set up separately: when doing so, you need to include
+# read/write/configure permissions for the queue.
+#
+# === Modifying queues and bindings
+#
+# The provider for the rabbitmq_binding resource identifies instances without reference to the routing key.
+# This makes it rather awkward to add or change bindings on any queue which already has a binding, because the
+# provider will think the binding already exists even if the routing keys differ, and will assume
+# that no work needs doing.
+# At present the workaround for changing a binding is to create a new queue for the new binding. Then switch the
+# consumers over to the new queue, and remove the old queue.
+# Another side effect of this problem is you can't define more than one binding for a queue.
+# This may be fixed by https://github.com/voxpupuli/puppet-rabbitmq/pull/504
+#
+# govuk_rabbitmq::remove_queues and govuk_rabbitmq::remove_bindings can be used
+# to ensure old queues and bindings are cleaned up.
+#
+# === Parameters
+#
+# [*amqp_exchange*]
+#   The RabbitMQ exchange to configure permissions for.
+#
+# [*amqp_queue*]
+#   The RabbitMQ queue to create and configure permissions for.
+#
+# [*routing_key*]
+#   The routing key to create a binding for on the RabbitMQ queue.
+#
+# [*durable*]
+#   Queues can be durable or transient. Durable queues survive broker restart, transient queues do not.
+#   (default: true)
+#
+define govuk_rabbitmq::queue_with_binding (
+  $amqp_exchange,
+  $amqp_queue,
+  $routing_key,
+  $durable = true
+) {
+  validate_re($routing_key, '^.+$', '$routing_key must be non-empty')
+  $amqp_user = $title
+
+  rabbitmq_queue { "${amqp_queue}@/":
+    ensure      => present,
+    user        => 'root',
+    password    => $::govuk_rabbitmq::root_password,
+    durable     => $durable,
+    auto_delete => false,
+    arguments   => {},
+  } ->
+  rabbitmq_binding { "binding_${routing_key}_${amqp_exchange}@${amqp_queue}@/":
+    ensure           => present,
+    name             => "${amqp_exchange}@${amqp_queue}@/",
+    user             => 'root',
+    password         => $::govuk_rabbitmq::root_password,
+    destination_type => 'queue',
+    routing_key      => $routing_key,
+    arguments        => {},
+  }
+
+  govuk_rabbitmq::monitor_consumers {"${title}_${amqp_queue}_consumer_monitoring":
+    ensure            => present,
+    rabbitmq_hostname => 'localhost',
+    rabbitmq_queue    => $amqp_queue,
+  }
+}

--- a/modules/govuk_rabbitmq/spec/defines/govuk_rabbitmq__consumer_spec.rb
+++ b/modules/govuk_rabbitmq/spec/defines/govuk_rabbitmq__consumer_spec.rb
@@ -15,6 +15,9 @@ describe 'govuk_rabbitmq::consumer', :type => :define do
       :routing_key => 'some routing key',
       :amqp_queue_2 => 'a_second_queue',
       :routing_key_2 => 'another routing key',
+      :read_permission  => ".*",
+      :write_permission => "^$",
+      :configure_permission => "^a_second_queue$"
     }}
 
     it { is_expected.to contain_rabbitmq_user('a_user').with_password('super_secret') }
@@ -49,7 +52,10 @@ describe 'govuk_rabbitmq::consumer', :type => :define do
         :routing_key => 'some routing key',
         :amqp_queue_2 => 'a_second_queue',
         :routing_key_2 => 'another routing key',
-        :create_queue => false
+        :create_queue => false,
+        :read_permission  => '.*',
+        :write_permission => '^$',
+        :configure_permission => '^a_second_queue$'
       }}
 
       it {
@@ -60,9 +66,9 @@ describe 'govuk_rabbitmq::consumer', :type => :define do
 
     it {
       is_expected.to contain_rabbitmq_user_permissions('a_user@/').with(
-        :configure_permission => '^(amq\.gen.*|a_queue|a_second_queue)$',
-        :write_permission => '^(amq\.gen.*|a_queue|a_second_queue)$',
-        :read_permission => '^(amq\.gen.*|a_queue|a_second_queue|an_exchange)$',
+        :read_permission => '.*',
+        :write_permission => '^$',
+        :configure_permission => '^a_second_queue$',
       )
     }
 
@@ -75,6 +81,9 @@ describe 'govuk_rabbitmq::consumer', :type => :define do
       :amqp_exchange => 'an_exchange',
       :amqp_queue => 'a_queue',
       :routing_key => '',
+      :read_permission  => '.*',
+      :write_permission => '^$',
+      :configure_permission => '^a_queue$'
       }}
 
       it { is_expected.to raise_error(Puppet::Error, /\$routing_key must be non-empty/) }
@@ -88,6 +97,9 @@ describe 'govuk_rabbitmq::consumer', :type => :define do
       :routing_key => 'some routing key',
       :amqp_queue_2 => 'a_second_queue',
       :routing_key_2 => '',
+      :read_permission  => '.*',
+      :write_permission => '^$',
+      :configure_permission => '^a_second_queue$'
       }}
 
       it { is_expected.to raise_error(Puppet::Error, /\$routing_key_2 must be non-empty/) }
@@ -99,6 +111,9 @@ describe 'govuk_rabbitmq::consumer', :type => :define do
       :amqp_exchange => 'an_exchange',
       :amqp_queue => 'a_queue',
       :routing_key => 'some routing key',
+      :read_permission  => '.*',
+      :write_permission => '^$',
+      :configure_permission => '^a_queue$'
     }}
 
     it { is_expected.to contain_rabbitmq_user('a_user').with_password('super_secret') }
@@ -119,9 +134,9 @@ describe 'govuk_rabbitmq::consumer', :type => :define do
 
     it {
       is_expected.to contain_rabbitmq_user_permissions('a_user@/').with(
-        :configure_permission => '^(amq\.gen.*|a_queue)$',
-        :write_permission => '^(amq\.gen.*|a_queue)$',
-        :read_permission => '^(amq\.gen.*|a_queue|an_exchange)$',
+        :configure_permission => '^a_queue$',
+        :write_permission => '^$',
+        :read_permission => '.*',
       )
     }
 

--- a/modules/govuk_rabbitmq/spec/defines/govuk_rabbitmq__consumer_spec.rb
+++ b/modules/govuk_rabbitmq/spec/defines/govuk_rabbitmq__consumer_spec.rb
@@ -127,37 +127,4 @@ describe 'govuk_rabbitmq::consumer', :type => :define do
 
     it { is_expected.not_to contain_govuk_rabbitmq__exchange }
   end
-
-  context 'for a test exchange' do
-    let(:params) {{
-      :amqp_pass => 'super_secret',
-      :amqp_exchange => 'an_exchange',
-      :amqp_queue => 'a_queue',
-      :routing_key => 'some routing key',
-      :is_test_exchange => true,
-    }}
-
-    it { is_expected.to contain_govuk_rabbitmq__exchange('an_exchange@/').with_type('topic') }
-
-    it {
-      is_expected.to contain_rabbitmq_user_permissions('a_user@/').with(
-        :configure_permission => '^(amq\.gen.*|a_queue)$',
-        :write_permission => '^(amq\.gen.*|a_queue|an_exchange)$',
-        :read_permission => '^(amq\.gen.*|a_queue|an_exchange)$',
-      )
-    }
-  end
-
-  context 'creating the test exchange with a non-default type' do
-    let(:params) {{
-      :amqp_pass => 'super_secret',
-      :amqp_exchange => 'an_exchange',
-      :amqp_queue => 'a_queue',
-      :routing_key => 'some routing key',
-      :is_test_exchange => true,
-      :exchange_type => 'direct',
-    }}
-
-    it { is_expected.to contain_govuk_rabbitmq__exchange('an_exchange@/').with_type('direct') }
-  end
 end

--- a/modules/govuk_rabbitmq/spec/defines/govuk_rabbitmq__consumer_spec.rb
+++ b/modules/govuk_rabbitmq/spec/defines/govuk_rabbitmq__consumer_spec.rb
@@ -7,139 +7,20 @@ describe 'govuk_rabbitmq::consumer', :type => :define do
     staging_http_get: 'curl',
   }}
 
-  context 'multiple queues' do
-    let(:params) {{
-      :amqp_pass => 'super_secret',
-      :amqp_exchange => 'an_exchange',
-      :amqp_queue => 'a_queue',
-      :routing_key => 'some routing key',
-      :amqp_queue_2 => 'a_second_queue',
-      :routing_key_2 => 'another routing key',
-      :read_permission  => ".*",
-      :write_permission => "^$",
-      :configure_permission => "^a_second_queue$"
-    }}
+  let(:params) {{
+    :amqp_pass => 'super_secret',
+    :read_permission  => '.*',
+    :write_permission => '^$',
+    :configure_permission => '^a_queue$'
+  }}
 
-    it { is_expected.to contain_rabbitmq_user('a_user').with_password('super_secret') }
+  it { is_expected.to contain_rabbitmq_user('a_user').with_password('super_secret') }
 
-    it {
-      is_expected.to contain_rabbitmq_queue('a_queue@/').with(
-          :durable     => true,
-          :auto_delete => false,
-      )
-      is_expected.to contain_rabbitmq_queue('a_second_queue@/').with(
-          :durable     => true,
-          :auto_delete => false,
-      )
-    }
-
-    it {
-      is_expected.to contain_rabbitmq_binding('binding_some routing key_an_exchange@a_queue@/').with(
-          :destination_type => 'queue',
-          :routing_key      => 'some routing key',
-      )
-      is_expected.to contain_rabbitmq_binding('binding_another routing key_an_exchange@a_second_queue@/').with(
-          :destination_type => 'queue',
-          :routing_key      => 'another routing key',
-      )
-    }
-
-    context 'when create_queue is false' do
-      let(:params) {{
-        :amqp_pass => 'super_secret',
-        :amqp_exchange => 'an_exchange',
-        :amqp_queue => 'a_queue',
-        :routing_key => 'some routing key',
-        :amqp_queue_2 => 'a_second_queue',
-        :routing_key_2 => 'another routing key',
-        :create_queue => false,
-        :read_permission  => '.*',
-        :write_permission => '^$',
-        :configure_permission => '^a_second_queue$'
-      }}
-
-      it {
-        is_expected.not_to contain_rabbitmq_queue('a_queue@/')
-        is_expected.not_to contain_rabbitmq_queue('a_second_queue@/')
-      }
-    end
-
-    it {
-      is_expected.to contain_rabbitmq_user_permissions('a_user@/').with(
-        :read_permission => '.*',
-        :write_permission => '^$',
-        :configure_permission => '^a_second_queue$',
-      )
-    }
-
-    it { is_expected.not_to contain_govuk_rabbitmq__exchange }
-  end
-
-  context 'missing routing key' do
-    let(:params) {{
-      :amqp_pass => 'super_secret',
-      :amqp_exchange => 'an_exchange',
-      :amqp_queue => 'a_queue',
-      :routing_key => '',
-      :read_permission  => '.*',
+  it {
+    is_expected.to contain_rabbitmq_user_permissions('a_user@/').with(
+      :configure_permission => '^a_queue$',
       :write_permission => '^$',
-      :configure_permission => '^a_queue$'
-      }}
-
-      it { is_expected.to raise_error(Puppet::Error, /\$routing_key must be non-empty/) }
-  end
-
-  context 'missing routing key for optional queue' do
-    let(:params) {{
-      :amqp_pass => 'super_secret',
-      :amqp_exchange => 'an_exchange',
-      :amqp_queue => 'a_queue',
-      :routing_key => 'some routing key',
-      :amqp_queue_2 => 'a_second_queue',
-      :routing_key_2 => '',
-      :read_permission  => '.*',
-      :write_permission => '^$',
-      :configure_permission => '^a_second_queue$'
-      }}
-
-      it { is_expected.to raise_error(Puppet::Error, /\$routing_key_2 must be non-empty/) }
-  end
-
-  context 'minimum info' do
-    let(:params) {{
-      :amqp_pass => 'super_secret',
-      :amqp_exchange => 'an_exchange',
-      :amqp_queue => 'a_queue',
-      :routing_key => 'some routing key',
-      :read_permission  => '.*',
-      :write_permission => '^$',
-      :configure_permission => '^a_queue$'
-    }}
-
-    it { is_expected.to contain_rabbitmq_user('a_user').with_password('super_secret') }
-
-    it {
-      is_expected.to contain_rabbitmq_queue('a_queue@/').with(
-          :durable     => true,
-          :auto_delete => false,
-      )
-    }
-
-    it {
-      is_expected.to contain_rabbitmq_binding('binding_some routing key_an_exchange@a_queue@/').with(
-          :destination_type => 'queue',
-          :routing_key      => 'some routing key',
-      )
-    }
-
-    it {
-      is_expected.to contain_rabbitmq_user_permissions('a_user@/').with(
-        :configure_permission => '^a_queue$',
-        :write_permission => '^$',
-        :read_permission => '.*',
-      )
-    }
-
-    it { is_expected.not_to contain_govuk_rabbitmq__exchange }
-  end
+      :read_permission => '.*',
+    )
+  }
 end

--- a/modules/govuk_rabbitmq/spec/defines/govuk_rabbitmq__queue_with_binding_spec.rb
+++ b/modules/govuk_rabbitmq/spec/defines/govuk_rabbitmq__queue_with_binding_spec.rb
@@ -1,0 +1,41 @@
+require_relative '../../../../spec_helper'
+
+describe 'govuk_rabbitmq::queue_with_binding', :type => :define do
+  let(:title) { 'a_user' }
+
+  let(:facts) {{
+    staging_http_get: 'curl',
+  }}
+
+  context 'missing routing key' do
+    let(:params) {{
+      :amqp_exchange => 'an_exchange',
+      :amqp_queue => 'a_queue',
+      :routing_key => '',
+      }}
+
+    it { is_expected.to raise_error(Puppet::Error, /\$routing_key must be non-empty/) }
+  end
+
+  context 'minimum info' do
+    let(:params) {{
+      :amqp_exchange => 'an_exchange',
+      :amqp_queue => 'a_queue',
+      :routing_key => 'some routing key',
+    }}
+
+    it {
+      is_expected.to contain_rabbitmq_queue('a_queue@/').with(
+        :durable     => true,
+        :auto_delete => false,
+      )
+    }
+
+    it {
+      is_expected.to contain_rabbitmq_binding('binding_some routing key_an_exchange@a_queue@/').with(
+        :destination_type => 'queue',
+        :routing_key      => 'some routing key',
+      )
+    }
+  end
+end


### PR DESCRIPTION
This PR supersedes https://github.com/alphagov/govuk-puppet/pull/6442

Simplifying the consumer makes it easier to change the search infrastructure.
At the moment this is difficult because there is a lot of logic for
constructing permission strings.

By separating out the queue creation we can set up multiple queues per consumer. Rummager has two queues at the moment and I want to add a separate one for bulk reindexing.

This is best reviewed commit by commit.

Things I don't want to address in this PR:
- Implementing the new queue
- Changing the permissions used for each consumer
- Removing the unused RabbitMQ user for rummager

This is a refactor so I want it to have no effect when run.

Trello: https://trello.com/c/k2L67c4a/272-cleanup-puppet-module-for-declaring-message-queue-consumers