### PR TITLE
Remove transition-postgres alerts from PagerDuty

### DIFF
--- a/hieradata/class/transition_postgresql_master.yaml
+++ b/hieradata/class/transition_postgresql_master.yaml
@@ -3,8 +3,6 @@
 govuk_safe_to_reboot::can_reboot: 'no'
 govuk_safe_to_reboot::reason: 'Single point of failure for Transition application'
 
-icinga::client::contact_groups: 'urgent-priority'
-
 lv:
   data:
     pv: '/dev/sdb1'

--- a/hieradata/class/transition_postgresql_primary.yaml
+++ b/hieradata/class/transition_postgresql_primary.yaml
@@ -4,8 +4,6 @@ postgresql::globals::version: '9.5'
 govuk_safe_to_reboot::can_reboot: 'no'
 govuk_safe_to_reboot::reason: 'Single point of failure for Transition application'
 
-icinga::client::contact_groups: 'urgent-priority'
-
 lv:
   data:
     pv: '/dev/sdb1'

--- a/hieradata/class/transition_postgresql_slave.yaml
+++ b/hieradata/class/transition_postgresql_slave.yaml
@@ -2,8 +2,6 @@
 govuk_safe_to_reboot::can_reboot: 'no'
 govuk_safe_to_reboot::reason: 'Single point of failure for Bouncer application'
 
-icinga::client::contact_groups: 'urgent-priority'
-
 lv:
   postgresql:
     pv: '/dev/sdb1'

--- a/hieradata/class/transition_postgresql_standby.yaml
+++ b/hieradata/class/transition_postgresql_standby.yaml
@@ -4,8 +4,6 @@ postgresql::globals::version: '9.5'
 govuk_safe_to_reboot::can_reboot: 'no'
 govuk_safe_to_reboot::reason: 'Single point of failure for Bouncer application'
 
-icinga::client::contact_groups: 'urgent-priority'
-
 lv:
   postgresql:
     pv: '/dev/sdb1'


### PR DESCRIPTION
- We have migrated the service and it is now living in AWS for several
weeks.

- We will turn off these machines, but not delete them until the
migration is complete

- We have to remove PagerDuty triggers before we can turn off the
machnines safely

solo: @schmie