### PR TITLE
Remove email alert service/api from backend boxes

### DIFF
--- a/hieradata/class/backend.yaml
+++ b/hieradata/class/backend.yaml
@@ -6,6 +6,7 @@ govuk::apps::contacts::db_username: 'contacts'
 govuk::apps::contacts::db_password: "%{hiera('govuk::apps::contacts::db::mysql_contacts_admin')}"
 
 govuk::apps::email_alert_api::enabled: false
+govuk::apps::email_alert_service::enabled: false
 
 govuk::apps::event_store::mongodb_servers:
   - 'mongo-1.backend'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -396,6 +396,7 @@ govuk::apps::email_alert_api::email_address_override_whitelist:
   - thomas.leese@digital.cabinet-office.gov.uk
   - tijmen.brommet@digital.cabinet-office.gov.uk
 
+govuk::apps::email_alert_service::enabled: true
 govuk::apps::email_alert_service::rabbitmq_hosts:
   - rabbitmq-1.backend
   - rabbitmq-2.backend

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -25,6 +25,7 @@ node_class: &node_class
       - content-performance-manager
       - content-tagger
       - email-alert-api
+      - email-alert-service
       - event-store
       - hmrc-manuals-api
       - imminence

--- a/hieradata_aws/class/backend.yaml
+++ b/hieradata_aws/class/backend.yaml
@@ -6,6 +6,7 @@ govuk::apps::contacts::db_username: 'contacts'
 govuk::apps::contacts::db_password: "%{hiera('govuk::apps::contacts::db::mysql_contacts_admin')}"
 
 govuk::apps::email_alert_api::enabled: false
+govuk::apps::email_alert_service::enabled: false
 
 govuk::apps::manuals_publisher::mongodb_name: 'govuk_content_production'
 govuk::apps::manuals_publisher::mongodb_nodes:

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -404,6 +404,7 @@ govuk::apps::email_alert_api::email_address_override_whitelist:
   - thomas.leese@digital.cabinet-office.gov.uk
   - tijmen.brommet@digital.cabinet-office.gov.uk
 
+govuk::apps::email_alert_service::enabled: true
 govuk::apps::email_alert_service::rabbitmq_hosts:
   - rabbitmq
 govuk::apps::email_alert_service::redis_host: "%{hiera('sidekiq_host')}"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -23,6 +23,7 @@ node_class: &node_class
       - content-performance-manager
       - content-tagger
       - email-alert-api
+      - email-alert-service
       - event-store
       - hmrc-manuals-api
       - imminence

