### PR TITLE
[AWS] Override Plek for Publishing API so it uses the internal domain

### DIFF
--- a/modules/govuk/manifests/deploy/config.pp
+++ b/modules/govuk/manifests/deploy/config.pp
@@ -107,11 +107,12 @@ class govuk::deploy::config(
     # make sure they're separated out in those locations otherwise puppet
     # won't run cleanly.
     govuk_envvar {
-      'PLEK_SERVICE_MAPIT_URI': value     => "https://mapit.${app_domain_internal}";
-      'PLEK_SERVICE_RUMMAGER_URI': value  => "https://rummager.${app_domain_internal}";
-      'PLEK_SERVICE_SEARCH_URI': value    => "https://search.${app_domain_internal}";
-      'PLEK_SERVICE_STATIC_URI': value    => "https://static.${app_domain_internal}";
-      'PLEK_SERVICE_LICENSIFY_URI': value => "https://licensify.${licensify_app_domain}";
+      'PLEK_SERVICE_MAPIT_URI': value           => "https://mapit.${app_domain_internal}";
+      'PLEK_SERVICE_RUMMAGER_URI': value        => "https://rummager.${app_domain_internal}";
+      'PLEK_SERVICE_SEARCH_URI': value          => "https://search.${app_domain_internal}";
+      'PLEK_SERVICE_STATIC_URI': value          => "https://static.${app_domain_internal}";
+      'PLEK_SERVICE_LICENSIFY_URI': value       => "https://licensify.${licensify_app_domain}";
+      'PLEK_SERVICE_PUBLISHING_API_URI': value  => "https://publishing-api.${app_domain_internal}";
     }
   }
 }


### PR DESCRIPTION
- The Data_Sync_Complete job needs to run
  `publishing_api:publish_finders` for specialist-publisher, but can't
  because Plek is using the external domain for Publishing API, which we
  can't reach from backend boxes.