### PR TITLE
Enable timestamps plugin for a bunch of jenkins jobs

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
@@ -78,6 +78,7 @@
     wrappers:
         - ansicolor:
             colormap: xterm
+        - timestamps
     parameters:
         - choice:
             name: JOBLIST

--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_staging.yaml.erb
@@ -91,6 +91,7 @@
     wrappers:
         - ansicolor:
             colormap: xterm
+        - timestamps
     parameters:
         - choice:
             name: JOBLIST

--- a/modules/govuk_jenkins/templates/jobs/copy_licensify_data_to_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_licensify_data_to_staging.yaml.erb
@@ -61,6 +61,7 @@
     wrappers:
         - ansicolor:
             colormap: xterm
+        - timestamps
     parameters:
         - choice:
             name: JOBLIST

--- a/modules/govuk_jenkins/templates/jobs/copy_sanitised_whitehall_database.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_sanitised_whitehall_database.yaml.erb
@@ -33,3 +33,4 @@
     wrappers:
         - ansicolor:
             colormap: xterm
+        - timestamps

--- a/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
@@ -41,6 +41,7 @@
         - build-name:
             name: '${ENV,var="TARGET_APPLICATION"} ${ENV,var="TAG"}'
         - build-user-vars
+        - timestamps
     parameters:
         - choice:
             name: TARGET_APPLICATION

--- a/modules/govuk_jenkins/templates/jobs/run_rake_task.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/run_rake_task.yaml.erb
@@ -9,6 +9,7 @@
     wrappers:
       - ansicolor:
           colormap: xterm
+      - timestamps
     parameters:
       - choice:
           name: TARGET_APPLICATION

--- a/modules/govuk_jenkins/templates/jobs/run_whitehall_data_migrations.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/run_whitehall_data_migrations.yaml.erb
@@ -10,3 +10,4 @@
     wrappers:
         - ansicolor:
             colormap: xterm
+        - timestamps


### PR DESCRIPTION
This plugin is already used for deploy_puppet.
It shows timestamps next to output lines so you know when stuff happened.

This is useful for long running jobs to get an idea of how long parts of it take.