### PR TITLE
Increase rate per worker to reach 300 requests per second

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -361,7 +361,7 @@ govuk::apps::email_alert_api::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::email_alert_api::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::email_alert_api::db_hostname: 'postgresql-primary-1.backend'
 govuk::apps::email_alert_api::db_password: "%{hiera('govuk::apps::email_alert_api::db::password')}"
-govuk::apps::email_alert_api::govuk_notify_rate_per_worker: "8"
+govuk::apps::email_alert_api::govuk_notify_rate_per_worker: '10'
 
 govuk::apps::email_alert_service::rabbitmq_hosts:
   - rabbitmq-1.backend

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -37,7 +37,7 @@ govuk::apps::email_alert_api::enable_public_proxy: true
 govuk::apps::email_alert_api::govdelivery_account_code: 'UKGOVUKDUP'
 govuk::apps::email_alert_api::govdelivery_hostname: 'stage-api.govdelivery.com'
 govuk::apps::email_alert_api::govdelivery_public_hostname: 'stage-public.govdelivery.com'
-govuk::apps::email_alert_api::govuk_notify_rate_per_worker: '12'
+govuk::apps::email_alert_api::govuk_notify_rate_per_worker: '15'
 govuk::apps::event_store::enabled: true
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
 govuk::apps::publicapi::backdrop_host: 'www.preview.performance.service.gov.uk'


### PR DESCRIPTION
This is what we will suggest to Notify to increase their rate limit to and we want to do load testing with maximum theoretical values.

[Trello Card](https://trello.com/c/7zoZKZkS/281-agree-approach-and-run-load-testing-with-notify)