### PR TITLE
Add reload class back

### DIFF
--- a/modules/govuk_jenkins/manifests/init.pp
+++ b/modules/govuk_jenkins/manifests/init.pp
@@ -99,6 +99,8 @@ class govuk_jenkins (
     home_dir     => $jenkins_homedir,
   }
 
+  include ::govuk_jenkins::reload
+
   package { 'ghtools':
     ensure   => '0.20.0',
     provider => pip,


### PR DESCRIPTION
This class was accidentally removed in ec4fa1f75a1ea2a991cedb2e8c39c2321c8d4d93. Add it back in.