### PR TITLE
Make backend_lb class machines safe to reboot over night

### DIFF
--- a/hieradata/class/backend_lb.yaml
+++ b/hieradata/class/backend_lb.yaml
@@ -1,7 +1,8 @@
 ---
 
-govuk_safe_to_reboot::can_reboot: 'careful'
-govuk_safe_to_reboot::reason: 'NAT rule points directly at backend-lb-1 for backend services. Need to switch this before rebooting to backend-2'
+govuk_safe_to_reboot::can_reboot: overnight
+govuk_safe_to_reboot::reason: >
+  Traffic is balanced between backend-lb-1 and backend-lb-2.
 
 nginx::logging::days_to_keep: '45'
 nginx::package::nginx_package: 'nginx-extras'


### PR DESCRIPTION
The traffic should be balanced between both backend boxes so there shouldn't be a problem with rebooting these over night.