### PR TITLE
Fix putting CI job in wrong hieradata

### DIFF
--- a/hieradata_aws/class/integration/jenkins.yaml
+++ b/hieradata_aws/class/integration/jenkins.yaml
@@ -4,6 +4,3 @@ govuk_jenkins::config::banner_colour_text: 'white'
 govuk_jenkins::config::theme_colour: '#005EA5'
 govuk_jenkins::config::theme_text_colour: 'white'
 govuk_jenkins::config::theme_environment_name: 'AWS Integration'
-
-govuk_jenkins::job_builder::jobs:
-  - govuk_jenkins::jobs::content_publisher_whitehall_import

--- a/hieradata_aws/class/jenkins.yaml
+++ b/hieradata_aws/class/jenkins.yaml
@@ -62,6 +62,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::clear_template_cache
   - govuk_jenkins::jobs::clear_varnish_cache
   - govuk_jenkins::jobs::configure_github_repos
+  - govuk_jenkins::jobs::content_publisher_whitehall_import
   - govuk_jenkins::jobs::data_sync
   - govuk_jenkins::jobs::data_sync_complete_integration
   - govuk_jenkins::jobs::deploy_app


### PR DESCRIPTION
https://trello.com/c/ORACsrIh/172-create-a-jenkins-job-to-update-integration-content-publisher-with-whitehall-content

This was added due to confusion about how jobs need to be specified for
CI in each environment. Accidentally listing the job for the integration
environment caused all the other jobs to be removed; this should
actually have been put in the top-level jenkins config.