### PR TITLE
Send asset requests on www/www-origin/draft-origin to assets hosts

### DIFF
--- a/modules/router/templates/base.conf.erb
+++ b/modules/router/templates/base.conf.erb
@@ -48,5 +48,21 @@ server {
   include             /etc/nginx/ssl.conf;
   <%- end %>
 
+  # Redirect asset requests to the assets host
+  location ~ ^/government/uploads/system/uploads/attachment_data/file/[0-9]+/[^/]*$ {
+    if ($host ~* www\.(.*)) {
+      set $host_without_subdomain $1;
+      rewrite ^/(.*) https://assets.$host_without_subdomain/$1 permanent;
+    }
+    if ($host ~* www-origin\.(.*)) {
+      set $host_without_subdomain $1;
+      rewrite ^/(.*) https://assets-origin.$host_without_subdomain/$1 permanent;
+    }
+    if ($host ~* draft-origin\.(.*)) {
+      set $host_without_subdomain $1;
+      rewrite ^/(.*) https://draft-assets.$host_without_subdomain/$1 permanent;
+    }
+  }
+
   include             /etc/nginx/router_include.conf;
 }


### PR DESCRIPTION
This is to [replace a redirect in whitehall](https://github.com/alphagov/whitehall/blob/master/app/controllers/attachments_controller.rb#L5-L11), as we eventually want to drop that controller entirely.

---

[Trello card](https://trello.com/c/e1I8Cjhf/263-redirect-whitehall-assets-path-to-the-assets-host-in-nginx)