### PR TITLE
Revert "Remove LV and manual mounting in the AWS mapit"

### DIFF
--- a/hieradata_aws/class/mapit.yaml
+++ b/hieradata_aws/class/mapit.yaml
@@ -3,4 +3,15 @@
 govuk::node::s_base::apps:
   - mapit
 
+lv:
+  data:
+    pv: '/dev/xvdf'
+    vg: 'postgresql'
+
+mount:
+  /var/lib/postgresql:
+    disk: '/dev/mapper/postgresql-data'
+    govuk_lvm: 'data'
+    mountoptions: 'defaults'
+
 govuk_postgresql::server::listen_addresses: localhost

--- a/modules/govuk/manifests/node/s_mapit.pp
+++ b/modules/govuk/manifests/node/s_mapit.pp
@@ -3,11 +3,10 @@
 class govuk::node::s_mapit inherits govuk::node::s_base {
 
   include nginx
-  include ::govuk_postgresql::server::standalone
 
-  if ! $::aws_migration {
-    Govuk_mount['/var/lib/postgresql'] -> Class['govuk_postgresql::server::standalone']
-  }
+  Govuk_mount['/var/lib/postgresql']
+  ->
+  class { 'govuk_postgresql::server::standalone': }
 
   include collectd::plugin::memcached
   class { 'memcached':


### PR DESCRIPTION
Reverts alphagov/govuk-puppet#6375

- In the commit this reverts, the `mount /var/lib/postgresql ...` line was made to not be
executed on AWS (reasons unknown). However, in trying to make Puppet
run successfully for MapIt machines, we realised we needed this (and
accompanying volumes and mountpoints in mapit.yaml), a) to match the
existing and b) because the data is mounted into this directory.
ElasticSearch on AWS works in this way with volumes and data, so
there's prior art for this approach.

(Tested this revert on the MapIt machines in AWS by deploying a branch of Puppet and it ran successfully.)