### PR TITLE
Remove /api/organisations from nginx configuration

### DIFF
--- a/modules/govuk/templates/publicapi_nginx_extra_config.erb
+++ b/modules/govuk/templates/publicapi_nginx_extra_config.erb
@@ -7,7 +7,7 @@
   <%- if scope.lookupvar('::aws_migration') %>
   set $upstream_whitehall_api <%= @privateapi_protocol %>://<%= @whitehallapi %>;
   <%- end %>
-  location ~ ^/api/(governments|organisations|specialist|worldwide-organisations|world-locations)(/|$) {
+  location ~ ^/api/(governments|specialist|worldwide-organisations|world-locations)(/|$) {
     expires 30m;
 
     proxy_set_header Host <%= @whitehallapi %>;


### PR DESCRIPTION
This commit removes nginx handling of `/api/organisations` and everything under it. This prefix route is now published by collections-publisher and rendered by collections.

Trello: https://trello.com/c/p7ywlbk1/130-migrate-organisations-api