### PR TITLE
Fix Postgres ordering

### DIFF
--- a/modules/govuk_postgresql/manifests/server.pp
+++ b/modules/govuk_postgresql/manifests/server.pp
@@ -40,9 +40,14 @@ class govuk_postgresql::server (
     fail("Class ${name} cannot be used directly. Please use standalone/primary/standby")
   }
 
-  class {'postgresql::server':
+  include '::govuk_postgresql::mirror'
+
+  class {'::postgresql::server':
     listen_addresses => $listen_addresses,
   }
+
+  class {'::postgresql::server::contrib':}
+
   if ($listen_addresses == '*') {
     @ufw::allow { 'allow-postgresql-from-all':
       port => 5432,
@@ -76,9 +81,6 @@ class govuk_postgresql::server (
     }
   }
 
-  include govuk_postgresql::mirror
-  include postgresql::server::contrib
-
   if $configure_env_sync_user {
     include govuk_postgresql::env_sync_user
   }
@@ -106,12 +108,4 @@ class govuk_postgresql::server (
       host_name => $::fqdn,
     }
   }
-
-  file { "/var/lib/postgresql/${postgresql::globals::version}":
-    ensure => directory,
-    owner  => $postgresql::params::user,
-    group  => $postgresql::params::group,
-    mode   => '0755',
-  }
-
 }


### PR DESCRIPTION
This had been previously changed in commit 189f44b7, however this introduced a different bug as there is nothing to stop the File resource that was added from firing before `/var/lib/postgresql` had been created, therefore causing many other dependent resources to fail.

Whatever other resource was referencing `/var/lib/postgresql/${version}` has now gone.