### PR TITLE
Turn off GDS API adapter caching

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -339,6 +339,8 @@ filebeat::prospectors:
 
 gdal::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
+govuk_app_cache_api_calls: false
+
 govuk::apps::asset_manager::mongodb_nodes:
   - 'mongo-1.backend'
   - 'mongo-2.backend'

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -71,6 +71,8 @@ base::supported_kernel::enabled: false
 
 environment_ip_prefix: '10.3'
 
+govuk_app_cache_api_calls: true
+
 govuk::apps::asset_manager::aws_s3_bucket_name: 'govuk-assets-production'
 govuk::apps::asset_manager::aws_region: 'eu-west-1'
 govuk::apps::ckan::ckan_site_url: 'https://ckan.publishing.service.gov.uk'

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -354,6 +354,8 @@ filebeat::prospectors:
 
 gdal::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
+govuk_app_cache_api_calls: false
+
 govuk::apps::asset_manager::mongodb_nodes:
   - 'mongo-1'
   - 'mongo-2'

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -9,6 +9,8 @@ base::supported_kernel::enabled: false
 
 cron::daily_hour: 6
 
+govuk_app_cache_api_calls: true
+
 govuk::apps::asset_manager::aws_s3_bucket_name: 'govuk-assets-production'
 govuk::apps::asset_manager::aws_region: 'eu-west-1'
 govuk::apps::content_store::performance_platform_big_screen_view_url: 'https://performance-platform-big-screen-view-production.cloudapps.digital'

--- a/lib/puppet-lint/plugins/check_hiera.rb
+++ b/lib/puppet-lint/plugins/check_hiera.rb
@@ -34,6 +34,9 @@ PuppetLint.new_check(:hiera_explicit_lookup) do
     'govuk_mount::no_op',
     'govuk_lvm::no_op',
 
+    # This is temporary to allow us to set this across all apps in different environments
+    'govuk_app_cache_api_calls',
+
     # govuk::app::nginx_vhost defined type needs a global disable flag for
     # asset pipeline on dev vm
     'govuk::app::nginx_vhost::asset_pipeline_enabled',

--- a/modules/govuk/manifests/app.pp
+++ b/modules/govuk/manifests/app.pp
@@ -227,6 +227,11 @@
 # [*cpu_critical*]
 #   CPU usage percentage that alerts are sounded at
 #
+# [*cache_api_calls*]
+#   Control whether the app uses the in-memory cache that comes with
+#   GDS API adapters.
+#   Default: undef
+#
 define govuk::app (
   $app_type,
   $port = 0,
@@ -260,6 +265,7 @@ define govuk::app (
   $unicorn_worker_processes = undef,
   $cpu_warning = 150,
   $cpu_critical = 200,
+  $cache_api_calls = undef,
 ) {
 
   if ! ($app_type in ['procfile', 'rack', 'bare']) {
@@ -332,6 +338,7 @@ define govuk::app (
     unicorn_worker_processes       => $unicorn_worker_processes,
     cpu_warning                    => $cpu_warning,
     cpu_critical                   => $cpu_critical,
+    cache_api_calls                => $cache_api_calls,
   }
 
   govuk::app::service { $title:


### PR DESCRIPTION
This can be turned back on on a per-app basis by adding `cache_api_calls => true` to `govuk::app` invocations.

https://trello.com/c/OOMMRcLJ/397-disable-gds-api-adapters-cache-in-any-frontend-app-that-still-has-it-enabled