### PR TITLE
Remove vestiges of delayed_job from asset-manager

### DIFF
--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -91,7 +91,6 @@ govuk::node::s_development::apps:
 govuk_app_enable_capistrano_layout: false
 govuk_app_enable_services: false
 
-govuk::apps::asset_manager::enable_delayed_job_worker: false
 govuk::apps::asset_manager::mongodb_name: 'govuk_assets_development'
 govuk::apps::asset_manager::mongodb_nodes: ['localhost']
 govuk::apps::authenticating_proxy::mongodb_name: 'authenticating_proxy_development'

--- a/modules/govuk/manifests/apps/asset_manager.pp
+++ b/modules/govuk/manifests/apps/asset_manager.pp
@@ -8,9 +8,6 @@
 # [*port*]
 #   The port that Asset Manager is served on.
 #   Default: 3037
-# [*enable_delayed_job_worker*]
-#   Whether or not to enable the background worker for Delayed Job.
-#   Boolean value.
 # [*enable_procfile_worker*]
 #   Whether to enable the procfile worker
 #   Default: true
@@ -51,7 +48,6 @@
 class govuk::apps::asset_manager(
   $enabled = true,
   $port = '3037',
-  $enable_delayed_job_worker = true,
   $enable_procfile_worker = true,
   $errbit_api_key = undef,
   $sentry_dsn = undef,
@@ -216,10 +212,6 @@ class govuk::apps::asset_manager(
     govuk::app::envvar::mongodb_uri { $app_name:
       hosts    => $mongodb_nodes,
       database => $mongodb_name,
-    }
-
-    govuk::delayed_job::worker { 'asset-manager':
-      enable_service => $enable_delayed_job_worker,
     }
 
     govuk::procfile::worker { $app_name:


### PR DESCRIPTION
We've switched to using Sidekiq instead of DelayedJob in Asset Manager
(see https://github.com/alphagov/asset-manager/pull/232).

The presence of `govuk::delayed_job::worker` meant that the
asset-manager machines were trying to start and monitor the `jobs:work`
Rake task that is no longer available in the code.