### PR TITLE
Add Integration specific jenkins.yaml

### DIFF
--- a/hieradata_aws/class/integration/jenkins.yaml
+++ b/hieradata_aws/class/integration/jenkins.yaml
@@ -1,0 +1,6 @@
+govuk_jenkins::config::banner_string: 'AWS Integration'
+govuk_jenkins::config::banner_colour_background: '#005EA5'
+govuk_jenkins::config::banner_colour_text: 'white'
+govuk_jenkins::config::theme_colour: '#005EA5'
+govuk_jenkins::config::theme_text_colour: 'white'
+govuk_jenkins::config::theme_environment_name: 'AWS Integration'


### PR DESCRIPTION
I believe Puppet deploys have broken in Integration since this PR:
https://github.com/alphagov/govuk-secrets/pull/245

This is because we do not have a directory called 'integration' which is causing the job to fail.

We should create an Integration directory to copy, but I can only check it in if I have a file inside it, so I'm using the Jenkins specific theme for Integration to do this.