### PR TITLE
Increase file descriptors for router

### DIFF
--- a/modules/govuk/manifests/node/s_cache.pp
+++ b/modules/govuk/manifests/node/s_cache.pp
@@ -45,6 +45,13 @@ class govuk::node::s_cache (
   include router::gor
   include nscd
 
+  limits::limits { 'deploy_nofile_router':
+    ensure     => present,
+    user       => 'deploy',
+    limit_type => 'nofile',
+    both       => 65535,
+  }
+
   if $router_as_container {
     include ::govuk_containers::apps::router
   }


### PR DESCRIPTION
This commit increases the number of allowed file descriptors for the `router` app (which runs under the `deploy` user) from 16384 to 65535 to allow it to handle more concurrent connections.