### PR TITLE
Disable auto-start of Stagecraft beat service

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -468,7 +468,7 @@ govuk::apps::stagecraft::enabled: true
 govuk::apps::stagecraft::database_password: "%{hiera('govuk::apps::stagecraft::postgresql_db::password')}"
 govuk::apps::stagecraft::message_queue_password: "%{hiera('govuk::apps::stagecraft::rabbitmq::amqp_pass')}"
 govuk::apps::stagecraft::worker::enabled: true
-govuk::apps::stagecraft::beat::enabled: true
+govuk::apps::stagecraft::beat::enabled: false
 govuk::apps::stagecraft::celerycam::enabled: true
 govuk::apps::stagecraft::postgresql_db::api_ip_range: "%{hiera('environment_ip_prefix')}.4.0/24"
 

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -468,7 +468,7 @@ govuk::apps::stagecraft::enabled: true
 govuk::apps::stagecraft::database_password: "%{hiera('govuk::apps::stagecraft::postgresql_db::password')}"
 govuk::apps::stagecraft::message_queue_password: "%{hiera('govuk::apps::stagecraft::rabbitmq::amqp_pass')}"
 govuk::apps::stagecraft::worker::enabled: true
-govuk::apps::stagecraft::beat::enabled: true
+govuk::apps::stagecraft::beat::enabled: false
 govuk::apps::stagecraft::celerycam::enabled: true
 govuk::apps::stagecraft::postgresql_db::api_ip_range: "%{hiera('environment_ip_prefix')}.4.0/24"
 


### PR DESCRIPTION
As part of the migration of Performance Platform to PaaS, we need to prevent the stagecraft-beat-procfile-worker service from being restarted automatically after we manually stop it.

Is this the correct way to disable automatic restart?