### PR TITLE
Remove the 'all' option from the deploy DNS Jenkins job

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_dns.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_dns.yaml.erb
@@ -41,7 +41,6 @@
             name: PROVIDERS
             choices:
                 - PICK ONE
-                - all
                 - aws
                 - gcp
         - choice:


### PR DESCRIPTION
- This doesn't work properly.