### PR TITLE
Call initializeParameters in buildProject

### DIFF
--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -115,6 +115,20 @@ def buildProject(Map options = [:]) {
     [$class: 'ParametersDefinitionProperty', parameterDefinitions: parameterDefinitions],
   ])
 
+  def defaultParameterValuesMap = [:]
+  parameterDefinitions.each {
+    // to handle params defined with the xxxParam(...) DSL instead of
+    // [$class: ... ] style because we can't call .name / .defaultValue
+    // on them directly
+    if (it.class == org.jenkinsci.plugins.structs.describable.UninstantiatedDescribable) {
+      def mapVersionOfIt = it.toMap()
+      defaultParameterValuesMap[mapVersionOfIt.name] = mapVersionOfIt.defaultValue
+    } else {
+      defaultParameterValuesMap[it.name] = it.defaultValue
+    }
+  }
+  initializeParameters(defaultParameterValuesMap)
+
   try {
     if (!isAllowedBranchBuild(env.BRANCH_NAME)) {
       return


### PR DESCRIPTION
This makes sure that build parameters are always available as environment
variables, and have their default values set if they've not been provided.
This definitely feels like something that should be handled by Jenkins
already, but it's not.

To avoid having to set separate default values as arugments we iterate
over the existing parameterDefinitions (which may be augmented by
extraParameters).  The issue here is that we can have two separate types
of parameter definitions:

1. those defined as simple map objects, for example:
    
        [$class: 'StringParameterDefinition',
          name: 'SCHEMA_BRANCH',
          defaultValue: 'deployed-to-production',
          description: 'The branch of govuk-content-schemas to test against']

2. those defined using the DSL, for example:

        stringParam(
          name: 'SCHEMA_BRANCH',
          defaultValue: 'deployed-to-production',
          description: 'The branch of govuk-content-schemas to test against']
        )

Those defined in the first way can have their details read via simple
accessors, whereas those defined the second way need to be converted
into a map first as they are (at this point anyway) objects of type
`org.jenkinsci.plugins.structs.describable.UninstantiatedDescribable`
(see: https://github.com/jenkinsci/structs-plugin/blob/master/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/UninstantiatedDescribable.java).

This also requires that we approve using the `toMap` method of
`org.jenkinsci.plugins.structs.describable.UninstantiatedDescribable`
in [the script approval area of jenkins](https://jenkins.io/doc/book/managing/script-approval/).