### PR TITLE
Use Postgresql module devel for mapit dependencies 

### DIFF
--- a/modules/govuk/manifests/apps/mapit.pp
+++ b/modules/govuk/manifests/apps/mapit.pp
@@ -56,6 +56,9 @@ class govuk::apps::mapit (
       ensure => present,
     }
 
+    # Install postgrest developments dependencies
+    include postgresql::lib::devel
+
     include gdal::repo
     package { 'gdal':
       ensure  => $gdal_version,


### PR DESCRIPTION
This add's the postgres package to mapit nodes. I have added this to the mapit deployment puppet manifest. This seemed to be the simplest method since it will only run on nodes with the mapit role enabled.