### PR TITLE
Increase nagios memory usage thresholds for publishing api

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -597,8 +597,8 @@ govuk::apps::publishing_api::redis_host: "redis-2.backend"
 govuk::apps::publishing_api::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::publishing_api::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 govuk::apps::publishing_api::govuk_content_schemas_path: '/data/apps/govuk-content-schemas/current'
-govuk::apps::publishing_api::nagios_memory_warning: 1000
-govuk::apps::publishing_api::nagios_memory_critical: 1200
+govuk::apps::publishing_api::nagios_memory_warning: 2000
+govuk::apps::publishing_api::nagios_memory_critical: 2500
 
 govuk::apps::release::db_hostname: "master.mysql"
 govuk::apps::release::db_username: "release"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -509,9 +509,6 @@ govuk::apps::publisher::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
 govuk::apps::publisher::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::publisher::redis_port: "%{hiera('sidekiq_port')}"
 
-govuk::apps::publishing_api::nagios_memory_warning: 1000
-govuk::apps::publishing_api::nagios_memory_critical: 1200
-
 govuk::apps::short_url_manager::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::short_url_manager::redis_port: "%{hiera('sidekiq_port')}"
 
@@ -615,8 +612,8 @@ govuk::apps::publishing_api::db::backend_ip_range: "%{hiera('environment_ip_pref
 govuk::apps::publishing_api::db::allow_auth_from_lb: true
 govuk::apps::publishing_api::db::lb_ip_range: "%{hiera('environment_ip_prefix')}.0.0/16"
 govuk::apps::publishing_api::govuk_content_schemas_path: '/data/apps/govuk-content-schemas/current'
-govuk::apps::publishing_api::nagios_memory_warning: 2500
-govuk::apps::publishing_api::nagios_memory_critical: 3000
+govuk::apps::publishing_api::nagios_memory_warning: 2000
+govuk::apps::publishing_api::nagios_memory_critical: 2500
 
 govuk::apps::release::db_hostname: "mysql-primary"
 govuk::apps::release::db_username: "release"


### PR DESCRIPTION
Publishing API has been using up to 1.2GB of memory in busy periods.
It appears memory is reclaimed but looking at the last 90 days of usage
the thresholds need to be revised.
Also remove duplicate configuration in the AWS yaml file missed in https://github.com/alphagov/govuk-puppet/pull/8168.