### PR TITLE
Add BrowserMob Proxy port

### DIFF
--- a/development-vm/Procfile
+++ b/development-vm/Procfile
@@ -173,5 +173,6 @@ content-audit-tool-sidekiq-publishing-api:  govuk_setenv content-audit-tool ./ru
 organisations-publisher-sidekiq:                     govuk_setenv organisations-publisher            ./run_in.sh ../../organisations-publisher bundle exec sidekiq -C ./config/sidekiq.yml
 organisations-publisher: govuk_setenv organisations-publisher ./run_in.sh ../../organisations-publisher bundle exec rails s -p 3218
 # sidekiq-monitoring for organisations-publisher uses port 3219
-# ckan uses 3220
+# ckan uses port 3220
 content-publisher: govuk_setenv content-publisher ./run_in.sh ../../content-publisher bundle exec rails s -p 3221
+# Smokey BrowserMob Proxy uses ports 3222-3229


### PR DESCRIPTION
This commit adds a comment to the `Procfile` about the BrowserMob Proxy port to prevent clashes.