### PR TITLE
Update deployment dashboard dependent apps

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1120,6 +1120,8 @@ grafana::dashboards::deployment_applications:
   government-frontend: {}
   hmrc-manuals-api: {}
   imminence:
+    dependent_app_5xx_errors:
+      - frontend
     show_sidekiq_graphs: true
     has_workers: true
   info-frontend: {}
@@ -1128,12 +1130,17 @@ grafana::dashboards::deployment_applications:
   link-checker-api:
     show_sidekiq_graphs: true
     has_workers: true
-  local-links-manager: {}
+  local-links-manager:
+    dependent_app_5xx_errors:
+      - frontend
   manuals-frontend: {}
   manuals-publisher:
     show_sidekiq_graphs: true
     has_workers: true
   mapit:
+    dependent_app_5xx_errors:
+      - frontend
+      - imminence
     # No data in kibana
     show_controller_errors: false
     show_slow_requests: false
@@ -1160,6 +1167,7 @@ grafana::dashboards::deployment_applications:
       - collections
       - finder-frontend
       - frontend
+      - government-frontend
       - whitehall-frontend
   search-admin: {}
   service-manual-frontend: {}

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1006,6 +1006,8 @@ grafana::dashboards::deployment_applications:
   government-frontend: {}
   hmrc-manuals-api: {}
   imminence:
+    dependent_app_5xx_errors:
+      - frontend
     show_sidekiq_graphs: true
     has_workers: true
   info-frontend: {}
@@ -1014,12 +1016,17 @@ grafana::dashboards::deployment_applications:
   link-checker-api:
     show_sidekiq_graphs: true
     has_workers: true
-  local-links-manager: {}
+  local-links-manager:
+    dependent_app_5xx_errors:
+      - frontend
   manuals-frontend: {}
   manuals-publisher:
     show_sidekiq_graphs: true
     has_workers: true
   mapit:
+    dependent_app_5xx_errors:
+      - frontend
+      - imminence
     # No data in kibana
     show_controller_errors: false
     show_slow_requests: false
@@ -1046,6 +1053,7 @@ grafana::dashboards::deployment_applications:
       - collections
       - finder-frontend
       - frontend
+      - government-frontend
       - whitehall-frontend
   search-admin: {}
   service-manual-frontend: {}


### PR DESCRIPTION
These additions show 500 errors for associated applications on the relevant deployment dashboards.  It's useful to be able to see if your deployment of (for example) Imminence has coincided with a spike of 500 errors on Frontend.

This is shown in a section like this:
![screen shot 2018-09-17 at 14 31 44](https://user-images.githubusercontent.com/773037/45626146-a156bb80-ba86-11e8-8d0c-744b442e4f1a.png)
(from the [rummager dashboard on staging](https://grafana.staging.publishing.service.gov.uk/dashboard/file/deployment_rummager.json?refresh=5s&orgId=1))

I've added government-frontend to the rummager section in part because rummager powers the related content section of the sidebar navigation component which is shown.  We also ran the content pages navigation test in government frontend, which used rummager heavily.  We've stopped this test now, but I can easily see another incarnation being run at some point.