### PR TITLE
Correct the unpublishing routing key

### DIFF
--- a/modules/govuk/manifests/apps/email_alert_service/rabbitmq.pp
+++ b/modules/govuk/manifests/apps/email_alert_service/rabbitmq.pp
@@ -39,7 +39,7 @@ class govuk::apps::email_alert_service::rabbitmq (
   govuk_rabbitmq::queue_with_binding { $amqp_unpublishing_queue:
     amqp_exchange => $amqp_exchange,
     amqp_queue    => $amqp_unpublishing_queue,
-    routing_key   => 'redirect.unpublishing.#',
+    routing_key   => 'redirect.unpublish.#',
     durable       => true,
   } ->
 

--- a/modules/govuk/manifests/apps/email_alert_service/rabbitmq_test_permissions.pp
+++ b/modules/govuk/manifests/apps/email_alert_service/rabbitmq_test_permissions.pp
@@ -47,7 +47,7 @@ class govuk::apps::email_alert_service::rabbitmq_test_permissions (
   govuk_rabbitmq::queue_with_binding { $amqp_unpublishing_queue:
     amqp_exchange => $amqp_exchange,
     amqp_queue    => $amqp_unpublishing_queue,
-    routing_key   => 'redirect.unpublishing.#',
+    routing_key   => 'redirect.unpublish.#',
     durable       => true,
   } ->
 


### PR DESCRIPTION
The unpublishing queue that listens to unpublishing events was
using the wrong routing key. This PR fixes that.