### PR TITLE
Configure a Slack channel for the CDN dictionary Jenkins job

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/update_cdn_dictionaries.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/update_cdn_dictionaries.yaml.erb
@@ -41,6 +41,7 @@
           team-domain: <%= @slack_team_domain %>
           auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN']%>
           build-server-url: <%= @slack_build_server_url %>
+          room: <%= @slack_room %>
     wrappers:
         - ansicolor:
             colormap: xterm


### PR DESCRIPTION
Add a Slack channel to the `publishers` section of the CDN dictionaries Jenkins job to fix an error in the Jenkins job builder.

We don't think this channel is actually used by the Jenkins job since it always falls back to the default channel (see #6830), but apparently it needs to be configured anyway.