### PR TITLE
Add HTTP/2 preconnect header for assets

### DIFF
--- a/modules/router/templates/router_include.conf.erb
+++ b/modules/router/templates/router_include.conf.erb
@@ -63,6 +63,8 @@ location ~ ^/contact/govuk/(|service-feedback|problem_reports|foi|page_improveme
 location / {
   <%= scope.function_template(['router/fragments/_basic_auth.erb']) -%>
 
+  add_header Link "<https://assets.<%= @app_domain %>>; rel=preconnect";
+
   # HTML verification for DWP YouTube channel
   location = /dla-ending/google6db9c061ce178960.html {
     add_header Content-Type text/html;


### PR DESCRIPTION
This commit adds a `Link` HTTP header pointing at the relevant assets subdomain for the environment.

This header is used by browsers that support HTTP/2 to indicate that they should immediately initiate a TCP connection to this subdomain in anticipation of downloading assets from it.

This allows the connection initiation overheads to happen while the HTML is being downloaded, so that referenced assets can then be downloaded immediately rather than waiting for the connection to be initiated.