### PR TITLE
Add redis-tools to db_admin

### DIFF
--- a/modules/govuk/manifests/node/s_db_admin.pp
+++ b/modules/govuk/manifests/node/s_db_admin.pp
@@ -49,6 +49,10 @@ class govuk::node::s_db_admin(
     require => Apt::Source['gof3r'],
   }
 
+  package { 'redis-tools':
+    ensure  => $ensure,
+  }
+
   $alert_hostname = 'alert'
 
   ### MySQL ###


### PR DESCRIPTION
Install redis-tools so we can access redis on the AWS integration environment

Related to: https://github.com/alphagov/govuk-aws/pull/522

For: https://trello.com/c/CA3PFmY1/129-install-redis-tools-on-aws-integration