### PR TITLE
Remove redundant Asset Manager environment variables

### DIFF
--- a/modules/govuk/manifests/apps/asset_manager.pp
+++ b/modules/govuk/manifests/apps/asset_manager.pp
@@ -262,6 +262,7 @@ class govuk::apps::asset_manager(
     # that should be served by proxying the request to S3 via nginx
     govuk::app::envvar {
       "${title}-PROXY_PERCENTAGE_OF_ASSET_REQUESTS_TO_S3_VIA_NGINX":
+        ensure  => 'absent',
         varname => 'PROXY_PERCENTAGE_OF_ASSET_REQUESTS_TO_S3_VIA_NGINX',
         value   => $proxy_percentage_of_asset_requests_to_s3_via_nginx;
     }
@@ -271,6 +272,7 @@ class govuk::apps::asset_manager(
     # nginx
     govuk::app::envvar {
       "${title}-PROXY_PERCENTAGE_OF_WHITEHALL_ASSET_REQUESTS_TO_S3_VIA_NGINX":
+        ensure  => 'absent',
         varname => 'PROXY_PERCENTAGE_OF_WHITEHALL_ASSET_REQUESTS_TO_S3_VIA_NGINX',
         value   => $proxy_percentage_of_whitehall_asset_requests_to_s3_via_nginx;
     }


### PR DESCRIPTION
These variables were made redundant by alphagov/asset-manager#328 in which proxying asset requests to S3 via Nginx becomes the default for both Mainstream & Whitehall assets.

We will need to follow this change up with another PR to actually remove the `govuk::app::envvar` statements altogether.

This can safely be merged & applied once alphagov/asset-manager#328 has been deployed to production.