### PR TITLE
Remove pentest details

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1841,11 +1841,4 @@ unattended_upgrades::origins:
 
 unicornherder::version: '0.0.8'
 
-# Pete Leaman needs access to the licensing machines for his work
-users::pentest_machines:
-  - 'licensing-backend-1'
-  - 'licensing-backend-2'
-users::pentest_usernames:
-  - 'peteleaman'
-
 yarn::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"


### PR DESCRIPTION
These will be changed and moved to govuk-secrets.

Trello: https://trello.com/c/iG2eZcDn/215-give-pete-l-apto-access-to-the-licensing-boxes