### PR TITLE
Add configuration for separate publishing-api rds and db_admin

### DIFF
--- a/hieradata/class/publishing_api_postgresql.yaml
+++ b/hieradata/class/publishing_api_postgresql.yaml
@@ -1,0 +1,20 @@
+---
+postgresql::globals::version: '9.6'
+
+govuk_safe_to_reboot::can_reboot: 'no'
+govuk_safe_to_reboot::reason: 'Single point of failure for publishing API'
+
+icinga::client::contact_groups: 'urgent-priority'
+
+lv:
+  data:
+    pv:
+      - '/dev/sdb1'
+      - '/dev/sdc1'
+    vg: 'postgresql'
+
+mount:
+  /var/lib/postgresql:
+    disk: '/dev/mapper/postgresql-data'
+    govuk_lvm: 'data'
+    mountoptions: 'defaults'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -763,6 +763,8 @@ govuk::node::s_mysql_master::aws_access_key_id: "%{hiera('govuk::node::s_mysql_b
 govuk::node::s_mysql_master::aws_secret_access_key: "%{hiera('govuk::node::s_mysql_backup::aws_secret_access_key')}"
 govuk::node::s_mysql_master::encryption_key: "%{hiera('govuk::node::s_mysql_backup::encryption_key')}"
 
+govuk::node::s_publishing_api_db_admin::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+
 govuk::node::s_transition_db_admin::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 govuk::node::s_warehouse_db_admin::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"

--- a/hieradata/vagrant_credentials.yaml
+++ b/hieradata/vagrant_credentials.yaml
@@ -181,6 +181,12 @@ govuk::node::s_email_alert_api_postgresql::s3_bucket_url: 'bucket'
 govuk::node::s_email_alert_api_postgresql::wale_private_gpg_key: 'key'
 govuk::node::s_email_alert_api_postgresql::wale_private_gpg_key_fingerprint: 'AIFAED1POOX9MOA3THI9CIE0IEQU7ULAIWEI4SOF'
 
+govuk::node::s_publishing_api_postgresql::aws_access_key_id: 'foo'
+govuk::node::s_publishing_api_postgresql::aws_secret_access_key: 'bar'
+govuk::node::s_publishing_api_postgresql::s3_bucket_url: 'bucket'
+govuk::node::s_publishing_api_postgresql::wale_private_gpg_key: 'key'
+govuk::node::s_publishing_api_postgresql::wale_private_gpg_key_fingerprint: 'AIFAED1POOX9MOA3THI9CIE0IEQU7ULAIWEI4SOF'
+
 govuk_jenkins::config::environment_variables:
   ORGANISATION: development
 

--- a/hieradata_aws/class/publishing_api_db_admin.yaml
+++ b/hieradata_aws/class/publishing_api_db_admin.yaml
@@ -1,0 +1,7 @@
+---
+postgresql::globals::version: '9.6'
+postgresql::globals::manage_package_repo: true
+postgresql::server::role::rds: true
+govuk_sudo::sudo_conf:
+  govuk-backup:
+    content: 'govuk-backup ALL=NOPASSWD:/usr/bin/psql,/usr/bin/dropdb,/usr/bin/dropuser,/usr/bin/pg_restore'

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -820,6 +820,8 @@ govuk::node::s_mysql_master::encryption_key: "%{hiera('govuk::node::s_mysql_back
 
 govuk::node::s_postgresql_primary::alert_hostname: 'alert'
 
+govuk::node::s_publishing_api_db_admin::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+
 govuk::node::s_whitehall_mysql_master::aws_access_key_id: "%{hiera('govuk::node::s_mysql_backup::aws_access_key_id')}"
 govuk::node::s_whitehall_mysql_master::aws_secret_access_key: "%{hiera('govuk::node::s_mysql_backup::aws_secret_access_key')}"
 govuk::node::s_whitehall_mysql_master::encryption_key: "%{hiera('govuk::node::s_mysql_backup::encryption_key')}"
@@ -1170,6 +1172,8 @@ monitoring::checks::rds::servers:
    - 'warehouse-postgresql-standby'
    - 'email-alert-api-postgresql-primary'
    - 'email-alert-api-postgresql-standby'
+   - 'publishing-api-postgresql-primary'
+   - 'publishing-api-postgresql-standby'
    - 'mysql-primary'
    - 'mysql-replica'
 

