### PR TITLE
Increase timeout for Content Performance Manager

### DIFF
--- a/modules/govuk/manifests/apps/content_performance_manager.pp
+++ b/modules/govuk/manifests/apps/content_performance_manager.pp
@@ -66,6 +66,11 @@
 #   Redis port for Sidekiq.
 #   Default: undef
 #
+# [*read_timeout*]
+# Configure the amount of time the nginx proxy vhost will wait for
+# before it sends the client a 504. We override the default 15 seconds
+# to 60.
+#
 # [*secret_key_base*]
 #   The key for Rails to use when signing/encrypting sessions.
 #
@@ -107,6 +112,7 @@ class govuk::apps::content_performance_manager(
     health_check_path => '/api/v1/healthcheck',
     json_health_check => true,
     asset_pipeline    => true,
+    read_timeout      => 60,
   }
 
   Govuk::App::Envvar {


### PR DESCRIPTION
We are seeing timeout issues when the Content Performance Manager
is running slow queries. We are not able to reproduce this error on
other environments other than on production.

For now we are upping the timeout limit to address the timeouts,
and allow opportunities for performance optimisation later.

[Related PR](https://github.com/alphagov/govuk-puppet/pull/8595).