### PR TITLE
Adjust cdn-logs offsite backup hour

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -62,7 +62,7 @@ backup::offsite::jobs:
     destination: 's3://s3-eu-west-1.amazonaws.com/govuk-offsite-backups-production/backup-cdn-logs/'
     aws_access_key_id: "%{hiera('backup::offsite::job::aws_access_key_id')}"
     aws_secret_access_key: "%{hiera('backup::offsite::job::aws_secret_access_key')}"
-    hour: 7,
+    hour: 6,
     minute: 12,
     # CDN logs are backed up unencrypted because they don't contain any sensitive information
 


### PR DESCRIPTION
- Duplicity fails datastore offsite backup because a lock is in place.

- Working hypothesis is the logs backup scheduled an hour before is
  taking too long.

- Running cdn-logs offsite backup an hour early to prevent this

@schmie