### PR TITLE
Add a fields_prefix in deployment dashboards

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -826,10 +826,11 @@ grafana::dashboards::machine_suffix_metrics: ''
 grafana::dashboards::deployment_applications:
   asset-manager: {}
   calculators:
-    # Status, duration, controller missing @fields. prefix
-    show_controller_errors: false
-    show_slow_requests: false
-  calendars: {}
+    # logstasher >1.x
+    fields_prefix: ''
+  calendars:
+    # logstasher >1.x
+    fields_prefix: ''
   collections: {}
   collections-publisher:
     # Low usage
@@ -838,13 +839,16 @@ grafana::dashboards::deployment_applications:
   contacts:
     docs_name: 'contacts-admin'
   content-performance-manager:
-    # Missing duration, status, controller fields
-    show_controller_errors: false
-    show_slow_requests: false
+    # logstasher >1.x
+    fields_prefix: ''
   content-store: {}
   content-tagger:
+    # logstasher >1.x
+    fields_prefix: ''
     has_workers: true
   email-alert-api:
+    # logstasher >1.x
+    fields_prefix: ''
     has_workers: true
   email-alert-frontend:
     # Missing duration, status, controller fields
@@ -853,9 +857,8 @@ grafana::dashboards::deployment_applications:
   feedback: {}
   finder-frontend: {}
   frontend:
-    # Status, duration, controller missing @fields. prefix
-    show_controller_errors: false
-    show_slow_requests: false
+    # logstasher >1.x
+    fields_prefix: ''
   government-frontend: {}
   hmrc-manuals-api:
     # Missing @fields.status
@@ -864,9 +867,8 @@ grafana::dashboards::deployment_applications:
     has_workers: true
   info-frontend: {}
   licencefinder:
-    # Status, duration, controller missing @fields. prefix
-    show_controller_errors: false
-    show_slow_requests: false
+    # logstasher >1.x
+    fields_prefix: ''
     docs_name: 'licence-finder'
   link-checker-api:
     has_workers: true
@@ -888,6 +890,8 @@ grafana::dashboards::deployment_applications:
     show_controller_errors: false
     show_slow_requests: false
   publisher:
+    # logstasher >1.x
+    fields_prefix: ''
     has_workers: true
   publishing-api:
     has_workers: true
@@ -932,10 +936,11 @@ grafana::dashboards::deployment_applications:
   travel-advice-publisher:
     has_workers: true
   whitehall:
+    # logstasher >1.x
+    fields_prefix: ''
     has_workers: true
     error_threshold: 50
     warning_threshold: 25
-
 
 grub2::recordfail_timeout: 5
 

--- a/modules/grafana/manifests/dashboards/deployment_dashboard.pp
+++ b/modules/grafana/manifests/dashboards/deployment_dashboard.pp
@@ -27,6 +27,12 @@
 # [*logit_only*]
 #   Set to true if we're using Logit as the Elasticsearch data source.
 #
