### PR TITLE
Don't clear Fastly in integration and staging

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -73,6 +73,7 @@ environment_ip_prefix: '10.3'
 
 govuk::apps::asset_manager::aws_s3_bucket_name: 'govuk-assets-production'
 govuk::apps::asset_manager::aws_region: 'eu-west-1'
+govuk::apps::cache_clearing_service::clear_fastly: true
 govuk::apps::ckan::ckan_site_url: 'https://ckan.publishing.service.gov.uk'
 govuk::apps::content_publisher::aws_s3_bucket: "govuk-production-content-publisher-activestorage"
 govuk::apps::content_publisher::google_tag_manager_auth: "O0DrItJxJeQ5Q2W6YCZzvw"

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -13,6 +13,7 @@ environment_ip_prefix: '10.3'
 
 govuk::apps::asset_manager::aws_s3_bucket_name: 'govuk-assets-production'
 govuk::apps::asset_manager::aws_region: 'eu-west-1'
+govuk::apps::cache_clearing_service::clear_fastly: true
 govuk::apps::content_publisher::aws_s3_bucket: "govuk-production-content-publisher-activestorage"
 govuk::apps::content_publisher::google_tag_manager_auth: "O0DrItJxJeQ5Q2W6YCZzvw"
 govuk::apps::content_publisher::google_tag_manager_id: "GTM-NQXC4TG"

--- a/modules/govuk/manifests/apps/cache_clearing_service.pp
+++ b/modules/govuk/manifests/apps/cache_clearing_service.pp
@@ -31,6 +31,11 @@
 #   The region in AWS the app is running in.
 #   Default: eu-west-1
 #
+# [*clear_fastly*]
+#   Whether to clear Fastly or not. We need this because Fastly is currently
+#   not configured in all environments.
+#   Default: false
+#
 class govuk::apps::cache_clearing_service (
   $enabled = false,
   $sentry_dsn = undef,
@@ -39,6 +44,7 @@ class govuk::apps::cache_clearing_service (
   $rabbitmq_password = 'cache_clearing_service',
   $puppetdb_node_url = undef,
   $aws_region = 'eu-west-1',
+  $clear_fastly = false,
 ) {
   $ensure = $enabled ? {
     true  => 'present',
@@ -65,6 +71,13 @@ class govuk::apps::cache_clearing_service (
     hosts    => $rabbitmq_hosts,
     user     => $rabbitmq_user,
     password => $rabbitmq_password,
+  }
+
+  if $clear_fastly {
+    govuk::app::envvar { "${title}-CLEAR_FASTLY":
+      varname => 'CLEAR_FASTLY',
+      value   => 'yes';
+    }
   }
 
   if $::aws_migration {


### PR DESCRIPTION
We currently don't have a suitable Fastly set up in integration and staging and this causes exceptions in those environments.

[Trello Card](https://trello.com/c/9k1peA1F/434-make-the-new-cache-clearing-app-invalidate-cache-in-fastly)