### PR TITLE
Change Jenkins jobs that run on an hour to use London timezone

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/check_cdn_ip_ranges.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/check_cdn_ip_ranges.yaml.erb
@@ -29,4 +29,6 @@
         - email:
             recipients: 2nd-line-support@digital.cabinet-office.gov.uk
     triggers:
-        - timed: 'H 3 * * *'
+        - timed: |
+            TZ=Europe/London
+            H 3 * * *

--- a/modules/govuk_jenkins/templates/jobs/check_content_consistency.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/check_content_consistency.yaml.erb
@@ -20,7 +20,9 @@
       numToKeep: 10
       artifactDaysToKeep: 3
     triggers:
-        - timed: 'H 11 * * *'
+        - timed: |
+            TZ=Europe/London
+            H 11 * * *
     properties:
         - build-discarder:
             days-to-keep: 30

--- a/modules/govuk_jenkins/templates/jobs/configure_github_repos.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/configure_github_repos.yaml.erb
@@ -17,7 +17,10 @@
     logrotate:
         numToKeep: 250
     triggers:
-        - timed: '0 8 * * *' # 8PM every day
+        - timed: |
+            TZ=Europe/London
+            # 8PM every day
+            0 8 * * *
     properties:
         - build-discarder:
             days-to-keep: 30

--- a/modules/govuk_jenkins/templates/jobs/copy_attachments_to_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_attachments_to_integration.yaml.erb
@@ -25,7 +25,9 @@
     logrotate:
         numToKeep: 10
     triggers:
-        - timed: 'H 1 * * 1-5'
+        - timed: |
+            TZ=Europe/London
+            H 1 * * 1-5
     builders:
         - shell: |
             set -eu

--- a/modules/govuk_jenkins/templates/jobs/copy_attachments_to_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_attachments_to_staging.yaml.erb
@@ -25,7 +25,9 @@
     logrotate:
         numToKeep: 10
     triggers:
-        - timed: 'H 1 * * 1-5'
+        - timed: |
+            TZ=Europe/London
+            H 1 * * 1-5
     builders:
         - shell: |
             set -eu

--- a/modules/govuk_jenkins/templates/jobs/copy_data_from_integration_to_aws.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_from_integration_to_aws.yaml.erb
@@ -29,7 +29,9 @@
     logrotate:
         numToKeep: 10
     triggers:
-        - timed: 'H 11 * * 1-5'
+        - timed: |
+            TZ=Europe/London
+            H 11 * * 1-5
     builders:
         - shell: |
             set -eu

--- a/modules/govuk_jenkins/templates/jobs/copy_data_from_production_to_aws.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_from_production_to_aws.yaml.erb
@@ -29,7 +29,9 @@
     logrotate:
         numToKeep: 10
     triggers:
-        - timed: 'H 11 * * *'
+        - timed: |
+            TZ=Europe/London
+            H 11 * * *
     builders:
         - shell: |
             set +x

--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
@@ -30,7 +30,7 @@
     triggers:
         - timed: |
             TZ=Europe/London
-            H 4 * * 1-5'
+            H 3 * * 1-5'
     builders:
         - shell: |
             set -eu

--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
@@ -28,7 +28,9 @@
     logrotate:
         numToKeep: 10
     triggers:
-        - timed: 'H 4 * * 1-5'
+        - timed: |
+            TZ=Europe/London
+            H 4 * * 1-5'
     builders:
         - shell: |
             set -eu

--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_staging.yaml.erb
@@ -27,7 +27,9 @@
     logrotate:
         numToKeep: 10
     triggers:
-        - timed: 'H 1 * * *'
+        - timed: |
+            TZ=Europe/London
+            H 1 * * *
     builders:
         - shell: |
             set +x

--- a/modules/govuk_jenkins/templates/jobs/copy_licensify_data_to_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_licensify_data_to_staging.yaml.erb
@@ -26,7 +26,9 @@
     logrotate:
         numToKeep: 10
     triggers:
-        - timed: 'H 1 * * *'
+        - timed: |
+            TZ=Europe/London
+            H 1 * * *
     builders:
         - shell: |
             set +x

--- a/modules/govuk_jenkins/templates/jobs/copy_sanitised_whitehall_database.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_sanitised_whitehall_database.yaml.erb
@@ -25,7 +25,9 @@
     logrotate:
         numToKeep: 10
     triggers:
