### PR TITLE
Update deploy DNS job

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -135,6 +135,8 @@ govuk_jenkins::job::network_config_deploy::environments:
 
 govuk_jenkins::job::deploy_dns::gce_project_id: 'govuk-integration'
 govuk_jenkins::job::deploy_kubernetes::gce_project_id: 'govuk-integration'
+govuk_jenkins::job::deploy_dns::zones:
+  - 'dnstest.alphagov.co.uk'
 
 govuk_jenkins::job::search_benchmark::cron_schedule: '30 9 * * 1-5'
 govuk_jenkins::job::search_test_spelling_suggestions::cron_schedule: '0 10 * * 1-5'

--- a/modules/govuk_jenkins/manifests/job/deploy_dns.pp
+++ b/modules/govuk_jenkins/manifests/job/deploy_dns.pp
@@ -16,12 +16,17 @@
 # [*gce_credential_id*]
 #   Jenkins credential ID that stores the Gcloud account.
 #
+# [*zones*]
+#   An array of zones to deploy.
 #
 class govuk_jenkins::job::deploy_dns (
   $dyn_zone_id = undef,
   $gce_project_id = undef,
   $gce_credential_id = undef,
+  $zones = [],
 ) {
+
+  validate_array($zones)
 
   contain '::govuk_jenkins::packages::terraform'
 

--- a/modules/govuk_jenkins/manifests/job/deploy_dns.pp
+++ b/modules/govuk_jenkins/manifests/job/deploy_dns.pp
@@ -3,13 +3,9 @@
 # Create the Jenkins job to deploy DNS records.
 # Target platforms are:
 #      AWS Route 53
-#      Dyn
 #      Google Cloud DNS
 #
 # === Parameters
-#
-# [*dyn_customer_name*]
-#    Customer account to use for Dyn (not to be confused with the Dyn user name)
 #
 # [*dyn_zone_id*]
 #   ID of the Dyn DNS zone to upload the DNS records to.
@@ -22,7 +18,6 @@
 #
 #
 class govuk_jenkins::job::deploy_dns (
-  $dyn_customer_name = undef,
   $dyn_zone_id = undef,
   $gce_project_id = undef,
   $gce_credential_id = undef,

--- a/modules/govuk_jenkins/templates/jobs/deploy_dns.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_dns.yaml.erb
@@ -30,6 +30,8 @@
                variable: GOOGLE_CREDENTIALS
     builders:
         - shell: |
+            export GOOGLE_PROJECT=<%= @gce_project_id %>
+            export GOOGLE_REGION=europe-west1
             export DEPLOY_ENV=<%= @environment %>
             ./jenkins.sh ${ACTION}
     parameters:
@@ -56,10 +58,6 @@
             name: ROUTE53_ZONE_ID
             description: Which AWS Route53 zone to deploy to
         - string:
-            name: GOOGLE_REGION
-            description: See available zones https://cloud.google.com/compute/images/zones_diagram.svg
-            default: europe-west1
-        - string:
             name: GOOGLE_ZONE_NAME
             description: Friendly name of the DNS zone within the Google project
             default: false
@@ -67,10 +65,6 @@
             name: GOOGLE_DNS_NAME
             description: Full DNS name of the zone (i.e. foo.example.com)
             default: false
-        - string:
-            name: GOOGLE_PROJECT
-            description: The name of the Google Compute Engine project that contains the dns zone you want to interact with.
-            default: <%= @gce_project_id %>
         - choice:
             name: ACTION
             description: Choose whether to plan (default) or apply

--- a/modules/govuk_jenkins/templates/jobs/deploy_dns.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_dns.yaml.erb
@@ -54,17 +54,6 @@
             name: AWS_SECRET_ACCESS_KEY
             default: false
             description: This is required for all providers
-        - string:
-            name: ROUTE53_ZONE_ID
-            description: Which AWS Route53 zone to deploy to
-        - string:
-            name: GOOGLE_ZONE_NAME
-            description: Friendly name of the DNS zone within the Google project
-            default: false
-        - string:
-            name: GOOGLE_DNS_NAME
-            description: Full DNS name of the zone (i.e. foo.example.com)
-            default: false
         - choice:
             name: ACTION
             description: Choose whether to plan (default) or apply

--- a/modules/govuk_jenkins/templates/jobs/deploy_dns.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_dns.yaml.erb
@@ -33,6 +33,8 @@
             export GOOGLE_PROJECT=<%= @gce_project_id %>
             export GOOGLE_REGION=europe-west1
             export DEPLOY_ENV=<%= @environment %>
+
+            export ZONEFILE=$ZONE.yaml
             ./jenkins.sh ${ACTION}
     parameters:
         - choice:
@@ -40,12 +42,12 @@
             choices:
                 - PICK ONE
                 - all
-                - gce
-                - route53
-        - string:
-            name: ZONEFILE
-            default: publishing.service.gov.uk.yaml
-            description: Set the zonefile to deploy
+                - aws
+                - gcp
+        - choice:
+            name: ZONE
+            description: Choose the zone to deploy
+            choices: <%= ['-- Choose a zone'] + @zones %>
         - string:
             name: AWS_ACCESS_KEY_ID
             default: false


### PR DESCRIPTION
Update the Deploy DNS job to move in line with the changes made in [this](https://github.com/alphagov/govuk-dns/pull/37) PR.

Also requires https://github.com/alphagov/govuk-secrets/pull/102.

https://trello.com/c/nusU3o0e/800-update-govuk-dns-to-get-route-53-and-google-cloud-dns-configuration-from-config-file