### PR TITLE
Add a default value for `aws_migration`

### DIFF
--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -47,6 +47,7 @@ RSpec.configure do |c|
     :puppetversion           => '3.8.6',
     :kernel                  => 'Linux',
     :ipaddress_eth0          => '127.0.0.1',
+    :aws_migration           => false,
   }
 
   c.after(:suite) do


### PR DESCRIPTION
We use this variable a lot now and it's undefined in many of the tests. This
change doesn't fix everything but it does drop us from

861 examples, 223 failures

to

861 examples, 78 failures