### PR TITLE
Move setting the draft-origin URI to the deploy config

### DIFF
--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -138,11 +138,6 @@ define govuk::app::config (
         varname => "PLEK_SERVICE_${app_env_var}_URI",
         value   => "https://${title}.${app_domain}",
       }
-
-      govuk::app::envvar { 'PLEK_SERVICE_DRAFT_ORIGIN_URI':
-        varname => 'PLEK_SERVICE_DRAFT_ORIGIN_URI',
-        value   => "https://draft-origin.${app_domain}",
-      }
     }
 
     if $app_type == 'rack' and $unicorn_herder_timeout != 'NOTSET' {

--- a/modules/govuk/manifests/deploy/config.pp
+++ b/modules/govuk/manifests/deploy/config.pp
@@ -104,6 +104,10 @@ class govuk::deploy::config(
       # By default traffic should route internally
       'GOVUK_APP_DOMAIN':           value => $app_domain_internal;
       'GOVUK_APP_DOMAIN_INTERNAL':  value => $app_domain_internal;
+      # Apps lookup the draft origin to link users to, so that they
+      # can preview content, therefore it needs to be the Publishing
+      # domain
+      'PLEK_SERVICE_DRAFT_ORIGIN_URI': value => "https://draft-origin.${app_domain}";
       # We do not host Licensify in AWS, so need to redirect to
       # it's external domain
       'PLEK_SERVICE_LICENSIFY_URI': value => "https://licensify.${licensify_app_domain}";


### PR DESCRIPTION
This is more consistent, and it avoids problems with the draft-origin
app.