### PR TITLE
Configure maintenance mode not on load balancers

### DIFF
--- a/modules/loadbalancer/manifests/balance.pp
+++ b/modules/loadbalancer/manifests/balance.pp
@@ -80,15 +80,6 @@ define loadbalancer::balance(
     }
   }
 
-  if ! defined(File['/etc/nginx/includes/maintenance.conf']) {
-    file { '/etc/nginx/includes/maintenance.conf':
-      ensure  => present,
-      content => template('loadbalancer/etc/nginx/includes/maintenance.conf.erb'),
-      require => File['/etc/nginx/includes'],
-      notify  => Class['nginx::service'],
-    }
-  }
-
   if $maintenance_mode {
     include loadbalancer::maintenance
   }

--- a/modules/loadbalancer/manifests/maintenance.pp
+++ b/modules/loadbalancer/manifests/maintenance.pp
@@ -4,6 +4,13 @@
 # into maintenance mode.
 #
 class loadbalancer::maintenance {
+  file { '/etc/nginx/includes/maintenance.conf':
+    ensure  => present,
+    content => template('loadbalancer/etc/nginx/includes/maintenance.conf.erb'),
+    require => File['/etc/nginx/includes'],
+    notify  => Class['nginx::service'],
+  }
+
   file { '/usr/share/nginx/www':
     ensure  => directory,
     mode    => '0755',

--- a/modules/nginx/manifests/config.pp
+++ b/modules/nginx/manifests/config.pp
@@ -17,12 +17,25 @@
 #   This is only used in AWS. This adds a resolver so that nginx refreshes resolved addresses
 #   from DNS if an upstream lookup fails. This is the prefix address defined for a VPC.
 #
+# [*maintenance_mode*]
+#   Whether or not the site is in maintenance mode.
+#   Default: false.
+#
 class nginx::config (
   $server_names_hash_max_size,
   $variables_hash_max_size = 1024,
   $denied_ip_addresses,
   $stack_network_prefix = '10.1.0',
+  $maintenance_mode = false,
 ) {
+
+  file { '/etc/nginx/includes':
+    ensure => 'directory',
+  }
+
+  if $maintenance_mode {
+    include loadbalancer::maintenance
+  }
 
   file { '/etc/nginx':
     ensure  => directory,


### PR DESCRIPTION
- In AWS, we don't have loadbalancers. We don't want to rearchitect the entire maintenance mode work right now, so include the loadbalancers::maintenance class for machines with nginx on them, if maintenance mode is turned on.

https://trello.com/c/EkXtb3cN/887-find-out-what-migration-mode-does-and-plan-for-using-it-during-migration