### PR TITLE
Add mongodb_nodes for router back in

### DIFF
--- a/hieradata_aws/class/cache.yaml
+++ b/hieradata_aws/class/cache.yaml
@@ -4,4 +4,10 @@ govuk::apps::authenticating_proxy::mongodb_nodes:
   - 'router-backend-2'
   - 'router-backend-3'
 
+govuk::apps::router::mongodb_name: 'router'
+govuk::apps::router::mongodb_nodes:
+  - 'router-backend-1'
+  - 'router-backend-2'
+  - 'router-backend-3'
+
 govuk::deploy::config::app_domain: "%{hiera('app_domain_internal')}"

--- a/hieradata_aws/class/draft_cache.yaml
+++ b/hieradata_aws/class/draft_cache.yaml
@@ -11,6 +11,12 @@ govuk::apps::router_api::mongodb_nodes:
   - 'router-backend-2'
   - 'router-backend-3'
 
+govuk::apps::router::mongodb_name: "%{hiera('govuk::apps::router_api::mongodb_name')}"
+govuk::apps::router::mongodb_nodes:
+  - 'router-backend-1'
+  - 'router-backend-2'
+  - 'router-backend-3'
+
 govuk::apps::router_api::router_nodes_class: 'draft_cache'
 
 govuk::apps::router_api::vhost: 'draft-router-api'


### PR DESCRIPTION
Router is being deployed due to the changes in how we assign apps to nodes, and now Puppet is erroring because we're not setting these nodes in AWS.

https://trello.com/c/IbnMEmul/793-router-move-away-from-container-deployment