### PR TITLE
Handle draft-whitehall-frontend through the whitehall-frontend

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1360,7 +1360,6 @@ hosts::production::backend::app_hostnames:
   - 'content-publisher'
   - 'content-tagger'
   - 'docs'
-  - 'draft-whitehall-frontend'
   - 'email-alert-api'
   - 'email-alert-api-public'
   - 'event-store'
@@ -1469,6 +1468,7 @@ hosts::production::frontend::app_hostnames:
   - 'smartanswers'
   - 'static'
   - 'whitehall-frontend'
+  - 'draft-whitehall-frontend'
 
 hosts::production::licensify::hosts:
   licensify-lb-1:

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -178,7 +178,6 @@ hosts::production::backend::app_hostnames:
   - 'content-publisher'
   - 'content-tagger'
   - 'docs'
-  - 'draft-whitehall-frontend'
   - 'email-alert-api'
   - 'email-alert-api-public'
   - 'event-store'

--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -206,6 +206,7 @@ class govuk::apps::whitehall(
 
     if $::aws_migration {
       $whitehall_frontend_vhost_    = 'whitehall-frontend'
+      $whitehall_frontend_aliases   = ['draft-whitehall-frontend']
       $whitehall_nginx_extra_config = "
       set \$upstream_whitehall_admin ${app_protocol}://whitehall-admin.${app_domain};
       location /government/uploads {
@@ -215,6 +216,7 @@ class govuk::apps::whitehall(
       "
     } else {
       $whitehall_frontend_vhost_    = "whitehall-frontend.${app_domain}"
+      $whitehall_frontend_aliases   = ["draft-whitehall-frontend.${app_domain}"]
       $whitehall_nginx_extra_config = "
       location /government/uploads {
         proxy_set_header Host 'whitehall-admin.${app_domain}';
@@ -225,6 +227,7 @@ class govuk::apps::whitehall(
 
     govuk::app::nginx_vhost { 'whitehall-frontend':
       vhost                 => $whitehall_frontend_vhost_,
+      aliases               => $whitehall_frontend_aliases,
       protected             => $vhost_protected,
       app_port              => $port,
       asset_pipeline        => true,
@@ -252,15 +255,8 @@ class govuk::apps::whitehall(
       $whitehall_admin_vhost_ = "whitehall-admin.${app_domain}"
     }
 
-    if $::aws_migration {
-      $whitehall_admin_aliases = ['draft-whitehall-frontend']
-    } else {
-      $whitehall_admin_aliases = ["draft-whitehall-frontend.${app_domain}"]
-    }
-
     govuk::app::nginx_vhost { 'whitehall-admin':
       vhost                 => $whitehall_admin_vhost_,
-      aliases               => $whitehall_admin_aliases,
       app_port              => $port,
       protected             => $vhost_protected,
       protected_location    => '/government/admin/fact_check_requests/',

--- a/modules/govuk/manifests/node/s_backend_lb.pp
+++ b/modules/govuk/manifests/node/s_backend_lb.pp
@@ -89,7 +89,6 @@ class govuk::node::s_backend_lb (
 
   loadbalancer::balance { [
       'whitehall-admin',
-      'draft-whitehall-frontend',
     ]:
       deny_crawlers => true,
       servers       => $whitehall_backend_servers,

--- a/modules/govuk/manifests/node/s_frontend_lb.pp
+++ b/modules/govuk/manifests/node/s_frontend_lb.pp
@@ -45,7 +45,10 @@ class govuk::node::s_frontend_lb (
       'smartanswers',
     ]:
       servers       => $calculators_frontend_servers;
-    'whitehall-frontend':
+    [
+      'whitehall-frontend',
+      'draft-whitehall-frontend',
+    ]:
       servers       => $whitehall_frontend_servers;
   }
 }


### PR DESCRIPTION
Rather than the whitehall-admin load balancer and service. Currently,
some of the resources on the draft-whitehall-frontend rendered pages
don't load, because they are loaded from the Whitehall Admin, and the
browsers Same Origin Policy doesn't allow loading these.

Serving the requests from the whitehall-frontend uses different
configuration for the assets, which use relative URLs which work.