### PR TITLE
Re-enable CKAN in staging

### DIFF
--- a/hieradata/class/staging/ckan.yaml
+++ b/hieradata/class/staging/ckan.yaml
@@ -1,3 +1,3 @@
 ---
 
-govuk::apps::ckan::enabled: false
+govuk::apps::ckan::enabled: true


### PR DESCRIPTION
The issue with postgres connections which we saw previously
may have been resolved by the use of pgbouncer, so we're
re-enabling in staging only to see if the problem persists.