### PR TITLE
Add a second disk to CI Master for Jenkins to use.

### DIFF
--- a/hieradata/class/ci_master.yaml
+++ b/hieradata/class/ci_master.yaml
@@ -286,3 +286,14 @@ govuk_jenkins::plugins:
       version: "0.34"
 
 icinga::client::check_cputype::cputype: 'intel'
+
+lv:
+  data:
+    pv: '/dev/sdb1'
+    vg: 'jenkins'
+
+mount:
+  /var/lib/jenkins:
+    disk: '/dev/mapper/jenkins-data'
+    govuk_lvm: 'data'
+    mountoptions: 'defaults'


### PR DESCRIPTION
Jenkins uses a LOT of small files in /var/lib/jenkins/jobs and the base / filesystem runs out of inodes long before it runs out of space. Added a second disk and created a new VG and LV on it. This new filesystem was created with 'mkfs -t ext4 -i 4096 /dev/jenkins/data' so that it created a higher number of inodes than default.