### PR TITLE
Improve the event-store configuration

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -455,6 +455,8 @@ govuk::apps::email_alert_service::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::email_alert_service::rabbitmq::queue_size_critical_threshold: 25
 govuk::apps::email_alert_service::rabbitmq::queue_size_warning_threshold: 5
 
+govuk::apps::event_store::enabled: false
+
 govuk::apps::finder_frontend::enabled: true
 govuk::apps::finder_frontend::nagios_memory_warning: 2000
 govuk::apps::finder_frontend::nagios_memory_critical: 2500

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -116,7 +116,6 @@ govuk::apps::email_alert_api::enable_procfile_worker: false
 govuk::apps::email_alert_service::rabbitmq_hosts: ['localhost']
 govuk::apps::email_alert_service::rabbitmq::queue_size_critical_threshold: 25
 govuk::apps::email_alert_service::rabbitmq::queue_size_warning_threshold: 5
-govuk::apps::event_store::enabled: true
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
 govuk::apps::government_frontend::enable_running_in_draft_mode::content_store: 'http://draft-content-store.dev.gov.uk'
 govuk::apps::imminence::enable_procfile_worker: false

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -479,6 +479,8 @@ govuk::apps::email_alert_service::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::email_alert_service::rabbitmq::queue_size_critical_threshold: 25
 govuk::apps::email_alert_service::rabbitmq::queue_size_warning_threshold: 5
 
+govuk::apps::event_store::enabled: false
+
 govuk::apps::finder_frontend::enabled: true
 govuk::apps::finder_frontend::nagios_memory_warning: 2000
 govuk::apps::finder_frontend::nagios_memory_critical: 2500

--- a/modules/govuk/manifests/apps/event_store.pp
+++ b/modules/govuk/manifests/apps/event_store.pp
@@ -20,24 +20,27 @@ class govuk::apps::event_store (
   $mongodb_servers = [],
   $port = '3097',
 ) {
-  if $enabled {
-    Govuk::App::Envvar {
-      app => 'event-store',
-    }
+  $ensure = $enabled ? {
+    true  => 'present',
+    false => 'absent',
+  }
 
-    govuk::app::envvar {
-      'EVENT_STORE_MONGO_NODES':
-        value => join($mongodb_servers, ',');
-    }
+  Govuk::App::Envvar {
+    ensure => $ensure,
+    app    => 'event-store',
+  }
 
-    govuk::app { 'event-store':
-      ensure             => 'absent',
-      app_type           => 'bare',
-      command            => './event-store',
-      health_check_path  => '/healthcheck',
-      port               => $port,
-      enable_nginx_vhost => true,
-    }
+  govuk::app::envvar {
+    'EVENT_STORE_MONGO_NODES':
+      value => join($mongodb_servers, ',');
+  }
 
+  govuk::app { 'event-store':
+    ensure             => $ensure,
+    app_type           => 'bare',
+    command            => './event-store',
+    health_check_path  => '/healthcheck',
+    port               => $port,
+    enable_nginx_vhost => true,
   }
 }


### PR DESCRIPTION
Transform the enabled value in to the ensure value, and then pass that
value in to the different components, including the environment
variables.

Then, disable the app in both the AWS and non-AWS hieradata, removing
the redundant value from the development specific hieradata.

These changes should solve some govuk-puppet errors related to the
event-store.