### PR TITLE
Remove redundant s3backup hieradata from hieradata_aws

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -985,7 +985,6 @@ limits::entries:
 
 mongodb::backup::alert_hostname: 'alert'
 mongodb::repository::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
-mongodb::s3backup::backup::alert_hostname: 'alert'
 mongodb::server::version: '2.4.9'
 
 monitoring::checks::http_username: "%{hiera('http_username')}"

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -121,7 +121,6 @@ govuk_ppa::path: 'preview'
 grafana::dashboards::machine_suffix_metrics: '_integration'
 
 mongodb::backup::mongo_backup_node: 'localhost'
-mongodb::s3backup::cron::daily_hour: 16
 
 monitoring::checks::sidekiq::enable_support_check: false
 monitoring::checks::pingdom::enable: false


### PR DESCRIPTION
The mongodb:s3backup approach seems not to be in use anymore on AWS
based deployments of GOV.UK, so remove the remaining configuration.