### PR TITLE
Use the DGU user authenticator for CKAN application

### DIFF
--- a/modules/govuk/templates/ckan/who.ini.erb
+++ b/modules/govuk/templates/ckan/who.ini.erb
@@ -29,7 +29,7 @@ plugins =
 [authenticators]
 plugins =
     auth_tkt
-    ckan.lib.authenticator:UsernamePasswordAuthenticator
+    ckanext.datagovuk.lib.authenticator:UsernamePasswordAuthenticator
 
 [challengers]
 plugins =


### PR DESCRIPTION
The default CKAN authenticator only allows users to sign in with their username (which some legacy users have not set).

This switches CKAN to use our own authenticator, which allows users to use their email address or username.