### PR TITLE
Make it possible to disable rummager

### DIFF
--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -166,7 +166,7 @@ define govuk::app::config (
     }
 
     if $override_search_location {
-      govuk::app::envar {
+      govuk::app::envvar {
         "${title}-PLEK_SERVICE_SEARCH_URI":
           varname => 'PLEK_SERVICE_SEARCH_URI',
           value   => $override_search_location;

--- a/modules/govuk/manifests/apps/search_api.pp
+++ b/modules/govuk/manifests/apps/search_api.pp
@@ -76,6 +76,9 @@
 # [*oauth_secret*]
 #   The OAuth secret used to authenticate the app to GOV.UK Signon (in govuk-secrets)
 #
+# [*rummager_enable*]
+#   Whether rummager is enabled or not
+#
 class govuk::apps::search_api(
   $rabbitmq_user,
   $port = '3233',
@@ -97,13 +100,15 @@ class govuk::apps::search_api(
   $unicorn_worker_processes = undef,
   $oauth_id = undef,
   $oauth_secret = undef,
+  $rummager_enable = true,
 ) {
   $app_name = 'search-api'
 
-  # todo: uncomment this when rummager is removed (as it conflicts)
-  # package { ['aspell', 'aspell-en', 'libaspell-dev']:
-  #   ensure => $spelling_dependencies,
-  # }
+  if ! $rummager_enable {
+    package { ['aspell', 'aspell-en', 'libaspell-dev']:
+      ensure => $spelling_dependencies,
+    }
+  }
 
   govuk::app { 'search-api':
     app_type                 => 'rack',


### PR DESCRIPTION
This PR fixes an issue with re-targeting apps to search-api and makes it possible to remove rummager entirely.

Apps can be re-targeted like so:

```
govuk::apps::collections::override_search_location: 'https://search-api.integration.govuk-internal.digital'
govuk::apps::content_tagger::override_search_location: 'https://search-api.integration.govuk-internal.digital'
govuk::apps::finder_frontend::override_search_location: 'https://search-api.integration.govuk-internal.digital'
govuk::apps::hmrc_manuals_api::override_search_location: 'https://search-api.integration.govuk-internal.digital'
govuk::apps::licencefinder::override_search_location: 'https://search-api.integration.govuk-internal.digital'
govuk::apps::search_admin::override_search_location: 'https://search-api.integration.govuk-internal.digital'
govuk::apps::whitehall::override_search_location: 'https://search-api.integration.govuk-internal.digital'
```

Then rummager can be disabled like so:

```
govuk::apps::rummager::enable_rummager: false
govuk::apps::rummager::enable_procfile_worker: false
govuk::apps::rummager::enable_govuk_index_listener: false
govuk::apps::rummager::enable_bulk_reindex_listener: false
govuk::apps::rummager::enable_publishing_listener: false
govuk::apps::rummager::rabbitmq::enable_govuk_index_listener: false
govuk::apps::rummager::rabbitmq::enable_publishing_listener: false
govuk::apps::rummager::rabbitmq::enable_bulk_reindex_listener: false
govuk::apps::search_api::enable_rummager: false
```

If rummager is re-enabled again (which is just removing that hiera), then it needs to be re-deployed.

---

[Trello card](https://trello.com/c/tDgQG8cX/61-make-it-possible-to-remove-rummager)