### PR TITLE
Set package as stable rather than distribution

### DIFF
--- a/modules/govuk_jenkins/manifests/packages/sops.pp
+++ b/modules/govuk_jenkins/manifests/packages/sops.pp
@@ -14,7 +14,7 @@ class govuk_jenkins::packages::sops (
 
   apt::source { 'sops':
     location     => "http://${apt_mirror_hostname}/sops",
-    release      => $::lsbdistcodename,
+    release      => 'stable',
     architecture => $::architecture,
     key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
   }

--- a/modules/govuk_jenkins/manifests/packages/vale.pp
+++ b/modules/govuk_jenkins/manifests/packages/vale.pp
@@ -14,7 +14,7 @@ class govuk_jenkins::packages::vale (
 
   apt::source { 'vale':
     location     => "http://${apt_mirror_hostname}/vale",
-    release      => $::lsbdistcodename,
+    release      => 'stable',
     architecture => $::architecture,
     key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
   }


### PR DESCRIPTION
Within http://apt.publishing.service.gov.uk they are listed under 'stable' rather than 'trusty' because I blindly copied the docs.

Without changing this Puppet runs will fail on the places where these packages are included.