### PR TITLE
Add content-publisher as a CI pipeline job

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -742,6 +742,7 @@ govuk_ci::master::pipeline_jobs:
   async_experiments: {}
   backdrop-transactions-explorer-collector: {}
   cdn-acceptance-tests: {}
+  content-publisher: {}
   deprecated_columns: {}
   email-alert-monitoring: {}
   event-store: {}


### PR DESCRIPTION
This is added temporarily so we can get CI before it is added in as a deployable application.