### PR TITLE
Add second Content Performance Manager Sidekiq process

### DIFF
--- a/modules/govuk/manifests/apps/content_performance_manager.pp
+++ b/modules/govuk/manifests/apps/content_performance_manager.pp
@@ -103,8 +103,16 @@ class govuk::apps::content_performance_manager(
     app    => $app_name,
   }
 
-  govuk::procfile::worker {$app_name:
+  govuk::procfile::worker { "${app_name}-google-analytics-worker":
     enable_service => $enable_procfile_worker,
+    setenv_as      => $app_name,
+    process_type   => 'google-analytics-worker',
+  }
+
+  govuk::procfile::worker { "${app_name}-publishing-api-worker":
+    enable_service => $enable_procfile_worker,
+    setenv_as      => $app_name,
+    process_type   => 'publishing-api-worker',
   }
 
   govuk::app::envvar {


### PR DESCRIPTION
A previous commit added a second Sidekiq process to the development VM,
but did not update this Puppet config to also run the new process.

This change runs the new processes, as defined in the corresponding
Content Performance Manager update.

## Dependencies

- [x] https://github.com/alphagov/content-performance-manager/pull/361