### PR TITLE
Add agnieszkadufrat manifest for integration and CI

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -219,6 +219,7 @@ postfix::smarthost:
   - 'ses-smtp-eu-west-1-prod-345515633.eu-west-1.elb.amazonaws.com:587'
 
 users::usernames:
+  - agnieszkadufrat
   - alangabbianelli
   - alexandrujurubita
   - alextorrance

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -161,6 +161,7 @@ router::nginx::check_requests_warning: '@0.5'
 router::nginx::check_requests_critical: '@0.25'
 
 users::usernames:
+  - agnieszkadufrat
   - alangabbianelli
   - alexandrujurubita
   - alextorrance


### PR DESCRIPTION
The manifest was created in October.
This commit is adding it into the list of `users::usernames` in `hieradata_aws/integration.yam`l for integration and in `hieradata/integration.yaml` for CI.