### PR TITLE
More govuk delivery removal

### DIFF
--- a/hieradata/class/backend.yaml
+++ b/hieradata/class/backend.yaml
@@ -58,6 +58,7 @@ govuk::node::s_base::apps:
   - email_alert_api
   - email_alert_service
   - event_store
+  - govuk_delivery
   - hmrc_manuals_api
   - imminence
   - kibana

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -342,7 +342,10 @@ govuk::apps::govuk_delivery::mongodb_hosts:
   - 'mongo-1.backend'        
   - 'mongo-2.backend'        
   - 'mongo-3.backend'        
+govuk::apps::govuk_delivery::redis_host: "%{hiera('sidekiq_host')}"
+govuk::apps::govuk_delivery::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::govuk_delivery::mongodb_database: 'govuk_delivery'
+govuk::apps::govuk_delivery::list_title_format: '%s'
 
 govuk::apps::imminence::mongodb_nodes:
   - 'mongo-1.backend'

--- a/hieradata_aws/class/backend.yaml
+++ b/hieradata_aws/class/backend.yaml
@@ -56,6 +56,7 @@ govuk::node::s_base::apps:
   - email_alert_api
   - email_alert_service
   - event_store
+  - govuk_delivery
   - hmrc_manuals_api
   - imminence
   - kibana

--- a/modules/govuk/manifests/apps/govuk_delivery.pp
+++ b/modules/govuk/manifests/apps/govuk_delivery.pp
@@ -73,20 +73,17 @@ class govuk::apps::govuk_delivery(
     enable_service => $enable_procfile_worker,
   }
 
-  Govuk::App::Envvar {
-    app => $app_name,
+  Govuk::App::Envvar { app => $app_name,
   }
 
   govuk::app::envvar::mongodb_uri { $app_name:
-    ensure   => 'absent',
     hosts    => $mongodb_hosts,
     database => $mongodb_database,
   }
 
   govuk::app::envvar::redis { $app_name:
-    ensure => 'absent',
-    host   => $redis_host,
-    port   => $redis_port,
+    host => $redis_host,
+    port => $redis_port,
   }
 
   govuk::app::envvar {

--- a/modules/govuk/manifests/apps/govuk_delivery.pp
+++ b/modules/govuk/manifests/apps/govuk_delivery.pp
@@ -60,7 +60,7 @@ class govuk::apps::govuk_delivery(
   include govuk_python
 
   govuk::app { $app_name:
-    ensure             => absent,
+    ensure             => 'absent',
     app_type           => 'procfile',
     port               => $port,
     vhost_ssl_only     => true,
@@ -69,7 +69,7 @@ class govuk::apps::govuk_delivery(
   }
 
   govuk::procfile::worker { 'govuk-delivery':
-    ensure         => absent,
+    ensure         => 'absent',
     enable_service => $enable_procfile_worker,
   }
 


### PR DESCRIPTION
We are trying to remove govuk_delivery as it has been retired. The resources have been marked `ensure => 'absent'` within the govuk_delivery app but because it was also removed from the backend class that file was not being executed.