### PR TITLE
Publishing API Metrics Dashboard

### DIFF
--- a/modules/grafana/files/dashboards/publishing_api.json
+++ b/modules/grafana/files/dashboards/publishing_api.json
@@ -122,12 +122,12 @@
           "targets": [
             {
               "refId": "C",
-              "target": "alias(summarize(maxSeries(stats.gauges.govuk.app.publishing-api.*.workers.queues.downstream_low.latency), '30d', 'max'), 'Monthly')",
+              "target": "alias(summarize(maxSeries(stats.gauges.govuk.app.publishing-api.*.workers.queues.downstream_low.latency), '1month', 'max'), 'Monthly')",
               "textEditor": true
             },
             {
               "refId": "B",
-              "target": "alias(summarize(maxSeries(stats.gauges.govuk.app.publishing-api.*.workers.queues.downstream_low.latency), '7d', 'max'), 'Weekly')",
+              "target": "alias(summarize(maxSeries(stats.gauges.govuk.app.publishing-api.*.workers.queues.downstream_low.latency), '1w', 'max'), 'Weekly')",
               "textEditor": true
             },
             {
@@ -398,5 +398,5 @@
   },
   "timezone": "",
   "title": "Publishing API Metrics",
-  "version": 6
+  "version": 7
 }

--- a/modules/grafana/files/dashboards/publishing_api.json
+++ b/modules/grafana/files/dashboards/publishing_api.json
@@ -11,7 +11,7 @@
   "rows": [
     {
       "collapse": false,
-      "height": "300",
+      "height": "280",
       "panels": [
         {
           "cacheTimeout": null,
@@ -179,6 +179,96 @@
       "showTitle": true,
       "title": "Downstream Low Activity",
       "titleSize": "h5"
+    },
+    {
+      "collapse": false,
+      "height": "240",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Graphite",
+          "fill": 1,
+          "id": 3,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 12,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "refId": "A",
+              "target": "alias(averageSeries(publishing-api-*.load.load.shortterm), 'Publishing API')",
+              "textEditor": true
+            },
+            {
+              "refId": "B",
+              "target": "alias(averageSeries(postgresql-*.load.load.shortterm), 'PostgreSQL')",
+              "textEditor": true
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Machine Load",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "Machine",
+      "titleSize": "h5"
     }
   ],
   "schemaVersion": 14,
@@ -218,5 +308,5 @@
   },
   "timezone": "",
   "title": "Publishing API Metrics",
-  "version": 3
+  "version": 4
 }

--- a/modules/grafana/files/dashboards/publishing_api.json
+++ b/modules/grafana/files/dashboards/publishing_api.json
@@ -421,6 +421,18 @@
               "target": "alias(offset(asPercent(timeShift(#D, '1M'), #D), -100), 'Latency compared to the month before')",
               "targetFull": "alias(offset(asPercent(timeShift(summarize(maxSeries(stats.gauges.govuk.app.publishing-api.*.workers.queues.downstream_low.latency), '1M', 'max'), '1M'), #D), -100), 'Latency compared to the month before')",
               "textEditor": true
+            },
+            {
+              "hide": true,
+              "refId": "E",
+              "target": "summarize(maxSeries(stats.gauges.govuk.app.publishing-api.*.workers.queues.downstream_low.latency), '4M', 'max')",
+              "textEditor": true
+            },
+            {
+              "refId": "F",
+              "target": "alias(offset(asPercent(timeShift(#E, '4M'), #E), -100), 'Latency compared to the quarter before')",
+              "targetFull": "alias(offset(asPercent(timeShift(summarize(maxSeries(stats.gauges.govuk.app.publishing-api.*.workers.queues.downstream_low.latency), '4M', 'max'), '4M'), #E), -100), 'Latency compared to the quarter before')",
+              "textEditor": true
             }
           ],
           "thresholds": [],

--- a/modules/grafana/files/dashboards/publishing_api.json
+++ b/modules/grafana/files/dashboards/publishing_api.json
@@ -76,7 +76,7 @@
             }
           ],
           "thresholds": "1800,3600",
