### PR TITLE
Refine jenkins Email Check approach

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/email_alert_check.pp
+++ b/modules/govuk_jenkins/manifests/jobs/email_alert_check.pp
@@ -52,18 +52,22 @@ class govuk_jenkins::jobs::email_alert_check (
 
   @@icinga::passive_check {
     "${drug_check_name}_${::hostname}":
-      service_description => $drug_service_description,
-      host_name           => $::fqdn,
-      freshness_threshold => 5400, # 90 minutes
-      action_url          => $drug_job_url,
-      notes_url           => monitoring_docs_url(email-alerts);
+      service_description     => $drug_service_description,
+      host_name               => $::fqdn,
+      freshness_threshold     => 5400, # 90 minutes
+      freshness_alert_level   => 'critical',
+      freshness_alert_message => 'Jenkins job has stopped running or is unstable',
+      action_url              => $drug_job_url,
+      notes_url               => monitoring_docs_url(email-alerts);
     "${travel_advice_check_name}_${::hostname}":
-      service_template    => 'govuk_urgent_priority',
-      service_description => $travel_advice_service_description,
-      host_name           => $::fqdn,
-      freshness_threshold => 5400, # 90 minutes
-      action_url          => $travel_advice_job_url,
-      notes_url           => monitoring_docs_url(email-alerts);
+      service_template        => 'govuk_urgent_priority',
+      service_description     => $travel_advice_service_description,
+      host_name               => $::fqdn,
+      freshness_threshold     => 5400, # 90 minutes
+      freshness_alert_level   => 'critical',
+      freshness_alert_message => 'Jenkins job has stopped running or is unstable',
+      action_url              => $travel_advice_job_url,
+      notes_url               => monitoring_docs_url(email-alerts);
 
   }
 }

--- a/modules/govuk_jenkins/templates/jobs/drug_email_alert_check.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/drug_email_alert_check.yaml.erb
@@ -13,16 +13,18 @@
             days-to-keep: 30
             artifact-num-to-keep: 5
     builders:
-        - shell: |
-            (
-              git clone https://github.com/alphagov/email-alert-monitoring tmp &&
-              rm -rf email-alert-monitoring &&
-              mv tmp email-alert-monitoring
-            ) || echo "Cloning failed. Re-using directory from previous run."
+        - shell:
+            command: |
+              (
+                git clone https://github.com/alphagov/email-alert-monitoring tmp &&
+                rm -rf email-alert-monitoring &&
+                mv tmp email-alert-monitoring
+              ) || echo "Cloning failed. Re-using directory from previous run."
 
-            cd email-alert-monitoring
-            bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
-            bundle exec rake run
+              cd email-alert-monitoring
+              bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
+              bundle exec rake run
+            unstable-return: 1
     publishers:
       - text-finder:
           regexp: "Cloning failed"

--- a/modules/govuk_jenkins/templates/jobs/drug_email_alert_check.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/drug_email_alert_check.yaml.erb
@@ -7,7 +7,7 @@
     logrotate:
         numToKeep: 100
     triggers:
-        - timed: '21 * * * *' # every hour on the 21st minute
+        - timed: '21,51 * * * *' # every hour on the 21st and 51st minute
     properties:
         - build-discarder:
             days-to-keep: 30

--- a/modules/govuk_jenkins/templates/jobs/travel_advice_email_alert_check.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/travel_advice_email_alert_check.yaml.erb
@@ -13,16 +13,18 @@
             days-to-keep: 30
             artifact-num-to-keep: 5
     builders:
-        - shell: |
-            (
-              git clone https://github.com/alphagov/email-alert-monitoring tmp &&
-              rm -rf email-alert-monitoring &&
-              mv tmp email-alert-monitoring
-            ) || echo "Cloning failed. Re-using directory from previous run."
+        - shell:
+            command: |
+              (
+                git clone https://github.com/alphagov/email-alert-monitoring tmp &&
+                rm -rf email-alert-monitoring &&
+                mv tmp email-alert-monitoring
+              ) || echo "Cloning failed. Re-using directory from previous run."
 
