### PR TITLE
Postgresql data directory

### DIFF
--- a/modules/govuk_postgresql/manifests/server.pp
+++ b/modules/govuk_postgresql/manifests/server.pp
@@ -106,4 +106,12 @@ class govuk_postgresql::server (
       host_name => $::fqdn,
     }
   }
+
+  file { "/var/lib/postgresql/${postgresql::globals::version}":
+    ensure => directory,
+    owner  => $postgresql::params::user,
+    group  => $postgresql::params::group,
+    mode   => '0755',
+  }
+
 }


### PR DESCRIPTION
- The govuk_postgresql::server relies on postgresql::server to install
  the postgresql package. postgresql::server has a class called
postgresql::server::initdb. This class created the
'/var/lib/postgresql/{version}/main' directory. However,
'/var/lib/postgresql/{version}/' doesn't get created by installing the
package. Since the directory tree is not present , puppet fails while
trying to create '/var/lib/postgresql/{version}/main'.

- To address this issue, we are capturing the version number derived by
  the vendor module (class postgresql::globals) and creating the data
directory tree.

https://trello.com/c/ZcvYGyj4/1101-puppet-rebuild-and-test

Solo: @suthagarht