### PR TITLE
Grafana: summarise and aggregate metrics (CPM)

### DIFF
--- a/modules/grafana/files/dashboards/content-data-api.json
+++ b/modules/grafana/files/dashboards/content-data-api.json
@@ -30,7 +30,7 @@
             "current": false,
             "max": false,
             "min": false,
-            "show": true,
+            "show": false,
             "total": false,
             "values": false
           },
@@ -164,7 +164,7 @@
             "current": false,
             "max": false,
             "min": false,
-            "show": true,
+            "show": false,
             "total": false,
             "values": false
           },
@@ -300,7 +300,7 @@
             "current": false,
             "max": false,
             "min": false,
-            "show": true,
+            "show": false,
             "total": false,
             "values": false
           },
@@ -320,7 +320,7 @@
           "targets": [
             {
               "refId": "A",
-              "target": "integral(stats_counts.govuk.app.content-performance-manager.*.monitor.etl.daily.satisfaction_score)",
+              "target": "sumSeries(summarize(stats_counts.govuk.app.content-performance-manager.*.monitor.etl.daily.satisfaction_score,'1d','sum',false))",
               "textEditor": false
             }
           ],
@@ -406,8 +406,8 @@
           "targets": [
             {
               "refId": "A",
-              "target": "integral(stats_counts.govuk.app.content-performance-manager.*.monitor.etl.daily.unique_pageviews)",
-              "textEditor": true
+              "target": "sumSeries(summarize(stats_counts.govuk.app.content-performance-manager.*.monitor.etl.daily.unique_pageviews,'1d','sum',false))",
+              "textEditor": false
             }
           ],
           "thresholds": [],
@@ -480,8 +480,8 @@
           "targets": [
             {
               "refId": "A",
-              "target": "integral(stats_counts.govuk.app.content-performance-manager.*.monitor.etl.edition.number_of_pdfs)",
-              "textEditor": true
+              "target": "sumSeries(summarize(stats_counts.govuk.app.content-performance-manager.*.monitor.etl.edition.number_of_pdfs,'1d','sum',false))",
+              "textEditor": false
             }
           ],
           "thresholds": [],
@@ -566,8 +566,8 @@
           "targets": [
             {
               "refId": "A",
-              "target": "integral(stats_counts.govuk.app.content-performance-manager.*.monitor.etl.daily.number_of_internal_searches)",
-              "textEditor": true
+              "target": "sumSeries(summarize(stats_counts.govuk.app.content-performance-manager.*.monitor.etl.daily.number_of_internal_searches,'1d','sum',false))",
+              "textEditor": false
             }
           ],
           "thresholds": [],
@@ -640,7 +640,7 @@
           "targets": [
             {
               "refId": "A",
-              "target": "integral(stats_counts.govuk.app.content-performance-manager.*.monitor.etl.daily.feedex_comments)",
+              "target": "sumSeries(summarize(stats_counts.govuk.app.content-performance-manager.*.monitor.etl.daily.feedex_comments,'1d','sum',false))",
               "textEditor": false
             }
           ],
@@ -727,7 +727,7 @@
             "current": false,
             "max": false,
             "min": false,
-            "show": true,
+            "show": false,
             "total": false,
             "values": false
           },
@@ -747,8 +747,8 @@
           "targets": [
             {
               "refId": "A",
-              "target": "integral(stats_counts.govuk.app.content-performance-manager.*.monitor.dimensions.base_paths)",
-              "textEditor": true
+              "target": "sumSeries(summarize(stats_counts.govuk.app.content-performance-manager.*.monitor.dimensions.base_paths, '1d', 'sum', false))",
+              "textEditor": false
             }
           ],
           "thresholds": [],
@@ -800,7 +800,7 @@
             "current": false,
             "max": false,
             "min": false,
-            "show": true,
+            "show": false,
             "total": false,
             "values": false
           },
@@ -820,8 +820,8 @@
           "targets": [
             {
               "refId": "A",
-              "target": "integral(stats_counts.govuk.app.content-performance-manager.*.monitor.dimensions.latest_base_paths)",
-              "textEditor": true
+              "target": "sumSeries(summarize(stats_counts.govuk.app.content-performance-manager.*.monitor.dimensions.latest_base_paths,'1d','sum',false))",
+              "textEditor": false
             }
           ],
           "thresholds": [],
