### PR TITLE
Increase number of unicorn workers on finder-frontend from 2 to 4

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -456,6 +456,7 @@ govuk::apps::email_alert_service::rabbitmq::queue_size_warning_threshold: 5
 govuk::apps::finder_frontend::enabled: true
 govuk::apps::finder_frontend::nagios_memory_warning: 2000
 govuk::apps::finder_frontend::nagios_memory_critical: 2500
+govuk::apps::finder_frontend::unicorn_worker_processes: "4"
 
 govuk::apps::frontend::nagios_memory_warning: 1200
 govuk::apps::frontend::nagios_memory_critical: 1400

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -478,6 +478,7 @@ govuk::apps::email_alert_service::rabbitmq::queue_size_warning_threshold: 5
 govuk::apps::finder_frontend::enabled: true
 govuk::apps::finder_frontend::nagios_memory_warning: 2000
 govuk::apps::finder_frontend::nagios_memory_critical: 2500
+govuk::apps::finder_frontend::unicorn_worker_processes: "4"
 
 govuk::apps::frontend::nagios_memory_warning: 1200
 govuk::apps::frontend::nagios_memory_critical: 1400

--- a/modules/govuk/manifests/apps/finder_frontend.pp
+++ b/modules/govuk/manifests/apps/finder_frontend.pp
@@ -37,19 +37,21 @@ class govuk::apps::finder_frontend(
   $email_alert_api_bearer_token = undef,
   $qa_enabled = false,
   $qa_to_content_enabled = false,
+  $unicorn_worker_processes = undef,
 ) {
 
   if $enabled {
     govuk::app { 'finder-frontend':
-      app_type               => 'rack',
-      port                   => $port,
-      sentry_dsn             => $sentry_dsn,
-      health_check_path      => '/cma-cases',
-      log_format_is_json     => true,
-      asset_pipeline         => true,
-      asset_pipeline_prefix  => 'finder-frontend',
-      nagios_memory_warning  => $nagios_memory_warning,
-      nagios_memory_critical => $nagios_memory_critical,
+      app_type                 => 'rack',
+      port                     => $port,
+      sentry_dsn               => $sentry_dsn,
+      health_check_path        => '/cma-cases',
+      log_format_is_json       => true,
+      asset_pipeline           => true,
+      asset_pipeline_prefix    => 'finder-frontend',
+      nagios_memory_warning    => $nagios_memory_warning,
+      nagios_memory_critical   => $nagios_memory_critical,
+      unicorn_worker_processes => $unicorn_worker_processes,
     }
   }
 


### PR DESCRIPTION
This commit increases the number of unicorn workers from 2 to 6 per instance. This allows more requests to be handled simultaneously. This affects proper finders and advanced search and should make them able to handle larger numbers of unique requests at the same time 

### Testing
This was tested using gatling on staging. In general it has helped to lower the upper limits of response time. The following screenshots were from data following tests involving ~5k requests using about 500 unique URL's

Before
<img width="456" alt="screen shot 2018-12-10 at 13 57 46" src="https://user-images.githubusercontent.com/24547207/49737065-bd33bd00-fc83-11e8-896e-0bb94e83d301.png">

After
<img width="458" alt="screen shot 2018-12-10 at 13 57 57" src="https://user-images.githubusercontent.com/24547207/49737071-c1f87100-fc83-11e8-88e8-9c0f705ed1e4.png">

