### PR TITLE
Try to slow down SharePoint crawlers causing too many 429s

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1612,6 +1612,10 @@ router::nginx::robotstxt: |
   # whether or not it supports crawl-delay.
   User-agent: deepcrawl
   Disallow: /
+  # Complaints of 429 'Too many requests' seem to be coming from SharePoint servers
+  # (https://social.msdn.microsoft.com/Forums/en-US/3ea268ed-58a6-4166-ab40-d3f4fc55fef4)
+  User-agent: Mozilla/4.0 (compatible; MSIE 4.01; Windows NT; MS Search 6.0 Robot)
+  Crawl-delay: 1
 
 sidekiq_host: 'redis-1.backend'
 sidekiq_port: '6379'

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1596,6 +1596,10 @@ router::nginx::robotstxt: |
   # whether or not it supports crawl-delay.
   User-agent: deepcrawl
   Disallow: /
+  # Complaints of 429 'Too many requests' seem to be coming from SharePoint servers
+  # (https://social.msdn.microsoft.com/Forums/en-US/3ea268ed-58a6-4166-ab40-d3f4fc55fef4)
+  User-agent: Mozilla/4.0 (compatible; MSIE 4.01; Windows NT; MS Search 6.0 Robot)
+  Crawl-delay: 1
 
 sidekiq_host: 'redis-1.backend'
 sidekiq_port: '6379'


### PR DESCRIPTION
We've identified that this user agent that is used by SharePoint servers
(https://social.msdn.microsoft.com/Forums/en-US/3ea268ed-58a6-4166-ab40-d3f4fc55fef4)
is hitting GOV.UK with too many requests causing our mointoring to go above it's threshold
often.

We're adding a crawl-delay here in the hopes it'll slow down these requests but we're
not sure if the crawl-delay directive is implemented by SharePoint, so this may need to be reviewed later.