### PR TITLE
Remove signon from AWS staging

### DIFF
--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -25,7 +25,6 @@ node_class: &node_class
       - kibana
       - link-checker-api
       - local-links-manager
-      - signon
       - support
       - support-api
       - support_api_csv_env_sync


### PR DESCRIPTION
- The migration team has used signon in AWS migration for testing but
are not anymore.
- We see the service flapping as it is not fully configured at the
moment.

solo: @schmie