### PR TITLE
Fix statsd for govuk-uptime-collector

### DIFF
--- a/modules/monitoring/manifests/uptime_collector.pp
+++ b/modules/monitoring/manifests/uptime_collector.pp
@@ -15,8 +15,8 @@ class monitoring::uptime_collector (
   $environment = '',
   $aws = false,
 ) {
-  exec { 'install statsd into 2.3 rbenv':
-    environment => 'RBENV_VERSION=2.3',
+  exec { 'install statsd into 2.5 rbenv':
+    environment => 'RBENV_VERSION=2.5',
     path        => ['/usr/lib/rbenv/shims', '/usr/local/bin', '/usr/bin', '/bin'],
     command     => 'gem install statsd-ruby',
     unless      => 'gem list -i statsd-ruby',


### PR DESCRIPTION
This has been switched to Ruby 2.5

https://github.com/alphagov/govuk-puppet/commit/d3b0846658fdd84c548824c01b510fd0786112ba