### PR TITLE
Add email-alert-api and email-alert-service to new VMs

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -24,6 +24,7 @@ node_class: &node_class
       - content-audit-tool
       - content-performance-manager
       - content-tagger
+      # Remove the next two apps after migration to new servers
       - email-alert-api
       - email-alert-service
       - event-store
@@ -80,6 +81,10 @@ node_class: &node_class
       - manuals-frontend
       - service-manual-frontend
       - static
+  email_alert_api:
+    apps:
+      - email-alert-api
+      - email-alert-service
   frontend:
     apps:
       - canary-frontend

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -22,6 +22,7 @@ node_class: &node_class
       - content-audit-tool
       - content-performance-manager
       - content-tagger
+      # Remove the next two apps after migration to new servers
       - email-alert-api
       - email-alert-service
       - event-store
@@ -79,6 +80,10 @@ node_class: &node_class
       - manuals-frontend
       - service-manual-frontend
       - static
+  email_alert_api:
+    apps:
+      - email-alert-api
+      - email-alert-service
   frontend:
     apps:
       - canary-frontend


### PR DESCRIPTION
This commit adds the email-alert-api and email-alert-service apps to the new email-alert-api-* VMs.

Trello: https://trello.com/c/oqi6Xvnu/629-move-email-alert-api-and-email-alert-service-to-dedicated-vms