### PR TITLE
(DO-NOT-MERGE) Staging content store app domain update

### DIFF
--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -121,7 +121,7 @@ govuk::apps::content_publisher::aws_s3_bucket: "govuk-staging-content-publisher-
 govuk::apps::content_publisher::google_tag_manager_auth: "QaRG0YPL6_pwZdxCbyMXPQ"
 govuk::apps::content_publisher::google_tag_manager_id: "GTM-NQXC4TG"
 govuk::apps::content_publisher::google_tag_manager_preview: "env-5"
-govuk::apps::content_store::app_domain: staging.publishing.service.gov.uk
+govuk::apps::content_store::app_domain: staging.govuk-internal.digital
 govuk::apps::content_store::performance_platform_big_screen_view_url: 'https://performance-platform-big-screen-view-staging.cloudapps.digital'
 govuk::apps::content_store::performance_platform_spotlight_url: 'https://performance-platform-spotlight-staging.cloudapps.digital'
 govuk::apps::content_store::plek_service_whitehall_frontend_uri: 'https://whitehall-frontend.staging.publishing.service.gov.uk'


### PR DESCRIPTION
# Context
As part of the migration we need to update the app domain for the content store
so that the content store is aware of the new app (frontend) locations.

# Decision
Update the hiera to reflect the new app domain, i.e. change from
staging.publishing.service.gov.uk to staging.govuk-internal.digital.