### PR TITLE
Remove older pinned Terraform versions

### DIFF
--- a/hieradata/class/integration/jenkins.yaml
+++ b/hieradata/class/integration/jenkins.yaml
@@ -10,5 +10,3 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::network_config_deploy
   - govuk_jenkins::jobs::passive_checks
   - govuk_jenkins::jobs::run_rake_task
-
-govuk_jenkins::packages::terraform::version: '0.11.2'

--- a/hieradata/node/ci-agent-1.ci.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/ci-agent-1.ci.integration.publishing.service.gov.uk.yaml
@@ -1,4 +1,2 @@
 ---
 mongodb::server::version: '2.4.9'
-
-govuk_jenkins::packages::terraform::version: '0.8.1'


### PR DESCRIPTION
This commit removes pinned Terraform versions in two places so the version defaults to 0.11.7 as defined in modules/govuk_jenkins/manifests/packages/terraform.pp.