### PR TITLE
Add postgresql-warehouse to Jenkins options

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_staging.yaml.erb
@@ -124,3 +124,4 @@
                 - mysql-whitehall
                 - postgresql-backend
                 - postgresql-transition
+                - postgresql-warehouse


### PR DESCRIPTION
The Jenkins job to sync data to staging was missing the option
when you manually run the job with parameters.