### PR TITLE
firebreak: adding prometheus local apt repo

### DIFF
--- a/modules/govuk/manifests/node/s_apt.pp
+++ b/modules/govuk/manifests/node/s_apt.pp
@@ -152,6 +152,7 @@ class govuk::node::s_apt (
   aptly::repo { 'gor': }
   aptly::repo { 'govuk-datascrubber': }
   aptly::repo { 'govuk-jenkins': }
+  aptly::repo { 'govuk-prometheus-node-exporter': }
   aptly::repo { 'govuk-python': }
   aptly::repo { 'govuk-rubygems': }
   aptly::repo { 'govuk-splunk-configurator': }


### PR DESCRIPTION
prometheus do not maintain their own linux package repos and the
prometheus node exporter packages and other packages are not available
on the ubuntu mirrors for trusty.

So we are building the packages required using fpm and require this
local aptly repo to host them.

@ronocg <conor.glynn@digital.cabinet-office.gov.uk>