### PR TITLE
Define unicorn workers as a govuk::app::config thing and make local-links-manager, whitehall, signon use it

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -472,6 +472,7 @@ govuk::apps::local_links_manager::db_hostname: "postgresql-primary-1.backend"
 govuk::apps::local_links_manager::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 govuk::apps::local_links_manager::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::local_links_manager::redis_port: "%{hiera('sidekiq_port')}"
+govuk::apps::local_links_manager::unicorn_worker_processes: "4"
 
 govuk::apps::mapit::enabled: true
 

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -571,6 +571,7 @@ govuk::apps::signon::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::signon::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::signon::nagios_memory_warning: 900
 govuk::apps::signon::nagios_memory_critical: 1000
+govuk::apps::signon::unicorn_worker_processes: "4"
 
 govuk::apps::specialist_publisher::enabled: true
 govuk::apps::specialist_publisher::nagios_memory_warning: 1100

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -572,6 +572,7 @@ govuk::apps::signon::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::signon::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::signon::nagios_memory_warning: 900
 govuk::apps::signon::nagios_memory_critical: 1000
+govuk::apps::signon::unicorn_worker_processes: "4"
 
 govuk::apps::specialist_publisher::enabled: true
 govuk::apps::specialist_publisher::nagios_memory_warning: 1100

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -476,6 +476,7 @@ govuk::apps::local_links_manager::db_hostname: "postgresql-primary"
 govuk::apps::local_links_manager::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 govuk::apps::local_links_manager::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::local_links_manager::redis_port: "%{hiera('sidekiq_port')}"
+govuk::apps::local_links_manager::unicorn_worker_processes: "4"
 
 govuk::apps::mapit::enabled: true
 

