### PR TITLE
Separate Asset Manager uploads process

### DIFF
--- a/development-vm/Procfile
+++ b/development-vm/Procfile
@@ -42,6 +42,7 @@ release:               govuk_setenv release               ./run_in.sh ../../rele
 asset-manager:         govuk_setenv asset-manager         ./run_in.sh ../../asset-manager  bundle exec rails server -p 3037
 asset-manager-sidekiq:  govuk_setenv asset-manager         ./run_in.sh ../../asset-manager  bundle exec sidekiq -C ./config/sidekiq.yml
 # asset-manager sidekiq monitoring uses 3038
+# asset-manager uploads uses 3039
 # limelight used port 3040
 # transaction_wrappers used port 3041
 # govuk-delivery used port 3042

--- a/modules/govuk/manifests/apps/asset_manager.pp
+++ b/modules/govuk/manifests/apps/asset_manager.pp
@@ -113,6 +113,11 @@ class govuk::apps::asset_manager(
       nagios_memory_critical   => $nagios_memory_critical,
     }
 
+    govuk::procfile::worker { 'asset-manager-upload':
+      setenv_as    => $app_name,
+      process_type => 'web-upload',
+    }
+
     govuk::app::envvar {
       "${title}-UPLOAD_PORT":
         varname => 'UPLOAD_PORT',

--- a/modules/govuk/manifests/apps/asset_manager.pp
+++ b/modules/govuk/manifests/apps/asset_manager.pp
@@ -8,6 +8,7 @@
 # [*port*]
 #   The port that Asset Manager is served on.
 #   Default: 3037
+#
 # [*enable_procfile_worker*]
 #   Whether to enable the procfile worker
 #   Default: true
@@ -17,32 +18,45 @@
 #
 # [*oauth_id*]
 #   Sets the OAuth ID
+#
 # [*oauth_secret*]
 #   Sets the OAuth Secret Key
+#
 # [*secret_key_base*]
 #   The key for Rails to use when signing/encrypting sessions.
+#
 # [*mongodb_nodes*]
 #   An array of MongoDB instance hostnames
+#
 # [*mongodb_name*]
 #   The name of the MongoDB database to use
+#
 # [*aws_s3_bucket_name*]
 #   The name of the AWS S3 bucket to use for storing/serving assets
+#
 # [*aws_region*]
 #   AWS region of the S3 bucket
+#
 # [*aws_access_key_id*]
 #   AWS access key for a user with permission to write to the S3 bucket
+#
 # [*aws_secret_access_key*]
 #   AWS secret key for a user with permission to write to the S3 bucket
+#
 # [*redis_host*]
 #   Redis host for Sidekiq.
 #   Default: undef
+#
 # [*redis_port*]
 #   Redis port for Sidekiq.
 #   Default: undef
+#
 # [*unicorn_worker_processes*]
 #   The number of unicorn workers to run for an instance of this app
+#
 # [*nagios_memory_warning*]
 #   The threshold that memory must be reached to be triggered as a warning
+#
 # [*nagios_memory_critical*]
 #   The threshold that memory must be reached to be triggered as a critical issue
 #

--- a/modules/govuk/manifests/apps/asset_manager.pp
+++ b/modules/govuk/manifests/apps/asset_manager.pp
@@ -93,10 +93,6 @@ class govuk::apps::asset_manager(
       app => $app_name,
     }
 
-    # The X-Frame-Options response header is set explicitly in the
-    # relevant location blocks.
-    $deny_framing = false
-
     govuk::app { $app_name:
       app_type                 => 'rack',
       port                     => $port,
@@ -104,7 +100,7 @@ class govuk::apps::asset_manager(
       vhost_ssl_only           => true,
       health_check_path        => '/healthcheck',
       log_format_is_json       => true,
-      deny_framing             => $deny_framing,
+      deny_framing             => true,
       depends_on_nfs           => true,
       nginx_extra_config       => template('govuk/asset_manager_extra_nginx_config.conf.erb'),
       unicorn_worker_processes => $unicorn_worker_processes,

--- a/modules/govuk/manifests/apps/asset_manager.pp
+++ b/modules/govuk/manifests/apps/asset_manager.pp
@@ -9,6 +9,10 @@
 #   The port that Asset Manager is served on.
 #   Default: 3037
 #
+# [*upload_port*]
+#   The port that Asset Manager uploads are served on.
+#   Default: 3039
+#
 # [*enable_procfile_worker*]
 #   Whether to enable the procfile worker
 #   Default: true
@@ -63,6 +67,7 @@
 class govuk::apps::asset_manager(
   $enabled = true,
   $port = '3037',
+  $upload_port = '3039',
   $enable_procfile_worker = true,
   $sentry_dsn = undef,
   $oauth_id = undef,
@@ -109,6 +114,9 @@ class govuk::apps::asset_manager(
     }
 
     govuk::app::envvar {
+      "${title}-UPLOAD_PORT":
+        varname => 'UPLOAD_PORT',
+        value   => $upload_port;
       "${title}-OAUTH_ID":
         varname => 'OAUTH_ID',
         value   => $oauth_id;

--- a/modules/govuk/templates/asset_manager_extra_nginx_config.conf.erb
+++ b/modules/govuk/templates/asset_manager_extra_nginx_config.conf.erb
@@ -1,5 +1,15 @@
 client_max_body_size 500m;
 
+# Proxy POST, PUT or DELETE requests to /uploads to the uploads instance of unicorn,
+# otherwise send it to the usual location.
+location ~ /uploads {
+  proxy_pass http://localhost:<%= @upload_port %>;
+
+  limit_except PUT POST DELETE {
+    proxy_pass http://localhost:<%= @port %>;
+  }
+}
+
 # Store values from Rails response headers for use in the
 # cloud-storage-proxy location block below.
 set $etag_from_rails $upstream_http_etag;


### PR DESCRIPTION
This introduces a second unicorn process for Asset Manager which will be used to handle upload requests. This should help to avoid a situation where if all the unicorn workers are being used to upload files, then no unicorns are available to serve requests for assets or the health check endpoint.

Depends on https://github.com/alphagov/asset-manager/pull/557

[Trello Card](https://trello.com/c/ktNXJSsb/154-improve-resources-for-asset-manager-3)