### PR TITLE
Remove feedback link to deployment dashboards

### DIFF
--- a/modules/grafana/templates/dashboards/deployment_panels/_links.json.erb
+++ b/modules/grafana/templates/dashboards/deployment_panels/_links.json.erb
@@ -1,5 +1,5 @@
 {
-  "content": "<ul style=\"font-size: 20px;\">\n<li><a target=\"_blank\" href=\"https://sentry.io/govuk/app-<%= @app_name %>/?query=is%3Aunresolved+environment%3A<%= @sentry_environment %>\">Errors for <%= @app_name %> (Sentry)</a></li>\n<li><a target=\"_blank\" href=\"https://kibana.logit.io\">Kibana (Logit)</a></li>\n<li><a target=\"_blank\" href=\"https://alert.<%= @app_domain %>/\">Icinga</a></li>\n<li><a target=\"_blank\" href=\"https://docs.publishing.service.gov.uk/apps/<%= @docs_name %>.html\"><%= @app_name %> documentation</a></li>\n<li><a target=\"_blank\" href=\"https://govuk.zendesk.com/agent/filters/135081425\">Dashboard feedback</a></li>\n</ul>\n",
+  "content": "<ul style=\"font-size: 20px;\">\n<li><a target=\"_blank\" href=\"https://sentry.io/govuk/app-<%= @app_name %>/?query=is%3Aunresolved+environment%3A<%= @sentry_environment %>\">Errors for <%= @app_name %> (Sentry)</a></li>\n<li><a target=\"_blank\" href=\"https://kibana.logit.io\">Kibana (Logit)</a></li>\n<li><a target=\"_blank\" href=\"https://alert.<%= @app_domain %>/\">Icinga</a></li>\n<li><a target=\"_blank\" href=\"https://docs.publishing.service.gov.uk/apps/<%= @docs_name %>.html\"><%= @app_name %> documentation</a></li>\n</ul>\n",
   "editable": true,
   "error": false,
   "id": 12,


### PR DESCRIPTION
It doesn't seem to link anywhere and I doubt it's being monitored.

[Trello Card](https://trello.com/c/VSoSx2eK/117-fix-or-remove-broken-feedback-on-deployment-dashboards)