### PR TITLE
add attachments paramater to the copy_data_to_integration config

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
@@ -88,6 +88,7 @@
             choices:
                 - all
                 - assets
+                - attachments
                 - elasticsearch-rummager
                 - mongo-api
                 - mongo-exceptions


### PR DESCRIPTION
This PR adds the attachments sync task to the copy_data_to_integration job so we can rerun this single import on integration.

It seems like this is safe to do, based on attachments being an option on the list of jobs in [env-sync-and-back-up](https://github.com/alphagov/env-sync-and-backup/blob/master/jobs/attachments.sh)