### PR TITLE
Add documentation to icinga alerts

### DIFF
--- a/modules/clamav/manifests/service.pp
+++ b/modules/clamav/manifests/service.pp
@@ -22,6 +22,7 @@ class clamav::service (
       check_command       => 'check_nrpe!check_proc_running!clamd',
       service_description => 'clamd not running',
       host_name           => $::fqdn,
+      notes_url           => monitoring_docs_url(check-process-running),
     }
   }
 }

--- a/modules/filebeat/manifests/service.pp
+++ b/modules/filebeat/manifests/service.pp
@@ -18,6 +18,7 @@ class filebeat::service {
     check_command       => 'check_nrpe!check_proc_running!filebeat',
     service_description => 'filebeat running',
     host_name           => $::fqdn,
+    notes_url           => monitoring_docs_url(check-process-running),
   }
 
 }

--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -331,5 +331,6 @@ define govuk::app::config (
     check_command       => "check_nrpe!check_upstart_status!${title}",
     service_description => "${title} upstart not up",
     host_name           => $::fqdn,
+    notes_url           => monitoring_docs_url(check-process-running),
   }
 }

--- a/modules/govuk/manifests/apps/router.pp
+++ b/modules/govuk/manifests/apps/router.pp
@@ -55,6 +55,7 @@ class govuk::apps::router (
     check_command       => "check_nrpe!check_app_up!${api_port} ${api_healthcheck}",
     service_description => 'router app healthcheck',
     host_name           => $::fqdn,
+    notes_url           => monitoring_docs_url(app-healthcheck-failed),
   }
 
   govuk_logging::logstream { 'router-error-json-log':

--- a/modules/govuk/manifests/node/s_graphite.pp
+++ b/modules/govuk/manifests/node/s_graphite.pp
@@ -55,12 +55,14 @@ class govuk::node::s_graphite (
     check_command       => 'check_nrpe!check_proc_running!carbon-cache.py',
     service_description => 'carbon-cache running',
     host_name           => $::fqdn,
+    notes_url           => monitoring_docs_url(check-process-running),
   }
 
   @@icinga::check { "check_carbon_aggregator_running_on_${::hostname}":
     check_command       => 'check_nrpe!check_proc_running!carbon-aggregat',
     service_description => 'carbon-aggregator running',
     host_name           => $::fqdn,
+    notes_url           => monitoring_docs_url(check-process-running),
   }
 
   @ufw::allow {

--- a/modules/govuk/manifests/procfile/worker.pp
+++ b/modules/govuk/manifests/procfile/worker.pp
@@ -71,6 +71,7 @@ define govuk::procfile::worker (
         check_command       => "check_nrpe!check_procfile_workers!${service_name} ${process_count}",
         service_description => "${title} procfile worker upstart up",
         host_name           => $::fqdn,
+        notes_url           => monitoring_docs_url(check-process-running),
       }
     }
   } else {

--- a/modules/govuk_containers/manifests/app.pp
+++ b/modules/govuk_containers/manifests/app.pp
@@ -98,6 +98,7 @@ define govuk_containers::app (
       check_command       => "check_nrpe!check_app_up!${port} ${healthcheck_path}",
       service_description => "${title} app healthcheck",
       host_name           => $::fqdn,
+      notes_url           => monitoring_docs_url(app-healthcheck-failed),
     }
     if $json_healthcheck {
       include icinga::client::check_json_healthcheck

--- a/modules/govuk_containers/manifests/apps/router.pp
+++ b/modules/govuk_containers/manifests/apps/router.pp
@@ -32,6 +32,7 @@ class govuk_containers::apps::router (
       check_command       => "check_nrpe!check_app_up!${api_port} ${healthcheck_path}",
       service_description => 'router app healthcheck',
       host_name           => $::fqdn,
+      notes_url           => monitoring_docs_url(app-healthcheck-failed),
     }
   }
 }

--- a/modules/govuk_containers/manifests/etcd.pp
+++ b/modules/govuk_containers/manifests/etcd.pp
@@ -32,6 +32,7 @@ class govuk_containers::etcd {
     check_command       => 'check_nrpe!check_proc_running!etcd',
     service_description => 'etcd running',
     host_name           => $::fqdn,
+    notes_url           => monitoring_docs_url(check-process-running),
   }
 
 }

--- a/modules/govuk_containers/manifests/frontend/haproxy.pp
+++ b/modules/govuk_containers/manifests/frontend/haproxy.pp
@@ -79,6 +79,7 @@ class govuk_containers::frontend::haproxy (
     check_command       => 'check_nrpe!check_proc_running_with_arg!haproxy /etc/haproxy/haproxy.cfg',
     service_description => 'HAProxy running',
     host_name           => $::fqdn,
+    notes_url           => monitoring_docs_url(check-process-running),
   }
 
   class { 'collectd::plugin::haproxy': }

