### PR TITLE
Fix puppet exec order

### DIFF
--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -230,7 +230,7 @@ monitoring::checks::rds::servers:
 
 # START OF TEMPORARY DEFECT FIX: # Smokey tests are not running correctly due to defects reported in: https://trello.com/c/XzGHhe3l/1629-investigate-cause-of-jenkins-oom-crashes-in-aws-staging-and-production
 # monitoring::checks::smokey::environment: 'staging'
-# END OF TEMPORARY DEFECT FIX
+# END OF TEMPORARY DEFECT FIX  
 
 monitoring::uptime_collector::environment: 'staging'
 

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -218,6 +218,16 @@ monitoring::checks::ses::region: 'eu-west-1'
 monitoring::checks::rds::region: 'eu-west-1'
 monitoring::checks::cache::region: 'eu-west-1'
 
+
+monitoring::checks::rds::servers:
+   - 'postgresql-primary'
+   - 'postgresql-standby'
+   - 'transition-postgresql-primary'
+   - 'transition-postgresql-standby'
+   - 'mysql-primary'
+   - 'mysql-replica'
+
+
 # START OF TEMPORARY DEFECT FIX: # Smokey tests are not running correctly due to defects reported in: https://trello.com/c/XzGHhe3l/1629-investigate-cause-of-jenkins-oom-crashes-in-aws-staging-and-production
 # monitoring::checks::smokey::environment: 'staging'
 # END OF TEMPORARY DEFECT FIX

--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_cache_memory
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_cache_memory
@@ -192,15 +192,20 @@ end = datetime.datetime.now()
 # 'Average' - We are defining that we won't the average for the matric. 		#
 # 'CacheClusterId' - The unique identifier which we use to query. 			#
 #########################################################################################
-data = cw_conn.get_metric_statistics(
-   300,
-   start,
-   end,
-   'FreeableMemory',
-   'AWS/ElastiCache',
-   'Average',
-   {'CacheClusterId': [args.instanceid]},
-)
+
+
+try:
+    data = cw_conn.get_metric_statistics(
+    300,
+    start,
+    end,
+    'FreeableMemory',
+    'AWS/ElastiCache',
+    'Average',
+    {'CacheClusterId': [args.instanceid]},
+  )
+except boto.exception.BotoServerError as err:
+    print "WARNING: The instance specified {} was not found!".format(args.instanceid)
 
 ##################################################################################################
 # Metrics                                                                                        #

--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_rds_cpu
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_rds_cpu
@@ -127,15 +127,18 @@ slice = 300
 # 'DBInstanceIdentifier' - The unique identifier which we use to query.     #
 #############################################################################
 
-data = cw_conn.get_metric_statistics(
-   slice,
-   start,
-   end,
-   'CPUUtilization',
-   'AWS/RDS',
-   'Average',
-   {'DBInstanceIdentifier': [args.instanceid]},
-)
+try:
+    data = cw_conn.get_metric_statistics(
+      slice,
+      start,
+      end,
+      'CPUUtilization',
+      'AWS/RDS',
+      'Average',
+      {'DBInstanceIdentifier': [args.instanceid]},
+    )
+except boto.exception.BotoServerError as err:
+    print "WARNING: The instance specified {} was not found!".format(args.instanceid)
 
 ##################################################################################################
 # Metrics											 #
@@ -164,11 +167,6 @@ data = cw_conn.get_metric_statistics(
 #   methods and attributes.							#
 # pprint.pprint(dir(data))							#
 #################################################################################
-
-
-if data == []:
-  print "WARNING: The instance specified {} was not found!".format(args.instanceid)
-  sys.exit()
 
 #########################################
 # Dissect the result			#

--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_rds_memory
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_rds_memory
@@ -133,7 +133,12 @@ db_classes = {
 ####################################################
 client = boto3.client('rds', region_name=args.region)
 # Collect DB instance attributes
-response = client.describe_db_instances(DBInstanceIdentifier=args.instanceid)
+
+try:
+    response = client.describe_db_instances(DBInstanceIdentifier=args.instanceid)
+except boto.exception.BotoServerError as err:
+    print "WARNING: The instance specified {} was not found!".format(args.instanceid)
+
 db_instance_data = response.get('DBInstances')
 # Get the allocated storage
 for attributes in db_instance_data:

--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_rds_storage
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_rds_storage
@@ -99,7 +99,14 @@ cw_conn = boto.ec2.cloudwatch.connect_to_region(args.region)
 ####################################################
 client = boto3.client('rds', region_name=args.region)
 # Collect DB instance attributes
-response = client.describe_db_instances(DBInstanceIdentifier=args.instanceid)
+
+
+try:
+    response = client.describe_db_instances(DBInstanceIdentifier=args.instanceid)
+except boto.exception.BotoServerError as err:
+    print "WARNING: The instance specified {} was not found!".format(args.instanceid)
+
+
 db_instance_data = response.get('DBInstances')
 # Get the allocated storage
 for attributes in db_instance_data:
@@ -140,15 +147,20 @@ slice = 300
 # 'DBInstanceIdentifier' - The unique identifier which we use to query.     #
 #############################################################################
 
-data = cw_conn.get_metric_statistics(
-   slice,
-   start,
-   end,
-   'FreeStorageSpace',
-   'AWS/RDS',
-   'Average',
-   {'DBInstanceIdentifier': [args.instanceid]},
-)
+
+
+try:
+    data = cw_conn.get_metric_statistics(
+      slice,
+      start,
+      end,
+      'FreeStorageSpace',
+      'AWS/RDS',
+      'Average',
+      {'DBInstanceIdentifier': [args.instanceid]},
+    )
+except boto.exception.BotoServerError as err:
+    print "WARNING: The instance specified {} was not found!".format(args.instanceid)
 
 ##################################################################################################
 # Metrics											 #

--- a/modules/monitoring/manifests/init.pp
+++ b/modules/monitoring/manifests/init.pp
@@ -24,7 +24,7 @@ class monitoring (
 
   unless $ci_environment {
     # Monitoring server only.
-    include ::govuk_jenkins::packages::govuk_python
+    include govuk_jenkins::packages::govuk_python
     include monitoring::checks
     include monitoring::edge
     include monitoring::pagerduty_drill


### PR DESCRIPTION
- Remove puppet global class definition which effects the execution order of the puppet manifest when installing python. This means that python gets installed after items that depend on it.  
- Add better try to catch statements to the Nagios checkers
- Remove applications that do not require a check a place.