### PR TITLE
Add links-checker to the backends on staging AWS

### DIFF
--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -19,6 +19,7 @@ node_class: &node_class
     apps:
       - transition
       - imminence
+      - link-checker-api
       - local-links-manager
       - signon
   bouncer:


### PR DESCRIPTION
  As part of the migration on AWS