### PR TITLE
Add an ssh config for jenkins

### DIFF
--- a/modules/govuk_jenkins/files/ssh-config
+++ b/modules/govuk_jenkins/files/ssh-config
@@ -1,0 +1,2 @@
+Host *
+  StrictHostKeyChecking no

--- a/modules/govuk_jenkins/manifests/ssh_key.pp
+++ b/modules/govuk_jenkins/manifests/ssh_key.pp
@@ -33,6 +33,14 @@ class govuk_jenkins::ssh_key (
     group  => $jenkins_user,
   }
 
+  file { "${ssh_dir}/config":
+    source  => 'puppet:///modules/govuk_jenkins/ssh-config',
+    owner   => $jenkins_user,
+    group   => $jenkins_user,
+    mode    => '0600',
+    require => File[$ssh_dir],
+  }
+
   if $private_key and $public_key {
     file { $public_key_filename:
       content => "ssh-rsa ${public_key}",


### PR DESCRIPTION
That set StrictHostKeyChecking to no.

This is similar to
https://github.com/alphagov/govuk-app-deployment/pull/212, but slightly
different. App deployments also run rysnc as part of the deployments,
- this does not use the capistrano ssh config, but uses the ssh config
files on the system

A new machine coming up requires puppet to run to add the known host to
`/etc/ssh/ssh_known_hosts` - if this is not there the deploy will
currently fail because there is no `usr/bin/ssh-askpass` program
available - it would fail requiring interactive confirmation that we
trust the host key. If we set StrictHostKeyChecking to yes, it would
fail until puppet is run.

As we are ignoring host keys for capistrano deployments, although we
could fix this rsync issue by making sure puppet was run before
deployments kick off, it wouldn't give us any benefits over simply
ignoring the host key verification, which we do for capistrano
operations in the deployment anyway.