### PR TITLE
Add ENV to enable Icinga alerts for ETL in CPM

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -19,6 +19,8 @@ govuk::apps::ckan::vhost_protected: true
 govuk::apps::content_data_admin::google_tag_manager_auth: 'wFyiBTovFhDv5qMe_LXt7Q'
 govuk::apps::content_data_admin::google_tag_manager_preview: 'env-7'
 govuk::apps::content_data_admin::google_tag_manager_id: 'GTM-NZG8SF2'
+govuk::apps::content_performance_manager::etl_healthcheck_enabled: true
+govuk::apps::content_performance_manager::etl_healthcheck_enabled_from_hour: 14
 govuk::apps::content_publisher::aws_s3_bucket: "govuk-integration-content-publisher-activestorage"
 govuk::apps::content_publisher::google_tag_manager_auth: "xTPyDeRcMiXFWvscgkLowg"
 govuk::apps::content_publisher::google_tag_manager_id: "GTM-NQXC4TG"

--- a/modules/govuk/manifests/apps/content_performance_manager.pp
+++ b/modules/govuk/manifests/apps/content_performance_manager.pp
@@ -18,6 +18,14 @@
 # [*db_username*]
 #   The username to use in the DATABASE_URL.
 #
+# [*etl_healthcheck_enabled*]
+#   Enables or disables the ETL checks via the healthcheck endpoint
+#   Default: false
+#
+# [*etl_healthcheck_enabled_from_hour*]
+#   The hour of the day where ETL healthcheck alerts are enabled
+#   Default: undef
+#
 # [*google_analytics_govuk_view_id*]
 #   The view id of GOV.UK in Google Analytics
 #   Default: undef
@@ -86,6 +94,8 @@ class govuk::apps::content_performance_manager(
   $db_password = undef,
   $db_username = 'content_performance_manager',
   $enable_procfile_worker = true,
+  $etl_healthcheck_enabled = false,
+  $etl_healthcheck_enabled_from_hour = undef,
   $google_analytics_govuk_view_id = undef,
   $google_client_email = undef,
   $google_private_key = undef,
@@ -171,6 +181,17 @@ class govuk::apps::content_performance_manager(
     "${title}-SUPPORT_API_BEARER_TOKEN":
       varname => 'SUPPORT_API_BEARER_TOKEN',
       value   => $support_api_bearer_token;
+  }
+
+  if $etl_healthcheck_enabled {
+    govuk::app::envvar {
+      "${title}-ETL_HEALTHCHECK_ENABLED":
+        varname => 'ETL_HEALTHCHECK_ENABLED',
+        value   => '1';
+      "${title}-ETL_HEALTHCHECK_ENABLED_FROM_HOUR":
+        varname => 'ETL_HEALTHCHECK_ENABLED_FROM_HOUR',
+        value   => $etl_healthcheck_enabled_from_hour;
+    }
   }
 
   govuk::app::envvar::redis { $app_name:

--- a/modules/govuk/manifests/apps/content_performance_manager.pp
+++ b/modules/govuk/manifests/apps/content_performance_manager.pp
@@ -119,7 +119,7 @@ class govuk::apps::content_performance_manager(
     app_type          => 'rack',
     port              => $port,
     sentry_dsn        => $sentry_dsn,
-    health_check_path => '/api/v1/healthcheck',
+    health_check_path => '/healthcheck',
     json_health_check => true,
     asset_pipeline    => true,
     read_timeout      => 60,


### PR DESCRIPTION
[Trello card](https://trello.com/c/zdEK6FMr/1103-2-2nd-line-alarm-documentation-for-content-data-and-content-performance-manager)

It adds the environment variable `ETL_HEALTHCHECK_ENABLED_FROM_HOUR` to
the development and integration environment which will enable and configure 
the ETL validations in Icinga via the health check endpoint.