### PR TITLE
Set CI Master to allow 6GB max heap size for Jenkins

### DIFF
--- a/hieradata/class/ci_master.yaml
+++ b/hieradata/class/ci_master.yaml
@@ -20,6 +20,13 @@ jenkins_admin_permission_list: &jenkins_admin_permission_list
   - 'hudson.model.View.Read'
   - 'hudson.scm.SCM.Tag'
 
+govuk_jenkins::config:
+  JAVA_ARGS:
+    value: >-
+      -Djava.awt.headless=true
+      -Djenkins.install.runSetupWizard=false
+      -Xmx6144m
+
 govuk_jenkins::config::user_permissions:
   -
     user: 'ci_alphagov'


### PR DESCRIPTION
We have been having lots of problems with performance and hanging of the
CI Master box on Jenkins. This has been reflected in high CPU usage and
the application freezing and hanging.

From a bunch of googling and a meagre understanding my expectation is
that the Java heap is reaching it's maximum auto allocated size and the
app is freezing up with tons of GC trying to keep the memory down.

In experimenting the box seemed to work better by specifying a max heap
size of 6GB (which seemed to be 2GB more than what it allocates by
default) although it could be that it's better to just bump the memory
on the box and let Java decide how much to use.