### PR TITLE
Trello-1731: Gor Replay ste header

### DIFF
--- a/hieradata/class/staging/content_store.yaml
+++ b/hieradata/class/staging/content_store.yaml
@@ -5,5 +5,6 @@ nscd::config::dns_cache: 'yes'
 router::gor::add_hosts: false
 router::gor::replay_targets:
   'content-store.staging.govuk.digital': {}
+router::gor::http_set_header: 'Forwarded:'
 
 router::gor::input_raw: ':3068'

--- a/modules/router/manifests/gor.pp
+++ b/modules/router/manifests/gor.pp
@@ -14,7 +14,8 @@
 class router::gor (
   $replay_targets = {},
   $add_hosts = true,
-  $input_raw = '127.0.0.1:7999'
+  $input_raw = '127.0.0.1:7999',
+  $http_set_header = 'X-Forwarded-Host:'
 ) {
   validate_hash($replay_targets)
 
@@ -45,7 +46,7 @@ class router::gor (
       '-http-allow-method' => [
         'GET', 'HEAD', 'OPTIONS',
       ],
-      '-http-set-header'   => 'X-Forwarded-Host:',
+      '-http-set-header'   => $http_set_header,
     },
     envvars => {
       'GODEBUG' => 'netdns=go',


### PR DESCRIPTION
The content-store application only supports the "Forwarded:" header
therefore the "X-Forwarded-Host:" header can be changed for the content
store.
NOTE: defaulting to the "X-Forwarded-Host:" header as the cache router
that also uses the gor replay class needs to support this.

Pair: @ronocg <conor.glynn@digital.cabinet-office.gov.uk>
& @fredericfran-gds <frederic.francois@digital.cabinet-office.gov.uk>