### PR TITLE
Move default Jenkins Jobs to common.yaml

### DIFF
--- a/hieradata_aws/class/jenkins.yaml
+++ b/hieradata_aws/class/jenkins.yaml
@@ -50,43 +50,6 @@ govuk_jenkins::config::user_permissions:
       - 'hudson.model.Item.Build'
       - 'hudson.model.Item.Read'
 
-govuk_jenkins::config::banner_string: 'AWS Integration'
-govuk_jenkins::config::banner_colour_background: '#005EA5'
-govuk_jenkins::config::banner_colour_text: 'white'
-govuk_jenkins::config::theme_colour: '#005EA5'
-govuk_jenkins::config::theme_text_colour: 'white'
-govuk_jenkins::config::theme_environment_name: 'AWS Integration'
-
-govuk_jenkins::job_builder::jobs:
-  - govuk_jenkins::jobs::check_content_consistency
-  - govuk_jenkins::jobs::check_content_store
-  - govuk_jenkins::jobs::configure_github_repos
-  - govuk_jenkins::jobs::data_sync_complete_integration
-  - govuk_jenkins::jobs::deploy_app
-  - govuk_jenkins::jobs::deploy_dns
-  - govuk_jenkins::jobs::deploy_emergency_banner
-  - govuk_jenkins::jobs::deploy_puppet
-  - govuk_jenkins::jobs::deploy_router_data
-  - govuk_jenkins::jobs::enhanced_ecommerce
-  - govuk_jenkins::jobs::passive_checks
-  - govuk_jenkins::jobs::record_taxonomy_metrics
-  - govuk_jenkins::jobs::remove_emergency_banner
-  - govuk_jenkins::jobs::run_deploy_lag_badger
-  - govuk_jenkins::jobs::run_rake_task
-  - govuk_jenkins::jobs::run_whitehall_data_migrations
-  - govuk_jenkins::jobs::search_benchmark
-  - govuk_jenkins::jobs::search_fetch_analytics_data
-  - govuk_jenkins::jobs::search_index_checks
-  - govuk_jenkins::jobs::search_reindex_with_new_schema
-  - govuk_jenkins::jobs::search_test_spelling_suggestions
-  - govuk_jenkins::jobs::signon_cron_rake_tasks
-  - govuk_jenkins::jobs::smokey
-  - govuk_jenkins::jobs::smokey_deploy
-  - govuk_jenkins::jobs::transition_load_site_config
-  - govuk_jenkins::jobs::transition_load_transition_stats_hits
-  - govuk_jenkins::jobs::user_monitor
-  - govuk_jenkins::jobs::whitehall_update_integration_data
-
 govuk_jenkins::packages::terraform::version: '0.8.1'
 
 govuk_jenkins::plugins:

--- a/hieradata_aws/class/staging/jenkins.yaml
+++ b/hieradata_aws/class/staging/jenkins.yaml
@@ -1,8 +1,0 @@
----
-govuk_jenkins::job_builder::jobs:
-  - govuk_jenkins::jobs::deploy_app
-  - govuk_jenkins::jobs::deploy_puppet
-  - govuk_jenkins::jobs::passive_checks
-  - govuk_jenkins::jobs::run_rake_task
-  - govuk_jenkins::jobs::smokey
-  - govuk_jenkins::jobs::smokey_deploy

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -755,6 +755,43 @@ govuk_jenkins::jobs::integration_deploy::applications: *deployable_applications
 govuk_jenkins::jobs::deploy_lambda_app::lambda_apps:
   - 'email_alert_notifications'
 
+govuk_jenkins::config::banner_string: 'AWS Integration'
+govuk_jenkins::config::banner_colour_background: '#005EA5'
+govuk_jenkins::config::banner_colour_text: 'white'
+govuk_jenkins::config::theme_colour: '#005EA5'
+govuk_jenkins::config::theme_text_colour: 'white'
+govuk_jenkins::config::theme_environment_name: 'AWS Integration'
+
+govuk_jenkins::job_builder::jobs:
+  - govuk_jenkins::jobs::check_content_consistency
+  - govuk_jenkins::jobs::check_content_store
+  - govuk_jenkins::jobs::configure_github_repos
+  - govuk_jenkins::jobs::data_sync_complete_integration
+  - govuk_jenkins::jobs::deploy_app
+  - govuk_jenkins::jobs::deploy_dns
+  - govuk_jenkins::jobs::deploy_emergency_banner
+  - govuk_jenkins::jobs::deploy_puppet
+  - govuk_jenkins::jobs::deploy_router_data
+  - govuk_jenkins::jobs::enhanced_ecommerce
+  - govuk_jenkins::jobs::passive_checks
+  - govuk_jenkins::jobs::record_taxonomy_metrics
+  - govuk_jenkins::jobs::remove_emergency_banner
+  - govuk_jenkins::jobs::run_deploy_lag_badger
+  - govuk_jenkins::jobs::run_rake_task
+  - govuk_jenkins::jobs::run_whitehall_data_migrations
+  - govuk_jenkins::jobs::search_benchmark
+  - govuk_jenkins::jobs::search_fetch_analytics_data
+  - govuk_jenkins::jobs::search_index_checks
+  - govuk_jenkins::jobs::search_reindex_with_new_schema
+  - govuk_jenkins::jobs::search_test_spelling_suggestions
+  - govuk_jenkins::jobs::signon_cron_rake_tasks
+  - govuk_jenkins::jobs::smokey
+  - govuk_jenkins::jobs::smokey_deploy
+  - govuk_jenkins::jobs::transition_load_site_config
+  - govuk_jenkins::jobs::transition_load_transition_stats_hits
+  - govuk_jenkins::jobs::user_monitor
+  - govuk_jenkins::jobs::whitehall_update_integration_data
+
 govuk_postgresql::backup::alert_hostname: 'alert'
 govuk_postgresql::server::configure_env_sync_user: true
 

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -59,11 +59,13 @@ govuk_jenkins::config::theme_environment_name: 'AWS Staging'
 govuk_elasticsearch::dump::run_es_dump_hour: '4'
 
 govuk_jenkins::job_builder::environment: 'staging'
-
-govuk_jenkins::jobs::network_config_deploy::environments:
-  - 'carrenza-staging'
-  - 'carrenza-staging-dr'
-  - 'skyscape-staging'
+govuk_jenkins::job_builder::jobs:
+  - govuk_jenkins::jobs::deploy_app
+  - govuk_jenkins::jobs::deploy_puppet
+  - govuk_jenkins::jobs::passive_checks
+  - govuk_jenkins::jobs::run_rake_task
+  - govuk_jenkins::jobs::smokey
+  - govuk_jenkins::jobs::smokey_deploy
 
 govuk_jenkins::jobs::search_fetch_analytics_data::skip_page_traffic_load: true
 govuk_jenkins::jobs::search_fetch_analytics_data::cron_schedule: '30 8 * * 1-5'


### PR DESCRIPTION
The motivation behind this change is that we need to overwrite the settings for the `jenkins` node. While default configuration lives in the class based `jenkins.yaml`, we would have to create a new hierarchy for `class/staging/jenkins.yaml` to overwrite it. This isn't really required and just adds more places to look to find different data.

If we move the default configuration to `common.yaml`, then we can overwrite it using `staging.yaml`, which is clearer to understand.

This commit also removes some unneeded hieradata related to deploying stuff with vCloud Tools.

https://trello.com/c/licP4V2x/925-build-staging-in-aws-and-review