### PR TITLE
Upgrade nginx

### DIFF
--- a/hieradata/class/api_lb.yaml
+++ b/hieradata/class/api_lb.yaml
@@ -1,3 +1,0 @@
----
-
-nginx::package::nginx_package: 'nginx-extras'

--- a/hieradata/class/backend_lb.yaml
+++ b/hieradata/class/backend_lb.yaml
@@ -5,4 +5,3 @@ govuk_safe_to_reboot::reason: >
   Traffic is balanced between backend-lb-1 and backend-lb-2.
 
 nginx::logging::days_to_keep: '45'
-nginx::package::nginx_package: 'nginx-extras'

--- a/hieradata/class/cache.yaml
+++ b/hieradata/class/cache.yaml
@@ -11,6 +11,4 @@ govuk::apps::authenticating_proxy::mongodb_nodes:
   - 'router-backend-2.router'
   - 'router-backend-3.router'
 
-nginx::package::nginx_package: 'nginx-extras'
-
 varnish::environment_ip_prefix: "%{hiera('environment_ip_prefix')}"

--- a/hieradata/class/draft_cache.yaml
+++ b/hieradata/class/draft_cache.yaml
@@ -21,7 +21,5 @@ govuk::apps::router_api::router_nodes:
   - 'draft-cache-2.router:3055'
 govuk::apps::router_api::vhost: 'draft-router-api'
 
-nginx::package::nginx_package: 'nginx-extras'
-
 router::nginx::check_requests_warning: '@0'
 router::nginx::check_requests_critical: '@0'

--- a/hieradata/class/frontend_lb.yaml
+++ b/hieradata/class/frontend_lb.yaml
@@ -1,2 +1,0 @@
----
-nginx::package::nginx_package: 'nginx-extras'

--- a/hieradata/class/licensify_lb.yaml
+++ b/hieradata/class/licensify_lb.yaml
@@ -8,5 +8,3 @@ hosts::production::licensify::app_hostnames:
   - 'uploadlicence'
   - 'licensify-admin'
   - 'licensing-web-forms'
-
-nginx::package::nginx_package: 'nginx-extras'

--- a/hieradata/common.precise.yaml
+++ b/hieradata/common.precise.yaml
@@ -5,7 +5,7 @@ collectd::package::yajl_package: 'libyajl1'
 
 duplicity::packages::version: '0.6.18-0ubuntu3.5'
 
-nginx::package::version: '1.4.4-1~precise0'
+nginx::package::nginx_version: "1.12.0-1~precise"
 
 nodejs::version: '0.10.37-1chl1~precise1'
 

--- a/hieradata/common.xenial.yaml
+++ b/hieradata/common.xenial.yaml
@@ -8,8 +8,6 @@ govuk_unattended_reboot::manage_repo_class: true
 
 icinga::client::host_ipaddress: "%{::ipaddress}"
 
-nginx::package::version: 'present'
-
 nodejs::version: '4.2.6~dfsg-1ubuntu4.1'
 
 puppet::package::facter_version: '2.4.6-1'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1723,7 +1723,8 @@ monitoring::vpn_gateways::endpoints:
 # FIXME: this has been added to avoid a bug until we move to v3 of the module
 mysql::client::package_ensure: 'present'
 
-nginx::package::version: '1.4.6-1ubuntu3.8'
+nginx::package::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+nginx::package::nginx_version: "1.14.0-1~trusty"
 
 nodejs::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 nodejs::version: '6.14.3-1nodesource1'

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1199,8 +1199,8 @@ monitoring::uptime_collector::aws: true
 # FIXME: this has been added to avoid a bug until we move to v3 of the module
 mysql::client::package_ensure: 'present'
 
-nginx::package::nginx_package: 'nginx-extras'
-nginx::package::version: '1.4.6-1ubuntu3.8'
+nginx::package::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+nginx::package::nginx_version: "1.14.0-1~trusty"
 
 nodejs::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 nodejs::version: '6.14.3-1nodesource1'

--- a/modules/nginx/manifests/package.pp
+++ b/modules/nginx/manifests/package.pp
@@ -4,34 +4,37 @@
 #
 # === Parameters
 #
