### PR TITLE
Provide platform-specific config for node lookup

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -359,6 +359,7 @@ govuk::apps::bouncer::nagios_memory_critical: 1500
 govuk::apps::bouncer::unicorn_worker_processes: "8"
 
 govuk::apps::cache_clearing_service::enabled: true
+govuk::apps::cache_clearing_service::puppetdb_node_url: 'http://puppetdb.cluster/v2/nodes'
 govuk::apps::cache_clearing_service::rabbitmq_hosts:
   - rabbitmq-1.backend
   - rabbitmq-2.backend

--- a/modules/govuk/manifests/apps/cache_clearing_service.pp
+++ b/modules/govuk/manifests/apps/cache_clearing_service.pp
@@ -24,12 +24,16 @@
 #   RabbitMQ password.
 #   Default: cache_clearing_service
 #
+# [*puppetdb_node_url*]
+#   The `nodes` endpoint URL for Puppet DB
+#
 class govuk::apps::cache_clearing_service (
   $enabled = false,
   $sentry_dsn = undef,
   $rabbitmq_hosts = ['localhost'],
   $rabbitmq_user = 'cache_clearing_service',
   $rabbitmq_password = 'cache_clearing_service',
+  $puppetdb_node_url = undef,
 ) {
   $ensure = $enabled ? {
     true  => 'present',
@@ -56,5 +60,17 @@ class govuk::apps::cache_clearing_service (
     hosts    => $rabbitmq_hosts,
     user     => $rabbitmq_user,
     password => $rabbitmq_password,
+  }
+
+  if $::aws_migration {
+    govuk::app::envvar { "${title}-AWS_STACKNAME":
+      varname => 'AWS_STACKNAME',
+      value   => $::aws_stackname;
+    }
+  } else {
+    govuk::app::envvar { "${title}-PUPPETDB_NODE_URL":
+      varname => 'PUPPETDB_NODE_URL',
+      value   => $puppetdb_node_url;
+    }
   }
 }


### PR DESCRIPTION
This config is used by `cache-clearing-service` to look up cache nodes
dynamically in order to clear varnish caches.

https://trello.com/c/f8U7EfUh/427-make-the-new-cache-clearing-app-invalidate-cache-in-varnish