### PR TITLE
Remove PagerDuty drill from Carrenza

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -597,7 +597,6 @@ monitoring::contacts::slack_channel: '#webops-monitoring'
 monitoring::contacts::slack_username: 'Production Icinga'
 monitoring::contacts::slack_alert_url: "https://alert.%{hiera('app_domain')}/cgi-bin/icinga/status.cgi"
 monitoring::edge::enabled: true
-monitoring::pagerduty_drill::enabled: true
 monitoring::uptime_collector::environment: 'production'
 
 postfix::smarthost:


### PR DESCRIPTION
This commit disables the PagerDuty drill on Carrenza, since it is now running in AWS and we don’t want two drills.