### PR TITLE
Add rate_limit_token to Smokey

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -572,6 +572,7 @@ govuk::apps::smokey::http_password: "%{hiera('http_password')}"
 govuk::apps::smokey::smokey_signon_email: "%{hiera('smokey_signon_email')}"
 govuk::apps::smokey::smokey_signon_password: "%{hiera('smokey_signon_password')}"
 govuk::apps::smokey::smokey_bearer_token: "%{hiera('smokey_bearer_token')}"
+govuk::apps::smokey::rate_limit_token: "%{hiera('smokey_rate_limit_token')}"
 
 govuk::apps::static::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::static::redis_port: "%{hiera('sidekiq_port')}"


### PR DESCRIPTION
I missed adding the rate limit token in 0c3263985d5eaa05414c1fb3c80ffa09ac941ce4, so this adds it in. The value is collected in the same way from encrypted hieradata.