### PR TITLE
Rework build script for mirror repos check

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/mirror_repos.yaml
+++ b/modules/govuk_jenkins/templates/jobs/mirror_repos.yaml
@@ -9,21 +9,12 @@
             days-to-keep: 30
             artifact-num-to-keep: 5
     builders:
-        - conditional-step:
-            condition-kind: strings-match
-            condition-string-1: 'SUCCESS'
-            condition-string-2: ${{ENV,var="STATUS"}}
-            steps:
-                - shell: |
-                    echo "Upstream Mirror_Repositories job succeeded."
-        - conditional-step:
-            condition-kind: strings-match
-            condition-string-1: 'FAILED'
-            condition-string-2: ${{ENV,var="STATUS"}}
-            steps:
-                - shell: |
-                    echo "Upstream Mirror_Repositories job failed."; exit 1;
+        - shell: |
+            echo "Check that GOV.UK Github repos are mirrored to AWS CodeCommit - ${STATUS}"
 
+            if [ ${STATUS:-''} = "FAILED" ]; then
+              exit 1;
+            fi
     publishers:
       - trigger-parameterized-builds:
         - project: Success_Passive_Check
@@ -36,3 +27,9 @@
           predefined-parameters: |
             NSCA_CHECK_DESCRIPTION=<%= @service_description %>
             NSCA_OUTPUT=<%= @service_description %> failed
+    parameters:
+        - string:
+            name: STATUS
+            description: Status of the CI Mirror_Repositories build.
+            default: FAILED
+


### PR DESCRIPTION
https://trello.com/c/TX8kPxzK/319-start-backing-up-our-code-in-aws-codecommit-not-gitlab

Initially this job acted as a placeholder for the Icinga service and didn't get triggered or built. The service check for mirroring repos worked but it wasn't quite as intended because the conditional string comparison steps didn't appear correctly in Jenkins and didn't work.

The script has been simplified so that the build is parameterised
with the `STATUS` param - the status of the upstream [Mirror_Repositories](https://ci.integration.publishing.service.gov.uk/job/Mirror_Repositories/) build and this is used to pass or fail the build. 
See https://deploy.integration.publishing.service.gov.uk/job/Check_Mirror_Repositories/7/console