### PR TITLE
Enable email-alert-api-public proxy

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -355,6 +355,7 @@ govuk::apps::content_tagger::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::content_tagger::redis_port: "%{hiera('sidekiq_port')}"
 
 govuk::apps::email_alert_api::enabled: true
+govuk::apps::email_alert_api::enable_public_proxy: false
 govuk::apps::email_alert_api::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 govuk::apps::email_alert_api::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::email_alert_api::redis_port: "%{hiera('sidekiq_port')}"
@@ -1219,6 +1220,7 @@ hosts::production::backend::app_hostnames:
   - 'docs'
   - 'draft-whitehall-frontend'
   - 'email-alert-api'
+  - 'email-alert-api-public'
   - 'event-store'
   - 'hmrc-manuals-api'
   - 'imminence'

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -100,6 +100,7 @@ govuk::apps::content_store::mongodb_nodes: ['localhost']
 govuk::apps::content_store::mongodb_name: 'content_store_development'
 govuk::apps::content_tagger::enable_procfile_worker: false
 govuk::apps::email_alert_api::enable_procfile_worker: false
+govuk::apps::email_alert_api::enable_public_proxy: true
 govuk::apps::email_alert_service::rabbitmq_hosts: ['localhost']
 govuk::apps::event_store::enabled: true
 govuk::apps::event_store::mongodb_servers: ['localhost']
@@ -255,6 +256,7 @@ hosts::development::apps:
   - 'draft-static'
   - 'draft-whitehall-frontend'
   - 'email-alert-api'
+  - 'email-alert-api-public'
   - 'email-alert-frontend'
   - 'event-store'
   - 'feedback'

--- a/hieradata/development_credentials.yaml
+++ b/hieradata/development_credentials.yaml
@@ -216,6 +216,8 @@ govuk::apps::contacts::publishing_api_bearer_token: 'oauth-bearer-token-publishi
 govuk::apps::content_tagger::oauth_id: 'oauth-content-tagger'
 govuk::apps::content_tagger::oauth_secret: 'secret'
 govuk::apps::content_tagger::publishing_api_bearer_token: 'oauth-bearer-token-publishing-api'
+govuk::apps::email_alert_api::oauth_id: 'oauth-email-alert-api'
+govuk::apps::email_alert_api::oauth_secret: 'secret'
 govuk::apps::email_alert_frontend::publishing_api_bearer_token: 'oauth-bearer-token-publishing-api'
 govuk::apps::hmrc_manuals_api::oauth_id: 'oauth-hmrc-manuals-api'
 govuk::apps::hmrc_manuals_api::oauth_secret: 'secret'

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -33,6 +33,7 @@ govuk::apps::content_performance_manager::feature_auditing_theme_filtering: true
 govuk::apps::content_store::performance_platform_big_screen_view_url: 'https://performance-platform-big-screen-view-staging.cloudapps.digital'
 govuk::apps::content_store::performance_platform_spotlight_url: 'https://performance-platform-spotlight-staging.cloudapps.digital'
 govuk::apps::email_alert_api::allow_govdelivery_topic_syncing: true
+govuk::apps::email_alert_api::enable_public_proxy: true
 govuk::apps::email_alert_api::govdelivery_account_code: 'UKGOVUKDUP'
 govuk::apps::email_alert_api::govdelivery_hostname: 'stage-api.govdelivery.com'
 govuk::apps::email_alert_api::govdelivery_public_hostname: 'stage-public.govdelivery.com'

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -36,7 +36,7 @@ govuk::apps::email_alert_api::allow_govdelivery_topic_syncing: true
 govuk::apps::email_alert_api::govdelivery_account_code: 'UKGOVUKDUP'
 govuk::apps::email_alert_api::govdelivery_hostname: 'stage-api.govdelivery.com'
 govuk::apps::email_alert_api::govdelivery_public_hostname: 'stage-public.govdelivery.com'
-govuk::apps::email_alert_api::govuk_notify_rate_per_worker: '12' 
+govuk::apps::email_alert_api::govuk_notify_rate_per_worker: '12'
 govuk::apps::event_store::enabled: true
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
 govuk::apps::publicapi::backdrop_host: 'www.preview.performance.service.gov.uk'

--- a/modules/govuk/manifests/apps/email_alert_api.pp
+++ b/modules/govuk/manifests/apps/email_alert_api.pp
@@ -63,6 +63,12 @@
 # [*secret_key_base*]
 #   The key for Rails to use when signing/encrypting sessions.
 #
