### PR TITLE
Fix monitoring in CI

### DIFF
--- a/modules/monitoring/manifests/init.pp
+++ b/modules/monitoring/manifests/init.pp
@@ -19,10 +19,10 @@ class monitoring (
   include nsca::server
 
   include govuk_htpasswd
+  include monitoring::contacts
 
   unless $ci_environment {
     # Monitoring server only.
-    include monitoring::contacts
     include monitoring::checks
     include monitoring::edge
     include monitoring::event_handlers


### PR DESCRIPTION
In e09d2523715677e053f647c91bd5b90f7819190a I removed a bunch of classes from being run in CI, but we require for the monitoring::contacts class for templates.

Caused the error:

```
Error: Template 'govuk_high_priority' specified in service definition could not be found (config file '/etc/icinga/conf.d/icinga_host_vpn_gateway_redirector_dr/check_ping_vpn_gateway_redirector_dr.cfg', starting on line 1)
```