### PR TITLE
Alert when at 60% disk space on mongo boxes

### DIFF
--- a/hieradata/class/api_mongo.yaml
+++ b/hieradata/class/api_mongo.yaml
@@ -27,6 +27,8 @@ mount:
     disk: '/dev/mapper/mongodb-data'
     govuk_lvm: 'data'
     mountoptions: 'defaults'
+    percent_threshold_warning: 60
+    percent_threshold_critical: 85
   /var/lib/automongodbbackup:
     disk: '/dev/mapper/backup-mongodb'
     govuk_lvm: 'mongodb'

--- a/hieradata/class/licensing_mongo.yaml
+++ b/hieradata/class/licensing_mongo.yaml
@@ -25,6 +25,8 @@ mount:
     disk: '/dev/mapper/mongodb-databases'
     govuk_lvm: 'databases'
     mountoptions: 'defaults'
+    percent_threshold_warning: 60
+    percent_threshold_critical: 85
   /var/lib/s3backup:
     disk: '/dev/mapper/mongo-s3backups'
     govuk_lvm: 's3backups'

--- a/hieradata/class/mongo.yaml
+++ b/hieradata/class/mongo.yaml
@@ -24,6 +24,8 @@ mount:
     disk: '/dev/mapper/mongodb-data'
     govuk_lvm: 'data'
     mountoptions: 'defaults'
+    percent_threshold_warning: 60
+    percent_threshold_critical: 85
   /var/lib/automongodbbackup:
     disk: '/dev/mapper/backup-mongodb'
     govuk_lvm: 'mongodb'

--- a/hieradata/class/performance_mongo.yaml
+++ b/hieradata/class/performance_mongo.yaml
@@ -21,6 +21,8 @@ mount:
     disk: '/dev/mapper/mongodb-data'
     govuk_lvm: 'data'
     mountoptions: 'defaults'
+    percent_threshold_warning: 60
+    percent_threshold_critical: 85
   /var/lib/automongodbbackup:
     disk: '/dev/mapper/backup-mongodb'
     govuk_lvm: 'mongodb'

--- a/hieradata_aws/class/mongo.yaml
+++ b/hieradata_aws/class/mongo.yaml
@@ -21,5 +21,5 @@ mount:
     disk: '/dev/mapper/mongo-data'
     govuk_lvm: 'data'
     mountoptions: 'defaults'
-    percent_threshold_warning: 16
-    percent_threshold_critical: 11
+    percent_threshold_warning: 60
+    percent_threshold_critical: 85


### PR DESCRIPTION
Trello: https://trello.com/c/pha57o5F/204-adjust-mongo-disk-space-alerts-so-it-alerts-when-there-is-still-a-good-amount-of-space-left

We learnt in the incident on the 18th May that disk space can shoot up
rapidly on mongo boxes and to avoid risks of further incidents the
recommendation was that our mongo boxes have ~50% disk space available
as leeway.

This sets alerts on all mongo data directories when they hit 60% disk
usage and goes to critical at 85%. There is the option that we think
about what each machine stores and set alerts individually for them but
I felt that added a bunch of complexity and that all our mongo boxes
could suffer the same fate if data rapidly changed.

A side effect of this is that it will produce some alerts straight away
as we have 74% disk usage in mongo-* servers and are close with 59% on
performance-mongo-*.