### PR TITLE
add imminence to the staging backend server

### DIFF
--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -18,6 +18,7 @@ node_class: &node_class
   backend:
     apps:
       - transition
+      - imminence
   bouncer:
     apps:
       - bouncer


### PR DESCRIPTION
# Context

During the AWS migration, we switched off all apps except transition on AWS backend server. 
The next step now is to migration `imminence` to AWS staging and therefore, we need to activate it.

# Decision

Add `imminence` back to the list of apps on the AWS staging backend server.