### PR TITLE
Serve Whitehall's image data attachments from Asset Manager

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1627,6 +1627,7 @@ router::assets_origin::asset_routes:
   '/government/uploads/system/uploads/person/image/': "static"
   '/government/uploads/system/uploads/promotional_feature_item/image/': "static"
   '/government/uploads/system/uploads/take_part_page/image/': "static"
+  '/government/uploads/system/uploads/image_data/file/': "static"
   '/government-frontend/': "government-frontend"
   '/info-frontend/': "info-frontend"
   '/manuals-frontend/': "manuals-frontend"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1040,6 +1040,7 @@ router::assets_origin::asset_routes:
   '/government/uploads/system/uploads/person/image/': "static"
   '/government/uploads/system/uploads/promotional_feature_item/image/': "static"
   '/government/uploads/system/uploads/take_part_page/image/': "static"
+  '/government/uploads/system/uploads/image_data/file/': "static"
   '/government-frontend/': "government-frontend"
   '/info-frontend/': "info-frontend"
   '/manuals-frontend/': "manuals-frontend"

--- a/modules/govuk/templates/static_extra_nginx_config.conf.erb
+++ b/modules/govuk/templates/static_extra_nginx_config.conf.erb
@@ -24,7 +24,8 @@ location /robots.txt {
   '/government/uploads/system/uploads/default_news_organisation_image_data/file/',
   '/government/uploads/system/uploads/person/image/',
   '/government/uploads/system/uploads/promotional_feature_item/image/',
-  '/government/uploads/system/uploads/take_part_page/image/'
+  '/government/uploads/system/uploads/take_part_page/image/',
+  '/government/uploads/system/uploads/image_data/file/'
 ].each do |path_to_be_proxied_to_asset_manager| %>
 
   location ~ ^<%= path_to_be_proxied_to_asset_manager %> {


### PR DESCRIPTION
c.f. https://github.com/alphagov/asset-manager/issues/404

This commit proxies all requests for Whitehall image data assets to
Asset Manager.

We have migrated all existing Whitehall assets under
`system/uploads/image_data/file` on the NFS mount to Asset
Manager[1]. We've been uploading all new assets of this type to Asset
Manager since alphagov/whitehall#3602.

[1] https://github.com/alphagov/asset-manager/issues/404#issuecomment-359395022