### PR TITLE
Disable default alerts in CI environment

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -252,6 +252,7 @@ mongodb::s3backup::backup::s3_bucket_daily: 'govuk-mongodb-backup-s3-daily-integ
 mongodb::backup::mongo_backup_node: 'localhost'
 mongodb::s3backup::cron::daily_hour: 16
 
+monitoring::ci_environment: true
 monitoring::checks::sidekiq::enable_support_check: false
 monitoring::checks::pingdom::enable: false
 monitoring::checks::ses::region: eu-west-1

--- a/modules/monitoring/manifests/init.pp
+++ b/modules/monitoring/manifests/init.pp
@@ -2,7 +2,14 @@
 #
 # Sets up monitoring.
 #
-class monitoring {
+# === Parameters:
+#
+# [*ci_environment*]
+#   Disables lots of default alerts if this is the CI environment.
+#
+class monitoring (
+  $ci_environment = false,
+) {
 
   package { 'python-rrdtool':
     ensure => 'installed',
@@ -13,13 +20,15 @@ class monitoring {
 
   include govuk_htpasswd
 
-  # Monitoring server only.
-  include monitoring::contacts
-  include monitoring::checks
-  include monitoring::edge
-  include monitoring::event_handlers
-  include monitoring::pagerduty_drill
-  include monitoring::uptime_collector
+  unless $ci_environment {
+    # Monitoring server only.
+    include monitoring::contacts
+    include monitoring::checks
+    include monitoring::edge
+    include monitoring::event_handlers
+    include monitoring::pagerduty_drill
+    include monitoring::uptime_collector
+  }
 
   if ! $::aws_migration {
     include monitoring::vpn_gateways


### PR DESCRIPTION
If this is the CI environment then we should disable all the default alerts that get created on the monitoring instance.

Carrenza Integration is now essentially a full CI environment, with a smattering of Licensify.

Host specific alerts should still be present.