### PR TITLE
Add checks for staging and integration TLS certificates

### DIFF
--- a/modules/monitoring/manifests/checks.pp
+++ b/modules/monitoring/manifests/checks.pp
@@ -67,17 +67,32 @@ class monitoring::checks (
     # Note we connect to www-origin, but specify www.gov.uk as the server name using SNI
     check_command       => "check_ssl_cert!www-origin.${app_domain}!www.gov.uk!30",
     host_name           => $::fqdn,
-    service_description => 'check the www.gov.uk SSL certificate at ORIGIN is valid and not due to expire',
+    service_description => 'check the www.gov.uk TLS certificate at ORIGIN is valid and not due to expire',
+    notes_url           => monitoring_docs_url(renew-tls-certificate),
   }
   icinga::check { 'check_www_cert_valid_at_edge':
     check_command       => 'check_ssl_cert!www.gov.uk!www.gov.uk!30',
     host_name           => $::fqdn,
-    service_description => 'check the www.gov.uk SSL certificate at EDGE is valid and not due to expire',
+    service_description => 'check the www.gov.uk TLS certificate at EDGE is valid and not due to expire',
+    notes_url           => monitoring_docs_url(renew-tls-certificate),
+  }
+  icinga::check { 'check_www_staging_cert_valid_at_edge':
+    check_command       => 'check_ssl_cert!www.staging.publishing.service.gov.uk!www.staging.publishing.service.gov.uk!30',
+    host_name           => $::fqdn,
+    service_description => 'check the www.staging.publishing.service.gov.uk TLS certificate at EDGE is valid and not due to expire',
+    notes_url           => monitoring_docs_url(renew-tls-certificate),
+  }
+  icinga::check { 'check_www_integration_cert_valid_at_edge':
+    check_command       => 'check_ssl_cert!www.integration.publishing.service.gov.uk!www.integration.publishing.service.gov.uk!30',
+    host_name           => $::fqdn,
+    service_description => 'check the www.integration.publishing.service.gov.uk TLS certificate at EDGE is valid and not due to expire',
+    notes_url           => monitoring_docs_url(renew-tls-certificate),
   }
   icinga::check { 'check_wildcard_cert_valid':
     check_command       => "check_ssl_cert!signon.${app_domain}!signon.${app_domain}!30",
     host_name           => $::fqdn,
-    service_description => "check the STAR.${app_domain} SSL certificate is valid and not due to expire",
+    service_description => "check the STAR.${app_domain} TLS certificate is valid and not due to expire",
+    notes_url           => monitoring_docs_url(renew-tls-certificate),
   }
 
   # AWS cannot access mirror machines in Carrenza


### PR DESCRIPTION
This commit adds two Icinga checks to ensure the certificates served by Fastly for our staging and integration CDN environments are valid. These certificates are the wildcard publishing certificates but they are hosted by Fastly, so whenever they are renewed, we also need to provide a copy to Fastly.

It also adds links for all of the certificate checks to a page on the developer docs with more information.