### PR TITLE
add splunk local repo because splunk does not maintain its own repo

### DIFF
--- a/modules/govuk/manifests/node/s_apt.pp
+++ b/modules/govuk/manifests/node/s_apt.pp
@@ -163,6 +163,7 @@ class govuk::node::s_apt (
     distribution => 'xenial',
   }
   aptly::repo { 'sops': }
+  aptly::repo { 'splunk': }
   aptly::repo { 'statsd': }
   aptly::repo { 'terraform': }
   aptly::repo { 'terraform-docs': }


### PR DESCRIPTION
# Context

There is a need to install a Splunk forwarder on the EC2 instances so that the local logs are forwarded to the Splunk service. Unfortunately, there is no Splunk ubuntu repo ([see pending request](https://answers.splunk.com/answers/33933/is-there-a-yum-rpm-repo-for-splunk.html)).

Hence, there is a need to create a local repo on the local apt server to serve the Splunk package by following the instructions set [here](https://docs.publishing.service.gov.uk/manual/debian-packaging.html#header)

# Decisions
1. Instruct aptly to create the Splunk apt repo