### PR TITLE
[AWS] Fix rummager checks

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/benchmark_search.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/benchmark_search.yaml.erb
@@ -24,7 +24,7 @@
             bundle install --path "${HOME}/bundles/${JOB_NAME}";
             bundle exec bin/health_check --download
             <%- if scope.lookupvar('::aws_migration') %>
-            bundle exec bin/health_check --json=https://www-origin.<%= @app_domain_internal %>/api/search.json --type=<%= @test_type %> --auth="$AUTH_USERNAME:$AUTH_PASSWORD" --rate_limit_token=$RATE_LIMIT_TOKEN
+            bundle exec bin/health_check --json=https://search.<%= @app_domain_internal %>/api/search.json --type=<%= @test_type %> --auth="$AUTH_USERNAME:$AUTH_PASSWORD" --rate_limit_token=$RATE_LIMIT_TOKEN
             <%- else %>
             bundle exec bin/health_check --json=https://www-origin.<%= @app_domain %>/api/search.json --type=<%= @test_type %> --auth="$AUTH_USERNAME:$AUTH_PASSWORD" --rate_limit_token=$RATE_LIMIT_TOKEN
             <%- end %>


### PR DESCRIPTION
In AWS we can don't need to go in via the cache machines, we can just call the Rummager API by going to the DNS record for the Search machines.