### PR TITLE
Serve Whitehall's default news org images from Asset Manager

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1622,6 +1622,7 @@ router::assets_origin::asset_routes:
   '/government/uploads/': "whitehall-frontend"
   '/government/uploads/system/uploads/organisation/logo/': "static"
   '/government/uploads/system/uploads/consultation_response_form_data/file/': "static"
+  '/government/uploads/system/uploads/default_news_organisation_image_data/file/': "static"
   '/government/uploads/system/uploads/promotional_feature_item/image/': "static"
   '/government/uploads/system/uploads/take_part_page/image/': "static"
   '/government-frontend/': "government-frontend"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1035,6 +1035,7 @@ router::assets_origin::asset_routes:
   '/government/uploads/': "whitehall-frontend"
   '/government/uploads/system/uploads/organisation/logo/': "static"
   '/government/uploads/system/uploads/consultation_response_form_data/file/': "static"
+  '/government/uploads/system/uploads/default_news_organisation_image_data/file/': "static"
   '/government/uploads/system/uploads/promotional_feature_item/image/': "static"
   '/government/uploads/system/uploads/take_part_page/image/': "static"
   '/government-frontend/': "government-frontend"

--- a/modules/govuk/templates/static_extra_nginx_config.conf.erb
+++ b/modules/govuk/templates/static_extra_nginx_config.conf.erb
@@ -20,6 +20,7 @@ location /robots.txt {
   '/media/',
   '/government/uploads/system/uploads/organisation/logo/',
   '/government/uploads/system/uploads/consultation_response_form_data/file/',
+  '/government/uploads/system/uploads/default_news_organisation_image_data/file/',
   '/government/uploads/system/uploads/promotional_feature_item/image/',
   '/government/uploads/system/uploads/take_part_page/image/'
 ].each do |path_to_be_proxied_to_asset_manager| %>


### PR DESCRIPTION
See https://github.com/alphagov/asset-manager/issues/400 for more information.

We've been uploading all new default news org images to Asset Manager since https://github.com/alphagov/whitehall/pull/3602 was merged and deployed.

We uploaded all historical default news org images on 18 Dec 2017[1].

[1]: https://github.com/alphagov/asset-manager/issues/215#issuecomment-352468387