### PR TITLE
Get link-checker-api redis host to work in dev VM

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -387,6 +387,8 @@ govuk::apps::hmrc_manuals_api::redis_port: "%{hiera('sidekiq_port')}"
 
 govuk::apps::link_checker_api::db_hostname: "postgresql-primary-1.backend"
 govuk::apps::link_checker_api::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
+# Hardcoded to its own redis server to improve performance
+# This setting is overridden in `development.yaml`
 govuk::apps::link_checker_api::redis_host: "redis-2.backend"
 govuk::apps::link_checker_api::redis_port: "%{hiera('sidekiq_port')}"
 

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -113,6 +113,7 @@ govuk::apps::licencefinder::mongodb_nodes: ['localhost']
 govuk::apps::manuals_frontend::enable_running_in_draft_mode::content_store: 'http://draft-content-store.dev.gov.uk'
 govuk::apps::link_checker_api::enable_procfile_worker: false
 govuk::apps::link_checker_api::enabled: true
+govuk::apps::link_checker_api::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::manuals_publisher::enable_procfile_worker: false
 govuk::apps::manuals_publisher::mongodb_nodes: ['localhost']
 govuk::apps::manuals_publisher::mongodb_name: 'manuals_publisher_development'


### PR DESCRIPTION
The redis host for `link-checker-api` is hardcoded in hiera data to a separate host to improve performance. This commit resets it to `localhost` for the development VM otherwise `link-checker-api` does not work locally.