### PR TITLE
Terraform deployment job

### DIFF
--- a/hieradata/class/integration/jenkins.yaml
+++ b/hieradata/class/integration/jenkins.yaml
@@ -4,6 +4,7 @@ govuk_jenkins::config::executors: '4'
 govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::deploy_licensify
   - govuk_jenkins::jobs::deploy_puppet
+  - govuk_jenkins::jobs::deploy_terraform_govuk_aws
   - govuk_jenkins::jobs::launch_vms
   - govuk_jenkins::jobs::network_config_deploy
   - govuk_jenkins::jobs::passive_checks

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -635,6 +635,7 @@ govuk_htpasswd::http_username: "%{hiera('http_username')}"
 
 govuk_jenkins::packages::gcloud::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk_jenkins::packages::terraform::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_jenkins::packages::sops::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 govuk::node::s_api_redis::allowed_api_ip_range: "%{hiera('environment_ip_prefix')}.4.0/24"
 govuk::node::s_api_redis::allowed_backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"

--- a/modules/govuk/manifests/node/s_apt.pp
+++ b/modules/govuk/manifests/node/s_apt.pp
@@ -139,6 +139,7 @@ class govuk::node::s_apt (
   aptly::repo { 'rbenv-ruby-xenial':
     distribution => 'xenial',
   }
+  aptly::repo { 'sops': }
   aptly::repo { 'statsd': }
   aptly::repo { 'terraform': }
 

--- a/modules/govuk_jenkins/manifests/jobs/deploy_terraform_govuk_aws.pp
+++ b/modules/govuk_jenkins/manifests/jobs/deploy_terraform_govuk_aws.pp
@@ -1,0 +1,9 @@
+# == Class: govuk_jenkins::jobs::deploy_terraform_govuk_aws
+#
+class govuk_jenkins::jobs::deploy_terraform_govuk_aws {
+  file { '/etc/jenkins_jobs/jobs/deploy_terraform_govuk_aws.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/deploy_terraform_govuk_aws.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+}

--- a/modules/govuk_jenkins/manifests/jobs/deploy_terraform_project.pp
+++ b/modules/govuk_jenkins/manifests/jobs/deploy_terraform_project.pp
@@ -1,5 +1,7 @@
 # == Class: govuk_jenkins::jobs::deploy_terraform_project
 #
+# This deploys the old Terraform code. New code should be moved to govuk-aws.
+#
 # === Parameters
 #
 # [*aws_account_id*]

--- a/modules/govuk_jenkins/manifests/packages/sops.pp
+++ b/modules/govuk_jenkins/manifests/packages/sops.pp
@@ -1,0 +1,27 @@
+# == Class: govuk_jenkins::packages::sops
+#
+# Installs sops https://github.com/mozilla/sops
+#
+# === Parameters
+#
+# [*apt_mirror_hostname*]
+#   The hostname of an APT mirror
+#
+class govuk_jenkins::packages::sops (
+  $apt_mirror_hostname = undef,
+  $version = '3.0.2',
+){
+
+  apt::source { 'sops':
+    location     => "http://${apt_mirror_hostname}/sops",
+    release      => $::lsbdistcodename,
+    architecture => $::architecture,
+    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+  }
+
+  package { 'sops':
+    ensure  => $version,
+    require => Apt::Source['sops'],
+  }
+
+}

--- a/modules/govuk_jenkins/templates/jobs/deploy_terraform_govuk_aws.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_terraform_govuk_aws.yaml.erb
@@ -1,0 +1,73 @@
+---
+- scm:
+    name: govuk-aws_Deploy_Terraform_Govuk_AWS
+    scm:
+        - git:
+            url: git@github.com:alphagov/govuk-aws.git
+            branches:
+                - master
+- job:
+    name: Deploy_Terraform_Project
+    display-name: Deploy_Terraform_Project
+    project-type: freestyle
+    description: |
+        Deploy GOV.UK AWS Infrastructure using Terraform.
+
+        For available projects to deploy, please see the <a href=https://github.com/alphagov/govuk-aws/tree/master/terraform/projects>Terraform repository</a>
+
+    properties:
+        - github:
+            url: https://github.com/alphagov/govuk-aws/
+    scm:
+        - govuk-aws_Deploy_Terraform_Govuk_AWS
+    wrappers:
+        - ansicolor:
+            colormap: xterm
+        - build-name:
+          name: '${ENV,var=ENVIRONMENT} ${ENV,var="STACKNAME"} ${ENV,var="PROJECT"} ${ENV,var="COMMAND"}'
+    builders:
+        - shell: |
+            ./jenkins.sh
+
+    parameters:
+        - string:
+            name: AWS_ACCESS_KEY_ID
+            description: Your AWS access key ID
+            default: false
+        - password:
+            name: AWS_SECRET_ACCESS_KEY
+            description: Your AWS secret access key
+            default: false
+        - password:
+            name: AWS_SESSION_TOKEN
+            description: The AWS session token
+            default: false
+        - choice:
+            name: COMMAND
+            description: Choose whether to plan (default), apply or destroy
+            choices:
+                - plan
+                - apply
+                - destroy
+        - choice:
+            name: ENVIRONMENT
+            description: Which environment to deploy to
+            choices:
+                - integration
+                - staging
+                - production
+        - choice:
+            name: STACKNAME
+            description: Choose which stack to deploy into
+            choices:
+                - blue
+                - green
+                - govuk
+        - string:
+            name: PROJECT
+            description: Name of the project you wish to deploy
+            default: false
+        - string:
+            name: TERRAFORM_VERSION
+            description: Version of Terraform to run against. Leave blank for default.
+            default: false

--- a/modules/govuk_jenkins/templates/jobs/deploy_terraform_project.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_terraform_project.yaml.erb
@@ -11,6 +11,8 @@
     display-name: Deploy_Terraform_Project
     project-type: freestyle
     description: |
+        This project is deprecated and code should be moved to https://github.com/alphagov/govuk-aws
+
         Deploy a specific Terraform project in <%= @environment -%>.
         Projects currently available can be found in Github: https://github.com/alphagov/govuk-terraform-provisioning/tree/master/projects
 


### PR DESCRIPTION
This creates a job on ci-deploy that can take some credentials and trigger a build of a `./jenkins.sh` script that lives in the repo.

I'll need to do the stuff for `sops` as well before this will work.

Related: https://github.com/alphagov/govuk-aws/pull/472

https://trello.com/c/qAzTAU4p/952-build-box-spike-on-adding-tf-deploys-to-current-integration-carrenza-deploy-jenkins