### PR TITLE
Create an extension with quotes around the name

### DIFF
--- a/modules/govuk_postgresql/manifests/extension.pp
+++ b/modules/govuk_postgresql/manifests/extension.pp
@@ -19,7 +19,7 @@ define govuk_postgresql::extension {
         $db = $extracted_title[0]
         $extension = $extracted_title[1]
         exec {"Load ${extension} for Postgres DB: ${db}":
-            command => "psql -d ${db} -c 'CREATE EXTENSION IF NOT EXISTS ${extension}'",
+            command => "psql -d ${db} -c 'CREATE EXTENSION IF NOT EXISTS \"${extension}\"'",
             unless  => "psql -d ${db} -c '\\dx' | grep -q ${extension}",
             user    => 'postgres',
             require => [Class['postgresql::server::contrib'], Postgresql::Server::Db[$db]],


### PR DESCRIPTION
When trying to install the extension 'uuid-ossp' this failed because of the dash in the name, but if we use quotes this should succeed.