### PR TITLE
Use copytruncate to rotate CDN logs

### DIFF
--- a/modules/govuk_cdnlogs/templates/etc/logrotate.cdn_logs_hourly.conf.erb
+++ b/modules/govuk_cdnlogs/templates/etc/logrotate.cdn_logs_hourly.conf.erb
@@ -13,10 +13,7 @@ to_rotate_hourly.map { |name| "#{ @log_dir }/cdn-#{ name }.log" }.join("\n")
   dateformat -%Y%m%d-%s
   compress
   size 1
+  copytruncate
   missingok
-  postrotate
-    invoke-rc.d rsyslog reload >/dev/null 2>&1 || true
-    sleep 10
-  endscript
 }
 <% end %>


### PR DESCRIPTION
cf9fd75 moved CDN logs from the `logs-cdn` machine class to
`monitoring`, and also changed the frequency of log rotation from
daily to hourly.

On staging, traffic on the govuk CDN is so slow that frequently an
hour passes with no traffic.  In consequence, the logs are frequently
rotated between checks.  This causes a critical alert as the expected
log file does not exist.

The `copytruncate` option in logrotate causes it to leave the original
file in place, but truncate it.  This solves the alert problem.  As
it's the original file, we don't need to reload rsyslog, as its
current file handles will still be valid.

---

This is an alternative to #8273

[Trello card](https://trello.com/c/D8dyNE9y/524-transition-athena-logs-stretch-goal-remove-logs-cdn-1)