### PR TITLE
Mongo Data-Sync

### DIFF
--- a/modules/govuk_env_sync/manifests/init.pp
+++ b/modules/govuk_env_sync/manifests/init.pp
@@ -8,5 +8,7 @@ class govuk_env_sync(
   $aws_region = 'eu-west-1',
 ) {
 
+  include govuk_env_sync::lock_file
+
   create_resources(govuk_env_sync::task, $tasks)
 }

--- a/modules/govuk_env_sync/manifests/lock_file.pp
+++ b/modules/govuk_env_sync/manifests/lock_file.pp
@@ -1,0 +1,15 @@
+# == Class: govuk_env_sync::lock_file
+#
+# Set permissions on the lock file
+#
+class govuk_env_sync::lock_file
+{
+
+  # Lock file
+  #
+  file { '/etc/unattended-reboot/no-reboot/govuk_env_sync':
+    mode  => '0660',
+    owner => $govuk_env_sync::user,
+    group => $govuk_env_sync::user,
+  }
+}

--- a/modules/govuk_env_sync/manifests/task.pp
+++ b/modules/govuk_env_sync/manifests/task.pp
@@ -59,14 +59,7 @@ define govuk_env_sync::task(
   }
 
   file { $temppath:
-    ensure => present,
-    mode   => '0775',
-    owner  => $govuk_env_sync::user,
-    group  => $govuk_env_sync::user,
-  }
-
-  file { '/etc/unattended-reboot/no-reboot/govuk_env_sync':
-    mode  => '0660',
+    mode  => '0775',
     owner => $govuk_env_sync::user,
     group => $govuk_env_sync::user,
   }


### PR DESCRIPTION
- There were some errors noticed during puppet runs.

```
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Duplicate declaration: File[/etc/unattended-reboot/no-reboot/govuk_env_sync] is already declared in file /usr/share/puppet/production/current/modules/govuk_env_sync/manifests/task.pp:72; cannot redeclare at /usr/share/puppet/production/current/modules/govuk_env_sync/manifests/task.pp:72 on node postgresql-primary-1.backend.staging.publishing.service.gov.uk
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run```

- This change is intended to correct the duplicate declaration.

Note: Original change https://github.com/alphagov/govuk-puppet/pull/7927

https://trello.com/c/8wzAOsrV/1314-adapt-jenkins-jobs-to-run-mongo-backup-jobs

Solo: @suthagarht