### PR TITLE
Disable all apps except transition on backend for AWS staging and production

### DIFF
--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -11,6 +11,95 @@ cron::daily_hour: 6
 
 environment_ip_prefix: '10.13'
 
+node_class: &node_class
+  asset_master:
+    apps:
+      - asset_env_sync
+  backend:
+    apps:
+      - transition
+  bouncer:
+    apps:
+      - bouncer
+  cache:
+    apps:
+      - router
+      - publicapi
+  content_store:
+    apps:
+      - content-store
+  calculators_frontend:
+    apps:
+      - calculators
+      - calendars
+      - finder-frontend
+      - licencefinder
+      - smartanswers
+  ckan:
+    apps:
+      - ckan
+  draft_cache:
+    apps:
+      - authenticating-proxy
+      - router
+      - router-api
+  draft_content_store:
+    apps:
+      - content-store
+  draft_frontend:
+    apps:
+      - collections
+      - email-alert-frontend
+      - frontend
+      - government-frontend
+      - manuals-frontend
+      - service-manual-frontend
+      - smartanswers
+      - static
+  email_alert_api:
+    apps:
+      - email-alert-api
+      - email-alert-service
+  frontend:
+    apps:
+      - canary-frontend
+      - collections
+      - email-alert-frontend
+      - feedback
+      - frontend
+      - government-frontend
+      - info-frontend
+      - manuals-frontend
+      - service-manual-frontend
+      - static
+  mapit:
+    apps:
+      - mapit
+  mirrorer:
+    apps:
+      - govuk-crawler-worker
+  publishing_api:
+    apps:
+      - publishing-api
+  router_backend:
+    apps:
+      - router-api
+  search:
+    apps:
+      - rummager
+  whitehall_backend:
+    apps:
+      - whitehall
+  whitehall_frontend:
+    apps:
+      - whitehall
+
+govuk::node::s_base::node_apps:
+  <<: *node_class
+
+govuk_jenkins::deploy_all_apps::apps_on_nodes:
+  <<: *node_class
+
 govuk::apps::asset_manager::aws_s3_bucket_name: 'govuk-assets-production'
 govuk::apps::asset_manager::aws_region: 'eu-west-1'
 govuk::apps::ckan::s3_bucket_name: "datagovuk-production-ckan-organogram"

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -11,6 +11,12 @@ cron::daily_hour: 6
 
 environment_ip_prefix: '10.12'
 
+govuk::node::s_base::node_apps::node_class::backend::apps:
+  - transition
+
+govuk_jenkins::deploy_all_apps::apps_on_nodes::node_class::backend::apps:
+  - transition
+
 govuk::apps::asset_manager::aws_s3_bucket_name: 'govuk-assets-staging'
 govuk::apps::asset_manager::aws_region: 'eu-west-1'
 govuk::apps::ckan::s3_bucket_name: "datagovuk-staging-ckan-organogram"
@@ -125,7 +131,11 @@ monitoring::checks::sidekiq::enable_support_check: false
 monitoring::checks::ses::region: 'eu-west-1'
 monitoring::checks::rds::region: 'eu-west-1'
 monitoring::checks::cache::region: 'eu-west-1'
-monitoring::checks::smokey::environment: 'staging'
+
+# START OF TEMPORARY DEFECT FIX: # Smokey tests are not running correctly due to defects reported in: https://trello.com/c/XzGHhe3l/1629-investigate-cause-of-jenkins-oom-crashes-in-aws-staging-and-production
+# monitoring::checks::smokey::environment: 'staging'
+# END OF TEMPORARY DEFECT FIX
+
 monitoring::uptime_collector::environment: 'staging'
 
 postfix::smarthost:

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -11,11 +11,94 @@ cron::daily_hour: 6
 
 environment_ip_prefix: '10.12'
 
-govuk::node::s_base::node_apps::node_class::backend::apps:
-  - transition
+node_class: &node_class
+  asset_master:
+    apps:
+      - asset_env_sync
+  backend:
+    apps:
+      - transition
+  bouncer:
+    apps:
+      - bouncer
+  cache:
+    apps:
+      - router
+      - publicapi
+  content_store:
+    apps:
+      - content-store
+  calculators_frontend:
+    apps:
+      - calculators
+      - calendars
+      - finder-frontend
+      - licencefinder
+      - smartanswers
+  ckan:
+    apps:
+      - ckan
+  draft_cache:
+    apps:
+      - authenticating-proxy
+      - router
+      - router-api
+  draft_content_store:
+    apps:
+      - content-store
+  draft_frontend:
+    apps:
+      - collections
+      - email-alert-frontend
+      - frontend
+      - government-frontend
+      - manuals-frontend
+      - service-manual-frontend
+      - smartanswers
+      - static
+  email_alert_api:
+    apps:
+      - email-alert-api
+      - email-alert-service
+  frontend:
+    apps:
+      - canary-frontend
+      - collections
+      - email-alert-frontend
+      - feedback
+      - frontend
+      - government-frontend
+      - info-frontend
+      - manuals-frontend
+      - service-manual-frontend
+      - static
+  mapit:
+    apps:
+      - mapit
+  mirrorer:
+    apps:
+      - govuk-crawler-worker
+  publishing_api:
+    apps:
+      - publishing-api
+  router_backend:
+    apps:
+      - router-api
+  search:
+    apps:
+      - rummager
+  whitehall_backend:
+    apps:
+      - whitehall
+  whitehall_frontend:
+    apps:
+      - whitehall
 
-govuk_jenkins::deploy_all_apps::apps_on_nodes::node_class::backend::apps:
-  - transition
+govuk::node::s_base::node_apps:
+  <<: *node_class
+
+govuk_jenkins::deploy_all_apps::apps_on_nodes:
+  <<: *node_class
 
 govuk::apps::asset_manager::aws_s3_bucket_name: 'govuk-assets-staging'
 govuk::apps::asset_manager::aws_region: 'eu-west-1'


### PR DESCRIPTION
# CONTEXT

Right now, there is only transition deployed since we are deploying the apps in staged separate sets.
Hence, only deploy `transition` app on the backend server.

# Decisions

The `staging.yaml` and `production.yml` in `hieradata_aws` folder needs to change to modify the apps to be deployed on the backed box.

# TODO after merge

In Jenkins in AWS staging and production, there is a need to trigger the `Deploy_Puppet` job with the new master rather than this branch `disable_all_apps_except_transition_on_backend`