### PR TITLE
Add nginx repo mirror

### DIFF
--- a/modules/govuk/manifests/node/s_apt.pp
+++ b/modules/govuk/manifests/node/s_apt.pp
@@ -86,6 +86,10 @@ class govuk::node::s_apt (
       location => 'https://repo.mongodb.org/apt/ubuntu',
       release  => 'trusty/mongodb-org/3.2',
       key      => 'EA312927';
+    'nginx':
+      location => 'https://nginx.org/packages/ubuntu/',
+      release  => 'trusty',
+      key      => 'ABF5BD827BD9BF62';
     'nodejs':
       location => 'https://deb.nodesource.com/node_6.x',
       release  => 'trusty',


### PR DESCRIPTION
This commit adds a mirrored repo for nginx. This allows us to upgrade our nginx version independently of Ubuntu.

Trello: https://trello.com/c/qHMl0NwV/599-upgrade-nginx