### PR TITLE
Disable GovDelivery and enable our email subscription frontend

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -384,6 +384,8 @@ govuk::apps::email_alert_api::db_hostname: 'postgresql-primary-1.backend'
 govuk::apps::email_alert_api::db_password: "%{hiera('govuk::apps::email_alert_api::db::password')}"
 govuk::apps::email_alert_api::govuk_notify_rate_per_worker: '12'
 govuk::apps::email_alert_api::unicorn_worker_processes: '4'
+govuk::apps::email_alert_api::disable_govdelivery_emails: true
+govuk::apps::email_alert_api::use_email_alert_frontend_for_email_collection: true
 
 govuk::apps::email_alert_service::rabbitmq_hosts:
   - rabbitmq-1.backend

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -390,6 +390,8 @@ govuk::apps::email_alert_api::db_hostname: 'postgresql-primary'
 govuk::apps::email_alert_api::db_password: "%{hiera('govuk::apps::email_alert_api::db::password')}"
 govuk::apps::email_alert_api::govuk_notify_rate_per_worker: '12'
 govuk::apps::email_alert_api::unicorn_worker_processes: '4'
+govuk::apps::email_alert_api::disable_govdelivery_emails: true
+govuk::apps::email_alert_api::use_email_alert_frontend_for_email_collection: true
 
 govuk::apps::email_alert_service::rabbitmq_hosts:
   - rabbitmq

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -13,8 +13,6 @@ govuk::apps::asset_manager::aws_region: 'eu-west-1'
 
 govuk::apps::email_alert_api::allow_govdelivery_topic_syncing: true
 govuk::apps::email_alert_api::govuk_notify_template_id: '1fc69d3a-09a2-40f9-852b-03f6fcef5340'
-govuk::apps::email_alert_api::disable_govdelivery_emails: true
-govuk::apps::email_alert_api::use_email_alert_frontend_for_email_collection: true
 govuk::apps::email_alert_api::email_address_override: 'success@simulator.amazonses.com'
 govuk::apps::email_alert_api::email_address_override_whitelist_only: true
 govuk::apps::email_alert_api::delivery_request_threshold: "3000"


### PR DESCRIPTION
We will have already changed these environment variables on the machines, but we need to also make the changes in Puppet.

[Trello Card](https://trello.com/c/adC9zZHY/672-do-not-merge-pr-for-puppet-to-solidify-deploy-vars)