### PR TITLE
Add search-api to CI

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -852,6 +852,7 @@ govuk_ci::master::pipeline_jobs:
   rails_translation_manager: {}
   router-data: {}
   seal: {}
+  search-api: {}
   shared_mustache: {}
   slimmer: {}
   smokey: {}


### PR DESCRIPTION
Apps which are deployable in hieradata get automatically added to CI,
but search-api is only deployable in hieradata_aws for now.

---

[Trello card](https://trello.com/c/xNNHprUZ/20-set-up-new-search-api-app)