### PR TITLE
add link checker api to AWS production backend servers

### DIFF
--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -19,6 +19,7 @@ node_class: &node_class
     apps:
       - transition
       - imminence
+      - link-checker-api
       - local-links-manager
   bouncer:
     apps:


### PR DESCRIPTION
# Context

As part of the AWS migration, there is a need to re-enable the `link-checker-api` application on the AWS Production Backend machines.

# Decisions

1. add `link-checker-api` to the list of applications on AWS Production Backend machines. 
    This PR is similar to the AWS Staging migration in [here](https://github.com/alphagov/govuk-puppet/pull/8349)