### PR TITLE
Differentiate between static and uploaded assets

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1650,7 +1650,7 @@ router::assets_origin::whitehall_uploaded_assets_routes:
   - '/government/placeholder'
   - '/government/uploads/'
 
-router::assets_origin::asset_manager_routes:
+router::assets_origin::asset_manager_uploaded_assets_routes:
   - '/government/uploads/government/uploads/system/uploads/'
   - '/government/uploads/system/uploads/attachment/file'
   - '/government/uploads/system/uploads/classification_featuring_image_data/file/'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1646,7 +1646,7 @@ router::assets_origin::app_specific_static_asset_routes:
   '/service-manual-frontend/': "service-manual-frontend"
   '/smartanswers/': "smartanswers"
 
-router::assets_origin::whitehall_asset_routes:
+router::assets_origin::whitehall_uploaded_assets_routes:
   - '/government/placeholder'
   - '/government/uploads/'
 

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1629,7 +1629,7 @@ resolvconf::options:
 
 # Note: it's important that all targets here have matching host entries both in
 # production, and on the dev VM, otherwise nginx will fail to start.
-router::assets_origin::app_specific_asset_routes:
+router::assets_origin::app_specific_static_asset_routes:
   '/asset-manager': "asset-manager"
   '/calculators/': "calculators"
   '/calendars/': "calendars"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1039,7 +1039,7 @@ rcs::tmptime: '7'
 
 # Note: it's important that all targets here have matching host entries both in
 # production, and on the dev VM, otherwise nginx will fail to start.
-router::assets_origin::app_specific_asset_routes:
+router::assets_origin::app_specific_static_asset_routes:
   '/asset-manager': "asset-manager"
   '/calculators/': "calculators"
   '/calendars/': "calendars"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1060,7 +1060,7 @@ router::assets_origin::whitehall_uploaded_assets_routes:
   - '/government/placeholder'
   - '/government/uploads/'
 
-router::assets_origin::asset_manager_routes:
+router::assets_origin::asset_manager_uploaded_assets_routes:
   - '/government/uploads/government/uploads/system/uploads/'
   - '/government/uploads/system/uploads/attachment/file'
   - '/government/uploads/system/uploads/classification_featuring_image_data/file/'

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1056,7 +1056,7 @@ router::assets_origin::app_specific_static_asset_routes:
   '/service-manual-frontend/': "service-manual-frontend"
   '/smartanswers/': "smartanswers"
 
-router::assets_origin::whitehall_asset_routes:
+router::assets_origin::whitehall_uploaded_assets_routes:
   - '/government/placeholder'
   - '/government/uploads/'
 

--- a/lib/puppet-lint/plugins/check_hiera.rb
+++ b/lib/puppet-lint/plugins/check_hiera.rb
@@ -49,9 +49,9 @@ PuppetLint.new_check(:hiera_explicit_lookup) do
     # metrics
     'govuk_logging::logstream::metrics_only',
 
-    # Allow sharing of asset_manager_routes array between assets-origin and static
+    # Allow sharing of asset_manager_uploaded_assets_routes array between assets-origin and static
     # nginx virtual host configuration
-    'router::assets_origin::asset_manager_routes',
+    'router::assets_origin::asset_manager_uploaded_assets_routes',
 
     'mysql_replica_password',
     'mysql_root',

