### PR TITLE
Add email-alert-api Notify rate env var

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -246,6 +246,7 @@ govuk::apps::email_alert_api::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::email_alert_api::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::email_alert_api::db_hostname: 'postgresql-primary-1.backend'
 govuk::apps::email_alert_api::db_password: "%{hiera('govuk::apps::email_alert_api::db::password')}"
+govuk::apps::email_alert_api::notify_rate_per_worker: 8
 
 govuk::apps::email_alert_service::rabbitmq_hosts:
   - rabbitmq-1.backend

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -36,6 +36,7 @@ govuk::apps::email_alert_api::allow_govdelivery_topic_syncing: true
 govuk::apps::email_alert_api::govdelivery_account_code: 'UKGOVUKDUP'
 govuk::apps::email_alert_api::govdelivery_hostname: 'stage-api.govdelivery.com'
 govuk::apps::email_alert_api::govdelivery_public_hostname: 'stage-public.govdelivery.com'
+govuk::apps::email_alert_api::notify_rate_per_worker: 12 
 govuk::apps::event_store::enabled: true
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
 govuk::apps::publicapi::backdrop_host: 'www.preview.performance.service.gov.uk'

--- a/modules/govuk/manifests/apps/email_alert_api.pp
+++ b/modules/govuk/manifests/apps/email_alert_api.pp
@@ -51,6 +51,10 @@
 # [*govuk_notify_api_key*]
 #   API key for integration with GOV.UK Notify for sending emails
 #
+# [*govuk_notify_rate_per_worker*]
+#   Number of requests per seconds that the notify delivery worker
+#   is allowed to make (currently 50 requests/s / 6 workers = 8 (ish)
+#
 # [*secret_key_base*]
 #   The key for Rails to use when signing/encrypting sessions.
 #
@@ -78,6 +82,7 @@ class govuk::apps::email_alert_api(
   $govdelivery_hostname = undef,
   $govdelivery_public_hostname = undef,
   $govuk_notify_api_key = undef,
+  $govuk_notify_rate_per_worker = undef,
   $secret_key_base = undef,
   $db_username = 'email-alert-api',
   $db_password = undef,
@@ -172,6 +177,9 @@ class govuk::apps::email_alert_api(
       "${title}-GOVUK_NOTIFY_API_KEY":
           varname => 'GOVUK_NOTIFY_API_KEY',
           value   => $govuk_notify_api_key;
+      "${title}-GOVUK_NOTIFY_RATE_PER_WORKER":
+          varname => 'GOVUK_NOTIFY_RATE_PER_WORKER',
+          value   => $govuk_notify_rate_per_worker;
       "${title}-SECRET_KEY_BASE":
           varname => 'SECRET_KEY_BASE',
           value   => $secret_key_base;


### PR DESCRIPTION
We need to throttle requests from email-alert-api to Notify to keep the rate under 50/s. We are implementing this with a per worker rate.

This commit adds the GOVUK_NOTIFY_RATE_PER_WORKER env var and sets it to 8 in production and staging and 12 in integration (there are 6 workers in production and 4 in integration 50/number_of_workers)