### PR TITLE
Mongodb - Maximum open files

### DIFF
--- a/modules/govuk/manifests/node/s_api_mongo.pp
+++ b/modules/govuk/manifests/node/s_api_mongo.pp
@@ -10,6 +10,13 @@ class govuk::node::s_api_mongo inherits govuk::node::s_base {
     outgoing => 27017,
   }
 
+  limits::limits { 'api_mongo_nofile':
+    ensure     => present,
+    user       => 'mongodb',
+    limit_type => 'nofile',
+    both       => 4096,
+  }
+
   if ! $::aws_migration {
     Govuk_mount['/var/lib/mongodb'] -> Class['mongodb::server']
     Govuk_mount['/var/lib/automongodbbackup'] -> Class['mongodb::backup']


### PR DESCRIPTION
- We have experienced two recorded occasions where the mongo cluster
failed.

- During the investigation , we found-out that the number of openfiles
exceeded 3000. However, the current limit is set at 2000.

- This change will increase the acceptable number of openfiles to 4096.

https://govuk.zendesk.com/agent/tickets/2782624

Solo: @suthagarht