### PR TITLE
Remove Data Warehouse from main db servers

### DIFF
--- a/modules/govuk/manifests/node/s_db_admin.pp
+++ b/modules/govuk/manifests/node/s_db_admin.pp
@@ -132,7 +132,6 @@ class govuk::node::s_db_admin(
 
   # include all PostgreSQL classes that create databases and users
   class { '::govuk::apps::content_audit_tool::db': } ->
-  class { '::govuk::apps::content_performance_manager::db': } ->
   class { '::govuk::apps::content_tagger::db': } ->
   class { '::govuk::apps::email_alert_api::db': } ->
   class { '::govuk::apps::link_checker_api::db': } ->

--- a/modules/govuk/manifests/node/s_postgresql_base.pp
+++ b/modules/govuk/manifests/node/s_postgresql_base.pp
@@ -4,7 +4,6 @@
 #
 class govuk::node::s_postgresql_base inherits govuk::node::s_base {
   include govuk::apps::content_audit_tool::db
-  include govuk::apps::content_performance_manager::db
   include govuk::apps::content_tagger::db
   include govuk::apps::email_alert_api::db
   include govuk::apps::link_checker_api::db


### PR DESCRIPTION
This now lives on its own set of servers.

This won't remove the DB, but it will prevent it being recreated once it's dropped.