### PR TITLE
Fix Plek Licensify error in AWS

### DIFF
--- a/modules/govuk/manifests/node/s_draft_frontend.pp
+++ b/modules/govuk/manifests/node/s_draft_frontend.pp
@@ -13,16 +13,16 @@ class govuk::node::s_draft_frontend() inherits govuk::node::s_base {
   govuk_envvar {
     'PLEK_HOSTNAME_PREFIX': value => 'draft-';
     'PLEK_SERVICE_IMMINENCE_URI': value => "https://imminence.${app_domain}";
-    'PLEK_SERVICE_LICENSIFY_URI': value => "https://licensify.${app_domain}";
     'PLEK_SERVICE_LOCAL_LINKS_MANAGER_URI': value => "https://local-links-manager.${app_domain}";
   }
 
   unless $::aws_migration {
     # This is set for all apps in AWS so we skip adding it here
     govuk_envvar {
-      'PLEK_SERVICE_MAPIT_URI': value  => "https://mapit.${app_domain}";
-      'PLEK_SERVICE_SEARCH_URI': value => "https://search.${app_domain}";
-      'PLEK_SERVICE_RUMMAGER_URI': value => "https://rummager.${app_domain}";
+      'PLEK_SERVICE_MAPIT_URI': value     => "https://mapit.${app_domain}";
+      'PLEK_SERVICE_SEARCH_URI': value    => "https://search.${app_domain}";
+      'PLEK_SERVICE_RUMMAGER_URI': value  => "https://rummager.${app_domain}";
+      'PLEK_SERVICE_LICENSIFY_URI': value => "https://licensify.${app_domain}";
     }
   }
 


### PR DESCRIPTION
This fixes:

```
Could not retrieve catalog from remote server: Error 400 on SERVER: Duplicate declaration: Govuk_envvar[PLEK_SERVICE_LICENSIFY_URI] is already declared in file /usr/share/puppet/production/current/modules/govuk/manifests/deploy/config.pp:115; cannot redeclare at /usr/share/puppet/production/current/modules/govuk/manifests/node/s_draft_frontend.pp:18
```