### PR TITLE
Reduce RAM allocated to Varnish

### DIFF
--- a/modules/govuk/manifests/node/s_cache.pp
+++ b/modules/govuk/manifests/node/s_cache.pp
@@ -66,7 +66,7 @@ class govuk::node::s_cache (
   }
 
   # The storage size for the cache, excluding per object and static overheads
-  $varnish_storage_size_pre = floor($::memorysize_mb * 0.70 - 1536)
+  $varnish_storage_size_pre = floor($::memorysize_mb * 0.70 - 2048)
 
   # Ensure that there's some varnish storage in small environments (eg, vagrant).
   if $varnish_storage_size_pre < 100 {


### PR DESCRIPTION
We're running low on RAM on cache boxes again, most likely due to the increased RAM usage of the router as we add more routes. This change will still allocate around 13.7GB to varnish per box, which should be plenty.