### PR TITLE
Discard old builds after 30 days on deploy jenkins

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/backdrop_transactions_explorer_collector.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/backdrop_transactions_explorer_collector.yaml.erb
@@ -19,6 +19,9 @@
             url: https://github.com/alphagov/backdrop-transactions-explorer-collector/
     scm:
       - backdrop_transactions_explorer_collector
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
         - shell: |
             set +x

--- a/modules/govuk_jenkins/templates/jobs/benchmark_search.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/benchmark_search.yaml.erb
@@ -19,6 +19,9 @@
       </ul>
     scm:
         - search-performance-explorer_<%= @job_name %>
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
         - shell: |
             bundle install --path "${HOME}/bundles/${JOB_NAME}";

--- a/modules/govuk_jenkins/templates/jobs/bouncer_cdn.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/bouncer_cdn.yaml.erb
@@ -19,6 +19,9 @@
         - cdn-configs_Bouncer_CDN
     logrotate:
         numToKeep: 20
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
         - shell: |
             cd fastly

--- a/modules/govuk_jenkins/templates/jobs/build_fpm_package.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/build_fpm_package.yaml.erb
@@ -20,6 +20,9 @@
         - string:
             name: RECIPE_NAME
             description: The name of an fpm-cookery recipe
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
         - shell: |
             cd fpm/

--- a/modules/govuk_jenkins/templates/jobs/build_offsite_backup.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/build_offsite_backup.yaml.erb
@@ -17,6 +17,9 @@
             url: http://github.com/alphagov/govuk_offsitebackups-puppet/
     scm:
       - govuk_offsitebackups-puppet_Build-Offsite-Backup
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
         - shell: |
             ./vcloud/box/carrenza/jenkins.sh

--- a/modules/govuk_jenkins/templates/jobs/check_cdn_ip_ranges.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/check_cdn_ip_ranges.yaml.erb
@@ -18,6 +18,9 @@
             url: https://github.com/alphagov/govuk-provisioning/
     scm:
       - govuk-provisioning_Check_CDN_IP_Ranges
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
         - shell: |
             bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment

--- a/modules/govuk_jenkins/templates/jobs/check_content_consistency.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/check_content_consistency.yaml.erb
@@ -21,6 +21,9 @@
       artifactDaysToKeep: 3
     triggers:
         - timed: 'H 11 * * *'
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
       - shell: |
           #!/bin/bash

--- a/modules/govuk_jenkins/templates/jobs/check_content_store.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/check_content_store.yaml.erb
@@ -10,6 +10,9 @@
       artifactDaysToKeep: 3
     triggers:
         - timed: '40 * * * *'
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
       - shell: |
           #!/bin/bash

--- a/modules/govuk_jenkins/templates/jobs/check_pingdom_ip_ranges.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/check_pingdom_ip_ranges.yaml.erb
@@ -18,6 +18,9 @@
             url: https://github.com/alphagov/govuk_mirror-deployment/
     scm:
       - govuk-provisioning_Check_Pingdom_IP_Ranges
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
         - shell: |
             ruby tools/pingdom_ips.rb

--- a/modules/govuk_jenkins/templates/jobs/configure_github_repos.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/configure_github_repos.yaml.erb
@@ -18,6 +18,9 @@
         numToKeep: 250
     triggers:
         - timed: '0 8 * * *' # 8PM every day
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
         - shell: |
             bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment

--- a/modules/govuk_jenkins/templates/jobs/content_audit_tool.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/content_audit_tool.yaml.erb
@@ -4,6 +4,9 @@
     display-name: Content Audit Tool - import inventory
     project-type: freestyle
     description: "<p>Run the import:all_content_items rake task.</p>"
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
       - shell: ssh deploy@$(govuk_node_list -c backend --single-node) "cd /var/apps/content-audit-tool && govuk_setenv content-audit-tool bundle exec rake import:all_content_items"
     wrappers:

--- a/modules/govuk_jenkins/templates/jobs/content_performance_manager.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/content_performance_manager.yaml.erb
@@ -4,6 +4,9 @@
     display-name: Content Performance Manager - import inventory
     project-type: freestyle
     description: "<p>Run the import:all_content_items rake task.</p>"
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
       - shell: ssh deploy@$(govuk_node_list -c backend --single-node) "cd /var/apps/content-performance-manager && govuk_setenv content-performance-manager bundle exec rake import:all_content_items"
     wrappers:

