### PR TITLE
Add data sync jobs for migration of imminence

### DIFF
--- a/hieradata/node/mongo-4.backend.publishing.service.gov.uk.yaml
+++ b/hieradata/node/mongo-4.backend.publishing.service.gov.uk.yaml
@@ -1,1 +1,14 @@
 icinga::client::check_cputype::cputype: 'amd'
+
+govuk_env_sync::tasks:
+  "push_imminence_production":
+    ensure: "absent"
+    hour: "3"
+    minute: "0"
+    action: "push"
+    dbms: "mongo"
+    storagebackend: "s3"
+    database: "imminence_production"
+    temppath: "/var/lib/mongodb/.dumps"
+    url: "govuk-production-database-backups"
+    path: "mongo-normal"

--- a/hieradata_aws/class/production/mongo.yaml
+++ b/hieradata_aws/class/production/mongo.yaml
@@ -1,0 +1,23 @@
+govuk_env_sync::tasks:
+  "push_imminence_production":
+    ensure: "present"
+    hour: "3"
+    minute: "0"
+    action: "push"
+    dbms: "mongo"
+    storagebackend: "s3"
+    database: "imminence_production"
+    temppath: "/var/lib/mongodb/.dumps"
+    url: "govuk-production-database-backups"
+    path: "mongo-normal"
+  "pull_imminence_production":
+    ensure: "absent"
+    hour: "3"
+    minute: "0"
+    action: "pull"
+    dbms: "mongo"
+    storagebackend: "s3"
+    database: "imminence_production"
+    temppath: "/var/lib/mongodb/.dumps"
+    url: "govuk-production-database-backups"
+    path: "mongo-normal"


### PR DESCRIPTION
- This is a template for future changes as well

- Setting push/pull in the "wrong" direction to absent will create the
required configuration, but no cron jobs

- These can then be triggered manually (and removed post-migration)

solo: @schmie