### PR TITLE
Tweak the collectd bare process regex

### DIFF
--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -254,7 +254,7 @@ define govuk::app::config (
   if $app_type in ['rack', 'bare', 'procfile'] {
     $collectd_process_regex = $app_type ? {
       'rack' => "unicorn (master|worker\\[[0-9]+\\]).* -P ${govuk_app_run}/app\\.pid",
-      'bare' => inline_template('<%= "^" + Regexp.escape(@command) + "$" -%>'),
+      'bare' => inline_template('<%= Regexp.escape(@command) + "$" -%>'),
       'procfile' => "gunicorn .* ${govuk_app_run}/app\\.pid",
     }
     collectd::plugin::process { "app-${title_underscore}":

--- a/modules/govuk/spec/defines/govuk__app__config_spec.rb
+++ b/modules/govuk/spec/defines/govuk__app__config_spec.rb
@@ -110,7 +110,7 @@ describe 'govuk::app::config', :type => :define do
 
       it do
         is_expected.to contain_collectd__plugin__process('app-giraffe').with(
-          :regex => '^\\./launch_zoo$'
+          :regex => '\\./launch_zoo$'
         )
       end
     end


### PR DESCRIPTION
Currently the regex doesn't catch processes for services like the
email-alert-service. If command points at a binary, then this regex
will work, but for scripts, you'll see "ruby " at the start.

Therefore, to try and catch scripts by default as well, make the regex
a little more permissive.