### PR TITLE
Add email_alert_api machine class to Jenkins

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/run_rake_task.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/run_rake_task.yaml.erb
@@ -27,6 +27,7 @@
             - draft_cache
             - draft_content_store
             - draft_frontend
+            - email_alert_api
             - frontend
             - router_backend
             - publishing_api


### PR DESCRIPTION
This commit adds the new `email_alert_api` machine class to the Jenkins job for running rake tasks.

Trello: https://trello.com/c/oqi6Xvnu/629-move-email-alert-api-and-email-alert-service-to-dedicated-vms