### PR TITLE
Allow selectively changing where apps look for rummager

### DIFF
--- a/modules/govuk/manifests/app.pp
+++ b/modules/govuk/manifests/app.pp
@@ -237,6 +237,9 @@
 # [*collectd_process_regex*]
 #   Regex to use to identify the process.
 #
+# [*override_search_location*]
+#   Alternative hostname to use for Plek("search") and Plek("rummager")
+#
 define govuk::app (
   $app_type,
   $port = 0,
@@ -273,6 +276,7 @@ define govuk::app (
   $cpu_warning = 150,
   $cpu_critical = 200,
   $collectd_process_regex = undef,
+  $override_search_location = undef,
 ) {
 
   if ! ($app_type in ['procfile', 'rack', 'bare']) {
@@ -348,6 +352,7 @@ define govuk::app (
     cpu_warning                      => $cpu_warning,
     cpu_critical                     => $cpu_critical,
     collectd_process_regex           => $collectd_process_regex,
+    override_search_location         => $override_search_location,
   }
 
   govuk::app::service { $title:

--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -43,6 +43,9 @@
 # [*collectd_process_regex*]
 #   Regex to use to identify the process.
 #
+# [*override_search_location*]
+#   Alternative hostname to use for Plek("search") and Plek("rummager")
+#
 define govuk::app::config (
   $app_type,
   $domain,
@@ -78,6 +81,7 @@ define govuk::app::config (
   $cpu_critical = 200,
   $collectd_process_regex = undef,
   $alert_when_threads_exceed = 100,
+  $override_search_location = undef,
 ) {
   $ensure_directory = $ensure ? {
     'present' => 'directory',
@@ -154,6 +158,17 @@ define govuk::app::config (
       "${title}-SENTRY_DSN":
         varname => 'SENTRY_DSN',
         value   => $sentry_dsn;
+    }
+
+    if $override_search_location {
+      govuk::app::envar {
+        "${title}-PLEK_SERVICE_SEARCH_URI":
+          varname => 'PLEK_SERVICE_SEARCH_URI',
+          value   => $override_search_location;
+        "${title}-PLEK_SERVICE_RUMMAGER_URI":
+          varname => 'PLEK_SERVICE_RUMMAGER_URI',
+          value   => $override_search_location;
+      }
     }
 
     if 'development' != $::govuk_node_class {

--- a/modules/govuk/manifests/apps/collections.pp
+++ b/modules/govuk/manifests/apps/collections.pp
@@ -30,6 +30,9 @@
 # [*email_alert_api_bearer_token*]
 #   Bearer token for communication with the email-alert-api
 #
+# [*override_search_location*]
+#   Alternative hostname to use for Plek("search") and Plek("rummager")
+#
 class govuk::apps::collections(
   $vhost = 'collections',
   $port = '3070',
@@ -38,18 +41,20 @@ class govuk::apps::collections(
   $nagios_memory_warning = undef,
   $nagios_memory_critical = undef,
   $email_alert_api_bearer_token = undef,
+  $override_search_location = undef,
 ) {
   govuk::app { 'collections':
-    app_type               => 'rack',
-    port                   => $port,
-    health_check_path      => '/topic/oil-and-gas',
-    log_format_is_json     => true,
-    asset_pipeline         => true,
-    asset_pipeline_prefix  => 'collections',
-    vhost                  => $vhost,
-    nagios_memory_warning  => $nagios_memory_warning,
-    nagios_memory_critical => $nagios_memory_critical,
-    sentry_dsn             => $sentry_dsn,
+    app_type                 => 'rack',
+    port                     => $port,
+    health_check_path        => '/topic/oil-and-gas',
+    log_format_is_json       => true,
+    asset_pipeline           => true,
+    asset_pipeline_prefix    => 'collections',
+    vhost                    => $vhost,
+    nagios_memory_warning    => $nagios_memory_warning,
+    nagios_memory_critical   => $nagios_memory_critical,
+    sentry_dsn               => $sentry_dsn,
+    override_search_location => $override_search_location,
   }
 
   Govuk::App::Envvar {

--- a/modules/govuk/manifests/apps/content_tagger.pp
+++ b/modules/govuk/manifests/apps/content_tagger.pp
@@ -61,6 +61,9 @@
 #   Whether to enable the procfile worker
 #   Default: true
 #
+# [*override_search_location*]
+#   Alternative hostname to use for Plek("search") and Plek("rummager")
+#
 class govuk::apps::content_tagger(
   $port = '3116',
   $secret_key_base = undef,
@@ -78,18 +81,20 @@ class govuk::apps::content_tagger(
   $redis_host = undef,
   $redis_port = undef,
   $enable_procfile_worker = true,
+  $override_search_location = undef
 ) {
   $app_name = 'content-tagger'
 
   govuk::app { $app_name:
-    app_type           => 'rack',
-    port               => $port,
-    vhost_ssl_only     => true,
-    health_check_path  => '/healthcheck',
-    log_format_is_json => true,
-    asset_pipeline     => true,
-    deny_framing       => false,
-    sentry_dsn         => $sentry_dsn,
+    app_type                 => 'rack',
+    port                     => $port,
+    vhost_ssl_only           => true,
+    health_check_path        => '/healthcheck',
+    log_format_is_json       => true,
+    asset_pipeline           => true,
+    deny_framing             => false,
+    sentry_dsn               => $sentry_dsn,
+    override_search_location => $override_search_location,
   }
 
   Govuk::App::Envvar {

--- a/modules/govuk/manifests/apps/finder_frontend.pp
+++ b/modules/govuk/manifests/apps/finder_frontend.pp
@@ -21,6 +21,9 @@
 # [*email_alert_api_bearer_token*]
 #   Bearer token for communication with the email-alert-api
 #
+# [*override_search_location*]
+#   Alternative hostname to use for Plek("search") and Plek("rummager")
+#
 class govuk::apps::finder_frontend(
   $port = '3062',
   $enabled = false,
@@ -30,6 +33,7 @@ class govuk::apps::finder_frontend(
   $secret_key_base = undef,
   $email_alert_api_bearer_token = undef,
   $unicorn_worker_processes = undef,
+  $override_search_location = undef,
 ) {
 
   if $enabled {
@@ -44,6 +48,7 @@ class govuk::apps::finder_frontend(
       nagios_memory_warning    => $nagios_memory_warning,
       nagios_memory_critical   => $nagios_memory_critical,
       unicorn_worker_processes => $unicorn_worker_processes,
+      override_search_location => $override_search_location,
     }
   }
 

--- a/modules/govuk/manifests/apps/hmrc_manuals_api.pp
+++ b/modules/govuk/manifests/apps/hmrc_manuals_api.pp
@@ -34,6 +34,9 @@
 #   The bearer token to use when communicating with Publishing API.
 #   Default: undef
 #
+# [*override_search_location*]
+#   Alternative hostname to use for Plek("search") and Plek("rummager")
+#
 class govuk::apps::hmrc_manuals_api(
   $port = '3071',
   $sentry_dsn = undef,
@@ -42,6 +45,7 @@ class govuk::apps::hmrc_manuals_api(
   $oauth_secret = undef,
   $publish_topics = true,
   $publishing_api_bearer_token = undef,
+  $override_search_location = undef,
 ) {
 
   Govuk::App::Envvar {
@@ -77,11 +81,12 @@ class govuk::apps::hmrc_manuals_api(
   }
 
   govuk::app { 'hmrc-manuals-api':
-    app_type           => 'rack',
-    port               => $port,
-    sentry_dsn         => $sentry_dsn,
-    vhost_ssl_only     => true,
-    health_check_path  => '/healthcheck',
-    log_format_is_json => true,
+    app_type                 => 'rack',
+    port                     => $port,
+    sentry_dsn               => $sentry_dsn,
+    vhost_ssl_only           => true,
+    health_check_path        => '/healthcheck',
+    log_format_is_json       => true,
+    override_search_location => $override_search_location,
   }
 }

--- a/modules/govuk/manifests/apps/licencefinder.pp
+++ b/modules/govuk/manifests/apps/licencefinder.pp
@@ -24,6 +24,9 @@
 #   The bearer token to use when communicating with Publishing API.
 #   Default: undef
 #
+# [*override_search_location*]
+#   Alternative hostname to use for Plek("search") and Plek("rummager")
+#
 class govuk::apps::licencefinder(
   $port = '3014',
   $sentry_dsn = undef,
@@ -31,19 +34,21 @@ class govuk::apps::licencefinder(
   $mongodb_name = 'licence_finder_production',
   $secret_key_base = undef,
   $publishing_api_bearer_token = undef,
+  $override_search_location = undef,
 ) {
 
   $app_name = 'licencefinder'
 
   govuk::app { $app_name:
-    app_type              => 'rack',
-    port                  => $port,
-    sentry_dsn            => $sentry_dsn,
-    health_check_path     => '/licence-finder/sectors',
-    log_format_is_json    => true,
-    asset_pipeline        => true,
-    asset_pipeline_prefix => 'licencefinder',
-    repo_name             => 'licence-finder',
+    app_type                 => 'rack',
+    port                     => $port,
+    sentry_dsn               => $sentry_dsn,
+    health_check_path        => '/licence-finder/sectors',
+    log_format_is_json       => true,
+    asset_pipeline           => true,
+    asset_pipeline_prefix    => 'licencefinder',
+    repo_name                => 'licence-finder',
+    override_search_location => $override_search_location,
   }
 
   if $::govuk_node_class !~ /^development$/ {

--- a/modules/govuk/manifests/apps/search_admin.pp
+++ b/modules/govuk/manifests/apps/search_admin.pp
@@ -42,6 +42,10 @@
 # [*rummager_bearer_token*]
 #   The bearer token to use when communicating with Rummager.
 #   Default: undef
+#
+# [*override_search_location*]
+#   Alternative hostname to use for Plek("search") and Plek("rummager")
+#
 class govuk::apps::search_admin(
   $db_hostname = undef,
   $db_name = undef,
@@ -54,18 +58,20 @@ class govuk::apps::search_admin(
   $oauth_secret = undef,
   $secret_key_base = undef,
   $rummager_bearer_token = undef,
+  $override_search_location = undef,
 ) {
   $app_name = 'search-admin'
 
   govuk::app { $app_name:
-    app_type           => 'rack',
-    port               => $port,
-    sentry_dsn         => $sentry_dsn,
-    vhost_ssl_only     => true,
-    health_check_path  => '/queries',
-    log_format_is_json => true,
-    asset_pipeline     => true,
-    deny_framing       => true,
+    app_type                 => 'rack',
+    port                     => $port,
+    sentry_dsn               => $sentry_dsn,
+    vhost_ssl_only           => true,
+    health_check_path        => '/queries',
+    log_format_is_json       => true,
+    asset_pipeline           => true,
+    deny_framing             => true,
+    override_search_location => $override_search_location,
   }
 
   Govuk::App::Envvar {

--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -122,6 +122,10 @@
 # [*rummager_bearer_token*]
 #   The bearer token to use when communicating with Rummager.
 #   Default: undef
+#
+# [*override_search_location*]
+#   Alternative hostname to use for Plek("search") and Plek("rummager")
+#
 class govuk::apps::whitehall(
   $admin_db_name = undef,
   $admin_db_hostname = undef,
@@ -160,6 +164,7 @@ class govuk::apps::whitehall(
   $cpu_warning = 150,
   $cpu_critical = 200,
   $rummager_bearer_token = undef,
+  $override_search_location = undef,
 ) {
 
   $app_name = 'whitehall'
@@ -199,6 +204,7 @@ class govuk::apps::whitehall(
     unicorn_worker_processes => $unicorn_worker_processes,
     cpu_warning              => $cpu_warning,
     cpu_critical             => $cpu_critical,
+    override_search_location => $override_search_location,
   }
 
   Govuk::App::Envvar {


### PR DESCRIPTION
This is going to be useful as we migrate from rummager to search-api.  When we're happy the data in rummager and search-api is consistent, and that updates are being sent to both apps, we can gradually change which one is used for queries.

---

[Trello card](https://trello.com/c/YTAtoA21/22-add-an-option-to-each-app-which-uses-rummager-to-override-plek)