### PR TITLE
Give "GOV.UK DNS Administrators" admin access to Jenkins

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1025,6 +1025,9 @@ govuk_jenkins::config::user_permissions:
     user: 'alphagov*GOV.UK Production'
     permissions: *jenkins_admin_permission_list
   -
+    user: 'alphagov*GOV.UK DNS Administrators'
+    permissions: *jenkins_admin_permission_list
+  -
     user: 'anonymous'
     permissions:
       - 'hudson.model.Hudson.Read'


### PR DESCRIPTION
This allows people in this new team (https://github.com/orgs/alphagov/teams/gov-uk-dns-administrators) to
access our Jenkins instances. This is needed because people in the "RE Autom8" team need to be able to deploy DNS, because:

> One of the team's responsibilities is Verify ops cover. This involves
modifying signin.service.gov.uk.

In an ideal world this team would have only access to the `Deploy_DNS` job, but that would require us to re-model the permissions in Jenkins (from what I gather, we need to use "project-based matrix authorization" instead of our current matrix authorization").