### PR TITLE
Add a jenkins job to clear the frontend caches

### DIFF
--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -8,6 +8,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::check_content_consistency
   - govuk_jenkins::jobs::check_content_store
   - govuk_jenkins::jobs::check_pingdom_ip_ranges
+  - govuk_jenkins::jobs::clear_frontend_caches
   - govuk_jenkins::jobs::content_audit_tool
   - govuk_jenkins::jobs::content_performance_manager
   - govuk_jenkins::jobs::copy_data_to_integration

--- a/hieradata/class/staging/jenkins.yaml
+++ b/hieradata/class/staging/jenkins.yaml
@@ -2,6 +2,7 @@
 govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::check_content_consistency
   - govuk_jenkins::jobs::check_content_store
+  - govuk_jenkins::jobs::clear_frontend_caches
   - govuk_jenkins::jobs::content_performance_manager
   - govuk_jenkins::jobs::data_sync_complete_staging
   - govuk_jenkins::jobs::deploy_app

--- a/hieradata_aws/class/jenkins.yaml
+++ b/hieradata_aws/class/jenkins.yaml
@@ -60,6 +60,7 @@ govuk_jenkins::config::theme_environment_name: 'AWS Integration'
 govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::check_content_consistency
   - govuk_jenkins::jobs::check_content_store
+  - govuk_jenkins::jobs::clear_frontend_caches
   - govuk_jenkins::jobs::configure_github_repos
   - govuk_jenkins::jobs::data_sync_complete_integration
   - govuk_jenkins::jobs::deploy_app

--- a/modules/govuk_jenkins/manifests/jobs/clear_frontend_caches.pp
+++ b/modules/govuk_jenkins/manifests/jobs/clear_frontend_caches.pp
@@ -1,0 +1,12 @@
+# == Class: govuk_jenkins::jobs::clear_frontend_caches
+#
+# Create a file on disk that can be parsed by jenkins-job-builder
+#
+class govuk_jenkins::jobs::clear_frontend_caches {
+
+  file { '/etc/jenkins_jobs/jobs/clear_frontend_caches.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/clear_frontend_caches.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+}

--- a/modules/govuk_jenkins/templates/jobs/clear_frontend_caches.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/clear_frontend_caches.yaml.erb
@@ -1,0 +1,23 @@
+---
+- job:
+    name: clear-frontend-caches
+    display-name: Clear the frontend caches
+    project-type: freestyle
+    description: "Clears the application caches for all frontend applications"
+    builders:
+      - shell: |
+          #!/usr/bin/env bash
+
+          <% {
+            frontend: %w[collections email-alert-frontend feedback frontend government-frontend info-frontend manuals-frontend service-manual-frontend static],
+            whitehall_frontend: %w[whitehall],
+            calculators_frontend: %w[calculators calendars finder-frontend licencefinder smartanswers],
+          }.each do |class_name, apps| %>
+          <% apps.each do |app_name| %>
+          ssh deploy@$(govuk_node_list -c <%= class_name %> --single-node) "cd /var/apps/<%= app_name %> && govuk_setenv <%= app_name %> bundle exec bundle exec rails runner 'puts Rails.cache.clear'"
+          <% end %>
+          <% end %>
+
+    wrappers:
+      - ansicolor:
+          colormap: xterm


### PR DESCRIPTION
This is intended to be used as a downstream task for the emergency publishing.

Part of improvements during a emergency publishing drill: https://trello.com/c/ktLcZLIN