### PR TITLE
AWS Elastic Cache Monitoring via Icinga

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1075,6 +1075,10 @@ monitoring::checks::smokey::features:
   check_whitehall:
     feature: whitehall
 
+monitoring::checks::cache::servers:
+  - 'blue-backend-redis-001'
+  - 'blue-backend-redis-002'
+
 monitoring::uptime_collector::aws: true
 
 # FIXME: this has been added to avoid a bug until we move to v3 of the module

--- a/modules/monitoring/files/etc/nagios3/conf.d/check_aws_cache_cpu.cfg
+++ b/modules/monitoring/files/etc/nagios3/conf.d/check_aws_cache_cpu.cfg
@@ -1,0 +1,4 @@
+define command {
+    command_name check_aws_cache_cpu
+    command_line /usr/lib/nagios/plugins/check_aws_cache_cpu -r $ARG1$ -w $ARG2$ -c $ARG3$ -i $ARG4$
+}

--- a/modules/monitoring/files/etc/nagios3/conf.d/check_aws_cache_memory.cfg
+++ b/modules/monitoring/files/etc/nagios3/conf.d/check_aws_cache_memory.cfg
@@ -1,0 +1,4 @@
+define command {
+    command_name check_aws_cache_memory
+    command_line /usr/lib/nagios/plugins/check_aws_cache_memory -r $ARG1$ -w $ARG2$ -c $ARG3$ -i $ARG4$
+}

