### PR TITLE
Add option to replay Rummager traffic in real-time with Gor

### DIFF
--- a/modules/govuk_search/manifests/gor.pp
+++ b/modules/govuk_search/manifests/gor.pp
@@ -4,6 +4,11 @@
 # way to recover from failure as we can restore the last backup and then replay the
 # traffic (POST requests are for data insert/update only)
 #
+# Also optionally replays traffic, in real-time, to a given list of
+# target hosts.  This is a temporary measure so we can replay
+# Whitehall and Search Admin updates from Rummager to Search API
+# during the migration.
+#
 # Traffic can then be replayed by follow the guide at:
 # https://github.com/buger/goreplay/wiki/Capturing-and-replaying-traffic
 #
@@ -18,9 +23,14 @@
 #   If the output path contains an `_` then either the filename need to end in an `_`
 #   or output-file-append needs to be set to true for the filename generation to work
 #   as expected.
+#
+# [*replay_target_hosts*]
+#   Hosts to replay traffic to; defaults to an empty list.
+#
 class govuk_search::gor (
   $output_path = '/var/log/gor_dump',
-  $enabled = false
+  $enabled = false,
+  $replay_target_hosts = [],
 ) {
 
   validate_bool($enabled)
@@ -47,6 +57,7 @@ class govuk_search::gor (
         '-output-file'        => $output_file,
         '-output-file-append' => true,
         '-http-allow-method'  => ['POST', 'DELETE'],
+        '-output-http'        => $replay_target_hosts,
         '-http-original-host' => '',
       },
       envvars => {

--- a/modules/govuk_search/spec/classes/govuk_search__gor_spec.rb
+++ b/modules/govuk_search/spec/classes/govuk_search__gor_spec.rb
@@ -5,6 +5,7 @@ describe 'govuk_search::gor', :type => :class do
     '-input-raw'          => ':3009',
     '-output-file-append' => true,
     '-http-allow-method'  => %w{POST DELETE},
+    '-output-http'        => [],
     '-http-original-host' => '',
   }}
 


### PR DESCRIPTION
This will be used during the migration from Rummager to Search API to
ensure that updates from Whitehall and Search Admin (which are sent
via POST and DELETE requests) make it to both search servers.

---

[Trello card](https://trello.com/c/MK4lguCm/23-make-it-possible-to-replay-rummager-http-traffic-to-search-api)