### PR TITLE
Use default (json-file) log driver with Docker

### DIFF
--- a/modules/govuk_docker/manifests/init.pp
+++ b/modules/govuk_docker/manifests/init.pp
@@ -25,7 +25,6 @@ class govuk_docker (
     docker_users                => $docker_users,
     use_upstream_package_source => false,
     version                     => $version,
-    log_driver                  => 'syslog',
   }
 
   package { 'ctop':


### PR DESCRIPTION
Trello: https://trello.com/c/U9nNDFrH/222-decide-on-whether-e2e-tests-should-include-email-alert-api-following-on-from-content-tagger-work

In [#7588][7588-pr] the docker configuration was changed to use syslog
everywhere, unfortunately this limits a feature of our primary use of
docker e2e tests.

This change to default driver is to resolve the issue where our docker
log outputs say:

```
Attaching to ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_publishing-e2e-tests_1, ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_contacts-admin_1, ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_manuals-publisher_1, ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_publisher_1, ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_whitehall-admin_1, ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_draft-whitehall-frontend_1, ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_travel-advice-publisher_1, ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_frontend_1, ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_collections_1, ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_whitehall-frontend_1, ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_calendars_1, ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_draft-collections_1, ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_draft-frontend_1, ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_collections-publisher_1, ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_finder-frontend_1, ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_rummager_1, ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_rummager-worker_1, ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_manuals-publisher-worker_1, ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_collections-publisher-worker_1, ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_content-tagger_1, ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_travel-advice-publisher-worker_1, ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_publisher-worker_1, ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_specialist-publisher_1, ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_publishing-api_1, ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_manuals-frontend_1, ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_government-frontend_1, ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_publishing-api-worker_1, ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_draft-government-frontend_1, ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_draft-manuals-frontend_1, ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_content-store_1, ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_draft-content-store_1, ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_email-alert-service_1, ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_draft-router-api_1, ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_router-api_1, ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_asset-manager_1, ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_email-alert-api_1, ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_router_1, ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_whitehall-worker_1, ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_draft-router_1, ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_rummager-listener-publishing-queue_1, ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_rummager-listener-bulk-insert-data_1, ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_content-tagger-worker_1, ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_draft-static_1, ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_asset-manager-worker_1, ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_email-alert-api-worker_1, ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_rummager-listener-insert-data_1, ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_static_1, ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_diet-error-handler_1, ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_nginx-proxy_1, ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_memcached_1, ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_mysql_1, ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_elasticsearch_1, ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_postgres_1, ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_rabbitmq_1, ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_redis_1, ge2etestsemailalertapikeqm34ykudq6dkxvkj3gzntvchifa7m33yzy7xzje73msxyscqla_mongo_1
[31;1masset-manager_1                       |[0m WARNING: no logs are available with the 'syslog' log driver
[31;1mcalendars_1                           |[0m WARNING: no logs are available with the 'syslog' log driver
[31;1mspecialist-publisher_1                |[0m WARNING: no logs are available with the 'syslog' log driver
[31;1mstatic_1                              |[0m WARNING: no logs are available with the 'syslog' log driver
```

[7588-pr]: https://github.com/alphagov/govuk-puppet/pull/7588/files#diff-a4dd6279fa42a84a6aa506b07e1b7b85L24