### PR TITLE
Add Carbon aggregation schema for Mtail metrics

### DIFF
--- a/modules/govuk/files/node/s_graphite/storage-aggregation.conf
+++ b/modules/govuk/files/node/s_graphite/storage-aggregation.conf
@@ -44,6 +44,12 @@ xFilesFactor = 0.1
 pattern = ^stats_counts\..*
 aggregationMethod = sum
 
+# incremental counter, keep last value
+[mtail-counter-incremental]
+pattern = \.nginx_metrics\.mtail\.http_requests_total.*
+aggregationMethod = last
+xFilesFactor = 0.1
+
 [default]
 pattern = .*
 aggregationMethod = average


### PR DESCRIPTION
Mtail http_requests_total Nginx metrics are incremental counters. In Carbon,
we want to keep the last value received in the aggregation window. Also, reduce
the xFilesFactor from the default value (0.5) to 0.1 to avoid storing false nulls.