### PR TITLE
Disable environment sync in integration

### DIFF
--- a/hieradata_aws/class/integration/db_admin.yaml
+++ b/hieradata_aws/class/integration/db_admin.yaml
@@ -1,6 +1,6 @@
 govuk_env_sync::tasks:
   "pull_ckan_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "4"
     minute: "15"
     action: "pull"
@@ -11,7 +11,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "pull_content_audit_tool_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "4"
     minute: "12"
     action: "pull"
@@ -22,7 +22,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "pull_content-register_production":
-    ensure: "present"
+    ensure: "absent"
     hour: "4"
     minute: "13"
     action: "pull"
@@ -33,7 +33,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "pull_content_tagger_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "4"
     minute: "7"
     action: "pull"
@@ -44,7 +44,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "pull_collections_publisher_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "4"
     minute: "22"
     action: "pull"
@@ -55,7 +55,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mysql"
   "pull_contacts_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "4"
     minute: "55"
     action: "pull"
@@ -66,7 +66,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mysql"
   "pull_email-alert-monitor_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "4"
     minute: "45"
     action: "pull"
@@ -77,7 +77,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "pull_link_checker_api_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "4"
     minute: "2"
     action: "pull"
@@ -88,7 +88,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "pull_local-links-manager_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "4"
     minute: "0"
     action: "pull"
@@ -99,7 +99,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "pull_organisations-publisher_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "4"
     minute: "1"
     action: "pull"
@@ -110,7 +110,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "pull_release_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "4"
     minute: "28"
     action: "pull"
@@ -121,7 +121,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mysql"
   "pull_search_admin_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "4"
     minute: "30"
     action: "pull"
@@ -132,7 +132,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mysql"
   "pull_service-manual-publisher_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "4"
     minute: "4"
     action: "pull"
@@ -143,7 +143,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "pull_support_contacts_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "4"
     minute: "3"
     action: "pull"
@@ -154,7 +154,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "pull_content_publisher_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "4"
     minute: "14"
     action: "pull"
@@ -165,7 +165,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "pull_content_data_admin_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "4"
     minute: "18"
     action: "pull"

--- a/hieradata_aws/class/integration/mongo.yaml
+++ b/hieradata_aws/class/integration/mongo.yaml
@@ -1,6 +1,6 @@
 govuk_env_sync::tasks:
   "pull_content_store_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "4" 
     minute: "16"
     action: "pull"
@@ -11,7 +11,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mongo-api"
   "pull_draft_content_store_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "4" 
     minute: "16"
     action: "pull"
@@ -22,7 +22,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mongo-api"
   "pull_licence_finder_production":
-    ensure: "present"
+    ensure: "absent"
     hour: "4"
     minute: "21"
     action: "pull"
@@ -33,7 +33,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mongo-normal"
   "pull_maslow_production":
-    ensure: "present"
+    ensure: "absent"
     hour: "4"
     minute: "21"
     action: "pull"
@@ -44,7 +44,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mongo-normal"
   "pull_publisher_production":
-    ensure: "present"
+    ensure: "absent"
     hour: "4"
     minute: "21"
     action: "pull"
@@ -55,7 +55,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mongo-normal"
   "pull_short_url_manager_production":
-    ensure: "present"
+    ensure: "absent"
     hour: "4"
     minute: "21"
     action: "pull"
@@ -66,7 +66,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mongo-normal"
   "pull_travel_advice_publisher_production":
-    ensure: "present"
+    ensure: "absent"
     hour: "4"
     minute: "21"
     action: "pull"
@@ -77,7 +77,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mongo-normal"
   "pull_govuk_assets_production":
-    ensure: "present"
+    ensure: "absent"
     hour: "4"
     minute: "41"
     action: "pull"
@@ -88,7 +88,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mongo-normal"
   "pull_govuk_content_production":
-    ensure: "present"
+    ensure: "absent"
     hour: "4"
     minute: "51"
     action: "pull"
@@ -99,7 +99,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mongo-normal"
   "pull_imminence_production":
-    ensure: "present"
+    ensure: "absent"
     hour: "4"
     minute: "0"
     action: "pull"

--- a/hieradata_aws/class/integration/router_backend.yaml
+++ b/hieradata_aws/class/integration/router_backend.yaml
@@ -1,6 +1,6 @@
 govuk_env_sync::tasks:
   "pull_router_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "3"
     minute: "24"
     action: "pull"
@@ -11,7 +11,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mongo-router"
   "pull_draft_router_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "3"
     minute: "45"
     action: "pull"
@@ -22,7 +22,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mongo-router"
   "pull_authenticating_proxy_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "3"
     minute: "55"
     action: "pull"

--- a/hieradata_aws/class/integration/rummager_elasticsearch.yaml
+++ b/hieradata_aws/class/integration/rummager_elasticsearch.yaml
@@ -1,6 +1,6 @@
 govuk_env_sync::tasks:
   "pull_es_metasearch_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "4"
     minute: "24"
     action: "pull"
@@ -11,7 +11,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "elasticsearch"
   "pull_es_page_traffic_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "4"
     minute: "24"
     action: "pull"
@@ -22,7 +22,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "elasticsearch"
   "pull_es_detailed_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "4"
     minute: "24"
     action: "pull"
@@ -33,7 +33,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "elasticsearch"
   "pull_es_government_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "4"
     minute: "24"
     action: "pull"
@@ -44,7 +44,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "elasticsearch"
   "pull_es_govuk_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "4"
     minute: "24"
     action: "pull"

--- a/hieradata_aws/class/integration/transition_db_admin.yaml
+++ b/hieradata_aws/class/integration/transition_db_admin.yaml
@@ -1,6 +1,6 @@
 govuk_env_sync::tasks:
   "pull_transition_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "5"
     minute: "30"
     action: "pull"

--- a/hieradata_aws/class/integration/warehouse_db_admin.yaml
+++ b/hieradata_aws/class/integration/warehouse_db_admin.yaml
@@ -1,6 +1,6 @@
 govuk_env_sync::tasks:
   "pull_content_performance_manager_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "4"
     minute: "45"
     action: "pull"


### PR DESCRIPTION
- The autumn budget publication next Monday is prepared this weekend in integration

- We disable all environment synchronisation until next Tuesday

solo: @schmie