-          "title": "",
+          "title": "Downstream Low Latency",
           "transparent": false,
           "type": "singlestat",
           "valueFontSize": "50%",
@@ -139,7 +139,7 @@
           "thresholds": [],
           "timeFrom": "180d",
           "timeShift": null,
-          "title": "Historical Maximum Latency",
+          "title": "Historical Maximum Downstream Low Latency",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -176,7 +176,7 @@
       "repeat": null,
       "repeatIteration": null,
       "repeatRowId": null,
-      "showTitle": true,
+      "showTitle": false,
       "title": "Downstream Low Activity",
       "titleSize": "h5"
     },
@@ -266,8 +266,98 @@
       "repeat": null,
       "repeatIteration": null,
       "repeatRowId": null,
-      "showTitle": true,
+      "showTitle": false,
       "title": "Machine",
+      "titleSize": "h5"
+    },
+    {
+      "collapse": false,
+      "height": "240",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Graphite",
+          "fill": 1,
+          "id": 4,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "Errors",
+              "color": "#BF1B00"
+            }
+          ],
+          "spaceLength": 10,
+          "span": 12,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "refId": "A",
+              "target": "alias(sumSeries(stats.publishing-api*.nginx_logs.*.http_5*), 'Errors')",
+              "textEditor": true
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "HTTP Responses",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Responses",
       "titleSize": "h5"
     }
   ],
@@ -308,5 +398,5 @@
   },
   "timezone": "",
   "title": "Publishing API Metrics",
-  "version": 4
+  "version": 6
 }

--- a/modules/grafana/files/dashboards/publishing_api.json
+++ b/modules/grafana/files/dashboards/publishing_api.json
@@ -1,0 +1,222 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "hideControls": false,
+  "id": null,
+  "links": [],
+  "rows": [
+    {
+      "collapse": false,
+      "height": "300",
+      "panels": [
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(50, 172, 45, 0.97)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(245, 54, 54, 0.9)"
+          ],
+          "datasource": "Graphite",
+          "decimals": 1,
+          "format": "s",
+          "gauge": {
+            "maxValue": 7200,
+            "minValue": 0,
+            "show": true,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 1,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 3,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "refId": "A",
+              "target": "maxSeries(stats.gauges.govuk.app.publishing-api.*.workers.queues.downstream_low.latency)",
+              "textEditor": true
+            }
+          ],
+          "thresholds": "1800,3600",
+          "title": "",
+          "transparent": false,
+          "type": "singlestat",
+          "valueFontSize": "50%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Graphite",
+          "fill": 1,
+          "id": 2,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 9,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "refId": "C",
+              "target": "alias(summarize(maxSeries(stats.gauges.govuk.app.publishing-api.*.workers.queues.downstream_low.latency), '30d', 'max'), 'Monthly')",
+              "textEditor": true
+            },
+            {
+              "refId": "B",
+              "target": "alias(summarize(maxSeries(stats.gauges.govuk.app.publishing-api.*.workers.queues.downstream_low.latency), '7d', 'max'), 'Weekly')",
+              "textEditor": true
+            },
+            {
+              "refId": "A",
+              "target": "alias(summarize(maxSeries(stats.gauges.govuk.app.publishing-api.*.workers.queues.downstream_low.latency), '1d', 'max'), 'Daily')",
+              "textEditor": true
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": "180d",
+          "timeShift": null,
+          "title": "Historical Maximum Latency",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "Downstream Low Activity",
+      "titleSize": "h5"
+    }
+  ],
+  "schemaVersion": 14,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Publishing API Metrics",
+  "version": 3
+}

