### PR TITLE
Add db port for Content Data Admin

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -387,6 +387,8 @@ govuk::apps::content_audit_tool::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::content_audit_tool::redis_port: "%{hiera('sidekiq_port')}"
 
 govuk::apps::content_data_admin::db_hostname: "postgresql-primary-1.backend"
+govuk::apps::content_data_admin::db_port: 6432
+govuk::apps::content_data_admin::db_allow_prepared_statements: false
 govuk::apps::content_data_admin::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 
 govuk::apps::content_performance_manager::rabbitmq_user: "content_performance_manager"


### PR DESCRIPTION
We need to specify the port for Content Data Admin because it was using
the default one (443) which is not correct.