### PR TITLE
Migrate local links manager to aws

### DIFF
--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -128,6 +128,7 @@ govuk::apps::email_alert_api::delivery_request_threshold: "3000"
 govuk::apps::email_alert_frontend::subscription_management_enabled: true
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::kibana::logit_environment: b13bfb70-e07a-473b-9903-02e806ebd045
+govuk:apps::local-links-manager::app_domain: staging.govuk.digital
 govuk::apps::link_checker_api::govuk_basic_auth_credentials: "%{hiera('http_username')}:%{hiera('http_password')}"
 govuk::apps::publicapi::backdrop_host: 'www.staging.performance.service.gov.uk'
 govuk::apps::publisher::run_fact_check_fetcher: false

--- a/modules/govuk/manifests/apps/local_links_manager.pp
+++ b/modules/govuk/manifests/apps/local_links_manager.pp
@@ -91,6 +91,10 @@
 #   The number of unicorn worker processes to run
 #   Default: undef
 #
+# [*app_domain]
+#   The external subdomain used by the app
+#   Default: undef
+#
 class govuk::apps::local_links_manager(
   $port = 3121,
   $enabled = true,
@@ -117,6 +121,7 @@ class govuk::apps::local_links_manager(
   $google_export_tracker_id = undef,
   $run_links_ga_export = false,
   $unicorn_worker_processes = undef,
+  $app_domain = undef,
 ) {
   $app_name = 'local-links-manager'
 
@@ -177,6 +182,17 @@ class govuk::apps::local_links_manager(
       "${title}-RUN_LINK_GA_EXPORT":
         varname => 'RUN_LINK_GA_EXPORT',
         value   => bool2str($run_links_ga_export);
+    }
+
+    if $app_domain {
+       govuk::app::envvar {
+        "${title}-GOVUK_APP_DOMAIN":
+        varname => 'GOVUK_APP_DOMAIN',
+        value   => $app_domain;
+        "${title}-GOVUK_APP_DOMAIN_EXTERNAL":
+        varname => 'GOVUK_APP_DOMAIN_EXTERNAL',
+        value   => $app_domain;
+      }
     }
 
     if $local_links_manager_passive_checks {


### PR DESCRIPTION
During the migration we need to test local-links-manager in AWS by having it
talk to the AWS signon service. This uses a different app_domain to Carrenza so
not only needs a new value but a conditional statement in order to determine
what VAR and VALUE is used. This adds the puppet code to accomodate for this 