### PR TITLE
Add JWS_AUTH_SECRET to collections-publisher

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -363,6 +363,7 @@ govuk::apps::collections::nagios_memory_warning: 900
 govuk::apps::collections::nagios_memory_critical: 1000
 
 govuk::apps::collections_publisher::db_hostname: "mysql-master-1.backend"
+govuk::apps::collections_publisher::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
 govuk::apps::collections_publisher::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::collections_publisher::redis_port: "%{hiera('sidekiq_port')}"
 

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -380,6 +380,7 @@ govuk::apps::collections::nagios_memory_warning: 900
 govuk::apps::collections::nagios_memory_critical: 1000
 
 govuk::apps::collections_publisher::db_hostname: "mysql-primary"
+govuk::apps::collections_publisher::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
 govuk::apps::collections_publisher::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::collections_publisher::redis_port: "%{hiera('sidekiq_port')}"
 

--- a/modules/govuk/manifests/apps/collections_publisher.pp
+++ b/modules/govuk/manifests/apps/collections_publisher.pp
@@ -42,6 +42,10 @@
 # [*db_name*]
 #   The database name to use in the DATABASE_URL.
 #
+# [*jwt_auth_secret*]
+#   The secret used to encode JWT authentication tokens. This value needs to be
+#   shared with authenticating-proxy which decodes the tokens.
+#
 # [*redis_host*]
 #   Redis host for Sidekiq.
 #   Default: undef
@@ -64,6 +68,7 @@ class govuk::apps::collections_publisher(
   $db_name = 'collections_publisher_production',
   $redis_host = undef,
   $redis_port = undef,
+  $jwt_auth_secret = undef,
 ) {
   $app_name = 'collections-publisher'
 
@@ -104,6 +109,9 @@ class govuk::apps::collections_publisher(
     "${title}-PUBLISHING_API_BEARER_TOKEN":
       varname => 'PUBLISHING_API_BEARER_TOKEN',
       value   => $publishing_api_bearer_token;
+    "${title}-JWT_AUTH_SECRET":
+      varname => 'JWT_AUTH_SECRET',
+      value   => $jwt_auth_secret;
   }
 
   if $::govuk_node_class !~ /^development$/ {


### PR DESCRIPTION
Trello: https://trello.com/c/9ZMVHe0u

## Motivation
We want to allow people with an access_limiting token to be able to view content published
by collections-publisher on the draft stack without the need of a signon account.

The first step is to create JWS_AUTH_SECRET environment variable that will be used to generate
the token.