### PR TITLE
remove transition app from Carrenza backend as it has been transitioned to AWS

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -45,7 +45,6 @@ node_class: &node_class
       - specialist-publisher
       - support
       - support-api
-      - transition
       - travel-advice-publisher
   bouncer:
     apps:


### PR DESCRIPTION
# Context

The transition app has been transitioned to AWS, therefore the app should be removed from Carrenza backend so that the alerts are no longer there in Icinga Carrenza.

# Decisions
1. remove `transition` from the list of backend apps in Carrenza common hiera. 