### PR TITLE
Enable email subscription management in integration

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -15,6 +15,7 @@ govuk::apps::email_alert_api::govuk_notify_template_id: '1fc69d3a-09a2-40f9-852b
 govuk::apps::email_alert_api::email_address_override: 'success@simulator.amazonses.com'
 govuk::apps::email_alert_api::email_address_override_whitelist_only: true
 govuk::apps::email_alert_api::delivery_request_threshold: "3000"
+govuk::apps::email_alert_frontend::subscription_management_enabled: true
 govuk::apps::govuk_crawler_worker::enabled: false
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
 govuk::apps::kibana::logit_environment: 2694f14b-6519-4607-81f2-8a2130e5aaec

--- a/modules/govuk/manifests/apps/email_alert_frontend.pp
+++ b/modules/govuk/manifests/apps/email_alert_frontend.pp
@@ -28,6 +28,9 @@
 # [*email_alert_api_bearer_token*]
 #   Bearer token for communication with the email-alert-api
 #
+# [*subscription_management_enabled*]
+#   Whether the subscription management interface is enabled.
+#
 class govuk::apps::email_alert_frontend(
   $vhost = 'email-alert-frontend',
   $port = '3099',
@@ -35,6 +38,7 @@ class govuk::apps::email_alert_frontend(
   $secret_key_base = undef,
   $sentry_dsn = undef,
   $email_alert_api_bearer_token = undef,
+  $subscription_management_enabled = false,
 ) {
   govuk::app { 'email-alert-frontend':
     app_type              => 'rack',
@@ -59,5 +63,12 @@ class govuk::apps::email_alert_frontend(
     "${title}-EMAIL_ALERT_API_BEARER_TOKEN":
         varname => 'EMAIL_ALERT_API_BEARER_TOKEN',
         value   => $email_alert_api_bearer_token;
+  }
+
+  if $subscription_management_enabled {
+    govuk::app::envvar { "${title}-SUBSCRIPTION_MANAGEMENT_ENABLED":
+      varname => 'SUBSCRIPTION_MANAGEMENT_ENABLED',
+      value   => 'yes';
+    }
   }
 }


### PR DESCRIPTION
This commit adds an environment variable to integration only that enables the new subscription management interface in email-alert-frontend for testing purposes.

Trello: https://trello.com/c/zy8FYa0N/722-add-a-page-to-show-all-subscriptions-for-a-subscriber