### PR TITLE
Setup statsd to not send previous values for gauges

### DIFF
--- a/modules/statsd/templates/etc/statsd.conf.erb
+++ b/modules/statsd/templates/etc/statsd.conf.erb
@@ -44,4 +44,5 @@ Optional Variables:
 , graphiteHost: "<%= @graphite_hostname -%>"
 , port: 8125
 , flushInterval: 5000
+, deleteGauges: true
 }


### PR DESCRIPTION
Currently, when statsd receives a value for a gauge, it will continue
to send this each time metrics are flushed to graphite. As many of
the gauges used within GOV.UK could end up being sent from multiple
machines, this could be causing some contention over metrics in
graphite, between different statsd instances on different machines,
possibly with different values.

To avoid this, setup statsd not to repeat the last value for
gauges. The empty regions can then be filled in by using the
keepLastValue function in graphite.