### PR TITLE
Allow search results to be crawled, not indexed

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1687,8 +1687,6 @@ router::nginx::check_requests_critical: '@8'
 router::nginx::robotstxt: |
   User-agent: *
   Disallow: /*/print$
-  # Don't allow indexing of search results
-  Disallow: /search?
   # We only allow indexing of the licence-finder landing page
   Disallow: /licence-finder/
   Allow: /licence-finder

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1089,8 +1089,6 @@ router::nginx::check_requests_critical: '@8'
 router::nginx::robotstxt: |
   User-agent: *
   Disallow: /*/print$
-  # Don't allow indexing of search results
-  Disallow: /search?
   # We only allow indexing of the licence-finder landing page
   Disallow: /licence-finder/
   Allow: /licence-finder


### PR DESCRIPTION
Finder-frontend, which powers search, [includes a robots ‘noindex’ meta tag][1] which was [added (originally to Frontend) to prevent GOV.UK search results from appearing in search engines][2].

Unfortunately, the robots.txt file prevents Google (and other search engines) from crawling the page, which means they never see the directive.

As per [Google’s own documentation][3], ‘disallowing’ a location in the robots.txt file only prevents a page from being crawled, it *does not* prevent it from showing up in search results.:

> Important! For the noindex directive to be effective, the page must not be blocked by a robots.txt file. If the page is blocked by a robots.txt file, the crawler will never see the noindex directive, and the page can still appear in search results, for example if other pages link to it.

<img width="1392" alt="screen shot 2018-04-06 at 07 55 04bst" src="https://user-images.githubusercontent.com/121939/38407469-75c725fe-3971-11e8-91f7-ff871e3dc8c1.png">

[1]: https://github.com/alphagov/finder-frontend/blob/8d76d409e3f00118665d996d271ce1523e63ccc3/app/views/search/index.html.erb#L7
[2]: https://github.com/alphagov/frontend/pull/1230
[3]: https://support.google.com/webmasters/answer/93710?hl=en