### PR TITLE
Remove govuk_high_priority checks for AWS RDS

### DIFF
--- a/modules/monitoring/manifests/checks/rds_config.pp
+++ b/modules/monitoring/manifests/checks/rds_config.pp
@@ -30,7 +30,6 @@ define monitoring::checks::rds_config (
 ){
   icinga::check { "check_aws_rds_cpu-${title}":
     check_command       => "check_aws_rds_cpu!${region}!${cpu_warning}!${cpu_critical}!${::aws_stackname}-${title}",
-    use                 => 'govuk_urgent_priority',
     host_name           => $::fqdn,
     service_description => "${title} - AWS RDS CPU Utilization",
     notes_url           => monitoring_docs_url(aws-rds-cpu),
@@ -39,7 +38,6 @@ define monitoring::checks::rds_config (
 
   icinga::check { "check_aws_rds_memory-${title}":
     check_command       => "check_aws_rds_memory!${region}!${memory_warning}!${memory_critical}!${::aws_stackname}-${title}",
-    use                 => 'govuk_urgent_priority',
     host_name           => $::fqdn,
     service_description => "${title} - AWS RDS Memory Utilization",
     notes_url           => monitoring_docs_url(aws-rds-memory),
@@ -48,7 +46,6 @@ define monitoring::checks::rds_config (
 
   icinga::check { "check_aws_rds_storage-${title}":
     check_command       => "check_aws_rds_storage!${region}!${storage_warning}!${storage_critical}!${::aws_stackname}-${title}",
-    use                 => 'govuk_urgent_priority',
     host_name           => $::fqdn,
     service_description => "${title} - AWS RDS Storage Utilization",
     notes_url           => monitoring_docs_url(aws-rds-storage),


### PR DESCRIPTION
These alerts were set to govuk_urgent_priority without a notification_period which meant any critical alerts of these would trigger pager duty 24x7.

This is inconsistent with the GOV.UK on call policy where out of hours we only intend to wake people up for user noticeable symptoms , such as 500 errors rather than internal problems.

I've removed the use of `use` here as this will default these to a govuk regular service which seems to just trigger icinga and not pagerduty. I was a bit confused though what the difference was between regular, normal priority and high priority: https://github.com/alphagov/govuk-puppet/blob/81cb1eadd1c3457df22c030b8fb2b01cdc186437/modules/monitoring/manifests/contacts.pp