### PR TITLE
[WIP] Introduce statsd repeating into graphite.cluster

### DIFF
--- a/hieradata/class/graphite.yaml
+++ b/hieradata/class/graphite.yaml
@@ -6,6 +6,8 @@ govuk_safe_to_reboot::reason: 'We lose stats and some alerting when this machine
 icinga::client::checks::disk_time_warn: 280 # milliseconds
 icinga::client::checks::disk_time_critical: 400 # milliseconds
 
+statsd::use_smart_repeater: false
+
 lv:
   data:
     pv:

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1511,6 +1511,9 @@ sidekiq_port: '6379'
 
 ssh::config::allow_users_enable: true
 
+statsd::use_smart_repeater: true
+statsd::graphite_hostname: "graphite.cluster"
+statsd::smart_repeater_hostname: "graphite.cluster"
 statsd::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk_unattended_reboot::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 

--- a/modules/monitoring/manifests/client.pp
+++ b/modules/monitoring/manifests/client.pp
@@ -17,9 +17,7 @@ class monitoring::client (
     require  => Package['update-notifier-common'],
   }
 
-  class { 'statsd':
-    graphite_hostname => $graphite_hostname,
-  }
+  include statsd
 
   file { '/usr/local/bin/notify_passive_check':
     ensure  => present,

--- a/modules/statsd/files/smart_repeater.js
+++ b/modules/statsd/files/smart_repeater.js
@@ -1,0 +1,265 @@
+/*
+ * Flush stats to a downstream statsd server.
+ *
+ * To enable this backend, include 'smart_repeater' in the backends
+ * configuration array:
+ *
+ *   backends: ['smart_repeater']
+ */
+
+var util = require('util'),
+    dgram = require('dgram'),
+    net = require('net'),
+    logger = require('../lib/logger');
+
+var l;
+var debug;
+
+function SmartRepeater(startupTime, config, emitter){
+	var self = this;
+
+	this.config = config.smartRepeater || {};
+
+	this.prefix = this.config.prefix || '';
+	this.prefix = (this.prefix.length == 0) ? "" : (this.prefix + ".");
+	this.checkExistingPrefix = this.config.checkExistingPrefix || false;
+	this.batchSize = this.config.batchSize || 1024;
+	this.blacklist = this.config.blacklist || [];
+
+	this.hostinfo = [];
+	for (var i = 0; i < this.config.hosts.length; i++) {
+		var host = this.config.hosts[i];
+		this.hostinfo.push({
+			config: host,
+			errors: 0,
+			flushTime: 0,
+			flushes: 0,
+		});
+	}
+
+	emitter.on('flush', function(time_stamp, metrics) { self.process(time_stamp, metrics); });
+};
+
+SmartRepeater.prototype.prefixedKey = function(key) {
+	if (this.checkExistingPrefix && key.indexOf(this.prefix) === 0) {
+		return key;
+	}
+
+	return this.prefix + key;
+}
+
+SmartRepeater.prototype.blacklisted = function(key) {
+	var i;
+
+	for (i = 0; i < this.blacklist.length; i++) {
+		if (this.blacklist[i].test(key)) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+SmartRepeater.prototype.sampleRateToString = function(number) {
+	var string = number.toFixed(3);
+	var index = string.length - 1;
+
+	if (string[index] == "0") {
+		while (index >= 0 && (string[index] == "0" || string[index] == ".")) { index--; }
+		if (index < 0) {
+			string = '0';
+		}
+		else {
+			string = string.substring(0, index + 1);
+		}
+	}
+
+	return string;
+};
+
+SmartRepeater.prototype.reconstituteMessages = function(metrics) {
+	var key, i;
+	var outgoing = [];
+
+	for (key in metrics.gauges) {
+		if (this.blacklisted(key)) { continue; }
+		outgoing.push(this.prefixedKey(key) + ":" + metrics.gauges[key] + "|g");
+	}
+
+	for (key in metrics.counters) {
+		if (this.blacklisted(key)) { continue; }
+		outgoing.push(this.prefixedKey(key) + ":" + metrics.counters[key] + "|c");
+	}
+
+	for (key in metrics.timers) {
+		if (this.blacklisted(key)) { continue; }
+		var values = metrics.timers[key];
+		var sampleRate = values.length / metrics.timer_counters[key];
+		var sampleRateString = (sampleRate >= 1) ? "" : ("|@" + this.sampleRateToString(sampleRate));
+
+		var rebuiltValues = [];
+		for (i = 0; i < values.length; i++) {
+			rebuiltValues.push(values[i] + "|ms" + sampleRateString);
+		}
+
+		outgoing.push(this.prefixedKey(key) + ":" + rebuiltValues.join(":"));
+	}
+
+	for (key in metrics.sets) {
+		if (this.blacklisted(key)) { continue; }
+		var values = metrics.sets[key].values();
+
+		var rebuiltValues = [];
+		for (i = 0; i < values.length; i++) {
+			rebuiltValues.push(values[i] + "|s");
+		}
+
+		outgoing.push(this.prefixedKey(key) + ":" + rebuiltValues.join(":"));
+	}
+
+	return outgoing;
+};
+
+SmartRepeater.prototype.sendToHost = function(host, metrics) {
+	var i;
+
+	var starttime = Date.now();
+
+	var data = this.splitStats([
+		this.prefix + "statsd-smart-repeater.errors:" + host.errors + "|g",
+		this.prefix + "statsd-smart-repeater.flushTime:" + host.flushTime + "|g",
+		this.prefix + "statsd-smart-repeater.flushes:" + host.flushes + "|g",
+	]).concat(metrics);
+
+	try {
+		if (host.config.protocol == "udp4" || host.config.protocol == "udp6") {
+			var sent = 0;
+			var sock = dgram.createSocket(host.config.protocol);
+			try {
+				for (i = 0; i < data.length; i++) {
+					var single = data[i];
+					var buffer = new Buffer(single);
+					sock.send(buffer, 0, single.length, host.config.port, host.config.hostname, function(err, bytes) {
+						sent++;
+						if (err && debug) {
+							l.log(err);
+						}
+
+						if (sent == data.length) {
+							sock.close();
+						}
+					});
+				}
+			}
+			catch(e) {
+				if (debug) {
+					l.log(e);
+					host.errors++;
+				}
+			}
+		}
+		else {
+			var sock = net.createConnection(host.config.port, host.config.hostname);
+			sock.setEncoding('utf8');
+			sock.setKeepAlive(false);
+			sock.setTimeout(5000, function() {
+				if (debug) {
+					l.log("Socket timed out");
+				}
+				host.errors++;
+				sock.end();
+			});
+			sock.addListener('error', function(connectionException) {
+				if (debug) {
+					l.log(connectionException);
+				}
+				host.errors++;
+				sock.end();
+			});
+			sock.on('connect', function() {
+				try {
+					for (i = 0; i < data.length; i++) {
+						var single = data[i];
+						if (i != 0) {
+							sock.write("\n");
+						}
+						sock.write(single);
+					}
+				}
+				catch(e) {
+					if (debug) {
+						l.log(e);
+					}
+					host.errors++;
+				}
+				finally {
+					sock.end();
+				}
+			});
+		}
+	}
+	catch(e) {
+		if (debug) {
+			l.log(e);
+		}
+		host.errors++;
+	}
+
+	host.flushTime = (Date.now() - starttime);
+	host.flushes++;
+};
+
+SmartRepeater.prototype.splitStats = function(stats) {
+	var i;
+
+	var buffers = [];
+	var buffer = [];
+	var bufferLength = 0;
+
+	for (i = 0; i < stats.length; i++) {
+		var line = stats[i];
+		var lineLength = line.length;
+
+		if (bufferLength != 0 && (bufferLength + lineLength) > this.batchSize) {
+			buffers.push(buffer);
+			buffer = [];
+			bufferLength = 0;
+		}
+
+		buffer.push(line);
+		bufferLength += lineLength;
+	}
+
+	if (bufferLength > 0) {
+		buffers.push(buffer);
+	}
+
+	var lines = [];
+	for (i = 0; i < buffers.length; i++) {
+		lines.push(buffers[i].join("\n"));
+	}
+
+	return lines;
+}
+
+SmartRepeater.prototype.distribute = function(reconstituted) {
+	var i;
+
+	var lines = this.splitStats(reconstituted);
+
+	for (i = 0; i < this.hostinfo.length; i++) {
+		var host = this.hostinfo[i];
+		this.sendToHost(host, lines);
+	}
+};
+
+SmartRepeater.prototype.process = function(time_stamp, metrics) {
+	this.distribute(this.reconstituteMessages(metrics));
+};
+
+exports.init = function(startupTime, config, events) {
+	var instance = new SmartRepeater(startupTime, config, events);
+	l = new logger.Logger(config.log || {});
+	debug = config.debug;
+	return true;
+};

--- a/modules/statsd/manifests/init.pp
+++ b/modules/statsd/manifests/init.pp
@@ -12,7 +12,9 @@
 #   Default: false (use 'govuk_ppa' repository)
 #
 class statsd(
-  $graphite_hostname,
+  $use_smart_repeater = false,
+  $graphite_hostname = undef,
+  $smart_repeater_hostname = undef,
   $manage_repo_class = false,
 ) {
 
@@ -24,6 +26,23 @@ class statsd(
     include statsd::repo
   } else {
     include govuk_ppa
+  }
+
+  if ($use_smart_repeater) and ($smart_repeater_hostname == undef) {
+    fail 'A $smart_repeater_hostname is required'
+  }
+
+  # commented out while graphite hostname is required
+  # if (!$use_smart_repeater) and ($graphite_hostname == undef) {
+  #   fail 'A $graphite_hostname is required'
+  # }
+
+  file { '/usr/share/statsd/backends/smart_repeater.js':
+    ensure => present,
+    mode   => '0644',
+    owner  => 'root',
+    group  => 'root',
+    source => 'puppet:///modules/statsd/smart_repeater.js',
   }
 
   package { 'statsd':

--- a/modules/statsd/templates/etc/statsd.conf.erb
+++ b/modules/statsd/templates/etc/statsd.conf.erb
@@ -38,10 +38,36 @@ Optional Variables:
   console:
     prettyprint:    whether to prettyprint the console backend
                     output [true or false, default: true]
-*/
+
+Smart Repeater Required Variables:
+  smartRepeater:
+    hosts:              array of host data to repeat information to
+      hostname:         hostname or ip address
+      port:             TCP port
+      protocol:         udp4, udp6, tcp4, tcp6
+
+Smart Repeater Optional Variables:
+  smartRepeater:
+    prefix:               stat prefix (prepended to all outgoing stats)
+    checkExistingPrefix:  true to not prepend the prefix if it's already there
+    batchSize:            max message size to send downstream
+    blacklist:            array of regexes for blacklisting metrics
 {
   graphitePort: 2003
 , graphiteHost: "<%= @graphite_hostname -%>"
+<% if @use_smart_repeater %>
+  smartRepeater: {
+    prefix: "smart_repeater",
+    checkExistingPrefix: false,
+    batchSize: 1024,
+    hosts: [
+      { hostname: "<%= @smart_repeater_hostname %>", port: 8125, protocol: "tcp4" },
+    ],
+    blacklist: [
+      /^statsd/
+    ]
+  },
+<% end %>
 , port: 8125
 , flushInterval: 5000
 }


### PR DESCRIPTION
We have identified a problem with our statsd configuration that affects statistics that can be sent with the same key from multiple hosts. Graphite will only store the last value sent within a window (this is currently configured to 5 seconds). If two hosts send a statistic with the same key within this window only the last one will be recorded and may mean for some rapidly changing statistics our data represents a 1/2 or 1/3 of the actual value.

This PR introduces a plugin to statsd - statsd_smart_repeater - which is used to send the aggregated statistics of a host to another statsd instance which then sends this data to graphite. This second statsd instance will do the aggregation between hosts.

The scope of this PR is to introduce this functionality in addition to current behaviour (with all the stats behind a namespace of smart_repeater) to allow comparison with existing behaviour.

The script for statsd_smart_repeater is from https://github.com/lucidsoftware/statsd-smart-repeater this was used instead of the repeater packaged with statsd as that does not support
aggregating stats. A slightly more popular alternative seems to be https://github.com/wanelo/gossip_girl however this was rejected due to it not supporting TCP (and it's a little less feature rich e.g. namespaces).

There's a couple of things I'm not sure about with this PR though

- [ ] Whether I'd need to open up statsd port on graphite.cluster
- [ ] Whether repeating all statsd stats in graphite for comparison may cause some sort of disk space catasrophe
