### PR TITLE
Revert "etcd should be switched to internal dns name"

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1353,7 +1353,7 @@ unattended_reboot::cron_env_vars:
   - 'MAILTO=""'
 unattended_reboot::cron_hour: '0-5'
 unattended_reboot::etcd_endpoints:
-  - "http://etcd.%{hiera('app_domain_internal')}:2379"
+  - "http://etcd.%{hiera('app_domain')}:2379"
 
 unattended_upgrades::blacklist:
  - 'mysql-server.*'


### PR DESCRIPTION
**We need to revert this because the automated reboot was tested in AWS Staging and it killed a node.**

Will re-apply after further investigations

Reverts alphagov/govuk-puppet#8741