### PR TITLE
Monitor the data warehouse ETL job

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/content_performance_manager.pp
+++ b/modules/govuk_jenkins/manifests/jobs/content_performance_manager.pp
@@ -11,10 +11,23 @@
 #
 class govuk_jenkins::jobs::content_performance_manager (
   $rake_etl_master_process_cron_schedule = undef,
+  $app_domain = hiera('app_domain'),
 ) {
   file { '/etc/jenkins_jobs/jobs/content_performance_manager.yaml':
     ensure  => present,
     content => template('govuk_jenkins/jobs/content_performance_manager.yaml.erb'),
     notify  => Exec['jenkins_jobs_update'],
+  }
+
+  $check_name = 'etl-data-warehouse'
+  $service_description = 'Data warehouse ETL'
+  $job_url = "https://deploy.${app_domain}/job/content_performance_manager_import_etl_master_process/"
+
+  @@icinga::passive_check { "${check_name}_${::hostname}":
+    service_description => $service_description,
+    host_name           => $::fqdn,
+    freshness_threshold => 104400,
+    action_url          => $job_url,
+    notes_url           => monitoring_docs_url(data-warehouse-etl-failed),
   }
 }

--- a/modules/govuk_jenkins/templates/jobs/content_performance_manager.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/content_performance_manager.yaml.erb
@@ -18,4 +18,17 @@
   <% end %>
     logrotate:
         numToKeep: 10
+    publishers:
+      - trigger-parameterized-builds:
+          - project: Success_Passive_Check
+            condition: 'SUCCESS'
+            predefined-parameters: |
+                NSCA_CHECK_DESCRIPTION=<%= @service_description %>
+                NSCA_OUTPUT=<%= @service_description %> success
+          - project: Failure_Passive_Check
+            condition: 'FAILED'
+            predefined-parameters: |
+                NSCA_CHECK_DESCRIPTION=<%= @service_description %>
+                NSCA_OUTPUT=<%= @service_description %> failed
+                NSCA_CODE=2
 


### PR DESCRIPTION
This adds a passive icinga check to the jenkins job.
If it runs, it will notify icinga of success/fail. If it doesn't
run for 29 hours, the alert will hit its freshness threshold and
fail.

The job failing is a critical alert in icinga, but it shouldn't trigger pagerduty, because the data is not being consumed on a daily basis (yet).

Trello: https://trello.com/c/HzWvnSCy/345-2-alert-2nd-line-when-no-data-is-retrieved