### PR TITLE
Revert "Make safeDockerTag in the jenkins build script actually safe"

### DIFF
--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -881,11 +881,7 @@ def pushDockerImageToGCR(imageName, tagName) {
 }
 
 def safeDockerTag(tagName) {
-  // A valid tag is:
-  //   ascii, uppercase, lowercase, digits, underscore, dash, period,
-  //   128 chars, can't start with dash or period
-  // See: https://docs.docker.com/engine/reference/commandline/tag/#extended-description
-  return tagName.replaceAll(/[^a-zA-Z0-9-_.]|^[-.]/, "_"​).take(128)
+  return tagName.replace("/", "_")
 }
 
 /*


### PR DESCRIPTION
Reverts alphagov/govuk-puppet#7194 - it's causing build failures:

```
hudson.remoting.ProxyException: org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
Script1.groovy: 888: expecting ')', found '​' @ line 888, column 57.
   l(/[^a-zA-Z0-9-_.]|^[-.]/, "_"​).take(12
                                 ^
```

Unsure why as it worked in an online groovy repl.