### PR TITLE
[WIP] Initial Puppetserver 5 provisioning

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -110,9 +110,10 @@ apt::sources:
 
 backup::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
-base::packages::gems:
-  ruby-shadow:
-    ensure: 2.5.0
+# Puppet 5 didn't work with Gem provider
+# base::packages::gems:
+#   ruby-shadow:
+#     ensure: 2.5.0
 
 base::packages::packages:
   - 'ack-grep'
@@ -676,6 +677,15 @@ govuk_ci::master::ci_agents:
 govuk_ci::master::credentials_id: 'jenkins-ssh-slave'
 
 govuk_ci::agent::master_ssh_key: "%{hiera('govuk_jenkins::ssh_key::public_key')}"
+
+govuk_containers::puppetdb::envvars:
+  - "PUPPETDB_DATABASE_CONNECTION=//puppetdb-postgres:5432/puppetdb"
+  - "PUPPETDB_USER=puppetdb"
+  - "PUPPETDB_PASSWORD=testchangeme"
+
+govuk_containers::puppetdb_postgres::envvars:
+  - "POSTGRES_USER=puppetdb"
+  - "POSTGRES_PASSWORD=testchangeme"
 
 govuk_containers::app::config::global_envvars:
   - "GOVUK_ENV=production"

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -29,10 +29,10 @@ Class['apt::update'] -> Package <|
 # Cannot be spoofed by Facter from `puppet agent`.
 $govuk_node_class = govuk_node_class()
 
