### PR TITLE
Remove link-checker-api from the /etc/hosts file on staging

### DIFF
--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -399,7 +399,6 @@ hosts::production::backend::app_hostnames:
   - 'event-store'
   - 'hmrc-manuals-api'
   - 'kibana'
-  - 'link-checker-api'
   - 'maslow'
   - 'manuals-publisher'
   - 'publisher'


### PR DESCRIPTION
  As part of the AWS migration