### PR TITLE
Rename GOV.UK Rate Limit token for Link Checker API

### DIFF
--- a/modules/govuk/manifests/apps/link_checker_api.pp
+++ b/modules/govuk/manifests/apps/link_checker_api.pp
@@ -49,7 +49,7 @@
 #   start.
 #   Default: undef
 #
-# [*rate_limit_token*]
+# [*govuk_rate_limit_token*]
 #   The token used to bypass the rate limiting on GOV.uk
 #   Default: undef
 #
@@ -70,7 +70,7 @@ class govuk::apps::link_checker_api (
   $redis_host = undef,
   $redis_port = undef,
   $secret_key_base = undef,
-  $rate_limit_token = undef,
+  $govuk_rate_limit_token = undef,
   $govuk_basic_auth_credentials = undef,
 ) {
   $app_name = 'link-checker-api'
@@ -112,10 +112,10 @@ class govuk::apps::link_checker_api (
     }
   }
 
-  if $rate_limit_token != undef {
-    govuk::app::envvar { "${title}-RATE_LIMIT_TOKEN":
-      varname => 'RATE_LIMIT_TOKEN',
-      value   => $rate_limit_token,
+  if $govuk_rate_limit_token != undef {
+    govuk::app::envvar { "${title}-GOVUK_RATE_LIMIT_TOKEN":
+      varname => 'GOVUK_RATE_LIMIT_TOKEN',
+      value   => $govuk_rate_limit_token,
     }
   }
 


### PR DESCRIPTION
This better reflects that the token is only used for accessing GOV.UK.