### PR TITLE
Add Build User Vars plugin

### DIFF
--- a/hieradata/class/jenkins.yaml
+++ b/hieradata/class/jenkins.yaml
@@ -58,6 +58,8 @@ govuk_jenkins::plugins:
     version: '1.6.7'
   build-pipeline-plugin:
     version: '1.5.7.1'
+  build-user-vars-plugin:
+    version: '1.5'
   build-with-parameters:
     version: '1.4'
   cloudbees-folder:

--- a/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
@@ -56,6 +56,7 @@
             colormap: xterm
         - build-name:
             name: '${ENV,var="TARGET_APPLICATION"} ${ENV,var="TAG"}'
+        - build-user-vars
     parameters:
         - choice:
             name: TARGET_APPLICATION


### PR DESCRIPTION
The [Build User Vars plugin][plugin] adds environment variables
describing the user who kicked off the build. This will be used to
notify (eg Slack) who kicked off a deployment.

[plugin]: https://wiki.jenkins.io/display/JENKINS/Build+User+Vars+Plugin