### PR TITLE
Configure staging email-alert-api to use pseudo email sending provider

### DIFF
--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -23,6 +23,7 @@ govuk::apps::email_alert_api::govdelivery_hostname: 'stage-api.govdelivery.com'
 govuk::apps::email_alert_api::govdelivery_public_hostname: 'stage-public.govdelivery.com'
 govuk::apps::email_alert_api::govuk_notify_base_url: 'https://api.staging-notify.works'
 govuk::apps::email_alert_api::govuk_notify_template_id: '76d21ce7-54c3-4fb7-8830-ba3b79287985'
+govuk::apps::email_alert_api::email_service_provider: 'PSEUDO'
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::publicapi::backdrop_host: 'www.staging.performance.service.gov.uk'
 govuk::apps::publisher::run_fact_check_fetcher: false

--- a/modules/govuk/manifests/apps/email_alert_api.pp
+++ b/modules/govuk/manifests/apps/email_alert_api.pp
@@ -79,7 +79,9 @@
 #   Sets the OAuth Secret Key
 #
 # [*email_service_provider*]
-#   Configure which provider to use for sending emails. Either PSEUDO or NOTIFY.
+#   Configure which provider to use for sending emails.
+#    PSUEDO - Don't actually send emails, instead just log them.
+#    NOTIFY - Use GOV.UK Notify to send the emails.
 #
 class govuk::apps::email_alert_api(
   $port = '3088',

--- a/modules/govuk/manifests/apps/email_alert_api.pp
+++ b/modules/govuk/manifests/apps/email_alert_api.pp
@@ -78,6 +78,9 @@
 # [*oauth_secret*]
 #   Sets the OAuth Secret Key
 #
+# [*email_service_provider*]
+#   Configure which provider to use for sending emails. Either PSEUDO or NOTIFY.
+#
 class govuk::apps::email_alert_api(
   $port = '3088',
   $enabled = false,
@@ -106,6 +109,7 @@ class govuk::apps::email_alert_api(
   $secret_key_base = undef,
   $oauth_id = undef,
   $oauth_secret = undef,
+  $email_service_provider = 'NOTIFY',
   $db_username = 'email-alert-api',
   $db_password = undef,
   $db_hostname = undef,
@@ -211,6 +215,9 @@ class govuk::apps::email_alert_api(
       "${title}-OAUTH_SECRET":
           varname => 'OAUTH_SECRET',
           value   => $oauth_secret;
+      "${title}-EMAIL_SERVICE_PROVIDER":
+          varname => 'EMAIL_SERVICE_PROVIDER',
+          value   => $email_service_provider;
     }
 
     if $allow_govdelivery_topic_syncing {


### PR DESCRIPTION
This is so that we can do loading testing in staging.

[Trello Card](https://trello.com/c/7zoZKZkS/281-agree-approach-for-load-testing-with-notify)