### PR TITLE
fix search and rummager domains when syncing

### DIFF
--- a/modules/govuk_env_sync/files/govuk_env_sync.sh
+++ b/modules/govuk_env_sync/files/govuk_env_sync.sh
@@ -361,6 +361,12 @@ function postprocess_router {
   whitehall_domain="${source_domain}"
   mongo_backend_domain_manipulator "whitehall-frontend" "${whitehall_domain}"
   mongo_backend_domain_manipulator "whitehall" "${whitehall_domain}"
+
+  search_domain="${source_domain}"
+  mongo_backend_domain_manipulator "search" "${search_domain}"
+  
+  rummager_domain="${source_domain}"
+  mongo_backend_domain_manipulator "rummager" "${rummager_domain}"
 }
 
 function postprocess_database {


### PR DESCRIPTION
# Context

As part of the AWS migration, the search and rummager still leaves in Carrenza. Therefore, when synching, we still need the original domain for these backends in the router database.

# Decisions
1. change the govuk_env_sync to keep search and rummager with Carrenza domains