### PR TITLE
Add link to documentation for data sync alert

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/copy_licensify_data_to_staging.pp
+++ b/modules/govuk_jenkins/manifests/jobs/copy_licensify_data_to_staging.pp
@@ -21,5 +21,6 @@ class govuk_jenkins::jobs::copy_licensify_data_to_staging (
     host_name           => $::fqdn,
     freshness_threshold => 115200,
     action_url          => $job_url,
+    notes_url           => monitoring_docs_url(data-sync),
   }
 }


### PR DESCRIPTION
There currently isn't a link to the documentation for the alert "Copy Licensify Data to Staging" in Icinga.

Trello card: https://trello.com/c/3mCxyEj0/87-alert-about-high-load-on-postgresql-primary-1backend-doesnt-have-any-documentation