### PR TITLE
Add signon service URI to draft content store boxes

### DIFF
--- a/modules/govuk/manifests/node/s_draft_content_store.pp
+++ b/modules/govuk/manifests/node/s_draft_content_store.pp
@@ -15,6 +15,7 @@ class govuk::node::s_draft_content_store() inherits govuk::node::s_base {
 
   govuk_envvar {
     'PLEK_HOSTNAME_PREFIX': value => 'draft-';
+    'PLEK_SERVICE_SIGNON_URI': value => "https://signon.${app_domain}";
   }
 
   if ($::aws_environment == 'staging') or ($::aws_environment == 'production') {


### PR DESCRIPTION
Otherwise they try communicate with draft-signon.* which is a
non-existent service.