### PR TITLE
Try removing cyclic dependency for db_admin

### DIFF
--- a/modules/govuk/manifests/node/s_db_admin.pp
+++ b/modules/govuk/manifests/node/s_db_admin.pp
@@ -141,7 +141,6 @@ class govuk::node::s_db_admin(
 
   # include all PostgreSQL classes that create databases and users
   class { '::govuk::apps::content_audit_tool::db': } ->
-  class { '::govuk::apps::content_publisher::db': } ->
   class { '::govuk::apps::content_tagger::db': } ->
   class { '::govuk::apps::email_alert_api::db': } ->
   class { '::govuk::apps::link_checker_api::db': } ->
@@ -150,7 +149,8 @@ class govuk::node::s_db_admin(
   class { '::govuk::apps::policy_publisher::db': } ->
   class { '::govuk::apps::publishing_api::db': } ->
   class { '::govuk::apps::service_manual_publisher::db': } ->
-  class { '::govuk::apps::support_api::db': }
+  class { '::govuk::apps::support_api::db': } ->
+  class { '::govuk::apps::content_publisher::db': }
 
   $postgres_backup_desc = 'RDS PostgreSQL backup to S3'
 


### PR DESCRIPTION
https://trello.com/c/CPWJzL9y/5-create-skeleton-rails-app

The puppet logs are showing a cyclic dependency involving
content_audit_tool and content_publisher when attempting to modify the
pg_hba config for the latter. It's unclear why there's a dependency
chain for these databases, but since content_publisher is new it's
possible the previous dependencies were satisfied 'in bulk' at some
point, while new dependencies should be at the top of the list.