### PR TITLE
Revert "Enable HTTP/2 and server push"

### DIFF
--- a/modules/router/templates/base.conf.erb
+++ b/modules/router/templates/base.conf.erb
@@ -21,12 +21,12 @@ server {
 server {
   server_name         www.gov.uk;
   <%- unless scope.lookupvar('::aws_migration') %>
-  listen              443 ssl http2;
+  listen              443 ssl;
   ssl_certificate     /etc/nginx/ssl/www.gov.uk.crt;
   ssl_certificate_key /etc/nginx/ssl/www.gov.uk.key;
   include             /etc/nginx/ssl.conf;
   <%- else %>
-  listen 80 http2;
+  listen 80;
   # Send the Strict-Transport-Security header
   include             /etc/nginx/add-sts.conf;
   <%- end %>
@@ -37,12 +37,12 @@ server {
 server {
   <%- if scope.lookupvar('::aws_migration') %>
   server_name         www.* www-origin.* draft-origin.*;
-  listen 80 http2;
+  listen 80;
   # Send the Strict-Transport-Security header
   include             /etc/nginx/add-sts.conf;
   <%- else %>
   server_name         www.<%= @app_domain %> www-origin.<%= @app_domain %> draft-origin.<%= @app_domain %>;
-  listen              443 ssl http2;
+  listen              443 ssl;
   ssl_certificate     /etc/nginx/ssl/www.<%= @app_domain %>.crt;
   ssl_certificate_key /etc/nginx/ssl/www.<%= @app_domain %>.key;
   include             /etc/nginx/ssl.conf;

--- a/modules/router/templates/router_include.conf.erb
+++ b/modules/router/templates/router_include.conf.erb
@@ -63,11 +63,7 @@ location ~ ^/contact/govuk/(|service-feedback|problem_reports|foi|page_improveme
 location / {
   <%= scope.function_template(['router/fragments/_basic_auth.erb']) -%>
 
-  # Enable asset domain preconnect for HTTP/2-capable clients
   add_header Link "<https://assets.<%= @app_domain %>>; rel=preconnect; crossorigin";
-
-  # Enable server push for HTTP/2-capable clients
-  http2_push_preload on;
 
   # HTML verification for DWP YouTube channel
   location = /dla-ending/google6db9c061ce178960.html {


### PR DESCRIPTION
Reverts alphagov/govuk-puppet#8297

This caused issues with nginx returning invalid responses so reverting until I can investigate.