### PR TITLE
Remove email-alert apps from backend group in hieradata

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -24,8 +24,6 @@ node_class: &node_class
       - content-audit-tool
       - content-performance-manager
       - content-tagger
-      - email-alert-api
-      - email-alert-service
       - event-store
       - hmrc-manuals-api
       - imminence

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -22,8 +22,6 @@ node_class: &node_class
       - content-audit-tool
       - content-performance-manager
       - content-tagger
-      - email-alert-api
-      - email-alert-service
       - event-store
       - hmrc-manuals-api
       - imminence


### PR DESCRIPTION
It seems that `email-alert-api` and `email-alert-service` are no longer on the
backend machines so we update hieradata to reflect this, as the dev docs are
currently displaying the wrong machines for these apps.