### PR TITLE
Re-add record_taxonomy_metrics job

### DIFF
--- a/hieradata/class/integration/jenkins.yaml
+++ b/hieradata/class/integration/jenkins.yaml
@@ -24,6 +24,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::launch_vms
   - govuk_jenkins::jobs::network_config_deploy
   - govuk_jenkins::jobs::passive_checks
+  - govuk_jenkins::jobs::record_taxonomy_metrics
   - govuk_jenkins::jobs::remove_emergency_banner
   - govuk_jenkins::jobs::run_deploy_lag_badger
   - govuk_jenkins::jobs::run_rake_task

--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -33,6 +33,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::passive_checks
   - govuk_jenkins::jobs::performance_platform_data_sync
   - govuk_jenkins::jobs::publishing_api_archive_events
+  - govuk_jenkins::jobs::record_taxonomy_metrics
   - govuk_jenkins::jobs::remove_emergency_banner
   - govuk_jenkins::jobs::run_rake_task
   - govuk_jenkins::jobs::run_whitehall_data_migrations

--- a/hieradata/class/staging/jenkins.yaml
+++ b/hieradata/class/staging/jenkins.yaml
@@ -17,6 +17,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::launch_vms
   - govuk_jenkins::jobs::network_config_deploy
   - govuk_jenkins::jobs::passive_checks
+  - govuk_jenkins::jobs::record_taxonomy_metrics
   - govuk_jenkins::jobs::remove_emergency_banner
   - govuk_jenkins::jobs::run_rake_task
   - govuk_jenkins::jobs::run_whitehall_data_migrations


### PR DESCRIPTION
This seems to have been accidentally removed in a previous PR [1]

[1] https://github.com/alphagov/govuk-puppet/pull/6881