### PR TITLE
Enable the secure flag on CKAN's authorisation cookie

### DIFF
--- a/modules/govuk/templates/ckan/ckan.ini.erb
+++ b/modules/govuk/templates/ckan/ckan.ini.erb
@@ -34,6 +34,7 @@ app_instance_uuid = fdee5057-84ad-4b96-804a-d8c2dc027721
 who.config_file = %(here)s/who.ini
 who.log_level = warning
 who.log_file = %(cache_dir)s/who_log.ini
+who.secure = True
 
 ## Database Settings
 sqlalchemy.url = <%= "postgresql://#{@db_username}:#{@db_password}@#{@db_hostname}/#{@db_name}"%>


### PR DESCRIPTION
This determines whether the secure flag will be set for the `repoze.who` authorisation cookie. If True, the cookie will be sent over HTTPS, so setting that here to enable this for data.gov.uk's CKAN.

Trello card: https://trello.com/c/mrrHcGci/108-finding-311-enable-whosecure-in-ckan-config