### PR TITLE
Add default worker to cpm

### DIFF
--- a/modules/govuk/manifests/apps/content_performance_manager.pp
+++ b/modules/govuk/manifests/apps/content_performance_manager.pp
@@ -109,16 +109,10 @@ class govuk::apps::content_performance_manager(
     app    => $app_name,
   }
 
-  govuk::procfile::worker { "${app_name}-google-analytics-worker":
+  govuk::procfile::worker { "${app_name}-default-worker":
     enable_service => $enable_procfile_worker,
     setenv_as      => $app_name,
-    process_type   => 'google-analytics-worker',
-  }
-
-  govuk::procfile::worker { "${app_name}-publishing-api-worker":
-    enable_service => $enable_procfile_worker,
-    setenv_as      => $app_name,
-    process_type   => 'publishing-api-worker',
+    process_type   => 'default-worker',
   }
 
   govuk::procfile::worker { "${app_name}-publishing-api-consumer":


### PR DESCRIPTION
Add default-workers to content_performance_manager.pp and delete google-analytics-worker
and publishing-api-worker which are no longer used.