### PR TITLE
Add Puppet configuration for the Content Data API

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -22,6 +22,7 @@ node_class: &node_class
       - contacts
       - content-audit-tool
       - content-data-admin
+      - content-data-api
       - content-performance-manager
       - content-publisher
       - content-tagger
@@ -155,6 +156,8 @@ deployable_applications: &deployable_applications
     repository: 'contacts-admin'
   content-audit-tool: {}
   content-data-admin: {}
+  content-data-api:
+    repository: 'content-performance-manager'
   content-performance-manager: {}
   content-publisher: {}
   content-store: {}

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -645,6 +645,7 @@ hosts::backend_migration::hosts:
       - contacts-admin.publishing.service.gov.uk
       - content-audit-tool.publishing.service.gov.uk
       - content-data-admin.publishing.service.gov.uk
+      - content-data-api.publishing.service.gov.uk
       - content-performance-manager.publishing.service.gov.uk
       - content-publisher.publishing.service.gov.uk
       - content-tagger.publishing.service.gov.uk

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -410,6 +410,7 @@ hosts::backend_migration::hosts:
       - contacts-admin.staging.publishing.service.gov.uk
       - content-audit-tool.staging.publishing.service.gov.uk
       - content-data-admin.staging.publishing.service.gov.uk
+      - content-data-api.staging.publishing.service.gov.uk
       - content-performance-manager.staging.publishing.service.gov.uk
       - content-publisher.staging.publishing.service.gov.uk
       - content-tagger.staging.publishing.service.gov.uk

