### PR TITLE
Upgrade to collectd 5.8 and use CollectFileDescriptor

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -299,9 +299,6 @@ collectd::package::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 collectd::plugin::docker::repo: "https://github.com/lebauce/docker-collectd-plugin.git"
 collectd::plugin::docker::commit: "c3edc64555f35d8ffcc9aee23b69c289e8f309fb"
 
-collectd::package::collectd_version: '5.6.0-0.1~pl5~trusty1'
-collectd::package::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
-
 duplicity::packages::version: '0.7.11-0ubuntu0ppa1263~ubuntu14.04.1'
 
 filebeat::prospectors:

--- a/modules/collectd/manifests/package.pp
+++ b/modules/collectd/manifests/package.pp
@@ -14,7 +14,7 @@
 #   The hostname of the local aptly mirror.
 #
 class collectd::package (
-  $collectd_version = '5.4.0-3ubuntu2',
+  $collectd_version = '5.8.0.145.gca1cb27-1~trusty',
   $yajl_package = 'libyajl2',
   $apt_mirror_hostname,
 ) {

--- a/modules/collectd/manifests/plugin/process.pp
+++ b/modules/collectd/manifests/plugin/process.pp
@@ -21,6 +21,8 @@ define collectd::plugin::process(
   # Sanitise file and metric names.
   validate_re($title, '^[\w\-]+$')
 
+  $collect_file_descriptor = $::lsbdistcodename != 'precise'
+
   @collectd::plugin { "process-${title}":
     ensure  => $ensure,
     content => template('collectd/etc/collectd/conf.d/process.conf.erb'),

--- a/modules/collectd/spec/classes/collectd__package_spec.rb
+++ b/modules/collectd/spec/classes/collectd__package_spec.rb
@@ -1,7 +1,7 @@
 require_relative '../../../../spec_helper'
 
 describe 'collectd::package', :type => :class do
-  it { is_expected.to contain_package('collectd-core').with_ensure('5.4.0-3ubuntu2') }
+  it { is_expected.to contain_package('collectd-core').with_ensure('5.8.0.145.gca1cb27-1~trusty') }
 
   it { is_expected.to contain_package('libyajl2') }
 

--- a/modules/collectd/spec/defines/collectd__plugin__process_spec.rb
+++ b/modules/collectd/spec/defines/collectd__plugin__process_spec.rb
@@ -9,6 +9,7 @@ describe 'collectd::plugin::process', :type => :define do
     it {
         is_expected.to contain_collectd__plugin('process-giraffe').with_content(<<EOS
 <Plugin Processes>
+  CollectFileDescriptor true
   Process "giraffe"
 </Plugin>
 EOS
@@ -22,7 +23,21 @@ EOS
       it {
         is_expected.to contain_collectd__plugin('process-giraffe').with_content(<<EOS
 <Plugin Processes>
+  CollectFileDescriptor true
   ProcessMatch "giraffe" "^gi.*fe$"
+</Plugin>
+EOS
+      )}
+    end
+
+    describe "disables CollectFileDescriptor on precise" do
+      let(:facts) {{ 'lsbdistcodename' => 'precise' }}
+      let(:title) { 'giraffe' }
+
+      it {
+        is_expected.to contain_collectd__plugin('process-giraffe').with_content(<<EOS
+<Plugin Processes>
+  Process "giraffe"
 </Plugin>
 EOS
       )}
@@ -36,6 +51,7 @@ EOS
       it {
         is_expected.to contain_collectd__plugin('process-giraffe').with_content(<<EOS
 <Plugin Processes>
+  CollectFileDescriptor true
   ProcessMatch "giraffe" "^giraffe\\\\.giraffe\\\\\\\\$"
 </Plugin>
 EOS

--- a/modules/collectd/templates/etc/collectd/conf.d/process.conf.erb
+++ b/modules/collectd/templates/etc/collectd/conf.d/process.conf.erb
@@ -1,4 +1,7 @@
 <Plugin Processes>
+<% if @collect_file_descriptor -%>
+  CollectFileDescriptor true
+<%end -%>
 <% if @regex == '' -%>
   Process "<%= @title -%>"
 <% else -%>


### PR DESCRIPTION
This is a follow up task from the 2019-02-02 - 5xx rate on GOV.UK incident.

The intention here is to monitor how many files a particular process is using which can help give us a better insight into what has happened and what should change if we receive errors to say that number of files used is too high.

Graphs can be looked up in graphite like so:

<img width="582" alt="screen shot 2019-02-12 at 17 41 29" src="https://user-images.githubusercontent.com/282717/52656059-79606c80-2eed-11e9-8c68-b1828ddaa283.png">

This is done so by using the CollectFileDescriptor option provided by [Processes plugin](https://collectd.org/documentation/manpages/collectd.conf.5.shtml#plugin_processes). This feature was added in [collectd 5.8](https://collectd.org/wiki/index.php/Plugin:Processes) and thus this updates collectd to be 5.8 (aptly is already updated).

An area I wasn't clear on was why we weren't running collectd 5.6 in Carrenza as that's what we use in AWS. I couldn't find a reason that we don't use it there, only that we need features introduced since 5.4 in AWS.