### PR TITLE
Remove content audit tool jenkins job

### DIFF
--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -8,7 +8,6 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::check_content_consistency
   - govuk_jenkins::jobs::check_content_store
   - govuk_jenkins::jobs::check_pingdom_ip_ranges
-  - govuk_jenkins::jobs::content_audit_tool
   - govuk_jenkins::jobs::content_performance_manager
   - govuk_jenkins::jobs::copy_data_to_integration
   - govuk_jenkins::jobs::copy_data_to_staging


### PR DESCRIPTION
I believe this will resolve the current failure when running puppet on jenkins in production.