### PR TITLE
Whitelist Amazon simulator email

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -410,6 +410,7 @@ govuk::apps::email_alert_api::unicorn_worker_processes: '4'
 govuk::apps::email_alert_api::email_address_override_whitelist:
   - govuk-email-courtesy-copies@digital.cabinet-office.gov.uk
   - bevan.loon@digital.cabinet-office.gov.uk
+  - complaint@simulator.amazonses.com
   - kevin.dew@digital.cabinet-office.gov.uk
   - ruben.arakelyan@digital.cabinet-office.gov.uk
   - thomas.leese@digital.cabinet-office.gov.uk

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -423,6 +423,7 @@ govuk::apps::email_alert_api::unicorn_worker_processes: '4'
 govuk::apps::email_alert_api::email_address_override_whitelist:
   - govuk-email-courtesy-copies@digital.cabinet-office.gov.uk
   - bevan.loon@digital.cabinet-office.gov.uk
+  - complaint@simulator.amazonses.com
   - kevin.dew@digital.cabinet-office.gov.uk
   - ruben.arakelyan@digital.cabinet-office.gov.uk
   - thomas.leese@digital.cabinet-office.gov.uk


### PR DESCRIPTION
This email address allows to simulate spam reports without affecting our rating
with Amazon. We'd like to be able to test a spam report feature, and this allow
emails to be sent to that address in staging. 

cc @thomasleese 

https://trello.com/c/DRM82ETh/328-auto-unsubscribe-email-alert-api-users-who-report-spam