### PR TITLE
Remove support and support-api from Carrenza hosts

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -317,8 +317,6 @@ hosts::production::backend::app_hostnames:
   - 'specialist-publisher'
   - 'specialist-publisher-rebuild'
   - 'specialist-publisher-rebuild-standalone'
-  - 'support'
-  - 'support-api'
   - 'travel-advice-publisher'
   - 'whitehall-admin'
 


### PR DESCRIPTION
- This completes migration to AWS by forcing traffic to support and
support-api to be resolved by DNS and send to AWS

solo: @schmie