### PR TITLE
Add govuk-python repo to aptly machines

### DIFF
--- a/modules/govuk/manifests/node/s_apt.pp
+++ b/modules/govuk/manifests/node/s_apt.pp
@@ -134,6 +134,7 @@ class govuk::node::s_apt (
   aptly::repo { 'google-cloud-sdk-trusty': }
   aptly::repo { 'gor': }
   aptly::repo { 'govuk-jenkins': }
+  aptly::repo { 'govuk-python': }
   aptly::repo { 'govuk-rubygems': }
   aptly::repo { 'jenkins-agent': }
   aptly::repo { 'locksmithctl': }


### PR DESCRIPTION
- This is required for custom build packages of Python 2.7.16

- Python 2.7.6, included in Trusty, is incompatible with the Jenkins job
  search-fetch-analytics-data

- Installation / Python upgrade on Jenkins machines should be sufficient

solo: @schmie