### PR TITLE
Disable pull_content_store_daily job

### DIFF
--- a/hieradata_aws/class/integration/mongo.yaml
+++ b/hieradata_aws/class/integration/mongo.yaml
@@ -1,6 +1,6 @@
 govuk_env_sync::tasks:
   "pull_content_store_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "4" 
     minute: "16"
     action: "pull"


### PR DESCRIPTION
This PR disables the pull_content_store_daily job to allow for testing of a large amount of unpublished data in integration. It is expected that the job will be re-enabled on or around 11th February (subject to again being disabled for more testing on integration.)