### PR TITLE
Add docker as an apt-mirror

### DIFF
--- a/modules/govuk/manifests/node/s_apt.pp
+++ b/modules/govuk/manifests/node/s_apt.pp
@@ -117,6 +117,11 @@ class govuk::node::s_apt (
       location => 'http://ppa.launchpad.net/duplicity-team/ppa/ubuntu',
       release  => 'trusty',
       key      => 'AF953139C1DF9EF3476DE1D58F571BB27A86F4A2';
+    'docker':
+      location => 'https://download.docker.com/linux/ubuntu',
+      release  => 'trusty',
+      repos    => ['stable'],
+      key      => '9DC858229FC7DD38854AE2D88D81803C0EBFCD88';
   }
 
   aptly::repo { 'elastic-beats': }


### PR DESCRIPTION
With the release of docker-ce docker is now it's own repository.
See: https://docs.docker.com/engine/installation/linux/docker-ce/ubuntu/#set-up-the-repository
for more details

I've added repos of stable as there are directories of different
releases inside
https://download.docker.com/linux/ubuntu/dists/trusty/

and the key is based on the one provided on the above link.

I have no idea how to test this so any pointers on that would be very useful 🙏 