### PR TITLE
BAU YAML Syntax Change

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -644,7 +644,7 @@ govuk_htpasswd::http_username: "%{hiera('http_username')}"
 govuk_jenkins::packages::gcloud::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk_jenkins::packages::terraform::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
-govuk_jenkins::jobs::deploy_app::graphite_host: 'graphite.%{hiera('app_domain_internal')}'
+govuk_jenkins::jobs::deploy_app::graphite_host: "graphite.%{hiera('app_domain_internal')}"
 govuk_jenkins::jobs::deploy_app::graphite_port: '443'
 
 govuk_jenkins::deploy_all_apps::deploy_environment: "%{hiera('govuk_jenkins::job_builder::environment')}"


### PR DESCRIPTION
- We identified a syntatctical error graphite hiera lookup. This has
  been corrected via this change.

**Symptom**
We received the following error while performing a puppet run.
`Error: Error from DataBinding 'hiera' while looking up 'govuk::node::s_base::node_apps': (<unknown>): did not find expected key while parsing a block mapping at line 2 column 1 on node i-0a432be76092fd5b4
Error: Error from DataBinding 'hiera' while looking up 'govuk::node::s_base::node_apps': (<unknown>): did not find expected key while parsing a block mapping at line 2 column 1 on node i-0a432be76092fd5b4`

**Prognosis**
This event is very recent hence a change made recently is the most probable cause.

**Diagnosis**
Checked recent changes via the following resources.
[Puppet Manifest](https://validate.puppet.com/)
[YAML Lint](http://www.yamllint.com/)

We noticed that the issue was related to a recent commit #7027.


Solo: @suthagarht