### PR TITLE
Change the Taxons at level stat to the current value

### DIFF
--- a/modules/grafana/files/dashboards/topic_taxonomy.json
+++ b/modules/grafana/files/dashboards/topic_taxonomy.json
@@ -1326,7 +1326,7 @@
               "value": "null"
             }
           ],
-          "valueName": "avg"
+          "valueName": "current"
         }
       ],
       "repeat": null,


### PR DESCRIPTION
The current value of the metric is best to use, as only a single value
is shown.