### PR TITLE
Add Whitehall to Rummager dependencies

### DIFF
--- a/development-vm/Pinfile
+++ b/development-vm/Pinfile
@@ -62,7 +62,7 @@ process :'publishing-components'
 process :release
 process :router
 process :'router-api'
-process :rummager => [:'publishing-api-read', :'rummager-sidekiq', :'rummager-publishing-listener', :'rummager-govuk-index-listener']
+process :rummager => [:'publishing-api-read', :'rummager-sidekiq', :'rummager-publishing-listener', :'rummager-govuk-index-listener', :'whitehall']
 process :'rummager-sidekiq'
 process :'rummager-publishing-listener'
 process :'rummager-govuk-index-listener'


### PR DESCRIPTION
This is a temporary dependency. Rummager now needs Whitehall, as Whitehall is the source
of world locations. Once these have been extracted from Whitehall, we can remove this
depedency.

Related pull request in Rummager:
https://github.com/alphagov/rummager/pull/1318