### PR TITLE
Increase icinga threshold for whitehall frontend CPU alert

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -95,6 +95,8 @@ govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-eve
 govuk::apps::support_api::pp_data_url: 'https://www.performance.service.gov.uk'
 govuk::apps::support_api::zendesk_anonymous_ticket_email: 'zd-api-public@digital.cabinet-office.gov.uk'
 govuk::apps::travel_advice_publisher::enable_email_alerts: true
+govuk::apps::whitehall::cpu_warning: 400
+govuk::apps::whitehall::cpu_critical: 600
 
 govuk::deploy::actionmailer_enable_delivery: true
 

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -37,6 +37,8 @@ govuk::apps::short_url_manager::instance_name: 'staging'
 govuk::apps::signon::instance_name: 'staging'
 govuk::apps::support_api::pp_data_url: 'https://www.staging.performance.service.gov.uk'
 govuk::apps::travel_advice_publisher::enable_email_alerts: true
+govuk::apps::whitehall::cpu_warning: 400
+govuk::apps::whitehall::cpu_critical: 600
 
 govuk::deploy::aws_ses_smtp_host: 'email-smtp.eu-west-1.amazonaws.com'
 govuk::deploy::config::errbit_environment_name: 'staging'

--- a/modules/govuk/manifests/app.pp
+++ b/modules/govuk/manifests/app.pp
@@ -220,6 +220,13 @@
 #   don't set the env var, and use on govuk_app_config's default value.
 #   Default: undef
 #
+# [*cpu_warning*]
+#   CPU usage percentage that alerts are sounded at
+#   Default: undef
+#
+# [*cpu_critical*]
+#   CPU usage percentage that alerts are sounded at
+#
 define govuk::app (
   $app_type,
   $port = 0,
@@ -251,6 +258,8 @@ define govuk::app (
   $repo_name = undef,
   $sentry_dsn = undef,
   $unicorn_worker_processes = undef,
+  $cpu_warning = 150,
+  $cpu_critical = 200,
 ) {
 
   if ! ($app_type in ['procfile', 'rack', 'bare']) {
@@ -321,6 +330,8 @@ define govuk::app (
     sentry_dsn                     => $sentry_dsn,
     proxy_http_version_1_1_enabled => $proxy_http_version_1_1_enabled,
     unicorn_worker_processes       => $unicorn_worker_processes,
+    cpu_warning                    => $cpu_warning,
+    cpu_critical                   => $cpu_critical,
   }
 
   govuk::app::service { $title:

--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -25,6 +25,13 @@
 #   don't set the env var, and use on govuk_app_config's default value.
 #   Default: undef
 #
+# [*cpu_warning*]
+#   CPU usage percentage that alerts are sounded at
+#   Default: undef
+#
+# [*cpu_critical*]
+#   CPU usage percentage that alerts are sounded at
+#
 define govuk::app::config (
   $app_type,
   $domain,
@@ -54,6 +61,8 @@ define govuk::app::config (
   $proxy_http_version_1_1_enabled = false,
   $sentry_dsn = undef,
   $unicorn_worker_processes = undef,
+  $cpu_warning = 150,
+  $cpu_critical = 200,
 ) {
   $ensure_directory = $ensure ? {
     'present' => 'directory',
@@ -235,8 +244,8 @@ define govuk::app::config (
     @@icinga::check::graphite { "check_${title}_app_cpu_usage${::hostname}":
       ensure    => $ensure,
       target    => "scale(sumSeries(${::fqdn_metrics}.processes-app-${title_underscore}.ps_cputime.*),0.0001)",
-      warning   => 150,
-      critical  => 200,
+      warning   => $cpu_warning,
+      critical  => $cpu_critical,
       desc      => "high CPU usage for ${title} app",
       host_name => $::fqdn,
     }

--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -108,6 +108,13 @@
 # [*email_alert_api_bearer_token*]
 #   Bearer token for communication with the email-alert-api
 #
+# [*cpu_warning*]
+#   CPU usage percentage that alerts are sounded at
+#   Default: undef
+#
+# [*cpu_critical*]
+#   CPU usage percentage that alerts are sounded at
+#
 class govuk::apps::whitehall(
   $admin_db_name = undef,
   $admin_db_hostname = undef,
@@ -142,6 +149,8 @@ class govuk::apps::whitehall(
   $jwt_auth_secret = undef,
   $co_nss_watchkeeper_email_address = undef,
   $link_checker_api_secret_token = undef,
+  $cpu_warning = 150,
+  $cpu_critical = 200,
 ) {
 
   $app_name = 'whitehall'
@@ -179,6 +188,8 @@ class govuk::apps::whitehall(
     unicorn_herder_timeout   => 45,
     require                  => Package['unzip'],
     unicorn_worker_processes => $unicorn_worker_processes,
+    cpu_warning              => $cpu_warning,
+    cpu_critical             => $cpu_critical,
   }
 
   Govuk::App::Envvar {


### PR DESCRIPTION
We are getting lots of alerts from whitehall frontend when the CPU usage goes
pass the current thresholds, however this server has 8 CPU and as such the
default thresholds don't make much sense. I have set this up so that staging
and prod are configures with higher thresholds.

I have initentionally not updated AWS data as this will need to be reviewed
once the new machine are started and we are better off getting false positives
on these alarms (i.e. leave it with the lower threshold to begin with)