### PR TITLE
AWS RDS Postgresql password

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/copy_data_from_staging_to_aws.pp
+++ b/modules/govuk_jenkins/manifests/jobs/copy_data_from_staging_to_aws.pp
@@ -5,8 +5,8 @@
 class govuk_jenkins::jobs::copy_data_from_staging_to_aws (
   $mysql_src_root_pw = hiera('mysql_root'),
   $mysql_dst_root_pw = undef,
-  $pg_src_env_sync_pw = undef,
-  $pg_dst_env_sync_pw = undef,
+  $pg_src_env_sync_pw,
+  $pg_dst_env_sync_pw,
   $pg_tr_dst_env_sync_pw = undef,
   $whitehall_mysql_password = undef,
   $app_domain = hiera('app_domain'),


### PR DESCRIPTION
- In our juenkins job to copy data from Carrenza staging to AWS staging,
  we have a neccity to provide 'aws_db_admin' as the destination user.
While we do provide the user name explicity via the script used to
perform the task, we wer not providing the password from secrets.

https://trello.com/c/cYTPEGvn/1044-data-sync-from-staging-carrenza-to-staging-aws

Solo: @suthagarht