### PR TITLE
Clean-up config for email alert apps

### DIFF
--- a/hieradata/class/backend.yaml
+++ b/hieradata/class/backend.yaml
@@ -5,10 +5,6 @@ govuk::apps::contacts::db_hostname: 'mysql-master-1.backend'
 govuk::apps::contacts::db_username: 'contacts'
 govuk::apps::contacts::db_password: "%{hiera('govuk::apps::contacts::db::mysql_contacts_admin')}"
 
-govuk::apps::email_alert_api::enable_procfile_worker: false
-govuk::apps::email_alert_api::ensure: 'absent'
-govuk::apps::email_alert_service::ensure: 'absent'
-
 govuk::apps::event_store::mongodb_servers:
   - 'mongo-1.backend'
   - 'mongo-2.backend'

--- a/modules/govuk/manifests/apps/email_alert_api.pp
+++ b/modules/govuk/manifests/apps/email_alert_api.pp
@@ -8,11 +8,6 @@
 # [*port*]
 #   What port should the app run on?
 #
-# [*ensure*]
-#   Should the application be present or absent. Used for transitioning from
-#   backend servers to own servers.
-#   Default: present
-#
 # [*enabled*]
 #   Should the application should be enabled. Set in hiera data for each
 #   environment.
@@ -115,7 +110,6 @@
 #
 class govuk::apps::email_alert_api(
   $port = '3088',
-  $ensure = 'present',
   $enabled = false,
   $enable_public_proxy = true,
   $enable_procfile_worker = true,
@@ -157,7 +151,6 @@ class govuk::apps::email_alert_api(
 
   if $enabled {
     govuk::app { 'email-alert-api':
-      ensure             => $ensure,
       app_type           => 'rack',
       port               => $port,
       sentry_dsn         => $sentry_dsn,
@@ -169,7 +162,6 @@ class govuk::apps::email_alert_api(
     include govuk_postgresql::client #installs libpq-dev package needed for pg gem
 
     govuk::procfile::worker {'email-alert-api':
-      ensure         => $ensure,
       enable_service => $enable_procfile_worker,
     }
 

--- a/modules/govuk/manifests/apps/email_alert_service.pp
+++ b/modules/govuk/manifests/apps/email_alert_service.pp
@@ -5,11 +5,6 @@
 #
 # === Parameters
 #
-# [*ensure*]
-#   Should the application be present or absent. Used for transitioning from
-#   backend servers to own servers.
-#   Default: present
-#
 # [*enabled*]
 #   Should the application should be enabled. Set in hiera data for each
 #   environment.
@@ -34,7 +29,6 @@
 #   Bearer token for communication with the email-alert-api
 #
 class govuk::apps::email_alert_service(
-  $ensure = 'present',
   $rabbitmq_hosts = ['localhost'],
   $rabbitmq_user = 'email_alert_service',
   $rabbitmq_password = 'email_alert_service',
@@ -43,7 +37,6 @@ class govuk::apps::email_alert_service(
   $email_alert_api_bearer_token = undef,
 ) {
   govuk::app { 'email-alert-service':
-    ensure             => $ensure,
     app_type           => 'bare',
     enable_nginx_vhost => false,
     sentry_dsn         => $sentry_dsn,


### PR DESCRIPTION
This commit cleans up config for email-alert-api and email-alert-service that was added to aid their migration to separate VMs.

Trello: https://trello.com/c/oqi6Xvnu/629-move-email-alert-api-and-email-alert-service-to-dedicated-vms