### PR TITLE
Include openjdk-7-jdk on CI agents

### DIFF
--- a/hieradata/node/ci-agent-6.ci.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/ci-agent-6.ci.integration.publishing.service.gov.uk.yaml
@@ -1,3 +1,0 @@
----
-
-govuk_ci::agent::elasticsearch_enabled: false

--- a/modules/govuk_ci/manifests/agent.pp
+++ b/modules/govuk_ci/manifests/agent.pp
@@ -20,9 +20,6 @@ class govuk_ci::agent(
   include ::clamav::cron_freshclam
   include ::govuk_ci::agent::redis
   include ::govuk_ci::agent::docker
-  if $elasticsearch_enabled {
-    include ::govuk_ci::agent::elasticsearch
-  }
   include ::golang
   include ::govuk_ci::agent::gcloud
   include ::govuk_ci::agent::mongodb
@@ -40,6 +37,15 @@ class govuk_ci::agent(
   include ::govuk_rbenv::all
   include ::govuk_sysdig
   include ::govuk_testing_tools
+
+  if $elasticsearch_enabled {
+    include ::govuk_ci::agent::elasticsearch
+  } else {
+    class { 'govuk_java::set_defaults':
+      jdk => 'openjdk7',
+      jre => 'openjdk7',
+    }
+  }
 
   # Override sudoers.d resource (managed by sudo module) to enable Jenkins user to run sudo tests
   File<|title == '/etc/sudoers.d/'|> {


### PR DESCRIPTION
ci-agent-6 specifically failed to join the Jenkins master as an agent
because a JDK was not installed. This was because it had been explicitly
excluded from installing Elasticsearch (probably from when we were using
it to test Xenial).

If we're not including Elasticsearch then we should include a JDK
instead.