### PR TITLE
Make puppet use the PostgreSQL apt repo for 9.6

### DIFF
--- a/hieradata_aws/class/warehouse_db_admin.yaml
+++ b/hieradata_aws/class/warehouse_db_admin.yaml
@@ -1,3 +1,4 @@
 ---
 postgresql::globals::version: '9.6'
+postgresql::globals::manage_package_repo: true
 postgresql::server::role::rds: true


### PR DESCRIPTION
9.6 isn't available in Trusty