### PR TITLE
Remove unused postgres block in collectd defaults

### DIFF
--- a/modules/collectd/templates/etc/collectd/conf.d/postgresql.conf.erb
+++ b/modules/collectd/templates/etc/collectd/conf.d/postgresql.conf.erb
@@ -47,13 +47,4 @@ LoadPlugin postgresql
     Query global_backends
     Query global_xlog_position
   </Database>
-
-  <Database postgres>
-    Host "localhost"
-    User "<%= @user %>"
-    Password "<%= @password %>"
-    SSLMode "prefer"
-    # By not specifying a specific query, we pull in the defaults
-    # which are specific to the `postgres` database
-  </Database>
 </Plugin>


### PR DESCRIPTION
The 00-postgresql config contains a standalone database block, which
monitors the postgres database. Because this database has no tables,
collectd continually spams its log file with a parsing error. Removing
this block has no effect on the monitoring of other databases.

https://github.com/collectd/collectd/issues/1905