### PR TITLE
Fix the data sync pull "path" value for transition_production

### DIFF
--- a/hieradata_aws/class/staging/transition-db-admin.yaml
+++ b/hieradata_aws/class/staging/transition-db-admin.yaml
@@ -8,4 +8,4 @@ govuk_env_sync::tasks:
     database: "transition_production"
     temppath: "/tmp/transition_production"
     url: "govuk-staging-database-backups"
-    path: "transition-postgresql-backend"
+    path: "transition-postgresql"


### PR DESCRIPTION
- If this doesn't match its [`push` counterpart](https://github.com/alphagov/govuk-puppet/blob/master/hieradata/node/transition-postgresql-master-1.staging.publishing.service.gov.uk.yaml#L11), then the script won't
  find the data in the S3 bucket.

https://trello.com/c/l7dNI7Th/1411-configure-the-postgres-data-sync-policy-via-hieradata-and-ensure-it-is-functioning