### PR TITLE
remove transition on backup node

### DIFF
--- a/hieradata/class/backup.yaml
+++ b/hieradata/class/backup.yaml
@@ -35,10 +35,6 @@ govuk::node::s_backup::directories:
     directory: /var/lib/autopostgresqlbackup/
     fq_dn: puppetmaster-1.management.%{hiera('app_domain')}
     priority: '003'
-  backup_postgresql_backups_transition_postgresql_master_1:
-    directory: /var/lib/autopostgresqlbackup/
-    fq_dn: transition-postgresql-master-1.backend.%{hiera('app_domain')}
-    priority: '001'
   backup_graphite_storage_whisper_graphite-1:
     directory: /opt/graphite/storage/backups
     fq_dn: graphite-1.management.%{hiera('app_domain')}


### PR DESCRIPTION
# Context

Since the transition app has been migrated to AWS, remove the Icinga alert for backup the transition app postgres

# Decisions

1. remove backup for the transition postgres database.