### PR TITLE
Restrict asset requests that end up in Whitehall

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1638,23 +1638,6 @@ router::assets_origin::whitehall_uploaded_assets_routes:
   - '/government/uploads/uploaded/hmrc/'
 
 router::assets_origin::asset_manager_uploaded_assets_routes:
-  - '/government/uploads/government/uploads/system/uploads/'
-  - '/government/uploads/system/uploads/attachment/file'
-  - '/government/uploads/system/uploads/classification_featuring_image_data/file/'
-  - '/government/uploads/system/uploads/consultation_response_form/file'
-  - '/government/uploads/system/uploads/consultation_response_form_data/file/'
-  - '/government/uploads/system/uploads/default_news_organisation_image_data/file/'
-  - '/government/uploads/system/uploads/edition_organisation_image_data/file'
-  - '/government/uploads/system/uploads/edition_world_location_image_data/file'
-  - '/government/uploads/system/uploads/feature/image/'
-  - '/government/uploads/system/uploads/image_data/file/'
-  - '/government/uploads/system/uploads/news_article/featuring_image'
-  - '/government/uploads/system/uploads/news_article/image'
-  - '/government/uploads/system/uploads/organisation/logo/'
-  - '/government/uploads/system/uploads/person/image/'
-  - '/government/uploads/system/uploads/promotional_feature_item/image/'
-  - '/government/uploads/system/uploads/take_part_page/image/'
-  - '/government/uploads/system/uploads/topical_event/logo'
   - '/government/uploads/'
   - '/media/'
 

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1634,7 +1634,8 @@ router::assets_origin::app_specific_static_asset_routes:
 
 router::assets_origin::whitehall_uploaded_assets_routes:
   - '/government/placeholder'
-  - '/government/uploads/'
+  - '/government/uploads/system/uploads/attachment_data/file/'
+  - '/government/uploads/uploaded/hmrc/'
 
 router::assets_origin::asset_manager_uploaded_assets_routes:
   - '/government/uploads/government/uploads/system/uploads/'
@@ -1654,7 +1655,7 @@ router::assets_origin::asset_manager_uploaded_assets_routes:
   - '/government/uploads/system/uploads/promotional_feature_item/image/'
   - '/government/uploads/system/uploads/take_part_page/image/'
   - '/government/uploads/system/uploads/topical_event/logo'
-  - '/government/uploads/uploaded/number10/'
+  - '/government/uploads/'
   - '/media/'
 
 router::assets_origin::vhost_aliases:

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1048,23 +1048,6 @@ router::assets_origin::whitehall_uploaded_assets_routes:
   - '/government/uploads/uploaded/hmrc/'
 
 router::assets_origin::asset_manager_uploaded_assets_routes:
-  - '/government/uploads/government/uploads/system/uploads/'
-  - '/government/uploads/system/uploads/attachment/file'
-  - '/government/uploads/system/uploads/classification_featuring_image_data/file/'
-  - '/government/uploads/system/uploads/consultation_response_form/file'
-  - '/government/uploads/system/uploads/consultation_response_form_data/file/'
-  - '/government/uploads/system/uploads/default_news_organisation_image_data/file/'
-  - '/government/uploads/system/uploads/edition_organisation_image_data/file'
-  - '/government/uploads/system/uploads/edition_world_location_image_data/file'
-  - '/government/uploads/system/uploads/feature/image/'
-  - '/government/uploads/system/uploads/image_data/file/'
-  - '/government/uploads/system/uploads/news_article/featuring_image'
-  - '/government/uploads/system/uploads/news_article/image'
-  - '/government/uploads/system/uploads/organisation/logo/'
-  - '/government/uploads/system/uploads/person/image/'
-  - '/government/uploads/system/uploads/promotional_feature_item/image/'
-  - '/government/uploads/system/uploads/take_part_page/image/'
-  - '/government/uploads/system/uploads/topical_event/logo'
   - '/government/uploads/'
   - '/media/'
 

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1044,7 +1044,8 @@ router::assets_origin::app_specific_static_asset_routes:
 
 router::assets_origin::whitehall_uploaded_assets_routes:
   - '/government/placeholder'
-  - '/government/uploads/'
+  - '/government/uploads/system/uploads/attachment_data/file/'
+  - '/government/uploads/uploaded/hmrc/'
 
 router::assets_origin::asset_manager_uploaded_assets_routes:
   - '/government/uploads/government/uploads/system/uploads/'
@@ -1064,7 +1065,7 @@ router::assets_origin::asset_manager_uploaded_assets_routes:
   - '/government/uploads/system/uploads/promotional_feature_item/image/'
   - '/government/uploads/system/uploads/take_part_page/image/'
   - '/government/uploads/system/uploads/topical_event/logo'
-  - '/government/uploads/uploaded/number10/'
+  - '/government/uploads/'
   - '/media/'
 
 router::assets_origin::vhost_aliases:


### PR DESCRIPTION
As of the 1 Feb 2018 the only asset requests being served by Whitehall
are for attachments and HMRC. I confirmed this by using the following
query in Kibana:

    request:/GET \/government\/uploads\/.*/
    AND application:/whitehall.*/
    AND status:200
    -attachment_data
    -hmrc

I've also looked at the assets stored in the Whitehall directory on the
NFS mount and confirmed that the only files remaining are attachments
and the special case HMRC files.

Note that the HMRC assets URLs use www.gov.uk instead of
assets.publishing.service.gov.uk. I've added an explicit route for them
here in case anyone was relying on being able to access them via the
assets host.

Moving the '/government/uploads/' catch-all route means that all
non-attachment and non-HMRC asset requests are now sent to asset-manager
(via static). This is preferable to sending them to Whitehall as, since
https://github.com/alphagov/whitehall/pull/3763, sending them to
Whitehall would result in an infinite redirect loop.
