### PR TITLE
Call the in office on call people for Redis memory alerts

### DIFF
--- a/hieradata/class/redis.yaml
+++ b/hieradata/class/redis.yaml
@@ -4,4 +4,4 @@ govuk_safe_to_reboot::can_reboot: 'no'
 govuk_safe_to_reboot::reason: 'Single point of failure for applications, no clustering'
 
 icinga::client::contact_groups: 'urgent-priority'
-
+icinga::client::check_linux_free_memory::urgent: true

--- a/modules/icinga/manifests/client/check_linux_free_memory.pp
+++ b/modules/icinga/manifests/client/check_linux_free_memory.pp
@@ -2,7 +2,9 @@
 #
 # Install a Nagios plugin that alerts when the free memory on a box falls below a certain percentage
 #
-class icinga::client::check_linux_free_memory {
+class icinga::client::check_linux_free_memory(
+  $urgent = false,
+) {
 
   ensure_packages(['dbus'])
 
@@ -14,11 +16,18 @@ class icinga::client::check_linux_free_memory {
     source  => 'puppet:///modules/icinga/etc/nagios/nrpe.d/check_linux_free_memory.cfg',
   }
 
+  if $urgent {
+    $use = 'govuk_urgent_priority'
+    $notification_period = 'inoffice'
+  }
+
   @@icinga::check { "check_linux_free_memory_${::hostname}":
     check_command       => 'check_nrpe_1arg!check_linux_free_memory',
     service_description => 'percentage of memory free',
     host_name           => $::fqdn,
     notes_url           => monitoring_docs_url(free-memory-warning-on-backend),
     linked_metric       => "${::fqdn_metrics}.memory.memory-free",
+    use                 => $use,
+    notification_period => $notification_period,
   }
 }


### PR DESCRIPTION
This is the result of an incident we've concluded that this alert is important enough to call someone.

[Trello Card](https://trello.com/c/RebOoK8g/76-incident-review-action-make-redis-out-of-memory-alerts-call-on-call-during-office-hours)