### PR TITLE
Don't install pip3 on Precise

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -254,7 +254,6 @@ base::packages::packages:
   - 'manpages'
   - 'ncdu'
   - 'pv'
-  - 'python3-pip'
   - 'strace'
   - 'tar'
   - 'tcpdump'

--- a/modules/base/manifests/packages.pp
+++ b/modules/base/manifests/packages.pp
@@ -57,5 +57,11 @@ class base::packages (
     }
   }
 
+  unless $::lsbdistcodename == 'precise' {
+    package { 'python3-pip':
+      ensure => 'latest',
+    }
+  }
+
   include nodejs
 }


### PR DESCRIPTION
It's not available on 12.04, and none of our 12.04 machines need it.