### PR TITLE
Add dependant apps to the Content Store dashboard

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1028,7 +1028,20 @@ grafana::dashboards::deployment_applications:
   content-performance-manager:
     show_sidekiq_graphs: true
     has_workers: true
-  content-store: {}
+  content-store:
+    dependent_app_5xx_errors:
+      - calendars
+      - collections
+      - contacts
+      - email-alert-frontend
+      - finder-frontend
+      - frontend
+      - government-frontend
+      - info-frontend
+      - manuals-frontend
+      - publishing-api
+      - smartanswers
+      - whitehall-frontend
   content-tagger:
     show_sidekiq_graphs: true
     has_workers: true

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -893,7 +893,20 @@ grafana::dashboards::deployment_applications:
   content-performance-manager:
     show_sidekiq_graphs: true
     has_workers: true
-  content-store: {}
+  content-store:
+    dependent_app_5xx_errors:
+      - calendars
+      - collections
+      - contacts
+      - email-alert-frontend
+      - finder-frontend
+      - frontend
+      - government-frontend
+      - info-frontend
+      - manuals-frontend
+      - publishing-api
+      - smartanswers
+      - whitehall-frontend
   content-tagger:
     show_sidekiq_graphs: true
     has_workers: true


### PR DESCRIPTION
This list includes both frontend apps which read from it, and the
Publishing API which writes to it.