### PR TITLE
Remove app_domain hieradata for content store forcing default

### DIFF
--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -122,7 +122,6 @@ govuk::apps::content_publisher::aws_s3_bucket: "govuk-staging-content-publisher-
 govuk::apps::content_publisher::google_tag_manager_auth: "QaRG0YPL6_pwZdxCbyMXPQ"
 govuk::apps::content_publisher::google_tag_manager_id: "GTM-NQXC4TG"
 govuk::apps::content_publisher::google_tag_manager_preview: "env-5"
-govuk::apps::content_store::app_domain: staging.govuk-internal.digital
 govuk::apps::content_store::performance_platform_big_screen_view_url: 'https://performance-platform-big-screen-view-staging.cloudapps.digital'
 govuk::apps::content_store::performance_platform_spotlight_url: 'https://performance-platform-spotlight-staging.cloudapps.digital'
 govuk::apps::content_store::plek_service_whitehall_frontend_uri: 'https://whitehall-frontend.staging.publishing.service.gov.uk'


### PR DESCRIPTION
# Context

As part of the migration we need to update the app domain for the content store
so that the content store is aware of the new app (frontend) locations. This
was previously done by changing the value for
govuk::apps::content_store::app_domain, however if this data is absent then the
app_domain for content store is set to the appropriate default value.

# Decision

Remove the hiera data so that we fall back to the default defined in the
govuk::deploy::config class.