### PR TITLE
Add spoof_target_domain to Smokey

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -102,6 +102,10 @@ govuk_ppa::path: 'preview'
 
 grafana::dashboards::machine_suffix_metrics: '_integration'
 
+# FIXME: this should be removed after the migration
+icinga::config::smokey::spoof_target_domain: 'cache.integration.govuk.digital'
+govuk_jenkins::job::smokey::spoof_target_domain: "%{hiera('icinga::config::smokey::spoof_target_domain')}"
+
 mongodb::s3backup::backup::s3_bucket: 'govuk-mongodb-backup-s3-integration'
 mongodb::s3backup::backup::s3_bucket_daily: 'govuk-mongodb-backup-s3-daily-integration'
 mongodb::backup::mongo_backup_node: 'localhost'

--- a/modules/govuk_jenkins/manifests/job/smokey.pp
+++ b/modules/govuk_jenkins/manifests/job/smokey.pp
@@ -22,6 +22,10 @@
 # [*smokey_rate_limit_token*]
 #   Token to pass as an HTTP header to bypass rate limiting
 #
+# [*spoof_target_domain*]
+#   If you wish to run tests against an environment that is different to the
+#   main app_domain parameter.
+#
 # [*smokey_task*]
 #   The rake task to run for the tests
 #
@@ -33,7 +37,8 @@ class govuk_jenkins::job::smokey (
   $smokey_bearer_token = undef,
   $smokey_rate_limit_token = undef,
   $smokey_task = 'test:production',
-  $app_domain = hiera('app_domain')
+  $spoof_target_domain = undef,
+  $app_domain = hiera('app_domain'),
 ) {
   $slack_team_domain = 'govuk'
   $slack_room = '2ndline'

--- a/modules/govuk_jenkins/manifests/job_builder_update.pp
+++ b/modules/govuk_jenkins/manifests/job_builder_update.pp
@@ -16,7 +16,7 @@ class govuk_jenkins::job_builder_update (
   include govuk_jenkins::job_builder
 
   exec { 'jenkins_jobs_update':
-    command => '/usr/bin/jenkins-jobs update --delete-old /etc/jenkins_jobs/jobs/',
+    command => '/usr/local/bin/jenkins-jobs update --delete-old /etc/jenkins_jobs/jobs/',
     onlyif  => "/usr/bin/curl ${jenkins_url}",
     require => Class['govuk_jenkins::job_builder'],
   }

--- a/modules/govuk_jenkins/templates/jobs/smokey.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/smokey.yaml.erb
@@ -63,6 +63,9 @@
     builders:
         - shell: |
             set +x
+            <%- if @spoof_target_domain -%>
+            export SPOOF_TARGET_DOMAIN='<%= @spoof_target_domain %>'
+            <%- end -%>
             export TARGET_PLATFORM=<%= @environment %>
             export AUTH_USERNAME='<%= @auth_username %>'
             export AUTH_PASSWORD='<%= @auth_password %>'

--- a/modules/icinga/manifests/config/smokey.pp
+++ b/modules/icinga/manifests/config/smokey.pp
@@ -22,6 +22,10 @@
 # [*smokey_bearer_token*]
 #   Bearer token for something
 #
+# [*spoof_target_domain*]
+#   If you wish to run tests against an environment that is different to the
+#   main app_domain parameter.
+#
 class icinga::config::smokey (
   $http_username = 'UNSET',
   $http_password = 'UNSET',
@@ -29,6 +33,7 @@ class icinga::config::smokey (
   $smokey_signon_email = 'UNSET',
   $smokey_signon_password = 'UNSET',
   $smokey_bearer_token = 'UNSET',
+  $spoof_target_domain = undef,
 ) {
   $smokey_vars = {
     'AUTH_USERNAME'    => $http_username,

--- a/modules/icinga/templates/etc/smokey.sh.erb
+++ b/modules/icinga/templates/etc/smokey.sh.erb
@@ -7,3 +7,6 @@
 -%>
 export <%= key -%>="<%= val -%>"
 <% end -%>
+<% if @spoof_target_domain -%>
+export SPOOF_TARGET_DOMAIN=<%= @spoof_target_domain %>
+<% end -%>


### PR DESCRIPTION
This sets the SPOOF_TARGET_DOMAIN environment variable in Smokey for our Integration environment in AWS (ref: https://github.com/alphagov/smokey/commit/410e558170f791b4a7a6af8fcfd08ef63a5401b5).

We need to set this because we want to test against the top level publishing domain before we perform the full DNS migration.

After the migration has been completed, this can be removed, but is useful to keep for future migrations.

https://trello.com/c/C2Zk644r/875-run-smokey-tests-against-service-domain