### PR TITLE
Remove configuration around notifying to Slack

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -596,11 +596,6 @@ monitoring::checks::ses::region: us-east-1
 monitoring::checks::smokey::environment: 'production'
 monitoring::contacts::notify_graphite: true
 monitoring::contacts::notify_pager: true
-monitoring::contacts::notify_slack: true
-monitoring::contacts::slack_subdomain: 'govuk'
-monitoring::contacts::slack_channel: '#webops-monitoring'
-monitoring::contacts::slack_username: 'Production Icinga'
-monitoring::contacts::slack_alert_url: "https://alert.%{hiera('app_domain')}/cgi-bin/icinga/status.cgi"
 monitoring::edge::enabled: true
 monitoring::uptime_collector::environment: 'production'
 

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -227,11 +227,6 @@ monitoring::checks::rds::region: 'eu-west-1'
 monitoring::checks::cache::region: 'eu-west-1'
 monitoring::contacts::notify_graphite: true
 monitoring::contacts::notify_pager: true
-monitoring::contacts::notify_slack: true
-monitoring::contacts::slack_subdomain: 'govuk'
-monitoring::contacts::slack_channel: '#webops-monitoring'
-monitoring::contacts::slack_username: 'Production Icinga'
-monitoring::contacts::slack_alert_url: "https://alert.%{hiera('app_domain')}/cgi-bin/icinga/status.cgi"
 monitoring::edge::enabled: true
 monitoring::pagerduty_drill::enabled: true
 

--- a/modules/monitoring/manifests/contacts.pp
+++ b/modules/monitoring/manifests/contacts.pp
@@ -12,42 +12,12 @@
 #   Whether to alert PagerDuty.
 #   Default: false
 #
-# [*notify_slack*]
-#   Whether to alert Slack.
-#   Default: false
-#
-# [*slack_subdomain*]
-#   Slack subdomain to send alerts to.
-#   Default: undef
-#
-# [*slack_channel*]
-#   Slack channel to send alerts to.
-#   Default: undef
-#
-# [*slack_username*]
-#   Slack username to send alerts with.
-#   Default: undef
-#
-# [*slack_token*]
-#   Slack token to send alerts with.
-#   Default: undef
-#
-# [*slack_alert_url*]
-#   URL to include in Slack alerts.
-#   Default: 'https://example.com/cgi-bin/icinga/status.cgi'
-#
 class monitoring::contacts (
   $pagerduty_servicekey = '',
   $notify_pager = false,
-  $notify_slack = false,
   $notify_graphite = false,
-  $slack_subdomain = undef,
-  $slack_channel = undef,
-  $slack_username = 'Icinga',
-  $slack_token = undef,
-  $slack_alert_url = 'https://example.com/cgi-bin/icinga/status.cgi',
 ) {
-  validate_bool($notify_pager, $notify_slack, $notify_graphite)
+  validate_bool($notify_pager, $notify_graphite)
 
   $midnight_day_start = '00:00'
   $office_day_start = '09:30'
@@ -106,20 +76,6 @@ class monitoring::contacts (
     timeperiod_alias => 'Never',
   }
 
-  if $notify_slack and ($slack_subdomain and $slack_token and $slack_channel) {
-    icinga::slack_contact { 'slack_notification':
-      slack_token     => $slack_token,
-      slack_channel   => $slack_channel,
-      slack_subdomain => $slack_subdomain,
-      slack_username  => $slack_username,
-      nagios_cgi_url  => $slack_alert_url,
-    }
-
-    $slack_members = ['slack_notification']
-  } else {
-    $slack_members = []
-  }
-
   if $notify_graphite {
     icinga::graphite_contact { 'graphite_notification': }
     $graphite_members = ['graphite_notification']
@@ -144,7 +100,6 @@ class monitoring::contacts (
     group_alias => 'Contacts for urgent priority alerts',
     members     => flatten([
       $graphite_members,
-      $slack_members,
       $pager_members,
     ]),
   }
@@ -157,7 +112,6 @@ class monitoring::contacts (
     group_alias => 'Contacts for high priority alerts',
     members     => flatten([
       $graphite_members,
-      $slack_members,
     ]),
   }
   icinga::service_template { 'govuk_high_priority':
@@ -169,7 +123,6 @@ class monitoring::contacts (
     group_alias => 'Contacts for normal priority alerts',
     members     => flatten([
       $graphite_members,
-      $slack_members,
     ]),
   }
   icinga::service_template { 'govuk_normal_priority':
@@ -181,7 +134,6 @@ class monitoring::contacts (
     group_alias => 'Contacts for regular alerts',
     members     => flatten([
       $graphite_members,
-      $slack_members,
     ]),
   }
   icinga::service_template { [

--- a/modules/monitoring/spec/classes/contacts_spec.rb
+++ b/modules/monitoring/spec/classes/contacts_spec.rb
@@ -35,27 +35,6 @@ describe 'monitoring::contacts', :type => :class do
       []
   end
 
-  context 'notify_pager => true, notify_slack => true, slack creds' do
-    let(:params) {{
-      :notify_pager       => true,
-      :notify_slack       => true,
-      :slack_token        => 'peach',
-      :slack_channel      => 'pear',
-      :slack_subdomain    => 'plum',
-    }}
-
-    it { is_expected.to contain_icinga__slack_contact('slack_notification').with(
-      :slack_token     => 'peach',
-      :slack_channel   => 'pear',
-      :slack_subdomain => 'plum'
-    )}
-
-    it_should_behave_like 'configured contact groups',
-      ['slack_notification', 'pagerduty_24x7'],
-      ['slack_notification'],
-      ['slack_notification']
-  end
-
   context 'notify_graphite => true' do
     let(:params) {{
       :notify_graphite => true,


### PR DESCRIPTION
It doesn't seem like anyone is using this and since moving Slack instance this hasn't worked anyway.

[Trello Card](https://trello.com/c/SaR74X9M/705-should-alerts-be-going-to-slack)