### PR TITLE
[AWS] assets-origin fix

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -604,7 +604,7 @@ govuk_beat::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 govuk_ci::agent::gcloud::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
-govuk::deploy::config::asset_root: "https://%{hiera('router::assets_origin::vhost_name')}"
+govuk::deploy::config::asset_root: "https://assets-origin.%{hiera('app_domain')}"
 govuk::deploy::config::website_root: "https://www-origin.%{hiera('app_domain')}"
 govuk::deploy::config::app_domain: "%{hiera('app_domain')}"
 govuk::deploy::setup::gemstash_server: 'http://gemstash'
@@ -1159,8 +1159,6 @@ router::assets_origin::asset_routes:
 router::assets_origin::vhost_aliases:
   - 'assets.digital.cabinet-office.gov.uk'
   - 'assets.publishing.service.gov.uk'
-
-router::assets_origin::vhost_name: "assets-origin"
 
 router::nginx::check_requests_warning: '@10'
 router::nginx::check_requests_critical: '@8'

--- a/modules/router/manifests/assets_origin.pp
+++ b/modules/router/manifests/assets_origin.pp
@@ -21,7 +21,7 @@ class router::assets_origin(
   $asset_routes = {},
   $real_ip_header = '',
   $vhost_aliases = [],
-  $vhost_name,
+  $vhost_name = 'assets-origin',
 ) {
   validate_array($vhost_aliases)
 


### PR DESCRIPTION
In c18de1e41bce03a2e49f158cd55b497ec61df01a I changed hieradata which affected a pretty core environment variable set by the govuk::deploy::config class.

I have now set the default vhost_name in router::assets_origin::vhost_name, which will still be overwritten in the current environments, but removes an required bit of hieradata since it doesn't really change.

Set the govuk::deploy::config::asset_root parameter with the true assets-origin FQDN.