### PR TITLE
Set up EMAIL_ALERT_AUTH_TOKEN env vars

### DIFF
--- a/modules/govuk/manifests/apps/email_alert_api.pp
+++ b/modules/govuk/manifests/apps/email_alert_api.pp
@@ -50,6 +50,10 @@
 # [*oauth_secret*]
 #   Sets the OAuth Secret Key
 #
+# [*email_alert_auth_token*]
+#   Sets the secret token used for encrypting and decrypting messages shared
+#   between email alert applications
+#
 # [*email_service_provider*]
 #   Configure which provider to use for sending emails.
 #    PSUEDO - Don't actually send emails, instead just log them.
@@ -90,6 +94,7 @@ class govuk::apps::email_alert_api(
   $secret_key_base = undef,
   $oauth_id = undef,
   $oauth_secret = undef,
+  $email_alert_auth_token = undef,
   $email_service_provider = 'NOTIFY',
   $email_address_override = undef,
   $email_address_override_whitelist = undef,
@@ -176,6 +181,9 @@ class govuk::apps::email_alert_api(
       "${title}-OAUTH_SECRET":
           varname => 'OAUTH_SECRET',
           value   => $oauth_secret;
+      "${title}-EMAIL_ALERT_AUTH_TOKEN":
+          varname => 'EMAIL_ALERT_AUTH_TOKEN',
+          value   => $email_alert_auth_token;
       "${title}-EMAIL_SERVICE_PROVIDER":
           varname => 'EMAIL_SERVICE_PROVIDER',
           value   => $email_service_provider;

--- a/modules/govuk/manifests/apps/email_alert_frontend.pp
+++ b/modules/govuk/manifests/apps/email_alert_frontend.pp
@@ -28,6 +28,10 @@
 # [*email_alert_api_bearer_token*]
 #   Bearer token for communication with the email-alert-api
 #
+# [*email_alert_auth_token*]
+#   Sets the secret token used for encrypting and decrypting messages shared
+#   between email alert applications
+#
 # [*subscription_management_enabled*]
 #   Whether the subscription management interface is enabled.
 #
@@ -38,6 +42,7 @@ class govuk::apps::email_alert_frontend(
   $secret_key_base = undef,
   $sentry_dsn = undef,
   $email_alert_api_bearer_token = undef,
+  $email_alert_auth_token = undef,
   $subscription_management_enabled = false,
 ) {
   govuk::app { 'email-alert-frontend':
@@ -63,6 +68,9 @@ class govuk::apps::email_alert_frontend(
     "${title}-EMAIL_ALERT_API_BEARER_TOKEN":
         varname => 'EMAIL_ALERT_API_BEARER_TOKEN',
         value   => $email_alert_api_bearer_token;
+    "${title}-EMAIL_ALERT_AUTH_TOKEN":
+        varname => 'EMAIL_ALERT_AUTH_TOKEN',
+        value   => $email_alert_auth_token;
   }
 
   if $subscription_management_enabled {


### PR DESCRIPTION
Trello: https://trello.com/c/6YmlH3Mq/725-add-token-based-login-for-the-subscription-management-interface-to-email-alert-frontend

EMAIL_ALERT_AUTH_TOKEN is a secret that is a secret that is shared
between apps to encrypt/decrpyt JWT tokens used for authenticating
users.

Email Alert API is responsible for generating and emailing tokens to
users, whereas Email Alert Frontend is responsible for decrypting it and
making use of the contents.