### PR TITLE
Clone alphagov/packager over https not ssh

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/build_fpm_package.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/build_fpm_package.yaml.erb
@@ -3,7 +3,7 @@
     name: build_fpm_package
     scm:
         - git:
-            url: git@github.com:alphagov/packager.git
+            url: https://github.com/alphagov/packager
             branches:
               - master
 


### PR DESCRIPTION
The build_fpm_package job was failing due to Jenkins being unable to authenticate to Github over SSH. As https://github.com/alphagov/packager is a public repo, just clone it over HTTPS.