### PR TITLE
Copy attachments to staging every day

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/copy_attachments_to_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_attachments_to_staging.yaml.erb
@@ -27,7 +27,7 @@
     triggers:
         - timed: |
             TZ=Europe/London
-            H 22 * * 1-5
+            H 22 * * *
     builders:
         - shell: |
             set -eu


### PR DESCRIPTION
I noticed that we were seeing alerts on 2nd line because this runs at
10pm Monday to Friday, which means on Monday morning it hasn't run since
Friday night and is, therefore, stale. I was going to change this to run
Sunday to Thursday but I noticed that the copy-data-to-staging runs
every day so it makes sense that this should also run at an identical
frequency.