### PR TITLE
Add CKAN GA config to ckan.ini

### DIFF
--- a/modules/govuk/templates/ckan/ckan.ini.erb
+++ b/modules/govuk/templates/ckan/ckan.ini.erb
@@ -148,6 +148,13 @@ ckan.storage_path = /var/ckan/default
 ckan.max_resource_size = 50
 #ckan.max_image_size = 2
 
+## GA Settings
+googleanalytics.account = data.gov.uk
+googleanalytics.id = UA-10855508-1
+googleanalytics.token.filepath = /var/apps/ckan/ga_token
+ga-report.bounce_url = /
+ga-report.period = monthly
+
 ## Datapusher settings
 
 # Make sure you have set up the DataStore


### PR DESCRIPTION
This adds the configuration required for the ckanext-ga-report module to access Google Analytics data