### PR TITLE
Grafana_dashboard_500_to_5xx

### DIFF
--- a/modules/grafana/templates/dashboards/deployment_panels/_5xx_rate.json.erb
+++ b/modules/grafana/templates/dashboards/deployment_panels/_5xx_rate.json.erb
@@ -42,7 +42,7 @@
   "thresholds": [],
   "timeFrom": null,
   "timeShift": null,
-  "title": "500 Rate over time",
+  "title": "5xx Rate over time",
   "tooltip": {
     "msResolution": false,
     "shared": true,


### PR DESCRIPTION
Grafana dashboard title incorrect, data returned contains 5xx not just 500.