### PR TITLE
Add govuk-python to jenkins

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -666,6 +666,7 @@ govuk_gor::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk_htpasswd::http_username: "%{hiera('http_username')}"
 
 govuk_jenkins::packages::gcloud::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_jenkins::packages::govuk_python::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk_jenkins::packages::terraform::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk_jenkins::packages::terraform_docs::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk_jenkins::packages::sops::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -679,6 +679,7 @@ govuk_htpasswd::http_username: "%{hiera('http_username')}"
 
 govuk_jenkins::packages::gcloud::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk_jenkins::packages::terraform::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_jenkins::packages::govuk_python::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 govuk_jenkins::jobs::deploy_app::graphite_host: "graphite.%{hiera('app_domain_internal')}"
 govuk_jenkins::jobs::deploy_app::graphite_port: '443'

--- a/modules/govuk_ci/manifests/agent.pp
+++ b/modules/govuk_ci/manifests/agent.pp
@@ -32,6 +32,7 @@ class govuk_ci::agent(
   include ::govuk_ci::limits
   include ::govuk_jenkins::packages::terraform
   include ::govuk_jenkins::packages::terraform_docs
+  include ::govuk_jenkins::packages::govuk_python
   include ::govuk_jenkins::packages::vale
   include ::govuk_jenkins::pipeline
   include ::govuk_jenkins::user

--- a/modules/govuk_jenkins/manifests/init.pp
+++ b/modules/govuk_jenkins/manifests/init.pp
@@ -57,8 +57,8 @@ class govuk_jenkins (
 ) {
   validate_hash($config, $plugins)
 
-  include ::govuk_python
   include ::golang
+  include ::govuk_jenkins::packages::govuk_python
 
   file { "${jenkins_homedir}/workspace":
     ensure => directory,

--- a/modules/govuk_jenkins/manifests/packages/govuk_python.pp
+++ b/modules/govuk_jenkins/manifests/packages/govuk_python.pp
@@ -1,0 +1,39 @@
+# == Class: govuk_jenkins::packages::govuk-python
+#
+# Installs Python in /usr/local/bin/
+#
+# === Parameters
+#
+# [*apt_mirror_hostname*]
+#   The hostname of an APT mirror
+#
+class govuk_jenkins::packages::govuk_python (
+  $apt_mirror_hostname = undef,
+  $govuk_python_version = '2.7.14',
+  $govuk_python_setuptools_version = '39.0.1',
+  $govuk_python_pip_version = '10.0.1',
+){
+
+  apt::source { 'govuk-python':
+    location     => "http://${apt_mirror_hostname}/govuk-python",
+    release      => 'stable',
+    architecture => $::architecture,
+    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+  }
+
+  package { 'govuk-python':
+    ensure  => $govuk_python_version,
+    require => Apt::Source['govuk-python'],
+  }
+
+  package { 'govuk-python-setuptools':
+    ensure  => $govuk_python_setuptools_version,
+    require => Apt::Source['govuk-python'],
+  }
+
+  package { 'govuk-python-pip':
+    ensure  => $govuk_python_pip_version,
+    require => Apt::Source['govuk-python'],
+  }
+
+}


### PR DESCRIPTION
- This is required to add a current python installation (2.7.14) to jenkins

- Python newer than 2.7.6 (Trustys own) is required for SSL in
  search-fetch-analytics-data job.

- Installation is to /opt/python2.7 to minimise impact on existing
  Python.

@schmie