### PR TITLE
Configure an Asset Manager token for Content Publisher

### DIFF
--- a/hieradata/development_credentials.yaml
+++ b/hieradata/development_credentials.yaml
@@ -216,6 +216,7 @@ govuk::apps::collections_publisher::publishing_api_bearer_token: 'oauth-bearer-t
 govuk::apps::contacts::oauth_id: 'oauth-contacts-admin'
 govuk::apps::contacts::oauth_secret: 'secret'
 govuk::apps::contacts::publishing_api_bearer_token: 'oauth-bearer-token-publishing-api'
+govuk::apps::content_publisher::asset_manager_bearer_token: 'oauth-bearer-token-asset-manager'
 govuk::apps::content_publisher::publishing_api_bearer_token: 'oauth-bearer-token-publishing-api'
 govuk::apps::content_tagger::oauth_id: 'oauth-content-tagger'
 govuk::apps::content_tagger::oauth_secret: 'secret'

--- a/modules/govuk/manifests/apps/content_publisher.pp
+++ b/modules/govuk/manifests/apps/content_publisher.pp
@@ -71,6 +71,10 @@
 # [*google_tag_manager_auth*]
 #   The identifier of an environment for Google Tag Manager
 #
+# [*asset_manager_bearer_token*]
+#   The bearer token to use when communicating with Asset Manager.
+#   Default: undef
+#
 class govuk::apps::content_publisher (
   $port = '3221',
   $enabled = true,
@@ -93,6 +97,7 @@ class govuk::apps::content_publisher (
   $google_tag_manager_id = undef,
   $google_tag_manager_preview = undef,
   $google_tag_manager_auth = undef,
+  $asset_manager_bearer_token = undef,
 ) {
   $app_name = 'content-publisher'
 
@@ -156,6 +161,9 @@ class govuk::apps::content_publisher (
     "${title}-GOOGLE_TAG_MANAGER_AUTH":
         varname => 'GOOGLE_TAG_MANAGER_AUTH',
         value   => $google_tag_manager_auth;
+    "${title}-ASSET_MANAGER_BEARER_TOKEN":
+        varname => 'ASSET_MANAGER_BEARER_TOKEN',
+        value   => $asset_manager_bearer_token;
   }
 
   if $::govuk_node_class !~ /^development$/ {


### PR DESCRIPTION
For https://trello.com/c/2BSsLGFS/239-upload-images-to-asset-manager-and-set-lead-image-in-publishing-api

This sets an environment variable for Content Publisher to use to authenticate
requests to Asset Manager.

The Asset Manager bearer tokens have been added here: https://github.com/alphagov/govuk-secrets/pull/443