### PR TITLE
remove asset manager from AWS production to match AWS Staging

### DIFF
--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -17,7 +17,6 @@ node_class: &node_class
       - asset_env_sync
   backend:
     apps:
-      - asset-manager
       - cache-clearing-service
       - canary-backend
       - transition


### PR DESCRIPTION
# Context

Remove asset-manager from AWS production as documented for AWS staging: https://github.com/alphagov/govuk-puppet/pull/8716