### PR TITLE
Extend the AWS session expiry time for the replication script

### DIFF
--- a/development-vm/replication/aws.sh
+++ b/development-vm/replication/aws.sh
@@ -27,6 +27,7 @@ aws_auth() {
                     --role-session-name $SESSION_NAME \
                     --role-arn $ROLE_ARN \
                     --serial-number $MFA_SERIAL \
+                    --duration-seconds 28800 \
                     --token-code $MFA_TOKEN"
 
     CREDENTIALS=$(${aws_assume_role})


### PR DESCRIPTION
- This brings this aws assume-role command in line with the one in
  `govukcli` and extends the duration from one hour to the maximum
  of eight hours.