### PR TITLE
Remove JS tracking nginx config for frontend

### DIFF
--- a/modules/govuk/manifests/apps/frontend.pp
+++ b/modules/govuk/manifests/apps/frontend.pp
@@ -70,11 +70,6 @@ class govuk::apps::frontend(
     nagios_memory_warning    => $nagios_memory_warning,
     nagios_memory_critical   => $nagios_memory_critical,
     vhost                    => $vhost,
-    nginx_extra_config       => '
-  location ^~ /frontend/homepage/no-cache/ {
-    expires epoch;
-  }
-  ',
     unicorn_worker_processes => $unicorn_worker_processes,
   }
 


### PR DESCRIPTION
This was added in https://github.com/alphagov/govuk-puppet/pull/5624 to support the JS/No-JS tracking experiment, which we're removing.