### PR TITLE
Enable Asset Manager proxying to S3 in all environments

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -398,6 +398,8 @@ govuk::apps::service_manual_publisher::db::backend_ip_range: "%{hiera('environme
 
 govuk::apps::sidekiq_monitoring::asset_manager_redis_host: "%{hiera('govuk::apps::asset_manager::redis_host')}"
 govuk::apps::sidekiq_monitoring::asset_manager_redis_port: "%{hiera('govuk::apps::asset_manager::redis_port')}"
+govuk::apps::asset_manager::proxy_percentage_of_asset_requests_to_s3_via_nginx: '100'
+govuk::apps::asset_manager::proxy_percentage_of_whitehall_asset_requests_to_s3_via_nginx: '100'
 govuk::apps::sidekiq_monitoring::content_performance_manager_redis_host: "%{hiera('govuk::apps::content_performance_manager::redis_host')}"
 govuk::apps::sidekiq_monitoring::content_performance_manager_redis_port: "%{hiera('govuk::apps::content_performance_manager::redis_port')}"
 govuk::apps::sidekiq_monitoring::content_tagger_redis_host: "%{hiera('govuk::apps::content_tagger::redis_host')}"

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -69,8 +69,6 @@ environment_ip_prefix: '10.3'
 
 govuk::apps::asset_manager::aws_s3_bucket_name: 'govuk-assets-production'
 govuk::apps::asset_manager::aws_region: 'eu-west-1'
-govuk::apps::asset_manager::proxy_percentage_of_asset_requests_to_s3_via_nginx: '100'
-govuk::apps::asset_manager::proxy_percentage_of_whitehall_asset_requests_to_s3_via_nginx: '100'
 govuk::apps::content_performance_manager::feature_auditing_allocation: false
 govuk::apps::content_performance_manager::feature_auditing_theme_filtering: false
 govuk::apps::content_store::performance_platform_big_screen_view_url: 'https://performance-platform-big-screen-view-production.cloudapps.digital'


### PR DESCRIPTION
This was enabled in production in #6432 & #6736 and has been working successfully for some time. However, we haven't been able to enable it in staging & integration, because we haven't had the nightly syncs of Asset Manager assets from the production S3 bucket to the integration & staging buckets.

Since some Whitehall assets are now served via Asset Manager and their URLs are environment-specific, not having the nightly syncs in place would've meant existing Whitehall assets wouldn't have been served successfully via Asset Manager in integration & staging.

We're planning to enable the nightly syncs shortly in the PRs mentioned in [this comment][1]. At that point, we should be able to merge & deploy the changes in this commit.

We haven't been able to enable it in development, because we felt it was too onerous to require developers to setup the relevant S3 resources just for a development environment. However, now that we've [implemented a "fake" S3 within the Rails app][2], it's safe to make this change.

See https://github.com/alphagov/asset-manager/issues/294 for details.

[1]:
https://github.com/alphagov/asset-manager/issues/145#issuecomment-342894788
[2]: https://github.com/alphagov/asset-manager/pull/267