### PR TITLE
Remove govuk_delivery mongo env

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -341,13 +341,6 @@ govuk::apps::govuk_crawler_worker::root_urls:
   - 'https://assets.publishing.service.gov.uk/'
   - 'https://www.gov.uk/'
 
-govuk::apps::govuk_delivery::mongodb_hosts:        
-  - 'mongo-1.backend'        
-  - 'mongo-2.backend'        
-  - 'mongo-3.backend'        
-govuk::apps::govuk_delivery::redis_host: "%{hiera('sidekiq_host')}"
-govuk::apps::govuk_delivery::redis_port: "%{hiera('sidekiq_port')}"
-govuk::apps::govuk_delivery::mongodb_database: 'govuk_delivery'
 govuk::apps::govuk_delivery::list_title_format: '%s'
 
 govuk::apps::imminence::mongodb_nodes:

--- a/modules/govuk/manifests/apps/govuk_delivery.pp
+++ b/modules/govuk/manifests/apps/govuk_delivery.pp
@@ -43,8 +43,6 @@
 # [*enable_procfile_worker*]
 #   Run the celery worker defined in the procfile
 class govuk::apps::govuk_delivery(
-  $mongodb_hosts,
-  $mongodb_database,
   $list_title_format,
   $govdelivery_username = undef,
   $govdelivery_password = undef,
@@ -72,11 +70,6 @@ class govuk::apps::govuk_delivery(
   }
 
   Govuk::App::Envvar { app => $app_name,
-  }
-
-  govuk::app::envvar::mongodb_uri { $app_name:
-    hosts    => $mongodb_hosts,
-    database => $mongodb_database,
   }
 
   govuk::app::envvar {


### PR DESCRIPTION
As part of my ongoing struggle to get rid of govuk_delivery. This commit removes the mongodb env. Setting the app itself to absent removes the app's directory from env.d so the mongo bit causes errors when it tries to write to a directory that no longer exists.

Once this is deployed I think we'll be able to remove this file altogether, finally... (fingers crossed).

[Trello](https://trello.com/c/xHgvQXOX/137-archive-and-remove-govuk-delivery)