### PR TITLE
Increase power of Jenkins Integration

### DIFF
--- a/hieradata/class/integration/jenkins.yaml
+++ b/hieradata/class/integration/jenkins.yaml
@@ -1,4 +1,6 @@
 ---
+govuk_jenkins::config::executors: '12'
+
 govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::backdrop_transactions_explorer_collector
   - govuk_jenkins::job::check_content_consistency


### PR DESCRIPTION
This Jenkins instance often has lots of jobs queued. We have increased resources and are increasing the number of executors to 12 to stop bottlenecks.