### PR TITLE
Increase timeout for Content Data Admin

### DIFF
--- a/modules/govuk/manifests/apps/content_data_admin.pp
+++ b/modules/govuk/manifests/apps/content_data_admin.pp
@@ -50,6 +50,11 @@
 # [*google_tag_manager_auth*]
 #   The identifier of an environment for Google Tag Manager
 #
+# [*read_timeout*]
+# Configure the amount of time the nginx proxy vhost will wait for the
+# backing app before it sends the client a 504. We override the default 15 seconds
+# to 60.
+#
 class govuk::apps::content_data_admin (
   $port                         = '3230',
   $enabled                      = true,
@@ -85,6 +90,7 @@ class govuk::apps::content_data_admin (
     health_check_path => '/healthcheck', # must return HTTP 200 for an unauthenticated request
     deny_framing      => true,
     asset_pipeline    => true,
+    read_timeout      => 60,
   }
 
   Govuk::App::Envvar {


### PR DESCRIPTION
We are seeing timeout issues when the Content Performance Manager
is running slow queries. The timeout does not occur at the API end
and we are not able to reproduce this error on other environments.
This problem only occurs on production. For now we are upping the
timeout on the client end to address the timeouts, and allow
opportunities for performance optimisation later.