### PR TITLE
Add env var for partials links on Smart Answers

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -50,6 +50,7 @@ govuk::apps::short_url_manager::instance_name: 'integration'
 govuk::apps::signon::instance_name: 'integration'
 govuk::apps::smartanswers::expose_govspeak: true
 govuk::apps::smartanswers::show_draft_flows: true
+govuk::apps::smartanswers::enable_debug_partial_template_paths: true
 govuk::apps::specialist_publisher::publish_pre_production_finders: true
 govuk::apps::support_api::pp_data_url: 'https://www.preview.performance.service.gov.uk'
 govuk::apps::travel_advice_publisher::enable_email_alerts: true

--- a/modules/govuk/manifests/apps/smartanswers.pp
+++ b/modules/govuk/manifests/apps/smartanswers.pp
@@ -18,6 +18,10 @@
 #   shown in an environment
 #   Default: false
 #
+# [*enable_debug_partial_template_paths*]
+#   A boolean value indicating if the partials used in view can be linked to in Github.
+#   Default: false
+#
 # [*publishing_api_bearer_token*]
 #   The bearer token to use when communicating with Publishing API.
 #   Default: undef
@@ -31,7 +35,6 @@
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
-#
 # [*secret_key_base*]
 #   The key for Rails to use when signing/encrypting sessions.
 #
@@ -39,6 +42,7 @@ class govuk::apps::smartanswers(
   $port = '3010',
   $expose_govspeak = false,
   $show_draft_flows = false,
+  $enable_debug_partial_template_paths = false,
   $sentry_dsn = undef,
   $publishing_api_bearer_token = undef,
   $nagios_memory_warning = undef,
@@ -61,6 +65,14 @@ class govuk::apps::smartanswers(
     govuk::app::envvar {
       "${title}-SHOW_DRAFT_FLOWS":
         varname => 'SHOW_DRAFT_FLOWS',
+        value   => '1';
+    }
+  }
+
+  if $enable_debug_partial_template_paths {
+    govuk::app::envvar {
+      "${title}-ENABLE_DEBUG_PARTIAL_TEMPLATE_PATHS":
+        varname => 'ENABLE_DEBUG_PARTIAL_TEMPLATE_PATHS',
         value   => '1';
     }
   }


### PR DESCRIPTION
This toggles whether to enable the debug feature that allows content
designers to see links to Github for the partials. This is only enabled
on integration.