### PR TITLE
Increase the high CPU thresholds for Asset Manager

### DIFF
--- a/modules/govuk/manifests/apps/asset_manager.pp
+++ b/modules/govuk/manifests/apps/asset_manager.pp
@@ -99,6 +99,8 @@ class govuk::apps::asset_manager(
       unicorn_worker_processes => $unicorn_worker_processes,
       nagios_memory_warning    => $nagios_memory_warning,
       nagios_memory_critical   => $nagios_memory_critical,
+      cpu_warning              => 300,
+      cpu_critical             => 400,
     }
 
     govuk::app::envvar {


### PR DESCRIPTION
When large numbers of documents are uploaded to Asset Manager, it has to run the virus scanner on each of those. This causes brief spikes in CPU usage.

This has been the case since around September 2018, especially since Whitehall was migrated to use Asset Manager for attachments. I think we can probably increase the thresholds since it doesn't appear to be causing any significant issues, and we have other alerts that will tell us if Asset Manager is starting to serve 5xx errors which could be a consequence of high CPU usage.

I picked these numbers based on past values for the spikes.

[Trello Card](https://trello.com/c/myqAy86u/303-%F0%9F%93%88-high-cpu-usage-for-asset-manager)