### PR TITLE
Work towards supporting notifications for app healthchecks

### DIFF
--- a/modules/govuk/manifests/app.pp
+++ b/modules/govuk/manifests/app.pp
@@ -80,6 +80,13 @@
 # Setting this to true will add a monitoring check that the healthcheck
 # reports the app's status as OK.
 #
+# [*health_check_service_template*]
+#   The title of a `Icinga::Service_template` from which the
+#   healthcheck check should inherit.
+#
+# [*health_check_notification_period*]
+#   The title of a `Icinga::Timeperiod` resource to be used by the
+#   healthcheck.
 #
 # [*deny_framing*]
 # should we allow this app to be framed
@@ -236,6 +243,8 @@ define govuk::app (
   $health_check_path = 'NOTSET',
   $expose_health_check = true,
   $json_health_check = false,
+  $health_check_service_template = 'govuk_regular_service',
+  $health_check_notification_period = undef,
   $deny_framing = false,
   $enable_nginx_vhost = true,
   $vhost = undef,

--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -6,6 +6,14 @@
 #
 # FIXME: Document all parameters
 #
+# [*health_check_service_template*]
+#   The title of a `Icinga::Service_template` from which the
+#   healthcheck check should inherit.
+#
+# [*health_check_notification_period*]
+#   The title of a `Icinga::Timeperiod` resource to be used by the
+#   healthcheck.
+#
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
@@ -46,6 +54,8 @@ define govuk::app::config (
   $health_check_path = 'NOTSET',
   $expose_health_check = true,
   $json_health_check = false,
+  $health_check_service_template = 'govuk_regular_service',
+  $health_check_notification_period = undef,
   $deny_framing = false,
   $enable_nginx_vhost = true,
   $unicorn_herder_timeout = 'NOTSET',
@@ -312,6 +322,8 @@ define govuk::app::config (
         ensure              => $ensure,
         check_command       => "check_nrpe!check_json_healthcheck!${port} ${health_check_path}",
         service_description => $healthcheck_desc,
+        use                 => $health_check_service_template,
+        notification_period => $health_check_notification_period,
         host_name           => $::fqdn,
         notes_url           => monitoring_docs_url($healthcheck_opsmanual),
       }

--- a/modules/govuk/manifests/apps/publishing_api.pp
+++ b/modules/govuk/manifests/apps/publishing_api.pp
@@ -153,17 +153,19 @@ class govuk::apps::publishing_api(
   include govuk_postgresql::client #installs libpq-dev package needed for pg gem
 
   govuk::app { $app_name:
-    ensure                 => $ensure,
-    app_type               => 'rack',
-    port                   => $port,
-    sentry_dsn             => $sentry_dsn,
-    vhost_ssl_only         => true,
-    health_check_path      => '/healthcheck',
-    json_health_check      => true,
-    log_format_is_json     => true,
-    deny_framing           => true,
-    nagios_memory_warning  => $nagios_memory_warning,
-    nagios_memory_critical => $nagios_memory_critical,
+    ensure                           => $ensure,
+    app_type                         => 'rack',
+    port                             => $port,
+    sentry_dsn                       => $sentry_dsn,
+    vhost_ssl_only                   => true,
+    health_check_path                => '/healthcheck',
+    health_check_service_template    => 'govuk_urgent_priority',
+    health_check_notification_period => 'inoffice',
+    json_health_check                => true,
+    log_format_is_json               => true,
+    deny_framing                     => true,
+    nagios_memory_warning            => $nagios_memory_warning,
+    nagios_memory_critical           => $nagios_memory_critical,
   }
 
   govuk::procfile::worker {'publishing-api':


### PR DESCRIPTION
This relates to the addition of monitoring for the high priority downstream queue in to the Publishing API healthcheck ( https://github.com/alphagov/publishing-api/pull/1308 ), and then the change in govuk-puppet to actually monitor the details of the healthcheck in Icinga ( https://github.com/alphagov/govuk-puppet/pull/8463 ).

We've had a couple of incidents now where the growing length of the `downstream_high` queue could have been caught sooner, and these changes work towards that.