### PR TITLE
[DISCUSS] add durable option for published_documents exchange

### DIFF
--- a/modules/govuk/manifests/apps/publishing_api/rabbitmq.pp
+++ b/modules/govuk/manifests/apps/publishing_api/rabbitmq.pp
@@ -43,6 +43,7 @@ class govuk::apps::publishing_api::rabbitmq (
 
   govuk_rabbitmq::exchange { "${amqp_exchange}@/":
     type     => 'topic',
+    durable  => true,
   }
 
   if $configure_test_exchange {

--- a/modules/govuk_rabbitmq/manifests/exchange.pp
+++ b/modules/govuk_rabbitmq/manifests/exchange.pp
@@ -14,9 +14,14 @@
 #   Type of RabbitMQ exchange to create
 #   Default: undef
 #
+# [*durable*]
+#   Exchanges can be durable or transient. Durable exchanges survive broker restart whereas transient exchanges do not (they have to be redeclared when broker comes back online).
+#   Default: false
+#
 define govuk_rabbitmq::exchange (
   $ensure = present,
   $type = undef,
+  $durable = false,
 ) {
 
   if $ensure == 'present' {
@@ -30,5 +35,6 @@ define govuk_rabbitmq::exchange (
     user     => 'root',
     password => $::govuk_rabbitmq::root_password,
     type     => $type,
+    durable  => $durable,
   }
 }


### PR DESCRIPTION
https://www.rabbitmq.com/tutorials/amqp-concepts.html

> Exchanges can be durable or transient. Durable exchanges survive broker restart whereas transient exchanges do not (they have to be redeclared when broker comes back online). Not all scenarios and use cases require exchanges to be durable.

All of our queues have the durable bit set, but the exchange doesn't, so if the
cluster went down, we'd have to wait for puppet to run again to re-declare the
exchange.

Merging this PR as is doesn't actually change the exchange to set the durable flag.

As far as I can tell, you can't alter an already declared exchange, only create a new one.

```
vagrant@development:/var/govuk/govuk-puppet$ rabbitmqadmin --username=root --password=root declare exchange name=published_documents  type=topic durable=true
*** 406 PRECONDITION_FAILED - inequivalent arg 'durable' for exchange 'published_documents' in vhost '/': received 'true' but current is 'false'
```

So I'm not sure how to change this on production without interruption.