### PR TITLE
Indicate pending items in a terraform plan

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_terraform_govuk_aws.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_terraform_govuk_aws.yaml.erb
@@ -32,6 +32,12 @@
         - shell: |
             ./jenkins.sh
 
+    publishers:
+        - text-finder:
+            regexp: "Plan.*\d* to add, \d* to change, \d* to destroy."
+            also-check-console-output: true
+            unstable-if-found: true
+
     parameters:
         - string:
             name: AWS_ACCESS_KEY_ID


### PR DESCRIPTION
# Context
The deploy terrafrom govuk aws project allows for plans and applies of
terraform but when running a plan there is no indicator that there are pending
changes. This can be misleading if scanning down a list of "green" jobs, the
assumption could be that everything is working and deployed.

# Decision
Use the Jenkins Text Finder plugin in a post-build action to identify pending
changes and mark the job as unstable (yellow).