### PR TITLE
Reduce monitoring machine disk alert warning threshold to 15%

### DIFF
--- a/hieradata/class/monitoring.yaml
+++ b/hieradata/class/monitoring.yaml
@@ -4,3 +4,5 @@ govuk_cdnlogs::log_dir: '/var/log/cdn'
 
 govuk_safe_to_reboot::can_reboot: 'overnight'
 govuk_safe_to_reboot::reason: 'We lose alerting while this is down'
+
+icinga::client::checks::disk_space_warn: 15

--- a/hieradata_aws/class/monitoring.yaml
+++ b/hieradata_aws/class/monitoring.yaml
@@ -2,6 +2,8 @@
 
 govuk_cdnlogs::log_dir: '/var/log/cdn'
 
+icinga::client::checks::disk_space_warn: 15
+
 lv:
   data:
     pv: '/dev/nvme1n1'

--- a/modules/icinga/manifests/client/checks.pp
+++ b/modules/icinga/manifests/client/checks.pp
@@ -13,10 +13,21 @@
 #   The duration in minutes to include in the moving average window
 #   for disk time checks.
 #
+# [*disk_space_warn*]
+#   A warning is triggered when free disk space falls below this
+#   percentage.
+#
+# [*disk_space_critical*]
+#   A critical is triggered when free disk space falls below this
+#   percentage.
+#
+#
 class icinga::client::checks (
   $disk_time_warn = 100,
   $disk_time_critical = 200,
   $disk_time_window_minutes = 5,
+  $disk_space_warn = 20,
+  $disk_space_critical = 10,
 ) {
 
   if ! $::aws_migration {
@@ -54,7 +65,7 @@ class icinga::client::checks (
   }
 
   @@icinga::check { "check_root_disk_space_${::hostname}":
-    check_command       => 'check_nrpe!check_disk_space_arg!20% 10% /',
+    check_command       => "check_nrpe!check_disk_space_arg!${disk_space_warn}% ${disk_space_critical}% /",
     service_description => 'low available disk space on root',
     use                 => 'govuk_high_priority',
     host_name           => $::fqdn,


### PR DESCRIPTION
Now that CDN logs are being sent to monitoring-1, we're regularly
tripping the old warning threshold of 20%.

This won't solve the warning until #8313 is also merged.