### PR TITLE
Adjust nginx configuration after Email Alert API testing

### DIFF
--- a/modules/govuk/manifests/apps/email_alert_api.pp
+++ b/modules/govuk/manifests/apps/email_alert_api.pp
@@ -309,7 +309,7 @@ class govuk::apps::email_alert_api(
     if $enable_public_proxy {
       nginx::conf { 'email-alert-api-public-rate-limiting':
         content => '
-          limit_req_zone $binary_remote_addr zone=email_alert_api_public:1m rate=100r/s;
+          limit_req_zone $binary_remote_addr zone=email_alert_api_public:1m rate=50r/s;
           limit_req_status 429;
         ',
       }

--- a/modules/govuk/manifests/node/s_graphite.pp
+++ b/modules/govuk/manifests/node/s_graphite.pp
@@ -46,14 +46,6 @@ class govuk::node::s_graphite (
     ],
   }
 
-  limits::limits { 'www-data_nofile':
-    ensure     => present,
-    user       => 'www-data',
-    limit_type => 'nofile',
-    both       => 16384,
-    notify     => Class['graphite::service'],
-  }
-
   @@icinga::check { "check_carbon_cache_running_on_${::hostname}":
     check_command       => 'check_nrpe!check_proc_running!carbon-cache.py',
     service_description => 'carbon-cache running',

--- a/modules/nginx/manifests/init.pp
+++ b/modules/nginx/manifests/init.pp
@@ -18,6 +18,13 @@ class nginx (
     notify => Class['nginx::service'];
   }
 
+  limits::limits { 'www-data_nofile':
+    ensure     => present,
+    user       => 'www-data',
+    limit_type => 'nofile',
+    both       => 16384,
+  }
+
   class { 'nginx::package':
     require => Anchor['nginx::begin'],
     notify  => Class['nginx::service'];

--- a/modules/nginx/templates/etc/nginx/nginx.conf.erb
+++ b/modules/nginx/templates/etc/nginx/nginx.conf.erb
@@ -1,5 +1,6 @@
 user www-data;
 worker_processes  4;
+worker_rlimit_nofile 4096;
 
 error_log  /var/log/nginx/error.log;
 pid        /run/nginx.pid;


### PR DESCRIPTION
Trello: https://trello.com/c/Fi3LqZdb/665-look-into-rate-limiting-again

This adjusts the configuration of the load balancer boxes to allow more files to be open - this is to prevent an error that was seen a lot testing load on a backend box:

```
2018/03/05 16:37:52 [alert] 9212#0: *11488473 socket() failed (24: Too many open files) while connecting to upstream, client: 213.86.153.236, server: email-alert-api-public.staging.publishing.service.gov.uk, request: "POST /status-updates HTTP/1.1", upstream: "https://10.2.3.40:443/status-updates", host: "email-alert-api-public.staging.publishing.service.gov.uk"
```

It also decreases the requests per second allowed to Email Alert API Public endpoint so that the app has a higher chance of returning a 429 response than timing out with a 502 or 504.