### PR TITLE
Revert "[AWS] Fix reboot check"

### DIFF
--- a/modules/govuk/manifests/node/s_puppetmaster.pp
+++ b/modules/govuk/manifests/node/s_puppetmaster.pp
@@ -5,15 +5,6 @@ class govuk::node::s_puppetmaster inherits govuk::node::s_base {
 
   if $::aws_migration {
     include puppet::puppetserver
-
-    # We do not allow other hosts to connect to puppetdb, so the reboot check
-    # lives on the Puppetmaster, and we alias puppetdb to localhost so we
-    # do not go back out and in through the load balancer.
-    include monitoring::checks::reboots
-    host { 'puppetdb':
-      ensure => 'present',
-      ip     => '127.0.0.1',
-    }
   } else {
     include puppet::master
   }

--- a/modules/monitoring/manifests/checks.pp
+++ b/modules/monitoring/manifests/checks.pp
@@ -26,10 +26,8 @@ class monitoring::checks (
 
   $app_domain = hiera('app_domain')
 
-  unless $::aws_migration {
-    if $app_domain != 'integration.publishing.service.gov.uk' {
-      include monitoring::checks::reboots
-    }
+  if $app_domain != 'integration.publishing.service.gov.uk' {
+    include monitoring::checks::reboots
   }
 
   include icinga::plugin::check_http_timeout_noncrit


### PR DESCRIPTION
This reverts commit 97b9a53e8a44456005d003150b6f43fb7c93e25a.

This caused a relationship error I can't be bothered to fix for now:

```
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Invalid relationship: File[/etc/icinga/conf.d/icinga_host_ip-10-1-4-115.eu-west-1.compute.internal/check_reboots_required.cfg] { require => Class[Icinga::Package] }, because Class[Icinga::Package] doesn't seem to be in the catalog
```