### PR TITLE
Set ELASTICSEARCH_URI for rummager integration

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -36,6 +36,7 @@ govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
 govuk::apps::publicapi::backdrop_host: 'www.preview.performance.service.gov.uk'
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-integration'
 govuk::apps::publishing_api::content_api_prototype: true
+govuk::apps::rummager::elasticsearch_hosts: 'http://rummager-elasticsearch-1.api:9200,http://rummager-elasticsearch-2.api:9200,http://rummager-elasticsearch-3.api:9200'
 govuk::apps::short_url_manager::instance_name: 'integration'
 govuk::apps::signon::instance_name: 'integration'
 govuk::apps::smartanswers::expose_govspeak: true

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -394,6 +394,7 @@ govuk::apps::rummager::rabbitmq::enable_publishing_listener: true
 govuk::apps::rummager::rabbitmq_user: 'rummager-v2'
 govuk::apps::rummager::redis_host: 'backend-redis'
 govuk::apps::rummager::redis_port: '6379'
+govuk::apps::rummager::elasticsearch_hosts: 'http://rummager-elasticsearch:9200'
 
 govuk::apps::search_admin::db_name: 'search_admin_production'
 govuk::apps::search_admin::db_hostname: 'mysql-primary'

--- a/modules/govuk/manifests/apps/rummager.pp
+++ b/modules/govuk/manifests/apps/rummager.pp
@@ -80,6 +80,7 @@ class govuk::apps::rummager(
   $nagios_memory_warning = undef,
   $nagios_memory_critical = undef,
   $spelling_dependencies = 'present',
+  $elasticsearch_hosts = undef,
 ) {
 
   package { ['aspell', 'aspell-en', 'libaspell-dev']:
@@ -174,10 +175,8 @@ class govuk::apps::rummager(
       value   => $publishing_api_bearer_token;
   }
 
-  if $::aws_migration {
-    govuk::app::envvar { "${title}-ELASTICSEARCH_URI":
-      varname => 'ELASTICSEARCH_URI',
-      value   => 'http://rummager-elasticsearch:9200',
-    }
+  govuk::app::envvar { "${title}-ELASTICSEARCH_URI":
+    varname => 'ELASTICSEARCH_URI',
+    value   => $elasticsearch_hosts,
   }
 }


### PR DESCRIPTION
This is the first step to removing the need for the rummager localproxy
settings.

This works with PR: https://github.com/alphagov/rummager/pull/949