### PR TITLE
Update content data api dashboard

### DIFF
--- a/modules/grafana/files/dashboards/content-data-api.json
+++ b/modules/grafana/files/dashboards/content-data-api.json
@@ -1,13 +1,14 @@
 {
-  "id": 5,
-  "title": "Content Data API - monitor",
-  "originalTitle": "Content Data API - monitor",
-  "tags": [],
-  "style": "dark",
-  "timezone": "browser",
+  "annotations": {
+    "list": []
+  },
   "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
   "hideControls": false,
-  "sharedCrosshair": false,
+  "id": 5,
+  "links": [],
+  "refresh": false,
   "rows": [
     {
       "collapse": false,
@@ -699,41 +700,16 @@
       "titleSize": "h6"
     }
   ],
-  "time": {
-    "from": "now-24h",
-    "to": "now"
-  },
-  "timepicker": {
-    "refresh_intervals": [
-      "5s",
-      "10s",
-      "30s",
-      "1m",
-      "5m",
-      "15m",
-      "30m",
-      "1h",
-      "2h",
-      "1d"
-    ],
-    "time_options": [
-      "5m",
-      "15m",
-      "1h",
-      "6h",
-      "12h",
-      "24h",
-      "2d",
-      "7d",
-      "30d"
-    ]
-  },
+  "schemaVersion": 14,
+  "style": "dark",
+  "tags": [],
   "templating": {
     "list": [
       {
         "auto": false,
+        "auto_count": 30,
+        "auto_min": "10s",
         "current": {
-          "tags": [],
           "text": "1m",
           "value": "1m"
         },
@@ -811,16 +787,41 @@
           }
         ],
         "query": "1s,10s,30s,1m,10m,30m,1h,6h,12h,1d,7d,14d,30d",
-        "refresh": 0,
+        "refresh": 2,
         "type": "interval"
       }
     ]
   },
-  "annotations": {
-    "list": []
+  "time": {
+    "from": "now-24h",
+    "to": "now"
   },
-  "refresh": false,
-  "schemaVersion": 12,
-  "version": 3,
-  "links": []
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "browser",
+  "title": "Content Data API - monitor",
+  "version": 3
 }

--- a/modules/grafana/files/dashboards/content-data-api.json
+++ b/modules/grafana/files/dashboards/content-data-api.json
@@ -319,7 +319,7 @@
           "targets": [
             {
               "refId": "A",
-              "target": "integral(stats_counts.govuk.app.content-performance-manager.*.monitor.etl.daily.satisfaction_score.select metric)",
+              "target": "integral(stats_counts.govuk.app.content-performance-manager.*.monitor.etl.daily.satisfaction_score)",
               "textEditor": true
             }
           ],
@@ -479,7 +479,7 @@
           "targets": [
             {
               "refId": "A",
-              "target": "integral(stats_counts.govuk.app.content-performance-manager.*.monitor.etl.daily.number_of_pdfs)",
+              "target": "integral(stats_counts.govuk.app.content-performance-manager.*.monitor.etl.edition.number_of_pdfs)",
               "textEditor": true
             }
           ],
@@ -639,7 +639,7 @@
           "targets": [
             {
               "refId": "A",
-              "target": "feedex_comments",
+              "target": "integral(stats_counts.govuk.app.content-performance-manager.*.monitor.etl.daily.feedex_comments)",
               "textEditor": true
             }
           ],


### PR DESCRIPTION
[Trello card](https://trello.com/c/XSVkcFvP/616-etl-monitor-add-data-about-acquisition-metrics)

Updates Grafana targets for `number_of_issues` and `number_of_pdfs`