### PR TITLE
Use external GOV.UK Jenkins library

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,9 +2,9 @@
 
 REPOSITORY = 'govuk-puppet'
 
-node {
-  def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
+library("govuk")
 
+node {
   properties([
     buildDiscarder(logRotator(numToKeepStr: '50')),
   ])


### PR DESCRIPTION
This uses the library defined in [the external Jenkins library](https://github.com/alphagov/govuk-jenkinslib) hosted in an external repository.

The library is implicitly loaded as defined in the Jenkins configuration.

If the library is not implicitly loaded, then the following would need to be defined in each `Jenkinsfile`:

`library("govuk")`

I am not sure on which approach I prefer - the second approach would allow you specify specific branches if you wanted to test changes in the Groovy library, but the first means you don't have to worry about specifying it all.

https://trello.com/c/88RFcs4R/994-make-jenkinslibgroovy-its-own-repo-refactor

Relates to https://github.com/alphagov/govuk-puppet/pull/7282 which will define the library in Jenkins itself.