### PR TITLE
AWS GOV.UK Synchronize Data from Production to Integration

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/copy_data_to_aws_integration.pp
+++ b/modules/govuk_jenkins/manifests/jobs/copy_data_to_aws_integration.pp
@@ -1,0 +1,33 @@
+# == Class: govuk_jenkins::jobs::copy_data_to_aws_integration
+#
+# Create a file on disk that can be parsed by jenkins-job-builder
+#
+class govuk_jenkins::jobs::copy_data_to_aws_integration (
+  $ci_alphagov_api_key = undef,
+  $auth_token = undef,
+  $enable_slack_notifications = true,
+  $app_domain = hiera('app_domain'),
+) {
+
+  $check_name = 'copy_data_to_aws_integration'
+  $service_description = 'Copy Data to AWS Integration'
+  $job_url = "https://deploy.${app_domain}/job/copy_data_to_integration"
+
+  $slack_team_domain = 'gds'
+  $slack_room = 'govuk-2ndline'
+  $slack_build_server_url = "https://deploy.${app_domain}/"
+
+  file { '/etc/jenkins_jobs/jobs/copy_data_to_aws_integration.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/copy_data_to_aws_integration.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+
+  @@icinga::passive_check { "${check_name}_${::hostname}":
+    service_description => $service_description,
+    host_name           => $::fqdn,
+    freshness_threshold => 115200,
+    action_url          => $job_url,
+    notes_url           => monitoring_docs_url(data-sync),
+  }
+}

--- a/modules/govuk_jenkins/spec/classes/govuk_jenkins__jobs__each_spec.rb
+++ b/modules/govuk_jenkins/spec/classes/govuk_jenkins__jobs__each_spec.rb
@@ -11,6 +11,7 @@ BROKEN_SPECS = %w[
   copy_attachments_to_integration.pp
   copy_attachments_to_staging.pp
   copy_data_to_integration.pp
+  copy_data_to_aws_integration.pp
   copy_data_to_staging.pp
   deploy_cdn.pp
   deploy_puppet.pp

--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_aws_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_aws_integration.yaml.erb
@@ -1,0 +1,93 @@
+---
+- scm:
+    name: govuk-env-sync_Copy_Data_to_AWS_Integration
+    scm:
+        - git:
+            url: git@github.com:alphagov/govuk-env-sync.git
+            branches:
+              - master
+
+- job:
+    name: Copy_Data_to_AWS_Integration
+    display-name: Copy_Data_to_AWS_Integration
+    project-type: freestyle
+    description: |
+        This job copies databases from production S3 database backup bucket to integration. It runs periodically
+        to keep the integration environment up to date. The signon database isn't copied.
+    properties:
+        - github:
+            url: https://github.com/alphagov/govuk-env-sync/
+        - inject:
+            properties-content: |
+              PARALLEL_JOBS=3
+        - build-discarder:
+            days-to-keep: 30
+            artifact-num-to-keep: 5
+    scm:
+      - govuk-env-sync_Copy_Data_to_Integration
+    logrotate:
+        numToKeep: 10
+    triggers:
+        - timed: |
+            TZ=Europe/London
+            H 3 * * 1-5
+    builders:
+        - shell: |
+            set -eu
+            cd "${WORKSPACE}"
+            echo "Syncing data"
+    publishers:
+      - trigger-parameterized-builds:
+        - project: Success_Passive_Check
+          condition: 'SUCCESS'
+          predefined-parameters: |
+            NSCA_CHECK_DESCRIPTION=<%= @service_description %>
+            NSCA_OUTPUT=<%= @service_description %> success
+        - project: Failure_Passive_Check
+          condition: 'FAILED'
+          predefined-parameters: |
+            NSCA_CHECK_DESCRIPTION=<%= @service_description %>
+            NSCA_OUTPUT=<%= @service_description %> failed
+        - project: trigger_data_sync_complete
+          condition: 'ALWAYS'
+          predefined-parameters: |
+            HOSTNAME=deploy.integration.publishing.service.gov.uk
+            API_KEY=<%= @ci_alphagov_api_key %>
+            AUTH_TOKEN=<%= @auth_token %>
+      <% if @enable_slack_notifications %>
+      - slack:
+          team-domain: <%= @slack_team_domain %>
+          auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN']%>
+          build-server-url: <%= @slack_build_server_url %>
+          notify-start: false
+          notify-success: true
+          notify-aborted: true
+          notify-notbuilt: true
+          notify-unstable: false
+          notify-failure: true
+          notify-backtonormal: false
+          notify-repeatedfailure: false
+          include-test-summary: false
+          room: <%= @slack_room %>
+      <% end %>
+    wrappers:
+        - ansicolor:
+            colormap: xterm
+        - timestamps
+    parameters:
+        - choice:
+            name: JOBLIST
+            description: 'Choose the thing to sync. All is the default, but some jobs may run but not do anything due to your config for the destination environment.'
+            choices:
+                - all
+                - assets
+                - elasticsearch-rummager
+                - mongo-api
+                - mongo-exceptions
+                - mongo-licensify
+                - mongo-normal
+                - mongo-router
+                - mysql-normal
+                - postgresql-backend
+                - postgresql-transition
+                - postgresql-warehouse


### PR DESCRIPTION
- We in the process of creating a new jenkins job that will copy
database backups stored in the production S3 database backup bucket to
the target environment.

- The actual script that will perform the task will be built in to
https://github.com/alphagov/govuk-env-sync/. This part is still in
progress https://github.com/alphagov/govuk-env-sync/pull/2.

- The current change will create a Jenkins job, without the mechanism.

https://trello.com/c/3LnSFoVo/1199-create-jenkins-job-definition-in-puppet-to-allow-us-to-run-the-new-code

Pair: @suthagarht @szd55gds