### PR TITLE
Trello-1963: Add PLEK envvars for frontend aws

### DIFF
--- a/modules/govuk/manifests/app/envvar/plek_uri_overrides.pp
+++ b/modules/govuk/manifests/app/envvar/plek_uri_overrides.pp
@@ -1,0 +1,30 @@
+# == Define: govuk::app::envvar::plek_uri_overrides
+#
+# Defines Plek Overrides which are required as part 
+# of the migration processi from carrenza to aws.
+#
+# === Parameters
+#
+# [*app*]
+#   An optional GOV.UK app that the env vars are for.
+#
+define govuk::app::envvar::plek_uri_overrides (
+  $app_domain,
+) {
+
+  Govuk::App::Envvar {
+    app => $title,
+  }
+
+  govuk::app::envvar {
+    "${title}-PLEK_SERVICE_SEARCH_URI":
+      varname => PLEK_SERVICE_SEARCH_URI,
+      value   => "search.${app_domain}";
+    "${title}-PLEK_SERVICE_EMAIL_ALERT_API_URI":
+      varname => PLEK_SERVICE_EMAIL_ALERT_API_URI,
+      value   => "email-alert-api.${app_domain}";
+    "${title}-PLEK_SERVICE_PUBLISHING_API_URI":
+      varname => PLEK_SERVICE_PUBLISHING_API_URI,
+      value   => "publishing-api.${app_domain}";
+  }
+}

--- a/modules/govuk/manifests/apps/calculators.pp
+++ b/modules/govuk/manifests/apps/calculators.pp
@@ -47,4 +47,12 @@ class govuk::apps::calculators(
         varname => 'SECRET_KEY_BASE',
         value   => $secret_key_base;
   }
+
+  $app_domain = hiera('app_domain')
+
+  if ($::aws_environment == 'staging') or ($::aws_environment == 'production') {
+    govuk::app::envvar::plek_uri_overrides { 'calculators':
+      app_domain => $app_domain,
+    }
+  }
 }

--- a/modules/govuk/manifests/apps/frontend.pp
+++ b/modules/govuk/manifests/apps/frontend.pp
@@ -83,6 +83,14 @@ class govuk::apps::frontend(
     port => $redis_port,
   }
 
+  $app_domain = hiera('app_domain')
+
+  if ($::aws_environment == 'staging') or ($::aws_environment == 'production') {
+    govuk::app::envvar::plek_uri_overrides { 'frontend':
+      app_domain => $app_domain,
+    }
+  }
+
   Govuk::App::Envvar {
     app => 'frontend',
   }

--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -438,6 +438,20 @@ class govuk::apps::whitehall(
       value   => $rummager_bearer_token;
   }
 
+  if ($::aws_environment == 'staging') or ($::aws_environment == 'production') {
+    govuk::app::envvar {
+      "${title}-PLEK_SERVICE_SEARCH_URI":
+        varname => PLEK_SERVICE_SEARCH_URI,
+        value   => "search.${app_domain}";
+      "${title}-PLEK_SERVICE_EMAIL_ALERT_API_URI":
+        varname => PLEK_SERVICE_EMAIL_ALERT_API_URI,
+        value   => "email-alert-api.${app_domain}";
+      "${title}-PLEK_SERVICE_PUBLISHING_API_URI":
+        varname => PLEK_SERVICE_PUBLISHING_API_URI,
+        value   => "publishing-api.${app_domain}";
+    }
+  }
+
   if $basic_auth_credentials != undef {
     govuk::app::envvar {
       "${title}-BASIC_AUTH_CREDENTIALS":

--- a/modules/govuk/manifests/node/s_draft_frontend.pp
+++ b/modules/govuk/manifests/node/s_draft_frontend.pp
@@ -12,10 +12,15 @@ class govuk::node::s_draft_frontend() inherits govuk::node::s_base {
 
   $app_domain = hiera('app_domain')
 
-  if $::aws_migration {
-    $app_domain_internal = hiera('app_domain_internal')
+  if ($::aws_environment == 'staging') or ($::aws_environment == 'production') {
+    $app_domain_internal      = hiera('app_domain_internal')
+    $plek_uri_domain_override = $app_domain
+  } elsif $::aws_environment == 'integration' {
+    $app_domain_internal      = hiera('app_domain_internal')
+    $plek_uri_domain_override = $app_domain_internal
   } else {
-    $app_domain_internal = $app_domain
+    $app_domain_internal      = $app_domain
+    $plek_uri_domain_override = $app_domain
   }
 
   govuk_envvar {
@@ -23,9 +28,9 @@ class govuk::node::s_draft_frontend() inherits govuk::node::s_base {
     'PLEK_SERVICE_IMMINENCE_URI': value => "https://imminence.${app_domain}";
     'PLEK_SERVICE_LOCAL_LINKS_MANAGER_URI': value => "https://local-links-manager.${app_domain}";
     'PLEK_SERVICE_MAPIT_URI': value     => "https://mapit.${app_domain_internal}";
-    'PLEK_SERVICE_SEARCH_URI': value    => "https://search.${app_domain_internal}";
+    'PLEK_SERVICE_SEARCH_URI': value    => "https://search.${plek_uri_domain_override}";
     'PLEK_SERVICE_RUMMAGER_URI': value  => "https://rummager.${app_domain_internal}";
-    'PLEK_SERVICE_EMAIL_ALERT_API_URI': value  => "https://email-alert-api.${app_domain_internal}";
+    'PLEK_SERVICE_EMAIL_ALERT_API_URI': value  => "https://email-alert-api.${plek_uri_domain_override}";
     'PLEK_SERVICE_WHITEHALL_ADMIN_URI': value  => "https://whitehall-admin.${app_domain_internal}";
   }
 


### PR DESCRIPTION
The frontends once migrated to aws will still need to contact search,
email-alert-api and publishing-api in carrenza.

Here we are setting the PLEK env var overrides so those carrenza
services can be contacted by those aws frontend apps.

@ronocg <conor.glynn@digital.cabinet-office.gov.uk>
@jstandring-gds <julian.standring@digital.cabinet-office.gov.uk>