### PR TITLE
Run correct app for dummy-content-store

### DIFF
--- a/development-vm/Procfile
+++ b/development-vm/Procfile
@@ -69,7 +69,7 @@ specialist-publisher-worker: govuk_setenv specialist-publisher ./run_in.sh ../..
 manuals-publisher:     govuk_setenv manuals-publisher     ./run_in.sh ../../manuals-publisher bundle exec foreman start
 # specialist-frontend used port 3065
 content-store:         govuk_setenv content-store         ./run_in.sh ../../content-store  bundle exec rails server -p 3068
-dummy-content-store:   govuk_setenv content-store         ./run_in.sh ../../govuk-content-schemas  bundle exec dummy_content_store
+dummy-content-store:   govuk_setenv content-store         ./run_in.sh ../../govuk-content-schemas  bundle exec ruby app.rb
 # content-store also uses port 3069
 collections:           govuk_setenv collections           ./run_in.sh ../../collections    bundle exec rails server -p 3070
 # hmrc-manuals-api uses port 3071


### PR DESCRIPTION
This changed in https://github.com/alphagov/govuk-content-schemas/pull/665.