### PR TITLE
Fix release / repo name for yarn package

### DIFF
--- a/modules/govuk/manifests/node/s_apt.pp
+++ b/modules/govuk/manifests/node/s_apt.pp
@@ -128,8 +128,8 @@ class govuk::node::s_apt (
       key      => 'D27A72F32D867DF9300A241574490FD6EC51E8C4';
     'yarn':
       location => 'https://dl.yarnpkg.com/debian/',
-      release  => 'main',
-      repos    => ['stable'],
+      release  => 'stable',
+      repos    => ['main'],
       key      => '72ECF46A56B4AD39C907BBB71646B01B86E50310';
   }
 


### PR DESCRIPTION
These were the wrong way round causing a puppet error.