### PR TITLE
[DO NOT MERGE] Switch applications to use search-api

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -52,8 +52,7 @@ govuk::apps::url_arbiter::db::backend_ip_range: '10.1.3.0/24'
 govuk::apps::whitehall::basic_auth_credentials: "%{hiera('http_username')}:%{hiera('http_password')}"
 govuk::apps::whitehall::highlight_words_to_avoid: true
 
-govuk_search::gor::replay_target_hosts:
-  - 'http://localhost:3233'
+govuk_search::gor::port: 3233
 govuk_search::monitoring::es_port: '80'
 govuk_search::monitoring::es_host: 'elasticsearch5.blue.integration.govuk-internal.digital'
 

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -57,6 +57,14 @@ govuk_search::gor::replay_target_hosts:
 govuk_search::monitoring::es_port: '80'
 govuk_search::monitoring::es_host: 'elasticsearch5.blue.integration.govuk-internal.digital'
 
+govuk::apps::collections::override_search_location: 'https://search-api.integration.govuk-internal.digital'
+govuk::apps::content_tagger::override_search_location: 'https://search-api.integration.govuk-internal.digital'
+govuk::apps::finder_frontend::override_search_location: 'https://search-api.integration.govuk-internal.digital'
+govuk::apps::hmrc_manuals_api::override_search_location: 'https://search-api.integration.govuk-internal.digital'
+govuk::apps::licencefinder::override_search_location: 'https://search-api.integration.govuk-internal.digital'
+govuk::apps::search_admin::override_search_location: 'https://search-api.integration.govuk-internal.digital'
+govuk::apps::whitehall::override_search_location: 'https://search-api.integration.govuk-internal.digital'
+
 govuk::deploy::aws_ses_smtp_host: 'email-smtp.eu-west-1.amazonaws.com'
 govuk::deploy::config::errbit_environment_name: "integration-%{hiera('stackname')}-aws"
 govuk::deploy::config::licensify_app_domain: 'integration.publishing.service.gov.uk'

--- a/modules/govuk/manifests/apps/rummager.pp
+++ b/modules/govuk/manifests/apps/rummager.pp
@@ -242,5 +242,10 @@ class govuk::apps::rummager(
         varname => 'OAUTH_SECRET',
         value   => $oauth_secret;
     }
+
+    govuk::app::envvar { "${title}-XRAY_SAMPLE_RATE":
+      varname => 'XRAY_SAMPLE_RATE',
+      value   => '1.0',
+    }
   }
 }


### PR DESCRIPTION
We're going to switch over app-by-app, environment-by-environment, and then change the apps to refer to search-api directly.

Or alternatively we could change the apps to refer to "search" directly instead of "rummager" (which I think most of them do already) and then make "search" an alias for "search-api", which could make doing this again in the future easier.

---

[Trello card](https://trello.com/c/YFZ1i0CM/48-integration-application-switchover)