### PR TITLE
Add app for support-api CSV sync

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -45,6 +45,7 @@ node_class: &node_class
       - specialist-publisher
       - support
       - support-api
+      - support_api_csv_env_sync
       - travel-advice-publisher
   bouncer:
     apps:

--- a/hieradata/node/backend-1.backend.publishing.service.gov.uk.yaml
+++ b/hieradata/node/backend-1.backend.publishing.service.gov.uk.yaml
@@ -1,0 +1,1 @@
+govuk::apps::support_api_csv_env_sync::enabled: true

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -43,6 +43,7 @@ node_class: &node_class
       - specialist-publisher
       - support
       - support-api
+      - support_api_csv_env_sync
       - transition
       - travel-advice-publisher
   bouncer:

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -25,6 +25,7 @@ node_class: &node_class
       - local-links-manager
       - support
       - support-api
+      - support_api_csv_env_sync
   bouncer:
     apps:
       - bouncer

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -26,6 +26,7 @@ node_class: &node_class
       - signon
       - support
       - support-api
+      - support_api_csv_env_sync
   bouncer:
     apps:
       - bouncer

--- a/modules/govuk/manifests/apps/support_api_csv_env_sync.pp
+++ b/modules/govuk/manifests/apps/support_api_csv_env_sync.pp
@@ -1,0 +1,56 @@
+# class: govuk::apps::support_api_csv_env_sync
+#
+# Environment for syncing Support API CSVs from production
+# to staging and integration.
+#
+# === Parameters
+#
+# [*aws_access_key_id*]
+#   AWS access key for a user with permission to write to the S3 bucket
+# [*aws_secret_access_key*]
+#   AWS secret key for a user with permission to write to the S3 bucket
+# [*enabled*]
+#   Determines whether the environment is made available
+#
+class govuk::apps::support_api_csv_env_sync(
+  $aws_access_key_id = undef,
+  $aws_secret_access_key = undef,
+  $enabled = false,
+) {
+
+  $app_name = 'support-api-csv-env-sync'
+
+  if $enabled {
+    require '::govuk_awscli'
+
+    # Ensure config dir exists
+    file { "/etc/govuk/${app_name}":
+      ensure  => 'directory',
+      purge   => true,
+      recurse => true,
+      force   => true,
+    }
+
+    # Ensure env dir exists
+    file { "/etc/govuk/${app_name}/env.d":
+      ensure  => 'directory',
+      purge   => true,
+      recurse => true,
+      force   => true,
+    }
+
+    Govuk::App::Envvar {
+      app => $app_name,
+      notify_service => false,
+    }
+
+    govuk::app::envvar {
+      "${title}-AWS_ACCESS_KEY_ID":
+        varname => 'AWS_ACCESS_KEY_ID',
+        value   => $aws_access_key_id;
+      "${title}-AWS_SECRET_ACCESS_KEY":
+        varname => 'AWS_SECRET_ACCESS_KEY',
+        value   => $aws_secret_access_key;
+    }
+  }
+}

--- a/modules/govuk_jenkins/manifests/node_app_deploy.pp
+++ b/modules/govuk_jenkins/manifests/node_app_deploy.pp
@@ -34,6 +34,7 @@ define govuk_jenkins::node_app_deploy (
     'canary-frontend',
     'publicapi',
     'draft-publicapi',
+    'support_api_csv_env_sync',
   ]
 
   unless empty($apps) {


### PR DESCRIPTION
This commit adds a new “app” which sets the environment up for the support-api CSV sync. This sync job (in `env-sync-and-backup`) will sync the production S3 bucket that holds CSV exports from support-api with the equivalent buckets in staging and integration.