### PR TITLE
Update AWS IPs again again

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -106,11 +106,11 @@ grafana::dashboards::machine_suffix_metrics: '_integration'
 # FIXME: this should be removed after the migration when DNS has been switched over
 hosts::migration::hosts:
   assets-origin.integration.publishing.service.gov.uk:
-    ip: 54.72.106.18
+    ip: 52.48.37.76
     host_aliases:
       - 'www-origin.integration.publishing.service.gov.uk'
   backend.integration.publishing.service.gov.uk:
-    ip: 52.209.64.175
+    ip: 54.77.11.116
     host_aliases:
       - 'collections-publisher.integration.publishing.service.gov.uk'
       - 'contacts-admin.integration.publishing.service.gov.uk'
@@ -133,11 +133,11 @@ hosts::migration::hosts:
       - 'transition.integration.publishing.service.gov.uk'
       - 'travel-advice-publisher.integration.publishing.service.gov.uk'
   bouncer.integration.publishing.service.gov.uk:
-    ip: 52.213.179.163
+    ip: 52.49.244.25
   draft-origin.integration.publishing.service.gov.uk:
-    ip: 52.51.208.154
+    ip: 54.77.195.72
   whitehall-admin.integration.publishing.service.gov.uk:
-    ip: 54.76.229.24
+    ip: 54.76.88.158
 
 mongodb::s3backup::backup::s3_bucket: 'govuk-mongodb-backup-s3-integration'
 mongodb::s3backup::backup::s3_bucket_daily: 'govuk-mongodb-backup-s3-daily-integration'


### PR DESCRIPTION
- Before, I used `host app.stackname.integration.govuk.digital` rather than
  just `host app.integration.govuk.digital` to find the IPs, so #7042 didn't have the correct IPs.