### PR TITLE
Allow restoring WAL-E backups on replica boxes

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -781,6 +781,12 @@ govuk::node::s_whitehall_mysql_master::encryption_key: "%{hiera('govuk::node::s_
 govuk::node::s_transition_postgresql_slave::redirector_ip_range: 10.6.0.1/16
 govuk::node::s_transition_postgresql_standby::redirector_ip_range: "%{hiera('govuk::node::s_transition_postgresql_slave::redirector_ip_range')}"
 
+govuk::node::s_postgresql_standby::aws_access_key_id: "%{hiera('govuk::node::s_postgresql_primary::aws_access_key_id')}"
+govuk::node::s_postgresql_standby::aws_secret_access_key: "%{hiera('govuk::node::s_postgresql_primary::aws_secret_access_key')}"
+govuk::node::s_postgresql_standby::s3_bucket_url: "%{hiera('govuk::node::s_postgresql_primary::s3_bucket_url')}"
+govuk::node::s_postgresql_standby::wale_private_gpg_key: "%{hiera('govuk::node::s_postgresql_primary::wale_private_gpg_key')}"
+govuk::node::s_postgresql_standby::wale_private_gpg_key_fingerprint: "%{hiera('govuk::node::s_postgresql_primary::wale_private_gpg_key_fingerprint')}"
+
 govuk_postgresql::mirror::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk_ppa::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -787,6 +787,12 @@ govuk::node::s_postgresql_standby::s3_bucket_url: "%{hiera('govuk::node::s_postg
 govuk::node::s_postgresql_standby::wale_private_gpg_key: "%{hiera('govuk::node::s_postgresql_primary::wale_private_gpg_key')}"
 govuk::node::s_postgresql_standby::wale_private_gpg_key_fingerprint: "%{hiera('govuk::node::s_postgresql_primary::wale_private_gpg_key_fingerprint')}"
 
+govuk::node::s_transition_postgresql_slave::aws_access_key_id: "%{hiera('govuk::node::s_transition_postgresql_master::aws_access_key_id')}"
+govuk::node::s_transition_postgresql_slave::aws_secret_access_key: "%{hiera('govuk::node::s_transition_postgresql_master::aws_secret_access_key')}"
+govuk::node::s_transition_postgresql_slave::s3_bucket_url: "%{hiera('govuk::node::s_transition_postgresql_master::s3_bucket_url')}"
+govuk::node::s_transition_postgresql_slave::wale_private_gpg_key: "%{hiera('govuk::node::s_transition_postgresql_master::wale_private_gpg_key')}"
+govuk::node::s_transition_postgresql_slave::wale_private_gpg_key_fingerprint: "%{hiera('govuk::node::s_transition_postgresql_master::wale_private_gpg_key_fingerprint')}"
+
 govuk_postgresql::mirror::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk_ppa::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -836,6 +836,12 @@ govuk::node::s_postgresql_standby::s3_bucket_url: "%{hiera('govuk::node::s_postg
 govuk::node::s_postgresql_standby::wale_private_gpg_key: "%{hiera('govuk::node::s_postgresql_primary::wale_private_gpg_key')}"
 govuk::node::s_postgresql_standby::wale_private_gpg_key_fingerprint: "%{hiera('govuk::node::s_postgresql_primary::wale_private_gpg_key_fingerprint')}"
 
+govuk::node::s_transition_postgresql_slave::aws_access_key_id: "%{hiera('govuk::node::s_transition_postgresql_master::aws_access_key_id')}"
+govuk::node::s_transition_postgresql_slave::aws_secret_access_key: "%{hiera('govuk::node::s_transition_postgresql_master::aws_secret_access_key')}"
+govuk::node::s_transition_postgresql_slave::s3_bucket_url: "%{hiera('govuk::node::s_transition_postgresql_master::s3_bucket_url')}"
+govuk::node::s_transition_postgresql_slave::wale_private_gpg_key: "%{hiera('govuk::node::s_transition_postgresql_master::wale_private_gpg_key')}"
+govuk::node::s_transition_postgresql_slave::wale_private_gpg_key_fingerprint: "%{hiera('govuk::node::s_transition_postgresql_master::wale_private_gpg_key_fingerprint')}"
+
 govuk::node::s_warehouse_db_admin::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 govuk_bundler::config::service: 'http://gemstash'

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -830,6 +830,12 @@ govuk::node::s_transition_postgresql_master::alert_hostname: 'alert'
 govuk::node::s_transition_postgresql_slave::redirector_ip_range: 10.6.0.1/16
 govuk::node::s_transition_postgresql_standby::redirector_ip_range: "%{hiera('govuk::node::s_transition_postgresql_slave::redirector_ip_range')}"
 
