### PR TITLE
Further removes @fields to fix nginx log graphs

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -957,7 +957,7 @@ grafana::dashboards::deployment_applications:
     # logstasher >1.x
     fields_prefix: ''
   hmrc-manuals-api:
-    # Missing @fields.status
+    # Missing status from logs
     show_controller_errors: false
   imminence:
     # logstasher >1.x

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -821,7 +821,7 @@ grafana::dashboards::deployment_applications:
     # logstasher >1.x
     fields_prefix: ''
   hmrc-manuals-api:
-    # Missing @fields.status
+    # Missing status from logs
     show_controller_errors: false
   imminence:
     # logstasher >1.x

--- a/modules/govuk/manifests/apps/bouncer.pp
+++ b/modules/govuk/manifests/apps/bouncer.pp
@@ -175,9 +175,9 @@ class govuk::apps::bouncer(
     'www.mhra.gov.uk-json.event.access.log':
       json          => true,
       logstream     => present,
-      statsd_metric => "${::fqdn_metrics}.nginx_logs.mhra_proxy.http_%{@fields.status}",
+      statsd_metric => "${::fqdn_metrics}.nginx_logs.mhra_proxy.http_%{status}",
       statsd_timers => [{metric => "${::fqdn_metrics}.nginx_logs.mhra_proxy.time_request",
-                          value => '@fields.request_time'}];
+                          value => 'request_time'}];
     'www.mhra.gov.uk-error.log':
       logstream     => present;
   }

--- a/modules/govuk/manifests/apps/bouncer/vhost.pp
+++ b/modules/govuk/manifests/apps/bouncer/vhost.pp
@@ -49,9 +49,9 @@ define govuk::apps::bouncer::vhost(
     "${title}-json.event.access.log":
       json          => true,
       logstream     => present,
-      statsd_metric => "${::fqdn_metrics}.nginx_logs.${title}.http_%{@fields.status}",
+      statsd_metric => "${::fqdn_metrics}.nginx_logs.${title}.http_%{status}",
       statsd_timers => [{metric => "${::fqdn_metrics}.nginx_logs.${title}.time_request",
-                          value => '@fields.request_time'}];
+                          value => 'request_time'}];
     "${title}-error.log":
       logstream     => present;
   }

--- a/modules/govuk_logging/spec/defines/govuk_logging__logstream_spec.rb
+++ b/modules/govuk_logging/spec/defines/govuk_logging__logstream_spec.rb
@@ -73,13 +73,13 @@ describe 'govuk_logging::logstream', :type => :define do
     let(:params) { {
       :logfile       => log_file,
       :ensure        => 'present',
-      :statsd_metric => 'tom_jerry.foo.%{@fields.bar}',
+      :statsd_metric => 'tom_jerry.foo.%{bar}',
     } }
 
     it 'should pass statsd_counter arg' do
       is_expected.to contain_file(upstart_conf).with(
         :ensure  => 'present',
-        :content => /\| logship -f init_json,add_timestamp,add_source_host -s statsd_counter,metric=tom_jerry.foo.%{@fields.bar}$/,
+        :content => /\| logship -f init_json,add_timestamp,add_source_host -s statsd_counter,metric=tom_jerry.foo.%{bar}$/,
       )
     end
     it 'should not contain any configuration related to logs or redis' do
@@ -92,14 +92,14 @@ describe 'govuk_logging::logstream', :type => :define do
     let(:params) { {
       :logfile       => log_file,
       :ensure        => 'present',
-      :statsd_timers => [{'metric' => 'tom_jerry.foo','value' => '@fields.foo'},
-                         {'metric' => 'tom_jerry.bar','value' => '@fields.bar'}],
+      :statsd_timers => [{'metric' => 'tom_jerry.foo','value' => 'foo'},
+                         {'metric' => 'tom_jerry.bar','value' => 'bar'}],
     } }
 
     it 'should pass statsd_timer arg' do
       is_expected.to contain_file(upstart_conf).with(
         :ensure  => 'present',
-        :content => /\| logship -f init_json,add_timestamp,add_source_host -s statsd_timer,metric=tom_jerry.foo,timed_field=@fields.foo statsd_timer,metric=tom_jerry.bar,timed_field=@fields.bar$/,
+        :content => /\| logship -f init_json,add_timestamp,add_source_host -s statsd_timer,metric=tom_jerry.foo,timed_field=foo statsd_timer,metric=tom_jerry.bar,timed_field=bar$/,
       )
     end
     it 'should not contain any configuration related to logs or redis' do
