### PR TITLE
Remove performance_frontend_* references

### DIFF
--- a/modules/govuk/manifests/node/s_frontend_lb.pp
+++ b/modules/govuk/manifests/node/s_frontend_lb.pp
@@ -4,8 +4,6 @@ class govuk::node::s_frontend_lb (
   $draft_frontend_servers,
   $frontend_servers,
   $whitehall_frontend_servers,
-  $performance_frontend_apps = [],
-  $performance_frontend_servers = [],
 ){
   include govuk::node::s_base
   include loadbalancer
@@ -50,7 +48,5 @@ class govuk::node::s_frontend_lb (
       servers       => $calculators_frontend_servers;
     'whitehall-frontend':
       servers       => $whitehall_frontend_servers;
-    $performance_frontend_apps:
-      servers       => $performance_frontend_servers;
   }
 }

--- a/modules/govuk/manifests/node/s_performance_frontend.pp
+++ b/modules/govuk/manifests/node/s_performance_frontend.pp
@@ -1,8 +1,0 @@
-# == Class: govuk::node::s_performance_frontend
-#
-# Class to define machines that run the Performance Platform frontend.
-#
-class govuk::node::s_performance_frontend inherits govuk::node::s_base {
-  include nginx
-  include nodejs
-}


### PR DESCRIPTION
There are no longer any performance platform frontend apps being deployed through puppet so we should be okay to get rid of this.

We're still running backdrop so I didn't touch any of the backend stuff though.