### PR TITLE
Group dashboard response times by action

### DIFF
--- a/modules/grafana/manifests/dashboards/deployment_dashboard.pp
+++ b/modules/grafana/manifests/dashboards/deployment_dashboard.pp
@@ -72,7 +72,7 @@ define grafana::dashboards::deployment_dashboard (
 
   if $show_slow_requests {
     $duration_by_controller_row = [
-      ['response_times_by_controller']
+      ['response_times_by_controller_action']
     ]
   } else {
     $duration_by_controller_row = []

--- a/modules/grafana/templates/dashboards/deployment_panels/_response_times_by_controller_action.json.erb
+++ b/modules/grafana/templates/dashboards/deployment_panels/_response_times_by_controller_action.json.erb
@@ -49,6 +49,17 @@
           "type": "terms"
         },
         {
+          "fake": true,
+          "field": "<%= @fields_prefix -%>action",
+          "id": "4",
+          "settings": {
+            "order": "desc",
+            "orderBy": "_count"
+            "size": "10",
+          }
+          "type": "terms",
+        },
+        {
           "field": "@timestamp",
           "id": "2",
           "settings": {


### PR DESCRIPTION
If we spot a repeatedly slow response time, it'd be useful to get the action too ([we already do this for errors](https://github.com/alphagov/govuk-puppet/blob/master/modules/grafana/templates/dashboards/deployment_panels/_errors_by_controller_action.json.erb)).