### PR TITLE
Use common node runtime for performance platform

### DIFF
--- a/hieradata/class/performance_backend.yaml
+++ b/hieradata/class/performance_backend.yaml
@@ -1,6 +1,4 @@
 ---
 
-nodejs::version: '0.10.37-1chl1~%{::lsbdistcodename}1'
-
 govuk::node::s_base::apps:
   - performanceplatform_admin

--- a/hieradata/class/performance_frontend.yaml
+++ b/hieradata/class/performance_frontend.yaml
@@ -1,7 +1,5 @@
 ---
 
-nodejs::version: '0.10.37-1chl1~%{::lsbdistcodename}1'
-
 govuk::node::s_base::apps:
   - performanceplatform_big_screen_view
   - spotlight


### PR DESCRIPTION
The Performance Platform Spotlight app has been upgraded to v6.11.2 so we need to remove the use of node 0.10.37 on the PP frontend and backend boxes.