### PR TITLE
Set the transition authentication variables when syncing staging

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
@@ -55,6 +55,10 @@
             sed -i "s/PG_DST_ENV_SYNC_PW=PLACEHOLDER/PG_DST_ENV_SYNC_PW='<%= @pg_dst_env_sync_pw %>'/" scripts/sync-postgresql.sh
             sed -i "s/PG_DST_ENV_SYNC_PW=TR_PLACEHOLDER/PG_DST_ENV_SYNC_PW='<%= @pg_tr_dst_env_sync_pw %>'/" scripts/sync-postgresql.sh
 
+            echo "Putting in the real Transition Postgresql transition password"
+            sed -i.bak "s/PG_TR_SRC_ENV_SYNC_PW=PLACEHOLDER/PG_TR_SRC_ENV_SYNC_PW='<%= @pg_src_env_sync_pw %>'/" scripts/sync-transition-postgresql.sh
+            sed -i "s/PG_TR_DST_ENV_SYNC_PW=PLACEHOLDER/PG_TR_DST_ENV_SYNC_PW='<%= @pg_tr_dst_env_sync_pw %>'/" scripts/sync-transition-postgresql.sh
+
             echo "Syncing data"
             bash sync production integration
     publishers:

--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_staging.yaml.erb
@@ -52,6 +52,10 @@
             sed -i.bak "s/PG_SRC_ENV_SYNC_PW=PLACEHOLDER/PG_SRC_ENV_SYNC_PW='<%= @pg_src_env_sync_pw %>'/" scripts/sync-postgresql.sh
             sed -i "s/PG_DST_ENV_SYNC_PW=PLACEHOLDER/PG_DST_ENV_SYNC_PW='<%= @pg_dst_env_sync_pw %>'/" scripts/sync-postgresql.sh
 
+            echo "Putting in the real Transition Postgresql transition password"
+            sed -i.bak "s/PG_TR_SRC_ENV_SYNC_PW=PLACEHOLDER/PG_TR_SRC_ENV_SYNC_PW='<%= @pg_src_env_sync_pw %>'/" scripts/sync-transition-postgresql.sh
+            sed -i "s/PG_TR_DST_ENV_SYNC_PW=PLACEHOLDER/PG_TR_DST_ENV_SYNC_PW='<%= @pg_dst_env_sync_pw %>'/" scripts/sync-transition-postgresql.sh
+
             set +e
 
             echo "Disabling Gor traffic replay"


### PR DESCRIPTION
The staging sync was recently [changed to use a new script which has different variable names for the passwords, `PG_TR_SRC_ENV_SYNC_PW` and `PG_TR_DST_ENV_SYNC_PW`](https://github.com/alphagov/env-sync-and-backup/pull/72/files#diff-f99ca43a8a970b1128838bdd6b3d6866R11). Since before we were using the same password for normal postgres and transition postgres, I assume that we can set it to be the same as normal postgres.