### PR TITLE
Switch Licensing to use OpenJDK rather than Oracle for Java

### DIFF
--- a/modules/govuk/manifests/node/s_licensing_backend.pp
+++ b/modules/govuk/manifests/node/s_licensing_backend.pp
@@ -5,10 +5,27 @@
 class govuk::node::s_licensing_backend inherits govuk::node::s_base {
   include clamav
 
-  include govuk_java::oracle8
+  class { 'govuk_java::oracle8':
+    ensure => absent,
+  }
 
+  include govuk_java::openjdk8::jdk
+  include govuk_java::openjdk8::jre
   include licensify::apps::licensify_admin
   include licensify::apps::licensify_feed
+
+  class { 'govuk_java::set_defaults':
+    jdk     => 'openjdk8',
+    jre     => 'openjdk8',
+    require => [
+                Class['govuk_java::openjdk8::jdk'],
+                Class['govuk_java::openjdk8::jre'],
+              ],
+    notify  => [
+                Class['licensify::apps::licensify_admin'],
+                Class['licensify::apps::licensify_feed'],
+              ],
+  }
 
   include nginx
 }

--- a/modules/govuk/manifests/node/s_licensing_frontend.pp
+++ b/modules/govuk/manifests/node/s_licensing_frontend.pp
@@ -5,10 +5,27 @@
 class govuk::node::s_licensing_frontend inherits govuk::node::s_base {
   include clamav
 
-  include govuk_java::oracle8
+  class { 'govuk_java::oracle8':
+    ensure => absent,
+  }
 
+  include govuk_java::openjdk8::jdk
+  include govuk_java::openjdk8::jre
   include licensify::apps::licensify
   include licensify::apps::licensing_web_forms
+
+  class { 'govuk_java::set_defaults':
+    jdk     => 'openjdk8',
+    jre     => 'openjdk8',
+    require => [
+                Class['govuk_java::openjdk8::jdk'],
+                Class['govuk_java::openjdk8::jre'],
+              ],
+    notify  => [
+                Class['licensify::apps::licensify'],
+                Class['licensify::apps::licensing_web_forms'],
+              ],
+  }
 
   include nginx
 }

--- a/modules/govuk_java/manifests/oracle8.pp
+++ b/modules/govuk_java/manifests/oracle8.pp
@@ -3,7 +3,12 @@
 # Installs (and removes) the oracle-java8-installer package and accepts the
 # license agreement.
 #
-class govuk_java::oracle8 {
+# [*ensure*]
+# Whether to install the package. Default: 'present'
+#
+class govuk_java::oracle8 (
+  $ensure = 'present'
+) {
 
   include govuk_ppa
 
@@ -15,7 +20,7 @@ class govuk_java::oracle8 {
   }
 
   package { 'oracle-java8-installer':
-    ensure  => present,
+    ensure  => $ensure,
     require => [Exec['set-licence-selected'], Exec['set-licence-seen']],
   }
 


### PR DESCRIPTION
This is because our Oracle 8 package will no longer install so we can't
actually build this on new machines.