### PR TITLE
Separate attachment sync from data sync

### DIFF
--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -11,6 +11,8 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::check_pingdom_ip_ranges
   - govuk_jenkins::jobs::content_audit_tool
   - govuk_jenkins::jobs::content_performance_manager
+  - govuk_jenkins::jobs::copy_attachments_to_integration
+  - govuk_jenkins::jobs::copy_attachments_to_staging
   - govuk_jenkins::jobs::copy_data_to_integration
   - govuk_jenkins::jobs::copy_data_to_staging
   - govuk_jenkins::jobs::copy_licensify_data_to_staging

--- a/modules/govuk_jenkins/manifests/jobs/copy_attachments_to_integration.pp
+++ b/modules/govuk_jenkins/manifests/jobs/copy_attachments_to_integration.pp
@@ -1,0 +1,30 @@
+# == Class: govuk_jenkins::jobs::copy_attachments_to_integration
+#
+# Create a file on disk that can be parsed by jenkins-job-builder
+#
+class govuk_jenkins::jobs::copy_attachments_to_integration (
+  $app_domain = hiera('app_domain'),
+) {
+
+  $check_name = 'copy_attachments_to_integration'
+  $service_description = 'Copy Attachments to Integration'
+  $job_url = "https://deploy.${app_domain}/job/copy_attachments_to_integration"
+
+  $slack_team_domain = 'govuk'
+  $slack_room = '2ndline'
+  $slack_build_server_url = "https://deploy.${app_domain}/"
+
+  file { '/etc/jenkins_jobs/jobs/copy_attachments_to_integration.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/copy_attachments_to_integration.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+
+  @@icinga::passive_check { "${check_name}_${::hostname}":
+    service_description => $service_description,
+    host_name           => $::fqdn,
+    freshness_threshold => 115200,
+    action_url          => $job_url,
+    notes_url           => monitoring_docs_url(data-sync),
+  }
+}

--- a/modules/govuk_jenkins/manifests/jobs/copy_attachments_to_staging.pp
+++ b/modules/govuk_jenkins/manifests/jobs/copy_attachments_to_staging.pp
@@ -1,0 +1,30 @@
+# == Class: govuk_jenkins::jobs::copy_attachments_to_staging
+#
+# Create a file on disk that can be parsed by jenkins-job-builder
+#
+class govuk_jenkins::jobs::copy_attachments_to_staging (
+  $app_domain = hiera('app_domain'),
+) {
+
+  $check_name = 'copy_attachments_to_staging'
+  $service_description = 'Copy Attachments to staging'
+  $job_url = "https://deploy.${app_domain}/job/copy_attachments_to_staging"
+
+  $slack_team_domain = 'govuk'
+  $slack_room = '2ndline'
+  $slack_build_server_url = "https://deploy.${app_domain}/"
+
+  file { '/etc/jenkins_jobs/jobs/copy_attachments_to_staging.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/copy_attachments_to_staging.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+
+  @@icinga::passive_check { "${check_name}_${::hostname}":
+    service_description => $service_description,
+    host_name           => $::fqdn,
+    freshness_threshold => 115200,
+    action_url          => $job_url,
+    notes_url           => monitoring_docs_url(data-sync),
+  }
+}

--- a/modules/govuk_jenkins/spec/classes/govuk_jenkins__jobs__each_spec.rb
+++ b/modules/govuk_jenkins/spec/classes/govuk_jenkins__jobs__each_spec.rb
@@ -8,6 +8,8 @@ BROKEN_SPECS = %w[
   copy_data_from_integration_to_aws.pp
   copy_data_from_staging_to_aws.pp
   copy_data_from_production_to_aws.pp
+  copy_attachments_to_integration.pp
+  copy_attachments_to_staging.pp
   copy_data_to_integration.pp
   copy_data_to_staging.pp
   deploy_cdn.pp

--- a/modules/govuk_jenkins/templates/jobs/copy_attachments_to_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_attachments_to_integration.yaml.erb
@@ -1,0 +1,68 @@
+---
+- scm:
+    name: env-sync-and-backup_Copy_Attachments_to_Integration
+    scm:
+        - git:
+            url: git@github.com:alphagov/env-sync-and-backup.git
+            branches:
+              - master
+
+- job:
+    name: Copy_Attachments_to_Integration
+    display-name: Copy_Attachments_to_Integration
+    project-type: freestyle
+    description: |
+        This job copies databases from production to integration. It runs periodically
+        to keep the integration environment up to date. The signon database isn't copied.
+    properties:
+        - github:
+            url: https://github.com/alphagov/env-sync-and-backup/
+        - build-discarder:
+            days-to-keep: 30
+            artifact-num-to-keep: 5
+        - slack:
+            notify-start: false
+            notify-success: true
+            notify-aborted: true
+            notify-notbuilt: true
+            notify-unstable: false
+            notify-failure: true
+            notify-backtonormal: false
+            notify-repeatedfailure: false
+            include-test-summary: false
+            room: <%= @slack_room %>
+    scm:
+      - env-sync-and-backup_Copy_Data_to_Integration
+    logrotate:
+        numToKeep: 10
+    triggers:
+        - timed: 'H 1 * * 1-5'
+    builders:
+        - shell: |
+            set -eu
+
+            cd "${WORKSPACE}"
+
+            echo "Syncing attachments"
+            JOBLIST=attachments bash sync production integration
+    publishers:
+      - trigger-parameterized-builds:
+        - project: Success_Passive_Check
+          condition: 'SUCCESS'
+          predefined-parameters: |
+            NSCA_CHECK_DESCRIPTION=<%= @service_description %>
+            NSCA_OUTPUT=<%= @service_description %> success
+        - project: Failure_Passive_Check
+          condition: 'FAILED'
+          predefined-parameters: |
+            NSCA_CHECK_DESCRIPTION=<%= @service_description %>
+            NSCA_OUTPUT=<%= @service_description %> failed
+      - slack:
+          team-domain: <%= @slack_team_domain %>
+          auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN']%>
+          build-server-url: <%= @slack_build_server_url %>
+          room: <%= @slack_room %>
+    wrappers:
+        - ansicolor:
+            colormap: xterm
+        - timestamps

--- a/modules/govuk_jenkins/templates/jobs/copy_attachments_to_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_attachments_to_staging.yaml.erb
@@ -1,0 +1,68 @@
+---
+- scm:
+    name: env-sync-and-backup_Copy_Attachments_to_staging
+    scm:
+        - git:
+            url: git@github.com:alphagov/env-sync-and-backup.git
+            branches:
+              - master
+
+- job:
+    name: Copy_Attachments_to_staging
+    display-name: Copy_Attachments_to_staging
+    project-type: freestyle
+    description: |
+        This job copies databases from production to staging. It runs periodically
+        to keep the staging environment up to date. The signon database isn't copied.
+    properties:
+        - github:
+            url: https://github.com/alphagov/env-sync-and-backup/
+        - build-discarder:
+            days-to-keep: 30
+            artifact-num-to-keep: 5
+        - slack:
+            notify-start: false
+            notify-success: true
+            notify-aborted: true
+            notify-notbuilt: true
+            notify-unstable: false
+            notify-failure: true
+            notify-backtonormal: false
+            notify-repeatedfailure: false
+            include-test-summary: false
+            room: <%= @slack_room %>
+    scm:
+      - env-sync-and-backup_Copy_Data_to_staging
+    logrotate:
+        numToKeep: 10
+    triggers:
+        - timed: 'H 1 * * 1-5'
+    builders:
+        - shell: |
+            set -eu
+
+            cd "${WORKSPACE}"
+
+            echo "Syncing attachments"
+            JOBLIST=attachments bash sync production staging
+    publishers:
+      - trigger-parameterized-builds:
+        - project: Success_Passive_Check
+          condition: 'SUCCESS'
+          predefined-parameters: |
+            NSCA_CHECK_DESCRIPTION=<%= @service_description %>
+            NSCA_OUTPUT=<%= @service_description %> success
+        - project: Failure_Passive_Check
+          condition: 'FAILED'
+          predefined-parameters: |
+            NSCA_CHECK_DESCRIPTION=<%= @service_description %>
+            NSCA_OUTPUT=<%= @service_description %> failed
+      - slack:
+          team-domain: <%= @slack_team_domain %>
+          auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN']%>
+          build-server-url: <%= @slack_build_server_url %>
+          room: <%= @slack_room %>
+    wrappers:
+        - ansicolor:
+            colormap: xterm
+        - timestamps

--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
@@ -95,7 +95,6 @@
             choices:
                 - all
                 - assets
-                - attachments
                 - elasticsearch-rummager
                 - mongo-api
                 - mongo-exceptions
@@ -103,6 +102,5 @@
                 - mongo-normal
                 - mongo-router
                 - mysql-normal
-                - mysql-whitehall
                 - postgresql-backend
                 - postgresql-transition


### PR DESCRIPTION
The attachments sync to integration blocks the main data syncs for too
long now that the destination is using EFS. Moving the sync into a
separate job allows the non-production environments to stabilise more
quickly in the morning.

https://github.com/alphagov/env-sync-and-backup/pull/84 needs to be merged first