### PR TITLE
Use the Xenial HWE stack on Trusty machines

### DIFF
--- a/hieradata/class/licensify_lb.yaml
+++ b/hieradata/class/licensify_lb.yaml
@@ -1,5 +1,6 @@
 ---
 
+base::supported_kernel::enabled: false
 hosts::production::external_licensify: false
 
 hosts::production::licensify::app_hostnames:

--- a/hieradata/class/puppetmaster.yaml
+++ b/hieradata/class/puppetmaster.yaml
@@ -1,4 +1,5 @@
 ---
 
+base::supported_kernel::enabled: false
 govuk_postgresql::server::listen_addresses: localhost
 govuk_postgresql::server::max_connections: 100

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -64,7 +64,7 @@ backup::offsite::jobs:
     # CDN logs are backed up unencrypted because they don't contain any sensitive information
 
 base::shell::shell_prompt_string: 'production'
-base::supported_kernel::enabled: true
+base::supported_kernel::enabled: false
 
 environment_ip_prefix: '10.3'
 

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -4,7 +4,7 @@ app_domain: 'staging.publishing.service.gov.uk'
 backup::server::backup_hour: 9
 
 base::shell::shell_prompt_string: 'staging'
-base::supported_kernel::enabled: true
+base::supported_kernel::enabled: false
 
 cron::daily_hour: 6
 

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -3,7 +3,7 @@ app_domain: "integration.publishing.service.gov.uk"
 app_domain_internal: "integration.govuk-internal.digital"
 
 base::shell::shell_prompt_string: 'integration'
-base::supported_kernel::enabled: true
+base::supported_kernel::enabled: false
 
 cron::weekly_dow: 1
 cron::daily_hour: 6

--- a/modules/base/files/check_supported_kernel.py
+++ b/modules/base/files/check_supported_kernel.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python
 
+from decimal import Decimal
+import math
 import os
 import sys
 
@@ -20,19 +22,12 @@ def unknown(message):
     nagios_exit("UNKNOWN: " + message, 3)
 
 try:
-    version = os.uname()[2].split('.')
-    major_version = int(version[0])
-    minor_version = int(version[1])
-    if major_version == 3:
-        if minor_version == 13 :
-            ok("Running the recommended kernel version")
-        elif minor_version in [ 11, 8, 5 ]:
-            critical("Not running a supported kernel version, see https://wiki.ubuntu.com/1204_HWE_EOL - may just need to reboot")
-        elif minor_version == 2:
-            warning("Not running a recommended kernel version, upgrade to linux-generic-lts-trusty series, see https://wiki.ubuntu.com/1204_HWE_EOL - may just need to reboot")
-        else:
-            critical("Unknown kernel - not expecting Ubuntu machines to run a 3.{0} kernel".format(minor_version))
+    version = Decimal("{0}.{1}".format(*os.uname()[2].split('.')))
+    if version < Decimal('4.4'):
+        critical("Not running a supported kernel version, see https://wiki.ubuntu.com/1404_HWE_EOL - may just need to reboot")
+    elif version >= 5:
+        unknown("Not expecting a kernel major version of {0} - see https://wiki.ubuntu.com/1404_HWE_EOL".format(math.floor(version)))
     else:
-        unknown("Not expecting a kernel major version of {0} - see https://wiki.ubuntu.com/1204_HWE_EOL".format(major_version))
+        ok("Running the recommended kernel version")
 except Exception, e:
     unknown("Unknown error: {0}".format(e))

--- a/modules/base/manifests/supported_kernel.pp
+++ b/modules/base/manifests/supported_kernel.pp
@@ -9,8 +9,13 @@
 #   and monitored or not.
 #   Default: false
 #
