### PR TITLE
Update hiera config in AWS

### DIFF
--- a/hiera_aws.yml
+++ b/hiera_aws.yml
@@ -1,7 +1,8 @@
 ---
 :hierarchy:
-  - 'node/%{::fqdn}'
+  - 'class/%{::aws_stackname}/%{::environment}/%{::govuk_node_class}'
   - 'class/%{::aws_stackname}/%{::govuk_node_class}'
+  - 'class/%{::environment}/%{::govuk_node_class}'
   - 'class/%{::govuk_node_class}'
   - '%{::aws_stackname}/%{::environment}_credentials'
   - '%{::environment}_credentials'


### PR DESCRIPTION
I made the change in 1afad89017f56e748bd6fcc91ca8bd6ae3b14274, but thought it had caused an issue so reverted it. It turns out that something that got merged at a similar time caused the issue (7b43b616752953cd045657639ddb046b507c8b99).

This adds it back in, but also removes the node specific override as this is redundant in AWS as machines are not pinned to a specific hostname.