### PR TITLE
Remove spotlight from GOV.UK infrastructure

### DIFF
--- a/development-vm/Pinfile
+++ b/development-vm/Pinfile
@@ -69,7 +69,6 @@ process :signon
 process :smartanswers => [:static, :'content-store', :imminence]
 process :'specialist-publisher' => ['asset-manager', :rummager, :'publishing-api', :'email-alert-api']
 process :'specialist-publisher-worker' => [:rummager, :'email-alert-api']
-process :spotlight
 process :stagecraft => [:backdrop_write]
 process :static
 process :support => [:'support-api']

--- a/development-vm/Procfile
+++ b/development-vm/Procfile
@@ -58,7 +58,7 @@ maslow:                govuk_setenv maslow                ./run_in.sh ../../masl
 # router uses ports 3054 and 3055
 router:                govuk_setenv router                ./run_go.sh router               make run
 router-api:            govuk_setenv router-api            ./run_in.sh ../../router-api     bundle exec rails server -p 3056
-spotlight:                                                ./run_in.sh ../../spotlight      ./start-app.sh # port 3057
+# spotlight used port 3057
 # content_planner used port 3058
 screenshot_as_a_service:                                  ./run_in.sh ../../screenshot-as-a-service ./start-app.sh # ports 3059 and 3060
 # business-support-api used port 3061

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1537,7 +1537,6 @@ router::assets_origin::asset_routes:
   '/licencefinder/': "licencefinder"
   '/service-manual-frontend/': "service-manual-frontend"
   '/smartanswers/': "smartanswers"
-  '/spotlight/': "spotlight"
   '/stagecraft/': "stagecraft"
 
 router::assets_origin::vhost_aliases:

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1266,7 +1266,6 @@ hosts::production::frontend::app_hostnames:
   - 'service-manual'
   - 'service-manual-frontend'
   - 'smartanswers'
-  - 'spotlight'
   - 'static'
   - 'whitehall-frontend'
 

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -66,7 +66,6 @@ deployable_applications: &deployable_applications
   smartanswers:
     repository: 'smart-answers'
   specialist-publisher: {}
-  spotlight: {}
   stagecraft: {}
   static: {}
   support: {}

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -603,7 +603,6 @@ govuk_ci::master::pipeline_jobs:
   shared_mustache: {}
   slimmer: {}
   smokey: {}
-  spotlight-performance: {}
   transition-config: {}
   ubuntu_unused_kernels:
     repo_owner: 'gds-operations'

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -298,7 +298,6 @@ hosts::development::apps:
   - 'signon'
   - 'smartanswers'
   - 'specialist-publisher'
-  - 'spotlight'
   - 'stagecraft'
   - 'static'
   - 'support'

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -71,7 +71,6 @@ deployable_applications: &deployable_applications
   smartanswers:
     repository: 'smart-answers'
   specialist-publisher: {}
-  spotlight: {}
   stagecraft: {}
   static: {}
   support: {}

--- a/modules/govuk/manifests/apps/spotlight.pp
+++ b/modules/govuk/manifests/apps/spotlight.pp
@@ -38,6 +38,7 @@ class govuk::apps::spotlight (
 
   if $enabled {
     govuk::app { 'spotlight':
+      ensure                  => 'absent',
       alert_5xx_warning_rate  => $alert_5xx_warning_rate,
       alert_5xx_critical_rate => $alert_5xx_critical_rate,
       app_type                => 'bare',
@@ -51,6 +52,7 @@ class govuk::apps::spotlight (
     }
 
     govuk::app::envvar { "${title}-PUBLISHING_API_BEARER_TOKEN":
+      ensure  => 'absent',
       app     => 'spotlight',
       varname => 'PUBLISHING_API_BEARER_TOKEN',
       value   => $publishing_api_bearer_token,

--- a/modules/grafana/files/dashboards/processes.json
+++ b/modules/grafana/files/dashboards/processes.json
@@ -1417,11 +1417,6 @@
             "selected": false
           },
           {
-            "text": "processes-app-spotlight",
-            "value": "processes-app-spotlight",
-            "selected": false
-          },
-          {
             "text": "processes-app-stagecraft",
             "value": "processes-app-stagecraft",
             "selected": false


### PR DESCRIPTION
Remove the spotlight application from GOV.UK infrastructure. 
Since last month, [spotlight](https://github.com/alphagov/spotlight) has been moved to PaaS, where it now runs at [https://performance-platform-spotlight-production.cloudapps.digital](https://performance-platform-spotlight-production.cloudapps.digital). We now manage the deployment process so we want to get rid of this one.

This pull request ensures that spotlight is absent from the server, and a follow-up pull request -- #6705 -- removes all references to spotlight. (Hopefully I've done this right.)

Notes:
- there's some [spotlight-related stuff](https://github.com/alphagov/govuk-app-deployment/search?utf8=%E2%9C%93&q=spotlight&type=) in a repo called [`govuk-app-deployment`](https://github.com/alphagov/govuk-app-deployment/)

