### PR TITLE
Remove zero width space character

### DIFF
--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -885,7 +885,7 @@ def safeDockerTag(tagName) {
   //   ascii, uppercase, lowercase, digits, underscore, dash, period,
   //   128 chars, can't start with dash or period
   // See: https://docs.docker.com/engine/reference/commandline/tag/#extended-description
-  return tagName.replaceAll(/[^a-zA-Z0-9-_.]|^[-.]/, "_"​).take(128)
+  return tagName.replaceAll(/[^a-zA-Z0-9-_.]|^[-.]/, "_").take(128)
 }
 
 /*


### PR DESCRIPTION
Causing this error:
Script1.groovy: 888: expecting ')', found '​' @ line 888, column 57.
   l(/[^a-zA-Z0-9-_.]|^[-.]/, "_"​).take(12