### PR TITLE
Adds ruby versions updated with security patches

### DIFF
--- a/modules/govuk_rbenv/manifests/all.pp
+++ b/modules/govuk_rbenv/manifests/all.pp
@@ -42,8 +42,11 @@ class govuk_rbenv::all (
   rbenv::version { '2.2.4':
     bundler_version => '1.15.1',
   }
+  rbenv::version { '2.2.8':
+    bundler_version => '1.15.1',
+  }
   rbenv::alias { '2.2':
-    to_version => '2.2.4',
+    to_version => '2.2.8',
   }
 
   rbenv::version { '2.3.0':
@@ -52,14 +55,20 @@ class govuk_rbenv::all (
   rbenv::version { '2.3.1':
     bundler_version => '1.15.1',
   }
+  rbenv::version { '2.3.5':
+    bundler_version => '1.15.1',
+  }
   rbenv::alias { '2.3':
-    to_version => '2.3.1',
+    to_version => '2.3.5',
   }
 
   rbenv::version { '2.4.0':
     bundler_version => '1.15.1',
   }
+  rbenv::version { '2.4.2':
+    bundler_version => '1.15.1',
+  }
   rbenv::alias { '2.4':
-    to_version => '2.4.0',
+    to_version => '2.4.2',
   }
 }


### PR DESCRIPTION
Depends on https://github.com/alphagov/packager/pull/137 being merged and 'deployed'. ( @surminus I think I need some infrastructure magic for that.)

Security patches addressing:

CVE-2017-0898: Buffer underrun vulnerability in Kernel.sprintf
CVE-2017-10784: Escape sequence injection vulnerability in the Basic
authentication of WEBrick
CVE-2017-14033: Buffer underrun vulnerability in OpenSSL ASN1 docode
CVE-2017-14064: Heap exposure vulnerability in generating JSON
Multiple vulnerabilities in RubyGems
Updated bundled libyaml to version 0.1.7

[2.4.2](https://www.ruby-lang.org/en/news/2017/09/14/ruby-2-4-2-released/)
[2.3.5](https://www.ruby-lang.org/en/news/2017/09/14/ruby-2-3-5-released/)
[2.2.8](https://www.ruby-lang.org/en/news/2017/09/14/ruby-2-2-8-released/)