@@ -113,13 +113,13 @@ describe 'govuk_logging::logstream', :type => :define do
       :logfile => log_file,
       :ensure  => 'present',
       :tags    => ['zebra', 'llama'],
-      :statsd_metric => 'tom_jerry.foo.%{@fields.bar}',
+      :statsd_metric => 'tom_jerry.foo.%{bar}',
     } }
 
     it 'should pass add_tags with list in filter chain' do
       is_expected.to contain_file(upstart_conf).with(
         :ensure  => 'present',
-        :content => /\| logship -f #{default_filters},add_tags:zebra:llama -s statsd_counter,metric=tom_jerry.foo.%{@fields.bar}$/,
+        :content => /\| logship -f #{default_filters},add_tags:zebra:llama -s statsd_counter,metric=tom_jerry.foo.%{bar}$/,
       )
     end
   end
@@ -129,13 +129,13 @@ describe 'govuk_logging::logstream', :type => :define do
       :logfile => log_file,
       :ensure  => 'present',
       :fields  => {'zebra' => 'stripey', 'llama' => 'fluffy'},
-      :statsd_metric => 'tom_jerry.foo.%{@fields.bar}',
+      :statsd_metric => 'tom_jerry.foo.%{bar}',
     } }
 
     it 'should pass --fields with kv pairs' do
       is_expected.to contain_file(upstart_conf).with(
         :ensure  => 'present',
-        :content => /\| logship -f #{default_filters},add_fields:zebra=stripey:llama=fluffy -s statsd_counter,metric=tom_jerry.foo.%{@fields.bar}$/,
+        :content => /\| logship -f #{default_filters},add_fields:zebra=stripey:llama=fluffy -s statsd_counter,metric=tom_jerry.foo.%{bar}$/,
       )
     end
   end

--- a/modules/licensify/manifests/apps/licensify.pp
+++ b/modules/licensify/manifests/apps/licensify.pp
@@ -40,9 +40,9 @@ class licensify::apps::licensify (
     "${vhost_name}-json.event.access.log":
       json          => true,
       logstream     => present,
-      statsd_metric => "${counter_basename}.http_%{@fields.status}",
+      statsd_metric => "${counter_basename}.http_%{status}",
       statsd_timers => [{metric => "${counter_basename}.time_request",
-                          value => '@fields.request_time'}];
+                          value => 'request_time'}];
     "${vhost_name}-error.log":
       logstream => present;
   }

--- a/modules/nginx/manifests/config/vhost/proxy.pp
+++ b/modules/nginx/manifests/config/vhost/proxy.pp
@@ -138,9 +138,9 @@ define nginx::config::vhost::proxy(
       json          => true,
       logpath       => $logpath,
       logstream     => $ensure,
-      statsd_metric => "${counter_basename}.http_%{@fields.status}",
+      statsd_metric => "${counter_basename}.http_%{status}",
       statsd_timers => [{metric => "${counter_basename}.time_request",
-                          value => '@fields.request_time'}];
+                          value => 'request_time'}];
     $error_log:
       logpath   => $logpath,
       logstream => $ensure;

--- a/modules/nginx/manifests/config/vhost/static.pp
+++ b/modules/nginx/manifests/config/vhost/static.pp
@@ -77,9 +77,9 @@ define nginx::config::vhost::static(
       json          => true,
       logpath       => $logpath,
       logstream     => $logstream_ensure,
-      statsd_metric => "${counter_basename}.http_%{@fields.status}",
+      statsd_metric => "${counter_basename}.http_%{status}",
       statsd_timers => [{metric => "${counter_basename}.time_request",
-                          value => '@fields.request_time'}];
+                          value => 'request_time'}];
     $error_log:
       logpath   => $logpath,
       logstream => $logstream_ensure;

