### PR TITLE
Change S3 mirror instance aws crawler writes to.

### DIFF
--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -45,7 +45,7 @@ govuk_cdnlogs::critical_cdn_freshness: 172800 # 2 days
 govuk_crawler::seed_enable: true
 govuk_crawler::sync_enable: true
 govuk_crawler::targets:
-  - 's3://govuk-mirror-staging/'
+  - 's3://govuk-staging-mirror-1/'
 
 govuk_elasticsearch::dump::run_es_dump_hour: '4'
 


### PR DESCRIPTION
- Move target away from current/Carrenza staging mirror govuk-mirror-staging to
  recently added govuk-staging-mirror-1 (To be replicated to
  govuk-staging-mirror-2 in London)

Solo: @schmie