### PR TITLE
Upgrade UNKNOWN to CRITICAL

### DIFF
--- a/modules/puppet/files/usr/lib/nagios/plugins/check_puppet_agent
+++ b/modules/puppet/files/usr/lib/nagios/plugins/check_puppet_agent
@@ -43,8 +43,8 @@ begin
     exit 1
   end
 rescue
-  puts "UNKNOWN: Could not parse puppet summary file"
-  exit 3
+  puts "CRITICAL: Could not parse puppet summary file"
+  exit 2
 end
 
 puts "OK: Puppet is doing good [ver: #{config_version}]"


### PR DESCRIPTION
This alert appears to be raised when there is a problem with the Puppet summary file, which more often than not means that it has not been written correctly. As an example:

```
---
  version:
    config:
    puppet: "3.8.5"
  time:
    last_run: 1511542072
```

We think this is when Puppet cannot receive the catalogue, which means it doesn't even write any failures in the state.

UNKNOWN alerts tend to go unnoticed by 2ndline, and being unable to retrieve the catalogue is usually related to a relationship or duplicate resource error. These should be fixed as priority, so upgrade the alert to CRITICAL, rather than WARNING.