### PR TITLE
Enable run_metadata_tagger jenkins job

### DIFF
--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -44,6 +44,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::record_superfluous_taggings_metrics
   - govuk_jenkins::jobs::remove_emergency_banner
   - govuk_jenkins::jobs::run_rake_task
+  - govuk_jenkins::jobs::run_metadata_tagger
   - govuk_jenkins::jobs::run_whitehall_data_migrations
   - govuk_jenkins::jobs::scrape_icinga_alerts_for_dashboard_metrics
   - govuk_jenkins::jobs::search_benchmark

--- a/hieradata/class/staging/jenkins.yaml
+++ b/hieradata/class/staging/jenkins.yaml
@@ -28,6 +28,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::record_taxonomy_metrics
   - govuk_jenkins::jobs::remove_emergency_banner
   - govuk_jenkins::jobs::run_rake_task
+  - govuk_jenkins::jobs::run_metadata_tagger
   - govuk_jenkins::jobs::run_whitehall_data_migrations
   - govuk_jenkins::jobs::scrape_icinga_alerts_for_dashboard_metrics
   - govuk_jenkins::jobs::search_fetch_analytics_data

--- a/hieradata/vagrant.yaml
+++ b/hieradata/vagrant.yaml
@@ -111,6 +111,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::launch_vms
   - govuk_jenkins::jobs::network_config_deploy
   - govuk_jenkins::jobs::passive_checks
+  - govuk_jenkins::jobs::run_metadata_tagger
   - govuk_jenkins::jobs::run_whitehall_data_migrations
   - govuk_jenkins::jobs::smokey
   - govuk_jenkins::jobs::smokey_deploy

--- a/hieradata_aws/class/integration/jenkins.yaml
+++ b/hieradata_aws/class/integration/jenkins.yaml
@@ -30,6 +30,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::remove_emergency_banner
   - govuk_jenkins::jobs::run_deploy_lag_badger
   - govuk_jenkins::jobs::run_rake_task
+  - govuk_jenkins::jobs::run_metadata_tagger
   - govuk_jenkins::jobs::run_whitehall_data_migrations
   - govuk_jenkins::jobs::scrape_icinga_alerts_for_dashboard_metrics
   - govuk_jenkins::jobs::search_benchmark


### PR DESCRIPTION
https://trello.com/c/spSQHcZ9/34-bug-some-items-of-content-are-disappearing-from-finder


Enables the Rummager rake task `tag_metadata` on a scheduled basis.
See: https://github.com/alphagov/govuk-puppet/pull/8623
