### PR TITLE
Integrate compression/decompression in dump/restore

### DIFF
--- a/modules/govuk_env_sync/files/govuk_env_sync.sh
+++ b/modules/govuk_env_sync/files/govuk_env_sync.sh
@@ -53,16 +53,6 @@ function set_filename {
   filename="${timestamp}-${database}.gz"
 }
 
-function compress_data {
-  cd "${tempdir}"
-  tar --create --gzip --force-local --file "${filename}" "${database}"
-}
-
-function decompress_data {
-  cd "${tempdir}"
-  tar --extract --gzip --file "${filename}"
-}
-
 function is_writable_mongo {
   mongo --quiet --eval "print(db.isMaster()[\"ismaster\"]);" "localhost/$database"
 }
@@ -80,14 +70,18 @@ function dump_mongo {
       --out "${tempdir}"
 
   done
+
+  cd "${tempdir}"
+  tar --create --gzip --force-local --file "${filename}" "${database}"
 }
 
 function restore_mongo {
+  cd "${tempdir}"
+  tar --extract --gzip --file "${filename}"
 
-    mongorestore --drop \
-      --db "${database}" \
-      "${tempdir}/${database}"
-
+  mongorestore --drop \
+    --db "${database}" \
+    "${tempdir}/${database}"
 }
 
 function push_s3 {


### PR DESCRIPTION
- DBMS other than Mongo 2.4.x do support compression natively
  therefore separation of compression steps is not required and creates
  unecessary overhead.

- Moving compression and decompression into mongo dump/restore and
  removing separate calls from algorithm in main script.

solo @schmie