### PR TITLE
Add missing Jenkins job manifest for Audit Tool

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/content_audit_tool.pp
+++ b/modules/govuk_jenkins/manifests/jobs/content_audit_tool.pp
@@ -1,0 +1,26 @@
+# == Class: govuk_jenkins::jobs::content_audit_tool
+#
+# Create a jenkins job to periodically run rake for the following tasks:
+# - import:all_content_items
+# - import:all_ga_metrics
+#
+# === Parameters:
+#
+# [*rake_import_all_content_items_frequency *]
+#   The cron timings for the import:all_content_items rake task
+#   Default: undef
+#
+# [*rake_import_all_ga_metrics_frequency *]
+#   The cron timings for the import:all_ga_metrics rake task
+#   Default: undef
+#
+class govuk_jenkins::jobs::content_audit_tool (
+  $rake_import_all_content_items_frequency = undef,
+  $rake_import_all_ga_metrics_frequency = undef,
+) {
+  file { '/etc/jenkins_jobs/jobs/content_audit_tool.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/content_audit_tool.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+}


### PR DESCRIPTION
This is needed for the Jenkins jobs in [1] to run.

[1] https://github.com/alphagov/govuk-puppet/pull/7154/files