### PR TITLE
Configure gor to correctly set host and forwarded host headers

### DIFF
--- a/modules/router/manifests/gor.pp
+++ b/modules/router/manifests/gor.pp
@@ -40,12 +40,12 @@ class router::gor (
 
   class { 'govuk_gor':
     args    => {
-      '-input-raw'          => $input_raw,
-      '-output-http'        => prefix(keys($replay_targets), 'https://'),
-      '-http-allow-method'  => [
+      '-input-raw'         => $input_raw,
+      '-output-http'       => prefix(keys($replay_targets), 'https://'),
+      '-http-allow-method' => [
         'GET', 'HEAD', 'OPTIONS',
       ],
-      '-http-original-host' => '',
+      '-http-set-header'   => 'X-Forwarded-Host:',
     },
     envvars => {
       'GODEBUG' => 'netdns=go',

--- a/modules/router/spec/classes/router__gor_spec.rb
+++ b/modules/router/spec/classes/router__gor_spec.rb
@@ -9,8 +9,8 @@ describe 'router::gor', :type => :class do
   }}
   let(:args_default) {{
     '-input-raw'          => '127.0.0.1:7999',
-    '-http-allow-method' => %w{GET HEAD OPTIONS},
-    '-http-original-host' => '',
+    '-http-allow-method'  => %w{GET HEAD OPTIONS},
+    '-http-set-header'    => 'X-Forwarded-Host:',
   }}
 
   context 'no targets defined (disabled)' do


### PR DESCRIPTION
This commit changes the `gor` configuration when running the router traffic replay to:

1. Rewrite the HTTP `Host` header automatically to match the host the traffic is being replayed to by removing the `-http-original-host` flag.
2. Set the HTTP `X-Forwarded-Host` header to be empty, since `gor` does not touch this header by default.

The end result is that there will only be a `Host` header, and that will match the environment the traffic is being replayed to.

The reason for this change is that Rails uses the `X-Forwarded-Host` HTTP header (and `Host` when the former is unavailable) to construct absolute URLs for redirections. Due to the current `gor` configuration, redirects sent by Rails as responses to replayed traffic in staging actually use the production host details which means staging requests are redirected to production. These requests are subsequently cached by Varnish and the mis-redirection persists.

With `X-Forwarded-Host`:

```
$ curl -H 'X-Forwarded-Host: www.gov.uk' 'http://smartanswers.dev.gov.uk/state-pension-age/y?utf8=%E2%9C%93&response=age&next=1'
<html><body>You are being <a href="http://www.gov.uk/state-pension-age/y/age">redirected</a>.</body></html>
```

Without `X-Forwarded-Host`:

```
$ curl 'http://smartanswers.dev.gov.uk/state-pension-age/y?utf8=%E2%9C%93&response=age&next=1'
<html><body>You are being <a href="http://smartanswers.dev.gov.uk/state-pension-age/y/age">redirected</a>.</body></html>
```

Trello: https://trello.com/c/Ht45vvrL/619-smart-answers-on-staging-sometimes-redirects-to-production