### PR TITLE
Simplify the govuk_taxonomy_supervised_learning Jenkins job

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/govuk_taxonomy_supervised_learning.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/govuk_taxonomy_supervised_learning.yaml.erb
@@ -24,21 +24,10 @@
           #!/bin/bash
           git checkout -B ${GIT_BRANCH} origin/${GIT_BRANCH}
 
-          rm -rf ./venv
-          virtualenv --python=python3 --no-site-packages ./venv
-          export VIRTUAL_ENV="$PWD/venv"
-          export PATH="$PWD/venv/bin:$PATH"
-          pip3 install --upgrade pip
-
-          make pip_install
-
           export PLEK_SERVICE_RUMMAGER_URI=https://<%= @rummager_api %>
           export PLEK_SERVICE_DRAFT_CONTENT_STORE_URI=https://<%= @draft_content_store_api %>
 
-          make clean
-          make data/taxons.json.gz
-          make data/content.json.gz
-          make measure_average_taxons
+          source bin/govuk_taxonomy_supervised_learning_jenkins_script
     parameters:
         - string:
             name: GIT_BRANCH


### PR DESCRIPTION
Most of the stuff is worth keeping in the
govuk-taxonomy-supervised-learning repository, so that it's easier to change.

This depends on the changes in https://github.com/alphagov/govuk-taxonomy-supervised-learning/pull/80