### PR TITLE
Add designprinciples back to frontend classes

### DIFF
--- a/hieradata/class/frontend.yaml
+++ b/hieradata/class/frontend.yaml
@@ -2,6 +2,7 @@
 govuk::node::s_base::apps:
   - canary_frontend
   - collections
+  - designprinciples
   - email_alert_frontend
   - feedback
   - frontend

--- a/hieradata_aws/class/frontend.yaml
+++ b/hieradata_aws/class/frontend.yaml
@@ -2,6 +2,7 @@
 govuk::node::s_base::apps:
   - canary_frontend
   - collections
+  - designprinciples
   - email_alert_frontend
   - feedback
   - frontend


### PR DESCRIPTION
For: https://trello.com/c/M45WyUGZ/261-retire-design-principles

Our previous PR (#6781) to ensure design principles is removed from our
deployed servers was too zealous.  Removing the designprinciples entry
from the frontend class definition means the `ensure => 'absent'` in
designprinciples.pp is meaningless because puppet won't use that file
anymore on the machines it's deployed to.  Adding it back means it will
understand that it still has to deal with designprinciples.pp and this
will actually remove the designprinciples app from those machines.