### PR TITLE
Set up env vars for Publisher

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -285,6 +285,9 @@ govuk::apps::manuals_publisher::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::publisher::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
 govuk::apps::publisher::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::publisher::redis_port: "%{hiera('sidekiq_port')}"
+govuk::apps::publisher::email_group_dev: 'govuk-dev@digital.cabinet-office.gov.uk'
+govuk::apps::publisher::email_group_business: 'govuk-dev@digital.cabinet-office.gov.uk'
+govuk::apps::publisher::email_group_citizen: 'govuk-dev@digital.cabinet-office.gov.uk'
 
 govuk::apps::short_url_manager::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::short_url_manager::redis_port: "%{hiera('sidekiq_port')}"

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -39,6 +39,8 @@ govuk::apps::email_alert_api::govdelivery_public_hostname: 'stage-public.govdeli
 govuk::apps::event_store::enabled: true
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
 govuk::apps::publicapi::backdrop_host: 'www.preview.performance.service.gov.uk'
+govuk::apps::publisher::run_fact_check_fetcher: true
+govuk::apps::publisher::fact_check_address_format: 'govuk-factcheck-preview+{id}@digital.cabinet-office.gov.uk'
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-integration'
 govuk::apps::publishing_api::content_api_prototype: true
 govuk::apps::rummager::elasticsearch_hosts: 'http://rummager-elasticsearch-1.api:9200,http://rummager-elasticsearch-2.api:9200,http://rummager-elasticsearch-3.api:9200'

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -81,6 +81,8 @@ govuk::apps::email_alert_api::govdelivery_public_hostname: 'public.govdelivery.c
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::local_links_manager::local_links_manager_passive_checks: true
 govuk::apps::publicapi::backdrop_host: 'www.performance.service.gov.uk'
+govuk::apps::publisher::run_fact_check_fetcher: true
+govuk::apps::publisher::fact_check_address_format: 'factcheck+production-{id}@alphagov.co.uk'
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-production'
 govuk::apps::support_api::pp_data_url: 'https://www.performance.service.gov.uk'
 govuk::apps::support_api::zendesk_anonymous_ticket_email: 'zd-api-public@digital.cabinet-office.gov.uk'

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -83,6 +83,9 @@ govuk::apps::local_links_manager::local_links_manager_passive_checks: true
 govuk::apps::publicapi::backdrop_host: 'www.performance.service.gov.uk'
 govuk::apps::publisher::run_fact_check_fetcher: true
 govuk::apps::publisher::fact_check_address_format: 'factcheck+production-{id}@alphagov.co.uk'
+govuk::apps::publisher::email_group_dev: 'govuk-dev@digital.cabinet-office.gov.uk'
+govuk::apps::publisher::email_group_business: 'publisher-alerts-business@digital.cabinet-office.gov.uk'
+govuk::apps::publisher::email_group_citizen: 'publisher-alerts-citizen@digital.cabinet-office.gov.uk'
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-production'
 govuk::apps::support_api::pp_data_url: 'https://www.performance.service.gov.uk'
 govuk::apps::support_api::zendesk_anonymous_ticket_email: 'zd-api-public@digital.cabinet-office.gov.uk'

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -23,6 +23,8 @@ govuk::apps::email_alert_api::govdelivery_hostname: 'stage-api.govdelivery.com'
 govuk::apps::email_alert_api::govdelivery_public_hostname: 'stage-public.govdelivery.com'
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::publicapi::backdrop_host: 'www.staging.performance.service.gov.uk'
+govuk::apps::publisher::run_fact_check_fetcher: false
+govuk::apps::publisher::fact_check_address_format: 'factcheck+staging-{id}@alphagov.co.uk'
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-staging'
 govuk::apps::short_url_manager::instance_name: 'staging'
 govuk::apps::signon::instance_name: 'staging'

--- a/modules/govuk/manifests/apps/publisher.pp
+++ b/modules/govuk/manifests/apps/publisher.pp
@@ -63,6 +63,15 @@
 # [*fact_check_password*]
 #   The password to use for Basic Auth for fact check
 #
+# [*email_group_dev*]
+#   The email address to use dev alerts
+#
+# [*email_group_business*]
+#   The email address to use business alerts
+#
+# [*email_group_citizen*]
+#   The email address to use citizen alerts
+#
 class govuk::apps::publisher(
     $port = '3000',
     $enable_procfile_worker = true,
@@ -82,6 +91,9 @@ class govuk::apps::publisher(
     $fact_check_address_format = undef,
     $fact_check_username = undef,
     $fact_check_password = undef,
+    $email_group_dev = undef,
+    $email_group_business = undef,
+    $email_group_citizen = undef,
   ) {
 
   govuk::app { 'publisher':
@@ -177,5 +189,14 @@ class govuk::apps::publisher(
     "${title}-FACT_CHECK_PASSWORD":
       varname => 'FACT_CHECK_PASSWORD',
       value   => $fact_check_password;
+    "${title}-EMAIL_GROUP_DEV":
+      varname => 'EMAIL_GROUP_DEV',
+      value   => $email_group_dev;
+    "${title}-EMAIL_GROUP_BUSINESS":
+      varname => 'EMAIL_GROUP_BUSINESS',
+      value   => $email_group_business;
+    "${title}-EMAIL_GROUP_CITIZEN":
+      varname => 'EMAIL_GROUP_CITIZEN',
+      value   => $email_group_citizen;
   }
 }

--- a/modules/govuk/manifests/apps/publisher.pp
+++ b/modules/govuk/manifests/apps/publisher.pp
@@ -44,12 +44,18 @@
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
-#
 # [*oauth_id*]
 #   The application's OAuth ID from Signon
 #
 # [*oauth_secret*]
 #   The application's OAuth Secret from Signon
+#
+# [*run_fact_check_fetcher*]
+#   Whether to perform fetches for fact checks
+#   Default: false
+#
+# [*fact_check_address_format*]
+#   The address format used for sending fact checks
 #
 # [*fact_check_username*]
 #   The username to use for Basic Auth for fact check
@@ -72,6 +78,8 @@ class govuk::apps::publisher(
     $sentry_dsn = undef,
     $oauth_id = undef,
     $oauth_secret = undef,
+    $run_fact_check_fetcher = false,
+    $fact_check_address_format = undef,
     $fact_check_username = undef,
     $fact_check_password = undef,
   ) {
@@ -133,6 +141,14 @@ class govuk::apps::publisher(
     app => 'publisher',
   }
 
+  if $run_fact_check_fetcher {
+    govuk::app::envvar {
+      "${title}-RUN_FACT_CHECK_FETCHER":
+        varname => 'RUN_FACT_CHECK_FETCHER',
+        value   => '1';
+    }
+  }
+
   govuk::app::envvar {
     "${title}-PUBLISHING_API_BEARER_TOKEN":
       varname => 'PUBLISHING_API_BEARER_TOKEN',
@@ -152,6 +168,9 @@ class govuk::apps::publisher(
     "${title}-OAUTH_SECRET":
       varname => 'OAUTH_SECRET',
       value   => $oauth_secret;
+    "${title}-FACT_CHECK_ADDRESS_FORMAT":
+      varname => 'FACT_CHECK_ADDRESS_FORMAT',
+      value   => $fact_check_address_format;
     "${title}-FACT_CHECK_USERNAME":
       varname => 'FACT_CHECK_USERNAME',
       value   => $fact_check_username;


### PR DESCRIPTION
This is to enable the retiring of alphagov-deployment for managing the configurations within: https://github.com/alphagov/alphagov-deployment/tree/master/publisher