### PR TITLE
Add a job to clear the redis uniquejobs hash

### DIFF
--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -21,6 +21,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::copy_data_to_staging
   - govuk_jenkins::jobs::copy_licensify_data_to_staging
   - govuk_jenkins::jobs::copy_sanitised_whitehall_database
+  - govuk_jenkins::jobs::delete_redis_uniquejobs
   - govuk_jenkins::jobs::deploy_app
   - govuk_jenkins::jobs::deploy_cdn
   - govuk_jenkins::jobs::deploy_dns

--- a/hieradata/class/staging/jenkins.yaml
+++ b/hieradata/class/staging/jenkins.yaml
@@ -9,6 +9,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::content_performance_manager
   - govuk_jenkins::jobs::copy_data_from_staging_to_aws
   - govuk_jenkins::jobs::data_sync_complete_staging
+  - govuk_jenkins::jobs::delete_redis_uniquejobs
   - govuk_jenkins::jobs::deploy_app
   - govuk_jenkins::jobs::deploy_cdn
   - govuk_jenkins::jobs::deploy_dns

--- a/modules/govuk_jenkins/manifests/jobs/delete_redis_uniquejobs.pp
+++ b/modules/govuk_jenkins/manifests/jobs/delete_redis_uniquejobs.pp
@@ -1,0 +1,12 @@
+# == Class: govuk_jenkins::jobs::whitehall_publisher_notifications
+#
+# Create a jenkins job to periodically remove redis uniquejobs key
+#
+class govuk_jenkins::jobs::delete_redis_uniquejobs {
+  file { '/etc/jenkins_jobs/jobs/delete_redis_uniquejobs.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/delete_redis_uniquejobs.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+}
+

--- a/modules/govuk_jenkins/templates/jobs/delete_redis_uniquejobs.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/delete_redis_uniquejobs.yaml.erb
@@ -1,0 +1,28 @@
+---
+- job:
+    name: delete-redis-uniquejobs
+    display-name: Delete redis uniquejobs
+    project-type: freestyle
+    description: >
+      Delete the redis uniquejobs hash.
+    properties:
+      - build-discarder:
+          num-to-keep: 30
+    builders:
+      # The argument to `-c` is in this case `frontend` but the value is used by both `static` and `frontend` applications.
+      # Rake does not handle commas in its arguments very well, so we have to escape them with a backslash. Since we're
+      # running the whole query inside quotes, we also need to escape quote marks.
+      - shell: |
+          #!/usr/bin/env bash
+          set -ex
+
+          for node in `govuk_node_list -c redis`; do
+            ssh deploy@$node "redis-cli DEL uniquejobs"
+          done
+    triggers:
+      - timed: "0 7 * * *"
+    wrappers:
+      - ansicolor:
+          colormap: xterm
+    logrotate:
+        numToKeep: 10


### PR DESCRIPTION
The redis uniquejobs hash has the propensity to grow and use all of the
available redis memory. We want to regularly clear it.