### PR TITLE
Split audit tool

### DIFF
--- a/development-vm/Pinfile
+++ b/development-vm/Pinfile
@@ -15,6 +15,7 @@ process :collections => [:static, :'content-store', :rummager]
 process :'collections-publisher' => [:'publishing-api', :'collections-publisher-worker']
 process :'collections-publisher-worker'
 process :'contacts-admin' => [:'publishing-api', :whitehall]
+process :'content-audit-tool' => [:'publishing-api-read', :'content-audit-tool-sidekiq-google-analytics', :'content-audit-tool-sidekiq-publishing-api']
 process :'content-performance-manager' => [:'publishing-api-read', :'content-performance-manager-sidekiq-google-analytics', :'content-performance-manager-sidekiq-publishing-api']
 process :'content-store'
 # Example usage: bowl [your-app] dummy-content-store --without content-store

--- a/development-vm/Procfile
+++ b/development-vm/Procfile
@@ -159,3 +159,7 @@ link-checker-api-sidekiq:             govuk_setenv link-checker-api            .
 # sidekiq-monitoring for specialist-publisher uses port 3210
 # sidekiq-monitoring's web frontend listens on port 3211 and proxies requests per app to other ports (defined elsewhere in this file)
 publishing-components:                govuk_setenv publishing-components       ./run_in.sh ../../govuk_publishing_components bundle exec foreman start
+# sidekiq-monitoring for content-audit-tool uses port 3212
+content-audit-tool: govuk_setenv content-audit-tool ./run_in.sh ../../content-audit-tool bundle exec rails server -p 3212
+content-audit-tool-sidekiq-google-analytics:  govuk_setenv content-audit-tool ./run_in.sh ../../content-audit-tool bundle exec sidekiq -C ./config/sidekiq/google_analytics.yml
+content-audit-tool-sidekiq-publishing-api:  govuk_setenv content-audit-tool ./run_in.sh ../../content-audit-tool bundle exec sidekiq -C ./config/sidekiq/publishing_api.yml

--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -8,6 +8,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::check_content_consistency
   - govuk_jenkins::jobs::check_content_store
   - govuk_jenkins::jobs::check_pingdom_ip_ranges
+  - govuk_jenkins::jobs::content_audit_tool
   - govuk_jenkins::jobs::content_performance_manager
   - govuk_jenkins::jobs::copy_data_to_integration
   - govuk_jenkins::jobs::copy_data_to_staging

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -343,6 +343,11 @@ govuk::apps::collections_publisher::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::contacts::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::contacts::redis_port: "%{hiera('sidekiq_port')}"
 
+govuk::apps::content_audit_tool::db_hostname: "postgresql-primary-1.backend"
+govuk::apps::content_audit_tool::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
+govuk::apps::content_audit_tool::redis_host: "%{hiera('sidekiq_host')}"
+govuk::apps::content_audit_tool::redis_port: "%{hiera('sidekiq_port')}"
+
 govuk::apps::content_performance_manager::db_hostname: "postgresql-primary-1.backend"
 govuk::apps::content_performance_manager::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 govuk::apps::content_performance_manager::redis_host: "%{hiera('sidekiq_host')}"
@@ -526,6 +531,8 @@ govuk::apps::service_manual_publisher::db::backend_ip_range: "%{hiera('environme
 
 govuk::apps::sidekiq_monitoring::asset_manager_redis_host: "%{hiera('govuk::apps::asset_manager::redis_host')}"
 govuk::apps::sidekiq_monitoring::asset_manager_redis_port: "%{hiera('govuk::apps::asset_manager::redis_port')}"
+govuk::apps::sidekiq_monitoring::content_audit_tool_redis_host: "%{hiera('govuk::apps::content_audit_tool::redis_host')}"
+govuk::apps::sidekiq_monitoring::content_audit_tool_redis_port: "%{hiera('govuk::apps::content_audit_tool::redis_port')}"
 govuk::apps::sidekiq_monitoring::content_performance_manager_redis_host: "%{hiera('govuk::apps::content_performance_manager::redis_host')}"
 govuk::apps::sidekiq_monitoring::content_performance_manager_redis_port: "%{hiera('govuk::apps::content_performance_manager::redis_port')}"
 govuk::apps::sidekiq_monitoring::content_tagger_redis_host: "%{hiera('govuk::apps::content_tagger::redis_host')}"

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -29,6 +29,7 @@ govuk::node::s_development::apps:
   - 'collections'
   - 'collections_publisher'
   - 'contacts'
