### PR TITLE
Add rummager-elasticsearch in AWS

### DIFF
--- a/hieradata_aws/class/rummager_elasticsearch.yaml
+++ b/hieradata_aws/class/rummager_elasticsearch.yaml
@@ -1,0 +1,19 @@
+---
+
+govuk_safe_to_reboot::can_reboot: 'careful'
+govuk_safe_to_reboot::reason: 'Reboot a single node at time and check that the cluster goes green between reboots'
+
+govuk_elasticsearch::version: '2.4.6'
+
+lv:
+  data:
+    pv: '/dev/xvdf'
+    vg: 'elasticsearch'
+
+mount:
+  /mnt/elasticsearch:
+    disk: '/dev/mapper/elasticsearch-data'
+    govuk_lvm: 'data'
+    mountoptions: 'defaults'
+    percent_threshold_warning: 16
+    percent_threshold_critical: 11

--- a/modules/govuk/manifests/apps/rummager.pp
+++ b/modules/govuk/manifests/apps/rummager.pp
@@ -162,7 +162,7 @@ class govuk::apps::rummager(
   if $::aws_migration {
     govuk::app::envvar { "${title}-ELASTICSEARCH_URI":
       varname => 'ELASTICSEARCH_URI',
-      value   => 'http://elasticsearch:9200',
+      value   => 'http://rummager-elasticsearch:9200',
     }
   }
 }


### PR DESCRIPTION
Ensure that AWS is still in sync with the changes in the current environment by updating to the rummager elasticsearch instances.

Required: https://github.com/alphagov/govuk-aws/pull/273

https://trello.com/c/ypEmCQBQ/739-update-app-elasticsearch-to-app-rummager-elasticsearch-in-aws