### PR TITLE
Revert "Configure staging email-alert-api to use PSEUDO"

### DIFF
--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -23,7 +23,6 @@ govuk::apps::email_alert_api::govdelivery_hostname: 'stage-api.govdelivery.com'
 govuk::apps::email_alert_api::govdelivery_public_hostname: 'stage-public.govdelivery.com'
 govuk::apps::email_alert_api::govuk_notify_base_url: 'https://api.staging-notify.works'
 govuk::apps::email_alert_api::govuk_notify_template_id: '76d21ce7-54c3-4fb7-8830-ba3b79287985'
-govuk::apps::email_alert_api::email_service_provider: 'PSEUDO'
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::publicapi::backdrop_host: 'www.staging.performance.service.gov.uk'
 govuk::apps::publisher::run_fact_check_fetcher: false


### PR DESCRIPTION
This reverts commit f18ca29a6fc630992b314eb7dab711c26773c6f5.

We've finished doing load testing of our system so we need to start sending requests through notify again.