### PR TITLE
Fix the transition db hostname on Carrenza

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -499,6 +499,7 @@ govuk::apps::support_api::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::support_api::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 
 govuk::apps::transition::postgresql_db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
+govuk::apps::transition::db_hostname: "transition-postgresql-master-1.backend"
 govuk::apps::transition::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::transition::redis_port: "%{hiera('sidekiq_port')}"
 


### PR DESCRIPTION
In https://github.com/alphagov/govuk-puppet/pull/6494 I tried to set the `DATABASE_URL` for transition, but I put the value in `hieradata_aws/common.yaml` instead of `hieradata/common.yaml`.

This causes a half DATABASE_URL to be set, causing the app to crash (https://deploy.integration.publishing.service.gov.uk/job/Deploy_App/3416/console). Sad.