### PR TITLE
Add nginx config for spam reports endpoint

### DIFF
--- a/modules/govuk/templates/email_alert_api_public_nginx_extra_config.conf.erb
+++ b/modules/govuk/templates/email_alert_api_public_nginx_extra_config.conf.erb
@@ -2,3 +2,8 @@ location ~ ^/status-updates(/|$) {
   limit_req zone=email_alert_api_public burst=20 nodelay;
   proxy_pass http://localhost:<%= @port %>;
 }
+
+location ~ ^/spam-reports(/|$) {
+  limit_req zone=email_alert_api_public burst=20 nodelay;
+  proxy_pass http://localhost:<%= @port %>;
+}


### PR DESCRIPTION
This is required to allow Notify to hit our spam-reports endpoint, which will allow us to unsubscribe users that have categorised our emails as spam.

cc @thomasleese 

https://trello.com/c/DRM82ETh/328-auto-unsubscribe-email-alert-api-users-who-report-spam
