### PR TITLE
Add Yarn to GOV.UK infrastructure

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1816,3 +1816,5 @@ unattended_upgrades::origins:
  - "%{::lsbdistid} %{::lsbdistcodename}-security"
 
 unicornherder::version: '0.0.8'
+
+yarn::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1256,3 +1256,5 @@ unattended_upgrades::origins:
  - "%{::lsbdistid} %{::lsbdistcodename}-security"
 
 unicornherder::version: '0.0.8'
+
+yarn::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"

--- a/modules/govuk/manifests/node/s_apt.pp
+++ b/modules/govuk/manifests/node/s_apt.pp
@@ -126,6 +126,11 @@ class govuk::node::s_apt (
       location => 'http://download.draios.com/stable/deb',
       release  => 'stable-amd64/',
       key      => 'D27A72F32D867DF9300A241574490FD6EC51E8C4';
+    'yarn':
+      location => 'https://dl.yarnpkg.com/debian/',
+      release  => 'main',
+      repos    => ['stable'],
+      key      => '72ECF46A56B4AD39C907BBB71646B01B86E50310';
   }
 
   aptly::repo { 'awscli': }

--- a/modules/yarn/manifests/init.pp
+++ b/modules/yarn/manifests/init.pp
@@ -1,0 +1,20 @@
+# == Class: yarn
+#
+# Installs yarn, javascript package management tool: https://yarnpkg.com/en/
+#
+# === Parameters:
+#
+# [*version*]
+#   Version to install. Defaults to 'present' which will install latest version
+#
+class yarn(
+  $version = 'present',
+) {
+
+  class { '::yarn::repo': }
+
+  package { 'yarn':
+    ensure  => $version,
+    require => Class['Yarn::Repo'],
+  }
+}

--- a/modules/yarn/manifests/repo.pp
+++ b/modules/yarn/manifests/repo.pp
@@ -1,0 +1,20 @@
+# == Class: yarn::repo
+#
+# Use our own mirror of the yarn repo.
+#
+# === Parameters
+#
+# [*apt_mirror_hostname*]
+#   Hostname to use for the APT mirror.
+#
+class yarn::repo(
+  $apt_mirror_hostname = undef,
+) {
+  apt::source { 'yarn':
+    location     => "http://${apt_mirror_hostname}/yarn",
+    release      => $::lsbdistcodename,
+    architecture => $::architecture,
+    repos        => 'stable',
+    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+  }
+}

--- a/modules/yarn/spec/classes/yarn_spec.rb
+++ b/modules/yarn/spec/classes/yarn_spec.rb
@@ -1,0 +1,10 @@
+require_relative '../../../../spec_helper'
+
+describe 'yarn', :type => :class do
+
+  it { is_expected.to compile }
+
+  it { is_expected.to compile.with_all_deps }
+
+  it { is_expected.to contain_class('yarn') }
+end


### PR DESCRIPTION
This is a semi-popular alternative to NPM that Rails has a preference
for. Installing this so that it can be used to install node packages as
part of Rails asset pipeline.

The reason for installing this in addition to NPM already existing on
our boxes (as part of Node) is because Rails will utilise this package
manager automatically as part of the asset-pipeline process. Rails also
has a preference for Yarn over NPM which means that all Node package
related tasks become more difficult when using NPM.