### PR TITLE
Fix exporting enhanced ecommerce data

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/enhanced_ecommerce.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/enhanced_ecommerce.yaml.erb
@@ -15,13 +15,13 @@
             predefined-parameters: |
               TARGET_APPLICATION=rummager
               MACHINE_CLASS=search
-              RAKE_TASK="analytics:create_data_import_csv EXPORT_PATH=/data/export/enhanced_ecommerce"
+              RAKE_TASK="analytics:create_data_import_csv[/data/export/enhanced_ecommerce]"
           - project: run-rake-task
             block: true
             predefined-parameters: |
               TARGET_APPLICATION=rummager
               MACHINE_CLASS=search
-              RAKE_TASK="analytics:delete_old_files EXPORT_PATH=/data/export/enhanced_ecommerce EXPORT_FILE_LIMIT=10"
+              RAKE_TASK="analytics:delete_old_files[/data/export/enhanced_ecommerce,10]"
     triggers:
         - timed: '<%= @cron_schedule %>'
     publishers:


### PR DESCRIPTION
This task uses the Jenkins run-rake-task task. The analytics:create_data_import_csv
and analytics:create_data_import_csv have been modified to accept
parameters instead of environment variables.

See: git:
 - https://github.com/alphagov/rummager/pull/1317,
 - https://github.com/alphagov/govuk-puppet/pull/8301