### PR TITLE
Enable Asset Manager proxying to S3 in all environments

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -399,6 +399,8 @@ govuk::apps::service_manual_publisher::db::backend_ip_range: "%{hiera('environme
 
 govuk::apps::sidekiq_monitoring::asset_manager_redis_host: "%{hiera('govuk::apps::asset_manager::redis_host')}"
 govuk::apps::sidekiq_monitoring::asset_manager_redis_port: "%{hiera('govuk::apps::asset_manager::redis_port')}"
+govuk::apps::asset_manager::proxy_percentage_of_asset_requests_to_s3_via_nginx: '100'
+govuk::apps::asset_manager::proxy_percentage_of_whitehall_asset_requests_to_s3_via_nginx: '100'
 govuk::apps::sidekiq_monitoring::content_performance_manager_redis_host: "%{hiera('govuk::apps::content_performance_manager::redis_host')}"
 govuk::apps::sidekiq_monitoring::content_performance_manager_redis_port: "%{hiera('govuk::apps::content_performance_manager::redis_port')}"
 govuk::apps::sidekiq_monitoring::content_tagger_redis_host: "%{hiera('govuk::apps::content_tagger::redis_host')}"

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -69,8 +69,6 @@ environment_ip_prefix: '10.3'
 
 govuk::apps::asset_manager::aws_s3_bucket_name: 'govuk-assets-production'
 govuk::apps::asset_manager::aws_region: 'eu-west-1'
-govuk::apps::asset_manager::proxy_percentage_of_asset_requests_to_s3_via_nginx: '100'
-govuk::apps::asset_manager::proxy_percentage_of_whitehall_asset_requests_to_s3_via_nginx: '100'
 govuk::apps::content_performance_manager::feature_auditing_allocation: false
 govuk::apps::content_performance_manager::feature_auditing_theme_filtering: false
 govuk::apps::content_store::performance_platform_big_screen_view_url: 'https://performance-platform-big-screen-view-production.cloudapps.digital'


### PR DESCRIPTION
This was enabled in production in these [two][1] [PRs][2] and has been working successfully for some time. However, we haven't been able to enable it in staging & integration, because we haven't had the nightly syncs of Asset Manager assets from the production S3 bucket to the integration & staging buckets.

Since some Whitehall assets are now served via Asset Manager and their URLs are environment-specific, not having the nightly syncs in place would've meant existing Whitehall assets wouldn't have been served successfully via Asset Manager in integration & staging.

We attempted to enable the nightly sync recently in the PRs mentioned in [this comment][3], but we ran into a problem with permissions on the sync-ed 3 objects as described in [this issue][4].

This problem has now been resolved in these [two][5] [PRs][6] and last night's sync from production to staging & integration completed successfully. [I've also confirmed that Asset Manager can proxy asset requests to S3 via Nginx by making use of the query string flag][7].

We haven't previously been able to enable proxying to S3 in development, because we felt it was too onerous to require developers to setup the relevant S3 resources just for a development environment. However, in [this PR][8] we implemented a "fake" S3 within the Rails app for just this purpose.

All of the above means I'm now happy that it's safe to deploy & apply these changes.

Note that these changes were originally applied in #6769, but then reverted in #6792.

[1]: https://github.com/alphagov/govuk-puppet/pull/6432
[2]: https://github.com/alphagov/govuk-puppet/pull/6736
[3]:
https://github.com/alphagov/asset-manager/issues/145#issuecomment-342894788
[4]: https://github.com/alphagov/asset-manager/issues/303
[5]: https://github.com/alphagov/env-sync-and-backup/pull/37
[6]: https://github.com/alphagov/govuk-terraform-provisioning/pull/148
[7]:
https://github.com/alphagov/asset-manager/issues/303#issuecomment-345212785
[8]: https://github.com/alphagov/asset-manager/pull/267