### PR TITLE
Mongodb dailybackup storage

### DIFF
--- a/hieradata/class/mongo.yaml
+++ b/hieradata/class/mongo.yaml
@@ -10,6 +10,7 @@ lv:
     pv:
       - '/dev/sdb1'
       - '/dev/sdd1'
+      - '/dev/sdf1'
     vg: 'backup'
   data:
     pv: '/dev/sdc1'


### PR DESCRIPTION
- We have added a 32GB disk called /dev/sdf1 to
  '/var/lib/automongodbbackup'. This was done to accomodate the current
storage requirement.

Solo: @suthagarht