### PR TITLE
Refactor Sentry config for PuppetServer

### DIFF
--- a/modules/puppet/manifests/puppetserver.pp
+++ b/modules/puppet/manifests/puppetserver.pp
@@ -3,7 +3,16 @@
 # Install and configure a puppetserver.
 # Includes PuppetDB on the same host.
 #
-class puppet::puppetserver {
+# === Parameters
+#
+# [*sentry_dsn*]
+#   This is the Sentry DSN to send Puppet reports to.
+#   If unset, Sentry reporting is disabled.
+#
+class puppet::puppetserver (
+  $sentry_dsn = undef,
+)
+{
   require '::puppet'
 
   include '::puppet::repository'
@@ -30,6 +39,13 @@ class puppet::puppetserver {
 
   Class['::puppet::puppetserver::generate_cert']
     ~> Class['::puppet::puppetserver::nginx']
+
+  if $sentry_dsn {
+    class { '::puppet::puppetserver::sentry':
+      require => Class['::puppet::puppetserver::package'],
+      notify  => Class['::puppet::puppetserver::service'],
+    }
+  }
 
   file { '/etc/puppet/gpg':
     ensure  => directory,

--- a/modules/puppet/manifests/puppetserver/package.pp
+++ b/modules/puppet/manifests/puppetserver/package.pp
@@ -2,14 +2,7 @@
 #
 # Install packages for a Puppetserver.
 #
-# === Parameters
-#
-# [*puppet_sentry_dsn*]
-#   This is the DSN to send puppet reports to.
-#
-class puppet::puppetserver::package(
-  $puppet_sentry_dsn = undef,
-) {
+class puppet::puppetserver::package {
   require '::govuk_java::openjdk7::jre'
 
   package { 'puppetserver':
@@ -37,16 +30,4 @@ class puppet::puppetserver::package(
     require => Package['puppetserver'],
   }
 
-  exec { '/usr/bin/puppetserver gem install sentry-raven':
-    unless  => '/usr/bin/puppetserver gem list | /bin/grep sentry-raven',
-    require => Package['puppetserver'],
-  }
-
-  file_line { 'puppetserver_config_sentry':
-    ensure  => present,
-    path    => '/etc/default/puppetserver',
-    line    => inline_template("PUPPET_SENTRY_DSN=${puppet_sentry_dsn}\n"),
-    match   => '^PUPPET_SENTRY_DSN=',
-    require => Package['puppetserver'],
-  }
 }

--- a/modules/puppet/manifests/puppetserver/sentry.pp
+++ b/modules/puppet/manifests/puppetserver/sentry.pp
@@ -1,0 +1,17 @@
+# == Class: puppet::puppetserver::sentry
+#
+# Installs the sentry-raven Ruby Gem into the PuppetServer and sets the
+# PUPPET_SENTRY_DSN environment variable.
+#
+class puppet::puppetserver::sentry {
+  exec { '/usr/bin/puppetserver gem install sentry-raven':
+    unless  => '/usr/bin/puppetserver gem list | /bin/grep sentry-raven',
+  }
+
+  file_line { 'puppetserver_sentry_dsn':
+    ensure => present,
+    path   => '/etc/default/puppetserver',
+    line   => sprintf('PUPPET_SENTRY_DSN="%s"', $::puppet::puppetserver::sentry_dsn),
+    match  => '^PUPPET_SENTRY_DSN=',
+  }
+}

--- a/modules/puppet/spec/classes/puppet__puppetserver__sentry_spec.rb
+++ b/modules/puppet/spec/classes/puppet__puppetserver__sentry_spec.rb
@@ -1,0 +1,17 @@
+require_relative '../../../../spec_helper'
+
+describe 'puppet::puppetserver::sentry', :type => :class do
+  let (:pre_condition) do
+    <<-EOF
+      class {'::puppet::puppetserver':
+        sentry_dsn => 'rspec dsn',
+      }
+    EOF
+  end
+
+  it do
+    is_expected.to contain_exec('/usr/bin/puppetserver gem install sentry-raven')
+    is_expected.to contain_file_line('puppetserver_sentry_dsn').with_line('PUPPET_SENTRY_DSN="rspec dsn"')
+  end
+end
+

--- a/modules/puppet/spec/classes/puppet__puppetserver_spec.rb
+++ b/modules/puppet/spec/classes/puppet__puppetserver_spec.rb
@@ -18,5 +18,16 @@ describe 'puppet::puppetserver', :type => :class do
   it do
     is_expected.to contain_class('puppet')
     is_expected.to contain_class('puppet::puppetserver::config')
+    is_expected.not_to contain_class('puppet::puppetserver::sentry')
+  end
+
+  context 'with sentry_dsn' do
+    let(:params) do
+      { :sentry_dsn => 'rspec' }
+    end
+
+    it do
+      is_expected.to contain_class('puppet::puppetserver::sentry')
+    end
   end
 end


### PR DESCRIPTION
Having `$puppet_sentry_dsn` be a parameter of `puppet::puppetserver::package` doesn't really make sense. Make it a parameter of `puppet::puppetserver` instead.

Separate the Sentry resources into their own class, and include that if a Sentry DSN is specified in the class parameters.

Update the rspec tests and add some new ones.

Replace the `inline_template()` that was used to write the environment variable line with a `sprintf()` and ensure that the DSN is double-quoted in the `/etc/default/puppetserver` file.