### PR TITLE
allow aws to access carrenza elasticsearch

### DIFF
--- a/hieradata/class/production/rummager_elasticsearch.yaml
+++ b/hieradata/class/production/rummager_elasticsearch.yaml
@@ -1,0 +1,3 @@
+---
+
+govuk::node::s_rummager_elasticsearch::aws_subnet: 10.13.0.0/16

--- a/hieradata/class/staging/rummager_elasticsearch.yaml
+++ b/hieradata/class/staging/rummager_elasticsearch.yaml
@@ -1,0 +1,3 @@
+---
+
+govuk::node::s_rummager_elasticsearch::aws_subnet: 10.12.0.0/16

--- a/modules/govuk/manifests/node/s_rummager_elasticsearch.pp
+++ b/modules/govuk/manifests/node/s_rummager_elasticsearch.pp
@@ -2,7 +2,16 @@
 #
 # Machines for the elasticsearch cluster in the API vDC
 #
-class govuk::node::s_rummager_elasticsearch inherits govuk::node::s_base {
+# === Parameters
+#
+# [*aws_subnet*]
+#   IPv4 subnet which will allow AWS hosts to contact this host when in
+#   Staging or Production
+#   Default: null
+#
+class govuk::node::s_rummager_elasticsearch (
+  $aws_subnet = null,
+) inherits govuk::node::s_base {
   include govuk_java::openjdk7::jre
   include govuk_env_sync
 
@@ -59,6 +68,13 @@ class govuk::node::s_rummager_elasticsearch inherits govuk::node::s_base {
       port    => 9200,
       from    => getparam(Govuk_host['calculators-frontend-3'], 'ip'),
       require => Govuk_host['calculators-frontend-3'],
+    }
+  }
+
+  if (! $::aws_migration) {
+    @ufw::allow { 'allow-elasticsearch-http-9200-from-aws':
+      port => 9200,
+      from => $aws_subnet,
     }
   }
 


### PR DESCRIPTION
# Context

As part of the migration of the licencefinder frontend to AWS, there is a need to allow this frontend to access the elasticsearch in Carrenza. Hence, we need to open the Carrenza Elasticsearch UFW firewall.

# Decisions
1. open Carrenza ufw to AWS IPs.