### PR TITLE
Upgrade PuppetServer

### DIFF
--- a/modules/puppet/manifests/puppetserver/package.pp
+++ b/modules/puppet/manifests/puppetserver/package.pp
@@ -6,7 +6,7 @@ class puppet::puppetserver::package {
   require '::govuk_java::openjdk7::jre'
 
   package { 'puppetserver':
-    ensure  => installed,
+    ensure => 'latest',
   }
 
   package { ['aws-sdk-ec2', 'aws-sdk-core']:


### PR DESCRIPTION
Upgrade the PuppetServer to 1.2.0 which is the most recent version of the Puppet 3.x series and the most recent available in the 3.x series repos (which will not be updated).