### PR TITLE
Fixes puppet error with RabbitMQ in VM for CPM

### DIFF
--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -103,7 +103,7 @@ govuk::apps::content_store::mongodb_nodes: ['localhost']
 govuk::apps::content_store::mongodb_name: 'content_store_development'
 govuk::apps::content_performance_manager::rabbitmq_user: 'content_performance_manager'
 govuk::apps::content_performance_manager::rabbitmq_hosts: ['localhost']
-
+govuk::apps::content_performance_manager::rabbitmq::amqp_pass: 'content_performance_manager'
 govuk::apps::content_tagger::enable_procfile_worker: false
 govuk::apps::email_alert_api::enable_procfile_worker: false
 govuk::apps::email_alert_service::rabbitmq_hosts: ['localhost']


### PR DESCRIPTION
Puppet was failing with this error in the VM

```
Error: Validation of Rabbitmq_user[content_performance_manager] failed: must set password when creating user at /var/govuk/govuk-puppet/modules/govuk_rabbitmq/manifests/consumer.pp:40
```

This PR fixes this problem by setting the password in the `development.yaml`. This is consistent with the way the password is set in integration, staging and production.
