### PR TITLE
Add mongodb s3_bucket config to Carrenza/hieradata

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -181,6 +181,9 @@ monitoring::checks::ses::region: eu-west-1
 monitoring::checks::smokey::environment: 'integration'
 monitoring::uptime_collector::environment: 'integration'
 
+mongodb::s3backup::backup::s3_bucket: 'govuk-mongodb-backup-s3-staging'
+mongodb::s3backup::backup::s3_bucket_daily: 'govuk-mongodb-backup-s3-daily-staging'
+
 postfix::smarthost:
   - 'email-smtp.eu-west-1.amazonaws.com:587'
   - 'ses-smtp-eu-west-1-prod-345515633.eu-west-1.elb.amazonaws.com:587'


### PR DESCRIPTION
- The CI-licensify mongo backup to s3 fails because these bucket names
  are not defined in the non-AWS environment hieradata

- This change will re-enable the backups which have not run in half a
  year.

- This answers a ticket from 2nd-line
  (https://govuk.zendesk.com/agent/tickets/2820116)

Solo @schmie