### PR TITLE
Add Unicorn worker processes for rummager

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -417,6 +417,7 @@ govuk::apps::publisher::email_group_dev: 'govuk-dev@digital.cabinet-office.gov.u
 govuk::apps::publisher::email_group_business: 'govuk-dev@digital.cabinet-office.gov.uk'
 govuk::apps::publisher::email_group_citizen: 'govuk-dev@digital.cabinet-office.gov.uk'
 
+
 govuk::apps::short_url_manager::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::short_url_manager::redis_port: "%{hiera('sidekiq_port')}"
 
@@ -525,6 +526,7 @@ govuk::apps::rummager::rabbitmq::enable_publishing_listener: true
 govuk::apps::rummager::rabbitmq_user: 'rummager-v2'
 govuk::apps::rummager::redis_host: 'api-redis-1.api'
 govuk::apps::rummager::redis_port: '6379'
+govuk::apps::rummager::unicorn_worker_processes: "6"
 
 govuk::apps::search_admin::db_name: 'search_admin_production'
 govuk::apps::search_admin::db_hostname: 'master.mysql'

--- a/modules/govuk/manifests/apps/rummager.pp
+++ b/modules/govuk/manifests/apps/rummager.pp
@@ -67,6 +67,9 @@
 # [*sitemap_generation_time*]
 #   A time of day in a format supported by https://github.com/javan/whenever
 #
+# [*unicorn_worker_processes*]
+#   The number of unicorn workers to run for an instance of this app
+#
 class govuk::apps::rummager(
   $rabbitmq_user,
   $port = '3009',
@@ -85,6 +88,7 @@ class govuk::apps::rummager(
   $spelling_dependencies = 'present',
   $elasticsearch_hosts = undef,
   $sitemap_generation_time = '1.10am',
+  $unicorn_worker_processes = undef,
 ) {
 
   package { ['aspell', 'aspell-en', 'libaspell-dev']:
@@ -92,17 +96,17 @@ class govuk::apps::rummager(
   }
 
   govuk::app { 'rummager':
-    app_type               => 'rack',
-    port                   => $port,
-    sentry_dsn             => $sentry_dsn,
-    health_check_path      => '/search?q=search_healthcheck',
+    app_type                 => 'rack',
+    port                     => $port,
+    sentry_dsn               => $sentry_dsn,
+    health_check_path        => '/search?q=search_healthcheck',
 
     # support search as an alias for ease of migration from old
     # cluster running in backend VDC.
-    vhost_aliases          => ['search'],
+    vhost_aliases            => ['search'],
 
-    log_format_is_json     => true,
-    nginx_extra_config     => '
+    log_format_is_json       => true,
+    nginx_extra_config       => '
     client_max_body_size 500m;
 
     location ^~ /sitemap.xml {
@@ -114,8 +118,9 @@ class govuk::apps::rummager(
       add_header Cache-Control public;
     }
     ',
-    nagios_memory_warning  => $nagios_memory_warning,
-    nagios_memory_critical => $nagios_memory_critical,
+    nagios_memory_warning    => $nagios_memory_warning,
+    nagios_memory_critical   => $nagios_memory_critical,
+    unicorn_worker_processes => $unicorn_worker_processes,
   }
 
   govuk::app::envvar::rabbitmq { 'rummager':


### PR DESCRIPTION
This allows this to be configured via puppet env vars rather than
being hardcoded in the app is is currently done.

Once this is done https://github.com/alphagov/rummager/blob/0d09662cecd356a8733facdf8f4802ab07899f1c/config/unicorn.rb can have the worker_processes line removed.