### PR TITLE
Remove the CPM pull job from AWS Staging

### DIFF
--- a/hieradata_aws/class/staging/warehouse_db_admin.yaml
+++ b/hieradata_aws/class/staging/warehouse_db_admin.yaml
@@ -1,6 +1,6 @@
 govuk_env_sync::tasks:
   "pull_content_performance_manager_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "3"
     minute: "45"
     action: "pull"


### PR DESCRIPTION
The Content Performance Manager isn't currently running in AWS
Staging, and we're changing the name of the app as we migrate it. So,
to start with a clean slate, make this absent so govuk-puppet cleans
up the configuration.