### PR TITLE
Add job template for Content Audit Tool

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/content_audit_tool.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/content_audit_tool.yaml.erb
@@ -1,0 +1,39 @@
+---
+- job:
+    name: content_audit_tool_import_all_content_items
+    display-name: Content Audit Tool - import inventory
+    project-type: freestyle
+    description: "<p>Run the import:all_content_items rake task.</p>"
+    builders:
+      - shell: ssh deploy@$(govuk_node_list -c backend --single-node) "cd /var/apps/content-audit-tool && govuk_setenv content-audit-tool bundle exec rake import:all_content_items"
+    wrappers:
+      - ansicolor:
+          colormap: xterm
+    publishers:
+      - email:
+          recipients: govuk-ci-notifications@digital.cabinet-office.gov.uk
+  <% if @rake_import_all_content_items_frequency %>
+    triggers:
+      - timed: <%= @rake_import_all_content_items_frequency %>
+  <% end %>
+    logrotate:
+        numToKeep: 10
+- job:
+    name: content_audit_tool_import_all_ga_metrics
+    display-name: Content Audit Tool - import GA
+    project-type: freestyle
+    description: "<p>Run the import:all_ga_metrics rake task.</p>"
+    builders:
+      - shell: ssh deploy@$(govuk_node_list -c backend --single-node) "cd /var/apps/content-audit-tool && govuk_setenv content-audit-tool bundle exec rake import:all_ga_metrics"
+    wrappers:
+      - ansicolor:
+          colormap: xterm
+    publishers:
+      - email:
+          recipients: govuk-ci-notifications@digital.cabinet-office.gov.uk
+  <% if @rake_import_all_ga_metrics_frequency %>
+    triggers:
+      - timed: <%= @rake_import_all_ga_metrics_frequency %>
+  <% end %>
+    logrotate:
+        numToKeep: 10


### PR DESCRIPTION
Jenkins jobs to run rake tasks for Content Audit Tool. These
import content items and grab GA stats for them. These are copied
over from the Content Performance Manager, as part of splitting
the Audit Tool out of the CPM.