### PR TITLE
James Alderman has left, so `ensure => absent` his user account

### DIFF
--- a/modules/users/manifests/jamesalderman.pp
+++ b/modules/users/manifests/jamesalderman.pp
@@ -1,6 +1,7 @@
 # Creates the jamesalderman user
 class users::jamesalderman {
   govuk_user { 'jamesalderman':
+    ensure   => absent,
     fullname => 'James Alderman',
     email    => 'james.alderman@digital.cabinet-office.gov.uk',
     ssh_key  => [


### PR DESCRIPTION
- As per the [new
  process](https://docs.publishing.service.gov.uk/manual/removing-a-user-from-puppet.html),
  removing a user is a two-step process so their home directory doesn't
  hang around.