### PR TITLE
Add index for pip installation of nagios plugins

### DIFF
--- a/modules/monitoring/manifests/client.pp
+++ b/modules/monitoring/manifests/client.pp
@@ -12,9 +12,10 @@ class monitoring::client (
   include collectd::plugin::tcp
 
   package {'gds-nagios-plugins':
-    ensure   => '1.5.0',
-    provider => 'pip',
-    require  => Package['update-notifier-common'],
+    ensure          => '1.5.0',
+    provider        => 'pip',
+    require         => Package['update-notifier-common'],
+    install_options => '--index https://pypi.python.org/pypi',
   }
 
   class { 'statsd':


### PR DESCRIPTION
Pip currently uses the https://pypi.python.org/simple index to look for the gds-nagios-plugins v1.5.0 plugin. However, pip encounters SSL issue when using that index. This commit makes pip explicitly use https://pypi.python.org/pypi, which has no issues with. This a short term fix - Pip version should be updated as longer term fix for SSL certificate issues.