### PR TITLE
Add a second Content Performance Manager Sidekiq process

### DIFF
--- a/development-vm/Pinfile
+++ b/development-vm/Pinfile
@@ -15,7 +15,7 @@ process :collections => [:static, :'content-store', :rummager]
 process :'collections-publisher' => [:'publishing-api', :rummager, :'collections-publisher-worker']
 process :'collections-publisher-worker'
 process :'contacts-admin' => [:rummager, :'publishing-api', :whitehall]
-process :'content-performance-manager' => [:'publishing-api-read', :'content-performance-manager-sidekiq']
+process :'content-performance-manager' => [:'publishing-api-read', :'content-performance-manager-sidekiq-google-analytics', :'content-performance-manager-sidekiq-publishing-api']
 process :'content-store'
 # Example usage: bowl [your-app] dummy-content-store --without content-store
 process :'dummy-content-store'

--- a/development-vm/Procfile
+++ b/development-vm/Procfile
@@ -152,7 +152,8 @@ draft-router-api:            govuk_setenv draft-router-api            ./run_in.s
 # manuals-publisher has reserved port 3205
 # sidekiq-monitoring for content-performance-manager uses port 3207
 content-performance-manager:      govuk_setenv content-performance-manager ./run_in.sh ../../content-performance-manager bundle exec rails server -p 3206
-content-performance-manager-sidekiq:  govuk_setenv content-performance-manager ./run_in.sh ../../content-performance-manager bundle exec sidekiq -C ./config/sidekiq.yml
+content-performance-manager-sidekiq-google-analytics:  govuk_setenv content-performance-manager ./run_in.sh ../../content-performance-manager bundle exec sidekiq -C ./config/sidekiq/google_analytics.yml
+content-performance-manager-sidekiq-publishing-api:  govuk_setenv content-performance-manager ./run_in.sh ../../content-performance-manager bundle exec sidekiq -C ./config/sidekiq/publishing_api.yml
 # sidekiq-monitoring for link-checker-api-sidekiq uses port 3209
 link-checker-api:                     govuk_setenv link-checker-api            ./run_in.sh ../../link-checker-api bundle exec rails server -p 3208
 link-checker-api-sidekiq:             govuk_setenv link-checker-api            ./run_in.sh ../../link-checker-api bundle exec sidekiq -C ./config/sidekiq.yml


### PR DESCRIPTION
Content Performance Manager requires two different queues with their
own concurrency settings. According to [the documentation][sidekiq],
the best way to achieve this is to have two separate queues, each with
their own concurrency, and then have two separate processes that own
those queues.

This change adds a second Sidekiq process.

## Dependencies

- [x] https://github.com/alphagov/content-performance-manager/pull/358

[sidekiq]: https://github.com/mperham/sidekiq/wiki/Advanced-Options#reserved-queues