### PR TITLE
Allow public access to the homepage in the Content Store

### DIFF
--- a/modules/govuk/templates/publicapi_nginx_extra_config.erb
+++ b/modules/govuk/templates/publicapi_nginx_extra_config.erb
@@ -22,7 +22,7 @@
     proxy_pass <%= @privateapi_protocol %>://<%= @rummager_api %>;
   }
 
-  location ~ ^/api/content/ {
+  location ~ ^/api/content(/|$) {
     limit_except GET {
       deny all;
     }


### PR DESCRIPTION
Adjust the relevant location to allow requests like
https://www.gov.uk/api/content and https://www.gov.uk/api/content/
through to the Content Store.