### PR TITLE
fix icinga reboot formatting

### DIFF
--- a/modules/govuk_scripts/templates/govuk_node_list_aws.erb
+++ b/modules/govuk_scripts/templates/govuk_node_list_aws.erb
@@ -42,6 +42,31 @@ def ec2_nodes(stackname, nodeclass=None):
 
     return(hosts)
 
+def ec2_nodes_list_with_puppet_class(stackname):
+    client = boto3.client('ec2', region_name=region)
+
+    response = client.describe_instances(
+                   Filters=[
+                          {'Name': 'tag:aws_stackname', 'Values': [stackname]},
+                          {'Name': 'instance-state-name','Values': ['running']}
+                   ]
+               )
+
+    nodes = response['Reservations']
+
+    return [
+        "%s:%s" % (
+            instance['Instances'][0]['PrivateDnsName'],
+            next(
+                filter(
+                    lambda t: t['Key'] == 'aws_hostname',
+                    instance['Instances'][0]['Tags']
+                )
+            )['Value']
+        )
+        for instance in list(nodes)
+    ]
+
 def ec2_classes(stackname):
     client = boto3.client('ec2', region_name=region)
 
@@ -110,6 +135,9 @@ def main():
         for instance in instance_ids:
             hosts.append(get_hostname_by_id(instance[host_key]))
 
+    elif opts.nodes_list_with_puppet_class:
+        hosts = ec2_nodes_list_with_puppet_class(stackname)
+
     else:
         hosts = ec2_nodes(stackname)
 
@@ -151,6 +179,13 @@ parser.add_option(
     help='List the available classes',
     action='store_true',
     dest='classes',
+)
+
+parser.add_option(
+    '--with-puppet-class',
+    help='List the nodes in the format of aws_fqdn:name',
+    action='store_true',
+    dest='nodes_list_with_puppet_class',
 )
 
 if __name__ == '__main__':

--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_reboots_required
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_reboots_required
@@ -1,9 +1,33 @@
 #!/usr/bin/env ruby
 
+def create_machines_hash
+  machines_names_hash = Hash.new
+
+  `/usr/local/bin/govuk_node_list --with-puppet-class`.each_line do |machine|
+    hostname, name = machine.chomp.split(":")
+    machines_names_hash[hostname] = name
+  end
+
+  return machines_names_hash
+end
+
+def hostname_with_node_name(hostname, machines_names_hash)
+  name = machines_names_hash[hostname]
+
+  if name
+    "%s with hostname: %s" % [name, hostname]
+  else
+    hostname
+  end
+
+end
+
 all_machines = `/usr/local/bin/govuk_node_list`.split("\n")
 
 unsafe_machines = `/usr/local/bin/govuk_node_list --puppet-class govuk_safe_to_reboot::careful,govuk_safe_to_reboot::no`.split("\n")
 safe_machines = `/usr/local/bin/govuk_node_list --puppet-class govuk_safe_to_reboot::yes,govuk_safe_to_reboot::overnight`.split("\n")
+
+machines_names_hash = create_machines_hash
 
 # Safety check that we haven't added other safe to reboot options
 # that we don't account for here.
@@ -30,14 +54,16 @@ else
     puts "\n"
     puts 'These hosts need to be rebooted manually:'
     unsafe_machines.sort.each do |hostname|
-      puts "- #{hostname}"
+      hydrated_name = hostname_with_node_name(hostname, machines_names_hash)
+      puts "- #{hydrated_name}"
     end
   end
   if safe_machines.length > 0
     puts "\n"
     puts 'These hosts should reboot overnight:'
     safe_machines.sort.each do |hostname|
-      puts "- #{hostname}"
+      hydrated_name = hostname_with_node_name(hostname, machines_names_hash)
+      puts "- #{hydrated_name}"
     end
   end
   exit 1


### PR DESCRIPTION
# Context

In the AWS Icinga, there is a check for the machines that need to be reboot. The check displays a list of such machines in the format of their AWS DNS names only: 
`ip-x-x-x-x.eu-west-1.compute.internal` which does not give immediate insight which machines need to be rebooted.

The new display format will be:
<puppet_class_name> with hostname:	ip-x-x-x-x.eu-west-1.compute.internal

# Decisions
1. modify the `govuk_node_list` to have the new option/subcommand `--list` which will return a list of hosts in the format of `aws_dns_name`:`puppet_class_name`
2. make the `check_reboots_required` script to hydrate/augment the hostname with the information gathered in Step 1 so that to achieve a better list display for the icinga alert