### PR TITLE
Temporarily disable the CPM daily push

### DIFF
--- a/hieradata/node/warehouse-postgresql-1.backend.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/warehouse-postgresql-1.backend.staging.publishing.service.gov.uk.yaml
@@ -1,6 +1,6 @@
 govuk_env_sync::tasks:
   "push_content_performance_manager_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "3"
     minute: "3"
     action: "push"


### PR DESCRIPTION
The configuration/sync script isn't currently able to handle the
Content Performance Manager database, so the push is failing. I'm not
sure how to fix it, so for now, just disable it.

There seems to be multiple issues, both around the hostname the data
is read from, and the PostgreSQL user used for the connection.