### PR TITLE
Restart procfile workers on environment variable changes

### DIFF
--- a/modules/govuk/manifests/app/envvar.pp
+++ b/modules/govuk/manifests/app/envvar.pp
@@ -35,6 +35,10 @@ define govuk::app::envvar (
       content => $nulls_for_newlines_value,
       notify  => Govuk::App::Service[$app],
     }
+
+    if defined(Govuk::Procfile::Worker[$app]) {
+      File["${envdir}/${varname}"] ~> Govuk::Procfile::Worker[$app]
+    }
   } else {
     file { "${envdir}/${varname}":
       ensure  => $ensure,


### PR DESCRIPTION
Previously, if there was a change to environment variables in a deployment the worker processes would not be able to access the new values. Sidekiq automatically reloads the workers so they are running with the latest application code, but the Sidekiq process itself would still be running with old environment variables.

[Trello Card](https://trello.com/c/ffBIwu8R/516-look-into-restarting-procfile-worker-on-email-alert-api-deploy)