### PR TITLE
Add run whitehall data migrations job

### DIFF
--- a/hieradata_aws/class/jenkins.yaml
+++ b/hieradata_aws/class/jenkins.yaml
@@ -72,6 +72,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::remove_emergency_banner
   - govuk_jenkins::jobs::run_deploy_lag_badger
   - govuk_jenkins::jobs::run_rake_task
+  - govuk_jenkins::jobs::run_whitehall_data_migrations
   - govuk_jenkins::jobs::search_benchmark
   - govuk_jenkins::jobs::search_fetch_analytics_data
   - govuk_jenkins::jobs::search_index_checks

--- a/modules/govuk_jenkins/templates/jobs/run_whitehall_data_migrations.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/run_whitehall_data_migrations.yaml.erb
@@ -3,10 +3,10 @@
     name: Run_Whitehall_Data_Migrations
     display-name: Run_Whitehall_Data_Migrations
     project-type: freestyle
-    description: "This job SSHes to whitehall-backend-2.backend.<%= @app_domain -%> and runs 'cd /var/apps/whitehall ; RAILS_ENV=production       bundle exec rake db:data:migrate'"
+    description: "This job SSHes onto a whitehall-backend node and runs 'cd /var/apps/whitehall ; RAILS_ENV=production bundle exec rake db:data:migrate'"
     builders:
         - shell: |
-            ssh deploy@whitehall-backend-2.backend.<%= @app_domain -%> 'cd /var/apps/whitehall ; govuk_setenv whitehall bundle exec rake db:data:migrate'
+            ssh deploy@$(govuk_node_list -c whitehall_backend --single-node) "cd /var/apps/whitehall ; govuk_setenv whitehall bundle exec rake db:data:migrate"
     wrappers:
         - ansicolor:
             colormap: xterm


### PR DESCRIPTION
The previous version of the `run_whitehall_data_migrations` job wouldn't work on AWS and wasn't included in hieradata_aws/class/jenkins.yml.

This PR fixes and includes it.