### PR TITLE
Update sidekiq paths for grafana

### DIFF
--- a/modules/grafana/files/dashboards/rummager_queues.json
+++ b/modules/grafana/files/dashboards/rummager_queues.json
@@ -277,11 +277,11 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "alias(consolidateBy(summarize(stats.gauges.govuk.app.rummager.workers.enqueued, '10s', 'max'), 'max'), 'Enqueued')",
+              "target": "alias(consolidateBy(summarize(stats.gauges.govuk.app.rummager.*.workers.enqueued, '10s', 'max'), 'max'), 'Enqueued')",
               "refId": "A"
             },
             {
-              "target": "alias(consolidateBy(summarize(stats.gauges.govuk.app.rummager.workers.retry_set_size, '10s', 'max'), 'max'), 'Retry Set')",
+              "target": "alias(consolidateBy(summarize(stats.gauges.govuk.app.rummager.*.workers.retry_set_size, '10s', 'max'), 'max'), 'Retry Set')",
               "refId": "B"
             }
           ],

--- a/modules/grafana/templates/dashboards/deployment_panels/_sidekiq_queue_length.json.erb
+++ b/modules/grafana/templates/dashboards/deployment_panels/_sidekiq_queue_length.json.erb
@@ -45,12 +45,12 @@
   "targets": [
     {
       "refId": "B",
-      "target": "alias(stats.gauges.govuk.app.<%= @app_name %>.workers.enqueued, 'Enqueued')",
+      "target": "alias(stats.gauges.govuk.app.<%= @app_name %>.*.workers.enqueued, 'Enqueued')",
       "textEditor": false
     },
     {
       "refId": "C",
-      "target": "alias(perSecond(stats.gauges.govuk.app.<%= @app_name %>.workers.processed), 'Processed/Sec')",
+      "target": "alias(perSecond(stats.gauges.govuk.app.<%= @app_name %>.*.workers.processed), 'Processed/Sec')",
       "textEditor": false
     }
   ],

--- a/modules/monitoring/manifests/checks/sidekiq.pp
+++ b/modules/monitoring/manifests/checks/sidekiq.pp
@@ -10,7 +10,7 @@ class monitoring::checks::sidekiq (
   $enable_support_check = true,
 ) {
   icinga::check::graphite { 'check_rummager_queue_latency':
-    target              => 'keepLastValue(stats.gauges.govuk.app.rummager.workers.queues.default.latency)',
+    target              => 'keepLastValue(maxSeries(stats.gauges.govuk.app.rummager.*.workers.queues.default.latency))',
     warning             => 0.3,
     critical            => 15,
     use                 => 'govuk_normal_priority',


### PR DESCRIPTION
This moves to the govuk_sidekiq gem naming syntax which includes the server
name in the metric path. We currently only display the metric graph for
rummager, but have made this change global as the assumption is that all apps
should be using our gem.

https://trello.com/c/OBhgB1Lw/531-code-tidy-up