-            cd email-alert-monitoring
-            bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
-            bundle exec rake run_travel_alerts
+              cd email-alert-monitoring
+              bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
+              bundle exec rake run_travel_alerts
+            unstable-return: 1
     publishers:
       - text-finder:
           regexp: "Cloning failed"

--- a/modules/icinga/manifests/passive_check.pp
+++ b/modules/icinga/manifests/passive_check.pp
@@ -40,19 +40,24 @@
 define icinga::passive_check (
   $service_description,
   $host_name,
-  $ensure              = 'present',
-  $freshness_threshold = '',
-  $action_url          = undef,
-  $notes_url           = undef,
-  $service_template = 'govuk_regular_service',
+  $ensure                  = 'present',
+  $freshness_threshold     = '',
+  $freshness_alert_level   = 'warning',
+  $freshness_alert_message = 'Freshness threshold exceeded',
+  $action_url              = undef,
+  $notes_url               = undef,
+  $service_template        = 'govuk_regular_service',
 ){
 
   validate_re($service_description, '^(\w|\s|\-|/|\[|\]|:|\.)*$', "Icinga check \"${service_description}\" contains invalid characters")
+  validate_re($freshness_alert_level, '^(warning|critical)$')
 
   $active_message = $freshness_threshold ? {
     ''      => 'Unexpected active check on passive service',
-    default => 'Freshness threshold exceeded',
+    default => $freshness_alert_message,
   }
+
+  $active_code = $freshness_alert_level ? { 'critical' => '2', default => '1' }
 
   Icinga::Host[$host_name] -> Icinga::Passive_check[$title]
 

--- a/modules/icinga/spec/defines/icinga__passive_check_spec.rb
+++ b/modules/icinga/spec/defines/icinga__passive_check_spec.rb
@@ -33,3 +33,22 @@ describe 'icinga::passive_check', :type => :define do
      }
 end
 
+# icinga::passive_check should allow customisable freshness code and message
+describe 'icinga::passive_check', :type => :define do
+  let(:title) { 'heartbeat' }
+  let(:facts) {{
+    'ipaddress' => '10.10.10.10',
+    :fqdn_short => 'fakehost-1.management',
+  }}
+  let(:pre_condition) {  'icinga::host{"bruce-forsyth":}' }
+  let(:params) {{
+    "host_name" => "bruce-forsyth",
+    "service_description" => "to see you nice",
+    "freshness_threshold" => "1000",
+    "freshness_alert_level" => "critical",
+    "freshness_alert_message" => "Critical alert"
+  }}
+  it { is_expected.to contain_file('/etc/icinga/conf.d/icinga_host_bruce-forsyth/heartbeat.cfg').
+       with_content(/check_command\s+check_dummy!2!"Critical\salert/)
+     }
+end

--- a/modules/icinga/templates/passive_service.erb
+++ b/modules/icinga/templates/passive_service.erb
@@ -8,7 +8,7 @@ define service {
   check_freshness           1
   freshness_threshold       <%= @freshness_threshold %>
 <% end -%>
-  check_command             check_dummy!1!"<%= @active_message -%>"
+  check_command             check_dummy!<%= @active_code %>!"<%= @active_message -%>"
   max_check_attempts        1
 <%- if @action_url -%>
   action_url                <%= @action_url %>


### PR DESCRIPTION
Trello: https://trello.com/c/xeq75b8T/128-update-email-alert-checks-to-not-call-people-on-http-issues

This changes the Email Check jobs that run in Jenkins so that they are flagged as unstable if they exit with a code of 1 and are fails if they exit with 2 (which is the code used in https://github.com/alphagov/email-alert-monitoring).

This then sets the freshness threshold to return a critical when these have not had a passive check for 90 minutes.