### PR TITLE
Upgrade Grafana to 4.5.2

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -222,6 +222,7 @@ govuk_sudo::sudo_conf:
 govuk_ppa::path: 'preview'
 
 grafana::dashboards::machine_suffix_metrics: '_integration'
+grafana::version: '4.5.2'
 
 hosts::production::ip_api_lb: '10.1.4.254'
 hosts::production::ip_backend_lb: '10.1.3.254'

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -148,6 +148,7 @@ govuk_sudo::sudo_conf:
 govuk_ppa::path: 'preview'
 
 grafana::dashboards::machine_suffix_metrics: '_integration'
+grafana::version: '4.5.2'
 
 icinga::client::check_cputype::cputype: 'amd'
 

--- a/modules/grafana/manifests/init.pp
+++ b/modules/grafana/manifests/init.pp
@@ -2,12 +2,19 @@
 #
 # Set up grafana.
 #
-class grafana {
+# === Parameters:
+#
+# [*version*]
+#   Which version of Grafana to pin to.
+#
+class grafana (
+  $version = '3.1.1-1470047149',
+) {
   include grafana::repo
   include grafana::dashboards
 
   package { 'grafana':
-    ensure  => '3.1.1-1470047149',
+    ensure  => $version,
     require => Class['grafana::repo'],
   }
 


### PR DESCRIPTION
Since we're running Logit as our ELK stack we're using Elasticsearch 5.x. Grafana 3 does not support this version of Elasticsearch, so we need to upgrade.

This is a sensible alternative to https://github.com/alphagov/govuk-puppet/pull/6627

https://trello.com/c/J7rEF3IO/752-add-logit-to-grafana-data-sources