### PR TITLE
Revert "Disable retries for non-idempotent requests"

### DIFF
--- a/modules/loadbalancer/templates/nginx_balance.conf.erb
+++ b/modules/loadbalancer/templates/nginx_balance.conf.erb
@@ -52,12 +52,6 @@ server {
   # Try next upstream if one returns an error
   proxy_next_upstream error http_500;
 
-  # Disable trying next upstream for non-idempotent requests
-  # See https://trac.nginx.org/nginx/ticket/488
-  if ($request_method ~ ^(POST|LOCK|DELETE)$) {
-    proxy_next_upstream off;
-  }
-
   proxy_set_header Host $http_host;
   proxy_set_header X-Real-IP $remote_addr;
   proxy_set_header X-Forwarded-Server $host;

--- a/modules/loadbalancer/templates/nginx_balance_no_ssl.conf.erb
+++ b/modules/loadbalancer/templates/nginx_balance_no_ssl.conf.erb
@@ -35,12 +35,6 @@ server {
   # Try next upstream if one returns an error
   proxy_next_upstream error http_500;
 
-  # Disable trying next upstream for non-idempotent requests
-  # See https://trac.nginx.org/nginx/ticket/488
-  if ($request_method ~ ^(POST|LOCK|DELETE)$) {
-    proxy_next_upstream off;
-  }
-
   proxy_set_header Host $http_host;
   proxy_set_header X-Real-IP $remote_addr;
   proxy_set_header X-Forwarded-Server $host;


### PR DESCRIPTION
Reverts alphagov/govuk-puppet#8182

Looks like nginx doesn't like this configuration so reverting until we can take a better look at it. This will prevent issues if nginx tries to restart and fails because of this config.