### PR TITLE
Remove deployment dependency on github

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
@@ -1,13 +1,4 @@
 ---
-- scm:
-    name: alphagov-deployment_Deploy_App
-    scm:
-        - git:
-            url: git@github.com:alphagov/govuk-app-deployment.git
-            branches:
-              - master
-            wipe-workspace: true
-
 - job:
     name: Deploy_App
     display-name: Deploy_App
@@ -16,14 +7,11 @@
     <%- if @auth_token -%>
     auth-token: <%= @auth_token %>
     <%- end -%>
-    properties:
-        - github:
-            url: https://github.com/alphagov/govuk-app-deployment
-    scm:
-      - alphagov-deployment_Deploy_App
     builders:
         - shell: |
             #!/usr/bin/env bash
+            set -x
+
             export DEPLOY_TO="<%= @environment -%>"
             export DEPLOY_TASK="$DEPLOY_TASK"
             export TAG="$TAG"
@@ -38,6 +26,7 @@
               export GIT_ORIGIN_PREFIX="git@gitlab.com:govuk"
             fi
 
+            git clone ${GIT_ORIGIN_PREFIX="git@github.com:alphagov"}/govuk-app-deployment.git --branch master --single-branch --depth 1 ./
             ./jenkins.sh
     publishers:
         - trigger:
@@ -52,6 +41,7 @@
             recipients: govuk-ci-notifications@digital.cabinet-office.gov.uk
             send-to-individuals: true
     wrappers:
+        - workspace-cleanup
         - ansicolor:
             colormap: xterm
         - build-name:


### PR DESCRIPTION
This changes the deploy app job to no longer have a SCM association with github.com:alphagov/govuk-app-deployment. Instead the repository that is associated with this is determined based on whether the deploy with gitlab checkbox is selected or not.

We specify the banch of master even though it is not required so that it will be clear for future users of this script where to change this when you want to use different branches of govuk-app-deployment.

A final problem that will need resolving beyond this is govuk-app-deployment has a dependency on cloning [alphagov-deployment](https://github.com/alphagov/govuk-app-deployment/blob/master/jenkins.sh#L9) which is currently not mirrored on gitlab.

Here are 2 examples of this script running (presuming they've not been cleaned up by now):

- with GitHub: https://deploy.integration.publishing.service.gov.uk/job/Deploy_App/4007/console
- with GitLab: https://deploy.integration.publishing.service.gov.uk/job/Deploy_App/4008/console