### PR TITLE
Fix X-Forwarded-Host for asset requests

### DIFF
--- a/modules/govuk/templates/static_extra_nginx_config.conf.erb
+++ b/modules/govuk/templates/static_extra_nginx_config.conf.erb
@@ -32,7 +32,6 @@ location /robots.txt {
 ].each do |path_to_be_proxied_to_asset_manager| %>
 
   location ~ ^<%= path_to_be_proxied_to_asset_manager %> {
-    proxy_set_header Host <%= @asset_manager_host %>;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-Server $host;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/modules/govuk/templates/static_extra_nginx_config.conf.erb
+++ b/modules/govuk/templates/static_extra_nginx_config.conf.erb
@@ -36,7 +36,6 @@ location /robots.txt {
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-Server $host;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Host $host;
     proxy_pass <%= @enable_ssl || @proxy_pass_asset_manager_host_https ? 'https' : 'http' %>://<%= @asset_manager_host %>;
 
     # Explicitly re-include Strict-Transport-Security header, this

--- a/modules/router/templates/assets_origin.conf.erb
+++ b/modules/router/templates/assets_origin.conf.erb
@@ -43,17 +43,12 @@ server {
 
   <%- @asset_routes.each do |alias_path, vhost_name| -%>
   location <%= alias_path %> {
-    <%- if alias_path == '/government/uploads/' && vhost_name == 'whitehall-frontend' -%>
-      proxy_set_header X-Forwarded-Host $host;
-    <%- end -%>
-    proxy_set_header Host <%= vhost_name %>.<%= @app_domain %>;
     proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://<%= vhost_name %>.<%= @app_domain %>;
   }
 
   <%- end -%>
 
   location / {
-    proxy_set_header Host static.<%= @app_domain %>;
     proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://static.<%= @app_domain %>;
   }
 }


### PR DESCRIPTION
We're about to introduce a new `draft-assets` virtual host and we're going to want Asset Manager to be able to distinguish whether a request for an asset has come via `draft-assets` or `assets-origin`.

Previously the `X-Forwarded-Host` header was not being set in the `assets-origin` virtual host, because of some confusing behaviour of [Nginx's `proxy_set_header` directive][1] where calling it inside a location block means any calls outside the location block are ignored:

> These directives are inherited from the previous level if and only if there are no proxy_set_header directives defined on the current level.

This PR fixes that problem so that all the `X-*` headers (including `X-Forwarded-Host`) set in the outer `server` block are sent to the proxy as was presumably originally intended.

Also the `X-Forwarded-Host` header was then being set to the `static` hostname in the `static` virtual host which meant that [`ActionDispatch::Request#original_url`][2] was returning a URL with the `static` hostname inside the Rails application.

This was quite confusing and will be more of a problem when we want to distinguish between a request for an asset that has come via `draft-assets` vs one that has come via `assets-origin`. After this PR has been applied, `ActionDispatch::Request#original_url` will return a URL with the `assets-origin` hostname.

[1]: http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_set_header
[2]: http://api.rubyonrails.org/v5.1.4/classes/ActionDispatch/Request.html#method-i-original_url
