### PR TITLE
Fix new drive being in backup volume group

### DIFF
--- a/hieradata/class/mongo.yaml
+++ b/hieradata/class/mongo.yaml
@@ -11,10 +11,11 @@ lv:
       - '/dev/sdb1'
       - '/dev/sdd1'
       - '/dev/sdf1'
-      - '/dev/sdg1'
     vg: 'backup'
   data:
-    pv: '/dev/sdc1'
+    pv: 
+      - '/dev/sdc1'
+      - '/dev/sdg1'
     vg: 'mongodb'
   s3backups:
     pv: '/dev/sde1'


### PR DESCRIPTION
Trello: https://trello.com/c/pha57o5F/204-adjust-mongo-disk-space-alerts-so-it-alerts-when-there-is-still-a-good-amount-of-space-left

D'oh I got confused and associated it with the wrong volume group.