### PR TITLE
Add Ruby 2.5.0 support and update Bundler

### DIFF
--- a/modules/govuk_rbenv/manifests/all.pp
+++ b/modules/govuk_rbenv/manifests/all.pp
@@ -21,23 +21,23 @@ class govuk_rbenv::all (
   }
 
   rbenv::version { '2.2.8':
-    bundler_version  => '1.15.1',
+    bundler_version  => '1.16.1',
     install_gem_docs => false,
   }
   rbenv::version { '2.3.1':
-    bundler_version  => '1.15.1',
+    bundler_version  => '1.16.1',
     install_gem_docs => false,
   }
   rbenv::version { '2.3.5':
-    bundler_version  => '1.15.1',
+    bundler_version  => '1.16.1',
     install_gem_docs => false,
   }
   rbenv::version { '2.4.0':
-    bundler_version  => '1.15.1',
+    bundler_version  => '1.16.1',
     install_gem_docs => false,
   }
   rbenv::version { '2.4.2':
-    bundler_version  => '1.15.1',
+    bundler_version  => '1.16.1',
     install_gem_docs => false,
   }
 

--- a/modules/govuk_rbenv/manifests/all.pp
+++ b/modules/govuk_rbenv/manifests/all.pp
@@ -20,27 +20,7 @@ class govuk_rbenv::all (
     key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
   }
 
-  rbenv::version { '2.1.5':
-    bundler_version  => '1.15.1',
-    install_gem_docs => false,
-  }
-  rbenv::version { '2.2.2':
-    bundler_version  => '1.15.1',
-    install_gem_docs => false,
-  }
-  rbenv::version { '2.2.3':
-    bundler_version  => '1.15.1',
-    install_gem_docs => false,
-  }
-  rbenv::version { '2.2.4':
-    bundler_version  => '1.15.1',
-    install_gem_docs => false,
-  }
   rbenv::version { '2.2.8':
-    bundler_version  => '1.15.1',
-    install_gem_docs => false,
-  }
-  rbenv::version { '2.3.0':
     bundler_version  => '1.15.1',
     install_gem_docs => false,
   }

--- a/modules/govuk_rbenv/manifests/all.pp
+++ b/modules/govuk_rbenv/manifests/all.pp
@@ -40,6 +40,10 @@ class govuk_rbenv::all (
     bundler_version  => '1.16.1',
     install_gem_docs => false,
   }
+  rbenv::version { '2.5.0':
+    bundler_version  => '1.16.1',
+    install_gem_docs => false,
+  }
 
   # These aliases re solve .ruby-version 2.x to an installed Ruby version.
   rbenv::alias { '2.2':
@@ -50,5 +54,8 @@ class govuk_rbenv::all (
   }
   rbenv::alias { '2.4':
     to_version => '2.4.2',
+  }
+  rbenv::alias { '2.5':
+    to_version => '2.5.0',
   }
 }


### PR DESCRIPTION
This is dependent on https://github.com/alphagov/packager/pull/141 and the .deb being added to Aptly. Both are now done.

This adds Ruby 2.5.0, updates Bundler to current (1.16.1) and removes Rubies that are no longer available on Aptly.