--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_cache_cpu
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_cache_cpu
@@ -1,0 +1,211 @@
+#!/usr/bin/env python
+
+##########################################################
+# This script will cpture and report on AWS ElasticCache #
+# CPUUtilization         	                         #
+##########################################################
+
+###########################################################
+# Objective                                               #
+# ---------                                               #
+# This script performs the following steps.               #
+# 1) Check whether a valid AWS region is specified        #
+# 2) Check whether the redis instance ID provided exisits.#
+# 3) If 1 and 2 are correct, check whether the average    #
+#    CPUUtilization is in the WARNING or CRITICAL state.  #
+#    Else, mark the status as OK.                         #
+###########################################################
+
+#################################################################################################
+# How to use and test this script?                                            			#
+# --------------------------------                                            			#
+#                                                                             			#
+# This script takes input from the following file when it is used by icinga.  			#
+# /etc/icinga/conf.d/icinga_host_ip-10-2-5-245.eu-west-1.compute.internal/    			#
+# check_aws_cache_cpu.cfg                                                     			#
+#                                                                             			#
+# The script takes 4 input variables.                                         			#
+# 1) AWS Region. This is called with '-r'                                    			#
+# 2) Icinga warning value. This is called with '-w'                           			#
+# 3) Icinga critical vale. This is called with '-c'                           			#
+# 4) The AWS Redis Instance name. This is called with '-i'                    			#
+#                                                                             			#
+# Test                                                                        			#
+# ----                                                                        			#
+# You can test this script by following the steps below.                      			#
+#                                                                             			#
+# 1) Connect to the 'blue-monitoring' instance via ssh.                       			#
+# 2) Become root. (sudo -i)                                                   			#
+# 3) Change directory. (cd /usr/lib/nagios/plugins)                           			#
+# 4) Execute the script with manual input.                                    			#
+#    -r = eu-west-1  (Example AWS Staging region)                            			#
+#    -i = blue-backend-redis-001 (Example. This instance should be present)  			#
+#                                                                             			#
+#    python check_aws_cache_cpu -r eu-west-1 -i blue-backend-redis-001        			#
+#                                                                             			#
+#                                                                             			#
+# The result should look like the example below.                              			#
+# OK: Current AWS:ElasticCache CPU Utilization for blue-backend-redis-002 is 0.666759284986 %	#
+#################################################################################################
+
+####################
+# Imported modules #
+####################
+import sys
+import argparse
+import pprint
+import boto.rds
+import boto.elasticache
+import boto.ec2.cloudwatch
+import datetime
+
+#################################
+# Passing acceptable parameters #
+#################################
+parser = argparse.ArgumentParser()
+parser.add_argument("-r","--region", type=str, choices=['us-east-1','eu-west-1'], help="AWS region to check")
+parser.add_argument("-w","--warning", type=float, help="Percentage at which to raise a warning alert (80)", default=80)
+parser.add_argument("-c","--critical", type=float, help="Percentage at which to raise a critical alert (90)", default=90)
+parser.add_argument("-i","--instanceid", type=str, help="Instanceid", default=0)
+args = parser.parse_args()
+
+############################################
+# Check whether a region has been provided.#
+############################################
+if args.region is None:
+    print "UNKNOWN: You have not supplied a region to connect to!"
+    sys.exit(3)
+
+#########################################################
+# Initiate a connection to the AWS ElasticCache Cluster.#
+#########################################################
+elasticache = boto.elasticache.connect_to_region(args.region)
+
+#########################################################
+# Initiate a connection to the AWS ElasticCache Cluster.#
+#########################################################
+try:
+ cluster_info = elasticache.describe_cache_clusters(args.instanceid)
+except boto.exception.BotoServerError as err:
+ print "There was an error while initiating a connection to the Elastic Cache Cluster. Please check the error message below. [cluster_info = elasticache.describe_cache_clusters(args.instanceid)]",err
+ sys.exit(3)
+
+#################################################################################
+# Debug AWS ElasticCache Cluster Details.					#
+#################################################################################
+# To view the cluster and member details, uncomment the two lines below		#
+#										#
+# cluster_info = elasticache.describe_cache_clusters()[				#
+#                'DescribeCacheClustersResponse'][				#
+#                'DescribeCacheClustersResult'][				#
+#                'CacheClusters']						#
+# pprint.pprint(cluster_info)							#
+#										#
+# To view the details for a specific member, you can use index numbers. For 	#				
+# example [0] is will match the first member. To do this, uncomment the two 	#
+# lines below and replace the number to suit your need.				#
+#										#
+# cluster_info = elasticache.describe_cache_clusters()[                         #
+#                'DescribeCacheClustersResponse'][                              #
+#                'DescribeCacheClustersResult'][                                #
+#                'CacheClusters'][0]                                            #
+# pprint.pprint(cluster_info)                                                   #
+#################################################################################
+
+##########################################
+# Create a cloud watch connection client.#
+##########################################
+cw_conn = boto.ec2.cloudwatch.connect_to_region(args.region)
+
+###########################################################
+# Define start and end times                              #
+# Here we have give 5 minutes because that is the window  #
+# we are using to calculate the average.                  #
+# Note: The time should be in UTC format.                 #
+###########################################################
+start = datetime.datetime.now() - datetime.timedelta(seconds=300)
+end = datetime.datetime.now()
+
+
+#########################################################################################
+# Use the cloutwatch connection and get metrics.                        		#
+# ----------------------------------------------                        		#
+#                                                                       		#
+# 'data' - The results are captured in this variable. Type = object     		#
+# '300'  - This is the time slice that we are refering, when we ask for 		#
+#          the average value. This implies that "one output from AWS   		        #
+#          will cover 300 seconds (5 minutes)". This will match our     		#
+#          start and end times. This also mean that we will get "one"   		#
+#          output (very important. Nagios will only take one result)   		        #
+# 'start'- This will pass the start time.                               		#
+# 'end'  - This will pass the end time.                                 		#
+# 'CPUUtilization' - This is the matric that we are asking for from     		#
+#                    CloudWatch.                                        		#
+# 'AWS/AWS/ElastiCache' - This is the CloudWatch space/area where RDS stats reside. 	#
+# 'Average' - We are defining that we won't the average for the matric. 		#
+# 'CacheClusterId' - The unique identifier which we use to query. 			#
+#########################################################################################
+data = cw_conn.get_metric_statistics(
+   300,
+   start,
+   end,
+   'CPUUtilization',
+   'AWS/ElastiCache',
+   'Average',
+   {'CacheClusterId': [args.instanceid]},
+)
+
+##################################################################################################
+# Metrics                                                                                        #
+# -------                                                                                        #
+# There is a considerable amount of metrics available. You can vew them                          #
+# all by uncommenting the code segment below.                                                    #
+#                                                                                                #
+# metrics = cw_conn.list_metrics(dimensions={'CacheClusterId': [ args.instanceid ] }) 		 #
+# pprint.pprint(metrics)                                                                         #
+#                                                                                                #
+##################################################################################################
+
+#################################################################################
+# Metrics Debugging                                                             #
+# -----------------                                                             #
+# You might have a necessity to debug the output. The following might help.     #
+#                                                                               #
+# - If you wan't to view the raw output from the metrics query. Uncomment the   #
+#   line below.                                                                 #
+# pprint.pprint(data)                                                           #
+#                                                                               #
+#                                                                               #
+# - The result is actually an 'object'. This object has some built in metods.   #
+#   These methods are useful. For example you might have a 'get' metod that     #
+#   saves you some code. You can uncomment the line below and view all the      #
+#   methods and attributes.                                                     #
+# pprint.pprint(dir(data))                                                      #
+#################################################################################
+
+#########################################################################################################
+# Disect the result                                                                                     #
+# -----------------                                                                                     #
+# The result that we get is a 'list' of 'dictonary' elements. Hence, we will                            #
+# iterate over the list and get the first element. Then we will get the first value for "Average"       #
+# This will help us to get just one "Average", if the time slot returns two "Average" values.           #
+#########################################################################################################
+item = []
+item = data[0]
+average = item["Average"]
+
+#########################################################
+# Print the output                                     #
+# This is the final step. We do the following here.     #
+# 1) Change the average vale to 'float' type.           #
+# 2) Convert the defined value to 'float' type.         #
+# 3) Compare the check vs actual.                       #
+#########################################################
+if float(average) > args.critical:
+  print "CRITICAL: Current AWS:ElasticCache CPU Utilization for {} is {} %".format(args.instanceid, average)
+  sys.exit(2)
+elif float(average) > args.warning:
+  print "WARNING: Current AWS:ElasticCache CPU Utilization for {} is {} %".format(args.instanceid, average)
+  sys.exit(1)
+else:
+  print "OK: Current AWS:ElasticCache CPU Utilization for {} is {} %".format(args.instanceid, average)

