### PR TITLE
Move mongo sync directory to mongodb::server class

### DIFF
--- a/modules/govuk/manifests/node/s_api_mongo.pp
+++ b/modules/govuk/manifests/node/s_api_mongo.pp
@@ -10,34 +10,10 @@ class govuk::node::s_api_mongo inherits govuk::node::s_base {
     outgoing => 27017,
   }
 
-  if $::aws_migration {
-    file { '/var/lib/mongo-sync':
-      ensure  => directory,
-      owner   => 'deploy',
-      group   => 'deploy',
-      mode    => '0775',
-      purge   => false,
-      require => [
-        Group['deploy'],
-        User['deploy'],
-      ],
-    }
-  } else {
+  if ! $::aws_migration {
     Govuk_mount['/var/lib/mongodb'] -> Class['mongodb::server']
     Govuk_mount['/var/lib/automongodbbackup'] -> Class['mongodb::backup']
     Govuk_mount['/var/lib/s3backup'] -> Class['mongodb::backup']
-
-    file { '/var/lib/mongo-sync':
-      ensure  => directory,
-      owner   => 'deploy',
-      group   => 'deploy',
-      mode    => '0775',
-      purge   => false,
-      require => [
-        Group['deploy'],
-        User['deploy'],
-        Govuk_mount['/var/lib/mongo-sync']
-      ],
-    }
+    Govuk_mount['/var/lib/mongo-sync'] -> Class['mongodb::server']
   }
 }

--- a/modules/mongodb/manifests/server.pp
+++ b/modules/mongodb/manifests/server.pp
@@ -24,12 +24,17 @@
 #   Saves space at the expense of data integrity.
 #   Default: false
 #
+# [*syncpath*]
+#   Path to directory that will be used for storing dumps whilst syncing
+#   between environments.
+#
 class mongodb::server (
   $version,
   $dbpath = '/var/lib/mongodb',
   $oplog_size = undef,
   $replicaset_members = {},
   $development = false,
+  $syncpath = '/var/lib/mongo-sync'
 ) {
 
   if versioncmp($version, '3.0.0') >= 0 {
@@ -89,6 +94,19 @@ class mongodb::server (
     owner => 'mongodb',
     group => 'mongodb',
     mode  => '0755',
+  }
+
+  file { "Ensure existence and correct owner of ${syncpath}":
+    ensure  => directory,
+    path    => $syncpath,
+    owner   => 'deploy',
+    group   => 'deploy',
+    mode    => '0775',
+    purge   => false,
+    require => [
+      Group['deploy'],
+      User['deploy'],
+    ],
   }
 
   class { 'mongodb::config':


### PR DESCRIPTION
In https://github.com/alphagov/govuk-puppet/pull/7573 I added an extra
mount for the sync process which used the /var/lib/mongo-sync directory.
This was only added to the api_mongo node and meant that the sync was
failing on other mongo nodes as they lacked this directory.

I have now moved it to be defined as part of mongodb::server so all
nodes which include this class will have it and the same directory can
be used throughout the sync.