### PR TITLE
Adds docs for mongo

### DIFF
--- a/modules/mongodb/manifests/backup.pp
+++ b/modules/mongodb/manifests/backup.pp
@@ -89,6 +89,7 @@ class mongodb::backup(
       service_description => $service_desc,
       freshness_threshold => $threshold_secs,
       host_name           => $::fqdn,
+      notes_url           => monitoring_docs_url(low-space-for-automongodbbackup),
     }
   }
 

--- a/modules/mongodb/manifests/monitoring.pp
+++ b/modules/mongodb/manifests/monitoring.pp
@@ -70,5 +70,6 @@ class mongodb::monitoring (
     check_command       => 'check_nrpe!check_mongodb!replset_state',
     service_description => 'mongod replset state',
     host_name           => $::fqdn,
+    notes_url           => monitoring_docs_url(recreate-a-mongo-instance-in-aws),
   }
 }


### PR DESCRIPTION
This will add docs for two Icinga alerts:

1. Repairing a mongodb cluster - this already had a doc written up and just need to be hooked up. 
2. Mongo DB backups running out of space - this also required a new [PR in govuk-developer-docs](https://github.com/alphagov/govuk-developer-docs/pull/735)