### PR TITLE
Use run-rake-task in (almost) all of the jobs which previously did ssh+rake

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/content_audit_tool.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/content_audit_tool.yaml.erb
@@ -5,7 +5,13 @@
     project-type: freestyle
     description: "<p>Run the import:all_content_items rake task.</p>"
     builders:
-      - shell: ssh deploy@$(govuk_node_list -c backend --single-node) "cd /var/apps/content-audit-tool && govuk_setenv content-audit-tool bundle exec rake import:all_content_items"
+      - trigger-builds:
+          - project: run-rake-task
+            block: true
+            predefined-parameters: |
+              TARGET_APPLICATION=content-audit-tool
+              MACHINE_CLASS=backend
+              RAKE_TASK=import:all_content_items
     wrappers:
       - ansicolor:
           colormap: xterm
@@ -28,7 +34,13 @@
           days-to-keep: 30
           artifact-num-to-keep: 5
     builders:
-      - shell: ssh deploy@$(govuk_node_list -c backend --single-node) "cd /var/apps/content-audit-tool && govuk_setenv content-audit-tool bundle exec rake import:all_ga_metrics"
+      - trigger-builds:
+          - project: run-rake-task
+            block: true
+            predefined-parameters: |
+              TARGET_APPLICATION=content-audit-tool
+              MACHINE_CLASS=backend
+              RAKE_TASK=import:all_content_ga_metrics
     wrappers:
       - ansicolor:
           colormap: xterm

--- a/modules/govuk_jenkins/templates/jobs/content_performance_manager.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/content_performance_manager.yaml.erb
@@ -5,7 +5,13 @@
     project-type: freestyle
     description: "<p>Run the etl:master rake task.</p>"
     builders:
-      - shell: ssh deploy@$(govuk_node_list -c backend --single-node) "cd /var/apps/content-performance-manager && govuk_setenv content-performance-manager bundle exec rake etl:master"
+      - trigger-builds:
+          - project: run-rake-task
+            block: true
+            predefined-parameters: |
+              TARGET_APPLICATION=content-performance-manager
+              MACHINE_CLASS=backend
+              RAKE_TASK=etl:master
     wrappers:
       - ansicolor:
           colormap: xterm

--- a/modules/govuk_jenkins/templates/jobs/enhanced_ecommerce.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/enhanced_ecommerce.yaml.erb
@@ -9,16 +9,19 @@
           days-to-keep: 30
           artifact-num-to-keep: 5
     builders:
-        - shell: |
-          <%- if scope.lookupvar('::aws_migration') %>
-            ssh deploy@$(govuk_node_list -c search --single-node) '
-          <%- else -%>
-            ssh deploy@search-1.api '
-          <%- end -%>
-            cd /var/apps/rummager &&
-            govuk_setenv rummager bundle exec rake analytics:create_data_import_csv EXPORT_PATH=/data/export/enhanced_ecommerce &&
-            govuk_setenv rummager bundle exec rake analytics:delete_old_files EXPORT_PATH=/data/export/enhanced_ecommerce EXPORT_FILE_LIMIT=10
-            '
+      - trigger-builds:
+          - project: run-rake-task
+            block: true
+            predefined-parameters: |
+              TARGET_APPLICATION=rummager
+              MACHINE_CLASS=search
+              RAKE_TASK="analytics:create_data_import_csv EXPORT_PATH=/data/export/enhanced_ecommerce"
+          - project: run-rake-task
+            block: true
+            predefined-parameters: |
+              TARGET_APPLICATION=rummager
+              MACHINE_CLASS=search
+              RAKE_TASK="analytics:delete_old_files EXPORT_PATH=/data/export/enhanced_ecommerce EXPORT_FILE_LIMIT=10"
     triggers:
         - timed: '<%= @cron_schedule %>'
     publishers:

--- a/modules/govuk_jenkins/templates/jobs/monitor_taxonomy_health.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/monitor_taxonomy_health.yaml.erb
@@ -15,12 +15,10 @@
           days-to-keep: 30
           artifact-num-to-keep: 5
     builders:
-      - shell: |
-          #!/bin/bash
-          set -eu
-
-          cd "${WORKSPACE}"
-
-          CONTENT_TAGGER=$(govuk_node_list --single-node -c backend)
-
-          ssh deploy@$CONTENT_TAGGER "cd /var/apps/content-tagger && govuk_setenv content-tagger bundle exec rake taxonomy:health_checks"
+      - trigger-builds:
+          - project: run-rake-task
+            block: true
+            predefined-parameters: |
+              TARGET_APPLICATION=content-tagger
+              MACHINE_CLASS=backend
+              RAKE_TASK=taxonomy:health_checks

