### PR TITLE
Trello-2020: Plek envvar for whitehall on content-store and draft-content-store

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -184,6 +184,7 @@ task :check_consistency_between_aws_and_carrenza do
     govuk::apps::content_publisher::db::allow_auth_from_lb
     govuk::apps::content_publisher::db::lb_ip_range
     govuk::apps::content_publisher::db::rds
+    govuk::apps::content_store::plek_service_whitehall_frontend_uri
     govuk::apps::content_tagger::db::allow_auth_from_lb
     govuk::apps::content_tagger::db::lb_ip_range
     govuk::apps::content_tagger::db::rds

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -122,6 +122,7 @@ govuk::apps::content_publisher::google_tag_manager_preview: "env-7"
 govuk::apps::content_store::app_domain: publishing.service.gov.uk
 govuk::apps::content_store::performance_platform_big_screen_view_url: 'https://performance-platform-big-screen-view-production.cloudapps.digital'
 govuk::apps::content_store::performance_platform_spotlight_url: 'https://performance-platform-spotlight-production.cloudapps.digital'
+govuk::apps::content_store::plek_service_whitehall_frontend_uri: 'https://whitehall-frontend.publishing.service.gov.uk'
 govuk::apps::email_alert_api::db::backend_ip_range: '10.13.3.0/24'
 govuk::apps::email_alert_api::email_archive_s3_bucket: 'govuk-production-email-alert-api-archive'
 # This shouldn't be enabled at the same time we have carrenza s3 export enabled unless they have separate buckets

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -124,6 +124,7 @@ govuk::apps::content_publisher::google_tag_manager_preview: "env-5"
 govuk::apps::content_store::app_domain: staging.publishing.service.gov.uk
 govuk::apps::content_store::performance_platform_big_screen_view_url: 'https://performance-platform-big-screen-view-staging.cloudapps.digital'
 govuk::apps::content_store::performance_platform_spotlight_url: 'https://performance-platform-spotlight-staging.cloudapps.digital'
+govuk::apps::content_store::plek_service_whitehall_frontend_uri: 'https://whitehall-frontend.staging.publishing.service.gov.uk'
 govuk::apps::email_alert_api::db::backend_ip_range: '10.12.3.0/24'
 govuk::apps::email_alert_api::email_archive_s3_bucket: 'govuk-staging-email-alert-api-archive'
 # This shouldn't be enabled at the same time we have carrenza s3 export enabled unless they have separate buckets

--- a/modules/govuk/manifests/apps/content_store.pp
+++ b/modules/govuk/manifests/apps/content_store.pp
@@ -57,6 +57,10 @@
 # [*router_api_bearer_token*]
 #   The bearer token that will be used to authenticate with the router api
 #
+# [*plek_service_whitehall_frontend_uri*]
+#   whitehall-frontend URL envvar
+#   Default: undef
+#
 
 class govuk::apps::content_store(
   $port = '3068',
@@ -77,6 +81,7 @@ class govuk::apps::content_store(
   $oauth_secret = undef,
   $router_api_bearer_token = undef,
   $create_default_nginx_config = false,
+  $plek_service_whitehall_frontend_uri = undef,
 ) {
   $app_name = 'content-store'
 
@@ -140,5 +145,8 @@ class govuk::apps::content_store(
     "${title}-PERFORMANCEPLATFORM_SPOTLIGHT":
       varname => 'PLEK_SERVICE_SPOTLIGHT_URI',
       value   => $performance_platform_spotlight_url;
+    "${title}-WHITEHALL_FRONTEND_URI":
+      varname => 'PLEK_SERVICE_WHITEHALL_FRONTEND_URI',
+      value   => $plek_service_whitehall_frontend_uri;
   }
 }


### PR DESCRIPTION
When router-api and its database migrate to AWS, whitehall is staying in
carrenza, therefore the whitehall backends in the router-api DB will need
to have the associated publishing.service.gov.uk domain.
This has been completed already by manually setting the whitehall backend
in the router api database with the correct domain.
BUT these could possibly be updated at any time from content-store, so
content-store and draft-content-store need the PLEK envvars in place for
the whitehall-frontend backend URI.

The end state for the variables should be;

staging:
https://whitehall-frontend.staging.publishing.service.gov.uk

production:
https://whitehall-frontend.publishing.service.gov.uk

Also because this parameter will be undef for other environments other than
aws staging and aws production they will not be laid down for those
other envs.

@ronocg <conor.glynn@digital.cabinet-office.gov.uk>
@jstandring-gds <julian.standring@digital.cabinet-office.gov.uk>