-if chomp(hiera('HIERA_EYAML_GPG_CHECK')) != "It's all OK penguins" {
-  fail("Hiera eYAML GPG encryption backend is not working; you should read: \
-https://docs.publishing.service.gov.uk/manual/encrypted-hiera-data.html#puppet-fails-because-my-it-can39t-find-a-usable-gpg-key")
-}
+#if chomp(hiera('HIERA_EYAML_GPG_CHECK')) != "It's all OK penguins" {
+#  fail("Hiera eYAML GPG encryption backend is not working; you should read: \
+#https://docs.publishing.service.gov.uk/manual/encrypted-hiera-data.html#puppet-fails-because-my-it-can39t-find-a-usable-gpg-key")
+#}
 
 node default {
   govuk_check_hostname_facts()

--- a/modules/base/manifests/init.pp
+++ b/modules/base/manifests/init.pp
@@ -13,7 +13,11 @@ class base {
   include cron
   include curl
   include govuk::deploy
-  include govuk_apt::unused_kernels
+
+  if $::govuk_node_class != 'puppetserver' {
+    include govuk_apt::unused_kernels
+  }
+
   include govuk_apt::package_blacklist
   include govuk_envsys
   include govuk_scripts
@@ -22,7 +26,10 @@ class base {
   include govuk_unattended_reboot
   include logrotate
   include ntp
-  include puppet
+
+  if $::govuk_node_class != 'puppetserver' {
+    include puppet
+  }
 
   if ! $::aws_migration {
     include resolvconf

--- a/modules/govuk/manifests/node/s_puppetserver.pp
+++ b/modules/govuk/manifests/node/s_puppetserver.pp
@@ -1,0 +1,38 @@
+# == Class: govuk::node::s_puppetmaster
+#
+class govuk::node::s_puppetserver inherits govuk::node::s_base {
+  include govuk_postgresql::backup
+
+  include ::govuk_docker
+  include ::govuk_containers::puppetdb_postgres
+  include ::govuk_containers::puppetdb
+  include ::govuk_containers::puppetserver
+
+  docker_network { 'docker_gwbridge':
+    ensure  => present,
+    driver  => 'bridge',
+    subnet  => '172.30.0.0/16',
+    options => [
+      'com.docker.network.bridge.name=docker_gwbridge',
+      'com.docker.network.bridge.enable_icc=true',
+    ],
+    require => Class['govuk_docker'],
+  }
+
+  Class['govuk_containers::puppetserver'] ->
+  Class['govuk_containers::puppetdb_postgres'] ->
+  Class['govuk_containers::puppetdb']
+
+  file { '/var/lib/govuk_containers':
+    ensure => directory,
+    group  => 'docker',
+  }
+
+  @ufw::allow { 'allow-puppetserver-from-all':
+    port => 8140,
+  }
+
+  @ufw::allow { 'allow-puppetdb-from-all':
+    port => 8080,
+  }
+}

--- a/modules/govuk_beat/manifests/repo.pp
+++ b/modules/govuk_beat/manifests/repo.pp
@@ -16,6 +16,6 @@ class govuk_beat::repo(
     location     => "http://${apt_mirror_hostname}/elastic-beats",
     release      => 'stable',
     architecture => $::architecture,
-    key          => '',
+    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
   }
 }

--- a/modules/govuk_containers/files/puppet/certsigner.rb
+++ b/modules/govuk_containers/files/puppet/certsigner.rb
@@ -1,0 +1,72 @@
+#!/usr/bin/env ruby
+
+require 'etc'
+
+ENV['HOME'] = Etc.getpwuid(Process.uid).dir
+
+require 'puppet'
+require 'puppet/ssl/certificate_request'
+require 'aws-sdk-core'
+
+certname = ARGV.pop
+csr = Puppet::SSL::CertificateRequest.from_s(STDIN.read)
+
+# because we aren't loading all of puppet we don't have the full mappings
+# keeping it simple, just using their OID numbers
+# https://docs.puppetlabs.com/puppet/latest/reference/ssl_attributes_extensions.html#puppet-specific-registered-ids
+
+instance_id = csr.request_extensions.find { |a| a['oid'] == 'pp_instance_id' }['value']
+ami_id = csr.request_extensions.find { |a| a['oid'] == 'pp_image_name' }['value']
+aws_region = csr.request_extensions.find { |a| a['oid'] == '1.3.6.1.4.1.34380.1.1.18' }['value']
+
+returncode = 100
+
+ec2 = Aws::EC2::Client.new( region: aws_region )
+
+server = ec2.describe_instances({
+  instance_ids: [instance_id],
+  filters: [
+    {
+      name: 'instance-state-name',
+      values: ['running']
+    },
+  ],
+})
+
+tags = server.reservations[0].instances[0].tags
+image_id = server.reservations[0].instances[0].image_id
+
+# we are checking to see if this instance has already been signed
+signed = false
+tags.each do |tag|
+  if tag.key == 'puppet_cert_signed'
+    signed = true
+  end
+end
+
+# lets make sure we can get a positive match also, this assumes you are using
+# pp_image_name in csr_attributes.yaml
+if image_id == ami_id
+  ami_match = true
+else
+  ami_match = false
+end
+
+# the only time we can sign this cert is if this instance hasn't been given a signed
+# cert before and we match on the instance in AWS also
+if signed != true && ami_match == true
+  ec2.create_tags({
+    resources: [instance_id],
+    tags: [
+      {
+        key: 'puppet_cert_signed',
+        value: certname,
+      },
+    ],
+  })
+  returncode = 0
+else
+  returncode = 200
+end
+
+exit returncode

--- a/modules/govuk_containers/files/puppet/puppetdb.conf
+++ b/modules/govuk_containers/files/puppet/puppetdb.conf
@@ -1,0 +1,3 @@
+[main]
+server_urls = https://puppetdb:8081
+soft_write_failure = true

--- a/modules/govuk_containers/files/puppetdb/bootstrap.cfg
+++ b/modules/govuk_containers/files/puppetdb/bootstrap.cfg
@@ -1,0 +1,28 @@
+# This file is used by the application framework (trapperkeeper) to
+# determine what services should be loaded at boot time.
+# For more info, see:
+#  https://github.com/puppetlabs/trapperkeeper/wiki/Bootstrapping
+
+# Web Server
+puppetlabs.trapperkeeper.services.webserver.jetty9-service/jetty9-service
+
+# Webrouting
+puppetlabs.trapperkeeper.services.webrouting.webrouting-service/webrouting-service
+
+# TK status
+puppetlabs.trapperkeeper.services.metrics.metrics-service/metrics-webservice
+puppetlabs.trapperkeeper.services.status.status-service/status-service
+puppetlabs.trapperkeeper.services.scheduler.scheduler-service/scheduler-service
+
+# PuppetDB Services
+puppetlabs.puppetdb.cli.services/puppetdb-service
+puppetlabs.puppetdb.command/command-service
+puppetlabs.puppetdb.pdb-routing/maint-mode-service
+puppetlabs.puppetdb.pdb-routing/pdb-routing-service
+puppetlabs.puppetdb.config/config-service
+
+# NREPL
+puppetlabs.trapperkeeper.services.nrepl.nrepl-service/nrepl-service
+
+# Dashboard redirect: remove to disable
+puppetlabs.puppetdb.dashboard/dashboard-redirect-service

--- a/modules/govuk_containers/files/puppetdb/conf.d/config.conf
+++ b/modules/govuk_containers/files/puppetdb/conf.d/config.conf
@@ -1,0 +1,4 @@
+global: {
+  vardir: /opt/puppetlabs/server/data/puppetdb
+  logging-config: /etc/puppetlabs/puppetdb/logging/logback.xml
+}

--- a/modules/govuk_containers/files/puppetdb/conf.d/database.conf
+++ b/modules/govuk_containers/files/puppetdb/conf.d/database.conf
@@ -1,0 +1,8 @@
+database: {
+  classname: org.postgresql.Driver
+  subprotocol: postgresql
+  subname: ${PUPPETDB_DATABASE_CONNECTION}
+  username: ${PUPPETDB_USER}
+  password: ${PUPPETDB_PASSWORD}
+  log-slow-statements: 10
+}

--- a/modules/govuk_containers/files/puppetdb/conf.d/jetty.ini
+++ b/modules/govuk_containers/files/puppetdb/conf.d/jetty.ini
@@ -1,0 +1,33 @@
+[jetty]
+# IP address or hostname to listen for clear-text HTTP. To avoid resolution
+# issues, IP addresses are recommended over hostnames.
+# Default is `localhost`.
+host = 0.0.0.0
+
+# Port to listen on for clear-text HTTP.
+port = 8080
+
+# The following are SSL specific settings. They can be configured
+# automatically with the tool `puppetdb ssl-setup`, which is normally
+# ran during package installation.
+
+# IP address to listen on for HTTPS connections. Hostnames can also be used
+# but are not recommended to avoid DNS resolution issues. To listen on all
+# interfaces, use `0.0.0.0`.
+ssl-host = 0.0.0.0
+
+# The port to listen on for HTTPS connections
+ssl-port = 8081
+
+# Private key path
+ssl-key = /etc/puppetlabs/puppetdb/ssl/private.pem
+
+# Public certificate path
+ssl-cert = /etc/puppetlabs/puppetdb/ssl/public.pem
+
+# Certificate authority path
+ssl-ca-cert = /etc/puppetlabs/puppetdb/ssl/ca.pem
+
+# Access logging configuration path. To turn off access logging
+# comment out the line with `access-log-config=...`
+access-log-config = /etc/puppetlabs/puppetdb/logging/request-logging.xml

--- a/modules/govuk_containers/files/puppetdb/logging/logback.xml
+++ b/modules/govuk_containers/files/puppetdb/logging/logback.xml
@@ -1,0 +1,11 @@
+<configuration scan="true">
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d %-5p [%c{2}] %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/modules/govuk_containers/files/puppetdb/logging/request-logging.xml
+++ b/modules/govuk_containers/files/puppetdb/logging/request-logging.xml
@@ -1,0 +1,9 @@
+<configuration debug="false">
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+          <pattern>combined</pattern>
+        </encoder>
+    </appender>
+
+    <appender-ref ref="STDOUT"/>
+</configuration>

--- a/modules/govuk_containers/files/puppetserver/conf.d/auth.conf
+++ b/modules/govuk_containers/files/puppetserver/conf.d/auth.conf
@@ -1,0 +1,171 @@
+authorization: {
+    version: 1
+    rules: [
+        {
+            # Allow nodes to retrieve their own catalog
+            match-request: {
+                path: "^/puppet/v3/catalog/([^/]+)$"
+                type: regex
+                method: [get, post]
+            }
+            allow: "$1"
+            sort-order: 500
+            name: "puppetlabs catalog"
+        },
+        {
+            # Allow nodes to retrieve the certificate they requested earlier
+            match-request: {
+                path: "/puppet-ca/v1/certificate/"
+                type: path
+                method: get
+            }
+            allow-unauthenticated: true
+            sort-order: 500
+            name: "puppetlabs certificate"
+        },
+        {
+            # Allow all nodes to access the certificate revocation list
+            match-request: {
+                path: "/puppet-ca/v1/certificate_revocation_list/ca"
+                type: path
+                method: get
+            }
+            allow-unauthenticated: true
+            sort-order: 500
+            name: "puppetlabs crl"
+        },
+        {
+            # Allow nodes to request a new certificate
+            match-request: {
+                path: "/puppet-ca/v1/certificate_request"
+                type: path
+                method: [get, put]
+            }
+            allow-unauthenticated: true
+            sort-order: 500
+            name: "puppetlabs csr"
+        },
+        {
+            match-request: {
+                path: "/puppet/v3/environments"
+                type: path
+                method: get
+            }
+            allow: "*"
+            sort-order: 500
+            name: "puppetlabs environments"
+        },
+        {
+            # Allow nodes to access all file_bucket_files.  Note that access for
+            # the 'delete' method is forbidden by Puppet regardless of the
+            # configuration of this rule.
+            match-request: {
+                path: "/puppet/v3/file_bucket_file"
+                type: path
+                method: [get, head, post, put]
+            }
+            allow: "*"
+            sort-order: 500
+            name: "puppetlabs file bucket file"
+        },
+        {
+            # Allow nodes to access all file_content.  Note that access for the
+            # 'delete' method is forbidden by Puppet regardless of the
+            # configuration of this rule.
+            match-request: {
+                path: "/puppet/v3/file_content"
+                type: path
+                method: [get, post]
+            }
+            allow: "*"
+            sort-order: 500
+            name: "puppetlabs file content"
+        },
+        {
+            # Allow nodes to access all file_metadata.  Note that access for the
+            # 'delete' method is forbidden by Puppet regardless of the
+            # configuration of this rule.
+            match-request: {
+                path: "/puppet/v3/file_metadata"
+                type: path
+                method: [get, post]
+            }
+            allow: "*"
+            sort-order: 500
+            name: "puppetlabs file metadata"
+        },
+        {
+            # Allow nodes to retrieve only their own node definition
+            match-request: {
+                path: "^/puppet/v3/node/([^/]+)$"
+                type: regex
+                method: get
+            }
+            allow: "$1"
+            sort-order: 500
+            name: "puppetlabs node"
+        },
+        {
+            # Allow nodes to store only their own reports
+            match-request: {
+                path: "^/puppet/v3/report/([^/]+)$"
+                type: regex
+                method: put
+            }
+            allow: "$1"
+            sort-order: 500
+            name: "puppetlabs report"
+        },
+        {
+            match-request: {
+                path: "/puppet/v3/status"
+                type: path
+                method: get
+            }
+            allow-unauthenticated: true
+            sort-order: 500
+            name: "puppetlabs status"
+        },
+        {
+            match-request: {
+                path: "/puppet/v3/static_file_content"
+                type: path
+                method: get
+            }
+            allow: "*"
+            sort-order: 500
+            name: "puppetlabs static file content"
+        },
+        {
+            match-request: {
+                path: "/puppet/v3/tasks"
+                type: path
+            }
+            allow: "*"
+            sort-order: 500
+            name: "puppet tasks information"
+        },
+        {
+            # Allow all users access to the experimental endpoint
+            # which currently only provides a dashboard web ui.
+            match-request: {
+                path: "/puppet/experimental"
+                type: path
+            }
+            allow-unauthenticated: true
+            sort-order: 500
+            name: "puppetlabs experimental"
+        },
+        {
+            # Deny everything else. This ACL is not strictly
+            # necessary, but illustrates the default policy
+            match-request: {
+                path: "/"
+                type: path
+            }
+            deny: "*"
+            sort-order: 999
+            name: "puppetlabs deny all"
+        }
+    ]
+}

--- a/modules/govuk_containers/files/puppetserver/conf.d/global.conf
+++ b/modules/govuk_containers/files/puppetserver/conf.d/global.conf
@@ -1,0 +1,5 @@
+global: {
+    # Path to logback logging configuration file; for more
+    # info, see http://logback.qos.ch/manual/configuration.html
+    logging-config: /etc/puppetlabs/puppetserver/logback.xml
+}

--- a/modules/govuk_containers/files/puppetserver/conf.d/metrics.conf
+++ b/modules/govuk_containers/files/puppetserver/conf.d/metrics.conf
@@ -1,0 +1,52 @@
+metrics: {
+    # a server id that will be used as part of the namespace for metrics produced
+    # by this server
+    server-id: localhost
+    registries: {
+        puppetserver: {
+            # specify metrics to allow in addition to those in the default list
+            #metrics-allowed: ["compiler.compile.production"]
+
+            reporters: {
+                # enable or disable JMX metrics reporter
+                jmx: {
+                    enabled: true
+                }
+                # enable or disable Graphite metrics reporter
+                #graphite: {
+                #    enabled: true
+                #}
+            }
+
+        }
+    }
+
+    # this section is used to configure settings for reporters that will send
+    # the metrics to various destinations for external viewing
+    reporters: {
+        #graphite: {
+        #    # graphite host
+        #    host: "127.0.0.1"
+        #    # graphite metrics port
+        #    port: 2003
+        #    # how often to send metrics to graphite
+        #    update-interval-seconds: 5
+        #}
+    }
+    metrics-webservice: {
+        jolokia: {
+            # Enable or disable the Jolokia-based metrics/v2 endpoint.
+            # Default is true.
+            # enabled: false
+
+            # Configure any of the settings listed at:
+            #   https://jolokia.org/reference/html/agents.html#war-agent-installation
+            servlet-init-params: {
+                # Specify a custom security policy:
+                #  https://jolokia.org/reference/html/security.html
+                # policyLocation: "file:///etc/puppetlabs/puppetserver/jolokia-access.xml"
+            }
+        }
+    }
+
+}

--- a/modules/govuk_containers/files/puppetserver/conf.d/puppetserver.conf
+++ b/modules/govuk_containers/files/puppetserver/conf.d/puppetserver.conf
@@ -1,0 +1,76 @@
+# configuration for the JRuby interpreters
+jruby-puppet: {
+    # Where the puppet-agent dependency places puppet, facter, etc...
+    # Puppet server expects to load Puppet from this location
+    ruby-load-path: [/opt/puppetlabs/puppet/lib/ruby/vendor_ruby]
+
+    # This setting determines where JRuby will install gems.  It is used for loading gems,
+    # and also by the `puppetserver gem` command line tool.
+    gem-home: /opt/puppetlabs/server/data/puppetserver/jruby-gems
+
+    # This setting defines the complete "GEM_PATH" for jruby.  If set, it should include
+    # the gem-home directory as well as any other directories that gems can be loaded
+    # from (including the vendored gems directory for gems that ship with puppetserver)
+    gem-path: [${jruby-puppet.gem-home}, "/opt/puppetlabs/server/data/puppetserver/vendored-jruby-gems"]
+
+    # PLEASE NOTE: Use caution when modifying the below settings. Modifying
+    # these settings will change the value of the corresponding Puppet settings
+    # for Puppet Server, but not for the Puppet CLI tools. This likely will not
+    # be a problem with master-var-dir, master-run-dir, or master-log-dir unless
+    # some critical setting in puppet.conf is interpolating the value of one
+    # of the corresponding settings, but it is important that any changes made to
+    # master-conf-dir and master-code-dir are also made to the corresponding Puppet
+    # settings when running the Puppet CLI tools. See
+    # https://docs.puppetlabs.com/puppetserver/latest/puppet_conf_setting_diffs.html#overriding-puppet-settings-in-puppet-server
+    # for more information.
+
+    # (optional) path to puppet conf dir; if not specified, will use
+    # /etc/puppetlabs/puppet
+    master-conf-dir: /etc/puppetlabs/puppet
+
+    # (optional) path to puppet code dir; if not specified, will use
+    # /etc/puppetlabs/code
+    master-code-dir: /etc/puppetlabs/code
+
+    # (optional) path to puppet var dir; if not specified, will use
+    # /opt/puppetlabs/server/data/puppetserver
+    master-var-dir: /opt/puppetlabs/server/data/puppetserver
+
+    # (optional) path to puppet run dir; if not specified, will use
+    # /var/run/puppetlabs/puppetserver
+    master-run-dir: /var/run/puppetlabs/puppetserver
+
+    # (optional) path to puppet log dir; if not specified, will use
+    # /var/log/puppetlabs/puppetserver
+    master-log-dir: /var/log/puppetlabs/puppetserver
+
+    # (optional) maximum number of JRuby instances to allow
+    #max-active-instances: 1
+
+    # (optional) Authorize access to Puppet master endpoints via rules
+    # specified in the legacy Puppet auth.conf file (if true) or via rules
+    # specified in the Puppet Server HOCON-formatted auth.conf (if false or not
+    # specified).
+    #use-legacy-auth-conf: true
+}
+
+# settings related to HTTPS client requests made by Puppet Server
+http-client: {
+    # A list of acceptable protocols for making HTTPS requests
+    #ssl-protocols: [TLSv1, TLSv1.1, TLSv1.2]
+
+    # A list of acceptable cipher suites for making HTTPS requests
+    #cipher-suites: [TLS_RSA_WITH_AES_256_CBC_SHA256,
+    #                TLS_RSA_WITH_AES_256_CBC_SHA,
+    #                TLS_RSA_WITH_AES_128_CBC_SHA256,
+    #                TLS_RSA_WITH_AES_128_CBC_SHA]
+
+    # Whether to enable http-client metrics; defaults to 'true'.
+    #metrics-enabled: true
+}
+
+# settings related to profiling the puppet Ruby code
+profiler: {
+    # enable or disable profiling for the Ruby code; defaults to 'true'.
+    #enabled: true
+}

--- a/modules/govuk_containers/files/puppetserver/conf.d/web-routes.conf
+++ b/modules/govuk_containers/files/puppetserver/conf.d/web-routes.conf
@@ -1,0 +1,16 @@
+web-router-service: {
+    # These two should not be modified because the Puppet 4.x agent expects them to
+    # be mounted at these specific paths
+    "puppetlabs.services.ca.certificate-authority-service/certificate-authority-service": "/puppet-ca"
+    "puppetlabs.services.master.master-service/master-service": "/puppet"
+    "puppetlabs.services.legacy-routes.legacy-routes-service/legacy-routes-service": ""
+
+    # This controls the mount point for the puppet admin API.
+    "puppetlabs.services.puppet-admin.puppet-admin-service/puppet-admin-service": "/puppet-admin-api"
+
+    # This controls the mount point for the status API
+    "puppetlabs.trapperkeeper.services.status.status-service/status-service": "/status"
+
+    # This controls the mount point for the metrics API
+    "puppetlabs.trapperkeeper.services.metrics.metrics-service/metrics-webservice": "/metrics"
+}

--- a/modules/govuk_containers/files/puppetserver/conf.d/webserver.conf
+++ b/modules/govuk_containers/files/puppetserver/conf.d/webserver.conf
@@ -1,0 +1,6 @@
+webserver: {
+    access-log-config: /etc/puppetlabs/puppetserver/request-logging.xml
+    client-auth: want
+    ssl-host: 0.0.0.0
+    ssl-port: 8140
+}

--- a/modules/govuk_containers/manifests/puppetdb.pp
+++ b/modules/govuk_containers/manifests/puppetdb.pp
@@ -1,0 +1,90 @@
+# == Class: Govuk_containers::Puppetdb
+#
+# A class that installs and configures the puppetdb
+# container.
+#
+# === Parameters:
+#
+# [*image*]
+#   The container image to run.
+#
+# [*ensure*]
+#   Whether to ensure the frameworking for the app to exist.
+#   Default: present
+#
+# [*image_tag*]
+#   The image tag to run. In our deployment this should not be specified
+#   as we will explicitly tag images. However, for local development this
+#   parameter can be set.
+#
+# [*envvars*]
+#   An array of environment variables to start the container with.
+#
+class govuk_containers::puppetdb (
+  $image = 'puppet/puppetdb',
+  $ensure = 'present',
+  $image_tag = '5.1.0',
+  $envvars = [],
+) {
+
+  validate_array($envvars)
+
+  file { [
+      '/var/lib/govuk_containers/puppetdb',
+      '/var/lib/govuk_containers/puppetdb/puppetlabs',
+      '/var/lib/govuk_containers/puppetdb/puppetlabs/puppetdb',
+  ]:
+    ensure  => directory,
+    group   => 'docker',
+    mode    => '0775',
+    require => File['/var/lib/govuk_containers'],
+  }
+
+  file{ '/var/lib/govuk_containers/puppetdb/puppetlabs/puppetdb/conf.d' :
+    ensure  => directory,
+    group   => 'docker',
+    mode    => '0770',
+    recurse => true,
+    source  => 'puppet:///modules/govuk_containers/puppetdb/conf.d',
+    require => File['/var/lib/govuk_containers/puppetdb/puppetlabs/puppetdb'],
+  }
+
+  file{ '/var/lib/govuk_containers/puppetdb/puppetlabs/puppetdb/logging' :
+    ensure  => directory,
+    group   => 'docker',
+    mode    => '0775',
+    recurse => true,
+    source  => 'puppet:///modules/govuk_containers/puppetdb/logging',
+    require => File['/var/lib/govuk_containers/puppetdb/puppetlabs/puppetdb'],
+  }
+
+  file{ '/var/lib/govuk_containers/puppetdb/puppetlabs/puppetdb/bootstrap.cfg' :
+    ensure  => present,
+    group   => 'docker',
+    mode    => '0644',
+    source  => 'puppet:///modules/govuk_containers/puppetdb/bootstrap.cfg',
+    require => File['/var/lib/govuk_containers/puppetdb/puppetlabs/puppetdb'],
+  }
+
+  ::docker::run { 'puppetdb':
+    ensure   => $ensure,
+    image    => "${image}:${image_tag}",
+    net      => 'docker_gwbridge',
+    hostname => 'puppetdb',
+    env      => $envvars,
+    volumes  => [
+      '/var/lib/govuk_containers/puppetdb/puppetlabs:/etc/puppetlabs',
+    ],
+    ports    => ['8080:8080','8081:8081'],
+    require  => [
+      Class['govuk_docker'],
+        File['/var/lib/govuk_containers/puppetdb'],
+    ],
+  }
+
+  @@icinga::check { "check_docker_puppetdb_running_${::hostname}":
+    check_command       => 'check_nrpe!check_app_up!8080 /pdb/meta/v1/version/latest',
+    service_description => 'puppetdb running',
+    host_name           => $::fqdn,
+  }
+}

--- a/modules/govuk_containers/manifests/puppetdb_postgres.pp
+++ b/modules/govuk_containers/manifests/puppetdb_postgres.pp
@@ -1,0 +1,52 @@
+# == Class: Govuk_containers::Puppetdb_postgres
+#
+# A class that installs and configures the puppetdb-postgres
+# container.
+#
+# === Parameters:
+#
+# [*image*]
+#   The container image to run.
+#
+# [*ensure*]
+#   Whether to ensure the frameworking for the app to exist.
+#   Default: present
+#
+# [*image_tag*]
+#   The image tag to run. In our deployment this should not be specified
+#   as we will explicitly tag images. However, for local development this
+#   parameter can be set.
+#
+# [*envvars*]
+#   An array of environment variables to start the container with.
+#
+class govuk_containers::puppetdb_postgres (
+  $image = 'puppet/puppetdb-postgres',
+  $ensure = 'present',
+  $image_tag = '9.6.3',
+  $envvars = [],
+) {
+
+  validate_array($envvars)
+
+  file { ['/var/lib/govuk_containers/puppetdb-postgres', '/var/lib/govuk_containers/puppetdb-postgres/data']:
+    ensure  => directory,
+    require => File['/var/lib/govuk_containers'],
+  }
+
+  ::docker::run { 'puppetdb-postgres':
+    ensure   => $ensure,
+    image    => "${image}:${image_tag}",
+    net      => 'docker_gwbridge',
+    hostname => 'puppetdb-postgres',
+    env      => $envvars,
+    ports    => ['5432:5432'],
+    volumes  => [
+      '/var/lib/govuk_containers/puppetdb-postgres/data:/var/lib/postgresql/data',
+    ],
+    require  => [
+      Class['govuk_docker'],
+      File['/var/lib/govuk_containers/puppetdb-postgres/data'],
+    ],
+  }
+}

--- a/modules/govuk_containers/manifests/puppetserver.pp
+++ b/modules/govuk_containers/manifests/puppetserver.pp
@@ -1,0 +1,99 @@
+# == Class: Govuk_containers::Puppetserver
+#
+# A class that installs and configures the puppetserver
+# container.
+#
+# === Parameters:
+#
+# [*image*]
+#   The container image to run.
+#
+# [*ensure*]
+#   Whether to ensure the frameworking for the app to exist.
+#   Default: present
+#
+# [*image_tag*]
+#   The image tag to run. In our deployment this should not be specified
+#   as we will explicitly tag images. However, for local development this
+#   parameter can be set.
+#
+# [*envvars*]
+#   An array of environment variables to start the container with.
+#
+class govuk_containers::puppetserver (
+  $image = 'puppet/puppetserver',
+  $ensure = 'present',
+  $image_tag = '5.1.0',
+  $envvars = [],
+) {
+
+  validate_array($envvars)
+
+  file { [
+      '/var/lib/govuk_containers/puppetserver',
+      '/var/lib/govuk_containers/puppetserver/puppetlabs',
+      '/var/lib/govuk_containers/puppetserver/puppetlabs/puppetserver',
+      '/var/lib/govuk_containers/puppetserver/puppetlabs/puppet',
+  ]:
+    ensure  => directory,
+    group   => 'docker',
+    require => File['/var/lib/govuk_containers'],
+  }
+
+  file { '/var/lib/govuk_containers/puppetserver/puppetlabs/puppet/ssl':
+    ensure  => directory,
+    group   => 'docker',
+    mode    => '0775',
+    require => File['/var/lib/govuk_containers'],
+  }
+
+  file { '/var/lib/govuk_containers/puppetserver/puppetlabs/puppetserver/conf.d':
+    ensure  => directory,
+    group   => 'docker',
+    recurse => true,
+    source  => 'puppet:///modules/govuk_containers/puppetserver/conf.d',
+    require => File['/var/lib/govuk_containers/puppetserver/puppetlabs/puppetserver'],
+  }
+
+  file { '/var/lib/govuk_containers/puppetserver/puppetlabs/puppet/puppet.conf':
+    ensure  => present,
+    group   => 'docker',
+    mode    => '0644',
+    content => template('govuk_containers/puppet/puppet.conf.erb'),
+    require => File['/var/lib/govuk_containers/puppetserver/puppetlabs/puppet'],
+  }
+
+  file { '/var/lib/govuk_containers/puppetserver/puppetlabs/puppet/certsigner.rb':
+    ensure  => present,
+    group   => 'docker',
+    mode    => '0755',
+    source  => 'puppet:///modules/govuk_containers/puppet/certsigner.rb',
+    require => File['/var/lib/govuk_containers/puppetserver/puppetlabs/puppet'],
+  }
+
+  file { '/var/lib/govuk_containers/puppetserver/puppetlabs/puppet/puppetdb.conf':
+    ensure  => present,
+    group   => 'docker',
+    source  => 'puppet:///modules/govuk_containers/puppet/puppetdb.conf',
+    require => File['/var/lib/govuk_containers/puppetserver/puppetlabs/puppet'],
+  }
+
+  ::docker::run { 'puppet':
+    ensure   => $ensure,
+    image    => "${image}:${image_tag}",
+    net      => 'docker_gwbridge',
+    hostname => 'puppet',
+    env      => $envvars,
+    volumes  => [
+      '/var/lib/govuk_containers/puppetserver/puppetlabs/puppetserver/conf.d:/etc/puppetlabs/puppetserver/conf.d',
+      '/var/lib/govuk_containers/puppetserver/puppetlabs/puppet:/etc/puppetlabs/puppet',
+      '/usr/share/puppet/production/current:/etc/puppetlabs/code:ro',
+    ],
+    ports    => ['8140:8140'],
+    require  => [
+      Class['govuk_docker'],
+      File['/var/lib/govuk_containers/puppetserver/puppetlabs/puppetserver/conf.d'],
+      File['/var/lib/govuk_containers/puppetserver/puppetlabs/puppet'],
+    ],
+  }
+}

--- a/modules/govuk_containers/templates/puppet/puppet.conf.erb
+++ b/modules/govuk_containers/templates/puppet/puppet.conf.erb
@@ -1,0 +1,29 @@
+[main]
+vardir = /opt/puppetlabs/server/data/puppetserver
+logdir = /var/log/puppetlabs/puppetserver
+rundir = /var/run/puppetlabs/puppetserver
+pidfile = /var/run/puppetlabs/puppetserver/puppetserver.pid
+codedir = /etc/puppetlabs/code
+
+lastrunfile = $statedir/last_run_summary.yaml { mode = 644 }
+usecacheonfailure = false
+environment = <%= scope.lookupvar("::environment") %>
+strict_variables = true
+certname = puppet
+
+[master]
+reports = store,sentry
+report = true
+storeconfigs = true
+storeconfigs_backend = puppetdb
+<%- if scope.lookupvar('::aws_migration') %>
+hiera_config = /usr/share/puppet/production/current/hiera_aws.yml
+<%- else -%>
+hiera_config = /usr/share/puppet/production/current/hiera.yml
+<%- end -%>
+environmentpath = /usr/share/puppet/production/current/environments
+<%- if scope.lookupvar('::aws_migration') %>
+#autosign = /etc/puppetlabs/puppet/certsigner.rb
+autosign = true
+<%- end -%>
+

--- a/modules/govuk_docker/manifests/init.pp
+++ b/modules/govuk_docker/manifests/init.pp
@@ -30,7 +30,7 @@ class govuk_docker (
     class {'::docker':
       docker_users => $docker_users,
       version      => $version,
-      log_driver   => 'syslog',
+      log_driver   => 'json-file',
     }
   }
 

--- a/modules/hosts/manifests/purge.pp
+++ b/modules/hosts/manifests/purge.pp
@@ -16,6 +16,7 @@ class hosts::purge {
   # eg hosts that are only present in AWS
   $whitelist = [
     'db-admin-1',
+    'puppetserver-1',
   ]
 
   if ! ($::hostname in $whitelist) {


### PR DESCRIPTION
- New puppetserver node class to install puppetserver from containers
- Disable hiera-eyaml-gpg check in site.pp, which is not supported in Puppet5
- Disable puppet and unused_kernel classes in base class, that need to be updated
for Puppet5 clients
- Remove ruby-shadow gem from Hieradata, as the Gem provider didn't work on Puppet5
- Restore default logging driver on AWS containers (json-file), as syslog is not
logging messages.
- Add elastic-beat apt repo key that was missing and failing on Puppet 5
- Add container classes and test configuration for puppetserver, puppetdb and
puppetdb-postgres