### PR TITLE
Allows ensure to be set to `absent` for rabbitmq

### DIFF
--- a/modules/govuk/manifests/apps/content_performance_manager/rabbitmq.pp
+++ b/modules/govuk/manifests/apps/content_performance_manager/rabbitmq.pp
@@ -29,6 +29,7 @@ class govuk::apps::content_performance_manager::rabbitmq (
 ) {
 
   govuk_rabbitmq::queue_with_binding { $amqp_queue:
+    ensure        => 'absent',
     amqp_exchange => $amqp_exchange,
     amqp_queue    => $amqp_queue,
     routing_key   => '*.#.#',
@@ -36,6 +37,7 @@ class govuk::apps::content_performance_manager::rabbitmq (
   } ->
 
   govuk_rabbitmq::consumer { $amqp_user:
+    ensure               => 'absent',
     amqp_pass            => $amqp_pass,
     read_permission      => "^${amqp_queue}\$",
     write_permission     => "^\$",

--- a/modules/govuk_rabbitmq/manifests/queue_with_binding.pp
+++ b/modules/govuk_rabbitmq/manifests/queue_with_binding.pp
@@ -38,13 +38,14 @@ define govuk_rabbitmq::queue_with_binding (
   $amqp_exchange,
   $amqp_queue,
   $routing_key,
-  $durable = true
+  $durable = true,
+  $ensure = 'present'
 ) {
   validate_re($routing_key, '^.+$', '$routing_key must be non-empty')
   $amqp_user = $title
 
   rabbitmq_queue { "${amqp_queue}@/":
-    ensure      => present,
+    ensure      => $ensure,
     user        => 'root',
     password    => $::govuk_rabbitmq::root_password,
     durable     => $durable,
@@ -52,7 +53,7 @@ define govuk_rabbitmq::queue_with_binding (
     arguments   => {},
   } ->
   rabbitmq_binding { "binding_${routing_key}_${amqp_exchange}@${amqp_queue}@/":
-    ensure           => present,
+    ensure           => $ensure,
     name             => "${amqp_exchange}@${amqp_queue}@/",
     user             => 'root',
     password         => $::govuk_rabbitmq::root_password,
@@ -62,7 +63,7 @@ define govuk_rabbitmq::queue_with_binding (
   }
 
   govuk_rabbitmq::monitor_consumers {"${title}_${amqp_queue}_consumer_monitoring":
-    ensure            => present,
+    ensure            => $ensure,
     rabbitmq_hostname => 'localhost',
     rabbitmq_queue    => $amqp_queue,
   }


### PR DESCRIPTION
We're trying to allow rabbitmq to be turned off using `ensure => absent`