### PR TITLE
Downgrade from node 8 to 6

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1706,7 +1706,7 @@ mysql::client::package_ensure: 'present'
 nginx::package::version: '1.4.6-1ubuntu3.8'
 
 nodejs::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
-nodejs::version: '8.11.3-1nodesource1'
+nodejs::version: '6.11.2-1nodesource1~%{::lsbdistcodename}1'
 
 ntp::server_list:
   - 'ntp.ubuntu.com'

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1172,7 +1172,7 @@ nginx::package::nginx_package: 'nginx-extras'
 nginx::package::version: '1.4.6-1ubuntu3.8'
 
 nodejs::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
-nodejs::version: '8.11.3-1nodesource1'
+nodejs::version: '6.11.2-1nodesource1~%{::lsbdistcodename}1'
 
 ntp::server_list:
   - 'ntp.ubuntu.com'

--- a/modules/govuk/manifests/node/s_apt.pp
+++ b/modules/govuk/manifests/node/s_apt.pp
@@ -87,7 +87,7 @@ class govuk::node::s_apt (
       release  => 'trusty/mongodb-org/3.2',
       key      => 'EA312927';
     'nodejs':
-      location => 'https://deb.nodesource.com/node_8.x',
+      location => 'https://deb.nodesource.com/node_6.x',
       release  => 'trusty',
       repos    => ['main'],
       key      => '68576280';


### PR DESCRIPTION
Node 8 breaks statsd, so we need to downgrade for now until we can do something about statsd.