--- a/modules/grafana/files/dashboards/publishing_api.json
+++ b/modules/grafana/files/dashboards/publishing_api.json
@@ -123,7 +123,7 @@
           "targets": [
             {
               "refId": "C",
-              "target": "alias(summarize(maxSeries(stats.gauges.govuk.app.publishing-api.*.workers.queues.downstream_low.latency), '1month', 'max'), 'Monthly')",
+              "target": "alias(summarize(maxSeries(stats.gauges.govuk.app.publishing-api.*.workers.queues.downstream_low.latency), '1M', 'max'), 'Monthly')",
               "textEditor": true
             },
             {
@@ -138,7 +138,7 @@
             }
           ],
           "thresholds": [],
-          "timeFrom": "180d",
+          "timeFrom": "6M",
           "timeShift": null,
           "title": "Historical Maximum Downstream Low Latency",
           "tooltip": {
@@ -360,6 +360,112 @@
       "showTitle": false,
       "title": "Responses",
       "titleSize": "h5"
+    },
+    {
+      "collapse": false,
+      "height": "240",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Graphite",
+          "fill": 1,
+          "id": 5,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 12,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "hide": true,
+              "refId": "A",
+              "target": "summarize(maxSeries(stats.gauges.govuk.app.publishing-api.*.workers.queues.downstream_low.latency), '1w', 'max')",
+              "textEditor": true
+            },
+            {
+              "hide": false,
+              "refId": "C",
+              "target": "alias(offset(asPercent(timeShift(#A, '1w'), #A), -100), 'Latency compared to the week before')",
+              "targetFull": "alias(offset(asPercent(timeShift(summarize(maxSeries(stats.gauges.govuk.app.publishing-api.*.workers.queues.downstream_low.latency), '1w', 'max'), '1w'), #A), -100), 'Latency compared to the week before')",
+              "textEditor": true
+            },
+            {
+              "hide": true,
+              "refId": "D",
+              "target": "summarize(maxSeries(stats.gauges.govuk.app.publishing-api.*.workers.queues.downstream_low.latency), '1M', 'max')",
+              "textEditor": true
+            },
+            {
+              "hide": false,
+              "refId": "B",
+              "target": "alias(offset(asPercent(timeShift(#D, '1M'), #D), -100), 'Latency compared to the month before')",
+              "targetFull": "alias(offset(asPercent(timeShift(summarize(maxSeries(stats.gauges.govuk.app.publishing-api.*.workers.queues.downstream_low.latency), '1M', 'max'), '1M'), #D), -100), 'Latency compared to the month before')",
+              "textEditor": true
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": "6M",
+          "timeShift": null,
+          "title": "Performance",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "percent",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
     }
   ],
   "schemaVersion": 14,
@@ -399,5 +505,5 @@
   },
   "timezone": "",
   "title": "Publishing API Metrics",
-  "version": 7
+  "version": 9
 }

--- a/modules/grafana/files/dashboards/publishing_api.json
+++ b/modules/grafana/files/dashboards/publishing_api.json
@@ -8,6 +8,7 @@
   "hideControls": false,
   "id": null,
   "links": [],
+  "refresh": "10s",
   "rows": [
     {
       "collapse": false,

--- a/modules/grafana/templates/dashboards/publishing_api_overview.json.erb
+++ b/modules/grafana/templates/dashboards/publishing_api_overview.json.erb
@@ -1,6 +1,6 @@
 {
   "id": null,
-  "title": "Publishing API Metrics",
+  "title": "Publishing API Overview",
   "tags": [],
   "style": "dark",
   "timezone": "browser",


### PR DESCRIPTION
Add a dashboard that provides an overview of Publishing API metrics, similar to the Email Alert API metrics dashboard.

Includes information about the downstream low latency, including a historical view, the load on both the Publishing API and PostgreSQL machines, and then HTTP error rate.

This is an initial attempt at the dashboard and we will continue to iterate it as we need to.

<img width="1431" alt="screen shot 2018-10-31 at 13 35 42" src="https://user-images.githubusercontent.com/510498/47791582-ed498100-dd11-11e8-81cb-2c3e6c5b91dd.png">

[Trello Card](https://trello.com/c/eYgY2zUJ/587-build-a-dashboard-for-showing-how-weve-improved-the-pipeline-links-edition)