### PR TITLE
Auth logs were not being shipped to Logit.

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -309,6 +309,7 @@ filebeat::prospectors:
   syslog:
     paths:
       - '/var/log/syslog'
+      - '/var/log/auth.log'
     fields:
       application: 'syslog'
   unattended-upgrades:

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -311,6 +311,7 @@ filebeat::prospectors:
   syslog:
     paths:
       - '/var/log/syslog'
+      - '/var/log/auth.log'
     fields:
       application: 'syslog'
   unattended-upgrades:


### PR DESCRIPTION
This means we couldn't analyse them in Kibana and we don't have visibility of who's logging in to the infrastructure, sudoing and so on. This is the start of building something to mitigate this identified risk in GOV.UK

https://trello.com/c/TBSbA0T2/61-we-arent-alerted-to-suspicious-connections-to-our-infrastructure