### PR TITLE
Use EMAIL_ADDRESSES_TO_CHECK

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -961,8 +961,6 @@ govuk_jenkins::config::github_api_uri: "https://api.github.com"
 govuk_jenkins::config::github_web_uri: "https://github.com"
 govuk_jenkins::jobs::deploy_app::app_domain: "%{hiera('app_domain')}"
 
-govuk_jenkins::jobs::email_alert_check::emails_that_should_send_alerts: "govuk-email-courtesy-copies@digital.cabinet-office.gov.uk,gov.uk.email@notifications.service.gov.uk"
-
 govuk_jenkins::jobs::search_benchmark::auth_username: "%{hiera('http_username')}"
 govuk_jenkins::jobs::search_benchmark::auth_password: "%{hiera('http_password')}"
 

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -961,6 +961,15 @@ govuk_jenkins::config::github_api_uri: "https://api.github.com"
 govuk_jenkins::config::github_web_uri: "https://github.com"
 govuk_jenkins::jobs::deploy_app::app_domain: "%{hiera('app_domain')}"
 
+govuk_jenkins::jobs::email_alert_check::email_addresses_to_check: >-
+  govuk-email-courtesy-copies@digital.cabinet-office.gov.uk
+  ,
+  govuk-email-courtesy-copies@digital.cabinet-office.gov.uk
+  :
+  govuk_email_check@digital.cabinet-office.gov.uk
+  ,
+  gov.uk.email@notifications.service.gov.uk
+
 govuk_jenkins::jobs::search_benchmark::auth_username: "%{hiera('http_username')}"
 govuk_jenkins::jobs::search_benchmark::auth_password: "%{hiera('http_password')}"
 

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -891,8 +891,6 @@ govuk_jenkins::config::github_api_uri: "https://api.github.com"
 govuk_jenkins::config::github_web_uri: "https://github.com"
 govuk_jenkins::jobs::deploy_app::app_domain: "%{hiera('app_domain')}"
 
-govuk_jenkins::jobs::email_alert_check::emails_that_should_send_alerts: "govuk-email-courtesy-copies@digital.cabinet-office.gov.uk,gov.uk.email@notifications.service.gov.uk"
-
 govuk_jenkins::jobs::passive_checks::alert_hostname: 'alert'
 
 govuk_jenkins::jobs::search_benchmark::auth_username: "%{hiera('http_username')}"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -891,6 +891,15 @@ govuk_jenkins::config::github_api_uri: "https://api.github.com"
 govuk_jenkins::config::github_web_uri: "https://github.com"
 govuk_jenkins::jobs::deploy_app::app_domain: "%{hiera('app_domain')}"
 
+govuk_jenkins::jobs::email_alert_check::email_addresses_to_check: >-
+  govuk-email-courtesy-copies@digital.cabinet-office.gov.uk
+  ,
+  govuk-email-courtesy-copies@digital.cabinet-office.gov.uk
+  :
+  govuk_email_check@digital.cabinet-office.gov.uk
+  ,
+  gov.uk.email@notifications.service.gov.uk
+
 govuk_jenkins::jobs::passive_checks::alert_hostname: 'alert'
 
 govuk_jenkins::jobs::search_benchmark::auth_username: "%{hiera('http_username')}"

--- a/modules/govuk_jenkins/manifests/jobs/email_alert_check.pp
+++ b/modules/govuk_jenkins/manifests/jobs/email_alert_check.pp
@@ -31,7 +31,7 @@ class govuk_jenkins::jobs::email_alert_check (
   $google_client_secret = undef,
   $emails_that_should_receive_drug_alerts = undef,
   $emails_that_should_receive_travel_advice_alerts = undef,
-  $emails_that_should_send_alerts = undef,
+  $email_addresses_to_check = undef,
   $app_domain = hiera('app_domain'),
   $sentry_dsn = undef,
 ) {

--- a/modules/govuk_jenkins/templates/jobs/drug_email_alert_check.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/drug_email_alert_check.yaml.erb
@@ -60,8 +60,8 @@
               - name: EMAILS_THAT_SHOULD_RECEIVE_DRUG_ALERTS
                 password:
                   '<%= @emails_that_should_receive_drug_alerts %>'
-              - name: EMAILS_THAT_SHOULD_SEND_ALERTS
-                password: '<%= @emails_that_should_send_alerts %>'
+              - name: EMAIL_ADDRESSES_TO_CHECK
+                password: '<%= @email_addresses_to_check %>'
               - name: SENTRY_DSN
                 password:
                   '<%= @sentry_dsn %>'

--- a/modules/govuk_jenkins/templates/jobs/travel_advice_email_alert_check.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/travel_advice_email_alert_check.yaml.erb
@@ -60,8 +60,8 @@
               - name: EMAILS_THAT_SHOULD_RECEIVE_TRAVEL_ADVICE_ALERTS
                 password:
                   '<%= @emails_that_should_receive_travel_advice_alerts %>'
-              - name: EMAILS_THAT_SHOULD_SEND_ALERTS
-                password: '<%= @emails_that_should_send_alerts %>'
+              - name: EMAIL_ADDRESSES_TO_CHECK
+                password: '<%= @email_addresses_to_check %>'
               - name: SENTRY_DSN
                 password:
                   '<%= @sentry_dsn %>'


### PR DESCRIPTION
This is the new way of defining the configuration for `email-alert-monitoring`.

The actual value will be set in `govuk-secrets`.

[Trello Card](https://trello.com/c/dqOgNIPf/499-make-email-alert-monitoring-also-check-courtesy-copies)