### PR TITLE
Fix search depth for mongorestore files

### DIFF
--- a/development-vm/replication/sync-aws-mongo.sh
+++ b/development-vm/replication/sync-aws-mongo.sh
@@ -69,7 +69,7 @@ else
   NAME_MUNGE_COMMAND="cat"
 fi
 
-for dir in $(find $MONGO_DIR -mindepth 5 -maxdepth 5 -type d | grep -v '*'); do
+for dir in $(find $MONGO_DIR -mindepth 6 -maxdepth 6 -type d | grep -v '*'); do
   if $DRY_RUN; then
     status "MongoDB (not) restoring $(basename $dir)"
   else


### PR DESCRIPTION
This commit changes the search depth from 5 to 6 when looking for Mongo files to restore. Mongo dump files seem to be one level lower in the directory structure than before.