### PR TITLE
Update Logit accounts for AWS

### DIFF
--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -121,7 +121,7 @@ govuk::apps::email_alert_api::email_archive_s3_bucket: 'govuk-production-email-a
 govuk::apps::email_alert_api::email_archive_s3_enabled: false
 govuk::apps::email_alert_api::govuk_notify_template_id: '76d21ce7-54c3-4fb7-8830-ba3b79287985'
 govuk::apps::hmrc_manuals_api::publish_topics: false
-govuk::apps::kibana::logit_environment: 0ea55710-075b-4eab-bfc3-475f28cdd0c3
+govuk::apps::kibana::logit_environment: 283f08f6-d117-48df-9667-c4aa492b81f9
 govuk::apps::link_checker_api::govuk_basic_auth_credentials: "%{hiera('http_username')}:%{hiera('http_password')}"
 govuk::apps::publicapi::backdrop_host: 'www.performance.service.gov.uk'
 govuk::apps::publisher::run_fact_check_fetcher: false

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -126,7 +126,7 @@ govuk::apps::email_alert_api::email_address_override_whitelist_only: true
 govuk::apps::email_alert_api::delivery_request_threshold: "3000"
 govuk::apps::email_alert_frontend::subscription_management_enabled: true
 govuk::apps::hmrc_manuals_api::publish_topics: false
-govuk::apps::kibana::logit_environment: d414187a-2796-4ea7-9b9a-d40c341646d6
+govuk::apps::kibana::logit_environment: b13bfb70-e07a-473b-9903-02e806ebd045
 govuk::apps::link_checker_api::govuk_basic_auth_credentials: "%{hiera('http_username')}:%{hiera('http_password')}"
 govuk::apps::publicapi::backdrop_host: 'www.staging.performance.service.gov.uk'
 govuk::apps::publisher::run_fact_check_fetcher: false


### PR DESCRIPTION
This commit updates the Logit account IDs for AWS staging/production to point to the correct stacks.