### PR TITLE
Show draft flows env variable for smart answers

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -46,6 +46,7 @@ govuk::apps::rummager::sitemap_generation_time: '6.10am'
 govuk::apps::short_url_manager::instance_name: 'integration'
 govuk::apps::signon::instance_name: 'integration'
 govuk::apps::smartanswers::expose_govspeak: true
+govuk::apps::smartanswers::show_draft_flows: true
 govuk::apps::specialist_publisher::publish_pre_production_finders: true
 govuk::apps::support_api::pp_data_url: 'https://www.preview.performance.service.gov.uk'
 govuk::apps::travel_advice_publisher::enable_email_alerts: true

--- a/modules/govuk/manifests/apps/smartanswers.pp
+++ b/modules/govuk/manifests/apps/smartanswers.pp
@@ -13,6 +13,11 @@
 #   available alongside other formats (e.g. html, json)
 #   Default: false
 #
+# [*show_draft_flows*]
+#   A boolean value indicating if the draft flows of smart answers will be
+#   shown in an environment
+#   Default: false
+#
 # [*publishing_api_bearer_token*]
 #   The bearer token to use when communicating with Publishing API.
 #   Default: undef
@@ -33,6 +38,7 @@
 class govuk::apps::smartanswers(
   $port = '3010',
   $expose_govspeak = false,
+  $show_draft_flows = false,
   $sentry_dsn = undef,
   $publishing_api_bearer_token = undef,
   $nagios_memory_warning = undef,
@@ -47,6 +53,14 @@ class govuk::apps::smartanswers(
     govuk::app::envvar {
       "${title}-EXPOSE_GOVSPEAK":
         varname => 'EXPOSE_GOVSPEAK',
+        value   => '1';
+    }
+  }
+
+  if $show_draft_flows {
+    govuk::app::envvar {
+      "${title}-SHOW_DRAFT_FLOWS":
+        varname => 'SHOW_DRAFT_FLOWS',
         value   => '1';
     }
   }


### PR DESCRIPTION
This is to move smart answers towards being a 12 factor application.
Currently this configuration is made by the deployment of different
files at deploy time. This commit changes this to be be defined by an
environment variable.