### PR TITLE
Remove apps that can't deploy

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -10,10 +10,6 @@ app_domain_internal: 'dev.gov.uk'
 deployable_applications: &deployable_applications
   asset-manager: {}
   authenticating-proxy: {}
-  backdrop-read:
-    repository: 'backdrop'
-  backdrop-write:
-    repository: 'backdrop'
   bouncer: {}
   calculators: {}
   calendars: {}
@@ -48,7 +44,6 @@ deployable_applications: &deployable_applications
   manuals-publisher: {}
   mapit: {}
   maslow: {}
-  performanceplatform-admin: {}
   performanceplatform-big-screen-view: {}
   policy-publisher: {}
   publisher: {}
@@ -67,7 +62,6 @@ deployable_applications: &deployable_applications
     repository: 'smart-answers'
   specialist-publisher: {}
   spotlight: {}
-  stagecraft: {}
   static: {}
   support: {}
   support-api: {}

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -44,7 +44,6 @@ deployable_applications: &deployable_applications
   manuals-publisher: {}
   mapit: {}
   maslow: {}
-  performanceplatform-big-screen-view: {}
   policy-publisher: {}
   publisher: {}
   publishing-api: {}
@@ -61,7 +60,6 @@ deployable_applications: &deployable_applications
   smartanswers:
     repository: 'smart-answers'
   specialist-publisher: {}
-  spotlight: {}
   static: {}
   support: {}
   support-api: {}


### PR DESCRIPTION
With the retiring of [alphagov-deployment][] these apps will no longer
be safe to deploy as they won't have files automatically copied into
them. Therefore to avoid accidental incorrect deployments they are
removed from the list of deployable applications.

If someone was in a bind it'd still be easy to deploy an app as you'd
just have to edit the jenkins job to add the application to the list.

[alphagov-deployment]: https://github.com/alphagov/alphagov-deployment