### PR TITLE
Deploy CDN from govuk-cdn-config

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_cdn.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_cdn.yaml.erb
@@ -3,7 +3,7 @@
     name: cdn-configs_Deploy_CDN
     scm:
         - git:
-            url: git@github.com:alphagov/fastly-configure.git
+            url: git@github.com:alphagov/govuk-cdn-config.git
             branches:
               - master
             wipe-workspace: true
@@ -19,7 +19,7 @@
             days-to-keep: 30
             artifact-num-to-keep: 5
         - github:
-            url: https://github.com/alphagov/fastly-configure/
+            url: https://github.com/alphagov/govuk-cdn-config/
     scm:
       - cdn-configs_Deploy_CDN
     builders:


### PR DESCRIPTION
We've merged the code to deploy the CDN into alphagov/govuk-cdn-config (https://github.com/alphagov/govuk-cdn-config/pull/89).

Part of an effort to pay down tech debt in the CDN configuration:

https://trello.com/c/y6MIgxjp