### PR TITLE
Add build token plugin and allow passing in auth token

### DIFF
--- a/hieradata_aws/class/jenkins.yaml
+++ b/hieradata_aws/class/jenkins.yaml
@@ -84,6 +84,8 @@ govuk_jenkins::plugins:
     version: '1.6.7'
   build-pipeline-plugin:
     version: '1.5.7.1'
+  build-token-root:
+    version: '1.4'
   build-with-parameters:
     version: '1.4'
   cloudbees-folder:

--- a/modules/govuk_jenkins/manifests/deploy_all_apps.pp
+++ b/modules/govuk_jenkins/manifests/deploy_all_apps.pp
@@ -27,6 +27,7 @@ class govuk_jenkins::deploy_all_apps (
   $user = 'jenkins',
   $apps_on_nodes = {},
   $deploy_environment = 'development',
+  $auth_token = '',
 ) {
 
   $project_directory = "${jobs_directory}/${project_name}"
@@ -55,6 +56,7 @@ class govuk_jenkins::deploy_all_apps (
   $defaults = {
     project_dir => $project_directory,
     environment => $deploy_environment,
+    auth_token  => $auth_token,
   }
 
   create_resources('govuk_jenkins::node_app_deploy', $apps_on_nodes, $defaults)

--- a/modules/govuk_jenkins/manifests/node_app_deploy.pp
+++ b/modules/govuk_jenkins/manifests/node_app_deploy.pp
@@ -19,6 +19,7 @@ define govuk_jenkins::node_app_deploy (
   $user = 'jenkins',
   $apps = [],
   $environment = 'development',
+  $auth_token = '',
 ) {
 
   validate_array($apps)

--- a/modules/govuk_jenkins/spec/defines/govuk_jenkins__node_app_deploy_spec.rb
+++ b/modules/govuk_jenkins/spec/defines/govuk_jenkins__node_app_deploy_spec.rb
@@ -16,5 +16,10 @@ describe 'govuk_jenkins::node_app_deploy', :type => :define do
     it { should contain_file('/path/to/dir/jobs/my_node_class').with_ensure('directory') }
 
     it { should contain_file('/path/to/dir/jobs/my_node_class/config.xml').with_content(/TARGET_APPLICATION=super-furry-cat/) }
+    it { should contain_file('/path/to/dir/jobs/my_node_class/config.xml').without_content(/authToken/) }
+  end
+  context 'with auth token' do
+    let(:params) { default_params.merge({:auth_token => 'tim test token'}) }
+    it { should contain_file('/path/to/dir/jobs/my_node_class/config.xml').with_content(/<authToken>tim test token<\/authToken>/) }
   end
 end

--- a/modules/govuk_jenkins/templates/node_app_deploy.xml.erb
+++ b/modules/govuk_jenkins/templates/node_app_deploy.xml.erb
@@ -13,6 +13,9 @@
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
   <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <%- if @auth_token != '' -%>
+  <authToken><%= auth_token %></authToken>
+  <%- end -%>
   <triggers/>
   <concurrentBuild>false</concurrentBuild>
   <builders>


### PR DESCRIPTION
The standard auth token functionality in jenkins doesnt work, so we need to add
a plugin to make this work - more details in commit message

Also allow passing through an auth token to for deploying apps, which we can use to trigger a build from the app machine