### PR TITLE
Make email-alert-api use pgbouncer in Carrenza

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -409,6 +409,8 @@ govuk::apps::email_alert_api::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::email_alert_api::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::email_alert_api::db_hostname: 'postgresql-primary-1.backend'
 govuk::apps::email_alert_api::db_password: "%{hiera('govuk::apps::email_alert_api::db::password')}"
+govuk::apps::email_alert_api::db_port: 6432
+govuk::apps::email_alert_api::db_allow_prepared_statements: false
 govuk::apps::email_alert_api::unicorn_worker_processes: '4'
 # This list should be kept in sync with https://www.notifications.service.gov.uk/services/ecfc7e2f-5145-45a6-9413-5d9b6e813ea9/users
 govuk::apps::email_alert_api::email_address_override_whitelist:


### PR DESCRIPTION
Depends on #7866 

---

[Trello card](https://trello.com/c/BosbZ9n9/336-investigate-postgres-connection-pooling)