### PR TITLE
[AWS] Update Jenkins theme for AWS Integration

### DIFF
--- a/hieradata_aws/class/blue/jenkins.yaml
+++ b/hieradata_aws/class/blue/jenkins.yaml
@@ -1,7 +1,0 @@
----
-govuk_jenkins::config::banner_colour_background: '#005EA5'
-govuk_jenkins::config::banner_colour_text: 'white'
-govuk_jenkins::config::banner_string: 'AWS INTEGRATION: BLUESTACK'
-govuk_jenkins::config::theme_colour: '#005EA5'
-govuk_jenkins::config::theme_text_colour: 'white'
-govuk_jenkins::config::theme_environment_name: 'Integration: Blue'

--- a/hieradata_aws/class/jenkins.yaml
+++ b/hieradata_aws/class/jenkins.yaml
@@ -50,7 +50,7 @@ govuk_jenkins::config::user_permissions:
       - 'hudson.model.Item.Build'
       - 'hudson.model.Item.Read'
 
-govuk_jenkins::config::banner_string: 'AWS Deploy'
+govuk_jenkins::config::banner_string: 'AWS Integration'
 
 govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::job::data_sync_complete_integration


### PR DESCRIPTION
We have removed the ability to have green/blue stacks at an application level, which also applies to Jenkins.

Remove the "blue stack" specific banner theme and specify the Jenkins instance as "AWS Integration".