### PR TITLE
create proxy elasticsearch for licence frontend 

### DIFF
--- a/hieradata_aws/class/production/calculators_frontend.yaml
+++ b/hieradata_aws/class/production/calculators_frontend.yaml
@@ -1,0 +1,6 @@
+---
+
+govuk_elasticsearch::local_proxy::servers:
+  - 'rummager-elasticsearch-cz-1.production.govuk-internal.digital'
+  - 'rummager-elasticsearch-cz-2.production.govuk-internal.digital'
+  - 'rummager-elasticsearch-cz-3.production.govuk-internal.digital'

--- a/hieradata_aws/class/staging/calculators_frontend.yaml
+++ b/hieradata_aws/class/staging/calculators_frontend.yaml
@@ -1,0 +1,6 @@
+---
+
+govuk_elasticsearch::local_proxy::servers:
+  - 'rummager-elasticsearch-cz-1.staging.govuk-internal.digital'
+  - 'rummager-elasticsearch-cz-2.staging.govuk-internal.digital'
+  - 'rummager-elasticsearch-cz-3.staging.govuk-internal.digital'

--- a/modules/govuk/manifests/node/s_calculators_frontend.pp
+++ b/modules/govuk/manifests/node/s_calculators_frontend.pp
@@ -7,7 +7,7 @@ class govuk::node::s_calculators_frontend inherits govuk::node::s_base {
   include nginx
 
   # Local proxy for licence-finder to access ES cluster.
-  if ! $::aws_migration {
+  if (! $::aws_migration) or ($::aws_environment == 'staging') or ($::aws_environment == 'production') {
     include govuk_elasticsearch::local_proxy
   }
 


### PR DESCRIPTION
# Context

As part of the AWS migration of licence finder frontend, the rummager search instances have not been migrated and therefore we still need the elastic search proxy for AWS Staging and Production

# Decisions
1. redefine the logic to include the elastic search proxy for AWS Staging and Production
2. configure the addresses of the rummager search instances