### PR TITLE
Revert DNS resolver changes

### DIFF
--- a/hieradata/class/production/licensify_lb.yaml
+++ b/hieradata/class/production/licensify_lb.yaml
@@ -1,3 +1,0 @@
-resolvconf::nameservers:
-  - 8.8.8.8
-  - 8.8.4.4

--- a/hieradata/class/production/licensing_backend.yaml
+++ b/hieradata/class/production/licensing_backend.yaml
@@ -1,3 +1,0 @@
-resolvconf::nameservers:
-  - 8.8.8.8
-  - 8.8.4.4

--- a/hieradata/class/production/licensing_frontend.yaml
+++ b/hieradata/class/production/licensing_frontend.yaml
@@ -1,3 +1,0 @@
-resolvconf::nameservers:
-  - 8.8.8.8
-  - 8.8.4.4

--- a/hieradata/class/production/licensing_mongo.yaml
+++ b/hieradata/class/production/licensing_mongo.yaml
@@ -1,3 +1,0 @@
-resolvconf::nameservers:
-  - 8.8.8.8
-  - 8.8.4.4

--- a/hieradata/class/staging/licensify_lb.yaml
+++ b/hieradata/class/staging/licensify_lb.yaml
@@ -1,3 +1,0 @@
-resolvconf::nameservers:
-  - 8.8.8.8
-  - 8.8.4.4

--- a/hieradata/class/staging/licensing_backend.yaml
+++ b/hieradata/class/staging/licensing_backend.yaml
@@ -1,3 +1,0 @@
-resolvconf::nameservers:
-  - 8.8.8.8
-  - 8.8.4.4

--- a/hieradata/class/staging/licensing_frontend.yaml
+++ b/hieradata/class/staging/licensing_frontend.yaml
@@ -1,3 +1,0 @@
-resolvconf::nameservers:
-  - 8.8.8.8
-  - 8.8.4.4

--- a/hieradata/class/staging/licensing_mongo.yaml
+++ b/hieradata/class/staging/licensing_mongo.yaml
@@ -1,3 +1,0 @@
-resolvconf::nameservers:
-  - 8.8.8.8
-  - 8.8.4.4

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1583,10 +1583,8 @@ redis::conf_tcp_keepalive: false
 redis::conf_timeout: 300
 
 resolvconf::nameservers:
-  - 195.225.219.96 # Carrenza London
-  - 195.225.219.97 # Carrenza London
-  - 31.210.244.104 # Carrenza Amsterdam
-  - 31.210.244.105 # Carrenza Amsterdam
+  - 8.8.8.8
+  - 8.8.4.4
 
 resolvconf::options:
    - 'single-request-reopen'


### PR DESCRIPTION
This change was not required, and moving back to the Google DNS servers means that we are not dependent on Carrenza resolvers (which are not accessible from all instances).