### PR TITLE
Create Jenkins job for the deploy lag badger

### DIFF
--- a/hieradata/class/integration/jenkins.yaml
+++ b/hieradata/class/integration/jenkins.yaml
@@ -24,6 +24,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::network_config_deploy
   - govuk_jenkins::job::passive_checks
   - govuk_jenkins::job::remove_emergency_banner
+  - govuk_jenkins::job::run_deploy_lag_badger
   - govuk_jenkins::job::run_rake_task
   - govuk_jenkins::job::run_whitehall_data_migrations
   - govuk_jenkins::job::search_benchmark

--- a/modules/govuk_jenkins/manifests/job/run_deploy_lag_badger.pp
+++ b/modules/govuk_jenkins/manifests/job/run_deploy_lag_badger.pp
@@ -1,0 +1,11 @@
+# == Class: govuk_jenkins::job::run_deploy_lag_badger
+#
+# Create a file on disk that can be parsed by jenkins-job-builder
+#
+class govuk_jenkins::job::run_deploy_lag_badger {
+  file { '/etc/jenkins_jobs/jobs/run_deploy_lag_badger.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/run_deploy_lag_badger.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+}

--- a/modules/govuk_jenkins/templates/jobs/run_deploy_lag_badger.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/run_deploy_lag_badger.yaml.erb
@@ -1,0 +1,28 @@
+---
+- scm:
+    name: deploy-lag-badger-repo
+    scm:
+        - git:
+            url: git@github.com:alphagov/govuk-deploy-lag-badger.git
+            branches:
+              - master
+
+- job:
+    name: run-deploy-lag-badger
+    display-name: Run deploy lag badger
+    project-type: freestyle
+    description: "The deploy lag badger notifies developers that there are undeployed PRs"
+    scm:
+      - deploy-lag-badger-repo
+    logrotate:
+        numToKeep: 100
+    triggers:
+        - timed: '0 13 * * *' # 1PM every day
+    builders:
+        - shell: |
+            export REALLY_POST_TO_SLACK=1
+            bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
+            bundle exec rake run
+    wrappers:
+      - ansicolor:
+          colormap: xterm


### PR DESCRIPTION
The deploy lag badger tells people that there are undeployed PRs in an app. Reminding people of this makes sure that we don't let undeployed code lying around for too long.

This currently runs on my Heroku account. Moving it to Jenkins to it's more discoverable and others can contribute.

https://trello.com/c/3JanUKZP