### PR TITLE
Add gdal package repo config to AWS common hiera

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -348,6 +348,8 @@ filebeat::prospectors:
     fields:
       application: 'apt'
 
+gdal::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+
 govuk::apps::asset_manager::mongodb_nodes:
   - 'mongo-1'
   - 'mongo-2'


### PR DESCRIPTION
Mirror of https://github.com/alphagov/govuk-puppet/blob/master/hieradata/common.yaml#L336