### PR TITLE
Fix mongodump-to-s3 backups again

### DIFF
--- a/modules/mongodb/templates/mongodump-to-s3.erb
+++ b/modules/mongodb/templates/mongodump-to-s3.erb
@@ -48,7 +48,7 @@ if /usr/bin/mongo --quiet --eval "db.isMaster().primary === db.isMaster().me" | 
   tar -zcvf <%= @backup_dir -%>/mongodump.tgz <%= @backup_dir -%>/mongodump
 
   echo "Uploading mongodump to S3"
-  /usr/bin/aws s3 --quiet --region <%= @aws_region -%> --sse AES256 cp <%= @backup_dir -%>/mongodump.tgz s3://<%= @bucket -%>/${BUCKET_KEY}/mongodump-$(date +%F_%H%M).tgz
+  /usr/bin/aws s3 --quiet --region <%= @aws_region -%> cp --sse <%= @backup_dir -%>/mongodump.tgz s3://<%= @bucket -%>/${BUCKET_KEY}/mongodump-$(date +%F_%H%M).tgz
 
   echo "Completed successfully"
   NAGIOS_CODE=0


### PR DESCRIPTION
It appears my bugfix in 524e056d51a348667482fbccc7ca34a929b811a1 was incorrect.

I was caught out by differences between the awscli tool on my work client, and the version on the server.

The error was not related to where the argument was placed, but rather providing the encryption after the argument. Not setting the type of encryption defaults to AES256, and I have successfully tested and pushed files to an S3 bucket with this command.

I have deleted any non-encrypted backups until this is fixed.