### PR TITLE
MongoDB S3 backups in AWS

### DIFF
--- a/modules/mongodb/manifests/aws_backup.pp
+++ b/modules/mongodb/manifests/aws_backup.pp
@@ -1,0 +1,75 @@
+# == Class: mongodb::aws_backup
+#
+# This class handles everything related to regular backups
+# in AWS. While it's similar to the current MongoDB to S3 backups,
+# there are enough differences to create a new, simpler class.
+#
+# === Parameters:
+#
+# [*ensure*]
+#   Set to false to remove all resources.
+#
+# [*bucket*]
+#   Name of the bucket to backup to.
+#
+# [*interval*]
+#   How often backups should be taken in minutes.
+#
+# [*daily_time*]
+#   What time signifies that a backup is for long-term storage.
+#   Format: <hour>:<minute>
+#
+class mongodb::aws_backup (
+  $ensure     = 'present',
+  $backup_dir = '/var/lib/mongodump',
+  $bucket     = undef,
+  $interval   = 15,
+  $daily_time = '00:00',
+) {
+
+  validate_integer($interval)
+  validate_re($daily_time, '^(\d\d):(\d\d)$')
+
+  $alert_hostname = 'alert'
+  $threshold_secs = 3600
+  $service_desc = 'MongoDB backup to S3'
+
+  if $ensure == 'present' {
+    $ensure_dir = 'directory'
+  } else {
+    $ensure_dir = 'absent'
+  }
+
+  if ($ensure == 'present' and $bucket) {
+    $_ensure = 'present'
+  } else {
+    $_ensure = 'absent'
+  }
+
+  file { $backup_dir:
+    ensure => $ensure_dir,
+  }
+
+  file { '/usr/local/bin/mongodump-to-s3':
+    ensure  => $_ensure,
+    content => template('mongodb/mongodump-to-s3.erb'),
+    mode    => '0755',
+    require => File[$backup_dir],
+  }
+
+  cron::crondotdee { 'mongodump-to-s3':
+    ensure  => $_ensure,
+    command => '/usr/bin/setlock -n /var/run/mongodump-to-s3 /usr/local/bin/mongodump-to-s3',
+    hour    => '*',
+    minute  => "*/${interval}",
+    require => File['/usr/local/bin/mongodump-to-s3'],
+  }
+
+  @@icinga::passive_check { "check-mongodb-backup-to-s3-${::hostname}":
+    ensure              => $_ensure,
+    service_description => $service_desc,
+    freshness_threshold => $threshold_secs,
+    host_name           => $::fqdn,
+    notes_url           => monitoring_docs_url(backup-passive-checks),
+  }
+}

