### PR TITLE
[DO NOT MERGE] Update hostalias in AWS for Icinga

### DIFF
--- a/modules/govuk/lib/facter/fqdn_short.rb
+++ b/modules/govuk/lib/facter/fqdn_short.rb
@@ -3,7 +3,11 @@
 Facter.add("fqdn_short") do
   setcode do
     fqdn_short = Facter.value("fqdn").dup
-    fqdn_short.gsub!(/\.publishing\.service\.gov\.uk$/, '')
+    if Facter.value(:aws_migration)
+      fqdn_short.gsub(/\..*/, '')
+    else
+      fqdn_short.gsub!(/\.publishing\.service\.gov\.uk$/, '')
+    end
 
     fqdn_short
   end

--- a/modules/icinga/manifests/client.pp
+++ b/modules/icinga/manifests/client.pp
@@ -55,14 +55,17 @@ class icinga::client (
   }
 
   if $::aws_migration {
-    # If it's in AWS, display the Puppet role and the IP address of the instance.
-    $display_name = "${::aws_migration} (${::ipaddress_eth0})"
+    # If it's in AWS, display the Puppet role and short hostname: graphite_ip-10-1-6-6
+    # Set both display_name and hostalias to the same so that ordering is correct
+    $display_name = "${::aws_migration}_${::fqdn_short}"
+    $hostalias    = $display_name
   } else {
     $display_name = $::fqdn_short
+    $hostalias    = $::fqdn
   }
 
-  @@icinga::host { $::fqdn:
-    hostalias      => $::fqdn,
+  @@icinga::host { $hostalias:
+    hostalias      => $hostalias,
     address        => $host_ipaddress,
     display_name   => $display_name,
     parents        => $parents,


### PR DESCRIPTION
The idea behind this commit is being able to sort hosts in the Icinga dashboard in alphabetical order.

Currently the display name gives us a friendly name, but because the underlying host is something like "ip-10-1-6-6.eu-west-1.compute.internal" the hosts are not sorted in a friendly manner. Sorting hosts in a friendly way makes it easy to see if all hosts of the same type are suffering from the same issue, or if it is only a single host that has a problem.

To ensure that the display_name matches the underlying host, the "hostalias" needs to be updated. This updates the full host naming within Icinga, so hosts will be reported as:

`graphite_ip-10-1-6-6`

I fully expect this change in it's current state to cause problems for the monitoring in the environment. I am not sure where to update the frequent uses of "fqdn" and "fqdn_short" that is used throughout our codebase without causing issues, but the way we currently have to use Icinga is not friendly for someone working on 2ndline.

The big drawback to this is when you click on the host, you are not presented with a hostname that you can directly push into SSH configuration. For example, it currently looks like:

![screen shot 2017-11-14 at 17 44 10](https://user-images.githubusercontent.com/5610276/32795429-876d9686-c963-11e7-862c-9293286e4d0a.png)

However, ordering looks something like this when apparently sorted by alphabetical order:

![screen shot 2017-11-14 at 17 46 18](https://user-images.githubusercontent.com/5610276/32795500-c2f64a86-c963-11e7-9ddb-43030b9979a6.png)

If I were to do 2ndline for a week, I know this is something that would annoy me, so I am looking for solutions early before we have to field a flurry of complaints.