### PR TITLE
Revert "Really enable mirror repos check"

### DIFF
--- a/hieradata/class/integration/jenkins.yaml
+++ b/hieradata/class/integration/jenkins.yaml
@@ -6,6 +6,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::deploy_puppet
   - govuk_jenkins::jobs::deploy_terraform_govuk_aws
   - govuk_jenkins::jobs::launch_vms
+  - govuk_jenkins::jobs::mirror_repos
   - govuk_jenkins::jobs::network_config_deploy
   - govuk_jenkins::jobs::passive_checks
   - govuk_jenkins::jobs::run_rake_task

--- a/hieradata_aws/class/integration/jenkins.yaml
+++ b/hieradata_aws/class/integration/jenkins.yaml
@@ -4,6 +4,3 @@ govuk_jenkins::config::banner_colour_text: 'white'
 govuk_jenkins::config::theme_colour: '#005EA5'
 govuk_jenkins::config::theme_text_colour: 'white'
 govuk_jenkins::config::theme_environment_name: 'AWS Integration'
-
-govuk_jenkins::job_builder::jobs:
-  - govuk_jenkins::jobs::mirror_repos


### PR DESCRIPTION
Reverts alphagov/govuk-puppet#7901

This did not work as expected, common jobs have been overwritten rather than the additional ones appended.

![screenshot from 2018-08-02 16-31-42](https://user-images.githubusercontent.com/93511/43594202-920e26ce-9671-11e8-8c68-4a10c02ac4d0.png)
