### PR TITLE
Remove a bit more govuk-delivery

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -338,6 +338,12 @@ govuk::apps::govuk_crawler_worker::root_urls:
   - 'https://assets.publishing.service.gov.uk/'
   - 'https://www.gov.uk/'
 
+govuk::apps::govuk_delivery::mongodb_hosts:        
+  - 'mongo-1.backend'        
+  - 'mongo-2.backend'        
+  - 'mongo-3.backend'        
+govuk::apps::govuk_delivery::mongodb_database: 'govuk_delivery'
+
 govuk::apps::imminence::mongodb_nodes:
   - 'mongo-1.backend'
   - 'mongo-2.backend'

--- a/modules/govuk/manifests/apps/govuk_delivery.pp
+++ b/modules/govuk/manifests/apps/govuk_delivery.pp
@@ -54,7 +54,7 @@ class govuk::apps::govuk_delivery(
   $govdelivery_hostname = undef,
   $govdelivery_signup_form = undef,
   $port = '3042',
-  $enable_procfile_worker = true,
+  $enable_procfile_worker = false,
 ) {
   $app_name = 'govuk-delivery'
   include govuk_python


### PR DESCRIPTION
The previous PR to remove govuk-delivery has only removed bits of it. The app and worker are still present and running on the `backend-*` boxes. 

This PR makes a couple of changes to try and coax it into removing the other bits.

[Trello](https://trello.com/c/xHgvQXOX/137-archive-and-remove-govuk-delivery)