### PR TITLE
Firebreak: adding prometheus node exporter

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -129,6 +129,8 @@ govuk::node::s_whitehall_backend::sync_mirror: true
 govuk::node::s_transition_postgresql_slave::redirector_ip_range: '10.1.5.0/24'
 govuk::node::s_transition_postgresql_standby::redirector_ip_range: "%{hiera('govuk::node::s_transition_postgresql_slave::redirector_ip_range')}"
 
+govuk_prometheus_node_exporter::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+
 govuk_sudo::sudo_conf:
   deploy_service_postgresql:
     content: 'deploy ALL=NOPASSWD:/etc/init.d/postgresql'

--- a/modules/base/manifests/init.pp
+++ b/modules/base/manifests/init.pp
@@ -36,6 +36,11 @@ class base {
     include resolvconf
   }
 
+  # Only for testing
+  if $::aws_environment == 'integration' {
+    include govuk_prometheus_node_exporter
+  }
+
   include ssh
   include timezone
   include tmpreaper

--- a/modules/govuk_prometheus_node_exporter/manifests/init.pp
+++ b/modules/govuk_prometheus_node_exporter/manifests/init.pp
@@ -1,0 +1,24 @@
+# == Class: govuk_prometheus_node_exporter
+#
+# Install and run Prometheus Node Exporter
+#
+class govuk_prometheus_node_exporter {
+
+  include govuk_prometheus_node_exporter::repo
+
+  package { 'node-exporter':
+    ensure  => latest,
+    require => Apt::Source['govuk-prometheus-node-exporter'],
+  }
+
+  service { 'node-exporter':
+    ensure  => running,
+  }
+
+  @@icinga::check { "check_prometheus_node_exporter_running_${::hostname}":
+    check_command       => 'check_nrpe!check_proc_running!node_exporter',
+    service_description => 'prometheus_node_exporter running',
+    host_name           => $::fqdn,
+    notes_url           => monitoring_docs_url(check-process-running),
+  }
+}

--- a/modules/govuk_prometheus_node_exporter/manifests/repo.pp
+++ b/modules/govuk_prometheus_node_exporter/manifests/repo.pp
@@ -1,0 +1,23 @@
+# == Class: govuk_prometheus_node_exporter::repo
+#
+# Installs the following Deb package:
+# prometheus node exporter: 
+# which makes its possible for the prometheus server to pull metrics from a host
+#
+#
+# === Parameters:
+#
+# [*apt_mirror_hostname*]
+#   Hostname to use for the APT mirror.
+#
+class govuk_prometheus_node_exporter::repo (
+  $apt_mirror_hostname,
+) {
+  apt::source { 'govuk-prometheus-node-exporter':
+    location     => "http://${apt_mirror_hostname}/govuk-prometheus-node-exporter",
+    release      => $::lsbdistcodename,
+    architecture => $::architecture,
+    repos        => 'stable',
+    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+  }
+}


### PR DESCRIPTION
As part of firebreak we wish to deploy the prometheus node exporter to
the govuk integration environment. In order to gather metrics from hosts
into a prometheus server.

@ronocg <conor.glynn@digital.cabinet-office.gov.uk>