### PR TITLE
Add rorymacdonald user to integration environment

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -316,6 +316,7 @@ users::usernames:
   - peterhartshorn
   - philippotter
   - richardboulton
+  - rorymacdonald
   - rosafox
   - rubenarakelyan
   - sebashton


### PR DESCRIPTION
Previously opened a PR to create my user #6701, but missed adding to the integration environment. This should resolve this. 