### PR TITLE
Specify Ruby version in Jenkins job

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/scrape_icinga_alerts_for_dashboard_metrics.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/scrape_icinga_alerts_for_dashboard_metrics.yaml.erb
@@ -26,6 +26,8 @@
           artifact-num-to-keep: 5
     builders:
        - shell: |
+          export RBENV_VERSION=2.3
+          export PATH=/usr/lib/rbenv/shims:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
           bundle install
           bundle exec rake run_monthly_report
     publishers:


### PR DESCRIPTION
I tried to run the `scrape_icinga_alerts_for_dashboard_metrics` Jenkins job in `production`, but it was unable to find the right Ruby version to `bundle`. Hopefully specifying these environment variables will fix this issue.

Trello card: https://trello.com/c/B1dtJ48q/420-improve-alerting-information-on-the-platform-health-dashboard