### PR TITLE
Set search-api elasticsearch host in integration

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -38,6 +38,7 @@ govuk::apps::kibana::logit_environment: 2694f14b-6519-4607-81f2-8a2130e5aaec
 govuk::apps::link_checker_api::govuk_basic_auth_credentials: "%{hiera('http_username')}:%{hiera('http_password')}"
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-integration'
 govuk::apps::publishing_api::content_api_prototype: true
+govuk::apps::search_api::elasticsearch_hosts: 'http://elasticsearch5.blue.integration.govuk-internal.digital:9200'
 govuk::apps::short_url_manager::instance_name: 'integration'
 govuk::apps::signon::instance_name: 'integration'
 govuk::apps::smartanswers::expose_govspeak: true


### PR DESCRIPTION
The AWS common hieradata uses a nicer hostname for the rummager elasticsearch 2 host:

```
michaelswalker@ec2-integration-blue-search-ip-10-1-5-52:~$ curl http://rummager-elasticsearch:9200
{
  "name" : "ip-10-1-5-227.eu-west-1.compute.internal",
  "cluster_name" : "govuk-content",
  "cluster_uuid" : "QM3vDU1cRkOXACpxnPpDiw",
  "version" : {
    "number" : "2.4.6",
    "build_hash" : "5376dca9f70f3abef96a77f4bb22720ace8240fd",
    "build_timestamp" : "2017-07-18T12:17:44Z",
    "build_snapshot" : false,
    "lucene_version" : "5.5.4"
  },
  "tagline" : "You Know, for Search"
}
```

A similarly nice hostname doesn't seem to have been created for the elasticsearch 5 host:

```
michaelswalker@ec2-integration-blue-search-ip-10-1-5-52:~$ curl http://elasticsearch5:9200
curl: (6) Could not resolve host: elasticsearch5
```

This is something worth looking in to (later).

---

[Trello card](https://trello.com/c/AVCxefdY/42-configure-search-api-to-use-new-cluster-in-integration)