### PR TITLE
Revert "Staging-Migr-plan: etc hosts for content-node migration"

### DIFF
--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -382,14 +382,6 @@ hosts::production::backend::hosts:
   whitehall-mysql-slave-3:
     ip: '10.2.11.31'
 
-hosts::production::api::app_hostnames:
-  - 'backdrop-read'
-  - 'backdrop-write'
-  - 'rummager'
-  - 'search'
-
-hosts::production::api::draft_app_hostnames:
-
 hosts::production::backend::app_hostnames:
   - 'asset-manager'
   - 'canary-backend'


### PR DESCRIPTION
# Content

We need to reverts alphagov/govuk-puppet#8392 which removed Carrenza content-store data in the Carrenza Staging /etc/hosts because we want to run the migration from Step 1 again.

# Decisions

1. revert the PR through the Github button. 

