### PR TITLE
add publishing_api entries to /etc/hosts to AWS Staging Backends

### DIFF
--- a/hieradata_aws/class/staging/backend.yaml
+++ b/hieradata_aws/class/staging/backend.yaml
@@ -1,0 +1,7 @@
+---
+
+hosts::migration::hosts:
+  publishing-api-1:
+    ip: '10.2.3.45'
+  publishing-api-2:
+    ip: '10.2.3.46'

--- a/modules/govuk/manifests/node/s_backend.pp
+++ b/modules/govuk/manifests/node/s_backend.pp
@@ -42,6 +42,10 @@ class govuk::node::s_backend inherits govuk::node::s_base {
     include govuk_elasticsearch::local_proxy
   }
 
+  if $::aws_migration {
+    include hosts::migration
+  }
+
   # Ensure memcached is available to backend nodes
   include collectd::plugin::memcached
   class { 'memcached':


### PR DESCRIPTION
# Context

During the AWS migration, the `link-checker-api` is being migrated to AWS without migrating the `publishing-api` which still lives in Carrenza. For the AWS `link-checker-api` migration, the AWS backend machines (which hosts the `link-checker-api` application) need to retrieve the IP of the Carrenza `publishing-api` machines. Hence, the {ip, fqdn} entry needs to be added in '/etc/hosts' file of the AWS backend machines.

# Decision

For AWS staging environment:
1. Add the `hosts::migration` class to the `backend` node class
2. Configure the AWS hiera data to include {ip, fqdn} entry