### PR TITLE
A clone dependent function for govuk_jenkins

### DIFF
--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -369,6 +369,35 @@ def checkoutFromGitHubWithSSH(String repository, Map options = [:]) {
 }
 
 /**
+ * Checkout a dependent repo.
+ * This function acts as a wrapper around checkoutFromGitHubWithSSH with
+ * options tailored towards the needs of a secondary repo cloned as part of a
+ * pipeline job
+ *
+ * It can accept an optional closure that is run within the directory that has
+ * been cloned
+ */
+def checkoutDependent(String repository, options = [:], Closure closure = null) {
+  def defaultOptions = [
+    branch: "master",
+    changelog: false,
+    directory: "tmp/${repository}",
+    poll: false
+  ]
+  options = defaultOptions << options
+
+  stage("Cloning ${repository}") {
+    checkoutFromGitHubWithSSH(repository, options)
+  }
+
+  if (closure) {
+    dir(options.directory) {
+      closure.call()
+    }
+  }
+}
+
+/**
   * Check if the git HEAD is ahead of master.
   * This will be false for development branches and true for release branches,
   * and master itself.

--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -153,10 +153,7 @@ def buildProject(Map options = [:]) {
       setEnvar("DISPLAY", ":99")
     }
 
-    stage("Set up content schema dependency") {
-      contentSchemaDependency(params.SCHEMA_BRANCH)
-      setEnvar("GOVUK_CONTENT_SCHEMAS_PATH", "tmp/govuk-content-schemas")
-    }
+    contentSchemaDependency(params.SCHEMA_BRANCH)
 
     stage("bundle install") {
       if (isGem()) {
@@ -572,14 +569,8 @@ def precompileAssets() {
  * Clone govuk-content-schemas dependency for contract tests
  */
 def contentSchemaDependency(String schemaGitCommit = 'deployed-to-production') {
-  sshagent(['govuk-ci-ssh-key']) {
-    echo 'Cloning govuk-content-schemas'
-    sh('rm -rf tmp/govuk-content-schemas')
-    sh('git clone git@github.com:alphagov/govuk-content-schemas.git tmp/govuk-content-schemas')
-    dir("tmp/govuk-content-schemas") {
-      sh("git checkout ${schemaGitCommit}")
-    }
-    env."GOVUK_CONTENT_SCHEMAS_PATH" = "tmp/govuk-content-schemas"
+  checkoutDependent("govuk-content-schemas", [ branch: schemaGitCommit ]) {
+    setEnvar("GOVUK_CONTENT_SCHEMAS_PATH", pwd())
   }
 }
 

--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -142,10 +142,6 @@ def buildProject(Map options = [:]) {
       checkoutFromGitHubWithSSH(repoName)
     }
 
-    stage("Clean up workspace") {
-      cleanupGit()
-    }
-
     stage("Merge master") {
       mergeMasterBranch()
     }
@@ -326,7 +322,7 @@ def checkoutFromGitHubWithSSH(String repository, Map options = [:]) {
   def defaultOptions = [
     branch: null,
     changelog: true,
-    directory: null,
+    location: null,
     org: "alphagov",
     poll: true,
     host: "github.com"
@@ -340,7 +336,11 @@ def checkoutFromGitHubWithSSH(String repository, Map options = [:]) {
     branches = scm.branches
   }
 
-  def extensions = []
+  def extensions = [
+    [
+      $class: "CleanCheckout"
+    ]
+  ]
 
   if(options.directory) {
     extensions << [


### PR DESCRIPTION
It's common that in building a repo we may need to clone another repo, we've solved this problem in different ways: [exhibit A](https://github.com/alphagov/gds-api-adapters/blob/master/Jenkinsfile#L91-L117), [exhibit B](https://github.com/alphagov/publishing-api/blob/master/Jenkinsfile#L72-L99) and this can be quite verbose and lead to inconsistencies.

This PR introduces a new function `cloneDependent` which can be used to perform this operation in a consistent succinct method. Example:

```groovy
  govuk.checkoutDependent("publishing-api", [ branch: PUBLISHING_API_BRANCH ]) {
    stage("Run publishing-api pact") {
      govuk.bundleApp()
      lock("publishing-api-$NODE_NAME-test") {
        govuk.runRakeTask("db:reset")
        govuk.runRakeTask("pact:verify:branch[${env.BRANCH_NAME}]")
      }
    }
  }
```

This uses the GitSCM Jenkins plugin to clone the repositories and uses the same function that we use to clone the main one of a repo. I believe there's a bunch of upsides to using this such as smaller clones, more consistent reset handling. However there a couple of downsides. One is that it will show each checked out revision on the build screen, example: https://ci.integration.publishing.service.gov.uk/job/gds-api-adapters/job/jenkinsfile/29/ and the other that it will set env vars of GIT_URL, etc to the last repo cloned. From my searching we don't use any of those env vars so it doesn't seem like it would have an affect.

An example of this building is https://ci.integration.publishing.service.gov.uk/job/gds-api-adapters/job/jenkinsfile/29/ - there are also some further details in each commit message.


