### PR TITLE
Increase number of processes on postgresql-primary

### DIFF
--- a/modules/govuk/manifests/node/s_postgresql_primary.pp
+++ b/modules/govuk/manifests/node/s_postgresql_primary.pp
@@ -21,6 +21,13 @@ class govuk::node::s_postgresql_primary (
     slave_password => $standby_password,
   }
 
+  limits::limits { 'postgres_nproc':
+    ensure     => present,
+    user       => 'postgres',
+    limit_type => 'nproc',
+    both       => 1024,
+  }
+
   govuk_postgresql::wal_e::backup { $title:
     aws_access_key_id                => $aws_access_key_id,
     aws_secret_access_key            => $aws_secret_access_key,


### PR DESCRIPTION
The wal-e backup push has been failing on postgres-primary for the last
2 days. Stacktrace below.

This ups the limit of processes from 256 to 1024. It is likely that we
are reaching the limit of number of processes of 256 as we now allow 300
db connections for a postgres user on this box.

```
wal-e_postgres_base_backup_push:         STRUCTURED: time=2018-03-12T12:10:38.705171-00 pid=32442
wal-e_postgres_base_backup_push: Traceback (most recent call last):
wal-e_postgres_base_backup_push:   File "/usr/local/lib/python2.7/dist-packages/gevent/greenlet.py", line 534, in run
wal-e_postgres_base_backup_push:     result = self._run(*self.args, **self.kwargs)
wal-e_postgres_base_backup_push:   File "/usr/local/lib/python2.7/dist-packages/wal_e/worker/upload.py", line 93, in __call__
wal-e_postgres_base_backup_push:     gpg_key=self.gpg_key) as pl:
wal-e_postgres_base_backup_push:   File "/usr/local/lib/python2.7/dist-packages/wal_e/pipeline.py", line 88, in __enter__
wal-e_postgres_base_backup_push:     last_command.start()
wal-e_postgres_base_backup_push:   File "/usr/local/lib/python2.7/dist-packages/wal_e/pipeline.py", line 148, in start
wal-e_postgres_base_backup_push:     close_fds=True)
wal-e_postgres_base_backup_push:   File "/usr/local/lib/python2.7/dist-packages/wal_e/piper.py", line 83, in __call__
wal-e_postgres_base_backup_push:     proc = subprocess.Popen(*args, **kwargs)
wal-e_postgres_base_backup_push:   File "/usr/local/lib/python2.7/dist-packages/wal_e/subprocess.py", line 711, in __init__
wal-e_postgres_base_backup_push:     errread, errwrite)
wal-e_postgres_base_backup_push:   File "/usr/local/lib/python2.7/dist-packages/wal_e/subprocess.py", line 1205, in _execute_child
wal-e_postgres_base_backup_push:     self.pid = os.fork()
wal-e_postgres_base_backup_push:   File "/usr/local/lib/python2.7/dist-packages/gevent/os.py", line 385, in fork
wal-e_postgres_base_backup_push:     return fork_and_watch(*args, **kwargs)
wal-e_postgres_base_backup_push:   File "/usr/local/lib/python2.7/dist-packages/gevent/os.py", line 337, in fork_and_watch
wal-e_postgres_base_backup_push:     pid = fork()
wal-e_postgres_base_backup_push:   File "/usr/local/lib/python2.7/dist-packages/gevent/os.py", line 168, in fork_gevent
wal-e_postgres_base_backup_push:     result = _raw_fork()
wal-e_postgres_base_backup_push: OSError: [Errno 11] Resource temporarily unavailable
```