### PR TITLE
Adding variable use_tls to the govuk_cdnlogs module

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -691,6 +691,7 @@ govuk_sshkeys::deployment_keys:
     key: 'AAAAB3NzaC1yc2EAAAADAQABAAABAQC5y+7bm9YIMJXYbSdk2pVzl/w110eFrLIvirT4HKYATp7pxV454T2YoWIvIbtKF7GKz1SwX79uKePmwFKBQ8LIYlmFBbcYf8j3Jl9Px4vcmDPkWjZlfg/aqZUJI3WqwVCNelYM+RTlgtDsME8hIK2FbyPIjotF1WRsE1JgsMLfpzK/rVACGbktfQdmgY+56Ze9WA/rfCCKvrCtdavFR1rNxwkjm+GMImlcgmYTIT8BCEM2pkK0dIEJwKJWBVyyRBcTwHZDgvfVM/EyEfe+gIsgiQTORa1JaScHntH7Q7CBagpXvQHr/tSngGvbSBM1vMRLdtrw8BF5//AmNLOW3glZ'
 
 govuk_cdnlogs::rotate_logs_hourly: ['bouncer']
+govuk_cdnlogs::use_tls: '1'
 govuk_cdnlogs::service_port_map:
   govuk: 6514
   assets: 6515

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -717,6 +717,7 @@ govuk_sshkeys::deployment_keys:
     key: 'AAAAB3NzaC1yc2EAAAADAQABAAABAQC5y+7bm9YIMJXYbSdk2pVzl/w110eFrLIvirT4HKYATp7pxV454T2YoWIvIbtKF7GKz1SwX79uKePmwFKBQ8LIYlmFBbcYf8j3Jl9Px4vcmDPkWjZlfg/aqZUJI3WqwVCNelYM+RTlgtDsME8hIK2FbyPIjotF1WRsE1JgsMLfpzK/rVACGbktfQdmgY+56Ze9WA/rfCCKvrCtdavFR1rNxwkjm+GMImlcgmYTIT8BCEM2pkK0dIEJwKJWBVyyRBcTwHZDgvfVM/EyEfe+gIsgiQTORa1JaScHntH7Q7CBagpXvQHr/tSngGvbSBM1vMRLdtrw8BF5//AmNLOW3glZ'
 
 govuk_cdnlogs::rotate_logs_hourly: ['bouncer']
+govuk_cdnlogs::use_tls: '0'
 govuk_cdnlogs::service_port_map:
   govuk: 6514
   assets: 6515

--- a/modules/govuk_cdnlogs/manifests/init.pp
+++ b/modules/govuk_cdnlogs/manifests/init.pp
@@ -24,6 +24,11 @@
 #   Hash of service names and ports, e.g.
 #     { 'govuk' => 6514 }
 #
+# [*use_tls*]
+#   0: do not expect encrypted connection
+#   1: expect encrypted connection
+#
+
 class govuk_cdnlogs (
   $log_dir,
   $govuk_monitoring_enabled = true,
@@ -33,6 +38,7 @@ class govuk_cdnlogs (
   $critical_cdn_freshness = 3600,
   $server_key,
   $server_crt,
+  $use_tls = '1' ,
   $service_port_map,
 ) {
   validate_hash($service_port_map)

--- a/modules/govuk_cdnlogs/templates/etc/rsyslog.d/ccc-cdnlogs.conf.erb
+++ b/modules/govuk_cdnlogs/templates/etc/rsyslog.d/ccc-cdnlogs.conf.erb
@@ -13,7 +13,7 @@ $DefaultNetstreamDriverCertFile <%= @crt_file %>
 $DefaultNetstreamDriverKeyFile <%= @key_file %>
 
 # Verify server, not client.
-$InputTCPServerStreamDriverMode 1
+$InputTCPServerStreamDriverMode <%= @use_tls %>
 $InputTCPServerStreamDriverAuthMode anon
 
 # Temporarily disable message de-dupe.


### PR DESCRIPTION
  We set the value to '1' on carrenza so nothing changes, on AWS we set the value to '0' as we've moved the SSL endpoint to the ELB and therefore the last leg between the ELB and the vm is left unencrypted