### PR TITLE
Add environment specific hieradata for AWS

### DIFF
--- a/hiera_aws.yml
+++ b/hiera_aws.yml
@@ -1,7 +1,9 @@
 ---
 :hierarchy:
   - 'node/%{::fqdn}'
+  - 'class/%{::aws_stackname}/%{::environment}/%{::govuk_node_class}'
   - 'class/%{::aws_stackname}/%{::govuk_node_class}'
+  - 'class/%{::environment}/%{::govuk_node_class}'
   - 'class/%{::govuk_node_class}'
   - '%{::aws_stackname}/%{::environment}_credentials'
   - '%{::environment}_credentials'

--- a/hieradata_aws/class/staging/jenkins.yaml
+++ b/hieradata_aws/class/staging/jenkins.yaml
@@ -1,0 +1,8 @@
+---
+govuk_jenkins::job_builder::jobs:
+  - govuk_jenkins::jobs::deploy_app
+  - govuk_jenkins::jobs::deploy_puppet
+  - govuk_jenkins::jobs::passive_checks
+  - govuk_jenkins::jobs::run_rake_task
+  - govuk_jenkins::jobs::smokey
+  - govuk_jenkins::jobs::smokey_deploy


### PR DESCRIPTION
This adds environment specific overrides in `hiera_aws.yml`.

It also adds some specific environment data for Jenkins.