--- a/modules/govuk/manifests/apps/content_data_api.pp
+++ b/modules/govuk/manifests/apps/content_data_api.pp
@@ -1,0 +1,213 @@
+# == Class: govuk::apps::content_data_api
+#
+# App details at: https://github.com/alphagov/content-performance-manager
+#
+# === Parameters
+#
+# [*db_hostname*]
+#   The hostname of the database server to use in the DATABASE_URL.
+#   Default: undef
+#
+# [*db_name*]
+#   The database name to use in the DATABASE_URL.
+#
+# [*db_password*]
+#   The password for the database.
+#   Default: undef
+#
+# [*db_username*]
+#   The username to use in the DATABASE_URL.
+#
+# [*etl_healthcheck_enabled*]
+#   Enables or disables the ETL checks via the healthcheck endpoint
+#   Default: false
+#
+# [*etl_healthcheck_enabled_from_hour*]
+#   The hour of the day where ETL healthcheck alerts are enabled
+#   Default: undef
+#
+# [*google_analytics_govuk_view_id*]
+#   The view id of GOV.UK in Google Analytics
+#   Default: undef
+#
+# [*google_client_email*]
+#   Google authentication email
+#   Default: undef
+#
+# [*google_private_key*]
+#   Google authentication private key
+#   Default: undef
+#
+# [*oauth_id*]
+#   Sets the OAuth ID for using GDS-SSO
+#   Default: undef
+#
+# [*oauth_secret*]
+#   Sets the OAuth Secret Key for using GDS-SSO
+#   Default: undef
+#
+# [*port*]
+#   The port that it is served on.
+#   Default: 3206
+#
+# [*publishing_api_bearer_token*]
+#   The bearer token to use when communicating with Publishing API.
+#   Default: undef
+#
+# [*rabbitmq_hosts*]
+#   RabbitMQ hosts to connect to.
+#   Default: localhost
+#
+# [*rabbitmq_user*]
+#   RabbitMQ username.
+#   This is a required parameter
+#
+# [*rabbitmq_password*]
+#   RabbitMQ password.
+#   This is a required parameter
+#
+# [*redis_host*]
+#   Redis host for Sidekiq.
+#   Default: undef
+#
+# [*redis_port*]
+#   Redis port for Sidekiq.
+#   Default: undef
+#
+# [*secret_key_base*]
+#   The key for Rails to use when signing/encrypting sessions.
+#
+# [*sentry_dsn*]
+#   The URL used by Sentry to report exceptions
+#
+# [*support_api_bearer_token*]
+#   The bearer token that will be used to authenticate with support-api
+#
+class govuk::apps::content_data_api(
+  $db_hostname = undef,
+  $db_name = 'content_data_api_production',
+  $db_password = undef,
+  $db_username = 'content_data_api',
+  $enable_procfile_worker = true,
+  $etl_healthcheck_enabled = false,
+  $etl_healthcheck_enabled_from_hour = undef,
+  $google_analytics_govuk_view_id = undef,
+  $google_client_email = undef,
+  $google_private_key = undef,
+  $oauth_id = undef,
+  $oauth_secret = undef,
+  $port = '3206',
+  $publishing_api_bearer_token = undef,
+  $rabbitmq_hosts = ['localhost'],
+  $rabbitmq_vhost = '/',
+  $rabbitmq_password = undef,
+  $rabbitmq_user = undef,
+  $redis_host = undef,
+  $redis_port = undef,
+  $secret_key_base = undef,
+  $sentry_dsn = undef,
+  $support_api_bearer_token = undef,
+) {
+  $app_name = 'content-data-api'
+
+  govuk::app { $app_name:
+    app_type          => 'rack',
+    port              => $port,
+    sentry_dsn        => $sentry_dsn,
+    health_check_path => '/healthcheck',
+    json_health_check => true,
+    asset_pipeline    => true,
+    read_timeout      => 60,
+  }
+
+  Govuk::App::Envvar {
+    app    => $app_name,
+  }
+
+  govuk::procfile::worker { "${app_name}-default-worker":
+    enable_service => $enable_procfile_worker,
+    setenv_as      => $app_name,
+    process_type   => 'default-worker',
+  }
+
+  govuk::procfile::worker { "${app_name}-publishing-api-consumer":
+    enable_service => $enable_procfile_worker,
+    setenv_as      => $app_name,
+    process_type   => 'publishing-api-consumer',
+  }
+
+  govuk::procfile::worker { 'content-data-api-bulk-import-publishing-api-consumer':
+    enable_service => $enable_procfile_worker,
+    setenv_as      => $app_name,
+    process_type   => 'bulk-import-publishing-api-consumer',
+  }
+
+  govuk::app::envvar {
+    "${title}-GOOGLE_ANALYTICS_GOVUK_VIEW_ID":
+      varname => 'GOOGLE_ANALYTICS_GOVUK_VIEW_ID',
+      value   => $google_analytics_govuk_view_id;
+    "${title}-GOOGLE_PRIVATE_KEY":
+      varname => 'GOOGLE_PRIVATE_KEY',
+      value   => $google_private_key;
+    "${title}-GOOGLE_CLIENT_EMAIL":
+      varname => 'GOOGLE_CLIENT_EMAIL',
+      value   => $google_client_email;
+    "${title}-OAUTH_ID":
+      varname => 'OAUTH_ID',
+      value   => $oauth_id;
+    "${title}-OAUTH_SECRET":
+      varname => 'OAUTH_SECRET',
+      value   => $oauth_secret;
+    "${title}-PUBLISHING_API_BEARER_TOKEN":
+      varname => 'PUBLISHING_API_BEARER_TOKEN',
+      value   => $publishing_api_bearer_token;
+    "${title}-RABBITMQ_HOSTS":
+      varname => 'RABBITMQ_HOSTS',
+      value   => join($rabbitmq_hosts, ',');
+    "${title}-RABBITMQ_VHOST":
+      varname => 'RABBITMQ_VHOST',
+      value   => $rabbitmq_vhost;
+    "${title}-RABBITMQ_USER":
+      varname => 'RABBITMQ_USER',
+      value   => $rabbitmq_user;
+    "${title}-RABBITMQ_PASSWORD":
+      varname => 'RABBITMQ_PASSWORD',
+      value   => $rabbitmq_password;
+    "${title}-SUPPORT_API_BEARER_TOKEN":
+      varname => 'SUPPORT_API_BEARER_TOKEN',
+      value   => $support_api_bearer_token;
+  }
+
+  if $etl_healthcheck_enabled {
+    govuk::app::envvar {
+      "${title}-ETL_HEALTHCHECK_ENABLED":
+        varname => 'ETL_HEALTHCHECK_ENABLED',
+        value   => '1';
+      "${title}-ETL_HEALTHCHECK_ENABLED_FROM_HOUR":
+        varname => 'ETL_HEALTHCHECK_ENABLED_FROM_HOUR',
+        value   => $etl_healthcheck_enabled_from_hour;
+    }
+  }
+
+  govuk::app::envvar::redis { $app_name:
+    host => $redis_host,
+    port => $redis_port,
+  }
+
+  if $secret_key_base != undef {
+    govuk::app::envvar { "${title}-SECRET_KEY_BASE":
+      varname => 'SECRET_KEY_BASE',
+      value   => $secret_key_base,
+    }
+  }
+
+  if $::govuk_node_class !~ /^development$/ {
+    govuk::app::envvar::database_url { $app_name:
+      type     => 'postgresql',
+      username => $db_username,
+      password => $db_password,
+      host     => $db_hostname,
+      database => $db_name,
+    }
+  }
+}

