### PR TITLE
Fix the AWS Production email-alert-api backend IP range

### DIFF
--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -19,7 +19,7 @@ govuk::apps::content_publisher::google_tag_manager_id: "GTM-NQXC4TG"
 govuk::apps::content_publisher::google_tag_manager_preview: "env-7"
 govuk::apps::content_store::performance_platform_big_screen_view_url: 'https://performance-platform-big-screen-view-production.cloudapps.digital'
 govuk::apps::content_store::performance_platform_spotlight_url: 'https://performance-platform-spotlight-production.cloudapps.digital'
-govuk::apps::email_alert_api::db::backend_ip_range: '10.12.3.0/24'
+govuk::apps::email_alert_api::db::backend_ip_range: '10.13.3.0/24'
 govuk::apps::email_alert_api::email_archive_s3_bucket: 'govuk-production-email-alert-api-archive'
 # This shouldn't be enabled at the same time we have carrenza s3 export enabled unless they have separate buckets
 govuk::apps::email_alert_api::email_archive_s3_enabled: false


### PR DESCRIPTION
- This wasn't updated when we moved from 10.3 to 10.13 in Production, as
  it was wrongly the staging IP range.
- Fixes https://github.com/alphagov/govuk-puppet/pull/8133#pullrequestreview-157287324.