### PR TITLE
Allow deploy app job to use AWS credentials

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/deploy_app.pp
+++ b/modules/govuk_jenkins/manifests/jobs/deploy_app.pp
@@ -20,6 +20,12 @@
 # [*enable_slack_notifications*]
 #   Set to true to post details of a deployment into a Slack channel.
 #
+# [*aws_access_key_id*]
+#   AWS credential used when deploying from AWS CodeCommit.
+#
+# [*aws_secret_access_key*]
+#   AWS credential used when deploying from AWS CodeCommit.
+#
 class govuk_jenkins::jobs::deploy_app (
   $app_domain = undef,
   $auth_token = undef,
@@ -29,6 +35,8 @@ class govuk_jenkins::jobs::deploy_app (
   $graphite_port = '80',
   $notify_release_app = true,
   $enable_slack_notifications = true,
+  $aws_access_key_id = undef,
+  $aws_secret_access_key = undef,
 ) {
   if $::aws_migration {
     $aws_deploy = true

--- a/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
@@ -66,6 +66,14 @@
                 credential-id: govukci-docker-hub
                 username: DOCKER_HUB_USERNAME
                 password: DOCKER_HUB_PASSWORD
+        - inject-passwords:
+            global: false
+            mask-password-params: true
+            job-passwords:
+                - name: AWS_ACCESS_KEY_ID
+                  password: '<%= @aws_access_key_id %>'
+                - name: AWS_SECRET_ACCESS_KEY
+                  password: '<%= @aws_secret_access_key %>'
         - timestamps
     parameters:
         - choice:


### PR DESCRIPTION
When deploying from AWS CodeCommit the correct access is required
to checkout from this remote, so include the relevant AWS credentials
in the deploy job.

cc @rubenarakelyan 