### PR TITLE
Add whitehall govuk_basic_auth_credentials to link checker api for integration & staging

### DIFF
--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -25,6 +25,7 @@ govuk::apps::email_alert_api::govuk_notify_base_url: 'https://api.staging-notify
 govuk::apps::email_alert_api::govuk_notify_template_id: '76d21ce7-54c3-4fb7-8830-ba3b79287985'
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::kibana::logit_environment: d414187a-2796-4ea7-9b9a-d40c341646d6
+govuk::apps::link_checker_api::govuk_basic_auth_credentials: "%{hiera('http_username')}:%{hiera('http_password')}"
 govuk::apps::publicapi::backdrop_host: 'www.staging.performance.service.gov.uk'
 govuk::apps::publisher::run_fact_check_fetcher: false
 govuk::apps::publisher::fact_check_address_format: 'factcheck+staging-{id}@alphagov.co.uk'

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -14,6 +14,7 @@ govuk::apps::email_alert_api::allow_govdelivery_topic_syncing: true
 govuk::apps::govuk_crawler_worker::enabled: false
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
 govuk::apps::kibana::logit_environment: 2694f14b-6519-4607-81f2-8a2130e5aaec
+govuk::apps::link_checker_api::govuk_basic_auth_credentials: "%{hiera('http_username')}:%{hiera('http_password')}"
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-integration'
 govuk::apps::publishing_api::content_api_prototype: true
 govuk::apps::short_url_manager::instance_name: 'integration'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -24,6 +24,7 @@ govuk::apps::email_alert_api::govuk_notify_base_url: 'https://api.staging-notify
 govuk::apps::email_alert_api::govuk_notify_template_id: '76d21ce7-54c3-4fb7-8830-ba3b79287985'
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::kibana::logit_environment: d414187a-2796-4ea7-9b9a-d40c341646d6
+govuk::apps::link_checker_api::govuk_basic_auth_credentials: "%{hiera('http_username')}:%{hiera('http_password')}"
 govuk::apps::publicapi::backdrop_host: 'www.staging.performance.service.gov.uk'
 govuk::apps::publisher::run_fact_check_fetcher: false
 govuk::apps::publisher::fact_check_address_format: 'factcheck+staging-{id}@alphagov.co.uk'

--- a/modules/govuk/manifests/apps/link_checker_api.pp
+++ b/modules/govuk/manifests/apps/link_checker_api.pp
@@ -53,6 +53,10 @@
 #   The token used to bypass the rate limiting on GOV.uk
 #   Default: undef
 #
+# [*govuk_basic_auth_credentials*]
+#   Basic auth credentials for Whitehall used on integration and staging.
+#   Default: undef
+#
 class govuk::apps::link_checker_api (
   $db_hostname = undef,
   $db_username = 'link_checker_api',
@@ -67,6 +71,7 @@ class govuk::apps::link_checker_api (
   $redis_port = undef,
   $secret_key_base = undef,
   $rate_limit_token = undef,
+  $govuk_basic_auth_credentials = undef,
 ) {
   $app_name = 'link-checker-api'
 
@@ -111,6 +116,13 @@ class govuk::apps::link_checker_api (
     govuk::app::envvar { "${title}-RATE_LIMIT_TOKEN":
       varname => 'RATE_LIMIT_TOKEN',
       value   => $rate_limit_token,
+    }
+  }
+
+  if $govuk_basic_auth_credentials != undef {
+    govuk::app::envvar { "${title}-GOVUK_BASIC_AUTH_CREDENTIALS":
+      varname => 'GOVUK_BASIC_AUTH_CREDENTIALS',
+      value   => $govuk_basic_auth_credentials,
     }
   }
 


### PR DESCRIPTION
This PR adds a new env var to set the basic auth credentials for the link checker API to pass the basic auth challenge on integration.