### PR TITLE
Configure the CKAN S3 plugin

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -384,6 +384,8 @@ govuk::apps::ckan::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::ckan::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::ckan::ckan_site_url: "http://ckan.dev.gov.uk"
 govuk::apps::ckan::gunicorn_worker_processes: "8"
+govuk::apps::ckan::s3_aws_access_key_id: "%{hiera('s3_aws_access_key_id')}"
+govuk::apps::ckan::s3_aws_secret_access_key: "%{hiera('s3_aws_secret_access_key')}"
 
 govuk::apps::collections::nagios_memory_warning: 900
 govuk::apps::collections::nagios_memory_critical: 1000

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -12,6 +12,9 @@ environment_ip_prefix: '10.1'
 
 govuk::apps::asset_manager::aws_s3_bucket_name: 'govuk-assets-integration'
 govuk::apps::asset_manager::aws_region: 'eu-west-1'
+govuk::apps::ckan::ckan_site_url: 'https://ckan.integration.publishing.service.gov.uk'
+govuk::apps::ckan::s3_bucket_name: "datagovuk-integration-ckan-organogram"
+govuk::apps::ckan::s3_aws_region_name: "eu-west-1"
 govuk::apps::content_data_admin::google_tag_manager_auth: 'wFyiBTovFhDv5qMe_LXt7Q'
 govuk::apps::content_data_admin::google_tag_manager_preview: 'env-7'
 govuk::apps::content_data_admin::google_tag_manager_id: 'GTM-NZG8SF2'
@@ -26,7 +29,6 @@ govuk::apps::email_alert_api::email_address_override: 'success@simulator.amazons
 govuk::apps::email_alert_api::email_address_override_whitelist_only: true
 govuk::apps::email_alert_api::delivery_request_threshold: "3000"
 govuk::apps::email_alert_frontend::subscription_management_enabled: true
-govuk::apps::ckan::ckan_site_url: 'https://ckan.integration.publishing.service.gov.uk'
 govuk::apps::govuk_crawler_worker::enabled: false
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
 govuk::apps::kibana::logit_environment: 2694f14b-6519-4607-81f2-8a2130e5aaec

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -13,6 +13,8 @@ environment_ip_prefix: '10.13'
 
 govuk::apps::asset_manager::aws_s3_bucket_name: 'govuk-assets-production'
 govuk::apps::asset_manager::aws_region: 'eu-west-1'
+govuk::apps::ckan::s3_bucket_name: "datagovuk-production-ckan-organogram"
+govuk::apps::ckan::s3_aws_region_name: "eu-west-1"
 govuk::apps::content_data_admin::google_tag_manager_auth: 'bcb35jL0VPLO8b6W2rJXyA'
 govuk::apps::content_data_admin::google_tag_manager_id: 'GTM-NZG8SF2'
 govuk::apps::content_data_admin::google_tag_manager_preview: 'env-8'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -13,6 +13,8 @@ environment_ip_prefix: '10.12'
 
 govuk::apps::asset_manager::aws_s3_bucket_name: 'govuk-assets-staging'
 govuk::apps::asset_manager::aws_region: 'eu-west-1'
+govuk::apps::ckan::s3_bucket_name: "datagovuk-staging-ckan-organogram"
+govuk::apps::ckan::s3_aws_region_name: "eu-west-1"
 govuk::apps::content_data_admin::google_tag_manager_auth: 'xcAlGBhKTIeO6y_JhmEapQ'
 govuk::apps::content_data_admin::google_tag_manager_id: 'GTM-NZG8SF2'
 govuk::apps::content_data_admin::google_tag_manager_preview: 'env-5'

--- a/modules/govuk/manifests/apps/ckan.pp
+++ b/modules/govuk/manifests/apps/ckan.pp
@@ -48,6 +48,10 @@ class govuk::apps::ckan (
   $smtp_username                  = undef,
   $smtp_password                  = undef,
   $smtp_hostname                  = undef,
+  $s3_aws_access_key_id           = undef,
+  $s3_aws_secret_access_key       = undef,
+  $s3_bucket_name                 = undef,
+  $s3_aws_region_name             = undef,
 ) {
   $ckan_home = '/var/ckan'
   $ckan_ini  = "${ckan_home}/ckan.ini"

--- a/modules/govuk/templates/ckan/ckan.ini.erb
+++ b/modules/govuk/templates/ckan/ckan.ini.erb
@@ -85,7 +85,7 @@ ckan.cors.origin_allow_all = true
 #       Add ``datapusher`` to enable DataPusher
 #       Add ``resource_proxy`` to enable resorce proxying and get around the
 #       same origin policy
-ckan.plugins = datagovuk_publisher_form datagovuk dcat harvest ckan_harvester dcat_rdf_harvester dcat_json_harvester dcat_json_interface spatial_metadata spatial_query spatial_harvest_metadata_api csw_harvester waf_harvester doc_harvester inventory_harvester
+ckan.plugins = datagovsg_s3_resources datagovuk_publisher_form datagovuk dcat harvest ckan_harvester dcat_rdf_harvester dcat_json_harvester dcat_json_interface spatial_metadata spatial_query spatial_harvest_metadata_api csw_harvester waf_harvester doc_harvester inventory_harvester
 
 # These are marked as legacy harvesters
 # gemini_csw_harvester gemini_doc_harvester gemini_waf_harvester
@@ -93,6 +93,12 @@ ckan.plugins = datagovuk_publisher_form datagovuk dcat harvest ckan_harvester dc
 # This needs fixing
 # inventory_harvester
 
+## S3 Settings
+ckan.datagovsg_s3_resources.s3_aws_access_key_id = <%= @s3_aws_access_key_id%>
+ckan.datagovsg_s3_resources.s3_aws_secret_access_key = <%= @s3_aws_secret_access_key%>
+ckan.datagovsg_s3_resources.s3_bucket_name = <%= @s3_bucket_name%>
+ckan.datagovsg_s3_resources.s3_url_prefix = https://s3-<%= @s3_aws_region_name%>.amazonaws.com/<%= @s3_bucket_name%>/
+ckan.datagovsg_s3_resources.s3_aws_region_name = <%= @s3_aws_region_name%>
 
 # Harvesting settings
 ckan.harvest.mq.type = redis


### PR DESCRIPTION
Organograms are being stored in a S3 bucket in the new CKAN.  This adds the relevant configuration items to `ckan.ini`.

Trello card: https://trello.com/c/odHiWSoq/63-implement-upload-organogram-to-s3