### PR TITLE
Remove final es 1.7 references

### DIFF
--- a/development-vm/fix-elasticsearch-2.4.sh
+++ b/development-vm/fix-elasticsearch-2.4.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # This file need to be run in order to remove elasticsearch 1.7 specific file which
-# prevent elastiocsearch 2.4 from loading
+# prevent elasticsearch 2.4 from loading
 
 echo "Stopping the ES service if it is running"
 sudo service elasticsearch-development.development stop

--- a/hieradata/class/search.yaml
+++ b/hieradata/class/search.yaml
@@ -5,12 +5,6 @@ govuk_elasticsearch::local_proxy::servers:
   - 'rummager-elasticsearch-2.api'
   - 'rummager-elasticsearch-3.api'
 
-govuk_elasticsearch::rummager_local_proxy::servers:
-  - 'rummager-elasticsearch-1.api'
-  - 'rummager-elasticsearch-2.api'
-  - 'rummager-elasticsearch-3.api'
-govuk_elasticsearch::rummager_local_proxy::remote_port: 9200
-
 govuk::node::s_base::apps:
   - rummager
 

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -650,19 +650,19 @@ govuk_ci::master::pipeline_jobs:
 govuk_ci::master::ci_agents:
   ci-agent-1:
     agent_hostname: 'ci-agent-1.ci'
-    labels: 'mongodb-2.4 docker ci-agent-1 elasticsearch terraform-0.8.1'
+    labels: 'mongodb-2.4 docker ci-agent-1 elasticsearch-2.4 terraform-0.8.1'
   ci-agent-2:
     agent_hostname: 'ci-agent-2.ci'
-    labels: 'mongodb-2.4 docker ci-agent-2 elasticsearch terraform'
+    labels: 'mongodb-2.4 docker ci-agent-2 elasticsearch-2.4 terraform'
   ci-agent-3:
     agent_hostname: 'ci-agent-3.ci'
     labels: 'mongodb-2.4 docker ci-agent-3 elasticsearch-2.4 terraform'
   ci-agent-4:
     agent_hostname: 'ci-agent-4.ci'
-    labels: 'mongodb-3.2 docker ci-agent-4 elasticsearch terraform'
+    labels: 'mongodb-3.2 docker ci-agent-4 elasticsearch-2.4 terraform'
   ci-agent-5:
     agent_hostname: 'ci-agent-5.ci'
-    labels: 'mongodb-3.2 docker ci-agent-5 elasticsearch terraform'
+    labels: 'mongodb-3.2 docker ci-agent-5 elasticsearch-2.4 terraform'
 
 govuk_ci::master::credentials_id: 'jenkins-ssh-slave'
 

--- a/modules/govuk/manifests/node/s_search.pp
+++ b/modules/govuk/manifests/node/s_search.pp
@@ -14,6 +14,5 @@ class govuk::node::s_search inherits govuk::node::s_base {
   # Local proxy for Rummager to access ES cluster.
   if ! $::aws_migration {
     include govuk_elasticsearch::local_proxy
-    include govuk_elasticsearch::rummager_local_proxy
   }
 }

--- a/modules/govuk_jenkins/templates/jobs/copy_data_from_integration_to_aws.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_from_integration_to_aws.yaml.erb
@@ -80,7 +80,6 @@
             description: 'Choose the thing to sync. All is the default, but some jobs may run but not do anything due to your config for the destination environment.'
             choices:
                 - all
-                - elasticsearch-api
                 - elasticsearch-rummager
                 - mongo-api
                 - mongo-normal

--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
@@ -85,7 +85,6 @@
             choices:
                 - all
                 - assets
-                - elasticsearch-api
                 - elasticsearch-rummager
                 - mongo-api
                 - mongo-exceptions

--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_staging.yaml.erb
@@ -98,7 +98,6 @@
             choices:
                 - all
                 - assets
-                - elasticsearch-api
                 - elasticsearch-rummager
                 - mongo-api
                 - mongo-exceptions


### PR DESCRIPTION
* Move all CI machines to use ES 2.4
* Remove elasticsearch-api form all "copy-data-to-X" jobs
* Remove the rummager localproxy on port 19200 to ES 2.4

https://trello.com/c/KMIQEH5p/281-cleanup-tasks