### PR TITLE
[Do Not Merge] Fail fast if Nginx config contains a syntax error

### DIFF
--- a/modules/govuk/manifests/apps/asset_manager.pp
+++ b/modules/govuk/manifests/apps/asset_manager.pp
@@ -100,7 +100,7 @@ class govuk::apps::asset_manager(
          proxy_set_header X-Sendfile-Type X-Accel-Redirect;
          proxy_set_header X-Accel-Mapping /var/apps/asset-manager/uploads/assets/=/raw/;
 
-         proxy_pass http://asset-manager.<%= @app_domain %>-proxy;
+         proxy_pass http://asset-manager.intentionally-broken-<%= @app_domain %>-proxy;
        }
 
       # /raw/(.*) is the path mapping sent from the rails application to

--- a/modules/nginx/manifests/service.pp
+++ b/modules/nginx/manifests/service.pp
@@ -4,7 +4,7 @@ class nginx::service {
   service { 'nginx':
     ensure    => running,
     hasstatus => true,
-    restart   => '/etc/init.d/nginx reload',
+    restart   => 'nginx -t && /etc/init.d/nginx reload',
   }
 
 }


### PR DESCRIPTION
Previously if the Nginx config changed (e.g. in an individual virtual host config), but it contained a syntax error, the following would occur when running `govuk_puppet`:

1. Puppet notices the config has changed and triggers a restart of the Nginx service
2. Puppet runs `/etc/init.d/nginx reload` to restart the Nginx service
3. The syntax error prevents the new config from being loaded
4. Nginx continues to run with the old config
5. `/etc/init.d/nginx reload` returns a zero (success) error code (it seems to do this whether or not the reload succeeds!)
6. Puppet assumes the restart has completed successfully and continues without any warnings or errors
7. If the Nginx process is subsequently restarted (e.g. on reboot), it will stop and then fail to start, because of the syntax error

After this change, Puppet's restart of the Nginx service first checks that there are no syntax errors in the config and fails fast with a useful error message if there is a syntax error. Otherwise it continues as before.

Ideally we'd also roll back the change to the Nginx configuration, but I'm not sure how to do that. However, I still think that this change is an improvement, because (assuming we have alerts setup for the Puppet cron job failing), we'll find out immediately if there is a syntax error in the Nginx config.

The motivation behind this change was [a real case where a syntax error in the Nginx config was accidentally introduced][1] and Nginx silently failed to reload the config. Later when the (integration) machine was rebooted, the OS attempted to start Nginx, but it failed to start, meaning that all requests to any Nginx virtual hosts failed.

I'm no Puppet expert and I'm unsure whether this is the best approach, but it feels as if there's something no quite right about the current behaviour.

Here's some sample output when a syntax error occurs with the change from this PR in place:

```
Notice: /Stage[main]/Govuk::Apps::Asset_manager/Govuk::App[asset-manager]/Govuk::App::Config[asset-manager]/Govuk::App::Nginx_vhost[asset-manager]/Nginx::Config::Vhost::Proxy[asset-manager.dev.gov.uk]/Nginx::Config::Site[asset-manager.dev.gov.uk]/File[/etc/nginx/sites-available/asset-manager.dev.gov.uk]/content: content changed '{md5}b1d58c15d80d37cd43de5e57a0b4ff49' to '{md5}6d3942333b7e7d4a57b1a70b1d9f4bc9'
Error: /Stage[main]/Nginx::Service/Service[nginx]: Failed to call refresh: Could not restart Service[nginx]: Execution of 'nginx -t && /etc/init.d/nginx reload' returned 1: nginx: [emerg] host not found in upstream "asset-manager.yyydev.gov.uk-proxy" in /etc/nginx/sites-enabled/asset-manager.dev.gov.uk:56
nginx: configuration file /etc/nginx/nginx.conf test failed
Error: /Stage[main]/Nginx::Service/Service[nginx]: Could not restart Service[nginx]: Execution of 'nginx -t && /etc/init.d/nginx reload' returned 1: nginx: [emerg] host not found in upstream "asset-manager.yyydev.gov.uk-proxy" in /etc/nginx/sites-enabled/asset-manager.dev.gov.uk:56
nginx: configuration file /etc/nginx/nginx.conf test failed
Notice: Finished catalog run in 56.68 seconds
```

[1]: https://github.com/alphagov/govuk-puppet/pull/6683