### PR TITLE
Skip master releases for schema tests

### DIFF
--- a/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy
@@ -162,7 +162,7 @@ def buildProject(Map options = [:]) {
       nonDockerBuildTasks(options, jobName, repoName)
     }
 
-    if (env.BRANCH_NAME == "master") {
+    if (env.BRANCH_NAME == "master" && !params.IS_SCHEMA_TEST) {
       if (isGem()) {
         stage("Publish Gem to Rubygems") {
           publishGem(repoName, env.BRANCH_NAME)


### PR DESCRIPTION
Although it is unusual for schema tests to run against master it is
still do-able and they were previously breaking. To execute the block
there is an expectation that a docker image is created, and this skipped
on a schema test.

We also don't need to do the various releases if we are running as a
schema test so this will be skipped.