### PR TITLE
Disable processing transition logs

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -107,8 +107,6 @@ govuk::deploy::setup::ssh_keys:
 govuk_bouncer::gor::enabled: true
 govuk_bouncer::gor::target: '195.225.216.149'
 
-govuk_cdnlogs::transition_logs::enable_cron: true
-
 govuk_jenkins::config::banner_colour_background: '#df3034'
 govuk_jenkins::config::banner_colour_text: 'white'
 govuk_jenkins::config::banner_string: 'Carrenza PRODUCTION'

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -850,9 +850,6 @@ govuk_cdnlogs::service_port_map:
   assets: 6515
   bouncer: 6516
 
-govuk_cdnlogs::transition_logs::alert_hostname: 'alert'
-govuk_cdnlogs::transition_logs::enabled: false
-
 govuk_containers::app::config::global_envvars:
   - "GOVUK_ENV=production"
   - "NODE_ENV=production"

--- a/modules/govuk_cdnlogs/manifests/transition_logs.pp
+++ b/modules/govuk_cdnlogs/manifests/transition_logs.pp
@@ -23,7 +23,7 @@ class govuk_cdnlogs::transition_logs (
   $transition_stats_private_ssh_key = undef,
   $pre_transition_stats_private_ssh_key = undef,
   $user = 'logs_processor',
-  $enabled = true,
+  $enabled = false,
   $enable_cron = false,
   $alert_hostname = 'alert.cluster',
 ) {

--- a/modules/govuk_cdnlogs/manifests/transition_logs.pp
+++ b/modules/govuk_cdnlogs/manifests/transition_logs.pp
@@ -44,7 +44,6 @@ class govuk_cdnlogs::transition_logs (
     fullname => 'Logs Processor',
   }
 
-
   if $transition_stats_private_ssh_key and $pre_transition_stats_private_ssh_key {
     $ssh_dir = "/home/${user}/.ssh"
 
@@ -111,27 +110,36 @@ class govuk_cdnlogs::transition_logs (
     content => template('govuk_cdnlogs/process_transition_logs.erb'),
   }
 
-  if $enable_cron {
-    cron::crondotdee { 'process_transition_logs':
-      ensure  => $ensure,
-      command => $process_script,
-      hour    => '*',
-      minute  => '30',
-      user    => $user,
-      path    => '/usr/lib/rbenv/shims:/usr/sbin:/usr/bin:/sbin:/bin',
-      require => File[$process_script],
-    }
+  $ensure_cron = $enable_cron ? {
+    true => 'present',
+    false => 'absent',
+  }
 
-    @@icinga::passive_check { "transition-logs-processing-script-${::hostname}":
-      service_description => $service_desc,
-      host_name           => $::fqdn,
-      freshness_threshold => 3600,
-      notes_url           => monitoring_docs_url(data-sources-for-transition),
-    }
+  cron::crondotdee { 'process_transition_logs':
+    ensure  => $ensure_cron,
+    command => $process_script,
+    hour    => '*',
+    minute  => '30',
+    user    => $user,
+    path    => '/usr/lib/rbenv/shims:/usr/sbin:/usr/bin:/sbin:/bin',
+    require => File[$process_script],
+  }
+
+  @@icinga::passive_check { "transition-logs-processing-script-${::hostname}":
+    ensure              => $ensure_cron,
+    service_description => $service_desc,
+    host_name           => $::fqdn,
+    freshness_threshold => 3600,
+    notes_url           => monitoring_docs_url(data-sources-for-transition),
   }
 
   # Provides /opt/mawk required by pre-transition-stats
+  $ensure_mawk = $enabled ? {
+    true => 'installed',
+    false => 'absent',
+  }
+
   package { 'mawk-1.3.4':
-    ensure => installed,
+    ensure => $ensure_mawk,
   }
 }


### PR DESCRIPTION
This is now handled by a Lambda in AWS which reads from Athena, exports to an S3 bucket which is then read by the Transition tool directly.

Depends on #8137.

[Trello Card](https://trello.com/c/dNtEfmJM/395-move-transition-hit-stats-processing-to-s3-and-athena-%F0%9F%8D%90-portunity)