### PR TITLE
Re-order the CKAN plugins

### DIFF
--- a/modules/govuk/templates/ckan/ckan.ini.erb
+++ b/modules/govuk/templates/ckan/ckan.ini.erb
@@ -86,7 +86,7 @@ ckan.cors.origin_allow_all = true
 #       Add ``datapusher`` to enable DataPusher
 #       Add ``resource_proxy`` to enable resorce proxying and get around the
 #       same origin policy
-ckan.plugins = datagovsg_s3_resources datagovuk_publisher_form datagovuk dcat harvest ckan_harvester dcat_rdf_harvester dcat_json_harvester dcat_json_interface spatial_metadata spatial_query spatial_harvest_metadata_api csw_harvester waf_harvester doc_harvester inventory_harvester
+ckan.plugins = datagovuk_publisher_form datagovuk datagovsg_s3_resources dcat harvest ckan_harvester dcat_rdf_harvester dcat_json_harvester dcat_json_interface spatial_metadata spatial_query spatial_harvest_metadata_api csw_harvester waf_harvester doc_harvester inventory_harvester
 
 # These are marked as legacy harvesters
 # gemini_csw_harvester gemini_doc_harvester gemini_waf_harvester


### PR DESCRIPTION
The S3 resource uploader plugin must activate
after the broader govuk plugin, as it messes with
the resource metadata in ways which break our
XLS to CSV plugin.

The XLS to CSV plugin does its best to simulate
real manual file uploads, so the S3 plugin works
fine with them.

https://trello.com/c/EtJxbHIw/76-implement-xls-to-csv-convertor