### PR TITLE
Add default vhost to Graphite

### DIFF
--- a/modules/govuk/manifests/node/s_graphite.pp
+++ b/modules/govuk/manifests/node/s_graphite.pp
@@ -91,6 +91,10 @@ class govuk::node::s_graphite (
     extra_config => $cors_headers,
   }
 
+  if $::aws_migration {
+    nginx::config::vhost::default { 'default': }
+  }
+
   ## Make compressed archives of Whisper data to backup off-box rather than
   ## backing up the raw files
   file { '/usr/local/bin/govuk_backup_graphite_whisper_files':


### PR DESCRIPTION
Add the default Vhost to Nginx in the Graphite box, so it can serve
the healthcheck page for AWS LBs.