### PR TITLE
Create User - govuk-backup

### DIFF
--- a/modules/backup/manifests/client.pp
+++ b/modules/backup/manifests/client.pp
@@ -17,8 +17,12 @@ class backup::client (
     fullname    => 'Backup User',
     email       => 'webops@digital.cabinet-office.gov.uk',
     ssh_key     => "ssh-rsa ${backup_public_key}",
-    groups      => [],
+    groups      => ['govuk-backup'],
     purgegroups => true,
+  }
+
+  group { 'govuk-backup':
+    ensure => 'present',
   }
 
 }

--- a/modules/govuk/manifests/deploy/setup.pp
+++ b/modules/govuk/manifests/deploy/setup.pp
@@ -33,6 +33,7 @@ class govuk::deploy::setup (
     $deploy_gid = undef,
 ){
   validate_hash($ssh_keys)
+  require  backup::client
 
   if $::aws_migration {
     include govuk::deploy::sync
@@ -42,7 +43,7 @@ class govuk::deploy::setup (
     include assets::group
 
     $deploy_groups = ['assets','govuk-backup']
-    Group['assets'] -> User['deploy']
+    Group['assets','govuk-backup'] -> User['deploy']
   }
 
   group { 'deploy':


### PR DESCRIPTION
- When a Dev VM is created for the first time, govuk-backup doesn't
get created by default.

- This was happening because the `govuk::deploy::setup` class doesn't
call the class that creates the `govuk-backup` user. [backup::client]

- To address this issue, we are calling the `backup::client` class
within `govuk::deploy::setup`. We are doing this at the highest level ,
because this does apply to the new AWS environments and the old Carrenza
environments.

https://trello.com/c/8wzAOsrV/1314-adapt-jenkins-jobs-to-run-mongo-backup-jobs

Solo: @suthagarht