### PR TITLE
AWS fix whitehall preview redirection

### DIFF
--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -233,6 +233,11 @@ class govuk::apps::whitehall(
         varname => 'PLEK_SERVICE_WHITEHALL_ADMIN_URI',
         value   => "https://whitehall-admin.${app_domain}",
       }
+
+      govuk::app::envvar { 'PLEK_SERVICE_DRAFT_ORIGIN_URI':
+        varname => 'PLEK_SERVICE_DRAFT_ORIGIN_URI',
+        value   => "https://draft-origin.${app_domain}",
+      }
     } else {
       $whitehall_admin_vhost_ = "whitehall-admin.${app_domain}"
     }


### PR DESCRIPTION
whitehall/plek issue: previewing a draft redirects to
draft-origin.integration.govuk-internal.digital

Override draft-origin URI in whitehall-admin to use the
public facing domain.