### PR TITLE
Enable content-data-admin in all environments

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -10,7 +10,6 @@ cron::daily_hour: 6
 
 govuk::apps::asset_manager::aws_s3_bucket_name: 'govuk-assets-integration'
 govuk::apps::asset_manager::aws_region: 'eu-west-1'
-govuk::apps::content_data_admin::enabled: true
 govuk::apps::email_alert_api::email_archive_s3_bucket: 'govuk-integration-email-alert-api-archive'
 govuk::apps::email_alert_api::email_archive_s3_enabled: true
 govuk::apps::email_alert_api::govuk_notify_template_id: '1fc69d3a-09a2-40f9-852b-03f6fcef5340'

--- a/modules/govuk/manifests/apps/content_data_admin.pp
+++ b/modules/govuk/manifests/apps/content_data_admin.pp
@@ -39,7 +39,7 @@
 #
 class govuk::apps::content_data_admin (
   $port                         = '3230',
-  $enabled                      = false,
+  $enabled                      = true,
   $secret_key_base              = undef,
   $sentry_dsn                   = undef,
   $oauth_id                     = undef,


### PR DESCRIPTION
We only have content-data-admin enabled in integration
at the moment.

This commit enables it by default to enable it in all environments.