### PR TITLE
Run Smokey loop with its own user

### DIFF
--- a/modules/monitoring/manifests/checks/smokey.pp
+++ b/modules/monitoring/manifests/checks/smokey.pp
@@ -21,7 +21,10 @@ class monitoring::checks::smokey (
 
   include govuk::apps::smokey
 
-  # TODO: Should this really run as root?
+  govuk_user { 'smokey':
+    fullname    => 'Smokey',
+  }
+
   file { $service_file:
     ensure  => present,
     content => template('monitoring/smokey-loop.conf'),
@@ -36,5 +39,4 @@ class monitoring::checks::smokey (
 
   $defaults = { 'notes_url' => monitoring_docs_url(high-priority-tests) }
   create_resources(icinga::check_feature, $features, $defaults)
-
 }

--- a/modules/monitoring/templates/smokey-loop.conf
+++ b/modules/monitoring/templates/smokey-loop.conf
@@ -6,4 +6,4 @@ description "Smokey loop outputs JSON which is consumed by monitoring"
 start on runlevel [2345] and stopped $UPSTART_JOB
 respawn
 
-exec /opt/smokey/tests_json_output.sh /tmp/smokey.json <%= @environment %>
+exec sudo -i smokey /opt/smokey/tests_json_output.sh /tmp/smokey.json <%= @environment %>


### PR DESCRIPTION
This commit changes the Smokey loop to run as a new `smokey` user rather than `root`. This is because:

* Running as `root` is not a good idea
* Google Chrome does not like running as `root`

Trello: https://trello.com/c/80OiCEtH/308-more-reliable-smokey-tests-on-aws-environments