### PR TITLE
Link Rummager size change alert to grafana graphs

### DIFF
--- a/modules/grafana/manifests/dashboards.pp
+++ b/modules/grafana/manifests/dashboards.pp
@@ -24,6 +24,8 @@ class grafana::dashboards (
 
   $app_domain_metrics = regsubst($app_domain, '\.', '_', 'G')
 
+  $index_names = ['govuk', 'mainstream', 'government', 'detailed']
+
   file { $dashboard_directory:
     ensure  => directory,
     recurse => true,
@@ -38,6 +40,7 @@ class grafana::dashboards (
     "${dashboard_directory}/origin_health.json": content => template('grafana/dashboards/origin_health.json.erb');
     "${dashboard_directory}/whitehall_health.json": content => template('grafana/dashboards/whitehall_health.json.erb');
     "${dashboard_directory}/publishing_api_overview.json": content => template('grafana/dashboards/publishing_api_overview.json.erb');
+    "${dashboard_directory}/rummager_index_size.json": content => template('grafana/dashboards/rummager_index_size.json.erb');
   }
 
   create_resources('grafana::dashboards::deployment_dashboard', $deployment_applications, {

--- a/modules/grafana/templates/dashboards/_index_size.json.erb
+++ b/modules/grafana/templates/dashboards/_index_size.json.erb
@@ -1,0 +1,174 @@
+<% @index_names.each_with_index do |index_name, j| %>
+  <%= ',' if j > 0 %>{
+    "collapse": false,
+    "height": 250,
+    "panels": [
+      {
+        "columns": [
+          {
+            "text": "Current",
+            "value": "current"
+          }
+        ],
+        "datasource": "Graphite",
+        "fontSize": "100%",
+        "hideTimeOverride": true,
+        "id": <%= j * 2 %>,
+        "links": [],
+        "pageSize": null,
+        "scroll": true,
+        "showHeader": true,
+        "sort": {
+          "col": 0,
+          "desc": true
+        },
+        "span": 4,
+        "styles": [
+          {
+            "alias": "Time",
+            "dateFormat": "DD MMM YYYY",
+            "pattern": "Time",
+            "type": "date"
+          },
+          {
+            "alias": "",
+            "colorMode": null,
+            "colors": [
+              "rgba(245, 54, 54, 0.9)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(50, 172, 45, 0.97)"
+            ],
+            "decimals": 0,
+            "pattern": "/.*/",
+            "thresholds": [
+              ""
+            ],
+            "type": "number",
+            "unit": "none"
+          }
+        ],
+        "targets": [
+          {
+            "refId": "A",
+            "target": "alias(diffSeries(stats.gauges.govuk.app.rummager.<%= index_name %>_index.docs.count, timeShift(stats.gauges.govuk.app.rummager.<%= index_name %>_index.docs.count, '7d')),'Change')",
+            "textEditor": true
+          },
+          {
+            "refId": "B",
+            "target": "alias(stats.gauges.govuk.app.rummager.<%= index_name %>_index.docs.count,'Index size')",
+            "textEditor": true
+          },
+          {
+            "refId": "C",
+            "target": "alias(timeShift(stats.gauges.govuk.app.rummager.<%= index_name %>_index.docs.count, '7d'),'Index size (last week)')",
+            "textEditor": true
+          }
+        ],
+        "timeFrom": "5s",
+        "timeShift": null,
+        "title": "Change stats - <%= index_name %>",
+        "transform": "timeseries_aggregations",
+        "type": "table"
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "Graphite",
+        "fill": 1,
+        "hideTimeOverride": true,
+        "id": <%= 1 + (j * 2) %>,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null",
+        "percentage": false,
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [
+          {
+            "alias": "Change",
+            "color": "#BF1B00",
+            "linewidth": 5,
+            "yaxis": 2
+          }
+        ],
+        "spaceLength": 10,
+        "span": 8,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "refId": "C",
+            "target": "alias(diffSeries(stats.gauges.govuk.app.rummager.<%= index_name %>_index.docs.count, timeShift(stats.gauges.govuk.app.rummager.<%= index_name %>_index.docs.count, '7d')),'Change')",
+            "textEditor": true
+          },
+          {
+            "refId": "A",
+            "target": "alias(stats.gauges.govuk.app.rummager.<%= index_name %>_index.docs.count, 'Index size')",
+            "textEditor": true
+          },
+          {
+            "refId": "B",
+            "target": "alias(timeShift(stats.gauges.govuk.app.rummager.<%= index_name %>_index.docs.count,'7d'), 'Index size (last week)')",
+            "textEditor": true
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": "1d",
+        "timeShift": null,
+        "title": "<%= index_name %>",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "decimals": 0,
+            "format": "short",
+            "label": "Index Size",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "decimals": 0,
+            "format": "short",
+            "label": "Change (count)",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ]
+      }
+    ],
+    "repeat": null,
+    "repeatIteration": null,
+    "repeatRowId": null,
+    "showTitle": false,
+    "title": "Dashboard Row",
+    "titleSize": "h6"
+  }
+<% end %>

--- a/modules/grafana/templates/dashboards/deployment_panels/_sidekiq_queue_length.json.erb
+++ b/modules/grafana/templates/dashboards/deployment_panels/_sidekiq_queue_length.json.erb
@@ -45,12 +45,12 @@
   "targets": [
     {
       "refId": "B",
-      "target": "alias(stats.gauges.govuk.app.<%= app_name %>.workers.enqueued, 'Enqueued')",
+      "target": "alias(stats.gauges.govuk.app.<%= @app_name %>.workers.enqueued, 'Enqueued')",
       "textEditor": false
     },
     {
       "refId": "C",
-      "target": "alias(perSecond(stats.gauges.govuk.app.<%= app_name %>.workers.processed), 'Prococessed/Sec')",
+      "target": "alias(perSecond(stats.gauges.govuk.app.<%= @app_name %>.workers.processed), 'Prococessed/Sec')",
       "textEditor": false
     }
   ],

--- a/modules/grafana/templates/dashboards/rummager_index_size.json.erb
+++ b/modules/grafana/templates/dashboards/rummager_index_size.json.erb
@@ -1,0 +1,73 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "hideControls": false,
+  "id": 63,
+  "links": [],
+  "refresh": false,
+  "rows": [
+    {
+      "collapse": false,
+      "height": 250,
+      "panels": [
+        {
+          "content": "# Index change time periods\n\nWe only store the last 8 days of data in graphite in 5 second intervals (after this it is aggregated). \n\nWe can only view the last days worth of data, as we compare using a 7 day offset,  as 7 + 1 = 8, our maximum range of data.",
+          "id": 6,
+          "mode": "markdown",
+          "span": 12,
+          "title": "Panel Title",
+          "type": "text"
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    },
+    <%= scope.function_template(["grafana/dashboards/_index_size.json.erb"]) %>
+  ],
+  "schemaVersion": 14,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-7d",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Rummager (Elasticsearch) index sizing",
+  "version": 1
+}

--- a/modules/monitoring/manifests/checks.pp
+++ b/modules/monitoring/manifests/checks.pp
@@ -121,6 +121,7 @@ class monitoring::checks (
     desc                => 'rummager govuk index size has significantly increased/decreased over the last 7 days',
     host_name           => $::fqdn,
     notification_period => 'inoffice',
+    action_url          => "https://grafana.${app_domain}/dashboard/db/rummager-elasticsearch-index-sizing",
   }
 
   # Mainstream is comparable to the govuk index.
@@ -131,6 +132,7 @@ class monitoring::checks (
     desc                => 'rummager mainstream index size has significantly increased/decreased over the last 7 days',
     host_name           => $::fqdn,
     notification_period => 'inoffice',
+    action_url          => "https://grafana.${app_domain}/dashboard/db/rummager-elasticsearch-index-sizing",
   }
 
   # Government is comparable to the govuk index.
@@ -141,6 +143,7 @@ class monitoring::checks (
     desc                => 'rummager government index size has significantly increased/decreased over the last 7 days',
     host_name           => $::fqdn,
     notification_period => 'inoffice',
+    action_url          => "https://grafana.${app_domain}/dashboard/db/rummager-elasticsearch-index-sizing",
   }
 
   # Detailed is smaller than the other indexes (about 4500 documents)
@@ -151,6 +154,7 @@ class monitoring::checks (
     desc                => 'rummager detailed index size has significantly increased/decreased over the last 3 days',
     host_name           => $::fqdn,
     notification_period => 'inoffice',
+    action_url          => "https://grafana.${app_domain}/dashboard/db/rummager-elasticsearch-index-sizing",
   }
 
   # END search


### PR DESCRIPTION
When the index size change alert is triggered these graphs should
help to determine the size/impact of the change. In addition they
should help identify when the alert is triggered as a result of a
historic change (i.e. the data from a week ago had a spike)

https://trello.com/c/MlnXML1q/480-better-documentation-for-index-size-alerts