### PR TITLE
Alert on the Publishing API downstream_high latency

### DIFF
--- a/modules/monitoring/manifests/checks/sidekiq.pp
+++ b/modules/monitoring/manifests/checks/sidekiq.pp
@@ -45,6 +45,21 @@ class monitoring::checks::sidekiq (
     args      => '--dropfirst -60',
   }
 
+  @@icinga::check::graphite { 'check_publishing_api_downstream_high_queue_latency':
+    target              => 'transformNull(keepLastValue(maxSeries(stats.gauges.govuk.app.publishing-api.*.workers.queues.downstream_high.latency)), 0)',
+    warning             => 20, # seconds
+    critical            => 60, # seconds
+    # Use data from the last 24 hours, to avoid not getting any
+    # datapoints back.
+    from                => '24hours',
+    # Take an average over the most recent 36 datapoints, which at 5
+    # seconds per datapoint is the last 3 minutes
+    args                => '--dropfirst -36',
+    desc                => 'Check Publishing API downstream_high queue latency',
+    host_name           => $::fqdn,
+    notification_period => 'inoffice',
+  }
+
   if $enable_support_check {
     icinga::check::graphite { 'check_support_default_queue_size':
       target    => 'transformNull(averageSeries(keepLastValue(stats.gauges.govuk.app.support.*.workers.queues.default.enqueued)), 0)',


### PR DESCRIPTION
The downstream_high queue in the Publishing API is a Sidekiq queue
used to process new and changed content which is a direct result of a
publisher action, for example, someone pressing a publish button.

It's expected that jobs in this queue are processed very quickly, so
the warning threshold has been set to 20 seconds, and the critical
threshold to 60 seconds.

As this is a new alert, just have it notify people in hours, but I'd
consider also alerting on this out of hours eventually.