### PR TITLE
Deploy_App AWS use graphite internal domain

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -643,7 +643,7 @@ govuk_htpasswd::http_username: "%{hiera('http_username')}"
 govuk_jenkins::packages::gcloud::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk_jenkins::packages::terraform::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
-govuk_jenkins::jobs::deploy_app::graphite_host: 'graphite'
+govuk_jenkins::jobs::deploy_app::graphite_host: 'graphite.%{hiera('app_domain_internal')}'
 govuk_jenkins::jobs::deploy_app::graphite_port: '443'
 
 govuk_jenkins::deploy_all_apps::deploy_environment: "%{hiera('govuk_jenkins::job_builder::environment')}"


### PR DESCRIPTION
Related with https://github.com/alphagov/govuk-puppet/pull/7027

We are now using the right protocol and port to connect with Graphite
but we are still getting:

```
Graphite notification failed: SSL_connect returned=1 errno=0 state=SSLv3
read server certificate B: certificate verify failed
```

Use the full internal domain to send the request to avoid the certificate
error, that was requested for *.govuk-internal.digital