### PR TITLE
normalize support contacts sync  config file names

### DIFF
--- a/hieradata/node/postgresql-primary-1.backend.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/postgresql-primary-1.backend.staging.publishing.service.gov.uk.yaml
@@ -120,7 +120,7 @@ govuk_env_sync::tasks:
     temppath: "/var/lib/autopostgresqlbackup/service-manual-publisher_production"
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
-  "push_support_contacts_production_daily":
+  "push_support-contacts_production_daily":
     ensure: "present"
     hour: "0"
     minute: "3"

--- a/hieradata_aws/class/staging/db_admin.yaml
+++ b/hieradata_aws/class/staging/db_admin.yaml
@@ -164,7 +164,7 @@ govuk_env_sync::tasks:
     temppath: "/tmp/service-manual-publisher_production"
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
-  "pull_support_contacts_production_daily":
+  "pull_support-contacts_production_daily":
     ensure: "present"
     hour: "2"
     minute: "3"


### PR DESCRIPTION
# Contents

When putting the `support-contacts` data sync config files, there was a mistake in the format of the cfg file name.

# Decisions
1. Correct the formatting of the data sync config files.