### PR TITLE
Switch to pgbouncer session pooling

### DIFF
--- a/modules/govuk_pgbouncer/manifests/init.pp
+++ b/modules/govuk_pgbouncer/manifests/init.pp
@@ -40,7 +40,7 @@ class govuk_pgbouncer(
     config_params => {
       auth_type     => 'hba',
       auth_hba_file => '/etc/pgbouncer/pg_hba.conf',
-      pool_mode     => 'transaction',
+      pool_mode     => 'session',
     },
   }
 }


### PR DESCRIPTION
Transaction pooling breaks advisory locks (https://github.com/rails/rails/issues/32622).

The email-alert-api uses advisory locks to prevent concurrently executing workers from sending duplicate emails.  Furthermore, although we haven't directly seen this, database migrations in all apps are likely to be broken.

---

[Trello card](https://trello.com/c/BosbZ9n9/336-investigate-postgres-connection-pooling)