### PR TITLE
Reduce monitoring disk warning threshold to 12%

### DIFF
--- a/hieradata/class/monitoring.yaml
+++ b/hieradata/class/monitoring.yaml
@@ -5,4 +5,4 @@ govuk_cdnlogs::log_dir: '/var/log/cdn'
 govuk_safe_to_reboot::can_reboot: 'overnight'
 govuk_safe_to_reboot::reason: 'We lose alerting while this is down'
 
-icinga::client::checks::disk_space_warn: 15
+icinga::client::checks::disk_space_warn: 12

--- a/hieradata_aws/class/monitoring.yaml
+++ b/hieradata_aws/class/monitoring.yaml
@@ -2,7 +2,7 @@
 
 govuk_cdnlogs::log_dir: '/var/log/cdn'
 
-icinga::client::checks::disk_space_warn: 15
+icinga::client::checks::disk_space_warn: 12
 
 lv:
   data:


### PR DESCRIPTION
This was reduced to 15% in #8314, to handle the increased disk usage
due to the CDN logs.  However, we're still frequently going past that
threshold towards the end of each log rotation period (hourly).  I
haven't seen it drop below 13% free, so set 12% as the threshold.

This does mean that there's only 2 percentage points between the
warning and the critical thresholds, which seems not great though.