### PR TITLE
Enable scraping alerts job in all environments

### DIFF
--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -66,5 +66,6 @@ govuk_jenkins::job_builder::jobs:
 
 govuk_jenkins::jobs::deploy_cdn::enable_slack_notifications: true
 govuk_jenkins::jobs::deploy_puppet::enable_slack_notifications: true
+govuk_jenkins::jobs::scrape_icinga_alerts_for_dashboard_metrics::run_monthly: true
 govuk_jenkins::jobs::smokey::enable_slack_notifications: true
 govuk_jenkins::jobs::validate_published_dns::run_daily: true

--- a/hieradata/class/staging/jenkins.yaml
+++ b/hieradata/class/staging/jenkins.yaml
@@ -29,6 +29,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::remove_emergency_banner
   - govuk_jenkins::jobs::run_rake_task
   - govuk_jenkins::jobs::run_whitehall_data_migrations
+  - govuk_jenkins::jobs::scrape_icinga_alerts_for_dashboard_metrics
   - govuk_jenkins::jobs::search_fetch_analytics_data
   - govuk_jenkins::jobs::search_index_checks
   - govuk_jenkins::jobs::search_reindex_with_new_schema

--- a/hieradata_aws/class/integration/jenkins.yaml
+++ b/hieradata_aws/class/integration/jenkins.yaml
@@ -32,6 +32,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::run_deploy_lag_badger
   - govuk_jenkins::jobs::run_rake_task
   - govuk_jenkins::jobs::run_whitehall_data_migrations
+  - govuk_jenkins::jobs::scrape_icinga_alerts_for_dashboard_metrics
   - govuk_jenkins::jobs::search_benchmark
   - govuk_jenkins::jobs::search_fetch_analytics_data
   - govuk_jenkins::jobs::search_index_checks

--- a/modules/govuk_jenkins/manifests/jobs/scrape_icinga_alerts_for_dashboard_metrics.pp
+++ b/modules/govuk_jenkins/manifests/jobs/scrape_icinga_alerts_for_dashboard_metrics.pp
@@ -20,6 +20,9 @@
 # [*client_x509_cert_url*]
 #   Specific to access the Google API.
 #
+# [*run_monthly*]
+#   Set to true if the job should run by itself every month.
+#
 class govuk_jenkins::jobs::scrape_icinga_alerts_for_dashboard_metrics (
   $project_id = 'gam-project-v3f-sr7-n9p',
   $private_key_id = undef,
@@ -29,6 +32,7 @@ class govuk_jenkins::jobs::scrape_icinga_alerts_for_dashboard_metrics (
   $client_x509_cert_url = undef,
   $enable_slack_notifications = true,
   $slack_auth_token = undef,
+  $run_monthly = false,
   $app_domain = hiera('app_domain'),
 ) {
 

--- a/modules/govuk_jenkins/templates/jobs/scrape_icinga_alerts_for_dashboard_metrics.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/scrape_icinga_alerts_for_dashboard_metrics.yaml.erb
@@ -18,9 +18,11 @@
     logrotate:
         numToKeep: 10
     triggers:
-        - timed: |
-            TZ=Europe/London
-            0 7 1 * *
+      <% if @run_monthly %>
+      - timed: |
+          TZ=Europe/London
+          0 7 1 * *
+      <% end %>
     properties:
       - build-discarder:
           days-to-keep: 30


### PR DESCRIPTION
This makes it easier to test changes because we can try them before deploying to production.

I've configured the job to not run automatically in the other environments.

[Trello Card](https://trello.com/c/serdtvuZ/635-improve-alerting-information-on-the-platform-health-dashboard)