--- a/modules/govuk_containers/manifests/gemstash.pp
+++ b/modules/govuk_containers/manifests/gemstash.pp
@@ -39,5 +39,6 @@ class govuk_containers::gemstash(
     check_command       => 'check_nrpe!check_proc_running!gemstash',
     service_description => 'gemstash running',
     host_name           => $::fqdn,
+    notes_url           => monitoring_docs_url(check-process-running),
   }
 }

--- a/modules/govuk_containers/manifests/memcached.pp
+++ b/modules/govuk_containers/manifests/memcached.pp
@@ -40,5 +40,6 @@ class govuk_containers::memcached(
     check_command       => 'check_nrpe!check_proc_running!memcached',
     service_description => 'memcached running',
     host_name           => $::fqdn,
+    notes_url           => monitoring_docs_url(check-process-running),
   }
 }

--- a/modules/govuk_containers/manifests/redis.pp
+++ b/modules/govuk_containers/manifests/redis.pp
@@ -45,5 +45,6 @@ class govuk_containers::redis(
     check_command       => 'check_nrpe!check_proc_running!redis-server',
     service_description => 'redis running',
     host_name           => $::fqdn,
+    notes_url           => monitoring_docs_url(check-process-running),
   }
 }

--- a/modules/govuk_docker/manifests/init.pp
+++ b/modules/govuk_docker/manifests/init.pp
@@ -56,6 +56,7 @@ class govuk_docker (
     check_command       => 'check_nrpe!check_proc_running!dockerd',
     service_description => 'dockerd running',
     host_name           => $::fqdn,
+    notes_url           => monitoring_docs_url(check-process-running),
   }
 
 }

--- a/modules/govuk_jenkins/manifests/ssh_slave.pp
+++ b/modules/govuk_jenkins/manifests/ssh_slave.pp
@@ -70,6 +70,7 @@ define govuk_jenkins::ssh_slave (
     check_command       => "check_nrpe!check_jenkins_agent!${agent_name}",
     service_description => "${title} is not connected to the Jenkins master",
     host_name           => $::fqdn,
+    notes_url           => monitoring_docs_url(jenkins-agent-not-connected-to-master),
   }
 
 }

--- a/modules/govuk_mtail/manifests/init.pp
+++ b/modules/govuk_mtail/manifests/init.pp
@@ -80,5 +80,6 @@ class govuk_mtail(
     check_command       => 'check_nrpe!check_proc_running!mtail',
     service_description => 'mtail not running',
     host_name           => $::fqdn,
+    notes_url           => monitoring_docs_url(check-process-running),
   }
 }

