### PR TITLE
Enable SSL for draft-assets

### DIFF
--- a/modules/router/manifests/draft_assets.pp
+++ b/modules/router/manifests/draft_assets.pp
@@ -30,4 +30,8 @@ class router::draft_assets(
   nginx::config::site { $vhost_name:
     content => template('router/draft-assets.conf.erb'),
   }
+
+  nginx::config::ssl { $vhost_name:
+    certtype => 'wildcard_publishing',
+  }
 }

--- a/modules/router/templates/draft-assets.conf.erb
+++ b/modules/router/templates/draft-assets.conf.erb
@@ -6,6 +6,17 @@ server {
   <%- end %>
 
   listen 80;
+<% if @enable_ssl -%>
+  rewrite ^/(.*) https://$host/$1 permanent;
+}
+
+server {
+  server_name <%= @vhost_name -%>;
+  listen              443 ssl;
+  ssl_certificate     /etc/nginx/ssl/<%= @vhost_name -%>.crt;
+  ssl_certificate_key /etc/nginx/ssl/<%= @vhost_name -%>.key;
+  include             /etc/nginx/ssl.conf;
+<% end -%>
 
   proxy_set_header X-Real-IP $remote_addr;
   proxy_set_header X-Forwarded-Server $host;


### PR DESCRIPTION
This addresses https://github.com/alphagov/asset-manager/issues/430.

This will allow us to start responding to requests to draft-assets in staging and production. I've copied the necessary bits of the config from assets_origin.pp and assets-origin.conf.erb.

Note that draft-assets doesn't require SSL to be configured on the virtual host in integration because we're terminating SSL requests at the ELB.