### PR TITLE
Set Plek env var rummager for draft machines

### DIFF
--- a/modules/govuk/manifests/node/s_draft_frontend.pp
+++ b/modules/govuk/manifests/node/s_draft_frontend.pp
@@ -22,6 +22,7 @@ class govuk::node::s_draft_frontend() inherits govuk::node::s_base {
     govuk_envvar {
       'PLEK_SERVICE_MAPIT_URI': value  => "https://mapit.${app_domain}";
       'PLEK_SERVICE_SEARCH_URI': value => "https://search.${app_domain}";
+      'PLEK_SERVICE_RUMMAGER_URI': value => "https://rummager.${app_domain}";
     }
   }
 


### PR DESCRIPTION
Without this, on the draft stack Plek will return 'draft-rummager' for Rummager, but we don't currently have a draft version of Rummager. We are seeing a lot of errors in Sentry for this. We already added [a similar thing for 'search'](https://github.com/alphagov/govuk-puppet/blob/3904afcc3404cf5638cdacf372ef48d7d1eda0f1/modules/govuk/manifests/node/s_draft_frontend.pp#L24).

https://sentry.io/govuk/app-government-frontend/issues/398079951/

Specifically this should fix a bug, where publishers previewing their content on the draft stack (using either the government-frontend or frontend application) are not seeing related items in the taxonomy side bar which should be fetched from Rummager. See code that would be called here: -> https://github.com/alphagov/govuk_navigation_helpers/blob/master/lib/govuk_navigation_helpers/rummager_taxonomy_sidebar_links.rb#L35