### PR TITLE
Monitoring RDS and Elasticcache

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -128,7 +128,9 @@ mongodb::backup::mongo_backup_node: 'localhost'
 
 monitoring::checks::sidekiq::enable_support_check: false
 monitoring::checks::pingdom::enable: false
-monitoring::checks::ses::region: eu-west-1
+monitoring::checks::ses::region: 'eu-west-1'
+monitoring::checks::rds_config::region: 'eu-west-1'
+monitoring::checks::cache_config::region: 'eu-west-1'
 monitoring::checks::smokey::environment: 'integration'
 monitoring::uptime_collector::environment: 'integration'
 

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -104,7 +104,9 @@ licensify::apps::licensify_feed::environment: 'production'
 licensify::apps::licensing_web_forms::enabled: false
 
 monitoring::checks::sidekiq::enable_support_check: false
-monitoring::checks::ses::region: eu-west-1
+monitoring::checks::ses::region: 'eu-west-1'
+monitoring::checks::rds_config::region: 'eu-west-1'
+monitoring::checks::cache_config::region: 'eu-west-1'
 monitoring::checks::smokey::environment: 'production'
 monitoring::uptime_collector::environment: 'production'
 

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -110,7 +110,9 @@ licensify::apps::licensify_feed::environment: 'staging'
 licensify::apps::licensing_web_forms::enabled: false
 
 monitoring::checks::sidekiq::enable_support_check: false
-monitoring::checks::ses::region: eu-west-1
+monitoring::checks::ses::region: 'eu-west-1'
+monitoring::checks::rds_config::region: 'eu-west-1'
+monitoring::checks::cache_config::region: 'eu-west-1'
 monitoring::checks::smokey::environment: 'staging'
 monitoring::uptime_collector::environment: 'staging'
 


### PR DESCRIPTION
- We have introduced monitoring capabilities for AWS RDS and Elastic
cache.

- These plugins require the AWS Region data. We have provided this data
via this commit.

Note: Please view these PRs and Trello card for details.

https://github.com/alphagov/govuk-puppet/pull/7638

https://github.com/alphagov/govuk-puppet/pull/7639

https://trello.com/c/C7SY8edZ/1123-monitor-rds-and-elasticache-in-aws-and-alert-icinga

Pair: @szd55gds @suthagarht