### PR TITLE
Fix monitoring in CI again

### DIFF
--- a/modules/monitoring/manifests/init.pp
+++ b/modules/monitoring/manifests/init.pp
@@ -20,12 +20,12 @@ class monitoring (
 
   include govuk_htpasswd
   include monitoring::contacts
+  include monitoring::event_handlers
 
   unless $ci_environment {
     # Monitoring server only.
     include monitoring::checks
     include monitoring::edge
-    include monitoring::event_handlers
     include monitoring::pagerduty_drill
     include monitoring::uptime_collector
   }


### PR DESCRIPTION
I'm trying again, since 53fb3364a2502c75dcf941ef5b0a2b3fdc77f872 failed.

Licensify has a dependency on event_handlers which restarts apps if they trigger memory alerts.