### PR TITLE
Increase router memory thresholds

### DIFF
--- a/modules/govuk/manifests/apps/router.pp
+++ b/modules/govuk/manifests/apps/router.pp
@@ -41,11 +41,13 @@ class govuk::apps::router (
   }
 
   govuk::app { 'router':
-    app_type           => 'bare',
-    command            => './router',
-    port               => $port,
-    enable_nginx_vhost => $enable_nginx_vhost,
-    vhost_aliases      => $vhost_aliases,
+    app_type               => 'bare',
+    command                => './router',
+    port                   => $port,
+    enable_nginx_vhost     => $enable_nginx_vhost,
+    vhost_aliases          => $vhost_aliases,
+    nagios_memory_warning  => 750,
+    nagios_memory_critical => 900,
   }
 
   # We can't pass `health_check_path` to `govuk::app` because it has the


### PR DESCRIPTION
When lots of publishing is happening, the memory usage for router often goes slightly over 700 MB. This is likely because we have more routes than before.

The cache machines have around 4 GB free, so we can safely increase the router thresholds by 50 MB to stop alerting unnecessarily.