### PR TITLE
Schedule tag_metadata Rummager rake task twice daily

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/run_metadata_tagger.pp
+++ b/modules/govuk_jenkins/manifests/jobs/run_metadata_tagger.pp
@@ -1,0 +1,11 @@
+# == Class: govuk_jenkins::jobs::run_metadata_tagger
+#
+# Create a file on disk that can be parsed by jenkins-job-builder
+#
+class govuk_jenkins::jobs::run_metadata_tagger {
+  file { '/etc/jenkins_jobs/jobs/run_metadata_tagger.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/run_metadata_tagger.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+}

--- a/modules/govuk_jenkins/templates/jobs/run_metadata_tagger.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/run_metadata_tagger.yaml.erb
@@ -1,7 +1,7 @@
 ---
 - job:
-    name: Run_Metadata_Tagger
-    display-name: Run_Metadata_Tagger
+    name: Run_Rummager_Metadata_Tagger
+    display-name: Run_Rummager_Metadata_Tagger
     project-type: freestyle
     description: "This job SSHs onto a search backend and runs the rake task 'govuk_setenv rummager bundle exec rake tag_metadata'"
     properties:

--- a/modules/govuk_jenkins/templates/jobs/run_metadata_tagger.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/run_metadata_tagger.yaml.erb
@@ -1,0 +1,24 @@
+---
+- job:
+    name: Run_Metadata_Tagger
+    display-name: Run_Metadata_Tagger
+    project-type: freestyle
+    description: "This job SSHs onto a search backend and runs the rake task 'govuk_setenv rummager bundle exec rake tag_metadata'"
+    properties:
+      - build-discarder:
+          days-to-keep: 7
+          artifact-num-to-keep: 5
+    builders:
+      - trigger-builds:
+          - project: run-rake-task
+            block: true
+            predefined-parameters: |
+              TARGET_APPLICATION=rummager
+              MACHINE_CLASS=search
+              RAKE_TASK=tag_metadata
+    triggers:
+        - timed: '30 12,16 * * 1-5'
+    wrappers:
+        - ansicolor:
+            colormap: xterm
+        - timestamps


### PR DESCRIPTION
https://trello.com/c/spSQHcZ9/34-bug-some-items-of-content-are-disappearing-from-finder

There's a bug in how updates to the mainstream index write metadata
via the [`GovukIndex::PublishingEventWorker` class in Rummager](https://github.com/alphagov/rummager/blob/master/lib/govuk_index/publishing_event_worker.rb) which surfaces when Mainstream Publisher content updates are made to content present in the 'Find EU Exit guidance for your business' finder.
This PR adds a job to schedule running the retagging rake task which successfully re-applies the relevant metadata, this is scheduled in line with 2ndline timing for applying updates for convenience.