### PR TITLE
Remove Terraboard Icinga check

### DIFF
--- a/modules/govuk_containers/manifests/terraboard.pp
+++ b/modules/govuk_containers/manifests/terraboard.pp
@@ -122,6 +122,7 @@ class govuk_containers::terraboard(
   }
 
   @@icinga::check { "check_terraboard_running_${::hostname}":
+    ensure              => absent,
     check_command       => 'check_nrpe!check_proc_running!terraboard',
     service_description => 'terraboard running',
     host_name           => $::fqdn,


### PR DESCRIPTION
This check doesn’t work since Terraboard is run inside Docker so we can’t detect it.

Trello: https://trello.com/c/6UMlTRpa/490-get-terraboard-running-on-the-monitoring-machines-in-each-environment