### PR TITLE
Fix deployments of govuk_crawler_worker to AWS

### DIFF
--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -769,7 +769,7 @@ def uploadArtefactToS3(artefact_path, s3_path){
                      credentialsId: 'govuk-s3-artefact-creds',
                      usernameVariable: 'AWS_ACCESS_KEY_ID',
                      passwordVariable: 'AWS_SECRET_ACCESS_KEY']]){
-    sh "s3cmd --region eu-west-1 --access_key $AWS_ACCESS_KEY_ID --secret_key $AWS_SECRET_ACCESS_KEY put $artefact_path $s3_path"
+    sh "s3cmd --region eu-west-1 --acl-public --access_key $AWS_ACCESS_KEY_ID --secret_key $AWS_SECRET_ACCESS_KEY put $artefact_path $s3_path"
   }
 }
 

--- a/modules/govuk_jenkins/manifests/job/deploy_app.pp
+++ b/modules/govuk_jenkins/manifests/job/deploy_app.pp
@@ -19,6 +19,10 @@ class govuk_jenkins::job::deploy_app (
   $ci_deploy_jenkins_api_key = undef,
   $applications = undef,
 ) {
+  if $::aws_migration {
+    $aws_deploy = true
+  }
+
   file { '/etc/jenkins_jobs/jobs/deploy_app.yaml':
     ensure  => present,
     content => template('govuk_jenkins/jobs/deploy_app.yaml.erb'),

--- a/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
@@ -29,6 +29,10 @@
             export TAG="$TAG"
             export ORGANISATION="<%= @environment -%>"
             export CI_DEPLOY_JENKINS_API_KEY="<%= @ci_deploy_jenkins_api_key -%>"
+            <%- if @aws_deploy %>
+            export USE_S3="true"
+            export S3_ARTEFACT_BUCKET="govuk-integration-artefact"
+            <% end -%>
 
             if [ "$DEPLOY_FROM_GITHUB_ENTERPRISE" == "true" ]; then
               export GIT_ORIGIN_PREFIX="git@github.digital.cabinet-office.gov.uk:gds-production-backup"


### PR DESCRIPTION
Enable deployments of govuk_crawler_worker to AWS from S3.

It:
* makes artefacts uploaded to the s3 artefact bucket publicly readable
* sets the appropriate environment variables in Jenkins to use the S3
bucket