### PR TITLE
Environment configurable sitemap schedule for Rummager

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -39,6 +39,7 @@ govuk::apps::publicapi::backdrop_host: 'www.preview.performance.service.gov.uk'
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-integration'
 govuk::apps::publishing_api::content_api_prototype: true
 govuk::apps::rummager::elasticsearch_hosts: 'http://rummager-elasticsearch-1.api:9200,http://rummager-elasticsearch-2.api:9200,http://rummager-elasticsearch-3.api:9200'
+govuk::apps::rummager::sitemap_generation_time: '6.10am'
 govuk::apps::short_url_manager::instance_name: 'integration'
 govuk::apps::signon::instance_name: 'integration'
 govuk::apps::smartanswers::expose_govspeak: true

--- a/modules/govuk/manifests/apps/rummager.pp
+++ b/modules/govuk/manifests/apps/rummager.pp
@@ -64,6 +64,9 @@
 # [*spelling_dependencies*]
 #   Install the spelling package dependencies
 #
+# [*sitemap_generation_time*]
+#   A time of day in a format supported by https://github.com/javan/whenever
+#
 class govuk::apps::rummager(
   $rabbitmq_user,
   $port = '3009',
@@ -81,6 +84,7 @@ class govuk::apps::rummager(
   $nagios_memory_critical = undef,
   $spelling_dependencies = 'present',
   $elasticsearch_hosts = undef,
+  $sitemap_generation_time = '1.10am',
 ) {
 
   package { ['aspell', 'aspell-en', 'libaspell-dev']:
@@ -178,5 +182,10 @@ class govuk::apps::rummager(
   govuk::app::envvar { "${title}-ELASTICSEARCH_URI":
     varname => 'ELASTICSEARCH_URI',
     value   => $elasticsearch_hosts,
+  }
+
+  govuk::app::envvar { "${title}-SITEMAP_GENERATION_TIME":
+    varname => 'SITEMAP_GENERATION_TIME',
+    value   => $sitemap_generation_time,
   }
 }


### PR DESCRIPTION
One of the lingering things in alphagov-deployment is the copying of the
schedule config file at deployment time. This sets up an environment
variable for this configuration to enable us to remove this file.