### PR TITLE
Fix index url install flag for nagios plugins

### DIFF
--- a/modules/monitoring/manifests/client.pp
+++ b/modules/monitoring/manifests/client.pp
@@ -15,7 +15,7 @@ class monitoring::client (
     ensure          => '1.5.0',
     provider        => 'pip',
     require         => Package['update-notifier-common'],
-    install_options => '--index https://pypi.python.org/pypi',
+    install_options => '--index-url https://pypi.python.org/pypi',
   }
 
   class { 'statsd':


### PR DESCRIPTION
This fixes the flag need by pip to specify a different index url. 

The flag is needed to fix an error whereby older versions of `pip` raise a SSL certificate exception when accessing the default index of `https://pypi.python.org/simple`. 