### PR TITLE
Add Shellcheck to CI

### DIFF
--- a/modules/govuk_ci/manifests/agent.pp
+++ b/modules/govuk_ci/manifests/agent.pp
@@ -66,6 +66,7 @@ class govuk_ci::agent(
     'libfreetype6-dev', # govuk-taxonomy-supervised-learning
     'libgdal-dev', # mapit
     'python3-dev', # govuk-taxonomy-supervised-learning
+    'shellcheck',
   ]
 
   ensure_packages($deb_packages, {'ensure' => 'installed'})

--- a/modules/govuk_ci/manifests/agent.pp
+++ b/modules/govuk_ci/manifests/agent.pp
@@ -61,24 +61,18 @@ class govuk_ci::agent(
     require => Class['::govuk_jenkins::user'],
   }
 
-  package { 'libgdal-dev': # needed for mapit
-    ensure => installed,
-  }
-  package { 'jq':
-    ensure => installed,
-  }
+  $deb_packages = [
+    'jq',
+    'libfreetype6-dev', # govuk-taxonomy-supervised-learning
+    'libgdal-dev', # mapit
+    'python3-dev', # govuk-taxonomy-supervised-learning
+  ]
+
+  ensure_packages($deb_packages, {'ensure' => 'installed'})
 
   package { 's3cmd':
     ensure   => 'present',
     provider => 'pip',
-  }
-
-  # Needed for govuk-taxonomy-supervised-learning
-  package { 'python3-dev':
-    ensure => installed,
-  }
-  package { 'libfreetype6-dev':
-    ensure => installed,
   }
 
   govuk_bundler::config {'jenkins-bundler':


### PR DESCRIPTION
Shellcheck is a tool that outputs errors and warnings against shell scripts. Writing scripts in Bash mean they are difficult to test, and shellcheck can help root out any bugs that may occur from them.

The plan is to add a method into the Jenkins library to detect any files shell scripts.