### PR TITLE
elasticsearch is available on localhost in AWS Staging and Production

### DIFF
--- a/modules/govuk/manifests/apps/licencefinder.pp
+++ b/modules/govuk/manifests/apps/licencefinder.pp
@@ -73,11 +73,19 @@ class govuk::apps::licencefinder(
     value   => $publishing_api_bearer_token,
   }
 
-  if $::aws_migration {
-    govuk::app::envvar { "${title}-ELASTICSEARCH_URI":
-      app     => $app_name,
-      varname => 'ELASTICSEARCH_URI',
-      value   => 'http://rummager-elasticsearch:9200',
+  if $::aws_migration  {
+    if ($::aws_environment == 'integration') {
+      govuk::app::envvar { "${title}-ELASTICSEARCH_URI":
+        app     => $app_name,
+        varname => 'ELASTICSEARCH_URI',
+        value   => 'http://rummager-elasticsearch:9200',
+      }
+    } else {
+      govuk::app::envvar { "${title}-ELASTICSEARCH_URI":
+        app     => $app_name,
+        varname => 'ELASTICSEARCH_URI',
+        value   => 'http://localhost:9200',
+      }
     }
   }
 }


### PR DESCRIPTION
# Context

As part of the migration of licencefinder frontend for AWS Staging and Production, the rummanger elastic search cluster was kept on Carrenza and accessed via a localhost proxy on port 9200 on the licencefinder hosts. Hence we set the elasticsearch url to be `localhost` rather than `rummanger-elasticsearch`.

# Decisions
1. set the rummager-elasticsearch URL to `localhost` for AWS Staging and Production
