### PR TITLE
Remove performanceplatform-admin from GOV.UK infrastructure

### DIFF
--- a/development-vm/Pinfile
+++ b/development-vm/Pinfile
@@ -46,7 +46,6 @@ process :'manuals-frontend' => [:static, :'content-store']
 process :'manuals-publisher' => ['asset-manager', :rummager, :'publishing-api']
 process :mapit
 process :maslow
-process :'performanceplatform-admin' => [:stagecraft]
 process :'policy-publisher' => [:'publishing-api', :rummager]
 process :publisher => [:'publishing-api', 'publisher-worker', :calendars] # for some requests also uses: mapit
 process :'publishing-api-read' => [:'publishing-api-web']

--- a/development-vm/Procfile
+++ b/development-vm/Procfile
@@ -108,7 +108,7 @@ draft-content-store:   govuk_setenv draft-content-store   ./run_in.sh ../../cont
 backdrop_read:                                            ./run_in.sh ../../backdrop ./start-app.sh read 3101
 backdrop_write:                                           ./run_in.sh ../../backdrop ./start-app.sh write 3102
 stagecraft:                                               ./run_in.sh ../../stagecraft ./start-app.sh 3103
-admin:                                                    ./run_in.sh ../../performanceplatform-admin ./start-app.sh 3104
+# performanceplatform-admin used port 3104
 # datainsight-everything-recorder used port 3105
 # datainsight-insidegov-recorder used port 3106
 authenticating-proxy:  govuk_setenv authenticating-proxy  ./run_in.sh ../../authenticating-proxy bundle exec rails server -p 3107

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1124,7 +1124,6 @@ hosts::production::backend::app_hostnames:
   - 'local-links-manager'
   - 'maslow'
   - 'manuals-publisher'
-  - 'performanceplatform-admin'
   - 'policy-publisher'
   - 'publisher'
   - 'publishing-api'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -48,7 +48,6 @@ deployable_applications: &deployable_applications
   manuals-publisher: {}
   mapit: {}
   maslow: {}
-  performanceplatform-admin: {}
   policy-publisher: {}
   publisher: {}
   publishing-api: {}

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -278,7 +278,6 @@ hosts::development::apps:
   - 'manuals-publisher'
   - 'mapit'
   - 'maslow'
-  - 'performanceplatform-admin'
   - 'policy-publisher'
   - 'publicapi'
   - 'public-event-store'

--- a/modules/govuk/manifests/apps/performanceplatform_admin.pp
+++ b/modules/govuk/manifests/apps/performanceplatform_admin.pp
@@ -17,6 +17,7 @@ class govuk::apps::performanceplatform_admin (
     ensure_packages(['libffi-dev'])
 
     govuk::app { 'performanceplatform-admin':
+      ensure             => 'absent',
       app_type           => 'bare',
       port               => $port,
       command            => "./venv/bin/gunicorn application:app --bind 127.0.0.1:${port} --workers 4",

--- a/modules/govuk/manifests/node/s_backend_lb.pp
+++ b/modules/govuk/manifests/node/s_backend_lb.pp
@@ -98,13 +98,6 @@ class govuk::node::s_backend_lb (
     servers      => $backend_servers,
   }
 
-  if !empty($performance_backend_servers) {
-    loadbalancer::balance { 'performanceplatform-admin':
-      servers       => $performance_backend_servers,
-      internal_only => false,
-    }
-  }
-
   nginx::config::vhost::redirect { "backdrop-admin.${app_domain}" :
     to => "https://admin.${perfplat_public_app_domain}/",
   }

--- a/modules/grafana/files/dashboards/processes.json
+++ b/modules/grafana/files/dashboards/processes.json
@@ -1332,11 +1332,6 @@
             "selected": false
           },
           {
-            "text": "processes-app-performanceplatform-admin",
-            "value": "processes-app-performanceplatform-admin",
-            "selected": false
-          },
-          {
             "text": "processes-app-policy-publisher",
             "value": "processes-app-policy-publisher",
             "selected": false


### PR DESCRIPTION
Remove the performanceplatform-admin application from GOV.UK infrastructure.
Since last month, [performanceplatform-admin](https://github.com/alphagov/performanceplatform-admin) has been moved to PaaS, where it now runs at https://performance-platform-admin-production.cloudapps.digital.

This pull request ensures that big-screen-view is absent from the server, and a follow-up pull request -- (TBA) -- removes all references to performanceplatform-admin. 