### PR TITLE
Docker cleanup tweaking

### DIFF
--- a/modules/govuk_ci/manifests/agent/docker.pp
+++ b/modules/govuk_ci/manifests/agent/docker.pp
@@ -15,14 +15,6 @@ class govuk_ci::agent::docker {
     version => '1.17.1',
   }
 
-  # TODO: remove this once the file has been purged
-  cron::crondotdee { 'docker_system_prune' :
-    ensure  => 'absent',
-    hour    => '*/2',
-    minute  => 0,
-    command => 'docker system prune -a -f --filter="until=24h"',
-  }
-
   cron::crondotdee { 'docker_system_prune_dangling' :
     hour    => '*',
     minute  => 0,

--- a/modules/govuk_ci/manifests/agent/docker.pp
+++ b/modules/govuk_ci/manifests/agent/docker.pp
@@ -23,7 +23,7 @@ class govuk_ci::agent::docker {
 
   cron::crondotdee { 'docker_system_prune_all' :
     hour    => 4,
-    minute  => 0,
+    minute  => 30,
     command => 'docker system prune -a -f --filter="until=48h"',
   }
 


### PR DESCRIPTION
This changes the prune command to run half an hour after the other clean command so we don't have two prune commands running at the same time. As that just stops one with this output "Error response from daemon: a prune operation is already running"

It also removes an old absent file.