+# [*oauth_id*]
+#   Sets the OAuth ID
+#
+# [*oauth_secret*]
+#   Sets the OAuth Secret Key
+#
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
@@ -91,6 +97,8 @@ class govuk::apps::email_alert_api(
   $govuk_notify_api_key = undef,
   $govuk_notify_rate_per_worker = undef,
   $secret_key_base = undef,
+  $oauth_id = undef,
+  $oauth_secret = undef,
   $db_username = 'email-alert-api',
   $db_password = undef,
   $db_hostname = undef,
@@ -184,6 +192,12 @@ class govuk::apps::email_alert_api(
       "${title}-SECRET_KEY_BASE":
           varname => 'SECRET_KEY_BASE',
           value   => $secret_key_base;
+      "${title}-OAUTH_ID":
+          varname => 'OAUTH_ID',
+          value   => $oauth_id;
+      "${title}-OAUTH_SECRET":
+          varname => 'OAUTH_SECRET',
+          value   => $oauth_secret;
     }
 
     if $allow_govdelivery_topic_syncing {

--- a/modules/govuk/manifests/apps/email_alert_api.pp
+++ b/modules/govuk/manifests/apps/email_alert_api.pp
@@ -5,6 +5,9 @@
 #
 # === Parameters
 #
+# [*port*]
+#   What port should the app run on?
+#
 # [*enabled*]
 #   Should the application should be enabled. Set in hiera data for each
 #   environment.
@@ -13,9 +16,6 @@
 #   Whether to create a public proxy into this application for handling
 #   select public endpoints
 #   Default: false
-#
-# [*port*]
-#   What port should the app run on?
 #
 # [*enable_procfile_worker*]
 #   Should the Foreman-based background worker be enabled by default. Set in
@@ -28,6 +28,9 @@
 # [*redis_port*]
 #   Redis port for Sidekiq.
 #   Default: undef
+#
+# [*sentry_dsn*]
+#   The URL used by Sentry to report exceptions
 #
 # [*allow_govdelivery_topic_syncing*]
 #   If set to `true`, allows the running of a script which deletes all topics
@@ -68,10 +71,6 @@
 #
 # [*oauth_secret*]
 #   Sets the OAuth Secret Key
-#
-# [*sentry_dsn*]
-#   The URL used by Sentry to report exceptions
-#
 #
 class govuk::apps::email_alert_api(
   $port = '3088',

--- a/modules/govuk/manifests/apps/email_alert_api.pp
+++ b/modules/govuk/manifests/apps/email_alert_api.pp
@@ -9,6 +9,11 @@
 #   Should the application should be enabled. Set in hiera data for each
 #   environment.
 #
+# [*enable_public_proxy*]
+#   Whether to create a public proxy into this application for handling
+#   select public endpoints
+#   Default: false
+#
 # [*port*]
 #   What port should the app run on?
 #
@@ -61,9 +66,11 @@
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
+#
 class govuk::apps::email_alert_api(
   $port = '3088',
   $enabled = false,
+  $enable_public_proxy = false,
   $enable_procfile_worker = true,
   $sidekiq_retry_critical = '20',
   $sidekiq_retry_warning = '10',
@@ -183,6 +190,24 @@ class govuk::apps::email_alert_api(
       govuk::app::envvar { "${title}-ALLOW_GOVDELIVERY_SYNC":
         varname => 'ALLOW_GOVDELIVERY_SYNC',
         value   => 'allow';
+      }
+    }
+
+    $app_domain = hiera('app_domain')
+
+    if $enable_public_proxy {
+      nginx::config::vhost::proxy { "email-alert-api-public.${app_domain}":
+        to               => ["localhost:${port}"],
+        ssl_only         => true,
+        protected        => false,
+        extra_app_config => "
+          return 404;
+        ",
+        extra_config     => "
+          location ~ ^/status-updates(/|$) {
+            proxy_pass http://localhost:${port};
+          }
+        ",
       }
     }
   }

--- a/modules/govuk/manifests/node/s_backend_lb.pp
+++ b/modules/govuk/manifests/node/s_backend_lb.pp
@@ -49,6 +49,7 @@ class govuk::node::s_backend_lb (
     'contacts-admin',
     'content-performance-manager',
     'content-tagger',
+    'email-alert-api-public',
     'imminence',
     'link-checker-api',
     'local-links-manager',

--- a/modules/govuk/templates/email_alert_api_public_nginx_extra_config.conf.erb
+++ b/modules/govuk/templates/email_alert_api_public_nginx_extra_config.conf.erb
@@ -1,0 +1,4 @@
+location ~ ^/status-updates(/|$) {
+  limit_req zone=email_alert_api_public burst=20 nodelay;
+  proxy_pass http://localhost:<%= @port %>;
+}


### PR DESCRIPTION
Trello: https://trello.com/c/7pDM2swr/372-proxy-requests-from-a-public-url-to-the-statusupdates-endpoint

This adds a hostname, email-alert-api-public, that is exposed
publicly which is used as a means for external services to route
requests in to email-alert-api.

We decided to go with the unconventional name of email-alert-api-public
as it wasn't clear about all the usages of this hostname might be and
this seemed to be the clearest about the intent of it.

It proxies the endpoint status-updates and will accept any subroutes
that start with that segment. Any other requests will receive a 404.

This is currently only enabled on integration until we have completed
authentication work.