### PR TITLE
Add streaming RDS backup scripts

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -535,6 +535,9 @@ govuk::node::s_asset_base::firewall_allow_ip_range: "%{hiera('environment_ip_pre
 
 govuk::node::s_base::log_remote: false
 
+govuk::node::s_db_admin::apt_mirror_hostname: "${hiera('apt_mirror_hostname')}"
+govuk::node::s_db_admin::backup_s3_bucket: "govuk-integration-rds-backups"
+
 govuk::node::s_licensify_lb::backend_app_servers:
   - 'licensing-backend'
   - 'licensing-backend'
@@ -551,6 +554,9 @@ govuk::node::s_postgresql_primary::alert_hostname: 'alert'
 govuk::node::s_whitehall_mysql_master::aws_access_key_id: "%{hiera('govuk::node::s_mysql_backup::aws_access_key_id')}"
 govuk::node::s_whitehall_mysql_master::aws_secret_access_key: "%{hiera('govuk::node::s_mysql_backup::aws_secret_access_key')}"
 govuk::node::s_whitehall_mysql_master::encryption_key: "${hiera('govuk::node::s_mysql_backup::encryption_key')}"
+
+govuk::node::s_transition_db_admin::apt_mirror_hostname: "${hiera('apt_mirror_hostname')}"
+govuk::node::s_transition_db_admin::backup_s3_bucket: "govuk-integration-rds-backups"
 
 govuk::node::s_transition_postgresql_master::alert_hostname: 'alert'
 govuk::node::s_transition_postgresql_slave::redirector_ip_range: 10.6.0.1/16

--- a/modules/govuk/manifests/node/s_transition_db_admin.pp
+++ b/modules/govuk/manifests/node/s_transition_db_admin.pp
@@ -4,14 +4,33 @@
 #
 # === Parameters
 #
