### PR TITLE
AWS override Errbit domain

### DIFF
--- a/modules/govuk/manifests/deploy/config.pp
+++ b/modules/govuk/manifests/deploy/config.pp
@@ -102,6 +102,7 @@ class govuk::deploy::config(
     govuk_envvar {
       'PLEK_SERVICE_RUMMAGER_URI': value => "https://rummager.${app_domain_internal}";
       'PLEK_SERVICE_SEARCH_URI': value   => "https://search.${app_domain_internal}";
+      'PLEK_SERVICE_ERRBIT_URI': value   => "https://errbit.${app_domain_internal}";
     }
 
   }


### PR DESCRIPTION
On AWS, use the internal domain to connect applications with the Errbit service.