### PR TITLE
Fix content publisher DB params

### DIFF
--- a/docs/adding-a-new-app.md
+++ b/docs/adding-a-new-app.md
@@ -114,14 +114,25 @@ Also add a file in `modules/govuk/manifests/apps/my_app` named `db.pp`:
 # [*rds*]
 #   Whether to use RDS i.e. when running on AWS
 #
+# [*username*]
+#   The DB instance username.
+#
+# [*password*]
+#   The DB instance password.
+#
+# [*db_name*]
+#   The DB instance name.
+#
 class govuk::apps::myapp::db (
-  $password,
   $backend_ip_range = '10.3.0.0/16',
   $rds = false,
+  $username = 'myapp',
+  $password = undef,
+  $name = 'myapp_production',
 ) {
-  govuk_postgresql::db { $govuk::apps::myapp::db_name:
-    user                    => $govuk::apps::myapp::db_username,
-    password                => $govuk::apps::myapp::db_password,
+  govuk_postgresql::db { $db_name:
+    user                    => $username,
+    password                => $password,
     allow_auth_from_backend => true,
     backend_ip_range        => $backend_ip_range,
     rds                     => $rds,

--- a/hieradata/vagrant_credentials.yaml
+++ b/hieradata/vagrant_credentials.yaml
@@ -38,7 +38,8 @@ govuk::apps::content_audit_tool::db::password: 'MDgTmQKvEAax4wgefQAZRNDTajkdtEVf
 govuk::apps::content_audit_tool::db_password: "%{hiera('govuk::apps::content_audit_tool::db::password')}"
 govuk::apps::content_performance_manager::db_password: "%{hiera('govuk::apps::content_performance_manager::db::password')}"
 govuk::apps::content_performance_manager::db::password: 'jo6Kah0kuokaighoughePhooch1Eequu'
-govuk::apps::content_publisher::db_password: 'a7NnCu8JNPcKsYDFJpC3HpbxsdZYttMt'
+govuk::apps::eontent_publisher::db::password: 'a7NnCu8JNPcKsYDFJpC3HpbxsdZYttMt'
+govuk::apps::content_publisher::db_password: "%{hiera('govuk::apps::content_publisher::db::password')}"
 govuk::apps::content_tagger::db_password: "%{hiera('govuk::apps::content_tagger::db::password')}"
 govuk::apps::content_tagger::db::password: '6bab0d694abaabc64f4b40fcd7e51'
 govuk::apps::email_alert_api::db::password: '8WB3h7RXohmTvmU7bmmDK4ppsd8BU7Ki'

--- a/modules/govuk/manifests/apps/content_publisher/db.pp
+++ b/modules/govuk/manifests/apps/content_publisher/db.pp
@@ -8,13 +8,25 @@
 # [*rds*]
 #   Whether to use RDS i.e. when running on AWS
 #
+# [*username*]
+#   The DB instance username.
+#
+# [*password*]
+#   The DB instance password.
+#
+# [*name*]
+#   The DB instance name.
+#
 class govuk::apps::content_publisher::db (
   $backend_ip_range = '10.3.0.0/16',
   $rds = false,
+  $username = 'content_publisher',
+  $password = undef,
+  $db_name = 'content_publisher_production',
 ) {
-  govuk_postgresql::db { $govuk::apps::content_publisher::db_name:
-    user                    => $govuk::apps::content_publisher::db_username,
-    password                => $govuk::apps::content_publisher::db_password,
+  govuk_postgresql::db { $db_name:
+    user                    => $username,
+    password                => $password,
     allow_auth_from_backend => true,
     backend_ip_range        => $backend_ip_range,
     rds                     => $rds,


### PR DESCRIPTION
https://trello.com/c/CPWJzL9y/5-create-skeleton-rails-app

A previous attempt to re-use the DB parameters passed to the app
content-publisher class was unsuccessful, so this PR reverts back to
the previous method of passing the params separately to each class,
while retaining the advantage of avoiding literal strings within the
class.