### PR TITLE
Fix typo in Grafana dashboard

### DIFF
--- a/modules/grafana/templates/dashboards/deployment_panels/_sidekiq_queue_length.json.erb
+++ b/modules/grafana/templates/dashboards/deployment_panels/_sidekiq_queue_length.json.erb
@@ -28,7 +28,7 @@
   "renderer": "flot",
   "seriesOverrides": [
     {
-      "alias": "Prococessed/Sec",
+      "alias": "Processed/Sec",
       "color": "#DEDAF7",
       "yaxis": 2
     },
@@ -50,7 +50,7 @@
     },
     {
       "refId": "C",
-      "target": "alias(perSecond(stats.gauges.govuk.app.<%= @app_name %>.workers.processed), 'Prococessed/Sec')",
+      "target": "alias(perSecond(stats.gauges.govuk.app.<%= @app_name %>.workers.processed), 'Processed/Sec')",
       "textEditor": false
     }
   ],


### PR DESCRIPTION
Fix typo in Sidekiq panel used by the rummager deployment dashboard.