### PR TITLE
remove the smokey and deploy smokey jobs

### DIFF
--- a/hieradata_aws/class/production/jenkins.yaml
+++ b/hieradata_aws/class/production/jenkins.yaml
@@ -11,8 +11,10 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::deploy_puppet
   - govuk_jenkins::jobs::passive_checks
   - govuk_jenkins::jobs::run_rake_task
-  - govuk_jenkins::jobs::smokey
-  - govuk_jenkins::jobs::smokey_deploy
+# START OF TEMPORARY DEFECT FIX: # Smokey tests are not running correctly due to defects reported in: https://trello.com/c/XzGHhe3l/1629-investigate-cause-of-jenkins-oom-crashes-in-aws-staging-and-production
+#  - govuk_jenkins::jobs::smokey
+#  - govuk_jenkins::jobs::smokey_deploy
+# END OF TEMPORARY DEFECT FIX
   - govuk_jenkins::jobs::transition_load_all_data
   - govuk_jenkins::jobs::transition_load_site_config
   - govuk_jenkins::jobs::bouncer_cdn

--- a/hieradata_aws/class/staging/jenkins.yaml
+++ b/hieradata_aws/class/staging/jenkins.yaml
@@ -12,8 +12,10 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::mongo_data_sync
   - govuk_jenkins::jobs::passive_checks
   - govuk_jenkins::jobs::run_rake_task
-  - govuk_jenkins::jobs::smokey
-  - govuk_jenkins::jobs::smokey_deploy
+# START OF TEMPORARY DEFECT FIX: # Smokey tests are not running correctly due to defects reported in: https://trello.com/c/XzGHhe3l/1629-investigate-cause-of-jenkins-oom-crashes-in-aws-staging-and-production  
+#  - govuk_jenkins::jobs::smokey
+#  - govuk_jenkins::jobs::smokey_deploy
+# END OF TEMPORARY DEFECT FIX
   - govuk_jenkins::jobs::data_sync
   - govuk_jenkins::jobs::transition_load_all_data_redirect
   - govuk_jenkins::jobs::transition_load_site_config_redirect


### PR DESCRIPTION
smokey and deploy smokey jobs in AWS Jenkins need to be disable temporarily until they are fixed because they cause defunct processes