### PR TITLE
AWS remove old sshkey resources

### DIFF
--- a/modules/ssh/manifests/init.pp
+++ b/modules/ssh/manifests/init.pp
@@ -31,6 +31,11 @@ class ssh {
     require => Class['ssh::firewall'],
   }
 
+  # On AWS, make sure decommissioned host keys are purged
+  if $::aws_migration {
+    resources { 'sshkey': purge => true }
+  }
+
   # The "internally-qualified domain name" of a machine is the first two
   # components of its fully-qualified domain name. i.e. the IQDN of a machine with
   # FQDN foo-1.bar.publishing.example.com is foo-1.bar. Internal references to other


### PR DESCRIPTION
On AWS machines are created and destroyed quite often, generating
conflicting entries in the known_hosts file when IPs are reused.

The `sshkey` resource that we export and collect doesn't remove
old entries automatically from the known_hosts file, even when resources
are no longer present in PuppetDb. This change forces the resource
to be purged.