### PR TITLE
Revert "Use an internal domain for frontends"

### DIFF
--- a/hieradata_aws/class/cache.yaml
+++ b/hieradata_aws/class/cache.yaml
@@ -9,5 +9,3 @@ govuk::apps::router::mongodb_nodes:
   - 'router-backend-1'
   - 'router-backend-2'
   - 'router-backend-3'
-
-govuk::deploy::config::app_domain: "%{hiera('app_domain_internal')}"

--- a/hieradata_aws/class/calculators_frontend.yaml
+++ b/hieradata_aws/class/calculators_frontend.yaml
@@ -1,2 +1,0 @@
----
-govuk::deploy::config::app_domain: "%{hiera('app_domain_internal')}"

--- a/hieradata_aws/class/frontend.yaml
+++ b/hieradata_aws/class/frontend.yaml
@@ -2,5 +2,3 @@
 govuk::apps::contacts::db_hostname: 'mysql-replica'
 govuk::apps::contacts::db_username: 'contacts_fe'
 govuk::apps::contacts::db_password: "%{hiera('govuk::apps::contacts::db::mysql_contacts_frontend')}"
-
-govuk::deploy::config::app_domain: "%{hiera('app_domain_internal')}"

--- a/hieradata_aws/class/whitehall_frontend.yaml
+++ b/hieradata_aws/class/whitehall_frontend.yaml
@@ -7,5 +7,3 @@ govuk::apps::whitehall::vhost_protected: false
 
 govuk_safe_to_reboot::can_reboot: 'overnight'
 govuk_safe_to_reboot::reason: 'Whitehall application is slow to start, recommend rebooting a single node at a time'
-
-govuk::deploy::config::app_domain: "%{hiera('app_domain_internal')}"


### PR DESCRIPTION
This reverts commit 5cfb53453c9ba8117c61cbb2f39200a86387d91a.

We do not believe this is required to set any longer for these instances.