### PR TITLE
Add content-data-admin to integration backend names

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -174,6 +174,7 @@ hosts::production::backend::app_hostnames:
   - 'collections-publisher'
   - 'contacts-admin'
   - 'content-audit-tool'
+  - 'content-data-admin'
   - 'content-performance-manager'
   - 'content-publisher'
   - 'content-tagger'


### PR DESCRIPTION
It seems that we missed this configuration entry when provisioning the
new application.