### PR TITLE
Add JWT_AUTH_SECRET to asset manager

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -338,6 +338,7 @@ filebeat::prospectors:
 
 gdal::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
+govuk::apps::asset_manager::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
 govuk::apps::asset_manager::mongodb_nodes:
   - 'mongo-1.backend'
   - 'mongo-2.backend'

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -351,6 +351,7 @@ filebeat::prospectors:
 
 gdal::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
+govuk::apps::asset_manager::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
 govuk::apps::asset_manager::mongodb_nodes:
   - 'mongo-1'
   - 'mongo-2'

--- a/modules/govuk/manifests/apps/asset_manager.pp
+++ b/modules/govuk/manifests/apps/asset_manager.pp
@@ -21,6 +21,8 @@
 #   Sets the OAuth Secret Key
 # [*secret_key_base*]
 #   The key for Rails to use when signing/encrypting sessions.
+# [*jwt_auth_secret*]
+#   The secret used to decode JWT authentication tokens.
 # [*mongodb_nodes*]
 #   An array of MongoDB instance hostnames
 # [*mongodb_name*]
@@ -54,6 +56,7 @@ class govuk::apps::asset_manager(
   $oauth_id = undef,
   $oauth_secret = undef,
   $secret_key_base = undef,
+  $jwt_auth_secret = undef,
   $mongodb_nodes,
   $mongodb_name = 'govuk_assets_production',
   $aws_s3_bucket_name = undef,
@@ -115,11 +118,18 @@ class govuk::apps::asset_manager(
     if $secret_key_base {
       govuk::app::envvar {
         "${title}-SECRET_KEY_BASE":
-        varname => 'SECRET_KEY_BASE',
-        value   => $secret_key_base;
+          varname => 'SECRET_KEY_BASE',
+          value   => $secret_key_base;
       }
     }
 
+    if $jwt_auth_secret {
+      govuk::app::envvar {
+        "${title}-JWT_AUTH_SECRET":
+          varname => 'JWT_AUTH_SECRET',
+          value   => $jwt_auth_secret,
+      }
+    }
     govuk::app::envvar::mongodb_uri { $app_name:
       hosts    => $mongodb_nodes,
       database => $mongodb_name,


### PR DESCRIPTION
Trello: https://trello.com/c/dawXVwdW/439-asset-manager-files-are-not-available-when-using-access-tokens-or-if-someone-doesnt-have-asset-manager-permission

This adds the shared JWT authentication secret, used for encrypting and
decrypting tokens, to asset manager. This is added so that asset manager
can determine, based on a token, whether an unauthenticated user should
have access to a resource.