### PR TITLE
[DISCUSS] Run asset precompilation in production mode in build project

### DIFF
--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -488,7 +488,7 @@ def sassLinter(String dirs = 'app/assets/stylesheets') {
 def precompileAssets() {
   echo 'Precompiling the assets'
   withStatsdTiming("assets_precompile") {
-    sh('bundle exec rake assets:clobber assets:precompile')
+    sh('RAILS_ENV=production GOVUK_WEBSITE_ROOT=http://www.test.gov.uk GOVUK_APP_DOMAIN=test.gov.uk GOVUK_ASSET_ROOT=https://static.test.gov.uk GOVUK_ASSET_HOST=https://static.test.gov.uk bundle exec rake assets:clobber assets:precompile')
   }
 }
 

--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -488,7 +488,7 @@ def sassLinter(String dirs = 'app/assets/stylesheets') {
 def precompileAssets() {
   echo 'Precompiling the assets'
   withStatsdTiming("assets_precompile") {
-    sh('bundle exec rake assets:clean assets:precompile')
+    sh('bundle exec rake assets:clobber assets:precompile')
   }
 }
 


### PR DESCRIPTION
For: https://trello.com/c/QtpGwa2A/288-improve-feedback-on-github-for-changes-to-govuk-content-schemas

This will allow whitehall to use the standard `buildProject` because whitehall already runs asset precompilation in production mode.  This feels like a sensible choice so rather than allowing an override we'd rather make all apps with assets do the same.  There's more detail in the two commits about why we're doing this.

## Checking other apps

I did a search for [repos that use `buildProject`](https://github.com/search?q=org%3Aalphagov+buildProject&type=Code) and filtered out those that wouldn't actually run asset precompilation (because they have no `app/assets` folder).  I also searched for [repos that use or `precompileAssets`](https://github.com/search?utf8=%E2%9C%93&q=org%3Aalphagov+precompileAssets&type=Code) and added those to the list.  I then ran the following script in my dev VM to see if the new precompileAssets would pass or fail.

```sh
#!/bin/sh

apps="asset-manager \
calculators \
calendars \
collections \
collections-publisher \
contacts-admin \
content-performance-manager \
content-tagger \
design-principles \
email-alert-frontend \
feedback \
finder-frontend \
frontend \
government-frontend \
govuk_admin_template \
govuk_publishing_components \
imminence \
info-frontend \
licence-finder \
local-links-manager \
manuals-frontend \
manuals-publisher \
maslow \
policy-publisher \
publisher \
release \
search-admin \
service-manual-frontend \
service-manual-publisher \
short-url-manager \
smart-answers \
specialist-publisher \
static \
support \
transition \
travel-advice-publisher \
whitehall";

for app in $apps
do
  echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>"
  echo ""
  echo "PRECOMPILING ASSETS FOR $app";
  echo ""
  echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>"

  cd $app;

  RAILS_ENV=production GOVUK_WEBSITE_ROOT=http://www.test.gov.uk GOVUK_APP_DOMAIN=test.gov.uk GOVUK_ASSET_ROOT=https://static.test.gov.uk GOVUK_ASSET_HOST=https://static.test.gov.uk bundle exec rake assets:clobber assets:precompile;

  cd ..;

  echo "<<<<<<<<<<<<<<<<<<<<<<<<<<<"
  echo ""
  echo "DONE PRECOMPILING ASSETS FOR $app";
  echo ""
  echo "<<<<<<<<<<<<<<<<<<<<<<<<<<<"
done
```

A handful failed and there are PRs to change these to work with this new version of `precompileAssets`:

 - [x] asset-manager - failed because it needs an extra env var specified to set an aws bucket name in production mode - see: https://github.com/alphagov/asset-manager/pull/314
 - [x] finder-frontend - failed because it uses the rails 3 era gemfile structure that means asset gems don't load in production mode (it's a rails 5 app now) - see: https://github.com/alphagov/finder-frontend/pull/321
 - [x] govuk_publishing_components - failed because it has no assets:clobber rake task, and then was missing the uglifier dependency for building assets in production mode - see: https://github.com/alphagov/govuk_publishing_components/pull/99
 - [x] govuk_admin_template - failed because it has no assets:clobber rake task (the others are just placeholders that do nothing) - see: https://github.com/alphagov/govuk_admin_template/pull/156

This PR is marked as DNM until all of these failures have been addressed as otherwise merging it would break those apps.