### PR TITLE
Set up (non-data-sync) Jenkins jobs for Search API

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -286,6 +286,8 @@ task :check_consistency_between_aws_and_carrenza do
     govuk_cdnlogs::warning_cdn_freshness
     govuk_elasticsearch::dump::run_es_dump_hour
     govuk_jenkins::jobs::data_sync_complete_production::signon_domains_to_migrate
+    govuk_jenkins::jobs::search_api_fetch_analytics_data_search::cron_schedule
+    govuk_jenkins::jobs::search_api_fetch_analytics_data_search::skip_page_traffic_load
     govuk_jenkins::jobs::search_fetch_analytics_data::cron_schedule
     govuk_jenkins::jobs::search_fetch_analytics_data::skip_page_traffic_load
     govuk_jenkins::jobs::smokey::environment

--- a/hieradata_aws/class/integration/jenkins.yaml
+++ b/hieradata_aws/class/integration/jenkins.yaml
@@ -40,6 +40,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::search_api_index_checks
   - govuk_jenkins::jobs::search_index_checks
   - govuk_jenkins::jobs::search_reindex_with_new_schema
+  - govuk_jenkins::jobs::search_api_reindex_with_new_schema
   - govuk_jenkins::jobs::search_test_spelling_suggestions
   - govuk_jenkins::jobs::send_bulk_email
   - govuk_jenkins::jobs::signon_cron_rake_tasks

--- a/hieradata_aws/class/integration/jenkins.yaml
+++ b/hieradata_aws/class/integration/jenkins.yaml
@@ -37,6 +37,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::search_benchmark
   - govuk_jenkins::jobs::search_api_fetch_analytics_data
   - govuk_jenkins::jobs::search_fetch_analytics_data
+  - govuk_jenkins::jobs::search_api_index_checks
   - govuk_jenkins::jobs::search_index_checks
   - govuk_jenkins::jobs::search_reindex_with_new_schema
   - govuk_jenkins::jobs::search_test_spelling_suggestions

--- a/hieradata_aws/class/integration/jenkins.yaml
+++ b/hieradata_aws/class/integration/jenkins.yaml
@@ -35,6 +35,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::run_whitehall_data_migrations
   - govuk_jenkins::jobs::scrape_icinga_alerts_for_dashboard_metrics
   - govuk_jenkins::jobs::search_benchmark
+  - govuk_jenkins::jobs::search_api_fetch_analytics_data
   - govuk_jenkins::jobs::search_fetch_analytics_data
   - govuk_jenkins::jobs::search_index_checks
   - govuk_jenkins::jobs::search_reindex_with_new_schema

--- a/hieradata_aws/class/integration/jenkins.yaml
+++ b/hieradata_aws/class/integration/jenkins.yaml
@@ -20,6 +20,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::deploy_puppet
   - govuk_jenkins::jobs::deploy_router_data
   - govuk_jenkins::jobs::enhanced_ecommerce
+  - govuk_jenkins::jobs::enhanced_ecommerce_search_api
   - govuk_jenkins::jobs::extract_app_performance
   - govuk_jenkins::jobs::govuk_content_api_docs
   - govuk_jenkins::jobs::govuk_taxonomy_supervised_learning

--- a/hieradata_aws/class/production/jenkins.yaml
+++ b/hieradata_aws/class/production/jenkins.yaml
@@ -16,6 +16,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::search_api_fetch_analytics_data_search
   - govuk_jenkins::jobs::search_fetch_analytics_data_search_api
   - govuk_jenkins::jobs::search_api_index_checks
+  - govuk_jenkins::jobs::search_api_reindex_with_new_schema
   - govuk_jenkins::jobs::smokey
   - govuk_jenkins::jobs::smokey_deploy
   - govuk_jenkins::jobs::transition_load_all_data

