### PR TITLE
Set unicorn worker processes for content store

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -358,6 +358,7 @@ govuk::apps::content_performance_manager::redis_port: "%{hiera('sidekiq_port')}"
 
 govuk::apps::content_store::nagios_memory_warning: 2300
 govuk::apps::content_store::nagios_memory_critical: 2500
+govuk::apps::content_store::unicorn_worker_processes: "6"
 
 govuk::apps::content_tagger::db_hostname: "postgresql-primary-1.backend"
 govuk::apps::content_tagger::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"

--- a/modules/govuk/manifests/apps/content_store.pp
+++ b/modules/govuk/manifests/apps/content_store.pp
@@ -45,6 +45,9 @@
 # [*secret_key_base*]
 #   The key for Rails to use when signing/encrypting sessions.
 #
+# [*unicorn_worker_processes*]
+#   The number of unicorn workers to run for an instance of this app
+#
 class govuk::apps::content_store(
   $port = '3068',
   $mongodb_nodes,
@@ -58,19 +61,21 @@ class govuk::apps::content_store(
   $nagios_memory_critical = undef,
   $secret_key_base = undef,
   $sentry_dsn = undef,
+  $unicorn_worker_processes = undef,
 ) {
   $app_name = 'content-store'
 
   govuk::app { $app_name:
-    app_type               => 'rack',
-    port                   => $port,
-    sentry_dsn             => $sentry_dsn,
-    vhost_ssl_only         => true,
-    health_check_path      => '/healthcheck',
-    log_format_is_json     => true,
-    vhost                  => $vhost,
-    nagios_memory_warning  => $nagios_memory_warning,
-    nagios_memory_critical => $nagios_memory_critical,
+    app_type                 => 'rack',
+    port                     => $port,
+    sentry_dsn               => $sentry_dsn,
+    vhost_ssl_only           => true,
+    health_check_path        => '/healthcheck',
+    log_format_is_json       => true,
+    vhost                    => $vhost,
+    nagios_memory_warning    => $nagios_memory_warning,
+    nagios_memory_critical   => $nagios_memory_critical,
+    unicorn_worker_processes => $unicorn_worker_processes,
   }
 
   Govuk::App::Envvar {


### PR DESCRIPTION
This moves this configuration which is currently hardcoded into content
store into an environment variable.