### PR TITLE
Trello-1728: mongo-api cluster

### DIFF
--- a/hieradata/class/mongo_api.yaml
+++ b/hieradata/class/mongo_api.yaml
@@ -1,0 +1,10 @@
+---
+
+# Temporarily placed to in carrenza hieradata to satisfy the spec tests
+# The monog-api-* VMs do not exist in Carrenza.
+# This will be collapsed down once the migrations to AWS are complete.
+
+mongodb::server::replicaset_members:
+  'mongo-api-1':
+  'mongo-api-2':
+  'mongo-api-3':

--- a/hieradata_aws/class/mongo_api.yaml
+++ b/hieradata_aws/class/mongo_api.yaml
@@ -1,0 +1,26 @@
+---
+
+govuk_safe_to_reboot::can_reboot: 'overnight'
+govuk_safe_to_reboot::reason: 'Secondaries will reboot overnight if cluster is healthy'
+
+icinga::client::checks::disk_time_window_minutes: 10
+
+mongodb::server::oplog_size: 14392 # 14 * 1024
+mongodb::server::replicaset_members:
+  'mongo-api-1':
+  'mongo-api-2':
+  'mongo-api-3':
+  'mongo-api-4':
+
+lv:
+  data:
+    pv: '/dev/nvme1n1'
+    vg: 'mongo'
+
+mount:
+  /var/lib/mongodb:
+    disk: '/dev/mapper/mongo-data'
+    govuk_lvm: 'data'
+    mountoptions: 'defaults'
+    percent_threshold_warning: 40
+    percent_threshold_critical: 15

--- a/hieradata_aws/class/mongo_api.yaml
+++ b/hieradata_aws/class/mongo_api.yaml
@@ -10,7 +10,6 @@ mongodb::server::replicaset_members:
   'mongo-api-1':
   'mongo-api-2':
   'mongo-api-3':
-  'mongo-api-4':
 
 lv:
   data:

--- a/hieradata_aws/class/staging/mongo_api.yaml
+++ b/hieradata_aws/class/staging/mongo_api.yaml
@@ -1,0 +1,12 @@
+govuk_env_sync::tasks:
+  "pull_content_store_daily":
+    ensure: "absent"
+    hour: "0"
+    minute: "00"
+    action: "pull"
+    dbms: "mongo"
+    storagebackend: "s3"
+    database: "content_store_production"
+    temppath: "/var/lib/mongodb/.dumps"
+    url: "govuk-staging-database-backups"
+    path: "mongo-api"

--- a/modules/govuk/manifests/node/s_mongo_api.pp
+++ b/modules/govuk/manifests/node/s_mongo_api.pp
@@ -1,0 +1,13 @@
+# == Class: govuk::node::s_mongo_api
+#
+# mongo-api node
+#
+class govuk::node::s_mongo_api inherits govuk::node::s_base {
+  include mongodb::server
+  include govuk_env_sync
+
+  collectd::plugin::tcpconn { 'mongo_api':
+    incoming => 27017,
+    outgoing => 27017,
+  }
+}

--- a/modules/hosts/manifests/purge.pp
+++ b/modules/hosts/manifests/purge.pp
@@ -19,6 +19,7 @@ class hosts::purge {
     'email-alert-api-postgresql',
     'publishing-api-db-admin-1',
     'publishing-api-postgresql-1',
+    'mongo-api-1',
   ]
 
   if ! ($::hostname in $whitelist) {


### PR DESCRIPTION
### What ###
We need to create a mongo cluster (mongo_api) that will be used for testing addition and removal on mongo cluster nodes which will be carried out in card #1725

The mongo cluster will be built using the same module as existing mongo
module: mongodb::server

### Why ###
If our tests are successful in #1725 we will be able to have a no-downtime migration of the mongo databases.
It is also envisaged that the mongo cluster will be split up, in other
words the content-store will use mongo-api cluster (that we are
currently building here) and immenence will continue to use the existing
mongo cluster.

There is hieradata being added to the carrenza side as part of this
commit, that is to satisfy the spec tests, once migrations are fully
completed this hieradata will be collapsed into one, so it is
temporary.

Pair: @th31nitiate @ronocg