### PR TITLE
Update parameter for transition db_password

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -468,7 +468,7 @@ govuk::apps::support_api::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::support_api::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::support_api::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 
-govuk::apps::transition::db_password: "%{hiera('govuk::apps::transition::db::password')}"
+govuk::apps::transition::db_password: "%{hiera('govuk::apps::transition::postgresql_db::password')}"
 govuk::apps::transition::db_hostname: "transition-postgresql-primary"
 govuk::apps::transition::postgresql_db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 govuk::apps::transition::redis_host: "%{hiera('sidekiq_host')}"


### PR DESCRIPTION
This was set incorrectly. For our current setup, it is set in our encrypted hieradata, but we should set it in the normal hiera so it is clearer to understand what is being set where.