### PR TITLE
Trello-359: Staging push sync

### DIFF
--- a/hieradata/node/postgresql-primary-1.backend.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/postgresql-primary-1.backend.staging.publishing.service.gov.uk.yaml
@@ -1,6 +1,6 @@
 govuk_env_sync::tasks:
   "push_ckan_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "0"
     minute: "15"
     action: "push"
@@ -11,7 +11,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "push_content_audit_tool_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "0"
     minute: "12"
     action: "push"
@@ -22,7 +22,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "push_content-register_production":
-    ensure: "present"
+    ensure: "absent"
     hour: "0"
     minute: "13"
     action: "push"
@@ -33,7 +33,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "push_content_publisher_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "0"
     minute: "10"
     action: "push"
@@ -44,7 +44,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "push_content_tagger_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "0"
     minute: "7"
     action: "push"
@@ -55,7 +55,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "push_email-alert-api_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "1"
     minute: "12"
     action: "push"
@@ -66,7 +66,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "push_email-alert-monitor_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "0"
     minute: "45"
     action: "push"
@@ -77,7 +77,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "push_link_checker_api_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "0"
     minute: "2"
     action: "push"
@@ -88,7 +88,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "push_local-links-manager_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "0"
     minute: "0"
     action: "push"
@@ -99,7 +99,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "push_publishing_api_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "2"
     minute: "20"
     action: "push"
@@ -110,7 +110,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "push_service-manual-publisher_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "0"
     minute: "4"
     action: "push"
@@ -121,7 +121,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "push_support-contacts_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "0"
     minute: "3"
     action: "push"
@@ -132,7 +132,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "push_content_data_admin_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "0"
     minute: "14"
     action: "push"


### PR DESCRIPTION
There are 13 push data sync jobs in staging that are currently
Acknowledged as failing on icinga. These push jobs are not required in
staging any longer and can be disabled to clear the icinga alerts.
During migration of these databases to AWS Staging we will be
temporarily enabling the jobs again to do a push during the migration.

Solo: @ronocg <conor.glynn@digital.cabinet-office.gov.uk>