### PR TITLE
Allow CI to build email-alert-monitoring

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -546,6 +546,7 @@ govuk_ci::master::pipeline_jobs:
   backdrop-transactions-explorer-collector: {}
   cdn-acceptance-tests: {}
   deprecated_columns: {}
+  email-alert-monitoring: {}
   event-store: {}
   gapy: {}
   gds-api-adapters: {}


### PR DESCRIPTION
We currently don't have CI running on [this repo](https://github.com/alphagov/email-alert-monitoring) despite tests existing.