### PR TITLE
Add Terraboard to the monitoring machines

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -109,6 +109,9 @@ govuk_bouncer::gor::target: '195.225.216.149'
 
 govuk_cdnlogs::transition_logs::enable_cron: true
 
+govuk_containers::terraboard::aws_bucket: 'govuk-terraform-steppingstone-production'
+govuk_containers::terraboard::oauth2_proxy_base_url: 'https://terraboard.publishing.service.gov.uk'
+
 govuk_jenkins::config::banner_colour_background: '#df3034'
 govuk_jenkins::config::banner_colour_text: 'white'
 govuk_jenkins::config::banner_string: 'Carrenza PRODUCTION'

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -60,6 +60,9 @@ govuk_cdnlogs::bouncer_monitoring_enabled: false
 govuk_cdnlogs::warning_cdn_freshness: 86400   # 1 day
 govuk_cdnlogs::critical_cdn_freshness: 172800 # 2 days
 
+govuk_containers::terraboard::aws_bucket: 'govuk-terraform-steppingstone-staging'
+govuk_containers::terraboard::oauth2_proxy_base_url: 'https://terraboard.staging.publishing.service.gov.uk'
+
 govuk_crawler::seed_enable: true
 govuk_crawler::sync_enable: true
 govuk_crawler::targets:

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -54,6 +54,9 @@ govuk::deploy::setup::ssh_keys:
 govuk_cdnlogs::govuk_monitoring_enabled: false
 govuk_cdnlogs::bouncer_monitoring_enabled: false
 
+govuk_containers::terraboard::aws_bucket: 'govuk-terraform-steppingstone-integration'
+govuk_containers::terraboard::oauth2_proxy_base_url: 'https://terraboard.integration.publishing.service.gov.uk'
+
 govuk_elasticsearch::dump::run_es_dump_hour: '9'
 
 govuk_jenkins::job_builder::environment: 'integration'

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -49,6 +49,9 @@ govuk_cdnlogs::bouncer_monitoring_enabled: false
 govuk_cdnlogs::warning_cdn_freshness: 86400   # 1 day
 govuk_cdnlogs::critical_cdn_freshness: 172800 # 2 days
 
+govuk_containers::terraboard::aws_bucket: 'govuk-terraform-steppingstone-production'
+govuk_containers::terraboard::oauth2_proxy_base_url: 'https://terraboard.publishing.service.gov.uk'
+
 govuk_crawler::seed_enable: true
 govuk_crawler::sync_enable: true
 govuk_crawler::targets:

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -55,6 +55,9 @@ govuk_cdnlogs::bouncer_monitoring_enabled: false
 govuk_cdnlogs::warning_cdn_freshness: 86400   # 1 day
 govuk_cdnlogs::critical_cdn_freshness: 172800 # 2 days
 
+govuk_containers::terraboard::aws_bucket: 'govuk-terraform-steppingstone-staging'
+govuk_containers::terraboard::oauth2_proxy_base_url: 'https://terraboard.staging.publishing.service.gov.uk'
+
 govuk_crawler::seed_enable: true
 govuk_crawler::sync_enable: true
 govuk_crawler::targets:

