### PR TITLE
AWS add missing asset-manager sidekiq_monitoring parameters

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -521,6 +521,8 @@ govuk::apps::service_manual_publisher::db_hostname: 'postgresql-primary'
 
 govuk::apps::service_manual_publisher::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 
+govuk::apps::sidekiq_monitoring::asset_manager_redis_host: "%{hiera('govuk::apps::asset_manager::redis_host')}"
+govuk::apps::sidekiq_monitoring::asset_manager_redis_port: "%{hiera('govuk::apps::asset_manager::redis_port')}"
 govuk::apps::sidekiq_monitoring::content_performance_manager_redis_host: "%{hiera('govuk::apps::content_performance_manager::redis_host')}"
 govuk::apps::sidekiq_monitoring::content_performance_manager_redis_port: "%{hiera('govuk::apps::content_performance_manager::redis_port')}"
 govuk::apps::sidekiq_monitoring::content_tagger_redis_host: "%{hiera('govuk::apps::content_tagger::redis_host')}"


### PR DESCRIPTION
In addition to 95cf58b, add missing parameters to AWS Hieradata for
asset-manager sidekiq_monitoring.

The original configuration on Carrenza was requested in
https://github.com/alphagov/govuk-puppet/pull/6501
