### PR TITLE
Configure Email Alert API for load testing in staging

### DIFF
--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -21,6 +21,7 @@ govuk::apps::email_alert_api::db::backend_ip_range: '10.2.3.0/24'
 govuk::apps::email_alert_api::govdelivery_account_code: 'UKGOVUK'
 govuk::apps::email_alert_api::govdelivery_hostname: 'stage-api.govdelivery.com'
 govuk::apps::email_alert_api::govdelivery_public_hostname: 'stage-public.govdelivery.com'
+govuk::apps::email_alert_api::govuk_notify_base_url: 'https://api.staging-notify.works'
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::publicapi::backdrop_host: 'www.staging.performance.service.gov.uk'
 govuk::apps::publisher::run_fact_check_fetcher: false

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -22,6 +22,7 @@ govuk::apps::email_alert_api::govdelivery_account_code: 'UKGOVUK'
 govuk::apps::email_alert_api::govdelivery_hostname: 'stage-api.govdelivery.com'
 govuk::apps::email_alert_api::govdelivery_public_hostname: 'stage-public.govdelivery.com'
 govuk::apps::email_alert_api::govuk_notify_base_url: 'https://api.staging-notify.works'
+govuk::apps::email_alert_api::govuk_notify_template_id: '76d21ce7-54c3-4fb7-8830-ba3b79287985'
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::publicapi::backdrop_host: 'www.staging.performance.service.gov.uk'
 govuk::apps::publisher::run_fact_check_fetcher: false

--- a/modules/govuk/manifests/apps/email_alert_api.pp
+++ b/modules/govuk/manifests/apps/email_alert_api.pp
@@ -59,6 +59,9 @@
 # [*govuk_notify_api_key*]
 #   API key for integration with GOV.UK Notify for sending emails
 #
+# [*govuk_notify_template_id*]
+#   Template ID for GOV.UK Notify
+#
 # [*govuk_notify_base_url*]
 #   Base URL for GOV.UK Notify API
 #
@@ -97,6 +100,7 @@ class govuk::apps::email_alert_api(
   $govdelivery_hostname = undef,
   $govdelivery_public_hostname = undef,
   $govuk_notify_api_key = undef,
+  $govuk_notify_template_id = undef,
   $govuk_notify_base_url = undef,
   $govuk_notify_rate_per_worker = undef,
   $secret_key_base = undef,
@@ -189,6 +193,9 @@ class govuk::apps::email_alert_api(
       "${title}-GOVUK_NOTIFY_API_KEY":
           varname => 'GOVUK_NOTIFY_API_KEY',
           value   => $govuk_notify_api_key;
+      "${title}-GOVUK_NOTIFY_TEMPLATE_ID":
+          varname => 'GOVUK_NOTIFY_TEMPLATE_ID',
+          value   => $govuk_notify_template_id;
       "${title}-GOVUK_NOTIFY_BASE_URL":
           varname => 'GOVUK_NOTIFY_BASE_URL',
           value   => $govuk_notify_base_url;

--- a/modules/govuk/manifests/apps/email_alert_api.pp
+++ b/modules/govuk/manifests/apps/email_alert_api.pp
@@ -59,6 +59,9 @@
 # [*govuk_notify_api_key*]
 #   API key for integration with GOV.UK Notify for sending emails
 #
+# [*govuk_notify_base_url*]
+#   Base URL for GOV.UK Notify API
+#
 # [*govuk_notify_rate_per_worker*]
 #   Number of requests per seconds that the notify delivery worker
 #   is allowed to make (currently 50 requests/s / 6 workers = 8 (ish)
@@ -94,6 +97,7 @@ class govuk::apps::email_alert_api(
   $govdelivery_hostname = undef,
   $govdelivery_public_hostname = undef,
   $govuk_notify_api_key = undef,
+  $govuk_notify_base_url = undef,
   $govuk_notify_rate_per_worker = undef,
   $secret_key_base = undef,
   $oauth_id = undef,
@@ -185,6 +189,9 @@ class govuk::apps::email_alert_api(
       "${title}-GOVUK_NOTIFY_API_KEY":
           varname => 'GOVUK_NOTIFY_API_KEY',
           value   => $govuk_notify_api_key;
+      "${title}-GOVUK_NOTIFY_BASE_URL":
+          varname => 'GOVUK_NOTIFY_BASE_URL',
+          value   => $govuk_notify_base_url;
       "${title}-GOVUK_NOTIFY_RATE_PER_WORKER":
           varname => 'GOVUK_NOTIFY_RATE_PER_WORKER',
           value   => $govuk_notify_rate_per_worker;


### PR DESCRIPTION
We have to add support for configuring the GOV.UK Notify Base URL and Template ID through Puppet and then set it to the necessary values for GOV.UK Notify's staging environment.

[Trello Card](https://trello.com/c/7zoZKZkS/281-agree-approach-and-run-load-testing-with-notify)