### PR TITLE
Update Grafana dashboards for AWS

### DIFF
--- a/modules/grafana/templates/dashboards/2ndline_health.json.erb
+++ b/modules/grafana/templates/dashboards/2ndline_health.json.erb
@@ -332,7 +332,7 @@
           "targets": [
             {
               "hide": false,
-              "target": "movingAverage(asPercent(divideSeries(diffSeries(sumSeries(stats.cache-?_router.nginx_logs.www-origin.http_4xx), sumSeries(stats.cache-?_router.nginx_logs.www-origin.http_429)), sumSeries(stats.cache-?_router.nginx_logs.www-origin.http_*xx)),1), '1min')",
+              "target": "movingAverage(asPercent(divideSeries(diffSeries(sumSeries(stats.cache-*.nginx_logs.www-origin.http_4xx), sumSeries(stats.cache-*.nginx_logs.www-origin.http_429)), sumSeries(stats.cache-*.nginx_logs.www-origin.http_*xx)),1), '1min')",
               "refId": "A",
               "textEditor": true
             }
@@ -399,7 +399,7 @@
           "targets": [
             {
               "hide": false,
-              "target": "movingAverage(asPercent(divideSeries(sumSeries(stats.cache-?_router.nginx_logs.www-origin.http_5xx), sumSeries(stats.cache-?_router.nginx_logs.www-origin.http_*xx)),1), '1min')",
+              "target": "movingAverage(asPercent(divideSeries(sumSeries(stats.cache-*.nginx_logs.www-origin.http_5xx), sumSeries(stats.cache-*.nginx_logs.www-origin.http_*xx)),1), '1min')",
               "refId": "A",
               "textEditor": true
             }
@@ -466,7 +466,7 @@
           "targets": [
             {
               "hide": false,
-              "target": "movingAverage(asPercent(divideSeries(sumSeries(stats.cache-?_router.nginx_logs.www-origin.http_429), sumSeries(stats.cache-?_router.nginx_logs.www-origin.http_*xx)),1), '1min')",
+              "target": "movingAverage(asPercent(divideSeries(sumSeries(stats.cache-*.nginx_logs.www-origin.http_429), sumSeries(stats.cache-*.nginx_logs.www-origin.http_*xx)),1), '1min')",
               "refId": "A",
               "textEditor": true
             }

--- a/modules/grafana/templates/dashboards/application_health.json.erb
+++ b/modules/grafana/templates/dashboards/application_health.json.erb
@@ -83,11 +83,11 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "alias(scale(averageSeries(stats.timers.calculators-frontend-?_frontend*.nginx_logs.smartanswers_*.time_request.mean),1000),\"nginx\")",
+              "target": "alias(scale(averageSeries(stats.timers.calculators-frontend-*.nginx_logs.smartanswers_*.time_request.mean),1000),\"nginx\")",
               "refId": "A"
             },
             {
-              "target": "groupByNode(stats.timers.calculators-frontend-?_frontend*.smartanswers.time_*.mean,4,\"avg\")",
+              "target": "groupByNode(stats.timers.calculators-frontend-*.smartanswers.time_*.mean,4,\"avg\")",
               "refId": "B"
             }
           ],
@@ -187,11 +187,11 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "alias(scale(averageSeries(stats.timers.frontend-?_frontend*.nginx_logs.frontend_*.time_request.mean),1000),\"nginx\")",
+              "target": "alias(scale(averageSeries(stats.timers.frontend-*.nginx_logs.frontend_*.time_request.mean),1000),\"nginx\")",
               "refId": "A"
             },
             {
-              "target": "groupByNode(stats.timers.frontend-?_frontend.frontend*.time_*.mean,4,\"avg\")",
+              "target": "groupByNode(stats.timers.frontend-*.frontend*.time_*.mean,4,\"avg\")",
               "refId": "B"
             }
           ],
@@ -301,11 +301,11 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "alias(scale(averageSeries(stats.timers.search-?_api*.nginx_logs.rummager_*.time_request.mean),1000),\"nginx\")",
+              "target": "alias(scale(averageSeries(stats.timers.search-*.nginx_logs.rummager_*.time_request.mean),1000),\"nginx\")",
               "refId": "A"
             },
             {
-              "target": "groupByNode(stats.timers.search-?_api*.rummager.time_*.mean,4,\"avg\")",
+              "target": "groupByNode(stats.timers.search-*.rummager.time_*.mean,4,\"avg\")",
               "refId": "B"
             }
           ],
@@ -405,7 +405,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "groupByNode(stats.timers.whitehall-frontend-?_frontend*.whitehall.time_*.mean,4,\"avg\")",
+              "target": "groupByNode(stats.timers.whitehall-frontend-*.whitehall.time_*.mean,4,\"avg\")",
               "refId": "A"
             }
           ],
@@ -506,8 +506,12 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "aliasSub(groupByNode(stats.*_frontend*.nginx_logs.*_publishing_service_gov_uk.http_503,3,\"sum\"),\"_.*\",\"\")",
+              "target": "aliasSub(groupByNode(stats.{calculators,draft-email-campaign,draft,email-campaign,performance,whitehall}-frontend-*.nginx_logs.*_publishing_service_gov_uk.http_503,3,\"sum\"),\"_.*\",\"\")",
               "refId": "A"