--- a/modules/govuk_jenkins/templates/jobs/publication_delay_report.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/publication_delay_report.yaml.erb
@@ -8,14 +8,13 @@
       - build-discarder:
           artifact-num-to-keep: 30
     builders:
-      - shell: |
-          #!/bin/bash
-          set -eu
-
-          MACHINE=$(govuk_node_list --single-node -c content_store)
-          COMMAND="cd /var/apps/content-store && govuk_setenv content-store bundle exec rake report:publication_delay_report"
-
-          ssh deploy@$MACHINE $COMMAND
+      - trigger-builds:
+          - project: run-rake-task
+            block: true
+            predefined-parameters: |
+              TARGET_APPLICATION=content-store
+              MACHINE_CLASS=content_store
+              RAKE_TASK=report:publication_delay_report
     triggers:
       - timed: |
           TZ=Europe/London

--- a/modules/govuk_jenkins/templates/jobs/publishing_api_archive_events.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/publishing_api_archive_events.yaml.erb
@@ -9,7 +9,13 @@
           days-to-keep: 30
           artifact-num-to-keep: 5
     builders:
-      - shell: ssh deploy@$(govuk_node_list -c publishing_api --single-node) "cd /var/apps/publishing-api && govuk_setenv publishing-api bundle exec rake events:export_to_s3"
+      - trigger-builds:
+          - project: run-rake-task
+            block: true
+            predefined-parameters: |
+              TARGET_APPLICATION=publishing-api
+              MACHINE_CLASS=publishing_api
+              RAKE_TASK=events:export_to_s3
     logrotate:
       numToKeep: 10
     triggers:

--- a/modules/govuk_jenkins/templates/jobs/record_superfluous_taggings_metrics.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/record_superfluous_taggings_metrics.yaml.erb
@@ -18,12 +18,10 @@
           days-to-keep: 30
           artifact-num-to-keep: 5
     builders:
-      - shell: |
-          #!/bin/bash
-          set -eu
-
-          cd "${WORKSPACE}"
-
-          CONTENT_TAGGER=$(govuk_node_list --single-node -c backend)
-
-          ssh deploy@$CONTENT_TAGGER "cd /var/apps/content-tagger && govuk_setenv content-tagger bundle exec rake metrics:taxonomy:record_number_of_superfluous_taggings_metrics"
+      - trigger-builds:
+          - project: run-rake-task
+            block: true
+            predefined-parameters: |
+              TARGET_APPLICATION=content-tagger
+              MACHINE_CLASS=backend
+              RAKE_TASK=metrics:taxonomy:record_number_of_superfluous_taggings_metrics

--- a/modules/govuk_jenkins/templates/jobs/record_taxonomy_metrics.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/record_taxonomy_metrics.yaml.erb
@@ -15,12 +15,10 @@
           days-to-keep: 30
           artifact-num-to-keep: 5
     builders:
-      - shell: |
-          #!/bin/bash
-          set -eu
-
-          cd "${WORKSPACE}"
-
-          CONTENT_TAGGER=$(govuk_node_list --single-node -c backend)
-
-          ssh deploy@$CONTENT_TAGGER "cd /var/apps/content-tagger && govuk_setenv content-tagger bundle exec rake metrics:taxonomy:record_all"
+      - trigger-builds:
+          - project: run-rake-task
+            block: true
+            predefined-parameters: |
+              TARGET_APPLICATION=content-tagger
+              MACHINE_CLASS=backend
+              RAKE_TASK=metrics:taxonomy:record_all

--- a/modules/govuk_jenkins/templates/jobs/remove_emergency_banner.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/remove_emergency_banner.yaml.erb
@@ -9,9 +9,13 @@
       - build-discarder:
           num-to-keep: 30
     builders:
-      # The argument to `-c` is in this case `frontend` but the value is used by both `static` and `frontend` applications
-      - shell: ssh deploy@$(govuk_node_list -c frontend --single-node) "cd /var/apps/static && govuk_setenv static bundle exec rake emergency_banner:remove"
       - trigger-builds:
+          - project: run-rake-task
+            block: true
+            predefined-parameters: |
+              TARGET_APPLICATION=static
+              MACHINE_CLASS=frontend
+              RAKE_TASK=emergency_banner:remove
           - project: clear-template-cache
             block: true
           - project: clear-frontend-memcache

