### PR TITLE
Update device for elasticsearch VG to work with m5 instances.

### DIFF
--- a/hieradata_aws/class/rummager_elasticsearch.yaml
+++ b/hieradata_aws/class/rummager_elasticsearch.yaml
@@ -7,7 +7,7 @@ govuk_elasticsearch::version: '2.4.6'
 
 lv:
   data:
-    pv: '/dev/xvdf'
+    pv: '/dev/nvme1n1'
     vg: 'elasticsearch'
 
 mount:


### PR DESCRIPTION
When we run these VMs as m5 types, the device name will change and Puppet needs to know what the new device will be. This doesn't seem to be resolvable with disk labels.