### PR TITLE
Disable metadata tagger

### DIFF
--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -45,7 +45,6 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::record_superfluous_taggings_metrics
   - govuk_jenkins::jobs::remove_emergency_banner
   - govuk_jenkins::jobs::run_rake_task
-  - govuk_jenkins::jobs::run_metadata_tagger
   - govuk_jenkins::jobs::run_whitehall_data_migrations
   - govuk_jenkins::jobs::scrape_icinga_alerts_for_dashboard_metrics
   - govuk_jenkins::jobs::search_benchmark

--- a/hieradata/class/staging/jenkins.yaml
+++ b/hieradata/class/staging/jenkins.yaml
@@ -29,7 +29,6 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::record_taxonomy_metrics
   - govuk_jenkins::jobs::remove_emergency_banner
   - govuk_jenkins::jobs::run_rake_task
-  - govuk_jenkins::jobs::run_metadata_tagger
   - govuk_jenkins::jobs::run_whitehall_data_migrations
   - govuk_jenkins::jobs::scrape_icinga_alerts_for_dashboard_metrics
   - govuk_jenkins::jobs::search_fetch_analytics_data

--- a/hieradata/vagrant.yaml
+++ b/hieradata/vagrant.yaml
@@ -115,7 +115,6 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::network_config_deploy
   - govuk_jenkins::jobs::passive_checks
   - govuk_jenkins::jobs::publish_special_routes
-  - govuk_jenkins::jobs::run_metadata_tagger
   - govuk_jenkins::jobs::run_whitehall_data_migrations
   - govuk_jenkins::jobs::smokey
   - govuk_jenkins::jobs::smokey_deploy

--- a/hieradata_aws/class/integration/jenkins.yaml
+++ b/hieradata_aws/class/integration/jenkins.yaml
@@ -31,7 +31,6 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::remove_emergency_banner
   - govuk_jenkins::jobs::run_deploy_lag_badger
   - govuk_jenkins::jobs::run_rake_task
-  - govuk_jenkins::jobs::run_metadata_tagger
   - govuk_jenkins::jobs::run_whitehall_data_migrations
   - govuk_jenkins::jobs::scrape_icinga_alerts_for_dashboard_metrics
   - govuk_jenkins::jobs::search_benchmark


### PR DESCRIPTION
https://trello.com/c/1JHAXTgd/185-investigate-lack-of-tagging-email-alerts

Emails are now sent when tagging new content to the EU Exit finder,
there's an issue where items which disappear from the Rummager index
get treated as new content and cause repeated emails to be sent.
Disable this job while we investigate.