--- a/modules/govuk_containers/manifests/terraboard.pp
+++ b/modules/govuk_containers/manifests/terraboard.pp
@@ -1,0 +1,130 @@
+# == Class: govuk_containers::terraboard
+#
+# Install and run Terraboard in a Docker container with PostgreSQL backend
+# and OAuth2 Proxy for authentication, also in Docker containers. All containers
+# are connected to the `terranet` bridge network.
+#
+# The PostgreSQL database is used to cache Terraform states to reduce the amount
+# of traffic.
+#
+# === Parameters
+#
+# [*aws_region*]
+#   The AWS region to fetch Terraform state from.
+#
+# [*aws_access_key_id*]
+#   The AWS access key ID to use when fetching Terraform state.
+#
+# [*aws_secret_access_key*]
+#   The AWS secret access key to use when fetching Terraform state.
+#
+# [*aws_bucket*]
+#   The AWS bucket to fetch the Terraform state from.
+#
+# [*db_password*]
+#   The database password for the PostgreSQL Docker instance used by Terraboard.
+#
+# [*github_oauth_client_id*]
+#   The OAuth client ID provided by GitHub for authentication.
+#
+# [*github_oauth_client_secret*]
+#   The OAuth client secret provided by GitHub for authentication.
+#
+# [*oauth2_proxy_base_url*]
+#   The base URL of the OAuth2 Proxy installation.
+#
+# [*oauth2_proxy_cookie_secret*]
+#   A Base64-encoded secret used to encrypt the OAuth2 Proxy cookie.
+#
+class govuk_containers::terraboard(
+  $aws_region = 'eu-west-1',
+  $aws_access_key_id = undef,
+  $aws_secret_access_key = undef,
+  $aws_bucket = undef,
+  $db_password = undef,
+  $github_oauth_client_id = undef,
+  $github_oauth_client_secret = undef,
+  $oauth2_proxy_base_url = undef,
+  $oauth2_proxy_cookie_secret = undef,
+) {
+
+  # These names come from the Terraboard defaults
+  # GORM is an ORM for Golang
+  $db_username = 'gorm'
+  $db_name = 'gorm'
+
+  file { ['/opt/terraboard', '/opt/terraboard/conf']:
+    ensure => directory,
+    mode   => '0700',
+  }
+
+  file { '/opt/terraboard/conf/oauth2_proxy.cfg':
+    ensure  => present,
+    mode    => '0600',
+    content => template('govuk_containers/terraboard/conf/oauth2_proxy.cfg.erb'),
+  }
+
+  docker_network { 'terranet':
+    ensure => present,
+  }
+
+  ::docker::image { 'postgres':
+    ensure    => present,
+    require   => Class['govuk_docker'],
+    image_tag => '10.5',
+  }
+
+  ::docker::run { 'terraboard-db':
+    net     => 'terranet',
+    image   => 'postgres',
+    require => Docker::Image['postgres'],
+    env     => [
+      "POSTGRES_USER=${db_username}",
+      "POSTGRES_DB=${db_name}",
+      "POSTGRES_PASSWORD=${db_password}",
+    ],
+  }
+
+  ::docker::image { 'camptocamp/terraboard':
+    ensure    => present,
+    require   => Class['govuk_docker'],
+    image_tag => 'latest',
+  }
+
+  ::docker::run { 'terraboard':
+    net     => 'terranet',
+    image   => 'camptocamp/terraboard',
+    require => Docker::Image['camptocamp/terraboard'],
+    depends => 'terraboard-db',
+    env     => [
+      "AWS_REGION=${aws_region}",
+      "AWS_ACCESS_KEY_ID=${aws_access_key_id}",
+      "AWS_SECRET_ACCESS_KEY=${aws_secret_access_key}",
+      "AWS_BUCKET=${aws_bucket}",
+      'DB_HOST=terraboard-db',
+      "DB_PASSWORD=${db_password}",
+    ],
+  }
+
+  ::docker::image { 'govuk/govuk-oauth2-proxy-docker':
+    ensure    => present,
+    require   => Class['govuk_docker'],
+    image_tag => 'latest',
+  }
+
+  ::docker::run { 'terraboard-oauth2-proxy':
+    net     => 'terranet',
+    image   => 'govuk/govuk-oauth2-proxy-docker',
+    require => Docker::Image['govuk/govuk-oauth2-proxy-docker'],
+    ports   => ['7920:4180'],
+    volumes => ['/opt/terraboard/conf:/conf'],
+    depends => 'terraboard',
+  }
+
+  @@icinga::check { "check_terraboard_running_${::hostname}":
+    check_command       => 'check_nrpe!check_proc_running!terraboard',
+    service_description => 'terraboard running',
+    host_name           => $::fqdn,
+    notes_url           => monitoring_docs_url(check-process-running),
+  }
+}

--- a/modules/govuk_containers/templates/terraboard/conf/oauth2_proxy.cfg.erb
+++ b/modules/govuk_containers/templates/terraboard/conf/oauth2_proxy.cfg.erb
@@ -1,0 +1,46 @@
+# OAuth2 Proxy Config File
+# https://github.com/bitly/oauth2_proxy
+
+# <addr>:<port> to listen on for HTTP clients
+http_address = "0.0.0.0:4180"
+
+# The HTTP URL(s) of the upstream endpoint(s)
+# If multiple, routing is based on path
+upstreams = ["http://terraboard:8080/"]
+
+# Email domains to allow authentication for (this authorises any email on this domain)
+email_domains = ["*"]
+
+# OAuth provider, client ID, secret and redirect URL
+provider = "github"
+client_id = "<%= @github_oauth_client_id %>"
+client_secret = "<%= @github_oauth_client_secret %>"
+redirect_url = "<%= @oauth2_proxy_base_url %>/oauth2/callback"
+
+# GitHub organisation and team to restrict authentication to
+github_org = "alphagov"
+github_team = "gov-uk-production"
+
+# Don't display the default footer
+footer = "-"
+
+## Cookie settings
+## Name     - the cookie name
+## Secret   - the seed string for secure cookies; should be 16, 24, or 32 bytes
+##            for use with an AES cipher when cookie_refresh or pass_access_token
+##            is set
+## Domain   - (optional) cookie domain to force cookies to (ie: .yourcompany.com)
+## Expire   - (duration) expire timeframe for cookie
+## Refresh  - (duration) refresh the cookie when duration has elapsed after cookie was initially set.
+##            Should be less than cookie_expire; set to 0 to disable.
+##            On refresh, OAuth token is re-validated.
+##            (ie: 1h means tokens are refreshed on request 1hr+ after it was set)
+## Secure   - secure cookies are only sent by the browser of a HTTPS connection (recommended)
+## HttpOnly - httponly cookies are not readable by javascript (recommended)
+cookie_name = "_terraboard_oauth2_proxy"
+cookie_secret = "<%= @oauth2_proxy_cookie_secret %>"
+# cookie_domain = ""
+cookie_expire = "24h"
+cookie_refresh = "1h"
+cookie_secure = true
+cookie_httponly = true


### PR DESCRIPTION
This commit installs Terraboard to the monitoring machines along with dependencies.

* Installs Docker
* Creates a new custom bridge network called terranet
* Creates a configuration file for OAuth2 Proxy
* Downloads and runs Docker images for Terraboard, PostgreSQL and OAuth2 Proxy
* Creates an Icinga check to ensure Terraboard is running
* Adds non-secret hieradata
* Adds an nginx proxy for the external Terraboard subdomain to the OAuth2 Proxy Docker container

Depends on https://github.com/alphagov/govuk-secrets/pull/446

Trello: https://trello.com/c/6UMlTRpa/490-get-terraboard-running-on-the-monitoring-machines-in-each-environment