### PR TITLE
Adjust the support queue size check for a change to statsd

### DIFF
--- a/modules/monitoring/manifests/checks/sidekiq.pp
+++ b/modules/monitoring/manifests/checks/sidekiq.pp
@@ -47,7 +47,11 @@ class monitoring::checks::sidekiq (
 
   if $enable_support_check {
     icinga::check::graphite { 'check_support_default_queue_size':
-      target    => 'stats.gauges.govuk.app.support.workers.queues.default.enqueued',
+      target    => 'keepLastValue(stats.gauges.govuk.app.support.workers.queues.default.enqueued)',
+      from      => '24hours',
+      # Take an average over the most recent 36 datapoints, which at 5
+      # seconds per datapoint is the last 3 minutes
+      args      => '--dropfirst -36',
       warning   => 10,
       critical  => 20,
       desc      => 'support app background processing: unexpectedly large default queue size',


### PR DESCRIPTION
Increase the from argument to 24 hours to account for missing data (as
the Sidekiq statsd middleware only reports metrics when there is
activity), and use dropfirst to focus on the most recent ~3 minutes
worth of data.

This change is a result of changing the statsd configuration to delete
gauges. As statsd isn't sending old values anymore, this check needed
adjusting to not fail on missing data.