+govuk::node::s_postgresql_standby::aws_access_key_id: "%{hiera('govuk::node::s_postgresql_primary::aws_access_key_id')}"
+govuk::node::s_postgresql_standby::aws_secret_access_key: "%{hiera('govuk::node::s_postgresql_primary::aws_secret_access_key')}"
+govuk::node::s_postgresql_standby::s3_bucket_url: "%{hiera('govuk::node::s_postgresql_primary::s3_bucket_url')}"
+govuk::node::s_postgresql_standby::wale_private_gpg_key: "%{hiera('govuk::node::s_postgresql_primary::wale_private_gpg_key')}"
+govuk::node::s_postgresql_standby::wale_private_gpg_key_fingerprint: "%{hiera('govuk::node::s_postgresql_primary::wale_private_gpg_key_fingerprint')}"
+
 govuk::node::s_warehouse_db_admin::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 govuk_bundler::config::service: 'http://gemstash'

--- a/modules/govuk/manifests/node/s_postgresql_standby.pp
+++ b/modules/govuk/manifests/node/s_postgresql_standby.pp
@@ -10,8 +10,21 @@
 #
 class govuk::node::s_postgresql_standby (
   $primary_password,
+  $aws_access_key_id,
+  $aws_secret_access_key,
+  $s3_bucket_url,
+  $wale_private_gpg_key,
+  $wale_private_gpg_key_fingerprint,
 ) inherits govuk::node::s_postgresql_base {
   class { 'govuk_postgresql::server::standby':
     master_password => $primary_password,
+  }
+
+  govuk_postgresql::wal_e::restore { $title:
+    aws_access_key_id                => $aws_access_key_id,
+    aws_secret_access_key            => $aws_secret_access_key,
+    s3_bucket_url                    => $s3_bucket_url,
+    wale_private_gpg_key             => $wale_private_gpg_key,
+    wale_private_gpg_key_fingerprint => $wale_private_gpg_key_fingerprint,
   }
 }

--- a/modules/govuk/manifests/node/s_transition_postgresql_slave.pp
+++ b/modules/govuk/manifests/node/s_transition_postgresql_slave.pp
@@ -14,6 +14,11 @@
 class govuk::node::s_transition_postgresql_slave (
   $master_password,
   $redirector_ip_range,
+  $aws_access_key_id,
+  $aws_secret_access_key,
+  $s3_bucket_url,
+  $wale_private_gpg_key,
+  $wale_private_gpg_key_fingerprint,
 ) inherits govuk::node::s_transition_postgresql_base {
   validate_string($redirector_ip_range)
 
@@ -27,5 +32,13 @@ class govuk::node::s_transition_postgresql_slave (
     user        => 'bouncer',
     address     => $redirector_ip_range,
     auth_method => 'md5',
+  }
+
+  govuk_postgresql::wal_e::restore { $title:
+    aws_access_key_id                => $aws_access_key_id,
+    aws_secret_access_key            => $aws_secret_access_key,
+    s3_bucket_url                    => $s3_bucket_url,
+    wale_private_gpg_key             => $wale_private_gpg_key,
+    wale_private_gpg_key_fingerprint => $wale_private_gpg_key_fingerprint,
   }
 }

--- a/modules/govuk_postgresql/manifests/wal_e/package.pp
+++ b/modules/govuk_postgresql/manifests/wal_e/package.pp
@@ -12,6 +12,12 @@ class govuk_postgresql::wal_e::package {
     require => Class['govuk_postgresql::server'],
   }
 