@@ -873,7 +873,7 @@
             "current": false,
             "max": false,
             "min": false,
-            "show": true,
+            "show": false,
             "total": false,
             "values": false
           },
@@ -893,8 +893,8 @@
           "targets": [
             {
               "refId": "A",
-              "target": "integral(stats_counts.govuk.app.content-performance-manager.*.monitor.dimensions.content_items)",
-              "textEditor": true
+              "target": "sumSeries(summarize(stats_counts.govuk.app.content-performance-manager.*.monitor.dimensions.content_items,'1d','sum',false))",
+              "textEditor": false
             }
           ],
           "thresholds": [],
@@ -946,7 +946,7 @@
             "current": false,
             "max": false,
             "min": false,
-            "show": true,
+            "show": false,
             "total": false,
             "values": false
           },
@@ -966,8 +966,8 @@
           "targets": [
             {
               "refId": "A",
-              "target": "integral(stats_counts.govuk.app.content-performance-manager.*.monitor.dimensions.latest_content_items)",
-              "textEditor": true
+              "target": "sumSeries(summarize(stats_counts.govuk.app.content-performance-manager.*.monitor.dimensions.latest_content_items,'1d','sum',false))",
+              "textEditor": false
             }
           ],
           "thresholds": [],
@@ -1019,7 +1019,7 @@
             "current": false,
             "max": false,
             "min": false,
-            "show": true,
+            "show": false,
             "total": false,
             "values": false
           },
@@ -1039,8 +1039,8 @@
           "targets": [
             {
               "refId": "A",
-              "target": "integral(stats_counts.govuk.app.content-performance-manager.*.monitor.facts.all_metrics)",
-              "textEditor": true
+              "target": "sumSeries(summarize(stats_counts.govuk.app.content-performance-manager.*.monitor.facts.all_metrics,'1d','sum',false))",
+              "textEditor": false
             }
           ],
           "thresholds": [],
@@ -1092,7 +1092,7 @@
             "current": false,
             "max": false,
             "min": false,
-            "show": true,
+            "show": false,
             "total": false,
             "values": false
           },
@@ -1112,8 +1112,8 @@
           "targets": [
             {
               "refId": "A",
-              "target": "integral(stats_counts.govuk.app.content-performance-manager.*.monitor.facts.daily_metrics)",
-              "textEditor": true
+              "target": "sumSeries(summarize(stats_counts.govuk.app.content-performance-manager.*.monitor.facts.daily_metrics,'1d','sum',false))",
+              "textEditor": false
             }
           ],
           "thresholds": [],
@@ -1165,7 +1165,7 @@
             "current": false,
             "max": false,
             "min": false,
-            "show": true,
+            "show": false,
             "total": false,
             "values": false
           },
@@ -1185,8 +1185,8 @@
           "targets": [
             {
               "refId": "A",
-              "target": "integral(stats_counts.govuk.app.content-performance-manager.*.monitor.facts.all_editions)",
-              "textEditor": true
+              "target": "sumSeries(summarize(stats_counts.govuk.app.content-performance-manager.*.monitor.facts.all_editions,'1d','sum',false))",
+              "textEditor": false
             }
           ],
           "thresholds": [],
@@ -1238,7 +1238,7 @@
             "current": false,
             "max": false,
             "min": false,
-            "show": true,
+            "show": false,
             "total": false,
             "values": false
           },
@@ -1258,8 +1258,8 @@
           "targets": [
             {
               "refId": "A",
-              "target": "integral(stats_counts.govuk.app.content-performance-manager.*.monitor.facts.daily_editions)",
-              "textEditor": true
+              "target": "sumSeries(summarize(stats_counts.govuk.app.content-performance-manager.*.monitor.facts.daily_editions,'1d','sum',false))",
+              "textEditor": false
             }
           ],
           "thresholds": [],
@@ -1400,7 +1400,7 @@
     ]
   },
   "time": {
-    "from": "now-3h",
+    "from": "now-7d",
     "to": "now"
   },
   "timepicker": {


### PR DESCRIPTION
There is no need to show metrics per node as we only care about the
aggregated number per day, so in this PR I am addressing two 
improvements:

1. Summarise per day (as we collect data once a day)
2. Summarise the series