### PR TITLE
Remove redundant Asset Manager environment variable definitions

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -519,8 +519,6 @@ govuk::apps::service_manual_publisher::db::backend_ip_range: "%{hiera('environme
 
 govuk::apps::sidekiq_monitoring::asset_manager_redis_host: "%{hiera('govuk::apps::asset_manager::redis_host')}"
 govuk::apps::sidekiq_monitoring::asset_manager_redis_port: "%{hiera('govuk::apps::asset_manager::redis_port')}"
-govuk::apps::asset_manager::proxy_percentage_of_asset_requests_to_s3_via_nginx: '100'
-govuk::apps::asset_manager::proxy_percentage_of_whitehall_asset_requests_to_s3_via_nginx: '100'
 govuk::apps::sidekiq_monitoring::content_performance_manager_redis_host: "%{hiera('govuk::apps::content_performance_manager::redis_host')}"
 govuk::apps::sidekiq_monitoring::content_performance_manager_redis_port: "%{hiera('govuk::apps::content_performance_manager::redis_port')}"
 govuk::apps::sidekiq_monitoring::content_tagger_redis_host: "%{hiera('govuk::apps::content_tagger::redis_host')}"

--- a/modules/govuk/manifests/apps/asset_manager.pp
+++ b/modules/govuk/manifests/apps/asset_manager.pp
@@ -33,12 +33,6 @@
 #   AWS access key for a user with permission to write to the S3 bucket
 # [*aws_secret_access_key*]
 #   AWS secret key for a user with permission to write to the S3 bucket
-# [*proxy_percentage_of_asset_requests_to_s3_via_nginx*]
-#   Value between 0 and 100 controlling the percentage of traffic that should
-#   be served by proxying the asset from S3
-# [*proxy_percentage_of_whitehall_asset_requests_to_s3_via_nginx*]
-#   Value between 0 and 100 controlling the percentage of traffic that should
-#   be served by proxying the Whitehall asset from S3
 # [*redis_host*]
 #   Redis host for Sidekiq.
 #   Default: undef
@@ -60,8 +54,6 @@ class govuk::apps::asset_manager(
   $aws_region = undef,
   $aws_access_key_id = undef,
   $aws_secret_access_key = undef,
-  $proxy_percentage_of_asset_requests_to_s3_via_nginx = '0',
-  $proxy_percentage_of_whitehall_asset_requests_to_s3_via_nginx = '0',
   $redis_host = undef,
   $redis_port = undef
 ) {
@@ -256,25 +248,6 @@ class govuk::apps::asset_manager(
       "${title}-AWS_SECRET_KEY":
         varname => 'AWS_SECRET_KEY',
         value   => $aws_secret_access_key;
-    }
-
-    # Write the environment variable to configure the percentage of requests
-    # that should be served by proxying the request to S3 via nginx
-    govuk::app::envvar {
-      "${title}-PROXY_PERCENTAGE_OF_ASSET_REQUESTS_TO_S3_VIA_NGINX":
-        ensure  => 'absent',
-        varname => 'PROXY_PERCENTAGE_OF_ASSET_REQUESTS_TO_S3_VIA_NGINX',
-        value   => $proxy_percentage_of_asset_requests_to_s3_via_nginx;
-    }
-
-    # Write the environment variable to configure the percentage of Whitehall
-    # asset requests that should be served by proxying the request to S3 via
-    # nginx
-    govuk::app::envvar {
-      "${title}-PROXY_PERCENTAGE_OF_WHITEHALL_ASSET_REQUESTS_TO_S3_VIA_NGINX":
-        ensure  => 'absent',
-        varname => 'PROXY_PERCENTAGE_OF_WHITEHALL_ASSET_REQUESTS_TO_S3_VIA_NGINX',
-        value   => $proxy_percentage_of_whitehall_asset_requests_to_s3_via_nginx;
     }
   }
 }


### PR DESCRIPTION
These variables were made redundant by alphagov/asset-manager#328 in which proxying asset requests to S3 via Nginx became the default for both Mainstream & Whitehall assets.

This is a follow-up to #6952 which actually removed these variables from `/etc/govuk/asset-manager/env.d/`.

This PR can safely be merged & applied once #6952 has been merged & applied.

Note that this PR currently contains the commit from #6952, so ideally it will need to be rebased against master and force-pushed once that PR has been merged.
