### PR TITLE
Add AWS X-Ray daemon repo

### DIFF
--- a/modules/govuk/manifests/node/s_apt.pp
+++ b/modules/govuk/manifests/node/s_apt.pp
@@ -134,6 +134,7 @@ class govuk::node::s_apt (
   }
 
   aptly::repo { 'awscli': }
+  aptly::repo { 'aws-xray-daemon': }
   aptly::repo { 'collectd': }
   aptly::repo { 'elastic-beats': }
   aptly::repo { 'etcdctl': }

--- a/modules/govuk_aws_xray_daemon/manifests/init.pp
+++ b/modules/govuk_aws_xray_daemon/manifests/init.pp
@@ -1,0 +1,26 @@
+# == Class: govuk_aws_xray_daemon
+#
+# Installs the Apt repo for the AWS X-Ray daemon, and installs the AWS X-Ray daemon from the Apt repo
+#
+# === Parameters:
+#
+# [*apt_mirror_hostname*]
+#   The hostname of the Apt mirror containing the aws-xray-daemon repo
+#
+class govuk_aws_xray_daemon (
+  $apt_mirror_hostname,
+)
+{
+  apt::source { 'aws-xray-daemon':
+    ensure       => present,
+    location     => "http://${apt_mirror_hostname}/aws-xray-daemon",
+    release      => $::lsbdistcodename,
+    architecture => $::architecture,
+    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+  }
+
+  package { 'aws-xray-daemon':
+    ensure  => latest,
+    require => Apt::Source['aws-xray-daemon'],
+  }
+}


### PR DESCRIPTION
This commit adds a new aptly repo which will contain the AWS X-Ray daemon, which will be installed on all machines that run backend or frontend apps.

The AWS X-Ray daemon listens on port 2000 and collects traces from individual apps, sending them to AWS in batches to reduce traffic.

Trello: https://trello.com/c/YMZBPMGF/450-provision-x-ray-and-set-up-permissions-%F0%9F%8D%90-portunity