### PR TITLE
Don't clear the cache on republish

### DIFF
--- a/modules/govuk/manifests/apps/cache_clearing_service/rabbitmq.pp
+++ b/modules/govuk/manifests/apps/cache_clearing_service/rabbitmq.pp
@@ -56,7 +56,7 @@ class govuk::apps::cache_clearing_service::rabbitmq (
   }
 
   rabbitmq_binding { "binding_republish_${amqp_exchange}@${amqp_queue}@/":
-    ensure           => 'present',
+    ensure           => absent,
     name             => "${amqp_exchange}@${amqp_queue}@republish@/",
     user             => 'root',
     password         => $::govuk_rabbitmq::root_password,


### PR DESCRIPTION
The content of the page won't have changed if it's been republished, so we don't need to clear the cache.

[Trello Card](https://trello.com/c/9k1peA1F/434-make-the-new-cache-clearing-app-invalidate-cache-in-fastly)