### PR TITLE
add pagerduty to some boxes in production environment

### DIFF
--- a/hieradata_aws/class/production/backend.yaml
+++ b/hieradata_aws/class/production/backend.yaml
@@ -7,3 +7,5 @@ icinga::client::check_pings::endpoints:
      ip: 10.3.3.254
    backdrop-lb:
      ip: 10.3.4.254
+
+icinga::client::contact_groups: 'urgent-priority'

--- a/hieradata_aws/class/production/content_store.yaml
+++ b/hieradata_aws/class/production/content_store.yaml
@@ -3,3 +3,5 @@
 icinga::client::check_pings::endpoints:
    router-api:
      ip: 10.3.1.253
+
+icinga::client::contact_groups: 'urgent-priority'

--- a/hieradata_aws/class/production/draft_content_store.yaml
+++ b/hieradata_aws/class/production/draft_content_store.yaml
@@ -3,3 +3,5 @@
 icinga::client::check_pings::endpoints:
    draft-router-api:
      ip: 10.3.1.252
+
+icinga::client::contact_groups: 'urgent-priority'


### PR DESCRIPTION
# Context

During the AWS migration, if some production virtual machines in AWS lose connection with Carrenza, then there should be an alert on Pagerduty to notify about the downtime.

# Decisions

1. add the high-priority hieradata to the config of the relevant servers: backend, content-store, draft-content-store