### PR TITLE
[AWS] Update jenkins-cli and include with app machines

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -608,6 +608,8 @@ govuk::deploy::config::asset_root: "https://%{hiera('router::assets_origin::vhos
 govuk::deploy::config::website_root: "https://www-origin.%{hiera('app_domain')}"
 govuk::deploy::config::app_domain: "%{hiera('app_domain')}"
 govuk::deploy::setup::gemstash_server: 'http://gemstash'
+govuk::deploy::setup::jenkins_url: "deploy.%{hiera('app_domain_internal')}"
+govuk::deploy::setup::jenkins_jar_directory: '/usr/local/etc'
 
 govuk_gor::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 

--- a/modules/govuk/manifests/deploy/setup.pp
+++ b/modules/govuk/manifests/deploy/setup.pp
@@ -24,6 +24,8 @@ class govuk::deploy::setup (
     $aws_ses_smtp_password,
     $gemstash_server = 'http://gemstash.cluster',
     $ssh_keys = { 'not set in hiera' => 'NONE_IN_HIERA' },
+    $jenkins_url = undef,
+    $jenkins_jar_directory = undef,
 ){
   validate_hash($ssh_keys)
 
@@ -105,5 +107,14 @@ class govuk::deploy::setup (
     require   => User['deploy'],
     user_home => '/home/deploy',
     username  => 'deploy',
+  }
+
+  # In AWS we wish to automate deploys using Jenkins when a node is created
+  # for all application instances
+  if $::aws_migration {
+    class { 'govuk_jenkins::cli':
+      jenkins_url   => $jenkins_url,
+      jar_directory => $jenkins_jar_directory,
+    }
   }
 }

--- a/modules/govuk_jenkins/manifests/cli.pp
+++ b/modules/govuk_jenkins/manifests/cli.pp
@@ -12,9 +12,12 @@
 #
 # === Parameters:
 #
-# [*jenkins_home*]
-#   The home directory of the Jenkins install, and where to put the
-#   Jenkins CLI jar.
+# [*jenkins_url*]
+#   The URL of the Jenkins instance. Must include protocol and ports:
+#   http://localhost:8080
+#
+# [*jar_directory*]
+#   Where to install the Jenkins CLI jar file.
 #
 # [*jenkins_api_user*]
 #   The user used to authenticate with the Jenkins API.
@@ -23,15 +26,14 @@
 #   The token used to authenticate with the Jenkins API.
 #
 class govuk_jenkins::cli (
-  $jenkins_home = '/var/lib/jenkins',
+  $jenkins_url = 'http://localhost:8080',
+  $jar_directory = '/var/lib/jenkins',
   $jenkins_api_user = 'jenkins_api_user',
   $jenkins_api_token = '',
 ) {
-  require ::govuk_jenkins
-
   curl::fetch { 'Jenkins CLI tool':
-    source      => 'http://localhost:8080/jnlpJars/jenkins-cli.jar',
-    destination => "${jenkins_home}/jenkins-cli.jar",
+    source      => "${jenkins_url}/jnlpJars/jenkins-cli.jar",
+    destination => "${jar_directory}/jenkins-cli.jar",
     timeout     => 0,
     verbose     => false,
   }

--- a/modules/govuk_jenkins/templates/jenkins-cli.erb
+++ b/modules/govuk_jenkins/templates/jenkins-cli.erb
@@ -5,4 +5,4 @@ if [ "$EUID" -ne 0 ]
   exit 1
 fi
 
-/usr/bin/java -jar <%= @jenkins_home %>/jenkins-cli.jar -s http://localhost:8080/ -http -auth <%= @jenkins_api_user %>:<%= @jenkins_api_token %> "$@"
+/usr/bin/java -jar <%= @jar_directory %>/jenkins-cli.jar -s <%= @jenkins_url %> -http -auth <%= @jenkins_api_user %>:<%= @jenkins_api_token %> "$@"


### PR DESCRIPTION
This would allow a machine to interact with Jenkins using the jenkins-cli tool. In AWS,
we wish for machines to trigger a job which deploys all apps that they should run
when they are first created at boot.

Including the jenkins-cli tool allows an easy way to trigger a job, and already
includes the credentials neccessary to do this.

We may want to create a specific user for this however, as the current API user
has quite far reaching permissions in Jenkins.

https://trello.com/c/Xd9oR5ww/836-create-jenkins-job-to-deploy-all-apps-to-a-given-node-class