### PR TITLE
Add spurious errors encountered in pg databases

### DIFF
--- a/modules/govuk_env_sync/files/govuk_env_sync.sh
+++ b/modules/govuk_env_sync/files/govuk_env_sync.sh
@@ -56,7 +56,7 @@ function filter_pg_stderr {
   # This function filters out the known errors and triggers exit 1 if encountering a different error.
   #
   # This reads the postgres stderr errors identified by the "Command was:" string into an array
-  IFS="--" read -r -a pg_errors <<< "$( echo "${pg_stderr}" | grep -B 1 "Command was:" | tr -d "\\n" )"
+  IFS="#" read -r -a pg_errors <<< "$( echo "${pg_stderr}" | grep -B 1 "Command was:" | tr -d "\\n" | sed s/--/#/g)"
   for pg_error in "${pg_errors[@]}"
   do
     # The removal of the newlines in grep output above causes unset array elements, filter those
@@ -70,6 +70,8 @@ function filter_pg_stderr {
         b863dfa39e930334d9163a9a3e4269b18bfd363cf25e894e0b35d512d98581c4);;
         a5b0047fcfeb0e0a57fd8750ebc28808f4ed407bae59c4644e8c8614b5d3a079);;
         a6028cd4e6e01ccda0bb415e2a66b7a2ca5cef8c469ca0ef4b3de0bdb954dde1);;
+        a24d3736ce830147868c0cea77f0935dc5d7b8137ac16396a63ad96b44b16520);;
+        54df370bdbba3aa3badc2b0841b106267ec38c69d89eb600aeee6aa391369571);;
         *)
           log "Error running \"$0 ${args[*]:-''}\" in function ${FUNCNAME[1]} on line $1 executing \"${BASH_COMMAND}\"" "user.err"
           log "${pg_error}" "user.err"


### PR DESCRIPTION
- email-alert-api add different COMMENT lines / uses different
extensions than other databases, these create warnings we have to handle
manually

- Also changed the array separator used to avoid clashes with use of
hypens in the data set/pg errors.

solo @schmie