### PR TITLE
Add a weekly Jenkins task which runs the publication delay report

### DIFF
--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -36,6 +36,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::network_config_deploy
   - govuk_jenkins::jobs::passive_checks
   - govuk_jenkins::jobs::performance_platform_data_sync
+  - govuk_jenkins::jobs::publication_delay_report
   - govuk_jenkins::jobs::publishing_api_archive_events
   - govuk_jenkins::jobs::record_taxonomy_metrics
   - govuk_jenkins::jobs::remove_emergency_banner

--- a/hieradata/class/staging/jenkins.yaml
+++ b/hieradata/class/staging/jenkins.yaml
@@ -20,6 +20,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::launch_vms
   - govuk_jenkins::jobs::network_config_deploy
   - govuk_jenkins::jobs::passive_checks
+  - govuk_jenkins::jobs::publication_delay_report
   - govuk_jenkins::jobs::record_taxonomy_metrics
   - govuk_jenkins::jobs::remove_emergency_banner
   - govuk_jenkins::jobs::run_rake_task

--- a/hieradata_aws/class/jenkins.yaml
+++ b/hieradata_aws/class/jenkins.yaml
@@ -71,6 +71,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::extract_app_performance
   - govuk_jenkins::jobs::govuk_taxonomy_supervised_learning
   - govuk_jenkins::jobs::passive_checks
+  - govuk_jenkins::jobs::publication_delay_report
   - govuk_jenkins::jobs::record_taxonomy_metrics
   - govuk_jenkins::jobs::remove_emergency_banner
   - govuk_jenkins::jobs::run_deploy_lag_badger

--- a/modules/govuk_jenkins/manifests/jobs/publication_delay_report.pp
+++ b/modules/govuk_jenkins/manifests/jobs/publication_delay_report.pp
@@ -1,0 +1,11 @@
+# == Class: govuk_jenkins::jobs::publication_delay_report
+#
+# Run a publication delay report showing delays in publications over the last week.
+#
+class govuk_jenkins::jobs::publication_delay_report {
+  file { '/etc/jenkins_jobs/jobs/publication_delay_report.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/publication_delay_report.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+}

--- a/modules/govuk_jenkins/templates/jobs/publication_delay_report.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/publication_delay_report.yaml.erb
@@ -1,0 +1,25 @@
+---
+- job:
+    name: publication-delay-report
+    display-name: Publication delay report
+    project-type: freestyle
+    description: Run a publication delay report showing delays in publications over the last week.
+    properties:
+      - build-discarder:
+          artifact-num-to-keep: 30
+    builders:
+      - shell: |
+          #!/bin/bash
+          set -eu
+
+          MACHINE=$(govuk_node_list --single-node -c content_store)
+          COMMAND="cd /var/apps/content-store && govuk_setenv content-store bundle exec rake report:publication_delay_report"
+
+          ssh deploy@$MACHINE $COMMAND
+    triggers:
+      - timed: |
+          TZ=Europe/London
+          0 9 * * 0
+    wrappers:
+      - ansicolor:
+          colormap: xterm


### PR DESCRIPTION
This runs the task [recently added to the Content Store](https://github.com/alphagov/content-store/pull/438).

[Trello Card](https://trello.com/c/rkOiRFUV/128-run-the-statistics-publication-delay-report-weekly-and-send-it-to-alice-2)