### PR TITLE
Respond with 404 for unrecognised requests to draft-assets

### DIFF
--- a/modules/router/templates/draft-assets.conf.erb
+++ b/modules/router/templates/draft-assets.conf.erb
@@ -32,6 +32,11 @@ server {
   add_header "Access-Control-Allow-Methods" "GET, OPTIONS";
   add_header "Access-Control-Allow-Headers" "origin, authorization";
 
+  # Avoid falling through to the default host if none of our locations match
+  location / {
+    return 404;
+  }
+
   location /auth/ {
     proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://asset-manager.<%= @app_domain %>;
   }


### PR DESCRIPTION
This avoids us falling through to the default nginx host for requests that we don't recognise; which will mean we avoid rendering the default nginx welcome page at the root of draft-assets.