### PR TITLE
Mitigate race condition between puppet and Deploy_Node_Apps

### DIFF
--- a/modules/govuk/templates/usr/local/bin/govuk_sync_apps
+++ b/modules/govuk/templates/usr/local/bin/govuk_sync_apps
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 set -euo pipefail
-
+sleep 180
 curl 'https://<%= @jenkins_domain -%>/buildByToken/build?job=Deploy_Node_Apps/<%= @aws_migration %>&token=<%= @auth_token %>'


### PR DESCRIPTION
# Context
There is userdata applied when a new instance comes up, for example, when
terminating an instance the ASG will work to keep the configured count of
instances. The steps on the way ip run puppet, puppet triggers a Jenkins
project and  that project then deploys the app. If the app is being deployed
before puppet there are errors in the deployment, namely with required folders.

# Decision
Add a wait before triggering the app deployment.