### PR TITLE
Update filebeat options

### DIFF
--- a/modules/filebeat/manifests/prospector.pp
+++ b/modules/filebeat/manifests/prospector.pp
@@ -8,7 +8,7 @@ define filebeat::prospector (
   $encoding              = 'plain',
   $input_type            = 'log',
   $fields                = {},
-  $fields_under_root     = false,
+  $fields_under_root     = true,
   $ignore_older          = undef,
   $close_older           = undef,
   $doc_type              = 'log',

--- a/modules/filebeat/templates/prospector.yml.erb
+++ b/modules/filebeat/templates/prospector.yml.erb
@@ -80,6 +80,8 @@ filebeat:
           # If you enable this setting, the keys are copied top level in the output document.
           <%- if @json['keys_under_root'] -%>
           keys_under_root: <%= @json['keys_under_root'] %>
+          <%- else -%>
+          keys_under_root: true
           <%- end -%>
 
           # If keys_under_root and this setting are enabled, then the values from the decoded
@@ -87,6 +89,8 @@ filebeat:
           # in case of conflicts.
           <%- if @json['overwrite_keys'] -%>
           overwrite_keys: <%= @json['overwrite_keys'] %>
+          <%- else -%>
+          overwrite_keys: true
           <%- end -%>
 
           # If this setting is enabled, Filebeat adds a "json_error" key in case of JSON


### PR DESCRIPTION
Currently the outputs are appearing in Kibana like:

`json.@fields.foo`
`fields.application`

Ideally we do not want to have these fields prefixed as such, as per the
guidance
[here](https://gds-way.cloudapps.digital/manuals/logging.html#naming-conventions).

This sets some sensible defaults that can be overridden if required. It
sets the "keys_under_root" option for both "fields" and "json" type
logfiles.