### PR TITLE
Remove asset-related resources marked as absent & unmount NFS mount on asset slaves

### DIFF
--- a/modules/govuk/manifests/apps/asset_manager.pp
+++ b/modules/govuk/manifests/apps/asset_manager.pp
@@ -66,14 +66,6 @@ class govuk::apps::asset_manager(
 
     $app_domain = hiera('app_domain')
 
-    govuk::app::envvar {
-      "${title}-PRIVATE_ASSET_MANAGER_HOST":
-        ensure  => 'absent',
-        app     => 'asset-manager',
-        varname => 'PRIVATE_ASSET_MANAGER_HOST',
-        value   => "private-asset-manager.${app_domain}";
-    }
-
     Govuk::App::Envvar {
       app => $app_name,
     }

--- a/modules/govuk/manifests/node/s_asset_slave.pp
+++ b/modules/govuk/manifests/node/s_asset_slave.pp
@@ -41,13 +41,6 @@ class govuk::node::s_asset_slave (
     require  => File['/data/master-uploads'],
   }
 
-  cron { 'sync-asset-manager-from-master':
-    ensure  => 'absent',
-    user    => 'assets',
-    minute  => '*/10',
-    command => '/usr/bin/setlock -n /var/tmp/asset-manager.lock /usr/bin/rsync -a --delete /data/master-uploads/asset-manager/ /mnt/uploads/asset-manager',
-  }
-
   $master_metrics_hostname = regsubst($::fqdn_metrics, 'slave-\d', 'master-1')
   $graphite_mnt_uploads_metric = 'df-mnt-uploads.df_complex-used'
   $master_metric = "${master_metrics_hostname}.${graphite_mnt_uploads_metric}"

--- a/modules/govuk/manifests/node/s_asset_slave.pp
+++ b/modules/govuk/manifests/node/s_asset_slave.pp
@@ -32,7 +32,7 @@ class govuk::node::s_asset_slave (
 
   # FIXME: Remove the NFS mount once asset-manager is no longer using it.
   mount { '/data/master-uploads':
-    ensure   => 'mounted',
+    ensure   => 'absent',
     device   => "asset-master.${app_domain}:/mnt/uploads",
     fstype   => 'nfs',
     options  => 'rw,soft',


### PR DESCRIPTION
* Remove `PRIVATE_ASSET_MANAGER_HOST` environment variable resource from Asset Manager
* Remove `sync-asset-manager-from-master` cron job resource from asset slaves
* Unmount & remove `/data/master-uploads` NFS mount from asset slaves

See individual commits for more details.