### PR TITLE
Add Tim Mower user and add support for ed25519 keys

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem "rspec-puppet"
 # https://github.com/rodjek/rspec-puppet/issues/56
 gem 'puppetlabs_spec_helper', '1.0.1'
 gem "webmock", "~> 1.20.0"
-gem "sshkey", "1.7.0"
+gem "sshkey", "1.9.0"
 
 gem "parallel_tests"
 gem "parallel"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,7 +97,7 @@ GEM
     rspec-support (3.3.0)
     rsync (1.0.9)
     safe_yaml (1.0.4)
-    sshkey (1.7.0)
+    sshkey (1.9.0)
     thor (0.19.1)
     thread_safe (0.3.4)
     trollop (2.1.2)
@@ -124,5 +124,5 @@ DEPENDENCIES
   puppetlabs_spec_helper (= 1.0.1)
   rake
   rspec-puppet
-  sshkey (= 1.7.0)
+  sshkey (= 1.9.0)
   webmock (~> 1.20.0)

--- a/modules/users/manifests/timmower.pp
+++ b/modules/users/manifests/timmower.pp
@@ -1,0 +1,8 @@
+# Creates the timmower user
+class users::timmower {
+  govuk_user { 'timmower':
+    fullname => 'Tim Mower',
+    email    => 'tim.mower@digital.cabinet-office.gov.uk',
+    ssh_key  => 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINeiPTmKWTt+a+0RXcYejPqYoxePS4e77FVONdf3fGm0 Tim Mower',
+  }
+}

--- a/modules/users/spec/classes/users_spec.rb
+++ b/modules/users/spec/classes/users_spec.rb
@@ -61,7 +61,9 @@ user_list.each do |username|
 
       ssh_keys.each do |key|
         if key != 'ssh-rsa REPLACE ME'
+          expect(SSHKey.valid_ssh_public_key? key).to be true
           key_strength = SSHKey.ssh_public_key_bits key
+          next if key.match(/^ssh-ed25519/)
           expect(key_strength).to be >= 4096, "SSH key for #{user[:name]} is only #{key_strength} bits and must be stronger"
         end
       end


### PR DESCRIPTION
Add a user for Tim Mower

Update the tests to support ed25519 keys, as i'm trying to use this for new machines - [this article](https://blog.g3rt.nl/upgrade-your-ssh-keys.html) has more info on these keys

https://trello.com/c/dnZtqAKp/760-add-access-for-tim-mower