--- a/modules/govuk/manifests/apps/content_data_api/db.pp
+++ b/modules/govuk/manifests/apps/content_data_api/db.pp
@@ -1,0 +1,25 @@
+# == Class: govuk::apps::content_data_api::db
+#
+# === Parameters
+#
+# [*password*]
+#   The DB instance password.
+#
+# [*backend_ip_range*]
+#   Backend IP addresses to allow access to the database.
+#
+class govuk::apps::content_data_api::db (
+  $password,
+  $backend_ip_range = undef,
+  $rds = false,
+) {
+  govuk_postgresql::db { 'content_performance_manager_production':
+    user                    => 'content_performance_manager',
+    password                => $password,
+    allow_auth_from_backend => true,
+    backend_ip_range        => $backend_ip_range,
+    rds                     => $rds,
+    extensions              => ['plpgsql'],
+    enable_in_pgbouncer     => false,
+  }
+}

--- a/modules/govuk/manifests/apps/content_data_api/rabbitmq.pp
+++ b/modules/govuk/manifests/apps/content_data_api/rabbitmq.pp
@@ -1,0 +1,100 @@
+# == Class: govuk::apps::content_data_api::rabbitmq
+#
+# Permissions for the Content Data API to read messages from the
+# published_documents AMQP exchange.
+#
+# This sets up the user, and permits read/write/configure
+# to the queue, and read-only to the exchange.
+#
+# === Parameters
+#
+# [*amqp_user*]
+#   The RabbitMQ username (default: 'content_data_api')
+#
+# [*amqp_pass*]
+#   The RabbitMQ password. This is a required parameter.
+#
+# [*amqp_exchange*]
+#   The RabbitMQ exchange to read from (default: 'published_documents')
+#
+# [*amqp_queue*]
+#   The RabbitMQ queue to set up for workers of this type to read from
+#   (default: 'content_data_api')
+#
+# [*amqp_bulk_importing_queue]
+#   The RabbitMQ queue to set up for workers of this type to read from
+#   for bulk importer of content into the Content Data API
+#   (default: 'content_data_api_govuk_importer')
+#
+class govuk::apps::content_data_api::rabbitmq (
+  $amqp_user  = 'content_data_api',
+  $amqp_pass = undef,
+  $amqp_exchange = 'published_documents',
+  $amqp_queue = 'content_data_api',
+  $amqp_bulk_importing_queue = 'content_data_api_govuk_importer'
+) {
+
+  govuk_rabbitmq::queue_with_binding { $amqp_queue:
+    ensure        => 'present',
+    amqp_exchange => $amqp_exchange,
+    amqp_queue    => $amqp_queue,
+    routing_key   => '*.major',
+    durable       => true,
+  }
+
+  rabbitmq_binding { "binding_minor_${amqp_exchange}@${amqp_queue}@/":
+    ensure           => 'present',
+    name             => "${amqp_exchange}@${amqp_queue}@minor@/",
+    user             => 'root',
+    password         => $::govuk_rabbitmq::root_password,
+    destination_type => 'queue',
+    routing_key      => '*.minor',
+    arguments        => {},
+  }
+
+  rabbitmq_binding { "binding_links_${amqp_exchange}@${amqp_queue}@/":
+    ensure           => 'present',
+    name             => "${amqp_exchange}@${amqp_queue}@links@/",
+    user             => 'root',
+    password         => $::govuk_rabbitmq::root_password,
+    destination_type => 'queue',
+    routing_key      => '*.links',
+    arguments        => {},
+  }
+
+  rabbitmq_binding { "binding_republish_${amqp_exchange}@${amqp_queue}@/":
+    ensure           => 'present',
+    name             => "${amqp_exchange}@${amqp_queue}@republish@/",
+    user             => 'root',
+    password         => $::govuk_rabbitmq::root_password,
+    destination_type => 'queue',
+    routing_key      => '*.republish',
+    arguments        => {},
+  }
+
+  rabbitmq_binding { "binding_unpublish_${amqp_exchange}@${amqp_queue}@/":
+    ensure           => 'present',
+    name             => "${amqp_exchange}@${amqp_queue}@unpublish@/",
+    user             => 'root',
+    password         => $::govuk_rabbitmq::root_password,
+    destination_type => 'queue',
+    routing_key      => '*.unpublish',
+    arguments        => {},
+  }
+
+  govuk_rabbitmq::queue_with_binding { $amqp_bulk_importing_queue:
+    ensure        => 'present',
+    amqp_exchange => $amqp_exchange,
+    amqp_queue    => $amqp_bulk_importing_queue,
+    routing_key   => '*.bulk.data-warehouse',
+    durable       => true,
+  }
+
+  govuk_rabbitmq::consumer { $amqp_user:
+    ensure               => 'present',
+    amqp_pass            => $amqp_pass,
+    read_permission      => "^${amqp_queue}|${amqp_bulk_importing_queue}\$",
+    write_permission     => "^\$",
+    configure_permission => "^\$",
+  }
+}

