### PR TITLE
Raise disk-time warning threshold on asset-master

### DIFF
--- a/hieradata_aws/class/integration/asset_master.yaml
+++ b/hieradata_aws/class/integration/asset_master.yaml
@@ -1,0 +1,2 @@
+icinga::client::checks::disk_time_warn: 350 # milliseconds
+icinga::client::checks::disk_time_critical: 450 # milliseconds


### PR DESCRIPTION
- The clamscan process exceeds the default disk-time threshold of 200 ms
  for a critical warning by default.

- Setting 350 ms warning, 450 ms critical for disk-time monitoring

solo @schmie