### PR TITLE
Run smokey after deploying CDN

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/bouncer_cdn.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/bouncer_cdn.yaml.erb
@@ -39,6 +39,9 @@
               predefined-parameters: |
                   NSCA_CHECK_DESCRIPTION=<%= @service_description %>
                   NSCA_OUTPUT=<%= @service_description %> failed
+        - trigger:
+            project: Smokey
+            threshold: SUCCESS
     wrappers:
         - ansicolor:
             colormap: xterm

--- a/modules/govuk_jenkins/templates/jobs/deploy_cdn.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_cdn.yaml.erb
@@ -43,6 +43,9 @@
           include-test-summary: false
           room: <%= @slack_room %>
       <% end %>
+      - trigger:
+          project: Smokey
+          threshold: SUCCESS
     wrappers:
         - ansicolor:
             colormap: xterm

--- a/modules/govuk_jenkins/templates/jobs/update_cdn_dictionaries.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/update_cdn_dictionaries.yaml.erb
@@ -41,6 +41,9 @@
           notify-repeatedfailure: false
           include-test-summary: false
           room: <%= @slack_room %>
+      - trigger:
+          project: Smokey
+          threshold: SUCCESS
     wrappers:
         - ansicolor:
             colormap: xterm


### PR DESCRIPTION
This causes Smokey to run after the CDN is deployed. Because Smokey now uses Fastly as well, this should give us more confidence when deploying to staging.
