### PR TITLE
Trello-1902: Add prometheus server aptly repo

### DIFF
--- a/modules/govuk/manifests/node/s_apt.pp
+++ b/modules/govuk/manifests/node/s_apt.pp
@@ -152,6 +152,7 @@ class govuk::node::s_apt (
   aptly::repo { 'gor': }
   aptly::repo { 'govuk-datascrubber': }
   aptly::repo { 'govuk-jenkins': }
+  aptly::repo { 'govuk-prometheus': }
   aptly::repo { 'govuk-prometheus-node-exporter': }
   aptly::repo { 'govuk-python': }
   aptly::repo { 'govuk-rubygems': }


### PR DESCRIPTION
local aptly repo required for prometheus server.

@ronocg <conor.glynn@digital.cabinet-office.gov.uk>
@jstandring-gds <julian.standring@digital.cabinet-office.gov.uk>