### PR TITLE
Allow base packages to be removed.

### DIFF
--- a/modules/base/manifests/packages.pp
+++ b/modules/base/manifests/packages.pp
@@ -13,14 +13,18 @@
 # [*ruby_version*]
 #   Which version of the `ruby` package to install
 #
+# [*ensure_packages*]
+#   The state of the base packages. 'absent' or 'present'
+#
 class base::packages (
   $gems = {},
   $packages = [],
   $ruby_version = installed,
+  $ensure_packages = 'present',
 ) {
   validate_array($packages)
 
-  ensure_packages($packages)
+  ensure_packages($packages, { ensure => $ensure_packages })
 
   alternatives { 'editor':
     path    => '/usr/bin/vim.nox',


### PR DESCRIPTION
Allow the state of the base packages to be set. Default to present so other locations can also use ensure packages, and everything will work correctly if both use `present`