### PR TITLE
[AWS] Add STS headers

### DIFF
--- a/modules/nginx/templates/proxy-vhost.conf
+++ b/modules/nginx/templates/proxy-vhost.conf
@@ -85,6 +85,7 @@ server {
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   <%- if scope.lookupvar('::aws_migration') -%>
   proxy_set_header GOVUK-Request-Id $govuk_request_id;
+  include /etc/nginx/add-sts.conf;
   <%- end -%>
   proxy_redirect off;
   proxy_connect_timeout 1s;


### PR DESCRIPTION
This is normally included when we include SSL, but this is offloaded to ELBs in AWS land.