### PR TITLE
AWS do not set Graphite/Grafana aliases

### DIFF
--- a/modules/govuk/manifests/node/s_graphite.pp
+++ b/modules/govuk/manifests/node/s_graphite.pp
@@ -83,16 +83,20 @@ class govuk::node::s_graphite (
   add_header "Access-Control-Allow-Headers" "origin, authorization, accept";
 '
 
+  if $::aws_migration {
+    nginx::config::vhost::default { 'default': }
+
+    $graphite_aliases = undef
+  } else {
+    $graphite_aliases = ['graphite.*']
+  }
+
   nginx::config::vhost::proxy { 'graphite':
     to           => ['localhost:33333'],
     root         => "${graphite_path}/webapp",
-    aliases      => ['graphite.*'],
+    aliases      => $graphite_aliases,
     protected    => false,
     extra_config => $cors_headers,
-  }
-
-  if $::aws_migration {
-    nginx::config::vhost::default { 'default': }
   }
 
   ## Make compressed archives of Whisper data to backup off-box rather than

--- a/modules/grafana/manifests/init.pp
+++ b/modules/grafana/manifests/init.pp
@@ -36,7 +36,6 @@ class grafana (
     nginx::config::vhost::proxy { 'grafana':
       to           => ['localhost:3204'],
       root         => '/usr/share/grafana',
-      aliases      => ['grafana.*'],
       protected    => false,
       ssl_only     => true,
       ssl_certtype => 'wildcard_publishing',


### PR DESCRIPTION
The change in 66feb46 adds an extra '.*' in the graphite and grafana
vhost server_names to the already set wildcard aliases.

In this change we remove the aliases in AWS, the wildcard gets set
from the vhost name