### PR TITLE
Update asset_routes in AWS hieradata

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1014,6 +1014,7 @@ rcs::tmptime: '7'
 # Note: it's important that all targets here have matching host entries both in
 # production, and on the dev VM, otherwise nginx will fail to start.
 router::assets_origin::asset_routes:
+  '/asset-manager': "asset-manager"
   '/calculators/': "calculators"
   '/calendars/': "calendars"
   '/collections/': "collections"
@@ -1024,6 +1025,8 @@ router::assets_origin::asset_routes:
   '/government/assets/': "whitehall-frontend"
   '/government/placeholder': "whitehall-frontend"
   '/government/uploads/': "whitehall-frontend"
+  '/government/uploads/system/uploads/organisation/logo/': "static"
+  '/government/uploads/system/uploads/consultation_response_form_data/file/': "static"
   '/government-frontend/': "government-frontend"
   '/info-frontend/': "info-frontend"
   '/manuals-frontend/': "manuals-frontend"


### PR DESCRIPTION
These routes have been updated in hieradata/common.yaml since it was
forked to create hieradata_aws/common.yaml. See the following commits
for the details of the changes:

* f295da5ad42a16b52ee6c6fae9e7ad07fce73f4a
* 17e2e1d4dbfd9d26d41837c0a50a67a4b4f079c4
* 7ade2aaf9ca63c6c46ef38d42b03a8b4513665ab