### PR TITLE
Update to mysql-replica

### DIFF
--- a/hieradata_aws/class/frontend.yaml
+++ b/hieradata_aws/class/frontend.yaml
@@ -12,7 +12,7 @@ govuk::node::s_base::apps:
   - service_manual_frontend
   - static
 
-govuk::apps::contacts::db_hostname: 'mysql-slave-1'
+govuk::apps::contacts::db_hostname: 'mysql-replica'
 govuk::apps::contacts::db_username: 'contacts_fe'
 govuk::apps::contacts::db_password: "%{hiera('govuk::apps::contacts::db::mysql_contacts_frontend')}"
 


### PR DESCRIPTION
We're using an RDS read replica which resolves to "mysql-replica".

This appears to be the only application that uses a MySQL slave to read from.

https://trello.com/c/F6UQeeiN/777-design-rds-replicas-and-backups