### PR TITLE
Add transition DB password to env-sync

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/copy_data_from_integration_to_aws.pp
+++ b/modules/govuk_jenkins/manifests/jobs/copy_data_from_integration_to_aws.pp
@@ -7,6 +7,7 @@ class govuk_jenkins::jobs::copy_data_from_integration_to_aws (
   $mysql_dst_root_pw = undef,
   $pg_src_env_sync_pw = undef,
   $pg_dst_env_sync_pw = undef,
+  $pg_tr_dst_env_sync_pw = undef,
   $whitehall_mysql_password = undef,
   $app_domain = hiera('app_domain'),
 ) {

--- a/modules/govuk_jenkins/templates/jobs/copy_data_from_integration_to_aws.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_from_integration_to_aws.yaml.erb
@@ -51,6 +51,7 @@
             echo "Putting in the real PostgreSQL env-sync password"
             sed -i.bak "s/PG_SRC_ENV_SYNC_PW=PLACEHOLDER/PG_SRC_ENV_SYNC_PW='<%= @pg_src_env_sync_pw %>'/" scripts/sync-postgresql.sh
             sed -i "s/PG_DST_ENV_SYNC_PW=PLACEHOLDER/PG_DST_ENV_SYNC_PW='<%= @pg_dst_env_sync_pw %>'/" scripts/sync-postgresql.sh
+            sed -i "s/PG_DST_ENV_SYNC_PW=TR_PLACEHOLDER/PG_DST_ENV_SYNC_PW='<%= @pg_tr_dst_env_sync_pw %>'/" scripts/sync-postgresql.sh
 
             echo "Syncing data"
             bash sync integration aws


### PR DESCRIPTION
On AWS the transition db password could be different
to the shared postgresql one. This needs to be reflected
in the environment data sync. There is a PR in the env sync
repository to complete this update.