### PR TITLE
Add Chrome to monitoring machines

### DIFF
--- a/modules/govuk/manifests/node/s_monitoring.pp
+++ b/modules/govuk/manifests/node/s_monitoring.pp
@@ -17,8 +17,11 @@ class govuk::node::s_monitoring (
 
   validate_bool($enable_fastly_metrics, $offsite_backups)
 
+  include google_chrome
   include govuk_rbenv::all
+  include ::chromedriver
   include ::phantomjs
+  include ::selenium
   include monitoring
   include collectd::plugin::icinga
   include govuk_java::openjdk8::jre


### PR DESCRIPTION
This commit adds Google Chrome, ChromeDriver and Selenium to the monitoring machines to allow them to run Smokey.

Trello: https://trello.com/c/80OiCEtH/308-more-reliable-smokey-tests-on-aws-environments