### PR TITLE
Add GOVUK_APP_DOMAIN env var for publish special routes

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/publish_special_routes.pp
+++ b/modules/govuk_jenkins/manifests/jobs/publish_special_routes.pp
@@ -5,6 +5,12 @@
 class govuk_jenkins::jobs::publish_special_routes(
   $publishing_api_bearer_token = undef,
 ) {
+  if $::aws_migration {
+    $app_domain = hiera('app_domain_internal')
+  } else {
+    $app_domain = hiera('app_domain')
+  }
+
   file { '/etc/jenkins_jobs/jobs/publish_special_routes.yaml':
     ensure  => present,
     content => template('govuk_jenkins/jobs/publish_special_routes.yaml.erb'),

--- a/modules/govuk_jenkins/templates/jobs/publish_special_routes.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/publish_special_routes.yaml.erb
@@ -25,6 +25,7 @@
       - special-route-publisher_Publish_Special_Routes
     builders:
         - shell: |
+            export GOVUK_APP_DOMAIN=<%= @app_domain %>
             export PUBLISHING_API_BEARER_TOKEN=<%= @publishing_api_bearer_token %>
             bundle install --path "${HOME}/bundles/${JOB_NAME}"
             bundle exec rake publish_special_routes


### PR DESCRIPTION
This commit adds the `GOVUK_APP_DOMAIN` environment variable for the “Publish special routes” Jenkins job, so Plek can find the Publishing API correctly.