### PR TITLE
Add ASSET_MANAGER_BEARER_TOKEN env var to Whitehall

### DIFF
--- a/hieradata/development_credentials.yaml
+++ b/hieradata/development_credentials.yaml
@@ -236,4 +236,5 @@ govuk::apps::travel_advice_publisher::asset_manager_bearer_token: 'oauth-bearer-
 govuk::apps::travel_advice_publisher::publishing_api_bearer_token: 'oauth-bearer-token-publishing-api'
 govuk::apps::whitehall::oauth_id: 'oauth-whitehall'
 govuk::apps::whitehall::oauth_secret: 'secret'
+govuk::apps::whitehall::asset_manager_bearer_token: 'oauth-bearer-token-asset-manager'
 govuk::apps::whitehall::publishing_api_bearer_token: 'oauth-bearer-token-publishing-api'

--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -334,8 +334,9 @@ class govuk::apps::whitehall(
           value   => '0';
     }
 
-    # Protocol relative URL so assets in admin are on the same domain but work
-    # in production and development. (This is needed for IE8)
+    # NOTE. The GOVUK_ASSET_ROOT environment variable uses a protocol relative
+    # URL so assets in admin are on the same domain but work in production and
+    # development. (This is needed for IE8)
     govuk::app::envvar {
       "${title}-ASSET_MANAGER_BEARER_TOKEN":
         varname => 'ASSET_MANAGER_BEARER_TOKEN',

--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -22,6 +22,10 @@
 #   Rack limit for how many form parameters it will parse.
 #   Default: undef
 #
+# [*asset_manager_bearer_token*]
+#   The bearer token to use when communicating with Asset Manager.
+#   Default: undef
+#
 # [*basic_auth_credentials*]
 #   Basic auth credentials (necessary for LinkChecker config) used
 #   by some environments.
@@ -97,6 +101,7 @@ class govuk::apps::whitehall(
   $admin_db_password = undef,
   $admin_db_username = undef,
   $admin_key_space_limit = undef,
+  $asset_manager_bearer_token = undef,
   $basic_auth_credentials = undef,
   $configure_frontend = false,
   $configure_admin = false,
@@ -332,6 +337,9 @@ class govuk::apps::whitehall(
     # Protocol relative URL so assets in admin are on the same domain but work
     # in production and development. (This is needed for IE8)
     govuk::app::envvar {
+      "${title}-ASSET_MANAGER_BEARER_TOKEN":
+        varname => 'ASSET_MANAGER_BEARER_TOKEN',
+        value   => $asset_manager_bearer_token;
       "${title}-GOVUK_ASSET_ROOT":
         app     => $app_name,
         varname => 'GOVUK_ASSET_ROOT',


### PR DESCRIPTION
In preparation for us being able to save Whitehall assets to Asset
Manager.

I've tested this change in the Dev VM and confirmed that the environment
variable is written as expected.

We'll also need to ask someone to:

1. Add an application token for Asset Manager to the Whitehall API user
in signon.

2. Store the token generated in step 1 in the govuk-secrets repository.