### PR TITLE
Add AWS_REGION environment variable for cache-clearing-service

### DIFF
--- a/modules/govuk/manifests/apps/cache_clearing_service.pp
+++ b/modules/govuk/manifests/apps/cache_clearing_service.pp
@@ -27,6 +27,10 @@
 # [*puppetdb_node_url*]
 #   The `nodes` endpoint URL for Puppet DB
 #
+# [*aws_region*]
+#   The region in AWS the app is running in.
+#   Default: eu-west-1
+#
 class govuk::apps::cache_clearing_service (
   $enabled = false,
   $sentry_dsn = undef,
@@ -34,6 +38,7 @@ class govuk::apps::cache_clearing_service (
   $rabbitmq_user = 'cache_clearing_service',
   $rabbitmq_password = 'cache_clearing_service',
   $puppetdb_node_url = undef,
+  $aws_region = 'eu-west-1',
 ) {
   $ensure = $enabled ? {
     true  => 'present',
@@ -63,9 +68,13 @@ class govuk::apps::cache_clearing_service (
   }
 
   if $::aws_migration {
-    govuk::app::envvar { "${title}-AWS_STACKNAME":
-      varname => 'AWS_STACKNAME',
-      value   => $::aws_stackname;
+    govuk::app::envvar {
+      "${title}-AWS_STACKNAME":
+        varname => 'AWS_STACKNAME',
+        value   => $::aws_stackname;
+      "${title}-AWS_REGION":
+        varname => 'AWS_REGION',
+        value   => $aws_region;
     }
   } else {
     govuk::app::envvar { "${title}-PUPPETDB_NODE_URL":


### PR DESCRIPTION
We need this region to use the AWS API to get the EC2 nodes of the cache machines.

[Trello Card](https://trello.com/c/f8U7EfUh/427-make-the-new-cache-clearing-app-invalidate-cache-in-varnish)