### PR TITLE
pip depends in monitoring

### DIFF
--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_cache_cpu
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_cache_cpu
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/opt/python2.7/bin/python
 
 ##########################################################
 # This script will cpture and report on AWS ElastiCache #
@@ -183,6 +183,9 @@ data = cw_conn.get_metric_statistics(
 # pprint.pprint(dir(data))                                                      #
 #################################################################################
 
+if data == []:
+  print "WARNING: The instance specified {} was not found!".format(args.instanceid)
+  sys.exit()
 #########################################################################################################
 # Dissect the result                                                                                     #
 # -----------------                                                                                     #

--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_cache_memory
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_cache_memory
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/opt/python2.7/bin/python
 
 ##########################################################
 # This script will cpture and report on AWS ElastiCache #

--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_quota
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_quota
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/opt/python2.7/bin/python
 
 import argparse
 import boto.ses

--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_rds_cpu
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_rds_cpu
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/opt/python2.7/bin/python
 
 ##################################################
 # This script will capture and report on AWS RDS #
@@ -164,6 +164,11 @@ data = cw_conn.get_metric_statistics(
 #   methods and attributes.							#
 # pprint.pprint(dir(data))							#
 #################################################################################
+
+
+if data == []:
+  print "WARNING: The instance specified {} was not found!".format(args.instanceid)
+  sys.exit()
 
 #########################################
 # Dissect the result			#

--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_rds_memory
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_rds_memory
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/opt/python2.7/bin/python
 
 ##################################################
 # This script will capture and report on AWS RDS #
@@ -185,6 +185,11 @@ data = cw_conn.get_metric_statistics(
    'Average',
    {'DBInstanceIdentifier': [args.instanceid]},
 )
+
+
+if data == []:
+  print "WARNING: The instance specified {} was not found!".format(args.instanceid)
+  sys.exit()
 
 ##################################################################################################
 # Metrics											 #

--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_rds_storage
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_rds_storage
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/opt/python2.7/bin/python
 
 ##################################################
 # This script will capture and report on AWS RDS #
@@ -177,6 +177,10 @@ data = cw_conn.get_metric_statistics(
 #   methods and attributes.							#
 # pprint.pprint(dir(data))							#
 #################################################################################
+
+if data == []:
+  print "WARNING: The instance specified {} was not found!".format(args.instanceid)
+  sys.exit()
 
 #########################################
 # Dissect the result			#

--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_hsts_headers
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_hsts_headers
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/opt/python2.7/bin/python
 
 import argparse
 import sys

--- a/modules/monitoring/manifests/checks.pp
+++ b/modules/monitoring/manifests/checks.pp
@@ -14,6 +14,17 @@ class monitoring::checks (
   $http_username = 'UNSET',
   $http_password = 'UNSET',
 ) {
+
+    exec { 'install_boto':
+          path    => ['/opt/python2.7/bin', '/usr/bin', '/usr/sbin'],
+          command => ['/opt/python2.7/bin/pip install boto'],
+    }
+
+    exec { 'install_boto3':
+          path    => ['/opt/python2.7/bin', '/usr/bin', '/usr/sbin'],
+          command => ['/opt/python2.7/bin/pip install boto3'],
+    }
+
   include monitoring::checks::mirror
   include monitoring::checks::pingdom
   include monitoring::checks::ses

--- a/modules/monitoring/manifests/checks/cache.pp
+++ b/modules/monitoring/manifests/checks/cache.pp
@@ -21,7 +21,7 @@ class monitoring::checks::cache (
 
     icinga::plugin { 'check_aws_cache_cpu':
         source  => 'puppet:///modules/monitoring/usr/lib/nagios/plugins/check_aws_cache_cpu',
-        require => Package['boto'],
+        require => Exec['install_boto'],
     }
 
     icinga::check_config { 'check_aws_cache_cpu':
@@ -31,7 +31,7 @@ class monitoring::checks::cache (
 
     icinga::plugin { 'check_aws_cache_memory':
         source  => 'puppet:///modules/monitoring/usr/lib/nagios/plugins/check_aws_cache_memory',
-        require => Package['boto'],
+        require => Exec['install_boto'],
     }
 
     icinga::check_config { 'check_aws_cache_memory':

--- a/modules/monitoring/manifests/checks/rds.pp
+++ b/modules/monitoring/manifests/checks/rds.pp
@@ -21,7 +21,7 @@ class monitoring::checks::rds (
 
     icinga::plugin { 'check_aws_rds_cpu':
         source  => 'puppet:///modules/monitoring/usr/lib/nagios/plugins/check_aws_rds_cpu',
-        require => Package['boto'],
+        require => Exec['install_boto'],
     }
 
     icinga::check_config { 'check_aws_rds_cpu':
@@ -31,7 +31,7 @@ class monitoring::checks::rds (
 
     icinga::plugin { 'check_aws_rds_memory':
         source  => 'puppet:///modules/monitoring/usr/lib/nagios/plugins/check_aws_rds_memory',
-        require => Package['boto'],
+        require => Exec['install_boto'],
     }
 
     icinga::check_config { 'check_aws_rds_memory':
@@ -41,7 +41,7 @@ class monitoring::checks::rds (
 
     icinga::plugin { 'check_aws_rds_storage':
         source  => 'puppet:///modules/monitoring/usr/lib/nagios/plugins/check_aws_rds_storage',
-        require => Package['boto'],
+        require => Exec['install_boto'],
     }
 
     icinga::check_config { 'check_aws_rds_storage':

--- a/modules/monitoring/manifests/checks/ses.pp
+++ b/modules/monitoring/manifests/checks/ses.pp
@@ -31,14 +31,14 @@ class monitoring::checks::ses (
         $critical = 50,
     ) {
 
-    package {'boto':
-        ensure   => '2.24.0',
-        provider => pip,
-    }
+    #package {'boto':
+    #    ensure   => '2.24.0',
+    #    provider => pip,
+    #}
 
     icinga::plugin { 'check_aws_quota':
         source  => 'puppet:///modules/monitoring/usr/lib/nagios/plugins/check_aws_quota',
-        require => Package['boto'],
+        require => Exec['install_boto'],
     }
 
     icinga::check_config { 'check_aws_quota':

--- a/modules/monitoring/manifests/init.pp
+++ b/modules/monitoring/manifests/init.pp
@@ -24,6 +24,7 @@ class monitoring (
 
   unless $ci_environment {
     # Monitoring server only.
+    include ::govuk_jenkins::packages::govuk_python
     include monitoring::checks
     include monitoring::edge
     include monitoring::pagerduty_drill


### PR DESCRIPTION
This commit adds pip dependencies monitoring instances. This is to prevent errors in Nagios checks. 