### PR TITLE
Change the temppath for the PostgreSQL env sync

### DIFF
--- a/hieradata/node/postgresql-standby-2.backend.publishing.service.gov.uk.yaml
+++ b/hieradata/node/postgresql-standby-2.backend.publishing.service.gov.uk.yaml
@@ -24,7 +24,7 @@ govuk_env_sync::tasks:
     dbms: "postgresql"
     storagebackend: "s3"
     database: "link_checker_api_production"
-    temppath: "/tmp/"
+    temppath: "/tmp/govuk_env_sync/"
     url: "govuk-production-database-backups"
     path: "postgresql-backend"
   "push_support-contacts_production_daily":
@@ -35,6 +35,6 @@ govuk_env_sync::tasks:
     dbms: "postgresql"
     storagebackend: "s3"
     database: "support_contacts_production"
-    temppath: "/tmp/"
+    temppath: "/tmp/govuk_env_sync/"
     url: "govuk-production-database-backups"
     path: "postgresql-backend"


### PR DESCRIPTION
Currently, the value of "/tmp/" is causing Puppet to change /tmp to be
owned by govuk-backup, which is breaking NRPE (the Nagios Remote
Plugin Executor) on that machine for some checks.

I'm not quite sure if /tmp is the best place anyway, but for now, just
use a subdirectory to hopefully fix NRPE.