### PR TITLE
Add global shared library to Jenkins

### DIFF
--- a/modules/govuk_jenkins/manifests/pipeline.pp
+++ b/modules/govuk_jenkins/manifests/pipeline.pp
@@ -28,4 +28,18 @@ class govuk_jenkins::pipeline (
     source  => 'puppet:///modules/govuk_jenkins/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy',
     require => File['/var/lib/jenkins/groovy_scripts'],
   }
+
+  $jenkins_libraries = {
+    'govuk' => {
+      'org'             => 'alphagov',
+      'repository'      => 'govuk-jenkinslib',
+      'implicit_load'   => false,
+      'default_version' => 'master',
+    },
+  }
+
+  file { '/var/lib/jenkins/org.jenkinsci.plugins.workflow.libs.GlobalLibraries.xml':
+    ensure  => present,
+    content => template('govuk_jenkins/config/org.jenkinsci.plugins.workflow.libs.GlobalLibraries.xml'),
+  }
 }

--- a/modules/govuk_jenkins/spec/classes/jenkins__pipeline_spec.rb
+++ b/modules/govuk_jenkins/spec/classes/jenkins__pipeline_spec.rb
@@ -1,0 +1,13 @@
+require_relative '../../../../spec_helper'
+
+describe 'govuk_jenkins::pipeline', :type => :class do
+  describe 'manage config' do
+    it { is_expected.to contain_file('/var/lib/jenkins/groovy_scripts').with_ensure('directory') }
+    it { is_expected.to contain_file('/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy') }
+    it { is_expected.to contain_file('/var/lib/jenkins/org.jenkinsci.plugins.workflow.libs.GlobalLibraries.xml').with_content(/<name>govuk<\/name/) }
+    it { is_expected.to contain_file('/var/lib/jenkins/org.jenkinsci.plugins.workflow.libs.GlobalLibraries.xml').with_content(/<repoOwner>alphagov<\/repoOwner>/) }
+    it { is_expected.to contain_file('/var/lib/jenkins/org.jenkinsci.plugins.workflow.libs.GlobalLibraries.xml').with_content(/<repository>govuk-jenkinslib<\/repository>/) }
+    it { is_expected.to contain_file('/var/lib/jenkins/org.jenkinsci.plugins.workflow.libs.GlobalLibraries.xml').with_content(/<defaultVersion>master<\/defaultVersion>/) }
+    it { is_expected.to contain_file('/var/lib/jenkins/org.jenkinsci.plugins.workflow.libs.GlobalLibraries.xml').with_content(/<implicit>false<\/implicit>/) }
+  end
+end

--- a/modules/govuk_jenkins/templates/config/org.jenkinsci.plugins.workflow.libs.GlobalLibraries.xml
+++ b/modules/govuk_jenkins/templates/config/org.jenkinsci.plugins.workflow.libs.GlobalLibraries.xml
@@ -1,0 +1,29 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<org.jenkinsci.plugins.workflow.libs.GlobalLibraries plugin="workflow-cps-global-lib@2.8">
+  <libraries>
+    <%- @jenkins_libraries.each do |name, values| -%>
+    <org.jenkinsci.plugins.workflow.libs.LibraryConfiguration>
+      <name><%= name %></name>
+      <retriever class="org.jenkinsci.plugins.workflow.libs.SCMSourceRetriever">
+        <scm class="org.jenkinsci.plugins.github_branch_source.GitHubSCMSource" plugin="github-branch-source@2.0.5">
+          <checkoutCredentialsId>SAME</checkoutCredentialsId>
+          <scanCredentialsId>github-token-govuk-ci-username</scanCredentialsId>
+          <repoOwner><%= values['org'] %></repoOwner>
+          <repository><%= values['repository'] %></repository>
+          <includes>*</includes>
+          <excludes></excludes>
+          <buildOriginBranch>true</buildOriginBranch>
+          <buildOriginBranchWithPR>true</buildOriginBranchWithPR>
+          <buildOriginPRMerge>false</buildOriginPRMerge>
+          <buildOriginPRHead>false</buildOriginPRHead>
+          <buildForkPRMerge>true</buildForkPRMerge>
+          <buildForkPRHead>false</buildForkPRHead>
+        </scm>
+      </retriever>
+      <defaultVersion><%= values['default_version'] %></defaultVersion>
+      <implicit><%= values['implicit_load'].to_s %></implicit>
+      <allowVersionOverride>true</allowVersionOverride>
+    </org.jenkinsci.plugins.workflow.libs.LibraryConfiguration>
+    <%- end -%>
+  </libraries>
+</org.jenkinsci.plugins.workflow.libs.GlobalLibraries>


### PR DESCRIPTION
This is related to
https://github.com/alphagov/govuk-jenkinslib/commit/c2e84ed07a17d2afd17d090bf4a87b0d62efeef9.

This sets the global option to enable loading in a shared library from a repository. Pass in a hash of the libraries you wish to load, and then you should be able to load the libraries in using a Jenkinsfile.

I used an embedded hash within the manifest because at the moment it's a single library. In the future it may be easier to create a default set of values, and pass in a hash from hiera.

There are a few advantages over loading in an external shared library, including keeping the library in it's own version control, being able to potentially add unit tests, because able to explictly call a job from a branch of the library to test changes and making the code more portable and visible.

https://trello.com/c/88RFcs4R/994-make-jenkinslibgroovy-its-own-repo-refactor

This requires [this PR](https://github.com/alphagov/govuk-jenkinslib/pull/1) to be merged before merging as otherwise Jenkins will get upset.