### PR TITLE
Add data sync for ckan_production in AWS

### DIFF
--- a/hieradata_aws/class/production/db_admin.yaml
+++ b/hieradata_aws/class/production/db_admin.yaml
@@ -1,4 +1,15 @@
 govuk_env_sync::tasks:
+  "push_ckan_production_daily":
+    ensure: "present"
+    hour: "23"
+    minute: 30"
+    action: "push"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "ckan_production"
+    temppath: "/tmp/ckan_production"
+    url: "govuk-production-database-backups"
+    path: "postgresql-backend"
   "push_local-links-manager_production_daily":
     ensure: "present"
     hour: "3"

--- a/hieradata_aws/class/staging/db_admin.yaml
+++ b/hieradata_aws/class/staging/db_admin.yaml
@@ -1,7 +1,7 @@
 govuk_env_sync::tasks:
   "pull_ckan_production_daily":
     ensure: "present"
-    hour: "2"
+    hour: "3"
     minute: "15"
     action: "pull"
     dbms: "postgresql"


### PR DESCRIPTION
- We are leaving out sync for integration for the time being, in order
to assess if the ckan db contains sensitive data
- The ckan db is fairly large (120G+), so we need to increase the disk
size of the db_admin machine as well

solo: @schmie