### PR TITLE
Support sidekiq workers with larger class hierarchies

### DIFF
--- a/modules/grafana/templates/dashboards/deployment_panels/_sidekiq_errors.json.erb
+++ b/modules/grafana/templates/dashboards/deployment_panels/_sidekiq_errors.json.erb
@@ -9,7 +9,7 @@
   "targets": [
     {
       "refId": "A",
-      "target": "groupByNode(stats.govuk.app.<%= @app_name %>.*.workers.*.failure, 6, 'sumSeries')",
+      "target": "aliasByNode(sumSeriesWithWildcards(stats.govuk.app.<%= @app_name %>.*.workers.*.failure, 4), 5)",
       "textEditor": true
     },
     {

--- a/modules/grafana/templates/dashboards/deployment_panels/_sidekiq_errors.json.erb
+++ b/modules/grafana/templates/dashboards/deployment_panels/_sidekiq_errors.json.erb
@@ -16,6 +16,16 @@
       "refId": "B",
       "target": "aliasByNode(sumSeriesWithWildcards(stats.govuk.app.<%= @app_name %>.*.workers.*.*.failure, 4), 5, 6)",
       "textEditor": true
+    },
+    {
+      "refId": "C",
+      "target": "aliasByNode(sumSeriesWithWildcards(stats.govuk.app.<%= @app_name %>.*.workers.*.*.*.failure, 4), 5, 6, 7)",
+      "textEditor": true
+    },
+    {
+      "refId": "D",
+      "target": "aliasByNode(sumSeriesWithWildcards(stats.govuk.app.<%= @app_name %>.*.workers.*.*.*.*.failure, 4), 5, 6, 7, 8)",
+      "textEditor": true
     }
   ],
   "datasource": "Graphite",

--- a/modules/grafana/templates/dashboards/deployment_panels/_worker_failures.json.erb
+++ b/modules/grafana/templates/dashboards/deployment_panels/_worker_failures.json.erb
@@ -58,6 +58,16 @@
       "refId": "B",
       "target": "aliasByNode(transformNull(hitcount(stats.govuk.app.<%= @app_name %>.*.workers.*.*.failure, '5m'),0), 6, 7)",
       "textEditor": true
+    },
+    {
+      "refId": "C",
+      "target": "aliasByNode(transformNull(hitcount(stats.govuk.app.<%= @app_name %>.*.workers.*.*.*.failure, '5m'),0), 6, 7, 8)",
+      "textEditor": true
+    },
+    {
+      "refId": "D",
+      "target": "aliasByNode(transformNull(hitcount(stats.govuk.app.<%= @app_name %>.*.workers.*.*.*.*.failure, '5m'),0), 6, 7, 8, 9)",
+      "textEditor": true
     }
   ],
   "timeFrom": "24h",

--- a/modules/grafana/templates/dashboards/deployment_panels/_worker_failures.json.erb
+++ b/modules/grafana/templates/dashboards/deployment_panels/_worker_failures.json.erb
@@ -51,22 +51,22 @@
   "targets": [
     {
       "refId": "A",
-      "target": "aliasByNode(transformNull(hitcount(stats.govuk.app.<%= @app_name %>.*.workers.*.failure, '5m'),0), 6)",
+      "target": "aliasByNode(sumSeriesWithWildcards(transformNull(hitcount(stats.govuk.app.<%= @app_name %>.*.workers.*.failure, '5m'), 0), 4), 5)",
       "textEditor": true
     },
     {
       "refId": "B",
-      "target": "aliasByNode(transformNull(hitcount(stats.govuk.app.<%= @app_name %>.*.workers.*.*.failure, '5m'),0), 6, 7)",
+      "target": "aliasByNode(sumSeriesWithWildcards(transformNull(hitcount(stats.govuk.app.<%= @app_name %>.*.workers.*.*.failure, '5m'), 0), 4), 5, 6)",
       "textEditor": true
     },
     {
       "refId": "C",
-      "target": "aliasByNode(transformNull(hitcount(stats.govuk.app.<%= @app_name %>.*.workers.*.*.*.failure, '5m'),0), 6, 7, 8)",
+      "target": "aliasByNode(sumSeriesWithWildcards(transformNull(hitcount(stats.govuk.app.<%= @app_name %>.*.workers.*.*.*.failure, '5m'), 0), 4), 5, 6, 7)",
       "textEditor": true
     },
     {
       "refId": "D",
-      "target": "aliasByNode(transformNull(hitcount(stats.govuk.app.<%= @app_name %>.*.workers.*.*.*.*.failure, '5m'),0), 6, 7, 8, 9)",
+      "target": "aliasByNode(sumSeriesWithWildcards(transformNull(hitcount(stats.govuk.app.<%= @app_name %>.*.workers.*.*.*.*.failure, '5m'), 0), 4), 5, 6, 7, 8)",
       "textEditor": true
     }
   ],

