### PR TITLE
Increase thread count threshold for cache clearing service

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -356,6 +356,7 @@ govuk::apps::bouncer::nagios_memory_warning: 1400
 govuk::apps::bouncer::nagios_memory_critical: 1500
 govuk::apps::bouncer::unicorn_worker_processes: "8"
 
+govuk::apps::cache_clearing_service::alert_when_threads_exceed: 150
 govuk::apps::cache_clearing_service::enabled: true
 govuk::apps::cache_clearing_service::nagios_memory_warning: 2750
 govuk::apps::cache_clearing_service::nagios_memory_critical: 3000

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -371,6 +371,7 @@ govuk::apps::bouncer::nagios_memory_warning: 1400
 govuk::apps::bouncer::nagios_memory_critical: 1500
 govuk::apps::bouncer::unicorn_worker_processes: "8"
 
+govuk::apps::cache_clearing_service::alert_when_threads_exceed: 150
 govuk::apps::cache_clearing_service::enabled: true
 govuk::apps::cache_clearing_service::nagios_memory_warning: 2750
 govuk::apps::cache_clearing_service::nagios_memory_critical: 3000

--- a/modules/govuk/manifests/apps/cache_clearing_service.pp
+++ b/modules/govuk/manifests/apps/cache_clearing_service.pp
@@ -47,6 +47,7 @@ class govuk::apps::cache_clearing_service (
   $aws_region = 'eu-west-1',
   $nagios_memory_warning = undef,
   $nagios_memory_critical = undef,
+  $alert_when_threads_exceed = undef,
 ) {
   $ensure = $enabled ? {
     true  => 'present',
@@ -56,14 +57,15 @@ class govuk::apps::cache_clearing_service (
   $app_name = 'cache-clearing-service'
 
   govuk::app { $app_name:
-    ensure                 => $ensure,
-    app_type               => 'bare',
-    enable_nginx_vhost     => false,
-    sentry_dsn             => $sentry_dsn,
-    command                => './bin/cache_clearing_service',
-    collectd_process_regex => 'cache-clearing-service/.*rake message_queue:consumer',
-    nagios_memory_warning  => $nagios_memory_warning,
-    nagios_memory_critical => $nagios_memory_critical,
+    ensure                    => $ensure,
+    app_type                  => 'bare',
+    enable_nginx_vhost        => false,
+    sentry_dsn                => $sentry_dsn,
+    command                   => './bin/cache_clearing_service',
+    collectd_process_regex    => 'cache-clearing-service/.*rake message_queue:consumer',
+    nagios_memory_warning     => $nagios_memory_warning,
+    nagios_memory_critical    => $nagios_memory_critical,
+    alert_when_threads_exceed => $alert_when_threads_exceed,
   }
 
   Govuk::App::Envvar {


### PR DESCRIPTION
The increase in workers for cache clearing service has increased
the number of processes spawned so alert on a higher thread count.