### PR TITLE
Disable smokey staging and production

### DIFF
--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -119,7 +119,11 @@ monitoring::checks::sidekiq::enable_support_check: false
 monitoring::checks::ses::region: 'eu-west-1'
 monitoring::checks::rds::region: 'eu-west-1'
 monitoring::checks::cache::region: 'eu-west-1'
+
+# START OF TEMPORARY DEFECT FIX: # Smokey tests are not running correctly due to defects reported in: https://trello.com/c/XzGHhe3l/1629-investigate-cause-of-jenkins-oom-crashes-in-aws-staging-and-production
 monitoring::checks::smokey::environment: 'production'
+# END OF TEMPORARY DEFECT FIX
+
 monitoring::uptime_collector::environment: 'production'
 
 postfix::smarthost:

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -121,7 +121,7 @@ monitoring::checks::rds::region: 'eu-west-1'
 monitoring::checks::cache::region: 'eu-west-1'
 
 # START OF TEMPORARY DEFECT FIX: # Smokey tests are not running correctly due to defects reported in: https://trello.com/c/XzGHhe3l/1629-investigate-cause-of-jenkins-oom-crashes-in-aws-staging-and-production
-monitoring::checks::smokey::environment: 'production'
+# monitoring::checks::smokey::environment: 'production'
 # END OF TEMPORARY DEFECT FIX
 
 monitoring::uptime_collector::environment: 'production'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -125,7 +125,11 @@ monitoring::checks::sidekiq::enable_support_check: false
 monitoring::checks::ses::region: 'eu-west-1'
 monitoring::checks::rds::region: 'eu-west-1'
 monitoring::checks::cache::region: 'eu-west-1'
-monitoring::checks::smokey::environment: 'staging'
+
+# START OF TEMPORARY DEFECT FIX: # Smokey tests are not running correctly due to defects reported in: https://trello.com/c/XzGHhe3l/1629-investigate-cause-of-jenkins-oom-crashes-in-aws-staging-and-production
+# monitoring::checks::smokey::environment: 'staging'
+# END OF TEMPORARY DEFECT FIX
+
 monitoring::uptime_collector::environment: 'staging'
 
 postfix::smarthost:


### PR DESCRIPTION
# Context

Smokey in AWS staging and production are not working because:
they are still probing the Carrenza URLs and AWS servers do not have access to these URLs due to network restrictions on the Carrenza side.

# Decision

Disable Smokey because:
1. it is not working and needs to be fixed by the developers of Smokey
2. there is a bug in the software where Smokey is not cleaning up after itself when exceptions arise and there are many defunct processes