### PR TITLE
Change the notification_period for the Publishing API healthcheck

### DIFF
--- a/modules/govuk/manifests/apps/publishing_api.pp
+++ b/modules/govuk/manifests/apps/publishing_api.pp
@@ -160,7 +160,7 @@ class govuk::apps::publishing_api(
     vhost_ssl_only                   => true,
     health_check_path                => '/healthcheck',
     health_check_service_template    => 'govuk_urgent_priority',
-    health_check_notification_period => 'inoffice',
+    health_check_notification_period => '24x7',
     json_health_check                => true,
     log_format_is_json               => true,
     deny_framing                     => true,


### PR DESCRIPTION
This healthcheck was added following some incidents with delayed
publishing due to issues with the Publishing API downstream high
queue.

The healthcheck now includes the queue latency. The check was first
added using the inoffice notification period, for testing purposes,
but now that it hasn't alerted spuriously, it's being changed to 24x7,
as this is something that needs to work all day, every day.