### PR TITLE
Increase cache-clearing-service RabbitMQ thresholds

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -364,8 +364,8 @@ govuk::apps::cache_clearing_service::rabbitmq_hosts:
   - rabbitmq-1.backend
   - rabbitmq-2.backend
   - rabbitmq-3.backend
-govuk::apps::cache_clearing_service::rabbitmq::queue_size_critical_threshold: 10000
-govuk::apps::cache_clearing_service::rabbitmq::queue_size_warning_threshold: 1000
+govuk::apps::cache_clearing_service::rabbitmq::queue_size_critical_threshold: 100000
+govuk::apps::cache_clearing_service::rabbitmq::queue_size_warning_threshold: 80000
 
 govuk::apps::ckan::db_hostname: "postgresql-primary-1.backend"
 govuk::apps::ckan::db_port: 6432

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -377,8 +377,8 @@ govuk::apps::cache_clearing_service::enabled: true
 govuk::apps::cache_clearing_service::nagios_memory_warning: 2750
 govuk::apps::cache_clearing_service::nagios_memory_critical: 3000
 govuk::apps::cache_clearing_service::rabbitmq_hosts: [rabbitmq]
-govuk::apps::cache_clearing_service::rabbitmq::queue_size_critical_threshold: 10000
-govuk::apps::cache_clearing_service::rabbitmq::queue_size_warning_threshold: 1000
+govuk::apps::cache_clearing_service::rabbitmq::queue_size_critical_threshold: 100000
+govuk::apps::cache_clearing_service::rabbitmq::queue_size_warning_threshold: 80000
 
 govuk::apps::ckan::db_hostname: "postgresql-primary"
 govuk::apps::ckan::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"


### PR DESCRIPTION
Since [we made the queue automatically expire messages after an hour](https://github.com/alphagov/govuk-puppet/pull/8577), there's less of a risk of this growth being a significant problem.

I've looked back in the last week and the highest the queue ever got to was 80k, so it seems fine to increase the thresholds to those sorts of levels.