### PR TITLE
set aws staging and production not to have search upstream

### DIFF
--- a/modules/govuk/manifests/app/publicapi.pp
+++ b/modules/govuk/manifests/app/publicapi.pp
@@ -57,16 +57,31 @@ define govuk::app::publicapi (
     $privateapi_protocol = 'http'
   }
 
-  nginx::config::vhost::proxy { $full_domain:
-    to               => [$whitehallapi, $rummager_api, $content_store_api],
-    to_ssl           => $privateapi_ssl,
-    protected        => false,
-    ssl_only         => false,
-    extra_app_config => "
-      # Don't proxy_pass / anywhere, just return 404. All real requests will
-      # be handled by the location blocks below.
-      return 404;
-    ",
-    extra_config     => template('govuk/publicapi_nginx_extra_config.erb'),
+  if ($::aws_environment == 'staging') or ($::aws_environment == 'production') {
+    nginx::config::vhost::proxy { $full_domain:
+      to               => [$whitehallapi, $content_store_api],
+      to_ssl           => $privateapi_ssl,
+      protected        => false,
+      ssl_only         => false,
+      extra_app_config => "
+        # Don't proxy_pass / anywhere, just return 404. All real requests will
+        # be handled by the location blocks below.
+        return 404;
+      ",
+      extra_config     => template('govuk/publicapi_nginx_extra_config.erb'),
+    }
+  } else {
+    nginx::config::vhost::proxy { $full_domain:
+      to               => [$whitehallapi, $rummager_api, $content_store_api],
+      to_ssl           => $privateapi_ssl,
+      protected        => false,
+      ssl_only         => false,
+      extra_app_config => "
+        # Don't proxy_pass / anywhere, just return 404. All real requests will
+        # be handled by the location blocks below.
+        return 404;
+      ",
+      extra_config     => template('govuk/publicapi_nginx_extra_config.erb'),
+    }
   }
 }


### PR DESCRIPTION
# Context

For AWS Staging and Production, there is a need to remove the `search` service from the publicapi config of the nginx service of on cache machines because the `search` service is _not_ yet resolvable. 

# Decision
1. branch the publicapi config to not include the `search` service if `aws_environment` is `staging` or `production`.