### PR TITLE
Add Strict-Transport-Security headers in integration

### DIFF
--- a/modules/nginx/templates/default-vhost.conf
+++ b/modules/nginx/templates/default-vhost.conf
@@ -1,6 +1,8 @@
 server {
   listen 80 default_server;
   <%- if scope.lookupvar('::aws_migration') %>
+  # Send the Strict-Transport-Security header
+  include /etc/nginx/add-sts.conf;
   # Required for Layer 7 Application Load Balancer
   location = /_healthcheck {
     return 200;

--- a/modules/nginx/templates/proxy-vhost.conf
+++ b/modules/nginx/templates/proxy-vhost.conf
@@ -52,6 +52,8 @@ server {
 server {
   <%- if scope.lookupvar('::aws_migration') %>
   server_name <%= @name -%> <%= @name %>.* <%= @aliases.join(" ") unless @aliases.empty? %> <%= @aliases_wildcard.join(" ") unless @aliases_wildcard.empty? %>;
+  # Send the Strict-Transport-Security header
+  include /etc/nginx/add-sts.conf;
   <%- else %>
   server_name <%= @name %> <%= @aliases.join(" ") unless @aliases.empty? %>;
   <%- end %>

--- a/modules/nginx/templates/static-vhost.conf
+++ b/modules/nginx/templates/static-vhost.conf
@@ -43,6 +43,10 @@ server {
 <%- ports.each do |port| -%>
 server {
   server_name <%= @name %> <%= @aliases.join(" ") unless @aliases.empty? %>;
+  <%- if scope.lookupvar('::aws_migration') -%>
+  # Send the Strict-Transport-Security header
+  include /etc/nginx/add-sts.conf;
+  <%- end -%>
 
   <%- if port == 443 -%>
   listen              443 ssl<%= $is_default_vhost ? " default_server" : "" %>;

--- a/modules/router/templates/base.conf.erb
+++ b/modules/router/templates/base.conf.erb
@@ -27,6 +27,8 @@ server {
   include             /etc/nginx/ssl.conf;
   <%- else %>
   listen 80;
+  # Send the Strict-Transport-Security header
+  include             /etc/nginx/add-sts.conf;
   <%- end %>
 
   include             /etc/nginx/router_include.conf;
@@ -36,6 +38,8 @@ server {
   <%- if scope.lookupvar('::aws_migration') %>
   server_name         www.* www-origin.* draft-origin.*;
   listen 80;
+  # Send the Strict-Transport-Security header
+  include             /etc/nginx/add-sts.conf;
   <%- else %>
   server_name         www.<%= @app_domain %> www-origin.<%= @app_domain %> draft-origin.<%= @app_domain %>;
   listen              443 ssl;

--- a/modules/router/templates/default-vhost.conf.erb
+++ b/modules/router/templates/default-vhost.conf.erb
@@ -7,6 +7,8 @@ server {
   }
 
   <%- if scope.lookupvar('::aws_migration') %>
+  # Send the Strict-Transport-Security header
+  include /etc/nginx/add-sts.conf;
   # Required for L7 ALB
   location = /_healthcheck {
     return 200;

--- a/modules/router/templates/draft-assets.conf.erb
+++ b/modules/router/templates/draft-assets.conf.erb
@@ -1,6 +1,8 @@
 server {
   <%- if scope.lookupvar('::aws_migration') %>
   server_name <%= @vhost_name %> <%= @vhost_name %>.*;
+  # Send the Strict-Transport-Security header
+  include /etc/nginx/add-sts.conf;
   <%- else %>
   server_name <%= @vhost_name %>;
   <%- end %>


### PR DESCRIPTION
This commit includes the `add-sts.conf` file in nginx config for integration, which will set the `Strict-Transport-Security` header. AWS ELBs should pass this through to the requester.

This is done separately in integration since we disable SSL completely, and a side-effect of this is
to stop setting the `Strict-Transport-Security` header. SSL is disabled because SSL in integration is
 terminated at the AWS ELBs.