### PR TITLE
Remove references to SSH for data sync

### DIFF
--- a/development-vm/replication/README.md
+++ b/development-vm/replication/README.md
@@ -1,17 +1,5 @@
 # Data replication
 
-Dumps are generated from production data in the early hours each day, and are then downloaded from integration.
-
-If you have integration access, you can download and import the latest data by running:
-
-```
-./replicate-data-local.sh -u $USERNAME -F ../ssh_config
-```
-
-If you don't have integration access, ask someone to give you a copy of their dump. Then, from this directory, run:
-
-```
-./replicate-data-local.sh -d path/to/dir -s
-```
+Dumps are generated from production data in the early hours each day, and are then downloaded from S3.
 
 For more information, see the guide in the developer docs on [replicating application data locally for development](https://docs.publishing.service.gov.uk/manual/replicate-app-data-locally.html).

--- a/development-vm/replication/common-args.sh
+++ b/development-vm/replication/common-args.sh
@@ -14,8 +14,6 @@ ${USAGE_DESCRIPTION-}
 
 OPTIONS:
     -h       Show this message
-    -F file  Use a custom SSH configuration file
-    -u user  SSH user to log in as (overrides SSH config)
     -d dir   Use named directory to store and load backups
     -s       Skip downloading the backups (use with -d to load old backups)
     -r       Reset ignore list. This overrides any default ignores
@@ -39,7 +37,6 @@ SKIP_POSTGRES=false
 SKIP_MYSQL=false
 SKIP_ELASTIC=false
 SKIP_MAPIT=false
-SSH_CONFIG="../ssh_config"
 RENAME_DATABASES=true
 DRY_RUN=false
 KEEP_BACKUPS=false
@@ -64,12 +61,6 @@ do
     h )
       usage
       exit 1
-      ;;
-    F )
-      SSH_CONFIG=$OPTARG
-      ;;
-    u )
-      SSH_USER=$OPTARG
       ;;
     d )
       DIR=$OPTARG


### PR DESCRIPTION
As described in https://github.com/alphagov/govuk-developer-docs/pull/1514, we don't need integration SSH access for the data sync - just AWS access. This commit removes the options from the data sync script and updates the docs.