### PR TITLE
Revert "disable smokey tests in staging and production"

### DIFF
--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -244,11 +244,7 @@ monitoring::checks::rds::servers:
    - 'mysql-primary'
    - 'mysql-replica'
 
-
-# START OF TEMPORARY DEFECT FIX: # Smokey tests are not running correctly due to defects reported in: https://trello.com/c/XzGHhe3l/1629-investigate-cause-of-jenkins-oom-crashes-in-aws-staging-and-production
-# monitoring::checks::smokey::environment: 'production'
-# END OF TEMPORARY DEFECT FIX
-
+monitoring::checks::smokey::environment: 'production'
 monitoring::uptime_collector::environment: 'production'
 
 postfix::smarthost:

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -236,9 +236,7 @@ monitoring::checks::rds::servers:
    - 'mysql-replica'
 
 
-# START OF TEMPORARY DEFECT FIX: # Smokey tests are not running correctly due to defects reported in: https://trello.com/c/XzGHhe3l/1629-investigate-cause-of-jenkins-oom-crashes-in-aws-staging-and-production
-# monitoring::checks::smokey::environment: 'staging'
-# END OF TEMPORARY DEFECT FIX
+monitoring::checks::smokey::environment: 'staging'
 
 monitoring::uptime_collector::environment: 'staging'
 


### PR DESCRIPTION
I don't think this had the intended effect, as I believe Smokey tests
are still enabled in Staging and Production.

Furthermore, by re-enabling deployements, and improving
Smokey (e.g. [1]), it seems to be more reliable now.

Currently, the smokey-loop service in AWS Staging is configured to use
the production profile (the default), due to the value in the
hieradata being commented out. But the profile doesn't really have an
effect at the moment, so this change shouldn't either.

1: https://github.com/alphagov/smokey/pull/438

This reverts commit cec39f363fd8ff1dff0eb299ca8cc7a11e031c4d and
commit 9cfe01a975253ddd210aa306db21b7efd2ebeb0c.