### PR TITLE
fix_mongo_mount

### DIFF
--- a/hieradata_aws/class/staging/mongo.yaml
+++ b/hieradata_aws/class/staging/mongo.yaml
@@ -13,7 +13,7 @@ mongodb::server::replicaset_members:
 
 lv:
   data:
-    pv: '/dev/nvme1n1'
+    pv: '/dev/xvdf'
     vg: 'mongo'
 
 mount:


### PR DESCRIPTION
device name not allowed need to use /dev/xvdf