### PR TITLE
Start the autobackup of postgresql 2 hours early

### DIFF
--- a/modules/govuk_postgresql/manifests/backup.pp
+++ b/modules/govuk_postgresql/manifests/backup.pp
@@ -23,7 +23,7 @@
 #   The hostname of the alert service, to send ncsa notifications.
 #
 class govuk_postgresql::backup (
-  $auto_postgresql_backup_hour = 8,
+  $auto_postgresql_backup_hour = 6,
   $auto_postgresql_backup_minute = 0,
   $alert_hostname = 'alert.cluster',
 ) {


### PR DESCRIPTION
- There was a race condition between the autobackup process creating a current
  archive on postgresql-primary-1 and duplicity pulling it to backup-1 (missed it by 7 mins)

- This caused the duplicity process to hang as well as a "backup failed" crit.

Solo: @schmie