### PR TITLE
Revert "Make GA_UNIVERSAL_ID env var available to Publisher"

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -12,7 +12,6 @@ base::supported_kernel::enabled: true
 cron::weekly_dow: 1
 cron::daily_hour: 6
 
-govuk::apps::publisher::ga_universal_id: 'UA-26179049-22'
 govuk::apps::static::ga_universal_id: 'UA-26179049-22'
 
 govuk::deploy::aws_ses_smtp_host: 'email-smtp.eu-west-1.amazonaws.com'

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -86,7 +86,6 @@ govuk::apps::publisher::fact_check_address_format: 'factcheck+production-{id}@al
 govuk::apps::publisher::email_group_dev: 'govuk-dev@digital.cabinet-office.gov.uk'
 govuk::apps::publisher::email_group_business: 'publisher-alerts-business@digital.cabinet-office.gov.uk'
 govuk::apps::publisher::email_group_citizen: 'publisher-alerts-citizen@digital.cabinet-office.gov.uk'
-govuk::apps::publisher::ga_universal_id: 'UA-26179049-1'
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-production'
 govuk::apps::static::ga_universal_id: 'UA-26179049-1'
 govuk::apps::support_api::pp_data_url: 'https://www.performance.service.gov.uk'

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -38,7 +38,6 @@ govuk::apps::link_checker_api::govuk_basic_auth_credentials: "%{hiera('http_user
 govuk::apps::publicapi::backdrop_host: 'www.staging.performance.service.gov.uk'
 govuk::apps::publisher::run_fact_check_fetcher: false
 govuk::apps::publisher::fact_check_address_format: 'factcheck+staging-{id}@alphagov.co.uk'
-govuk::apps::publisher::ga_universal_id: 'UA-26179049-20'
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-staging'
 govuk::apps::short_url_manager::instance_name: 'staging'
 govuk::apps::signon::instance_name: 'staging'

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -29,7 +29,6 @@ govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
 govuk::apps::kibana::logit_environment: 2694f14b-6519-4607-81f2-8a2130e5aaec
 govuk::apps::link_checker_api::govuk_basic_auth_credentials: "%{hiera('http_username')}:%{hiera('http_password')}"
 govuk::apps::organisations_publisher::enabled: true
-govuk::apps::publisher::ga_universal_id: 'UA-26179049-22'
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-integration'
 govuk::apps::publishing_api::content_api_prototype: true
 govuk::apps::short_url_manager::instance_name: 'integration'

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -30,7 +30,6 @@ govuk::apps::link_checker_api::govuk_basic_auth_credentials: "%{hiera('http_user
 govuk::apps::publicapi::backdrop_host: 'www.performance.service.gov.uk'
 govuk::apps::publisher::run_fact_check_fetcher: false
 govuk::apps::publisher::fact_check_address_format: 'factcheck+production-{id}@alphagov.co.uk'
-govuk::apps::publisher::ga_universal_id: 'UA-26179049-1'
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-production'
 govuk::apps::short_url_manager::instance_name: 'production'
 govuk::apps::static::ga_universal_id: 'UA-26179049-1'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -34,7 +34,6 @@ govuk::apps::link_checker_api::govuk_basic_auth_credentials: "%{hiera('http_user
 govuk::apps::publicapi::backdrop_host: 'www.staging.performance.service.gov.uk'
 govuk::apps::publisher::run_fact_check_fetcher: false
 govuk::apps::publisher::fact_check_address_format: 'factcheck+staging-{id}@alphagov.co.uk'
-govuk::apps::publisher::ga_universal_id: 'UA-26179049-20'
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-staging'
 govuk::apps::short_url_manager::instance_name: 'staging'
 govuk::apps::signon::instance_name: 'staging'

--- a/modules/govuk/manifests/apps/publisher.pp
+++ b/modules/govuk/manifests/apps/publisher.pp
@@ -76,10 +76,6 @@
 #   The Link Checker API secret token.
 #   Default: undef
 #
-# [*ga_universal_id*]
-#   The Google Analytics ID.
-#   Default: undef
-#
 class govuk::apps::publisher(
     $port = '3000',
     $enable_procfile_worker = true,
@@ -103,7 +99,6 @@ class govuk::apps::publisher(
     $email_group_business = undef,
     $email_group_citizen = undef,
     $link_checker_api_secret_token = undef,
-    $ga_universal_id = undef,
   ) {
 
   $app_name = 'publisher'
@@ -219,12 +214,5 @@ class govuk::apps::publisher(
     "${title}-LINK_CHECKER_API_SECRET_TOKEN":
         varname => 'LINK_CHECKER_API_SECRET_TOKEN',
         value   => $link_checker_api_secret_token;
-  }
-
-  if $ga_universal_id != undef {
-    govuk::app::envvar { "${title}-GA_UNIVERSAL_ID":
-      varname => 'GA_UNIVERSAL_ID',
-      value   => $ga_universal_id,
-    }
   }
 }


### PR DESCRIPTION
Reverts alphagov/govuk-puppet#8125

In the end this wasn't necessary so remove the env var.