### PR TITLE
Don't send Postgres backups offsite

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -39,7 +39,6 @@ backup::offsite::jobs:
     sources:
       - '/data/backups/*/var/lib/automongodbbackup/latest'
       - '/data/backups/*/var/lib/automysqlbackup/latest.tbz2'
-      - '/data/backups/*/var/lib/autopostgresqlbackup/latest.tbz2'
       - '/data/backups/archived'
     destination: 's3://s3-eu-west-1.amazonaws.com/govuk-offsite-backups-production/govuk-datastores/'
     aws_access_key_id: "%{hiera('backup::offsite::job::aws_access_key_id')}"


### PR DESCRIPTION
We've replaced autopostgresql backups with WAL-E, which by design backs up to S3. This job backs up almost 300GB of data to S3 daily, and ends up taking longer than 24 hours, meaning the safety of our MySQL and Mongo backups is reduced.

TODO:
- [x] Finish testing the WAL-E restore in staging