### PR TITLE
Fix permissions on /srv/redis on mirrorer.

### DIFF
--- a/modules/govuk_containers/manifests/redis.pp
+++ b/modules/govuk_containers/manifests/redis.pp
@@ -21,6 +21,8 @@ class govuk_containers::redis(
   # store the state dumps here on the docker host
   file { '/srv/redis':
     ensure => directory,
+    mode   => '770',
+    group  => 'docker',
   }
 
   ::docker::image { $image_name:

--- a/modules/govuk_containers/manifests/redis.pp
+++ b/modules/govuk_containers/manifests/redis.pp
@@ -21,7 +21,7 @@ class govuk_containers::redis(
   # store the state dumps here on the docker host
   file { '/srv/redis':
     ensure => directory,
-    mode   => '770',
+    mode   => '0770',
     group  => 'docker',
   }
 


### PR DESCRIPTION
Because the running Redis container couldn't write to /srv/redis, it couldn't rotate the append-only file in that directory and it grew and grew. This PR fixes the permissions on that directory so that 'BGREWRITEAOF' succeeds. In theory, Redis should now handle this rotation regularly itself.