### PR TITLE
[AWS] Set everything as internal in AWS

### DIFF
--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -128,6 +128,19 @@ define govuk::app::config (
         value   => $sentry_dsn;
     }
 
+    if $::aws_migration {
+      $app_domain = hiera('app_domain')
+      $app_uri = "${title}.${app_domain}"
+
+      $app_env_var = regsubst(upcase($title), '-', '_', G)
+
+      govuk::app::envvar { "${title}-PLEK_SERVICE_APP_URI":
+        varname => "PLEK_SERVICE_${app_env_var}_URI",
+        value   => "https://${title}.${app_domain}",
+      }
+
+    }
+
     if $app_type == 'rack' and $unicorn_herder_timeout != 'NOTSET' {
       govuk::app::envvar { "${title}-UNICORN_HERDER_TIMEOUT":
         varname => 'UNICORN_HERDER_TIMEOUT',

--- a/modules/govuk/manifests/apps/content_store.pp
+++ b/modules/govuk/manifests/apps/content_store.pp
@@ -89,15 +89,6 @@ class govuk::apps::content_store(
     }
   }
 
-  if $::aws_migration {
-    $app_domain_internal = hiera('app_domain_internal')
-
-    govuk::app::envvar { "${title}-PLEK_SERVICE_ROUTER_API_URI":
-      varname => 'PLEK_SERVICE_ROUTER_API_URI',
-      value   => "https://router-api.${app_domain_internal}",
-    }
-  }
-
   govuk::app::envvar {
     "${title}-DEFAULT_TTL":
       varname => 'DEFAULT_TTL',

--- a/modules/govuk/manifests/deploy/config.pp
+++ b/modules/govuk/manifests/deploy/config.pp
@@ -92,31 +92,25 @@ class govuk::deploy::config(
 
     'ERRBIT_ENVIRONMENT_NAME': value   => $errbit_environment_name;
     'SENTRY_CURRENT_ENV': value        => $errbit_environment_name;
-    'GOVUK_APP_DOMAIN': value          => $app_domain;
     'GOVUK_ASSET_HOST': value          => $asset_root;
     'GOVUK_ASSET_ROOT': value          => $asset_root;
     'GOVUK_WEBSITE_ROOT': value        => $website_root;
   }
 
-  # TODO: Set some internal services specifically before we've figured out
-  # how to entirely use internal domains
   if $::aws_migration {
     $app_domain_internal = hiera('app_domain_internal')
 
     govuk_envvar {
-      'GOVUK_APP_DOMAIN_INTERNAL': value        => $app_domain_internal;
-
-      # These variables are manually set in the draft stack (e.g. s_draft_cache),
-      # make sure they're separated out in those locations otherwise puppet
-      # won't run cleanly.
-      'PLEK_SERVICE_CONTENT_STORE_URI': value   => "https://content-store.${app_domain_internal}";
-      'PLEK_SERVICE_EMAIL_ALERT_API_URI': value => "https://email-alert-api.${app_domain_internal}";
-      'PLEK_SERVICE_LICENSIFY_URI': value       => "https://licensify.${licensify_app_domain}";
-      'PLEK_SERVICE_MAPIT_URI': value           => "https://mapit.${app_domain_internal}";
-      'PLEK_SERVICE_PUBLISHING_API_URI': value  => "https://publishing-api.${app_domain_internal}";
-      'PLEK_SERVICE_RUMMAGER_URI': value        => "https://rummager.${app_domain_internal}";
-      'PLEK_SERVICE_SEARCH_URI': value          => "https://search.${app_domain_internal}";
-      'PLEK_SERVICE_STATIC_URI': value          => "https://static.${app_domain_internal}";
+      # By default traffic should route internally
+      'GOVUK_APP_DOMAIN':           value => $app_domain_internal;
+      'GOVUK_APP_DOMAIN_INTERNAL':  value => $app_domain_internal;
+      # We do not host Licensify in AWS, so need to redirect to
+      # it's external domain
+      'PLEK_SERVICE_LICENSIFY_URI': value => "https://licensify.${licensify_app_domain}";
+    }
+  } else {
+    govuk_envvar { 'GOVUK_APP_DOMAIN':
+      value => $app_domain,
     }
   }
 }

--- a/modules/govuk/manifests/deploy/config.pp
+++ b/modules/govuk/manifests/deploy/config.pp
@@ -107,6 +107,9 @@ class govuk::deploy::config(
       # We do not host Licensify in AWS, so need to redirect to
       # it's external domain
       'PLEK_SERVICE_LICENSIFY_URI': value => "https://licensify.${licensify_app_domain}";
+      # Applications use Plek to redirect users back to Signon, so we need
+      # set Signon to use the Publishing domain
+      'PLEK_SERVICE_SIGNON_URI':    value => "https://signon.${app_domain}";
     }
   } else {
     govuk_envvar { 'GOVUK_APP_DOMAIN':

--- a/modules/govuk/spec/defines/govuk__app__config_spec.rb
+++ b/modules/govuk/spec/defines/govuk__app__config_spec.rb
@@ -92,6 +92,45 @@ describe 'govuk::app::config', :type => :define do
       end
     end
 
+    context 'in AWS' do
+      let(:params) do
+        {
+          :port => '8000',
+          :app_type => 'rack',
+          :domain => 'foo.bar.baz',
+          :vhost_full => 'giraffe.foo.bar.baz',
+        }
+      end
+      let(:facts) {{ :aws_migration => true }}
+
+      it do
+        is_expected.to contain_govuk__app__envvar('giraffe-PLEK_SERVICE_APP_URI').with(
+          :varname => 'PLEK_SERVICE_GIRAFFE_URI',
+          :value   => 'https://giraffe.environment.example.com',
+        )
+      end
+    end
+
+    context 'in AWS with hyphenated app name' do
+      let(:title) { 'bella-the-cat' }
+      let(:params) do
+        {
+          :port => '8000',
+          :app_type => 'rack',
+          :domain => 'foo.bar.baz',
+          :vhost_full => 'giraffe.foo.bar.baz',
+        }
+      end
+      let(:facts) {{ :aws_migration => true }}
+
+      it do
+        is_expected.to contain_govuk__app__envvar('bella-the-cat-PLEK_SERVICE_APP_URI').with(
+          :varname => 'PLEK_SERVICE_BELLA_THE_CAT_URI',
+          :value   => 'https://bella-the-cat.environment.example.com',
+        )
+      end
+    end
+
     context 'with app_type => bare, command => ./launch_zoo' do
       let(:params) {{
         :port => '123',


### PR DESCRIPTION
This change comes off the back of a discussion that was had in a [PR that I opened for Plek][1]. It looks to solve an issue where we initially tried to override specific cases of Plek lookups, but kept running into small edge cases.

Set "GOVUK_APP_DOMAIN" as internal by default. Ensure that each application sets a Plek override for itself so that if it ever references itself, it redirects the user to the correct location.

This hopefully solves a bunch of problems we have come across when trying to correctly route traffic internally. We had an issue where applications would misuse Plek to find out what their URL is to redirect users.

[1]: https://github.com/alphagov/plek/pull/54#issuecomment-353390978