### PR TITLE
Increase government-frontend memory alert thresholds

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -466,8 +466,8 @@ govuk::apps::frontend::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::frontend::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::frontend::unicorn_worker_processes: "4"
 
-govuk::apps::government_frontend::nagios_memory_warning: 1800
-govuk::apps::government_frontend::nagios_memory_critical: 2000
+govuk::apps::government_frontend::nagios_memory_warning: 2500
+govuk::apps::government_frontend::nagios_memory_critical: 2800
 govuk::apps::government_frontend::unicorn_worker_processes: "8"
 
 govuk::apps::kibana::logit_account: 1c6b2316-16e2-4ca5-a3df-ff18631b0e74

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -488,8 +488,8 @@ govuk::apps::frontend::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::frontend::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::frontend::unicorn_worker_processes: "4"
 
-govuk::apps::government_frontend::nagios_memory_warning: 1800
-govuk::apps::government_frontend::nagios_memory_critical: 2000
+govuk::apps::government_frontend::nagios_memory_warning: 2500
+govuk::apps::government_frontend::nagios_memory_critical: 2800
 govuk::apps::government_frontend::unicorn_worker_processes: "8"
 
 govuk::apps::link_checker_api::db_hostname: "db-admin"


### PR DESCRIPTION
This app is hitting the critical line every 2 hours or so.
There's enough headroom to allow it to consume another 800MB.
We know this could be the hallmark of a memory leak, if this additional memory is consumed we can investigate.

![screenshot from 2018-10-16 15-16-51](https://user-images.githubusercontent.com/93511/47022975-8abf8500-d156-11e8-8e57-ef1e32e6c8ec.png)
