### PR TITLE
Add more Asset Manager unicorn workers

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -333,9 +333,9 @@ govuk::apps::asset_manager::mongodb_nodes:
   - 'mongo-3.backend'
 govuk::apps::asset_manager::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::asset_manager::redis_port: "%{hiera('sidekiq_port')}"
-govuk::apps::asset_manager::unicorn_worker_processes: "8"
-govuk::apps::asset_manager::nagios_memory_warning: 1500
-govuk::apps::asset_manager::nagios_memory_critical: 1750
+govuk::apps::asset_manager::unicorn_worker_processes: "16"
+govuk::apps::asset_manager::nagios_memory_warning: 2500
+govuk::apps::asset_manager::nagios_memory_critical: 2750
 
 govuk::apps::authenticating_proxy::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
 

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -345,9 +345,9 @@ govuk::apps::asset_manager::mongodb_nodes:
   - 'mongo-3'
 govuk::apps::asset_manager::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::asset_manager::redis_port: "%{hiera('sidekiq_port')}"
-govuk::apps::asset_manager::unicorn_worker_processes: "8"
-govuk::apps::asset_manager::nagios_memory_warning: 1500
-govuk::apps::asset_manager::nagios_memory_critical: 1750
+govuk::apps::asset_manager::unicorn_worker_processes: "16"
+govuk::apps::asset_manager::nagios_memory_warning: 2500
+govuk::apps::asset_manager::nagios_memory_critical: 2750
 
 govuk::apps::authenticating_proxy::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
 


### PR DESCRIPTION
Although 8 seems to have solved the problem we should increase the number of workers available to cope with future expansion before further work on the architecture of Asset Manager happens which will split out uploads either into a separate app or into a system that enables direct uploads to S3.

There is plenty of free resources available on backend machines (mostly since we moved email-alert-api off these machines) to handle this.

[Trello Card](https://trello.com/c/ktNXJSsb/154-improve-resources-for-asset-manager-3)