### PR TITLE
Increase healthcheck timeout

### DIFF
--- a/modules/icinga/files/usr/lib/nagios/plugins/check_json_healthcheck
+++ b/modules/icinga/files/usr/lib/nagios/plugins/check_json_healthcheck
@@ -143,7 +143,7 @@ if __name__ == "__main__":
     check_url = url_from_arguments(sys.argv[1:])
 
     try:
-        with closing(urlopen(json_request(check_url), timeout=1)) as response:
+        with closing(urlopen(json_request(check_url), timeout=10)) as response:
             healthcheck_info = HealthCheckInfo(json.load(response))
     except HTTPError as e:
         report_error("healthcheck returned HTTP error %d" % (e.code,))


### PR DESCRIPTION
If the healthcheck takes a long time to respond but still provides a useful response it would be better to let Icinga show the warning or critical about how long it took to respond, and also include the warning/critical healthcheck status.