### PR TITLE
Add escapes to regex

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_terraform_govuk_aws.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_terraform_govuk_aws.yaml.erb
@@ -34,7 +34,7 @@
 
     publishers:
         - text-finder:
-            regexp: "Plan.*\d* to add, \d* to change, \d* to destroy."
+            regexp: "Plan.*\\d* to add, \\d* to change, \\d* to destroy."
             also-check-console-output: true
             unstable-if-found: true
 


### PR DESCRIPTION
The "\d" needs another escape char in order to be processed as intended.