### PR TITLE
Remove big-screen-view from GOV.UK infrastructure

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -49,7 +49,6 @@ deployable_applications: &deployable_applications
   mapit: {}
   maslow: {}
   performanceplatform-admin: {}
-  performanceplatform-big-screen-view: {}
   policy-publisher: {}
   publisher: {}
   publishing-api: {}

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1259,7 +1259,6 @@ hosts::production::frontend::app_hostnames:
   - 'info-frontend'
   - 'manuals-frontend'
   - 'licencefinder'
-  - 'performanceplatform-big-screen-view'
   - 'publicapi'
   - 'public-event-store'
   - 'service-manual'

--- a/modules/govuk/manifests/apps/performanceplatform_big_screen_view.pp
+++ b/modules/govuk/manifests/apps/performanceplatform_big_screen_view.pp
@@ -28,7 +28,7 @@ class govuk::apps::performanceplatform_big_screen_view (
       vhost_full => $vhost_full,
     }
     govuk::app::nginx_vhost { $app_name:
-      ensure          => present,
+      ensure          => 'absent',
       single_page_app => '/performance/big-screen/index.html',
       vhost           => $vhost_full,
       ssl_only        => true,
@@ -36,12 +36,13 @@ class govuk::apps::performanceplatform_big_screen_view (
     }
     # Since this is not a full app, we need to ensure env dir exists.
     file { ["/etc/govuk/${app_name}", "/etc/govuk/${app_name}/env.d"]:
-      ensure  => 'directory',
+      ensure  => 'absent',
       purge   => true,
       recurse => true,
       force   => true,
     }
     govuk::app::envvar { "${app_name}-PUBLISHING_API_BEARER_TOKEN":
+      ensure         => 'absent',
       app            => $app_name,
       varname        => 'PUBLISHING_API_BEARER_TOKEN',
       value          => $publishing_api_bearer_token,


### PR DESCRIPTION
Remove the big-screen-view application from GOV.UK infrastructure.
Since last month, [big-screen-view](https://github.com/alphagov/performanceplatform-big-screen-view) has been moved to PaaS, where it now runs at https://performance-platform-big-screen-view-production.cloudapps.digital ([example with a real service](https://performance-platform-big-screen-view-production.cloudapps.digital/performance/big-screen/hmrc-customs)).

This pull request ensures that big-screen-view is absent from the server, and a follow-up pull request -- #6714 -- removes all references to big-screen-view. 