### PR TITLE
Only send email alert api emails if whitelisted

### DIFF
--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -24,6 +24,7 @@ govuk::apps::email_alert_api::govdelivery_hostname: 'stage-api.govdelivery.com'
 govuk::apps::email_alert_api::govdelivery_public_hostname: 'stage-public.govdelivery.com'
 govuk::apps::email_alert_api::govuk_notify_template_id: '2844a647-6bf1-4b01-a25c-569d2cc00849'
 govuk::apps::email_alert_api::email_address_override: 'success@simulator.amazonses.com'
+govuk::apps::email_alert_api::email_address_override_whitelist_only: true
 govuk::apps::email_alert_api::delivery_request_threshold: 3000
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::kibana::logit_environment: d414187a-2796-4ea7-9b9a-d40c341646d6

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -19,6 +19,7 @@ govuk::apps::email_alert_api::govuk_notify_template_id: '1fc69d3a-09a2-40f9-852b
 govuk::apps::email_alert_api::disable_govdelivery_emails: true
 govuk::apps::email_alert_api::use_email_alert_frontend_for_email_collection: true
 govuk::apps::email_alert_api::email_address_override: 'success@simulator.amazonses.com'
+govuk::apps::email_alert_api::email_address_override_whitelist_only: true
 govuk::apps::email_alert_api::delivery_request_threshold: 3000
 govuk::apps::govuk_crawler_worker::enabled: false
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -20,6 +20,7 @@ govuk::apps::email_alert_api::govdelivery_hostname: 'stage-api.govdelivery.com'
 govuk::apps::email_alert_api::govdelivery_public_hostname: 'stage-public.govdelivery.com'
 govuk::apps::email_alert_api::govuk_notify_template_id: '2844a647-6bf1-4b01-a25c-569d2cc00849'
 govuk::apps::email_alert_api::email_address_override: 'success@simulator.amazonses.com'
+govuk::apps::email_alert_api::email_address_override_whitelist_only: true
 govuk::apps::email_alert_api::delivery_request_threshold: 3000
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::kibana::logit_environment: d414187a-2796-4ea7-9b9a-d40c341646d6

--- a/modules/govuk/manifests/apps/email_alert_api.pp
+++ b/modules/govuk/manifests/apps/email_alert_api.pp
@@ -102,6 +102,9 @@
 # [*email_address_override_whitelist*]
 #   Allow a whitelist of email addresses that ignore the override option.
 #
+# [*email_address_override_whitelist_only*]
+#   Specify that only emails that are whitelisted should be sent out.
+#
 # [*delivery_request_threshold*]
 #   Configure the number of requests that the rate limit will allow to be made in one minute.
 #
@@ -138,6 +141,7 @@ class govuk::apps::email_alert_api(
   $email_service_provider = 'NOTIFY',
   $email_address_override = undef,
   $email_address_override_whitelist = undef,
+  $email_address_override_whitelist_only = false,
   $delivery_request_threshold = undef,
   $db_username = 'email-alert-api',
   $db_password = undef,
@@ -257,6 +261,13 @@ class govuk::apps::email_alert_api(
       govuk::app::envvar { "${title}-EMAIL_ADDRESS_OVERRIDE_WHITELIST":
         varname => 'EMAIL_ADDRESS_OVERRIDE_WHITELIST',
         value   => join($email_address_override_whitelist, ',');
+      }
+    }
+
+    if $email_address_override_whitelist_only {
+      govuk::app::envvar { "${title}-EMAIL_ADDRESS_OVERRIDE_WHITELIST_ONLY":
+        varname => 'EMAIL_ADDRESS_OVERRIDE_WHITELIST_ONLY',
+        value   => 'yes';
       }
     }
 


### PR DESCRIPTION
This means that in integration and staging, we will only send out emails on the whitelist. This reduces the number of emails we send out thus reducing the load on GOV.UK Notify.

Depends on https://github.com/alphagov/email-alert-api/pull/442.

[Trello Card](https://trello.com/c/Q7xZvdUN/630-only-send-emails-to-the-whitelist)