### PR TITLE
Remove conditional around include loadbalancer::maintenance

### DIFF
--- a/modules/loadbalancer/manifests/balance.pp
+++ b/modules/loadbalancer/manifests/balance.pp
@@ -89,7 +89,5 @@ define loadbalancer::balance(
     }
   }
 
-  if $maintenance_mode {
-    include loadbalancer::maintenance
-  }
+  include loadbalancer::maintenance
 }


### PR DESCRIPTION
The sole purpose of this configuration is to ensure the loadbalancer
has the page to return when in maintainance mode.

It's best to include it all the time, so all of the loadbalancers are
ready for maintainance mode, and so the relevant code is used and
tested, before you actually need it.