-# [*nginx_package*]
-#   Which nginx package variant to install. Ubuntu provides 7 variants of nginx
-#   with different sets of compile options. Default: 'nginx-full'
+#  [*apt_mirror_hostname*]
+#    The hostname of the local aptly mirror.
 #
-# [*version*]
+# [*nginx_version*]
+#   Which version of the nginx package to install. Default: 'present'
 #
-#   Which version of the nginx packages to install. Default: 'present'
+# [*nginx_module_perl_version*]
+#   Which version of the nginx perl module package to install. Default: 'present'
 #
 class nginx::package(
-  $nginx_package = 'nginx-full',
-  $version       = 'present',
+  $apt_mirror_hostname,
+  $nginx_version             = 'present',
+  $nginx_module_perl_version = 'present',
 ) {
 
-  include govuk_ppa
-
-  # nginx package actually has nothing useful in it; we normally need nginx-full
-  package { 'nginx':
-    ensure => purged,
+  apt::source { 'nginx':
+    location     => "http://${apt_mirror_hostname}/nginx",
+    release      => $::lsbdistcodename,
+    architecture => $::architecture,
+    repos        => 'nginx',
+    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
   }
 
-  package { 'nginx-common':
-    ensure => $version,
+  package { 'nginx':
+    ensure => $nginx_version,
     notify => Class['nginx::restart'],
   }
 
-  package { $nginx_package:
-    ensure  => $version,
+  package { 'nginx-module-perl':
+    ensure  => $nginx_module_perl_version,
     notify  => Class['nginx::restart'],
-    require => Package['nginx-common'],
+    require => Package['nginx'],
   }
 }

--- a/modules/nginx/spec/classes/nginx__package_spec.rb
+++ b/modules/nginx/spec/classes/nginx__package_spec.rb
@@ -3,46 +3,27 @@ require_relative '../../../../spec_helper'
 describe 'nginx::package', :type => :class do
   context 'defaults' do
     it do
-      is_expected.to contain_package('nginx-full').with(
+      is_expected.to contain_package('nginx-module-perl').with(
         'ensure'  => 'present',
         'notify'  => 'Class[Nginx::Restart]',
-        'require' => 'Package[nginx-common]',
+        'require' => 'Package[nginx]',
       )
-      is_expected.to contain_package('nginx-common').with(
-        'ensure'  => 'present',
+      is_expected.to contain_package('nginx').with(
+        'ensure'  => '1.14.0-1~trusty',
         'notify'  => 'Class[Nginx::Restart]',
       )
-      is_expected.to contain_package('nginx').with_ensure('purged')
-      is_expected.to contain_class('govuk_ppa')
     end
   end
-  context 'version set' do
-    let (:params) { {:version => '1.4.4-precise1'} }
-    it do
-      is_expected.to contain_package('nginx-full').with_ensure('1.4.4-precise1')
-      is_expected.to contain_package('nginx-common').with_ensure('1.4.4-precise1')
-      is_expected.to contain_package('nginx').with_ensure('purged')
-    end
-  end
-  context 'nginx_package set' do
-    let (:params) { {:nginx_package => 'nginx-extras'} }
-    it do
-      is_expected.to contain_package('nginx-extras').with_ensure('present')
-      is_expected.to contain_package('nginx-common').with_ensure('present')
-      is_expected.to contain_package('nginx').with_ensure('purged')
-    end
-  end
-  context 'nginx_package and version set' do
+  context 'nginx_version and nginx_module_perl_version set' do
     let (:params) {
       {
-        :nginx_package => 'nginx-light',
-        :version       => '1.7-trusty1',
+        :nginx_version => '1.12.0-1~trusty',
+        :nginx_module_perl_version => '1.10.0-1~trusty'
       }
     }
     it do
-      is_expected.to contain_package('nginx-light').with_ensure('1.7-trusty1')
-      is_expected.to contain_package('nginx-common').with_ensure('1.7-trusty1')
-      is_expected.to contain_package('nginx').with_ensure('purged')
+      is_expected.to contain_package('nginx').with_ensure('1.12.0-1~trusty')
+      is_expected.to contain_package('nginx-module-perl').with_ensure('1.10.0-1~trusty')
     end
   end
 end

--- a/modules/nginx/spec/classes/nginx_spec.rb
+++ b/modules/nginx/spec/classes/nginx_spec.rb
@@ -2,7 +2,7 @@ require_relative '../../../../spec_helper'
 
 describe 'nginx', :type => :class do
   it do
-    is_expected.to contain_package('nginx').with_ensure('purged')
-    is_expected.to contain_package('nginx-full').with_ensure('present')
+    is_expected.to contain_package('nginx').with_ensure('1.14.0-1~trusty')
+    is_expected.to contain_package('nginx-module-perl').with_ensure('present')
   end
 end

--- a/modules/nginx/templates/etc/nginx/nginx.conf.erb
+++ b/modules/nginx/templates/etc/nginx/nginx.conf.erb
@@ -2,6 +2,8 @@ user www-data;
 worker_processes  4;
 worker_rlimit_nofile 4096;
 
+load_module /usr/lib/nginx/modules/ngx_http_perl_module.so;
+
 error_log  /var/log/nginx/error.log;
 pid        /run/nginx.pid;
 

--- a/modules/router/spec/classes/router__nginx_spec.rb
+++ b/modules/router/spec/classes/router__nginx_spec.rb
@@ -83,7 +83,7 @@ describe 'router::nginx', :type => :class do
         :vhost_protected => false,
       }}
 
-      it { is_expected.to contain_file(router_config).with_content(/^more_set_headers -s 404 "Cache-Control: public, max-age=30";/) }
+      it { is_expected.to contain_file(router_config).with_content(/add_header Cache-Control "public, max-age=30" always;/) }
     end
 
     context 'a different number' do
@@ -92,7 +92,7 @@ describe 'router::nginx', :type => :class do
         :vhost_protected => false,
       }}
 
-      it { is_expected.to contain_file(router_config).with_content(/^more_set_headers -s 404 "Cache-Control: public, max-age=668";/) }
+      it { is_expected.to contain_file(router_config).with_content(/add_header Cache-Control "public, max-age=668" always;/) }
     end
   end
 end

--- a/modules/router/templates/router_include.conf.erb
+++ b/modules/router/templates/router_include.conf.erb
@@ -97,10 +97,6 @@ error_page 504 /504.html;
 # compat because these previously emitted 503.
 error_page 429 /503.html;
 
-# Set Cache-Control headers on 404 pages since we overide those set by apps.
-# So that we dont fall through to the default provided by the CDN.
-more_set_headers -s 404 "Cache-Control: public, max-age=<%= @page_ttl_404 -%>";
-
 # Set the Content-Type to UTF-8 on the static pages, since they contain UTF-8
 # characters like the copyright symbol
 charset utf-8;
@@ -110,6 +106,9 @@ location /400.html {
   internal;
 }
 location /404.html {
+  # Set Cache-Control headers on 404 pages since we overide those set by apps.
+  # So that we dont fall through to the default provided by the CDN.
+  add_header Cache-Control "public, max-age=<%= @page_ttl_404 -%>" always;
   root /usr/share/nginx/www;
   internal;
 }

--- a/spec/fixtures/hieradata/common.yaml
+++ b/spec/fixtures/hieradata/common.yaml
@@ -109,6 +109,9 @@ mongodb::s3backup::backup::private_gpg_key_fingerprint: 'CB77872D51ADD27CF75BD63
 # FIXME: this has been added to avoid a bug until we move to v3 of the module
 mysql::client::package_ensure: 'present'
 
+nginx::package::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+nginx::package::nginx_version: "1.14.0-1~trusty"
+
 nodejs::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 puppet::repository::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"


### PR DESCRIPTION
This PR upgrades nginx to the latest available version on each platform by using a mirrored version of the master nginx repo rather than the Ubuntu one.

See each commit for more details.

Trello: https://trello.com/c/qHMl0NwV/599-upgrade-nginx