### PR TITLE
Postgresql slow-query logging

### DIFF
--- a/modules/govuk_postgresql/manifests/server/primary.pp
+++ b/modules/govuk_postgresql/manifests/server/primary.pp
@@ -44,6 +44,8 @@ class govuk_postgresql::server::primary (
       value => 3;
     'wal_keep_segments':
       value => 256;
+    'log_min_duration_statement':
+      value => 1000;
   }
 
   if versioncmp($::postgresql::globals::version, '9.5') < 0 {


### PR DESCRIPTION
- We have noticed high CPU load on the GOV.UK production (primary)
postgresql server. We would like to identify queries that execute for a
relatively longer duration.

- We are adding a change to record queries that execute for more than
1000 milliseconds.

https://govuk.zendesk.com/agent/tickets/2820157

https://www.postgresql.org/docs/9.5/static/runtime-config-logging.html

Solo: @suthagarht