### PR TITLE
Use new statsd key for errors

### DIFF
--- a/modules/grafana/templates/dashboards/deployment_panels/_error_counts_table.json.erb
+++ b/modules/grafana/templates/dashboards/deployment_panels/_error_counts_table.json.erb
@@ -50,7 +50,7 @@
   "targets": [
     {
       "refId": "B",
-      "target": "alias(hitcount(stats.govuk.app.<%= @app_name %>.errbit.errors_occurred, '5m'), 'Errors')",
+      "target": "alias(hitcount(stats.govuk.app.<%= @app_name %>.errors_occurred, '5m'), 'Errors')",
       "textEditor": true
     },
     {


### PR DESCRIPTION
govuk_app_config has been reporting to both:

https://github.com/alphagov/govuk_app_config/blob/55cdb003db9521889d5d4371cb3195947093d47a/lib/govuk_app_config/configure.rb#L12-L15

Now that all apps are using govuk_app_config we can remove the old key and just use the new one.

https://trello.com/c/h7Rt76jU