### PR TITLE
Add on/off switch for govuk_env_sync

### DIFF
--- a/hieradata/node/api-mongo-4.api.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/api-mongo-4.api.staging.publishing.service.gov.uk.yaml
@@ -4,6 +4,7 @@ govuk_safe_to_reboot::reason: 'DR node: only used in the event of a disaster'
 
 govuk_env_sync::tasks:
   "push_content_store_daily":
+    ensure: "present"
     hour: "0"
     minute: "12"
     action: "push"
@@ -14,6 +15,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mongo-api"
   "push_draft_content_store_daily":
+    ensure: "present"
     hour: "1"
     minute: "12"
     action: "push"

--- a/hieradata/node/mongo-1.backend.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/mongo-1.backend.staging.publishing.service.gov.uk.yaml
@@ -1,5 +1,6 @@
 govuk_env_sync::tasks:
   "push_licence_finder_production":
+    ensure: "present"
     hour: "1"
     minute: "21"
     action: "push"
@@ -10,6 +11,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mongo-normal"
   "push_maslow_production":
+    ensure: "present"
     hour: "1"
     minute: "21"
     action: "push"
@@ -20,6 +22,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mongo-normal"
   "push_publisher_production":
+    ensure: "present"
     hour: "1"
     minute: "21"
     action: "push"
@@ -30,6 +33,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mongo-normal"
   "push_short_url_manager_production":
+    ensure: "present"
     hour: "1"
     minute: "21"
     action: "push"
@@ -40,6 +44,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mongo-normal"
   "push_travel_advice_publisher_production":
+    ensure: "present"
     hour: "1"
     minute: "21"
     action: "push"
@@ -50,6 +55,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mongo-normal"
   "push_govuk_assets_production":
+    ensure: "present"
     hour: "1"
     minute: "41"
     action: "push"
@@ -60,6 +66,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mongo-normal"
   "push_govuk_content_production":
+    ensure: "present"
     hour: "2"
     minute: "51"
     action: "push"
@@ -70,6 +77,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mongo-normal"
   "push_imminence_production":
+    ensure: "present"
     hour: "3"
     minute: "0"
     action: "push"

--- a/hieradata/node/mysql-backup-1.backend.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/mysql-backup-1.backend.staging.publishing.service.gov.uk.yaml
@@ -3,6 +3,7 @@ govuk_sudo::sudo_conf:
     content: 'govuk-backup ALL=NOPASSWD:/usr/bin/mysqldump'
 govuk_env_sync::tasks:
   "push_collections_publisher_production_daily":
+    ensure: "present"
     hour: "0"
     minute: "12"
     action: "push"
@@ -13,6 +14,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mysql"
   "push_contacts_production_daily":
+    ensure: "present"
     hour: "0"
     minute: "14"
     action: "push"
@@ -23,6 +25,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mysql"
   "push_release_production_daily":
+    ensure: "present"
     hour: "0"
     minute: "16"
     action: "push"
@@ -33,6 +36,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mysql"
   "push_search_admin_production_daily":
+    ensure: "present"
     hour: "0"
     minute: "18"
     action: "push"
@@ -43,6 +47,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mysql"
   "push_signon_production_daily":
+    ensure: "present"
     hour: "1"
     minute: "20"
     action: "push"

--- a/hieradata/node/postgresql-primary-1.backend.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/postgresql-primary-1.backend.staging.publishing.service.gov.uk.yaml
@@ -1,5 +1,6 @@
 govuk_env_sync::tasks:
   "push_ckan_production_daily":
+    ensure: "present"
     hour: "0"
     minute: "15"
     action: "push"
@@ -10,6 +11,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "push_content_audit_tool_production_daily":
+    ensure: "present"
     hour: "0"
     minute: "12"
     action: "push"
@@ -20,6 +22,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "push_content-register_production":
+    ensure: "present"
     hour: "0"
     minute: "13"
     action: "push"
@@ -30,6 +33,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "push_content_publisher_production_daily":
+    ensure: "present"
     hour: "0"
     minute: "10"
     action: "push"
@@ -40,6 +44,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "push_content_tagger_production_daily":
+    ensure: "present"
     hour: "0"
     minute: "7"
     action: "push"