+            },
+            {
+              "target": "aliasSub(groupByNode(stats.frontend-*.nginx_logs.*_publishing_service_gov_uk.http_503,3,\"sum\"),\"_.*\",\"\")",
+              "refId": "B"
             }
           ],
           "title": "fe HTTP 503/s",

--- a/modules/grafana/templates/dashboards/application_http_error_codes.json.erb
+++ b/modules/grafana/templates/dashboards/application_http_error_codes.json.erb
@@ -56,11 +56,11 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "groupByNode(stats.frontend-?_frontend*.nginx_logs.*.http_4xx, 3, \"sumSeries\")",
+              "target": "groupByNode(stats.frontend-*.nginx_logs.*.http_4xx, 3, \"sumSeries\")",
               "refId": "A"
             },
             {
-              "target": "groupByNode(stats.*-frontend-?_frontend*.nginx_logs.*.http_4xx, 3, \"sumSeries\")",
+              "target": "groupByNode(stats.{calculators,draft-email-campaign,draft,email-campaign,performance,whitehall}-frontend-*.nginx_logs.*.http_4xx, 3, \"sumSeries\")",
               "refId": "B"
             }
           ],
@@ -142,11 +142,11 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "groupByNode(stats.frontend-?_frontend*.nginx_logs.*.http_5xx, 3, \"sumSeries\")",
+              "target": "groupByNode(stats.frontend-*.nginx_logs.*.http_5xx, 3, \"sumSeries\")",
               "refId": "A"
             },
             {
-              "target": "groupByNode(stats.*-frontend-?_frontend*.nginx_logs.*.http_5xx, 3, \"sumSeries\")",
+              "target": "groupByNode(stats.{calculators,draft-email-campaign,draft,email-campaign,performance,whitehall}-frontend-*.nginx_logs.*.http_5xx, 3, \"sumSeries\")",
               "refId": "B"
             }
           ],

--- a/modules/grafana/templates/dashboards/origin_health.json.erb
+++ b/modules/grafana/templates/dashboards/origin_health.json.erb
@@ -84,7 +84,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "aliasSub(stats.cache-*_router.nginx_logs.www-origin.http_5xx,\".*(cache-\\d+).*\", \"\\1\")",
+              "target": "aliasSub(stats.cache-*.nginx_logs.www-origin.http_5xx,\".*(cache-\\d+).*\", \"\\1\")",
               "refId": "A"
             }
           ],
@@ -184,7 +184,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "aliasSub(movingMedian(cache-*_router.nginx.nginx_requests, '1min'),\".*(cache-\\d+).*\", \"\\1\")",
+              "target": "aliasSub(movingMedian(cache-*.nginx.nginx_requests, '1min'),\".*(cache-\\d+).*\", \"\\1\")",
               "refId": "A"
             }
           ],
@@ -284,17 +284,17 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "alias(movingAverage(asPercent(divideSeries(stats.cache-1_router.nginx_logs.www-origin.http_5xx,sum(stats.cache-1_router.nginx_logs.www-origin.http_*xx)),1), '1min'),\"cache-1\")",
+              "target": "alias(movingAverage(asPercent(divideSeries(stats.cache-1_*.nginx_logs.www-origin.http_5xx,sum(stats.cache-1_*.nginx_logs.www-origin.http_*xx)),1), '1min'),\"cache-1\")",
               "refId": "A",
               "textEditor": true
             },
             {
-              "target": "alias(movingAverage(asPercent(divideSeries(stats.cache-2_router.nginx_logs.www-origin.http_5xx,sum(stats.cache-2_router.nginx_logs.www-origin.http_*xx)),1), '1min'),\"cache-2\")",
+              "target": "alias(movingAverage(asPercent(divideSeries(stats.cache-2_*.nginx_logs.www-origin.http_5xx,sum(stats.cache-2_*.nginx_logs.www-origin.http_*xx)),1), '1min'),\"cache-2\")",
               "refId": "B",
               "textEditor": true
             },
             {
-              "target": "alias(movingAverage(asPercent(divideSeries(stats.cache-3_router.nginx_logs.www-origin.http_5xx,sum(stats.cache-3_router.nginx_logs.www-origin.http_*xx)),1), '1min'),\"cache-3\")",
+              "target": "alias(movingAverage(asPercent(divideSeries(stats.cache-3_*.nginx_logs.www-origin.http_5xx,sum(stats.cache-3_*.nginx_logs.www-origin.http_*xx)),1), '1min'),\"cache-3\")",
               "refId": "C",
               "textEditor": true
             }
@@ -405,7 +405,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "aliasSub(stats.timers.cache-*_router.nginx_logs.www-origin.time_request.mean,\".*(cache-\\d+).*\", \"\\1\")",
+              "target": "aliasSub(stats.timers.cache-*.nginx_logs.www-origin.time_request.mean,\".*(cache-\\d+).*\", \"\\1\")",
               "refId": "A"
             }
           ],
