### PR TITLE
Add Publishing API bearer token for Email Alert Frontend

### DIFF
--- a/hieradata/development_credentials.yaml
+++ b/hieradata/development_credentials.yaml
@@ -216,6 +216,7 @@ govuk::apps::contacts::publishing_api_bearer_token: 'oauth-bearer-token-publishi
 govuk::apps::content_tagger::oauth_id: 'oauth-content-tagger'
 govuk::apps::content_tagger::oauth_secret: 'secret'
 govuk::apps::content_tagger::publishing_api_bearer_token: 'oauth-bearer-token-publishing-api'
+govuk::apps::email_alert_frontend::publishing_api_bearer_token: 'oauth-bearer-token-publishing-api'
 govuk::apps::hmrc_manuals_api::oauth_id: 'oauth-hmrc-manuals-api'
 govuk::apps::hmrc_manuals_api::oauth_secret: 'secret'
 govuk::apps::imminence::oauth_id: 'oauth-imminence'

--- a/modules/govuk/manifests/apps/email_alert_frontend.pp
+++ b/modules/govuk/manifests/apps/email_alert_frontend.pp
@@ -15,6 +15,9 @@
 # [*port*]
 #   What port should the app run on?
 #
+# [*publishing_api_bearer_token*]
+#   The bearer token to use when communicating with Publishing API.
+#   Default: undef
 #
 # [*secret_key_base*]
 #   The key for Rails to use when signing/encrypting sessions.
@@ -25,6 +28,7 @@
 class govuk::apps::email_alert_frontend(
   $vhost = 'email-alert-frontend',
   $port = '3099',
+  $publishing_api_bearer_token = undef,
   $secret_key_base = undef,
   $sentry_dsn = undef,
 ) {
@@ -45,5 +49,8 @@ class govuk::apps::email_alert_frontend(
     "${title}-SECRET_KEY_BASE":
         varname => 'SECRET_KEY_BASE',
         value   => $secret_key_base;
+    "${title}-PUBLISHING_API_BEARER_TOKEN":
+        varname => 'PUBLISHING_API_BEARER_TOKEN',
+        value   => $publishing_api_bearer_token;
   }
 }


### PR DESCRIPTION
To allow Email Alert Frontend to publish special routes to the
Publishing API.

[Part of Trello](https://trello.com/c/M0ODsZHV/398-add-prefix-route-to-router-to-point-email-to-email-alert-frontend)