### PR TITLE
AWS update content-store and rummager datastores

### DIFF
--- a/hieradata_aws/class/content_store.yaml
+++ b/hieradata_aws/class/content_store.yaml
@@ -2,9 +2,9 @@
 
 govuk::apps::content_store::mongodb_name: 'content_store_production'
 govuk::apps::content_store::mongodb_nodes:
-  - 'api-mongo-1'
-  - 'api-mongo-2'
-  - 'api-mongo-3'
+  - 'mongo-1'
+  - 'mongo-2'
+  - 'mongo-3'
 
 govuk::node::s_base::apps:
   - content_store

--- a/hieradata_aws/class/draft_content_store.yaml
+++ b/hieradata_aws/class/draft_content_store.yaml
@@ -3,9 +3,9 @@
 govuk::apps::content_store::default_ttl: '1'
 govuk::apps::content_store::mongodb_name: 'draft_content_store_production'
 govuk::apps::content_store::mongodb_nodes:
-  - 'api-mongo-1'
-  - 'api-mongo-2'
-  - 'api-mongo-3'
+  - 'mongo-1'
+  - 'mongo-2'
+  - 'mongo-3'
 govuk::apps::content_store::vhost: 'draft-content-store'
 
 govuk::node::s_base::apps:

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -414,7 +414,7 @@ govuk::apps::rummager::nagios_memory_critical: 4900
 govuk::apps::rummager::enable_publishing_listener: true
 govuk::apps::rummager::rabbitmq::enable_publishing_listener: true
 govuk::apps::rummager::rabbitmq_user: 'rummager-v2'
-govuk::apps::rummager::redis_host: 'api-redis'
+govuk::apps::rummager::redis_host: 'backend-redis'
 govuk::apps::rummager::redis_port: '6379'
 
 govuk::apps::search_admin::db_name: 'search_admin_production'


### PR DESCRIPTION
- Update content_store to use mongo host database
- Update rummager to use backend-redis database

This will allow us to remove api-mongo and api-redis machines on AWS, we got
confirmation that it is safe to share those machines for different applications.

https://trello.com/c/tYFjLuSF/741-combine-api-mongo-into-mongo-and-api-redis-into-backend-redis