### PR TITLE
Configure draft-assets vhost in all environments

### DIFF
--- a/modules/router/manifests/draft_assets.pp
+++ b/modules/router/manifests/draft_assets.pp
@@ -26,7 +26,7 @@ class router::draft_assets(
     $upstream_ssl = $enable_ssl
   }
 
-  nginx::config::site { 'draft-assets':
+  nginx::config::site { $vhost_name:
     content => template('router/draft-assets.conf.erb'),
   }
 }

--- a/modules/router/manifests/draft_assets.pp
+++ b/modules/router/manifests/draft_assets.pp
@@ -17,6 +17,7 @@ class router::draft_assets(
   $vhost_name = 'draft-assets',
 ) {
   $enable_ssl = hiera('nginx_enable_ssl', true)
+  $asset_manager_routes = hiera('router::assets_origin::asset_manager_routes', [])
 
   if $::aws_migration {
     $app_domain = hiera('app_domain_internal')

--- a/modules/router/manifests/nginx.pp
+++ b/modules/router/manifests/nginx.pp
@@ -61,6 +61,10 @@ class router::nginx (
     real_ip_header => $real_ip_header,
   }
 
+  class { 'router::draft_assets':
+    real_ip_header => $real_ip_header,
+  }
+
   $app_domain = hiera('app_domain')
 
   nginx::config::ssl { "www.${app_domain}":

--- a/modules/router/templates/draft-assets.conf.erb
+++ b/modules/router/templates/draft-assets.conf.erb
@@ -32,7 +32,9 @@ server {
   add_header "Access-Control-Allow-Methods" "GET, OPTIONS";
   add_header "Access-Control-Allow-Headers" "origin, authorization";
 
-  location / {
+  <%- @asset_manager_routes.each do |path| -%>
+  location <%= path %> {
     proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://asset-manager.<%= @app_domain %>;
   }
+  <%- end -%>
 }

--- a/modules/router/templates/draft-assets.conf.erb
+++ b/modules/router/templates/draft-assets.conf.erb
@@ -32,6 +32,10 @@ server {
   add_header "Access-Control-Allow-Methods" "GET, OPTIONS";
   add_header "Access-Control-Allow-Headers" "origin, authorization";
 
+  location /auth/gds/ {
+    proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://asset-manager.<%= @app_domain %>;
+  }
+
   <%- @asset_manager_routes.each do |path| -%>
   location <%= path %> {
     proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://asset-manager.<%= @app_domain %>;

--- a/modules/router/templates/draft-assets.conf.erb
+++ b/modules/router/templates/draft-assets.conf.erb
@@ -32,7 +32,7 @@ server {
   add_header "Access-Control-Allow-Methods" "GET, OPTIONS";
   add_header "Access-Control-Allow-Headers" "origin, authorization";
 
-  location /auth/gds/ {
+  location /auth/ {
     proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://asset-manager.<%= @app_domain %>;
   }
 


### PR DESCRIPTION
This adds the draft-assets virtual host in all (integration, staging and production) environments.

Note that it'll be added to the cache and draft-cache servers and we'll rely on DNS to route requests to the draft-cache servers.