-        - timed: '15 5 * * 1-5'
+        - timed: |
+            TZ=Europe/London
+            15 5 * * 1-5'
     builders:
         - shell: |
             cd "$WORKSPACE/whitehall/"

--- a/modules/govuk_jenkins/templates/jobs/govuk_cdn_nightly_2xx_status_collection.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/govuk_cdn_nightly_2xx_status_collection.yaml.erb
@@ -32,4 +32,6 @@
     logrotate:
       numToKeep: 14
     triggers:
-      - timed: 'H 7 * * *'
+        - timed: |
+            TZ=Europe/London
+            H 7 * * *

--- a/modules/govuk_jenkins/templates/jobs/govuk_navigation_link_analysis.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/govuk_navigation_link_analysis.yaml.erb
@@ -20,7 +20,9 @@
     logrotate:
       numToKeep: 10
     triggers:
-        - timed: 'H 0 * * 1'
+        - timed: |
+            TZ=Europe/London
+            H 0 * * 1
     properties:
         - build-discarder:
             days-to-keep: 30

--- a/modules/govuk_jenkins/templates/jobs/govuk_taxonomy_supervised_learning.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/govuk_taxonomy_supervised_learning.yaml.erb
@@ -18,7 +18,9 @@
     scm:
       - govuk-taxonomy-supervised-learning
     triggers:
-        - timed: 'H 2 * * 1-5'
+        - timed: |
+            TZ=Europe/London
+            H 2 * * 1-5
     properties:
         - build-discarder:
             days-to-keep: 30

--- a/modules/govuk_jenkins/templates/jobs/publishing_api_archive_events.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/publishing_api_archive_events.yaml.erb
@@ -13,7 +13,9 @@
     logrotate:
       numToKeep: 10
     triggers:
-        - timed: 'H 5 * * 0'
+        - timed: |
+            TZ=Europe/London
+            H 5 * * 0
     publishers:
         - email:
             recipients: 2nd-line-support@digital.cabinet-office.gov.uk

--- a/modules/govuk_jenkins/templates/jobs/run_deploy_lag_badger.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/run_deploy_lag_badger.yaml.erb
@@ -17,7 +17,10 @@
     logrotate:
         numToKeep: 100
     triggers:
-        - timed: '0 13 * * *' # 1PM every day
+        - timed: |
+            TZ=Europe/London
+            # 1PM every day
+            0 13 * * *
     properties:
         - build-discarder:
             days-to-keep: 30

--- a/modules/govuk_jenkins/templates/jobs/smokey_deploy.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/smokey_deploy.yaml.erb
@@ -28,4 +28,6 @@
             <%- end %>
             sh -x deploy.sh
     triggers:
-        - timed: 'H 9 * * *'
+        - timed: |
+            TZ=Europe/London
+            H 9 * * *

--- a/modules/govuk_jenkins/templates/jobs/whitehall_publisher_notifications.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/whitehall_publisher_notifications.yaml.erb
@@ -16,6 +16,8 @@
         - email:
             recipients: govuk-ci-notifications@digital.cabinet-office.gov.uk
     triggers:
-      - timed: "0 1 * * *"
+        - timed: |
+            TZ=Europe/London
+            0 1 * * *
     logrotate:
         numToKeep: 10

--- a/modules/govuk_jenkins/templates/jobs/whitehall_run_broken_link_checker.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/whitehall_run_broken_link_checker.yaml.erb
@@ -13,7 +13,9 @@
             ssh deploy@$(govuk_node_list -c whitehall_backend --single-node) 'cd /var/apps/whitehall; govuk_setenv whitehall nohup bundle exec rake generate_broken_link_reports[/tmp/bad_link_reports,second-line-content@digital.cabinet-office.gov.uk]'
             echo "Broken link checker run"
     triggers:
-        - timed: '0 2 1 * *'
+        - timed: |
+            TZ=Europe/London
+            0 2 1 * *
     wrappers:
         - ansicolor:
             colormap: xterm


### PR DESCRIPTION
This is to stop the various jobs all changing the time they run out when
we switch between GMT and BST. This is somewhat more pertinent for the
long running nightly jobs which can drag into the morning and disrupt
the working day.