### PR TITLE
Add transition and bouncer jenkins to AWS

### DIFF
--- a/hieradata/class/staging/jenkins.yaml
+++ b/hieradata/class/staging/jenkins.yaml
@@ -39,12 +39,8 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::user_monitor
   - govuk_jenkins::jobs::validate_published_dns
   - govuk_jenkins::jobs::whitehall_publisher_notifications
-  - govuk_jenkins::jobs::transition_load_all_data
-  - govuk_jenkins::jobs::transition_load_site_config
-  - govuk_jenkins::jobs::bouncer_cdn
+
 
 govuk_jenkins::jobs::deploy_cdn::enable_slack_notifications: true
 govuk_jenkins::jobs::deploy_puppet::enable_slack_notifications: true
 govuk_jenkins::jobs::smokey::enable_slack_notifications: true
-govuk_jenkins::jobs::transition_load_all_data::enable_slack_notifications: true
-govuk_jenkins::jobs::transition_load_site_config::enable_slack_notifications: true

--- a/hieradata_aws/class/production/jenkins.yaml
+++ b/hieradata_aws/class/production/jenkins.yaml
@@ -13,7 +13,13 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::run_rake_task
   - govuk_jenkins::jobs::smokey
   - govuk_jenkins::jobs::smokey_deploy
+  - govuk_jenkins::jobs::transition_load_all_data
+  - govuk_jenkins::jobs::transition_load_site_config
+  - govuk_jenkins::jobs::bouncer_cdn
+
 
 govuk_jenkins::jobs::deploy_cdn::enable_slack_notifications: false
 govuk_jenkins::jobs::deploy_puppet::enable_slack_notifications: false
 govuk_jenkins::jobs::smokey::enable_slack_notifications: false
+govuk_jenkins::jobs::transition_load_all_data::enable_slack_notifications: true
+govuk_jenkins::jobs::transition_load_site_config::enable_slack_notifications: true

--- a/hieradata_aws/class/staging/jenkins.yaml
+++ b/hieradata_aws/class/staging/jenkins.yaml
@@ -15,7 +15,13 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::smokey
   - govuk_jenkins::jobs::smokey_deploy
   - govuk_jenkins::jobs::data_sync
+  - govuk_jenkins::jobs::transition_load_all_data
+  - govuk_jenkins::jobs::transition_load_site_config
+  - govuk_jenkins::jobs::bouncer_cdn
+
 
 govuk_jenkins::jobs::deploy_cdn::enable_slack_notifications: false
 govuk_jenkins::jobs::deploy_puppet::enable_slack_notifications: false
 govuk_jenkins::jobs::smokey::enable_slack_notifications: false
+govuk_jenkins::jobs::transition_load_all_data::enable_slack_notifications: true
+govuk_jenkins::jobs::transition_load_site_config::enable_slack_notifications: true


### PR DESCRIPTION
We are migrating transition and bouncer to AWS. We require these jobs to deploy into those
enviroments via Jenkins.

Solo: @th31nitiate