### PR TITLE
Change content publisher import to be periodic

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/content_publisher_whitehall_import.pp
+++ b/modules/govuk_jenkins/manifests/jobs/content_publisher_whitehall_import.pp
@@ -5,6 +5,7 @@
 class govuk_jenkins::jobs::content_publisher_whitehall_import (
   $enable_slack_notifications = false,
   $app_domain = hiera('app_domain'),
+  $cron_schedule = '0 9 * * 1-5'
 ) {
   $slack_team_domain = 'gds'
   $slack_room = 'govuk-pubworkflow-dev'

--- a/modules/govuk_jenkins/templates/jobs/content_publisher_whitehall_import.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/content_publisher_whitehall_import.yaml.erb
@@ -15,6 +15,8 @@
            ssh deploy@$(govuk_node_list -c whitehall_backend --single-node) 'cd /data/apps/whitehall/current; govuk_setenv whitehall bundle exec rake export:news_documents 2>&1' |
            grep created_at |
            ssh deploy@$(govuk_node_list -c backend --single-node) 'cd /data/apps/content-publisher/current; govuk_setenv content-publisher bundle exec rake import:whitehall_news'
+    triggers:
+        - timed: '<%= @cron_schedule %>'
     publishers:
       <% if @enable_slack_notifications %>
       - slack:

--- a/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
@@ -40,7 +40,5 @@
                 TARGET_APPLICATION=whitehall
                 MACHINE_CLASS=whitehall_backend
                 RAKE_TASK=publishing:scheduled:requeue_all_jobs
-            - project: content-publisher-whitehall-import
-              trigger-with-no-params: true
         - email:
             recipients: govuk-ci-notifications@digital.cabinet-office.gov.uk


### PR DESCRIPTION
We were having issues with this job running immediately after the data
sync is completed, probably due to the Whitehall machines being OOM.