### PR TITLE
Remove cron job definitions already marked as absent

### DIFF
--- a/modules/govuk/manifests/node/s_asset_master.pp
+++ b/modules/govuk/manifests/node/s_asset_master.pp
@@ -61,16 +61,6 @@ class govuk::node::s_asset_master (
     require => $cron_requires,
   }
 
-  # FIXME: Remove once purged from production
-  cron { 'rsync-clean':
-    ensure => absent,
-    user   => 'assets',
-  }
-  cron { 'rsync-clean-draft':
-    ensure => absent,
-    user   => 'assets',
-  }
-
   @@icinga::passive_check { "check_process_attachments_${::hostname}":
     service_description => 'Process attachments last run',
     host_name           => $::fqdn,

--- a/modules/govuk_postgresql/manifests/backup.pp
+++ b/modules/govuk_postgresql/manifests/backup.pp
@@ -31,11 +31,6 @@ class govuk_postgresql::backup (
     $threshold_secs = 28 * 3600
     $service_desc = 'AutoPostgreSQL backup'
 
-    #FIXME Remove once this has been deployed.
-    file {'/etc/cron.daily/autopostgresqlbackup':
-        ensure => absent,
-    }
-
     file {'/usr/local/bin/autopostgresqlbackup':
         mode    => '0755',
         content => template('govuk_postgresql/usr/local/bin/autopostgresqlbackup.erb'),


### PR DESCRIPTION
These cron job definitions were marked as `ensure => absent` some time ago, so I think it's safe to assume we can remove them and de-clutter the `govuk-puppet` repo very slightly.