### PR TITLE
Add postgres client to jenkins boxes

### DIFF
--- a/modules/govuk/manifests/node/s_jenkins.pp
+++ b/modules/govuk/manifests/node/s_jenkins.pp
@@ -23,6 +23,7 @@ class govuk::node::s_jenkins (
   $environment_variables = {},
 ) inherits govuk::node::s_base {
   include nginx
+  include govuk_postgresql::client
   include govuk_rbenv::all
   include ::phantomjs
 


### PR DESCRIPTION
We're running a jenkins job that checks out an app and runs a script from it.

[It fails because it doesn't have the postgres libraries installed](https://deploy.integration.publishing.service.gov.uk/job/search_benchmark/211/console). This is a side effect of [moving the healthcheck to another repo](https://github.com/alphagov/govuk-puppet/pull/6965). We used to checkout rummager on the jenkins host, and now we check out search-performance-explorer.

Technically the app doesn't need to be using a database right now at all, but we want it to use one in the future, so adding the pg library is a simpler workaround than changing the rails configuration.

Normally, when jenkins runs a script thats packaged up with an app, the jenkins job ssh's into the box that runs it the app and runs the script from there. In this case the app runs on heroku so it's not as straightforward to run it remotely.

The alternative is to just remove the search benchmark jobs altogether.