### PR TITLE
Add email-alert-api node and IP addresses

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1181,6 +1181,12 @@ hosts::production::backend::hosts:
     ip: '10.1.3.16'
   elasticsearch-3:
     ip: '10.1.3.17'
+  email-alert-api-1:
+    ip: '10.1.3.40'
+  email-alert-api-2:
+    ip: '10.1.3.41'
+  email-alert-api-3:
+    ip: '10.1.3.42'
   mongo-1:
     ip: '10.1.3.6'
     service_aliases:

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -329,6 +329,12 @@ hosts::production::backend::hosts:
     ip: '10.3.3.16'
   elasticsearch-3:
     ip: '10.3.3.17'
+  email-alert-api-1:
+    ip: '10.3.3.40'
+  email-alert-api-2:
+    ip: '10.3.3.41'
+  email-alert-api-3:
+    ip: '10.3.3.42'
   mongo-1:
     ip: '10.3.3.6'
     service_aliases:

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -268,6 +268,12 @@ hosts::production::backend::hosts:
     ip: '10.2.3.16'
   elasticsearch-3:
     ip: '10.2.3.17'
+  email-alert-api-1:
+    ip: '10.2.3.40'
+  email-alert-api-2:
+    ip: '10.2.3.41'
+  email-alert-api-3:
+    ip: '10.2.3.42'
   mongo-1:
     ip: '10.2.3.6'
     service_aliases:

--- a/modules/govuk/manifests/node/s_email_alert_api.pp
+++ b/modules/govuk/manifests/node/s_email_alert_api.pp
@@ -1,0 +1,34 @@
+# == Class: govuk::node::email_alert_api
+#
+# Email Alert API machine definition. Email Alert API machines are used for running
+# the email alert API and email alert service applications and workers.
+#
+class govuk::node::s_email_alert_api inherits govuk::node::s_base {
+  include ::govuk_rbenv::all
+
+  limits::limits { 'root_nofile':
+    ensure     => present,
+    user       => 'root',
+    limit_type => 'nofile',
+    both       => 16384,
+  }
+
+  limits::limits { 'root_nproc':
+    ensure     => present,
+    user       => 'root',
+    limit_type => 'nproc',
+    both       => 1024,
+  }
+
+  include nginx
+
+  # If we miss all the apps, throw a 500 to be caught by the cache nginx
+  nginx::config::vhost::default { 'default': }
+
+  # Ensure memcached is available to backend nodes
+  include collectd::plugin::memcached
+  class { 'memcached':
+    max_memory => '12%',
+    listen_ip  => '127.0.0.1',
+  }
+}


### PR DESCRIPTION
This commit adds a new node type for email-alert-api and the IP addresses of the new email-alert-api machines in staging and production.

Trello: https://trello.com/c/oqi6Xvnu/629-move-email-alert-api-and-email-alert-service-to-dedicated-vms