### PR TITLE
Update permissions for RabbitMQ unpublishing events

### DIFF
--- a/modules/govuk/manifests/apps/email_alert_service/rabbitmq.pp
+++ b/modules/govuk/manifests/apps/email_alert_service/rabbitmq.pp
@@ -25,20 +25,28 @@ class govuk::apps::email_alert_service::rabbitmq (
   $amqp_user  = 'email_alert_service',
   $amqp_pass  = 'email_alert_service',
   $amqp_exchange = 'published_documents',
-  $amqp_queue = 'email_alert_service',
+  $amqp_major_change_queue = 'email_alert_service',
+  $amqp_unpublishing_queue = 'email_unpublishing'
 ) {
 
-  govuk_rabbitmq::queue_with_binding { $amqp_queue:
+  govuk_rabbitmq::queue_with_binding { $amqp_major_change_queue:
     amqp_exchange => $amqp_exchange,
-    amqp_queue    => $amqp_queue,
+    amqp_queue    => $amqp_major_change_queue,
     routing_key   => '*.major.#',
+    durable       => true,
+  } ->
+
+  govuk_rabbitmq::queue_with_binding { $amqp_unpublishing_queue:
+    amqp_exchange => $amqp_exchange,
+    amqp_queue    => $amqp_unpublishing_queue,
+    routing_key   => 'redirect.unpublishing.#',
     durable       => true,
   } ->
 
   govuk_rabbitmq::consumer { $amqp_user:
     amqp_pass            => $amqp_pass,
-    read_permission      => "^(amq\\.gen.*|${amqp_queue}|${amqp_exchange})\$",
-    write_permission     => "^(amq\\.gen.*|${amqp_queue})\$",
-    configure_permission => "^(amq\\.gen.*|${amqp_queue})\$",
+    read_permission      => "^(amq\\.gen.*|${amqp_major_change_queue}|${amqp_unpublishing_queue}|${amqp_exchange})\$",
+    write_permission     => "^(amq\\.gen.*|${amqp_major_change_queue}|${amqp_unpublishing_queue})\$",
+    configure_permission => "^(amq\\.gen.*|${amqp_major_change_queue}|${amqp_unpublishing_queue})\$",
   }
 }


### PR DESCRIPTION
The email alert service is now listening to unpublishing messages on a new queue 'email_unpublishing'

This PR updates the non-test configuration to add the new queue and update the permissions.

Related PR: alphagov/email-alert-service#178

Trello: https://trello.com/c/fPAplaaV/67-send-notifications-when-unpublishing-taxons