### PR TITLE
Update puppet pinfile

### DIFF
--- a/development-vm/Pinfile
+++ b/development-vm/Pinfile
@@ -42,7 +42,7 @@ process :'link-checker-api' => [:'link-checker-api-sidekiq']
 process :'link-checker-api-sidekiq'
 process :'local-links-manager' => [:'link-checker-api']
 process :'manuals-frontend' => [:static, :'content-store']
-process :'manuals-publisher' => ['asset-manager', :'publishing-api']
+process :'manuals-publisher' => ['asset-manager', :'publishing-api', :'link-checker-api']
 process :mapit
 process :maslow
 process :'policy-publisher' => [:'publishing-api']

--- a/development-vm/Pinfile
+++ b/development-vm/Pinfile
@@ -72,7 +72,7 @@ process :static
 process :support => [:'support-api']
 process :'support-api'
 process :transition
-process :travel_advice_publisher => [:static, 'asset-manager', :'travel_advice_publisher_worker', :'email-alert-api']
+process :travel_advice_publisher => [:static, 'asset-manager', :'travel_advice_publisher_worker', :'email-alert-api', :'link-checker-api']
 process :travel_advice_publisher_worker
 process :whitehall => [:'asset-manager', :static, :'publishing-api', :rummager, :'whitehall-worker', :'link-checker-api']
 

--- a/development-vm/Pinfile
+++ b/development-vm/Pinfile
@@ -74,7 +74,7 @@ process :'support-api'
 process :transition
 process :travel_advice_publisher => [:static, 'asset-manager', :'travel_advice_publisher_worker', :'email-alert-api']
 process :travel_advice_publisher_worker
-process :whitehall => [:'asset-manager', :static, :'publishing-api', :rummager, :'whitehall-worker']
+process :whitehall => [:'asset-manager', :static, :'publishing-api', :rummager, :'whitehall-worker', :'link-checker-api']
 
 # pseudo processes to reflect what's needed for www.dev.gov.uk to work at all
 # www.dev.gov.uk will still depend on the relevant other frontend applications being

--- a/development-vm/Pinfile
+++ b/development-vm/Pinfile
@@ -46,7 +46,7 @@ process :'manuals-publisher' => ['asset-manager', :'publishing-api', :'link-chec
 process :mapit
 process :maslow
 process :'policy-publisher' => [:'publishing-api']
-process :publisher => [:'publishing-api', 'publisher-worker', :calendars] # for some requests also uses: mapit
+process :publisher => [:'publishing-api', 'publisher-worker', :calendars, :'link-checker-api'] # for some requests also uses: mapit
 process :'publishing-api-read' => [:'publishing-api-web']
 process :'publishing-api' => [:'publishing-api-web', :'content-store', :'draft-content-store', :'router-api', :'draft-router-api', :'publishing-api-worker']
 process :'publishing-api-worker' => [:'content-store', :'router-api']


### PR DESCRIPTION
Pinfile updated so apps (whitehall, publisher, manuals publisher and travel advice publisher) run the linkchecker api when bowl command is used.

https://trello.com/c/cFtuQdaz/99-update-pinfile
https://github.com/alphagov/whitehall/pull/3557
https://github.com/alphagov/publisher/pull/728
https://github.com/alphagov/manuals-publisher/pull/1230
https://github.com/alphagov/travel-advice-publisher/pull/259