--- a/modules/grafana/templates/dashboards/deployment_panels/_worker_successes.json.erb
+++ b/modules/grafana/templates/dashboards/deployment_panels/_worker_successes.json.erb
@@ -51,22 +51,22 @@
   "targets": [
     {
       "refId": "A",
-      "target": "aliasByNode(transformNull(hitcount(stats.govuk.app.<%= @app_name %>.*.workers.*.success, '5m'),0), 6)",
+      "target": "aliasByNode(sumSeriesWithWildcards(transformNull(hitcount(stats.govuk.app.<%= @app_name %>.*.workers.*.success, '5m'), 0), 4), 5)",
       "textEditor": true
     },
     {
       "refId": "B",
-      "target": "aliasByNode(transformNull(hitcount(stats.govuk.app.<%= @app_name %>.*.workers.*.*.success, '5m'),0), 6, 7)",
+      "target": "aliasByNode(sumSeriesWithWildcards(transformNull(hitcount(stats.govuk.app.<%= @app_name %>.*.workers.*.*.success, '5m'), 0), 4), 5, 6)",
       "textEditor": true
     },
     {
       "refId": "C",
-      "target": "aliasByNode(transformNull(hitcount(stats.govuk.app.<%= @app_name %>.*.workers.*.*.*.success, '5m'),0), 6, 7, 8)",
+      "target": "aliasByNode(sumSeriesWithWildcards(transformNull(hitcount(stats.govuk.app.<%= @app_name %>.*.workers.*.*.*.success, '5m'), 0), 4), 5, 6, 7)",
       "textEditor": true
     },
     {
       "refId": "D",
-      "target": "aliasByNode(transformNull(hitcount(stats.govuk.app.<%= @app_name %>.*.workers.*.*.*.*.success, '5m'),0), 6, 7, 8, 9)",
+      "target": "aliasByNode(sumSeriesWithWildcards(transformNull(hitcount(stats.govuk.app.<%= @app_name %>.*.workers.*.*.*.*.success, '5m'), 0), 4), 5, 6, 7, 8)",
       "textEditor": true
     }
   ],

--- a/modules/grafana/templates/dashboards/deployment_panels/_worker_successes.json.erb
+++ b/modules/grafana/templates/dashboards/deployment_panels/_worker_successes.json.erb
@@ -58,6 +58,16 @@
       "refId": "B",
       "target": "aliasByNode(transformNull(hitcount(stats.govuk.app.<%= @app_name %>.*.workers.*.*.success, '5m'),0), 6, 7)",
       "textEditor": true
+    },
+    {
+      "refId": "C",
+      "target": "aliasByNode(transformNull(hitcount(stats.govuk.app.<%= @app_name %>.*.workers.*.*.*.success, '5m'),0), 6, 7, 8)",
+      "textEditor": true
+    },
+    {
+      "refId": "D",
+      "target": "aliasByNode(transformNull(hitcount(stats.govuk.app.<%= @app_name %>.*.workers.*.*.*.*.success, '5m'),0), 6, 7, 8, 9)",
+      "textEditor": true
     }
   ],
   "timeFrom": "24h",


### PR DESCRIPTION
On the deployment dashboards. Applications like Signon use ActiveJob,
and the worker gets recorded as
ActiveJob.QueueAdapters.SidekiqAdapter.JobWrapper, so add support for
up to 4 wildcards to capture these workers.

Plus a couple of other improvements.