### PR TITLE
Remove remnants of delayed job files and service

### DIFF
--- a/modules/govuk/manifests/apps/asset_manager.pp
+++ b/modules/govuk/manifests/apps/asset_manager.pp
@@ -208,6 +208,11 @@ class govuk::apps::asset_manager(
       database => $mongodb_name,
     }
 
+    # Temporary code to remove delayed job related files & services
+    govuk::delayed_job::worker { 'asset-manager':
+      enable_service => false,
+    }
+
     govuk::procfile::worker { $app_name:
       enable_service => $enable_procfile_worker,
     }

--- a/modules/govuk/manifests/delayed_job.pp
+++ b/modules/govuk/manifests/delayed_job.pp
@@ -1,0 +1,6 @@
+# Temporary code to remove delayed job related files & services
+class govuk::delayed_job {
+  file { '/usr/local/bin/govuk_run_delayed_job_worker':
+    ensure => absent,
+  }
+}

--- a/modules/govuk/manifests/delayed_job/worker.pp
+++ b/modules/govuk/manifests/delayed_job/worker.pp
@@ -1,0 +1,19 @@
+# Temporary code to remove delayed job related files & services
+define govuk::delayed_job::worker (
+  $setenv_as = $title,
+  $enable_service = false,
+) {
+  include govuk::delayed_job
+
+  $service_name = "${title}-delayed-job-worker"
+
+  file { "/etc/init/${service_name}.conf":
+    ensure  => absent,
+  }
+
+  service { $service_name:
+    ensure    => $enable_service,
+    notify    => File["/etc/init/${service_name}.conf"],
+    subscribe => Class['Govuk::Delayed_job'],
+  }
+}


### PR DESCRIPTION
* Remove `/usr/local/bin/govuk_run_delayed_job_worker` script.

* Stop the `asset-manager-delayed-job-worker` service and remove its corresponding `/etc/init/asset-manager-delayed-job-worker.conf` configuration file.

These things should've been done as part of #6559 & #6570. Exceptions like [this one][1] have been occurring because they weren't.

I'm not a Puppet expert, but it *looks* like this is doing the right thing on my development VM.

### Before running `govuk_puppet`

```
$ ls -l /usr/local/bin/govuk_run_delayed_job_worker
-rwxr-xr-x 1 root root 827 Aug 23 22:03 /usr/local/bin/govuk_run_delayed_job_worker

$ ls -l /etc/init/asset-manager-delayed-job-worker.conf
-rw-r--r-- 1 root root 318 Aug 23 22:03 /etc/init/asset-manager-delayed-job-worker.conf

$ sudo service asset-manager-delayed-job-worker status
asset-manager-delayed-job-worker stop/waiting
```

### Running `govuk_puppet`

```
Notice: /Stage[main]/Govuk::Delayed_job/File[/usr/local/bin/govuk_run_delayed_job_worker]/ensure: removed
Notice: /Stage[main]/Govuk::Apps::Asset_manager/Govuk::Delayed_job::Worker[asset-manager]/Service[asset-manager-delayed-job-worker]: Triggered 'refresh' from 1 events
Notice: /Stage[main]/Govuk::Apps::Asset_manager/Govuk::Delayed_job::Worker[asset-manager]/File[/etc/init/asset-manager-delayed-job-worker.conf]/ensure: removed
```

### After running `govuk_puppet`

```
$ ls -l /usr/local/bin/govuk_run_delayed_job_worker
ls: cannot access /usr/local/bin/govuk_run_delayed_job_worker: No such file or directory

$ ls -l /etc/init/asset-manager-delayed-job-worker.conf
ls: cannot access /etc/init/asset-manager-delayed-job-worker.conf: No such file or directory

$ sudo service asset-manager-delayed-job-worker status
asset-manager-delayed-job-worker: unrecognized service
```

[1]: https://sentry.io/govuk/app-asset-manager/issues/356452564