### PR TITLE
Change sidekiq stats in Email Alert API dashboard

### DIFF
--- a/modules/grafana/files/dashboards/email_alert_api.json
+++ b/modules/grafana/files/dashboards/email_alert_api.json
@@ -791,23 +791,20 @@
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
-          "span": 3,
+          "span": 6,
           "stack": false,
           "steppedLine": false,
           "targets": [
             {
               "refId": "A",
-              "target": "alias(stats.gauges.govuk.app.email-alert-api.workers.queues.*.enqueued, 'enqueued')"
-            },
-            {
-              "refId": "B",
-              "target": "alias(stats.gauges.govuk.app.email-alert-api.workers.queues.*.latency, 'latency')"
+              "target": "aliasSub(aliasByNode(keepLastValue(consolidateBy(stats.gauges.govuk.app.email-alert-api.backend-1.workers.queues.*.enqueued, \"sum\")), 8),  \"(.*)\", \"\\1 enqueued\")",
+              "textEditor": true
             }
           ],
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Sidekiq Queue",
+          "title": "Sidekiq Enqueued",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -847,6 +844,91 @@
           "dashes": false,
           "datasource": "Graphite",
           "fill": 1,
+          "id": 16,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "refId": "A",
+              "target": "aliasSub(aliasByNode(keepLastValue(consolidateBy(stats.gauges.govuk.app.email-alert-api.backend-1.workers.queues.*.latency, \"sum\")), 8),  \"(.*)\", \"\\1 latency\")",
+              "textEditor": true
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Sidekiq Latency",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "ms",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 296,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Graphite",
+          "fill": 1,
           "id": 13,
           "legend": {
             "avg": false,
@@ -867,7 +949,7 @@
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
-          "span": 3,
+          "span": 4,
           "stack": false,
           "steppedLine": false,
           "targets": [
@@ -939,7 +1021,7 @@
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
-          "span": 3,
+          "span": 4,
           "stack": false,
           "steppedLine": false,
           "targets": [
@@ -1011,7 +1093,7 @@
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
-          "span": 3,
+          "span": 4,
           "stack": false,
           "steppedLine": false,
           "targets": [
@@ -1102,5 +1184,5 @@
   },
   "timezone": "",
   "title": "Email Alert API Metrics",
-  "version": 1
+  "version": 4
 }


### PR DESCRIPTION
These weren't coming through since they're now tied to a hostname.
They've now also been separated by queue.

As these are the same on each host name they are tied to backend-1.

Produces this graph: 
![screen shot 2017-12-12 at 15 39 26](https://user-images.githubusercontent.com/282717/33893193-bf00927e-df52-11e7-9da1-7754caf12937.png)

Which can be accessed here: https://grafana.integration.publishing.service.gov.uk/dashboard/db/email-alert-api-metrics-test?orgId=1