### PR TITLE
Enable authentication in Content Store

### DIFF
--- a/hieradata/class/draft_content_store.yaml
+++ b/hieradata/class/draft_content_store.yaml
@@ -6,6 +6,9 @@ govuk::apps::content_store::mongodb_nodes:
   - 'api-mongo-1.api'
   - 'api-mongo-2.api'
   - 'api-mongo-3.api'
+
+govuk::apps::content_store::oauth_id: "%{hiera('govuk::apps::content_store::draft_oauth_id')}"
+govuk::apps::content_store::oauth_secret: "%{hiera('govuk::apps::content_store::draft_oauth_secret')}"
 govuk::apps::content_store::vhost: 'draft-content-store'
 
 lv:

--- a/hieradata_aws/class/draft_content_store.yaml
+++ b/hieradata_aws/class/draft_content_store.yaml
@@ -6,4 +6,6 @@ govuk::apps::content_store::mongodb_nodes:
   - 'mongo-1'
   - 'mongo-2'
   - 'mongo-3'
+govuk::apps::content_store::oauth_id: "%{hiera('govuk::apps::content_store::draft_oauth_id')}"
+govuk::apps::content_store::oauth_secret: "%{hiera('govuk::apps::content_store::draft_oauth_secret')}"
 govuk::apps::content_store::vhost: 'draft-content-store'

--- a/modules/govuk/manifests/apps/content_store.pp
+++ b/modules/govuk/manifests/apps/content_store.pp
@@ -48,6 +48,12 @@
 # [*unicorn_worker_processes*]
 #   The number of unicorn workers to run for an instance of this app
 #
+# [*oauth_id*]
+#   The OAuth ID used to identify the app to GOV.UK Signon (in govuk-secrets)
+#
+# [*oauth_secret*]
+#   The OAuth secret used to authenticate the app to GOV.UK Signon (in govuk-secrets)
+#
 class govuk::apps::content_store(
   $port = '3068',
   $mongodb_nodes,
@@ -63,6 +69,8 @@ class govuk::apps::content_store(
   $sentry_dsn = undef,
   $unicorn_worker_processes = undef,
   $app_domain = undef,
+  $oauth_id = undef,
+  $oauth_secret = undef,
 ) {
   $app_name = 'content-store'
 
@@ -107,6 +115,12 @@ class govuk::apps::content_store(
     "${title}-DEFAULT_TTL":
       varname => 'DEFAULT_TTL',
       value   => $default_ttl;
+    "${title}-OAUTH_ID":
+      varname => 'OAUTH_ID',
+      value   => $oauth_id;
+    "${title}-OAUTH_SECRET":
+      varname => 'OAUTH_SECRET',
+      value   => $oauth_secret;
     "${title}-PUBLISHING_API_BEARER_TOKEN":
       varname => 'PUBLISHING_API_BEARER_TOKEN',
       value   => $publishing_api_bearer_token;

--- a/modules/govuk/manifests/apps/publishing_api.pp
+++ b/modules/govuk/manifests/apps/publishing_api.pp
@@ -16,9 +16,16 @@
 #   Is a URL that tells publishing API which content store to save
 #   published content in.
 #
+# [*content_store_bearer_token*]
+#   The bearer token that will be used to authenticate with the content store
+#
 # [*draft_content_store*]
 #   Is a URL that tells publishing API which content store to save
 #   draft content in.
+#
+# [*draft_content_store_bearer_token*]
+#   The bearer token that will be used to authenticate with the draft content
+#   store
 #
 # [*suppress_draft_store_502_error*]
 #   Suppresses "502 Bad Gateway" returned by nginx when publishing API
@@ -110,7 +117,9 @@ class govuk::apps::publishing_api(
   $ensure = 'present',
   $port = '3093',
   $content_store = '',
+  $content_store_bearer_token = undef,
   $draft_content_store = '',
+  $draft_content_store_bearer_token = undef,
   $suppress_draft_store_502_error = '',
   $sentry_dsn = undef,
   $secret_key_base = undef,
@@ -182,9 +191,15 @@ class govuk::apps::publishing_api(
       "${title}-CONTENT_STORE":
         varname => 'CONTENT_STORE',
         value   => $content_store;
+      "${title}-CONTENT_STORE_BEARER_TOKEN":
+        varname => 'CONTENT_STORE_BEARER_TOKEN',
+        value   => $content_store_bearer_token;
       "${title}-DRAFT_CONTENT_STORE":
         varname => 'DRAFT_CONTENT_STORE',
         value   => $draft_content_store;
+      "${title}-DRAFT_CONTENT_STORE_BEARER_TOKEN":
+        varname => 'DRAFT_CONTENT_STORE_BEARER_TOKEN',
+        value   => $draft_content_store_bearer_token;
       "${title}-SUPPRESS_DRAFT_STORE_502_ERROR":
         varname => 'SUPPRESS_DRAFT_STORE_502_ERROR',
         value   => $suppress_draft_store_502_error;


### PR DESCRIPTION
This adds the env vars needed for using GDS-SSO between these two apps.

One thing I wasn't sure on, was what the art is for doing different secret hieradata for draft and live versions of apps. I could only find examples of non-secret. The approach I took was to create variables in secret hieradata e.g `govuk::apps::content_store::draft_oauth_id` and then use that to override the hieradata on the host specific file: https://github.com/alphagov/govuk-puppet/blob/aab72ec0ec0371ff45225941eb0a03a78a4050fb/hieradata/class/draft_content_store.yaml#L10-L11

Not sure if anyone knows a reason why that might go wrong though? I'm assuming these classes can handle being sent extra undeclared variables they ignore and that secrets are populated way earlier than host hieradata.