### PR TITLE
Add job to configure GitHub repos

### DIFF
--- a/hieradata/class/integration/jenkins.yaml
+++ b/hieradata/class/integration/jenkins.yaml
@@ -5,6 +5,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::backdrop_transactions_explorer_collector
   - govuk_jenkins::job::check_content_consistency
   - govuk_jenkins::job::check_content_store
+  - govuk_jenkins::job::configure_github_repos
   - govuk_jenkins::job::content_performance_manager
   - govuk_jenkins::job::copy_data_from_integration_to_aws
   - govuk_jenkins::job::data_sync_complete_integration

--- a/modules/govuk_jenkins/manifests/job/configure_github_repos.pp
+++ b/modules/govuk_jenkins/manifests/job/configure_github_repos.pp
@@ -1,0 +1,18 @@
+# == Class: govuk_jenkins::job::configure_github_repos
+#
+# Create a file on disk that can be parsed by jenkins-job-builder
+#
+# === Parameters
+#
+# [*github_token*]
+#   A GitHub access token with `repo` and `admin:repo_hook` permissions
+#
+class govuk_jenkins::job::configure_github_repos (
+  $github_token = undef,
+) {
+  file { '/etc/jenkins_jobs/jobs/configure_github_repos.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/configure_github_repos.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+}

--- a/modules/govuk_jenkins/templates/jobs/configure_github_repos.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/configure_github_repos.yaml.erb
@@ -1,0 +1,35 @@
+---
+- scm:
+    name: govuk-saas-config-repo
+    scm:
+        - git:
+            url: git@github.com:alphagov/govuk-saas-config.git
+            branches:
+              - master
+
+- job:
+    name: configure-github-repos
+    display-name: Configure GitHub repos
+    project-type: freestyle
+    description: "Configures GitHub repos with correct settings, branch protection and webhooks"
+    scm:
+      - govuk-saas-config-repo
+    logrotate:
+        numToKeep: 250
+    triggers:
+        - timed: '0 8 * * *' # 8PM every day
+    builders:
+        - shell: |
+            cd github
+            bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
+            bundle exec rake configure_repos
+    wrappers:
+      - ansicolor:
+          colormap: xterm
+      - inject-passwords:
+          global: false
+          mask-password-params: true
+          job-passwords:
+            - name: GITHUB_TOKEN
+              password:
+                '<%= @github_token %>'


### PR DESCRIPTION
This job runs the GitHub configuration script in govuk-saas-config (https://github.com/alphagov/govuk-saas-config/pull/3). The required GitHub token has been added in https://github.com/alphagov/govuk-secrets/pull/70.