### PR TITLE
Fix pipenv version to allow clean puppet run on blue-deploy

### DIFF
--- a/modules/govuk_jenkins/manifests/init.pp
+++ b/modules/govuk_jenkins/manifests/init.pp
@@ -112,7 +112,7 @@ class govuk_jenkins (
   }
 
   package { 'pipenv':
-    ensure   => 'present',
+    ensure   => '11.8',
     provider => 'pip',
   }
 


### PR DESCRIPTION
- Version 11.9 pip install failed with error:
  error in pipenv setup command: 'install_requires' must be a string
  or list of strings containing valid project/version requirement
  specifiers

- Fixing pipenv version to 11.8 to remedy this.

Solo: @schmie