### PR TITLE
AWS RDA Transition DB Postgresql

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/copy_data_from_staging_to_aws.pp
+++ b/modules/govuk_jenkins/manifests/jobs/copy_data_from_staging_to_aws.pp
@@ -8,6 +8,7 @@ class govuk_jenkins::jobs::copy_data_from_staging_to_aws (
   $pg_src_env_sync_pw = undef,
   $pg_dst_env_sync_pw = undef,
   $pg_tr_dst_env_sync_pw = undef,
+  $pg_tr_src_env_sync_pw = undef,
   $whitehall_mysql_password = undef,
   $app_domain = hiera('app_domain'),
 ) {

--- a/modules/govuk_jenkins/templates/jobs/copy_data_from_staging_to_aws.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_from_staging_to_aws.yaml.erb
@@ -52,6 +52,10 @@
             sed -i.bak "s/PG_SRC_ENV_SYNC_PW=PLACEHOLDER/PG_SRC_ENV_SYNC_PW='<%= @pg_src_env_sync_pw %>'/" scripts/sync-postgresql.sh
             sed -i "s/PG_DST_ENV_SYNC_PW=PLACEHOLDER/PG_DST_ENV_SYNC_PW='<%= @pg_dst_env_sync_pw %>'/" scripts/sync-postgresql.sh
 
+            echo "Putting in the real Transition Postgresql transition password"
+            sed -i.bak "s/PG_TR_SRC_ENV_SYNC_PW=PLACEHOLDER/PG_TR_SRC_ENV_SYNC_PW='<%= @pg_tr_src_env_sync_pw %>'/" scripts/sync-transition-postgresql.sh
+            sed -i "s/PG_TR_DST_ENV_SYNC_PW=PLACEHOLDER/PG_TR_DST_ENV_SYNC_PW='<%= @pg_tr_dst_env_sync_pw %>'/" scripts/sync-transition-postgresql.sh
+
             set +e
 
             echo "Running Data Sync"


### PR DESCRIPTION
- When we copy data from the Carrenza 'transition' postgresql database
  to AWS RDS, we have to provide the database user authentication
details. This has been covered by this commit.

Solo: @suthagarht