### PR TITLE
Serve Whitehall's number10 assets from Asset Manager

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1630,6 +1630,7 @@ router::assets_origin::asset_routes:
   '/government/uploads/system/uploads/promotional_feature_item/image/': "static"
   '/government/uploads/system/uploads/take_part_page/image/': "static"
   '/government/uploads/system/uploads/image_data/file/': "static"
+  '/government/uploads/uploaded/number10/': "static"
   '/government-frontend/': "government-frontend"
   '/info-frontend/': "info-frontend"
   '/manuals-frontend/': "manuals-frontend"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1043,6 +1043,7 @@ router::assets_origin::asset_routes:
   '/government/uploads/system/uploads/promotional_feature_item/image/': "static"
   '/government/uploads/system/uploads/take_part_page/image/': "static"
   '/government/uploads/system/uploads/image_data/file/': "static"
+  '/government/uploads/uploaded/number10/': "static"
   '/government-frontend/': "government-frontend"
   '/info-frontend/': "info-frontend"
   '/manuals-frontend/': "manuals-frontend"

--- a/modules/govuk/templates/static_extra_nginx_config.conf.erb
+++ b/modules/govuk/templates/static_extra_nginx_config.conf.erb
@@ -27,7 +27,8 @@ location /robots.txt {
   '/government/uploads/system/uploads/person/image/',
   '/government/uploads/system/uploads/promotional_feature_item/image/',
   '/government/uploads/system/uploads/take_part_page/image/',
-  '/government/uploads/system/uploads/image_data/file/'
+  '/government/uploads/system/uploads/image_data/file/',
+  '/government/uploads/uploaded/number10/'
 ].each do |path_to_be_proxied_to_asset_manager| %>
 
   location ~ ^<%= path_to_be_proxied_to_asset_manager %> {


### PR DESCRIPTION
See https://github.com/alphagov/asset-manager/issues/268 for more information.

We [uploaded all historical number10 assets on 19 Jan 2018][1].

[1]: https://github.com/alphagov/asset-manager/issues/268#issuecomment-358964263