### PR TITLE
Add Grafana datasources automatically

### DIFF
--- a/modules/grafana/manifests/datasources.pp
+++ b/modules/grafana/manifests/datasources.pp
@@ -1,0 +1,74 @@
+# == Class: grafana::datasources
+#
+# Adds datasources to Grafana via its web API
+#
+# [*webapi_user*]
+#   The user used to authenticate to the web API
+#
+# [*webapi_password*]
+#   The password used to authenticate to the web API
+#
+# [*webapi_user*]
+#   The user used to authenticate to the Logit Elasticsearch interface
+#
+# [*webapi_password*]
+#   The password used to authenticate to the Logit Elasticsearch interface
+#
+# [*elasticsearch_endpoint*]
+#   Logit Elasticsearch Endpoint URL to connect to
+#
+class grafana::datasources(
+  $webapi_user = undef,
+  $webapi_password = undef,
+  $elasticsearch_endpoint = undef,
+  $elasticsearch_user = undef,
+  $elasticsearch_password = undef,
+) {
+
+  $graphitesourcejson = '{ "name":"Graphite","type":"graphite","url":"https://graphite","access":"proxy", }'
+
+  $graphitesourceadd = shellquote([
+    'curl',"http://${webapi_user}:${webapi_password}@127.0.0.1:3204/api/datasources",
+    '-X','POST','-H','Content-Type: application/json;charset=UTF-8',
+    '--data-binary',$graphitesourcejson,
+  ])
+
+  $graphitesourcemisses = shellquote([
+    'curl',"http://${webapi_user}:${webapi_password}@127.0.0.1:3204/api/datasources/name/Graphite",
+    '2>/dev/null','|','grep','{"message":"Data source not found"}',';','echo $?',
+  ])
+
+  $elasticsearchsourcejson = "{\
+    \"name\":\"Elasticsearch\",\
+    \"type\":\"elasticsearch\",\
+    \"url\":\"${elasticsearch_endpoint}\",\
+    \"basicAuth\":true,\
+    \"basicAuthUser\":\"${elasticsearch_user}\",\
+    \"basicAuthPassword\":\"${elasticsearch_password}\",\
+    \"database\":\"*-*\",\
+    \"jsonData\":{\"interval\":\"Daily\"},\
+  }"
+
+  $elasticsearchsourceadd = shellquote([
+    'curl',"http://${webapi_user}:${webapi_password}@127.0.0.1:3204/api/datasources",
+    '-X','POST','-H','Content-Type: application/json;charset=UTF-8',
+    '--data-binary',$elasticsearchsourcejson,
+  ])
+
+  $elasticsearchsourcemisses = shellquote([
+    'curl',"http://${webapi_user}:${webapi_password}@127.0.0.1:3204/api/datasources/name/Elasticsearch",
+    '2>/dev/null','|','grep','{"message":"Data source not found"}',';','echo $?',
+  ])
+
+  exec{'ensure-graphite-source':
+    require => [Package['curl']],
+    command => $graphitesourceadd,
+    onlyif  => $graphitesourcemisses,
+  }
+
+  exec{'ensure-elasticsearch-source':
+    require => [Package['curl']],
+    command => $elasticsearchsourceadd,
+    onlyif  => $elasticsearchsourcemisses,
+  }
+}

--- a/modules/grafana/manifests/init.pp
+++ b/modules/grafana/manifests/init.pp
@@ -12,6 +12,7 @@ class grafana (
 ) {
   include grafana::repo
   include grafana::dashboards
+  include grafana::datasources
 
   package { 'grafana':
     ensure  => $version,


### PR DESCRIPTION
- Grafana datasources have been added manually in the past.

- If AWS restarts an instance this introduces potential monitoring
  outages

- The web API of Grafana can be used to automatically add datasources

- This relies on https://github.com/alphagov/govuk-secrets/pull/395 to work

solo @schmie