### PR TITLE
remove local links manager from carrenza prodution /etc/hosts

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -300,7 +300,6 @@ hosts::production::backend::app_hostnames:
   - 'hmrc-manuals-api'
   - 'kibana'
   - 'link-checker-api'
-  - 'local-links-manager'
   - 'maslow'
   - 'manuals-publisher'
   - 'publisher'


### PR DESCRIPTION
# Context

During the AWS migration, after the local links manager is enabled in AWS production, we need to remove the local links manager from the /etc/hosts in Carrenza so that the apps starts using the local links manager in AWS production.

# Decision

1. change the carrenza to remove the local-links-manager `production.yaml`