### PR TITLE
Fix copy data to integration slack notification

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
@@ -70,7 +70,7 @@
             HOSTNAME=deploy.integration.publishing.service.gov.uk
             API_KEY=<%= @ci_alphagov_api_key %>
             AUTH_TOKEN=<%= @auth_token %>
-      <% if $enable_slack_notifications %>
+      <% if @enable_slack_notifications %>
       - slack:
           team-domain: <%= @slack_team_domain %>
           auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN']%>


### PR DESCRIPTION
This is treated as an instance variable in this context rather than
dollar prefixed as per the manifest.