### PR TITLE
Increase whitehall procfile worker process count

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -475,7 +475,7 @@ govuk::apps::whitehall::db_username: whitehall_fe
 govuk::apps::whitehall::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
 govuk::apps::whitehall::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::whitehall::redis_port: "%{hiera('sidekiq_port')}"
-govuk::apps::whitehall::procfile_worker_process_count: 2
+govuk::apps::whitehall::procfile_worker_process_count: 8
 
 govuk::apps::whitehall::db::whitehall_fe_password: "%{hiera('mysql_whitehall_frontend')}"
 

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -480,7 +480,7 @@ govuk::apps::whitehall::db_username: whitehall_fe
 govuk::apps::whitehall::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
 govuk::apps::whitehall::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::whitehall::redis_port: "%{hiera('sidekiq_port')}"
-govuk::apps::whitehall::procfile_worker_process_count: 2
+govuk::apps::whitehall::procfile_worker_process_count: 8
 
 govuk::apps::whitehall::db::whitehall_fe_password: "%{hiera('mysql_whitehall_frontend')}"
 


### PR DESCRIPTION
Now that Whitehall is also uploading attachments to asset-manager, and those attachments are being served from asset-manager it's important that they go out reasonably quickly.

Each Whitehall Sidekiq process is unable to run more than one thread as some of the workers aren't thread safe. Instead we can increase the number of Sidekiq processes.

I picked 8 because it seems like a reasonable jump up from 2 which seems very low. We've also recently increased the Postgres CPU speed which should help.

[Trello Card](https://trello.com/c/R0eXp4Di/281-think-about-asset-sidekiq-stuff)