### PR TITLE
Update GTM env values for content publisher

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -58,9 +58,9 @@ govuk::apps::asset_manager::aws_region: 'eu-west-1'
 govuk::apps::ckan::ckan_site_url: 'https://ckan.publishing.service.gov.uk'
 govuk::apps::content_data_admin::google_tag_manager_id: 'GTM-NZG8SF2'
 govuk::apps::content_publisher::aws_s3_bucket: "govuk-production-content-publisher-activestorage"
-govuk::apps::content_publisher::google_tag_manager_auth: "O0DrItJxJeQ5Q2W6YCZzvw"
+govuk::apps::content_publisher::google_tag_manager_auth: "sxvBI4QvwgTRX5e76vdIHA"
 govuk::apps::content_publisher::google_tag_manager_id: "GTM-NQXC4TG"
-govuk::apps::content_publisher::google_tag_manager_preview: "env-7"
+govuk::apps::content_publisher::google_tag_manager_preview: "env-2"
 govuk::apps::content_store::performance_platform_big_screen_view_url: 'https://performance-platform-big-screen-view-production.cloudapps.digital'
 govuk::apps::content_store::performance_platform_spotlight_url: 'https://performance-platform-spotlight-production.cloudapps.digital'
 govuk::apps::email_alert_api::db::backend_ip_range: '10.3.3.0/24'


### PR DESCRIPTION
After updating the Google Tag Manager setup for Content Publisher we ended up with different `gtm_auth` and `gtm_preview` values for tracking production of Content Publisher app.
This PR updates the environment variables to reflect this.

[Trello card](https://trello.com/c/QHmf1x47)