### PR TITLE
Future parser fixes for postfix module

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,7 +24,7 @@ GEM
     builder (3.2.2)
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
-    diff-lcs (1.2.5)
+    diff-lcs (1.3)
     facter (2.4.6)
       CFPropertyList (~> 2.2.6)
     faraday (0.9.0)
@@ -59,8 +59,8 @@ GEM
       metaclass (~> 0.0.1)
     multi_json (1.10.1)
     multipart-post (2.0.0)
-    parallel (0.5.19)
-    parallel_tests (0.8.14)
+    parallel (1.12.1)
+    parallel_tests (2.9.0)
       parallel
     puppet (3.8.5)
       facter (> 1.6, < 3)
@@ -80,21 +80,21 @@ GEM
       rake
       rspec-puppet
     rake (10.1.0)
-    rspec (3.3.0)
-      rspec-core (~> 3.3.0)
-      rspec-expectations (~> 3.3.0)
-      rspec-mocks (~> 3.3.0)
-    rspec-core (3.3.2)
-      rspec-support (~> 3.3.0)
-    rspec-expectations (3.3.1)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.0)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.2)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.3.0)
-    rspec-mocks (3.3.2)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.3.0)
-    rspec-puppet (2.2.0)
+      rspec-support (~> 3.8.0)
+    rspec-puppet (2.7.2)
       rspec
-    rspec-support (3.3.0)
+    rspec-support (3.8.0)
     rsync (1.0.9)
     safe_yaml (1.0.4)
     sshkey (1.9.0)
@@ -126,3 +126,6 @@ DEPENDENCIES
   rspec-puppet
   sshkey (= 1.9.0)
   webmock (~> 1.20.0)
+
+BUNDLED WITH
+   1.17.3

--- a/lib/tasks/spec.rake
+++ b/lib/tasks/spec.rake
@@ -1,6 +1,5 @@
 require 'open3'
 require 'parallel_tests'
-require 'parallel_tests/cli'
 require 'rspec/core/rake_task'
 
 desc "Use the basic rspec rake task with no options WARNING: slow"
@@ -15,7 +14,7 @@ namespace :spec do
     cli_args.concat(matched_files)
 
     $stderr.puts '---> Running puppet specs'
-    ParallelTest::CLI.run(cli_args)
+    ParallelTests::CLI.new.run(cli_args)
   end
 
   desc "Run govuk::node class specs"

--- a/modules/postfix/spec/classes/postfix__config_spec.rb
+++ b/modules/postfix/spec/classes/postfix__config_spec.rb
@@ -10,11 +10,11 @@ describe 'postfix::config', :type => :class do
     :domain   => 'example.com',
     :hostname => 'host',
   }}
-  # This essentially mocks the defaults of the parent class.
+  # This mocks the defaults of the parent class.
   let(:default_params) {{
-    :smarthost           => '',
-    :smarthost_user      => '',
-    :smarthost_pass      => '',
+    :smarthost           => :undef,
+    :smarthost_user      => :undef,
+    :smarthost_pass      => :undef,
     :rewrite_mail_domain => 'localhost',
     :rewrite_mail_list   => 'noemail'
   }}
@@ -23,8 +23,8 @@ describe 'postfix::config', :type => :class do
     let(:params) { default_params }
 
     it { is_expected.to contain_file(main_cf).with_content(/^relayhost = $/) }
-    it { is_expected.not_to contain_file(main_cf).with_content(/^smtp_generic_maps/) }
-    it { is_expected.not_to contain_file(main_cf).with_content(/^smtp_sasl_auth_enable/) }
+    it { is_expected.to contain_file(main_cf).without_content(/^smtp_generic_maps/) }
+    it { is_expected.to contain_file(main_cf).without_content(/^smtp_sasl_auth_enable/) }
 
     it { is_expected.to contain_file(mailname).with_content("host.example.com\n") }
     it { is_expected.to contain_file(main_cf).with_content(/^myhostname = host\.example\.com$/) }
@@ -39,7 +39,7 @@ describe 'postfix::config', :type => :class do
 
       it { is_expected.to contain_file(main_cf).with_content(/^relayhost = mx\.example\.com:587$/) }
       it { is_expected.to contain_file(main_cf).with_content(/^smtp_generic_maps/) }
-      it { is_expected.not_to contain_file(main_cf).with_content(/^smtp_sasl_auth_enable/) }
+      it { is_expected.to contain_file(main_cf).without_content(/^smtp_sasl_auth_enable/) }
       it { is_expected.not_to contain_file(sasl_passwd) }
     end
 

--- a/modules/postfix/templates/etc/postfix/main.cf.erb
+++ b/modules/postfix/templates/etc/postfix/main.cf.erb
@@ -32,14 +32,14 @@ alias_maps = hash:/etc/aliases
 alias_database = hash:/etc/aliases
 myorigin = /etc/mailname
 mydestination = <%= @fqdn -%>, localhost.<%= @domain -%>, , localhost
-relayhost = <% unless @smarthost == '' -%><%= [@smarthost].flatten.first -%><% end %>
+relayhost = <% unless ['', nil].include?(@smarthost) -%><%= [@smarthost].flatten.first -%><% end %>
 mynetworks = 127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128
 mailbox_size_limit = 0
 recipient_delimiter = +
 inet_interfaces = loopback-only
-<% unless @smarthost == '' -%>
+<% unless ['', nil].include?(@smarthost) -%>
 
-<% unless (@smarthost_user == '' and @smarthost_pass == '') -%>
+<% unless (['', nil].include?(@smarthost_user) && ['', nil].include?(@smarthost_pass)) -%>
 smtp_sasl_auth_enable = yes
 smtp_sasl_security_options = noanonymous
 smtp_sasl_password_maps = hash:/etc/postfix/sasl_passwd

--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -8,7 +8,6 @@ RSpec.configure do |c|
   c.mock_framework = :rspec
   c.hiera_config = 'spec/fixtures/hiera/hiera.yaml'
 
-  c.manifest    = File.join(HERE, 'manifests')
   c.module_path = [
     File.join(HERE, 'modules'),
     File.join(HERE, 'vendor', 'modules')


### PR DESCRIPTION
* Fix up the postfix module and its spec tests to pass under Puppet 3's future parser
* Upgrade rspec-puppet and parallel_tests rubygems