### PR TITLE
Separate app specific and user generated asset routes

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1638,6 +1638,7 @@ router::assets_origin::app_specific_asset_routes:
   '/smartanswers/': "smartanswers"
 
 router::assets_origin::asset_manager_routes:
+  - '/media/'
   - '/government/uploads/government/uploads/system/uploads/'
   - '/government/uploads/system/uploads/organisation/logo/'
   - '/government/uploads/system/uploads/classification_featuring_image_data/file/'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1630,6 +1630,14 @@ router::assets_origin::asset_routes:
   '/government/assets/': "whitehall-frontend"
   '/government/placeholder': "whitehall-frontend"
   '/government/uploads/': "whitehall-frontend"
+  '/government-frontend/': "government-frontend"
+  '/info-frontend/': "info-frontend"
+  '/manuals-frontend/': "manuals-frontend"
+  '/licencefinder/': "licencefinder"
+  '/service-manual-frontend/': "service-manual-frontend"
+  '/smartanswers/': "smartanswers"
+
+router::assets_origin::asset_manager_routes:
   '/government/uploads/government/uploads/system/uploads/': "static"
   '/government/uploads/system/uploads/organisation/logo/': "static"
   '/government/uploads/system/uploads/classification_featuring_image_data/file/': "static"
@@ -1641,12 +1649,6 @@ router::assets_origin::asset_routes:
   '/government/uploads/system/uploads/take_part_page/image/': "static"
   '/government/uploads/system/uploads/image_data/file/': "static"
   '/government/uploads/uploaded/number10/': "static"
-  '/government-frontend/': "government-frontend"
-  '/info-frontend/': "info-frontend"
-  '/manuals-frontend/': "manuals-frontend"
-  '/licencefinder/': "licencefinder"
-  '/service-manual-frontend/': "service-manual-frontend"
-  '/smartanswers/': "smartanswers"
 
 router::assets_origin::vhost_aliases:
   - 'assets.digital.cabinet-office.gov.uk'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1638,17 +1638,17 @@ router::assets_origin::asset_routes:
   '/smartanswers/': "smartanswers"
 
 router::assets_origin::asset_manager_routes:
-  '/government/uploads/government/uploads/system/uploads/': "static"
-  '/government/uploads/system/uploads/organisation/logo/': "static"
-  '/government/uploads/system/uploads/classification_featuring_image_data/file/': "static"
-  '/government/uploads/system/uploads/consultation_response_form_data/file/': "static"
-  '/government/uploads/system/uploads/default_news_organisation_image_data/file/': "static"
-  '/government/uploads/system/uploads/feature/image/': "static"
-  '/government/uploads/system/uploads/person/image/': "static"
-  '/government/uploads/system/uploads/promotional_feature_item/image/': "static"
-  '/government/uploads/system/uploads/take_part_page/image/': "static"
-  '/government/uploads/system/uploads/image_data/file/': "static"
-  '/government/uploads/uploaded/number10/': "static"
+  - '/government/uploads/government/uploads/system/uploads/'
+  - '/government/uploads/system/uploads/organisation/logo/'
+  - '/government/uploads/system/uploads/classification_featuring_image_data/file/'
+  - '/government/uploads/system/uploads/consultation_response_form_data/file/'
+  - '/government/uploads/system/uploads/default_news_organisation_image_data/file/'
+  - '/government/uploads/system/uploads/feature/image/'
+  - '/government/uploads/system/uploads/person/image/'
+  - '/government/uploads/system/uploads/promotional_feature_item/image/'
+  - '/government/uploads/system/uploads/take_part_page/image/'
+  - '/government/uploads/system/uploads/image_data/file/'
+  - '/government/uploads/uploaded/number10/'
 
 router::assets_origin::vhost_aliases:
   - 'assets.digital.cabinet-office.gov.uk'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1618,7 +1618,7 @@ resolvconf::options:
 
 # Note: it's important that all targets here have matching host entries both in
 # production, and on the dev VM, otherwise nginx will fail to start.
-router::assets_origin::asset_routes:
+router::assets_origin::app_specific_asset_routes:
   '/asset-manager': "asset-manager"
   '/calculators/': "calculators"
   '/calendars/': "calendars"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1035,7 +1035,7 @@ rcs::tmptime: '7'
 
 # Note: it's important that all targets here have matching host entries both in
 # production, and on the dev VM, otherwise nginx will fail to start.
