### PR TITLE
Remove Asset Manager Nginx config related to serving files from NFS

### DIFF
--- a/modules/govuk/manifests/apps/asset_manager.pp
+++ b/modules/govuk/manifests/apps/asset_manager.pp
@@ -86,8 +86,9 @@ class govuk::apps::asset_manager(
 
       # Instruct Nginx to set "Sendfile" headers for both Mainstream and
       # Whitehall public asset URLs. The Rails app will respond with the
-      # X-Accel-Redirect header set to a path prefixed with /raw/ which will
-      # be handled by the internal `/raw/(.*)` location block below.
+      # X-Accel-Redirect header set to a path prefixed with /raw/ or
+      # /cloud-storage-proxy/ which will be handled by the relevant internal
+      # location block below.
       location ~ ^/(media|government/uploads)/(.*) {
          proxy_set_header X-Sendfile-Type X-Accel-Redirect;
          proxy_set_header X-Accel-Mapping /var/apps/asset-manager/uploads/assets/=/raw/;

--- a/modules/govuk/manifests/apps/asset_manager.pp
+++ b/modules/govuk/manifests/apps/asset_manager.pp
@@ -104,11 +104,11 @@ class govuk::apps::asset_manager(
         # $args:    Optional querystring params
         set $download_url $1$is_args$args;
 
-        # The X-CLOUD-STORAGE-URL header contains a signed URL for the asset on
-        # S3. The signature of this URL is based in part on the request headers
-        # set in the asset-manager Rails app at the time the URL is generated.
-        # The headers we send now must match otherwise Nginx will not be
-        # allowed to make the request. Since this location block inherits
+        # The X-Accel-Redirect header contains a signed URL, $download_url, for
+        # the asset on S3. The signature of this URL is based in part on the
+        # request headers set in the asset-manager Rails app at the time the URL
+        # is generated. The headers we send now must match otherwise Nginx will
+        # not be allowed to make the request. Since this location block inherits
         # `proxy_set_header` directives from previous levels[1], we explicitly
         # set the Host so that the inherited headers are over-written.
         #

--- a/modules/govuk/manifests/apps/asset_manager.pp
+++ b/modules/govuk/manifests/apps/asset_manager.pp
@@ -100,8 +100,8 @@ class govuk::apps::asset_manager(
          <%- end %>
        }
 
-      # /raw/(.*) is the path mapping sent from the rails application to
-      # nginx and is immediately picked up. /raw/(.*) is not available
+      # /raw/(.*) is the path mapping sent from the Rails application to
+      # Nginx and is immediately picked up. /raw/(.*) is not available
       # publicly as it is an internal path mapping.
       location ~ /raw/(.*) {
         internal;
@@ -122,7 +122,7 @@ class govuk::apps::asset_manager(
       set $x_frame_options_from_rails $upstream_http_x_frame_options;
 
       location ~ /cloud-storage-proxy/(.*) {
-        # Prevent requests to this location from outside nginx
+        # Prevent requests to this location from outside Nginx
         internal;
 
         # Construct download URL from:
@@ -136,7 +136,7 @@ class govuk::apps::asset_manager(
         # The X-CLOUD-STORAGE-URL header contains a signed URL for the asset on
         # S3. The signature of this URL is based in part on the request headers
         # set in the asset-manager Rails app at the time the URL is generated.
-        # The headers we send now must match otherwise nginx will not be
+        # The headers we send now must match otherwise Nginx will not be
         # allowed to make the request. Since this location block inherits
         # `proxy_set_header` directives from previous levels[1], we explicitly
         # set the Host so that the inherited headers are over-written.
@@ -158,7 +158,7 @@ class govuk::apps::asset_manager(
 
         # Additionally, we always prohibit passing on these headers from S3 to
         # the client as they are very likely to be wrong. There appears to be
-        # a race condition or similar in nginx that allows the S3 headers to
+        # a race condition or similar in Nginx that allows the S3 headers to
         # overwrite those set here or by Rails, possibly depending on the order
         # in which S3 sends them.
         proxy_hide_header ETag;

--- a/modules/govuk/manifests/apps/asset_manager.pp
+++ b/modules/govuk/manifests/apps/asset_manager.pp
@@ -84,43 +84,16 @@ class govuk::apps::asset_manager(
     $nginx_extra_config = inline_template('
       client_max_body_size 500m;
 
-      # Instruct Nginx to set "Sendfile" headers for both Mainstream and
-      # Whitehall public asset URLs. The Rails app will respond with the
-      # X-Accel-Redirect header set to a path prefixed with /raw/ or
-      # /cloud-storage-proxy/ which will be handled by the relevant internal
-      # location block below.
-      location ~ ^/(media|government/uploads)/(.*) {
-         proxy_set_header X-Sendfile-Type X-Accel-Redirect;
-         proxy_set_header X-Accel-Mapping /var/apps/asset-manager/uploads/assets/=/raw/;
-
-         <%- if @aws_migration %>
-         proxy_pass http://asset-manager-proxy;
-         <%- else %>
-         proxy_pass http://asset-manager.<%= @app_domain %>-proxy;
-         <%- end %>
-       }
-
-      # /raw/(.*) is the path mapping sent from the Rails application to
-      # Nginx and is immediately picked up. /raw/(.*) is not available
-      # publicly as it is an internal path mapping.
-      location ~ /raw/(.*) {
-        internal;
-        add_header GOVUK-Asset-Manager-File-Store NFS;
-
-        # Control whether the asset can be embedded in other pages[1] by
-        # respecting X-Frame-Options from the Rails application.
-        # [1]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
-        add_header X-Frame-Options $upstream_http_x_frame_options;
-
-        alias /var/apps/asset-manager/uploads/assets/$1;
-      }
-
       # Store values from Rails response headers for use in the
       # cloud-storage-proxy location block below.
       set $etag_from_rails $upstream_http_etag;
       set $last_modified_from_rails $upstream_http_last_modified;
       set $x_frame_options_from_rails $upstream_http_x_frame_options;
 
+      # For public assets requests, the Rails app will respond with the
+      # X-Accel-Redirect header set to a path prefixed with
+      # /cloud-storage-proxy/. This triggers an Nginx internal redirect
+      # to that path which is then handled by this location block.
       location ~ /cloud-storage-proxy/(.*) {
         # Prevent requests to this location from outside Nginx
         internal;

--- a/modules/govuk/manifests/apps/asset_manager.pp
+++ b/modules/govuk/manifests/apps/asset_manager.pp
@@ -104,8 +104,6 @@ class govuk::apps::asset_manager(
         # $args:    Optional querystring params
         set $download_url $1$is_args$args;
 
-        add_header GOVUK-Asset-Manager-File-Store S3;
-
         # The X-CLOUD-STORAGE-URL header contains a signed URL for the asset on
         # S3. The signature of this URL is based in part on the request headers
         # set in the asset-manager Rails app at the time the URL is generated.

--- a/modules/nginx/templates/etc/nginx/nginx.conf.erb
+++ b/modules/nginx/templates/etc/nginx/nginx.conf.erb
@@ -62,7 +62,6 @@ http {
                          '"govuk_original_url": "$http_govuk_original_url", '
                          '"govuk_dependency_resolution_source_content_id": "$http_govuk_dependency_resolution_source_content_id", '
                          '"govuk_abtest_educationnavigation": "$http_govuk_abtest_educationnavigation", '
-                         '"govuk_asset_manager_file_store": "$sent_http_govuk_asset_manager_file_store", '
                          '"varnish_id": "$http_x_varnish", '
                          '"ssl_protocol": "$ssl_protocol", '
                          '"ssl_cipher": "$ssl_cipher" } }';


### PR DESCRIPTION
This removes the `Sendfile`-related config from the `asset-manager` Nginx virtual host.

Since alphagov/asset-manager#328 the Rails app only ever proxies asset requests to S3; it no longer instructs Nginx to serve asset files from NFS.

The functionality for proxying to S3 does not rely on setting the `X-Sendfile-Type` or `X-Accel-Mapping` request headers - these are only needed when using the `Rack::Sendfile` middleware built in to Rails which we are no longer using. So we can remove the location for `/media/` & `/government/uploads/` and instead rely on the default location for `/` which is [provided by `proxy-vhost.conf`][1].

Similarly the Rails app will no longer ever use the `/raw/` prefix in the `X-Accel-Redirect` response header value and so we can also remove the corresponding location block.

This PR also removes the sending of the `GOVUK-Asset-Manager-File-Store` response header. Now that asset requests are only ever proxied to S3, there's no point in this header which was used to discriminate between responses which were served from NFS vs proxied to S3. And since this header will no longer be sent, there's no point in attempting to include it in the log output.

I've also done some updating and tidying up of the comments, e.g. I've added an explanatory comment to the `/cloud-storage-proxy/` location block to replace the comment which previously existed against the `/media/` & `/government/uploads/` location block.

[1]:
https://github.com/alphagov/govuk-puppet/blob/1485ebb5a8ce228f6d4e60e8329d05e6c95a0832/modules/nginx/templates/proxy-vhost.conf#L139-L142