### PR TITLE
Remove rkhunter

### DIFF
--- a/modules/govuk/manifests/node/s_base.pp
+++ b/modules/govuk/manifests/node/s_base.pp
@@ -24,7 +24,11 @@ class govuk::node::s_base (
   include monitoring::client
   include postfix
   include rcs
-  include rkhunter
+
+  # FIXME remove after deployed to Production
+  class { '::rkhunter':
+    ensure => 'absent',
+  }
 
   if ! $::aws_migration {
     include hosts

--- a/modules/rkhunter/manifests/config.pp
+++ b/modules/rkhunter/manifests/config.pp
@@ -1,5 +1,7 @@
 # FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
-class rkhunter::config {
+class rkhunter::config (
+  $ensure = 'present',
+) {
 
   $disabled_tests = [
     'apps',
@@ -16,12 +18,12 @@ class rkhunter::config {
   ]
 
   file { '/etc/default/rkhunter':
-    ensure => 'present',
+    ensure => $ensure,
     source => 'puppet:///modules/rkhunter/etc/default/rkhunter',
   }
 
   file { '/etc/rkhunter.conf.local':
-    ensure  => 'present',
+    ensure  => $ensure,
     content => template('rkhunter/rkhunter.conf.local.erb'),
   }
 

--- a/modules/rkhunter/manifests/init.pp
+++ b/modules/rkhunter/manifests/init.pp
@@ -2,18 +2,22 @@
 #
 # Install, configure and periodically run rkhunter on our hosts
 #
-class rkhunter {
+class rkhunter (
+  $ensure = 'present',
+){
 
   anchor { 'rkhunter::begin':
     notify => Class['rkhunter::config'];
   }
 
   class { 'rkhunter::package':
+    ensure  => $ensure,
     require => Anchor['rkhunter::begin'],
     notify  => Class['rkhunter::config'],
   }
 
   class { 'rkhunter::config':
+    ensure  => $ensure,
     require => Class['rkhunter::package'],
     notify  => [
       Class['rkhunter::update'],
@@ -26,6 +30,7 @@ class rkhunter {
   }
 
   class { 'rkhunter::monitoring':
+    ensure  => $ensure,
     require => Class['rkhunter::config'],
   }
 

--- a/modules/rkhunter/manifests/monitoring.pp
+++ b/modules/rkhunter/manifests/monitoring.pp
@@ -24,10 +24,18 @@
 #   The hostname of the alert service, to send ncsa notifications.
 #
 class rkhunter::monitoring (
+  $ensure         = 'present',
   $alert_hostname = 'alert.cluster',
 ) {
+
+  if $ensure =~ /present|installed/ {
+    $ensure_dir = 'directory'
+  } else {
+    $ensure_dir = 'absent'
+  }
+
   file { '/var/lib/rkhunter/db':
-    ensure  => directory,
+    ensure  => $ensure_dir,
     owner   => 'root',
     group   => 'nagios',
     mode    => '0750',
@@ -35,6 +43,7 @@ class rkhunter::monitoring (
   }
 
   file { '/var/lib/rkhunter/db/mirrors.dat':
+    ensure  => $ensure,
     owner   => root,
     group   => nagios,
     mode    => '0644',
@@ -53,13 +62,14 @@ class rkhunter::monitoring (
 
   # Script to run rkhunter as a passive check
   file { '/usr/local/bin/rkhunter-passive-check':
-    ensure  => present,
+    ensure  => $ensure,
     mode    => '0755',
     content => template('rkhunter/rkhunter-passive-check.erb'),
   }
 
   # Run it twice a day to stop superfluous alerting
   cron::crondotdee { 'rkhunter-passive-check':
+    ensure  => $ensure,
     command => '/usr/local/bin/rkhunter-passive-check',
     hour    => '6,14',
     minute  => '0',

--- a/modules/rkhunter/manifests/package.pp
+++ b/modules/rkhunter/manifests/package.pp
@@ -1,8 +1,10 @@
 # FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
-class rkhunter::package {
+class rkhunter::package (
+  $ensure = 'installed',
+){
 
   package { 'rkhunter':
-    ensure => installed,
+    ensure => $ensure,
   }
 
   # The rkhunter package adds an entry to cron.daily by default,


### PR DESCRIPTION
rkhunter has a vulnerability where it fetches it's definition updates from sourceforge over http, which means it's ripe for a MITM attack. Reference: http://www.cvedetails.com/cve/CVE-2017-7480/

Remove rkhunter.

/cc @davbo @stephenharker