### PR TITLE
Up executors for the Deploy Jenkins to 6

### DIFF
--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -1,4 +1,5 @@
 ---
+govuk_jenkins::config::executors: '6'
 govuk_jenkins::jobs::validate_published_dns::run_daily: true
 govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::bouncer_cdn

--- a/hieradata/class/staging/jenkins.yaml
+++ b/hieradata/class/staging/jenkins.yaml
@@ -1,4 +1,6 @@
 ---
+govuk_jenkins::config::executors: '6'
+
 govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::check_content_consistency
   - govuk_jenkins::jobs::check_content_store


### PR DESCRIPTION
In staging and production, as sometimes they get quite busy. Most of
the load is on other machines, so this shouldn't cause an issue with
load.