### PR TITLE
Specify the deployed zone in the Deploy DNS build name

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_dns.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_dns.yaml.erb
@@ -26,7 +26,7 @@
         - ansicolor:
             colormap: xterm
         - build-name:
-            name: '${ENV,var="PROVIDERS"} ${ENV,var="ACTION"}'
+            name: '${ENV,var="PROVIDERS"} ${ENV,var="ZONE"} ${ENV,var="ACTION"}'
         - credentials-binding:
             - text:
                credential-id: <%= @gce_credential_id %>


### PR DESCRIPTION
- Now we're deploying more than `publishing.service.gov.uk`, it would be
  useful to see the name of the zone that was deployed in the "name" field
  of the deploy log.