### PR TITLE
Install a couple of dev packages on ci agents

### DIFF
--- a/modules/govuk_ci/manifests/agent.pp
+++ b/modules/govuk_ci/manifests/agent.pp
@@ -72,6 +72,14 @@ class govuk_ci::agent(
     provider => 'pip',
   }
 
+  # Needed for govuk-taxonomy-supervised-learning
+  package { 'python3-dev':
+    ensure => installed,
+  }
+  package { 'libfreetype6-dev':
+    ensure => installed,
+  }
+
   govuk_bundler::config {'jenkins-bundler':
     server    => $gemstash_server,
     username  => 'jenkins',


### PR DESCRIPTION
These are needed to make pip install the requirements for the
govuk-taxonomy-supervised-learning project, which I'm trying to get
running on CI for running the testsuite.