### PR TITLE
BAU: disable nscd for bouncer

### DIFF
--- a/hieradata_aws/class/production/bouncer.yaml
+++ b/hieradata_aws/class/production/bouncer.yaml
@@ -1,5 +1,4 @@
 ---
-nscd::config::dns_cache: 'yes'
 
 govuk_bouncer::gor::enabled: true
 govuk_bouncer::gor::target: bouncer.blue.staging.govuk.digital

--- a/hieradata_aws/class/staging/bouncer.yaml
+++ b/hieradata_aws/class/staging/bouncer.yaml
@@ -1,3 +1,0 @@
----
-
-nscd::config::dns_cache: 'yes'

--- a/modules/govuk/manifests/node/s_bouncer.pp
+++ b/modules/govuk/manifests/node/s_bouncer.pp
@@ -17,7 +17,6 @@ class govuk::node::s_bouncer (
   include govuk_bouncer::gor
   include govuk::node::s_app_server
   include nginx
-  include nscd
 
   @@icinga::check::graphite { "check_nginx_connections_writing_${::hostname}":
     target    => "${::fqdn_metrics}.nginx.nginx_connections-writing",


### PR DESCRIPTION
# Context

Last week, it was decided that we would enable DNS caching on bouncer in
AWS production and AWS staging. It was envisaged that this would reduce
the DNS resolution requests during Gor traffic replay.

But it turns out that Bouncer is not doing DNS lookups on the URL names,
it simply looks them up in the Transition DB and then sends back either:
(i) 301 redirect without carrying out a DNS lookup on the new URL or
(ii) 410 meaning the URL resource has been permanently removed.

# Decisions

Since NSCD is not used for DNS caching on Bouncer,  it will be removed from AWS
staging and AWS production:
(i) by removing its references from the puppet code
(ii) manually clean up the individual Bouncer machines to disable and uninstall the service.
and remove any leftover files. 

Solo: @ronocg @FredericFran-GDS