### PR TITLE
Enable email-alert-api public proxy

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -355,7 +355,6 @@ govuk::apps::content_tagger::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::content_tagger::redis_port: "%{hiera('sidekiq_port')}"
 
 govuk::apps::email_alert_api::enabled: true
-govuk::apps::email_alert_api::enable_public_proxy: false
 govuk::apps::email_alert_api::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 govuk::apps::email_alert_api::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::email_alert_api::redis_port: "%{hiera('sidekiq_port')}"

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -100,7 +100,6 @@ govuk::apps::content_store::mongodb_nodes: ['localhost']
 govuk::apps::content_store::mongodb_name: 'content_store_development'
 govuk::apps::content_tagger::enable_procfile_worker: false
 govuk::apps::email_alert_api::enable_procfile_worker: false
-govuk::apps::email_alert_api::enable_public_proxy: true
 govuk::apps::email_alert_service::rabbitmq_hosts: ['localhost']
 govuk::apps::event_store::enabled: true
 govuk::apps::event_store::mongodb_servers: ['localhost']

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -33,7 +33,6 @@ govuk::apps::content_performance_manager::feature_auditing_theme_filtering: true
 govuk::apps::content_store::performance_platform_big_screen_view_url: 'https://performance-platform-big-screen-view-staging.cloudapps.digital'
 govuk::apps::content_store::performance_platform_spotlight_url: 'https://performance-platform-spotlight-staging.cloudapps.digital'
 govuk::apps::email_alert_api::allow_govdelivery_topic_syncing: true
-govuk::apps::email_alert_api::enable_public_proxy: true
 govuk::apps::email_alert_api::govdelivery_account_code: 'UKGOVUKDUP'
 govuk::apps::email_alert_api::govdelivery_hostname: 'stage-api.govdelivery.com'
 govuk::apps::email_alert_api::govdelivery_public_hostname: 'stage-public.govdelivery.com'

--- a/modules/govuk/manifests/apps/email_alert_api.pp
+++ b/modules/govuk/manifests/apps/email_alert_api.pp
@@ -15,7 +15,7 @@
 # [*enable_public_proxy*]
 #   Whether to create a public proxy into this application for handling
 #   select public endpoints
-#   Default: false
+#   Default: true
 #
 # [*enable_procfile_worker*]
 #   Should the Foreman-based background worker be enabled by default. Set in
@@ -92,7 +92,7 @@
 class govuk::apps::email_alert_api(
   $port = '3088',
   $enabled = false,
-  $enable_public_proxy = false,
+  $enable_public_proxy = true,
   $enable_procfile_worker = true,
   $sidekiq_retry_critical = '20',
   $sidekiq_retry_warning = '10',


### PR DESCRIPTION
Notify have enabled callbacks on their end and we've enabled authentication on the endpoint so no reason to keep it disabled.