### PR TITLE
[AWS] Fix reboot check

### DIFF
--- a/modules/govuk/manifests/node/s_puppetmaster.pp
+++ b/modules/govuk/manifests/node/s_puppetmaster.pp
@@ -5,6 +5,15 @@ class govuk::node::s_puppetmaster inherits govuk::node::s_base {
 
   if $::aws_migration {
     include puppet::puppetserver
+
+    # We do not allow other hosts to connect to puppetdb, so the reboot check
+    # lives on the Puppetmaster, and we alias puppetdb to localhost so we
+    # do not go back out and in through the load balancer.
+    include monitoring::checks::reboots
+    host { 'puppetdb':
+      ensure => 'present',
+      ip     => '127.0.0.1',
+    }
   } else {
     include puppet::master
   }

--- a/modules/monitoring/manifests/checks.pp
+++ b/modules/monitoring/manifests/checks.pp
@@ -26,8 +26,10 @@ class monitoring::checks (
 
   $app_domain = hiera('app_domain')
 
-  if $app_domain != 'integration.publishing.service.gov.uk' {
-    include monitoring::checks::reboots
+  unless $::aws_migration {
+    if $app_domain != 'integration.publishing.service.gov.uk' {
+      include monitoring::checks::reboots
+    }
   }
 
   include icinga::plugin::check_http_timeout_noncrit


### PR DESCRIPTION
Currently the unattended reboot check is run from monitoring-1, and connects to puppetdb over http. It queries whether a class includes either `govuk_safe_to_reboot::yes` or `govuk_safe_to_reboot::no`, and reports to Icinga which machines need to be rebooted.

We do not allow connections over http to puppetdb in AWS, so we must move the check to the puppetmaster itself, and set up an alias so that the script `govuk_node_list` queries localhost using the correct host header, rather than going back out and in through the load balancer.