### PR TITLE
Put mongo backups in the data partition for mongo

### DIFF
--- a/modules/mongodb/manifests/aws_backup.pp
+++ b/modules/mongodb/manifests/aws_backup.pp
@@ -21,7 +21,7 @@
 #
 class mongodb::aws_backup (
   $ensure     = 'present',
-  $backup_dir = '/var/lib/mongodump',
+  $backup_dir = '/var/lib/mongodb/backup',
   $bucket     = undef,
   $interval   = 30,
   $daily_time = '00:00',

--- a/modules/mongodb/spec/classes/mongodb__aws_backup_spec.rb
+++ b/modules/mongodb/spec/classes/mongodb__aws_backup_spec.rb
@@ -3,7 +3,7 @@ require_relative '../../../../spec_helper'
 describe 'mongodb::aws_backup', :type => :class do
   context "default settings" do
     let(:params){{ 'bucket' => 'my-bucket' }}
-    it { is_expected.to contain_file('/var/lib/mongodump').with_ensure('directory') }
+    it { is_expected.to contain_file('/var/lib/mongodb/backup').with_ensure('directory') }
     it { is_expected.to contain_file('/usr/local/bin/mongodump-to-s3').with_ensure('present') }
     it { is_expected.to contain_cron__crondotdee('mongodump-to-s3').with_minute('*/30') }
   end


### PR DESCRIPTION
https://trello.com/c/bh0lZG83/98-move-mongo-aws-backups-into-var-lib-mongodb-backup-big-disk

Currently the backups for mongo go into the root partition, which is
causing disk warnings and backups to fail. Moving the backup into a
larger partition should fix this issue for the foreseeable future.