### PR TITLE
Add --verbose to some librarian-puppet commands

### DIFF
--- a/lib/tasks/librarian.rake
+++ b/lib/tasks/librarian.rake
@@ -16,13 +16,13 @@ namespace :librarian do
 
   desc "Install modules and update cache"
   task :package do
-    librarian_run('package --clean', true)
+    librarian_run('package --clean --verbose', true)
   end
 
   desc "Update a module version and cache"
   task :update, :module_name do |t, args|
     system('librarian-puppet config mode --local --delete')
-    system("librarian-puppet update #{args[:module_name]}")
+    system("librarian-puppet update --verbose #{args[:module_name]}")
     Rake::Task['librarian:package'].invoke
   end
 end


### PR DESCRIPTION
The README.md recommends against running librarian-puppet directly,
and the output from the librarian:package and librarian:update Rake
tasks isn't sufficient to resolve issues, so add the --verbose flag so
that the output is a little more useful.