### PR TITLE
AWS rummager enable Rabbitmq govuk_index_listener

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -399,6 +399,7 @@ govuk::apps::release::github_username: "govuk-ci"
 govuk::apps::rummager::nagios_memory_warning: 4600
 govuk::apps::rummager::nagios_memory_critical: 4900
 govuk::apps::rummager::enable_publishing_listener: true
+govuk::apps::rummager::rabbitmq::enable_govuk_index_listener: true
 govuk::apps::rummager::rabbitmq::enable_publishing_listener: true
 govuk::apps::rummager::rabbitmq_user: 'rummager-v2'
 govuk::apps::rummager::redis_host: 'backend-redis'


### PR DESCRIPTION
Enable the Rummager govuk_index Rabbitmq consumer on AWS. It was originally
disabled, probably missed during the migration.