### PR TITLE
Add mirror repos check to jenkins

### DIFF
--- a/hieradata_aws/class/jenkins.yaml
+++ b/hieradata_aws/class/jenkins.yaml
@@ -71,6 +71,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::enhanced_ecommerce
   - govuk_jenkins::jobs::extract_app_performance
   - govuk_jenkins::jobs::govuk_taxonomy_supervised_learning
+  - govuk_jenkins::jobs::mirror_repos
   - govuk_jenkins::jobs::monitor_taxonomy_health
   - govuk_jenkins::jobs::passive_checks
   - govuk_jenkins::jobs::publication_delay_report


### PR DESCRIPTION
https://trello.com/c/TX8kPxzK/319-start-backing-up-our-code-in-aws-codecommit-not-gitlab

Add mirror repositories check to the list of jenkins jobs. Again.

For context: https://github.com/alphagov/govuk-puppet/pull/7893