### PR TITLE
Fix how size of sidekiq queue is shown

### DIFF
--- a/modules/grafana/files/dashboards/email_alert_api.json
+++ b/modules/grafana/files/dashboards/email_alert_api.json
@@ -1480,7 +1480,7 @@
           "targets": [
             {
               "refId": "A",
-              "target": "aliasSub(aliasByNode(keepLastValue(consolidateBy(groupByNode(stats.gauges.govuk.app.email-alert-api.*.workers.queues.*.enqueued, 8, \"averageSeries\"), \"sum\")), 0), \"(.*)\", \"\\1 enqueued\")",
+              "target": "aliasSub(aliasByNode(keepLastValue(consolidateBy(groupByNode(stats.gauges.govuk.app.email-alert-api.*.workers.queues.*.enqueued, 8, \"averageSeries\"), \"average\")), 0), \"(.*)\", \"\\1 enqueued\")",
               "textEditor": true
             }
           ],


### PR DESCRIPTION
Previously we sum the values in each time range, but really we want to get the average.

[Trello Card](https://trello.com/c/0BM0CrW7/626-investigate-number-of-digest-jobs-being-queued)