### PR TITLE
Add signon-sidekiq process to dev VM

### DIFF
--- a/development-vm/Pinfile
+++ b/development-vm/Pinfile
@@ -65,7 +65,8 @@ process :'search-admin' => [:rummager, :'publishing-api']
 process :'service-manual-frontend' => [:'content-store', :static]
 process :'service-manual-publisher' => [:'publishing-api']
 process :'short-url-manager' => [:'publishing-api']
-process :signon
+process :signon => [:'signon-sidekiq']
+process :'signon-sidekiq'
 process :smartanswers => [:static, :'content-store', :imminence]
 process :'specialist-publisher' => ['asset-manager', :'publishing-api', :'email-alert-api']
 process :'specialist-publisher-worker' => [:'email-alert-api']

--- a/development-vm/Procfile
+++ b/development-vm/Procfile
@@ -16,6 +16,7 @@ static:                govuk_setenv static                ./run_in.sh ../../stat
 licencefinder:         govuk_setenv licencefinder         ./run_in.sh ../../licence-finder bundle exec rails server -p 3014
 # migratorator used port 3015
 signon:                govuk_setenv signon                ./run_in.sh ../../signon         bundle exec rails server -p 3016
+signon-sidekiq:        govuk_setenv signon                ./run_in.sh ../../signon         bundle exec sidekiq -C ./config/sidekiq.yml
 # tradetariff used port 3017
 # tradetariffapi used port 3018
 # efg used port 3019


### PR DESCRIPTION
I've tried to follow the pattern used by other apps, but some use a "-worker" suffix while other use "-sidekiq". The latter seems to be in the majority, so I've gone with that.

I'm not 100% sure the sidekiq process should depend on the signon app by default, but I assume it should. I needed it running in order to test the migration in [this Signon PR][1].

I was also slightly confused by the fact that Signon's `config/sidekiq.yml` defines a log file rather than outputting to standard out. However, I haven't changed that in this PR.

[1]: https://github.com/alphagov/signon/pull/672