### PR TITLE
need a hard kill for nginx in second try

### DIFF
--- a/modules/nginx/manifests/restart.pp
+++ b/modules/nginx/manifests/restart.pp
@@ -1,7 +1,7 @@
 # FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
 class nginx::restart {
 
-  exec { '/etc/init.d/nginx configtest && (/etc/init.d/nginx restart || { nginx -s quit; /etc/init.d/nginx start;})':
+  exec { '/etc/init.d/nginx configtest && (/etc/init.d/nginx restart || { killall nginx; /etc/init.d/nginx start;})':
     refreshonly => true,
   }
 

--- a/modules/nginx/manifests/service.pp
+++ b/modules/nginx/manifests/service.pp
@@ -3,7 +3,7 @@ class nginx::service {
 
   service { 'nginx':
     ensure    => running,
-    start     => '/etc/init.d/nginx start || { nginx -s quit; /etc/init.d/nginx start;}',
+    start     => '/etc/init.d/nginx start || { killall nginx; /etc/init.d/nginx start;}',
     hasstatus => true,
     restart   => '/etc/init.d/nginx configtest && /etc/init.d/nginx reload',
   }


### PR DESCRIPTION
# Context

Need a hard kill for nginx if start or restart command does not work, see ticket for further details:
https://trac.nginx.org/nginx/ticket/753

# Decisions
1. use `killall nginx` rather than graceful kill in 2nd attempt