### PR TITLE
Enable ETL master process execution in Integration via Jenkins

### DIFF
--- a/hieradata_aws/class/integration/jenkins.yaml
+++ b/hieradata_aws/class/integration/jenkins.yaml
@@ -10,6 +10,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::clear_template_cache
   - govuk_jenkins::jobs::clear_varnish_cache
   - govuk_jenkins::jobs::configure_github_repos
+  - govuk_jenkins::jobs::content_performance_manager
   - govuk_jenkins::jobs::data_sync
   - govuk_jenkins::jobs::data_sync_complete_integration
   - govuk_jenkins::jobs::deploy_app

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -70,6 +70,8 @@ govuk_elasticsearch::dump::run_es_dump_hour: '9'
 govuk_jenkins::job_builder::environment: 'integration'
 govuk_jenkins::config::executors: '8'
 
+govuk_jenkins::jobs::content_performance_manager::rake_etl_master_process_cron_schedule: '0 13 * * *'
+
 govuk_jenkins::jobs::content_publisher_whitehall_import::enable_slack_notifications: true
 govuk_jenkins::jobs::deploy_dns::gce_project_id: 'govuk-integration'
 govuk_jenkins::jobs::deploy_dns::zones:


### PR DESCRIPTION
[Trello card](https://trello.com/c/lJ0YzNDt/1145-3-raise-2ndline-alarms-when-the-core-google-analytics-metrics-are-not-collected-from-google)

It will run the master process daily at 13:00, which will enable
the team to test the Icinga alarms if any error occur. 