### PR TITLE
Revert "Remove the `curl` line for autodeploys to AWS"

### DIFF
--- a/hieradata/class/jenkins.yaml
+++ b/hieradata/class/jenkins.yaml
@@ -35,10 +35,6 @@ govuk_jenkins::config:
       -Djenkins.install.runSetupWizard=false
       -Dhudson.tasks.MailSender.SEND_TO_USERS_WITHOUT_READ=true
 
-# FIXME: During the upgrade this stopped deploys being triggered from CI. When
-# the resolution has been configured remove this.
-govuk_jenkins::config::csrf_version: false
-
 govuk_jenkins::packages::terraform::version: '0.8.1'
 
 govuk_jenkins::plugins:

--- a/modules/govuk_jenkins/templates/jobs/integration_app_deploy.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/integration_app_deploy.yaml.erb
@@ -9,7 +9,12 @@
           JSON="{\"parameter\": [{\"name\": \"TARGET_APPLICATION\", \"value\": \"$TARGET_APPLICATION\"}, {\"name\": \"TAG\", \"value\": \"$TAG\"}, {\"name\": \"DEPLOY_TASK\", \"value\": \"$DEPLOY_TASK\"}], \"\": \"\"}"
 
           # Deploy to integration environment
-          curl -f -XPOST https://<%= @jenkins_integration_api_user %>:<%= @jenkins_integration_api_password %>@deploy.integration.publishing.service.gov.uk/job/Deploy_App/build --data-urlencode json="$JSON"
+          CRUMB=$(curl https://<%= @jenkins_integration_api_user %>:<%= @jenkins_integration_api_password %>@deploy.integration.publishing.service.gov.uk/crumbIssuer/api/xml?xpath=concat(//crumbRequestField,":",//crumb)')
+          curl -f -H "$CRUMB" -XPOST https://<%= @jenkins_integration_api_user %>:<%= @jenkins_integration_api_password %>@deploy.integration.publishing.service.gov.uk/job/Deploy_App/build --data-urlencode json="$JSON"
+
+          # Deploy to AWS Integration environment
+          CRUMB=$(curl https://<%= @jenkins_integration_aws_api_user %>:<%= @jenkins_integration_aws_api_password %>@<%= @aws_deploy_url %>/crumbIssuer/api/xml?xpath=concat(//crumbRequestField,":",//crumb)')
+          curl -f -H "$CRUMB" -XPOST https://<%= @jenkins_integration_aws_api_user %>:<%= @jenkins_integration_aws_api_password %>@<%= @aws_deploy_url %>/job/Deploy_App/build --data-urlencode json="$JSON"
     wrappers:
         - ansicolor:
             colormap: xterm


### PR DESCRIPTION
This reverts commit a5ecaf0816139fa820d2c63f9cc9c5ff547ea5dc.

This is something that I needed to fix for deployments to non-AWS Integration but didn't get round to it, and just disabled CSRF protection as a short term fix.

It requires issuing the crumb by making a request, and then adding in the header (https://wiki.jenkins.io/display/jenkins/remote+access+api)