+# [*fields_prefix*]
+#   Add the prefix to Elasticsearch queries. Depending on the version of logstasher
+#   some applications do not include the @fields prefix. Add this prefix by default,
+#   with the option to override with a blank field for apps that use a different
+#   configuration of the logstasher gem.
+#
 define grafana::dashboards::deployment_dashboard (
   $app_name = $title,
   $docs_name = $title,
@@ -42,6 +48,7 @@ define grafana::dashboards::deployment_dashboard (
   $dependent_app_5xx_errors = undef,
   $show_elasticsearch_stats = false,
   $logit_only = false,
+  $fields_prefix = '@fields.',
 ) {
   if $has_workers {
     $worker_row = [['worker_failures', 'worker_successes']]

--- a/modules/grafana/templates/dashboards/deployment_panels/_errors_by_controller_action.json.erb
+++ b/modules/grafana/templates/dashboards/deployment_panels/_errors_by_controller_action.json.erb
@@ -39,7 +39,7 @@
       "bucketAggs": [
         {
           "fake": true,
-          "field": "@fields.controller",
+          "field": "<%= @fields_prefix -%>controller",
           "id": "3",
           "settings": {
             "order": "desc",
@@ -50,7 +50,7 @@
         },
         {
           "fake": true,
-          "field": "@fields.action",
+          "field": "<%= @fields_prefix -%>action",
           "id": "4",
           "settings": {
             "order": "desc",
@@ -79,9 +79,9 @@
         }
       ],
       <% if @logit_only -%>
-      "query": "application:<%= @app_name %> AND @fields.status:[ 500 TO 599 ]",
+      "query": "application:<%= @app_name %> AND <%= @fields_prefix -%>status:[ 500 TO 599 ]",
       <% else -%>
-      "query": "@fields.application:<%= @app_name %> AND @fields.status:[ 500 TO 599 ]",
+      "query": "@fields.application:<%= @app_name %> AND <%= @fields_prefix -%>status:[ 500 TO 599 ]",
       <% end -%>
       "refId": "A",
       "target": "",

--- a/modules/grafana/templates/dashboards/deployment_panels/_response_times.json.erb
+++ b/modules/grafana/templates/dashboards/deployment_panels/_response_times.json.erb
@@ -51,7 +51,7 @@
       "dsType": "elasticsearch",
       "metrics": [
         {
-          "field": "@fields.duration",
+          "field": "<%= @fields_prefix -%>duration",
           "id": "1",
           "meta": {},
           "settings": {

--- a/modules/grafana/templates/dashboards/deployment_panels/_response_times_by_controller.json.erb
+++ b/modules/grafana/templates/dashboards/deployment_panels/_response_times_by_controller.json.erb
@@ -39,7 +39,7 @@
       "bucketAggs": [
         {
           "fake": true,
-          "field": "@fields.controller",
+          "field": "<%= @fields_prefix -%>controller",
           "id": "3",
           "settings": {
             "order": "desc",
@@ -62,7 +62,7 @@
       "dsType": "elasticsearch",
       "metrics": [
         {
-          "field": "@fields.duration",
+          "field": "<%= @fields_prefix -%>duration",
           "id": "1",
           "meta": {},
           "settings": {

--- a/modules/grafana/templates/dashboards/publishing_api_overview.json.erb
+++ b/modules/grafana/templates/dashboards/publishing_api_overview.json.erb
@@ -69,14 +69,14 @@
               "dsType": "elasticsearch",
               "metrics": [
                 {
-                  "field": "@fields.duration",
+                  "field": "<%= @fields_prefix -%>duration",
                   "id": "1",
                   "meta": {},
                   "settings": {},
                   "type": "max"
                 }
               ],
-              "query": "@fields.application:publishing-api* AND @fields.method:GET",
+              "query": "@fields.application:publishing-api* AND <%= @fields_prefix -%>method:GET",
               "refId": "A",
               "timeField": "@timestamp",
               "hide": false
@@ -98,14 +98,14 @@
               "dsType": "elasticsearch",
               "metrics": [
                 {
-                  "field": "@fields.duration",
+                  "field": "<%= @fields_prefix -%>duration",
                   "id": "3",
                   "meta": {},
                   "settings": {},
                   "type": "max"
                 }
               ],
-              "query": "@fields.application:publishing-api* AND @fields.request:\"*/v2/content*\" AND @fields.method:GET",
+              "query": "@fields.application:publishing-api* AND <%= @fields_prefix -%>request:\"*/v2/content*\" AND <%= @fields_prefix -%>method:GET",
               "refId": "B",
               "timeField": "@timestamp"
             },
@@ -126,14 +126,14 @@
               "dsType": "elasticsearch",
               "metrics": [
                 {
-                  "field": "@fields.duration",
+                  "field": "<%= @fields_prefix -%>duration",
                   "id": "3",
                   "meta": {},
                   "settings": {},
                   "type": "max"
                 }
               ],
-              "query": "@fields.application:publishing-api* AND @fields.request:\"*/v2/links*\" AND @fields.method:GET",
+              "query": "@fields.application:publishing-api* AND <%= @fields_prefix -%>request:\"*/v2/links*\" AND <%= @fields_prefix -%>method:GET",
               "refId": "C",
               "timeField": "@timestamp"
             },
@@ -156,14 +156,14 @@
               "hide": false,
               "metrics": [
                 {
-                  "field": "@fields.duration",
+                  "field": "<%= @fields_prefix -%>duration",
                   "id": "3",
                   "meta": {},
                   "settings": {},
                   "type": "max"
                 }
               ],
-              "query": "@fields.application:publishing-api* AND @fields.request:\"*/v2/linkables*\" AND @fields.method:GET",
+              "query": "@fields.application:publishing-api* AND <%= @fields_prefix -%>request:\"*/v2/linkables*\" AND <%= @fields_prefix -%>method:GET",
               "refId": "D",
               "timeField": "@timestamp"
             },
@@ -184,14 +184,14 @@
               "dsType": "elasticsearch",
               "metrics": [
                 {
-                  "field": "@fields.duration",
+                  "field": "<%= @fields_prefix -%>duration",
                   "id": "1",
                   "meta": {},
                   "settings": {},
                   "type": "max"
                 }
               ],
-              "query": "@fields.application:publishing-api* AND @fields.request:\"*/v2/linked*\" AND @fields.method:GET",
+              "query": "@fields.application:publishing-api* AND <%= @fields_prefix -%>request:\"*/v2/linked*\" AND <%= @fields_prefix -%>method:GET",
               "refId": "E",
               "timeField": "@timestamp"
             },
@@ -212,14 +212,14 @@
               "dsType": "elasticsearch",
               "metrics": [
                 {
-                  "field": "@fields.duration",
+                  "field": "<%= @fields_prefix -%>duration",
                   "id": "1",
                   "meta": {},
                   "settings": {},
                   "type": "max"
                 }
               ],
-              "query": "@fields.application:publishing-api* AND @fields.request:\"*/v2/expanded-links*\" AND @fields.method:GET",
+              "query": "@fields.application:publishing-api* AND <%= @fields_prefix -%>request:\"*/v2/expanded-links*\" AND <%= @fields_prefix -%>method:GET",
               "refId": "F",
               "timeField": "@timestamp",
               "hide": false
@@ -241,14 +241,14 @@
               "dsType": "elasticsearch",
               "metrics": [
                 {
-                  "field": "@fields.duration",
+                  "field": "<%= @fields_prefix -%>duration",
                   "id": "1",
                   "meta": {},
                   "settings": {},
                   "type": "max"
                 }
               ],
-              "query": "@fields.application:publishing-api* AND @fields.request:\"*/v2/editions*\" AND @fields.method:GET",
+              "query": "@fields.application:publishing-api* AND <%= @fields_prefix -%>request:\"*/v2/editions*\" AND <%= @fields_prefix -%>method:GET",
               "refId": "G",
               "timeField": "@timestamp",
               "hide": false
@@ -342,14 +342,14 @@
               "dsType": "elasticsearch",
               "metrics": [
                 {
-                  "field": "@fields.duration",
+                  "field": "<%= @fields_prefix -%>duration",
                   "id": "3",
                   "meta": {},
                   "settings": {},
                   "type": "max"
                 }
               ],
-              "query": "@fields.application:publishing-api* AND @fields.method:(POST,PUT,DELETE,PATCH)",
+              "query": "@fields.application:publishing-api* AND <%= @fields_prefix -%>method:(POST,PUT,DELETE,PATCH)",
               "refId": "A",
               "timeField": "@timestamp"
             },
@@ -370,14 +370,14 @@
               "dsType": "elasticsearch",
               "metrics": [
                 {
-                  "field": "@fields.duration",
+                  "field": "<%= @fields_prefix -%>duration",
                   "id": "3",
                   "meta": {},
                   "settings": {},
                   "type": "max"
                 }
               ],
-              "query": "@fields.application:publishing-api* AND @fields.request:\"*/v2/content*\" AND @fields.method:PUT",
+              "query": "@fields.application:publishing-api* AND <%= @fields_prefix -%>request:\"*/v2/content*\" AND <%= @fields_prefix -%>method:PUT",
               "refId": "B",
               "timeField": "@timestamp"
             },
@@ -398,14 +398,14 @@
               "dsType": "elasticsearch",
               "metrics": [
                 {
-                  "field": "@fields.duration",
+                  "field": "<%= @fields_prefix -%>duration",
                   "id": "3",
                   "meta": {},
                   "settings": {},
                   "type": "max"
                 }
               ],
-              "query": "@fields.application:publishing-api* AND @fields.request:\"*/v2/links/*\" AND @fields.method:PATCH",
+              "query": "@fields.application:publishing-api* AND <%= @fields_prefix -%>request:\"*/v2/links/*\" AND <%= @fields_prefix -%>method:PATCH",
               "refId": "C",
               "timeField": "@timestamp"
             },
@@ -426,14 +426,14 @@
               "dsType": "elasticsearch",
               "metrics": [
                 {
-                  "field": "@fields.duration",
+                  "field": "<%= @fields_prefix -%>duration",
                   "id": "3",
                   "meta": {},
                   "settings": {},
                   "type": "max"
                 }
               ],
-              "query": "@fields.application:publishing-api* AND @fields.request:\"*/v2/content/*\" AND @fields.request:\"*/publish*\" AND @fields.method:POST",
+              "query": "@fields.application:publishing-api* AND <%= @fields_prefix -%>request:\"*/v2/content/*\" AND <%= @fields_prefix -%>request:\"*/publish*\" AND <%= @fields_prefix -%>method:POST",
               "refId": "D",
               "timeField": "@timestamp",
               "hide": false
@@ -455,14 +455,14 @@
               "dsType": "elasticsearch",
               "metrics": [
                 {
-                  "field": "@fields.duration",
+                  "field": "<%= @fields_prefix -%>duration",
                   "id": "1",
                   "meta": {},
                   "settings": {},
                   "type": "max"
                 }
               ],
-              "query": "@fields.application:publishing-api* AND @fields.request:\"*/v2/content/*\" AND @fields.request:\"*/unpublish*\" AND @fields.method:POST",
+              "query": "@fields.application:publishing-api* AND <%= @fields_prefix -%>request:\"*/v2/content/*\" AND <%= @fields_prefix -%>request:\"*/unpublish*\" AND <%= @fields_prefix -%>method:POST",
               "refId": "E",
               "timeField": "@timestamp"
             },
@@ -483,14 +483,14 @@
               "dsType": "elasticsearch",
               "metrics": [
                 {
-                  "field": "@fields.duration",
+                  "field": "<%= @fields_prefix -%>duration",
                   "id": "1",
                   "meta": {},
                   "settings": {},
                   "type": "max"
                 }
               ],
-              "query": "@fields.application:publishing-api* AND @fields.request:\"*/v2/content/*\" AND @fields.request:\"*/discard-draft*\" AND @fields.method:POST",
+              "query": "@fields.application:publishing-api* AND <%= @fields_prefix -%>request:\"*/v2/content/*\" AND <%= @fields_prefix -%>request:\"*/discard-draft*\" AND <%= @fields_prefix -%>method:POST",
               "refId": "F",
               "timeField": "@timestamp"
             }
@@ -599,7 +599,7 @@
                   "type": "count"
                 }
               ],
-              "query": "@fields.application:publishing-api* AND @fields.status:[400 TO 509]",
+              "query": "@fields.application:publishing-api* AND <%= @fields_prefix -%>status:[400 TO 509]",
               "refId": "A",
               "timeField": "@timestamp"
             },
@@ -625,7 +625,7 @@
                   "type": "count"
                 }
               ],
