### PR TITLE
Update deploy UID/GID

### DIFF
--- a/hieradata_aws/class/asset_master.yaml
+++ b/hieradata_aws/class/asset_master.yaml
@@ -1,2 +1,2 @@
-govuk::deploy::setup::deploy_uid: 2910
-govuk::deploy::setup::deploy_gid: 2910
+govuk::deploy::setup::deploy_uid: 2899
+govuk::deploy::setup::deploy_gid: 2899

--- a/hieradata_aws/class/backend.yaml
+++ b/hieradata_aws/class/backend.yaml
@@ -41,5 +41,5 @@ govuk::apps::travel_advice_publisher::mongodb_nodes:
   - 'mongo-2'
   - 'mongo-3'
 
-govuk::deploy::setup::deploy_uid: 2910
-govuk::deploy::setup::deploy_gid: 2910
+govuk::deploy::setup::deploy_uid: 2899
+govuk::deploy::setup::deploy_gid: 2899

--- a/hieradata_aws/class/whitehall_backend.yaml
+++ b/hieradata_aws/class/whitehall_backend.yaml
@@ -6,5 +6,5 @@ govuk::apps::whitehall::port: '3026'
 govuk::apps::whitehall::vhost: 'whitehall-admin'
 govuk::apps::whitehall::vhost_protected: true
 
-govuk::deploy::setup::deploy_uid: 2910
-govuk::deploy::setup::deploy_gid: 2910
+govuk::deploy::setup::deploy_uid: 2899
+govuk::deploy::setup::deploy_gid: 2899


### PR DESCRIPTION
Related with https://github.com/alphagov/govuk-puppet/pull/7097, updates
settings in https://github.com/alphagov/govuk-puppet/pull/7113

The assets::user class still gets included from the main assets class that
is at the same time included in whitehall via whitehall-admin. If the assets
user is deployed before the admin users and deploy, users get assigned UIDs
after 2900, probably locking 2910 that we assigned to 'deploy' before.

We update the original IDs to 2899 to ensure it's not taken even if assets
runs before in the machine.