### PR TITLE
Content-store health check via nginx

### DIFF
--- a/hieradata_aws/class/staging/content_store.yaml
+++ b/hieradata_aws/class/staging/content_store.yaml
@@ -3,3 +3,5 @@
 icinga::client::check_pings::endpoints:
    router-api:
      ip: 10.2.1.253
+
+govuk::apps::content_store::create_default_nginx_config: true

--- a/modules/govuk/manifests/app.pp
+++ b/modules/govuk/manifests/app.pp
@@ -240,6 +240,10 @@
 # [*override_search_location*]
 #   Alternative hostname to use for Plek("search") and Plek("rummager")
 #
+# [*create_default_nginx_config*]
+#   Create the default.conf site in nginx
+#   Default: false
+#
 define govuk::app (
   $app_type,
   $port = 0,
@@ -277,6 +281,7 @@ define govuk::app (
   $cpu_critical = 200,
   $collectd_process_regex = undef,
   $override_search_location = undef,
+  $create_default_nginx_config = false,
 ) {
 
   if ! ($app_type in ['procfile', 'rack', 'bare']) {
@@ -353,6 +358,7 @@ define govuk::app (
     cpu_critical                     => $cpu_critical,
     collectd_process_regex           => $collectd_process_regex,
     override_search_location         => $override_search_location,
+    create_default_nginx_config      => $create_default_nginx_config,
   }
 
   govuk::app::service { $title:

--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -46,6 +46,10 @@
 # [*override_search_location*]
 #   Alternative hostname to use for Plek("search") and Plek("rummager")
 #
+# [*create_default_nginx_config*]
+#   Create the default.conf site in nginx
+#   Default: false
+#
 define govuk::app::config (
   $app_type,
   $domain,
@@ -82,6 +86,7 @@ define govuk::app::config (
   $collectd_process_regex = undef,
   $alert_when_threads_exceed = 100,
   $override_search_location = undef,
+  $create_default_nginx_config = false,
 ) {
   $ensure_directory = $ensure ? {
     'present' => 'directory',
@@ -257,6 +262,16 @@ define govuk::app::config (
       alert_5xx_critical_rate        => $alert_5xx_critical_rate,
       proxy_http_version_1_1_enabled => $proxy_http_version_1_1_enabled,
     }
+
+    if ($create_default_nginx_config == true) and ($::aws_environment == 'staging') {
+      nginx::config::vhost::app_default { 'default':
+        app_healthcheck_url     => $health_check_path,
+        app_hostname            => $title,
+        app_port                => $port,
+        default_healthcheck_url => '/_healthcheck',
+      }
+    }
+
   }
   $title_underscore = regsubst($title, '\.', '_', 'G')
 

--- a/modules/govuk/manifests/apps/content_store.pp
+++ b/modules/govuk/manifests/apps/content_store.pp
@@ -76,20 +76,22 @@ class govuk::apps::content_store(
   $oauth_id = undef,
   $oauth_secret = undef,
   $router_api_bearer_token = undef,
+  $create_default_nginx_config = false,
 ) {
   $app_name = 'content-store'
 
   govuk::app { $app_name:
-    app_type                 => 'rack',
-    port                     => $port,
-    sentry_dsn               => $sentry_dsn,
-    vhost_ssl_only           => true,
-    health_check_path        => '/healthcheck',
-    log_format_is_json       => true,
-    vhost                    => $vhost,
-    nagios_memory_warning    => $nagios_memory_warning,
-    nagios_memory_critical   => $nagios_memory_critical,
-    unicorn_worker_processes => $unicorn_worker_processes,
+    app_type                    => 'rack',
+    port                        => $port,
+    sentry_dsn                  => $sentry_dsn,
+    vhost_ssl_only              => true,
+    health_check_path           => '/healthcheck',
+    log_format_is_json          => true,
+    vhost                       => $vhost,
+    nagios_memory_warning       => $nagios_memory_warning,
+    nagios_memory_critical      => $nagios_memory_critical,
+    unicorn_worker_processes    => $unicorn_worker_processes,
+    create_default_nginx_config => $create_default_nginx_config,
   }
 
   Govuk::App::Envvar {

--- a/modules/govuk/manifests/node/s_content_store.pp
+++ b/modules/govuk/manifests/node/s_content_store.pp
@@ -6,9 +6,11 @@ class govuk::node::s_content_store inherits govuk::node::s_base {
   include nscd
   include router::gor
 
-  # If we miss all the apps, throw a 500 to be caught by the cache nginx
-  nginx::config::vhost::default { 'default': }
 
+  if ($::aws_environment != 'staging') {
+    # If we miss all the apps, throw a 500 to be caught by the cache nginx
+    nginx::config::vhost::default { 'default': }
+  }
   if ($::aws_environment == 'staging') or ($::aws_environment == 'production') {
     include ::hosts::default
     include ::hosts::backend_migration

--- a/modules/govuk/manifests/node/s_content_store.pp
+++ b/modules/govuk/manifests/node/s_content_store.pp
@@ -6,14 +6,17 @@ class govuk::node::s_content_store inherits govuk::node::s_base {
   include nscd
   include router::gor
 
-
+  # In Staging environment, the content-store app will create its own default
+  # vhost
   if ($::aws_environment != 'staging') {
     # If we miss all the apps, throw a 500 to be caught by the cache nginx
     nginx::config::vhost::default { 'default': }
   }
+
   if ($::aws_environment == 'staging') or ($::aws_environment == 'production') {
     include ::hosts::default
     include ::hosts::backend_migration
     include icinga::client::check_pings
   }
 }
+

--- a/modules/nginx/manifests/config/vhost/app_default.pp
+++ b/modules/nginx/manifests/config/vhost/app_default.pp
@@ -1,0 +1,32 @@
+# == Define: nginx::config::vhost::app_default
+#
+# Creates the default nginx vhost file
+#
+# === Parameters
+#
+# [*app_hostname*]
+#   The "Host" value that the app expects in the HTML header request.
+#
+# [*app_port*]
+#   The network port on which the app is listening.
+#
+# [*app_healthcheck_url*]
+#   The URL from which the app serves the health check.
+#   Default: "/healthcheck"
+#
+# [*default_healthcheck_url*]
+#   The default URL that nginx expects the health check requests to have.
+#   Default: "/_healthcheck"
+#
+define nginx::config::vhost::app_default(
+  $app_hostname,
+  $app_port,
+  $app_healthcheck_url = '/healthcheck',
+  $default_healthcheck_url = '/_healthcheck',
+) {
+
+  nginx::config::site { 'default':
+    content => template('nginx/app-default-vhost.conf'),
+  }
+
+}

--- a/modules/nginx/templates/app-default-vhost.conf
+++ b/modules/nginx/templates/app-default-vhost.conf
@@ -1,0 +1,17 @@
+server {
+  listen 80 default_server;
+
+  rewrite ^<%= @default_healthcheck_url %>$ <%= @app_healthcheck_url %>;
+
+  # Send the Strict-Transport-Security header
+  include /etc/nginx/add-sts.conf;
+  # Required for Layer 7 Application Load Balancer
+  location = <%= @app_healthcheck_url %> {
+    proxy_set_header Host <%= @app_name %>;
+    proxy_pass http://localhost:<%= @app_port %>;
+  }
+
+  location / {
+    return 500 '{"error": "Fell through to default vhost"}\n';
+  }
+}


### PR DESCRIPTION
# Context

It was discovered that the load balancers in AWS use the endpoint `_healthcheck` to verify the health of the content-store. This endpoint only check the health of the nginx application and not the content-store app hosted behind nginx. Therefore, the health check may be passing but traffic to the content-store app via nginx maybe failing.

This is not an ideal scenario and therefore, we want to change the default nginx config so that health checks requests are routed to the app.

# Decisions
1. add an option to use a custom default nginx config which will route the health check to the app. This requires change to the logic inside puppet along with new hieradata

# Notes
1. This will work only where there is only one app fronted by the nginx server.