### PR TITLE
Add content publisher to data_sync_complete_integration

### DIFF
--- a/docs/adding-a-new-app.md
+++ b/docs/adding-a-new-app.md
@@ -202,6 +202,7 @@ Check if your app appears in these files (use existing apps as examples).
   * modules/grafana/files/dashboards/processes.json
   * modules/govuk/manifests/node/s_backend_lb.pp (if a backend app)
   * modules/govuk/manifests/node/s_frontend_lb.pp (if a frontend app)
+  * modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
   * development-vm/Procfile
   * development-vm/Pinfile
   * development-vm/alphagov_repos

--- a/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
@@ -29,7 +29,7 @@
            ssh deploy@$(govuk_node_list -c backend --single-node) 'cd /var/apps/specialist-publisher ; govuk_setenv specialist-publisher bundle exec rake publishing_api:publish_finders'
     publishers:
         - trigger-parameterized-builds:
-            <%- %w{ publishing-api collections-publisher service-manual-publisher local-links-manager email-alert-api transition link-checker-api content-performance-manager content-tagger }.each do |app| -%>
+            <%- %w{ publishing-api collections-publisher service-manual-publisher local-links-manager email-alert-api transition link-checker-api content-performance-manager content-tagger content-publisher }.each do |app| -%>
             - project: Deploy_App
               predefined-parameters: |
                 TARGET_APPLICATION=<%= app %>


### PR DESCRIPTION
This allows the app to have it's migrations run each time the data sync
complete task runs.

It does make me a little nervous that this task may form some sort of
race condition with the whitehall import for content into content
publisher but I think we'll get around this by the order of the builds.
If this becomes more of a problem we may want to run a db:migrate at the
start of the whitehall import.