### PR TITLE
Increase warning threshold for nginx high active connections

### DIFF
--- a/modules/nginx/manifests/config.pp
+++ b/modules/nginx/manifests/config.pp
@@ -77,7 +77,7 @@ class nginx::config (
 
   @@icinga::check::graphite { "check_nginx_active_connections_${::hostname}":
     target    => "${::fqdn_metrics}.nginx.nginx_connections-active",
-    warning   => 500,
+    warning   => 650,
     critical  => 1000,
     desc      => 'nginx high active conn',
     host_name => $::fqdn,


### PR DESCRIPTION
The number of active connection is regularly above the 500 warning
threshold. Increasing to 650 as this is still 350 below the critical
threshold.

this covers the levels we are seeing regularly

![screen shot 2019-01-30 at 16 46 53](https://user-images.githubusercontent.com/511319/51997466-b456af00-24ae-11e9-9139-e58706cb647c.png)
