### PR TITLE
Fix govuk_notify_rate_per_worker name

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -246,7 +246,7 @@ govuk::apps::email_alert_api::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::email_alert_api::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::email_alert_api::db_hostname: 'postgresql-primary-1.backend'
 govuk::apps::email_alert_api::db_password: "%{hiera('govuk::apps::email_alert_api::db::password')}"
-govuk::apps::email_alert_api::notify_rate_per_worker: 8
+govuk::apps::email_alert_api::govuk_notify_rate_per_worker: "8"
 
 govuk::apps::email_alert_service::rabbitmq_hosts:
   - rabbitmq-1.backend

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -36,7 +36,7 @@ govuk::apps::email_alert_api::allow_govdelivery_topic_syncing: true
 govuk::apps::email_alert_api::govdelivery_account_code: 'UKGOVUKDUP'
 govuk::apps::email_alert_api::govdelivery_hostname: 'stage-api.govdelivery.com'
 govuk::apps::email_alert_api::govdelivery_public_hostname: 'stage-public.govdelivery.com'
-govuk::apps::email_alert_api::notify_rate_per_worker: 12 
+govuk::apps::email_alert_api::govuk_notify_rate_per_worker: '12' 
 govuk::apps::event_store::enabled: true
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
 govuk::apps::publicapi::backdrop_host: 'www.preview.performance.service.gov.uk'


### PR DESCRIPTION
This PR fixes incorrect naming introduced in  #6794. Also sets the variables as strings rather than fixnums to avoid having to convert them when setting the envvar.