### PR TITLE
Add variable for integration database password

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/copy_sanitised_whitehall_database.pp
+++ b/modules/govuk_jenkins/manifests/jobs/copy_sanitised_whitehall_database.pp
@@ -4,6 +4,7 @@
 #
 class govuk_jenkins::jobs::copy_sanitised_whitehall_database (
   $whitehall_mysql_password = undef,
+  $mysql_dst_root_pw = undef,
   $app_domain = hiera('app_domain'),
 ) {
 

--- a/modules/govuk_jenkins/templates/jobs/copy_sanitised_whitehall_database.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_sanitised_whitehall_database.yaml.erb
@@ -30,9 +30,11 @@
             15 5 * * 1-5
     builders:
         - shell: |
+            set +x
+
             cd "$WORKSPACE/whitehall/"
             echo "Sanitising whitehall database"
-            ./sanitise-and-sync-db.sh "<%= @whitehall_mysql_password %>"
+            ./sanitise-and-sync-db.sh "<%= @whitehall_mysql_password %>" "<%= @mysql_dst_root_pw %>"
     publishers:
       - trigger-parameterized-builds:
         - project: Success_Passive_Check


### PR DESCRIPTION
Add the password param for the root db admin on AWS MySQL. 
The param comes from encrypted hieradata in govuk-secrets.

Subsequently use this parameter in the Jenkins job definition.

At the same time, disable printing the commands to the Jenkins console so we don't leak sensitive information on screen.

This relies on the related [PR 333](https://github.com/alphagov/govuk-secrets/pull/333) in [GOV.UK Secrets](https://github.com/alphagov/govuk-secrets)

[Trello](https://trello.com/c/H9kjXcdb/182-whitehall-sanitise-env-sync-and-backup-3)