### PR TITLE
Run CKAN data sync on CKAN machines directly

### DIFF
--- a/hieradata_aws/class/integration/ckan.yaml
+++ b/hieradata_aws/class/integration/ckan.yaml
@@ -1,16 +1,12 @@
----
-
-govuk::apps::ckan::enabled: true
-
 govuk_env_sync::tasks:
-  pull_ckan_production_daily:
+  pull_ckan_staging_daily:
     ensure: present
-    hour: '3'
+    hour: '4'
     minute: '15'
     action: pull
     dbms: postgresql
     storagebackend: 's3'
     database: ckan_production
-    temppath: /tmp/ckan_production_pull
-    url: govuk-production-database-backups
+    temppath: '/tmp/ckan_production'
+    url: govuk-staging-database-backups
     path: postgresql-backend

--- a/hieradata_aws/class/integration/ckan.yaml
+++ b/hieradata_aws/class/integration/ckan.yaml
@@ -1,3 +1,9 @@
+govuk_sudo::sudo_conf:
+  govuk-backup:
+    content: 'govuk-backup ALL=NOPASSWD:/usr/bin/psql,/usr/bin/dropdb,/usr/bin/dropuser,/usr/bin/pg_restore,/usr/bin/pg_dump'
+  env-sync-script:
+    content: 'Cmnd_Alias BACKUP=/usr/local/bin/govuk_env_sync.sh'
+
 govuk_env_sync::tasks:
   pull_ckan_staging_daily:
     ensure: present

--- a/hieradata_aws/class/staging/ckan.yaml
+++ b/hieradata_aws/class/staging/ckan.yaml
@@ -2,6 +2,12 @@
 
 govuk::apps::ckan::enabled: true
 
+govuk_sudo::sudo_conf:
+  govuk-backup:
+    content: 'govuk-backup ALL=NOPASSWD:/usr/bin/psql,/usr/bin/dropdb,/usr/bin/dropuser,/usr/bin/pg_restore,/usr/bin/pg_dump'
+  env-sync-script:
+    content: 'Cmnd_Alias BACKUP=/usr/local/bin/govuk_env_sync.sh'
+
 govuk_env_sync::tasks:
   pull_ckan_production_daily:
     ensure: present

--- a/hieradata_aws/class/staging/db_admin.yaml
+++ b/hieradata_aws/class/staging/db_admin.yaml
@@ -1,6 +1,6 @@
 govuk_env_sync::tasks:
   "pull_ckan_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "3"
     minute: "15"
     action: "pull"

--- a/modules/govuk/manifests/node/s_ckan.pp
+++ b/modules/govuk/manifests/node/s_ckan.pp
@@ -18,6 +18,7 @@ class govuk::node::s_ckan inherits govuk::node::s_base {
     both       => 1024,
   }
 
+  include govuk_env_sync
   include govuk_python
   include nginx
   include postgresql::lib::devel

--- a/modules/govuk/manifests/node/s_ckan.pp
+++ b/modules/govuk/manifests/node/s_ckan.pp
@@ -23,6 +23,7 @@ class govuk::node::s_ckan inherits govuk::node::s_base {
   include postgresql::lib::devel
   include govuk_java::openjdk7::jdk
   include govuk_solr
+  include govuk_postgresql::client
 
   package { 'libgeos-c1':
     ensure => latest,

--- a/modules/govuk_env_sync/files/govuk_env_sync.sh
+++ b/modules/govuk_env_sync/files/govuk_env_sync.sh
@@ -241,6 +241,8 @@ function restore_postgresql {
     db_hostname='postgresql-primary'
   fi
 
+  DBPASSWORD="${db_password}"
+
 # Checking if the database already exist
 # If it does we will drop the database
   DB_OWNER=''

--- a/modules/govuk_env_sync/files/govuk_env_sync.sh
+++ b/modules/govuk_env_sync/files/govuk_env_sync.sh
@@ -241,6 +241,10 @@ function restore_postgresql {
     db_hostname='postgresql-primary'
   fi
 
+  # this is used up by the psql command to try and authenticate
+  # we don't need this on db_admin machines because it authenticates using
+  # normal Unix users, but from a different machine, i.e. ckan, we need to
+  # send the password directly
   DBPASSWORD="${db_password}"
 
 # Checking if the database already exist

--- a/modules/govuk_env_sync/files/govuk_env_sync.sh
+++ b/modules/govuk_env_sync/files/govuk_env_sync.sh
@@ -372,9 +372,7 @@ function postprocess_router {
 }
 
 function postprocess_ckan {
-  ckan=$(govuk_node_list -c ckan --single-node)
-  cmd="cd /var/apps/ckan && sudo -u deploy govuk_setenv ckan venv/bin/paster --plugin=ckan search-index rebuild -o -c /var/ckan/ckan.ini"
-  ssh "$ckan" '$cmd'
+  cd /var/apps/ckan && sudo -u deploy govuk_setenv ckan venv/bin/paster --plugin=ckan search-index rebuild -o -c /var/ckan/ckan.ini
 }
 
 function postprocess_database {

--- a/modules/govuk_env_sync/manifests/init.pp
+++ b/modules/govuk_env_sync/manifests/init.pp
@@ -6,9 +6,12 @@ class govuk_env_sync(
   $user = 'govuk-backup',
   $conf_dir = '/etc/govuk_env_sync',
   $aws_region = 'eu-west-1',
+  $db_password = undef,
 ) {
 
   include govuk_env_sync::lock_file
 
-  create_resources(govuk_env_sync::task, $tasks)
+  create_resources(govuk_env_sync::task, $tasks, {
+    'db_password' => $db_password,
+  })
 }

--- a/modules/govuk_env_sync/manifests/task.pp
+++ b/modules/govuk_env_sync/manifests/task.pp
@@ -1,6 +1,6 @@
 # == Custom resource type: govuk_env_sync::task
 #
-# Creates a configuration file and cron-job, parameterising the govuk_env_sync.sh 
+# Creates a configuration file and cron-job, parameterising the govuk_env_sync.sh
 # from data provided in hieradata govuk_env_sync::tasks:
 #
 # [*hour*]
@@ -45,6 +45,7 @@ define govuk_env_sync::task(
   $database,
   $url,
   $path,
+  $db_password = undef,
   $ensure = 'present',
 ) {
 

--- a/modules/govuk_env_sync/templates/govuk_env_sync_job.conf.erb
+++ b/modules/govuk_env_sync/templates/govuk_env_sync_job.conf.erb
@@ -5,3 +5,7 @@ temppath="<%= @temppath %>"
 database="<%= @database %>"
 url="<%= @url %>"
 path="<%= @path %>"
+
+<% if @db_password %>
+db_password="<%= @db_password %>"
+<% end %>


### PR DESCRIPTION
We need to do this because it's not possible to SSH into the `ckan` machines from the `db_admin` machine. This also refactors the script to allow the database password to be set directly which will be configured in govuk-secrets, we need to do this because we can no longer rely on PostgreSQL authenticating the user from normal Unix user permissions as it was doing before on `db_admin`.

[Trello Card](https://trello.com/c/RiOpZ1qs/762-get-ckan-database-up-and-running-on-staging)