### PR TITLE
Using puppet generated basic errors pages templates

### DIFF
--- a/modules/router/manifests/errorpage.pp
+++ b/modules/router/manifests/errorpage.pp
@@ -10,15 +10,13 @@ define router::errorpage () {
   # Only triggers every 6h or if the file doesn't exist.
   $filename = "/usr/share/nginx/www/${title}.html"
 
-  if $::aws_migration {
-    $s3_artefact_bucket = "govuk-${::aws_environment}-artefact"
-    $s3_url = "s3://${s3_artefact_bucket}/templates/${title}.html.erb"
-    $cmd = "aws --region eu-west-1 s3 cp ${s3_url} ${filename}"
+  $static_url = "https://static.${app_domain}/templates/${title}.html.erb"
 
-  } else {
-    $static_url = "https://static.${app_domain}/templates/${title}.html.erb"
-    $cmd = "curl --connect-timeout 1 -sf ${static_url} -o ${filename}"
-  }
+# We're dealing with a chicken and egg problem when building gov.uk here, static is not up before router, and router needs static for its error pages templates
+# To solve this we want router to try to get the templates from static
+# If that fails : keep the templates it has
+# If that fails and it has no templates: we generate basic tamplates for it.
+  $cmd = "curl --connect-timeout 1 -sf ${static_url} -o ${filename} || if [ ! -f ${filename} ]; then echo '<!DOCTYPE html><html><b>${title}</b></html>' > ${filename}; fi"
 
   exec { "update_error_page_${title}":
     command => $cmd,


### PR DESCRIPTION
  We were using an S3 bucket to store the templates so that router can access them, but the undesirable consequence is that router doesn't get its templates directly from static anymore

We now connect directly to static for the templates, in order to solve the circular dependencies issues (that were the reasons for using an S3 bucket in the first place) the script updating the templates has been modified to have the following behaviour : 
- If static replies : get the templates from static
- If static doesn't reply and there are templates existing already : keep the existing templates
- If static doesn't reply and there are no templates existing : generate some basic templates 