### PR TITLE
Use Signon /healthcheck endpoint

### DIFF
--- a/modules/govuk/manifests/apps/signon.pp
+++ b/modules/govuk/manifests/apps/signon.pp
@@ -87,7 +87,7 @@ class govuk::apps::signon(
     port                     => $port,
     sentry_dsn               => $sentry_dsn,
     vhost_ssl_only           => true,
-    health_check_path        => '/users/sign_in',
+    health_check_path        => '/healthcheck',
     asset_pipeline           => true,
     deny_framing             => true,
     log_format_is_json       => true,


### PR DESCRIPTION
This uses the endpoint added in https://github.com/alphagov/signon/pull/866. This should hopefully remove some of the Sentry errors for Signon.