### PR TITLE
Serve staging whitehall assets from asset-manager

### DIFF
--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -522,5 +522,10 @@ router::nginx::robotstxt: |
   User-agent: *
   Disallow: /
 
+router::assets_origin::whitehall_uploaded_assets_routes:
+  - '/government/placeholder'
+  - '~ ^/government/uploads/system/uploads/attachment_data/file/[0-9]+/.*/preview$'
+  - '/government/uploads/uploaded/hmrc/'
+
 mongodb::s3backup::backup::s3_bucket: 'govuk-mongodb-backup-s3-staging'
 mongodb::s3backup::backup::s3_bucket_daily: 'govuk-mongodb-backup-s3-daily-staging'

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -527,5 +527,9 @@ router::assets_origin::whitehall_uploaded_assets_routes:
   - '~ ^/government/uploads/system/uploads/attachment_data/file/[0-9]+/.*/preview$'
   - '/government/uploads/uploaded/hmrc/'
 
+# Note: we should remove this (inline it into conditionals) when we
+# apply it to production.
+router::assets_origin::use_new_consultation_response_form_redirect: true
+
 mongodb::s3backup::backup::s3_bucket: 'govuk-mongodb-backup-s3-staging'
 mongodb::s3backup::backup::s3_bucket_daily: 'govuk-mongodb-backup-s3-daily-staging'

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1098,6 +1098,10 @@ router::assets_origin::app_specific_static_asset_routes:
   '/service-manual-frontend/': "service-manual-frontend"
   '/smartanswers/': "smartanswers"
 
+# Note: we should remove this (inline it into conditionals) when we
+# apply it to production.
+router::assets_origin::use_new_consultation_response_form_redirect: true
+
 router::assets_origin::whitehall_uploaded_assets_routes:
   - '/government/placeholder'
   - '~ ^/government/uploads/system/uploads/attachment_data/file/[0-9]+/.*/preview$'

--- a/modules/router/manifests/assets_origin.pp
+++ b/modules/router/manifests/assets_origin.pp
@@ -23,6 +23,10 @@
 # [*vhost_name*]
 #   Primary vhost that assets should be served on at origin
 #
+# [*use_new_consultation_response_form_redirect*]
+#   Whether to directly redirect consultation forms or not.  Whitehall
+#   currently does this, but will not after we merge all the changes.
+#
 class router::assets_origin(
   $app_specific_static_asset_routes = {},
   $asset_manager_uploaded_assets_routes = [],
@@ -30,6 +34,7 @@ class router::assets_origin(
   $real_ip_header = '',
   $vhost_aliases = [],
   $vhost_name = 'assets-origin',
+  $use_new_consultation_response_form_redirect = false,
 ) {
   validate_array($vhost_aliases)
 

--- a/modules/router/templates/assets_origin.conf.erb
+++ b/modules/router/templates/assets_origin.conf.erb
@@ -41,7 +41,7 @@ server {
   add_header "Access-Control-Allow-Methods" "GET, OPTIONS";
   add_header "Access-Control-Allow-Headers" "origin, authorization";
 
-  <%- if scope.lookupvar('::aws_migration') %>
+  <%- if @use_new_consultation_response_form_redirect %>
     location /government/uploads/system/uploads/consultation_response_form/ {
       add_header Cache-Control "public";
       expires 1y;


### PR DESCRIPTION
I'm assuming here that the staging hieradata will override the common hieradata, as both define `router::assets_origin::whitehall_uploaded_assets_routes` - is that right?

---

#7648, but for staging.  Part of #7420.