### PR TITLE
AWS RDS Duplicate Instances

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
@@ -5,7 +5,7 @@
         - git:
             url: git@github.com:alphagov/env-sync-and-backup.git
             branches:
-              - master
+              - aws-rds-duplicate
 
 - job:
     name: Copy_Data_to_Integration


### PR DESCRIPTION
- We have created duplicated AWS RDS Instances in the Integration
environment.

- This was done to test that the data-sync works correctly and we can
apply the new terraform modules (when we apply the new modules, since
there are namong changes, the current instances will destroyed and
re-created).

- This change enables the old data-sync task to use a branch of
env-sync-and-backup. This change should be reversed once the work has
been completed.

https://trello.com/c/mp7FWAH2/1425-create-a-second-rds-duplicate-instance-in-aws-integration

Solo: suthagrht