### PR TITLE
change the app_domain_external also for imminence in AWS staging

### DIFF
--- a/modules/govuk/manifests/apps/imminence.pp
+++ b/modules/govuk/manifests/apps/imminence.pp
@@ -112,6 +112,9 @@ class govuk::apps::imminence(
       "${title}-GOVUK_APP_DOMAIN":
       varname => 'GOVUK_APP_DOMAIN',
       value   => $app_domain;
+      "${title}-GOVUK_APP_DOMAIN_EXTERNAL":
+      varname => 'GOVUK_APP_DOMAIN_EXTERNAL',
+      value   => $app_domain;
     }
   }
 


### PR DESCRIPTION
# CONTEXT

In the govuk migration, there is a need to set the `GOVUK_APP_DOMAIN_EXTERNAL` variable only for the imminence app on the backend machines in AWS staging, not the other APPs. 

# DECISIONS

1. modify the imminence app for if `$app_domain` is defined, then then the `GOVUK_APP_DOMAIN_EXTERNAL` is set to the `$app_domain`