### PR TITLE
Disable postgresql collectd plugin on CI

### DIFF
--- a/hieradata/class/ci_agent.yaml
+++ b/hieradata/class/ci_agent.yaml
@@ -8,6 +8,7 @@ clamav::use_service: false
 
 govuk_ci::agent::postgresql::mapit_role_password: 'mapit'
 postgresql::globals::version: '9.3'
+govuk_postgresql::server::enable_collectd: false
 
 govuk_mysql::server::innodb_flush_log_at_trx_commit: 2
 govuk_mysql::server::innodb_buffer_pool_size_proportion: 0.05


### PR DESCRIPTION
The version of collectd we’re using has a bug[1] where it will fail
noisily if a database has no tables. This is quite likely in a CI
environment, and the metrics it collects are not useful. This prevents
27 log lines every 10 seconds across all 5 CI boxes, which accounts for
some logit overuse.

[1]: https://github.com/collectd/collectd/issues/1905