### PR TITLE
Data scrubber: Export dumps to S3

### DIFF
--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -133,3 +133,4 @@ nginx::config::stack_network_prefix: '10.13.0'
 govuk_datascrubber::ensure: 'latest'
 govuk_datascrubber::share_with:
   - '210287912431'     # AWS integration
+govuk_datascrubber::s3_export_prefix: 's3://govuk-staging-database-backups/scrubbed'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -139,3 +139,4 @@ nginx::config::stack_network_prefix: '10.12.0'
 govuk_datascrubber::ensure: 'latest'
 govuk_datascrubber::share_with:
   - '210287912431'     # AWS integration
+govuk_datascrubber::s3_export_prefix: 's3://govuk-production-database-backups/scrubbed'

--- a/modules/govuk_datascrubber/manifests/init.pp
+++ b/modules/govuk_datascrubber/manifests/init.pp
@@ -40,6 +40,12 @@
 # [*alert_hostname*]
 #   The hostname to submit Icinga passive check notifications to
 #
+# [*s3_export_prefix*]
+#   The S3 URL prefix to export database dumps to, e.g.:
+#   s3://bucketname/prefix
+#   will result in dumps being pushed to
+#   s3://bucketname/prefix/dbname.sql.gz
+#
 class govuk_datascrubber (
   $ensure              = 'latest',
   $apt_mirror_hostname = undef,
@@ -52,6 +58,7 @@ class govuk_datascrubber (
   $share_with          = [],
   $aws_region          = undef,
   $alert_hostname      = 'alert.cluster',
+  $s3_export_prefix    = undef,
 ) {
 
   if $apt_mirror_hostname {
@@ -88,7 +95,12 @@ class govuk_datascrubber (
       $alert_hostname ? {
         undef   => [],
         default => ['--icinga-host', $alert_hostname],
-      }
+      },
+
+      $s3_export_prefix ? {
+        undef   => [],
+        default => ['--s3-export', $s3_export_prefix],
+      },
     ])
   )
 


### PR DESCRIPTION
Switch on the S3 export feature.

Depends on https://github.com/alphagov/govuk-datascrubber/pull/8