### PR TITLE
Add a rake task to count the number of superfluous taggings.

### DIFF
--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -41,6 +41,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::publication_delay_report
   - govuk_jenkins::jobs::publishing_api_archive_events
   - govuk_jenkins::jobs::record_taxonomy_metrics
+  - govuk_jenkins::jobs::record_superfluous_taggings_metrics
   - govuk_jenkins::jobs::remove_emergency_banner
   - govuk_jenkins::jobs::run_rake_task
   - govuk_jenkins::jobs::run_whitehall_data_migrations

--- a/modules/govuk_jenkins/manifests/jobs/record_superfluous_taggings_metrics.pp
+++ b/modules/govuk_jenkins/manifests/jobs/record_superfluous_taggings_metrics.pp
@@ -1,0 +1,11 @@
+# == Class: govuk_jenkins::jobs::record_taxonomy_metrics
+#
+# Create a file on disk that can be parsed by jenkins-job-builder
+#
+class govuk_jenkins::jobs::record_superfluous_taggings_metrics {
+  file { '/etc/jenkins_jobs/jobs/record_superfluous_taggings_metrics.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/record_superfluous_taggings_metrics.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+}

--- a/modules/govuk_jenkins/templates/jobs/record_superfluous_taggings_metrics.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/record_superfluous_taggings_metrics.yaml.erb
@@ -1,0 +1,27 @@
+---
+- job:
+    name: record_superfluous_taggings_metrics
+    display-name: Record the number of superfluous taggings in the Topic Taxonomy
+    project-type: freestyle
+    description: |
+      This job runs a rake task in Content Tagger to send the number of superfluous taggings
+      in the Topic Taxonomy to statsd. These are content items that are tagged to a particular
+      taxon and to an ancestor taxon.
+    logrotate:
+      daysToKeep: 30
+    triggers:
+      - timed: 'H 3 * * *'
+    properties:
+      - build-discarder:
+          days-to-keep: 30
+          artifact-num-to-keep: 5
+    builders:
+      - shell: |
+          #!/bin/bash
+          set -eu
+
+          cd "${WORKSPACE}"
+
+          CONTENT_TAGGER=$(govuk_node_list --single-node -c backend)
+
+          ssh deploy@$CONTENT_TAGGER "cd /var/apps/content-tagger && govuk_setenv content-tagger bundle exec rake metrics:taxonomy:record_number_of_superfluous_taggings_metrics"


### PR DESCRIPTION
This runs every day at 3 AM and counts all content that is tagged
to a taxon and its ancestor.

Trello: https://trello.com/c/VOLclckO/18-start-tracking-the-number-of-superfluous-tags-to-the-topic-taxonomy