### PR TITLE
Enable Content Audit Tool on staging

### DIFF
--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -13,8 +13,6 @@ cron::daily_hour: 6
 
 environment_ip_prefix: '10.2'
 
-govuk::apps::content_audit_tool::ensure: 'absent'
-
 govuk::apps::asset_manager::aws_s3_bucket_name: 'govuk-assets-staging'
 govuk::apps::asset_manager::aws_region: 'eu-west-1'
 govuk::apps::content_store::performance_platform_big_screen_view_url: 'https://performance-platform-big-screen-view-staging.cloudapps.digital'


### PR DESCRIPTION
This is part of the work to split the Content Audit Tool from the
Content Performance Manager.

Credential are now set in [govuk-secrets](https://github.com/alphagov/govuk-secrets/pull/210)