### PR TITLE
Serve non database backed whitehall assets from asset manager

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1638,18 +1638,18 @@ router::assets_origin::app_specific_asset_routes:
   '/smartanswers/': "smartanswers"
 
 router::assets_origin::asset_manager_routes:
-  - '/media/'
   - '/government/uploads/government/uploads/system/uploads/'
-  - '/government/uploads/system/uploads/organisation/logo/'
   - '/government/uploads/system/uploads/classification_featuring_image_data/file/'
   - '/government/uploads/system/uploads/consultation_response_form_data/file/'
   - '/government/uploads/system/uploads/default_news_organisation_image_data/file/'
   - '/government/uploads/system/uploads/feature/image/'
+  - '/government/uploads/system/uploads/image_data/file/'
+  - '/government/uploads/system/uploads/organisation/logo/'
   - '/government/uploads/system/uploads/person/image/'
   - '/government/uploads/system/uploads/promotional_feature_item/image/'
   - '/government/uploads/system/uploads/take_part_page/image/'
-  - '/government/uploads/system/uploads/image_data/file/'
   - '/government/uploads/uploaded/number10/'
+  - '/media/'
 
 router::assets_origin::vhost_aliases:
   - 'assets.digital.cabinet-office.gov.uk'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1639,15 +1639,22 @@ router::assets_origin::app_specific_asset_routes:
 
 router::assets_origin::asset_manager_routes:
   - '/government/uploads/government/uploads/system/uploads/'
+  - '/government/uploads/system/uploads/attachment/file'
   - '/government/uploads/system/uploads/classification_featuring_image_data/file/'
+  - '/government/uploads/system/uploads/consultation_response_form/file'
   - '/government/uploads/system/uploads/consultation_response_form_data/file/'
   - '/government/uploads/system/uploads/default_news_organisation_image_data/file/'
+  - '/government/uploads/system/uploads/edition_organisation_image_data/file'
+  - '/government/uploads/system/uploads/edition_world_location_image_data/file'
   - '/government/uploads/system/uploads/feature/image/'
   - '/government/uploads/system/uploads/image_data/file/'
+  - '/government/uploads/system/uploads/news_article/featuring_image'
+  - '/government/uploads/system/uploads/news_article/image'
   - '/government/uploads/system/uploads/organisation/logo/'
   - '/government/uploads/system/uploads/person/image/'
   - '/government/uploads/system/uploads/promotional_feature_item/image/'
   - '/government/uploads/system/uploads/take_part_page/image/'
+  - '/government/uploads/system/uploads/topical_event/logo'
   - '/government/uploads/uploaded/number10/'
   - '/media/'
 

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1056,15 +1056,22 @@ router::assets_origin::app_specific_asset_routes:
 
 router::assets_origin::asset_manager_routes:
   - '/government/uploads/government/uploads/system/uploads/'
+  - '/government/uploads/system/uploads/attachment/file'
   - '/government/uploads/system/uploads/classification_featuring_image_data/file/'
+  - '/government/uploads/system/uploads/consultation_response_form/file'
   - '/government/uploads/system/uploads/consultation_response_form_data/file/'
   - '/government/uploads/system/uploads/default_news_organisation_image_data/file/'
+  - '/government/uploads/system/uploads/edition_organisation_image_data/file'
+  - '/government/uploads/system/uploads/edition_world_location_image_data/file'
   - '/government/uploads/system/uploads/feature/image/'
   - '/government/uploads/system/uploads/image_data/file/'
+  - '/government/uploads/system/uploads/news_article/featuring_image'
+  - '/government/uploads/system/uploads/news_article/image'
   - '/government/uploads/system/uploads/organisation/logo/'
   - '/government/uploads/system/uploads/person/image/'
   - '/government/uploads/system/uploads/promotional_feature_item/image/'
   - '/government/uploads/system/uploads/take_part_page/image/'
+  - '/government/uploads/system/uploads/topical_event/logo'
   - '/government/uploads/uploaded/number10/'
   - '/media/'
 

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1055,18 +1055,18 @@ router::assets_origin::app_specific_asset_routes:
   '/smartanswers/': "smartanswers"
 
 router::assets_origin::asset_manager_routes:
-  - '/media/'
   - '/government/uploads/government/uploads/system/uploads/'
-  - '/government/uploads/system/uploads/organisation/logo/'
   - '/government/uploads/system/uploads/classification_featuring_image_data/file/'
   - '/government/uploads/system/uploads/consultation_response_form_data/file/'
   - '/government/uploads/system/uploads/default_news_organisation_image_data/file/'
   - '/government/uploads/system/uploads/feature/image/'
+  - '/government/uploads/system/uploads/image_data/file/'
+  - '/government/uploads/system/uploads/organisation/logo/'
   - '/government/uploads/system/uploads/person/image/'
   - '/government/uploads/system/uploads/promotional_feature_item/image/'
   - '/government/uploads/system/uploads/take_part_page/image/'
-  - '/government/uploads/system/uploads/image_data/file/'
   - '/government/uploads/uploaded/number10/'
+  - '/media/'
 
 router::assets_origin::vhost_aliases:
   - 'assets.digital.cabinet-office.gov.uk'


### PR DESCRIPTION
See: alphagov/asset-manager#216

The files under these paths have been migrated to Asset Manager from Whitehall. This PR changes the nginx configuration (by updating the asset_manager_routes hieradata in all environments) so that they are served by Asset Manager.