### PR TITLE
AWS add email-alert-api-public and email-alert-api override

### DIFF
--- a/modules/govuk/manifests/apps/email_alert_api.pp
+++ b/modules/govuk/manifests/apps/email_alert_api.pp
@@ -253,7 +253,13 @@ class govuk::apps::email_alert_api(
         ',
       }
 
-      nginx::config::vhost::proxy { "email-alert-api-public.${app_domain}":
+      if $::aws_migration {
+        $vhost_ = 'email-alert-api-public'
+      } else {
+        $vhost_ = "email-alert-api-public.${app_domain}"
+      }
+
+      nginx::config::vhost::proxy { $vhost_:
         to               => ["localhost:${port}"],
         ssl_only         => true,
         protected        => false,

--- a/modules/govuk/manifests/deploy/config.pp
+++ b/modules/govuk/manifests/deploy/config.pp
@@ -114,6 +114,7 @@ class govuk::deploy::config(
       'PLEK_SERVICE_LICENSIFY_URI': value       => "https://licensify.${licensify_app_domain}";
       'PLEK_SERVICE_PUBLISHING_API_URI': value  => "https://publishing-api.${app_domain_internal}";
       'PLEK_SERVICE_CONTENT_STORE_URI': value   => "https://content-store.${app_domain_internal}";
+      'PLEK_SERVICE_EMAIL_ALERT_API_URI': value => "https://email-alert-api.${app_domain_internal}";
     }
   }
 }


### PR DESCRIPTION
On AWS, remove domain information in email-alert-api-public vhost.

Add a Plek override to use email-alert-api internally.