### PR TITLE
Remove asset-manager-worker from development VM config

### DIFF
--- a/development-vm/Pinfile
+++ b/development-vm/Pinfile
@@ -2,7 +2,7 @@
 # See https://github.com/JordanHatch/bowler for some more info
 
 process :'authenticating-proxy' => [:'government-frontend']
-process :'asset-manager' => [:'asset-manager-worker', :'asset-manager-sidekiq']
+process :'asset-manager' => [:'asset-manager-sidekiq']
 process :'asset-manager-worker'
 process :'asset-manager-sidekiq'
 process :backdrop => [:backdrop_read, :backdrop_write, :stagecraft]

--- a/development-vm/Procfile
+++ b/development-vm/Procfile
@@ -39,7 +39,6 @@ travel_advice_publisher: govuk_setenv travel-advice-publisher ./run_in.sh ../../
 travel_advice_publisher_worker: govuk_setenv travel-advice-publisher ./run_in.sh ../../travel-advice-publisher bundle exec sidekiq -C ./config/sidekiq.yml
 release:               govuk_setenv release               ./run_in.sh ../../release        bundle exec rails server -p 3036
 asset-manager:         govuk_setenv asset-manager         ./run_in.sh ../../asset-manager  bundle exec rails server -p 3037
-asset-manager-worker:  govuk_setenv asset-manager         ./run_in.sh ../../asset-manager  bundle exec rake jobs:work
 asset-manager-sidekiq:  govuk_setenv asset-manager         ./run_in.sh ../../asset-manager  bundle exec sidekiq -C ./config/sidekiq.yml
 # asset-manager sidekiq monitoring uses 3038
 # limelight used port 3040


### PR DESCRIPTION
The `jobs:work` rake task hasn't been available in Asset Manager since `delayed_job` was removed in alphagov/asset-manager#232. This meant that an error occurred if you tried to run `bowl asset-manager`.

This change probably should've been made in #6559.