### PR TITLE
Increase disk size for postgres primary in staging

### DIFF
--- a/hieradata/class/staging/postgresql_primary.yaml
+++ b/hieradata/class/staging/postgresql_primary.yaml
@@ -1,1 +1,15 @@
+lv:
+  postgresql:
+    pv:
+      - '/dev/sda1'
+      - '/dev/sdc1'
+      - '/dev/sde1'
+      - '/dev/sdf1'
+      - '/dev/sdg1'
+      - '/dev/sdh1'
+    vg: 'backups'
+  data:
+    pv: '/dev/sdd1'
+    vg: 'postgresql'
+
 govuk_postgresql::server::max_connections: 120


### PR DESCRIPTION
postgres-primary in staging had 100GB less space than in prod. This should bring them to parity.