### PR TITLE
Disable CKAN in staging and production

### DIFF
--- a/hieradata/class/production/ckan.yaml
+++ b/hieradata/class/production/ckan.yaml
@@ -1,0 +1,3 @@
+---
+
+govuk::apps::ckan::enabled: false

--- a/hieradata/class/staging/ckan.yaml
+++ b/hieradata/class/staging/ckan.yaml
@@ -1,0 +1,3 @@
+---
+
+govuk::apps::ckan::enabled: false

--- a/hieradata_aws/class/production/ckan.yaml
+++ b/hieradata_aws/class/production/ckan.yaml
@@ -1,0 +1,3 @@
+---
+
+govuk::apps::ckan::enabled: false

--- a/hieradata_aws/class/staging/ckan.yaml
+++ b/hieradata_aws/class/staging/ckan.yaml
@@ -1,0 +1,3 @@
+---
+
+govuk::apps::ckan::enabled: false


### PR DESCRIPTION
CKAN is still being worked on, but only needed in integration for now. There are stability issues that might impact other applications on the Postgres instance, so it's safest to disable it and drop the database in Staging and Production.