### PR TITLE
[Do not merge] Increase oplog_size for api-mongos

### DIFF
--- a/hieradata/class/api_mongo.yaml
+++ b/hieradata/class/api_mongo.yaml
@@ -31,6 +31,7 @@ mount:
     govuk_lvm: 's3backups'
     mountoptions: 'defaults'
 
+mongodb::server::oplog_size: 7168
 mongodb::server::replicaset_members:
   'api-mongo-1':
   'api-mongo-2':


### PR DESCRIPTION
Attempts to address https://govuk.zendesk.com/agent/tickets/2782624

Secondary api-mongos are regularly getting stuck in recovery
state in staging. 
On investigation the oplog size is very
marginal compared to the number of items to replicate multiplied
by the average object size. Bother are ~3GB.
See https://stackoverflow.com/questions/30250872/endless-recovering-state-of-secondary for
information on oplog tuning.
We've already applied a similar config for other mongo clusters.
https://github.com/alphagov/govuk-puppet/blob/2b80fc6a11cfa1c1685fcb415802b52c0eb690fd/hieradata/class/mongo.yaml#L36

**edit** : I ran a test of 7GB oplog on one of the api-mongo secondaries overnight. It is still stuck in recovery this morning :(