### PR TITLE
Serve Whitehall attachments from Asset Manager

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1710,8 +1710,12 @@ router::assets_origin::app_specific_static_asset_routes:
 
 router::assets_origin::whitehall_uploaded_assets_routes:
   - '/government/placeholder'
-  - '/government/uploads/system/uploads/attachment_data/file/'
+  - '~ ^/government/uploads/system/uploads/attachment_data/file/[0-9]+/.*/preview$'
   - '/government/uploads/uploaded/hmrc/'
+
+# Note: we should remove this (inline it into conditionals) when we
+# apply it to production.
+router::assets_origin::use_new_consultation_response_form_redirect: true
 
 router::assets_origin::asset_manager_uploaded_assets_routes:
   - '/government/uploads/'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1713,10 +1713,6 @@ router::assets_origin::whitehall_uploaded_assets_routes:
   - '~ ^/government/uploads/system/uploads/attachment_data/file/[0-9]+/.*/preview$'
   - '/government/uploads/uploaded/hmrc/'
 
-# Note: we should remove this (inline it into conditionals) when we
-# apply it to production.
-router::assets_origin::use_new_consultation_response_form_redirect: true
-
 router::assets_origin::asset_manager_uploaded_assets_routes:
   - '/government/uploads/'
   - '/media/'

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -524,14 +524,5 @@ router::nginx::robotstxt: |
   User-agent: *
   Disallow: /
 
-router::assets_origin::whitehall_uploaded_assets_routes:
-  - '/government/placeholder'
-  - '~ ^/government/uploads/system/uploads/attachment_data/file/[0-9]+/.*/preview$'
-  - '/government/uploads/uploaded/hmrc/'
-
-# Note: we should remove this (inline it into conditionals) when we
-# apply it to production.
-router::assets_origin::use_new_consultation_response_form_redirect: true
-
 mongodb::s3backup::backup::s3_bucket: 'govuk-mongodb-backup-s3-staging'
 mongodb::s3backup::backup::s3_bucket_daily: 'govuk-mongodb-backup-s3-daily-staging'

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1109,10 +1109,6 @@ router::assets_origin::app_specific_static_asset_routes:
   '/service-manual-frontend/': "service-manual-frontend"
   '/smartanswers/': "smartanswers"
 
-# Note: we should remove this (inline it into conditionals) when we
-# apply it to production.
-router::assets_origin::use_new_consultation_response_form_redirect: true
-
 router::assets_origin::whitehall_uploaded_assets_routes:
   - '/government/placeholder'
   - '~ ^/government/uploads/system/uploads/attachment_data/file/[0-9]+/.*/preview$'

--- a/modules/router/manifests/assets_origin.pp
+++ b/modules/router/manifests/assets_origin.pp
@@ -23,10 +23,6 @@
 # [*vhost_name*]
 #   Primary vhost that assets should be served on at origin
 #
-# [*use_new_consultation_response_form_redirect*]
-#   Whether to directly redirect consultation forms or not.  Whitehall
-#   currently does this, but will not after we merge all the changes.
-#
 class router::assets_origin(
   $app_specific_static_asset_routes = {},
   $asset_manager_uploaded_assets_routes = [],
@@ -34,7 +30,6 @@ class router::assets_origin(
   $real_ip_header = '',
   $vhost_aliases = [],
   $vhost_name = 'assets-origin',
-  $use_new_consultation_response_form_redirect = false,
 ) {
   validate_array($vhost_aliases)
 

--- a/modules/router/templates/assets_origin.conf.erb
+++ b/modules/router/templates/assets_origin.conf.erb
@@ -41,13 +41,11 @@ server {
   add_header "Access-Control-Allow-Methods" "GET, OPTIONS";
   add_header "Access-Control-Allow-Headers" "origin, authorization";
 
-  <%- if @use_new_consultation_response_form_redirect %>
-    location /government/uploads/system/uploads/consultation_response_form/ {
-      add_header Cache-Control "public";
-      expires 1y;
-      rewrite ^/government/uploads/system/uploads/consultation_response_form/(.*)$ /government/uploads/system/uploads/consultation_response_form_data/$1;
-    }
-  <%- end %>
+  location /government/uploads/system/uploads/consultation_response_form/ {
+    add_header Cache-Control "public";
+    expires 1y;
+    rewrite ^/government/uploads/system/uploads/consultation_response_form/(.*)$ /government/uploads/system/uploads/consultation_response_form_data/$1;
+  }
 
   <%- @app_specific_static_asset_routes.each do |alias_path, vhost_name| -%>
   <%- if scope.lookupvar('::aws_migration') %>


### PR DESCRIPTION
Removing this more specific path will mean that requests for Whitehall attachments will be caught by the more general '/government/uploads/' path and routed to Asset Manager instead of Whitehall.
