### PR TITLE
Fix typo in hieradata for government-frontend

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -463,9 +463,9 @@ govuk::apps::frontend::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::frontend::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::frontend::unicorn_worker_processes: "4"
 
-govuk::apps::government-frontend::nagios_memory_warning: 1800
-govuk::apps::government-frontend::nagios_memory_critical: 2000
-govuk::apps::government-frontend::unicorn_worker_processes: "8"
+govuk::apps::government_frontend::nagios_memory_warning: 1800
+govuk::apps::government_frontend::nagios_memory_critical: 2000
+govuk::apps::government_frontend::unicorn_worker_processes: "8"
 
 govuk::apps::kibana::logit_account: 1c6b2316-16e2-4ca5-a3df-ff18631b0e74
 


### PR DESCRIPTION
https://trello.com/c/vticNyhn/233-fix-government-frontend-unicorn

The variables were incorrectly using a hyphen in 'government-frontend',
instead of an underscore, which is what the module is expecting.