### PR TITLE
remove backup on the transition postgres

### DIFF
--- a/hieradata/class/transition_postgresql_master.yaml
+++ b/hieradata/class/transition_postgresql_master.yaml
@@ -1,5 +1,5 @@
 ---
-
+backup::client: 'absent'
 govuk_safe_to_reboot::can_reboot: 'no'
 govuk_safe_to_reboot::reason: 'Single point of failure for Transition application'
 

--- a/hieradata/class/transition_postgresql_master.yaml
+++ b/hieradata/class/transition_postgresql_master.yaml
@@ -14,6 +14,8 @@ mount:
     govuk_lvm: 'data'
     mountoptions: 'defaults'
 
+govuk_postgresql::server::primary::backup_enable: false
+
 govuk_postgresql::server::primary::slave_addresses:
   live:
     address: "%{hiera('postgresql_transition_slave_addresses_live')}"

--- a/hieradata/class/transition_postgresql_master.yaml
+++ b/hieradata/class/transition_postgresql_master.yaml
@@ -1,5 +1,5 @@
 ---
-backup::client: 'absent'
+backup::client::ensure: 'absent'
 govuk_safe_to_reboot::can_reboot: 'no'
 govuk_safe_to_reboot::reason: 'Single point of failure for Transition application'
 

--- a/hieradata/class/transition_postgresql_master.yaml
+++ b/hieradata/class/transition_postgresql_master.yaml
@@ -14,7 +14,7 @@ mount:
     govuk_lvm: 'data'
     mountoptions: 'defaults'
 
-govuk_postgresql::server::primary::backup_enable: false
+govuk_postgresql::backup::ensure: 'absent'
 
 govuk_postgresql::server::primary::slave_addresses:
   live:

--- a/hieradata/class/transition_postgresql_primary.yaml
+++ b/hieradata/class/transition_postgresql_primary.yaml
@@ -15,7 +15,7 @@ mount:
     govuk_lvm: 'data'
     mountoptions: 'defaults'
 
-govuk_postgresql::server::primary::backup_enable: false
+govuk_postgresql::backup::ensure: 'absent'
 
 govuk_postgresql::server::primary::slave_addresses:
   live:

--- a/hieradata/class/transition_postgresql_primary.yaml
+++ b/hieradata/class/transition_postgresql_primary.yaml
@@ -15,6 +15,8 @@ mount:
     govuk_lvm: 'data'
     mountoptions: 'defaults'
 
+govuk_postgresql::server::primary::backup_enable: false
+
 govuk_postgresql::server::primary::slave_addresses:
   live:
     address: "%{hiera('postgresql_transition_standby_addresses_live')}"

--- a/hieradata/class/transition_postgresql_primary.yaml
+++ b/hieradata/class/transition_postgresql_primary.yaml
@@ -1,4 +1,5 @@
 ---
+backup::client: 'absent'
 postgresql::globals::version: '9.5'
 
 govuk_safe_to_reboot::can_reboot: 'no'

--- a/hieradata/class/transition_postgresql_primary.yaml
+++ b/hieradata/class/transition_postgresql_primary.yaml
@@ -1,5 +1,5 @@
 ---
-backup::client: 'absent'
+backup::client::ensure: 'absent'
 postgresql::globals::version: '9.5'
 
 govuk_safe_to_reboot::can_reboot: 'no'

--- a/modules/backup/manifests/client.pp
+++ b/modules/backup/manifests/client.pp
@@ -9,8 +9,14 @@
 #   The public SSH RSA key used by the backup user.
 #   Default: ''
 #
