### PR TITLE
Update job description of search-fetch-analytics-data

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/search_fetch_analytics_data.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/search_fetch_analytics_data.yaml.erb
@@ -14,11 +14,11 @@
     description: |
       <p>Fetch analytics data from Google Analytics and index in search</p>
       <p>This is run nightly to update the information used by search to return more popular pages first.</p>
-      <p><strong>While running this task, Rummager's indexes will be locked and no indexing will take place. This task should only be run at night.</strong></p>
+      <p><strong>This task should only be run at night because it puts extra load on the search index.</strong></p>
       <p>More information:</p>
       <ul>
         <li><a href='https://github.com/alphagov/search-analytics'>alphagov/search-analytics on GitHub</a></li>
-        <li><a href='https://github.com/alphagov/rummager/blob/master/docs/popularity.md'>Docs on Rummager</a></li>
+        <li><a href='https://github.com/alphagov/rummager/blob/master/doc/popularity.md'>Docs on Rummager</a></li>
       </ul>
     scm:
         - search-analytics_search-fetch-analytics-data


### PR DESCRIPTION
- Fix link to rummager popularity docs
- Remove reference to index locking - this job now updates the data in-place