### PR TITLE
Add ValeLint to CI agents

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -636,6 +636,7 @@ govuk_htpasswd::http_username: "%{hiera('http_username')}"
 govuk_jenkins::packages::gcloud::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk_jenkins::packages::terraform::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk_jenkins::packages::sops::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_jenkins::packages::vale::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 govuk::node::s_api_redis::allowed_api_ip_range: "%{hiera('environment_ip_prefix')}.4.0/24"
 govuk::node::s_api_redis::allowed_backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"

--- a/modules/govuk_ci/manifests/agent.pp
+++ b/modules/govuk_ci/manifests/agent.pp
@@ -32,6 +32,7 @@ class govuk_ci::agent(
     include ::govuk_java::oracle8
   }
   include ::govuk_jenkins::packages::terraform
+  include ::govuk_jenkins::packages::vale
   include ::govuk_jenkins::pipeline
   include ::govuk_jenkins::user
   include ::govuk_rbenv::all

--- a/modules/govuk_jenkins/manifests/packages/vale.pp
+++ b/modules/govuk_jenkins/manifests/packages/vale.pp
@@ -1,0 +1,27 @@
+# == Class: govuk_jenkins::packages::vale
+#
+# Installs Vale lint
+#
+# === Parameters
+#
+# [*apt_mirror_hostname*]
+#   The hostname of an APT mirror
+#
+class govuk_jenkins::packages::vale (
+  $apt_mirror_hostname = undef,
+  $version = '0.10.0',
+){
+
+  apt::source { 'vale':
+    location     => "http://${apt_mirror_hostname}/vale",
+    release      => $::lsbdistcodename,
+    architecture => $::architecture,
+    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+  }
+
+  package { 'vale':
+    ensure  => $version,
+    require => Apt::Source['vale'],
+  }
+
+}


### PR DESCRIPTION
ValeLint is a tool that lints documentation: https://github.com/ValeLint/vale

We tried it on a pre-commit hook for govuk-developer-docs, but since this relies on trusting a someone has installed on govuk-developer-docs it is a less reliable way to ensure all our documentation is correctly linted.

To begin with we can start with a low threshold for error, but can catch fully incorrect grammer such as repeated words.

This will also need to be configured in the Jenkinsfile.

In the future we could potentially configure the jenkinslib to default check any markdown files and ensure that we have well-written documentation.