--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_cache_memory
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_cache_memory
@@ -1,0 +1,214 @@
+#!/usr/bin/env python
+
+##########################################################
+# This script will cpture and report on AWS ElasticCache #
+# FreeableMemory         	                         #
+##########################################################
+
+###########################################################
+# Objective                                               #
+# ---------                                               #
+# This script performs the following steps.               #
+# 1) Check whether a valid AWS region is specified        #
+# 2) Check whether the redis instance ID provided exisits.#
+# 3) If 1 and 2 are correct, check whether the average    #
+#    FreeableMemory is in the WARNING or CRITICAL state.  #
+#    Else, mark the status as OK.                         #
+###########################################################
+
+###############################################################################
+# How to use and test this script?                                            #
+# --------------------------------                                            #
+#                                                                             #
+# This script takes input from the following file when it is used by icinga.  #
+# /etc/icinga/conf.d/icinga_host_ip-10-2-5-245.eu-west-1.compute.internal/    #
+# check_aws_cache_memory.cfg                                                  #
+#                                                                             #
+# The script takes 4 input variables.                                         #
+# 1) AWS Region. This is called with '-r'                                     #
+# 2) Icinga warning value. This is called with '-w'                           #
+# 3) Icinga critical vale. This is called with '-c'                           #
+# 4) The AWS Redis Instance name. This is called with '-i'                    #
+#                                                                             #
+# Test                                                                        #
+# ----                                                                        #
+# You can test this script by following the steps below.                      #
+#                                                                             #
+# 1) Connect to the 'blue-monitoring' instance via ssh.                       #
+# 2) Become root. (sudo -i)                                                   #
+# 3) Change directory. (cd /usr/lib/nagios/plugins)                           #
+# 4) Execute the script with manual input.                                    #
+#    -r = eu-west-1  (Example AWS Staging region)                             #
+#    -i = blue-backend-redis-001 (Example. This instance should be present)   #
+#                                                                             #
+#    python check_aws_cache_memory -r eu-west-1 -i blue-backend-redis-001     #
+#                                                                             #
+#                                                                             #
+# The result should look like the example below.                              #
+# OK: Current AWS:RDS CPU Utilization for blue-postgresql-primary is 0.4169%  #
+###############################################################################
+
+####################
+# Imported modules #
+####################
+import sys
+import argparse
+import pprint
+import boto.rds
+import boto.elasticache
+import boto.ec2.cloudwatch
+import datetime
+
+#################################
+# Passing acceptable parameters #
+#################################
+parser = argparse.ArgumentParser()
+parser.add_argument("-r","--region", type=str, choices=['us-east-1','eu-west-1'], help="AWS region to check")
+parser.add_argument("-w","--warning", type=float, help="Value(GB) at which to raise a warning alert (8.0)", default=8.0)
+parser.add_argument("-c","--critical", type=float, help="Value(GB) at which to raise a critical alert (9.0)", default=9.0)
+parser.add_argument("-i","--instanceid", type=str, help="Instanceid", default=0)
+args = parser.parse_args()
+
+############################################
+# Check whether a region has been provided.#
+############################################
+if args.region is None:
+    print "UNKNOWN: You have not supplied a region to connect to!"
+    sys.exit(3)
+
+#########################################################
+# Initiate a connection to the AWS ElasticCache Cluster.#
+#########################################################
+elasticache = boto.elasticache.connect_to_region(args.region)
+
+#########################################################
+# Initiate a connection to the AWS ElasticCache Cluster.#
+#########################################################
+try:
+ cluster_info = elasticache.describe_cache_clusters(args.instanceid)
+except boto.exception.BotoServerError as err:
+ print "There was an error while initiating a connection to the Elastic Cache Cluster. Please check the error message below. [cluster_info = elasticache.describe_cache_clusters(args.instanceid)]",err
+ sys.exit(3)
+
+#################################################################################
+# Debug AWS ElasticCache Cluster Details.					#
+#################################################################################
+# To view the cluster and member details, uncomment the two lines below		#
+#										#
+# cluster_info = elasticache.describe_cache_clusters()[				#
+#                'DescribeCacheClustersResponse'][				#
+#                'DescribeCacheClustersResult'][				#
+#                'CacheClusters']						#
+# pprint.pprint(cluster_info)							#
+#										#
+# To view the details for a specific member, you can use index numbers. For 	#				
+# example [0] is will match the first member. To do this, uncomment the two 	#
+# lines below and replace the number to suit your need.				#
+#										#
+# cluster_info = elasticache.describe_cache_clusters()[                         #
+#                'DescribeCacheClustersResponse'][                              #
+#                'DescribeCacheClustersResult'][                                #
+#                'CacheClusters'][0]                                            #
+# pprint.pprint(cluster_info)                                                   #
+#################################################################################
+
+##########################################
+# Create a cloud watch connection client.#
+##########################################
+cw_conn = boto.ec2.cloudwatch.connect_to_region(args.region)
+
+###########################################################
+# Define start and end times                              #
+# Here we have give 5 minutes because that is the window  #
+# we are using to calculate the average.                  #
+# Note: The time should be in UTC format.                 #
+###########################################################
+start = datetime.datetime.now() - datetime.timedelta(seconds=300)
+end = datetime.datetime.now()
+
+
+#########################################################################################
+# Use the cloutwatch connection and get metrics.                        		#
+# ----------------------------------------------                        		#
+#                                                                       		#
+# 'data' - The results are captured in this variable. Type = object     		#
+# '300'  - This is the time slice that we are refering, when we ask for 		#
+#          the average value. This implies that "one output from AWS   		#
+#          will cover 300 seconds (5 minutes)". This will match our     		#
+#          start and end times. This also mean that we will get "one"   		#
+#          output (very important. Nagios will only take one result)   		#
+# 'start'- This will pass the start time.                               		#
+# 'end'  - This will pass the end time.                                 		#
+# 'CPUUtilization' - This is the matric that we are asking for from     		#
+#                    CloudWatch.                                        		#
+# 'AWS/AWS/ElastiCache' - This is the CloudWatch space/area where RDS stats reside. 	#
+# 'Average' - We are defining that we won't the average for the matric. 		#
+# 'CacheClusterId' - The unique identifier which we use to query. 			#
+#########################################################################################
+data = cw_conn.get_metric_statistics(
+   300,
+   start,
+   end,
+   'FreeableMemory',
+   'AWS/ElastiCache',
+   'Average',
+   {'CacheClusterId': [args.instanceid]},
+)
+
+##################################################################################################
+# Metrics                                                                                        #
+# -------                                                                                        #
+# There is a considerable amount of metrics available. You can vew them                          #
+# all by uncommenting the code segment below.                                                    #
+#                                                                                                #
+# metrics = cw_conn.list_metrics(dimensions={'CacheClusterId': [ args.instanceid ] }) 		 #
+# pprint.pprint(metrics)                                                                         #
+#                                                                                                #
+##################################################################################################
+
+#################################################################################
+# Metrics Debugging                                                             #
+# -----------------                                                             #
+# You might have a necessity to debug the output. The following might help.    #
+#                                                                               #
+# - If you wan't to view the raw output from the metrics query. Uncomment the  #
+#   line below.                                                                 #
+# pprint.pprint(data)                                                           #
+#                                                                               #
+#                                                                               #
+# - The result is actually an 'object'. This object has some built in metods.   #
+#   These methods are useful. For example you might have a 'get' metod that     #
+#   saves you some code. You can uncomment the line below and view all the      #
+#   methods and attributes.                                                     #
+# pprint.pprint(dir(data))                                                      #
+#################################################################################
+
+#########################################################################################################
+# Disect the result                                                                                     #
+# -----------------                                                                                     #
+# The result that we get is a 'list' of 'dictonary' elements. Hence, we will                            #
+# iterate over the list and get the first element. Then we will get the first value for "Average"       #
+# This will help us to get just one "Average", if the time slot returns two "Average" values.           #
+#########################################################################################################
+item = []
+item = data[0]
+average = item["Average"]
+
+# Convert bytes to gigabytes.
+average = average_bytes / (1024 * 1024 * 1024)
+
+#########################################################
+# Print the output                                     #
+# This is the final step. We do the following here.     #
+# 1) Change the average vale to 'float' type.           #
+# 2) Convert the defined value to 'float' type.         #
+# 3) Compare the check vs actual.                       #
+#########################################################
+if float(average) > args.critical:
+  print "CRITICAL: Current AWS:ElasticCache FreeableMemory for {} is {} %".format(args.instanceid, average)
+  sys.exit(2)
+elif float(average) > args.warning:
+  print "WARNING: Current AWS:ElasticCache FreeableMemory for {} is {} %".format(args.instanceid, average)
+  sys.exit(1)
+else:
+  print "OK: Current AWS:ElasticCache FreeableMemory for {} is {} %".format(args.instanceid, average)

