### PR TITLE
AWS set proxy_pass asset_manager_host with https

### DIFF
--- a/modules/govuk/manifests/apps/static.pp
+++ b/modules/govuk/manifests/apps/static.pp
@@ -55,6 +55,12 @@ class govuk::apps::static(
   $enable_ssl = hiera('nginx_enable_ssl', true)
   $app_name = 'static'
 
+  if $::aws_migration {
+    $proxy_pass_asset_manager_host_https = true
+  } else {
+    $proxy_pass_asset_manager_host_https = false
+  }
+
   govuk::app { $app_name:
     app_type              => 'rack',
     port                  => $port,

--- a/modules/govuk/templates/static_extra_nginx_config.conf.erb
+++ b/modules/govuk/templates/static_extra_nginx_config.conf.erb
@@ -27,7 +27,7 @@ location /robots.txt {
     proxy_set_header X-Forwarded-Server $host;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Host $host;
-    proxy_pass <%= @enable_ssl ? 'https' : 'http' %>://<%= @asset_manager_host %>;
+    proxy_pass <%= @enable_ssl or @proxy_pass_asset_manager_host_https ? 'https' : 'http' %>://<%= @asset_manager_host %>;
 
     # Explicitly re-include Strict-Transport-Security header, this
     # forces nginx not to clear Cache-Control headers further up the


### PR DESCRIPTION
On AWS, static needs to proxy requests to asset_manager using
https, because it's the only port we want to enable on the ELB.

The nginx_enable_ssl variable that the static vhost uses to
set the protocol is disabled on AWS, because it's used in other
places to set the vhost listening port. We add a new variable
to evaluate the conditional instead of playing with nginx_enable_ssl.