### PR TITLE
Allow setting ensure to absent

### DIFF
--- a/modules/govuk_rabbitmq/manifests/queue_with_binding.pp
+++ b/modules/govuk_rabbitmq/manifests/queue_with_binding.pp
@@ -35,6 +35,7 @@
 #   (default: true)
 #
 define govuk_rabbitmq::queue_with_binding (
+  $ensure = 'present',
   $amqp_exchange,
   $amqp_queue,
   $routing_key,
@@ -44,7 +45,7 @@ define govuk_rabbitmq::queue_with_binding (
   $amqp_user = $title
 
   rabbitmq_queue { "${amqp_queue}@/":
-    ensure      => present,
+    ensure      => $ensure,
     user        => 'root',
     password    => $::govuk_rabbitmq::root_password,
     durable     => $durable,
@@ -52,7 +53,7 @@ define govuk_rabbitmq::queue_with_binding (
     arguments   => {},
   } ->
   rabbitmq_binding { "binding_${routing_key}_${amqp_exchange}@${amqp_queue}@/":
-    ensure           => present,
+    ensure           => $ensure,
     name             => "${amqp_exchange}@${amqp_queue}@/",
     user             => 'root',
     password         => $::govuk_rabbitmq::root_password,
@@ -62,7 +63,7 @@ define govuk_rabbitmq::queue_with_binding (
   }
 
   govuk_rabbitmq::monitor_consumers {"${title}_${amqp_queue}_consumer_monitoring":
-    ensure            => present,
+    ensure            => $ensure,
     rabbitmq_hostname => 'localhost',
     rabbitmq_queue    => $amqp_queue,
   }


### PR DESCRIPTION
We wish to be able to confirm that these resources do not exist, so add
a parameter called 'ensure' and set it to `true` by default.