### PR TITLE
Update dashboards for govt-frontend and local links manager

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -957,7 +957,9 @@ grafana::dashboards::deployment_applications:
   frontend:
     # logstasher >1.x
     fields_prefix: ''
-  government-frontend: {}
+  government-frontend:
+    # logstasher >1.x
+    fields_prefix: ''
   hmrc-manuals-api:
     # Missing @fields.status
     show_controller_errors: false
@@ -972,7 +974,9 @@ grafana::dashboards::deployment_applications:
     docs_name: 'licence-finder'
   link-checker-api:
     has_workers: true
-  local-links-manager: {}
+  local-links-manager:
+    # logstasher >1.x
+    fields_prefix: ''
   manuals-frontend:
     # Missing status, duration, controller
     show_controller_errors: false

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -915,12 +915,15 @@ grafana::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 grafana::dashboards::app_domain: "%{hiera('app_domain')}"
 grafana::dashboards::machine_suffix_metrics: ''
 grafana::dashboards::deployment_applications:
-  asset-manager: {}
+  asset-manager:
+    show_sidekiq_graphs: true
+    has_workers: true
   calculators:
-    # Status, duration, controller missing @fields. prefix
-    show_controller_errors: false
-    show_slow_requests: false
-  calendars: {}
+    # logstasher >1.x
+    fields_prefix: ''
+  calendars:
+    # logstasher >1.x
+    fields_prefix: ''
   collections: {}
   collections-publisher:
     # Low usage
@@ -929,13 +932,16 @@ grafana::dashboards::deployment_applications:
   contacts:
     docs_name: 'contacts-admin'
   content-performance-manager:
-    # Missing duration, status, controller fields
-    show_controller_errors: false
-    show_slow_requests: false
+    # logstasher >1.x
+    fields_prefix: ''
   content-store: {}
   content-tagger:
+    # logstasher >1.x
+    fields_prefix: ''
     has_workers: true
   email-alert-api:
+    # logstasher >1.x
+    fields_prefix: ''
     has_workers: true
   email-alert-frontend:
     # Missing duration, status, controller fields
@@ -944,24 +950,28 @@ grafana::dashboards::deployment_applications:
   feedback: {}
   finder-frontend: {}
   frontend:
-    # Status, duration, controller missing @fields. prefix
-    show_controller_errors: false
-    show_slow_requests: false
-  government-frontend: {}
+    # logstasher >1.x
+    fields_prefix: ''
+  government-frontend:
+    # logstasher >1.x
+    fields_prefix: ''
   hmrc-manuals-api:
     # Missing @fields.status
     show_controller_errors: false
   imminence:
+    # logstasher >1.x
+    fields_prefix: ''
     has_workers: true
   info-frontend: {}
   licencefinder:
-    # Status, duration, controller missing @fields. prefix
-    show_controller_errors: false
-    show_slow_requests: false
+    # logstasher >1.x
+    fields_prefix: ''
     docs_name: 'licence-finder'
   link-checker-api:
     has_workers: true
-  local-links-manager: {}
+  local-links-manager:
+    # logstasher >1.x
+    fields_prefix: ''
   manuals-frontend:
     # Missing status, duration, controller
     show_controller_errors: false
@@ -980,6 +990,8 @@ grafana::dashboards::deployment_applications:
     show_slow_requests: false
   policy-publisher: {}
   publisher:
+    # logstasher >1.x
+    fields_prefix: ''
     has_workers: true
   publishing-api:
     has_workers: true
@@ -1024,6 +1036,8 @@ grafana::dashboards::deployment_applications:
   travel-advice-publisher:
     has_workers: true
   whitehall:
+    # logstasher >1.x
+    fields_prefix: ''
     has_workers: true
     error_threshold: 50
     warning_threshold: 25


### PR DESCRIPTION
Removing the field prefix means that we look for (for example) the `duration` field in Kibana logs rather than `@fields.duration`.  This changes when we use a version of logstasher that is greater than 1 which is a given if we've upgraded the app to govuk_app_config v1 or higher.

The AWS config for the deployment dashboards appears to have lagged a bit, so I've copy/pasted from the non-aws hieradata file.