### PR TITLE
Avoid S3 HTTP headers appearing in Asset Manager responses

### DIFF
--- a/modules/govuk/manifests/apps/asset_manager.pp
+++ b/modules/govuk/manifests/apps/asset_manager.pp
@@ -166,7 +166,7 @@ class govuk::apps::asset_manager(
         # [1]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
         add_header X-Frame-Options $x_frame_options_from_rails;
 
-        # Remove S3 HTTP headers listed in:
+        # Remove S3 HTTP headers including those listed in:
         # http://docs.aws.amazon.com/AmazonS3/latest/API/RESTCommonResponseHeaders.html
         # This keeps this HTTP response as similar as possible to the response
         # sent when using Sendfile to serve files from NFS
@@ -174,6 +174,8 @@ class govuk::apps::asset_manager(
         proxy_hide_header x-amz-id-2;
         proxy_hide_header x-amz-request-id;
         proxy_hide_header x-amz-version-id;
+        proxy_hide_header x-amz-replication-status;
+        proxy_hide_header x-amz-meta-md5-hexdigest;
 
         # Add Google DNS server to avoid "no resolver defined to resolve"
         # errors when trying to connect to S3


### PR DESCRIPTION
* `x-amz-replication-status` started appearing when we enabled cross-region replication on the production S3 bucket.

* `x-amz-meta-md5-hexdigest` has been appearing since we added this piece of custom metadata in [this commit][1].

This commit hides the above response headers when Asset Manager proxies asset requests to S3 via Nginx which it is now doing by default in all environments.

This addresses both [this issue][2] and [this other issue][3].

[1]:
https://github.com/alphagov/asset-manager/commit/ff2ed6163e80327d5b51f0cabfe16b8013601a84
[2]: https://github.com/alphagov/asset-manager/issues/270
[3]: https://github.com/alphagov/asset-manager/issues/289