### PR TITLE
Allow deploy AWS Terraform job to deploy to test environment

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_terraform_govuk_aws.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_terraform_govuk_aws.yaml.erb
@@ -59,6 +59,7 @@
                 - integration
                 - staging
                 - production
+                - test
         - choice:
             name: STACKNAME
             description: Choose which stack to deploy into


### PR DESCRIPTION
This commit adds the test environment to the list of available AWS environments to deploy Terraform to.