### PR TITLE
add splunk module and test on aws staging frontend-calculator

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -952,6 +952,8 @@ govuk_sudo::sudo_conf:
   ubuntu:
     content: 'ubuntu ALL=(ALL) NOPASSWD:ALL'
 
+govuk_splunk::repos::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+
 govuk_unattended_reboot::alert_hostname: 'alert'
 govuk_unattended_reboot::enabled: true
 govuk_unattended_reboot::mongodb::enabled: true

--- a/modules/govuk/manifests/node/s_calculators_frontend.pp
+++ b/modules/govuk/manifests/node/s_calculators_frontend.pp
@@ -22,4 +22,9 @@ class govuk::node::s_calculators_frontend inherits govuk::node::s_base {
     host_name => $::fqdn,
     notes_url => monitoring_docs_url(nginx-high-conn-writing-upstream-indicator-check),
   }
+
+  # Only for testing
+  if $::aws_environment == 'staging' {
+    include govuk_splunk
+  }
 }

--- a/modules/govuk_splunk/manifests/init.pp
+++ b/modules/govuk_splunk/manifests/init.pp
@@ -1,0 +1,148 @@
+# == Class: govuk_splunk
+#
+# Install, configure and run Splunk universal forwarder
+#
+# === Parameters:
+#
+# [*gds_servers*]
+#   string of comma delimited "ipaddress:portnumber" of GDS Splunk cloud servers
+#
+# [*gds_server_cert*]
+#   Private certificate and key of forwarder to contact GDS Splunk cloud
+#
+# [*gds_root_ca_cert*]
+#   certificate of certificate authority of GDS Splunk cloud
+#
+# [*gds_password*]
+#   password to use for GDS Splunk cloud
+#
+# [*gds_cname*]
+#   common name of GDS Splunk cloud
+#
+# [*cyber_servers*]
+#   string of comma delimited "ipaddress:portnumber" of Cyber Splunk cloud
+#   servers
+#
+# [*cyber_server_cert*]
+#   certificate of Cyber Splunk cloud
+#
+# [*cyber_root_ca_cert*]
+#   certificate of certificate authority of Cyber Splunk cloud
+#
+# [*cyber_cname*]
+#   common name of Cyber Splunk cloud
+#
+#
+class govuk_splunk(
+  $gds_servers,
+  $gds_server_cert,
+  $gds_root_ca_cert,
+  $gds_password,
+  $gds_cname,
+  $cyber_servers,
+  $cyber_server_cert,
+  $cyber_root_ca_cert,
+  $cyber_cname,
+) {
+
+  include govuk_splunk::repos
+
+  package { 'splunkforwarder':
+    ensure  => latest,
+    require => Apt::Source['splunk'],
+  }
+
+  package { 'acl':
+    ensure  => latest,
+  }
+
+  user { 'splunk':
+    ensure => present,
+  }
+
+  group { 'splunk':
+    ensure => present,
+  }
+
+  package { 'govuk-splunk-configurator':
+    ensure  => latest,
+    require => [ Package['splunkforwarder', 'acl'],
+                Apt::Source['govuk-splunk-configurator'],
+                User['splunk'],
+                Group['splunk'],
+                ],
+  }
+
+  file {'/opt/splunkforwarder/etc/apps/100_gds_splunkcloud/default/gds_server.pem':
+    ensure  => file,
+    owner   => 'splunk',
+    mode    => '0600',
+    content => $gds_server_cert,
+    require => Package['govuk-splunk-configurator'],
+    notify  => Service['splunk'],
+  }
+
+  file {'/opt/splunkforwarder/etc/apps/100_gds_splunkcloud/default/gds_cacert.pem':
+    ensure  => file,
+    owner   => 'splunk',
+    mode    => '0600',
+    content => $gds_root_ca_cert,
+    require => Package['govuk-splunk-configurator'],
+    notify  => Service['splunk'],
+  }
+
+  file { '/opt/splunkforwarder/etc/apps/100_gds_splunkcloud/default/outputs.conf':
+    ensure  => present,
+    owner   => 'splunk',
+    mode    => '0600',
+    content => template('govuk_splunk/opt/splunkforwarder/etc/apps/100_gds_splunkcloud/default/outputs.conf'),
+    require => Package['govuk-splunk-configurator'],
+    notify  => Service['splunk'],
+  }
+
+  file {'/opt/splunkforwarder/etc/apps/100_hf_connect/default/CyberSplunkUFCombinedCertificate.pem':
+    ensure  => file,
+    owner   => 'splunk',
+    mode    => '0600',
+    content => $cyber_server_cert,
+    require => Package['govuk-splunk-configurator'],
+    notify  => Service['splunk'],
+  }
+
+  file {'/opt/splunkforwarder/etc/apps/100_hf_connect/default/CyberSplunkCACertificate.pem':
+    ensure  => file,
+    owner   => 'splunk',
+    mode    => '0600',
+    content => $cyber_root_ca_cert,
+    require => Package['govuk-splunk-configurator'],
+    notify  => Service['splunk'],
+  }
+
+  file { '/opt/splunkforwarder/etc/apps/100_hf_connect/default/outputs.conf':
+    ensure  => present,
+    owner   => 'splunk',
+    mode    => '0600',
+    content => template('govuk_splunk/opt/splunkforwarder/etc/apps/100_hf_connect/default/outputs.conf'),
+    require => Package['govuk-splunk-configurator'],
+    notify  => Service['splunk'],
+  }
+
+  service { 'splunk':
+    ensure    => running,
+    subscribe => File['/opt/splunkforwarder/etc/apps/100_gds_splunkcloud/default/gds_server.pem',
+                      '/opt/splunkforwarder/etc/apps/100_gds_splunkcloud/default/gds_cacert.pem',
+                      '/opt/splunkforwarder/etc/apps/100_gds_splunkcloud/default/outputs.conf',
+                      '/opt/splunkforwarder/etc/apps/100_hf_connect/default/CyberSplunkUFCombinedCertificate.pem',
+                      '/opt/splunkforwarder/etc/apps/100_hf_connect/default/CyberSplunkCACertificate.pem',
+                      '/opt/splunkforwarder/etc/apps/100_hf_connect/default/outputs.conf'
+                      ],
+  }
+
+  @@icinga::check { "check_splunk_running_${::hostname}":
+    check_command       => 'check_nrpe!check_proc_running!splunk',
+    service_description => 'splunk universal forwarder running',
+    host_name           => $::fqdn,
+    notes_url           => monitoring_docs_url(check-process-running),
+  }
+
+}

