### PR TITLE
canary should be available on 443 and proper url regex

### DIFF
--- a/modules/govuk/manifests/apps/canary_backend.pp
+++ b/modules/govuk/manifests/apps/canary_backend.pp
@@ -13,7 +13,8 @@ class govuk::apps::canary_backend {
       content => "
         server {
           listen 80;
-          server_name canary-backend canary_backend.*;
+          listen 443 ssl;
+          server_name canary-backend.* canary_backend.*;
           location / {
             default_type application/json;
             add_header cache-control \"max-age=0,no-store,no-cache\";


### PR DESCRIPTION
# Context

For AWS environment, the canary-backend nginx config should be available on port 443 because the canary-frontend is requesting https. This is verified to be the same for Carrenza environment. Moreover, the url regex had to be corrected to match was the canary-frontend is sending.

# Decisions
1. open canary-backend on port 443
2. fix server url regex 