### PR TITLE
Update hiera syntax for `s_whitehall_mysql_master::encryption_key`

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -524,7 +524,7 @@ govuk::node::s_mysql_master::encryption_key: "%{hiera('govuk::node::s_mysql_back
 
 govuk::node::s_whitehall_mysql_master::aws_access_key_id: "%{hiera('govuk::node::s_mysql_backup::aws_access_key_id')}"
 govuk::node::s_whitehall_mysql_master::aws_secret_access_key: "%{hiera('govuk::node::s_mysql_backup::aws_secret_access_key')}"
-govuk::node::s_whitehall_mysql_master::encryption_key: "${hiera('govuk::node::s_mysql_backup::encryption_key')}"
+govuk::node::s_whitehall_mysql_master::encryption_key: "%{hiera('govuk::node::s_mysql_backup::encryption_key')}"
 
 govuk::node::s_transition_postgresql_slave::redirector_ip_range: 10.6.0.1/16
 govuk::node::s_transition_postgresql_standby::redirector_ip_range: "%{hiera('govuk::node::s_transition_postgresql_slave::redirector_ip_range')}"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -553,7 +553,7 @@ govuk::node::s_postgresql_primary::alert_hostname: 'alert'
 
 govuk::node::s_whitehall_mysql_master::aws_access_key_id: "%{hiera('govuk::node::s_mysql_backup::aws_access_key_id')}"
 govuk::node::s_whitehall_mysql_master::aws_secret_access_key: "%{hiera('govuk::node::s_mysql_backup::aws_secret_access_key')}"
-govuk::node::s_whitehall_mysql_master::encryption_key: "${hiera('govuk::node::s_mysql_backup::encryption_key')}"
+govuk::node::s_whitehall_mysql_master::encryption_key: "%{hiera('govuk::node::s_mysql_backup::encryption_key')}"
 
 govuk::node::s_transition_db_admin::apt_mirror_hostname: "${hiera('apt_mirror_hostname')}"
 govuk::node::s_transition_db_admin::backup_s3_bucket: "govuk-integration-rds-backups"


### PR DESCRIPTION
- Hiera should start with `%hiera{...` not `${hiera(...` otherwise it
  doesn't get expanded properly into the values.