### PR TITLE
Enable Gor for AWS on cache-1 staging

### DIFF
--- a/hieradata/node/cache-2.router.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/cache-2.router.staging.publishing.service.gov.uk.yaml
@@ -1,0 +1,5 @@
+---
+
+router::gor::add_hosts: false
+router::gor::replay_targets:
+  'www-origin.blue.integration.govuk.digital': {}

--- a/modules/router/manifests/gor.pp
+++ b/modules/router/manifests/gor.pp
@@ -7,8 +7,13 @@
 # [*replay_targets*]
 #   Hash of targets to replay traffic against.
 #
+# [*add_hosts*]
+#   Whether to add the target IP to the hosts file or not.
+#   Default: true
+#
 class router::gor (
   $replay_targets = {},
+  $add_hosts = true
 ) {
   validate_hash($replay_targets)
 
@@ -20,15 +25,17 @@ class router::gor (
     $gor_hosts_ensure = present
   }
 
-  # These host entries prevent Gor from performing DNS lookups, which occur
-  # once for *every* request/goroutine, and can be quite overwhelming.
-  $host_defaults = {
-    'ensure'  => $gor_hosts_ensure,
-    'notify'  => 'Class[Govuk_gor]',
-    'comment' => 'Used by Gor. See comments in router::gor.',
-  }
+  if $add_hosts {
+    # These host entries prevent Gor from performing DNS lookups, which occur
+    # once for *every* request/goroutine, and can be quite overwhelming.
+    $host_defaults = {
+      'ensure'  => $gor_hosts_ensure,
+      'notify'  => 'Class[Govuk_gor]',
+      'comment' => 'Used by Gor. See comments in router::gor.',
+    }
 
-  create_resources('host', $replay_targets, $host_defaults)
+    create_resources('host', $replay_targets, $host_defaults)
+  }
 
   class { 'govuk_gor':
     args    => {


### PR DESCRIPTION
Start replaying traffic on AWS Integration from cache-2 on Staging.
Add a new parameter to router::gor to disable adding the target IP
to the hosts file for the AWS endpoint (it's behind an ELB so we need
to resolve). On Carrenza we keep the current configuration, adding the
IP to the hosts file, to avoid making DNS calls.