### PR TITLE
Surround collectd database names with quotes

### DIFF
--- a/modules/collectd/templates/etc/collectd/conf.d/postgresql.conf.erb
+++ b/modules/collectd/templates/etc/collectd/conf.d/postgresql.conf.erb
@@ -37,7 +37,7 @@ LoadPlugin postgresql
     </Result>
   </Query>
 
-  <Database postgres>
+  <Database "postgres">
     Instance "global"
     Host "localhost"
     User "<%= @user %>"

--- a/modules/collectd/templates/etc/collectd/conf.d/postgresql_db.conf.erb
+++ b/modules/collectd/templates/etc/collectd/conf.d/postgresql_db.conf.erb
@@ -1,9 +1,9 @@
 <Plugin postgresql>
-    <Database <%= @title %>>
-	Host "localhost"
-	Port "5432"
-	User "collectd"
-	Password "<%= @password %>"
-	SSLMode "prefer"
-    </Database>
+  <Database "<%= @title %>">
+    Host "localhost"
+    Port "5432"
+    User "collectd"
+    Password "<%= @password %>"
+    SSLMode "prefer"
+  </Database>
 </Plugin>


### PR DESCRIPTION
Collectd warns on startup that the name of the database for the
postgresql plugin is not a single argument - surrounding with quotes
stops this warning from occuring but doesn't affect the function.