### PR TITLE
Add a mailmap file.

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,201 @@
+Aaron Keogh <aaron.keogh@digital.cabinet-office.gov.uk>
+Adrian Clay <adrian@madetech.com> <adieclay@gmail.com>
+Alec Gibson <alec.gibson@digital.cabinet-office.gov.uk> <aleckgibson@googlemail.com>
+Alex Muller <alex.muller@digital.cabinet-office.gov.uk> <alex@mullr.net>
+Alex Tomlins <alex.tomlins@digital.cabinet-office.gov.uk> <alex@tomlins.org.uk>
+Alex Torrance <alex.torrance@digital.cabinet-office.gov.uk> <hello@alextorrance.co.uk>
+ambrozic <ambrozic@gmail.com> <ambrozic@users.noreply.github.com>
+Ana Fernandez <ana.fernandez@digital.cabinet-office.gov.uk> <afda16@users.noreply.github.com>
+Andrea Grandi <a.grandi@gmail.com> <andreagrandi@gds5060.local>
+Andrew Garner <andrew.garner@digital.cabinet-office.gov.uk> <andrew@andrewgarner.com>
+Andrew Hilton <andrew.hilton@digital.cabinet-office.gov.uk> <igberty@gmail.com>
+Andrew Langhorn <andrew.langhorn@digital.cabinet-office.gov.uk> <ajlanghorn@users.noreply.github.com>
+Andy Sellick <andy.sellick@gmail.com> <andysellick@gds5516.local>
+Anna Shipman <anna.shipman@digital.cabinet-office.gov.uk> <anna@annashipman.co.uk>
+Anna Shipman <anna.shipman@digital.cabinet-office.gov.uk> <annashipman@hotmail.co.uk>
+Anna Shipman <anna.shipman@digital.cabinet-office.gov.uk> <annashipman@ubuntu.localdomain>
+Ben Hyland <ben.hyland@digital.cabinet-office.gov.uk> <mail@bhyland.co.uk>
+Bevan Loon <bevan.loon@digital.cabinet-office.gov.uk> <poissonpie@gmail.com>
+bob walker <bob.walker@digital.cabinet-office.gov.uk> <bob@randomness.org.uk>
+Bradley Wright <bradley.wright@digital.cabinet-office.gov.uk>
+Bradley Wright <bradley.wright@digital.cabinet-office.gov.uk> <brad@intranation.com>
+Bradley Wright <bradley.wright@digital.cabinet-office.gov.uk> <bradleywright@GDS367.local>
+Brendan Butler <brendan.butler@digital.cabinet-office.gov.uk>
+Brendan Butler <brendan.butler@digital.cabinet-office.gov.uk> <b@brenetic.com>
+Brendan Butler <brendan.butler@digital.cabinet-office.gov.uk> <brendanbutler@gds3694.local>
+Brendan Butler <brendan.butler@digital.cabinet-office.gov.uk> <brenetic@users.noreply.github.com>
+Cal Paterson <cal.paterson@digital.cabinet-office.gov.uk>
+Cal Paterson <cal.paterson@digital.cabinet-office.gov.uk> <cal@calpaterson.com>
+Cal Paterson <cal.paterson@digital.cabinet-office.gov.uk> <cpaterso@thoughtworks.com>
+Camilla van Klinken <camilla@madetech.com>
+Camilla van Klinken <camilla@madetech.com> <camillavk@users.noreply.github.com>
+Carl Massa <carl.massa@digital.cabinet-office.gov.uk> <carl.massa@digital.cabinet-office.gov>
+Caroline Green <caroline.green@digital.cabinet-office.gov.uk>
+Caroline Green <caroline.green@digital.cabinet-office.gov.uk> <carolinegreen@gds3696.local>
+Chris Carter <chris.carter@unboxedconsulting.com> <chris.carter1@ntlworld.com>
+Christopher Baines <christopher.baines@digital.cabinet-office.gov.uk> <cbaines8@gmail.com>
+Christopher Baines <christopher.baines@digital.cabinet-office.gov.uk> <cbaines@users.noreply.github.com>
+Dafydd Vaughan <dafydd.vaughan@digital.cabinet-office.gov.uk>
+Dafydd Vaughan <dafydd.vaughan@digital.cabinet-office.gov.uk> <dai@daibach.co.uk>
+Dan Abel <dan.abel@digital.cabinet-office.gov.uk>
+Dan Carley <dan.carley@digital.cabinet-office.gov.uk> <dan.carley+github@gmail.com>
+Dan Carley <dan.carley@digital.cabinet-office.gov.uk> <dan.carley@gmail.com>
+Daniel Roseman <daniel.roseman@digital.cabinet-office.gov.uk> <daniel@roseman.org.uk>
+David Ainslie <david.ainslie@digital.cabinet-office.gov.uk> <dainslie@gmail.com>
+David Heath <david.heath@digital.cabinet-office.gov.uk> <david@davidheath.org>
+David Henry <david@decoybecoy.com> <dw_henry@yahoo.com.au>
+David Illsley <david.illsley@digital.cabinet-office.gov.uk> <david@illsley.org>
+David Silva <david.silva@digital.cabinet-office.gov.uk> <davidslv@gmail.com>
+David Silva <david.silva@digital.cabinet-office.gov.uk> <Davidslv@users.noreply.github.com>
+David Singleton <david.singleton@digital.cabinet-office.gov.uk> <david@dsingleton.co.uk>
+David Thompson <david.thompson@digital.cabinet-office.gov.uk> <mail@fatbusinessman.com>
+Daz Ahern <daz.ahern@digital.cabinet-office.gov.uk>
+Daz Ahern <daz.ahern@digital.cabinet-office.gov.uk> <darren.ahern@gmail.com>
+Dean Wilson <dean.wilson@digital.cabinet-office.gov.uk> <dean.wilson@gmail.com>
+Dean Wilson <dean.wilson@digital.cabinet-office.gov.uk> <deanwilson@gmail.com>
+Deborah Chua <deborah.chua@digital.cabinet-office.gov.uk> <deborahchua@gds6358.local>
+Deborah Chua <deborah.chua@digital.cabinet-office.gov.uk> <dbrh.chua@gmail.com>
+Dominic Baggott <dominic.baggott@digital.cabinet-office.gov.uk>
+Dominic Baggott <dominic.baggott@digital.cabinet-office.gov.uk> <dominic.baggott@gmail.com>
+Douglas Roper <douglas.roper@digital.cabinet-office.gov.uk> <dougdroper@gmail.com>
+Edd Sowden <edd.sowden@digital.cabinet-office.gov.uk> <e@e26.co.uk>
+Elliot Crosby-McCullough <elliot.cm@gmail.com> <elliot.crosby-mccullough@digital.cabinet-office.gov.uk>
+Emma Beynon <emma.beynon@digital.cabinet-office.gov.uk> <emma.beynon@gmail.com>
+Gareth Rogers <grogers@thoughtworks.com>
+Gareth Rushgrove <gareth.rushgrove@digital.cabinet-office.gov.uk> <gareth@morethanseven.net>
+Garima Singh <garima.singh@digital.cabinet-office.gov.uk> <igarimasingh@gmail.com>
+Graham Pengelly <graham@three-tier.com> <graham.pengelly@digital.cabinet-office.gov.uk>
+Ian Maddison <ian.maddison@digital.cabinet-office.gov.uk> <ian@i.need.stronger.coffee>
+Ian Maddison <ian.maddison@digital.cabinet-office.gov.uk>
+Ikenna Okpala <ikenna.okpala@digital.cabinet-office.gov.uk> <ikennaokpala@users.noreply.github.com>
+Ikenna Okpala <ikenna.okpala@digital.cabinet-office.gov.uk> <me@ikennaokpala.com>
+Isabell Long <isabell.long@digital.cabinet-office.gov.uk> <isabell@issyl0.co.uk>
+Jack Scotti <jack.scotti@digital.cabinet-office.gov.uk> <jackscotti@users.noreply.github.com>
+Jack Scotti <jack.scotti@digital.cabinet-office.gov.uk> <jacopojackscotti@gmail.com>
+Jack Franklin <jack.franklin@digital.cabinet-office.gov.uk>
+Jacob Ashdown <jacob.ashdown@digital.cabinet-office.gov.uk>
+<jacob.ashdown@digital.cabinet-office.gov.uk> <jcbashdown@gmail.com>
+<jacob.ashdown@digital.cabinet-office.gov.uk> <jcbashdown@googlemail.com>
+Jake Benilov <jake.benilov@digital.cabinet-office.gov.uk>
+Jake Benilov <jake.benilov@digital.cabinet-office.gov.uk> <benilov@gmail.com>
+James Abley <james.abley@digital.cabinet-office.gov.uk> <james.abley@gmail.com>
+James Hughes <james@yobriefca.se> <jameshu@ubuntu.localdomain>
+James Stewart <james@jystewart.net> <jys@ketlai.co.uk>
+Jamie Cobbett <jamie.cobbett@digital.cabinet-office.gov.uk> <jamiec@ubuntu.localdomain>
+Jamie Cobbett <jamie.cobbett@digital.cabinet-office.gov.uk> <jamiecobbett85@gmail.com>
+Jamie Cobbett <jamie.cobbett@digital.cabinet-office.gov.uk> <jamiecobbett@GDS267.internal.localnet>
+Jim Gumbley <jim.gumbley@digital.cabinet-office.gov.uk> <jgumbley@thoughtworks.com>
+Jon Auman <info@compurama.net>
+Jordan Hatch <jordan.hatch@digital.cabinet-office.gov.uk> <jordan@jordanh.net>
+Jos Koetsier <jos.koetsier@digital.cabinet-office.gov.uk>
+Jos Koetsier <jos.koetsier@digital.cabinet-office.gov.uk> <george.koetsier@digital.cabinet-office.gov.uk>
+Josh Myers <josh.myers@digital.cabinet-office.gov.uk> <josh.myers@photobox.com>
+Josh Myers <josh.myers@digital.cabinet-office.gov.uk> <joshuajmyers@gmail.com>
+Katie Smith <katie.smith@digital.cabinet-office.gov.uk> <klssmith@users.noreply.github.com>
+Kelvin Gan <kelvin.gan@digital.cabinet-office.gov.uk> <dev@kelvingan.co.uk>
+Kelvin Gan <kelvin.gan@digital.cabinet-office.gov.uk> <gds@kelvingan.co.uk>
+Kevin Dew <kevin.dew@digital.cabinet-office.gov.uk> <kevindew@me.com>
+Kief Morris <kmorris@thoughtworks.com>
+Kushal Pisavadia <kushal.pisavadia@digital.cabinet-office.gov.uk> <kushi.p@gmail.com>
+Kyle Macpherson <kyle.macpherson@digital.cabinet-office.gov.uk> <kaimac2010@gmail.com>
+Laura Martin <laura.martin@digital.cabinet-office.gov.uk> <paul.martin@digital.cabinet-office.gov.uk>
+Laura Martin <laura.martin@digital.cabinet-office.gov.uk> <surminus@gmail.com>
+Lee Briggs <lee.briggs@digital.cabinet-office.gov.uk> <coffeegunshow@gmail.com>
+Leena Gupte <leena.gupte@digital.cabinet-office.gov.uk> <leena.gupte@gmail.com>
+Lee Longmore <lee.longmore@digital.cabinet-office.gov.uk>
+Lee Longmore <lee.longmore@digital.cabinet-office.gov.uk> <lee.longmore@gmail.com>
+Leon Derks <leon.derks@digital.cabinet-office.gov.uk>
+Leon Derks <leon.derks@digital.cabinet-office.gov.uk> <l.a.derks@gmail.com>
+Mark Needham <mark.needham@digital.cabinet-office.gov.uk> <m.h.needham@gmail.com>
+Mark Needham <mark.needham@digital.cabinet-office.gov.uk> <mneedham@ubuntu.localdomain>
+Martyn Inglis <martyn.inglis@digital.cabinet-office.gov.uk>
+Martyn Inglis <martyn.inglis@digital.cabinet-office.gov.uk> <martyn.inglis@guardian.co.uk>
+Martyn Inglis <martyn.inglis@digital.cabinet-office.gov.uk> <martyninglis@minglis-gds-macbook.internal.localnet>
+Martyn Inglis <martyn.inglis@digital.cabinet-office.gov.uk> <martyninglis@minglis-gds-macbook.local>
+Mark Norman Francis <mark.norman.francis@digital.cabinet-office.gov.uk>
+Mark Norman Francis <mark.norman.francis@digital.cabinet-office.gov.uk> <norm@cackhanded.net>
+Mark Sheldon <mark.sheldon@digital.cabinet-office.gov.uk>
+Mat Moore <mat.moore@digital.cabinet-office.gov.uk> <matmoore@users.noreply.github.com>
+Mat Moore <mat.moore@digital.cabinet-office.gov.uk> <mwehtam@gmail.com>
+Mat Wall <mat.wall@digital.cabinet-office.gov.uk> <mwall@alphagov.co.uk>
+Mat Wall <mat.wall@digital.cabinet-office.gov.uk> <mwall@ubuntu-vm-mwall.(none)>
+Mat Wall <mat.wall@digital.cabinet-office.gov.uk> <matwall@alphagov-vm-mwall.localdomain>
+Mathilda Thompson <mathilda.thompson@digital.cabinet-office.gov.uk> <mathildathompson288@gmail.com>
+Matt Bostock <matt.bostock@digital.cabinet-office.gov.uk> <matt@mattbostock.com>
+Matt Bostock <matt.bostock@digital.cabinet-office.gov.uk>
+Matteo Grassotti <matteo.grassotti@digital.cabinet-office.gov.uk> <matteo.grassotti@gmail.com>
+Matteo Grassotti <matteo.grassotti@digital.cabinet-office.gov.uk> <matteograssotti@gds3735.local>
+Matthew Ford <matt@bitzesty.com>
+Max Lehmann <max.lehmann@digital.cabinet-office.gov.uk> <31649453+maxgds@users.noreply.github.com>
+Mazz Mosley <mazz.mosley@digital.cabinet-office.gov.uk>
+Mazz Mosley <mazz.mosley@digital.cabinet-office.gov.uk> <marianne.mosley@gmail.com>
+Mazz Mosley <mazz.mosley@digital.cabinet-office.gov.uk> <mazzmoseley@GDSMazz.internal.localnet>
+Mikael <mikellallison@gmail.com> <djsd123@users.noreply.github.com>
+Mo Baig <mo.baig@digital.cabinet-office.gov.uk> <mo@mobaig.com>
+Nick Colley <nick.colley@digital.cabinet-office.gov.uk> <nickcolley7@gmail.com>
+Nick Colley <nick.colley@digital.cabinet-office.gov.uk> <nickcolley@gds0257.local>
+Nick Stenning <nick.stenning@digital.cabinet-office.gov.uk> <nick@whiteink.com>
+Oliver Byford <oliver.byford@digital.cabinet-office.gov.uk> <o@byford.org>
+Pablo Manrubia <pablo.manrubia@digital.cabinet-office.gov.uk> <pmanrubia@gmail.com>
+Paul Bowsher <paul.bowsher@digital.cabinet-office.gov.uk> <paul.bowsher@gmail.com>
+Paul Downey <paul.downey@whatfettle.com> <psd@whatfettle.com>
+Paulo Schneider <pschneid@thoughtworks.com> <paulo.schneider@gmail.com>
+Peter Hartshorn <peter.hartshorn@digital.cabinet-office.gov.uk> <peter.hartshorn1996@gmail.com>
+Philip Potter <philip.potter@digital.cabinet-office.gov.uk>
+Philip Potter <philip.potter@digital.cabinet-office.gov.uk> <philip.g.potter@gmail.com>
+Philip Potter <philip.potter@digital.cabinet-office.gov.uk> <philipgpotter@gmail.com>
+Richard Boulton <richard.boulton@digital.cabinet-office.gov.uk> Richard Boulton <richard@tartarus.org>
+Rob Young <rob.young@digital.cabinet-office.gov.uk>
+Rob Young <rob.young@digital.cabinet-office.gov.uk> <bubblenut@gmail.com>
+Rory MacDonald <rory@madetech.com> <rory@madebymade.co.uk>
+Rosa Fox <rosa.fox@digital.cabinet-office.gov.uk> <rosafox89@gmail.com>
+Rosa Fox <rosa.fox@digital.cabinet-office.gov.uk> <rosafox@gds0259.local>
+Rosa Fox <rosa.fox@digital.cabinet-office.gov.uk> <rosafox@gds3733.local>
+Ross Jones <ross@mailbolt.com> <ross@servercode.co.uk>
+Ruben Arakelyan <ruben.arakelyan@digital.cabinet-office.gov.uk> <ruben@arakelyan.uk>
+Ruben Arakelyan <ruben.arakelyan@digital.cabinet-office.gov.uk> <ruben@ra.me.uk>
+Russell Bate <russell.bate@digital.cabinet-office.gov.uk> <rjbate@users.noreply.github.com>
+Russell Bate <russell.bate@digital.cabinet-office.gov.uk> <russellbate@gds3902.local>
+Sam Cook <sam.cook@digital.cabinet-office.gov.uk> <sam.lindenrathen@gmail.com>
+Sam J Sharpe <sam.sharpe@digital.cabinet-office.gov.uk>
+Sam J Sharpe <sam.sharpe@digital.cabinet-office.gov.uk> <samjsharpe@users.noreply.github.com>
+shodhan sheth <shodhan.sheth@digital.cabinet-office.gov.uk>
+shodhan sheth <shodhan.sheth@digital.cabinet-office.gov.uk> <shodhan.sheth@digital.cabinet-office.gov.co.uk>
+shodhan sheth <shodhan.sheth@digital.cabinet-office.gov.uk> <shodhan.sheth@gmail.com>
+Simon Hughesdon <simon.hughesdon@digital.cabinet-office.gov.uk> <sihugh@users.noreply.github.com>
+Sneha Somwanshi <sneha.vishwas-somwanshi@digital.cabinet-office.gov.uk>
+Sneha Somwanshi <sneha.vishwas-somwanshi@digital.cabinet-office.gov.uk> <snehaso@thoughtworks.com>
+Stephen Harker <stephen.harker@digital.cabinet-office.gov.uk> <stephen.harker@gmail.com>
+Steve Laing <steve.laing@digital.cabinet-office.gov.uk>
+Steve Laing <steve.laing@digital.cabinet-office.gov.uk> <developer@laingsolutions.com>
+Steve Laing <steve.laing@digital.cabinet-office.gov.uk> <steve.laing@gmail.com>
+Stuart Gale <stuart.gale@digital.cabinet-office.gov.uk> <bishboria@gmail.com>
+suthagarht <suthagar.kathirkamathamby@digital.cabinet-office.gov.uk> <suthagarht@gmail.com>
+Suzanne Hamilton <suzanne.hamilton@digital.cabinet-office.gov.uk> <suzanne.m.hamilton@gmail.com>
+Suzanne Hamilton <suzanne.hamilton@digital.cabinet-office.gov.uk> <suzannehamilton@users.noreply.github.com>
+Tadas Tamosauskas <tadas@pdfcv.com> <tadas.tamosauskas@gmail.com>
+Tasmin Steer <tasminsteer@hotmail.com> <ts12569@my.bristol.ac.uk>
+Tatiana Stantonian <tatiana.stantonian@digital.cabinet-office.gov.uk>
+Tatiana Stantonian <tatiana.stantonian@digital.cabinet-office.gov.uk> <binaryberry@gmail.com>
+Tatiana Stantonian <tatiana.stantonian@digital.cabinet-office.gov.uk> <tatianastantonian@gds3822.local>
+Tatiana Stantonian <tatiana.stantonian@digital.cabinet-office.gov.uk> <tatiana.soukiassian@digital.cabinet-office.gov.uk>
+Tekin Suleyman <tekin@tekin.co.uk> <tekin.suleyman@digital.cabinet-office.gov.uk>
+Thomas Leese <thomas.leese@digital.cabinet-office.gov.uk> <thomas@leese.io>
+Tijmen Brommet <tijmen.brommet@digital.cabinet-office.gov.uk>
+Tijmen Brommet <tijmen.brommet@digital.cabinet-office.gov.uk>  <tijmen@gmail.com>
+Timothy Mower <timothy.mower@digital.cabinet-office.gov.uk> <timothy.mower@gmail.com>
+Tom Booth <tom.booth@digital.cabinet-office.gov.uk>
+Tom Booth <tom.booth@digital.cabinet-office.gov.uk> <tombooth@gmail.com>
+Tom Byers <tombaromba@gmail.com>
+Tom Byers <tombaromba@gmail.com> <tombyers@ubuntu.localdomain>
+Tom Natt <github@tomnatt.com>
+Tom Gladhill <tom.gladhill@digital.cabinet-office.gov.uk> <whoojemaflip@gmail.com>
+Tom Sabin <tom.sabin@unboxed.co> <tom.sabin@digital.cabinet-office.gov.uk>
+Tommy Palmer <tommy.palmer@digital.cabinet-office.gov.uk> <hi@tommyp.org>
+Tommy Palmer <tommy.palmer@digital.cabinet-office.gov.uk> <tommypalmer@GSD3510.local>
+Uttam Kini <uttam.kini@digital.cabinet-office.gov.uk> <uttamk@gds-vm.(none)>
+Uttam Kini <uttam.kini@digital.cabinet-office.gov.uk> <uttamkini@gmail.com>
+Vanita Barrett <vanitabarrett@gds3834.local> <vanitabarrett@gds6198.local>
+Vinay Patel <vinay.patel@digital.cabinet-office.gov.uk> <mail@vinayvinay.com>
+Will Tomlins <will.tomlins@unboxedconsulting.com> <will@tomlins.org.uk>
+Yael <ysembira@thoughtworks.com> <yael.sembira-nahum@digital.cabinet-office.gov.uk>


### PR DESCRIPTION
This standardizes the display of people's names and emails in git blame
and git shortlog. git log can be told to use it as well with `git log
--use-mailmap`