### PR TITLE
Don't disable gor when syncing Carrenza -> AWS in staging

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/copy_data_from_staging_to_aws.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_from_staging_to_aws.yaml.erb
@@ -53,19 +53,9 @@
 
             set +e
 
-            echo "Disabling Gor traffic replay"
-            for box in $(govuk_node_list -C 'govuk_gor'); do
-              ssh deploy@${box} 'echo "true" > /etc/govuk/env.d/FACTER_data_sync_in_progress; sudo initctl stop gor';
-            done
-
             echo "Running Data Sync"
             bash sync staging aws-staging
             EXITCODE=$?
-
-            echo "Re-enabling Gor traffic replay"
-            for box in $(govuk_node_list -C 'govuk_gor'); do
-              ssh deploy@${box} 'echo "" > /etc/govuk/env.d/FACTER_data_sync_in_progress; sudo initctl start gor';
-            done
 
             exit $EXITCODE
     publishers:

--- a/modules/govuk_jenkins/templates/jobs/copy_data_from_staging_to_aws.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_from_staging_to_aws.yaml.erb
@@ -8,13 +8,13 @@
               - master
 
 - job:
-    name: Copy_Data_from_Staging_to_AWS
-    display-name: Copy_Data_from_Staging_to_AWS
+    name: Copy_Data_from_Staging_to_AWS_Staging
+    display-name: Copy_Data_from_Staging_to_AWS_Staging
     project-type: freestyle
     description: |
-        This job copies databases from staging to AWS. It runs nightly and
-        can be run in an ad-hoc fashion. It doesn't copy the signon or
-        performance-platform databases.
+        This job copies databases from Carrenza staging to AWS. It runs
+        nightly and can be run in an ad-hoc fashion. It doesn't copy the signon
+        or performance-platform databases.
     properties:
         - github:
             url: https://github.com/alphagov/env-sync-and-backup/


### PR DESCRIPTION
Disabling gor here stops the replication of requests from staging to
integration and has no effect on the AWS staging environment. Disabling
this here causes alerts for #2ndline.

This also updates the job name for some extra clarity.