### PR TITLE
Create a Puppet Class for email-alert-api db-admin

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -765,6 +765,8 @@ govuk::node::s_transition_db_admin::apt_mirror_hostname: "%{hiera('apt_mirror_ho
 
 govuk::node::s_warehouse_db_admin::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
+govuk::node::s_email_alert_api_db_admin::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+
 govuk::node::s_whitehall_mysql_master::aws_access_key_id: "%{hiera('govuk::node::s_mysql_backup::aws_access_key_id')}"
 govuk::node::s_whitehall_mysql_master::aws_secret_access_key: "%{hiera('govuk::node::s_mysql_backup::aws_secret_access_key')}"
 govuk::node::s_whitehall_mysql_master::encryption_key: "%{hiera('govuk::node::s_mysql_backup::encryption_key')}"

--- a/hieradata/vagrant_credentials.yaml
+++ b/hieradata/vagrant_credentials.yaml
@@ -175,6 +175,12 @@ govuk::node::s_warehouse_postgresql::s3_bucket_url: 'bucket'
 govuk::node::s_warehouse_postgresql::wale_private_gpg_key: 'key'
 govuk::node::s_warehouse_postgresql::wale_private_gpg_key_fingerprint: 'AIFAED1POOX9MOA3THI9CIE0IEQU7ULAIWEI4SOF'
 
+govuk::node::s_email_alert_api_postgresql::aws_access_key_id: 'foo'
+govuk::node::s_email_alert_api_postgresql::aws_secret_access_key: 'bar'
+govuk::node::s_email_alert_api_postgresql::s3_bucket_url: 'bucket'
+govuk::node::s_email_alert_api_postgresql::wale_private_gpg_key: 'key'
+govuk::node::s_email_alert_api_postgresql::wale_private_gpg_key_fingerprint: 'AIFAED1POOX9MOA3THI9CIE0IEQU7ULAIWEI4SOF'
+
 govuk_jenkins::config::environment_variables:
   ORGANISATION: development
 

--- a/hieradata_aws/class/staging/email_alert_api_db_admin.yaml
+++ b/hieradata_aws/class/staging/email_alert_api_db_admin.yaml
@@ -1,0 +1,11 @@
+govuk_env_sync::tasks:
+  "pull_content_performance_manager_production_daily":
+    hour: "3"
+    minute: "45"
+    action: "pull"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "email-alert-api_production"
+    temppath: "/tmp/email-alert-api_production"
+    url: "govuk-staging-database-backups"
+    path: "email-alert-api-postgresql"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -804,6 +804,8 @@ govuk::node::s_base::log_remote: false
 
 govuk::node::s_db_admin::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
+govuk::node::s_email_alert_api_db_admin::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+
 govuk::node::s_graphite::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 govuk::node::s_licensify_lb::backend_app_servers:

