### PR TITLE
Fixes syntax error on minute parameter in db_admin

### DIFF
--- a/hieradata_aws/class/production/db_admin.yaml
+++ b/hieradata_aws/class/production/db_admin.yaml
@@ -2,7 +2,7 @@ govuk_env_sync::tasks:
   "push_ckan_production_daily":
     ensure: "present"
     hour: "23"
-    minute: 30"
+    minute: "30"
     action: "push"
     dbms: "postgresql"
     storagebackend: "s3"


### PR DESCRIPTION
The error that it fixes is
```Error: Failed to apply catalog: Parameter minute failed on Cron[push_ckan_production_daily]: 30" is not a valid minute at /usr/share/puppet/production/current/modules/govuk_env_sync/manifests/task.pp:83```