### PR TITLE
remove logit intermediate cert workaround

### DIFF
--- a/modules/govuk_docker/files/logspout/Dockerfile
+++ b/modules/govuk_docker/files/logspout/Dockerfile
@@ -3,12 +3,6 @@ LABEL maintainer="govuk-role-platform-accounts-members@digital.cabinet-office.go
       description="Run a logspout-logstash container shipping to Logit.io" \
       version="0.1.0"
 
-RUN apk update \
-  && apk add -U --virtual \
-    build-dependencies \
-    ca-certificates \
-    curl \
-  && curl https://cdn.logit.io/logit-intermediate.crt -o /usr/local/share/ca-certificates/logit-intermediate.crt \
-  && update-ca-certificates \
-  && apk del build-dependencies \
-  && rm -rf /var/cache/apk/*
+# The real magic happens in ./build.sh and ./modules.go, which are pulled
+# in by gliderlabs/logspout which has some ONBUILD COPY lines to
+# consume them


### PR DESCRIPTION
This removes the logit intermediate certificate workaround, which is
no longer needed.

I also added a comment in the Dockerfile to explain how build.sh and
modules.go get consumed because i found that really confusing the
first time around.

Build on docker hub was successful: https://hub.docker.com/r/govuk/logspout-alpine/builds/buhapzmzpvh84j3yz5vttjn/