### PR TITLE
BAU: Fix Dir and Perms for Icinga

### DIFF
--- a/modules/icinga/manifests/config.pp
+++ b/modules/icinga/manifests/config.pp
@@ -119,6 +119,24 @@ class icinga::config (
     source => 'puppet:///modules/icinga/etc/nagios-plugins/config/check_nrpe.cfg',
   }
 
+  file { '/var/lib/icinga/spool':
+    ensure => directory,
+    owner  => 'nagios',
+    group  => 'nagios',
+  }
+
+  file { '/var/lib/icinga/spool/checkresults':
+    ensure => directory,
+    owner  => 'nagios',
+    group  => 'nagios',
+  }
+
+  file { '/var/lib/icinga/rw':
+    ensure => directory,
+    owner  => 'nagios',
+    group  => 'www-data',
+  }
+
   file { '/var/lib/icinga/rw/nagios.cmd':
     owner => 'nagios',
     group => 'www-data',


### PR DESCRIPTION
icinga/spool/checkresults  &  icinga/rw  are not set down by puppet,
resulting in a failure to start icinga.
This fix ensures the directories exist with the correct permissions.

Group: @ronocg @fredericfran-gds @DavidJeche