### PR TITLE
Add a separate jenkins job for recreating the search indexes

### DIFF
--- a/hieradata/class/integration/jenkins.yaml
+++ b/hieradata/class/integration/jenkins.yaml
@@ -31,6 +31,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::run_whitehall_data_migrations
   - govuk_jenkins::job::search_benchmark
   - govuk_jenkins::job::search_index_checks
+  - govuk_jenkins::job::search_reindex_with_new_schema
   - govuk_jenkins::job::search_test_spelling_suggestions
   - govuk_jenkins::job::signon_cron_rake_tasks
   - govuk_jenkins::job::smokey

--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -40,6 +40,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::search_fetch_analytics_data
   - govuk_jenkins::job::search_test_spelling_suggestions
   - govuk_jenkins::job::search_index_checks
+  - govuk_jenkins::job::search_reindex_with_new_schema
   - govuk_jenkins::job::signon_cron_rake_tasks
   - govuk_jenkins::job::smokey
   - govuk_jenkins::job::smokey_deploy

--- a/hieradata/class/staging/jenkins.yaml
+++ b/hieradata/class/staging/jenkins.yaml
@@ -21,6 +21,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::run_rake_task
   - govuk_jenkins::job::run_whitehall_data_migrations
   - govuk_jenkins::job::search_index_checks
+  - govuk_jenkins::job::search_reindex_with_new_schema
   - govuk_jenkins::job::smokey
   - govuk_jenkins::job::smokey_deploy
   - govuk_jenkins::job::update_cdn_dictionaries

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -139,6 +139,8 @@ govuk_jenkins::job::deploy_dns::zones:
   - 'dnstest.alphagov.co.uk'
 
 govuk_jenkins::job::search_benchmark::cron_schedule: '30 9 * * 1-5'
+govuk_jenkins::job::search_reindex_with_new_schema::icinga_check_enabled: true
+govuk_jenkins::job::search_reindex_with_new_schema::cron_schedule: '0 12 * * 1'
 govuk_jenkins::job::search_test_spelling_suggestions::cron_schedule: '0 10 * * 1-5'
 
 govuk_jenkins::job::enhanced_ecommerce::cron_schedule: '30 9 * * 1-5'

--- a/modules/govuk_jenkins/manifests/job/search_reindex_with_new_schema.pp
+++ b/modules/govuk_jenkins/manifests/job/search_reindex_with_new_schema.pp
@@ -21,7 +21,6 @@ class govuk_jenkins::job::search_reindex_with_new_schema (
     host_name           => $::fqdn,
     freshness_threshold => 619200,
     action_url          => $job_url,
-    # TODO: add this to the developer docs
-    # notes_url           => monitoring_docs_url(search-reindex-failed),
+    notes_url           => monitoring_docs_url(search-reindex-failed),
   }
 }

