### PR TITLE
In AWS, bump the Puppet JVM heap size to 2G

### DIFF
--- a/modules/govuk_puppetdb/manifests/config.pp
+++ b/modules/govuk_puppetdb/manifests/config.pp
@@ -7,7 +7,7 @@ class govuk_puppetdb::config (
   # installing puppetdb-2.x on the new Trusty Puppetmasters on AWS
   # Use aws_migration fact
   if $::aws_migration {
-    $java_args = '-Xmx1024m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/puppetdb/puppetdb-oom.hprof -Djava.security.egd=file:/dev/urandom'
+    $java_args = '-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/puppetdb/puppetdb-oom.hprof -Djava.security.egd=file:/dev/urandom'
     $puppetdb_ssl_setup_creates = '/etc/puppetdb/ssl/ca.pem'
     $configfile = 'config.ini'
   } else {


### PR DESCRIPTION
- We're seeing the Puppetmaster run out of memory a lot and crash. Along with the other mitigations, like making the instance more powerful in staging and production, increase the maximum Java heap size as this is always the error we see.

https://trello.com/c/357jwiXx/1130-puppetmaster-in-need-of-bigger-heap-size