### PR TITLE
Ignore veth and br interfaces in Collectd

### DIFF
--- a/modules/collectd/files/etc/collectd/conf.d/default.conf
+++ b/modules/collectd/files/etc/collectd/conf.d/default.conf
@@ -9,6 +9,13 @@ LoadPlugin df
 LoadPlugin disk
 LoadPlugin entropy
 LoadPlugin interface
+
+<Plugin interface>
+  Interface "/^veth/"
+  Interface "/^br/"
+  IgnoreSelected true
+</Plugin>
+
 LoadPlugin load
 LoadPlugin memory
 LoadPlugin swap


### PR DESCRIPTION
Docker creates lots of virtual networks with bridges, which quickly fill
up lots of disk space for graphite. Since these are short lived these
stats are also effectively useless.

In ignoring these I'm somewhat concerned that there could be a network
bridge we do monitor that this regex will accidentally catch.