### PR TITLE
AWS Jenkins add mount

### DIFF
--- a/hieradata_aws/class/jenkins.yaml
+++ b/hieradata_aws/class/jenkins.yaml
@@ -1,4 +1,16 @@
 ---
+
+lv:
+  data:
+    pv: '/dev/xvdf'
+    vg: 'jenkins'
+
+mount:
+  /var/lib/jenkins:
+    disk: '/dev/mapper/jenkins-data'
+    govuk_lvm: 'data'
+    mountoptions: 'defaults'
+
 jenkins_admin_permission_list: &jenkins_admin_permission_list
   - 'hudson.model.Hudson.Administer'
   - 'hudson.model.Hudson.Read'

--- a/modules/govuk/manifests/node/s_jenkins.pp
+++ b/modules/govuk/manifests/node/s_jenkins.pp
@@ -34,6 +34,10 @@ class govuk::node::s_jenkins (
     environment_variables => $environment_variables,
   }
 
+  if $::aws_migration {
+    Govuk_mount['/var/lib/jenkins'] -> Class['govuk_jenkins']
+  }
+
   # Close connection if vhost not known
   nginx::config::vhost::default { 'default':
     status         => '444',


### PR DESCRIPTION
On AWS, mount the Jenkins home directory from a EBS volume.