### PR TITLE
Remove the @fields prefix from Imminence logs

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -819,6 +819,8 @@ grafana::dashboards::deployment_applications:
     # Missing @fields.status
     show_controller_errors: false
   imminence:
+    # logstasher >1.x
+    fields_prefix: ''
     has_workers: true
   info-frontend: {}
   licencefinder:


### PR DESCRIPTION
Logstasher is at 1.2.1 so isn't using the @fields prefix in its logs any more.