### PR TITLE
Environment variable to allow daily GA export

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -386,6 +386,8 @@ govuk::apps::govuk_cdn_logs_monitor::processed_data_dir: '/mnt/logs_cdn/data'
 govuk::apps::hmrc_manuals_api::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::hmrc_manuals_api::redis_port: "%{hiera('sidekiq_port')}"
 
+govuk::apps::local_links_manager::run_links_ga_export: false
+
 govuk::apps::link_checker_api::db_hostname: "postgresql-primary-1.backend"
 govuk::apps::link_checker_api::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 # Hardcoded to its own redis server to improve performance

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -79,6 +79,7 @@ govuk::apps::email_alert_api::govdelivery_hostname: 'api.govdelivery.com'
 govuk::apps::email_alert_api::govdelivery_public_hostname: 'public.govdelivery.com'
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::local_links_manager::local_links_manager_passive_checks: true
+govuk::apps::local_links_manager::run_links_ga_export: true
 govuk::apps::publicapi::backdrop_host: 'www.performance.service.gov.uk'
 govuk::apps::publisher::run_fact_check_fetcher: true
 govuk::apps::publisher::fact_check_address_format: 'factcheck+production-{id}@alphagov.co.uk'

--- a/modules/govuk/manifests/apps/local_links_manager.pp
+++ b/modules/govuk/manifests/apps/local_links_manager.pp
@@ -73,6 +73,12 @@
 # [*link_checker_api_secret_token*]
 #   The secret token used when verifying web hook responses from the Link
 #   Checker API.
+#
+# [*run_links_ga_export]
+#   Feature flag to allow a daily rake task to upload a list of bad links
+#   to GA.
+#   Default: false
+#
 class govuk::apps::local_links_manager(
   $port = 3121,
   $enabled = true,
@@ -95,6 +101,7 @@ class govuk::apps::local_links_manager(
   $google_export_account_id = undef,
   $google_export_custom_data_import_source_id = undef,
   $google_export_tracker_id = undef,
+  $run_links_ga_export = undef,
 ) {
   $app_name = 'local-links-manager'
 
@@ -151,6 +158,9 @@ class govuk::apps::local_links_manager(
       "${title}-LINK_CHECKER_API_SECRET_TOKEN":
         varname => 'LINK_CHECKER_API_SECRET_TOKEN',
         value   => $link_checker_api_secret_token;
+      "${title}-RUN_LINK_GA_EXPORT":
+        varname => 'RUN_LINK_GA_EXPORT',
+        value   => bool2str($run_links_ga_export);
     }
 
     if $local_links_manager_passive_checks {


### PR DESCRIPTION
The Local Links Manager app has a scheduled job which runs every morning at 6 AM and
uploads a list of bad links to GA (https://github.com/alphagov/local-links-manager/pull/136).

We don't need this export to run from integration or staging as it would upload bad data/duplicate
data respectively.

For: https://trello.com/c/9CHX7tje/312-run-daily-scheduled-export-of-bad-links-to-ga