### PR TITLE
Prevent Sharepoint crawling site

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1584,7 +1584,7 @@ router::nginx::robotstxt: |
   # The robot doesn't recognise its User-Agent string, see the MS support article:
   # https://support.microsoft.com/en-us/help/3019711/the-sharepoint-server-crawler-ignores-directives-in-robots-txt
   User-agent: MS Search 6.0 Robot
-  Crawl-delay: 1
+  Disallow: /
 
 sidekiq_host: 'redis-1.backend'
 sidekiq_port: '6379'

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1114,7 +1114,7 @@ router::nginx::robotstxt: |
   # The robot doesn't recognise its User-Agent string, see the MS support article:
   # https://support.microsoft.com/en-us/help/3019711/the-sharepoint-server-crawler-ignores-directives-in-robots-txt
   User-agent: MS Search 6.0 Robot
-  Crawl-delay: 1
+  Disallow: /
 
 sidekiq_host: 'backend-redis'
 sidekiq_port: '6379'


### PR DESCRIPTION
We have previously slowed the crawl, however it is still hitting our thresholds.
For the last few hours we have been hitting warnings and it has just jumped to
Critical levels.