### PR TITLE
Automate Puppet deploys to AWS

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/integration_puppet_deploy.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/integration_puppet_deploy.yaml.erb
@@ -8,9 +8,16 @@
       - shell: |
           JSON="{\"parameter\": [{\"name\": \"TAG\", \"value\": \"$TAG\"}], \"\": \"\"}"
 
+          # Deploy to Integration environment
           CRUMB=$(curl https://<%= @jenkins_integration_api_user %>:<%= @jenkins_integration_api_password %>@deploy.integration.publishing.service.gov.uk/crumbIssuer/api/json | jq --raw-output '. | .crumb')
 
           curl -f -H "Jenkins-Crumb:$CRUMB" -XPOST https://<%= @jenkins_integration_api_user %>:<%= @jenkins_integration_api_password %>@deploy.integration.publishing.service.gov.uk/job/Deploy_Puppet/build -d token=<%= @puppet_auth_token %> --data-urlencode json="$JSON"
+
+          # Deploy to AWS Integration environment
+          CRUMB=$(curl https://<%= @jenkins_integration_aws_api_user %>:<%= @jenkins_integration_aws_api_password %>@<%= @aws_deploy_url %>/crumbIssuer/api/json | jq --raw-output '. | .crumb')
+
+          curl -f -H "Jenkins-Crumb:$CRUMB" -XPOST https://<%= @jenkins_integration_aws_api_user %>:<%= @jenkins_integration_aws_api_password %>@<%= @aws_deploy_url %>/job/Deploy_Puppet/build -d token=<%= @puppet_auth_token %> --data-urlencode json="$JSON"
+
     wrappers:
         - ansicolor:
             colormap: xterm


### PR DESCRIPTION
I feel like the time has come to automatically deploy changes on Puppet to AWS.

This starts to get us in line when thinking about the migration.