### PR TITLE
Add LINK_CHECKER_API_SECRET_TOKEN to publisher

### DIFF
--- a/modules/govuk/manifests/apps/publisher.pp
+++ b/modules/govuk/manifests/apps/publisher.pp
@@ -72,6 +72,10 @@
 # [*email_group_citizen*]
 #   The email address to use citizen alerts
 #
+# [*link_checker_api_secret_token*]
+#   The Link Checker API secret token.
+#   Default: undef
+#
 class govuk::apps::publisher(
     $port = '3000',
     $enable_procfile_worker = true,
@@ -94,6 +98,7 @@ class govuk::apps::publisher(
     $email_group_dev = undef,
     $email_group_business = undef,
     $email_group_citizen = undef,
+    $link_checker_api_secret_token = undef,
   ) {
 
   $app_name = 'publisher'
@@ -200,5 +205,8 @@ class govuk::apps::publisher(
     "${title}-EMAIL_GROUP_CITIZEN":
       varname => 'EMAIL_GROUP_CITIZEN',
       value   => $email_group_citizen;
+    "${title}-LINK_CHECKER_API_SECRET_TOKEN":
+        varname => 'LINK_CHECKER_API_SECRET_TOKEN',
+        value   => $link_checker_api_secret_token;
   }
 }


### PR DESCRIPTION
This PR adds the secret token env variable required to secure the `link-checker-api` requests within `publisher`