### PR TITLE
Fix enforced unique temppath in sync jobs

### DIFF
--- a/modules/govuk_env_sync/files/govuk_env_sync.sh
+++ b/modules/govuk_env_sync/files/govuk_env_sync.sh
@@ -20,8 +20,8 @@ set -eu
 #     This is used to construct script names called, e.g. push_s3
 #
 #   T) temppath
-#     Path to create temporary directory in. Will be ensured to exist by Puppet
-#     Parent must exist
+#     Path to create temporary directory in. Directory will be created if 
+#     sufficient rights are granted to the govuk-backup user.
 #
 #   d) database
 #     Name of the database to be copied/sync'd
@@ -41,6 +41,7 @@ function create_timestamp {
 }
 
 function create_tempdir {
+  mkdir -p "${temppath}" || echo "Could not access ${temppath}"; exit 1
   tempdir="$(mktemp --directory -p "${temppath}")"
 }
 

--- a/modules/govuk_env_sync/manifests/task.pp
+++ b/modules/govuk_env_sync/manifests/task.pp
@@ -50,13 +50,6 @@ define govuk_env_sync::task(
   require govuk_env_sync::aws_auth
   require govuk_env_sync::sync_script
 
-  file { $temppath:
-    ensure => directory,
-    mode   => '0755',
-    owner  => $govuk_env_sync::user,
-    group  => $govuk_env_sync::user,
-  }
-
   file { "${govuk_env_sync::conf_dir}/${title}.cfg":
     ensure  => present,
     mode    => '0755',


### PR DESCRIPTION
- Puppet ensure=>directory requires resource to be unique.

- Ensuring dir exists by mkdir -p works well enough

- Unique database tasks can share temppath s.

solo @schmie