### PR TITLE
Upgrade PostgreSQL to 9.6 in the development VM

### DIFF
--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -214,6 +214,9 @@ govuk_logging::logstream::disabled: true
 
 govuk_mysql::server::slow_query_log: true
 
+postgresql::globals::version: '9.6'
+postgresql::globals::postgis_version: '2.4'
+
 govuk_postgresql::monitoring::password: password
 govuk_postgresql::server::configure_env_sync_user: false
 govuk_postgresql::server::snakeoil_ssl_certificate: certificate


### PR DESCRIPTION
9.6 is currently used in some places, but development is a bit
problematic, as this isn't available in the development VM.

These changes will cause PostgreSQL 9.6 to be installed in the
development-vm. The PostGIS version is set explicitly to one for which
packages are available for both 9.3 and 9.6. Initially, PostgreSQL 9.6
will be configured to use the same port as the 9.3 cluster, and thus
won't start.

To upgrade to 9.6, first stop bowl, any rails consoles and anything
else using PostgreSQL. Then to migrate the data, the following
commands can be used:
 - sudo pg_dropcluster 9.6 main --stop
 - sudo pg_upgradecluster --method=upgrade --link 9.3 main
 - sudo pg_dropcluster 9.3 main

At some point in the future, we may want uninstall the PostgreSQL 9.3
packages, possibly through Puppet, but I'm not too sure about this
yet.