### PR TITLE
Disable transition logs in AWS

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -707,6 +707,7 @@ govuk_cdnlogs::service_port_map:
   bouncer: 6516
 
 govuk_cdnlogs::transition_logs::alert_hostname: 'alert'
+govuk_cdnlogs::transition_logs::enabled: false
 
 govuk_containers::app::config::global_envvars:
   - "GOVUK_ENV=production"


### PR DESCRIPTION
Transition Logs is a thing which runs some analysis on the logs received from CDN and commits the results to Github, which is then picked up by the Transition app.

While we're testing we do not want to risk accidentally copying credentials over and committing incorrect data to the Github repository, so we should disable it entirely in AWS until we're ready to migrate the process to AWS.

This should not stop us testing receiving CDN logs from Fastly to AWS, which is the principle function of this instance.

https://trello.com/c/xVVqD9Gg/971-terraform-a-logs-cdn-machine-for-staging-and-production