### PR TITLE
Make content-audit-tool use pgbouncer in Carrenza

### DIFF
--- a/docs/adding-a-new-app.md
+++ b/docs/adding-a-new-app.md
@@ -169,6 +169,8 @@ Start with the following configuration for the app module variables.
 ```
 # hieradata/common.yaml
 govuk::apps::myapp::db_hostname: "postgresql-primary-1.backend"
+govuk::apps::myapp::db_port: 6432
+govuk::apps::myapp::db_allow_prepared_statements: false
 govuk::apps::myapp::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 
 # hieradata_aws/common.yaml

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -375,6 +375,8 @@ govuk::apps::contacts::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::contacts::redis_port: "%{hiera('sidekiq_port')}"
 
 govuk::apps::content_audit_tool::db_hostname: "postgresql-primary-1.backend"
+govuk::apps::content_audit_tool::db_port: 6432
+govuk::apps::content_audit_tool::db_allow_prepared_statements: false
 govuk::apps::content_audit_tool::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 govuk::apps::content_audit_tool::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::content_audit_tool::redis_port: "%{hiera('sidekiq_port')}"


### PR DESCRIPTION
This depends on https://github.com/alphagov/govuk-puppet/pull/7866, and I'd like to test it on staging before merging.

---

[Trello card](https://trello.com/c/BosbZ9n9/336-investigate-postgres-connection-pooling)