### PR TITLE
Add Jenkins placeholder - #1368

### DIFF
--- a/hieradata_aws/class/staging/jenkins.yaml
+++ b/hieradata_aws/class/staging/jenkins.yaml
@@ -15,9 +15,9 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::smokey
   - govuk_jenkins::jobs::smokey_deploy
   - govuk_jenkins::jobs::data_sync
-  - govuk_jenkins::jobs::transition_load_all_data
-  - govuk_jenkins::jobs::transition_load_site_config
-  - govuk_jenkins::jobs::bouncer_cdn
+  - govuk_jenkins::jobs::transition_load_all_data_redirect
+  - govuk_jenkins::jobs::transition_load_site_config_redirect
+  - govuk_jenkins::jobs::bouncer_cdn_redirect
 
 
 govuk_jenkins::jobs::deploy_cdn::enable_slack_notifications: false

--- a/modules/govuk_jenkins/manifests/jobs/bouncer_cdn_redirect.pp
+++ b/modules/govuk_jenkins/manifests/jobs/bouncer_cdn_redirect.pp
@@ -1,0 +1,28 @@
+# == Class: govuk_jenkins::jobs::bouncer_cdn_redirect
+#
+# Create a file on disk that can be parsed by jenkins-job-builder
+#
+# === Parameters
+#
+# [*cdn_password_encrypted*]
+#   Password for the `$cdn_username` account. This password
+#   must be encrypted by Jenkins before passing it in as a
+#   parameter. You can do this by taking the plaintext password,
+#   adding it as a password parameter in Jenkins and taking the
+#   result from the `config.xml` file.
+#
+# [*cdn_service_id*]
+#   CDN service ID.
+#
+# [*cdn_username*]
+#   Username for an account with our CDN provider.
+#
+class govuk_jenkins::jobs::bouncer_cdn_redirect {
+
+  file { '/etc/jenkins_jobs/jobs/bouncer_cdn.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/bouncer_cdn_redirect.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+
+}

--- a/modules/govuk_jenkins/manifests/jobs/transition_load_all_data_redirect.pp
+++ b/modules/govuk_jenkins/manifests/jobs/transition_load_all_data_redirect.pp
@@ -1,0 +1,11 @@
+# == Class: govuk_jenkins::jobs::transition_load_all_data_redirect
+#
+# Create a file on disk that can be parsed by jenkins-job-builder
+#
+class govuk_jenkins::jobs::transition_load_all_data_redirect {
+  file { '/etc/jenkins_jobs/jobs/transition_load_all_data.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/transition_load_all_data_redirect.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+}

--- a/modules/govuk_jenkins/manifests/jobs/transition_load_site_config_redirect.pp
+++ b/modules/govuk_jenkins/manifests/jobs/transition_load_site_config_redirect.pp
@@ -1,0 +1,11 @@
+# == Class: govuk_jenkins::jobs::transition_load_site_config_redirect
+#
+# Create a file on disk that can be parsed by jenkins-job-builder
+#
+class govuk_jenkins::jobs::transition_load_site_config_redirect {
+  file { '/etc/jenkins_jobs/jobs/transition_load_site_config.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/transition_load_site_config_redirect.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+}

--- a/modules/govuk_jenkins/templates/jobs/bouncer_cdn_redirect.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/bouncer_cdn_redirect.yaml.erb
@@ -1,0 +1,14 @@
+---
+- job:
+    name: Bouncer_CDN
+    display-name: Bouncer_CDN
+    project-type: freestyle
+    description: |
+        <strong>
+        This job has been migrated to AWS. Please execute it from 
+        <a href='https://deploy.blue.production.govuk.digital/job/Bouncer_CDN/'>
+        https://deploy.blue.production.govuk.digital/job/Bouncer_CDN/
+        </a>
+    builders:
+        - shell: |
+            echo "Job not runable please use alternative Jenkins"

--- a/modules/govuk_jenkins/templates/jobs/bouncer_cdn_redirect.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/bouncer_cdn_redirect.yaml.erb
@@ -5,10 +5,11 @@
     project-type: freestyle
     description: |
         <strong>
-        This job has been migrated to AWS. Please execute it from 
-        <a href='https://deploy.blue.production.govuk.digital/job/Bouncer_CDN/'>
-        https://deploy.blue.production.govuk.digital/job/Bouncer_CDN/
-        </a>
+            This job has been migrated to AWS. Please execute it from 
+            <a href='https://deploy.blue.production.govuk.digital/job/Bouncer_CDN/'>
+            https://deploy.blue.production.govuk.digital/job/Bouncer_CDN/
+            </a>
+        </strong>
     builders:
         - shell: |
             echo "Job not runable please use alternative Jenkins"

--- a/modules/govuk_jenkins/templates/jobs/transition_load_all_data_redirect.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/transition_load_all_data_redirect.yaml.erb
@@ -5,11 +5,11 @@
     project-type: freestyle
     description: |
         <strong>
-        This job has been migrated to AWS. Please execute it from 
-        <a href='https://deploy.blue.production.govuk.digital/job/Transition_load_all_data/'>
-        https://deploy.blue.production.govuk.digital/job/Transition_load_all_data/
-        </a>
-    </strong>
+            This job has been migrated to AWS. Please execute it from 
+            <a href='https://deploy.blue.production.govuk.digital/job/Transition_load_all_data/'>
+            https://deploy.blue.production.govuk.digital/job/Transition_load_all_data/
+            </a>
+        </strong>
     builders:
         - shell: |
             echo "Job not runable please is alternative Jenkins"

--- a/modules/govuk_jenkins/templates/jobs/transition_load_all_data_redirect.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/transition_load_all_data_redirect.yaml.erb
@@ -1,0 +1,15 @@
+---
+- job:
+    name: Transition_load_all_data
+    display-name: Transition_load_all_data
+    project-type: freestyle
+    description: |
+        <strong>
+        This job has been migrated to AWS. Please execute it from 
+        <a href='https://deploy.blue.production.govuk.digital/job/Transition_load_all_data/'>
+        https://deploy.blue.production.govuk.digital/job/Transition_load_all_data/
+        </a>
+    </strong>
+    builders:
+        - shell: |
+            echo "Job not runable please is alternative Jenkins"

--- a/modules/govuk_jenkins/templates/jobs/transition_load_site_config_redirect.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/transition_load_site_config_redirect.yaml.erb
@@ -5,11 +5,11 @@
     project-type: freestyle
     description: |
         <strong>
-        This job has been migrated to AWS. Please execute it from 
-        <a href='https://deploy.blue.production.govuk.digital/job/Transition_load_site_config/'>
-        https://deploy.blue.production.govuk.digital/job/Transition_load_site_config/
-        </a>
-    </strong>
+            This job has been migrated to AWS. Please execute it from 
+            <a href='https://deploy.blue.production.govuk.digital/job/Transition_load_site_config/'>
+            https://deploy.blue.production.govuk.digital/job/Transition_load_site_config/
+            </a>
+        </strong>
     builders:
         - shell: |
             echo "Job not runable please is alternative Jenkins"

--- a/modules/govuk_jenkins/templates/jobs/transition_load_site_config_redirect.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/transition_load_site_config_redirect.yaml.erb
@@ -1,0 +1,15 @@
+---
+- job:
+    name: Transition_load_site_config
+    display-name: Transition_load_site_config
+    project-type: freestyle
+    description: |
+        <strong>
+        This job has been migrated to AWS. Please execute it from 
+        <a href='https://deploy.blue.production.govuk.digital/job/Transition_load_site_config/'>
+        https://deploy.blue.production.govuk.digital/job/Transition_load_site_config/
+        </a>
+    </strong>
+    builders:
+        - shell: |
+            echo "Job not runable please is alternative Jenkins"


### PR DESCRIPTION
This PR is to add Jenkins HTML place holder to inform users of the migration to the new environment.

I have left the job configuration as is in order to keep environment intact. The solutions was to add a new class to hiera that generates the intended template with the write HTML. This method was chosen because if it was not then the changes will reflect to all Jenkins instance.