### PR TITLE
Fix authenticating-proxy setup

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -61,6 +61,7 @@ node_class: &node_class
       - smartanswers
   draft_cache:
     apps:
+      - authenticating-proxy
       - router
       - router-api
   draft_content_store:

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -63,6 +63,7 @@ node_class: &node_class
       - smartanswers
   draft_cache:
     apps:
+      - authenticating-proxy
       - router
       - router-api
   draft_content_store:

--- a/modules/govuk/manifests/apps/authenticating_proxy.pp
+++ b/modules/govuk/manifests/apps/authenticating_proxy.pp
@@ -44,7 +44,7 @@ class govuk::apps::authenticating_proxy(
   $mongodb_name = 'authenticating_proxy_production',
   $port = '3107',
   $sentry_dsn = undef,
-  $govuk_upstream_uri = undef,
+  $govuk_upstream_uri = 'http://localhost:3054',
   $oauth_id = undef,
   $oauth_secret = undef,
   $secret_key_base = undef,

--- a/modules/govuk/manifests/node/s_cache.pp
+++ b/modules/govuk/manifests/node/s_cache.pp
@@ -84,13 +84,6 @@ class govuk::node::s_cache (
     strip_cookies => $strip_cookies,
   }
 
-  if $enable_authenticating_proxy {
-    include govuk::node::s_app_server
-    class { 'govuk::apps::authenticating_proxy':
-      govuk_upstream_uri => 'http://localhost:3054',
-    }
-  }
-
   @@icinga::check::graphite { "check_nginx_connections_writing_${::hostname}":
     target    => "${::fqdn_metrics}.nginx.nginx_connections-writing",
     warning   => 150,

--- a/modules/govuk/manifests/node/s_draft_cache.pp
+++ b/modules/govuk/manifests/node/s_draft_cache.pp
@@ -8,6 +8,8 @@
 class govuk::node::s_draft_cache(
   $enable_authenticating_proxy = true,
 ) {
+  include govuk::node::s_app_server
+
   class { 'govuk::node::s_cache':
     enable_authenticating_proxy => $enable_authenticating_proxy,
   }


### PR DESCRIPTION
Include authenticating proxy on the draft cache instances by using the standard method of including apps.

Remove the explicit call of the app class from the conditional set in the `cache` node class.

Authenticating proxy is always enabled, so set it as enabled by default on `draft cache`.

https://trello.com/c/PuutBAQ0/854-fix-authenticating-proxy-setup