--- a/modules/govuk_splunk/manifests/repos.pp
+++ b/modules/govuk_splunk/manifests/repos.pp
@@ -1,0 +1,30 @@
+# == Class: govuk_splunk::repos
+#
+# Installs the following Debian packages:
+# 1. the Splunk universal forwarder: which collects and forwards the logs to
+#    the Splunk cloud
+# 2. the GDS Splunk configurator: which configures the Splunk forwarder
+#
+#
+# === Parameters:
+#
+# [*apt_mirror_hostname*]
+#   Hostname to use for the APT mirror.
+#
+class govuk_splunk::repos (
+  $apt_mirror_hostname,
+) {
+  apt::source { 'splunk':
+    location     => "http://${apt_mirror_hostname}/splunk",
+    release      => 'stable',
+    architecture => $::architecture,
+    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+  }
+
+  apt::source { 'govuk-splunk-configurator':
+    location     => "http://${apt_mirror_hostname}/govuk-splunk-configurator",
+    release      => 'stable',
+    architecture => $::architecture,
+    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+  }
+}

--- a/modules/govuk_splunk/templates/opt/splunkforwarder/etc/apps/100_gds_splunkcloud/default/outputs.conf
+++ b/modules/govuk_splunk/templates/opt/splunkforwarder/etc/apps/100_gds_splunkcloud/default/outputs.conf
@@ -1,0 +1,14 @@
+[tcpout]
+defaultGroup = splunkcloud
+
+[tcpout:splunkcloud]
+server = <%= gds_servers %>
+compressed = false
+
+sslCertPath = $SPLUNK_HOME/etc/apps/100_gds_splunkcloud/default/gds_server.pem
+sslRootCAPath = $SPLUNK_HOME/etc/apps/100_gds_splunkcloud/default/gds_cacert.pem
+sslPassword = <%= gds_password %>
+
+sslCommonNameToCheck = <%= gds_cname %>
+sslVerifyServerCert = true
+useClientSSLCompression = true

--- a/modules/govuk_splunk/templates/opt/splunkforwarder/etc/apps/100_hf_connect/default/outputs.conf
+++ b/modules/govuk_splunk/templates/opt/splunkforwarder/etc/apps/100_hf_connect/default/outputs.conf
@@ -1,0 +1,14 @@
+[tcpout]
+defaultGroup = splunkhf
+
+[tcpout:splunkhf]
+server = <%= cyber_servers %>
+compressed = false
+
+sslCertPath = $SPLUNK_HOME/etc/apps/100_hf_connect/default/CyberSplunkUFCombinedCertificate.pem
+sslRootCAPath = $SPLUNK_HOME/etc/apps/100_hf_connect/default/CyberSplunkCACertificate.pem
+sslPassword =
+
+sslCommonNameToCheck = <%= cyber_cname %>
+sslVerifyServerCert = true
+useClientSSLCompression = true


### PR DESCRIPTION
# Content

As part of the firebreak, the task was to deploy a splunk forwarder on the ec2 instances of govuk and make them communicate with the Splunk cloud of GDS.

Decisions.
1. add splunk local apt repo
2. add govuk-splunk-configurator repo (binary does not contain confidential info)
3. create govuk_splunk module to:
      1. install the splunk forwarder and govuk-splunk-configurator 
      2. create the splunk config files based on templates and secret info from govuk-secrets
4. tested on AWS staging frontend-calculator