### PR TITLE
Move external app domain of AWS staging to gov.uk

### DIFF
--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -1,5 +1,5 @@
 ---
-app_domain: 'staging.govuk.digital'
+app_domain: 'staging.publishing.service.gov.uk'
 app_domain_internal: "staging.govuk-internal.digital"
 
 backup::server::backup_hour: 9


### PR DESCRIPTION
- We hope this allows us to use Carrenza signon to authenticate AWS apps

solo: @schmie