### PR TITLE
Trello-1963: Envars for the frontend

### DIFF
--- a/modules/govuk/manifests/node/s_frontend.pp
+++ b/modules/govuk/manifests/node/s_frontend.pp
@@ -29,7 +29,7 @@ class govuk::node::s_frontend inherits govuk::node::s_base {
     listen_ip  => '0.0.0.0',
   }
 
-  if ($::aws_environment == 'staging') or ($::aws_environment == 'production') {
+  if ( ( $::aws_migration == 'frontend' ) and ($::aws_environment == 'staging') ) or ( ($::aws_migration == 'frontend' ) and ($::aws_environment == 'production') ) {
     $app_domain = hiera('app_domain')
 
     govuk_envvar {


### PR DESCRIPTION
The PLEK envvars for the draft_frontend are laid down in
modules/govuk/manifests/node/s_draft_frontend.pp  but because that class
includes the s_frontend class there would be duplication of the envvars
in puppet. Here we need to make the if conditional explicit to just
manage the vars if the node is a frontend node in aws staging or
production.

@ronocg <conor.glynn@digital.cabinet-office.gov.uk>