### PR TITLE
Change emergency deploy source to Gitlab

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
@@ -34,8 +34,8 @@
             export S3_ARTEFACT_BUCKET="govuk-integration-artefact"
             <% end -%>
 
-            if [ "$DEPLOY_FROM_GITHUB_ENTERPRISE" == "true" ]; then
-              export GIT_ORIGIN_PREFIX="git@github.digital.cabinet-office.gov.uk:gds-production-backup"
+            if [ "$DEPLOY_FROM_GITLAB" == "true" ]; then
+              export GIT_ORIGIN_PREFIX="git@gitlab.com:govuk"
             fi
 
             ./jenkins.sh
@@ -84,6 +84,6 @@
             description: Git tag/committish to deploy.
             default: release
         - bool:
-            name: DEPLOY_FROM_GITHUB_ENTERPRISE
+            name: DEPLOY_FROM_GITLAB
             default: false
-            description: Whether to deploy from GitHub Enterprise in case public GitHub is unavailable
+            description: Whether to deploy from GitLab.com in case GitHub is unavailable


### PR DESCRIPTION
We no longer use Github Enterprise for emergency deployments. The SSH
public keys for Jenkins instances is added to the govuk-ci gitlab
account.