### PR TITLE
Add “Publish special routes” job to Jenkins

### DIFF
--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -39,6 +39,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::passive_checks
   - govuk_jenkins::jobs::performance_platform_data_sync
   - govuk_jenkins::jobs::publication_delay_report
+  - govuk_jenkins::jobs::publish_special_routes
   - govuk_jenkins::jobs::publishing_api_archive_events
   - govuk_jenkins::jobs::record_taxonomy_metrics
   - govuk_jenkins::jobs::record_superfluous_taggings_metrics

--- a/hieradata/class/staging/jenkins.yaml
+++ b/hieradata/class/staging/jenkins.yaml
@@ -24,6 +24,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::network_config_deploy
   - govuk_jenkins::jobs::passive_checks
   - govuk_jenkins::jobs::publication_delay_report
+  - govuk_jenkins::jobs::publish_special_routes
   - govuk_jenkins::jobs::record_superfluous_taggings_metrics
   - govuk_jenkins::jobs::record_taxonomy_metrics
   - govuk_jenkins::jobs::remove_emergency_banner

--- a/hieradata/vagrant.yaml
+++ b/hieradata/vagrant.yaml
@@ -111,6 +111,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::launch_vms
   - govuk_jenkins::jobs::network_config_deploy
   - govuk_jenkins::jobs::passive_checks
+  - govuk_jenkins::jobs::publish_special_routes
   - govuk_jenkins::jobs::run_metadata_tagger
   - govuk_jenkins::jobs::run_whitehall_data_migrations
   - govuk_jenkins::jobs::smokey

--- a/hieradata_aws/class/integration/jenkins.yaml
+++ b/hieradata_aws/class/integration/jenkins.yaml
@@ -26,6 +26,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::monitor_taxonomy_health
   - govuk_jenkins::jobs::passive_checks
   - govuk_jenkins::jobs::publication_delay_report
+  - govuk_jenkins::jobs::publish_special_routes
   - govuk_jenkins::jobs::record_taxonomy_metrics
   - govuk_jenkins::jobs::remove_emergency_banner
   - govuk_jenkins::jobs::run_deploy_lag_badger

--- a/hieradata_aws/class/production/jenkins.yaml
+++ b/hieradata_aws/class/production/jenkins.yaml
@@ -10,6 +10,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::deploy_app
   - govuk_jenkins::jobs::deploy_puppet
   - govuk_jenkins::jobs::passive_checks
+  - govuk_jenkins::jobs::publish_special_routes
   - govuk_jenkins::jobs::run_rake_task
   - govuk_jenkins::jobs::smokey
   - govuk_jenkins::jobs::smokey_deploy

--- a/hieradata_aws/class/staging/jenkins.yaml
+++ b/hieradata_aws/class/staging/jenkins.yaml
@@ -11,6 +11,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::deploy_puppet
   - govuk_jenkins::jobs::mongo_data_sync
   - govuk_jenkins::jobs::passive_checks
+  - govuk_jenkins::jobs::publish_special_routes
   - govuk_jenkins::jobs::run_rake_task
   - govuk_jenkins::jobs::smokey
   - govuk_jenkins::jobs::smokey_deploy


### PR DESCRIPTION
This commit adds the new “Publish special routes” job to Jenkins in all environments.