### PR TITLE
Remove assets user dependency on AWS

### DIFF
--- a/modules/assets/manifests/init.pp
+++ b/modules/assets/manifests/init.pp
@@ -11,7 +11,12 @@
 class assets (
   $mount_asset_master = true,
   ) {
-  include assets::user
+
+  unless $::aws_migration {
+    include assets::user
+
+    Class['assets::user'] -> File['/data/uploads']
+  }
 
   package { 'nfs-common':
     ensure => installed,
@@ -23,11 +28,10 @@ class assets (
 
   # Ownership and permissions come from the mount.
   file { '/data/uploads':
-    ensure  => directory,
-    owner   => undef,
-    group   => undef,
-    mode    => undef,
-    require => Class['assets::user'],
+    ensure => directory,
+    owner  => undef,
+    group  => undef,
+    mode   => undef,
   }
 
   validate_bool($mount_asset_master)


### PR DESCRIPTION
Related with https://github.com/alphagov/govuk-puppet/pull/7113 having the directory
/mnt/uploads depending on the assets user creates errors in the AWS
boxes because it tries to create a 'assets' users with a fixed UID/GID that
has probably been taken.