### PR TITLE
Disable retries for non-idempotent requests

### DIFF
--- a/modules/loadbalancer/templates/nginx_balance.conf.erb
+++ b/modules/loadbalancer/templates/nginx_balance.conf.erb
@@ -52,6 +52,12 @@ server {
   # Try next upstream if one returns an error
   proxy_next_upstream error http_500;
 
+  # Disable trying next upstream for non-idempotent requests
+  # See https://trac.nginx.org/nginx/ticket/488
+  if ($request_method ~ ^(POST|LOCK|DELETE)$) {
+    proxy_next_upstream off;
+  }
+
   proxy_set_header Host $http_host;
   proxy_set_header X-Real-IP $remote_addr;
   proxy_set_header X-Forwarded-Server $host;

--- a/modules/loadbalancer/templates/nginx_balance_no_ssl.conf.erb
+++ b/modules/loadbalancer/templates/nginx_balance_no_ssl.conf.erb
@@ -35,6 +35,12 @@ server {
   # Try next upstream if one returns an error
   proxy_next_upstream error http_500;
 
+  # Disable trying next upstream for non-idempotent requests
+  # See https://trac.nginx.org/nginx/ticket/488
+  if ($request_method ~ ^(POST|LOCK|DELETE)$) {
+    proxy_next_upstream off;
+  }
+
   proxy_set_header Host $http_host;
   proxy_set_header X-Real-IP $remote_addr;
   proxy_set_header X-Forwarded-Server $host;


### PR DESCRIPTION
This commit disables the nginx proxy setting which retries failed requests, when the HTTP request is non-idempotent. This replicates a fix made to nginx in later versions.

Trello: https://trello.com/c/l0zAThUM/521-set-nginx-proxynextupstream-off