### PR TITLE
[AWS] Update app_domain and app_domain_internal

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -1,6 +1,6 @@
 ---
-app_domain: "%{::aws_stackname}.integration.govuk.digital"
-app_domain_internal: "%{::aws_stackname}.integration.govuk-internal.digital"
+app_domain: "integration.publishing.service.gov.uk"
+app_domain_internal: "integration.govuk-internal.digital"
 
 base::shell::shell_prompt_string: 'integration'
 base::supported_kernel::enabled: true


### PR DESCRIPTION
This is a change we are making pre-migration to test the functionality
of the site.

We update the main app_domain to ensure users are presented with the
correct domain when browsing the site.

We update the internal domain to the top level domain, which then
CNAMEs/attaches to a stack level set of instances.

WARNING: Everything may break (in AWS)