### PR TITLE
Include the environment in Smokey failure messages

### DIFF
--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -76,7 +76,8 @@ govuk_jenkins::jobs::network_config_deploy::environments:
 
 govuk_jenkins::jobs::search_fetch_analytics_data::skip_page_traffic_load: true
 govuk_jenkins::jobs::search_fetch_analytics_data::cron_schedule: '30 8 * * 1-5'
-govuk_jenkins::jobs::smokey::smokey_task: 'test:staging'
+
+govuk_jenkins::jobs::smokey::environment: staging
 
 govuk_jenkins::jobs::data_sync_complete_staging::signon_domains_to_migrate:
   -

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -65,7 +65,7 @@ govuk_jenkins::jobs::signon_cron_rake_tasks::rake_organisations_fetch_frequency:
 govuk_jenkins::jobs::signon_cron_rake_tasks::rake_users_suspend_inactive_frequency: '15 11 * * *'
 govuk_jenkins::jobs::signon_cron_rake_tasks::rake_users_send_suspension_reminders_frequency: '45 11 * * *'
 
-govuk_jenkins::jobs::smokey::smokey_task: 'test:integration'
+govuk_jenkins::jobs::smokey::environment: integration
 
 govuk_jenkins::jobs::deploy_dns::gce_project_id: 'govuk-integration'
 

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -57,7 +57,8 @@ govuk_jenkins::job_builder::environment: 'production'
 
 govuk_jenkins::jobs::search_fetch_analytics_data::skip_page_traffic_load: true
 govuk_jenkins::jobs::search_fetch_analytics_data::cron_schedule: '30 8 * * 1-5'
-govuk_jenkins::jobs::smokey::smokey_task: 'test:production'
+
+govuk_jenkins::jobs::smokey::environment: production
 
 govuk_jenkins::jobs::deploy_app::notify_release_app: false
 govuk_jenkins::jobs::deploy_app::enable_slack_notifications: false

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -61,7 +61,8 @@ govuk_jenkins::jobs::network_config_deploy::environments:
 
 govuk_jenkins::jobs::search_fetch_analytics_data::skip_page_traffic_load: true
 govuk_jenkins::jobs::search_fetch_analytics_data::cron_schedule: '30 8 * * 1-5'
-govuk_jenkins::jobs::smokey::smokey_task: 'test:staging'
+
+govuk_jenkins::jobs::smokey::environment: staging
 
 govuk_jenkins::jobs::data_sync_complete_staging::signon_domains_to_migrate:
   -

--- a/modules/govuk_jenkins/manifests/jobs/smokey.pp
+++ b/modules/govuk_jenkins/manifests/jobs/smokey.pp
@@ -7,13 +7,14 @@
 # [*enable_slack_notifications*]
 #   Whether slack should be notified about this job
 #
-# [*smokey_task*]
-#   The rake task to run for the tests
+# [*environment*]
+#   The environment which is running Smokey. Used to build the rake task.
 #
 class govuk_jenkins::jobs::smokey (
   $enable_slack_notifications = false,
-  $smokey_task = 'test:production',
+  $environment = 'production',
 ) {
+  $smokey_task = "test:${environment}"
   $app_domain = hiera('app_domain')
 
   $slack_team_domain = 'gds'

--- a/modules/govuk_jenkins/templates/jobs/smokey.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/smokey.yaml.erb
@@ -33,6 +33,8 @@
           notify-repeatedfailure: false
           include-test-summary: false
           room: <%= @slack_room %>
+          include-custom-message: true
+          custom-message: ':govuk-<%= @environment %>:'
       <% end %>
       - email-ext:
           recipients: govuk-ci-notifications@digital.cabinet-office.gov.uk


### PR DESCRIPTION
This should mean the environment is shown in Jenkins Slack messages about Smokey failures.

[Trello Card](https://trello.com/c/X6xh8u8r/354-make-smokey-slack-bot-say-the-environment)