### PR TITLE
Add a new postgres primary backup disk in integration

### DIFF
--- a/hieradata/class/integration/postgresql_primary.yaml
+++ b/hieradata/class/integration/postgresql_primary.yaml
@@ -8,6 +8,7 @@ lv:
       - '/dev/sde1'
       - '/dev/sdf1'
       - '/dev/sdg1'
+      - '/dev/sdh1'
     vg: 'backups'
   data:
     pv: '/dev/sdd1'


### PR DESCRIPTION
We're seeing alerts about this volume being full so we should increase its size by adding a new disk.