### PR TITLE
Collect sidekiq logs consistently

### DIFF
--- a/modules/govuk/manifests/app.pp
+++ b/modules/govuk/manifests/app.pp
@@ -370,6 +370,12 @@ define govuk::app (
     fields => {'application' => $title},
   }
 
+  @filebeat::prospector { "${title}_sidekiq_json_log":
+    paths  => ["/var/apps/${title}/log/sidekiq*.log"],
+    fields => {'application' => $title},
+    json   => {'add_error_key' => true},
+  }
+
   # FIXME: when we have migrated all apps to output logs to /var/log this
   # can be removed
   if ($app_type == 'rack' or  $log_format_is_json) {

--- a/modules/govuk/manifests/apps/email_alert_api.pp
+++ b/modules/govuk/manifests/apps/email_alert_api.pp
@@ -106,12 +106,6 @@ class govuk::apps::email_alert_api(
       enable_service => $enable_procfile_worker,
     }
 
-    @filebeat::prospector { 'email_alert_api_sidekiq_json_log':
-      paths  => ['/var/apps/email-alert-api/log/sidekiq.json.log'],
-      fields => {'application' => 'email-alert-api-sidekiq'},
-      json   => {'add_error_key' => true},
-    }
-
     @filebeat::prospector { 'govdelivery_json_log':
       paths  => ['/var/apps/email-alert-api/log/govdelivery.log'],
       fields => {'application' => 'email-alert-api-govdelivery'},

--- a/modules/govuk/manifests/apps/publisher.pp
+++ b/modules/govuk/manifests/apps/publisher.pp
@@ -96,7 +96,9 @@ class govuk::apps::publisher(
     $email_group_citizen = undef,
   ) {
 
-  govuk::app { 'publisher':
+  $app_name = 'publisher'
+
+  govuk::app { $app_name:
     app_type            => 'rack',
     port                => $port,
     sentry_dsn          => $sentry_dsn,
@@ -133,24 +135,24 @@ class govuk::apps::publisher(
     group  => 'assets',
   }
 
-  govuk::procfile::worker {'publisher':
+  govuk::procfile::worker { $app_name:
     enable_service => $enable_procfile_worker,
   }
 
   if $mongodb_nodes != undef {
-    govuk::app::envvar::mongodb_uri { 'publisher':
+    govuk::app::envvar::mongodb_uri { $app_name:
       hosts    => $mongodb_nodes,
       database => $mongodb_name,
     }
   }
 
-  govuk::app::envvar::redis { 'publisher':
+  govuk::app::envvar::redis { $app_name:
     host => $redis_host,
     port => $redis_port,
   }
 
   Govuk::App::Envvar {
-    app => 'publisher',
+    app => $app_name,
   }
 
   if $run_fact_check_fetcher {

--- a/modules/govuk/manifests/apps/publishing_api.pp
+++ b/modules/govuk/manifests/apps/publishing_api.pp
@@ -215,11 +215,4 @@ class govuk::apps::publishing_api(
       }
     }
   }
-
-  @filebeat::prospector { 'publishing_api_sidekiq_json_log':
-    paths  => ['/var/apps/publishing-api/log/sidekiq.json.log'],
-    fields => {'application' => 'publishing-api-sidekiq'},
-    json   => {'add_error_key' => true },
-  }
-
 }

--- a/modules/govuk/manifests/apps/specialist_publisher.pp
+++ b/modules/govuk/manifests/apps/specialist_publisher.pp
@@ -108,12 +108,6 @@ client_max_body_size 500m;
       asset_pipeline         => true,
     }
 
-    @filebeat::prospector { "${app_name}_sidekiq_json_log":
-      paths  => ["/var/apps/${app_name}/log/sidekiq.json.log"],
-      fields => {'application' => $app_name},
-      json   => {'add_error_key' => true},
-    }
-
     Govuk::App::Envvar {
       app => $app_name,
     }

--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -316,12 +316,6 @@ class govuk::apps::whitehall(
       json   => {'add_error_key' => true},
     }
 
-    @filebeat::prospector { 'whitehall_sidekiq_json_log':
-      paths  => ['/var/apps/whitehall/log/sidekiq.json.log'],
-      fields => {'application' => 'whitehall-sidekiq'},
-      json   => {'add_error_key' => true},
-    }
-
     govuk::procfile::worker { 'whitehall-admin':
       setenv_as      => $app_name,
       enable_service => $enable_procfile_worker,


### PR DESCRIPTION
I would like to collect logs for Publisher's workers, but feel it might be
useful to collect them for everything (and hopefully get closer to a consistent
logging experience across our apps).

Some apps log to sidekiq.json.log and some to sidekiq.log but it all seems to
be in json format so I think we should be OK.

If there are multiple files that the path matches then Filebeat will
[set up a harvester for each](https://www.elastic.co/guide/en/beats/filebeat/master/configuration-filebeat-options.html#prospector-paths)

I think it follows that if it doesn't find anything the, that's OK too.