### PR TITLE
Fix elasticsearch backup spec message

### DIFF
--- a/modules/govuk_elasticsearch/spec/classes/govuk_elasticsearch__backup_spec.rb
+++ b/modules/govuk_elasticsearch/spec/classes/govuk_elasticsearch__backup_spec.rb
@@ -39,6 +39,6 @@ describe 'govuk_elasticsearch::backup', :type => :class do
         ],
     }}
 
-    it { is_expected.to raise_error }
+    it { is_expected.to raise_error(Puppet::Error, /Must pass s3_bucket/) }
   end
 end


### PR DESCRIPTION
We were getting this:
```
WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives, since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the expectation to pass without even executing the method you are intending to call. Instead consider providing a specific error class or message. This message can be supressed by setting: `RSpec::Expectations.configuration.warn_about_potential_false_positives = false`. Called from .../modules/govuk_elasticsearch/spec/classes/govuk_elasticsearch__backup_spec.rb:42:in `block (3 levels) in <top (required)>'.
```

when other spec tests were failing.

Add an error message to the raise_error function.