### PR TITLE
Slightly increase rummager queue latency warning threshold

### DIFF
--- a/modules/monitoring/manifests/checks/sidekiq.pp
+++ b/modules/monitoring/manifests/checks/sidekiq.pp
@@ -11,7 +11,7 @@ class monitoring::checks::sidekiq (
 ) {
   icinga::check::graphite { 'check_rummager_queue_latency':
     target              => 'transformNull(keepLastValue(maxSeries(stats.gauges.govuk.app.rummager.*.workers.queues.default.latency)), 0)',
-    warning             => 0.3,
+    warning             => 0.5,
     critical            => 15,
     use                 => 'govuk_normal_priority',
     # Use data from the last 24 hours, to avoid not getting any


### PR DESCRIPTION
We often see small spikes where it can each 0.35 or 0.4 and that alerts us, but it doesn't seem to be a problem. It's probably fine to increase the threshold a bit up to 0.5.