### PR TITLE
Make the email-alert-check jobs resilient to GitHub being down

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/drug_email_alert_check.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/drug_email_alert_check.yaml.erb
@@ -1,12 +1,6 @@
 ---
 - scm:
     name: email-alert-check
-    scm:
-        - git:
-            url: git@github.com:alphagov/email-alert-monitoring.git
-            branches:
-              - master
-
 - job:
     name: email-alert-check
     display-name: EmailAlertCheck
@@ -20,9 +14,20 @@
         - timed: '21 * * * *' # every hour on the 21st minute
     builders:
         - shell: |
+            (
+              git clone https://github.com/alphagov/email-alert-monitoring tmp &&
+              rm -rf email-alert-monitoring &&
+              mv tmp email-alert-monitoring
+            ) || echo "Cloning failed. Re-using directory from previous run."
+
+            cd email-alert-monitoring
             bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
             bundle exec rake run
     publishers:
+      - text-finder:
+          regexp: "Cloning failed"
+          also-check-console-output: true
+          unstable-if-found: true
       - trigger-parameterized-builds:
         - project: Success_Passive_Check
           condition: 'SUCCESS'

--- a/modules/govuk_jenkins/templates/jobs/travel_advice_email_alert_check.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/travel_advice_email_alert_check.yaml.erb
@@ -1,12 +1,6 @@
 ---
 - scm:
     name: travel-advice-email-alert-check
-    scm:
-        - git:
-            url: git@github.com:alphagov/email-alert-monitoring.git
-            branches:
-              - master
-
 - job:
     name: travel-advice-email-alert-check
     display-name: TravelAdviceEmailAlertCheck
@@ -20,19 +14,18 @@
         - timed: '*/15 * * * *' # every 15 minutes
     builders:
         - shell: |
+            (
+              git clone https://github.com/alphagov/email-alert-monitoring tmp &&
+              rm -rf email-alert-monitoring &&
+              mv tmp email-alert-monitoring
+            ) || echo "Cloning failed. Re-using directory from previous run."
+
+            cd email-alert-monitoring
             bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
             bundle exec rake run_travel_alerts
     publishers:
       - text-finder:
-          regexp: "Could not read from remote repository"
-          also-check-console-output: true
-          unstable-if-found: true
-      - text-finder:
-          regexp: "The remote end hung up unexpectedly"
-          also-check-console-output: true
-          unstable-if-found: true
-      - text-finder:
-          regexp: "GitHub is offline for maintenance"
+          regexp: "Cloning failed"
           also-check-console-output: true
           unstable-if-found: true
       - trigger-parameterized-builds:


### PR DESCRIPTION
https://trello.com/c/0nNVddWb/408-%EF%B8%8F-dont-call-people-when-github-is-down

Previously, the build failed if the clone from GitHub failed. We'd tried
to use the Text Finder plugin to change the job status from 'failed' to
'unstable' so that Failure_Passive_Check wouldn't trigger post-build,
but this approach doesn't work.

The problem is the Text Finder plugin can only downgrade build statuses,
e.g. success -> unstable, it can't go fail -> unstable. See:
https://issues.jenkins-ci.org/browse/JENKINS-19641

This change makes it so we guard against the clone to GitHub failing by
cloning to a `tmp` directory, which only replaces the existing
email-alert-monitoring directory if the clone succeeds. Otherwise, we
echo from this command which causes execution to continue. This
has the effect of re-using the previously cloned directory from the last
time the job ran.

If the clone fails and the email check succeeds, we mark the build as
unstable by matching the 'Cloning failed' text in the build output. This
shouldn't alert in PagerDuty, but will add visibility that something
isn't quite right.

While working on this, I also looked at the Conditional Build Plugin and
Groovy Script Plugin, but I didn't manage to get either of these plugins
to trigger when the clone fails using Jenkins' default SCM settings for
the repository.