### PR TITLE
Fix the build_fpm_manager job config

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/build_fpm_package.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/build_fpm_package.yaml.erb
@@ -6,6 +6,7 @@
             url: https://github.com/alphagov/packager
             branches:
               - master
+            wipe-workspace: true
 
 - job:
     name: build_fpm_package
@@ -33,4 +34,4 @@
             ./container-build.sh
     publishers:
         - archive:
-            artifacts: 'build/*.deb'
+            artifacts: 'fpm/recipes/*/pkg/*.deb'


### PR DESCRIPTION
# Context
This job runs in a docker container that mounts the local system for sharing
the debian package. Archiving the *.deb files (artifacts) with "build/*.deb"
doesn't work - I assume this was a remnant of the pre-docker job config. The
debian is actually available locally with the "fpm" root and on the container
with the "build" root. In addition to this the workspace is not cleared. In
combination this results in the job failing (as it can't clear the workspace).
It also means that the created package is not archived by Jenkins.

# Decision
Wipe the workspace before starting and make sure the debian files are archived
using the Jenkins job config.

Co-authored-by: Conor Glynn <conor.glynn@digital.cabinet-office.gov.uk>