### PR TITLE
Add link to rummager queue latency alert

### DIFF
--- a/modules/monitoring/manifests/checks/sidekiq.pp
+++ b/modules/monitoring/manifests/checks/sidekiq.pp
@@ -21,7 +21,7 @@ class monitoring::checks::sidekiq (
     # seconds per datapoint is the last 3 minutes
     args                => '--dropfirst -36',
     host_name           => $::fqdn,
-    desc                => 'check rummager queue latency [in office hours]',
+    desc                => 'Rummager Sidekiq queue latency',
     notification_period => 'inoffice',
     notes_url           => monitoring_docs_url(rummager-queue-latency),
   }

--- a/modules/monitoring/manifests/checks/sidekiq.pp
+++ b/modules/monitoring/manifests/checks/sidekiq.pp
@@ -23,6 +23,7 @@ class monitoring::checks::sidekiq (
     host_name           => $::fqdn,
     desc                => 'check rummager queue latency [in office hours]',
     notification_period => 'inoffice',
+    notes_url           => monitoring_docs_url(rummager-queue-latency),
   }
 
   icinga::check::graphite { 'check_signon_queue_sizes':


### PR DESCRIPTION
And improve the description. Page created in https://github.com/alphagov/govuk-developer-docs/pull/1151.