### PR TITLE
Run nginx configtest before reloading or restarting

### DIFF
--- a/modules/nginx/manifests/restart.pp
+++ b/modules/nginx/manifests/restart.pp
@@ -1,9 +1,8 @@
 # FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
 class nginx::restart {
 
-  exec { '/etc/init.d/nginx restart':
+  exec { '/etc/init.d/nginx configtest && /etc/init.d/nginx restart':
     refreshonly => true,
-    onlyif      => '/etc/init.d/nginx configtest',
   }
 
 }

--- a/modules/nginx/manifests/service.pp
+++ b/modules/nginx/manifests/service.pp
@@ -4,7 +4,7 @@ class nginx::service {
   service { 'nginx':
     ensure    => running,
     hasstatus => true,
-    restart   => '/etc/init.d/nginx reload',
+    restart   => '/etc/init.d/nginx configtest && /etc/init.d/nginx reload',
   }
 
 }


### PR DESCRIPTION
This commit amends the Puppet classes that reload or restart nginx after various changes to always run a configtest beforehand. If the configtest fails, nginx will not be reloaded or restarted. This will prevent nginx either:

* Not restarting since the restart command was only run on a successful configcheck
* Reloading and failing