### PR TITLE
Enable CDN Jenkins jobs in integration

### DIFF
--- a/hieradata_aws/class/integration/jenkins.yaml
+++ b/hieradata_aws/class/integration/jenkins.yaml
@@ -14,6 +14,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::data_sync
   - govuk_jenkins::jobs::data_sync_complete_integration
   - govuk_jenkins::jobs::deploy_app
+  - govuk_jenkins::jobs::deploy_cdn
   - govuk_jenkins::jobs::deploy_dns
   - govuk_jenkins::jobs::deploy_emergency_banner
   - govuk_jenkins::jobs::deploy_puppet
@@ -40,7 +41,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::signon_cron_rake_tasks
   - govuk_jenkins::jobs::smokey
   - govuk_jenkins::jobs::smokey_deploy
+  - govuk_jenkins::jobs::update_cdn_dictionaries
   - govuk_jenkins::jobs::transition_load_site_config
   - govuk_jenkins::jobs::user_monitor
   - govuk_jenkins::jobs::whitehall_publisher_notifications
-


### PR DESCRIPTION
This commit enables the “Deploy CDN” and “Update CDN dictionaries” Jenkins jobs in integration since there is now an integration CDN environment.