### PR TITLE
Configure Google Analytics ID for static through hieradata

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -12,6 +12,8 @@ base::supported_kernel::enabled: true
 cron::weekly_dow: 1
 cron::daily_hour: 6
 
+govuk::apps::static::ga_universal_id: 'UA-26179049-22'
+
 govuk::deploy::aws_ses_smtp_host: 'email-smtp.eu-west-1.amazonaws.com'
 govuk::deploy::config::errbit_environment_name: 'integration'
 govuk::deploy::setup::ssh_keys:

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -91,6 +91,7 @@ govuk::apps::publisher::email_group_dev: 'govuk-dev@digital.cabinet-office.gov.u
 govuk::apps::publisher::email_group_business: 'publisher-alerts-business@digital.cabinet-office.gov.uk'
 govuk::apps::publisher::email_group_citizen: 'publisher-alerts-citizen@digital.cabinet-office.gov.uk'
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-production'
+govuk::apps::static::ga_universal_id: 'UA-26179049-1'
 govuk::apps::support_api::pp_data_url: 'https://www.performance.service.gov.uk'
 govuk::apps::support_api::zendesk_anonymous_ticket_email: 'zd-api-public@digital.cabinet-office.gov.uk'
 govuk::apps::travel_advice_publisher::enable_email_alerts: true

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -34,6 +34,7 @@ govuk::apps::publisher::fact_check_address_format: 'factcheck+staging-{id}@alpha
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-staging'
 govuk::apps::short_url_manager::instance_name: 'staging'
 govuk::apps::signon::instance_name: 'staging'
+govuk::apps::static::ga_universal_id: 'UA-26179049-20'
 govuk::apps::support_api::pp_data_url: 'https://www.staging.performance.service.gov.uk'
 govuk::apps::travel_advice_publisher::enable_email_alerts: true
 govuk::apps::whitehall::cpu_warning: 400

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -26,6 +26,7 @@ govuk::apps::short_url_manager::instance_name: 'integration'
 govuk::apps::signon::instance_name: 'integration'
 govuk::apps::smartanswers::expose_govspeak: true
 govuk::apps::specialist_publisher::publish_pre_production_finders: true
+govuk::apps::static::ga_universal_id: 'UA-26179049-22'
 govuk::apps::travel_advice_publisher::enable_email_alerts: true
 govuk::apps::travel_advice_publisher::show_historical_edition_link: true
 govuk::apps::url_arbiter::db::backend_ip_range: '10.1.3.0/24'

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -23,6 +23,7 @@ govuk::apps::publisher::run_fact_check_fetcher: false
 govuk::apps::publisher::fact_check_address_format: 'factcheck+production-{id}@alphagov.co.uk'
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-production'
 govuk::apps::short_url_manager::instance_name: 'production'
+govuk::apps::static::ga_universal_id: 'UA-26179049-1'
 govuk::apps::support_api::pp_data_url: 'https://www.performance.service.gov.uk'
 govuk::apps::travel_advice_publisher::enable_email_alerts: true
 

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -28,6 +28,7 @@ govuk::apps::publisher::fact_check_address_format: 'factcheck+staging-{id}@alpha
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-staging'
 govuk::apps::short_url_manager::instance_name: 'staging'
 govuk::apps::signon::instance_name: 'staging'
+govuk::apps::static::ga_universal_id: 'UA-26179049-20'
 govuk::apps::support_api::pp_data_url: 'https://www.staging.performance.service.gov.uk'
 govuk::apps::travel_advice_publisher::enable_email_alerts: true
 

--- a/modules/govuk/manifests/apps/static.pp
+++ b/modules/govuk/manifests/apps/static.pp
@@ -29,6 +29,10 @@
 #   The bearer token to use when communicating with Publishing API.
 #   Default: undef
 #
+# [*ga_universal_id*]
+#   The Google Analytics ID.
+#   Default: undef
+#
 # [*redis_host*]
 #   Redis host for Sidekiq.
 #   Default: undef
@@ -44,6 +48,7 @@ class govuk::apps::static(
   $draft_environment = false,
   $secret_key_base = undef,
   $publishing_api_bearer_token = undef,
+  $ga_universal_id = undef,
   $redis_host = undef,
   $redis_port = undef,
 ) {
@@ -89,5 +94,12 @@ class govuk::apps::static(
   govuk::app::envvar { "${title}-PUBLISHING_API_BEARER_TOKEN":
     varname => 'PUBLISHING_API_BEARER_TOKEN',
     value   => $publishing_api_bearer_token,
+  }
+
+  if $ga_universal_id != undef {
+    govuk::app::envvar { "${title}-GA_UNIVERSAL_ID":
+      varname => 'GA_UNIVERSAL_ID',
+      value   => $ga_universal_id,
+    }
   }
 }


### PR DESCRIPTION
https://github.com/alphagov/static/pull/1377 makes static check the variable `GA_UNIVERSAL_ID` for the Google Analytics ID, so we can use different IDs on production, staging, and integration.

This PR sets those IDs.  Or will, as soon as we hear back about the actual values for those IDs.  But the logic changes are all made.

---

Part of https://trello.com/c/uLUgPcvI/50-stop-sending-staging-and-integration-data-to-same-ga-property-as-live-site-2