### PR TITLE
Add Pete Leaman and grant access to licensing

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1841,4 +1841,11 @@ unattended_upgrades::origins:
 
 unicornherder::version: '0.0.8'
 
+# Pete Leaman needs access to the licensing machines for his work
+users::pentest_machines:
+  - 'licensing-backend-1'
+  - 'licensing-backend-2'
+users::pentest_usernames:
+  - 'peteleaman'
+
 yarn::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"

--- a/modules/users/manifests/peteleaman.pp
+++ b/modules/users/manifests/peteleaman.pp
@@ -1,0 +1,8 @@
+# Creates the peteleaman user
+class users::peteleaman {
+  govuk_user { 'peteleaman':
+    fullname => 'Pete Leaman',
+    email    => 'pete.leaman@digital.cabinet-office.gov.uk',
+    ssh_key  => 'ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAgEAlCqMuykoxYHfK7eLuo6n68U/o7b9rVIR43YWkCrwlQ4Hr3s+b7pHZbtkdkweZP7LdKJVsAGBE14jFiLv4dzrAaRMgQuev1paArzkd9ObKDb/TwqSqPHdrwbckDoLMBXvqTvhRG+rdORLJX5t3Or77dW+TAyqOhmws8E0dFKCMX7Ct5OUM/AemB6x3yFxWdp8cjDV6ENvzfmrbaNUhRgl9M2z66Bs8xIHPDgu+rUESAFNzfZNl9oJMycQyN3JwydPsOBZWYWDVc4zRHK6VK+kecT9OWmAd/kdfIR5Wjgy9v9D+O3ipo9xViV7hs0/0dOEA5qZdd+dJNjWkG9/EahntAmXZ99MxmaNQV81gZY0PNhFaxdgvzR9+bch7GaRzE+u42Pg4E3ydNBtlsAnZByJsf2vPfoHCMWJK3ZUERpI6xskbFinNIYQEu9v9xqxIpSVLvciKqAnYFW4sl07c8pAl6wQC/P2RSxK19IhvkftiZjAKAg1LX9tt+Gl8LH8wVgQe4FFxv9zopXvZJLa4/IFclQvXkJVgIHIT/OBX8DnihmHm7i54CWkjXR6I8obM8rbzAqVbavF506xp4Z+1PjIr1nQaPPqDm8JLH/m1fuUZ5c1dwFlvYJqq95B0tTUKhBR9uPlKWw639ok36wLvA9JWwv2eWEZSnpYTlVCatP6/GU=',
+  }
+}


### PR DESCRIPTION
This commit adds Pete Leaman’s SSH key and grants him access to the licensing machines only using the pentest mechanism.

Trello: https://trello.com/c/iG2eZcDn/215-give-pete-l-apto-access-to-the-licensing-boxes