### PR TITLE
Trello-1963/1970: Plek envars for aws frontends

### DIFF
--- a/modules/govuk/manifests/node/s_calculators_frontend.pp
+++ b/modules/govuk/manifests/node/s_calculators_frontend.pp
@@ -33,4 +33,15 @@ class govuk::node::s_calculators_frontend inherits govuk::node::s_base {
   if $::aws_environment == 'staging' {
     include govuk_splunk
   }
+
+  if ($::aws_environment == 'staging') or ($::aws_environment == 'production') {
+    $app_domain = hiera('app_domain')
+
+    govuk_envvar {
+      'PLEK_SERVICE_SEARCH_URI': value    => "https://search.${app_domain}";
+      'PLEK_SERVICE_RUMMAGER_URI': value  => "https://rummager.${app_domain}";
+      'PLEK_SERVICE_EMAIL_ALERT_API_URI': value  => "https://email-alert-api.${app_domain}";
+      'PLEK_SERVICE_PUBLISHING_API_URI': value  => "https://publishing-api.${app_domain}";
+    }
+  }
 }

--- a/modules/govuk/manifests/node/s_draft_frontend.pp
+++ b/modules/govuk/manifests/node/s_draft_frontend.pp
@@ -12,10 +12,15 @@ class govuk::node::s_draft_frontend() inherits govuk::node::s_base {
 
   $app_domain = hiera('app_domain')
 
-  if $::aws_migration {
-    $app_domain_internal = hiera('app_domain_internal')
+  if ($::aws_environment == 'staging') or ($::aws_environment == 'production') {
+    $app_domain_internal      = hiera('app_domain_internal')
+    $plek_uri_domain_override = $app_domain
+  } elsif $::aws_environment == 'integration' {
+    $app_domain_internal      = hiera('app_domain_internal')
+    $plek_uri_domain_override = $app_domain_internal
   } else {
-    $app_domain_internal = $app_domain
+    $app_domain_internal      = $app_domain
+    $plek_uri_domain_override = $app_domain
   }
 
   govuk_envvar {
@@ -23,9 +28,9 @@ class govuk::node::s_draft_frontend() inherits govuk::node::s_base {
     'PLEK_SERVICE_IMMINENCE_URI': value => "https://imminence.${app_domain}";
     'PLEK_SERVICE_LOCAL_LINKS_MANAGER_URI': value => "https://local-links-manager.${app_domain}";
     'PLEK_SERVICE_MAPIT_URI': value     => "https://mapit.${app_domain_internal}";
-    'PLEK_SERVICE_SEARCH_URI': value    => "https://search.${app_domain_internal}";
-    'PLEK_SERVICE_RUMMAGER_URI': value  => "https://rummager.${app_domain_internal}";
-    'PLEK_SERVICE_EMAIL_ALERT_API_URI': value  => "https://email-alert-api.${app_domain_internal}";
+    'PLEK_SERVICE_SEARCH_URI': value    => "https://search.${plek_uri_domain_override}";
+    'PLEK_SERVICE_RUMMAGER_URI': value  => "https://rummager.${plek_uri_domain_override}";
+    'PLEK_SERVICE_EMAIL_ALERT_API_URI': value  => "https://email-alert-api.${plek_uri_domain_override}";
     'PLEK_SERVICE_WHITEHALL_ADMIN_URI': value  => "https://whitehall-admin.${app_domain_internal}";
   }
 

--- a/modules/govuk/manifests/node/s_frontend.pp
+++ b/modules/govuk/manifests/node/s_frontend.pp
@@ -28,4 +28,15 @@ class govuk::node::s_frontend inherits govuk::node::s_base {
     max_memory => '12%',
     listen_ip  => '0.0.0.0',
   }
+
+  if ($::aws_environment == 'staging') or ($::aws_environment == 'production') {
+    $app_domain = hiera('app_domain')
+
+    govuk_envvar {
+      'PLEK_SERVICE_SEARCH_URI': value    => "https://search.${app_domain}";
+      'PLEK_SERVICE_RUMMAGER_URI': value  => "https://rummager.${app_domain}";
+      'PLEK_SERVICE_EMAIL_ALERT_API_URI': value  => "https://email-alert-api.${app_domain}";
+      'PLEK_SERVICE_PUBLISHING_API_URI': value  => "https://publishing-api.${app_domain}";
+    }
+  }
 }

--- a/modules/govuk/manifests/node/s_whitehall_frontend.pp
+++ b/modules/govuk/manifests/node/s_whitehall_frontend.pp
@@ -20,4 +20,14 @@ class govuk::node::s_whitehall_frontend inherits govuk::node::s_base {
     max_memory => '12%',
     listen_ip  => '0.0.0.0',
   }
+
+  if ($::aws_environment == 'staging') or ($::aws_environment == 'production') {
+
+    govuk_envvar {
+      'PLEK_SERVICE_SEARCH_URI': value    => "https://search.${app_domain}";
+      'PLEK_SERVICE_RUMMAGER_URI': value  => "https://rummager.${app_domain}";
+      'PLEK_SERVICE_EMAIL_ALERT_API_URI': value  => "https://email-alert-api.${app_domain}";
+      'PLEK_SERVICE_PUBLISHING_API_URI': value  => "https://publishing-api.${app_domain}";
+    }
+  }
 }


### PR DESCRIPTION
The frontends once migrated to aws will still need to contact search,
email-alert-api, rummager and publishing-api in carrenza.

Here we are setting the PLEK env var overrides so those carrenza
services can be contacted by those aws frontend apps.

@ronocg conor.glynn@digital.cabinet-office.gov.uk