### PR TITLE
Remove "new" GEMINI harvesters

### DIFF
--- a/modules/govuk/templates/ckan/ckan.ini.erb
+++ b/modules/govuk/templates/ckan/ckan.ini.erb
@@ -90,7 +90,7 @@ ckan.cors.origin_allow_all = true
 #       Add ``datapusher`` to enable DataPusher
 #       Add ``resource_proxy`` to enable resorce proxying and get around the
 #       same origin policy
-ckan.plugins = datagovuk_publisher_form datagovuk datagovsg_s3_resources dcat harvest ckan_harvester dcat_rdf_harvester dcat_json_harvester dcat_json_interface spatial_metadata spatial_query spatial_harvest_metadata_api csw_harvester gemini_csw_harvester waf_harvester gemini_waf_harvester doc_harvester gemini_doc_harvester inventory_harvester
+ckan.plugins = datagovuk_publisher_form datagovuk datagovsg_s3_resources dcat harvest ckan_harvester dcat_rdf_harvester dcat_json_harvester dcat_json_interface spatial_metadata spatial_query spatial_harvest_metadata_api gemini_csw_harvester gemini_waf_harvester gemini_doc_harvester inventory_harvester
 
 # These are marked as legacy harvesters
 # gemini_csw_harvester gemini_doc_harvester gemini_waf_harvester


### PR DESCRIPTION
We don't want people to use them, and simply loading the plugins causes them to show up as options in the publisher interface.

We'll need to ensure we convert any recently created "new" ones via something like `update harvest_source set type = 'gemini-csw' where type = 'csw';`.