### PR TITLE
Remove Mapit from the hosts file

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1280,7 +1280,6 @@ hosts::production::api::app_hostnames:
   - 'backdrop-read'
   - 'backdrop-write'
   - 'content-store'
-  - 'mapit'
   - 'rummager'
   - 'search'
 


### PR DESCRIPTION
Remove Mapit from the host's file within Carranza. This is to aid in the migration.
