### PR TITLE
Remove ERRBIT_API_KEY API for all applications

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -662,7 +662,6 @@ govuk_containers::app::config::global_envvars:
   - "GOVUK_WEBSITE_ROOT=%{hiera('govuk::deploy::config::website_root')}"
 
 govuk_containers::apps::release::envvars:
-  - "ERRBIT_API_KEY=%{hiera('govuk::apps::release::errbit_api_key')}"
   - "OAUTH_ID=%{hiera('govuk::apps::release::oauth_id')}"
   - "OAUTH_SECRET=%{hiera('govuk::apps::release::oauth_secret')}"
   - "GITHUB_USERNAME=%{hiera('govuk::apps::release::github_username')}"

--- a/hieradata/vagrant_credentials.yaml
+++ b/hieradata/vagrant_credentials.yaml
@@ -23,7 +23,6 @@ backup::server::backup_private_key: |
 
 collectd::plugin::postgresql::password: 'password'
 
-govuk::apps::authenticating_proxy::errbit_api_key: '1234567812345678'
 govuk::apps::bouncer::postgresql_role::password: 'sKnvsmsAEeviNNl3Ded90NzxoT7eFI6Qd1cOVmaA'
 govuk::apps::collections_publisher::db::mysql_password: 'BeDrefCoopdevAynhagmimUmdicuvKas'
 govuk::apps::collections_publisher::db_password: "%{hiera('govuk::apps::collections_publisher::db::mysql_password')}"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -703,7 +703,6 @@ govuk_containers::app::config::global_envvars:
   - "GOVUK_WEBSITE_ROOT=%{hiera('govuk::deploy::config::website_root')}"
 
 govuk_containers::apps::release::envvars:
-  - "ERRBIT_API_KEY=%{hiera('govuk::apps::release::errbit_api_key')}"
   - "OAUTH_ID=%{hiera('govuk::apps::release::oauth_id')}"
   - "OAUTH_SECRET=%{hiera('govuk::apps::release::oauth_secret')}"
   - "GITHUB_USERNAME=%{hiera('govuk::apps::release::github_username')}"

--- a/modules/govuk/manifests/apps/asset_manager.pp
+++ b/modules/govuk/manifests/apps/asset_manager.pp
@@ -15,8 +15,6 @@
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
-# [*errbit_api_key*]
-#   Errbit API key used by airbrake
 # [*oauth_id*]
 #   Sets the OAuth ID
 # [*oauth_secret*]
@@ -49,7 +47,6 @@ class govuk::apps::asset_manager(
   $enabled = true,
   $port = '3037',
   $enable_procfile_worker = true,
-  $errbit_api_key = undef,
   $sentry_dsn = undef,
   $oauth_id = undef,
   $oauth_secret = undef,
@@ -185,9 +182,6 @@ class govuk::apps::asset_manager(
     }
 
     govuk::app::envvar {
-      "${title}-ERRBIT_API_KEY":
-        varname => 'ERRBIT_API_KEY',
-        value   => $errbit_api_key;
       "${title}-OAUTH_ID":
         varname => 'OAUTH_ID',
         value   => $oauth_id;

--- a/modules/govuk/manifests/apps/authenticating_proxy.pp
+++ b/modules/govuk/manifests/apps/authenticating_proxy.pp
@@ -19,10 +19,6 @@
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
-# [*errbit_api_key*]
-#   Errbit API key used by airbrake
-#   Default: ''
-#
 # [*govuk_upstream_uri*]
 #   The URI of the upstream service that we proxy to.
 #   Default: undef
@@ -47,7 +43,6 @@ class govuk::apps::authenticating_proxy(
   $mongodb_nodes,
   $mongodb_name = 'authenticating_proxy_production',
   $port = '3107',
-  $errbit_api_key = undef,
   $sentry_dsn = undef,
   $govuk_upstream_uri = undef,
   $oauth_id = undef,
@@ -77,14 +72,6 @@ class govuk::apps::authenticating_proxy(
           app     => $app_name,
           varname => 'GOVUK_UPSTREAM_URI',
           value   => $govuk_upstream_uri;
-    }
-  }
-
-  if $errbit_api_key {
-    govuk::app::envvar { "${title}-ERRBIT_API_KEY":
-      app     => $app_name,
-      varname => 'ERRBIT_API_KEY',
-      value   => $errbit_api_key,
     }
   }
 
@@ -126,9 +113,5 @@ class govuk::apps::authenticating_proxy(
       app     => $app_name,
       varname => 'PLEK_SERVICE_SIGNON_URI',
       value   => "https://signon.${app_domain}";
-    "${title}-PLEK_SERVICE_ERRBIT_URI":
-      app     => $app_name,
-      varname => 'PLEK_SERVICE_ERRBIT_URI',
-      value   => "https://errbit.${app_domain}";
   }
 }

--- a/modules/govuk/manifests/apps/bouncer.pp
+++ b/modules/govuk/manifests/apps/bouncer.pp
@@ -7,9 +7,6 @@
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
-# [*errbit_api_key*]
-#   An API key to send exceptions to Errbit.
-#
 # [*port*]
 #   The port on which Bouncer is served on.
 #   Default: 3049
@@ -33,7 +30,6 @@
 #   Memory use at which Nagios should generate a critical alert.
 #
 class govuk::apps::bouncer(
-  $errbit_api_key = '',
   $sentry_dsn = undef,
   $db_username = 'bouncer',
   $db_password = '',
@@ -188,11 +184,5 @@ class govuk::apps::bouncer(
       host     => $db_hostname,
       database => $db_name,
     }
-  }
-
-  govuk::app::envvar {
-    "${title}-ERRBIT_API_KEY":
-      varname => 'ERRBIT_API_KEY',
-      value   => $errbit_api_key;
   }
 }

--- a/modules/govuk/manifests/apps/calculators.pp
+++ b/modules/govuk/manifests/apps/calculators.pp
@@ -15,8 +15,6 @@
 #   The bearer token to use when communicating with Publishing API.
 #   Default: undef
 #
-# [*errbit_api_key*]
-#   Errbit API key used by airbrake
 #
 # [*secret_key_base*]
 #   The key for Rails to use when signing/encrypting sessions.
