### PR TITLE
Fix env var issue with manuals-frontend

### DIFF
--- a/modules/govuk/manifests/apps/manuals_frontend.pp
+++ b/modules/govuk/manifests/apps/manuals_frontend.pp
@@ -38,11 +38,15 @@ class govuk::apps::manuals_frontend(
     vhost                 => $vhost,
   }
 
+  Govuk::App::Envvar {
+    app => 'manuals-frontend',
+  }
+
   govuk::app::envvar { "${title}-PUBLISHING_API_BEARER_TOKEN":
-    app     => 'manuals-frontend',
     varname => 'PUBLISHING_API_BEARER_TOKEN',
     value   => $publishing_api_bearer_token,
   }
+
   if $secret_key_base != undef {
     govuk::app::envvar { "${title}-SECRET_KEY_BASE":
       varname => 'SECRET_KEY_BASE',


### PR DESCRIPTION
Pass `app` to Govuk::App::Envvar outside of the env var setting so as the value is used for all env vars in manuals_frontend.pp