### PR TITLE
Remove open_firewall_from_all parameter

### DIFF
--- a/modules/govuk/manifests/node/s_rummager_elasticsearch.pp
+++ b/modules/govuk/manifests/node/s_rummager_elasticsearch.pp
@@ -16,26 +16,18 @@ class govuk::node::s_rummager_elasticsearch inherits govuk::node::s_base {
   }
 
   class { 'govuk_elasticsearch':
-    cluster_hosts          => ['rummager-elasticsearch-1.api:9300', 'rummager-elasticsearch-2.api:9300', 'rummager-elasticsearch-3.api:9300'],
-    cluster_name           => 'govuk-content',
-    heap_size              => "${es_heap_size}m",
-    number_of_replicas     => '1',
-    host                   => $::fqdn,
-    open_firewall_from_all => false,
-    require                => Class['govuk_java::openjdk7::jre'],
-    aws_cluster_name       => $aws_cluster_name,
-    log_slow_queries       => true,
-    slow_query_log_level   => 'info',
+    cluster_hosts        => ['rummager-elasticsearch-1.api:9300', 'rummager-elasticsearch-2.api:9300', 'rummager-elasticsearch-3.api:9300'],
+    cluster_name         => 'govuk-content',
+    heap_size            => "${es_heap_size}m",
+    number_of_replicas   => '1',
+    host                 => $::fqdn,
+    require              => Class['govuk_java::openjdk7::jre'],
+    aws_cluster_name     => $aws_cluster_name,
+    log_slow_queries     => true,
+    slow_query_log_level => 'info',
   }
 
-  if $::aws_migration {
-
-    @ufw::allow { 'allow-elasticsearch-http-9200':
-      port => 9200,
-    }
-
-  } else {
-
+  unless $::aws_migration {
     @ufw::allow { 'allow-elasticsearch-http-9200-from-search-1':
       port    => 9200,
       from    => getparam(Govuk_host['search-1'], 'ip'),


### PR DESCRIPTION
This is set to false by default: https://github.com/alphagov/govuk-puppet/blob/3b50c761aa27dbce48c20691cafaaec34681acdd/modules/govuk_elasticsearch/manifests/init.pp#L67

It gets overrides set in hieradata for both development and AWS. We were seeing strange behaviour where the rule was being added, and then removed.

```
Notice: /Stage[main]/Govuk::Node::S_rummager_elasticsearch/Ufw::Allow[allow-elasticsearch-http-9200]/Exec[ufw-allow-tcp-from-any-to-any-port-9200]/returns: executed successfully
Notice: /Stage[main]/Users/User[timmower]/ensure: removed
Notice: /Stage[main]/Users/User[timmower]/uid: audit change: newly-recorded value 1062
Notice: /Stage[main]/Govuk_elasticsearch/Exec[remove-allow-elasticsearch-http-9200-from-all]/returns: executed successfully
Notice: Finished catalog run in 6.52 seconds
```

We remove the parameter, and set it open by default in AWS in hieradata.  We use security groups to manage what is allowed to access the cluster rather than UFW.