### PR TITLE
Remove output piping from cache clearing service command

### DIFF
--- a/modules/govuk/manifests/apps/cache_clearing_service.pp
+++ b/modules/govuk/manifests/apps/cache_clearing_service.pp
@@ -60,7 +60,7 @@ class govuk::apps::cache_clearing_service (
     app_type               => 'bare',
     enable_nginx_vhost     => false,
     sentry_dsn             => $sentry_dsn,
-    command                => './bin/cache_clearing_service',
+    command                => 'bundle exec foreman start',
     collectd_process_regex => 'cache-clearing-service/.*rake message_queue:consumer',
     nagios_memory_warning  => $nagios_memory_warning,
     nagios_memory_critical => $nagios_memory_critical,


### PR DESCRIPTION
This will break kibana logging but will fix an issue where child processes are not killed if the foreman process is killed outside of the upstart commands.

https://trello.com/c/qBtWYsPC/717-speed-up-cache-clearing-service