### PR TITLE
Remove logstream resource that isn't statsd

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -40,8 +40,6 @@ deployable_applications: &deployable_applications
   hmrc-manuals-api: {}
   imminence: {}
   info-frontend: {}
-  kibana:
-    repository: 'kibana-gds'
   licencefinder:
     repository: 'licence-finder'
   link-checker-api: {}
@@ -340,8 +338,6 @@ govuk::apps::imminence::nagios_memory_warning: 1200
 govuk::apps::imminence::nagios_memory_critical: 1400
 
 govuk::apps::info_frontend::enabled: true
-
-govuk::apps::kibana::signon_root: "https://signon.%{hiera('app_domain')}"
 
 govuk::apps::local_links_manager::db_hostname: "postgresql-primary-1.backend"
 govuk::apps::local_links_manager::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -48,7 +48,6 @@ govuk::node::s_development::apps:
   - 'hmrc_manuals_api'
   - 'imminence'
   - 'info_frontend'
-  - 'kibana'
   - 'licencefinder'
   - 'link_checker_api'
   - 'local_links_manager'
@@ -114,7 +113,6 @@ govuk::apps::government_frontend::enable_running_in_draft_mode::content_store: '
 govuk::apps::govuk_cdn_logs_monitor::enabled: false
 govuk::apps::imminence::enable_procfile_worker: false
 govuk::apps::imminence::redis_host: 'localhost'
-govuk::apps::kibana::elasticsearch_host: 'localhost'
 govuk::apps::licencefinder::mongodb_nodes: ['localhost']
 govuk::apps::manuals_frontend::enable_running_in_draft_mode::content_store: 'http://draft-content-store.dev.gov.uk'
 govuk::apps::link_checker_api::enable_procfile_worker: false
@@ -276,7 +274,6 @@ hosts::development::apps:
   - 'hmrc-manuals-api'
   - 'imminence'
   - 'info-frontend'
-  - 'kibana'
   - 'licencefinder'
   - 'local-links-manager'
   - 'manuals-frontend'

--- a/modules/govuk/manifests/app.pp
+++ b/modules/govuk/manifests/app.pp
@@ -327,27 +327,12 @@ define govuk::app (
     subscribe  => Class['govuk::deploy'],
   }
 
-  govuk_logging::logstream { "${title}-upstart-out":
-    ensure  => $ensure,
-    logfile => "/var/log/${title}/upstart.out.log",
-    tags    => ['stdout', 'upstart'],
-    fields  => {'application' => $title},
-  }
-
   @filebeat::prospector { "${title}-upstart-out":
     ensure => $ensure,
     paths  => ["/var/log/${title}/upstart.out.log"],
     tags   => ['stdout', 'upstart'],
     fields => {'application' => $title},
   }
