### PR TITLE
Improve the CPU row on the Machine dashboard

### DIFF
--- a/modules/grafana/files/dashboards/machine.json
+++ b/modules/grafana/files/dashboards/machine.json
@@ -133,7 +133,7 @@
           "datasource": "Graphite",
           "editable": true,
           "error": false,
-          "fill": 1,
+          "fill": 0,
           "grid": {},
           "id": 1,
           "legend": {
@@ -153,7 +153,12 @@
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
-          "seriesOverrides": [],
+          "seriesOverrides": [
+            {
+              "alias": "/user/",
+              "linewidth": 2
+            }
+          ],
           "spaceLength": 10,
           "span": 12,
           "stack": false,
@@ -543,7 +548,13 @@
       },
       {
         "allValue": "*",
-        "current": {},
+        "current": {
+          "text": "cpu-system + cpu-user",
+          "value": [
+            "cpu-system",
+            "cpu-user"
+          ]
+        },
         "datasource": "Graphite",
         "hide": 0,
         "includeAll": true,


### PR DESCRIPTION
Still very much a work in progress, but display less data (just the
system and user stats), and make the user line a bit thicker than the
system line.

# Before

![cpu-before](https://user-images.githubusercontent.com/1130010/44917228-b960d800-ad2f-11e8-92a9-9ade5fcb9fa3.png)

# After 

![cpu-after](https://user-images.githubusercontent.com/1130010/44917235-be258c00-ad2f-11e8-9901-495e7433b2e2.png)
