### PR TITLE
Add ES 2.4 local proxy for licence-finder

### DIFF
--- a/hieradata/class/calculators_frontend.yaml
+++ b/hieradata/class/calculators_frontend.yaml
@@ -5,6 +5,12 @@ govuk_elasticsearch::local_proxy::servers:
   - 'api-elasticsearch-2.api'
   - 'api-elasticsearch-3.api'
 
+govuk_elasticsearch::rummager_local_proxy::servers:
+  - 'rummager-elasticsearch-1.api'
+  - 'rummager-elasticsearch-2.api'
+  - 'rummager-elasticsearch-3.api'
+govuk_elasticsearch::rummager_local_proxy::remote_port: 9200
+
 govuk::node::s_base::apps:
   - calculators
   - calendars

--- a/modules/govuk/manifests/node/s_calculators_frontend.pp
+++ b/modules/govuk/manifests/node/s_calculators_frontend.pp
@@ -7,6 +7,7 @@ class govuk::node::s_calculators_frontend inherits govuk::node::s_base {
   # Local proxy for licence-finder to access ES cluster.
   if ! $::aws_migration {
     include govuk_elasticsearch::local_proxy
+    include govuk_elasticsearch::rummager_local_proxy
   }
 
   # If we miss all the apps, throw a 500 to be caught by the cache nginx


### PR DESCRIPTION
This is the first step to migrating licence-finder off ES 1.7

https://trello.com/c/iDliRu73/315-licence-finder-on-es-24