### PR TITLE
Add a Grafana dashboard for RabbitMQ

### DIFF
--- a/modules/grafana/files/dashboards/rabbitmq.json
+++ b/modules/grafana/files/dashboards/rabbitmq.json
@@ -1,0 +1,333 @@
+{
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "4.5.2"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "graphite",
+      "name": "Graphite",
+      "version": "1.0.0"
+    }
+  ],
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "hideControls": false,
+  "id": null,
+  "links": [],
+  "refresh": "10s",
+  "rows": [
+    {
+      "collapse": false,
+      "height": 250,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Graphite",
+          "fill": 0,
+          "id": 3,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 12,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "refId": "A",
+              "target": "alias(rabbitmq_%2F.exchanges-$Exchanges.confirm_details-rate, 'confirm rate')"
+            },
+            {
+              "refId": "B",
+              "target": "alias(rabbitmq_%2F.exchanges-$Exchanges.publish_in_details-rate, 'publish (in) rate')"
+            },
+            {
+              "refId": "C",
+              "target": "alias(rabbitmq_%2F.exchanges-$Exchanges.publish_out_details-rate, 'publish (out) rate')"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "ops",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": "Exchanges",
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "Exchange: $Exchanges",
+      "titleSize": "h4"
+    },
+    {
+      "collapse": false,
+      "height": "300px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Graphite",
+          "fill": 0,
+          "id": 1,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "messages ready",
+              "fill": 3,
+              "linewidth": 0,
+              "yaxis": 2
+            },
+            {
+              "alias": "messages unacknowledged",
+              "fill": 3,
+              "linewidth": 0,
+              "yaxis": 2
+            }
+          ],
+          "spaceLength": 10,
+          "span": 12,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "refId": "D",
+              "target": "alias(rabbitmq_%2F.queues-$Queues.messages_ready, 'messages ready')"
+            },
+            {
+              "refId": "E",
+              "target": "alias(rabbitmq_%2F.queues-$Queues.messages_unacknowledged, 'messages unacknowledged')"
+            },
+            {
+              "hide": false,
+              "refId": "A",
+              "target": "alias(rabbitmq_%2F.queues-$Queues.publish_details-rate, 'publish')",
+              "textEditor": false
+            },
+            {
+              "hide": false,
+              "refId": "B",
+              "target": "alias(rabbitmq_%2F.queues-$Queues.ack_details-rate, 'ack')"
+            },
+            {
+              "hide": false,
+              "refId": "C",
+              "target": "alias(rabbitmq_%2F.queues-$Queues.deliver_details-rate, 'deliver')"
+            },
+            {
+              "hide": false,
+              "refId": "F",
+              "target": "alias(rabbitmq_%2F.queues-$Queues.ack_details-rate, 'ack')"
+            },
+            {
+              "hide": false,
+              "refId": "G",
+              "target": "alias(rabbitmq_%2F.queues-$Queues.redeliver_details-rate, 'redeliver')"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "ops",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": "Queues",
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "Queue: $Queues",
+      "titleSize": "h4"
+    }
+  ],
+  "schemaVersion": 14,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": "*",
+        "current": {},
+        "datasource": "Graphite",
+        "hide": 0,
+        "includeAll": true,
+        "label": null,
+        "multi": true,
+        "name": "Queues",
+        "options": [],
+        "query": "rabbitmq_%2F.queues-*",
+        "refresh": 1,
+        "regex": "/queues-(.*)/",
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": "*",
+        "current": {},
+        "datasource": "Graphite",
+        "hide": 0,
+        "includeAll": true,
+        "label": null,
+        "multi": true,
+        "name": "Exchanges",
+        "options": [],
+        "query": "rabbitmq_%2F.exchanges-*",
+        "refresh": 1,
+        "regex": "/exchanges-(.*)/",
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "RabbitMQ",
+  "version": 9
+}


### PR DESCRIPTION
This displays data from the CollectD plugin for RabbitMQ. This is
similar to the data available from the RabbitMQ admin interface, but
it's easier to view historical data in Grafana, and you don't have to
use the RabbitMQ root password to login.

![rabbitmq-dashboard](https://user-images.githubusercontent.com/1130010/50635102-bcbbd880-0f48-11e9-85bc-db9e82c3abd0.png)
