### PR TITLE
Local links manager logs json

### DIFF
--- a/modules/govuk/manifests/apps/local_links_manager.pp
+++ b/modules/govuk/manifests/apps/local_links_manager.pp
@@ -102,11 +102,12 @@ class govuk::apps::local_links_manager(
 
   if $enabled {
     govuk::app { $app_name:
-      app_type          => 'rack',
-      port              => $port,
-      sentry_dsn        => $sentry_dsn,
-      vhost_ssl_only    => true,
-      health_check_path => '/healthcheck',
+      app_type           => 'rack',
+      log_format_is_json => true,
+      port               => $port,
+      sentry_dsn         => $sentry_dsn,
+      vhost_ssl_only     => true,
+      health_check_path  => '/healthcheck',
     }
 
     Govuk::App::Envvar {


### PR DESCRIPTION
Local links manager [logs to json files](https://github.com/alphagov/local-links-manager/blob/f9e849ba4541e38bde525b9ba16c36364a8eee45/config/environments/production.rb#L40) so we should use them.  

We're currently reading from production.log which has virtually nothing in it.  Using this should mean that [we read from the decent logs](https://github.com/alphagov/govuk-puppet/blob/6d5fe42a96439933419828a94b9f973e1704dcfa/modules/govuk/manifests/app.pp#L362)