--- a/modules/govuk_jenkins/manifests/job/search_reindex_with_new_schema.pp
+++ b/modules/govuk_jenkins/manifests/job/search_reindex_with_new_schema.pp
@@ -4,6 +4,8 @@
 #
 class govuk_jenkins::job::search_reindex_with_new_schema (
   $app_domain = hiera('app_domain'),
+  $icinga_check_enabled = false,
+  $cron_schedule = undef,
 ) {
 
   $check_name = 'search-reindex-with-new-schema'
@@ -16,11 +18,13 @@ class govuk_jenkins::job::search_reindex_with_new_schema (
     notify  => Exec['jenkins_jobs_update'],
   }
 
-  @@icinga::passive_check { "${check_name}_${::hostname}":
-    service_description => $service_description,
-    host_name           => $::fqdn,
-    freshness_threshold => 619200,
-    action_url          => $job_url,
-    notes_url           => monitoring_docs_url(search-reindex-failed),
+  if ($icinga_check_enabled) {
+    @@icinga::passive_check { "${check_name}_${::hostname}":
+      service_description => $service_description,
+      host_name           => $::fqdn,
+      freshness_threshold => 619200,
+      action_url          => $job_url,
+      notes_url           => monitoring_docs_url(search-reindex-failed),
+    }
   }
 }

--- a/modules/govuk_jenkins/manifests/job/search_reindex_with_new_schema.pp
+++ b/modules/govuk_jenkins/manifests/job/search_reindex_with_new_schema.pp
@@ -1,0 +1,27 @@
+# == Class: govuk_jenkins::job::search-reindex-with-new-schema
+#
+# Test rebuilding the search indexes and reindexing all content
+#
+class govuk_jenkins::job::search_reindex_with_new_schema (
+  $app_domain = hiera('app_domain'),
+) {
+
+  $check_name = 'search-reindex-with-new-schema'
+  $service_description = 'Rebuild new search indexes with up to date settings and mappings, and reindex all content from the existing indexes.'
+  $job_url = "https://deploy.${app_domain}/job/search-reindex-with-new-schema/"
+
+  file { '/etc/jenkins_jobs/jobs/search_reindex_with_new_schema.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/search_reindex_with_new_schema.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+
+  @@icinga::passive_check { "${check_name}_${::hostname}":
+    service_description => $service_description,
+    host_name           => $::fqdn,
+    freshness_threshold => 619200,
+    action_url          => $job_url,
+    # TODO: add this to the developer docs
+    # notes_url           => monitoring_docs_url(search-reindex-failed),
+  }
+}

--- a/modules/govuk_jenkins/templates/jobs/search_reindex_with_new_schema.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/search_reindex_with_new_schema.yaml.erb
@@ -7,9 +7,9 @@
       Rebuild new search indexes with up to date settings and mappings, and reindex all content from the existing indexes.
     logrotate:
       numToKeep: 10
-<% if @environment == 'integration' %>
+<% if @cron_schedule %>
     triggers:
-        - timed: '0 12 * * 1'  # Every monday at midday
+        - timed: '<%= @cron_schedule %>'
 <% end %>
     builders:
         - shell: ssh deploy@$(govuk_node_list -c search --single-node) "cd /var/apps/rummager && govuk_setenv rummager CONFIRM_INDEX_MIGRATION_START=1 bundle exec rake rummager:migrate_schema"

--- a/modules/govuk_jenkins/templates/jobs/search_reindex_with_new_schema.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/search_reindex_with_new_schema.yaml.erb
@@ -9,7 +9,7 @@
       numToKeep: 10
 <% if @environment == 'integration' %>
     triggers:
-        - timed: '12 * * * 1'  # Every monday
+        - timed: '0 12 * * 1'  # Every monday at midday
 <% end %>
     builders:
         - shell: ssh deploy@$(govuk_node_list -c search --single-node) "cd /var/apps/rummager && govuk_setenv rummager CONFIRM_INDEX_MIGRATION_START=1 bundle exec rake rummager:migrate_schema"

--- a/modules/govuk_jenkins/templates/jobs/search_reindex_with_new_schema.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/search_reindex_with_new_schema.yaml.erb
@@ -1,0 +1,19 @@
+---
+- job:
+    name: search_reindex_with_new_schema
+    display-name: Search reindex with new schema
+    project-type: freestyle
+    description: |
+      Rebuild new search indexes with up to date settings and mappings, and reindex all content from the existing indexes.
+    logrotate:
+      numToKeep: 10
+<% if @environment == 'integration' %>
+    triggers:
+        - timed: '12 * * * 1'  # Every monday
+<% end %>
+    builders:
+        - shell: ssh deploy@$(govuk_node_list -c search --single-node) "cd /var/apps/rummager && govuk_setenv rummager CONFIRM_INDEX_MIGRATION_START=1 bundle exec rake rummager:migrate_schema"
+    wrappers:
+      - ansicolor:
+          colormap: xterm
+      - timestamps


### PR DESCRIPTION
This process
- uses rummager's configuration to generate the settings/mappings for a
  new set of search indexes
- creates the new indexes
- triggers a reindex of content from the old index to the new one
- while this is happening, a write lock is placed on the old index so
  data isn't lost
- after completing the reindex, it runs some checks on the new index, and
  switches over to it if successful (by moving aliases)

This used to be part of the `search_fetch_analytics` job, and ran every
night but we split it out, and now only need to run it when changing
the mappings or updating elasticsearch.

This is a very slow process, so we don't want to hook it into our CI
pipeline, but we do want to test it periodically on integration.

https://trello.com/c/9nZLUhqi/439-regularly-test-reindex-task