### PR TITLE
[WIP] Add a role for read-only access to CPM for data scientists

### DIFF
--- a/modules/govuk/manifests/apps/content_performance_manager/data_scientist_role.pp
+++ b/modules/govuk/manifests/apps/content_performance_manager/data_scientist_role.pp
@@ -1,0 +1,27 @@
+# FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
+class govuk::apps::content_performance_manager::data_scientist_role (
+  $password = '',
+  $rds = undef,
+  ){
+  $data_scientist_role = 'data_scientist'
+  $db           = 'content_performance_manager_production'
+
+  postgresql::server::role { $data_scientist_role:
+    password_hash => postgresql_password($data_scientist_role, $password),
+    rds           => $rds,
+  }
+
+  postgresql::server::database_grant { "${data_scientist_role} can connect to ${db}":
+    privilege => 'CONNECT',
+    db        => $db,
+    role      => $data_scientist_role,
+    require   => [Postgresql::Server::Role[$data_scientist_role], Class['govuk::apps::content_performance_manager::db']],
+  }
+
+  postgresql::server::grant { "${data_scientist_role} can SELECT from all tables in ${db}":
+    privilege   => 'SELECT',
+    object_type => 'ALL TABLES IN SCHEMA',
+    db          => $db,
+    role        => $data_scientist_role,
+  }
+}

--- a/modules/govuk/manifests/node/s_warehouse_db_admin.pp
+++ b/modules/govuk/manifests/node/s_warehouse_db_admin.pp
@@ -68,7 +68,10 @@ class govuk::node::s_warehouse_db_admin(
   class { '::govuk_postgresql::client': } ->
 
   # include all PostgreSQL classes that create databases and users
-  class { '::govuk::apps::content_performance_manager::db': }
+  class { '::govuk::apps::content_performance_manager::db': } ->
+
+  # Include the CPM Data Scientist Role class for its database permissions
+  class { '::govuk::apps::content_performance_manager::data_scientist_role': }
 
   $postgres_backup_desc = 'RDS Warehouse PostgreSQL backup to S3'
 

--- a/modules/govuk/manifests/node/s_warehouse_postgresql.pp
+++ b/modules/govuk/manifests/node/s_warehouse_postgresql.pp
@@ -15,6 +15,7 @@ class govuk::node::s_warehouse_postgresql (
   include govuk_postgresql::server::standalone
   include govuk_postgresql::tuning
   include govuk::apps::content_performance_manager::db
+  include govuk::apps::content_performance_manager::data_scientist_role
 
   govuk_postgresql::wal_e::backup { $title:
     aws_access_key_id                => $aws_access_key_id,


### PR DESCRIPTION
- They would like to have SELECT permissions on the
  content_performance_manager_production database in all environments.