### PR TITLE
Add queue latency to the Sidekiq dashboard

### DIFF
--- a/modules/grafana/files/dashboards/sidekiq.json
+++ b/modules/grafana/files/dashboards/sidekiq.json
@@ -32,7 +32,7 @@
   "rows": [
     {
       "collapse": false,
-      "height": 281,
+      "height": 300,
       "panels": [
         {
           "aliasColors": {},
@@ -122,7 +122,93 @@
     },
     {
       "collapse": false,
-      "height": 250,
+      "height": 300,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Graphite",
+          "fill": 1,
+          "id": 5,
+          "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 1,
+          "points": true,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 12,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "refId": "A",
+              "target": "aliasByNode(averageSeriesWithWildcards(stats.gauges.govuk.app.$Application.*.workers.queues.$Queues.latency, max, 5), 7)"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Queue Latency",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "dtdurations",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 300,
       "panels": [
         {
           "aliasColors": {},
@@ -217,7 +303,7 @@
     },
     {
       "collapse": false,
-      "height": "250px",
+      "height": 300,
       "panels": [
         {
           "aliasColors": {},
@@ -460,5 +546,5 @@
   },
   "timezone": "browser",
   "title": "Sidekiq",
-  "version": 8
+  "version": 9
 }


### PR DESCRIPTION
This adds a graph which shows the queue latency to the Sidekiq dashboard.