### PR TITLE
Add Draft Router API keys and access token

### DIFF
--- a/hieradata/class/draft_cache.yaml
+++ b/hieradata/class/draft_cache.yaml
@@ -5,6 +5,9 @@ govuk::apps::authenticating_proxy::mongodb_nodes:
   - 'router-backend-2.router'
   - 'router-backend-3.router'
 
+govuk::apps::router_api::oauth_id: "%{hiera('govuk::apps::router_api::draft_oauth_id')}"
+govuk::apps::router_api::oauth_secret: "%{hiera('govuk::apps::router_api::draft_oauth_secret')}"
+
 govuk::apps::router::mongodb_name: "%{hiera('govuk::apps::router_api::mongodb_name')}"
 govuk::apps::router::mongodb_nodes:
   - 'router-backend-1.router'

--- a/hieradata/class/draft_content_store.yaml
+++ b/hieradata/class/draft_content_store.yaml
@@ -9,6 +9,7 @@ govuk::apps::content_store::mongodb_nodes:
 
 govuk::apps::content_store::oauth_id: "%{hiera('govuk::apps::content_store::draft_oauth_id')}"
 govuk::apps::content_store::oauth_secret: "%{hiera('govuk::apps::content_store::draft_oauth_secret')}"
+govuk::apps::content_store::router_api_bearer_token: "%{hiera('govuk::apps::content_store::draft_router_api_bearer_token')}"
 govuk::apps::content_store::vhost: 'draft-content-store'
 
 lv:

--- a/hieradata_aws/class/draft_cache.yaml
+++ b/hieradata_aws/class/draft_cache.yaml
@@ -5,6 +5,9 @@ govuk::apps::authenticating_proxy::mongodb_nodes:
   - 'router-backend-2'
   - 'router-backend-3'
 
+govuk::apps::router_api::oauth_id: "%{hiera('govuk::apps::router_api::draft_oauth_id')}"
+govuk::apps::router_api::oauth_secret: "%{hiera('govuk::apps::router_api::draft_oauth_secret')}"
+
 govuk::apps::router_api::mongodb_name: 'draft_router'
 govuk::apps::router_api::mongodb_nodes:
   - 'router-backend-1'

--- a/hieradata_aws/class/draft_content_store.yaml
+++ b/hieradata_aws/class/draft_content_store.yaml
@@ -9,3 +9,4 @@ govuk::apps::content_store::mongodb_nodes:
 govuk::apps::content_store::oauth_id: "%{hiera('govuk::apps::content_store::draft_oauth_id')}"
 govuk::apps::content_store::oauth_secret: "%{hiera('govuk::apps::content_store::draft_oauth_secret')}"
 govuk::apps::content_store::vhost: 'draft-content-store'
+govuk::apps::content_store::router_api_bearer_token: "%{hiera('govuk::apps::content_store::draft_router_api_bearer_token')}"


### PR DESCRIPTION
Following 25c0efb, its also necessary to provide a draft set
of keys and tokens for the router-api, as we run an instance
of the router-api in the draft stack.