### PR TITLE
Use ci-agent-4 for postgresql 9.6 only

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -814,16 +814,16 @@ govuk_ci::master::pipeline_jobs:
 govuk_ci::master::ci_agents:
   ci-agent-1:
     agent_hostname: 'ci-agent-1.ci'
-    labels: 'mongodb-2.4 ci-agent-1 elasticsearch-2.4 terraform-0.8.1'
+    labels: 'mongodb-2.4 ci-agent-1 elasticsearch-2.4 terraform-0.8.1 postgresql-9.3'
   ci-agent-2:
     agent_hostname: 'ci-agent-2.ci'
-    labels: 'mongodb-2.4 ci-agent-2 elasticsearch-2.4 terraform'
+    labels: 'mongodb-2.4 ci-agent-2 elasticsearch-2.4 terraform postgresql-9.3'
   ci-agent-3:
     agent_hostname: 'ci-agent-3.ci'
-    labels: 'mongodb-2.4 ci-agent-3 elasticsearch-2.4 terraform'
+    labels: 'mongodb-2.4 ci-agent-3 elasticsearch-2.4 terraform postgresql-9.3'
   ci-agent-4:
     agent_hostname: 'ci-agent-4.ci'
-    labels: 'mongodb-3.2 ci-agent-4 elasticsearch-2.4 terraform'
+    labels: 'mongodb-3.2 ci-agent-4 elasticsearch-2.4 terraform postgresql-9.6'
   ci-agent-5:
     agent_hostname: 'ci-agent-5.ci'
     exclusive: true

--- a/hieradata/node/ci-agent-4.ci.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/ci-agent-4.ci.integration.publishing.service.gov.uk.yaml
@@ -1,0 +1,3 @@
+---
+
+postgresql::globals::version: '9.6'


### PR DESCRIPTION
This is needed for the Data Warehouse tests.

I'll go and update Jenkinsfiles for Postgres apps to use the correct node label.