### PR TITLE
Amend RDS backups

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -526,8 +526,7 @@ govuk::node::s_asset_base::firewall_allow_ip_range: "%{hiera('environment_ip_pre
 
 govuk::node::s_base::log_remote: false
 
-govuk::node::s_db_admin::apt_mirror_hostname: "${hiera('apt_mirror_hostname')}"
-govuk::node::s_db_admin::backup_s3_bucket: "govuk-integration-rds-backups"
+govuk::node::s_db_admin::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 govuk::node::s_licensify_lb::backend_app_servers:
   - 'licensing-backend'
@@ -546,8 +545,7 @@ govuk::node::s_whitehall_mysql_master::aws_access_key_id: "%{hiera('govuk::node:
 govuk::node::s_whitehall_mysql_master::aws_secret_access_key: "%{hiera('govuk::node::s_mysql_backup::aws_secret_access_key')}"
 govuk::node::s_whitehall_mysql_master::encryption_key: "%{hiera('govuk::node::s_mysql_backup::encryption_key')}"
 
-govuk::node::s_transition_db_admin::apt_mirror_hostname: "${hiera('apt_mirror_hostname')}"
-govuk::node::s_transition_db_admin::backup_s3_bucket: "govuk-integration-rds-backups"
+govuk::node::s_transition_db_admin::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 govuk::node::s_transition_postgresql_master::alert_hostname: 'alert'
 govuk::node::s_transition_postgresql_slave::redirector_ip_range: 10.6.0.1/16

--- a/modules/govuk/manifests/node/s_db_admin.pp
+++ b/modules/govuk/manifests/node/s_db_admin.pp
@@ -30,7 +30,14 @@ class govuk::node::s_db_admin(
 ) {
   include ::govuk::node::s_base
 
+  if $backup_s3_bucket {
+    $ensure = 'present'
+  } else {
+    $ensure = 'absent'
+  }
+
   apt::source { 'gof3r':
+    ensure       => $ensure,
     location     => "http://${apt_mirror_hostname}/gof3r",
     release      => $::lsbdistcodename,
     architecture => $::architecture,
@@ -38,7 +45,7 @@ class govuk::node::s_db_admin(
   }
 
   package { 'gof3r':
-    ensure  => '0.5.0',
+    ensure  => $ensure,
     require => Apt::Source['gof3r'],
   }
 
@@ -63,13 +70,14 @@ class govuk::node::s_db_admin(
   $mysql_backup_desc = 'RDS MySQL backup to S3'
 
   @@icinga::passive_check { "check_rds_mysql_s3_backup-${::hostname}":
+    ensure              => $ensure,
     service_description => $mysql_backup_desc,
     freshness_threshold => 28 * 3600,
     host_name           => $::fqdn,
   }
 
   file { '/usr/local/bin/rds-mysql-to-s3':
-    ensure  => 'present',
+    ensure  => $ensure,
     content => template('govuk/node/s_db_admin/rds-mysql-to-s3.erb'),
     owner   => 'root',
     group   => 'root',
@@ -81,6 +89,7 @@ class govuk::node::s_db_admin(
   }
 
   cron::crondotdee { 'rds-mysql-to-s3':
+    ensure  => $ensure,
     hour    => $mysql_backup_hour,
     minute  => $mysql_backup_min,
     command => '/usr/local/bin/rds-mysql-to-s3',
@@ -132,13 +141,14 @@ class govuk::node::s_db_admin(
   $postgres_backup_desc = 'RDS PostgreSQL backup to S3'
 
   @@icinga::passive_check { "check_rds_postgres_s3_backup-${::hostname}":
+    ensure              => $ensure,
     service_description => $postgres_backup_desc,
     freshness_threshold => 28 * 3600,
     host_name           => $::fqdn,
   }
 
   file { '/usr/local/bin/rds-postgres-to-s3':
-    ensure  => 'present',
+    ensure  => $ensure,
     content => template('govuk/node/s_db_admin/rds-postgres-to-s3.erb'),
     owner   => 'root',
     group   => 'root',
@@ -150,6 +160,7 @@ class govuk::node::s_db_admin(
   }
 
   cron::crondotdee { 'rds-postgres-to-s3':
+    ensure  => $ensure,
     hour    => $postgres_backup_hour,
     minute  => $postgres_backup_min,
     command => '/usr/local/bin/rds-postgres-to-s3',


### PR DESCRIPTION
This updates some logic to allow protection against Puppet errors, and removes the
placeholder bucket name in hieradata.

https://trello.com/c/F6UQeeiN/777-design-rds-replicas-and-backups