### PR TITLE
Update Docker tag names

### DIFF
--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -188,7 +188,7 @@ def buildProject(Map options = [:]) {
 
     if (hasDockerfile()) {
       stage("Build Docker image") {
-        buildDockerImage(jobName, env.BRANCH_NAME)
+        buildDockerImage(jobName)
       }
     }
 
@@ -766,8 +766,12 @@ def hasDockerfile() {
   sh(script: "test -e Dockerfile", returnStatus: true) == 0
 }
 
-def buildDockerImage(imageName, tagName) {
-  docker.build("govuk/${imageName}:${tagName}")
+def buildDockerImage(imageName) {
+  docker.build("govuk/${imageName}:${getDockerImageTagName()}")
+}
+
+def getDockerImageTagName() {
+  return env.BRANCH_NAME.replaceAll("/", "_")
 }
 
 


### PR DESCRIPTION
Docker tag does not allow forward slashes in the tag names, and for
repos with both this and dependabot enabled, the tests were failing due
to dependabots branch naming containing forward slashes.

To get around this, we have replaced the forward slashes with
underscores in the tag name, and created a method for if this tag name
will be used elsewhere within the future