### PR TITLE
Remove backups for "email-alert-monitor_production"

### DIFF
--- a/hieradata/node/postgresql-primary-1.backend.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/postgresql-primary-1.backend.staging.publishing.service.gov.uk.yaml
@@ -65,17 +65,6 @@ govuk_env_sync::tasks:
     temppath: "/var/lib/autopostgresqlbackup/email-alert-api_production"
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
-  "push_email-alert-monitor_production_daily":
-    ensure: "absent"
-    hour: "0"
-    minute: "45"
-    action: "push"
-    dbms: "postgresql"
-    storagebackend: "s3"
-    database: "email-alert-monitor_production"
-    temppath: "/var/lib/autopostgresqlbackup/email-alert-monitor_production"
-    url: "govuk-staging-database-backups"
-    path: "postgresql-backend"
   "push_link_checker_api_production_daily":
     ensure: "absent"
     hour: "0"

--- a/hieradata_aws/class/integration/db_admin.yaml
+++ b/hieradata_aws/class/integration/db_admin.yaml
@@ -65,17 +65,6 @@ govuk_env_sync::tasks:
     temppath: "/tmp/contacts_production"
     url: "govuk-staging-database-backups"
     path: "mysql"
-  "pull_email-alert-monitor_production_daily":
-    ensure: "absent"
-    hour: "4"
-    minute: "45"
-    action: "pull"
-    dbms: "postgresql"
-    storagebackend: "s3"
-    database: "email-alert-monitor_production"
-    temppath: "/tmp/email-alert-monitor_production"
-    url: "govuk-staging-database-backups"
-    path: "postgresql-backend"
   "pull_link_checker_api_production_daily":
     ensure: "absent"
     hour: "4"

--- a/hieradata_aws/class/staging/db_admin.yaml
+++ b/hieradata_aws/class/staging/db_admin.yaml
@@ -65,17 +65,6 @@ govuk_env_sync::tasks:
     temppath: "/tmp/contacts_production"
     url: "govuk-staging-database-backups"
     path: "mysql"
-  "pull_email-alert-monitor_production_daily":
-    ensure: "present"
-    hour: "2"
-    minute: "45"
-    action: "pull"
-    dbms: "postgresql"
-    storagebackend: "s3"
-    database: "email-alert-monitor_production"
-    temppath: "/tmp/email-alert-monitor_production"
-    url: "govuk-staging-database-backups"
-    path: "postgresql-backend"
   "pull_link_checker_api_production_daily":
     ensure: "present"
     hour: "2"


### PR DESCRIPTION
This database doesn't exist (the email-alert-monitor isn't an app and doesn't use a database). The resulting file that we download in data sync is an empty SQL dump.

Was added in https://github.com/alphagov/govuk-puppet/pull/7960, but I'm not sure why.