### PR TITLE
Icinga checks for data scrubber tasks

### DIFF
--- a/modules/govuk_datascrubber/manifests/icinga_check.pp
+++ b/modules/govuk_datascrubber/manifests/icinga_check.pp
@@ -1,0 +1,15 @@
+# == Define: govuk_datascrubber::icinga_check
+#
+# Create Icinga passive checks for scrubber tasks
+#
+define govuk_datascrubber::icinga_check {
+  $check_title = "datascrubber-${title}"
+  $service_desc = "GOV.UK data scrubber: ${title})"
+  $threshold_secs = 28 * 3600
+
+  @@icinga::passive_check { $check_title :
+    service_description => $service_desc,
+    freshness_threshold => $threshold_secs,
+    host_name           => $::fqdn,
+  }
+}

--- a/modules/govuk_datascrubber/manifests/init.pp
+++ b/modules/govuk_datascrubber/manifests/init.pp
@@ -95,4 +95,18 @@ class govuk_datascrubber (
     command => $cron_command,
   }
 
+  # The canonical Puppet way to do this would be something like:
+  #
+  #   $mysql_hosts.each do |host| {
+  #     @@icinga::passive_check { "datascrubber-${host}":
+  #       ... other parameters ...
+  #     }
+  #   }
+  #
+  # The following is a hack to work around the unavailability of iterators in
+  # Puppet 3.8 w/o future parser.
+  #
+  $icinga_checks = parsejson(template('govuk_datascrubber/generate_icinga_checks.erb'))
+  create_resources('::govuk_datascrubber::icinga_check', $icinga_checks)
+
 }

--- a/modules/govuk_datascrubber/spec/classes/govuk_datascrubber_spec.rb
+++ b/modules/govuk_datascrubber/spec/classes/govuk_datascrubber_spec.rb
@@ -1,0 +1,8 @@
+require_relative '../../../../spec_helper'
+
+describe 'govuk_datascrubber', :type => :class do
+  it { is_expected.to contain_package('govuk-datascrubber') }
+  it { is_expected.to contain_cron('datascrubber') }
+  it { is_expected.to contain_govuk_datascrubber__icinga_check('mysql-primary') }
+  it { is_expected.to contain_govuk_datascrubber__icinga_check('postgresql-primary') }
+end

--- a/modules/govuk_datascrubber/templates/generate_icinga_checks.erb
+++ b/modules/govuk_datascrubber/templates/generate_icinga_checks.erb
@@ -1,0 +1,6 @@
+<%
+checks = {}
+[scope['mysql_hosts'], scope['postgresql_hosts']].flatten.each do |h|
+  checks.merge!( { h => {} } )
+end
+%><%= checks.to_json %>


### PR DESCRIPTION
Set up Icinga passive checks for each data scrubber task.

Not quite ready yet as the tool itself will need some additional configuration to submit check results.