### PR TITLE
Increase memory alerting thresholds for cache clearing service

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -357,6 +357,8 @@ govuk::apps::bouncer::nagios_memory_critical: 1500
 govuk::apps::bouncer::unicorn_worker_processes: "8"
 
 govuk::apps::cache_clearing_service::enabled: true
+govuk::apps::cache_clearing_service::nagios_memory_warning: 2750
+govuk::apps::cache_clearing_service::nagios_memory_critical: 3000
 govuk::apps::cache_clearing_service::puppetdb_node_url: 'http://puppetdb.cluster/v2/nodes'
 govuk::apps::cache_clearing_service::rabbitmq_hosts:
   - rabbitmq-1.backend

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -372,6 +372,8 @@ govuk::apps::bouncer::nagios_memory_critical: 1500
 govuk::apps::bouncer::unicorn_worker_processes: "8"
 
 govuk::apps::cache_clearing_service::enabled: true
+govuk::apps::cache_clearing_service::nagios_memory_warning: 2750
+govuk::apps::cache_clearing_service::nagios_memory_critical: 3000
 govuk::apps::cache_clearing_service::rabbitmq_hosts: [rabbitmq]
 govuk::apps::cache_clearing_service::rabbitmq::queue_size_critical_threshold: 10000
 govuk::apps::cache_clearing_service::rabbitmq::queue_size_warning_threshold: 1000

--- a/modules/govuk/manifests/apps/cache_clearing_service.pp
+++ b/modules/govuk/manifests/apps/cache_clearing_service.pp
@@ -31,6 +31,12 @@
 #   The region in AWS the app is running in.
 #   Default: eu-west-1
 #
+# [*nagios_memory_warning*]
+#   The threshold that memory must be reached to be triggered as a warning
+#
+# [*nagios_memory_critical*]
+#   The threshold that memory must be reached to be triggered as a critical issue
+#
 class govuk::apps::cache_clearing_service (
   $enabled = false,
   $sentry_dsn = undef,
@@ -39,6 +45,8 @@ class govuk::apps::cache_clearing_service (
   $rabbitmq_password = 'cache_clearing_service',
   $puppetdb_node_url = undef,
   $aws_region = 'eu-west-1',
+  $nagios_memory_warning = undef,
+  $nagios_memory_critical = undef,
 ) {
   $ensure = $enabled ? {
     true  => 'present',
@@ -54,6 +62,8 @@ class govuk::apps::cache_clearing_service (
     sentry_dsn             => $sentry_dsn,
     command                => './bin/cache_clearing_service',
     collectd_process_regex => 'cache-clearing-service/.*rake message_queue:consumer',
+    nagios_memory_warning  => $nagios_memory_warning,
+    nagios_memory_critical => $nagios_memory_critical,
   }
 
   Govuk::App::Envvar {


### PR DESCRIPTION
[The number of workers for cache clearing service has been increased](https://github.com/alphagov/cache-clearing-service/pull/72/commits/95829b014a43f92b5d43e88e8645f35cd3f96053) resulting
in higher memory usage so increase the warning thresholds.
(There's sufficient memory on the relevant machines to accommodate this)