### PR TITLE
Increase pgbouncer pool size even more

### DIFF
--- a/modules/govuk_pgbouncer/manifests/init.pp
+++ b/modules/govuk_pgbouncer/manifests/init.pp
@@ -41,7 +41,7 @@ class govuk_pgbouncer(
       auth_type         => 'hba',
       auth_hba_file     => '/etc/pgbouncer/pg_hba.conf',
       pool_mode         => 'session',
-      default_pool_size => 30,
+      default_pool_size => 150,
     },
   }
 }


### PR DESCRIPTION
30 connections is still too few now that we are using session pooling.  So we're increasing the limit even more as an immediate fix.

Figuring out how to get transactions working (ie, retiring our use of advisory locks) is future work.

---

email-alert-api has the most database connections, with a sidekiq concurrency of 30 and 6 unicorn workers, across on 3 boxes (108 connections).  So 150 gives a bit of breathing room.

---

[Trello card](https://trello.com/c/BosbZ9n9/336-investigate-postgres-connection-pooling)