### PR TITLE
Don't run Publishing end-to-end tests for schema builds

### DIFF
--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -220,7 +220,7 @@ def buildProject(Map options = [:]) {
       }
     }
 
-    if (options.publishingE2ETests == true) {
+    if (options.publishingE2ETests == true && !params.IS_SCHEMA_TEST) {
       stage("End-to-end tests") {
         if ( env.PUBLISHING_E2E_TESTS_APP_PARAM == null ) {
           appCommitishName = jobName.replace("-", "_").toUpperCase() + "_COMMITISH"


### PR DESCRIPTION
When govuk-content-schemas builds it triggers tests for many
applications, and these applications then kick off end-to-end tests.
Which can lead to a huge amount of builds. These end-to-end test builds
don't actually offer any value since we don't offer the ability to build
against a particular content-schema commit.

A future iteration could be that govuk-content-schemas kicks off it's
own build of the end-to-end tests once we support specifying the build.