-router::assets_origin::asset_routes:
+router::assets_origin::app_specific_asset_routes:
   '/asset-manager': "asset-manager"
   '/calculators/': "calculators"
   '/calendars/': "calendars"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1055,6 +1055,7 @@ router::assets_origin::app_specific_asset_routes:
   '/smartanswers/': "smartanswers"
 
 router::assets_origin::asset_manager_routes:
+  - '/media/'
   - '/government/uploads/government/uploads/system/uploads/'
   - '/government/uploads/system/uploads/organisation/logo/'
   - '/government/uploads/system/uploads/classification_featuring_image_data/file/'

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1055,17 +1055,17 @@ router::assets_origin::asset_routes:
   '/smartanswers/': "smartanswers"
 
 router::assets_origin::asset_manager_routes:
-  '/government/uploads/government/uploads/system/uploads/': "static"
-  '/government/uploads/system/uploads/organisation/logo/': "static"
-  '/government/uploads/system/uploads/classification_featuring_image_data/file/': "static"
-  '/government/uploads/system/uploads/consultation_response_form_data/file/': "static"
-  '/government/uploads/system/uploads/default_news_organisation_image_data/file/': "static"
-  '/government/uploads/system/uploads/feature/image/': "static"
-  '/government/uploads/system/uploads/person/image/': "static"
-  '/government/uploads/system/uploads/promotional_feature_item/image/': "static"
-  '/government/uploads/system/uploads/take_part_page/image/': "static"
-  '/government/uploads/system/uploads/image_data/file/': "static"
-  '/government/uploads/uploaded/number10/': "static"
+  - '/government/uploads/government/uploads/system/uploads/'
+  - '/government/uploads/system/uploads/organisation/logo/'
+  - '/government/uploads/system/uploads/classification_featuring_image_data/file/'
+  - '/government/uploads/system/uploads/consultation_response_form_data/file/'
+  - '/government/uploads/system/uploads/default_news_organisation_image_data/file/'
+  - '/government/uploads/system/uploads/feature/image/'
+  - '/government/uploads/system/uploads/person/image/'
+  - '/government/uploads/system/uploads/promotional_feature_item/image/'
+  - '/government/uploads/system/uploads/take_part_page/image/'
+  - '/government/uploads/system/uploads/image_data/file/'
+  - '/government/uploads/uploaded/number10/'
 
 router::assets_origin::vhost_aliases:
   - 'assets.digital.cabinet-office.gov.uk'

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1047,6 +1047,14 @@ router::assets_origin::asset_routes:
   '/government/assets/': "whitehall-frontend"
   '/government/placeholder': "whitehall-frontend"
   '/government/uploads/': "whitehall-frontend"
+  '/government-frontend/': "government-frontend"
+  '/info-frontend/': "info-frontend"
+  '/manuals-frontend/': "manuals-frontend"
+  '/licencefinder/': "licencefinder"
+  '/service-manual-frontend/': "service-manual-frontend"
+  '/smartanswers/': "smartanswers"
+
+router::assets_origin::asset_manager_routes:
   '/government/uploads/government/uploads/system/uploads/': "static"
   '/government/uploads/system/uploads/organisation/logo/': "static"
   '/government/uploads/system/uploads/classification_featuring_image_data/file/': "static"
@@ -1058,12 +1066,6 @@ router::assets_origin::asset_routes:
   '/government/uploads/system/uploads/take_part_page/image/': "static"
   '/government/uploads/system/uploads/image_data/file/': "static"
   '/government/uploads/uploaded/number10/': "static"
-  '/government-frontend/': "government-frontend"
-  '/info-frontend/': "info-frontend"
-  '/manuals-frontend/': "manuals-frontend"
-  '/licencefinder/': "licencefinder"
-  '/service-manual-frontend/': "service-manual-frontend"
-  '/smartanswers/': "smartanswers"
 
 router::assets_origin::vhost_aliases:
   - 'assets.digital.cabinet-office.gov.uk'

--- a/lib/puppet-lint/plugins/check_hiera.rb
+++ b/lib/puppet-lint/plugins/check_hiera.rb
@@ -49,6 +49,10 @@ PuppetLint.new_check(:hiera_explicit_lookup) do
     # metrics
     'govuk_logging::logstream::metrics_only',
 
