### PR TITLE
PuppetDB Java Heap Size.

### DIFF
--- a/modules/govuk_puppetdb/manifests/config.pp
+++ b/modules/govuk_puppetdb/manifests/config.pp
@@ -7,7 +7,7 @@ class govuk_puppetdb::config (
   # installing puppetdb-2.x on the new Trusty Puppetmasters on AWS
   # Use aws_migration fact
   if $::aws_migration {
-    $java_args = '-Xmx1024m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/puppetdb/puppetdb-oom.hprof -Djava.security.egd=file:/dev/urandom'
+    $java_args = '-Xmx192m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/puppetdb/puppetdb-oom.hprof -Djava.security.egd=file:/dev/urandom'
     $puppetdb_ssl_setup_creates = '/etc/puppetdb/ssl/ca.pem'
     $configfile = 'config.ini'
   } else {


### PR DESCRIPTION
- We have noticed that the AWS Staging pupet master is crashing
frequently.
- The symptom is always `java.lang.OutOfMemoryError: Java heap space`.
- We can see that Carrenza staging is still using 192MB. We also know
that we have 4CPU cores in AWS compared to 8 in Carrenza. However,
reducing the heap size might/should trigger frequent garbage collection
and ultimately less probability of getting full.
- This might have an adverse effect. however, this is a simpler change
to test in the new environment before choosing an expensive instance
type.

Note: Please check the trello card for more details.

https://trello.com/c/nr8kuCOv/1170-aws-staging-puppet-is-broken

Solo: @suthagarht