### PR TITLE
Allow logstream to only ship statsd metrics

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -527,6 +527,8 @@ govuk_htpasswd::http_username: "%{hiera('http_username')}"
 govuk_jenkins::packages::gcloud::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk_jenkins::packages::terraform::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
+govuk_logging::logstream::metrics_only: true
+
 govuk::node::s_api_postgresql_primary::alert_hostname: 'alert'
 
 govuk::node::s_api_redis::allowed_api_ip_range: "%{hiera('environment_ip_prefix')}.4.0/24"

--- a/lib/puppet-lint/plugins/check_hiera.rb
+++ b/lib/puppet-lint/plugins/check_hiera.rb
@@ -45,6 +45,10 @@ PuppetLint.new_check(:hiera_explicit_lookup) do
     # logstream defined type needs a global disable flag for dev vm
     'govuk_logging::logstream::disabled',
 
+    # Override for a defined type where we want to enable logstream only doing
+    # metrics
+    'govuk_logging::logstream::metrics_only',
+
     'mysql_replica_password',
     'mysql_root',
     'nginx_enable_ssl',

--- a/modules/govuk_logging/spec/defines/govuk_logging__logstream_spec.rb
+++ b/modules/govuk_logging/spec/defines/govuk_logging__logstream_spec.rb
@@ -142,4 +142,36 @@ describe 'govuk_logging::logstream', :type => :define do
         )
     end
   end
+
+  context 'with json set to false and metrics_only set to true' do
+    let(:params) { {
+      :logfile       => log_file,
+      :ensure        => 'present',
+      :json          => false,
+      } }
+    let(:hiera_config) { File.expand_path('../../fixtures/hiera/hiera.yaml', __FILE__) }
+    it 'should ensure the upstart configuration is absent' do
+      is_expected.to contain_file(upstart_conf).with(
+        :ensure => 'absent',
+      )
+    end
+  end
+
+  context 'with metrics_only set to true' do
+    let(:params) { {
+      :logfile       => log_file,
+      :ensure        => 'present',
+      :json          => true,
+      :statsd_timers => [{'metric' => 'tom_jerry.foo','value' => '@fields.foo'},
+                         {'metric' => 'tom_jerry.bar','value' => '@fields.bar'}],
+      } }
+    let(:hiera_config) { File.expand_path('../../fixtures/hiera/hiera.yaml', __FILE__) }
+
+    let(:facts) {{ :aws_migration => true }}
+
+    it 'should not contain any configuration related to logs or redis' do
+      is_expected.to contain_file(upstart_conf).with(
+        :ensure => 'present').without_content(/#{default_shipper}/)
+    end
+  end
 end

--- a/modules/govuk_logging/spec/fixtures/hiera/hiera.yaml
+++ b/modules/govuk_logging/spec/fixtures/hiera/hiera.yaml
@@ -1,0 +1,7 @@
+---
+:backends:
+  - yaml
+:yaml:
+  :datadir: 'modules/govuk_logging/spec/fixtures/hieradata'
+:hierarchy:
+  - 'common'

--- a/modules/govuk_logging/spec/fixtures/hieradata/common.yaml
+++ b/modules/govuk_logging/spec/fixtures/hieradata/common.yaml
@@ -1,0 +1,3 @@
+govuk_logging::logstream::metrics_only: true
+
+app_domain: 'dev.example.com'

--- a/modules/govuk_logging/templates/logstream_metrics.erb
+++ b/modules/govuk_logging/templates/logstream_metrics.erb
@@ -1,0 +1,37 @@
+description "GOV.UK Logstream: Application Metrics"
+
+start on runlevel [2345]
+stop on runlevel [!2345]
+
+respawn
+
+# If the app respawns more than 5 times in 20 seconds, it has deeper problems
+# and should be killed off.
+respawn limit 5 20
+
+# example:
+# initctl start logstream LOG_FILE=/var/log/whitehall/upstart.err.log \
+#                         TAG="whitehall UPSTART STDERR"
+#
+# LOG_FILE: specify the location of log file to be tailed
+# TAG: should be a string of tags to tag a log line with me
+instance "<%= @logfile %>"
+
+<%
+input_filter = @json.to_s == 'true' ? 'init_json' : 'init_txt'
+filters = [input_filter, 'add_timestamp', 'add_source_host']
+filters << (['add_tags'] + @tags).join(':') unless @tags.empty?
+filters << (['add_fields'] + @fields.map {|k,v| "#{k}=#{v}"}).join(':') unless @fields.empty?
+-%>
+<%
+shippers = []
+shippers << ['statsd_counter', "metric=#{@statsd_metric}"].join(',') if @statsd_metric
+
+@statsd_timers.each do |timer|
+  shippers << ['statsd_timer', "metric=#{timer['metric']}","timed_field=#{timer['value']}"].join(',')
+end
+-%>
+script
+
+    tail -F <%= @logfile %> | logship -f <%= filters.join(',') %> -s <%= shippers.join(' ') %>
+end script


### PR DESCRIPTION
We are looking to migrate pushing our logs to The GDS Way (tm) sanctioned SaaS ELK provider. We are accomplishing this using Filebeat (fb624f2fc351e9bffa81b5e76733b80cc538fc2f) rather than Logship.

We use Logship to also ship statsd metrics and timers for applications based upon application log files.

During our migration phase, we do not want to disrupt sending of the metrics, but we do want to turn off any infrastructure related to our current ELK stack.

This commit adds a conditional that can be set globally to override the defined type, and adds a template which only ships statsd metrics.

It also adds tests which rely on setting some additional hiera config in the spec tests.