### PR TITLE
Update bouncer healthcheck in AWS

### DIFF
--- a/modules/govuk/manifests/apps/bouncer.pp
+++ b/modules/govuk/manifests/apps/bouncer.pp
@@ -63,6 +63,18 @@ class govuk::apps::bouncer(
 
   if $::aws_migration {
     $vhost = 'bouncer'
+
+    nginx::config::site { 'healthcheck':
+      content => '
+        # Required for ALB healthchecks
+        server {
+          listen 80;
+          location = /_healthcheck {
+            return 200;
+          }
+        }
+      ',
+    }
   } else {
     $vhost = "bouncer.${app_domain}"
   }

--- a/modules/govuk/templates/bouncer_nginx_vhost.conf.erb
+++ b/modules/govuk/templates/bouncer_nginx_vhost.conf.erb
@@ -22,11 +22,6 @@ server {
     # with ".html" appended, then fallback to the app (bouncer).
     try_files $uri $uri.html @app;
   }
-  <%- if scope.lookupvar('::aws_migration') %>
-  location = /_healthcheck {
-    return 200;
-  }
-  <%- end %>
 
   location @app {
     proxy_pass http://<%= "bouncer.#{@app_domain}-proxy" %>;


### PR DESCRIPTION
In fcad11ccc9a31750ff85aa7e8f7eac6521db0e9d I added the healthcheck config in the wrong vhost.

Bouncer has a default vhost as it accepts all hosts due to the number of domains that it handles.

Add configuration that specifically listens for the healthcheck URL.