### PR TITLE
Added Puppet ensure for /data/uploads owned by deploy.deploy

### DIFF
--- a/modules/govuk/manifests/deploy/setup.pp
+++ b/modules/govuk/manifests/deploy/setup.pp
@@ -91,6 +91,13 @@ class govuk::deploy::setup (
     require => File['/data'],
   }
 
+  file { '/data/uploads':
+    ensure  => directory,
+    owner   => 'deploy',
+    group   => 'deploy',
+    require => File['/data'],
+  }
+
   file { '/var/apps':
     ensure => directory,
   }


### PR DESCRIPTION
 In order to fix asset-master deployment