### PR TITLE
Add AWS X-Ray daemon configuration

### DIFF
--- a/modules/govuk_aws_xray_daemon/files/etc/amazon/xray/cfg.yaml
+++ b/modules/govuk_aws_xray_daemon/files/etc/amazon/xray/cfg.yaml
@@ -1,0 +1,31 @@
+# Maximum buffer size in MB (minimum 3). Choose 0 to use 1% of host memory.
+TotalBufferSizeMB: 0
+# Maximum number of concurrent calls to AWS X-Ray to upload segment documents.
+Concurrency: 8
+# Send segments to AWS X-Ray service in a specific region
+Region: "eu-west-1"
+# Change the X-Ray service endpoint to which the daemon sends segment documents.
+Endpoint: ""
+Socket:
+  # Change the address and port on which the daemon listens for UDP packets containing segment documents.
+  UDPAddress: "127.0.0.1:2000"
+  # Change the address and port on which the daemon listens for HTTP requests to proxy to AWS X-Ray.
+  TCPAddress: "127.0.0.1:2000"
+Logging:
+  LogRotation: true
+  # Change the log level, from most verbose to least: dev, debug, info, warn, error, prod (default).
+  LogLevel: "prod"
+  # Output logs to the specified file path.
+  LogPath: ""
+# Turn on local mode to skip EC2 instance metadata check.
+LocalMode: true
+# Amazon Resource Name (ARN) of the AWS resource running the daemon.
+ResourceARN: ""
+# Assume an IAM role to upload segments to a different account.
+RoleARN: ""
+# Disable TLS certificate verification.
+NoVerifySSL: false
+# Upload segments to AWS X-Ray through a proxy.
+ProxyAddress: ""
+# Daemon configuration file format version.
+Version: 2

--- a/modules/govuk_aws_xray_daemon/manifests/init.pp
+++ b/modules/govuk_aws_xray_daemon/manifests/init.pp
@@ -7,8 +7,16 @@
 # [*apt_mirror_hostname*]
 #   The hostname of the Apt mirror containing the aws-xray-daemon repo
 #
+# [*aws_access_key_id*]
+#   The AWS access key for the IAM role that has permissions to upload traces to AWS X-Ray
+#
+# [*aws_secret_access_key*]
+#   The AWS secret access key for the IAM role that has permissions to upload traces to AWS X-Ray
+#
 class govuk_aws_xray_daemon (
-  $apt_mirror_hostname,
+  $apt_mirror_hostname = undef,
+  $aws_access_key_id = undef,
+  $aws_secret_access_key = undef,
 )
 {
   apt::source { 'aws-xray-daemon':
@@ -20,14 +28,48 @@ class govuk_aws_xray_daemon (
   }
 
   user { 'xray':
-    ensure => present,
-    name   => 'xray',
-    shell  => '/bin/false',
-    system => true,
+    ensure     => present,
+    name       => 'xray',
+    home       => '/home/xray',
+    managehome => true,
+    shell      => '/bin/false',
+    system     => true,
+  }
+
+  file { '/home/xray':
+    ensure  => directory,
+    owner   => 'xray',
+    group   => 'xray',
+    mode    => '0750',
+    require => User['xray'],
+  }
+
+  file { '/home/xray/.aws':
+    ensure => directory,
+    owner  => 'xray',
+    group  => 'xray',
+    mode   => '0700',
+  }
+
+  file { '/home/xray/.aws/credentials':
+    ensure  => present,
+    owner   => 'xray',
+    group   => 'xray',
+    mode    => '0600',
+    content => template('govuk_aws_xray_daemon/credentials.erb'),
   }
 
   package { 'xray':
     ensure  => latest,
     require => Apt::Source['aws-xray-daemon'],
+  }
+
+  file { '/etc/amazon/xray/cfg.yaml':
+    ensure  => present,
+    owner   => 'xray',
+    group   => 'xray',
+    mode    => '0644',
+    source  => 'puppet:///modules/govuk_aws_xray_daemon/etc/amazon/xray/cfg.yaml',
+    require => Package['xray'],
   }
 }

--- a/modules/govuk_aws_xray_daemon/templates/credentials.erb
+++ b/modules/govuk_aws_xray_daemon/templates/credentials.erb
@@ -1,0 +1,3 @@
+[default]
+aws_access_key_id=<%= @aws_access_key_id %>
+aws_secret_access_key=<%= @aws_secret_access_key %>

--- a/spec/fixtures/hieradata/common.yaml
+++ b/spec/fixtures/hieradata/common.yaml
@@ -36,6 +36,10 @@ govuk_mount::no_op: false
 
 govuk_app_enable_services: false
 
+govuk_aws_xray_daemon::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_aws_xray_daemon::aws_access_key_id: 'ABC'
+govuk_aws_xray_daemon::aws_secret_access_key: '123'
+
 govuk_beat::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 govuk_cdnlogs::govuk_monitoring_enabled: false
@@ -49,8 +53,6 @@ govuk_gor::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk_java::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 govuk_awscli::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
-
-govuk_aws_xray_daemon::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 govuk_jenkins::package::apt_mirror_hostname: 'apt.example.com'
 


### PR DESCRIPTION
This commit adds configuration for the AWS X-Ray daemon. This includes configuring the correct AWS region and providing credentials.

Depends on https://github.com/alphagov/govuk-aws/pull/642 and https://github.com/alphagov/govuk-secrets/pull/442.

Trello: https://trello.com/c/YMZBPMGF/450-provision-x-ray-and-set-up-permissions-%F0%9F%8D%90-portunity