### PR TITLE
Configure sidekiq for asset manager

### DIFF
--- a/development-vm/Pinfile
+++ b/development-vm/Pinfile
@@ -2,8 +2,9 @@
 # See https://github.com/JordanHatch/bowler for some more info
 
 process :'authenticating-proxy' => [:'government-frontend']
-process :'asset-manager' => [:'asset-manager-worker']
+process :'asset-manager' => [:'asset-manager-worker', :'asset-manager-sidekiq']
 process :'asset-manager-worker'
+process :'asset-manager-sidekiq'
 process :backdrop => [:backdrop_read, :backdrop_write, :stagecraft]
 process :backdrop_read
 process :backdrop_write

--- a/development-vm/Procfile
+++ b/development-vm/Procfile
@@ -40,6 +40,7 @@ travel_advice_publisher_worker: govuk_setenv travel-advice-publisher ./run_in.sh
 release:               govuk_setenv release               ./run_in.sh ../../release        bundle exec rails server -p 3036
 asset-manager:         govuk_setenv asset-manager         ./run_in.sh ../../asset-manager  bundle exec rails server -p 3037
 asset-manager-worker:  govuk_setenv asset-manager         ./run_in.sh ../../asset-manager  bundle exec rake jobs:work
+asset-manager-sidekiq:  govuk_setenv asset-manager         ./run_in.sh ../../asset-manager  bundle exec sidekiq -C ./config/sidekiq.yml
 # limelight used port 3040
 # transaction_wrappers used port 3041
 govuk-delivery:        govuk_setenv govuk-delivery        ./run_in.sh ../../govuk-delivery ./startup.sh # govuk-delivery uses port 3042

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -226,6 +226,9 @@ govuk::apps::asset_manager::mongodb_nodes:
   - 'mongo-1.backend'
   - 'mongo-2.backend'
   - 'mongo-3.backend'
+govuk::apps::asset_manager::redis_host: "%{hiera('sidekiq_host')}"
+govuk::apps::asset_manager::redis_port: "%{hiera('sidekiq_port')}"
+
 govuk::apps::authenticating_proxy::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
 
 govuk::apps::bouncer::db_hostname: "transition-postgresql-slave-1.backend"


### PR DESCRIPTION
Contributes to: https://github.com/alphagov/asset-manager/issues/179

I've followed the [instructions in govuk_sidekiq](https://github.com/alphagov/govuk_sidekiq#4-configure-puppet) to configure puppet to run Sidekiq for asset manager. The relevant worker config [was added to Asset manager in this PR](https://github.com/alphagov/asset-manager/pull/191) and deployed to production in `release_136`. 

I'll open a separate PR against `govuk_app_deployment` to restart the workers on deploy. 

Does this look OK @tijmenb? 