### PR TITLE
Set correct logging for Signon

### DIFF
--- a/modules/govuk/manifests/apps/signon.pp
+++ b/modules/govuk/manifests/apps/signon.pp
@@ -90,6 +90,7 @@ class govuk::apps::signon(
     health_check_path        => '/users/sign_in',
     asset_pipeline           => true,
     deny_framing             => true,
+    log_format_is_json       => true,
     nagios_memory_warning    => $nagios_memory_warning,
     nagios_memory_critical   => $nagios_memory_critical,
     unicorn_worker_processes => $unicorn_worker_processes,


### PR DESCRIPTION
Signon machines are currently filling up with logs like:

```
WARNING: Could not ship message via StatsdShipper: key '@field' not
found in message when constructing metric
backend-2_backend_staging.signon.http_%{@field.status}
```

We think that somehow this is connected to the JSON logging, which is `true` for almost every other app. There's no difference between these and Signon.

@suzannehamilton 