### PR TITLE
Add mapit internal domain

### DIFF
--- a/modules/govuk/manifests/deploy/config.pp
+++ b/modules/govuk/manifests/deploy/config.pp
@@ -103,11 +103,11 @@ class govuk::deploy::config(
     # make sure they're separated out in those locations otherwise puppet
     # won't run cleanly.
     govuk_envvar {
+      'PLEK_SERVICE_ERRBIT_URI': value   => "https://errbit.${app_domain_internal}";
+      'PLEK_SERVICE_MAPIT_URI': value    => "https://mapit.${app_domain_internal}";
       'PLEK_SERVICE_RUMMAGER_URI': value => "https://rummager.${app_domain_internal}";
       'PLEK_SERVICE_SEARCH_URI': value   => "https://search.${app_domain_internal}";
-      'PLEK_SERVICE_ERRBIT_URI': value   => "https://errbit.${app_domain_internal}";
       'PLEK_SERVICE_STATIC_URI': value   => "https://static.${app_domain_internal}";
-      'PLEK_SERVICE_MAPIT_URI': value    => "https://mapit.${app_domain_internal}";
     }
   }
 }

--- a/modules/govuk/manifests/deploy/config.pp
+++ b/modules/govuk/manifests/deploy/config.pp
@@ -107,6 +107,7 @@ class govuk::deploy::config(
       'PLEK_SERVICE_SEARCH_URI': value   => "https://search.${app_domain_internal}";
       'PLEK_SERVICE_ERRBIT_URI': value   => "https://errbit.${app_domain_internal}";
       'PLEK_SERVICE_STATIC_URI': value   => "https://static.${app_domain_internal}";
+      'PLEK_SERVICE_MAPIT_URI': value    => "https://mapit.${app_domain_internal}";
     }
   }
 }


### PR DESCRIPTION
Imminence was still trying to call mapit over the external domain, but mapit is available internally everywhere over the internal domain.

https://trello.com/c/fenlgsMp/745-make-icinga-in-aws-green