### PR TITLE
Point to draft content store when request is draft

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -70,6 +70,7 @@ node_class: &node_class
   draft_cache:
     apps:
       - authenticating-proxy
+      - draft-publicapi
       - router
       - router-api
   draft_content_store:
@@ -1529,6 +1530,7 @@ hosts::production::frontend::app_hostnames:
   - 'draft-frontend'
   - 'draft-government-frontend'
   - 'draft-manuals-frontend'
+  - 'draft-publicapi'
   - 'draft-service-manual-frontend'
   - 'draft-smartanswers'
   - 'draft-static'

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -71,7 +71,7 @@ node_class: &node_class
       - authenticating-proxy
       - router
       - router-api
-      - publicapi
+      - draft-publicapi
   draft_content_store:
     apps:
       - content-store

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -43,6 +43,7 @@ node_class: &node_class
       - authenticating-proxy
       - router
       - router-api
+      - draft-publicapi
   draft_content_store:
     apps:
       - content-store

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -43,6 +43,7 @@ node_class: &node_class
       - authenticating-proxy
       - router
       - router-api
+      - draft-publicapi
   draft_content_store:
     apps:
       - content-store

--- a/modules/govuk/manifests/app/publicapi.pp
+++ b/modules/govuk/manifests/app/publicapi.pp
@@ -1,0 +1,72 @@
+# govuk::app::publicapi
+#
+# Definition used by both
+# modules/govuk/manifests/apps/publicapi.pp
+# and
+# modules/govuk/manifests/apps/draft_publicapi.pp
+#
+# === Parameters
+#
+# [*backdrop_protocol*]
+#   String. The protocol to use when proxying to Backdrop (e.g. 'https').
+#
+# [*backdrop_host*]
+#   String. The host to use when proxying to Backdrop (e.g. 'www.performance.service.gov.uk').
+#
+# [*privateapi_ssl*]
+#   Boolean. Whether to use SSL for the private API.
+#
+# [*prefix*]
+#   String. It specifies if it's the live publicapi or the draft publicapi (set
+#   to '' for live, or to 'draft-' for draft).
+#
+
+define govuk::app::publicapi (
+  $backdrop_protocol,
+  $backdrop_host,
+  $privateapi_ssl,
+  $prefix,
+) {
+  $app_domain = hiera('app_domain')
+  $app_name = "${prefix}publicapi"
+
+  if $::aws_migration {
+    # In AWS the upstream should use the internal domain. The nginx server_name
+    # directive automatically gets assigned the internal domain by the
+    # nginx::config::vhost::proxy defined type.
+    $app_domain_internal = hiera('app_domain_internal')
+
+    $whitehallapi = "whitehall-frontend.${app_domain_internal}"
+    $rummager_api = "search.${app_domain_internal}"
+    $content_store_api = "${prefix}content-store.${app_domain_internal}"
+
+    $full_domain = $app_name
+  } else {
+    $whitehallapi = "whitehall-frontend.${app_domain}"
+    $rummager_api = "search.${app_domain}"
+    $content_store_api = "${prefix}content-store.${app_domain}"
+
+    $full_domain = "${app_name}.${app_domain}"
+  }
+
+  $backdrop_url = "${backdrop_protocol}://${backdrop_host}"
+
+  if ($privateapi_ssl) {
+    $privateapi_protocol = 'https'
+  } else {
+    $privateapi_protocol = 'http'
+  }
+
+  nginx::config::vhost::proxy { $full_domain:
+    to               => [$whitehallapi, $rummager_api, $content_store_api],
+    to_ssl           => $privateapi_ssl,
+    protected        => false,
+    ssl_only         => false,
+    extra_app_config => "
+      # Don't proxy_pass / anywhere, just return 404. All real requests will
+      # be handled by the location blocks below.
+      return 404;
+    ",
+    extra_config     => template('govuk/publicapi_nginx_extra_config.erb'),
+  }
+}

--- a/modules/govuk/manifests/apps/draft_publicapi.pp
+++ b/modules/govuk/manifests/apps/draft_publicapi.pp
@@ -1,12 +1,12 @@
 # FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
