### PR TITLE
Correct the CKAN site URL configuration in integration

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -26,7 +26,7 @@ govuk::apps::email_alert_api::email_address_override: 'success@simulator.amazons
 govuk::apps::email_alert_api::email_address_override_whitelist_only: true
 govuk::apps::email_alert_api::delivery_request_threshold: "3000"
 govuk::apps::email_alert_frontend::subscription_management_enabled: true
-govuk::apps::ckan::ckan_site_url: 'https://test.data.gov.uk'
+govuk::apps::ckan::ckan_site_url: 'https://ckan.integration.publishing.service.gov.uk'
 govuk::apps::govuk_crawler_worker::enabled: false
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
 govuk::apps::kibana::logit_environment: 2694f14b-6519-4607-81f2-8a2130e5aaec


### PR DESCRIPTION
`test.data.gov.uk` is not currently pointing at integration.  CKAN does some redirecting to this URL at times, so it results in a broken user journey on integration.