### PR TITLE
Decrease Varnish RAM usage

### DIFF
--- a/modules/govuk/manifests/node/s_cache.pp
+++ b/modules/govuk/manifests/node/s_cache.pp
@@ -82,7 +82,7 @@ class govuk::node::s_cache (
   }
 
   # The storage size for the cache, excluding per object and static overheads
-  $varnish_storage_size_pre = floor($::memorysize_mb * 0.70 - 2048)
+  $varnish_storage_size_pre = floor($::memorysize_mb * 0.70 - 3072)
 
   # Ensure that there's some varnish storage in small environments (eg, vagrant).
   if $varnish_storage_size_pre < 100 {


### PR DESCRIPTION
This commit deceases the storage RAM limit for Varnish by 1GB to accommodate more RAM being used for `nf_conntrack` and the router.