### PR TITLE
Add email-alert-api to the list of non-draft services

### DIFF
--- a/modules/govuk/manifests/node/s_draft_frontend.pp
+++ b/modules/govuk/manifests/node/s_draft_frontend.pp
@@ -23,6 +23,7 @@ class govuk::node::s_draft_frontend() inherits govuk::node::s_base {
     'PLEK_SERVICE_MAPIT_URI': value     => "https://mapit.${app_domain_internal}";
     'PLEK_SERVICE_SEARCH_URI': value    => "https://search.${app_domain_internal}";
     'PLEK_SERVICE_RUMMAGER_URI': value  => "https://rummager.${app_domain_internal}";
+    'PLEK_SERVICE_EMAIL_ALERT_API_URI': value  => "https://email-alert-api.${app_domain_internal}";
     'PLEK_SERVICE_WHITEHALL_ADMIN_URI': value  => "https://whitehall-admin.${app_domain_internal}";
   }
 


### PR DESCRIPTION
This means that the draft email-alert-frontend will not error when
trying to talk to the email-alert-api, as currently the draft- prefix
is used, and no draft instance of the email-alert-api runs.