### PR TITLE
Remove the AWS conditional from the Plek config

### DIFF
--- a/modules/govuk/manifests/node/s_draft_frontend.pp
+++ b/modules/govuk/manifests/node/s_draft_frontend.pp
@@ -14,15 +14,9 @@ class govuk::node::s_draft_frontend() inherits govuk::node::s_base {
     'PLEK_HOSTNAME_PREFIX': value => 'draft-';
     'PLEK_SERVICE_IMMINENCE_URI': value => "https://imminence.${app_domain}";
     'PLEK_SERVICE_LOCAL_LINKS_MANAGER_URI': value => "https://local-links-manager.${app_domain}";
-  }
-
-  unless $::aws_migration {
-    # This is set for all apps in AWS so we skip adding it here
-    govuk_envvar {
-      'PLEK_SERVICE_MAPIT_URI': value     => "https://mapit.${app_domain}";
-      'PLEK_SERVICE_SEARCH_URI': value    => "https://search.${app_domain}";
-      'PLEK_SERVICE_RUMMAGER_URI': value  => "https://rummager.${app_domain}";
-      'PLEK_SERVICE_LICENSIFY_URI': value => "https://licensify.${app_domain}";
-    }
+    'PLEK_SERVICE_MAPIT_URI': value     => "https://mapit.${app_domain}";
+    'PLEK_SERVICE_SEARCH_URI': value    => "https://search.${app_domain}";
+    'PLEK_SERVICE_RUMMAGER_URI': value  => "https://rummager.${app_domain}";
+    'PLEK_SERVICE_LICENSIFY_URI': value => "https://licensify.${app_domain}";
   }
 }


### PR DESCRIPTION
For the draft frontend nodes.

As the removed comment says, this was done when the
PLEK_SERVICE_..._URI environment variables were set when using
AWS. This is no longer the case, and these environment variables need
setting for apps on the draft frontend boxes, to make sure they use
the right URLs (e.g. search not draft-search).