### PR TITLE
Increase number of processes deploy user can run

### DIFF
--- a/modules/govuk/manifests/deploy/config.pp
+++ b/modules/govuk/manifests/deploy/config.pp
@@ -45,7 +45,7 @@ class govuk::deploy::config(
     ensure     => present,
     user       => 'deploy',
     limit_type => 'nproc',
-    both       => 1024,
+    both       => 2048,
   }
 
   file { '/etc/govuk/unicorn.rb':


### PR DESCRIPTION
All of the processes, e.g. running a rails console, deploying applications) that the `deploy` user tries to invoke in Integration is failing with the following error:

`sudo: unable to fork: Resource temporarily unavailable`

This was due to the deploy user using up all of it’s available processes.

We devops a fix by upping the process limit to 2048 in /etc/security/limits.d/deploy_nproc.conf on both machines.

This change replicates that fix.