### PR TITLE
Inline setEnvar call into initializeParameters

### DIFF
--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -371,11 +371,15 @@ def mergeMasterBranch() {
  *
  * Cannot iterate over maps in Jenkins2 currently
  *
+ * Note: for scope-related reasons the code in here is inlined directly
+ * in the initializeParameters method below, if you change our version
+ * you should update it there too.
+ *
  * @param key
  * @param value
  */
 def setEnvar(String key, String value) {
-  echo 'Setting environment variable'
+  echo 'Setting environment variable ${key}'
   env."${key}" = value
 }
 
@@ -387,12 +391,17 @@ def setEnvar(String key, String value) {
  * every subsequent build, whether it is triggered automatically by a branch
  * push or manually by a Jenkins user.
  *
+ * This doesn't use setEnvar because for some scope-related reason we couldn't
+ * work out, first builds would fail because it couldn't find setEnvar. We
+ * inline the code instead.
+ *
  * @param defaultBuildParams map of build parameter names to default values
  */
 def initializeParameters(Map<String, String> defaultBuildParams) {
   for (param in defaultBuildParams) {
     if (env."${param.key}" == null) {
-      setEnvar(param.key, param.value)
+      echo 'Setting environment variable ${param.key}'
+      env."${param.key}" = param.value
     }
   }
 }


### PR DESCRIPTION
After making `initializeParameters` part of the standard `buildProject`
again we started getting reports of failed builds.  The builds would fail
with the following error:

    java.lang.NoSuchMethodError: No such DSL method 'setEnvar'

and the following relevant stack trace entries:

    at Script1.initializeParameters(Script1.groovy:395)
    at Script1.buildProject(Script1.groovy:130)

This points us at the invocation of `initializeParameters` we added to
the start of `buildProject`.  It's entirely unclear why this call to
`initializeParameters` can't find `setEnvar`, it's presumably a scope
issue, but I can't work it out.  More curious is that the same builds
would continue to fail if build in response to new commits, but would
sometimes start to pass if built manually, or replayed.  Once the build
passes once (or fails for a real reason - e.g. it gets past the call to
`initializeParameters`) it would continue to run properly.

The workaround seems to be inlining the code form `setEnvar` into
`initializeParameters` directly to avoid the scoping issue.  An
alternative would be to stop calling `initializeParameters` but we know
that first time builds of some projects (publishing-api in particular)
will fail if we don't call it because of a Jenkins bug (JENKINS-40574)
meaning env vars aren't properly set to their default values from build
parameters for 1st time builds in a pipeline.