### PR TITLE
Warehouse DB Admin needs postgres 9.6

### DIFF
--- a/hieradata_aws/class/warehouse_db_admin.yaml
+++ b/hieradata_aws/class/warehouse_db_admin.yaml
@@ -1,0 +1,3 @@
+---
+postgresql::globals::version: '9.6'
+postgresql::server::role::rds: true


### PR DESCRIPTION
It's connecting to a 9.6 server so needs 9.6 tools to connect and dump data