### PR TITLE
Fixes for draft stack in development VM

### DIFF
--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -93,6 +93,7 @@ govuk::apps::asset_manager::mongodb_nodes: ['localhost']
 govuk::apps::authenticating_proxy::mongodb_name: 'authenticating_proxy_development'
 govuk::apps::authenticating_proxy::mongodb_nodes: ['localhost']
 govuk::apps::authenticating_proxy::govuk_upstream_uri: 'http://government-frontend.dev.gov.uk'
+govuk::apps::authenticating_proxy::signon_uri_scheme: 'http'
 govuk::apps::backdrop_write::enable_procfile_worker: false
 govuk::apps::collections_publisher::enable_procfile_worker: false
 govuk::apps::contacts::extra_aliases: ['contacts-admin']

--- a/hieradata/development_credentials.yaml
+++ b/hieradata/development_credentials.yaml
@@ -205,6 +205,8 @@ www_key: |
   3efv6yltLy65qffs8jH6djXFjBOGMxpEt429y42l0v09NIJxI4walhBRwPE=
   -----END RSA PRIVATE KEY-----
 
+govuk::apps::authenticating_proxy::oauth_id: 'oauth-authenticating-proxy'
+govuk::apps::authenticating_proxy::oauth_secret: 'secret'
 govuk::apps::asset_manager::oauth_id: 'oauth-asset-manager'
 govuk::apps::asset_manager::oauth_secret: 'secret'
 govuk::apps::collections::email_alert_api_bearer_token: 'oauth-bearer-token-email-alert-api'

--- a/modules/govuk/manifests/apps/authenticating_proxy.pp
+++ b/modules/govuk/manifests/apps/authenticating_proxy.pp
@@ -39,6 +39,9 @@
 #   The secret used to decode JWT authentication tokens. This value needs to be
 #   shared with the publishing apps that generate the encoded tokens.
 #
+# [*signon_uri_scheme*]
+#   Scheme to use for signon URI.
+#   Default: 'https'
 class govuk::apps::authenticating_proxy(
   $mongodb_nodes,
   $mongodb_name = 'authenticating_proxy_production',
@@ -49,6 +52,7 @@ class govuk::apps::authenticating_proxy(
   $oauth_secret = undef,
   $secret_key_base = undef,
   $jwt_auth_secret = undef,
+  $signon_uri_scheme = 'https',
 ) {
   $app_name = 'authenticating-proxy'
 
@@ -112,6 +116,6 @@ class govuk::apps::authenticating_proxy(
     "${title}-PLEK_SERVICE_SIGNON_URI":
       app     => $app_name,
       varname => 'PLEK_SERVICE_SIGNON_URI',
-      value   => "https://signon.${app_domain}";
+      value   => "${signon_uri_scheme}://signon.${app_domain}";
   }
 }


### PR DESCRIPTION
I've recently been running the draft stack on my development VM and ran into a couple of issues:

* Unlike other apps, the authenticating-proxy app had no OAuth credentials by default. This made it more work to set the credentials on the app in the Signon app. By adding default credentials like the other apps, we can make life a bit simpler.

* The `PLEK_SERVICE_SIGNON_URI` environment variable for the authenticating-proxy app was being set to a URI with the `https` scheme, but none of the apps (including Signon) run with SSL on the development VM and so when attempting to authenticate a user by redirecting to Signon, the request would fail.
