### PR TITLE
Add blank lines to robots.txt

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1809,14 +1809,17 @@ router::nginx::robotstxt: |
   # Don't allow indexing of user needs pages
   Disallow: /info/*
   Sitemap: https://www.gov.uk/sitemap.xml
+
   # https://ahrefs.com/robot/ crawls the site frequently
   User-agent: AhrefsBot
   Crawl-delay: 10
+
   # https://www.deepcrawl.com/bot/ makes lots of requests. Ideally
   # we'd slow it down rather than blocking it but it doesn't mention
   # whether or not it supports crawl-delay.
   User-agent: deepcrawl
   Disallow: /
+
   # Complaints of 429 'Too many requests' seem to be coming from SharePoint servers
   # (https://social.msdn.microsoft.com/Forums/en-US/3ea268ed-58a6-4166-ab40-d3f4fc55fef4)
   # The robot doesn't recognise its User-Agent string, see the MS support article:

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1265,14 +1265,17 @@ router::nginx::robotstxt: |
   # Don't allow indexing of user needs pages
   Disallow: /info/*
   Sitemap: https://www.gov.uk/sitemap.xml
+
   # https://ahrefs.com/robot/ crawls the site frequently
   User-agent: AhrefsBot
   Crawl-delay: 10
+
   # https://www.deepcrawl.com/bot/ makes lots of requests. Ideally
   # we'd slow it down rather than blocking it but it doesn't mention
   # whether or not it supports crawl-delay.
   User-agent: deepcrawl
   Disallow: /
+
   # Complaints of 429 'Too many requests' seem to be coming from SharePoint servers
   # (https://social.msdn.microsoft.com/Forums/en-US/3ea268ed-58a6-4166-ab40-d3f4fc55fef4)
   # The robot doesn't recognise its User-Agent string, see the MS support article:


### PR DESCRIPTION
This adds some blank lines to robots.txt, which some parsers need. Fixes https://github.com/alphagov/govuk-puppet/issues/8518.