### PR TITLE
Add more data to rummager deployment dashboard

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -903,8 +903,16 @@ grafana::dashboards::deployment_applications:
   rummager:
     # @fields.controller is blank and rummager is a sinatra app
     show_controller_errors: false
+    show_elasticsearch_stats: true
+    show_response_times: true
+    show_sidekiq_graphs: true
     show_slow_requests: false
     has_workers: true
+    dependent_app_5xx_errors:
+      - collections
+      - finder-frontend
+      - frontend
+      - whitehall-frontend
   search-admin:
     # No data in kibana
     show_controller_errors: false

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -908,8 +908,16 @@ grafana::dashboards::deployment_applications:
   rummager:
     # @fields.controller is blank and rummager is a sinatra app
     show_controller_errors: false
+    show_elasticsearch_stats: true
+    show_response_times: true
+    show_sidekiq_graphs: true
     show_slow_requests: false
     has_workers: true
+    dependent_app_5xx_errors:
+      - collections
+      - finder-frontend
+      - frontend
+      - whitehall-frontend
   search-admin:
     # No data in kibana
     show_controller_errors: false

--- a/modules/grafana/manifests/dashboards/deployment_dashboard.pp
+++ b/modules/grafana/manifests/dashboards/deployment_dashboard.pp
@@ -32,8 +32,12 @@ define grafana::dashboards::deployment_dashboard (
   $has_workers = false,
   $error_threshold = 20,
   $warning_threshold = 10,
+  $show_sidekiq_graphs = false,
   $show_controller_errors = true,
-  $show_slow_requests = true
+  $show_response_times = false,
+  $show_slow_requests = true,
+  $dependent_app_5xx_errors = undef,
+  $show_elasticsearch_stats = false
 ) {
   if $has_workers {
     $worker_row = [['worker_failures', 'worker_successes']]
@@ -49,12 +53,47 @@ define grafana::dashboards::deployment_dashboard (
     $errors_by_controller_row = []
   }
 
+  if $show_response_times {
+    $show_response_times_row = [
+      ['response_times']
+    ]
+  } else {
+    $show_response_times_row = []
+  }
+
   if $show_slow_requests {
     $duration_by_controller_row = [
       ['response_times_by_controller']
     ]
   } else {
     $duration_by_controller_row = []
+  }
+
+  if $show_sidekiq_graphs {
+    $sidekiq_graph_row = [
+      ['sidekiq_queue_length', 'sidekiq_errors']
+    ]
+  } else {
+    $sidekiq_graph_row = []
+  }
+
+  if $dependent_app_5xx_errors {
+    $dependent_app_5xx_row = [
+      ['dependent_app_5xx']
+    ]
+  } else {
+    $dependent_app_5xx_row = []
+  }
+
+  if $show_elasticsearch_stats {
+    $elasticsearch_stats = [
+      [
+        'elasticsearch_disk_io',
+        'elasticsearch_free_memory',
+        'elasticsearch_idle_cpu']
+    ]
+  } else {
+    $elasticsearch_stats = []
   }
 
   $panel_partials = concat(
@@ -64,7 +103,11 @@ define grafana::dashboards::deployment_dashboard (
     ],
     $worker_row,
     $errors_by_controller_row,
-    $duration_by_controller_row
+    $show_response_times_row,
+    $duration_by_controller_row,
+    $dependent_app_5xx_row,
+    $sidekiq_graph_row,
+    $elasticsearch_stats
   )
 
   file {

--- a/modules/grafana/templates/dashboards/deployment_panels/_dependent_app_5xx.json.erb
+++ b/modules/grafana/templates/dashboards/deployment_panels/_dependent_app_5xx.json.erb
@@ -1,0 +1,77 @@
+{
+  "aliasColors": {},
+  "bars": false,
+  "datasource": "Graphite",
+  "editable": true,
+  "error": false,
+  "fill": 0,
+  "grid": {
+    "threshold1": null,
+    "threshold1Color": "rgba(216, 200, 27, 0.27)",
+    "threshold2": null,
+    "threshold2Color": "rgba(234, 112, 112, 0.22)"
+  },
+  "id": 4,
+  "isNew": true,
+  "legend": {
+    "avg": false,
+    "current": false,
+    "max": false,
+    "min": false,
+    "show": true,
+    "total": false,
+    "values": false
+  },
+  "lines": true,
+  "linewidth": 2,
+  "links": [],
+  "nullPointMode": "connected",
+  "percentage": false,
+  "pointradius": 5,
+  "points": false,
+  "renderer": "flot",
+  "seriesOverrides": [],
+  "span": 12,
+  "stack": false,
+  "steppedLine": false,
+  "targets": [
+    <% @dependent_app_5xx_errors.each_with_index do |app, index| %>
+      <%= ',' if index > 0 %> {
+        "refId": "<%= index %>",
+        "target": "groupByNode(stats.*.nginx_logs.<%= app %>*.http_5xx, 3, 'sum')",
+        "textEditor": true
+      }
+    <% end %>
+  ],
+  "timeFrom": null,
+  "timeShift": null,
+  "title": "Dependent app 5xx errors",
+  "tooltip": {
+    "msResolution": true,
+    "shared": true,
+    "sort": 0,
+    "value_type": "cumulative"
+  },
+  "type": "graph",
+  "xaxis": {
+    "show": true
+  },
+  "yaxes": [
+    {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+    },
+    {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+    }
+  ]
+}

--- a/modules/grafana/templates/dashboards/deployment_panels/_elasticsearch_disk_io.json.erb
+++ b/modules/grafana/templates/dashboards/deployment_panels/_elasticsearch_disk_io.json.erb
@@ -1,0 +1,80 @@
+{
+  "title": "Elasticsearch disk IO time",
+  "error": false,
+  "span": 4,
+  "editable": true,
+  "type": "graph",
+  "isNew": true,
+  "id": 13,
+  "targets": [
+    {
+      "refId": "A",
+      "target": "alias(averageSeries(rummager-elasticsearch-*.disk-sdb1.disk_time.read), 'read')",
+      "textEditor": true
+    },
+    {
+      "refId": "B",
+      "target": "alias(averageSeries(rummager-elasticsearch-*.disk-sdb1.disk_time.write), 'write')",
+      "textEditor": true
+    }
+  ],
+  "datasource": "Graphite",
+  "renderer": "flot",
+  "yaxes": [
+    {
+      "label": null,
+      "show": true,
+      "logBase": 1,
+      "min": null,
+      "max": null,
+      "format": "short"
+    },
+    {
+      "label": null,
+      "show": true,
+      "logBase": 1,
+      "min": null,
+      "max": null,
+      "format": "short"
+    }
+  ],
+  "xaxis": {
+    "show": true
+  },
+  "grid": {
+    "threshold1": null,
+    "threshold2": null,
+    "threshold1Color": "rgba(216, 200, 27, 0.27)",
+    "threshold2Color": "rgba(234, 112, 112, 0.22)"
+  },
+  "lines": true,
+  "fill": 1,
+  "linewidth": 2,
+  "points": false,
+  "pointradius": 5,
+  "bars": false,
+  "stack": false,
+  "percentage": false,
+  "legend": {
+    "show": true,
+    "values": false,
+    "min": false,
+    "max": false,
+    "current": false,
+    "total": false,
+    "avg": false
+  },
+  "nullPointMode": "connected",
+  "steppedLine": false,
+  "tooltip": {
+    "value_type": "cumulative",
+    "shared": true,
+    "sort": 0,
+    "msResolution": true
+  },
+  "timeFrom": null,
+  "timeShift": null,
+  "aliasColors": {},
+  "seriesOverrides": [],
+  "links": []
+}

--- a/modules/grafana/templates/dashboards/deployment_panels/_elasticsearch_free_memory.json.erb
+++ b/modules/grafana/templates/dashboards/deployment_panels/_elasticsearch_free_memory.json.erb
@@ -1,0 +1,75 @@
+{
+  "title": "Elasticsearch free memory",
+  "error": false,
+  "span": 4,
+  "editable": true,
+  "type": "graph",
+  "isNew": true,
+  "id": 14,
+  "targets": [
+    {
+      "refId": "A",
+      "target": "rummager-elasticsearch-*.memory.memory-free",
+      "textEditor": true
+    }
+  ],
+  "datasource": "Graphite",
+  "renderer": "flot",
+  "yaxes": [
+    {
+      "label": null,
+      "show": true,
+      "logBase": 1,
+      "min": null,
+      "max": null,
+      "format": "bytes"
+    },
+    {
+      "label": null,
+      "show": true,
+      "logBase": 1,
+      "min": null,
+      "max": null,
+      "format": "short"
+    }
+  ],
+  "xaxis": {
+    "show": true
+  },
+  "grid": {
+    "threshold1": null,
+    "threshold2": null,
+    "threshold1Color": "rgba(216, 200, 27, 0.27)",
+    "threshold2Color": "rgba(234, 112, 112, 0.22)"
+  },
+  "lines": true,
+  "fill": 1,
+  "linewidth": 2,
+  "points": false,
+  "pointradius": 5,
+  "bars": false,
+  "stack": false,
+  "percentage": false,
+  "legend": {
+    "show": true,
+    "values": false,
+    "min": false,
+    "max": false,
+    "current": false,
+    "total": false,
+    "avg": false
+  },
+  "nullPointMode": "connected",
+  "steppedLine": false,
+  "tooltip": {
+    "value_type": "cumulative",
+    "shared": true,
+    "sort": 0,
+    "msResolution": true
+  },
+  "timeFrom": null,
+  "timeShift": null,
+  "aliasColors": {},
+  "seriesOverrides": [],
+  "links": []
+}

--- a/modules/grafana/templates/dashboards/deployment_panels/_elasticsearch_idle_cpu.json.erb
+++ b/modules/grafana/templates/dashboards/deployment_panels/_elasticsearch_idle_cpu.json.erb
@@ -1,0 +1,75 @@
+{
+  "title": "Elasticsearch idle CPU",
+  "error": false,
+  "span": 4,
+  "editable": true,
+  "type": "graph",
+  "isNew": true,
+  "id": 15,
+  "targets": [
+    {
+      "refId": "A",
+      "target": "rummager-elasticsearch-*.cpu-0.cpu-idle",
+      "textEditor": true
+    }
+  ],
+  "datasource": "Graphite",
+  "renderer": "flot",
+  "yaxes": [
+    {
+      "label": null,
+      "show": true,
+      "logBase": 1,
+      "min": null,
+      "max": null,
+      "format": "short"
+    },
+    {
+      "label": null,
+      "show": true,
+      "logBase": 1,
+      "min": null,
+      "max": null,
+      "format": "percent"
+    }
+  ],
+  "xaxis": {
+    "show": true
+  },
+  "grid": {
+    "threshold1": null,
+    "threshold2": null,
+    "threshold1Color": "rgba(216, 200, 27, 0.27)",
+    "threshold2Color": "rgba(234, 112, 112, 0.22)"
+  },
+  "lines": true,
+  "fill": 1,
+  "linewidth": 2,
+  "points": false,
+  "pointradius": 5,
+  "bars": false,
+  "stack": false,
+  "percentage": false,
+  "legend": {
+    "show": true,
+    "values": false,
+    "min": false,
+    "max": false,
+    "current": false,
+    "total": false,
+    "avg": false
+  },
+  "nullPointMode": "connected",
+  "steppedLine": false,
+  "tooltip": {
+    "value_type": "cumulative",
+    "shared": true,
+    "sort": 0,
+    "msResolution": true
+  },
+  "timeFrom": null,
+  "timeShift": null,
+  "aliasColors": {},
+  "seriesOverrides": [],
+  "links": []
+}

--- a/modules/grafana/templates/dashboards/deployment_panels/_response_times.json.erb
+++ b/modules/grafana/templates/dashboards/deployment_panels/_response_times.json.erb
@@ -1,0 +1,105 @@
+{
+  "aliasColors": {},
+  "bars": false,
+  "datasource": "Elasticsearch",
+  "editable": true,
+  "error": false,
+  "fill": 0,
+  "grid": {
+    "threshold1": null,
+    "threshold1Color": "rgba(216, 200, 27, 0.27)",
+    "threshold2": null,
+    "threshold2Color": "rgba(234, 112, 112, 0.22)"
+  },
+  "id": 3,
+  "isNew": true,
+  "legend": {
+    "avg": false,
+    "current": false,
+    "max": false,
+    "min": false,
+    "show": true,
+    "total": false,
+    "values": false
+  },
+  "lines": true,
+  "linewidth": 1,
+  "links": [],
+  "nullPointMode": "connected",
+  "percentage": false,
+  "pointradius": 5,
+  "points": false,
+  "renderer": "flot",
+  "seriesOverrides": [],
+  "span": 12,
+  "stack": false,
+  "steppedLine": false,
+  "targets": [
+    {
+      "bucketAggs": [
+        {
+          "field": "@timestamp",
+          "id": "2",
+          "settings": {
+            "interval": "auto",
+            "min_doc_count": 0,
+            "trimEdges": 0
+          },
+          "type": "date_histogram"
+        }
+      ],
+      "dsType": "elasticsearch",
+      "metrics": [
+        {
+          "field": "@fields.duration",
+          "id": "1",
+          "meta": {},
+          "settings": {
+            "percents": [
+              "20",
+              "50",
+              "90",
+              "95",
+              "99"
+            ]
+          },
+          "type": "percentiles"
+        }
+      ],
+      "query": "@fields.application:<%= @app_name %>",
+      "refId": "A",
+      "timeField": "@timestamp"
+    }
+  ],
+  "timeFrom": "6h",
+  "timeShift": null,
+  "title": "Response Times",
+  "tooltip": {
+    "msResolution": true,
+    "shared": true,
+    "sort": 2,
+    "value_type": "cumulative"
+  },
+  "type": "graph",
+  "xaxis": {
+    "show": true
+  },
+  "yaxes": [
+    {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+    },
+    {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+    }
+  ]
+}

--- a/modules/grafana/templates/dashboards/deployment_panels/_sidekiq_errors.json.erb
+++ b/modules/grafana/templates/dashboards/deployment_panels/_sidekiq_errors.json.erb
@@ -1,0 +1,80 @@
+{
+  "title": "Sidekiq worker errors",
+  "error": false,
+  "span": 6,
+  "editable": true,
+  "type": "graph",
+  "isNew": true,
+  "id": 6,
+  "targets": [
+    {
+      "refId": "A",
+      "target": "aliasByNode(stats.govuk.app.<%= @app_name %>.workers.*.failure, 5)",
+      "textEditor": true
+    },
+    {
+      "refId": "B",
+      "target": "aliasByNode(stats.govuk.app.<%= @app_name %>.workers.*.*.failure, 6)",
+      "textEditor": true
+    }
+  ],
+  "datasource": "Graphite",
+  "renderer": "flot",
+  "yaxes": [
+    {
+      "label": null,
+      "show": true,
+      "logBase": 1,
+      "min": null,
+      "max": null,
+      "format": "short"
+    },
+    {
+      "label": null,
+      "show": true,
+      "logBase": 1,
+      "min": null,
+      "max": null,
+      "format": "short"
+    }
+  ],
+  "xaxis": {
+    "show": true
+  },
+  "grid": {
+    "threshold1": null,
+    "threshold2": null,
+    "threshold1Color": "rgba(216, 200, 27, 0.27)",
+    "threshold2Color": "rgba(234, 112, 112, 0.22)"
+  },
+  "lines": true,
+  "fill": 1,
+  "linewidth": 2,
+  "points": false,
+  "pointradius": 5,
+  "bars": false,
+  "stack": false,
+  "percentage": false,
+  "legend": {
+    "show": true,
+    "values": false,
+    "min": false,
+    "max": false,
+    "current": false,
+    "total": false,
+    "avg": false
+  },
+  "nullPointMode": "connected",
+  "steppedLine": false,
+  "tooltip": {
+    "value_type": "cumulative",
+    "shared": true,
+    "sort": 0,
+    "msResolution": true
+  },
+  "timeFrom": null,
+  "timeShift": null,
+  "aliasColors": {},
+  "seriesOverrides": [],
+  "links": []
+}

--- a/modules/grafana/templates/dashboards/deployment_panels/_sidekiq_queue_length.json.erb
+++ b/modules/grafana/templates/dashboards/deployment_panels/_sidekiq_queue_length.json.erb
@@ -1,0 +1,75 @@
+{
+  "title": "Sidekiq queue length",
+  "error": false,
+  "span": 6,
+  "editable": true,
+  "type": "graph",
+  "isNew": true,
+  "id": 5,
+  "targets": [
+    {
+      "refId": "B",
+      "target": "stats.gauges.govuk.app.<%= @app_name %>.workers.enqueued",
+      "textEditor": true
+    }
+  ],
+  "datasource": "Graphite",
+  "renderer": "flot",
+  "yaxes": [
+    {
+      "label": null,
+      "show": true,
+      "logBase": 1,
+      "min": null,
+      "max": null,
+      "format": "short"
+    },
+    {
+      "label": null,
+      "show": true,
+      "logBase": 1,
+      "min": null,
+      "max": null,
+      "format": "short"
+    }
+  ],
+  "xaxis": {
+    "show": true
+  },
+  "grid": {
+    "threshold1": null,
+    "threshold2": null,
+    "threshold1Color": "rgba(216, 200, 27, 0.27)",
+    "threshold2Color": "rgba(234, 112, 112, 0.22)"
+  },
+  "lines": true,
+  "fill": 1,
+  "linewidth": 2,
+  "points": false,
+  "pointradius": 5,
+  "bars": false,
+  "stack": false,
+  "percentage": false,
+  "legend": {
+    "show": true,
+    "values": false,
+    "min": false,
+    "max": false,
+    "current": false,
+    "total": false,
+    "avg": false
+  },
+  "nullPointMode": "connected",
+  "steppedLine": false,
+  "tooltip": {
+    "value_type": "cumulative",
+    "shared": true,
+    "sort": 0,
+    "msResolution": true
+  },
+  "timeFrom": null,
+  "timeShift": null,
+  "aliasColors": {},
+  "seriesOverrides": [],
+  "links": []
+}


### PR DESCRIPTION
Add extra graphs:
- Sidekiq queue size and error count
- Request durations (the existing graph does not work for rummager
  because it depends on stats for Rails controllers, and rummager is a
  sinatra app)
- 5xx errors in apps which depend on rummager, such as frontend
- Stats for the Elasticsearch machines, such as memory usage

These graphs have been useful when debugging recent errors caused by the overnight popularity updates.

<img width="1420" alt="screen shot 2017-09-20 at 17 25 39" src="https://user-images.githubusercontent.com/754712/30655426-c4c3275a-9e28-11e7-9802-d005af9e3f17.png">
<img width="1420" alt="screen shot 2017-09-20 at 17 25 32" src="https://user-images.githubusercontent.com/754712/30655425-c4bff10c-9e28-11e7-8df1-be53df74d26f.png">

https://trello.com/c/saDruTlG/307-investigate-1-day-intermittent-rummager-timeouts