### PR TITLE
add new vhost and enable ssl on static nginx frontend

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1300,6 +1300,7 @@ router::assets_origin::asset_manager_uploaded_assets_routes:
 router::assets_origin::vhost_aliases:
   - 'assets.digital.cabinet-office.gov.uk'
   - 'assets.publishing.service.gov.uk'
+  - 'assets.production.govuk.digital'
 
 router::nginx::check_requests_warning: '@10'
 router::nginx::check_requests_critical: '@8'


### PR DESCRIPTION
# Context

The assets canary on the AWS machines is broken because:
1. the assets-origin nginx config on the cache machines misses a vhost name that fastly uses to probe whether the server/backend is working.

Note: there is no need to configure the static nginx config on the frontend AWS machines to listen to on 443 SSL because the AWS ELB will terminate this.

# Decisions
1. add the vhost server for assets-origin: assets.production.govuk.digital