### PR TITLE
Increase unicorn workers for Email Alert API

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -598,6 +598,7 @@ govuk::apps::specialist_publisher::redis_port: "%{hiera('sidekiq_port')}"
 
 govuk::apps::smartanswers::nagios_memory_warning: 4000
 govuk::apps::smartanswers::nagios_memory_critical: 4500
+govuk::apps::smartanswers::unicorn_worker_processes: "4"
 
 govuk::apps::smokey::http_username: "%{hiera('http_username')}"
 govuk::apps::smokey::http_password: "%{hiera('http_password')}"

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -383,6 +383,7 @@ govuk::apps::email_alert_api::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::email_alert_api::db_hostname: 'postgresql-primary-1.backend'
 govuk::apps::email_alert_api::db_password: "%{hiera('govuk::apps::email_alert_api::db::password')}"
 govuk::apps::email_alert_api::govuk_notify_rate_per_worker: '12'
+govuk::apps::email_alert_api::unicorn_worker_processes: '4'
 
 govuk::apps::email_alert_service::rabbitmq_hosts:
   - rabbitmq-1.backend

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -388,6 +388,7 @@ govuk::apps::email_alert_api::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::email_alert_api::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::email_alert_api::db_hostname: 'postgresql-primary'
 govuk::apps::email_alert_api::db_password: "%{hiera('govuk::apps::email_alert_api::db::password')}"
+govuk::apps::email_alert_api::unicorn_worker_processes: '4'
 
 govuk::apps::email_alert_service::rabbitmq_hosts:
   - rabbitmq

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -591,6 +591,7 @@ govuk::apps::specialist_publisher::redis_port: "%{hiera('sidekiq_port')}"
 
 govuk::apps::smartanswers::nagios_memory_warning: 4000
 govuk::apps::smartanswers::nagios_memory_critical: 4500
+govuk::apps::smartanswers::unicorn_worker_processes: "4"
 
 govuk::apps::smokey::http_username: "%{hiera('http_username')}"
 govuk::apps::smokey::http_password: "%{hiera('http_password')}"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -388,6 +388,7 @@ govuk::apps::email_alert_api::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::email_alert_api::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::email_alert_api::db_hostname: 'postgresql-primary'
 govuk::apps::email_alert_api::db_password: "%{hiera('govuk::apps::email_alert_api::db::password')}"
+govuk::apps::email_alert_api::govuk_notify_rate_per_worker: '12'
 govuk::apps::email_alert_api::unicorn_worker_processes: '4'
 
 govuk::apps::email_alert_service::rabbitmq_hosts:

--- a/modules/govuk/manifests/apps/email_alert_api.pp
+++ b/modules/govuk/manifests/apps/email_alert_api.pp
@@ -108,6 +108,9 @@
 # [*delivery_request_threshold*]
 #   Configure the number of requests that the rate limit will allow to be made in one minute.
 #
+# [*unicorn_worker_processes*]
+#   The number of unicorn workers to run for an instance of this app
+#
 class govuk::apps::email_alert_api(
   $port = '3088',
   $enabled = false,
@@ -147,16 +150,18 @@ class govuk::apps::email_alert_api(
   $db_password = undef,
   $db_hostname = undef,
   $db_name = 'email-alert-api_production',
+  $unicorn_worker_processes = undef,
 ) {
 
   if $enabled {
     govuk::app { 'email-alert-api':
-      app_type           => 'rack',
-      port               => $port,
-      sentry_dsn         => $sentry_dsn,
-      log_format_is_json => true,
-      health_check_path  => '/healthcheck',
-      json_health_check  => true,
+      app_type                 => 'rack',
+      port                     => $port,
+      sentry_dsn               => $sentry_dsn,
+      log_format_is_json       => true,
+      health_check_path        => '/healthcheck',
+      json_health_check        => true,
+      unicorn_worker_processes => $unicorn_worker_processes,
     }
 
     include govuk_postgresql::client #installs libpq-dev package needed for pg gem

--- a/modules/govuk/manifests/apps/smartanswers.pp
+++ b/modules/govuk/manifests/apps/smartanswers.pp
@@ -35,6 +35,9 @@
 # [*secret_key_base*]
 #   The key for Rails to use when signing/encrypting sessions.
 #
+# [*unicorn_worker_processes*]
+#   The number of unicorn workers to run for an instance of this app
+#
 class govuk::apps::smartanswers(
   $port = '3010',
   $expose_govspeak = false,
@@ -44,6 +47,7 @@ class govuk::apps::smartanswers(
   $nagios_memory_warning = undef,
   $nagios_memory_critical = undef,
   $secret_key_base = undef,
+  $unicorn_worker_processes = undef,
 ) {
   Govuk::App::Envvar {
     app => 'smartanswers',
@@ -75,17 +79,18 @@ class govuk::apps::smartanswers(
   }
 
   govuk::app { 'smartanswers':
-    app_type                => 'rack',
-    port                    => $port,
-    sentry_dsn              => $sentry_dsn,
-    health_check_path       => '/pay-leave-for-parents',
-    log_format_is_json      => true,
-    asset_pipeline          => true,
-    asset_pipeline_prefix   => 'smartanswers',
-    nagios_memory_warning   => $nagios_memory_warning,
-    nagios_memory_critical  => $nagios_memory_critical,
-    alert_5xx_warning_rate  => 0.001,
-    alert_5xx_critical_rate => 0.005,
-    repo_name               => 'smart-answers',
+    app_type                 => 'rack',
+    port                     => $port,
+    sentry_dsn               => $sentry_dsn,
+    health_check_path        => '/pay-leave-for-parents',
+    log_format_is_json       => true,
+    asset_pipeline           => true,
+    asset_pipeline_prefix    => 'smartanswers',
+    nagios_memory_warning    => $nagios_memory_warning,
+    nagios_memory_critical   => $nagios_memory_critical,
+    alert_5xx_warning_rate   => 0.001,
+    alert_5xx_critical_rate  => 0.005,
+    repo_name                => 'smart-answers',
+    unicorn_worker_processes => $unicorn_worker_processes,
   }
 }


### PR DESCRIPTION
Trello: https://trello.com/c/Fi3LqZdb/665-look-into-rate-limiting-again

This ups them from their default value of 2 to enable more web processes
to be available. This is to reflect their change to new dedicated
machines.

This also fixes a missing bit of configuration from AWS and sets up similar
env var for smartanswers (to match what is hardcoded in the app)