### PR TITLE
Add AWS for puppet-syntax hieradata lookup

### DIFF
--- a/lib/tasks/syntax.rake
+++ b/lib/tasks/syntax.rake
@@ -1,3 +1,9 @@
 require 'puppet-syntax/tasks/puppet-syntax'
 
 PuppetSyntax.exclude_paths = ["vendor/**/*"]
+PuppetSyntax.hieradata_paths = [
+  "**/data/**/*.yaml",
+  "hieradata/**/*.yaml",
+  "hieradata_aws/**/*.yaml",
+  "hiera*.yaml",
+]


### PR DESCRIPTION
We forked hieradata, but never updated puppet-syntax to ensure our hieradata was valid.

This adds the `hieradata_aws` path so that we can catch any errors. It expands on the default:

https://github.com/voxpupuli/puppet-syntax/blob/49f7d4d1125cd9c671511fe3e727ff4c2f38fb04/lib/puppet-syntax.rb#L9

We were recently caught with a syntax error that took a little while to find which was similar to:

`key: 'something.%{hiera('foo')}'`

The value would have been read as:

`something.%{hiera(`

The rest would have been invalid YAML, which caused hiera to break.