### PR TITLE
Allow open Elasticsearch on AWS by default

### DIFF
--- a/hieradata_aws/class/logs_elasticsearch.yaml
+++ b/hieradata_aws/class/logs_elasticsearch.yaml
@@ -4,7 +4,6 @@ govuk_safe_to_reboot::can_reboot: 'careful'
 govuk_safe_to_reboot::reason: 'Reboot a single node at time and check that the cluster goes green between reboots'
 
 govuk_elasticsearch::version: '1.4.4'
-govuk_elasticsearch::open_firewall_from_all: true
 
 icinga::client::checks::disk_time_warn: 200 # milliseconds
 icinga::client::checks::disk_time_critical: 300 # milliseconds

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -735,6 +735,8 @@ govuk_crawler::site_root: 'https://www.gov.uk'
 govuk_elasticsearch::backup::alert_hostname: 'alert'
 govuk_elasticsearch::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
+govuk_elasticsearch::open_firewall_from_all: true
+
 govuk_jenkins::package::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk_jenkins::github_enterprise_cert::certificate: |
     -----BEGIN CERTIFICATE-----


### PR DESCRIPTION
We use security groups to manage connections rather than UFW, so ensure that elasticsearch is open on any Elasticsearch cluster in this environment.