### PR TITLE
Sidekiq monitoring for asset manager

### DIFF
--- a/development-vm/Procfile
+++ b/development-vm/Procfile
@@ -41,6 +41,7 @@ release:               govuk_setenv release               ./run_in.sh ../../rele
 asset-manager:         govuk_setenv asset-manager         ./run_in.sh ../../asset-manager  bundle exec rails server -p 3037
 asset-manager-worker:  govuk_setenv asset-manager         ./run_in.sh ../../asset-manager  bundle exec rake jobs:work
 asset-manager-sidekiq:  govuk_setenv asset-manager         ./run_in.sh ../../asset-manager  bundle exec sidekiq -C ./config/sidekiq.yml
+# asset-manager sidekiq monitoring uses 3038
 # limelight used port 3040
 # transaction_wrappers used port 3041
 govuk-delivery:        govuk_setenv govuk-delivery        ./run_in.sh ../../govuk-delivery ./startup.sh # govuk-delivery uses port 3042

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -420,6 +420,8 @@ govuk::apps::service_manual_publisher::http_password: "%{hiera('http_password')}
 
 govuk::apps::service_manual_publisher::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 
+govuk::apps::sidekiq_monitoring::asset_manager_redis_host: "%{hiera('govuk::apps::asset_manager::redis_host')}"
+govuk::apps::sidekiq_monitoring::asset_manager_redis_port: "%{hiera('govuk::apps::asset_manager::redis_port')}"
 govuk::apps::sidekiq_monitoring::content_performance_manager_redis_host: "%{hiera('govuk::apps::content_performance_manager::redis_host')}"
 govuk::apps::sidekiq_monitoring::content_performance_manager_redis_port: "%{hiera('govuk::apps::content_performance_manager::redis_port')}"
 govuk::apps::sidekiq_monitoring::content_tagger_redis_host: "%{hiera('govuk::apps::content_tagger::redis_host')}"

--- a/modules/govuk/manifests/apps/sidekiq_monitoring.pp
+++ b/modules/govuk/manifests/apps/sidekiq_monitoring.pp
@@ -3,6 +3,13 @@
 # App to monitor Sidekiq for multiple GOV.UK apps.
 #
 # === Parameters
+# [*asset_manager_redis_host*]
+#   Redis host for Asset Manager Sidekiq.
+#   Default: undef
+#
+# [*asset_manager_redis_port*]
+#   Redis port for Asset Manager Sidekiq.
+#   Default: undef
 #
 # [*content_performance_manager_redis_host*]
 #   Redis host for Content Performance Manager Sidekiq.
@@ -109,6 +116,8 @@
 #   Default: undef
 #
 class govuk::apps::sidekiq_monitoring (
+  $asset_manager_redis_host = undef,
+  $asset_manager_redis_port = undef,
   $content_performance_manager_redis_host = undef,
   $content_performance_manager_redis_port = undef,
   $content_tagger_redis_host = undef,
@@ -152,6 +161,11 @@ class govuk::apps::sidekiq_monitoring (
   }
 
   govuk::app::envvar::redis{
+    "${app_name}_asset_manager":
+      prefix => 'asset_manager',
+      host   => $asset_manager_redis_host,
+      port   => $asset_manager_redis_port;
+
     "${app_name}_content_performance_manager":
       prefix => 'content_performance_manager',
       host   => $content_performance_manager_redis_host,

--- a/modules/govuk/templates/sidekiq_monitoring_nginx_config.conf.erb
+++ b/modules/govuk/templates/sidekiq_monitoring_nginx_config.conf.erb
@@ -14,6 +14,10 @@ server {
     try_files $uri/index.html $uri.html $uri @app;
   }
 
+  location /asset-manager {
+    proxy_pass http://localhost:3038;
+  }
+
   location /content-performance-manager {
     proxy_pass http://localhost:3207;
   }


### PR DESCRIPTION
This PR enables monitoring for the Asset Manager Sidekiq queues as per [these instructions](https://docs.publishing.service.gov.uk/manual/setting-up-new-sidekiq-monitoring-app.html). 

The [companion PR](https://github.com/alphagov/sidekiq-monitoring/pull/32) against `alphagov/sidekiq-monitoring` adds the monitoring web interface.