### PR TITLE
Include sudo for pg_dump in data sync

### DIFF
--- a/hieradata_aws/class/db_admin.yaml
+++ b/hieradata_aws/class/db_admin.yaml
@@ -3,4 +3,4 @@ postgresql::server::role::rds: true
 postgresql::globals::version: '9.6'
 govuk_sudo::sudo_conf:
   govuk-backup:
-    content: 'govuk-backup ALL=NOPASSWD:/usr/bin/psql,/usr/bin/dropdb,/usr/bin/dropuser,/usr/bin/pg_restore,/usr/bin/mysql'
+    content: 'govuk-backup ALL=NOPASSWD:/usr/bin/psql,/usr/bin/dropdb,/usr/bin/dropuser,/usr/bin/pg_restore,/usr/bin/mysql,/usr/bin/pg_dump'

--- a/hieradata_aws/class/email_alert_api_db_admin.yaml
+++ b/hieradata_aws/class/email_alert_api_db_admin.yaml
@@ -3,4 +3,4 @@ postgresql::server::role::rds: true
 postgresql::globals::version: '9.6'
 govuk_sudo::sudo_conf:
   govuk-backup:
-    content: 'govuk-backup ALL=NOPASSWD:/usr/bin/psql,/usr/bin/dropdb,/usr/bin/dropuser,/usr/bin/pg_restore'
+    content: 'govuk-backup ALL=NOPASSWD:/usr/bin/psql,/usr/bin/dropdb,/usr/bin/dropuser,/usr/bin/pg_restore,/usr/bin/pg_dump'

--- a/hieradata_aws/class/publishing_api_db_admin.yaml
+++ b/hieradata_aws/class/publishing_api_db_admin.yaml
@@ -4,4 +4,4 @@ postgresql::globals::manage_package_repo: true
 postgresql::server::role::rds: true
 govuk_sudo::sudo_conf:
   govuk-backup:
-    content: 'govuk-backup ALL=NOPASSWD:/usr/bin/psql,/usr/bin/dropdb,/usr/bin/dropuser,/usr/bin/pg_restore'
+    content: 'govuk-backup ALL=NOPASSWD:/usr/bin/psql,/usr/bin/dropdb,/usr/bin/dropuser,/usr/bin/pg_restore,/usr/bin/pg_dump'

--- a/hieradata_aws/class/transition_db_admin.yaml
+++ b/hieradata_aws/class/transition_db_admin.yaml
@@ -3,4 +3,4 @@ postgresql::server::role::rds: true
 postgresql::globals::version: '9.6'
 govuk_sudo::sudo_conf:
   govuk-backup:
-    content: 'govuk-backup ALL=NOPASSWD:/usr/bin/psql,/usr/bin/dropdb,/usr/bin/dropuser,/usr/bin/pg_restore'
+    content: 'govuk-backup ALL=NOPASSWD:/usr/bin/psql,/usr/bin/dropdb,/usr/bin/dropuser,/usr/bin/pg_restore,/usr/bin/pg_dump'

--- a/hieradata_aws/class/warehouse_db_admin.yaml
+++ b/hieradata_aws/class/warehouse_db_admin.yaml
@@ -4,4 +4,4 @@ postgresql::globals::manage_package_repo: true
 postgresql::server::role::rds: true
 govuk_sudo::sudo_conf:
   govuk-backup:
-    content: 'govuk-backup ALL=NOPASSWD:/usr/bin/psql,/usr/bin/dropdb,/usr/bin/dropuser,/usr/bin/pg_restore'
+    content: 'govuk-backup ALL=NOPASSWD:/usr/bin/psql,/usr/bin/dropdb,/usr/bin/dropuser,/usr/bin/pg_restore,/usr/bin/pg_dump'

--- a/modules/govuk_env_sync/files/govuk_env_sync.sh
+++ b/modules/govuk_env_sync/files/govuk_env_sync.sh
@@ -215,7 +215,17 @@ function restore_elasticsearch {
 }
 
 function  dump_postgresql {
-  pg_dump -F c "${database}" > "${tempdir}/${filename}"
+  # Check which postgres instance the database needs to restore into
+  # (warehouse, transition, or postgresql-primary).
+  if [ "${database}" == 'transition_production' ]; then
+    db_hostname='transition-postgresql-primary'
+  elif [ "${database}" == 'content_performance_manager_production' ]; then
+    db_hostname='warehouse-postgresql-primary'
+  else
+    db_hostname='postgresql-primary'
+  fi
+
+  sudo pg_dump -U aws_db_admin -h "${db_hostname}" --no-password -F c "${database}" > "${tempdir}/${filename}"
 }
 
 function restore_postgresql {

--- a/modules/govuk_env_sync/files/govuk_env_sync.sh
+++ b/modules/govuk_env_sync/files/govuk_env_sync.sh
@@ -225,6 +225,8 @@ function  dump_postgresql {
     db_hostname='postgresql-primary'
   fi
 
+# We do not need sudo rights to write the output file
+# shellcheck disable=SC2024
   sudo pg_dump -U aws_db_admin -h "${db_hostname}" --no-password -F c "${database}" > "${tempdir}/${filename}"
 }
 


### PR DESCRIPTION
- We had issues with missing users in these and can circumvent those by
using aws_db_admin for dumping databases as well

- We should paramterise the database name resolution at some point -
this is not nice

solo: @schmie