### PR TITLE
Add new machines for email-alert-api to LB

### DIFF
--- a/hieradata/class/backend.yaml
+++ b/hieradata/class/backend.yaml
@@ -5,6 +5,8 @@ govuk::apps::contacts::db_hostname: 'mysql-master-1.backend'
 govuk::apps::contacts::db_username: 'contacts'
 govuk::apps::contacts::db_password: "%{hiera('govuk::apps::contacts::db::mysql_contacts_admin')}"
 
+govuk::apps::email_alert_api::enable_procfile_worker: false
+
 govuk::apps::event_store::mongodb_servers:
   - 'mongo-1.backend'
   - 'mongo-2.backend'
@@ -47,6 +49,7 @@ govuk::apps::travel_advice_publisher::mongodb_nodes:
   - 'mongo-1.backend'
   - 'mongo-2.backend'
   - 'mongo-3.backend'
+
 
 govuk_elasticsearch::local_proxy::servers:
   - 'elasticsearch-1.backend'

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -166,6 +166,13 @@ govuk::node::s_backend_lb::backend_servers:
   - 'backend-1.backend'
   - 'backend-2.backend'
   - 'backend-3.backend'
+govuk::node::s_backend_lb::email_alert_api_backend_servers:
+  - 'backend-1.backend'
+  - 'backend-2.backend'
+  - 'backend-3.backend'
+  - 'email-alert-api-1.backend'
+  - 'email-alert-api-2.backend'
+  - 'email-alert-api-3.backend'
 govuk::node::s_backend_lb::performance_backend_servers:
   - 'performance-backend-1.backend'
   - 'performance-backend-2.backend'

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -119,6 +119,13 @@ govuk::node::s_backend_lb::backend_servers:
   - 'backend-1.backend'
   - 'backend-2.backend'
   - 'backend-3.backend'
+govuk::node::s_backend_lb::email_alert_api_backend_servers:
+  - 'backend-1.backend'
+  - 'backend-2.backend'
+  - 'backend-3.backend'
+  - 'email-alert-api-1.backend'
+  - 'email-alert-api-2.backend'
+  - 'email-alert-api-3.backend'
 govuk::node::s_backend_lb::performance_backend_servers:
   - 'performance-backend-1.backend'
   - 'performance-backend-2.backend'

--- a/hieradata/vagrant.yaml
+++ b/hieradata/vagrant.yaml
@@ -69,6 +69,11 @@ govuk::node::s_asset_base::firewall_allow_ip_range: '127.0.0.1'
 govuk::node::s_backend_lb::backend_servers:
   - 'backend-1.backend'
   - 'backend-2.backend'
+govuk::node::s_backend_lb::email_alert_api_backend_servers:
+  - 'backend-1.backend'
+  - 'backend-2.backend'
+  - 'email-alert-api-1.backend'
+  - 'email-alert-api-2.backend'
 govuk::node::s_backend_lb::whitehall_backend_servers:
   - 'whitehall-backend-1.backend'
   - 'whitehall-backend-2.backend'

--- a/modules/govuk/manifests/node/s_backend_lb.pp
+++ b/modules/govuk/manifests/node/s_backend_lb.pp
@@ -16,6 +16,9 @@
 # [*whitehall_backend_servers*]
 #   An array of whitehall backend app servers
 #
+# [*email_alert_api_backend_servers*]
+#   An array of email-alert-api backend app servers
+#
 # [*publishing_api_backend_servers*]
 #   An array of publishing-api backend app servers
 #
@@ -27,6 +30,7 @@ class govuk::node::s_backend_lb (
   $backend_servers,
   $performance_backend_servers = [],
   $whitehall_backend_servers,
+  $email_alert_api_backend_servers,
   $publishing_api_backend_servers,
   $maintenance_mode = false,
 ){
@@ -50,7 +54,6 @@ class govuk::node::s_backend_lb (
     'content-audit-tool',
     'content-performance-manager',
     'content-tagger',
-    'email-alert-api-public',
     'imminence',
     'link-checker-api',
     'local-links-manager',
@@ -74,7 +77,6 @@ class govuk::node::s_backend_lb (
   loadbalancer::balance { [
       'asset-manager',
       'canary-backend',
-      'email-alert-api',
       'event-store',
       'support-api',
     ]:
@@ -88,6 +90,15 @@ class govuk::node::s_backend_lb (
     ]:
       deny_crawlers => true,
       servers       => $whitehall_backend_servers,
+  }
+
+  loadbalancer::balance { 'email-alert-api':
+      internal_only => true,
+      servers       => unique(flatten([$backend_servers, $email_alert_api_backend_servers])),
+  }
+
+  loadbalancer::balance { 'email-alert-api-public':
+      servers       => unique(flatten([$backend_servers, $email_alert_api_backend_servers])),
   }
 
   loadbalancer::balance { 'publishing-api':


### PR DESCRIPTION
This commit adds new machines for email-alert-api to the load balancers and balances between the new and current machines.

We're adding these new machines since email-alert-api is using the majority of resources on the current backend machines and we'd like to give it space as well as reduce any possible impact on other backend apps. This is a result of the work to migrate all email sending to our own systems.

Depends on https://github.com/alphagov/govuk-provisioning/pull/41 and https://github.com/alphagov/govuk-aws/pull/494.

Trello: https://trello.com/c/oqi6Xvnu/629-move-email-alert-api-and-email-alert-service-to-dedicated-vms