### PR TITLE
[DO NOT MERGE] Enable sysdig everywhere

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -877,7 +877,6 @@ govuk_sudo::sudo_conf:
     content: 'ubuntu ALL=(ALL) NOPASSWD:ALL'
 
 govuk_sysdig::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
-govuk_sysdig::ensure: 'absent'
 
 govuk_unattended_reboot::enabled: true
 govuk_unattended_reboot::mongodb::enabled: true

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -878,7 +878,6 @@ govuk_sudo::sudo_conf:
     content: 'ubuntu ALL=(ALL) NOPASSWD:ALL'
 
 govuk_sysdig::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
-govuk_sysdig::ensure: 'absent'
 
 govuk_unattended_reboot::alert_hostname: 'alert'
 govuk_unattended_reboot::enabled: true

--- a/modules/base/manifests/init.pp
+++ b/modules/base/manifests/init.pp
@@ -13,12 +13,13 @@ class base {
   include cron
   include curl
   include govuk::deploy
-  include govuk_apt::unused_kernels
   include govuk_apt::package_blacklist
+  include govuk_apt::unused_kernels
   include govuk_envsys
   include govuk_scripts
   include govuk_sshkeys
   include govuk_sudo
+  include govuk_sysdig
   include govuk_unattended_reboot
   include logrotate
   include ntp

--- a/modules/base/manifests/init.pp
+++ b/modules/base/manifests/init.pp
@@ -4,37 +4,37 @@
 # both `govuk::node::s_base` and `govuk::node::s_development`.
 #
 class base {
-  include apparmor
-  include apt
-  include base::packages
-  include base::screen
-  include base::shell
-  include base::supported_kernel
-  include cron
-  include curl
-  include govuk::deploy
-  include govuk_apt::package_blacklist
-  include govuk_apt::unused_kernels
-  include govuk_envsys
-  include govuk_scripts
-  include govuk_sshkeys
-  include govuk_sudo
-  include govuk_sysdig
-  include govuk_unattended_reboot
-  include logrotate
-  include ntp
-  include puppet
+  include ::apparmor
+  include ::apt
+  include ::base::packages
+  include ::base::screen
+  include ::base::shell
+  include ::base::supported_kernel
+  include ::cron
+  include ::curl
+  include ::govuk::deploy
+  include ::govuk_apt::package_blacklist
+  include ::govuk_apt::unused_kernels
+  include ::govuk_envsys
+  include ::govuk_scripts
+  include ::govuk_sshkeys
+  include ::govuk_sudo
+  include ::govuk_sysdig
+  include ::govuk_unattended_reboot
+  include ::logrotate
+  include ::ntp
+  include ::puppet
 
   if ! $::aws_migration {
-    include resolvconf
+    include ::resolvconf
   }
 
-  include ssh
-  include timezone
-  include tmpreaper
-  include unattended_upgrades
-  include users
-  include wget
+  include ::ssh
+  include ::timezone
+  include ::tmpreaper
+  include ::unattended_upgrades
+  include ::users
+  include ::wget
 
   ensure_packages([ 'gcc', 'build-essential' ])
 

--- a/modules/govuk_ci/manifests/agent.pp
+++ b/modules/govuk_ci/manifests/agent.pp
@@ -35,7 +35,6 @@ class govuk_ci::agent(
   include ::govuk_jenkins::pipeline
   include ::govuk_jenkins::user
   include ::govuk_rbenv::all
-  include ::govuk_sysdig
   include ::govuk_testing_tools
 
   # Override sudoers.d resource (managed by sudo module) to enable Jenkins user to run sudo tests

--- a/modules/govuk_sysdig/manifests/init.pp
+++ b/modules/govuk_sysdig/manifests/init.pp
@@ -8,22 +8,20 @@
 #   Hostname to use for the APT mirror.
 #   Defaults to undefined because `$use_mirror` can be disabled.
 #
-class govuk_sysdig (
-  $ensure = 'present',
+class govuk_sysdig(
   $apt_mirror_hostname = undef,
 ) {
 
   apt::source { 'sysdig':
-    ensure   => $ensure,
     location => "http://${apt_mirror_hostname}/sysdig",
     release  => 'stable-amd64',
     key      => 'D27A72F32D867DF9300A241574490FD6EC51E8C4',
   }
 
-  ensure_packages( [ "linux-headers-${::kernelrelease}" ])
+  ensure_packages( [ "linux-headers-${::kernelrelease}" ] )
 
   package { 'sysdig':
-    ensure  => $ensure,
+    ensure  => 'installed',
     require => [
       Apt::Source['sysdig'],
       Package["linux-headers-${::kernelrelease}"],


### PR DESCRIPTION
Sysdig is an extremely useful tool for diagnosing any OS level issues.

It is something that should be a default tool at our disposable in our systems. A reboot would be required to enable it, but we should organically let it be enabled over time as instances are rebooted.

https://trello.com/c/3y6WEkin/821-check-sysdig-repository-and-add-back-in