### PR TITLE
Fixups to support Puppet future parser

### DIFF
--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -138,7 +138,7 @@ define govuk::app::config (
         value   => $app_type;
       "${title}-PORT":
         varname => 'PORT',
-        value   => $port;
+        value   => "${port}"; # lint:ignore:only_variable_string
       "${title}-GOVUK_APP_NAME":
         varname => 'GOVUK_APP_NAME',
         value   => $title;
@@ -166,7 +166,7 @@ define govuk::app::config (
     if $app_type == 'rack' and $unicorn_herder_timeout != 'NOTSET' {
       govuk::app::envvar { "${title}-UNICORN_HERDER_TIMEOUT":
         varname => 'UNICORN_HERDER_TIMEOUT',
-        value   => $unicorn_herder_timeout;
+        value   => "${unicorn_herder_timeout}"; # lint:ignore:only_variable_string
       }
     }
 
@@ -187,7 +187,7 @@ define govuk::app::config (
     if $unicorn_worker_processes {
       govuk::app::envvar { "${title}-UNICORN_WORKER_PROCESSES":
         varname => 'UNICORN_WORKER_PROCESSES',
-        value   => $unicorn_worker_processes;
+        value   => "${unicorn_worker_processes}"; # lint:ignore:only_variable_string
       }
     }
   }

--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -156,7 +156,7 @@ define govuk::app::config (
         value   => $sentry_dsn;
     }
 
-    if $::govuk_node_class !~ /^development$/ {
+    if 'development' != $::govuk_node_class {
       govuk::app::envvar { "${title}-GOVUK_APP_LOGROOT":
         varname => 'GOVUK_APP_LOGROOT',
         value   => "/var/log/${title}",

--- a/modules/govuk/manifests/apps/content_store/enable_running_in_draft_mode.pp
+++ b/modules/govuk/manifests/apps/content_store/enable_running_in_draft_mode.pp
@@ -73,7 +73,7 @@ class govuk::apps::content_store::enable_running_in_draft_mode(
       value   => 'draft-';
     "${title}-PORT":
       varname => 'PORT',
-      value   => $draft_content_store_port;
+      value   => "${draft_content_store_port}"; # lint:ignore:only_variable_string
   }
 
   govuk::app::envvar::mongodb_uri { $app_name:

--- a/modules/govuk/manifests/apps/government_frontend/enable_running_in_draft_mode.pp
+++ b/modules/govuk/manifests/apps/government_frontend/enable_running_in_draft_mode.pp
@@ -68,6 +68,6 @@ class govuk::apps::government_frontend::enable_running_in_draft_mode(
       value   => $content_store;
     "${title}-PORT":
       varname => 'PORT',
-      value   => $draft_government_frontend_port;
+      value   => "${draft_government_frontend_port}"; # lint:ignore:only_variable_string
   }
 }

--- a/modules/govuk/manifests/apps/manuals_frontend/enable_running_in_draft_mode.pp
+++ b/modules/govuk/manifests/apps/manuals_frontend/enable_running_in_draft_mode.pp
@@ -68,6 +68,6 @@ class govuk::apps::manuals_frontend::enable_running_in_draft_mode(
       value   => $content_store;
     "${title}-PORT":
       varname => 'PORT',
-      value   => $draft_manuals_frontend_port;
+      value   => "${draft_manuals_frontend_port}"; # lint:ignore:only_variable_string
   }
 }

--- a/modules/govuk/manifests/apps/smartanswers/enable_running_in_draft_mode.pp
+++ b/modules/govuk/manifests/apps/smartanswers/enable_running_in_draft_mode.pp
@@ -68,6 +68,6 @@ class govuk::apps::smartanswers::enable_running_in_draft_mode(
       value   => $content_store;
     "${title}-PORT":
       varname => 'PORT',
-      value   => $draft_smartanswers_port;
+      value   => "${draft_smartanswers_port}"; # lint:ignore:only_variable_string
   }
 }

--- a/modules/govuk/manifests/node/s_bouncer.pp
+++ b/modules/govuk/manifests/node/s_bouncer.pp
@@ -27,9 +27,11 @@ class govuk::node::s_bouncer (
     notes_url => monitoring_docs_url(nginx-high-conn-writing-upstream-indicator-check),
   }
 
+  $warning_threshold = 1.2 * $minimum_request_rate
+
   @@icinga::check::graphite { "check_nginx_requests_${::hostname}":
     target              => "${::fqdn_metrics}.nginx.nginx_requests",
-    warning             => "@${minimum_request_rate * 1.2}",
+    warning             => "@${warning_threshold}",
     critical            => "@${minimum_request_rate}",
     desc                => 'Minimum HTTP request rate for bouncer',
     host_name           => $::fqdn,

--- a/modules/govuk_beat/manifests/repo.pp
+++ b/modules/govuk_beat/manifests/repo.pp
@@ -16,6 +16,5 @@ class govuk_beat::repo(
     location     => "http://${apt_mirror_hostname}/elastic-beats",
     release      => 'stable',
     architecture => $::architecture,
-    key          => '',
   }
 }

--- a/modules/govuk_containers/manifests/app.pp
+++ b/modules/govuk_containers/manifests/app.pp
@@ -57,7 +57,7 @@ define govuk_containers::app (
   include ::govuk_containers::app::config
 
   validate_array($envvars)
-  validate_re($restart_attempts, [ 'never', 'always', '^\d$' ])
+  validate_re("${restart_attempts}", [ 'never', 'always', '^\d$' ]) # lint:ignore:only_variable_string
 
   $exposed_port = "${port}:${port}"
 

--- a/modules/govuk_jenkins/manifests/jobs/update_cdn_dictionaries.pp
+++ b/modules/govuk_jenkins/manifests/jobs/update_cdn_dictionaries.pp
@@ -6,6 +6,7 @@ class govuk_jenkins::jobs::update_cdn_dictionaries(
   $app_domain = hiera('app_domain'),
 ) {
 
+  $environment_variables = $govuk_jenkins::environment_variables
   $slack_team_domain = 'gds'
   $slack_room = 'govuk-deploy'
   $slack_build_server_url = "https://deploy.${app_domain}/"

--- a/modules/icinga/manifests/check/graphite.pp
+++ b/modules/icinga/manifests/check/graphite.pp
@@ -91,11 +91,11 @@ define icinga::check::graphite(
   # Only display lines when threshold is an integer or float.
   # The '@' symbol indicates to icinga that the threshold is a minimum so we
   # allow that and capture the numbers for display in graphite.
-  $warn_line = $warning ? {
+  $warn_line = "${warning}" ? { # lint:ignore:only_variable_string
     /^@?([0-9.]+)$/ => "&target=alias(dashed(constantLine(${1})),%22warning%22)",
     default    => '',
   }
-  $crit_line = $critical ? {
+  $crit_line = "${critical}" ? { # lint:ignore:only_variable_string
     /^@?([0-9.]+)$/ => "&target=alias(dashed(constantLine(${1})),%22critical%22)",
     default    => '',
   }

--- a/modules/mongodb/templates/configure-node-priority.js.erb
+++ b/modules/mongodb/templates/configure-node-priority.js.erb
@@ -1,9 +1,11 @@
 var expectedReplicaSetMembers = [
-  <%- @members.each do |host, properties| -%>
+  <%-
+    @members.each do |host, properties|
+      properties ||= {} -%>
     {
       host: '<%= host %>:27017',
-      priority: <%= properties ? properties.fetch('priority', 1) : 1 %>,
-      hidden: <%= properties ? properties.fetch('hidden', false) : false %>,
+      priority: <%= properties['priority'] || 1 %>,
+      hidden: <%= properties['hidden'] || false %>,
     },
   <%- end -%>
 ]


### PR DESCRIPTION
The Puppet 4.x parser is stricter than the 3.x one. Here are a bunch of rather random changes to improve our compatibility with Puppet 4. There are still a few more things to fix before the tests all pass, but these are the ones which I think are nice and safe.

The fix to `govuk_jenkins` is rather ugly and I'm not proud of it. Maybe we should find a better way to do that, maybe not?