### PR TITLE
Disable checks for Router on Docker

### DIFF
--- a/modules/govuk_containers/manifests/apps/router.pp
+++ b/modules/govuk_containers/manifests/apps/router.pp
@@ -7,12 +7,15 @@ class govuk_containers::apps::router (
   $port = '3054',
   $api_port = '3055',
   $envvars = [],
-  $healthcheck_path = '/healthcheck',
+  $healthcheck_path = undef,
+  $enable_ufw = false,
 ) {
   validate_array($envvars)
 
-  @ufw::allow { 'allow-router-reload-from-all':
-    port => $api_port,
+  if $enable_ufw {
+    @ufw::allow { 'allow-router-reload-from-all':
+      port => $api_port,
+    }
   }
 
   govuk_containers::app { 'router':
@@ -24,10 +27,11 @@ class govuk_containers::apps::router (
   # While we pass the port to the govuk_containers::app class, the container
   # appears to also expose the API port so we can do the healthcheck against
   # the API
-  @@icinga::check { "check_app_router_up_on_${::hostname}":
-    check_command       => "check_nrpe!check_app_up!${api_port} ${healthcheck_path}",
-    service_description => 'router app healthcheck',
-    host_name           => $::fqdn,
+  if $healthcheck_path {
+    @@icinga::check { "check_app_router_up_on_${::hostname}":
+      check_command       => "check_nrpe!check_app_up!${api_port} ${healthcheck_path}",
+      service_description => 'router app healthcheck',
+      host_name           => $::fqdn,
+    }
   }
-
 }


### PR DESCRIPTION
The UFW rule and healthcheck are provided by the default included class govuk::node::s_cache. Rather than try to ensure this is not included (which becomes complicated quickly), just ensure the resources that clash (UFW and Icinga checks) are not enabled.

This is a short-term change to work enable unblocking work and this class will not be used in the long-term, so is the safest place to make these changes.