### PR TITLE
Tag sidekiq logs with sidekiq

### DIFF
--- a/modules/govuk/manifests/app.pp
+++ b/modules/govuk/manifests/app.pp
@@ -378,6 +378,7 @@ define govuk::app (
     paths  => ["/var/apps/${title}/log/sidekiq*.log"],
     fields => {'application' => $title},
     json   => {'add_error_key' => true},
+    tags   => ['sidekiq'],
   }
 
   # FIXME: when we have migrated all apps to output logs to /var/log this


### PR DESCRIPTION
This is to make them easier to filter by since they're no longer flagged
as a specific *-sidekiq application.