### PR TITLE
Ensure the workspace is clear before running the job

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/build_fpm_package.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/build_fpm_package.yaml.erb
@@ -19,7 +19,9 @@
         - github:
             url: https://github.com/alphagov/packager/
     scm:
-      - build_fpm_package
+        - build_fpm_package
+    wrappers:
+        - workspace-cleanup
     parameters:
         - string:
             name: RECIPE


### PR DESCRIPTION
# Context
When running this job there is a java.nio.file.FileSystemException error when attempting to remove the git repo.

# Decision
Clear the workspace prior to running the job. This was though to have been done in a previous commit but the yaml there was wrong. Adding the wrapper is the correct way to achieve this.