### PR TITLE
Increase CKAN timeout again to 60s

### DIFF
--- a/modules/govuk/manifests/apps/ckan.pp
+++ b/modules/govuk/manifests/apps/ckan.pp
@@ -69,7 +69,7 @@ class govuk::apps::ckan (
       vhost_ssl_only     => true,
       health_check_path  => '/healthcheck',
       log_format_is_json => false,
-      read_timeout       => 30,
+      read_timeout       => 60,
     }
 
     $toggled_priority_ensure = $priority_worker_processes ? {


### PR DESCRIPTION
This matches the configuration in bytemark and gives us some breathing room to sort more pressing issues before looking into ameliorating this.

https://trello.com/c/pIyPoUxJ/741-spike-the-extent-of-gateway-timeouts-on-datagovuk