### PR TITLE
Fix worker panels on deployment dashboards

### DIFF
--- a/modules/grafana/templates/dashboards/deployment_panels/_worker_failures.json.erb
+++ b/modules/grafana/templates/dashboards/deployment_panels/_worker_failures.json.erb
@@ -50,12 +50,12 @@
   ],
   "targets": [
     {
-      "refId": "C",
+      "refId": "A",
       "target": "aliasByNode(transformNull(hitcount(stats.govuk.app.<%= @app_name %>.workers.*.failure, '5m'),0), 5 )",
       "textEditor": true
     },
     {
-      "refId": "C",
+      "refId": "B",
       "target": "aliasByNode(transformNull(hitcount(stats.govuk.app.<%= @app_name %>.workers.*.*.failure, '5m'),0), 6)",
       "textEditor": true
     }

--- a/modules/grafana/templates/dashboards/deployment_panels/_worker_successes.json.erb
+++ b/modules/grafana/templates/dashboards/deployment_panels/_worker_successes.json.erb
@@ -50,12 +50,12 @@
   ],
   "targets": [
     {
-      "refId": "D",
+      "refId": "A",
       "target": "aliasByNode(transformNull(hitcount(stats.govuk.app.<%= @app_name %>.workers.*.success, '5m'),0), 5)",
       "textEditor": true
     },
     {
-      "refId": "D",
+      "refId": "B",
       "target": "aliasByNode(transformNull(hitcount(stats.govuk.app.<%= @app_name %>.workers.*.*.success, '5m'),0), 6)",
       "textEditor": true
     }


### PR DESCRIPTION
The refIds need to be unique otherwise the latter configuration overwrites the former.
This results in some of the worker panels on dashboards not working (for example on the
[Publisher deployment dashboard](https://grafana.publishing.service.gov.uk/dashboard/file/deployment_publisher.json?refresh=5s&orgId=1)).

It appears that you can leave the the refIds out altogether, but this is not the convention used by other configuration, so we'll just use A and B.