--- a/modules/govuk/manifests/node/s_backend_lb.pp
+++ b/modules/govuk/manifests/node/s_backend_lb.pp
@@ -62,6 +62,7 @@ class govuk::node::s_backend_lb (
     'contacts-admin',
     'content-audit-tool',
     'content-data-admin',
+    'content-data-api',
     'content-performance-manager',
     'content-publisher',
     'content-tagger',

--- a/modules/govuk_jenkins/templates/jobs/content_data_api.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/content_data_api.yaml.erb
@@ -1,0 +1,40 @@
+---
+- job:
+    name: content_data_api_import_etl_master_process
+    display-name: Content Data API - ETL master
+    project-type: freestyle
+    description: "<p>Run the etl:master rake task.</p>"
+    builders:
+      - trigger-builds:
+          - project: run-rake-task
+            block: true
+            predefined-parameters: |
+              TARGET_APPLICATION=content-data-api
+              MACHINE_CLASS=backend
+              RAKE_TASK=etl:master
+    wrappers:
+      - ansicolor:
+          colormap: xterm
+    publishers:
+      - email:
+          recipients: govuk-ci-notifications@digital.cabinet-office.gov.uk
+  <% if @rake_etl_master_process_cron_schedule %>
+    triggers:
+      - timed: <%= @rake_etl_master_process_cron_schedule %>
+  <% end %>
+    logrotate:
+        numToKeep: 10
+    publishers:
+      - trigger-parameterized-builds:
+          - project: Success_Passive_Check
+            condition: 'SUCCESS'
+            predefined-parameters: |
+                NSCA_CHECK_DESCRIPTION=<%= @service_description %>
+                NSCA_OUTPUT=<%= @service_description %> success
+          - project: Failure_Passive_Check
+            condition: 'FAILED'
+            predefined-parameters: |
+                NSCA_CHECK_DESCRIPTION=<%= @service_description %>
+                NSCA_OUTPUT=<%= @service_description %> failed
+                NSCA_CODE=2
+


### PR DESCRIPTION
The Content Performance Manager application is being renamed to the
Content Data API to better reflect it's current function.

The Puppet configuration added in this commit relates to the new
configuration for the Content Data API. It's basically a copy of the
Content Performance Manager configuration.

Once the migration from the Content Performance Manager to the Content
Data API has been completed, the Content Performance Manager
configuration can be removed.