### PR TITLE
Remove unnecessary env var for Audit Tool

### DIFF
--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -96,8 +96,6 @@ govuk::apps::authenticating_proxy::govuk_upstream_uri: 'http://government-fronte
 govuk::apps::backdrop_write::enable_procfile_worker: false
 govuk::apps::collections_publisher::enable_procfile_worker: false
 govuk::apps::contacts::extra_aliases: ['contacts-admin']
-govuk::apps::content_performance_manager::feature_auditing_allocation: true
-govuk::apps::content_performance_manager::feature_auditing_theme_filtering: true
 govuk::apps::content_store::mongodb_nodes: ['localhost']
 govuk::apps::content_store::mongodb_name: 'content_store_development'
 govuk::apps::content_tagger::enable_procfile_worker: false

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -70,8 +70,6 @@ environment_ip_prefix: '10.3'
 
 govuk::apps::asset_manager::aws_s3_bucket_name: 'govuk-assets-production'
 govuk::apps::asset_manager::aws_region: 'eu-west-1'
-govuk::apps::content_performance_manager::feature_auditing_allocation: false
-govuk::apps::content_performance_manager::feature_auditing_theme_filtering: false
 govuk::apps::content_store::performance_platform_big_screen_view_url: 'https://performance-platform-big-screen-view-production.cloudapps.digital'
 govuk::apps::content_store::performance_platform_spotlight_url: 'https://performance-platform-spotlight-production.cloudapps.digital'
 govuk::apps::email_alert_api::db::backend_ip_range: '10.3.3.0/24'

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -12,8 +12,6 @@ environment_ip_prefix: '10.2'
 
 govuk::apps::asset_manager::aws_s3_bucket_name: 'govuk-assets-staging'
 govuk::apps::asset_manager::aws_region: 'eu-west-1'
-govuk::apps::content_performance_manager::feature_auditing_allocation: true
-govuk::apps::content_performance_manager::feature_auditing_theme_filtering: false
 govuk::apps::content_store::performance_platform_big_screen_view_url: 'https://performance-platform-big-screen-view-staging.cloudapps.digital'
 govuk::apps::content_store::performance_platform_spotlight_url: 'https://performance-platform-spotlight-staging.cloudapps.digital'
 govuk::apps::email_alert_api::allow_govdelivery_topic_syncing: true

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -11,8 +11,6 @@ cron::daily_hour: 6
 
 govuk::apps::asset_manager::aws_s3_bucket_name: 'govuk-assets-staging'
 govuk::apps::asset_manager::aws_region: 'eu-west-1'
-govuk::apps::content_performance_manager::feature_auditing_allocation: true
-govuk::apps::content_performance_manager::feature_auditing_theme_filtering: false
 govuk::apps::content_store::performance_platform_big_screen_view_url: 'https://performance-platform-big-screen-view-staging.cloudapps.digital'
 govuk::apps::content_store::performance_platform_spotlight_url: 'https://performance-platform-spotlight-staging.cloudapps.digital'
 govuk::apps::email_alert_api::allow_govdelivery_topic_syncing: true

--- a/modules/govuk/manifests/apps/content_performance_manager.pp
+++ b/modules/govuk/manifests/apps/content_performance_manager.pp
@@ -22,14 +22,6 @@
 #   The view id of GOV.UK in Google Analytics
 #   Default: undef
 #
-# [*feature_auditing_allocation*]
-#   Whether the auditing allocation feature should be enabled/disabled.
-#   Default: false
-#
-# [*feature_auditing_theme_filtering*]
-#   Whether the auditing filters for themes are enabled/disabled.
-#   Default: false
-#
 # [*google_client_email*]
 #   Google authentication email
 #   Default: undef
@@ -74,8 +66,6 @@ class govuk::apps::content_performance_manager(
   $db_password = undef,
   $db_username = 'content_performance_manager',
   $enable_procfile_worker = true,
-  $feature_auditing_allocation = false,
-  $feature_auditing_theme_filtering = false,
   $google_analytics_govuk_view_id = undef,
   $google_client_email = undef,
   $google_private_key = undef,
@@ -115,12 +105,6 @@ class govuk::apps::content_performance_manager(
   }
 
   govuk::app::envvar {
-    "${title}-FEATURE_AUDITING_ALLOCATION":
-      varname => 'FEATURE_AUDITING_ALLOCATION',
-      value   => bool2str($feature_auditing_allocation);
-    "${title}-FEATURE_AUDITING_THEME_FILTERING":
-      varname => 'FEATURE_AUDITING_THEME_FILTERING',
-      value   => bool2str($feature_auditing_theme_filtering);
     "${title}-GOOGLE_ANALYTICS_GOVUK_VIEW_ID":
       varname => 'GOOGLE_ANALYTICS_GOVUK_VIEW_ID',
       value   => $google_analytics_govuk_view_id;


### PR DESCRIPTION
The feature flags that rely on these env vars are not in use in the app, so these env vars can be removed.