### PR TITLE
Increase total process limits

### DIFF
--- a/modules/icinga/templates/etc/nagios/nrpe.cfg.erb
+++ b/modules/icinga/templates/etc/nagios/nrpe.cfg.erb
@@ -211,7 +211,7 @@ command[check_users]=/usr/lib/nagios/plugins/check_users -w 10 -c 20
 # fallback check if individual ones havent been set up.
 command[check_disk]=/usr/lib/nagios/plugins/check_disk -w 6% -c 3% -W 6% -K 3% -x /var/lib/ureadahead/debugfs/tracing
 command[check_zombie_procs]=/usr/lib/nagios/plugins/check_procs -w 5 -c 10 -s Z
-command[check_total_procs]=/usr/lib/nagios/plugins/check_procs -w 1200 -c 1500
+command[check_total_procs]=/usr/lib/nagios/plugins/check_procs -w 1300 -c 1650
 command[check_puppet_agent]=/usr/lib/nagios/plugins/check_puppet_agent
 command[check_rw_rootfs]=/usr/lib/nagios/plugins/check_rw_rootfs
 command[check_ntp_time]=/usr/lib/nagios/plugins/check_ntp_time -4 -q -H ntp.ubuntu.com -w 2 -c 3


### PR DESCRIPTION
We're starting to see this flag up in Icinga because each monitoring process is a single process and as we add more monitoring this is likely to hit the limit.

Unfortunately this meaning increasing the global thresholds, but in reality on most machines the process count isn't anywhere near the levels right now and this alert is only relevant for the monitoring machines.