### PR TITLE
Run Router in a container in Staging

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -721,6 +721,13 @@ govuk_containers::app::config::global_envvars:
   - "GOVUK_ASSET_ROOT=%{hiera('govuk::deploy::config::asset_root')}"
   - "GOVUK_WEBSITE_ROOT=%{hiera('govuk::deploy::config::website_root')}"
 
+govuk_containers::apps::router::envvars:
+  - "ROUTER_PUBADDR=localhost:3054"
+  - "ROUTER_APIADDR=:3055"
+  - "ROUTER_MONGO_DB=router"
+  - "ROUTER_MONGO_URL=router-backend-1,router-backend-2,router-backend-3"
+  - "ROUTER_BACKEND_HEADER_TIMEOUT=20s"
+
 govuk_crawler::alert_hostname: 'alert'
 govuk_crawler::amqp_host: 'localhost'
 govuk_crawler::site_root: 'https://www.gov.uk'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -90,6 +90,7 @@ govuk_mysql::server::slow_query_log: true
 govuk::node::s_asset_master::copy_attachments_hour: 7
 
 govuk::node::s_cache::real_ip_header: 'True-Client-Ip'
+govuk::node::s_cache::router_as_container: true
 govuk::node::s_monitoring::offsite_backups: false
 
 govuk_sudo::sudo_conf:

--- a/modules/govuk/manifests/node/s_cache.pp
+++ b/modules/govuk/manifests/node/s_cache.pp
@@ -30,15 +30,23 @@
 #
 #   Default: false
 #
+# [*router_as_container*]
+#   Set to true to run Router as a container in Docker.
+#
 class govuk::node::s_cache (
   $protect_cache_servers = false,
   $real_ip_header = undef,
   $denied_ip_addresses = undef,
   $enable_authenticating_proxy = false,
+  $router_as_container = false,
 ) inherits govuk::node::s_base {
 
   include govuk_htpasswd
   include router::gor
+
+  if $router_as_container {
+    include ::govuk_containers::apps::router
+  }
 
   class { 'nginx':
     denied_ip_addresses     => $denied_ip_addresses,


### PR DESCRIPTION
We are waiting on some other work to allow deployment of Router as the binary artefact, and this is blocking testing deployment of other apps.

An easy way around this is to deploy Router in a container, which we have prior art for.