### PR TITLE
Placing all nginx modifications needed on AWS in conditional blocks

### DIFF
--- a/modules/govuk/templates/bouncer_nginx_vhost.conf.erb
+++ b/modules/govuk/templates/bouncer_nginx_vhost.conf.erb
@@ -23,10 +23,16 @@ server {
     try_files $uri $uri.html @app;
   }
 
-  set $upstream_bouncerproxy http://<%= scope.lookupvar('::aws_migration') ? 'bouncer-proxy' : "bouncer.#{@app_domain}-proxy" %>;
+    <%- if scope.lookupvar('::aws_migration') %>
+    set $upstream_bouncerproxy http://bouncer-proxy;
+    <%- end %>
 
   location @app {
+    <%- if scope.lookupvar('::aws_migration') %>
     proxy_pass $upstream_bouncerproxy;
+    <%- else %>
+    proxy_pass http://<%= "bouncer.#{@app_domain}-proxy" %>;
+    <%- end %>
     proxy_set_header Host $http_host;
   }
 }

--- a/modules/govuk/templates/publicapi_nginx_extra_config.erb
+++ b/modules/govuk/templates/publicapi_nginx_extra_config.erb
@@ -4,15 +4,23 @@
   # requests made to that path without a trailing slash, *if* there is a
   # proxy_pass directive in the block.
 
+  <%- if scope.lookupvar('::aws_migration') %>
   set $upstream_whitehall_api <%= @privateapi_protocol %>://<%= @whitehallapi %>;
+  <%- end %>
   location ~ ^/api/(governments|organisations|specialist|worldwide-organisations|world-locations)(/|$) {
     expires 30m;
 
     proxy_set_header Host <%= @whitehallapi %>;
+    <%- if scope.lookupvar('::aws_migration') %>
     proxy_pass $upstream_whitehall_api;
+    <%- else %>
+    proxy_pass <%= @privateapi_protocol %>://<%= @whitehallapi %>;
+    <%- end %>
   }
 
+  <%- if scope.lookupvar('::aws_migration') %>
   set $upstream_rummager_api <%= @privateapi_protocol %>://<%= @rummager_api %>;
+  <%- end %>
   location ~ ^/api/search.json {
     expires 30m;
 
@@ -21,10 +29,16 @@
     add_header Access-Control-Allow-Origin *;
     proxy_set_header Host <%= @rummager_api %>;
     proxy_set_header API-PREFIX api;
+    <%- if scope.lookupvar('::aws_migration') %>
     proxy_pass $upstream_rummager_api;
+    <%- else %>
+    proxy_pass <%= @privateapi_protocol %>://<%= @rummager_api %>;
+    <%- end %>
   }
 
+  <%- if scope.lookupvar('::aws_migration') %>
   set $upstream_content_store_api <%= @privateapi_protocol %>://<%= @content_store_api %>;
