### PR TITLE
Do not add pgbouncer entries for CPM, mapit, or transition

### DIFF
--- a/modules/govuk/manifests/apps/content_performance_manager/db.pp
+++ b/modules/govuk/manifests/apps/content_performance_manager/db.pp
@@ -19,5 +19,6 @@ class govuk::apps::content_performance_manager::db (
     allow_auth_from_backend => true,
     backend_ip_range        => $backend_ip_range,
     rds                     => $rds,
+    enable_in_pgbouncer     => false,
   }
 }

--- a/modules/govuk/manifests/apps/mapit.pp
+++ b/modules/govuk/manifests/apps/mapit.pp
@@ -37,9 +37,10 @@ class govuk::apps::mapit (
     }
 
     govuk_postgresql::db { 'mapit':
-      user       => 'mapit',
-      password   => $db_password,
-      extensions => ['plpgsql', 'postgis'],
+      user                => 'mapit',
+      password            => $db_password,
+      extensions          => ['plpgsql', 'postgis'],
+      enable_in_pgbouncer => false,
     }
 
     class { 'postgresql::server::postgis': }

--- a/modules/govuk/manifests/apps/transition/postgresql_db.pp
+++ b/modules/govuk/manifests/apps/transition/postgresql_db.pp
@@ -31,5 +31,6 @@ class govuk::apps::transition::postgresql_db (
     allow_auth_from_lb      => $allow_auth_from_lb,
     lb_ip_range             => $lb_ip_range,
     rds                     => $rds,
+    enable_in_pgbouncer     => false,
   }
 }

--- a/modules/govuk_postgresql/manifests/db.pp
+++ b/modules/govuk_postgresql/manifests/db.pp
@@ -49,6 +49,10 @@
 # [*lb_ip_range*]
 # Network range for the load balancer.
 #
+# [*enable_in_pgbouncer*]
+# Whether to allow access to this database from pgbouncer.
+# Default: true
+#
 # [*ssl_only*]
 # Whether to configure the pg_hba.conf rules to only respond to clients who
 # connect over SSL. If it is false it will allow either.
@@ -66,6 +70,7 @@ define govuk_postgresql::db (
     $allow_auth_from_lb      = false,
     $lb_ip_range             = undef,
     $ssl_only                = false,
+    $enable_in_pgbouncer     = true,
     $rds                     = false,
     $rds_root_user           = 'aws_db_admin',
 ) {
@@ -158,21 +163,23 @@ define govuk_postgresql::db (
     }
   }
 
-  if $rds {
-    $host = $postgresql::server::default_connect_settings['PGHOST']
-  } else {
-    $host = '127.0.0.1'
-  }
+  if $enable_in_pgbouncer {
+    if $rds {
+      $host = $postgresql::server::default_connect_settings['PGHOST']
+    } else {
+      $host = '127.0.0.1'
+    }
 
-  govuk_pgbouncer::db { $title:
-    user                    => $user,
-    password_hash           => $password_hash,
-    database                => $db_name,
-    allow_auth_from_backend => $allow_auth_from_backend,
-    backend_ip_range        => $backend_ip_range,
-    allow_auth_from_lb      => $allow_auth_from_lb,
-    lb_ip_range             => $lb_ip_range,
-    hba_type                => $hba_type,
-    host                    => $host,
+    govuk_pgbouncer::db { $title:
+      user                    => $user,
+      password_hash           => $password_hash,
+      database                => $db_name,
+      allow_auth_from_backend => $allow_auth_from_backend,
+      backend_ip_range        => $backend_ip_range,
+      allow_auth_from_lb      => $allow_auth_from_lb,
+      lb_ip_range             => $lb_ip_range,
+      hba_type                => $hba_type,
+      host                    => $host,
+    }
   }
 }


### PR DESCRIPTION
The nodes these apps live on do not enable pgbouncer, so trying to set
up pgbouncer config entries results in puppet failing with missing
resources.