### PR TITLE
add support and support api to AWS Staging backend

### DIFF
--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -22,6 +22,8 @@ node_class: &node_class
       - link-checker-api
       - local-links-manager
       - signon
+      - support
+      - support-api
   bouncer:
     apps:
       - bouncer


### PR DESCRIPTION
# Context

As part of the AWS migration, we need to add the `support` and `support-api` application back on the AWS Staging backend servers for the `support` app migration.

# Decisions
1. Add the `support` and `support-api` apps to the list of apps on the AWS Staging backend servers.