### PR TITLE
Add a Jenkins task to send out bulk emails

### DIFF
--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -45,6 +45,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::search_index_checks
   - govuk_jenkins::jobs::search_reindex_with_new_schema
   - govuk_jenkins::jobs::search_test_spelling_suggestions
+  - govuk_jenkins::jobs::send_bulk_email
   - govuk_jenkins::jobs::signon_cron_rake_tasks
   - govuk_jenkins::jobs::smokey
   - govuk_jenkins::jobs::smokey_deploy

--- a/hieradata/class/staging/jenkins.yaml
+++ b/hieradata/class/staging/jenkins.yaml
@@ -28,6 +28,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::search_fetch_analytics_data
   - govuk_jenkins::jobs::search_index_checks
   - govuk_jenkins::jobs::search_reindex_with_new_schema
+  - govuk_jenkins::jobs::send_bulk_email
   - govuk_jenkins::jobs::smokey
   - govuk_jenkins::jobs::smokey_deploy
   - govuk_jenkins::jobs::update_cdn_dictionaries

--- a/hieradata_aws/class/jenkins.yaml
+++ b/hieradata_aws/class/jenkins.yaml
@@ -82,6 +82,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::search_index_checks
   - govuk_jenkins::jobs::search_reindex_with_new_schema
   - govuk_jenkins::jobs::search_test_spelling_suggestions
+  - govuk_jenkins::jobs::send_bulk_email
   - govuk_jenkins::jobs::signon_cron_rake_tasks
   - govuk_jenkins::jobs::smokey
   - govuk_jenkins::jobs::smokey_deploy

--- a/modules/govuk_jenkins/manifests/jobs/send_bulk_email.pp
+++ b/modules/govuk_jenkins/manifests/jobs/send_bulk_email.pp
@@ -1,0 +1,12 @@
+# == Class: govuk_jenkins::jobs::send_bulk_email
+#
+# Send a bulk email to a number of subscriber lists.
+#
+class govuk_jenkins::jobs::send_bulk_email {
+
+  file { '/etc/jenkins_jobs/jobs/send_bulk_email.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/send_bulk_email.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+}

--- a/modules/govuk_jenkins/templates/jobs/send_bulk_email.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/send_bulk_email.yaml.erb
@@ -1,0 +1,33 @@
+---
+- job:
+    name: send-bulk-email
+    display-name: Send bulk email
+    project-type: freestyle
+    description: "Send a bulk email to a number of subscriber lists."
+    properties:
+      - build-discarder:
+          days-to-keep: 30
+          artifact-num-to-keep: 5
+    builders:
+      - shell: |
+          #!/usr/bin/env bash
+
+          hostname=$(govuk_node_list -c email_alert_api --single-node)
+          command="cd /var/apps/email-alert-api && govuk_setenv email-alert-api bundle exec rake \"bulk:email[$SUBSCRIBER_LIST_IDS]\""
+
+          echo "Running $command on $hostname"
+
+          ssh deploy@$hostname "export SUBJECT=\"$SUBJECT\" && export BODY=\"$BODY\" && $command"
+    wrappers:
+      - ansicolor:
+          colormap: xterm
+    parameters:
+      - string:
+          name: SUBJECT
+          description: The subject of the email
+      - text:
+          name: BODY
+          description: The body of the email
+      - string:
+          name: SUBSCRIBER_LIST_IDS
+          description: The IDs of the subscriber lists to send the email to


### PR DESCRIPTION
This calls the new `bulk:email` Rake task defined in https://github.com/alphagov/email-alert-api/pull/586.

[Trello Card](https://trello.com/c/e90wvivv/49-build-tooling-for-bulk-contacting-email-subscribers-for-a-given-subscriber-list-2)