### PR TITLE
remove content-store and draft-content-store lbs from /etc/hosts carrenza

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1267,12 +1267,8 @@ hosts::production::api::hosts:
 hosts::production::api::app_hostnames:
   - 'backdrop-read'
   - 'backdrop-write'
-  - 'content-store'
   - 'rummager'
   - 'search'
-
-hosts::production::api::draft_app_hostnames:
-  - 'draft-content-store'
 
 hosts::production::backend::hosts:
   asset-master-1:

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -382,14 +382,6 @@ hosts::production::backend::hosts:
   whitehall-mysql-slave-3:
     ip: '10.2.11.31'
 
-hosts::production::api::app_hostnames:
-  - 'backdrop-read'
-  - 'backdrop-write'
-  - 'rummager'
-  - 'search'
-
-hosts::production::api::draft_app_hostnames:
-
 hosts::production::backend::app_hostnames:
   - 'asset-manager'
   - 'canary-backend'


### PR DESCRIPTION
# Context

As part of the AWS migration, when the content-store and draft ones are migrated to AWS, the /etc/hosts entries in Carrenza for these services should be removed so that the services resolve the AWS located services using the public DNS.

# Decisions
1. remove the LB entries for the content store from the /etc/hosts of Carrenza
2. cleanup to remove the server IPs is left for a later date since this action was not done in the staging rehearsal.

