### PR TITLE
Remove legacy logging

### DIFF
--- a/modules/govuk/manifests/apps/government_frontend.pp
+++ b/modules/govuk/manifests/apps/government_frontend.pp
@@ -39,7 +39,6 @@ class govuk::apps::government_frontend(
     sentry_dsn            => $sentry_dsn,
     vhost_ssl_only        => true,
     health_check_path     => '/healthcheck',
-    legacy_logging        => false,
     asset_pipeline        => true,
     asset_pipeline_prefix => 'government-frontend',
     vhost                 => $vhost,

--- a/modules/govuk/manifests/apps/govuk_cdn_logs_monitor.pp
+++ b/modules/govuk/manifests/apps/govuk_cdn_logs_monitor.pp
@@ -47,7 +47,6 @@ class govuk::apps::govuk_cdn_logs_monitor (
       app_type           => 'bare',
       command            => 'bundle exec ruby scripts/monitor_logs.rb',
       enable_nginx_vhost => false,
-      legacy_logging     => false,
     }
   }
 }

--- a/modules/govuk/manifests/apps/publishing_api.pp
+++ b/modules/govuk/manifests/apps/publishing_api.pp
@@ -123,7 +123,6 @@ class govuk::apps::publishing_api(
     sentry_dsn         => $sentry_dsn,
     vhost_ssl_only     => true,
     health_check_path  => '/healthcheck',
-    legacy_logging     => false,
     log_format_is_json => true,
     deny_framing       => true,
   }

--- a/modules/govuk/manifests/apps/service_manual_frontend.pp
+++ b/modules/govuk/manifests/apps/service_manual_frontend.pp
@@ -41,7 +41,6 @@ class govuk::apps::service_manual_frontend(
       sentry_dsn            => $sentry_dsn,
       vhost_ssl_only        => true,
       health_check_path     => '/healthcheck',
-      legacy_logging        => false,
       asset_pipeline        => true,
       asset_pipeline_prefix => 'service-manual-frontend',
       vhost                 => $vhost,

--- a/modules/govuk/manifests/apps/signon.pp
+++ b/modules/govuk/manifests/apps/signon.pp
@@ -83,7 +83,6 @@ class govuk::apps::signon(
     sentry_dsn             => $sentry_dsn,
     vhost_ssl_only         => true,
     health_check_path      => '/users/sign_in',
-    legacy_logging         => false,
     asset_pipeline         => true,
     deny_framing           => true,
     nagios_memory_warning  => $nagios_memory_warning,

--- a/modules/govuk/spec/defines/govuk__app__spec.rb
+++ b/modules/govuk/spec/defines/govuk__app__spec.rb
@@ -121,10 +121,6 @@ describe 'govuk::app', :type => :define do
     end
 
     context "a 12-factor app" do
-      before :each do
-        params[:legacy_logging] = false
-      end
-
       it "collects stdout logging as JSON" do
         expect(subject).to contain_govuk_logging__logstream("#{title}-app-out")
           .with_logfile("/var/log/#{title}/app.out.log")
@@ -137,20 +133,9 @@ describe 'govuk::app', :type => :define do
         expect(subject).to contain_filebeat__prospector("#{title}-app-err")
           .with_paths(["/var/log/#{title}/app.err.log"])
       end
-
-      it "removes collection of the apps production.log" do
-        expect(subject).to contain_govuk_logging__logstream("#{title}-production-log")
-          .with_ensure("absent")
-
-        expect(subject).to_not contain_filebeat__prospector("#{title}-production-log")
-      end
     end
 
     context "a non-12-factor app" do
-      before :each do
-        params[:legacy_logging] = true
-      end
-
       it "collects stderr logging as plain text" do
         expect(subject).to contain_filebeat__prospector("#{title}-app-err")
           .with_paths(["/var/log/#{title}/app.err.log"])


### PR DESCRIPTION
/cc @tijmenb

We are doing work to ensure all applications log in a consistent manner.

Currently, depending on how they're configured, they log to either:

`/var/app/$application/log/production.log`
`/var/app/$application/log/production.json.log`
`/var/log/$application/app.out.log`

We had a conditional that we would have to change when an app has been migrated over. We're looking to centralise configuration and update apps, and so it would be easier to just try logging from both places. It should not cause any errors if the log files are empty, it just won't log anything.

This will make it easier to switch over and ensure we're not losing any logs when we migrate.

When this has been completed, we should remove all code related to `production.log` and `production.json.log`, and ensure that the only places that apps log are `/var/log/$application`.

https://trello.com/c/mNI2G3z4/774-remove-legacylogging-code-from-govuk-puppet