### PR TITLE
Remove a couple of inconsistent comments

### DIFF
--- a/modules/govuk/manifests/apps/content_data_admin.pp
+++ b/modules/govuk/manifests/apps/content_data_admin.pp
@@ -50,11 +50,6 @@
 # [*google_tag_manager_auth*]
 #   The identifier of an environment for Google Tag Manager
 #
-# [*read_timeout*]
-# Configure the amount of time the nginx proxy vhost will wait for the
-# backing app before it sends the client a 504. We override the default 15 seconds
-# to 60.
-#
 class govuk::apps::content_data_admin (
   $port                         = '3230',
   $enabled                      = true,

--- a/modules/govuk/manifests/apps/content_performance_manager.pp
+++ b/modules/govuk/manifests/apps/content_performance_manager.pp
@@ -74,11 +74,6 @@
 #   Redis port for Sidekiq.
 #   Default: undef
 #
-# [*read_timeout*]
-# Configure the amount of time the nginx proxy vhost will wait for
-# before it sends the client a 504. We override the default 15 seconds
-# to 60.
-#
 # [*secret_key_base*]
 #   The key for Rails to use when signing/encrypting sessions.
 #


### PR DESCRIPTION
The comments at the top of a class normally describe the
arguments. These comments don't correspond to an argument, so remove
them.