### PR TITLE
Add link checker api address association and add link-checker-api to collections-publisher process

### DIFF
--- a/development-vm/Pinfile
+++ b/development-vm/Pinfile
@@ -12,7 +12,7 @@ process :bouncer
 process :calculators => [:static, :'content-store']
 process :calendars => [:static, :'content-store']
 process :collections => [:static, :'content-store', :rummager]
-process :'collections-publisher' => [:'publishing-api', :'collections-publisher-worker']
+process :'collections-publisher' => [:'publishing-api', :'collections-publisher-worker', :'link-checker-api']
 process :'collections-publisher-worker'
 process :'contacts-admin' => [:'publishing-api', :whitehall]
 process :'content-audit-tool' => [:'publishing-api-read', :'content-audit-tool-sidekiq-google-analytics', :'content-audit-tool-sidekiq-publishing-api']

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -283,6 +283,7 @@ hosts::development::apps:
   - 'imminence'
   - 'info-frontend'
   - 'licencefinder'
+  - 'link-checker-api'
   - 'local-links-manager'
   - 'manuals-frontend'
   - 'manuals-publisher'


### PR DESCRIPTION
As part of the work to improve the collections-publisher tool, we discovered that link-checker-api had no host entry on the development VM. This first commit here fixes that. The second commit adds the link-checker-api service to the collections-publisher process, so that when you `bowl collections-publisher` you get all the services you need to make it work.