### PR TITLE
Fix WAL-E backups for Data Warehouse

### DIFF
--- a/modules/govuk_postgresql/manifests/server/standalone.pp
+++ b/modules/govuk_postgresql/manifests/server/standalone.pp
@@ -5,4 +5,13 @@
 class govuk_postgresql::server::standalone {
   include govuk_postgresql::server
   include govuk_postgresql::server::not_slave
+
+  postgresql::server::config_entry {
+    'wal_level':
+      value => 'replica';
+    'max_wal_senders':
+      value => 3;
+    'wal_keep_segments':
+      value => 256;
+  }
 }

--- a/modules/govuk_postgresql/manifests/wal_e/package.pp
+++ b/modules/govuk_postgresql/manifests/wal_e/package.pp
@@ -12,9 +12,9 @@ class govuk_postgresql::wal_e::package {
     require => Class['govuk_postgresql::server'],
   }
 
-  package { 'wal-e':
-    ensure   => '0.9.2',
-    provider => pip,
+  package { 'wal-e[aws]':
+    ensure   => '1.1.0',
+    provider => pip3,
   }
 
   $dependencies = [
@@ -23,18 +23,5 @@ class govuk_postgresql::wal_e::package {
 
   package { $dependencies:
     ensure => present,
-  }
-
-  # pip should take care of version deps but we need to manually upgrade
-  # a couple of things
-
-  package { 'requests':
-    ensure   => '2.10.0',
-    provider => pip,
-  }
-
-  package { 'six':
-    ensure   => '1.10.0',
-    provider => pip,
   }
 }

--- a/modules/puppet/lib/puppet/provider/package/pip3.rb
+++ b/modules/puppet/lib/puppet/provider/package/pip3.rb
@@ -1,0 +1,20 @@
+# Puppet package provider for Python's `pip3` package management frontend.
+# <http://pip.pypa.io/>
+
+require 'puppet/provider/package/pip'
+
+Puppet::Type.type(:package).provide :pip3,
+  :parent => :pip do
+
+  desc "Python packages via `pip3`.
+
+  This provider supports the `install_options` attribute, which allows command-line flags to be passed to pip3.
+  These options should be specified as a string (e.g. '--flag'), a hash (e.g. {'--flag' => 'value'}),
+  or an array where each element is either a string or a hash."
+
+  has_feature :installable, :uninstallable, :upgradeable, :versionable, :install_options
+
+  def self.cmd
+    ["pip3"]
+  end
+end


### PR DESCRIPTION
- Actually enables WAL-E to be installed, as this was broken. This would have been a problem anyway if we'd had to reprovision other Postgres servers 3caf449
- Enables storing of WAL segments in order to back them up f0eb4ea