### PR TITLE
Increase no of unicorn workers for gov-frontend

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -411,8 +411,8 @@ govuk::apps::frontend::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::frontend::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::frontend::unicorn_worker_processes: "4"
 
-govuk::apps::government-frontend::nagios_memory_warning: 900
-govuk::apps::government-frontend::nagios_memory_critical: 1000
+govuk::apps::government-frontend::nagios_memory_warning: 1800
+govuk::apps::government-frontend::nagios_memory_critical: 2000
 govuk::apps::government-frontend::unicorn_worker_processes: "8"
 
 govuk::apps::govuk_cdn_logs_monitor::processed_data_dir: '/mnt/logs_cdn/data'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -413,7 +413,7 @@ govuk::apps::frontend::unicorn_worker_processes: "4"
 
 govuk::apps::government-frontend::nagios_memory_warning: 900
 govuk::apps::government-frontend::nagios_memory_critical: 1000
-govuk::apps::government-frontend::unicorn_worker_processes: "2"
+govuk::apps::government-frontend::unicorn_worker_processes: "8"
 
 govuk::apps::govuk_cdn_logs_monitor::processed_data_dir: '/mnt/logs_cdn/data'
 

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -202,10 +202,6 @@ govuk::node::s_frontend_lb::whitehall_frontend_servers:
   - 'whitehall-frontend-1.frontend'
   - 'whitehall-frontend-2.frontend'
   - 'whitehall-frontend-3.frontend'
-  - 'whitehall-frontend-4.frontend'
-  - 'whitehall-frontend-5.frontend'
-  - 'whitehall-frontend-6.frontend'
-  - 'whitehall-frontend-7.frontend'
 govuk::node::s_monitoring::enable_fastly_metrics: true
 govuk::node::s_mysql_backup::s3_bucket_name: 'govuk-mysql-xtrabackups-production'
 govuk::node::s_mysql_master::s3_bucket_name: "%{hiera('govuk::node::s_mysql_backup::s3_bucket_name')}"
@@ -458,14 +454,6 @@ hosts::production::frontend::hosts:
     ip: '10.3.2.6'
   whitehall-frontend-3:
     ip: '10.3.2.10'
-  whitehall-frontend-4:
-    ip: '10.3.2.14'
-  whitehall-frontend-5:
-    ip: '10.3.2.15'
-  whitehall-frontend-6:
-    ip: '10.3.2.16'
-  whitehall-frontend-7:
-    ip: '10.3.2.17'
   frontend-lb-1:
     ip: '10.3.2.101'
   frontend-lb-2:

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -78,6 +78,8 @@ govuk::apps::content_store::performance_platform_big_screen_view_url: 'https://p
 govuk::apps::content_store::performance_platform_spotlight_url: 'https://performance-platform-spotlight-production.cloudapps.digital'
 govuk::apps::email_alert_api::db::backend_ip_range: '10.3.3.0/24'
 govuk::apps::email_alert_api::govuk_notify_template_id: 'cb633abc-6ae6-4843-ae6f-82ca500b6de2'
+govuk::apps::government-frontend::cpu_warning: 200
+govuk::apps::government-frontend::cpu_critical: 300
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::kibana::logit_environment: 0ea55710-075b-4eab-bfc3-475f28cdd0c3
 govuk::apps::local_links_manager::local_links_manager_passive_checks: true

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -23,6 +23,8 @@ govuk::apps::email_alert_api::email_address_override: 'success@simulator.amazons
 govuk::apps::email_alert_api::email_address_override_whitelist_only: true
 govuk::apps::email_alert_api::delivery_request_threshold: "3000"
 govuk::apps::hmrc_manuals_api::publish_topics: false
+govuk::apps::government-frontend::cpu_warning: 200
+govuk::apps::government-frontend::cpu_critical: 300
 govuk::apps::kibana::logit_environment: d414187a-2796-4ea7-9b9a-d40c341646d6
 govuk::apps::link_checker_api::govuk_basic_auth_credentials: "%{hiera('http_username')}:%{hiera('http_password')}"
 govuk::apps::publicapi::backdrop_host: 'www.staging.performance.service.gov.uk'

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -152,10 +152,6 @@ govuk::node::s_frontend_lb::whitehall_frontend_servers:
   - 'whitehall-frontend-1.frontend'
   - 'whitehall-frontend-2.frontend'
   - 'whitehall-frontend-3.frontend'
-  - 'whitehall-frontend-4.frontend'
-  - 'whitehall-frontend-5.frontend'
-  - 'whitehall-frontend-6.frontend'
-  - 'whitehall-frontend-7.frontend'
 govuk::node::s_monitoring::offsite_backups: false
 govuk::node::s_mysql_backup::s3_bucket_name: 'govuk-mysql-xtrabackups-staging'
 govuk::node::s_mysql_master::s3_bucket_name: "%{hiera('govuk::node::s_mysql_backup::s3_bucket_name')}"
