### PR TITLE
Add a Jenkins job to trigger recording of taxonomy metrics

### DIFF
--- a/hieradata/class/integration/jenkins.yaml
+++ b/hieradata/class/integration/jenkins.yaml
@@ -25,6 +25,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::launch_vms
   - govuk_jenkins::job::network_config_deploy
   - govuk_jenkins::job::passive_checks
+  - govuk_jenkins::job::record_taxonomy_metrics
   - govuk_jenkins::job::remove_emergency_banner
   - govuk_jenkins::job::run_deploy_lag_badger
   - govuk_jenkins::job::run_rake_task

--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -33,6 +33,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::passive_checks
   - govuk_jenkins::job::performance_platform_data_sync
   - govuk_jenkins::job::publishing_api_archive_events
+  - govuk_jenkins::job::record_taxonomy_metrics
   - govuk_jenkins::job::remove_emergency_banner
   - govuk_jenkins::job::run_rake_task
   - govuk_jenkins::job::run_whitehall_data_migrations

--- a/hieradata/class/staging/jenkins.yaml
+++ b/hieradata/class/staging/jenkins.yaml
@@ -17,6 +17,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::launch_vms
   - govuk_jenkins::job::network_config_deploy
   - govuk_jenkins::job::passive_checks
+  - govuk_jenkins::job::record_taxonomy_metrics
   - govuk_jenkins::job::remove_emergency_banner
   - govuk_jenkins::job::run_rake_task
   - govuk_jenkins::job::run_whitehall_data_migrations

--- a/modules/govuk_jenkins/manifests/job/record_taxonomy_metrics.pp
+++ b/modules/govuk_jenkins/manifests/job/record_taxonomy_metrics.pp
@@ -1,0 +1,11 @@
+# == Class: govuk_jenkins::job::record_taxonomy_metrics
+#
+# Create a file on disk that can be parsed by jenkins-job-builder
+#
+class govuk_jenkins::job::record_taxonomy_metrics {
+  file { '/etc/jenkins_jobs/jobs/record_taxonomy_metrics.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/record_taxonomy_metrics.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+}

--- a/modules/govuk_jenkins/templates/jobs/record_taxonomy_metrics.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/record_taxonomy_metrics.yaml.erb
@@ -1,0 +1,23 @@
+---
+- job:
+    name: record-taxonomy-metrics
+    display-name: Record metrics about the Topic Taxonomy
+    project-type: freestyle
+    description: |
+      This job runs a rake task in Content Tagger to send metrics
+      about the Topic Taxonomy to statsd.
+    logrotate:
+      numToKeep: 30
+      artifactDaysToKeep: 3
+    triggers:
+      - timed: 'H 8-19 * * *'
+    builders:
+      - shell: |
+          #!/bin/bash
+          set -eu
+          
+          cd "${WORKSPACE}"
+          
+          CONTENT_TAGGER=$(govuk_node_list --single-node -c backend)
+          
+          ssh deploy@$CONTENT_TAGGER "cd /var/apps/content-tagger && govuk_setenv content-tagger bundle exec rake metrics:taxonomy:count_content_per_level metrics:taxonomy:record_content_coverage_metrics


### PR DESCRIPTION
Trello: https://trello.com/c/qfrviEaq/145-execute-content-tagging-coverage-measurement