### PR TITLE
Install latest version Terraform on ci-deploy

### DIFF
--- a/hieradata/class/integration/jenkins.yaml
+++ b/hieradata/class/integration/jenkins.yaml
@@ -9,3 +9,5 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::network_config_deploy
   - govuk_jenkins::jobs::passive_checks
   - govuk_jenkins::jobs::run_rake_task
+
+govuk_jenkins::packages::terraform::version: '0.11.2'


### PR DESCRIPTION
We're using the CI Jenkins deploy instance to manage all builds of Terraform infrastructure (a central build box).

This needs to have the latest version of Terraform installed for this to work for our code.

https://trello.com/c/qAzTAU4p/952-build-box-spike-on-adding-tf-deploys-to-current-integration-carrenza-deploy-jenkins