### PR TITLE
Clean up the postfix module; future parser compatibility

### DIFF
--- a/modules/postfix/manifests/config.pp
+++ b/modules/postfix/manifests/config.pp
@@ -41,11 +41,17 @@ class postfix::config(
 
   if $smarthost {
 
-    postfix::postmapfile { 'outbound_rewrites': }
-    postfix::postmapfile { 'local_remote_rewrites': }
+    postfix::postmapfile { 'outbound_rewrites':
+      content => template('postfix/etc/postfix/outbound_rewrites.erb'),
+    }
+    postfix::postmapfile { 'local_remote_rewrites':
+      content => template('postfix/etc/postfix/local_remote_rewrites.erb'),
+    }
 
     if ($smarthost_user and $smarthost_pass) {
-      postfix::postmapfile { 'sasl_passwd': }
+      postfix::postmapfile { 'sasl_passwd':
+        content => template('postfix/etc/postfix/sasl_passwd.erb'),
+      }
     }
   }
 

--- a/modules/postfix/manifests/config.pp
+++ b/modules/postfix/manifests/config.pp
@@ -41,11 +41,11 @@ class postfix::config(
 
   if $smarthost {
 
-    postfix::postmapfile { 'outbound_rewrites':     named => 'outbound_rewrites' }
-    postfix::postmapfile { 'local_remote_rewrites': named => 'local_remote_rewrites' }
+    postfix::postmapfile { 'outbound_rewrites': }
+    postfix::postmapfile { 'local_remote_rewrites': }
 
     if ($smarthost_user and $smarthost_pass) {
-      postfix::postmapfile { 'sasl_passwd': named => 'sasl_passwd' }
+      postfix::postmapfile { 'sasl_passwd': }
     }
   }
 

--- a/modules/postfix/manifests/postmapfile.pp
+++ b/modules/postfix/manifests/postmapfile.pp
@@ -1,19 +1,14 @@
 # FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
 define postfix::postmapfile() {
-  exec { "postmap_${title}":
-    command     => "/usr/sbin/postmap /etc/postfix/${title}",
-    refreshonly => true,
-    require     => [
-      File["/etc/postfix/${title}"],
-      Package['postfix']
-    ],
-  }
-
   file { "/etc/postfix/${title}":
     ensure  => present,
     mode    => '0644',
     content => template("postfix/etc/postfix/${title}.erb"),
-    notify  => Exec["postmap_${title}"],
+  }
+  ~> exec { "postmap_${title}":
+    command     => "/usr/sbin/postmap /etc/postfix/${title}",
+    refreshonly => true,
+    require     => Package['postfix'],
   }
 }
 

--- a/modules/postfix/manifests/postmapfile.pp
+++ b/modules/postfix/manifests/postmapfile.pp
@@ -1,12 +1,14 @@
 # FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
 define postfix::postmapfile() {
-  file { "/etc/postfix/${title}":
+  $filename = "/etc/postfix/${title}"
+
+  file { $filename:
     ensure  => present,
     mode    => '0644',
     content => template("postfix/etc/postfix/${title}.erb"),
   }
   ~> exec { "postmap_${title}":
-    command     => "/usr/sbin/postmap /etc/postfix/${title}",
+    command     => "/usr/sbin/postmap ${filename}",
     refreshonly => true,
     require     => Package['postfix'],
   }

--- a/modules/postfix/manifests/postmapfile.pp
+++ b/modules/postfix/manifests/postmapfile.pp
@@ -1,17 +1,17 @@
 # FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
-define postfix::postmapfile($named) {
-        exec { "postmap_${named}":
-                command     => "/usr/sbin/postmap /etc/postfix/${named}",
+define postfix::postmapfile() {
+        exec { "postmap_${title}":
+                command     => "/usr/sbin/postmap /etc/postfix/${title}",
                 refreshonly => true,
                 require     => [
-                            File["/etc/postfix/${named}"],
+                            File["/etc/postfix/${title}"],
                             Package['postfix']],
         }
-        file { "/etc/postfix/${named}":
+        file { "/etc/postfix/${title}":
                 ensure  => present,
                 mode    => '0644',
-                content => template("postfix/etc/postfix/${named}.erb"),
-                notify  => Exec["postmap_${named}"],
+                content => template("postfix/etc/postfix/${title}.erb"),
+                notify  => Exec["postmap_${title}"],
         }
 }
 

--- a/modules/postfix/manifests/postmapfile.pp
+++ b/modules/postfix/manifests/postmapfile.pp
@@ -1,17 +1,19 @@
 # FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
 define postfix::postmapfile() {
-        exec { "postmap_${title}":
-                command     => "/usr/sbin/postmap /etc/postfix/${title}",
-                refreshonly => true,
-                require     => [
-                            File["/etc/postfix/${title}"],
-                            Package['postfix']],
-        }
-        file { "/etc/postfix/${title}":
-                ensure  => present,
-                mode    => '0644',
-                content => template("postfix/etc/postfix/${title}.erb"),
-                notify  => Exec["postmap_${title}"],
-        }
+  exec { "postmap_${title}":
+    command     => "/usr/sbin/postmap /etc/postfix/${title}",
+    refreshonly => true,
+    require     => [
+      File["/etc/postfix/${title}"],
+      Package['postfix']
+    ],
+  }
+
+  file { "/etc/postfix/${title}":
+    ensure  => present,
+    mode    => '0644',
+    content => template("postfix/etc/postfix/${title}.erb"),
+    notify  => Exec["postmap_${title}"],
+  }
 }
 

--- a/modules/postfix/manifests/postmapfile.pp
+++ b/modules/postfix/manifests/postmapfile.pp
@@ -1,11 +1,13 @@
 # FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
-define postfix::postmapfile() {
+define postfix::postmapfile(
+  $content,
+) {
   $filename = "/etc/postfix/${title}"
 
   file { $filename:
     ensure  => present,
     mode    => '0644',
-    content => template("postfix/etc/postfix/${title}.erb"),
+    content => $content,
   }
   ~> exec { "postmap_${title}":
     command     => "/usr/sbin/postmap ${filename}",

--- a/modules/postfix/manifests/postmapfile.pp
+++ b/modules/postfix/manifests/postmapfile.pp
@@ -4,7 +4,8 @@ define postfix::postmapfile(
 ) {
   $filename = "/etc/postfix/${title}"
 
-  file { $filename:
+  Package['postfix']
+  -> file { $filename:
     ensure  => present,
     mode    => '0644',
     content => $content,
@@ -12,7 +13,6 @@ define postfix::postmapfile(
   ~> exec { "postmap_${title}":
     command     => "/usr/sbin/postmap ${filename}",
     refreshonly => true,
-    require     => Package['postfix'],
   }
 }
 

--- a/modules/postfix/spec/classes/postfix__config_spec.rb
+++ b/modules/postfix/spec/classes/postfix__config_spec.rb
@@ -1,6 +1,7 @@
 require_relative '../../../../spec_helper'
 
 describe 'postfix::config', :type => :class do
+  let(:pre_condition) { 'package { "postfix": }' }
   let(:mailname)    { '/etc/mailname' }
   let(:main_cf)     { '/etc/postfix/main.cf' }
   let(:sasl_passwd) { '/etc/postfix/sasl_passwd' }

--- a/modules/postfix/templates/etc/postfix/sasl_passwd.erb
+++ b/modules/postfix/templates/etc/postfix/sasl_passwd.erb
@@ -1,6 +1,6 @@
 <%
-[scope.lookupvar('postfix::config::smarthost')].flatten.each do |smarthost_entry|
+[@smarthost].flatten.each do |smarthost_entry|
   unless smarthost_entry.empty?
 -%>
-<%= smarthost_entry -%> <%= scope.lookupvar('postfix::config::smarthost_user') -%>:<%= scope.lookupvar('postfix::config::smarthost_pass') %>
+<%= smarthost_entry -%> <%= @smarthost_user -%>:<%= @smarthost_pass %>
 <% end end -%>


### PR DESCRIPTION
The postfix module has some issues under future parser related to variable scoping. Refactor it to be cleaner and avoid these issues.
See individual commits for details.