### PR TITLE
Update Jenkins Slack plugin and kill Envinject warning

### DIFF
--- a/hieradata/class/jenkins.yaml
+++ b/hieradata/class/jenkins.yaml
@@ -172,9 +172,8 @@ govuk_jenkins::plugins:
     version: '1.0'
   simple-theme-plugin:
     version: '0.4'
-  # Don't upgrade this to 2.2, it has bugs
   slack:
-    version: '1.7'
+    version: '2.3'
   ssh-credentials:
     version: '1.13'
   ssh-slaves:

--- a/hieradata_aws/class/jenkins.yaml
+++ b/hieradata_aws/class/jenkins.yaml
@@ -227,9 +227,8 @@ govuk_jenkins::plugins:
     version: '1.0'
   simple-theme-plugin:
     version: '0.4'
-  # Don't upgrade this to 2.2, it has bugs
   slack:
-    version: '1.7'
+    version: '2.3'
   ssh-credentials:
     version: '1.13'
   ssh-slaves:

--- a/modules/govuk_jenkins/files/var/lib/jenkins/jenkins.security.UpdateSiteWarningsConfiguration.xml
+++ b/modules/govuk_jenkins/files/var/lib/jenkins/jenkins.security.UpdateSiteWarningsConfiguration.xml
@@ -1,0 +1,6 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<jenkins.security.UpdateSiteWarningsConfiguration>
+  <ignoredWarnings>
+    <string>SECURITY-248</string>
+  </ignoredWarnings>
+</jenkins.security.UpdateSiteWarningsConfiguration>

--- a/modules/govuk_jenkins/manifests/config.pp
+++ b/modules/govuk_jenkins/manifests/config.pp
@@ -192,6 +192,11 @@ class govuk_jenkins::config (
       source => 'puppet:///modules/govuk_jenkins/var/lib/jenkins/jenkins.security.QueueItemAuthenticatorConfiguration.xml',
     }
 
+    file {'/var/lib/jenkins/jenkins.security.UpdateSiteWarningsConfiguration.xml':
+      ensure => file,
+      source => 'puppet:///modules/govuk_jenkins/var/lib/jenkins/jenkins.security.UpdateSiteWarningsConfiguration.xml',
+    }
+
     file {'/var/lib/jenkins/org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder.xml':
       ensure => file,
       source => 'puppet:///modules/govuk_jenkins/var/lib/jenkins/org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder.xml',


### PR DESCRIPTION
Trello: https://trello.com/c/TTjN1BNU/57-3-out-of-date-jenkins-plugins

This is a couple of follow up changes from https://github.com/alphagov/govuk-puppet/pull/7460

This updates the slack plugin and gets rid of the envinject warning. Which will leave us with (currently) just the github multibranch plugin to sort out for CI to bring Jenkins (temporarily) up to date.