### PR TITLE
Remove publicapi from cache machines

### DIFF
--- a/development-vm/Procfile
+++ b/development-vm/Procfile
@@ -33,7 +33,7 @@ whitehall-worker:      govuk_setenv whitehall             ./run_in.sh ../../whit
 feedback:              govuk_setenv feedback              ./run_in.sh ../../feedback       bundle exec rails server -p 3028
 # errbit used 3029
 support:               govuk_setenv support               ./run_in.sh ../../support        bundle exec rails server -p 3031
-# publicapi uses port 3032
+# publicapi used port 3032
 # contracts-finder used port 3033
 # url-arbiter used port 3034
 travel-advice-publisher: govuk_setenv travel-advice-publisher ./run_in.sh ../../travel-advice-publisher bundle exec rails server -p 3035

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1660,7 +1660,6 @@ hosts::production::router::hosts:
     ip: '10.1.1.252'
     legacy_aliases:
       - "draft-router-api.%{hiera('app_domain')}"
-      - "draft-publicapi.%{hiera('app_domain')}"
 
 icinga::config::http_username: "%{hiera('http_username')}"
 icinga::config::http_password: "%{hiera('http_password')}"

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -134,7 +134,6 @@ govuk::apps::manuals_publisher::mongodb_nodes: ['localhost']
 govuk::apps::manuals_publisher::mongodb_name: 'manuals_publisher_development'
 govuk::apps::maslow::mongodb_nodes: ['localhost']
 govuk::apps::maslow::mongodb_name: 'maslow_development'
-govuk::apps::publicapi::privateapi_ssl: false
 govuk::apps::publisher::enable_procfile_worker: false
 govuk::apps::publishing_api::content_store: 'http://content-store.dev.gov.uk'
 govuk::apps::publishing_api::draft_content_store: 'http://draft-content-store.dev.gov.uk'

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -590,7 +590,6 @@ hosts::production::router::hosts:
     ip: '10.3.1.252'
     legacy_aliases:
       - "draft-router-api.%{hiera('app_domain')}"
-      - "draft-publicapi.%{hiera('app_domain')}"
 
 licensify::apps::licensify_admin::environment: 'production'
 licensify::apps::licensify::environment: 'production'

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -545,7 +545,6 @@ hosts::production::router::hosts:
     ip: '10.2.1.252'
     legacy_aliases:
       - "draft-router-api.%{hiera('app_domain')}"
-      - "draft-publicapi.%{hiera('app_domain')}"
 
 licensify::apps::licensify_admin::environment: 'staging'
 licensify::apps::licensify::environment: 'staging'

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -313,7 +313,6 @@ hosts::backend_migration::hosts:
       - info-frontend.publishing.service.gov.uk
       - manuals-frontend.publishing.service.gov.uk
       - licencefinder.publishing.service.gov.uk
-      - publicapi.publishing.service.gov.uk
       - service-manual.publishing.service.gov.uk
       - service-manual-frontend.publishing.service.gov.uk
       - smartanswers.publishing.service.gov.uk
@@ -505,7 +504,6 @@ hosts::backend_migration::hosts:
       - draft-cache-internal-lb.router
       - draft-cache-internal-lb
       - draft-router-api.publishing.service.gov.uk
-      - draft-publicapi.publishing.service.gov.uk
   mirrorer-1.management.publishing.service.gov.uk:
     ip: 10.3.0.128
     host_aliases:

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -308,7 +308,6 @@ hosts::backend_migration::hosts:
       - info-frontend.staging.publishing.service.gov.uk
       - manuals-frontend.staging.publishing.service.gov.uk
       - licencefinder.staging.publishing.service.gov.uk
-      - publicapi.staging.publishing.service.gov.uk
       - service-manual.staging.publishing.service.gov.uk
       - service-manual-frontend.staging.publishing.service.gov.uk
       - smartanswers.staging.publishing.service.gov.uk
@@ -523,7 +522,6 @@ hosts::backend_migration::hosts:
       - draft-cache-internal-lb.router
       - draft-cache-internal-lb
       - draft-router-api.staging.publishing.service.gov.uk
-      - draft-publicapi.staging.publishing.service.gov.uk
   mirrorer-1.management.staging.publishing.service.gov.uk:
     ip: 10.2.0.128
     host_aliases:

--- a/modules/govuk/manifests/app/publicapi.pp
+++ b/modules/govuk/manifests/app/publicapi.pp
@@ -49,6 +49,7 @@ define govuk::app::publicapi (
 
   if ($::aws_environment == 'staging') or ($::aws_environment == 'production') {
     nginx::config::vhost::proxy { $full_domain:
+      ensure           => absent,
       to               => [$whitehallapi, $content_store_api],
       to_ssl           => $privateapi_ssl,
       protected        => false,
@@ -62,6 +63,7 @@ define govuk::app::publicapi (
     }
   } else {
     nginx::config::vhost::proxy { $full_domain:
+      ensure           => absent,
       to               => [$whitehallapi, $rummager_api, $content_store_api],
       to_ssl           => $privateapi_ssl,
       protected        => false,


### PR DESCRIPTION
This commit removes publicapi from the cache machines. The routes previously routed by publicapi are now routed by the router.

Trello: https://trello.com/c/C2DS0GbF/46-some-routing-info-is-in-nginx-config