### PR TITLE
Add a separate queue for bulk search indexing

### DIFF
--- a/development-vm/Pinfile
+++ b/development-vm/Pinfile
@@ -61,7 +61,7 @@ process :rummager => [:'publishing-api-read', :'rummager-sidekiq', :'rummager-pu
 process :'rummager-sidekiq'
 process :'rummager-publishing-listener'
 process :'rummager-govuk-index-listener'
-process :'rummager-govuk-index-reindex-listener'
+process :'rummager-bulk-reindex-listener'
 process :screenshot_as_a_service
 process :'search-admin' => [:rummager]
 process :'service-manual-frontend' => [:'content-store', :static]

--- a/development-vm/Procfile
+++ b/development-vm/Procfile
@@ -9,7 +9,7 @@ rummager:              govuk_setenv rummager              ./run_in.sh ../../rumm
 rummager-sidekiq:      govuk_setenv rummager              ./run_in.sh ../../rummager       bundle exec sidekiq -C ./config/sidekiq.yml
 rummager-publishing-listener: govuk_setenv rummager       ./run_in.sh ../../rummager       bundle exec rake message_queue:listen_to_publishing_queue
 rummager-govuk-index-listener: govuk_setenv rummager      ./run_in.sh ../../rummager       bundle exec rake message_queue:insert_data_into_govuk
-rummager-govuk-index-reindex-listener: govuk_setenv rummager ./run_in.sh ../../rummager    bundle exec rake message_queue:listen_to_reindexing_messages
+rummager-bulk-reindex-listener: govuk_setenv rummager ./run_in.sh ../../rummager    bundle exec rake message_queue:bulk_insert_data_into_govuk
 smartanswers:          govuk_setenv smartanswers          ./run_in.sh ../../smart-answers  bundle exec rails server -p 3010
 calendars:             govuk_setenv calendars             ./run_in.sh ../../calendars      bundle exec rails server -p 3011
 static:                govuk_setenv static                ./run_in.sh ../../static         bundle exec rails server -p 3013

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -156,6 +156,9 @@ govuk::apps::router_api::enable_running_in_draft_mode::router_nodes: ['localhost
 govuk::apps::rummager::enable_procfile_worker: false
 govuk::apps::rummager::rabbitmq_hosts: ['localhost']
 govuk::apps::rummager::redis_host: 'localhost'
+govuk::apps::rummager::enable_bulk_reindex_listener: true
+govuk::apps::rummager::rabbitmq::enable_bulk_reindex_listener: true
+
 govuk::apps::signon::enable_procfile_worker: false
 govuk::apps::smartanswers::expose_govspeak: true
 govuk::apps::short_url_manager::mongodb_name: 'short_url_manager_development'

--- a/modules/govuk/manifests/apps/rummager.pp
+++ b/modules/govuk/manifests/apps/rummager.pp
@@ -21,6 +21,9 @@
 #   Whether to enable the procfile worker service for the govuk index.
 #   Default: false
 #
+# [*enable_bulk_reindex_listener*]
+#   Whether or not to configure the queue for the rummager bulk indexer
+#
 # [*enable_publishing_listener*]
 #   Whether to enable the procfile indexing service.
 #   Default: false
@@ -67,6 +70,7 @@ class govuk::apps::rummager(
   $port = '3009',
   $enable_procfile_worker = true,
   $enable_govuk_index_listener = false,
+  $enable_bulk_reindex_listener = false,
   $enable_publishing_listener = false,
   $errbit_api_key = undef,
   $sentry_dsn = undef,
@@ -132,6 +136,11 @@ class govuk::apps::rummager(
     default => absent,
   }
 
+  $toggled_bulk_reindex_listener = $enable_bulk_reindex_listener ? {
+    true    => present,
+    default => absent,
+  }
+
   govuk::procfile::worker { 'rummager-publishing-queue-listener':
     ensure         => $toggled_ensure,
     setenv_as      => 'rummager',
@@ -144,6 +153,13 @@ class govuk::apps::rummager(
     setenv_as      => 'rummager',
     enable_service => $enable_govuk_index_listener,
     process_type   => 'govuk-index-queue-listener',
+  }
+
+  govuk::procfile::worker { 'rummager-bulk-reindex-queue-listener':
+    ensure         => $toggled_bulk_reindex_listener,
+    setenv_as      => 'rummager',
+    enable_service => $enable_bulk_reindex_listener,
+    process_type   => 'bulk-reindex-queue-listener',
   }
 
   Govuk::App::Envvar {


### PR DESCRIPTION
Enabled on development only for the moment.

This will allow us to bulk reindex content without republishing new editions.

Haven't tested end to end, because my elasticsearch is a bit broken, but I've verified using the rabbitmq console that messages published by `rake queue:requeue_document_type[answer]` in publishing api get picked up the rummager consumer.

Corresponding rummager change: https://github.com/alphagov/rummager/pull/924

https://trello.com/c/nPiykYmS/270-get-rummager-reindex-working-in-dev