### PR TITLE
Add repo for ValeLint

### DIFF
--- a/modules/govuk/manifests/node/s_apt.pp
+++ b/modules/govuk/manifests/node/s_apt.pp
@@ -141,6 +141,7 @@ class govuk::node::s_apt (
   }
   aptly::repo { 'statsd': }
   aptly::repo { 'terraform': }
+  aptly::repo { 'vale': }
 
   include nginx
   nginx::config::site { $apt_service:


### PR DESCRIPTION
ValeLint is a super useful tool that I'd like to set up in our CI environment to do linting across our documentation.

We can begin with govuk-developer-docs, but it may be worth running against anything in .md files and adding to the default Jenkinslib.

This creates a repository so I can add the package available for install.