### PR TITLE
Revert "revert to upstream logspout"

### DIFF
--- a/modules/govuk_docker/files/logspout/Dockerfile
+++ b/modules/govuk_docker/files/logspout/Dockerfile
@@ -1,0 +1,14 @@
+FROM gliderlabs/logspout
+LABEL maintainer="govuk-role-platform-accounts-members@digital.cabinet-office.gov.uk" \
+      description="Run a logspout-logstash container shipping to Logit.io" \
+      version="0.1.0"
+
+RUN apk update \
+  && apk add -U --virtual \
+    build-dependencies \
+    ca-certificates \
+    curl \
+  && curl https://cdn.logit.io/logit-intermediate.crt -o /usr/local/share/ca-certificates/logit-intermediate.crt \
+  && update-ca-certificates \
+  && apk del build-dependencies \
+  && rm -rf /var/cache/apk/*

--- a/modules/govuk_docker/files/logspout/README.md
+++ b/modules/govuk_docker/files/logspout/README.md
@@ -1,0 +1,50 @@
+## Intro
+
+This Dockerfile creates a [logspout-logstash](https://github.com/looplab/logspout-logstash) container for use with [logit.io](logit.io).
+
+[Logspout](https://github.com/gliderlabs/logspout) is a log router that uses a variety of adaptors to ship logs from docker containers. This one ships json logs to logstash.
+
+This only provides support for TCP (with TLS), UDP cannot be used.
+
+## Usage
+
+This container can be run using:
+```bash
+docker run \
+  --name="logit" \
+  --volume=/var/run/docker.sock:/var/run/docker.sock \
+  govuk/logspout-alpine \
+  logstash+tls://<your-logit.io-endpoint>:<your-tcp-ssl-port>
+```
+
+Where:
+
+* `logstash+tls` indicates the adapter to use (for insecure logging use `logstash+tcp`)
+* `your-logit.io-endpoint` will be something like `th1s1snt-r3al-soit-aint-w0rth7rying1-yo.logit.io` (and can be found by going to your dashboard>stack settings>logstash)
+* `your-tcp-ssl-port` is the port listed on the same page as the endpoint in the `input` block.
+
+## Additional settings
+
+Both the core [logship](https://github.com/gliderlabs/logspout#environment-variables) and [logstash adapter](https://github.com/looplab/logspout-logstash#available-configuration-options) take environment variables to configure them. This is an (incomplete) list of some of the relevant options:
+
+* ALLOW_TTY - include logs from containers started with -t or --tty (i.e. * Allocate a pseudo-TTY)
+* BACKLOG - suppress container tail backlog
+* DEBUG - emit debug logs
+* EXCLUDE_LABEL - exclude logs with a given label
+* INACTIVITY_TIMEOUT - detect hang in Docker API (default 0)
+* LOGSTASH_TAGS - Set of tags to apply to the log entry (e.g. "production, docker")
+* LOGSTASH_FIELDS - a map of `key=value` pairs to add to the entry.
+* DOCKER_LABELS - include all container labels to the entry as fields (any non-empty string is considered true and sets this).
+
+For example these could be used like:
+
+```bash
+docker run \
+  --name="logit" \
+  --volume=/var/run/docker.sock:/var/run/docker.sock \
+  -e EXCLUDE_LABEL="testing" \          # Exclude containers labelled "testing"
+  -e LOGSTASH_TAGS="app-foo,docker" \   # Set some tags
+  -e LOGSTASH_FIELDS="json_logs=true" \ # Flag the logs as json formatted
+  govuk/logspout-alpine \
+  logstash+tls://<your-logit.io-endpoint>:<your-tcp-ssl-port>
+```

--- a/modules/govuk_docker/files/logspout/build.sh
+++ b/modules/govuk_docker/files/logspout/build.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+apk add --update go build-base git mercurial ca-certificates
+mkdir -p /go/src/github.com/gliderlabs
+cp -r /src /go/src/github.com/gliderlabs/logspout
+cd /go/src/github.com/gliderlabs/logspout
+export GOPATH=/go
+go get
+go build -ldflags "-X main.Version=$1" -o /bin/logspout
+apk del go git mercurial build-base
+rm -rf /go /var/cache/apk/* /root/.glide
+
+# backwards compatibility
+ln -fs /tmp/docker.sock /var/run/docker.sock

--- a/modules/govuk_docker/files/logspout/modules.go
+++ b/modules/govuk_docker/files/logspout/modules.go
@@ -1,0 +1,7 @@
+package main
+
+import (
+	_ "github.com/gliderlabs/logspout/transports/tcp"
+	_ "github.com/gliderlabs/logspout/transports/tls"
+	_ "github.com/looplab/logspout-logstash"
+)

--- a/modules/govuk_docker/manifests/logspout.pp
+++ b/modules/govuk_docker/manifests/logspout.pp
@@ -26,7 +26,7 @@ class govuk_docker::logspout (
   validate_array($tags)
   validate_string($endpoint)
 
-  $image_name = 'gliderlabs/logspout'
+  $image_name = 'govuk/logspout-alpine'
 
   $tag_list = join(concat($tags, ['docker', 'json_log']), ',')
   $tag_env = "LOGSTASH_TAGS=${tag_list}"

--- a/modules/govuk_docker/spec/classes/govuk_docker__logspout_spec.rb
+++ b/modules/govuk_docker/spec/classes/govuk_docker__logspout_spec.rb
@@ -11,17 +11,17 @@ describe 'govuk_docker::logspout', :type => :class do
   context {
     let(:params){{ :endpoint => 'example.com' }}
     it {
-      is_expected.to contain_docker__image('gliderlabs/logspout').with(
+      is_expected.to contain_docker__image('govuk/logspout-alpine').with(
         'ensure'    => 'present',
         'image_tag' => 'latest',
       )
 
       is_expected.to contain_docker__run('logspout').with(
-        'image'   => 'gliderlabs/logspout:latest',
+        'image'   => 'govuk/logspout-alpine:latest',
         'env'     => ['LOGSTASH_TAGS=docker,json_log'],
         'volumes' => ['/var/run/docker.sock:/var/run/docker.sock'],
         'command' => 'logstash+tls://example.com',
-        'require' => 'Docker::Image[gliderlabs/logspout]',
+        'require' => 'Docker::Image[govuk/logspout-alpine]',
       )
     }
   }


### PR DESCRIPTION
Reverts alphagov/govuk-puppet#6456

It turns out that although we don't need the intermediate cert stuff, we *do* need the logstash logspout provider that we bake into our image.