### PR TITLE
Use docker system prune to clean up docker artefacts

### DIFF
--- a/modules/govuk_ci/manifests/agent/docker.pp
+++ b/modules/govuk_ci/manifests/agent/docker.pp
@@ -15,15 +15,15 @@ class govuk_ci::agent::docker {
     version => '1.17.1',
   }
 
-  cron::crondotdee { 'remove_docker_dangling_images' :
+  cron::crondotdee { 'docker_system_prune' :
     hour    => '*/2',
     minute  => 0,
-    command => 'docker rmi $(docker images --filter "dangling=true" -q --no-trunc)',
+    command => 'docker system prune -a -f --filter="until=24h"',
   }
 
-  cron::crondotdee { 'remove_docker_dangling_volumes' :
+  cron::crondotdee { 'docker_volume_prune' :
     hour    => '*/2',
-    minute  => 2,
-    command => 'docker volume rm $(docker volume ls -qf dangling=true)',
+    minute  => 5,
+    command => 'docker volume prune -f',
   }
 }


### PR DESCRIPTION
[docker system prune][1] is a more modern command that we can use to
clean up the various things that are left behind by docker builds. It
removes all things that are older than 24 hours and not in use - so this
may cause some additional building of containers but I'm expecting
effect to be low.

Running this on ci-agent-4 reclaimed 75.75GB space

This uses docker volume prune to remove the images as they are not
removed with `docker system prune` after version 17.06 and do not
support the filter command.

[1]: https://docs.docker.com/engine/reference/commandline/system_prune/