### PR TITLE
Temporarily remove sysdig

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -757,6 +757,7 @@ govuk_sudo::sudo_conf:
     content: 'ubuntu ALL=(ALL) NOPASSWD:ALL'
 
 govuk_sysdig::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_sysdig::ensure: 'absent'
 
 govuk_unattended_reboot::enabled: true
 govuk_unattended_reboot::mongodb::enabled: true

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -764,6 +764,7 @@ govuk_sudo::sudo_conf:
     content: 'ubuntu ALL=(ALL) NOPASSWD:ALL'
 
 govuk_sysdig::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_sysdig::ensure: 'absent'
 
 govuk_unattended_reboot::alert_hostname: 'alert'
 govuk_unattended_reboot::enabled: true

--- a/modules/govuk_sysdig/manifests/init.pp
+++ b/modules/govuk_sysdig/manifests/init.pp
@@ -8,20 +8,22 @@
 #   Hostname to use for the APT mirror.
 #   Defaults to undefined because `$use_mirror` can be disabled.
 #
-class govuk_sysdig(
+class govuk_sysdig (
+  $ensure = 'present',
   $apt_mirror_hostname = undef,
 ) {
 
   apt::source { 'sysdig':
+    ensure   => $ensure,
     location => "http://${apt_mirror_hostname}/sysdig",
     release  => 'stable-amd64',
     key      => 'D27A72F32D867DF9300A241574490FD6EC51E8C4',
   }
 
-  ensure_packages( [ "linux-headers-${::kernelrelease}" ] )
+  ensure_packages( [ "linux-headers-${::kernelrelease}" ])
 
   package { 'sysdig':
-    ensure  => 'installed',
+    ensure  => $ensure,
     require => [
       Apt::Source['sysdig'],
       Package["linux-headers-${::kernelrelease}"],


### PR DESCRIPTION
The upstream repository seems to have an error:

```
lauramartin@production-apt-1:~$ curl -I http://download.draios.com/stable/deb/
HTTP/1.1 403 Forbidden
x-amz-error-code: AccessDenied
x-amz-error-message: Access Denied
x-amz-request-id: CE4598B9BE9C20AB
x-amz-id-2: wrAmh+0R67lDx4I3gDcJGmyDcHo8+IA2jhxbG5Bc9eRpEfykaD1zEo0XkstkbSSJ1z2ZUxmVasA=
Transfer-Encoding: chunked
Date: Mon, 20 Nov 2017 10:33:32 GMT
Server: AmazonS3
```

We don't appear to have taken a snapshot of the mirror, so we no longer have any packages appearing in our mirror of the repo: http://apt.publishing.service.gov.uk/sysdig/dists/

This is causing problems when `apt-get update` runs.

This is blocking other work, so add an ensure parameter, and remove it for the time-being. We can add it back when the upstream repository is up, and ensure we add a mirror.

https://trello.com/c/3y6WEkin/821-check-sysdig-repository-and-add-back-in