### PR TITLE
add asset manager app on AWS backend for both production and staging

### DIFF
--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -17,6 +17,7 @@ node_class: &node_class
       - asset_env_sync
   backend:
     apps:
+      - asset-manager
       - transition
       - imminence
       - kibana

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -17,6 +17,7 @@ node_class: &node_class
       - asset_env_sync
   backend:
     apps:
+      - asset-manager
       - transition
       - imminence
       - kibana


### PR DESCRIPTION
# Context

As part of the AWS migration, need to add `asset-manager` on the AWS backend servers because the folder `/data/uploads` need to be present when the `support-app` apps are deployed.

# Decisions
1. add `asset-manager` in the list of backend apps on AWS Staging and Production