### PR TITLE
Only keep two daily backup archives on graphite-1

### DIFF
--- a/modules/govuk/files/usr/local/bin/govuk_backup_graphite_whisper_files
+++ b/modules/govuk/files/usr/local/bin/govuk_backup_graphite_whisper_files
@@ -2,7 +2,7 @@
 
 TIMESTAMP=`date +%Y-%m-%d_%Hh%Mm.%A`
 
-DAYS_TO_KEEP="3"
+DAYS_TO_KEEP="2"
 
 GRAPHITE_STORAGE_DIRECTORY="/opt/graphite/storage"
 GRAPHITE_WHISPER_DIRECTORY_NAME="whisper"


### PR DESCRIPTION
There's not quite enough space for three, especially in Integration, so we'll just keep two. These are copied over to backup-1 and then to S3 after that so it's not crucial to keep them hanging around on graphite-1 itself.