### PR TITLE
Force removal of cdn logs archive

### DIFF
--- a/modules/govuk_cdnlogs/manifests/transition_logs.pp
+++ b/modules/govuk_cdnlogs/manifests/transition_logs.pp
@@ -102,6 +102,7 @@ class govuk_cdnlogs::transition_logs (
   # @TODO remove these once this has been run in production
   file { "${log_dir}/cache/archive":
     ensure => absent,
+    force  => true,
   }
 
   file { '/etc/logrotate.d/transition_logs_cache':


### PR DESCRIPTION
This couldn't be removed before as it's a directory and you need to pass the force parameter to delete one.