### PR TITLE
Add "aggregation" template variable to publishing-api metrics dash

### DIFF
--- a/modules/grafana/files/dashboards/publishing_api.json
+++ b/modules/grafana/files/dashboards/publishing_api.json
@@ -47,17 +47,17 @@
           "targets": [
             {
               "refId": "C",
-              "target": "alias(summarize(maxSeries(stats.gauges.govuk.app.publishing-api.*.workers.queues.downstream_low.latency), '1M', 'max'), 'Monthly Maximum')",
+              "target": "alias(summarize(maxSeries(stats.gauges.govuk.app.publishing-api.*.workers.queues.downstream_low.latency), '1M', '[[aggregation]]'), 'Monthly')",
               "textEditor": true
             },
             {
               "refId": "B",
-              "target": "alias(summarize(maxSeries(stats.gauges.govuk.app.publishing-api.*.workers.queues.downstream_low.latency), '1w', 'max'), 'Weekly Maximum')",
+              "target": "alias(summarize(maxSeries(stats.gauges.govuk.app.publishing-api.*.workers.queues.downstream_low.latency), '1w', '[[aggregation]]'), 'Weekly')",
               "textEditor": true
             },
             {
               "refId": "A",
-              "target": "alias(summarize(maxSeries(stats.gauges.govuk.app.publishing-api.*.workers.queues.downstream_low.latency), '1d', 'max'), 'Daily Maximum')",
+              "target": "alias(summarize(maxSeries(stats.gauges.govuk.app.publishing-api.*.workers.queues.downstream_low.latency), '1d', '[[aggregation]]'), 'Daily')",
               "textEditor": true
             }
           ],
@@ -142,17 +142,17 @@
           "targets": [
             {
               "refId": "A",
-              "target": "alias(summarize(maxSeries(stats.gauges.govuk.app.publishing-api.*.workers.queues.downstream_low.enqueued), '1M', 'max'), 'Monthly Maximum')",
+              "target": "alias(summarize(maxSeries(stats.gauges.govuk.app.publishing-api.*.workers.queues.downstream_low.enqueued), '1M', '[[aggregation]]'), 'Monthly')",
               "textEditor": true
             },
             {
               "refId": "B",
-              "target": "alias(summarize(maxSeries(stats.gauges.govuk.app.publishing-api.*.workers.queues.downstream_low.enqueued), '1w', 'max'), 'Weekly Maximum')",
+              "target": "alias(summarize(maxSeries(stats.gauges.govuk.app.publishing-api.*.workers.queues.downstream_low.enqueued), '1w', '[[aggregation]]'), 'Weekly')",
               "textEditor": true
             },
             {
               "refId": "C",
-              "target": "alias(summarize(maxSeries(stats.gauges.govuk.app.publishing-api.*.workers.queues.downstream_low.enqueued), '1d', 'max'), 'Daily Maximum')",
+              "target": "alias(summarize(maxSeries(stats.gauges.govuk.app.publishing-api.*.workers.queues.downstream_low.enqueued), '1d', '[[aggregation]]'), 'Daily')",
               "textEditor": true
             }
           ],
@@ -523,7 +523,35 @@
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "tags": [],
+          "text": "max",
+          "value": "max"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Aggregation",
+        "multi": false,
+        "name": "aggregation",
+        "options": [
+          {
+            "selected": true,
+            "text": "max",
+            "value": "max"
+          },
+          {
+            "selected": false,
+            "text": "avg",
+            "value": "avg"
+          }
+        ],
+        "query": "max, avg",
+        "type": "custom"
+      }
+    ]
   },
   "time": {
     "from": "now-6M",
@@ -556,5 +584,5 @@
   },
   "timezone": "",
   "title": "Publishing API Metrics",
-  "version": 11
+  "version": 12
 }


### PR DESCRIPTION
Also adds "avg" as an option.

---

[Trello card](https://trello.com/c/gY7vXxYR/691-add-averages-to-the-downstream-low-latency-and-size-graphs-on-the-publishing-api-metrics-dashboard)