### PR TITLE
Create en email-alert-api postgresql class

### DIFF
--- a/hieradata/vagrant_credentials.yaml
+++ b/hieradata/vagrant_credentials.yaml
@@ -175,6 +175,12 @@ govuk::node::s_warehouse_postgresql::s3_bucket_url: 'bucket'
 govuk::node::s_warehouse_postgresql::wale_private_gpg_key: 'key'
 govuk::node::s_warehouse_postgresql::wale_private_gpg_key_fingerprint: 'AIFAED1POOX9MOA3THI9CIE0IEQU7ULAIWEI4SOF'
 
+govuk::node::s_email_alert_api_postgresql::aws_access_key_id: 'foo'
+govuk::node::s_email_alert_api_postgresql::aws_secret_access_key: 'bar'
+govuk::node::s_email_alert_api_postgresql::s3_bucket_url: 'bucket'
+govuk::node::s_email_alert_api_postgresql::wale_private_gpg_key: 'key'
+govuk::node::s_email_alert_api_postgresql::wale_private_gpg_key_fingerprint: 'AIFAED1POOX9MOA3THI9CIE0IEQU7ULAIWEI4SOF'
+
 govuk_jenkins::config::environment_variables:
   ORGANISATION: development
 

--- a/hieradata_aws/class/staging/email_alert_api_db_admin.yaml
+++ b/hieradata_aws/class/staging/email_alert_api_db_admin.yaml
@@ -1,0 +1,11 @@
+govuk_env_sync::tasks:
+  "pull_content_performance_manager_production_daily":
+    hour: "3"
+    minute: "45"
+    action: "pull"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "email-alert-api_production"
+    temppath: "/tmp/email-alert-api_production"
+    url: "govuk-staging-database-backups"
+    path: "email-alert-api-postgresql"

--- a/modules/govuk/manifests/node/s_email_alert_api_postgresql.pp
+++ b/modules/govuk/manifests/node/s_email_alert_api_postgresql.pp
@@ -1,0 +1,28 @@
+# == Class: govuk::node::s_email_alert_api_postgresql
+#
+# PostgreSQL node for the email-alert-api.
+#
+class govuk::node::s_email_alert_api_postgresql (
+  $aws_access_key_id,
+  $aws_secret_access_key,
+  $s3_bucket_url,
+  $wale_private_gpg_key,
+  $wale_private_gpg_key_fingerprint,
+  $alert_hostname = 'alert.cluster',
+) inherits govuk::node::s_base  {
+  include govuk_env_sync
+  Govuk_mount['/var/lib/postgresql'] -> Class['govuk_postgresql::server::standalone']
+
+  include govuk_postgresql::server::standalone
+  include govuk_postgresql::tuning
+  include govuk::apps::content_performance_manager::db
+
+  govuk_postgresql::wal_e::backup { $title:
+    aws_access_key_id                => $aws_access_key_id,
+    aws_secret_access_key            => $aws_secret_access_key,
+    s3_bucket_url                    => $s3_bucket_url,
+    wale_private_gpg_key             => $wale_private_gpg_key,
+    wale_private_gpg_key_fingerprint => $wale_private_gpg_key_fingerprint,
+    alert_hostname                   => $alert_hostname,
+  }
+}


### PR DESCRIPTION
- This commit covers changes related to email-alert-api postgresql.

https://trello.com/c/ljsMBGQ4/1419-split-email-alert-api-into-its-own-rds-instance

Solo: @suthagarht