### PR TITLE
Add internal DNS for content-performance-manager

### DIFF
--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -264,6 +264,7 @@ hosts::development::apps:
   - 'collections-publisher'
   - 'contacts-admin'
   - 'content-data-admin'
+  - 'content-performance-manager'
   - 'content-publisher'
   - 'content-store'
   - 'content-tagger'


### PR DESCRIPTION
Added content-performance-manager to
hosts::development::apps in development.yaml
This is because this service could not be resolved inside
the development VM.

Needed for: https://trello.com/c/zms3rqZ1/590-3-display-a-chart-unique-page-views-for-a-single-content-item