### PR TITLE
Don't set PLEK_HOSTNAME_PREFIX on the draft_cache nodes

### DIFF
--- a/modules/govuk/manifests/node/s_draft_cache.pp
+++ b/modules/govuk/manifests/node/s_draft_cache.pp
@@ -15,8 +15,4 @@ class govuk::node::s_draft_cache(
   }
 
   $app_domain = hiera('app_domain')
-
-  govuk_envvar {
-    'PLEK_HOSTNAME_PREFIX': value => 'draft-';
-  }
 }


### PR DESCRIPTION
The only applications which run on these nodes are
authenticating-proxy, router and router-api. The only one of these
that uses Plek is authenticating-proxy, and the only thing it uses
Plek for is to find Signon.

There is no draft Signon, so previously this was overridden in the
authenticating_proxy class. I removed that override breaking
authenticating-proxy, but rather than putting it back, I think it
makes more sense to remove the use of PLEK_HOSTNAME_PREFIX for the
draft_cache nodes. Less configuration is probably better, especially
if I'm correct in saying that the setting is redundant.