### PR TITLE
add support and support api to AWS Production backend

### DIFF
--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -21,6 +21,8 @@ node_class: &node_class
       - imminence
       - link-checker-api
       - local-links-manager
+      - support
+      - support-api
   bouncer:
     apps:
       - bouncer


### PR DESCRIPTION
# Context

As part of the AWS migration, we need to add the `support` and `support-api` application back on the AWS Production backend servers for the `support` app migration.

# Decisions
1. Add the `support` and `support-api` apps to the list of apps on the AWS Production backend servers.