### PR TITLE
Monitoring AWS RDS and ElasticCache - Fixes

### DIFF
--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_cache_memory
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_cache_memory
@@ -205,10 +205,10 @@ average = average_bytes / (1024 * 1024 * 1024)
 # 3) Compare the check vs actual.                       #
 #########################################################
 if float(average) > args.critical:
-  print "CRITICAL: Current AWS:ElasticCache FreeableMemory for {} is {} %".format(args.instanceid, average)
+  print "CRITICAL: Current AWS:ElasticCache FreeableMemory for {} is {} Gigabytes".format(args.instanceid, average)
   sys.exit(2)
 elif float(average) > args.warning:
-  print "WARNING: Current AWS:ElasticCache FreeableMemory for {} is {} %".format(args.instanceid, average)
+  print "WARNING: Current AWS:ElasticCache FreeableMemory for {} is {} Gigabytes".format(args.instanceid, average)
   sys.exit(1)
 else:
-  print "OK: Current AWS:ElasticCache FreeableMemory for {} is {} %".format(args.instanceid, average)
+  print "OK: Current AWS:ElasticCache FreeableMemory for {} is {} Gigabytes".format(args.instanceid, average)

--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_rds_memory
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_rds_memory
@@ -187,10 +187,10 @@ memory = memory_bytes / (1024 * 1024 * 1024)
 # 3) Compare the check vs actual.			#
 #########################################################
 if memory < args.critical:
-  print "CRITICAL: Current AWS:RDS FreeableMemory for {} is {} Giga Bytes".format(args.instanceid, memory)
+  print "CRITICAL: Current AWS:RDS FreeableMemory for {} is {} Gigabytes".format(args.instanceid, memory)
   sys.exit(2)
 elif memory < args.warning:
-  print "WARNING: Current AWS:RDS FreeableMemory for {} is {} Giga Bytes".format(args.instanceid, memory)
+  print "WARNING: Current AWS:RDS FreeableMemory for {} is {} Gigabytes".format(args.instanceid, memory)
   sys.exit(1)
 else:
-  print "OK: Current AWS:RDS FreeableMemory for {} is {} Giga Bytes".format(args.instanceid, memory)
+  print "OK: Current AWS:RDS FreeableMemory for {} is {} Gigabytes".format(args.instanceid, memory)

--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_rds_storage
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_rds_storage
@@ -187,10 +187,10 @@ average = average_bytes / (1024 * 1024 * 1024)
 # 3) Compare the check vs actual.			#
 #########################################################
 if float(average) < args.critical:
-  print "CRITICAL: Current AWS:RDS FreeStorageSpace for {} is {} %".format(args.instanceid, average)
+  print "CRITICAL: Current AWS:RDS FreeStorageSpace for {} is {} Gigabytes".format(args.instanceid, average)
   sys.exit(2)
 elif float(average) < args.warning:
-  print "WARNING: Current AWS:RDS FreeStorageSpace for {} is {} %".format(args.instanceid, average)
+  print "WARNING: Current AWS:RDS FreeStorageSpace for {} is {} Gigabytes".format(args.instanceid, average)
   sys.exit(1)
 else:
-  print "OK: Current AWS:RDS FreeStorageSpace for {} is {} %".format(args.instanceid, average)
+  print "OK: Current AWS:RDS FreeStorageSpace for {} is {} Gigabytes".format(args.instanceid, average)


### PR DESCRIPTION
- We noticed that the output displayed on "Icinga" doesn't explicitly
say the measure of the value. For example percentage or gigabytes. We
have added context to the output via this commit.

https://trello.com/c/C7SY8edZ/1123-monitor-rds-and-elasticache-in-aws-and-alert-icinga

Solo: @suthagarht