### PR TITLE
Update static dependent apps

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1065,6 +1065,7 @@ grafana::dashboards::deployment_applications:
       - calendars
       - collections
       - contacts
+      - email-alert-frontend
       - finder-frontend
       - frontend
       - government-frontend

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -928,6 +928,7 @@ grafana::dashboards::deployment_applications:
       - calendars
       - collections
       - contacts
+      - email-alert-frontend
       - finder-frontend
       - frontend
       - government-frontend


### PR DESCRIPTION
We had an incident recently where static removed a thing that a frontend app was reliant on.  

We should keep this list of apps up to date as it will help us detect when we break things, as it will show up on the [deployment dashboard](https://grafana.publishing.service.gov.uk/dashboard/file/deployment_static.json?refresh=5s&orgId=1)