### PR TITLE
Configure Deploy App Jenkins job for Docker tagging

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
@@ -33,6 +33,11 @@
     publishers:
         - trigger:
             project: Smokey
+            threshold: UNSTABLE
+        - text-finder:
+            regexp: "DOCKER TAG FAILED"
+            also-check-console-output: true
+            unstable-if-found: true
         - email:
             recipients: govuk-ci-notifications@digital.cabinet-office.gov.uk
             send-to-individuals: true
@@ -43,6 +48,11 @@
         - build-name:
             name: '${ENV,var="TARGET_APPLICATION"} ${ENV,var="TAG"}'
         - build-user-vars
+        - credentials-binding:
+            - username-password-separated:
+                credential-id: govukci-docker-hub
+                username: DOCKER_HUB_USERNAME
+                password: DOCKER_HUB_PASSWORD
         - timestamps
     parameters:
         - choice:


### PR DESCRIPTION
This binds the Docker Hub credentials show they can be used in the
deploy job build. It adds the text finder plugin so that any builds
which output "DOCKER TAG FAILED" can be marked as unstable. Finally, it
changes the configuration of the Smokey job to run even if the build is
marked as unstable.

Paired with this is the need to set up the govukci-docker-hub credential
ID on each machine.