### PR TITLE
[WIP] Allow apps to upload assets

### DIFF
--- a/modules/govuk/manifests/deploy/setup.pp
+++ b/modules/govuk/manifests/deploy/setup.pp
@@ -31,6 +31,9 @@ class govuk::deploy::setup (
     $ssh_keys = { 'not set in hiera' => 'NONE_IN_HIERA' },
     $deploy_uid = undef,
     $deploy_gid = undef,
+    $assets_aws_s3_bucket_name = undef,
+    $assets_aws_access_key_id = undef,
+    $assets_aws_secret_access_key = undef,
 ){
   validate_hash($ssh_keys)
 
@@ -123,5 +126,23 @@ class govuk::deploy::setup (
     require   => User['deploy'],
     user_home => '/home/deploy',
     username  => 'deploy',
+  }
+
+  # After deploy, frontend apps will upload their assets to S3
+  package { 's3cmd':
+    ensure   => 'present',
+    provider => 'pip',
+  }
+
+  govuk::app::envvar {
+    "${title}-ASSETS_AWS_S3_BUCKET":
+      varname => 'ASSETS_AWS_S3_BUCKET_NAME',
+      value   => $assets_aws_s3_bucket_name;
+    "${title}-ASSETS_AWS_ACCESS_KEY":
+      varname => 'ASSETS_AWS_ACCESS_KEY',
+      value   => $assets_aws_access_key_id;
+    "${title}-ASSETS_AWS_SECRET_KEY":
+      varname => 'ASSETS_AWS_SECRET_KEY',
+      value   => $assets_aws_secret_access_key;
   }
 }


### PR DESCRIPTION
This is part of an effort to upload all the applications' static assets to S3 (https://github.com/alphagov/govuk-rfcs/pull/91).

This PR is to sanity check the approach. What I intend to do:

1. Create a S3 bucket (https://github.com/alphagov/govuk-terraform-provisioning/pull/161)
2. Add the S3 credentials to all machines
3. Install `s3cmd` on all machines
4. After the assets are precompiled by Rails run a command like `s3cmd sync -H -v --acl-public --skip-existing --guess-mime-type --no-delete-removed /data/apps/collections/shared/assets/ s3://govuk-static-assets/shared/` on 1 of the machines the app lives on
5. Proxy `assets.publishing.service.gov.uk/shared` to the S3 bucket
6. Make the apps point to `assets.publishing.service.gov.uk/shared` for assets

This PR does steps 2 and 3.

https://trello.com/c/dCXLbdBH