### PR TITLE
Remove event store

### DIFF
--- a/hieradata_aws/class/backend.yaml
+++ b/hieradata_aws/class/backend.yaml
@@ -5,11 +5,6 @@ govuk::apps::contacts::db_hostname: 'mysql-primary'
 govuk::apps::contacts::db_username: 'contacts'
 govuk::apps::contacts::db_password: "%{hiera('govuk::apps::contacts::db::mysql_contacts_admin')}"
 
-govuk::apps::event_store::mongodb_servers:
-  - 'mongo-1'
-  - 'mongo-2'
-  - 'mongo-3'
-
 govuk::apps::manuals_publisher::mongodb_name: 'govuk_content_production'
 govuk::apps::manuals_publisher::mongodb_nodes:
   - 'mongo-1'
@@ -55,7 +50,6 @@ govuk::node::s_base::apps:
   - content_tagger
   - email_alert_api
   - email_alert_service
-  - event_store
   - hmrc_manuals_api
   - imminence
   - kibana

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -31,7 +31,6 @@ govuk::apps::asset_manager::aws_s3_bucket_name: 'govuk-assets-integration'
 govuk::apps::asset_manager::aws_region: 'eu-west-1'
 govuk::apps::email_alert_api::allow_govdelivery_topic_syncing: true
 govuk::apps::errbit::errbit_email_from: 'govuk-winston+errbit-integration@digital.cabinet-office.gov.uk'
-govuk::apps::event_store::enabled: true
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-integration'
 govuk::apps::publishing_api::content_api_prototype: true


### PR DESCRIPTION
This is no longer used, so at least remove from AWS.