### PR TITLE
Remove conditional from the broken link checker job

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/whitehall_run_broken_link_checker.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/whitehall_run_broken_link_checker.yaml.erb
@@ -6,12 +6,7 @@
     description: "<p>Triggers the broken link checker rake task on whitehall-backend-1.</p>"
     builders:
         - shell: |
-        <%- if scope.lookupvar('::aws_migration') %>
-        ssh deploy@$(govuk_node_list -c whitehall_backend --single-node) '
-        <%- else -%>
-        ssh deploy@whitehall-backend-1.backend '
-        <%- end -%>
-        cd /var/apps/whitehall; govuk_setenv whitehall nohup bundle exec rake generate_broken_link_reports[/tmp/bad_link_reports,second-line-content@digital.cabinet-office.gov.uk]'
+            ssh deploy@$(govuk_node_list -c whitehall_backend --single-node) 'cd /var/apps/whitehall; govuk_setenv whitehall nohup bundle exec rake generate_broken_link_reports[/tmp/bad_link_reports,second-line-content@digital.cabinet-office.gov.uk]'
             echo "Broken link checker run"
     triggers:
         - timed: '0 2 1 * *'


### PR DESCRIPTION
The indentation and position of the command is wrong. Rather than
trying to figure out how to layout the erb, lets try removing the
conditional and changing the behaviour not to specify a machine. I've
had a quick look at the rake task being run, and it doesn't look to be
machine dependant.