### PR TITLE
Change the app_name to cpm to reduce the metric length

### DIFF
--- a/modules/govuk/manifests/apps/content_performance_manager.pp
+++ b/modules/govuk/manifests/apps/content_performance_manager.pp
@@ -127,7 +127,7 @@ class govuk::apps::content_performance_manager(
     process_type   => 'publishing-api-consumer',
   }
 
-  govuk::procfile::worker { "${app_name}-bulk-import-publishing-api-consumer":
+  govuk::procfile::worker { 'cpm-bulk-import-publishing-api-consumer':
     enable_service => $enable_procfile_worker,
     setenv_as      => $app_name,
     process_type   => 'bulk-import-publishing-api-consumer',


### PR DESCRIPTION
Without this change, the data in Graphite shows up as
"processes-app-worker-content-performance-manager-bulk-import-publishing-a"
which is too long, and gets truncated somewhere.

This breaks the Icinga check on worker thread counts, as it uses the
untruncated name.