### PR TITLE
Remove enable_authenticating_proxy hieradata again

### DIFF
--- a/hieradata/class/draft_cache.yaml
+++ b/hieradata/class/draft_cache.yaml
@@ -21,8 +21,6 @@ govuk::apps::router_api::router_nodes:
   - 'draft-cache-2.router:3055'
 govuk::apps::router_api::vhost: 'draft-router-api'
 
-govuk::node::s_cache::enable_authenticating_proxy: true
-
 nginx::package::nginx_package: 'nginx-extras'
 
 router::nginx::check_requests_warning: '@0'

--- a/hieradata_aws/class/draft_cache.yaml
+++ b/hieradata_aws/class/draft_cache.yaml
@@ -15,7 +15,5 @@ govuk::apps::router_api::router_nodes_class: 'draft_cache'
 
 govuk::apps::router_api::vhost: 'draft-router-api'
 
-govuk::node::s_draft_cache::enable_authenticating_proxy: true
-
 router::nginx::check_requests_warning: '@0'
 router::nginx::check_requests_critical: '@0'


### PR DESCRIPTION
- In 89e8096, these parameters were removed. In dbb639e, these were
  accidentally added back in again (presumably in a wonky rebase). We
  don't want them.