### PR TITLE
[DO NOT MERGE] Correct Jenkins job credentials path

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/scrape_icinga_alerts_for_dashboard_metrics.pp
+++ b/modules/govuk_jenkins/manifests/jobs/scrape_icinga_alerts_for_dashboard_metrics.pp
@@ -44,7 +44,7 @@ class govuk_jenkins::jobs::scrape_icinga_alerts_for_dashboard_metrics (
 
   file { '/var/lib/jenkins/workspace/scrape_icinga_alerts_for_dashboard_metrics/credentials.json':
     ensure  => present,
-    content => template('govuk_jenkins/google_api/credentials.json.erb'),
+    content => template('govuk_jenkins/templates/google_api/credentials.json.erb'),
     owner   => 'jenkins',
     group   => 'jenkins',
   }


### PR DESCRIPTION
[DO NOT MERGE] Failing tests.

Because that's where it is: https://github.com/alphagov/govuk-puppet/blob/master/modules/govuk_jenkins/templates/google_api/credentials.json.erb

https://trello.com/c/B1dtJ48q/420-improve-alerting-information-on-the-platform-health-dashboard