### PR TITLE
Set LINK_CHECKER_API_CALLBACK_HOST

### DIFF
--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -356,6 +356,10 @@ class govuk::apps::whitehall(
       "${title}-LINK_CHECKER_API_SECRET_TOKEN":
         varname => 'LINK_CHECKER_API_SECRET_TOKEN',
         value   => $link_checker_api_secret_token;
+      "${title}-LINK_CHECKER_API_CALLBACK_HOST":
+        app     => $app_name,
+        varname => 'LINK_CHECKER_API_CALLBACK_HOST',
+        value   => "https://whitehall-admin.${app_domain}";
     }
 
     if $::govuk_node_class !~ /^development$/ {


### PR DESCRIPTION
This PR adds an env var to use for the URL host when building a Callback URL for Link Checker API requests from Whitehall scheduled workers alphagov/whitehall#3574
