### PR TITLE
Remove configs for unused transition feature

### DIFF
--- a/modules/govuk/manifests/apps/transition.pp
+++ b/modules/govuk/manifests/apps/transition.pp
@@ -41,15 +41,6 @@
 # [*errbit_api_key*]
 #   Errbit API key used by airbrake
 #
-# [*ga_auth_provider_x509_cert_url*]
-# [*ga_auth_uri*]
-# [*ga_client_email*]
-# [*ga_client_id*]
-# [*ga_client_x509_cert_url*]
-# [*ga_key_p12_b64*]
-# [*ga_token_uri*]
-#   Authentication credentials for Google Analytics
-#
 # [*db_hostname*]
 #   The hostname of the database server to use in the DATABASE_URL.
 #
@@ -74,13 +65,6 @@ class govuk::apps::transition(
   $basic_auth_username = undef,
   $basic_auth_password = undef,
   $errbit_api_key = undef,
-  $ga_auth_provider_x509_cert_url = undef,
-  $ga_auth_uri = undef,
-  $ga_client_email = undef,
-  $ga_client_id = undef,
-  $ga_client_x509_cert_url = undef,
-  $ga_key_p12_b64 = undef,
-  $ga_token_uri = undef,
   $db_hostname = undef,
   $db_username = 'transition',
   $db_password = undef,
@@ -143,27 +127,6 @@ class govuk::apps::transition(
       "${title}-ERRBIT_API_KEY":
         varname => 'ERRBIT_API_KEY',
         value   => $errbit_api_key;
-      "${title}-GA_AUTH_PROVIDER_X509_CERT_URL":
-        varname => 'GA_AUTH_PROVIDER_X509_CERT_URL',
-        value   => $ga_auth_provider_x509_cert_url;
-      "${title}-GA_AUTH_URI":
-        varname => 'GA_AUTH_URI',
-        value   => $ga_auth_uri;
-      "${title}-GA_CLIENT_EMAIL":
-        varname => 'GA_CLIENT_EMAIL',
-        value   => $ga_client_email;
-      "${title}-GA_CLIENT_ID":
-        varname => 'GA_CLIENT_ID',
-        value   => $ga_client_id;
-      "${title}-GA_CLIENT_X509_CERT_URL":
-        varname => 'GA_CLIENT_X509_CERT_URL',
-        value   => $ga_client_x509_cert_url;
-      "${title}-GA_KEY_P12_B64":
-        varname => 'GA_KEY_P12_B64',
-        value   => $ga_key_p12_b64;
-      "${title}-GA_TOKEN_URI":
-        varname => 'GA_TOKEN_URI',
-        value   => $ga_token_uri;
     }
   }
 }


### PR DESCRIPTION
This feature wasn't used. It's been removed in https://github.com/alphagov/transition/pull/543. It wasn't actually using the environment vars yet.

https://trello.com/c/bxvXAF4S