### PR TITLE
Remove dns-test.publishing... from the integration deployable DNS zones

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -55,7 +55,6 @@ govuk_jenkins::config::executors: '6'
 
 govuk_jenkins::jobs::deploy_dns::gce_project_id: 'govuk-integration'
 govuk_jenkins::jobs::deploy_dns::zones:
-  - 'dns-test.integration.publishing.service.gov.uk'
   - 'dnstest.alphagov.co.uk'
 
 govuk_jenkins::jobs::integration_deploy::jenkins_integration_api_user: "%{hiera('govuk::node::s_jenkins::jenkins_api_user')}"


### PR DESCRIPTION
- The govuk-dns-config repo doesn't have a YAML file for it any more.