### PR TITLE
Update healthcheck path for Service Manual Frontend

### DIFF
--- a/modules/govuk/manifests/apps/service_manual_frontend.pp
+++ b/modules/govuk/manifests/apps/service_manual_frontend.pp
@@ -40,7 +40,7 @@ class govuk::apps::service_manual_frontend(
       port                  => $port,
       sentry_dsn            => $sentry_dsn,
       vhost_ssl_only        => true,
-      health_check_path     => '/healthcheck',
+      health_check_path     => '/service-manual',
       asset_pipeline        => true,
       asset_pipeline_prefix => 'service-manual-frontend',
       vhost                 => $vhost,


### PR DESCRIPTION
The healthcheck path for `service-manual-frontend` is currently set to `/healthcheck`. It only checks that the app boots up fine but does not check that a `service-manual-frontend` page is rendered properly.

Trello card: [Improve icinga healthchecks for frontend apps](https://trello.com/c/1EvxPr5h/94-improve-icinga-healthchecks-for-frontend-apps-2)

The healthcheck path has been changed to point to the  Service Manual landing page.
![service_manual_frontend_updated_healthcheck_path](https://user-images.githubusercontent.com/19667619/39120977-19815e20-46e8-11e8-9571-38e01db759d7.png)
