### PR TITLE
Configure a publishing API token for search-admin

### DIFF
--- a/hieradata/development_credentials.yaml
+++ b/hieradata/development_credentials.yaml
@@ -234,6 +234,7 @@ govuk::apps::manuals_publisher::asset_manager_bearer_token: 'oauth-bearer-token-
 govuk::apps::manuals_publisher::publishing_api_bearer_token: 'oauth-bearer-token-publishing-api'
 govuk::apps::publishing_api::oauth_id: 'oauth-publishing-api'
 govuk::apps::publishing_api::oauth_secret: 'secret'
+govuk::apps::search_admin::publishing_api_bearer_token: 'oauth-bearer-token-publishing-api'
 govuk::apps::service_manual_publisher::oauth_id: 'oauth-service-manual-publisher'
 govuk::apps::service_manual_publisher::oauth_secret: 'secret'
 govuk::apps::service_manual_publisher::asset_manager_bearer_token: 'oauth-bearer-token-asset-manager'

--- a/modules/govuk/manifests/apps/search_admin.pp
+++ b/modules/govuk/manifests/apps/search_admin.pp
@@ -24,6 +24,10 @@
 #   The port where the Rails app is running.
 #   Default: 3073
 #
+# [*publishing_api_bearer_token*]
+#   The bearer token to use when communicating with Publishing API.
+#   Default: undef
+#
 # [*oauth_id*]
 #   Sets the OAuth ID for using GDS-SSO
 #   Default: undef
@@ -42,6 +46,7 @@ class govuk::apps::search_admin(
   $db_username = undef,
   $sentry_dsn = undef,
   $port = '3073',
+  $publishing_api_bearer_token = undef,
   $oauth_id = undef,
   $oauth_secret = undef,
   $secret_key_base = undef,
@@ -64,6 +69,9 @@ class govuk::apps::search_admin(
   }
 
   govuk::app::envvar {
+    "${title}-PUBLISHING_API_BEARER_TOKEN":
+      varname => 'PUBLISHING_API_BEARER_TOKEN',
+      value   => $publishing_api_bearer_token;
     "${title}-OAUTH_ID":
       varname => 'OAUTH_ID',
       value   => $oauth_id;


### PR DESCRIPTION
Set an environment variable for search-admin to use to authenticate requests to the publishing API.

search-admin will use this to save external content (aka recommended links) to the publishing API rather than sending them to rummager directly.

https://trello.com/c/rDurYmt8/525-send-external-links-from-search-admin-to-the-publishing-api