### PR TITLE
AWS RDS email-alert-api

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1167,6 +1167,8 @@ monitoring::checks::rds::servers:
    - 'transition-postgresql-standby'
    - 'warehouse-postgresql-primary'
    - 'warehouse-postgresql-standby'
+   - 'email-alert-api-postgresql-primary'
+   - 'email-alert-api-postgresql-standby'
    - 'mysql-primary'
    - 'mysql-replica'
 


### PR DESCRIPTION
- We have created a separate AWS RDS instance for email-alert-api.
Hence, we are adding these instances to monitoring.

https://trello.com/c/ljsMBGQ4/1419-split-email-alert-api-into-its-own-rds-instance

Solo:@suthagarht