### PR TITLE
Increase the max postgres connections in staging to match production

### DIFF
--- a/hieradata/class/staging/postgresql_primary.yaml
+++ b/hieradata/class/staging/postgresql_primary.yaml
@@ -1,4 +1,4 @@
-govuk_postgresql::server::max_connections: 200
+govuk_postgresql::server::max_connections: 300
 
 lv:
   postgresql:

--- a/hieradata/class/staging/postgresql_standby.yaml
+++ b/hieradata/class/staging/postgresql_standby.yaml
@@ -1,1 +1,1 @@
-govuk_postgresql::server::max_connections: 200
+govuk_postgresql::server::max_connections: 300

--- a/hieradata/class/staging/transition_postgresql_master.yaml
+++ b/hieradata/class/staging/transition_postgresql_master.yaml
@@ -1,1 +1,1 @@
-govuk_postgresql::server::max_connections: 200
+govuk_postgresql::server::max_connections: 300

--- a/hieradata/class/staging/transition_postgresql_slave.yaml
+++ b/hieradata/class/staging/transition_postgresql_slave.yaml
@@ -1,1 +1,1 @@
-govuk_postgresql::server::max_connections: 200
+govuk_postgresql::server::max_connections: 300


### PR DESCRIPTION
There is no reason for them to be different, as both environments should be the same.

This change will restart Postgres in staging.

I decided not to merge the two staging and production settings into a common configuration file, because I'm not sure if that may affect any other production Postgres databases which would lead to them being restarted in office hours.