### PR TITLE
Fix relationship error

### DIFF
--- a/modules/govuk/manifests/node/s_draft_frontend.pp
+++ b/modules/govuk/manifests/node/s_draft_frontend.pp
@@ -15,12 +15,12 @@ class govuk::node::s_draft_frontend() inherits govuk::node::s_base {
     'PLEK_SERVICE_IMMINENCE_URI': value => "https://imminence.${app_domain}";
     'PLEK_SERVICE_LICENSIFY_URI': value => "https://licensify.${app_domain}";
     'PLEK_SERVICE_LOCAL_LINKS_MANAGER_URI': value => "https://local-links-manager.${app_domain}";
-    'PLEK_SERVICE_MAPIT_URI': value  => "https://mapit.${app_domain}";
   }
 
   unless $::aws_migration {
     # This is set for all apps in AWS so we skip adding it here
     govuk_envvar {
+      'PLEK_SERVICE_MAPIT_URI': value  => "https://mapit.${app_domain}";
       'PLEK_SERVICE_SEARCH_URI': value => "https://search.${app_domain}";
     }
   }


### PR DESCRIPTION
The following error was being returned on draft_frontend in AWS:

```
Could not retrieve catalog from remote server: Error 400 on SERVER: Duplicate declaration: Govuk_envvar[PLEK_SERVICE_MAPIT_URI] is already declared in file /usr/share/puppet/production/current/modules/govuk/manifests/deploy/config.pp:110; cannot redeclare at /usr/share/puppet/production/current/modules/govuk/manifests/node/s_draft_frontend.pp:19 on node i-010c28952e4eb296f
```

Move out the env var like we already do for Search.