### PR TITLE
Change app_domain for aws staging to staging.govuk.digital

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -473,9 +473,8 @@ govuk::apps::govuk_crawler_worker::blacklist_paths:
 
 govuk::apps::govuk_crawler_worker::enabled: true
 govuk::apps::govuk_crawler_worker::root_urls:
-  - 'https://assets.digital.cabinet-office.gov.uk/'
-  - 'https://assets.publishing.service.gov.uk/'
-  - 'https://www.gov.uk/'
+  - "https://assets-origin.%{hiera('app_domain')}"
+  - "https://www-origin.%{hiera('app_domain')}"
 
 govuk::apps::imminence::mongodb_nodes:
   - 'mongo-1'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -1,5 +1,5 @@
 ---
-app_domain: 'staging.publishing.service.gov.uk'
+app_domain: 'staging.govuk.digital'
 app_domain_internal: "staging.govuk-internal.digital"
 
 backup::server::backup_hour: 9


### PR DESCRIPTION
- config in hieradata_aws/staging.yaml still pointed to staging.publishing.service.gov.uk and is causing the
  govuk_crawler_worker to get confused.

- Furthermore, the targets of crawler as they are defined in hieradata_aws/common.yaml.
  Changed this now to prevent the crawler from timing out trying to access Carrenza.

Solo: @schmie