### PR TITLE
Redirect URLs containing uppercase characters

### DIFF
--- a/modules/router/templates/router_include.conf.erb
+++ b/modules/router/templates/router_include.conf.erb
@@ -29,7 +29,7 @@ error_log  /var/log/nginx/lb-error.log;
 # If slug contains no lowercase letters then lowercase it
 # eg www.gov.uk/GOVERNMENT/GUIDANCE -> www.gov.uk/government/guidance
 # eg WWW.GOV.UK/GOVERNMENT/GUIDANCE -> www.gov.uk/government/guidance
-location ~ ^\/[A-Z]+[A-Z\W\d]+$ {
+location ~ [A-Z] {
   rewrite ^(.*)$ $scheme://$host$uri_lowercase permanent;
 }
 


### PR DESCRIPTION
The W3C standard for URLs says:

>URLs in general are case-sensitive (with the exception of machine
>names). There may be URLs, or parts of URLs, where case doesn't matter,
>but identifying these may not be easy. Users should always consider
>that URLs are case-sensitive.

Although this is 'generally' true, in GOV.UK's specific case, we don't
really have a user need to treat URLs differently depending on case.
We had a Zendesk ticket come through because we were handling `/world`
taxon pages differently depending on case. We could cater for this at
an application level, but I'm wondering if it's better to handle this
all in one place?

I apprecicate this change might be contentious. Feedback would be
great. I'd also like to see if there's an Nginx module to do this,
but I thought I'd open the discussion as early as possible.

https://trello.com/c/v8557oJ2/188-fix-case-sensitivity-of-world-location-pages