### PR TITLE
Give varnish half a gig less RAM to work with

### DIFF
--- a/modules/govuk/manifests/node/s_cache.pp
+++ b/modules/govuk/manifests/node/s_cache.pp
@@ -66,7 +66,7 @@ class govuk::node::s_cache (
   }
 
   # The storage size for the cache, excluding per object and static overheads
-  $varnish_storage_size_pre = floor($::memorysize_mb * 0.70 - 1024)
+  $varnish_storage_size_pre = floor($::memorysize_mb * 0.70 - 1536)
 
   # Ensure that there's some varnish storage in small environments (eg, vagrant).
   if $varnish_storage_size_pre < 100 {


### PR DESCRIPTION
The cache boxes are regularly hitting less than 5% free RAM in
production and staging. This is due to the slowly increasing size of
the routing table, meaning router needs more RAM. Varnish uses the
entirety of its available RAM, however it very rarely evicts objects
due to running low on memory. Almost all objects are evicted due to
expiration. This indicates that we can afford to give varnish less RAM
and not have our hit ratio suffer.

Rather than messing with the percentage of the VM’s RAM we make
available, we just take away another half gig, which is approximately
the current normal usage of a `router` process.