### PR TITLE
AWS Plek overrides

### DIFF
--- a/modules/govuk/manifests/deploy/config.pp
+++ b/modules/govuk/manifests/deploy/config.pp
@@ -106,7 +106,7 @@ class govuk::deploy::config(
       'PLEK_SERVICE_RUMMAGER_URI': value => "https://rummager.${app_domain_internal}";
       'PLEK_SERVICE_SEARCH_URI': value   => "https://search.${app_domain_internal}";
       'PLEK_SERVICE_ERRBIT_URI': value   => "https://errbit.${app_domain_internal}";
+      'PLEK_SERVICE_STATIC_URI': value   => "https://static.${app_domain_internal}";
     }
-
   }
 }

--- a/modules/govuk/manifests/node/s_draft_frontend.pp
+++ b/modules/govuk/manifests/node/s_draft_frontend.pp
@@ -25,4 +25,12 @@ class govuk::node::s_draft_frontend() inherits govuk::node::s_base {
       'PLEK_SERVICE_SEARCH_URI': value => "https://search.${app_domain}";
     }
   }
+
+  if $::aws_migration {
+    $app_domain_internal = hiera('app_domain_internal')
+
+    govuk_envvar {
+      'PLEK_SERVICE_CONTENT_STORE_URI': value => "https://content-store.${app_domain_internal}";
+    }
+  }
 }


### PR DESCRIPTION
On AWS, draft-content-store, static and draft-static are only available internally.
Override the Plek variable to point to the right domain.