### PR TITLE
[AWS] Enable authenticating proxy on draft-origin

### DIFF
--- a/hieradata_aws/class/draft_cache.yaml
+++ b/hieradata_aws/class/draft_cache.yaml
@@ -18,7 +18,7 @@ govuk::apps::router_api::vhost: 'draft-router-api'
 govuk::node::s_base::apps:
   - router_api
 
-govuk::node::s_cache::enable_authenticating_proxy: true
+govuk::node::s_draft_cache::enable_authenticating_proxy: true
 
 router::nginx::check_requests_warning: '@0'
 router::nginx::check_requests_critical: '@0'


### PR DESCRIPTION
- This was set to the wrong node class (`s_cache`, not `s_draft_cache`), so the
  unauthenticated redirect to Signon wasn't working (and causing Smokey to fail).