### PR TITLE
Use exec for installing nagios-plugin

### DIFF
--- a/modules/monitoring/manifests/client.pp
+++ b/modules/monitoring/manifests/client.pp
@@ -11,11 +11,10 @@ class monitoring::client (
   include collectd
   include collectd::plugin::tcp
 
-  package {'gds-nagios-plugins':
-    ensure          => '1.5.0',
-    provider        => 'pip',
-    require         => Package['update-notifier-common'],
-    install_options => '--index-url https://pypi.python.org/pypi',
+  exec { 'gds-nagios-plugins':
+    path    => ['/usr/local/bin', '/usr/bin', '/bin'],
+    command => 'pip install setuptools-pep8 gds-nagios-plugins==1.5.0 --index-url https://pypi.python.org/pypi',
+    require => Package['update-notifier-common'],
   }
 
   class { 'statsd':


### PR DESCRIPTION
Due to issues with older versions of pip, we need to specify the `--index-url` flag. However, because we are running an older version of puppet (v3) - it doesn't support the use of flags via the `install_options`. Hence to overcome this we have specified the install task as an exec command. 

There is also a requirement for `setuptools-pep8` to install `gds-nagios-plugins`.