### PR TITLE
Enable data sync tasks left out post-migration

### DIFF
--- a/hieradata_aws/class/integration/mongo.yaml
+++ b/hieradata_aws/class/integration/mongo.yaml
@@ -1,6 +1,6 @@
 govuk_env_sync::tasks:
   "pull_content_store_daily":
-    ensure: "absent"
+    ensure: "present"
     hour: "4" 
     minute: "16"
     action: "pull"
@@ -11,7 +11,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mongo-api"
   "pull_draft_content_store_daily":
-    ensure: "absent"
+    ensure: "present"
     hour: "4" 
     minute: "16"
     action: "pull"
@@ -99,7 +99,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mongo-normal"
   "pull_imminence_production":
-    ensure: "absent"
+    ensure: "present"
     hour: "4"
     minute: "0"
     action: "pull"

--- a/hieradata_aws/class/staging/mongo.yaml
+++ b/hieradata_aws/class/staging/mongo.yaml
@@ -1,6 +1,6 @@
 govuk_env_sync::tasks:
   "pull_content_store_daily":
-    ensure: "absent"
+    ensure: "present"
     hour: "1" 
     minute: "16"
     action: "pull"
@@ -11,7 +11,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mongo-api"
   "pull_draft_content_store_daily":
-    ensure: "absent"
+    ensure: "present"
     hour: "2" 
     minute: "16"
     action: "pull"


### PR DESCRIPTION
- Only the push (backup) portion was active on prod

- These changes add pull for content-store and imminence mongo databases
into integration and staging

solo: @schmie