### PR TITLE
Make postgres connections consistent across environments

### DIFF
--- a/hieradata/class/integration/transition_postgresql_master.yaml
+++ b/hieradata/class/integration/transition_postgresql_master.yaml
@@ -1,0 +1,1 @@
+govuk_postgresql::server::max_connections: 200

--- a/hieradata/class/integration/transition_postgresql_slave.yaml
+++ b/hieradata/class/integration/transition_postgresql_slave.yaml
@@ -1,0 +1,1 @@
+govuk_postgresql::server::max_connections: 200

--- a/hieradata/class/staging/transition_postgresql_master.yaml
+++ b/hieradata/class/staging/transition_postgresql_master.yaml
@@ -1,0 +1,1 @@
+govuk_postgresql::server::max_connections: 200

--- a/hieradata/class/staging/transition_postgresql_slave.yaml
+++ b/hieradata/class/staging/transition_postgresql_slave.yaml
@@ -1,0 +1,1 @@
+govuk_postgresql::server::max_connections: 200


### PR DESCRIPTION
This sets the max_connections for postgres to 200 in staging and integration, like production. It's intended to solve a problem in bouncer:

https://sentry.io/govuk/app-bouncer/issues/335728174/

A previous PR for this was reverted because it changed the default value for other postgresses as well.