### PR TITLE
Expose DATABASE_URL for Transition

### DIFF
--- a/hieradata/vagrant_credentials.yaml
+++ b/hieradata/vagrant_credentials.yaml
@@ -57,6 +57,7 @@ govuk::apps::signon::db::mysql_signonotron: 'Yo68brC26TBdCf2NzCmwszv9UHtqbH8G'
 govuk::apps::stagecraft::postgresql_db::password: 'stagecraft_postgresql_password'
 govuk::apps::support_api::db::password: '6ba55037a05b6d7061d5401305bd0c43'
 govuk::apps::transition::postgresql_db::password: 'ood8Michej4phaquuchi'
+govuk::apps::transition::db_password: 'ood8Michej4phaquuchi'
 govuk::apps::whitehall::db::mysql_whitehall_admin: 'lB2gKNzWLBt75P8qBEtKkkCapePqAvd2'
 
 govuk_cdnlogs::server_key: |

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -500,6 +500,8 @@ govuk::apps::support_api::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::support_api::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::support_api::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 
+govuk::apps::transition::db_password: "%{hiera('govuk::apps::transition::db::password')}"
+govuk::apps::transition::db_hostname: "transition-postgresql-master-1.backend"
 govuk::apps::transition::postgresql_db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 govuk::apps::transition::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::transition::redis_port: "%{hiera('sidekiq_port')}"

--- a/modules/govuk/manifests/apps/transition.pp
+++ b/modules/govuk/manifests/apps/transition.pp
@@ -50,6 +50,18 @@
 # [*ga_token_uri*]
 #   Authentication credentials for Google Analytics
 #
+# [*db_hostname*]
+#   The hostname of the database server to use in the DATABASE_URL.
+#
+# [*db_username*]
+#   The username to use in the DATABASE_URL.
+#
+# [*db_password*]
+#   The password for the database.
+#
+# [*db_name*]
+#   The database name to use in the DATABASE_URL.
+#
 class govuk::apps::transition(
   $port = '3044',
   $enable_procfile_worker = true,
@@ -69,6 +81,10 @@ class govuk::apps::transition(
   $ga_client_x509_cert_url = undef,
   $ga_key_p12_b64 = undef,
   $ga_token_uri = undef,
+  $db_hostname = undef,
+  $db_username = 'transition',
+  $db_password = undef,
+  $db_name = 'transition_production',
 ) {
   $app_name = 'transition'
 
@@ -95,6 +111,16 @@ class govuk::apps::transition(
   govuk::app::envvar::redis { $app_name:
     host => $redis_host,
     port => $redis_port,
+  }
+
+  if $::govuk_node_class !~ /^(development|training)$/ {
+    govuk::app::envvar::database_url { $app_name:
+      type     => 'postgresql',
+      username => $db_username,
+      password => $db_password,
+      host     => $db_hostname,
+      database => $db_name,
+    }
   }
 
   if $secret_key_base {


### PR DESCRIPTION
This sets up the DATABASE_URL for transition, so we can remove the config from alphagov-deployment (which overwrites database.yml).

PR to set database password: https://github.com/alphagov/govuk-secrets/pull/59.

https://trello.com/c/bxvXAF4S