### PR TITLE
Enable authentication in link-checker-api

### DIFF
--- a/modules/govuk/manifests/apps/collections_publisher.pp
+++ b/modules/govuk/manifests/apps/collections_publisher.pp
@@ -26,6 +26,10 @@
 #   Whether to enable the procfile worker
 #   Default: true
 #
+# [*link_checker_api_bearer_token*]
+#   The bearer token that will be used to authenticate with link-checker-api
+#   Default: undef
+#
 # [*publishing_api_bearer_token*]
 #   The bearer token to use when communicating with Publishing API.
 #   Default: undef
@@ -61,6 +65,7 @@ class govuk::apps::collections_publisher(
   $oauth_id = undef,
   $oauth_secret = undef,
   $enable_procfile_worker = true,
+  $link_checker_api_bearer_token = undef,
   $publishing_api_bearer_token = undef,
   $db_hostname = undef,
   $db_username = 'collections_pub',
@@ -106,6 +111,9 @@ class govuk::apps::collections_publisher(
     "${title}-OAUTH_SECRET":
       varname => 'OAUTH_SECRET',
       value   => $oauth_secret;
+    "${title}-LINK_CHECKER_API_BEARER_TOKEN":
+        varname => 'LINK_CHECKER_API_BEARER_TOKEN',
+        value   => $link_checker_api_bearer_token;
     "${title}-PUBLISHING_API_BEARER_TOKEN":
       varname => 'PUBLISHING_API_BEARER_TOKEN',
       value   => $publishing_api_bearer_token;

--- a/modules/govuk/manifests/apps/link_checker_api.pp
+++ b/modules/govuk/manifests/apps/link_checker_api.pp
@@ -40,6 +40,13 @@
 #   uset these checks won't be performed
 #   Default: undef
 #
+# [*oauth_id*]
+# The Oauth ID used to identify the app to GOV.UK Signon (in govuk-secrets)
+#
+# [*oauth_secret*]
+# The Oauth secret used to authenticate the app to GOV.UK Signon (in govuk-secrets)
+#
+#
 # [*port*]
 #   The port that it is served on.
 #   Default: 3208
@@ -76,6 +83,8 @@ class govuk::apps::link_checker_api (
   $enable_procfile_worker = true,
   $sentry_dsn = undef,
   $google_api_key = undef,
+  $oauth_id = undef,
+  $oauth_secret = undef,
   $port = 3208,
   $redis_host = undef,
   $redis_port = undef,
@@ -98,6 +107,15 @@ class govuk::apps::link_checker_api (
 
   Govuk::App::Envvar {
     app => $app_name,
+  }
+
+  govuk::app::envvar {
+    "${title}-OAUTH_ID":
+      varname => 'OAUTH_ID',
+      value   => $oauth_id;
+    "${title}-OAUTH_SECRET":
+      varname => 'OAUTH_SECRET',
+      value   => $oauth_secret;
   }
 
   govuk::procfile::worker { $app_name:

--- a/modules/govuk/manifests/apps/local_links_manager.pp
+++ b/modules/govuk/manifests/apps/local_links_manager.pp
@@ -82,6 +82,10 @@
 #   The secret token used when verifying web hook responses from the Link
 #   Checker API.
 #
+# [*link_checker_api_bearer_token*]
+#   The bearer token that will be used to authenticate with link-checker-api
+#   Default: undef
+#
 # [*run_links_ga_export]
 #   Feature flag to allow a daily rake task to upload a list of bad links
 #   to GA.
@@ -114,6 +118,7 @@ class govuk::apps::local_links_manager(
   $google_analytics_govuk_view_id = undef,
   $publishing_api_bearer_token = undef,
   $link_checker_api_secret_token = undef,
+  $link_checker_api_bearer_token = undef,
   $google_client_email = undef,
   $google_private_key = undef,
   $google_export_account_id = undef,
@@ -179,6 +184,9 @@ class govuk::apps::local_links_manager(
       "${title}-LINK_CHECKER_API_SECRET_TOKEN":
         varname => 'LINK_CHECKER_API_SECRET_TOKEN',
         value   => $link_checker_api_secret_token;
+      "${title}-LINK_CHECKER_API_BEARER_TOKEN":
+          varname => 'LINK_CHECKER_API_BEARER_TOKEN',
+          value   => $link_checker_api_bearer_token;
       "${title}-RUN_LINK_GA_EXPORT":
         varname => 'RUN_LINK_GA_EXPORT',
         value   => bool2str($run_links_ga_export);

--- a/modules/govuk/manifests/apps/manuals_publisher.pp
+++ b/modules/govuk/manifests/apps/manuals_publisher.pp
@@ -57,6 +57,10 @@
 #   The Link Checker API secret token.
 #   Default: undef
 #
+# [*link_checker_api_bearer_token*]
+#   The bearer token that will be used to authenticate with link-checker-api
+#   Default: undef
+#
 class govuk::apps::manuals_publisher(
   $port = 3205,
   $asset_manager_bearer_token = undef,
@@ -72,6 +76,7 @@ class govuk::apps::manuals_publisher(
   $redis_port = undef,
   $secret_key_base = undef,
   $link_checker_api_secret_token = undef,
+  $link_checker_api_bearer_token = undef,
 ) {
   $app_name = 'manuals-publisher'
 
@@ -121,6 +126,9 @@ class govuk::apps::manuals_publisher(
     "${title}-LINK_CHECKER_API_SECRET_TOKEN":
       varname => 'LINK_CHECKER_API_SECRET_TOKEN',
       value   => $link_checker_api_secret_token;
+    "${title}-LINK_CHECKER_API_BEARER_TOKEN":
+        varname => 'LINK_CHECKER_API_BEARER_TOKEN',
+        value   => $link_checker_api_bearer_token;
   }
 
   if $secret_key_base != undef {

--- a/modules/govuk/manifests/apps/publisher.pp
+++ b/modules/govuk/manifests/apps/publisher.pp
@@ -76,6 +76,10 @@
 #   The Link Checker API secret token.
 #   Default: undef
 #
+# [*link_checker_api_bearer_token*]
+#   The bearer token that will be used to authenticate with link-checker-api
+#   Default: undef
+#
 class govuk::apps::publisher(
     $port = '3000',
     $enable_procfile_worker = true,
@@ -99,6 +103,7 @@ class govuk::apps::publisher(
     $email_group_business = undef,
     $email_group_citizen = undef,
     $link_checker_api_secret_token = undef,
+    $link_checker_api_bearer_token = undef,
   ) {
 
   $app_name = 'publisher'
@@ -214,5 +219,8 @@ class govuk::apps::publisher(
     "${title}-LINK_CHECKER_API_SECRET_TOKEN":
         varname => 'LINK_CHECKER_API_SECRET_TOKEN',
         value   => $link_checker_api_secret_token;
+    "${title}-LINK_CHECKER_API_BEARER_TOKEN":
+        varname => 'LINK_CHECKER_API_BEARER_TOKEN',
+        value   => $link_checker_api_bearer_token;
   }
 }

--- a/modules/govuk/manifests/apps/travel_advice_publisher.pp
+++ b/modules/govuk/manifests/apps/travel_advice_publisher.pp
@@ -60,6 +60,10 @@
 #   The Link Checker API secret token.
 #   Default: undef
 #
+# [*link_checker_api_bearer_token*]
+#   The bearer token that will be used to authenticate with link-checker-api
+#   Default: undef
+#
 class govuk::apps::travel_advice_publisher(
   $asset_manager_bearer_token = undef,
   $enable_email_alerts = false,
@@ -77,6 +81,7 @@ class govuk::apps::travel_advice_publisher(
   $show_historical_edition_link = false,
   $email_alert_api_bearer_token = undef,
   $link_checker_api_secret_token = undef,
+  $link_checker_api_bearer_token = undef,
 ) {
   $app_name = 'travel-advice-publisher'
 
@@ -130,6 +135,9 @@ class govuk::apps::travel_advice_publisher(
     "${title}-LINK_CHECKER_API_SECRET_TOKEN":
         varname => 'LINK_CHECKER_API_SECRET_TOKEN',
         value   => $link_checker_api_secret_token;
+    "${title}-LINK_CHECKER_API_BEARER_TOKEN":
+        varname => 'LINK_CHECKER_API_BEARER_TOKEN',
+        value   => $link_checker_api_bearer_token;
   }
 
   validate_bool($show_historical_edition_link)

--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -105,6 +105,10 @@
 #   The Link Checker API secret token.
 #   Default: undef
 #
+# [*link_checker_api_bearer_token*]
+#   The bearer token that will be used to authenticate with link-checker-api
+#   Default: undef
+#
 # [*email_alert_api_bearer_token*]
 #   Bearer token for communication with the email-alert-api
 #
@@ -149,6 +153,7 @@ class govuk::apps::whitehall(
   $jwt_auth_secret = undef,
   $co_nss_watchkeeper_email_address = undef,
   $link_checker_api_secret_token = undef,
+  $link_checker_api_bearer_token = undef,
   $cpu_warning = 150,
   $cpu_critical = 200,
 ) {
@@ -321,6 +326,9 @@ class govuk::apps::whitehall(
       "${title}-LINK_CHECKER_API_SECRET_TOKEN":
         varname => 'LINK_CHECKER_API_SECRET_TOKEN',
         value   => $link_checker_api_secret_token;
+      "${title}-LINK_CHECKER_API_BEARER_TOKEN":
+          varname => 'LINK_CHECKER_API_BEARER_TOKEN',
+          value   => $link_checker_api_bearer_token;
     }
 
     if $::govuk_node_class !~ /^development$/ {


### PR DESCRIPTION
Trello: https://trello.com/c/2IdzHdtp

Related to: https://github.com/alphagov/link-checker-api/pull/227

Adds the environment variables needed to allow applications to authenticate with link-checker-api using signon.