### PR TITLE
Remove elasticsearch plugin

### DIFF
--- a/modules/govuk_elasticsearch/manifests/plugins.pp
+++ b/modules/govuk_elasticsearch/manifests/plugins.pp
@@ -43,13 +43,6 @@ class govuk_elasticsearch::plugins (
       module_dir => 'head',
       instances  => $::fqdn,
     }
-
-    elasticsearch::plugin { 'elasticsearch-migration':
-      module_dir => 'elasticsearch-migration',
-      url        => 'https://github.com/elastic/elasticsearch-migration/releases/download/v2.0.4/elasticsearch-migration-2.0.4.zip',
-      instances  => $::fqdn,
-    }
-
   }
   # If the version is 5.0 or newer, then install the two plugins it got split into:
   # https://www.elastic.co/guide/en/elasticsearch/plugins/5.0/cloud-aws.html


### PR DESCRIPTION
When run on integration, this gives " ERROR: failed to download out of
all possible locations..., use --verbose to get detailed information"
and changing the `module_dir` to match how we had it previously
didn't make a difference.

I'm not sure what the puppet provider is doing, as it works fine
from the CLI with the same URL.

I'm just going to remove this for now as it's not important right now and
I can install through the CLI on integration anyway.