### PR TITLE
Serve Whitehall's legacy assets from Asset Manager

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1620,6 +1620,7 @@ router::assets_origin::asset_routes:
   '/government/assets/': "whitehall-frontend"
   '/government/placeholder': "whitehall-frontend"
   '/government/uploads/': "whitehall-frontend"
+  '/government/uploads/government/uploads/system/uploads/': "static"
   '/government/uploads/system/uploads/organisation/logo/': "static"
   '/government/uploads/system/uploads/classification_featuring_image_data/file/': "static"
   '/government/uploads/system/uploads/consultation_response_form_data/file/': "static"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1033,6 +1033,7 @@ router::assets_origin::asset_routes:
   '/government/assets/': "whitehall-frontend"
   '/government/placeholder': "whitehall-frontend"
   '/government/uploads/': "whitehall-frontend"
+  '/government/uploads/government/uploads/system/uploads/': "static"
   '/government/uploads/system/uploads/organisation/logo/': "static"
   '/government/uploads/system/uploads/classification_featuring_image_data/file/': "static"
   '/government/uploads/system/uploads/consultation_response_form_data/file/': "static"

--- a/modules/govuk/templates/static_extra_nginx_config.conf.erb
+++ b/modules/govuk/templates/static_extra_nginx_config.conf.erb
@@ -18,6 +18,7 @@ location /robots.txt {
 
 <% [
   '/media/',
+  '/government/uploads/government/uploads/system/uploads/',
   '/government/uploads/system/uploads/organisation/logo/',
   '/government/uploads/system/uploads/classification_featuring_image_data/file/',
   '/government/uploads/system/uploads/consultation_response_form_data/file/',


### PR DESCRIPTION
See https://github.com/alphagov/asset-manager/issues/420 for more information.

We [uploaded all historical legacy assets on 19 Jan 2018][1].

[1]: https://github.com/alphagov/asset-manager/issues/420#issuecomment-358982845