### PR TITLE
Revert "AWS RDS Duplicate Instances"

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
@@ -5,7 +5,7 @@
         - git:
             url: git@github.com:alphagov/env-sync-and-backup.git
             branches:
-              - aws-rds-duplicate
+              - master
 
 - job:
     name: Copy_Data_to_Integration


### PR DESCRIPTION
Reverts alphagov/govuk-puppet#8002

We have tested the possibility of using duplicate instances. Hence we are reverting the change.