### PR TITLE
Add Slack notification to CDN dictionary deployment

### DIFF
--- a/modules/govuk_jenkins/manifests/job/update_cdn_dictionaries.pp
+++ b/modules/govuk_jenkins/manifests/job/update_cdn_dictionaries.pp
@@ -2,7 +2,14 @@
 #
 # Create a file on disk that can be parsed by jenkins-job-builder
 #
-class govuk_jenkins::job::update_cdn_dictionaries {
+class govuk_jenkins::job::update_cdn_dictionaries(
+  $app_domain = hiera('app_domain'),
+) {
+
+  $slack_team_domain = 'govuk'
+  $slack_room = '2ndline'
+  $slack_build_server_url = "https://deploy.${app_domain}/"
+
   file { '/etc/jenkins_jobs/jobs/update_cdn_dictionaries.yaml':
     ensure  => present,
     content => template('govuk_jenkins/jobs/update_cdn_dictionaries.yaml.erb'),

--- a/modules/govuk_jenkins/templates/jobs/update_cdn_dictionaries.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/update_cdn_dictionaries.yaml.erb
@@ -17,6 +17,18 @@
     properties:
         - github:
             url: https://github.com/alphagov/cdn-configs/
+        - slack:
+            notify-start: false
+            notify-success: true
+            notify-aborted: true
+            notify-notbuilt: true
+            notify-unstable: false
+            notify-failure: true
+            notify-backtonormal: false
+            notify-repeatedfailure: false
+            include-test-summary: false
+            room: <%= @slack_room %>
+
     scm:
       - update_cdn_dictionaries
     builders:
@@ -24,6 +36,11 @@
             cd fastly
             bundle install --path "${HOME}/bundles/${JOB_NAME}"
             bundle exec ./dictionaries/configure_dictionaries ${vhost} <%= @environment %>
+    publishers:
+      - slack:
+          team-domain: <%= @slack_team_domain %>
+          auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN']%>
+          build-server-url: <%= @slack_build_server_url %>
     wrappers:
         - ansicolor:
             colormap: xterm


### PR DESCRIPTION
Notify the govuk-deploy channel when the Update_CDN_Dictionaries Jenkins job finishes.

The CDN deployment job already does this, but it's useful to know about dictionary updates too because they could also cause errors if misconfigured.