### PR TITLE
Include old spatial harvesters in CKAN

### DIFF
--- a/modules/govuk/templates/ckan/ckan.ini.erb
+++ b/modules/govuk/templates/ckan/ckan.ini.erb
@@ -90,7 +90,7 @@ ckan.cors.origin_allow_all = true
 #       Add ``datapusher`` to enable DataPusher
 #       Add ``resource_proxy`` to enable resorce proxying and get around the
 #       same origin policy
-ckan.plugins = datagovuk_publisher_form datagovuk datagovsg_s3_resources dcat harvest ckan_harvester dcat_rdf_harvester dcat_json_harvester dcat_json_interface spatial_metadata spatial_query spatial_harvest_metadata_api csw_harvester waf_harvester doc_harvester inventory_harvester
+ckan.plugins = datagovuk_publisher_form datagovuk datagovsg_s3_resources dcat harvest ckan_harvester dcat_rdf_harvester dcat_json_harvester dcat_json_interface spatial_metadata spatial_query spatial_harvest_metadata_api csw_harvester gemini_csw_harvester waf_harvester gemini_waf_harvester doc_harvester gemini_doc_harvester inventory_harvester
 
 # These are marked as legacy harvesters
 # gemini_csw_harvester gemini_doc_harvester gemini_waf_harvester


### PR DESCRIPTION
We think we'll need to rollback to use the legacy harvesters. This enables them in CKAN.

We don't need to worry about them conflicting with the new harvesters because they use a different `type` field in the database so it's safe to run both at the same time.

[Trello Card](https://trello.com/c/Qb7SyPRK/782-investigate-rolling-back-dgu-ckan-harvester-to-previous-harvesters-to-see-if-that-helps-in-the-short-term-to-fix-the-user-report)