### PR TITLE
Create new s_elasticsearch5 node type

### DIFF
--- a/hieradata/class/elasticsearch5.yaml
+++ b/hieradata/class/elasticsearch5.yaml
@@ -1,0 +1,22 @@
+---
+
+# dummy file so CI is happy
+
+govuk_safe_to_reboot::can_reboot: 'careful'
+govuk_safe_to_reboot::reason: 'Reboot a single node at time and check that the cluster goes green between reboots'
+
+govuk_elasticsearch::version: '5.6.14'
+
+lv:
+  data:
+    pv: '/dev/nvme1n1'
+    vg: 'elasticsearch'
+
+mount:
+  /mnt/elasticsearch:
+    disk: '/dev/mapper/elasticsearch-data'
+    govuk_lvm: 'data'
+    mountoptions: 'defaults'
+    percent_threshold_warning: 16
+    percent_threshold_critical: 11
+

--- a/hieradata_aws/class/elasticsearch5.yaml
+++ b/hieradata_aws/class/elasticsearch5.yaml
@@ -1,0 +1,20 @@
+---
+
+govuk_safe_to_reboot::can_reboot: 'careful'
+govuk_safe_to_reboot::reason: 'Reboot a single node at time and check that the cluster goes green between reboots'
+
+govuk_elasticsearch::version: '5.6.14'
+
+lv:
+  data:
+    pv: '/dev/nvme1n1'
+    vg: 'elasticsearch'
+
+mount:
+  /mnt/elasticsearch:
+    disk: '/dev/mapper/elasticsearch-data'
+    govuk_lvm: 'data'
+    mountoptions: 'defaults'
+    percent_threshold_warning: 16
+    percent_threshold_critical: 11
+

--- a/modules/govuk/manifests/node/s_elasticsearch5.pp
+++ b/modules/govuk/manifests/node/s_elasticsearch5.pp
@@ -1,0 +1,38 @@
+# == Class: govuk::node::s_elasticsearch5
+#
+# Machines for the elasticsearch cluster in the API vDC
+#
+class govuk::node::s_elasticsearch5 inherits govuk::node::s_base {
+  include govuk_java::openjdk7::jre
+  include govuk_env_sync
+
+  $es_heap_size = floor($::memorysize_mb / 2)
+
+  class { 'govuk_elasticsearch::dump':
+    require => Class['govuk_elasticsearch'], # required for elasticsearch user to exist
+  }
+
+  class { 'govuk_elasticsearch':
+    cluster_hosts        => ['elasticsearch5-1.api:9300', 'elasticsearch5-2.api:9300', 'elasticsearch5-3.api:9300'],
+    cluster_name         => 'govuk-content',
+    heap_size            => "${es_heap_size}m",
+    number_of_replicas   => '1',
+    host                 => $::fqdn,
+    require              => Class['govuk_java::openjdk7::jre'],
+    aws_cluster_name     => "elasticsearch5-${::aws_stackname}",
+    log_slow_queries     => true,
+    slow_query_log_level => 'info',
+    version              => '5.6.14',
+  }
+
+  collectd::plugin::tcpconn { 'es-9200':
+    incoming => 9200,
+    outgoing => 9200,
+  }
+  collectd::plugin::tcpconn { 'es-9300':
+    incoming => 9300,
+    outgoing => 9300,
+  }
+
+  Govuk_mount['/mnt/elasticsearch'] -> Class['govuk_elasticsearch']
+}

--- a/modules/govuk_elasticsearch/manifests/init.pp
+++ b/modules/govuk_elasticsearch/manifests/init.pp
@@ -247,7 +247,11 @@ class govuk_elasticsearch (
   }
 
   if ! $::aws_migration {
-    govuk_elasticsearch::firewall_transport_rule { $cluster_hosts: }
+    # temporary hack so that CI will build this AWS-only host without
+    # trying to include the firewall class.
+    if ($::hostname != 'elasticsearch5-1') {
+      govuk_elasticsearch::firewall_transport_rule { $cluster_hosts: }
+    }
   } else {
     # Since UFW is setup as deny by default we need to open the up the firewall
     # from everyone, and firewalling is handled by Security Groups

--- a/modules/hosts/manifests/purge.pp
+++ b/modules/hosts/manifests/purge.pp
@@ -16,6 +16,7 @@ class hosts::purge {
   # eg hosts that are only present in AWS
   $whitelist = [
     'db-admin-1',
+    'elasticsearch5-1',
     'email-alert-api-postgresql',
     'publishing-api-db-admin-1',
     'publishing-api-postgresql-1',


### PR DESCRIPTION
We've possibly hit a dealbreaker with the managed elasticsearch, as it can only be in one or two availability zones.

The set-up work is rapidly increasing compared to just duplicating the existing work done for rummager-elasticsearch.

---

[Trello card](https://trello.com/c/AAn6fHf2/41-wrangle-a-new-non-managed-es5-cluster)