### PR TITLE
Don't require `govuk_awscli` from `govuk_mysql::xtrabackup::packages`

### DIFF
--- a/modules/govuk_mysql/manifests/xtrabackup/packages.pp
+++ b/modules/govuk_mysql/manifests/xtrabackup/packages.pp
@@ -8,8 +8,6 @@
 class govuk_mysql::xtrabackup::packages (
   $apt_mirror_hostname  = '',
 ) {
-  require '::govuk_awscli'
-
   package { 'xtrabackup':
     ensure  => present,
     require => Class[Mysql::Server],


### PR DESCRIPTION
For some reason that isn't immediately obvious, this introduces a circular dependency. We're including `govuk_awscli` from `base` anyway.

Reported by @kevindew 