### PR TITLE
Reduce mirrrorer redis key prefix length

### DIFF
--- a/modules/govuk/manifests/apps/govuk_crawler_worker.pp
+++ b/modules/govuk/manifests/apps/govuk_crawler_worker.pp
@@ -76,7 +76,7 @@ class govuk::apps::govuk_crawler_worker (
       'REDIS_ADDRESS':
         value => '127.0.0.1:6379';
       'REDIS_KEY_PREFIX':
-        value => 'govuk_crawler_worker';
+        value => 'gcw';
       'ROOT_URLS':
         value => join($root_urls, ',');
       'MIRROR_ROOT':


### PR DESCRIPTION
This is to help reduce memory usage in redis.