### PR TITLE
Revert "Increase whitehall procfile worker process count"

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -475,7 +475,7 @@ govuk::apps::whitehall::db_username: whitehall_fe
 govuk::apps::whitehall::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
 govuk::apps::whitehall::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::whitehall::redis_port: "%{hiera('sidekiq_port')}"
-govuk::apps::whitehall::procfile_worker_process_count: 8
+govuk::apps::whitehall::procfile_worker_process_count: 2
 
 govuk::apps::whitehall::db::whitehall_fe_password: "%{hiera('mysql_whitehall_frontend')}"
 

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -480,7 +480,7 @@ govuk::apps::whitehall::db_username: whitehall_fe
 govuk::apps::whitehall::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
 govuk::apps::whitehall::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::whitehall::redis_port: "%{hiera('sidekiq_port')}"
-govuk::apps::whitehall::procfile_worker_process_count: 8
+govuk::apps::whitehall::procfile_worker_process_count: 2
 
 govuk::apps::whitehall::db::whitehall_fe_password: "%{hiera('mysql_whitehall_frontend')}"
 


### PR DESCRIPTION
Reverts alphagov/govuk-puppet#7729

Now that we've merged https://github.com/alphagov/whitehall/pull/4178, we should revert this.  Otherwise each box will have 64 Sidekiq threads, which seems a lot.

---

[Trello card](https://trello.com/c/R0eXp4Di/281-think-about-asset-sidekiq-stuff)