### PR TITLE
Enable Rummager bulk reindex in AWS Integration

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -501,8 +501,10 @@ govuk::apps::release::github_username: "govuk-ci"
 
 govuk::apps::rummager::nagios_memory_warning: 4600
 govuk::apps::rummager::nagios_memory_critical: 4900
+govuk::apps::rummager::enable_bulk_reindex_listener: true
 govuk::apps::rummager::enable_publishing_listener: true
 govuk::apps::rummager::enable_govuk_index_listener: true
+govuk::apps::rummager::rabbitmq::enable_bulk_reindex_listener: true
 govuk::apps::rummager::rabbitmq::enable_govuk_index_listener: true
 govuk::apps::rummager::rabbitmq::enable_publishing_listener: true
 govuk::apps::rummager::rabbitmq_user: 'rummager-v2'


### PR DESCRIPTION
This was missed from AWS hieradata