### PR TITLE
Remove redundant backdrop publicapi configuration

### DIFF
--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -130,8 +130,6 @@ govuk::apps::manuals_publisher::mongodb_nodes: ['localhost']
 govuk::apps::manuals_publisher::mongodb_name: 'manuals_publisher_development'
 govuk::apps::maslow::mongodb_nodes: ['localhost']
 govuk::apps::maslow::mongodb_name: 'maslow_development'
-govuk::apps::publicapi::backdrop_host: 'read.backdrop.dev.gov.uk'
-govuk::apps::publicapi::backdrop_protocol: 'http'
 govuk::apps::publicapi::privateapi_ssl: false
 govuk::apps::publisher::enable_procfile_worker: false
 govuk::apps::publishing_api::content_store: 'http://content-store.dev.gov.uk'

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -73,7 +73,6 @@ govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::kibana::logit_environment: 0ea55710-075b-4eab-bfc3-475f28cdd0c3
 govuk::apps::local_links_manager::local_links_manager_passive_checks: true
 govuk::apps::local_links_manager::run_links_ga_export: true
-govuk::apps::publicapi::backdrop_host: 'www.performance.service.gov.uk'
 govuk::apps::publisher::run_fact_check_fetcher: true
 govuk::apps::publisher::fact_check_address_format: 'factcheck+production-{id}@alphagov.co.uk'
 govuk::apps::publisher::email_group_dev: 'govuk-dev@digital.cabinet-office.gov.uk'

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -38,7 +38,6 @@ govuk::apps::government-frontend::cpu_warning: 200
 govuk::apps::government-frontend::cpu_critical: 300
 govuk::apps::kibana::logit_environment: d414187a-2796-4ea7-9b9a-d40c341646d6
 govuk::apps::link_checker_api::govuk_basic_auth_credentials: "%{hiera('http_username')}:%{hiera('http_password')}"
-govuk::apps::publicapi::backdrop_host: 'www.staging.performance.service.gov.uk'
 govuk::apps::publisher::run_fact_check_fetcher: false
 govuk::apps::publisher::fact_check_address_format: 'factcheck+staging-{id}@alphagov.co.uk'
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-staging'

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -132,7 +132,6 @@ govuk::apps::email_alert_api::govuk_notify_template_id: '76d21ce7-54c3-4fb7-8830
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::kibana::logit_environment: 283f08f6-d117-48df-9667-c4aa492b81f9
 govuk::apps::link_checker_api::govuk_basic_auth_credentials: "%{hiera('http_username')}:%{hiera('http_password')}"
-govuk::apps::publicapi::backdrop_host: 'www.performance.service.gov.uk'
 govuk::apps::publisher::run_fact_check_fetcher: false
 govuk::apps::publisher::fact_check_address_format: 'factcheck+production-{id}@alphagov.co.uk'
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-production'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -137,7 +137,6 @@ govuk::apps::email_alert_frontend::subscription_management_enabled: true
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::kibana::logit_environment: b13bfb70-e07a-473b-9903-02e806ebd045
 govuk::apps::link_checker_api::govuk_basic_auth_credentials: "%{hiera('http_username')}:%{hiera('http_password')}"
-govuk::apps::publicapi::backdrop_host: 'www.staging.performance.service.gov.uk'
 govuk::apps::publisher::run_fact_check_fetcher: false
 govuk::apps::publisher::fact_check_address_format: 'factcheck+staging-{id}@alphagov.co.uk'
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-staging'

--- a/modules/govuk/manifests/app/publicapi.pp
+++ b/modules/govuk/manifests/app/publicapi.pp
@@ -7,12 +7,6 @@
 #
 # === Parameters
 #
-# [*backdrop_protocol*]
-#   String. The protocol to use when proxying to Backdrop (e.g. 'https').
-#
-# [*backdrop_host*]
-#   String. The host to use when proxying to Backdrop (e.g. 'www.performance.service.gov.uk').
-#
 # [*privateapi_ssl*]
 #   Boolean. Whether to use SSL for the private API.
 #
@@ -22,8 +16,6 @@
 #
 
 define govuk::app::publicapi (
-  $backdrop_protocol,
-  $backdrop_host,
   $privateapi_ssl,
   $prefix,
 ) {
@@ -48,8 +40,6 @@ define govuk::app::publicapi (
 
     $full_domain = "${app_name}.${app_domain}"
   }
-
-  $backdrop_url = "${backdrop_protocol}://${backdrop_host}"
 
   if ($privateapi_ssl) {
     $privateapi_protocol = 'https'

--- a/modules/govuk/manifests/apps/draft_publicapi.pp
+++ b/modules/govuk/manifests/apps/draft_publicapi.pp
@@ -1,13 +1,9 @@
 # FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
 class govuk::apps::draft_publicapi (
-  $backdrop_protocol = 'https',
-  $backdrop_host = 'www.performance.service.gov.uk',
   $privateapi_ssl = true,
 ) {
   govuk::app::publicapi { 'draft-publicapi':
-    backdrop_protocol => $backdrop_protocol,
-    backdrop_host     => $backdrop_host,
-    privateapi_ssl    => $privateapi_ssl,
-    prefix            => 'draft-',
+    privateapi_ssl => $privateapi_ssl,
+    prefix         => 'draft-',
   }
 }

--- a/modules/govuk/manifests/apps/publicapi.pp
+++ b/modules/govuk/manifests/apps/publicapi.pp
@@ -1,13 +1,9 @@
 # FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
 class govuk::apps::publicapi (
-  $backdrop_protocol = 'https',
-  $backdrop_host = 'www.performance.service.gov.uk',
   $privateapi_ssl = true,
 ) {
   govuk::app::publicapi { 'live-publicapi':
-    backdrop_protocol => $backdrop_protocol,
-    backdrop_host     => $backdrop_host,
-    privateapi_ssl    => $privateapi_ssl,
-    prefix            => '',
+    privateapi_ssl => $privateapi_ssl,
+    prefix         => '',
   }
 }

--- a/modules/govuk/templates/publicapi_nginx_extra_config.erb
+++ b/modules/govuk/templates/publicapi_nginx_extra_config.erb
@@ -58,11 +58,3 @@
   location ~ ^/api(/|$) {
     return 410;
   }
-
-  location ~ ^/performance/(.*)/api/(.*) {
-    rewrite ^/performance/(.*)/api/(.*)$ /data/$1/$2 break;
-
-    proxy_ssl_session_reuse off;
-    proxy_set_header Host <%= @backdrop_host %>;
-    proxy_pass <%= @backdrop_url %>;
-  }


### PR DESCRIPTION
The router has a prefix route for /performance, and no more specific
routes that override this [1]. Due to this, the nginx configuration
for backdrop is unused, as any traffic that matches the /performance
path will be routed elsewhere by the router.

You can double check this by looking at the logs in Logit, as there
are no results for [2].

1:
```
irb(main):022:0> Route.where(
  incoming_path: /^\/performance/,
  handler: 'backend'
).pluck(:incoming_path, :route_type, :backend_id)
=> [["/performance", "prefix", "spotlight"],
    ["/performance/big-screen", "prefix", "performanceplatform-big-screen-view"]]
```

2:
```
application:publicapi.publishing.service.gov.uk-json.event.access  AND "GET /performance*"
```