### PR TITLE
Add nginx repo for Ubuntu Precise

### DIFF
--- a/modules/nginx/manifests/package.pp
+++ b/modules/nginx/manifests/package.pp
@@ -27,6 +27,16 @@ class nginx::package(
     key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
   }
 
+  if $::lsbdistcodename == 'precise' {
+    apt::source { 'nginx-precise':
+      location     => "http://${apt_mirror_hostname}/nginx-precise",
+      release      => $::lsbdistcodename,
+      architecture => $::architecture,
+      repos        => 'nginx',
+      key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+    }
+  }
+
   package { 'nginx':
     ensure => $nginx_version,
     notify => Class['nginx::restart'],


### PR DESCRIPTION
This commit adds the nginx repository for Ubuntu Precise to those machines so they can retrieve the latest version.

Trello: https://trello.com/c/qHMl0NwV/599-upgrade-nginx