### PR TITLE
Add 'Link' header to proxied storage response

### DIFF
--- a/modules/govuk/templates/asset_manager_extra_nginx_config.conf.erb
+++ b/modules/govuk/templates/asset_manager_extra_nginx_config.conf.erb
@@ -5,6 +5,7 @@ client_max_body_size 500m;
 set $etag_from_rails $upstream_http_etag;
 set $last_modified_from_rails $upstream_http_last_modified;
 set $x_frame_options_from_rails $upstream_http_x_frame_options;
+set $link_from_rails $upstream_http_link;
 
 # For public assets requests, the Rails app will respond with the
 # X-Accel-Redirect header set to a path prefixed with
@@ -42,6 +43,10 @@ location ~ /cloud-storage-proxy/(.*) {
   # default, so we do not have to do that explicitly here.
   add_header ETag $etag_from_rails;
   add_header Last-Modified $last_modified_from_rails;
+  # Respect the optional Link header set by the Rails application,
+  # this optional header refers to the asset's owning document.
+  add_header Link $link_from_rails;
+
 
   # Additionally, we always prohibit passing on these headers from S3 to
   # the client as they are very likely to be wrong. There appears to be


### PR DESCRIPTION
https://trello.com/c/cPdqtO7c/294-investigate-link-header-in-whitehall-assets

Respects the optional `Link` response header which can be set by asset-manager.
This header needs to be passed to the [cloud-storage-proxy location block](https://github.com/alphagov/govuk-puppet/blob/a50f107ca05dcc75dc2b7596253b73622fd53d25/modules/govuk/templates/asset_manager_extra_nginx_config.conf.erb#L13) to be present in the ultimate response.
If set [this will contain a reference to the owning content for an attachment](https://github.com/alphagov/asset-manager/blob/master/app/controllers/media_controller.rb#L82-L86).

See http://nginx.org/en/docs/http/ngx_http_upstream_module.html for documentation about `$upstream_http_*` response headers.

Tested in dev VM:
```
[vagrant@development asset-manager (master)]$ curl -I http://assets-origin.dev.gov.uk/media/5b45cd0a759b744a2df5cea0/tmp.txt
HTTP/1.1 200 OK 
Server: nginx
Date: Wed, 11 Jul 2018 09:26:46 GMT
Content-Type: text/plain
Content-Length: 29
Connection: close
Vary: Accept-Encoding
Vary: Accept-Encoding
Content-Disposition: inline; filename="tmp.txt"
Cache-Control: max-age=0, private, must-revalidate
Vary: Accept-Encoding
X-Request-Id: 57341724-059a-434b-a016-65415978b916
X-Runtime: 0.013331
ETag: "5b45cd0a-1d"
Last-Modified: Wed, 11 Jul 2018 09:25:30 GMT
Link: <https://www.gov.uk/vat-rates>; rel="up"
X-Frame-Options: DENY
Strict-Transport-Security: max-age=31536000
Access-Control-Allow-Origin: *
Access-Control-Allow-Methods: GET, OPTIONS
Access-Control-Allow-Headers: origin, authorization
```

cc @elliotcm 