### PR TITLE
Add X-Forwarded-Host header for whitehall asset requests

### DIFF
--- a/modules/router/templates/assets_origin.conf.erb
+++ b/modules/router/templates/assets_origin.conf.erb
@@ -43,6 +43,9 @@ server {
 
   <%- @asset_routes.each do |alias_path, vhost_name| -%>
   location <%= alias_path %> {
+    <%- if alias_path =~ %r(/government/uploads/) && vhost_name =~ %r(whitehall-frontend) -%>
+      proxy_set_header X-Forwarded-Host $host;
+    <%- end -%>
     proxy_set_header Host <%= vhost_name %>.<%= @app_domain %>;
     proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://<%= vhost_name %>.<%= @app_domain %>;
   }

--- a/modules/router/templates/assets_origin.conf.erb
+++ b/modules/router/templates/assets_origin.conf.erb
@@ -43,7 +43,7 @@ server {
 
   <%- @asset_routes.each do |alias_path, vhost_name| -%>
   location <%= alias_path %> {
-    <%- if alias_path =~ %r(/government/uploads/) && vhost_name =~ %r(whitehall-frontend) -%>
+    <%- if alias_path == '/government/uploads/' && vhost_name == 'whitehall-frontend' -%>
       proxy_set_header X-Forwarded-Host $host;
     <%- end -%>
     proxy_set_header Host <%= vhost_name %>.<%= @app_domain %>;


### PR DESCRIPTION
Whitehall assets (available at /government/uploads and served by the
PublicUploadsController) can be requested at www.gov.uk and at
assets-origin.publishing.service.gov.uk.  We're in the process of making
assets-origin the canonical host for assets and want to redirect assets
requests via www.gov.uk to assets-origin.

This nginx change results in the `X-Forwarded-Host` header being sent to
the Whitehall Rails app via the whitehall-frontend and whitehall-admin
nginx virtual hosts. This will allow me to determine whether a request
for a Whitehall asset via www.gov.uk or via
assets.publishing.service.gov.uk and to redirect if appropriate.

I've tested this change in the dev-vm and confirm that after this
change, the host (`request.base_url`) for requests made via
assets-origin is assets-origin.dev.gov.uk instead of
whitehall-admin.dev.gov.uk.

The X-Forwarded-Host header (along with X-Real-IP, X-Forwarded-Server
and X-Forwarded-For) is already being set at the top of the
assets-origin nginx config. I suspect the intention is for all these
headers to be set in the requests to the backend servers but that's not
currently the case because the use of `proxy_set_header` in the various
`location` blocks nullifies the setting of these headers at the
top-level. As far as I can tell, these 4 calls to `proxy_set_header`
won't have had any effect since 75b8645a416dc4361938f24a3d72df0be3af92ba
(Dec 3 2013). I considered setting each of these 4 headers each
`location` configured in this config but I don't have confidence that
this is definitely what we want.

There's a similar problem in the nginx config for whitehall-frontend.
The location block for /government/uploads contains a `set_proxy_header`
directive which will mean that it doesn't also set the other HTTP
headers in that config.

An alternative approach might've been to add something to the router but
I'm fairly confident that I can't add a route for /government/uploads
when /government is already registered.

I'm really missing some way of testing the effect of these nginx changes
and wonder whether something like this blog post from the Verify team
might give us some ideas[1]

[1]: https://gdstechnology.blog.gov.uk/2015/03/25/test-driving-web-server-configuration/