### PR TITLE
Add new disk to api-mongo machines

### DIFF
--- a/hieradata/class/api_mongo.yaml
+++ b/hieradata/class/api_mongo.yaml
@@ -8,6 +8,7 @@ lv:
     pv:
     - '/dev/sdb1'
     - '/dev/sdd1'
+    - '/dev/sdf1'
     vg: 'backup'
   data:
     pv: '/dev/sdc1'


### PR DESCRIPTION
Backups are failing due to disk space limitations on the partition mounted at `/var/lib/automongodbbackup`  so add another disk to allow this partition to grow.

Related https://github.com/alphagov/govuk-provisioning/pull/56