### PR TITLE
Allow smartanswers to run in draft preview

### DIFF
--- a/development-vm/Pinfile
+++ b/development-vm/Pinfile
@@ -28,6 +28,7 @@ process :'draft-government-frontend' => [:'government-frontend', :'draft-content
 process :'draft-manuals-frontend' => [:'manuals-frontend', :'draft-content-store', :'draft-static']
 process :'draft-router'
 process :'draft-router-api'
+process :'draft-smartanswers' => [:smartanswers, :'draft-content-store', :'draft-static', :imminence]
 process :'draft-static'
 process :'email-alert-api' => [:'email-alert-api-worker']
 process :'email-alert-api-worker'

--- a/development-vm/Procfile
+++ b/development-vm/Procfile
@@ -176,3 +176,4 @@ organisations-publisher: govuk_setenv organisations-publisher ./run_in.sh ../../
 content-publisher: govuk_setenv content-publisher ./run_in.sh ../../content-publisher bundle exec rails s -p 3221
 # Smokey BrowserMob Proxy uses ports 3222-3229
 content-data-admin: govuk_setenv content-data-admin ./run_in.sh ../../content-data-admin bundle exec rails s -p 3230
+draft-smartanswers: govuk_setenv draft-smartanswers ./run_in.sh ../../smart-answers bundle exec rails server -p 3231 -P tmp/pids/draft-smartanswers.pid

--- a/hieradata/class/draft_frontend.yaml
+++ b/hieradata/class/draft_frontend.yaml
@@ -6,6 +6,7 @@ govuk::apps::frontend::vhost: 'draft-frontend'
 govuk::apps::government_frontend::vhost: 'draft-government-frontend'
 govuk::apps::manuals_frontend::vhost: 'draft-manuals-frontend'
 govuk::apps::service_manual_frontend::vhost: 'draft-service-manual-frontend'
+govuk::apps::smartanswers::vhost: 'draft-smartanswers'
 
 govuk::apps::static::draft_environment: true
 govuk::apps::static::vhost: 'draft-static'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -83,6 +83,7 @@ node_class: &node_class
       - government-frontend
       - manuals-frontend
       - service-manual-frontend
+      - smartanswers
       - static
   email_alert_api:
     apps:
@@ -1491,6 +1492,7 @@ hosts::production::frontend::app_hostnames:
   - 'draft-government-frontend'
   - 'draft-manuals-frontend'
   - 'draft-service-manual-frontend'
+  - 'draft-smartanswers'
   - 'draft-static'
   - 'email-alert-frontend'
   - 'feedback'

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -81,6 +81,7 @@ govuk::node::s_development::apps:
   - 'sidekiq_monitoring'
   - 'signon'
   - 'smartanswers'
+  - 'smartanswers::enable_running_in_draft_mode'
   - 'specialist_publisher'
   - 'static'
   - 'static::enable_running_in_draft_mode'

--- a/hieradata_aws/class/draft_frontend.yaml
+++ b/hieradata_aws/class/draft_frontend.yaml
@@ -6,6 +6,7 @@ govuk::apps::frontend::vhost: 'draft-frontend'
 govuk::apps::government_frontend::vhost: 'draft-government-frontend'
 govuk::apps::manuals_frontend::vhost: 'draft-manuals-frontend'
 govuk::apps::service_manual_frontend::vhost: 'draft-service-manual-frontend'
+govuk::apps::smartanswers::vhost: 'draft-smartanswers'
 
 govuk::apps::static::draft_environment: true
 govuk::apps::static::vhost: 'draft-static'

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -82,6 +82,7 @@ node_class: &node_class
       - government-frontend
       - manuals-frontend
       - service-manual-frontend
+      - smartanswers
       - static
   email_alert_api:
     apps:

--- a/modules/govuk/manifests/apps/smartanswers.pp
+++ b/modules/govuk/manifests/apps/smartanswers.pp
@@ -4,6 +4,10 @@
 #
 # === Parameters
 #
+# [*vhost*]
+#   Virtual host used by the application.
+#   Default: 'smartanswers'
+#
 # [*port*]
 #   The port that Smart Answers is served on.
 #   Default: 3010
@@ -39,6 +43,7 @@
 #   The number of unicorn workers to run for an instance of this app
 #
 class govuk::apps::smartanswers(
+  $vhost = 'smartanswers',
   $port = '3010',
   $expose_govspeak = false,
   $show_draft_flows = false,
@@ -86,6 +91,7 @@ class govuk::apps::smartanswers(
     log_format_is_json       => true,
     asset_pipeline           => true,
     asset_pipeline_prefix    => 'smartanswers',
+    vhost                    => $vhost,
     nagios_memory_warning    => $nagios_memory_warning,
     nagios_memory_critical   => $nagios_memory_critical,
     alert_5xx_warning_rate   => 0.001,

--- a/modules/govuk/manifests/apps/smartanswers/enable_running_in_draft_mode.pp
+++ b/modules/govuk/manifests/apps/smartanswers/enable_running_in_draft_mode.pp
@@ -1,0 +1,73 @@
+# == Class govuk::apps::smartanswers::enable_running_in_draft_mode
+#
+# Enables running smartanswers for serving draft content.
+#
+# Intended to be used only in development.
+# In draft mode smartanswers:
+#
+# 1. runs on a different port: 3231
+# 2. is served via a different nginx vhost: draft-smartanswers.dev.gov.uk
+#
+class govuk::apps::smartanswers::enable_running_in_draft_mode(
+  $content_store = '',
+) {
+  $draft_smartanswers_port = 3231
+  $app_name = 'draft-smartanswers'
+  $parent_app_name = 'smartanswers'
+  $app_domain = hiera('app_domain')
+
+  govuk::app::nginx_vhost { $app_name:
+    vhost    => "${app_name}.${app_domain}",
+    app_port => $draft_smartanswers_port,
+  }
+
+  # Necessary because we're not creating a govuk::app instance for this.
+  file { ["/etc/govuk/${app_name}", "/etc/govuk/${app_name}/env.d"]:
+    ensure  => directory,
+    purge   => true,
+    recurse => true,
+    force   => true,
+  }
+
+  Govuk::App::Envvar {
+    app            => $app_name,
+    notify_service => false,
+    require        => File["/etc/govuk/${app_name}/env.d"],
+  }
+
+  govuk::app::envvar {
+    "${title}-GOVUK_APP_LOGROOT":
+      varname => 'GOVUK_APP_LOGROOT',
+      value   => "/var/log/${app_name}";
+    "${title}-GOVUK_APP_NAME":
+      varname => 'GOVUK_APP_NAME',
+      value   => $app_name;
+    "${title}-GOVUK_APP_ROOT":
+      varname => 'GOVUK_APP_ROOT',
+      value   => "/var/apps/${parent_app_name}";
+    "${title}-GOVUK_APP_RUN":
+      varname => 'GOVUK_APP_RUN',
+      value   => "/var/run/${app_name}";
+    "${title}-GOVUK_APP_TYPE":
+      varname => 'GOVUK_APP_TYPE',
+      value   => 'rack';
+    "${title}-GOVUK_GROUP":
+      varname => 'GOVUK_GROUP',
+      value   => 'deploy';
+    "${title}-GOVUK_STATSD_PREFIX":
+      varname => 'GOVUK_STATSD_PREFIX',
+      value   => "govuk.app.${app_name}.development";
+    "${title}-GOVUK_USER":
+      varname => 'GOVUK_USER',
+      value   => 'deploy';
+    "${title}-PLEK_HOSTNAME_PREFIX":
+      varname => 'PLEK_HOSTNAME_PREFIX',
+      value   => 'draft-';
+    "${title}-PLEK_SERVICE_CONTENT_STORE_URI":
+      varname => 'PLEK_SERVICE_CONTENT_STORE_URI',
+      value   => $content_store;
+    "${title}-PORT":
+      varname => 'PORT',
+      value   => $draft_smartanswers_port;
+  }
+}

--- a/modules/govuk/manifests/node/s_draft_frontend.pp
+++ b/modules/govuk/manifests/node/s_draft_frontend.pp
@@ -23,6 +23,7 @@ class govuk::node::s_draft_frontend() inherits govuk::node::s_base {
     'PLEK_SERVICE_MAPIT_URI': value     => "https://mapit.${app_domain_internal}";
     'PLEK_SERVICE_SEARCH_URI': value    => "https://search.${app_domain_internal}";
     'PLEK_SERVICE_RUMMAGER_URI': value  => "https://rummager.${app_domain_internal}";
+    'PLEK_SERVICE_WHITEHALL_ADMIN_URI': value  => "https://whitehall-admin.${app_domain_internal}";
   }
 
   unless $::aws_migration {

--- a/modules/govuk/manifests/node/s_frontend_lb.pp
+++ b/modules/govuk/manifests/node/s_frontend_lb.pp
@@ -20,6 +20,7 @@ class govuk::node::s_frontend_lb (
       'draft-government-frontend',
       'draft-manuals-frontend',
       'draft-service-manual-frontend',
+      'draft-smartanswers',
       'draft-static',
     ]:
       servers       => $draft_frontend_servers;


### PR DESCRIPTION
Trello: https://trello.com/c/W86Z7ABG/214-get-smart-answers-working-on-draft-stack

At the moment a 500 error is returned when you try to navigate the landing page of a smartanswer in draft preview.
I think this is because the smartanswers app is not running in draft.

These changes are based on the set-up for `draft-government-frontend`
Rather than starting up a new `calculators` machine, draft-smartanswers will be run on the `frontend` machine on port 3231