### PR TITLE
Remove nginx::restart

### DIFF
--- a/modules/nginx/manifests/init.pp
+++ b/modules/nginx/manifests/init.pp
@@ -58,11 +58,6 @@ class nginx (
     ],
   }
 
-  # Include ability to do a full restart of nginx. This does not explicitly
-  # trigger a restart, but simply makes the class available to any manifest
-  # that `include`s nginx.
-  include nginx::restart
-
   class { 'collectd::plugin::nginx':
     status_url => 'http://127.0.0.234/nginx_status',
     require    => Class['nginx::config'],

--- a/modules/nginx/manifests/package.pp
+++ b/modules/nginx/manifests/package.pp
@@ -37,14 +37,13 @@ class nginx::package(
     }
   }
 
-  package { 'nginx':
-    ensure => $nginx_version,
-    notify => Class['nginx::restart'],
+  package {
+    'nginx':
+      ensure => $nginx_version,
+    ;
+    'nginx-module-perl':
+      ensure  => $nginx_module_perl_version,
+      require => Package['nginx'],
   }
-
-  package { 'nginx-module-perl':
-    ensure  => $nginx_module_perl_version,
-    notify  => Class['nginx::restart'],
-    require => Package['nginx'],
-  }
+  ~> Service <| title == 'nginx' |>
 }

--- a/modules/nginx/manifests/restart.pp
+++ b/modules/nginx/manifests/restart.pp
@@ -1,8 +1,0 @@
-# FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
-class nginx::restart {
-
-  exec { '/etc/init.d/nginx configtest && /etc/init.d/nginx restart':
-    refreshonly => true,
-  }
-
-}

--- a/modules/nginx/spec/classes/nginx__package_spec.rb
+++ b/modules/nginx/spec/classes/nginx__package_spec.rb
@@ -2,16 +2,17 @@ require_relative '../../../../spec_helper'
 
 describe 'nginx::package', :type => :class do
   context 'defaults' do
+    let(:pre_condition) { 'service {"nginx":}' }
+
     it do
-      is_expected.to contain_package('nginx-module-perl').with(
-        'ensure'  => 'present',
-        'notify'  => 'Class[Nginx::Restart]',
-        'require' => 'Package[nginx]',
-      )
-      is_expected.to contain_package('nginx').with(
-        'ensure'  => '1.14.0-1~trusty',
-        'notify'  => 'Class[Nginx::Restart]',
-      )
+      is_expected.to contain_package('nginx-module-perl')
+        .with_ensure('present')
+        .that_notifies('Service[nginx]')
+        .that_requires('Package[nginx]')
+
+      is_expected.to contain_package('nginx')
+        .with_ensure('1.14.0-1~trusty')
+        .that_notifies('Service[nginx]')
     end
   end
   context 'nginx_version and nginx_module_perl_version set' do


### PR DESCRIPTION
We already define a restart command on the 'nginx' service, so we can replace
this class with a notification against the service.

Use a resource collector in nginx::package, because that doesn't include the
service (so it may not be defined)

Sprinkle some code and test tidyups around whilst we're at it.