### PR TITLE
Set public CKAN URL

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -16,7 +16,7 @@ govuk::apps::email_alert_api::email_address_override: 'success@simulator.amazons
 govuk::apps::email_alert_api::email_address_override_whitelist_only: true
 govuk::apps::email_alert_api::delivery_request_threshold: "3000"
 govuk::apps::email_alert_frontend::subscription_management_enabled: true
-govuk::apps::ckan::ckan_site_url: 'https://ckan.integration.publishing.service.gov.uk'
+govuk::apps::ckan::ckan_site_url: 'https://test.data.gov.uk'
 govuk::apps::govuk_crawler_worker::enabled: false
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
 govuk::apps::kibana::logit_environment: 2694f14b-6519-4607-81f2-8a2130e5aaec


### PR DESCRIPTION
CKAN appears to render this to the DOM, for example `<body data-site-root="https://ckan.integration.publishing.service.gov.uk/" data-locale root="https://ckan.integration.publishing.service.gov.uk/">`