### PR TITLE
Add pagerduty watch to bouncer instances in AWS

### DIFF
--- a/hieradata_aws/class/production/bouncer.yaml
+++ b/hieradata_aws/class/production/bouncer.yaml
@@ -2,3 +2,5 @@
 
 govuk_bouncer::gor::enabled: true
 govuk_bouncer::gor::target: bouncer.blue.staging.govuk.digital
+
+icinga::client::contact_groups: 'urgent-priority'


### PR DESCRIPTION
- The original checks of transition PG are redundant, because this now
lives in RDS

solo: @schmie