### PR TITLE
[DO NOT MERGE] Remove email-alert apps from backend servers

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -24,9 +24,6 @@ node_class: &node_class
       - content-audit-tool
       - content-performance-manager
       - content-tagger
-      # Remove the next two apps after migration to new servers
-      - email-alert-api
-      - email-alert-service
       - event-store
       - hmrc-manuals-api
       - imminence

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -22,9 +22,6 @@ node_class: &node_class
       - content-audit-tool
       - content-performance-manager
       - content-tagger
-      # Remove the next two apps after migration to new servers
-      - email-alert-api
-      - email-alert-service
       - event-store
       - hmrc-manuals-api
       - imminence


### PR DESCRIPTION
This commit removes email-alert-api and email-alert-service from the backend servers since they are now served by their own servers.

Trello: https://trello.com/c/oqi6Xvnu/629-move-email-alert-api-and-email-alert-service-to-dedicated-vms