### PR TITLE
Add govuk_env_sync to postgres-standby machines

### DIFF
--- a/modules/govuk/manifests/node/s_postgresql_standby.pp
+++ b/modules/govuk/manifests/node/s_postgresql_standby.pp
@@ -16,6 +16,7 @@ class govuk::node::s_postgresql_standby (
   $wale_private_gpg_key,
   $wale_private_gpg_key_fingerprint,
 ) inherits govuk::node::s_postgresql_base {
+  include govuk_env_sync
   class { 'govuk_postgresql::server::standby':
     master_password => $primary_password,
   }


### PR DESCRIPTION
- During in-hours migration, we want to sync from machines with lower load

solo: @schmie