### PR TITLE
Jenkins job copy attachments from Stg to AWS

### DIFF
--- a/hieradata/class/staging/jenkins.yaml
+++ b/hieradata/class/staging/jenkins.yaml
@@ -3,6 +3,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::check_content_consistency
   - govuk_jenkins::jobs::check_content_store
   - govuk_jenkins::jobs::content_performance_manager
+  - govuk_jenkins::jobs::copy_attachments_from_staging_to_aws
   - govuk_jenkins::jobs::data_sync_complete_staging
   - govuk_jenkins::jobs::deploy_app
   - govuk_jenkins::jobs::deploy_cdn

--- a/modules/govuk_jenkins/manifests/jobs/copy_attachments_from_staging_to_aws.pp
+++ b/modules/govuk_jenkins/manifests/jobs/copy_attachments_from_staging_to_aws.pp
@@ -1,0 +1,13 @@
+# == Class: govuk_jenkins::jobs::copy_attachments_from_staging_to_aws
+#
+# Create a file on disk that can be parsed by jenkins-job-builder
+#
+class govuk_jenkins::jobs::copy_attachments_from_staging_to_aws (
+  $app_domain = hiera('app_domain'),
+) {
+  file { '/etc/jenkins_jobs/jobs/copy_attachments_from_staging_to_aws.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/copy_attachments_from_staging_to_aws.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+}

--- a/modules/govuk_jenkins/templates/jobs/copy_attachments_from_staging_to_aws.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_attachments_from_staging_to_aws.yaml.erb
@@ -1,0 +1,43 @@
+---
+- scm:
+    name: env-sync-and-backup_Copy_Attachments_from_Staging_to_AWS
+    scm:
+        - git:
+            url: git@github.com:alphagov/env-sync-and-backup.git
+            branches:
+              - master
+
+- job:
+    name: Copy_Attachments_from_Staging_to_AWS
+    display-name: Copy_Attachments_from_Staging_to_AWS
+    project-type: freestyle
+    description: |
+        This job copies assets attachments from Staging to AWS.
+    properties:
+        - github:
+            url: https://github.com/alphagov/env-sync-and-backup/
+        - inject:
+            properties-content: |
+              PARALLEL_JOBS=1
+    scm:
+      - env-sync-and-backup_Copy_Attachments_from_Staging_to_AWS
+    logrotate:
+        numToKeep: 10
+    builders:
+        - shell: |
+            set -eu
+
+            cd "${WORKSPACE}"
+
+            echo "Syncing data"
+            export JOBLIST=attachments
+            bash sync staging integration
+    wrappers:
+        - ansicolor:
+            colormap: xterm
+    parameters:
+        - choice:
+            name: JOBLIST
+            description: 'Choose the thing to sync. All is the default, but some jobs may run but not do anything due to your config for the destination environment.'
+            choices:
+                - attachments


### PR DESCRIPTION
We had to rebuild the asset-master instance on AWS to fix permissions
in the shared directory, and now we need to sync all the attachments.

Given the high volume of data to sync, we are going to run a single job
to copy the data from Staging to AWS, that will probably take a couple
of days.

The job is configured on Jenkins in Staging to avoid load/traffic increase
on production.