### PR TITLE
De-duplicate the ack metric on the RabbitMQ Grafana dashboard

### DIFF
--- a/modules/grafana/files/dashboards/rabbitmq.json
+++ b/modules/grafana/files/dashboards/rabbitmq.json
@@ -198,11 +198,6 @@
             {
               "hide": false,
               "refId": "F",
-              "target": "alias(rabbitmq_%2F.queues-$Queues.ack_details-rate, 'ack')"
-            },
-            {
-              "hide": false,
-              "refId": "G",
               "target": "alias(rabbitmq_%2F.queues-$Queues.redeliver_details-rate, 'redeliver')"
             }
           ],


### PR DESCRIPTION
It was there twice for some reason, this commit removes one of the
occurrences.