### PR TITLE
Env vars for Email Alert API AWS integration

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -78,6 +78,8 @@ govuk::apps::ckan::ckan_site_url: 'https://ckan.publishing.service.gov.uk'
 govuk::apps::content_store::performance_platform_big_screen_view_url: 'https://performance-platform-big-screen-view-production.cloudapps.digital'
 govuk::apps::content_store::performance_platform_spotlight_url: 'https://performance-platform-spotlight-production.cloudapps.digital'
 govuk::apps::email_alert_api::db::backend_ip_range: '10.3.3.0/24'
+govuk::apps::email_alert_api::email_archive_s3_bucket: 'govuk-production-email-alert-api-archive'
+govuk::apps::email_alert_api::email_archive_s3_enabled: true
 govuk::apps::email_alert_api::govuk_notify_template_id: 'cb633abc-6ae6-4843-ae6f-82ca500b6de2'
 govuk::apps::government-frontend::cpu_warning: 200
 govuk::apps::government-frontend::cpu_critical: 300

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -19,6 +19,8 @@ govuk::apps::ckan::ckan_site_url: 'https://ckan.staging.publishing.service.gov.u
 govuk::apps::content_store::performance_platform_big_screen_view_url: 'https://performance-platform-big-screen-view-staging.cloudapps.digital'
 govuk::apps::content_store::performance_platform_spotlight_url: 'https://performance-platform-spotlight-staging.cloudapps.digital'
 govuk::apps::email_alert_api::db::backend_ip_range: '10.2.3.0/24'
+govuk::apps::email_alert_api::email_archive_s3_bucket: 'govuk-staging-email-alert-api-archive'
+govuk::apps::email_alert_api::email_archive_s3_enabled: true
 govuk::apps::email_alert_api::govuk_notify_template_id: '2844a647-6bf1-4b01-a25c-569d2cc00849'
 govuk::apps::email_alert_api::email_address_override: 'success@simulator.amazonses.com'
 govuk::apps::email_alert_api::email_address_override_whitelist_only: true

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -11,6 +11,8 @@ cron::daily_hour: 6
 govuk::apps::asset_manager::aws_s3_bucket_name: 'govuk-assets-integration'
 govuk::apps::asset_manager::aws_region: 'eu-west-1'
 
+govuk::apps::email_alert_api::email_archive_s3_bucket: 'govuk-integration-email-alert-api-archive'
+govuk::apps::email_alert_api::email_archive_s3_enabled: true
 govuk::apps::email_alert_api::govuk_notify_template_id: '1fc69d3a-09a2-40f9-852b-03f6fcef5340'
 govuk::apps::email_alert_api::email_address_override: 'success@simulator.amazonses.com'
 govuk::apps::email_alert_api::email_address_override_whitelist_only: true

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -14,6 +14,9 @@ govuk::apps::asset_manager::aws_region: 'eu-west-1'
 govuk::apps::content_store::performance_platform_big_screen_view_url: 'https://performance-platform-big-screen-view-production.cloudapps.digital'
 govuk::apps::content_store::performance_platform_spotlight_url: 'https://performance-platform-spotlight-production.cloudapps.digital'
 govuk::apps::email_alert_api::db::backend_ip_range: '10.2.3.0/24'
+govuk::apps::email_alert_api::email_archive_s3_bucket: 'govuk-production-email-alert-api-archive'
+# This shouldn't be enabled at the same time we have carrenza s3 export enabled unless they have separate buckets
+govuk::apps::email_alert_api::email_archive_s3_enabled: false
 govuk::apps::email_alert_api::govuk_notify_template_id: '76d21ce7-54c3-4fb7-8830-ba3b79287985'
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::kibana::logit_environment: 0ea55710-075b-4eab-bfc3-475f28cdd0c3

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -14,6 +14,9 @@ govuk::apps::asset_manager::aws_region: 'eu-west-1'
 govuk::apps::content_store::performance_platform_big_screen_view_url: 'https://performance-platform-big-screen-view-staging.cloudapps.digital'
 govuk::apps::content_store::performance_platform_spotlight_url: 'https://performance-platform-spotlight-staging.cloudapps.digital'
 govuk::apps::email_alert_api::db::backend_ip_range: '10.2.3.0/24'