--- a/modules/govuk/manifests/apps/email_alert_api.pp
+++ b/modules/govuk/manifests/apps/email_alert_api.pp
@@ -107,149 +107,146 @@ class govuk::apps::email_alert_api(
   $unicorn_worker_processes = undef,
 ) {
 
-  if $enabled {
-    govuk::app { 'email-alert-api':
-      app_type                 => 'rack',
-      port                     => $port,
-      sentry_dsn               => $sentry_dsn,
-      log_format_is_json       => true,
-      health_check_path        => '/healthcheck',
-      json_health_check        => true,
-      unicorn_worker_processes => $unicorn_worker_processes,
-    }
+  $ensure = $enabled ? {
+    true  => 'present',
+    false => 'absent',
+  }
 
-    include govuk_postgresql::client #installs libpq-dev package needed for pg gem
+  govuk::app { 'email-alert-api':
+    ensure                   => $ensure,
+    app_type                 => 'rack',
+    port                     => $port,
+    sentry_dsn               => $sentry_dsn,
+    log_format_is_json       => true,
+    health_check_path        => '/healthcheck',
+    json_health_check        => true,
+    unicorn_worker_processes => $unicorn_worker_processes,
+  }
 
-    govuk::procfile::worker {'email-alert-api':
-      enable_service => $enable_procfile_worker,
-    }
+  include govuk_postgresql::client #installs libpq-dev package needed for pg gem
 
-    Govuk::App::Envvar {
-      app => 'email-alert-api',
-    }
+  govuk::procfile::worker {'email-alert-api':
+    ensure         => $ensure,
+    enable_service => $enable_procfile_worker,
+  }
 
-    if $::govuk_node_class !~ /^development$/ {
-      govuk::app::envvar::database_url { 'email-alert-api':
-        type     => 'postgresql',
-        username => $db_username,
-        password => $db_password,
-        host     => $db_hostname,
-        database => $db_name,
-      }
-    }
+  Govuk::App::Envvar {
+    ensure          => $ensure,
+    app             => 'email-alert-api',
+    notify_service  => $enabled,
+  }
 
-    govuk::app::envvar::redis { 'email-alert-api':
-      host => $redis_host,
-      port => $redis_port,
-    }
-
-    govuk::app::envvar {
-      "${title}-SIDEKIQ_RETRY_CRITICAL_THRESHOLD":
-          varname => 'SIDEKIQ_RETRY_SIZE_CRITICAL',
-          value   => $sidekiq_retry_critical;
-      "${title}-SIDEKIQ_RETRY_WARNING_THRESHOLD":
-          varname => 'SIDEKIQ_RETRY_SIZE_WARNING',
-          value   => $sidekiq_retry_warning;
-      "${title}-SIDEKIQ_QUEUE_SIZE_CRITICAL_THRESHOLD":
-          varname => 'SIDEKIQ_QUEUE_SIZE_CRITICAL',
-          value   => $sidekiq_queue_size_critical;
-      "${title}-SIDEKIQ_QUEUE_SIZE_WARNING_THRESHOLD":
-          varname => 'SIDEKIQ_QUEUE_SIZE_WARNING',
-          value   => $sidekiq_queue_size_warning;
-      "${title}-SIDEKIQ_QUEUE_LATENCY_CRITICAL_THRESHOLD":
-          varname => 'SIDEKIQ_QUEUE_LATENCY_CRITICAL',
-          value   => $sidekiq_queue_latency_critical;
-      "${title}-SIDEKIQ_QUEUE_LATENCY_WARNING_THRESHOLD":
-          varname => 'SIDEKIQ_QUEUE_LATENCY_WARNING',
-          value   => $sidekiq_queue_latency_warning;
-      "${title}-GOVUK_NOTIFY_API_KEY":
-          varname => 'GOVUK_NOTIFY_API_KEY',
-          value   => $govuk_notify_api_key;
-      "${title}-GOVUK_NOTIFY_TEMPLATE_ID":
-          varname => 'GOVUK_NOTIFY_TEMPLATE_ID',
-          value   => $govuk_notify_template_id;
-      "${title}-GOVUK_NOTIFY_BASE_URL":
-          ensure  => 'absent',
-          varname => 'GOVUK_NOTIFY_BASE_URL',
-          value   => $govuk_notify_base_url;
-      "${title}-SECRET_KEY_BASE":
-          varname => 'SECRET_KEY_BASE',
-          value   => $secret_key_base;
-      "${title}-OAUTH_ID":
-          varname => 'OAUTH_ID',
-          value   => $oauth_id;
-      "${title}-OAUTH_SECRET":
-          varname => 'OAUTH_SECRET',
-          value   => $oauth_secret;
-      "${title}-EMAIL_ALERT_AUTH_TOKEN":
-          varname => 'EMAIL_ALERT_AUTH_TOKEN',
-          value   => $email_alert_auth_token;
-      "${title}-EMAIL_SERVICE_PROVIDER":
-          varname => 'EMAIL_SERVICE_PROVIDER',
-          value   => $email_service_provider;
-      "${title}-EMAIL_ADDRESS_OVERRIDE":
-          varname => 'EMAIL_ADDRESS_OVERRIDE',
-          value   => $email_address_override;
-    }
-
-    if $email_address_override_whitelist {
-      govuk::app::envvar { "${title}-EMAIL_ADDRESS_OVERRIDE_WHITELIST":
-        varname => 'EMAIL_ADDRESS_OVERRIDE_WHITELIST',
-        value   => join($email_address_override_whitelist, ',');
-      }
-    }
-
-    if $email_address_override_whitelist_only {
-      govuk::app::envvar { "${title}-EMAIL_ADDRESS_OVERRIDE_WHITELIST_ONLY":
-        varname => 'EMAIL_ADDRESS_OVERRIDE_WHITELIST_ONLY',
-        value   => 'yes';
-      }
-    }
-
-    if $delivery_request_threshold {
-      govuk::app::envvar { "${title}-DELIVERY_REQUEST_THRESHOLD":
-        varname => 'DELIVERY_REQUEST_THRESHOLD',
-        value   => $delivery_request_threshold;
-      }
-    }
-
-    $app_domain = hiera('app_domain')
-
-    if $enable_public_proxy {
-      nginx::conf { 'email-alert-api-public-rate-limiting':
-        content => '
-          limit_req_zone $binary_remote_addr zone=email_alert_api_public:1m rate=50r/s;
-          limit_req_status 429;
-        ',
-      }
-
-      if $::aws_migration {
-        $vhost_ = 'email-alert-api-public'
-      } else {
-        $vhost_ = "email-alert-api-public.${app_domain}"
-      }
-
-      nginx::config::vhost::proxy { $vhost_:
-        to               => ["localhost:${port}"],
-        ssl_only         => true,
-        protected        => false,
-        extra_app_config => "
-          return 404;
-        ",
-        extra_config     => template('govuk/email_alert_api_public_nginx_extra_config.conf.erb'),
-      }
+  if $::govuk_node_class !~ /^development$/ {
+    govuk::app::envvar::database_url { 'email-alert-api':
+      type     => 'postgresql',
+      username => $db_username,
+      password => $db_password,
+      host     => $db_hostname,
+      database => $db_name,
     }
   }
-  else {
-    govuk::app { 'email-alert-api':
-      ensure   => 'absent',
-      app_type => 'rack',
-      port     => $port,
+
+  govuk::app::envvar::redis { 'email-alert-api':
+    host => $redis_host,
+    port => $redis_port,
+  }
+
+  govuk::app::envvar {
+    "${title}-SIDEKIQ_RETRY_CRITICAL_THRESHOLD":
+        varname => 'SIDEKIQ_RETRY_SIZE_CRITICAL',
+        value   => $sidekiq_retry_critical;
+    "${title}-SIDEKIQ_RETRY_WARNING_THRESHOLD":
+        varname => 'SIDEKIQ_RETRY_SIZE_WARNING',
+        value   => $sidekiq_retry_warning;
+    "${title}-SIDEKIQ_QUEUE_SIZE_CRITICAL_THRESHOLD":
+        varname => 'SIDEKIQ_QUEUE_SIZE_CRITICAL',
+        value   => $sidekiq_queue_size_critical;
+    "${title}-SIDEKIQ_QUEUE_SIZE_WARNING_THRESHOLD":
+        varname => 'SIDEKIQ_QUEUE_SIZE_WARNING',
+        value   => $sidekiq_queue_size_warning;
+    "${title}-SIDEKIQ_QUEUE_LATENCY_CRITICAL_THRESHOLD":
+        varname => 'SIDEKIQ_QUEUE_LATENCY_CRITICAL',
+        value   => $sidekiq_queue_latency_critical;
+    "${title}-SIDEKIQ_QUEUE_LATENCY_WARNING_THRESHOLD":
+        varname => 'SIDEKIQ_QUEUE_LATENCY_WARNING',
+        value   => $sidekiq_queue_latency_warning;
+    "${title}-GOVUK_NOTIFY_API_KEY":
+        varname => 'GOVUK_NOTIFY_API_KEY',
+        value   => $govuk_notify_api_key;
+    "${title}-GOVUK_NOTIFY_TEMPLATE_ID":
+        varname => 'GOVUK_NOTIFY_TEMPLATE_ID',
+        value   => $govuk_notify_template_id;
+    "${title}-GOVUK_NOTIFY_BASE_URL":
+        ensure  => 'absent',
+        varname => 'GOVUK_NOTIFY_BASE_URL',
+        value   => $govuk_notify_base_url;
+    "${title}-SECRET_KEY_BASE":
+        varname => 'SECRET_KEY_BASE',
+        value   => $secret_key_base;
+    "${title}-OAUTH_ID":
+        varname => 'OAUTH_ID',
+        value   => $oauth_id;
+    "${title}-OAUTH_SECRET":
+        varname => 'OAUTH_SECRET',
+        value   => $oauth_secret;
+    "${title}-EMAIL_ALERT_AUTH_TOKEN":
+        varname => 'EMAIL_ALERT_AUTH_TOKEN',
+        value   => $email_alert_auth_token;
+    "${title}-EMAIL_SERVICE_PROVIDER":
+        varname => 'EMAIL_SERVICE_PROVIDER',
+        value   => $email_service_provider;
+    "${title}-EMAIL_ADDRESS_OVERRIDE":
+        varname => 'EMAIL_ADDRESS_OVERRIDE',
+        value   => $email_address_override;
+  }
+
+  if $email_address_override_whitelist {
+    govuk::app::envvar { "${title}-EMAIL_ADDRESS_OVERRIDE_WHITELIST":
+      varname => 'EMAIL_ADDRESS_OVERRIDE_WHITELIST',
+      value   => join($email_address_override_whitelist, ',');
+    }
+  }
+
+  if $email_address_override_whitelist_only {
+    govuk::app::envvar { "${title}-EMAIL_ADDRESS_OVERRIDE_WHITELIST_ONLY":
+      varname => 'EMAIL_ADDRESS_OVERRIDE_WHITELIST_ONLY',
+      value   => 'yes';
+    }
+  }
+
+  if $delivery_request_threshold {
+    govuk::app::envvar { "${title}-DELIVERY_REQUEST_THRESHOLD":
+      varname => 'DELIVERY_REQUEST_THRESHOLD',
+      value   => $delivery_request_threshold;
+    }
+  }
+
+  $app_domain = hiera('app_domain')
+
+  if $enable_public_proxy {
+    nginx::conf { 'email-alert-api-public-rate-limiting':
+      ensure  => $ensure,
+      content => '
+        limit_req_zone $binary_remote_addr zone=email_alert_api_public:1m rate=50r/s;
+        limit_req_status 429;
+      ',
     }
 
-    govuk::procfile::worker {'email-alert-api':
-      ensure         => 'absent',
-      enable_service => false,
+    if $::aws_migration {
+      $vhost_ = 'email-alert-api-public'
+    } else {
+      $vhost_ = "email-alert-api-public.${app_domain}"
+    }
+
+    nginx::config::vhost::proxy { $vhost_:
+      ensure           => $ensure,
+      to               => ["localhost:${port}"],
+      ssl_only         => true,
+      protected        => false,
+      extra_app_config => "
+        return 404;
+      ",
+      extra_config     => template('govuk/email_alert_api_public_nginx_extra_config.conf.erb'),
     }
   }
 }

--- a/modules/govuk/manifests/apps/email_alert_service.pp
+++ b/modules/govuk/manifests/apps/email_alert_service.pp
@@ -29,6 +29,7 @@
 #   Bearer token for communication with the email-alert-api
 #
 class govuk::apps::email_alert_service(
+  $enabled = false,
   $rabbitmq_hosts = ['localhost'],
   $rabbitmq_user = 'email_alert_service',
   $rabbitmq_password = 'email_alert_service',
@@ -36,7 +37,14 @@ class govuk::apps::email_alert_service(
   $redis_host = undef,
   $email_alert_api_bearer_token = undef,
 ) {
+
+  $ensure = $enabled ? {
+    true  => 'present',
+    false => 'absent',
+  }
+
   govuk::app { 'email-alert-service':
+    ensure             => $ensure,
     app_type           => 'bare',
     enable_nginx_vhost => false,
     sentry_dsn         => $sentry_dsn,
@@ -44,7 +52,9 @@ class govuk::apps::email_alert_service(
   }
 
   Govuk::App::Envvar {
-    app => 'email-alert-service',
+    ensure          => $ensure,
+    app             => 'email-alert-service',
+    notify_service  => $enabled,
   }
 
   govuk::app::envvar::rabbitmq { 'email-alert-service':


### PR DESCRIPTION
This removes Email Alert Service and Email Alert API from backend boxes. Email Alert API was mostly removed but there were still various bits kicking around to do with the public proxy. 

Before:

```
kevindew@ec2-integration-blue-backend-ip-10-1-5-128:/data/vhost/email-alert-api$ ps aux | grep email
deploy    1196  0.0  0.2 386764 36516 ?        Ssl  14:29   0:00 ruby ./bin/email_alert_service
root      1556  0.0  0.0   4380   608 ?        S    Mar29   0:00 tail -F /var/log/nginx/email-alert-api-public-json.event.access.log
root      1557  0.0  0.0  54852 10564 ?        S    Mar29   0:00 /usr/bin/python /usr/local/bin/logship -f init_json,add_timestamp,add_source_host,add_tags:nginx,add_fields:application=email-alert-api-public-json.event.access -s statsd_counter,metric=backend-1_blue_integration.nginx_logs.email-alert-api-public.http_%{status} statsd_timer,metric=backend-1_blue_integration.nginx_logs.email-alert-api-public.time_request,timed_field=request_time
root      1655  0.0  0.0   4380   356 ?        S    Mar29   0:00 tail -F /var/log/email-alert-service/app.out.log
root      1656  0.0  0.0  54852 10568 ?        S    Mar29   0:00 /usr/bin/python /usr/local/bin/logship -f init_json,add_timestamp,add_source_host,add_tags:application,add_fields:application=email-alert-service -s statsd_counter,metric=backend-1_blue_integration.email-alert-service.http_%{@field.status} statsd_timer,metric=backend-1_blue_integration.email-alert-service.time_duration,timed_field=@fields.duration statsd_timer,metric=backend-1_blue_integration.email-alert-service.time_db,timed_field=@fields.db statsd_timer,metric=backend-1_blue_integration.email-alert-service.time_view,timed_field=@fields.view
kevindew  1858  0.0  0.0  10476   912 pts/2    S+   17:08   0:00 grep --color=auto email
deploy   11619  0.0  0.0   4448   648 ?        S    15:46   0:00 sh -c GOVUK_APP_NAME=email-alert-api bundle exec rackup -p 3089
deploy   11623  0.0  0.0   4448   648 ?        S    15:46   0:00 sh -c GOVUK_APP_NAME=email-campaign-api bundle exec rackup -p 3117
root     28779  0.0  0.0   4380   356 ?        S    17:00   0:00 tail -F /var/log/nginx/email-alert-api-json.event.access.log
root     28780  0.0  0.0  54912 10568 ?        S    17:00   0:00 /usr/bin/python /usr/local/bin/logship -f init_json,add_timestamp,add_source_host,add_tags:nginx,add_fields:application=email-alert-api-json.event.access -s statsd_counter,metric=backend-1_blue_integration.nginx_logs.email-alert-api.http_%{status} statsd_timer,metric=backend-1_blue_integration.nginx_logs.email-alert-api.time_request,timed_field=request_time
root     28795  0.0  0.0   4380   608 ?        S    17:00   0:00 tail -F /data/vhost/email-alert-api/shared/log/production.json.log
root     28796  0.0  0.0  54912 10564 ?        S    17:00   0:00 /usr/bin/python /usr/local/bin/logship -f init_json,add_timestamp,add_source_host,add_tags:stdout:application,add_fields:application=email-alert-api -s statsd_counter,metric=backend-1_blue_integration.email-alert-api.http_%{@field.status} statsd_timer,metric=backend-1_blue_integration.email-alert-api.time_duration,timed_field=@fields.duration statsd_timer,metric=backend-1_blue_integration.email-alert-api.time_db,timed_field=@fields.db statsd_timer,metric=backend-1_blue_integration.email-alert-api.time_view,timed_field=@fields.view
root     28820  0.0  0.0   4380   352 ?        S    17:00   0:00 tail -F /var/log/email-alert-api/app.out.log
root     28821  0.0  0.0  54912 10564 ?        S    17:00   0:00 /usr/bin/python /usr/local/bin/logship -f init_json,add_timestamp,add_source_host,add_tags:application,add_fields:application=email-alert-api -s statsd_counter,metric=backend-1_blue_integration.email-alert-api.http_%{@field.status} statsd_timer,metric=backend-1_blue_integration.email-alert-api.time_duration,timed_field=@fields.duration statsd_timer,metric=backend-1_blue_integration.email-alert-api.time_db,timed_field=@fields.db statsd_timer,metric=backend-1_blue_integration.email-alert-api.time_view,timed_field=@fields.view
```

After:
```
kevindew@ec2-integration-blue-backend-ip-10-1-5-128:~$ ps aux | grep email
deploy   11619  0.0  0.0   4448   648 ?        S    15:46   0:00 sh -c GOVUK_APP_NAME=email-alert-api bundle exec rackup -p 3089
deploy   11623  0.0  0.0   4448   648 ?        S    15:46   0:00 sh -c GOVUK_APP_NAME=email-campaign-api bundle exec rackup -p 3117
kevindew 11966  0.0  0.0  10476   924 pts/2    S+   17:16   0:00 grep --color=auto email
```

(note rackup is sidekiq monitoring)
