### PR TITLE
Remove outer add_header for X-Frame-Options in AssetManager Nginx config

### DIFF
--- a/modules/govuk/manifests/apps/asset_manager.pp
+++ b/modules/govuk/manifests/apps/asset_manager.pp
@@ -81,7 +81,9 @@ class govuk::apps::asset_manager(
       app => $app_name,
     }
 
-    $deny_framing = true
+    # The X-Frame-Options response header is set explicitly in the
+    # relevant location blocks.
+    $deny_framing = false
 
     $nginx_extra_config = inline_template('
       client_max_body_size 500m;


### PR DESCRIPTION
I should've done this as part of #6602. Since that PR, the two location blocks which are used to serve the only public URLs from the Asset Manager app, both set the X-Frame-Options response header explicitly, so the "outer" `add_header` statement is adding a spurious extra value for this header.

I've tested this change on my development VM and have confirmed that the spurious response header is removed as intended leaving the correct version of the header (`DENY` for Mainstream assets and `SAMEORIGIN` for Whitehall assets):

## Mainstream

### Before change to Nginx

```
$ curl -I http://assets-origin.dev.gov.uk/media/59d25ac7759b745a57285b47/tmp.txt
HTTP/1.1 200 OK 
Access-Control-Allow-Headers: origin, authorization
Access-Control-Allow-Methods: GET, OPTIONS
Access-Control-Allow-Origin: *
Cache-Control: private
Connection: close
Content-Disposition: inline; filename="tmp.txt"
Content-Length: 0
Content-Transfer-Encoding: binary
Content-Type: text/plain
Date: Thu, 05 Oct 2017 15:27:44 GMT
Server: nginx
Strict-Transport-Security: max-age=31536000
X-Content-Type-Options: nosniff
X-Frame-Options: DENY                                      ## <- spurious header
X-Frame-Options: DENY
X-Request-Id: 404671eb-e8db-4c65-9b7b-8069d2df6a49
X-Runtime: 0.062294
X-Xss-Protection: 1; mode=block
```

### After change to Nginx

```
$ curl -I http://assets-origin.dev.gov.uk/media/59d25ac7759b745a57285b47/tmp.txt
HTTP/1.1 200 OK 
Access-Control-Allow-Methods: GET, OPTIONS
Access-Control-Allow-Origin: *
Cache-Control: private
Connection: close
Content-Disposition: inline; filename="tmp.txt"
Content-Length: 0
Content-Transfer-Encoding: binary
Content-Type: text/plain
Date: Thu, 05 Oct 2017 15:50:46 GMT
Server: nginx
Strict-Transport-Security: max-age=31536000
X-Content-Type-Options: nosniff
X-Frame-Options: DENY
X-Request-Id: 9b2dd80e-975a-4924-9142-609c11d2b430
X-Runtime: 0.017176
X-Xss-Protection: 1; mode=block
```

## Whitehall

### Before change to Nginx

```
$ curl -I http://asset-manager.dev.gov.uk/government/uploads/path/to/tmp.txt
HTTP/1.1 200 OK 
Cache-Control: private
Connection: close
Content-Disposition: inline; filename="tmp.txt"
Content-Length: 0
Content-Transfer-Encoding: binary
Content-Type: text/plain
Date: Thu, 05 Oct 2017 15:58:39 GMT
Server: nginx
X-Content-Type-Options: nosniff
X-Frame-Options: DENY                                  ## <- spurious header
X-Frame-Options: SAMEORIGIN
X-Request-Id: c48df6f2-63e1-4fd7-a3e5-20f5a14caa92
X-Runtime: 0.069311
X-Xss-Protection: 1; mode=block
```

### After change to Nginx

```
$ curl -I http://asset-manager.dev.gov.uk/government/uploads/path/to/tmp.txt
HTTP/1.1 200 OK 
Connection: close
Content-Disposition: inline; filename="tmp.txt"
Content-Length: 0
Content-Transfer-Encoding: binary
Content-Type: text/plain
Date: Thu, 05 Oct 2017 15:52:39 GMT
Server: nginx
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
X-Request-Id: d38e5722-6bae-47af-86b3-679e4bf6a9e9
X-Runtime: 0.086137
X-Xss-Protection: 1; mode=block
```
