### PR TITLE
Fix example db::lb_ip_range in new app docs

### DIFF
--- a/docs/adding-a-new-app.md
+++ b/docs/adding-a-new-app.md
@@ -179,7 +179,7 @@ govuk::apps::myapp::db_port: 6432
 govuk::apps::myapp::db_allow_prepared_statements: false
 govuk::apps::myapp::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 govuk::apps::myapp::db::allow_auth_from_lb: true
-govuk::apps::myapp::db::lb_ip_range: "%{hiera('environment_ip_prefix')}.5.0/24"
+govuk::apps::myapp::db::lb_ip_range: "%{hiera('environment_ip_prefix')}.0.0/16"
 govuk::apps::myapp::db::rds: true
 
 # hieradata/vagrant_credentials.yaml


### PR DESCRIPTION
We need the wider range because some things are on 10.1.5 and others are on 10.1.6