### PR TITLE
Fix for filebeat Icinga check

### DIFF
--- a/modules/filebeat/manifests/service.pp
+++ b/modules/filebeat/manifests/service.pp
@@ -6,8 +6,15 @@ class filebeat::service {
     enable => $filebeat::service_enable,
   }
 
+  # If service_enable set to true ensure there is a check
+  if $filebeat::service_enable {
+    $check_ensure = 'present'
+  } else {
+    $check_ensure = 'absent'
+  }
+
   @@icinga::check { "check_filebeat_running_${::hostname}":
-    ensure              => $filebeat::service_ensure,
+    ensure              => $check_ensure,
     check_command       => 'check_nrpe!check_proc_running!filebeat',
     service_description => 'filebeat running',
     host_name           => $::fqdn,


### PR DESCRIPTION
$filebeat::service_ensure is set to "running" rather than "present", which caused Puppet to throw an error.