### PR TITLE
Data scrubber: set AWS region

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1290,3 +1290,4 @@ yarn::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 govuk_datascrubber::ensure: 'absent'
 govuk_datascrubber::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_datascrubber::aws_region: 'eu-west-1'

--- a/modules/govuk_datascrubber/manifests/init.pp
+++ b/modules/govuk_datascrubber/manifests/init.pp
@@ -34,6 +34,9 @@
 #   List of AWS accounts to share the scrubbed snapshots with.
 #   Defaults to empty list.
 #
+# [*aws_region*]
+#   The AWS region to operate in
+#
 class govuk_datascrubber (
   $ensure              = 'latest',
   $apt_mirror_hostname = undef,
@@ -43,6 +46,7 @@ class govuk_datascrubber (
   $cron_hour           = 20,
   $cron_minute         = 0,
   $share_with          = [],
+  $aws_region          = undef,
 ) {
 
   if $apt_mirror_hostname {
@@ -69,8 +73,12 @@ class govuk_datascrubber (
       size($share_with) ? {
         0       => [],
         default => ['--share-with', $share_with],
-      }
+      },
 
+      $aws_region ? {
+        undef   => [],
+        default => ['--region', $aws_region],
+      },
     ])
   )
 


### PR DESCRIPTION
The current AWS region isn't in the environment for cron jobs, so we need to configure it explicitly.

Dependent on https://github.com/alphagov/govuk-datascrubber/pull/5