### PR TITLE
Add draft-assets to hosts::development::apps

### DIFF
--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -250,6 +250,7 @@ hosts::development::apps:
   - 'contacts-admin'
   - 'content-store'
   - 'content-tagger'
+  - 'draft-assets'
   - 'draft-content-store'
   - 'draft-government-frontend'
   - 'draft-manuals-frontend'


### PR DESCRIPTION
This ensures that draft-assets is added to /etc/hosts so that we can
access it from the development VM.