### PR TITLE
Update AWS hosts IPs for migration

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -106,11 +106,11 @@ grafana::dashboards::machine_suffix_metrics: '_integration'
 # FIXME: this should be removed after the migration when DNS has been switched over
 hosts::migration::hosts:
   assets-origin.integration.publishing.service.gov.uk:
-    ip: 54.72.137.192
+    ip: 54.154.251.153
     host_aliases:
       - 'www-origin.integration.publishing.service.gov.uk'
   backend.integration.publishing.service.gov.uk:
-    ip: 54.171.27.150
+    ip: 54.229.131.171
     host_aliases:
       - 'collections-publisher.integration.publishing.service.gov.uk'
       - 'contacts-admin.integration.publishing.service.gov.uk'
@@ -133,11 +133,11 @@ hosts::migration::hosts:
       - 'transition.integration.publishing.service.gov.uk'
       - 'travel-advice-publisher.integration.publishing.service.gov.uk'
   bouncer.integration.publishing.service.gov.uk:
-    ip: 52.30.142.193
+    ip: 54.229.111.17
   draft-origin.integration.publishing.service.gov.uk:
-    ip: 54.229.123.10
+    ip: 54.171.170.185
   whitehall-admin.integration.publishing.service.gov.uk:
-    ip: 52.210.192.30
+    ip: 34.250.228.194
 
 mongodb::s3backup::backup::s3_bucket: 'govuk-mongodb-backup-s3-integration'
 mongodb::s3backup::backup::s3_bucket_daily: 'govuk-mongodb-backup-s3-daily-integration'


### PR DESCRIPTION
Updating these IPs will ensure Smokey can pass tests.

These can be removed after we have migrated and updated the DNS.