### PR TITLE
Install pip3 on all boxes

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -254,6 +254,7 @@ base::packages::packages:
   - 'manpages'
   - 'ncdu'
   - 'pv'
+  - 'python3-pip'
   - 'strace'
   - 'tar'
   - 'tcpdump'


### PR DESCRIPTION
Supports the pip3 package provider.

Missed this in #7538 