### PR TITLE
Increase email-alert-api rate per worker to 360 req/s

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -361,7 +361,7 @@ govuk::apps::email_alert_api::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::email_alert_api::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::email_alert_api::db_hostname: 'postgresql-primary-1.backend'
 govuk::apps::email_alert_api::db_password: "%{hiera('govuk::apps::email_alert_api::db::password')}"
-govuk::apps::email_alert_api::govuk_notify_rate_per_worker: '10'
+govuk::apps::email_alert_api::govuk_notify_rate_per_worker: '12'
 
 govuk::apps::email_alert_service::rabbitmq_hosts:
   - rabbitmq-1.backend

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -37,7 +37,7 @@ govuk::apps::email_alert_api::enable_public_proxy: true
 govuk::apps::email_alert_api::govdelivery_account_code: 'UKGOVUKDUP'
 govuk::apps::email_alert_api::govdelivery_hostname: 'stage-api.govdelivery.com'
 govuk::apps::email_alert_api::govdelivery_public_hostname: 'stage-public.govdelivery.com'
-govuk::apps::email_alert_api::govuk_notify_rate_per_worker: '15'
+govuk::apps::email_alert_api::govuk_notify_rate_per_worker: '18'
 govuk::apps::event_store::enabled: true
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
 govuk::apps::publicapi::backdrop_host: 'www.preview.performance.service.gov.uk'


### PR DESCRIPTION
GOV.UK Notify will be increasing the rate limit to 450 req/s so it seems like we can use a slightly higher rate limit here. With the previous rate limits we were able to achieve 83,333 emails in 4 minutes 48 seconds, and increasing this limit should mean we can get a few more emails through.