### PR TITLE
Make draft-publicapi an alias in the production and staging hiera

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -581,6 +581,7 @@ hosts::production::router::hosts:
     ip: '10.3.1.252'
     legacy_aliases:
       - "draft-router-api.%{hiera('app_domain')}"
+      - "draft-publicapi.%{hiera('app_domain')}"
 
 licensify::apps::licensify_admin::environment: 'production'
 licensify::apps::licensify::environment: 'production'

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -543,6 +543,7 @@ hosts::production::router::hosts:
     ip: '10.2.1.252'
     legacy_aliases:
       - "draft-router-api.%{hiera('app_domain')}"
+      - "draft-publicapi.%{hiera('app_domain')}"
 
 licensify::apps::licensify_admin::environment: 'staging'
 licensify::apps::licensify::environment: 'staging'


### PR DESCRIPTION
They both override the common, so #8285 did nothing except remove the alias from the frontend-lb.

---

[Trello card](https://trello.com/c/JDiLJ8h1/570-enable-viewing-content-store-on-draft-stack)