### PR TITLE
bring up canary backend in AWS Staging and Production

### DIFF
--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -18,6 +18,7 @@ node_class: &node_class
   backend:
     apps:
       - asset-manager
+      - canary-backend
       - transition
       - imminence
       - kibana

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -19,6 +19,7 @@ node_class: &node_class
     apps:
       - asset-manager
       - cache-clearing-service
+      - canary-backend
       - transition
       - imminence
       - kibana


### PR DESCRIPTION
# Context

Since in AWS migration of frontends, canary-frontend is being migrated, then the canary-backend must be active also on the backends.

# Decisions
1. activate canary-backend on the backend machines in AWS Staging and Production