@@ -605,8 +605,12 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "maximumAbove(aliasSub(groupByNode(stats.*_frontend.nginx_logs.*_publishing_service_gov_uk.http_500,3,\"sum\"),\"_.*\",\"\"),0)",
+              "target": "maximumAbove(aliasSub(groupByNode(stats.{calculators,draft-email-campaign,draft,email-campaign,performance,whitehall}-frontend-*.nginx_logs.*_publishing_service_gov_uk.http_500,3,\"sum\"),\"_.*\",\"\"),0)",
               "refId": "A"
+            },
+            {
+              "target": "maximumAbove(aliasSub(groupByNode(stats.frontend-*.nginx_logs.*_publishing_service_gov_uk.http_500,3,\"sum\"),\"_.*\",\"\"),0)",
+              "refId": "B"
             }
           ],
           "title": "HTTP 5xx/app",

--- a/modules/grafana/templates/dashboards/publishing_api_overview.json.erb
+++ b/modules/grafana/templates/dashboards/publishing_api_overview.json.erb
@@ -831,15 +831,15 @@
           "targets": [
             {
               "refId": "A",
-              "target": "publishing-api-1_backend*.processes-app-publishing-api.ps_rss"
+              "target": "publishing-api-1_*.processes-app-publishing-api.ps_rss"
             },
             {
               "refId": "B",
-              "target": "publishing-api-2_backend*.processes-app-publishing-api.ps_rss"
+              "target": "publishing-api-2_*.processes-app-publishing-api.ps_rss"
             },
             {
               "refId": "C",
-              "target": "publishing-api-3_backend*.processes-app-publishing-api.ps_rss"
+              "target": "publishing-api-3_*.processes-app-publishing-api.ps_rss"
             }
           ],
           "timeFrom": null,

--- a/modules/grafana/templates/dashboards/whitehall_health.json.erb
+++ b/modules/grafana/templates/dashboards/whitehall_health.json.erb
@@ -57,7 +57,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "groupByNode(stats.whitehall-frontend-?_frontend*.nginx_logs.whitehall-frontend_*publishing_service_gov_uk.http_5xx,4,\"sumSeries\")",
+              "target": "groupByNode(stats.whitehall-frontend-*.nginx_logs.whitehall-frontend_*publishing_service_gov_uk.http_5xx,4,\"sumSeries\")",
               "refId": "A"
             }
           ],
@@ -129,7 +129,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "groupByNode(stats.whitehall-backend-?_backend*.nginx_logs.whitehall-admin_*publishing_service_gov_uk.http_5xx,4,\"sumSeries\")",
+              "target": "groupByNode(stats.whitehall-backend-*.nginx_logs.whitehall-admin_*publishing_service_gov_uk.http_5xx,4,\"sumSeries\")",
               "refId": "A"
             }
           ],
@@ -209,11 +209,11 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "groupByNode(whitehall-frontend-*_frontend*.nginx.nginx_connections-writing,-1,\"sum\")",
+              "target": "groupByNode(whitehall-frontend-*.nginx.nginx_connections-writing,-1,\"sum\")",
               "refId": "A"
             },
             {
-              "target": "groupByNode(whitehall-frontend-*_frontend*.nginx.nginx_requests,-1,\"sum\")",
+              "target": "groupByNode(whitehall-frontend-*.nginx.nginx_requests,-1,\"sum\")",
               "refId": "B"
             }
           ],
@@ -283,11 +283,11 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "groupByNode(whitehall-backend-*_backend*.nginx.nginx_connections-writing,-1,\"sum\")",
+              "target": "groupByNode(whitehall-backend-*.nginx.nginx_connections-writing,-1,\"sum\")",
               "refId": "A"
             },
             {
-              "target": "groupByNode(whitehall-backend-*_backend*.nginx.nginx_requests,-1,\"sum\")",
+              "target": "groupByNode(whitehall-backend-*.nginx.nginx_requests,-1,\"sum\")",
               "refId": "B"
             }
           ],
@@ -445,7 +445,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "aliasSub(groupByNode({elasticsearch,support}-?_backend*.cpu-*.cpu-user,0,\"sumSeries\"),\"_backend\",\"\")",
+              "target": "aliasSub(groupByNode({rummager-elasticsearch,elasticsearch,support}-*.cpu-*.cpu-user,0,\"sumSeries\"),\"_backend\",\"\")",
               "refId": "A"
             }
           ],


### PR DESCRIPTION
Our Grafana dashboards are using hostname regular expressions that
don't work on AWS. On Carrenza the metric fqdn is created including the
VPC name, which is not part of the AWS infrastructure (on AWS we use
`stackname_environment` as part of the metric fqdn), so the VPC part
needs to be removed from the expression.

All the `*_frontend` expressions need to be updated to explicity exclude efg
and licensing (if we use `*frontend*` we would be including efg and
licensing on the Carrenza dashboards, which is not bad but currently
are not included).