### PR TITLE
Fix service manual publisher dashboard

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1019,9 +1019,7 @@ grafana::dashboards::deployment_applications:
     fields_prefix: ''
   service-manual-frontend: {}
   service-manual-publisher:
-    # Status, duration, controller missing @fields. prefix
-    show_controller_errors: false
-    show_slow_requests: false
+    fields_prefix: ''
   short-url-manager:
     fields_prefix: ''
   signon:

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -881,9 +881,7 @@ grafana::dashboards::deployment_applications:
     fields_prefix: ''
   service-manual-frontend: {}
   service-manual-publisher:
-    # Status, duration, controller missing @fields. prefix
-    show_controller_errors: false
-    show_slow_requests: false
+    fields_prefix: ''
   short-url-manager:
     fields_prefix: ''
   signon:


### PR DESCRIPTION
Service manual publisher now logs correctly, so we can update the dashboard to
reflect this.