### PR TITLE
Update node 6 to latest minor version

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1706,7 +1706,7 @@ mysql::client::package_ensure: 'present'
 nginx::package::version: '1.4.6-1ubuntu3.8'
 
 nodejs::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
-nodejs::version: '6.11.2-1nodesource1~%{::lsbdistcodename}1'
+nodejs::version: '6.14.3-1nodesource1'
 
 ntp::server_list:
   - 'ntp.ubuntu.com'

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1172,7 +1172,7 @@ nginx::package::nginx_package: 'nginx-extras'
 nginx::package::version: '1.4.6-1ubuntu3.8'
 
 nodejs::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
-nodejs::version: '6.11.2-1nodesource1~%{::lsbdistcodename}1'
+nodejs::version: '6.14.3-1nodesource1'
 
 ntp::server_list:
   - 'ntp.ubuntu.com'


### PR DESCRIPTION
This commit updates node 6 to the latest minor version since that’s what’s now available in apt.