### PR TITLE
Disable remote syslog logging

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -546,6 +546,8 @@ govuk::node::s_asset_base::firewall_allow_ip_range: "%{hiera('environment_ip_pre
 govuk::node::s_backend_lb::errbit_servers:
   - 'exception-handler'
 
+govuk::node::s_base::log_remote: false
+
 govuk::node::s_licensify_lb::backend_app_servers:
   - 'licensing-backend'
   - 'licensing-backend'

--- a/modules/govuk/manifests/node/s_base.pp
+++ b/modules/govuk/manifests/node/s_base.pp
@@ -7,8 +7,13 @@
 # [*apps*]
 #   An array of GOV.UK applications that should be included on this machine.
 #
+# [*log_remote*]
+#   Whether to enable sending syslogs to remote syslog server. Parameter should
+#   be removed when we have fully migrated to using Filebeat for shipping logs.
+#
 class govuk::node::s_base (
   $apps = [],
+  $log_remote = true,
 ) {
   validate_array($apps)
 
@@ -48,9 +53,17 @@ class govuk::node::s_base (
     $logging_hostname = 'logging.cluster'
   }
 
-  class { 'rsyslog::client':
-    server    => $logging_hostname,
-    log_local => true,
+  if $log_remote {
+    class { 'rsyslog::client':
+      server    => $logging_hostname,
+      log_local => true,
+    }
+  } else {
+    # Syslogs are collected by Filebeat
+    class { 'rsyslog::client':
+      log_local  => true,
+      log_remote => false,
+    }
   }
 
   # Enable default tcpconn monitoring for port 22


### PR DESCRIPTION
We are using Filebeat to ship syslogs straight to our ELK stack, so we no longer need to send to our old syslog server.

This adds a conditional and only sets it to false in AWS for now. Once I've tested then we can remove the paramemter, set the behaviour as default, and remove all the old machines.

https://trello.com/c/YrTOpoq7/746-logit-migration