### PR TITLE
Add release app and slack build params to CI deploy trigger job

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/integration_app_deploy.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/integration_app_deploy.yaml.erb
@@ -6,7 +6,7 @@
     description: "Kicks off an appliction deploy in the Integration environment"
     builders:
       - shell: |
-          JSON="{\"parameter\": [{\"name\": \"TARGET_APPLICATION\", \"value\": \"$TARGET_APPLICATION\"}, {\"name\": \"TAG\", \"value\": \"$TAG\"}, {\"name\": \"DEPLOY_TASK\", \"value\": \"$DEPLOY_TASK\"}], \"\": \"\"}"
+          JSON="{\"parameter\": [{\"name\": \"TARGET_APPLICATION\", \"value\": \"$TARGET_APPLICATION\"}, {\"name\": \"TAG\", \"value\": \"$TAG\"}, {\"name\": \"DEPLOY_TASK\", \"value\": \"$DEPLOY_TASK\"}, {\"name\": \"NOTIFY_RELEASE_APP\", \"value\": \"true\"}, {\"name\": \"SLACK_NOTIFICATIONS\", \"value\": \"true\"}], \"\": \"\"}"
 
           # Deploy to AWS Integration environment
           CRUMB=$(curl https://<%= @jenkins_integration_aws_api_user %>:<%= @jenkins_integration_aws_api_password %>@<%= @aws_deploy_url %>/crumbIssuer/api/json | jq --raw-output '. | .crumb')


### PR DESCRIPTION
If we don't send these build parameters in the trigger then 
jenkins doesn't default them and so the deployment won't try
to talk to the release app or to slack.  It doesn't actually talk
to slack anyway, because there's code that only does it for
staging or production, but that might change and we wouldn't
want to have to edit this script again to enable it.