### PR TITLE
Add cache-clearing-service

### DIFF
--- a/development-vm/Pinfile
+++ b/development-vm/Pinfile
@@ -9,6 +9,7 @@ process :backdrop => [:backdrop_read, :backdrop_write]
 process :backdrop_read
 process :backdrop_write
 process :bouncer
+process :'cache-clearing-service'
 process :calculators => [:static, :'content-store']
 process :calendars => [:static, :'content-store']
 process :collections => [:static, :'content-store', :rummager]

--- a/development-vm/Procfile
+++ b/development-vm/Procfile
@@ -178,3 +178,4 @@ content-publisher: govuk_setenv content-publisher ./run_in.sh ../../content-publ
 content-data-admin: govuk_setenv content-data-admin ./run_in.sh ../../content-data-admin bundle exec rails s -p 3230
 draft-smartanswers: govuk_setenv draft-smartanswers ./run_in.sh ../../smart-answers bundle exec rails server -p 3231 -P tmp/pids/draft-smartanswers.pid
 # content-publisher has reserved 3232 for webpack-dev-server
+cache-clearing-service: govuk_setenv cache-clearing-service ./run_in.sh ../../cache-clearing-service bundle exec bin/cache_clearing_service

--- a/development-vm/alphagov_repos
+++ b/development-vm/alphagov_repos
@@ -1,4 +1,5 @@
 asset-manager
+cache-clearing-service
 calculators
 calendars
 collections

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -18,6 +18,7 @@ node_class: &node_class
   backend:
     apps:
       - asset-manager
+      - cache-clearing-service
       - canary-backend
       - collections-publisher
       - contacts
@@ -141,6 +142,7 @@ deployable_applications: &deployable_applications
   backdrop-write:
     repository: 'backdrop'
   bouncer: {}
+  cache-clearing-service: {}
   calculators: {}
   calendars: {}
   ckan:

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -16,6 +16,7 @@ node_class: &node_class
   backend:
     apps:
       - asset-manager
+      - cache-clearing-service
       - canary-backend
       - collections-publisher
       - contacts
@@ -144,6 +145,7 @@ deployable_applications: &deployable_applications
   backdrop-write:
     repository: 'backdrop'
   bouncer: {}
+  cache-clearing-service: {}
   calculators: {}
   calendars: {}
   ckan:

--- a/modules/govuk/manifests/apps/cache_clearing_service.pp
+++ b/modules/govuk/manifests/apps/cache_clearing_service.pp
@@ -1,0 +1,37 @@
+# == Class: govuk::apps::cache_clearing_service
+#
+# This is a message queue consumer application which clears Fastly and Varnish
+# caches when new content is published.
+#
+# === Parameters
+#
+# [*enabled*]
+#   Should the application should be enabled. Set in hiera data for each
+#   environment.
+#
+# [*sentry_dsn*]
+#   The URL used by Sentry to report exceptions
+#
+class govuk::apps::cache_clearing_service (
+  $enabled = false,
+  $sentry_dsn = undef,
+) {
+  $ensure = $enabled ? {
+    true  => 'present',
+    false => 'absent',
+  }
+
+  govuk::app { 'cache-clearing-service':
+    ensure             => $ensure,
+    app_type           => 'bare',
+    enable_nginx_vhost => false,
+    sentry_dsn         => $sentry_dsn,
+    command            => './bin/cache_clearing_service',
+  }
+
+  Govuk::App::Envvar {
+    ensure          => $ensure,
+    app             => 'cache-clearing-service',
+    notify_service  => $enabled,
+  }
+}

--- a/modules/grafana/files/dashboards/processes.json
+++ b/modules/grafana/files/dashboards/processes.json
@@ -1132,6 +1132,11 @@
             "selected": false
           },
           {
+            "text": "processes-app-cache-clearing-service",
+            "value": "processes-app-cache-clearing-service",
+            "selected": false
+          },
+          {
             "text": "processes-app-calculators",
             "value": "processes-app-calculators",
             "selected": false


### PR DESCRIPTION
This a new app we're developing to automatically clear Fastly and Varnish caches when new content is published.

https://github.com/alphagov/cache-clearing-service

[Trello Card](https://trello.com/c/qJONbAdR/411-make-and-deploy-a-new-basic-non-rails-app)