### PR TITLE
Revert "Use run-rake-task in search_reindex_with_new_schema job"

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/search_reindex_with_new_schema.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/search_reindex_with_new_schema.yaml.erb
@@ -16,13 +16,7 @@
           days-to-keep: 30
           artifact-num-to-keep: 5
     builders:
-      - trigger-builds:
-          - project: run-rake-task
-            block: true
-            predefined-parameters: |
-              TARGET_APPLICATION=rummager
-              MACHINE_CLASS=search
-              RAKE_TASK="rummager:migrate_schema CONFIRM_INDEX_MIGRATION_START=1 RUMMAGER_INDEX=all"
+        - shell: ssh deploy@$(govuk_node_list -c search --single-node) "cd /var/apps/rummager && govuk_setenv rummager bundle exec rake rummager:migrate_schema CONFIRM_INDEX_MIGRATION_START=1 RUMMAGER_INDEX=all"
     wrappers:
       - ansicolor:
           colormap: xterm


### PR DESCRIPTION
I broke two Jenkins jobs in #8301.  One of them was fixed in d864758f7c6e37565a6ed12f1a020e2e98550a70, this fixes the other.