### PR TITLE
Data scrubber: Add /usr/sbin to PATH of cron job

### DIFF
--- a/modules/govuk_datascrubber/manifests/init.pp
+++ b/modules/govuk_datascrubber/manifests/init.pp
@@ -102,7 +102,7 @@ class govuk_datascrubber (
     user    => $cron_user,
     hour    => $cron_hour,
     minute  => $cron_minute,
-    command => $cron_command,
+    command => "PATH=/usr/sbin:/usr/bin:/bin ${cron_command}",
   }
 
   # The canonical Puppet way to do this would be something like:


### PR DESCRIPTION
`send_nsca` is installed in `/usr/sbin`.