### PR TITLE
Upgrade setuptools before trying to install pip dependencies

### DIFF
--- a/development-vm/single-update-pip.sh
+++ b/development-vm/single-update-pip.sh
@@ -4,10 +4,6 @@ set -e
 
 . ./support_functions.sh
 
-run_pip_install () {
-  $DIRECTORY/bin/pip install -qr requirements.txt
-}
-
 DIRECTORY='.venv'
 
 cd "$(dirname "$0")"
@@ -24,10 +20,18 @@ else
   outputfile=$(mktemp -t update-pip.XXXXXX)
   trap "rm -f '$outputfile'" EXIT
 
-  if $(run_pip_install) >"$outputfile" 2>&1; then
+  . $DIRECTORY/bin/activate
+
+  if ! pip install --upgrade setuptools >"$outputfile" 2>&1; then
+    error "failed to upgrade setuptools with pip output:"
+    cat "$outputfile"
+    exit 1
+  fi
+
+  if pip install -r requirements.txt >"$outputfile" 2>&1; then
     ok "ok"
   else
-    error "failed with pip output:"
+    error "failed to install dependencies with pip output:"
     cat "$outputfile"
     exit 1
   fi


### PR DESCRIPTION
The version of `setuptools` installed by `virtualenv` is too old (from 2014), which makes the `pycrypto` dependency of `fabric-scripts` fail to build, unless you update it first.

Adding `setuptools >= 18.5` to the `requirements.txt` of `fabric-scripts` doesn't solve the problem, but upgrading `setuptools` beforehand does.

---

I have to say, this is a bit icky.  Unconditionally updating `setuptools` seems not great.  An alternative would be to pick a reasonably recent version (18.5 is the minimum version required by `pycrypto`) and pin it to that.