### PR TITLE
Enable pull_content_store_daily job

### DIFF
--- a/hieradata_aws/class/integration/mongo.yaml
+++ b/hieradata_aws/class/integration/mongo.yaml
@@ -1,6 +1,6 @@
 govuk_env_sync::tasks:
   "pull_content_store_daily":
-    ensure: "absent"
+    ensure: "present"
     hour: "4" 
     minute: "16"
     action: "pull"


### PR DESCRIPTION
This PR enables the pull_content_store_daily job to ensure that integration is kept up-to-date with production content on a daily basis.