### PR TITLE
Monitoring AWS RDS & Elastic Cache

### DIFF
--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -105,8 +105,8 @@ licensify::apps::licensing_web_forms::enabled: false
 
 monitoring::checks::sidekiq::enable_support_check: false
 monitoring::checks::ses::region: 'eu-west-1'
-monitoring::checks::rds_config::region: 'eu-west-1'
-monitoring::checks::cache_config::region: 'eu-west-1'
+monitoring::checks::rds::region: 'eu-west-1'
+monitoring::checks::cache::region: 'eu-west-1'
 monitoring::checks::smokey::environment: 'production'
 monitoring::uptime_collector::environment: 'production'
 

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -111,8 +111,8 @@ licensify::apps::licensing_web_forms::enabled: false
 
 monitoring::checks::sidekiq::enable_support_check: false
 monitoring::checks::ses::region: 'eu-west-1'
-monitoring::checks::rds_config::region: 'eu-west-1'
-monitoring::checks::cache_config::region: 'eu-west-1'
+monitoring::checks::rds::region: 'eu-west-1'
+monitoring::checks::cache::region: 'eu-west-1'
 monitoring::checks::smokey::environment: 'staging'
 monitoring::uptime_collector::environment: 'staging'
 

--- a/modules/monitoring/manifests/checks/cache.pp
+++ b/modules/monitoring/manifests/checks/cache.pp
@@ -4,8 +4,14 @@
 #
 # === Parameters
 #
+# [*enabled*]
+#   This variable enables to define whether to perform Icinga Elastic-Cache checks. [This is set to 'true' by default.]
+#
 # [*servers*]
 #   List of RDS instances.
+#
+# [*region*]
+#   Which AWS region should be checked ['us-east-1','eu-west-1']
 #
 class monitoring::checks::cache (
       $enabled = true,

--- a/modules/monitoring/manifests/checks/rds.pp
+++ b/modules/monitoring/manifests/checks/rds.pp
@@ -4,6 +4,9 @@
 #
 # === Parameters
 #
+# [*region*]
+#   Which AWS region should be checked ['us-east-1','eu-west-1']
+#
 # [*servers*]
 #   List of RDS instances.
 #


### PR DESCRIPTION
- In the initial version, we have referenced the AWS Region as a
variable. However, this variable was called from inside the resource.

- This meant that declaring the variable as ```
monitoring::checks::rds_config::region: ``` will not be useful.

- To correct this, we have declared the variable inside the actual
class (For example: monitoring::checks::rds::region). Then we pass the
variable by calling the resource within the class.

- We have introduced this change and corrected comments within files.

https://trello.com/c/C7SY8edZ/1123-monitor-rds-and-elasticache-in-aws-and-alert-icinga

Solo: @suthagarht