@@ -50,6 +55,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "push_email-alert-api_production_daily":
+    ensure: "present"
     hour: "1"
     minute: "12"
     action: "push"
@@ -60,6 +66,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "push_email-alert-monitor_production_daily":
+    ensure: "present"
     hour: "0"
     minute: "45"
     action: "push"
@@ -70,6 +77,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "push_link_checker_api_production_daily":
+    ensure: "present"
     hour: "0"
     minute: "2"
     action: "push"
@@ -80,6 +88,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "push_local-links-manager_production_daily":
+    ensure: "present"
     hour: "0"
     minute: "0"
     action: "push"
@@ -90,6 +99,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "push_organisations-publisher_production_daily":
+    ensure: "present"
     hour: "0"
     minute: "1"
     action: "push"
@@ -100,6 +110,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "push_publishing_api_production_daily":
+    ensure: "present"
     hour: "2"
     minute: "20"
     action: "push"
@@ -110,6 +121,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "push_service-manual-publisher_production_daily":
+    ensure: "present"
     hour: "0"
     minute: "4"
     action: "push"
@@ -120,6 +132,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "push_support_contacts_production_daily":
+    ensure: "present"
     hour: "0"
     minute: "3"
     action: "push"
@@ -130,6 +143,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "push_content_data_admin_production_daily":
+    ensure: "present"
     hour: "0"
     minute: "14"
     action: "push"

--- a/hieradata/node/router-backend-1.router.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/router-backend-1.router.staging.publishing.service.gov.uk.yaml
@@ -1,5 +1,6 @@
 govuk_env_sync::tasks:
   "push_router_daily":
+    ensure: "present"
     hour: "0"
     minute: "24"
     action: "push"
@@ -10,6 +11,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mongo-router"
   "push_draft_router_daily":
+    ensure: "present"
     hour: "0"
     minute: "45"
     action: "push"
@@ -20,6 +22,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mongo-router"
   "push_authenticating_proxy_production_daily":
+    ensure: "present"
     hour: "0"
     minute: "55"
     action: "push"

--- a/hieradata/node/rummager-elasticsearch-1.api.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/rummager-elasticsearch-1.api.staging.publishing.service.gov.uk.yaml
@@ -1,5 +1,6 @@
 govuk_env_sync::tasks:
   "push_es_metasearch_daily":
+    ensure: "present"
     hour: "0"
     minute: "20"
     action: "push"
@@ -10,6 +11,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "elasticsearch"
   "push_es_page_traffic_daily":
+    ensure: "present"
     hour: "0"
     minute: "20"
     action: "push"
@@ -20,6 +22,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "elasticsearch"
   "push_es_detailed_daily":
+    ensure: "present"
     hour: "0"
     minute: "20"
     action: "push"
@@ -30,6 +33,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "elasticsearch"
   "push_es_government_daily":
+    ensure: "present"
     hour: "0"
     minute: "20"
     action: "push"
@@ -40,6 +44,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "elasticsearch"
   "push_es_govuk_daily":
+    ensure: "present"
     hour: "0"
     minute: "20"
     action: "push"
@@ -50,6 +55,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "elasticsearch"
   "push_es_licence_finder_daily":
+    ensure: "present"
     hour: "0"
     minute: "20"
     action: "push"

--- a/hieradata/node/transition-postgresql-master-1.backend.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/transition-postgresql-master-1.backend.staging.publishing.service.gov.uk.yaml
@@ -1,5 +1,6 @@
 govuk_env_sync::tasks:
   "push_transition_production_daily":
+    ensure: "present"
     hour: "3"
     minute: "3"
     action: "push"

--- a/hieradata/node/warehouse-postgresql-1.backend.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/warehouse-postgresql-1.backend.staging.publishing.service.gov.uk.yaml
@@ -1,5 +1,6 @@
 govuk_env_sync::tasks:
   "push_content_performance_manager_production_daily":
+    ensure: "present"
     hour: "3"
     minute: "3"
     action: "push"

--- a/hieradata/node/whitehall-mysql-backup-1.backend.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/whitehall-mysql-backup-1.backend.staging.publishing.service.gov.uk.yaml
@@ -3,6 +3,7 @@ govuk_sudo::sudo_conf:
     content: 'govuk-backup ALL=NOPASSWD:/usr/bin/mysqldump'
 govuk_env_sync::tasks:
   "push_mysql_whitehall_production_daily":
