### PR TITLE
Update stats on scheduled publishing dashboard

### DIFF
--- a/modules/grafana/files/dashboards/scheduled_publishing.json
+++ b/modules/grafana/files/dashboards/scheduled_publishing.json
@@ -28,6 +28,7 @@
             "current": false,
             "max": false,
             "min": false,
+            "rightSide": true,
             "show": true,
             "total": false,
             "values": false
@@ -48,8 +49,33 @@
           "targets": [
             {
               "refId": "A",
-              "target": "groupByNode(stats.gauges.govuk.app.content-store.*.scheduled_publishing.aggregate.*, 8, 'sum')",
-              "textEditor": true
+              "target": "alias(stats.gauges.govuk.app.content-store.content-store-1.scheduled_publishing.aggregate.national_statistics.mean_ms, 'mean - national statistics')",
+              "textEditor": false
+            },
+            {
+              "refId": "B",
+              "target": "alias(stats.gauges.govuk.app.content-store.content-store-1.scheduled_publishing.aggregate.official_statistics.mean_ms, 'mean - official statistics')",
+              "textEditor": false
+            },
+            {
+              "refId": "C",
+              "target": "alias(stats.gauges.govuk.app.content-store.content-store-1.scheduled_publishing.aggregate.other_document_types.mean_ms, 'mean - other doc types')",
+              "textEditor": false
+            },
+            {
+              "refId": "D",
+              "target": "alias(stats.gauges.govuk.app.content-store.content-store-1.scheduled_publishing.aggregate.national_statistics.95_percentile_ms, '95pc - national statistics')",
+              "textEditor": false
+            },
+            {
+              "refId": "E",
+              "target": "alias(stats.gauges.govuk.app.content-store.content-store-1.scheduled_publishing.aggregate.official_statistics.95_percentile_ms, '95pc - official statistics')",
+              "textEditor": false
+            },
+            {
+              "refId": "F",
+              "target": "alias(stats.gauges.govuk.app.content-store.content-store-1.scheduled_publishing.aggregate.other_document_types.95_percentile_ms, '95pc - other doc types')",
+              "textEditor": false
             }
           ],
           "thresholds": [],


### PR DESCRIPTION
Update the grafana dashboard which shows scheduled publishing delays. The stats were split by document type in https://github.com/alphagov/content-store/pull/401, so plot them as separate series on the same graph.

https://trello.com/c/pMHR10Rv/85-2-scheduled-publication-reporting