### PR TITLE
Update Dev VM for content-publisher

### DIFF
--- a/development-vm/Procfile
+++ b/development-vm/Procfile
@@ -177,3 +177,4 @@ content-publisher: govuk_setenv content-publisher ./run_in.sh ../../content-publ
 # Smokey BrowserMob Proxy uses ports 3222-3229
 content-data-admin: govuk_setenv content-data-admin ./run_in.sh ../../content-data-admin bundle exec rails s -p 3230
 draft-smartanswers: govuk_setenv draft-smartanswers ./run_in.sh ../../smart-answers bundle exec rails server -p 3231 -P tmp/pids/draft-smartanswers.pid
+# content-publisher has reserved 3232 for webpack-dev-server

--- a/development-vm/Procfile
+++ b/development-vm/Procfile
@@ -173,7 +173,7 @@ organisations-publisher-sidekiq:                     govuk_setenv organisations-
 organisations-publisher: govuk_setenv organisations-publisher ./run_in.sh ../../organisations-publisher bundle exec rails s -p 3218
 # sidekiq-monitoring for organisations-publisher uses port 3219
 # ckan uses port 3220
-content-publisher: govuk_setenv content-publisher ./run_in.sh ../../content-publisher bundle exec rails s -p 3221
+content-publisher: govuk_setenv content-publisher ./run_in.sh ../../content-publisher bundle exec foreman start -f Procfile.dev
 # Smokey BrowserMob Proxy uses ports 3222-3229
 content-data-admin: govuk_setenv content-data-admin ./run_in.sh ../../content-data-admin bundle exec rails s -p 3230
 draft-smartanswers: govuk_setenv draft-smartanswers ./run_in.sh ../../smart-answers bundle exec rails server -p 3231 -P tmp/pids/draft-smartanswers.pid

--- a/development-vm/single-update-yarn.sh
+++ b/development-vm/single-update-yarn.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+set -e
+
+. ./support_functions.sh
+
+if [ "$#" -ne "1" ]; then
+  echo "Usage: $(basename "$0") <reponame>"
+  exit 1
+fi
+
+cd "$(dirname "$0")"
+
+REPO="$1"
+
+cd "../../$REPO"
+
+if [ -f lock ]; then
+  warn "skipped because 'lock' file exists"
+else
+  echo "Updating $REPO..."
+  outputfile=$(mktemp -t update-yarn.XXXXXX)
+  trap "rm -f '$outputfile'" EXIT
+
+  if yarn install >"$outputfile" 2>&1; then
+    ok "ok"
+  else
+    error "failed with bundler output:"
+    cat "$outputfile"
+    exit 1
+  fi
+fi
+

--- a/development-vm/single-update-yarn.sh
+++ b/development-vm/single-update-yarn.sh
@@ -20,7 +20,7 @@ if [ -f lock ]; then
 else
   echo "Updating $REPO..."
   outputfile=$(mktemp -t update-yarn.XXXXXX)
-  trap "rm -f '$outputfile'" EXIT
+  trap 'rm -f $outputfile' EXIT
 
   if yarn install >"$outputfile" 2>&1; then
     ok "ok"

--- a/development-vm/update-all.sh
+++ b/development-vm/update-all.sh
@@ -6,3 +6,4 @@ cd $( dirname "${BASH_SOURCE[0]}" )
 govuk_puppet
 ./update-bundler.sh
 ./update-pip.sh
+./update-yarn.sh

--- a/development-vm/update-all.sh
+++ b/development-vm/update-all.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cd $( dirname "${BASH_SOURCE[0]}" )
+cd "$( dirname "${BASH_SOURCE[0]}" )"
 
 ./update-git.sh
 govuk_puppet

--- a/development-vm/update-yarn.sh
+++ b/development-vm/update-yarn.sh
@@ -5,7 +5,7 @@ set -e
 cd "$(dirname "$0")"
 
 find_repos () {
-  ls -d ../../*/yarn.lock | cut -d/ -f3
+  find ../../*/yarn.lock | cut -d/ -f3
 }
 
 find_repos | xargs -n1 ./single-update-yarn.sh

--- a/development-vm/update-yarn.sh
+++ b/development-vm/update-yarn.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+
+cd "$(dirname "$0")"
+
+find_repos () {
+  ls -d ../../*/yarn.lock | cut -d/ -f3
+}
+
+find_repos | xargs -n1 ./single-update-yarn.sh


### PR DESCRIPTION
Content Publisher uses Yarn for JS dependencies and foreman to start the app. This brings the Dev VM up to parity with the app so that it can run as other apps using bowl and the various update scripts.