### PR TITLE
Add Router API authentication

### DIFF
--- a/hieradata/class/router_backend.yaml
+++ b/hieradata/class/router_backend.yaml
@@ -1,5 +1,8 @@
 ---
 
+govuk::apps::router_api::oauth_id: "%{hiera('govuk::apps::router_api::oauth_id')}"
+govuk::apps::router_api::oauth_secret: "%{hiera('govuk::apps::router_api::oauth_secret')}"
+
 govuk::apps::router_api::mongodb_name: 'router'
 govuk::apps::router_api::mongodb_nodes:
   - 'router-backend-1.router'

--- a/hieradata_aws/class/router_backend.yaml
+++ b/hieradata_aws/class/router_backend.yaml
@@ -1,5 +1,8 @@
 ---
 
+govuk::apps::router_api::oauth_id: "%{hiera('govuk::apps::router_api::oauth_id')}"
+govuk::apps::router_api::oauth_secret: "%{hiera('govuk::apps::router_api::oauth_secret')}"
+
 govuk::apps::router_api::mongodb_name: 'router'
 govuk::apps::router_api::mongodb_nodes:
   - 'router-backend-1'

--- a/modules/govuk/manifests/apps/content_store.pp
+++ b/modules/govuk/manifests/apps/content_store.pp
@@ -54,6 +54,10 @@
 # [*oauth_secret*]
 #   The OAuth secret used to authenticate the app to GOV.UK Signon (in govuk-secrets)
 #
+# [*router_api_bearer_token*]
+#   The bearer token that will be used to authenticate with the router api
+#
+
 class govuk::apps::content_store(
   $port = '3068',
   $mongodb_nodes,
@@ -71,6 +75,7 @@ class govuk::apps::content_store(
   $app_domain = undef,
   $oauth_id = undef,
   $oauth_secret = undef,
+  $router_api_bearer_token = undef,
 ) {
   $app_name = 'content-store'
 
@@ -124,6 +129,9 @@ class govuk::apps::content_store(
     "${title}-PUBLISHING_API_BEARER_TOKEN":
       varname => 'PUBLISHING_API_BEARER_TOKEN',
       value   => $publishing_api_bearer_token;
+    "${title}-ROUTER_API_BEARER_TOKEN":
+        varname => 'ROUTER_API_BEARER_TOKEN',
+        value   => $router_api_bearer_token;
     "${title}-PERFORMANCEPLATFORM_BIG_SCREEN_VIEW":
       varname => 'PLEK_SERVICE_PERFORMANCEPLATFORM_BIG_SCREEN_VIEW_URI',
       value   => $performance_platform_big_screen_view_url;

--- a/modules/govuk/manifests/apps/router_api.pp
+++ b/modules/govuk/manifests/apps/router_api.pp
@@ -32,6 +32,13 @@
 # [*router_nodes_class*]
 #   The class or classes of machine that run router that require reloading
 #   after app deployment. Acceptable formats are "cache" or "cache,draft_cache"
+#
+# [*oauth_id*]
+#   The OAuth ID used to identify the app to GOV.UK Signon (in govuk-secrets)
+#
+# [*oauth_secret*]
+#   The OAuth secret used to authenticate the app to GOV.UK Signon (in govuk-secrets)
+#
 
 class govuk::apps::router_api(
   $port = '3056',
@@ -42,6 +49,8 @@ class govuk::apps::router_api(
   $secret_key_base = undef,
   $sentry_dsn = undef,
   $router_nodes_class = undef,
+  $oauth_id = undef,
+  $oauth_secret = undef,
 ) {
   $app_name = 'router-api'
 
@@ -65,6 +74,12 @@ class govuk::apps::router_api(
     "${title}-SECRET_KEY_BASE":
       varname => 'SECRET_KEY_BASE',
       value   => $secret_key_base;
+    "${title}-OAUTH_ID":
+      varname => 'OAUTH_ID',
+      value   => $oauth_id;
+    "${title}-OAUTH_SECRET":
+      varname => 'OAUTH_SECRET',
+      value   => $oauth_secret;
   }
 
   govuk::app::envvar::mongodb_uri { $app_name:


### PR DESCRIPTION
This adds the environment variables required by router-api
and content-store for use in GDS-SSO authentication.

Prior art that I want to follow: https://github.com/alphagov/govuk-puppet/pull/8426.