### PR TITLE
Fix puppet syntax in copy staging to aws

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/copy_data_from_staging_to_aws.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_from_staging_to_aws.yaml.erb
@@ -86,10 +86,10 @@
             HOSTNAME=deploy.blue.staging.govuk.digital
             API_KEY=<%= @ci_alphagov_api_key %>
             AUTH_TOKEN=<%= @auth_token %>
-     - slack:
+      - slack:
         team-domain: <%= @slack_team_domain %>
         auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN']%>
-        build-server-url: <% @slack_build_server_url %>
+        build-server-url: <%= @slack_build_server_url %>
         room: <%= @slack_room %>
     wrappers:
         - ansicolor:


### PR DESCRIPTION
-We have edited the layout of the YAML file. The reason for this change was the actual puppet run on the Jenkins server fails due to a validation error.

```
Error: /Stage[main]/Govuk_jenkins::Job_builder_update/Exec[jenkins_jobs_update]: Failed to call refresh: /usr/local/bin/jenkins-jobs update --delete-old /etc/jenkins_jobs/jobs/ returned 1 instead of one of [0]
Error: /Stage[main]/Govuk_jenkins::Job_builder_update/Exec[jenkins_jobs_update]: /usr/local/bin/jenkins-jobs update --delete-old /etc/jenkins_jobs/jobs/ returned 1 instead of one of [0]```

Pair: @schmie @suthagarht