### PR TITLE
Move the old 'deploy terraform project' Jenkins job to AWS

### DIFF
--- a/hieradata/class/integration/jenkins.yaml
+++ b/hieradata/class/integration/jenkins.yaml
@@ -4,7 +4,6 @@ govuk_jenkins::config::executors: '4'
 govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::deploy_licensify
   - govuk_jenkins::jobs::deploy_puppet
-  - govuk_jenkins::jobs::deploy_terraform_project
   - govuk_jenkins::jobs::launch_vms
   - govuk_jenkins::jobs::network_config_deploy
   - govuk_jenkins::jobs::passive_checks

--- a/hieradata_aws/class/jenkins.yaml
+++ b/hieradata_aws/class/jenkins.yaml
@@ -67,6 +67,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::deploy_emergency_banner
   - govuk_jenkins::jobs::deploy_puppet
   - govuk_jenkins::jobs::deploy_router_data
+  - govuk_jenkins::jobs::deploy_terraform_project
   - govuk_jenkins::jobs::enhanced_ecommerce
   - govuk_jenkins::jobs::extract_app_performance
   - govuk_jenkins::jobs::govuk_taxonomy_supervised_learning


### PR DESCRIPTION
- It's using terraform v0.8, whereas the new terraform build job we want
  to add runs terraform v0.11, which won't install in parallel.

(This was noted in https://github.com/alphagov/govuk-puppet/pull/7179#issuecomment-361953825.)