### PR TITLE
Correct jenkins build plugin YAML

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/extract_app_performance.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/extract_app_performance.yaml.erb
@@ -43,7 +43,7 @@
                 '<%= @google_client_id %>'
 
     parameters:
-        - share_email:
+        - string:
             name: PLATFORM_METRICS_MAILING_LIST
             description: Email to share reports with.
             default: <%= @google_share_email %>


### PR DESCRIPTION
Corrects https://github.com/alphagov/govuk-puppet/pull/7371

Currently this breaks the job builder plugin.

`Notice: /Stage[main]/Govuk_jenkins::Job_builder_update/Exec[jenkins_jobs_update]/returns: jenkins_jobs.errors.JenkinsJobsException: Unknown entry point or macro 'share_email' for component type: 'parameter'.`