### PR TITLE
Add credentials for copy_staging_to_aws

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/copy_data_from_staging_to_aws.pp
+++ b/modules/govuk_jenkins/manifests/jobs/copy_data_from_staging_to_aws.pp
@@ -3,7 +3,7 @@
 # Create a file on disk that can be parsed by jenkins-job-builder
 #
 class govuk_jenkins::jobs::copy_data_from_staging_to_aws (
-  $mysql_src_root_pw = undef,
+  $mysql_src_root_pw = hiera('mysql_root'),
   $mysql_dst_root_pw = undef,
   $pg_src_env_sync_pw = undef,
   $pg_dst_env_sync_pw = undef,


### PR DESCRIPTION
- Added hiera lookup of mysql_root to Puppet file describing the Jenskins job
     copying staging databases to AWS

Pair: @suthagarht @schmie