### PR TITLE
Add CKAN cronjobs

### DIFF
--- a/modules/govuk/manifests/apps/ckan.pp
+++ b/modules/govuk/manifests/apps/ckan.pp
@@ -111,6 +111,8 @@ class govuk::apps::ckan (
       process_type   => 'harvester_gather_consumer',
     }
 
+    include govuk::apps::ckan::cronjobs
+
     Govuk::App::Envvar {
       app => 'ckan',
     }

--- a/modules/govuk/manifests/apps/ckan/cronjobs.pp
+++ b/modules/govuk/manifests/apps/ckan/cronjobs.pp
@@ -1,0 +1,17 @@
+# == Class: govuk::apps::ckan::cronjobs
+#
+class govuk::apps::ckan::cronjobs {
+
+  govuk::apps::ckan::paster_cronjob { 'harvester run':
+    paster_command => 'harvester run',
+    plugin         => 'ckanext-harvest',
+    minute         => '*/10',
+  }
+
+  govuk::apps::ckan::paster_cronjob { 'harvester cleanup':
+    paster_command => 'harvester clean_harvest_log',
+    plugin         => 'ckanext-harvest',
+    hour           => '2',
+  }
+
+}

--- a/modules/govuk/manifests/apps/ckan/paster_cronjob.pp
+++ b/modules/govuk/manifests/apps/ckan/paster_cronjob.pp
@@ -1,0 +1,41 @@
+# == Define: govuk::apps::ckan::paster_cronjob
+#
+# Creates a cronjob entry specifically for paster commands
+#
+# === Parameters
+#
+# [*hour*]
+# [*minute*]
+# [*month*]
+# [*monthday*]
+# [*weekday*]
+# Same timing parameters as a normal cronjob
+#
+# [*plugin*]
+# Paster plugin to use
+#
+# [*paster_command*]
+# Paster command to run eg "archiver update"
+#
+define govuk::apps::ckan::paster_cronjob (
+  $hour = undef,
+  $minute = undef,
+  $month = undef,
+  $monthday = undef,
+  $weekday = undef,
+  $plugin = undef,
+  $paster_command = undef,
+) {
+
+  validate_string($plugin, $paster_command)
+
+  cron { $title:
+    command  => "cd /var/apps/ckan; govuk_setenv ckan venv/bin/paster --plugin=${plugin} ${paster_command} --config=/var/ckan/ckan.ini",
+    user     => 'deploy',
+    hour     => $hour,
+    minute   => $minute,
+    month    => $month,
+    monthday => $monthday,
+    weekday  => $weekday,
+  }
+}


### PR DESCRIPTION
Includes a helper type for defining jobs that are calls to paster commands.

@andrewgarner @brucebolt is this easy enough to add new jobs as needed?