### PR TITLE
Permit varnish cache purge from 10.1.0.0/16

### DIFF
--- a/modules/varnish/templates/default.vcl.erb
+++ b/modules/varnish/templates/default.vcl.erb
@@ -13,6 +13,7 @@
 
 acl purge_acl {
   "localhost";
+  "10.1.0.0"/16;
 }
 
 sub vcl_recv {


### PR DESCRIPTION
This is so our backend machines can issue specific URL cache purges when a document is (re)published.

https://trello.com/c/f8U7EfUh/427-make-the-new-cache-clearing-app-invalidate-cache-in-varnish