### PR TITLE
Enable HTTP/2 and server push

### DIFF
--- a/modules/router/templates/base.conf.erb
+++ b/modules/router/templates/base.conf.erb
@@ -21,12 +21,12 @@ server {
 server {
   server_name         www.gov.uk;
   <%- unless scope.lookupvar('::aws_migration') %>
-  listen              443 ssl;
+  listen              443 ssl http2;
   ssl_certificate     /etc/nginx/ssl/www.gov.uk.crt;
   ssl_certificate_key /etc/nginx/ssl/www.gov.uk.key;
   include             /etc/nginx/ssl.conf;
   <%- else %>
-  listen 80;
+  listen 80 http2;
   # Send the Strict-Transport-Security header
   include             /etc/nginx/add-sts.conf;
   <%- end %>
@@ -37,12 +37,12 @@ server {
 server {
   <%- if scope.lookupvar('::aws_migration') %>
   server_name         www.* www-origin.* draft-origin.*;
-  listen 80;
+  listen 80 http2;
   # Send the Strict-Transport-Security header
   include             /etc/nginx/add-sts.conf;
   <%- else %>
   server_name         www.<%= @app_domain %> www-origin.<%= @app_domain %> draft-origin.<%= @app_domain %>;
-  listen              443 ssl;
+  listen              443 ssl http2;
   ssl_certificate     /etc/nginx/ssl/www.<%= @app_domain %>.crt;
   ssl_certificate_key /etc/nginx/ssl/www.<%= @app_domain %>.key;
   include             /etc/nginx/ssl.conf;

--- a/modules/router/templates/router_include.conf.erb
+++ b/modules/router/templates/router_include.conf.erb
@@ -63,7 +63,11 @@ location ~ ^/contact/govuk/(|service-feedback|problem_reports|foi|page_improveme
 location / {
   <%= scope.function_template(['router/fragments/_basic_auth.erb']) -%>
 
+  # Enable asset domain preconnect for HTTP/2-capable clients
   add_header Link "<https://assets.<%= @app_domain %>>; rel=preconnect; crossorigin";
+
+  # Enable server push for HTTP/2-capable clients
+  http2_push_preload on;
 
   # HTML verification for DWP YouTube channel
   location = /dla-ending/google6db9c061ce178960.html {


### PR DESCRIPTION
This commit enables HTTP/2 and server push for www.gov.uk.

This will allow server push link headers set by apps to be picked up by nginx and the relevant files proactively pushed to clients. These will in turn be cached by Fastly.

In AWS, since we terminate HTTPS at the load balancers, we enable H2C (HTTP/2 cleartext) in nginx so it can continue to pick up the server push headers. Clients will still connect using HTTPS to the load balancers.

Trello: https://trello.com/c/0Ek526Jn/602-enable-http-2-and-server-push