### PR TITLE
Slightly increase the number of unicorn processes for content-store

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -417,9 +417,9 @@ govuk::apps::content_publisher::db::backend_ip_range: "%{hiera('environment_ip_p
 govuk::apps::content_publisher::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
 govuk::apps::content_publisher::aws_region: "eu-west-1"
 
-govuk::apps::content_store::nagios_memory_warning: 2300
-govuk::apps::content_store::nagios_memory_critical: 2500
-govuk::apps::content_store::unicorn_worker_processes: "6"
+govuk::apps::content_store::nagios_memory_warning: 2600
+govuk::apps::content_store::nagios_memory_critical: 2800
+govuk::apps::content_store::unicorn_worker_processes: "8"
 
 govuk::apps::content_tagger::db_hostname: "postgresql-primary-1.backend"
 govuk::apps::content_tagger::db_port: 6432


### PR DESCRIPTION
Since we've disabled caching, we're seeing a slight increase in the number of requests to content-store. To cope with potential future load, I thought it would be a good idea to increase the number of unicorn workers.

[Trello Card](https://trello.com/c/0HSDBjNk/398-remove-gds-api-adapters-cache)