### PR TITLE
Remove mapit from the /etc/hosts on Staging Carrenza

### DIFF
--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -245,6 +245,13 @@ hosts::production::api::hosts:
   search-3:
     ip: '10.2.4.6'
 
+hosts::production::api::app_hostnames:
+  - 'backdrop-read'
+  - 'backdrop-write'
+  - 'content-store'
+  - 'rummager'
+  - 'search'
+
 hosts::production::backend::hosts:
   asset-master-1:
     ip: '10.2.3.20'


### PR DESCRIPTION
  We're migrating the mapit service to AWS, we have a new DNS
record to point to the AWS ALB and we need to disable the local
resolving on Staging Carrenza machines for it to take effect.