### PR TITLE
Run the taxonomy supervised learning job on staging and production

### DIFF
--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -40,9 +40,9 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::run_whitehall_data_migrations
   - govuk_jenkins::jobs::search_benchmark
   - govuk_jenkins::jobs::search_fetch_analytics_data
-  - govuk_jenkins::jobs::search_test_spelling_suggestions
   - govuk_jenkins::jobs::search_index_checks
   - govuk_jenkins::jobs::search_reindex_with_new_schema
+  - govuk_jenkins::jobs::search_test_spelling_suggestions
   - govuk_jenkins::jobs::signon_cron_rake_tasks
   - govuk_jenkins::jobs::smokey
   - govuk_jenkins::jobs::smokey_deploy

--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -28,6 +28,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::govuk_cdn_nightly_2xx_status_collection
   - govuk_jenkins::jobs::govuk_navigation_link_analysis
   - govuk_jenkins::jobs::govuk_tagging_monitor
+  - govuk_jenkins::jobs::govuk_taxonomy_supervised_learning
   - govuk_jenkins::jobs::launch_vms
   - govuk_jenkins::jobs::mirror_network_config
   - govuk_jenkins::jobs::network_config_deploy

--- a/hieradata/class/staging/jenkins.yaml
+++ b/hieradata/class/staging/jenkins.yaml
@@ -14,6 +14,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::deploy_router_data
   - govuk_jenkins::jobs::deploy_terraform_project
   - govuk_jenkins::jobs::govuk_cdn_nightly_2xx_status_collection
+  - govuk_jenkins::jobs::govuk_taxonomy_supervised_learning
   - govuk_jenkins::jobs::launch_vms
   - govuk_jenkins::jobs::network_config_deploy
   - govuk_jenkins::jobs::passive_checks


### PR DESCRIPTION
This now used to report the metrics on average taxons per content item
to Graphite, and hopefully more metrics to Graphite, which would be
useful to have in all environments.