### PR TITLE
Increase freshness threshold for duplicity backups

### DIFF
--- a/modules/backup/manifests/offsite/job.pp
+++ b/modules/backup/manifests/offsite/job.pp
@@ -108,9 +108,9 @@ define backup::offsite::job(
   }
 
   if $weekday == undef { # duplicity job runs daily
-    $freshness_threshold = 28 * 60 * 60 # one day plus 4 hours
+    $freshness_threshold = 32 * 60 * 60 # one day plus 8 hours
   } else { # duplicity runs weekly
-    $freshness_threshold = (4 + (7 * 24)) * 60 * 60 # one week plus 4 hours
+    $freshness_threshold = (8 + (7 * 24)) * 60 * 60 # one week plus 8 hours
   }
 
   @@icinga::passive_check { "check_backup_offsite-${title}-${::hostname}":


### PR DESCRIPTION
These backups seem to take a long time. They start at 4:20 in the
morning, and we are being alerted that the backup is still running at
10am.

Our developer docs warn that the task may still be running, so this
seems like a common occurance.
https://docs.publishing.service.gov.uk/manual/alerts/offsite-backups.html

We have no logs for this process, so I'm going to raise a separate
PR to add logs.