### PR TITLE
Include Terraform package for Terraform job

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/deploy_terraform_govuk_aws.pp
+++ b/modules/govuk_jenkins/manifests/jobs/deploy_terraform_govuk_aws.pp
@@ -6,4 +6,6 @@ class govuk_jenkins::jobs::deploy_terraform_govuk_aws {
     content => template('govuk_jenkins/jobs/deploy_terraform_govuk_aws.yaml.erb'),
     notify  => Exec['jenkins_jobs_update'],
   }
+
+  include ::govuk_jenkins::packages::terraform
 }


### PR DESCRIPTION
Deploying Terraform becomes tricker when you don't have Terraform. I forgot to include the class that installs it within the class that creates the Jenkins job itself.