### PR TITLE
Add google tag manager env vars to content data admin

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -64,6 +64,9 @@ environment_ip_prefix: '10.3'
 govuk::apps::asset_manager::aws_s3_bucket_name: 'govuk-assets-production'
 govuk::apps::asset_manager::aws_region: 'eu-west-1'
 govuk::apps::ckan::ckan_site_url: 'https://ckan.publishing.service.gov.uk'
+govuk::apps::content_data_admin::google_tag_manager_auth: 'bcb35jL0VPLO8b6W2rJXyA'
+govuk::apps::content_data_admin::google_tag_manager_id: 'GTM-NZG8SF2'
+govuk::apps::content_data_admin::google_tag_manager_preview: 'env-8'
 govuk::apps::content_publisher::aws_s3_bucket: "govuk-production-content-publisher-activestorage"
 govuk::apps::content_publisher::google_tag_manager_auth: "O0DrItJxJeQ5Q2W6YCZzvw"
 govuk::apps::content_publisher::google_tag_manager_id: "GTM-NQXC4TG"

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -16,6 +16,9 @@ environment_ip_prefix: '10.2'
 govuk::apps::asset_manager::aws_s3_bucket_name: 'govuk-assets-staging'
 govuk::apps::asset_manager::aws_region: 'eu-west-1'
 govuk::apps::ckan::ckan_site_url: 'https://ckan.staging.publishing.service.gov.uk'
+govuk::apps::content_data_admin::google_tag_manager_auth: 'xcAlGBhKTIeO6y_JhmEapQ'
+govuk::apps::content_data_admin::google_tag_manager_id: 'GTM-NZG8SF2'
+govuk::apps::content_data_admin::google_tag_manager_preview: 'env-5'
 govuk::apps::content_publisher::aws_s3_bucket: "govuk-staging-content-publisher-activestorage"
 govuk::apps::content_publisher::google_tag_manager_auth: "QaRG0YPL6_pwZdxCbyMXPQ"
 govuk::apps::content_publisher::google_tag_manager_id: "GTM-NQXC4TG"

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -12,6 +12,9 @@ environment_ip_prefix: '10.1'
 
 govuk::apps::asset_manager::aws_s3_bucket_name: 'govuk-assets-integration'
 govuk::apps::asset_manager::aws_region: 'eu-west-1'
+govuk::apps::content_data_admin::google_tag_manager_auth: 'wFyiBTovFhDv5qMe_LXt7Q'
+govuk::apps::content_data_admin::google_tag_manager_preview: 'GTM-NZG8SF2'
+govuk::apps::content_data_admin::google_tag_manager_id: 'env-7'
 govuk::apps::content_publisher::aws_s3_bucket: "govuk-integration-content-publisher-activestorage"
 govuk::apps::content_publisher::google_tag_manager_auth: "xTPyDeRcMiXFWvscgkLowg"
 govuk::apps::content_publisher::google_tag_manager_id: "GTM-NQXC4TG"

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -13,6 +13,9 @@ environment_ip_prefix: '10.13'
 
 govuk::apps::asset_manager::aws_s3_bucket_name: 'govuk-assets-production'
 govuk::apps::asset_manager::aws_region: 'eu-west-1'
+govuk::apps::content_data_admin::google_tag_manager_auth: 'bcb35jL0VPLO8b6W2rJXyA'
+govuk::apps::content_data_admin::google_tag_manager_id: 'GTM-NZG8SF2'
+govuk::apps::content_data_admin::google_tag_manager_preview: 'env-8'
 govuk::apps::content_publisher::aws_s3_bucket: "govuk-production-content-publisher-activestorage"
 govuk::apps::content_publisher::google_tag_manager_auth: "O0DrItJxJeQ5Q2W6YCZzvw"
 govuk::apps::content_publisher::google_tag_manager_id: "GTM-NQXC4TG"

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -13,6 +13,9 @@ environment_ip_prefix: '10.12'
 
 govuk::apps::asset_manager::aws_s3_bucket_name: 'govuk-assets-staging'
 govuk::apps::asset_manager::aws_region: 'eu-west-1'
+govuk::apps::content_data_admin::google_tag_manager_auth: 'xcAlGBhKTIeO6y_JhmEapQ'
+govuk::apps::content_data_admin::google_tag_manager_id: 'GTM-NZG8SF2'
+govuk::apps::content_data_admin::google_tag_manager_preview: 'env-5'
 govuk::apps::content_publisher::aws_s3_bucket: "govuk-staging-content-publisher-activestorage"
 govuk::apps::content_publisher::google_tag_manager_auth: "QaRG0YPL6_pwZdxCbyMXPQ"
 govuk::apps::content_publisher::google_tag_manager_id: "GTM-NQXC4TG"

--- a/modules/govuk/manifests/apps/content_data_admin.pp
+++ b/modules/govuk/manifests/apps/content_data_admin.pp
@@ -40,6 +40,16 @@
 # [*content_performance_manager_bearer_token*]
 #   The bearer token to use when communicating with Content Performance Manager.
 #   Default: undef
+#
+# [*google_tag_manager_id*]
+#   The ID for the Google Tag Manager account
+#
+# [*google_tag_manager_preview*]
+#   Allows a tag to be previewed in the Google Tag Manager interface
+#
+# [*google_tag_manager_auth*]
+#   The identifier of an environment for Google Tag Manager
+#
 class govuk::apps::content_data_admin (
   $port                         = '3230',
   $enabled                      = true,
@@ -54,6 +64,9 @@ class govuk::apps::content_data_admin (
   $db_password                  = undef,
   $db_name                      = 'content_data_admin_production',
   $content_performance_manager_bearer_token = undef,
+  $google_tag_manager_id = undef,
+  $google_tag_manager_preview = undef,
+  $google_tag_manager_auth = undef,
 ) {
   $app_name = 'content-data-admin'
 
@@ -93,6 +106,15 @@ class govuk::apps::content_data_admin (
     "${title}-CONTENT_PERFORMANCE_MANAGER_BEARER_TOKEN":
       varname => 'CONTENT_PERFORMANCE_MANAGER_BEARER_TOKEN',
       value   => $content_performance_manager_bearer_token;
+    "${title}-GOOGLE_TAG_MANAGER_ID":
+        varname => 'GOOGLE_TAG_MANAGER_ID',
+        value   => $google_tag_manager_id;
+    "${title}-GOOGLE_TAG_MANAGER_PREVIEW":
+        varname => 'GOOGLE_TAG_MANAGER_PREVIEW',
+        value   => $google_tag_manager_preview;
+    "${title}-GOOGLE_TAG_MANAGER_AUTH":
+        varname => 'GOOGLE_TAG_MANAGER_AUTH',
+        value   => $google_tag_manager_auth;
   }
 
   if $::govuk_node_class !~ /^development$/ {


### PR DESCRIPTION
[I used this PR for reference](https://github.com/alphagov/govuk-puppet/pull/8041)

[Trello card](https://trello.com/c/ldax4jWq/631-1-embed-google-tag-manager-code-in-header-and-body-of-each-page-of-the-content-data-app)



