### PR TITLE
Add JWT_AUTH_SECRET to content publisher

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -406,6 +406,7 @@ govuk::apps::content_publisher::db_hostname: "postgresql-primary-1.backend"
 govuk::apps::content_publisher::db_port: 6432
 govuk::apps::content_publisher::db_allow_prepared_statements: false
 govuk::apps::content_publisher::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
+govuk::apps::content_publisher::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
 
 govuk::apps::content_store::nagios_memory_warning: 2300
 govuk::apps::content_store::nagios_memory_critical: 2500

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -433,6 +433,7 @@ govuk::apps::content_publisher::backend_ip_range: "%{hiera('environment_ip_prefi
 govuk::apps::content_publisher::db::allow_auth_from_lb: true
 govuk::apps::content_publisher::db::lb_ip_range: "%{hiera('environment_ip_prefix')}.0.0/16"
 govuk::apps::content_publisher::db::rds: true
+govuk::apps::content_publisher::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
 
 govuk::apps::content_store::nagios_memory_warning: 2300
 govuk::apps::content_store::nagios_memory_critical: 2500

--- a/modules/govuk/manifests/apps/content_publisher.pp
+++ b/modules/govuk/manifests/apps/content_publisher.pp
@@ -41,6 +41,10 @@
 # [*db_name*]
 #   The database name to use for the DATABASE_URL environment variable
 #
+# [*jwt_auth_secret*]
+#   The secret used to encode JWT authentication tokens. This value needs to be
+#   shared with authenticating-proxy which decodes the tokens.
+#
 # [*publishing_api_bearer_token*]
 #   The bearer token to use when communicating with Publishing API.
 #   Default: undef
@@ -59,6 +63,7 @@ class govuk::apps::content_publisher (
   $db_allow_prepared_statements = undef,
   $db_name = 'content_publisher_production',
   $publishing_api_bearer_token = undef,
+  $jwt_auth_secret = undef,
 ) {
   $app_name = 'content-publisher'
 
@@ -98,6 +103,9 @@ class govuk::apps::content_publisher (
     "${title}-PUBLISHING_API_BEARER_TOKEN":
       varname => 'PUBLISHING_API_BEARER_TOKEN',
       value   => $publishing_api_bearer_token;
+    "${title}-JWT_AUTH_SECRET":
+      varname => 'JWT_AUTH_SECRET',
+      value   => $jwt_auth_secret;
   }
 
   if $::govuk_node_class !~ /^development$/ {


### PR DESCRIPTION
This will allow content publisher to generate secret shareable preview URLs for the draft stack. Identical to a recent PR for collections publisher: https://github.com/alphagov/govuk-puppet/pull/7754.

Needed to get https://github.com/alphagov/content-publisher/pull/130 working.

https://trello.com/c/ECYqAHfX