### PR TITLE
Add measuring average taxons to taxonomy pipeline jenkins job

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/govuk_taxonomy_supervised_learning.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/govuk_taxonomy_supervised_learning.yaml.erb
@@ -38,6 +38,7 @@
           make clean
           make data/taxons.json.gz
           make data/content.json.gz
+          make measure_average_taxons
     parameters:
         - string:
             name: GIT_BRANCH


### PR DESCRIPTION
trello: https://trello.com/c/4GiJH8d6/7-visualise-average-number-of-taxons-associated-with-a-content-item-in-grafana