### PR TITLE
Remove unused FASTLY_OTP from Fastly job

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_cdn.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_cdn.yaml.erb
@@ -61,7 +61,3 @@
         - password:
             name: FASTLY_PASS
             default: false
-        - string:
-            name: FASTLY_OTP
-            description: A six digit two-factor authentication code
-            default: false


### PR DESCRIPTION
This was part of a feature that was never implemented: https://github.com/alphagov/fastly-configure/pull/13.

Removing it because it is confusing.