### PR TITLE
Fix logstream errors

### DIFF
--- a/modules/govuk_logging/manifests/logstream.pp
+++ b/modules/govuk_logging/manifests/logstream.pp
@@ -48,7 +48,7 @@ define govuk_logging::logstream (
 
     exec { "logstream-STOP-${upstart_name}" :
       command => "initctl stop logstream-${upstart_name}",
-      onlyif  => "initctl status logstream-${upstart_name}",
+      onlyif  => "test -f /etc/init/logstream-${upstart_name}.conf",
     }
   } else {
     file { "/etc/init/logstream-${upstart_name}.conf":


### PR DESCRIPTION
Seeing errors like this because the `exec` isn't handled very well:

```
Notice: /Stage[main]/Govuk::Node::S_backend_lb/Loadbalancer::Balance[manuals-publisher]/Nginx::Log[manuals-publisher.integration.publishing.service.gov.uk-json.event.access.log]/Govuk_logging::Logstream[manuals-publisher.integration.publishing.service.gov.uk-json.event.access.log]/Exec[logstream-STOP-manuals-publisher-json.event.access.log]/returns: initctl: Unknown instance: /var/log/nginx/manuals-publisher.integration.publishing.service.gov.uk-json.event.access.log
Error: initctl stop logstream-manuals-publisher-json.event.access.log returned 1 instead of one of [0]
Error: /Stage[main]/Govuk::Node::S_backend_lb/Loadbalancer::Balance[manuals-publisher]/Nginx::Log[manuals-publisher.integration.publishing.service.gov.uk-json.event.access.log]/Govuk_logging::Logstream[manuals-publisher.integration.publishing.service.gov.uk-json.event.access.log]/Exec[logstream-STOP-manuals-publisher-json.event.access.log]/returns: change from notrun to 0 failed: initctl stop logstream-manuals-publisher-json.event.access.log returned 1 instead of one of [0]
```

Change the logic slightly to only try stopping if the upstart file exists.