### PR TITLE
Staging-Migrations-Fix: Plek Envvar required

### DIFF
--- a/modules/govuk/manifests/node/s_calculators_frontend.pp
+++ b/modules/govuk/manifests/node/s_calculators_frontend.pp
@@ -42,6 +42,7 @@ class govuk::node::s_calculators_frontend inherits govuk::node::s_base {
       'PLEK_SERVICE_RUMMAGER_URI': value  => "https://rummager.${app_domain}";
       'PLEK_SERVICE_EMAIL_ALERT_API_URI': value  => "https://email-alert-api.${app_domain}";
       'PLEK_SERVICE_PUBLISHING_API_URI': value  => "https://publishing-api.${app_domain}";
+      'PLEK_SERVICE_WHITEHALL_ADMIN_URI': value  => "https://whitehall-admin.${app_domain}";
     }
   }
 }


### PR DESCRIPTION
smartanswers frontend needs to access whitehall-admin (which is staying
in carraenza for the moment).
Currently smartanswers in the AWS environments attempts to access
whitehall-admin using the govuk.digital name. So in order to override
that we are laying down a PLEK envvar on the calculators-frontend
machines for whitehall-admin so traffic will be directed to carrenza
whitehall-admin..

@ronocg <conor.glynn@digital.cabinet-office.gov.uk>