### PR TITLE
Include sops

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/deploy_terraform_govuk_aws.pp
+++ b/modules/govuk_jenkins/manifests/jobs/deploy_terraform_govuk_aws.pp
@@ -8,4 +8,5 @@ class govuk_jenkins::jobs::deploy_terraform_govuk_aws {
   }
 
   include ::govuk_jenkins::packages::terraform
+  include ::govuk_jenkins::packages::sops
 }


### PR DESCRIPTION
The deploy job also requires sops to decrypt encrypted data.