### PR TITLE
Add an AWS_SESSION_TOKEN parameter to the Deploy DNS job

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_dns.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_dns.yaml.erb
@@ -58,6 +58,10 @@
             name: AWS_SECRET_ACCESS_KEY
             default: false
             description: This is required for all providers
+        - password:
+            name: AWS_SESSION_TOKEN
+            default: false
+            description: This is required for all providers
         - choice:
             name: ACTION
             description: Choose whether to plan (default) or apply


### PR DESCRIPTION
- People deploying DNS these days don't have old style credentials per
  environment, they have to `aws assume-role`, for which AWS also
  requires a `SESSION_TOKEN`.