### PR TITLE
Update Ruby version in Jenkins Job

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/scrape_icinga_alerts_for_dashboard_metrics.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/scrape_icinga_alerts_for_dashboard_metrics.yaml.erb
@@ -26,7 +26,7 @@
           artifact-num-to-keep: 5
     builders:
        - shell: |
-          export RBENV_VERSION=2.3
+          export RBENV_VERSION=2.5.1
           export PATH=/usr/lib/rbenv/shims:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
           bundle install
           bundle exec rake run_monthly_report


### PR DESCRIPTION
The current Ruby version doesn't match the one set in `[govuk-alert-tracker](https://github.com/alphagov/govuk-alert-tracker/blob/master/Gemfile)` (completely my fault!)

Trello card: https://trello.com/c/B1dtJ48q/420-improve-alerting-information-on-the-platform-health-dashboard

