### PR TITLE
Remove remnants of the "content register" app

### DIFF
--- a/hieradata/node/postgresql-primary-1.backend.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/postgresql-primary-1.backend.staging.publishing.service.gov.uk.yaml
@@ -21,17 +21,6 @@ govuk_env_sync::tasks:
     temppath: "/var/lib/autopostgresqlbackup/content_audit_tool_production"
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
-  "push_content-register_production":
-    ensure: "absent"
-    hour: "0"
-    minute: "13"
-    action: "push"
-    dbms: "postgresql"
-    storagebackend: "s3"
-    database: "content-register_production"
-    temppath: "/var/lib/autopostgresqlbackup/content-register_production"
-    url: "govuk-staging-database-backups"
-    path: "postgresql-backend"
   "push_content_publisher_production_daily":
     ensure: "absent"
     hour: "0"

--- a/hieradata_aws/class/integration/db_admin.yaml
+++ b/hieradata_aws/class/integration/db_admin.yaml
@@ -21,17 +21,6 @@ govuk_env_sync::tasks:
     temppath: "/tmp/content_audit_tool_production"
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
-  "pull_content-register_production":
-    ensure: "absent"
-    hour: "4"
-    minute: "13"
-    action: "pull"
-    dbms: "postgresql"
-    storagebackend: "s3"
-    database: "content-register_production"
-    temppath: "/tmp/content-register_production"
-    url: "govuk-staging-database-backups"
-    path: "postgresql-backend"
   "pull_content_tagger_production_daily":
     ensure: "absent"
     hour: "4"

--- a/hieradata_aws/class/staging/db_admin.yaml
+++ b/hieradata_aws/class/staging/db_admin.yaml
@@ -21,17 +21,6 @@ govuk_env_sync::tasks:
     temppath: "/tmp/content_audit_tool_production"
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
-  "pull_content-register_production":
-    ensure: "present"
-    hour: "2"
-    minute: "13"
-    action: "pull"
-    dbms: "postgresql"
-    storagebackend: "s3"
-    database: "content-register_production"
-    temppath: "/tmp/content-register_production"
-    url: "govuk-staging-database-backups"
-    path: "postgresql-backend"
   "pull_content_tagger_production_daily":
     ensure: "present"
     hour: "2"

--- a/modules/govuk_ci/manifests/agent/rabbitmq.pp
+++ b/modules/govuk_ci/manifests/agent/rabbitmq.pp
@@ -6,8 +6,6 @@ class govuk_ci::agent::rabbitmq {
   contain ::govuk_rabbitmq
 
   rabbitmq_user {
-    'content_register_test':
-      password => 'content_register';
     'email_alert_service_test':
       password => 'email_alert_service_test';
     'govuk_seed_crawler':
@@ -20,10 +18,6 @@ class govuk_ci::agent::rabbitmq {
   }
 
   rabbitmq_user_permissions {
-    'content_register_test@/':
-      configure_permission => '^(amq\.gen.*|content_register_test)$',
-      read_permission      => '^(amq\.gen.*|content_register_test|content_register_published_documents_test_exchange)$',
-      write_permission     => '^(amq\.gen.*|content_register_test|content_register_published_documents_test_exchange)$';
     'email_alert_service_test@/':
       configure_permission => '^(amq\.gen.*|email_alert_service_published_documents_test_exchange|email_alert_service_published_documents_test_queue|email_alert_service_unpublishing_documents_test_queue)$',
       read_permission      => '^(amq\.gen.*|email_alert_service_published_documents_test_exchange|email_alert_service_published_documents_test_queue|email_alert_service_unpublishing_documents_test_queue)$',
@@ -44,7 +38,6 @@ class govuk_ci::agent::rabbitmq {
 
   govuk_rabbitmq::exchange {
     [
-      'content_register_published_documents_test_exchange@/',
       'email_alert_service_published_documents_test_exchange@/',
       'published_documents_test@/',
     ]:

--- a/modules/grafana/files/dashboards/processes.json
+++ b/modules/grafana/files/dashboards/processes.json
@@ -1147,11 +1147,6 @@
             "selected": false
           },
           {
-            "text": "processes-app-content-register",
-            "value": "processes-app-content-register",
-            "selected": false
-          },
-          {
             "text": "processes-app-content-store",
             "value": "processes-app-content-store",
             "selected": true


### PR DESCRIPTION
The content-register app was retired a long time ago.

I noticed this during a data sync - it seems we still download & restore the content-register database.

It was added in https://github.com/alphagov/govuk-puppet/pull/7960.