-
 class govuk::node::s_transition_db_admin(
-  $postgres_host     = undef,
-  $postgres_user     = undef,
-  $postgres_password = undef,
-  $postgres_port     = '5432',
+  $apt_mirror_hostname  = undef,
+  $backup_s3_bucket     = undef,
+  $postgres_host        = undef,
+  $postgres_user        = undef,
+  $postgres_password    = undef,
+  $postgres_port        = '5432',
+  $postgres_backup_hour = 7,
+  $postgres_backup_min  = 30,
 ) {
   include ::govuk::node::s_base
+
+  apt::source { 'gof3r':
+    location     => "http://${apt_mirror_hostname}/gof3r",
+    release      => $::lsbdistcodename,
+    architecture => $::architecture,
+    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+  }
+
+  package { 'gof3r':
+    ensure  => '0.5.0',
+    require => Apt::Source['gof3r'],
+  }
+
+  $alert_hostname = 'alert'
+
+  ### PostgreSQL ###
 
   $default_connect_settings = {
     'PGUSER'     => $postgres_user,
@@ -43,4 +62,31 @@ class govuk::node::s_transition_db_admin(
 
   # include all PostgreSQL classes that create databases and users
   class { '::govuk::apps::transition::postgresql_db': }
+
+  $postgres_backup_desc = 'RDS Transition PostgreSQL backup to S3'
+
+  @@icinga::passive_check { "check_rds_postgres_s3_backup-${::hostname}":
+    service_description => $postgres_backup_desc,
+    freshness_threshold => 28 * 3600,
+    host_name           => $::fqdn,
+  }
+
+  file { '/usr/local/bin/rds-postgres-to-s3':
+    ensure  => 'present',
+    content => template('govuk/node/s_db_admin/rds-postgres-to-s3.erb'),
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0775',
+    require => [
+      Package['gof3r'],
+      File['/root/.pgpass'],
+    ],
+  }
+
+  cron::crondotdee { 'rds-transition-postgres-to-s3':
+    hour    => $postgres_backup_hour,
+    minute  => $postgres_backup_min,
+    command => '/usr/local/bin/rds-postgres-to-s3',
+    require => File['/usr/local/bin/rds-postgres-to-s3'],
+  }
 }

--- a/modules/govuk/templates/node/s_db_admin/rds-mysql-to-s3.erb
+++ b/modules/govuk/templates/node/s_db_admin/rds-mysql-to-s3.erb
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# Script to stream mysqldump straight to an S3 bucket
+#
+exec 1> >(logger -s -t $(basename $0)) 2>&1
+
+# The default Icinga passive alert assumes that the script failed
+NAGIOS_CODE=2
+NAGIOS_MESSAGE="CRITICAL: RDS MySQL backup to S3 failed"
+
+# Triggered whenever this script exits, successful or otherwise. The values
+# of CODE/MESSAGE will be taken from that point in time.
+function nagios_passive () {
+  printf "<%= @ipaddress %>\t<%= @mysql_backup_desc %>\t${NAGIOS_CODE}\t${NAGIOS_MESSAGE}\n" | /usr/sbin/send_nsca -H <%= @alert_hostname %> >/dev/null
+}
+
+trap nagios_passive EXIT
+
+DATABASES=$(mysql --batch --skip-column-names -e "show databases" |egrep -v "^mysql$|^lost\+found$|^information_schema$")
+ERRORLOG="/tmp/rds-mysql-to-s3.errors-$(date +%F)"
+
+for database in $DATABASES; do
+  echo "Starting dump of ${database} to S3"
+  mysqldump $database | /usr/local/bin/gof3r put --endpoint s3-<%= @aws_region -%>.amazonaws.com -b <%= @backup_s3_bucket -%> -k mysql/$(date +%F)/$database.dump
+
+  if [[ $? != 0 ]]; then
+    echo "Error dumping ${database}"
+    echo $database >> $ERRORLOG
+  else
+    echo "Finished dump of ${database} to S3"
+  fi
+done
+
+if [[ ! -e $ERRORLOG ]]; then
+  NAGIOS_CODE=0
+  NAGIOS_MESSAGE="OK: RDS MySQL backup to S3 succeeded"
+fi

--- a/modules/govuk/templates/node/s_db_admin/rds-postgres-to-s3.erb
+++ b/modules/govuk/templates/node/s_db_admin/rds-postgres-to-s3.erb
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+# Script to stream pg_dump straight to an S3 bucket
+#
+exec 1> >(logger -s -t $(basename $0)) 2>&1
+
+# The default Icinga passive alert assumes that the script failed
+NAGIOS_CODE=2
+NAGIOS_MESSAGE="CRITICAL: RDS PostgreSQL backup to S3 failed"
+
+# Triggered whenever this script exits, successful or otherwise. The values
+# of CODE/MESSAGE will be taken from that point in time.
+function nagios_passive () {
+  printf "<%= @ipaddress %>\t<%= @postgres_backup_desc %>\t${NAGIOS_CODE}\t${NAGIOS_MESSAGE}\n" | /usr/sbin/send_nsca -H <%= @alert_hostname %> >/dev/null
+}
+
+trap nagios_passive EXIT
+
+PSQL_OPTS="-U <%= @postgres_user -%> -p <%= @postgres_port -%> -h <%= @postgres_host -%>"
+
+DATABASES=$(psql ${PSQL_OPTS} -At -c 'select datname from pg_catalog.pg_database;' |egrep -v "^template[0-9]$|^postgres$")
+ERRORLOG="/tmp/rds-postgres-to-s3.errors-$(date +%F)"
+
+for database in $DATABASES; do
+  echo "Starting dump of ${database} to S3"
+  pg_dump ${PSQL_OPTS} $database | /usr/local/bin/gof3r put --endpoint s3-<%= @aws_region -%>.amazonaws.com -b <%= @backup_s3_bucket -%> -k postgres/$(date +%F)/$database.dump
+
+  if [[ $? != 0 ]]; then
+    echo "Error dumping ${database}"
+    echo $database >> $ERRORLOG
+  else
+    echo "Finished dump of ${database} to S3"
+  fi
+done
+
+if [[ ! -e $ERRORLOG ]]; then
+  NAGIOS_CODE=0
+  NAGIOS_MESSAGE="OK: RDS MySQL backup to S3 succeeded"
+fi


### PR DESCRIPTION
Add backup scripts that do not do anything too clever: take a list of databases, excluding some specific ones, take a dump, and stream the output to a file in an S3 bucket. All backups will go into the same bucket, which we'll enable with expiration dates to manage storage.

Ensure there are passive checks that alert us if a backup fails.

In theory these scripts could also be run on demand if developers wanted more up to date data to import.

We are relying on the connection during transfer being encrypted (which is by default with gof3r), and the bucket being encrypted at rest.

We will use IAM roles to allow access to the bucket from the instance.

https://trello.com/c/F6UQeeiN/777-design-rds-replicas-and-backups