### PR TITLE
Change $scheme to https in uppercase to lowercase rewrite rule in AWS

### DIFF
--- a/modules/router/templates/router_include.conf.erb
+++ b/modules/router/templates/router_include.conf.erb
@@ -30,7 +30,7 @@ error_log  /var/log/nginx/lb-error.log;
 # eg www.gov.uk/GOVERNMENT/GUIDANCE -> www.gov.uk/government/guidance
 # eg WWW.GOV.UK/GOVERNMENT/GUIDANCE -> www.gov.uk/government/guidance
 location ~ ^\/[A-Z]+[A-Z\W\d]+$ {
-  rewrite ^(.*)$ $scheme://$host$uri_lowercase permanent;
+  rewrite ^(.*)$ <%= scope.lookupvar('::aws_migration') ? 'https' : '$scheme' %>://$host$uri_lowercase permanent;
 }
 
 location ~ ^/apply-for-a-licence/? {


### PR DESCRIPTION
  Everything is http internally within AWS, it creates problems for our tests when we return an http url however.