### PR TITLE
Add Configuration for Publishing API Consumer in Content Performace Manager

### DIFF
--- a/development-vm/Pinfile
+++ b/development-vm/Pinfile
@@ -16,7 +16,7 @@ process :'collections-publisher' => [:'publishing-api', :'collections-publisher-
 process :'collections-publisher-worker'
 process :'contacts-admin' => [:'publishing-api', :whitehall]
 process :'content-audit-tool' => [:'publishing-api-read', :'content-audit-tool-sidekiq-google-analytics', :'content-audit-tool-sidekiq-publishing-api']
-process :'content-performance-manager' => [:'publishing-api-read', :'content-performance-manager-sidekiq-google-analytics', :'content-performance-manager-sidekiq-publishing-api']
+process :'content-performance-manager' => [:'publishing-api-read', :'content-performance-manager-sidekiq-google-analytics', :'content-performance-manager-sidekiq-publishing-api', :'content-performance-manager-publishing-api-consumer']
 process :'content-store'
 # Example usage: bowl [your-app] dummy-content-store --without content-store
 process :'dummy-content-store'

--- a/development-vm/Procfile
+++ b/development-vm/Procfile
@@ -152,7 +152,8 @@ draft-router-api:            govuk_setenv draft-router-api            ./run_in.s
 # manuals-publisher has reserved port 3205
 # sidekiq-monitoring for content-performance-manager uses port 3207
 content-performance-manager:      govuk_setenv content-performance-manager ./run_in.sh ../../content-performance-manager bundle exec rails server -p 3206
-content-performance-manager-sidekiq-google-analytics:  govuk_setenv content-performance-manager ./run_in.sh ../../content-performance-manager bundle exec sidekiq -C ./config/sidekiq/google_analytics.yml
+content-performance-manager-publishing-api-consumer: govuk_setenv content-performance-manager ./run_in.sh ../../content-performance-manager bundle exec rake publishing_api:consumer
+content-performance-manager-sidekiq-google-analytics: govuk_setenv content-performance-manager ./run_in.sh ../../content-performance-manager bundle exec sidekiq -C ./config/sidekiq/google_analytics.yml
 content-performance-manager-sidekiq-publishing-api:  govuk_setenv content-performance-manager ./run_in.sh ../../content-performance-manager bundle exec sidekiq -C ./config/sidekiq/publishing_api.yml
 # sidekiq-monitoring for link-checker-api-sidekiq uses port 3209
 link-checker-api:                     govuk_setenv link-checker-api            ./run_in.sh ../../link-checker-api bundle exec rails server -p 3208

--- a/hieradata/class/rabbitmq.yaml
+++ b/hieradata/class/rabbitmq.yaml
@@ -5,6 +5,7 @@ govuk::node::s_rabbitmq::apps_using_rabbitmq:
   - email_alert_service
   - publishing_api
   - rummager
+  - content_performance_manager
 
 govuk_safe_to_reboot::can_reboot: 'careful'
 govuk_safe_to_reboot::reason: 'rabbitmq-1 is a single point of failure for content-store, apps not resilient'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -352,10 +352,17 @@ govuk::apps::content_audit_tool::db::backend_ip_range: "%{hiera('environment_ip_
 govuk::apps::content_audit_tool::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::content_audit_tool::redis_port: "%{hiera('sidekiq_port')}"
 
+govuk::apps::content_performance_manager::rabbitmq::amqp_pass: 'content_performance_manager'
+govuk::apps::content_performance_manager::rabbitmq_password: 'content_performance_manager'
 govuk::apps::content_performance_manager::db_hostname: "postgresql-primary-1.backend"
 govuk::apps::content_performance_manager::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
+govuk::apps::content_performance_manager::rabbitmq_hosts:
+  - rabbitmq-1.backend
+  - rabbitmq-2.backend
+  - rabbitmq-3.backend
 govuk::apps::content_performance_manager::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::content_performance_manager::redis_port: "%{hiera('sidekiq_port')}"
+
 
 govuk::apps::content_store::nagios_memory_warning: 2300
 govuk::apps::content_store::nagios_memory_critical: 2500
@@ -542,6 +549,7 @@ govuk::apps::sidekiq_monitoring::asset_manager_redis_host: "%{hiera('govuk::apps
 govuk::apps::sidekiq_monitoring::asset_manager_redis_port: "%{hiera('govuk::apps::asset_manager::redis_port')}"
 govuk::apps::sidekiq_monitoring::content_audit_tool_redis_host: "%{hiera('govuk::apps::content_audit_tool::redis_host')}"
 govuk::apps::sidekiq_monitoring::content_audit_tool_redis_port: "%{hiera('govuk::apps::content_audit_tool::redis_port')}"
+
 govuk::apps::sidekiq_monitoring::content_performance_manager_redis_host: "%{hiera('govuk::apps::content_performance_manager::redis_host')}"
 govuk::apps::sidekiq_monitoring::content_performance_manager_redis_port: "%{hiera('govuk::apps::content_performance_manager::redis_port')}"
 govuk::apps::sidekiq_monitoring::content_tagger_redis_host: "%{hiera('govuk::apps::content_tagger::redis_host')}"

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -31,6 +31,7 @@ govuk::node::s_development::apps:
   - 'contacts'
   - 'content_audit_tool'
   - 'content_performance_manager'
+  - 'content_performance_manager::rabbitmq'
   - 'content_store'
   - 'content_store::enable_running_in_draft_mode'
   - 'content_tagger'
@@ -100,6 +101,9 @@ govuk::apps::collections_publisher::enable_procfile_worker: false
 govuk::apps::contacts::extra_aliases: ['contacts-admin']
 govuk::apps::content_store::mongodb_nodes: ['localhost']
 govuk::apps::content_store::mongodb_name: 'content_store_development'
+govuk::apps::content_performance_manager::rabbitmq_user: 'content_performance_manager'
+govuk::apps::content_performance_manager::rabbitmq_hosts: ['localhost']
+
 govuk::apps::content_tagger::enable_procfile_worker: false
 govuk::apps::email_alert_api::enable_procfile_worker: false
 govuk::apps::email_alert_service::rabbitmq_hosts: ['localhost']

--- a/hieradata_aws/class/rabbitmq.yaml
+++ b/hieradata_aws/class/rabbitmq.yaml
@@ -5,6 +5,7 @@ govuk::node::s_rabbitmq::apps_using_rabbitmq:
   - email_alert_service
   - publishing_api
   - rummager
+  - content_performance_manager
 
 govuk_rabbitmq::aws_clustering: true
 

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -364,6 +364,8 @@ govuk::apps::content_audit_tool::redis_port: "%{hiera('sidekiq_port')}"
 
 govuk::apps::content_performance_manager::db_hostname: "postgresql-primary"
 govuk::apps::content_performance_manager::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
+govuk::apps::content_performance_manager::rabbitmq_hosts:
+  - rabbitmq
 govuk::apps::content_performance_manager::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::content_performance_manager::redis_port: "%{hiera('sidekiq_port')}"
 

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -10,6 +10,10 @@ cron::daily_hour: 6
 
 govuk::apps::asset_manager::aws_s3_bucket_name: 'govuk-assets-integration'
 govuk::apps::asset_manager::aws_region: 'eu-west-1'
+govuk::apps::content_performance_manager::rabbitmq::amqp_pass: 'content_performance_manager'
+govuk::apps::content_performance_manager::rabbitmq_password: 'content_performance_manager'
+govuk::apps::content_performance_manager::rabbitmq_user: 'content_performance_manager'
+
 govuk::apps::email_alert_api::allow_govdelivery_topic_syncing: true
 govuk::apps::email_alert_api::govuk_notify_template_id: '1fc69d3a-09a2-40f9-852b-03f6fcef5340'
 govuk::apps::email_alert_api::disable_govdelivery_emails: true

--- a/modules/govuk/manifests/apps/content_performance_manager.pp
+++ b/modules/govuk/manifests/apps/content_performance_manager.pp
@@ -46,6 +46,18 @@
 #   The bearer token to use when communicating with Publishing API.
 #   Default: undef
 #
+# [*rabbitmq_hosts*]
+#   RabbitMQ hosts to connect to.
+#   Default: localhost
+#
+# [*rabbitmq_user*]
+#   RabbitMQ username.
+#   This is a required parameter
+#
+# [*rabbitmq_password*]
+#   RabbitMQ password.
+#   This is a required parameter
+#
 # [*redis_host*]
 #   Redis host for Sidekiq.
 #   Default: undef
@@ -73,6 +85,10 @@ class govuk::apps::content_performance_manager(
   $oauth_secret = undef,
   $port = '3206',
   $publishing_api_bearer_token = undef,
+  $rabbitmq_hosts = ['localhost'],
+  $rabbitmq_vhost = '/',
+  $rabbitmq_password,
+  $rabbitmq_user,
   $redis_host = undef,
   $redis_port = undef,
   $secret_key_base = undef,
@@ -104,6 +120,12 @@ class govuk::apps::content_performance_manager(
     process_type   => 'publishing-api-worker',
   }
 
+  govuk::procfile::worker { "${app_name}-publishing-api-consumer":
+    enable_service => $enable_procfile_worker,
+    setenv_as      => $app_name,
+    process_type   => 'publishing-api-consumer',
+  }
+
   govuk::app::envvar {
     "${title}-GOOGLE_ANALYTICS_GOVUK_VIEW_ID":
       varname => 'GOOGLE_ANALYTICS_GOVUK_VIEW_ID',
@@ -123,6 +145,18 @@ class govuk::apps::content_performance_manager(
     "${title}-PUBLISHING_API_BEARER_TOKEN":
       varname => 'PUBLISHING_API_BEARER_TOKEN',
       value   => $publishing_api_bearer_token;
+    "${title}-RABBITMQ_HOSTS":
+      varname => 'RABBITMQ_HOSTS',
+      value   => join($rabbitmq_hosts, ',');
+    "${title}-RABBITMQ_VHOST":
+      varname => 'RABBITMQ_VHOST',
+      value   => $rabbitmq_vhost;
+    "${title}-RABBITMQ_USER":
+      varname => 'RABBITMQ_USER',
+      value   => $rabbitmq_user;
+    "${title}-RABBITMQ_PASSWORD":
+      varname => 'RABBITMQ_PASSWORD',
+      value   => $rabbitmq_password;
   }
 
   govuk::app::envvar::redis { $app_name:

--- a/modules/govuk/manifests/apps/content_performance_manager/rabbitmq.pp
+++ b/modules/govuk/manifests/apps/content_performance_manager/rabbitmq.pp
@@ -1,0 +1,44 @@
+# == Class: govuk::apps::content_performance_manager::rabbitmq
+#
+# Permissions for the content_performance_manager to read messages from
+# the publishing API's AMQP exchange.
+#
+# This sets up the user, and permits read/write/configure
+# to the queue, and read-only to the exchange.
+#
+# === Parameters
+#
+# [*amqp_user*]
+#   The RabbitMQ username (default: 'content_performance_manager')
+#
+# [*amqp_pass*]
+#   The RabbitMQ password. This is a required parameter.
+#
+# [*amqp_exchange*]
+#   The RabbitMQ exchange to read from (default: 'published_documents')
+#
+# [*amqp_queue*]
+#   The RabbitMQ queue to set up for workers of this type to read from
+#   (default: 'content_performance_manager')
+#
+class govuk::apps::content_performance_manager::rabbitmq (
+  $amqp_user  = 'content_performance_manager',
+  $amqp_pass,
+  $amqp_exchange = 'published_documents',
+  $amqp_queue = 'content_performance_manager',
+) {
+
+  govuk_rabbitmq::queue_with_binding { $amqp_queue:
+    amqp_exchange => $amqp_exchange,
+    amqp_queue    => $amqp_queue,
+    routing_key   => '*.#.#',
+    durable       => true,
+  } ->
+
+  govuk_rabbitmq::consumer { $amqp_user:
+    amqp_pass            => $amqp_pass,
+    read_permission      => "^${amqp_queue}\$",
+    write_permission     => "^\$",
+    configure_permission => "^\$",
+  }
+}

--- a/modules/govuk_rabbitmq/manifests/queue_with_binding.pp
+++ b/modules/govuk_rabbitmq/manifests/queue_with_binding.pp
@@ -13,7 +13,8 @@
 # At present the workaround for changing a binding is to create a new queue for the new binding. Then switch the
 # consumers over to the new queue, and remove the old queue.
 # Another side effect of this problem is you can't define more than one binding for a queue.
-# This may be fixed by https://github.com/voxpupuli/puppet-rabbitmq/pull/504
+# This is possible in version 6.0.0, however that version also drops Puppet 3 support.
+# https://forge.puppet.com/puppet/rabbitmq/changelog
 #
 # govuk_rabbitmq::remove_queues and govuk_rabbitmq::remove_bindings can be used
 # to ensure old queues and bindings are cleaned up.


### PR DESCRIPTION
Creates a queue, user, and Procfile workers

amq.gen* is for randomly generated queue names - I don't think we need it.
We also don't need to deal with the exchange if the queue is configured
and bound in puppet.

this is for [94 - Subscribe to content Changes in Publishing-API](https://trello.com/c/D1ht9Mb5/94-3-subscribe-to-content-changes-in-publishing-api)

There is a related [PR in content performance manager](https://github.com/alphagov/content-performance-manager/pull/491)