### PR TITLE
Remove shared CSVs directory

### DIFF
--- a/modules/govuk/manifests/apps/support.pp
+++ b/modules/govuk/manifests/apps/support.pp
@@ -78,7 +78,6 @@ class govuk::apps::support(
 
   $app_name = 'support'
 
-  # TODO: Remove the `/csvs/` location once CSVs have been moved to S3
   govuk::app { $app_name:
     app_type           => 'rack',
     port               => $port,
@@ -90,14 +89,6 @@ class govuk::apps::support(
       location /_status {
         allow   127.0.0.0/8;
         deny    all;
-      }
-
-      proxy_set_header X-Sendfile-Type X-Accel-Redirect;
-      proxy_set_header X-Accel-Mapping /data/uploads/support-api/csvs/=/csvs/;
-
-      location /csvs/ {
-        internal;
-        root /data/uploads/support-api;
       }',
     asset_pipeline     => true,
   }

--- a/modules/govuk/manifests/apps/support_api.pp
+++ b/modules/govuk/manifests/apps/support_api.pp
@@ -149,18 +149,9 @@ class govuk::apps::support_api(
     port => $redis_port,
   }
 
-  if $::aws_migration {
-    $data_dir_user = 'deploy'
-  } else {
-    $data_dir_user = 'assets'
-  }
-
-  # TODO: Remove once CSVs have been moved to S3
+  # TODO: Remove once directories have been deleted
   file { ['/data/uploads/support-api', '/data/uploads/support-api/csvs']:
-    ensure => directory,
-    mode   => '0775',
-    owner  => $data_dir_user,
-    group  => $data_dir_user,
+    ensure => absent,
   }
 
   govuk::procfile::worker { $app_name:


### PR DESCRIPTION
This commit removes the shared directory `/data/uploads/support-api` and everything underneath it since these files are now stored in and served from AWS S3.