### PR TITLE
Fix incorrect user for content-publisher DB

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -391,7 +391,7 @@ govuk::apps::content_performance_manager::rabbitmq_hosts:
 govuk::apps::content_performance_manager::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::content_performance_manager::redis_port: "%{hiera('sidekiq_port')}"
 
-govuk::apps::content_publisher::db_hostname: "postgresql-primary-1.backend"
+govuk::apps::content_publisher::db::hostname: "postgresql-primary-1.backend"
 govuk::apps::content_publisher::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 
 govuk::apps::content_store::nagios_memory_warning: 2300

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -406,7 +406,7 @@ govuk::apps::content_performance_manager::rabbitmq_hosts:
 govuk::apps::content_performance_manager::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::content_performance_manager::redis_port: "%{hiera('sidekiq_port')}"
 
-govuk::apps::content_publisher::db_hostname: "postgresql-primary"
+govuk::apps::content_publisher::db::hostname: "postgresql-primary"
 govuk::apps::content_publisher::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 govuk::apps::content_publisher::db::rds: true
 

--- a/modules/govuk/manifests/apps/content_publisher.pp
+++ b/modules/govuk/manifests/apps/content_publisher.pp
@@ -21,28 +21,13 @@
 # [*oauth_secret*]
 #   The OAuth secret used to authenticate the app to GOV.UK Signon (in govuk-secrets)
 #
-# [*db_hostname*]
-#   The hostname of the database server to use for in DATABASE_URL environment variable
-#
-# [*db_username*]
-#   The username to use for the DATABASE_URL environment variable
-#
-# [*db_password*]
-#   The password to use for the DATABASE_URL environment variable
-#
-# [*db_name*]
-#   The database name to use for the DATABASE_URL environment variable
-#
 class govuk::apps::content_publisher (
   $port = '3221',
   $enabled = false,
   $secret_key_base = undef,
   $sentry_dsn = undef,
   $oauth_id = undef,
-  $oauth_secret = undef,
-  $db_hostname = undef,
-  $db_password = undef,
-  $db_name = 'content_publisher_production',
+  $oauth_secret = undef
 ) {
   $app_name = 'content-publisher'
 
@@ -79,15 +64,5 @@ class govuk::apps::content_publisher (
     "${title}-OAUTH_SECRET":
       varname => 'OAUTH_SECRET',
       value   => $oauth_secret;
-  }
-
-  if $::govuk_node_class !~ /^development$/ {
-    govuk::app::envvar::database_url { $app_name:
-      type     => 'postgresql',
-      username => $app_name,
-      password => $db_password,
-      host     => $db_hostname,
-      database => $db_name,
-    }
   }
 }

--- a/modules/govuk/manifests/apps/content_publisher/db.pp
+++ b/modules/govuk/manifests/apps/content_publisher/db.pp
@@ -2,8 +2,14 @@
 #
 # === Parameters
 #
+# [*user*]
+#   The DB instance user.
+#
 # [*password*]
 #   The DB instance password.
+#
+# [*hostname*]
+#   The DB instance hostname.
 #
 # [*backend_ip_range*]
 #   Backend IP addresses to allow access to the database.
@@ -12,15 +18,27 @@
 #   Whether to use RDS i.e. when running on AWS
 #
 class govuk::apps::content_publisher::db (
+  $user = 'content_publisher',
+  $hostname,
   $password,
   $backend_ip_range = '10.3.0.0/16',
   $rds = false,
 ) {
-  govuk_postgresql::db { 'content_publisher_production':
-    user                    => 'content_publisher',
+  govuk_postgresql::db { "${user}_production":
+    user                    => $user,
     password                => $password,
     allow_auth_from_backend => true,
     backend_ip_range        => $backend_ip_range,
     rds                     => $rds,
+  }
+
+  if $::govuk_node_class !~ /^development$/ {
+    govuk::app::envvar::database_url { $app_name:
+      type     => 'postgresql',
+      username => $user,
+      password => $password,
+      host     => $hostname,
+      database => "${user}_production"
+    }
   }
 }


### PR DESCRIPTION
https://trello.com/c/CPWJzL9y/5-create-skeleton-rails-app

Using a combination of literal strings and variables with different
conventions for '-' and '_' made this mistake easy to make.

Instead of simply correcting the error, we've also moved similar uses of
content-publisher/content_publisher into the same class, and removed
uses of literal strings, as well as recommending others do the same.

We will make a corresponding update in govuk-secrets to remove the need
for db::password and db_password to be set for content-publisher.