### PR TITLE
Fix queue length stats for Publishing API.

### DIFF
--- a/modules/grafana/files/dashboards/publishing_api_worker_speed_and_throughput.json
+++ b/modules/grafana/files/dashboards/publishing_api_worker_speed_and_throughput.json
@@ -139,7 +139,7 @@
           "targets": [
             {
               "refId": "A",
-              "target": "groupByNode(stats.gauges.govuk.app.publishing-api.*.workers.queues.*.enqueued, 8, 'sum')"
+              "target": "groupByNode(stats.gauges.govuk.app.publishing-api.*.workers.queues.*.enqueued, 8, 'avg')"
             }
           ],
           "thresholds": [],


### PR DESCRIPTION
https://trello.com/c/sSFxdCHU/86-fix-publishing-api-worker-speed-and-throughput-to-not-show-sum-of-sidekiq-workers

The queue length reported by each instance is for the entire queue,
which means the use of 'sum' was counting the entire queue length
multiple times. Using avg should give us a more reasonable number!