### PR TITLE
Revert "Disable gds api adapters cache everywhere"

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -341,6 +341,8 @@ filebeat::prospectors:
 
 gdal::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
+govuk_app_cache_api_calls: false
+
 govuk::apps::asset_manager::mongodb_nodes:
   - 'mongo-1.backend'
   - 'mongo-2.backend'

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -71,6 +71,8 @@ base::supported_kernel::enabled: false
 
 environment_ip_prefix: '10.3'
 
+govuk_app_cache_api_calls: true
+
 govuk::apps::asset_manager::aws_s3_bucket_name: 'govuk-assets-production'
 govuk::apps::asset_manager::aws_region: 'eu-west-1'
 govuk::apps::ckan::ckan_site_url: 'https://ckan.publishing.service.gov.uk'

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -356,6 +356,8 @@ filebeat::prospectors:
 
 gdal::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
+govuk_app_cache_api_calls: false
+
 govuk::apps::asset_manager::mongodb_nodes:
   - 'mongo-1'
   - 'mongo-2'

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -9,6 +9,8 @@ base::supported_kernel::enabled: false
 
 cron::daily_hour: 6
 
+govuk_app_cache_api_calls: true
+
 govuk::apps::asset_manager::aws_s3_bucket_name: 'govuk-assets-production'
 govuk::apps::asset_manager::aws_region: 'eu-west-1'
 govuk::apps::content_publisher::aws_s3_bucket: "govuk-production-content-publisher-activestorage"

--- a/lib/puppet-lint/plugins/check_hiera.rb
+++ b/lib/puppet-lint/plugins/check_hiera.rb
@@ -34,6 +34,9 @@ PuppetLint.new_check(:hiera_explicit_lookup) do
     'govuk_mount::no_op',
     'govuk_lvm::no_op',
 
+    # This is temporary to allow us to set this across all apps in different environments
+    'govuk_app_cache_api_calls',
+
     # govuk::app::nginx_vhost defined type needs a global disable flag for
     # asset pipeline on dev vm
     'govuk::app::nginx_vhost::asset_pipeline_enabled',

--- a/modules/govuk/manifests/app.pp
+++ b/modules/govuk/manifests/app.pp
@@ -230,7 +230,7 @@
 # [*cache_api_calls*]
 #   Control whether the app uses the in-memory cache that comes with
 #   GDS API adapters.
-#   Default: false
+#   Default: undef
 #
 define govuk::app (
   $app_type,
@@ -265,7 +265,7 @@ define govuk::app (
   $unicorn_worker_processes = undef,
   $cpu_warning = 150,
   $cpu_critical = 200,
-  $cache_api_calls = false,
+  $cache_api_calls = undef,
 ) {
 
   if ! ($app_type in ['procfile', 'rack', 'bare']) {

--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -35,7 +35,7 @@
 # [*cache_api_calls*]
 #   Control whether the app uses the in-memory cache that comes with
 #   GDS API adapters.
-#   Default: false
+#   Default: undef
 #
 define govuk::app::config (
   $app_type,
@@ -69,7 +69,7 @@ define govuk::app::config (
   $cpu_warning = 150,
   $cpu_critical = 200,
   $alert_when_threads_exceed = 100,
-  $cache_api_calls = false,
+  $cache_api_calls = undef,
 ) {
   $ensure_directory = $ensure ? {
     'present' => 'directory',
@@ -148,7 +148,9 @@ define govuk::app::config (
         value   => $sentry_dsn;
     }
 
-    if $cache_api_calls {
+    $cache_api_calls_final = pick($cache_api_calls, hiera('govuk_app_cache_api_calls', true))
+
+    if $cache_api_calls_final {
       $ensure_disable_cache_var = 'absent'
     } else {
       $ensure_disable_cache_var = 'present'


### PR DESCRIPTION
Reverts alphagov/govuk-puppet#8036

Just in case... this will make the PR ready to merge quickly by already running the tests on CI.