### PR TITLE
Enable PagerDuty drills in AWS production

### DIFF
--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -209,6 +209,7 @@ monitoring::checks::sidekiq::enable_support_check: false
 monitoring::checks::ses::region: 'eu-west-1'
 monitoring::checks::rds::region: 'eu-west-1'
 monitoring::checks::cache::region: 'eu-west-1'
+monitoring::pagerduty_drill::enabled: true
 
 # START OF TEMPORARY DEFECT FIX: # Smokey tests are not running correctly due to defects reported in: https://trello.com/c/XzGHhe3l/1629-investigate-cause-of-jenkins-oom-crashes-in-aws-staging-and-production
 # monitoring::checks::smokey::environment: 'production'


### PR DESCRIPTION
- We are migrating the bouncer app this afternoon and will need
  pagerduty to be live in AWS prod

solo: @schmie