### PR TITLE
Change the installed AWS gem for Puppet.

### DIFF
--- a/modules/puppet/files/etc/puppet/certsigner.rb
+++ b/modules/puppet/files/etc/puppet/certsigner.rb
@@ -6,7 +6,7 @@ ENV['HOME'] = Etc.getpwuid(Process.uid).dir
 
 require 'puppet'
 require 'puppet/ssl/certificate_request'
-require 'aws-sdk-core'
+require 'aws-sdk-ec2'
 
 certname = ARGV.pop
 csr = Puppet::SSL::CertificateRequest.from_s(STDIN.read)

--- a/modules/puppet/manifests/puppetserver/package.pp
+++ b/modules/puppet/manifests/puppetserver/package.pp
@@ -24,7 +24,7 @@ class puppet::puppetserver::package(
     require => Package['openjdk-7-jre-headless'],
   }
 
-  package { 'aws-sdk-core':
+  package { 'aws-sdk-ec2':
     provider => system_gem,
   }
 

--- a/modules/puppet/manifests/puppetserver/package.pp
+++ b/modules/puppet/manifests/puppetserver/package.pp
@@ -24,7 +24,7 @@ class puppet::puppetserver::package(
     require => Package['openjdk-7-jre-headless'],
   }
 
-  package { 'aws-sdk-ec2':
+  package { ['aws-sdk-ec2', 'aws-sdk-core']:
     provider => system_gem,
   }
 


### PR DESCRIPTION
The aws-sdk-core gem doesn't have the Aws::EC2 class which breaks the auto-signing in the Puppetmaster. aws-sdk-ec2 however does have it.