### PR TITLE
[DO NOT MERGE] Remove govuk delivery

### DIFF
--- a/development-vm/Pinfile
+++ b/development-vm/Pinfile
@@ -35,8 +35,6 @@ process :feedback => [:static, :support, :'support-api']
 process :'finder-frontend' => [:static, :rummager, :'content-store']
 process :frontend => [:static, :'content-store', :rummager]
 process :'government-frontend' => [:'content-store', :static, :rummager]
-process :'govuk-delivery'
-process :'govuk-delivery-worker'
 process :'hmrc-manuals-api' => [:'publishing-api', :rummager]
 process :imminence => [:mapit]
 process :'info-frontend' => [:static, :'content-store']

--- a/development-vm/Procfile
+++ b/development-vm/Procfile
@@ -42,8 +42,7 @@ asset-manager:         govuk_setenv asset-manager         ./run_in.sh ../../asse
 asset-manager-worker:  govuk_setenv asset-manager         ./run_in.sh ../../asset-manager  bundle exec rake jobs:work
 # limelight used port 3040
 # transaction_wrappers used port 3041
-govuk-delivery:        govuk_setenv govuk-delivery        ./run_in.sh ../../govuk-delivery ./startup.sh # govuk-delivery uses port 3042
-govuk-delivery-worker: govuk_setenv govuk-delivery        ./run_in.sh ../../govuk-delivery ./venv/bin/celery worker -A service
+# govuk-delivery used port 3042
 # tariff_demo_api uses port 3043 in integration only
 transition:            govuk_setenv transition            ./run_in.sh ../../transition     bundle exec rails server -p 3044
 # tariff_demo uses port 3045 in integration only

--- a/hieradata/class/backend.yaml
+++ b/hieradata/class/backend.yaml
@@ -58,7 +58,6 @@ govuk::node::s_base::apps:
   - email_alert_api
   - email_alert_service
   - event_store
-  - govuk_delivery
   - hmrc_manuals_api
   - imminence
   - kibana

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -341,15 +341,6 @@ govuk::apps::govuk_crawler_worker::root_urls:
   - 'https://assets.publishing.service.gov.uk/'
   - 'https://www.gov.uk/'
 
-govuk::apps::govuk_delivery::redis_host: "%{hiera('sidekiq_host')}"
-govuk::apps::govuk_delivery::redis_port: "%{hiera('sidekiq_port')}"
-govuk::apps::govuk_delivery::mongodb_hosts:
-  - 'mongo-1.backend'
-  - 'mongo-2.backend'
-  - 'mongo-3.backend'
-govuk::apps::govuk_delivery::mongodb_database: 'govuk_delivery'
-govuk::apps::govuk_delivery::list_title_format: '%s'
-
 govuk::apps::imminence::mongodb_nodes:
   - 'mongo-1.backend'
   - 'mongo-2.backend'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -34,7 +34,6 @@ deployable_applications: &deployable_applications
   finder-frontend: {}
   frontend: {}
   government-frontend: {}
-  govuk-delivery: {}
   govuk-cdn-logs-monitor: {}
   govuk-content-schemas: {}
   govuk_crawler_worker: {}
@@ -1183,7 +1182,6 @@ hosts::production::backend::app_hostnames:
   - 'email-alert-api'
   - 'errbit'
   - 'event-store'
-  - 'govuk-delivery'
   - 'hmrc-manuals-api'
   - 'imminence'
   - 'kibana'

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -45,7 +45,6 @@ govuk::node::s_development::apps:
   - 'frontend'
   - 'government_frontend'
   - 'government_frontend::enable_running_in_draft_mode'
-  - 'govuk_delivery'
   - 'hmrc_manuals_api'
   - 'imminence'
   - 'info_frontend'
@@ -114,7 +113,6 @@ govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
 govuk::apps::hmrc_manuals_api::enable_procfile_worker: false
 govuk::apps::government_frontend::enable_running_in_draft_mode::content_store: 'http://draft-content-store.dev.gov.uk'
 govuk::apps::govuk_cdn_logs_monitor::enabled: false
-govuk::apps::govuk_delivery::enable_procfile_worker: false
 govuk::apps::imminence::enable_procfile_worker: false
 govuk::apps::imminence::redis_host: 'localhost'
 govuk::apps::kibana::elasticsearch_host: 'localhost'
@@ -278,7 +276,6 @@ hosts::development::apps:
   - 'feedback'
   - 'finder-frontend'
   - 'frontend'
