### PR TITLE
Cache Clearing Service RabbitMQ Configuration

### DIFF
--- a/hieradata/class/rabbitmq.yaml
+++ b/hieradata/class/rabbitmq.yaml
@@ -6,6 +6,7 @@ govuk::node::s_rabbitmq::apps_using_rabbitmq:
   - publishing_api
   - rummager
   - content_performance_manager
+  - cache_clearing_service
 
 govuk_safe_to_reboot::can_reboot: 'careful'
 govuk_safe_to_reboot::reason: 'rabbitmq-1 is a single point of failure for content-store, apps not resilient'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -361,6 +361,10 @@ govuk::apps::bouncer::nagios_memory_critical: 1500
 govuk::apps::bouncer::unicorn_worker_processes: "8"
 
 govuk::apps::cache_clearing_service::enabled: true
+govuk::apps::cache_clearing_service::rabbitmq_hosts:
+  - rabbitmq-1.backend
+  - rabbitmq-2.backend
+  - rabbitmq-3.backend
 
 govuk::apps::ckan::db_hostname: "postgresql-primary-1.backend"
 govuk::apps::ckan::db_port: 6432

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -23,6 +23,7 @@ govuk::node::s_development::apps:
   - 'backdrop_write::rabbitmq'
   - 'bouncer'
   - 'cache_clearing_service'
+  - 'cache_clearing_service::rabbitmq'
   - 'calculators'
   - 'calendars'
   - 'canary_backend'

--- a/hieradata_aws/class/rabbitmq.yaml
+++ b/hieradata_aws/class/rabbitmq.yaml
@@ -6,6 +6,7 @@ govuk::node::s_rabbitmq::apps_using_rabbitmq:
   - publishing_api
   - rummager
   - content_performance_manager
+  - cache_clearing_service
 
 govuk_rabbitmq::aws_clustering: true
 

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -377,6 +377,7 @@ govuk::apps::bouncer::nagios_memory_critical: 1500
 govuk::apps::bouncer::unicorn_worker_processes: "8"
 
 govuk::apps::cache_clearing_service::enabled: true
+govuk::apps::cache_clearing_service::rabbitmq_hosts: [rabbitmq]
 
 govuk::apps::ckan::db_hostname: "db-admin"
 govuk::apps::ckan::db_port: 6432

--- a/modules/govuk/manifests/apps/cache_clearing_service.pp
+++ b/modules/govuk/manifests/apps/cache_clearing_service.pp
@@ -12,16 +12,33 @@
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
+# [*rabbitmq_hosts*]
+#   RabbitMQ hosts to connect to.
+#   Default: localhost
+#
+# [*rabbitmq_user*]
+#   RabbitMQ username.
+#   Default: cache_clearing_service
+#
+# [*rabbitmq_password*]
+#   RabbitMQ password.
+#   Default: cache_clearing_service
+#
 class govuk::apps::cache_clearing_service (
   $enabled = false,
   $sentry_dsn = undef,
+  $rabbitmq_hosts = ['localhost'],
+  $rabbitmq_user = 'cache_clearing_service',
+  $rabbitmq_password = 'cache_clearing_service',
 ) {
   $ensure = $enabled ? {
     true  => 'present',
     false => 'absent',
   }
 
-  govuk::app { 'cache-clearing-service':
+  $app_name = 'cache-clearing-service'
+
+  govuk::app { $app_name:
     ensure             => $ensure,
     app_type           => 'bare',
     enable_nginx_vhost => false,
@@ -31,7 +48,13 @@ class govuk::apps::cache_clearing_service (
 
   Govuk::App::Envvar {
     ensure          => $ensure,
-    app             => 'cache-clearing-service',
+    app             => $app_name,
     notify_service  => $enabled,
+  }
+
+  govuk::app::envvar::rabbitmq { $app_name:
+    hosts    => $rabbitmq_hosts,
+    user     => $rabbitmq_user,
+    password => $rabbitmq_password,
   }
 }

--- a/modules/govuk/manifests/apps/cache_clearing_service/rabbitmq.pp
+++ b/modules/govuk/manifests/apps/cache_clearing_service/rabbitmq.pp
@@ -1,0 +1,85 @@
+# == Class: govuk::apps::cache_clearing_service::rabbitmq
+#
+# Permissions for the cache_clearing_service to read messages from
+# the publishing API's AMQP exchange.
+#
+# This sets up the user, and permits read/write/configure
+# to the queue, and read-only to the exchange.
+#
+# === Parameters
+#
+# [*amqp_user*]
+#   The RabbitMQ username (default: 'cache_clearing_service')
+#
+# [*amqp_pass*]
+#   The RabbitMQ password. This is a required parameter.
+#
+# [*amqp_exchange*]
+#   The RabbitMQ exchange to read from (default: 'published_documents')
+#
+# [*amqp_queue*]
+#   The RabbitMQ queue to set up for workers of this type to read from
+#   (default: 'cache_clearing_service')
+#
+class govuk::apps::cache_clearing_service::rabbitmq (
+  $amqp_user  = 'cache_clearing_service',
+  $amqp_pass = undef,
+  $amqp_exchange = 'published_documents',
+  $amqp_queue = 'cache_clearing_service',
+) {
+  govuk_rabbitmq::queue_with_binding { $amqp_queue:
+    ensure        => 'present',
+    amqp_exchange => $amqp_exchange,
+    amqp_queue    => $amqp_queue,
+    routing_key   => '*.major',
+    durable       => true,
+  }
+
+  rabbitmq_binding { "binding_minor_${amqp_exchange}@${amqp_queue}@/":
+    ensure           => 'present',
+    name             => "${amqp_exchange}@${amqp_queue}@minor@/",
+    user             => 'root',
+    password         => $::govuk_rabbitmq::root_password,
+    destination_type => 'queue',
+    routing_key      => '*.minor',
+    arguments        => {},
+  }
+
+  rabbitmq_binding { "binding_links_${amqp_exchange}@${amqp_queue}@/":
+    ensure           => 'present',
+    name             => "${amqp_exchange}@${amqp_queue}@links@/",
+    user             => 'root',
+    password         => $::govuk_rabbitmq::root_password,
+    destination_type => 'queue',
+    routing_key      => '*.links',
+    arguments        => {},
+  }
+
+  rabbitmq_binding { "binding_republish_${amqp_exchange}@${amqp_queue}@/":
+    ensure           => 'present',
+    name             => "${amqp_exchange}@${amqp_queue}@republish@/",
+    user             => 'root',
+    password         => $::govuk_rabbitmq::root_password,
+    destination_type => 'queue',
+    routing_key      => '*.republish',
+    arguments        => {},
+  }
+
+  rabbitmq_binding { "binding_unpublish_${amqp_exchange}@${amqp_queue}@/":
+    ensure           => 'present',
+    name             => "${amqp_exchange}@${amqp_queue}@unpublish@/",
+    user             => 'root',
+    password         => $::govuk_rabbitmq::root_password,
+    destination_type => 'queue',
+    routing_key      => '*.unpublish',
+    arguments        => {},
+  }
+
+  govuk_rabbitmq::consumer { $amqp_user:
+    ensure               => 'present',
+    amqp_pass            => $amqp_pass,
+    read_permission      => "^${amqp_queue}\$",
+    write_permission     => "^\$",
+    configure_permission => "^\$",
+  }
+}


### PR DESCRIPTION
This PR adds the necessary RabbitMQ configuration for cache-clearing-service so it can listen to events.

[Trello Card](https://trello.com/c/Dx3qs8Y6/88-connect-the-cache-clearing-app-up-to-the-message-queue)