+# [*check_enabled*]
+#   Controls whether the kernel version alert is enabled or not.
+#   Default: false
+#
 class base::supported_kernel (
   $enabled = false,
+  $check_enabled = false,
 ) {
   # Required for hwe-support-status tool
   ensure_packages(['update-manager-core'])
@@ -32,12 +37,13 @@ class base::supported_kernel (
     }
   }
   if ($enabled) {
-      if ($latest_lts_supported != 'none') {
-        ensure_packages([
-                "linux-generic-lts-${latest_lts_supported}",
-                "linux-image-generic-lts-${latest_lts_supported}",
-            ])
+    if ($latest_lts_supported != 'none') {
+      ensure_packages([
+              "linux-generic-lts-${latest_lts_supported}",
+              "linux-image-generic-lts-${latest_lts_supported}",
+          ])
 
+      if ($check_enabled) {
         @@icinga::check { "check_supported_kernel_${::hostname}":
             check_command       => 'check_nrpe_1arg!check_supported_kernel.cfg',
             service_description => 'machine is not running a supported kernel',
@@ -45,5 +51,6 @@ class base::supported_kernel (
             notes_url           => 'https://wiki.ubuntu.com/1404_HWE_EOL',
         }
       }
+    }
   }
 }

--- a/modules/base/manifests/supported_kernel.pp
+++ b/modules/base/manifests/supported_kernel.pp
@@ -1,6 +1,14 @@
-# This class will ensure that the machine is using a kernel which is currently
-# supported upstream. It assumes Ubuntu Precise at the moment, but could be
-# extended if we upgrade to Trusty
+# == Class: assets
+#
+# Ensures a machine is running the correct HWE kernel
+#
+# === Parameters
+#
+# [*enabled*]
+#   Controls whether the correct HWE kernel package is installed
+#   and monitored or not.
+#   Default: false
+#
 class base::supported_kernel (
   $enabled = false,
 ) {
@@ -16,8 +24,8 @@ class base::supported_kernel (
   }
 
   case $::lsbdistcodename {
-    'precise': {
-        $latest_lts_supported = 'trusty'
+    'trusty': {
+        $latest_lts_supported = 'xenial'
     }
     default: {
         $latest_lts_supported = 'none'
@@ -31,10 +39,10 @@ class base::supported_kernel (
             ])
 
         @@icinga::check { "check_supported_kernel_${::hostname}":
-            check_command       => 'check_nrpe_1arg!check_supported_kernel',
+            check_command       => 'check_nrpe_1arg!check_supported_kernel.cfg',
             service_description => 'machine is not running a supported kernel',
             host_name           => $::fqdn,
-            notes_url           => 'https://wiki.ubuntu.com/1204_HWE_EOL',
+            notes_url           => 'https://wiki.ubuntu.com/1404_HWE_EOL',
         }
       }
   }

--- a/modules/base/spec/classes/base__supported_kernel_spec.rb
+++ b/modules/base/spec/classes/base__supported_kernel_spec.rb
@@ -2,23 +2,23 @@ require_relative '../../../../spec_helper'
 
 describe 'base::supported_kernel', :type => :class do
 
-  describe 'disabled on precise (default)' do
-    let(:facts) {{ 'lsbdistcodename' => 'precise' }}
+  describe 'disabled on trusty (default)' do
+    let(:facts) {{ 'lsbdistcodename' => 'trusty' }}
     it do
         is_expected.to contain_package('update-manager-core')
         is_expected.not_to contain_package('linux-generic-lts-trusty')
     end
   end
 
-  describe 'enabled on precise' do
+  describe 'enabled on trusty' do
     let(:params) {{ 'enabled' => true }}
-    let(:facts) {{ 'lsbdistcodename' => 'precise' }}
-    it { is_expected.to contain_package('linux-generic-lts-trusty') }
+    let(:facts) {{ 'lsbdistcodename' => 'trusty' }}
+    it { is_expected.to contain_package('linux-generic-lts-xenial') }
   end
 
-  describe 'enabled on trusty' do
-    let(:facts) {{ 'lsbdistcodename' => 'trusty' }}
-    it { is_expected.not_to contain_package('linux-generic-lts-trusty') }
+  describe 'enabled on precise' do
+    let(:facts) {{ 'lsbdistcodename' => 'precise' }}
+    it { is_expected.not_to contain_package('linux-generic-lts-xenial') }
   end
 
 end


### PR DESCRIPTION
Install the Xenial kernel on Trusty (14.04 LTS) machines in order to
get the latest kernel updates, including for Spectre/Meltdown.

Change the icinga check script to check for this kernel version, and
remove the ability to check our precise machines, for simplicity.

We only run precise on two classes of machines in production -
puppetmaster and licensify-lb. We need to patch these manually for now.

Test this kernel on Carrenza integration only for now. For AWS, we should 
bake an AMI running this kernel, deploy it then enable the check.

See https://wiki.ubuntu.com/Kernel/LTSEnablementStack
