### PR TITLE
Trello-1901: Firewall rule for node-exporter

### DIFF
--- a/modules/govuk_prometheus_node_exporter/manifests/firewall.pp
+++ b/modules/govuk_prometheus_node_exporter/manifests/firewall.pp
@@ -1,0 +1,9 @@
+# == Class: govuk_prometheus_node_exporter::firewall
+#
+# Allow Firewall rule into prometheus node-exporter
+#
+class govuk_prometheus_node_exporter::firewall {
+  @ufw::allow { 'allow-prometheus-scraping-from-all':
+    port => 9080,
+  }
+}

--- a/modules/govuk_prometheus_node_exporter/manifests/init.pp
+++ b/modules/govuk_prometheus_node_exporter/manifests/init.pp
@@ -5,6 +5,7 @@
 class govuk_prometheus_node_exporter {
 
   include govuk_prometheus_node_exporter::repo
+  include govuk_prometheus_node_exporter::firewall
 
   package { 'node-exporter':
     ensure  => latest,


### PR DESCRIPTION
This firewall rule allows the prometheus server to scrape metrics from
the prometheus node-exporters on port 9080. The corresponding Security
groups are also being put in place.

@ronocg <conor.glynn@digital.cabinet-office.gov.uk>
@jstandring-gds <julian.standring@digital.cabinet-office.gov.uk>