### PR TITLE
Stop commits to the local master branch

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,3 +5,8 @@
       entry: bundle exec rake lint
       language: system
       files: \.pp$
+- repo: https://github.com/pre-commit/pre-commit-hooks.git
+  sha: v0.9.5
+  hooks:
+  -  id: no-commit-to-branch
+


### PR DESCRIPTION
If you're using the pre-commit tool, and you should be, adding
this configuration stops you from committing to your local master
branch. As we do all changes in branches and PRs you'll almost never
want to change master directly.

Note: This does not stop you pushing to master from a different branch.