### PR TITLE
Trello-1951: email-alert-api nginx config

### DIFF
--- a/modules/govuk/manifests/node/s_backend_lb.pp
+++ b/modules/govuk/manifests/node/s_backend_lb.pp
@@ -29,7 +29,7 @@
 #   Whether the backend should be taken offline in nginx
 #
 # [*aws_egress_nat_ips*]
-#   NAT Gateway Egress IPs from AWS Environment
+#   NAT Gateway Egress IPs from AWS Environment & Internal IP Ranges
 #
 class govuk::node::s_backend_lb (
   $perfplat_public_app_domain = 'performance.service.gov.uk',
@@ -97,8 +97,8 @@ class govuk::node::s_backend_lb (
   }
 
   loadbalancer::balance { 'email-alert-api':
-      internal_only => true,
-      servers       => $email_alert_api_backend_servers,
+      aws_egress_nat_ips => $aws_egress_nat_ips,
+      servers            => $email_alert_api_backend_servers,
   }
 
   loadbalancer::balance { 'email-alert-api-public':

--- a/modules/loadbalancer/templates/nginx_balance.conf.erb
+++ b/modules/loadbalancer/templates/nginx_balance.conf.erb
@@ -90,10 +90,12 @@ server {
     allow 127.0.0.1;
     deny all;
     <%- elsif @aws_egress_nat_ips -%>
-    # Only accept connnections from AWS Environment
+    # Only accept connnections from AWS Environment and internal machines
     <%- [@aws_egress_nat_ips].flatten.each do |ip| -%>
     allow <%= ip %>;
     <%- end -%>
+    allow 10.0.0.0/8;
+    allow 127.0.0.1;
     deny all;
     <%- end -%>
     include includes/maintenance.conf;

--- a/modules/loadbalancer/templates/nginx_balance_no_ssl.conf.erb
+++ b/modules/loadbalancer/templates/nginx_balance_no_ssl.conf.erb
@@ -73,10 +73,12 @@ server {
     allow 127.0.0.1;
     deny all;
     <%- elsif @aws_egress_nat_ips -%>
-    # Only accept connnections from AWS Environment
+    # Only accept connnections from AWS Environment and internal machines
     <%- [@aws_egress_nat_ips].flatten.each do |ip| -%>
     allow <%= ip %>;
     <%- end -%>
+    allow 10.0.0.0/8;
+    allow 127.0.0.1;
     deny all;
     <%- end -%> 
     include includes/maintenance.conf;


### PR DESCRIPTION
This will allow the nginx load balancer that runs on the backend-lbs in
carrenza to accept connections from our AWS nat gateways, this is
required for migrating the frontends to AWS.

Also making a change to allow internal ranges to be able to connect if
we allow AWS ranges to connect.

@ronocg <conor.glynn@digital.cabinet-office.gov.uk>