### PR TITLE
Don't hardcode `publishing.service.gov.uk` in govuk_uptime_collector

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -967,6 +967,8 @@ monitoring::checks::smokey::features:
   check_travel_advice:
     feature: travel_advice
 
+monitoring::uptime_collector::aws: true
+
 # FIXME: this has been added to avoid a bug until we move to v3 of the module
 mysql::client::package_ensure: 'present'
 

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -110,6 +110,7 @@ monitoring::checks::enable_support_check: false
 monitoring::checks::pingdom::enable: false
 monitoring::checks::ses::region: eu-west-1
 monitoring::checks::smokey::environment: 'integration'
+monitoring::uptime_collector::environment: 'integration'
 
 postfix::smarthost:
   - 'email-smtp.eu-west-1.amazonaws.com:587'

--- a/modules/monitoring/files/usr/local/bin/govuk_uptime_collector
+++ b/modules/monitoring/files/usr/local/bin/govuk_uptime_collector
@@ -9,10 +9,11 @@ require "time"
 require "statsd"
 
 class Collector
-  def initialize(service_name, environment)
+  def initialize(service_name, environment, aws)
     @statsd = Statsd.new("127.0.0.1")
     @service_name = service_name
     @environment = environment
+    @aws = aws
   end
 
   def call
@@ -24,12 +25,16 @@ class Collector
 
 private
 
-  attr_reader :statsd, :service_name, :environment
+  attr_reader :statsd, :service_name, :environment, :aws
 
   def healthcheck_uri
     @healthcheck_uri ||= begin
-      prefix = environment == "production" ? "#{service_name}" : "#{service_name}.#{environment}"
-      URI("https://#{prefix}.publishing.service.gov.uk/healthcheck")
+      if aws
+        URI("https://#{service_name}.blue.integration.govuk.digital/healthcheck")
+      else
+        prefix = environment == "production" ? "#{service_name}" : "#{service_name}.#{environment}"
+        URI("https://#{prefix}.publishing.service.gov.uk/healthcheck")
+      end
     end
   end
 
@@ -58,10 +63,11 @@ def main
   threads = []
 
   environment = ARGV[0]
+  aws = ARGV[1] == 'true' ? true : false
 
-  ARGV[1..-1].each do |service_name|
+  ARGV[2..-1].each do |service_name|
     threads << Thread.new do
-      Collector.new(service_name, environment).call
+      Collector.new(service_name, environment, aws).call
     end
   end
 

--- a/modules/monitoring/manifests/uptime_collector.pp
+++ b/modules/monitoring/manifests/uptime_collector.pp
@@ -8,8 +8,12 @@
 #   The environment the uptime collecting is running in. For example:
 #     production, integration or staging.
 #
+# [*aws*]
+#   Optional. True or false, depending on whether we're running in AWS or not.
+
 class monitoring::uptime_collector (
   $environment = '',
+  $aws = false,
 ) {
   exec { 'install statsd into 2.3 rbenv':
     environment => 'RBENV_VERSION=2.3',

--- a/modules/monitoring/templates/govuk-uptime-collector.conf.erb
+++ b/modules/monitoring/templates/govuk-uptime-collector.conf.erb
@@ -6,4 +6,4 @@ respawn
 env RBENV_VERSION=2.3
 env PATH=/usr/lib/rbenv/shims:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
-exec govuk_uptime_collector <%= @environment %> content-store hmrc-manuals-api link-checker-api manuals-publisher publishing-api specialist-publisher travel-advice-publisher
+exec govuk_uptime_collector <%= @environment %> <%= @aws %> content-store hmrc-manuals-api link-checker-api manuals-publisher publishing-api specialist-publisher travel-advice-publisher


### PR DESCRIPTION
- Adjust this for AWS, with a new parameter to run the script with (defaults to
  `false`) and some hieradata.