### PR TITLE
Use awscli rather than s3cmd

### DIFF
--- a/modules/govuk_mysql/manifests/xtrabackup/packages.pp
+++ b/modules/govuk_mysql/manifests/xtrabackup/packages.pp
@@ -13,7 +13,7 @@ class govuk_mysql::xtrabackup::packages (
     require => Class[Mysql::Server],
   }
 
-  package { 's3cmd':
+  package { ['s3cmd', 'awscli']:
     ensure   => 'present',
     provider => 'pip',
   }

--- a/modules/govuk_mysql/templates/usr/local/bin/xtrabackup_s3_base.erb
+++ b/modules/govuk_mysql/templates/usr/local/bin/xtrabackup_s3_base.erb
@@ -25,10 +25,10 @@ date +%Y%m%d-%H%M%S > /var/lib/mysql/xtrabackup_date
 innobackupex --extra-lsndir='/var/lib/mysql/' --encrypt=AES256 --encrypt-key="<%= @encryption_key %>" --stream=xbstream --compress . | envdir /etc/mysql/xtrabackup/env.d /usr/local/bin/gof3r put --endpoint s3-<%= @aws_region -%>.amazonaws.com -b <%= @s3_bucket_name %> -k latest/$TMPNAME
 
 # If a previous backup exists then move it to an archive directory
-envdir /etc/mysql/xtrabackup/env.d /usr/local/bin/s3cmd mv s3://<%= @s3_bucket_name %>/latest/base.xbcrypt s3://<%= @s3_bucket_name %>/$(cat /var/lib/mysql/xtrabackup_date)/base.xbcrypt || echo "No previous backup found for archiving"
+envdir /etc/mysql/xtrabackup/env.d /usr/local/bin/aws s3 mv s3://<%= @s3_bucket_name %>/latest/base.xbcrypt s3://<%= @s3_bucket_name %>/$(cat /var/lib/mysql/xtrabackup_date)/base.xbcrypt >/dev/null || echo "No previous backup found for archiving"
 
 # Rename the temporary backup to a name used by the restore method
-envdir /etc/mysql/xtrabackup/env.d /usr/local/bin/s3cmd mv s3://<%= @s3_bucket_name %>/latest/$TMPNAME s3://<%= @s3_bucket_name %>/latest/base.xbcrypt
+envdir /etc/mysql/xtrabackup/env.d /usr/local/bin/aws s3 mv s3://<%= @s3_bucket_name %>/latest/$TMPNAME s3://<%= @s3_bucket_name %>/latest/base.xbcrypt >/dev/null
 
 if [ $? == 0 ]
   then

--- a/modules/govuk_mysql/templates/usr/local/bin/xtrabackup_s3_incremental.erb
+++ b/modules/govuk_mysql/templates/usr/local/bin/xtrabackup_s3_incremental.erb
@@ -25,10 +25,10 @@ if [ -e /var/lib/mysql/xtrabackup_date ]; then
   innobackupex --incremental-basedir='/var/lib/mysql/' --encrypt=AES256 --encrypt-key="<%= @encryption_key %>" --stream=xbstream --compress --incremental . | envdir /etc/mysql/xtrabackup/env.d /usr/local/bin/gof3r put --endpoint s3-<%= @aws_region -%>.amazonaws.com -b <%= @s3_bucket_name %> -k latest/$TMPNAME
 
   # If a previous backup exists then move it to an archive directory
-  envdir /etc/mysql/xtrabackup/env.d /usr/local/bin/s3cmd mv s3://<%= @s3_bucket_name %>/latest/incremental.xbcrypt s3://<%= @s3_bucket_name %>/$(cat /var/lib/mysql/xtrabackup_date)/incremental-$(date +%Y%m%d-%H%M).xbcrypt || echo "No previous backup found for archiving"
+  envdir /etc/mysql/xtrabackup/env.d /usr/local/bin/aws s3 mv s3://<%= @s3_bucket_name %>/latest/incremental.xbcrypt s3://<%= @s3_bucket_name %>/$(cat /var/lib/mysql/xtrabackup_date)/incremental-$(date +%Y%m%d-%H%M).xbcrypt >/dev/null || echo "No previous backup found for archiving"
 
   # Rename the temporary backup to a name used by the restore method
-  envdir /etc/mysql/xtrabackup/env.d /usr/local/bin/s3cmd mv s3://<%= @s3_bucket_name %>/latest/$TMPNAME s3://<%= @s3_bucket_name %>/latest/incremental.xbcrypt
+  envdir /etc/mysql/xtrabackup/env.d /usr/local/bin/aws s3 mv s3://<%= @s3_bucket_name %>/latest/$TMPNAME s3://<%= @s3_bucket_name %>/latest/incremental.xbcrypt >/dev/null
 
 fi
 


### PR DESCRIPTION
Streaming backups for MySQL started failing for the nightly "base" backup.

They failed because filenames were not being renamed in the S3 bucket, but in S3 terms this is classed as a full copy and rename of an object.

This is because the `s3cmd` tool is unable to process files above 5GB. We have only recently hit this limit for our base backups. There is an [open issue](https://github.com/s3tools/s3cmd/issues/830) regarding this that has not yet have a fix.

It seems that the `awscli` tool is able to handle this, although it does also include some very verbose output which is not suitable for an automated script.

I am not removing the `s3cmd` tool as it's used for other things within these manifests.