### PR TITLE
Configure the rabbitmq hosts used by publishing_api

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -362,6 +362,10 @@ govuk::apps::policy_publisher::db_hostname: "postgresql-primary-1.backend"
 govuk::apps::publishing_api::content_store: "https://content-store.%{hiera('app_domain')}"
 govuk::apps::publishing_api::db_hostname: "postgresql-primary-1.backend"
 govuk::apps::publishing_api::draft_content_store: "https://draft-content-store.%{hiera('app_domain')}"
+govuk::apps::publishing_api::rabbitmq_hosts:
+  - rabbitmq-1.backend
+  - rabbitmq-2.backend
+  - rabbitmq-3.backend
 govuk::apps::publishing_api::rabbitmq_password: "%{hiera('govuk::apps::publishing_api::rabbitmq::amqp_pass')}"
 govuk::apps::publishing_api::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::publishing_api::redis_port: "%{hiera('sidekiq_port')}"

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -126,9 +126,10 @@ govuk::apps::publisher::enable_procfile_worker: false
 govuk::apps::publishing_api::content_store: 'http://content-store.dev.gov.uk'
 govuk::apps::publishing_api::draft_content_store: 'http://draft-content-store.dev.gov.uk'
 govuk::apps::publishing_api::enable_procfile_worker: false
-govuk::apps::publishing_api::rabbitmq::configure_test_exchange: true
-govuk::apps::publishing_api::suppress_draft_store_502_error: '1'
 govuk::apps::publishing_api::govuk_content_schemas_path: '/var/govuk/govuk-content-schemas'
+govuk::apps::publishing_api::rabbitmq::configure_test_exchange: true
+govuk::apps::publishing_api::rabbitmq_hosts: ['localhost']
+govuk::apps::publishing_api::suppress_draft_store_502_error: '1'
 govuk::apps::router::error_log: STDERR
 govuk::apps::router::enable_nginx_vhost: true
 govuk::apps::router::mongodb_name: "%{hiera('govuk::apps::router_api::mongodb_name')}"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -367,10 +367,11 @@ govuk::apps::licencefinder::mongodb_nodes:
 
 govuk::apps::policy_publisher::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 govuk::apps::policy_publisher::db_hostname: "postgresql-primary"
-
 govuk::apps::publishing_api::content_store: "https://content-store.%{hiera('app_domain')}"
 govuk::apps::publishing_api::db_hostname: "postgresql-primary"
 govuk::apps::publishing_api::draft_content_store: "https://draft-content-store.%{hiera('app_domain')}"
+govuk::apps::publishing_api::rabbitmq_hosts:
+  - rabbitmq
 govuk::apps::publishing_api::rabbitmq_password: "%{hiera('govuk::apps::publishing_api::rabbitmq::amqp_pass')}"
 govuk::apps::publishing_api::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::publishing_api::redis_port: "%{hiera('sidekiq_port')}"

--- a/modules/govuk/manifests/apps/publishing_api.pp
+++ b/modules/govuk/manifests/apps/publishing_api.pp
@@ -63,6 +63,13 @@
 # [*oauth_secret*]
 #   Sets the OAuth Secret Key
 #
+# [*rabbitmq_hosts*]
+#   RabbitMQ hosts to connect to.
+#   Default: localhost
+#
+# [*rabbitmq_user*]
+#   RabbitMQ username.
+#
 # [*rabbitmq_password*]
 #   A password to connect to RabbitMQ:
 #   https://github.com/alphagov/publishing-api/blob/master/config/rabbitmq.yml
@@ -102,6 +109,8 @@ class govuk::apps::publishing_api(
   $enable_procfile_worker = true,
   $oauth_id = undef,
   $oauth_secret = undef,
+  $rabbitmq_hosts = ['localhost'],
+  $rabbitmq_user = 'publishing_api',
   $rabbitmq_password = undef,
   $govuk_content_schemas_path = '',
   $event_log_aws_bucketname = undef,
@@ -143,6 +152,12 @@ class govuk::apps::publishing_api(
       port => $redis_port,
     }
 
+    govuk::app::envvar::rabbitmq { $app_name:
+      hosts    => $rabbitmq_hosts,
+      user     => $rabbitmq_user,
+      password => $rabbitmq_password,
+    }
+
     govuk::app::envvar {
       "${title}-CONTENT_STORE":
         varname => 'CONTENT_STORE',
@@ -159,9 +174,6 @@ class govuk::apps::publishing_api(
       "${title}-OAUTH_SECRET":
         varname => 'OAUTH_SECRET',
         value   => $oauth_secret;
-      "${title}-RABBITMQ_PASSWORD":
-        varname => 'RABBITMQ_PASSWORD',
-        value   => $rabbitmq_password;
       "${title}-GOVUK_CONTENT_SCHEMAS_PATH":
         varname => 'GOVUK_CONTENT_SCHEMAS_PATH',
         value   => $govuk_content_schemas_path;


### PR DESCRIPTION
In our current provider we use a set of servers, addressed by name.
In AWS we use an ELB endpoint with an ASG beind it.