### PR TITLE
Add extra disk to apt machine

### DIFF
--- a/hieradata/class/apt.yaml
+++ b/hieradata/class/apt.yaml
@@ -4,7 +4,9 @@ govuk::node::s_apt::root_dir: '/mnt/apt'
 
 lv:
   data:
-    pv: '/dev/sdb1'
+    pv:
+      - '/dev/sdb1'
+      - '/dev/sdc1'
     vg: 'apt'
 
 mount:


### PR DESCRIPTION
The mounted disk for apt package caching and mirroring is running out of space.