### PR TITLE
Remove email address override whitelist

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -381,25 +381,6 @@ govuk::apps::email_alert_api::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::email_alert_api::db_hostname: 'postgresql-primary-1.backend'
 govuk::apps::email_alert_api::db_password: "%{hiera('govuk::apps::email_alert_api::db::password')}"
 govuk::apps::email_alert_api::govuk_notify_rate_per_worker: '12'
-govuk::apps::email_alert_api::email_address_override_whitelist:
-  - govuk-email-courtesy-copies@digital.cabinet-office.gov.uk
-  - graham.pengelly@digital.cabinet-office.gov.uk
-  - kevin.dew@digital.cabinet-office.gov.uk
-  - keith.emmerson@digital.cabinet-office.gov.uk
-  - paul.cronk@digital.cabinet-office.gov.uk
-  - antonia.simmons@digital.cabinet-office.gov.uk
-  - antonia.nadine@gmail.com
-  - antoniadrake@hotmail.com
-  - tijmen.brommet@digital.cabinet-office.gov.uk
-  - steve.messer@digital.cabinet-office.gov.uk
-  - stevenjmesser@gmail.com
-  - lee.ryan@digital.cabinet-office.gov.uk
-  - si.stephens@digital.cabinet-office.gov.uk
-  - simonstephens@gmail.com
-  - christopher.dennett@digital.cabinet-office.gov.uk
-  - martin.lugton@digital.cabinet-office.gov.uk
-  - hong.nguyen@digital.cabinet-office.gov.uk
-  - thomas.leese@digital.cabinet-office.gov.uk
 
 govuk::apps::email_alert_service::rabbitmq_hosts:
   - rabbitmq-1.backend

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -384,25 +384,6 @@ govuk::apps::email_alert_api::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::email_alert_api::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::email_alert_api::db_hostname: 'postgresql-primary'
 govuk::apps::email_alert_api::db_password: "%{hiera('govuk::apps::email_alert_api::db::password')}"
-govuk::apps::email_alert_api::email_address_override_whitelist:
-  - govuk-email-courtesy-copies@digital.cabinet-office.gov.uk
-  - graham.pengelly@digital.cabinet-office.gov.uk
-  - kevin.dew@digital.cabinet-office.gov.uk
-  - keith.emmerson@digital.cabinet-office.gov.uk
-  - paul.cronk@digital.cabinet-office.gov.uk
-  - antonia.simmons@digital.cabinet-office.gov.uk
-  - antonia.nadine@gmail.com
-  - antoniadrake@hotmail.com
-  - tijmen.brommet@digital.cabinet-office.gov.uk
-  - steve.messer@digital.cabinet-office.gov.uk
-  - stevenjmesser@gmail.com
-  - lee.ryan@digital.cabinet-office.gov.uk
-  - si.stephens@digital.cabinet-office.gov.uk
-  - simonstephens@gmail.com
-  - christopher.dennett@digital.cabinet-office.gov.uk
-  - martin.lugton@digital.cabinet-office.gov.uk
-  - hong.nguyen@digital.cabinet-office.gov.uk
-  - thomas.leese@digital.cabinet-office.gov.uk
 
 govuk::apps::email_alert_service::rabbitmq_hosts:
   - rabbitmq


### PR DESCRIPTION
This will be stored in govuk-secrets now.

Depends on https://github.com/alphagov/govuk-secrets/pull/251.