### PR TITLE
Remove mongo api backup

### DIFF
--- a/hieradata/class/backup.yaml
+++ b/hieradata/class/backup.yaml
@@ -7,10 +7,6 @@ govuk::node::s_backup::directories:
     directory: /var/lib/automongodbbackup/
     fq_dn: mongo-1.backend.%{hiera('app_domain')}
     priority: '001'
-  backup_mongodb_backups_api_mongo:
-    directory: /var/lib/automongodbbackup/
-    fq_dn: api-mongo-1.api.%{hiera('app_domain')}
-    priority: '001'
   backup_mongodb_backups_performance_mongo:
     directory: /var/lib/automongodbbackup/
     fq_dn: performance-mongo-1.api.%{hiera('app_domain')}


### PR DESCRIPTION
# Context

Since the content-store and draft-content-store app has been migrated to AWS, remove the Icinga alert for backup the api-mongo backup which is only used by content-store and draft-content.

# Decisions

1. remove backup for the api-mongo database.