### PR TITLE
Remove gtm_auth and gtm_preview for production env

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -64,9 +64,7 @@ environment_ip_prefix: '10.3'
 govuk::apps::asset_manager::aws_s3_bucket_name: 'govuk-assets-production'
 govuk::apps::asset_manager::aws_region: 'eu-west-1'
 govuk::apps::ckan::ckan_site_url: 'https://ckan.publishing.service.gov.uk'
-govuk::apps::content_data_admin::google_tag_manager_auth: 'KnLtSFTrXv8BN1orNy5z9A'
 govuk::apps::content_data_admin::google_tag_manager_id: 'GTM-NZG8SF2'
-govuk::apps::content_data_admin::google_tag_manager_preview: 'env-2'
 govuk::apps::content_publisher::aws_s3_bucket: "govuk-production-content-publisher-activestorage"
 govuk::apps::content_publisher::google_tag_manager_auth: "O0DrItJxJeQ5Q2W6YCZzvw"
 govuk::apps::content_publisher::google_tag_manager_id: "GTM-NQXC4TG"


### PR DESCRIPTION
### What?
This PR removes the gtm auth and gtm preview env variables from content data admin's production environment

### Why?
The auth and preview env variables are not needed in production. . The component will default to using a nil value which seems to be what is required in the production environment if it is not passed these values.