### PR TITLE
Add govuk-lint dependency on CI

### DIFF
--- a/modules/govuk_ci/manifests/agent.pp
+++ b/modules/govuk_ci/manifests/agent.pp
@@ -60,6 +60,10 @@ class govuk_ci::agent(
     require => Class['::govuk_jenkins::user'],
   }
 
+  package { 'libffi-dev': # needed for ffi: a dependency of govuk-lint
+    ensure => installed,
+  }
+
   package { 'libgdal-dev': # needed for mapit
     ensure => installed,
   }


### PR DESCRIPTION
govuk-lint depends on sass-lint, which depends on sass, which depends on sass-listen which depends on rb-inotify which depends on ffi.

ffi has a [dependency on a dev ffi package](https://github.com/ffi/ffi#requirements) which is [already on deploy jenkins boxes](https://github.com/alphagov/govuk-puppet/blob/30e9430d24ca502c373a057870f59d9e8eed70fd/modules/govuk_jenkins/manifests/init.pp#L120)

I'm not sure why this has stopped working, but [it's stopping builds at the moment](https://ci.integration.publishing.service.gov.uk/job/govuk_navigation_helpers/job/update-learn-to-drive-content).