### PR TITLE
Add class for Data Warehouse postgresql machine

### DIFF
--- a/hieradata/class/warehouse_postgresql.yaml
+++ b/hieradata/class/warehouse_postgresql.yaml
@@ -1,0 +1,18 @@
+---
+postgresql::globals::version: '9.6'
+
+govuk_safe_to_reboot::can_reboot: 'no'
+govuk_safe_to_reboot::reason: 'Single point of failure for Data Warehouse'
+
+icinga::client::contact_groups: 'urgent-priority'
+
+lv:
+  data:
+    pv: '/dev/sdb1'
+    vg: 'postgresql'
+
+mount:
+  /var/lib/postgresql:
+    disk: '/dev/mapper/postgresql-data'
+    govuk_lvm: 'data'
+    mountoptions: 'defaults'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1264,6 +1264,8 @@ hosts::production::backend::hosts:
     ip: '10.1.3.161'
   transition-postgresql-standby-2:
     ip: '10.1.11.161'
+  warehouse-postgresql-1:
+    ip: '10.1.3.110'
   whitehall-backend-1:
     ip: '10.1.3.25'
   whitehall-backend-2:

--- a/hieradata/vagrant_credentials.yaml
+++ b/hieradata/vagrant_credentials.yaml
@@ -157,6 +157,12 @@ govuk::node::s_transition_postgresql_master::s3_bucket_url: 'bucket'
 govuk::node::s_transition_postgresql_master::wale_private_gpg_key: 'key'
 govuk::node::s_transition_postgresql_master::wale_private_gpg_key_fingerprint: 'AIFAED1POOX9MOA3THI9CIE0IEQU7ULAIWEI4SOF'
 
+govuk::node::s_warehouse_postgresql::aws_access_key_id: 'foo'
+govuk::node::s_warehouse_postgresql::aws_secret_access_key: 'bar'
+govuk::node::s_warehouse_postgresql::s3_bucket_url: 'bucket'
+govuk::node::s_warehouse_postgresql::wale_private_gpg_key: 'key'
+govuk::node::s_warehouse_postgresql::wale_private_gpg_key_fingerprint: 'AIFAED1POOX9MOA3THI9CIE0IEQU7ULAIWEI4SOF'
+
 govuk_jenkins::config::environment_variables:
   ORGANISATION: development
 

--- a/modules/govuk/manifests/node/s_warehouse_postgresql.pp
+++ b/modules/govuk/manifests/node/s_warehouse_postgresql.pp
@@ -1,0 +1,27 @@
+# == Class: govuk::node::s_warehouse_postgresql
+#
+# PostgreSQL node for the Data Warehouse.
+#
+class govuk::node::s_warehouse_postgresql (
+  $aws_access_key_id,
+  $aws_secret_access_key,
+  $s3_bucket_url,
+  $wale_private_gpg_key,
+  $wale_private_gpg_key_fingerprint,
+  $alert_hostname = 'alert.cluster',
+) inherits govuk::node::s_base  {
+  Govuk_mount['/var/lib/postgresql'] -> Class['govuk_postgresql::server::standalone']
+
+  include govuk_postgresql::server::standalone
+  include govuk_postgresql::tuning
+  include govuk::apps::content_performance_manager::db
+
+  govuk_postgresql::wal_e::backup { $title:
+    aws_access_key_id                => $aws_access_key_id,
+    aws_secret_access_key            => $aws_secret_access_key,
+    s3_bucket_url                    => $s3_bucket_url,
+    wale_private_gpg_key             => $wale_private_gpg_key,
+    wale_private_gpg_key_fingerprint => $wale_private_gpg_key_fingerprint,
+    alert_hostname                   => $alert_hostname,
+  }
+}


### PR DESCRIPTION
This is a standalone machine as it’s not critical to the live operation
of GOV.UK, and the retention provided by the WAL defaults are
sufficient.