### PR TITLE
Set up extra CI hosts for Publishing end-to-end tests

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -727,19 +727,19 @@ govuk_ci::master::pipeline_jobs:
 govuk_ci::master::ci_agents:
   ci-agent-1:
     agent_hostname: 'ci-agent-1.ci'
-    labels: 'mongodb-2.4 docker ci-agent-1 elasticsearch-2.4 terraform-0.8.1'
+    labels: 'mongodb-2.4 ci-agent-1 elasticsearch-2.4 terraform-0.8.1'
   ci-agent-2:
     agent_hostname: 'ci-agent-2.ci'
-    labels: 'mongodb-2.4 docker ci-agent-2 elasticsearch-2.4 terraform'
+    labels: 'mongodb-2.4 ci-agent-2 elasticsearch-2.4 terraform'
   ci-agent-3:
     agent_hostname: 'ci-agent-3.ci'
-    labels: 'mongodb-2.4 docker ci-agent-3 elasticsearch-2.4 terraform'
+    labels: 'mongodb-2.4 ci-agent-3 elasticsearch-2.4 terraform'
   ci-agent-4:
     agent_hostname: 'ci-agent-4.ci'
-    labels: 'mongodb-3.2 docker ci-agent-4 elasticsearch-2.4 terraform'
+    labels: 'mongodb-3.2 ci-agent-4 elasticsearch-2.4 terraform'
   ci-agent-5:
     agent_hostname: 'ci-agent-5.ci'
-    labels: 'mongodb-3.2 docker ci-agent-5 elasticsearch-2.4 terraform'
+    labels: 'mongodb-3.2 ci-agent-5 elasticsearch-2.4 terraform'
 
 govuk_ci::master::credentials_id: 'jenkins-ssh-slave'
 

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -739,7 +739,24 @@ govuk_ci::master::ci_agents:
     labels: 'mongodb-3.2 ci-agent-4 elasticsearch-2.4 terraform'
   ci-agent-5:
     agent_hostname: 'ci-agent-5.ci'
-    labels: 'mongodb-3.2 ci-agent-5 elasticsearch-2.4 terraform'
+    exclusive: true
+    executors: 1
+    labels: 'publishing-e2e-tests'
+  ci-agent-6:
+    agent_hostname: 'ci-agent-6.ci'
+    exclusive: true
+    executors: 1
+    labels: 'publishing-e2e-tests'
+  ci-agent-7:
+    agent_hostname: 'ci-agent-7.ci'
+    exclusive: true
+    executors: 1
+    labels: 'publishing-e2e-tests'
+  ci-agent-8:
+    agent_hostname: 'ci-agent-8.ci'
+    exclusive: true
+    executors: 1
+    labels: 'publishing-e2e-tests'
 
 govuk_ci::master::credentials_id: 'jenkins-ssh-slave'
 
@@ -1260,6 +1277,12 @@ hosts::production::ci::hosts:
     ip: '10.1.6.24'
   ci-agent-5:
     ip: '10.1.6.25'
+  ci-agent-6:
+    ip: '10.1.6.26'
+  ci-agent-7:
+    ip: '10.1.6.27'
+  ci-agent-8:
+    ip: '10.1.6.28'
 
 hosts::production::frontend::hosts:
   calculators-frontend-1:

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -768,7 +768,24 @@ govuk_ci::master::ci_agents:
     labels: 'mongodb-3.2 ci-agent-4 elasticsearch'
   ci-agent-5:
     agent_hostname: 'ci-agent-5.ci'
-    labels: 'mongodb-3.2 ci-agent-5 elasticsearch'
+    exclusive: true
+    executors: 1
+    labels: 'publishing-e2e-tests'
+  ci-agent-6:
+    agent_hostname: 'ci-agent-6.ci'
+    exclusive: true
+    executors: 1
+    labels: 'publishing-e2e-tests'
+  ci-agent-7:
+    agent_hostname: 'ci-agent-7.ci'
+    exclusive: true
+    executors: 1
+    labels: 'publishing-e2e-tests'
+  ci-agent-8:
+    agent_hostname: 'ci-agent-8.ci'
+    exclusive: true
+    executors: 1
+    labels: 'publishing-e2e-tests'
 
 govuk_ci::master::credentials_id: 'jenkins-ssh-slave'
 

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -756,19 +756,19 @@ govuk_ci::master::pipeline_jobs:
 govuk_ci::master::ci_agents:
   ci-agent-1:
     agent_hostname: 'ci-agent-1.ci'
