### PR TITLE
Add internal aliases to nginx proxy in AWS

### DIFF
--- a/modules/nginx/manifests/config/vhost/proxy.pp
+++ b/modules/nginx/manifests/config/vhost/proxy.pp
@@ -118,11 +118,14 @@ define nginx::config::vhost::proxy(
     # We want to add the internal version of the domain everywhere in AWS,
     # but when this defined type is called the external domain name is appended.
     # We want the plain app name, which we can then add in the template.
+    $app_domain_internal = hiera('app_domain_internal')
     if $name =~ /\.(.*)/ {
       $app_name = regsubst($name, '\.(.*)', '')
-      $app_domain_internal = hiera('app_domain_internal')
       $name_internal = "${app_name}.${app_domain_internal}"
+
+      $internal_aliases = regsubst($aliases, '\.(.*)', ".${app_domain_internal}")
     }
+
   }
 
   nginx::config::ssl { $name:

--- a/modules/nginx/templates/proxy-vhost.conf
+++ b/modules/nginx/templates/proxy-vhost.conf
@@ -29,7 +29,7 @@ server {
 <%- ports.each do |port| -%>
 server {
   <%- if scope.lookupvar('::aws_migration') %>
-  server_name <%= @name %> <%= @name_internal %> <%= @aliases.join(" ") unless @aliases.empty? %>;
+  server_name <%= @name %> <%= @name_internal %> <%= @aliases.join(" ") unless @aliases.empty? %> <%= @internal_aliases.join(" ") unless @aliases.empty? %>;
   <%- else %>
   server_name <%= @name %> <%= @aliases.join(" ") unless @aliases.empty? %>;
   <%- end %>


### PR DESCRIPTION
I added code previously that would automatically add the internal domain to any nginx vhost servernames:

`server_name foo.external foo.internal`

Sometimes apps pass in aliases to this class, and somewhere up the line the (in the `govuk::app::config` class) we append the external domain to every alias. We should also include the internal alias.

https://trello.com/c/fenlgsMp/745-make-icinga-in-aws-green