### PR TITLE
Add PROXY_PERCENTAGE_OF_WHITEHALL_ASSET_REQUESTS_TO_S3_VIA_NGINX env var

### DIFF
--- a/modules/govuk/manifests/apps/asset_manager.pp
+++ b/modules/govuk/manifests/apps/asset_manager.pp
@@ -36,6 +36,9 @@
 # [*proxy_percentage_of_asset_requests_to_s3_via_nginx*]
 #   Value between 0 and 100 controlling the percentage of traffic that should
 #   be served by proxying the asset from S3
+# [*proxy_percentage_of_whitehall_asset_requests_to_s3_via_nginx*]
+#   Value between 0 and 100 controlling the percentage of traffic that should
+#   be served by proxying the Whitehall asset from S3
 # [*redis_host*]
 #   Redis host for Sidekiq.
 #   Default: undef
@@ -58,6 +61,7 @@ class govuk::apps::asset_manager(
   $aws_access_key_id = undef,
   $aws_secret_access_key = undef,
   $proxy_percentage_of_asset_requests_to_s3_via_nginx = '0',
+  $proxy_percentage_of_whitehall_asset_requests_to_s3_via_nginx = '0',
   $redis_host = undef,
   $redis_port = undef
 ) {
@@ -245,6 +249,15 @@ class govuk::apps::asset_manager(
       "${title}-PROXY_PERCENTAGE_OF_ASSET_REQUESTS_TO_S3_VIA_NGINX":
         varname => 'PROXY_PERCENTAGE_OF_ASSET_REQUESTS_TO_S3_VIA_NGINX',
         value   => $proxy_percentage_of_asset_requests_to_s3_via_nginx;
+    }
+
+    # Write the environment variable to configure the percentage of Whitehall
+    # asset requests that should be served by proxying the request to S3 via
+    # nginx
+    govuk::app::envvar {
+      "${title}-PROXY_PERCENTAGE_OF_WHITEHALL_ASSET_REQUESTS_TO_S3_VIA_NGINX":
+        varname => 'PROXY_PERCENTAGE_OF_WHITEHALL_ASSET_REQUESTS_TO_S3_VIA_NGINX',
+        value   => $proxy_percentage_of_whitehall_asset_requests_to_s3_via_nginx;
     }
   }
 }


### PR DESCRIPTION
This complements the change made to Asset Manager [in PR 263][1].

[1]: https://github.com/alphagov/asset-manager/pull/263