### PR TITLE
Define backup::assets::backup_private_gpg_key_fingerprint

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -4,6 +4,7 @@ _: &offsite_gpg_key 'C30AC3E9B1CA573BC7F1D71AE6482BDB7C6961BD'
 
 app_domain: 'publishing.service.gov.uk'
 
+backup::assets::backup_private_gpg_key_fingerprint: *offsite_gpg_key
 backup::assets::jobs:
   'assets-whitehall-s3':
     sources: '/mnt/uploads/whitehall'


### PR DESCRIPTION
This is needed so that the backup::assets manifest writes the details
of the secret key to disk on the backup assets machines.  The value for
this was added in #7122 when we rotated the backup gpg key after it
expired.  However, the variable wasn't defined to use it (the value is
used in other places) as the backup_private_gpg_key_fingerprint.  Looks
like this was removed in error as part of a cleanup PR (#5540) aiming to
remove things from common.yaml that were only used in production.

The key hasn't changed since then so the on disk files for the
backup::assets weren't removed, but as soon as we changed it the on disk
files weren't written because we hadn't defined the fingerprint.

This restores the fingerprint, so the ondisk files for the new key should
be written out again.