### PR TITLE
Work around netcat-openbsd bug

### DIFF
--- a/modules/govuk/templates/node/s_asset_base/process-uploaded-attachments.sh.erb
+++ b/modules/govuk/templates/node/s_asset_base/process-uploaded-attachments.sh.erb
@@ -33,7 +33,7 @@ while IFS= read -r -d '' FILE
     logger -t process_uploaded_attachment "Processing uploaded file $FILE"
     # Send metric to Statsd
     WAITING_TIME=$(expr $(date +%s) - $(stat -c %Y $FILE))
-    echo "govuk.app.asset-master.scan-queue:${WAITING_TIME}|ms" | nc -w 1 -u localhost 8125
+    echo "govuk.app.asset-master.scan-queue:${WAITING_TIME}|ms" | nc -q 1 -u localhost 8125
     # This parameter substition strips "$INCOMING_DIR/" from the beginning of $FILE.
     FILE_PATH=${FILE#$INCOMING_DIR/}
     if /usr/local/bin/virus-scan-file.sh "$FILE"; then

--- a/modules/govuk_crawler/templates/govuk_sync_mirror.erb
+++ b/modules/govuk_crawler/templates/govuk_sync_mirror.erb
@@ -71,7 +71,7 @@ done
 STOP_UPLOAD=$(date +%s%3N)
 DURATION_UPLOAD=$(expr $STOP_UPLOAD - $START_UPLOAD)
 
-echo "govuk.app.sync_mirror.upload_duration:$DURATION_UPLOAD|ms" | nc -w 1 -u localhost 8125
+echo "govuk.app.sync_mirror.upload_duration:$DURATION_UPLOAD|ms" | nc -q 1 -u localhost 8125
 
 log "user.info" "Finished synchronising to GOV.UK mirrors"
 

--- a/modules/puppet/templates/govuk_puppet
+++ b/modules/puppet/templates/govuk_puppet
@@ -202,6 +202,6 @@ RBENV_VERSION=1.9.3 /usr/local/bin/govuk_setenv default puppet agent --onetime -
 set -e
 
 TIME_TOOK=$((`date +%s%3N`-start_time))
-echo "<%= @fqdn_metrics %>.puppet.run_duration:${TIME_TOOK}|ms" | nc -w 1 -u localhost 8125
+echo "<%= @fqdn_metrics %>.puppet.run_duration:${TIME_TOOK}|ms" | nc -q 1 -u localhost 8125
 
 /usr/local/bin/puppet_passive_check_update >/dev/null


### PR DESCRIPTION
`nc` commands used to send datapoints into statsd can end up pegging the CPU and failing to exit. I observed this in Puppet master builds in Vagrant. It wasn't clear why this doesn't happen in all cases, but it is a known bug: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=752931

The workaround is to use `-q 1` instead of `-w 1`.

The bug is fixed upstream and the netcat in Ubuntu Bionic shouldn't be affected (Xenial's netcat is the same version as Trusty's though).