### PR TITLE
Fix Smokey loop configuration

### DIFF
--- a/modules/monitoring/manifests/checks/smokey.pp
+++ b/modules/monitoring/manifests/checks/smokey.pp
@@ -21,8 +21,11 @@ class monitoring::checks::smokey (
 
   include govuk::apps::smokey
 
-  govuk_user { 'smokey':
-    fullname    => 'Smokey',
+  user { 'smokey':
+    ensure => present,
+    name   => 'Smokey',
+    shell  => '/bin/false',
+    system => true,
   }
 
   file { $service_file:

--- a/modules/monitoring/templates/smokey-loop.conf
+++ b/modules/monitoring/templates/smokey-loop.conf
@@ -6,4 +6,4 @@ description "Smokey loop outputs JSON which is consumed by monitoring"
 start on runlevel [2345] and stopped $UPSTART_JOB
 respawn
 
-exec sudo -i smokey /opt/smokey/tests_json_output.sh /tmp/smokey.json <%= @environment %>
+exec sudo -u smokey /opt/smokey/tests_json_output.sh /tmp/smokey.json <%= @environment %>


### PR DESCRIPTION
Use `-u` rather than `-i` when running sudo. Also, define the smokey user as a system user and provide a fake shell.

Trello: https://trello.com/c/80OiCEtH/308-more-reliable-smokey-tests-on-aws-environments