### PR TITLE
AWS puppet-node-clean filter terminated

### DIFF
--- a/modules/puppet/files/puppet_node_clean.sh
+++ b/modules/puppet/files/puppet_node_clean.sh
@@ -16,7 +16,7 @@ fi
 awk 'FNR==NR{ array[$0];next}
 { if ( $1 in array ) next
 print $1}
-' <(aws ec2 describe-instances --filters "Name=tag:aws_stackname,Values=${STACKNAME}" --output=json | jq -r '.Reservations[] | .Instances[] | .InstanceId ') <(curl 'http://localhost:8080/v3/nodes' 2>/dev/null | grep name | awk '{print $3}' | tr -d '",') | while read NODE
+' <(aws ec2 describe-instances --filters "Name=tag:aws_stackname,Values=${STACKNAME}" "Name=instance-state-name,Values=pending,running,shutting-down,stopping,stopped" --output=json | jq -r '.Reservations[] | .Instances[] | .InstanceId ') <(curl 'http://localhost:8080/v3/nodes' 2>/dev/null | grep name | awk '{print $3}' | tr -d '",') | while read NODE
 do
   echo "[$(date '+%H:%M:%S %d-%m-%Y')] Preparing to delete: ${NODE}:"
   curl http://localhost:8080/v3/nodes/${NODE}/facts/aws_migration


### PR DESCRIPTION
The puppet-node-clean cron job removes instances from Puppetdb that no
longer exist on AWS. Terminated instances take a little bit of time to
fully disappear from AWS and during this time its status is set to `terminated`.

To make sure we clean Puppetdb nodes in time and we don't have nodes down
on our monitoring, for instance, for a long period of time, we can update
the puppet-node-clean job to also remove instances with status `terminated`
on AWS.