### PR TITLE
Fix CKAN cron jobs

### DIFF
--- a/modules/govuk/manifests/apps/ckan/cronjobs.pp
+++ b/modules/govuk/manifests/apps/ckan/cronjobs.pp
@@ -5,7 +5,7 @@ class govuk::apps::ckan::cronjobs {
   govuk::apps::ckan::paster_cronjob { 'harvester run':
     paster_command => 'harvester run',
     plugin         => 'ckanext-harvest',
-    minute         => '*/10',
+    minute         => '*/5',
   }
 
   govuk::apps::ckan::paster_cronjob { 'harvester cleanup':

--- a/modules/govuk/manifests/apps/ckan/paster_cronjob.pp
+++ b/modules/govuk/manifests/apps/ckan/paster_cronjob.pp
@@ -30,7 +30,7 @@ define govuk::apps::ckan::paster_cronjob (
   validate_string($plugin, $paster_command)
 
   cron { $title:
-    command  => "cd /var/apps/ckan; govuk_setenv ckan venv/bin/paster --plugin=${plugin} ${paster_command} --config=/var/ckan/ckan.ini",
+    command  => "cd /var/apps/ckan; ./venv/bin/paster --plugin=${plugin} ${paster_command} --config=/var/ckan/ckan.ini",
     user     => 'deploy',
     hour     => $hour,
     minute   => $minute,


### PR DESCRIPTION
These cron jobs run regularly to: start automatic scheduled harvesters, mark finished harvesters as finished, and clear up the harvesting logs.

Previously they were not running on integration, with an error `/bin/sh: 1: govuk_setenv: not found`.  This fixes that error and also makes the start/stop job execute more frequently (resulting in jobs getting marked as 'Finished' sooner).

Trello card: https://trello.com/c/MTf9rBKK/3-get-harvesting-working-on-integration