### PR TITLE
Increase number of processors user can run

### DIFF
--- a/modules/govuk/manifests/node/s_backend.pp
+++ b/modules/govuk/manifests/node/s_backend.pp
@@ -17,7 +17,7 @@ class govuk::node::s_backend inherits govuk::node::s_base {
     ensure     => present,
     user       => 'root',
     limit_type => 'nproc',
-    both       => 1024,
+    both       => 2048,
   }
 
   package { 'graphviz':


### PR DESCRIPTION
Attempting to run `govuk_app_console` on backend boxes results in
`sudo: unable to fork: Resource temporarily unavailable`.

A similar issue was fixed in this PR https://github.com/alphagov/govuk-puppet/pull/7945
by upping the process limit to 2048.

This change replicates that fix.