### PR TITLE
Revert "Revert "Staging-Migr-plan: etc hosts for content-node migration""

### DIFF
--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -382,6 +382,14 @@ hosts::production::backend::hosts:
   whitehall-mysql-slave-3:
     ip: '10.2.11.31'
 
+hosts::production::api::app_hostnames:
+  - 'backdrop-read'
+  - 'backdrop-write'
+  - 'rummager'
+  - 'search'
+
+hosts::production::api::draft_app_hostnames:
+
 hosts::production::backend::app_hostnames:
   - 'asset-manager'
   - 'canary-backend'


### PR DESCRIPTION
Reverts alphagov/govuk-puppet#8400

# Context

As we go the migration again, we need to remove the content-store and the draft ones from the /etc/hosts in Carrenza.

# Decisions

- Re-revert, also known as, apply the first PR which removes the /etc/hosts entries.