### PR TITLE
Fix crawlers to crawl their own environment

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -526,9 +526,8 @@ govuk::apps::govuk_crawler_worker::blacklist_paths:
 
 govuk::apps::govuk_crawler_worker::enabled: true
 govuk::apps::govuk_crawler_worker::root_urls:
-  - 'https://assets.digital.cabinet-office.gov.uk/'
-  - 'https://assets.publishing.service.gov.uk/'
-  - 'https://www.gov.uk/'
+  - "https://assets-origin.%{hiera('app_domain')}"
+  - "https://www-origin.%{hiera('app_domain')}"
 
 govuk::apps::imminence::mongodb_nodes:
   - 'mongo-1.backend'
@@ -925,7 +924,7 @@ govuk_containers::frontend::haproxy::wildcard_publishing_certificate: "%{hiera('
 govuk_containers::frontend::haproxy::wildcard_publishing_key: "%{hiera('wildcard_publishing_key')}"
 
 govuk_crawler::amqp_host: 'localhost'
-govuk_crawler::site_root: 'https://www.gov.uk'
+govuk_crawler::site_root: "https://www-origin.%{hiera('app_domain')}"
 
 govuk_docker::version: "17.09.0~ce-0~ubuntu"
 govuk_docker::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -203,6 +203,7 @@ govuk_postgresql::backup::auto_postgresql_backup_minute: 0
 
 govuk_crawler::seed_enable: true
 govuk_crawler::sync_enable: true
+govuk_crawler::site_root: 'https://www.gov.uk'
 
 govuk_crawler::targets:
   - 'mirror-rsync@mirror0.mirror.provider1.production.govuk.service.gov.uk'
@@ -215,6 +216,11 @@ govuk_crawler::ssh_keys:
   mirror1.mirror.provider1.production.govuk.service.gov.uk:
     key: 'AAAAB3NzaC1yc2EAAAADAQABAAABAQDHi69quH4i1jY4uVLuIYOoUi7yc+6/fJjDKJciWIIgyH1rCSGtTXrfcJQHQKxKEyndQ+LoUs8krImD9CtzQTvoqdXYKu+XgpjqiZ5HfQhx55ZoMCXnx9vqCwGtx2LwH4PaBZRvsNJbbY+sG3W13eXkgwQnIcI2FgGpDDJQ9lfxSNzt6jMJQuvAhhDrKtZEsA56AznPIRd1mIHmuZ6gILBzJmDw5EIpqQhSb4+NrNTNnGxHyFkZISTMG0mx9lRtlyS1SMZVoPJQbShSEScKMXRlacrpkiNOTvrGDrhsLjTUtT5g1bo4XMFRubReAwFCeTZI0Qv1Bvpzj8V9c8B4+p6b'
     type: 'ssh-rsa'
+
+govuk::apps::govuk_crawler_worker::root_urls:
+  - 'https://assets.digital.cabinet-office.gov.uk/'
+  - "https://assets.%{hiera('app_domain')}/"
+  - 'https://www.gov.uk/'
 
 hosts::production::ip_api_lb: '10.3.4.254'
 hosts::production::ip_backend_lb: '10.3.3.254'

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -865,7 +865,7 @@ govuk_containers::apps::router::envvars:
 
 govuk_crawler::alert_hostname: 'alert'
 govuk_crawler::amqp_host: 'localhost'
-govuk_crawler::site_root: 'https://www.gov.uk'
+govuk_crawler::site_root: "https://www-origin.%{hiera('app_domain')}"
 
 govuk_docker::version: "17.09.0~ce-0~ubuntu"
 govuk_docker::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -151,8 +151,14 @@ govuk_containers::terraboard::oauth2_proxy_base_url: 'https://terraboard.product
 
 govuk_crawler::seed_enable: true
 govuk_crawler::sync_enable: true
+govuk_crawler::site_root: 'https://www.gov.uk'
 govuk_crawler::targets:
   - 's3://govuk-mirror-production/'
+
+govuk::apps::govuk_crawler_worker::root_urls:
+  - 'https://assets.digital.cabinet-office.gov.uk/'
+  - "https://assets.%{hiera('app_domain')}/"
+  - 'https://www.gov.uk/'
 
 govuk_jenkins::config::banner_colour_background: '#df3034'
 govuk_jenkins::config::banner_colour_text: 'white'


### PR DESCRIPTION
https://trello.com/c/IDBl5Xna/349-fix-govuk-crawler-on-staging

Previously the crawlers for each environment were all crawling
www.gov.uk, which has recently (for some reason) generated rate limit
alerts, as the limit bypass tokens aren't shared between environments.

This changes the crawler config for integration and staging (and
similarly for AWS) to crawl origin for each environment. We've chosen to
crawl the origin instead of the CDN in these environments because:

   * The Carenza machines map www -> www-origin anyway
   * The AWS mirror machines can't access the CDN
   * The load impact of the crawler isn't such an issue

Ideally we should crawl the CDN on all environments, using a common URL
structure (compare www.gov.uk vs www.staging.publishing...), but this
isn't essential, although we should still aim to do this for AWS.