### PR TITLE
fix nginx restart

### DIFF
--- a/modules/nginx/manifests/restart.pp
+++ b/modules/nginx/manifests/restart.pp
@@ -1,7 +1,7 @@
 # FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
 class nginx::restart {
 
-  exec { '/etc/init.d/nginx configtest && /etc/init.d/nginx restart':
+  exec { '/etc/init.d/nginx configtest && (/etc/init.d/nginx restart || { nginx -s quit; /etc/init.d/nginx start;})':
     refreshonly => true,
   }
 

--- a/modules/nginx/manifests/service.pp
+++ b/modules/nginx/manifests/service.pp
@@ -3,6 +3,7 @@ class nginx::service {
 
   service { 'nginx':
     ensure    => running,
+    start     => '/etc/init.d/nginx start || { nginx -s quit; /etc/init.d/nginx start;}',
     hasstatus => true,
     restart   => '/etc/init.d/nginx configtest && /etc/init.d/nginx reload',
   }


### PR DESCRIPTION
# Context

Some AWS machines (e.g. content-store) fails on nginx start phase during the second run of Puppet when a new machine comes up and it is being configured by Puppet. The main complain of Puppet is that the address `0.0.0.0:80` is already taken and the new instance of nginx to be started can't have such a port.

Upon further investigation, it was found nginx was already running on port 80 and there was no PID number in the `/var/run/nginx.pid`

# Decisions
1. when nginx is to be started/restarted, ensure that no nginx is running on the machine.

