### PR TITLE
Add Nginx config for Asset Manager Rails asset pipeline assets

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1530,6 +1530,7 @@ resolvconf::options:
 # Note: it's important that all targets here have matching host entries both in
 # production, and on the dev VM, otherwise nginx will fail to start.
 router::assets_origin::asset_routes:
+  '/asset-manager': "asset-manager"
   '/calculators/': "calculators"
   '/calendars/': "calendars"
   '/collections/': "collections"


### PR DESCRIPTION
We have enabled the Rails asset pipeline for Asset Manager in alphagov/asset-manager#199 and enabled asset precompilation in alphagov/govuk-app-deployment#183. In order to make the Rails asset pipeline assets in Asset Manager available to members of the public, we need to add this Nginx configuration which conforms to the same pattern as other Rails apps, e.g. calculators.

As explained in alphagov/asset-manager#199, we need this in order to move the `thumbnail-placeholder.png` image from Whitehall to Asset Manager as part of the plan to serve Whitehall assets from Asset Manager as described in alphagov/asset-manager#200.

I've run `govuk_puppet` with these changes on my development-vm and it added the following lines to `/etc/nginx/sites-available/assets-origin.dev.gov.uk` as I expected:

    location /asset-manager {
      proxy_set_header Host asset-manager.dev.gov.uk;
      proxy_pass http://asset-manager.dev.gov.uk;
    }

I also then tested the change by adding an image to Asset Manager at `app/assets/images/example.png`, using the Rails console to obtain the URL path for the image, and then requesting the image using `curl` via the `assets-origin.dev.gov.uk` host. The Asset Manager Rails app successfully served the image at the following URL, so I'm happy that this configuration change is correct.

    http://assets-origin.dev.gov.uk/asset-manager/example-721110d114be906508233916f3750f05576596ef0d51ed839c931912ca67eede.png

For further details of this test, see the output below:

```
vagrant@development:/var/govuk/asset-manager$ bundle exec rails c
Loading development environment (Rails 4.2.7.1)
irb(main):001:0> helper.image_url('example.png')
=> "/asset-manager/example-721110d114be906508233916f3750f05576596ef0d51ed839c931912ca67eede.png"

jamesmead@trooz:~$ curl -s -v http://assets-origin.dev.gov.uk/asset-manager/example-721110d114be906508233916f3750f05576596ef0d51ed839c931912ca67eede.png >/dev/null
*   Trying 10.1.1.254...
* TCP_NODELAY set
* Connected to assets-origin.dev.gov.uk (10.1.1.254) port 80 (#0)
> GET /asset-manager/example-721110d114be906508233916f3750f05576596ef0d51ed839c931912ca67eede.png HTTP/1.1
> Host: assets-origin.dev.gov.uk
> User-Agent: curl/7.54.0
> Accept: */*
> 
< HTTP/1.1 200 OK 
< Server: nginx
< Date: Tue, 19 Sep 2017 12:02:33 GMT
< Content-Type: image/png
< Content-Length: 244876
< Connection: close
< Cache-Control: public, max-age=31536000
< Etag: "721110d114be906508233916f3750f05576596ef0d51ed839c931912ca67eede"
< X-Request-Id: b473d3ba-a6b7-4719-9f17-631e7a84c0f7
< X-Runtime: 0.163211
< X-Frame-Options: DENY
< Access-Control-Allow-Origin: *
< Access-Control-Allow-Methods: GET, OPTIONS
< Access-Control-Allow-Headers: origin, authorization
< 
{ [13633 bytes data]
* Closing connection 0
```

Closes alphagov/asset-manager#202.