### PR TITLE
Add the correct memory threshold

### DIFF
--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_rds_memory
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_rds_memory
@@ -65,8 +65,8 @@ import boto3
 #################################
 parser = argparse.ArgumentParser()
 parser.add_argument("-r","--region", type=str, choices=['us-east-1','eu-west-1'], help="AWS region to check")
-parser.add_argument("-w","--warning", type=float, help="Value(GB) at which to raise a warning alert (5.0)", default=5.0)
-parser.add_argument("-c","--critical", type=float, help="Value(GB) at which to raise a critical alert (2.0)", default=2.0)
+parser.add_argument("-w","--warning", type=float, help="Value(GB) at which to raise a warning alert (2.0)", default=2.0)
+parser.add_argument("-c","--critical", type=float, help="Value(GB) at which to raise a critical alert (1.0)", default=1.0)
 parser.add_argument("-i","--instanceid", type=str, help="Instanceid", default=0)
 args = parser.parse_args()
 

--- a/modules/monitoring/manifests/checks/rds_config.pp
+++ b/modules/monitoring/manifests/checks/rds_config.pp
@@ -23,8 +23,8 @@ define monitoring::checks::rds_config (
   $region = undef,
   $cpu_warning = 80,
   $cpu_critical = 90,
-  $memory_warning = 20,
-  $memory_critical = 10,
+  $memory_warning = 2,
+  $memory_critical = 1,
   $storage_warning = 20,
   $storage_critical = 10,
 ){


### PR DESCRIPTION
Fix the issue with the threshold alerting at the wrong times. This I believe was caused by the decimal point within the code. Please review trello card for more infromation: https://trello.com/c/GJDx8cFx/1755-adjust-mysql-rds-instance-memory-warning-threshold

