### PR TITLE
Add pseudo app to setup environment for syncing Asset Manager assets stored on S3 from production to staging & integration

### DIFF
--- a/hieradata/class/asset_master.yaml
+++ b/hieradata/class/asset_master.yaml
@@ -1,5 +1,8 @@
 ---
 
+govuk::node::s_base::apps:
+  - asset_env_sync
+
 govuk::node::s_asset_master::asset_slave_ip_ranges:
   asset_slave_1_nfs:
     from: "%{hiera('environment_ip_prefix')}.3.21"

--- a/hieradata/node/asset-master-1.backend.publishing.service.gov.uk.yaml
+++ b/hieradata/node/asset-master-1.backend.publishing.service.gov.uk.yaml
@@ -1,1 +1,2 @@
 govuk::node::s_asset_base::process_uploaded_attachments_to_s3: true
+govuk::apps::asset_env_sync::enabled: true

--- a/modules/govuk/manifests/apps/asset_env_sync.pp
+++ b/modules/govuk/manifests/apps/asset_env_sync.pp
@@ -1,0 +1,59 @@
+# class: govuk::apps::asset_env_sync
+#
+# Environment for syncing Asset Manager assets from production
+# to staging and integration.
+#
+# === Parameters
+#
+# [*aws_access_key_id*]
+#   AWS access key for a user with permission to write to the S3 bucket
+# [*aws_secret_access_key*]
+#   AWS secret key for a user with permission to write to the S3 bucket
+# [*enabled*]
+#   Determines whether the environment is made available
+#
+class govuk::apps::asset_env_sync(
+  $aws_access_key_id = undef,
+  $aws_secret_access_key = undef,
+  $enabled = false,
+) {
+
+  $app_name = 'asset-env-sync'
+
+  if $enabled {
+    package { 'awscli':
+      ensure   => 'present',
+      provider => 'pip',
+    }
+
+    # Ensure config dir exists
+    file { "/etc/govuk/${app_name}":
+      ensure  => 'directory',
+      purge   => true,
+      recurse => true,
+      force   => true,
+    }
+
+    # Ensure env dir exists
+    file { "/etc/govuk/${app_name}/env.d":
+      ensure  => 'directory',
+      purge   => true,
+      recurse => true,
+      force   => true,
+    }
+
+    Govuk::App::Envvar {
+      app => $app_name,
+      notify_service => false,
+    }
+
+    govuk::app::envvar {
+      "${title}-AWS_ACCESS_KEY_ID":
+        varname => 'AWS_ACCESS_KEY_ID',
+        value   => $aws_access_key_id;
+      "${title}-AWS_SECRET_ACCESS_KEY":
+        varname => 'AWS_SECRET_ACCESS_KEY',
+        value   => $aws_secret_access_key;
+    }
+  }
+}


### PR DESCRIPTION
The new `asset_env_sync` class declares the dependencies which the `env-sync-and-backup` project will need in order to sync Asset Manager assets from the production S3 bucket to the staging & integration S3 buckets. That project will use the AWS command line tool to do the sync operation. In order to be able to do this, it will need the credentials for the `asset-manager-production-env-sync-user` IAM user which has read access to the production S3 bucket and write access to the staging & integration S3 bcukets. These credentials are made available in the `asset-env-sync` environment in the usual way.

The new pseudo-app, `asset_env_sync` is allocated to the `asset-master-1` node in all environments (except development), but is only enabled in production, because the latter is the only environment in which the `env-sync-and-backup` project needs to execute the sync operation.

See alphagov/asset-manager#145 for more details.

@chrisroos & I tested this by deploying the branch to integration and running the "assets" job from the `env-sync-and-backup` repo against `asset-master-1` in integration while pointing it at the S3 buckets created when testing alphagov/govuk-terraform-provisioning#143. We were able to ensure that the AWS command-line tool was available and that the AWS credentials for the `govuk-assets-production-env-sync-user` were made available.

See alphagov/env-sync-and-backup#34 for the related changes to the environment syncing repo.

/cc @danielroseman, @stephenharker 