### PR TITLE
Remove custom disk mapping for postgres staging

### DIFF
--- a/hieradata/class/staging/postgresql_primary.yaml
+++ b/hieradata/class/staging/postgresql_primary.yaml
@@ -1,18 +1,1 @@
 govuk_postgresql::server::max_connections: 300
-
-lv:
-  postgresql:
-    pv:
-      - '/dev/sdb1'
-      - '/dev/sdd1'
-      - '/dev/sde1'
-      - '/dev/sdf1'
-      - '/dev/sdg1'
-      - '/dev/sdh1'
-      - '/dev/sdj1'
-    vg: 'backups'
-  data:
-    pv:
-      - '/dev/sdc1'
-      - '/dev/sdi1'
-    vg: 'postgresql'


### PR DESCRIPTION
This has now been made (mostly) consistent with production so we no
longer need this extra config.