### PR TITLE
Serve whitehall organisation logos from asset manager

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1475,6 +1475,7 @@ router::assets_origin::asset_routes:
   '/government/assets/': "whitehall-frontend"
   '/government/placeholder': "whitehall-frontend"
   '/government/uploads/': "whitehall-frontend"
+  '/government/uploads/system/uploads/organisation/logo/': "static"
   '/government-frontend/': "government-frontend"
   '/info-frontend/': "info-frontend"
   '/manuals-frontend/': "manuals-frontend"

--- a/modules/govuk/templates/static_extra_nginx_config.conf.erb
+++ b/modules/govuk/templates/static_extra_nginx_config.conf.erb
@@ -16,30 +16,22 @@ location /robots.txt {
   expires 1w;
 }
 
-location ~ ^/media/ {
-  proxy_set_header Host <%= @asset_manager_host %>;
-  proxy_set_header X-Real-IP $remote_addr;
-  proxy_set_header X-Forwarded-Server $host;
-  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-  proxy_set_header X-Forwarded-Host $host;
-  proxy_pass <%= @enable_ssl ? 'https' : 'http' %>://<%= @asset_manager_host %>;
+<% [
+  '/media/',
+  '/government/uploads/system/uploads/organisation/logo/'
+].each do |path_to_be_proxied_to_asset_manager| %>
 
-  # Explicitly re-include Strict-Transport-Security header, this
-  # forces nginx not to clear Cache-Control headers further up the
-  # stack.
-  include /etc/nginx/add-sts.conf;
-}
+  location ~ ^<%= path_to_be_proxied_to_asset_manager %> {
+    proxy_set_header Host <%= @asset_manager_host %>;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-Server $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Host $host;
+    proxy_pass <%= @enable_ssl ? 'https' : 'http' %>://<%= @asset_manager_host %>;
 
-location ~ ^/government/uploads/system/uploads/organisation/logo/ {
-  proxy_set_header Host <%= @asset_manager_host %>;
-  proxy_set_header X-Real-IP $remote_addr;
-  proxy_set_header X-Forwarded-Server $host;
-  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-  proxy_set_header X-Forwarded-Host $host;
-  proxy_pass <%= @enable_ssl ? 'https' : 'http' %>://<%= @asset_manager_host %>;
-
-  # Explicitly re-include Strict-Transport-Security header, this
-  # forces nginx not to clear Cache-Control headers further up the
-  # stack.
-  include /etc/nginx/add-sts.conf;
-}
+    # Explicitly re-include Strict-Transport-Security header, this
+    # forces nginx not to clear Cache-Control headers further up the
+    # stack.
+    include /etc/nginx/add-sts.conf;
+  }
+<% end %>

--- a/modules/govuk/templates/static_extra_nginx_config.conf.erb
+++ b/modules/govuk/templates/static_extra_nginx_config.conf.erb
@@ -29,3 +29,17 @@ location ~ ^/media/ {
   # stack.
   include /etc/nginx/add-sts.conf;
 }
+
+location ~ ^/government/uploads/system/uploads/organisation/logo/ {
+  proxy_set_header Host <%= @asset_manager_host %>;
+  proxy_set_header X-Real-IP $remote_addr;
+  proxy_set_header X-Forwarded-Server $host;
+  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  proxy_set_header X-Forwarded-Host $host;
+  proxy_pass <%= @enable_ssl ? 'https' : 'http' %>://<%= @asset_manager_host %>;
+
+  # Explicitly re-include Strict-Transport-Security header, this
+  # forces nginx not to clear Cache-Control headers further up the
+  # stack.
+  include /etc/nginx/add-sts.conf;
+}


### PR DESCRIPTION
__NOTE.__ This can't be merged until the following dependencies have been deployed:

* [Upload all existing Whitehall organisation logos to Asset Manager](https://github.com/alphagov/asset-manager/issues/276)
  * Merging this change first would result in 404s for organisation logos that don't yet exist on Asset Manager.
* [Configure Asset Manager to serve Whitehall assets from S3](https://github.com/alphagov/asset-manager/issues/283)
  * Merging this PR first would mean we'd invalidate the caches of existing Whitehall organisation logos. While this isn't a big deal in the case of organisations (because there are so few of them) it would potentially cause us problems when migrating a larger group of assets.

---

This routes requests for Whitehall organisations logos to Asset Manager instead of to Whitehall. See [this milestone](https://github.com/alphagov/asset-manager/milestone/9) for more info.

The change to `common.yaml` results in a new `location` block being added to the `assets-origin` Nginx config to proxy the request to `static`.

The change to `static_extra_nginx_config.conf.erb` adds a `location` block to proxy the request to `asset-manager`. The additional configuration is a duplication of the configuration required to proxy requests for `/media` to `static` in the same file. I plan to DRY this duplication up in a subsequent commit.

Requests for organisation logos were previously being proxied from `assets-origin` to `whitehall-frontend` by the `/government/uploads` location configured in `hierdata/common.yaml`.

I've tested the effect of this change on my development VM and am confident that it's working as expected. I saw the following differences in response headers but I don't think we need to worry about any of them:

* Cache-Control
  * `max-age=14400, public` from Whitehall
  * `private` from Asset Manager
  * This is expected because I'm running Asset Manager in development mode. It'll add the correct `Cache-Control` headers in production.

* Last-Modified
  * `Wed, 25 Oct 2017 15:01:08 GMT` from Whitehall
  * `Wed, 25 Oct 2017 15:00:34 GMT` from Asset Manager
  * This is expected because this was a new image uploaded to Whitehall which was then sent to Asset Manager so it'll have been written to the two different places on disk at different times.

* ETag
  * `"59f0a734-13767"` from Whitehall
  * `"59f0a712-13767"` from Asset Manager
  * This is expected because this was a new image uploaded to Whitehall which was then sent to Asset Manager. Part of this etag is based on the Last Modified time which, as explained above, is also different.

* Strict-Transport-Security
  * Not present from Whitehall
  * `max-age=31536000` from Asset Manager
  * This is added by the `location` block in the static nginx configuration.
  * It seems fine to add this header given that we want to encourage browsers to always access this site over HTTPS.
