### PR TITLE
Could not retrieve catalog from remote server: Error 400 on SERVER:

### DIFF
--- a/modules/govuk_mysql/manifests/server/logging.pp
+++ b/modules/govuk_mysql/manifests/server/logging.pp
@@ -38,7 +38,7 @@ class govuk_mysql::server::logging(
     }
 
     @filebeat::prospector { 'mysql-slow-query-logs':
-      paths  => $slow_query_log,
+      paths  => [$slow_query_log],
       tags   => ['slow-query'],
       fields => {'application' => 'mysql'},
     }


### PR DESCRIPTION
"/var/log/mysql/mysql-slow.log" is not an Array.  It looks to be a
String at
/usr/share/puppet/production/current/modules/filebeat/manifests/prospector.pp:39
on node mysql-slave-1.backend.integration.publishing.service.gov.uk.

[This was caused by providing a string for array]