### PR TITLE
Increase pgbouncer pool size to 30

### DIFF
--- a/modules/govuk_pgbouncer/manifests/init.pp
+++ b/modules/govuk_pgbouncer/manifests/init.pp
@@ -38,9 +38,10 @@ class govuk_pgbouncer(
     databases     => false,
     userlist      => false,
     config_params => {
-      auth_type     => 'hba',
-      auth_hba_file => '/etc/pgbouncer/pg_hba.conf',
-      pool_mode     => 'session',
+      auth_type         => 'hba',
+      auth_hba_file     => '/etc/pgbouncer/pg_hba.conf',
+      pool_mode         => 'session',
+      default_pool_size => 30,
     },
   }
 }


### PR DESCRIPTION
We think the default size of 20 is causing issues with opening a rails
console for the publishing-api.  There are 3 publishing-api machines,
and each machine is running 6 sidekiq workers, which is 18 connections
at least + the rails app itself.

---

[Trello card](https://trello.com/c/BosbZ9n9/336-investigate-postgres-connection-pooling)