### PR TITLE
Upgrade included facter to avoid compatibility issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem "puppet-syntax", '2.1.0'
 gem "puppet-lint", '2.0.0'
 gem 'puppet-lint-trailing_comma-check', '0.3.2', :require => false
 gem "puppet", '3.8.5'
-gem 'facter', '2.0.2'
+gem 'facter', '2.4.6'
 gem "hiera", "1.3.4"
 gem "hiera-eyaml-gpg", :git => 'https://github.com/alphagov/hiera-eyaml-gpg.git', :branch => 'avoid_gpghome_env_var'
 gem "rspec-puppet"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,7 +25,7 @@ GEM
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
-    facter (2.0.2)
+    facter (2.4.6)
       CFPropertyList (~> 2.2.6)
     faraday (0.9.0)
       multipart-post (>= 1.2, < 3)
@@ -111,7 +111,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  facter (= 2.0.2)
+  facter (= 2.4.6)
   hiera (= 1.3.4)
   hiera-eyaml-gpg!
   librarian-puppet


### PR DESCRIPTION
- function flatten_structure not available in 2.0.2. 
- This is required by something run during initial "puppet apply" on puppetmaster
- Puppetmaster automated bootstrap https://github.com/alphagov/govuk-aws/pull/562 depends on this to work.