### PR TITLE
Monitoring EBS Volume

### DIFF
--- a/hieradata_aws/class/monitoring.yaml
+++ b/hieradata_aws/class/monitoring.yaml
@@ -1,0 +1,12 @@
+lv:
+  data:
+    pv: '/dev/nvme1n1'
+    vg: 'monitoring'
+
+mount:
+  /var/lib/icinga:
+    disk: '/dev/mapper/monitoring-data'
+    govuk_lvm: 'data'
+    mountoptions: 'defaults'
+    percent_threshold_warning: 16
+    percent_threshold_critical: 11


### PR DESCRIPTION
- We have provided an additional EBS volume to the monitoring instance
[icinga]. This change will attach the EBS volume under /var/lib/icinga.

https://trello.com/c/b6So3Wxl/1145-integration-monitoring-instance-ebs-volume

Solo:@suthagarht