### PR TITLE
Add /api/batch_search.json

### DIFF
--- a/modules/govuk/templates/publicapi_nginx_extra_config.erb
+++ b/modules/govuk/templates/publicapi_nginx_extra_config.erb
@@ -21,10 +21,10 @@
   <%- if scope.lookupvar('::aws_migration') %>
   set $upstream_rummager_api <%= @privateapi_protocol %>://<%= @rummager_api %>;
   <%- end %>
-  location ~ ^/api/search.json {
+  location ~ ^/api/(search|batch_search).json {
     expires 30m;
 
-    rewrite ^/api/search.json(.*) /search.json$1 break;
+    rewrite ^/api/([a-z_]+).json(.*) /$1.json$2 break;
 
     add_header Access-Control-Allow-Origin *;
     proxy_set_header Host <%= @rummager_api %>;


### PR DESCRIPTION
This proxies the request to Rummager and makes it much easier to debug working with the API since the frontend apps can run against the live GOV.UK and still use that API.

Endpoint added in https://github.com/alphagov/rummager/pull/1299.