### PR TITLE
Update nginx config check in restart class

### DIFF
--- a/modules/nginx/manifests/restart.pp
+++ b/modules/nginx/manifests/restart.pp
@@ -3,7 +3,7 @@ class nginx::restart {
 
   exec { '/etc/init.d/nginx restart':
     refreshonly => true,
-    onlyif      => '/etc/init.d/nginx configtest',
+    onlyif      => 'nginx -t',
   }
 
 }


### PR DESCRIPTION
I investigated the difference between `/etc/init.d/nginx configtest` and
`nginx -t` while reviewing PR #6693.

On my dev-vm, and therefore presumably in our other environments,
`/etc/init.d/nginx configtest` always appears to exit with a status code
of 0 irrespective of whether there are errors in the config. Puppet uses
the exit code of this `onlyif` command to determine whether to run the
main command[1]. Because it was always exiting with 0, an invalid nginx
config wouldn't actually prevent the restart command from being run.

I've confirmed that `nginx -t` does exit with a non-zero code when it
encounters an error in the config so I think this is a better command to
use when checking whether we can restart.

While I'm fairly confident this change is good, I've not been able to
test it on my dev-vm. The only things that trigger `nginx::restart` are
an install/upgrade of nginx-common and nginx-full so I think I'd have to
somehow change the version being installed and it's not clear how I'd do
that.

This snippets below illustrate the differences between `nginx -t` and
`configtest` having first updated the nginx config to contain a syntax
error:

== Using `configtest`

```
$ sudo /etc/init.d/nginx configtest
 * Testing nginx configuration
   ...fail!

$ echo $?
0

$ sudo /etc/init.d/nginx configtest && echo "nginx config ok"
 * Testing nginx configuration
   ...fail!
nginx config ok
```

== Using `nginx -t`

```
$ sudo nginx -t
nginx: [emerg] unknown directive "foo" in /etc/nginx/nginx.conf:3
nginx: configuration file /etc/nginx/nginx.conf test failed

$ echo $?
1

$ sudo nginx -t && echo "nginx config ok"
nginx: [emerg] unknown directive "foo" in /etc/nginx/nginx.conf:3
nginx: configuration file /etc/nginx/nginx.conf test failed
```

[1]: https://puppet.com/docs/puppet/5.2/types/exec.html#exec-attribute-onlyif