### PR TITLE
Add Performance Platform PaaS URls to content store manifest

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -30,6 +30,8 @@ govuk::apps::asset_manager::aws_s3_bucket_name: 'govuk-assets-integration'
 govuk::apps::asset_manager::aws_region: 'eu-west-1'
 govuk::apps::content_performance_manager::feature_auditing_allocation: true
 govuk::apps::content_performance_manager::feature_auditing_theme_filtering: true
+govuk::apps::content_store::performance_platform_big_screen_view_url: 'https://performance-platform-big-screen-view-staging.cloudapps.digital'
+govuk::apps::content_store::performance_platform_spotlight_url: 'https://performance-platform-spotlight-staging.cloudapps.digital'
 govuk::apps::email_alert_api::allow_govdelivery_topic_syncing: true
 govuk::apps::event_store::enabled: true
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -72,6 +72,8 @@ govuk::apps::asset_manager::aws_region: 'eu-west-1'
 govuk::apps::asset_manager::proxy_percentage_of_asset_requests_to_s3_via_nginx: '100'
 govuk::apps::content_performance_manager::feature_auditing_allocation: false
 govuk::apps::content_performance_manager::feature_auditing_theme_filtering: false
+govuk::apps::content_store::performance_platform_big_screen_view_url: 'https://performance-platform-big-screen-view-production.cloudapps.digital'
+govuk::apps::content_store::performance_platform_spotlight_url: 'https://performance-platform-spotlight-production.cloudapps.digital'
 govuk::apps::email_alert_api::db::backend_ip_range: '10.3.3.0/24'
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::local_links_manager::local_links_manager_passive_checks: true

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -14,6 +14,8 @@ govuk::apps::asset_manager::aws_s3_bucket_name: 'govuk-assets-staging'
 govuk::apps::asset_manager::aws_region: 'eu-west-1'
 govuk::apps::content_performance_manager::feature_auditing_allocation: true
 govuk::apps::content_performance_manager::feature_auditing_theme_filtering: false
+govuk::apps::content_store::performance_platform_big_screen_view_url: 'https://performance-platform-big-screen-view-staging.cloudapps.digital'
+govuk::apps::content_store::performance_platform_spotlight_url: 'https://performance-platform-spotlight-staging.cloudapps.digital'
 govuk::apps::email_alert_api::allow_govdelivery_topic_syncing: true
 govuk::apps::email_alert_api::db::backend_ip_range: '10.2.3.0/24'
 govuk::apps::hmrc_manuals_api::publish_topics: false

--- a/modules/govuk/manifests/apps/content_store.pp
+++ b/modules/govuk/manifests/apps/content_store.pp
@@ -14,6 +14,14 @@
 #   The mongo database to be used. Overriden in development
 #   to be 'content_store_development'.
 #
+# [*performance_platform_big_screen_view_url*]
+#   Performance platform big screen view url
+#   Default: undef
+#
+# [*performance_platform_spotlight_url*]
+#   Performance paltform spotlight url
+#   Default: undef
+#
 # [*vhost*]
 #   Virtual host for this application.
 #   Default: content-store
@@ -43,6 +51,8 @@ class govuk::apps::content_store(
   $mongodb_name,
   $vhost = 'content-store',
   $default_ttl = '1800',
+  $performance_platform_big_screen_view_url = undef,
+  $performance_platform_spotlight_url = undef,
   $publishing_api_bearer_token = undef,
   $nagios_memory_warning = undef,
   $nagios_memory_critical = undef,
@@ -95,5 +105,11 @@ class govuk::apps::content_store(
     "${title}-PUBLISHING_API_BEARER_TOKEN":
       varname => 'PUBLISHING_API_BEARER_TOKEN',
       value   => $publishing_api_bearer_token;
+    "${title}-PERFORMANCEPLATFORM_BIG_SCREEN_VIEW":
+      varname => 'PLEK_SERVICE_PERFORMANCEPLATFORM_BIG_SCREEN_VIEW_URI',
+      value   => $performance_platform_big_screen_view_url;
+    "${title}-PERFORMANCEPLATFORM_SPOTLIGHT":
+      varname => 'PLEK_SERVICE_SPOTLIGHT_URI',
+      value   => $performance_platform_spotlight_url;
   }
 }


### PR DESCRIPTION
We need to set the Plek service envars for both the performance platform big screen view and spotlight as these have now moved to the PaaS.

This will enable us to re register the backends in the router-api.