### PR TITLE
Install yarn on dev, ci and app servers

### DIFF
--- a/modules/govuk/manifests/node/s_app_server.pp
+++ b/modules/govuk/manifests/node/s_app_server.pp
@@ -13,4 +13,6 @@ class govuk::node::s_app_server {
   # sprockets-rails, the library which compiles assets, depends on Uglifier,
   # which depends on ExecJS, depends on Node.js
   include nodejs
+  # Allows installing assets yarn based assets on app machines
+  include yarn
 }

--- a/modules/govuk/manifests/node/s_development.pp
+++ b/modules/govuk/manifests/node/s_development.pp
@@ -27,6 +27,7 @@ class govuk::node::s_development (
   include nodejs
   include redis
   include tmpreaper
+  include yarn
 
   include govuk_python
   include govuk_testing_tools

--- a/modules/govuk_ci/manifests/agent.pp
+++ b/modules/govuk_ci/manifests/agent.pp
@@ -44,6 +44,7 @@ class govuk_ci::agent(
   include ::govuk_rbenv::all
   include ::govuk_sysdig
   include ::govuk_testing_tools
+  include ::yarn
 
   include ::govuk_ci::agent::elasticsearch
 


### PR DESCRIPTION
DNM until https://github.com/alphagov/govuk-puppet/pull/7934 is merged, deployed and aptly updated

This will allow the use of Yarn (https://yarnpkg.com/) to install Node
JS packages. This is the preferred Node package manager of Rails since
the 5.1 release of Rails https://guides.rubyonrails.org/5_1_release_notes.html#yarn-support

I expect this will only be needed on CI agents (for builds), app servers
(for building assets on a deploy) and development (for local usage) -
this contrasts with nodejs that seems to be installed on every box which
seems unnecessary. I might well be missing an important place for this
though.