### PR TITLE
Serve Whitehall's people images from Asset Manager

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1624,6 +1624,7 @@ router::assets_origin::asset_routes:
   '/government/uploads/system/uploads/classification_featuring_image_data/file/': "static"
   '/government/uploads/system/uploads/consultation_response_form_data/file/': "static"
   '/government/uploads/system/uploads/default_news_organisation_image_data/file/': "static"
+  '/government/uploads/system/uploads/person/image/': "static"
   '/government/uploads/system/uploads/promotional_feature_item/image/': "static"
   '/government/uploads/system/uploads/take_part_page/image/': "static"
   '/government-frontend/': "government-frontend"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1037,6 +1037,7 @@ router::assets_origin::asset_routes:
   '/government/uploads/system/uploads/classification_featuring_image_data/file/': "static"
   '/government/uploads/system/uploads/consultation_response_form_data/file/': "static"
   '/government/uploads/system/uploads/default_news_organisation_image_data/file/': "static"
+  '/government/uploads/system/uploads/person/image/': "static"
   '/government/uploads/system/uploads/promotional_feature_item/image/': "static"
   '/government/uploads/system/uploads/take_part_page/image/': "static"
   '/government-frontend/': "government-frontend"

--- a/modules/govuk/templates/static_extra_nginx_config.conf.erb
+++ b/modules/govuk/templates/static_extra_nginx_config.conf.erb
@@ -22,6 +22,7 @@ location /robots.txt {
   '/government/uploads/system/uploads/classification_featuring_image_data/file/',
   '/government/uploads/system/uploads/consultation_response_form_data/file/',
   '/government/uploads/system/uploads/default_news_organisation_image_data/file/',
+  '/government/uploads/system/uploads/person/image/',
   '/government/uploads/system/uploads/promotional_feature_item/image/',
   '/government/uploads/system/uploads/take_part_page/image/'
 ].each do |path_to_be_proxied_to_asset_manager| %>


### PR DESCRIPTION
See https://github.com/alphagov/asset-manager/issues/402 for more information.

We've been uploading all new people images to Asset Manager since https://github.com/alphagov/whitehall/pull/3602 was merged and deployed.

We uploaded all historical people images on 5 Jan 2018[1].

[1]: https://github.com/alphagov/asset-manager/issues/215#issuecomment-355536113