### PR TITLE
Limit the temporary rabbitmq federation to AWS prod and staging

### DIFF
--- a/modules/govuk_rabbitmq/manifests/init.pp
+++ b/modules/govuk_rabbitmq/manifests/init.pp
@@ -23,8 +23,6 @@ class govuk_rabbitmq (
       ensure   => '1.7.1',
       provider => pip,
     }
-# Temporary purging of queues not consumed during the migration to AWS
-    include govuk_rabbitmq::purge_queues
   }
 
   include '::rabbitmq'
@@ -48,11 +46,17 @@ class govuk_rabbitmq (
       ensure => present,
     }
 
+  if ($::aws_environment == 'staging') or ($::aws_environment == 'production') {
+
     # Temporary federation setup for the duration of the migration to AWS
     # Remove once the migration is over
     include govuk_rabbitmq::federate
+
+    # Temporary purging of queues not consumed during the migration to AWS
+    include govuk_rabbitmq::purge_queues
   }
 
+  }
   rabbitmq_user { 'root':
     admin    => true,
     password => $root_password,


### PR DESCRIPTION
  We want the rabbitmq federation setup to be applied only on
AWS staging and AWS production, it was applied to integration
before which breaks puppet.