### PR TITLE
remove asset manager

### DIFF
--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -17,7 +17,6 @@ node_class: &node_class
       - asset_env_sync
   backend:
     apps:
-      - asset-manager
       - cache-clearing-service
       - canary-backend
       - transition


### PR DESCRIPTION
# Context

During AWS migration of support, there was a need to add asset manager to the backend because it was this class which mounted the EBS volume. Asset manager itself is not migrated. Hence, we will remove asset manager from the backend so as to clear the icinga alerts related to asset manager not Jenkins-deployed on the backends.

support-api not longer needs this EBS volume as it uses s3 buckets: https://github.com/alphagov/support-api/pull/263


# Decisions
1. remove `asset-manager` from the list of backend apps. 