### PR TITLE
Fix the Sidekiq Grafana dashboard

### DIFF
--- a/modules/grafana/files/dashboards/sidekiq.json
+++ b/modules/grafana/files/dashboards/sidekiq.json
@@ -1,14 +1,4 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_GRAPHITE",
-      "label": "Graphite",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "graphite",
-      "pluginName": "Graphite"
-    }
-  ],
   "__requires": [
     {
       "type": "grafana",
@@ -49,7 +39,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_GRAPHITE}",
+          "datasource": "Graphite",
           "editable": true,
           "error": false,
           "fill": 1,
@@ -139,7 +129,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_GRAPHITE}",
+          "datasource": "Graphite",
           "editable": true,
           "error": false,
           "fill": 1,
@@ -233,7 +223,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_GRAPHITE}",
+          "datasource": "Graphite",
           "editable": true,
           "error": false,
           "fill": 1,
@@ -310,7 +300,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_GRAPHITE}",
+          "datasource": "Graphite",
           "editable": true,
           "error": false,
           "fill": 1,
@@ -399,7 +389,7 @@
       {
         "allValue": "*",
         "current": {},
-        "datasource": "${DS_GRAPHITE}",
+        "datasource": "Graphite",
         "hide": 0,
         "includeAll": false,
         "label": null,
@@ -419,7 +409,7 @@
       {
         "allValue": "*",
         "current": {},
-        "datasource": "${DS_GRAPHITE}",
+        "datasource": "Graphite",
         "hide": 0,
         "includeAll": true,
         "label": null,


### PR DESCRIPTION
Remove the __inputs, and change the datasource to Graphite rather than
${DS_GRAPHITE}.

This appears to be a new thing with Grafana 3.1+.