### PR TITLE
Ensure mtail directory is deleted by puppet

### DIFF
--- a/modules/mtail/manifests/init.pp
+++ b/modules/mtail/manifests/init.pp
@@ -57,6 +57,7 @@ class mtail(
 #    ensure  => directory,
     ensure => 'absent',
     mode   => '0755',
+    force  => true,
 #    require => Package['mtail'],
   }
 


### PR DESCRIPTION
Set `force` parameter to ensure the `/etc/mtail` directory is deleted. Puppet avoids deleting directories without this parameter set to `true`.

cc @chao-xian 