### PR TITLE
Set the "hot_standby" WAL level

### DIFF
--- a/modules/govuk_postgresql/manifests/server/standalone.pp
+++ b/modules/govuk_postgresql/manifests/server/standalone.pp
@@ -8,7 +8,7 @@ class govuk_postgresql::server::standalone {
 
   postgresql::server::config_entry {
     'wal_level':
-      value => 'replica';
+      value => 'hot_standby';
     'max_wal_senders':
       value => 3;
     'wal_keep_segments':


### PR DESCRIPTION
`replica` was only introduced in Postgres 9.6. `hot_standby` is still valid in 9.6 for backwards compatibility, and is mapped to `replica`. For 9.6 upwards this change is functionally equivalent. For 9.5 and below this allows postgres to boot again.