### PR TITLE
Puppetise the data scrubber

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1848,3 +1848,5 @@ unattended_upgrades::origins:
 unicornherder::version: '0.0.8'
 
 yarn::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+
+govuk_datascrubber::ensure: absent

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1281,3 +1281,5 @@ unattended_upgrades::origins:
 unicornherder::version: '0.0.8'
 
 yarn::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+
+govuk_datascrubber::ensure: 'absent'

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -125,3 +125,5 @@ router::nginx::robotstxt: |
   Disallow: /
 
 nginx::config::stack_network_prefix: '10.3.0'
+
+govuk_datascrubber::ensure: 'present'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -131,3 +131,5 @@ router::nginx::robotstxt: |
   Disallow: /
 
 nginx::config::stack_network_prefix: '10.2.0'
+
+govuk_datascrubber::ensure: 'present'

--- a/modules/govuk/manifests/node/s_db_admin.pp
+++ b/modules/govuk/manifests/node/s_db_admin.pp
@@ -184,4 +184,6 @@ class govuk::node::s_db_admin(
     command => '/usr/local/bin/rds-postgres-to-s3',
     require => File['/usr/local/bin/rds-postgres-to-s3'],
   }
+
+  class { '::govuk_datascrubber': }
 }

--- a/modules/govuk_datascrubber/manifests/init.pp
+++ b/modules/govuk_datascrubber/manifests/init.pp
@@ -1,0 +1,79 @@
+# == Class: govuk_datascrubber
+#
+# Install the data scrubber and configure cron to run it
+# https://github.com/alphagov/govuk-datascrubber
+#
+# === Parameters:
+#
+# [*ensure*]
+#   Specify whether to install or remove the tool and its cron job(s)
+#   Default is 'latest'
+#
+# [*mysql_hosts*]
+#   List of hostnames of MySQL servers to look for snapshots of
+#   Default is 'mysql-primary'
+#
+# [*postgresql_hosts*]
+#   List of hostnames of Postgres servers to look for snapshots of
+#   Default is 'postgresql-primary'
+#
+# [*cron_user*]
+#   The account to run the cron job as (default: 'deploy')
+#
+# [*cron_hour*]
+#   To control the schedule.
+#   Passed through to the `hour` parameter of the `cron` resource.
+#   Default is 20 (8pm)
+#
+# [*cron_minute*]
+#   To control the schedule.
+#   Passed through to the `minute` parameter of the `cron` resource
+#   Default is 0 (first minute of the hour)
+#
+# [*share_with*]
+#   List of AWS accounts to share the scrubbed snapshots with.
+#   Defaults to empty list.
+#
+class govuk_datascrubber (
+  $ensure           = 'latest',
+  $mysql_hosts      = ['mysql-primary'],
+  $postgresql_hosts = ['postgresql-primary'],
+  $cron_user        = 'deploy',
+  $cron_hour        = 20,
+  $cron_minute      = 0,
+  $share_with       = [],
+) {
+
+  package { 'govuk-datascrubber':
+    ensure => $ensure,
+  }
+
+  $cron_command = shellquote(
+    flatten([
+      'datascrubber',
+
+      '--mysql-hosts', $mysql_hosts,
+      '--postgresql-hosts', $postgresql_hosts,
+
+      size($share_with) ? {
+        0       => [],
+        default => ['--share-with', $share_with],
+      }
+
+    ])
+  )
+
+  $cron_ensure = $ensure ? {
+    'absent' => 'absent',
+    default  => 'present',
+  }
+
+  cron { 'datascrubber' :
+    ensure  => $cron_ensure,
+    user    => $cron_user,
+    hour    => $cron_hour,
+    minute  => $cron_minute,
+    command => $cron_command,
+  }
+
+}


### PR DESCRIPTION
Add a single-class Puppet module that installs the data scrubber and configures a cron job.

I've set the cron job to run at 20:00 daily but this is open to discussion.

It's configured to run on AWS staging and prod, nowhere else.

Note - this will need the package to have been built and published to Aptly before this code can apply cleanly.