### PR TITLE
Remove the `curl` line for autodeploys to AWS

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/integration_app_deploy.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/integration_app_deploy.yaml.erb
@@ -10,9 +10,6 @@
 
           # Deploy to integration environment
           curl -f -XPOST https://<%= @jenkins_integration_api_user %>:<%= @jenkins_integration_api_password %>@deploy.integration.publishing.service.gov.uk/job/Deploy_App/build --data-urlencode json="$JSON"
-
-          # Deploy to AWS Integration environment
-          curl -f -XPOST https://<%= @jenkins_integration_aws_api_user %>:<%= @jenkins_integration_aws_api_password %>@<%= @aws_deploy_url %>/job/Deploy_App/build --data-urlencode json="$JSON"
     wrappers:
         - ansicolor:
             colormap: xterm


### PR DESCRIPTION
- This was causing builds to fail because: "Error 403 No valid crumb was
  included in the request". According to
  `jenkinsapi` repo issue 503, this happens
  because the Jenkins instance we're trying to talk to has CSRF
  protection enabled and we need to pass some parameters to fix it.

Not reverting the entirety of #6551 because it's churn and this will stop the problem temporarily until we have time to make it actually work.