### PR TITLE
Trello-1963: access publishing-api from aws frontends

### DIFF
--- a/modules/govuk/manifests/node/s_backend_lb.pp
+++ b/modules/govuk/manifests/node/s_backend_lb.pp
@@ -106,8 +106,8 @@ class govuk::node::s_backend_lb (
   }
 
   loadbalancer::balance { 'publishing-api':
-      internal_only => true,
-      servers       => $publishing_api_backend_servers,
+      aws_egress_nat_ips => $aws_egress_nat_ips,
+      servers            => $publishing_api_backend_servers,
   }
 
   loadbalancer::balance { 'search':


### PR DESCRIPTION
After the frontends migrate to AWS, some will still require access to
the publishing-api, which is nginx load balanced via the backend-lb, so
here we are opening up the publishing-api to be able to accept connects
from the 3 egress nat gateway IPs from aws.

@ronocg <conor.glynn@digital.cabinet-office.gov.uk>