### PR TITLE
Fix content publisher import job not triggering

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
@@ -41,5 +41,6 @@
                 MACHINE_CLASS=whitehall_backend
                 RAKE_TASK=publishing:scheduled:requeue_all_jobs
             - project: content-publisher-whitehall-import
+              trigger-with-no-params: true
         - email:
             recipients: govuk-ci-notifications@digital.cabinet-office.gov.uk


### PR DESCRIPTION
https://trello.com/c/ORACsrIh/172-create-a-jenkins-job-to-update-integration-content-publisher-with-whitehall-content