### PR TITLE
Serve HMRC assets from the Asset Manager

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1737,7 +1737,6 @@ router::assets_origin::app_specific_static_asset_routes:
 router::assets_origin::whitehall_uploaded_assets_routes:
   - '/government/placeholder'
   - '~ ^/government/uploads/system/uploads/attachment_data/file/[0-9]+/.*/preview$'
-  - '/government/uploads/uploaded/hmrc/'
 
 router::assets_origin::asset_manager_uploaded_assets_routes:
   - '/government/uploads/'

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1204,7 +1204,6 @@ router::assets_origin::app_specific_static_asset_routes:
 router::assets_origin::whitehall_uploaded_assets_routes:
   - '/government/placeholder'
   - '~ ^/government/uploads/system/uploads/attachment_data/file/[0-9]+/.*/preview$'
-  - '/government/uploads/uploaded/hmrc/'
 
 router::assets_origin::asset_manager_uploaded_assets_routes:
   - '/government/uploads/'


### PR DESCRIPTION
This should not be merged until the current HMRC assets have been pulled into the Asset Manager using the rake tasks defined in https://github.com/alphagov/asset-manager/pull/585

---

[Trello card](https://trello.com/c/SFeIQ9Dp/371-serve-hmrc-assets-from-the-asset-manager)