### PR TITLE
Fix ETL warehouse alert in environments other than production

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/content_performance_manager.pp
+++ b/modules/govuk_jenkins/manifests/jobs/content_performance_manager.pp
@@ -29,7 +29,6 @@ class govuk_jenkins::jobs::content_performance_manager (
       host_name           => $::fqdn,
       freshness_threshold => 104400,
       action_url          => $job_url,
-      notes_url           => monitoring_docs_url(data-warehouse-etl-failed),
     }
   }
 }

--- a/modules/govuk_jenkins/manifests/jobs/content_performance_manager.pp
+++ b/modules/govuk_jenkins/manifests/jobs/content_performance_manager.pp
@@ -23,11 +23,13 @@ class govuk_jenkins::jobs::content_performance_manager (
   $service_description = 'Data warehouse ETL'
   $job_url = "https://deploy.${app_domain}/job/content_performance_manager_import_etl_master_process/"
 
-  @@icinga::passive_check { "${check_name}_${::hostname}":
-    service_description => $service_description,
-    host_name           => $::fqdn,
-    freshness_threshold => 104400,
-    action_url          => $job_url,
-    notes_url           => monitoring_docs_url(data-warehouse-etl-failed),
+  if $rake_etl_master_process_cron_schedule {
+    @@icinga::passive_check { "${check_name}_${::hostname}":
+      service_description => $service_description,
+      host_name           => $::fqdn,
+      freshness_threshold => 104400,
+      action_url          => $job_url,
+      notes_url           => monitoring_docs_url(data-warehouse-etl-failed),
+    }
   }
 }


### PR DESCRIPTION
This makes sure the alert is only found in production, because the task only runs in production. It also removes a documentation link which doesn't exist.