### PR TITLE
Add alert app domain management subdomain to /etc/hosts

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1561,6 +1561,7 @@ hosts::production::management::hosts:
     legacy_aliases:
       - 'monitoring'
       - "grafana.%{hiera('app_domain')}"
+      - "alert.%{hiera('app_domain')}"
     service_aliases:
       - 'alert'
       - 'monitoring'

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -504,6 +504,7 @@ hosts::production::management::hosts:
     legacy_aliases:
       - 'monitoring'
       - "grafana.%{hiera('app_domain')}"
+      - "alert.%{hiera('app_domain')}"
     service_aliases:
       - 'alert'
       - 'monitoring'

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -461,6 +461,7 @@ hosts::production::management::hosts:
     legacy_aliases:
       - 'monitoring'
       - "grafana.%{hiera('app_domain')}"
+      - "alert.%{hiera('app_domain')}"
     service_aliases:
       - 'alert'
       - 'monitoring'


### PR DESCRIPTION
Trying to access Icinga alerts from Jenkins leads to connection errors because there are no appropriate hosts defined which connect to the right server. Using the external domain right now doesn't map to an internal IP address.

We can't use alert.cluster here because the HTTPS server is checking that the domain name matches the server name in the certificate.

[Trello Card](https://trello.com/c/serdtvuZ/635-improve-alerting-information-on-the-platform-health-dashboard)