### PR TITLE
Trim commit hash for govuk_jenkins groovy

### DIFF
--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -947,7 +947,7 @@ def getFullCommitHash() {
   return sh(
     script: "git rev-parse HEAD",
     returnStdout: true
-  )
+  ).trim()
 }
 
 return this;


### PR DESCRIPTION
Running `git rev-parse HEAD` returns the commit hash with a trailing new
line, which then gets passed on to other builds and can cause really
hard to debug issues such as:

```
[Pipeline] sh
14:24:05 [hing-e2e-tests_test-against-BA77P3BHVW3OSKBL52JIGDUBRDSDHD5KRJROBMDMC3S4IXVGCJ2A] Running shell script
14:24:05 + COLLECTIONS_PUBLISHER_COMMITISH=336dc12ee2addf9c67553a1c0a2663c22f2bed45 docker-compose pull --ignore-pull-failures collections-publisher
14:24:07 Pulling collections-publisher (govuk/collections-publisher:336dc12ee2addf9c67553a1c0a2663c22f2bed45)...
14:24:08 404 Client Error: Not Found ("manifest for govuk/collections-publisher:336dc12ee2addf9c67553a1c0a2663c22f2bed45 not found")
[Pipeline] sh
14:24:08 [hing-e2e-tests_test-against-BA77P3BHVW3OSKBL52JIGDUBRDSDHD5KRJROBMDMC3S4IXVGCJ2A] Running shell script
14:24:08 + docker-compose pull --ignore-pull-failures collections-publisher
14:24:10 Pulling collections-publisher (govuk/collections-publisher:336dc12ee2addf9c67553a1c0a2663c22f2bed45
14:24:10 )...
14:24:10 invalid tag format
```