### PR TITLE
Install foreman for ruby on Dev VM

### DIFF
--- a/modules/govuk/manifests/node/s_development.pp
+++ b/modules/govuk/manifests/node/s_development.pp
@@ -32,7 +32,9 @@ class govuk::node::s_development (
   include govuk_python
   include govuk_testing_tools
 
-  include govuk_rbenv::all
+  class { 'govuk_rbenv::all':
+    with_foreman => true,
+  }
 
   include router::assets_origin
   include router::draft_assets

--- a/modules/govuk_rbenv/manifests/all.pp
+++ b/modules/govuk_rbenv/manifests/all.pp
@@ -10,6 +10,7 @@
 #
 class govuk_rbenv::all (
   $apt_mirror_hostname,
+  $with_foreman = false,
 ) {
   include govuk_rbenv
 
@@ -20,37 +21,19 @@ class govuk_rbenv::all (
     key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
   }
 
-  rbenv::version { '2.2.8':
-    bundler_version  => '1.16.2',
-    install_gem_docs => false,
-  }
-  rbenv::version { '2.3.1':
-    bundler_version  => '1.16.2',
-    install_gem_docs => false,
-  }
-  rbenv::version { '2.3.5':
-    bundler_version  => '1.16.2',
-    install_gem_docs => false,
-  }
-  rbenv::version { '2.4.0':
-    bundler_version  => '1.16.2',
-    install_gem_docs => false,
-  }
-  rbenv::version { '2.4.2':
-    bundler_version  => '1.16.2',
-    install_gem_docs => false,
-  }
-  rbenv::version { '2.4.4':
-    bundler_version  => '1.16.2',
-    install_gem_docs => false,
-  }
-  rbenv::version { '2.5.0':
-    bundler_version  => '1.16.2',
-    install_gem_docs => false,
-  }
-  rbenv::version { '2.5.1':
-    bundler_version  => '1.16.2',
-    install_gem_docs => false,
+  $ruby_versions = [
+    '2.2.8',
+    '2.3.1',
+    '2.3.5',
+    '2.4.0',
+    '2.4.2',
+    '2.4.4',
+    '2.5.0',
+    '2.5.1',
+  ]
+
+  govuk_rbenv::install_ruby_version { $ruby_versions:
+    with_foreman => $with_foreman,
   }
 
   # These aliases re solve .ruby-version 2.x to an installed Ruby version.

--- a/modules/govuk_rbenv/manifests/install_ruby_version.pp
+++ b/modules/govuk_rbenv/manifests/install_ruby_version.pp
@@ -1,0 +1,35 @@
+# == Define: govuk_rbenv::install_ruby_version
+#
+# Installs a version of Ruby passed in as the name value. This define was
+# wrote as a means to get around the lack of explicit loop support in Puppet 3
+# and is thus a bit of a hack - if it transpires that we need to support
+# different gem versions for different rubies this could be a problem but this
+# hasn't been the case for years on GOV.UK
+#
+# === Parameters
+#
+# [*with_foreman*]
+#   Whether to install the foreman gem on the system
+#
+define govuk_rbenv::install_ruby_version(
+  $with_foreman = false,
+) {
+  rbenv::version { $name:
+    bundler_version  => '1.16.2',
+    install_gem_docs => false,
+  }
+
+  if $with_foreman {
+    $foreman_version = '0.85'
+    $gem_cmd = "${rbenv::params::rbenv_binary} exec gem"
+    exec { "install foreman for ruby ${name}":
+      command     => "${gem_cmd} install foreman -v ${foreman_version}",
+      unless      => "${gem_cmd} query -i -n foreman -v ${foreman_version}",
+      environment => [
+        "RBENV_ROOT=${rbenv::params::rbenv_root}",
+        "RBENV_VERSION=${name}",
+      ],
+      notify      => Rbenv::Rehash[$name],
+    }
+  }
+}

--- a/modules/govuk_rbenv/spec/defines/govuk_rbenv__install_ruby_version_spec.rb
+++ b/modules/govuk_rbenv/spec/defines/govuk_rbenv__install_ruby_version_spec.rb
@@ -1,0 +1,22 @@
+require_relative '../../../../spec_helper'
+
+describe "govuk_rbenv::install_ruby_version", :type => :define do
+  let(:title) { '2.5.1' }
+
+  it { is_expected.to contain_rbenv__version(title) }
+
+  context "when with_foreman is true" do
+    let(:params) { { :with_foreman => true } }
+
+    it do
+      is_expected.to contain_exec('install foreman for ruby 2.5.1')
+        .with_command(%r{gem install foreman})
+    end
+  end
+
+  context "when with_foreman is false" do
+    let(:params) { { :with_foreman => false } }
+
+    it { is_expected.not_to contain_exec('install foreman for ruby 2.5.1') }
+  end
+end


### PR DESCRIPTION
This installs foreman with each version of Ruby in the dev VM
environment. Quite a few of our Rails apps use foreman and nearly all of
them make use of a procfile, however frequently we use the approach that is
distinctly discouraged by the foreman author by installing it in the
Gemfile.

On most systems or local machines it's really not too much of a
bother installing foreman it's something we can put in a ./startup.sh
script, however on the dev VM when gems need to be installed as root
this is more difficult - and it feels an anti-pattern to have a `sudo
gem install foreman` in a ./startup.sh script.

Now onto the actual implementation, in an ideal world this would be
handled by updating https://github.com/gds-operations/puppet-rbenv to
support a hash of gems and versions to install, however since the
version of puppet we currently use has very little loop support this
would be very difficult. Instead I've implemented this in the
govuk_rbenv as I was able to use a define as a means of processing a
loop.

This solution could hit problems if we decide we need to install
different versions of gems for different versions of ruby. In that case
it might be that we decide we want to extend
https://github.com/gds-operations/puppet-rbenv and look at defines there
that can be used for installing a particular gem.