### PR TITLE
Add JDK to monitoring machines

### DIFF
--- a/modules/govuk/manifests/node/s_monitoring.pp
+++ b/modules/govuk/manifests/node/s_monitoring.pp
@@ -22,7 +22,9 @@ class govuk::node::s_monitoring (
   include monitoring
   include collectd::plugin::icinga
   include govuk_java::openjdk8::jre
+  include govuk_java::openjdk8::jdk
   class { 'govuk_java::set_defaults':
+    jdk => 'openjdk8',
     jre => 'openjdk8',
   }
 


### PR DESCRIPTION
This commit adds JDK to the monitoring machines since `set_defaults` doesn’t work otherwise.