### PR TITLE
Add extra disks to postgres primary on staging

### DIFF
--- a/hieradata/class/staging/postgresql_primary.yaml
+++ b/hieradata/class/staging/postgresql_primary.yaml
@@ -9,7 +9,10 @@ lv:
       - '/dev/sdf1'
       - '/dev/sdg1'
       - '/dev/sdh1'
+      - '/dev/sdj1'
     vg: 'backups'
   data:
-    pv: '/dev/sdc1'
+    pv:
+      - '/dev/sdc1'
+      - '/dev/sdi1'
     vg: 'postgresql'


### PR DESCRIPTION
Two extra disks - one for data and one for backup to take into account the extra data we expect to generate from Email Alert Api.

[Trello](https://trello.com/c/T2ChiLVo/621-increase-disk-space-on-postgres-machines)