### PR TITLE
AWS remove client_max_body_size from Nginx template

### DIFF
--- a/modules/nginx/spec/defines/nginx__config__vhost__proxy_spec.rb
+++ b/modules/nginx/spec/defines/nginx__config__vhost__proxy_spec.rb
@@ -130,10 +130,9 @@ describe 'nginx::config::vhost::proxy', :type => :define do
      :aws_migration => true,
     }}
 
-    it 'should add original lb headers and client_max_body_size' do
+    it 'should add original lb headers' do
       is_expected.to contain_nginx__config__site('rabbit')
         .with_content(/proxy_set_header GOVUK-Request-Id \$govuk_request_id;/)
-        .with_content(/client_max_body_size 4g;/)
     end
   end
 

--- a/modules/nginx/templates/proxy-vhost.conf
+++ b/modules/nginx/templates/proxy-vhost.conf
@@ -85,7 +85,6 @@ server {
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   <%- if scope.lookupvar('::aws_migration') -%>
   proxy_set_header GOVUK-Request-Id $govuk_request_id;
-  client_max_body_size 4g;
   <%- end -%>
   proxy_redirect off;
   proxy_connect_timeout 1s;

--- a/modules/nginx/templates/static-vhost.conf
+++ b/modules/nginx/templates/static-vhost.conf
@@ -56,7 +56,6 @@ server {
   <%- if scope.lookupvar('::aws_migration') -%>
 
   proxy_set_header GOVUK-Request-Id $govuk_request_id;
-  client_max_body_size 4g;
   <%- end -%>
 
   access_log <%= @logpath %>/<%= @access_log %> timed_combined;


### PR DESCRIPTION
This setting doesn't make sense here, applications with higher
requirements are already setting the parameter with the
nginx_extra_config setting in govuk::app