### PR TITLE
AWS fix whitehall-admin access

### DIFF
--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -228,6 +228,11 @@ class govuk::apps::whitehall(
 
     if $::aws_migration {
       $whitehall_admin_vhost_ = 'whitehall-admin'
+
+      govuk::app::envvar { 'PLEK_SERVICE_WHITEHALL_ADMIN_URI':
+        varname => 'PLEK_SERVICE_WHITEHALL_ADMIN_URI',
+        value   => "https://whitehall-admin.${app_domain}",
+      }
     } else {
       $whitehall_admin_vhost_ = "whitehall-admin.${app_domain}"
     }


### PR DESCRIPTION
whitehall-admin needs to override the default internal domain with
the publishing one, same as the rest of the applications are doing
in app::config

For more information, check 00879e