### PR TITLE
Switch DB connection from Carrenza to AWS for support_api

### DIFF
--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -45,6 +45,7 @@ govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-eve
 govuk::apps::short_url_manager::instance_name: 'staging'
 govuk::apps::signon::instance_name: 'staging'
 govuk::apps::static::ga_universal_id: 'UA-26179049-20'
+govuk::apps::support_api::db_hostname: '10.12.4.18'
 govuk::apps::support_api::pp_data_url: 'https://www.staging.performance.service.gov.uk'
 govuk::apps::travel_advice_publisher::enable_email_alerts: true
 govuk::apps::whitehall::cpu_warning: 400

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -109,6 +109,8 @@ govuk::node::s_base::node_apps:
 govuk_jenkins::deploy_all_apps::apps_on_nodes:
   <<: *node_class
 
+govuk_pgbouncer::db::backend_ip_range: "10.2.0.0/16"
+
 govuk::apps::asset_manager::aws_s3_bucket_name: 'govuk-assets-staging'
 govuk::apps::asset_manager::aws_region: 'eu-west-1'
 govuk::apps::ckan::ckan_site_url: 'https://ckan.staging.publishing.service.gov.uk'


### PR DESCRIPTION
  As part of the migration we redirect support_api to the db on
AWS instead of Carrenza.