### PR TITLE
Shift additional sudoers entries for govuk_env_sync

### DIFF
--- a/hieradata_aws/class/db_admin.yaml
+++ b/hieradata_aws/class/db_admin.yaml
@@ -4,3 +4,7 @@ postgresql::globals::version: '9.6'
 govuk_sudo::sudo_conf:
   govuk-backup:
     content: 'govuk-backup ALL=NOPASSWD:/usr/bin/psql,/usr/bin/dropdb,/usr/bin/dropuser,/usr/bin/pg_restore,/usr/bin/mysql,/usr/bin/pg_dump'
+  env-sync-script:
+    content: 'Cmnd_Alias BACKUP=/usr/local/bin/govuk_env_sync.sh'
+  deploy-user-env-sync:
+    content: 'deploy ALL=(govuk-backup) NOPASSWD:BACKUP'

--- a/hieradata_aws/class/email_alert_api_db_admin.yaml
+++ b/hieradata_aws/class/email_alert_api_db_admin.yaml
@@ -4,3 +4,7 @@ postgresql::globals::version: '9.6'
 govuk_sudo::sudo_conf:
   govuk-backup:
     content: 'govuk-backup ALL=NOPASSWD:/usr/bin/psql,/usr/bin/dropdb,/usr/bin/dropuser,/usr/bin/pg_restore,/usr/bin/pg_dump'
+  env-sync-script:
+    content: 'Cmnd_Alias BACKUP=/usr/local/bin/govuk_env_sync.sh'
+  deploy-user-env-sync:
+    content: 'deploy ALL=(govuk-backup) NOPASSWD:BACKUP'

--- a/hieradata_aws/class/mongo.yaml
+++ b/hieradata_aws/class/mongo.yaml
@@ -1,4 +1,9 @@
 ---
+govuk_sudo::sudo_conf:
+  env-sync-script:
+    content: 'Cmnd_Alias BACKUP=/usr/local/bin/govuk_env_sync.sh'
+  deploy-user-env-sync:
+    content: 'deploy ALL=(govuk-backup) NOPASSWD:BACKUP'
 
 govuk_safe_to_reboot::can_reboot: 'overnight'
 govuk_safe_to_reboot::reason: 'Secondaries will reboot overnight if cluster is healthy'

--- a/hieradata_aws/class/mongo_api.yaml
+++ b/hieradata_aws/class/mongo_api.yaml
@@ -1,4 +1,9 @@
 ---
+govuk_sudo::sudo_conf:
+  env-sync-script:
+    content: 'Cmnd_Alias BACKUP=/usr/local/bin/govuk_env_sync.sh'
+  deploy-user-env-sync:
+    content: 'deploy ALL=(govuk-backup) NOPASSWD:BACKUP'
 
 govuk_safe_to_reboot::can_reboot: 'overnight'
 govuk_safe_to_reboot::reason: 'Secondaries will reboot overnight if cluster is healthy'

--- a/hieradata_aws/class/publishing_api_db_admin.yaml
+++ b/hieradata_aws/class/publishing_api_db_admin.yaml
@@ -5,3 +5,7 @@ postgresql::server::role::rds: true
 govuk_sudo::sudo_conf:
   govuk-backup:
     content: 'govuk-backup ALL=NOPASSWD:/usr/bin/psql,/usr/bin/dropdb,/usr/bin/dropuser,/usr/bin/pg_restore,/usr/bin/pg_dump'
+  env-sync-script:
+    content: 'Cmnd_Alias BACKUP=/usr/local/bin/govuk_env_sync.sh'
+  deploy-user-env-sync:
+    content: 'deploy ALL=(govuk-backup) NOPASSWD:BACKUP'

--- a/hieradata_aws/class/router_backend.yaml
+++ b/hieradata_aws/class/router_backend.yaml
@@ -1,4 +1,9 @@
 ---
+govuk_sudo::sudo_conf:
+  env-sync-script:
+    content: 'Cmnd_Alias BACKUP=/usr/local/bin/govuk_env_sync.sh'
+  deploy-user-env-sync:
+    content: 'deploy ALL=(govuk-backup) NOPASSWD:BACKUP'
 
 govuk::apps::router_api::mongodb_name: 'router'
 govuk::apps::router_api::mongodb_nodes:

--- a/hieradata_aws/class/transition_db_admin.yaml
+++ b/hieradata_aws/class/transition_db_admin.yaml
@@ -4,3 +4,7 @@ postgresql::globals::version: '9.6'
 govuk_sudo::sudo_conf:
   govuk-backup:
     content: 'govuk-backup ALL=NOPASSWD:/usr/bin/psql,/usr/bin/dropdb,/usr/bin/dropuser,/usr/bin/pg_restore,/usr/bin/pg_dump'
+  env-sync-script:
+    content: 'Cmnd_Alias BACKUP=/usr/local/bin/govuk_env_sync.sh'
+  deploy-user-env-sync:
+    content: 'deploy ALL=(govuk-backup) NOPASSWD:BACKUP'

--- a/hieradata_aws/class/warehouse_db_admin.yaml
+++ b/hieradata_aws/class/warehouse_db_admin.yaml
@@ -5,3 +5,7 @@ postgresql::server::role::rds: true
 govuk_sudo::sudo_conf:
   govuk-backup:
     content: 'govuk-backup ALL=NOPASSWD:/usr/bin/psql,/usr/bin/dropdb,/usr/bin/dropuser,/usr/bin/pg_restore,/usr/bin/pg_dump'
+  env-sync-script:
+    content: 'Cmnd_Alias BACKUP=/usr/local/bin/govuk_env_sync.sh'
+  deploy-user-env-sync:
+    content: 'deploy ALL=(govuk-backup) NOPASSWD:BACKUP'

--- a/modules/govuk_env_sync/manifests/init.pp
+++ b/modules/govuk_env_sync/manifests/init.pp
@@ -10,15 +10,5 @@ class govuk_env_sync(
 
   include govuk_env_sync::lock_file
 
-  file_line { 'sudo_rule_command':
-    path => '/etc/sudoers',
-    line => 'Cmnd_Alias BACKUP=/usr/local/bin/govuk_env_sync.sh',
-  }
-
-  file_line { 'sudo_rule_govuk_backup':
-    path => '/etc/sudoers',
-    line => 'deploy ALL=(govuk-backup) NOPASSWD:BACKUP',
-  }
-
   create_resources(govuk_env_sync::task, $tasks)
 }


### PR DESCRIPTION
- We require additional sudoers configuration to allow the
govuk_env_sync script to be executed by the deploy user/via Jenkins.

- The intially added configuration did start a tug-of-war with the sudo
module.

- This moves the problematic config from the govuk_env_sync and moves it
into govuk_sudo hieradata.

solo: @schmie