### PR TITLE
Allow access to 7999/tcp on cache boxes

### DIFF
--- a/modules/govuk/manifests/node/s_cache.pp
+++ b/modules/govuk/manifests/node/s_cache.pp
@@ -92,6 +92,11 @@ class govuk::node::s_cache (
     strip_cookies => $strip_cookies,
   }
 
+  @ufw::allow {
+    'allow-cache-clearing-from-all':
+      port => 7999;
+  }
+
   @@icinga::check::graphite { "check_nginx_connections_writing_${::hostname}":
     target    => "${::fqdn_metrics}.nginx.nginx_connections-writing",
     warning   => 150,


### PR DESCRIPTION
- A new cache-clearing on (re-)publishing mechanism requires backend
  machines to access 7999.

- More fine-grained access limits are defined in the vCloud VDC edge
  rules (Allow access to router 7999 by backend.

solo: @schmie