### PR TITLE
Run bundle as sudo

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/scrape_icinga_alerts_for_dashboard_metrics.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/scrape_icinga_alerts_for_dashboard_metrics.yaml.erb
@@ -26,9 +26,7 @@
           artifact-num-to-keep: 5
     builders:
        - shell: |
-          export RBENV_VERSION=2.5.1
-          export PATH=/usr/lib/rbenv/shims:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          bundle install
+          bundle install --path "${HOME}/bundles/${JOB_NAME}";
           bundle exec rake run_monthly_report
     publishers:
       <% if @enable_slack_notifications %>


### PR DESCRIPTION
At the moment, running the Jenkins job fails with the output:
```
sudo: no tty present and no askpass program specified
Bundler::SudoNotPermittedError: Bundler requires sudo access to install at the
moment. Try installing again, granting Bundler sudo access when prompted, or
installing into a different path.
```
I'm hoping running the bundle command on a different path will fix it.

https://trello.com/b/16mTLUnP/platform-health-doing