### PR TITLE
Display Sidekiq graphs on Whitehall deployment dashboard

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1053,6 +1053,7 @@ grafana::dashboards::deployment_applications:
   whitehall:
     # logstasher >1.x
     fields_prefix: ''
+    show_sidekiq_graphs: true
     has_workers: true
     error_threshold: 50
     warning_threshold: 25

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1050,6 +1050,7 @@ grafana::dashboards::deployment_applications:
   whitehall:
     # logstasher >1.x
     fields_prefix: ''
+    show_sidekiq_graphs: true
     has_workers: true
     error_threshold: 50
     warning_threshold: 25


### PR DESCRIPTION
c.f. #7012 in which we did the same thing for Asset Manager.

I've found having the graphs accessible from the dashboard very useful.

Note that I've updated both the hieradata & AWS hieradata as per [this commit][1].

[1]:
https://github.com/alphagov/govuk-puppet/commit/418a02bd1bacde312e0fefa287a604ed782a7dc1