--- a/modules/govuk/manifests/node/s_publishing_api_db_admin.pp
+++ b/modules/govuk/manifests/node/s_publishing_api_db_admin.pp
@@ -1,0 +1,102 @@
+# == Class: Govuk_Node::S_publishing_api_db_admin
+#
+# This machine class is used to administer publishing_api PostgreSQL RDS instances.
+#
+# === Parameters
+#
+class govuk::node::s_publishing_api_db_admin(
+  $backup_s3_bucket     = undef,
+  $postgres_host        = undef,
+  $postgres_user        = undef,
+  $postgres_password    = undef,
+  $postgres_port        = '5432',
+  $postgres_backup_hour = 7,
+  $postgres_backup_min  = 30,
+  $apt_mirror_hostname,
+) {
+  include govuk_env_sync
+  include ::govuk::node::s_base
+
+  $alert_hostname = 'alert'
+
+  if $backup_s3_bucket {
+    $ensure = 'present'
+  } else {
+    $ensure = 'absent'
+  }
+
+  apt::source { 'gof3r':
+    ensure       => $ensure,
+    location     => "http://${apt_mirror_hostname}/gof3r",
+    release      => $::lsbdistcodename,
+    architecture => $::architecture,
+    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+  }
+
+  package { 'gof3r':
+    ensure  => $ensure,
+    require => Apt::Source['gof3r'],
+  }
+
+  ### PostgreSQL ###
+
+  $default_connect_settings = {
+    'PGUSER'     => $postgres_user,
+    'PGPASSWORD' => $postgres_password,
+    'PGHOST'     => $postgres_host,
+    'PGPORT'     => $postgres_port,
+  }
+
+  # To manage remote databases using the puppetlabs-postgresql module we require
+  # a local PostgreSQL server instance to be installed
+  class { '::postgresql::server':
+    default_connect_settings => $default_connect_settings,
+  } ->
+
+  # This allows easy administration of the PostgreSQL backend:
+  # https://www.postgresql.org/docs/9.3/static/libpq-pgpass.html
+  file { '/root/.pgpass':
+    ensure  => present,
+    mode    => '0600',
+    content => "${postgres_host}:5432:*:${postgres_user}:${postgres_password}",
+  }
+
+  # This class collects the resources that are exported by the
+  # govuk_postgresql::server::db defined type
+  include ::govuk_postgresql::server::not_slave
+
+  # Ensure the client class is installed
+  class { '::govuk_postgresql::client': } ->
+
+  # include all PostgreSQL classes that create databases and users
+  class { '::govuk::apps::publishing_api::db': }
+
+  $postgres_backup_desc = 'RDS publishing_api PostgreSQL backup to S3'
+
+  @@icinga::passive_check { "check_rds_postgres_s3_backup-${::hostname}":
+    ensure              => $ensure,
+    service_description => $postgres_backup_desc,
+    freshness_threshold => 28 * 3600,
+    host_name           => $::fqdn,
+  }
+
+  file { '/usr/local/bin/rds-postgres-to-s3':
+    ensure  => $ensure,
+    content => template('govuk/node/s_db_admin/rds-postgres-to-s3.erb'),
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0775',
+    require => [
+      Package['gof3r'],
+      File['/root/.pgpass'],
+    ],
+  }
+
+  cron::crondotdee { 'rds-publishing_api-postgres-to-s3':
+    ensure  => $ensure,
+    hour    => $postgres_backup_hour,
+    minute  => $postgres_backup_min,
+    command => '/usr/local/bin/rds-postgres-to-s3',
+    require => File['/usr/local/bin/rds-postgres-to-s3'],
+  }
+}

--- a/modules/govuk/manifests/node/s_publishing_api_postgresql.pp
+++ b/modules/govuk/manifests/node/s_publishing_api_postgresql.pp
@@ -1,0 +1,28 @@
+# == Class: govuk::node::s_publishing_api_postgresql
+#
+# PostgreSQL node for the Data publishing_api.
+#
+class govuk::node::s_publishing_api_postgresql (
+  $aws_access_key_id,
+  $aws_secret_access_key,
+  $s3_bucket_url,
+  $wale_private_gpg_key,
+  $wale_private_gpg_key_fingerprint,
+  $alert_hostname = 'alert.cluster',
+) inherits govuk::node::s_base  {
+  include govuk_env_sync
+  Govuk_mount['/var/lib/postgresql'] -> Class['govuk_postgresql::server::standalone']
+
+  include govuk_postgresql::server::standalone
+  include govuk_postgresql::tuning
+  include govuk::apps::content_performance_manager::db
+
+  govuk_postgresql::wal_e::backup { $title:
+    aws_access_key_id                => $aws_access_key_id,
+    aws_secret_access_key            => $aws_secret_access_key,
+    s3_bucket_url                    => $s3_bucket_url,
+    wale_private_gpg_key             => $wale_private_gpg_key,
+    wale_private_gpg_key_fingerprint => $wale_private_gpg_key_fingerprint,
+    alert_hostname                   => $alert_hostname,
+  }
+}

--- a/modules/hosts/manifests/purge.pp
+++ b/modules/hosts/manifests/purge.pp
@@ -17,6 +17,8 @@ class hosts::purge {
   $whitelist = [
     'db-admin-1',
     'email-alert-api-postgresql',
+    'publishing-api-db-admin-1',
+    'publishing-api-postgresql-1',
   ]
 
   if ! ($::hostname in $whitelist) {


### PR DESCRIPTION
- To reduce load on individual instances, we are splitting
publishing-api and email-alert-api into seperate rds instances

- This does not "flip the switch" for use by publishing-api, yet, but will configure the instances and allow us to test and sync data before switching the app over to use it.

- Files created from warehouse equivalents and s/warehouse/publishing-api/g

Update/Do not merge: This now includes publishing_api::db, where I like to double check it does not
interact with the app in it's current state

@schmie