### PR TITLE
Disable Trigger

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/copy_data_from_staging_to_aws.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_from_staging_to_aws.yaml.erb
@@ -36,8 +36,6 @@
       - env-sync-and-backup_Copy_Data_to_Staging
     logrotate:
         numToKeep: 10
-    triggers:
-        - timed: 'H 11 * * *'
     builders:
         - shell: |
             set +x


### PR DESCRIPTION
- The job to copy Currenza staging data to AWS staging was setup with a
  trigger with 1100 every day. This is not necessary. We only need this
job to be executed manually.

Solo: @suthagarht