### PR TITLE
Increase intervals of mongodb backups in AWS

### DIFF
--- a/modules/mongodb/manifests/aws_backup.pp
+++ b/modules/mongodb/manifests/aws_backup.pp
@@ -23,7 +23,7 @@ class mongodb::aws_backup (
   $ensure     = 'present',
   $backup_dir = '/var/lib/mongodump',
   $bucket     = undef,
-  $interval   = 15,
+  $interval   = 30,
   $daily_time = '00:00',
 ) {
 

--- a/modules/mongodb/spec/classes/mongodb__aws_backup_spec.rb
+++ b/modules/mongodb/spec/classes/mongodb__aws_backup_spec.rb
@@ -5,6 +5,6 @@ describe 'mongodb::aws_backup', :type => :class do
     let(:params){{ 'bucket' => 'my-bucket' }}
     it { is_expected.to contain_file('/var/lib/mongodump').with_ensure('directory') }
     it { is_expected.to contain_file('/usr/local/bin/mongodump-to-s3').with_ensure('present') }
-    it { is_expected.to contain_cron__crondotdee('mongodump-to-s3').with_minute('*/15') }
+    it { is_expected.to contain_cron__crondotdee('mongodump-to-s3').with_minute('*/30') }
   end
 end


### PR DESCRIPTION
Full dumps of MongoDB are taking longer than 15 minutes, and the lock does not wait for a clean slot so the cron job does not run. The "daily" backup works on the basis of what time the job is started to say if it is "daily" or not; so if a job overruns, then a daily job will never run.

Increasing the interval will mean that the jobs should run and complete every half an hour, without any missing jobs due to weird timings.