### PR TITLE
Add redis-tools package to monitoring machines

### DIFF
--- a/modules/govuk/manifests/node/s_monitoring.pp
+++ b/modules/govuk/manifests/node/s_monitoring.pp
@@ -50,4 +50,7 @@ class govuk::node::s_monitoring (
     group  => 'deploy',
   }
 
+  package { 'redis-tools':
+    ensure => installed,
+  }
 }


### PR DESCRIPTION
In Carrenza we can ssh onto the redis machines and run redis-cli to
run queries directly against redis.  On AWS we can't ssh onto the
elasticache redis instances so we can't do this.  We don't have redis-cli
on many boxes, so adding it to the monitoring ones seems like a good
first step.