### PR TITLE
Revert "Allow deploy app job to use AWS credentials"

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/deploy_app.pp
+++ b/modules/govuk_jenkins/manifests/jobs/deploy_app.pp
@@ -20,12 +20,6 @@
 # [*enable_slack_notifications*]
 #   Set to true to post details of a deployment into a Slack channel.
 #
-# [*aws_access_key_id*]
-#   AWS credential used when deploying from AWS CodeCommit.
-#
-# [*aws_secret_access_key*]
-#   AWS credential used when deploying from AWS CodeCommit.
-#
 class govuk_jenkins::jobs::deploy_app (
   $app_domain = undef,
   $auth_token = undef,
@@ -35,8 +29,6 @@ class govuk_jenkins::jobs::deploy_app (
   $graphite_port = '80',
   $notify_release_app = true,
   $enable_slack_notifications = true,
-  $aws_access_key_id = undef,
-  $aws_secret_access_key = undef,
 ) {
   if $::aws_migration {
     $aws_deploy = true

--- a/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
@@ -66,14 +66,6 @@
                 credential-id: govukci-docker-hub
                 username: DOCKER_HUB_USERNAME
                 password: DOCKER_HUB_PASSWORD
-        - inject-passwords:
-            global: false
-            mask-password-params: true
-            job-passwords:
-                - name: AWS_ACCESS_KEY_ID
-                  password: '<%= @aws_access_key_id %>'
-                - name: AWS_SECRET_ACCESS_KEY
-                  password: '<%= @aws_secret_access_key %>'
         - timestamps
     parameters:
         - choice:


### PR DESCRIPTION
Reverts alphagov/govuk-puppet#8401

This PR introduced some access credentials to allow us to deploy from AWS repos, this workd but these credentials seem to conflict with other later build steps causing the error `An error occurred (UnauthorizedOperation) when calling the DescribeInstances operation: You are not authorized to perform this operation.`