### PR TITLE
Fix triggers on data warehouse jenkins job

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/content_performance_manager.pp
+++ b/modules/govuk_jenkins/manifests/jobs/content_performance_manager.pp
@@ -13,15 +13,16 @@ class govuk_jenkins::jobs::content_performance_manager (
   $rake_etl_master_process_cron_schedule = undef,
   $app_domain = hiera('app_domain'),
 ) {
+
+  $check_name = 'etl-data-warehouse'
+  $service_description = 'Data warehouse ETL'
+  $job_url = "https://deploy.${app_domain}/job/content_performance_manager_import_etl_master_process/"
+
   file { '/etc/jenkins_jobs/jobs/content_performance_manager.yaml':
     ensure  => present,
     content => template('govuk_jenkins/jobs/content_performance_manager.yaml.erb'),
     notify  => Exec['jenkins_jobs_update'],
   }
-
-  $check_name = 'etl-data-warehouse'
-  $service_description = 'Data warehouse ETL'
-  $job_url = "https://deploy.${app_domain}/job/content_performance_manager_import_etl_master_process/"
 
   if $rake_etl_master_process_cron_schedule {
     @@icinga::passive_check { "${check_name}_${::hostname}":


### PR DESCRIPTION
The $service_description parameter is being read as blank when the
template is rendered, which causes the success/fail passive check
jobs to be passed broken parameters. This results in freshness
threshold exceeded alerts for this job.

Make sure the variables are defined when declaring the template
resource.