### PR TITLE
[AWS] assets-origin vhost update

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1160,7 +1160,7 @@ router::assets_origin::vhost_aliases:
   - 'assets.digital.cabinet-office.gov.uk'
   - 'assets.publishing.service.gov.uk'
 
-router::assets_origin::vhost_name: "assets-origin.%{hiera('app_domain')}"
+router::assets_origin::vhost_name: "assets-origin"
 
 router::nginx::check_requests_warning: '@10'
 router::nginx::check_requests_critical: '@8'


### PR DESCRIPTION
Update assets-origin to use the vhosts as we have defined everywhere else in AWS, so not using the fully-qualified domain name.