### PR TITLE
Make enable_authenticating_proxy parameter clearer

### DIFF
--- a/hieradata/class/draft_cache.yaml
+++ b/hieradata/class/draft_cache.yaml
@@ -25,8 +25,6 @@ govuk::node::s_base::apps:
   - router
   - router_api
 
-govuk::node::s_cache::enable_authenticating_proxy: true
-
 nginx::package::nginx_package: 'nginx-extras'
 
 router::nginx::check_requests_warning: '@0'

--- a/hieradata_aws/class/draft_cache.yaml
+++ b/hieradata_aws/class/draft_cache.yaml
@@ -18,7 +18,5 @@ govuk::apps::router_api::vhost: 'draft-router-api'
 govuk::node::s_base::apps:
   - router_api
 
-govuk::node::s_draft_cache::enable_authenticating_proxy: true
-
 router::nginx::check_requests_warning: '@0'
 router::nginx::check_requests_critical: '@0'

--- a/modules/govuk/manifests/node/s_draft_cache.pp
+++ b/modules/govuk/manifests/node/s_draft_cache.pp
@@ -5,8 +5,12 @@
 #
 # Includes `govuk::node::s_cache`.
 #
-class govuk::node::s_draft_cache() {
-  include govuk::node::s_cache
+class govuk::node::s_draft_cache(
+  $enable_authenticating_proxy = true,
+) {
+  class { 'govuk::node::s_cache':
+    enable_authenticating_proxy => $enable_authenticating_proxy,
+  }
 
   $app_domain = hiera('app_domain')
 


### PR DESCRIPTION
When checking this I found it extremely confusing. We inherit a class, and set a parameter in the hieradata for a different node type.

It would be clearer to call the class so we can understand what is going on here.

This change will make it more obvious that authenticating proxy is disabled on s_cache, but enabled on s_draft_cache.