### PR TITLE
Update govuk.buildProject to tag docker similar to github tags

### DIFF
--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -220,7 +220,9 @@ def buildProject(Map options = [:]) {
       }
     }
 
-    if (hasDockerfile()) {
+    // We won't push docker images for deployed-to-* branches as they should be
+    // created automatically at deployment time.
+    if (hasDockerfile() && !(env.BRANCH_NAME ==~ /^deployed-to/)) {
       stage("Push Docker image") {
         pushDockerImage(jobName, env.BRANCH_NAME)
 


### PR DESCRIPTION
This stops docker tags being created for deployed-to-* branches (as we intend to create those automatically at deploy time) and adds a tag for release which is consistent with our github tags.

This is to enable the tags to be consistent with those which are input into deploy jobs as the deploy jobs will copy the tag inputted to them to create deployed-to-* branches.