### PR TITLE
Increase number of unicorn workers for Static

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -687,6 +687,7 @@ govuk::apps::smokey::rate_limit_token: "%{hiera('smokey_rate_limit_token')}"
 
 govuk::apps::static::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::static::redis_port: "%{hiera('sidekiq_port')}"
+govuk::apps::static::unicorn_worker_processes: "8"
 
 govuk::apps::support::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::support::redis_port: "%{hiera('sidekiq_port')}"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -709,6 +709,7 @@ govuk::apps::smokey::rate_limit_token: "%{hiera('smokey_rate_limit_token')}"
 
 govuk::apps::static::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::static::redis_port: "%{hiera('sidekiq_port')}"
+govuk::apps::static::unicorn_worker_processes: "8"
 
 govuk::apps::support::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::support::redis_port: "%{hiera('sidekiq_port')}"

--- a/modules/govuk/manifests/apps/static.pp
+++ b/modules/govuk/manifests/apps/static.pp
@@ -41,6 +41,10 @@
 #   Redis port for Sidekiq.
 #   Default: undef
 #
+# [*unicorn_worker_processes*]
+#   The number of unicorn worker processes to run.
+#   Default: undef
+#
 class govuk::apps::static(
   $vhost = 'static',
   $port = '3013',
@@ -51,20 +55,22 @@ class govuk::apps::static(
   $ga_universal_id = undef,
   $redis_host = undef,
   $redis_port = undef,
+  $unicorn_worker_processes = undef
 ) {
   $enable_ssl = hiera('nginx_enable_ssl', true)
   $app_name = 'static'
 
   govuk::app { $app_name:
-    app_type              => 'rack',
-    port                  => $port,
-    sentry_dsn            => $sentry_dsn,
-    health_check_path     => '/templates/wrapper.html.erb',
-    log_format_is_json    => true,
-    nginx_extra_config    => template('govuk/static_extra_nginx_config.conf.erb'),
-    asset_pipeline        => true,
-    asset_pipeline_prefix => $app_name,
-    vhost                 => $vhost,
+    app_type                 => 'rack',
+    port                     => $port,
+    sentry_dsn               => $sentry_dsn,
+    health_check_path        => '/templates/wrapper.html.erb',
+    log_format_is_json       => true,
+    nginx_extra_config       => template('govuk/static_extra_nginx_config.conf.erb'),
+    asset_pipeline           => true,
+    asset_pipeline_prefix    => $app_name,
+    vhost                    => $vhost,
+    unicorn_worker_processes => $unicorn_worker_processes,
   }
 
   Govuk::App::Envvar {


### PR DESCRIPTION
[Trello](https://trello.com/c/vN1bhcxG/680-from-load-testing-make-static-more-resilient)

- Response to outcome of load test in which `frontend` had some difficulty talking to `static`, resulting in 500s

Co-authored-by: Jonathan Kerr <jonathan.kerr@digital.cabinet-office.gov.uk>