### PR TITLE
AWS add missing redis parameters to asset-manager

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -332,6 +332,10 @@ govuk::apps::asset_manager::mongodb_nodes:
   - 'mongo-1'
   - 'mongo-2'
   - 'mongo-3'
+
+govuk::apps::asset_manager::redis_host: "%{hiera('sidekiq_host')}"
+govuk::apps::asset_manager::redis_port: "%{hiera('sidekiq_port')}"
+
 govuk::apps::authenticating_proxy::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
 
 govuk::apps::bouncer::db_hostname: "transition-postgresql-standby"


### PR DESCRIPTION
On AWS asset-manager is trying to connect with Redis
on localhost, it's missing the host and port parameters
already present in Carrenza Hieradata.