### PR TITLE
Add a target job for Mirror_Repositories builds on CI

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/mirror_repos.pp
+++ b/modules/govuk_jenkins/manifests/jobs/mirror_repos.pp
@@ -1,0 +1,25 @@
+# == Class: govuk_jenkins::jobs::mirror_repos
+#
+# Create a file on disk that can be parsed by jenkins-job-builder
+#
+class govuk_jenkins::jobs::mirror_repos (
+  $app_domain = hiera('app_domain'),
+) {
+
+  $service_description = 'Check that GOV.UK Github repos are mirrored to AWS CodeCommit'
+
+  file { '/etc/jenkins_jobs/jobs/mirror_repos.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/mirror_repos.yaml'),
+    notify  => Exec['jenkins_jobs_update'];
+  }
+
+  @@icinga::passive_check {
+    "user_monitor_${::hostname}":
+      service_description => $service_description,
+      host_name           => $::fqdn,
+      freshness_threshold => 5400, # 90 minutes
+      action_url          => "https://deploy.${app_domain}/job/mirror-repos/",
+      notes_url           => 'https://github.com/alphagov/govuk-repo-mirror';
+  }
+}

--- a/modules/govuk_jenkins/templates/jobs/mirror_repos.yaml
+++ b/modules/govuk_jenkins/templates/jobs/mirror_repos.yaml
@@ -1,0 +1,38 @@
+---
+- job:
+    name: Check_Mirror_Repositories
+    display-name: Check_Mirror_Repositories
+    project-type: freestyle
+    description: "This job checks if the GOV.UK Github repositories have been mirrored to AWS CodeCommit."
+    properties:
+        - build-discarder:
+            days-to-keep: 30
+            artifact-num-to-keep: 5
+    builders:
+        - conditional-step:
+            condition-kind: strings-match
+            condition-string-1: 'SUCCESS'
+            condition-string-2: ${{ENV,var="STATUS"}}
+            steps:
+                - shell: |
+                    echo "Upstream Mirror_Repositories job succeeded."
+        - conditional-step:
+            condition-kind: strings-match
+            condition-string-1: 'FAILED'
+            condition-string-2: ${{ENV,var="STATUS"}}
+            steps:
+                - shell: |
+                    echo "Upstream Mirror_Repositories job failed."; exit 1;
+
+    publishers:
+      - trigger-parameterized-builds:
+        - project: Success_Passive_Check
+          condition: 'SUCCESS'
+          predefined-parameters: |
+            NSCA_CHECK_DESCRIPTION=<%= @service_description %>
+            NSCA_OUTPUT=<%= @service_description %> success
+        - project: Failure_Passive_Check
+          condition: 'FAILED'
+          predefined-parameters: |
+            NSCA_CHECK_DESCRIPTION=<%= @service_description %>
+            NSCA_OUTPUT=<%= @service_description %> failed


### PR DESCRIPTION
https://trello.com/c/TX8kPxzK/319-start-backing-up-our-code-in-aws-codecommit-not-gitlab

This job will echo the status of the [Mirror_Repositories CI project](https://ci.integration.publishing.service.gov.uk/job/Mirror_Repositories/) builds and trigger passive success or failure checks in Icinga.