### PR TITLE
Fix bouncer template vhost

### DIFF
--- a/modules/govuk/templates/bouncer_nginx_vhost.conf.erb
+++ b/modules/govuk/templates/bouncer_nginx_vhost.conf.erb
@@ -24,7 +24,11 @@ server {
   }
 
   location @app {
+    <%- if scope.lookupvar('::aws_migration') %>
+    proxy_pass http://bouncer-proxy;
+    <%- else %>
     proxy_pass http://<%= "bouncer.#{@app_domain}-proxy" %>;
+    <%- end %>
     proxy_set_header Host $http_host;
   }
 }


### PR DESCRIPTION
This was erroring and I guess was never caught before because NGINX was never restarted (and bouncer is rarely changed).

It caused this error:

```
2018/01/05 18:46:16 [emerg] 27168#0: host not found in upstream "bouncer.integration.publishing.service.gov.uk-proxy" in /etc/nginx/sites-enabled/businesslink:38
```

In AWS we just use the plain app name rather than a FQDN.