### PR TITLE
Test gems against Ruby 2.3, 2.4 & 2.5

### DIFF
--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -575,7 +575,7 @@ def runTests(String test_task = 'default') {
  * addition to the versions currently supported by all GOV.UK applications
  */
 def testGemWithAllRubies(extraRubyVersions = []) {
-  def rubyVersions = ["2.2", "2.3", "2.4"]
+  def rubyVersions = ["2.3", "2.4", "2.5"]
 
   rubyVersions.addAll(extraRubyVersions)
 


### PR DESCRIPTION
I have removed Ruby 2.2 as it is almost end of life and nearly all of
our apps are running on Ruby 2.4 now so 2.2 compatibility seems the
exception rather than the rule.

Ruby 2.5 is out now and this will test our gems against that.