### PR TITLE
Enable cache-clearing-service on staging AWS

### DIFF
--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -18,6 +18,7 @@ node_class: &node_class
   backend:
     apps:
       - asset-manager
+      - cache-clearing-service
       - transition
       - imminence
       - kibana


### PR DESCRIPTION
  As part of the migration to AWS