### PR TITLE
Revert "remove the smokey and deploy smokey jobs"

### DIFF
--- a/hieradata_aws/class/production/jenkins.yaml
+++ b/hieradata_aws/class/production/jenkins.yaml
@@ -11,9 +11,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::deploy_puppet
   - govuk_jenkins::jobs::passive_checks
   - govuk_jenkins::jobs::run_rake_task
-# START OF TEMPORARY DEFECT FIX: # Smokey tests are not running correctly due to defects reported in: https://trello.com/c/XzGHhe3l/1629-investigate-cause-of-jenkins-oom-crashes-in-aws-staging-and-production
-#  - govuk_jenkins::jobs::smokey
-# END OF TEMPORARY DEFECT FIX
+  - govuk_jenkins::jobs::smokey
   - govuk_jenkins::jobs::smokey_deploy
   - govuk_jenkins::jobs::transition_load_all_data
   - govuk_jenkins::jobs::transition_load_site_config

--- a/hieradata_aws/class/staging/jenkins.yaml
+++ b/hieradata_aws/class/staging/jenkins.yaml
@@ -12,9 +12,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::mongo_data_sync
   - govuk_jenkins::jobs::passive_checks
   - govuk_jenkins::jobs::run_rake_task
-# START OF TEMPORARY DEFECT FIX: # Smokey tests are not running correctly due to defects reported in: https://trello.com/c/XzGHhe3l/1629-investigate-cause-of-jenkins-oom-crashes-in-aws-staging-and-production  
-#  - govuk_jenkins::jobs::smokey
-# END OF TEMPORARY DEFECT FIX
+  - govuk_jenkins::jobs::smokey
   - govuk_jenkins::jobs::smokey_deploy
   - govuk_jenkins::jobs::data_sync
   - govuk_jenkins::jobs::transition_load_all_data_redirect


### PR DESCRIPTION
The Smokey deploy job has already been restored, and this commit
restores the Smokey job as well.

The Smokey Jenkins job is triggered when deploying apps, and as we are
now running apps in AWS based environments, it's important to be
running Smokey as part of the deployement process, to help identify
issues.

This was disabled as Smokey wasn't running reliably, but it now runs
reliably on the monitoring boxes, so I see no reason why we shouldn't
try it again on the deploy machines.

This reverts commit ce9f0051dcfd8f43d6b7324cdd72f0b353ad7d7f.