### PR TITLE
Show more app info on deployment dashboard

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -885,8 +885,6 @@ grafana::dashboards::deployment_applications:
     # Missing @fields.status
     show_controller_errors: false
   imminence:
-    # Missing @fields.status
-    show_controller_errors: false
     has_workers: true
   info-frontend: {}
   licencefinder:
@@ -895,13 +893,8 @@ grafana::dashboards::deployment_applications:
     show_slow_requests: false
     docs_name: 'licence-finder'
   link-checker-api:
-    # Missing kibana logs with this name
-    show_controller_errors: false
-    show_slow_requests: false
-  local-links-manager:
-    # Missing status, duration, controller
-    show_controller_errors: false
-    show_slow_requests: false
+    has_workers: true
+  local-links-manager: {}
   manuals-frontend:
     # Missing status, duration, controller
     show_controller_errors: false

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -887,8 +887,6 @@ grafana::dashboards::deployment_applications:
     # Missing @fields.status
     show_controller_errors: false
   imminence:
-    # Missing @fields.status
-    show_controller_errors: false
     has_workers: true
   info-frontend: {}
   licencefinder:
@@ -897,13 +895,8 @@ grafana::dashboards::deployment_applications:
     show_slow_requests: false
     docs_name: 'licence-finder'
   link-checker-api:
-    # Missing kibana logs with this name
-    show_controller_errors: false
-    show_slow_requests: false
-  local-links-manager:
-    # Missing status, duration, controller
-    show_controller_errors: false
-    show_slow_requests: false
+    has_workers: true
+  local-links-manager: {}
   manuals-frontend:
     # Missing status, duration, controller
     show_controller_errors: false

--- a/modules/govuk/manifests/apps/link_checker_api.pp
+++ b/modules/govuk/manifests/apps/link_checker_api.pp
@@ -73,11 +73,12 @@ class govuk::apps::link_checker_api (
   include govuk_postgresql::client #installs libpq-dev package needed for pg gem
 
   govuk::app { $app_name:
-    app_type          => 'rack',
-    port              => $port,
-    sentry_dsn        => $sentry_dsn,
-    vhost_ssl_only    => true,
-    health_check_path => '/healthcheck',
+    app_type           => 'rack',
+    log_format_is_json => true,
+    port               => $port,
+    sentry_dsn         => $sentry_dsn,
+    vhost_ssl_only     => true,
+    health_check_path  => '/healthcheck',
   }
 
   Govuk::App::Envvar {


### PR DESCRIPTION
Start collecting json logs from link-checker-api.

Once we do this, we can then show more information for it on the deployment dashboard.  We also  show extra panels for imminence and local-links-manager.