### PR TITLE
Add email alert api to aws backend

### DIFF
--- a/hieradata_aws/class/backend.yaml
+++ b/hieradata_aws/class/backend.yaml
@@ -5,6 +5,8 @@ govuk::apps::contacts::db_hostname: 'mysql-primary'
 govuk::apps::contacts::db_username: 'contacts'
 govuk::apps::contacts::db_password: "%{hiera('govuk::apps::contacts::db::mysql_contacts_admin')}"
 
+govuk::apps::email_alert_api::enabled: false
+
 govuk::apps::manuals_publisher::mongodb_name: 'govuk_content_production'
 govuk::apps::manuals_publisher::mongodb_nodes:
   - 'mongo-1'

--- a/hieradata_aws/class/backend.yaml
+++ b/hieradata_aws/class/backend.yaml
@@ -5,9 +5,6 @@ govuk::apps::contacts::db_hostname: 'mysql-primary'
 govuk::apps::contacts::db_username: 'contacts'
 govuk::apps::contacts::db_password: "%{hiera('govuk::apps::contacts::db::mysql_contacts_admin')}"
 
-govuk::apps::email_alert_api::ensure: 'absent'
-govuk::apps::email_alert_service::ensure: 'absent'
-
 govuk::apps::manuals_publisher::mongodb_name: 'govuk_content_production'
 govuk::apps::manuals_publisher::mongodb_nodes:
   - 'mongo-1'

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -22,6 +22,7 @@ node_class: &node_class
       - content-audit-tool
       - content-performance-manager
       - content-tagger
+      - email-alert-api
       - event-store
       - hmrc-manuals-api
       - imminence

--- a/modules/govuk/manifests/apps/email_alert_api.pp
+++ b/modules/govuk/manifests/apps/email_alert_api.pp
@@ -103,6 +103,8 @@ class govuk::apps::email_alert_api(
 ) {
 
   if $enabled {
+    notify { 'Email alert api enabled': }
+
     govuk::app { 'email-alert-api':
       app_type                 => 'rack',
       port                     => $port,
@@ -233,6 +235,8 @@ class govuk::apps::email_alert_api(
     }
   }
   else {
+    notify { 'Email alert api not enabled': }
+
     govuk::app { 'email-alert-api':
       ensure   => 'absent',
       app_type => 'rack',

--- a/modules/govuk/manifests/apps/email_alert_api.pp
+++ b/modules/govuk/manifests/apps/email_alert_api.pp
@@ -232,4 +232,16 @@ class govuk::apps::email_alert_api(
       }
     }
   }
+  else {
+    govuk::app { 'email-alert-api':
+      ensure   => 'absent',
+      app_type => 'rack',
+      port     => $port,
+    }
+
+    govuk::procfile::worker {'email-alert-api':
+      ensure         => 'absent',
+      enable_service => false,
+    }
+  }
 }


### PR DESCRIPTION
Email alert api is still hanging around on `backend` machines despite now having its own servers. A previous commit set `govuk::apps::email_alert_api::ensure: 'absent'` in `hieradata/class/backend.yaml` but this had no effect because backend machines were not configured to include `email-alert-api`. We still want to stop and remove the various `email-alert-api` services and processes on `backend` machines.

This PR attempts to address that on our integration environment by creating an `else` condition in `email_alert_api` manifest which ensures the app is absent when it is not `$enabled`.

If this successfully removes the recalcitrant services, a subsequent PR will do the same to non-aws environments so that it runs on staging and production.