### PR TITLE
Revert "Revert "Install custom-built gdal 1.11.5 on mapit servers""

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -333,6 +333,8 @@ filebeat::prospectors:
     fields:
       application: 'apt'
 
+gdal::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+
 govuk::apps::asset_manager::mongodb_nodes:
   - 'mongo-1.backend'
   - 'mongo-2.backend'
@@ -448,6 +450,8 @@ govuk::apps::link_checker_api::redis_port: "%{hiera('sidekiq_port')}"
 
 govuk::apps::manuals_publisher::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::manuals_publisher::redis_port: "%{hiera('sidekiq_port')}"
+
+govuk::apps::mapit::gdal_version: "1.11.5"
 
 govuk::apps::publisher::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
 govuk::apps::publisher::redis_host: "%{hiera('sidekiq_host')}"

--- a/modules/gdal/manifests/repo.pp
+++ b/modules/gdal/manifests/repo.pp
@@ -1,0 +1,17 @@
+# == Class: gdal::repo
+#
+# === Parameters:
+#
+# [*apt_mirror_hostname*]
+#   Hostname to use for the APT mirror.
+#
+class gdal::repo (
+  $apt_mirror_hostname,
+) {
+  apt::source { 'gdal':
+    location     => "http://${apt_mirror_hostname}/gdal",
+    release      => 'stable',
+    architecture => $::architecture,
+    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+  }
+}

--- a/modules/govuk/manifests/apps/mapit.pp
+++ b/modules/govuk/manifests/apps/mapit.pp
@@ -23,6 +23,7 @@ class govuk::apps::mapit (
   $db_password,
   $django_secret_key = undef,
   $sentry_dsn = undef,
+  $gdal_version,
 ) {
   if $enabled {
     govuk::app { 'mapit':
@@ -45,16 +46,27 @@ class govuk::apps::mapit (
 
     package {
       [
-        # These three packages are recommended when installing geospatial
+        # These packages are recommended when installing geospatial
         # support for Django:
         # https://docs.djangoproject.com/en/1.8/ref/contrib/gis/install/geolibs/
         'binutils',
         'libproj-dev',
-        'gdal-bin',
-        # This is also needed to be able to install python GDAL packages:
-        'libgdal-dev',
       ]:
       ensure => present,
+    }
+
+    package {
+      [
+        'gdal-bin',
+        'libgdal-dev',
+      ]:
+      ensure => absent,
+    }
+
+    include gdal::repo
+    package { 'gdal':
+      ensure  => $gdal_version,
+      require => Class['gdal::repo'],
     }
   }
 


### PR DESCRIPTION
Reverts alphagov/govuk-puppet#7769

Puppet is disabled on mapit 1 and 2 on integration, staging, and production.