### PR TITLE
Change the way we create temp path to avoid duplicate resources

### DIFF
--- a/hieradata/node/api-mongo-4.api.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/api-mongo-4.api.staging.publishing.service.gov.uk.yaml
@@ -10,7 +10,7 @@ govuk_env_sync::tasks:
     dbms: "mongo"
     storagebackend: "s3"
     database: "content_store_production"
-    temppath: "/var/lib/mongodb/.dumps_content"
+    temppath: "/var/lib/mongodb/.dumps"
     url: "govuk-staging-database-backups"
     path: "mongo-api"
   "push_draft_content_store_daily":
@@ -20,6 +20,6 @@ govuk_env_sync::tasks:
     dbms: "mongo"
     storagebackend: "s3"
     database: "draft_content_store_production"
-    temppath: "/var/lib/mongodb/.dumps_draft_content"
+    temppath: "/var/lib/mongodb/.dumps"
     url: "govuk-staging-database-backups"
     path: "mongo-api"

--- a/modules/govuk_env_sync/manifests/task.pp
+++ b/modules/govuk_env_sync/manifests/task.pp
@@ -58,6 +58,13 @@ define govuk_env_sync::task(
     content => template('govuk_env_sync/govuk_env_sync_job.conf.erb'),
   }
 
+  ensure_resource('file', $temppath, {
+    ensure => 'directory',
+    mode   => '0775',
+    owner  => $govuk_env_sync::user,
+    group  => $govuk_env_sync::user,
+  })
+
   $synccommand = shellquote([
     '/usr/bin/ionice','-c','2','-n','6',
     '/usr/bin/setlock','/etc/unattended-reboot/no-reboot/govuk_env_sync',


### PR DESCRIPTION
  We use puppet to create the temp directory, this is preferable
since puppet is running as root and so can set up permissions for
us. Using ensure_resource prevents the duplcate resources error.