### PR TITLE
Increase deploy-jenkins executors on integration

### DIFF
--- a/hieradata/class/integration/jenkins.yaml
+++ b/hieradata/class/integration/jenkins.yaml
@@ -1,5 +1,5 @@
 ---
-govuk_jenkins::config::executors: '4'
+govuk_jenkins::config::executors: '8'
 
 govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::deploy_licensify


### PR DESCRIPTION
This will help us avoid a long queue of app deployments and other tasks.

Jobs on deploy-jenkins don't tend to use many resources on the Jenkins box itself - they mostly trigger deployments or rake tasks on other hosts. So it's safe to increase the number of parallel jobs run by Jenkins.

cc @boffbowsh 