### PR TITLE
Deploy_Apps router

### DIFF
--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -89,7 +89,8 @@ govuk_mysql::server::slow_query_log: true
 govuk::node::s_asset_master::copy_attachments_hour: 7
 
 govuk::node::s_cache::real_ip_header: 'True-Client-Ip'
-govuk::node::s_cache::router_as_container: true
+# The option below can be changed to enable router to run as a container
+govuk::node::s_cache::router_as_container: false
 govuk::node::s_monitoring::offsite_backups: false
 
 govuk_sudo::sudo_conf:


### PR DESCRIPTION
- During the initial staging build we encontered a problem with having
  access to the application binary files from the seed environment. For
example integration will be the seed environment of staging. Due to this
conundrum, we created a temporary solution to allow the router
application (key to all the other applications) to run as a container
using DockerHub. This is no longer required. However, this is an option
that has been proven to work. Hence, we have mearly changed the option
from true to false.

Solo: @suthagarht