### PR TITLE
AWS update govuk_node_list for multiple network interfaces

### DIFF
--- a/modules/govuk_scripts/templates/govuk_node_list_aws.erb
+++ b/modules/govuk_scripts/templates/govuk_node_list_aws.erb
@@ -42,7 +42,7 @@ def ec2_nodes(stackname, nodeclass=None):
 
     hosts = []
     for instance in nodes:
-        hosts.append((instance['Instances'][0]['NetworkInterfaces'][0]['PrivateDnsName']))
+        hosts.append((instance['Instances'][0]['PrivateDnsName']))
 
     return(hosts)
 


### PR DESCRIPTION
The NetworkInterfaces.0.PrivateDnsName not always points to the device
ID 0 when an instance has several network interfaces attached. For instance,
after deploying the new router-backend machines, this resource pointed to
the DNS of the reserved IP, that is not open on SSH.

We could select the top PrivateDnsName value or select a network interface
where the device id is 0, but the first option looks simpler.