### PR TITLE
Serve requests to consultation response form assets from Asset Manager

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1627,6 +1627,7 @@ router::assets_origin::asset_routes:
   '/government/placeholder': "whitehall-frontend"
   '/government/uploads/': "whitehall-frontend"
   '/government/uploads/system/uploads/organisation/logo/': "static"
+  '/government/uploads/system/uploads/consultation_response_form_data/file/': "static"
   '/government-frontend/': "government-frontend"
   '/info-frontend/': "info-frontend"
   '/manuals-frontend/': "manuals-frontend"

--- a/modules/govuk/templates/static_extra_nginx_config.conf.erb
+++ b/modules/govuk/templates/static_extra_nginx_config.conf.erb
@@ -18,7 +18,8 @@ location /robots.txt {
 
 <% [
   '/media/',
-  '/government/uploads/system/uploads/organisation/logo/'
+  '/government/uploads/system/uploads/organisation/logo/',
+  '/government/uploads/system/uploads/consultation_response_form_data/file/'
 ].each do |path_to_be_proxied_to_asset_manager| %>
 
   location ~ ^<%= path_to_be_proxied_to_asset_manager %> {


### PR DESCRIPTION
We have changed Whitehall to save consultation
response forms in Asset Manager[1] and have migrated all existing data
to Asset Manager[2].

This commit changes `nginx` to serve requests for these assets from
Asset Manager instead of Whitehall.

We made an equivalent change for Organisation logos in
17e2e1d4dbf. That commit has details about the considerations around
cache control headers which also apply here.

[1] https://github.com/alphagov/whitehall/pull/3523
[2] https://github.com/alphagov/asset-manager/issues/297#issuecomment-343971912