### PR TITLE
Remove private-asset-manager vhost alias

### DIFF
--- a/modules/govuk/manifests/apps/asset_manager.pp
+++ b/modules/govuk/manifests/apps/asset_manager.pp
@@ -68,6 +68,7 @@ class govuk::apps::asset_manager(
 
     govuk::app::envvar {
       "${title}-PRIVATE_ASSET_MANAGER_HOST":
+        ensure  => 'absent',
         app     => 'asset-manager',
         varname => 'PRIVATE_ASSET_MANAGER_HOST',
         value   => "private-asset-manager.${app_domain}";
@@ -169,7 +170,6 @@ class govuk::apps::asset_manager(
       sentry_dsn         => $sentry_dsn,
       vhost_ssl_only     => true,
       health_check_path  => '/healthcheck',
-      vhost_aliases      => ['private-asset-manager'],
       log_format_is_json => true,
       deny_framing       => $deny_framing,
       depends_on_nfs     => true,


### PR DESCRIPTION
Also removes the associated environment variable which made the vhost name available to the Asset Manager Rails app.

This virtual host alias was never used and the related functionality in Asset Manager was removed in [this PR][1].

Note that we will need to open a separate PR to remove the environment variable definition once this PR has been merged and applied in all environments.

[1]: https://github.com/alphagov/asset-manager/pull/426
