### PR TITLE
add carrenza hosts to content stores and draft ones.

### DIFF
--- a/modules/govuk/manifests/node/s_content_store.pp
+++ b/modules/govuk/manifests/node/s_content_store.pp
@@ -8,4 +8,9 @@ class govuk::node::s_content_store inherits govuk::node::s_base {
 
   # If we miss all the apps, throw a 500 to be caught by the cache nginx
   nginx::config::vhost::default { 'default': }
+
+  if ($::aws_environment == 'staging') or ($::aws_environment == 'production') {
+    include ::hosts::default
+    include ::hosts::backend_migration
+  }
 }

--- a/modules/govuk/manifests/node/s_draft_content_store.pp
+++ b/modules/govuk/manifests/node/s_draft_content_store.pp
@@ -16,4 +16,9 @@ class govuk::node::s_draft_content_store() inherits govuk::node::s_base {
   govuk_envvar {
     'PLEK_HOSTNAME_PREFIX': value => 'draft-';
   }
+
+  if ($::aws_environment == 'staging') or ($::aws_environment == 'production') {
+    include ::hosts::default
+    include ::hosts::backend_migration
+  }
 }


### PR DESCRIPTION
# Context
During the AWS migration, the content-store and the draft-content-stores need to contact some machines in Carrenza and therefore, a hosts file need to be included on the these machines so that they can obtain the IP address of Carrenza hosted govuk services.

# Decisions
1. include the backend migration list to the content-store and draft-content-store machines

# Deferred actions
1. Need to clean up later based on decision whether to include the Carrenza hosts file on all AWS machines.