### PR TITLE
Remove nightly off-site backup of Asset Manager assets from production NFS to S3

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -19,6 +19,7 @@ backup::assets::jobs:
     s3_multipart_chunk_size: 200
     s3_multipart_max_procs: 4
   'asset-manager-s3':
+    ensure: 'absent'
     sources: '/mnt/uploads/asset-manager'
     destination: 's3://s3-eu-west-1.amazonaws.com/govuk-offsite-backups-production/asset-manager/'
     aws_access_key_id: "%{hiera('backup::offsite::job::aws_access_key_id')}"

--- a/modules/backup/manifests/offsite/job.pp
+++ b/modules/backup/manifests/offsite/job.pp
@@ -113,13 +113,12 @@ define backup::offsite::job(
     $freshness_threshold = (4 + (7 * 24)) * 60 * 60 # one week plus 4 hours
   }
 
-  if $ensure == 'present' {
-    @@icinga::passive_check { "check_backup_offsite-${title}-${::hostname}":
-      service_description => $service_description,
-      host_name           => $::fqdn,
-      freshness_threshold => $freshness_threshold,
-      notes_url           => monitoring_docs_url(offsite-backups),
-      action_url          => "https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/#!searchin/machine.email.carrenza/${::hostname}\$20duplicity%7Csort:date",
-    }
+  @@icinga::passive_check { "check_backup_offsite-${title}-${::hostname}":
+    ensure              => $ensure,
+    service_description => $service_description,
+    host_name           => $::fqdn,
+    freshness_threshold => $freshness_threshold,
+    notes_url           => monitoring_docs_url(offsite-backups),
+    action_url          => "https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/#!searchin/machine.email.carrenza/${::hostname}\$20duplicity%7Csort:date",
   }
 }


### PR DESCRIPTION
Once we're happy that cross-site replication from the `govuk-assets-production` S3 bucket to the `govuk-assets-backup-production` S3 bucket is working OK, we should be able to remove this `asset-manager-s3` job which does a nightly backup of Asset Manager assets from NFS in production to the `govuk-offsite-backups-production` S3 bucket.

Unfortunately I haven't been able to test that specifying `ensure: 'absent'` removes the relevant resources, because this job is only declared in the production environment. However, reading the code it looks as if it should work.

We should be able to check it has worked by checking the `asset-manager-s3` entry is removed from the crontab for the `root` user on the `asset-slave-1` machine in production (see [this comment](https://github.com/alphagov/asset-manager/issues/295#issuecomment-346863418) for further details).

Similarly, we should be able to check that the "offsite backups: asset-manager-s3" check has been removed from the Icinga dashboard for the `asset-slave-1` machine in production.

Note that due to some interactive rebasing, GitHub is listing the two commits in the wrong order.

We should follow up this PR with another which removes the `asset-manager-s3` job config entirely once the changes in this PR have been applied in production.

Note that the `assets-whitehall-s3` job should stay in place until all existing Whitehall assets have been migrated to Asset Manager.

See https://github.com/alphagov/asset-manager/issues/295 for more info.