### PR TITLE
Fix hard-coded proxy pass for Asset Manager

### DIFF
--- a/modules/govuk/manifests/apps/asset_manager.pp
+++ b/modules/govuk/manifests/apps/asset_manager.pp
@@ -96,7 +96,7 @@ class govuk::apps::asset_manager(
          proxy_set_header X-Sendfile-Type X-Accel-Redirect;
          proxy_set_header X-Accel-Mapping /var/apps/asset-manager/uploads/assets/=/raw/;
 
-         proxy_pass http://asset-manager.dev.gov.uk-proxy;
+         proxy_pass http://asset-manager.<%= @app_domain %>-proxy;
        }
 
       # /raw/(.*) is the path mapping sent from the rails application to


### PR DESCRIPTION
9b3b712714 attempted to change the configuration so that existing
headers were only added to a subset of requests proxied to the Rails
app. The `proxy_pass` URL was, however, hard-coded to
`http://asset-manager.dev.gov.uk-proxy`. This is not correct for all
environments.

This commit uses `@app_domain` to make sure it is correctly set.