### PR TITLE
add signon to AWS staging backend

### DIFF
--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -19,6 +19,7 @@ node_class: &node_class
     apps:
       - transition
       - imminence
+      - signon
   bouncer:
     apps:
       - bouncer


### PR DESCRIPTION
# Context
During the AWS migration, we switched off all apps except transition on AWS backend server.
The next step is to add `signon` so that we have a `signon` for the AWS staging environment.

# Decision
Add `signon` back to the list of apps on the AWS staging backend server.