### PR TITLE
Trello-1970: rummager nginx config

### DIFF
--- a/modules/govuk/manifests/node/s_backend_lb.pp
+++ b/modules/govuk/manifests/node/s_backend_lb.pp
@@ -110,6 +110,11 @@ class govuk::node::s_backend_lb (
       servers            => $publishing_api_backend_servers,
   }
 
+  loadbalancer::balance { 'rummager':
+      aws_egress_nat_ips => $aws_egress_nat_ips,
+      servers            => $search_servers,
+  }
+
   loadbalancer::balance { 'search':
       aws_egress_nat_ips => $aws_egress_nat_ips,
       servers            => $search_servers,


### PR DESCRIPTION
This will enable the aws frontends to access search via the name
rummager.  By  allowing the nginx load balancer that runs on the
backend-lbs in carrenza to accept connections from our AWS nat
gateways, this is required for migrating the frontends to AWS.

@ronocg <conor.glynn@digital.cabinet-office.gov.uk>