--- a/modules/govuk_mysql/manifests/server/monitoring.pp
+++ b/modules/govuk_mysql/manifests/server/monitoring.pp
@@ -19,6 +19,7 @@ class govuk_mysql::server::monitoring (
     check_command       => 'check_nrpe!check_proc_running!mysqld',
     service_description => 'mysqld not running',
     host_name           => $::fqdn,
+    notes_url           => monitoring_docs_url(check-process-running),
   }
 
   @@icinga::check::graphite { "check_mysql_connections_${::hostname}":

--- a/modules/govuk_postgresql/manifests/monitoring.pp
+++ b/modules/govuk_postgresql/manifests/monitoring.pp
@@ -26,6 +26,7 @@ class govuk_postgresql::monitoring (
     check_command       => 'check_nrpe!check_proc_running!postgres',
     service_description => 'postgresql not running',
     host_name           => $::fqdn,
+    notes_url           => monitoring_docs_url(check-process-running),
   }
 
   @icinga::nrpe_config { 'check_postgresql_database':

--- a/modules/govuk_postgresql/manifests/monitoring/db.pp
+++ b/modules/govuk_postgresql/manifests/monitoring/db.pp
@@ -15,6 +15,7 @@ define govuk_postgresql::monitoring::db () {
     check_command       => "check_nrpe!check_postgresql_database_connection!${title}",
     service_description => "Connection to ${title} postgresql database",
     host_name           => $::fqdn,
+    notes_url           => monitoring_docs_url(check-process-running),
   }
 
 }

--- a/modules/govuk_rabbitmq/manifests/monitoring.pp
+++ b/modules/govuk_rabbitmq/manifests/monitoring.pp
@@ -16,6 +16,7 @@ class govuk_rabbitmq::monitoring (
     check_command       => 'check_nrpe!check_proc_running!rabbitmq-server',
     service_description => 'rabbitmq-server not running',
     host_name           => $::fqdn,
+    notes_url           => monitoring_docs_url(check-process-running),
   }
 
   @@icinga::check { "check_rabbitmq_network_partitions_${::hostname}":

--- a/modules/icinga/manifests/client/checks.pp
+++ b/modules/icinga/manifests/client/checks.pp
@@ -74,6 +74,7 @@ class icinga::client::checks (
       service_description => 'low available disk space on /boot',
       use                 => 'govuk_high_priority',
       host_name           => $::fqdn,
+      notes_url           => monitoring_docs_url(low-available-disk-space),
     }
   }
 

--- a/modules/icinga/templates/etc/nagios/nrpe.cfg.erb
+++ b/modules/icinga/templates/etc/nagios/nrpe.cfg.erb
@@ -206,7 +206,7 @@ connection_timeout=300
 
 # The following examples use hardcoded command arguments...
 
-command[check_users]=/usr/lib/nagios/plugins/check_users -w 5 -c 10
+command[check_users]=/usr/lib/nagios/plugins/check_users -w 10 -c 20
 #command[check_load]=/usr/lib/nagios/plugins/check_load -w 15,10,5 -c 30,25,20
 # fallback check if individual ones havent been set up.
 command[check_disk]=/usr/lib/nagios/plugins/check_disk -w 6% -c 3% -W 6% -K 3% -x /var/lib/ureadahead/debugfs/tracing

--- a/modules/mongodb/manifests/monitoring.pp
+++ b/modules/mongodb/manifests/monitoring.pp
@@ -38,12 +38,14 @@ class mongodb::monitoring (
     check_command       => 'check_nrpe!check_proc_running!mongod',
     service_description => 'mongod not running',
     host_name           => $::fqdn,
+    notes_url           => monitoring_docs_url(check-process-running),
   }
 
   @@icinga::check { "check_mongod_responds_${::hostname}":
     check_command       => 'check_nrpe!check_mongodb!connect 2 4',
     service_description => 'mongod not responding',
     host_name           => $::fqdn,
+    notes_url           => monitoring_docs_url(check-process-running),
   }
 
   @@icinga::check { "check_mongod_rollbacks_${::hostname}":

--- a/modules/nginx/manifests/init.pp
+++ b/modules/nginx/manifests/init.pp
@@ -77,6 +77,7 @@ class nginx (
     check_command       => 'check_nrpe!check_proc_running!nginx',
     service_description => 'nginx not running',
     host_name           => $::fqdn,
+    notes_url           => monitoring_docs_url(check-process-running),
   }
 
   if $::aws_migration {
@@ -88,12 +89,14 @@ class nginx (
       check_command       => 'check_nrpe!check_http_local!monitoring-vhost.test 5 10',
       service_description => 'nginx http port unresponsive',
       host_name           => $::fqdn,
+      notes_url           => monitoring_docs_url(check-process-running),
     }
   } else {
     @@icinga::check { "check_http_response_${::hostname}":
       check_command       => 'check_http_port!monitoring-vhost.test!5!10',
       service_description => 'nginx http port unresponsive',
       host_name           => $::fqdn,
+      notes_url           => monitoring_docs_url(check-process-running),
     }
   }
 

--- a/modules/nsca/manifests/server.pp
+++ b/modules/nsca/manifests/server.pp
@@ -37,6 +37,7 @@ class nsca::server {
     check_command       => 'check_nrpe!check_proc_running!nsca',
     service_description => 'nsca not running',
     host_name           => $::fqdn,
+    notes_url           => monitoring_docs_url(check-process-running),
   }
 
 }

--- a/modules/statsd/manifests/init.pp
+++ b/modules/statsd/manifests/init.pp
@@ -46,5 +46,6 @@ class statsd(
     check_command       => 'check_nrpe!check_upstart_status!statsd',
     service_description => 'statsd upstart up',
     host_name           => $::fqdn,
+    notes_url           => monitoring_docs_url(check-process-running),
   }
 }

--- a/modules/varnish/manifests/monitoring.pp
+++ b/modules/varnish/manifests/monitoring.pp
@@ -17,6 +17,7 @@ class varnish::monitoring {
     check_command       => 'check_nrpe!check_proc_running!varnishd',
     service_description => 'varnishd not running',
     host_name           => $::fqdn,
+    notes_url           => monitoring_docs_url(check-process-running),
   }
 
   @icinga::nrpe_config { 'check_varnish_responding':


### PR DESCRIPTION
This makes sure that most Icinga alerts have documentation associated with them.

I also took the opportunity in this PR to increase the limit on the number of logged in users at any one time.

This depends on https://github.com/alphagov/govuk-developer-docs/pull/897 and https://github.com/alphagov/govuk-developer-docs/pull/896 being deployed.

[Trello Card](https://trello.com/c/x9gjfwqn/117-find-out-how-many-alerts-do-not-point-to-documentation-on-how-to-fix-the-problem-2)