### PR TITLE
Fix Nginx static configuration

### DIFF
--- a/modules/govuk/templates/static_extra_nginx_config.conf.erb
+++ b/modules/govuk/templates/static_extra_nginx_config.conf.erb
@@ -28,7 +28,7 @@ location /robots.txt {
     proxy_set_header X-Forwarded-Server $host;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Host $host;
-    proxy_pass <%= @enable_ssl or @proxy_pass_asset_manager_host_https ? 'https' : 'http' %>://<%= @asset_manager_host %>;
+    proxy_pass <%= @enable_ssl || @proxy_pass_asset_manager_host_https ? 'https' : 'http' %>://<%= @asset_manager_host %>;
 
     # Explicitly re-include Strict-Transport-Security header, this
     # forces nginx not to clear Cache-Control headers further up the


### PR DESCRIPTION
Changes in ff60dcd are causing the protocol to be the string 'true'
when `enable_ssl` is true.