### PR TITLE
Support secret_token and secret_key_base in inconsistent apps

### DIFF
--- a/modules/govuk/manifests/apps/manuals_publisher.pp
+++ b/modules/govuk/manifests/apps/manuals_publisher.pp
@@ -49,6 +49,14 @@
 #   Redis port for sidekiq.
 #   Default: 6379
 #
+# [*secret_key_base*]
+#   The secret key base value for rails
+#   Default: undef
+#
+# [*secret_token*]
+#   Deprecated. The old name for the secret key base valur
+#   Default: undef
+#
 # [*link_checker_api_secret_token*]
 #   The Link Checker API secret token.
 #   Default: undef
@@ -66,6 +74,7 @@ class govuk::apps::manuals_publisher(
   $publishing_api_bearer_token = undef,
   $redis_host = undef,
   $redis_port = undef,
+  $secret_key_base = undef,
   $secret_token = undef,
   $link_checker_api_secret_token = undef,
 ) {
@@ -119,6 +128,15 @@ class govuk::apps::manuals_publisher(
       value   => $link_checker_api_secret_token;
   }
 
+  if $secret_key_base != undef {
+    govuk::app::envvar { "${title}-SECRET_KEY_BASE":
+      varname => 'SECRET_KEY_BASE',
+      value   => $secret_key_base,
+    }
+  }
+
+  # @FIXME: This should be removed once secret_token has been changed to
+  # secret_key_base in https://github.com/alphagov/govuk-secrets/pull/213
   if $secret_token != undef {
     govuk::app::envvar { "${title}-SECRET_TOKEN":
       varname => 'SECRET_TOKEN',

--- a/modules/govuk/manifests/apps/specialist_publisher.pp
+++ b/modules/govuk/manifests/apps/specialist_publisher.pp
@@ -63,11 +63,12 @@
 #   Redis port for sidekiq.
 #   Default: 6379
 #
+# [*secret_key_base*]
+#   The secret key base value for rails
+#   Default: undef
+#
 # [*secret_token*]
-#   Used to set the app ENV var SECRET_TOKEN which is used to configure
-#   rails 4.x signed cookie mechanism. If unset the app will be unable to
-#   start. SECRET_TOKEN is used rather than SECRET_KEY_BASE so that
-#   specialist publisher can share signed cookies with version 1.
+#   Deprecated. The old name for the secret key base valur
 #   Default: undef
 #
 class govuk::apps::specialist_publisher(
@@ -87,6 +88,7 @@ class govuk::apps::specialist_publisher(
   $nagios_memory_critical = undef,
   $redis_host = undef,
   $redis_port = undef,
+  $secret_key_base = undef,
   $secret_token = undef,
 ) {
 
@@ -151,6 +153,15 @@ client_max_body_size 500m;
       value   => $email_alert_api_bearer_token;
     }
 
+    if $secret_key_base != undef {
+      govuk::app::envvar { "${title}-SECRET_KEY_BASE":
+        varname => 'SECRET_KEY_BASE',
+        value   => $secret_key_base,
+      }
+    }
+
+    # @FIXME: This should be removed once secret_token has been changed to
+    # secret_key_base in https://github.com/alphagov/govuk-secrets/pull/213
     if $secret_token != undef {
       govuk::app::envvar { "${title}-SECRET_TOKEN":
         varname => 'SECRET_TOKEN',

--- a/modules/govuk/manifests/apps/specialist_publisher.pp
+++ b/modules/govuk/manifests/apps/specialist_publisher.pp
@@ -22,7 +22,6 @@
 # [*enable_procfile_worker*]
 #   Whether to enable the procfile worker
 #   Default: true
-
 #
 # [*mongodb_nodes*]
 #   Array of hostnames for the mongo cluster to use.


### PR DESCRIPTION
For apps that are inconsistent, Specialist Publisher and Manuals
Publisher, this allows them to have hieradata values for secret_token
and secret_key_base to allow for the switch over of these variables.

The support for secret_token should be removed once this has been
shipped to production and
alphagov/govuk-secrets#213 has been merged.