### PR TITLE
Add one spec for all of the Jenkins jobs manifests

### DIFF
--- a/modules/govuk_jenkins/spec/classes/govuk_jenkins__job__each_spec.rb
+++ b/modules/govuk_jenkins/spec/classes/govuk_jenkins__job__each_spec.rb
@@ -1,0 +1,16 @@
+require_relative '../../../../spec_helper'
+
+job_directory = File.join(File.dirname(__FILE__), '../../manifests/job')
+FILES = Dir.entries(job_directory).reject{ |f| f == "." || f == ".." }
+
+FILES.each do |filename|
+  classname = filename.split(".")[0]
+
+  describe "govuk_jenkins::job::#{classname}", :type => :class do
+    it { is_expected.to compile }
+
+    it { is_expected.to compile.with_all_deps }
+
+    it { is_expected.to contain_class("govuk_jenkins::job::#{classname}") }
+  end
+end


### PR DESCRIPTION
- In PR 6875, it was decided that we should make one spec test for all
  the Jenkins jobs, rather than forgetting to add new spec tests for
  new jobs, and rather than increasing the amount of Puppet code to do
  exactly the same tests for every job.
- This is an attempt at that. `Dir.entries` ouputs the filename with the
  extension, hence `split` then being used to get rid of the `.pp`
  extension.

The specs themselves are extremely unhappy, but the same happened with #6875, so ¯\_(ツ)_/¯.

https://trello.com/c/KeLujIgw/855-add-specs-for-jenkins-jobs