### PR TITLE
Increase Puppetserver RAM

### DIFF
--- a/modules/puppet/manifests/puppetserver/config.pp
+++ b/modules/puppet/manifests/puppetserver/config.pp
@@ -1,7 +1,7 @@
 # FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
 class puppet::puppetserver::config {
 
-  $java_args = '-Xms6g -Xmx6g -XX:MaxPermSize=1g'
+  $java_args = '-Xms12g -Xmx12g -XX:MaxPermSize=1g'
 
   file {'/etc/puppet/puppetdb.conf':
     content => template('puppet/etc/puppet/puppetdb.conf.erb'),


### PR DESCRIPTION
- 6G max heap causes the machine to crash from time to time.

- Had to give the machine 16G RAM, so might as well use it - doubling max
heap to 12G

solo: @schmie