### PR TITLE
Move sidekiq monitoring to a new port and enable on dev vm

### DIFF
--- a/development-vm/Procfile
+++ b/development-vm/Procfile
@@ -157,3 +157,4 @@ content-performance-manager-sidekiq-publishing-api:  govuk_setenv content-perfor
 link-checker-api:                     govuk_setenv link-checker-api            ./run_in.sh ../../link-checker-api bundle exec rails server -p 3208
 link-checker-api-sidekiq:             govuk_setenv link-checker-api            ./run_in.sh ../../link-checker-api bundle exec sidekiq -C ./config/sidekiq.yml
 # sidekiq-monitoring for specialist-publisher uses port 3210
+# sidekiq-monitoring's web frontend listens on port 3211 and proxies requests per app to other ports (defined elsewhere in this file)

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -72,6 +72,7 @@ govuk::node::s_development::apps:
   - 'service_manual_frontend'
   - 'service_manual_publisher'
   - 'short_url_manager'
+  - 'sidekiq_monitoring'
   - 'signon'
   - 'smartanswers'
   - 'specialist_publisher'
@@ -154,6 +155,7 @@ govuk::apps::signon::enable_procfile_worker: false
 govuk::apps::smartanswers::expose_govspeak: true
 govuk::apps::short_url_manager::mongodb_name: 'short_url_manager_development'
 govuk::apps::short_url_manager::mongodb_nodes: ['localhost']
+govuk::apps::sidekiq_monitoring::nginx_location: '/var/govuk/sidekiq-monitoring/public'
 govuk::apps::specialist_publisher::enable_procfile_worker: false
 govuk::apps::specialist_publisher::publish_pre_production_finders: true
 govuk::apps::specialist_publisher::mongodb_nodes: ['localhost']

--- a/modules/govuk/manifests/apps/sidekiq_monitoring.pp
+++ b/modules/govuk/manifests/apps/sidekiq_monitoring.pp
@@ -9,6 +9,11 @@
 #   interfaces.
 #   Default: 3211
 #
+# [*nginx_location*]
+#   Path on the server where the public folder of the
+#   sidekiq-monitoring app can be found.
+#   Default: /data/vhost/{value based on app name and domain}/current/public
+#
 # [*asset_manager_redis_host*]
 #   Redis host for Asset Manager Sidekiq.
 #   Default: undef
@@ -123,6 +128,7 @@
 #
 class govuk::apps::sidekiq_monitoring (
   $port = 3211,
+  $nginx_location = undef,
   $asset_manager_redis_host = undef,
   $asset_manager_redis_port = undef,
   $content_performance_manager_redis_host = undef,
@@ -159,6 +165,12 @@ class govuk::apps::sidekiq_monitoring (
     $full_domain = $app_name
   } else {
     $full_domain = "${app_name}.${app_domain}"
+  }
+
+  if $nginx_location == undef {
+    $nginx_location_path = "/data/vhost/${full_domain}/current/public"
+  } else {
+    $nginx_location_path = $nginx_location
   }
 
   Govuk::App::Envvar::Redis {

--- a/modules/govuk/manifests/apps/sidekiq_monitoring.pp
+++ b/modules/govuk/manifests/apps/sidekiq_monitoring.pp
@@ -3,6 +3,12 @@
 # App to monitor Sidekiq for multiple GOV.UK apps.
 #
 # === Parameters
+# [*port*]
+#   Port that the sidekiq monitoring web frontend listens
+#   on and proxies requests to the individual app sidekiq
+#   interfaces.
+#   Default: 3211
+#
 # [*asset_manager_redis_host*]
 #   Redis host for Asset Manager Sidekiq.
 #   Default: undef
@@ -116,6 +122,7 @@
 #   Default: undef
 #
 class govuk::apps::sidekiq_monitoring (
+  $port = 3211,
   $asset_manager_redis_host = undef,
   $asset_manager_redis_port = undef,
   $content_performance_manager_redis_host = undef,

--- a/modules/govuk/templates/sidekiq_monitoring_nginx_config.conf.erb
+++ b/modules/govuk/templates/sidekiq_monitoring_nginx_config.conf.erb
@@ -74,6 +74,6 @@ server {
     proxy_pass http://localhost:3081;
   }
 
-  root /data/vhost/<%= @full_domain %>/current/public;
+  root <%= @nginx_location_path %>;
 
 }

--- a/modules/govuk/templates/sidekiq_monitoring_nginx_config.conf.erb
+++ b/modules/govuk/templates/sidekiq_monitoring_nginx_config.conf.erb
@@ -5,7 +5,7 @@ server {
   server_name <%= @full_domain %>;
   <%- end %>
 
-  listen 80;
+  listen <%= @port %>;
 
   proxy_connect_timeout 1s;
   proxy_read_timeout 15s;


### PR DESCRIPTION
While trying to view sidekiq monitoring for support-api and following [the docs](https://docs.publishing.service.gov.uk/manual/monitor-sidekiq-workers.html) I found out that all I got was a:

```json
{
  "error": "Fell through to default vhost"
}
```

error from nginx.  It seems that 60a89ae9a7a30406225a3ff37cf17928941fd427 removed the `localhost` definition from the nginx config that made these instructions work.  We can't really put it back because it'll never work on AWS, so instead we give sidekiq-monitoring it's own port.

We also make it available on the dev VM so you don't have to tunnel to see the monitoring on there.

If this PR is accepted, I'll make a PR to the docs repo to change to reflect the new reality introduced by this PR.