### PR TITLE
Declaring temppath resource in task breaks sync

### DIFF
--- a/modules/govuk_env_sync/manifests/task.pp
+++ b/modules/govuk_env_sync/manifests/task.pp
@@ -58,12 +58,6 @@ define govuk_env_sync::task(
     content => template('govuk_env_sync/govuk_env_sync_job.conf.erb'),
   }
 
-  file { $temppath:
-    mode  => '0775',
-    owner => $govuk_env_sync::user,
-    group => $govuk_env_sync::user,
-  }
-
   $synccommand = shellquote([
     '/usr/bin/ionice','-c','2','-n','6',
     '/usr/bin/setlock','/etc/unattended-reboot/no-reboot/govuk_env_sync',


### PR DESCRIPTION
- We want to be able to declare multiple tasks using the same temppath.

- Puppet requires resources to be unique.

- Will need ensure directory existence/access rights by other means.

@schmie