### PR TITLE
Reduce puppet master unicorn workers to 2

### DIFF
--- a/modules/puppet/files/etc/puppet/unicorn.conf
+++ b/modules/puppet/files/etc/puppet/unicorn.conf
@@ -1,3 +1,3 @@
-worker_processes 6
+worker_processes 2
 stderr_path "/var/log/puppetmaster/unicorn.log"
 timeout 600


### PR DESCRIPTION
- The average load on the puppet master seems to be below 2.

- There is a baseline of memory usage per puppet master process of 700M.

- We like to see whether the puppetmaster-1 VM can be reduced in size
  without sacrificing functionality.

solo: @schmie