### PR TITLE
Avoid asset requests going via static

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -622,7 +622,6 @@ govuk::apps::smokey::smokey_signon_password: "%{hiera('smokey_signon_password')}
 govuk::apps::smokey::smokey_bearer_token: "%{hiera('smokey_bearer_token')}"
 govuk::apps::smokey::rate_limit_token: "%{hiera('smokey_rate_limit_token')}"
 
-govuk::apps::static::asset_manager_host: "asset-manager.%{hiera('app_domain')}"
 govuk::apps::static::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::static::redis_port: "%{hiera('sidekiq_port')}"
 

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -612,7 +612,6 @@ govuk::apps::smokey::smokey_signon_password: "%{hiera('smokey_signon_password')}
 govuk::apps::smokey::smokey_bearer_token: "%{hiera('smokey_bearer_token')}"
 govuk::apps::smokey::rate_limit_token: "%{hiera('smokey_rate_limit_token')}"
 
-govuk::apps::static::asset_manager_host: "asset-manager.%{hiera('app_domain_internal')}"
 govuk::apps::static::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::static::redis_port: "%{hiera('sidekiq_port')}"
 

--- a/lib/puppet-lint/plugins/check_hiera.rb
+++ b/lib/puppet-lint/plugins/check_hiera.rb
@@ -49,7 +49,7 @@ PuppetLint.new_check(:hiera_explicit_lookup) do
     # metrics
     'govuk_logging::logstream::metrics_only',
 
-    # Allow sharing of asset_manager_uploaded_assets_routes array between assets-origin and static
+    # Allow sharing of asset_manager_uploaded_assets_routes array between assets-origin and draft-assets
     # nginx virtual host configuration
     'router::assets_origin::asset_manager_uploaded_assets_routes',
 

--- a/modules/govuk/manifests/apps/static.pp
+++ b/modules/govuk/manifests/apps/static.pp
@@ -37,10 +37,6 @@
 #   Redis port for Sidekiq.
 #   Default: undef
 #
-# [*asset_manager_host*]
-#   The hostname that will proxy pass to asset manager.
-#   Default: undef
-#
 class govuk::apps::static(
   $vhost = 'static',
   $port = '3013',
@@ -50,17 +46,9 @@ class govuk::apps::static(
   $publishing_api_bearer_token = undef,
   $redis_host = undef,
   $redis_port = undef,
-  $asset_manager_host = undef,
 ) {
   $enable_ssl = hiera('nginx_enable_ssl', true)
   $app_name = 'static'
-  $asset_manager_uploaded_assets_routes = hiera('router::assets_origin::asset_manager_uploaded_assets_routes', [])
-
-  if $::aws_migration {
-    $proxy_pass_asset_manager_host_https = true
-  } else {
-    $proxy_pass_asset_manager_host_https = false
-  }
 
   govuk::app { $app_name:
     app_type              => 'rack',

--- a/modules/govuk/manifests/apps/static/enable_running_in_draft_mode.pp
+++ b/modules/govuk/manifests/apps/static/enable_running_in_draft_mode.pp
@@ -44,16 +44,8 @@ class govuk::apps::static::enable_running_in_draft_mode(
   $redis_port = undef,
 ) {
   $app_domain = hiera('app_domain')
-  $asset_manager_host = "asset-manager.${app_domain}"
   $enable_ssl = hiera('nginx_enable_ssl', true)
   $app_name = 'draft-static'
-  $asset_manager_uploaded_assets_routes = hiera('router::assets_origin::asset_manager_uploaded_assets_routes', [])
-
-  if $::aws_migration {
-    $proxy_pass_asset_manager_host_https = true
-  } else {
-    $proxy_pass_asset_manager_host_https = false
-  }
 
   govuk::app { $app_name:
     app_type              => 'rack',

--- a/modules/govuk/templates/static_extra_nginx_config.conf.erb
+++ b/modules/govuk/templates/static_extra_nginx_config.conf.erb
@@ -15,18 +15,3 @@ location /__canary__ {
 location /robots.txt {
   expires 1w;
 }
-
-<% @asset_manager_uploaded_assets_routes.each do |path_to_be_proxied_to_asset_manager| %>
-
-  location ~ ^<%= path_to_be_proxied_to_asset_manager %> {
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-Server $host;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_pass <%= @enable_ssl || @proxy_pass_asset_manager_host_https ? 'https' : 'http' %>://<%= @asset_manager_host %>;
-
-    # Explicitly re-include Strict-Transport-Security header, this
-    # forces nginx not to clear Cache-Control headers further up the
-    # stack.
-    include /etc/nginx/add-sts.conf;
-  }
-<% end %>

--- a/modules/router/templates/assets_origin.conf.erb
+++ b/modules/router/templates/assets_origin.conf.erb
@@ -49,7 +49,16 @@ server {
 
   <%- @asset_manager_uploaded_assets_routes.each do |path| -%>
   location <%= path %> {
-    proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://static.<%= @app_domain %>;
+    # Explicitly re-include Strict-Transport-Security header, this
+    # forces nginx not to clear Cache-Control headers further up the
+    # stack.
+    include /etc/nginx/add-sts.conf;
+
+    add_header "Access-Control-Allow-Origin" "*";
+    add_header "Access-Control-Allow-Methods" "GET, OPTIONS";
+    add_header "Access-Control-Allow-Headers" "origin, authorization";
+
+    proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://asset-manager.<%= @app_domain %>;
   }
   <%- end -%>
 


### PR DESCRIPTION
It seems unnecessary to route these requests to asset-manager via static.
    
Routing these requests directly to asset-manager mirrors the configuration in draft-assets.