### PR TITLE
Correct the title of response times dashboard panel

### DIFF
--- a/modules/grafana/templates/dashboards/deployment_panels/_response_times_by_controller_action.json.erb
+++ b/modules/grafana/templates/dashboards/deployment_panels/_response_times_by_controller_action.json.erb
@@ -91,7 +91,7 @@
   ],
   "timeFrom": "6h",
   "timeShift": null,
-  "title": "90th Percentile Response Time by Controller",
+  "title": "90th Percentile Response Time by Controller and Action",
   "tooltip": {
     "msResolution": true,
     "shared": true,


### PR DESCRIPTION
We modified this recently to show the response times by action and controller
rather than just controller.  I forgot to update the title at the time :-( .