### PR TITLE
Future parser test fixups

### DIFF
--- a/modules/govuk/spec/classes/govuk__apt_spec.rb
+++ b/modules/govuk/spec/classes/govuk__apt_spec.rb
@@ -6,7 +6,7 @@ describe 'govuk::node::s_apt' do
     :vdc            => 'fake_vdc',
   }}
   let(:node) { 'apt-1.management.somethingsomething' }
-  let(:pre_condition) { 'govuk_mount { "/root/dir": }' }
+  let(:pre_condition) { 'govuk_mount { "/root/dir": disk => \'/dev/null\', }' }
 
   describe 'real_ip_header' do
     context 'when not specified' do

--- a/modules/govuk/spec/classes/govuk__node__s_base_spec.rb
+++ b/modules/govuk/spec/classes/govuk__node__s_base_spec.rb
@@ -27,7 +27,8 @@ describe 'govuk::node::s_base', :type => :class do
   context 'if node in AWS' do
     let(:facts) {{
       :aws_migration => 'backend',
-      :fqdn_short => 'backend-1.backend.foo'
+      :fqdn_short => 'backend-1.backend.foo',
+      :vdc => 'dummy-vdc',
     }}
     it 'it includes all apps that run on backend' do
       is_expected.to contain_class('govuk::apps::some_null_class')
@@ -36,7 +37,8 @@ describe 'govuk::node::s_base', :type => :class do
 
   context 'if node not in AWS' do
     let(:facts) {{
-      :fqdn_short => 'backend-1.backend'
+      :fqdn_short => 'backend-1.backend',
+      :vdc => 'dummy-vdc',
     }}
     it 'it includes all apps that run on backend' do
       is_expected.to contain_class('govuk::apps::some_null_class')
@@ -46,6 +48,7 @@ describe 'govuk::node::s_base', :type => :class do
   context 'if we do not set an app for the class' do
     let(:facts) {{
       :aws_migration => 'some_fake_node_class',
+      :vdc => 'dummy-vdc',
     }}
     it 'we should not include anything' do
       is_expected.to_not contain_class('govuk::apps::some_null_class')
@@ -54,7 +57,8 @@ describe 'govuk::node::s_base', :type => :class do
 
   context 'if node class name has an underscore and hostname has a hyphen' do
     let(:facts) {{
-      :fqdn_short => 'calculators-frontend-1.api'
+      :fqdn_short => 'calculators-frontend-1.api',
+      :vdc => 'dummy-vdc',
     }}
     it 'it includes all apps that run on calculators_frontend' do
       is_expected.to contain_class('govuk::apps::calc_null_class')

--- a/modules/govuk/spec/classes/govuk_nodes_spec_optional.rb
+++ b/modules/govuk/spec/classes/govuk_nodes_spec_optional.rb
@@ -36,6 +36,7 @@ ENV.fetch('classes').split(",").each do |class_name|
         :memorysize =>  '3.86 GB',
         :memorysize_mb => 3953.43,
         :aws_migration => (class_name =~ /db_admin/ ? true : false),
+        :vdc => 'example',
       }}
 
       let(:hiera_config) { temporary_hiera_file.path }

--- a/modules/govuk_containers/spec/defines/govuk_containers__app__spec.rb
+++ b/modules/govuk_containers/spec/defines/govuk_containers__app__spec.rb
@@ -18,9 +18,9 @@ describe 'govuk_containers::app', :type => :define do
       is_expected.to contain_docker__run('bella').with(
         'net' => 'host',
         'image' => 'cat:current',
-        'ports' => '1234:1234',
+        'ports' => ['1234:1234'],
         'env_file' => '/etc/global.env',
-        'extra_parameters' => '--restart=on-failure:3',
+        'extra_parameters' => ['--restart=on-failure:3'],
       )
     end
   end
@@ -36,10 +36,10 @@ describe 'govuk_containers::app', :type => :define do
       is_expected.to contain_docker__run('bella').with(
         'net' => 'host',
         'image' => 'cat:current',
-        'ports' => '1234:1234',
+        'ports' => ['1234:1234'],
         'env_file' => '/etc/global.env',
         'env' => [ 'cheese=milk', 'wheat=bread' ],
-        'extra_parameters' => '--restart=on-failure:3',
+        'extra_parameters' => ['--restart=on-failure:3'],
       )
     end
   end
@@ -55,9 +55,9 @@ describe 'govuk_containers::app', :type => :define do
       is_expected.to contain_docker__run('bella').with(
         'net' => 'host',
         'image' => 'cat:current',
-        'ports' => '1234:1234',
+        'ports' => ['1234:1234'],
         'env_file' => '/etc/global.env',
-        'extra_parameters' => '--restart=no',
+        'extra_parameters' => ['--restart=no'],
       )
     end
   end
@@ -73,9 +73,9 @@ describe 'govuk_containers::app', :type => :define do
       is_expected.to contain_docker__run('bella').with(
         'net' => 'host',
         'image' => 'cat:current',
-        'ports' => '1234:1234',
+        'ports' => ['1234:1234'],
         'env_file' => '/etc/global.env',
-        'extra_parameters' => '--restart=always',
+        'extra_parameters' => ['--restart=always'],
       )
     end
   end

--- a/modules/govuk_jenkins/spec/classes/govuk_jenkins__jobs__each_spec.rb
+++ b/modules/govuk_jenkins/spec/classes/govuk_jenkins__jobs__each_spec.rb
@@ -20,9 +20,7 @@ BROKEN_SPECS = %w[
 ]
 
 # test everything apart from known broken exceptions
-FILES = FILES - BROKEN_SPECS
-
-FILES.each do |filename|
+(FILES - BROKEN_SPECS).each do |filename|
   classname = filename.split(".")[0]
 
   describe "govuk_jenkins::jobs::#{classname}", :type => :class do

--- a/modules/mongodb/spec/classes/mongodb_spec.rb
+++ b/modules/mongodb/spec/classes/mongodb_spec.rb
@@ -34,7 +34,7 @@ describe 'mongodb::server', :type => :class do
     } }
 
     it do
-      is_expected.to raise_error(Puppet::Error, /^Replica set can't have no members/)
+      is_expected.to raise_error(Puppet::Error, /Replica set can't have no members/)
     end
   end
 

--- a/modules/phantomjs/spec/classes/phantomjs_spec.rb
+++ b/modules/phantomjs/spec/classes/phantomjs_spec.rb
@@ -1,6 +1,11 @@
 require_relative '../../../../spec_helper'
 
 describe 'phantomjs', :type => :class do
+  let(:facts) do
+    {
+      :operatingsystem => 'Linux',
+    }
+  end
 
   it { is_expected.to compile }
 


### PR DESCRIPTION
Fix up a bunch of tests so that they pass under the Puppet 3 future parser.

There are further changes needed to get all tests to pass under the future parser, but that requires additional changes in the main puppet codebase, a couple of puppet module updates and an rspec upgrade. This is a tests-only change.