+    ensure: "present"
     hour: "1"
     minute: "13"
     action: "push"

--- a/hieradata_aws/class/integration/db_admin.yaml
+++ b/hieradata_aws/class/integration/db_admin.yaml
@@ -1,5 +1,6 @@
 govuk_env_sync::tasks:
   "pull_ckan_production_daily":
+    ensure: "present"
     hour: "4"
     minute: "15"
     action: "pull"
@@ -10,6 +11,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "pull_content_audit_tool_production_daily":
+    ensure: "present"
     hour: "4"
     minute: "12"
     action: "pull"
@@ -20,6 +22,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "pull_content-register_production":
+    ensure: "present"
     hour: "4"
     minute: "13"
     action: "pull"
@@ -30,6 +33,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "pull_content_tagger_production_daily":
+    ensure: "present"
     hour: "4"
     minute: "7"
     action: "pull"
@@ -40,6 +44,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "pull_collections_publisher_production_daily":
+    ensure: "present"
     hour: "4"
     minute: "22"
     action: "pull"
@@ -50,6 +55,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mysql"
   "pull_contacts_production_daily":
+    ensure: "present"
     hour: "4"
     minute: "55"
     action: "pull"
@@ -60,6 +66,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mysql"
   "pull_email-alert-monitor_production_daily":
+    ensure: "present"
     hour: "4"
     minute: "45"
     action: "pull"
@@ -70,6 +77,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "pull_link_checker_api_production_daily":
+    ensure: "present"
     hour: "4"
     minute: "2"
     action: "pull"
@@ -80,6 +88,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "pull_local-links-manager_production_daily":
+    ensure: "present"
     hour: "4"
     minute: "0"
     action: "pull"
@@ -90,6 +99,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "pull_organisations-publisher_production_daily":
+    ensure: "present"
     hour: "4"
     minute: "1"
     action: "pull"
@@ -100,6 +110,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "pull_release_production_daily":
+    ensure: "present"
     hour: "4"
     minute: "28"
     action: "pull"
@@ -110,6 +121,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mysql"
   "pull_search_admin_production_daily":
+    ensure: "present"
     hour: "4"
     minute: "30"
     action: "pull"
@@ -120,6 +132,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mysql"
   "pull_service-manual-publisher_production_daily":
+    ensure: "present"
     hour: "4"
     minute: "4"
     action: "pull"
@@ -130,6 +143,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "pull_support_contacts_production_daily":
+    ensure: "present"
     hour: "4"
     minute: "3"
     action: "pull"
@@ -140,6 +154,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "pull_content_publisher_production_daily":
+    ensure: "present"
     hour: "4"
     minute: "14"
     action: "pull"
@@ -150,6 +165,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "pull_content_data_admin_production_daily":
+    ensure: "present"
     hour: "4"
     minute: "18"
     action: "pull"
@@ -159,4 +175,3 @@ govuk_env_sync::tasks:
     temppath: "/tmp/content_data_admin_production"
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
-

--- a/hieradata_aws/class/integration/mongo.yaml
+++ b/hieradata_aws/class/integration/mongo.yaml
@@ -1,5 +1,6 @@
 govuk_env_sync::tasks:
   "pull_content_store_daily":
+    ensure: "present"
     hour: "4" 
     minute: "16"
     action: "pull"
@@ -10,6 +11,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mongo-api"
   "pull_draft_content_store_daily":
+    ensure: "present"
     hour: "4" 
     minute: "16"
     action: "pull"
@@ -20,6 +22,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mongo-api"
   "pull_licence_finder_production":
+    ensure: "present"
     hour: "4"
     minute: "21"
     action: "pull"
@@ -30,6 +33,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mongo-normal"
   "pull_maslow_production":
+    ensure: "present"
     hour: "4"
     minute: "21"
     action: "pull"
@@ -40,6 +44,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mongo-normal"
   "pull_publisher_production":
+    ensure: "present"
     hour: "4"
     minute: "21"
     action: "pull"
@@ -50,6 +55,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mongo-normal"
   "pull_short_url_manager_production":
+    ensure: "present"
     hour: "4"
     minute: "21"
     action: "pull"
@@ -60,6 +66,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mongo-normal"
   "pull_travel_advice_publisher_production":
