### PR TITLE
Remove postgresql-api job from Jenkins

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/copy_data_from_integration_to_aws.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_from_integration_to_aws.yaml.erb
@@ -85,6 +85,5 @@
                 - mongo-router
                 - mysql-normal
                 - mysql-whitehall
-                - postgresql-api
                 - postgresql-backend
                 - postgresql-transition

--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
@@ -93,6 +93,5 @@
                 - mongo-router
                 - mysql-normal
                 - mysql-whitehall
-                - postgresql-api
                 - postgresql-backend
                 - postgresql-transition

--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_staging.yaml.erb
@@ -107,6 +107,5 @@
                 - mongo-router
                 - mysql-normal
                 - mysql-whitehall
-                - postgresql-api
                 - postgresql-backend
                 - postgresql-transition


### PR DESCRIPTION
As per https://github.com/alphagov/env-sync-and-backup/pull/33/, the user
will no longer be able to choose the option to copy data from 
`postgresql-api`. 

We are removing this option from all the jenkins jobs (integration, 
staging and AWS)