### PR TITLE
Move db env vars into ensure block

### DIFF
--- a/modules/govuk/manifests/apps/content_audit_tool.pp
+++ b/modules/govuk/manifests/apps/content_audit_tool.pp
@@ -143,15 +143,15 @@ class govuk::apps::content_audit_tool(
         value   => $secret_key_base,
       }
     }
-  }
 
-  if $::govuk_node_class !~ /^development$/ {
-    govuk::app::envvar::database_url { $app_name:
-      type     => 'postgresql',
-      username => $db_username,
-      password => $db_password,
-      host     => $db_hostname,
-      database => $db_name,
+    if $::govuk_node_class !~ /^development$/ {
+      govuk::app::envvar::database_url { $app_name:
+        type     => 'postgresql',
+        username => $db_username,
+        password => $db_password,
+        host     => $db_hostname,
+        database => $db_name,
+      }
     }
   }
 }


### PR DESCRIPTION
These should have been placed inside the ensure block in previous
PR https://github.com/alphagov/govuk-puppet/pull/7141

This is to prevent puppet run errors when it tries to create
env vars for an application that is 'absent' on the staging
and production environments.