### PR TITLE
remove support from the Carrenza Staging /etc/hosts

### DIFF
--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -410,7 +410,6 @@ hosts::production::backend::app_hostnames:
   - 'specialist-publisher'
   - 'specialist-publisher-rebuild'
   - 'specialist-publisher-rebuild-standalone'
-  - 'support'
   - 'support-api'
   - 'travel-advice-publisher'
   - 'whitehall-admin'


### PR DESCRIPTION
# Context

As part of the AWS migration of the `support` feature, need to remove the `support` host entry in Carrenza Staging `/etc/hosts` file so that any upstream application will resolve `support` ip address via DNS which will point to the AWS Staging instance.

# Decision

1. remove `support` in the list of `/etc/hosts` entries