### PR TITLE
Remove Bouncer default healthcheck

### DIFF
--- a/modules/govuk/manifests/apps/bouncer.pp
+++ b/modules/govuk/manifests/apps/bouncer.pp
@@ -63,18 +63,6 @@ class govuk::apps::bouncer(
 
   if $::aws_migration {
     $vhost = 'bouncer'
-
-    nginx::config::site { 'healthcheck':
-      content => '
-        # Required for ALB healthchecks
-        server {
-          listen 80;
-          location = /_healthcheck {
-            return 200;
-          }
-        }
-      ',
-    }
   } else {
     $vhost = "bouncer.${app_domain}"
   }


### PR DESCRIPTION
This was made redundant by https://github.com/alphagov/govuk-aws/commit/9595cf9e8ae632d760578aa17f7dfa672a57598f.