### PR TITLE
Fix broken links

### DIFF
--- a/modules/puppet/manifests/monitoring.pp
+++ b/modules/puppet/manifests/monitoring.pp
@@ -31,7 +31,13 @@ class puppet::monitoring (
       'from'  => '4h',
     }
 
-    $action_url = "kibana5_url(${kibana_url}, ${kibana_search})"
+    @@icinga::passive_check { "check_puppet_${::hostname}":
+      service_description => 'puppet last run errors',
+      host_name           => $::fqdn,
+      freshness_threshold => 7200,
+      action_url          => kibana5_url($kibana_url, $kibana_search),
+      notes_url           => monitoring_docs_url(puppet-last-run-errors),
+    }
   } else {
     $kibana_url = "https://kibana.${app_domain}"
 
@@ -42,14 +48,13 @@ class puppet::monitoring (
       'from'  => '4h',
     }
 
-    $action_url = "kibana3_url(${kibana_url}, ${kibana_search})"
+    @@icinga::passive_check { "check_puppet_${::hostname}":
+      service_description => 'puppet last run errors',
+      host_name           => $::fqdn,
+      freshness_threshold => 7200,
+      action_url          => kibana3_url($kibana_url, $kibana_search),
+      notes_url           => monitoring_docs_url(puppet-last-run-errors),
+    }
   }
 
-  @@icinga::passive_check { "check_puppet_${::hostname}":
-    service_description => 'puppet last run errors',
-    host_name           => $::fqdn,
-    freshness_threshold => 7200,
-    action_url          => $action_url,
-    notes_url           => monitoring_docs_url(puppet-last-run-errors),
-  }
 }

--- a/modules/varnish/manifests/monitoring.pp
+++ b/modules/varnish/manifests/monitoring.pp
@@ -39,22 +39,28 @@ class varnish::monitoring (
       'query' => "host:${hostname_prefix[0]}* AND @fields.status:[500 TO 599]",
       'from'  => '4h',
     }
-    $action_url = "kibana5_url(${kibana_url}, ${kibana_search})"
+    @@icinga::check { "check_varnish_responding_${::hostname}":
+      check_command       => 'check_nrpe_1arg!check_varnish_responding',
+      service_description => 'varnishd port not responding',
+      host_name           => $::fqdn,
+      use                 => 'govuk_urgent_priority',
+      notes_url           => monitoring_docs_url(varnish-port-not-responding),
+      action_url          => kibana5_url($kibana_url, $kibana_search),
+    }
     } else {
     $kibana_url = "https://kibana.${app_domain}"
     $kibana_search = {
       'query' => "@source_host:${hostname_prefix[0]}* AND status:[500 TO 599]",
       'from'  => '4h',
     }
-    $action_url = "kibana3_url(${kibana_url}, ${kibana_search})"
+    @@icinga::check { "check_varnish_responding_${::hostname}":
+      check_command       => 'check_nrpe_1arg!check_varnish_responding',
+      service_description => 'varnishd port not responding',
+      host_name           => $::fqdn,
+      use                 => 'govuk_urgent_priority',
+      notes_url           => monitoring_docs_url(varnish-port-not-responding),
+      action_url          => kibana3_url($kibana_url, $kibana_search),
+    }
   }
 
-  @@icinga::check { "check_varnish_responding_${::hostname}":
-    check_command       => 'check_nrpe_1arg!check_varnish_responding',
-    service_description => 'varnishd port not responding',
-    host_name           => $::fqdn,
-    use                 => 'govuk_urgent_priority',
-    notes_url           => monitoring_docs_url(varnish-port-not-responding),
-    action_url          => $action_url,
-  }
 }


### PR DESCRIPTION
The Icinga::Passive_check defined type did not pass the variable like I had hoped.

It's only in two places, so pass in the full block with the different action_url.