### PR TITLE
Add local DNS caching to Carrenza staging cache machines

### DIFF
--- a/hieradata/class/staging/cache.yaml
+++ b/hieradata/class/staging/cache.yaml
@@ -1,0 +1,1 @@
+nscd::config::dns_cache: 'yes'

--- a/modules/govuk/manifests/node/s_cache.pp
+++ b/modules/govuk/manifests/node/s_cache.pp
@@ -43,6 +43,7 @@ class govuk::node::s_cache (
 
   include govuk_htpasswd
   include router::gor
+  include nscd
 
   if $router_as_container {
     include ::govuk_containers::apps::router

--- a/modules/nscd/manifests/config.pp
+++ b/modules/nscd/manifests/config.pp
@@ -1,0 +1,17 @@
+# == Class: nscd::config
+#
+# === Parameters:
+#
+class nscd::config (
+  $dns_cache = 'no',
+) {
+
+  file { '/etc/nscd.conf':
+    ensure  => file,
+    content => template('nscd/nscd_config.erb'),
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+  }
+
+}

--- a/modules/nscd/manifests/init.pp
+++ b/modules/nscd/manifests/init.pp
@@ -1,0 +1,24 @@
+# == Class: nscd
+class nscd {
+
+  anchor { 'nscd::begin':
+    notify => Class['nscd::service'];
+  }
+
+  class { 'nscd::package':
+    require => Anchor['nscd::begin'],
+    notify  => Class['nscd::service'];
+  }
+
+  class { 'nscd::config':
+    require => Class['nscd::package'],
+    notify  => Class['nscd::service'];
+  }
+
+  class { 'nscd::service': }
+
+  anchor { 'nscd::end':
+    require => Class['nscd::service'],
+  }
+
+}

--- a/modules/nscd/manifests/package.pp
+++ b/modules/nscd/manifests/package.pp
@@ -1,0 +1,11 @@
+# == Class: nscd::package
+#
+# Install packages to set up nscd on a machine.
+#
+class nscd::package {
+
+  package { 'nscd':
+    ensure => present,
+  }
+
+}

--- a/modules/nscd/manifests/service.pp
+++ b/modules/nscd/manifests/service.pp
@@ -1,0 +1,8 @@
+# == Class: nscd::service
+class nscd::service {
+
+  service { 'nscd':
+    ensure => running,
+  }
+
+}

--- a/modules/nscd/templates/nscd_config.erb
+++ b/modules/nscd/templates/nscd_config.erb
@@ -1,0 +1,90 @@
+#
+# /etc/nscd.conf
+#
+# An example Name Service Cache config file.  This file is needed by nscd.
+#
+# Legal entries are:
+#
+#	logfile			<file>
+#	debug-level		<level>
+#	threads			<initial #threads to use>
+#	max-threads		<maximum #threads to use>
+#	server-user             <user to run server as instead of root>
+#		server-user is ignored if nscd is started with -S parameters
+#       stat-user               <user who is allowed to request statistics>
+#	reload-count		unlimited|<number>
+#	paranoia		<yes|no>
+#	restart-interval	<time in seconds>
+#
+#       enable-cache		<service> <yes|no>
+#	positive-time-to-live	<service> <time in seconds>
+#	negative-time-to-live   <service> <time in seconds>
+#       suggested-size		<service> <prime number>
+#	check-files		<service> <yes|no>
+#	persistent		<service> <yes|no>
+#	shared			<service> <yes|no>
+#	max-db-size		<service> <number bytes>
+#	auto-propagate		<service> <yes|no>
+#
+# Currently supported cache names (services): passwd, group, hosts, services
+#
+
+
+#	logfile			/var/log/nscd.log
+#	threads			4
+#	max-threads		32
+#	server-user		nobody
+#	stat-user		somebody
+	debug-level		8
+#	reload-count		5
+	paranoia		no
+#	restart-interval	3600
+
+	enable-cache		passwd		no
+	positive-time-to-live	passwd		600
+	negative-time-to-live	passwd		20
+	suggested-size		passwd		211
+	check-files		passwd		yes
+	persistent		passwd		yes
+	shared			passwd		yes
+	max-db-size		passwd		33554432
+	auto-propagate		passwd		yes
+
+	enable-cache		group		no
+	positive-time-to-live	group		3600
+	negative-time-to-live	group		60
+	suggested-size		group		211
+	check-files		group		yes
+	persistent		group		yes
+	shared			group		yes
+	max-db-size		group		33554432
+	auto-propagate		group		yes
+
+	enable-cache		hosts		<%= @dns_cache %>
+	positive-time-to-live	hosts		3600
+	negative-time-to-live	hosts		20
+	suggested-size		hosts		211
+	check-files		hosts		yes
+	persistent		hosts		yes
+	shared			hosts		yes
+	max-db-size		hosts		33554432
+
+	enable-cache		services	no
+	positive-time-to-live	services	28800
+	negative-time-to-live	services	20
+	suggested-size		services	211
+	check-files		services	yes
+	persistent		services	yes
+	shared			services	yes
+	max-db-size		services	33554432
+
+# netgroup caching is known-broken, so disable it in the default config,
+# see: https://bugs.launchpad.net/ubuntu/+source/eglibc/+bug/1068889
+	enable-cache		netgroup	no
+	positive-time-to-live	netgroup	28800
+	negative-time-to-live	netgroup	20
+	suggested-size		netgroup	211
+	check-files		netgroup	yes
+	persistent		netgroup	yes
+	shared			netgroup	yes
+	max-db-size		netgroup	33554432


### PR DESCRIPTION
We want to cache DNS request during trafic replay so as not to overwhelm the resolver on which cache machines depend. 