### PR TITLE
Enable search fetch analytics data in all environs

### DIFF
--- a/hieradata/class/integration/jenkins.yaml
+++ b/hieradata/class/integration/jenkins.yaml
@@ -30,6 +30,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::run_rake_task
   - govuk_jenkins::job::run_whitehall_data_migrations
   - govuk_jenkins::job::search_benchmark
+  - govuk_jenkins::job::search_fetch_analytics_data
   - govuk_jenkins::job::search_index_checks
   - govuk_jenkins::job::search_reindex_with_new_schema
   - govuk_jenkins::job::search_test_spelling_suggestions

--- a/hieradata/class/staging/jenkins.yaml
+++ b/hieradata/class/staging/jenkins.yaml
@@ -20,6 +20,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::remove_emergency_banner
   - govuk_jenkins::job::run_rake_task
   - govuk_jenkins::job::run_whitehall_data_migrations
+  - govuk_jenkins::job::search_fetch_analytics_data
   - govuk_jenkins::job::search_index_checks
   - govuk_jenkins::job::search_reindex_with_new_schema
   - govuk_jenkins::job::smokey

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -138,6 +138,7 @@ govuk_jenkins::job::deploy_dns::gce_project_id: 'govuk-integration'
 govuk_jenkins::job::deploy_dns::zones:
   - 'dnstest.alphagov.co.uk'
 
+govuk_jenkins::job::search_fetch_analytics_data::skip_page_traffic_load: true
 govuk_jenkins::job::search_benchmark::cron_schedule: '30 9 * * 1-5'
 govuk_jenkins::job::search_reindex_with_new_schema::icinga_check_enabled: true
 govuk_jenkins::job::search_reindex_with_new_schema::cron_schedule: '0 12 * * 1'

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -139,6 +139,7 @@ govuk_jenkins::job::deploy_dns::zones:
   - 'dnstest.alphagov.co.uk'
 
 govuk_jenkins::job::search_fetch_analytics_data::skip_page_traffic_load: true
+govuk_jenkins::job::search_fetch_analytics_data::cron_schedule: '30 9 * * 1-5'
 govuk_jenkins::job::search_benchmark::cron_schedule: '30 9 * * 1-5'
 govuk_jenkins::job::search_reindex_with_new_schema::icinga_check_enabled: true
 govuk_jenkins::job::search_reindex_with_new_schema::cron_schedule: '0 12 * * 1'

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -64,6 +64,7 @@ govuk_jenkins::job::network_config_deploy::environments:
   - 'carrenza-staging-dr'
   - 'skyscape-staging'
 
+govuk_jenkins::job::search_fetch_analytics_data::skip_page_traffic_load: true
 govuk_jenkins::job::smokey::smokey_task: 'test:staging'
 
 govuk_jenkins::job::data_sync_complete_staging::signon_domains_to_migrate:

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -65,6 +65,7 @@ govuk_jenkins::job::network_config_deploy::environments:
   - 'skyscape-staging'
 
 govuk_jenkins::job::search_fetch_analytics_data::skip_page_traffic_load: true
+govuk_jenkins::job::search_fetch_analytics_data::cron_schedule: '30 8 * * 1-5'
 govuk_jenkins::job::smokey::smokey_task: 'test:staging'
 
 govuk_jenkins::job::data_sync_complete_staging::signon_domains_to_migrate:

--- a/modules/govuk_jenkins/manifests/job/search_fetch_analytics_data.pp
+++ b/modules/govuk_jenkins/manifests/job/search_fetch_analytics_data.pp
@@ -5,6 +5,7 @@
 class govuk_jenkins::job::search_fetch_analytics_data (
   $ga_auth_password = undef,
   $app_domain = hiera('app_domain'),
+  $skip_page_traffic_load = false,
 ) {
 
   $check_name = 'search-fetch-analytics-data'

--- a/modules/govuk_jenkins/manifests/job/search_fetch_analytics_data.pp
+++ b/modules/govuk_jenkins/manifests/job/search_fetch_analytics_data.pp
@@ -6,6 +6,7 @@ class govuk_jenkins::job::search_fetch_analytics_data (
   $ga_auth_password = undef,
   $app_domain = hiera('app_domain'),
   $skip_page_traffic_load = false,
+  $cron_schedule = '5 4 * * *',
 ) {
 
   $check_name = 'search-fetch-analytics-data'

--- a/modules/govuk_jenkins/templates/jobs/search_fetch_analytics_data.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/search_fetch_analytics_data.yaml.erb
@@ -24,7 +24,7 @@
         - search-analytics_search-fetch-analytics-data
     builders:
         - shell: |
-            ./nightly-run.sh
+            ./nightly-run.sh <%= @skip_page_traffic_load && 'SKIP_TRAFFIC_LOAD=true' %>
     triggers:
         - timed: '5 4 * * *'
     publishers:

--- a/modules/govuk_jenkins/templates/jobs/search_fetch_analytics_data.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/search_fetch_analytics_data.yaml.erb
@@ -26,7 +26,7 @@
         - shell: |
             ./nightly-run.sh <%= @skip_page_traffic_load && 'SKIP_TRAFFIC_LOAD=true' %>
     triggers:
-        - timed: '5 4 * * *'
+        - timed: '<%= @cron_schedule %>'
     publishers:
         - trigger-parameterized-builds:
             - project: Success_Passive_Check


### PR DESCRIPTION
This includes the ability to disable the GA data download
on a per environment basic.

https://trello.com/c/3VkbdYrB/456-test-nightly-popularity-rebuild-on-integration-and-staging