### PR TITLE
Workaround to fix nginx permanent caching of load balancers IPs

### DIFF
--- a/modules/govuk/templates/bouncer_nginx_vhost.conf.erb
+++ b/modules/govuk/templates/bouncer_nginx_vhost.conf.erb
@@ -22,13 +22,11 @@ server {
     # with ".html" appended, then fallback to the app (bouncer).
     try_files $uri $uri.html @app;
   }
+  
+  set upstream_bouncerproxy <%= scope.lookupvar('::aws_migration') ? 'http://bouncer-proxy' : "bouncer.#{@app_domain}-proxy" %>;
 
   location @app {
-    <%- if scope.lookupvar('::aws_migration') %>
-    proxy_pass http://bouncer-proxy;
-    <%- else %>
-    proxy_pass http://<%= "bouncer.#{@app_domain}-proxy" %>;
-    <%- end %>
+    proxy_pass $upstream_bouncerproxy;
     proxy_set_header Host $http_host;
   }
 }

--- a/modules/govuk/templates/publicapi_nginx_extra_config.erb
+++ b/modules/govuk/templates/publicapi_nginx_extra_config.erb
@@ -4,13 +4,15 @@
   # requests made to that path without a trailing slash, *if* there is a
   # proxy_pass directive in the block.
 
+  set upstream_whitehall_api <%= @privateapi_protocol %>://<%= @whitehallapi %>;
   location ~ ^/api/(governments|organisations|specialist|worldwide-organisations|world-locations)(/|$) {
     expires 30m;
 
     proxy_set_header Host <%= @whitehallapi %>;
-    proxy_pass <%= @privateapi_protocol %>://<%= @whitehallapi %>;
+    proxy_pass $upstream_whitehall_api;
   }
 
+  set upstream_rummager_api <%= @privateapi_protocol %>://<%= @rummager_api %>;
   location ~ ^/api/search.json {
     expires 30m;
 
@@ -19,9 +21,10 @@
     add_header Access-Control-Allow-Origin *;
     proxy_set_header Host <%= @rummager_api %>;
     proxy_set_header API-PREFIX api;
-    proxy_pass <%= @privateapi_protocol %>://<%= @rummager_api %>;
+    proxy_pass $upstream_rummager_api;
   }
 
+  set upstream_content_store_api <%= @privateapi_protocol %>://<%= @content_store_api %>;
   location ~ ^/api/content(/|$) {
     limit_except GET {
       deny all;
@@ -31,7 +34,7 @@
 
     add_header Access-Control-Allow-Origin *;
     proxy_set_header Host <%= @content_store_api %>;
-    proxy_pass <%= @privateapi_protocol %>://<%= @content_store_api %>;
+    proxy_pass $upstream_content_store_api;
   }
 
   location ~ ^/api(/|$) {

--- a/modules/govuk/templates/www.mhra.gov.uk_nginx.conf.erb
+++ b/modules/govuk/templates/www.mhra.gov.uk_nginx.conf.erb
@@ -61,12 +61,10 @@ server {
   <% end %>
 
   # Fall back to Bouncer
+  set upstream_bouncerproxy <%= scope.lookupvar('::aws_migration') ? 'http://bouncer-proxy' : "bouncer.#{@app_domain}-proxy" %>;
+
   location / {
-    <%- if scope.lookupvar('::aws_migration') %>
-    proxy_pass http://bouncer-proxy;
-    <%- else %>
-    proxy_pass http://<%= "bouncer.#{@app_domain}-proxy" %>;
-    <%- end %>
+    proxy_pass $upstream_bouncerproxy;
     proxy_set_header Host $http_host;
   }
 }

--- a/modules/router/templates/draft-assets.conf.erb
+++ b/modules/router/templates/draft-assets.conf.erb
@@ -50,13 +50,14 @@ server {
     return 404;
   }
 
+  set upstream_asset_manager <%= @upstream_ssl ? 'https' : 'http' %>://asset-manager.<%= @app_domain %>;
   location /auth/ {
-    proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://asset-manager.<%= @app_domain %>;
+    proxy_pass $upstream_asset_manager;
   }
 
   <%- @asset_manager_uploaded_assets_routes.each do |path| -%>
   location <%= path %> {
-    proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://asset-manager.<%= @app_domain %>;
+    proxy_pass $upstream_asset_manager;
   }
   <%- end -%>
 }


### PR DESCRIPTION
  nginx only resolves IPs of the load balancers used in proxy_pass instructions at start.
Since those IPs are going to change on AWS we need to trick it into resolving those IPs again by using intermediates variables