### PR TITLE
Proxy API docs for content performance API to github pages

### DIFF
--- a/modules/govuk/manifests/node/s_backend_lb.pp
+++ b/modules/govuk/manifests/node/s_backend_lb.pp
@@ -128,4 +128,9 @@ class govuk::node::s_backend_lb (
     to        => ['alphagov.github.io'],
     protected => false,
   }
+
+  nginx::config::vhost::proxy { "content-performance-api.${app_domain}" :
+    to        => ['alphagov.github.io'],
+    protected => false,
+  }
 }


### PR DESCRIPTION
We're setting up a new API for content performance manager.

This needs further configuration, but this part tells nginx to proxy the request to github pages.

See also: https://github.com/alphagov/govuk-dns-config/pull/54
Trello: https://trello.com/c/qZppXq2l/134-setup-the-api-documentation-technical-stuff