+    ensure: "present"
     hour: "4"
     minute: "21"
     action: "pull"
@@ -70,6 +77,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mongo-normal"
   "pull_govuk_assets_production":
+    ensure: "present"
     hour: "4"
     minute: "41"
     action: "pull"
@@ -80,6 +88,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mongo-normal"
   "pull_govuk_content_production":
+    ensure: "present"
     hour: "4"
     minute: "51"
     action: "pull"
@@ -90,6 +99,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mongo-normal"
   "pull_imminence_production":
+    ensure: "present"
     hour: "4"
     minute: "0"
     action: "pull"
@@ -99,4 +109,3 @@ govuk_env_sync::tasks:
     temppath: "/var/lib/mongodb/.dumps"
     url: "govuk-staging-database-backups"
     path: "mongo-normal"
-

--- a/hieradata_aws/class/integration/router_backend.yaml
+++ b/hieradata_aws/class/integration/router_backend.yaml
@@ -1,5 +1,6 @@
 govuk_env_sync::tasks:
   "pull_router_daily":
+    ensure: "present"
     hour: "3"
     minute: "24"
     action: "pull"
@@ -10,6 +11,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mongo-router"
   "pull_draft_router_daily":
+    ensure: "present"
     hour: "3"
     minute: "45"
     action: "pull"
@@ -20,6 +22,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mongo-router"
   "pull_authenticating_proxy_production_daily":
+    ensure: "present"
     hour: "3"
     minute: "55"
     action: "pull"

--- a/hieradata_aws/class/integration/rummager_elasticsearch.yaml
+++ b/hieradata_aws/class/integration/rummager_elasticsearch.yaml
@@ -1,5 +1,6 @@
 govuk_env_sync::tasks:
   "pull_es_metasearch_daily":
+    ensure: "present"
     hour: "4"
     minute: "24"
     action: "pull"
@@ -10,6 +11,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "elasticsearch"
   "pull_es_page_traffic_daily":
+    ensure: "present"
     hour: "4"
     minute: "24"
     action: "pull"
@@ -20,6 +22,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "elasticsearch"
   "pull_es_detailed_daily":
+    ensure: "present"
     hour: "4"
     minute: "24"
     action: "pull"
@@ -30,6 +33,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "elasticsearch"
   "pull_es_government_daily":
+    ensure: "present"
     hour: "4"
     minute: "24"
     action: "pull"
@@ -40,6 +44,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "elasticsearch"
   "pull_es_govuk_daily":
+    ensure: "present"
     hour: "4"
     minute: "24"
     action: "pull"

--- a/hieradata_aws/class/integration/transition_db_admin.yaml
+++ b/hieradata_aws/class/integration/transition_db_admin.yaml
@@ -1,5 +1,6 @@
 govuk_env_sync::tasks:
   "pull_transition_production_daily":
+    ensure: "present"
     hour: "5"
     minute: "30"
     action: "pull"

--- a/hieradata_aws/class/integration/warehouse_db_admin.yaml
+++ b/hieradata_aws/class/integration/warehouse_db_admin.yaml
@@ -1,5 +1,6 @@
 govuk_env_sync::tasks:
   "pull_content_performance_manager_production_daily":
+    ensure: "present"
     hour: "4"
     minute: "45"
     action: "pull"

--- a/hieradata_aws/class/staging/db_admin.yaml
+++ b/hieradata_aws/class/staging/db_admin.yaml
@@ -1,5 +1,6 @@
 govuk_env_sync::tasks:
   "pull_ckan_production_daily":
+    ensure: "present"
     hour: "2"
     minute: "15"
     action: "pull"
@@ -10,6 +11,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "pull_content_audit_tool_production_daily":
+    ensure: "present"
     hour: "2"
     minute: "12"
     action: "pull"
@@ -20,6 +22,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "pull_content-register_production":
+    ensure: "present"
     hour: "2"
     minute: "13"
     action: "pull"
@@ -30,6 +33,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "pull_content_tagger_production_daily":
+    ensure: "present"
     hour: "2"
     minute: "7"
     action: "pull"
@@ -40,6 +44,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "pull_collections_publisher_production_daily":
+    ensure: "present"
     hour: "2"
     minute: "22"
     action: "pull"
