### PR TITLE
Removing imminence app from Staging Carrenza

### DIFF
--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -398,7 +398,6 @@ hosts::production::backend::app_hostnames:
   - 'email-alert-api-public'
   - 'event-store'
   - 'hmrc-manuals-api'
-  - 'imminence'
   - 'kibana'
   - 'link-checker-api'
   - 'local-links-manager'


### PR DESCRIPTION
As prep for the migration of this app we need this PR to update the
`/etc/hosts` and remove the entry for the app.

solo: @jstandring-gds