### PR TITLE
Prepend dollar sign to fix some nginx variables

### DIFF
--- a/modules/govuk/templates/bouncer_nginx_vhost.conf.erb
+++ b/modules/govuk/templates/bouncer_nginx_vhost.conf.erb
@@ -22,8 +22,8 @@ server {
     # with ".html" appended, then fallback to the app (bouncer).
     try_files $uri $uri.html @app;
   }
-  
-  set upstream_bouncerproxy http://<%= scope.lookupvar('::aws_migration') ? 'bouncer-proxy' : "bouncer.#{@app_domain}-proxy" %>;
+
+  set $upstream_bouncerproxy http://<%= scope.lookupvar('::aws_migration') ? 'bouncer-proxy' : "bouncer.#{@app_domain}-proxy" %>;
 
   location @app {
     proxy_pass $upstream_bouncerproxy;

--- a/modules/govuk/templates/publicapi_nginx_extra_config.erb
+++ b/modules/govuk/templates/publicapi_nginx_extra_config.erb
@@ -4,7 +4,7 @@
   # requests made to that path without a trailing slash, *if* there is a
   # proxy_pass directive in the block.
 
-  set upstream_whitehall_api <%= @privateapi_protocol %>://<%= @whitehallapi %>;
+  set $upstream_whitehall_api <%= @privateapi_protocol %>://<%= @whitehallapi %>;
   location ~ ^/api/(governments|organisations|specialist|worldwide-organisations|world-locations)(/|$) {
     expires 30m;
 
@@ -12,7 +12,7 @@
     proxy_pass $upstream_whitehall_api;
   }
 
-  set upstream_rummager_api <%= @privateapi_protocol %>://<%= @rummager_api %>;
+  set $upstream_rummager_api <%= @privateapi_protocol %>://<%= @rummager_api %>;
   location ~ ^/api/search.json {
     expires 30m;
 
@@ -24,7 +24,7 @@
     proxy_pass $upstream_rummager_api;
   }
 
-  set upstream_content_store_api <%= @privateapi_protocol %>://<%= @content_store_api %>;
+  set $upstream_content_store_api <%= @privateapi_protocol %>://<%= @content_store_api %>;
   location ~ ^/api/content(/|$) {
     limit_except GET {
       deny all;

--- a/modules/govuk/templates/www.mhra.gov.uk_nginx.conf.erb
+++ b/modules/govuk/templates/www.mhra.gov.uk_nginx.conf.erb
@@ -61,7 +61,7 @@ server {
   <% end %>
 
   # Fall back to Bouncer
-  set upstream_bouncerproxy http://<%= scope.lookupvar('::aws_migration') ? 'bouncer-proxy' : "bouncer.#{@app_domain}-proxy" %>;
+  set $upstream_bouncerproxy http://<%= scope.lookupvar('::aws_migration') ? 'bouncer-proxy' : "bouncer.#{@app_domain}-proxy" %>;
 
   location / {
     proxy_pass $upstream_bouncerproxy;

--- a/modules/router/templates/assets_origin.conf.erb
+++ b/modules/router/templates/assets_origin.conf.erb
@@ -63,14 +63,14 @@ server {
     proxy_pass $upstream_asset_manager;
   }
   <%- end -%>
-  
+
   set $upstream_whitehall <%= @upstream_ssl ? 'https' : 'http' %>://whitehall-frontend.<%= @app_domain %>;
   <%- @whitehall_uploaded_assets_routes.each do |path| -%>
   location <%= path %> {
     proxy_pass $upstream_whitehall;
   }
   <%- end -%>
-  
+
   set $upstream_static <%= @upstream_ssl ? 'https' : 'http' %>://static.<%= @app_domain %>;
   location = /static/a {
     proxy_pass $upstream_static;

--- a/modules/router/templates/draft-assets.conf.erb
+++ b/modules/router/templates/draft-assets.conf.erb
@@ -50,7 +50,7 @@ server {
     return 404;
   }
 
-  set upstream_asset_manager <%= @upstream_ssl ? 'https' : 'http' %>://asset-manager.<%= @app_domain %>;
+  set $upstream_asset_manager <%= @upstream_ssl ? 'https' : 'http' %>://asset-manager.<%= @app_domain %>;
   location /auth/ {
     proxy_pass $upstream_asset_manager;
   }


### PR DESCRIPTION
NGINX expects variable to be prepended with a `$` even when setting
them. Add some missing dollars.