### PR TITLE
Redirect to Logit docs for testing

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -33,6 +33,7 @@ govuk::apps::content_performance_manager::feature_auditing_theme_filtering: true
 govuk::apps::email_alert_api::allow_govdelivery_topic_syncing: true
 govuk::apps::event_store::enabled: true
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
+govuk::apps::kibana::logit_only: true
 govuk::apps::publicapi::backdrop_host: 'www.preview.performance.service.gov.uk'
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-integration'
 govuk::apps::publishing_api::content_api_prototype: true

--- a/modules/govuk/manifests/apps/kibana.pp
+++ b/modules/govuk/manifests/apps/kibana.pp
@@ -30,34 +30,42 @@ class govuk::apps::kibana (
   $signon_client_id = undef,
   $signon_client_secret = undef,
   $signon_root = undef,
+  $logit_only = false,
 ) {
   $app_name = 'kibana'
 
-  govuk::app { $app_name:
-    app_type => 'rack',
-    port     => $port,
-  }
+  $app_domain = hiera('app_domain')
 
-  Govuk::App::Envvar {
-    app => $app_name,
-  }
+  if $logit_only {
+    nginx::config::vhost::redirect { "${app_name}.${app_domain}":
+      to => 'https://docs.publishing.service.gov.uk/manual/logit.html',
+    }
+  } else {
+    govuk::app { $app_name:
+      app_type => 'rack',
+      port     => $port,
+    }
 
-  govuk::app::envvar {
-    "${title}-ES_HOST":
-      varname => 'ES_HOST',
-      value   => $elasticsearch_host;
-    "${title}-SECRET_KEY":
-      varname => 'SECRET_KEY',
-      value   => $secret_key;
-    "${title}-SIGNON_CLIENT_ID":
-      varname => 'SIGNON_CLIENT_ID',
-      value   => $signon_client_id;
-    "${title}-SIGNON_CLIENT_SECRET":
-      varname => 'SIGNON_CLIENT_SECRET',
-      value   => $signon_client_secret;
-    "${title}-SIGNON_ROOT":
-      varname => 'SIGNON_ROOT',
-      value   => $signon_root;
-  }
+    Govuk::App::Envvar {
+      app => $app_name,
+    }
 
+    govuk::app::envvar {
+      "${title}-ES_HOST":
+        varname => 'ES_HOST',
+        value   => $elasticsearch_host;
+      "${title}-SECRET_KEY":
+        varname => 'SECRET_KEY',
+        value   => $secret_key;
+      "${title}-SIGNON_CLIENT_ID":
+        varname => 'SIGNON_CLIENT_ID',
+        value   => $signon_client_id;
+      "${title}-SIGNON_CLIENT_SECRET":
+        varname => 'SIGNON_CLIENT_SECRET',
+        value   => $signon_client_secret;
+      "${title}-SIGNON_ROOT":
+        varname => 'SIGNON_ROOT',
+        value   => $signon_root;
+    }
+  }
 }


### PR DESCRIPTION
To help "encourage" testing of Logit, redirect people to the docs related to Logit in Integration only when browsing to https://kibana.integration.publishing.service.gov.uk.

Requires https://github.com/alphagov/govuk-developer-docs/pull/485 to be merged.

https://trello.com/c/YrTOpoq7/746-logit-migration