### PR TITLE
Iterating Docker CI pruning

### DIFF
--- a/modules/govuk_ci/manifests/agent/docker.pp
+++ b/modules/govuk_ci/manifests/agent/docker.pp
@@ -15,6 +15,14 @@ class govuk_ci::agent::docker {
     version => '1.17.1',
   }
 
+  # TODO: remove this once the file has been purged
+  cron::crondotdee { 'docker_system_prune' :
+    ensure  => 'absent',
+    hour    => '*/2',
+    minute  => 0,
+    command => 'docker system prune -a -f --filter="until=24h"',
+  }
+
   cron::crondotdee { 'docker_system_prune_dangling' :
     hour    => '*/2',
     minute  => 0,

--- a/modules/govuk_ci/manifests/agent/docker.pp
+++ b/modules/govuk_ci/manifests/agent/docker.pp
@@ -24,7 +24,7 @@ class govuk_ci::agent::docker {
   }
 
   cron::crondotdee { 'docker_system_prune_dangling' :
-    hour    => '*/2',
+    hour    => '*',
     minute  => 0,
     command => 'docker system prune -f --filter="until=1h"',
   }
@@ -36,8 +36,8 @@ class govuk_ci::agent::docker {
   }
 
   cron::crondotdee { 'docker_volume_prune' :
-    hour    => 5,
-    minute  => 0,
+    hour    => '*',
+    minute  => 5,
     command => 'docker volume prune -f',
   }
 }


### PR DESCRIPTION
We just had an issue where we ran out of disk space on ci-agent-8 so I've tried to see if there was more that could be done to stop the data usage.

This should remove a cron file that was left hanging around and increase the clearing of volumes/dangling artefacts.