### PR TITLE
Make draft-publicapi an alias for draft-cache-internal-lb

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1517,7 +1517,6 @@ hosts::production::frontend::app_hostnames:
   - 'draft-frontend'
   - 'draft-government-frontend'
   - 'draft-manuals-frontend'
-  - 'draft-publicapi'
   - 'draft-service-manual-frontend'
   - 'draft-smartanswers'
   - 'draft-static'
@@ -1647,6 +1646,7 @@ hosts::production::router::hosts:
     ip: '10.1.1.252'
     legacy_aliases:
       - "draft-router-api.%{hiera('app_domain')}"
+      - "draft-publicapi.%{hiera('app_domain')}"
 
 icinga::config::http_username: "%{hiera('http_username')}"
 icinga::config::http_password: "%{hiera('http_password')}"


### PR DESCRIPTION
draft-publicapi runs on the draft-cache machines, not the frontend-lb
machines.

---

[Trello card](https://trello.com/c/JDiLJ8h1/570-enable-viewing-content-store-on-draft-stack)