### PR TITLE
Allow puppetdb requests from FQDN

### DIFF
--- a/modules/puppet/templates/puppetdb-vhost.conf
+++ b/modules/puppet/templates/puppetdb-vhost.conf
@@ -5,7 +5,7 @@ upstream puppetmaster_puppetdb {
 server {
     listen 80;
     <%- if scope.lookupvar('::aws_migration') %>
-    server_name puppetdb;
+    server_name puppetdb puppetdb.*;
     <%- else %>
     server_name puppetdb puppetdb.cluster;
     <%- end %>


### PR DESCRIPTION
In this commit we use the FQDN to speak to PuppetDB from the monitoring instance so we can use a HTTPS connection: e5e20dba95952b891d6334cbd2ad2653ec2ec4b0

The vhost for PuppetDB only accepted connections for "puppetdb" rather than the FQDN, so allow full FQDN connections.