### PR TITLE
Update static deployment dashboard

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1026,7 +1026,17 @@ grafana::dashboards::deployment_applications:
   smartanswers:
     docs_name: 'smart-answers'
   specialist-publisher: {}
-  static: {}
+  static:
+    dependent_app_5xx_errors:
+      - calendars
+      - collections
+      - contacts
+      - finder-frontend
+      - frontend
+      - government-frontend
+      - manuals-frontend
+      - smartanswers
+      - whitehall-frontend
   support: {}
   support-api: {}
   transition:

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1013,7 +1013,17 @@ grafana::dashboards::deployment_applications:
   smartanswers:
     docs_name: 'smart-answers'
   specialist-publisher: {}
-  static: {}
+  static:
+    dependent_app_5xx_errors:
+      - calendars
+      - collections
+      - contacts
+      - finder-frontend
+      - frontend
+      - government-frontend
+      - manuals-frontend
+      - smartanswers
+      - whitehall-frontend
   support: {}
   support-api: {}
   transition:


### PR DESCRIPTION
The rummager dashboard has a [cool graph of 500s for apps that depend upon it working][1].  

Static really needs this too, as it makes it much easier to spot when you've killed something without having to leave the deployment dashboard.

[1]: https://grafana.publishing.service.gov.uk/dashboard/file/deployment_rummager.json?refresh=5s&panelId=4&fullscreen&orgId=1