### PR TITLE
Serve Whitehall's promo feature images from Asset Manager

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1622,6 +1622,7 @@ router::assets_origin::asset_routes:
   '/government/uploads/': "whitehall-frontend"
   '/government/uploads/system/uploads/organisation/logo/': "static"
   '/government/uploads/system/uploads/consultation_response_form_data/file/': "static"
+  '/government/uploads/system/uploads/promotional_feature_item/image/': "static"
   '/government-frontend/': "government-frontend"
   '/info-frontend/': "info-frontend"
   '/manuals-frontend/': "manuals-frontend"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1035,6 +1035,7 @@ router::assets_origin::asset_routes:
   '/government/uploads/': "whitehall-frontend"
   '/government/uploads/system/uploads/organisation/logo/': "static"
   '/government/uploads/system/uploads/consultation_response_form_data/file/': "static"
+  '/government/uploads/system/uploads/promotional_feature_item/image/': "static"
   '/government-frontend/': "government-frontend"
   '/info-frontend/': "info-frontend"
   '/manuals-frontend/': "manuals-frontend"

--- a/modules/govuk/templates/static_extra_nginx_config.conf.erb
+++ b/modules/govuk/templates/static_extra_nginx_config.conf.erb
@@ -19,7 +19,8 @@ location /robots.txt {
 <% [
   '/media/',
   '/government/uploads/system/uploads/organisation/logo/',
-  '/government/uploads/system/uploads/consultation_response_form_data/file/'
+  '/government/uploads/system/uploads/consultation_response_form_data/file/',
+  '/government/uploads/system/uploads/promotional_feature_item/image/'
 ].each do |path_to_be_proxied_to_asset_manager| %>
 
   location ~ ^<%= path_to_be_proxied_to_asset_manager %> {


### PR DESCRIPTION
We've been uploading all new promo feature images to Asset Manager since
https://github.com/alphagov/whitehall/pull/3602 was merged and deployed.

We uploaded all historical promo feature images on 18 Dec 2017[1].

[1]:
https://github.com/alphagov/asset-manager/issues/215#issuecomment-352438264