### PR TITLE
Workaround to fix nginx permanent caching of load balancers IPs

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -202,3 +202,5 @@ users::usernames:
   - tomsabin
   - vanitabarrett
   - vitaliemogoreanu
+
+nginx::config::stack_network_prefix: '10.1.0'

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -114,3 +114,5 @@ postfix::rewrite_mail_list: 'machine.email.carrenza'
 router::nginx::robotstxt: |
   User-agent: *
   Disallow: /
+
+nginx::config::stack_network_prefix: '10.3.0'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -120,3 +120,5 @@ postfix::rewrite_mail_list: 'machine.email.carrenza'
 router::nginx::robotstxt: |
   User-agent: *
   Disallow: /
+
+nginx::config::stack_network_prefix: '10.2.0'

--- a/modules/govuk/templates/bouncer_nginx_vhost.conf.erb
+++ b/modules/govuk/templates/bouncer_nginx_vhost.conf.erb
@@ -22,13 +22,11 @@ server {
     # with ".html" appended, then fallback to the app (bouncer).
     try_files $uri $uri.html @app;
   }
+  
+  set upstream_bouncerproxy http://<%= scope.lookupvar('::aws_migration') ? 'bouncer-proxy' : "bouncer.#{@app_domain}-proxy" %>;
 
   location @app {
-    <%- if scope.lookupvar('::aws_migration') %>
-    proxy_pass http://bouncer-proxy;
-    <%- else %>
-    proxy_pass http://<%= "bouncer.#{@app_domain}-proxy" %>;
-    <%- end %>
+    proxy_pass $upstream_bouncerproxy;
     proxy_set_header Host $http_host;
   }
 }

--- a/modules/govuk/templates/publicapi_nginx_extra_config.erb
+++ b/modules/govuk/templates/publicapi_nginx_extra_config.erb
@@ -4,13 +4,15 @@
   # requests made to that path without a trailing slash, *if* there is a
   # proxy_pass directive in the block.
 
+  set upstream_whitehall_api <%= @privateapi_protocol %>://<%= @whitehallapi %>;
   location ~ ^/api/(governments|organisations|specialist|worldwide-organisations|world-locations)(/|$) {
     expires 30m;
 
     proxy_set_header Host <%= @whitehallapi %>;
-    proxy_pass <%= @privateapi_protocol %>://<%= @whitehallapi %>;
+    proxy_pass $upstream_whitehall_api;
   }
 
+  set upstream_rummager_api <%= @privateapi_protocol %>://<%= @rummager_api %>;
   location ~ ^/api/search.json {
     expires 30m;
 
@@ -19,9 +21,10 @@
     add_header Access-Control-Allow-Origin *;
     proxy_set_header Host <%= @rummager_api %>;
     proxy_set_header API-PREFIX api;
-    proxy_pass <%= @privateapi_protocol %>://<%= @rummager_api %>;
+    proxy_pass $upstream_rummager_api;
   }
 
+  set upstream_content_store_api <%= @privateapi_protocol %>://<%= @content_store_api %>;
   location ~ ^/api/content(/|$) {
     limit_except GET {
       deny all;
@@ -31,7 +34,7 @@
 
     add_header Access-Control-Allow-Origin *;
     proxy_set_header Host <%= @content_store_api %>;
-    proxy_pass <%= @privateapi_protocol %>://<%= @content_store_api %>;
+    proxy_pass $upstream_content_store_api;
   }
 
   location ~ ^/api(/|$) {

--- a/modules/govuk/templates/www.mhra.gov.uk_nginx.conf.erb
+++ b/modules/govuk/templates/www.mhra.gov.uk_nginx.conf.erb
@@ -61,12 +61,10 @@ server {
   <% end %>
 
   # Fall back to Bouncer
+  set upstream_bouncerproxy http://<%= scope.lookupvar('::aws_migration') ? 'bouncer-proxy' : "bouncer.#{@app_domain}-proxy" %>;
+
   location / {
-    <%- if scope.lookupvar('::aws_migration') %>
-    proxy_pass http://bouncer-proxy;
-    <%- else %>
-    proxy_pass http://<%= "bouncer.#{@app_domain}-proxy" %>;
-    <%- end %>
+    proxy_pass $upstream_bouncerproxy;
     proxy_set_header Host $http_host;
   }
 }

--- a/modules/router/templates/assets_origin.conf.erb
+++ b/modules/router/templates/assets_origin.conf.erb
@@ -42,11 +42,13 @@ server {
   add_header "Access-Control-Allow-Headers" "origin, authorization";
 
   <%- @app_specific_static_asset_routes.each do |alias_path, vhost_name| -%>
+  set $upstream_<%= vhost_name.delete "-" %> <%= @upstream_ssl ? 'https' : 'http' %>://<%= vhost_name %>.<%= @app_domain %>;
   location <%= alias_path %> {
-    proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://<%= vhost_name %>.<%= @app_domain %>;
+    proxy_pass $upstream_<%= vhost_name.delete "-" %>;
   }
   <%- end -%>
 
+  set $upstream_asset_manager <%= @upstream_ssl ? 'https' : 'http' %>://asset-manager.<%= @app_domain %>;
   <%- @asset_manager_uploaded_assets_routes.each do |path| -%>
   location <%= path %> {
     # Explicitly re-include Strict-Transport-Security header, this
@@ -58,25 +60,27 @@ server {
     add_header "Access-Control-Allow-Methods" "GET, OPTIONS";
     add_header "Access-Control-Allow-Headers" "origin, authorization";
 
-    proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://asset-manager.<%= @app_domain %>;
+    proxy_pass $upstream_asset_manager;
   }
   <%- end -%>
-
+  
+  set $upstream_whitehall <%= @upstream_ssl ? 'https' : 'http' %>://whitehall-frontend.<%= @app_domain %>;
   <%- @whitehall_uploaded_assets_routes.each do |path| -%>
   location <%= path %> {
-    proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://whitehall-frontend.<%= @app_domain %>;
+    proxy_pass $upstream_whitehall;
   }
   <%- end -%>
-
+  
+  set $upstream_static <%= @upstream_ssl ? 'https' : 'http' %>://static.<%= @app_domain %>;
   location = /static/a {
-    proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://static.<%= @app_domain %>;
+    proxy_pass $upstream_static;
   }
 
   location /__canary__ {
-    proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://static.<%= @app_domain %>;
+    proxy_pass $upstream_static;
   }
 
   location / {
-    proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://static.<%= @app_domain %>;
+    proxy_pass $upstream_static;
   }
 }

--- a/modules/router/templates/draft-assets.conf.erb
+++ b/modules/router/templates/draft-assets.conf.erb
@@ -50,13 +50,14 @@ server {
     return 404;
   }
 
+  set upstream_asset_manager <%= @upstream_ssl ? 'https' : 'http' %>://asset-manager.<%= @app_domain %>;
   location /auth/ {
-    proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://asset-manager.<%= @app_domain %>;
+    proxy_pass $upstream_asset_manager;
   }
 
   <%- @asset_manager_uploaded_assets_routes.each do |path| -%>
   location <%= path %> {
-    proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://asset-manager.<%= @app_domain %>;
+    proxy_pass $upstream_asset_manager;
   }
   <%- end -%>
 }


### PR DESCRIPTION
  nginx only resolves IPs of the load balancers used in proxy_pass instructions at start.
Since those IPs are going to change on AWS we need to trick it into resolving those IPs again by using intermediates variables