### PR TITLE
AWS RDS and Elastic Cache Monitoring Fixes

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1110,8 +1110,8 @@ monitoring::checks::smokey::features:
     feature: whitehall
 
 monitoring::checks::cache::servers:
-  - 'blue-backend-redis-001'
-  - 'blue-backend-redis-002'
+  - 'backend-redis-001'
+  - 'backend-redis-002'
 
 monitoring::checks::rds::servers:
    - 'postgresql-primary'

--- a/modules/monitoring/manifests/checks/cache.pp
+++ b/modules/monitoring/manifests/checks/cache.pp
@@ -40,7 +40,7 @@ class monitoring::checks::cache (
     }
 
     if $enabled {
-      monitoring::checks::rds_config { $servers:
+      monitoring::checks::cache_config { $servers:
         region => $region,
       }
     }

--- a/modules/monitoring/manifests/checks/cache_config.pp
+++ b/modules/monitoring/manifests/checks/cache_config.pp
@@ -33,7 +33,7 @@ define monitoring::checks::cache_config (
     check_command       => "check_aws_cache_cpu!${region}!${cpu_warning}!${cpu_critical}!${::aws_stackname}-${title}",
     use                 => 'govuk_urgent_priority',
     host_name           => $::fqdn,
-    service_description => 'AWS ElasticCache CPU Utilization',
+    service_description => "${title} - AWS ElasticCache CPU Utilization",
     notes_url           => monitoring_docs_url(aws-cache-cpu),
     require             => Icinga::Check_config['check_aws_cache_cpu'],
   }
@@ -42,7 +42,7 @@ define monitoring::checks::cache_config (
     check_command       => "check_aws_cache_memory!${region}!${memory_warning}!${memory_critical}!${::aws_stackname}-${title}",
     use                 => 'govuk_urgent_priority',
     host_name           => $::fqdn,
-    service_description => 'AWS ElasticCache Memory Utilization',
+    service_description => "${title} - AWS ElasticCache Memory Utilization",
     notes_url           => monitoring_docs_url(aws-cache-memory),
     require             => Icinga::Check_config['check_aws_cache_memory'],
   }

--- a/modules/monitoring/manifests/checks/rds_config.pp
+++ b/modules/monitoring/manifests/checks/rds_config.pp
@@ -32,7 +32,7 @@ define monitoring::checks::rds_config (
     check_command       => "check_aws_rds_cpu!${region}!${cpu_warning}!${cpu_critical}!${::aws_stackname}-${title}",
     use                 => 'govuk_urgent_priority',
     host_name           => $::fqdn,
-    service_description => 'AWS RDS CPU Utilization',
+    service_description => "${title} - AWS RDS CPU Utilization",
     notes_url           => monitoring_docs_url(aws-rds-cpu),
     require             => Icinga::Check_config['check_aws_rds_cpu'],
   }
@@ -41,7 +41,7 @@ define monitoring::checks::rds_config (
     check_command       => "check_aws_rds_memory!${region}!${memory_warning}!${memory_critical}!${::aws_stackname}-${title}",
     use                 => 'govuk_urgent_priority',
     host_name           => $::fqdn,
-    service_description => 'AWS RDS Memory Utilization',
+    service_description => "${title} - AWS RDS Memory Utilization",
     notes_url           => monitoring_docs_url(aws-rds-memory),
     require             => Icinga::Check_config['check_aws_rds_memory'],
   }
@@ -50,7 +50,7 @@ define monitoring::checks::rds_config (
     check_command       => "check_aws_rds_storage!${region}!${storage_warning}!${storage_critical}!${::aws_stackname}-${title}",
     use                 => 'govuk_urgent_priority',
     host_name           => $::fqdn,
-    service_description => 'AWS RDS Storage Utilization',
+    service_description => "${title} - AWS RDS Storage Utilization",
     notes_url           => monitoring_docs_url(aws-rds-storage),
     require             => Icinga::Check_config['check_aws_rds_storage'],
   }


### PR DESCRIPTION
- We were using a common "Service Description" when we were iterating
over the server list in puppet. This meant that the checks were not
separated correctly.

- To overcome this issue, we are using the "title" variable  (server name) that
gets passed to the resource, to denote the description. This will create
unique descriptions.

https://trello.com/c/C7SY8edZ/1123-monitor-rds-and-elasticache-in-aws-and-alert-icinga

Solo: @suthagarht