### PR TITLE
Set a default cache-clearing-service RabbitMQ password

### DIFF
--- a/modules/govuk/manifests/apps/cache_clearing_service/rabbitmq.pp
+++ b/modules/govuk/manifests/apps/cache_clearing_service/rabbitmq.pp
@@ -23,7 +23,7 @@
 #
 class govuk::apps::cache_clearing_service::rabbitmq (
   $amqp_user  = 'cache_clearing_service',
-  $amqp_pass = undef,
+  $amqp_pass = 'cache_clearing_service',
   $amqp_exchange = 'published_documents',
   $amqp_queue = 'cache_clearing_service',
 ) {


### PR DESCRIPTION
When we added this service, we copied the puppet configuration for content-performance-manager which is unusual in that it doesn't set a default password for RabbitMQ. Every other service does, and this is currently preventing Puppet from running, so I've added one here.

In production, the password comes from the secrets in hieradata.