### PR TITLE
Supply new variable to Deploy_Terraform_Project Jenkins job

### DIFF
--- a/modules/govuk_jenkins/manifests/job/deploy_terraform_project.pp
+++ b/modules/govuk_jenkins/manifests/job/deploy_terraform_project.pp
@@ -5,8 +5,12 @@
 # [*aws_account_id*]
 #   The account ID for Amazon Web Services, required by our Terraform code
 #
+# [*production_aws_account_id*]
+#   The account ID for the production AWS account
+#
 class govuk_jenkins::job::deploy_terraform_project (
   $aws_account_id = '',
+  $production_aws_account_id = '',
 ) {
 
   contain 'govuk_jenkins::packages::terraform'

--- a/modules/govuk_jenkins/templates/jobs/deploy_terraform_project.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_terraform_project.yaml.erb
@@ -33,6 +33,7 @@
                 export $ADDITIONAL_ENVIRONMENT_VARIABLES
             fi
             export TF_VAR_account_id=<%= @aws_account_id %>
+            export TF_VAR_production_aws_account_id=<%= @production_aws_account_id %>
             bundle install --path "${HOME}/bundles/${JOB_NAME}"
             bundle exec rake ${ACTION}
 


### PR DESCRIPTION
The asset-manager terraform project requires a new terraform variable, `production_aws_account_id`. This is used to grant a user in the production AWS account access to the asset S3 buckets in staging & integration environments in order to allow the assets to be synced every night. See the following issue and pull requests for details:

* https://github.com/alphagov/asset-manager/issues/145
* https://github.com/alphagov/govuk-terraform-provisioning/pull/143
* https://github.com/alphagov/govuk-puppet/pull/6763
* https://github.com/alphagov/env-sync-and-backup/pull/34

We'll need someone to add the relevant AWS account ID to the secrets for integration, staging & production against the following key:

    govuk_jenkins::job::deploy_terraform_project::production_aws_account_id

I tested this change by using the following command to provision a Jenkins box using Vagrant and adding a dummy value for the above key to `hieradata/vagrant_credentials.yaml`:

    vagrant up jenkins-1.management

I then SSH-ed onto the box and verified that the `/etc/jenkins_jobs/jobs/deploy_terraform_project.yaml` file contained the following extra line against the job.builders.shell key:

    export TF_VAR_production_aws_account_id=<dummy-value-from-hieradata>

Given that this shell script already contained an almost identical line for another Terraform variable supplied via an environment variable, I'm happy that this should work as expected.

Note that the value for production is not actually needed by the Terrform project, although it is a required variable. Thus it could be set to any non-blank value, e.g. "not-used".
