### PR TITLE
Add EMAIL_ALERT_API_BEARER_TOKEN for email-alert-service

### DIFF
--- a/modules/govuk/manifests/apps/email_alert_service.pp
+++ b/modules/govuk/manifests/apps/email_alert_service.pp
@@ -25,12 +25,16 @@
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
+# [*email_alert_api_bearer_token*]
+#   Bearer token for communication with the email-alert-api
+#
 class govuk::apps::email_alert_service(
   $rabbitmq_hosts = ['localhost'],
   $rabbitmq_user = 'email_alert_service',
   $rabbitmq_password = 'email_alert_service',
   $sentry_dsn = undef,
   $redis_host = undef,
+  $email_alert_api_bearer_token = undef,
 ) {
   govuk::app { 'email-alert-service':
     app_type           => 'bare',
@@ -51,5 +55,11 @@ class govuk::apps::email_alert_service(
 
   govuk::app::envvar::redis { 'email-alert-service':
     host => $redis_host,
+  }
+
+  govuk::app::envvar {
+    "${title}-EMAIL_ALERT_API_BEARER_TOKEN":
+        varname => 'EMAIL_ALERT_API_BEARER_TOKEN',
+        value   => $email_alert_api_bearer_token;
   }
 }


### PR DESCRIPTION
Adds an env var for email-alert-service.

[Trello](https://trello.com/c/75sVuXhA/455-require-all-apps-to-authenticate-with-email-alert-api)