### PR TITLE
Only keep one hour of old CDN logs

### DIFF
--- a/modules/govuk_cdnlogs/spec/classes/govuk_cdnlogs_spec.rb
+++ b/modules/govuk_cdnlogs/spec/classes/govuk_cdnlogs_spec.rb
@@ -103,7 +103,7 @@ ruleset\(name="cdn-giraffe"\) \{
       it 'should rotate the giraffe logs hourly' do
         is_expected.to contain_file('/etc/logrotate.cdn_logs_hourly.conf')
           .with_content(%r{^/tmp/logs/cdn-giraffe\.log$})
-          .with_content(/rotate 3/)
+          .with_content(/rotate 1/)
       end
 
       it 'should rotate the elephant logs hourly' do

--- a/modules/govuk_cdnlogs/templates/etc/logrotate.cdn_logs_hourly.conf.erb
+++ b/modules/govuk_cdnlogs/templates/etc/logrotate.cdn_logs_hourly.conf.erb
@@ -8,7 +8,7 @@ to_rotate_hourly.map { |name| "#{ @log_dir }/cdn-#{ name }.log" }.join("\n")
 
 {
   su root deploy
-  rotate 3
+  rotate 1
   dateext
   dateformat -%Y%m%d-%s
   compress


### PR DESCRIPTION
CDN logs are archived to S3.  The only reason we send them to our
monitoring server is so that we have real-time logs if necessary, as
there's a 15-minute lag on them being sent to S3 by Fastly.

Given that we're not archiving logs here, there's no more to keep more
than the bare minimum.  The previous hour's logs could be useful if
you're investigating something in real-time, so only keep one
rotation.