### PR TITLE
Logrotate maxsize

### DIFF
--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -301,6 +301,7 @@ define govuk::app::config (
   @logrotate::conf { "govuk-${title}":
     ensure  => $ensure,
     matches => "/var/log/${title}/*.log",
+    maxsize => '500M',
   }
 
   @logrotate::conf { "govuk-${title}-rack":
@@ -308,6 +309,7 @@ define govuk::app::config (
     matches => "/data/vhost/${vhost_full}/shared/log/*.log",
     user    => 'deploy',
     group   => 'deploy',
+    maxsize => '500M',
   }
 
   if $health_check_path != 'NOTSET' {

--- a/modules/logrotate/manifests/conf.pp
+++ b/modules/logrotate/manifests/conf.pp
@@ -40,6 +40,9 @@
 # [*sharedscripts*]
 #   Boolean, sets the sharedscripts option in logrotate
 #
+# [*maxsize*]
+#   Specify the maximum size of a log file before it must get rotated.
+#
 define logrotate::conf (
   $matches,
   $days_to_keep = '31',
@@ -53,6 +56,7 @@ define logrotate::conf (
   $postrotate = undef,
   $rotate_if_empty = false,
   $sharedscripts = false,
+  $maxsize = undef,
 ) {
 
   file { "/etc/logrotate.d/${title}":

--- a/modules/logrotate/templates/logrotate.conf.erb
+++ b/modules/logrotate/templates/logrotate.conf.erb
@@ -33,4 +33,7 @@
     <%= @postrotate %>
   endscript
   <%- end -%>
+  <%- if @maxsize -%>
+  maxsize <%= @maxsize %>
+  <%- end -%>
 }


### PR DESCRIPTION
We had an incident recently where the log files were many GBs because of a bug and that filled the disk space and took out all the other apps on the backend machines.

One suggestion would be to make logrotate work on log sizes as well as the usual daily rotation.

I can't find an application log file bigger than 65 MB currently across all our machine classes which run apps, so 500 MB should mean we never lose daily logs under normal circumstances.

[Docs for `logrotate`](https://manpages.debian.org/jessie/logrotate/logrotate.8.en.html)

[Trello Card](https://trello.com/c/QgUDCI9L/424-rotate-logs-based-on-size)