### PR TITLE
Persist python dependencies

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/extract_app_performance.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/extract_app_performance.yaml.erb
@@ -46,4 +46,4 @@
         - string:
             name: PLATFORM_METRICS_MAILING_LIST
             description: Email to share reports with.
-            default: <%= @google_share_email %>
+            default: '<%= @google_share_email %>'

--- a/modules/govuk_jenkins/templates/jobs/extract_app_performance.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/extract_app_performance.yaml.erb
@@ -17,8 +17,8 @@
         - extract-app-performance
     builders:
         - shell: |
-            PIPENV_VENV_IN_PROJECT=1 pipenv install --three --skip-lock
-            PIPENV_VENV_IN_PROJECT=1 GRAPHITE_URL='https://graphite.<%= @app_domain_internal %>' ./run.sh
+            pipenv install --three --skip-lock
+            GRAPHITE_URL='https://graphite.<%= @app_domain_internal %>' ./run.sh
     triggers:
         - timed: '<%= @cron_schedule %>'
 


### PR DESCRIPTION
I originally set this up to create virtualenvs in the workspace, to isolate the job from the rest of the system as much as possible. However, on this environment, it takes 15 minutes to install the python dependencies, and then a few seconds to run the actual code I want to run.

By default, pipenv will create a virtualenv in the user's home directory, using a name based on the path to the Pipenv file.

This means that if the job is moved or deleted, the virtualenv will be left behind, and packages will hang around between builds. The workspace itself will still be cleaned each time.