### PR TITLE
Deploy_Node_Apps - Release Tag [WIP]

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
@@ -32,6 +32,13 @@
               export GIT_ORIGIN_PREFIX="git@gitlab.com:govuk"
             fi
 
+            if [ "$TYPE" == "deploy_node_app" ]; then
+              export BRANCH_TAG=$(git ls-remote ${GIT_ORIGIN_PREFIX="git@github.com:alphagov"}/"${TARGET_APPLICATION}".git deployed-to-"<%= @environment -%>" | awk {'print $1'})
+              export RELEASE_VERSION="$BRANCH_TAG"
+            else
+              export RELEASE_VERSION="$TAG"
+            fi
+
             git clone ${GIT_ORIGIN_PREFIX="git@github.com:alphagov"}/govuk-app-deployment.git --branch master --single-branch --depth 1 ./
             ./jenkins.sh
     publishers:
@@ -50,7 +57,7 @@
         - ansicolor:
             colormap: xterm
         - build-name:
-            name: '${ENV,var="TARGET_APPLICATION"} ${ENV,var="TAG"}'
+            name: '${ENV,var="TARGET_APPLICATION"} ${ENV,var="RELEASE_VERSION"}'
         - build-user-vars
         - credentials-binding:
             - username-password-separated:
@@ -84,6 +91,15 @@
             name: TAG
             description: Git tag/committish to deploy.
             default: release
+        - string:
+            name: TYPE
+            description: Define whether this is a Node_App_Deploy job triggered task. 
+        - string:
+            name: BRANCH_TAG
+            description: Define the branch tag (latest).
+        - string:
+            name: RELEASE_VERSION
+            description: Define the build release version..
         - bool:
             name: DEPLOY_FROM_GITLAB
             default: false

--- a/modules/govuk_jenkins/templates/node_app_deploy.xml.erb
+++ b/modules/govuk_jenkins/templates/node_app_deploy.xml.erb
@@ -27,6 +27,7 @@
           <configs>
             <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
               <properties>TARGET_APPLICATION=<%= app %>
+TYPE=deploy_node_app
 DEPLOY_TASK=deploy:without_migrations
 TAG=deployed-to-<%= @environment -%></properties>
             </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>


### PR DESCRIPTION
- The Deploy_Node_Apps triggers the Deploy_Apps jenkins job. The
deployment happens from a branch for the related application (for
example deployed-to-{environment}).

- The above mentioned process means that the "signon" web interface will
show a release name like "deployed-to-{environment}". The is a generic
name that can't be matched to a release tag.

- The change attempts to indicate the release version/tag.

https://trello.com/c/7TuoLXtJ/1193-l-replace-deployed-to-x-branch-with-release-tag-in-deploy-apps

Solo: @suthagarht