### PR TITLE
Tidy up content performance manager sidekiq queues

### DIFF
--- a/development-vm/Pinfile
+++ b/development-vm/Pinfile
@@ -16,8 +16,7 @@ process :'collections-publisher' => [:'publishing-api', :'collections-publisher-
 process :'collections-publisher-worker'
 process :'contacts-admin' => [:'publishing-api', :whitehall]
 process :'content-audit-tool' => [:'publishing-api-read', :'content-audit-tool-sidekiq-google-analytics', :'content-audit-tool-sidekiq-publishing-api']
-process :'content-performance-manager' => [:'publishing-api', :'content-performance-manager-sidekiq-google-analytics', :'content-performance-manager-sidekiq-publishing-api', :'content-performance-manager-publishing-api-consumer', 'content-store' , 'content-performance-manager-bulk-import-publishing-api-consumer']
-process :'content-publisher'
+process :'content-performance-manager' => [:'publishing-api', :'content-performance-manager-sidekiq-default', :'content-performance-manager-publishing-api-consumer', 'content-store']
 process :'content-store'
 # Example usage: bowl [your-app] dummy-content-store --without content-store
 process :'dummy-content-store'

--- a/development-vm/Procfile
+++ b/development-vm/Procfile
@@ -155,8 +155,7 @@ content-performance-manager:      govuk_setenv content-performance-manager ./run
 # sidekiq-monitoring for content-performance-manager uses port 3207
 content-performance-manager-publishing-api-consumer: govuk_setenv content-performance-manager ./run_in.sh ../../content-performance-manager bundle exec rake publishing_api:consumer
 content-performance-manager-bulk-import-publishing-api-consumer: govuk_setenv content-performance-manager ./run_in.sh ../../content-performance-manager bundle exec rake publishing_api:bulk_import_consumer
-content-performance-manager-sidekiq-google-analytics: govuk_setenv content-performance-manager ./run_in.sh ../../content-performance-manager bundle exec sidekiq -C ./config/sidekiq/google_analytics.yml
-content-performance-manager-sidekiq-publishing-api:  govuk_setenv content-performance-manager ./run_in.sh ../../content-performance-manager bundle exec sidekiq -C ./config/sidekiq/publishing_api.yml
+content-performance-manager-sidekiq-default:  govuk_setenv content-performance-manager ./run_in.sh ../../content-performance-manager bundle exec sidekiq -C ./config/sidekiq/default.yml
 # sidekiq-monitoring for link-checker-api-sidekiq uses port 3209
 link-checker-api:                     govuk_setenv link-checker-api            ./run_in.sh ../../link-checker-api bundle exec rails server -p 3208
 link-checker-api-sidekiq:             govuk_setenv link-checker-api            ./run_in.sh ../../link-checker-api bundle exec sidekiq -C ./config/sidekiq.yml


### PR DESCRIPTION
Remove the unused google analytics worker for cpm, and rename the publishing api worker to default worker.