### PR TITLE
Update LVM physical volumes for staging asset boxes

### DIFF
--- a/hieradata/node/asset-master-1.backend.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/asset-master-1.backend.staging.publishing.service.gov.uk.yaml
@@ -1,1 +1,11 @@
+---
+
 govuk::node::s_asset_base::s3_env_sync_enabled: true
+
+# note: remove this and update 'class/asset_master.yaml' when the
+# change has also been applied to production.
+lv:
+  data:
+    pv:
+        - '/dev/sdb1'
+    vg: 'uploads'

--- a/hieradata/node/asset-slave-1.backend.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/asset-slave-1.backend.staging.publishing.service.gov.uk.yaml
@@ -3,8 +3,6 @@ lv:
   data:
     pv:
       - '/dev/sdc1'
-      - '/dev/sdd1'
-      - '/dev/sde1'
     vg: 'uploads'
   cache:
     pv:

--- a/hieradata/node/asset-slave-2.backend.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/asset-slave-2.backend.staging.publishing.service.gov.uk.yaml
@@ -1,3 +1,13 @@
+---
+
 icinga::client::check_cputype::cputype: 'amd'
 govuk_safe_to_reboot::can_reboot: 'overnight'
 govuk_safe_to_reboot::reason: 'DR node: only used in the event of a disaster'
+
+# note: remove this and update 'class/asset_slave.yaml' when the
+# change has also been applied to production.
+lv:
+  data:
+    pv:
+      - '/dev/sdb1'
+    vg: 'uploads'


### PR DESCRIPTION
```
michaelswalker@staging-asset-master-1:~$ sudo pvs
  PV         VG      Fmt  Attr PSize   PFree
  /dev/sda2  os      lvm2 a--   49.52g    0 
  /dev/sdb1  uploads lvm2 a--  100.00g    0

michaelswalker@staging-asset-slave-1:~$ sudo pvs
  PV         VG        Fmt  Attr PSize   PFree
  /dev/sda1  duplicity lvm2 a--   45.00g    0 
  /dev/sdb2  os        lvm2 a--   49.52g    0 
  /dev/sdc1  uploads   lvm2 a--  100.00g    0 

michaelswalker@staging-asset-slave-2:~$ sudo pvs
  PV         VG      Fmt  Attr PSize   PFree
  /dev/sda2  os      lvm2 a--   49.52g    0 
  /dev/sdb1  uploads lvm2 a--  100.00g    0 
```

---

[Trello card](https://trello.com/c/M3Dfrj8S/443-remove-attachments-from-nfs)