### PR TITLE
Add deploy_dns job to AWS integration Jenkins for testing.

### DIFF
--- a/hieradata_aws/class/jenkins.yaml
+++ b/hieradata_aws/class/jenkins.yaml
@@ -63,6 +63,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::configure_github_repos
   - govuk_jenkins::jobs::data_sync_complete_integration
   - govuk_jenkins::jobs::deploy_app
+  - govuk_jenkins::jobs::deploy_dns
   - govuk_jenkins::jobs::deploy_emergency_banner
   - govuk_jenkins::jobs::deploy_puppet
   - govuk_jenkins::jobs::deploy_router_data

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -41,6 +41,9 @@ govuk_elasticsearch::dump::run_es_dump_hour: '9'
 
 govuk_jenkins::job_builder::environment: 'integration'
 
+govuk_jenkins::jobs::deploy_dns::gce_project_id: 'govuk-integration'
+govuk_jenkins::jobs::deploy_dns::zones: 'dns-test.integration.publishing.service.gov.uk'
+
 govuk_jenkins::jobs::integration_deploy::jenkins_integration_api_user: "%{hiera('govuk::node::s_jenkins::jenkins_api_user')}"
 govuk_jenkins::jobs::integration_deploy::jenkins_integration_api_password: "%{hiera('govuk::node::s_jenkins::jenkins_api_token')}"
 


### PR DESCRIPTION
We hadn't enabled this job before but now we need to debug the broken terraform statefile issue we need it here.