### PR TITLE
Trello-1904: add govuk_prometheus puppet module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ REVISION
 /gpg/random_seed
 nodes.local.yaml
 gpg_recipients/.*last_updated
+*.swp

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -783,6 +783,8 @@ govuk::node::s_transition_postgresql_slave::wale_private_gpg_key_fingerprint: "%
 
 govuk_postgresql::mirror::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk_ppa::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_prometheus::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_prometheus_node_exporter::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 govuk_sshkeys::deployment_keys:
   github.com:

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -840,6 +840,8 @@ govuk::node::s_warehouse_db_admin::apt_mirror_hostname: "%{hiera('apt_mirror_hos
 govuk_bundler::config::service: 'http://gemstash'
 
 govuk_postgresql::mirror::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_prometheus_node_exporter::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_prometheus::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk_ppa::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 govuk_sshkeys::deployment_keys:

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -129,8 +129,6 @@ govuk::node::s_whitehall_backend::sync_mirror: true
 govuk::node::s_transition_postgresql_slave::redirector_ip_range: '10.1.5.0/24'
 govuk::node::s_transition_postgresql_standby::redirector_ip_range: "%{hiera('govuk::node::s_transition_postgresql_slave::redirector_ip_range')}"
 
-govuk_prometheus_node_exporter::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
-
 govuk_sudo::sudo_conf:
   deploy_service_postgresql:
     content: 'deploy ALL=NOPASSWD:/etc/init.d/postgresql'

--- a/modules/base/manifests/init.pp
+++ b/modules/base/manifests/init.pp
@@ -36,11 +36,6 @@ class base {
     include resolvconf
   }
 
-  # Only for testing
-  if $::aws_environment == 'integration' {
-    include govuk_prometheus_node_exporter
-  }
-
   include ssh
   include timezone
   include tmpreaper
@@ -57,5 +52,6 @@ class base {
     }
 
     include hosts::migration
+    include govuk_prometheus_node_exporter
   }
 }

--- a/modules/govuk/manifests/apps/prometheus.pp
+++ b/modules/govuk/manifests/apps/prometheus.pp
@@ -1,0 +1,64 @@
+# == Class: govuk::apps::prometheus
+#
+# Read more: https://github.com/alphagov/myapp
+#
+# === Parameters
+# [*port*]
+#   What port should the app run on? Find the next free one in development-vm/Procfile
+#
+# [*enabled*]
+#   Whether to install or uninstall the app. Defaults to true (install on all enviroments)
+#
+# [*secret_key_base*]
+#   The key for Rails to use when signing/encrypting sessions (in govuk-secrets)
+#
+# [*sentry_dsn*]
+#   The app-specific URL used by Sentry to report exceptions (in govuk-secrets)
+#
+# [*oauth_id*]
+#   The OAuth ID used to identify the app to GOV.UK Signon (in govuk-secrets)
+#
+# [*oauth_secret*]
+#   The OAuth secret used to authenticate the app to GOV.UK Signon (in govuk-secrets)
+#
+# [*db_hostname*]
+#   The hostname of the database server to use for in DATABASE_URL environment variable
+#
+# [*db_username*]
+#   The username to use for the DATABASE_URL environment variable
+#
+# [*db_password*]
+#   The password to use for the DATABASE_URL environment variable
+#
+# [*db_port*]
+#   The port of the database server to use in the DATABASE_URL.
+#   Default: undef
+#
+# [*db_allow_prepared_statements*]
+#   The ?prepared_statements= parameter to use in the DATABASE_URL.
+#   Default: undef
+#
+# [*db_name*]
+#   The database name to use for the DATABASE_URL environment variable
+#
+class govuk::apps::prometheus (
+  $port = 9090,
+  $enabled = false,
+  $secret_key_base = undef,
+  $sentry_dsn = undef,
+  $oauth_id = undef,
+  $oauth_secret = undef,
+  $db_username = undef,
+  $db_hostname = undef,
+  $db_port = undef,
+  $db_allow_prepared_statements = undef,
+  $db_password = undef,
+  $db_name = undef,
+) {
+  $app_name = 'prometheus'
+
+  $ensure = $enabled ? {
+    true  => 'present',
+    false => 'absent',
+  }
+}

--- a/modules/govuk/manifests/node/s_prometheus.pp
+++ b/modules/govuk/manifests/node/s_prometheus.pp
@@ -1,0 +1,10 @@
+# == Class: govuk::node::s_prometheus
+#
+# Class to specify a machine as a prometheus server
+#
+class govuk::node::s_prometheus inherits govuk::node::s_base {
+
+  include govuk::apps::prometheus
+  include govuk_prometheus
+
+}

