### PR TITLE
Add Content Audit Tool to db_admin config

### DIFF
--- a/modules/govuk/manifests/node/s_db_admin.pp
+++ b/modules/govuk/manifests/node/s_db_admin.pp
@@ -127,6 +127,7 @@ class govuk::node::s_db_admin(
   class { '::govuk_postgresql::client': } ->
 
   # include all PostgreSQL classes that create databases and users
+  class { '::govuk::apps::content_audit_tool::db': } ->
   class { '::govuk::apps::content_performance_manager::db': } ->
   class { '::govuk::apps::content_tagger::db': } ->
   class { '::govuk::apps::email_alert_api::db': } ->


### PR DESCRIPTION
db_admin needs to know about the Content Audit Tool in order to
administer the database and database users for it.

See https://github.com/alphagov/govuk-aws/blob/master/doc/guides/rds-database-management.md