### PR TITLE
[AWS] Update draft-origin IP

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -135,7 +135,7 @@ hosts::migration::hosts:
   bouncer.integration.publishing.service.gov.uk:
     ip: 52.30.142.193
   draft-origin.integration.publishing.service.gov.uk:
-    ip: 54.171.20.177
+    ip: 54.229.123.10
   whitehall-admin.integration.publishing.service.gov.uk:
     ip: 52.210.192.30
 


### PR DESCRIPTION
The DNS appears to have changed which is causing Smokey tests to fail to the draft-origin.

This is only temporary until we switch the DNS, and will occasionally happen in AWS.