### PR TITLE
Add rudimentary rsync storage backend

### DIFF
--- a/modules/govuk_env_sync/files/govuk_env_sync.sh
+++ b/modules/govuk_env_sync/files/govuk_env_sync.sh
@@ -123,6 +123,19 @@ function get_timestamp_s3 {
   | grep -o '[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}T[0-9]\{2\}:[0-9]\{2\}:[0-9]\{2\}')"
 }
 
+function push_rsync {
+  rsync -acq "${tempdir}/${filename}" "${url}:/${path}/${filename}"
+}
+
+function pull_rsync {
+  rsync -acq "${url}:${path}/${filename}" "${tempdir}/${filename}"
+}
+
+function get_timestamp_rsync {
+  timestamp = "$(ssh "${url}" "ls -rt \"${path}/*${database}*\" |tail -1" \
+  | grep -o '[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}T[0-9]\{2\}:[0-9]\{2\}:[0-9]\{2\}')"
+}
+
 usage() {
   echo "help text"
   exit 0


### PR DESCRIPTION
- We might want to use this script to copy files somewhere different
  from S3.

- The rsync script bits may need to include encryption/this version is
  unsuitable for sensitive data

- This assumes the executing user has suitable SSH pubkey authentication in place

solo @schmie