### PR TITLE
Enable uuid-ossp Postgres extension on email-alert-api

### DIFF
--- a/hieradata/class/ci_agent.yaml
+++ b/hieradata/class/ci_agent.yaml
@@ -7,6 +7,7 @@ mongodb::server::replicaset_members:
 clamav::use_service: false
 
 govuk_ci::agent::postgresql::mapit_role_password: 'mapit'
+govuk_ci::agent::postgresql::email_alert_api_role_password: 'email-alert-api'
 postgresql::globals::version: '9.3'
 govuk_postgresql::server::enable_collectd: false
 

--- a/modules/govuk/manifests/apps/email_alert_api/db.pp
+++ b/modules/govuk/manifests/apps/email_alert_api/db.pp
@@ -23,5 +23,6 @@ class govuk::apps::email_alert_api::db (
     allow_auth_from_backend => true,
     backend_ip_range        => $backend_ip_range,
     rds                     => $rds,
+    extensions              => ['uuid-ossp'],
   }
 }

--- a/modules/govuk/manifests/apps/email_alert_api/db.pp
+++ b/modules/govuk/manifests/apps/email_alert_api/db.pp
@@ -23,6 +23,6 @@ class govuk::apps::email_alert_api::db (
     allow_auth_from_backend => true,
     backend_ip_range        => $backend_ip_range,
     rds                     => $rds,
-    extensions              => ['uuid-ossp'],
+    extensions              => ['plpgsql', 'uuid-ossp'],
   }
 }

--- a/modules/govuk_ci/manifests/agent/postgresql.pp
+++ b/modules/govuk_ci/manifests/agent/postgresql.pp
@@ -5,9 +5,14 @@
 # === Parameters
 #
 # [*mapit_role_password*]
+#  The password for the mapit role.
+#
+# [*email_alert_api_role_password*]
+#  The password for the email-alert-api role.
 #
 class govuk_ci::agent::postgresql (
   $mapit_role_password = undef,
+  $email_alert_api_role_password = undef,
 ) {
   contain ::govuk_postgresql::mirror
   include ::govuk_postgresql::server::standalone
@@ -16,17 +21,23 @@ class govuk_ci::agent::postgresql (
   include ::postgresql::lib::devel
 
   validate_slength($mapit_role_password, 20, 3)
+  validate_slength($email_alert_api_role_password, 20, 3)
 
   postgresql::server::role { 'jenkins':
     password_hash => postgresql_password('jenkins', 'jenkins'),
     createdb      => true,
   }
 
-  # The mapit role needs to be a superuser in order to load the PostGIS
-  # extension for the test database.
+  # The mapit role needs to be a superuser in order to load the PostGIS extension for the test database.
   postgresql::server::role { 'mapit':
     superuser     => true,
     password_hash => postgresql_password('mapit', $mapit_role_password);
+  }
+
+  # The emai-alert-api role needs to be superuser in order to load the uuid-ossp extension for the test databsase.
+  postgresql::server::role { 'email-alert-api':
+    superuser     => true,
+    password_hash => postgresql_password('email-alert-api', $email_alert_api_role_password);
   }
 
 }

--- a/modules/govuk_postgresql/manifests/db.pp
+++ b/modules/govuk_postgresql/manifests/db.pp
@@ -119,8 +119,9 @@ define govuk_postgresql::db (
         tag      => 'govuk_postgresql::server::not_slave',
     }
 
+    validate_array($extensions)
+
     if ! $rds {
-      validate_array($extensions)
       if (!empty($extensions)) {
           $temp_extensions = prefix($extensions,"${db_name}:")
           @govuk_postgresql::extension { $temp_extensions:
@@ -157,6 +158,13 @@ define govuk_postgresql::db (
     if ! $rds {
       collectd::plugin::postgresql_db{$db_name:}
       govuk_postgresql::monitoring::db{$db_name:}
+    }
+  } else {
+    if (!empty($extensions)) {
+      postgresql::server::extension { $extensions:
+        ensure   => present,
+        database => $db_name,
+      }
     }
   }
 }


### PR DESCRIPTION
We're going to be using this extension to generate UUID values within Postgres.

[Trello Card](https://trello.com/c/B8db764N/637-switch-some-of-our-primary-keys-from-id-to-uuid)