### PR TITLE
Update healthcheck path for Government Frontend

### DIFF
--- a/modules/govuk/manifests/apps/government_frontend.pp
+++ b/modules/govuk/manifests/apps/government_frontend.pp
@@ -52,7 +52,7 @@ class govuk::apps::government_frontend(
     port                     => $port,
     sentry_dsn               => $sentry_dsn,
     vhost_ssl_only           => true,
-    health_check_path        => '/healthcheck',
+    health_check_path        => '/government/case-studies/example-case-studies-eu-citizens-rights-in-the-uk',
     asset_pipeline           => true,
     asset_pipeline_prefix    => 'government-frontend',
     vhost                    => $vhost,


### PR DESCRIPTION
The healthcheck path for `government-frontend` is currently set to `/healthcheck`. It only checks that the app boots up fine but does not check that a `government-frontend` page is rendered properly.

Trello card: [Improve icinga healthchecks for frontend apps](https://trello.com/c/1EvxPr5h/94-improve-icinga-healthchecks-for-frontend-apps-2)

Updated healthcheck path for `government-frontend`:
![government_frontend_updated_healthcheck_path](https://user-images.githubusercontent.com/19667619/39119440-c481088e-46e3-11e8-92aa-9bbf746440eb.png)
