### PR TITLE
Add the `terraform-docs` package to the CI machines

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -660,6 +660,7 @@ govuk_htpasswd::http_username: "%{hiera('http_username')}"
 
 govuk_jenkins::packages::gcloud::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk_jenkins::packages::terraform::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_jenkins::packages::terraform-docs::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk_jenkins::packages::sops::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk_jenkins::packages::vale::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 

--- a/modules/govuk/manifests/node/s_apt.pp
+++ b/modules/govuk/manifests/node/s_apt.pp
@@ -146,6 +146,7 @@ class govuk::node::s_apt (
   aptly::repo { 'sops': }
   aptly::repo { 'statsd': }
   aptly::repo { 'terraform': }
+  aptly::repo { 'terraform-docs': }
   aptly::repo { 'vale': }
   aptly::repo { 'whisper-backup': }
 

--- a/modules/govuk_ci/manifests/agent.pp
+++ b/modules/govuk_ci/manifests/agent.pp
@@ -31,6 +31,7 @@ class govuk_ci::agent(
   include ::govuk_ci::credentials
   include ::govuk_ci::limits
   include ::govuk_jenkins::packages::terraform
+  include ::govuk_jenkins::packages::terraform_docs
   include ::govuk_jenkins::packages::vale
   include ::govuk_jenkins::pipeline
   include ::govuk_jenkins::user

--- a/modules/govuk_jenkins/manifests/packages/terraform_docs.pp
+++ b/modules/govuk_jenkins/manifests/packages/terraform_docs.pp
@@ -1,0 +1,27 @@
+# == Class: govuk_jenkins::packages::terraform_docs
+#
+# Installs terraform-docs
+#
+# === Parameters
+#
+# [*apt_mirror_hostname*]
+#   The hostname of an APT mirror
+#
+class govuk_jenkins::packages::terraform_docs (
+  $apt_mirror_hostname = undef,
+  $version = '0.3.0',
+){
+
+  apt::source { 'terraform-docs':
+    location     => "http://${apt_mirror_hostname}/terraform-docs",
+    release      => 'stable',
+    architecture => $::architecture,
+    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+  }
+
+  package { 'terraform-docs':
+    ensure  => $version,
+    require => Apt::Source['terraform-docs'],
+  }
+
+}


### PR DESCRIPTION
- This is needed for https://github.com/alphagov/govuk-aws/pull/553 to
  be able to run CI checks for up to date Terraform documentation.