### PR TITLE
WIP: Share memcached between the Publishing API machines

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -549,6 +549,10 @@ govuk::apps::publishing_api::rabbitmq_hosts:
   - rabbitmq-1.backend
   - rabbitmq-2.backend
   - rabbitmq-3.backend
+govuk::apps::publishing_api::memcache_hosts:
+  - publishing-api-1.backend
+  - publishing-api-2.backend
+  - publishing-api-3.backend
 govuk::apps::publishing_api::rabbitmq_password: "%{hiera('govuk::apps::publishing_api::rabbitmq::amqp_pass')}"
 # Hardcoded to redis-2 to improve performance
 # This setting is overridden in `development.yaml`

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -139,6 +139,7 @@ govuk::apps::publishing_api::enable_procfile_worker: false
 govuk::apps::publishing_api::govuk_content_schemas_path: '/var/govuk/govuk-content-schemas'
 govuk::apps::publishing_api::rabbitmq::configure_test_exchange: true
 govuk::apps::publishing_api::rabbitmq_hosts: ['localhost']
+govuk::apps::publishing_api::memcache_hosts: ['localhost']
 govuk::apps::publishing_api::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::publishing_api::suppress_draft_store_502_error: '1'
 govuk::apps::router::error_log: STDERR

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -549,6 +549,14 @@ govuk::apps::publishing_api::db_hostname: "postgresql-primary"
 govuk::apps::publishing_api::draft_content_store: "https://draft-content-store.%{hiera('app_domain')}"
 govuk::apps::publishing_api::rabbitmq_hosts:
   - rabbitmq
+# TODO: This probably won't work, but I don't know what will... Maybe
+# one approach here is similar to database clusters, just pay Amazon
+# money and use it's managed service (which I think is called
+# ElastiCache)?
+govuk::apps::publishing_api::memcache_hosts:
+  - publishing-api-1
+  - publishing-api-2
+  - publishing-api-3
 govuk::apps::publishing_api::rabbitmq_password: "%{hiera('govuk::apps::publishing_api::rabbitmq::amqp_pass')}"
 govuk::apps::publishing_api::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::publishing_api::redis_port: "%{hiera('sidekiq_port')}"

--- a/modules/govuk/manifests/app/envvar/memcache_servers.pp
+++ b/modules/govuk/manifests/app/envvar/memcache_servers.pp
@@ -1,0 +1,26 @@
+# == Define: govuk::app::envvar::memcache_servers
+#
+# Defines a MEMCACHE_SERVERS environment variable for an app. This
+# constructs the value from the given parameters.
+#
+# === Parameters
+#
+# [*hosts*]
+#   An array of hostnames of the memcache servers.
+#
+define govuk::app::envvar::memcache_servers (
+  $hosts,
+) {
+
+  validate_array($hosts)
+  if ($hosts == []) {
+    fail 'must pass hosts'
+  }
+
+  $hosts_string = join($hosts, ',')
+  govuk::app::envvar { "${title}-MEMCACHE_SERVERS":
+    app     => $title,
+    varname => 'MEMCACHE_SERVERS',
+    value   => $hosts_string,
+  }
+}

--- a/modules/govuk/manifests/apps/publishing_api.pp
+++ b/modules/govuk/manifests/apps/publishing_api.pp
@@ -74,6 +74,9 @@
 #   A password to connect to RabbitMQ:
 #   https://github.com/alphagov/publishing-api/blob/master/config/rabbitmq.yml
 #
+# [*memcache_hosts*]
+#   Hosts to connect to for Memcached
+#
 # [*govuk_content_schemas_path*]
 #   The path for generated govuk-content-schemas
 #
@@ -112,6 +115,7 @@ class govuk::apps::publishing_api(
   $rabbitmq_hosts = ['localhost'],
   $rabbitmq_user = 'publishing_api',
   $rabbitmq_password = undef,
+  $memcache_hosts = undef,
   $govuk_content_schemas_path = '',
   $event_log_aws_bucketname = undef,
   $event_log_aws_username   = undef,
@@ -156,6 +160,10 @@ class govuk::apps::publishing_api(
       hosts    => $rabbitmq_hosts,
       user     => $rabbitmq_user,
       password => $rabbitmq_password,
+    }
+
+    govuk::app::envvar::memcache_servers { $app_name:
+      hosts => $memcache_hosts,
     }
 
     govuk::app::envvar {


### PR DESCRIPTION
This makes it possible to do distributed cache invalidation, as well
as increasing the available space in the cache.

The AWS configuration is a bit tricky, as I'm not even sure there is a
way to address the machines...

It also depends on https://github.com/alphagov/govuk-puppet/pull/7797 and possibly some more changes related to the actual networking...