--- a/modules/nginx/manifests/logging.pp
+++ b/modules/nginx/manifests/logging.pp
@@ -26,9 +26,9 @@ class nginx::logging (
     'json.event.access.log':
       json          => true,
       logstream     => present,
-      statsd_metric => "${::fqdn_metrics}.nginx_logs.default.http_%{@fields.status}",
+      statsd_metric => "${::fqdn_metrics}.nginx_logs.default.http_%{status}",
       statsd_timers => [{metric => "${::fqdn_metrics}.nginx_logs.default.time_request",
-                          value => '@fields.request_time'}];
+                          value => 'request_time'}];
     'error.log':
       logstream => present;
   }

--- a/modules/puppet/manifests/master/nginx.pp
+++ b/modules/puppet/manifests/master/nginx.pp
@@ -23,9 +23,9 @@ class puppet::master::nginx (
     'puppetmaster-json.event.access.log':
       json          => true,
       logstream     => present,
-      statsd_metric => "${counter_basename}.http_%{@fields.status}",
+      statsd_metric => "${counter_basename}.http_%{status}",
       statsd_timers => [{metric => "${counter_basename}.time_request",
-                          value => '@fields.request_time'}];
+                          value => 'request_time'}];
     'puppetmaster-error.log':
       logstream => present;
   }

--- a/modules/puppet/manifests/puppetserver/nginx.pp
+++ b/modules/puppet/manifests/puppetserver/nginx.pp
@@ -15,9 +15,9 @@ class puppet::puppetserver::nginx {
     'puppetdb-json.event.access.log':
       json          => true,
       logstream     => present,
-      statsd_metric => "${counter_basename}.http_%{@fields.status}",
+      statsd_metric => "${counter_basename}.http_%{status}",
       statsd_timers => [{metric => "${counter_basename}.time_request",
-                          value => '@fields.request_time'}];
+                          value => 'request_time'}];
     'puppetdb-error.log':
       logstream => present;
   }

--- a/modules/router/manifests/assets_origin.pp
+++ b/modules/router/manifests/assets_origin.pp
@@ -49,9 +49,9 @@ class router::assets_origin(
     "${vhost_name}-json.event.access.log":
       json          => true,
       logstream     => present,
-      statsd_metric => "${::fqdn_metrics}.nginx_logs.assets-origin.http_%{@fields.status}",
+      statsd_metric => "${::fqdn_metrics}.nginx_logs.assets-origin.http_%{status}",
       statsd_timers => [{metric => "${::fqdn_metrics}.nginx_logs.assets-origin.time_request",
-                          value => '@fields.request_time'}];
+                          value => 'request_time'}];
     "${vhost_name}-error.log":
       logstream => present;
   }

--- a/modules/router/manifests/nginx.pp
+++ b/modules/router/manifests/nginx.pp
@@ -100,9 +100,9 @@ class router::nginx (
     'lb-json.event.access.log':
       json          => true,
       logstream     => present,
-      statsd_metric => "${::fqdn_metrics}.nginx_logs.www-origin.http_%{@fields.status}",
+      statsd_metric => "${::fqdn_metrics}.nginx_logs.www-origin.http_%{status}",
       statsd_timers => [{metric => "${::fqdn_metrics}.nginx_logs.www-origin.time_request",
-                          value => '@fields.request_time'}];
+                          value => 'request_time'}];
     'lb-error.log':
       logstream => present;
   }


### PR DESCRIPTION
For: https://trello.com/c/Y9Rc6jWR/49-http-stats-not-being-logged-in-graphite

Following a PR to remove "@fields" from the logs nginx template (see:
 #6658), a bunch of graphs in grafana and graphite have stopped reporting data (from 11th of Jan 2018).

<img width="1368" alt="screen shot 2018-01-23 at 14 04 52" src="https://user-images.githubusercontent.com/1354439/35279915-6b512e12-0046-11e8-9524-09fa24c85c54.png">


This PR aims to remove the mentions of "@fields" in order to bring back the graphs.

There is a planned PR from branch `remove-fields-prefix-from-nginx-config` which will rename `@fields` to `access`, as well as renaming some of the fields. You can see this below: 

<img width="1101" alt="screen shot 2018-01-23 at 14 03 20" src="https://user-images.githubusercontent.com/1354439/35279845-333aa594-0046-11e8-8cbb-b950cd89f3e3.png">
