### PR TITLE
Add a Publishing API bearer token to the tagging monitor

### DIFF
--- a/modules/govuk_jenkins/manifests/job/govuk_tagging_monitor.pp
+++ b/modules/govuk_jenkins/manifests/job/govuk_tagging_monitor.pp
@@ -11,8 +11,13 @@
 #   Sets the header "Rate-Limit-Token" which ensures that the tagging monitor is
 #   whitelisted by the rate limiting function (receiving 429 status)
 #
+# [*publishing_api_bearer_token*]
+#   Sets the PUBLISHING_API_BEARER_TOKEN when running the
+#   govuk_tagging_monitor to allow it to use the Publishing API.
+#
 class govuk_jenkins::job::govuk_tagging_monitor (
   $rate_limit_token = undef,
+  $publishing_api_bearer_token = undef,
 ) {
 
   file { '/etc/jenkins_jobs/jobs/govuk_tagging_monitor.yaml':

--- a/modules/govuk_jenkins/templates/jobs/govuk_tagging_monitor.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/govuk_tagging_monitor.yaml.erb
@@ -26,6 +26,7 @@
           set -eu
 
           cd govuk-tagging-monitor
+          export PUBLISHING_API_BEARER_TOKEN="<%= @publishing_api_bearer_token -%>"
           export RATE_LIMIT_TOKEN="<%= @rate_limit_token -%>"
           bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
           bundle exec rake run


### PR DESCRIPTION
It would be useful to access the Publishing API from the GOV.UK
Tagging Monitor to get information about links.