### PR TITLE
Collect uptime stats for major publishing apps

### DIFF
--- a/modules/monitoring/templates/govuk-uptime-collector.conf.erb
+++ b/modules/monitoring/templates/govuk-uptime-collector.conf.erb
@@ -6,4 +6,4 @@ respawn
 env RBENV_VERSION=2.3
 env PATH=/usr/lib/rbenv/shims:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
-exec govuk_uptime_collector <%= @environment %> publishing-api content-store
+exec govuk_uptime_collector <%= @environment %> content-store hmrc-manuals-api link-checker-api manuals-publisher publishing-api specialist-publisher travel-advice-publisher


### PR DESCRIPTION
https://trello.com/c/77uzac6A/1113-add-uptime-statistics-to-all-the-apps

Whitehall admin has been omitted because it doesn't have a healthcheck
endpoint for the admin/publishing system.
Mainstream publisher has this endpoint but it doesn't appear to be accessible via `publisher.env.publishing.service.gov.uk/healthcheck` so it won't work with the current method of collecting uptime stats. 