### PR TITLE
Set parameter default to false

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -386,8 +386,6 @@ govuk::apps::govuk_cdn_logs_monitor::processed_data_dir: '/mnt/logs_cdn/data'
 govuk::apps::hmrc_manuals_api::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::hmrc_manuals_api::redis_port: "%{hiera('sidekiq_port')}"
 
-govuk::apps::local_links_manager::run_links_ga_export: false
-
 govuk::apps::link_checker_api::db_hostname: "postgresql-primary-1.backend"
 govuk::apps::link_checker_api::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 # Hardcoded to its own redis server to improve performance

--- a/modules/govuk/manifests/apps/local_links_manager.pp
+++ b/modules/govuk/manifests/apps/local_links_manager.pp
@@ -101,7 +101,7 @@ class govuk::apps::local_links_manager(
   $google_export_account_id = undef,
   $google_export_custom_data_import_source_id = undef,
   $google_export_tracker_id = undef,
-  $run_links_ga_export = undef,
+  $run_links_ga_export = false,
 ) {
   $app_name = 'local-links-manager'
 


### PR DESCRIPTION
If the default is `false`, and only `true` in Production, set it to false in the manifest rather than hieradata.