### PR TITLE
Remove govuk_notify_base_url env var

### DIFF
--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -18,7 +18,6 @@ govuk::apps::email_alert_api::db::backend_ip_range: '10.2.3.0/24'
 govuk::apps::email_alert_api::govdelivery_account_code: 'UKGOVUK'
 govuk::apps::email_alert_api::govdelivery_hostname: 'api.govdelivery.com'
 govuk::apps::email_alert_api::govdelivery_public_hostname: 'public.govdelivery.com'
-govuk::apps::email_alert_api::govuk_notify_base_url: 'https://api.production-notify.works'
 govuk::apps::email_alert_api::govuk_notify_template_id: '76d21ce7-54c3-4fb7-8830-ba3b79287985'
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::kibana::logit_environment: 0ea55710-075b-4eab-bfc3-475f28cdd0c3

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -18,7 +18,6 @@ govuk::apps::email_alert_api::db::backend_ip_range: '10.2.3.0/24'
 govuk::apps::email_alert_api::govdelivery_account_code: 'UKGOVUK'
 govuk::apps::email_alert_api::govdelivery_hostname: 'stage-api.govdelivery.com'
 govuk::apps::email_alert_api::govdelivery_public_hostname: 'stage-public.govdelivery.com'
-govuk::apps::email_alert_api::govuk_notify_base_url: 'https://api.staging-notify.works'
 govuk::apps::email_alert_api::govuk_notify_template_id: '2844a647-6bf1-4b01-a25c-569d2cc00849'
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::kibana::logit_environment: d414187a-2796-4ea7-9b9a-d40c341646d6

--- a/modules/govuk/manifests/apps/email_alert_api.pp
+++ b/modules/govuk/manifests/apps/email_alert_api.pp
@@ -76,7 +76,7 @@
 #   Template ID for GOV.UK Notify
 #
 # [*govuk_notify_base_url*]
-#   Base URL for GOV.UK Notify API
+#   Deprecated env var to switch notify environments. 
 #
 # [*govuk_notify_rate_per_worker*]
 #   Number of requests per seconds that the notify delivery worker
@@ -120,8 +120,8 @@ class govuk::apps::email_alert_api(
   $govdelivery_hostname = undef,
   $govdelivery_public_hostname = undef,
   $govuk_notify_api_key = undef,
-  $govuk_notify_template_id = undef,
   $govuk_notify_base_url = undef,
+  $govuk_notify_template_id = undef,
   $govuk_notify_rate_per_worker = undef,
   $secret_key_base = undef,
   $oauth_id = undef,
@@ -218,6 +218,7 @@ class govuk::apps::email_alert_api(
           varname => 'GOVUK_NOTIFY_TEMPLATE_ID',
           value   => $govuk_notify_template_id;
       "${title}-GOVUK_NOTIFY_BASE_URL":
+          ensure  => 'absent',
           varname => 'GOVUK_NOTIFY_BASE_URL',
           value   => $govuk_notify_base_url;
       "${title}-GOVUK_NOTIFY_RATE_PER_WORKER":


### PR DESCRIPTION
This was used by email-alert-api when we were testing using the notify staging environment. We no longer use different environments so we no longer need this env var.

This 'ensures' it is absent. It will be fully removed in a subsequent commit.