### PR TITLE
Execute AWS Jenkins job for data sync complete

### DIFF
--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -58,6 +58,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::transition_load_site_config
   - govuk_jenkins::jobs::transition_load_transition_stats_hits
   - govuk_jenkins::jobs::trigger_data_sync_complete
+  - govuk_jenkins::jobs::trigger_data_sync_complete_aws
   - govuk_jenkins::jobs::update_cdn_dictionaries
   - govuk_jenkins::jobs::user_monitor
   - govuk_jenkins::jobs::validate_published_dns

--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
@@ -68,7 +68,7 @@
           predefined-parameters: |
             NSCA_CHECK_DESCRIPTION=<%= @service_description %>
             NSCA_OUTPUT=<%= @service_description %> failed
-        - project: trigger_data_sync_complete
+        - project: trigger_data_sync_complete_aws
           condition: 'ALWAYS'
           predefined-parameters: |
             HOSTNAME=deploy.integration.publishing.service.gov.uk


### PR DESCRIPTION
- The data_sync_complete Jenkins job will have never been triggered in
  integration since it has moved to AWS.

- If this is working, the logic around the
trigger_data_sync_complete(_aws) jobs should be revisited as it is quite
messy (at least added to backlog/techdebt

solo: @schmie