-    labels: 'mongodb-2.4 docker ci-agent-1 elasticsearch'
+    labels: 'mongodb-2.4 ci-agent-1 elasticsearch'
   ci-agent-2:
     agent_hostname: 'ci-agent-2.ci'
-    labels: 'mongodb-2.4 docker ci-agent-2 elasticsearch'
+    labels: 'mongodb-2.4 ci-agent-2 elasticsearch'
   ci-agent-3:
     agent_hostname: 'ci-agent-3.ci'
-    labels: 'mongodb-2.4 docker ci-agent-3 elasticsearch'
+    labels: 'mongodb-2.4 ci-agent-3 elasticsearch'
   ci-agent-4:
     agent_hostname: 'ci-agent-4.ci'
-    labels: 'mongodb-3.2 docker ci-agent-4 elasticsearch'
+    labels: 'mongodb-3.2 ci-agent-4 elasticsearch'
   ci-agent-5:
     agent_hostname: 'ci-agent-5.ci'
-    labels: 'mongodb-3.2 docker ci-agent-5 elasticsearch'
+    labels: 'mongodb-3.2 ci-agent-5 elasticsearch'
 
 govuk_ci::master::credentials_id: 'jenkins-ssh-slave'
 

--- a/modules/govuk_jenkins/manifests/ssh_slave.pp
+++ b/modules/govuk_jenkins/manifests/ssh_slave.pp
@@ -21,6 +21,10 @@
 # [*executors*]
 #   Set how many jobs the instance can build at any one time.
 #
+# [*exclusive*]
+#   Boolean to indicate whether or not to "Only build jobs with label
+#   expressions matching this node"
+#
 # [*ssh_port*]
 #   Set the SSH port that the master connects to.
 #
@@ -37,6 +41,7 @@ define govuk_jenkins::ssh_slave (
   $labels = undef,
   $description = 'Generic build agent',
   $executors = 4,
+  $exclusive = false,
   $ssh_port = 22,
   $jenkins_home = '/var/lib/jenkins',
   $jenkins_user = 'jenkins',

--- a/modules/govuk_jenkins/templates/ssh_slave_config.xml.erb
+++ b/modules/govuk_jenkins/templates/ssh_slave_config.xml.erb
@@ -4,7 +4,7 @@
   <description><%= @description %></description>
   <remoteFS><%= @jenkins_home %></remoteFS>
   <numExecutors><%= @executors %></numExecutors>
-  <mode>NORMAL</mode>
+  <mode><% if @exclusive %>EXCLUSIVE<% else %>NORMAL<% end %></mode>
   <retentionStrategy class="hudson.slaves.RetentionStrategy$Always"/>
   <launcher class="hudson.plugins.sshslaves.SSHLauncher" plugin="ssh-slaves@1.16">
     <host><%= @agent_hostname %></host>


### PR DESCRIPTION
This configures the 3 additional CI Agents introduced in https://github.com/alphagov/govuk-provisioning/pull/33 so that there are 4 CI agents dedicated to running just end-to-end tests, this will isolate these from the rest of CI. 

When adding these there are a few future expectations:

1. We should resolve issues that stop us running end-to-end tests in parallel, so hopefully they can make better usage of the parallel builds - when these come we can up the executors.
2. There's a good amount of low hanging fruit surrounding end-to-end test performance that we can pick off so they should get faster
3. More applications are going to be added to run end-to-end tests so there will eventually be more of them
4. With the introduction of [Dependabot](https://dependabot.com/) to our stack there is likely to be an increase in builds and thus end-to-end tests.