### PR TITLE
Fix docker collectd issue

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -287,8 +287,8 @@ collectd::plugin::tcp::metrics:
   - 'PassiveOpens'
 
 collectd::package::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
-collectd::plugin::docker::repo: "https://github.com/lebauce/docker-collectd-plugin.git"
-collectd::plugin::docker::commit: "c3edc64555f35d8ffcc9aee23b69c289e8f309fb"
+collectd::plugin::docker::repo: "https://github.com/alphagov/docker-collectd-plugin.git"
+collectd::plugin::docker::commit: "e56ddb84536065786e0a55143faa8c6fc035c119"
 
 duplicity::packages::version: '0.7.11-0ubuntu0ppa1263~ubuntu14.04.1'
 

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -296,8 +296,8 @@ collectd::plugin::tcp::metrics:
   - 'PassiveOpens'
 
 collectd::package::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
-collectd::plugin::docker::repo: "https://github.com/lebauce/docker-collectd-plugin.git"
-collectd::plugin::docker::commit: "c3edc64555f35d8ffcc9aee23b69c289e8f309fb"
+collectd::plugin::docker::repo: "https://github.com/alphagov/docker-collectd-plugin.git"
+collectd::plugin::docker::commit: "e56ddb84536065786e0a55143faa8c6fc035c119"
 
 collectd::package::collectd_version: '5.6.0-0.1~pl5~trusty1'
 collectd::package::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"

--- a/modules/collectd/manifests/plugin/docker.pp
+++ b/modules/collectd/manifests/plugin/docker.pp
@@ -16,7 +16,7 @@ class collectd::plugin::docker(
 ) {
 
   $dependencies = [
-    'py-dateutil',
+    'py-dateutil<=2.2',
   ]
 
   package { $dependencies:
@@ -29,7 +29,7 @@ class collectd::plugin::docker(
   # seems to be fixed in puppet 4: https://tickets.puppetlabs.com/browse/PUP-1073
   exec { 'pip install docker':
     path    => ['/usr/local/bin', '/usr/bin', '/bin'],
-    command => 'pip install docker',
+    command => 'pip install docker<=2.6.1',
   }
 
   package { 'docker-py':


### PR DESCRIPTION
This PR changes repo for python docker collectd plugin to fetch from alphagov, as this includes a patch that makes it more compatible with the python docker library. It also specifies versions in `collectd::plugin::docker` to avoid installing the latest versions, which may not be compatible.