### PR TITLE
Improve cache clearing service performance

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,6 +126,3 @@ DEPENDENCIES
   rspec-puppet
   sshkey (= 1.9.0)
   webmock (~> 1.20.0)
-
-BUNDLED WITH
-   1.17.3

--- a/modules/varnish/templates/default.vcl.erb
+++ b/modules/varnish/templates/default.vcl.erb
@@ -94,7 +94,7 @@ sub vcl_recv {
     if (!client.ip ~ purge_acl) {
       error 405 "Not allowed";
     } else {
-      ban("req.url == " + req.url);
+      ban("obj.http.url == " + req.url);
       error 200 "Purged";
     }
   }
@@ -178,6 +178,8 @@ sub vcl_fetch {
   if (beresp.http.Set-Cookie) {
     return(deliver);
   }
+
+  set beresp.http.x-url = req.url;
 }
 
 sub vcl_hash {
@@ -192,6 +194,8 @@ sub vcl_deliver {
   } else {
     set resp.http.X-Cache = "MISS";
   }
+
+  unset resp.http.x-url;
 }
 
 sub vcl_error {


### PR DESCRIPTION
This allows the ban lurker to action and clear out bans in the background, reducing the number of bans in memory and perhaps improving performance.

https://varnish-cache.org/docs/3.0/tutorial/purging.html#bans

https://trello.com/c/qBtWYsPC/717-speed-up-cache-clearing-service