+    # Allow sharing of asset_manager_routes array between assets-origin and static
+    # nginx virtual host configuration
+    'router::assets_origin::asset_manager_routes',
+
     'mysql_replica_password',
     'mysql_root',
     'nginx_enable_ssl',

--- a/modules/govuk/manifests/apps/static.pp
+++ b/modules/govuk/manifests/apps/static.pp
@@ -54,6 +54,7 @@ class govuk::apps::static(
 ) {
   $enable_ssl = hiera('nginx_enable_ssl', true)
   $app_name = 'static'
+  $asset_manager_routes = hiera('router::assets_origin::asset_manager_routes', [])
 
   if $::aws_migration {
     $proxy_pass_asset_manager_host_https = true

--- a/modules/govuk/manifests/apps/static/enable_running_in_draft_mode.pp
+++ b/modules/govuk/manifests/apps/static/enable_running_in_draft_mode.pp
@@ -47,6 +47,7 @@ class govuk::apps::static::enable_running_in_draft_mode(
   $asset_manager_host = "asset-manager.${app_domain}"
   $enable_ssl = hiera('nginx_enable_ssl', true)
   $app_name = 'draft-static'
+  $asset_manager_routes = hiera('router::assets_origin::asset_manager_routes', [])
 
   if $::aws_migration {
     $proxy_pass_asset_manager_host_https = true

--- a/modules/govuk/templates/static_extra_nginx_config.conf.erb
+++ b/modules/govuk/templates/static_extra_nginx_config.conf.erb
@@ -16,20 +16,7 @@ location /robots.txt {
   expires 1w;
 }
 
-<% [
-  '/media/',
-  '/government/uploads/government/uploads/system/uploads/',
-  '/government/uploads/system/uploads/organisation/logo/',
-  '/government/uploads/system/uploads/classification_featuring_image_data/file/',
-  '/government/uploads/system/uploads/consultation_response_form_data/file/',
-  '/government/uploads/system/uploads/default_news_organisation_image_data/file/',
-  '/government/uploads/system/uploads/feature/image/',
-  '/government/uploads/system/uploads/person/image/',
-  '/government/uploads/system/uploads/promotional_feature_item/image/',
-  '/government/uploads/system/uploads/take_part_page/image/',
-  '/government/uploads/system/uploads/image_data/file/',
-  '/government/uploads/uploaded/number10/'
-].each do |path_to_be_proxied_to_asset_manager| %>
+<% @asset_manager_routes.each do |path_to_be_proxied_to_asset_manager| %>
 
   location ~ ^<%= path_to_be_proxied_to_asset_manager %> {
     proxy_set_header X-Real-IP $remote_addr;

--- a/modules/router/manifests/assets_origin.pp
+++ b/modules/router/manifests/assets_origin.pp
@@ -22,7 +22,7 @@
 #
 class router::assets_origin(
   $asset_routes = {},
-  $asset_manager_routes = {},
+  $asset_manager_routes = [],
   $real_ip_header = '',
   $vhost_aliases = [],
   $vhost_name = 'assets-origin',

--- a/modules/router/manifests/assets_origin.pp
+++ b/modules/router/manifests/assets_origin.pp
@@ -7,6 +7,9 @@
 # [*asset_routes*]
 #   Hash of paths => vhost_names.  Each entry will be added as a route in the vhost
 #
+# [*asset_manager_routes*]
+#   Hash of paths => vhost_names.  Each entry will be added as a route in the vhost
+#
 # [*real_ip_header*]
 #   Uses the Nginx realip module (http://nginx.org/en/docs/http/ngx_http_realip_module.html)
 #   to change the client IP address to the one in the specified HTTP header.
@@ -19,6 +22,7 @@
 #
 class router::assets_origin(
   $asset_routes = {},
+  $asset_manager_routes = {},
   $real_ip_header = '',
   $vhost_aliases = [],
   $vhost_name = 'assets-origin',

--- a/modules/router/manifests/assets_origin.pp
+++ b/modules/router/manifests/assets_origin.pp
@@ -4,7 +4,7 @@
 #
 # === Parameters
 #
-# [*asset_routes*]
+# [*app_specific_asset_routes*]
 #   Hash of paths => vhost_names.  Each entry will be added as a route in the vhost
 #
 # [*asset_manager_routes*]
@@ -21,7 +21,7 @@
 #   Primary vhost that assets should be served on at origin
 #
 class router::assets_origin(
-  $asset_routes = {},
+  $app_specific_asset_routes = {},
   $asset_manager_routes = [],
   $real_ip_header = '',
   $vhost_aliases = [],

--- a/modules/router/spec/classes/router__assets_origin_spec.rb
+++ b/modules/router/spec/classes/router__assets_origin_spec.rb
@@ -2,8 +2,8 @@ require_relative '../../../../spec_helper'
 
 describe "router::assets_origin", :type => :class do
 
-  describe "asset_routes targets" do
-    let(:asset_routes) { YAML.load_file(File.expand_path("../../../../../hieradata/common.yaml", __FILE__))['router::assets_origin::asset_routes'] }
+  describe "app_specific_asset_routes targets" do
+    let(:app_specific_asset_routes) { YAML.load_file(File.expand_path("../../../../../hieradata/common.yaml", __FILE__))['router::assets_origin::app_specific_asset_routes'] }
 
     let(:all_hostnames) {
       subject.call.resources.each_with_object([]) do |resource, hostnames|
@@ -20,9 +20,9 @@ describe "router::assets_origin", :type => :class do
       let(:pre_condition) { "include hosts::production" }
 
       it "should have host entries for each route target" do
-        asset_routes.each do |_, target|
+        app_specific_asset_routes.each do |_, target|
           hostname = "#{target}.publishing.service.gov.uk"
-          message = "asset_routes point at non-existent host '#{hostname}' in production"
+          message = "app_specific_asset_routes point at non-existent host '#{hostname}' in production"
           expect(all_hostnames).to include(hostname), message
         end
       end
@@ -33,9 +33,9 @@ describe "router::assets_origin", :type => :class do
       let(:pre_condition) { "include hosts::development" }
 
       it "should have host entries for each route target" do
-        asset_routes.each do |_, target|
+        app_specific_asset_routes.each do |_, target|
           hostname = "#{target}.dev.gov.uk"
-          message = "asset_routes point at non-existent host '#{hostname}' on the dev VM"
+          message = "app_specific_asset_routes point at non-existent host '#{hostname}' on the dev VM"
           expect(all_hostnames).to include(hostname), message
         end
       end

--- a/modules/router/spec/classes/router__assets_origin_spec.rb
+++ b/modules/router/spec/classes/router__assets_origin_spec.rb
@@ -60,8 +60,8 @@ describe "router::assets_origin", :type => :class do
       let(:pre_condition) { "include hosts::production" }
 
       it "should have host entries for each route target" do
-        asset_manager_routes.each do |_, target|
-          hostname = "#{target}.publishing.service.gov.uk"
+        asset_manager_routes.each do |_path|
+          hostname = "static.publishing.service.gov.uk"
           message = "asset_manager_routes point at non-existent host '#{hostname}' in production"
           expect(all_hostnames).to include(hostname), message
         end
@@ -73,8 +73,8 @@ describe "router::assets_origin", :type => :class do
       let(:pre_condition) { "include hosts::development" }
 
       it "should have host entries for each route target" do
-        asset_manager_routes.each do |_, target|
-          hostname = "#{target}.dev.gov.uk"
+        asset_manager_routes.each do |_path|
+          hostname = "static.dev.gov.uk"
           message = "asset_manager_routes point at non-existent host '#{hostname}' on the dev VM"
           expect(all_hostnames).to include(hostname), message
         end

--- a/modules/router/spec/classes/router__assets_origin_spec.rb
+++ b/modules/router/spec/classes/router__assets_origin_spec.rb
@@ -41,4 +41,44 @@ describe "router::assets_origin", :type => :class do
       end
     end
   end
+
+  describe "asset_manager_routes targets" do
+    let(:asset_manager_routes) { YAML.load_file(File.expand_path("../../../../../hieradata/common.yaml", __FILE__))['router::assets_origin::asset_manager_routes'] }
+
+    let(:all_hostnames) {
+      subject.call.resources.each_with_object([]) do |resource, hostnames|
+        next unless resource.type == "Host"
+        hostnames << resource.title
+        hostnames << resource[:host_aliases]
+      end.flatten.compact
+    }
+
+    let(:hiera_config) { File.expand_path("../../../../../spec/fixtures/hiera/real_data.yaml", __FILE__) }
+
+    context "in a production-like environment" do
+      let(:facts) {{ :environment => 'production' }}
+      let(:pre_condition) { "include hosts::production" }
+
+      it "should have host entries for each route target" do
+        asset_manager_routes.each do |_, target|
+          hostname = "#{target}.publishing.service.gov.uk"
+          message = "asset_manager_routes point at non-existent host '#{hostname}' in production"
+          expect(all_hostnames).to include(hostname), message
+        end
+      end
+    end
+
+    context "on the dev VM" do
+      let(:facts) {{ :environment => 'development' }}
+      let(:pre_condition) { "include hosts::development" }
+
+      it "should have host entries for each route target" do
+        asset_manager_routes.each do |_, target|
+          hostname = "#{target}.dev.gov.uk"
+          message = "asset_manager_routes point at non-existent host '#{hostname}' on the dev VM"
+          expect(all_hostnames).to include(hostname), message
+        end
+      end
+    end
+  end
 end

--- a/modules/router/templates/assets_origin.conf.erb
+++ b/modules/router/templates/assets_origin.conf.erb
@@ -61,6 +61,10 @@ server {
     proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://static.<%= @app_domain %>;
   }
 
+  location /media/ {
+    proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://static.<%= @app_domain %>;
+  }
+
   location / {
     proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://static.<%= @app_domain %>;
   }

--- a/modules/router/templates/assets_origin.conf.erb
+++ b/modules/router/templates/assets_origin.conf.erb
@@ -53,6 +53,10 @@ server {
   }
   <%- end -%>
 
+  location = /static/a {
+    proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://static.<%= @app_domain %>;
+  }
+
   location / {
     proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://static.<%= @app_domain %>;
   }

--- a/modules/router/templates/assets_origin.conf.erb
+++ b/modules/router/templates/assets_origin.conf.erb
@@ -41,7 +41,7 @@ server {
   add_header "Access-Control-Allow-Methods" "GET, OPTIONS";
   add_header "Access-Control-Allow-Headers" "origin, authorization";
 
-  <%- @asset_routes.each do |alias_path, vhost_name| -%>
+  <%- @app_specific_asset_routes.each do |alias_path, vhost_name| -%>
   location <%= alias_path %> {
     proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://<%= vhost_name %>.<%= @app_domain %>;
   }

--- a/modules/router/templates/assets_origin.conf.erb
+++ b/modules/router/templates/assets_origin.conf.erb
@@ -61,10 +61,6 @@ server {
     proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://static.<%= @app_domain %>;
   }
 
-  location /media/ {
-    proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://static.<%= @app_domain %>;
-  }
-
   location / {
     proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://static.<%= @app_domain %>;
   }

--- a/modules/router/templates/assets_origin.conf.erb
+++ b/modules/router/templates/assets_origin.conf.erb
@@ -45,7 +45,12 @@ server {
   location <%= alias_path %> {
     proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://<%= vhost_name %>.<%= @app_domain %>;
   }
+  <%- end -%>
 
+  <%- @asset_manager_routes.each do |alias_path, vhost_name| -%>
+  location <%= alias_path %> {
+    proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://<%= vhost_name %>.<%= @app_domain %>;
+  }
   <%- end -%>
 
   location / {

--- a/modules/router/templates/assets_origin.conf.erb
+++ b/modules/router/templates/assets_origin.conf.erb
@@ -57,6 +57,10 @@ server {
     proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://static.<%= @app_domain %>;
   }
 
+  location /__canary__ {
+    proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://static.<%= @app_domain %>;
+  }
+
   location / {
     proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://static.<%= @app_domain %>;
   }

--- a/modules/router/templates/assets_origin.conf.erb
+++ b/modules/router/templates/assets_origin.conf.erb
@@ -47,9 +47,9 @@ server {
   }
   <%- end -%>
 
-  <%- @asset_manager_routes.each do |alias_path, vhost_name| -%>
-  location <%= alias_path %> {
-    proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://<%= vhost_name %>.<%= @app_domain %>;
+  <%- @asset_manager_routes.each do |path| -%>
+  location <%= path %> {
+    proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://static.<%= @app_domain %>;
   }
   <%- end -%>
 


### PR DESCRIPTION
We were using the `router::assets_origin::asset_routes` hash to configure nginx `location` blocks for app-specific assets and for assets served by asset-manager. I've split this `asset_routes` hash into the `app_specific_asset_routes` hash and the `asset_manager_routes` array to make the dual purpose clearer.

Extracting the `asset_manager_routes` array allowed me to remove some duplication from the nginx config for the static virtual host.
