### PR TITLE
Disallow core dumping by setuid and setgid programs

### DIFF
--- a/modules/govuk_harden/files/sysctl/sysctl.conf
+++ b/modules/govuk_harden/files/sysctl/sysctl.conf
@@ -15,3 +15,6 @@ net.ipv4.tcp_syncookies = 1
 
 # Increase max_user_instances of inotify instances from default of 128
 fs.inotify.max_user_instances=1024
+
+# Disallow core dumping by setuid and setgid programs
+fs.suid_dumpable = 0


### PR DESCRIPTION
This is in response to our security audit / pentest. It only covers
setuid and setgid processes, there will be other PRs to cover non-priviledged
ones.