### PR TITLE
Explicitly manage rake

### DIFF
--- a/modules/govuk_elasticsearch/manifests/dump.pp
+++ b/modules/govuk_elasticsearch/manifests/dump.pp
@@ -2,9 +2,16 @@
 class govuk_elasticsearch::dump (
   $run_es_dump_hour = '3',
 ) {
+
+  package { 'rake':
+    ensure   => '12.2.0',
+    provider => 'system_gem',
+  }
+
   package { 'es_dump_restore':
     ensure   => '2.2.2',
     provider => 'system_gem',
+    require  => Package['rake'],
   }
 
   file { '/var/es_dump':


### PR DESCRIPTION
es_dump_restore has an unbounded rake requirement so when it's installed
it pulls in the newest version, which is not compatiable with the system
ruby version. Rake 12.2.0 is compatible with ruby1.9.3, the ruby default,
so we pin it to that.