### PR TITLE
Fix the CPU count on the Machine dashboard

### DIFF
--- a/modules/grafana/files/dashboards/machine.json
+++ b/modules/grafana/files/dashboards/machine.json
@@ -68,7 +68,7 @@
             {
               "hide": false,
               "refId": "B",
-              "target": "alias(countSeries($hostname.cpu-*.cpu-user), 'CPU Count')",
+              "target": "alias(scale(sumSeries(offset($hostname.cpu-*.cpu-user, 100000)), 0.00001), 'CPU Count')",
               "textEditor": false
             },
             {


### PR DESCRIPTION
countSeries doesn't handle null values very well, so when CPU's are
added, the CPU's appear to have always been added. So, switch to doing
some funky scaling to produce a number which better describes how many
CPU's the machine had at that time.

# Before

![machine-cpu-before](https://user-images.githubusercontent.com/1130010/45037571-36a18b00-b057-11e8-9165-4c895e1b2749.png)

# After

![machine-cpu-after](https://user-images.githubusercontent.com/1130010/45037579-3a351200-b057-11e8-9e14-19f7e5fdd8ed.png)
