### PR TITLE
Disable setting logroot env var in development environment

### DIFF
--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -124,15 +124,19 @@ define govuk::app::config (
       "${title}-GOVUK_APP_RUN":
         varname => 'GOVUK_APP_RUN',
         value   => $govuk_app_run;
-      "${title}-GOVUK_APP_LOGROOT":
-        varname => 'GOVUK_APP_LOGROOT',
-        value   => "/var/log/${title}";
       "${title}-GOVUK_STATSD_PREFIX":
         varname => 'GOVUK_STATSD_PREFIX',
         value   => "govuk.app.${title}.${::hostname}";
       "${title}-SENTRY_DSN":
         varname => 'SENTRY_DSN',
         value   => $sentry_dsn;
+    }
+
+    if $::govuk_node_class !~ /^development$/ {
+      govuk::app::envvar { "${title}-GOVUK_APP_LOGROOT":
+        varname => 'GOVUK_APP_LOGROOT',
+        value   => "/var/log/${title}",
+      }
     }
 
     if $::aws_migration {


### PR DESCRIPTION
When govuk_setenv is run for an app it sets a GOVUK_APP_LOGROOT
variable which is to a directory that is owned by the deploy:deploy
user - it is also more normal in the dev environment to want the log to
come to STDOUT. When this env var is set for an application utilising
[govuk_app_config unicorn] this will then cause the application to try
write to this log file.

This problem seems to mostly occur when bowl is used to start apps as
that wraps commands within govuk_setenv.

To resolve this we avoid setting this environment variable in the
development class. Unfortunately as govuk::app::config is a Puppet
define rather than a class we can't use the automatic parameter lookup
to apply this across all apps.

[govuk_app_config unicorn]: https://github.com/alphagov/govuk_app_config/blob/d0eb72d0321f089b34b60b4f1a080d74f749941e/lib/govuk_app_config/govuk_unicorn.rb

/cc @bevanloon 