### PR TITLE
Update email alert api govdelivery config

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -33,6 +33,8 @@ govuk::apps::content_performance_manager::feature_auditing_theme_filtering: true
 govuk::apps::content_store::performance_platform_big_screen_view_url: 'https://performance-platform-big-screen-view-staging.cloudapps.digital'
 govuk::apps::content_store::performance_platform_spotlight_url: 'https://performance-platform-spotlight-staging.cloudapps.digital'
 govuk::apps::email_alert_api::allow_govdelivery_topic_syncing: true
+govuk::apps::email_alert_api::govdelivery_hostname: 'stage-api.govdelivery.com'
+govuk::apps::email_alert_api::govdelivery_public_hostname: 'stage-public.govdelivery.com'
 govuk::apps::event_store::enabled: true
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
 govuk::apps::publicapi::backdrop_host: 'www.preview.performance.service.gov.uk'

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -33,6 +33,7 @@ govuk::apps::content_performance_manager::feature_auditing_theme_filtering: true
 govuk::apps::content_store::performance_platform_big_screen_view_url: 'https://performance-platform-big-screen-view-staging.cloudapps.digital'
 govuk::apps::content_store::performance_platform_spotlight_url: 'https://performance-platform-spotlight-staging.cloudapps.digital'
 govuk::apps::email_alert_api::allow_govdelivery_topic_syncing: true
+govuk::apps::email_alert_api::govdelivery_account_code: 'UKGOVUKDUP'
 govuk::apps::email_alert_api::govdelivery_hostname: 'stage-api.govdelivery.com'
 govuk::apps::email_alert_api::govdelivery_public_hostname: 'stage-public.govdelivery.com'
 govuk::apps::event_store::enabled: true

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -75,6 +75,7 @@ govuk::apps::content_performance_manager::feature_auditing_theme_filtering: fals
 govuk::apps::content_store::performance_platform_big_screen_view_url: 'https://performance-platform-big-screen-view-production.cloudapps.digital'
 govuk::apps::content_store::performance_platform_spotlight_url: 'https://performance-platform-spotlight-production.cloudapps.digital'
 govuk::apps::email_alert_api::db::backend_ip_range: '10.3.3.0/24'
+govuk::apps::email_alert_api::govdelivery_account_code: 'UKGOVUK'
 govuk::apps::email_alert_api::govdelivery_hostname: 'api.govdelivery.com'
 govuk::apps::email_alert_api::govdelivery_public_hostname: 'public.govdelivery.com'
 govuk::apps::hmrc_manuals_api::publish_topics: false

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -75,6 +75,8 @@ govuk::apps::content_performance_manager::feature_auditing_theme_filtering: fals
 govuk::apps::content_store::performance_platform_big_screen_view_url: 'https://performance-platform-big-screen-view-production.cloudapps.digital'
 govuk::apps::content_store::performance_platform_spotlight_url: 'https://performance-platform-spotlight-production.cloudapps.digital'
 govuk::apps::email_alert_api::db::backend_ip_range: '10.3.3.0/24'
+govuk::apps::email_alert_api::govdelivery_hostname: 'api.govdelivery.com'
+govuk::apps::email_alert_api::govdelivery_public_hostname: 'public.govdelivery.com'
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::local_links_manager::local_links_manager_passive_checks: true
 govuk::apps::publicapi::backdrop_host: 'www.performance.service.gov.uk'

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -18,6 +18,8 @@ govuk::apps::content_store::performance_platform_big_screen_view_url: 'https://p
 govuk::apps::content_store::performance_platform_spotlight_url: 'https://performance-platform-spotlight-staging.cloudapps.digital'
 govuk::apps::email_alert_api::allow_govdelivery_topic_syncing: true
 govuk::apps::email_alert_api::db::backend_ip_range: '10.2.3.0/24'
+govuk::apps::email_alert_api::govdelivery_hostname: 'stage-api.govdelivery.com'
+govuk::apps::email_alert_api::govdelivery_public_hostname: 'stage-public.govdelivery.com'
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::publicapi::backdrop_host: 'www.staging.performance.service.gov.uk'
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-staging'

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -18,6 +18,7 @@ govuk::apps::content_store::performance_platform_big_screen_view_url: 'https://p
 govuk::apps::content_store::performance_platform_spotlight_url: 'https://performance-platform-spotlight-staging.cloudapps.digital'
 govuk::apps::email_alert_api::allow_govdelivery_topic_syncing: true
 govuk::apps::email_alert_api::db::backend_ip_range: '10.2.3.0/24'
+govuk::apps::email_alert_api::govdelivery_account_code: 'UKGOVUK'
 govuk::apps::email_alert_api::govdelivery_hostname: 'stage-api.govdelivery.com'
 govuk::apps::email_alert_api::govdelivery_public_hostname: 'stage-public.govdelivery.com'
 govuk::apps::hmrc_manuals_api::publish_topics: false

--- a/modules/govuk/manifests/apps/email_alert_api.pp
+++ b/modules/govuk/manifests/apps/email_alert_api.pp
@@ -39,12 +39,14 @@
 # [*govdelivery_account_code*]
 #   Identifier for GOV.UK within the govdelivery service
 #
+# [*govdelivery_protocol*]
+#   Protocol used for the govdelivery service
+#
 # [*govdelivery_hostname*]
 #   Hostname for the govdelivery API (changes depending on environment)
 #
-# [*govdelivery_signup_form*]
-#   URL to the public govdelivery page users are redirected to to enter their
-#   email and subscribe (URL should include a %s to provide a topic ID)
+# [*govdelivery_public_hostname*]
+#   Public hostname for the govdelivery API
 #
 #
 # [*secret_key_base*]
@@ -69,8 +71,9 @@ class govuk::apps::email_alert_api(
   $govdelivery_username = undef,
   $govdelivery_password = undef,
   $govdelivery_account_code = undef,
+  $govdelivery_protocol = 'https',
   $govdelivery_hostname = undef,
-  $govdelivery_signup_form = undef,
+  $govdelivery_public_hostname = undef,
   $secret_key_base = undef,
   $db_username = 'email-alert-api',
   $db_password = undef,
@@ -153,12 +156,15 @@ class govuk::apps::email_alert_api(
       "${title}-GOVDELIVERY_ACCOUNT_CODE":
           varname => 'GOVDELIVERY_ACCOUNT_CODE',
           value   => $govdelivery_account_code;
+      "${title}-GOVDELIVERY_PROTOCOL":
+          varname => 'GOVDELIVERY_PROTOCOL',
+          value   => $govdelivery_protocol;
       "${title}-GOVDELIVERY_HOSTNAME":
           varname => 'GOVDELIVERY_HOSTNAME',
           value   => $govdelivery_hostname;
-      "${title}-GOVDELIVERY_SIGNUP_FORM":
-          varname => 'GOVDELIVERY_SIGNUP_FORM',
-          value   => $govdelivery_signup_form;
+      "${title}-GOVDELIVERY_PUBLIC_HOSTNAME":
+          varname => 'GOVDELIVERY_PUBLIC_HOSTNAME',
+          value   => $govdelivery_public_hostname;
       "${title}-SECRET_KEY_BASE":
           varname => 'SECRET_KEY_BASE',
           value   => $secret_key_base;


### PR DESCRIPTION
To support a future where all the configuration is loaded from the environment.

[Trello Card](https://trello.com/c/QRXDQQab/214-put-email-alert-api-govdelivery-credentials-into-environment-variables-and-remove-from-alphagov-deployment)