### PR TITLE
Set pipenv version to full version

### DIFF
--- a/modules/govuk_jenkins/manifests/init.pp
+++ b/modules/govuk_jenkins/manifests/init.pp
@@ -112,7 +112,7 @@ class govuk_jenkins (
   }
 
   package { 'pipenv':
-    ensure   => '11.8',
+    ensure   => '11.8.0',
     provider => 'pip',
   }
 


### PR DESCRIPTION
Otherwise on each puppet run we get a:

```
Notice: /Stage[main]/Govuk_jenkins/Package[pipenv]/ensure: ensure changed '11.8.0' to '11.8'
```