### PR TITLE
fix unicorn monitoring

### DIFF
--- a/modules/icinga/files/usr/lib/nagios/plugins/check_unicorn_workers
+++ b/modules/icinga/files/usr/lib/nagios/plugins/check_unicorn_workers
@@ -21,7 +21,7 @@ cd /var/apps/${APPLICATION}/
 EXPECTED_WORKERS=$(env -i /usr/local/bin/govuk_setenv ${APPLICATION} \
     env HOME=/tmp GOVUK_APP_LOGROOT=/tmp bundle exec ruby \
     -e 'require "unicorn"; puts Unicorn::Configurator.new(:config_file => "'${CONFIG_FILE}'")[:worker_processes]' \
-    2>/dev/null)
+    2>/dev/null | grep -Eo '[0-9]+$')
 
 # Bail if not an integer.
 [[ $EXPECTED_WORKERS != *[!0-9]* ]] || exit_unknown


### PR DESCRIPTION
# Context

The unicorn monitoring requires getting the number of unicorn via a ruby script. This script sometimes output spurious log rather than the number of unicorns only. Hence, we modify the unicorn monitoring to parse the script output and get the number of unicorns.

# Decisions
1. parse the script output for the number of unicorn workers. 