### PR TITLE
Add nginx vhost for Audit Tool sidekiq monitoring

### DIFF
--- a/modules/govuk/templates/sidekiq_monitoring_nginx_config.conf.erb
+++ b/modules/govuk/templates/sidekiq_monitoring_nginx_config.conf.erb
@@ -22,6 +22,10 @@ server {
     proxy_pass http://localhost:3038;
   }
 
+  location /content-audit-tool {
+    proxy_pass http://localhost:3212;
+  }
+
   location /content-performance-manager {
     proxy_pass http://localhost:3207;
   }


### PR DESCRIPTION
As per instruction:

https://docs.publishing.service.gov.uk/manual/setting-up-new-sidekiq-monitoring-app.html#configuring-a-path-under-the-sidekiq-monitoring-vhost