### PR TITLE
Update query for logit use

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -222,6 +222,7 @@ govuk_sudo::sudo_conf:
 govuk_ppa::path: 'preview'
 
 grafana::dashboards::machine_suffix_metrics: '_integration'
+grafana::dashboards::logit_only: true
 grafana::version: '4.5.2'
 
 hosts::production::ip_api_lb: '10.1.4.254'

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -831,6 +831,7 @@ govuk_unattended_reboot::monitoring_basic_auth:
 
 grafana::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 grafana::dashboards::app_domain: "%{hiera('app_domain')}"
+grafana::dashboards::logit_only: true
 grafana::dashboards::machine_suffix_metrics: ''
 grafana::dashboards::deployment_applications:
   asset-manager: {}

--- a/modules/grafana/manifests/dashboards.pp
+++ b/modules/grafana/manifests/dashboards.pp
@@ -10,13 +10,17 @@
 # [*machine_suffix_metrics*]
 #   The machine hostname suffix for Graphite metrics.
 #
-# [$deployment_applications]
+# [*deployment_applications*]
 #   Hash of application that require a deployment dashboard
+#
+# [*logit_only*]
+#   Set to true if the Elasticsearch datasource is using logit.io
 #
 class grafana::dashboards (
   $app_domain = undef,
   $machine_suffix_metrics = undef,
   $deployment_applications = undef,
+  $logit_only = false,
 ) {
   validate_string($app_domain, $machine_suffix_metrics)
 
@@ -42,6 +46,7 @@ class grafana::dashboards (
 
   create_resources('grafana::dashboards::deployment_dashboard', $deployment_applications, {
     'dashboard_directory' => $dashboard_directory,
-    'app_domain' => $app_domain
+    'app_domain'          => $app_domain,
+    'logit_only'          => $logit_only,
   })
 }

--- a/modules/grafana/manifests/dashboards/deployment_dashboard.pp
+++ b/modules/grafana/manifests/dashboards/deployment_dashboard.pp
@@ -24,6 +24,9 @@
 # [*error_threshold*]
 #   Point at which count turns `red` in the error count table data
 #
+# [*logit_only*]
+#   Set to true if we're using Logit as the Elasticsearch data source.
+#
 define grafana::dashboards::deployment_dashboard (
   $app_name = $title,
   $docs_name = $title,
@@ -37,7 +40,8 @@ define grafana::dashboards::deployment_dashboard (
   $show_response_times = false,
   $show_slow_requests = true,
   $dependent_app_5xx_errors = undef,
-  $show_elasticsearch_stats = false
+  $show_elasticsearch_stats = false,
+  $logit_only = false,
 ) {
   if $has_workers {
     $worker_row = [['worker_failures', 'worker_successes']]

--- a/modules/grafana/templates/dashboards/deployment_panels/_errors_by_controller_action.json.erb
+++ b/modules/grafana/templates/dashboards/deployment_panels/_errors_by_controller_action.json.erb
@@ -78,7 +78,11 @@
           "type": "count"
         }
       ],
+      <% if @logit_only -%>
+      "query": "application:<%= @app_name %> AND @fields.status:[ 500 TO 599 ]",
+      <% else -%>
       "query": "@fields.application:<%= @app_name %> AND @fields.status:[ 500 TO 599 ]",
+      <% end -%>
       "refId": "A",
       "target": "",
       "timeField": "@timestamp"

--- a/modules/grafana/templates/dashboards/deployment_panels/_response_times.json.erb
+++ b/modules/grafana/templates/dashboards/deployment_panels/_response_times.json.erb
@@ -66,7 +66,11 @@
           "type": "percentiles"
         }
       ],
+      <% if @logit_only -%>
+      "query": "application:<%= @app_name %>",
+      <% else -%>
       "query": "@fields.application:<%= @app_name %>",
+      <% end -%>
       "refId": "A",
       "timeField": "@timestamp"
     }

--- a/modules/grafana/templates/dashboards/deployment_panels/_response_times_by_controller.json.erb
+++ b/modules/grafana/templates/dashboards/deployment_panels/_response_times_by_controller.json.erb
@@ -73,7 +73,11 @@
           "type": "percentiles"
         }
       ],
+      <% if @logit_only -%>
+      "query": "application:<%= @app_name %>",
+      <% else -%>
       "query": "@fields.application:<%= @app_name %>",
+      <% end -%>
       "refId": "A",
       "timeField": "@timestamp"
     }


### PR DESCRIPTION
The only index that needs changing is "@fields.application", so I did wonder if it would be easier to add Logstash configuration that made a duplicate field.

However, in the future we ideally want to move away from using the `@fields` prefix (something I'm still trying to work out to do), so I think it's best to put in a conditional until we've entirely migrated to Logit.

I've tested the datasource and it correctly works, but it does require Logit specifically enabling it for us via a support ticket.

EDIT:

As suspected, I've tested this out on our current Grafana 3 -> ES5.4, and it's not supported. There is an [open issue](https://github.com/grafana/grafana/issues/6238) regarding this as we receive the following error:

```
{
  "error": {
    "root_cause": [
      {
        "type": "illegal_argument_exception",
        "reason": "No search type for [count]"
      }
    ],
    "type": "illegal_argument_exception",
    "reason": "No search type for [count]"
  },
  "status": 400
}
```

Which means we probably want to organise the upgrade of Grafana, which I [already have an open PR about](https://github.com/alphagov/govuk-puppet/pull/6627).

/cc @sihugh 