### PR TITLE
Display sidekiq graphs & stats on Asset Manager deployment dashboard

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -917,7 +917,9 @@ grafana::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 grafana::dashboards::app_domain: "%{hiera('app_domain')}"
 grafana::dashboards::machine_suffix_metrics: ''
 grafana::dashboards::deployment_applications:
-  asset-manager: {}
+  asset-manager:
+    show_sidekiq_graphs: true
+    has_workers: true
   calculators:
     # logstasher >1.x
     fields_prefix: ''


### PR DESCRIPTION
I suspect these were not added originally, because Asset Manager used to use Delayed Job rather than Sidekiq.

I think these will be a useful addition, particularly now that we have two different workers - one for virus scanning and the other for uploading to S3 - both of which are integral to the app working correctly.