### PR TITLE
Add PagerDuty parameters to Icinga AWS prod conf

### DIFF
--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -209,6 +209,14 @@ monitoring::checks::sidekiq::enable_support_check: false
 monitoring::checks::ses::region: 'eu-west-1'
 monitoring::checks::rds::region: 'eu-west-1'
 monitoring::checks::cache::region: 'eu-west-1'
+monitoring::contacts::notify_graphite: true
+monitoring::contacts::notify_pager: true
+monitoring::contacts::notify_slack: true
+monitoring::contacts::slack_subdomain: 'govuk'
+monitoring::contacts::slack_channel: '#webops-monitoring'
+monitoring::contacts::slack_username: 'Production Icinga'
+monitoring::contacts::slack_alert_url: "https://alert.%{hiera('app_domain')}/cgi-bin/icinga/status.cgi"
+monitoring::edge::enabled: true
 monitoring::pagerduty_drill::enabled: true
 
 # START OF TEMPORARY DEFECT FIX: # Smokey tests are not running correctly due to defects reported in: https://trello.com/c/XzGHhe3l/1629-investigate-cause-of-jenkins-oom-crashes-in-aws-staging-and-production


### PR DESCRIPTION
- As we are migrating to AWS, we need alerting to be configured from AWS
  production machines

- The added parameters are needed by the pagerduty_contacts class, but
  are named only "contacts" so I missed their relevance the first time
  around.

solo: @schmie