### PR TITLE
Remove email alert api and procfile worker from backend

### DIFF
--- a/hieradata/class/backend.yaml
+++ b/hieradata/class/backend.yaml
@@ -5,8 +5,7 @@ govuk::apps::contacts::db_hostname: 'mysql-master-1.backend'
 govuk::apps::contacts::db_username: 'contacts'
 govuk::apps::contacts::db_password: "%{hiera('govuk::apps::contacts::db::mysql_contacts_admin')}"
 
-govuk::apps::email_alert_api::ensure: 'absent'
-govuk::apps::email_alert_service::ensure: 'absent'
+govuk::apps::email_alert_api::enabled: false
 
 govuk::apps::event_store::mongodb_servers:
   - 'mongo-1.backend'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -24,6 +24,7 @@ node_class: &node_class
       - content-audit-tool
       - content-performance-manager
       - content-tagger
+      - email-alert-api
       - event-store
       - hmrc-manuals-api
       - imminence

--- a/hieradata_aws/class/backend.yaml
+++ b/hieradata_aws/class/backend.yaml
@@ -5,8 +5,7 @@ govuk::apps::contacts::db_hostname: 'mysql-primary'
 govuk::apps::contacts::db_username: 'contacts'
 govuk::apps::contacts::db_password: "%{hiera('govuk::apps::contacts::db::mysql_contacts_admin')}"
 
-govuk::apps::email_alert_api::ensure: 'absent'
-govuk::apps::email_alert_service::ensure: 'absent'
+govuk::apps::email_alert_api::enabled: false
 
 govuk::apps::manuals_publisher::mongodb_name: 'govuk_content_production'
 govuk::apps::manuals_publisher::mongodb_nodes:

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -22,6 +22,7 @@ node_class: &node_class
       - content-audit-tool
       - content-performance-manager
       - content-tagger
+      - email-alert-api
       - event-store
       - hmrc-manuals-api
       - imminence

--- a/modules/govuk/manifests/apps/email_alert_api.pp
+++ b/modules/govuk/manifests/apps/email_alert_api.pp
@@ -232,4 +232,16 @@ class govuk::apps::email_alert_api(
       }
     }
   }
+  else {
+    govuk::app { 'email-alert-api':
+      ensure   => 'absent',
+      app_type => 'rack',
+      port     => $port,
+    }
+
+    govuk::procfile::worker {'email-alert-api':
+      ensure         => 'absent',
+      enable_service => false,
+    }
+  }
 }


### PR DESCRIPTION
We want to stop email-alert-api and associated profile worker from running on backend machines. 

* Add `email-alert-api` into backend machines in the hieradata
* Set `email_alert_api::enabled` to `false` in backend hieradata
* Remove `email_alert_api::ensure` setting from backend hieradata since we are relying on `enabled` instead.
* Add else condition on `enabled` in `email_alert_api` manifest and when it is `false`, ensure `email-alert-api` and its profile worker are absent

This gets us most of the way to remove all traces of email-alert-api from backend machines. After this there will still be some logship processes hanging around and also a `rackup` command.

[Trello](https://trello.com/c/ida7jtCQ/715-investigate-properly-removing-email-alert-api-from-backend-machines)