### PR TITLE
Use the same hieradata value everywhere.

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -286,6 +286,7 @@ collectd::plugin::tcp::metrics:
   - 'ActiveOpens'
   - 'PassiveOpens'
 
+collectd::package::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 collectd::plugin::docker::repo: "https://github.com/lebauce/docker-collectd-plugin.git"
 collectd::plugin::docker::commit: "c3edc64555f35d8ffcc9aee23b69c289e8f309fb"
 

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -292,6 +292,7 @@ collectd::plugin::tcp::metrics:
   - 'ActiveOpens'
   - 'PassiveOpens'
 
+collectd::package::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 collectd::plugin::docker::repo: "https://github.com/lebauce/docker-collectd-plugin.git"
 collectd::plugin::docker::commit: "c3edc64555f35d8ffcc9aee23b69c289e8f309fb"
 

--- a/modules/collectd/manifests/package.pp
+++ b/modules/collectd/manifests/package.pp
@@ -16,8 +16,7 @@
 class collectd::package (
   $collectd_version = '5.4.0-3ubuntu2',
   $yajl_package = 'libyajl2',
-  $apt_mirror_hostname = 'apt.production.alphagov.co.uk',
-
+  $apt_mirror_hostname = undef,
 ) {
   include govuk_ppa
 


### PR DESCRIPTION
This will make migrating the service easier as we only have to change
one value in hiera.