### PR TITLE
Sentry: fix environment variable name

### DIFF
--- a/modules/puppet/manifests/puppetserver/sentry.pp
+++ b/modules/puppet/manifests/puppetserver/sentry.pp
@@ -11,7 +11,7 @@ class puppet::puppetserver::sentry {
   file_line { 'puppetserver_sentry_dsn':
     ensure => present,
     path   => '/etc/default/puppetserver',
-    line   => sprintf('PUPPET_SENTRY_DSN="%s"', $::puppet::puppetserver::sentry_dsn),
-    match  => '^PUPPET_SENTRY_DSN=',
+    line   => sprintf('export SENTRY_DSN="%s"', $::puppet::puppetserver::sentry_dsn),
+    match  => '^export SENTRY_DSN=',
   }
 }

--- a/modules/puppet/spec/classes/puppet__puppetserver__sentry_spec.rb
+++ b/modules/puppet/spec/classes/puppet__puppetserver__sentry_spec.rb
@@ -11,7 +11,7 @@ describe 'puppet::puppetserver::sentry', :type => :class do
 
   it do
     is_expected.to contain_exec('/usr/bin/puppetserver gem install sentry-raven')
-    is_expected.to contain_file_line('puppetserver_sentry_dsn').with_line('PUPPET_SENTRY_DSN="rspec dsn"')
+    is_expected.to contain_file_line('puppetserver_sentry_dsn').with_line('export SENTRY_DSN="rspec dsn"')
   end
 end
 


### PR DESCRIPTION
The environment variable is `SENTRY_DSN` not `PUPPET_SENTRY_DSN`.

Also, `export` is needed for the variable to be passed through to the PuppetServer process's environnment.