### PR TITLE
Future parser fixups

### DIFF
--- a/docs/dependency-management.md
+++ b/docs/dependency-management.md
@@ -1,17 +1,14 @@
 # Dependency management
 
 -   Prefer `require` to `before`.
--   Do not use `->` and `~>`, use `require`, `notify` or `subscribe`
-    instead.
--   *Never* use `<-` or `<~`. (Lint will stop you, anyway.)
 -   Don't break encapsulation. In particular, a resource within one module
     should not create a dependency (require or notify) to a resource deep within
     another. For example, `File[/etc/nginx/sites-available/foo]` from module
     `foo` should *not* directly notify `Service[nginx]` in module `nginx`.
     Instead consider these options:
-  -   use the anchor pattern to ensure dependencies are passed up and down
-      the include hierarchy correctly, and specify the dependency at the
-      top level. In our example, this means we would have:
+  -   use `contain` in modules to ensure dependencies are inherited to contained
+      classes correctly, and specify the dependency at the top level. In our
+      example, this means we would have:
 
         ```
         class {'foo': notify => Class['nginx']}
@@ -24,82 +21,8 @@
       to create an nginx configuration and will make sure it happens after
       `nginx::package` and before `nginx::service`, without the other module
       even knowing the existence of these classes.
--   When a class includes or instantiates another class, consider
-    whether you need to use the anchor pattern (see below). In
-    particular, for a top-level class `foo` which includes
-    `foo::package`, `foo::config` and `foo::service`, *definitely* use
-    the anchor pattern.
-
-## Anchor pattern example
-
-The problem:
-
-Suppose I have an nginx class, which installs nginx and starts it
-running. We want to ensure logstash is running before nginx, so that
-we catch all of the log files. We also want to run some smoke tests
-every time nginx is restarted. You might expect this to work out of
-the box:
-
-    class {'nginx':
-        require => Class['logstash'],
-        notify  => Class['smoke-tests'],
-    }
-
-But by default this will not do what you want, because Puppet
-dependencies between classes don't work the obvious way. If the
-`nginx` class includes `nginx::package`, `nginx::config`, and
-`nginx::service`, then these classes will not inherit the `require`
-and `notify` directives we have specified, and so we have no guarantee
-that nginx will be installed after logstash, and that smoke tests will
-be run after nginx is restarted.
-
-What we have to do to get this to work is to use the anchor pattern
-within the nginx class, something like this:
-
-    class nginx {
-        anchor {'nginx::begin':
-            notify => Class['nginx::service']
-        }
-
-        class {'nginx::package':
-            require => Anchor['nginx::begin']
-        }
-
-        class {'nginx::config':
-            require => Class['nginx::package']
-            notify  => Class['nginx::service']
-        }
-
-        class {'nginx::service':
-            notify => Anchor['nginx::end']
-        }
-
-        anchor {'nginx::end':
-        }
-    }
-
-Now, when you specify at the top that the `nginx` class `require`s the
-`logstash` class, this relationship is inherited by the anchors
-because they are first-class resources and not merely classes. So
-`Anchor[nginx-begin]` and `Anchor[nginx-end]` both require
-`Class[logstash]`. We then use all of the other relationships within
-the class to ensure the dependencies are passed on correctly. In this
-case, we can be sure that `Class[nginx::package]` is installed after
-`Class[logstash]` because `Class[nginx::package]` requires
-`Anchor[nginx::begin]` which in turn requires `Class[logstash]`.
-
-Similarly, we can be sure that the smoke tests will run after nginx is
-restarted because `Class[nginx::service]` notifies
-`Anchor[nginx::end]`, which in turn notifies `Class[smoke-tests]`.
-
-Without the anchors, the relationships specified on `Class[nginx]`
-would simply not be passed on to the included classes such as
-`Class[nginx::package]`.
-
-More information on the anchor pattern can be found on
-[the Puppet wiki](http://projects.puppetlabs.com/projects/puppet/wiki/Anchor_Pattern).
-
-(NB the anchor type in puppetstdlib
-[does not propagate refresh events](http://projects.puppetlabs.com/issues/12510),
-so that the notify example above will fail. We have our own anchor
-type in puppet/modules/anchor, which fixes this bug.)
+-   When a class includes or instantiates another class, consider whether
+    you should use `contain` instead of `include` or `class`. See the
+    [Puppet documentation](https://puppet.com/docs/puppet/6.1/lang_containment.html).
+	 If class `a` contains class `b` then any resource relationships made to
+    class `a` also apply to class `b`.

--- a/modules/govuk_jenkins/manifests/deploy_all_apps.pp
+++ b/modules/govuk_jenkins/manifests/deploy_all_apps.pp
@@ -30,6 +30,7 @@ class govuk_jenkins::deploy_all_apps (
   $auth_token = '',
 ) {
 
+  $environment_variables = $govuk_jenkins::environment_variables
   $project_directory = "${jobs_directory}/${project_name}"
 
   File {

--- a/modules/govuk_jenkins/manifests/jobs/content_publisher_whitehall_import.pp
+++ b/modules/govuk_jenkins/manifests/jobs/content_publisher_whitehall_import.pp
@@ -7,6 +7,7 @@ class govuk_jenkins::jobs::content_publisher_whitehall_import (
   $app_domain = hiera('app_domain'),
   $cron_schedule = '0 9 * * 1-5'
 ) {
+  $environment_variables = $govuk_jenkins::environment_variables
   $slack_team_domain = 'gds'
   $slack_room = 'govuk-pubworkflow-dev'
   $slack_build_server_url = "https://deploy.${app_domain}/"

--- a/modules/govuk_jenkins/manifests/jobs/copy_attachments_to_integration.pp
+++ b/modules/govuk_jenkins/manifests/jobs/copy_attachments_to_integration.pp
@@ -8,6 +8,7 @@ class govuk_jenkins::jobs::copy_attachments_to_integration (
 ) {
 
   $check_name = 'copy_attachments_to_integration'
+  $environment_variables = $govuk_jenkins::environment_variables
   $service_description = 'Copy Attachments to Integration'
   $job_url = "https://deploy.${app_domain}/job/copy_attachments_to_integration"
 

--- a/modules/govuk_jenkins/manifests/jobs/copy_attachments_to_staging.pp
+++ b/modules/govuk_jenkins/manifests/jobs/copy_attachments_to_staging.pp
@@ -8,6 +8,7 @@ class govuk_jenkins::jobs::copy_attachments_to_staging (
 ) {
 
   $check_name = 'copy_attachments_to_staging'
+  $environment_variables = $govuk_jenkins::environment_variables
   $service_description = 'Copy Attachments to staging'
   $job_url = "https://deploy.${app_domain}/job/copy_attachments_to_staging"
 

--- a/modules/govuk_jenkins/manifests/jobs/copy_data_to_integration.pp
+++ b/modules/govuk_jenkins/manifests/jobs/copy_data_to_integration.pp
@@ -14,6 +14,7 @@ class govuk_jenkins::jobs::copy_data_to_integration (
 ) {
 
   $check_name = 'copy_data_to_integration'
+  $environment_variables = $govuk_jenkins::environment_variables
   $service_description = 'Copy Data to Integration'
   $job_url = "https://deploy.${app_domain}/job/copy_data_to_integration"
 

--- a/modules/govuk_jenkins/manifests/jobs/copy_data_to_staging.pp
+++ b/modules/govuk_jenkins/manifests/jobs/copy_data_to_staging.pp
@@ -13,6 +13,7 @@ class govuk_jenkins::jobs::copy_data_to_staging (
 ) {
 
   $check_name = 'copy_data_to_staging'
+  $environment_variables = $govuk_jenkins::environment_variables
   $service_description = 'Copy Data to Staging'
   $job_url = "https://deploy.${app_domain}/job/copy_data_to_staging/"
 

--- a/modules/govuk_jenkins/manifests/jobs/deploy_cdn.pp
+++ b/modules/govuk_jenkins/manifests/jobs/deploy_cdn.pp
@@ -7,6 +7,7 @@ class govuk_jenkins::jobs::deploy_cdn(
   $enable_slack_notifications = false,
 ) {
 
+  $environment_variables = $govuk_jenkins::environment_variables
   $slack_team_domain = 'gds'
   $slack_room = 'govuk-deploy'
   $slack_build_server_url = "https://deploy.${app_domain}/"

--- a/modules/govuk_jenkins/manifests/jobs/deploy_puppet.pp
+++ b/modules/govuk_jenkins/manifests/jobs/deploy_puppet.pp
@@ -19,6 +19,7 @@ class govuk_jenkins::jobs::deploy_puppet (
   $enable_slack_notifications = false,
   $app_domain = hiera('app_domain')
 ) {
+  $environment_variables = $govuk_jenkins::environment_variables
   $slack_team_domain = 'gds'
   $slack_room = 'govuk-deploy'
   $slack_build_server_url = "https://deploy.${app_domain}/"

--- a/modules/govuk_jenkins/manifests/jobs/smokey.pp
+++ b/modules/govuk_jenkins/manifests/jobs/smokey.pp
@@ -14,6 +14,7 @@ class govuk_jenkins::jobs::smokey (
   $enable_slack_notifications = false,
   $environment = 'production',
 ) {
+  $environment_variables = $govuk_jenkins::environment_variables
   $smokey_task = "test:${environment}"
   $app_domain = hiera('app_domain')
 

--- a/modules/icinga/manifests/init.pp
+++ b/modules/icinga/manifests/init.pp
@@ -1,30 +1,16 @@
 # FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
 class icinga {
 
-  anchor { 'icinga::begin':
-    before => Class['icinga::package'],
-    notify => Class['icinga::service'];
-  }
+  contain icinga::package
+  contain icinga::config
+  contain icinga::service
+  include icinga::nginx
 
-  class { 'icinga::package':
-    require => Class['nginx'],
-    notify  => Class['icinga::service'];
-  }
+  Class['icinga::package']
+  -> Class['icinga::config']
+  ~> Class['icinga::service']
 
-  class { 'icinga::config':
-    require => Class['icinga::package'],
-    notify  => Class['icinga::service'];
-  }
-
-  class { 'icinga::service': }
-  class { 'icinga::nginx': }
-
-  anchor { 'icinga::end':
-    require => Class[
-      'icinga::service',
-      'icinga::nginx'
-    ],
-  }
+  Class['icinga::package'] ~> Class['icinga::service']
 
   Icinga::Host            <<||>> { notify => Class['icinga::service'] }
   Icinga::Check           <<||>> { notify => Class['icinga::service'] }

--- a/modules/icinga/manifests/package.pp
+++ b/modules/icinga/manifests/package.pp
@@ -17,7 +17,8 @@ class icinga::package {
     ensure => 'purged',
   }
 
-  include nginx::fcgi
+  include ::nginx
+  include ::nginx::fcgi
 
   package { [
     'icinga',
@@ -71,5 +72,5 @@ class icinga::package {
     command => 'dpkg-statoverride --update --add nagios nagios 751 /var/lib/icinga',
     unless  => 'dpkg-statoverride --list /var/lib/icinga',
     require => Package['icinga'],
-    }
+  }
 }

--- a/modules/nginx/manifests/config/site.pp
+++ b/modules/nginx/manifests/config/site.pp
@@ -6,6 +6,9 @@ define nginx::config::site(
 ) {
   validate_re($ensure, '^(absent|present)$', 'Invalid ensure value')
 
+  include nginx::package
+  include nginx::service
+
   if $content != 'UNSET' {
     file { "/etc/nginx/sites-available/${title}":
       ensure  => $ensure,

--- a/modules/nginx/manifests/fcgi.pp
+++ b/modules/nginx/manifests/fcgi.pp
@@ -1,6 +1,8 @@
 # FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
 class nginx::fcgi {
 
+  include nginx::service
+
   include govuk_ppa
 
   package { 'spawn-fcgi':

--- a/modules/nginx/manifests/package.pp
+++ b/modules/nginx/manifests/package.pp
@@ -19,6 +19,8 @@ class nginx::package(
   $nginx_module_perl_version = 'present',
 ) {
 
+  include nginx::restart
+
   apt::source { 'nginx':
     location     => "http://${apt_mirror_hostname}/nginx",
     release      => $::lsbdistcodename,


### PR DESCRIPTION
Work around some variable scoping issues in `govuk_jenkins`

Remove `anchor`s from `icinga` and `nginx` modules, replace it with `contains` and class resource dependencies