### PR TITLE
Set info-frontend vhost_aliases in hieradata

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -456,6 +456,8 @@ govuk::apps::imminence::nagios_memory_warning: 1200
 govuk::apps::imminence::nagios_memory_critical: 1400
 
 govuk::apps::info_frontend::enabled: true
+govuk::apps::info_frontend::vhost_aliases:
+  - 'info-frontend'
 
 govuk::apps::local_links_manager::db_hostname: "postgresql-primary-1.backend"
 govuk::apps::local_links_manager::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"

--- a/modules/govuk/manifests/apps/info_frontend.pp
+++ b/modules/govuk/manifests/apps/info_frontend.pp
@@ -20,12 +20,16 @@
 #   The bearer token to use when communicating with Publishing API.
 #   Default: undef
 #
+# [*vhost_aliases*]
+#   An array of aliases to pass to NGINX.
+#
 class govuk::apps::info_frontend(
   $port = '3085',
   $enabled = false,
   $secret_key_base = undef,
   $publishing_api_bearer_token = undef,
   $sentry_dsn = undef,
+  $vhost_aliases = [],
 ) {
   $app_name = 'info-frontend'
 
@@ -33,7 +37,7 @@ class govuk::apps::info_frontend(
     app_type              => 'rack',
     port                  => $port,
     sentry_dsn            => $sentry_dsn,
-    vhost_aliases         => ['info-frontend'],
+    vhost_aliases         => $vhost_aliases,
     log_format_is_json    => true,
     asset_pipeline        => true,
     asset_pipeline_prefix => 'info-frontend',


### PR DESCRIPTION
In AWS we do not need to pass this alias in because we do not define FQDN in our NGINX configuration, so this gets passed twice and causes NGINX to warn on restart:

```
2018/01/05 15:11:01 [warn] 23132#0: conflicting server name "info-frontend" on 0.0.0.0:80, ignored
2018/01/05 15:11:01 [warn] 23132#0: conflicting server name "info-frontend.*" on 0.0.0.0:80, ignored
```

Moving into hieradata is the easiest way to define a default empty array, and override in standard `common.yaml`.