### PR TITLE
Change quotes on default logger prority

### DIFF
--- a/modules/govuk_env_sync/files/govuk_env_sync.sh
+++ b/modules/govuk_env_sync/files/govuk_env_sync.sh
@@ -44,11 +44,11 @@ args=("$@")
 
 function log {
   echo -ne "$(basename "$0"): $1\\n"
-  logger --priority "${2:-'user.info'}" --tag "$(basename "$0")" "$1"
+  logger --priority "${2:-"user.info"}" --tag "$(basename "$0")" "$1"
 }
 
 function report_error {
-  log "Error running \"$0 ${args[*]:-''}\" in function ${FUNCNAME[1]} on line $1 executing \"${BASH_COMMAND}\"" user.err
+  log "Error running \"$0 ${args[*]:-''}\" in function ${FUNCNAME[1]} on line $1 executing \"${BASH_COMMAND}\"" "user.err"
 }
 
 # Trap all errors and log them


### PR DESCRIPTION
- In a "use default when empty" parameter expansion, hard quooring seems
  to only work sometimes ${2:-'user.info'} does not work in staging, but
  ${2:-"user.info"} does work. Unsure why my tests did not pick this up.

solo @schmie