### PR TITLE
Drop the log_min_duration_statement to 10000

### DIFF
--- a/modules/govuk_postgresql/manifests/server/primary.pp
+++ b/modules/govuk_postgresql/manifests/server/primary.pp
@@ -45,7 +45,7 @@ class govuk_postgresql::server::primary (
     'wal_keep_segments':
       value => 256;
     'log_min_duration_statement':
-      value => 60000;
+      value => 10000;
   }
 
   if versioncmp($::postgresql::globals::version, '9.5') < 0 {


### PR DESCRIPTION
Down from 60000. Currently, I'm trying to investigate slow responses
from the Publishing API linkables endpoint, but while these are often
taking as long as 40 seconds, this isn't long enough for the queries
involved to get logged.

Therefore, drop the time to 10000. I'm hoping this will show the slow
queries I'm looking for, while not throwing up too many false
positives.