### PR TITLE
Add a jenkins job to extract data from graphite

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -4,6 +4,9 @@ _: &offsite_gpg_key 'BF7CE69AB6DA000D8CC3841EA98D1837723776D7'
 
 app_domain: 'publishing.service.gov.uk'
 
+# Staging/production will not have separate internal load balancers until migrated to AWS
+app_domain_internal: 'publishing.service.gov.uk'
+
 backup::assets::backup_private_gpg_key_fingerprint: *offsite_gpg_key
 backup::assets::jobs:
   'assets-whitehall-s3':

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -1,6 +1,9 @@
 ---
 app_domain: 'staging.publishing.service.gov.uk'
 
+# Staging/production will not have separate internal load balancers until migrated to AWS
+app_domain_internal: 'staging.publishing.service.gov.uk'
+
 backup::server::backup_hour: 9
 
 base::shell::shell_prompt_string: 'staging'

--- a/hieradata_aws/class/jenkins.yaml
+++ b/hieradata_aws/class/jenkins.yaml
@@ -68,6 +68,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::deploy_puppet
   - govuk_jenkins::jobs::deploy_router_data
   - govuk_jenkins::jobs::enhanced_ecommerce
+  - govuk_jenkins::jobs::extract_app_performance
   - govuk_jenkins::jobs::govuk_taxonomy_supervised_learning
   - govuk_jenkins::jobs::passive_checks
   - govuk_jenkins::jobs::record_taxonomy_metrics

--- a/modules/govuk_jenkins/manifests/init.pp
+++ b/modules/govuk_jenkins/manifests/init.pp
@@ -111,6 +111,11 @@ class govuk_jenkins (
     provider => 'pip',
   }
 
+  package { 'pipenv':
+    ensure   => 'present',
+    provider => 'pip',
+  }
+
   # Runtime dependency of: https://github.com/alphagov/search-analytics
   ensure_packages(['libffi-dev'])
 

--- a/modules/govuk_jenkins/manifests/jobs/extract_app_performance.pp
+++ b/modules/govuk_jenkins/manifests/jobs/extract_app_performance.pp
@@ -1,0 +1,14 @@
+# == Class: govuk_jenkins::jobs::extract_app_performance
+#
+# Create a file on disk that can be parsed by jenkins-job-builder
+#
+class govuk_jenkins::jobs::extract_app_performance (
+  $app_domain_internal = hiera('app_domain_internal'),
+  $cron_schedule = '0 6 1 * *',
+) {
+  file { '/etc/jenkins_jobs/jobs/extract_app_performance.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/extract_app_performance.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+}

--- a/modules/govuk_jenkins/templates/jobs/extract_app_performance.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/extract_app_performance.yaml.erb
@@ -19,5 +19,6 @@
         - shell: |
             PIPENV_VENV_IN_PROJECT=1 pipenv install --three --skip-lock
             PIPENV_VENV_IN_PROJECT=1 GRAPHITE_URL='https://graphite.<%= app_domain_internal %>' pipenv run python run_summary.py
+            PIPENV_VENV_IN_PROJECT=1 pipenv run python lint_data.py output/*.csv
     triggers:
         - timed: '<%= @cron_schedule %>'

--- a/modules/govuk_jenkins/templates/jobs/extract_app_performance.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/extract_app_performance.yaml.erb
@@ -1,0 +1,23 @@
+---
+- scm:
+    name: extract-app-performance
+    scm:
+        - git:
+            url: git@github.com:alphagov/app-performance-summary.git
+            branches:
+              - master
+- job:
+    name: extract-app-performance
+    display-name: extract-app-performance
+    project-type: freestyle
+    description: |
+      <p>Extracts error rate information in graphite.</p>
+      <p>More information:<a href='https://github.com/alphagov/app-performance-summary'>alphagov/app-performance-summary on GitHub</a>.</p>
+    scm:
+        - extract-app-performance
+    builders:
+        - shell: |
+            PIPENV_VENV_IN_PROJECT=1 pipenv install --three --skip-lock
+            PIPENV_VENV_IN_PROJECT=1 GRAPHITE_URL='https://graphite.<%= app_domain_internal %>' pipenv run python run_summary.py
+    triggers:
+        - timed: '<%= @cron_schedule %>'


### PR DESCRIPTION
This job extracts error rate data out of graphite for all the GOV.UK applications.

I'd like to store this data in an accessible place, like google drive or an s3 bucket, but I haven't got that far yet. This measure can be used to understand how GOV.UK-the-programme is doing so we want to make it easy for non-developers to access.

Basically this change takes us from this:
<img width="762" alt="screen shot 2018-01-31 at 13 47 16" src="https://user-images.githubusercontent.com/87579/35626391-81a6dcf0-068d-11e8-90ee-49c2eef071ff.png">

To this:
<img width="788" alt="screen shot 2018-01-31 at 13 50 17" src="https://user-images.githubusercontent.com/87579/35626463-b4c88890-068d-11e8-8e69-bbeccdaf03d5.png">

See https://github.com/alphagov/app-performance-summary/pull/1

Note: I had to use `app_domain_internal` to get this to work on AWS, but that variable wasn't defined on prod/staging, so I set it to be the same as `app_domain`.