### PR TITLE
Reduce ttl on cache clearing low queue to 30 mins

### DIFF
--- a/modules/govuk/manifests/apps/cache_clearing_service/rabbitmq.pp
+++ b/modules/govuk/manifests/apps/cache_clearing_service/rabbitmq.pp
@@ -86,7 +86,7 @@ class govuk::apps::cache_clearing_service::rabbitmq (
     definition => {
       'ha-mode'      => 'all',
       'ha-sync-mode' => 'automatic',
-      'message-ttl'  => 3600000, # one hour
+      'message-ttl'  => 1800000, # 30 minutes
     },
   }
 


### PR DESCRIPTION
Since documents on GOV.UK don't have a cache header higher than 30
minutes there isn't any value in doing any cache clearing once we hit or
exceed the 30 minute mark.

It is hoped that this will also address problems with the sizes this
queue will reach.