--- a/modules/govuk/manifests/app.pp
+++ b/modules/govuk/manifests/app.pp
@@ -214,6 +214,12 @@
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
+# [*unicorn_worker_processe*s]
+#   The number of unicorn worker processes to run, set as an env var
+#   and read by govuk_app_config.  The default value of undef means
+#   don't set the env var, and use on govuk_app_config's default value.
+#   Default: undef
+#
 define govuk::app (
   $app_type,
   $port = 0,
@@ -244,6 +250,7 @@ define govuk::app (
   $proxy_http_version_1_1_enabled = false,
   $repo_name = undef,
   $sentry_dsn = undef,
+  $unicorn_worker_processes = undef,
 ) {
 
   if ! ($app_type in ['procfile', 'rack', 'bare']) {
@@ -313,6 +320,7 @@ define govuk::app (
     read_timeout                   => $read_timeout,
     sentry_dsn                     => $sentry_dsn,
     proxy_http_version_1_1_enabled => $proxy_http_version_1_1_enabled,
+    unicorn_worker_processes       => $unicorn_worker_processes,
   }
 
   govuk::app::service { $title:

--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -19,6 +19,12 @@
 #   Boolean, whether to enable HTTP/1.1 for proxying from the Nginx vhost
 #   to the app server.
 #
+# [*unicorn_worker_processe*s]
+#   The number of unicorn worker processes to run, set as an env var
+#   and read by govuk_app_config.  The default value of undef means
+#   don't set the env var, and use on govuk_app_config's default value.
+#   Default: undef
+#
 define govuk::app::config (
   $app_type,
   $domain,
@@ -47,6 +53,7 @@ define govuk::app::config (
   $read_timeout = 15,
   $proxy_http_version_1_1_enabled = false,
   $sentry_dsn = undef,
+  $unicorn_worker_processes = undef,
 ) {
   $ensure_directory = $ensure ? {
     'present' => 'directory',
@@ -158,6 +165,13 @@ define govuk::app::config (
       govuk::app::envvar { "${title}-GOVUK_APP_CMD":
         varname => 'GOVUK_APP_CMD',
         value   => $command,
+      }
+    }
+
+    if $unicorn_worker_processes {
+      govuk::app::envvar { "${title}-UNICORN_WORKER_PROCESSES":
+        varname => 'UNICORN_WORKER_PROCESSES',
+        value   => $unicorn_worker_processes;
       }
     }
   }

--- a/modules/govuk/manifests/apps/local_links_manager.pp
+++ b/modules/govuk/manifests/apps/local_links_manager.pp
@@ -79,6 +79,10 @@
 #   to GA.
 #   Default: false
 #
+# [*unicorn_worker_processe*s]
+#   The number of unicorn worker processes to run
+#   Default: undef
+#
 class govuk::apps::local_links_manager(
   $port = 3121,
   $enabled = true,
@@ -102,17 +106,19 @@ class govuk::apps::local_links_manager(
   $google_export_custom_data_import_source_id = undef,
   $google_export_tracker_id = undef,
   $run_links_ga_export = false,
+  $unicorn_worker_processes = undef,
 ) {
   $app_name = 'local-links-manager'
 
   if $enabled {
     govuk::app { $app_name:
-      app_type           => 'rack',
-      log_format_is_json => true,
-      port               => $port,
-      sentry_dsn         => $sentry_dsn,
-      vhost_ssl_only     => true,
-      health_check_path  => '/healthcheck',
+      app_type                 => 'rack',
+      log_format_is_json       => true,
+      port                     => $port,
+      sentry_dsn               => $sentry_dsn,
+      vhost_ssl_only           => true,
+      health_check_path        => '/healthcheck',
+      unicorn_worker_processes =>  $unicorn_worker_processes,
     }
 
     Govuk::App::Envvar {

--- a/modules/govuk/manifests/apps/signon.pp
+++ b/modules/govuk/manifests/apps/signon.pp
@@ -57,6 +57,10 @@
 # [*sso_push_user_email*]
 #   Email address for the SSO sync push user.
 #
+# [*unicorn_worker_processe*s]
+#   The number of unicorn worker processes to run
+#   Default: undef
+#
 class govuk::apps::signon(
   $db_hostname = undef,
   $db_name = undef,
@@ -74,19 +78,21 @@ class govuk::apps::signon(
   $redis_port = undef,
   $secret_key_base = undef,
   $sso_push_user_email = undef,
+  $unicorn_worker_processes = undef,
 ) {
   $app_name = 'signon'
 
   govuk::app { $app_name:
-    app_type               => 'rack',
-    port                   => $port,
-    sentry_dsn             => $sentry_dsn,
-    vhost_ssl_only         => true,
-    health_check_path      => '/users/sign_in',
-    asset_pipeline         => true,
-    deny_framing           => true,
-    nagios_memory_warning  => $nagios_memory_warning,
-    nagios_memory_critical => $nagios_memory_critical,
+    app_type                 => 'rack',
+    port                     => $port,
+    sentry_dsn               => $sentry_dsn,
+    vhost_ssl_only           => true,
+    health_check_path        => '/users/sign_in',
+    asset_pipeline           => true,
+    deny_framing             => true,
+    nagios_memory_warning    => $nagios_memory_warning,
+    nagios_memory_critical   => $nagios_memory_critical,
+    unicorn_worker_processes => $unicorn_worker_processes,
   }
 
   Govuk::App::Envvar {

--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -164,20 +164,21 @@ class govuk::apps::whitehall(
   }
 
   govuk::app { $app_name:
-    app_type               => 'rack',
-    vhost                  => $vhost,
-    port                   => $port,
-    sentry_dsn             => $sentry_dsn,
-    log_format_is_json     => true,
-    health_check_path      => $health_check_path,
-    expose_health_check    => false,
-    json_health_check      => true,
-    depends_on_nfs         => true,
-    enable_nginx_vhost     => false,
-    nagios_memory_warning  => $nagios_memory_warning,
-    nagios_memory_critical => $nagios_memory_critical,
-    unicorn_herder_timeout => 45,
-    require                => Package['unzip'],
+    app_type                 => 'rack',
+    vhost                    => $vhost,
+    port                     => $port,
+    sentry_dsn               => $sentry_dsn,
+    log_format_is_json       => true,
+    health_check_path        => $health_check_path,
+    expose_health_check      => false,
+    json_health_check        => true,
+    depends_on_nfs           => true,
+    enable_nginx_vhost       => false,
+    nagios_memory_warning    => $nagios_memory_warning,
+    nagios_memory_critical   => $nagios_memory_critical,
+    unicorn_herder_timeout   => 45,
+    require                  => Package['unzip'],
+    unicorn_worker_processes => $unicorn_worker_processes,
   }
 
   Govuk::App::Envvar {
@@ -480,9 +481,6 @@ class govuk::apps::whitehall(
     "${title}-PUBLISHING_API_BEARER_TOKEN":
       varname => 'PUBLISHING_API_BEARER_TOKEN',
       value   => $publishing_api_bearer_token;
-    "${title}-UNICORN_WORKER_PROCESSES":
-      varname => 'UNICORN_WORKER_PROCESSES',
-      value   => $unicorn_worker_processes;
   }
 
   if $basic_auth_credentials != undef {


### PR DESCRIPTION
We've upgraded local-links-manager to configure unicorn via
govuk_app_config, and the expected way to change the number of worker
processes used by unicorn is via an env var picked up by govuk_app_config,
rather than hardcoded directly in the apps own config/unicorn.rb.

We set the workers to 4 because local-links-manager has had 4 unicorn
workers since alphagov/local-links-manager#52

Note: this should be merged and deployed before https://github.com/alphagov/local-links-manager/pull/181 otherwise we'll have a blip where local-links-manager only has 2 workers (the default when no env var is present).