### PR TITLE
Add more unicorn workers to asset manager

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -333,6 +333,7 @@ govuk::apps::asset_manager::mongodb_nodes:
   - 'mongo-3.backend'
 govuk::apps::asset_manager::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::asset_manager::redis_port: "%{hiera('sidekiq_port')}"
+govuk::apps::asset_manager::unicorn_worker_processes: "8"
 
 govuk::apps::authenticating_proxy::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
 

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -343,9 +343,9 @@ govuk::apps::asset_manager::mongodb_nodes:
   - 'mongo-1'
   - 'mongo-2'
   - 'mongo-3'
-
 govuk::apps::asset_manager::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::asset_manager::redis_port: "%{hiera('sidekiq_port')}"
+govuk::apps::asset_manager::unicorn_worker_processes: "8"
 
 govuk::apps::authenticating_proxy::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
 

--- a/modules/govuk/manifests/apps/asset_manager.pp
+++ b/modules/govuk/manifests/apps/asset_manager.pp
@@ -39,6 +39,8 @@
 # [*redis_port*]
 #   Redis port for Sidekiq.
 #   Default: undef
+# [*unicorn_worker_processes*]
+#   The number of unicorn workers to run for an instance of this app
 #
 class govuk::apps::asset_manager(
   $enabled = true,
@@ -55,7 +57,8 @@ class govuk::apps::asset_manager(
   $aws_access_key_id = undef,
   $aws_secret_access_key = undef,
   $redis_host = undef,
-  $redis_port = undef
+  $redis_port = undef,
+  $unicorn_worker_processes = undef,
 ) {
 
   $app_name = 'asset-manager'
@@ -75,15 +78,16 @@ class govuk::apps::asset_manager(
     $deny_framing = false
 
     govuk::app { $app_name:
-      app_type           => 'rack',
-      port               => $port,
-      sentry_dsn         => $sentry_dsn,
-      vhost_ssl_only     => true,
-      health_check_path  => '/healthcheck',
-      log_format_is_json => true,
-      deny_framing       => $deny_framing,
-      depends_on_nfs     => true,
-      nginx_extra_config => template('govuk/asset_manager_extra_nginx_config.conf.erb'),
+      app_type                 => 'rack',
+      port                     => $port,
+      sentry_dsn               => $sentry_dsn,
+      vhost_ssl_only           => true,
+      health_check_path        => '/healthcheck',
+      log_format_is_json       => true,
+      deny_framing             => $deny_framing,
+      depends_on_nfs           => true,
+      nginx_extra_config       => template('govuk/asset_manager_extra_nginx_config.conf.erb'),
+      unicorn_worker_processes => $unicorn_worker_processes,
     }
 
     govuk::app::envvar {


### PR DESCRIPTION
We're seeing timeouts while large uploads are happening so this should help the situation.

As asset manager continues to serve and receive more assets this will become more necessary.

[Trello Card](https://trello.com/c/ktNXJSsb/220-improve-resources-for-asset-manager)