### PR TITLE
Make default data sync ensure present

### DIFF
--- a/modules/govuk_env_sync/manifests/task.pp
+++ b/modules/govuk_env_sync/manifests/task.pp
@@ -45,14 +45,14 @@ define govuk_env_sync::task(
   $database,
   $url,
   $path,
-  $ensure = 'absent',
+  $ensure = 'present',
 ) {
 
   require govuk_env_sync::aws_auth
   require govuk_env_sync::sync_script
 
   file { "${govuk_env_sync::conf_dir}/${title}.cfg":
-    ensure  => $ensure,
+    ensure  => 'present',
     mode    => '0755',
     owner   => $govuk_env_sync::user,
     group   => $govuk_env_sync::user,


### PR DESCRIPTION
- We had set this to absent in order to make sure all misconfigured jobs
vanish

- As a day to day default, ensuring existence of a configured job is moe
intuitive

- We also want to keep configuration files after removing cron jobs for manual testing

solo: @schmie