### PR TITLE
Configure a Publishing API token for Content Publisher

### DIFF
--- a/hieradata/development_credentials.yaml
+++ b/hieradata/development_credentials.yaml
@@ -216,6 +216,7 @@ govuk::apps::collections_publisher::publishing_api_bearer_token: 'oauth-bearer-t
 govuk::apps::contacts::oauth_id: 'oauth-contacts-admin'
 govuk::apps::contacts::oauth_secret: 'secret'
 govuk::apps::contacts::publishing_api_bearer_token: 'oauth-bearer-token-publishing-api'
+govuk::apps::content_publisher::publishing_api_bearer_token: 'oauth-bearer-token-publishing-api'
 govuk::apps::content_tagger::oauth_id: 'oauth-content-tagger'
 govuk::apps::content_tagger::oauth_secret: 'secret'
 govuk::apps::content_tagger::email_alert_api_bearer_token: 'oauth-bearer-token-email-alert-api'

--- a/modules/govuk/manifests/apps/content_publisher.pp
+++ b/modules/govuk/manifests/apps/content_publisher.pp
@@ -33,6 +33,10 @@
 # [*db_name*]
 #   The database name to use for the DATABASE_URL environment variable
 #
+# [*publishing_api_bearer_token*]
+#   The bearer token to use when communicating with Publishing API.
+#   Default: undef
+
 class govuk::apps::content_publisher (
   $port = '3221',
   $enabled = true,
@@ -44,6 +48,7 @@ class govuk::apps::content_publisher (
   $db_hostname = undef,
   $db_password = undef,
   $db_name = 'content_publisher_production',
+  $publishing_api_bearer_token = undef,
 ) {
   $app_name = 'content-publisher'
 
@@ -80,6 +85,9 @@ class govuk::apps::content_publisher (
     "${title}-OAUTH_SECRET":
       varname => 'OAUTH_SECRET',
       value   => $oauth_secret;
+    "${title}-PUBLISHING_API_BEARER_TOKEN":
+      varname => 'PUBLISHING_API_BEARER_TOKEN',
+      value   => $publishing_api_bearer_token;
   }
 
   if $::govuk_node_class !~ /^development$/ {


### PR DESCRIPTION
For https://trello.com/c/37DKTxgQ/32-add-necessary-changes-to-communicate-with-publishing-api-s

This sets an environment variable for Content Publisher to use to authenticate
requests to the Publishing API.