### PR TITLE
Revert "Merge pull request #6769" to disable Asset Manager proxying to S3 in staging & integration

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -398,8 +398,6 @@ govuk::apps::service_manual_publisher::db::backend_ip_range: "%{hiera('environme
 
 govuk::apps::sidekiq_monitoring::asset_manager_redis_host: "%{hiera('govuk::apps::asset_manager::redis_host')}"
 govuk::apps::sidekiq_monitoring::asset_manager_redis_port: "%{hiera('govuk::apps::asset_manager::redis_port')}"
-govuk::apps::asset_manager::proxy_percentage_of_asset_requests_to_s3_via_nginx: '100'
-govuk::apps::asset_manager::proxy_percentage_of_whitehall_asset_requests_to_s3_via_nginx: '100'
 govuk::apps::sidekiq_monitoring::content_performance_manager_redis_host: "%{hiera('govuk::apps::content_performance_manager::redis_host')}"
 govuk::apps::sidekiq_monitoring::content_performance_manager_redis_port: "%{hiera('govuk::apps::content_performance_manager::redis_port')}"
 govuk::apps::sidekiq_monitoring::content_tagger_redis_host: "%{hiera('govuk::apps::content_tagger::redis_host')}"

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -69,6 +69,8 @@ environment_ip_prefix: '10.3'
 
 govuk::apps::asset_manager::aws_s3_bucket_name: 'govuk-assets-production'
 govuk::apps::asset_manager::aws_region: 'eu-west-1'
+govuk::apps::asset_manager::proxy_percentage_of_asset_requests_to_s3_via_nginx: '100'
+govuk::apps::asset_manager::proxy_percentage_of_whitehall_asset_requests_to_s3_via_nginx: '100'
 govuk::apps::content_performance_manager::feature_auditing_allocation: false
 govuk::apps::content_performance_manager::feature_auditing_theme_filtering: false
 govuk::apps::content_store::performance_platform_big_screen_view_url: 'https://performance-platform-big-screen-view-production.cloudapps.digital'


### PR DESCRIPTION
It turns out that assets sync-ed from the production S3 bucket to the staging & production buckets have a different owner and therefore are not accessible by the Asset Manager.

This only affects Whitehall assets served from Asset Manager which is currently only the Organisation Logos. This is because the URLs for Mainstream assets are embedded in content in the Content Store and the data for the latter is sync-ed from production to staging & integration. This in turn means that URLs for existing Mainstream assets are always production URLs and those are working OK, because objects are not sync-ed into the production S3 bucket.

The problem also only affects existing assets; not new assets uploaded in the relevant environment.

Although the problem is small, it seems sensible to revert these changes while we come up with a fix.

This reverts commit 47797a44cc8683ea742c7653bc2a3786ba9e6a0a, reversing
changes made to 87c24a46b512e12991fd9960032bf297ef26b84c.