### PR TITLE
Sets email api delivery threshold as string

### DIFF
--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -25,7 +25,7 @@ govuk::apps::email_alert_api::govdelivery_public_hostname: 'stage-public.govdeli
 govuk::apps::email_alert_api::govuk_notify_template_id: '2844a647-6bf1-4b01-a25c-569d2cc00849'
 govuk::apps::email_alert_api::email_address_override: 'success@simulator.amazonses.com'
 govuk::apps::email_alert_api::email_address_override_whitelist_only: true
-govuk::apps::email_alert_api::delivery_request_threshold: 3000
+govuk::apps::email_alert_api::delivery_request_threshold: "3000"
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::kibana::logit_environment: d414187a-2796-4ea7-9b9a-d40c341646d6
 govuk::apps::link_checker_api::govuk_basic_auth_credentials: "%{hiera('http_username')}:%{hiera('http_password')}"

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -20,7 +20,7 @@ govuk::apps::email_alert_api::disable_govdelivery_emails: true
 govuk::apps::email_alert_api::use_email_alert_frontend_for_email_collection: true
 govuk::apps::email_alert_api::email_address_override: 'success@simulator.amazonses.com'
 govuk::apps::email_alert_api::email_address_override_whitelist_only: true
-govuk::apps::email_alert_api::delivery_request_threshold: 3000
+govuk::apps::email_alert_api::delivery_request_threshold: "3000"
 govuk::apps::govuk_crawler_worker::enabled: false
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
 govuk::apps::kibana::logit_environment: 2694f14b-6519-4607-81f2-8a2130e5aaec

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -21,7 +21,7 @@ govuk::apps::email_alert_api::govdelivery_public_hostname: 'stage-public.govdeli
 govuk::apps::email_alert_api::govuk_notify_template_id: '2844a647-6bf1-4b01-a25c-569d2cc00849'
 govuk::apps::email_alert_api::email_address_override: 'success@simulator.amazonses.com'
 govuk::apps::email_alert_api::email_address_override_whitelist_only: true
-govuk::apps::email_alert_api::delivery_request_threshold: 3000
+govuk::apps::email_alert_api::delivery_request_threshold: "3000"
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::kibana::logit_environment: d414187a-2796-4ea7-9b9a-d40c341646d6
 govuk::apps::link_checker_api::govuk_basic_auth_credentials: "%{hiera('http_username')}:%{hiera('http_password')}"


### PR DESCRIPTION
Following the deployment of this PR : https://github.com/alphagov/govuk-puppet/commit/fc142c9fedb5f187160c1a8d4774e833e6aafacf there have been a number of errors complaining that the `email_alert_api::delivery_request_threshold` env var is a number instead of a string. 

```
Could not retrieve catalog from remote server: Error 400 on SERVER: 3000 is not a string.  It looks to be a Fixnum ...
```