### PR TITLE
Turn on real-time traffic replay from rummager to search-api in integration

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -960,6 +960,8 @@ govuk_rabbitmq::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 govuk_rbenv::all::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
+govuk_search::gor::enabled: true
+
 govuk_sudo::sudo_conf:
   deploy_docker_image:
     content: 'deploy ALL=NOPASSWD:/usr/bin/docker image *'

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -52,6 +52,9 @@ govuk::apps::url_arbiter::db::backend_ip_range: '10.1.3.0/24'
 govuk::apps::whitehall::basic_auth_credentials: "%{hiera('http_username')}:%{hiera('http_password')}"
 govuk::apps::whitehall::highlight_words_to_avoid: true
 
+govuk_search::gor::replay_target_hosts:
+  - 'http://localhost:3233'
+
 govuk::deploy::aws_ses_smtp_host: 'email-smtp.eu-west-1.amazonaws.com'
 govuk::deploy::config::errbit_environment_name: "integration-%{hiera('stackname')}-aws"
 govuk::deploy::config::licensify_app_domain: 'integration.publishing.service.gov.uk'


### PR DESCRIPTION
We're using traffic replay so that whitehall and search-admin don't need to know there are two search services which need to receive the updates they send over HTTP.

---

[Trello card](https://trello.com/c/EZ9afT7r/37-replay-traffic-to-new-integration-cluster)