### PR TITLE
Change the Publishing API to use a JSON healthcheck

### DIFF
--- a/modules/govuk/manifests/apps/publishing_api.pp
+++ b/modules/govuk/manifests/apps/publishing_api.pp
@@ -159,6 +159,7 @@ class govuk::apps::publishing_api(
     sentry_dsn             => $sentry_dsn,
     vhost_ssl_only         => true,
     health_check_path      => '/healthcheck',
+    json_health_check      => true,
     log_format_is_json     => true,
     deny_framing           => true,
     nagios_memory_warning  => $nagios_memory_warning,


### PR DESCRIPTION
Currently the information in the Publishing API healthcheck isn't
making it through to Icinga, as it simply isn't looking at the JSON
returned. This change should fix that.