### PR TITLE
Add cron job to purge unused rabbitmq queues in AWS

### DIFF
--- a/modules/govuk_rabbitmq/manifests/init.pp
+++ b/modules/govuk_rabbitmq/manifests/init.pp
@@ -23,6 +23,8 @@ class govuk_rabbitmq (
       ensure   => '1.7.1',
       provider => pip,
     }
+# Temporary purging of queues not consumed during the migration to AWS
+    include govuk_rabbitmq::purge_queues
   }
 
   include '::rabbitmq'

--- a/modules/govuk_rabbitmq/manifests/purge_queues.pp
+++ b/modules/govuk_rabbitmq/manifests/purge_queues.pp
@@ -1,0 +1,37 @@
+# == Class: govuk_rabbitmq::purge_queues
+#
+# Create a cron job to purge rabbitmq queues
+#
+
+class govuk_rabbitmq::purge_queues {
+  cron::crondotdee { 'purge_content_performance_manager':
+    command => '/usr/sbin/rabbitmqctl purge content_performance_manager > /dev/null 2>&1',
+    hour    => '*',
+    minute  => '0',
+    user    => 'root',
+  }
+  cron::crondotdee { 'purge_email_alert_service':
+    command => '/usr/sbin/rabbitmqctl purge email_alert_service > /dev/null 2>&1',
+    hour    => '*',
+    minute  => '1',
+    user    => 'root',
+  }
+  cron::crondotdee { 'purge_email_unpublishing':
+    command => '/usr/sbin/rabbitmqctl purge email_unpublishing > /dev/null 2>&1',
+    hour    => '*',
+    minute  => '2',
+    user    => 'root',
+  }
+  cron::crondotdee { 'purge_rummager_govuk_index':
+    command => '/usr/sbin/rabbitmqctl purge rummager_govuk_index > /dev/null 2>&1',
+    hour    => '*',
+    minute  => '3',
+    user    => 'root',
+  }
+  cron::crondotdee { 'purge_rummager_to_be_indexed':
+    command => '/usr/sbin/rabbitmqctl purge rummager_to_be_indexed > /dev/null 2>&1',
+    hour    => '*',
+    minute  => '4',
+    user    => 'root',
+  }
+}


### PR DESCRIPTION
  We have a federated rabbitmq exchange in AWS.
Only queues of services that have been migrated to AWS are
consumed. We purge the others so that they don't grow too large