### PR TITLE
Configure deployment dashboard for contacts app

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -835,6 +835,8 @@ grafana::dashboards::deployment_applications:
     # Low usage
     show_controller_errors: false
     show_slow_requests: false
+  contacts:
+    docs_name: 'contacts-admin'
   content-performance-manager:
     # Missing duration, status, controller fields
     show_controller_errors: false

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -844,6 +844,8 @@ grafana::dashboards::deployment_applications:
     # Low usage
     show_controller_errors: false
     show_slow_requests: false
+  contacts:
+    docs_name: 'contacts-admin'
   content-performance-manager:
     # Missing duration, status, controller fields
     show_controller_errors: false


### PR DESCRIPTION
The contacts app (aka Contacts Admin) is a standard Rails app, so the dashboard can use the default panels.