### PR TITLE
Fix race condition in emergency banner cache clearing

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_emergency_banner.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_emergency_banner.yaml.erb
@@ -28,16 +28,16 @@
           LINK_TEXT=$(escapeRakeArg $LINK_TEXT)
 
           ssh deploy@$(govuk_node_list -c frontend --single-node) "cd /var/apps/static && govuk_setenv static bundle exec rake \"emergency_banner:deploy[$CAMPAIGN_CLASS,$HEADING,$SHORT_DESCRIPTION,$LINK,$LINK_TEXT]\""
-    publishers:
-      - trigger:
-          project: clear-template-cache
-      - trigger:
-          project: clear-frontend-memcache
-      - trigger:
-          project: clear-varnish-cache
+      - trigger-builds:
+          - project: clear-template-cache
+            block: true
+          - project: clear-frontend-memcache
+            block: true
+          - project: clear-varnish-cache
+            block: true
       <%- if @clear_cdn_cache -%>
-      - trigger:
-          project: clear-cdn-cache
+          - project: clear-cdn-cache
+            block: true
       <%- end -%>
     wrappers:
       - ansicolor:

--- a/modules/govuk_jenkins/templates/jobs/remove_emergency_banner.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/remove_emergency_banner.yaml.erb
@@ -11,16 +11,16 @@
     builders:
       # The argument to `-c` is in this case `frontend` but the value is used by both `static` and `frontend` applications
       - shell: ssh deploy@$(govuk_node_list -c frontend --single-node) "cd /var/apps/static && govuk_setenv static bundle exec rake emergency_banner:remove"
-    publishers:
-      - trigger:
-          project: clear-template-cache
-      - trigger:
-          project: clear-frontend-memcache
-      - trigger:
-          project: clear-varnish-cache
+      - trigger-builds:
+          - project: clear-template-cache
+            block: true
+          - project: clear-frontend-memcache
+            block: true
+          - project: clear-varnish-cache
+            block: true
       <%- if @clear_cdn_cache -%>
-      - trigger:
-          project: clear-cdn-cache
+          - project: clear-cdn-cache
+            block: true
       <%- end -%>
     wrappers:
       - ansicolor:


### PR DESCRIPTION
We encountered a problem in the emergency publishing drill today, where the banner did not display on the homepage until the Varnish cache was cleared a second time.  Here's what we think happened:

1. The frontend cache and varnish caches were cleared concurrently
2. The varnish cache job finished.
3. A request came in, repopulating the varnish cache.
4. The frontend cache cleared.

The varnish cache was repopulated with stale data.  This explains why it didn't crop up in the previous emergency publishing drill, as it's nondeterministic.

This PR makes the cache clearing synchronous.  These jobs seem to be pretty fast, so that shouldn't be much of a problem.
