### PR TITLE
Fix the target for the procfile worker thread count check

### DIFF
--- a/modules/govuk/manifests/procfile/worker.pp
+++ b/modules/govuk/manifests/procfile/worker.pp
@@ -81,7 +81,7 @@ define govuk::procfile::worker (
 
       if $alert_when_threads_exceed {
         @@icinga::check::graphite { "check_app_${title}_procfile_worker_thread_count_${::hostname}":
-          target    => "${::hostname}.processes-app-worker-${title_underscore}.ps_count.threads",
+          target    => "${::fqdn_metrics}.processes-app-worker-${title_underscore}.ps_count.threads",
           warning   => $alert_when_threads_exceed,
           critical  => $alert_when_threads_exceed,
           desc      => "Thread count for ${title_underscore} exceeds ${alert_when_threads_exceed}",


### PR DESCRIPTION
Looking around, ${::fqdn_metrics} looks like it's the right thing to
use. Not sure where I got ${::hostname} from...