### PR TITLE
UK timezone for Content Publisher Whitehall import

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/content_publisher_whitehall_import.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/content_publisher_whitehall_import.yaml.erb
@@ -16,7 +16,9 @@
            grep created_at |
            ssh deploy@$(govuk_node_list -c backend --single-node) 'cd /data/apps/content-publisher/current; govuk_setenv content-publisher bundle exec rake import:whitehall_news'
     triggers:
-        - timed: '<%= @cron_schedule %>'
+      - timed: |
+          TZ=Europe/London
+          <%= @cron_schedule %>
     publishers:
       <% if @enable_slack_notifications %>
       - slack:


### PR DESCRIPTION
Previously this would use the server time which is UTC - this meant this
import was running at 10am rather than the expected 9am.