### PR TITLE
Set resolvers for UKCloud servers to Google

### DIFF
--- a/hieradata/class/production/licensify_lb.yaml
+++ b/hieradata/class/production/licensify_lb.yaml
@@ -1,0 +1,3 @@
+resolvconf::nameservers:
+  - 8.8.8.8
+  - 8.8.4.4

--- a/hieradata/class/production/licensing_backend.yaml
+++ b/hieradata/class/production/licensing_backend.yaml
@@ -1,0 +1,3 @@
+resolvconf::nameservers:
+  - 8.8.8.8
+  - 8.8.4.4

--- a/hieradata/class/production/licensing_frontend.yaml
+++ b/hieradata/class/production/licensing_frontend.yaml
@@ -1,0 +1,3 @@
+resolvconf::nameservers:
+  - 8.8.8.8
+  - 8.8.4.4

--- a/hieradata/class/production/licensing_mongo.yaml
+++ b/hieradata/class/production/licensing_mongo.yaml
@@ -1,0 +1,3 @@
+resolvconf::nameservers:
+  - 8.8.8.8
+  - 8.8.4.4

--- a/hieradata/class/staging/licensify_lb.yaml
+++ b/hieradata/class/staging/licensify_lb.yaml
@@ -1,0 +1,3 @@
+resolvconf::nameservers:
+  - 8.8.8.8
+  - 8.8.4.4

--- a/hieradata/class/staging/licensing_backend.yaml
+++ b/hieradata/class/staging/licensing_backend.yaml
@@ -1,0 +1,3 @@
+resolvconf::nameservers:
+  - 8.8.8.8
+  - 8.8.4.4

--- a/hieradata/class/staging/licensing_frontend.yaml
+++ b/hieradata/class/staging/licensing_frontend.yaml
@@ -1,0 +1,3 @@
+resolvconf::nameservers:
+  - 8.8.8.8
+  - 8.8.4.4

--- a/hieradata/class/staging/licensing_mongo.yaml
+++ b/hieradata/class/staging/licensing_mongo.yaml
@@ -1,0 +1,3 @@
+resolvconf::nameservers:
+  - 8.8.8.8
+  - 8.8.4.4


### PR DESCRIPTION
I updated the resolvers in 15f15ccf7d8002bd61e58667d8077d143f51b301 to the Carrenza resolvers.

Carrenza only allow Carrenza IPs to access their resolvers, and Licensing is a special snowflake that lives in UKCloud.

Set the resolvers back to the Google ones for UKCloud in Staging and Production. Integration is not affected as that is in Carrenza.