### PR TITLE
Remove asset_master_and_slave_disk_space_similar alert + clean-up an unused mountpoint

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -100,8 +100,6 @@ govuk::node::s_api_lb::search_servers:
 
 govuk::node::s_asset_master::copy_attachments_hour: 11
 
-govuk::node::s_asset_slave::notification_period: 'inoffice_afternoon'
-
 govuk::node::s_backend_lb::backend_servers:
   - 'backend-1.backend'
   - 'backend-2.backend'

--- a/modules/govuk/manifests/node/s_asset_slave.pp
+++ b/modules/govuk/manifests/node/s_asset_slave.pp
@@ -19,11 +19,7 @@ class govuk::node::s_asset_slave (
     include backup::assets
   }
 
-  # Ownership and permissions come from the mount.
   file { '/data/master-uploads':
-    ensure => directory,
-    owner  => undef,
-    group  => undef,
-    mode   => undef,
+    ensure => absent,
   }
 }

--- a/modules/govuk/manifests/node/s_asset_slave.pp
+++ b/modules/govuk/manifests/node/s_asset_slave.pp
@@ -26,17 +26,4 @@ class govuk::node::s_asset_slave (
     group  => undef,
     mode   => undef,
   }
-
-  $app_domain = hiera('app_domain')
-
-  # FIXME: Remove the NFS mount once asset-manager is no longer using it.
-  mount { '/data/master-uploads':
-    ensure   => 'absent',
-    device   => "asset-master.${app_domain}:/mnt/uploads",
-    fstype   => 'nfs',
-    options  => 'rw,soft',
-    remounts => false,
-    atboot   => true,
-    require  => File['/data/master-uploads'],
-  }
 }

--- a/modules/govuk/manifests/node/s_asset_slave.pp
+++ b/modules/govuk/manifests/node/s_asset_slave.pp
@@ -9,7 +9,6 @@
 #
 class govuk::node::s_asset_slave (
   $offsite_backups = false,
-  $notification_period = '24x7',
 ) inherits govuk::node::s_asset_base {
 
   validate_bool($offsite_backups)
@@ -39,20 +38,5 @@ class govuk::node::s_asset_slave (
     remounts => false,
     atboot   => true,
     require  => File['/data/master-uploads'],
-  }
-
-  $master_metrics_hostname = regsubst($::fqdn_metrics, 'slave-\d', 'master-1')
-  $graphite_mnt_uploads_metric = 'df-mnt-uploads.df_complex-used'
-  $master_metric = "${master_metrics_hostname}.${graphite_mnt_uploads_metric}"
-  $slave_metric = "${::fqdn_metrics}.${graphite_mnt_uploads_metric}"
-
-  @@icinga::check::graphite { "asset_master_and_slave_disk_space_similar_from_${::hostname}":
-    target              => "movingMedian(absolute(transformNull(diffSeries(${slave_metric},${master_metric}),0)),10)",
-    critical            => to_bytes('512 MB'),
-    warning             => to_bytes('384 MB'),
-    desc                => 'Asset master and slave are using about the same amount of disk space',
-    host_name           => $::fqdn,
-    notes_url           => monitoring_docs_url(asset-master-slave-disk-space-comparison),
-    notification_period => $notification_period,
   }
 }


### PR DESCRIPTION
The NFS share is only used as temporary scratch space to coordinate
the asset manager instances, and to store a few files by publisher and
support-api.

---

[Trello card](https://trello.com/c/M3Dfrj8S/443-remove-attachments-from-nfs)