### PR TITLE
Email Alert API rate limit in integration and staging

### DIFF
--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -24,6 +24,7 @@ govuk::apps::email_alert_api::govdelivery_hostname: 'stage-api.govdelivery.com'
 govuk::apps::email_alert_api::govdelivery_public_hostname: 'stage-public.govdelivery.com'
 govuk::apps::email_alert_api::govuk_notify_template_id: '2844a647-6bf1-4b01-a25c-569d2cc00849'
 govuk::apps::email_alert_api::email_address_override: 'success@simulator.amazonses.com'
+govuk::apps::email_alert_api::delivery_request_threshold: 3000
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::kibana::logit_environment: d414187a-2796-4ea7-9b9a-d40c341646d6
 govuk::apps::link_checker_api::govuk_basic_auth_credentials: "%{hiera('http_username')}:%{hiera('http_password')}"

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -19,6 +19,7 @@ govuk::apps::email_alert_api::govuk_notify_template_id: '1fc69d3a-09a2-40f9-852b
 govuk::apps::email_alert_api::disable_govdelivery_emails: true
 govuk::apps::email_alert_api::use_email_alert_frontend_for_email_collection: true
 govuk::apps::email_alert_api::email_address_override: 'success@simulator.amazonses.com'
+govuk::apps::email_alert_api::delivery_request_threshold: 3000
 govuk::apps::govuk_crawler_worker::enabled: false
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
 govuk::apps::kibana::logit_environment: 2694f14b-6519-4607-81f2-8a2130e5aaec

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -20,6 +20,7 @@ govuk::apps::email_alert_api::govdelivery_hostname: 'stage-api.govdelivery.com'
 govuk::apps::email_alert_api::govdelivery_public_hostname: 'stage-public.govdelivery.com'
 govuk::apps::email_alert_api::govuk_notify_template_id: '2844a647-6bf1-4b01-a25c-569d2cc00849'
 govuk::apps::email_alert_api::email_address_override: 'success@simulator.amazonses.com'
+govuk::apps::email_alert_api::delivery_request_threshold: 3000
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::kibana::logit_environment: d414187a-2796-4ea7-9b9a-d40c341646d6
 govuk::apps::link_checker_api::govuk_basic_auth_credentials: "%{hiera('http_username')}:%{hiera('http_password')}"

--- a/modules/govuk/manifests/apps/email_alert_api.pp
+++ b/modules/govuk/manifests/apps/email_alert_api.pp
@@ -102,6 +102,9 @@
 # [*email_address_override_whitelist*]
 #   Allow a whitelist of email addresses that ignore the override option.
 #
+# [*delivery_request_threshold*]
+#   Configure the number of requests that the rate limit will allow to be made in one minute.
+#
 class govuk::apps::email_alert_api(
   $port = '3088',
   $enabled = false,
@@ -135,6 +138,7 @@ class govuk::apps::email_alert_api(
   $email_service_provider = 'NOTIFY',
   $email_address_override = undef,
   $email_address_override_whitelist = undef,
+  $delivery_request_threshold = undef,
   $db_username = 'email-alert-api',
   $db_password = undef,
   $db_hostname = undef,
@@ -253,6 +257,13 @@ class govuk::apps::email_alert_api(
       govuk::app::envvar { "${title}-EMAIL_ADDRESS_OVERRIDE_WHITELIST":
         varname => 'EMAIL_ADDRESS_OVERRIDE_WHITELIST',
         value   => join($email_address_override_whitelist, ',');
+      }
+    }
+
+    if $delivery_request_threshold {
+      govuk::app::envvar { "${title}-DELIVERY_REQUEST_THRESHOLD":
+        varname => 'DELIVERY_REQUEST_THRESHOLD',
+        value   => $delivery_request_threshold;
       }
     }
 


### PR DESCRIPTION
In integration and staging our GOV.UK Notify rate limit is lower than our production environment.