### PR TITLE
Use the API healthcheck for content performance manager

### DIFF
--- a/modules/govuk/manifests/apps/content_performance_manager.pp
+++ b/modules/govuk/manifests/apps/content_performance_manager.pp
@@ -100,7 +100,8 @@ class govuk::apps::content_performance_manager(
     app_type          => 'rack',
     port              => $port,
     sentry_dsn        => $sentry_dsn,
-    health_check_path => '/',
+    health_check_path => '/api/v1/healthcheck',
+    json_health_check => true,
     asset_pipeline    => true,
   }
 


### PR DESCRIPTION
CPM no longer exists as an app, so the homepage returns a 404. The API is still
part of it though so we should monitor that.

See https://github.com/alphagov/content-performance-manager/pull/593