### PR TITLE
 Fix Slack channel config in deployment Jenkins

### DIFF
--- a/modules/govuk_jenkins/manifests/job/deploy_cdn.pp
+++ b/modules/govuk_jenkins/manifests/job/deploy_cdn.pp
@@ -7,7 +7,7 @@ class govuk_jenkins::job::deploy_cdn(
 ) {
 
   $slack_team_domain = 'govuk'
-  $slack_room = '2ndline'
+  $slack_room = 'govuk-deploy'
   $slack_build_server_url = "https://deploy.${app_domain}/"
 
   file { '/etc/jenkins_jobs/jobs/deploy_cdn.yaml':

--- a/modules/govuk_jenkins/manifests/job/update_cdn_dictionaries.pp
+++ b/modules/govuk_jenkins/manifests/job/update_cdn_dictionaries.pp
@@ -7,7 +7,7 @@ class govuk_jenkins::job::update_cdn_dictionaries(
 ) {
 
   $slack_team_domain = 'govuk'
-  $slack_room = '2ndline'
+  $slack_room = 'govuk-deploy'
   $slack_build_server_url = "https://deploy.${app_domain}/"
 
   file { '/etc/jenkins_jobs/jobs/update_cdn_dictionaries.yaml':

--- a/modules/govuk_jenkins/templates/jobs/copy_data_from_integration_to_aws.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_from_integration_to_aws.yaml.erb
@@ -31,6 +31,7 @@
             notify-backtonormal: false
             notify-repeatedfailure: false
             include-test-summary: false
+            room: <%= @slack_room %>
     scm:
       - env-sync-and-backup_Copy_Data_from_Integration_to_AWS
     logrotate:

--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
@@ -30,6 +30,7 @@
             notify-backtonormal: false
             notify-repeatedfailure: false
             include-test-summary: false
+            room: <%= @slack_room %>
     scm:
       - env-sync-and-backup_Copy_Data_to_Integration
     logrotate:

--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_staging.yaml.erb
@@ -29,6 +29,7 @@
             notify-backtonormal: false
             notify-repeatedfailure: false
             include-test-summary: false
+            room: <%= @slack_room %>
     scm:
       - env-sync-and-backup_Copy_Data_to_Staging
     logrotate:

--- a/modules/govuk_jenkins/templates/jobs/deploy_cdn.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_cdn.yaml.erb
@@ -27,6 +27,7 @@
             notify-backtonormal: false
             notify-repeatedfailure: false
             include-test-summary: false
+            room: <%= @slack_room %>
     scm:
       - cdn-configs_Deploy_CDN
     builders:

--- a/modules/govuk_jenkins/templates/jobs/deploy_puppet.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_puppet.yaml.erb
@@ -42,6 +42,7 @@
             notify-backtonormal: false
             notify-repeatedfailure: false
             include-test-summary: false
+            room: <%= @slack_room %>
     scm:
       - deployment_Deploy_Puppet
     builders:

--- a/modules/govuk_jenkins/templates/jobs/smokey.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/smokey.yaml.erb
@@ -24,6 +24,7 @@
           notify-backtonormal: true
           notify-repeatedfailure: false
           include-test-summary: false
+          room: <%= @slack_room %>
     publishers:
       - slack:
           team-domain: <%= @slack_team_domain %>


### PR DESCRIPTION
Several Jenkins jobs were posting to #govuk-deploy despite being configured to post to other channels. The problem is that the Slack channel has to be configured in two places:

- In the `publisher` section. This setting is not actually used, but it is required by the Slack plugin.
- In the `job.properties` section. If the room is not configured here, Jenkins will always notify the default Slack channel (#govuk-deploy).

Previously, we just configured the first section. This change adds it to the second section as well.

Notifications will change for these jobs:
- `Copy_Data_from_Integration_to_AWS` will notify #govuk-infrastructure
- `Copy_Data_to_Staging` and `Copy_Data_to_Integration` will notify #2ndline
- `Smokey` will notify #2ndline

I've reconfigured the CDN deployment and Fastly dictionary deployments to deliberately notify #govuk-deploy because they are useful notifications for other people who are deploying apps at the same time. But we could configure them to also post to #2ndline as well, if people think that would be useful?

cc @deanwilson, who figured out the problem with the original config.