### PR TITLE
Restore the smokey_deploy job in AWS Staging and AWS Production

### DIFF
--- a/hieradata_aws/class/production/jenkins.yaml
+++ b/hieradata_aws/class/production/jenkins.yaml
@@ -13,8 +13,8 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::run_rake_task
 # START OF TEMPORARY DEFECT FIX: # Smokey tests are not running correctly due to defects reported in: https://trello.com/c/XzGHhe3l/1629-investigate-cause-of-jenkins-oom-crashes-in-aws-staging-and-production
 #  - govuk_jenkins::jobs::smokey
-#  - govuk_jenkins::jobs::smokey_deploy
 # END OF TEMPORARY DEFECT FIX
+  - govuk_jenkins::jobs::smokey_deploy
   - govuk_jenkins::jobs::transition_load_all_data
   - govuk_jenkins::jobs::transition_load_site_config
   - govuk_jenkins::jobs::bouncer_cdn

--- a/hieradata_aws/class/staging/jenkins.yaml
+++ b/hieradata_aws/class/staging/jenkins.yaml
@@ -14,8 +14,8 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::run_rake_task
 # START OF TEMPORARY DEFECT FIX: # Smokey tests are not running correctly due to defects reported in: https://trello.com/c/XzGHhe3l/1629-investigate-cause-of-jenkins-oom-crashes-in-aws-staging-and-production  
 #  - govuk_jenkins::jobs::smokey
-#  - govuk_jenkins::jobs::smokey_deploy
 # END OF TEMPORARY DEFECT FIX
+  - govuk_jenkins::jobs::smokey_deploy
   - govuk_jenkins::jobs::data_sync
   - govuk_jenkins::jobs::transition_load_all_data_redirect
   - govuk_jenkins::jobs::transition_load_site_config_redirect


### PR DESCRIPTION
This job was removed in [1], but the smokey-loop serivce is still
running on the monitoring boxes in both environments.

While there may be some problems with smokey in AWS environments, it's
still useful to be able to run the deploy Jenkins job, so that at
least an up to date version is running.

1: ce9f0051dcfd8f43d6b7324cdd72f0b353ad7d7f