### PR TITLE
Trello-2029: Enable Cache Clearing for AWS Production

### DIFF
--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -18,6 +18,7 @@ node_class: &node_class
   backend:
     apps:
       - asset-manager
+      - cache-clearing-service
       - canary-backend
       - transition
       - imminence


### PR DESCRIPTION
The cache clearing service needs to be enabled for AWS production.
As I understand this will be required as part of the migration of the
frontends to AWS.

@ronocg <conor.glynn@digital.cabinet-office.gov.uk>