### PR TITLE
Re-enable GOV.UK Content API docs job for AWS Jenkins

### DIFF
--- a/hieradata_aws/class/jenkins.yaml
+++ b/hieradata_aws/class/jenkins.yaml
@@ -70,6 +70,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::deploy_router_data
   - govuk_jenkins::jobs::enhanced_ecommerce
   - govuk_jenkins::jobs::extract_app_performance
+  - govuk_jenkins::jobs::govuk_content_api_docs
   - govuk_jenkins::jobs::govuk_taxonomy_supervised_learning
   - govuk_jenkins::jobs::mirror_repos
   - govuk_jenkins::jobs::monitor_taxonomy_health

--- a/modules/govuk_jenkins/templates/jobs/govuk_content_api_docs.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/govuk_content_api_docs.yaml.erb
@@ -19,7 +19,7 @@
       numToKeep: 10
       artifactDaysToKeep: 3
     triggers:
-      - timed: 'H * * * *'
+      - timed: 'H H * * *'
     properties:
       - build-discarder:
           days-to-keep: 30

--- a/modules/govuk_jenkins/templates/jobs/govuk_content_api_docs.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/govuk_content_api_docs.yaml.erb
@@ -27,7 +27,7 @@
     builders:
       - shell: |
           #!/bin/bash
-          set -eu
+          set -eux
 
           cd "${WORKSPACE}"
 
@@ -38,6 +38,8 @@
           cd govuk-content-api-docs
 
           export BUNDLE_PATH="${HOME}/bundles/${JOB_NAME}"
+          mkdir -p $BUNDLE_PATH
+
           make publish API_SPEC=../content-store/openapi.yaml
 
           cd ..


### PR DESCRIPTION
This re-enables the job which got lost in the switch to AWS and switches the
frequency the job runs at from once an hour to once a day.