### PR TITLE
Adjust icinga service description for datascrubber

### DIFF
--- a/modules/govuk_datascrubber/manifests/icinga_check.pp
+++ b/modules/govuk_datascrubber/manifests/icinga_check.pp
@@ -4,7 +4,7 @@
 #
 define govuk_datascrubber::icinga_check {
   $check_title = "datascrubber-${title}"
-  $service_desc = "GOV.UK data scrubber: ${title})"
+  $service_desc = "GOV.UK data scrubber ${title}"
   $threshold_secs = 28 * 3600
 
   @@icinga::passive_check { $check_title :


### PR DESCRIPTION
- This made Puppet fail on first run in monitoring (illegal char)

- Removing both colon and closed bracket, because I am lazy

- assuming a version discrepancy?!

solo: @schmie