### PR TITLE
Reduce graphite backup retention period

### DIFF
--- a/modules/govuk/files/usr/local/bin/govuk_backup_graphite_whisper_files
+++ b/modules/govuk/files/usr/local/bin/govuk_backup_graphite_whisper_files
@@ -2,7 +2,7 @@
 
 TIMESTAMP=`date +%Y-%m-%d_%Hh%Mm.%A`
 
-DAYS_TO_KEEP="2"
+DAYS_TO_KEEP="1"
 
 GRAPHITE_STORAGE_DIRECTORY="/opt/graphite/storage"
 GRAPHITE_WHISPER_DIRECTORY_NAME="whisper"
@@ -34,7 +34,7 @@ else
   exit 1
 fi
 
-# Remove any backups older than 7 days
+# Remove any backups older than 1 days
 find ${BACKUP_DIRECTORY} -type f -name "*.${BACKUP_FILE_NAME_EXTENSION}" -mtime ${DAYS_TO_KEEP} | xargs -xi rm {}
 
 # Backup Whisper files


### PR DESCRIPTION
There is only space on the machines for 2 days of backup and depending on when this script runs occasionally we end up with 3 backups which then alerts.

This PR reduces the retention period to 1 day which should fix it.