+  - 'content_audit_tool'
   - 'content_performance_manager'
   - 'content_store'
   - 'content_store::enable_running_in_draft_mode'

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -68,6 +68,8 @@ base::supported_kernel::enabled: false
 
 environment_ip_prefix: '10.3'
 
+govuk::apps::content_audit_tool::ensure: 'absent'
+
 govuk::apps::asset_manager::aws_s3_bucket_name: 'govuk-assets-production'
 govuk::apps::asset_manager::aws_region: 'eu-west-1'
 govuk::apps::content_store::performance_platform_big_screen_view_url: 'https://performance-platform-big-screen-view-production.cloudapps.digital'
@@ -118,6 +120,9 @@ govuk_jenkins::jobs::network_config_deploy::environments:
   - 'carrenza-production'
   - 'carrenza-production-dr'
   - 'skyscape-production'
+
+govuk_jenkins::jobs::content_audit_tool::rake_import_all_content_items_frequency: '0 1 * * 0,3'
+govuk_jenkins::jobs::content_audit_tool::rake_import_all_ga_metrics_frequency: '0 6 * * 0,3'
 
 govuk_jenkins::jobs::content_performance_manager::rake_import_all_content_items_frequency: '0 2 * * *'
 govuk_jenkins::jobs::content_performance_manager::rake_import_all_ga_metrics_frequency: '0 7 * * *'

--- a/hieradata/vagrant_credentials.yaml
+++ b/hieradata/vagrant_credentials.yaml
@@ -28,6 +28,8 @@ govuk::apps::collections_publisher::db::mysql_password: 'BeDrefCoopdevAynhagmimU
 govuk::apps::collections_publisher::db_password: "%{hiera('govuk::apps::collections_publisher::db::mysql_password')}"
 govuk::apps::contacts::db::mysql_contacts_frontend: 'DfM7oUW8Hsn9g23WZW3Hvv4wmr69deQX'
 govuk::apps::contacts::db::mysql_contacts_admin: 'DO7910Lz5ohJukmnvC6GrN3e4jtUP82l'
+govuk::apps::content_audit_tool::db::password: 'MDgTmQKvEAax4wgefQAZRNDTajkdtEVf'
+govuk::apps::content_audit_tool::db_password: "%{hiera('govuk::apps::content_audit_tool::db::password')}"
 govuk::apps::content_performance_manager::db_password: "%{hiera('govuk::apps::content_performance_manager::db::password')}"
 govuk::apps::content_performance_manager::db::password: 'jo6Kah0kuokaighoughePhooch1Eequu'
 govuk::apps::content_tagger::db_password: "%{hiera('govuk::apps::content_tagger::db::password')}"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -19,6 +19,7 @@ node_class: &node_class
       - canary-backend
       - collections-publisher
       - contacts
+      - content-audit-tool
       - content-performance-manager
       - content-tagger
       - email-alert-api
@@ -353,6 +354,11 @@ govuk::apps::collections_publisher::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::contacts::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::contacts::redis_port: "%{hiera('sidekiq_port')}"
 
+govuk::apps::content_audit_tool::db_hostname: "postgresql-primary"
+govuk::apps::content_audit_tool::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
+govuk::apps::content_audit_tool::redis_host: "%{hiera('sidekiq_host')}"
+govuk::apps::content_audit_tool::redis_port: "%{hiera('sidekiq_port')}"
+
 govuk::apps::content_performance_manager::db_hostname: "postgresql-primary"
 govuk::apps::content_performance_manager::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 govuk::apps::content_performance_manager::redis_host: "%{hiera('sidekiq_host')}"
@@ -525,6 +531,8 @@ govuk::apps::service_manual_publisher::db::backend_ip_range: "%{hiera('environme
 
 govuk::apps::sidekiq_monitoring::asset_manager_redis_host: "%{hiera('govuk::apps::asset_manager::redis_host')}"
 govuk::apps::sidekiq_monitoring::asset_manager_redis_port: "%{hiera('govuk::apps::asset_manager::redis_port')}"
+govuk::apps::sidekiq_monitoring::content_audit_tool_redis_host: "%{hiera('govuk::apps::content_audit_tool::redis_host')}"
+govuk::apps::sidekiq_monitoring::content_audit_tool_redis_port: "%{hiera('govuk::apps::content_audit_tool::redis_port')}"
 govuk::apps::sidekiq_monitoring::content_performance_manager_redis_host: "%{hiera('govuk::apps::content_performance_manager::redis_host')}"
 govuk::apps::sidekiq_monitoring::content_performance_manager_redis_port: "%{hiera('govuk::apps::content_performance_manager::redis_port')}"
 govuk::apps::sidekiq_monitoring::content_tagger_redis_host: "%{hiera('govuk::apps::content_tagger::redis_host')}"
