### PR TITLE
Change the URL for application dashboards

### DIFF
--- a/modules/grafana/manifests/dashboards/application_dashboard.pp
+++ b/modules/grafana/manifests/dashboards/application_dashboard.pp
@@ -120,7 +120,7 @@ define grafana::dashboards::application_dashboard (
   )
 
   file {
-    "${dashboard_directory}/${app_name}_dashboard.json":
+    "${dashboard_directory}/${app_name}.json":
     notify  => Service['grafana-server'],
     content => template('grafana/dashboards/application_dashboard_template.json.erb');
   }


### PR DESCRIPTION
Back to the same URL they had when they were deployment
dashboards. The name without the _dashboard suffix it probably better,
and it avoids having to change the links to these dashboards (e.g. in
the Release app).