### PR TITLE
Ensure data upload dir present

### DIFF
--- a/hieradata/node/postgresql-primary-1.backend.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/postgresql-primary-1.backend.staging.publishing.service.gov.uk.yaml
@@ -120,7 +120,7 @@ govuk_env_sync::tasks:
     temppath: "/var/lib/autopostgresqlbackup/service-manual-publisher_production"
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
-  "push_support_contacts_production_daily":
+  "push_support-contacts_production_daily":
     ensure: "present"
     hour: "0"
     minute: "3"

--- a/hieradata_aws/class/staging/db_admin.yaml
+++ b/hieradata_aws/class/staging/db_admin.yaml
@@ -164,7 +164,7 @@ govuk_env_sync::tasks:
     temppath: "/tmp/service-manual-publisher_production"
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
-  "pull_support_contacts_production_daily":
+  "pull_support-contacts_production_daily":
     ensure: "present"
     hour: "2"
     minute: "3"

--- a/modules/govuk/manifests/apps/support_api.pp
+++ b/modules/govuk/manifests/apps/support_api.pp
@@ -127,7 +127,7 @@ class govuk::apps::support_api(
     $data_dir_user = 'assets'
   }
 
-  file { ['/data/uploads/support-api', '/data/uploads/support-api/csvs']:
+  file { ['/data/uploads', '/data/uploads/support-api', '/data/uploads/support-api/csvs']:
     ensure => directory,
     mode   => '0775',
     owner  => $data_dir_user,


### PR DESCRIPTION
# Context

As part of the AWS migration of support-api, there is a need to deploy the `support-api` app on the Backend boxes but unfortunately the puppet run fails because `/data/uploads` directory is not present.

# Decisions

1. Ensure the directory is created in puppet code