### PR TITLE
Fix mongo going critical when less than 85% of disk is free

### DIFF
--- a/hieradata/class/api_mongo.yaml
+++ b/hieradata/class/api_mongo.yaml
@@ -27,8 +27,8 @@ mount:
     disk: '/dev/mapper/mongodb-data'
     govuk_lvm: 'data'
     mountoptions: 'defaults'
-    percent_threshold_warning: 60
-    percent_threshold_critical: 85
+    percent_threshold_warning: 40
+    percent_threshold_critical: 15
   /var/lib/automongodbbackup:
     disk: '/dev/mapper/backup-mongodb'
     govuk_lvm: 'mongodb'

--- a/hieradata/class/licensing_mongo.yaml
+++ b/hieradata/class/licensing_mongo.yaml
@@ -25,8 +25,8 @@ mount:
     disk: '/dev/mapper/mongodb-databases'
     govuk_lvm: 'databases'
     mountoptions: 'defaults'
-    percent_threshold_warning: 60
-    percent_threshold_critical: 85
+    percent_threshold_warning: 40
+    percent_threshold_critical: 15
   /var/lib/s3backup:
     disk: '/dev/mapper/mongo-s3backups'
     govuk_lvm: 's3backups'

--- a/hieradata/class/mongo.yaml
+++ b/hieradata/class/mongo.yaml
@@ -13,7 +13,7 @@ lv:
       - '/dev/sdf1'
     vg: 'backup'
   data:
-    pv: 
+    pv:
       - '/dev/sdc1'
       - '/dev/sdg1'
     vg: 'mongodb'
@@ -26,8 +26,8 @@ mount:
     disk: '/dev/mapper/mongodb-data'
     govuk_lvm: 'data'
     mountoptions: 'defaults'
-    percent_threshold_warning: 60
-    percent_threshold_critical: 85
+    percent_threshold_warning: 40
+    percent_threshold_critical: 15
   /var/lib/automongodbbackup:
     disk: '/dev/mapper/backup-mongodb'
     govuk_lvm: 'mongodb'

--- a/hieradata/class/performance_mongo.yaml
+++ b/hieradata/class/performance_mongo.yaml
@@ -22,8 +22,8 @@ mount:
     disk: '/dev/mapper/mongodb-data'
     govuk_lvm: 'data'
     mountoptions: 'defaults'
-    percent_threshold_warning: 60
-    percent_threshold_critical: 85
+    percent_threshold_warning: 40
+    percent_threshold_critical: 15
   /var/lib/automongodbbackup:
     disk: '/dev/mapper/backup-mongodb'
     govuk_lvm: 'mongodb'

--- a/hieradata_aws/class/mongo.yaml
+++ b/hieradata_aws/class/mongo.yaml
@@ -21,5 +21,5 @@ mount:
     disk: '/dev/mapper/mongo-data'
     govuk_lvm: 'data'
     mountoptions: 'defaults'
-    percent_threshold_warning: 60
-    percent_threshold_critical: 85
+    percent_threshold_warning: 40
+    percent_threshold_critical: 15


### PR DESCRIPTION
Whoops! I got all these numbers the wrong way round. This was causing
critical alerts when less than 85% of the disk was remaining when the
intention was actually to alert when 85% was used and thus alert when
15% is free.