### PR TITLE
Reorder AWS CLI arguments

### DIFF
--- a/modules/mongodb/templates/mongodump-to-s3.erb
+++ b/modules/mongodb/templates/mongodump-to-s3.erb
@@ -78,7 +78,7 @@ if [ "${my_name}" == "${secondary}" ]
   tar -zcvf <%= @backup_dir -%>/mongodump.tgz <%= @backup_dir -%>/mongodump
 
   echo "Uploading mongodump to S3"
-  $AWS s3 --quiet --region <%= @aws_region -%> cp --sse <%= @backup_dir -%>/mongodump.tgz s3://<%= @bucket -%>/${BUCKET_KEY}/mongodump-$(date +%F_%H%M).tgz
+  $AWS s3 --quiet --region <%= @aws_region -%> cp <%= @backup_dir -%>/mongodump.tgz s3://<%= @bucket -%>/${BUCKET_KEY}/mongodump-$(date +%F_%H%M).tgz --sse
 
   echo "Completed successfully"
   NAGIOS_CODE=0


### PR DESCRIPTION
Move the `--sse` argument to `aws s3 cp` to the end of the command (after the positional args).

Reason: the `--sse` option in newer versions of the AWS CLI accept an optional encryption type. This means it must be given at the end of the argument list, as there would be an ambiguity between the encryption type and the positional argument that followed (the source file for thecopy, in this case).