### PR TITLE
Adding whisper database backup to S3 for graphite node

### DIFF
--- a/modules/govuk/manifests/node/s_apt.pp
+++ b/modules/govuk/manifests/node/s_apt.pp
@@ -143,6 +143,7 @@ class govuk::node::s_apt (
   aptly::repo { 'statsd': }
   aptly::repo { 'terraform': }
   aptly::repo { 'vale': }
+  aptly::repo { 'whisper-backup': }
 
   include nginx
   nginx::config::site { $apt_service:


### PR DESCRIPTION
Adding requirement for packages whisper-backup and google snappy, and cron job for regular backups on S3