### PR TITLE
Reinstate govuk_delivery hieradata

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -336,6 +336,13 @@ govuk::apps::govuk_crawler_worker::root_urls:
   - 'https://assets.publishing.service.gov.uk/'
   - 'https://www.gov.uk/'
 
+govuk::apps::govuk_delivery::mongodb_hosts:        
+  - 'mongo-1.backend'        
+  - 'mongo-2.backend'        
+  - 'mongo-3.backend'        
+govuk::apps::govuk_delivery::redis_host: "%{hiera('sidekiq_host')}"
+govuk::apps::govuk_delivery::redis_port: "%{hiera('sidekiq_port')}"
+govuk::apps::govuk_delivery::mongodb_database: 'govuk_delivery'
 govuk::apps::govuk_delivery::list_title_format: '%s'
 
 govuk::apps::imminence::mongodb_nodes:


### PR DESCRIPTION
The missing mongo hosts is now causing errors. This commit puts it all back so as we can run and then it will all be removed when the govuk_delivery app is removed.