### PR TITLE
Use JSON, not XML when issuing crumb

### DIFF
--- a/modules/govuk_ci/manifests/master.pp
+++ b/modules/govuk_ci/manifests/master.pp
@@ -83,4 +83,7 @@ class govuk_ci::master (
     minute  => 0,
   }
 
+  # Required for a job that issues Jenkins Crumbs
+  ensure_packages(['jq'])
+
 }

--- a/modules/govuk_jenkins/templates/jobs/integration_app_deploy.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/integration_app_deploy.yaml.erb
@@ -9,12 +9,12 @@
           JSON="{\"parameter\": [{\"name\": \"TARGET_APPLICATION\", \"value\": \"$TARGET_APPLICATION\"}, {\"name\": \"TAG\", \"value\": \"$TAG\"}, {\"name\": \"DEPLOY_TASK\", \"value\": \"$DEPLOY_TASK\"}], \"\": \"\"}"
 
           # Deploy to integration environment
-          CRUMB=$(curl https://<%= @jenkins_integration_api_user %>:<%= @jenkins_integration_api_password %>@deploy.integration.publishing.service.gov.uk/crumbIssuer/api/xml?xpath=concat(//crumbRequestField,":",//crumb)')
-          curl -f -H "$CRUMB" -XPOST https://<%= @jenkins_integration_api_user %>:<%= @jenkins_integration_api_password %>@deploy.integration.publishing.service.gov.uk/job/Deploy_App/build --data-urlencode json="$JSON"
+          CRUMB=$(curl https://<%= @jenkins_integration_api_user %>:<%= @jenkins_integration_api_password %>@deploy.integration.publishing.service.gov.uk/crumbIssuer/api/json | jq '. | .crumb' | sed 's/"//g"')
+          curl -f -H "Jenkins-Crumb:$CRUMB" -XPOST https://<%= @jenkins_integration_api_user %>:<%= @jenkins_integration_api_password %>@deploy.integration.publishing.service.gov.uk/job/Deploy_App/build --data-urlencode json="$JSON"
 
           # Deploy to AWS Integration environment
-          CRUMB=$(curl https://<%= @jenkins_integration_aws_api_user %>:<%= @jenkins_integration_aws_api_password %>@<%= @aws_deploy_url %>/crumbIssuer/api/xml?xpath=concat(//crumbRequestField,":",//crumb)')
-          curl -f -H "$CRUMB" -XPOST https://<%= @jenkins_integration_aws_api_user %>:<%= @jenkins_integration_aws_api_password %>@<%= @aws_deploy_url %>/job/Deploy_App/build --data-urlencode json="$JSON"
+          CRUMB=$(curl https://<%= @jenkins_integration_aws_api_user %>:<%= @jenkins_integration_aws_api_password %>@<%= @aws_deploy_url %>/crumbIssuer/api/json | jq '. | .crumb' | sed 's/"//g"')
+          curl -f -H "Jenkins-Crumb:$CRUMB" -XPOST https://<%= @jenkins_integration_aws_api_user %>:<%= @jenkins_integration_aws_api_password %>@<%= @aws_deploy_url %>/job/Deploy_App/build --data-urlencode json="$JSON"
     wrappers:
         - ansicolor:
             colormap: xterm

--- a/modules/govuk_jenkins/templates/jobs/integration_puppet_deploy.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/integration_puppet_deploy.yaml.erb
@@ -8,7 +8,9 @@
       - shell: |
           JSON="{\"parameter\": [{\"name\": \"TAG\", \"value\": \"$TAG\"}], \"\": \"\"}"
 
-          curl -f -XPOST https://<%= @jenkins_integration_api_user %>:<%= @jenkins_integration_api_password %>@deploy.integration.publishing.service.gov.uk/job/Deploy_Puppet/build -d token=<%= @puppet_auth_token %> --data-urlencode json="$JSON"
+          CRUMB=$(curl https://<%= @jenkins_integration_api_user %>:<%= @jenkins_integration_api_password %>@deploy.integration.publishing.service.gov.uk/crumbIssuer/api/json | jq '. | .crumb' | sed 's/"//g"')
+
+          curl -f -H "Jenkins-Crumb:$CRUMB" -XPOST https://<%= @jenkins_integration_api_user %>:<%= @jenkins_integration_api_password %>@deploy.integration.publishing.service.gov.uk/job/Deploy_Puppet/build -d token=<%= @puppet_auth_token %> --data-urlencode json="$JSON"
     wrappers:
         - ansicolor:
             colormap: xterm


### PR DESCRIPTION
The recommended way of issuing the crumb in a Jenkins shell threw an error.

It feels cleaner and clearer to me to use json, and parse it using jq, then use the method suggested in cURL.

Ensure that jq is installed on the ci-master that runs this particular job.