### PR TITLE
Fix external vs internal routing for draft frontend apps

### DIFF
--- a/modules/govuk/manifests/node/s_draft_frontend.pp
+++ b/modules/govuk/manifests/node/s_draft_frontend.pp
@@ -10,18 +10,25 @@ class govuk::node::s_draft_frontend() inherits govuk::node::s_base {
 
   $app_domain = hiera('app_domain')
 
+  if $::aws_migration {
+    $app_domain_internal = hiera('app_domain_internal')
+  } else {
+    $app_domain_internal = $app_domain
+  }
+
   govuk_envvar {
     'PLEK_HOSTNAME_PREFIX': value => 'draft-';
     'PLEK_SERVICE_IMMINENCE_URI': value => "https://imminence.${app_domain}";
     'PLEK_SERVICE_LOCAL_LINKS_MANAGER_URI': value => "https://local-links-manager.${app_domain}";
+    'PLEK_SERVICE_MAPIT_URI': value     => "https://mapit.${app_domain_internal}";
+    'PLEK_SERVICE_SEARCH_URI': value    => "https://search.${app_domain_internal}";
+    'PLEK_SERVICE_RUMMAGER_URI': value  => "https://rummager.${app_domain_internal}";
   }
 
   unless $::aws_migration {
-    # This is set for all apps in AWS so we skip adding it here
+    # This is set from govuk::deploy::config when using AWS, so only
+    # set this here if we are not using AWS
     govuk_envvar {
-      'PLEK_SERVICE_MAPIT_URI': value     => "https://mapit.${app_domain}";
-      'PLEK_SERVICE_SEARCH_URI': value    => "https://search.${app_domain}";
-      'PLEK_SERVICE_RUMMAGER_URI': value  => "https://rummager.${app_domain}";
       'PLEK_SERVICE_LICENSIFY_URI': value => "https://licensify.${app_domain}";
     }
   }


### PR DESCRIPTION
These environment variables need setting for apps on the draft
frontend boxes, to make sure they use the right URLs (e.g. search not
draft-search). Some of these services need accessing over the internal
domain, so make this the case.