### PR TITLE
CKAN changes

### DIFF
--- a/hieradata/class/staging/ckan.yaml
+++ b/hieradata/class/staging/ckan.yaml
@@ -1,3 +1,3 @@
 ---
 
-govuk::apps::ckan::enabled: true
+govuk::apps::ckan::enabled: false

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -375,9 +375,7 @@ govuk::apps::bouncer::unicorn_worker_processes: "8"
 govuk::apps::cache_clearing_service::enabled: true
 govuk::apps::cache_clearing_service::rabbitmq_hosts: [rabbitmq]
 
-govuk::apps::ckan::db_hostname: "db-admin"
-govuk::apps::ckan::db_port: 6432
-govuk::apps::ckan::db_allow_prepared_statements: false
+govuk::apps::ckan::db_hostname: "postgresql-primary"
 govuk::apps::ckan::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 govuk::apps::ckan::db::allow_auth_from_lb: true
 govuk::apps::ckan::db::lb_ip_range: "%{hiera('environment_ip_prefix')}.0.0/16"

--- a/modules/govuk/manifests/apps/ckan.pp
+++ b/modules/govuk/manifests/apps/ckan.pp
@@ -17,14 +17,6 @@
 # [*db_password*]
 #   The password for the postgresql role
 #
-# [*db_port*]
-#   The port of the database server to use in the DATABASE_URL.
-#   Default: 5432
-#
-# [*db_allow_prepared_statements*]
-#   The ?prepared_statements= parameter to use in the DATABASE_URL.
-#   Default: true
-#
 # [*db_name*]
 #   The database that CKAN should use
 #
@@ -41,8 +33,6 @@ class govuk::apps::ckan (
   $enabled                        = false,
   $port                           = '3220',
   $db_hostname                    = undef,
-  $db_port                        = 5432,
-  $db_allow_prepared_statements   = true,
   $db_username                    = 'ckan',
   $db_password                    = 'foo',
   $db_name                        = 'ckan_production',

--- a/modules/govuk/templates/ckan/ckan.ini.erb
+++ b/modules/govuk/templates/ckan/ckan.ini.erb
@@ -35,7 +35,7 @@ who.log_level = warning
 who.log_file = %(cache_dir)s/who_log.ini
 
 ## Database Settings
-sqlalchemy.url = <%= "postgresql://#{@db_username}:#{@db_password}@#{@db_hostname}:#{@db_port}/#{@db_name}?prepared_statements=#{@db_allow_prepared_statements}"%>
+sqlalchemy.url = <%= "postgresql://#{@db_username}:#{@db_password}@#{@db_hostname}/#{@db_name}"%>
 
 #ckan.datastore.write_url = postgresql://ckan_default:pass@localhost/datastore_default
 #ckan.datastore.read_url = postgresql://datastore_default:pass@localhost/datastore_default


### PR DESCRIPTION
- Remove pg bouncer from CKAN.  This is because the pg libraries used by CKAN do not support the `prepared_statements` option.
- Disable CKAN in staging again.  This is because we were hoping that pg bouncer would deal with a "too many pg connections" issue that was present in all environments.