### PR TITLE
[AWS] Alternative way to test pre-migration

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -102,9 +102,39 @@ govuk_ppa::path: 'preview'
 
 grafana::dashboards::machine_suffix_metrics: '_integration'
 
-# FIXME: this should be removed after the migration
-icinga::config::smokey::spoof_target_domain: 'cache.integration.govuk.digital'
-govuk_jenkins::job::smokey::spoof_target_domain: "%{hiera('icinga::config::smokey::spoof_target_domain')}"
+# FIXME: this should be removed after the migration when DNS has been switched over
+hosts::migration::hosts:
+  assets-origin.integration.publishing.service.gov.uk:
+    ip: 54.72.137.192
+    host_aliases:
+      - 'www-origin.integration.publishing.service.gov.uk'
+  backend.integration.publishing.service.gov.uk:
+    ip: 54.171.27.150
+    host_aliases:
+      - 'collections-publisher.integration.publishing.service.gov.uk'
+      - 'contacts-admin.integration.publishing.service.gov.uk'
+      - 'content-performance-manager.integration.publishing.service.gov.uk'
+      - 'content-tagger.integration.publishing.service.gov.uk'
+      - 'hmrc-manuals-api.integration.publishing.service.gov.uk'
+      - 'imminence.integration.publishing.service.gov.uk'
+      - 'local-links-manager.integration.publishing.service.gov.uk'
+      - 'manuals-publisher.integration.publishing.service.gov.uk'
+      - 'maslow.integration.publishing.service.gov.uk'
+      - 'policy-publisher.integration.publishing.service.gov.uk'
+      - 'publisher.integration.publishing.service.gov.uk'
+      - 'release.integration.publishing.service.gov.uk'
+      - 'search-admin.integration.publishing.service.gov.uk'
+      - 'service-manual-publisher.integration.publishing.service.gov.uk'
+      - 'short-url-manager.integration.publishing.service.gov.uk'
+      - 'signon.integration.publishing.service.gov.uk'
+      - 'specialist-publisher.integration.publishing.service.gov.uk'
+      - 'support.integration.publishing.service.gov.uk'
+      - 'transition.integration.publishing.service.gov.uk'
+      - 'travel-advice-publisher.integration.publishing.service.gov.uk'
+  bouncer.integration.publishing.service.gov.uk:
+    ip: 52.30.142.193
+  whitehall-admin.integration.publishing.service.gov.uk:
+    ip: 52.210.192.30
 
 mongodb::s3backup::backup::s3_bucket: 'govuk-mongodb-backup-s3-integration'
 mongodb::s3backup::backup::s3_bucket_daily: 'govuk-mongodb-backup-s3-daily-integration'

--- a/modules/base/manifests/init.pp
+++ b/modules/base/manifests/init.pp
@@ -42,5 +42,7 @@ class base {
       ensure  => 'present',
       content => template('base/motd.erb'),
     }
+
+    include hosts::migration
   }
 }

--- a/modules/hosts/manifests/migration.pp
+++ b/modules/hosts/manifests/migration.pp
@@ -1,0 +1,23 @@
+# == Class: Hosts::Migration
+#
+# Create hosts file for all hosts on the publishing domain. This is to help us
+# run tests and use backend apps through Signon before we fully switch the DNS
+# over.
+#
+# === Parameters:
+#
+# [*ensure*]
+#   Set to ensure the hosts exist in /etc/hosts.
+#
+# [*hosts*]
+#   Hash of the hosts and associated IPs to add.
+#
+class hosts::migration (
+  $ensure = 'present',
+  $hosts = {},
+) {
+  $defaults = {
+    'ensure' => $ensure,
+  }
+  create_resources(host, $hosts, $defaults)
+}


### PR DESCRIPTION
This is a really horrible way to test the stack pre-migration, but I can't think of another way around it.

Both sets of Smokey tests (in Icinga and Jenkins) rely on running against backend publishing apps. I tried setting the "SPOOF_TARGET_DOMAIN" env var, but this did not take into account the backend apps, which means we can't fully test the stack.

Setting these hosts will also enable us to log into backend apps, as otherwise they try to authenticate with Signon in the current Integration, which means we are unable to login to them.

The IPs are liable to change because of the way ELBs are dynamic, but we can always regenerate them using the tool created in [govuk-aws](https://github.com/alphagov/govuk-aws/blob/master/tools/migration-hosts.sh).