+govuk::apps::email_alert_api::email_archive_s3_bucket: 'govuk-staging-email-alert-api-archive'
+# This shouldn't be enabled at the same time we have carrenza s3 export enabled unless they have separate buckets
+govuk::apps::email_alert_api::email_archive_s3_enabled: false
 govuk::apps::email_alert_api::govuk_notify_template_id: '2844a647-6bf1-4b01-a25c-569d2cc00849'
 govuk::apps::email_alert_api::email_address_override: 'success@simulator.amazonses.com'
 govuk::apps::email_alert_api::email_address_override_whitelist_only: true

--- a/modules/govuk/manifests/apps/email_alert_api.pp
+++ b/modules/govuk/manifests/apps/email_alert_api.pp
@@ -74,6 +74,23 @@
 # [*unicorn_worker_processes*]
 #   The number of unicorn workers to run for an instance of this app
 #
+# [*aws_access_key_id*]
+#   An access key that can be use with Amazon Web Services
+#
+# [*aws_secret_access_key*]
+#   The secret key that corresponds with the aws_access_key_id
+#
+# [*aws_region*]
+#   The AWS region which is used for AWS Services
+#   default: eu-west-1
+#
+# [*email_archive_s3_bucket*]
+#   An S3 bucket in the specified AWS region which can be used to write the
+#   archived data too
+#
+# [*email_archive_s3_enabled*]
+#   Whether or not to perform S3 archiving in the current environment
+#
 class govuk::apps::email_alert_api(
   $port = '3088',
   $enabled = false,
@@ -105,6 +122,11 @@ class govuk::apps::email_alert_api(
   $db_hostname = undef,
   $db_name = 'email-alert-api_production',
   $unicorn_worker_processes = undef,
+  $aws_access_key_id = undef,
+  $aws_secret_access_key = undef,
+  $aws_region = 'eu-west-1',
+  $email_archive_s3_bucket = undef,
+  $email_archive_s3_enabled = undef,
 ) {
 
   $ensure = $enabled ? {
@@ -198,6 +220,18 @@ class govuk::apps::email_alert_api(
     "${title}-EMAIL_ADDRESS_OVERRIDE":
         varname => 'EMAIL_ADDRESS_OVERRIDE',
         value   => $email_address_override;
+    "${title}-AWS_ACCESS_KEY_ID":
+        varname => 'AWS_ACCESS_KEY_ID',
+        value   => $aws_access_key_id;
+    "${title}-AWS_SECRET_ACCESS_KEY":
+        varname => 'AWS_SECRET_ACCESS_KEY',
+        value   => $aws_secret_access_key;
+    "${title}-AWS_REGION":
+        varname => 'AWS_REGION',
+        value   => $aws_region;
+    "${title}-EMAIL_ARCHIVE_S3_BUCKET":
+        varname => 'EMAIL_ARCHIVE_S3_BUCKET',
+        value   => $email_archive_s3_bucket;
   }
 
   if $email_address_override_whitelist {
@@ -218,6 +252,13 @@ class govuk::apps::email_alert_api(
     govuk::app::envvar { "${title}-DELIVERY_REQUEST_THRESHOLD":
       varname => 'DELIVERY_REQUEST_THRESHOLD',
       value   => $delivery_request_threshold;
+    }
+  }
+
+  if $email_archive_s3_enabled {
+    govuk::app::envvar { "${title}-EMAIL_ARCHIVE_S3_ENABLED":
+      varname => 'EMAIL_ARCHIVE_S3_ENABLED',
+      value   => 'yes';
     }
   }
 


### PR DESCRIPTION
Trello: https://trello.com/c/FM3MCuAl/255-investigate-email-alert-api-database-size-and-push-email-archives-to-s3

We're planning to archive data stored in Email Alert API databases in
S3. This sets up the environment variables so it can integrate with it.