### PR TITLE
This file was added by a previous version of the elasticsearch module

### DIFF
--- a/modules/base/manifests/init.pp
+++ b/modules/base/manifests/init.pp
@@ -53,4 +53,9 @@ class base {
 
     include hosts::migration
   }
+
+  # TODO: remove this once it's run on all machines - or by 2018/09/01
+  file { '/usr/lib/sysctl.d/elasticsearch.conf':
+    ensure => 'absent',
+  }
 }


### PR DESCRIPTION
It is now set as part of in the init script so we don't need the file