### PR TITLE
Ensure Mtail service is stopped

### DIFF
--- a/modules/govuk_mtail/manifests/init.pp
+++ b/modules/govuk_mtail/manifests/init.pp
@@ -75,6 +75,7 @@ class govuk_mtail(
   }
 
   @@icinga::check { "check_mtail_up_${::hostname}":
+    ensure              => 'absent',
     check_command       => 'check_nrpe!check_proc_running!mtail',
     service_description => 'mtail not running',
     host_name           => $::fqdn,

--- a/modules/mtail/manifests/init.pp
+++ b/modules/mtail/manifests/init.pp
@@ -65,7 +65,8 @@ class mtail(
   }
 
   service { 'mtail':
-    ensure  => running,
+#    ensure  => running,
+    ensure  => stopped,
     require => [Package['mtail'], File['/etc/init.d/mtail']],
   }
 }


### PR DESCRIPTION
We are not going to continue working on Mtail for now,
there are some problems with exporting the metrics to
Graphite/Statsd. Ensure the service is stopped.