### PR TITLE
Remove link-checker-api from the backend load balancers

### DIFF
--- a/modules/govuk/manifests/node/s_backend_lb.pp
+++ b/modules/govuk/manifests/node/s_backend_lb.pp
@@ -56,7 +56,6 @@ class govuk::node::s_backend_lb (
     'content-performance-manager',
     'content-publisher',
     'content-tagger',
-    'link-checker-api',
     'manuals-publisher',
     'maslow',
     'publisher',


### PR DESCRIPTION
  link-checker-api has been migrated to AWS and is no longer in use
on Carrenza