### PR TITLE
Don't double declare classes for draft stack

### DIFF
--- a/modules/govuk/manifests/deploy/config.pp
+++ b/modules/govuk/manifests/deploy/config.pp
@@ -99,6 +99,9 @@ class govuk::deploy::config(
   if $::aws_migration {
     $app_domain_internal = hiera('app_domain_internal')
 
+    # These variables are manually set in the draft stack (e.g. s_draft_cache),
+    # make sure they're separated out in those locations otherwise puppet
+    # won't run cleanly.
     govuk_envvar {
       'PLEK_SERVICE_RUMMAGER_URI': value => "https://rummager.${app_domain_internal}";
       'PLEK_SERVICE_SEARCH_URI': value   => "https://search.${app_domain_internal}";

--- a/modules/govuk/manifests/node/s_draft_cache.pp
+++ b/modules/govuk/manifests/node/s_draft_cache.pp
@@ -12,6 +12,12 @@ class govuk::node::s_draft_cache() {
 
   govuk_envvar {
     'PLEK_HOSTNAME_PREFIX': value => 'draft-';
-    'PLEK_SERVICE_ERRBIT_URI': value => "https://errbit.${app_domain}";
+  }
+
+  unless $::aws_migration {
+    # This is set for all apps in AWS so we skip adding it here
+    govuk_envvar {
+      'PLEK_SERVICE_ERRBIT_URI': value => "https://errbit.${app_domain}";
+    }
   }
 }

--- a/modules/govuk/manifests/node/s_draft_content_store.pp
+++ b/modules/govuk/manifests/node/s_draft_content_store.pp
@@ -13,7 +13,13 @@ class govuk::node::s_draft_content_store() inherits govuk::node::s_base {
 
   govuk_envvar {
     'PLEK_HOSTNAME_PREFIX': value => 'draft-';
-    'PLEK_SERVICE_ERRBIT_URI': value => "https://errbit.${app_domain}";
+  }
+
+  unless $::aws_migration {
+    # This is set for all apps in AWS so we skip adding it here
+    govuk_envvar {
+      'PLEK_SERVICE_ERRBIT_URI': value => "https://errbit.${app_domain}";
+    }
   }
 }
 

--- a/modules/govuk/manifests/node/s_draft_frontend.pp
+++ b/modules/govuk/manifests/node/s_draft_frontend.pp
@@ -12,11 +12,17 @@ class govuk::node::s_draft_frontend() inherits govuk::node::s_base {
 
   govuk_envvar {
     'PLEK_HOSTNAME_PREFIX': value => 'draft-';
-    'PLEK_SERVICE_ERRBIT_URI': value => "https://errbit.${app_domain}";
     'PLEK_SERVICE_IMMINENCE_URI': value => "https://imminence.${app_domain}";
     'PLEK_SERVICE_LICENSIFY_URI': value => "https://licensify.${app_domain}";
     'PLEK_SERVICE_LOCAL_LINKS_MANAGER_URI': value => "https://local-links-manager.${app_domain}";
     'PLEK_SERVICE_MAPIT_URI': value  => "https://mapit.${app_domain}";
-    'PLEK_SERVICE_SEARCH_URI': value => "https://search.${app_domain}";
+  }
+
+  unless $::aws_migration {
+    # This is set for all apps in AWS so we skip adding it here
+    govuk_envvar {
+      'PLEK_SERVICE_ERRBIT_URI': value => "https://errbit.${app_domain}";
+      'PLEK_SERVICE_SEARCH_URI': value => "https://search.${app_domain}";
+    }
   }
 }


### PR DESCRIPTION
The draft stack manually over-rides several plek services. These are
also over-ridden in AWS causing puppet errors as it tries to create
duplicate catalogue entries.

This makes sure the entries aren't duplicated.