### PR TITLE
Add number of Sentry errors to the 2nd line dashboard

### DIFF
--- a/modules/grafana/templates/dashboards/2ndline_health.json.erb
+++ b/modules/grafana/templates/dashboards/2ndline_health.json.erb
@@ -491,6 +491,81 @@
             "thresholdMarkers": true,
             "thresholdLabels": false
           }
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": true,
+          "colors": [
+            "rgba(50, 172, 45, 0.97)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(245, 54, 54, 0.9)"
+          ],
+          "datasource": "Graphite",
+          "editable": true,
+          "error": false,
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "height": "250",
+          "id": 13,
+          "interval": null,
+          "links": [
+            {
+              "dashboard": "origin_health.json",
+              "name": "Drilldown dashboard",
+              "title": "Sentry dashboard",
+              "type": "absolute",
+              "url": "/dashboard/db/sentry-errors"
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "null as zero",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "80%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 4,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "hide": false,
+              "refId": "A",
+              "target": "sumSeries(stats.gauges.sentry-error-count-last-hour.*)",
+              "textEditor": true
+            }
+          ],
+          "thresholds": "100,1000",
+          "title": "Sentry errors in the last hour",
+          "type": "singlestat",
+          "valueFontSize": "200%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
         }
       ],
       "showTitle": false,


### PR DESCRIPTION
This adds a metric with the number of errors reported in Sentry over the last hour. It gets this from
`stats.gauges.sentry-error-count-last-hour.(appname)`, which is populated every 10 minutes by this Jenkins job:

https://deploy.publishing.service.gov.uk/job/govuk-sentry-monitor

Which runs the script in this repo:

https://github.com/alphagov/govuk-sentry-monitor

The intention is that we'll some visibility on the error reporting. We started paying per-error since the move to Sentry so preventing some apps from eating up all our budget is important.

Here's what it looks like currently:

![screen shot 2017-10-27 at 14 43 59](https://user-images.githubusercontent.com/233676/32107492-a743153a-bb26-11e7-880c-0de3e4610abe.png)


https://trello.com/c/btVExJP7