@@ -25,7 +23,6 @@ class govuk::apps::calculators(
   $port = '3047',
   $sentry_dsn = undef,
   $publishing_api_bearer_token = undef,
-  $errbit_api_key = undef,
   $secret_key_base = undef,
 ) {
   govuk::app { 'calculators':
@@ -46,9 +43,6 @@ class govuk::apps::calculators(
     "${title}-PUBLISHING_API_BEARER_TOKEN":
         varname => 'PUBLISHING_API_BEARER_TOKEN',
         value   => $publishing_api_bearer_token;
-    "${title}-ERRBIT_API_KEY":
-        varname => 'ERRBIT_API_KEY',
-        value   => $errbit_api_key;
     "${title}-SECRET_KEY_BASE":
         varname => 'SECRET_KEY_BASE',
         value   => $secret_key_base;

--- a/modules/govuk/manifests/apps/calendars.pp
+++ b/modules/govuk/manifests/apps/calendars.pp
@@ -19,15 +19,12 @@
 #   The bearer token to use when communicating with Publishing API.
 #   Default: undef
 #
-# [*errbit_api_key*]
-#   Errbit API key used by airbrake
 #
 class govuk::apps::calendars(
   $port = '3011',
   $sentry_dsn = undef,
   $secret_key_base = undef,
   $publishing_api_bearer_token = undef,
-  $errbit_api_key = undef,
 ) {
   $app_name = 'calendars'
 
@@ -49,9 +46,6 @@ class govuk::apps::calendars(
     "${title}-PUBLISHING_API_BEARER_TOKEN":
         varname => 'PUBLISHING_API_BEARER_TOKEN',
         value   => $publishing_api_bearer_token;
-    "${title}-ERRBIT_API_KEY":
-        varname => 'ERRBIT_API_KEY',
-        value   => $errbit_api_key;
   }
 
   if $secret_key_base {

--- a/modules/govuk/manifests/apps/collections.pp
+++ b/modules/govuk/manifests/apps/collections.pp
@@ -14,8 +14,6 @@
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
-# [*errbit_api_key*]
-#   Errbit API key used by airbrake
 #
 # [*secret_key_base*]
 #   The key for Rails to use when signing/encrypting sessions.
@@ -32,7 +30,6 @@
 class govuk::apps::collections(
   $vhost = 'collections',
   $port = '3070',
-  $errbit_api_key = undef,
   $secret_key_base = undef,
   $sentry_dsn = undef,
   $nagios_memory_warning = undef,
@@ -56,9 +53,6 @@ class govuk::apps::collections(
   }
 
   govuk::app::envvar {
-    "${title}-ERRBIT_API_KEY":
-        varname => 'ERRBIT_API_KEY',
-        value   => $errbit_api_key;
     "${title}-SECRET_KEY_BASE":
         varname => 'SECRET_KEY_BASE',
         value   => $secret_key_base;

--- a/modules/govuk/manifests/apps/collections_publisher.pp
+++ b/modules/govuk/manifests/apps/collections_publisher.pp
@@ -15,8 +15,6 @@
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
-# [*errbit_api_key*]
-#   Errbit API key used by airbrake
 #
 # [*oauth_id*]
 #   Sets the OAuth ID used by gds-sso
@@ -55,7 +53,6 @@
 class govuk::apps::collections_publisher(
   $port = '3078',
   $secret_key_base = undef,
-  $errbit_api_key = undef,
   $sentry_dsn = undef,
   $oauth_id = undef,
   $oauth_secret = undef,
@@ -98,9 +95,6 @@ class govuk::apps::collections_publisher(
   }
 
   govuk::app::envvar {
-    "${title}-ERRBIT_API_KEY":
-      varname => 'ERRBIT_API_KEY',
-      value   => $errbit_api_key;
     "${title}-OAUTH_ID":
       varname => 'OAUTH_ID',
       value   => $oauth_id;

--- a/modules/govuk/manifests/apps/contacts.pp
+++ b/modules/govuk/manifests/apps/contacts.pp
@@ -11,10 +11,6 @@
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
-# [*errbit_api_key*]
-#   Errbit API key used by airbrake
-#   Default: undef
-#
 # [*secret_key_base*]
 #   Used to set the app ENV var SECRET_KEY_BASE which is used to configure
 #   rails 4.x signed cookie mechanism. If unset the app will be unable to
@@ -78,7 +74,6 @@ class govuk::apps::contacts(
   $db_username = undef,
   $db_password = undef,
   $enabled = true,
-  $errbit_api_key = undef,
   $sentry_dsn = undef,
   $oauth_id = undef,
   $oauth_secret = undef,
@@ -127,9 +122,6 @@ class govuk::apps::contacts(
     }
 
     govuk::app::envvar {
-      "${title}-ERRBIT_API_KEY":
-        varname => 'ERRBIT_API_KEY',
-        value   => $errbit_api_key;
       "${title}-PUBLISHING_API_BEARER_TOKEN":
         app     => $app_name,
         varname => 'PUBLISHING_API_BEARER_TOKEN',

--- a/modules/govuk/manifests/apps/content_performance_manager.pp
+++ b/modules/govuk/manifests/apps/content_performance_manager.pp
@@ -86,7 +86,6 @@ class govuk::apps::content_performance_manager(
   $redis_host = undef,
   $redis_port = undef,
   $secret_key_base = undef,
-  $errbit_api_key = undef,
   $sentry_dsn = undef,
 ) {
   $app_name = 'content-performance-manager'
@@ -140,10 +139,6 @@ class govuk::apps::content_performance_manager(
     "${title}-PUBLISHING_API_BEARER_TOKEN":
       varname => 'PUBLISHING_API_BEARER_TOKEN',
       value   => $publishing_api_bearer_token;
-    "${title}-ERRBIT_API_KEY":
-      varname => 'ERRBIT_API_KEY',
-      app     => $app_name,
-      value   => $errbit_api_key;
   }
 
   govuk::app::envvar::redis { $app_name:

--- a/modules/govuk/manifests/apps/content_store.pp
+++ b/modules/govuk/manifests/apps/content_store.pp
@@ -34,10 +34,6 @@
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
-# [*errbit_api_key*]
-#   Errbit API key used by airbrake
-#   Default: ''
-#
 # [*secret_key_base*]
 #   The key for Rails to use when signing/encrypting sessions.
 #
@@ -50,7 +46,6 @@ class govuk::apps::content_store(
   $publishing_api_bearer_token = undef,
   $nagios_memory_warning = undef,
   $nagios_memory_critical = undef,
-  $errbit_api_key = '',
   $secret_key_base = undef,
   $sentry_dsn = undef,
 ) {
@@ -100,8 +95,5 @@ class govuk::apps::content_store(
     "${title}-PUBLISHING_API_BEARER_TOKEN":
       varname => 'PUBLISHING_API_BEARER_TOKEN',
       value   => $publishing_api_bearer_token;
-    "${title}-ERRBIT_API_KEY":
-      varname => 'ERRBIT_API_KEY',
-      value   => $errbit_api_key;
   }
 }

--- a/modules/govuk/manifests/apps/content_tagger.pp
+++ b/modules/govuk/manifests/apps/content_tagger.pp
@@ -14,8 +14,6 @@
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
-# [*errbit_api_key*]
-#   Errbit API key used by airbrake
 #
 # [*db_hostname*]
 #   The hostname of the database server to use in the DATABASE_URL.
@@ -55,7 +53,6 @@ class govuk::apps::content_tagger(
   $port = '3116',
   $secret_key_base = undef,
   $sentry_dsn = undef,
-  $errbit_api_key = '',
   $db_hostname = undef,
   $db_username = 'content_tagger',
   $db_password = undef,
@@ -97,9 +94,6 @@ class govuk::apps::content_tagger(
   }
 
   govuk::app::envvar {
-    "${title}-ERRBIT_API_KEY":
-      varname => 'ERRBIT_API_KEY',
-      value   => $errbit_api_key;
     "${title}-OAUTH_ID":
       varname => 'OAUTH_ID',
       value   => $oauth_id;

--- a/modules/govuk/manifests/apps/email_alert_api.pp
+++ b/modules/govuk/manifests/apps/email_alert_api.pp
@@ -46,8 +46,6 @@
 #   URL to the public govdelivery page users are redirected to to enter their
 #   email and subscribe (URL should include a %s to provide a topic ID)
 #
-# [*errbit_api_key*]
-#   Errbit API key used by airbrake
 #
 # [*secret_key_base*]
 #   The key for Rails to use when signing/encrypting sessions.
@@ -73,7 +71,6 @@ class govuk::apps::email_alert_api(
   $govdelivery_account_code = undef,
   $govdelivery_hostname = undef,
   $govdelivery_signup_form = undef,
-  $errbit_api_key = undef,
   $secret_key_base = undef,
   $db_username = 'email-alert-api',
   $db_password = undef,
@@ -174,9 +171,6 @@ class govuk::apps::email_alert_api(
       "${title}-GOVDELIVERY_SIGNUP_FORM":
           varname => 'GOVDELIVERY_SIGNUP_FORM',
           value   => $govdelivery_signup_form;
-      "${title}-ERRBIT_API_KEY":
-          varname => 'ERRBIT_API_KEY',
-          value   => $errbit_api_key;
       "${title}-SECRET_KEY_BASE":
           varname => 'SECRET_KEY_BASE',
           value   => $secret_key_base;

--- a/modules/govuk/manifests/apps/email_alert_frontend.pp
+++ b/modules/govuk/manifests/apps/email_alert_frontend.pp
@@ -15,8 +15,6 @@
 # [*port*]
 #   What port should the app run on?
 #
-# [*errbit_api_key*]
-#   Errbit API key used by airbrake
 #
 # [*secret_key_base*]
 #   The key for Rails to use when signing/encrypting sessions.
@@ -27,7 +25,6 @@
 class govuk::apps::email_alert_frontend(
   $vhost = 'email-alert-frontend',
   $port = '3099',
-  $errbit_api_key = undef,
   $secret_key_base = undef,
   $sentry_dsn = undef,
 ) {
@@ -45,9 +42,6 @@ class govuk::apps::email_alert_frontend(
   }
 
   govuk::app::envvar {
-    "${title}-ERRBIT_API_KEY":
-        varname => 'ERRBIT_API_KEY',
-        value   => $errbit_api_key;
     "${title}-SECRET_KEY_BASE":
         varname => 'SECRET_KEY_BASE',
         value   => $secret_key_base;

--- a/modules/govuk/manifests/apps/email_alert_service.pp
+++ b/modules/govuk/manifests/apps/email_alert_service.pp
@@ -21,8 +21,6 @@
 #   RabbitMQ password.
 #   Default: email_alert_service
 #
-# [*errbit_api_key*]
-#   Errbit API key used by airbrake
 #
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
@@ -32,7 +30,6 @@ class govuk::apps::email_alert_service(
   $rabbitmq_user = 'email_alert_service',
   $rabbitmq_password = 'email_alert_service',
   $sentry_dsn = undef,
-  $errbit_api_key = undef,
   $redis_host = undef,
 ) {
   govuk::app { 'email-alert-service':
@@ -54,11 +51,5 @@ class govuk::apps::email_alert_service(
 
   govuk::app::envvar::redis { 'email-alert-service':
     host => $redis_host,
-  }
-
-  govuk::app::envvar {
-    "${title}-ERRBIT_API_KEY":
-        varname => 'ERRBIT_API_KEY',
-        value   => $errbit_api_key;
   }
 }

--- a/modules/govuk/manifests/apps/feedback.pp
+++ b/modules/govuk/manifests/apps/feedback.pp
@@ -7,10 +7,6 @@
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
-# [*errbit_api_key*]
-#   Errbit API key used by airbrake
-#   Default: ''
-#
 # [*publishing_api_bearer_token*]
 #   The bearer token to use when communicating with Publishing API.
 #   Default: undef
@@ -27,7 +23,6 @@
 #
 class govuk::apps::feedback(
   $port = '3028',
-  $errbit_api_key = undef,
   $sentry_dsn = undef,
   $secret_key_base = undef,
   $support_api_bearer_token = undef,
@@ -51,13 +46,6 @@ class govuk::apps::feedback(
 
   Govuk::App::Envvar {
     app => $app_name,
-  }
-
-  if $errbit_api_key {
-    govuk::app::envvar { "${title}-ERRBIT_API_KEY":
-      varname => 'ERRBIT_API_KEY',
-      value   => $errbit_api_key,
-    }
   }
 
   if $secret_key_base != undef {

--- a/modules/govuk/manifests/apps/finder_frontend.pp
+++ b/modules/govuk/manifests/apps/finder_frontend.pp
@@ -15,8 +15,6 @@
 # [*nagios_memory_critical*]
 #   Memory use at which Nagios should generate a critical alert.
 #
-# [*errbit_api_key*]
-#   Errbit API key used by airbrake
 #
 # [*secret_key_base*]
 #   The key for Rails to use when signing/encrypting sessions.
@@ -27,7 +25,6 @@ class govuk::apps::finder_frontend(
   $nagios_memory_warning = undef,
   $nagios_memory_critical = undef,
   $sentry_dsn = undef,
-  $errbit_api_key = undef,
   $secret_key_base = undef,
 ) {
 
@@ -50,9 +47,6 @@ class govuk::apps::finder_frontend(
   }
 
   govuk::app::envvar {
-    "${title}-ERRBIT_API_KEY":
-        varname => 'ERRBIT_API_KEY',
-        value   => $errbit_api_key;
     "${title}-SECRET_KEY_BASE":
         varname => 'SECRET_KEY_BASE',
         value   => $secret_key_base;

--- a/modules/govuk/manifests/apps/frontend.pp
+++ b/modules/govuk/manifests/apps/frontend.pp
@@ -37,8 +37,6 @@
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
-# [*errbit_api_key*]
-#   Errbit API key used by airbrake
 #
 class govuk::apps::frontend(
   $vhost = 'frontend',
@@ -49,7 +47,6 @@ class govuk::apps::frontend(
   $nagios_memory_critical = undef,
   $redis_host = undef,
   $redis_port = undef,
-  $errbit_api_key = undef,
   $sentry_dsn = undef,
 ) {
 
@@ -85,8 +82,5 @@ class govuk::apps::frontend(
     "${title}-PUBLISHING_API_BEARER_TOKEN":
         varname => 'PUBLISHING_API_BEARER_TOKEN',
         value   => $publishing_api_bearer_token;
-    "${title}-ERRBIT_API_KEY":
-        varname => 'ERRBIT_API_KEY',
-        value   => $errbit_api_key;
   }
 }

--- a/modules/govuk/manifests/apps/government_frontend.pp
+++ b/modules/govuk/manifests/apps/government_frontend.pp
@@ -14,28 +14,17 @@
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
-# [*errbit_api_key*]
-#   Errbit API key used by airbrake
-#   Default: ''
-#
 # [*secret_key_base*]
 #   The key for Rails to use when signing/encrypting sessions.
 #
 class govuk::apps::government_frontend(
   $vhost = 'government-frontend',
   $port = '3090',
-  $errbit_api_key = '',
   $sentry_dsn = undef,
   $secret_key_base = undef,
 ) {
   Govuk::App::Envvar {
     app => 'government-frontend',
-  }
-
-  govuk::app::envvar {
-    "${title}-ERRBIT_API_KEY":
-      varname => 'ERRBIT_API_KEY',
-      value   => $errbit_api_key;
   }
 
   if $secret_key_base != undef {

--- a/modules/govuk/manifests/apps/hmrc_manuals_api.pp
+++ b/modules/govuk/manifests/apps/hmrc_manuals_api.pp
@@ -21,10 +21,6 @@
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
-# [*errbit_api_key*]
-#   Errbit API key used by airbrake
-#   Default: undef
-#
 # [*oauth_id*]
 #   Sets the OAuth ID for using GDS-SSO
 #   Default: undef
@@ -52,7 +48,6 @@
 class govuk::apps::hmrc_manuals_api(
   $port = '3071',
   $enable_procfile_worker = true,
-  $errbit_api_key = undef,
   $sentry_dsn = undef,
   $allow_unknown_hmrc_manual_slugs = false,
   $oauth_id = undef,
@@ -89,9 +84,6 @@ class govuk::apps::hmrc_manuals_api(
   }
 
   govuk::app::envvar {
-    "${title}-ERRBIT_API_KEY":
-      varname => 'ERRBIT_API_KEY',
-      value   => $errbit_api_key;
     "${title}-OAUTH_ID":
       varname => 'OAUTH_ID',
       value   => $oauth_id;

--- a/modules/govuk/manifests/apps/imminence.pp
+++ b/modules/govuk/manifests/apps/imminence.pp
@@ -17,8 +17,6 @@
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
-# [*errbit_api_key*]
-#   Errbit API key used by airbrake
 #
 # [*mongodb_nodes*]
 #   An array of MongoDB instance hostnames
@@ -50,7 +48,6 @@
 class govuk::apps::imminence(
   $port = '3002',
   $enable_procfile_worker = true,
-  $errbit_api_key = undef,
   $sentry_dsn = undef,
   $mongodb_nodes = undef,
   $mongodb_name = 'imminence_production',
@@ -83,9 +80,6 @@ class govuk::apps::imminence(
   }
 
   govuk::app::envvar {
-    "${title}-ERRBIT_API_KEY":
-      varname => 'ERRBIT_API_KEY',
-      value   => $errbit_api_key;
     "${title}-OAUTH_ID":
       varname => 'OAUTH_ID',
       value   => $oauth_id;

--- a/modules/govuk/manifests/apps/info_frontend.pp
+++ b/modules/govuk/manifests/apps/info_frontend.pp
@@ -13,10 +13,6 @@
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
-# [*errbit_api_key*]
-#   Errbit API key used by airbrake
-#   Default: ''
-#
 # [*secret_key_base*]
 #   The key for Rails to use when signing/encrypting sessions.
 #
@@ -27,7 +23,6 @@
 class govuk::apps::info_frontend(
   $port = '3085',
   $enabled = false,
-  $errbit_api_key = '',
   $secret_key_base = undef,
   $publishing_api_bearer_token = undef,
   $sentry_dsn = undef,
@@ -59,8 +54,5 @@ class govuk::apps::info_frontend(
     "${title}-PUBLISHING_API_BEARER_TOKEN":
       varname => 'PUBLISHING_API_BEARER_TOKEN',
       value   => $publishing_api_bearer_token;
-    "${title}-ERRBIT_API_KEY":
-      varname => 'ERRBIT_API_KEY',
-      value   => $errbit_api_key;
   }
 }

--- a/modules/govuk/manifests/apps/licencefinder.pp
+++ b/modules/govuk/manifests/apps/licencefinder.pp
@@ -11,10 +11,6 @@
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
-# [*errbit_api_key*]
-#   Errbit API key used by airbrake
-#   Default: ''
-#
 # [*mongodb_nodes*]
 #   An array of MongoDB instance hostnames
 #
@@ -30,7 +26,6 @@
 #
 class govuk::apps::licencefinder(
   $port = '3014',
-  $errbit_api_key = undef,
   $sentry_dsn = undef,
   $mongodb_nodes,
   $mongodb_name = 'licence_finder_production',
@@ -49,15 +44,6 @@ class govuk::apps::licencefinder(
     asset_pipeline        => true,
     asset_pipeline_prefix => 'licencefinder',
     repo_name             => 'licence-finder',
-  }
-
-  if $errbit_api_key {
-    govuk::app::envvar {
-      "${title}-ERRBIT_API_KEY":
-        app     => $app_name,
-        varname => 'ERRBIT_API_KEY',
-        value   => $errbit_api_key;
-    }
   }
 
   if $::govuk_node_class !~ /^(development|training)$/ {

--- a/modules/govuk/manifests/apps/link_checker_api.pp
+++ b/modules/govuk/manifests/apps/link_checker_api.pp
@@ -27,10 +27,6 @@
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
-# [*errbit_api_key*]
-#   Errbit API key for sending errors.
-#   Default: undef
-#
 # [*google_api_key*]
 #   A Google API Key which will be used for Google Safebrowing checks. If
 #   uset these checks won't be performed
@@ -60,7 +56,6 @@ class govuk::apps::link_checker_api (
   $db_name = 'link_checker_api_production',
   $enabled = false,
   $enable_procfile_worker = true,
-  $errbit_api_key = undef,
   $sentry_dsn = undef,
   $google_api_key = undef,
   $port = 3208,
@@ -92,11 +87,6 @@ class govuk::apps::link_checker_api (
   govuk::app::envvar::redis { $app_name:
     host => $redis_host,
     port => $redis_port,
-  }
-
-  govuk::app::envvar { "${title}-ERRBIT_API_KEY":
-    varname => 'ERRBIT_API_KEY',
-    value   => $errbit_api_key;
   }
 
   if $google_api_key != undef {

--- a/modules/govuk/manifests/apps/local_links_manager.pp
+++ b/modules/govuk/manifests/apps/local_links_manager.pp
@@ -14,10 +14,6 @@
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
-# [*errbit_api_key*]
-#   Errbit API key used by airbrake
-#   Default: undef
-#
 # [*secret_key_base*]
 #   Used to set the app ENV var SECRET_KEY_BASE which is used to configure
 #   rails 4.x signed cookie mechanism. If unset the app will be unable to
@@ -80,7 +76,6 @@
 class govuk::apps::local_links_manager(
   $port = 3121,
   $enabled = true,
-  $errbit_api_key = undef,
   $sentry_dsn = undef,
   $secret_key_base = undef,
   $oauth_id = undef,
@@ -120,9 +115,6 @@ class govuk::apps::local_links_manager(
     }
 
     govuk::app::envvar {
-      "${title}-ERRBIT_API_KEY":
-        varname => 'ERRBIT_API_KEY',
-        value   => $errbit_api_key;
       "${title}-GOOGLE_ANALYTICS_GOVUK_VIEW_ID":
         varname => 'GOOGLE_ANALYTICS_GOVUK_VIEW_ID',
         value   => $google_analytics_govuk_view_id;

--- a/modules/govuk/manifests/apps/manuals_publisher.pp
+++ b/modules/govuk/manifests/apps/manuals_publisher.pp
@@ -23,10 +23,6 @@
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
-# [*errbit_api_key*]
-#   Errbit API key for sending errors.
-#   Default: undef
-#
 # [*mongodb_nodes*]
 #   Array of hostnames for the mongo cluster to use.
 #
@@ -58,7 +54,6 @@ class govuk::apps::manuals_publisher(
   $asset_manager_bearer_token = undef,
   $email_alert_api_bearer_token = undef,
   $enable_procfile_worker = true,
-  $errbit_api_key = undef,
   $sentry_dsn = undef,
   $mongodb_nodes,
   $mongodb_name,
@@ -102,9 +97,6 @@ class govuk::apps::manuals_publisher(
     "${title}-ASSET_MANAGER_BEARER_TOKEN":
       varname => 'ASSET_MANAGER_BEARER_TOKEN',
       value   => $asset_manager_bearer_token;
-    "${title}-ERRBIT_API_KEY":
-      varname => 'ERRBIT_API_KEY',
-      value   => $errbit_api_key;
     "${title}-EMAIL_ALERT_API_BEARER_TOKEN":
       varname => 'EMAIL_ALERT_API_BEARER_TOKEN',
       value   => $email_alert_api_bearer_token;

--- a/modules/govuk/manifests/apps/maslow.pp
+++ b/modules/govuk/manifests/apps/maslow.pp
@@ -22,8 +22,6 @@
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
-# [*errbit_api_key*]
-#   Errbit API key used by airbrake
 #
 # [*oauth_id*]
 #   The application's OAuth ID from Signon
@@ -38,7 +36,6 @@ class govuk::apps::maslow(
   $publishing_api_bearer_token = undef,
   $secret_key_base = undef,
   $sentry_dsn = undef,
-  $errbit_api_key = undef,
   $oauth_id = undef,
   $oauth_secret = undef,
 ) {
@@ -72,9 +69,6 @@ class govuk::apps::maslow(
     "${title}-OAUTH_SECRET":
       varname => 'OAUTH_SECRET',
       value   => $oauth_secret;
-    "${title}-ERRBIT_API_KEY":
-        varname => 'ERRBIT_API_KEY',
-        value   => $errbit_api_key;
     "${title}-SECRET_KEY_BASE":
       varname => 'SECRET_KEY_BASE',
       value   => $secret_key_base;

--- a/modules/govuk/manifests/apps/policy_publisher.pp
+++ b/modules/govuk/manifests/apps/policy_publisher.pp
@@ -21,8 +21,6 @@
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
-# [*errbit_api_key*]
-#   Errbit API key used by airbrake
 #
 # [*db_hostname*]
 #   The hostname of the database server to use in the DATABASE_URL.
@@ -46,7 +44,6 @@ class govuk::apps::policy_publisher(
   $port = '3098',
   $publishing_api_bearer_token = undef,
   $secret_key_base = undef,
-  $errbit_api_key = '',
   $sentry_dsn = undef,
   $db_hostname = undef,
   $db_username = 'policy_publisher',
@@ -82,9 +79,6 @@ class govuk::apps::policy_publisher(
   }
 
   govuk::app::envvar {
-    "${title}-ERRBIT_API_KEY":
-      varname => 'ERRBIT_API_KEY',
-      value   => $errbit_api_key;
     "${title}-OAUTH_ID":
       varname => 'OAUTH_ID',
       value   => $oauth_id;

--- a/modules/govuk/manifests/apps/publisher.pp
+++ b/modules/govuk/manifests/apps/publisher.pp
@@ -44,8 +44,6 @@
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
-# [*errbit_api_key*]
-#   Errbit API key used by airbrake
 #
 # [*oauth_id*]
 #   The application's OAuth ID from Signon
@@ -72,7 +70,6 @@ class govuk::apps::publisher(
     $jwt_auth_secret = undef,
     $alert_hostname = 'alert.cluster',
     $sentry_dsn = undef,
-    $errbit_api_key = undef,
     $oauth_id = undef,
     $oauth_secret = undef,
     $fact_check_username = undef,
@@ -155,9 +152,6 @@ class govuk::apps::publisher(
     "${title}-OAUTH_SECRET":
       varname => 'OAUTH_SECRET',
       value   => $oauth_secret;
-    "${title}-ERRBIT_API_KEY":
-      varname => 'ERRBIT_API_KEY',
-      value   => $errbit_api_key;
     "${title}-FACT_CHECK_USERNAME":
       varname => 'FACT_CHECK_USERNAME',
       value   => $fact_check_username;

--- a/modules/govuk/manifests/apps/publishing_api.pp
+++ b/modules/govuk/manifests/apps/publishing_api.pp
@@ -30,10 +30,6 @@
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
-# [*errbit_api_key*]
-#   Errbit API key used by airbrake
-#   Default: ''
-#
 # [*secret_key_base*]
 #   The key for Rails to use when signing/encrypting sessions.
 #
@@ -95,7 +91,6 @@ class govuk::apps::publishing_api(
   $content_store = '',
   $draft_content_store = '',
   $suppress_draft_store_502_error = '',
-  $errbit_api_key = '',
   $sentry_dsn = undef,
   $secret_key_base = undef,
   $db_hostname = undef,
@@ -158,9 +153,6 @@ class govuk::apps::publishing_api(
       "${title}-SUPPRESS_DRAFT_STORE_502_ERROR":
         varname => 'SUPPRESS_DRAFT_STORE_502_ERROR',
         value   => $suppress_draft_store_502_error;
-      "${title}-ERRBIT_API_KEY":
-        varname => 'ERRBIT_API_KEY',
-        value   => $errbit_api_key;
       "${title}-OAUTH_ID":
         varname => 'OAUTH_ID',
         value   => $oauth_id;

--- a/modules/govuk/manifests/apps/release.pp
+++ b/modules/govuk/manifests/apps/release.pp
@@ -11,10 +11,6 @@
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
-# [*errbit_api_key*]
-#   Errbit API key used by airbrake
-#   Default: ''
-#
 # [*secret_key_base*]
 #   The key for Rails to use when signing/encrypting sessions.
 #
@@ -44,7 +40,6 @@
 #
 class govuk::apps::release(
   $port = '3036',
-  $errbit_api_key = '',
   $sentry_dsn = undef,
   $secret_key_base = undef,
   $db_hostname = undef,
@@ -73,9 +68,6 @@ class govuk::apps::release(
   }
 
   govuk::app::envvar {
-    "${title}-ERRBIT_API_KEY":
-      varname => 'ERRBIT_API_KEY',
-      value   => $errbit_api_key;
     "${title}-OAUTH_ID":
       varname => 'OAUTH_ID',
       value   => $oauth_id;

--- a/modules/govuk/manifests/apps/router_api.pp
+++ b/modules/govuk/manifests/apps/router_api.pp
@@ -25,8 +25,6 @@
 # [*secret_key_base*]
 #   The key for Rails to use when signing/encrypting sessions.
 #
-# [*errbit_api_key*]
-#   Errbit API key used by airbrake
 #
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
@@ -43,7 +41,6 @@ class govuk::apps::router_api(
   $vhost = 'router-api',
   $secret_key_base = undef,
   $sentry_dsn = undef,
-  $errbit_api_key = undef,
   $router_nodes_class = undef,
 ) {
   $app_name = 'router-api'
@@ -68,9 +65,6 @@ class govuk::apps::router_api(
     "${title}-SECRET_KEY_BASE":
       varname => 'SECRET_KEY_BASE',
       value   => $secret_key_base;
-    "${title}-ERRBIT_API_KEY":
-        varname => 'ERRBIT_API_KEY',
-        value   => $errbit_api_key;
   }
 
   govuk::app::envvar::mongodb_uri { $app_name:

--- a/modules/govuk/manifests/apps/rummager.pp
+++ b/modules/govuk/manifests/apps/rummager.pp
@@ -31,10 +31,6 @@
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
-# [*errbit_api_key*]
-#   Errbit API key used by Airbrake
-#   Default: undef
-#
 # [*publishing_api_bearer_token*]
 #   The bearer token to use when communicating with Publishing API.
 #   Default: undef
@@ -72,7 +68,6 @@ class govuk::apps::rummager(
   $enable_govuk_index_listener = false,
   $enable_bulk_reindex_listener = false,
   $enable_publishing_listener = false,
-  $errbit_api_key = undef,
   $sentry_dsn = undef,
   $publishing_api_bearer_token = undef,
   $rabbitmq_hosts = ['localhost'],
@@ -167,9 +162,6 @@ class govuk::apps::rummager(
   }
 
   govuk::app::envvar {
-    "${title}-ERRBIT_API_KEY":
-      varname => 'ERRBIT_API_KEY',
-      value   => $errbit_api_key;
     "${title}-PUBLISHING_API_BEARER_TOKEN":
       varname => 'PUBLISHING_API_BEARER_TOKEN',
       value   => $publishing_api_bearer_token;

--- a/modules/govuk/manifests/apps/search_admin.pp
+++ b/modules/govuk/manifests/apps/search_admin.pp
@@ -20,10 +20,6 @@
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
-# [*errbit_api_key*]
-#   Errbit API key used by airbrake
-#   Default: undef
-#
 # [*port*]
 #   The port where the Rails app is running.
 #   Default: 3073
@@ -44,7 +40,6 @@ class govuk::apps::search_admin(
   $db_name = undef,
   $db_password = undef,
   $db_username = undef,
-  $errbit_api_key = undef,
   $sentry_dsn = undef,
   $port = '3073',
   $oauth_id = undef,
@@ -69,9 +64,6 @@ class govuk::apps::search_admin(
   }
 
   govuk::app::envvar {
-    "${title}-ERRBIT_API_KEY":
-      varname => 'ERRBIT_API_KEY',
-      value   => $errbit_api_key;
     "${title}-OAUTH_ID":
       varname => 'OAUTH_ID',
       value   => $oauth_id;

--- a/modules/govuk/manifests/apps/service_manual_frontend.pp
+++ b/modules/govuk/manifests/apps/service_manual_frontend.pp
@@ -17,10 +17,6 @@
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
-# [*errbit_api_key*]
-#   Errbit API key used by airbrake
-#   Default: ''
-#
 # [*secret_key_base*]
 #   Used to set the app ENV var SECRET_KEY_BASE which is used to configure
 #   rails 4.x signed cookie mechanism. If unset the app will be unable to
@@ -31,7 +27,6 @@ class govuk::apps::service_manual_frontend(
   $vhost = 'service-manual-frontend',
   $port = 3122,
   $enabled = true,
-  $errbit_api_key = undef,
   $sentry_dsn = undef,
   $secret_key_base = undef,
 ) {
@@ -53,9 +48,6 @@ class govuk::apps::service_manual_frontend(
     }
 
     govuk::app::envvar {
-      "${title}-ERRBIT_API_KEY":
-        varname => 'ERRBIT_API_KEY',
-        value   => $errbit_api_key;
       "${title}-SECRET_KEY_BASE":
         varname => 'SECRET_KEY_BASE',
         value   => $secret_key_base;

--- a/modules/govuk/manifests/apps/service_manual_publisher.pp
+++ b/modules/govuk/manifests/apps/service_manual_publisher.pp
@@ -19,10 +19,6 @@
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
-# [*errbit_api_key*]
-#   Errbit API key used by airbrake
-#   Default: ''
-#
 # [*oauth_id*]
 #   Sets the OAuth ID
 #
@@ -56,7 +52,6 @@ class govuk::apps::service_manual_publisher(
   $db_name = 'service-manual-publisher_production',
   $db_password = undef,
   $db_username = 'service_manual_publisher',
-  $errbit_api_key = '',
   $sentry_dsn = undef,
   $oauth_id = '',
   $oauth_secret = '',
@@ -86,9 +81,6 @@ class govuk::apps::service_manual_publisher(
   }
 
   govuk::app::envvar {
-    "${title}-ERRBIT_API_KEY":
-      varname => 'ERRBIT_API_KEY',
-      value   => $errbit_api_key;
     "${title}-OAUTH_ID":
       varname => 'OAUTH_ID',
       value   => $oauth_id;

--- a/modules/govuk/manifests/apps/short_url_manager.pp
+++ b/modules/govuk/manifests/apps/short_url_manager.pp
@@ -7,10 +7,6 @@
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
-# [*errbit_api_key*]
-#   Errbit API key for sending errors.
-#   Default: undef
-#
 # [*instance_name*]
 #   Environment specific name used when sending emails.
 #   Default: undef
@@ -52,7 +48,6 @@
 #   Default: undef
 #
 class govuk::apps::short_url_manager(
-  $errbit_api_key = undef,
   $sentry_dsn = undef,
   $instance_name = undef,
   $mongodb_name = undef,
@@ -82,9 +77,6 @@ class govuk::apps::short_url_manager(
   }
 
   govuk::app::envvar {
-    "${title}-ERRBIT_API_KEY":
-      varname => 'ERRBIT_API_KEY',
-      value   => $errbit_api_key;
     "${title}-OAUTH_ID":
       varname => 'OAUTH_ID',
       value   => $oauth_id;

--- a/modules/govuk/manifests/apps/signon.pp
+++ b/modules/govuk/manifests/apps/signon.pp
@@ -29,10 +29,6 @@
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
-# [*errbit_api_key*]
-#   Errbit API key used by airbrake
-#   Default: ''
-#
 # [*instance_name*]
 #   Environment specific name used when sending emails.
 #   Default: undef
@@ -69,7 +65,6 @@ class govuk::apps::signon(
   $devise_pepper = undef,
   $devise_secret_key = undef,
   $enable_procfile_worker = true,
-  $errbit_api_key = undef,
   $sentry_dsn = undef,
   $instance_name = undef,
   $nagios_memory_critical = undef,
@@ -110,9 +105,6 @@ class govuk::apps::signon(
     "${title}-DEVISE_SECRET_KEY":
       varname => 'DEVISE_SECRET_KEY',
       value   => $devise_secret_key;
-    "${title}-ERRBIT_API_KEY":
-      varname => 'ERRBIT_API_KEY',
-      value   => $errbit_api_key;
     "${title}-SSO_PUSH_USER_EMAIL":
       varname => 'SSO_PUSH_USER_EMAIL',
       value   => $sso_push_user_email;

--- a/modules/govuk/manifests/apps/smartanswers.pp
+++ b/modules/govuk/manifests/apps/smartanswers.pp
@@ -26,8 +26,6 @@
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
-# [*errbit_api_key*]
-#   Errbit API key used by airbrake
 #
 # [*secret_key_base*]
 #   The key for Rails to use when signing/encrypting sessions.
@@ -39,7 +37,6 @@ class govuk::apps::smartanswers(
   $publishing_api_bearer_token = undef,
   $nagios_memory_warning = undef,
   $nagios_memory_critical = undef,
-  $errbit_api_key = undef,
   $secret_key_base = undef,
 ) {
   Govuk::App::Envvar {
@@ -58,9 +55,6 @@ class govuk::apps::smartanswers(
     "${title}-PUBLISHING_API_BEARER_TOKEN":
       varname => 'PUBLISHING_API_BEARER_TOKEN',
       value   => $publishing_api_bearer_token;
-    "${title}-ERRBIT_API_KEY":
-      varname => 'ERRBIT_API_KEY',
-      value   => $errbit_api_key;
     "${title}-SECRET_KEY_BASE":
       varname => 'SECRET_KEY_BASE',
       value   => $secret_key_base;

--- a/modules/govuk/manifests/apps/specialist_publisher.pp
+++ b/modules/govuk/manifests/apps/specialist_publisher.pp
@@ -15,10 +15,6 @@
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
-# [*errbit_api_key*]
-#   Errbit API key for sending errors.
-#   Default: undef
-#
 # [*enabled*]
 #   Whether the app is enabled.
 #   Default: false
@@ -78,7 +74,6 @@
 class govuk::apps::specialist_publisher(
   $port = '3064',
   $asset_manager_bearer_token = undef,
-  $errbit_api_key = undef,
   $sentry_dsn = undef,
   $enabled = false,
   $enable_procfile_worker = true,
@@ -155,9 +150,6 @@ client_max_body_size 500m;
       "${title}-ASSET_MANAGER_BEARER_TOKEN":
       varname => 'ASSET_MANAGER_BEARER_TOKEN',
       value   => $asset_manager_bearer_token;
-      "${title}-ERRBIT_API_KEY":
-      varname => 'ERRBIT_API_KEY',
-      value   => $errbit_api_key;
       "${title}-OAUTH_ID":
       varname => 'OAUTH_ID',
       value   => $oauth_id;

--- a/modules/govuk/manifests/apps/static.pp
+++ b/modules/govuk/manifests/apps/static.pp
@@ -15,10 +15,6 @@
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
-# [*errbit_api_key*]
-#   Errbit API key used by airbrake
-#   Default: undef
-#
 # [*draft_environment*]
 #   A boolean to indicate whether we are in the draft environment.
 #   Sets the environment variable DRAFT_ENVIRONMENT to 'true' if
@@ -44,7 +40,6 @@
 class govuk::apps::static(
   $vhost = 'static',
   $port = '3013',
-  $errbit_api_key = undef,
   $sentry_dsn = undef,
   $draft_environment = false,
   $secret_key_base = undef,
@@ -71,13 +66,6 @@ class govuk::apps::static(
 
   Govuk::App::Envvar {
     app => $app_name,
-  }
-
-  if $errbit_api_key {
-    govuk::app::envvar { "${title}-ERRBIT_API_KEY":
-      varname => 'ERRBIT_API_KEY',
-      value   => $errbit_api_key,
-    }
   }
 
   if $draft_environment {

--- a/modules/govuk/manifests/apps/static/enable_running_in_draft_mode.pp
+++ b/modules/govuk/manifests/apps/static/enable_running_in_draft_mode.pp
@@ -12,10 +12,6 @@
 #   The port that the app is served on.
 #   Default: 3132
 #
-# [*errbit_api_key*]
-#   Errbit API key used by airbrake
-#   Default: undef
-#
 # [*draft_environment*]
 #   A boolean to indicate whether we are in the draft environment.
 #   Sets the environment variable DRAFT_ENVIRONMENT to 'true' if
@@ -41,7 +37,6 @@
 class govuk::apps::static::enable_running_in_draft_mode(
   $vhost = 'draft-static',
   $port = '3132',
-  $errbit_api_key = undef,
   $draft_environment = true,
   $secret_key_base = undef,
   $publishing_api_bearer_token = undef,
@@ -67,13 +62,6 @@ class govuk::apps::static::enable_running_in_draft_mode(
 
   Govuk::App::Envvar {
     app => $app_name,
-  }
-
-  if $errbit_api_key {
-    govuk::app::envvar { "${title}-ERRBIT_API_KEY":
-      varname => 'ERRBIT_API_KEY',
-      value   => $errbit_api_key,
-    }
   }
 
   if $draft_environment {

--- a/modules/govuk/manifests/apps/support.pp
+++ b/modules/govuk/manifests/apps/support.pp
@@ -15,10 +15,6 @@
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
-# [*errbit_api_key*]
-#   Errbit API key used by airbrake
-#   Default: ''
-#
 # [*oauth_id*]
 #   Sets the OAuth ID
 #
@@ -51,7 +47,6 @@
 #
 class govuk::apps::support(
   $emergency_contact_details = undef,
-  $errbit_api_key = undef,
   $sentry_dsn = undef,
   $enable_procfile_worker = true,
   $oauth_id = undef,
@@ -110,9 +105,6 @@ class govuk::apps::support(
     "${title}-EMERGENCY_CONTACT_DETAILS":
       varname => 'EMERGENCY_CONTACT_DETAILS',
       value   => $emergency_contact_details_json;
-    "${title}-ERRBIT_API_KEY":
-      varname => 'ERRBIT_API_KEY',
-      value   => $errbit_api_key;
     "${title}-OAUTH_ID":
       varname => 'OAUTH_ID',
       value   => $oauth_id;

--- a/modules/govuk/manifests/apps/support_api.pp
+++ b/modules/govuk/manifests/apps/support_api.pp
@@ -26,10 +26,6 @@
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
-# [*errbit_api_key*]
-#   Errbit API key used by airbrake
-#   Default: undef
-#
 # [*port*]
 #   The port where the Rails app is running.
 #   Default: 3075
@@ -66,7 +62,6 @@ class govuk::apps::support_api(
   $db_password = undef,
   $db_username = undef,
   $enable_procfile_worker = true,
-  $errbit_api_key = undef,
   $sentry_dsn = undef,
   $port = '3075',
   $pp_data_url = undef,
@@ -94,9 +89,6 @@ class govuk::apps::support_api(
   }
 
   govuk::app::envvar {
-    "${title}-ERRBIT_API_KEY":
-      varname => 'ERRBIT_API_KEY',
-      value   => $errbit_api_key;
     "${title}-PP_DATA_BEARER_TOKEN":
       varname => 'PP_DATA_BEARER_TOKEN',
       value   => $pp_data_bearer_token;

--- a/modules/govuk/manifests/apps/transition.pp
+++ b/modules/govuk/manifests/apps/transition.pp
@@ -38,8 +38,6 @@
 # [*basic_auth_password*]
 #   The password to use for Basic Auth
 #
-# [*errbit_api_key*]
-#   Errbit API key used by airbrake
 #
 # [*db_hostname*]
 #   The hostname of the database server to use in the DATABASE_URL.
@@ -64,7 +62,6 @@ class govuk::apps::transition(
   $secret_key_base = undef,
   $basic_auth_username = undef,
   $basic_auth_password = undef,
-  $errbit_api_key = undef,
   $db_hostname = undef,
   $db_username = 'transition',
   $db_password = undef,
@@ -124,9 +121,6 @@ class govuk::apps::transition(
       "${title}-BASIC_AUTH_PASSWORD":
         varname => 'BASIC_AUTH_PASSWORD',
         value   => $basic_auth_password;
-      "${title}-ERRBIT_API_KEY":
-        varname => 'ERRBIT_API_KEY',
-        value   => $errbit_api_key;
     }
   }
 }

--- a/modules/govuk/manifests/apps/travel_advice_publisher.pp
+++ b/modules/govuk/manifests/apps/travel_advice_publisher.pp
@@ -19,10 +19,6 @@
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
-# [*errbit_api_key*]
-#   Errbit API key used by airbrake
-#   Default: undef
-#
 # [*mongodb_name*]
 #   The Mongo database to be used.
 #
@@ -61,7 +57,6 @@ class govuk::apps::travel_advice_publisher(
   $asset_manager_bearer_token = undef,
   $enable_email_alerts = false,
   $enable_procfile_worker = true,
-  $errbit_api_key = undef,
   $sentry_dsn = undef,
   $mongodb_name = undef,
   $mongodb_nodes = undef,
@@ -107,9 +102,6 @@ class govuk::apps::travel_advice_publisher(
     "${title}-ASSET_MANAGER_BEARER_TOKEN":
       varname => 'ASSET_MANAGER_BEARER_TOKEN',
       value   => $asset_manager_bearer_token;
-    "${title}-ERRBIT_API_KEY":
-      varname => 'ERRBIT_API_KEY',
-      value   => $errbit_api_key;
     "${title}-OAUTH_ID":
       varname => 'OAUTH_ID',
       value   => $oauth_id;

--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -39,15 +39,9 @@
 # [*db_username*]
 #   The username to use in the DATABASE_URL.
 #
-# [*errbit_api_key*]
-#   Errbit API key used by airbrake
-#   Default: undef
-#
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
-# [*errbit_api_key*]
-#   Errbit API key used by airbrake
 #   Default: undef
 #
 # [*highlight_words_to_avoid*]
@@ -111,7 +105,6 @@ class govuk::apps::whitehall(
   $db_password = undef,
   $db_username = undef,
   $enable_procfile_worker = true,
-  $errbit_api_key = undef,
   $sentry_dsn = undef,
   $highlight_words_to_avoid = false,
   $nagios_memory_warning = undef,
@@ -436,9 +429,6 @@ class govuk::apps::whitehall(
   }
 
   govuk::app::envvar {
-    "${title}-ERRBIT_API_KEY":
-      varname => 'ERRBIT_API_KEY',
-      value   => $errbit_api_key;
     "${title}-PUBLISHING_API_BEARER_TOKEN":
       varname => 'PUBLISHING_API_BEARER_TOKEN',
       value   => $publishing_api_bearer_token;


### PR DESCRIPTION
This removes the ERRBIT_API_KEY variables from the configs. We don't need it anymore because we've moved to Sentry. Note that this doesn't remove the environment variable from the server. To do this we would need to use `ensure => absent`. This is too much work for it to be worth it.

https://trello.com/c/h7Rt76jU