### PR TITLE
add local links manager to backend box

### DIFF
--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -19,6 +19,7 @@ node_class: &node_class
     apps:
       - transition
       - imminence
+      - local-links-manager
   bouncer:
     apps:
       - bouncer


### PR DESCRIPTION
Co-Authored-By: Conor Glynn <ronocg@users.noreply.github.com>

# Context

As part of the AWS migration, we need to configure puppet to manage the `local-links-manager` in AWS production environment

# Decisions

1. Add `local-links-manager` in the list of applications for the backend machines in AWS production