### PR TITLE
Upgrade jenkins job builder

### DIFF
--- a/modules/govuk_jenkins/manifests/job_builder.pp
+++ b/modules/govuk_jenkins/manifests/job_builder.pp
@@ -47,7 +47,7 @@ class govuk_jenkins::job_builder (
   }
 
   package { 'jenkins-job-builder':
-    ensure   => '1.6.1',
+    ensure   => '2.0.3',
     provider => pip,
   }
 


### PR DESCRIPTION
The version we're on doesn't seem to understand the properties
I added in https://github.com/alphagov/govuk-puppet/pull/7386

Older versions used to use "logrotate" instead of build discarder.