### PR TITLE
Bump the number of Deploy Jenkins executors to 6

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -45,6 +45,7 @@ govuk_cdnlogs::bouncer_monitoring_enabled: false
 govuk_elasticsearch::dump::run_es_dump_hour: '9'
 
 govuk_jenkins::job_builder::environment: 'integration'
+govuk_jenkins::config::executors: '6'
 
 govuk_jenkins::jobs::deploy_dns::gce_project_id: 'govuk-integration'
 govuk_jenkins::jobs::deploy_dns::zones:


### PR DESCRIPTION
The Deploy Jenkins is mostly used to run jobs on other machines, and
the parallelism is controlled individually for each job. As the
resources of the Jenkins machine are not a concern for most jobs (as
the jobs are running on other machines), bump the number of executors
to allow more jobs to run in parallel.