### PR TITLE
Direct gor replay traffic AWS staging

### DIFF
--- a/hieradata/class/staging/cache.yaml
+++ b/hieradata/class/staging/cache.yaml
@@ -1,1 +1,9 @@
+---
 nscd::config::dns_cache: 'yes'
+
+# NOTE: These values should not be changed lightly once set.
+#
+# If changed, the old host record must be cleaned up;
+router::gor::replay_targets:
+  'www-origin.staging.govuk.digital': {}
+router::gor::add_hosts: false

--- a/hieradata/node/cache-1.router.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/cache-1.router.staging.publishing.service.gov.uk.yaml
@@ -1,8 +1,0 @@
----
-
-# NOTE: These values should not be changed lightly once set.
-#
-# If changed, the old host record must be cleaned up;
-router::gor::replay_targets:
-  'www-origin.integration.publishing.service.gov.uk':
-    ip: '31.210.245.98'

--- a/hieradata/node/cache-2.router.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/cache-2.router.staging.publishing.service.gov.uk.yaml
@@ -1,5 +1,0 @@
----
-
-router::gor::add_hosts: false
-router::gor::replay_targets:
-  'www-origin.blue.integration.govuk.digital': {}


### PR DESCRIPTION
```
We set a global conf for the whole cache class and delete the machine specific configs.
The goal is to direct some real traffic to AWS staging to test the infra
```

Roch did this work, and now we've got a DNS cache, we can make use of it!

https://trello.com/c/VCDTld3E/1169-traffic-replay-for-staging-m