### PR TITLE
Configure memcached to listen publicly

### DIFF
--- a/modules/govuk/manifests/node/s_backend.pp
+++ b/modules/govuk/manifests/node/s_backend.pp
@@ -44,6 +44,6 @@ class govuk::node::s_backend inherits govuk::node::s_base {
   include collectd::plugin::memcached
   class { 'memcached':
     max_memory => '12%',
-    listen_ip  => '127.0.0.1',
+    listen_ip  => '0.0.0.0',
   }
 }

--- a/modules/govuk/manifests/node/s_frontend.pp
+++ b/modules/govuk/manifests/node/s_frontend.pp
@@ -24,6 +24,6 @@ class govuk::node::s_frontend inherits govuk::node::s_base {
   include ::collectd::plugin::memcached
   class { 'memcached':
     max_memory => '12%',
-    listen_ip  => '127.0.0.1',
+    listen_ip  => '0.0.0.0',
   }
 }

--- a/modules/govuk/manifests/node/s_publishing_api.pp
+++ b/modules/govuk/manifests/node/s_publishing_api.pp
@@ -29,6 +29,6 @@ class govuk::node::s_publishing_api inherits govuk::node::s_base {
   include collectd::plugin::memcached
   class { 'memcached':
     max_memory => '12%',
-    listen_ip  => '127.0.0.1',
+    listen_ip  => '0.0.0.0',
   }
 }

--- a/modules/govuk/manifests/node/s_whitehall_backend.pp
+++ b/modules/govuk/manifests/node/s_whitehall_backend.pp
@@ -33,6 +33,6 @@ class govuk::node::s_whitehall_backend (
   include collectd::plugin::memcached
   class { 'memcached':
     max_memory => '12%',
-    listen_ip  => '127.0.0.1',
+    listen_ip  => '0.0.0.0',
   }
 }

--- a/modules/govuk/manifests/node/s_whitehall_frontend.pp
+++ b/modules/govuk/manifests/node/s_whitehall_frontend.pp
@@ -15,6 +15,6 @@ class govuk::node::s_whitehall_frontend inherits govuk::node::s_base {
   include collectd::plugin::memcached
   class { 'memcached':
     max_memory => '12%',
-    listen_ip  => '127.0.0.1',
+    listen_ip  => '0.0.0.0',
   }
 }


### PR DESCRIPTION
This will enable using memcached in a distributed way. This makes more
memory available, but the main advantage of this is that it allows
explicit cache invalidation to be done.

At the moment, you could remove entries from the cache when they
become invalid, but this would only take effect on the current
machine. When using memcached in a distributed way, the cache
invalidation would affect all machines.