### PR TITLE
AWS use content-store internal domain

### DIFF
--- a/modules/govuk/manifests/deploy/config.pp
+++ b/modules/govuk/manifests/deploy/config.pp
@@ -113,6 +113,7 @@ class govuk::deploy::config(
       'PLEK_SERVICE_STATIC_URI': value          => "https://static.${app_domain_internal}";
       'PLEK_SERVICE_LICENSIFY_URI': value       => "https://licensify.${licensify_app_domain}";
       'PLEK_SERVICE_PUBLISHING_API_URI': value  => "https://publishing-api.${app_domain_internal}";
+      'PLEK_SERVICE_CONTENT_STORE_URI': value   => "https://content-store.${app_domain_internal}";
     }
   }
 }

--- a/modules/govuk/manifests/node/s_draft_frontend.pp
+++ b/modules/govuk/manifests/node/s_draft_frontend.pp
@@ -25,12 +25,4 @@ class govuk::node::s_draft_frontend() inherits govuk::node::s_base {
       'PLEK_SERVICE_LICENSIFY_URI': value => "https://licensify.${app_domain}";
     }
   }
-
-  if $::aws_migration {
-    $app_domain_internal = hiera('app_domain_internal')
-
-    govuk_envvar {
-      'PLEK_SERVICE_CONTENT_STORE_URI': value => "https://content-store.${app_domain_internal}";
-    }
-  }
 }


### PR DESCRIPTION
Override the content-store domain to use internal only.