### PR TITLE
Change oplog size on AWS mongo machines

### DIFF
--- a/hieradata/class/mongo.yaml
+++ b/hieradata/class/mongo.yaml
@@ -37,7 +37,7 @@ mount:
     govuk_lvm: 's3backups'
     mountoptions: 'defaults'
 
-mongodb::server::oplog_size: 7168 # 7 * 1024
+mongodb::server::oplog_size: 14392 # 14 * 1024
 mongodb::server::replicaset_members:
   'mongo-1':
   'mongo-2':

--- a/hieradata_aws/class/mongo.yaml
+++ b/hieradata_aws/class/mongo.yaml
@@ -5,7 +5,7 @@ govuk_safe_to_reboot::reason: 'Secondaries will reboot overnight if cluster is h
 
 icinga::client::checks::disk_time_window_minutes: 10
 
-mongodb::server::oplog_size: 7168 # 7 * 1024
+mongodb::server::oplog_size: 14392 # 14 * 1024
 mongodb::server::replicaset_members:
   'mongo-1':
   'mongo-2':

--- a/modules/mongodb/spec/classes/mongodb__config_spec.rb
+++ b/modules/mongodb/spec/classes/mongodb__config_spec.rb
@@ -47,7 +47,7 @@ describe 'mongodb::config', :type => :class do
           :development => true,
           :replicaset_name  => 'development',
           :config_filename => '/etc/mongod.conf',
-          :oplog_size => '7168 # 7 * 1024',
+          :oplog_size => '14392 # 14 * 1024',
           :template_name => 'mongod.conf.erb'
       }}
 


### PR DESCRIPTION
- The mongo instances are de-syncing daily

- Upping the PRIMARY oplog increases replicaset resilience

- Set manually before and worked

solo @schmie