### PR TITLE
Remove robots entries for licence-finder

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1697,10 +1697,6 @@ router::nginx::check_requests_critical: '@8'
 router::nginx::robotstxt: |
   User-agent: *
   Disallow: /*/print$
-  # We only allow indexing of the licence-finder landing page
-  Disallow: /licence-finder/
-  Allow: /licence-finder
-  Disallow: /apply-for-a-licence/
   # Don't allow indexing of user needs pages
   Disallow: /info/*
   Sitemap: https://www.gov.uk/sitemap.xml

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1096,10 +1096,6 @@ router::nginx::check_requests_critical: '@8'
 router::nginx::robotstxt: |
   User-agent: *
   Disallow: /*/print$
-  # We only allow indexing of the licence-finder landing page
-  Disallow: /licence-finder/
-  Allow: /licence-finder
-  Disallow: /apply-for-a-licence/
   # Don't allow indexing of user needs pages
   Disallow: /info/*
   Sitemap: https://www.gov.uk/sitemap.xml


### PR DESCRIPTION
This should only be deployed after https://github.com/alphagov/licence-finder/pull/256

---

[Trello card](https://trello.com/c/UW69iqCW/198-noindex-licence-finder-and-remove-apply-for-a-licence-from-robotstxt)