### PR TITLE
add custom nginx for content-store

### DIFF
--- a/hieradata_aws/class/production/content_store.yaml
+++ b/hieradata_aws/class/production/content_store.yaml
@@ -1,5 +1,7 @@
 ---
 
+govuk::apps::content_store::create_default_nginx_config: true
+
 icinga::client::check_pings::endpoints:
    router-api:
      ip: 10.3.1.253

--- a/modules/govuk/manifests/node/s_content_store.pp
+++ b/modules/govuk/manifests/node/s_content_store.pp
@@ -8,7 +8,7 @@ class govuk::node::s_content_store inherits govuk::node::s_base {
 
   # In Staging environment, the content-store app will create its own default
   # vhost
-  if ($::aws_environment != 'staging') {
+  if ($::aws_environment != 'staging' and $::aws_environment != 'production') {
     # If we miss all the apps, throw a 500 to be caught by the cache nginx
     nginx::config::vhost::default { 'default': }
   }
@@ -19,4 +19,3 @@ class govuk::node::s_content_store inherits govuk::node::s_base {
     include icinga::client::check_pings
   }
 }
-


### PR DESCRIPTION
# Context

For the content-store in AWS Production, add the ability to appropriate healthcheck by overriding the default nginx config.

See PR for further details: https://github.com/alphagov/govuk-puppet/pull/8603

# Decisions
1. add hiera for app to create default nginx config and modify logic of content-store class