### PR TITLE
Increase backup freshness interval for mongo AWS

### DIFF
--- a/modules/mongodb/manifests/aws_backup.pp
+++ b/modules/mongodb/manifests/aws_backup.pp
@@ -31,7 +31,7 @@ class mongodb::aws_backup (
   validate_re($daily_time, '^(\d\d):(\d\d)$')
 
   $alert_hostname = 'alert'
-  $threshold_secs = 4800
+  $threshold_secs = 21600
   $service_desc = 'MongoDB backup to S3'
 
   if $ensure == 'present' {


### PR DESCRIPTION
https://trello.com/c/OSqZpWqo/101-increase-backup-interval-for-aws-mongo-from-15-hours-to-6-hours

Backups of AWS mongo on integration are habitually taking a couple of
hours to complete. As there's no obvious change we can make to decrease
the backup time, 6 hours seems like a reasonable maximum interval.