### PR TITLE
Remove parts of Errbit

### DIFF
--- a/development-vm/Pinfile
+++ b/development-vm/Pinfile
@@ -30,7 +30,6 @@ process :designprinciples => [:static]
 process :'email-alert-api'
 process :'email-alert-frontend' => [:'content-store', :'email-alert-api', :static]
 process :'email-alert-service'
-process :errbit
 process :'event-store'
 process :feedback => [:static, :support, :'support-api']
 process :'finder-frontend' => [:static, :rummager, :'content-store']

--- a/development-vm/Procfile
+++ b/development-vm/Procfile
@@ -30,7 +30,7 @@ designprinciples:      govuk_setenv designprinciples      ./run_in.sh ../../desi
 # whitehall_admin uses port 3026
 # datainsight-frontend used port 3027
 feedback:              govuk_setenv feedback              ./run_in.sh ../../feedback       bundle exec rails server -p 3028
-errbit:                govuk_setenv errbit                ./run_in.sh ../../errbit         bundle exec rails server -p 3029
+# errbit used 3029
 support:               govuk_setenv support               ./run_in.sh ../../support        bundle exec rails server -p 3031
 # publicapi uses port 3032
 # contracts-finder used port 3033

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -309,8 +309,6 @@ govuk::apps::whitehall::procfile_worker_process_count: 2
 
 govuk::apps::whitehall::db::whitehall_fe_password: "%{hiera('mysql_whitehall_frontend')}"
 
-govuk::apps::govuk_crawler_worker::airbrake_endpoint: "https://errbit.%{hiera('app_domain')}/notifier_api/v2/notices"
-govuk::apps::govuk_crawler_worker::airbrake_env: "%{hiera('govuk::deploy::config::errbit_environment_name')}"
 # FIXME: The API can be crawled when https://github.com/alphagov/govuk_crawler_worker/issues/97 is fixed.
 govuk::apps::govuk_crawler_worker::blacklist_paths:
   - '/api/'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -29,7 +29,6 @@ deployable_applications: &deployable_applications
   email-alert-api: {}
   email-alert-frontend: {}
   email-alert-service: {}
-  errbit: {}
   feedback: {}
   finder-frontend: {}
   frontend: {}

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -259,9 +259,6 @@ govuk::apps::email_alert_service::rabbitmq_hosts:
   - rabbitmq-3.backend
 govuk::apps::email_alert_service::redis_host: "%{hiera('sidekiq_host')}"
 
-govuk::apps::errbit::nagios_memory_warning: 2600
-govuk::apps::errbit::nagios_memory_critical: 3000
-
 govuk::apps::finder_frontend::enabled: true
 govuk::apps::finder_frontend::nagios_memory_warning: 2000
 govuk::apps::finder_frontend::nagios_memory_critical: 2500

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -30,7 +30,6 @@ govuk::apps::asset_manager::aws_region: 'eu-west-1'
 govuk::apps::content_performance_manager::feature_auditing_allocation: true
 govuk::apps::content_performance_manager::feature_auditing_theme_filtering: true
 govuk::apps::email_alert_api::allow_govdelivery_topic_syncing: true
-govuk::apps::errbit::errbit_email_from: 'govuk-winston+errbit-integration@digital.cabinet-office.gov.uk'
 govuk::apps::event_store::enabled: true
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
 govuk::apps::publicapi::backdrop_host: 'www.preview.performance.service.gov.uk'

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -72,7 +72,6 @@ govuk::apps::asset_manager::proxy_percentage_of_asset_requests_to_s3_via_nginx: 
 govuk::apps::content_performance_manager::feature_auditing_allocation: false
 govuk::apps::content_performance_manager::feature_auditing_theme_filtering: false
 govuk::apps::email_alert_api::db::backend_ip_range: '10.3.3.0/24'
-govuk::apps::errbit::errbit_email_from: 'govuk-winston+errbit-production@digital.cabinet-office.gov.uk'
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::local_links_manager::local_links_manager_passive_checks: true
 govuk::apps::publicapi::backdrop_host: 'www.performance.service.gov.uk'

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -15,7 +15,6 @@ govuk::apps::content_performance_manager::feature_auditing_allocation: true
 govuk::apps::content_performance_manager::feature_auditing_theme_filtering: false
 govuk::apps::email_alert_api::allow_govdelivery_topic_syncing: true
 govuk::apps::email_alert_api::db::backend_ip_range: '10.2.3.0/24'
-govuk::apps::errbit::errbit_email_from: 'govuk-winston+errbit-staging@digital.cabinet-office.gov.uk'
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::publicapi::backdrop_host: 'www.staging.performance.service.gov.uk'
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-staging'

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -34,7 +34,6 @@ deployable_applications: &deployable_applications
   email-alert-api: {}
   email-alert-frontend: {}
   email-alert-service: {}
-  errbit: {}
   feedback: {}
   finder-frontend: {}
   frontend: {}

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -316,8 +316,6 @@ govuk::apps::whitehall::procfile_worker_process_count: 2
 
 govuk::apps::whitehall::db::whitehall_fe_password: "%{hiera('mysql_whitehall_frontend')}"
 
-govuk::apps::govuk_crawler_worker::airbrake_endpoint: "https://errbit.%{hiera('app_domain')}/notifier_api/v2/notices"
-govuk::apps::govuk_crawler_worker::airbrake_env: "%{hiera('govuk::deploy::config::errbit_environment_name')}"
 # FIXME: The API can be crawled when https://github.com/alphagov/govuk_crawler_worker/issues/97 is fixed.
 govuk::apps::govuk_crawler_worker::blacklist_paths:
   - '/api/'

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -264,9 +264,6 @@ govuk::apps::email_alert_service::rabbitmq_hosts:
   - rabbitmq
 govuk::apps::email_alert_service::redis_host: "%{hiera('sidekiq_host')}"
 
