### PR TITLE
Remove transition from the backend loadbalancers

### DIFF
--- a/modules/govuk/manifests/node/s_backend_lb.pp
+++ b/modules/govuk/manifests/node/s_backend_lb.pp
@@ -68,7 +68,6 @@ class govuk::node::s_backend_lb (
     'short-url-manager',
     'support',
     'travel-advice-publisher',
-    'transition',
     ]:
       servers => $backend_servers,
   }


### PR DESCRIPTION
  Transition has been migrated to AWS and is no longer in use
on Carrenza