### PR TITLE
Update PV name for Graphite m5 machines

### DIFF
--- a/hieradata_aws/class/graphite.yaml
+++ b/hieradata_aws/class/graphite.yaml
@@ -9,7 +9,7 @@ icinga::client::checks::disk_time_critical: 400 # milliseconds
 lv:
   data:
     pv:
-      - /dev/xvdf
+      - /dev/nvme1n1
     vg: graphite
 
 mount:


### PR DESCRIPTION
m5 machines expose the EBS volume as nvme1n1. We still need to attach
the volume as xvdf but then the volume is renamed. For more info:

https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html