### PR TITLE
Reduce robots.txt crawl-delay to 0.1s

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1702,7 +1702,7 @@ router::nginx::robotstxt: |
   # Don't allow indexing of user needs pages
   Disallow: /info/*
   Sitemap: https://www.gov.uk/sitemap.xml
-  Crawl-delay: 0.3
+  Crawl-delay: 0.1
   # https://ahrefs.com/robot/ crawls the site frequently
   User-agent: AhrefsBot
   Crawl-delay: 10

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1100,7 +1100,7 @@ router::nginx::robotstxt: |
   # Don't allow indexing of user needs pages
   Disallow: /info/*
   Sitemap: https://www.gov.uk/sitemap.xml
-  Crawl-delay: 0.3
+  Crawl-delay: 0.1
   # https://ahrefs.com/robot/ crawls the site frequently
   User-agent: AhrefsBot
   Crawl-delay: 10


### PR DESCRIPTION
#7620 went out yesterday morning and nothing is on fire, so let's reduce it again.

---

[Trello card](https://trello.com/c/CdL0aCEb/197-reduce-robotstxt-crawl-delay-and-evaluate-the-impact)