### PR TITLE
Add draft-assets Nginx virtual host to development VM

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1646,6 +1646,7 @@ router::assets_origin::vhost_aliases:
   - 'assets.publishing.service.gov.uk'
 
 router::assets_origin::vhost_name: "assets-origin.%{hiera('app_domain')}"
+router::draft_assets::vhost_name: "draft-assets.%{hiera('app_domain')}"
 
 router::nginx::check_requests_warning: '@10'
 router::nginx::check_requests_critical: '@8'

--- a/modules/govuk/manifests/node/s_development.pp
+++ b/modules/govuk/manifests/node/s_development.pp
@@ -34,6 +34,7 @@ class govuk::node::s_development (
   include govuk_rbenv::all
 
   include router::assets_origin
+  include router::draft_assets
 
   $app_classes = regsubst($apps, '^', 'govuk::apps::')
   include $app_classes

--- a/modules/router/manifests/draft_assets.pp
+++ b/modules/router/manifests/draft_assets.pp
@@ -1,0 +1,32 @@
+# = Class: router::draft_assets
+#
+# Configure vhost for serving draft assets.
+#
+# === Parameters
+#
+# [*real_ip_header*]
+#   Uses the Nginx realip module (http://nginx.org/en/docs/http/ngx_http_realip_module.html)
+#   to change the client IP address to the one in the specified HTTP header.
+#
+# [*vhost_name*]
+#   Primary vhost for draft assets
+#
+
+class router::draft_assets(
+  $real_ip_header = '',
+  $vhost_name = 'draft-assets',
+) {
+  $enable_ssl = hiera('nginx_enable_ssl', true)
+
+  if $::aws_migration {
+    $app_domain = hiera('app_domain_internal')
+    $upstream_ssl = true
+  } else {
+    $app_domain = hiera('app_domain')
+    $upstream_ssl = $enable_ssl
+  }
+
+  nginx::config::site { 'draft-assets':
+    content => template('router/draft-assets.conf.erb'),
+  }
+}

--- a/modules/router/templates/draft-assets.conf.erb
+++ b/modules/router/templates/draft-assets.conf.erb
@@ -1,0 +1,38 @@
+server {
+  <%- if scope.lookupvar('::aws_migration') %>
+  server_name <%= @vhost_name %> <%= @vhost_name %>.*;
+  <%- else %>
+  server_name <%= @vhost_name %>;
+  <%- end %>
+
+  listen 80;
+
+  proxy_set_header X-Real-IP $remote_addr;
+  proxy_set_header X-Forwarded-Server $host;
+  proxy_set_header X-Forwarded-Host $host;
+  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+<% if @real_ip_header != '' -%>
+  # use an unspoofable header from an upstream cdn or l7 load balancer.
+  real_ip_header <%= @real_ip_header -%>;
+  real_ip_recursive on;
+  set_real_ip_from 0.0.0.0/0;
+
+  # Limit requests and connections based on $remote_addr.
+  # NB: This may not be accurate if there is a L3 load balancer upstream and
+  # real_ip_header cannot be set!
+  limit_req zone=rate burst=10 nodelay;
+  limit_conn connections 10;
+<% end -%>
+
+  access_log /var/log/nginx/<%= @vhost_name %>-json.event.access.log json_event;
+  error_log /var/log/nginx/<%= @vhost_name %>-error.log;
+
+  add_header "Access-Control-Allow-Origin" "*";
+  add_header "Access-Control-Allow-Methods" "GET, OPTIONS";
+  add_header "Access-Control-Allow-Headers" "origin, authorization";
+
+  location / {
+    proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://asset-manager.<%= @app_domain %>;
+  }
+}


### PR DESCRIPTION
We need this host to allow Asset Manager to protect draft assets behind SSO. We're only adding the new virtual host to the development VM for the moment, because we think we need to create SSL certificates, add DNS entries, and create new ELB instances to make use of this in other environments.

The configuration of the new virtual host is based heavily on that of the assets-origin virtual host. One significant difference is that it proxies all requests directly to Asset Manager - rather than doing this via the static virtual host. Note that it is important that the SSO-related paths (i.e. `/auth/gds/*`) as well as the Mainstream asset paths (i.e. `/media/*`) and Whitehall asset paths (i.e. `/government/uploads/*`).

We have intentionally not added a `proxy_set_header` directive to set the `Host` request header inside the `location` block, because this would mean that none of the `X-*` request headers set in the outer `server` block would be set. In particular Asset Manager will need to be able to rely on the value of `X-Forwarded-Host` being set correctly in order to determine whether an asset request came via `assets-origin` or `draft-assets`.

The new virtual host can be enabled in other environments by adding the following snippet to the body of `modules/router/manifests/nginx.pp`.

    class { 'router::draft_assets':
      real_ip_header => $real_ip_header,
    }

We have done some preliminary testing of the above snippet in the integration environment and it seemed to work correctly.
