### PR TITLE
Create Jenkins bundle/ directory with correct perms.

### DIFF
--- a/modules/govuk_jenkins/manifests/init.pp
+++ b/modules/govuk_jenkins/manifests/init.pp
@@ -135,4 +135,13 @@ class govuk_jenkins (
     require => Class['govuk_jenkins::user'],
   }
 
+  # This was created with root permissions which broke deploys.
+  file { "${jenkins_homedir}/bundles":
+    ensure  => directory,
+    owner   => $jenkins_user,
+    group   => $jenkins_user,
+    mode    => '0775',
+    require => Class['govuk_jenkins::user'],
+  }
+
 }


### PR DESCRIPTION
Jenkins was deployed and something created this directory as root. Let's create it right at the beginning with the correct permissions.