### PR TITLE
Configure Bouncer in AWS

### DIFF
--- a/hieradata_aws/class/bouncer.yaml
+++ b/hieradata_aws/class/bouncer.yaml
@@ -1,0 +1,4 @@
+---
+
+govuk::node::s_base::apps:
+  - bouncer

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -224,7 +224,7 @@ govuk::apps::asset_manager::mongodb_nodes:
   - 'mongo-3'
 govuk::apps::authenticating_proxy::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
 
-govuk::apps::bouncer::db_hostname: "transition-postgresql"
+govuk::apps::bouncer::db_hostname: "transition-postgresql-standby"
 govuk::apps::bouncer::nagios_memory_warning: 1400
 govuk::apps::bouncer::nagios_memory_critical: 1500
 

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -225,6 +225,7 @@ govuk::apps::asset_manager::mongodb_nodes:
 govuk::apps::authenticating_proxy::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
 
 govuk::apps::bouncer::db_hostname: "transition-postgresql-standby"
+govuk::apps::bouncer::postgresql_role::rds: true
 govuk::apps::bouncer::nagios_memory_warning: 1400
 govuk::apps::bouncer::nagios_memory_critical: 1500
 

--- a/modules/govuk/manifests/apps/bouncer/postgresql_role.pp
+++ b/modules/govuk/manifests/apps/bouncer/postgresql_role.pp
@@ -1,10 +1,14 @@
 # FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
-class govuk::apps::bouncer::postgresql_role ( $password = '' ){
+class govuk::apps::bouncer::postgresql_role (
+  $password = '',
+  $rds = undef,
+  ){
   $bouncer_role = 'bouncer'
   $db           = 'transition_production'
 
   postgresql::server::role { $bouncer_role:
     password_hash => postgresql_password($bouncer_role, $password),
+    rds           => $rds,
   }
 
   postgresql::server::database_grant { "${bouncer_role} can connect to ${db}":
@@ -14,21 +18,10 @@ class govuk::apps::bouncer::postgresql_role ( $password = '' ){
     require   => [Postgresql::Server::Role[$bouncer_role], Class['govuk::apps::transition::postgresql_db']],
   }
 
-  exec { "${bouncer_role} will be able to SELECT from all yet-to-be-created tables in ${db}":
-    command => "psql -d ${db} -c 'ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO ${bouncer_role}'",
-    unless  => "psql -d ${db} -c '\\ddp' | grep -q 'bouncer=r/'",
-    user    => 'postgres',
-    require => Postgresql::Server::Database_grant["${bouncer_role} can connect to ${db}"],
-  }
-
-  # FIXME: We will be able to do this via the postgres puppet module from version 4.2.0:
-  # https://github.com/puppetlabs/puppetlabs-postgresql/blob/master/CHANGELOG.md#2015-03-10---supported-release-420
-  # https://github.com/puppetlabs/puppetlabs-postgresql/pull/405
-  exec { "${bouncer_role} can SELECT from all existing tables in ${db}":
-    command => "psql -d ${db} -c 'GRANT SELECT ON ALL TABLES IN SCHEMA public TO ${bouncer_role}'",
-    # This only tests that the privilege is set for at least one table, not all of them:
-    unless  => "psql -d ${db} -c '\\dp' | grep -q 'bouncer=r/'",
-    user    => 'postgres',
-    require => Exec["${bouncer_role} will be able to SELECT from all yet-to-be-created tables in ${db}"],
+  postgresql::server::grant { "${bouncer_role} can SELECT from all tables in ${db}":
+    privilege   => 'SELECT',
+    object_type => 'ALL TABLES IN SCHEMA',
+    db          => $db,
+    role        => $bouncer_role,
   }
 }

--- a/modules/govuk/manifests/node/s_transition_db_admin.pp
+++ b/modules/govuk/manifests/node/s_transition_db_admin.pp
@@ -68,7 +68,10 @@ class govuk::node::s_transition_db_admin(
   class { '::govuk_postgresql::client': } ->
 
   # include all PostgreSQL classes that create databases and users
-  class { '::govuk::apps::transition::postgresql_db': }
+  class { '::govuk::apps::transition::postgresql_db': } ->
+
+  # Include the Bouncer PostgreSQL Role class for its database permissions
+  class { '::govuk::apps::bouncer::postgresql_role': }
 
   $postgres_backup_desc = 'RDS Transition PostgreSQL backup to S3'
 


### PR DESCRIPTION
EDIT (2017-11-02): This is finally working - Bouncer can read from the Transition database on the RDS replica (transition-postgresql-standby).

- This required a rework of the `postgresql_role` class to not use raw SQL commands but module classes instead (after an interlude where we tried to bodge it into working by specifying usernames, passwords and hosts in `aws_migration` conditionals), which reduces the amount of code and makes it a lot neater.