### PR TITLE
Increase the nagios memory thresholds for publishing API

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -597,8 +597,8 @@ govuk::apps::publishing_api::redis_host: "redis-2.backend"
 govuk::apps::publishing_api::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::publishing_api::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 govuk::apps::publishing_api::govuk_content_schemas_path: '/data/apps/govuk-content-schemas/current'
-govuk::apps::publishing_api::nagios_memory_warning: 2500
-govuk::apps::publishing_api::nagios_memory_critical: 3000
+govuk::apps::publishing_api::nagios_memory_warning: 1000
+govuk::apps::publishing_api::nagios_memory_critical: 1200
 
 govuk::apps::release::db_hostname: "master.mysql"
 govuk::apps::release::db_username: "release"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -509,6 +509,9 @@ govuk::apps::publisher::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
 govuk::apps::publisher::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::publisher::redis_port: "%{hiera('sidekiq_port')}"
 
+govuk::apps::publishing_api::nagios_memory_warning: 1000
+govuk::apps::publishing_api::nagios_memory_critical: 1200
+
 govuk::apps::short_url_manager::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::short_url_manager::redis_port: "%{hiera('sidekiq_port')}"
 

--- a/modules/govuk/manifests/apps/publishing_api.pp
+++ b/modules/govuk/manifests/apps/publishing_api.pp
@@ -100,6 +100,12 @@
 # [*content_api_prototype*]
 #  Set to true if you want to enable the Content API prototypes within the app
 #
+# [*nagios_memory_warning*]
+#   Memory use at which Nagios should generate a warning.
+#
+# [*nagios_memory_critical*]
+#   Memory use at which Nagios should generate a critical alert.
+#
 class govuk::apps::publishing_api(
   $ensure = 'present',
   $port = '3093',
@@ -128,6 +134,8 @@ class govuk::apps::publishing_api(
   $event_log_aws_access_id  = undef,
   $event_log_aws_secret_key = undef,
   $content_api_prototype = false,
+  $nagios_memory_warning = undef,
+  $nagios_memory_critical = undef,
 ) {
   $app_name = 'publishing-api'
 
@@ -136,14 +144,16 @@ class govuk::apps::publishing_api(
   include govuk_postgresql::client #installs libpq-dev package needed for pg gem
 
   govuk::app { $app_name:
-    ensure             => $ensure,
-    app_type           => 'rack',
-    port               => $port,
-    sentry_dsn         => $sentry_dsn,
-    vhost_ssl_only     => true,
-    health_check_path  => '/healthcheck',
-    log_format_is_json => true,
-    deny_framing       => true,
+    ensure                 => $ensure,
+    app_type               => 'rack',
+    port                   => $port,
+    sentry_dsn             => $sentry_dsn,
+    vhost_ssl_only         => true,
+    health_check_path      => '/healthcheck',
+    log_format_is_json     => true,
+    deny_framing           => true,
+    nagios_memory_warning  => $nagios_memory_warning,
+    nagios_memory_critical => $nagios_memory_critical,
   }
 
   govuk::procfile::worker {'publishing-api':


### PR DESCRIPTION
https://grafana.publishing.service.gov.uk/dashboard/file/publishing_api_overview.json?panelId=8&fullscreen&orgId=1&from=now-30d&to=now

The combined memory usage of Sidekiq, Rails and Redis is ~4GB. Rails hovers around 1GB during busy periods. It looks as though memory thresholds were added for the publishing api but never used via the puppet module so I've corrected and enabled these.