--- a/modules/govuk_jenkins/templates/jobs/copy_data_from_integration_to_aws.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_from_integration_to_aws.yaml.erb
@@ -38,6 +38,9 @@
         numToKeep: 10
     triggers:
         - timed: 'H 11 * * 1-5'
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
         - shell: |
             set -eu

--- a/modules/govuk_jenkins/templates/jobs/copy_data_from_production_to_aws.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_from_production_to_aws.yaml.erb
@@ -27,6 +27,9 @@
         numToKeep: 10
     triggers:
         - timed: 'H 11 * * *'
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
         - shell: |
             set +x

--- a/modules/govuk_jenkins/templates/jobs/copy_data_from_staging_to_aws.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_from_staging_to_aws.yaml.erb
@@ -36,6 +36,9 @@
       - env-sync-and-backup_Copy_Data_to_Staging
     logrotate:
         numToKeep: 10
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
         - shell: |
             set +x

--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
@@ -37,6 +37,9 @@
         numToKeep: 10
     triggers:
         - timed: 'H 4 * * 1-5'
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
         - shell: |
             set -eu

--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_staging.yaml.erb
@@ -36,6 +36,9 @@
         numToKeep: 10
     triggers:
         - timed: 'H 1 * * *'
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
         - shell: |
             set +x

--- a/modules/govuk_jenkins/templates/jobs/copy_licensify_data_to_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_licensify_data_to_staging.yaml.erb
@@ -24,6 +24,9 @@
         numToKeep: 10
     triggers:
         - timed: 'H 1 * * *'
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
         - shell: |
             set +x

--- a/modules/govuk_jenkins/templates/jobs/copy_sanitised_whitehall_database.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_sanitised_whitehall_database.yaml.erb
@@ -23,6 +23,9 @@
         numToKeep: 10
     triggers:
         - timed: '15 5 * * 1-5'
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
         - shell: |
             cd "$WORKSPACE/whitehall/"

--- a/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
@@ -9,6 +9,9 @@
     <%- end -%>
     logrotate:
       numToKeep: 10
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
        - shell: |
            # Clear the Sidekiq queues to stop any residual 'stale' jobs running

--- a/modules/govuk_jenkins/templates/jobs/data_sync_complete_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/data_sync_complete_staging.yaml.erb
@@ -9,6 +9,9 @@
     <%- end -%>
     logrotate:
       numToKeep: 10
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
        - shell: |
            <%- if @signon_domains_to_migrate -%>

--- a/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
@@ -7,6 +7,9 @@
     <%- if @auth_token -%>
     auth-token: <%= @auth_token %>
     <%- end -%>
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
         - shell: |
             #!/usr/bin/env bash

--- a/modules/govuk_jenkins/templates/jobs/deploy_cdn.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_cdn.yaml.erb
@@ -30,6 +30,9 @@
             room: <%= @slack_room %>
     scm:
       - cdn-configs_Deploy_CDN
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
         - shell: |
             export ENVIRONMENT=<%= @environment %>

--- a/modules/govuk_jenkins/templates/jobs/deploy_dns.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_dns.yaml.erb
@@ -28,6 +28,9 @@
             - text:
                credential-id: <%= @gce_credential_id %>
                variable: GOOGLE_CREDENTIALS
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
         - shell: |
             export GOOGLE_PROJECT=<%= @gce_project_id %>

--- a/modules/govuk_jenkins/templates/jobs/deploy_emergency_banner.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_emergency_banner.yaml.erb
@@ -4,6 +4,9 @@
     display-name: Deploy the emergency banner
     project-type: freestyle
     description: "Deploy the emergency banner on GOV.UK."
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
       # The argument to `-c` is in this case `frontend` but the value is used by both `static` and `frontend` applications.
       # Rake does not handle commas in its arguments very well, so we have to escape them with a backslash. Since we're

--- a/modules/govuk_jenkins/templates/jobs/deploy_lambda_app.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_lambda_app.yaml.erb
@@ -21,6 +21,9 @@
               ENVIRONMENT=<%= @environment %>
     scm:
       - govuk-lambda-app-deployment_Deploy_Lambda_App
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
       - shell: |
           #!/usr/bin/env bash

