### PR TITLE
[AWS] Create jobs that deploy all apps for a given node

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -90,10 +90,6 @@ node_class: &node_class
       - manuals-frontend
       - service-manual-frontend
       - static
-  frontend_lb:
-    apps:
-      - publicapi
-      - public-event-store
   logs_cdn:
     apps:
       - govuk-cdn-logs-monitor

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -122,6 +122,10 @@ node_class: &node_class
 govuk::node::s_base::node_apps:
   <<: *node_class
 
+govuk_jenkins::deploy_all_apps::apps_on_nodes:
+  <<: *node_class
+
+
 # If the repository name is the same as the application name
 # we don't need to explicitly declare the repository, but we
 # need to add an empty hash
@@ -615,6 +619,8 @@ govuk_htpasswd::http_username: "%{hiera('http_username')}"
 
 govuk_jenkins::packages::gcloud::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk_jenkins::packages::terraform::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+
+govuk_jenkins::deploy_all_apps::deploy_environment: "%{hiera('govuk_jenkins::job_builder::environment')}"
 
 govuk::node::s_api_redis::allowed_api_ip_range: "%{hiera('environment_ip_prefix')}.4.0/24"
 govuk::node::s_api_redis::allowed_backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"

--- a/modules/govuk/manifests/node/s_jenkins.pp
+++ b/modules/govuk/manifests/node/s_jenkins.pp
@@ -35,6 +35,10 @@ class govuk::node::s_jenkins (
 
   if $::aws_migration {
     Govuk_mount['/var/lib/jenkins'] -> Class['govuk_jenkins']
+
+    class { 'govuk_jenkins::deploy_all_apps':
+      require => Class['govuk_jenkins'],
+    }
   }
 
   # Close connection if vhost not known

--- a/modules/govuk_jenkins/manifests/deploy_all_apps.pp
+++ b/modules/govuk_jenkins/manifests/deploy_all_apps.pp
@@ -1,0 +1,61 @@
+# == Class: govuk_jenkins::deploy_all_apps
+#
+# Creates a project folder that contains all the jobs that deploy all apps on
+# specific nodes.
+#
+# === Parameters:
+#
+# [*jobs_directory*]
+#   This is where Jenkins jobs are set up.
+#
+# [*project_name*]
+#   The name of the folder that the jobs will be inside.
+#
+# [*user*]
+#   Which user Jenkins runs as.
+#
+# [*apps_on_nodes*]
+#   A hash containing the node classes, and which apps run on them.
+#
+# [*deploy_environment*]
+#   The environment to deploy to. This is important as we use it to find out
+#   what version of the application should be deployed.
+#
+class govuk_jenkins::deploy_all_apps (
+  $jobs_directory = '/var/lib/jenkins/jobs',
+  $project_name = 'Deploy_Node_Apps',
+  $user = 'jenkins',
+  $apps_on_nodes = {},
+  $deploy_environment = 'development',
+) {
+
+  $project_directory = "${jobs_directory}/${project_name}"
+
+  File {
+    owner => $user,
+    group => $user,
+  }
+
+  file { $project_directory:
+    ensure  => 'directory',
+    require => Class['::govuk_jenkins'],
+  }
+
+  file { "${project_directory}/config.xml":
+    ensure  => 'present',
+    content => template('govuk_jenkins/folder_config.xml.erb'),
+  }
+
+  file { "${project_directory}/jobs":
+    ensure  => 'directory',
+    require => File["${jobs_directory}/${project_name}"],
+    purge   => true,
+  }
+
+  $defaults = {
+    project_dir => $project_directory,
+    environment => $deploy_environment,
+  }
+
+  create_resources('govuk_jenkins::node_app_deploy', $apps_on_nodes, $defaults)
+}

--- a/modules/govuk_jenkins/manifests/node_app_deploy.pp
+++ b/modules/govuk_jenkins/manifests/node_app_deploy.pp
@@ -1,0 +1,54 @@
+# == Define: Govuk_jenkins::Node_app_deploy
+#
+# Create job configuration that triggers downstream builds of all the apps
+# on a specific node class.
+#
+# === Parameters:
+#
+# [*project_dir*]
+#   The project directory where to store all the created jobs.
+#
+# [*user*]
+#   User that Jenkins runs as.
+#
+# [*apps_to_deploy*]
+#   An array of apps to deploy for a given node.
+#
+define govuk_jenkins::node_app_deploy (
+  $project_dir,
+  $user = 'jenkins',
+  $apps = [],
+  $environment = 'development',
+) {
+
+  validate_array($apps)
+
+  # FIXME: These are apps which are only created by Puppet rather than
+  # deployed through Jenkins. They should be moved elsewhere in the future
+  # to avoid confusion.
+  $blacklist = [
+    'asset_env_sync',
+    'event-store',
+    'canary-backend',
+    'canary-frontend',
+    'publicapi',
+  ]
+
+  unless empty($apps) {
+    File {
+      owner => $user,
+      group => $user,
+    }
+
+    file { "${project_dir}/jobs/${title}":
+      ensure => 'directory',
+    }
+
+    # We need to do a hard restart when creating jobs on disk
+    file { "${project_dir}/jobs/${title}/config.xml":
+      ensure  => 'present',
+      content => template('govuk_jenkins/node_app_deploy.xml.erb'),
+      notify  => Service['jenkins'],
+    }
+  }
+}

--- a/modules/govuk_jenkins/spec/defines/govuk_jenkins__node_app_deploy_spec.rb
+++ b/modules/govuk_jenkins/spec/defines/govuk_jenkins__node_app_deploy_spec.rb
@@ -1,0 +1,20 @@
+require_relative '../../../../spec_helper'
+
+describe 'govuk_jenkins::node_app_deploy', :type => :define do
+
+  let(:title) { 'my_node_class' }
+
+  let (:default_params) {{
+    :project_dir    => '/path/to/dir',
+    :apps    => [
+      'super-furry-cat',
+    ]
+  }}
+
+  context 'with default settings' do
+    let(:params) { default_params }
+    it { should contain_file('/path/to/dir/jobs/my_node_class').with_ensure('directory') }
+
+    it { should contain_file('/path/to/dir/jobs/my_node_class/config.xml').with_content(/TARGET_APPLICATION=super-furry-cat/) }
+  end
+end

--- a/modules/govuk_jenkins/templates/folder_config.xml.erb
+++ b/modules/govuk_jenkins/templates/folder_config.xml.erb
@@ -1,0 +1,24 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<com.cloudbees.hudson.plugins.folder.Folder plugin="cloudbees-folder@6.1.2">
+  <actions/>
+  <description></description>
+  <properties/>
+  <folderViews class="com.cloudbees.hudson.plugins.folder.views.DefaultFolderViewHolder">
+    <views>
+      <hudson.model.AllView>
+        <owner class="com.cloudbees.hudson.plugins.folder.Folder" reference="../../../.."/>
+        <name>All</name>
+        <filterExecutors>false</filterExecutors>
+        <filterQueue>false</filterQueue>
+        <properties class="hudson.model.View$PropertyList"/>
+      </hudson.model.AllView>
+    </views>
+    <tabBar class="hudson.views.DefaultViewsTabBar"/>
+  </folderViews>
+  <healthMetrics>
+    <com.cloudbees.hudson.plugins.folder.health.WorstChildHealthMetric>
+      <nonRecursive>false</nonRecursive>
+    </com.cloudbees.hudson.plugins.folder.health.WorstChildHealthMetric>
+  </healthMetrics>
+  <icon class="com.cloudbees.hudson.plugins.folder.icons.StockFolderIcon"/>
+</com.cloudbees.hudson.plugins.folder.Folder>

--- a/modules/govuk_jenkins/templates/node_app_deploy.xml.erb
+++ b/modules/govuk_jenkins/templates/node_app_deploy.xml.erb
@@ -1,0 +1,43 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+  <description></description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+    <com.sonyericsson.rebuild.RebuildSettings plugin="rebuild@1.25">
+      <autoRebuild>false</autoRebuild>
+      <rebuildDisabled>false</rebuildDisabled>
+    </com.sonyericsson.rebuild.RebuildSettings>
+  </properties>
+  <scm class="hudson.scm.NullSCM"/>
+  <canRoam>true</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+    <hudson.plugins.parameterizedtrigger.TriggerBuilder plugin="parameterized-trigger@2.35.1">
+      <configs>
+        <%- @apps.each do |app| -%>
+        <%- next if @blacklist.include?(app) -%>
+        <hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig>
+          <configs>
+            <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
+              <properties>TARGET_APPLICATION=<%= app %>
+DEPLOY_TASK=deploy:without_migrations
+TAG=deployed-to-<%= @environment -%></properties>
+            </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
+          </configs>
+          <projects>Deploy_App</projects>
+          <condition>ALWAYS</condition>
+          <triggerWithNoParameters>false</triggerWithNoParameters>
+          <triggerFromChildProjects>false</triggerFromChildProjects>
+          <buildAllNodesWithLabel>false</buildAllNodesWithLabel>
+        </hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig>
+        <%- end -%>
+      </configs>
+    </hudson.plugins.parameterizedtrigger.TriggerBuilder>
+  </builders>
+  <publishers/>
+  <buildWrappers/>
+</project>


### PR DESCRIPTION
This is to allow easy deployment of all apps for a given node class. The context behind this is that if a node goes away in AWS, it will be rebuilt by the autoscaling group. If this occurs, then the applications will not be automatically deployed, and having to log in to deploy them all is problematic to do by hand.

This is a very short term solution that creates jobs for each type of node class, that triggers downstream jobs for each app that is on that node class. It will use the "deployed-to-integration" branch which is set whenever an app is deployed to determine what version of the application is running in each environment.

It will also deploy using the task "deploy:without_migrations", as we just want to deploy the code automatically rather than running any tasks against the database.

This does also kick off the Smokey job after each successful deployment of an app, and this takes ~6 minutes to run, but I don't think this is too problematic.

https://trello.com/c/Xd9oR5ww/836-create-jenkins-job-to-deploy-all-apps-to-a-given-node-class