### PR TITLE
Add Java to monitoring machines

### DIFF
--- a/modules/govuk/manifests/node/s_monitoring.pp
+++ b/modules/govuk/manifests/node/s_monitoring.pp
@@ -21,6 +21,10 @@ class govuk::node::s_monitoring (
   include ::phantomjs
   include monitoring
   include collectd::plugin::icinga
+  include govuk_java::openjdk8::jre
+  class { 'govuk_java::set_defaults':
+    jre => 'openjdk8',
+  }
 
   if $enable_fastly_metrics {
     include collectd::plugin::cdn_fastly


### PR DESCRIPTION
This commit adds Java to the monitoring machines to allow the all-new Smokey (using BrowserMob Proxy) to run correctly.