### PR TITLE
AWS add lb functions to Nginx upstream templates

### DIFF
--- a/modules/govuk/manifests/app/nginx_vhost.pp
+++ b/modules/govuk/manifests/app/nginx_vhost.pp
@@ -28,6 +28,9 @@
 # [*deny_framing*]
 #   Boolean, whether nginx should instruct browsers to not allow framing the page
 #
+# [*deny_crawlers*]
+#   Boolean, whether nginx should serve robots.txt
+#
 # [*is_default_vhost*]
 #   Boolean, whether to set `default_server` in nginx
 #
@@ -68,6 +71,7 @@ define govuk::app::nginx_vhost (
   $ssl_only = false,
   $nginx_extra_config = '',
   $deny_framing = false,
+  $deny_crawlers = false,
   $is_default_vhost = false,
   $asset_pipeline = false,
   $asset_pipeline_prefix = 'assets',
@@ -103,6 +107,7 @@ define govuk::app::nginx_vhost (
     ssl_only                       => $ssl_only,
     extra_config                   => $nginx_extra_config_real,
     deny_framing                   => $deny_framing,
+    deny_crawlers                  => $deny_crawlers,
     is_default_vhost               => $is_default_vhost,
     hidden_paths                   => $hidden_paths,
     single_page_app                => $single_page_app,

--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -210,6 +210,7 @@ class govuk::apps::whitehall(
       protected             => $vhost_protected,
       protected_location    => '/government/admin/fact_check_requests/',
       deny_framing          => true,
+      deny_crawlers         => true,
       asset_pipeline        => true,
       asset_pipeline_prefix => 'government/assets',
       hidden_paths          => [$health_check_path],
@@ -293,7 +294,8 @@ class govuk::apps::whitehall(
     }
 
     nginx::config::vhost::static { "draft-whitehall-frontend.${app_domain}":
-      locations => {'/government/uploads' => '/data/uploads/whitehall/clean'},
+      locations     => {'/government/uploads' => '/data/uploads/whitehall/clean'},
+      deny_crawlers => true,
     }
 
     @filebeat::prospector { 'whitehall_scheduled_publishing_json_log':

--- a/modules/nginx/manifests/config/vhost/proxy.pp
+++ b/modules/nginx/manifests/config/vhost/proxy.pp
@@ -69,6 +69,10 @@
 # [*http_host*]
 #   The HTTP `Host` header. Defaults to the HTTP host.
 #
+# [*deny_crawlers*]
+#   Boolean, whether Nginx should serve a robots.txt that
+#   prevents crawlers from indexing the thing being proxied.
+#
 define nginx::config::vhost::proxy(
   $to,
   $to_ssl = false,
@@ -90,6 +94,7 @@ define nginx::config::vhost::proxy(
   $alert_5xx_critical_rate = 0.1,
   $proxy_http_version_1_1_enabled = false,
   $http_host = undef,
+  $deny_crawlers = false,
 ) {
   validate_re($ensure, '^(absent|present)$', 'Invalid ensure value')
 

--- a/modules/nginx/manifests/config/vhost/static.pp
+++ b/modules/nginx/manifests/config/vhost/static.pp
@@ -17,6 +17,10 @@
 # [*deny_framing*]
 #   Boolean, whether nginx should instruct browsers to not allow framing the page
 #
+# [*deny_crawlers*]
+#   Boolean, whether Nginx should serve a robots.txt that
+#   prevents crawlers from indexing the thing being proxied.
+#
 # [*logstream*]
 #   Whether nginx logs should be shipped to the logging box
 #
@@ -35,6 +39,7 @@ define nginx::config::vhost::static(
   $locations = {},
   $extra_config = '',
   $deny_framing = false,
+  $deny_crawlers = false,
   $logstream = present,
   $is_default_vhost = false,
   $ssl_certtype = 'wildcard_publishing',

--- a/modules/nginx/spec/defines/nginx__config__vhost__proxy_spec.rb
+++ b/modules/nginx/spec/defines/nginx__config__vhost__proxy_spec.rb
@@ -119,6 +119,42 @@ describe 'nginx::config::vhost::proxy', :type => :define do
     end
   end
 
+  context 'if in aws' do
+    let(:title) { 'rabbit' }
+
+    let(:params) {{
+      :to            => ['a.internal'],
+    }}
+
+    let(:facts) {{
+     :aws_migration => true,
+    }}
+
+    it 'should add original lb headers and client_max_body_size' do
+      is_expected.to contain_nginx__config__site('rabbit')
+        .with_content(/proxy_set_header GOVUK-Request-Id \$govuk_request_id;/)
+        .with_content(/client_max_body_size 4g;/)
+    end
+  end
+
+  context 'if in aws and deny_crawlers set to true' do
+    let(:title) { 'rabbit' }
+
+    let(:params) {{
+      :to            => ['a.internal'],
+      :deny_crawlers => true,
+    }}
+
+    let(:facts) {{
+     :aws_migration => true,
+    }}
+
+    it 'should add location robots.txt' do
+      is_expected.to contain_nginx__config__site('rabbit')
+        .with_content(/location = \/robots.txt/)
+    end
+  end
+  
   context 'with to_ssl true' do
     let(:params) {{
       :to     => ['a.internal', 'b.internal', 'c.internal'],

--- a/modules/nginx/templates/proxy-vhost.conf
+++ b/modules/nginx/templates/proxy-vhost.conf
@@ -4,6 +4,28 @@ upstream <%= @name %>-proxy {
   <%- end -%>
 }
 
+<%- if scope.lookupvar('::aws_migration') -%>
+# Set GOVUK-Request-Id if not set
+# See http://nginx.org/en/docs/http/ngx_http_perl_module.html
+perl_modules perl/lib;
+perl_set $govuk_request_id '
+  sub {
+    my $r = shift;
+    my $current_header = $r->header_in("GOVUK-Request-Id");
+
+    if (defined $current_header && $current_header ne "") {
+      return $current_header;
+    } else {
+      my $pid = $r->variable("pid");
+      my $msec = $r->variable("msec");
+      my $remote_addr = $r->variable("remote_addr");
+      my $request_length = $r->variable("request_length");
+      return "$pid-$msec-$remote_addr-$request_length";
+    }
+  }
+';
+
+<%- end -%>
 <% if @enable_ssl and @ssl_only -%>
 server {
   server_name <%= @name %> <%= @aliases.join(" ") unless @aliases.empty? %>;
@@ -61,6 +83,10 @@ server {
   proxy_set_header X-Real-IP $remote_addr;
   proxy_set_header X-Forwarded-Server $host;
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  <%- if scope.lookupvar('::aws_migration') -%>
+  proxy_set_header GOVUK-Request-Id $govuk_request_id;
+  client_max_body_size 4g;
+  <%- end -%>
   proxy_redirect off;
   proxy_connect_timeout 1s;
   proxy_read_timeout <%= @read_timeout %>;
@@ -71,6 +97,12 @@ server {
 
   <%- if @deny_framing -%>
   add_header X-Frame-Options DENY;
+  <%- end -%>
+  <%- if scope.lookupvar('::aws_migration') and @deny_crawlers -%>
+  location = /robots.txt {
+    add_header content-type text/plain;
+    return 200 'User-agent: *\nDisallow: /';
+  }
   <%- end -%>
 
   location / {

--- a/modules/nginx/templates/static-vhost.conf
+++ b/modules/nginx/templates/static-vhost.conf
@@ -1,3 +1,25 @@
+<%- if scope.lookupvar('::aws_migration') -%>
+# Set GOVUK-Request-Id if not set
+# See http://nginx.org/en/docs/http/ngx_http_perl_module.html
+perl_modules perl/lib;
+perl_set $govuk_request_id '
+  sub {
+    my $r = shift;
+    my $current_header = $r->header_in("GOVUK-Request-Id");
+
+    if (defined $current_header && $current_header ne "") {
+      return $current_header;
+    } else {
+      my $pid = $r->variable("pid");
+      my $msec = $r->variable("msec");
+      my $remote_addr = $r->variable("remote_addr");
+      my $request_length = $r->variable("request_length");
+      return "$pid-$msec-$remote_addr-$request_length";
+    }
+  }
+';
+
+<%- end -%>
 <% if @enable_ssl -%>
 server {
   server_name <%= @name %> <%= @aliases.join(" ") unless @aliases.empty? %>;
@@ -31,6 +53,11 @@ server {
   <%- if port == 80 -%>
   listen 80<%= $is_default_vhost ? " default_server" : "" %>;
   <%- end -%>
+  <%- if scope.lookupvar('::aws_migration') -%>
+
+  proxy_set_header GOVUK-Request-Id $govuk_request_id;
+  client_max_body_size 4g;
+  <%- end -%>
 
   access_log <%= @logpath %>/<%= @access_log %> timed_combined;
   access_log <%= @logpath %>/<%= @json_access_log %> json_event;
@@ -38,6 +65,12 @@ server {
 
   <%- if @deny_framing -%>
   add_header X-Frame-Options DENY;
+  <%- end -%>
+  <%- if scope.lookupvar('::aws_migration') and @deny_crawlers -%>
+  location = /robots.txt {
+    add_header content-type text/plain;
+    return 200 'User-agent: *\nDisallow: /';
+  }
   <%- end -%>
 
   <%- @locations.each do |http_path, filesystem_path| -%>


### PR DESCRIPTION
Since removing {frontend,api,backend}-lb tiers, we're no longer setting some
specific things on the upstream instances. Ensure these are properly set.
To do this, we need to review which extra functions are added by the
{frontend,api,backend}-lb nodes, and update the Nginx templates that are deployed
on the backend and frontend machines.

In particular, {frontend,api,backend}-lb nodes implement loadbalancer::balance, that
applies modules/loadbalancer//templates/nginx_balance_no_ssl.conf.erb.
The backend and frontend node classes implement govuk::app::nginx_vhost (which
implements nginx::config::vhost::proxy). govuk::apps::whitehall also
implements nginx::config::vhost::static.

X-Frowarded-x headers don't need to be added because ELBs are already setting X-Forwarded-For,
X-Forwarded-Proto, and X-Forwarded-Port:
http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/x-forwarded-headers.html

These changes don't include how we manage the maintenance page, that might need to be
refactored on AWS.