### PR TITLE
Proxy CSS and JS requests from main domain to assets domain

### DIFF
--- a/modules/router/templates/router_include.conf.erb
+++ b/modules/router/templates/router_include.conf.erb
@@ -60,6 +60,13 @@ location ~ ^/contact/govuk/(|service-feedback|problem_reports|foi|page_improveme
   proxy_pass http://varnish;
 }
 
+# Allow serving CSS and JS assets from the main domain rather than assets domain
+# This helps performance with HTTP/2
+location ~ ^/assets/(.+)\.(css|js)$ {
+  proxy_set_header Host assets-origin.<%= @app_domain %>;
+  proxy_pass https://assets-origin.<%= @app_domain %>/$1.$2;
+}
+
 location / {
   <%= scope.function_template(['router/fragments/_basic_auth.erb']) -%>
 


### PR DESCRIPTION
This commit adds nginx configuration that allows CSS and JS files to be served under `www.gov.uk`, which will be proxied to `assets.publishing.service.gov.uk`. This helps with HTTP/2 performance since downloading CSS and JS files will no longer block requests for other assets.