### PR TITLE
Ignore the CPM database by default for local data replication

### DIFF
--- a/development-vm/replication/common-args.sh
+++ b/development-vm/replication/common-args.sh
@@ -1,5 +1,6 @@
 #! /usr/bin/env bash
-#
+# shellcheck disable=SC2034
+
 set -eu
 
 . ./status_functions.sh

--- a/development-vm/replication/common-args.sh
+++ b/development-vm/replication/common-args.sh
@@ -43,7 +43,7 @@ RENAME_DATABASES=true
 DRY_RUN=false
 KEEP_BACKUPS=false
 # By default, ignore large databases which are not useful when replicated.
-IGNORE="event_store transition backdrop support_contacts draft_content_store imminence draft_router"
+IGNORE="event_store transition backdrop support_contacts draft_content_store imminence draft_router content_performance_manager"
 
 # Test whether the given value is in the ignore list.
 function ignored() {

--- a/development-vm/replication/common-args.sh
+++ b/development-vm/replication/common-args.sh
@@ -107,5 +107,8 @@ do
     k )
       KEEP_BACKUPS=true
       ;;
+    * )
+      usage
+      exit 1
   esac
 done

--- a/development-vm/replication/common-args.sh
+++ b/development-vm/replication/common-args.sh
@@ -50,7 +50,7 @@ IGNORE="event_store transition backdrop support_contacts draft_content_store imm
 function ignored() {
   local value=$1
   for ignore_match in $IGNORE; do
-    if [ $ignore_match == $value ]; then
+    if [ "$ignore_match" == "$value" ]; then
       return 0
     fi
   done

--- a/lib/tasks/shellcheck.rake
+++ b/lib/tasks/shellcheck.rake
@@ -21,7 +21,7 @@ namespace :shell do
     end
 
     if files.length > 0 then
-      shellcheck_cmd = ['shellcheck', files].flatten
+      shellcheck_cmd = ['shellcheck', '-e', 'SC2034', files].flatten
       fail if not system(*shellcheck_cmd)
     end
   end


### PR DESCRIPTION
It's large enough (~100GB on production) that it'll cause problems
with the govuk-puppet devleopment-vm, which has only 150GB of storage.