### PR TITLE
Ensure the home directory for smokey exists

### DIFF
--- a/modules/monitoring/manifests/checks/smokey.pp
+++ b/modules/monitoring/manifests/checks/smokey.pp
@@ -22,10 +22,11 @@ class monitoring::checks::smokey (
   include govuk::apps::smokey
 
   user { 'smokey':
-    ensure => present,
-    name   => 'smokey',
-    shell  => '/bin/false',
-    system => true,
+    ensure     => present,
+    name       => 'smokey',
+    managehome => true,
+    shell      => '/bin/false',
+    system     => true,
   }
 
   file { $service_file:


### PR DESCRIPTION
Somehow, this exists on Staging and Production, but not
Integration. Smokey doesn't really require it's home directory, but
bundler ends up logging stuff [1] that breaks reading the output file
if the directory doesn't exist. So, just create the directory to try
to get this working.

1:
`/home/smokey` is not a directory.
Bundler will use `/tmp/user/999/bundler/home/smokey' as your home directory temporarily.