### PR TITLE
Update Jenkins cron for Audit Tool and CPM

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -123,7 +123,7 @@ govuk_jenkins::jobs::network_config_deploy::environments:
   - 'carrenza-production-dr'
   - 'skyscape-production'
 
-govuk_jenkins::jobs::content_audit_tool::rake_etl_master_process_cron_schedule: '0 1 * * *'
+govuk_jenkins::jobs::content_performance_manager::rake_etl_master_process_cron_schedule: '0 1 * * *'
 
 govuk_jenkins::jobs::content_performance_manager::rake_import_all_content_items_frequency: '0 2 * * *'
 govuk_jenkins::jobs::content_performance_manager::rake_import_all_ga_metrics_frequency: '0 7 * * *'

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -125,8 +125,8 @@ govuk_jenkins::jobs::network_config_deploy::environments:
 
 govuk_jenkins::jobs::content_performance_manager::rake_etl_master_process_cron_schedule: '0 1 * * *'
 
-govuk_jenkins::jobs::content_performance_manager::rake_import_all_content_items_frequency: '0 2 * * *'
-govuk_jenkins::jobs::content_performance_manager::rake_import_all_ga_metrics_frequency: '0 7 * * *'
+govuk_jenkins::jobs::content_audit_tool::rake_import_all_content_items_frequency: '0 1 * * 0,3'
+govuk_jenkins::jobs::content_audit_tool::rake_import_all_ga_metrics_frequency: '0 6 * * 0,3'
 
 govuk_jenkins::jobs::signon_cron_rake_tasks::configure_jobs: true
 govuk_jenkins::jobs::signon_cron_rake_tasks::rake_oauth_access_grants_delete_expired_frequency: '0 12 * * 0'


### PR DESCRIPTION
Reverts two changes in #7390:

1. Set `cron` Jenkins schedule for Content Performance Manager.
2. Set `cron` Jenkins schedule for Audit Tool.


