### PR TITLE
Update record taxonomy metrics Jenkins job

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/record_taxonomy_metrics.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/record_taxonomy_metrics.yaml.erb
@@ -19,4 +19,4 @@
           
           CONTENT_TAGGER=$(govuk_node_list --single-node -c backend)
           
-          ssh deploy@$CONTENT_TAGGER "cd /var/apps/content-tagger && govuk_setenv content-tagger bundle exec rake metrics:taxonomy:count_content_per_level metrics:taxonomy:record_content_coverage_metrics"
+          ssh deploy@$CONTENT_TAGGER "cd /var/apps/content-tagger && govuk_setenv content-tagger bundle exec rake metrics:taxonomy:record_all"


### PR DESCRIPTION
Running the tasks to record taxonomy metrics is consolidated in
a single 'record_all' Rake task. This change changes the Jenkins
job to run this single task instead of the individual recording
tasks.

See also: https://github.com/alphagov/content-tagger/pull/611