### PR TITLE
Remove unused Ruby versions

### DIFF
--- a/modules/govuk_rbenv/manifests/all.pp
+++ b/modules/govuk_rbenv/manifests/all.pp
@@ -22,14 +22,8 @@ class govuk_rbenv::all (
   }
 
   $ruby_versions = [
-    '2.2.8',
-    '2.3.1',
-    '2.3.5',
-    '2.4.0',
-    '2.4.2',
     '2.4.4',
     '2.4.5',
-    '2.5.0',
     '2.5.1',
     '2.5.3',
   ]
@@ -38,13 +32,7 @@ class govuk_rbenv::all (
     with_foreman => $with_foreman,
   }
 
-  # These aliases re solve .ruby-version 2.x to an installed Ruby version.
-  rbenv::alias { '2.2':
-    to_version => '2.2.8',
-  }
-  rbenv::alias { '2.3':
-    to_version => '2.3.5',
-  }
+  # These aliases resolve .ruby-version 2.x to an installed Ruby version.
   rbenv::alias { '2.4':
     to_version => '2.4.5',
   }

--- a/modules/monitoring/templates/govuk-uptime-collector.conf.erb
+++ b/modules/monitoring/templates/govuk-uptime-collector.conf.erb
@@ -3,7 +3,7 @@ description "govuk-uptime-collector"
 start on runlevel [2345]
 respawn
 
-env RBENV_VERSION=2.3
+env RBENV_VERSION=2.5
 env PATH=/usr/lib/rbenv/shims:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 exec govuk_uptime_collector <%= @environment %> <%= @aws %> content-store hmrc-manuals-api link-checker-api manuals-publisher publishing-api specialist-publisher travel-advice-publisher


### PR DESCRIPTION
These were found by running

```
$ fab production puppet_class:govuk_rbenv::all rbenv.version_in_use
```

for each Ruby version and checking the output.


[Trello Card](https://trello.com/c/TLzpRMz3/585-remove-unused-ruby-versions)