### PR TITLE
Use env var to override Plek for draft-assets in AWS environments

### DIFF
--- a/modules/govuk/manifests/apps/asset_manager.pp
+++ b/modules/govuk/manifests/apps/asset_manager.pp
@@ -73,6 +73,20 @@ class govuk::apps::asset_manager(
         value   => "private-asset-manager.${app_domain}";
     }
 
+    if $::aws_migration {
+      # The Asset Manager app needs to look up 'draft-assets' in order to
+      # decide whether to authenticate requests and to be able to redirect
+      # requests for draft assets. Thus the URI returned from `Plek#find` for
+      # 'draft-assets' needs to be on the public-facing domain and not the
+      # domain for internal services which is the default.
+      govuk::app::envvar {
+        "${title}-PLEK_SERVICE_DRAFT_ASSETS_URI":
+          app     => 'asset-manager',
+          varname => 'PLEK_SERVICE_DRAFT_ASSETS_URI',
+          value   => "https://draft-assets.${app_domain}";
+      }
+    }
+
     Govuk::App::Envvar {
       app => $app_name,
     }


### PR DESCRIPTION
The Asset Manager app needs to look up 'draft-assets' in order to decide whether to authenticate requests and to be able to redirect requests for draft assets. Thus the URI returned from `Plek#find` for 'draft-assets' needs to be on the public-facing domain and not the domain for internal services which is the default.

This is quite similar to [the setting of `PLEK_SERVICE_DRAFT_ORIGIN_URI` in `govuk::deploy::config`][1], although in this case it's specific to the Asset Manager app only.

The aim is for `Plek#find` to return the following values for 'draft-assets':

* Development VM: `'http://draft-assets.dev.gov.uk'`
* Integration (AWS): `'https://draft-assets.integration.publishing.service.gov.uk'`
* Staging: `'https://draft-assets.staging.publishing.service.gov.uk'`
* Production `'https://draft-assets.publishing.service.gov.uk'`

All except the value for integration would've been correct before this change.

I've tested the use of the overriding env var as follows:

### Development VM

```
$ govuk_app_console asset-manager
irb> Plek.new.find('draft-assets')
=> "http://draft-assets.dev.gov.uk"
```

```
$ sudo su -c 'echo -n https://draft-assets.dev.gov.uk > /etc/govuk/asset-manager/env.d/PLEK_SERVICE_DRAFT_ASSETS_URI'
$ govuk_app_console asset-manager
irb> Plek.new.find('draft-assets')
=> "http://draft-assets.dev.gov.uk"
```

### Integration (AWS)

```
$ govuk_app_console asset-manager
irb> Plek.new.find('draft-assets')
=> "https://draft-assets.integration.govuk-internal.digital"
```

```
$ sudo su -c 'echo -n https://draft-assets.integration.publishing.service.gov.uk > /etc/govuk/asset-manager/env.d/PLEK_SERVICE_DRAFT_ASSETS_URI'
$ govuk_app_console asset-manager
irb> Plek.new.find('draft-assets')
=> "https://draft-assets.integration.publishing.service.gov.uk"
```

[1]: https://github.com/alphagov/govuk-puppet/blob/19a1a860d2f0c5f13149e21e5e8a60ced9f19b2e/modules/govuk/manifests/deploy/config.pp#L107-L110