### PR TITLE
adjust gor replay to 2 out of 3 cache machines

### DIFF
--- a/hieradata/node/cache-1.router.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/cache-1.router.staging.publishing.service.gov.uk.yaml
@@ -6,4 +6,3 @@
 router::gor::replay_targets:
   'www-origin.integration.publishing.service.gov.uk':
     ip: '31.210.245.98'
-  'www-origin.blue.staging.govuk.digital': {}


### PR DESCRIPTION
# Context

As part of AWS migration, Gor replay was activated for `all` Staging cache machines from Carrenza to AWS. We only need a sample replay so we remove gor replay on `cache-1` in staging machine. `cache-2` and `cache-3` will continue replay to AWS staging.

# Decisions
1. remove gor replay on cache-1 to AWS staging.