### PR TITLE
Remove load balancer ip config from transition database

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -724,8 +724,6 @@ govuk::apps::support_api::db::lb_ip_range: "%{hiera('environment_ip_prefix')}.0.
 govuk::apps::transition::db_password: "%{hiera('govuk::apps::transition::postgresql_db::password')}"
 govuk::apps::transition::db_hostname: "transition-postgresql-primary"
 govuk::apps::transition::postgresql_db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
-govuk::apps::transition::db::allow_auth_from_lb: true
-govuk::apps::transition::db::lb_ip_range: "%{hiera('environment_ip_prefix')}.0.0/16"
 govuk::apps::transition::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::transition::redis_port: "%{hiera('sidekiq_port')}"
 


### PR DESCRIPTION
Transition doesn't connect through pgbouncer, so allowing this IP range is unnecessary; and even if it did, it should be `postgresql_db`, not `db`.

---

[Trello card](https://trello.com/c/BosbZ9n9/336-investigate-postgres-connection-pooling)