### PR TITLE
Change postgres standby critical threshold from 16MB to 512MB

### DIFF
--- a/modules/govuk_postgresql/manifests/server/standby.pp
+++ b/modules/govuk_postgresql/manifests/server/standby.pp
@@ -77,8 +77,8 @@ class govuk_postgresql::server::standby (
   @@icinga::check::graphite { "check_postgres_replication_lag_${::hostname}":
     target    => "movingMedian(transformNull(removeBelowValue(diffSeries(keepLastValue(${primary_metric}),keepLastValue(${standby_metric})),0),0),5)",
     desc      => 'replication on the postgres standby is too far behind primary [value in bytes]',
-    warning   => to_bytes('8 MB'),
-    critical  => to_bytes('16 MB'),
+    warning   => to_bytes('256 MB'),
+    critical  => to_bytes('512 MB'),
     args      => '--droplast 1',
     host_name => $::fqdn,
     notes_url => monitoring_docs_url(postgresql-replication-too-far-behind),


### PR DESCRIPTION
We regularly see this alert come through as a 2nd line critical alert
that quickly resolves itself, which indicates this really isn't a
critical alert.

From reading fbc9f18 these numbers were not picked for any particular
significance and from my (meagre) understanding of 90dc023b we store 4GB of
data to be synced. So this would imply that this isn't really a huge concern
unless we get close to exhausating this.

With the change in postgres usage from changes to Email Alert API and
Content Performance Manager we are seeing Postgres increase in data size
more rapidly and seems to cause this alert to trip. By moving this to
512MB we are much less likely to see this as critical unless something
has actually gone wrong.