### PR TITLE
Add additional message queue consumer for CPM

### DIFF
--- a/modules/govuk/manifests/apps/content_performance_manager/rabbitmq.pp
+++ b/modules/govuk/manifests/apps/content_performance_manager/rabbitmq.pp
@@ -21,20 +21,34 @@
 #   The RabbitMQ queue to set up for workers of this type to read from
 #   (default: 'content_performance_manager')
 #
+# [*amqp_bulk_importing_queue]
+#   The RabbitMQ queue to set up for workers of this type to read from
+#   for bulk importer of content into the Content Performance Manager
+#   (default: 'content_performance_manager_govuk_importer')
+#
 class govuk::apps::content_performance_manager::rabbitmq (
   $amqp_user  = 'content_performance_manager',
   $amqp_pass = undef,
   $amqp_exchange = 'published_documents',
   $amqp_queue = 'content_performance_manager',
+  $amqp_bulk_importing_queue = 'content_performance_manager_govuk_importer'
 ) {
 
   govuk_rabbitmq::queue_with_binding { $amqp_queue:
     ensure        => 'present',
     amqp_exchange => $amqp_exchange,
     amqp_queue    => $amqp_queue,
-    routing_key   => '*.#.#',
+    routing_key   => '*.*',
     durable       => true,
-  } ->
+  }
+
+  govuk_rabbitmq::queue_with_binding { $amqp_bulk_importing_queue:
+    ensure        => 'present',
+    amqp_exchange => $amqp_exchange,
+    amqp_queue    => $amqp_bulk_importing_queue,
+    routing_key   => '*.bulk.data-warehouse',
+    durable       => true,
+  }
 
   govuk_rabbitmq::consumer { $amqp_user:
     ensure               => 'present',


### PR DESCRIPTION
The CPM/Data Warehouse will need to preload its database with a bulk
import of data. We will be adding a rake task to the publishing-api
to send out all events with a corresponding routing key to this
queue.

Note that we will have to go into the RabbitMQ manager and manually delete the binding for the `content_performance_manager` queue to pick up the new routing key pattern we've set for it.

Paired with @MatMoore 