### PR TITLE
Increase alert threshold to avoid constant freshness warning

### DIFF
--- a/modules/mongodb/manifests/aws_backup.pp
+++ b/modules/mongodb/manifests/aws_backup.pp
@@ -31,7 +31,7 @@ class mongodb::aws_backup (
   validate_re($daily_time, '^(\d\d):(\d\d)$')
 
   $alert_hostname = 'alert'
-  $threshold_secs = 3600
+  $threshold_secs = 4800
   $service_desc = 'MongoDB backup to S3'
 
   if $ensure == 'present' {


### PR DESCRIPTION
- The MongoDB S3 backup takes just over an hour and provokes several freshness
  warnings per day.

- Increasing threshold for freshness warning by 20 mins to 4800 secs.

Solo: @schmie