### PR TITLE
Record Icinga alert counts in Graphite

### DIFF
--- a/modules/collectd/files/etc/collectd/conf.d/icinga.conf
+++ b/modules/collectd/files/etc/collectd/conf.d/icinga.conf
@@ -1,0 +1,5 @@
+LoadPlugin exec
+
+<Plugin exec>
+  Exec nobody "/usr/lib/collectd/icinga.sh"
+</Plugin>

--- a/modules/collectd/files/usr/lib/collectd/icinga.sh
+++ b/modules/collectd/files/usr/lib/collectd/icinga.sh
@@ -1,0 +1,31 @@
+#! /bin/bash
+
+HOSTNAME="${COLLECTD_HOSTNAME:-`hostname -f`}"
+INTERVAL="${COLLECTD_INTERVAL:-10}"
+
+# $3 is status, $13 is acked
+
+set -o pipefail
+
+while sleep "$INTERVAL"; do
+  result=$(curl -sH'Host: alert' 'localhost/cgi-bin/icinga/status.cgi?servicestatustypes=20&csvoutput=1' | awk -F ';' -f <(cat - <<-'EOD'
+    BEGIN {
+      statuses["warning_acknowledged"] = 0
+      statuses["warning_unacknowledged"] = 0
+      statuses["critical_acknowledged"] = 0
+      statuses["critical_unacknowledged"] = 0
+    }
+
+    NR>1 {
+      gsub(/\047/, "", $3)
+      statuses[tolower($3)"_"(($13=="'true'") ? "acknowledged" : "unacknowledged")] += 1
+    }
+
+    END {
+      for (key in statuses) {
+        print "PUTVAL $HOSTNAME/icinga/gauge-services_"key" interval=$INTERVAL N:"statuses[key]
+      }
+    }
+EOD
+  ) | sed 's/$INTERVAL/'$INTERVAL'/g' | sed 's/$HOSTNAME/'$HOSTNAME'/g') && echo "$result"
+done

--- a/modules/collectd/manifests/plugin/icinga.pp
+++ b/modules/collectd/manifests/plugin/icinga.pp
@@ -1,0 +1,23 @@
+# == Class: collectd::plugin::icinga
+#
+# Monitors the number of Icinga alerts
+#
+class collectd::plugin::icinga(
+) {
+
+  @file { '/usr/lib/collectd/icinga.sh':
+    ensure  => 'present',
+    mode    => '0755',
+    owner   => 'root',
+    group   => 'root',
+    content => file('collectd/usr/lib/collectd/icinga.sh'),
+    tag     => 'collectd::plugin',
+    require => Class['collectd::package'],
+  }
+
+  @collectd::plugin { 'icinga':
+    content => file('collectd/etc/collectd/conf.d/icinga.conf'),
+    require => File['/usr/lib/collectd/icinga.sh'],
+  }
+
+}

--- a/modules/govuk/manifests/node/s_monitoring.pp
+++ b/modules/govuk/manifests/node/s_monitoring.pp
@@ -20,6 +20,7 @@ class govuk::node::s_monitoring (
   include govuk_rbenv::all
   include ::phantomjs
   include monitoring
+  include collectd::plugin::icinga
 
   if $enable_fastly_metrics {
     include collectd::plugin::cdn_fastly


### PR DESCRIPTION
Adds a collectd plugin that gets the current service alert statuses and
records them as gauges in graphite. Records warnings and criticals
seperately, along with whether they’re acknowledged or not.

The eventual keys would be e.g.
`monitoring-1_blue_integration.icinga.gauge-services_critical_unacknowledged`