### PR TITLE
 Enable alerts for unprocessed messages in email-alert-service queue

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -449,6 +449,8 @@ govuk::apps::email_alert_service::rabbitmq_hosts:
   - rabbitmq-2.backend
   - rabbitmq-3.backend
 govuk::apps::email_alert_service::redis_host: "%{hiera('sidekiq_host')}"
+govuk::apps::email_alert_service::rabbitmq::queue_size_critical_threshold: 25
+govuk::apps::email_alert_service::rabbitmq::queue_size_warning_threshold: 5
 
 govuk::apps::finder_frontend::enabled: true
 govuk::apps::finder_frontend::nagios_memory_warning: 2000

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -114,6 +114,8 @@ govuk::apps::content_publisher::enabled: true
 govuk::apps::content_tagger::enable_procfile_worker: false
 govuk::apps::email_alert_api::enable_procfile_worker: false
 govuk::apps::email_alert_service::rabbitmq_hosts: ['localhost']
+govuk::apps::email_alert_service::rabbitmq::queue_size_critical_threshold: 25
+govuk::apps::email_alert_service::rabbitmq::queue_size_warning_threshold: 5
 govuk::apps::event_store::enabled: true
 govuk::apps::event_store::mongodb_servers: ['localhost']
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -471,6 +471,8 @@ govuk::apps::email_alert_service::enabled: true
 govuk::apps::email_alert_service::rabbitmq_hosts:
   - rabbitmq
 govuk::apps::email_alert_service::redis_host: "%{hiera('sidekiq_host')}"
+govuk::apps::email_alert_service::rabbitmq::queue_size_critical_threshold: 25
+govuk::apps::email_alert_service::rabbitmq::queue_size_warning_threshold: 5
 
 govuk::apps::finder_frontend::enabled: true
 govuk::apps::finder_frontend::nagios_memory_warning: 2000

