### PR TITLE
Ensure app logs are json

### DIFF
--- a/modules/govuk/manifests/app.pp
+++ b/modules/govuk/manifests/app.pp
@@ -427,6 +427,14 @@ define govuk::app (
                           value => '@fields.view'}],
           }
 
+    @filebeat::prospector { "${title}-app-out":
+      ensure => $ensure,
+      paths  => ["/var/log/${title}/app.out.log"],
+      tags   => ['application'],
+      json   => {'add_error_key' => true},
+      fields => {'application' => $title},
+    }
+
     govuk_logging::logstream { "${title}-app-err":
       ensure  => $ensure,
       logfile => "/var/log/${title}/app.err.log",
@@ -434,9 +442,9 @@ define govuk::app (
       fields  => {'application' => $title},
     }
 
-    @filebeat::prospector { "${title}-app-out-and-err":
+    @filebeat::prospector { "${title}-app-err":
       ensure => $ensure,
-      paths  => ["/var/log/${title}/app.err.log","/var/log/${title}/app.out.log"],
+      paths  => ["/var/log/${title}/app.err.log"],
       tags   => ['application'],
       fields => {'application' => $title},
     }


### PR DESCRIPTION
This is within a slightly confusing set of code, but the app out and err were combined in the filebeat resource, whereas the app out logs should be json, and the err logs should not be.

Deconstruct this to ensure that messages are correctly parsed as json.