### PR TITLE
Add a temporary directory for Whitehall / Asset Manager

### DIFF
--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -373,6 +373,7 @@ class govuk::apps::whitehall(
       # Create the directory structure for whitehall assets in development
       $asset_directories = [
         '/data/uploads/whitehall',
+        '/data/uploads/whitehall/asset-manager-tmp',
         '/data/uploads/whitehall/attachment-cache',
         '/data/uploads/whitehall/bulk-upload-zip-file-tmp',
         '/data/uploads/whitehall/carrierwave-tmp',
@@ -394,6 +395,12 @@ class govuk::apps::whitehall(
 
       # Symlink directories in the whitehall app root to the assets directories
       # Use `force` since some of these are created on git checkout.
+      file { '/var/govuk/whitehall/asset-manager-tmp':
+        ensure => symlink,
+        target => '/data/uploads/whitehall/asset-manager-tmp',
+        force  => true,
+      }
+
       file { '/var/govuk/whitehall/attachment-cache':
         ensure => symlink,
         target => '/data/uploads/whitehall/attachment-cache',

--- a/modules/govuk/manifests/node/s_asset_base.pp
+++ b/modules/govuk/manifests/node/s_asset_base.pp
@@ -66,6 +66,7 @@ class govuk::node::s_asset_base (
 
   $directories = [
     '/mnt/uploads/whitehall',
+    '/mnt/uploads/whitehall/asset-manager-tmp',
     '/mnt/uploads/whitehall/attachment-cache',
     '/mnt/uploads/whitehall/bulk-upload-zip-file-tmp',
     '/mnt/uploads/whitehall/carrierwave-tmp',


### PR DESCRIPTION
We are adding the ability for Whitehall to upload non-attachment
assets via the Asset Manager API. For this to work, the requests to
the Asset Manager API need to be made in Sidekiq workers rather than
in-request. This means we need some shared state (i.e the
`/mnt/uploads` NFS mount) between the machines to store the files
temporarily so that the upload and worker processes are able to run on
different machines.