### PR TITLE
GovUk-Migr-Trello-1626: Fix perms icinga

### DIFF
--- a/modules/icinga/manifests/config.pp
+++ b/modules/icinga/manifests/config.pp
@@ -135,12 +135,7 @@ class icinga::config (
     ensure => directory,
     owner  => 'nagios',
     group  => 'www-data',
-  }
-
-  file { '/var/lib/icinga/rw/nagios.cmd':
-    owner => 'nagios',
-    group => 'www-data',
-    mode  => '0660',
+    mode   => '2755',
   }
 
   user { 'www-data':


### PR DESCRIPTION
There is no need to lay down the nagios.cmd file using puppet.
It is a pipe that all icinga commands get sent to and when icinga starts
it will lay it down.

In order to send commands from the icinga webUI, example: command suck
as acknowledgements.

Then the nagios.cmd file will need to be executable by the www-data
group. We can make sure the nagios.cmd file ha group www-data by seting
the setgid bit on the upper directory rw.

Tested this in production_aws successfully.

Solo: @ronocg