### PR TITLE
Preconnect still cannot be seen in the waterfall after testing

### DIFF
--- a/modules/router/templates/router_include.conf.erb
+++ b/modules/router/templates/router_include.conf.erb
@@ -63,7 +63,7 @@ location ~ ^/contact/govuk/(|service-feedback|problem_reports|foi|page_improveme
 location / {
   <%= scope.function_template(['router/fragments/_basic_auth.erb']) -%>
 
-  add_header Link "<https://assets.<%= @app_domain %>>; rel=preconnect";
+  add_header Link "<https://assets.<%= @app_domain %>>; rel=preconnect; crossorigin";
 
   # HTML verification for DWP YouTube channel
   location = /dla-ending/google6db9c061ce178960.html {


### PR DESCRIPTION
This is an extension of [#8218](https://github.com/alphagov/govuk-puppet/pull/8218). Following testing in the Chrome network tab and via [WebPageTest](https://www.webpagetest.org/result/181022_WV_77c59332c7dfcf9ac262d6d4ae014ca1/1/details/#waterfall_view_step1) the preconnect, although visible in the headers, cannot be seen in the waterfall.

<img width="945" alt="screen shot 2018-10-22 at 18 41 23" src="https://user-images.githubusercontent.com/1223960/47308782-84d01500-d62a-11e8-9e43-12e3e9104d8c.png">

I'd expect to see something like the following image:

![waterfall-cdnplanet-after-preconnect-with-crossorigin](https://user-images.githubusercontent.com/1223960/47309072-6880a800-d62b-11e8-841f-117bf12aa78e.png)

After doing some research it looks like it's most likely caused by a missing `crossorigin` string in the header [see here](https://www.cdnplanet.com/blog/faster-google-webfonts-preconnect/).

More information about the `crossorigin` setting can be found in the [resource hint specification](https://www.w3.org/TR/resource-hints/#preconnect) and [HTML specification](https://html.spec.whatwg.org/multipage/urls-and-fetching.html#cors-settings-attributes)
