### PR TITLE
Upgrade node to 8.11.3

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1684,7 +1684,7 @@ mysql::client::package_ensure: 'present'
 nginx::package::version: '1.4.6-1ubuntu3.8'
 
 nodejs::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
-nodejs::version: '6.11.2-1nodesource1~%{::lsbdistcodename}1'
+nodejs::version: '8.11.3-1nodesource1'
 
 ntp::server_list:
   - 'ntp.ubuntu.com'

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1155,7 +1155,7 @@ nginx::package::nginx_package: 'nginx-extras'
 nginx::package::version: '1.4.6-1ubuntu3.8'
 
 nodejs::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
-nodejs::version: '6.11.2-1nodesource1~%{::lsbdistcodename}1'
+nodejs::version: '8.11.3-1nodesource1'
 
 ntp::server_list:
   - 'ntp.ubuntu.com'


### PR DESCRIPTION
DNM until https://github.com/alphagov/govuk-puppet/pull/7935 is merged, deployed and aptly is updated.

This upgrades all the instances using Node 6 to use Node 8 as this is a
newer LTS version.