### PR TITLE
Jenkins Slack Plugin configuration

### DIFF
--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -58,3 +58,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::user_monitor
   - govuk_jenkins::jobs::validate_published_dns
   - govuk_jenkins::jobs::whitehall_run_broken_link_checker
+
+govuk_jenkins::jobs::deploy_cdn::enable_slack_notifications: true
+govuk_jenkins::jobs::deploy_puppet::enable_slack_notifications: true
+govuk_jenkins::jobs::smokey::enable_slack_notifications: true

--- a/hieradata/class/staging/jenkins.yaml
+++ b/hieradata/class/staging/jenkins.yaml
@@ -34,3 +34,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::update_cdn_dictionaries
   - govuk_jenkins::jobs::user_monitor
   - govuk_jenkins::jobs::validate_published_dns
+
+govuk_jenkins::jobs::deploy_cdn::enable_slack_notifications: true
+govuk_jenkins::jobs::deploy_puppet::enable_slack_notifications: true
+govuk_jenkins::jobs::smokey::enable_slack_notifications: true

--- a/hieradata_aws/class/production/jenkins.yaml
+++ b/hieradata_aws/class/production/jenkins.yaml
@@ -13,3 +13,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::run_rake_task
   - govuk_jenkins::jobs::smokey
   - govuk_jenkins::jobs::smokey_deploy
+
+govuk_jenkins::jobs::deploy_cdn::enable_slack_notifications: false
+govuk_jenkins::jobs::deploy_puppet::enable_slack_notifications: false
+govuk_jenkins::jobs::smokey::enable_slack_notifications: false

--- a/hieradata_aws/class/staging/jenkins.yaml
+++ b/hieradata_aws/class/staging/jenkins.yaml
@@ -13,3 +13,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::run_rake_task
   - govuk_jenkins::jobs::smokey
   - govuk_jenkins::jobs::smokey_deploy
+
+govuk_jenkins::jobs::deploy_cdn::enable_slack_notifications: false
+govuk_jenkins::jobs::deploy_puppet::enable_slack_notifications: false
+govuk_jenkins::jobs::smokey::enable_slack_notifications: false

