### PR TITLE
Overhaul server_name lookups in AWS

### DIFF
--- a/modules/govuk/manifests/app.pp
+++ b/modules/govuk/manifests/app.pp
@@ -270,7 +270,11 @@ define govuk::app (
   }
 
   $app_domain = hiera('app_domain')
-  $vhost_full = "${vhost_real}.${app_domain}"
+  if $::aws_migration {
+    $vhost_full = $vhost_real
+  } else {
+    $vhost_full = "${vhost_real}.${app_domain}"
+  }
 
   include govuk::deploy
 

--- a/modules/govuk/manifests/apps/asset_manager.pp
+++ b/modules/govuk/manifests/apps/asset_manager.pp
@@ -100,7 +100,11 @@ class govuk::apps::asset_manager(
          proxy_set_header X-Sendfile-Type X-Accel-Redirect;
          proxy_set_header X-Accel-Mapping /var/apps/asset-manager/uploads/assets/=/raw/;
 
+         <%- if @aws_migration %>
+         proxy_pass http://asset-manager-proxy;
+         <%- else %>
          proxy_pass http://asset-manager.<%= @app_domain %>-proxy;
+         <%- end %>
        }
 
       # /raw/(.*) is the path mapping sent from the rails application to

--- a/modules/nginx/manifests/config/vhost/proxy.pp
+++ b/modules/nginx/manifests/config/vhost/proxy.pp
@@ -119,17 +119,6 @@ define nginx::config::vhost::proxy(
   # Whether to enable SSL. Used by template.
   $enable_ssl = hiera('nginx_enable_ssl', true)
 
-  if $::aws_migration {
-    # We want to add the internal version of the domain everywhere in AWS,
-    # but when this defined type is called the external domain name is appended.
-    # We want the plain app name, which we can then add in the template.
-    $app_domain_internal = hiera('app_domain_internal')
-    if $name =~ /\.(.*)/ {
-      $app_name = regsubst($name, '\.(.*)', '')
-      $name_internal = "${app_name}.${app_domain_internal}"
-    }
-  }
-
   nginx::config::ssl { $name:
     certtype => $ssl_certtype,
   }

--- a/modules/nginx/spec/defines/nginx__config__vhost__proxy_spec.rb
+++ b/modules/nginx/spec/defines/nginx__config__vhost__proxy_spec.rb
@@ -49,8 +49,8 @@ describe 'nginx::config::vhost::proxy', :type => :define do
     end
   end
 
-  context 'if in aws and passed full domain name' do
-    let(:title) { 'rabbit.dev.govuk.digital' }
+  context 'if in aws' do
+    let(:title) { 'rabbit' }
 
     let(:params) {{
       :to => ['a.internal'],
@@ -60,14 +60,14 @@ describe 'nginx::config::vhost::proxy', :type => :define do
      :aws_migration => true,
     }}
 
-    it 'should add the internal domain name by stripping the external domain name' do
-      is_expected.to contain_nginx__config__site('rabbit.dev.govuk.digital')
-        .with_content(/server_name rabbit.dev.govuk.digital rabbit.dev.govuk-internal.digital/)
+    it 'should add a wildcard match' do
+      is_expected.to contain_nginx__config__site('rabbit')
+        .with_content(/server_name rabbit rabbit.*/)
     end
   end
 
-  context 'if in aws and passed full domain name and an alias' do
-    let(:title) { 'rabbit.dev.govuk.digital' }
+  context 'if in aws and passed an alias' do
+    let(:title) { 'rabbit' }
 
     let(:params) {{
       :to      => ['a.internal'],
@@ -78,44 +78,9 @@ describe 'nginx::config::vhost::proxy', :type => :define do
      :aws_migration => true,
     }}
 
-    it 'should add the internal domain name by stripping the external domain name, and add the alias with the internal domain' do
-      is_expected.to contain_nginx__config__site('rabbit.dev.govuk.digital')
-        .with_content(/server_name rabbit.dev.govuk.digital rabbit.dev.govuk-internal.digital cat.dev.govuk.digital  cat.dev.govuk-internal.digital/)
-    end
-  end
-
-  context 'if in aws and not passed full domain name' do
-    let(:title) { 'rabbit' }
-
-    let(:params) {{
-      :to => ['a.internal'],
-    }}
-
-    let(:facts) {{
-     :aws_migration => true,
-    }}
-
-    it 'should not add the internal domain name' do
-      is_expected.not_to contain_nginx__config__site('rabbit')
-        .with_content(/rabbit.dev.govuk-internal.digital/)
-    end
-  end
-
-  context 'if in aws and not passed full domain name, but also passed an alias' do
-    let(:title) { 'rabbit' }
-
-    let(:params) {{
-      :to      => ['a.internal'],
-      :aliases => ['cat', 'mouse.*'],
-    }}
-
-    let(:facts) {{
-     :aws_migration => true,
-    }}
-
-    it 'should not add the internal domain name, but it should add an alias unless it is foo\.\*' do
+    it 'should add a wildcard match, and add the alias' do
       is_expected.to contain_nginx__config__site('rabbit')
-        .with_content(/rabbit  cat mouse.*  cat.dev.govuk-internal.digital/)
+        .with_content(/server_name rabbit rabbit.* cat.dev.govuk.digital/)
     end
   end
 

--- a/modules/nginx/templates/proxy-vhost.conf
+++ b/modules/nginx/templates/proxy-vhost.conf
@@ -51,11 +51,7 @@ server {
 <%- ports.each do |port| -%>
 server {
   <%- if scope.lookupvar('::aws_migration') %>
-  server_name <%= @name -%> <%= @name_internal %> <%= @aliases.join(" ") unless @aliases.empty? -%><%- @aliases.each do |a| -%>
-  <%-   unless a =~ /.*\.\*/ -%>
-  <%=     a.gsub(/\.(.*)/, '') + '.' + @app_domain_internal -%>
-  <%-   end -%>
-  <%- end -%>;
+  server_name <%= @name -%> <%= @name %>.* <%= @aliases.join(" ") unless @aliases.empty? %>;
   <%- else %>
   server_name <%= @name %> <%= @aliases.join(" ") unless @aliases.empty? %>;
   <%- end %>

--- a/modules/router/templates/assets_origin.conf.erb
+++ b/modules/router/templates/assets_origin.conf.erb
@@ -1,5 +1,9 @@
 server {
+  <%- if scope.lookupvar('::aws_migration') %>
+  server_name <%= @vhost_name -%> <%= @vhost_name -%>.* <%= @vhost_aliases.join(' ') -%>;
+  <%- else %>
   server_name <%= @vhost_name -%> <%= @vhost_aliases.join(' ') -%>;
+  <%- end %>
   listen 80;
 <% if @enable_ssl -%>
   rewrite ^/(.*) https://$host/$1 permanent;
@@ -7,7 +11,6 @@ server {
 
 server {
   server_name <%= @vhost_name -%> <%= @vhost_aliases.join(' ') -%>;
-
   listen              443 ssl;
   ssl_certificate     /etc/nginx/ssl/<%= @vhost_name -%>.crt;
   ssl_certificate_key /etc/nginx/ssl/<%= @vhost_name -%>.key;

--- a/modules/router/templates/base.conf.erb
+++ b/modules/router/templates/base.conf.erb
@@ -33,14 +33,15 @@ server {
 }
 
 server {
+  <%- if scope.lookupvar('::aws_migration') %>
+  server_name         www.* www-origin.* draft-origin.*;
+  listen 80;
+  <%- else %>
   server_name         www.<%= @app_domain %> www-origin.<%= @app_domain %> draft-origin.<%= @app_domain %>;
-  <%- unless scope.lookupvar('::aws_migration') %>
   listen              443 ssl;
   ssl_certificate     /etc/nginx/ssl/www.<%= @app_domain %>.crt;
   ssl_certificate_key /etc/nginx/ssl/www.<%= @app_domain %>.key;
   include             /etc/nginx/ssl.conf;
-  <%- else %>
-  listen 80;
   <%- end %>
 
   include             /etc/nginx/router_include.conf;


### PR DESCRIPTION
We normally statically set the server_name paramater in our NGINX config based upon the globally defined "app_domain" parameter.

This is problematic in AWS, particularly during our migration period, as we are going to use several different DNS records:

 - The external AWS top level DNS name (integration.govuk.digital)
 - The external AWS stack specific name (stack.integration.govuk.digital)
 - The internal AWS stack specific name (stack.integration.govuk-internal.digital)
 - The main service domain name (integration.publishing.service.gov.uk)

Having to work all these into our code was going to be problematic and require lots of logic that does not fit into the current way that NGINX is configured with Puppet.

We have made the decision to loosen the requirements, and only apply this to AWS.

Eventually most configuration is going to be applied on the Application Load Balancers so the server_name directive will be less of a thing in The New World.

This enables us to test both the service domain and internal/external names to help us migrate smoothly when the time comes.