### PR TITLE
Replay Bouncer traffic against AWS

### DIFF
--- a/hieradata/node/bouncer-1.redirector.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/bouncer-1.redirector.staging.publishing.service.gov.uk.yaml
@@ -1,4 +1,4 @@
 ---
 
 govuk_bouncer::gor::enabled: true
-govuk_bouncer::gor::ip_address: '31.210.245.101'
+govuk_bouncer::gor::target: '31.210.245.101'

--- a/hieradata/node/bouncer-2.redirector.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/bouncer-2.redirector.staging.publishing.service.gov.uk.yaml
@@ -1,0 +1,4 @@
+---
+
+govuk_bouncer::gor::enabled: true
+govuk_bouncer::gor::target: 'bouncer.blue.integration.govuk.digital'

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -100,7 +100,7 @@ govuk::deploy::setup::ssh_keys:
   jenkins_production_carrenza: 'AAAAB3NzaC1yc2EAAAADAQABAAACAQCfPjubgzCkZo1aTPlkgeXb1eh3IonRBRptx0qLMCjOV+e+M8uRAT/Xx3ydJYPd7sOgZDyx2xjSGb7Eefau0jSUAcMD1Xd01SXWBQPJRDfPmQLrdbM0xxOFH8nft39uo4Mz6ccZc34xrudL6q/urp732HZHYwltnNnbk9h58n1QIhemRtN3u9RrSSOILqw/F42S6Aj8lZ1v/DGgfc6F5pKyJ7TByHL1RlqwpZHbEjYYuvK0ZJJsKPlyVPbNDsX7UEYWwbpPsFs9LPvCC6epmj+7Lv25bTU8rKK8J3rNWa1FybpWS0VXbF/+mrLjtT0/vwvbwUzsjK6dSUsbEsBEn+cOqomxCYkLjMzUy1+ReYAh6+CjmzutPs1g4OjQRel2ONprhPTEsNUu+oNObnGDOUpzHK10ntAZxguA4QEUmOBBWfxuQhmJO60/b1zedCcc7MR8e9S0y4jtpXa8GBCe40+napArZTW9QXlHLWz+khkYQfO107Q+z1QaLFojdcrHlUfpqAc6DtVJQu7tsBt2vXTn0qq6mU5Eg6UY+X1l/3gWdFS3ZEvCUoGK6bLU3i50jZ1xsFogFFfvSux46S1DYW2Fk8a/2IBBdcQcL1YoM73jiAQgpU8Vs50wtk4mWhK1yBaMYmMAeL7mKFbJla7SjTAwaDdo5uezyrJlbZxqTb/Y3w=='
 
 govuk_bouncer::gor::enabled: true
-govuk_bouncer::gor::ip_address: '195.225.216.149'
+govuk_bouncer::gor::target: '195.225.216.149'
 
 govuk_cdnlogs::transition_logs::enable_cron: true
 

--- a/modules/govuk_bouncer/manifests/gor.pp
+++ b/modules/govuk_bouncer/manifests/gor.pp
@@ -7,23 +7,23 @@
 # [*enabled*]
 #   Boolean to determine if Bouncer traffic will be replayed; defaults to false.
 #
-# [*ip_address*]
-#   IP address of the Bouncer application to replay against; defaults to undef.
+# [*target*]
+#   IP or hostname of the Bouncer application to replay against; defaults to undef.
 #
 class govuk_bouncer::gor (
   $enabled = false,
-  $ip_address = undef,
+  $target = undef,
 ) {
 
   validate_bool($enabled)
 
-  if $enabled and is_ip_address($ip_address) {
-    $gor_enable         = true
+  if ($enabled and $target) {
+    $gor_enable  = true
     # Bouncer only receives traffic over HTTP (port 80)
-    $gor_targets        = ["http://${ip_address}"]
+    $gor_targets = ["http://${target}"]
   } else {
-    $gor_enable         = false
-    $gor_targets        = []
+    $gor_enable  = false
+    $gor_targets = []
   }
 
   class { 'govuk_gor':

--- a/modules/govuk_bouncer/spec/classes/govuk_bouncer__gor_spec.rb
+++ b/modules/govuk_bouncer/spec/classes/govuk_bouncer__gor_spec.rb
@@ -24,7 +24,7 @@ describe 'govuk_bouncer::gor', :type => :class do
   context '#enabled' do
     let(:params) {{
       :enabled => true,
-      :ip_address => ip_address,
+      :target  => ip_address,
     }}
 
     it {
@@ -40,20 +40,7 @@ describe 'govuk_bouncer::gor', :type => :class do
     }
   end
 
-  context 'enabled but no staging IP is invalid' do
-    let(:params) {{
-      :enabled => true,
-      :ip_address => 'not.an.ip.address',
-    }}
-
-    it {
-      is_expected.to contain_class('govuk_gor').with(
-        :enable => false,
-      )
-    }
-  end
-
-  context 'enabled but no staging IP specified' do
+  context 'enabled but no target specified' do
     let(:params) {{
       :enabled => true,
     }}


### PR DESCRIPTION
Update the class so that we're not tied to specific IP addresses, and allow running traffic replay against the AWS instance.