### PR TITLE
Modify S3_ARTEFACT_BUCKET Variable

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
@@ -21,7 +21,7 @@
             export GRAPHITE_PORT="<%= @graphite_port -%>"
             <%- if @aws_deploy %>
             export USE_S3="true"
-            export S3_ARTEFACT_BUCKET="govuk-integration-artefact"
+            export S3_ARTEFACT_BUCKET="govuk-<%= @environment -%>-artefact"
             <% end -%>
 
             if [ "$DEPLOY_FROM_GITLAB" == "true" ]; then


### PR DESCRIPTION
- S3_ARTEFACT_BUCKET was defined explicitly as "integration". This is
  causing a problem when we want to promote artefacts to different
environments.

Pari: @suthagarht @surminus