### PR TITLE
Add content publisher app

### DIFF
--- a/development-vm/Pinfile
+++ b/development-vm/Pinfile
@@ -17,6 +17,7 @@ process :'collections-publisher-worker'
 process :'contacts-admin' => [:'publishing-api', :whitehall]
 process :'content-audit-tool' => [:'publishing-api-read', :'content-audit-tool-sidekiq-google-analytics', :'content-audit-tool-sidekiq-publishing-api']
 process :'content-performance-manager' => [:'publishing-api', :'content-performance-manager-sidekiq-google-analytics', :'content-performance-manager-sidekiq-publishing-api', :'content-performance-manager-publishing-api-consumer', 'content-store' , 'content-performance-manager-bulk-import-publishing-api-consumer']
+process :'content-publisher'
 process :'content-store'
 # Example usage: bowl [your-app] dummy-content-store --without content-store
 process :'dummy-content-store'

--- a/development-vm/Procfile
+++ b/development-vm/Procfile
@@ -174,3 +174,4 @@ organisations-publisher-sidekiq:                     govuk_setenv organisations-
 organisations-publisher: govuk_setenv organisations-publisher ./run_in.sh ../../organisations-publisher bundle exec rails s -p 3218
 # sidekiq-monitoring for organisations-publisher uses port 3219
 # ckan uses 3220
+content-publisher: govuk_setenv content-publisher ./run_in.sh ../../content-publisher bundle exec rails s -p 3221

--- a/development-vm/alphagov_repos
+++ b/development-vm/alphagov_repos
@@ -4,6 +4,7 @@ calendars
 collections
 collections-publisher
 contacts-admin
+content-publisher
 content-store
 content-tagger
 email-alert-api

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -23,6 +23,7 @@ node_class: &node_class
       - contacts
       - content-audit-tool
       - content-performance-manager
+      - content-publisher
       - content-tagger
       - event-store
       - hmrc-manuals-api
@@ -151,6 +152,7 @@ deployable_applications: &deployable_applications
     repository: 'contacts-admin'
   content-audit-tool: {}
   content-performance-manager: {}
+  content-publisher: {}
   content-store: {}
   content-tagger: {}
   email-alert-api: {}
@@ -388,6 +390,8 @@ govuk::apps::content_performance_manager::rabbitmq_hosts:
 govuk::apps::content_performance_manager::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::content_performance_manager::redis_port: "%{hiera('sidekiq_port')}"
 
+govuk::apps::content_publisher::db_hostname: "postgresql-primary-1.backend"
+govuk::apps::content_publisher::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 
 govuk::apps::content_store::nagios_memory_warning: 2300
 govuk::apps::content_store::nagios_memory_critical: 2500
@@ -742,7 +746,6 @@ govuk_ci::master::pipeline_jobs:
   async_experiments: {}
   backdrop-transactions-explorer-collector: {}
   cdn-acceptance-tests: {}
-  content-publisher: {}
   deprecated_columns: {}
   email-alert-monitoring: {}
   event-store: {}
@@ -1031,6 +1034,7 @@ grafana::dashboards::deployment_applications:
   content-performance-manager:
     show_sidekiq_graphs: true
     has_workers: true
+  content-publisher: {}
   content-store:
     dependent_app_5xx_errors:
       - calendars
@@ -1355,6 +1359,7 @@ hosts::production::backend::app_hostnames:
   - 'contacts-admin'
   - 'content-audit-tool'
   - 'content-performance-manager'
+  - 'content-publisher'
   - 'content-tagger'
   - 'docs'
   - 'draft-whitehall-frontend'

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -32,6 +32,7 @@ govuk::node::s_development::apps:
   - 'content_audit_tool'
   - 'content_performance_manager'
   - 'content_performance_manager::rabbitmq'
+  - 'content_publisher'
   - 'content_store'
   - 'content_store::enable_running_in_draft_mode'
   - 'content_tagger'
@@ -107,6 +108,7 @@ govuk::apps::content_store::mongodb_name: 'content_store_development'
 govuk::apps::content_performance_manager::rabbitmq_user: 'content_performance_manager'
 govuk::apps::content_performance_manager::rabbitmq_hosts: ['localhost']
 govuk::apps::content_performance_manager::rabbitmq::amqp_pass: 'content_performance_manager'
+govuk::apps::content_publisher::enabled: true
 govuk::apps::content_tagger::enable_procfile_worker: false
 govuk::apps::email_alert_api::enable_procfile_worker: false
 govuk::apps::email_alert_service::rabbitmq_hosts: ['localhost']
@@ -259,6 +261,7 @@ hosts::development::apps:
   - 'collections'
   - 'collections-publisher'
   - 'contacts-admin'
+  - 'content-publisher'
   - 'content-store'
   - 'content-tagger'
   - 'draft-assets'

