### PR TITLE
Ensure email-alert-api is absent from backend

### DIFF
--- a/hieradata/class/backend.yaml
+++ b/hieradata/class/backend.yaml
@@ -5,6 +5,9 @@ govuk::apps::contacts::db_hostname: 'mysql-master-1.backend'
 govuk::apps::contacts::db_username: 'contacts'
 govuk::apps::contacts::db_password: "%{hiera('govuk::apps::contacts::db::mysql_contacts_admin')}"
 
+govuk::apps::email_alert_api::ensure: 'absent'
+govuk::apps::email_alert_service::ensure: 'absent'
+
 govuk::apps::event_store::mongodb_servers:
   - 'mongo-1.backend'
   - 'mongo-2.backend'

--- a/hieradata_aws/class/backend.yaml
+++ b/hieradata_aws/class/backend.yaml
@@ -5,6 +5,9 @@ govuk::apps::contacts::db_hostname: 'mysql-primary'
 govuk::apps::contacts::db_username: 'contacts'
 govuk::apps::contacts::db_password: "%{hiera('govuk::apps::contacts::db::mysql_contacts_admin')}"
 
+govuk::apps::email_alert_api::ensure: 'absent'
+govuk::apps::email_alert_service::ensure: 'absent'
+
 govuk::apps::manuals_publisher::mongodb_name: 'govuk_content_production'
 govuk::apps::manuals_publisher::mongodb_nodes:
   - 'mongo-1'


### PR DESCRIPTION
Email alert api has been moved to its own machine.
We still have some email-alert-api processes hanging around on backend
machines. Ensure they are absent to try and clean them up.