### PR TITLE
Make changes to scheduled Jenkins jobs

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/configure_github_repos.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/configure_github_repos.yaml.erb
@@ -19,8 +19,7 @@
     triggers:
         - timed: |
             TZ=Europe/London
-            # 8PM every day
-            0 8 * * *
+            H 8 * * *
     properties:
         - build-discarder:
             days-to-keep: 30

--- a/modules/govuk_jenkins/templates/jobs/delete_redis_uniquejobs.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/delete_redis_uniquejobs.yaml.erb
@@ -20,7 +20,9 @@
             ssh deploy@$node "redis-cli DEL uniquejobs"
           done
     triggers:
-      - timed: "0 7 * * *"
+      - timed: |
+        TZ=Europe/London
+        H 7 * * *
     wrappers:
       - ansicolor:
           colormap: xterm

--- a/modules/govuk_jenkins/templates/jobs/record_superfluous_taggings_metrics.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/record_superfluous_taggings_metrics.yaml.erb
@@ -10,7 +10,9 @@
     logrotate:
       daysToKeep: 30
     triggers:
-      - timed: 'H 3 * * *'
+      - timed: |
+        TZ=Europe/London
+        H 3 * * *
     properties:
       - build-discarder:
           days-to-keep: 30

--- a/modules/govuk_jenkins/templates/jobs/run_deploy_lag_badger.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/run_deploy_lag_badger.yaml.erb
@@ -19,8 +19,7 @@
     triggers:
         - timed: |
             TZ=Europe/London
-            # 1PM every day
-            0 13 * * *
+            0 13 * * 1-5
     properties:
         - build-discarder:
             days-to-keep: 30


### PR DESCRIPTION
This PR makes a number of changes to scheduled Jenkins jobs to spread the load.

Trello: https://trello.com/c/BfSZTIBP/339-audit-all-scheduled-jobs-in-deploy-jenkins