### PR TITLE
Bump port number for Content Audit Tool

### DIFF
--- a/development-vm/Procfile
+++ b/development-vm/Procfile
@@ -159,7 +159,7 @@ link-checker-api-sidekiq:             govuk_setenv link-checker-api            .
 # sidekiq-monitoring for specialist-publisher uses port 3210
 # sidekiq-monitoring's web frontend listens on port 3211 and proxies requests per app to other ports (defined elsewhere in this file)
 publishing-components:                govuk_setenv publishing-components       ./run_in.sh ../../govuk_publishing_components bundle exec foreman start
-# sidekiq-monitoring for content-audit-tool uses port 3212
-content-audit-tool: govuk_setenv content-audit-tool ./run_in.sh ../../content-audit-tool bundle exec rails server -p 3212
+# sidekiq-monitoring for content-audit-tool uses port 3213
+content-audit-tool: govuk_setenv content-audit-tool ./run_in.sh ../../content-audit-tool bundle exec rails server -p 3213
 content-audit-tool-sidekiq-google-analytics:  govuk_setenv content-audit-tool ./run_in.sh ../../content-audit-tool bundle exec sidekiq -C ./config/sidekiq/google_analytics.yml
 content-audit-tool-sidekiq-publishing-api:  govuk_setenv content-audit-tool ./run_in.sh ../../content-audit-tool bundle exec sidekiq -C ./config/sidekiq/publishing_api.yml

--- a/modules/govuk/manifests/apps/content_audit_tool.pp
+++ b/modules/govuk/manifests/apps/content_audit_tool.pp
@@ -76,7 +76,7 @@ class govuk::apps::content_audit_tool(
   $google_private_key = undef,
   $oauth_id = undef,
   $oauth_secret = undef,
-  $port = '3212',
+  $port = '3213',
   $publishing_api_bearer_token = undef,
   $redis_host = undef,
   $redis_port = undef,

--- a/modules/govuk/templates/sidekiq_monitoring_nginx_config.conf.erb
+++ b/modules/govuk/templates/sidekiq_monitoring_nginx_config.conf.erb
@@ -23,7 +23,7 @@ server {
   }
 
   location /content-audit-tool {
-    proxy_pass http://localhost:3212;
+    proxy_pass http://localhost:3213;
   }
 
   location /content-performance-manager {


### PR DESCRIPTION
The previous port number assigned was already assigned to another app.

[Related PR in govuk/sidekiq-monitoring](https://github.com/alphagov/sidekiq-monitoring/pull/35)