### PR TITLE
Increase asset manager memory thresholds

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -334,6 +334,8 @@ govuk::apps::asset_manager::mongodb_nodes:
 govuk::apps::asset_manager::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::asset_manager::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::asset_manager::unicorn_worker_processes: "8"
+govuk::apps::asset_manager::nagios_memory_warning: 1500
+govuk::apps::asset_manager::nagios_memory_critical: 1750
 
 govuk::apps::authenticating_proxy::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
 

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -346,6 +346,8 @@ govuk::apps::asset_manager::mongodb_nodes:
 govuk::apps::asset_manager::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::asset_manager::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::asset_manager::unicorn_worker_processes: "8"
+govuk::apps::asset_manager::nagios_memory_warning: 1500
+govuk::apps::asset_manager::nagios_memory_critical: 1750
 
 govuk::apps::authenticating_proxy::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
 

--- a/modules/govuk/manifests/apps/asset_manager.pp
+++ b/modules/govuk/manifests/apps/asset_manager.pp
@@ -41,6 +41,10 @@
 #   Default: undef
 # [*unicorn_worker_processes*]
 #   The number of unicorn workers to run for an instance of this app
+# [*nagios_memory_warning*]
+#   The threshold that memory must be reached to be triggered as a warning
+# [*nagios_memory_critical*]
+#   The threshold that memory must be reached to be triggered as a critical issue
 #
 class govuk::apps::asset_manager(
   $enabled = true,
@@ -59,6 +63,8 @@ class govuk::apps::asset_manager(
   $redis_host = undef,
   $redis_port = undef,
   $unicorn_worker_processes = undef,
+  $nagios_memory_warning = undef,
+  $nagios_memory_critical = undef,
 ) {
 
   $app_name = 'asset-manager'
@@ -88,6 +94,8 @@ class govuk::apps::asset_manager(
       depends_on_nfs           => true,
       nginx_extra_config       => template('govuk/asset_manager_extra_nginx_config.conf.erb'),
       unicorn_worker_processes => $unicorn_worker_processes,
+      nagios_memory_warning    => $nagios_memory_warning,
+      nagios_memory_critical   => $nagios_memory_critical,
     }
 
     govuk::app::envvar {


### PR DESCRIPTION
We increased the number of unicorn worker processes in #7525 which has increased memory usage, so we should also increase the thresholds.

I've chosen the numbers by [looking at this graph](https://graphite.publishing.service.gov.uk/render/?width=1000&height=600&colorList=red,orange,blue,green,purple,brown&target=alias(dashed(constantLine(800000000)),%22critical%22)&target=alias(dashed(constantLine(700000000)),%22warning%22)&target=backend-1_backend.processes-app-asset-manager.ps_rss) but they may need tuning in the future.