### PR TITLE
Add AWS X-Ray daemon user

### DIFF
--- a/modules/govuk_aws_xray_daemon/manifests/init.pp
+++ b/modules/govuk_aws_xray_daemon/manifests/init.pp
@@ -19,6 +19,13 @@ class govuk_aws_xray_daemon (
     key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
   }
 
+  user { 'xray':
+    ensure => present,
+    name   => 'xray',
+    shell  => '/bin/false',
+    system => true,
+  }
+
   package { 'xray':
     ensure  => latest,
     require => Apt::Source['aws-xray-daemon'],


### PR DESCRIPTION
The AWS X-Ray daemon adds this user during installation but it also needs to be in puppet otherwise it will be deleted on the next run.

Trello: https://trello.com/c/YMZBPMGF/450-provision-x-ray-and-set-up-permissions-%F0%9F%8D%90-portunity