### PR TITLE
Update Node repo to access v8

### DIFF
--- a/modules/govuk/manifests/node/s_apt.pp
+++ b/modules/govuk/manifests/node/s_apt.pp
@@ -87,7 +87,7 @@ class govuk::node::s_apt (
       release  => 'trusty/mongodb-org/3.2',
       key      => 'EA312927';
     'nodejs':
-      location => 'https://deb.nodesource.com/node_6.x',
+      location => 'https://deb.nodesource.com/node_8.x',
       release  => 'trusty',
       repos    => ['main'],
       key      => '68576280';


### PR DESCRIPTION
This will allow us to update to version 8 of Node (8.11.3 to be exact)
which is a long-term support version of Node. Ideally we'd update to
version 10 which is the current one but this is not supported on Trusty:
https://github.com/nodesource/distributions#debian-and-ubuntu-based-distributions

This will mean that the currently installed version isn't available once
this has been added so we'll have to deploy a change to update node
shortly after.