### PR TITLE
Environment variables to switch email-alert-api from Govdelivery to Notify

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -12,6 +12,8 @@ govuk::apps::asset_manager::aws_s3_bucket_name: 'govuk-assets-integration'
 govuk::apps::asset_manager::aws_region: 'eu-west-1'
 govuk::apps::email_alert_api::allow_govdelivery_topic_syncing: true
 govuk::apps::email_alert_api::govuk_notify_template_id: '1fc69d3a-09a2-40f9-852b-03f6fcef5340'
+govuk::apps::email_alert_api::disable_govdelivery_emails: true
+govuk::apps::email_alert_api::use_email_alert_frontend_for_email_collection: true
 govuk::apps::govuk_crawler_worker::enabled: false
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
 govuk::apps::kibana::logit_environment: 2694f14b-6519-4607-81f2-8a2130e5aaec

--- a/modules/govuk/manifests/apps/email_alert_api.pp
+++ b/modules/govuk/manifests/apps/email_alert_api.pp
@@ -38,7 +38,7 @@
 #   Must only be configured to `true` in staging or integration, never production.
 #   Default: false
 #
-# [*use_email_alert_frontend_for_email_collection]
+# [*use_email_alert_frontend_for_email_collection*]
 #   If set, users will be redirected to email-alert-frontend to enter their
 #   email address instead of govdelivery. This affects the `subscription_url`
 #   in responses from the Email Alert API which is used by `collections`,

--- a/modules/govuk/manifests/apps/email_alert_api.pp
+++ b/modules/govuk/manifests/apps/email_alert_api.pp
@@ -38,7 +38,13 @@
 #   Must only be configured to `true` in staging or integration, never production.
 #   Default: false
 #
-# [*use_email_alert_frontend_for_email_collection*]
+# [* disable_govdelivery_emails*]
+#   If set this disables the sending of email bulletins to govdelivery and will
+#   mean users aren't notified of events unless a different system (notably
+#   the notify based one) is in operation.
+#   Default: false
+#
+# [*use_email_alert_frontend_for_email_collection]
 #   If set, users will be redirected to email-alert-frontend to enter their
 #   email address instead of govdelivery. This affects the `subscription_url`
 #   in responses from the Email Alert API which is used by `collections`,
@@ -105,6 +111,7 @@ class govuk::apps::email_alert_api(
   $redis_port = undef,
   $sentry_dsn = undef,
   $allow_govdelivery_topic_syncing = false,
+  $disable_govdelivery_emails = false,
   $use_email_alert_frontend_for_email_collection = false,
   $govdelivery_username = undef,
   $govdelivery_password = undef,
@@ -234,6 +241,13 @@ class govuk::apps::email_alert_api(
       govuk::app::envvar { "${title}-ALLOW_GOVDELIVERY_SYNC":
         varname => 'ALLOW_GOVDELIVERY_SYNC',
         value   => 'allow';
+      }
+    }
+
+    if $disable_govdelivery_emails {
+      govuk::app::envvar { "${title}-DISABLE_GOVDELIVERY_EMAILS":
+        varname => 'DISABLE_GOVDELIVERY_EMAILS',
+        value   => 'yes';
       }
     }
 

--- a/modules/govuk/manifests/apps/email_alert_api.pp
+++ b/modules/govuk/manifests/apps/email_alert_api.pp
@@ -43,6 +43,7 @@
 #   email address instead of govdelivery. This affects the `subscription_url`
 #   in responses from the Email Alert API which is used by `collections`,
 #   `finder-frontend` and `whitehall`.
+#   Default: false
 #
 # [*govdelivery_username*]
 #   Username used to authenticate with govdelivery API


### PR DESCRIPTION
Trello: https://trello.com/c/CDYgpQDY/565-add-flags-to-enable-migration-from-govdelivery-to-notify

This adds an environment variable for Email Alert API of `DISABLE_GOVDELIVERY_EMAILS` which is used to disable this ability.

It also sets disable_govdelivery_emails and use_email_alert_frontend_for_email_collection to true in integration environment so that can we begin testing a notify flow there.