--- a/modules/govuk/manifests/apps/static.pp
+++ b/modules/govuk/manifests/apps/static.pp
@@ -54,7 +54,7 @@ class govuk::apps::static(
 ) {
   $enable_ssl = hiera('nginx_enable_ssl', true)
   $app_name = 'static'
-  $asset_manager_routes = hiera('router::assets_origin::asset_manager_routes', [])
+  $asset_manager_uploaded_assets_routes = hiera('router::assets_origin::asset_manager_uploaded_assets_routes', [])
 
   if $::aws_migration {
     $proxy_pass_asset_manager_host_https = true

--- a/modules/govuk/manifests/apps/static/enable_running_in_draft_mode.pp
+++ b/modules/govuk/manifests/apps/static/enable_running_in_draft_mode.pp
@@ -47,7 +47,7 @@ class govuk::apps::static::enable_running_in_draft_mode(
   $asset_manager_host = "asset-manager.${app_domain}"
   $enable_ssl = hiera('nginx_enable_ssl', true)
   $app_name = 'draft-static'
-  $asset_manager_routes = hiera('router::assets_origin::asset_manager_routes', [])
+  $asset_manager_uploaded_assets_routes = hiera('router::assets_origin::asset_manager_uploaded_assets_routes', [])
 
   if $::aws_migration {
     $proxy_pass_asset_manager_host_https = true

--- a/modules/govuk/templates/static_extra_nginx_config.conf.erb
+++ b/modules/govuk/templates/static_extra_nginx_config.conf.erb
@@ -16,7 +16,7 @@ location /robots.txt {
   expires 1w;
 }
 
-<% @asset_manager_routes.each do |path_to_be_proxied_to_asset_manager| %>
+<% @asset_manager_uploaded_assets_routes.each do |path_to_be_proxied_to_asset_manager| %>
 
   location ~ ^<%= path_to_be_proxied_to_asset_manager %> {
     proxy_set_header X-Real-IP $remote_addr;

--- a/modules/router/manifests/assets_origin.pp
+++ b/modules/router/manifests/assets_origin.pp
@@ -10,7 +10,7 @@
 # [*asset_manager_routes*]
 #   Hash of paths => vhost_names.  Each entry will be added as a route in the vhost
 #
-# [*whitehall_asset_routes*]
+# [*whitehall_uploaded_assets_routes*]
 #   Array of paths to proxy to whitehall-frontend.  Each entry will be added as a route in the vhost
 #
 # [*real_ip_header*]
@@ -26,7 +26,7 @@
 class router::assets_origin(
   $app_specific_static_asset_routes = {},
   $asset_manager_routes = [],
-  $whitehall_asset_routes = [],
+  $whitehall_uploaded_assets_routes = [],
   $real_ip_header = '',
   $vhost_aliases = [],
   $vhost_name = 'assets-origin',

--- a/modules/router/manifests/assets_origin.pp
+++ b/modules/router/manifests/assets_origin.pp
@@ -7,7 +7,7 @@
 # [*app_specific_static_asset_routes*]
 #   Hash of paths => vhost_names.  Each entry will be added as a route in the vhost
 #
-# [*asset_manager_routes*]
+# [*asset_manager_uploaded_assets_routes*]
 #   Hash of paths => vhost_names.  Each entry will be added as a route in the vhost
 #
 # [*whitehall_uploaded_assets_routes*]
@@ -25,7 +25,7 @@
 #
 class router::assets_origin(
   $app_specific_static_asset_routes = {},
-  $asset_manager_routes = [],
+  $asset_manager_uploaded_assets_routes = [],
   $whitehall_uploaded_assets_routes = [],
   $real_ip_header = '',
   $vhost_aliases = [],

--- a/modules/router/manifests/assets_origin.pp
+++ b/modules/router/manifests/assets_origin.pp
@@ -4,7 +4,7 @@
 #
 # === Parameters
 #
-# [*app_specific_asset_routes*]
+# [*app_specific_static_asset_routes*]
 #   Hash of paths => vhost_names.  Each entry will be added as a route in the vhost
 #
 # [*asset_manager_routes*]
@@ -24,7 +24,7 @@
 #   Primary vhost that assets should be served on at origin
 #
 class router::assets_origin(
-  $app_specific_asset_routes = {},
+  $app_specific_static_asset_routes = {},
   $asset_manager_routes = [],
   $whitehall_asset_routes = [],
   $real_ip_header = '',

--- a/modules/router/manifests/draft_assets.pp
+++ b/modules/router/manifests/draft_assets.pp
@@ -17,7 +17,7 @@ class router::draft_assets(
   $vhost_name = 'draft-assets',
 ) {
   $enable_ssl = hiera('nginx_enable_ssl', true)
-  $asset_manager_routes = hiera('router::assets_origin::asset_manager_routes', [])
+  $asset_manager_uploaded_assets_routes = hiera('router::assets_origin::asset_manager_uploaded_assets_routes', [])
 
   if $::aws_migration {
     $app_domain = hiera('app_domain_internal')

--- a/modules/router/spec/classes/router__assets_origin_spec.rb
+++ b/modules/router/spec/classes/router__assets_origin_spec.rb
@@ -2,8 +2,8 @@ require_relative '../../../../spec_helper'
 
 describe "router::assets_origin", :type => :class do
 
-  describe "app_specific_asset_routes targets" do
-    let(:app_specific_asset_routes) { YAML.load_file(File.expand_path("../../../../../hieradata/common.yaml", __FILE__))['router::assets_origin::app_specific_asset_routes'] }
+  describe "app_specific_static_asset_routes targets" do
+    let(:app_specific_static_asset_routes) { YAML.load_file(File.expand_path("../../../../../hieradata/common.yaml", __FILE__))['router::assets_origin::app_specific_static_asset_routes'] }
 
     let(:all_hostnames) {
       subject.call.resources.each_with_object([]) do |resource, hostnames|
@@ -20,9 +20,9 @@ describe "router::assets_origin", :type => :class do
       let(:pre_condition) { "include hosts::production" }
 
       it "should have host entries for each route target" do
-        app_specific_asset_routes.each do |_, target|
+        app_specific_static_asset_routes.each do |_, target|
           hostname = "#{target}.publishing.service.gov.uk"
-          message = "app_specific_asset_routes point at non-existent host '#{hostname}' in production"
+          message = "app_specific_static_asset_routes point at non-existent host '#{hostname}' in production"
           expect(all_hostnames).to include(hostname), message
         end
       end
@@ -33,9 +33,9 @@ describe "router::assets_origin", :type => :class do
       let(:pre_condition) { "include hosts::development" }
 
       it "should have host entries for each route target" do
-        app_specific_asset_routes.each do |_, target|
+        app_specific_static_asset_routes.each do |_, target|
           hostname = "#{target}.dev.gov.uk"
-          message = "app_specific_asset_routes point at non-existent host '#{hostname}' on the dev VM"
+          message = "app_specific_static_asset_routes point at non-existent host '#{hostname}' on the dev VM"
           expect(all_hostnames).to include(hostname), message
         end
       end

--- a/modules/router/spec/classes/router__assets_origin_spec.rb
+++ b/modules/router/spec/classes/router__assets_origin_spec.rb
@@ -42,8 +42,8 @@ describe "router::assets_origin", :type => :class do
     end
   end
 
-  describe "asset_manager_routes targets" do
-    let(:asset_manager_routes) { YAML.load_file(File.expand_path("../../../../../hieradata/common.yaml", __FILE__))['router::assets_origin::asset_manager_routes'] }
+  describe "asset_manager_uploaded_assets_routes targets" do
+    let(:asset_manager_uploaded_assets_routes) { YAML.load_file(File.expand_path("../../../../../hieradata/common.yaml", __FILE__))['router::assets_origin::asset_manager_uploaded_assets_routes'] }
 
     let(:all_hostnames) {
       subject.call.resources.each_with_object([]) do |resource, hostnames|
@@ -60,9 +60,9 @@ describe "router::assets_origin", :type => :class do
       let(:pre_condition) { "include hosts::production" }
 
       it "should have host entries for each route target" do
-        asset_manager_routes.each do |_path|
+        asset_manager_uploaded_assets_routes.each do |_path|
           hostname = "static.publishing.service.gov.uk"
-          message = "asset_manager_routes point at non-existent host '#{hostname}' in production"
+          message = "asset_manager_uploaded_assets_routes point at non-existent host '#{hostname}' in production"
           expect(all_hostnames).to include(hostname), message
         end
       end
@@ -73,9 +73,9 @@ describe "router::assets_origin", :type => :class do
       let(:pre_condition) { "include hosts::development" }
 
       it "should have host entries for each route target" do
-        asset_manager_routes.each do |_path|
+        asset_manager_uploaded_assets_routes.each do |_path|
           hostname = "static.dev.gov.uk"
-          message = "asset_manager_routes point at non-existent host '#{hostname}' on the dev VM"
+          message = "asset_manager_uploaded_assets_routes point at non-existent host '#{hostname}' on the dev VM"
           expect(all_hostnames).to include(hostname), message
         end
       end

--- a/modules/router/templates/assets_origin.conf.erb
+++ b/modules/router/templates/assets_origin.conf.erb
@@ -53,7 +53,7 @@ server {
   }
   <%- end -%>
 
-  <%- @whitehall_asset_routes.each do |path| -%>
+  <%- @whitehall_uploaded_assets_routes.each do |path| -%>
   location <%= path %> {
     proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://whitehall-frontend.<%= @app_domain %>;
   }

--- a/modules/router/templates/assets_origin.conf.erb
+++ b/modules/router/templates/assets_origin.conf.erb
@@ -41,7 +41,7 @@ server {
   add_header "Access-Control-Allow-Methods" "GET, OPTIONS";
   add_header "Access-Control-Allow-Headers" "origin, authorization";
 
-  <%- @app_specific_asset_routes.each do |alias_path, vhost_name| -%>
+  <%- @app_specific_static_asset_routes.each do |alias_path, vhost_name| -%>
   location <%= alias_path %> {
     proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://<%= vhost_name %>.<%= @app_domain %>;
   }

--- a/modules/router/templates/assets_origin.conf.erb
+++ b/modules/router/templates/assets_origin.conf.erb
@@ -47,7 +47,7 @@ server {
   }
   <%- end -%>
 
-  <%- @asset_manager_routes.each do |path| -%>
+  <%- @asset_manager_uploaded_assets_routes.each do |path| -%>
   location <%= path %> {
     proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://static.<%= @app_domain %>;
   }

--- a/modules/router/templates/draft-assets.conf.erb
+++ b/modules/router/templates/draft-assets.conf.erb
@@ -52,7 +52,7 @@ server {
     proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://asset-manager.<%= @app_domain %>;
   }
 
-  <%- @asset_manager_routes.each do |path| -%>
+  <%- @asset_manager_uploaded_assets_routes.each do |path| -%>
   location <%= path %> {
     proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://asset-manager.<%= @app_domain %>;
   }


### PR DESCRIPTION
I've renamed three `assets_origin` hiera variables to differentiate between static and uploaded assets. This mirrors the language we use to talk about assets in [Assets: how they work](https://docs.publishing.service.gov.uk/manual/assets.html).
