### PR TITLE
Include Postgres apt repo and govuk_pgbouncer in new db_admin machines

### DIFF
--- a/modules/govuk/manifests/node/s_email_alert_api_db_admin.pp
+++ b/modules/govuk/manifests/node/s_email_alert_api_db_admin.pp
@@ -49,6 +49,16 @@ class govuk::node::s_email_alert_api_db_admin(
 
   # To manage remote databases using the puppetlabs-postgresql module we require
   # a local PostgreSQL server instance to be installed
+  apt::source { 'postgresql':
+    ensure       => present,
+    location     => "http://${apt_mirror_hostname}/postgresql",
+    release      => "${::lsbdistcodename}-pgdg",
+    architecture => $::architecture,
+    key          => 'B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8',
+  } ->
+
+  # To manage remote databases using the puppetlabs-postgresql module we require
+  # a local PostgreSQL server instance to be installed
   class { '::postgresql::server':
     default_connect_settings => $default_connect_settings,
   } ->
@@ -67,6 +77,8 @@ class govuk::node::s_email_alert_api_db_admin(
 
   # Ensure the client class is installed
   class { '::govuk_postgresql::client': } ->
+
+  class { '::govuk_pgbouncer': } ->
 
   # include all PostgreSQL classes that create databases and users
   class { '::govuk::apps::email_alert_api::db': }

--- a/modules/govuk/manifests/node/s_publishing_api_db_admin.pp
+++ b/modules/govuk/manifests/node/s_publishing_api_db_admin.pp
@@ -49,6 +49,16 @@ class govuk::node::s_publishing_api_db_admin(
 
   # To manage remote databases using the puppetlabs-postgresql module we require
   # a local PostgreSQL server instance to be installed
+  apt::source { 'postgresql':
+    ensure       => present,
+    location     => "http://${apt_mirror_hostname}/postgresql",
+    release      => "${::lsbdistcodename}-pgdg",
+    architecture => $::architecture,
+    key          => 'B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8',
+  } ->
+
+  # To manage remote databases using the puppetlabs-postgresql module we require
+  # a local PostgreSQL server instance to be installed
   class { '::postgresql::server':
     default_connect_settings => $default_connect_settings,
   } ->
@@ -67,6 +77,8 @@ class govuk::node::s_publishing_api_db_admin(
 
   # Ensure the client class is installed
   class { '::govuk_postgresql::client': } ->
+
+  class { '::govuk_pgbouncer': } ->
 
   # include all PostgreSQL classes that create databases and users
   class { '::govuk::apps::publishing_api::db': }


### PR DESCRIPTION
The new db-admin machines for email-alert-api and publishing-api didn't include the pgbouncer class (thus causing other Puppet failures and preventing the databases from being provisioned). The missing Apt repo causes the wrong version of the Postgres client to be installed.