### PR TITLE
Add disk to postgresql-standby

### DIFF
--- a/hieradata/class/postgresql_standby.yaml
+++ b/hieradata/class/postgresql_standby.yaml
@@ -12,7 +12,9 @@ lv:
     pv: '/dev/sdb1'
     vg: 'backups'
   data:
-    pv: '/dev/sdc1'
+    pv:
+      - '/dev/sdc1'
+      - '/dev/sdd1'
     vg: 'postgresql'
 
 mount:


### PR DESCRIPTION
Add a disk to postgresql-standby to bring the data partition in line
with postgresql-primary.
[Trello](https://trello.com/c/T2ChiLVo/621-increase-disk-space-on-postgres-machines)