### PR TITLE
Replication space saving

### DIFF
--- a/development-vm/replication/common-args.sh
+++ b/development-vm/replication/common-args.sh
@@ -26,6 +26,7 @@ OPTIONS:
     -q       Skip MySQL import
     -e       Skip Elasticsearch import
     -t       Skip Mapit import
+    -k       Keep backups after import (will delete by default)
 
 EOF
 }
@@ -40,6 +41,7 @@ SKIP_MAPIT=false
 SSH_CONFIG="../ssh_config"
 RENAME_DATABASES=true
 DRY_RUN=false
+KEEP_BACKUPS=false
 # By default, ignore large databases which are not useful when replicated.
 IGNORE="event_store transition backdrop support_contacts draft_content_store imminence draft_router"
 
@@ -55,7 +57,7 @@ function ignored() {
 }
 
 
-while getopts "hF:u:d:sri:onmpqet" OPTION
+while getopts "hF:u:d:sri:onmpqetk" OPTION
 do
   case $OPTION in
     h )
@@ -100,6 +102,9 @@ do
       ;;
     t )
       SKIP_MAPIT=true
+      ;;
+    k )
+      KEEP_BACKUPS=true
       ;;
   esac
 done

--- a/development-vm/replication/common-args.sh
+++ b/development-vm/replication/common-args.sh
@@ -41,7 +41,7 @@ SSH_CONFIG="../ssh_config"
 RENAME_DATABASES=true
 DRY_RUN=false
 # By default, ignore large databases which are not useful when replicated.
-IGNORE="event_store transition backdrop support_contacts draft_content_store imminence"
+IGNORE="event_store transition backdrop support_contacts draft_content_store imminence draft_router"
 
 # Test whether the given value is in the ignore list.
 function ignored() {

--- a/development-vm/replication/sync-aws-elasticsearch.sh
+++ b/development-vm/replication/sync-aws-elasticsearch.sh
@@ -116,6 +116,11 @@ else
   status ""
   status "Remove alises from old indices and archiving"
   ruby $(dirname $0)/close_and_delete_old_indices.rb ${index_names}
+
+  if ! $KEEP_BACKUPS; then
+    status "Deleting ${LOCAL_ARCHIVE_PATH}"
+    rm -rf ${LOCAL_ARCHIVE_PATH}
+  fi
 fi
 
 ok "Restore complete"

--- a/development-vm/replication/sync-aws-mongo.sh
+++ b/development-vm/replication/sync-aws-mongo.sh
@@ -89,4 +89,9 @@ for dir in $(find $MONGO_DIR -mindepth 5 -maxdepth 5 -type d | grep -v '*'); do
   fi
 done
 
+if ! ($KEEP_BACKUPS || $DRY_RUN); then
+  status "Deleting ${MONGO_DIR} backups"
+  rm -rf $MONGO_DIR
+fi
+
 ok "Mongo replication from S3 (${SRC_HOSTNAME}) complete."

--- a/development-vm/replication/sync-aws-mongo.sh
+++ b/development-vm/replication/sync-aws-mongo.sh
@@ -57,7 +57,9 @@ if [ -e $MONGO_DIR/.extracted ]; then
   status "Mongo dump has already been extracted."
 else
   status "Extracting compressed files..."
-  pv $MONGO_DIR/*.tgz | tar -zxf - -C $MONGO_DIR
+  exclude=""
+  for i in $IGNORE; do exclude="${exclude}--exclude var/lib/mongodump/mongodump/${i}_production --exclude var/lib/mongodump/mongodump/${i} "; done
+  pv $MONGO_DIR/*.tgz | tar -zx ${exclude} -f - -C $MONGO_DIR
   touch $MONGO_DIR/.extracted
 fi
 

--- a/development-vm/replication/sync-aws-mysql.sh
+++ b/development-vm/replication/sync-aws-mysql.sh
@@ -89,6 +89,11 @@ for file in $(find $MYSQL_DIR -name '*production*.gz'); do
     mysql $MYSQL_ARGUMENTS -e "CREATE DATABASE $TARGET_DB_NAME"
     $PV_COMMAND $file | zcat | ${DB_MUNGE_COMMAND} | mysql $MYSQL_ARGUMENTS $TARGET_DB_NAME
     rm ${TEMP_SED_SCRIPT}
+
+    if ! $KEEP_BACKUPS; then
+      status "Deleting $(basename $file)"
+      rm ${file}
+    fi
   fi
 done
 

--- a/development-vm/replication/sync-aws-postgresql.sh
+++ b/development-vm/replication/sync-aws-postgresql.sh
@@ -97,6 +97,11 @@ for file in $(find $POSTGRESQL_DIR -name '*_production.dump.gz'); do
     do
       ${PSQL_COMMAND} -c "ALTER TABLE \"$tbl\" OWNER TO vagrant" ${TARGET_DB_NAME}
     done
+
+    if ! $KEEP_BACKUPS; then
+      status "Deleting ${DUMP_FILENAME}"
+      rm ${file}
+    fi
   fi
 done
 


### PR DESCRIPTION
Three things that will save us some space when replicating:

- By default, delete a dump once it's been restored from. Use `-k` to keep it instead.
- Don't extract mongo dumps from the tarball that we're supposed to ignore
- Ignore the `draft_router` mongo database as we rarely run the draft stack. `draft_content_store` is already ignored