### PR TITLE
[WIP] Try updating to use internal app domain globally

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -529,7 +529,7 @@ govuk_ci::agent::gcloud::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 govuk::deploy::config::asset_root: "https://%{hiera('router::assets_origin::vhost_name')}"
 govuk::deploy::config::website_root: "https://www-origin.%{hiera('app_domain')}"
-govuk::deploy::config::app_domain: "%{hiera('app_domain')}"
+govuk::deploy::config::app_domain: "%{hiera('app_domain_internal')}"
 govuk::deploy::setup::gemstash_server: 'http://gemstash'
 
 govuk_ghe_vpn::openconnect_version: '6.00-0~21~ubuntu14.04.1'

--- a/modules/govuk/manifests/deploy/config.pp
+++ b/modules/govuk/manifests/deploy/config.pp
@@ -93,16 +93,4 @@ class govuk::deploy::config(
     'GOVUK_ASSET_ROOT': value          => $asset_root;
     'GOVUK_WEBSITE_ROOT': value        => $website_root;
   }
-
-  # TODO: Set some internal services specifically before we've figured out
-  # how to entirely use internal domains
-  if $::aws_migration {
-    $app_domain_internal = hiera('app_domain_internal')
-
-    govuk_envvar {
-      'PLEK_SERVICE_RUMMAGER_URI': value => "https://rummager.${app_domain_internal}";
-      'PLEK_SERVICE_SEARCH_URI': value   => "https://search.${app_domain_internal}";
-    }
-
-  }
 }


### PR DESCRIPTION
I'm removing both frontend-lb and backend-lb so it's probably time to try setting everything to use internal again.

I suspect this will break things, so we may need to be specific with Plek services.

Equally I'm not against apps hitting back against the external load balancer for backend.

https://trello.com/c/goRJMaPL/712-remove-aws-backend-lb-machines