### PR TITLE
Add memcached for finder-frontend to use

### DIFF
--- a/modules/govuk/manifests/node/s_calculators_frontend.pp
+++ b/modules/govuk/manifests/node/s_calculators_frontend.pp
@@ -23,6 +23,12 @@ class govuk::node::s_calculators_frontend inherits govuk::node::s_base {
     notes_url => monitoring_docs_url(nginx-high-conn-writing-upstream-indicator-check),
   }
 
+  include ::collectd::plugin::memcached
+  class { 'memcached':
+    max_memory => '12%',
+    listen_ip  => '0.0.0.0',
+  }
+
   # Only for testing
   if $::aws_environment == 'staging' {
     include govuk_splunk

--- a/modules/govuk_jenkins/templates/jobs/clear_frontend_memcache.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/clear_frontend_memcache.yaml.erb
@@ -4,7 +4,7 @@
     display-name: Clear frontend memcache
     project-type: freestyle
     description: >
-      Clears memcache for frontend and whitehall on GOV.UK.
+      Clears memcache for finder-frontend, frontend and whitehall on GOV.UK.
     properties:
       - build-discarder:
           num-to-keep: 30
@@ -14,7 +14,7 @@
 
           set -ex
 
-          for node in `govuk_node_list -c "frontend,whitehall_frontend"`; do
+          for node in `govuk_node_list -c "calculators_frontend,frontend,whitehall_frontend"`; do
             ssh deploy@$node "sudo /etc/init.d/memcached restart"
           done
     wrappers:


### PR DESCRIPTION
We cache [some things on finder-frontend](https://github.com/alphagov/finder-frontend/search?q=cache&unscoped_q=cache), and it would be better if we used memcached rather than the Rails default cache store (which is [ActiveSupport::Cache::FileStore](https://guides.rubyonrails.org/caching_with_rails.html#activesupport-cache-filestore))