### PR TITLE
Add rudimentary file transfer capability

### DIFF
--- a/modules/govuk_env_sync/files/govuk_env_sync.sh
+++ b/modules/govuk_env_sync/files/govuk_env_sync.sh
@@ -101,13 +101,13 @@ function restore_mongo {
 }
 
 function dump_files {
-  tar --create --gzip --file "${tempdir}/$filename" "${database}"
+  tar --create --gzip --force-local --file "${tempdir}/$filename" "${database}"
 }
 
 function restore_files {
   mkdir -p "${database}"
   cd "${database}"
-  tar --extract --gzip --file "${tempdir}/${filename}"
+  tar --extract --gzip --force-local --file "${tempdir}/${filename}"
 }
 
 function dump_elasticsearch {

--- a/modules/govuk_env_sync/files/govuk_env_sync.sh
+++ b/modules/govuk_env_sync/files/govuk_env_sync.sh
@@ -24,7 +24,8 @@ set -eu
 #     sufficient rights are granted to the govuk-backup user.
 #
 #   d) database
-#     Name of the database to be copied/sync'd
+#     Name of the database to be copied/sync'd, if dbms is "files", this is the path
+#     to the directory to copy/sync.
 #
 #   u) url
 #     URL of storage backend, bucket name in case of S3
@@ -92,11 +93,21 @@ function dump_mongo {
 
 function restore_mongo {
   cd "${tempdir}"
-  tar --extract --gzip --file "${filename}"
+  tar --extract --gzip --force-local --file "${filename}"
 
   mongorestore --drop \
     --db "${database}" \
     "${tempdir}/${database}"
+}
+
+function dump_files {
+  tar --create --gzip --file "${tempdir}/$filename" "${database}"
+}
+
+function restore_files {
+  mkdir -p "${database}"
+  cd "${database}"
+  tar --extract --gzip --file "${tempdir}/${filename}"
 }
 
 function dump_elasticsearch {


### PR DESCRIPTION
- We may want to include a number of ordinary files in the data sync.

- The dbms type "files" allows to compress/push/pull/decompress a
  directory provided as "database" argument.

solo @schmie