### PR TITLE
Enable deploy from aws

### DIFF
--- a/modules/govuk_jenkins/files/ssh-config
+++ b/modules/govuk_jenkins/files/ssh-config
@@ -1,2 +1,0 @@
-Host *
-  StrictHostKeyChecking no

--- a/modules/govuk_jenkins/manifests/ssh_key.pp
+++ b/modules/govuk_jenkins/manifests/ssh_key.pp
@@ -16,11 +16,15 @@
 # [*home_dir*]
 #   Home directory of the Jenkins user
 #
+# [*aws_ssh_key_id*]
+#   AWS SSH key config ID (visible in AWS console).
+#
 class govuk_jenkins::ssh_key (
-  $private_key  = undef,
-  $public_key   = undef,
-  $jenkins_user = 'jenkins',
-  $home_dir     = '/var/lib/jenkins',
+  $private_key    = undef,
+  $public_key     = undef,
+  $jenkins_user   = 'jenkins',
+  $home_dir       = '/var/lib/jenkins',
+  $aws_ssh_key_id = undef,
 ) {
   $ssh_dir = "${home_dir}/.ssh"
   $private_key_filename = "${ssh_dir}/id_rsa"
@@ -34,7 +38,7 @@ class govuk_jenkins::ssh_key (
   }
 
   file { "${ssh_dir}/config":
-    source  => 'puppet:///modules/govuk_jenkins/ssh-config',
+    content => template('govuk_jenkins/ssh-config.erb'),
     owner   => $jenkins_user,
     group   => $jenkins_user,
     mode    => '0600',

--- a/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
@@ -30,11 +30,9 @@
 
             if [ "$DEPLOY_FROM_AWS_CODECOMMIT" == "true" ]; then
               export AWS_REGION=eu-west-1
-              export GIT_ORIGIN_PREFIX="https://git-codecommit.${AWS_REGION}.amazonaws.com/v1/repos"
+              export GIT_ORIGIN_PREFIX="ssh://git-codecommit.${AWS_REGION}.amazonaws.com/v1/repos"
               export APP_DEPLOYMENT_GIT_URL="${GIT_ORIGIN_PREFIX}/govuk-app-deployment"
               export APP_DEPLOYMENT_SECRET_GIT_URL="${GIT_ORIGIN_PREFIX}/govuk-app-deployment-secrets"
-              git config --global credential.helper '!aws codecommit credential-helper $@'
-              git config --global credential.UseHttpPath true
             else
               export APP_DEPLOYMENT_GIT_URL="git@github.com:alphagov/govuk-app-deployment.git"
               export APP_DEPLOYMENT_SECRET_GIT_URL="git@github.com:alphagov/govuk-app-deployment-secrets.git"

--- a/modules/govuk_jenkins/templates/ssh-config.erb
+++ b/modules/govuk_jenkins/templates/ssh-config.erb
@@ -1,0 +1,6 @@
+Host *
+  StrictHostKeyChecking no
+
+Host git-codecommit.*.amazonaws.com
+  User <%= @aws_ssh_key_id %>
+  IdentityFile <%= @private_key_filename %>


### PR DESCRIPTION
Enable deploy from AWS CodeCommit by adding the necessary SSH config for the Jenkins user.

This PR relies on secrets in https://github.com/alphagov/govuk-secrets/pull/516 for use in the codecommit section of the Jenkins SSH config file