-class govuk::apps::publicapi (
+class govuk::apps::draft_publicapi (
   $backdrop_protocol = 'https',
   $backdrop_host = 'www.performance.service.gov.uk',
   $privateapi_ssl = true,
 ) {
 
   $app_domain = hiera('app_domain')
-  $app_name = 'publicapi'
+  $app_name = 'draft-publicapi'
 
   if $::aws_migration {
     # In AWS the upstream should use the internal domain. The nginx server_name
@@ -16,13 +16,13 @@ class govuk::apps::publicapi (
 
     $whitehallapi = "whitehall-frontend.${app_domain_internal}"
     $rummager_api = "search.${app_domain_internal}"
-    $content_store_api = "content-store.${app_domain_internal}"
+    $content_store_api = "draft-content-store.${app_domain_internal}"
 
     $full_domain = $app_name
   } else {
     $whitehallapi = "whitehall-frontend.${app_domain}"
     $rummager_api = "search.${app_domain}"
-    $content_store_api = "content-store.${app_domain}"
+    $content_store_api = "draft-content-store.${app_domain}"
 
     $full_domain = "${app_name}.${app_domain}"
   }

--- a/modules/govuk/manifests/apps/draft_publicapi.pp
+++ b/modules/govuk/manifests/apps/draft_publicapi.pp
@@ -4,47 +4,10 @@ class govuk::apps::draft_publicapi (
   $backdrop_host = 'www.performance.service.gov.uk',
   $privateapi_ssl = true,
 ) {
-
-  $app_domain = hiera('app_domain')
-  $app_name = 'draft-publicapi'
-
-  if $::aws_migration {
-    # In AWS the upstream should use the internal domain. The nginx server_name
-    # directive automatically gets assigned the internal domain by the
-    # nginx::config::vhost::proxy defined type.
-    $app_domain_internal = hiera('app_domain_internal')
-
-    $whitehallapi = "whitehall-frontend.${app_domain_internal}"
-    $rummager_api = "search.${app_domain_internal}"
-    $content_store_api = "draft-content-store.${app_domain_internal}"
-
-    $full_domain = $app_name
-  } else {
-    $whitehallapi = "whitehall-frontend.${app_domain}"
-    $rummager_api = "search.${app_domain}"
-    $content_store_api = "draft-content-store.${app_domain}"
-
-    $full_domain = "${app_name}.${app_domain}"
-  }
-
-  $backdrop_url = "${backdrop_protocol}://${backdrop_host}"
-
-  if ($privateapi_ssl) {
-    $privateapi_protocol = 'https'
-  } else {
-    $privateapi_protocol = 'http'
-  }
-
-  nginx::config::vhost::proxy { $full_domain:
-    to               => [$whitehallapi, $rummager_api, $content_store_api],
-    to_ssl           => $privateapi_ssl,
-    protected        => false,
-    ssl_only         => false,
-    extra_app_config => "
-      # Don't proxy_pass / anywhere, just return 404. All real requests will
-      # be handled by the location blocks below.
-      return 404;
-    ",
-    extra_config     => template('govuk/publicapi_nginx_extra_config.erb'),
+  govuk::app::publicapi { 'draft-publicapi':
+    backdrop_protocol => $backdrop_protocol,
+    backdrop_host     => $backdrop_host,
+    privateapi_ssl    => $privateapi_ssl,
+    prefix            => 'draft-',
   }
 }

--- a/modules/govuk/manifests/apps/publicapi.pp
+++ b/modules/govuk/manifests/apps/publicapi.pp
@@ -4,47 +4,10 @@ class govuk::apps::publicapi (
   $backdrop_host = 'www.performance.service.gov.uk',
   $privateapi_ssl = true,
 ) {
-
-  $app_domain = hiera('app_domain')
-  $app_name = 'publicapi'
-
-  if $::aws_migration {
-    # In AWS the upstream should use the internal domain. The nginx server_name
-    # directive automatically gets assigned the internal domain by the
-    # nginx::config::vhost::proxy defined type.
-    $app_domain_internal = hiera('app_domain_internal')
-
-    $whitehallapi = "whitehall-frontend.${app_domain_internal}"
-    $rummager_api = "search.${app_domain_internal}"
-    $content_store_api = "content-store.${app_domain_internal}"
-
-    $full_domain = $app_name
-  } else {
-    $whitehallapi = "whitehall-frontend.${app_domain}"
-    $rummager_api = "search.${app_domain}"
-    $content_store_api = "content-store.${app_domain}"
-
-    $full_domain = "${app_name}.${app_domain}"
-  }
-
-  $backdrop_url = "${backdrop_protocol}://${backdrop_host}"
-
-  if ($privateapi_ssl) {
-    $privateapi_protocol = 'https'
-  } else {
-    $privateapi_protocol = 'http'
-  }
-
-  nginx::config::vhost::proxy { $full_domain:
-    to               => [$whitehallapi, $rummager_api, $content_store_api],
-    to_ssl           => $privateapi_ssl,
-    protected        => false,
-    ssl_only         => false,
-    extra_app_config => "
-      # Don't proxy_pass / anywhere, just return 404. All real requests will
-      # be handled by the location blocks below.
-      return 404;
-    ",
-    extra_config     => template('govuk/publicapi_nginx_extra_config.erb'),
+  govuk::app::publicapi { 'live-publicapi':
+    backdrop_protocol => $backdrop_protocol,
+    backdrop_host     => $backdrop_host,
+    privateapi_ssl    => $privateapi_ssl,
+    prefix            => '',
   }
 }

--- a/modules/govuk_jenkins/manifests/node_app_deploy.pp
+++ b/modules/govuk_jenkins/manifests/node_app_deploy.pp
@@ -33,6 +33,7 @@ define govuk_jenkins::node_app_deploy (
     'canary-backend',
     'canary-frontend',
     'publicapi',
+    'draft-publicapi',
   ]
 
   unless empty($apps) {


### PR DESCRIPTION
This is to enable viewing content store on draft stack.
- Add a draft public api class and pointed it to the draft content store
- Add that class to the draft cache machines in all environments
- Revert changes from https://github.com/alphagov/govuk-puppet/pull/8234

Trello card: https://trello.com/c/JDiLJ8h1/570-enable-viewing-content-store-on-draft-stack