### PR TITLE
Revert "Set CI Master to allow 6GB max heap size for Jenkins"

### DIFF
--- a/hieradata/class/ci_master.yaml
+++ b/hieradata/class/ci_master.yaml
@@ -20,13 +20,6 @@ jenkins_admin_permission_list: &jenkins_admin_permission_list
   - 'hudson.model.View.Read'
   - 'hudson.scm.SCM.Tag'
 
-govuk_jenkins::config:
-  JAVA_ARGS:
-    value: >-
-      -Djava.awt.headless=true
-      -Djenkins.install.runSetupWizard=false
-      -Xmx6144m
-
 govuk_jenkins::config::user_permissions:
   -
     user: 'ci_alphagov'


### PR DESCRIPTION
Reverts alphagov/govuk-puppet#7424

Having cleared out lots of the workspaces that jenkins has been failing to delete it seems to be performing healthily again with just the memory that Java decides it wants so I don't believe this code change is of benefit anymore.