### PR TITLE
Add healthcheck path to default vhost

### DIFF
--- a/modules/nginx/templates/default-vhost.conf
+++ b/modules/nginx/templates/default-vhost.conf
@@ -1,5 +1,11 @@
 server {
   listen 80 default_server;
+  <%- if scope.lookupvar('::aws_migration') %>
+  # Required for Layer 7 Application Load Balancer
+  location = /_healthcheck {
+    return 200;
+  }
+  <%- end %>
   location / {
     return <%= @status %> <%= @status_message %>;
   }


### PR DESCRIPTION
In AWS, we are looking at using the L7 Application Load Balancers. To ensure nodes are in service on some instances before we amend Puppet to go straight to the correct port as defined by host header, we are adding in a default healthcheck path to allow the node to be in service on the load balancer.

https://trello.com/c/SwKGQcCo/860-create-project-to-allow-delegation-of-integrationgovukdigital-to-stack-level-dns