### PR TITLE
Remove sync-asset-manager-from-master cron job from asset slaves

### DIFF
--- a/modules/govuk/manifests/node/s_asset_slave.pp
+++ b/modules/govuk/manifests/node/s_asset_slave.pp
@@ -42,6 +42,7 @@ class govuk::node::s_asset_slave (
   }
 
   cron { 'sync-asset-manager-from-master':
+    ensure  => 'absent',
     user    => 'assets',
     minute  => '*/10',
     command => '/usr/bin/setlock -n /var/tmp/asset-manager.lock /usr/bin/rsync -a --delete /data/master-uploads/asset-manager/ /mnt/uploads/asset-manager',


### PR DESCRIPTION
This cron job runs every 10 mins on each of the asset slaves copying Asset Manager (not Whitehall) asset files from the asset master using rsync via an NFS mount of the latter's `/mnt/uploads` directory.

As far as I can tell from [this commit][1] this cron job was added to solve a problem with environment syncing. However, environment syncing of Asset Manager assets is now taken care of by syncing of *S3 buckets* by [the `assets.sh` job][2] rather than by rsync-ing of *directories* by [the `attachments.sh` job][3].

Since [this change to Asset Manager][4] the files for new assets are deleted from the filesystem once they have been virus scanned and uploaded to S3, because Asset Manager now serves them from S3 via Nginx. Thus the Asset Manager app should no longer be permanently adding asset files to the filesystem and there's no need to have the sync provided by the `sync-asset-manager-from-master` cron job.

Furthermore we're about to delete the files for Asset Manager assets which have been uploaded to S3 i.e. the vast majority of them. We plan to use [this Asset Manager Rake task][5] to delete the files via the Carrierwave uploader mounted on `Asset#file`. This will delete the underlying file from the uploads directory under the Rails root directory which is sym-linked to `/data/uploads/asset-manager`. The latter is where the asset-master `/mnt/uploads` directory is mounted using NFS. If we were to leave the `sync-asset-manager-from-master` cron job in place, its `rsync` command would have to handle the sudden deletion of tens of thousands of file which might put undue load on the asset slaves and/or their NFS mounts.

Since Asset Manager is no longer permanently adding asset files to the filesystem, we can safely remove this cron job and avoid the problem mentioned above. Another advantage of doing this is that we will effectively retain a backup of the Asset Manager asset files on the asset slaves in case deleting the files causes an unforeseen problem. We can delete the files from the slaves once we're happy that everything is working OK.

We could probably also remove the /data/master-uploads NFS mount in this commit, but I think it's safer to apply that change separately later.

Note that we'll be able to remove the cron job definition entirely once the changes in this commit have been applied in all environments.

Note also that the [`asset_master_and_slave_disk_space_similar_from_xxx` Icinga alert][6] will be triggered if the disk space used by asset master vs asset slave is different by more than 384MB (warning) / 512MB (critical).

Since this checks compares the entire disk usage, not just the Asset Manager bit, if we disable the `sync-asset-manager-from-master` cron job and then delete all the Asset Manager asset files (60GB+) from the asset master, then this check will immediately go critical and stay critical. This is because there will be ~60GB more disk usage on the asset slaves compared to the master until we then later manually delete the Asset Manager asset files from the slaves.

As suggested by @danielroseman, we can warn 2nd Line that this will happen and they can acknowledge the alert with an expire time.

Another advantage of this approach is that we don't need to disable the `asset-manager-s3` nightly Duplicity backup to S3 which runs on `asset-slave-1` in production (see #6768) or exclude the Asset Manager asset files from the `push_attachments_to_s3` nightly cron job which runs on `asset-slave-2` in production until we delete the asset files.

[1]:
https://github.com/alphagov/govuk-puppet/commit/d9cf0eecd5190107618dec544fc2ea065b0aea7a
[2]:
https://github.com/alphagov/env-sync-and-backup/blob/169cb5846567f12030568c842e1ffe7630ca07fe/jobs/assets.sh
[3]:
https://github.com/alphagov/env-sync-and-backup/blob/169cb5846567f12030568c842e1ffe7630ca07fe/jobs/attachments.sh
[4]: https://github.com/alphagov/asset-manager/pull/373
[5]:
https://github.com/alphagov/asset-manager/blob/d803db930614a6063c0fc16730f6ba3eaf08e6d9/lib/tasks/govuk_assets.rake#L5
[6]: https://github.com/alphagov/govuk-puppet/blob/19837b4b351d97d84570bd8a7d01ef3420fbef94/modules/govuk/manifests/node/s_asset_slave.pp#L50-L63
