### PR TITLE
Monitoring AWS RDS and ElasticCache - Fixes

### DIFF
--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_cache_cpu
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_cache_cpu
@@ -128,7 +128,7 @@ end = datetime.datetime.now()
 
 
 #########################################################################################
-# Use the cloutwatch connection and get metrics.                        		#
+# Use the cloudwatch connection and get metrics.                        		#
 # ----------------------------------------------                        		#
 #                                                                       		#
 # 'data' - The results are captured in this variable. Type = object     		#
@@ -184,7 +184,7 @@ data = cw_conn.get_metric_statistics(
 #################################################################################
 
 #########################################################################################################
-# Disect the result                                                                                     #
+# Dissect the result                                                                                     #
 # -----------------                                                                                     #
 # The result that we get is a 'list' of 'dictonary' elements. Hence, we will                            #
 # iterate over the list and get the first element. Then we will get the first value for "Average"       #

--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_cache_memory
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_cache_memory
@@ -57,6 +57,7 @@ import pprint
 import boto.rds
 import boto.elasticache
 import boto.ec2.cloudwatch
+import boto3
 import datetime
 
 #################################
@@ -117,6 +118,52 @@ except boto.exception.BotoServerError as err:
 ##########################################
 cw_conn = boto.ec2.cloudwatch.connect_to_region(args.region)
 
+################################################
+# Elasticcache instances and Memory Dictionary #
+################################################
+# https://aws.amazon.com/elasticache/details/
+cache_classes = {
+   'cache.t2.small':    1.55,
+   'cache.t2.micro':    0.555,
+   'cache.t2.medium': 3.22,
+   'cache.r4.xlarge': 25.05,
+   'cache.r4.large': 12.3,
+   'cache.r4.8xlarge': 203.26,
+   'cache.r4.4xlarge': 101.38,
+   'cache.r4.2xlarge': 50.47,
+   'cache.r4.16xlarge': 407,
+   'cache.r3.xlarge':   28.4,
+   'cache.r3.large': 13.5,
+   'cache.r3.8xlarge': 237,
+   'cache.r3.4xlarge': 118,
+   'cache.r3.2xlarge': 58.2,
+   'cache.m4.xlarge':   14.28,
+   'cache.m4.large': 6.42,
+   'cache.m4.4xlarge': 60.78,
+   'cache.m4.2xlarge': 29.7,
+   'cache.m4.10xlarge': 154.64,
+   'cache.m3.xlarge':   13.3,
+   'cache.m3.medium': 2.78,
+   'cache.m3.large': 6.05,
+   'cache.m3.2xlarge': 27.9,
+}
+
+############################################
+# Create an ElasticCache client connection.#
+############################################
+client = boto3.client('elasticache')
+
+# Get instance type
+response = client.describe_cache_clusters(CacheClusterId=args.instanceid)
+# The 'response' is a dictionary of lists of dictionaries.
+cache_instance_data = response.get('CacheClusters')
+
+for attributes in cache_instance_data:
+  cache_instance_type = attributes['CacheNodeType']
+
+# Memory assigned to the instance type
+allocated_memory = cache_classes.get(cache_instance_type)
+
 ###########################################################
 # Define start and end times                              #
 # Here we have give 5 minutes because that is the window  #
@@ -128,7 +175,7 @@ end = datetime.datetime.now()
 
 
 #########################################################################################
-# Use the cloutwatch connection and get metrics.                        		#
+# Use the cloudwatch connection and get metrics.                        		#
 # ----------------------------------------------                        		#
 #                                                                       		#
 # 'data' - The results are captured in this variable. Type = object     		#
@@ -184,7 +231,7 @@ data = cw_conn.get_metric_statistics(
 #################################################################################
 
 #########################################################################################################
-# Disect the result                                                                                     #
+# Dissect the result                                                                                     #
 # -----------------                                                                                     #
 # The result that we get is a 'list' of 'dictonary' elements. Hence, we will                            #
 # iterate over the list and get the first element. Then we will get the first value for "Average"       #
@@ -197,6 +244,9 @@ average_bytes = item["Average"]
 # Convert bytes to gigabytes.
 average = average_bytes / (1024 * 1024 * 1024)
 
+# Calculate the percentage of available memory in comparison to the available amount.
+memory_percentage = 100 / float(allocated_memory) * float(average)
+
 #########################################################
 # Print the output                                     #
 # This is the final step. We do the following here.     #
@@ -204,11 +254,11 @@ average = average_bytes / (1024 * 1024 * 1024)
 # 2) Convert the defined value to 'float' type.         #
 # 3) Compare the check vs actual.                       #
 #########################################################
-if float(average) > args.critical:
-  print "CRITICAL: Current AWS:ElasticCache FreeableMemory for {} is {} Gigabytes".format(args.instanceid, average)
+if float(memory_percentage) < args.critical:
+  print "CRITICAL: Current AWS:ElasticCache FreeableMemory for {} is {}GB. [{}% of {}GB]".format(args.instanceid, average, memory_percentage, allocated_memory)
   sys.exit(2)
-elif float(average) > args.warning:
-  print "WARNING: Current AWS:ElasticCache FreeableMemory for {} is {} Gigabytes".format(args.instanceid, average)
+elif float(memory_percentage) < args.warning:
+  print "WARNING: Current AWS:ElasticCache FreeableMemory for {} is {}GB. [{}% of {}GB]".format(args.instanceid, average,memory_percentage, allocated_memory)
   sys.exit(1)
 else:
-  print "OK: Current AWS:ElasticCache FreeableMemory for {} is {} Gigabytes".format(args.instanceid, average)
+  print "OK: Current AWS:ElasticCache FreeableMemory for {} is {}GB. [{}% of {}GB]".format(args.instanceid, average, memory_percentage, allocated_memory)

--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_rds_cpu
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_rds_cpu
@@ -166,7 +166,7 @@ data = cw_conn.get_metric_statistics(
 #################################################################################
 
 #########################################
-# Disect the result			#
+# Dissect the result			#
 # -----------------			#
 # The result that we get is a 'list' of	#
 # 'dictonary' elements. Hence, we will	#

--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_rds_memory
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_rds_memory
@@ -57,6 +57,7 @@ import pprint
 import boto.rds
 import boto.ec2.cloudwatch
 import datetime
+import boto3
 
 
 #################################
@@ -92,6 +93,54 @@ instances = rds.get_all_dbinstances()
 # Create a cloud watch connection client.#
 ##########################################
 cw_conn = boto.ec2.cloudwatch.connect_to_region(args.region)
+
+######################################
+# DB instances and Memory Dictionary #
+######################################
+# http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html
+db_classes = {
+   'db.t1.micro': 0.615,
+   'db.m1.small': 1.7,
+   'db.m1.medium': 3.75,
+   'db.m1.large': 7.5,
+   'db.m1.xlarge': 15,
+   'db.m4.large': 8,
+   'db.m4.xlarge': 16,
+   'db.m4.2xlarge': 32,
+   'db.m4.4xlarge': 64,
+   'db.m4.10xlarge': 160,
+   'db.r3.large': 15,
+   'db.r3.xlarge': 30.5,
+   'db.r3.2xlarge': 61,
+   'db.r3.4xlarge': 122,
+   'db.r3.8xlarge': 244,
+   'db.t2.micro': 1,
+   'db.t2.small': 2,
+   'db.t2.medium': 4,
+   'db.t2.large': 8,
+   'db.m3.medium': 3.75,
+   'db.m3.large': 7.5,
+   'db.m3.xlarge': 15,
+   'db.m3.2xlarge': 30,
+   'db.m2.xlarge': 17.1,
+   'db.m2.2xlarge': 34.2,
+   'db.m2.4xlarge': 68.4,
+   'db.cr1.8xlarge': 244,
+}
+
+####################################################
+# Create a boto3 client to get the instance details#
+####################################################
+client = boto3.client('rds')
+# Collect DB instance attributes
+response = client.describe_db_instances(DBInstanceIdentifier=args.instanceid)
+db_instance_data = response.get('DBInstances')
+# Get the allocated storage
+for attributes in db_instance_data:
+  allocated_instance_type = attributes["DBInstanceClass"]
+
+# Memory assigned to the instance type
+allocated_memory = db_classes.get(allocated_instance_type)
 
 ###########################################################
 # Define start and end times      			  #
@@ -166,7 +215,7 @@ data = cw_conn.get_metric_statistics(
 #################################################################################
 
 #########################################
-# Disect the result			#
+# Dissect the result			#
 # -----------------			#
 # The result that we get is a 'list' of	#
 # 'dictonary' elements. Hence, we will	#
@@ -179,6 +228,9 @@ for item in data:
 # The average value is returned in bytes. Here we are converting it to giga bytes.
 memory = memory_bytes / (1024 * 1024 * 1024)
 
+# Calculate the percentage of available memory in comparison to the available amount.
+memory_percentage = 100 / float(allocated_memory) * float(memory)
+
 #########################################################
 # Print the output					#
 # This is the final step. We do the following here.	#
@@ -186,11 +238,11 @@ memory = memory_bytes / (1024 * 1024 * 1024)
 # 2) Convert the defined value to 'float' type.		#
 # 3) Compare the check vs actual.			#
 #########################################################
-if memory < args.critical:
-  print "CRITICAL: Current AWS:RDS FreeableMemory for {} is {} Gigabytes".format(args.instanceid, memory)
+if memory_percentage < args.critical:
+  print "CRITICAL: Current AWS:RDS FreeableMemory for {} is {}GB. [{}% of {}GB]".format(args.instanceid, memory, memory_percentage, allocated_memory)
   sys.exit(2)
-elif memory < args.warning:
-  print "WARNING: Current AWS:RDS FreeableMemory for {} is {} Gigabytes".format(args.instanceid, memory)
+elif memory_percentage < args.warning:
+  print "WARNING: Current AWS:RDS FreeableMemory for {} is {}GB. [{}% of {}GB]".format(args.instanceid, memory, memory_percentage, allocated_memory)
   sys.exit(1)
 else:
-  print "OK: Current AWS:RDS FreeableMemory for {} is {} Gigabytes".format(args.instanceid, memory)
+  print "OK: Current AWS:RDS FreeableMemory for {} is {}GB. [{}% of {}GB]".format(args.instanceid, memory, memory_percentage, allocated_memory)

--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_rds_storage
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_rds_storage
@@ -54,6 +54,7 @@
 import sys
 import argparse
 import pprint
+import boto3
 import boto.rds
 import boto.ec2.cloudwatch
 import datetime
@@ -92,6 +93,18 @@ instances = rds.get_all_dbinstances()
 # Create a cloud watch connection client.#
 ##########################################
 cw_conn = boto.ec2.cloudwatch.connect_to_region(args.region)
+
+####################################################
+# Create a boto3 client to get the instance details#
+####################################################
+client = boto3.client('rds')
+# Collect DB instance attributes
+response = client.describe_db_instances(DBInstanceIdentifier=args.instanceid)
+db_instance_data = response.get('DBInstances')
+# Get the allocated storage
+for attributes in db_instance_data:
+  allocated_storage = attributes["AllocatedStorage"]
+
 
 ###########################################################
 # Define start and end times      			  #
@@ -166,7 +179,7 @@ data = cw_conn.get_metric_statistics(
 #################################################################################
 
 #########################################
-# Disect the result			#
+# Dissect the result			#
 # -----------------			#
 # The result that we get is a 'list' of	#
 # 'dictonary' elements. Hence, we will	#
@@ -179,6 +192,9 @@ for item in data:
 # Converting bytes to giga bytes.
 average = average_bytes / (1024 * 1024 * 1024)
 
+# Calculate the percentage of free storage in comparison to the allocated storage.
+available_storage = 100 / float(allocated_storage) * float(average)
+
 #########################################################
 # Print the output					#
 # This is the final step. We do the following here.	#
@@ -186,11 +202,11 @@ average = average_bytes / (1024 * 1024 * 1024)
 # 2) Convert the defined value to 'float' type.		#
 # 3) Compare the check vs actual.			#
 #########################################################
-if float(average) < args.critical:
-  print "CRITICAL: Current AWS:RDS FreeStorageSpace for {} is {} Gigabytes".format(args.instanceid, average)
+if float(available_storage) < args.critical:
+  print "CRITICAL: Current AWS:RDS FreeStorageSpace for {} is {}GB.[{}% of {}GB] ".format(args.instanceid, average, available_storage, allocated_storage)
   sys.exit(2)
-elif float(average) < args.warning:
-  print "WARNING: Current AWS:RDS FreeStorageSpace for {} is {} Gigabytes".format(args.instanceid, average)
+elif float(available_storage) < args.warning:
+  print "WARNING: Current AWS:RDS FreeStorageSpace for {} is {}GB.[{}% of {}GB]".format(args.instanceid, average, available_storage, allocated_storage)
   sys.exit(1)
 else:
-  print "OK: Current AWS:RDS FreeStorageSpace for {} is {} Gigabytes".format(args.instanceid, average)
+  print "OK: Current AWS:RDS FreeStorageSpace for {} is {}GB.[{}% of {}GB]".format(args.instanceid, average, available_storage, allocated_storage)

--- a/modules/monitoring/manifests/checks/cache_config.pp
+++ b/modules/monitoring/manifests/checks/cache_config.pp
@@ -26,8 +26,8 @@ define monitoring::checks::cache_config (
   $region = undef,
   $cpu_warning = 80,
   $cpu_critical = 90,
-  $memory_warning = 5,
-  $memory_critical = 2,
+  $memory_warning = 20,
+  $memory_critical = 10,
   ){
   icinga::check { "check_aws_cache_cpu-${title}":
     check_command       => "check_aws_cache_cpu!${region}!${cpu_warning}!${cpu_critical}!${::aws_stackname}-${title}",

--- a/modules/monitoring/manifests/checks/rds_config.pp
+++ b/modules/monitoring/manifests/checks/rds_config.pp
@@ -14,17 +14,17 @@
 #  Defines the percentage of cpu usage for which a critical alert will be triggered. 
 #
 # [*memory_warning*]
-#  Defines the amount of free usable memory in gigabytes that will trigger a warning.
+#  Defines the percentage of free usable memory that will trigger a warning.
 #
 # [*memory_critical*]
-#  Defines the amount of free usable memory in gigabytes that will trigger a critical alert.
+#  Defines the percentage of free usable memory that will trigger a critical alert.
 #
 define monitoring::checks::rds_config (
   $region = undef,
   $cpu_warning = 80,
   $cpu_critical = 90,
-  $memory_warning = 5,
-  $memory_critical = 2,
+  $memory_warning = 20,
+  $memory_critical = 10,
   $storage_warning = 20,
   $storage_critical = 10,
 ){


### PR DESCRIPTION
- We noticed that the output displayed on "Icinga" doesn't explicitly
say the measure of the value. For example percentage or gigabytes. We
have added context to the output via this commit.

- The variable used to store the used memory average bytes wasn't
defined correctly. This has been corrected via this commit.

https://trello.com/c/C7SY8edZ/1123-monitor-rds-and-elasticache-in-aws-and-alert-icinga

Solo: @suthagarht