### PR TITLE
Increase frontend app 5xx thresholds

### DIFF
--- a/modules/govuk/manifests/apps/finder_frontend.pp
+++ b/modules/govuk/manifests/apps/finder_frontend.pp
@@ -49,6 +49,8 @@ class govuk::apps::finder_frontend(
       nagios_memory_critical   => $nagios_memory_critical,
       unicorn_worker_processes => $unicorn_worker_processes,
       override_search_location => $override_search_location,
+      alert_5xx_warning_rate   => 0.1,
+      alert_5xx_critical_rate  => 0.2,
     }
   }
 

--- a/modules/govuk/manifests/apps/government_frontend.pp
+++ b/modules/govuk/manifests/apps/government_frontend.pp
@@ -69,5 +69,7 @@ class govuk::apps::government_frontend(
     cpu_critical             => $cpu_critical,
     nagios_memory_warning    => $nagios_memory_warning,
     nagios_memory_critical   => $nagios_memory_critical,
+    alert_5xx_warning_rate   => 0.2,
+    alert_5xx_critical_rate  => 0.3,
   }
 }

--- a/modules/govuk/manifests/apps/manuals_frontend.pp
+++ b/modules/govuk/manifests/apps/manuals_frontend.pp
@@ -30,14 +30,16 @@ class govuk::apps::manuals_frontend(
   $secret_key_base = undef,
 ) {
   govuk::app { 'manuals-frontend':
-    app_type              => 'rack',
-    port                  => $port,
-    sentry_dsn            => $sentry_dsn,
-    asset_pipeline        => true,
-    asset_pipeline_prefix => 'manuals-frontend',
-    vhost                 => $vhost,
-    health_check_path     => '/healthcheck',
-    json_health_check     => true,
+    app_type                => 'rack',
+    port                    => $port,
+    sentry_dsn              => $sentry_dsn,
+    asset_pipeline          => true,
+    asset_pipeline_prefix   => 'manuals-frontend',
+    vhost                   => $vhost,
+    health_check_path       => '/healthcheck',
+    json_health_check       => true,
+    alert_5xx_warning_rate  => 0.1,
+    alert_5xx_critical_rate => 0.2,
   }
 
   Govuk::App::Envvar {

--- a/modules/govuk/manifests/apps/smartanswers.pp
+++ b/modules/govuk/manifests/apps/smartanswers.pp
@@ -94,8 +94,8 @@ class govuk::apps::smartanswers(
     vhost                    => $vhost,
     nagios_memory_warning    => $nagios_memory_warning,
     nagios_memory_critical   => $nagios_memory_critical,
-    alert_5xx_warning_rate   => 0.001,
-    alert_5xx_critical_rate  => 0.005,
+    alert_5xx_warning_rate   => 0.2,
+    alert_5xx_critical_rate  => 0.3,
     repo_name                => 'smart-answers',
     unicorn_worker_processes => $unicorn_worker_processes,
   }


### PR DESCRIPTION
Currently we're experiencing higher than usual 5xx rate for our frontend apps due to the AWS migration of content-store.

It makes it harder to understand which alerts need action and which don't because there are constant alerts for high 5xx rates in our frontend apps, when in reality there isn't much we can do about it until the apps are migrated to AWS. Fastly is still able to serve requests from the mirrors, so our overall 5xx rate hasn't increased by much.

This is very much designed as a temporary measure and should be reverted immediately after the migration has completed. I picked the numbers by looking at the graphs and seeing what would make the alerts less noisy.