### PR TITLE
Add special-route-publisher CI job

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -873,6 +873,7 @@ govuk_ci::master::pipeline_jobs:
   shared_mustache: {}
   slimmer: {}
   smokey: {}
+  special-route-publisher: {}
   transition-config: {}
   ubuntu_unused_kernels:
     repo_owner: 'gds-operations'


### PR DESCRIPTION
This will create a CI job for https://github.com/alphagov/special-route-publisher, so we can run the tests.