@@ -50,6 +55,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mysql"
   "pull_contacts_production_daily":
+    ensure: "present"
     hour: "2"
     minute: "55"
     action: "pull"
@@ -60,6 +66,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mysql"
   "pull_email-alert-monitor_production_daily":
+    ensure: "present"
     hour: "2"
     minute: "45"
     action: "pull"
@@ -70,6 +77,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "pull_link_checker_api_production_daily":
+    ensure: "present"
     hour: "2"
     minute: "2"
     action: "pull"
@@ -80,6 +88,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "pull_local-links-manager_production_daily":
+    ensure: "present"
     hour: "2"
     minute: "0"
     action: "pull"
@@ -90,6 +99,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "pull_mysql_whitehall_production_daily":
+    ensure: "present"
     hour: "2"
     minute: "26"
     action: "pull"
@@ -100,6 +110,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mysql"
   "pull_organisations-publisher_production_daily":
+    ensure: "present"
     hour: "2"
     minute: "1"
     action: "pull"
@@ -110,6 +121,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "pull_publishing_api_production_daily":
+    ensure: "present"
     hour: "2"
     minute: "20"
     action: "pull"
@@ -120,6 +132,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "pull_release_production_daily":
+    ensure: "present"
     hour: "2"
     minute: "28"
     action: "pull"
@@ -130,6 +143,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mysql"
   "pull_search_admin_production_daily":
+    ensure: "present"
     hour: "2"
     minute: "30"
     action: "pull"
@@ -140,6 +154,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mysql"
   "pull_signon_production_daily":
+    ensure: "present"
     hour: "2"
     minute: "32"
     action: "pull"
@@ -150,6 +165,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mysql"
   "pull_service-manual-publisher_production_daily":
+    ensure: "present"
     hour: "2"
     minute: "4"
     action: "pull"
@@ -160,6 +176,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "pull_support_contacts_production_daily":
+    ensure: "present"
     hour: "2"
     minute: "3"
     action: "pull"
@@ -170,6 +187,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "pull_content_publisher_production_daily":
+    ensure: "present"
     hour: "2"
     minute: "14"
     action: "pull"
@@ -180,6 +198,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "pull_content_data_admin_production_daily":
+    ensure: "present"
     hour: "0"
     minute: "18"
     action: "pull"
@@ -189,4 +208,3 @@ govuk_env_sync::tasks:
     temppath: "/tmp/content_data_admin_production"
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
-

--- a/hieradata_aws/class/staging/email_alert_api_db_admin.yaml
+++ b/hieradata_aws/class/staging/email_alert_api_db_admin.yaml
@@ -1,5 +1,6 @@
 govuk_env_sync::tasks:
   "pull_email-alert-api_production_daily":
+    ensure: "present"
     hour: "3"
     minute: "45"
     action: "pull"

--- a/hieradata_aws/class/staging/mongo.yaml
+++ b/hieradata_aws/class/staging/mongo.yaml
@@ -1,5 +1,6 @@
 govuk_env_sync::tasks:
   "pull_content_store_daily":
+    ensure: "present"
     hour: "1" 
     minute: "16"
     action: "pull"
@@ -10,6 +11,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mongo-api"
   "pull_draft_content_store_daily":
+    ensure: "present"
     hour: "2" 
     minute: "16"
     action: "pull"
@@ -20,6 +22,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mongo-api"
   "pull_licence_finder_production":
+    ensure: "present"
     hour: "1"
     minute: "21"
     action: "pull"
@@ -30,6 +33,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mongo-normal"
   "pull_maslow_production":
+    ensure: "present"
     hour: "1"
     minute: "21"
     action: "pull"
@@ -40,6 +44,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mongo-normal"
   "pull_publisher_production":
+    ensure: "present"
     hour: "1"
     minute: "21"
     action: "pull"
@@ -50,6 +55,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mongo-normal"
   "pull_short_url_manager_production":
+    ensure: "present"
     hour: "1"
     minute: "21"
     action: "pull"
@@ -60,6 +66,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mongo-normal"
   "pull_travel_advice_publisher_production":
+    ensure: "present"
     hour: "1"
     minute: "21"
     action: "pull"
@@ -70,6 +77,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mongo-normal"
   "pull_govuk_assets_production":
+    ensure: "present"
     hour: "1"
     minute: "41"
     action: "pull"
