### PR TITLE
Get Licensify deploying again

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_licensify.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_licensify.yaml.erb
@@ -19,9 +19,9 @@
             cd "$WORKSPACE"
             echo "Grabbing Build ${artefact_number} Artifacts from Jenkins"
             CI_BASE_URL="https://licensify:<%= @ci_new_jenkins_api_key -%>@ci.dev.publishing.service.gov.uk/job/${CI_JOB_NAME}/${artefact_number}/artifact"
-            curl -O "${CI_BASE_URL}/backend/${ARTIFACT_PATH}/backend-${app_version}.zip"
-            curl -O "${CI_BASE_URL}/feed/${ARTIFACT_PATH}/feed-${app_version}.zip"
-            curl -O "${CI_BASE_URL}/frontend/${ARTIFACT_PATH}/frontend-${app_version}.zip"
+            curl -O -k "${CI_BASE_URL}/backend/${ARTIFACT_PATH}/backend-${app_version}.zip"
+            curl -O -k "${CI_BASE_URL}/feed/${ARTIFACT_PATH}/feed-${app_version}.zip"
+            curl -O -k "${CI_BASE_URL}/frontend/${ARTIFACT_PATH}/frontend-${app_version}.zip"
             logger -p INFO -t jenkins "DEPLOYMENT: ${JOB_NAME} ${artefact_number} (${BUILD_URL})"
             export app_version=${app_version}
             exec bash -e elms/deploy/deploy.sh

--- a/modules/govuk_jenkins/templates/jobs/deploy_licensify.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_licensify.yaml.erb
@@ -35,7 +35,7 @@
         - ansicolor:
             colormap: xterm
         - build-name:
-            name: '${ENV,var="TARGET_APPLICATION"} ${ENV,var="TAG"}'
+            name: '${ENV,var="artefact_number"} #${BUILD_NUMBER}'
     parameters:
         - choice:
             name: BETA_PAYMENT_ACCOUNTS

--- a/modules/govuk_jenkins/templates/jobs/deploy_licensify.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_licensify.yaml.erb
@@ -17,6 +17,7 @@
     builders:
         - shell: |
             cd "$WORKSPACE"
+            curl -X POST -H 'Content-type: application/json' --data "{'text': ':govuk-${ORGANISATION}::mega: Version ${app_version}/${artefact_number} of <https://github.com/alphagov/licensify|licensify> is being deployed to *${ORGANISATION}*', 'channel': '#govuk-deploy', 'link_names': 1, 'username': 'Badger', 'icon_emoji': ':badger:'}" "${BADGER_SLACK_WEBHOOK_URL}"
             echo "Grabbing Build ${artefact_number} Artifacts from Jenkins"
             CI_BASE_URL="https://licensify:<%= @ci_new_jenkins_api_key -%>@ci.dev.publishing.service.gov.uk/job/${CI_JOB_NAME}/${artefact_number}/artifact"
             curl -O -k "${CI_BASE_URL}/backend/${ARTIFACT_PATH}/backend-${app_version}.zip"

--- a/modules/govuk_jenkins/templates/jobs/deploy_licensify.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_licensify.yaml.erb
@@ -3,7 +3,7 @@
     name: alphagov-deployment_Licensify_Deploy
     scm:
         - git:
-            url: git@github.digital.cabinet-office.gov.uk:gds/alphagov-deployment.git
+            url: git@github.com:alphagov/alphagov-deployment.git
             branches:
               - master
             wipe-workspace: false


### PR DESCRIPTION
* Repo has moved from GHE to github.com.
* Artefact happens in old-old CI, which is currently having cert issues, so need to skip cert checks for now.
* Change the build name to something that a) works, and b) is vaguely useful.
* Announce the build start in Slack. Completion announcement happens as part of the actual [deployment script](https://github.com/alphagov/alphagov-deployment/pull/19) due to the `exec`.