### PR TITLE
Correctly set the Transition DB hostname on AWS

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -489,7 +489,7 @@ govuk::apps::support_api::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::support_api::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 
 govuk::apps::transition::db_password: "%{hiera('govuk::apps::transition::db::password')}"
-govuk::apps::transition::db_hostname: "transition-postgresql-master-1.backend"
+govuk::apps::transition::db_hostname: "transition-postgresql-primary"
 govuk::apps::transition::postgresql_db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 govuk::apps::transition::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::transition::redis_port: "%{hiera('sidekiq_port')}"


### PR DESCRIPTION
- In #6503, the hostname was fixed for Carrenza, but not corrected to the right one for AWS.