### PR TITLE
Icinga - Data Retention

### DIFF
--- a/modules/icinga/manifests/config.pp
+++ b/modules/icinga/manifests/config.pp
@@ -50,6 +50,12 @@ class icinga::config (
     source  => 'puppet:///modules/icinga/etc/icinga/conf.d',
   }
 
+  file { '/var/lib/icinga/retention.dat':
+    ensure => present,
+    owner  => 'nagios',
+    group  => 'www-data',
+  }
+
   if $::aws_migration {
 
     file { '/var/lib/icinga/log':


### PR DESCRIPTION
- We noticed that the service status changed to 'PENDING' every time the icinga daemon was restarted [GOV.UK AWS Staging]

- The config file specifies the following [/etc/icinga/icinga.cfg]
  - retain_state_information=1
  - state_retention_file=/var/lib/icinga/retention.dat

- However, the 'icinga' package doesn't create '/var/lib/icinga/retention.dat' by default.
```
suthagarht@ec2-staging-blue-monitoring-ip-10-2-5-245:~$ sudo dpkg-query -L icinga-common
/.
....
var/lib
/var/lib/icinga
/var/lib/icinga/spool
/var/lib/icinga/spool/checkresults
/var/lib/icinga/rw
.....
```
- Hence, we are creating this file via puppet.

- Current icinga version
```
suthagarht@ec2-staging-blue-monitoring-ip-10-2-5-245:~$ icinga --version

Icinga 1.10.3
```

https://trello.com/c/C7SY8edZ/1123-monitor-rds-and-elasticache-in-aws-and-alert-icinga

Solo: @suthagarht