### PR TITLE
Log slow Elasticsearch queries

### DIFF
--- a/modules/govuk/manifests/node/s_rummager_elasticsearch.pp
+++ b/modules/govuk/manifests/node/s_rummager_elasticsearch.pp
@@ -24,6 +24,8 @@ class govuk::node::s_rummager_elasticsearch inherits govuk::node::s_base {
     open_firewall_from_all => false,
     require                => Class['govuk_java::openjdk7::jre'],
     aws_cluster_name       => $aws_cluster_name,
+    log_slow_queries       => true,
+    slow_query_log_level   => 'info',
   }
 
   if $::aws_migration {


### PR DESCRIPTION
Some queries from finder-frontend to Rummager have been timing out recently, which is causing 500 errors on finders. This would be easier to investigate if we could see which Elasticsearch queries were running slowly and at what times.

Only enable slow query logging on the rummager-elasticsearch boxes for now. We can easily enable it later on logs-elasticsearch or in development if it would be useful.

https://trello.com/c/saDruTlG/307-investigate-1-day-intermittent-rummager-timeouts