### PR TITLE
fix splunk process name to splunkd

### DIFF
--- a/modules/govuk_splunk/manifests/init.pp
+++ b/modules/govuk_splunk/manifests/init.pp
@@ -139,7 +139,7 @@ class govuk_splunk(
   }
 
   @@icinga::check { "check_splunk_running_${::hostname}":
-    check_command       => 'check_nrpe!check_proc_running!splunk',
+    check_command       => 'check_nrpe!check_proc_running!splunkd',
     service_description => 'splunk universal forwarder running',
     host_name           => $::fqdn,
     notes_url           => monitoring_docs_url(check-process-running),


### PR DESCRIPTION
# Context

As part of the Splunk deployment on GOVUK EC2 machines, an icinga alert was put to monitor the splunk process. Unfortunately, the process name is `splunkd` rather than `splunk`

# Decisions
1. fix the splunk process name in the alert