--- a/modules/govuk_rabbitmq/manifests/monitor_messages.pp
+++ b/modules/govuk_rabbitmq/manifests/monitor_messages.pp
@@ -40,7 +40,7 @@ define govuk_rabbitmq::monitor_messages (
     include icinga::plugin::check_rabbitmq_messages
 
     @@icinga::check { "check_rabbitmq_messages_for_${rabbitmq_queue}_on_${::hostname}":
-      check_command       => "check_nrpe!check_rabbitmq_messages!${rabbitmq_hostname} ${rabbitmq_admin_port} ${rabbitmq_queue} ${rabbitmq_user}",
+      check_command       => "check_nrpe!check_rabbitmq_messages!${rabbitmq_hostname} ${rabbitmq_admin_port} ${rabbitmq_queue} ${rabbitmq_user} ${critical_threshold} ${warning_threshold}",
       service_description => "Check that messages are being processed in rabbitmq queue ${rabbitmq_queue}",
       host_name           => $::fqdn,
       notes_url           => monitoring_docs_url(rabbitmq-no-consumers-consuming),

--- a/modules/govuk_rabbitmq/manifests/monitor_messages.pp
+++ b/modules/govuk_rabbitmq/manifests/monitor_messages.pp
@@ -1,0 +1,49 @@
+# = govuk_rabbitmq::monitor_messages
+#
+# Monitor for unprocessed messages on a rabbitmq queue
+#
+# [*rabbitmq_queue*]
+# The queue to monitor
+#
+# [*critical_threshold*]
+#   The threshold for a critical alert
+#
+# [*warning_threshold*]
+#   The threshold for a warning alert
+#
+# [*ensure*]
+#   Whether the monitoring should be created
+#
+# [*rabbitmq_hostname*]
+# The hostname of a server in the rabbitmq cluster
+# Default: rabbitmq-1.backend
+#
+# [*rabbitmq_user*]
+# The user to connect as when monitoring, the password will be passed from
+# Hiera as icinga::plugin::check_rabbitmq_consumers::monitoring_password
+# Default: monitoring
+#
+# [*rabbitmq_admin_port*]
+# The admin port of the rabbitmq server
+# Default: 15672
+define govuk_rabbitmq::monitor_messages (
+  $rabbitmq_queue,
+  $critical_threshold,
+  $warning_threshold,
+  $ensure = present,
+  $rabbitmq_hostname = 'rabbitmq-1.backend',
+  $rabbitmq_user = 'monitoring',
+  $rabbitmq_admin_port = 15672,
+){
+
+  if $ensure == present {
+    include icinga::plugin::check_rabbitmq_messages
+
+    @@icinga::check { "check_rabbitmq_messages_for_${rabbitmq_queue}_on_${::hostname}":
+      check_command       => "check_nrpe!check_rabbitmq_messages!${rabbitmq_hostname} ${rabbitmq_admin_port} ${rabbitmq_queue} ${rabbitmq_user}",
+      service_description => "Check that messages are being processed in rabbitmq queue ${rabbitmq_queue}",
+      host_name           => $::fqdn,
+      notes_url           => monitoring_docs_url(rabbitmq-no-consumers-consuming),
+    }
+  }
+}

--- a/modules/icinga/files/usr/lib/nagios/plugins/check_rabbitmq_messages
+++ b/modules/icinga/files/usr/lib/nagios/plugins/check_rabbitmq_messages
@@ -51,7 +51,7 @@ class RabbitMQCheck:
             raise Exception(self.error_message(response))
         return json.loads(response.content)
 
-    def check(self, warning_threshold, critical_threshold):
+    def check(self, critical_threshold, warning_threshold):
         """Check the number of messages in the queue."""
 
         queue_details = self.rabbit_request("queues/%2F/" + self._queue)
@@ -81,9 +81,9 @@ if __name__ == "__main__":
     queue = sys.argv[3]
     username = sys.argv[4]
     password = sys.argv[5]
-    warning_threshold = int(sys.argv[6])
-    critical_threshold = int(sys.argv[7])
+    critical_threshold = int(sys.argv[6])
+    warning_threshold = int(sys.argv[7])
 
     rabbitmq_check = RabbitMQCheck(host, port, queue, username, password)
 
-    report(*rabbitmq_check.check(warning_threshold, critical_threshold))
+    report(*rabbitmq_check.check(critical_threshold, warning_threshold))

--- a/modules/icinga/files/usr/lib/nagios/plugins/check_rabbitmq_messages
+++ b/modules/icinga/files/usr/lib/nagios/plugins/check_rabbitmq_messages
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+"""
+Checks the size of the rabbitmq queue.
+"""
+
+import json
+import requests
+import sys
+
+OK, WARNING, CRITICAL, UNKNOWN = 0, 1, 2, 3
+STATUSES = ["ok", "warning", "critical", "unknown"]
+
+
+def report(exit_code, message):
+    """Report the check's result to STDOUT, then exit."""
+    prefix = STATUSES[exit_code].upper()
+    print('%s: %s' % (prefix, message))
+    exit(exit_code)
+
+
+def handle_exception(exc_type, exception, traceback):
+    """Report uncaught exceptions to Nagios as UNKNOWN (exit code 3)."""
+    report(UNKNOWN, "unhandled exception: %s" % (exception,))
+
+
+class RabbitMQCheck:
+    def __init__(self, host, port, queue, username, password):
+        self._queue = queue
+        self._base_uri = "http://%s:%s/api/" % (host, port)
+        self._auth = (username, password)
+        self.allowed_max_idle_time = datetime.timedelta(seconds = 5 * 60)
+
+    def error_message(self, response):
+        msg = "HTTP %s error" % (response.status_code)
+        try:
+            json_body = json.loads(response.content)
+        except ValueError:
+            return msg
+        return "%s: %s: %s" % (
+            msg,
+            json_body.get("error", ""),
+            json_body.get("reason", ""),
+        )
+
+    def rabbit_request(self, path):
+        """Make a request to the rabbit API at the given path."""
+        uri = self._base_uri + path
+        response = requests.get(uri, auth=self._auth)
+
+        if response.status_code != 200:
+            raise Exception(self.error_message(response))
+        return json.loads(response.content)
+
+    def check(self, warning_threshold, critical_threshold):
+        """Check the number of messages in the queue."""
+
+        queue_details = self.rabbit_request("queues/%2F/" + self._queue)
+        messages = queue_details[u"messages"]
+
+        if messages > critical_threshold:
+            return CRITICAL, "Number of unprocessed messages above critical threshold (%s > %s)" % (
+                messages,
+                critical_threshold
+            )
+        elif messages > warning_threshold:
+            return WARNING, "Number of unprocessed messages above warning threshold (%s > %s)" % (
+                messages,
+                warning_threshold
+            )
+        return OK, "Number of unprocessed messages below warning threshold (%s <= %s)" % (
+            messages,
+            warning_threshold
+        )
+
+
+if __name__ == "__main__":
+    sys.excepthook = handle_exception
+
+    host = sys.argv[1]
+    port = sys.argv[2]
+    queue = sys.argv[3]
+    username = sys.argv[4]
+    password = sys.argv[5]
+    warning_threshold = int(sys.argv[6])
+    critical_threshold = int(sys.argv[7])
+
+    rabbitmq_check = RabbitMQCheck(host, port, queue, username, password)
+
+    report(*rabbitmq_check.check(warning_threshold, critical_threshold))

--- a/modules/icinga/manifests/plugin/check_rabbitmq_messages.pp
+++ b/modules/icinga/manifests/plugin/check_rabbitmq_messages.pp
@@ -1,0 +1,21 @@
+# == Class: icinga::plugin::check_rabbitmq_messages
+#
+# Install a Nagios plugin that alerts when a rabbitmq queue
+# contains more than a given number of messages.
+#
+class icinga::plugin::check_rabbitmq_messages (
+  $warning_threshold   = undef,
+  $critical_threshold  = undef,
+  $monitoring_password = '',
+){
+
+  @icinga::plugin { 'check_rabbitmq_messages':
+    source  => 'puppet:///modules/icinga/usr/lib/nagios/plugins/check_rabbitmq_messages',
+  }
+
+  @icinga::nrpe_config { 'check_rabbitmq_messages':
+    content  => template('icinga/etc/nagios/nrpe.d/check_rabbitmq_messages.cfg.erb'),
+  }
+
+  ensure_packages(['python-requests'])
+}

--- a/modules/icinga/manifests/plugin/check_rabbitmq_messages.pp
+++ b/modules/icinga/manifests/plugin/check_rabbitmq_messages.pp
@@ -4,8 +4,6 @@
 # contains more than a given number of messages.
 #
 class icinga::plugin::check_rabbitmq_messages (
-  $warning_threshold   = undef,
-  $critical_threshold  = undef,
   $monitoring_password = '',
 ){
 

--- a/modules/icinga/templates/etc/nagios/nrpe.d/check_rabbitmq_messages.cfg.erb
+++ b/modules/icinga/templates/etc/nagios/nrpe.d/check_rabbitmq_messages.cfg.erb
@@ -1,0 +1,1 @@
+command[check_rabbitmq_messages]=/usr/lib/nagios/plugins/check_rabbitmq_messages $ARG1$ $ARG2$ $ARG3$ $ARG4$ <%= @monitoring_password %> <%= @warning_threshold %> <%= @critical_threshold %>

--- a/modules/icinga/templates/etc/nagios/nrpe.d/check_rabbitmq_messages.cfg.erb
+++ b/modules/icinga/templates/etc/nagios/nrpe.d/check_rabbitmq_messages.cfg.erb
@@ -1,1 +1,1 @@
-command[check_rabbitmq_messages]=/usr/lib/nagios/plugins/check_rabbitmq_messages $ARG1$ $ARG2$ $ARG3$ $ARG4$ <%= @monitoring_password %> <%= @warning_threshold %> <%= @critical_threshold %>
+command[check_rabbitmq_messages]=/usr/lib/nagios/plugins/check_rabbitmq_messages $ARG1$ $ARG2$ $ARG3$ $ARG4$ <%= @monitoring_password %> $ARG5$ $ARG6$


### PR DESCRIPTION
Looking back over the 2018 data, the queues sizes are always below 3,
except when the service failed, and there was a sudden large build up.
I'm confident that these very low thresholds won't be too noisy, and
will usefully indicate when the service is up but failing to process
messages.

---

**Production:**
<img width="1602" alt="screen shot 2018-11-14 at 15 08 13" src="https://user-images.githubusercontent.com/75235/48491605-db8ed000-e81f-11e8-9230-cde3f386b17d.png">

**Staging:**
<img width="1607" alt="screen shot 2018-11-14 at 15 08 54" src="https://user-images.githubusercontent.com/75235/48491607-db8ed000-e81f-11e8-889e-c64c9d23e2d3.png">

---

[Trello card](https://trello.com/c/d3ouXvUN/626-add-alerting-around-high-rabbitmq-queues-for-email-alert-service)