### PR TITLE
This adds the node_class list to the staging yaml file used in Carren…

### DIFF
--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -536,3 +536,56 @@ router::nginx::robotstxt: |
 
 mongodb::s3backup::backup::s3_bucket: 'govuk-mongodb-backup-s3-staging'
 mongodb::s3backup::backup::s3_bucket_daily: 'govuk-mongodb-backup-s3-daily-staging'
+
+node_class: &node_class
+  api:
+    apps:
+      - backdrop-read
+      - backdrop-write
+  asset_master:
+    apps:
+      - asset_env_sync
+  backend:
+    apps:
+      - asset-manager
+      - cache-clearing-service
+      - canary-backend
+      - collections-publisher
+      - contacts
+      - content-audit-tool
+      - content-data-admin
+      - content-performance-manager
+      - content-publisher
+      - content-tagger
+      - event-store
+      - hmrc-manuals-api
+      - imminence
+      - kibana
+      - link-checker-api
+      - local-links-manager
+      - manuals-publisher
+      - maslow
+      - organisations-publisher
+      - publisher
+      - release
+      - search-admin
+      - service-manual-publisher
+      - short-url-manager
+      - sidekiq-monitoring
+      - signon
+      - specialist-publisher
+      - support
+      - support-api
+      - travel-advice-publisher
+  bouncer:
+    apps:
+      - bouncer
+  cache:
+    apps:
+      - router
+  content_store:
+    apps:
+      - content-store
+
+govuk::node::s_base::node_apps:
+  <<: *node_class


### PR DESCRIPTION
…za, with "transition" removed. This is done in order to migrate the backend app to AWS.
With this code in place transition will not be installed in Staging (Carrenza),
so when it's stopped manually it will not return unexpectedly.

The idea being to stop access to transition in Carrenza then switch DNS so the
new transition in AWS is used.