### PR TITLE
Use absolute URIs for Location headers

### DIFF
--- a/modules/varnish/templates/default.vcl.erb
+++ b/modules/varnish/templates/default.vcl.erb
@@ -35,7 +35,7 @@ sub vcl_recv {
   # vcl_error completes the redirect
   # Don't redirect "/" to "".
   if (req.url ~ "(.+)/$") {
-    set req.http.x-Redir-Url = regsub(req.url, "^(.+)/$", "\1");
+    set req.http.x-Redir-Url = "//" + req.http.host + regsub(req.url, "^(.+)/$", "\1");
     error 667 req.http.x-Redir-Url;
   }
 
@@ -43,7 +43,7 @@ sub vcl_recv {
   # Ignores URLs with query strings
   # vcl_error completes the redirect
   if (req.url ~ "^[^?]+\.$") {
-    set req.http.x-Redir-Url = regsub(req.url, "^(.*)\.$", "\1");
+    set req.http.x-Redir-Url = "//" + req.http.host + regsub(req.url, "^(.*)\.$", "\1");
     error 667 req.http.x-Redir-Url;
   }
 


### PR DESCRIPTION
We're now conforming with RFC 2616 section 14.30

https://tools.ietf.org/html/rfc2616#section-14.30