### PR TITLE
Run Docker cleanup more often to prevent buildup.

### DIFF
--- a/modules/govuk_ci/manifests/agent/docker.pp
+++ b/modules/govuk_ci/manifests/agent/docker.pp
@@ -16,13 +16,13 @@ class govuk_ci::agent::docker {
   }
 
   cron::crondotdee { 'remove_docker_dangling_images' :
-    hour    => */2,
+    hour    => '*/2',
     minute  => 0,
     command => 'docker rmi $(docker images --filter "dangling=true" -q --no-trunc)',
   }
 
   cron::crondotdee { 'remove_docker_dangling_volumes' :
-    hour    => */2,
+    hour    => '*/2',
     minute  => 2,
     command => 'docker volume rm $(docker volume ls -qf dangling=true)',
   }

--- a/modules/govuk_ci/manifests/agent/docker.pp
+++ b/modules/govuk_ci/manifests/agent/docker.pp
@@ -16,13 +16,13 @@ class govuk_ci::agent::docker {
   }
 
   cron::crondotdee { 'remove_docker_dangling_images' :
-    hour    => 10,
+    hour    => */2,
     minute  => 0,
     command => 'docker rmi $(docker images --filter "dangling=true" -q --no-trunc)',
   }
 
   cron::crondotdee { 'remove_docker_dangling_volumes' :
-    hour    => 10,
+    hour    => */2,
     minute  => 2,
     command => 'docker volume rm $(docker volume ls -qf dangling=true)',
   }


### PR DESCRIPTION
It does cleanup once per day at 10am at the moment but if a lot of builds happen throughout the day, it can fill up again. Let's run it every 2 hours instead.