### PR TITLE
Make Icinga refresh faster by default

### DIFF
--- a/modules/icinga/files/etc/icinga/cgi.cfg
+++ b/modules/icinga/files/etc/icinga/cgi.cfg
@@ -285,7 +285,7 @@ ping_syntax=/bin/ping -n -U -c 5 $HOSTADDRESS$
 # This option allows you to specify the refresh rate in seconds
 # of various CGIs (status, statusmap, extinfo, and outages).  
 
-refresh_rate=90
+refresh_rate=5
 
 
 


### PR DESCRIPTION
I find myself manually refreshing Icinga a lot and
it’d be nice if the default refresh interval were
much shorter.

I don’t think this would adversely affect
performance as refreshing the page normally takes
very little time so this is unlikely to
significantly increase load.