### PR TITLE
Remove email-alert apps from backend servers/LBs

### DIFF
--- a/hieradata/class/backend.yaml
+++ b/hieradata/class/backend.yaml
@@ -6,6 +6,8 @@ govuk::apps::contacts::db_username: 'contacts'
 govuk::apps::contacts::db_password: "%{hiera('govuk::apps::contacts::db::mysql_contacts_admin')}"
 
 govuk::apps::email_alert_api::enable_procfile_worker: false
+govuk::apps::email_alert_api::ensure: 'absent'
+govuk::apps::email_alert_service::ensure: 'absent'
 
 govuk::apps::event_store::mongodb_servers:
   - 'mongo-1.backend'
@@ -49,7 +51,6 @@ govuk::apps::travel_advice_publisher::mongodb_nodes:
   - 'mongo-1.backend'
   - 'mongo-2.backend'
   - 'mongo-3.backend'
-
 
 govuk_elasticsearch::local_proxy::servers:
   - 'elasticsearch-1.backend'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -24,9 +24,6 @@ node_class: &node_class
       - content-audit-tool
       - content-performance-manager
       - content-tagger
-      # Remove the next two apps after migration to new servers
-      - email-alert-api
-      - email-alert-service
       - event-store
       - hmrc-manuals-api
       - imminence

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -169,9 +169,6 @@ govuk::node::s_backend_lb::backend_servers:
   - 'backend-2.backend'
   - 'backend-3.backend'
 govuk::node::s_backend_lb::email_alert_api_backend_servers:
-  - 'backend-1.backend'
-  - 'backend-2.backend'
-  - 'backend-3.backend'
   - 'email-alert-api-1.backend'
   - 'email-alert-api-2.backend'
   - 'email-alert-api-3.backend'

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -122,9 +122,6 @@ govuk::node::s_backend_lb::backend_servers:
   - 'backend-2.backend'
   - 'backend-3.backend'
 govuk::node::s_backend_lb::email_alert_api_backend_servers:
-  - 'backend-1.backend'
-  - 'backend-2.backend'
-  - 'backend-3.backend'
   - 'email-alert-api-1.backend'
   - 'email-alert-api-2.backend'
   - 'email-alert-api-3.backend'

--- a/hieradata/vagrant.yaml
+++ b/hieradata/vagrant.yaml
@@ -70,8 +70,6 @@ govuk::node::s_backend_lb::backend_servers:
   - 'backend-1.backend'
   - 'backend-2.backend'
 govuk::node::s_backend_lb::email_alert_api_backend_servers:
-  - 'backend-1.backend'
-  - 'backend-2.backend'
   - 'email-alert-api-1.backend'
   - 'email-alert-api-2.backend'
 govuk::node::s_backend_lb::whitehall_backend_servers:

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -22,9 +22,6 @@ node_class: &node_class
       - content-audit-tool
       - content-performance-manager
       - content-tagger
-      # Remove the next two apps after migration to new servers
-      - email-alert-api
-      - email-alert-service
       - event-store
       - hmrc-manuals-api
       - imminence

--- a/modules/govuk/manifests/apps/email_alert_api.pp
+++ b/modules/govuk/manifests/apps/email_alert_api.pp
@@ -8,6 +8,11 @@
 # [*port*]
 #   What port should the app run on?
 #
+# [*ensure*]
+#   Should the application be present or absent. Used for transitioning from
+#   backend servers to own servers.
+#   Default: present
+#
 # [*enabled*]
 #   Should the application should be enabled. Set in hiera data for each
 #   environment.
@@ -44,7 +49,7 @@
 #   the notify based one) is in operation.
 #   Default: false
 #
-# [*use_email_alert_frontend_for_email_collection]
+# [*use_email_alert_frontend_for_email_collection*]
 #   If set, users will be redirected to email-alert-frontend to enter their
 #   email address instead of govdelivery. This affects the `subscription_url`
 #   in responses from the Email Alert API which is used by `collections`,
@@ -110,6 +115,7 @@
 #
 class govuk::apps::email_alert_api(
   $port = '3088',
+  $ensure = 'present',
   $enabled = false,
   $enable_public_proxy = true,
   $enable_procfile_worker = true,
@@ -151,6 +157,7 @@ class govuk::apps::email_alert_api(
 
   if $enabled {
     govuk::app { 'email-alert-api':
+      ensure             => $ensure,
       app_type           => 'rack',
       port               => $port,
       sentry_dsn         => $sentry_dsn,
@@ -162,6 +169,7 @@ class govuk::apps::email_alert_api(
     include govuk_postgresql::client #installs libpq-dev package needed for pg gem
 
     govuk::procfile::worker {'email-alert-api':
+      ensure         => $ensure,
       enable_service => $enable_procfile_worker,
     }
 

--- a/modules/govuk/manifests/apps/email_alert_service.pp
+++ b/modules/govuk/manifests/apps/email_alert_service.pp
@@ -5,6 +5,11 @@
 #
 # === Parameters
 #
+# [*ensure*]
+#   Should the application be present or absent. Used for transitioning from
+#   backend servers to own servers.
+#   Default: present
+#
 # [*enabled*]
 #   Should the application should be enabled. Set in hiera data for each
 #   environment.
@@ -29,6 +34,7 @@
 #   Bearer token for communication with the email-alert-api
 #
 class govuk::apps::email_alert_service(
+  $ensure = 'present',
   $rabbitmq_hosts = ['localhost'],
   $rabbitmq_user = 'email_alert_service',
   $rabbitmq_password = 'email_alert_service',
@@ -37,6 +43,7 @@ class govuk::apps::email_alert_service(
   $email_alert_api_bearer_token = undef,
 ) {
   govuk::app { 'email-alert-service':
+    ensure             => $ensure,
     app_type           => 'bare',
     enable_nginx_vhost => false,
     sentry_dsn         => $sentry_dsn,

--- a/modules/govuk/manifests/node/s_backend_lb.pp
+++ b/modules/govuk/manifests/node/s_backend_lb.pp
@@ -94,11 +94,11 @@ class govuk::node::s_backend_lb (
 
   loadbalancer::balance { 'email-alert-api':
       internal_only => true,
-      servers       => unique(flatten([$backend_servers, $email_alert_api_backend_servers])),
+      servers       => $email_alert_api_backend_servers,
   }
 
   loadbalancer::balance { 'email-alert-api-public':
-      servers       => unique(flatten([$backend_servers, $email_alert_api_backend_servers])),
+      servers       => $email_alert_api_backend_servers,
   }
 
   loadbalancer::balance { 'publishing-api':


### PR DESCRIPTION
This commit removes email-alert-api and email-alert-service from the backend servers and removes the backend servers from the list of servers to load balance for those apps.

Trello: https://trello.com/c/oqi6Xvnu/629-move-email-alert-api-and-email-alert-service-to-dedicated-vms