### PR TITLE
Make the integration_router_data_deploy job actually do something

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/integration_router_data_deploy.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/integration_router_data_deploy.yaml.erb
@@ -9,7 +9,8 @@
           JSON="{\"parameter\": [{\"name\": \"TAG\", \"value\": \"$TAG\"}], \"\": \"\"}"
 
           # Deploy to integration environment
-          echo curl -f -XPOST https://<%= @jenkins_integration_api_user %>:<%= @jenkins_integration_api_password %>@deploy.integration.publishing.service.gov.uk/job/deploy_router_data/build --data-urlencode json="$JSON"
+          CRUMB=$(curl https://<%= @jenkins_integration_api_user %>:<%= @jenkins_integration_api_password %>@deploy.integration.publishing.service.gov.uk/crumbIssuer/api/json | jq --raw-output '. | .crumb')
+          curl -f -H "Jenkins-Crumb:$CRUMB" -XPOST https://<%= @jenkins_integration_api_user %>:<%= @jenkins_integration_api_password %>@deploy.integration.publishing.service.gov.uk/job/deploy_router_data/build --data-urlencode json="$JSON"
     wrappers:
         - ansicolor:
             colormap: xterm


### PR DESCRIPTION
When this was added in 3fa8e443ed7a6b1117adcf0429c25da338967596 the job
only `echo`ed the curl to deploy.integration rather than actually calling
it.  This means the job is a no-op and doesn't actually trigger the
deploy.  We remove the echo so it does trigger the deploy and while we're
at it we also add the CRUMB stuff added to the integration_deploy_app job
in #6585.

Noticed while working on: https://trello.com/c/ufw2S0ZX/265-create-publishing-api-redirect-for-business-finance-support-finder