### PR TITLE
Add quoting to SQL statements in PG dump

### DIFF
--- a/modules/govuk_env_sync/files/govuk_env_sync.sh
+++ b/modules/govuk_env_sync/files/govuk_env_sync.sh
@@ -216,8 +216,8 @@ function restore_postgresql {
   fi
   pg_stderr=$(sudo pg_restore -U aws_db_admin -h postgresql-primary --create --no-password -d postgres "${tempdir}/${filename}" 2>&1)
   if [ "$DB_OWNER" != '' ] ; then
-     echo "GRANT ALL ON DATABASE $database TO $DB_OWNER" | sudo psql -U aws_db_admin -h postgresql-primary --no-password "${database}"
-     echo "ALTER DATABASE $database OWNER TO $DB_OWNER" | sudo psql -U aws_db_admin -h postgresql-primary --no-password "${database}"
+     echo "GRANT ALL ON DATABASE '$database' TO '$DB_OWNER'" | sudo psql -U aws_db_admin -h postgresql-primary --no-password "${database}"
+     echo "ALTER DATABASE '$database' OWNER TO '$DB_OWNER'" | sudo psql -U aws_db_admin -h postgresql-primary --no-password "${database}"
   fi
 }
 


### PR DESCRIPTION
- Special characters and/or spaces in database names cause errors
without this

solo: @schmie