### PR TITLE
Remove unneeded max idle time from check_rabbitmq_messages

### DIFF
--- a/modules/icinga/files/usr/lib/nagios/plugins/check_rabbitmq_messages
+++ b/modules/icinga/files/usr/lib/nagios/plugins/check_rabbitmq_messages
@@ -28,7 +28,6 @@ class RabbitMQCheck:
         self._queue = queue
         self._base_uri = "http://%s:%s/api/" % (host, port)
         self._auth = (username, password)
-        self.allowed_max_idle_time = datetime.timedelta(seconds = 5 * 60)
 
     def error_message(self, response):
         msg = "HTTP %s error" % (response.status_code)


### PR DESCRIPTION
This was inadvertently copied from check_rabbitmq_consumers.