### PR TITLE
Redirect kibana.*.publishing.service.gov.uk to Logit

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -385,6 +385,8 @@ govuk::apps::govuk_cdn_logs_monitor::processed_data_dir: '/mnt/logs_cdn/data'
 govuk::apps::hmrc_manuals_api::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::hmrc_manuals_api::redis_port: "%{hiera('sidekiq_port')}"
 
+govuk::apps::kibana::logit_account: 1c6b2316-16e2-4ca5-a3df-ff18631b0e74
+
 govuk::apps::link_checker_api::db_hostname: "postgresql-primary-1.backend"
 govuk::apps::link_checker_api::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 # Hardcoded to its own redis server to improve performance

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -39,6 +39,7 @@ govuk::apps::email_alert_api::govdelivery_public_hostname: 'stage-public.govdeli
 govuk::apps::email_alert_api::govuk_notify_rate_per_worker: '18'
 govuk::apps::event_store::enabled: true
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
+govuk::apps::kibana::logit_environment: 353b2977-c8b4-45e4-9cd7-373bff0d2f63
 govuk::apps::publicapi::backdrop_host: 'www.preview.performance.service.gov.uk'
 govuk::apps::publisher::run_fact_check_fetcher: true
 govuk::apps::publisher::fact_check_address_format: 'govuk-factcheck-preview+{id}@digital.cabinet-office.gov.uk'

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -78,6 +78,7 @@ govuk::apps::email_alert_api::govdelivery_account_code: 'UKGOVUK'
 govuk::apps::email_alert_api::govdelivery_hostname: 'api.govdelivery.com'
 govuk::apps::email_alert_api::govdelivery_public_hostname: 'public.govdelivery.com'
 govuk::apps::hmrc_manuals_api::publish_topics: false
+govuk::apps::kibana::logit_environment: 0ea55710-075b-4eab-bfc3-475f28cdd0c3
 govuk::apps::local_links_manager::local_links_manager_passive_checks: true
 govuk::apps::local_links_manager::run_links_ga_export: true
 govuk::apps::publicapi::backdrop_host: 'www.performance.service.gov.uk'

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -24,6 +24,7 @@ govuk::apps::email_alert_api::govdelivery_public_hostname: 'stage-public.govdeli
 govuk::apps::email_alert_api::govuk_notify_base_url: 'https://api.staging-notify.works'
 govuk::apps::email_alert_api::govuk_notify_template_id: '76d21ce7-54c3-4fb7-8830-ba3b79287985'
 govuk::apps::hmrc_manuals_api::publish_topics: false
+govuk::apps::kibana::logit_environment: d414187a-2796-4ea7-9b9a-d40c341646d6
 govuk::apps::publicapi::backdrop_host: 'www.staging.performance.service.gov.uk'
 govuk::apps::publisher::run_fact_check_fetcher: false
 govuk::apps::publisher::fact_check_address_format: 'factcheck+staging-{id}@alphagov.co.uk'

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -458,8 +458,7 @@ govuk::apps::imminence::nagios_memory_critical: 1400
 
 govuk::apps::info_frontend::enabled: true
 
-govuk::apps::kibana::signon_root: "https://signon.%{hiera('app_domain')}"
-govuk::apps::kibana::elasticsearch_host: "logs-elasticsearch"
+govuk::apps::kibana::logit_account: 1c6b2316-16e2-4ca5-a3df-ff18631b0e74
 
 govuk::apps::local_links_manager::db_hostname: "postgresql-primary"
 govuk::apps::local_links_manager::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -13,6 +13,7 @@ govuk::apps::asset_manager::aws_region: 'eu-west-1'
 govuk::apps::email_alert_api::allow_govdelivery_topic_syncing: true
 govuk::apps::govuk_crawler_worker::enabled: false
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
+govuk::apps::kibana::logit_environment: 2694f14b-6519-4607-81f2-8a2130e5aaec
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-integration'
 govuk::apps::publishing_api::content_api_prototype: true
 govuk::apps::short_url_manager::instance_name: 'integration'

--- a/modules/govuk/manifests/apps/kibana.pp
+++ b/modules/govuk/manifests/apps/kibana.pp
@@ -1,20 +1,17 @@
 # == Class: govuk::apps::kibana
 #
-# A redirect to point people using the legacy Kibana domain to
-# docs for how to check Kibana on our ELK SaaS provider.
+# A redirect to point people to Kibana provided by Logit.
+# The URL sets the account and environment in a session.
 #
-class govuk::apps::kibana {
-  $app_name = 'kibana'
+class govuk::apps::kibana(
+  $logit_account = undef,
+  $logit_environment = undef,
+) {
 
+  $app_name = 'kibana'
   $app_domain = hiera('app_domain')
 
-  if $::aws_migration {
-    nginx::config::vhost::redirect { $app_name:
-      to => 'https://docs.publishing.service.gov.uk/manual/logit.html',
-    }
-  } else {
-    nginx::config::vhost::redirect { "${app_name}.${app_domain}":
-      to => 'https://docs.publishing.service.gov.uk/manual/logit.html',
-    }
+  nginx::config::vhost::redirect { "${app_name}.${app_domain}":
+    to => "https://logit.io/a/${logit_account}/s/${logit_environment}/kibana/access",
   }
 }


### PR DESCRIPTION
This might be more efficient than going through
google apps. The environment is set in the session
from a UUID in the URL.