### PR TITLE
Change docker prune approach

### DIFF
--- a/modules/govuk_ci/manifests/agent/docker.pp
+++ b/modules/govuk_ci/manifests/agent/docker.pp
@@ -15,15 +15,21 @@ class govuk_ci::agent::docker {
     version => '1.17.1',
   }
 
-  cron::crondotdee { 'docker_system_prune' :
+  cron::crondotdee { 'docker_system_prune_dangling' :
     hour    => '*/2',
     minute  => 0,
-    command => 'docker system prune -a -f --filter="until=24h"',
+    command => 'docker system prune -f --filter="until=1h"',
+  }
+
+  cron::crondotdee { 'docker_system_prune_all' :
+    hour    => 4,
+    minute  => 0,
+    command => 'docker system prune -a -f --filter="until=48h"',
   }
 
   cron::crondotdee { 'docker_volume_prune' :
-    hour    => '*/2',
-    minute  => 5,
+    hour    => 5,
+    minute  => 0,
     command => 'docker volume prune -f',
   }
 }


### PR DESCRIPTION
The approach of doing a system prune -a every 2 hours seemed a bit too
aggressive as it was causing a build failure if a docker container was
being started at the point this was run.

This goes for the less aggressive just dangling option to run every 2
hours and then at 4am each day to run a more aggressive prune to remove
the non-dangling images too (hopefully it's less likely someone will be
running a build then).

Hopefully net effects of this should be that the disk space is kept at
bay whilst build failures are less and build times lower.