--- a/hieradata_aws/class/production/jenkins.yaml
+++ b/hieradata_aws/class/production/jenkins.yaml
@@ -9,6 +9,7 @@ govuk_jenkins::config::theme_environment_name: 'AWS Production'
 govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::deploy_app
   - govuk_jenkins::jobs::deploy_puppet
+  - govuk_jenkins::jobs::enhanced_ecommerce_search_api
   - govuk_jenkins::jobs::passive_checks
   - govuk_jenkins::jobs::publish_special_routes
   - govuk_jenkins::jobs::run_rake_task

--- a/hieradata_aws/class/production/jenkins.yaml
+++ b/hieradata_aws/class/production/jenkins.yaml
@@ -15,6 +15,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::run_rake_task
   - govuk_jenkins::jobs::search_api_fetch_analytics_data_search
   - govuk_jenkins::jobs::search_fetch_analytics_data_search_api
+  - govuk_jenkins::jobs::search_api_index_checks
   - govuk_jenkins::jobs::smokey
   - govuk_jenkins::jobs::smokey_deploy
   - govuk_jenkins::jobs::transition_load_all_data

--- a/hieradata_aws/class/production/jenkins.yaml
+++ b/hieradata_aws/class/production/jenkins.yaml
@@ -13,6 +13,8 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::passive_checks
   - govuk_jenkins::jobs::publish_special_routes
   - govuk_jenkins::jobs::run_rake_task
+  - govuk_jenkins::jobs::search_api_fetch_analytics_data_search
+  - govuk_jenkins::jobs::search_fetch_analytics_data_search_api
   - govuk_jenkins::jobs::smokey
   - govuk_jenkins::jobs::smokey_deploy
   - govuk_jenkins::jobs::transition_load_all_data

--- a/hieradata_aws/class/staging/jenkins.yaml
+++ b/hieradata_aws/class/staging/jenkins.yaml
@@ -16,6 +16,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::search_api_fetch_analytics_data
   - govuk_jenkins::jobs::search_fetch_analytics_data_search_api
   - govuk_jenkins::jobs::search_api_index_checks
+  - govuk_jenkins::jobs::search_api_reindex_with_new_schema
   - govuk_jenkins::jobs::smokey
   - govuk_jenkins::jobs::smokey_deploy
   - govuk_jenkins::jobs::data_sync

--- a/hieradata_aws/class/staging/jenkins.yaml
+++ b/hieradata_aws/class/staging/jenkins.yaml
@@ -15,6 +15,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::run_rake_task
   - govuk_jenkins::jobs::search_api_fetch_analytics_data
   - govuk_jenkins::jobs::search_fetch_analytics_data_search_api
+  - govuk_jenkins::jobs::search_api_index_checks
   - govuk_jenkins::jobs::smokey
   - govuk_jenkins::jobs::smokey_deploy
   - govuk_jenkins::jobs::data_sync

--- a/hieradata_aws/class/staging/jenkins.yaml
+++ b/hieradata_aws/class/staging/jenkins.yaml
@@ -13,6 +13,8 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::passive_checks
   - govuk_jenkins::jobs::publish_special_routes
   - govuk_jenkins::jobs::run_rake_task
+  - govuk_jenkins::jobs::search_api_fetch_analytics_data
+  - govuk_jenkins::jobs::search_fetch_analytics_data_search_api
   - govuk_jenkins::jobs::smokey
   - govuk_jenkins::jobs::smokey_deploy
   - govuk_jenkins::jobs::data_sync

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -100,6 +100,7 @@ govuk_jenkins::jobs::search_benchmark::cron_schedule: '30 9 * * 1-5'
 govuk_jenkins::jobs::search_test_spelling_suggestions::cron_schedule: '0 10 * * 1-5'
 
 govuk_jenkins::jobs::enhanced_ecommerce::cron_schedule: '30 9 * * 1-5'
