### PR TITLE
Don't install govuk_awscli on precise

### DIFF
--- a/modules/base/manifests/init.pp
+++ b/modules/base/manifests/init.pp
@@ -20,7 +20,11 @@ class base {
   include govuk_sshkeys
   include govuk_sudo
   include govuk_unattended_reboot
-  include govuk_awscli
+
+  unless $::lsbdistcodename == 'precise' {
+    include govuk_awscli
+  }
+
   include logrotate
   include ntp
   include puppet


### PR DESCRIPTION
Trello: https://trello.com/c/WQhxVqpT/139-resolve-puppet-awscli-puppet-errors-on-ci-integration-machines

There isn't a precise package available for this and puppet errors when
it runs because of this.