### PR TITLE
Create elasticsearch plugin .name files

### DIFF
--- a/modules/govuk_elasticsearch/manifests/plugins.pp
+++ b/modules/govuk_elasticsearch/manifests/plugins.pp
@@ -43,6 +43,17 @@ class govuk_elasticsearch::plugins (
       module_dir => 'head',
       instances  => $::fqdn,
     }
+
+    # this is a temporary hack needed so we can upgrade to a newer
+    # puppet-elasticsearch which expects these files to exist.
+    file { '/usr/share/elasticsearch/plugins/cloud-aws/.name':
+      ensure  => file,
+      content => 'cloud-aws/2.4.6',
+    }
+    file { '/usr/share/elasticsearch/plugins/head/.name':
+      ensure  => file,
+      content => 'mobz/elasticsearch-head',
+    }
   }
   # If the version is 5.0 or newer, then install the two plugins it got split into:
   # https://www.elastic.co/guide/en/elasticsearch/plugins/5.0/cloud-aws.html


### PR DESCRIPTION
The version of puppet-elasticsearch we're upgrading to in #8594
expects these files to exist, and uses them in its plugin version
detection.  If the plugin is installed but without the .name file (as
is currently the case), it will give an error asking you to manually
uninstall the plugins first.

This doesn't seem to be mentioned in the CHANGELOG with the other
breaking changes.

---

To test this I did these steps:

1. Deploy #8594 
2. Run puppet on a rummager-elasticsearch machine, confirm that it doesn't work
3. Deploy this
4. Run puppet on a rummager-elasticsearch machine
5. Deploy #8594 again
6. Run puppet on the same rummager-elasticsearch machine

I also checked the sha1sums after step 4:

```
605897c0d249c40d64008d47e6c7323332ba4712  .name
a1f02d5f26ba1d8c37e2bf9c847db3c6729dda00  aws-java-sdk-core-1.10.69.jar
afbff1ece8365859eb4cfe0d3ba543d68b154d26  aws-java-sdk-ec2-1.10.69.jar
ed74ff3872193b4704a751f0b72ab2cf0db0651b  aws-java-sdk-kms-1.10.69.jar
6fa48bf0bff43f26436956b88d8d3764b6cf109e  aws-java-sdk-s3-1.10.69.jar
7b68c18149db07fc700c7aaf8e69f97e2d008483  cloud-aws-2.4.6.jar
b7f0fc8f61ecadeb3695f0b9464755eee44374d4  commons-codec-1.6.jar
f6f66e966c70a83ffbdb6f17a0919eaf7c8aca7f  commons-logging-1.1.3.jar
4c47155e3e6c9a41a28db36680b828ced53b8af4  httpclient-4.3.6.jar
f91b7a4aadc5cf486df6e4634748d7dd7a73f06d  httpcore-4.3.3.jar
a2a55a3375bc1cef830ca426d68d2ea22961190e  jackson-annotations-2.5.0.jar
c37875ff66127d93e5f672708cb2dcc14c8232ab  jackson-databind-2.5.3.jar
23dc068864b61460a153276352be25b77789c324  plugin-descriptor.properties
34bbe727e8a1913830d7b6795d8e9f3a5a394969  plugin-security.policy
```

And after step 6, and after uninstalling the plugins and then running puppet to reinstall them.  In both cases the sums were the same as after step 4.  So identical plugins are getting installed by both puppet-elasticsearch versions, the only difference is the presence of the .name file.

---

[Trello card](https://trello.com/c/OnIS3C0b/24-make-it-possible-to-set-up-elasticsearch-5x-with-puppet)