### PR TITLE
Change namespace for signon background queue icinga check

### DIFF
--- a/modules/monitoring/manifests/checks/sidekiq.pp
+++ b/modules/monitoring/manifests/checks/sidekiq.pp
@@ -27,7 +27,7 @@ class monitoring::checks::sidekiq (
 
   icinga::check::graphite { 'check_signon_queue_sizes':
     # Check signon background worker average queue sizes
-    target    => 'keepLastValue(stats.gauges.govuk.app.signon.workers.queues.*.enqueued)',
+    target    => 'keepLastValue(stats.gauges.govuk.app.signon.*.workers.queues.*.enqueued)',
     warning   => 30,
     critical  => 50,
     desc      => 'signon background worker queue size unexpectedly large',


### PR DESCRIPTION
Since upgrading signon to govuk_sidekiq 3.x and govuk_app_config 1.3.x
it now includes the hostname in the namespace for the queue information
so we need to look in `stats.gauges.govuk.app.signon.*.workers`
instead of `stats.gauges.govuk.app.signon.workers.` or we get no datapoints.