### PR TITLE
Enable finder-frontend Q&A to content feature in integration

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -30,6 +30,7 @@ govuk::apps::email_alert_api::email_address_override_whitelist_only: true
 govuk::apps::email_alert_api::delivery_request_threshold: "3000"
 govuk::apps::email_alert_frontend::subscription_management_enabled: true
 govuk::apps::finder_frontend::qa_enabled: true
+govuk::apps::finder_frontend::qa_to_content_enabled: true
 govuk::apps::govuk_crawler_worker::enabled: false
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
 govuk::apps::kibana::logit_environment: 2694f14b-6519-4607-81f2-8a2130e5aaec

--- a/modules/govuk/manifests/apps/finder_frontend.pp
+++ b/modules/govuk/manifests/apps/finder_frontend.pp
@@ -24,6 +24,9 @@
 # [*qa_enabled*]
 #   Whether the Q&A feature is enabled
 #
+# [*qa_to_content_enabled*]
+#   Whether the Q&A to content feature is enabled
+#
 class govuk::apps::finder_frontend(
   $port = '3062',
   $enabled = false,
@@ -33,6 +36,7 @@ class govuk::apps::finder_frontend(
   $secret_key_base = undef,
   $email_alert_api_bearer_token = undef,
   $qa_enabled = false,
+  $qa_to_content_enabled = false,
 ) {
 
   if $enabled {
@@ -66,6 +70,14 @@ class govuk::apps::finder_frontend(
     govuk::app::envvar {
       "${title}-FINDER_FRONTEND_ENABLE_QA":
           varname => 'FINDER_FRONTEND_ENABLE_QA',
+          value   => 'yes';
+    }
+  }
+
+  if $qa_to_content_enabled {
+    govuk::app::envvar {
+      "${title}-FINDER_FRONTEND_ENABLE_QA_TO_CONTENT":
+          varname => 'FINDER_FRONTEND_ENABLE_QA_TO_CONTENT',
           value   => 'yes';
     }
   }


### PR DESCRIPTION
This commit enables the new finder-frontend Q&A to content feature in integration only for testing purposes.