### PR TITLE
Revert "Remove content audit tool jenkins job"

### DIFF
--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -8,6 +8,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::check_content_consistency
   - govuk_jenkins::jobs::check_content_store
   - govuk_jenkins::jobs::check_pingdom_ip_ranges
+  - govuk_jenkins::jobs::content_audit_tool
   - govuk_jenkins::jobs::content_performance_manager
   - govuk_jenkins::jobs::copy_data_to_integration
   - govuk_jenkins::jobs::copy_data_to_staging


### PR DESCRIPTION
Reverts alphagov/govuk-puppet#7177

Jenkins jobs were disabled[1] because credentials were not set up yet, and were causing errors. These credentials are set up now and we are ready to re-enable the Jenkins jobs.

[1] 4834e705fe61dad365a97519957b59a695d674f8 