### PR TITLE
Remove stagecraft rabbit user permissions

### DIFF
--- a/modules/govuk/manifests/apps/stagecraft/rabbitmq.pp
+++ b/modules/govuk/manifests/apps/stagecraft/rabbitmq.pp
@@ -39,14 +39,4 @@ class govuk::apps::stagecraft::rabbitmq (
     admin    => false,
     password => $amqp_pass,
   }
-
-  rabbitmq_user_permissions { "${amqp_user}@/${amqp_vhost}":
-    configure_permission => '.*',
-    read_permission      => '.*',
-    write_permission     => '.*',
-  }
-
-  rabbitmq_user_permissions { "${govuk_rabbitmq::monitoring_user}@/${amqp_vhost}":
-    read_permission      => '.*',
-  }
 }


### PR DESCRIPTION
The stagecraft rabbit mq user is `ensure => absent` so the permission config is now causing puppet run errors.

This commit removes the offending lines to allow puppet to run successfully.