### PR TITLE
Disable the use of insecure arcfour SSH ciphers

### DIFF
--- a/modules/ssh/templates/sshd_config.erb
+++ b/modules/ssh/templates/sshd_config.erb
@@ -4,6 +4,8 @@ HostKey                         /etc/ssh/ssh_host_rsa_key
 HostKey                         /etc/ssh/ssh_host_dsa_key
 UsePrivilegeSeparation          yes
 
+Ciphers -arcfour,arcfour128,arcfour256
+
 SyslogFacility                  AUTH
 LogLevel                        VERBOSE
 


### PR DESCRIPTION
- This was a recommendation from our pentest.
- From sshd_config(5):
    If the specified value begins with a `+' character,
    then the specified ciphers will be appended to the default set
    instead of replacing them.  If the specified value begins with a
    `-' character, then the specified ciphers (including wildcards)
    will be removed from the default set instead of replacing them.