### PR TITLE
Fix the check content consistency Jenkins job

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/check_content_consistency.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/check_content_consistency.yaml.erb
@@ -3,7 +3,7 @@
     name: check-content-consistency
     scm:
       - git:
-          url: git@github.digital.cabinet-office.gov.uk:gds/router-data.git
+          url: git@github.com:alphagov/router-data.git
           basedir: router-data
           branches:
             - master


### PR DESCRIPTION
The router-data git repository moved, and is now hosted on GitHub, so
update the url.