### PR TITLE
Add extra disks to mongo-* and performance-mongo-*

### DIFF
--- a/hieradata/class/mongo.yaml
+++ b/hieradata/class/mongo.yaml
@@ -11,6 +11,7 @@ lv:
       - '/dev/sdb1'
       - '/dev/sdd1'
       - '/dev/sdf1'
+      - '/dev/sdg1'
     vg: 'backup'
   data:
     pv: '/dev/sdc1'

--- a/hieradata/class/performance_mongo.yaml
+++ b/hieradata/class/performance_mongo.yaml
@@ -11,6 +11,7 @@ lv:
     pv:
       - '/dev/sdc1'
       - '/dev/sde1'
+      - '/dev/sdf1'
     vg: 'mongodb'
   s3backups:
     pv: '/dev/sdd1'


### PR DESCRIPTION
Trello: https://trello.com/c/pha57o5F/204-adjust-mongo-disk-space-alerts-so-it-alerts-when-there-is-still-a-good-amount-of-space-left

This is to ensure they have enough disk space so that we don't get alerts when: https://github.com/alphagov/govuk-puppet/pull/7600 is deployed.

Further details in commits