### PR TITLE
Use JSON module to generate valid JSON

### DIFF
--- a/modules/govuk_jenkins/templates/google_api/credentials.json.erb
+++ b/modules/govuk_jenkins/templates/google_api/credentials.json.erb
@@ -1,12 +1,12 @@
-{
-  "type": "service_account",
-  "project_id": "<%= @project_id -%>",
-  "private_key_id": "<%= @private_key_id -%>",
-  "private_key": "<%= @private_key -%>",
-  "client_email": "<%= @client_email -%>",
-  "client_id": "<%= @client_id -%>",
-  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
-  "token_uri": "https://accounts.google.com/o/oauth2/token",
-  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
-  "client_x509_cert_url": "<%= @client_x509_cert_url -%>"
-}
+<%= require "json"; JSON.pretty_generate({
+  type: "service_account",
+  project_id: @project_id,
+  private_key_id: @private_key_id,
+  private_key: @private_key,
+  client_email: @client_email,
+  client_id: @client_id,
+  auth_uri: "https://accounts.google.com/o/oauth2/auth",
+  token_uri: "https://accounts.google.com/o/oauth2/token",
+  auth_provider_x509_cert_url: "https://www.googleapis.com/oauth2/v1/certs",
+  client_x509_cert_url: @client_x509_cert_url,
+}) %>


### PR DESCRIPTION
Currently we use `erb` to expand variables into strings in the JSON for Google API credentials. This can sometimes end up generating malformed JSON (specifically in the case where the private key contains newline characters because JSON doesn't support multiline strings). Instead of generating JSON in this way we can let the JSON library generate the JSON blob thus handling all the special cases of JSON for us.

[Trello Card](https://trello.com/c/serdtvuZ/635-improve-alerting-information-on-the-platform-health-dashboard)