### PR TITLE
Add warehouse hostnames to puppet

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -408,6 +408,8 @@ hosts::production::backend::hosts:
     ip: '10.3.3.161'
   transition-postgresql-standby-2:
     ip: '10.3.11.161'
+  warehouse-postgresql-1:
+    ip: '10.3.3.110'
   whitehall-backend-1:
     ip: '10.3.3.25'
   whitehall-backend-2:

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -348,6 +348,8 @@ hosts::production::backend::hosts:
     ip: '10.2.3.161'
   transition-postgresql-standby-2:
     ip: '10.2.11.161'
+  warehouse-postgresql-1:
+    ip: '10.2.3.110'
   whitehall-backend-1:
     ip: '10.2.3.25'
   whitehall-backend-2:


### PR DESCRIPTION
This is used to populate /etc/hosts and won’t allow the machine to
provision otherwise.