### PR TITLE
Move credentials to different directory

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/scrape_icinga_alerts_for_dashboard_metrics.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/scrape_icinga_alerts_for_dashboard_metrics.yaml.erb
@@ -4,6 +4,7 @@
     scm:
         - git:
             url: git@github.com:alphagov/govuk-alert-tracker.git
+            basedir: govuk-alert-tracker
             branches:
               - master
 
@@ -26,6 +27,8 @@
           artifact-num-to-keep: 5
     builders:
        - shell: |
+          cd govuk-alert-tracker
+          cp ../credentials.json .
           bundle install --path "${HOME}/bundles/${JOB_NAME}";
           bundle exec rake run_monthly_report
     publishers:


### PR DESCRIPTION
When running the rake task, Jenkins starts by wiping out the workspace it's
running it from. This change ensures the task runs from a subfolder, and that
credentials have been copied to the parent folder.

For context - the credentials file is created during a puppet run, which
happens every 30 mn - this will need to have happened before running the rake
task.

https://trello.com/c/B1dtJ48q/420-improve-alerting-information-on-the-platform-health-dashboard