### PR TITLE
Increase maximum number of postgres connections

### DIFF
--- a/hieradata/class/production/postgresql_primary.yaml
+++ b/hieradata/class/production/postgresql_primary.yaml
@@ -12,4 +12,4 @@ lv:
     pv: '/dev/sdd1'
     vg: 'postgresql'
 
-govuk_postgresql::server::max_connections: 200
+govuk_postgresql::server::max_connections: 300

--- a/hieradata/class/production/postgresql_standby.yaml
+++ b/hieradata/class/production/postgresql_standby.yaml
@@ -1,1 +1,1 @@
-govuk_postgresql::server::max_connections: 200
+govuk_postgresql::server::max_connections: 300

--- a/hieradata/class/staging/postgresql_primary.yaml
+++ b/hieradata/class/staging/postgresql_primary.yaml
@@ -1,1 +1,1 @@
-govuk_postgresql::server::max_connections: 150
+govuk_postgresql::server::max_connections: 200

--- a/hieradata/class/staging/postgresql_standby.yaml
+++ b/hieradata/class/staging/postgresql_standby.yaml
@@ -1,1 +1,1 @@
-govuk_postgresql::server::max_connections: 150
+govuk_postgresql::server::max_connections: 200

--- a/modules/govuk_postgresql/manifests/server.pp
+++ b/modules/govuk_postgresql/manifests/server.pp
@@ -23,13 +23,13 @@
 #   3 for superuser connections, but if it runs out it can have an impact on
 #   applications waiting for connections. Ideally applications should close
 #   their connections to the database, but this doesn't always happen.
-#   Default: 100
+#   Default: 150
 class govuk_postgresql::server (
     $snakeoil_ssl_certificate,
     $snakeoil_ssl_key,
     $listen_addresses = '*',
     $configure_env_sync_user = false,
-    $max_connections = 100,
+    $max_connections = 150,
 ) {
   if !(
     defined(Class["${name}::standalone"]) or


### PR DESCRIPTION
We're looking at increasing the number of workers in one of our apps from 30 to 90 in staging and production. This will add another 60 connections to each environment, of which they both have about 30 spare connections available. Looking at the postgres machines they both have lots of spare memory capacity available to cope with this level of increase.

Note that this cause postgres to restart so this will be deployed out of hours.

[Trello Card](https://trello.com/c/JtjiwNpP/451-run-full-end-to-end-load-test)