### PR TITLE
Enable the future parser

### DIFF
--- a/modules/puppet/manifests/init.pp
+++ b/modules/puppet/manifests/init.pp
@@ -8,16 +8,10 @@
 #   Whether this environment should be controlled by a master
 #   or should run from a local catalog.
 #
-# [*future_parser*]
-#   Boolean, whether or not to use Puppet's future parser to
-#   help upgrade to Puppet 4.
-#
 class puppet (
-    $future_parser = false,
     $use_puppetmaster = true,
   ) {
 
-  validate_bool($future_parser)
   validate_bool($use_puppetmaster)
 
   include puppet::cronjob

--- a/modules/puppet/templates/etc/puppet/puppet.conf.erb
+++ b/modules/puppet/templates/etc/puppet/puppet.conf.erb
@@ -7,11 +7,9 @@ environment = <%= scope.lookupvar("::environment") %>
 <%- if @use_puppetmaster == false -%>
 environmentpath = /var/govuk/govuk-puppet/environments
 <%- end -%>
-<%- if @future_parser == true -%>
 parser = future
 stringify_facts = false
 strict_variables = true
-<%- end -%>
 <%- if scope.lookupvar('::aws_migration') %>
 ssldir = /etc/puppet/ssl
 <%- end -%>

--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -17,9 +17,7 @@ RSpec.configure do |c|
 
   c.strict_variables = ENV['PUPPET_RSPEC_STRICT_VARIABLES'] == '1'
 
-  if ENV['PUPPET_RSPEC_FUTURE_PARSER'] == '1'
-    c.parser = 'future'
-  end
+  c.parser = 'future'
 
   c.profile_examples = ENV['PUPPET_RSPEC_PROFILE_EXAMPLES'] == '1'
 


### PR DESCRIPTION
Supersedes https://github.com/alphagov/govuk-puppet/pull/8542

Puppet 4.x introduces a new parser for the Puppet DSL. This changes a lot of
things and potentially leads to lots of breakage of existing code.

See the upgrade guide here: https://puppet.com/docs/puppet/4.10/index.html#upgrading-from-puppet-3

The puppet 4.x parser has been backported and is included in Puppet 3.x to
enable compatibility testing and migration.

Enable the future parser whilst running tests and on our hosts.