### PR TITLE
Add additional disks to API Mongo boxes

### DIFF
--- a/hieradata/class/api_mongo.yaml
+++ b/hieradata/class/api_mongo.yaml
@@ -18,6 +18,9 @@ lv:
   s3backups:
     pv: '/dev/sde1'
     vg: 'mongo'
+  datasync:
+    pv: '/dev/sdh1'
+    vg: 'mongosync'
 
 mount:
   /var/lib/mongodb:
@@ -31,6 +34,10 @@ mount:
   /var/lib/s3backup:
     disk: '/dev/mapper/mongo-s3backups'
     govuk_lvm: 's3backups'
+    mountoptions: 'defaults'
+  /var/lib/mongo-sync:
+    disk: '/dev/mapper/mongosync-datasync'
+    govuk_lvm: 'datasync'
     mountoptions: 'defaults'
 
 mongodb::server::replicaset_members:

--- a/modules/govuk/manifests/node/s_api_mongo.pp
+++ b/modules/govuk/manifests/node/s_api_mongo.pp
@@ -14,5 +14,18 @@ class govuk::node::s_api_mongo inherits govuk::node::s_base {
     Govuk_mount['/var/lib/mongodb'] -> Class['mongodb::server']
     Govuk_mount['/var/lib/automongodbbackup'] -> Class['mongodb::backup']
     Govuk_mount['/var/lib/s3backup'] -> Class['mongodb::backup']
+
+    file { '/var/lib/mongo-sync':
+      ensure  => directory,
+      owner   => 'deploy',
+      group   => 'deploy',
+      mode    => '0775',
+      purge   => false,
+      require => [
+        Group['deploy'],
+        User['deploy'],
+        Govuk_mount['/var/lib/mongo-sync']
+      ],
+    }
   }
 }


### PR DESCRIPTION
Trello: https://trello.com/c/q4BLjTfL/179-post-incidents-clean-up

This adds an additional 64GB disk to the /var/lib/mongodb directory to match the storage in production.

This also adds a 64GB mount for the data sync process which is currently [failing](https://deploy.publishing.service.gov.uk/job/copy_data_to_integration/705/console) due to insufficient disk space.

Further details in individual commits.