### PR TITLE
Create /var/lib/mongo-sync on AWS integration machines

### DIFF
--- a/modules/govuk/manifests/node/s_api_mongo.pp
+++ b/modules/govuk/manifests/node/s_api_mongo.pp
@@ -10,7 +10,19 @@ class govuk::node::s_api_mongo inherits govuk::node::s_base {
     outgoing => 27017,
   }
 
-  if ! $::aws_migration {
+  if $::aws_migration {
+    file { '/var/lib/mongo-sync':
+      ensure  => directory,
+      owner   => 'deploy',
+      group   => 'deploy',
+      mode    => '0775',
+      purge   => false,
+      require => [
+        Group['deploy'],
+        User['deploy'],
+      ],
+    }
+  } else {
     Govuk_mount['/var/lib/mongodb'] -> Class['mongodb::server']
     Govuk_mount['/var/lib/automongodbbackup'] -> Class['mongodb::backup']
     Govuk_mount['/var/lib/s3backup'] -> Class['mongodb::backup']


### PR DESCRIPTION
Trello: https://trello.com/c/q4BLjTfL/179-post-incidents-clean-up

I've realised that by not creating this mount the sync will fail as
it will be trying to write to a directory that doesn't exist.

This adds the same directory to AWS migration environments but without
using the specific mount that is created for Carrenza environment.