--- a/modules/govuk/manifests/node/s_email_alert_api_db_admin.pp
+++ b/modules/govuk/manifests/node/s_email_alert_api_db_admin.pp
@@ -1,0 +1,102 @@
+# == Class: Govuk_Node::s_email_alert_api_db_admin
+#
+# This machine class is used to administer email-alert-api PostgreSQL RDS instances.
+#
+# === Parameters
+#
+class govuk::node::s_email_alert_api_db_admin(
+  $backup_s3_bucket     = undef,
+  $postgres_host        = undef,
+  $postgres_user        = undef,
+  $postgres_password    = undef,
+  $postgres_port        = '5432',
+  $postgres_backup_hour = 7,
+  $postgres_backup_min  = 30,
+  $apt_mirror_hostname,
+) {
+  include govuk_env_sync
+  include ::govuk::node::s_base
+
+  if $backup_s3_bucket {
+    $ensure = 'present'
+  } else {
+    $ensure = 'absent'
+  }
+
+  apt::source { 'gof3r':
+    ensure       => $ensure,
+    location     => "http://${apt_mirror_hostname}/gof3r",
+    release      => $::lsbdistcodename,
+    architecture => $::architecture,
+    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+  }
+
+  package { 'gof3r':
+    ensure  => $ensure,
+    require => Apt::Source['gof3r'],
+  }
+
+  $alert_hostname = 'alert'
+
+  ### PostgreSQL ###
+
+  $default_connect_settings = {
+    'PGUSER'     => $postgres_user,
+    'PGPASSWORD' => $postgres_password,
+    'PGHOST'     => $postgres_host,
+    'PGPORT'     => $postgres_port,
+  }
+
+  # To manage remote databases using the puppetlabs-postgresql module we require
+  # a local PostgreSQL server instance to be installed
+  class { '::postgresql::server':
+    default_connect_settings => $default_connect_settings,
+  } ->
+
+  # This allows easy administration of the PostgreSQL backend:
+  # https://www.postgresql.org/docs/9.3/static/libpq-pgpass.html
+  file { '/root/.pgpass':
+    ensure  => present,
+    mode    => '0600',
+    content => "${postgres_host}:5432:*:${postgres_user}:${postgres_password}",
+  }
+
+  # This class collects the resources that are exported by the
+  # govuk_postgresql::server::db defined type
+  include ::govuk_postgresql::server::not_slave
+
+  # Ensure the client class is installed
+  class { '::govuk_postgresql::client': } ->
+
+  # include all PostgreSQL classes that create databases and users
+  class { '::govuk::apps::email_alert_api::db': }
+
+  $postgres_backup_desc = 'RDS email-alert-api PostgreSQL backup to S3'
+
+  @@icinga::passive_check { "check_rds_postgres_s3_backup-${::hostname}":
+    ensure              => $ensure,
+    service_description => $postgres_backup_desc,
+    freshness_threshold => 28 * 3600,
+    host_name           => $::fqdn,
+  }
+
+  file { '/usr/local/bin/rds-postgres-to-s3':
+    ensure  => $ensure,
+    content => template('govuk/node/s_db_admin/rds-postgres-to-s3.erb'),
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0775',
+    require => [
+      Package['gof3r'],
+      File['/root/.pgpass'],
+    ],
+  }
+
+  cron::crondotdee { 'rds-email-alert-api-postgres-to-s3':
+    ensure  => $ensure,
+    hour    => $postgres_backup_hour,
+    minute  => $postgres_backup_min,
+    command => '/usr/local/bin/rds-postgres-to-s3',
+    require => File['/usr/local/bin/rds-postgres-to-s3'],
+  }
+}

--- a/modules/govuk/manifests/node/s_email_alert_api_postgresql.pp
+++ b/modules/govuk/manifests/node/s_email_alert_api_postgresql.pp
@@ -1,0 +1,28 @@
+# == Class: govuk::node::s_email_alert_api_postgresql
+#
+# PostgreSQL node for the email-alert-api.
+#
+class govuk::node::s_email_alert_api_postgresql (
+  $aws_access_key_id,
+  $aws_secret_access_key,
+  $s3_bucket_url,
+  $wale_private_gpg_key,
+  $wale_private_gpg_key_fingerprint,
+  $alert_hostname = 'alert.cluster',
+) inherits govuk::node::s_base  {
+  include govuk_env_sync
+  Govuk_mount['/var/lib/postgresql'] -> Class['govuk_postgresql::server::standalone']
+
+  include govuk_postgresql::server::standalone
+  include govuk_postgresql::tuning
+  include govuk::apps::email_alert_api::db
+
+  govuk_postgresql::wal_e::backup { $title:
+    aws_access_key_id                => $aws_access_key_id,
+    aws_secret_access_key            => $aws_secret_access_key,
+    s3_bucket_url                    => $s3_bucket_url,
+    wale_private_gpg_key             => $wale_private_gpg_key,
+    wale_private_gpg_key_fingerprint => $wale_private_gpg_key_fingerprint,
+    alert_hostname                   => $alert_hostname,
+  }
+}

--- a/modules/hosts/manifests/purge.pp
+++ b/modules/hosts/manifests/purge.pp
@@ -16,6 +16,7 @@ class hosts::purge {
   # eg hosts that are only present in AWS
   $whitelist = [
     'db-admin-1',
+    'email-alert-api-postgresql',
   ]
 
   if ! ($::hostname in $whitelist) {


### PR DESCRIPTION
- This change creates a puppet class to manage email-alert-api db-admin
instances.

https://trello.com/c/ljsMBGQ4/1419-split-email-alert-api-into-its-own-rds-instance

Solo: @suthagarht