### PR TITLE
Handle intermittent gauge metrics in monitoring targets

### DIFF
--- a/modules/grafana/templates/dashboards/_index_size.json.erb
+++ b/modules/grafana/templates/dashboards/_index_size.json.erb
@@ -50,17 +50,17 @@
         "targets": [
           {
             "refId": "A",
-            "target": "alias(diffSeries(stats.gauges.govuk.app.rummager.<%= index_name %>_index.docs.count, timeShift(stats.gauges.govuk.app.rummager.<%= index_name %>_index.docs.count, '7d')),'Change')",
+            "target": "alias(diffSeries(keepLastValue(stats.gauges.govuk.app.rummager.<%= index_name %>_index.docs.count,132), timeShift(keepLastValue(stats.gauges.govuk.app.rummager.<%= index_name %>_index.docs.count,132), '7d')),'Change')",
             "textEditor": true
           },
           {
             "refId": "B",
-            "target": "alias(stats.gauges.govuk.app.rummager.<%= index_name %>_index.docs.count,'Index size')",
+            "target": "alias(keepLastValue(stats.gauges.govuk.app.rummager.<%= index_name %>_index.docs.count,132),'Index size')",
             "textEditor": true
           },
           {
             "refId": "C",
-            "target": "alias(timeShift(stats.gauges.govuk.app.rummager.<%= index_name %>_index.docs.count, '7d'),'Index size (last week)')",
+            "target": "alias(timeShift(keepLastValue(stats.gauges.govuk.app.rummager.<%= index_name %>_index.docs.count,132), '7d'),'Index size (last week)')",
             "textEditor": true
           }
         ],
@@ -111,17 +111,17 @@
         "targets": [
           {
             "refId": "C",
-            "target": "alias(diffSeries(stats.gauges.govuk.app.rummager.<%= index_name %>_index.docs.count, timeShift(stats.gauges.govuk.app.rummager.<%= index_name %>_index.docs.count, '7d')),'Change')",
+            "target": "alias(diffSeries(keepLastValue(stats.gauges.govuk.app.rummager.<%= index_name %>_index.docs.count,132), timeShift(keepLastValue(stats.gauges.govuk.app.rummager.<%= index_name %>_index.docs.count,132), '7d')),'Change')",
             "textEditor": true
           },
           {
             "refId": "A",
-            "target": "alias(stats.gauges.govuk.app.rummager.<%= index_name %>_index.docs.count, 'Index size')",
+            "target": "alias(keepLastValue(stats.gauges.govuk.app.rummager.<%= index_name %>_index.docs.count,132), 'Index size')",
             "textEditor": true
           },
           {
             "refId": "B",
-            "target": "alias(timeShift(stats.gauges.govuk.app.rummager.<%= index_name %>_index.docs.count,'7d'), 'Index size (last week)')",
+            "target": "alias(timeShift(keepLastValue(stats.gauges.govuk.app.rummager.<%= index_name %>_index.docs.count,132),'7d'), 'Index size (last week)')",
             "textEditor": true
           }
         ],

--- a/modules/monitoring/manifests/checks/sidekiq.pp
+++ b/modules/monitoring/manifests/checks/sidekiq.pp
@@ -5,7 +5,7 @@
 #
 class monitoring::checks::sidekiq {
 
-  $graphite_target = 'movingAverage(stats.gauges.govuk.app.rummager.workers.queues.default.latency,"-600s")'
+  $graphite_target = 'movingAverage(keepLastValue(stats.gauges.govuk.app.rummager.workers.queues.default.latency),"-600s")'
 
   icinga::check::graphite { 'check_rummager_queue_latency':
     target              => $graphite_target,


### PR DESCRIPTION
Now that statsd isn't repeating the last know values, use the
keepLastValue function in graphite to smooth out the series for the
monitoring targets.