### PR TITLE
Activate environment sync intra AWS for transition

### DIFF
--- a/hieradata_aws/class/production/transition_db_admin.yaml
+++ b/hieradata_aws/class/production/transition_db_admin.yaml
@@ -1,8 +1,8 @@
 govuk_env_sync::tasks:
   "pull_transition_production_daily":
     ensure: "present"
-    hour: "4"
-    minute: "30"
+    hour: "3"
+    minute: "0"
     action: "pull"
     dbms: "postgresql"
     storagebackend: "s3"


### PR DESCRIPTION
- We migrated bouncer/transition and this is the new main backup
mechanism

solo: @schmie