--- a/modules/govuk_prometheus/files/etc/prometheus/prometheus.yml
+++ b/modules/govuk_prometheus/files/etc/prometheus/prometheus.yml
@@ -1,0 +1,29 @@
+# my global config
+global:
+  scrape_interval:     15s # Set the scrape interval to every 15 seconds. Default is every 1 minute.
+  evaluation_interval: 15s # Evaluate rules every 15 seconds. The default is every 1 minute.
+  # scrape_timeout is set to the global default (10s).
+
+  # Attach these labels to any time series or alerts when communicating with
+  # external systems (federation, remote storage, Alertmanager).
+  external_labels:
+    monitor: 'codelab-monitor'
+
+# Alertmanager configuration
+alerting:
+  alertmanagers:
+  - static_configs:
+    - targets:
+      # - alertmanager:9093
+
+# Load rules once and periodically evaluate them according to the global 'evaluation_interval'.
+rule_files:
+  # - "first_rules.yml"
+  # - "second_rules.yml"
+
+# A scrape configuration for ec2 instances
+scrape_configs:
+  - job_name: 'ec2'
+    ec2_sd_configs:
+      - region: "eu-west-1"
+        port: 9080

--- a/modules/govuk_prometheus/manifests/init.pp
+++ b/modules/govuk_prometheus/manifests/init.pp
@@ -1,0 +1,54 @@
+# == Class: govuk_prometheus
+#
+# Install and run Prometheus Server
+#
+class govuk_prometheus {
+
+  include ::nginx
+
+  $cors_headers = '
+  add_header "Access-Control-Allow-Methods" "GET, OPTIONS";
+  add_header "Access-Control-Allow-Headers" "origin, authorization, accept";
+'
+  nginx::config::vhost::default { 'default': }
+
+  nginx::config::vhost::proxy { 'prometheus':
+    to           => ['localhost:9090'],
+    root         => '/',
+    protected    => false,
+    extra_config => $cors_headers,
+  }
+
+  apt::source { 'govuk-prometheus':
+    location     => "http://${govuk_prometheus::apt_mirror_hostname}/govuk-prometheus",
+    release      => 'stable',
+    architecture => $::architecture,
+    repos        => 'main',
+    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+  }
+
+  package { 'prometheus':
+    ensure  => latest,
+    require => Apt::Source['govuk-prometheus'],
+  }
+
+  service { 'prometheus':
+    ensure  => running,
+    require => File['/etc/prometheus/prometheus.yml'],
+  }
+
+  file { '/etc/prometheus/prometheus.yml':
+    ensure  => present,
+    source  => 'puppet:///modules/govuk_prometheus/etc/prometheus/prometheus.yml',
+    mode    => '0755',
+    require => Package['prometheus'],
+    notify  => Service['prometheus'],
+  }
+
+  @@icinga::check { "check_prometheus_running_${::hostname}":
+    check_command       => 'check_nrpe!check_proc_running!prometheus',
+    service_description => 'prometheus running',
+    host_name           => $::fqdn,
+    notes_url           => monitoring_docs_url(check-process-running),
+  }
+}

--- a/modules/hosts/manifests/purge.pp
+++ b/modules/hosts/manifests/purge.pp
@@ -20,6 +20,7 @@ class hosts::purge {
     'publishing-api-db-admin-1',
     'publishing-api-postgresql-1',
     'mongo-api-1',
+    'prometheus-1',
   ]
 
   if ! ($::hostname in $whitelist) {

--- a/spec/fixtures/hieradata/common.yaml
+++ b/spec/fixtures/hieradata/common.yaml
@@ -83,6 +83,9 @@ govuk_postgresql::monitoring::password: password
 
 govuk_ppa::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
+govuk_prometheus::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_prometheus_node_exporter::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+
 govuk_rabbitmq::monitoring_password: 'rabbit_monitor'
 govuk_rabbitmq::root_password: 'rabbit_root'
 govuk_rabbitmq::repo::apt_mirror_hostname: 'rabbit_repo'


### PR DESCRIPTION
This module is used to stand up the prometheus server instance in each
environment. When an instance with a role of prometheus is built this
module will be used to configure prometheus on it.

Also allowiing the prometheus node exporter to be installed in all AWS
environments.

@ronocg <conor.glynn@digital.cabinet-office.gov.uk>