--- a/modules/govuk_jenkins/manifests/jobs/copy_attachments_to_integration.pp
+++ b/modules/govuk_jenkins/manifests/jobs/copy_attachments_to_integration.pp
@@ -4,6 +4,7 @@
 #
 class govuk_jenkins::jobs::copy_attachments_to_integration (
   $app_domain = hiera('app_domain'),
+  $enable_slack_notifications = true,
 ) {
 
   $check_name = 'copy_attachments_to_integration'

--- a/modules/govuk_jenkins/manifests/jobs/copy_attachments_to_staging.pp
+++ b/modules/govuk_jenkins/manifests/jobs/copy_attachments_to_staging.pp
@@ -4,6 +4,7 @@
 #
 class govuk_jenkins::jobs::copy_attachments_to_staging (
   $app_domain = hiera('app_domain'),
+  $enable_slack_notifications = true,
 ) {
 
   $check_name = 'copy_attachments_to_staging'

--- a/modules/govuk_jenkins/manifests/jobs/copy_data_from_integration_to_aws.pp
+++ b/modules/govuk_jenkins/manifests/jobs/copy_data_from_integration_to_aws.pp
@@ -14,10 +14,6 @@ class govuk_jenkins::jobs::copy_data_from_integration_to_aws (
   $check_name = 'copy_data_from_integration_to_aws'
   $service_description = 'Copy Data from Integration to Aws'
 
-  $slack_team_domain = 'govuk'
-  $slack_room = 'govuk-infrastructure'
-  $slack_build_server_url = "https://deploy.${app_domain}/"
-
   file { '/etc/jenkins_jobs/jobs/copy_data_from_integration_to_aws.yaml':
     ensure  => present,
     content => template('govuk_jenkins/jobs/copy_data_from_integration_to_aws.yaml.erb'),

--- a/modules/govuk_jenkins/manifests/jobs/copy_data_from_production_to_aws.pp
+++ b/modules/govuk_jenkins/manifests/jobs/copy_data_from_production_to_aws.pp
@@ -14,10 +14,6 @@ class govuk_jenkins::jobs::copy_data_from_production_to_aws (
   $check_name = 'copy_data_from_production_to_aws'
   $service_description = 'Copy Data from Production to Aws'
 
-  $slack_team_domain = 'govuk'
-  $slack_room = 'govuk-infrastructure'
-  $slack_build_server_url = "https://deploy.${app_domain}/"
-
   file { '/etc/jenkins_jobs/jobs/copy_data_from_production_to_aws.yaml':
     ensure  => present,
     content => template('govuk_jenkins/jobs/copy_data_from_production_to_aws.yaml.erb'),

--- a/modules/govuk_jenkins/manifests/jobs/copy_data_from_staging_to_aws.pp
+++ b/modules/govuk_jenkins/manifests/jobs/copy_data_from_staging_to_aws.pp
@@ -15,10 +15,6 @@ class govuk_jenkins::jobs::copy_data_from_staging_to_aws (
   $check_name = 'copy_data_from_staging_to_aws'
   $service_description = 'Copy Data from Production to Aws'
 
-  $slack_team_domain = 'govuk'
-  $slack_room = 'govuk-infrastructure'
-  $slack_build_server_url = "https://deploy.${app_domain}/"
-
   file { '/etc/jenkins_jobs/jobs/copy_data_from_staging_to_aws.yaml':
     ensure  => present,
     content => template('govuk_jenkins/jobs/copy_data_from_staging_to_aws.yaml.erb'),

--- a/modules/govuk_jenkins/manifests/jobs/copy_data_to_integration.pp
+++ b/modules/govuk_jenkins/manifests/jobs/copy_data_to_integration.pp
@@ -10,6 +10,7 @@ class govuk_jenkins::jobs::copy_data_to_integration (
   $pg_tr_dst_env_sync_pw = undef,
   $ci_alphagov_api_key = undef,
   $auth_token = undef,
+  $enable_slack_notifications = true,
   $app_domain = hiera('app_domain'),
 ) {
 

--- a/modules/govuk_jenkins/manifests/jobs/copy_data_to_staging.pp
+++ b/modules/govuk_jenkins/manifests/jobs/copy_data_to_staging.pp
@@ -8,6 +8,7 @@ class govuk_jenkins::jobs::copy_data_to_staging (
   $pg_src_env_sync_pw = undef,
   $pg_dst_env_sync_pw = undef,
   $ci_alphagov_api_key = undef,
+  $enable_slack_notifications = true,
   $auth_token = undef,
   $app_domain = hiera('app_domain'),
 ) {

--- a/modules/govuk_jenkins/manifests/jobs/deploy_cdn.pp
+++ b/modules/govuk_jenkins/manifests/jobs/deploy_cdn.pp
@@ -4,6 +4,7 @@
 #
 class govuk_jenkins::jobs::deploy_cdn(
   $app_domain = hiera('app_domain'),
+  $enable_slack_notifications = false,
 ) {
 
   $slack_team_domain = 'govuk'

--- a/modules/govuk_jenkins/manifests/jobs/deploy_puppet.pp
+++ b/modules/govuk_jenkins/manifests/jobs/deploy_puppet.pp
@@ -7,12 +7,16 @@
 # [*auth_token*]
 #   Token which will allow this job to be triggered remotely
 #
+# [*enable_slack_notifications*]
+#   Whether slack should be notified about this job
+#
 # [*commitish*]
 #   The commitish that the job should deploy by default. Defaults to 'release'
 #
 class govuk_jenkins::jobs::deploy_puppet (
   $auth_token = undef,
   $commitish   = 'release',
+  $enable_slack_notifications = false,
   $app_domain = hiera('app_domain')
 ) {
   $slack_team_domain = 'govuk'

--- a/modules/govuk_jenkins/manifests/jobs/smokey.pp
+++ b/modules/govuk_jenkins/manifests/jobs/smokey.pp
@@ -4,10 +4,14 @@
 #
 # === Parameters
 #
+# [*enable_slack_notifications*]
+#   Whether slack should be notified about this job
+#
 # [*smokey_task*]
 #   The rake task to run for the tests
 #
 class govuk_jenkins::jobs::smokey (
+  $enable_slack_notifications = false,
   $smokey_task = 'test:production',
 ) {
   $app_domain = hiera('app_domain')

--- a/modules/govuk_jenkins/templates/jobs/copy_attachments_to_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_attachments_to_integration.yaml.erb
@@ -20,17 +20,6 @@
         - build-discarder:
             days-to-keep: 30
             artifact-num-to-keep: 5
-        - slack:
-            notify-start: false
-            notify-success: true
-            notify-aborted: true
-            notify-notbuilt: true
-            notify-unstable: false
-            notify-failure: true
-            notify-backtonormal: false
-            notify-repeatedfailure: false
-            include-test-summary: false
-            room: <%= @slack_room %>
     scm:
       - env-sync-and-backup_Copy_Attachments_to_Integration
     logrotate:
@@ -61,6 +50,15 @@
           team-domain: <%= @slack_team_domain %>
           auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN']%>
           build-server-url: <%= @slack_build_server_url %>
+          notify-start: false
+          notify-success: true
+          notify-aborted: true
+          notify-notbuilt: true
+          notify-unstable: false
+          notify-failure: true
+          notify-backtonormal: false
+          notify-repeatedfailure: false
+          include-test-summary: false
           room: <%= @slack_room %>
     wrappers:
         - ansicolor:

--- a/modules/govuk_jenkins/templates/jobs/copy_attachments_to_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_attachments_to_integration.yaml.erb
@@ -46,6 +46,7 @@
           predefined-parameters: |
             NSCA_CHECK_DESCRIPTION=<%= @service_description %>
             NSCA_OUTPUT=<%= @service_description %> failed
+      <% if @enable_slack_notifications %>
       - slack:
           team-domain: <%= @slack_team_domain %>
           auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN']%>
@@ -60,6 +61,7 @@
           notify-repeatedfailure: false
           include-test-summary: false
           room: <%= @slack_room %>
+      <% end %>
     wrappers:
         - ansicolor:
             colormap: xterm

--- a/modules/govuk_jenkins/templates/jobs/copy_attachments_to_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_attachments_to_staging.yaml.erb
@@ -20,17 +20,6 @@
         - build-discarder:
             days-to-keep: 30
             artifact-num-to-keep: 5
-        - slack:
-            notify-start: false
-            notify-success: true
-            notify-aborted: true
-            notify-notbuilt: true
-            notify-unstable: false
-            notify-failure: true
-            notify-backtonormal: false
-            notify-repeatedfailure: false
-            include-test-summary: false
-            room: <%= @slack_room %>
     scm:
       - env-sync-and-backup_Copy_Attachments_to_staging
     logrotate:
@@ -61,6 +50,15 @@
           team-domain: <%= @slack_team_domain %>
           auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN']%>
           build-server-url: <%= @slack_build_server_url %>
+          notify-start: false
+          notify-success: true
+          notify-aborted: true
+          notify-notbuilt: true
+          notify-unstable: false
+          notify-failure: true
+          notify-backtonormal: false
+          notify-repeatedfailure: false
+          include-test-summary: false
           room: <%= @slack_room %>
     wrappers:
         - ansicolor:

--- a/modules/govuk_jenkins/templates/jobs/copy_attachments_to_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_attachments_to_staging.yaml.erb
@@ -46,6 +46,7 @@
           predefined-parameters: |
             NSCA_CHECK_DESCRIPTION=<%= @service_description %>
             NSCA_OUTPUT=<%= @service_description %> failed
+      <% if @enable_slack_notifications %>
       - slack:
           team-domain: <%= @slack_team_domain %>
           auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN']%>
@@ -60,6 +61,7 @@
           notify-repeatedfailure: false
           include-test-summary: false
           room: <%= @slack_room %>
+      <% end %>
     wrappers:
         - ansicolor:
             colormap: xterm

--- a/modules/govuk_jenkins/templates/jobs/copy_data_from_integration_to_aws.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_from_integration_to_aws.yaml.erb
@@ -24,17 +24,6 @@
         - build-discarder:
             days-to-keep: 30
             artifact-num-to-keep: 5
-        - slack:
-            notify-start: true
-            notify-success: true
-            notify-aborted: false
-            notify-notbuilt: false
-            notify-unstable: false
-            notify-failure: true
-            notify-backtonormal: false
-            notify-repeatedfailure: false
-            include-test-summary: false
-            room: <%= @slack_room %>
     scm:
       - env-sync-and-backup_Copy_Data_from_Integration_to_AWS
     logrotate:
@@ -80,6 +69,15 @@
           team-domain: <%= @slack_team_domain %>
           auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN']%>
           build-server-url: <%= @slack_build_server_url %>
+          notify-start: true
+          notify-success: true
+          notify-aborted: false
+          notify-notbuilt: false
+          notify-unstable: false
+          notify-failure: true
+          notify-backtonormal: false
+          notify-repeatedfailure: false
+          include-test-summary: false
           room: <%= @slack_room %>
     wrappers:
         - ansicolor:

--- a/modules/govuk_jenkins/templates/jobs/copy_data_from_integration_to_aws.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_from_integration_to_aws.yaml.erb
@@ -65,20 +65,6 @@
             HOSTNAME=deploy.blue.integration.govuk.digital
             API_KEY=<%= @ci_alphagov_api_key %>
             AUTH_TOKEN=<%= @auth_token %>
-      - slack:
-          team-domain: <%= @slack_team_domain %>
-          auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN']%>
-          build-server-url: <%= @slack_build_server_url %>
-          notify-start: true
-          notify-success: true
-          notify-aborted: false
-          notify-notbuilt: false
-          notify-unstable: false
-          notify-failure: true
-          notify-backtonormal: false
-          notify-repeatedfailure: false
-          include-test-summary: false
-          room: <%= @slack_room %>
     wrappers:
         - ansicolor:
             colormap: xterm

--- a/modules/govuk_jenkins/templates/jobs/copy_data_from_staging_to_aws.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_from_staging_to_aws.yaml.erb
@@ -70,20 +70,6 @@
             HOSTNAME=deploy.blue.staging.govuk.digital
             API_KEY=<%= @ci_alphagov_api_key %>
             AUTH_TOKEN=<%= @auth_token %>
-      - slack:
-          team-domain: <%= @slack_team_domain %>
-          auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN']%>
-          build-server-url: <%= @slack_build_server_url %>
-          notify-start: true
-          notify-success: true
-          notify-aborted: false
-          notify-notbuilt: false
-          notify-unstable: false
-          notify-failure: true
-          notify-backtonormal: false
-          notify-repeatedfailure: false
-          include-test-summary: false
-          room: <%= @slack_room %>
     wrappers:
         - ansicolor:
             colormap: xterm

--- a/modules/govuk_jenkins/templates/jobs/copy_data_from_staging_to_aws.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_from_staging_to_aws.yaml.erb
@@ -24,17 +24,6 @@
         - build-discarder:
             days-to-keep: 30
             artifact-num-to-keep: 5
-        - slack:
-            notify-start: true
-            notify-success: true
-            notify-aborted: false
-            notify-notbuilt: false
-            notify-unstable: false
-            notify-failure: true
-            notify-backtonormal: false
-            notify-repeatedfailure: false
-            include-test-summary: false
-            room: <%= @slack_room %>
     scm:
       - env-sync-and-backup_Copy_Data_to_Staging
     logrotate:
@@ -85,6 +74,15 @@
           team-domain: <%= @slack_team_domain %>
           auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN']%>
           build-server-url: <%= @slack_build_server_url %>
+          notify-start: true
+          notify-success: true
+          notify-aborted: false
+          notify-notbuilt: false
+          notify-unstable: false
+          notify-failure: true
+          notify-backtonormal: false
+          notify-repeatedfailure: false
+          include-test-summary: false
           room: <%= @slack_room %>
     wrappers:
         - ansicolor:

--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
@@ -23,17 +23,6 @@
         - build-discarder:
             days-to-keep: 30
             artifact-num-to-keep: 5
-        - slack:
-            notify-start: false
-            notify-success: true
-            notify-aborted: true
-            notify-notbuilt: true
-            notify-unstable: false
-            notify-failure: true
-            notify-backtonormal: false
-            notify-repeatedfailure: false
-            include-test-summary: false
-            room: <%= @slack_room %>
     scm:
       - env-sync-and-backup_Copy_Data_to_Integration
     logrotate:
@@ -83,6 +72,15 @@
           team-domain: <%= @slack_team_domain %>
           auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN']%>
           build-server-url: <%= @slack_build_server_url %>
+          notify-start: false
+          notify-success: true
+          notify-aborted: true
+          notify-notbuilt: true
+          notify-unstable: false
+          notify-failure: true
+          notify-backtonormal: false
+          notify-repeatedfailure: false
+          include-test-summary: false
           room: <%= @slack_room %>
     wrappers:
         - ansicolor:

--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
@@ -68,6 +68,7 @@
             HOSTNAME=deploy.integration.publishing.service.gov.uk
             API_KEY=<%= @ci_alphagov_api_key %>
             AUTH_TOKEN=<%= @auth_token %>
+      <% if $enable_slack_notifications %>
       - slack:
           team-domain: <%= @slack_team_domain %>
           auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN']%>
@@ -82,6 +83,7 @@
           notify-repeatedfailure: false
           include-test-summary: false
           room: <%= @slack_room %>
+      <% end %>
     wrappers:
         - ansicolor:
             colormap: xterm

--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_staging.yaml.erb
@@ -22,17 +22,6 @@
         - build-discarder:
             days-to-keep: 30
             artifact-num-to-keep: 5
-        - slack:
-            notify-start: false
-            notify-success: true
-            notify-aborted: true
-            notify-notbuilt: true
-            notify-unstable: false
-            notify-failure: true
-            notify-backtonormal: false
-            notify-repeatedfailure: false
-            include-test-summary: false
-            room: <%= @slack_room %>
     scm:
       - env-sync-and-backup_Copy_Data_to_Staging
     logrotate:
@@ -95,6 +84,15 @@
           team-domain: <%= @slack_team_domain %>
           auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN']%>
           build-server-url: <%= @slack_build_server_url %>
+          notify-start: false
+          notify-success: true
+          notify-aborted: true
+          notify-notbuilt: true
+          notify-unstable: false
+          notify-failure: true
+          notify-backtonormal: false
+          notify-repeatedfailure: false
+          include-test-summary: false
           room: <%= @slack_room %>
     wrappers:
         - ansicolor:

--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_staging.yaml.erb
@@ -80,6 +80,7 @@
             HOSTNAME=deploy.staging.publishing.service.gov.uk
             API_KEY=<%= @ci_alphagov_api_key %>
             AUTH_TOKEN=<%= @auth_token %>
+      <% if @enable_slack_notifications %>
       - slack:
           team-domain: <%= @slack_team_domain %>
           auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN']%>
@@ -94,6 +95,7 @@
           notify-repeatedfailure: false
           include-test-summary: false
           room: <%= @slack_room %>
+      <% end %>
     wrappers:
         - ansicolor:
             colormap: xterm

--- a/modules/govuk_jenkins/templates/jobs/deploy_cdn.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_cdn.yaml.erb
@@ -27,6 +27,7 @@
             export ENVIRONMENT=<%= @environment %>
             ./jenkins.sh
     publishers:
+      <% if @enable_slack_notifications %>
       - slack:
           team-domain: <%= @slack_team_domain %>
           auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN']%>
@@ -41,6 +42,7 @@
           notify-repeatedfailure: false
           include-test-summary: false
           room: <%= @slack_room %>
+      <% end %>
     wrappers:
         - ansicolor:
             colormap: xterm

--- a/modules/govuk_jenkins/templates/jobs/deploy_cdn.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_cdn.yaml.erb
@@ -20,17 +20,6 @@
             artifact-num-to-keep: 5
         - github:
             url: https://github.com/alphagov/fastly-configure/
-        - slack:
-            notify-start: false
-            notify-success: true
-            notify-aborted: true
-            notify-notbuilt: true
-            notify-unstable: false
-            notify-failure: true
-            notify-backtonormal: false
-            notify-repeatedfailure: false
-            include-test-summary: false
-            room: <%= @slack_room %>
     scm:
       - cdn-configs_Deploy_CDN
     builders:
@@ -42,6 +31,15 @@
           team-domain: <%= @slack_team_domain %>
           auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN']%>
           build-server-url: <%= @slack_build_server_url %>
+          notify-start: false
+          notify-success: true
+          notify-aborted: true
+          notify-notbuilt: true
+          notify-unstable: false
+          notify-failure: true
+          notify-backtonormal: false
+          notify-repeatedfailure: false
+          include-test-summary: false
           room: <%= @slack_room %>
     wrappers:
         - ansicolor:

--- a/modules/govuk_jenkins/templates/jobs/deploy_puppet.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_puppet.yaml.erb
@@ -46,7 +46,7 @@
     publishers:
         - trigger:
             project: Smokey
-        <%- unless @aws_migration -%>
+        <%- if @enable_slack_notifications -%>
         - slack:
             team-domain: <%= @slack_team_domain %>
             auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN']%>

--- a/modules/govuk_jenkins/templates/jobs/deploy_puppet.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_puppet.yaml.erb
@@ -35,17 +35,6 @@
             artifact-num-to-keep: 5
         - github:
             url: https://github.com/alphagov/govuk-secrets/
-        - slack:
-            notify-start: true
-            notify-success: true
-            notify-aborted: true
-            notify-notbuilt: true
-            notify-unstable: false
-            notify-failure: true
-            notify-backtonormal: false
-            notify-repeatedfailure: false
-            include-test-summary: false
-            room: <%= @slack_room %>
     scm:
       - deployment_Deploy_Puppet
     builders:
@@ -62,6 +51,15 @@
             team-domain: <%= @slack_team_domain %>
             auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN']%>
             build-server-url: <%= @slack_build_server_url %>
+            notify-start: true
+            notify-success: true
+            notify-aborted: true
+            notify-notbuilt: true
+            notify-unstable: false
+            notify-failure: true
+            notify-backtonormal: false
+            notify-repeatedfailure: false
+            include-test-summary: false
             room: <%= @slack_room %>
         <%- end -%>
     wrappers:

--- a/modules/govuk_jenkins/templates/jobs/smokey.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/smokey.yaml.erb
@@ -18,6 +18,7 @@
           days-to-keep: 30
           artifact-num-to-keep: 5
     publishers:
+      <% if @enable_slack_notifications %>
       - slack:
           team-domain: <%= @slack_team_domain %>
           auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN']%>
@@ -32,6 +33,7 @@
           notify-repeatedfailure: false
           include-test-summary: false
           room: <%= @slack_room %>
+      <% end %>
       - email-ext:
           recipients: govuk-ci-notifications@digital.cabinet-office.gov.uk
           attach-build-log: true

--- a/modules/govuk_jenkins/templates/jobs/smokey.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/smokey.yaml.erb
@@ -17,7 +17,11 @@
       - build-discarder:
           days-to-keep: 30
           artifact-num-to-keep: 5
+    publishers:
       - slack:
+          team-domain: <%= @slack_team_domain %>
+          auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN']%>
+          build-server-url: <%= @slack_build_server_url %>
           notify-start: false
           notify-success: false
           notify-aborted: true
@@ -27,12 +31,6 @@
           notify-backtonormal: true
           notify-repeatedfailure: false
           include-test-summary: false
-          room: <%= @slack_room %>
-    publishers:
-      - slack:
-          team-domain: <%= @slack_team_domain %>
-          auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN']%>
-          build-server-url: <%= @slack_build_server_url %>
           room: <%= @slack_room %>
       - email-ext:
           recipients: govuk-ci-notifications@digital.cabinet-office.gov.uk

--- a/modules/govuk_jenkins/templates/jobs/update_cdn_dictionaries.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/update_cdn_dictionaries.yaml.erb
@@ -20,18 +20,6 @@
             artifact-num-to-keep: 5
         - github:
             url: https://github.com/alphagov/cdn-configs/
-        - slack:
-            notify-start: false
-            notify-success: true
-            notify-aborted: true
-            notify-notbuilt: true
-            notify-unstable: false
-            notify-failure: true
-            notify-backtonormal: false
-            notify-repeatedfailure: false
-            include-test-summary: false
-            room: <%= @slack_room %>
-
     scm:
       - update_cdn_dictionaries
     builders:
@@ -44,6 +32,15 @@
           team-domain: <%= @slack_team_domain %>
           auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN']%>
           build-server-url: <%= @slack_build_server_url %>
+          notify-start: false
+          notify-success: true
+          notify-aborted: true
+          notify-notbuilt: true
+          notify-unstable: false
+          notify-failure: true
+          notify-backtonormal: false
+          notify-repeatedfailure: false
+          include-test-summary: false
           room: <%= @slack_room %>
     wrappers:
         - ansicolor:


### PR DESCRIPTION
Trello: https://trello.com/c/UhpTSd5a/25-look-into-slack-plugin-not-working-on-jenkins

With the update to Slack plugin > 2 for Jenkins we have needed to change the configuration as the previous approach to configuring this would cause errors when the job configuration was saved.

In resolving this I noticed that the previous way to disable Slack notifications (an env var with value of "disabled for environment") meant that running jobs in integration environments failed. Thus I've changed this to be configured by hieradata.

Finally I've also removed slack notifications to jobs to old rooms that no longer exist and thus were not likely even doing anything.