### PR TITLE
Add redis host for email-alert-service

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -261,6 +261,7 @@ govuk::apps::email_alert_service::rabbitmq_hosts:
   - rabbitmq-1.backend
   - rabbitmq-2.backend
   - rabbitmq-3.backend
+govuk::apps::email_alert_service::redis_host: "%{hiera('sidekiq_host')}"
 
 govuk::apps::errbit::nagios_memory_warning: 2600
 govuk::apps::errbit::nagios_memory_critical: 3000

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -266,6 +266,7 @@ govuk::apps::email_alert_api::redis_port: "%{hiera('sidekiq_port')}"
 
 govuk::apps::email_alert_service::rabbitmq_hosts:
   - rabbitmq
+govuk::apps::email_alert_service::redis_host: "%{hiera('sidekiq_host')}"
 
 govuk::apps::errbit::nagios_memory_warning: 2600
 govuk::apps::errbit::nagios_memory_critical: 3000

--- a/modules/govuk/manifests/apps/email_alert_service.pp
+++ b/modules/govuk/manifests/apps/email_alert_service.pp
@@ -33,6 +33,7 @@ class govuk::apps::email_alert_service(
   $rabbitmq_password = 'email_alert_service',
   $sentry_dsn = undef,
   $errbit_api_key = undef,
+  $redis_host = undef,
 ) {
   govuk::app { 'email-alert-service':
     app_type           => 'bare',
@@ -49,6 +50,10 @@ class govuk::apps::email_alert_service(
     hosts    => $rabbitmq_hosts,
     user     => $rabbitmq_user,
     password => $rabbitmq_password,
+  }
+
+  govuk::app::envvar::redis { 'email-alert-service':
+    host => $redis_host,
   }
 
   govuk::app::envvar {


### PR DESCRIPTION
We're looking to move values from hardcoded deployment scripts into Puppet and environment variables. This moves the redis host for email-alert-service.

Required: https://github.com/alphagov/email-alert-service/pull/81

https://trello.com/c/fenlgsMp/745-make-icinga-in-aws-green