--- a/modules/govuk_jenkins/templates/jobs/deploy_licensify.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_licensify.yaml.erb
@@ -14,6 +14,9 @@
     project-type: freestyle
     scm:
       - alphagov-deployment_Licensify_Deploy
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
         - shell: |
             cd "$WORKSPACE"

--- a/modules/govuk_jenkins/templates/jobs/deploy_puppet.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_puppet.yaml.erb
@@ -45,6 +45,9 @@
             room: <%= @slack_room %>
     scm:
       - deployment_Deploy_Puppet
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
         <%- if @aws_migration -%>
         - shell: sh -eu puppet_aws/deploy.sh

--- a/modules/govuk_jenkins/templates/jobs/deploy_router_data.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_router_data.yaml.erb
@@ -15,6 +15,9 @@
       numToKeep: 20
     scm:
       - router-data_deploy_router_data
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
         - shell: |
             bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment

--- a/modules/govuk_jenkins/templates/jobs/deploy_terraform_govuk_aws.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_terraform_govuk_aws.yaml.erb
@@ -25,6 +25,9 @@
             colormap: xterm
         - build-name:
             name: '${ENV,var="ENVIRONMENT"} ${ENV,var="STACKNAME"} ${ENV,var="PROJECT"} ${ENV,var="COMMAND"}'
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
         - shell: |
             ./jenkins.sh

--- a/modules/govuk_jenkins/templates/jobs/deploy_terraform_project.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_terraform_project.yaml.erb
@@ -29,6 +29,9 @@
             colormap: xterm
         - build-name:
             name: '${ENV,var="PROJECT_NAME"} ${ENV,var="ACTION"}'
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
         - shell: |
             if [ -n "$ADDITIONAL_ENVIRONMENT_VARIABLES" ]; then

