### PR TITLE
Update docker compose version

### DIFF
--- a/modules/collectd/manifests/plugin/docker.pp
+++ b/modules/collectd/manifests/plugin/docker.pp
@@ -6,11 +6,23 @@ class collectd::plugin::docker {
 
   $dependencies = [
     'py-dateutil',
-    'docker-py',
   ]
 
   package { $dependencies:
     ensure   => 'present',
+    provider => 'pip',
+  }
+
+  # This has to be installed via exec rather than a package as the namespace
+  # conflicts with the different (but same name) docker package. This issue
+  # seems to be fixed in puppet 4: https://tickets.puppetlabs.com/browse/PUP-1073
+  exec { 'pip install docker':
+    path    => ['/usr/local/bin', '/usr/bin', '/bin'],
+    command => 'pip install docker',
+  }
+
+  package { 'docker-py':
+    ensure   => 'absent',
     provider => 'pip',
   }
 

--- a/modules/govuk_ci/manifests/agent/docker.pp
+++ b/modules/govuk_ci/manifests/agent/docker.pp
@@ -11,7 +11,9 @@ class govuk_ci::agent::docker {
     docker_users => ['jenkins'],
   }
 
-  include ::docker::compose
+  class { '::docker::compose':
+    version => '1.17.1',
+  }
 
   cron::crondotdee { 'remove_docker_dangling_images' :
     hour    => 10,


### PR DESCRIPTION
This is to update docker-compose so we can make use of all the [shiny features](https://docs.docker.com/compose/compose-file/#healthcheck) that are available now we are using an up-to-date docker version. To update the docker-compose version we merely have to specify the version number in the include.

However once we update past Docker 1.9.0 we hit an issue where the dependency for [docker-py conflicts with docker-compose](https://github.com/docker/compose/issues/4569) and then we hit an even thornier issue when we try use package to do `pip install docker` as puppet won't allow us to have another package named `docker`. This uses exec to get around that constraint.

Couple of things I need to check before merging this:

- Is there an example of collectd docker output? it'd be useful to check this before and after doing a test deploy to integration as I'm not sure how to test it out locally.
- Do I need any extra checks in the exec pip install as per: https://github.com/alphagov/govuk-puppet/blob/master/modules/monitoring/manifests/uptime_collector.pp#L18-L24  ?