### PR TITLE
AWS set deploy user to manage assets dir

### DIFF
--- a/modules/govuk/manifests/apps/publisher.pp
+++ b/modules/govuk/manifests/apps/publisher.pp
@@ -133,11 +133,17 @@ class govuk::apps::publisher(
     content => template('govuk/local_authority_import_check.erb'),
   }
 
+  if $::aws_migration {
+    $data_dir_user = 'deploy'
+  } else {
+    $data_dir_user = 'assets'
+  }
+
   file { ['/data/uploads/publisher', '/data/uploads/publisher/reports']:
     ensure => directory,
     mode   => '0775',
-    owner  => 'assets',
-    group  => 'assets',
+    owner  => $data_dir_user,
+    group  => $data_dir_user,
   }
 
   govuk::procfile::worker { $app_name:

--- a/modules/govuk/manifests/apps/support_api.pp
+++ b/modules/govuk/manifests/apps/support_api.pp
@@ -111,11 +111,17 @@ class govuk::apps::support_api(
     port => $redis_port,
   }
 
+  if $::aws_migration {
+    $data_dir_user = 'deploy'
+  } else {
+    $data_dir_user = 'assets'
+  }
+
   file { ['/data/uploads/support-api', '/data/uploads/support-api/csvs']:
     ensure => directory,
     mode   => '0775',
-    owner  => 'assets',
-    group  => 'assets',
+    owner  => $data_dir_user,
+    group  => $data_dir_user,
   }
 
   govuk::procfile::worker { $app_name:


### PR DESCRIPTION
On VMware files in the uploads directory are owned by the 'assets'
user. This is required to facilitate SSH key sharing between the
asset-master and asset-slave machines. In the asset-master machine,
all file processing and file sync cron jobs belong to the 'assets'
user; data syncs from other environments are executed with the 'assets'
user, and files written on the directory from application processes
are owned by 'assets' via NFS settings.

On AWS we are not using NFS, we are using EFS instead. This is a problem
because applications are creating files with the app user 'deploy'. Then
file processing and environment sync jobs are failing because the 'assets'
user that executes those processes can't remove files created by 'deploy'.

On AWS we don't have the requirement of data sync between an asset master
and slave machines, so there is not reason for not using the 'deploy'
user to manage the data processes and own the uploads directory. This commit
updates the directories and cron jobs ownership on AWS to use 'deploy'.
