### PR TITLE
Respect X-Frame-Options header from Asset Manager Rails app

### DIFF
--- a/modules/govuk/manifests/apps/asset_manager.pp
+++ b/modules/govuk/manifests/apps/asset_manager.pp
@@ -95,15 +95,12 @@ class govuk::apps::asset_manager(
       location ~ /raw/(.*) {
         internal;
         add_header GOVUK-Asset-Manager-File-Store NFS;
-        <%- if @deny_framing -%>
-        # Avoid the asset being embedded in other pages[1]
-        # This header is already set in the outer virtual host config but the
-        # presence of additional `add_header` calls in this `location` block
-        # mean that the value from the outer block is not being inherited[2].
+
+        # Control whether the asset can be embedded in other pages[1] by
+        # respecting X-Frame-Options from the Rails application.
         # [1]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
-        # [2]: http://nginx.org/en/docs/http/ngx_http_headers_module.html#add_header
-        add_header X-Frame-Options DENY;
-        <%- end -%>
+        add_header X-Frame-Options $upstream_http_x_frame_options;
+
         alias /var/apps/asset-manager/uploads/assets/$1;
       }
 
@@ -112,6 +109,7 @@ class govuk::apps::asset_manager(
       set $etag_from_rails $upstream_http_etag;
       set $last_modified_from_rails $upstream_http_last_modified;
       set $content_type_from_rails $upstream_http_content_type;
+      set $x_frame_options_from_rails $upstream_http_x_frame_options;
 
       location ~ /cloud-storage-proxy/(.*) {
         # Prevent requests to this location from outside nginx
@@ -149,15 +147,10 @@ class govuk::apps::asset_manager(
         add_header Last-Modified $last_modified_from_rails;
         add_header Content-Type $content_type_from_rails;
 
-        <%- if @deny_framing -%>
-        # Avoid the asset being embedded in other pages[1]
-        # This header is already set in the outer virtual host config but the
-        # presence of additional `add_header` calls in this `location` block
-        # mean that the value from the outer block is not being inherited[2].
+        # Control whether the asset can be embedded in other pages[1] by
+        # respecting X-Frame-Options from the Rails application.
         # [1]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
-        # [2]: http://nginx.org/en/docs/http/ngx_http_headers_module.html#add_header
-        add_header X-Frame-Options DENY;
-        <%- end -%>
+        add_header X-Frame-Options $x_frame_options_from_rails;
 
         # Remove S3 HTTP headers listed in:
         # http://docs.aws.amazon.com/AmazonS3/latest/API/RESTCommonResponseHeaders.html

--- a/modules/govuk/manifests/apps/asset_manager.pp
+++ b/modules/govuk/manifests/apps/asset_manager.pp
@@ -95,6 +95,15 @@ class govuk::apps::asset_manager(
       location ~ /raw/(.*) {
         internal;
         add_header GOVUK-Asset-Manager-File-Store NFS;
+        <%- if @deny_framing -%>
+        # Avoid the asset being embedded in other pages[1]
+        # This header is already set in the outer virtual host config but the
+        # presence of additional `add_header` calls in this `location` block
+        # mean that the value from the outer block is not being inherited[2].
+        # [1]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
+        # [2]: http://nginx.org/en/docs/http/ngx_http_headers_module.html#add_header
+        add_header X-Frame-Options DENY;
+        <%- end -%>
         alias /var/apps/asset-manager/uploads/assets/$1;
       }
 


### PR DESCRIPTION
**NOTE**: This PR should not be merged until alphagov/asset-manager#246 has been merged and deployed to production.

The first commit in this PR just brings the "raw" `location` block into line with the "cloud-storage-proxy" `location` block in terms of the `X-Frame-Options` header. I could've had this as a separate PR, but given that it's not currently causing any problems (see commit note for details) and I want to make the change below, I decided to combine the two.

Currently the `X-Frame-Options` header is set to `DENY` for Mainstream assets [via the Nginx config for the `asset-manager` host][1]. For Whitehall assets this header is set to the value in the response from the Whitehall Rails app [by the Nginx config for the `whitehall-admin` host][2]. [By default Rails sets this value to `SAMEORIGIN`][3] and the default is not overridden in the Whitehall app config.

We're planning to serve Whitehall assets from Asset Manager. This PR changes the Nginx config for the `asset-manager` host to respect the value in the response from the Asset Manager Rails app. alphagov/asset-manager#246 contains a corresponding change in Asset Manager to set the header to `DENY` for Mainstream assets and to `SAMEORIGIN` for Whitehall assets in order to preserve the existing externally visible behaviour when we switch Whitehall assets to be served by Asset Manager.

In time, unless there's a good reason to use different values in different scenarios, we should standardise on one of the values in all scenarios.

Note that I've removed the dependency on the `@deny_framing` instance variable in the Nginx config template, because it no longer makes much sense to allow this setting to be disabled by the `deny_framing` Puppet parameter. I've also removed the comments which talk about the `location` blocks not inheriting the value from the outer block, because again this no longer seems so relevant.

Note also that for the "cloud-storage-proxy" `location` block, I had to store the value of the `X-Frame-Options` header from Rails in a variable so I could set it on the response proxied from S3 c.f. the `Content-Type` header.

[1]:
https://github.com/alphagov/govuk-puppet/blob/4cca939ec49a9b4c106b14b7cf896db31a003636/modules/govuk/manifests/apps/asset_manager.pp#L143-L151
[2]:
https://github.com/alphagov/govuk-puppet/blob/4cca939ec49a9b4c106b14b7cf896db31a003636/modules/govuk/manifests/apps/whitehall.pp#L235-L236
[3]:
http://guides.rubyonrails.org/v4.2.7.1/security.html#default-headers
