### PR TITLE
Increase disk time thresholds for api_mongo

### DIFF
--- a/hieradata/class/api_mongo.yaml
+++ b/hieradata/class/api_mongo.yaml
@@ -49,3 +49,6 @@ mongodb::server::replicaset_members:
     priority: 0
 
 icinga::client::checks::disk_time_window_minutes: 10
+
+icinga::client::checks::disk_time_warn: 350 # milliseconds
+icinga::client::checks::disk_time_critical: 450 # milliseconds

--- a/hieradata_aws/class/api_mongo.yaml
+++ b/hieradata_aws/class/api_mongo.yaml
@@ -6,3 +6,6 @@ mongodb::server::replicaset_members:
   'api-mongo-1':
   'api-mongo-2':
   'api-mongo-3':
+
+icinga::client::checks::disk_time_warn: 350 # milliseconds
+icinga::client::checks::disk_time_critical: 450 # milliseconds


### PR DESCRIPTION
We're seeing these regularly go over the thresholds but it's not causing any issues so we can increase these thresholds to avoid unnecessary alerting.