### PR TITLE
Set the nagios command pipe to allow access via the webui

### DIFF
--- a/modules/icinga/manifests/config.pp
+++ b/modules/icinga/manifests/config.pp
@@ -113,6 +113,11 @@ class icinga::config (
     source => 'puppet:///modules/icinga/etc/nagios-plugins/config/check_nrpe.cfg',
   }
 
+  file { '/var/lib/icinga/rw/nagios.cmd':
+    owner => 'nagios',
+    group => 'www-data',
+  }
+
   user { 'www-data':
     groups => ['nagios'],
   }


### PR DESCRIPTION
https://trello.com/c/fEcchyH4/92-fix-var-lib-icinga-rw-nagioscmd-ownership-on-aws-staging-monitoring

Don't manage the file contents but ensure the user and group.