### PR TITLE
Enable subscription management for staging Email Alert Frontend

### DIFF
--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -22,6 +22,7 @@ govuk::apps::email_alert_api::govuk_notify_template_id: '2844a647-6bf1-4b01-a25c
 govuk::apps::email_alert_api::email_address_override: 'success@simulator.amazonses.com'
 govuk::apps::email_alert_api::email_address_override_whitelist_only: true
 govuk::apps::email_alert_api::delivery_request_threshold: "3000"
+govuk::apps::email_alert_frontend::subscription_management_enabled: true
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::kibana::logit_environment: d414187a-2796-4ea7-9b9a-d40c341646d6
 govuk::apps::link_checker_api::govuk_basic_auth_credentials: "%{hiera('http_username')}:%{hiera('http_password')}"

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -18,6 +18,7 @@ govuk::apps::email_alert_api::govuk_notify_template_id: '2844a647-6bf1-4b01-a25c
 govuk::apps::email_alert_api::email_address_override: 'success@simulator.amazonses.com'
 govuk::apps::email_alert_api::email_address_override_whitelist_only: true
 govuk::apps::email_alert_api::delivery_request_threshold: "3000"
+govuk::apps::email_alert_frontend::subscription_management_enabled: true
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::kibana::logit_environment: d414187a-2796-4ea7-9b9a-d40c341646d6
 govuk::apps::link_checker_api::govuk_basic_auth_credentials: "%{hiera('http_username')}:%{hiera('http_password')}"


### PR DESCRIPTION
This allows the subscription management functionality to be available
for use in staging for testing prior to production deployment.