### PR TITLE
Set unicorn worker processes in puppet

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -398,9 +398,11 @@ govuk::apps::frontend::nagios_memory_warning: 1200
 govuk::apps::frontend::nagios_memory_critical: 1400
 govuk::apps::frontend::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::frontend::redis_port: "%{hiera('sidekiq_port')}"
+govuk::apps::frontend::unicorn_worker_processes: "4"
 
 govuk::apps::government-frontend::nagios_memory_warning: 900
 govuk::apps::government-frontend::nagios_memory_critical: 1000
+govuk::apps::government-frontend::unicorn_worker_processes: "2"
 
 govuk::apps::govuk_cdn_logs_monitor::processed_data_dir: '/mnt/logs_cdn/data'
 

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -401,9 +401,11 @@ govuk::apps::frontend::nagios_memory_warning: 1200
 govuk::apps::frontend::nagios_memory_critical: 1400
 govuk::apps::frontend::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::frontend::redis_port: "%{hiera('sidekiq_port')}"
+govuk::apps::frontend::unicorn_worker_processes: "4"
 
 govuk::apps::government-frontend::nagios_memory_warning: 900
 govuk::apps::government-frontend::nagios_memory_critical: 1000
+govuk::apps::government-frontend::unicorn_worker_processes: "2"
 
 govuk::apps::govuk_cdn_logs_monitor::processed_data_dir: '/mnt/logs_cdn/data'
 

--- a/modules/govuk/manifests/apps/frontend.pp
+++ b/modules/govuk/manifests/apps/frontend.pp
@@ -40,6 +40,10 @@
 # [*secret_key_base*]
 #   The key for Rails to use when signing/encrypting sessions.
 #
+# [*unicorn_worker_processes*]
+#   The number of unicorn worker processes to run
+#   Default: undef
+#
 class govuk::apps::frontend(
   $vhost = 'frontend',
   $port = '3005',
@@ -51,25 +55,27 @@ class govuk::apps::frontend(
   $redis_port = undef,
   $sentry_dsn = undef,
   $secret_key_base = undef,
+  $unicorn_worker_processes = undef,
 ) {
 
   govuk::app { 'frontend':
-    app_type               => 'rack',
-    port                   => $port,
-    sentry_dsn             => $sentry_dsn,
-    vhost_protected        => $vhost_protected,
-    health_check_path      => '/',
-    log_format_is_json     => true,
-    asset_pipeline         => true,
-    asset_pipeline_prefix  => 'frontend',
-    nagios_memory_warning  => $nagios_memory_warning,
-    nagios_memory_critical => $nagios_memory_critical,
-    vhost                  => $vhost,
-    nginx_extra_config     => '
+    app_type                 => 'rack',
+    port                     => $port,
+    sentry_dsn               => $sentry_dsn,
+    vhost_protected          => $vhost_protected,
+    health_check_path        => '/',
+    log_format_is_json       => true,
+    asset_pipeline           => true,
+    asset_pipeline_prefix    => 'frontend',
+    nagios_memory_warning    => $nagios_memory_warning,
+    nagios_memory_critical   => $nagios_memory_critical,
+    vhost                    => $vhost,
+    nginx_extra_config       => '
   location ^~ /frontend/homepage/no-cache/ {
     expires epoch;
   }
   ',
+    unicorn_worker_processes => $unicorn_worker_processes,
   }
 
   govuk::app::envvar::redis { 'frontend':

--- a/modules/govuk/manifests/apps/government_frontend.pp
+++ b/modules/govuk/manifests/apps/government_frontend.pp
@@ -17,11 +17,16 @@
 # [*secret_key_base*]
 #   The key for Rails to use when signing/encrypting sessions.
 #
+# [*unicorn_worker_processes*]
+#   The number of unicorn worker processes to run
+#   Default: undef
+#
 class govuk::apps::government_frontend(
   $vhost = 'government-frontend',
   $port = '3090',
   $sentry_dsn = undef,
   $secret_key_base = undef,
+  $unicorn_worker_processes = undef,
 ) {
   Govuk::App::Envvar {
     app => 'government-frontend',
@@ -34,13 +39,14 @@ class govuk::apps::government_frontend(
     }
   }
   govuk::app { 'government-frontend':
-    app_type              => 'rack',
-    port                  => $port,
-    sentry_dsn            => $sentry_dsn,
-    vhost_ssl_only        => true,
-    health_check_path     => '/healthcheck',
-    asset_pipeline        => true,
-    asset_pipeline_prefix => 'government-frontend',
-    vhost                 => $vhost,
+    app_type                 => 'rack',
+    port                     => $port,
+    sentry_dsn               => $sentry_dsn,
+    vhost_ssl_only           => true,
+    health_check_path        => '/healthcheck',
+    asset_pipeline           => true,
+    asset_pipeline_prefix    => 'government-frontend',
+    vhost                    => $vhost,
+    unicorn_worker_processes => $unicorn_worker_processes,
   }
 }


### PR DESCRIPTION
These apps are set up to read `UNICORN_WORKER_PROCESSES` env vars to set the
number of worker processes to use.

The default is 2 processes, but I know that platform support are likely to change
this as part of https://trello.com/c/5qhHri2F/90-check-if-we-have-enough-server-resource-serving-government-frontend so I've added it in anyway.

If this is merged, then we can remove the default from frontend's https://github.com/alphagov/frontend/blob/41d9f122404216c3c77e77c5933a9a02dc47ef57/config/unicorn.rb#L4