### PR TITLE
Add publishing_api data pull to sync new RDS

### DIFF
--- a/hieradata_aws/class/staging/publishing_api_db_admin.yaml
+++ b/hieradata_aws/class/staging/publishing_api_db_admin.yaml
@@ -1,0 +1,11 @@
+govuk_env_sync::tasks:
+  "pull_publishing-api_production_daily":
+    hour: "3"
+    minute: "45"
+    action: "pull"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "publishing-api_production"
+    temppath: "/tmp/publishing-api_production"
+    url: "govuk-staging-database-backups"
+    path: "publishing-api-postgresql"


### PR DESCRIPTION
- We have split oout the publishing-api DB to its own RDS

- This needs syncing and I had forgootten to add this hierdata to an
  earlier PR

solo: @schmie