### PR TITLE
Jenkins Job - Mongo data-sync [WIP]

### DIFF
--- a/hieradata_aws/class/mongo.yaml
+++ b/hieradata_aws/class/mongo.yaml
@@ -23,3 +23,15 @@ mount:
     mountoptions: 'defaults'
     percent_threshold_warning: 40
     percent_threshold_critical: 15
+
+govuk_env_sync::tasks:
+  "pull_api_mongo_daily":
+    hour: "1"
+    minute: "16"
+    action: "pull"
+    dbms: "mongo"
+    storagebackend: "s3"
+    database: "content_store_production"
+    temppath: "/var/lib/mongodb/.dumps"
+    url: "govuk-%{::aws_environment}-database-backups"
+    path: "mongo-api"

--- a/modules/govuk/manifests/deploy/setup.pp
+++ b/modules/govuk/manifests/deploy/setup.pp
@@ -41,7 +41,7 @@ class govuk::deploy::setup (
   } else {
     include assets::group
 
-    $deploy_groups = ['assets']
+    $deploy_groups = ['assets','govuk-backup']
     Group['assets'] -> User['deploy']
   }
 

--- a/modules/govuk_env_sync/manifests/task.pp
+++ b/modules/govuk_env_sync/manifests/task.pp
@@ -58,6 +58,13 @@ define govuk_env_sync::task(
     content => template('govuk_env_sync/govuk_env_sync_job.conf.erb'),
   }
 
+  file { $temppath:
+    ensure => present,
+    mode   => '0775',
+    owner  => $govuk_env_sync::user,
+    group  => $govuk_env_sync::user,
+  }
+
   $synccommand = shellquote([
     '/usr/bin/ionice','-c','2','-n','6',
     '/usr/bin/setlock','/etc/unattended-reboot/no-reboot/govuk_env_sync',


### PR DESCRIPTION
- We have a requirement to create a jenkins job that could used to
trigger the `data-sync`.

- This change addresses the following.

a) `govuk-backup` is the group that has the ownership of the backup
location. Hence, we are adding the `deploy` user to this group to
inherit the permissions.

b) The backup dumps were stored with complete permissions to the owner.
Here we are issuing write permissions to the group.

https://trello.com/c/8wzAOsrV/1314-adapt-jenkins-jobs-to-run-mongo-backup-jobs

Solo: @suthagarht