### PR TITLE
Add an AWS_SESSION_TOKEN parameter to all AWS Jenkins jobs

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_lambda_app.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_lambda_app.yaml.erb
@@ -48,3 +48,7 @@
             name: AWS_SECRET_ACCESS_KEY
             description: Your AWS secret access key
             default: false
+        - password:
+            name: AWS_SESSION_TOKEN
+            description: Your AWS session token
+            default: false

--- a/modules/govuk_jenkins/templates/jobs/deploy_terraform_project.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_terraform_project.yaml.erb
@@ -51,6 +51,10 @@
             name: AWS_SECRET_ACCESS_KEY
             description: Your AWS secret access key
             default: false
+        - password:
+            name: AWS_SESSION_TOKEN
+            description: Your AWS session token
+            default: false
         - choice:
             name: ACTION
             description: Choose whether to plan (default) or apply


### PR DESCRIPTION
- Now we have to assume roles to get tokens for AWS environments,
  AWS_SESSION_TOKEN has become a required parameter. As in
  04fb78cff3f36c4820ea2b78e032e0fc7846728e, add this to
  all remaining Jenkins jobs that ask for tokens to be pasted in.
- "Deploy_Terraform_Project" will go away soon, but we should be
  consistent for the time being as some things are still configured and
  deployed there.