@@ -80,6 +88,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mongo-normal"
   "pull_govuk_content_production":
+    ensure: "present"
     hour: "2"
     minute: "51"
     action: "pull"
@@ -90,6 +99,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mongo-normal"
   "pull_imminence_production":
+    ensure: "present"
     hour: "3"
     minute: "0"
     action: "pull"

--- a/hieradata_aws/class/staging/publishing_api_db_admin.yaml
+++ b/hieradata_aws/class/staging/publishing_api_db_admin.yaml
@@ -1,5 +1,6 @@
 govuk_env_sync::tasks:
   "pull_publishing-api_production_daily":
+    ensure: "present"
     hour: "3"
     minute: "45"
     action: "pull"

--- a/hieradata_aws/class/staging/router_backend.yaml
+++ b/hieradata_aws/class/staging/router_backend.yaml
@@ -1,5 +1,6 @@
 govuk_env_sync::tasks:
   "pull_router_daily":
+    ensure: "present"
     hour: "1"
     minute: "24"
     action: "pull"
@@ -10,6 +11,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mongo-router"
   "pull_draft_router_daily":
+    ensure: "present"
     hour: "1"
     minute: "45"
     action: "pull"
@@ -20,6 +22,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mongo-router"
   "pull_authenticating_proxy_production_daily":
+    ensure: "present"
     hour: "1"
     minute: "55"
     action: "pull"

--- a/hieradata_aws/class/staging/rummager_elasticsearch.yaml
+++ b/hieradata_aws/class/staging/rummager_elasticsearch.yaml
@@ -1,5 +1,6 @@
 govuk_env_sync::tasks:
   "pull_es_metasearch_daily":
+    ensure: "present"
     hour: "2"
     minute: "24"
     action: "pull"
@@ -10,6 +11,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "elasticsearch"
   "pull_es_page_traffic_daily":
+    ensure: "present"
     hour: "2"
     minute: "24"
     action: "pull"
@@ -20,6 +22,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "elasticsearch"
   "pull_es_detailed_daily":
+    ensure: "present"
     hour: "2"
     minute: "24"
     action: "pull"
@@ -30,6 +33,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "elasticsearch"
   "pull_es_government_daily":
+    ensure: "present"
     hour: "2"
     minute: "24"
     action: "pull"
@@ -40,6 +44,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "elasticsearch"
   "pull_es_govuk_daily":
+    ensure: "present"
     hour: "2"
     minute: "24"
     action: "pull"

--- a/hieradata_aws/class/staging/transition_db_admin.yaml
+++ b/hieradata_aws/class/staging/transition_db_admin.yaml
@@ -1,5 +1,6 @@
 govuk_env_sync::tasks:
   "pull_transition_production_daily":
+    ensure: "present"
     hour: "4"
     minute: "30"
     action: "pull"

--- a/hieradata_aws/class/staging/warehouse_db_admin.yaml
+++ b/hieradata_aws/class/staging/warehouse_db_admin.yaml
@@ -1,5 +1,6 @@
 govuk_env_sync::tasks:
   "pull_content_performance_manager_production_daily":
+    ensure: "present"
     hour: "3"
     minute: "45"
     action: "pull"

--- a/modules/govuk_env_sync/manifests/task.pp
+++ b/modules/govuk_env_sync/manifests/task.pp
@@ -45,13 +45,14 @@ define govuk_env_sync::task(
   $database,
   $url,
   $path,
+  $ensure = 'absent',
 ) {
 
   require govuk_env_sync::aws_auth
   require govuk_env_sync::sync_script
 
   file { "${govuk_env_sync::conf_dir}/${title}.cfg":
-    ensure  => present,
+    ensure  => $ensure,
     mode    => '0755',
     owner   => $govuk_env_sync::user,
     group   => $govuk_env_sync::user,
@@ -73,6 +74,7 @@ define govuk_env_sync::task(
     ])
 
   cron { $name:
+    ensure  => $ensure,
     command => $synccommand,
     user    => $govuk_env_sync::user,
     hour    => $hour,


### PR DESCRIPTION
- So far our hiera config only allowed to add things, rather than to
  remove them

- We want to be able to turn off data sync to preserve the state
  of integration and/or in some cases, e.g. autumn budget prep

solo: @schmie