### PR TITLE
Add SECRET_KEY_BASE env var for manuals-frontend and frontend

### DIFF
--- a/modules/govuk/manifests/apps/frontend.pp
+++ b/modules/govuk/manifests/apps/frontend.pp
@@ -37,6 +37,8 @@
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
+# [*secret_key_base*]
+#   The key for Rails to use when signing/encrypting sessions.
 #
 class govuk::apps::frontend(
   $vhost = 'frontend',
@@ -48,6 +50,7 @@ class govuk::apps::frontend(
   $redis_host = undef,
   $redis_port = undef,
   $sentry_dsn = undef,
+  $secret_key_base = undef,
 ) {
 
   govuk::app { 'frontend':
@@ -80,7 +83,15 @@ class govuk::apps::frontend(
 
   govuk::app::envvar {
     "${title}-PUBLISHING_API_BEARER_TOKEN":
-        varname => 'PUBLISHING_API_BEARER_TOKEN',
-        value   => $publishing_api_bearer_token;
+      varname => 'PUBLISHING_API_BEARER_TOKEN',
+      value   => $publishing_api_bearer_token;
+  }
+
+  if $secret_key_base != undef {
+    govuk::app::envvar {
+      "${title}-SECRET_KEY_BASE":
+        varname => 'SECRET_KEY_BASE',
+        value   => $secret_key_base;
+    }
   }
 }

--- a/modules/govuk/manifests/apps/manuals_frontend.pp
+++ b/modules/govuk/manifests/apps/manuals_frontend.pp
@@ -19,11 +19,15 @@
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
+# [*secret_key_base*]
+#   The key for Rails to use when signing/encrypting sessions.
+#
 class govuk::apps::manuals_frontend(
   $vhost = 'manuals-frontend',
   $port = '3072',
   $publishing_api_bearer_token = undef,
   $sentry_dsn = undef,
+  $secret_key_base = undef,
 ) {
   govuk::app { 'manuals-frontend':
     app_type              => 'rack',
@@ -38,5 +42,11 @@ class govuk::apps::manuals_frontend(
     app     => 'manuals-frontend',
     varname => 'PUBLISHING_API_BEARER_TOKEN',
     value   => $publishing_api_bearer_token,
+  }
+  if $secret_key_base != undef {
+    govuk::app::envvar { "${title}-SECRET_KEY_BASE":
+      varname => 'SECRET_KEY_BASE',
+      value   => $secret_key_base,
+    }
   }
 }


### PR DESCRIPTION
As part of an app upgrade, manuals frontend is now using the `SECRET_KEY_BASE` environment variable, or it would be if it was present. This PR sets it.

Update: added it for the frontend app too as that didn't have it either.