### PR TITLE
Update default resolvers

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1584,8 +1584,10 @@ redis::conf_tcp_keepalive: false
 redis::conf_timeout: 300
 
 resolvconf::nameservers:
-  - 8.8.8.8
-  - 8.8.4.4
+  - 195.225.219.96 # Carrenza London
+  - 195.225.219.97 # Carrenza London
+  - 31.210.244.104 # Carrenza Amsterdam
+  - 31.210.244.105 # Carrenza Amsterdam
 
 resolvconf::options:
    - 'single-request-reopen'


### PR DESCRIPTION
We defaulted to using Google resolvers, but recently they have implemented some rate-limiting which was noted when we ran the "Validate Published DNS" job.

Carrenza provide resolvers, so use these instead to ensure we do not suffer from timeouts when making lookups.

In AWS, we use the VPC for resolving and so this is not included.

https://trello.com/c/rVAkKEkP/861-fix-validatepublisheddns-job