### PR TITLE
Update es_dump_restore tool

### DIFF
--- a/development-vm/Gemfile
+++ b/development-vm/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 gem "foreman", "0.75.0"
 gem "bowler", "~> 2.1.0"
 
-gem "es_dump_restore", "~> 2.2.0"
+gem "es_dump_restore", "~> 2.2.2"
 
 # rubyzip 1.1.1 - 1.1.4 have a significant performance issue.
 # Add version constraint to ensure we're not using one of the bad versions

--- a/development-vm/Gemfile.lock
+++ b/development-vm/Gemfile.lock
@@ -6,7 +6,7 @@ GEM
     dotenv (0.11.1)
       dotenv-deployment (~> 0.0.2)
     dotenv-deployment (0.0.2)
-    es_dump_restore (2.0.0)
+    es_dump_restore (2.2.2)
       httpclient
       multi_json
       progress_bar
@@ -16,14 +16,14 @@ GEM
     foreman (0.75.0)
       dotenv (~> 0.11.1)
       thor (~> 0.19.1)
-    highline (1.6.21)
-    httpclient (2.6.0.1)
-    multi_json (1.11.1)
+    highline (1.7.8)
+    httpclient (2.8.3)
+    multi_json (1.12.2)
     options (2.3.2)
-    progress_bar (1.0.3)
-      highline (~> 1.6.1)
+    progress_bar (1.1.0)
+      highline (~> 1.6)
       options (~> 2.3.0)
-    rake (10.4.2)
+    rake (12.2.1)
     rubyzip (1.1.5)
     thor (0.19.1)
 
@@ -32,6 +32,6 @@ PLATFORMS
 
 DEPENDENCIES
   bowler (~> 2.1.0)
-  es_dump_restore (~> 2.0.0)
+  es_dump_restore (~> 2.2.2)
   foreman (= 0.75.0)
   rubyzip (>= 1.1.5)

--- a/modules/govuk_elasticsearch/manifests/dump.pp
+++ b/modules/govuk_elasticsearch/manifests/dump.pp
@@ -3,7 +3,7 @@ class govuk_elasticsearch::dump (
   $run_es_dump_hour = '3',
 ) {
   package { 'es_dump_restore':
-    ensure   => '2.2.0',
+    ensure   => '2.2.2',
     provider => 'system_gem',
   }
 


### PR DESCRIPTION
This will pick up David's change here https://github.com/patientslikeme/es_dump_restore/pull/22
which should stop our env sync job from failing as much.

Trello: https://trello.com/c/8FAmik4j/311-data-sync-for-elasticsearch-its-been-failing-a-lot