--- a/hieradata/vagrant_credentials.yaml
+++ b/hieradata/vagrant_credentials.yaml
@@ -38,6 +38,8 @@ govuk::apps::content_audit_tool::db::password: 'MDgTmQKvEAax4wgefQAZRNDTajkdtEVf
 govuk::apps::content_audit_tool::db_password: "%{hiera('govuk::apps::content_audit_tool::db::password')}"
 govuk::apps::content_performance_manager::db_password: "%{hiera('govuk::apps::content_performance_manager::db::password')}"
 govuk::apps::content_performance_manager::db::password: 'jo6Kah0kuokaighoughePhooch1Eequu'
+govuk::apps::content_publisher::db_password: "%{hiera('govuk::apps::content_publisher::db::password')}"
+govuk::apps::content_publisher::db::password: 'a7NnCu8JNPcKsYDFJpC3HpbxsdZYttMt'
 govuk::apps::content_tagger::db_password: "%{hiera('govuk::apps::content_tagger::db::password')}"
 govuk::apps::content_tagger::db::password: '6bab0d694abaabc64f4b40fcd7e51'
 govuk::apps::email_alert_api::db::password: '8WB3h7RXohmTvmU7bmmDK4ppsd8BU7Ki'

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -21,6 +21,7 @@ node_class: &node_class
       - contacts
       - content-audit-tool
       - content-performance-manager
+      - content-publisher
       - content-tagger
       - event-store
       - hmrc-manuals-api
@@ -154,6 +155,7 @@ deployable_applications: &deployable_applications
     repository: 'contacts-admin'
   content-audit-tool: {}
   content-performance-manager: {}
+  content-publisher: {}
   content-store: {}
   content-tagger: {}
   email-alert-api: {}
@@ -402,6 +404,10 @@ govuk::apps::content_performance_manager::rabbitmq_hosts:
   - rabbitmq
 govuk::apps::content_performance_manager::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::content_performance_manager::redis_port: "%{hiera('sidekiq_port')}"
+
+govuk::apps::content_publisher::db_hostname: "postgresql-primary"
+govuk::apps::content_publisher::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
+govuk::apps::content_publisher::rds: true
 
 govuk::apps::content_store::nagios_memory_warning: 2300
 govuk::apps::content_store::nagios_memory_critical: 2500
@@ -894,6 +900,7 @@ grafana::dashboards::deployment_applications:
   content-performance-manager:
     show_sidekiq_graphs: true
     has_workers: true
+  content-publisher: {}
   content-store:
     dependent_app_5xx_errors:
       - calendars

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -11,6 +11,7 @@ cron::daily_hour: 6
 govuk::apps::asset_manager::aws_s3_bucket_name: 'govuk-assets-integration'
 govuk::apps::asset_manager::aws_region: 'eu-west-1'
 
+govuk::apps::content_publisher::enabled: true
 govuk::apps::email_alert_api::email_archive_s3_bucket: 'govuk-integration-email-alert-api-archive'
 govuk::apps::email_alert_api::email_archive_s3_enabled: true
 govuk::apps::email_alert_api::govuk_notify_template_id: '1fc69d3a-09a2-40f9-852b-03f6fcef5340'

