### PR TITLE
Change the way the temp path are created to avoid duplicate

### DIFF
--- a/hieradata/node/api-mongo-4.api.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/api-mongo-4.api.staging.publishing.service.gov.uk.yaml
@@ -10,7 +10,7 @@ govuk_env_sync::tasks:
     dbms: "mongo"
     storagebackend: "s3"
     database: "content_store_production"
-    temppath: "/var/lib/mongodb/.dumps_content"
+    temppath: "/var/lib/mongodb/.dumps"
     url: "govuk-staging-database-backups"
     path: "mongo-api"
   "push_draft_content_store_daily":
@@ -20,6 +20,6 @@ govuk_env_sync::tasks:
     dbms: "mongo"
     storagebackend: "s3"
     database: "draft_content_store_production"
-    temppath: "/var/lib/mongodb/.dumps_draft_content"
+    temppath: "/var/lib/mongodb/.dumps"
     url: "govuk-staging-database-backups"
     path: "mongo-api"

--- a/modules/govuk_env_sync/manifests/task.pp
+++ b/modules/govuk_env_sync/manifests/task.pp
@@ -50,13 +50,13 @@ define govuk_env_sync::task(
   require govuk_env_sync::aws_auth
   require govuk_env_sync::sync_script
 
-  file { "${govuk_env_sync::conf_dir}/${title}.cfg":
+  ensure_resource('file',"${govuk_env_sync::conf_dir}/${title}.cfg", {
     ensure  => present,
     mode    => '0755',
     owner   => $govuk_env_sync::user,
     group   => $govuk_env_sync::user,
     content => template('govuk_env_sync/govuk_env_sync_job.conf.erb'),
-  }
+  })
 
   $synccommand = shellquote([
     '/usr/bin/ionice','-c','2','-n','6',


### PR DESCRIPTION
  The way tasks cfg files are created at the moment raises a
duplicate resources error in puppet if we use the same temp dir
more than once. This forces us to use different dirs and is
extremely error prone. This fixes this problem.