### PR TITLE
GovUK-Migr-Trello-1646: Set dns caching on bouncer

### DIFF
--- a/hieradata_aws/class/production/bouncer.yaml
+++ b/hieradata_aws/class/production/bouncer.yaml
@@ -1,0 +1,2 @@
+---
+nscd::config::dns_cache: 'yes'

--- a/hieradata_aws/class/staging/bouncer.yaml
+++ b/hieradata_aws/class/staging/bouncer.yaml
@@ -1,0 +1,3 @@
+---
+
+nscd::config::dns_cache: 'yes'

--- a/modules/govuk/manifests/node/s_bouncer.pp
+++ b/modules/govuk/manifests/node/s_bouncer.pp
@@ -17,6 +17,7 @@ class govuk::node::s_bouncer (
   include govuk_bouncer::gor
   include govuk::node::s_app_server
   include nginx
+  include nscd
 
   @@icinga::check::graphite { "check_nginx_connections_writing_${::hostname}":
     target    => "${::fqdn_metrics}.nginx.nginx_connections-writing",


### PR DESCRIPTION
Here we are enabling DNS caching on bouncer in staging_aws and
production_aws. Required to reduce the amount of idns lookups bouncer
will need to preform.

Pair: @ronocg @th31nitiatet