### PR TITLE
Switch link-checker-api to redis2

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -285,7 +285,7 @@ govuk::apps::hmrc_manuals_api::redis_port: "%{hiera('sidekiq_port')}"
 
 govuk::apps::link_checker_api::db_hostname: "postgresql-primary-1.backend"
 govuk::apps::link_checker_api::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
-govuk::apps::link_checker_api::redis_host: "%{hiera('sidekiq_host')}"
+govuk::apps::link_checker_api::redis_host: "redis-2.backend"
 govuk::apps::link_checker_api::redis_port: "%{hiera('sidekiq_port')}"
 
 govuk::apps::manuals_publisher::redis_host: "%{hiera('sidekiq_host')}"


### PR DESCRIPTION
For: https://trello.com/c/7WBKFT7W/231-investigate-support-api-timeouts

Link-checker-api needs more memory in order to perform, as it's currently causing timeouts for support-api every time it runs.

Moving it to its own redis will alleviate the load on the original redis in order to handle support-api requests successfully.