### PR TITLE
Upgrade postgresql to 9.6 on db_admin

### DIFF
--- a/hieradata_aws/class/db_admin.yaml
+++ b/hieradata_aws/class/db_admin.yaml
@@ -1,2 +1,3 @@
 ---
 postgresql::server::role::rds: true
+postgresql::globals::version: '9.6'

--- a/modules/govuk/manifests/node/s_db_admin.pp
+++ b/modules/govuk/manifests/node/s_db_admin.pp
@@ -111,6 +111,14 @@ class govuk::node::s_db_admin(
 
   # To manage remote databases using the puppetlabs-postgresql module we require
   # a local PostgreSQL server instance to be installed
+  apt::source { 'postgresql':
+    ensure       => present,
+    location     => "http://${apt_mirror_hostname}/postgresql",
+    release      => "${::lsbdistcodename}-pgdg",
+    architecture => $::architecture,
+    key          => 'B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8',
+  } ->
+
   class { '::postgresql::server':
     default_connect_settings => $default_connect_settings,
   } ->


### PR DESCRIPTION
  Since the upgrade of postgresql to 9.6 on the RDS instances we
have a version mismatch error coming from pg_dump when doing
backups