### PR TITLE
Revert "Sentry: fix environment variable name"

### DIFF
--- a/modules/puppet/manifests/puppetserver/sentry.pp
+++ b/modules/puppet/manifests/puppetserver/sentry.pp
@@ -11,7 +11,7 @@ class puppet::puppetserver::sentry {
   file_line { 'puppetserver_sentry_dsn':
     ensure => present,
     path   => '/etc/default/puppetserver',
-    line   => sprintf('export SENTRY_DSN="%s"', $::puppet::puppetserver::sentry_dsn),
-    match  => '^export SENTRY_DSN=',
+    line   => sprintf('export PUPPET_SENTRY_DSN="%s"', $::puppet::puppetserver::sentry_dsn),
+    match  => '^export PUPPET_SENTRY_DSN=',
   }
 }

--- a/modules/puppet/spec/classes/puppet__puppetserver__sentry_spec.rb
+++ b/modules/puppet/spec/classes/puppet__puppetserver__sentry_spec.rb
@@ -11,7 +11,7 @@ describe 'puppet::puppetserver::sentry', :type => :class do
 
   it do
     is_expected.to contain_exec('/usr/bin/puppetserver gem install sentry-raven')
-    is_expected.to contain_file_line('puppetserver_sentry_dsn').with_line('export SENTRY_DSN="rspec dsn"')
+    is_expected.to contain_file_line('puppetserver_sentry_dsn').with_line('export PUPPET_SENTRY_DSN="rspec dsn"')
   end
 end
 


### PR DESCRIPTION
This reverts commit 5b8f69c388aa27e6884e311aa83fb1cee0ef59e2.

I misread the situation in the previous commit - `SENTRY_DSN` is the environment variable given in the sentry-raven docs, but the Puppet module `alphagov/puppet-reporter-sentry` which glues Puppet's error reporting hooks to Sentry expects `PUPPET_SENTRY_DSN`.