### PR TITLE
Remove Whitehall Import job for Content Publisher

### DIFF
--- a/hieradata_aws/class/integration/jenkins.yaml
+++ b/hieradata_aws/class/integration/jenkins.yaml
@@ -10,7 +10,6 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::clear_template_cache
   - govuk_jenkins::jobs::clear_varnish_cache
   - govuk_jenkins::jobs::configure_github_repos
-  - govuk_jenkins::jobs::content_publisher_whitehall_import
   - govuk_jenkins::jobs::data_sync
   - govuk_jenkins::jobs::data_sync_complete_integration
   - govuk_jenkins::jobs::deploy_app


### PR DESCRIPTION
https://trello.com/c/mbehnjIS/493-temporarily-turn-off-whitehall-data-import

Previously we configured a Jenkins job on AWS Integration to
periodically import data from Whitehall into Content Publisher.

As we start to give integration access to our private beta partners, we
want to temporarily stop this import to avoid confusion.

Removing the Puppet configuration here will allow us to manually
disable/enable the job while we are in this transitional period.