### PR TITLE
Add Superfluous tagging metric to grafana

### DIFF
--- a/modules/grafana/files/dashboards/topic_taxonomy.json
+++ b/modules/grafana/files/dashboards/topic_taxonomy.json
@@ -1825,6 +1825,126 @@
       "showTitle": true,
       "title": "History for the amount of content tagged to each level",
       "titleSize": "h5"
+    },
+    {
+      "collapse": true,
+      "height": 121,
+      "panels": [
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "datasource": "Graphite",
+          "description": "Number of content items that are tagged to a taxon and to an ancestor.",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 121,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 12,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "hide": false,
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "mean"
+                  }
+                ]
+              ],
+              "tags": [],
+              "target": "stats.gauges.govuk.topic-taxonomy.superfluous_tagging_count"
+            }
+          ],
+          "thresholds": "",
+          "title": "Superfluous Tagging",
+          "type": "singlestat",
+          "valueFontSize": "200%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "avg"
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Health Metrics",
+      "titleSize": "h6"
     }
   ],
   "schemaVersion": 14,
@@ -1887,5 +2007,5 @@
   },
   "timezone": "",
   "title": "Topic Taxonomy",
-  "version": 26
+  "version": 27
 }


### PR DESCRIPTION
Counts the number of content items tagged to a taxon and its
ancestor and is

 therefore superfluous and could be removed.

Trello: https://trello.com/c/VOLclckO/18-start-tracking-the-number-of-superfluous-tags-to-the-topic-taxonomy

The metric is shown at the bottom in a collapsed row called 'health metrics' which can be used to add other taxonomy health metrics as needed

![image](https://user-images.githubusercontent.com/6050162/43070458-c9de225a-8e67-11e8-81a5-84b3ad94f9ed.png)

![image](https://user-images.githubusercontent.com/6050162/43070527-f5a4a620-8e67-11e8-8def-32cc37dd8e76.png)


