### PR TITLE
Fix sidekiq monitoring port number

### DIFF
--- a/modules/govuk/templates/sidekiq_monitoring_nginx_config.conf.erb
+++ b/modules/govuk/templates/sidekiq_monitoring_nginx_config.conf.erb
@@ -23,7 +23,7 @@ server {
   }
 
   location /content-audit-tool {
-    proxy_pass http://localhost:3213;
+    proxy_pass http://localhost:3214;
   }
 
   location /content-performance-manager {


### PR DESCRIPTION
The proxy pass that points to the sidekiq monitor for the Content
Audit Tool should be 3214, not 3213 which is the Content Audit
Tool's own port number.

As per https://github.com/alphagov/sidekiq-monitoring/pull/36