### PR TITLE
Add timestamper plugin to CI Jenkins

### DIFF
--- a/hieradata/class/ci_master.yaml
+++ b/hieradata/class/ci_master.yaml
@@ -250,6 +250,8 @@ govuk_jenkins::plugins:
       version: "1.10"
     throttle-concurrents:
       version: "2.0.1"
+    timestamper:
+      version: '1.8.9'
     token-macro:
       version: "2.1"
     versionnumber:


### PR DESCRIPTION
This is useful for profiling slow parts of CI jobs. We use this in
deploy Jenkins already

https://wiki.jenkins.io/display/JENKINS/Timestamper