### PR TITLE
Increase keepLastValue period for rummager index size check

### DIFF
--- a/modules/grafana/templates/dashboards/_index_size.json.erb
+++ b/modules/grafana/templates/dashboards/_index_size.json.erb
@@ -50,17 +50,17 @@
         "targets": [
           {
             "refId": "A",
-            "target": "alias(diffSeries(keepLastValue(stats.gauges.govuk.app.rummager.<%= index_name %>_index.docs.count,132), timeShift(keepLastValue(stats.gauges.govuk.app.rummager.<%= index_name %>_index.docs.count,132), '7d')),'Change')",
+            "target": "alias(diffSeries(keepLastValue(stats.gauges.govuk.app.rummager.<%= index_name %>_index.docs.count,252), timeShift(keepLastValue(stats.gauges.govuk.app.rummager.<%= index_name %>_index.docs.count,252), '7d')),'Change')",
             "textEditor": true
           },
           {
             "refId": "B",
-            "target": "alias(keepLastValue(stats.gauges.govuk.app.rummager.<%= index_name %>_index.docs.count,132),'Index size')",
+            "target": "alias(keepLastValue(stats.gauges.govuk.app.rummager.<%= index_name %>_index.docs.count,252),'Index size')",
             "textEditor": true
           },
           {
             "refId": "C",
-            "target": "alias(timeShift(keepLastValue(stats.gauges.govuk.app.rummager.<%= index_name %>_index.docs.count,132), '7d'),'Index size (last week)')",
+            "target": "alias(timeShift(keepLastValue(stats.gauges.govuk.app.rummager.<%= index_name %>_index.docs.count,252), '7d'),'Index size (last week)')",
             "textEditor": true
           }
         ],
@@ -111,17 +111,17 @@
         "targets": [
           {
             "refId": "C",
-            "target": "alias(diffSeries(keepLastValue(stats.gauges.govuk.app.rummager.<%= index_name %>_index.docs.count,132), timeShift(keepLastValue(stats.gauges.govuk.app.rummager.<%= index_name %>_index.docs.count,132), '7d')),'Change')",
+            "target": "alias(diffSeries(keepLastValue(stats.gauges.govuk.app.rummager.<%= index_name %>_index.docs.count,252), timeShift(keepLastValue(stats.gauges.govuk.app.rummager.<%= index_name %>_index.docs.count,252), '7d')),'Change')",
             "textEditor": true
           },
           {
             "refId": "A",
-            "target": "alias(keepLastValue(stats.gauges.govuk.app.rummager.<%= index_name %>_index.docs.count,132), 'Index size')",
+            "target": "alias(keepLastValue(stats.gauges.govuk.app.rummager.<%= index_name %>_index.docs.count,252), 'Index size')",
             "textEditor": true
           },
           {
             "refId": "B",
-            "target": "alias(timeShift(keepLastValue(stats.gauges.govuk.app.rummager.<%= index_name %>_index.docs.count,132),'7d'), 'Index size (last week)')",
+            "target": "alias(timeShift(keepLastValue(stats.gauges.govuk.app.rummager.<%= index_name %>_index.docs.count,252),'7d'), 'Index size (last week)')",
             "textEditor": true
           }
         ],


### PR DESCRIPTION
The data is generated by Jenkins jobs, however due to load, data points can be
delayed past the current 11  minute interval. Data should be generated every 10,
as such we are increasing the interval to 21 minutes.

As this only affects missing data points we don't feel that we are incraseing
teh risk of missin systemn issues.