### PR TITLE
Better support testing changes while locked

### DIFF
--- a/modules/puppet/templates/govuk_puppet
+++ b/modules/puppet/templates/govuk_puppet
@@ -191,10 +191,12 @@ if [[ " ${puppet_args} " =~ "--enable " ]]; then
   remove_lock
 fi
 
-locked=$(has_locks)
-if [ "$locked" == 1 ];then
-  list_locks
-  exit 1
+if [[ ! " ${puppet_args} " =~ "--noop " ]]; then
+  locked=$(has_locks)
+  if [ "$locked" == 1 ];then
+      list_locks
+      exit 1
+  fi
 fi
 
 set +e


### PR DESCRIPTION
Currently, you can't use govuk_puppet to run puppet if a lock is in
place. This makes it difficult to test what running govuk_puppet would
do.

This change makes it possible to run commands like the following to
test a what actually running govuk_puppet would do.:

  govuk_puppet --noop --test --agent_disabled_lockfile=/tmp/puppet.noop