### PR TITLE
Trello-1999: whitehall-frontends nginx config

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -109,6 +109,7 @@ task :check_consistency_between_aws_and_carrenza do
     govuk::node::s_backend_lb::perfplat_public_app_domain
     govuk::node::s_backend_lb::publishing_api_backend_servers
     govuk::node::s_backend_lb::whitehall_backend_servers
+    govuk::node::s_backend_lb::whitehall_frontend_servers
     govuk::node::s_frontend_lb::calculators_frontend_servers
     govuk::node::s_frontend_lb::draft_frontend_servers
     govuk::node::s_frontend_lb::frontend_servers

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -179,6 +179,10 @@ govuk::node::s_backend_lb::whitehall_backend_servers:
   - 'whitehall-backend-2.backend'
   - 'whitehall-backend-3.backend'
   - 'whitehall-backend-4.backend'
+govuk::node::s_backend_lb::whitehall_frontend_servers:
+  - 'whitehall-frontend-1.frontend'
+  - 'whitehall-frontend-2.frontend'
+  - 'whitehall-frontend-3.frontend'
 govuk::node::s_backend_lb::perfplat_public_app_domain: 'performance.service.gov.uk'
 
 govuk::node::s_backup::offsite_backups: true

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -156,6 +156,10 @@ govuk::node::s_backend_lb::whitehall_backend_servers:
   - 'whitehall-backend-2.backend'
   - 'whitehall-backend-3.backend'
   - 'whitehall-backend-4.backend'
+govuk::node::s_backend_lb::whitehall_frontend_servers:
+  - 'whitehall-frontend-1.frontend'
+  - 'whitehall-frontend-2.frontend'
+  - 'whitehall-frontend-3.frontend'
 govuk::node::s_backend_lb::perfplat_public_app_domain: 'staging.performance.service.gov.uk'
 govuk::node::s_cache::real_ip_header: 'True-Client-Ip'
 govuk::node::s_frontend_lb::calculators_frontend_servers:

--- a/hieradata/vagrant.yaml
+++ b/hieradata/vagrant.yaml
@@ -78,6 +78,9 @@ govuk::node::s_backend_lb::email_alert_api_backend_servers:
 govuk::node::s_backend_lb::whitehall_backend_servers:
   - 'whitehall-backend-1.backend'
   - 'whitehall-backend-2.backend'
+govuk::node::s_backend_lb::whitehall_frontend_servers:
+  - 'whitehall-frontend-1.frontend'
+  - 'whitehall-frontend-2.frontend'
 govuk::node::s_backend_lb::publishing_api_backend_servers:
   - 'publishing-api-1.backend'
   - 'publishing-api-2.backend'

--- a/modules/govuk/manifests/node/s_backend_lb.pp
+++ b/modules/govuk/manifests/node/s_backend_lb.pp
@@ -37,6 +37,7 @@ class govuk::node::s_backend_lb (
   $whitehall_backend_servers,
   $email_alert_api_backend_servers,
   $publishing_api_backend_servers,
+  $whitehall_frontend_servers,
   $aws_egress_nat_ips,
   $search_servers = [],
   $ckan_backend_servers = [],
@@ -130,6 +131,14 @@ class govuk::node::s_backend_lb (
     ]:
       deny_crawlers => true,
       servers       => $ckan_backend_servers,
+  }
+
+  loadbalancer::balance { [
+      'whitehall-frontend',
+      'draft-whitehall-frontend',
+    ]:
+      aws_egress_nat_ips => $aws_egress_nat_ips,
+      servers            => $whitehall_frontend_servers,
   }
 
   nginx::config::vhost::redirect { "backdrop-admin.${app_domain}" :


### PR DESCRIPTION
This will enable the aws router-app to access the whitehall-frontend and
draft-whitehall-frontend in carrenza. As the whitehall-frontends are not
migrating with the rest of the frontends to AWS.
This is achieved by allowing the nginx load balancer that runs on the
backend-lbs in carrenza to accept connections from our AWS nat
gateways, this is required for migrating the router app to AWS.

@ronocg <conor.glynn@digital.cabinet-office.gov.uk>