### PR TITLE
Set environment backup for transition db in AWS

### DIFF
--- a/hieradata_aws/class/production/transition_db_admin.yaml
+++ b/hieradata_aws/class/production/transition_db_admin.yaml
@@ -1,9 +1,9 @@
 govuk_env_sync::tasks:
-  "pull_transition_production_daily":
+  "push_transition_production_daily":
     ensure: "present"
     hour: "3"
     minute: "0"
-    action: "pull"
+    action: "push"
     dbms: "postgresql"
     storagebackend: "s3"
     database: "transition_production"


### PR DESCRIPTION
- This was accidentally configure to restore.

- The action was prevented by our access rules

solo: @schmie