### PR TITLE
Add Rummager  workers to deployment dashboards

### DIFF
--- a/modules/grafana/templates/dashboards/deployment_panels/_worker_failures.json.erb
+++ b/modules/grafana/templates/dashboards/deployment_panels/_worker_failures.json.erb
@@ -53,6 +53,11 @@
       "refId": "C",
       "target": "aliasByNode(transformNull(hitcount(stats.govuk.app.<%= @app_name %>.workers.*.failure, '5m'),0), 5 )",
       "textEditor": true
+    },
+    {
+      "refId": "C",
+      "target": "aliasByNode(transformNull(hitcount(stats.govuk.app.<%= @app_name %>.workers.*.*.failure, '5m'),0), 6)",
+      "textEditor": true
     }
   ],
   "timeFrom": "24h",

--- a/modules/grafana/templates/dashboards/deployment_panels/_worker_successes.json.erb
+++ b/modules/grafana/templates/dashboards/deployment_panels/_worker_successes.json.erb
@@ -53,6 +53,11 @@
       "refId": "D",
       "target": "aliasByNode(transformNull(hitcount(stats.govuk.app.<%= @app_name %>.workers.*.success, '5m'),0), 5)",
       "textEditor": true
+    },
+    {
+      "refId": "D",
+      "target": "aliasByNode(transformNull(hitcount(stats.govuk.app.<%= @app_name %>.workers.*.*.success, '5m'),0), 6)",
+      "textEditor": true
     }
   ],
   "timeFrom": "24h",


### PR DESCRIPTION
The Rummager workers have a different namespacing to many of the other applications, such as `Indexer` and `GovukIndex`. Unfortunately it does not look like Graphite supports wildcard matching across the `.` that separates path segments. Any workers that do not exist will simply not appear so the dashboard will remain uncluttered.

https://trello.com/c/KiCC8EmD