### PR TITLE
Rework logic for adding internal domains

### DIFF
--- a/modules/nginx/manifests/config/vhost/proxy.pp
+++ b/modules/nginx/manifests/config/vhost/proxy.pp
@@ -122,10 +122,7 @@ define nginx::config::vhost::proxy(
     if $name =~ /\.(.*)/ {
       $app_name = regsubst($name, '\.(.*)', '')
       $name_internal = "${app_name}.${app_domain_internal}"
-
-      $internal_aliases = regsubst($aliases, '\.(.*)', ".${app_domain_internal}")
     }
-
   }
 
   nginx::config::ssl { $name:

--- a/modules/nginx/templates/proxy-vhost.conf
+++ b/modules/nginx/templates/proxy-vhost.conf
@@ -29,7 +29,11 @@ server {
 <%- ports.each do |port| -%>
 server {
   <%- if scope.lookupvar('::aws_migration') %>
-  server_name <%= @name %> <%= @name_internal %> <%= @aliases.join(" ") unless @aliases.empty? %> <%= @internal_aliases.join(" ") unless @aliases.empty? %>;
+  server_name <%= @name -%> <%= @name_internal %> <%= @aliases.join(" ") unless @aliases.empty? -%><%- @aliases.each do |a| -%>
+  <%-   unless a =~ /.*\.\*/ -%>
+  <%=     a.gsub(/\.(.*)/, '') + '.' + @app_domain_internal -%>
+  <%-   end -%>
+  <%- end -%>;
   <%- else %>
   server_name <%= @name %> <%= @aliases.join(" ") unless @aliases.empty? %>;
   <%- end %>


### PR DESCRIPTION
This errored because the `$name` of the defined type was "graphite", which did not match the regex.

However, we pass an alias "graphite.*", so we were trying to add `$internal_aliases` when the variable was never created.

This means we have to add a bunch more logic into the template itself as Puppet is too limited to construct a check against an array.

If we pass `foo.external` as the `$title`, along with `bar.external` as an alias, we should create:

`server_name foo.external foo.internal bar.external bar.internal;`

If we pass `foo` as the `$title`, along with `bar` as an alias, we should create:

`server_name foo bar bar.internal`

However, if we pass `foo` as the `$title`, along with `foo.*` as an alias, we should only set:

`server_name foo foo.*`