### PR TITLE
Fix quoting issues in the rummager related checks

### DIFF
--- a/modules/monitoring/manifests/checks.pp
+++ b/modules/monitoring/manifests/checks.pp
@@ -131,7 +131,7 @@ class monitoring::checks (
   $keep_last_value_limit = '132'
 
   icinga::check::graphite { 'check_rummager_govuk_index_size_changed':
-    target              => "absolute(diffSeries(keepLastValue(stats.gauges.govuk.app.rummager.govuk_index.docs.count,${keep_last_value_limit}), timeShift(keepLastValue(stats.gauges.govuk.app.rummager.govuk_index.docs.count,${keep_last_value_limit}), '7d')))",
+    target              => "absolute(diffSeries(keepLastValue(stats.gauges.govuk.app.rummager.govuk_index.docs.count,${keep_last_value_limit}), timeShift(keepLastValue(stats.gauges.govuk.app.rummager.govuk_index.docs.count,${keep_last_value_limit}), '\\''7d'\\'')))",
     warning             => 2000,
     critical            => 10000,
     desc                => 'rummager govuk index size has significantly increased/decreased over the last 7 days',
@@ -144,7 +144,7 @@ class monitoring::checks (
 
   # Mainstream is comparable to the govuk index.
   icinga::check::graphite { 'check_rummager_mainstream_index_size_changed':
-    target              => "absolute(diffSeries(keepLastValue(stats.gauges.govuk.app.rummager.mainstream_index.docs.count,${keep_last_value_limit}), timeShift(keepLastValue(stats.gauges.govuk.app.rummager.mainstream_index.docs.count,${keep_last_value_limit}), '7d')))",
+    target              => "absolute(diffSeries(keepLastValue(stats.gauges.govuk.app.rummager.mainstream_index.docs.count,${keep_last_value_limit}), timeShift(keepLastValue(stats.gauges.govuk.app.rummager.mainstream_index.docs.count,${keep_last_value_limit}), '\\''7d'\\'')))",
     warning             => 500,
     critical            => 1000,
     desc                => 'rummager mainstream index size has significantly increased/decreased over the last 7 days',
@@ -157,7 +157,7 @@ class monitoring::checks (
 
   # Government is comparable to the govuk index.
   icinga::check::graphite { 'check_rummager_government_index_size_changed':
-    target              => "absolute(diffSeries(keepLastValue(stats.gauges.govuk.app.rummager.government_index.docs.count,${keep_last_value_limit}), timeShift(keepLastValue(stats.gauges.govuk.app.rummager.government_index.docs.count,${keep_last_value_limit}), '7d')))",
+    target              => "absolute(diffSeries(keepLastValue(stats.gauges.govuk.app.rummager.government_index.docs.count,${keep_last_value_limit}), timeShift(keepLastValue(stats.gauges.govuk.app.rummager.government_index.docs.count,${keep_last_value_limit}), '\\''7d'\\'')))",
     warning             => 1600,
     critical            => 8000,
     desc                => 'rummager government index size has significantly increased/decreased over the last 7 days',
@@ -170,7 +170,7 @@ class monitoring::checks (
 
   # Detailed is smaller than the other indexes (about 4500 documents)
   icinga::check::graphite { 'check_rummager_detailed_index_size_changed':
-    target              => "absolute(diffSeries(keepLastValue(stats.gauges.govuk.app.rummager.detailed_index.docs.count,${keep_last_value_limit}), timeShift(keepLastValue(stats.gauges.govuk.app.rummager.detailed_index.docs.count,${keep_last_value_limit}), '3d')))",
+    target              => "absolute(diffSeries(keepLastValue(stats.gauges.govuk.app.rummager.detailed_index.docs.count,${keep_last_value_limit}), timeShift(keepLastValue(stats.gauges.govuk.app.rummager.detailed_index.docs.count,${keep_last_value_limit}), '\\''3d'\\'')))",
     warning             => 100,
     critical            => 500,
     desc                => 'rummager detailed index size has significantly increased/decreased over the last 3 days',


### PR DESCRIPTION
By adding more quotes...

Then this string ends up in the command, its quoted using single
quotes, which doesn't work with the single quoted time shift
parameter. Therefore, include some more single quotes, and a literal
backslash (that has to be escaped for puppet).