### PR TITLE
Move the email alert api whitelist from secrets

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -384,6 +384,17 @@ govuk::apps::email_alert_api::db_hostname: 'postgresql-primary-1.backend'
 govuk::apps::email_alert_api::db_password: "%{hiera('govuk::apps::email_alert_api::db::password')}"
 govuk::apps::email_alert_api::govuk_notify_rate_per_worker: '12'
 govuk::apps::email_alert_api::unicorn_worker_processes: '4'
+govuk::apps::email_alert_api::email_address_override_whitelist:
+  - govuk-email-courtesy-copies@digital.cabinet-office.gov.uk
+  - bevan.loon@digital.cabinet-office.gov.uk
+  - keith.emmerson@digital.cabinet-office.gov.uk
+  - kevin.dew@digital.cabinet-office.gov.uk
+  - martin.lugton@digital.cabinet-office.gov.uk
+  - paul.cronk@digital.cabinet-office.gov.uk
+  - peter.hartshorn@digital.cabinet-office.gov.uk
+  - ruben.arakelyan@digital.cabinet-office.gov.uk
+  - thomas.leese@digital.cabinet-office.gov.uk
+  - tijmen.brommet@digital.cabinet-office.gov.uk
 
 govuk::apps::email_alert_service::rabbitmq_hosts:
   - rabbitmq-1.backend

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -390,6 +390,17 @@ govuk::apps::email_alert_api::db_hostname: 'postgresql-primary'
 govuk::apps::email_alert_api::db_password: "%{hiera('govuk::apps::email_alert_api::db::password')}"
 govuk::apps::email_alert_api::govuk_notify_rate_per_worker: '12'
 govuk::apps::email_alert_api::unicorn_worker_processes: '4'
+govuk::apps::email_alert_api::email_address_override_whitelist:
+  - govuk-email-courtesy-copies@digital.cabinet-office.gov.uk
+  - bevan.loon@digital.cabinet-office.gov.uk
+  - keith.emmerson@digital.cabinet-office.gov.uk
+  - kevin.dew@digital.cabinet-office.gov.uk
+  - martin.lugton@digital.cabinet-office.gov.uk
+  - paul.cronk@digital.cabinet-office.gov.uk
+  - peter.hartshorn@digital.cabinet-office.gov.uk
+  - ruben.arakelyan@digital.cabinet-office.gov.uk
+  - thomas.leese@digital.cabinet-office.gov.uk
+  - tijmen.brommet@digital.cabinet-office.gov.uk
 
 govuk::apps::email_alert_service::rabbitmq_hosts:
   - rabbitmq


### PR DESCRIPTION
We're no longer sending test emails to personal addresses so there is no need for this to be secret, and it makes it easier to manage.