### PR TITLE
Add asset_manager_host to hieradata

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -574,6 +574,7 @@ govuk::apps::smokey::smokey_signon_password: "%{hiera('smokey_signon_password')}
 govuk::apps::smokey::smokey_bearer_token: "%{hiera('smokey_bearer_token')}"
 govuk::apps::smokey::rate_limit_token: "%{hiera('smokey_rate_limit_token')}"
 
+govuk::apps::static::asset_manager_host: "asset-manager.%{hiera('app_domain')}"
 govuk::apps::static::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::static::redis_port: "%{hiera('sidekiq_port')}"
 

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -570,6 +570,7 @@ govuk::apps::smokey::smokey_signon_password: "%{hiera('smokey_signon_password')}
 govuk::apps::smokey::smokey_bearer_token: "%{hiera('smokey_bearer_token')}"
 govuk::apps::smokey::rate_limit_token: "%{hiera('smokey_rate_limit_token')}"
 
+govuk::apps::static::asset_manager_host: "asset-manager.%{hiera('app_domain_internal')}"
 govuk::apps::static::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::static::redis_port: "%{hiera('sidekiq_port')}"
 

--- a/modules/govuk/manifests/apps/static.pp
+++ b/modules/govuk/manifests/apps/static.pp
@@ -37,6 +37,10 @@
 #   Redis port for Sidekiq.
 #   Default: undef
 #
+# [*asset_manager_host*]
+#   The hostname that will proxy pass to asset manager.
+#   Default: undef
+#
 class govuk::apps::static(
   $vhost = 'static',
   $port = '3013',
@@ -46,9 +50,8 @@ class govuk::apps::static(
   $publishing_api_bearer_token = undef,
   $redis_host = undef,
   $redis_port = undef,
+  $asset_manager_host = undef,
 ) {
-  $app_domain = hiera('app_domain')
-  $asset_manager_host = "asset-manager.${app_domain}"
   $enable_ssl = hiera('nginx_enable_ssl', true)
   $app_name = 'static'
 


### PR DESCRIPTION
This requires a different domain in AWS, and so it's easier to override by moving to hieradata and setting as a default in `common.yaml`.