### PR TITLE
Add port and prepared statements options to database url env var

### DIFF
--- a/modules/govuk/manifests/app/envvar/database_url.pp
+++ b/modules/govuk/manifests/app/envvar/database_url.pp
@@ -21,18 +21,39 @@
 # [*database*]
 #   The database name.
 #
+# [*port*]
+#   The database port.  If not given, no port is included in the URL.
+#
+# [*allow_prepared_statements*]
+#    Whether to allow prepared statements.  If not given, no
+#    prepared_statements parameter is included in the URL.
+#
 define govuk::app::envvar::database_url (
   $type,
   $username,
   $password,
   $host,
   $database,
+  $port = undef,
+  $allow_prepared_statements = undef,
 ) {
+
+  if $port == undef {
+    $host_and_port = $host
+  } else {
+    $host_and_port = "${host}:${port}"
+  }
+
+  if $allow_prepared_statements == undef {
+    $query_string = ''
+  } else {
+    $query_string = "?prepared_statements=${allow_prepared_statements}"
+  }
 
   $escaped_password = inline_template('<%= CGI.escape(@password) %>')
   govuk::app::envvar { "${title}-DATABASE_URL":
     app     => $title,
     varname => 'DATABASE_URL',
-    value   => "${type}://${username}:${escaped_password}@${host}/${database}",
+    value   => "${type}://${username}:${escaped_password}@${host_and_port}/${database}${query_string}",
   }
 }


### PR DESCRIPTION
When switching an app to use pgbouncer, we will have to change the port and disable prepared statements.

---

[Trello card](https://trello.com/c/BosbZ9n9/336-investigate-postgres-connection-pooling)