-govuk::apps::errbit::nagios_memory_warning: 2600
-govuk::apps::errbit::nagios_memory_critical: 3000
-
 govuk::apps::finder_frontend::enabled: true
 govuk::apps::finder_frontend::nagios_memory_warning: 2000
 govuk::apps::finder_frontend::nagios_memory_critical: 2500

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -30,7 +30,6 @@ cron::daily_hour: 6
 govuk::apps::asset_manager::aws_s3_bucket_name: 'govuk-assets-integration'
 govuk::apps::asset_manager::aws_region: 'eu-west-1'
 govuk::apps::email_alert_api::allow_govdelivery_topic_syncing: true
-govuk::apps::errbit::errbit_email_from: 'govuk-winston+errbit-integration@digital.cabinet-office.gov.uk'
 govuk::apps::govuk_crawler_worker::enabled: false
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-integration'
@@ -234,4 +233,3 @@ users::usernames:
   - tijmenbrommet
   - timblair
   - vanitabarrett
-

--- a/modules/govuk/manifests/apps/errbit.pp
+++ b/modules/govuk/manifests/apps/errbit.pp
@@ -33,6 +33,7 @@ class govuk::apps::errbit(
   $oauth_secret = undef,
 ) {
   govuk::app { 'errbit':
+    ensure                 => 'absent',
     app_type               => 'rack',
     port                   => $port,
     vhost_ssl_only         => true,

--- a/modules/govuk/manifests/apps/errbit.pp
+++ b/modules/govuk/manifests/apps/errbit.pp
@@ -42,23 +42,4 @@ class govuk::apps::errbit(
     nagios_memory_warning  => $nagios_memory_warning,
     nagios_memory_critical => $nagios_memory_critical,
   }
-
-  Govuk::App::Envvar {
-    app => 'errbit',
-  }
-
-  $app_domain = hiera('app_domain')
-
-  govuk::app::envvar {
-    'ERRBIT_EMAIL_FROM':
-      value => $errbit_email_from;
-    'ERRBIT_HOST':
-      value => "errbit.${app_domain}";
-    'SECRET_KEY_BASE':
-      value => $errbit_secret_key_base;
-    'OAUTH_ID':
-      value => $oauth_id;
-    'OAUTH_SECRET':
-      value => $oauth_secret;
-  }
 }

--- a/modules/govuk/manifests/deploy/config.pp
+++ b/modules/govuk/manifests/deploy/config.pp
@@ -103,7 +103,6 @@ class govuk::deploy::config(
     # make sure they're separated out in those locations otherwise puppet
     # won't run cleanly.
     govuk_envvar {
-      'PLEK_SERVICE_ERRBIT_URI': value   => "https://errbit.${app_domain_internal}";
       'PLEK_SERVICE_MAPIT_URI': value    => "https://mapit.${app_domain_internal}";
       'PLEK_SERVICE_RUMMAGER_URI': value => "https://rummager.${app_domain_internal}";
       'PLEK_SERVICE_SEARCH_URI': value   => "https://search.${app_domain_internal}";

--- a/modules/govuk/manifests/node/s_draft_cache.pp
+++ b/modules/govuk/manifests/node/s_draft_cache.pp
@@ -13,11 +13,4 @@ class govuk::node::s_draft_cache() {
   govuk_envvar {
     'PLEK_HOSTNAME_PREFIX': value => 'draft-';
   }
-
-  unless $::aws_migration {
-    # This is set for all apps in AWS so we skip adding it here
-    govuk_envvar {
-      'PLEK_SERVICE_ERRBIT_URI': value => "https://errbit.${app_domain}";
-    }
-  }
 }

--- a/modules/govuk/manifests/node/s_draft_content_store.pp
+++ b/modules/govuk/manifests/node/s_draft_content_store.pp
@@ -14,12 +14,4 @@ class govuk::node::s_draft_content_store() inherits govuk::node::s_base {
   govuk_envvar {
     'PLEK_HOSTNAME_PREFIX': value => 'draft-';
   }
-
-  unless $::aws_migration {
-    # This is set for all apps in AWS so we skip adding it here
-    govuk_envvar {
-      'PLEK_SERVICE_ERRBIT_URI': value => "https://errbit.${app_domain}";
-    }
-  }
 }
-

--- a/modules/govuk/manifests/node/s_draft_frontend.pp
+++ b/modules/govuk/manifests/node/s_draft_frontend.pp
@@ -21,7 +21,6 @@ class govuk::node::s_draft_frontend() inherits govuk::node::s_base {
   unless $::aws_migration {
     # This is set for all apps in AWS so we skip adding it here
     govuk_envvar {
-      'PLEK_SERVICE_ERRBIT_URI': value => "https://errbit.${app_domain}";
       'PLEK_SERVICE_SEARCH_URI': value => "https://search.${app_domain}";
     }
   }


### PR DESCRIPTION
This removes a bunch of Errbit config. The key commit is https://github.com/alphagov/govuk-puppet/commit/f3c63f421b59d6018f1c0587f3344d90a21201f1, which is supposed to remove the Errbit application from the machines. I'm not sure how useful this is since the machine Errbit lives on (exception-handler-n) are also being retired.

There's a bunch more stuff to be deleted in future PRs.

https://trello.com/c/h7Rt76jU