### PR TITLE
Add the `app_domain_internal` variable to the Icinga config

### DIFF
--- a/modules/icinga/manifests/config.pp
+++ b/modules/icinga/manifests/config.pp
@@ -30,6 +30,7 @@ class icinga::config (
   contain icinga::config::smokey
 
   $app_domain = hiera('app_domain','dev.gov.uk')
+  $app_domain_internal = hiera('app_domain_internal','')
 
   $check_graphite_command = '/usr/local/bin/check_graphite'
 


### PR DESCRIPTION
- Without this, checks that use this variable (check_mapit, in AWS)
  won't work because it won't exist.

(Relates to #6824.)