### PR TITLE
Set passive check freshness to 2 hours

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/mirror_repos.pp
+++ b/modules/govuk_jenkins/manifests/jobs/mirror_repos.pp
@@ -15,10 +15,10 @@ class govuk_jenkins::jobs::mirror_repos (
   }
 
   @@icinga::passive_check {
-    "user_monitor_${::hostname}":
+    "mirror_repos_${::hostname}":
       service_description => $service_description,
       host_name           => $::fqdn,
-      freshness_threshold => 5400, # 90 minutes
+      freshness_threshold => 7200, # 2 hours
       action_url          => "https://deploy.${app_domain}/job/mirror-repos/",
       notes_url           => 'https://github.com/alphagov/govuk-repo-mirror';
   }


### PR DESCRIPTION
https://trello.com/c/TX8kPxzK/319-start-backing-up-our-code-in-aws-codecommit-not-gitlab

The `Mirror_Repositories` CI task runs every 2 hours.

Also fixes the passive check name.