### PR TITLE
Fix trigger_data_sync_complete_aws manifest

### DIFF
--- a/modules/govuk_jenkins/manifests/job/trigger_data_sync_complete_aws.pp
+++ b/modules/govuk_jenkins/manifests/job/trigger_data_sync_complete_aws.pp
@@ -20,6 +20,6 @@ class govuk_jenkins::job::trigger_data_sync_complete_aws (
   file { '/etc/jenkins_jobs/jobs/trigger_data_sync_complete_aws.yaml':
     ensure  => present,
     content => template('govuk_jenkins/jobs/trigger_data_sync_complete_aws.yaml.erb'),
-    notify  => Exec['jenkins_job_update'],
+    notify  => Exec['jenkins_jobs_update'],
   }
 }


### PR DESCRIPTION
It was receiving error:

```
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Invalid relationship: File[/etc/jenkins_jobs/jobs/trigger_data_sync_complete_aws.yaml] { notify => Exec[jenkins_job_update] }, because Exec[jenkins_job_update] doesn't seem to be in the catalog
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run
```