### PR TITLE
Do not email people on smokey failure

### DIFF
--- a/hieradata/class/jenkins.yaml
+++ b/hieradata/class/jenkins.yaml
@@ -82,8 +82,6 @@ govuk_jenkins::plugins:
     version: '1.9'
   durable-task:
     version: '1.22'
-  email-ext:
-    version: '2.62'
   envinject-api:
     version: '1.5'
   envinject:

--- a/hieradata_aws/class/jenkins.yaml
+++ b/hieradata_aws/class/jenkins.yaml
@@ -97,8 +97,6 @@ govuk_jenkins::plugins:
     version: '1.9'
   durable-task:
     version: '1.22'
-  email-ext:
-    version: '2.62'
   envinject-api:
     version: '1.5'
   envinject:

--- a/modules/govuk_jenkins/templates/jobs/smokey.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/smokey.yaml.erb
@@ -36,34 +36,6 @@
           include-custom-message: true
           custom-message: ':govuk-<%= @environment %>:'
       <% end %>
-      - email-ext:
-          recipients: govuk-ci-notifications@digital.cabinet-office.gov.uk
-          attach-build-log: true
-          failure: true
-          fixed: true
-          presend-script: |
-            import hudson.tasks.Mailer
-
-            def upstreamCause = build.getCause(Cause.UpstreamCause)
-
-            if (upstreamCause != null) {
-              def upstreamCauses = upstreamCause.getUpstreamCauses()
-              upstreamCauses.each() { cause ->
-                if (cause instanceof Cause.UserIdCause) {
-                  def user = User.get(cause.getUserId())
-                  def userEmail = user.getProperty(Mailer.UserProperty.class).getAddress()
-
-                  if (userEmail != null && userEmail.endsWith("@digital.cabinet-office.gov.uk")) {
-                    logger.println("Upstream user being emailed: " + userEmail)
-                    msg.addRecipient(javax.mail.Message.RecipientType.TO, new javax.mail.internet.InternetAddress(userEmail))
-                  }
-                }
-              }
-            }
-          send-to:
-            - recipients
-            - developers
-            - culprits
 
     builders:
         - shell: |


### PR DESCRIPTION
Most developers don't use their work email address for git, and as
this restricts to `@digital.cabinet-office.gov.uk` addresses, most
people won't get any notifications.  No other Jenkins job sends out
emails.

Furthermore, there have been reports of people receiving these
notifications on non-work email addresses, so the email filtering
doesn't seem to be working properly anyway.

As Jenkins already notifies slack on failure, so we're not losing any
coverage by removing this.

---

[Trello card](https://trello.com/c/Vht9tcXk/604-jenkins-smokey-is-emailing-non-work-addresses)