### PR TITLE
Remove imminence from backend load balancers

### DIFF
--- a/modules/govuk/manifests/node/s_backend_lb.pp
+++ b/modules/govuk/manifests/node/s_backend_lb.pp
@@ -53,7 +53,6 @@ class govuk::node::s_backend_lb (
     'content-performance-manager',
     'content-publisher',
     'content-tagger',
-    'imminence',
     'link-checker-api',
     'local-links-manager',
     'manuals-publisher',


### PR DESCRIPTION
  Imminence is now running on AWS