### PR TITLE
Stop crawling www-origin on staging (bad sitemap)

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -526,8 +526,8 @@ govuk::apps::govuk_crawler_worker::blacklist_paths:
 
 govuk::apps::govuk_crawler_worker::enabled: true
 govuk::apps::govuk_crawler_worker::root_urls:
-  - "https://assets-origin.%{hiera('app_domain')}"
-  - "https://www-origin.%{hiera('app_domain')}"
+  - "https://assets.%{hiera('app_domain')}"
+  - "https://www.%{hiera('app_domain')}"
 
 govuk::apps::imminence::mongodb_nodes:
   - 'mongo-1.backend'
@@ -924,7 +924,7 @@ govuk_containers::frontend::haproxy::wildcard_publishing_certificate: "%{hiera('
 govuk_containers::frontend::haproxy::wildcard_publishing_key: "%{hiera('wildcard_publishing_key')}"
 
 govuk_crawler::amqp_host: 'localhost'
-govuk_crawler::site_root: "https://www-origin.%{hiera('app_domain')}"
+govuk_crawler::site_root: "https://www.%{hiera('app_domain')}"
 
 govuk_docker::version: "17.09.0~ce-0~ubuntu"
 govuk_docker::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -544,8 +544,8 @@ govuk::apps::govuk_crawler_worker::blacklist_paths:
 
 govuk::apps::govuk_crawler_worker::enabled: true
 govuk::apps::govuk_crawler_worker::root_urls:
-  - "https://assets-origin.%{hiera('app_domain')}"
-  - "https://www-origin.%{hiera('app_domain')}"
+  - "https://assets.%{hiera('app_domain')}"
+  - "https://www.%{hiera('app_domain')}"
 
 govuk::apps::imminence::mongodb_nodes:
   - 'mongo-1'
@@ -865,7 +865,7 @@ govuk_containers::apps::router::envvars:
 
 govuk_crawler::alert_hostname: 'alert'
 govuk_crawler::amqp_host: 'localhost'
-govuk_crawler::site_root: "https://www-origin.%{hiera('app_domain')}"
+govuk_crawler::site_root: "https://www.%{hiera('app_domain')}"
 
 govuk_docker::version: "17.09.0~ce-0~ubuntu"
 govuk_docker::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"


### PR DESCRIPTION
https://trello.com/c/IDBl5Xna/349-fix-govuk-crawler-on-staging

Previously we fixed the GOV.UK crawler in staging to crawl the staging
environment and not production. The intention was to use www-origin to
avoid confusion around the www -> www-origin mapping in /etc/hosts and
to better support the migration of this service to AWS.

This removes -origin from the config, as these are not compatible
with the sitemap.xml entries the crawler uses to do its job. This means
we will have to rely on the www -> www-origin mapping on Carrenza for
the time being (staging machines don't have access to the real www CDN).