### PR TITLE
Add CKAN cronjob to import analytics data

### DIFF
--- a/modules/govuk/manifests/apps/ckan/cronjobs.pp
+++ b/modules/govuk/manifests/apps/ckan/cronjobs.pp
@@ -14,4 +14,10 @@ class govuk::apps::ckan::cronjobs {
     hour           => '2',
   }
 
+  govuk::apps::ckan::paster_cronjob { 'analytics import':
+    paster_command => 'loadanalytics latest',
+    plugin         => 'ckanext-ga-report',
+    hour           => '1',
+  }
+
 }


### PR DESCRIPTION
Adds a cron job to incrementally import data from Google Analytics into CKAN each night.

Trello card: https://trello.com/c/HQv5xUBu/33-setup-site-analytics-extension-05-days-spike-to-determine-the-approach