### PR TITLE
Make safeDockerTag in the jenkins build script actually safe

### DIFF
--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -881,7 +881,11 @@ def pushDockerImageToGCR(imageName, tagName) {
 }
 
 def safeDockerTag(tagName) {
-  return tagName.replace("/", "_")
+  // A valid tag is:
+  //   ascii, uppercase, lowercase, digits, underscore, dash, period,
+  //   128 chars, can't start with dash or period
+  // See: https://docs.docker.com/engine/reference/commandline/tag/#extended-description
+  return tagName.replaceAll(/[^a-zA-Z0-9-_.]|^[-.]/, "_"​).take(128)
 }
 
 /*


### PR DESCRIPTION
The [docker tag documentation](https://docs.docker.com/engine/reference/commandline/tag/)
says that a docker tag must be valid ascii, contain only lowercase, uppercase,
digits, underscore, dash and period characters.  It can't start with a dash or
a period, and it can only be 128 chars long.  Our previous version only replaced
slashes with underscores so didn't entirely guarantee the tag was safe.

Discovered when I used a `+` in the branch name for alphagov/whitehall#3471