### PR TITLE
Enable pg_trgm and fuzzystrmatch extensions

### DIFF
--- a/modules/govuk/manifests/apps/content_performance_manager/db.pp
+++ b/modules/govuk/manifests/apps/content_performance_manager/db.pp
@@ -19,6 +19,7 @@ class govuk::apps::content_performance_manager::db (
     allow_auth_from_backend => true,
     backend_ip_range        => $backend_ip_range,
     rds                     => $rds,
+    extensions              => ['plpgsql', 'pg_trgm', 'fuzzystrmatch'],
     enable_in_pgbouncer     => false,
   }
 }


### PR DESCRIPTION
For postgres content_performance_manager database.

We need these extensions to use the pg_search gem in order to implement:

https://trello.com/c/l2T9VoVG/725-5-index-page-filter-by-title-url