### PR TITLE
Use pgbouncer for ckan in AWS

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -368,7 +368,9 @@ govuk::apps::bouncer::nagios_memory_warning: 1400
 govuk::apps::bouncer::nagios_memory_critical: 1500
 govuk::apps::bouncer::unicorn_worker_processes: "8"
 
-govuk::apps::ckan::db_hostname: "postgresql-primary"
+govuk::apps::ckan::db_hostname: "db-admin"
+govuk::apps::ckan::db_port: 6432
+govuk::apps::ckan::db_allow_prepared_statements: false
 govuk::apps::ckan::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 govuk::apps::ckan::db::allow_auth_from_lb: true
 govuk::apps::ckan::db::lb_ip_range: "%{hiera('environment_ip_prefix')}.0.0/16"

--- a/modules/govuk/manifests/apps/ckan.pp
+++ b/modules/govuk/manifests/apps/ckan.pp
@@ -17,6 +17,14 @@
 # [*db_password*]
 #   The password for the postgresql role
 #
+# [*db_port*]
+#   The port of the database server to use in the DATABASE_URL.
+#   Default: 5432
+#
+# [*db_allow_prepared_statements*]
+#   The ?prepared_statements= parameter to use in the DATABASE_URL.
+#   Default: true
+#
 # [*db_name*]
 #   The database that CKAN should use
 #
@@ -33,6 +41,8 @@ class govuk::apps::ckan (
   $enabled                        = false,
   $port                           = '3220',
   $db_hostname                    = undef,
+  $db_port                        = 5432,
+  $db_allow_prepared_statements   = true,
   $db_username                    = 'ckan',
   $db_password                    = 'foo',
   $db_name                        = 'ckan_production',

--- a/modules/govuk/templates/ckan/ckan.ini.erb
+++ b/modules/govuk/templates/ckan/ckan.ini.erb
@@ -35,7 +35,7 @@ who.log_level = warning
 who.log_file = %(cache_dir)s/who_log.ini
 
 ## Database Settings
-sqlalchemy.url = <%= "postgresql://#{@db_username}:#{@db_password}@#{@db_hostname}/#{@db_name}"%>
+sqlalchemy.url = <%= "postgresql://#{@db_username}:#{@db_password}@#{@db_hostname}:#{@db_port}/#{@db_name}?prepared_statements=#{@db_allow_prepared_statements}"%>
 
 #ckan.datastore.write_url = postgresql://ckan_default:pass@localhost/datastore_default
 #ckan.datastore.read_url = postgresql://datastore_default:pass@localhost/datastore_default


### PR DESCRIPTION
CKAN is not using the `database_url` helper, so this change unconditionally adds the port number and `prepared_statements` query parameter to the generated config file.

---

[Trello card](https://trello.com/c/BosbZ9n9/336-investigate-postgres-connection-pooling)