### PR TITLE
Change dependency on removing logstream

### DIFF
--- a/modules/govuk_logging/manifests/logstream.pp
+++ b/modules/govuk_logging/manifests/logstream.pp
@@ -41,15 +41,16 @@ define govuk_logging::logstream (
   if ($disable_logstreams) {
     # noop
   } elsif ($statsd_metric == undef and $statsd_timers == []) or ($ensure == 'absent') {
-    file { "/etc/init/logstream-${upstart_name}.conf":
-      ensure  => absent,
-      require => Exec["logstream-STOP-${upstart_name}"],
-    }
 
     exec { "logstream-STOP-${upstart_name}" :
-      command => "initctl stop logstream-${upstart_name}",
+      command => "initctl stop logstream-${upstart_name} || echo 'already stopped'",
       onlyif  => "test -f /etc/init/logstream-${upstart_name}.conf",
+    } ->
+
+    file { "/etc/init/logstream-${upstart_name}.conf":
+      ensure  => absent,
     }
+
   } else {
     file { "/etc/init/logstream-${upstart_name}.conf":
       ensure    => present,

--- a/modules/govuk_logging/spec/defines/govuk_logging__logstream_spec.rb
+++ b/modules/govuk_logging/spec/defines/govuk_logging__logstream_spec.rb
@@ -24,7 +24,7 @@ describe 'govuk_logging::logstream', :type => :define do
 
     it 'should ensure the service is stopped' do
       is_expected.to contain_exec('logstream-STOP-giraffe').with(
-        :command => 'initctl stop logstream-giraffe',
+        :command => 'initctl stop logstream-giraffe || echo \'already stopped\'',
       )
     end
   end
@@ -64,7 +64,7 @@ describe 'govuk_logging::logstream', :type => :define do
 
     it 'should ensure the service is stopped' do
       is_expected.to contain_exec('logstream-STOP-giraffe').with(
-        :command => 'initctl stop logstream-giraffe',
+        :command => 'initctl stop logstream-giraffe || echo \'already stopped\'',
       )
     end
   end


### PR DESCRIPTION
This errored because `initctl stop` errored, which meant the dependency to remove the file never runs.