### PR TITLE
Hold back the version of Terraform on the AWS deploy Jenkins.

### DIFF
--- a/hieradata_aws/class/jenkins.yaml
+++ b/hieradata_aws/class/jenkins.yaml
@@ -87,6 +87,8 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::user_monitor
   - govuk_jenkins::jobs::whitehall_update_integration_data
 
+govuk_jenkins::packages::terraform::version: '0.8.1'
+
 govuk_jenkins::plugins:
   ace-editor:
     version: '1.1'


### PR DESCRIPTION
This should be kept at 0.8.1 for now while we debug DNS issues.