### PR TITLE
Add apt repo for goreplay

### DIFF
--- a/modules/govuk/manifests/node/s_apt.pp
+++ b/modules/govuk/manifests/node/s_apt.pp
@@ -150,6 +150,7 @@ class govuk::node::s_apt (
   aptly::repo { 'gof3r': }
   aptly::repo { 'google-cloud-sdk-trusty': }
   aptly::repo { 'gor': }
+  aptly::repo { 'goreplay': }
   aptly::repo { 'govuk-datascrubber': }
   aptly::repo { 'govuk-jenkins': }
   aptly::repo { 'govuk-prometheus': }


### PR DESCRIPTION
The official name for Gor has changed to Goreplay and therefore we need to put the new versions in a newly-named repo so apt-get can find it correctly.