### PR TITLE
Extract whitehall asset routes

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1647,8 +1647,8 @@ router::assets_origin::app_specific_asset_routes:
   '/smartanswers/': "smartanswers"
 
 router::assets_origin::whitehall_asset_routes:
-  '/government/placeholder': "whitehall-frontend"
-  '/government/uploads/': "whitehall-frontend"
+  - '/government/placeholder'
+  - '/government/uploads/'
 
 router::assets_origin::asset_manager_routes:
   - '/government/uploads/government/uploads/system/uploads/'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1639,14 +1639,16 @@ router::assets_origin::app_specific_asset_routes:
   '/finder-frontend/': "finder-frontend"
   '/frontend/': "frontend"
   '/government/assets/': "whitehall-frontend"
-  '/government/placeholder': "whitehall-frontend"
-  '/government/uploads/': "whitehall-frontend"
   '/government-frontend/': "government-frontend"
   '/info-frontend/': "info-frontend"
   '/manuals-frontend/': "manuals-frontend"
   '/licencefinder/': "licencefinder"
   '/service-manual-frontend/': "service-manual-frontend"
   '/smartanswers/': "smartanswers"
+
+router::assets_origin::whitehall_asset_routes:
+  '/government/placeholder': "whitehall-frontend"
+  '/government/uploads/': "whitehall-frontend"
 
 router::assets_origin::asset_manager_routes:
   - '/government/uploads/government/uploads/system/uploads/'

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1049,14 +1049,16 @@ router::assets_origin::app_specific_asset_routes:
   '/finder-frontend/': "finder-frontend"
   '/frontend/': "frontend"
   '/government/assets/': "whitehall-frontend"
-  '/government/placeholder': "whitehall-frontend"
-  '/government/uploads/': "whitehall-frontend"
   '/government-frontend/': "government-frontend"
   '/info-frontend/': "info-frontend"
   '/manuals-frontend/': "manuals-frontend"
   '/licencefinder/': "licencefinder"
   '/service-manual-frontend/': "service-manual-frontend"
   '/smartanswers/': "smartanswers"
+
+router::assets_origin::whitehall_asset_routes:
+  '/government/placeholder': "whitehall-frontend"
+  '/government/uploads/': "whitehall-frontend"
 
 router::assets_origin::asset_manager_routes:
   - '/government/uploads/government/uploads/system/uploads/'

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1057,8 +1057,8 @@ router::assets_origin::app_specific_asset_routes:
   '/smartanswers/': "smartanswers"
 
 router::assets_origin::whitehall_asset_routes:
-  '/government/placeholder': "whitehall-frontend"
-  '/government/uploads/': "whitehall-frontend"
+  - '/government/placeholder'
+  - '/government/uploads/'
 
 router::assets_origin::asset_manager_routes:
   - '/government/uploads/government/uploads/system/uploads/'

--- a/modules/router/manifests/assets_origin.pp
+++ b/modules/router/manifests/assets_origin.pp
@@ -10,6 +10,9 @@
 # [*asset_manager_routes*]
 #   Hash of paths => vhost_names.  Each entry will be added as a route in the vhost
 #
+# [*whitehall_asset_routes*]
+#   Hash of paths => vhost_names.  Each entry will be added as a route in the vhost
+#
 # [*real_ip_header*]
 #   Uses the Nginx realip module (http://nginx.org/en/docs/http/ngx_http_realip_module.html)
 #   to change the client IP address to the one in the specified HTTP header.
@@ -23,6 +26,7 @@
 class router::assets_origin(
   $app_specific_asset_routes = {},
   $asset_manager_routes = [],
+  $whitehall_asset_routes = {},
   $real_ip_header = '',
   $vhost_aliases = [],
   $vhost_name = 'assets-origin',

--- a/modules/router/manifests/assets_origin.pp
+++ b/modules/router/manifests/assets_origin.pp
@@ -11,7 +11,7 @@
 #   Hash of paths => vhost_names.  Each entry will be added as a route in the vhost
 #
 # [*whitehall_asset_routes*]
-#   Hash of paths => vhost_names.  Each entry will be added as a route in the vhost
+#   Array of paths to proxy to whitehall-frontend.  Each entry will be added as a route in the vhost
 #
 # [*real_ip_header*]
 #   Uses the Nginx realip module (http://nginx.org/en/docs/http/ngx_http_realip_module.html)
@@ -26,7 +26,7 @@
 class router::assets_origin(
   $app_specific_asset_routes = {},
   $asset_manager_routes = [],
-  $whitehall_asset_routes = {},
+  $whitehall_asset_routes = [],
   $real_ip_header = '',
   $vhost_aliases = [],
   $vhost_name = 'assets-origin',

--- a/modules/router/templates/assets_origin.conf.erb
+++ b/modules/router/templates/assets_origin.conf.erb
@@ -53,9 +53,9 @@ server {
   }
   <%- end -%>
 
-  <%- @whitehall_asset_routes.each do |alias_path, vhost_name| -%>
-  location <%= alias_path %> {
-    proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://<%= vhost_name %>.<%= @app_domain %>;
+  <%- @whitehall_asset_routes.each do |path| -%>
+  location <%= path %> {
+    proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://whitehall-frontend.<%= @app_domain %>;
   }
   <%- end -%>
 

--- a/modules/router/templates/assets_origin.conf.erb
+++ b/modules/router/templates/assets_origin.conf.erb
@@ -53,6 +53,12 @@ server {
   }
   <%- end -%>
 
+  <%- @whitehall_asset_routes.each do |alias_path, vhost_name| -%>
+  location <%= alias_path %> {
+    proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://<%= vhost_name %>.<%= @app_domain %>;
+  }
+  <%- end -%>
+
   location = /static/a {
     proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://static.<%= @app_domain %>;
   }


### PR DESCRIPTION
Splitting these Whitehall asset routes from the `app_specific_asset_routes` should make it clearer that these are the only non-app-specific assets served by Whitehall.