### PR TITLE
Add varnish purge ACL for staging/prod

### DIFF
--- a/hieradata/class/cache.yaml
+++ b/hieradata/class/cache.yaml
@@ -12,3 +12,5 @@ govuk::apps::authenticating_proxy::mongodb_nodes:
   - 'router-backend-3.router'
 
 nginx::package::nginx_package: 'nginx-extras'
+
+varnish::environment_ip_prefix: "%{hiera('environment_ip_prefix')}"

--- a/hieradata_aws/class/cache.yaml
+++ b/hieradata_aws/class/cache.yaml
@@ -9,3 +9,5 @@ govuk::apps::router::mongodb_nodes:
   - 'router-backend-1'
   - 'router-backend-2'
   - 'router-backend-3'
+
+varnish::environment_ip_prefix: "%{hiera('environment_ip_prefix')}"

--- a/modules/varnish/manifests/config.pp
+++ b/modules/varnish/manifests/config.pp
@@ -10,7 +10,14 @@
 # [*strip_cookies*]
 #   See varnish/manifests/init.pp.
 #
-class varnish::config($upstream_port, $strip_cookies) {
+# [*environment_ip_prefix*]
+#   The first two octets of the IP range we're on.
+#
+class varnish::config(
+  $upstream_port,
+  $strip_cookies,
+  $environment_ip_prefix,
+) {
   include varnish::restart
 
   $app_domain  = hiera('app_domain')

--- a/modules/varnish/manifests/init.pp
+++ b/modules/varnish/manifests/init.pp
@@ -30,11 +30,15 @@
 #
 #   Default: 3054 (the router)
 #
+# [*environment_ip_prefix*]
+#   The first two octets of the IP range we're on.
+#
 class varnish (
     $default_ttl  = 900,
     $strip_cookies = true,
     $storage_size = '512M',
     $upstream_port = 3054,
+    $environment_ip_prefix = undef,
 ) {
   anchor { 'varnish::begin':
     notify => Class['varnish::service'];
@@ -45,10 +49,11 @@ class varnish (
   }
 
   class { 'varnish::config':
-    strip_cookies => $strip_cookies,
-    upstream_port => $upstream_port,
-    require       => Class['varnish::package'],
-    notify        => Class['varnish::service'];
+    strip_cookies         => $strip_cookies,
+    upstream_port         => $upstream_port,
+    environment_ip_prefix => $environment_ip_prefix,
+    require               => Class['varnish::package'],
+    notify                => Class['varnish::service'];
   }
   class { 'collectd::plugin::varnish':
     require => Class['varnish::config'],

--- a/modules/varnish/templates/default.vcl.erb
+++ b/modules/varnish/templates/default.vcl.erb
@@ -13,7 +13,7 @@
 
 acl purge_acl {
   "localhost";
-  "10.1.0.0"/16;
+  "<%= @environment_ip_prefix %>.0.0"/16;
 }
 
 sub vcl_recv {


### PR DESCRIPTION
The previous CIDR was for integration only, this adds ranges for staging and production.

https://trello.com/c/f8U7EfUh/427-make-the-new-cache-clearing-app-invalidate-cache-in-varnish