### PR TITLE
Use govuk_node_list to find CKAN machine

### DIFF
--- a/modules/govuk_env_sync/files/govuk_env_sync.sh
+++ b/modules/govuk_env_sync/files/govuk_env_sync.sh
@@ -370,16 +370,8 @@ function postprocess_router {
 }
 
 function postprocess_ckan {
-  ckan=$(aws ec2 describe-instances \
-    --region eu-west-1 \
-    --filter \
-    Name=instance-state-name,Values=running \
-    Name=tag:aws_stackname,Values=blue \
-    Name=tag:aws_hostname,Values=ckan-1 \
-    | jq -r '.Reservations[0]|.Instances[]|.PrivateDnsName')
-
+  ckan=$(govuk_node_list -c ckan --single-node)
   cmd="cd /var/apps/ckan && sudo -u deploy govuk_setenv ckan venv/bin/paster --plugin=ckan search-index rebuild -o -c /var/ckan/ckan.ini"
-
   ssh "$ckan" '$cmd'
 }
 


### PR DESCRIPTION
This is simpler than using a complicated `aws` command, given that `govuk_node_list` is available on the db-admin machines.

[Trello Card](https://trello.com/c/RiOpZ1qs/762-get-ckan-database-up-and-running-on-staging)