### PR TITLE
Create deployment dashboard for policy-publisher

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -977,6 +977,7 @@ grafana::dashboards::deployment_applications:
     # Very low usage
     show_controller_errors: false
     show_slow_requests: false
+  policy-publisher: {}
   publisher:
     # logstasher >1.x
     fields_prefix: ''

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -970,6 +970,7 @@ grafana::dashboards::deployment_applications:
     # Very low usage
     show_controller_errors: false
     show_slow_requests: false
+  policy-publisher: {}
   publisher:
     has_workers: true
   publishing-api:


### PR DESCRIPTION
policy-publisher is a regular Rails app, so the default graphs should work without any extra configuration.