### PR TITLE
Add environment filter to sentry link on deployment dashboard

### DIFF
--- a/modules/grafana/manifests/dashboards/deployment_dashboard.pp
+++ b/modules/grafana/manifests/dashboards/deployment_dashboard.pp
@@ -45,6 +45,8 @@ define grafana::dashboards::deployment_dashboard (
   $dependent_app_5xx_errors = undef,
   $show_elasticsearch_stats = false,
   $fields_prefix = '@fields.',
+  $sentry_environment = $::govuk::deploy::config::errbit_environment_name,
+
 ) {
   if $has_workers {
     $worker_row = [['worker_failures', 'worker_successes']]

--- a/modules/grafana/templates/dashboards/deployment_panels/_links.json.erb
+++ b/modules/grafana/templates/dashboards/deployment_panels/_links.json.erb
@@ -1,5 +1,5 @@
 {
-  "content": "<ul style=\"font-size: 20px;\">\n<li><a target=\"_blank\" href=\"https://sentry.io/govuk/app-<%= @app_name %>/\">Errors for <%= @app_name %> (Sentry)</a></li>\n<li><a target=\"_blank\" href=\"https://kibana.logit.io\">Kibana (Logit)</a></li>\n<li><a target=\"_blank\" href=\"https://alert.<%= @app_domain %>/\">Icinga</a></li>\n<li><a target=\"_blank\" href=\"https://docs.publishing.service.gov.uk/apps/<%= @docs_name %>.html\"><%= @app_name %> documentation</a></li>\n<li><a target=\"_blank\" href=\"https://govuk.zendesk.com/agent/filters/135081425\">Dashboard feedback</a></li>\n</ul>\n",
+  "content": "<ul style=\"font-size: 20px;\">\n<li><a target=\"_blank\" href=\"https://sentry.io/govuk/app-<%= @app_name %>/?query=is%3Aunresolved+environment%3A<%= @sentry_environment %>\">Errors for <%= @app_name %> (Sentry)</a></li>\n<li><a target=\"_blank\" href=\"https://kibana.logit.io\">Kibana (Logit)</a></li>\n<li><a target=\"_blank\" href=\"https://alert.<%= @app_domain %>/\">Icinga</a></li>\n<li><a target=\"_blank\" href=\"https://docs.publishing.service.gov.uk/apps/<%= @docs_name %>.html\"><%= @app_name %> documentation</a></li>\n<li><a target=\"_blank\" href=\"https://govuk.zendesk.com/agent/filters/135081425\">Dashboard feedback</a></li>\n</ul>\n",
   "editable": true,
   "error": false,
   "id": 12,


### PR DESCRIPTION
Otherwise we link to all errors for the project.  Sentry doesn't make it
obvious via the UI how to filter to only see the errors for a given
environment so we might mean people don't check for errors because it's
too noisy, or worry about errors on integration when they're deploying
to production.