### PR TITLE
Allow rabbit consumer to read both CPM queues

### DIFF
--- a/modules/govuk/manifests/apps/content_performance_manager/rabbitmq.pp
+++ b/modules/govuk/manifests/apps/content_performance_manager/rabbitmq.pp
@@ -53,7 +53,7 @@ class govuk::apps::content_performance_manager::rabbitmq (
   govuk_rabbitmq::consumer { $amqp_user:
     ensure               => 'present',
     amqp_pass            => $amqp_pass,
-    read_permission      => "^${amqp_queue}\$",
+    read_permission      => "^${amqp_queue}|${amqp_bulk_importing_queue}\$",
     write_permission     => "^\$",
     configure_permission => "^\$",
   }


### PR DESCRIPTION
Content performance manager now has 2 queues set up,
so the user needs to read from both of them.