### PR TITLE
Add Jenkins job for govuk-alert-tracker

### DIFF
--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -45,6 +45,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::remove_emergency_banner
   - govuk_jenkins::jobs::run_rake_task
   - govuk_jenkins::jobs::run_whitehall_data_migrations
+  - govuk_jenkins::jobs::scrape_icinga_alerts_for_dashboard_metrics
   - govuk_jenkins::jobs::search_benchmark
   - govuk_jenkins::jobs::search_fetch_analytics_data
   - govuk_jenkins::jobs::search_index_checks

--- a/modules/govuk_jenkins/manifests/jobs/govuk_navigation_link_analysis.pp
+++ b/modules/govuk_jenkins/manifests/jobs/govuk_navigation_link_analysis.pp
@@ -30,6 +30,7 @@
 #
 class govuk_jenkins::jobs::govuk_navigation_link_analysis (
   $rate_limit_token = undef,
+  $project_id = 'govuk-tagging-monitor',
   $private_key_id = undef,
   $private_key = undef,
   $client_email = undef,

--- a/modules/govuk_jenkins/manifests/jobs/scrape_icinga_alerts_for_dashboard_metrics.pp
+++ b/modules/govuk_jenkins/manifests/jobs/scrape_icinga_alerts_for_dashboard_metrics.pp
@@ -1,0 +1,57 @@
+# == Class: govuk_jenkins::jobs::scrape_icinga_alerts_for_dashboard_metrics
+#
+#This is run monthly to call a script that scrapes hard alerts from Icinga, and stored in a Google sheet.
+#The data is used by the Platform Health dashboard to display metrics about our apps.
+#
+# === Parameters
+#
+# [*private_key_id*]
+#   Specific to access the Google API.
+#
+# [*private_key*]
+#   Specific to access the Google API.
+#
+# [*client_email*]
+#   Specific to access the Google API.
+#
+# [*client_id*]
+#   Specific to access the Google API.
+#
+# [*client_x509_cert_url*]
+#   Specific to access the Google API.
+#
+class govuk_jenkins::jobs::scrape_icinga_alerts_for_dashboard_metrics (
+  $project_id = 'gam-project-v3f-sr7-n9p',
+  $private_key_id = undef,
+  $private_key = undef,
+  $client_email = undef,
+  $client_id = undef,
+  $client_x509_cert_url = undef,
+  $enable_slack_notifications = true,
+  $slack_auth_token = undef,
+  $app_domain = hiera('app_domain'),
+) {
+
+  $slack_team_domain = 'gds'
+  $slack_room = 'platform-health'
+  $slack_build_server_url = "https://deploy.${app_domain}/"
+
+  file { '/var/lib/jenkins/workspace/scrape_icinga_alerts_for_dashboard_metrics/':
+    ensure => directory,
+    owner  => 'jenkins',
+    group  => 'jenkins',
+  }
+
+  file { '/var/lib/jenkins/workspace/scrape_icinga_alerts_for_dashboard_metrics/credentials.json':
+    ensure  => present,
+    content => template('govuk_jenkins/google_api/credentials.json.erb'),
+    owner   => 'jenkins',
+    group   => 'jenkins',
+  }
+
+  file { '/etc/jenkins_jobs/jobs/scrape_icinga_alerts_for_dashboard_metrics.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/scrape_icinga_alerts_for_dashboard_metrics.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+}

--- a/modules/govuk_jenkins/templates/google_api/credentials.json.erb
+++ b/modules/govuk_jenkins/templates/google_api/credentials.json.erb
@@ -1,6 +1,6 @@
 {
   "type": "service_account",
-  "project_id": "govuk-tagging-monitor",
+  "project_id": "<%= @project_id -%>",
   "private_key_id": "<%= @private_key_id -%>",
   "private_key": "<%= @private_key -%>",
   "client_email": "<%= @client_email -%>",

--- a/modules/govuk_jenkins/templates/jobs/scrape_icinga_alerts_for_dashboard_metrics.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/scrape_icinga_alerts_for_dashboard_metrics.yaml.erb
@@ -1,0 +1,49 @@
+---
+- scm:
+    name: scrape_icinga_alerts_for_dashboard_metrics
+    scm:
+        - git:
+            url: git@github.com:alphagov/govuk-alert-tracker.git
+            branches:
+              - master
+
+---
+- job:
+    name: scrape_icinga_alerts_for_dashboard_metrics
+    display-name: Scrape Icinga alerts for dashboard metrics
+    project-type: freestyle
+    scm:
+      - scrape_icinga_alerts_for_dashboard_metrics
+    description: "Extracts information about alerts into a Google sheet which the dashboard extracts data from"
+    logrotate:
+        numToKeep: 10
+    triggers:
+        - timed: |
+            TZ=Europe/London
+            0 7 1 * *
+    properties:
+      - build-discarder:
+          days-to-keep: 30
+          artifact-num-to-keep: 5
+    builders:
+       - shell: |
+          cd govuk-alert-tracker
+          bundle install
+          bundle exec rake run_monthly_report
+    publishers:
+      <% if @enable_slack_notifications %>
+      - slack:
+          team-domain: <%= @slack_team_domain %>
+          auth-token: <%= @slack_auth_token %>
+          build-server-url: <%= @slack_build_server_url %>
+          notify-start: false
+          notify-success: true
+          notify-aborted: false
+          notify-notbuilt: false
+          notify-unstable: false
+          notify-failure: true
+          notify-backtonormal: true
+          notify-repeatedfailure: true
+          include-test-summary: false
+          room: <%= @slack_room %>
+      <% end %>


### PR DESCRIPTION
We have a new app `govuk-alert-tracker` which runs a script that scrapes Icinga for alerts and stores it in a Google sheet. Our [Platform Health Dashboard](https://datastudio.google.com/u/0/reporting/1bXgS9j2mgMJtifuQrVHaZ5rYwxKCns0k/page/gKOG) then extracts the data from the sheet to populate the dashboard metrics.

This commit adds a Jenkins job that runs the rake task on the first day of each month at 7am.

Trello card: [Improve alerting information on the Platform Health dashboard](https://trello.com/c/B1dtJ48q/420-improve-alerting-information-on-the-platform-health-dashboard)

Related PR setting up the Google credentials: https://github.com/alphagov/govuk-secrets/pull/451