### PR TITLE
Add import job for content publisher

### DIFF
--- a/hieradata_aws/class/integration/jenkins.yaml
+++ b/hieradata_aws/class/integration/jenkins.yaml
@@ -4,3 +4,6 @@ govuk_jenkins::config::banner_colour_text: 'white'
 govuk_jenkins::config::theme_colour: '#005EA5'
 govuk_jenkins::config::theme_text_colour: 'white'
 govuk_jenkins::config::theme_environment_name: 'AWS Integration'
+
+govuk_jenkins::job_builder::jobs:
+  - govuk_jenkins::jobs::content_publisher_whitehall_import

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -56,6 +56,7 @@ govuk_elasticsearch::dump::run_es_dump_hour: '9'
 govuk_jenkins::job_builder::environment: 'integration'
 govuk_jenkins::config::executors: '8'
 
+govuk_jenkins::jobs::content_publisher_whitehall_import::enable_slack_notifications: true
 govuk_jenkins::jobs::deploy_dns::gce_project_id: 'govuk-integration'
 govuk_jenkins::jobs::deploy_dns::zones:
   - 'dnstest.alphagov.co.uk'

--- a/modules/govuk_jenkins/manifests/jobs/content_publisher_whitehall_import.pp
+++ b/modules/govuk_jenkins/manifests/jobs/content_publisher_whitehall_import.pp
@@ -1,0 +1,18 @@
+# == Class: govuk_jenkins::jobs::content_publisher_whitehall_import
+#
+# Create a file on disk that can be parsed by jenkins-job-builder
+#
+class govuk_jenkins::jobs::content_publisher_whitehall_import (
+  $enable_slack_notifications = false,
+  $app_domain = hiera('app_domain'),
+) {
+  $slack_team_domain = 'gds'
+  $slack_room = 'govuk-pubworkflow-dev'
+  $slack_build_server_url = "https://deploy.${app_domain}/"
+
+  file { '/etc/jenkins_jobs/jobs/content_publisher_whitehall_import.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/content_publisher_whitehall_import.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+}

--- a/modules/govuk_jenkins/templates/jobs/content_publisher_whitehall_import.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/content_publisher_whitehall_import.yaml.erb
@@ -1,0 +1,34 @@
+---
+- job:
+    name: content-publisher-whitehall-import
+    display-name: Content Publisher Whitehall Import
+    project-type: freestyle
+    description: "Import documents from Whitehall into Content Publisher"
+    logrotate:
+      numToKeep: 10
+    properties:
+      - build-discarder:
+          days-to-keep: 30
+          artifact-num-to-keep: 5
+    builders:
+       - shell: |
+           ssh deploy@$(govuk_node_list -c whitehall_backend --single-node) 'cd /data/apps/whitehall/current; govuk_setenv whitehall bundle exec rake export:news_documents 2>&1' |
+           grep created_at |
+           ssh deploy@$(govuk_node_list -c backend --single-node) 'cd /data/apps/content-publisher/current; govuk_setenv content-publisher bundle exec rake import:whitehall_news'
+    publishers:
+      <% if @enable_slack_notifications %>
+      - slack:
+          team-domain: <%= @slack_team_domain %>
+          auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN'] %>
+          build-server-url: <%= @slack_build_server_url %>
+          notify-start: false
+          notify-success: true
+          notify-aborted: false
+          notify-notbuilt: false
+          notify-unstable: false
+          notify-failure: true
+          notify-backtonormal: true
+          notify-repeatedfailure: true
+          include-test-summary: false
+          room: <%= @slack_room %>
+      <% end %>

--- a/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
@@ -40,5 +40,6 @@
                 TARGET_APPLICATION=whitehall
                 MACHINE_CLASS=whitehall_backend
                 RAKE_TASK=publishing:scheduled:requeue_all_jobs
+            - project: content-publisher-whitehall-import
         - email:
             recipients: govuk-ci-notifications@digital.cabinet-office.gov.uk


### PR DESCRIPTION
https://trello.com/c/ORACsrIh/172-create-a-jenkins-job-to-update-integration-content-publisher-with-whitehall-content

This commit adds a Jenkins job to stream documents from Whitehall into
Content Publisher over an SSH pipe, on integration only. This means we
can regularly test importing data as part of the lifecycle of the
application, and also preview the app with realistic data.

For some reason the combination of commands on the Whitehall machine
makes all the output go to STDERR. That and the unwanted logging sniffer
output means we use grep to filter for the lines which contain a valid
document export. Although somewhat hacky, this is only a temporary job.