### PR TITLE
Update monitoring URL for Logit Kibana

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -253,6 +253,8 @@ postfix::smarthost:
   - 'email-smtp.eu-west-1.amazonaws.com:587'
   - 'ses-smtp-eu-west-1-prod-345515633.eu-west-1.elb.amazonaws.com:587'
 
+puppet::monitoring::logit_kibana: true
+
 router::nginx::check_requests_warning: '@0.5'
 router::nginx::check_requests_critical: '@0.25'
 
@@ -318,3 +320,5 @@ users::usernames:
   - timblair
   - tomsabin
   - vanitabarrett
+
+varnish::monitoring::logit_kibana: true

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1046,6 +1046,7 @@ postgresql::globals::version: '9.3'
 puppet::puppetserver::puppetdb_version: '2.0.0-1puppetlabs1'
 
 puppet::monitoring::alert_hostname: 'alert'
+puppet::monitoring::logit_kibana: true
 
 puppet::repository::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
@@ -1135,3 +1136,5 @@ unattended_upgrades::origins:
  - "%{::lsbdistid} %{::lsbdistcodename}-security"
 
 unicornherder::version: '0.0.8'
+
+varnish::monitoring::logit_kibana: true

--- a/modules/govuk/lib/puppet/parser/functions/kibana5_url.rb
+++ b/modules/govuk/lib/puppet/parser/functions/kibana5_url.rb
@@ -1,0 +1,41 @@
+module Puppet::Parser::Functions
+  newfunction(:kibana5_url, :type => :rvalue, :doc => <<-EOS
+Craft a URL for a Kibana5 search. Positional arguments:
+
+1. BaseURL of your Kibana instance
+2. Search hash: containing `query` and (optionally) `from` period.
+    EOS
+  ) do |args|
+
+    raise(ArgumentError, "kibana5_url: Wrong number of arguments " +
+      "given #{args.size} for 2") unless args.size == 2
+
+    base_url = args[0]
+    search_hash = args[1]
+    logstash_dash_path = "/app/kibana#/discover"
+
+    raise(ArgumentError, "kibana5_url: No 'query' key found in hash") \
+      unless search_hash.has_key?('query')
+
+    # https://github.com/elasticsearch/kibana/issues/1284
+    raise(ArgumentError, "kibana5_url: Query must use single quotes instead of double") \
+      if search_hash['query'].include?('"')
+
+    if search_hash.has_key?('from')
+      query_prefix = URI.encode("_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:now-#{search_hash['from']},mode:quick,to:now))")
+    else
+      query_prefix = URI.encode("_g=()")
+    end
+
+    query_middle = URI.encode("&_a=(columns:!(_source),index:'*-*',interval:auto,query:(query_string:(analyze_wildcard:!t,query:'")
+    query_suffix = URI.encode("')),sort:!('@timestamp',desc))")
+
+    base_url.chomp!('/')
+    query_params = search_hash['query']
+    # Convert spaces because not application/x-www-form-urlencoded
+    #query_params.gsub!('+', '%20')
+    query_params.gsub!(' ', '+')
+
+    "#{base_url}#{logstash_dash_path}?#{query_prefix}#{query_middle}#{query_params}#{query_suffix}"
+  end
+end

--- a/modules/govuk/spec/functions/kibana5_url_spec.rb
+++ b/modules/govuk/spec/functions/kibana5_url_spec.rb
@@ -1,0 +1,46 @@
+require './spec_helper'
+
+# Put module's plugins on LOAD_PATH.
+dir = File.expand_path('../../', File.dirname(__FILE__))
+$LOAD_PATH.unshift File.join(dir, 'lib')
+
+describe 'kibana5_url' do
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
+  let(:base_url) { 'https://kibana.logit.io' }
+  let(:dash_url) { "#{base_url}/app/kibana#/discover" }
+
+  it 'should raise an error for less than 2 arguments' do
+    expect { scope.function_kibana5_url([:gruffalo]) }.to raise_error(ArgumentError, /given 1 for 2$/)
+  end
+
+  it 'should raise an error if hash does not contain query' do
+    expect { scope.function_kibana5_url([base_url, {}]) }.to raise_error(ArgumentError, /No 'query' key found/)
+  end
+
+  # https://github.com/elasticsearch/kibana/issues/1284
+  it 'should raise an error if query contains double quotes' do
+    in_hash = {
+      'query' => '@fields.tongue:"black"',
+    }
+    expect { scope.function_kibana5_url([base_url, in_hash]) }.to raise_error(ArgumentError, /single quotes instead of double/)
+  end
+
+  it 'should convert a hash with query to a URL with + characters rather than spaces' do
+    in_hash = {
+      'query' => 'tags:bella AND cat:furry',
+    }
+
+    res = scope.function_kibana5_url([base_url, in_hash])
+    expect(res).to eq("#{dash_url}?_g=()&_a=(columns:!(_source),index:'*-*',interval:auto,query:(query_string:(analyze_wildcard:!t,query:'tags:bella+AND+cat:furry')),sort:!('@timestamp',desc))")
+  end
+
+  it 'should convert a hash with query and from to a URL' do
+    in_hash = {
+      'query' => 'host:cache*',
+      'from'  => '24h',
+    }
+
+    res = scope.function_kibana5_url([base_url, in_hash])
+    expect(res).to eq("#{dash_url}?_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:now-24h,mode:quick,to:now))&_a=(columns:!(_source),index:'*-*',interval:auto,query:(query_string:(analyze_wildcard:!t,query:'host:cache*')),sort:!('@timestamp',desc))")
+  end
+end


### PR DESCRIPTION
Create a new function that processes that unbelievably gross Kibana 5 URL syntax for a query. Seriously, there must be a different way that I can't find documentation on.

Add a conditional that we will only enable in Integration now for testing.

Eventually we can remove the rest of the code related to the older, rather pleasant, syntax.

https://trello.com/c/YrTOpoq7/746-logit-migration

Will require users to check this branch of the documentation while we're testing:

https://github.com/alphagov/govuk-developer-docs/pull/480