### PR TITLE
Install an up to date AWS CLI

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -672,6 +672,8 @@ govuk::apps::transition::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::travel_advice_publisher::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::travel_advice_publisher::redis_port: "%{hiera('sidekiq_port')}"
 
+govuk_awscli::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+
 govuk_beat::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 govuk_ci::agent::gcloud::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -668,6 +668,8 @@ govuk::apps::transition::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::travel_advice_publisher::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::travel_advice_publisher::redis_port: "%{hiera('sidekiq_port')}"
 
+govuk_awscli::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+
 govuk::apps::content_audit_tool::db::rds: true
 govuk::apps::content_performance_manager::db::rds: true
 govuk::apps::content_tagger::db::rds: true

--- a/modules/base/manifests/init.pp
+++ b/modules/base/manifests/init.pp
@@ -20,6 +20,7 @@ class base {
   include govuk_sshkeys
   include govuk_sudo
   include govuk_unattended_reboot
+  include govuk_awscli
   include logrotate
   include ntp
   include puppet

--- a/modules/govuk/manifests/apps/asset_env_sync.pp
+++ b/modules/govuk/manifests/apps/asset_env_sync.pp
@@ -21,10 +21,7 @@ class govuk::apps::asset_env_sync(
   $app_name = 'asset-env-sync'
 
   if $enabled {
-    package { 'awscli':
-      ensure   => 'present',
-      provider => 'pip',
-    }
+    require '::govuk_awscli'
 
     # Ensure config dir exists
     file { "/etc/govuk/${app_name}":

--- a/modules/govuk_awscli/manifests/init.pp
+++ b/modules/govuk_awscli/manifests/init.pp
@@ -1,3 +1,12 @@
+# == Class: govuk_awscli
+#
+# Installs the Apt repo for the AWS CLI, and installs the AWS CLI from the Apt repo
+#
+# === Parameters:
+#
+# [*apt_mirror_hostname*]
+#   The hostname of the Apt mirror containing the awscli repo
+#
 class govuk_awscli (
   $apt_mirror_hostname,
 )

--- a/modules/govuk_awscli/manifests/init.pp
+++ b/modules/govuk_awscli/manifests/init.pp
@@ -1,0 +1,17 @@
+class govuk_awscli (
+  $apt_mirror_hostname,
+)
+{
+  apt::source { 'awscli':
+    ensure       => present,
+    location     => "http://${apt_mirror_hostname}/awscli",
+    release      => $::lsbdistcodename,
+    architecture => $::architecture,
+    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+  }
+
+  package { 'awscli':
+    ensure  => latest,
+    require => Apt::Source['awscli'],
+  }
+}

--- a/modules/govuk_mysql/manifests/xtrabackup/packages.pp
+++ b/modules/govuk_mysql/manifests/xtrabackup/packages.pp
@@ -8,12 +8,14 @@
 class govuk_mysql::xtrabackup::packages (
   $apt_mirror_hostname  = '',
 ) {
+  require '::govuk_awscli'
+
   package { 'xtrabackup':
     ensure  => present,
     require => Class[Mysql::Server],
   }
 
-  package { ['s3cmd', 'awscli']:
+  package { 's3cmd':
     ensure   => 'present',
     provider => 'pip',
   }

--- a/spec/fixtures/hieradata/common.yaml
+++ b/spec/fixtures/hieradata/common.yaml
@@ -28,6 +28,8 @@ govuk_app_enable_services: false
 govuk_cdnlogs::govuk_monitoring_enabled: false
 govuk_cdnlogs::bouncer_monitoring_enabled: false
 
+govuk_awscli::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+
 govuk_jenkins::package::apt_mirror_hostname: 'apt.example.com'
 
 govuk_jenkins::config::github_api_uri: foo


### PR DESCRIPTION
Install the AWS CLI from Apt as part of the base node configuration. Remove duplicate declarations of the package that use Pip to install the AWS CLI.

There are no usages of the AWS CLI in this codebase that would be broken by the upgrade.