### PR TITLE
Display thread count on the deployment dashboard

### DIFF
--- a/modules/grafana/manifests/dashboards/deployment_dashboard.pp
+++ b/modules/grafana/manifests/dashboards/deployment_dashboard.pp
@@ -107,8 +107,8 @@ define grafana::dashboards::deployment_dashboard (
 
   $panel_partials = concat(
     [
-      ['processor_count', '5xx_rate'],
-      ['error_counts_table', 'links']
+      ['processor_count', 'thread_count'],
+      ['error_counts_table', '5xx_rate']
     ],
     $worker_row,
     $errors_by_controller_row,
@@ -116,7 +116,8 @@ define grafana::dashboards::deployment_dashboard (
     $duration_by_controller_row,
     $dependent_app_5xx_row,
     $sidekiq_graph_row,
-    $elasticsearch_stats
+    $elasticsearch_stats,
+    [['links']]
   )
 
   file {

--- a/modules/grafana/templates/dashboards/deployment_panels/_links.json.erb
+++ b/modules/grafana/templates/dashboards/deployment_panels/_links.json.erb
@@ -6,7 +6,7 @@
   "isNew": true,
   "links": [],
   "mode": "html",
-  "span": 6,
+  "span": 12,
   "style": {
     "font-size": "20pt"
   },

--- a/modules/grafana/templates/dashboards/deployment_panels/_thread_count.json.erb
+++ b/modules/grafana/templates/dashboards/deployment_panels/_thread_count.json.erb
@@ -1,0 +1,97 @@
+{
+  "aliasColors": {},
+  "bars": false,
+  "datasource": "Graphite",
+  "description": "Shows the thread count for <%= @app_name %> backend machines. During deployment the number of threads should double and then return to normal. Code should be tested once the old threads have been killed.",
+  "fill": 0,
+  "grid": {
+    "threshold1": null,
+    "threshold1Color": "rgba(216, 200, 27, 0.27)",
+    "threshold2": null,
+    "threshold2Color": "rgba(234, 112, 112, 0.22)"
+  },
+  "id": 17,
+  "legend": {
+    "avg": false,
+    "current": true,
+    "max": false,
+    "min": false,
+    "show": true,
+    "total": false,
+    "values": true,
+    "alignAsTable": true,
+    "rightSide": true
+  },
+  "lines": true,
+  "linewidth": 1,
+  "links": [],
+  "nullPointMode": "null",
+  "percentage": false,
+  "pointradius": 5,
+  "points": false,
+  "renderer": "flot",
+  "seriesOverrides": [],
+  "span": 6,
+  "stack": false,
+  "steppedLine": false,
+  "targets": [
+    {
+      "bucketAggs": [
+        {
+          "id": "2",
+          "settings": {
+            "interval": "auto"
+          },
+          "type": "date_histogram"
+        }
+      ],
+      "dsType": "elasticsearch",
+      "metrics": [
+        {
+          "id": "1",
+          "type": "count"
+        }
+      ],
+      "refId": "A",
+      "target": "aliasByNode(*.processes-app-<%= @app_name %>.ps_count.threads,0)",
+      "textEditor": true,
+      "timeField": "@timestamp"
+    }
+  ],
+  "thresholds": [],
+  "timeFrom": "15m",
+  "timeShift": null,
+  "title": "Threads",
+  "tooltip": {
+    "msResolution": false,
+    "shared": true,
+    "sort": 0,
+    "value_type": "individual"
+  },
+  "type": "graph",
+  "xaxis": {
+    "mode": "time",
+    "name": null,
+    "show": true,
+    "values": []
+  },
+  "yaxes": [
+    {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+    },
+    {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+    }
+  ],
+  "decimals": 0
+}


### PR DESCRIPTION
I considered replacing the process count graph with a thread count graph, but decided against it.  It's useful to see both, because this allows distinguishing between process leaks and thread leaks.  A process leak will have both graphs going up, whereas a thread leak will only have the thread graph going up.

To make space, I moved the "useful links" panel to the bottom.

---

[Trello card](https://trello.com/c/mPzlp9D2/413-make-the-deployment-dashboard-show-the-number-of-threads)