### PR TITLE
Run data sync jobs earlier

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/copy_attachments_to_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_attachments_to_integration.yaml.erb
@@ -27,7 +27,7 @@
     triggers:
         - timed: |
             TZ=Europe/London
-            H 1 * * 1-5
+            H 0 * * 1-5
     builders:
         - shell: |
             set -eu

--- a/modules/govuk_jenkins/templates/jobs/copy_attachments_to_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_attachments_to_staging.yaml.erb
@@ -27,7 +27,7 @@
     triggers:
         - timed: |
             TZ=Europe/London
-            H 1 * * 1-5
+            H 22 * * 1-5
     builders:
         - shell: |
             set -eu

--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
@@ -30,7 +30,7 @@
     triggers:
         - timed: |
             TZ=Europe/London
-            H 3 * * 1-5
+            H 0 * * 1-5
     builders:
         - shell: |
             set -eu

--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_staging.yaml.erb
@@ -29,7 +29,7 @@
     triggers:
         - timed: |
             TZ=Europe/London
-            H 1 * * *
+            H 22 * * *
     builders:
         - shell: |
             set +x


### PR DESCRIPTION
This moves each data sync job to run at least 3 hours earlier than currently.

We often see integration and staging broken in the morning and it's more often than not due to the data sync still running. Even if it hasn't taken out the databases, it still prevents many applications from being useful as the Signon URLs aren't set correctly until it finishes.

There's also no need for the data sync to start so "late" in the day, since most devs have finished work by 6pm so won't be affected by the data sync starting.