### PR TITLE
Decrease the xFilesFactor for statsd gauges

### DIFF
--- a/modules/govuk/files/node/s_graphite/storage-aggregation.conf
+++ b/modules/govuk/files/node/s_graphite/storage-aggregation.conf
@@ -44,6 +44,10 @@ xFilesFactor = 0.1
 pattern = ^stats_counts\..*
 aggregationMethod = sum
 
+[statsd-gauges]
+pattern = ^stats.gauges\..*
+xFilesFactor = 0.01
+
 # incremental counter, keep last value
 [mtail-counter-incremental]
 pattern = \.nginx_metrics\.mtail\.http_requests_total.*


### PR DESCRIPTION
Currently, the metrics matching ^stats.* will be stored with 5 second
resolution for 8 days, and then with less resolution over longer time
periods thereafter. Currently if only one value is reported in a 1
minute interval, it won't be aggregated, so that data will only be
stored for 8 days.

I'm interested in the metrics in the stats.gauges.topic-taxonomy
namespace, as I want to use them to track changes over a period like 3
months to see how the Topic Taxonomy is changing over a financial
quarter.

I'm unsure what will happen with an xFilesFactor of 0, as Graphite
doesn't often handle null data as I'd expect, and has a tendency to
treat null as 0. So, I've just set the value low enough such that if
only 1 value is reported in a 1 minute interval, that value will be
aggregated and stored.

With a 1 minute interval being an aggregation of 12 5 second
intervals, if only one value is present, the fraction would be 1/12,
or 0.0833... so use 0.01 as that's a nice round power of 10.

Changing the configuration won't change the value stored in existing
files, that will have to be done manually.

With the current storage schema for statsd metrics, this change in
xFilesFactor should also mean that aggregation for the longer
intervals should also work, as the step up is smaller than this
initial interval change.
  