@@ -604,6 +612,7 @@ govuk::apps::transition::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::travel_advice_publisher::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::travel_advice_publisher::redis_port: "%{hiera('sidekiq_port')}"
 
+govuk::apps::content_audit_tool::db::rds: true
 govuk::apps::content_performance_manager::db::rds: true
 govuk::apps::content_tagger::db::rds: true
 govuk::apps::email_alert_api::db::rds: true

--- a/modules/govuk/manifests/apps/content_audit_tool.pp
+++ b/modules/govuk/manifests/apps/content_audit_tool.pp
@@ -5,8 +5,8 @@
 # === Parameters
 #
 # [*ensure*]
-# Whether the application should be exist. Can be specified for each
-# environment using deployment hieradata.
+#   Whether the application should be exist. Can be specified for each
+#   environment using deployment hieradata.
 #
 # [*db_hostname*]
 #   The hostname of the database server to use in the DATABASE_URL.

--- a/modules/govuk/manifests/apps/content_audit_tool.pp
+++ b/modules/govuk/manifests/apps/content_audit_tool.pp
@@ -1,0 +1,157 @@
+# == Class: govuk::apps::content_audit_tool
+#
+# App details at: https://github.com/alphagov/content-audit-tool
+#
+# === Parameters
+#
+# [*ensure*]
+# Whether the application should be exist. Can be specified for each
+# environment using deployment hieradata.
+#
+# [*db_hostname*]
+#   The hostname of the database server to use in the DATABASE_URL.
+#   Default: undef
+#
+# [*db_name*]
+#   The database name to use in the DATABASE_URL.
+#
+# [*db_password*]
+#   The password for the database.
+#   Default: undef
+#
+# [*db_username*]
+#   The username to use in the DATABASE_URL.
+#
+# [*google_analytics_govuk_view_id*]
+#   The view id of GOV.UK in Google Analytics
+#   Default: undef
+#
+# [*google_client_email*]
+#   Google authentication email
+#   Default: undef
+#
+# [*google_private_key*]
+#   Google authentication private key
+#   Default: undef
+#
+# [*oauth_id*]
+#   Sets the OAuth ID for using GDS-SSO
+#   Default: undef
+#
+# [*oauth_secret*]
+#   Sets the OAuth Secret Key for using GDS-SSO
+#   Default: undef
+#
+# [*port*]
+#   The port that it is served on.
+#   Default: 3206
+#
+# [*publishing_api_bearer_token*]
+#   The bearer token to use when communicating with Publishing API.
+#   Default: undef
+#
+# [*redis_host*]
+#   Redis host for Sidekiq.
+#   Default: undef
+#
+# [*redis_port*]
+#   Redis port for Sidekiq.
+#   Default: undef
+#
+# [*secret_key_base*]
+#   The key for Rails to use when signing/encrypting sessions.
+#
+# [*sentry_dsn*]
+#   The URL used by Sentry to report exceptions
+#
+class govuk::apps::content_audit_tool(
+  $ensure = 'present',
+  $db_hostname = undef,
+  $db_name = 'content_audit_tool_production',
+  $db_password = undef,
+  $db_username = 'content_audit_tool',
+  $enable_procfile_worker = true,
+  $google_analytics_govuk_view_id = undef,
+  $google_client_email = undef,
+  $google_private_key = undef,
+  $oauth_id = undef,
+  $oauth_secret = undef,
+  $port = '3212',
+  $publishing_api_bearer_token = undef,
+  $redis_host = undef,
+  $redis_port = undef,
+  $secret_key_base = undef,
+  $sentry_dsn = undef,
+) {
+  $app_name = 'content-audit-tool'
+
+  govuk::app { $app_name:
+    ensure            => $ensure,
+    app_type          => 'rack',
+    port              => $port,
+    sentry_dsn        => $sentry_dsn,
+    health_check_path => '/',
+    asset_pipeline    => true,
+  }
+
+  if $ensure == 'present' {
+    Govuk::App::Envvar {
+      app    => $app_name,
+    }
+
+    govuk::procfile::worker { "${app_name}-google-analytics-worker":
+      enable_service => $enable_procfile_worker,
+      setenv_as      => $app_name,
+      process_type   => 'google-analytics-worker',
+    }
+
+    govuk::procfile::worker { "${app_name}-publishing-api-worker":
+      enable_service => $enable_procfile_worker,
+      setenv_as      => $app_name,
+      process_type   => 'publishing-api-worker',
+    }
+
+    govuk::app::envvar {
+      "${title}-GOOGLE_ANALYTICS_GOVUK_VIEW_ID":
+        varname => 'GOOGLE_ANALYTICS_GOVUK_VIEW_ID',
+        value   => $google_analytics_govuk_view_id;
+      "${title}-GOOGLE_PRIVATE_KEY":
+        varname => 'GOOGLE_PRIVATE_KEY',
+        value   => $google_private_key;
+      "${title}-GOOGLE_CLIENT_EMAIL":
+        varname => 'GOOGLE_CLIENT_EMAIL',
+        value   => $google_client_email;
+      "${title}-OAUTH_ID":
+        varname => 'OAUTH_ID',
+        value   => $oauth_id;
+      "${title}-OAUTH_SECRET":
+        varname => 'OAUTH_SECRET',
+        value   => $oauth_secret;
+      "${title}-PUBLISHING_API_BEARER_TOKEN":
+        varname => 'PUBLISHING_API_BEARER_TOKEN',
+        value   => $publishing_api_bearer_token;
+    }
+
+    govuk::app::envvar::redis { $app_name:
+      host => $redis_host,
+      port => $redis_port,
+    }
+
+    if $secret_key_base != undef {
+      govuk::app::envvar { "${title}-SECRET_KEY_BASE":
+        varname => 'SECRET_KEY_BASE',
+        value   => $secret_key_base,
+      }
+    }
+  }
+
+  if $::govuk_node_class !~ /^development$/ {
+    govuk::app::envvar::database_url { $app_name:
+      type     => 'postgresql',
+      username => $db_username,
+      password => $db_password,
+      host     => $db_hostname,
+      database => $db_name,
+    }
+  }
+}

