### PR TITLE
Run the autopostgresql backup earlier

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -213,7 +213,7 @@ govuk::node::s_whitehall_mysql_master::s3_bucket_name: "%{hiera('govuk::node::s_
 govuk::node::s_transition_postgresql_slave::redirector_ip_range: '10.3.5.0/24'
 govuk::node::s_transition_postgresql_standby::redirector_ip_range: "%{hiera('govuk::node::s_transition_postgresql_slave::redirector_ip_range')}"
 
-govuk_postgresql::backup::auto_postgresql_backup_hour: 5
+govuk_postgresql::backup::auto_postgresql_backup_hour: 3
 govuk_postgresql::backup::auto_postgresql_backup_minute: 0
 
 govuk_crawler::seed_enable: true


### PR DESCRIPTION
The backup takes longer to run now and usually isn't ready by 9am when the backups get collected together.