### PR TITLE
Fix router-api puppet issue

### DIFF
--- a/hieradata/class/router_backend.yaml
+++ b/hieradata/class/router_backend.yaml
@@ -1,8 +1,5 @@
 ---
 
-govuk::apps::router_api::oauth_id: "%{hiera('govuk::apps::router_api::oauth_id')}"
-govuk::apps::router_api::oauth_secret: "%{hiera('govuk::apps::router_api::oauth_secret')}"
-
 govuk::apps::router_api::mongodb_name: 'router'
 govuk::apps::router_api::mongodb_nodes:
   - 'router-backend-1.router'

--- a/hieradata_aws/class/router_backend.yaml
+++ b/hieradata_aws/class/router_backend.yaml
@@ -1,8 +1,5 @@
 ---
 
-govuk::apps::router_api::oauth_id: "%{hiera('govuk::apps::router_api::oauth_id')}"
-govuk::apps::router_api::oauth_secret: "%{hiera('govuk::apps::router_api::oauth_secret')}"
-
 govuk::apps::router_api::mongodb_name: 'router'
 govuk::apps::router_api::mongodb_nodes:
   - 'router-backend-1'


### PR DESCRIPTION
This fixes an issue caused by 3cec1de that broke the hieradata (a circular dependency). The lines are unnecessary so can be removed, and should fix the issue.