### PR TITLE
Update README: preview -> integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ vagrant up frontend backend
 
 Vagrant will run the Puppet provisioner against the node when it boots up.
 Nodes should look almost identical to that of our real
-production/staging/preview environments.
+production/staging/integration environments.
 
 #### Customisation
 


### PR DESCRIPTION
Reflect the rename of the "preview" environment to "integration" in the README.

This was previously caught by @issyl0 in another PR (closed without merge), and managed to sneak back in on https://github.com/alphagov/govuk-puppet/pull/7781.