### PR TITLE
Update integration domain in router import script

### DIFF
--- a/development-vm/replication/replicate-data-local.sh
+++ b/development-vm/replication/replicate-data-local.sh
@@ -22,8 +22,8 @@ $(dirname $0)/sync-aws-elasticsearch.sh "$@"
 
 if ! ($SKIP_MONGO || $DRY_RUN); then
   status "Munging router backend hostnames for dev VM"
-  mongo --quiet --eval 'db = db.getSiblingDB("router"); db.backends.find().forEach( function(b) { b.backend_url = b.backend_url.replace(".integration.publishing.service.gov.uk", ".dev.gov.uk").replace("https","http"); db.backends.save(b); } );'
-  mongo --quiet --eval 'db = db.getSiblingDB("draft_router"); db.backends.find().forEach( function(b) { b.backend_url = b.backend_url.replace(".integration.publishing.service.gov.uk", ".dev.gov.uk").replace("https","http"); db.backends.save(b); } );'
+  mongo --quiet --eval 'db = db.getSiblingDB("router"); db.backends.find().forEach( function(b) { b.backend_url = b.backend_url.replace(".integration.govuk-internal.digital", ".dev.gov.uk").replace("https","http"); db.backends.save(b); } );'
+  mongo --quiet --eval 'db = db.getSiblingDB("draft_router"); db.backends.find().forEach( function(b) { b.backend_url = b.backend_url.replace(".integration.govuk-internal.digital", ".dev.gov.uk").replace("https","http"); db.backends.save(b); } );'
 fi
 
 if ignored "mapit"; then


### PR DESCRIPTION
The data import script used the old integration domain, so a fresh build of the dev VM is unable to resolve any internal names.