### PR TITLE
etcd should be switched to internal dns name

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1353,7 +1353,7 @@ unattended_reboot::cron_env_vars:
   - 'MAILTO=""'
 unattended_reboot::cron_hour: '0-5'
 unattended_reboot::etcd_endpoints:
-  - "http://etcd.%{hiera('app_domain')}:2379"
+  - "http://etcd.%{hiera('app_domain_internal')}:2379"
 
 unattended_upgrades::blacklist:
  - 'mysql-server.*'


### PR DESCRIPTION
# Context

In AWS environments, the etcd cluster is in the internal DNS domain and not the public one. Hence the hiera needs to be configured to correct this. The etcd cluster is needed to for the reboot as the mutex lock is coordinated there.

# Decisions
1. change the etcd address to its correct internal address.