--- a/modules/mongodb/manifests/s3backup/backup.pp
+++ b/modules/mongodb/manifests/s3backup/backup.pp
@@ -75,7 +75,6 @@ class mongodb::s3backup::backup(
 
   validate_re($private_gpg_key_fingerprint, '^[[:alnum:]]{40}$', 'Must supply full GPG fingerprint')
 
-
   file { $backup_dir:
     ensure => directory,
     owner  => $user,
@@ -161,13 +160,10 @@ class mongodb::s3backup::backup(
     require => Class['mongodb::s3backup::package'],
   }
 
-
   @@icinga::passive_check { "check_mongodb_s3backup-${::hostname}":
     service_description => $service_desc,
     freshness_threshold => $threshold_secs,
     host_name           => $::fqdn,
     notes_url           => monitoring_docs_url(backup-passive-checks),
   }
-
 }
-

--- a/modules/mongodb/manifests/s3backup/cron.pp
+++ b/modules/mongodb/manifests/s3backup/cron.pp
@@ -5,7 +5,6 @@
 # [*user*]
 #   The user to run the cronjob as.
 #
-#
 class mongodb::s3backup::cron(
   $user = 'govuk-backup',
   $realtime_hour = '*',
@@ -18,7 +17,6 @@ class mongodb::s3backup::cron(
   include ::backup::client
   require mongodb::s3backup::package
   require mongodb::s3backup::backup
-
 
   if $frequent_backups {
     # Here we use setlock to prevent the jobs from running asynchronously
@@ -36,5 +34,4 @@ class mongodb::s3backup::cron(
     hour    => $daily_hour,
     minute  => $daily_minute,
   }
-
 }

--- a/modules/mongodb/manifests/s3backup/package.pp
+++ b/modules/mongodb/manifests/s3backup/package.pp
@@ -3,12 +3,8 @@
 # Installs packages required for MongoDB S3 backups
 #
 class mongodb::s3backup::package {
-
-
-
   package { 's3cmd' :
     ensure   => present,
     provider => pip,
   }
-
 }

--- a/modules/mongodb/manifests/server.pp
+++ b/modules/mongodb/manifests/server.pp
@@ -50,9 +50,13 @@ class mongodb::server (
     fail("Replica set can't have no members")
   }
 
-  unless $development {
-    class { 'mongodb::backup':
-      replicaset_members => keys($replicaset_members),
+  if $::aws_migration {
+    include ::mongodb::aws_backup
+  } else {
+    unless $development {
+      class { 'mongodb::backup':
+        replicaset_members => keys($replicaset_members),
+      }
     }
   }
 

--- a/modules/mongodb/spec/classes/mongodb__aws_backup_spec.rb
+++ b/modules/mongodb/spec/classes/mongodb__aws_backup_spec.rb
@@ -1,0 +1,10 @@
+require_relative '../../../../spec_helper'
+
+describe 'mongodb::aws_backup', :type => :class do
+  context "default settings" do
+    let(:params){{ 'bucket' => 'my-bucket' }}
+    it { is_expected.to contain_file('/var/lib/mongodump').with_ensure('directory') }
+    it { is_expected.to contain_file('/usr/local/bin/mongodump-to-s3').with_ensure('present') }
+    it { is_expected.to contain_cron__crondotdee('mongodump-to-s3').with_minute('*/15') }
+  end
+end

--- a/modules/mongodb/templates/mongodump-to-s3.erb
+++ b/modules/mongodb/templates/mongodump-to-s3.erb
@@ -1,0 +1,58 @@
+#!/bin/bash
+#
+# This script takes a mongodump, copies it to an S3 bucket,
+# and cleans up afterward.
+#
+# At a set time it will push the backup to a different location
+# so we can set shorter expiration on the regular backups, and
+# keep one backup everyday for longer.
+#
+set -e
+
+exec 1> >(/usr/bin/logger -s -t $(basename $0)) 2>&1
+
+NAGIOS_CODE=2
+NAGIOS_MESSAGE='CRITICAL: MongoDB backup to S3 failed'
+
+# Triggered whenever this script exits, successful or otherwise. The values
+# # of CODE/MESSAGE will be taken from that point in time.
+function nagios_passive () {
+  printf "<%= @ipaddress %>\t<%= @service_desc %>\t${NAGIOS_CODE}\t${NAGIOS_MESSAGE}\n" | /usr/sbin/send_nsca -H <%= @alert_hostname %> >/dev/null
+}
+
+function housekeeping() {
+  /bin/rm -f <%= @backup_dir -%>/*mongodump*
+}
+
+function exit_trap() {
+  housekeeping
+  nagios_passive
+}
+
+trap exit_trap EXIT
+
+if [[ "$(date +%H:%M)" == "<%= @daily_time -%>" ]]; then
+  BUCKET_KEY='mongodb/daily/<%= @aws_migration -%>'
+else
+  BUCKET_KEY='mongodb/regular/<%= @aws_migration -%>'
+fi
+
+# Only run on the current primary
+if /usr/bin/mongo --quiet --eval "db.isMaster().primary === db.isMaster().me" | grep -q true; then
+  echo "Starting backup"
+  /usr/bin/mongodump -o <%= @backup_dir -%>/mongodump
+
+  echo "Compressing mongodump to tarball"
+  tar -zcvf <%= @backup_dir -%>/mongodump.tgz <%= @backup_dir -%>/mongodump
+
+  echo "Uploading mongodump to S3"
+  /usr/bin/aws s3 --region <%= @region -%> cp <%= @backup_dir -%>/mongodump.tgz s3://<%= @bucket -%>/${BUCKET_KEY}/mongodump-$(date +%F_%H%M).tgz
+
+  echo "Completed successfully"
+  NAGIOS_CODE=0
+  NAGIOS_MESSAGE="OK: MongoDB backup to S3 succeeded"
+else
+  echo "Not the primary instance: skipping backup"
+  NAGIOS_CODE=0
+  NAGIOS_MESSAGE="OK: Not the primary instance"
+fi


### PR DESCRIPTION
https://trello.com/c/FQYnkupU/779-design-backup-method-to-s3-for-mongo

We already have scripts and manifests that create backups for MongoDB to an S3 bucket. However, these scripts are heavily based on a few assumptions:

 - We want to encrypt using GPG
 - We are not in an AWS environment
 - Our hosts are static

Rather than try to work around all the code that does the above, I created a new class and template which excludes anything to do with GPG and AWS API settings.

Rather than also having to set a load of hieradata to specifically include the class of a specific node, I just include it on all nodes, but only run it if the instance is the primary instance.

We are unable to specify based upon hostname in AWS, and this also ensures that if primary goes away in our cluster, when the new primary steps up, backups continue to happen.

This means that a Nagios passive check is included on all machines, but they should always report back as "OK" if they're not a primary so should not cause any alarms.