### PR TITLE
Partially revert "Remove govuk_delivery data sync things"

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
@@ -32,5 +32,10 @@
                 TARGET_APPLICATION=whitehall
                 MACHINE_CLASS=whitehall_backend
                 RAKE_TASK=publishing:scheduled:requeue_all_jobs
+            - project: run-rake-task
+              predefined-parameters: |
+                TARGET_APPLICATION=email-alert-api
+                MACHINE_CLASS=backend
+                RAKE_TASK=sync_govdelivery_topic_mappings
         - email:
             recipients: govuk-ci-notifications@digital.cabinet-office.gov.uk

--- a/modules/govuk_jenkins/templates/jobs/data_sync_complete_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/data_sync_complete_staging.yaml.erb
@@ -22,5 +22,11 @@
            # Queue up any publisher scheduled editions that have been transferred across.
            ssh deploy@$(govuk_node_list -c backend --single-node) 'cd /var/apps/publisher ; govuk_setenv publisher bundle exec rake editions:requeue_scheduled_for_publishing'
     publishers:
+        - trigger-parameterized-builds:
+            - project: run-rake-task
+              predefined-parameters: |
+                TARGET_APPLICATION=email-alert-api
+                MACHINE_CLASS=backend
+                RAKE_TASK=sync_govdelivery_topic_mappings
         - email:
             recipients: govuk-ci-notifications@digital.cabinet-office.gov.uk


### PR DESCRIPTION
This partially reverts commit 016b5948fdad6d6a65df79f1ce52cda9ce691c0d.

We still need the `sync_govdelivery_topic_mappings` task to
run on integration and staging, regardless of the retirement
of gov-uk-delivery. There's more documentation about what
this task does here:
https://github.com/alphagov/email-alert-api/blob/master/doc/integration-staging-sync.md