-
-  govuk_logging::logstream { "${title}-upstart-err":
-    ensure  => $ensure,
-    logfile => "/var/log/${title}/upstart.err.log",
-    tags    => ['stderr', 'upstart'],
-    fields  => {'application' => $title},
-  }
-
   @filebeat::prospector { "${title}-upstart-err":
     ensure => $ensure,
     paths  => ["/var/log/${title}/upstart.err.log"],
@@ -363,13 +348,6 @@ define govuk::app (
       $err_log_json = true
     } else {
       $err_log_json = undef
-    }
-
-    govuk_logging::logstream { "${title}-app-err":
-      ensure  => $ensure,
-      logfile => "/var/log/${title}/app.err.log",
-      tags    => ['stderr', 'app'],
-      fields  => {'application' => $title},
     }
 
     @filebeat::prospector { "${title}-app-err":
@@ -430,13 +408,6 @@ define govuk::app (
       tags   => ['application'],
       json   => {'add_error_key' => true},
       fields => {'application' => $title},
-    }
-
-    govuk_logging::logstream { "${title}-app-err":
-      ensure  => $ensure,
-      logfile => "/var/log/${title}/app.err.log",
-      tags    => ['application'],
-      fields  => {'application' => $title},
     }
 
     @filebeat::prospector { "${title}-app-err":

--- a/modules/govuk/manifests/apps/email_alert_api.pp
+++ b/modules/govuk/manifests/apps/email_alert_api.pp
@@ -94,20 +94,10 @@ class govuk::apps::email_alert_api(
       enable_service => $enable_procfile_worker,
     }
 
-    govuk_logging::logstream { 'email_alert_api_sidekiq_json_log':
-      logfile => '/var/apps/email-alert-api/log/sidekiq.json.log',
-      fields  => {'application' => 'email-alert-api-sidekiq'},
-    }
-
     @filebeat::prospector { 'email_alert_api_sidekiq_json_log':
       paths  => ['/var/apps/email-alert-api/log/sidekiq.json.log'],
       fields => {'application' => 'email-alert-api-sidekiq'},
       json   => {'add_error_key' => true},
-    }
-
-    govuk_logging::logstream { 'govdelivery_json_log':
-      logfile => '/var/apps/email-alert-api/log/govdelivery.log',
-      fields  => {'application' => 'email-alert-api-govdelivery'},
     }
 
     @filebeat::prospector { 'govdelivery_json_log':

--- a/modules/govuk/manifests/apps/kibana.pp
+++ b/modules/govuk/manifests/apps/kibana.pp
@@ -1,72 +1,14 @@
 # == Class: govuk::apps::kibana
 #
-# Set up the Kibana application behind Signon
+# A redirect to point people using the legacy Kibana domain to
+# docs for how to check Kibana on our ELK SaaS provider.
 #
-# === Parameters
-#
-# [*elasticsearch_host*]
-#   Which logs-elasticsearch host Kibana should connect to, must
-#   be a single host: https://github.com/elasticsearch/kibana/issues/214
-#
-# [*port*]
-#   Port that the Kibana wrapper listens on
-#
-# [*secret_key*]
-#   A secret key for Rack's session cookies
-#
-# [*signon_client_id*]
-#   A client ID for GOV.UK's Signon
-#
-# [*signon_client_secret*]
-#   The secret which matches signon_client_id
-#
-# [*signon_root*]
-#   The HTTP location of Signon
-#
-class govuk::apps::kibana (
-  $elasticsearch_host = 'logs-elasticsearch-1.management',
-  $port = 3202,
-  $secret_key = undef,
-  $signon_client_id = undef,
-  $signon_client_secret = undef,
-  $signon_root = undef,
-) {
+class govuk::apps::kibana {
   $app_name = 'kibana'
 
   $app_domain = hiera('app_domain')
 
-  # FIXME: this should be added back after the code below has been removed.
-  #nginx::config::vhost::redirect { "${app_name}.${app_domain}":
-  #  to => 'https://docs.publishing.service.gov.uk/manual/logit.html',
-  #}
-
-  # FIXME: remove all below when deployed to Production
-  govuk::app { $app_name:
-    ensure   => 'absent',
-    app_type => 'rack',
-    port     => $port,
-  }
-
-  Govuk::App::Envvar {
-    app    => $app_name,
-    ensure => 'absent',
-  }
-
-  govuk::app::envvar {
-    "${title}-ES_HOST":
-      varname => 'ES_HOST',
-      value   => $elasticsearch_host;
-    "${title}-SECRET_KEY":
-      varname => 'SECRET_KEY',
-      value   => $secret_key;
-    "${title}-SIGNON_CLIENT_ID":
-      varname => 'SIGNON_CLIENT_ID',
-      value   => $signon_client_id;
-    "${title}-SIGNON_CLIENT_SECRET":
-      varname => 'SIGNON_CLIENT_SECRET',
-      value   => $signon_client_secret;
-    "${title}-SIGNON_ROOT":
-      varname => 'SIGNON_ROOT',
-      value   => $signon_root;
+  nginx::config::vhost::redirect { "${app_name}.${app_domain}":
+    to => 'https://docs.publishing.service.gov.uk/manual/logit.html',
   }
 }

--- a/modules/govuk/manifests/apps/publishing_api.pp
+++ b/modules/govuk/manifests/apps/publishing_api.pp
@@ -205,11 +205,6 @@ class govuk::apps::publishing_api(
     }
   }
 
-  govuk_logging::logstream { 'publishing_api_sidekiq_json_log':
-    logfile => '/var/apps/publishing-api/log/sidekiq.json.log',
-    fields  => {'application' => 'publishing-api-sidekiq'},
-  }
-
   @filebeat::prospector { 'publishing_api_sidekiq_json_log':
     paths  => ['/var/apps/publishing-api/log/sidekiq.json.log'],
     fields => {'application' => 'publishing-api-sidekiq'},

--- a/modules/govuk/manifests/apps/specialist_publisher.pp
+++ b/modules/govuk/manifests/apps/specialist_publisher.pp
@@ -108,11 +108,6 @@ client_max_body_size 500m;
       asset_pipeline         => true,
     }
 
-    govuk_logging::logstream { "${app_name}_sidekiq_json_log":
-      logfile => "/var/apps/${app_name}/log/sidekiq.json.log",
-      fields  => {'application' => $app_name},
-    }
-
     @filebeat::prospector { "${app_name}_sidekiq_json_log":
       paths  => ["/var/apps/${app_name}/log/sidekiq.json.log"],
       fields => {'application' => $app_name},

--- a/modules/govuk/manifests/apps/stagecraft.pp
+++ b/modules/govuk/manifests/apps/stagecraft.pp
@@ -36,10 +36,6 @@ class govuk::apps::stagecraft (
       health_check_path  => '/_status',
       log_format_is_json => true;
     }
-    govuk_logging::logstream { 'performanceplatform_collectors_log':
-      logfile => '/var/apps/stagecraft/log/collectors.json.log',
-      fields  => {'application' => 'performanceplatform-collectors'},
-    }
 
     @filebeat::prospector { 'performanceplatform_collectors_log':
       paths  => ['/var/apps/stagecraft/log/collectors.json.log'],

--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -296,20 +296,10 @@ class govuk::apps::whitehall(
       locations => {'/government/uploads' => '/data/uploads/whitehall/clean'},
     }
 
-    govuk_logging::logstream { 'whitehall_scheduled_publishing_json_log':
-      logfile => '/var/apps/whitehall/log/production_scheduled_publishing.json.log',
-      fields  => {'application' => 'whitehall'},
-    }
-
     @filebeat::prospector { 'whitehall_scheduled_publishing_json_log':
       paths  => ['/var/apps/whitehall/log/production_scheduled_publishing.json.log'],
       fields => {'application' => 'whitehall'},
       json   => {'add_error_key' => true},
-    }
-
-    govuk_logging::logstream { 'whitehall_sidekiq_json_log':
-      logfile => '/var/apps/whitehall/log/sidekiq.json.log',
-      fields  => {'application' => 'whitehall-sidekiq'},
     }
 
     @filebeat::prospector { 'whitehall_sidekiq_json_log':

--- a/modules/govuk/manifests/node/s_base.pp
+++ b/modules/govuk/manifests/node/s_base.pp
@@ -92,27 +92,6 @@ class govuk::node::s_base (
     matches => '/var/log/govuk/*.log',
   }
 
-  govuk_logging::logstream {
-    'apt-history':
-      logfile => '/var/log/apt/history.log',
-      tags    => ['history'],
-      fields  => {'application' => 'apt'};
-    'apt-term':
-      logfile => '/var/log/apt/term.log',
-      tags    => ['term'],
-      fields  => {'application' => 'apt'};
-    'dpkg':
-      logfile => '/var/log/dpkg.log',
-      fields  => {'application' => 'dpkg'};
-    'unattended-upgrades':
-      logfile => '/var/log/unattended-upgrades/unattended-upgrades.log',
-      tags    => ['unattended'],
-      fields  => {'application' => 'apt'};
-    'unattended-upgrades-shutdown':
-      logfile => '/var/log/unattended-upgrades/unattended-upgrades-shutdown.log',
-      tags    => ['unattended'],
-      fields  => {'application' => 'apt'};
-  }
   # whoopsie is the ubuntu crash reporter. We don't want to be running any
   # software that sends data from our machines to 3rd-party services. Remove it.
   package { 'whoopsie':

--- a/modules/govuk/spec/defines/govuk__app__spec.rb
+++ b/modules/govuk/spec/defines/govuk__app__spec.rb
@@ -134,9 +134,6 @@ describe 'govuk::app', :type => :define do
       end
 
       it "collects stderr logging as plain text" do
-        expect(subject).to contain_govuk_logging__logstream("#{title}-app-err")
-          .with_logfile("/var/log/#{title}/app.err.log")
-
         expect(subject).to contain_filebeat__prospector("#{title}-app-err")
           .with_paths(["/var/log/#{title}/app.err.log"])
       end
@@ -155,9 +152,6 @@ describe 'govuk::app', :type => :define do
       end
 
       it "collects stderr logging as plain text" do
-        expect(subject).to contain_govuk_logging__logstream("#{title}-app-err")
-          .with_logfile("/var/log/#{title}/app.err.log")
-
         expect(subject).to contain_filebeat__prospector("#{title}-app-err")
           .with_paths(["/var/log/#{title}/app.err.log"])
       end
@@ -188,9 +182,6 @@ describe 'govuk::app', :type => :define do
             :command            => '/bin/yes',
             :log_format_is_json => true,
           )
-
-          expect(subject).to contain_govuk_logging__logstream("#{title}-app-err")
-            .with_logfile("/var/log/#{title}/app.err.log")
 
           expect(subject).to contain_filebeat__prospector("#{title}-app-err")
             .with_paths(["/var/log/#{title}/app.err.log"])

--- a/modules/govuk_gor/manifests/init.pp
+++ b/modules/govuk_gor/manifests/init.pp
@@ -63,12 +63,6 @@ class govuk_gor(
     service_ensure => $gor_service_ensure,
     envvars        => $envvars,
     binary_path    => $binary_path,
-  } ->
-  govuk_logging::logstream { 'gor_upstart_log':
-    ensure  => $logstream_ensure,
-    fields  => {'application' => 'gor'},
-    logfile => '/var/log/upstart/gor.log',
-    tags    => ['stdout', 'stderr', 'upstart', 'gor'],
   }
 
   @filebeat::prospector { 'gor_upstart_log':

--- a/modules/govuk_gor/spec/classes/govuk_gor_spec.rb
+++ b/modules/govuk_gor/spec/classes/govuk_gor_spec.rb
@@ -6,13 +6,17 @@ describe 'govuk_gor', :type => :class do
     '-output-http-method' => %w{GET HEAD OPTIONS},
   }}
 
+  let :pre_condition do
+    'Filebeat::Prospector <| |>'
+  end
+
   context 'default (disabled)' do
     let(:params) {{
       'args' => args_default,
     }}
 
     it { is_expected.to contain_class('gor').with_service_ensure('stopped') }
-    it { is_expected.to contain_govuk_logging__logstream('gor_upstart_log').with_ensure('absent') }
+    it { is_expected.to contain_filebeat__prospector('gor_upstart_log').with_ensure('absent') }
   end
 
   context '#enable' do
@@ -24,7 +28,7 @@ describe 'govuk_gor', :type => :class do
       'data_sync_in_progress' => false,
     }}
 
-    it { is_expected.to contain_govuk_logging__logstream('gor_upstart_log').with_ensure('present') }
+    it { is_expected.to contain_filebeat__prospector('gor_upstart_log').with_ensure('present') }
 
     it {
       is_expected.to contain_class('gor').with(
@@ -43,7 +47,7 @@ describe 'govuk_gor', :type => :class do
       'data_sync_in_progress' => true,
     }}
 
-    it { is_expected.to contain_govuk_logging__logstream('gor_upstart_log').with_ensure('absent') }
+    it { is_expected.to contain_filebeat__prospector('gor_upstart_log').with_ensure('absent') }
 
     it {
       is_expected.to contain_class('gor').with(
@@ -61,7 +65,7 @@ describe 'govuk_gor', :type => :class do
       'data_sync_in_progress' => false,
     }}
 
-    it { is_expected.to contain_govuk_logging__logstream('gor_upstart_log').with_ensure('present') }
+    it { is_expected.to contain_filebeat__prospector('gor_upstart_log').with_ensure('present') }
 
     it {
       is_expected.to contain_class('gor').with(

--- a/modules/govuk_mysql/manifests/server/logging.pp
+++ b/modules/govuk_mysql/manifests/server/logging.pp
@@ -18,12 +18,6 @@ class govuk_mysql::server::logging(
   $error_log,
   $slow_query_log=undef,
 ) {
-  govuk_logging::logstream { 'mysql-error-logs':
-    logfile => $error_log,
-    tags    => ['error'],
-    fields  => {'application' => 'mysql'},
-  }
-
   @filebeat::prospector { 'mysql-error-logs':
     paths  => [$error_log],
     tags   => ['error'],
@@ -31,12 +25,6 @@ class govuk_mysql::server::logging(
   }
 
   if $slow_query_log {
-    govuk_logging::logstream { 'mysql-slow-query-logs':
-      logfile => $slow_query_log,
-      tags    => ['slow-query'],
-      fields  => {'application' => 'mysql'},
-    }
-
     @filebeat::prospector { 'mysql-slow-query-logs':
       paths  => [$slow_query_log],
       tags   => ['slow-query'],

--- a/modules/govuk_rabbitmq/manifests/logging.pp
+++ b/modules/govuk_rabbitmq/manifests/logging.pp
@@ -1,38 +1,13 @@
 # FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
 class govuk_rabbitmq::logging {
-  govuk_logging::logstream { 'rabbitmq_startup_log':
-    logfile => '/var/log/rabbitmq/startup_log',
-    fields  => {'application' => 'rabbitmq'},
-  }
-
-  govuk_logging::logstream { 'rabbitmq_startup_error':
-    logfile => '/var/log/rabbitmq/startup_error',
-    fields  => {'application' => 'rabbitmq'},
-  }
-
   @filebeat::prospector { 'rabbitmq_startup':
     paths  => ['/var/log/rabbitmq/startup_error','/var/log/rabbitmq/startup_log'],
     fields => {'application' => 'rabbitmq'},
   }
 
-  govuk_logging::logstream { 'rabbitmq_shutdown_log':
-    logfile => '/var/log/rabbitmq/shutdown_log',
-    fields  => {'application' => 'rabbitmq'},
-  }
-
-  govuk_logging::logstream { 'rabbitmq_shutdown_error':
-    logfile => '/var/log/rabbitmq/shutdown_error',
-    fields  => {'application' => 'rabbitmq'},
-  }
-
   @filebeat::prospector { 'rabbitmq_shutdown':
     paths  => ['/var/log/rabbitmq/shutdown_error','/var/log/rabbitmq/shutdown_log'],
     fields => {'application' => 'rabbitmq'},
-  }
-
-  govuk_logging::logstream { 'rabbitmq_host_log':
-    logfile => "/var/log/rabbitmq/rabbit@${::hostname}.log",
-    fields  => {'application' => 'rabbitmq'},
   }
 
   @filebeat::prospector { 'rabbitmq_host_log':

--- a/modules/icinga/manifests/service.pp
+++ b/modules/icinga/manifests/service.pp
@@ -7,14 +7,6 @@ class icinga::service {
     hasrestart => true,
   }
 
-  govuk_logging::logstream { 'icinga_server':
-    ensure  => 'present',
-    fields  => {'application' => 'icinga'},
-    logfile => '/var/log/icinga/icinga.log',
-    tags    => ['monitoring', 'icinga'],
-    require => Service['icinga'],
-  }
-
   @filebeat::prospector { 'icinga_server':
     ensure  => 'present',
     fields  => {'application' => 'icinga'},

--- a/modules/mongodb/manifests/backup.pp
+++ b/modules/mongodb/manifests/backup.pp
@@ -66,13 +66,6 @@ class mongodb::backup(
     group  => 'root',
   }
 
-  govuk_logging::logstream { 'automongodbbackup':
-    ensure  => $present,
-    fields  => {'application' => 'automongodbbackup'},
-    logfile => '/var/log/automongodbbackup/backup.log',
-    tags    => ['backup', 'automongodbbackup', 'mongo'],
-  }
-
   @filebeat::prospector { 'automongodbbackup':
     ensure => $present,
     fields => {'application' => 'automongodbbackup'},

--- a/modules/mongodb/manifests/logging.pp
+++ b/modules/mongodb/manifests/logging.pp
@@ -3,12 +3,6 @@
 # Configure logging for mongodb
 #
 class mongodb::logging {
-  govuk_logging::logstream { 'mongodb-logstream':
-    logfile => '/var/log/upstart/mongodb.log',
-    fields  => {'application' => 'mongodb'},
-    tags    => ['stdout', 'stderr', 'upstart', 'mongodb'],
-  }
-
   @filebeat::prospector { 'mongodb-logstream':
     paths  => ['/var/log/upstart/mongodb.log'],
     fields => {'application' => 'mongodb'},

--- a/modules/varnish/manifests/monitoring.pp
+++ b/modules/varnish/manifests/monitoring.pp
@@ -8,11 +8,6 @@ class varnish::monitoring {
     require => Package['varnish'],
   }
 
-  govuk_logging::logstream { 'varnishncsa':
-    logfile => '/var/log/varnish/varnishncsa.log',
-    fields  => {'application' => 'varnish'},
-  }
-
   @filebeat::prospector { 'varnishncsa':
     paths  => ['/var/log/varnish/varnishncsa.log'],
     fields => {'application' => 'varnish'},


### PR DESCRIPTION
We're only using logstream to ship metrics, so remove any resource references that are not explicitly sending statsd resources across.

https://trello.com/c/YrTOpoq7/746-logit-migration