-  - 'govuk-delivery'
   - 'government-frontend'
   - 'hmrc-manuals-api'
   - 'imminence'

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -32,7 +32,6 @@ govuk::apps::content_performance_manager::feature_auditing_theme_filtering: true
 govuk::apps::email_alert_api::allow_govdelivery_topic_syncing: true
 govuk::apps::errbit::errbit_email_from: 'govuk-winston+errbit-integration@digital.cabinet-office.gov.uk'
 govuk::apps::event_store::enabled: true
-govuk::apps::govuk_delivery::list_title_format: 'INTEGRATION: %s'
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
 govuk::apps::publicapi::backdrop_host: 'www.preview.performance.service.gov.uk'
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-integration'

--- a/hieradata_aws/class/backend.yaml
+++ b/hieradata_aws/class/backend.yaml
@@ -56,7 +56,6 @@ govuk::node::s_base::apps:
   - email_alert_api
   - email_alert_service
   - event_store
-  - govuk_delivery
   - hmrc_manuals_api
   - imminence
   - kibana

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -39,9 +39,6 @@ deployable_applications: &deployable_applications
   finder-frontend: {}
   frontend: {}
   government-frontend: {}
-  govuk-delivery:
-    repository: 'govuk_delivery'
-    source: 'github-enterprise'
   govuk-cdn-logs-monitor: {}
   govuk-content-schemas: {}
   govuk_crawler_worker: {}
@@ -349,15 +346,6 @@ govuk::apps::govuk_crawler_worker::root_urls:
   - 'https://assets.digital.cabinet-office.gov.uk/'
   - 'https://assets.publishing.service.gov.uk/'
   - 'https://www.gov.uk/'
-
-govuk::apps::govuk_delivery::redis_host: "%{hiera('sidekiq_host')}"
-govuk::apps::govuk_delivery::redis_port: "%{hiera('sidekiq_port')}"
-govuk::apps::govuk_delivery::mongodb_hosts:
-  - 'mongo-1'
-  - 'mongo-2'
-  - 'mongo-3'
-govuk::apps::govuk_delivery::mongodb_database: 'govuk_delivery'
-govuk::apps::govuk_delivery::list_title_format: '%s'
 
 govuk::apps::imminence::mongodb_nodes:
   - 'mongo-1'

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -30,7 +30,6 @@ cron::daily_hour: 6
 govuk::apps::email_alert_api::allow_govdelivery_topic_syncing: true
 govuk::apps::errbit::errbit_email_from: 'govuk-winston+errbit-integration@digital.cabinet-office.gov.uk'
 govuk::apps::event_store::enabled: true
-govuk::apps::govuk_delivery::list_title_format: 'INTEGRATION: %s'
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-integration'
 govuk::apps::publishing_api::content_api_prototype: true

