### PR TITLE
[DO NOT MERGE] Revert nf_conntrack_max setting

### DIFF
--- a/modules/govuk/manifests/node/s_cache.pp
+++ b/modules/govuk/manifests/node/s_cache.pp
@@ -57,6 +57,7 @@ class govuk::node::s_cache (
   }
 
   govuk_harden::sysctl::conf { 'cache-nf-conntrack-limit':
+    ensure  => absent,
     content => "net.netfilter.nf_conntrack_max = 65536\n",
   }
 


### PR DESCRIPTION
This commit reverts the `nf_conntrack_max` setting to the OS default to prevent out of memory issues with other apps running on the cache machines.