### PR TITLE
Remove gds api adapters cache

### DIFF
--- a/modules/govuk/manifests/app.pp
+++ b/modules/govuk/manifests/app.pp
@@ -227,11 +227,6 @@
 # [*cpu_critical*]
 #   CPU usage percentage that alerts are sounded at
 #
-# [*cache_api_calls*]
-#   Control whether the app uses the in-memory cache that comes with
-#   GDS API adapters.
-#   Default: false
-#
 define govuk::app (
   $app_type,
   $port = 0,
@@ -265,7 +260,6 @@ define govuk::app (
   $unicorn_worker_processes = undef,
   $cpu_warning = 150,
   $cpu_critical = 200,
-  $cache_api_calls = false,
 ) {
 
   if ! ($app_type in ['procfile', 'rack', 'bare']) {
@@ -338,7 +332,6 @@ define govuk::app (
     unicorn_worker_processes       => $unicorn_worker_processes,
     cpu_warning                    => $cpu_warning,
     cpu_critical                   => $cpu_critical,
-    cache_api_calls                => $cache_api_calls,
   }
 
   govuk::app::service { $title:

--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -32,11 +32,6 @@
 # [*cpu_critical*]
 #   CPU usage percentage that alerts are sounded at
 #
-# [*cache_api_calls*]
-#   Control whether the app uses the in-memory cache that comes with
-#   GDS API adapters.
-#   Default: false
-#
 define govuk::app::config (
   $app_type,
   $domain,
@@ -69,7 +64,6 @@ define govuk::app::config (
   $cpu_warning = 150,
   $cpu_critical = 200,
   $alert_when_threads_exceed = 100,
-  $cache_api_calls = false,
 ) {
   $ensure_directory = $ensure ? {
     'present' => 'directory',
@@ -146,18 +140,6 @@ define govuk::app::config (
       "${title}-SENTRY_DSN":
         varname => 'SENTRY_DSN',
         value   => $sentry_dsn;
-    }
-
-    if $cache_api_calls {
-      $ensure_disable_cache_var = 'absent'
-    } else {
-      $ensure_disable_cache_var = 'present'
-    }
-
-    govuk::app::envvar { "${title}-GDS_API_DISABLE_CACHE":
-      ensure  => $ensure_disable_cache_var,
-      varname => 'GDS_API_DISABLE_CACHE',
-      value   => "${!cache_api_calls_final}",
     }
 
     if $::govuk_node_class !~ /^development$/ {


### PR DESCRIPTION
This has no effect now as the cache has been disabled.

This depends on https://github.com/alphagov/gds-api-adapters/pull/848.

[Trello Card](https://trello.com/c/0HSDBjNk/398-remove-gds-api-adapters-cache)