--- a/modules/govuk/manifests/apps/govuk_delivery.pp
+++ b/modules/govuk/manifests/apps/govuk_delivery.pp
@@ -60,6 +60,7 @@ class govuk::apps::govuk_delivery(
   include govuk_python
 
   govuk::app { $app_name:
+    ensure             => 'absent',
     app_type           => 'procfile',
     port               => $port,
     vhost_ssl_only     => true,
@@ -68,6 +69,7 @@ class govuk::apps::govuk_delivery(
   }
 
   govuk::procfile::worker { 'govuk-delivery':
+    ensure         => 'absent',
     enable_service => $enable_procfile_worker,
   }
 
@@ -76,32 +78,40 @@ class govuk::apps::govuk_delivery(
   }
 
   govuk::app::envvar::mongodb_uri { $app_name:
+    ensure   => 'absent',
     hosts    => $mongodb_hosts,
     database => $mongodb_database,
   }
 
   govuk::app::envvar::redis { $app_name:
-    host => $redis_host,
-    port => $redis_port,
+    ensure => 'absent',
+    host   => $redis_host,
+    port   => $redis_port,
   }
 
   govuk::app::envvar {
     "${title}-GOVDELIVERY_USERNAME":
+      ensure  => 'absent',
       varname => 'GOVDELIVERY_USERNAME',
       value   => $govdelivery_username;
     "${title}-GOVDELIVERY_PASSWORD":
+      ensure  => 'absent',
       varname => 'GOVDELIVERY_PASSWORD',
       value   => $govdelivery_password;
     "${title}-GOVDELIVERY_ACCOUNT_CODE":
+      ensure  => 'absent',
       varname => 'GOVDELIVERY_ACCOUNT_CODE',
       value   => $govdelivery_account_code;
     "${title}-GOVDELIVERY_HOSTNAME":
+      ensure  => 'absent',
       varname => 'GOVDELIVERY_HOSTNAME',
       value   => $govdelivery_hostname;
     "${title}-GOVDELIVERY_SIGNUP_FORM":
+      ensure  => 'absent',
       varname => 'GOVDELIVERY_SIGNUP_FORM',
       value   => $govdelivery_signup_form;
     "${title}-LIST_TITLE_FORMAT":
+      ensure  => 'absent',
       varname => 'LIST_TITLE_FORMAT',
       value   => $list_title_format;
   }

--- a/modules/govuk/manifests/node/s_backend_lb.pp
+++ b/modules/govuk/manifests/node/s_backend_lb.pp
@@ -78,7 +78,6 @@ class govuk::node::s_backend_lb (
       'canary-backend',
       'email-alert-api',
       'event-store',
-      'govuk-delivery',
       'support-api',
     ]:
       internal_only => true,

--- a/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
@@ -19,8 +19,6 @@
            ssh deploy@$(govuk_node_list -c backend --single-node) 'cd /var/apps/publisher ; govuk_setenv publisher bundle exec rake editions:requeue_scheduled_for_publishing'
            # Publish any pre-production finders from Specialist Publisher.
            ssh deploy@$(govuk_node_list -c backend --single-node) 'cd /var/apps/specialist-publisher ; govuk_setenv specialist-publisher bundle exec rake publishing_api:publish_finders rummager:publish_finders'
-           # Update govuk-delivery's database for this environment.
-           ssh deploy@$(govuk_node_list -c backend --single-node) 'cd /var/apps/govuk-delivery ; govuk_setenv govuk-delivery ./venv/bin/python scripts/update_data_after_sync.py'
     publishers:
         - trigger-parameterized-builds:
             <%- %w{ publishing-api collections-publisher service-manual-publisher local-links-manager email-alert-api transition link-checker-api content-performance-manager content-tagger }.each do |app| -%>
@@ -34,10 +32,5 @@
                 TARGET_APPLICATION=whitehall
                 MACHINE_CLASS=whitehall_backend
                 RAKE_TASK=publishing:scheduled:requeue_all_jobs
-            - project: run-rake-task
-              predefined-parameters: |
-                TARGET_APPLICATION=email-alert-api
-                MACHINE_CLASS=backend
-                RAKE_TASK=sync_govdelivery_topic_mappings
         - email:
             recipients: govuk-ci-notifications@digital.cabinet-office.gov.uk

--- a/modules/govuk_jenkins/templates/jobs/data_sync_complete_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/data_sync_complete_staging.yaml.erb
@@ -21,14 +21,6 @@
            ssh deploy@$(govuk_node_list -c whitehall_backend --single-node) 'cd /var/apps/whitehall ; govuk_setenv whitehall bundle exec rake publishing:scheduled:requeue_all_jobs'
            # Queue up any publisher scheduled editions that have been transferred across.
            ssh deploy@$(govuk_node_list -c backend --single-node) 'cd /var/apps/publisher ; govuk_setenv publisher bundle exec rake editions:requeue_scheduled_for_publishing'
-           # Update govuk-delivery's database for this environment.
-           ssh deploy@$(govuk_node_list -c backend --single-node) 'cd /var/apps/govuk-delivery ; govuk_setenv govuk-delivery ./venv/bin/python scripts/update_data_after_sync.py'
     publishers:
-        - trigger-parameterized-builds:
-            - project: run-rake-task
-              predefined-parameters: |
-                TARGET_APPLICATION=email-alert-api
-                MACHINE_CLASS=backend
-                RAKE_TASK=sync_govdelivery_topic_mappings
         - email:
             recipients: govuk-ci-notifications@digital.cabinet-office.gov.uk


### PR DESCRIPTION
Depends on https://github.com/alphagov/whitehall/pull/3446 being merged to avoid Whitehall errors.

Whitehall is now sending email via the publishing API rabbit queue -> email-alert-service -> email-alert-api and no longer uses `govuk_delivery`.

This PR removes it from our infrastructure.

[Trello](https://trello.com/c/xHgvQXOX/137-archive-and-remove-govuk-delivery)

