### PR TITLE
Add rate limit IP addresses to MapIt env vars

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -364,6 +364,10 @@ govuk::apps::local_links_manager::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::local_links_manager::redis_port: "%{hiera('sidekiq_port')}"
 
 govuk::apps::mapit::enabled: true
+govuk::apps::mapit::rate_limit_ips:
+  - '127.0.0.1'
+  - "%{hiera('hosts::production::ip_draft_api_lb')}"
+  - "%{hiera('hosts::production::ip_api_lb')}"
 
 govuk::apps::rummager::rabbitmq_hosts:
   - rabbitmq-1.backend

--- a/modules/govuk/manifests/apps/mapit.pp
+++ b/modules/govuk/manifests/apps/mapit.pp
@@ -22,6 +22,7 @@ class govuk::apps::mapit (
   $port    = '3108',
   $db_password,
   $django_secret_key = undef,
+  $rate_limit_ips = [],
   $sentry_dsn = undef,
 ) {
   if $enabled {
@@ -69,5 +70,8 @@ class govuk::apps::mapit (
     "${title}-DJANGO_SECRET_KEY":
         varname => 'DJANGO_SECRET_KEY',
         value   => $django_secret_key;
+    "${title}-RATE_LIMIT_IPS":
+        varname => 'RATE_LIMIT_IPS',
+        value   => join($rate_limit_ips,',');
   }
 }


### PR DESCRIPTION
The rate limit IPs are the last remaining environment specific configuration left in [MapIt's configuration files][1].  (The other bits are env vars already, or have been superseded by us using Sentry for error reporting)

Once this is deployed and MapIt has been updated to read the config from env vars rather than general.yml, we can move the configuration file into the repo and rid ourselves of the bits in alphagov-deployment.

[1]: https://github.com/alphagov/alphagov-deployment/blob/1ecf707fd59ced975bac2dd9aa8bfb9f3b9809a8/mapit/settings/integration/general.yml"