### PR TITLE
On AWS, use the internal domain for MapIt checks

### DIFF
--- a/modules/icinga/templates/check_mapit.cfg.erb
+++ b/modules/icinga/templates/check_mapit.cfg.erb
@@ -1,5 +1,10 @@
 define command {
   command_name check_mapit
+  <%- if scope.lookupvar('::aws_migration') %>
+  command_line /usr/lib/nagios/plugins/check_http -H mapit.<%= @app_domain_internal %> -u /postcode/W54XA -w1 -c2 -s 'E14000676' --ssl
+  <%- else %>
   command_line /usr/lib/nagios/plugins/check_http -H mapit.<%= @app_domain %> -u /postcode/W54XA -w1 -c2 -s 'E14000676' --ssl
+  <%- end %>
+
 }
 


### PR DESCRIPTION
- We were seeing alerts for "not responding to postcode query - unable to open TCP socket".