### PR TITLE
Add AWS X-Ray daemon to app machines

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -725,6 +725,8 @@ govuk::apps::travel_advice_publisher::redis_port: "%{hiera('sidekiq_port')}"
 
 govuk_awscli::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
+govuk_aws_xray_daemon::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+
 govuk_beat::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 govuk_ci::agent::gcloud::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -746,6 +746,8 @@ govuk::apps::travel_advice_publisher::redis_port: "%{hiera('sidekiq_port')}"
 
 govuk_awscli::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
+govuk_aws_xray_daemon::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+
 govuk::apps::content_audit_tool::db::rds: true
 govuk::apps::content_performance_manager::db::rds: true
 govuk::apps::content_tagger::db::rds: true

--- a/modules/govuk/manifests/node/s_backend.pp
+++ b/modules/govuk/manifests/node/s_backend.pp
@@ -28,6 +28,8 @@ class govuk::node::s_backend inherits govuk::node::s_base {
     ensure => installed,
   }
 
+  include govuk_aws_xray_daemon
+
   include imagemagick
 
   include nginx

--- a/modules/govuk/manifests/node/s_bouncer.pp
+++ b/modules/govuk/manifests/node/s_bouncer.pp
@@ -13,6 +13,7 @@ class govuk::node::s_bouncer (
   $minimum_request_rate = 5,
 ) inherits govuk::node::s_base {
 
+  include govuk_aws_xray_daemon
   include govuk_bouncer::gor
   include govuk::node::s_app_server
   include nginx

--- a/modules/govuk/manifests/node/s_calculators_frontend.pp
+++ b/modules/govuk/manifests/node/s_calculators_frontend.pp
@@ -2,6 +2,8 @@
 class govuk::node::s_calculators_frontend inherits govuk::node::s_base {
   include govuk::node::s_app_server
 
+  include govuk_aws_xray_daemon
+
   include nginx
 
   # Local proxy for licence-finder to access ES cluster.

--- a/modules/govuk/manifests/node/s_content_store.pp
+++ b/modules/govuk/manifests/node/s_content_store.pp
@@ -2,9 +2,10 @@
 class govuk::node::s_content_store inherits govuk::node::s_base {
   include govuk::node::s_app_server
 
+  include govuk_aws_xray_daemon
+
   include nginx
 
   # If we miss all the apps, throw a 500 to be caught by the cache nginx
   nginx::config::vhost::default { 'default': }
 }
-

--- a/modules/govuk/manifests/node/s_draft_content_store.pp
+++ b/modules/govuk/manifests/node/s_draft_content_store.pp
@@ -9,6 +9,8 @@
 class govuk::node::s_draft_content_store() inherits govuk::node::s_base {
   include govuk::node::s_content_store
 
+  include govuk_aws_xray_daemon
+
   $app_domain = hiera('app_domain')
 
   govuk_envvar {

--- a/modules/govuk/manifests/node/s_draft_frontend.pp
+++ b/modules/govuk/manifests/node/s_draft_frontend.pp
@@ -8,6 +8,8 @@
 class govuk::node::s_draft_frontend() inherits govuk::node::s_base {
   include govuk::node::s_frontend
 
+  include govuk_aws_xray_daemon
+
   $app_domain = hiera('app_domain')
 
   if $::aws_migration {

--- a/modules/govuk/manifests/node/s_email_alert_api.pp
+++ b/modules/govuk/manifests/node/s_email_alert_api.pp
@@ -6,6 +6,8 @@
 class govuk::node::s_email_alert_api inherits govuk::node::s_base {
   include ::govuk_rbenv::all
 
+  include govuk_aws_xray_daemon
+
   limits::limits { 'root_nofile':
     ensure     => present,
     user       => 'root',

--- a/modules/govuk/manifests/node/s_frontend.pp
+++ b/modules/govuk/manifests/node/s_frontend.pp
@@ -7,6 +7,8 @@ class govuk::node::s_frontend inherits govuk::node::s_base {
 
   include govuk::node::s_app_server
 
+  include govuk_aws_xray_daemon
+
   include nginx
 
   # If we miss all the apps, throw a 500 to be caught by the cache nginx

--- a/modules/govuk/manifests/node/s_publishing_api.pp
+++ b/modules/govuk/manifests/node/s_publishing_api.pp
@@ -6,6 +6,8 @@
 class govuk::node::s_publishing_api inherits govuk::node::s_base {
   include ::govuk_rbenv::all
 
+  include govuk_aws_xray_daemon
+
   limits::limits { 'root_nofile':
     ensure     => present,
     user       => 'root',

--- a/modules/govuk/manifests/node/s_search.pp
+++ b/modules/govuk/manifests/node/s_search.pp
@@ -4,6 +4,9 @@
 #
 class govuk::node::s_search inherits govuk::node::s_base {
   include govuk::node::s_app_server
+
+  include govuk_aws_xray_daemon
+
   include govuk_search::gor
 
   include nginx

--- a/modules/govuk/manifests/node/s_whitehall_backend.pp
+++ b/modules/govuk/manifests/node/s_whitehall_backend.pp
@@ -4,6 +4,9 @@ class govuk::node::s_whitehall_backend (
 ) inherits govuk::node::s_base {
 
   include govuk::node::s_app_server
+
+  include govuk_aws_xray_daemon
+
   include nginx
 
   include imagemagick

--- a/modules/govuk/manifests/node/s_whitehall_frontend.pp
+++ b/modules/govuk/manifests/node/s_whitehall_frontend.pp
@@ -4,6 +4,9 @@
 #
 class govuk::node::s_whitehall_frontend inherits govuk::node::s_base {
   include govuk::node::s_app_server
+
+  include govuk_aws_xray_daemon
+
   include nginx
 
   $app_domain = hiera('app_domain')

--- a/spec/fixtures/hieradata/common.yaml
+++ b/spec/fixtures/hieradata/common.yaml
@@ -50,6 +50,8 @@ govuk_java::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 govuk_awscli::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
+govuk_aws_xray_daemon::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+
 govuk_jenkins::package::apt_mirror_hostname: 'apt.example.com'
 
 govuk_jenkins::config::github_api_uri: foo


### PR DESCRIPTION
This commit adds the AWS X-Ray daemon to all node types that host Ruby applications.

Depends on https://github.com/alphagov/govuk-puppet/pull/8102 being deployed.

Trello: https://trello.com/c/YMZBPMGF/450-provision-x-ray-and-set-up-permissions-%F0%9F%8D%90-portunity