+# [*ensure*]
+#   Specifies if this machine is configure for backup or not. Valid values are:
+#   1. 'present' - backup is configure on machine
+#   2. 'absent' - backup is not configured on machine
+#
 class backup::client (
   $backup_public_key = '',
+  $ensure = 'present'
 ) {
 
   govuk_user { 'govuk-backup':
@@ -22,7 +28,7 @@ class backup::client (
   }
 
   group { 'govuk-backup':
-    ensure => 'present',
+    ensure => $ensure,
   }
 
 }

--- a/modules/backup/manifests/client.pp
+++ b/modules/backup/manifests/client.pp
@@ -16,7 +16,7 @@
 #
 class backup::client (
   $backup_public_key = '',
-  $ensure = 'present'
+  $ensure = 'present',
 ) {
 
   govuk_user { 'govuk-backup':

--- a/modules/govuk_postgresql/manifests/backup.pp
+++ b/modules/govuk_postgresql/manifests/backup.pp
@@ -68,10 +68,7 @@ class govuk_postgresql::backup (
         source => 'puppet:///modules/govuk_postgresql/etc/default/autopostgresqlbackup',
     }
 
-    if $ensure != 'absent' {
-      include backup::client
-    }
-
+    include backup::client
     file {'/etc/postgresql-backup-post':
         ensure  => $ensure,
         mode    => '0755',

--- a/modules/govuk_postgresql/manifests/backup.pp
+++ b/modules/govuk_postgresql/manifests/backup.pp
@@ -22,28 +22,37 @@
 # [*alert_hostname*]
 #   The hostname of the alert service, to send ncsa notifications.
 #
+# [*ensure*]
+#   Determines whether backup is enabled or not. Valid values are:
+#   1. 'present' - backup is active
+#   2. 'absent' - backup is inactive
+#
 class govuk_postgresql::backup (
   $auto_postgresql_backup_hour = 6,
   $auto_postgresql_backup_minute = 0,
   $alert_hostname = 'alert.cluster',
+  $ensure = 'present',
 ) {
 
     $threshold_secs = 28 * 3600
     $service_desc = 'AutoPostgreSQL backup'
 
     file {'/usr/local/bin/autopostgresqlbackup':
+        ensure  => $ensure,
         mode    => '0755',
         content => template('govuk_postgresql/usr/local/bin/autopostgresqlbackup.erb'),
         require => File['/etc/default/autopostgresqlbackup'],
     }
 
     cron::crondotdee { 'auto_postgresql_backup':
+        ensure  => $ensure,
         command => '/usr/local/bin/autopostgresqlbackup',
         hour    => $auto_postgresql_backup_hour,
         minute  => $auto_postgresql_backup_minute,
     }
 
     @@icinga::passive_check { "check_autopostgresqlbackup-${::hostname}":
+        ensure              => $ensure,
         service_description => $service_desc,
         freshness_threshold => $threshold_secs,
         host_name           => $::fqdn,
@@ -55,16 +64,22 @@ class govuk_postgresql::backup (
     #    POSTBACKUP="/etc/postgresql-backup-post"
     #    PREBACKUP="/etc/postgresql-backup-pre"
     file {'/etc/default/autopostgresqlbackup':
-        source  => 'puppet:///modules/govuk_postgresql/etc/default/autopostgresqlbackup',
+        ensure => $ensure,
+        source => 'puppet:///modules/govuk_postgresql/etc/default/autopostgresqlbackup',
     }
 
-    include backup::client
+    if $ensure != 'absent' {
+      include backup::client
+    }
+
     file {'/etc/postgresql-backup-post':
+        ensure  => $ensure,
         mode    => '0755',
         source  => 'puppet:///modules/govuk_postgresql/etc/postgresql-backup-post',
         require => Class['backup::client'],
     }
     file {'/etc/postgresql-backup-pre':
+        ensure => $ensure,
         mode   => '0755',
         source => 'puppet:///modules/govuk_postgresql/etc/postgresql-backup-pre',
     }

--- a/modules/govuk_postgresql/manifests/server/primary.pp
+++ b/modules/govuk_postgresql/manifests/server/primary.pp
@@ -30,8 +30,13 @@ class govuk_postgresql::server::primary (
   $slave_password,
   $type = 'host',
   $user = 'replication',
+  $backup_enable = true,
 ) {
-  include govuk_postgresql::backup
+
+  if $backup_enable {
+    include govuk_postgresql::backup
+  }
+
   include govuk_postgresql::server
   include govuk_postgresql::server::not_slave
 

--- a/modules/govuk_postgresql/manifests/server/primary.pp
+++ b/modules/govuk_postgresql/manifests/server/primary.pp
@@ -30,13 +30,9 @@ class govuk_postgresql::server::primary (
   $slave_password,
   $type = 'host',
   $user = 'replication',
-  $backup_enable = true,
 ) {
 
-  if $backup_enable {
-    include govuk_postgresql::backup
-  }
-
+  include govuk_postgresql::backup
   include govuk_postgresql::server
   include govuk_postgresql::server::not_slave
 

--- a/modules/govuk_postgresql/manifests/server/primary.pp
+++ b/modules/govuk_postgresql/manifests/server/primary.pp
@@ -31,7 +31,6 @@ class govuk_postgresql::server::primary (
   $type = 'host',
   $user = 'replication',
 ) {
-
   include govuk_postgresql::backup
   include govuk_postgresql::server
   include govuk_postgresql::server::not_slave


### PR DESCRIPTION
# Context

Since the transition app has been migrated to AWS, there is no need to backup the transition app postgres

# Decisions

1. disable backup for the transition postgres database.
