### PR TITLE
Set directory ownership on mongo data dir.

### DIFF
--- a/modules/mongodb/manifests/server.pp
+++ b/modules/mongodb/manifests/server.pp
@@ -82,6 +82,15 @@ class mongodb::server (
     notify       => Class['mongodb::service'];
   }
 
+  # Some places we mount a separate disk for the mongodb
+  # so need to ensure the owner of the directory is set
+  file { "Ensure correct owner of ${dbpath}":
+    path  => $dbpath,
+    owner => 'mongodb',
+    group => 'mongodb',
+    mode  => '0755',
+  }
+
   class { 'mongodb::config':
     config_filename => $config_filename,
     dbpath          => $dbpath,


### PR DESCRIPTION
Some instances we are now adding a separate disk for mongo data and need to ensure
the mount has the correct ownership and permissions.