### PR TITLE
Only configure Sendfile for public asset requests from Asset Manager

### DIFF
--- a/modules/govuk/manifests/apps/asset_manager.pp
+++ b/modules/govuk/manifests/apps/asset_manager.pp
@@ -88,8 +88,16 @@ class govuk::apps::asset_manager(
     $nginx_extra_config = inline_template('
       client_max_body_size 500m;
 
-      proxy_set_header X-Sendfile-Type X-Accel-Redirect;
-      proxy_set_header X-Accel-Mapping /var/apps/asset-manager/uploads/assets/=/raw/;
+      # Instruct Nginx to set "Sendfile" headers for both Mainstream and
+      # Whitehall public asset URLs. The Rails app will respond with the
+      # X-Accel-Redirect header set to a path prefixed with /raw/ which will
+      # be handled by the internal `/raw/(.*)` location block below.
+      location ~ ^/(media|government/uploads)/(.*) {
+         proxy_set_header X-Sendfile-Type X-Accel-Redirect;
+         proxy_set_header X-Accel-Mapping /var/apps/asset-manager/uploads/assets/=/raw/;
+
+         proxy_pass http://asset-manager.dev.gov.uk-proxy;
+       }
 
       # /raw/(.*) is the path mapping sent from the rails application to
       # nginx and is immediately picked up. /raw/(.*) is not available


### PR DESCRIPTION
Previously we were setting the `X-Sendfile-Type` & `X-Accel-Mapping` request headers in *all* requests proxied from Nginx to the Rails app. However, these headers only need to be set for the `/media/*` (Mainstream) and `/government/uploads/*` (Whitehall) URL paths, because these are the only routes which ever make use of the Sendfile behaviour.

In the not too distant future, we're planning to change the Rails app to proxy all these public asset requests to S3, like public Mainstream asset requests already are in production. At this point, it will be possible to remove both this new Nginx `location` block and the related internal `location` block.

My initial motivation for doing this was to solve a problem with alphagov/asset-manager#267 in which the Rails app proxies public asset requests to fake S3 URLs served by the Rails app. Having the Sendfile-related headers set for the latter requests was problematic for serving the fake S3 URLs.

Note that I have introduced a bit of duplication in the new Nginx `location` block (in the `proxy_pass` statement). I did try referencing the existing named `location` block `@app`, but I couldn't get this to work. However, given that the amount of duplication is minimal, there is already duplication like this in the Nginx config, and the `location` block should be going away in the not too distant future, I'm happy to leave it like this.
