### PR TITLE
Fix content-publisher integration DB user

### DIFF
--- a/hieradata/vagrant_credentials.yaml
+++ b/hieradata/vagrant_credentials.yaml
@@ -38,8 +38,7 @@ govuk::apps::content_audit_tool::db::password: 'MDgTmQKvEAax4wgefQAZRNDTajkdtEVf
 govuk::apps::content_audit_tool::db_password: "%{hiera('govuk::apps::content_audit_tool::db::password')}"
 govuk::apps::content_performance_manager::db_password: "%{hiera('govuk::apps::content_performance_manager::db::password')}"
 govuk::apps::content_performance_manager::db::password: 'jo6Kah0kuokaighoughePhooch1Eequu'
-govuk::apps::content_publisher::db_password: "%{hiera('govuk::apps::content_publisher::db::password')}"
-govuk::apps::content_publisher::db::password: 'a7NnCu8JNPcKsYDFJpC3HpbxsdZYttMt'
+govuk::apps::content_publisher::db_password: 'a7NnCu8JNPcKsYDFJpC3HpbxsdZYttMt'
 govuk::apps::content_tagger::db_password: "%{hiera('govuk::apps::content_tagger::db::password')}"
 govuk::apps::content_tagger::db::password: '6bab0d694abaabc64f4b40fcd7e51'
 govuk::apps::email_alert_api::db::password: '8WB3h7RXohmTvmU7bmmDK4ppsd8BU7Ki'

--- a/modules/govuk/manifests/apps/content_publisher.pp
+++ b/modules/govuk/manifests/apps/content_publisher.pp
@@ -40,6 +40,7 @@ class govuk::apps::content_publisher (
   $sentry_dsn = undef,
   $oauth_id = undef,
   $oauth_secret = undef,
+  $db_username = 'content_publisher',
   $db_hostname = undef,
   $db_password = undef,
   $db_name = 'content_publisher_production',
@@ -84,7 +85,7 @@ class govuk::apps::content_publisher (
   if $::govuk_node_class !~ /^development$/ {
     govuk::app::envvar::database_url { $app_name:
       type     => 'postgresql',
-      username => $app_name,
+      username => $db_username,
       password => $db_password,
       host     => $db_hostname,
       database => $db_name,

--- a/modules/govuk/manifests/apps/content_publisher/db.pp
+++ b/modules/govuk/manifests/apps/content_publisher/db.pp
@@ -2,9 +2,6 @@
 #
 # === Parameters
 #
-# [*password*]
-#   The DB instance password.
-#
 # [*backend_ip_range*]
 #   Backend IP addresses to allow access to the database.
 #
@@ -12,13 +9,12 @@
 #   Whether to use RDS i.e. when running on AWS
 #
 class govuk::apps::content_publisher::db (
-  $password,
   $backend_ip_range = '10.3.0.0/16',
   $rds = false,
 ) {
-  govuk_postgresql::db { 'content_publisher_production':
-    user                    => 'content_publisher',
-    password                => $password,
+  govuk_postgresql::db { $govuk::apps::content_publisher::db_name:
+    user                    => $govuk::apps::content_publisher::db_username,
+    password                => $govuk::apps::content_publisher::db_password,
     allow_auth_from_backend => true,
     backend_ip_range        => $backend_ip_range,
     rds                     => $rds,


### PR DESCRIPTION
https://trello.com/c/CPWJzL9y/5-create-skeleton-rails-app

The DB user should be snake case, but was previously being set using the
app_name variable, which uses hyphens. This mistake was easy to make due
to the use of literal strings and variables, which has now been fixed by
centralising all the variables and explicitly referring to them in db.

We will make a corresponding change in govuk-secrets for content-publisher.