### PR TITLE
[AWS] Don't run router in a container

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -791,13 +791,6 @@ govuk_containers::apps::release::envvars:
   - "DATABASE_URL=mysql2://%{hiera('govuk::apps::release::db_username')}:%{hiera('govuk::apps::release::db_password')}@%{hiera('govuk::apps::release::db_hostname')}/release_production"
   - "RAILS_SERVE_STATIC_FILES=true"
 
-govuk_containers::apps::router::envvars:
-  - "ROUTER_PUBADDR=localhost:3054"
-  - "ROUTER_APIADDR=:3055"
-  - "ROUTER_MONGO_DB=router"
-  - "ROUTER_MONGO_URL=router-backend-1,router-backend-2,router-backend-3"
-  - "ROUTER_BACKEND_HEADER_TIMEOUT=20s"
-
 govuk_containers::frontend::haproxy::backend_mappings:
   - "release.%{hiera('app_domain')}": "release"
 govuk_containers::frontend::haproxy::wildcard_publishing_certificate: "%{hiera('wildcard_publishing_certificate')}"

--- a/modules/govuk/manifests/node/s_cache.pp
+++ b/modules/govuk/manifests/node/s_cache.pp
@@ -40,10 +40,6 @@ class govuk::node::s_cache (
   include govuk_htpasswd
   include router::gor
 
-  if $::aws_migration {
-    include ::govuk_containers::apps::router
-  }
-
   class { 'nginx':
     denied_ip_addresses     => $denied_ip_addresses,
     variables_hash_max_size => '768',


### PR DESCRIPTION
- This has been a snowflake. Remove the `govuk_containers` router manifest.
  We're going to revert to doing this normally, apart from pulling the binary
  from S3.

Reverts #6259 apart from the hieradata.
https://trello.com/c/IbnMEmul/793-router-move-away-from-container-deployment