### PR TITLE
Allow govuk sync script to work in Jenkins

### DIFF
--- a/modules/govuk_env_sync/manifests/init.pp
+++ b/modules/govuk_env_sync/manifests/init.pp
@@ -10,5 +10,15 @@ class govuk_env_sync(
 
   include govuk_env_sync::lock_file
 
+  file_line { 'sudo_rule_command':
+    path => '/etc/sudoers',
+    line => 'Cmnd_Alias BACKUP=/usr/local/bin/govuk_env_sync.sh',
+  }
+
+  file_line { 'sudo_rule_govuk_backup':
+    path => '/etc/sudoers',
+    line => 'deploy ALL=(govuk-backup) NOPASSWD:BACKUP',
+  }
+
   create_resources(govuk_env_sync::task, $tasks)
 }

--- a/modules/govuk_jenkins/templates/jobs/data_sync.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/data_sync.yaml.erb
@@ -18,7 +18,7 @@
             ssh deploy@${SYNC_HOST} \
             "/usr/bin/setlock /etc/unattended-reboot/no-reboot/govuk_env_sync \
              /usr/bin/envdir /etc/govuk_env_sync/env.d \
-             /usr/local/bin/govuk_env_sync.sh \
+             sudo -u govuk-backup /usr/local/bin/govuk_env_sync.sh \
              ${ARG_CONFIGFILE} \
              -a ${SYNC_ACTION} \
              -D ${SYNC_DBMS} \

--- a/modules/govuk_sudo/files/sudoers
+++ b/modules/govuk_sudo/files/sudoers
@@ -1,6 +1,7 @@
 # /etc/sudoers -- MANAGED BY PUPPET: DO NOT EDIT
 
 Defaults env_reset
+Defaults env_keep += "LOCAL_DOMAIN"
 Defaults secure_path=/usr/lib/rbenv/shims:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games
 
 # User privilege specification


### PR DESCRIPTION
The Govuk sync script is broken and is not able to run on the Jenkins agents.
Ensure's that the session sudo's with the correct user.