### PR TITLE
Fix date range for 'detailed' search index size check

### DIFF
--- a/modules/monitoring/manifests/checks.pp
+++ b/modules/monitoring/manifests/checks.pp
@@ -155,10 +155,10 @@ class monitoring::checks (
 
   # Detailed is smaller than the other indexes (about 4500 documents)
   icinga::check::graphite { 'check_rummager_detailed_index_size_changed':
-    target              => "absolute(diffSeries(keepLastValue(stats.gauges.govuk.app.rummager.detailed_index.docs.count,${keep_last_value_limit}), timeShift(keepLastValue(stats.gauges.govuk.app.rummager.detailed_index.docs.count,${keep_last_value_limit}), \"3d\")))",
+    target              => "absolute(diffSeries(keepLastValue(stats.gauges.govuk.app.rummager.detailed_index.docs.count,${keep_last_value_limit}), timeShift(keepLastValue(stats.gauges.govuk.app.rummager.detailed_index.docs.count,${keep_last_value_limit}), \"7d\")))",
     warning             => 100,
     critical            => 500,
-    desc                => 'rummager detailed index size has significantly increased/decreased over the last 3 days',
+    desc                => 'rummager detailed index size has significantly increased/decreased over the last 7 days',
     host_name           => $::fqdn,
     notification_period => 'inoffice',
     action_url          => "https://grafana.${app_domain}/dashboard/file/rummager_index_size.json",


### PR DESCRIPTION
When checking that the `detailed` search index hasn't changed significantly in size, compare the current size with the data from 7 days ago rather than 3.

This is important because integration is switched off over the weekend. Comparing a weekday with a weekend will cause spurious alerts because graphite will try to compare a full search index with a missing one.

The other indices were already using 7 days for the comparison. This just makes the `detailed` index consistent with the others.

Paired with @koetsier.

cc @dwhenry 