### PR TITLE
Make some Terraboard changes

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -109,9 +109,6 @@ govuk_bouncer::gor::target: '195.225.216.149'
 
 govuk_cdnlogs::transition_logs::enable_cron: true
 
-govuk_containers::terraboard::aws_bucket: 'govuk-terraform-steppingstone-production'
-govuk_containers::terraboard::oauth2_proxy_base_url: 'https://terraboard.publishing.service.gov.uk'
-
 govuk_jenkins::config::banner_colour_background: '#df3034'
 govuk_jenkins::config::banner_colour_text: 'white'
 govuk_jenkins::config::banner_string: 'Carrenza PRODUCTION'

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -60,9 +60,6 @@ govuk_cdnlogs::bouncer_monitoring_enabled: false
 govuk_cdnlogs::warning_cdn_freshness: 86400   # 1 day
 govuk_cdnlogs::critical_cdn_freshness: 172800 # 2 days
 
-govuk_containers::terraboard::aws_bucket: 'govuk-terraform-steppingstone-staging'
-govuk_containers::terraboard::oauth2_proxy_base_url: 'https://terraboard.staging.publishing.service.gov.uk'
-
 govuk_crawler::seed_enable: true
 govuk_crawler::sync_enable: true
 govuk_crawler::targets:

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -55,7 +55,7 @@ govuk_cdnlogs::govuk_monitoring_enabled: false
 govuk_cdnlogs::bouncer_monitoring_enabled: false
 
 govuk_containers::terraboard::aws_bucket: 'govuk-terraform-steppingstone-integration'
-govuk_containers::terraboard::oauth2_proxy_base_url: 'https://terraboard.integration.publishing.service.gov.uk'
+govuk_containers::terraboard::oauth2_proxy_base_url: 'https://terraboard.integration.govuk.digital'
 
 govuk_elasticsearch::dump::run_es_dump_hour: '9'
 

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -50,7 +50,7 @@ govuk_cdnlogs::warning_cdn_freshness: 86400   # 1 day
 govuk_cdnlogs::critical_cdn_freshness: 172800 # 2 days
 
 govuk_containers::terraboard::aws_bucket: 'govuk-terraform-steppingstone-production'
-govuk_containers::terraboard::oauth2_proxy_base_url: 'https://terraboard.publishing.service.gov.uk'
+govuk_containers::terraboard::oauth2_proxy_base_url: 'https://terraboard.production.govuk.digital'
 
 govuk_crawler::seed_enable: true
 govuk_crawler::sync_enable: true

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -56,7 +56,7 @@ govuk_cdnlogs::warning_cdn_freshness: 86400   # 1 day
 govuk_cdnlogs::critical_cdn_freshness: 172800 # 2 days
 
 govuk_containers::terraboard::aws_bucket: 'govuk-terraform-steppingstone-staging'
-govuk_containers::terraboard::oauth2_proxy_base_url: 'https://terraboard.staging.publishing.service.gov.uk'
+govuk_containers::terraboard::oauth2_proxy_base_url: 'https://terraboard.staging.govuk.digital'
 
 govuk_crawler::seed_enable: true
 govuk_crawler::sync_enable: true

--- a/modules/govuk/manifests/node/s_monitoring.pp
+++ b/modules/govuk/manifests/node/s_monitoring.pp
@@ -48,16 +48,16 @@ class govuk::node::s_monitoring (
     }
   }
 
-  # On AWS, the wildcard alias is already added
+  # Only install Terraboard in AWS
   if $::aws_migration {
-    $terraboard_aliases = []
+    $terraboard_ensure = present
   } else {
-    $terraboard_aliases = ['terraboard.*']
+    $terraboard_ensure = absent
   }
 
   nginx::config::vhost::proxy { 'terraboard':
+    ensure       => $terraboard_ensure,
     to           => ['localhost:7920'],
-    aliases      => $terraboard_aliases,
     ssl_only     => true,
     ssl_certtype => 'wildcard_publishing',
     protected    => false,


### PR DESCRIPTION
This commit:

* Re-points Terraboard in AWS to AWS-specific domains
* Removes Terraboard from Carrenza infrastructure along with hiera data for these environments
* Removes an Icinga check which has already been removed from Icinga
* Makes dependencies between the Docker bridge network and contains explicit so containers are not created before the network