### PR TITLE
Force urllib3 to ver 1.7.1 on rabbimq machines

### DIFF
--- a/modules/govuk_rabbitmq/manifests/init.pp
+++ b/modules/govuk_rabbitmq/manifests/init.pp
@@ -16,6 +16,9 @@ class govuk_rabbitmq (
 
   if ! $::aws_migration {
     include govuk_rabbitmq::repo
+  }
+
+  if $::aws_migration {
     package { 'urllib3':
       ensure   => '1.7.1',
       provider => pip,


### PR DESCRIPTION
  The version of urllib3 installed on the rabbitmq machines break
the nrpe plugins that checks the rabbitmq queues and messages.
Downgrading to 1.7.1 fixes it.
We want that fix on AWS AND NOT on carrenza.