+  <%- end %>
   location ~ ^/api/content(/|$) {
     limit_except GET {
       deny all;
@@ -34,7 +48,11 @@
 
     add_header Access-Control-Allow-Origin *;
     proxy_set_header Host <%= @content_store_api %>;
+    <%- if scope.lookupvar('::aws_migration') %>
     proxy_pass $upstream_content_store_api;
+    <%- else %>
+    proxy_pass <%= @privateapi_protocol %>://<%= @content_store_api %>;
+    <%- end %>
   }
 
   location ~ ^/api(/|$) {

--- a/modules/govuk/templates/www.mhra.gov.uk_nginx.conf.erb
+++ b/modules/govuk/templates/www.mhra.gov.uk_nginx.conf.erb
@@ -61,10 +61,15 @@ server {
   <% end %>
 
   # Fall back to Bouncer
-  set $upstream_bouncerproxy http://<%= scope.lookupvar('::aws_migration') ? 'bouncer-proxy' : "bouncer.#{@app_domain}-proxy" %>;
-
+  <%- if scope.lookupvar('::aws_migration') %>
+  set $upstream_bouncerproxy http://bouncer-proxy;
+  <%- end %>
   location / {
+    <%- if scope.lookupvar('::aws_migration') %>
     proxy_pass $upstream_bouncerproxy;
+    <%- else %>
+    proxy_pass http://<%= "bouncer.#{@app_domain}-proxy" %>;
+    <%- end %>
     proxy_set_header Host $http_host;
   }
 }

--- a/modules/router/templates/assets_origin.conf.erb
+++ b/modules/router/templates/assets_origin.conf.erb
@@ -42,13 +42,21 @@ server {
   add_header "Access-Control-Allow-Headers" "origin, authorization";
 
   <%- @app_specific_static_asset_routes.each do |alias_path, vhost_name| -%>
+  <%- if scope.lookupvar('::aws_migration') %>
   set $upstream_<%= vhost_name.delete "-" %> <%= @upstream_ssl ? 'https' : 'http' %>://<%= vhost_name %>.<%= @app_domain %>;
+  <%- end %>
   location <%= alias_path %> {
+    <%- if scope.lookupvar('::aws_migration') %>
     proxy_pass $upstream_<%= vhost_name.delete "-" %>;
+    <%- else %>
+    proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://<%= vhost_name %>.<%= @app_domain %>;
+    <%- end %>
   }
   <%- end -%>
 
+  <%- if scope.lookupvar('::aws_migration') %>
   set $upstream_asset_manager <%= @upstream_ssl ? 'https' : 'http' %>://asset-manager.<%= @app_domain %>;
+  <%- end %>
   <%- @asset_manager_uploaded_assets_routes.each do |path| -%>
   location <%= path %> {
     # Explicitly re-include Strict-Transport-Security header, this
@@ -60,27 +68,51 @@ server {
     add_header "Access-Control-Allow-Methods" "GET, OPTIONS";
     add_header "Access-Control-Allow-Headers" "origin, authorization";
 
+    <%- if scope.lookupvar('::aws_migration') %>
     proxy_pass $upstream_asset_manager;
+    <%- else %>
+    proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://asset-manager.<%= @app_domain %>;
+    <%- end %>
   }
   <%- end -%>
 
+  <%- if scope.lookupvar('::aws_migration') %>
   set $upstream_whitehall <%= @upstream_ssl ? 'https' : 'http' %>://whitehall-frontend.<%= @app_domain %>;
+  <%- end %>
   <%- @whitehall_uploaded_assets_routes.each do |path| -%>
   location <%= path %> {
+    <%- if scope.lookupvar('::aws_migration') %>
     proxy_pass $upstream_whitehall;
+    <%- else %>
+    proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://whitehall-frontend.<%= @app_domain %>;
+    <%- end %>
   }
   <%- end -%>
 
+  <%- if scope.lookupvar('::aws_migration') %>
   set $upstream_static <%= @upstream_ssl ? 'https' : 'http' %>://static.<%= @app_domain %>;
+  <%- end %>
   location = /static/a {
+    <%- if scope.lookupvar('::aws_migration') %>
     proxy_pass $upstream_static;
+    <%- else %>
+    proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://static.<%= @app_domain %>;
+    <%- end %>
   }
 
   location /__canary__ {
+    <%- if scope.lookupvar('::aws_migration') %>
     proxy_pass $upstream_static;
+    <%- else %>
+    proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://static.<%= @app_domain %>;
+    <%- end %>
   }
 
   location / {
+    <%- if scope.lookupvar('::aws_migration') %>
     proxy_pass $upstream_static;
+    <%- else %>
+    proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://static.<%= @app_domain %>;
+    <%- end %>
   }
 }

--- a/modules/router/templates/draft-assets.conf.erb
+++ b/modules/router/templates/draft-assets.conf.erb
@@ -49,15 +49,24 @@ server {
   location / {
     return 404;
   }
-
+  <%- if scope.lookupvar('::aws_migration') %>
   set $upstream_asset_manager <%= @upstream_ssl ? 'https' : 'http' %>://asset-manager.<%= @app_domain %>;
+  <%- end %>
   location /auth/ {
+    <%- if scope.lookupvar('::aws_migration') %>
     proxy_pass $upstream_asset_manager;
+    <%- else %>
+    proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://asset-manager.<%= @app_domain %>;
+    <%- end %>
   }
 
   <%- @asset_manager_uploaded_assets_routes.each do |path| -%>
   location <%= path %> {
+    <%- if scope.lookupvar('::aws_migration') %>
     proxy_pass $upstream_asset_manager;
+    <%- else %>
+    proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://asset-manager.<%= @app_domain %>;
+    <%- end %>
   }
   <%- end -%>
 }


### PR DESCRIPTION
Using `proxy_pass` with a variable to force NGINX to dynamically reload hostnames also requires the use of a `resolver`. Since this is only needed in AWS, only use variables for `proxy_pass` in AWS environments. In our non-AWS environments we can continue to use literal hostnames with `proxy_pass` and allow NGINX to cache the DNS lookups.