### PR TITLE
Try publishing overdue Whitehall publications before calling the on-call person

### DIFF
--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -509,4 +509,6 @@ class govuk::apps::whitehall(
       value   => $co_nss_watchkeeper_email_address,
     }
   }
+
+  include icinga::plugin::publish_overdue_whitehall
 }

--- a/modules/icinga/files/usr/lib/nagios/plugins/publish_overdue_whitehall
+++ b/modules/icinga/files/usr/lib/nagios/plugins/publish_overdue_whitehall
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -eu
+
+cd /var/apps/whitehall
+sudo -u deploy govuk_setenv whitehall bundle exec rake publishing:overdue:publish

--- a/modules/icinga/manifests/plugin/publish_overdue_whitehall.pp
+++ b/modules/icinga/manifests/plugin/publish_overdue_whitehall.pp
@@ -1,0 +1,15 @@
+# == Class: icinga::plugin::publish_overdue_whitehall
+#
+# Install a Nagios plugin that can be triggered to publish overdue Whitehall documents.
+#
+class icinga::plugin::publish_overdue_whitehall () {
+
+  @icinga::plugin { 'publish_overdue_whitehall':
+    source  => 'puppet:///modules/icinga/usr/lib/nagios/plugins/publish_overdue_whitehall',
+  }
+
+  @icinga::nrpe_config { 'publish_overdue_whitehall':
+    content  => template('icinga/etc/nagios/nrpe.d/publish_overdue_whitehall.cfg.erb'),
+  }
+
+}

--- a/modules/icinga/templates/etc/nagios/nrpe.d/publish_overdue_whitehall.cfg.erb
+++ b/modules/icinga/templates/etc/nagios/nrpe.d/publish_overdue_whitehall.cfg.erb
@@ -1,0 +1,1 @@
+command[publish_overdue_whitehall]=/usr/lib/nagios/plugins/publish_overdue_whitehall

--- a/modules/monitoring/files/publish_overdue_whitehall.cfg
+++ b/modules/monitoring/files/publish_overdue_whitehall.cfg
@@ -1,0 +1,4 @@
+define command {
+  command_name publish_overdue_whitehall
+  command_line /usr/local/bin/event_handlers/publish_overdue_whitehall.sh $SERVICESTATE$ $SERVICESTATETYPE$ $HOSTADDRESS$
+}

--- a/modules/monitoring/files/usr/local/bin/event_handlers/publish_overdue_whitehall.sh
+++ b/modules/monitoring/files/usr/local/bin/event_handlers/publish_overdue_whitehall.sh
@@ -8,9 +8,9 @@ SERVICESTATETYPE=$2
 HOSTADDRESS=$3
 
 case "${SERVICESTATE}" in
-  CRITICAL)
+  WARNING|CRITICAL)
     case "${SERVICESTATETYPE}" in
-      HARD)
+      SOFT)
         logger --tag govuk_icinga_event_handler "Publishing overdue Whitehall documents on ${HOSTADDRESS}"
         /usr/lib/nagios/plugins/check_nrpe -H ${HOSTADDRESS} -c publish_overdue_whitehall
         ;;

--- a/modules/monitoring/files/usr/local/bin/event_handlers/publish_overdue_whitehall.sh
+++ b/modules/monitoring/files/usr/local/bin/event_handlers/publish_overdue_whitehall.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#
+# Icinga event handler script for publishing Whitehall overdue documents.
+#
+
+SERVICESTATE=$1
+SERVICESTATETYPE=$2
+HOSTADDRESS=$3
+
+case "${SERVICESTATE}" in
+  CRITICAL)
+    case "${SERVICESTATETYPE}" in
+      HARD)
+        logger --tag govuk_icinga_event_handler "Publishing overdue Whitehall documents on ${HOSTADDRESS}"
+        /usr/lib/nagios/plugins/check_nrpe -H ${HOSTADDRESS} -c publish_overdue_whitehall
+        ;;
+    esac
+    ;;
+esac
+
+exit 0

--- a/modules/monitoring/manifests/checks.pp
+++ b/modules/monitoring/manifests/checks.pp
@@ -39,13 +39,15 @@ class monitoring::checks (
   }
 
   icinga::check { "check_whitehall_overdue_from_${::hostname}":
-    check_command       => 'check_whitehall_overdue',
-    service_description => 'overdue publications in Whitehall',
-    use                 => 'govuk_urgent_priority',
-    host_name           => $::fqdn,
-    notes_url           => monitoring_docs_url(whitehall-scheduled-publishing),
-    action_url          => "https://${whitehall_hostname}${whitehall_overdue_url}",
-    event_handler       => 'publish_overdue_whitehall',
+    check_command              => 'check_whitehall_overdue',
+    service_description        => 'overdue publications in Whitehall',
+    use                        => 'govuk_urgent_priority',
+    host_name                  => $::fqdn,
+    notes_url                  => monitoring_docs_url(whitehall-scheduled-publishing),
+    action_url                 => "https://${whitehall_hostname}${whitehall_overdue_url}",
+    event_handler              => 'publish_overdue_whitehall',
+    attempts_before_hard_state => 2,
+    retry_interval             => 10,
   }
   # END whitehall
 

--- a/modules/monitoring/manifests/checks.pp
+++ b/modules/monitoring/manifests/checks.pp
@@ -45,6 +45,7 @@ class monitoring::checks (
     host_name           => $::fqdn,
     notes_url           => monitoring_docs_url(whitehall-scheduled-publishing),
     action_url          => "https://${whitehall_hostname}${whitehall_overdue_url}",
+    event_handler       => 'publish_overdue_whitehall',
   }
   # END whitehall
 

--- a/modules/monitoring/manifests/event_handler/publish_overdue_whitehall.pp
+++ b/modules/monitoring/manifests/event_handler/publish_overdue_whitehall.pp
@@ -1,0 +1,17 @@
+# == Class: monitoring::event_handler::publish_overdue_whitehall
+#
+# Configure an Icinga event handler that publishes Whitehall overdue documents.
+#
+class monitoring::event_handler::publish_overdue_whitehall () {
+
+  icinga::check_config { 'publish_overdue_whitehall':
+    source  => 'puppet:///modules/monitoring/publish_overdue_whitehall.cfg',
+    require => File['/usr/local/bin/event_handlers/publish_overdue_whitehall.sh'],
+  }
+
+  file { '/usr/local/bin/event_handlers/publish_overdue_whitehall.sh':
+    source => 'puppet:///modules/monitoring/usr/local/bin/event_handlers/publish_overdue_whitehall.sh',
+    mode   => '0755',
+  }
+
+}

--- a/modules/monitoring/manifests/event_handlers.pp
+++ b/modules/monitoring/manifests/event_handlers.pp
@@ -9,5 +9,6 @@ class monitoring::event_handlers () {
   }
 
   include monitoring::event_handler::app_high_memory
+  include monitoring::event_handler::publish_overdue_whitehall
 
 }


### PR DESCRIPTION
This sets up an Icinga event handler to try and publish overdue Whitehall publications before calling the on-call person.

[Trello Card](https://trello.com/c/2fww91ri/118-make-icinga-try-publishing-overdue-whitehall-publications-before-calling-the-on-call-person-2)