### PR TITLE
Add govuk-tools AWS account to Terraform deploy job

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_terraform_govuk_aws.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_terraform_govuk_aws.yaml.erb
@@ -66,6 +66,7 @@
                 - staging
                 - production
                 - test
+                - tools
         - choice:
             name: STACKNAME
             description: Choose which stack to deploy into


### PR DESCRIPTION
This commit adds the new `govuk-tools` AWS account to the deploy Terraform Jenkins job.