### PR TITLE
Install libffi-dev with all rbenv installs

### DIFF
--- a/modules/govuk_ci/manifests/agent.pp
+++ b/modules/govuk_ci/manifests/agent.pp
@@ -61,10 +61,6 @@ class govuk_ci::agent(
     require => Class['::govuk_jenkins::user'],
   }
 
-  package { 'libffi-dev': # needed for ffi: a dependency of govuk-lint
-    ensure => installed,
-  }
-
   package { 'libgdal-dev': # needed for mapit
     ensure => installed,
   }

--- a/modules/govuk_rbenv/manifests/init.pp
+++ b/modules/govuk_rbenv/manifests/init.pp
@@ -6,6 +6,12 @@
 class govuk_rbenv {
   include rbenv
 
+  # @FIXME - Check once [ffi-gem](https://github.com/ffi/ffi) is past 1.9.21
+  # whether we still need to require this.
+  # It was added in as many ruby apps are installed with 1.9.21 and are
+  # failing to install some environments where this is not required.
+  ensure_packages(['libffi-dev'])
+
   unless $::lsbdistcodename == 'xenial' {
     rbenv::version { '1.9.3-p550':
       bundler_version  => '1.7.4',


### PR DESCRIPTION
This has been added to govuk_rbenv to bring it as close as possible to
installing for all environments which have Ruby. It is to resolve an
issue we have where a version of the ffi gem is blocking deployments on
a number of apps due to being able to install this gem, however as the
libffi-dev package is installed on CI these are aready merged in quite a
few places.

Therefore it felt like the path of least pain to install this package in
all ruby installations so that gems requiring it would install
consistently.

It looks like this issue should be resolved soon by this commit:
https://github.com/ffi/ffi/commit/bfc330a3c6cbeedea72a0134d603085b54953252
however the project does specify that you need libffi-dev installed
(however that could be just for developing) so there is a fixme note to
check and remove this once ffi has been updated.