--- a/modules/govuk_jenkins/templates/jobs/drug_email_alert_check.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/drug_email_alert_check.yaml.erb
@@ -8,6 +8,9 @@
         numToKeep: 100
     triggers:
         - timed: '21 * * * *' # every hour on the 21st minute
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
         - shell: |
             (

--- a/modules/govuk_jenkins/templates/jobs/enhanced_ecommerce.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/enhanced_ecommerce.yaml.erb
@@ -4,6 +4,9 @@
     name: <%= @job_name %>
     display-name: <%= @job_name %>
     project-type: freestyle
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
         - shell: |
           <%- if scope.lookupvar('::aws_migration') %>

--- a/modules/govuk_jenkins/templates/jobs/extract_app_performance.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/extract_app_performance.yaml.erb
@@ -15,6 +15,9 @@
       <p>More information:<a href='https://github.com/alphagov/app-performance-summary'>alphagov/app-performance-summary on GitHub</a>.</p>
     scm:
         - extract-app-performance
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
         - shell: |
             pipenv install --three --skip-lock

--- a/modules/govuk_jenkins/templates/jobs/failure_passive_check.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/failure_passive_check.yaml.erb
@@ -5,6 +5,9 @@
     project-type: freestyle
     description: "This job should be used to send a passive check to Icinga with a FAILED
       status. As such this should only be used as a triggered build for a FAILED (or unstable)       condition."
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
       - shell: |
           IPADDRESS=$(facter ipaddress)

--- a/modules/govuk_jenkins/templates/jobs/govuk_cdn_nightly_2xx_status_collection.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/govuk_cdn_nightly_2xx_status_collection.yaml.erb
@@ -19,6 +19,9 @@
       nightly, at a later time than log rotation typically happens.
     scm:
       - govuk-cdn-logs-monitor
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
       - shell: |
           ssh deploy@logs-cdn-1.management '

--- a/modules/govuk_jenkins/templates/jobs/govuk_content_api_docs.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/govuk_content_api_docs.yaml.erb
@@ -20,6 +20,9 @@
       artifactDaysToKeep: 3
     triggers:
       - timed: 'H * * * *'
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
       - shell: |
           #!/bin/bash

--- a/modules/govuk_jenkins/templates/jobs/govuk_navigation_link_analysis.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/govuk_navigation_link_analysis.yaml.erb
@@ -21,6 +21,9 @@
       numToKeep: 10
     triggers:
         - timed: 'H 0 * * 1'
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
       - shell: |
           #!/bin/bash

--- a/modules/govuk_jenkins/templates/jobs/govuk_tagging_monitor.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/govuk_tagging_monitor.yaml.erb
@@ -20,6 +20,9 @@
       numToKeep: 10
     triggers:
         - timed: 'H * * * *'
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
       - shell: |
           #!/bin/bash

--- a/modules/govuk_jenkins/templates/jobs/govuk_taxonomy_supervised_learning.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/govuk_taxonomy_supervised_learning.yaml.erb
@@ -19,6 +19,9 @@
       - govuk-taxonomy-supervised-learning
     triggers:
         - timed: 'H 2 * * 1-5'
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
       - shell: |
           #!/bin/bash

--- a/modules/govuk_jenkins/templates/jobs/integration_app_deploy.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/integration_app_deploy.yaml.erb
@@ -4,6 +4,9 @@
     display-name: integration-app-deploy
     project-type: freestyle
     description: "Kicks off an appliction deploy in the Integration environment"
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
       - shell: |
           JSON="{\"parameter\": [{\"name\": \"TARGET_APPLICATION\", \"value\": \"$TARGET_APPLICATION\"}, {\"name\": \"TAG\", \"value\": \"$TAG\"}, {\"name\": \"DEPLOY_TASK\", \"value\": \"$DEPLOY_TASK\"}, {\"name\": \"NOTIFY_RELEASE_APP\", \"value\": \"true\"}, {\"name\": \"SLACK_NOTIFICATIONS\", \"value\": \"true\"}], \"\": \"\"}"

--- a/modules/govuk_jenkins/templates/jobs/integration_licensify_deploy.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/integration_licensify_deploy.yaml.erb
@@ -4,6 +4,9 @@
     display-name: integration-licensify-deploy
     project-type: freestyle
     description: "Kicks off a Licensify deploy in the Integration environment"
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
       - shell: |
           JSON="{\"parameter\": [{\"name\": \"BETA_PAYMENT_ACCOUNTS\", \"value\": \"false\"}, {\"name\": \"artefact_number\", \"value\": \"$artefact_number\"}, {\"name\": \"app_version\", \"value\": \"$appVersion\"}, {\"name\": \"CI_JOB_NAME\", \"value\": \"Licensify\"}, {\"name\": \"ARTIFACT_PATH\", \"value\": \"target/universal\"}], \"\": \"\"}"

--- a/modules/govuk_jenkins/templates/jobs/integration_puppet_deploy.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/integration_puppet_deploy.yaml.erb
@@ -4,6 +4,9 @@
     display-name: integration-puppet-deploy
     project-type: freestyle
     description: "Kicks off a Puppet deploy in the integration environment"
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
       - shell: |
           JSON="{\"parameter\": [{\"name\": \"TAG\", \"value\": \"$TAG\"}], \"\": \"\"}"

--- a/modules/govuk_jenkins/templates/jobs/integration_router_data_deploy.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/integration_router_data_deploy.yaml.erb
@@ -4,6 +4,9 @@
     display-name: integration-router-data-deploy
     project-type: freestyle
     description: "Kicks off a router-data deploy in the Integration environment"
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
       - shell: |
           JSON="{\"parameter\": [{\"name\": \"TAG\", \"value\": \"$TAG\"}], \"\": \"\"}"

--- a/modules/govuk_jenkins/templates/jobs/launch_vms.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/launch_vms.yaml.erb
@@ -25,6 +25,9 @@
               VCLOUD_HOST=<%= @vcloud_properties['host'] %>
     scm:
       - govuk-provisioning_Launch_VMs
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
         - shell: |
             ./vcloud-launcher/jenkins.sh

--- a/modules/govuk_jenkins/templates/jobs/launch_vms_dr.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/launch_vms_dr.yaml.erb
@@ -25,6 +25,9 @@
               VCLOUD_HOST=<%= @vcloud_properties['host'] %>
     scm:
       - govuk-provisioning_Launch_VMs_DR
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
         - shell: |
             ./vcloud-launcher/jenkins.sh

--- a/modules/govuk_jenkins/templates/jobs/launch_vms_licensify.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/launch_vms_licensify.yaml.erb
@@ -25,6 +25,9 @@
               VCLOUD_HOST=<%= @vcloud_properties_licensify['host'] %>
     scm:
       - govuk-provisioning_Launch_VMs_Licensify
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
         - shell: |
             ./vcloud-launcher/jenkins.sh

--- a/modules/govuk_jenkins/templates/jobs/mirror_network_config.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/mirror_network_config.yaml.erb
@@ -17,6 +17,9 @@
             url: https://github.com/alphagov/govuk_mirror-deployment
     scm:
       - govuk_mirror-deployment_Mirror_Network_Config
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
         - shell: |
             ./vcloud-edge_gateway/jenkins.sh $ENVIRONMENT $EXTRA_ARGUMENTS

--- a/modules/govuk_jenkins/templates/jobs/network_config_deploy.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/network_config_deploy.yaml.erb
@@ -20,6 +20,9 @@
             url: https://github.com/alphagov/govuk-provisioning/
     scm:
       - govuk-provisioning_Network_Config_Deploy
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
         - shell: |
             if [ "$DRY_RUN" = true ]; then

--- a/modules/govuk_jenkins/templates/jobs/performance_platform_data_sync.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/performance_platform_data_sync.yaml.erb
@@ -20,6 +20,9 @@
       - env-sync-and-backup_Performance_Platform_Data_Sync
     logrotate:
         numToKeep: 10
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
         - shell: |
             set -eu

--- a/modules/govuk_jenkins/templates/jobs/publishing_api_archive_events.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/publishing_api_archive_events.yaml.erb
@@ -4,6 +4,9 @@
     display-name: Publishing_API_Archive_Events
     project-type: freestyle
     description: "This job periodically archives publishing API events to S3"
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
       - shell: ssh deploy@$(govuk_node_list -c publishing_api --single-node) "cd /var/apps/publishing-api && govuk_setenv publishing-api bundle exec rake events:export_to_s3"
     logrotate:

--- a/modules/govuk_jenkins/templates/jobs/record_taxonomy_metrics.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/record_taxonomy_metrics.yaml.erb
@@ -10,6 +10,9 @@
       daysToKeep: 30
     triggers:
       - timed: 'H/30 * * * *'
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
       - shell: |
           #!/bin/bash

--- a/modules/govuk_jenkins/templates/jobs/remove_emergency_banner.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/remove_emergency_banner.yaml.erb
@@ -4,6 +4,9 @@
     display-name: Remove the emergency banner
     project-type: freestyle
     description: "Remove the emergency banner from GOV.UK."
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
       # The argument to `-c` is in this case `frontend` but the value is used by both `static` and `frontend` applications
       - shell: ssh deploy@$(govuk_node_list -c frontend --single-node) "cd /var/apps/static && govuk_setenv static bundle exec rake emergency_banner:remove"

--- a/modules/govuk_jenkins/templates/jobs/run_deploy_lag_badger.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/run_deploy_lag_badger.yaml.erb
@@ -18,6 +18,9 @@
         numToKeep: 100
     triggers:
         - timed: '0 13 * * *' # 1PM every day
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
         - shell: |
             export REALLY_POST_TO_SLACK=1

--- a/modules/govuk_jenkins/templates/jobs/run_rake_task.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/run_rake_task.yaml.erb
@@ -5,6 +5,9 @@
     project-type: freestyle
     description: "Run a rake task on an application."
     concurrent: true
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
       - shell: ssh deploy@$(govuk_node_list -c $MACHINE_CLASS --single-node) "cd /var/apps/$TARGET_APPLICATION && govuk_setenv $TARGET_APPLICATION bundle exec rake $RAKE_TASK"
     wrappers:

--- a/modules/govuk_jenkins/templates/jobs/run_whitehall_data_migrations.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/run_whitehall_data_migrations.yaml.erb
@@ -4,6 +4,9 @@
     display-name: Run_Whitehall_Data_Migrations
     project-type: freestyle
     description: "This job SSHes onto a whitehall-backend node and runs 'cd /var/apps/whitehall ; RAILS_ENV=production bundle exec rake db:data:migrate'"
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
         - shell: |
             ssh deploy@$(govuk_node_list -c whitehall_backend --single-node) "cd /var/apps/whitehall ; govuk_setenv whitehall bundle exec rake db:data:migrate"

--- a/modules/govuk_jenkins/templates/jobs/search_fetch_analytics_data.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/search_fetch_analytics_data.yaml.erb
@@ -28,6 +28,9 @@
             properties-content: |
               SKIP_TRAFFIC_LOAD=true
 <% end %>
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
         - shell: |
             ./nightly-run.sh

--- a/modules/govuk_jenkins/templates/jobs/search_index_checks.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/search_index_checks.yaml.erb
@@ -9,6 +9,9 @@
       numToKeep: 10
     triggers:
         - timed: 'H/10 * * * *'
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
         - shell: ssh deploy@$(govuk_node_list -c search --single-node) "cd /var/apps/rummager && govuk_setenv rummager bundle exec rake rummager:monitor_indices"
     wrappers:

--- a/modules/govuk_jenkins/templates/jobs/search_reindex_with_new_schema.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/search_reindex_with_new_schema.yaml.erb
@@ -11,6 +11,9 @@
     triggers:
         - timed: '<%= @cron_schedule %>'
 <% end %>
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
         - shell: ssh deploy@$(govuk_node_list -c search --single-node) "cd /var/apps/rummager && govuk_setenv rummager bundle exec rake rummager:migrate_schema CONFIRM_INDEX_MIGRATION_START=1 RUMMAGER_INDEX=all"
     wrappers:

--- a/modules/govuk_jenkins/templates/jobs/signon_cron_rake_tasks.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/signon_cron_rake_tasks.yaml.erb
@@ -4,6 +4,9 @@
     display-name: "Signon: Delete expired OAuth access grants (scheduled)"
     project-type: freestyle
     description: "<p>Regularly run the oauth_access_grants:delete_expired rake task for signon.</p>"
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
         - trigger-builds:
             - project: run-rake-task

--- a/modules/govuk_jenkins/templates/jobs/smokey.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/smokey.yaml.erb
@@ -60,6 +60,9 @@
             - developers
             - culprits
 
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
         - shell: |
             set +x

--- a/modules/govuk_jenkins/templates/jobs/smokey_deploy.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/smokey_deploy.yaml.erb
@@ -16,6 +16,9 @@
             url: https://github.com/alphagov/smokey/
     scm:
       - smokey_Smokey_Deploy
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
         - shell: |
             <%- if scope.lookupvar('::aws_migration') %>

--- a/modules/govuk_jenkins/templates/jobs/start_vapps.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/start_vapps.yaml.erb
@@ -36,6 +36,9 @@
             job-passwords:
                 - name: VCLOUD_PASSWORD
                   password: '<%= @vcloud_properties['password'] -%>'
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
         - shell: |
             cd tools/start_stop_vapps/

--- a/modules/govuk_jenkins/templates/jobs/start_vapps_dr.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/start_vapps_dr.yaml.erb
@@ -34,6 +34,9 @@
             job-passwords:
                 - name: VCLOUD_PASSWORD
                   password: '<%= @vcloud_properties_dr['password'] -%>'
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
         - shell: |
             cd tools/start_stop_vapps/

--- a/modules/govuk_jenkins/templates/jobs/stop_vapps.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/stop_vapps.yaml.erb
@@ -35,6 +35,9 @@
             job-passwords:
                 - name: VCLOUD_PASSWORD
                   password: '<%= @vcloud_properties['password'] -%>'
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
         - shell: |
             cd tools/start_stop_vapps/

--- a/modules/govuk_jenkins/templates/jobs/stop_vapps_dr.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/stop_vapps_dr.yaml.erb
@@ -35,6 +35,9 @@
             job-passwords:
                 - name: VCLOUD_PASSWORD
                   password: '<%= @vcloud_properties_dr['password'] -%>'
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
         - shell: |
             cd tools/start_stop_vapps/

--- a/modules/govuk_jenkins/templates/jobs/success_passive_check.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/success_passive_check.yaml.erb
@@ -6,6 +6,9 @@
     description: "This job should be used to send a passive check to Icinga with a SUCCESS
       status. As such this should only be used as a triggered build for a stable (or related)
       condition."
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
       - shell: |
           IPADDRESS=$(facter ipaddress)

--- a/modules/govuk_jenkins/templates/jobs/transition_load_all_data.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/transition_load_all_data.yaml.erb
@@ -6,6 +6,9 @@
     description: "<p>Loads mapping data and statistics into Transition/Bouncer.</p>"
     logrotate:
       numToKeep: 30
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
         - shell: |
             rm -rf data

--- a/modules/govuk_jenkins/templates/jobs/transition_load_site_config.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/transition_load_site_config.yaml.erb
@@ -16,6 +16,9 @@
       - transition-config_Transition_load_site_config
     logrotate:
       numToKeep: 30
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
         - shell: |
             <%- if scope.lookupvar('::aws_migration') %>

--- a/modules/govuk_jenkins/templates/jobs/transition_load_transition_stats_hits.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/transition_load_transition_stats_hits.yaml.erb
@@ -11,6 +11,9 @@
             url: https://github.com/alphagov/transition-stats/
     triggers:
         - timed: '50 07-19 * * 1-5'
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
         - shell: |
             rm -rf data

--- a/modules/govuk_jenkins/templates/jobs/travel_advice_email_alert_check.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/travel_advice_email_alert_check.yaml.erb
@@ -8,6 +8,9 @@
         numToKeep: 100
     triggers:
         - timed: '*/15 * * * *' # every 15 minutes
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
         - shell: |
             (

--- a/modules/govuk_jenkins/templates/jobs/trigger_data_sync_complete.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/trigger_data_sync_complete.yaml.erb
@@ -6,6 +6,9 @@
     description: "This job triggers the Data_Sync_Complete jobs on a remote Jenkins machine"
     logrotate:
         numToKeep: 10
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
         - shell: |
             echo "Getting crumb..."

--- a/modules/govuk_jenkins/templates/jobs/trigger_data_sync_complete_aws.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/trigger_data_sync_complete_aws.yaml.erb
@@ -6,6 +6,9 @@
     description: "This job triggers the Data_Sync_Complete jobs on a remote Jenkins machine in AWS"
     logrotate:
         numToKeep: 10
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
         - shell: |
             # Trigger on AWS

--- a/modules/govuk_jenkins/templates/jobs/update_cdn_dictionaries.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/update_cdn_dictionaries.yaml.erb
@@ -31,6 +31,9 @@
 
     scm:
       - update_cdn_dictionaries
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
         - shell: |
             cd fastly

--- a/modules/govuk_jenkins/templates/jobs/user_monitor.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/user_monitor.yaml.erb
@@ -18,6 +18,9 @@
         numToKeep: 100
     triggers:
         - timed: '35 * * * *' # every hour on the 35th minute
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
         - shell: |
             bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment

--- a/modules/govuk_jenkins/templates/jobs/validate_published_dns.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/validate_published_dns.yaml.erb
@@ -21,6 +21,9 @@
             url: https://github.com/alphagov/govuk-dns/
     scm:
       - dns_tools
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
         - shell: |
             set -e

--- a/modules/govuk_jenkins/templates/jobs/whitehall_run_broken_link_checker.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/whitehall_run_broken_link_checker.yaml.erb
@@ -4,6 +4,9 @@
     display-name: whitehall_run_broken_link_checker
     project-type: freestyle
     description: "<p>Triggers the broken link checker rake task on whitehall-backend-1.</p>"
+    discard_old: # Discard old builds after:
+      days: 30 # Optional, number of days after which the build is deleted
+      artifact_number: 4 # Optional, number of builds after which the artifact is deleted
     builders:
         - shell: |
             ssh deploy@$(govuk_node_list -c whitehall_backend --single-node) 'cd /var/apps/whitehall; govuk_setenv whitehall nohup bundle exec rake generate_broken_link_reports[/tmp/bad_link_reports,second-line-content@digital.cabinet-office.gov.uk]'


### PR DESCRIPTION
At the moment we don't discard old builds, so jobs which get run a lot (like success_fail_passive_check) are using up a lot of disk space.

See https://github.com/constantcontact/jenkins_pipeline_builder/wiki/Job-and-Promotion-DSL