### PR TITLE
Change email-alert-api template ID for Notify

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -77,6 +77,7 @@ govuk::apps::email_alert_api::db::backend_ip_range: '10.3.3.0/24'
 govuk::apps::email_alert_api::govdelivery_account_code: 'UKGOVUK'
 govuk::apps::email_alert_api::govdelivery_hostname: 'api.govdelivery.com'
 govuk::apps::email_alert_api::govdelivery_public_hostname: 'public.govdelivery.com'
+govuk::apps::email_alert_api::govuk_notify_template_id: 'cb633abc-6ae6-4843-ae6f-82ca500b6de2'
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::kibana::logit_environment: 0ea55710-075b-4eab-bfc3-475f28cdd0c3
 govuk::apps::local_links_manager::local_links_manager_passive_checks: true

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -19,8 +19,7 @@ govuk::apps::email_alert_api::db::backend_ip_range: '10.2.3.0/24'
 govuk::apps::email_alert_api::govdelivery_account_code: 'UKGOVUK'
 govuk::apps::email_alert_api::govdelivery_hostname: 'stage-api.govdelivery.com'
 govuk::apps::email_alert_api::govdelivery_public_hostname: 'stage-public.govdelivery.com'
-govuk::apps::email_alert_api::govuk_notify_base_url: 'https://api.staging-notify.works'
-govuk::apps::email_alert_api::govuk_notify_template_id: '76d21ce7-54c3-4fb7-8830-ba3b79287985'
+govuk::apps::email_alert_api::govuk_notify_template_id: '2844a647-6bf1-4b01-a25c-569d2cc00849'
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::kibana::logit_environment: d414187a-2796-4ea7-9b9a-d40c341646d6
 govuk::apps::link_checker_api::govuk_basic_auth_credentials: "%{hiera('http_username')}:%{hiera('http_password')}"

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -11,6 +11,7 @@ cron::daily_hour: 6
 govuk::apps::asset_manager::aws_s3_bucket_name: 'govuk-assets-integration'
 govuk::apps::asset_manager::aws_region: 'eu-west-1'
 govuk::apps::email_alert_api::allow_govdelivery_topic_syncing: true
+govuk::apps::email_alert_api::govuk_notify_template_id: '1fc69d3a-09a2-40f9-852b-03f6fcef5340'
 govuk::apps::govuk_crawler_worker::enabled: false
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
 govuk::apps::kibana::logit_environment: 2694f14b-6519-4607-81f2-8a2130e5aaec

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -19,7 +19,7 @@ govuk::apps::email_alert_api::govdelivery_account_code: 'UKGOVUK'
 govuk::apps::email_alert_api::govdelivery_hostname: 'stage-api.govdelivery.com'
 govuk::apps::email_alert_api::govdelivery_public_hostname: 'stage-public.govdelivery.com'
 govuk::apps::email_alert_api::govuk_notify_base_url: 'https://api.staging-notify.works'
-govuk::apps::email_alert_api::govuk_notify_template_id: '76d21ce7-54c3-4fb7-8830-ba3b79287985'
+govuk::apps::email_alert_api::govuk_notify_template_id: '2844a647-6bf1-4b01-a25c-569d2cc00849'
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::kibana::logit_environment: d414187a-2796-4ea7-9b9a-d40c341646d6
 govuk::apps::link_checker_api::govuk_basic_auth_credentials: "%{hiera('http_username')}:%{hiera('http_password')}"


### PR DESCRIPTION
This commit adds/updates the Notify template IDs used by email-alert-api to reflect the separation of the production/staging/integration services.

Trello: https://trello.com/c/pvDExpMk/551-set-up-notify-callbacks-for-integration-staging