### PR TITLE
Enable authentication in Support API

### DIFF
--- a/modules/govuk/manifests/apps/content_performance_manager.pp
+++ b/modules/govuk/manifests/apps/content_performance_manager.pp
@@ -72,6 +72,9 @@
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
+# [*support_api_bearer_token*]
+#   The bearer token that will be used to authenticate with support-api
+#
 class govuk::apps::content_performance_manager(
   $db_hostname = undef,
   $db_name = 'content_performance_manager_production',
@@ -93,6 +96,7 @@ class govuk::apps::content_performance_manager(
   $redis_port = undef,
   $secret_key_base = undef,
   $sentry_dsn = undef,
+  $support_api_bearer_token = undef,
 ) {
   $app_name = 'content-performance-manager'
 
@@ -158,6 +162,9 @@ class govuk::apps::content_performance_manager(
     "${title}-RABBITMQ_PASSWORD":
       varname => 'RABBITMQ_PASSWORD',
       value   => $rabbitmq_password;
+    "${title}-SUPPORT_API_BEARER_TOKEN":
+      varname => 'SUPPORT_API_BEARER_TOKEN',
+      value   => $support_api_bearer_token;
   }
 
   govuk::app::envvar::redis { $app_name:

--- a/modules/govuk/manifests/apps/feedback.pp
+++ b/modules/govuk/manifests/apps/feedback.pp
@@ -14,6 +14,9 @@
 # [*secret_key_base*]
 #   The key for Rails to use when signing/encrypting sessions.
 #
+# [*support_bearer_token*]
+#   The bearer token to allow this app to submit anonymous feedback to the Support App.
+#
 # [*support_api_bearer_token*]
 #   The bearer token to allow this app to submit anonymous feedback to the Support API.
 #
@@ -25,6 +28,7 @@ class govuk::apps::feedback(
   $port = '3028',
   $sentry_dsn = undef,
   $secret_key_base = undef,
+  $support_bearer_token = undef,
   $support_api_bearer_token = undef,
   $publishing_api_bearer_token = undef,
   $assisted_digital_google_spreadsheet_key = undef,
@@ -52,6 +56,13 @@ class govuk::apps::feedback(
     govuk::app::envvar { "${title}-SECRET_KEY_BASE":
       varname => 'SECRET_KEY_BASE',
       value   => $secret_key_base,
+    }
+  }
+
+  if $support_bearer_token != undef {
+    govuk::app::envvar { "${title}-SUPPORT_BEARER_TOKEN":
+      varname => 'SUPPORT_BEARER_TOKEN',
+      value   => $support_bearer_token,
     }
   }
 

--- a/modules/govuk/manifests/apps/support.pp
+++ b/modules/govuk/manifests/apps/support.pp
@@ -36,6 +36,9 @@
 # [*secret_key_base*]
 #   The key for Rails to use when signing/encrypting sessions.
 #
+# [*support_api_bearer_token*]
+#   The bearer token that will be used to authenticate with support-api
+#
 # [*zendesk_anonymous_ticket_email*]
 #   Email address used for anonymous zendesk tickets.
 #
@@ -67,6 +70,7 @@ class govuk::apps::support(
   $redis_host = undef,
   $redis_port = undef,
   $secret_key_base = undef,
+  $support_api_bearer_token = undef,
   $zendesk_anonymous_ticket_email = undef,
   $zendesk_client_password = undef,
   $zendesk_client_username = undef,
@@ -119,6 +123,9 @@ class govuk::apps::support(
     "${title}-OAUTH_SECRET":
       varname => 'OAUTH_SECRET',
       value   => $oauth_secret;
+    "${title}-SUPPORT_API_BEARER_TOKEN":
+      varname => 'SUPPORT_API_BEARER_TOKEN',
+      value   => $support_api_bearer_token;
     "${title}-ZENDESK_ANONYMOUS_TICKET_EMAIL":
       varname => 'ZENDESK_ANONYMOUS_TICKET_EMAIL',
       value   => $zendesk_anonymous_ticket_email;

--- a/modules/govuk/manifests/apps/support_api.pp
+++ b/modules/govuk/manifests/apps/support_api.pp
@@ -34,6 +34,12 @@
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
+# [*oauth_id*]
+# The Oauth ID used to identify the app to GOV.UK Signon (in govuk-secrets)
+#
+# [*oauth_secret*]
+# The Oauth secret used to authenticate the app to GOV.UK Signon (in govuk-secrets)
+#
 # [*port*]
 #   The port where the Rails app is running.
 #   Default: 3075
@@ -85,6 +91,8 @@ class govuk::apps::support_api(
   $db_username = undef,
   $enable_procfile_worker = true,
   $sentry_dsn = undef,
+  $oauth_id = undef,
+  $oauth_secret = undef,
   $port = '3075',
   $pp_data_url = undef,
   $pp_data_bearer_token = undef,
@@ -115,6 +123,12 @@ class govuk::apps::support_api(
   }
 
   govuk::app::envvar {
+    "${title}-OAUTH_ID":
+      varname => 'OAUTH_ID',
+      value   => $oauth_id;
+    "${title}-OAUTH_SECRET":
+      varname => 'OAUTH_SECRET',
+      value   => $oauth_secret;
     "${title}-PP_DATA_BEARER_TOKEN":
       varname => 'PP_DATA_BEARER_TOKEN',
       value   => $pp_data_bearer_token;


### PR DESCRIPTION
Trello: https://trello.com/c/WR2MNxo6

Related to: https://github.com/alphagov/support-api/pull/266

Adds the environment variables needed to allow applications to authenticate with support-api using signon.

Do not merge until govuk-secrets has been updated.