### PR TITLE
GovUK-Migr-Trello-1675: db sync job for migration

### DIFF
--- a/hieradata/node/postgresql-standby-2.backend.publishing.service.gov.uk.yaml
+++ b/hieradata/node/postgresql-standby-2.backend.publishing.service.gov.uk.yaml
@@ -1,3 +1,15 @@
 icinga::client::check_cputype::cputype: 'amd'
 govuk_safe_to_reboot::can_reboot: 'overnight'
 govuk_safe_to_reboot::reason: 'DR node: only used in the event of a disaster'
+govuk_env_sync::tasks:
+  "push_local-links-manager_production_daily":
+    ensure: "absent"
+    hour: "0"
+    minute: "0"
+    action: "push"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "local-links-manager_production"
+    temppath: "/var/lib/autopostgresqlbackup/local-links-manager_production"
+    url: "govuk-production-database-backups"
+    path: "postgresql-backend"

--- a/hieradata_aws/class/production/db_admin.yaml
+++ b/hieradata_aws/class/production/db_admin.yaml
@@ -1,0 +1,23 @@
+govuk_env_sync::tasks:
+  "push_local-links-manager_production_daily":
+    ensure: "present"
+    hour: "3"
+    minute: "0"
+    action: "push"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "local-links-manager_production"
+    temppath: "/tmp/local-links-manager_production"
+    url: "govuk-production-database-backups"
+    path: "postgresql-backend"
+  "pull_local-links-manager_production_daily":
+    ensure: "absent"
+    hour: "0"
+    minute: "0"
+    action: "pull"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "local-links-manager_production"
+    temppath: "/tmp/local-links-manager_production"
+    url: "govuk-production-database-backups"
+    path: "postgresql-backend"


### PR DESCRIPTION
This PR lays down the govuk data sync job on one the standby postgres
node in production carrenza, it will not create a cron job, as this job
will be ran manually as part of the migration of local-links-manager.

The push script is also set down for the local-links-manager on
aws_production db_admin node. This is so we will have production
database backups nightly.

Co-Authored: Frederic Francois
frederic.francois@digital.cabinet-office.gov.uk