### PR TITLE
Support a null healthcheck message

### DIFF
--- a/modules/icinga/files/usr/lib/nagios/plugins/check_json_healthcheck
+++ b/modules/icinga/files/usr/lib/nagios/plugins/check_json_healthcheck
@@ -129,10 +129,10 @@ class HealthCheckInfo(object):
                 for (check_name, check_value) in checks.items()]
 
     def _check_parts(self, check_name, check_value):
-        base_parts = [check_name, check_value["status"]]
+        parts = [check_name, check_value["status"]]
         if check_value.get("message") is not None:
-            base_parts.append(check_value["message"])
-        return base_parts
+            parts.append(check_value["message"])
+        return parts
 
 
 if __name__ == "__main__":

--- a/modules/icinga/files/usr/lib/nagios/plugins/check_json_healthcheck
+++ b/modules/icinga/files/usr/lib/nagios/plugins/check_json_healthcheck
@@ -130,10 +130,9 @@ class HealthCheckInfo(object):
 
     def _check_parts(self, check_name, check_value):
         base_parts = [check_name, check_value["status"]]
-        if "message" in check_value:
-            return base_parts + [check_value["message"]]
-        else:
-            return base_parts
+        if check_value.get("message") is not None:
+            base_parts.append(check_value["message"])
+        return base_parts
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Some apps are returning a message which is `null` and we currently can't handle this and it means none of the healthchecks are checked. Although it would be good if the apps didn't return a `null` message, it seems reasonable for Icinga to be able to cope with this situation as it could happen.

Example healthcheck: https://content-performance-manager.publishing.service.gov.uk/healthcheck

<img width="1230" alt="screen shot 2019-02-12 at 12 49 33" src="https://user-images.githubusercontent.com/510498/52636509-ba905680-2ec4-11e9-9992-eae0a017acfc.png">