### PR TITLE
Remove 'http://' from ES5 monitoring host

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -55,7 +55,7 @@ govuk::apps::whitehall::highlight_words_to_avoid: true
 govuk_search::gor::replay_target_hosts:
   - 'http://localhost:3233'
 govuk_search::monitoring::es_port: '80'
-govuk_search::monitoring::es_host: 'http://elasticsearch5.blue.integration.govuk-internal.digital'
+govuk_search::monitoring::es_host: 'elasticsearch5.blue.integration.govuk-internal.digital'
 
 govuk::deploy::aws_ses_smtp_host: 'email-smtp.eu-west-1.amazonaws.com'
 govuk::deploy::config::errbit_environment_name: "integration-%{hiera('stackname')}-aws"


### PR DESCRIPTION
We end up with `http://http://elasticsearch5.blue.integration.govuk-internal.digital:80/_nodes/*/stats/indices,http,jvm,process,transport` in the collectd plugin at the moment