### PR TITLE
Fix the data_sync_complete job to rewrite to blue.staging.

### DIFF
--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -72,7 +72,7 @@ govuk_jenkins::jobs::smokey::smokey_task: 'test:staging'
 govuk_jenkins::jobs::data_sync_complete_staging::signon_domains_to_migrate:
   -
     old: publishing.service.gov.uk
-    new: staging.publishing.service.gov.uk
+    new: blue.staging.govuk.digital
   -
     old: performance.service.gov.uk
     new: staging.performance.service.gov.uk


### PR DESCRIPTION
When data is synced from production, some of the DBs need tweaking to correct the production domain to the staging domain.