--- a/modules/govuk_jenkins/templates/jobs/run_whitehall_data_migrations.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/run_whitehall_data_migrations.yaml.erb
@@ -9,8 +9,13 @@
           days-to-keep: 30
           artifact-num-to-keep: 5
     builders:
-        - shell: |
-            ssh deploy@$(govuk_node_list -c whitehall_backend --single-node) "cd /var/apps/whitehall ; govuk_setenv whitehall bundle exec rake db:data:migrate"
+      - trigger-builds:
+          - project: run-rake-task
+            block: true
+            predefined-parameters: |
+              TARGET_APPLICATION=whitehall
+              MACHINE_CLASS=whitehall_backend
+              RAKE_TASK=db:data:migrate
     wrappers:
         - ansicolor:
             colormap: xterm

--- a/modules/govuk_jenkins/templates/jobs/search_index_checks.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/search_index_checks.yaml.erb
@@ -14,7 +14,13 @@
             days-to-keep: 30
             artifact-num-to-keep: 5
     builders:
-        - shell: ssh deploy@$(govuk_node_list -c search --single-node) "cd /var/apps/rummager && govuk_setenv rummager bundle exec rake rummager:monitor_indices"
+      - trigger-builds:
+          - project: run-rake-task
+            block: true
+            predefined-parameters: |
+              TARGET_APPLICATION=rummager
+              MACHINE_CLASS=search
+              RAKE_TASK=rummager:monitor_indices
     wrappers:
       - ansicolor:
           colormap: xterm

--- a/modules/govuk_jenkins/templates/jobs/search_reindex_with_new_schema.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/search_reindex_with_new_schema.yaml.erb
@@ -16,7 +16,13 @@
           days-to-keep: 30
           artifact-num-to-keep: 5
     builders:
-        - shell: ssh deploy@$(govuk_node_list -c search --single-node) "cd /var/apps/rummager && govuk_setenv rummager bundle exec rake rummager:migrate_schema CONFIRM_INDEX_MIGRATION_START=1 RUMMAGER_INDEX=all"
+      - trigger-builds:
+          - project: run-rake-task
+            block: true
+            predefined-parameters: |
+              TARGET_APPLICATION=rummager
+              MACHINE_CLASS=search
+              RAKE_TASK="rummager:migrate_schema CONFIRM_INDEX_MIGRATION_START=1 RUMMAGER_INDEX=all"
     wrappers:
       - ansicolor:
           colormap: xterm

--- a/modules/govuk_jenkins/templates/jobs/whitehall_run_broken_link_checker.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/whitehall_run_broken_link_checker.yaml.erb
@@ -9,9 +9,13 @@
           days-to-keep: 30
           artifact-num-to-keep: 5
     builders:
-        - shell: |
-            ssh deploy@$(govuk_node_list -c whitehall_backend --single-node) 'cd /var/apps/whitehall; govuk_setenv whitehall nohup bundle exec rake generate_broken_link_reports[/tmp/bad_link_reports,second-line-content@digital.cabinet-office.gov.uk]'
-            echo "Broken link checker run"
+      - trigger-builds:
+          - project: run-rake-task
+            block: true
+            predefined-parameters: |
+              TARGET_APPLICATION=whitehall
+              MACHINE_CLASS=whitehall_backend
+              RAKE_TASK='generate_broken_link_reports[/tmp/bad_link_reports,second-line-content@digital.cabinet-office.gov.uk]'
     triggers:
         - timed: |
             TZ=Europe/London


### PR DESCRIPTION
To avoid creating hidden dependencies between machines, we should avoid connecting to things directly to run rake tasks, and instead use the `run-rake-task` job.

Some jobs still do the `ssh`+`rake` dance because `run-rake-task` is pretty simple:

- `content_publisher_whitehall_import.yaml.erb` uses the output.
- `data_sync_complete_integration.yaml.erb`, `data_sync_complete_staging.yaml.erb`, and `send_bulk_email.yaml.erb` use environment variables.
- `deploy_emergency_banner.yaml.erb` escapes its arguments.
- `transition_load_all_data.yaml.erb` and `transition_load_site_config.yaml.erb` use `rsync` to copy files to the target host beforehand

Not sure what to do about these.  Do we want to make `run-rake-task` more complicated to allow rewriting these?

---

[Trello card](https://trello.com/c/fNlQglk2/605-jenkins-job-ssh-sanitisation-to-remove-hidden-dependency)