### PR TITLE
Always point /api/content to AWS

### DIFF
--- a/modules/govuk/manifests/app/publicapi.pp
+++ b/modules/govuk/manifests/app/publicapi.pp
@@ -44,7 +44,7 @@ define govuk::app::publicapi (
   } else {
     $whitehallapi = "whitehall-frontend.${app_domain}"
     $rummager_api = "search.${app_domain}"
-    $content_store_api = "${prefix}content-store.${app_domain}"
+    $content_store_api = "${prefix}content-store.${::environment}.govuk-internal.digital"
 
     $full_domain = "${app_name}.${app_domain}"
   }


### PR DESCRIPTION
Content Store has been migrated to AWS, so always point `/api/content` to AWS even when accessed via Carrenza.