### PR TITLE
Change the contact_groups for some AWS machines

### DIFF
--- a/hieradata_aws/class/production/backend.yaml
+++ b/hieradata_aws/class/production/backend.yaml
@@ -7,5 +7,3 @@ icinga::client::check_pings::endpoints:
      ip: 10.3.3.254
    backdrop-lb:
      ip: 10.3.4.254
-
-icinga::client::contact_groups: 'urgent-priority'

--- a/hieradata_aws/class/production/content_store.yaml
+++ b/hieradata_aws/class/production/content_store.yaml
@@ -5,5 +5,3 @@ govuk::apps::content_store::create_default_nginx_config: true
 icinga::client::check_pings::endpoints:
    router-api:
      ip: 10.3.1.253
-
-icinga::client::contact_groups: 'urgent-priority'

--- a/hieradata_aws/class/production/draft_content_store.yaml
+++ b/hieradata_aws/class/production/draft_content_store.yaml
@@ -3,5 +3,3 @@
 icinga::client::check_pings::endpoints:
    draft-router-api:
      ip: 10.3.1.252
-
-icinga::client::contact_groups: 'urgent-priority'


### PR DESCRIPTION
Specifically the content-store and backend machines. It's unnecessary
to have this severity of alerting for these machines, as the recovery
process is entirely automated.

For the backend, content-store and draft-content-store machines,
requests are load balanced, and when a machine goes away, requests
will eventually stop being sent to it, and a new machine will be
brought up to replace it.

If anything goes wrong with these machines and it is necessary for
someone to intervene out of hours, that should be detected by alerting
on the important thing that's going wrong, e.g. too many requests with
a 5xx status reaching users.