### PR TITLE
Add all jobs provided by sync scripts to jenkins job description

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/copy_data_from_staging_to_aws.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_from_staging_to_aws.yaml.erb
@@ -96,6 +96,8 @@
             description: 'Choose the thing to sync. All is the default, but some jobs may run but not do anything due to your config for the destination environment.'
             choices:
                 - all
+                - attachments
+                - assets
                 - elasticsearch-rummager
                 - mongo-api
                 - mongo-normal


### PR DESCRIPTION
- The Jenkins job has an incomplete list and updating of the joblist via the
  web interface is currently broken due to error:
  SlackNotifier$SlackJobProperty is missing its descriptor

- Will open another card for the error, but this change is helping consistency
  in any case

Solo: @schmie