### PR TITLE
Fix Notify email members whitelist in Heiradata

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -385,14 +385,11 @@ govuk::apps::email_alert_api::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::email_alert_api::db_hostname: 'postgresql-primary-1.backend'
 govuk::apps::email_alert_api::db_password: "%{hiera('govuk::apps::email_alert_api::db::password')}"
 govuk::apps::email_alert_api::unicorn_worker_processes: '4'
+# This list should be kept in sync with https://www.notifications.service.gov.uk/services/ecfc7e2f-5145-45a6-9413-5d9b6e813ea9/users
 govuk::apps::email_alert_api::email_address_override_whitelist:
   - govuk-email-courtesy-copies@digital.cabinet-office.gov.uk
   - bevan.loon@digital.cabinet-office.gov.uk
-  - keith.emmerson@digital.cabinet-office.gov.uk
   - kevin.dew@digital.cabinet-office.gov.uk
-  - martin.lugton@digital.cabinet-office.gov.uk
-  - paul.cronk@digital.cabinet-office.gov.uk
-  - peter.hartshorn@digital.cabinet-office.gov.uk
   - ruben.arakelyan@digital.cabinet-office.gov.uk
   - thomas.leese@digital.cabinet-office.gov.uk
   - tijmen.brommet@digital.cabinet-office.gov.uk

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -393,14 +393,11 @@ govuk::apps::email_alert_api::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::email_alert_api::db_hostname: 'postgresql-primary'
 govuk::apps::email_alert_api::db_password: "%{hiera('govuk::apps::email_alert_api::db::password')}"
 govuk::apps::email_alert_api::unicorn_worker_processes: '4'
+# This list should be kept in sync with https://www.notifications.service.gov.uk/services/ecfc7e2f-5145-45a6-9413-5d9b6e813ea9/users
 govuk::apps::email_alert_api::email_address_override_whitelist:
   - govuk-email-courtesy-copies@digital.cabinet-office.gov.uk
   - bevan.loon@digital.cabinet-office.gov.uk
-  - keith.emmerson@digital.cabinet-office.gov.uk
   - kevin.dew@digital.cabinet-office.gov.uk
-  - martin.lugton@digital.cabinet-office.gov.uk
-  - paul.cronk@digital.cabinet-office.gov.uk
-  - peter.hartshorn@digital.cabinet-office.gov.uk
   - ruben.arakelyan@digital.cabinet-office.gov.uk
   - thomas.leese@digital.cabinet-office.gov.uk
   - tijmen.brommet@digital.cabinet-office.gov.uk


### PR DESCRIPTION
There were a number of email-alert-api app healthcheck not ok errors
(technical failures). Specifically the email whitelist in Notify was
different to the common.yaml files in hieradata and hieradata_aws
folders.

This fix removed individuals from the whitelists in the common.yaml
files that are no longer present in the Notify whitelist.