### PR TITLE
Remove the CPM database from the Publishing API database machine

### DIFF
--- a/modules/govuk/manifests/node/s_publishing_api_postgresql.pp
+++ b/modules/govuk/manifests/node/s_publishing_api_postgresql.pp
@@ -15,7 +15,6 @@ class govuk::node::s_publishing_api_postgresql (
 
   include govuk_postgresql::server::standalone
   include govuk_postgresql::tuning
-  include govuk::apps::content_performance_manager::db
 
   govuk_postgresql::wal_e::backup { $title:
     aws_access_key_id                => $aws_access_key_id,


### PR DESCRIPTION
The Content Performance Manager has it's own database machine, so this
configuration looks to be unnecessary.

This probably won't actually remove the database itself, so some
manual cleanup may be required for that.