### PR TITLE
Removing the staging over-ride

### DIFF
--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -245,13 +245,6 @@ hosts::production::api::hosts:
   search-3:
     ip: '10.2.4.6'
 
-hosts::production::api::app_hostnames:
-  - 'backdrop-read'
-  - 'backdrop-write'
-  - 'content-store'
-  - 'rummager'
-  - 'search'
-
 hosts::production::backend::hosts:
   asset-master-1:
     ip: '10.2.3.20'


### PR DESCRIPTION
While migrating mapit we wanted staging to not have an entry in `/etc/hosts`.
These are seeded through the app_hostnames var. Now that mapit has migrated we
no longer need a specific config for staging and can rely on the common.yaml.

solo: @jstandring-gds