### PR TITLE
Don't set the Signon instance name in production

### DIFF
--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -23,7 +23,6 @@ govuk::apps::publisher::run_fact_check_fetcher: false
 govuk::apps::publisher::fact_check_address_format: 'factcheck+production-{id}@alphagov.co.uk'
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-production'
 govuk::apps::short_url_manager::instance_name: 'production'
-govuk::apps::signon::instance_name: 'production'
 govuk::apps::support_api::pp_data_url: 'https://www.performance.service.gov.uk'
 govuk::apps::travel_advice_publisher::enable_email_alerts: true
 


### PR DESCRIPTION
Even on AWS. This differs from the current production environment, in
which this is unset, I believe intentionally.

The Signon service assumes that this will be unset in the production
environment, e.g. it won't enforce the use of 2 step verification for
admin users if this is set.