### PR TITLE
Update the Jenkins Terraform version in hieradata

### DIFF
--- a/hieradata/class/jenkins.yaml
+++ b/hieradata/class/jenkins.yaml
@@ -35,8 +35,6 @@ govuk_jenkins::config:
       -Djenkins.install.runSetupWizard=false
       -Dhudson.tasks.MailSender.SEND_TO_USERS_WITHOUT_READ=true
 
-govuk_jenkins::packages::terraform::version: '0.8.1'
-
 govuk_jenkins::plugins:
   ace-editor:
     version: '1.1'

--- a/hieradata_aws/class/jenkins.yaml
+++ b/hieradata_aws/class/jenkins.yaml
@@ -94,8 +94,6 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::user_monitor
   - govuk_jenkins::jobs::whitehall_publisher_notifications
 
-govuk_jenkins::packages::terraform::version: '0.8.1'
-
 govuk_jenkins::plugins:
   ace-editor:
     version: '1.1'

--- a/modules/govuk_jenkins/manifests/packages/terraform.pp
+++ b/modules/govuk_jenkins/manifests/packages/terraform.pp
@@ -9,7 +9,7 @@
 #
 class govuk_jenkins::packages::terraform (
   $apt_mirror_hostname = undef,
-  $version = '0.9.10',
+  $version = '0.11.7',
 ){
 
   apt::source { 'terraform':


### PR DESCRIPTION
- The Jenkins instance (used for deploying DNS) is configured to use a
  lower Terraform version than the repo, so the code changes I want to merge from govuk-dns, branch `use_newer_terraform_version` don't work.