### PR TITLE
Increase the Rummager index size monitoring time

### DIFF
--- a/modules/monitoring/manifests/checks.pp
+++ b/modules/monitoring/manifests/checks.pp
@@ -133,7 +133,7 @@ class monitoring::checks (
     notification_period => 'inoffice',
     action_url          => "https://grafana.${app_domain}/dashboard/file/rummager_index_size.json",
     notes_url           => monitoring_docs_url(rummager-index-size-change),
-    from                => '15minutes',
+    from                => '25minutes',
     args                => "--dropfirst ${drop_first}",
   }
 
@@ -147,7 +147,7 @@ class monitoring::checks (
     notification_period => 'inoffice',
     action_url          => "https://grafana.${app_domain}/dashboard/file/rummager_index_size.json",
     notes_url           => monitoring_docs_url(rummager-index-size-change),
-    from                => '15minutes',
+    from                => '25minutes',
     args                => "--dropfirst ${drop_first}",
   }
 
@@ -161,7 +161,7 @@ class monitoring::checks (
     notification_period => 'inoffice',
     action_url          => "https://grafana.${app_domain}/dashboard/file/rummager_index_size.json",
     notes_url           => monitoring_docs_url(rummager-index-size-change),
-    from                => '15minutes',
+    from                => '25minutes',
     args                => "--dropfirst ${drop_first}",
   }
 


### PR DESCRIPTION
We sometimes see this alert because the most recent index sizes haven't yet been added to Graphite. Since we increased the number of executors available in Jenkins (which is what populates the index sizes) we haven't seen this be as much of an issue. However it's not completely resolved so we can increase the time period to take graphite results from.

[Trello Card](https://trello.com/c/pFEBleeZ/399-fix-spurious-rummager-index-size-alerts)