### PR TITLE
Disable pull_content_store_daily_job #2

### DIFF
--- a/hieradata_aws/class/integration/mongo.yaml
+++ b/hieradata_aws/class/integration/mongo.yaml
@@ -1,6 +1,6 @@
 govuk_env_sync::tasks:
   "pull_content_store_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "4" 
     minute: "16"
     action: "pull"


### PR DESCRIPTION
This PR once again disables the `content_store_daily_job` as we prepare to ingest another large batch of unpublished data into integration.