### PR TITLE
remove imminence from Carrenza Production as migrating it to AWS

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -298,7 +298,6 @@ hosts::production::backend::app_hostnames:
   - 'email-alert-api-public'
   - 'event-store'
   - 'hmrc-manuals-api'
-  - 'imminence'
   - 'kibana'
   - 'link-checker-api'
   - 'local-links-manager'


### PR DESCRIPTION
# Context
As part of the AWS migration, we need to remove `imminence` from the list of `/etc/hosts` in Carrenza so that other apps use DNS to resolve to the AWS production imminence

# Decisions
1. we remove `imminence` from the list of apps
2. we keep the distinct `hosts::production::backend::app_hostnames:` list in each Carrenza env because we will use the list for other apps migration