### PR TITLE
Add golang 1.9.1

### DIFF
--- a/modules/golang/manifests/init.pp
+++ b/modules/golang/manifests/init.pp
@@ -11,9 +11,9 @@ class golang {
     require        => Class['govuk_ppa'],
   }
 
-  goenv::version { ['1.6.3', '1.7', '1.7.1', '1.9.1']: }
+  goenv::version { ['1.7.1', '1.9.1']: }
 
-  goenv::version { ['1.3.3', '1.4.2', '1.4.3', '1.5.1', '1.5.3', '1.6.2']:
+  goenv::version { ['1.6.3', '1.7']:
     ensure => absent,
   }
 

--- a/modules/golang/manifests/init.pp
+++ b/modules/golang/manifests/init.pp
@@ -7,11 +7,11 @@ class golang {
   include govuk_ppa
 
   class { 'goenv':
-    global_version => '1.7.1',
+    global_version => '1.9.1',
     require        => Class['govuk_ppa'],
   }
 
-  goenv::version { ['1.6.3', '1.7', '1.7.1']: }
+  goenv::version { ['1.6.3', '1.7', '1.7.1', '1.9.1']: }
 
   goenv::version { ['1.3.3', '1.4.2', '1.4.3', '1.5.1', '1.5.3', '1.6.2']:
     ensure => absent,

--- a/modules/golang/manifests/init.pp
+++ b/modules/golang/manifests/init.pp
@@ -17,9 +17,13 @@ class golang {
     ensure => absent,
   }
 
-  package { ['golang-gom', 'godep']:
+  package { ['godep']:
     ensure  => latest,
     require => Class['govuk_ppa'],
+  }
+
+  package { ['golang-gom']:
+    ensure => absent,
   }
 
   # Ensure that scm tools used by `go get` are present.


### PR DESCRIPTION
[We're upgrading router to golang 1.9.1](https://github.com/alphagov/router/pull/129) so it needs to be installed on CI to allow router to build.

This PR also removes some old versions and the `gom` package manager which we no longer used (as discussed [here](https://github.com/gds-attic/ci-puppet/pull/447) during the last upgrade).

I think this should be all we need to actually get it installed I think `goenv` handles the installation. Doesn't look like we've [built our own packages](https://github.com/alphagov/packager/blob/master/legacy-debuild/pkg/golang/debian/changelog) for a while.