### PR TITLE
Improve the throughput metric for the Publishing API

### DIFF
--- a/modules/grafana/files/dashboards/publishing_api_worker_speed_and_throughput.json
+++ b/modules/grafana/files/dashboards/publishing_api_worker_speed_and_throughput.json
@@ -227,7 +227,7 @@
           "targets": [
             {
               "refId": "A",
-              "target": "derivative(integral(groupByNode(stats.timers.*.app.publishing-api.*.workers.*.processing_time.count, 7, 'sum')))"
+              "target": "perSecond(integral(groupByNode(stats.timers.*.app.publishing-api.*.workers.*.processing_time.count, 7, 'sum')))"
             }
           ],
           "thresholds": [],
@@ -250,7 +250,7 @@
           },
           "yaxes": [
             {
-              "format": "short",
+              "format": "ops",
               "label": null,
               "logBase": 1,
               "max": null,


### PR DESCRIPTION
The previous use of derivative was the right idea, but the number that
comes out changed as the time interval changed (e.g. in
Grafana). Using perSecond results in a value which is more stable, and
hopefully the graph now actually represents the throughput per second.