### PR TITLE
Add monitoring for the cache-clearing-service queue size

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -362,6 +362,8 @@ govuk::apps::cache_clearing_service::rabbitmq_hosts:
   - rabbitmq-1.backend
   - rabbitmq-2.backend
   - rabbitmq-3.backend
+govuk::apps::cache_clearing_service::rabbitmq::queue_size_critical_threshold: 10000
+govuk::apps::cache_clearing_service::rabbitmq::queue_size_warning_threshold: 1000
 
 govuk::apps::ckan::db_hostname: "postgresql-primary-1.backend"
 govuk::apps::ckan::db_port: 6432

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -373,6 +373,8 @@ govuk::apps::bouncer::unicorn_worker_processes: "8"
 
 govuk::apps::cache_clearing_service::enabled: true
 govuk::apps::cache_clearing_service::rabbitmq_hosts: [rabbitmq]
+govuk::apps::cache_clearing_service::rabbitmq::queue_size_critical_threshold: 10000
+govuk::apps::cache_clearing_service::rabbitmq::queue_size_warning_threshold: 1000
 
 govuk::apps::ckan::db_hostname: "postgresql-primary"
 govuk::apps::ckan::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"

--- a/modules/govuk/manifests/apps/cache_clearing_service/rabbitmq.pp
+++ b/modules/govuk/manifests/apps/cache_clearing_service/rabbitmq.pp
@@ -26,6 +26,8 @@ class govuk::apps::cache_clearing_service::rabbitmq (
   $amqp_pass = 'cache_clearing_service',
   $amqp_exchange = 'published_documents',
   $amqp_queue = 'cache_clearing_service',
+  $queue_size_critical_threshold,
+  $queue_size_warning_threshold,
 ) {
   govuk_rabbitmq::queue_with_binding { $amqp_queue:
     ensure        => 'present',
@@ -33,6 +35,14 @@ class govuk::apps::cache_clearing_service::rabbitmq (
     amqp_queue    => $amqp_queue,
     routing_key   => '*.major',
     durable       => true,
+  }
+
+  govuk_rabbitmq::monitor_messages {"${amqp_queue}_message_monitoring":
+    ensure             => present,
+    rabbitmq_hostname  => 'localhost',
+    rabbitmq_queue     => $amqp_queue,
+    critical_threshold => $queue_size_critical_threshold,
+    warning_threshold  => $queue_size_warning_threshold,
   }
 
   rabbitmq_binding { "binding_minor_${amqp_exchange}@${amqp_queue}@/":


### PR DESCRIPTION
The cache clearing service reads from a RabbitMQ queue, which has
peaked at ~1,000,000 items recently. This commit adds some monitoring
via Icinga so that it's easier to see when the queue is "long".

The values are a complete guess, at the moment, it seems to be backing
up significantly, so hopefully this can be solved, and then the alert
values tuned to a more sensible range.