### PR TITLE
Change override address to use an AWS success address

### DIFF
--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -23,7 +23,7 @@ govuk::apps::email_alert_api::govdelivery_account_code: 'UKGOVUK'
 govuk::apps::email_alert_api::govdelivery_hostname: 'stage-api.govdelivery.com'
 govuk::apps::email_alert_api::govdelivery_public_hostname: 'stage-public.govdelivery.com'
 govuk::apps::email_alert_api::govuk_notify_template_id: '2844a647-6bf1-4b01-a25c-569d2cc00849'
-govuk::apps::email_alert_api::email_address_override: 'simulate-delivered@notifications.service.gov.uk'
+govuk::apps::email_alert_api::email_address_override: 'success@simulator.amazonses.com'
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::kibana::logit_environment: d414187a-2796-4ea7-9b9a-d40c341646d6
 govuk::apps::link_checker_api::govuk_basic_auth_credentials: "%{hiera('http_username')}:%{hiera('http_password')}"

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -18,7 +18,7 @@ govuk::apps::email_alert_api::allow_govdelivery_topic_syncing: true
 govuk::apps::email_alert_api::govuk_notify_template_id: '1fc69d3a-09a2-40f9-852b-03f6fcef5340'
 govuk::apps::email_alert_api::disable_govdelivery_emails: true
 govuk::apps::email_alert_api::use_email_alert_frontend_for_email_collection: true
-govuk::apps::email_alert_api::email_address_override: 'simulate-delivered@notifications.service.gov.uk'
+govuk::apps::email_alert_api::email_address_override: 'success@simulator.amazonses.com'
 govuk::apps::govuk_crawler_worker::enabled: false
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
 govuk::apps::kibana::logit_environment: 2694f14b-6519-4607-81f2-8a2130e5aaec

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -19,7 +19,7 @@ govuk::apps::email_alert_api::govdelivery_account_code: 'UKGOVUK'
 govuk::apps::email_alert_api::govdelivery_hostname: 'stage-api.govdelivery.com'
 govuk::apps::email_alert_api::govdelivery_public_hostname: 'stage-public.govdelivery.com'
 govuk::apps::email_alert_api::govuk_notify_template_id: '2844a647-6bf1-4b01-a25c-569d2cc00849'
-govuk::apps::email_alert_api::email_address_override: 'simulate-delivered@notifications.service.gov.uk'
+govuk::apps::email_alert_api::email_address_override: 'success@simulator.amazonses.com'
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::kibana::logit_environment: d414187a-2796-4ea7-9b9a-d40c341646d6
 govuk::apps::link_checker_api::govuk_basic_auth_credentials: "%{hiera('http_username')}:%{hiera('http_password')}"


### PR DESCRIPTION
This means we'll get status callbacks as we are fully exercising GOV.UK Notify.

[Trello Card](https://trello.com/c/UwM5NwqV/549-spike-enabling-a-full-test-run-for-integration)