### PR TITLE
Switch to 1.1.1.1 as primary DNS server

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1651,6 +1651,7 @@ redis::conf_tcp_keepalive: false
 redis::conf_timeout: 300
 
 resolvconf::nameservers:
+  - 1.1.1.1
   - 8.8.8.8
   - 8.8.4.4
 

--- a/modules/govuk/templates/asset_manager_extra_nginx_config.conf.erb
+++ b/modules/govuk/templates/asset_manager_extra_nginx_config.conf.erb
@@ -70,9 +70,9 @@ location ~ /cloud-storage-proxy/(.*) {
   proxy_hide_header x-amz-replication-status;
   proxy_hide_header x-amz-meta-md5-hexdigest;
 
-  # Add Google DNS server to avoid "no resolver defined to resolve"
-  # errors when trying to connect to S3
-  resolver 8.8.8.8;
+  # Add CloudFlare and Google DNS server to avoid "no resolver defined to resolve"
+  # errors when trying to connect to S3.
+  resolver 1.1.1.1 8.8.8.8 8.8.4.4;
 
   # Download the file and send it to client
   proxy_pass $download_url;

--- a/modules/govuk/templates/www.mhra.gov.uk_nginx.conf.erb
+++ b/modules/govuk/templates/www.mhra.gov.uk_nginx.conf.erb
@@ -51,8 +51,8 @@ server {
 
   <% proxied_locations.each do |proxied_location| %>
     location <%= proxied_location %> {
-      # Use Google to resolve www.wip.mhra.gov.uk
-      resolver 8.8.8.8;
+      # Use CloudFlare and Google to resolve www.wip.mhra.gov.uk
+      resolver 1.1.1.1 8.8.8.8 8.8.4.4;
       set $backend "http://www.wip.mhra.gov.uk:80";
       proxy_pass $backend;
       # Can't use $http_host as that might be eg aka.mhra.gov.uk

--- a/modules/monitoring/files/etc/nagios3/conf.d/check_dig.cfg
+++ b/modules/monitoring/files/etc/nagios3/conf.d/check_dig.cfg
@@ -1,0 +1,4 @@
+define command {
+  command_name check_dig
+  command_line /usr/lib/nagios/plugins/check_dig -H 1.1.1.1 -l '$ARG1$' $ARG2$
+}

--- a/modules/monitoring/files/etc/nagios3/conf.d/check_dig_google.cfg
+++ b/modules/monitoring/files/etc/nagios3/conf.d/check_dig_google.cfg
@@ -1,4 +1,0 @@
-define command {
-  command_name check_dig_google
-  command_line /usr/lib/nagios/plugins/check_dig -H 8.8.8.8 -l '$ARG1$' $ARG2$
-}

--- a/modules/monitoring/manifests/checks.pp
+++ b/modules/monitoring/manifests/checks.pp
@@ -89,15 +89,15 @@ class monitoring::checks (
   # END ssl certificate checks
 
   # START DNS checks
-  icinga::check_config { 'check_dig_google':
-    source  => 'puppet:///modules/monitoring/etc/nagios3/conf.d/check_dig_google.cfg',
+  icinga::check_config { 'check_dig':
+    source  => 'puppet:///modules/monitoring/etc/nagios3/conf.d/check_dig.cfg',
   }
 
   icinga::check { 'check_www_gov_uk_dns':
-    check_command       => 'check_dig_google!www.gov.uk!-a www-cdn.production.govuk.service.gov.uk --timeout 10 -w 2 -c 3 -T CNAME',
+    check_command       => 'check_dig!www.gov.uk!-a www-cdn.production.govuk.service.gov.uk --timeout 10 -w 2 -c 3 -T CNAME',
     host_name           => $::fqdn,
     service_description => 'check www.gov.uk DNS record',
-    require             => Icinga::Check_config['check_dig_google'],
+    require             => Icinga::Check_config['check_dig'],
   }
   # END DNS checks
 


### PR DESCRIPTION
It's faster than 8.8.8.8 and we're seeing some problems resolving domains which we think could be related.

I've also changed the Icinga DNS check on www.gov.uk to use 1.1.1.1 instead of 8.8.8.8.