### PR TITLE
Add cluster name

### DIFF
--- a/modules/govuk/manifests/node/s_rummager_elasticsearch.pp
+++ b/modules/govuk/manifests/node/s_rummager_elasticsearch.pp
@@ -23,6 +23,7 @@ class govuk::node::s_rummager_elasticsearch inherits govuk::node::s_base {
     host                   => $::fqdn,
     open_firewall_from_all => false,
     require                => Class['govuk_java::openjdk7::jre'],
+    aws_cluster_name       => $aws_cluster_name,
   }
 
   if $::aws_migration {


### PR DESCRIPTION
I forgot to add this before which meant the cluster has not correctly created itself in AWS.