### PR TITLE
Configure & test env_sync mysql push

### DIFF
--- a/hieradata/node/whitehall-mysql-backup-1.backend.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/whitehall-mysql-backup-1.backend.staging.publishing.service.gov.uk.yaml
@@ -1,3 +1,6 @@
+govuk_sudo::sudo_conf:
+  govuk-backup:
+    content: 'govuk-backup ALL=NOPASSWD:/usr/bin/mysqldump'
 govuk_env_sync::tasks:
   "push_mysql_whitehall_production_daily":
     hour: "1"

--- a/hieradata/node/whitehall-mysql-backup-1.backend.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/whitehall-mysql-backup-1.backend.staging.publishing.service.gov.uk.yaml
@@ -1,0 +1,11 @@
+govuk_env_sync::tasks:
+  "push_mysql_whitehall_production_daily":
+    hour: "1"
+    minute: "13"
+    action: "push"
+    dbms: "mysql"
+    storagebackend: "s3"
+    database: "whitehall_production"
+    temppath: "/var/lib/automysqlbackup/s3backup/"
+    url: "govuk-staging-database-backups"
+    path: "mysql"

--- a/hieradata_aws/class/staging/db_admin.yaml
+++ b/hieradata_aws/class/staging/db_admin.yaml
@@ -9,7 +9,6 @@ govuk_env_sync::tasks:
     temppath: "/tmp/content_publisher_production"
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
-govuk_env_sync::tasks:
   "pull_contacts_production_daily":
     hour: "1"
     minute: "12"
@@ -18,5 +17,15 @@ govuk_env_sync::tasks:
     storagebackend: "s3"
     database: "contacts_production"
     temppath: "/tmp/contacts_production"
+    url: "govuk-staging-database-backups"
+    path: "mysql"
+  "pull_mysql_whitehall_production_daily":
+    hour: "3"
+    minute: "37"
+    action: "pull"
+    dbms: "mysql"
+    storagebackend: "s3"
+    database: "whitehall_production"
+    temppath: "/tmp"
     url: "govuk-staging-database-backups"
     path: "mysql"

--- a/modules/backup/templates/etc/automysqlbackup/postbackup.erb
+++ b/modules/backup/templates/etc/automysqlbackup/postbackup.erb
@@ -20,3 +20,8 @@ logger -t automysqlbackup "MySQL backed up in T:$TOTALTIME seconds"
 
 # Remove the temporary file added by the prebackup
 rm /var/lock/mysql-backup.lock
+
+# If it exists, reset ownership of s3 dir after ownership set by automysqlbackup.
+if [ -d  /var/lib/automysqlbackup/s3backup ]; then
+  chown -R govuk-backup:govuk-backup /var/lib/automysqlbackup/s3backup
+fi

--- a/modules/govuk/manifests/node/s_whitehall_mysql_backup.pp
+++ b/modules/govuk/manifests/node/s_whitehall_mysql_backup.pp
@@ -22,6 +22,7 @@ class govuk::node::s_whitehall_mysql_backup (
   $s3_bucket_name = undef,
   $encryption_key = undef,
 ) inherits govuk::node::s_whitehall_mysql_slave {
+  include govuk_env_sync
   class { 'backup::mysql':
     mysql_dump_password => hiera('mysql_root',''),
     require             => Govuk_mount['/var/lib/automysqlbackup'],


### PR DESCRIPTION
Configure & test env_sync mysql push

- I needed to configure heiradata and other areas in order to test the 'push' side of env_sync (mysql).
- Source instance is: whitehall-mysql-backup-1.backend.staging.publishing.service.gov.uk.yaml
- DB: whitehall_production
- I had to edit a file in 'backup' module in order to retain correct ownership of /var/lib/automysqlbackup/s3backup because it is reset to root:root by daily cron automysqlbackup.