### PR TITLE
Add run_whitehall_data_migrations_job to AWS

### DIFF
--- a/hieradata_aws/class/jenkins.yaml
+++ b/hieradata_aws/class/jenkins.yaml
@@ -72,6 +72,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::remove_emergency_banner
   - govuk_jenkins::jobs::run_deploy_lag_badger
   - govuk_jenkins::jobs::run_rake_task
+  - govuk_jenkins::jobs::run_whitehall_data_migrations
   - govuk_jenkins::jobs::search_benchmark
   - govuk_jenkins::jobs::search_fetch_analytics_data
   - govuk_jenkins::jobs::search_index_checks


### PR DESCRIPTION
We still use this Jenkins job but it wasn't included in hieradata_aws. This PR restores it to its former glory.