### PR TITLE
Clean up files created for Check Content Consistency

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/check_content_consistency.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/check_content_consistency.yaml.erb
@@ -90,3 +90,8 @@
           scp draft-$CONTENT_CSV_GZ deploy@$PUBLISHING_API:
           ssh deploy@$PUBLISHING_API "cd /var/apps/publishing-api && govuk_setenv publishing-api bundle exec rake check_content_consistency[draft,/home/deploy/draft-$CONTENT_CSV_GZ]"
           ssh deploy@$PUBLISHING_API "rm draft-$CONTENT_CSV_GZ"
+
+          rm -rf $CONTENT_CSV_GZ
+          rm -rf draft-$CONTENT_CSV_GZ
+          rm -rf $ROUTES_CSV_GZ
+          rm -rf draft-$ROUTES_CSV_GZ


### PR DESCRIPTION
Each time this job runs it creates 4 temporary files which aren't cleaned up at the end of the run.

We've been building up quite a lot of data from each time this job runs and had to do some cleanups. 

This updates the script to clean up the file, but I do wonder if a better approach might be to select that jenkins deletes the workspace before each build. 

@thomasleese did you have any thoughts or any previous intentions for this?