### PR TITLE
Fix Rummager search index tests

### DIFF
--- a/modules/govuk/manifests/apps/rummager.pp
+++ b/modules/govuk/manifests/apps/rummager.pp
@@ -184,6 +184,11 @@ class govuk::apps::rummager(
     value   => $elasticsearch_hosts,
   }
 
+  govuk::app::envvar { "${title}-ELASTICSEARCH_HOSTS":
+    varname => 'ELASTICSEARCH_HOSTS',
+    value   => $elasticsearch_hosts,
+  }
+
   govuk::app::envvar { "${title}-SITEMAP_GENERATION_TIME":
     varname => 'SITEMAP_GENERATION_TIME',
     value   => $sitemap_generation_time,


### PR DESCRIPTION
In AWS the "Search Index" job failed because it was trying to connect to localhost:9200. In Carrenza this is not an issue as there is a proxy that listens on localhost, but in AWS we go directly to an Elastic Load Balancer, and so requests to localhost would fail.

This was because the rake task that ran this particular test[1][] used the ELASTICSEARCH_HOSTS environment variable to set the destination, rather than ELASTICSEARCH_URI. These values should be exactly the same, so add the additional environment variable.

This should be fixed in Rummager itself, but to ensure that nothing else breaks when using this env var, ensure that it is set everywhere.

[1]https://github.com/alphagov/rummager/blob/master/lib/services.rb#L27