### PR TITLE
Add check for filebeat

### DIFF
--- a/modules/filebeat/spec/defines/filebeat__prospector_spec.rb
+++ b/modules/filebeat/spec/defines/filebeat__prospector_spec.rb
@@ -1,0 +1,42 @@
+require_relative '../../../../spec_helper'
+
+describe 'filebeat::prospector', :type => :define do
+  let(:title) { 'apple' }
+  let (:default_params) {{
+    :paths => ['/path/to/file'],
+  }}
+
+  context 'with minimal settings' do
+    let(:params) { default_params }
+
+    it { should contain_file('filebeat-apple').with_path(
+      '/etc/filebeat/conf.d/apple.yml'
+    ).with_content(
+      /---\nfilebeat:\n  prospectors:\n    - input_type: log\n      paths:\n        - \/path\/to\/file/
+    ) }
+  end
+
+  context 'if add_error_key set to true' do
+    let(:params) { default_params.merge({
+      :json => {'add_error_key' => true}
+    })}
+
+    it { should contain_file('filebeat-apple').with_path(
+      '/etc/filebeat/conf.d/apple.yml'
+    ).with_content(
+      /add_error_key: true/
+    ) }
+  end
+
+  context 'if add_error_key set to undef' do
+    let(:params) { default_params.merge({
+      :json => {'add_error_key' => 'undef'}
+    })}
+
+    it { should_not contain_file('filebeat-apple').with_path(
+      '/etc/filebeat/conf.d/apple.yml'
+    ).with_content(
+      /add_error_key: true/
+    ) }
+  end
+end

--- a/modules/filebeat/templates/prospector.yml.erb
+++ b/modules/filebeat/templates/prospector.yml.erb
@@ -92,7 +92,7 @@ filebeat:
           # If this setting is enabled, Filebeat adds a "json_error" key in case of JSON
           # unmarshaling errors or when a text key is defined in the configuration but cannot
           # be used.
-          <%- if @json['add_error_key'] -%>
+          <%- if [true, false].include? @json['add_error_key'] -%>
           add_error_key: <%= @json['add_error_key'] %>
           <%- end -%>
       <%- end -%>


### PR DESCRIPTION
In our code we set a conditional that either sets `true` or `undef`:

https://github.com/alphagov/govuk-puppet/blob/a4d60bd1f1cd9782658b5d7e65032e01ca6c1870/modules/govuk/manifests/app.pp#L361-L366

The Ruby code in the template treats both as a string, so are set to `true`, but if `undef` is set, then this is written into the configuration file, which causes filebeat to fail on start up:

```
2017-09-19T12:09:43Z CRIT Exiting: Error in initing prospector: can not convert 'string' into 'bool' accessing 'filebeat.prospectors.0.json.add_error_key' (source:'/etc/filebeat/conf.d/asset-manager-app-err.yml')
Exiting: Error in initing prospector: can not convert 'string' into 'bool' accessing 'filebeat.prospectors.0.json.add_error_key' (source:'/etc/filebeat/conf.d/asset-manager-app-err.yml')
```

This adds a condition that if the value of the key "add_error_key" is set to a boolean then print it, otherwise do not add that option.

This also adds some tests to help catch any errors.