### PR TITLE
Directing gor replay traffic from carrenza staging cache machines to …

### DIFF
--- a/hieradata/class/staging/cache.yaml
+++ b/hieradata/class/staging/cache.yaml
@@ -4,5 +4,5 @@
 #
 # If changed, the old host record must be cleaned up;
 router::gor::replay_targets:
-  'www-origin.integration.publishing.service.gov.uk':
-    ip: '31.210.245.98'
+  'www-origin.staging.govuk.digital': {}
+router::gor::add_hosts: false

--- a/hieradata/node/cache-2.router.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/cache-2.router.staging.publishing.service.gov.uk.yaml
@@ -1,5 +1,0 @@
----
-
-router::gor::add_hosts: false
-router::gor::replay_targets:
-  'www-origin.blue.integration.govuk.digital': {}


### PR DESCRIPTION
…AWS staging

  We set a global conf for the whole cache class and delete the machine specific configs