### PR TITLE
Add govuk-aws to the list of repos to clone

### DIFF
--- a/development-vm/alphagov_repos
+++ b/development-vm/alphagov_repos
@@ -15,6 +15,7 @@ finder-frontend
 frontend
 gds-api-adapters
 government-frontend
+govuk-aws
 govuk-content-schema-test-helpers
 govuk-content-schemas
 govuk-puppet


### PR DESCRIPTION
This commit adds `govuk-aws` to the list of repos to be cloned when a new starter follows the get started page in the developer docs. This allows them to use `govukcli` to access AWS servers in integration.