### PR TITLE
Use 150GB Development VM Vagrant base boxes

### DIFF
--- a/development-vm/Vagrantfile
+++ b/development-vm/Vagrantfile
@@ -39,6 +39,12 @@ EOS
 
   config.vm.box = "govuk_dev_#{dist}64_#{LATEST_BOX_VERSION}"
   config.vm.box_url = "https://govuk-dev-boxes-test.s3.amazonaws.com/#{config.vm.box}.box"
+
+  config.vm.provider 'vmware_fusion' do |_, override|
+    override.vm.box = "govuk_dev_#{dist}64_vmware_fusion_#{LATEST_BOX_VERSION}"
+    override.vm.box_url = "https://govuk-dev-boxes-test.s3.amazonaws.com/#{override.vm.box}.box"
+  end
+
   # Static IP for NFS and DNS
   config.vm.network :private_network, :ip => "10.1.1.254"
   config.vm.hostname = "development.development"
@@ -80,6 +86,16 @@ Vagrant.configure("2") do |config|
     if override.respond_to? :cache
       override.cache.auto_detect = true
     end
+  end
+
+  # The HGFS driver is a VMware extension that provides shared folder support.
+  # Vagrant uses this feature to provide its default shared folder
+  # implementation when using the VMware provider. When you upgrade a kernel
+  # and reboot, the new kernel does not have this HGFS driver available and
+  # Vagrant will timeout waiting for this driver to load when trying to setup
+  # the shared folders.
+  config.vm.provider :vmware_fusion do |_, override|
+    override.vm.synced_folder '.', '/vagrant', disabled: true
   end
 
   # Allow using native shared folders

--- a/development-vm/Vagrantfile
+++ b/development-vm/Vagrantfile
@@ -7,14 +7,7 @@ DEFAULT_VM_PARAMS = {
   memory: 4096,
   cpus: 2,
 }
-BOXES = {
-  virtualbox: {
-    latest_versions: {
-      precise: '20160323',
-      trusty: '20160323',
-    },
-  },
-}
+LATEST_BOX_VERSION = '20171208'
 
 def common_config(config)
   # vagrant-dns is only supported on OS X
@@ -44,7 +37,7 @@ def default_config(config)
 EOS
   end
 
-  config.vm.box = "govuk_dev_#{dist}64_#{BOXES[:virtualbox][:latest_versions][dist]}"
+  config.vm.box = "govuk_dev_#{dist}64_#{LATEST_BOX_VERSION}"
   config.vm.box_url = "https://govuk-dev-boxes-test.s3.amazonaws.com/#{config.vm.box}.box"
   # Static IP for NFS and DNS
   config.vm.network :private_network, :ip => "10.1.1.254"

--- a/development-vm/Vagrantfile
+++ b/development-vm/Vagrantfile
@@ -9,7 +9,6 @@ DEFAULT_VM_PARAMS = {
 }
 BOXES = {
   virtualbox: {
-    bucket: 'govuk-dev-boxes-test',
     latest_versions: {
       precise: '20160323',
       trusty: '20160323',
@@ -45,10 +44,8 @@ def default_config(config)
 EOS
   end
 
-  default_box = "govuk_dev_#{dist}64_#{BOXES[:virtualbox][:latest_versions][dist]}"
-
-  config.vm.box = default_box
-  config.vm.box_url = "https://#{BOXES[:virtualbox][:bucket]}.s3.amazonaws.com/#{default_box}.box"
+  config.vm.box = "govuk_dev_#{dist}64_#{BOXES[:virtualbox][:latest_versions][dist]}"
+  config.vm.box_url = "https://govuk-dev-boxes-test.s3.amazonaws.com/#{config.vm.box}.box"
   # Static IP for NFS and DNS
   config.vm.network :private_network, :ip => "10.1.1.254"
   config.vm.hostname = "development.development"


### PR DESCRIPTION
This updates the Development VM Vagrant base box to the latest version that is configured with increased storage of 150GB.

Also fixes the configuration to allow use of the [VMWare Fusion Vagrant provider](https://www.vagrantup.com/vmware/index.html).

See alphagov/govuk-provisioning#27