### PR TITLE
Pin docker version to 17.09.0-ce

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -949,6 +949,7 @@ govuk_containers::frontend::haproxy::wildcard_publishing_key: "%{hiera('wildcard
 govuk_crawler::amqp_host: 'localhost'
 govuk_crawler::site_root: 'https://www.gov.uk'
 
+govuk_docker::version: "17.09.0-ce"
 govuk_docker::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 govuk_elasticsearch::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -877,6 +877,7 @@ govuk_crawler::alert_hostname: 'alert'
 govuk_crawler::amqp_host: 'localhost'
 govuk_crawler::site_root: 'https://www.gov.uk'
 
+govuk_docker::version: "17.09.0-ce"
 govuk_docker::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 govuk_elasticsearch::backup::alert_hostname: 'alert'


### PR DESCRIPTION
This is the current version which is currently 'controlled' by
whatever is the most recent version on the apt mirror.

We want to upgrade docker to the latest 17.x version, but
we don't want to go all the way to 18.x yet, which is what
would happen if we updated the mirror.

This pins docker to the current version so we can update
the mirror and update docker in a controlled way.