### PR TITLE
Add service check for filebeat

### DIFF
--- a/modules/filebeat/manifests/service.pp
+++ b/modules/filebeat/manifests/service.pp
@@ -6,4 +6,11 @@ class filebeat::service {
     enable => $filebeat::service_enable,
   }
 
+  @@icinga::check { "check_filebeat_running_${::hostname}":
+    ensure              => $filebeat::service_ensure,
+    check_command       => 'check_nrpe!check_proc_running!filebeat',
+    service_description => 'filebeat running',
+    host_name           => $::fqdn,
+  }
+
 }


### PR DESCRIPTION
This service is vital to shipping logs, so we will want to know if it stops working for any reason.