@@ -397,14 +393,6 @@ hosts::production::frontend::hosts:
     ip: '10.2.2.6'
   whitehall-frontend-3:
     ip: '10.2.2.10'
-  whitehall-frontend-4:
-    ip: '10.2.2.14'
-  whitehall-frontend-5:
-    ip: '10.2.2.15'
-  whitehall-frontend-6:
-    ip: '10.2.2.16'
-  whitehall-frontend-7:
-    ip: '10.2.2.17'
   frontend-lb-1:
     ip: '10.2.2.101'
   frontend-lb-2:

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -417,7 +417,7 @@ govuk::apps::frontend::unicorn_worker_processes: "4"
 
 govuk::apps::government-frontend::nagios_memory_warning: 900
 govuk::apps::government-frontend::nagios_memory_critical: 1000
-govuk::apps::government-frontend::unicorn_worker_processes: "2"
+govuk::apps::government-frontend::unicorn_worker_processes: "8"
 
 govuk::apps::govuk_cdn_logs_monitor::processed_data_dir: '/mnt/logs_cdn/data'
 

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -415,8 +415,8 @@ govuk::apps::frontend::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::frontend::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::frontend::unicorn_worker_processes: "4"
 
-govuk::apps::government-frontend::nagios_memory_warning: 900
-govuk::apps::government-frontend::nagios_memory_critical: 1000
+govuk::apps::government-frontend::nagios_memory_warning: 1800
+govuk::apps::government-frontend::nagios_memory_critical: 2000
 govuk::apps::government-frontend::unicorn_worker_processes: "8"
 
 govuk::apps::govuk_cdn_logs_monitor::processed_data_dir: '/mnt/logs_cdn/data'

--- a/modules/govuk/manifests/apps/government_frontend.pp
+++ b/modules/govuk/manifests/apps/government_frontend.pp
@@ -21,12 +21,21 @@
 #   The number of unicorn worker processes to run
 #   Default: undef
 #
+# [*cpu_warning*]
+#   CPU usage percentage that alerts are sounded at
+#   Default: undef
+#
+# [*cpu_critical*]
+#   CPU usage percentage that alerts are sounded at
+#
 class govuk::apps::government_frontend(
   $vhost = 'government-frontend',
   $port = '3090',
   $sentry_dsn = undef,
   $secret_key_base = undef,
   $unicorn_worker_processes = undef,
+  $cpu_warning = 150,
+  $cpu_critical = 200,
 ) {
   Govuk::App::Envvar {
     app => 'government-frontend',
@@ -48,5 +57,7 @@ class govuk::apps::government_frontend(
     asset_pipeline_prefix    => 'government-frontend',
     vhost                    => $vhost,
     unicorn_worker_processes => $unicorn_worker_processes,
+    cpu_warning              => $cpu_warning,
+    cpu_critical             => $cpu_critical,
   }
 }

--- a/modules/grafana/files/dashboards/processes.json
+++ b/modules/grafana/files/dashboards/processes.json
@@ -1056,26 +1056,6 @@
             "selected": false
           },
           {
-            "text": "whitehall-frontend-4_frontend",
-            "value": "whitehall-frontend-4_frontend",
-            "selected": false
-          },
-          {
-            "text": "whitehall-frontend-5_frontend",
-            "value": "whitehall-frontend-5_frontend",
-            "selected": false
-          },
-          {
-            "text": "whitehall-frontend-6_frontend",
-            "value": "whitehall-frontend-6_frontend",
-            "selected": false
-          },
-          {
-            "text": "whitehall-frontend-7_frontend",
-            "value": "whitehall-frontend-7_frontend",
-            "selected": false
-          },
-          {
             "text": "whitehall-mysql-backup-1_backend",
             "value": "whitehall-mysql-backup-1_backend",
             "selected": false


### PR DESCRIPTION
## Background 

Following the work done here: https://github.com/alphagov/govuk-puppet/pull/7255 we are increasing the number of unicorn workers to better handle the number of requests being done on the frontend boxes.

There's now a high amount of requests going to `government-frontend` as it has taken over responsibility from `whitehall`. 

## Current traffic

<img width="1500" alt="screen shot 2018-03-07 at 15 54 53" src="https://user-images.githubusercontent.com/1354439/37103446-24dc2b50-2222-11e8-8f41-2a9f318adc0e.png">

For a period between 9AM and 12PM (3 hours) there were 440K requests (GET & POST) made to `government-frontend`.

That boils down to 440.000 requests / 3 hours / 60 minutes / 60 seconds = **41 requests/s**.

We currently have 2 unicorn workers for each machine so 2 x 3 = 6 workers to consume these requests.

So 41 req / 6 workers = **~7 req / worker**

If we increase the workers from 2 to 4, that would result in 4x3 = 12 workers:

So 41 req / 12 workers = **~3.5 req / worker**

## Conclusion

1. As a first step, we'll increase the number of workers from 2 -> 4. 
2. We'll also increase the cpu warning threshold  for high CPU usage as we've increased `government-frontend` machines from 2 cores to 4 cores. 
