### PR TITLE
add petergoddard to hieradata_aws/integration.yaml

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -177,6 +177,7 @@ users::usernames:
   - pablomanrubia
   - paulbowsher
   - paulhayes
+  - petergoddard
   - peterhartshorn
   - philippotter
   - richardboulton


### PR DESCRIPTION
I missed adding myself to this file when I joined and therefore I can't ssh into integration.