-              "query": "@fields.application:publishing-api* AND @fields.status:[400 TO 509] AND @fields.method:GET",
+              "query": "@fields.application:publishing-api* AND <%= @fields_prefix -%>status:[400 TO 509] AND <%= @fields_prefix -%>method:GET",
               "refId": "B",
               "timeField": "@timestamp"
             },
@@ -651,7 +651,7 @@
                   "type": "count"
                 }
               ],
-              "query": "@fields.application:publishing-api* AND @fields.status:[400 TO 509] AND @fields.method:(POST,PUT,PATCH,DELETE)",
+              "query": "@fields.application:publishing-api* AND <%= @fields_prefix -%>status:[400 TO 509] AND <%= @fields_prefix -%>method:(POST,PUT,PATCH,DELETE)",
               "refId": "C",
               "timeField": "@timestamp"
             }


### PR DESCRIPTION
Previously when a dashboard did not work because of a missing `@fields` prefix, we removed the dashboard entirely (53510b39199c2fbc99c9d35a6c5d257fd592fecf).

We have narrowed down the change in behaviour for log outputs to the different versions of [logstasher](https://github.com/shadabahmed/logstasher).

It seems that anything below v1 adds a `@fields` hash which contains data such as request, duration etc. Anything above v1 does not contain this hash, and outputs this information as a top level object in the JSON output.

This means that it gets parsed in this manner straight into Kibana, and the queries we set on the deployment dashboards do not work.

In the future we would like to entirely remove the `@fields` prefix, so we are adding a new parameter in the dashboard defined type which can
set to help migrate to newer versions of logstasher (or at least a unified logging format across all apps).

It is difficult to remove `@fields` using logstash config due to the nested hash within the JSON object, and I would prefer not to be bandaid
it in this way to encourage movement to a consistent logging approach.

It's worth noting that the `@fields.application` is *not* affected by this, although in new world logging (ie using Filebeat), this is logged out as plain "application".