### PR TITLE
Remove Elasticsearch 1.7 for Rummager

### DIFF
--- a/development-vm/fix-elasticsearch-2.4.sh
+++ b/development-vm/fix-elasticsearch-2.4.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# This file need to be run in order to remove elasticsearch 1.7 specific file which
+# prevent elastiocsearch 2.4 from loading
+
+echo "Stopping the ES service if it is running"
+sudo service elasticsearch-development.development stop
+
+echo "Removing plugins.."
+
+if [ -d "/usr/share/elasticsearch/plugins/cloud-aws" ]; then
+  echo "Removing cloud-aws plugin"
+  sudo rm -rf /usr/share/elasticsearch/plugins/cloud-aws
+fi
+
+if [ -d "/usr/share/elasticsearch/plugins/migration" ]; then
+  echo "Removing migration plugin"
+  sudo rm -rf /usr/share/elasticsearch/plugins/migration
+fi
+
+echo "Removing Elasticsearch data directory"
+echo "This is required as the data needs to be rebuilt for ES 2.4"
+echo "You will need to run the data replication task after this "
+echo "script finishes in order to build the data."
+
+sudo rm -rf /mnt/elasticsearch/govuk-development
+
+echo "Starting the ES service"
+sudo service elasticsearch-development.development start
+

--- a/hieradata/class/search.yaml
+++ b/hieradata/class/search.yaml
@@ -1,9 +1,9 @@
 ---
 
 govuk_elasticsearch::local_proxy::servers:
-  - 'api-elasticsearch-1.api'
-  - 'api-elasticsearch-2.api'
-  - 'api-elasticsearch-3.api'
+  - 'rummager-elasticsearch-1.api'
+  - 'rummager-elasticsearch-2.api'
+  - 'rummager-elasticsearch-3.api'
 
 govuk_elasticsearch::rummager_local_proxy::servers:
   - 'rummager-elasticsearch-1.api'

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -205,7 +205,7 @@ govuk_containers::app::config::global_envvars:
   - "GOVUK_ASSET_ROOT=%{hiera('govuk::deploy::config::asset_root')}"
   - "GOVUK_WEBSITE_ROOT=%{hiera('govuk::deploy::config::website_root')}"
 
-govuk_elasticsearch::version: '1.7.5'
+govuk_elasticsearch::version: '2.4.6'
 govuk_elasticsearch::cors_enabled: true
 
 govuk_logging::logstream::disabled: true


### PR DESCRIPTION
We are now ready to use version 2.4.6 in the development vm. This will mean the next time puppet is run it will remove 1.x.x and install 2.4.6. After this the `fix-elasticsearch-2.4.sh` in order to remove incompatible plugins and also the data. Users will need to re-replicate the elasticsearch database.

We are also pointing the local proxy on 9200 to the elasticsearch 2.4 instances. Once we have upgraded Rummager to use this we will be removing the duplicate proxy on 19200.

https://trello.com/c/KMIQEH5p/281-es-24-cleanup-tasks