### PR TITLE
Add sent_http_content_type to json logformat

### DIFF
--- a/modules/nginx/templates/etc/nginx/nginx.conf.erb
+++ b/modules/nginx/templates/etc/nginx/nginx.conf.erb
@@ -49,6 +49,7 @@ http {
                          '"gzip_ratio": "$gzip_ratio", '
                          '"sent_http_x_cache": "$sent_http_x_cache", '
                          '"sent_http_location": "$sent_http_location", '
+                         '"sent_http_content_type": "$sent_http_content_type", '
                          '"http_host": "$http_host", '
                          '"server_name": "$server_name", '
                          '"server_port": "$server_port", '


### PR DESCRIPTION
This will help debugging the issue with content-types missing from
asset responses.