--- a/modules/monitoring/manifests/checks.pp
+++ b/modules/monitoring/manifests/checks.pp
@@ -19,6 +19,7 @@ class monitoring::checks (
   include monitoring::checks::ses
   include monitoring::checks::sidekiq
   include monitoring::checks::smokey
+  include monitoring::checks::cache
 
   $app_domain = hiera('app_domain')
 

--- a/modules/monitoring/manifests/checks/cache.pp
+++ b/modules/monitoring/manifests/checks/cache.pp
@@ -1,0 +1,38 @@
+# == Class: monitoring::checks::cache
+#
+# Nagios alerts for AWS Elastic Cache.
+#
+# === Parameters
+#
+# [*servers*]
+#   List of RDS instances.
+#
+class monitoring::checks::cache (
+      $enabled = true,
+      $servers = [],
+    ) {
+
+    icinga::plugin { 'check_aws_cache_cpu':
+        source  => 'puppet:///modules/monitoring/usr/lib/nagios/plugins/check_aws_cache_cpu',
+        require => Package['boto'],
+    }
+
+    icinga::check_config { 'check_aws_cache_cpu':
+        source  => 'puppet:///modules/monitoring/etc/nagios3/conf.d/check_aws_cache_cpu.cfg',
+        require => File['/usr/lib/nagios/plugins/check_aws_cache_cpu'],
+    }
+
+    icinga::plugin { 'check_aws_cache_memory':
+        source  => 'puppet:///modules/monitoring/usr/lib/nagios/plugins/check_aws_cache_memory',
+        require => Package['boto'],
+    }
+
+    icinga::check_config { 'check_aws_cache_memory':
+        source  => 'puppet:///modules/monitoring/etc/nagios3/conf.d/check_aws_cache_memory.cfg',
+        require => File['/usr/lib/nagios/plugins/check_aws_cache_memory'],
+    }
+
+    if $enabled {
+      monitoring::checks::cache_config { $servers: }
+    }
+}

--- a/modules/monitoring/manifests/checks/cache_config.pp
+++ b/modules/monitoring/manifests/checks/cache_config.pp
@@ -1,0 +1,49 @@
+# == Define: monitoring::checks::cache_config
+#
+# Nagios alert config for AWS Elastic Cache.
+#
+# === Parameters
+#
+# [*region*]
+#   Which AWS region should be checked ['us-east-1','eu-west-1']
+#
+# [*enabled*]
+#   Should we enable the monitoring check?
+#
+# [*cpu_warning*]
+#  This parameter defines the CPU usage percentage at which a warning is raised. 
+#
+# [*critical*]
+#  This parameter defines the CPU usage percentage at which a critcal alert is raised.
+#
+# [*memory_warning]
+#  This parameter defines the amount of free memory in Gigabytes for which a warning alert will be raised.
+#
+# [*memory_critical]
+#  This parameter defines the amount of free memory in Gigabytes for which a critical alert will be raised. 
+#
+define monitoring::checks::cache_config (
+  $region = undef,
+  $cpu_warning = 80,
+  $cpu_critical = 90,
+  $memory_warning = 5,
+  $memory_critical = 2,
+  ){
+  icinga::check { "check_aws_cache_cpu-${title}":
+    check_command       => "check_aws_cache_cpu!${region}!${cpu_warning}!${cpu_critical}!${::aws_stackname}-${title}",
+    use                 => 'govuk_urgent_priority',
+    host_name           => $::fqdn,
+    service_description => 'AWS ElasticCache CPU Utilization',
+    notes_url           => monitoring_docs_url(aws-cache-cpu),
+    require             => Icinga::Check_config['check_aws_cache_cpu'],
+  }
+
+  icinga::check { "check_aws_cache_memory-${title}":
+    check_command       => "check_aws_cache_memory!${region}!${memory_warning}!${memory_critical}!${::aws_stackname}-${title}",
+    use                 => 'govuk_urgent_priority',
+    host_name           => $::fqdn,
+    service_description => 'AWS ElasticCache Memory Utilization',
+    notes_url           => monitoring_docs_url(aws-cache-memory),
+    require             => Icinga::Check_config['check_aws_cache_memory'],
+  }
+}


### PR DESCRIPTION
- We have a requirement to monitor AWS Elastic Cache instances via the current
monitoring system (Icinga). We have made few changes to accomplish this
objective.

- We have created check scripts as plugins. These have been placed
inside 'modules/monitoring/files/usr/lib/nagios/plugins/'.

- We have created config files that will translate into the actual
command and parameters. This has been placed inside 'modules/monitoring/files/etc/nagios3/conf.d/'.

- We have created a new class called 'monitoring::checks::cache' to create
the necessary files in the monitoring instance. This resides inside 'modules/monitoring/manifests/checks/cache.pp'.

- We have enabled the class by calling it at 'modules/monitoring/manifests/checks.pp'.

- We have specified the server names in 'hieradata_aws/common.yaml'.

https://trello.com/c/C7SY8edZ/1123-monitor-rds-and-elasticache-in-aws-and-alert-icinga

Pair: @suthagarht @szd55gds