### PR TITLE
Fix ENVIRONMENT variable ordering for search jenkins jobs

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/search_fetch_analytics_data.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/search_fetch_analytics_data.yaml.erb
@@ -24,7 +24,7 @@
         - search-analytics_search-fetch-analytics-data
     builders:
         - shell: |
-            ./nightly-run.sh <%= @skip_page_traffic_load && 'SKIP_TRAFFIC_LOAD=true' %>
+            <%= @skip_page_traffic_load && 'SKIP_TRAFFIC_LOAD=true' %> ./nightly-run.sh
     triggers:
         - timed: '<%= @cron_schedule %>'
     publishers:

--- a/modules/govuk_jenkins/templates/jobs/search_reindex_with_new_schema.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/search_reindex_with_new_schema.yaml.erb
@@ -12,7 +12,7 @@
         - timed: '<%= @cron_schedule %>'
 <% end %>
     builders:
-        - shell: ssh deploy@$(govuk_node_list -c search --single-node) "cd /var/apps/rummager && govuk_setenv rummager CONFIRM_INDEX_MIGRATION_START=1 bundle exec rake rummager:migrate_schema"
+        - shell: ssh deploy@$(govuk_node_list -c search --single-node) "cd /var/apps/rummager && govuk_setenv rummager bundle exec rake rummager:migrate_schema CONFIRM_INDEX_MIGRATION_START=1 RUMMAGER_INDEX=all"
     wrappers:
       - ansicolor:
           colormap: xterm


### PR DESCRIPTION
search_fetch_analytics_data needs to set the var before calling the script
search_reindex_with_new_schema need to set the var after the rake task is called

https://trello.com/c/3VkbdYrB/456-test-nightly-popularity-rebuild-on-integration-and-staging