### PR TITLE
Revert "Disable the use of insecure arcfour SSH ciphers"

### DIFF
--- a/modules/ssh/templates/sshd_config.erb
+++ b/modules/ssh/templates/sshd_config.erb
@@ -4,8 +4,6 @@ HostKey                         /etc/ssh/ssh_host_rsa_key
 HostKey                         /etc/ssh/ssh_host_dsa_key
 UsePrivilegeSeparation          yes
 
-Ciphers -arcfour,arcfour128,arcfour256
-
 SyslogFacility                  AUTH
 LogLevel                        VERBOSE
 


### PR DESCRIPTION
Reverts alphagov/govuk-puppet#8153

- Do we have to specify ones we want to allow, it's not selectively declining the ones we specify to disable?