### PR TITLE
Revert "Uninstall Phantomjs"

### DIFF
--- a/modules/phantomjs/manifests/init.pp
+++ b/modules/phantomjs/manifests/init.pp
@@ -2,6 +2,8 @@
 #
 # Install PhantomJS <http://phantomjs.org/> from the GOV.UK package archive.
 #
+# This is used by Jasmine and Teaspoon to run tests.
+#
 class phantomjs {
   include govuk_ppa
 

--- a/modules/phantomjs/manifests/init.pp
+++ b/modules/phantomjs/manifests/init.pp
@@ -6,7 +6,7 @@ class phantomjs {
   include govuk_ppa
 
   package { 'phantomjs':
-    ensure  => absent,
+    ensure  => '1.9.7-0~ppa1',
     require => Class['govuk_ppa'],
   }
 }


### PR DESCRIPTION
Reverts alphagov/govuk-puppet#8120

Looks like we do need it for some whitehall builds.