### PR TITLE
Serve Whitehall's classification featuring images from Asset Manager

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1621,6 +1621,7 @@ router::assets_origin::asset_routes:
   '/government/placeholder': "whitehall-frontend"
   '/government/uploads/': "whitehall-frontend"
   '/government/uploads/system/uploads/organisation/logo/': "static"
+  '/government/uploads/system/uploads/classification_featuring_image_data/file/': "static"
   '/government/uploads/system/uploads/consultation_response_form_data/file/': "static"
   '/government/uploads/system/uploads/default_news_organisation_image_data/file/': "static"
   '/government/uploads/system/uploads/promotional_feature_item/image/': "static"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1034,6 +1034,7 @@ router::assets_origin::asset_routes:
   '/government/placeholder': "whitehall-frontend"
   '/government/uploads/': "whitehall-frontend"
   '/government/uploads/system/uploads/organisation/logo/': "static"
+  '/government/uploads/system/uploads/classification_featuring_image_data/file/': "static"
   '/government/uploads/system/uploads/consultation_response_form_data/file/': "static"
   '/government/uploads/system/uploads/default_news_organisation_image_data/file/': "static"
   '/government/uploads/system/uploads/promotional_feature_item/image/': "static"

--- a/modules/govuk/templates/static_extra_nginx_config.conf.erb
+++ b/modules/govuk/templates/static_extra_nginx_config.conf.erb
@@ -19,6 +19,7 @@ location /robots.txt {
 <% [
   '/media/',
   '/government/uploads/system/uploads/organisation/logo/',
+  '/government/uploads/system/uploads/classification_featuring_image_data/file/',
   '/government/uploads/system/uploads/consultation_response_form_data/file/',
   '/government/uploads/system/uploads/default_news_organisation_image_data/file/',
   '/government/uploads/system/uploads/promotional_feature_item/image/',


### PR DESCRIPTION
See https://github.com/alphagov/asset-manager/issues/401 for more information.

We've been uploading all new classification featuring images to Asset Manager since https://github.com/alphagov/whitehall/pull/3602 was merged and deployed.

We uploaded all historical classification featuring images on 18 Dec 2017[1].

[1]: https://github.com/alphagov/asset-manager/issues/215#issuecomment-352468387