### PR TITLE
Add a default SRID to CKAN config

### DIFF
--- a/modules/govuk/templates/ckan/ckan.ini.erb
+++ b/modules/govuk/templates/ckan/ckan.ini.erb
@@ -115,6 +115,7 @@ ckan.redis.url = redis://<%= @redis_host%>:<%= @redis_port%>/1
 
 ckan.spatial.validator.profiles = iso19139eden,constraints-1.4,gemini2-1.3
 ckan.spatial.validator.reject = true
+ckan.spatial.srid = 4258
 
 # Define which views should be created by default
 # (plugins must be loaded in ckan.plugins)


### PR DESCRIPTION
The CKAN database contains a constraint which requires all SRIDs
in geometry columns to be set to 4258.  This constraint was copied over
with the DB dump from CKAN in Bytemark, where it was presumably set manually.

Without this setting, the CKAN spatial extension will default new geometric
packages (INSPIRE/GEMINI) to SRID 4326, which will then conflict with the
constraint requiring SRID 4258.

This setting overrides the default and will allow spatial packages to be
harvested.

https://trello.com/c/qOelMdaw/743-pull-in-the-expected-data-when-we-harvest-geospatial-data-strongly-recommend-pairing