### PR TITLE
Remove worker process from HMRC Manuals API

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -402,9 +402,6 @@ govuk::apps::government-frontend::nagios_memory_critical: 1000
 
 govuk::apps::govuk_cdn_logs_monitor::processed_data_dir: '/mnt/logs_cdn/data'
 
-govuk::apps::hmrc_manuals_api::redis_host: "%{hiera('sidekiq_host')}"
-govuk::apps::hmrc_manuals_api::redis_port: "%{hiera('sidekiq_port')}"
-
 govuk::apps::kibana::logit_account: 1c6b2316-16e2-4ca5-a3df-ff18631b0e74
 
 govuk::apps::link_checker_api::db_hostname: "postgresql-primary-1.backend"

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -110,7 +110,6 @@ govuk::apps::email_alert_service::rabbitmq_hosts: ['localhost']
 govuk::apps::event_store::enabled: true
 govuk::apps::event_store::mongodb_servers: ['localhost']
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
-govuk::apps::hmrc_manuals_api::enable_procfile_worker: false
 govuk::apps::government_frontend::enable_running_in_draft_mode::content_store: 'http://draft-content-store.dev.gov.uk'
 govuk::apps::govuk_cdn_logs_monitor::enabled: false
 govuk::apps::imminence::enable_procfile_worker: false

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -403,9 +403,6 @@ govuk::apps::government-frontend::nagios_memory_critical: 1000
 
 govuk::apps::govuk_cdn_logs_monitor::processed_data_dir: '/mnt/logs_cdn/data'
 
-govuk::apps::hmrc_manuals_api::redis_host: "%{hiera('sidekiq_host')}"
-govuk::apps::hmrc_manuals_api::redis_port: "%{hiera('sidekiq_port')}"
-
 govuk::apps::link_checker_api::db_hostname: "postgresql-primary"
 govuk::apps::link_checker_api::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 govuk::apps::link_checker_api::redis_host: "%{hiera('sidekiq_host')}"

--- a/modules/govuk/manifests/apps/hmrc_manuals_api.pp
+++ b/modules/govuk/manifests/apps/hmrc_manuals_api.pp
@@ -9,10 +9,6 @@
 #   The port that hmrc-manuals-api is served on.
 #   Default: 3071
 #
-# [*enable_procfile_worker*]
-#   Whether to enable the procfile worker
-#   Default: true
-#
 # [*allow_unknown_hmrc_manual_slugs*]
 #   Feature flag to allow publishing manuals (and their sections) with
 #   non-whitelisted manual slugs.
@@ -38,24 +34,14 @@
 #   The bearer token to use when communicating with Publishing API.
 #   Default: undef
 #
-# [*redis_host*]
-#   Redis host for sidekiq.
-#
-# [*redis_port*]
-#   Redis port for sidekiq.
-#   Default: undef
-#
 class govuk::apps::hmrc_manuals_api(
   $port = '3071',
-  $enable_procfile_worker = true,
   $sentry_dsn = undef,
   $allow_unknown_hmrc_manual_slugs = false,
   $oauth_id = undef,
   $oauth_secret = undef,
   $publish_topics = true,
   $publishing_api_bearer_token = undef,
-  $redis_host = undef,
-  $redis_port = undef,
 ) {
 
   Govuk::App::Envvar {
@@ -76,11 +62,6 @@ class govuk::apps::hmrc_manuals_api(
         varname => 'PUBLISH_TOPICS',
         value   => '1';
     }
-  }
-
-  govuk::app::envvar::redis { 'hmrc-manuals-api':
-    host => $redis_host,
-    port => $redis_port,
   }
 
   govuk::app::envvar {
@@ -104,7 +85,8 @@ class govuk::apps::hmrc_manuals_api(
     log_format_is_json => true,
   }
 
+  # FIXME - Remove this when it's been run in production
   govuk::procfile::worker {'hmrc-manuals-api':
-    enable_service => $enable_procfile_worker,
+    ensure         => 'absent',
   }
 }

--- a/modules/govuk/manifests/procfile/worker.pp
+++ b/modules/govuk/manifests/procfile/worker.pp
@@ -84,7 +84,7 @@ define govuk::procfile::worker (
       require => Exec["stop_service_${service_name}"],
     }
 
-    file { "/etc/init/${service_name}-child.conf":
+    file { "/etc/init/${service_name}_child.conf":
       ensure  => absent,
       require => Exec["stop_service_${service_name}"],
     }


### PR DESCRIPTION
It no longer uses sidekiq and doesn't actually need this process to be
running anymore.

/cc @h-lame 