### PR TITLE
Add publishing-api to search-admin's bowl dependencies

### DIFF
--- a/development-vm/Pinfile
+++ b/development-vm/Pinfile
@@ -59,7 +59,7 @@ process :'rummager-publishing-listener'
 process :'rummager-govuk-index-listener'
 process :'rummager-bulk-reindex-listener'
 process :screenshot_as_a_service
-process :'search-admin' => [:rummager]
+process :'search-admin' => [:rummager, :'publishing-api']
 process :'service-manual-frontend' => [:'content-store', :static]
 process :'service-manual-publisher' => [:'publishing-api', :rummager]
 process :'short-url-manager' => [:'publishing-api']


### PR DESCRIPTION
Search admin will soon publish external content to the publishing API rather than rummager, so bowl should start the publishing-api in dev when running search-admin.

https://trello.com/c/rDurYmt8/525-send-external-links-from-search-admin-to-the-publishing-api