### PR TITLE
Really enable mirror repos check

### DIFF
--- a/hieradata/class/integration/jenkins.yaml
+++ b/hieradata/class/integration/jenkins.yaml
@@ -6,7 +6,6 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::deploy_puppet
   - govuk_jenkins::jobs::deploy_terraform_govuk_aws
   - govuk_jenkins::jobs::launch_vms
-  - govuk_jenkins::jobs::mirror_repos
   - govuk_jenkins::jobs::network_config_deploy
   - govuk_jenkins::jobs::passive_checks
   - govuk_jenkins::jobs::run_rake_task

--- a/hieradata_aws/class/integration/jenkins.yaml
+++ b/hieradata_aws/class/integration/jenkins.yaml
@@ -4,3 +4,6 @@ govuk_jenkins::config::banner_colour_text: 'white'
 govuk_jenkins::config::theme_colour: '#005EA5'
 govuk_jenkins::config::theme_text_colour: 'white'
 govuk_jenkins::config::theme_environment_name: 'AWS Integration'
+
+govuk_jenkins::job_builder::jobs:
+  - govuk_jenkins::jobs::mirror_repos


### PR DESCRIPTION
https://trello.com/c/TX8kPxzK/319-start-backing-up-our-code-in-aws-codecommit-not-gitlab

Added to the wrong config in https://github.com/alphagov/govuk-puppet/pull/7900
I *think* this is the right place now. (The job should appear on `deploy.integration...` jenkins)