### PR TITLE
Set Sentry DSN for Puppet Server...

### DIFF
--- a/modules/puppet/manifests/puppetserver/sentry.pp
+++ b/modules/puppet/manifests/puppetserver/sentry.pp
@@ -1,17 +1,18 @@
 # == Class: puppet::puppetserver::sentry
 #
 # Installs the sentry-raven Ruby Gem into the PuppetServer and sets the
-# PUPPET_SENTRY_DSN environment variable.
+# Sentry DSN in /etc/puppet/sentry.conf.
 #
 class puppet::puppetserver::sentry {
   exec { '/usr/bin/puppetserver gem install sentry-raven':
     unless  => '/usr/bin/puppetserver gem list | /bin/grep sentry-raven',
   }
 
-  file_line { 'puppetserver_sentry_dsn':
-    ensure => present,
-    path   => '/etc/default/puppetserver',
-    line   => sprintf('export PUPPET_SENTRY_DSN="%s"', $::puppet::puppetserver::sentry_dsn),
-    match  => '^export PUPPET_SENTRY_DSN=',
+  file { "${settings::confdir}/sentry.conf":
+    ensure  => present,
+    owner   => 'puppet',
+    group   => 'puppet',
+    mode    => '0400',
+    content => sprintf('dsn=%s', $::puppet::puppetserver::sentry_dsn),
   }
 }

--- a/modules/puppet/spec/classes/puppet__puppetserver__sentry_spec.rb
+++ b/modules/puppet/spec/classes/puppet__puppetserver__sentry_spec.rb
@@ -9,9 +9,11 @@ describe 'puppet::puppetserver::sentry', :type => :class do
     EOF
   end
 
+  Puppet.settings[:confdir] = '/etc/puppet'
+
   it do
     is_expected.to contain_exec('/usr/bin/puppetserver gem install sentry-raven')
-    is_expected.to contain_file_line('puppetserver_sentry_dsn').with_line('export PUPPET_SENTRY_DSN="rspec dsn"')
+    is_expected.to contain_file('/etc/puppet/sentry.conf').with_content('dsn=rspec dsn')
   end
 end
 

--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -53,6 +53,8 @@ RSpec.configure do |c|
     :aws_migration           => false,
   }
 
+  c.confdir = '/etc/puppet'
+
   c.after(:suite) do
     if ENV.fetch('FULL_COVERAGE_REPORT', false)
       RSpec::Puppet::Coverage.report!


### PR DESCRIPTION
... in `/etc/puppet/sentry.conf`, because we can't feed environment variables to the Puppet Master under our current version of Puppet Server.