### PR TITLE
Serve Whitehall's take part page images from Asset Manager

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1623,6 +1623,7 @@ router::assets_origin::asset_routes:
   '/government/uploads/system/uploads/organisation/logo/': "static"
   '/government/uploads/system/uploads/consultation_response_form_data/file/': "static"
   '/government/uploads/system/uploads/promotional_feature_item/image/': "static"
+  '/government/uploads/system/uploads/take_part_page/image/': "static"
   '/government-frontend/': "government-frontend"
   '/info-frontend/': "info-frontend"
   '/manuals-frontend/': "manuals-frontend"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1036,6 +1036,7 @@ router::assets_origin::asset_routes:
   '/government/uploads/system/uploads/organisation/logo/': "static"
   '/government/uploads/system/uploads/consultation_response_form_data/file/': "static"
   '/government/uploads/system/uploads/promotional_feature_item/image/': "static"
+  '/government/uploads/system/uploads/take_part_page/image/': "static"
   '/government-frontend/': "government-frontend"
   '/info-frontend/': "info-frontend"
   '/manuals-frontend/': "manuals-frontend"

--- a/modules/govuk/templates/static_extra_nginx_config.conf.erb
+++ b/modules/govuk/templates/static_extra_nginx_config.conf.erb
@@ -20,7 +20,8 @@ location /robots.txt {
   '/media/',
   '/government/uploads/system/uploads/organisation/logo/',
   '/government/uploads/system/uploads/consultation_response_form_data/file/',
-  '/government/uploads/system/uploads/promotional_feature_item/image/'
+  '/government/uploads/system/uploads/promotional_feature_item/image/',
+  '/government/uploads/system/uploads/take_part_page/image/'
 ].each do |path_to_be_proxied_to_asset_manager| %>
 
   location ~ ^<%= path_to_be_proxied_to_asset_manager %> {


### PR DESCRIPTION
See https://github.com/alphagov/asset-manager/issues/399 for more information.

We've been uploading all new take part page images to Asset Manager since https://github.com/alphagov/whitehall/pull/3602 was merged and deployed.

We uploaded all historical take part page images on 18 Dec 2017[1].

[1]: https://github.com/alphagov/asset-manager/issues/215#issuecomment-352468387