### PR TITLE
Strip slashes from docker image tags

### DIFF
--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -767,6 +767,7 @@ def hasDockerfile() {
 }
 
 def buildDockerImage(imageName, tagName) {
+  tagName = safeDockerTag(tagName)
   docker.build("govuk/${imageName}:${tagName}")
 }
 
@@ -776,12 +777,14 @@ def buildDockerImage(imageName, tagName) {
  * the image is also tagged with that value otherwise the `tagName` is used.
  */
 def pushDockerImage(imageName, tagName, asTag = null) {
+  tagName = safeDockerTag(tagName)
   docker.withRegistry('https://index.docker.io/v1/', 'govukci-docker-hub') {
     docker.image("govuk/${imageName}:${tagName}").push(asTag ?: tagName)
   }
 }
 
 def pushDockerImageToGCR(imageName, tagName) {
+  tagName = safeDockerTag(tagName)
   gcrName = "gcr.io/govuk-test/${imageName}"
   docker.build(gcrName)
 
@@ -797,6 +800,10 @@ def pushDockerImageToGCR(imageName, tagName) {
     command = "gcloud container images add-tag ${gcrName} ${gcrName}:${tagName}"
     sh command
   }
+}
+
+def safeDockerTag(tagName) {
+  return tagName.replace("/", "_")
 }
 
 /*


### PR DESCRIPTION
We pass branch names in to the Jenkins `buildDockerImage` function to
be used as a tag for the Docker image. However, a branch name might
contain a slash (eg `feature/awesome-new-feature`), which is not valid
in the Docker tag name.

In this case, the build will fail.

This change adds a method for replacing these slashes with underscores,
which are allowed in the tag name.

An example of this running successfully is here: https://ci.integration.publishing.service.gov.uk/job/content-performance-manager/job/feature%252Fcontent-preview/9/console