### PR TITLE
Add MapIt env var

### DIFF
--- a/modules/govuk/manifests/apps/mapit.pp
+++ b/modules/govuk/manifests/apps/mapit.pp
@@ -58,6 +58,9 @@ class govuk::apps::mapit (
   }
 
   govuk::app::envvar {
+    "${title}-DB_PASSWORD":
+        varname => 'MAPIT_DB_PASS',
+        value   => $db_password;
     "${title}-DJANGO_SECRET_KEY":
         varname => 'DJANGO_SECRET_KEY',
         value   => $django_secret_key;


### PR DESCRIPTION
We want to use this instead of having stuff in alphagov-deployment.  This should match the env variable in alphagov/mapit#42.

The env var name is the same as that in the MapIt yaml configuration ([general.yml](https://github.com/alphagov/mapit/blob/a55bddf61ba2bb25cb185eff69ebc2fe69f54600/conf/general.yml-example#L10) etc) to make it clear what it replaces.