### PR TITLE
remove link-checker-api from carrenza production /etc/hosts

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -305,7 +305,6 @@ hosts::production::backend::app_hostnames:
   - 'event-store'
   - 'hmrc-manuals-api'
   - 'kibana'
-  - 'link-checker-api'
   - 'maslow'
   - 'manuals-publisher'
   - 'publisher'


### PR DESCRIPTION
# Context

As part of the AWS migration, the link-checker-api will now live in AWS and therefore we need to remove the link-checker-api from the /etc/hosts of Carrenza hosts so that the hosts resolve to the the link-checker-api in AWS.

# Decisions

1. remove the `link-checker-api` from the hosts definitions in Carrenza