### PR TITLE
Update rabbitmq test permissions for email alert service

### DIFF
--- a/modules/govuk_ci/manifests/agent/rabbitmq.pp
+++ b/modules/govuk_ci/manifests/agent/rabbitmq.pp
@@ -25,9 +25,9 @@ class govuk_ci::agent::rabbitmq {
       read_permission      => '^(amq\.gen.*|content_register_test|content_register_published_documents_test_exchange)$',
       write_permission     => '^(amq\.gen.*|content_register_test|content_register_published_documents_test_exchange)$';
     'email_alert_service_test@/':
-      configure_permission => '^(amq\.gen.*|email_alert_service_published_documents_test_exchange|email_alert_service_published_documents_test_queue)$',
-      read_permission      => '^(amq\.gen.*|email_alert_service_published_documents_test_exchange|email_alert_service_published_documents_test_queue)$',
-      write_permission     => '^(amq\.gen.*|email_alert_service_published_documents_test_exchange|email_alert_service_published_documents_test_queue)$';
+      configure_permission => '^(amq\.gen.*|email_alert_service_published_documents_test_exchange|email_alert_service_published_documents_test_queue|email_alert_service_unpublishing_documents_test_queue)$',
+      read_permission      => '^(amq\.gen.*|email_alert_service_published_documents_test_exchange|email_alert_service_published_documents_test_queue|email_alert_service_unpublishing_documents_test_queue)$',
+      write_permission     => '^(amq\.gen.*|email_alert_service_published_documents_test_exchange|email_alert_service_published_documents_test_queue|email_alert_service_unpublishing_documents_test_queue)$';
     'govuk_seed_crawler@/':
       configure_permission => '^govuk_seed_crawler.*',
       read_permission      => '^govuk_seed_crawler.*',


### PR DESCRIPTION
The email alert service is now listening to unpublishing messages on a new queue 'email_unpublishing'

This PR updates the test configuration to add the new queue and update the permissions.

Related PR: https://github.com/alphagov/email-alert-service/pull/178

Trello: https://trello.com/c/fPAplaaV/67-send-notifications-when-unpublishing-taxons