### PR TITLE
[WIP] Enable logspout everywhere but dev

### DIFF
--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -90,6 +90,8 @@ govuk::node::s_development::apps:
 govuk_app_enable_capistrano_layout: false
 govuk_app_enable_services: false
 
+govuk_docker::enable_logspout: false
+
 govuk::apps::asset_manager::mongodb_name: 'govuk_assets_development'
 govuk::apps::asset_manager::mongodb_nodes: ['localhost']
 govuk::apps::authenticating_proxy::mongodb_name: 'authenticating_proxy_development'

--- a/modules/govuk_docker/manifests/init.pp
+++ b/modules/govuk_docker/manifests/init.pp
@@ -12,14 +12,17 @@
 #   Pin a version to use
 #   Default is present
 #
+# [*enable_logspout*]
+#   Set to true to use logspout to ship logs
+#
 class govuk_docker (
   $docker_users = [],
   $version = 'present',
+  $enable_logspout = true,
 ){
   validate_array($docker_users)
 
-  # We only have logit set up for integration, everywhere else use syslog
-  if $::domain =~ /^.*\.(dev|integration\.publishing\.service)\.gov\.uk/ {
+  if $enable_logspout {
     class { '::docker':
       docker_users => $docker_users,
       version      => $version,

--- a/modules/govuk_docker/spec/classes/govuk_docker_spec.rb
+++ b/modules/govuk_docker/spec/classes/govuk_docker_spec.rb
@@ -6,13 +6,12 @@ describe 'govuk_docker', :type => :class do
 
   it { is_expected.to compile.with_all_deps }
 
-  context 'it is integration' do
-    let(:facts) {{domain: '.integration.publishing.service.gov.uk'}}
+  context 'default params' do
     it { is_expected.to contain_class('Govuk_docker::Logspout') }
   end
 
-  context 'it is not in integration' do
-    let(:facts) {{domain: 'anything.else'}}
+  context 'enable_logspout set to false' do
+    let(:params) {{enable_logspout: false}}
     it { is_expected.not_to contain_class('Govuk_docker::Logspout') }
   end
 end


### PR DESCRIPTION
I didn't realise this was gated and not enabled. Since we're using Logit everywhere now, we should ship all Docker logs across by default.