### PR TITLE
Uninstall Phantomjs

### DIFF
--- a/modules/phantomjs/manifests/init.pp
+++ b/modules/phantomjs/manifests/init.pp
@@ -6,7 +6,7 @@ class phantomjs {
   include govuk_ppa
 
   package { 'phantomjs':
-    ensure  => '1.9.7-0~ppa1',
+    ensure  => absent,
     require => Class['govuk_ppa'],
   }
 }


### PR DESCRIPTION
We don't use it anymore so we don't need it on any of our machines.

[Trello Card](https://trello.com/c/hBDDBNYl/624-remove-phantomjs-from-puppet)