### PR TITLE
Fix Pinfile for CPM bulk import

### DIFF
--- a/development-vm/Pinfile
+++ b/development-vm/Pinfile
@@ -16,7 +16,7 @@ process :'collections-publisher' => [:'publishing-api', :'collections-publisher-
 process :'collections-publisher-worker'
 process :'contacts-admin' => [:'publishing-api', :whitehall]
 process :'content-audit-tool' => [:'publishing-api-read', :'content-audit-tool-sidekiq-google-analytics', :'content-audit-tool-sidekiq-publishing-api']
-process :'content-performance-manager' => [:'publishing-api-read', :'content-performance-manager-sidekiq-google-analytics', :'content-performance-manager-sidekiq-publishing-api', :'content-performance-manager-publishing-api-consumer', 'content-store']
+process :'content-performance-manager' => [:'publishing-api', :'content-performance-manager-sidekiq-google-analytics', :'content-performance-manager-sidekiq-publishing-api', :'content-performance-manager-publishing-api-consumer', 'content-store' , 'content-performance-manager-bulk-import-publishing-api-consumer']
 process :'content-store'
 # Example usage: bowl [your-app] dummy-content-store --without content-store
 process :'dummy-content-store'

--- a/development-vm/Procfile
+++ b/development-vm/Procfile
@@ -154,6 +154,7 @@ manuals-publisher-worker: govuk_setenv manuals-publisher ./run_in.sh ../../manua
 content-performance-manager:      govuk_setenv content-performance-manager ./run_in.sh ../../content-performance-manager bundle exec rails server -p 3206
 # sidekiq-monitoring for content-performance-manager uses port 3207
 content-performance-manager-publishing-api-consumer: govuk_setenv content-performance-manager ./run_in.sh ../../content-performance-manager bundle exec rake publishing_api:consumer
+content-performance-manager-bulk-import-publishing-api-consumer: govuk_setenv content-performance-manager ./run_in.sh ../../content-performance-manager bundle exec rake publishing_api:bulk_import_consumer
 content-performance-manager-sidekiq-google-analytics: govuk_setenv content-performance-manager ./run_in.sh ../../content-performance-manager bundle exec sidekiq -C ./config/sidekiq/google_analytics.yml
 content-performance-manager-sidekiq-publishing-api:  govuk_setenv content-performance-manager ./run_in.sh ../../content-performance-manager bundle exec sidekiq -C ./config/sidekiq/publishing_api.yml
 # sidekiq-monitoring for link-checker-api-sidekiq uses port 3209


### PR DESCRIPTION
The bulk import api consumer was not being started on the Dev VM, because we were calling `publishing-api-read` as a dependency for the CPM instead of `publishing-api`. The former does not have `publishing-api-worker` as a dependency itself but the latter does.