### PR TITLE
Output hostnames based on instance-ids

### DIFF
--- a/modules/govuk_scripts/templates/govuk_node_list_aws.erb
+++ b/modules/govuk_scripts/templates/govuk_node_list_aws.erb
@@ -46,6 +46,17 @@ def ec2_nodes(stackname, nodeclass=None):
 
     return(hosts)
 
+def get_hostname_by_id(instance_id):
+    client = boto3.client('ec2', region_name=region)
+    response = client.describe_instances(InstanceIds=[instance_id])
+    key = 'PrivateDnsName'
+    host = response['Reservations'][0]['Instances'][0]['NetworkInterfaces'][0]
+    if not key in host:
+        print("The instance attribute {} does not exist".format(key))
+        exit(1)
+    else:
+        return(host[key])
+
 def main():
     opts, args = parser.parse_args()
 
@@ -73,7 +84,12 @@ def main():
 
         qs = urllib.urlencode({'query': query})
         res = urllib2.urlopen('https://puppetdb.<%= @app_domain_internal %>/v2/{0}?{1}'.format(endpoint, qs))
-        hosts = json.load(res)
+        instance_ids = json.load(res)
+
+        hosts = []
+
+        for instance in instance_ids:
+            hosts.append(get_hostname_by_id(instance[host_key]))
 
     else:
         hosts = ec2_nodes(stackname)
@@ -82,10 +98,7 @@ def main():
         hosts = [random.choice(hosts)]
 
     for host in hosts:
-        if opts.puppet_class:
-            print(host[host_key])
-        else:
-            print(host)
+        print(host)
 
 parser = OptionParser(description='List nodes in this environment')
 


### PR DESCRIPTION
The `govuk_node_list` tool is very useful for working inside the environment. In AWS we can gather node classes by tags, but if we want to work with PuppetDB, then we need to convert InstanceIDs to hostnames.

We moved to using InstanceIDs so we did not run into conditions of repeated hostnames. In a DHCP environment, hostnames are reused, and so this was potentially conflicting in PuppetDB. With an InstanceID, we can guarantee a unique identifier.

We have checks for unattended reboots, that queries PuppetDB for specific classes. In the traditional way, this was outputting a list of InstanceIDs. While these IDs may be queried, it doesn't give you a way to immediately connect to the relevant hostname.

I've chosen to put the logic into `govuk_node_list` as this function is to list hostnames. The conversation does a look-up based upon the InstanceID, and returns the hostname.

We could potentially use this with our fabric scripts as well, which would mean less deviation from the way we currently support the system.