### PR TITLE
Make mirrorer build green on AWS

### DIFF
--- a/hieradata_aws/class/mirrorer.yaml
+++ b/hieradata_aws/class/mirrorer.yaml
@@ -1,0 +1,21 @@
+---
+govuk_crawler::mirror_root: '/mnt/crawler_worker'
+
+govuk::apps::govuk_crawler_worker::amqp_host: "%{hiera('govuk_crawler::amqp_host')}"
+
+govuk::node::s_base::apps:
+  - govuk_crawler_worker
+
+icinga::client::checks::disk_time_warn: 150 # milliseconds
+icinga::client::checks::disk_time_critical: 250 # milliseconds
+
+lv:
+  worker:
+    pv: '/dev/xvdf'
+    vg: 'crawler'
+
+mount:
+  /mnt/crawler_worker:
+    disk: '/dev/mapper/crawler-worker'
+    govuk_lvm: 'worker'
+    mountoptions: 'defaults'

--- a/hieradata_aws/class/rabbitmq.yaml
+++ b/hieradata_aws/class/rabbitmq.yaml
@@ -7,6 +7,8 @@ govuk::node::s_rabbitmq::apps_using_rabbitmq:
   - rummager
   - stagecraft
 
+govuk_rabbitmq::aws_clustering: true
+
 govuk_safe_to_reboot::can_reboot: 'careful'
 govuk_safe_to_reboot::reason: 'rabbitmq-1 is a single point of failure for content-store, apps not resilient'
 

--- a/modules/govuk_crawler/manifests/init.pp
+++ b/modules/govuk_crawler/manifests/init.pp
@@ -125,9 +125,11 @@ class govuk_crawler(
     owner  => $crawler_user,
   }
 
+  # This explicitly requires 'base::packages' so that nokogiri will build
   package { 'govuk_seed_crawler':
-        ensure   => '2.0.0',
+        ensure   => '2.0.1',
         provider => system_gem,
+        require  => Class['base::packages'],
   }
 
   # Needed to copy to AWS S3

--- a/modules/govuk_rabbitmq/manifests/init.pp
+++ b/modules/govuk_rabbitmq/manifests/init.pp
@@ -2,6 +2,7 @@
 class govuk_rabbitmq (
   $monitoring_password,
   $root_password,
+  $aws_clustering = false,
 ) {
   $root_vhost = '/'
   $monitoring_user = 'monitoring'
@@ -23,7 +24,7 @@ class govuk_rabbitmq (
     ensure => present,
   }
 
-  if $::aws_migration {
+  if $::aws_migration and $aws_clustering {
     staging::file { 'autocluster-0.8.0.ez':
       target => "/usr/lib/rabbitmq/lib/rabbitmq_server-${::rabbitmq_version}/plugins/autocluster-0.8.0.ez",
       source => 'https://github.com/rabbitmq/rabbitmq-autocluster/releases/download/0.8.0/autocluster-0.8.0.ez',


### PR DESCRIPTION
This configures the mirrorer class to work on AWS.

It:
* Adds a hierdata for the class
* Adds an explicit toggle for rabbitmq's clustering behaviour
* Updates the version of govuk_seed_crawler installed to 2.0.1
* Makes the installation of govuk_seed_crawler explicitly depend on the base ruby packages.