### PR TITLE
Switch licence-finder to use managed elasticsearch in AWS

### DIFF
--- a/modules/govuk/manifests/apps/licencefinder.pp
+++ b/modules/govuk/manifests/apps/licencefinder.pp
@@ -74,18 +74,10 @@ class govuk::apps::licencefinder(
   }
 
   if $::aws_migration  {
-    if ($::aws_environment == 'integration') {
-      govuk::app::envvar { "${title}-ELASTICSEARCH_URI":
-        app     => $app_name,
-        varname => 'ELASTICSEARCH_URI',
-        value   => 'http://rummager-elasticsearch:9200',
-      }
-    } else {
-      govuk::app::envvar { "${title}-ELASTICSEARCH_URI":
-        app     => $app_name,
-        varname => 'ELASTICSEARCH_URI',
-        value   => 'http://localhost:9200',
-      }
+    govuk::app::envvar { "${title}-ELASTICSEARCH_URI":
+      app     => $app_name,
+      varname => 'ELASTICSEARCH_URI',
+      value   => 'http://elasticsearch5',
     }
   }
 }


### PR DESCRIPTION
We can't make licence-finder es5 compatible (https://github.com/alphagov/licence-finder/pull/450) until requests to `/licence-finder` are being routed to AWS (ie, the frontend migration is complete), as the PR which achieves that breaks elasticsearch2 compatibility (and so blocks deploys to Carrenza).

---

licence-finder uses elasticsearch for its list of sectors.  These will
have to be reindexed, but it's a very small amount of dataand
completes quickly.

The frontend migration isn't complete yet, so this brief downtime
won't be visible in production anyway.

---

[Trello card](https://trello.com/c/dAA0IygI/28-make-licence-finder-able-to-use-es5)