### PR TITLE
Update healthcheck path for Smart Answers

### DIFF
--- a/modules/govuk/manifests/apps/smartanswers.pp
+++ b/modules/govuk/manifests/apps/smartanswers.pp
@@ -82,7 +82,7 @@ class govuk::apps::smartanswers(
     app_type                 => 'rack',
     port                     => $port,
     sentry_dsn               => $sentry_dsn,
-    health_check_path        => '/pay-leave-for-parents',
+    health_check_path        => '/pay-leave-for-parents/y',
     log_format_is_json       => true,
     asset_pipeline           => true,
     asset_pipeline_prefix    => 'smartanswers',


### PR DESCRIPTION
The "Start now" landing pages for smart answers are now rendered by `frontend`, so the current healthcheck path `/pay-leave-for-parents` does not test that the page hits `smart-answers`.

Trello card: [Improve icinga healthchecks for frontend apps](https://trello.com/c/1EvxPr5h/94-improve-icinga-healthchecks-for-frontend-apps-2)

Smartanswers original healthcheck path:
![smartanswers_original_healthcheck_path](https://user-images.githubusercontent.com/19667619/39115561-f47ad6aa-46d9-11e8-8ad9-98073a73292a.png)
Smartanswers updated healthcheck path:
![smartanswers_updated_healthcheck_path](https://user-images.githubusercontent.com/19667619/39115569-fa40beb0-46d9-11e8-9947-a4777c1b93c1.png)
