### PR TITLE
Fix capitalisation of Transition s3 bucket parameter

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/transition_load_all_data.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/transition_load_all_data.yaml.erb
@@ -36,7 +36,7 @@
             description: 'Passed on down a chain to the Redirector Smokey job'
             default: false
         - string:
-            name: bucket
+            name: BUCKET
             description: 'S3 bucket to fetch bouncer logs from'
             default: 'govuk-production-transition-fastly-logs'
     triggers:


### PR DESCRIPTION
<img width="747" alt="screen shot 2018-10-10 at 10 04 22" src="https://user-images.githubusercontent.com/75235/46725348-e92ac600-cc73-11e8-97b9-97c7b4fdfbd2.png">

Environment variable names are case sensitive.