+  # our version of setuptools is too old to use a newer gevent
+  package { 'gevent':
+    ensure   => '1.2.2',
+    provider => pip3,
+  } ->
+
   package { 'wal-e[aws]':
     ensure   => '1.1.0',
     provider => pip3,

--- a/modules/govuk_postgresql/manifests/wal_e/restore.pp
+++ b/modules/govuk_postgresql/manifests/wal_e/restore.pp
@@ -45,8 +45,6 @@ define govuk_postgresql::wal_e::restore (
 ) {
     include govuk_postgresql::wal_e::package
 
-    validate_re($wale_private_gpg_key_fingerprint, '^[[:alnum:]]{40}$', 'Must supply full GPG fingerprint')
-
     file { '/etc/wal-e/env.d':
       ensure => directory,
       owner  => 'postgres',

--- a/modules/govuk_postgresql/manifests/wal_e/restore.pp
+++ b/modules/govuk_postgresql/manifests/wal_e/restore.pp
@@ -1,0 +1,135 @@
+# == Define: Govuk_postgresql::Wal_e::Restore
+#
+# Allows restoring from an offsite backup of a PostgreSQL database
+# from an S3 bucket using WAL-E: https://github.com/wal-e/wal-e
+#
+# === Parameters:
+#
+# [*aws_access_key_id*]
+#   The AWS access ID for the user that is allowed to
+#   access the S3 bucket.
+#
+# [*aws_secret_access_key*]
+#   The AWS secret access key for the user that is allowed
+#   to access the S3 bucket.
+#
+# [*s3_bucket_url*]
+#   The unique address of the S3 bucket, in the format of:
+#   s3://bucketaddress/directory/foo
+#
+# [*aws_region*]
+#   The AWS region where the specified bucket resides.
+#   Default: eu-west-1
+#
+# [*wale_private_gpg_key*]
+#   The private GPG to import to allow encryption. If present, WAL-E will
+#   will encrypt the backups.
+#
+# [*wale_private_gpg_key_fingerprint*]
+#   The GPG key fingerprint for the above GPG key.
+#
+# [*db_dir*]
+#   The database directory to backup. WAL-E does hot backups
+#   so there should be no impact, and the default backups up
+#   everything.
+#   Default: /var/lib/postgresql/9.3/main
+#
+define govuk_postgresql::wal_e::restore (
+  $aws_access_key_id,
+  $aws_secret_access_key,
+  $s3_bucket_url,
+  $aws_region = 'eu-west-1',
+  $wale_private_gpg_key = undef,
+  $wale_private_gpg_key_fingerprint = undef,
+  $db_dir = $postgresql::params::datadir,
+) {
+    include govuk_postgresql::wal_e::package
+
+    validate_re($wale_private_gpg_key_fingerprint, '^[[:alnum:]]{40}$', 'Must supply full GPG fingerprint')
+
+    file { '/etc/wal-e/env.d':
+      ensure => directory,
+      owner  => 'postgres',
+      group  => 'postgres',
+      mode   => '0775',
+    }
+
+    file { '/etc/wal-e/env.d/AWS_SECRET_ACCESS_KEY':
+      content => $aws_secret_access_key,
+      owner   => 'postgres',
+      group   => 'postgres',
+      mode    => '0660',
+    }
+
+    file { '/etc/wal-e/env.d/AWS_ACCESS_KEY_ID':
+      content => $aws_access_key_id,
+      owner   => 'postgres',
+      group   => 'postgres',
+      mode    => '0640',
+    }
+
+    file { '/etc/wal-e/env.d/WALE_S3_PREFIX':
+      content => $s3_bucket_url,
+      owner   => 'postgres',
+      group   => 'postgres',
+      mode    => '0640',
+    }
+
+    file { '/etc/wal-e/env.d/AWS_REGION':
+      content => $aws_region,
+      owner   => 'postgres',
+      group   => 'postgres',
+      mode    => '0640',
+    }
+
+    if $wale_private_gpg_key and $wale_private_gpg_key_fingerprint {
+      validate_re($wale_private_gpg_key_fingerprint, '^[[:alnum:]]{40}$', 'Must supply full GPG fingerprint')
+
+      file { '/etc/wal-e/env.d/WALE_GPG_KEY_ID':
+        content => $wale_private_gpg_key_fingerprint,
+        owner   => 'postgres',
+        group   => 'postgres',
+        mode    => '0640',
+      }
+
+      file { '/var/lib/postgresql/.gnupg':
+        ensure  => directory,
+        mode    => '0700',
+        owner   => 'postgres',
+        group   => 'postgres',
+        require => Class['govuk_postgresql::server'],
+      }
+
+      # This ensures that stuff can be encrypted without prompt
+      file { '/var/lib/postgresql/.gnupg/gpg.conf':
+        ensure  => present,
+        content => 'trust-model always',
+        mode    => '0600',
+        owner   => 'postgres',
+        group   => 'postgres',
+      }
+
+      file { "/var/lib/postgresql/.gnupg/${wale_private_gpg_key_fingerprint}_secret_key.asc":
+        ensure  => present,
+        mode    => '0600',
+        content => $wale_private_gpg_key,
+        owner   => 'postgres',
+        group   => 'postgres',
+      }
+
+      exec { "import_gpg_secret_key_${::hostname}":
+        command     => "gpg --batch --delete-secret-and-public-key ${wale_private_gpg_key_fingerprint}; gpg --allow-secret-key-import --import /var/lib/postgresql/.gnupg/${wale_private_gpg_key_fingerprint}_secret_key.asc",
+        user        => 'postgres',
+        group       => 'postgres',
+        subscribe   => File["/var/lib/postgresql/.gnupg/${wale_private_gpg_key_fingerprint}_secret_key.asc"],
+        refreshonly => true,
+      }
+    }
+
+    file { '/usr/local/bin/wal-e_restore':
+      ensure  => present,
+      content => template('govuk_postgresql/usr/local/bin/wal-e_restore.erb'),
+      mode    => '0755',
+      require => Class['govuk_postgresql::wal_e::package'],
+    }
+}


### PR DESCRIPTION
Currently restoring a WAL-E backup leaves the replicas in an unhealthy state, unable to catch up with the primary, as you can see from this somewhat cryptic graph:

![download](https://user-images.githubusercontent.com/75235/46747247-b0591400-cca8-11e8-8766-17adde2b72cf.png)

I think that we can just run the WAL-E restore script on replicas to bring them up to speed, at which point normal replication would take over: https://groups.google.com/forum/#!topic/wal-e/usseZZYxE3s

However, our puppet is currently not set up to do this.  For a node to get the restore script, it also must be doing backups.  This is an attempt to split the two responsibilities up.

Rather than splitting the class, another approach would be to pass a `do_backups` param, which is `true` by default, and use that to enable/disable all the cron and icinga stuff.

---

[Trello card](https://trello.com/c/50tQsfZE/538-postgres-replicas-dont-recover-after-restoring-wal-e-backup)