+govuk_jenkins::jobs::enhanced_ecommerce_search_api::cron_schedule: '30 9 * * 1-5'
 
 govuk_jenkins::jobs::search_fetch_analytics_data::skip_page_traffic_load: true
 govuk_jenkins::jobs::search_fetch_analytics_data::cron_schedule: '30 9 * * 1-5'

--- a/modules/govuk_jenkins/manifests/jobs/enhanced_ecommerce.pp
+++ b/modules/govuk_jenkins/manifests/jobs/enhanced_ecommerce.pp
@@ -13,6 +13,7 @@ class govuk_jenkins::jobs::enhanced_ecommerce (
   $job_name = 'enhanced_ecommerce'
   $service_description = 'Export Enhanced Ecommerce data'
   $job_url = "https://deploy.${app_domain}/job/enhanced_ecommerce/"
+  $target_application = 'rummager'
 
   file { '/etc/jenkins_jobs/jobs/enhanced_ecommerce.yaml':
     ensure  => present,

--- a/modules/govuk_jenkins/manifests/jobs/enhanced_ecommerce_search_api.pp
+++ b/modules/govuk_jenkins/manifests/jobs/enhanced_ecommerce_search_api.pp
@@ -1,0 +1,31 @@
+# == Class: govuk_jenkins::jobs::enhanced_ecommerce_search_api
+#
+# Create a file on disk that can be parsed by jenkins-job-builder
+#
+class govuk_jenkins::jobs::enhanced_ecommerce_search_api (
+  $app_domain = hiera('app_domain'),
+  $auth_username = undef,
+  $auth_password = undef,
+  $rate_limit_token = undef,
+  $cron_schedule = '0 5 * * *'
+) {
+
+  $job_name = 'enhanced_ecommerce_search_api'
+  $service_description = 'Export Enhanced Ecommerce data (Search API)'
+  $job_url = "https://deploy.${app_domain}/job/enhanced_ecommerce_search_api/"
+  $target_application = 'search-api'
+
+  file { '/etc/jenkins_jobs/jobs/enhanced_ecommerce_search_api.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/enhanced_ecommerce.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+
+  @@icinga::passive_check { "${job_name}_${::hostname}":
+    service_description => $service_description,
+    host_name           => $::fqdn,
+    freshness_threshold => 104400,
+    action_url          => $job_url,
+    notes_url           => monitoring_docs_url(enhanced-ecommerce),
+  }
+}

--- a/modules/govuk_jenkins/manifests/jobs/run_metadata_tagger.pp
+++ b/modules/govuk_jenkins/manifests/jobs/run_metadata_tagger.pp
@@ -3,6 +3,9 @@
 # Create a file on disk that can be parsed by jenkins-job-builder
 #
 class govuk_jenkins::jobs::run_metadata_tagger {
+  $job_name = 'Run_Rummager_Metadata_Tagger'
+  $target_application = 'rummager'
+
   file { '/etc/jenkins_jobs/jobs/run_metadata_tagger.yaml':
     ensure  => present,
     content => template('govuk_jenkins/jobs/run_metadata_tagger.yaml.erb'),

--- a/modules/govuk_jenkins/manifests/jobs/run_metadata_tagger_search_api.pp
+++ b/modules/govuk_jenkins/manifests/jobs/run_metadata_tagger_search_api.pp
@@ -1,0 +1,14 @@
+# == Class: govuk_jenkins::jobs::run_metadata_tagger_search_api
+#
+# Create a file on disk that can be parsed by jenkins-job-builder
+#
+class govuk_jenkins::jobs::run_metadata_tagger_search_api {
+  $job_name = 'Run_Search_API_Metadata_Tagger'
+  $target_application = 'search-api'
+
+  file { '/etc/jenkins_jobs/jobs/run_metadata_tagger_search_api.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/run_metadata_tagger.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+}

--- a/modules/govuk_jenkins/manifests/jobs/search_api_fetch_analytics_data.pp
+++ b/modules/govuk_jenkins/manifests/jobs/search_api_fetch_analytics_data.pp
@@ -1,0 +1,31 @@
+# == Class: govuk_jenkins::jobs::search_api_fetch_analytics_data
+#
+# Create a file on disk that can be parsed by jenkins-job-builder
+#
+class govuk_jenkins::jobs::search_api_fetch_analytics_data (
+  $ga_auth_password = undef,
+  $app_domain = hiera('app_domain'),
+  $skip_page_traffic_load = false,
+  $cron_schedule = '5 4 * * *',
+) {
+
+  $job_name = 'search-api-fetch-analytics-data'
+  $check_name = 'search-api-fetch-analytics-data'
+  $service_description = 'Fetch analytics data for Search API'
+  $job_url = "https://deploy.${app_domain}/job/${job_name}/"
+  $target_application = 'search-api'
+
+  file { '/etc/jenkins_jobs/jobs/search_api_fetch_analytics_data.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/search_fetch_analytics_data.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+
+  @@icinga::passive_check { "${check_name}_${::hostname}":
+    service_description => $service_description,
+    host_name           => $::fqdn,
+    freshness_threshold => 104400,
+    action_url          => $job_url,
+    notes_url           => monitoring_docs_url(fetch-analytics-data-for-search-failed),
+  }
+}

--- a/modules/govuk_jenkins/manifests/jobs/search_api_index_checks.pp
+++ b/modules/govuk_jenkins/manifests/jobs/search_api_index_checks.pp
@@ -1,0 +1,15 @@
+# == Class: govuk_jenkins::jobs::search_api_index_checks
+#
+# Monitor the GOV.UK search indexes and report data to statsd
+#
+class govuk_jenkins::jobs::search_api_index_checks {
+  $job_name = 'search_api_index_checks'
+  $job_display_name = 'Search API index checks'
+  $target_application = 'search-api'
+
+  file { '/etc/jenkins_jobs/jobs/search_api_index_checks.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/search_index_checks.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+}

--- a/modules/govuk_jenkins/manifests/jobs/search_api_reindex_with_new_schema.pp
+++ b/modules/govuk_jenkins/manifests/jobs/search_api_reindex_with_new_schema.pp
@@ -1,0 +1,33 @@
+# == Class: govuk_jenkins::jobs::search_api_reindex_with_new_schema
+#
+# Test rebuilding the search indexes and reindexing all content
+#
+class govuk_jenkins::jobs::search_api_reindex_with_new_schema (
+  $app_domain = hiera('app_domain'),
+  $icinga_check_enabled = false,
+  $cron_schedule = undef,
+) {
+
+  $check_name = 'search-api-reindex-with-new-schema'
+  $service_description = 'Rebuild new Search API indexes with up to date settings and mappings and reindex all content from the existing indexes.'
+  $job_name = 'search_api_reindex_with_new_schema'
+  $job_display_name = 'Search API reindex with new schema'
+  $job_url = "https://deploy.${app_domain}/job/search-reindex-with-new-schema/"
+  $target_application = 'search-api'
+
+  file { '/etc/jenkins_jobs/jobs/search_api_reindex_with_new_schema.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/search_reindex_with_new_schema.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+
+  if ($icinga_check_enabled) {
+    @@icinga::passive_check { "${check_name}_${::hostname}":
+      service_description => $service_description,
+      host_name           => $::fqdn,
+      freshness_threshold => 619200,
+      action_url          => $job_url,
+      notes_url           => monitoring_docs_url(search-reindex-failed),
+    }
+  }
+}

--- a/modules/govuk_jenkins/manifests/jobs/search_fetch_analytics_data.pp
+++ b/modules/govuk_jenkins/manifests/jobs/search_fetch_analytics_data.pp
@@ -9,9 +9,11 @@ class govuk_jenkins::jobs::search_fetch_analytics_data (
   $cron_schedule = '5 4 * * *',
 ) {
 
+  $job_name = 'search-fetch-analytics-data'
   $check_name = 'search-fetch-analytics-data'
   $service_description = 'Fetch analytics data for search'
-  $job_url = "https://deploy.${app_domain}/job/search-fetch-analytics-data/"
+  $job_url = "https://deploy.${app_domain}/job/${job_name}/"
+  $target_application = 'rummager'
 
   file { '/etc/jenkins_jobs/jobs/search_fetch_analytics_data.yaml':
     ensure  => present,

--- a/modules/govuk_jenkins/manifests/jobs/search_index_checks.pp
+++ b/modules/govuk_jenkins/manifests/jobs/search_index_checks.pp
@@ -3,6 +3,9 @@
 # Monitor the GOV.UK search indexes and report data to statsd
 #
 class govuk_jenkins::jobs::search_index_checks {
+  $job_name = 'search_index_checks'
+  $job_display_name = 'Search index checks'
+  $target_application = 'rummager'
 
   file { '/etc/jenkins_jobs/jobs/search_index_checks.yaml':
     ensure  => present,

--- a/modules/govuk_jenkins/manifests/jobs/search_reindex_with_new_schema.pp
+++ b/modules/govuk_jenkins/manifests/jobs/search_reindex_with_new_schema.pp
@@ -10,7 +10,10 @@ class govuk_jenkins::jobs::search_reindex_with_new_schema (
 
   $check_name = 'search-reindex-with-new-schema'
   $service_description = 'Rebuild new search indexes with up to date settings and mappings and reindex all content from the existing indexes.'
+  $job_name = 'search_reindex_with_new_schema'
+  $job_display_name = 'Search reindex with new schema'
   $job_url = "https://deploy.${app_domain}/job/search-reindex-with-new-schema/"
+  $target_application = 'rummager'
 
   file { '/etc/jenkins_jobs/jobs/search_reindex_with_new_schema.yaml':
     ensure  => present,

--- a/modules/govuk_jenkins/templates/jobs/enhanced_ecommerce.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/enhanced_ecommerce.yaml.erb
@@ -13,13 +13,13 @@
           - project: run-rake-task
             block: true
             predefined-parameters: |
-              TARGET_APPLICATION=rummager
+              TARGET_APPLICATION=<%= @target_application %>
               MACHINE_CLASS=search
               RAKE_TASK="analytics:create_data_import_csv[/data/export/enhanced_ecommerce]"
           - project: run-rake-task
             block: true
             predefined-parameters: |
-              TARGET_APPLICATION=rummager
+              TARGET_APPLICATION=<%= @target_application %>
               MACHINE_CLASS=search
               RAKE_TASK="analytics:delete_old_files[/data/export/enhanced_ecommerce,10]"
     triggers:

--- a/modules/govuk_jenkins/templates/jobs/run_metadata_tagger.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/run_metadata_tagger.yaml.erb
@@ -1,9 +1,9 @@
 ---
 - job:
-    name: Run_Rummager_Metadata_Tagger
-    display-name: Run_Rummager_Metadata_Tagger
+    name: <%= @job_name %>
+    display-name: <%= @job_name %>
     project-type: freestyle
-    description: "This job SSHs onto a search backend and runs the rake task 'govuk_setenv rummager bundle exec rake tag_metadata'"
+    description: "This job SSHs onto a search backend and runs the rake task 'govuk_setenv <%= @target_application %> bundle exec rake tag_metadata'"
     properties:
       - build-discarder:
           days-to-keep: 7
@@ -13,7 +13,7 @@
           - project: run-rake-task
             block: true
             predefined-parameters: |
-              TARGET_APPLICATION=rummager
+              TARGET_APPLICATION=<%= @target_application %>
               MACHINE_CLASS=search
               RAKE_TASK=tag_metadata
     triggers:

--- a/modules/govuk_jenkins/templates/jobs/search_fetch_analytics_data.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/search_fetch_analytics_data.yaml.erb
@@ -8,8 +8,8 @@
               - master
 
 - job:
-    name: search-fetch-analytics-data
-    display-name: search-fetch-analytics-data
+    name: <%= @job_name %>
+    display-name: <%= @job_name %>
     project-type: freestyle
     description: |
       <p>Fetch analytics data from Google Analytics and index in search</p>
@@ -18,7 +18,7 @@
       <p>More information:</p>
       <ul>
         <li><a href='https://github.com/alphagov/search-analytics'>alphagov/search-analytics on GitHub</a></li>
-        <li><a href='https://github.com/alphagov/rummager/blob/master/doc/popularity.md'>Docs on Rummager</a></li>
+        <li><a href='https://github.com/alphagov/<%= @target_application %>/blob/master/doc/popularity.md'>Docs on Search</a></li>
       </ul>
     scm:
         - search-analytics_search-fetch-analytics-data
@@ -33,7 +33,7 @@
             artifact-num-to-keep: 5
     builders:
         - shell: |
-            ./nightly-run.sh
+            TARGET_APPLICATION=<%= @target_application %> ./nightly-run.sh
     triggers:
         - timed: '<%= @cron_schedule %>'
     publishers:

--- a/modules/govuk_jenkins/templates/jobs/search_index_checks.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/search_index_checks.yaml.erb
@@ -1,7 +1,7 @@
 ---
 - job:
-    name: search_index_checks
-    display-name: Search index checks
+    name: <%= @job_name %>
+    display-name: <%= @job_display_name %>
     project-type: freestyle
     description: |
       This job monitors the GOV.UK search indexes and sends data to statsd.
@@ -18,7 +18,7 @@
           - project: run-rake-task
             block: true
             predefined-parameters: |
-              TARGET_APPLICATION=rummager
+              TARGET_APPLICATION=<%= @target_application %>
               MACHINE_CLASS=search
               RAKE_TASK=rummager:monitor_indices
     wrappers:

--- a/modules/govuk_jenkins/templates/jobs/search_reindex_with_new_schema.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/search_reindex_with_new_schema.yaml.erb
@@ -1,7 +1,7 @@
 ---
 - job:
-    name: search_reindex_with_new_schema
-    display-name: Search reindex with new schema
+    name: <%= @job_name %>
+    display-name: <%= @job_display_name %>
     project-type: freestyle
     description: |
       Rebuild new search indexes with up to date settings and mappings, and reindex all content from the existing indexes.
@@ -16,7 +16,7 @@
           days-to-keep: 30
           artifact-num-to-keep: 5
     builders:
-        - shell: ssh deploy@$(govuk_node_list -c search --single-node) "cd /var/apps/rummager && govuk_setenv rummager bundle exec rake rummager:migrate_schema CONFIRM_INDEX_MIGRATION_START=1 RUMMAGER_INDEX=all"
+        - shell: ssh deploy@$(govuk_node_list -c search --single-node) "cd /var/apps/<%= @target_application %> && govuk_setenv <%= @target_application %> bundle exec rake rummager:migrate_schema CONFIRM_INDEX_MIGRATION_START=1 RUMMAGER_INDEX=all"
     wrappers:
       - ansicolor:
           colormap: xterm


### PR DESCRIPTION
These are all the Rummager-related Jenkins jobs which aren't to do with the data sync (we have a separate card for that).  Once Rummager is gone we can remove the old jobs.

Two relevant files have not been changed:

- `govuk_taxonomy_supervised_learning.pp`
- `govuk_taxonomy_supervised_learning.yaml.erb`

That's because these use the `search` alias for Rummager, so if we change that alias to point to Search API when the switch is complete, we don't need to update that job.

Some of these jobs aren't configured in AWS production or staging (probably because there isn't a Rummager there), but since Search API will be running in AWS, I have configured the new jobs.

---

[Trello card](https://trello.com/c/2pvWc0Ql/70-update-jenkins-tasks-for-search-api)