--- a/modules/govuk/manifests/apps/content_audit_tool/db.pp
+++ b/modules/govuk/manifests/apps/content_audit_tool/db.pp
@@ -8,6 +8,9 @@
 # [*backend_ip_range*]
 #   Backend IP addresses to allow access to the database.
 #
+# [*rds]
+#   Flag for whether we are usng AWS RDS.
+#
 class govuk::apps::content_audit_tool::db (
   $password,
   $backend_ip_range = undef,

--- a/modules/govuk/manifests/apps/content_audit_tool/db.pp
+++ b/modules/govuk/manifests/apps/content_audit_tool/db.pp
@@ -1,0 +1,23 @@
+# == Class: govuk::apps::content_audit_tool::db
+#
+# === Parameters
+#
+# [*password*]
+#   The DB instance password.
+#
+# [*backend_ip_range*]
+#   Backend IP addresses to allow access to the database.
+#
+class govuk::apps::content_audit_tool::db (
+  $password,
+  $backend_ip_range = undef,
+  $rds = false,
+) {
+  govuk_postgresql::db { 'content_audit_tool_production':
+    user                    => 'content_audit_tool',
+    password                => $password,
+    allow_auth_from_backend => true,
+    backend_ip_range        => $backend_ip_range,
+    rds                     => $rds,
+  }
+}

--- a/modules/govuk/manifests/node/s_backend_lb.pp
+++ b/modules/govuk/manifests/node/s_backend_lb.pp
@@ -47,6 +47,7 @@ class govuk::node::s_backend_lb (
   loadbalancer::balance { [
     'collections-publisher',
     'contacts-admin',
+    'content-audit-tool',
     'content-performance-manager',
     'content-tagger',
     'email-alert-api-public',

--- a/modules/govuk/manifests/node/s_postgresql_base.pp
+++ b/modules/govuk/manifests/node/s_postgresql_base.pp
@@ -3,6 +3,7 @@
 # Base node for s_postgresql_{master,slave}
 #
 class govuk::node::s_postgresql_base inherits govuk::node::s_base {
+  include govuk::apps::content_audit_tool::db
   include govuk::apps::content_performance_manager::db
   include govuk::apps::content_tagger::db
   include govuk::apps::email_alert_api::db


### PR DESCRIPTION
We are splitting out the Content Audit Tool from the Content Performance Manager. We are effectively freezing development on the Audit Tool, but it is in beta with users at the moment and needs to be available.

However we are going to be developing the Content Performance Manager extensively and as the Audit Tool is so coupled it is a risk to keep the two together - changes CPM code may break the Audit Tool and becomes a maintenance headache. This is the best, cleanest option at present.