### PR TITLE
Change fqdn_metrics and install cron job to clean up whisper data

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -292,6 +292,9 @@ collectd::plugin::tcp::metrics:
   - 'ActiveOpens'
   - 'PassiveOpens'
 
+collectd::package::collectd_version: '5.6.0-0.1~pl5~trusty1'
+collectd::package::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+
 duplicity::packages::version: '0.7.11-0ubuntu0ppa1263~ubuntu14.04.1'
 
 environment_ip_prefix: '10.1'

--- a/modules/collectd/manifests/package.pp
+++ b/modules/collectd/manifests/package.pp
@@ -10,12 +10,24 @@
 # [*yajl_package*]
 #   The libyajl (Yet Another JSON Library) package to install.
 #
+# [*apt_mirror_hostname*]
+#   The hostname of the local aptly mirror.
+#
 class collectd::package (
   $collectd_version = '5.4.0-3ubuntu2',
   $yajl_package = 'libyajl2',
+  $apt_mirror_hostname = 'apt.production.alphagov.co.uk',
+
 ) {
   include govuk_ppa
 
+  apt::source { 'collectd':
+    ensure       => present,
+    location     => "http://${apt_mirror_hostname}/collectd",
+    release      => $::lsbdistcodename,
+    architecture => $::architecture,
+    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+  }
   # collectd contains only configuration files, which we're overriding anyway
   package { 'collectd':
     ensure => purged,
@@ -23,7 +35,7 @@ class collectd::package (
   # collectd-core contains collectd itself, and all the compiled plugins
   package { 'collectd-core':
     ensure  => $collectd_version,
-    require => Package['collectd'],
+    require => [ Apt::Source['collectd'], Package['collectd'] ],
   }
   package { $yajl_package:
     ensure => present,

--- a/modules/collectd/templates/etc/collectd/collectd.conf.erb
+++ b/modules/collectd/templates/etc/collectd/collectd.conf.erb
@@ -6,11 +6,7 @@
 # You should also read /usr/share/doc/collectd-core/README.Debian.plugins
 # before enabling any more plugins.
 
-<% if scope.lookupvar('::aws_migration') -%>
-Hostname "<%= scope.lookupvar('::govuk_node_class') %>-<%= @fqdn %>"
-<% else -%>
 Hostname "<%= @fqdn_metrics %>"
-<% end -%>
 FQDNLookup false
 #BaseDir "/var/lib/collectd"
 #PluginDir "/usr/lib/collectd"

--- a/modules/govuk/lib/facter/fqdn_metrics.rb
+++ b/modules/govuk/lib/facter/fqdn_metrics.rb
@@ -7,7 +7,7 @@ Facter.add("fqdn_metrics") do
     if Facter.value("aws_migration").nil?
       fqdn_metrics = Facter.value("fqdn_short").dup
     else
-      fqdn_metrics = "#{Facter.value(:aws_hostname)}.#{Facter.value(:aws_stackname)}.#{Facter.value(:aws_environment)}"
+      fqdn_metrics = "#{Facter.value(:aws_migration)}-#{Facter.value('fqdn')}"
     end
 
     fqdn_metrics.gsub!(/\./, '_')

--- a/modules/govuk/manifests/node/s_apt.pp
+++ b/modules/govuk/manifests/node/s_apt.pp
@@ -128,6 +128,7 @@ class govuk::node::s_apt (
       key      => 'D27A72F32D867DF9300A241574490FD6EC51E8C4';
   }
 
+  aptly::repo { 'collectd': }
   aptly::repo { 'elastic-beats': }
   aptly::repo { 'etcdctl': }
   aptly::repo { 'gof3r': }

--- a/modules/govuk/manifests/node/s_graphite.pp
+++ b/modules/govuk/manifests/node/s_graphite.pp
@@ -98,6 +98,15 @@ class govuk::node::s_graphite (
     extra_config => $cors_headers,
   }
 
+  ## The way we generate graphite data with changing hostnames in AWS require a bit of clean up
+  if $::aws_migration {
+    file { '/etc/cron.daily/remove_old_whisper_data':
+      ensure  => present,
+      content => template('govuk/node/s_graphite/remove_old_whisper_data.erb'),
+      mode    => '0755',
+    }
+  }
+
   ## Backing up whisper database directly to S3 using the whisper-backup script
   if $::aws_migration {
     apt::source { 'whisper-backup':

--- a/modules/govuk/templates/node/s_graphite/remove_old_whisper_data.erb
+++ b/modules/govuk/templates/node/s_graphite/remove_old_whisper_data.erb
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+WHISPER_DIR='<%= @graphite_path %>/storage/whisper'
+
+for dir in $(ls $WHISPER_DIR); do
+  if [[ -z "$(find $WHISPER_DIR/$dir -mtime -14 )" && $? -eq 0 ]] ; then
+    if [[ ! -z $WHISPER_DIR && ! -z $dir ]] ; then
+      rm -fr $WHISPER_DIR/$dir;
+    fi
+  fi
+done


### PR DESCRIPTION
We change fqdn_metrics when on AWS to be in the format class-ip so that things are better organised in graphite, making the change at the variable definition level prevents problems we had in other places.
We also add a cron job to do a daily clean up of the whisper data, as the ever changing hostnames of the aws machines means we're left with useless leftover data