### PR TITLE
Add Email Alert API bearer token for Rummager

### DIFF
--- a/modules/govuk/manifests/apps/rummager.pp
+++ b/modules/govuk/manifests/apps/rummager.pp
@@ -35,6 +35,10 @@
 #   The bearer token to use when communicating with Publishing API.
 #   Default: undef
 #
+# [*email_alert_api_bearer_token*]
+#   The bearer token to use when communicating with Email Alert API.
+#   Default: undef
+#
 # [*rabbitmq_hosts*]
 #   RabbitMQ hosts to connect to.
 #   Default: localhost
@@ -85,6 +89,7 @@ class govuk::apps::rummager(
   $enable_publishing_listener = false,
   $sentry_dsn = undef,
   $publishing_api_bearer_token = undef,
+  $email_alert_api_bearer_token = undef,
   $rabbitmq_hosts = ['localhost'],
   $rabbitmq_password = 'rummager',
   $redis_host = undef,
@@ -190,6 +195,12 @@ class govuk::apps::rummager(
     "${title}-PUBLISHING_API_BEARER_TOKEN":
       varname => 'PUBLISHING_API_BEARER_TOKEN',
       value   => $publishing_api_bearer_token;
+  }
+
+  govuk::app::envvar {
+    "${title}-EMAIL_ALERT_API_BEARER_TOKEN":
+      varname => 'EMAIL_ALERT_API_BEARER_TOKEN',
+      value   => $email_alert_api_bearer_token;
   }
 
   govuk::app::envvar { "${title}-ELASTICSEARCH_URI":


### PR DESCRIPTION
This commit adds an Email Alert API bearer token for Rummager. This token will be used by the `tag_metadata` task in Rummager to send newly-tagged documents to Email Alert API to send out email alerts.