--- a/modules/govuk/manifests/apps/content_publisher.pp
+++ b/modules/govuk/manifests/apps/content_publisher.pp
@@ -1,0 +1,93 @@
+# == Class: govuk::apps::content-publisher
+#
+# Read more: https://github.com/alphagov/content-publisher
+#
+# === Parameters
+# [*port*]
+#   What port should the app run on? Find the next free one in development-vm/Procfile
+#
+# [*enabled*]
+#   Whether to install the app. Don't change the default (false) until production-ready
+#
+# [*secret_key_base*]
+#   The key for Rails to use when signing/encrypting sessions (in govuk-secrets)
+#
+# [*sentry_dsn*]
+#   The app-specific URL used by Sentry to report exceptions (in govuk-secrets)
+#
+# [*oauth_id*]
+#   The OAuth ID used to identify the app to GOV.UK Signon (in govuk-secrets)
+#
+# [*oauth_secret*]
+#   The OAuth secret used to authenticate the app to GOV.UK Signon (in govuk-secrets)
+#
+# [*db_hostname*]
+#   The hostname of the database server to use for in DATABASE_URL environment variable
+#
+# [*db_username*]
+#   The username to use for the DATABASE_URL environment variable
+#
+# [*db_password*]
+#   The password to use for the DATABASE_URL environment variable
+#
+# [*db_name*]
+#   The database name to use for the DATABASE_URL environment variable
+#
+class govuk::apps::content_publisher (
+  $port = '3221',
+  $enabled = false,
+  $secret_key_base = undef,
+  $sentry_dsn = undef,
+  $oauth_id = undef,
+  $oauth_secret = undef,
+  $db_hostname = undef,
+  $db_password = undef,
+  $db_name = 'content_publisher_production',
+) {
+  $app_name = 'content-publisher'
+
+  $ensure = $enabled ? {
+    true  => 'present',
+    false => 'absent',
+  }
+
+  # see modules/govuk/manifests/app.pp for more options
+  govuk::app { $app_name:
+    ensure            => $ensure,
+    app_type          => 'rack',
+    port              => $port,
+    sentry_dsn        => $sentry_dsn,
+    vhost_ssl_only    => true,
+    health_check_path => '/healthcheck', # must return HTTP 200 for an unauthenticated request
+    deny_framing      => true,
+    asset_pipeline    => true,
+  }
+
+  Govuk::App::Envvar {
+    app               => $app_name,
+    ensure            => $ensure,
+    notify_service    => $enabled,
+  }
+
+  govuk::app::envvar {
+    "${title}-SECRET_KEY_BASE":
+      varname => 'SECRET_KEY_BASE',
+      value   => $secret_key_base;
+    "${title}-OAUTH_ID":
+      varname => 'OAUTH_ID',
+      value   => $oauth_id;
+    "${title}-OAUTH_SECRET":
+      varname => 'OAUTH_SECRET',
+      value   => $oauth_secret;
+  }
+
+  if $::govuk_node_class !~ /^development$/ {
+    govuk::app::envvar::database_url { $app_name:
+      type     => 'postgresql',
+      username => $app_name,
+      password => $db_password,
+      host     => $db_hostname,
+      database => $db_name,
+    }
+  }
+}

--- a/modules/govuk/manifests/apps/content_publisher/db.pp
+++ b/modules/govuk/manifests/apps/content_publisher/db.pp
@@ -1,0 +1,26 @@
+# == Class: govuk::apps::content_publisher::db
+#
+# === Parameters
+#
+# [*password*]
+#   The DB instance password.
+#
+# [*backend_ip_range*]
+#   Backend IP addresses to allow access to the database.
+#
+# [*rds*]
+#   Whether to use RDS i.e. when running on AWS
+#
+class govuk::apps::content_publisher::db (
+  $password,
+  $backend_ip_range = '10.3.0.0/16',
+  $rds = false,
+) {
+  govuk_postgresql::db { 'content_publisher_production':
+    user                    => 'content_publisher',
+    password                => $password,
+    allow_auth_from_backend => true,
+    backend_ip_range        => $backend_ip_range,
+    rds                     => $rds,
+  }
+}

--- a/modules/govuk/manifests/node/s_backend_lb.pp
+++ b/modules/govuk/manifests/node/s_backend_lb.pp
@@ -54,6 +54,7 @@ class govuk::node::s_backend_lb (
     'contacts-admin',
     'content-audit-tool',
     'content-performance-manager',
+    'content-publisher',
     'content-tagger',
     'imminence',
     'link-checker-api',

--- a/modules/govuk/manifests/node/s_db_admin.pp
+++ b/modules/govuk/manifests/node/s_db_admin.pp
@@ -141,6 +141,7 @@ class govuk::node::s_db_admin(
 
   # include all PostgreSQL classes that create databases and users
   class { '::govuk::apps::content_audit_tool::db': } ->
+  class { '::govuk::apps::content_publisher::db': } ->
   class { '::govuk::apps::content_tagger::db': } ->
   class { '::govuk::apps::email_alert_api::db': } ->
   class { '::govuk::apps::link_checker_api::db': } ->

--- a/modules/govuk/manifests/node/s_postgresql_base.pp
+++ b/modules/govuk/manifests/node/s_postgresql_base.pp
@@ -5,6 +5,7 @@
 class govuk::node::s_postgresql_base inherits govuk::node::s_base {
   include govuk::apps::ckan::db
   include govuk::apps::content_audit_tool::db
+  include govuk::apps::content_publisher::db
   include govuk::apps::content_tagger::db
   include govuk::apps::email_alert_api::db
   include govuk::apps::link_checker_api::db

--- a/modules/grafana/files/dashboards/processes.json
+++ b/modules/grafana/files/dashboards/processes.json
@@ -1167,6 +1167,11 @@
             "selected": true
           },
           {
+            "text": "processes-app-content-publisher",
+            "value": "processes-app-content-publisher",
+            "selected": false
+          },
+          {
             "text": "processes-app-content-tagger",
             "value": "processes-app-content-tagger",
             "selected": false


### PR DESCRIPTION
https://trello.com/c/CPWJzL9y/5-create-skeleton-rails-app

This PR adds a new Rails app (content-publisher) with additional configuration for Postgres and Grafana. We've only enabled the app for integration to avoid spurious staging/production alerts.