### PR TITLE
Simplify Licensify deploy job parameters

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_licensify.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_licensify.yaml.erb
@@ -39,20 +39,24 @@
             name: '${BUILD_NUMBER}/${ENV,var="CI_JOB_NAME"}/${ENV,var="artefact_number"}'
     parameters:
         - choice:
-            name: BETA_PAYMENT_ACCOUNTS
+            name: CI_JOB_NAME
             choices:
-                - 'false'
+                - 'Licensify'
+                - 'Licensify_Branches'
+            description: Which job on CI Jenkins to fetch the artifact from
         - string:
             name: artefact_number
             description: This is the build number from CI Jenkins
         - string:
             name: app_version
-            description: version of the application (i.e. 1.1.0)
-        - string:
-            name: CI_JOB_NAME
-            default: Licensify
-            description: Which job on CI Jenkins to fetch the artifact from
-        - string:
+            description: Version of the application (i.e. 1.1.1). Must match the value in conf/application.conf of the built application.
+        - choice:
             name: ARTIFACT_PATH
-            default: target/universal
+            choices:
+                - 'target/universal'
             description: The path on CI Jenkins where the artifacts are stored
+        - choice:
+            name: BETA_PAYMENT_ACCOUNTS
+            choices:
+                - 'false'
+            description: Use beta test payment accounts? (No longer used.)

--- a/modules/govuk_jenkins/templates/jobs/deploy_licensify.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_licensify.yaml.erb
@@ -17,7 +17,7 @@
     builders:
         - shell: |
             cd "$WORKSPACE"
-            curl -X POST -H 'Content-type: application/json' --data "{'text': ':govuk-${ORGANISATION}::mega: Version ${app_version}/${artefact_number} of <https://github.com/alphagov/licensify|licensify> is being deployed to *${ORGANISATION}*', 'channel': '#govuk-deploy', 'link_names': 1, 'username': 'Badger', 'icon_emoji': ':badger:'}" "${BADGER_SLACK_WEBHOOK_URL}"
+            curl -X POST -H 'Content-type: application/json' --data "{'text': ':govuk-${ORGANISATION}::mega: Build \`${BUILD_DISPLAY_NAME}\` of <https://github.com/alphagov/licensify|licensify> is being deployed to *${ORGANISATION}*', 'channel': '#govuk-deploy', 'link_names': 1, 'username': 'Badger', 'icon_emoji': ':badger:'}" "${BADGER_SLACK_WEBHOOK_URL}"
             echo "Grabbing Build ${artefact_number} Artifacts from Jenkins"
             CI_BASE_URL="https://licensify:<%= @ci_new_jenkins_api_key -%>@ci.dev.publishing.service.gov.uk/job/${CI_JOB_NAME}/${artefact_number}/artifact"
             curl -O -k "${CI_BASE_URL}/backend/${ARTIFACT_PATH}/backend-${app_version}.zip"
@@ -36,7 +36,7 @@
         - ansicolor:
             colormap: xterm
         - build-name:
-            name: '${ENV,var="artefact_number"} #${BUILD_NUMBER}'
+            name: '${BUILD_NUMBER}/${ENV,var="CI_JOB_NAME"}/${ENV,var="artefact_number"}'
     parameters:
         - choice:
             name: BETA_PAYMENT_ACCOUNTS


### PR DESCRIPTION
* Make it clearer what build params needs to be completed, with what values, and what can be (needs to be) left alone.
* Update the build name and Slack notification to be more obvious what's being deployed.