### PR TITLE
Increase email alert api memory thresholds

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -435,6 +435,8 @@ govuk::apps::email_alert_api::db_hostname: 'postgresql-primary-1.backend'
 govuk::apps::email_alert_api::db_password: "%{hiera('govuk::apps::email_alert_api::db::password')}"
 govuk::apps::email_alert_api::db_port: 6432
 govuk::apps::email_alert_api::db_allow_prepared_statements: false
+govuk::apps::email_alert_api::nagios_memory_warning: 1200
+govuk::apps::email_alert_api::nagios_memory_critical: 1500
 govuk::apps::email_alert_api::unicorn_worker_processes: '4'
 # This list should be kept in sync with https://www.notifications.service.gov.uk/services/ecfc7e2f-5145-45a6-9413-5d9b6e813ea9/users
 govuk::apps::email_alert_api::email_address_override_whitelist:

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -463,6 +463,8 @@ govuk::apps::email_alert_api::db_hostname: 'db-admin'
 govuk::apps::email_alert_api::db_port: 6432
 govuk::apps::email_alert_api::db_allow_prepared_statements: false
 govuk::apps::email_alert_api::db_password: "%{hiera('govuk::apps::email_alert_api::db::password')}"
+govuk::apps::email_alert_api::nagios_memory_warning: 1200
+govuk::apps::email_alert_api::nagios_memory_critical: 1500
 govuk::apps::email_alert_api::unicorn_worker_processes: '4'
 # This list should be kept in sync with https://www.notifications.service.gov.uk/services/ecfc7e2f-5145-45a6-9413-5d9b6e813ea9/users
 govuk::apps::email_alert_api::email_address_override_whitelist:

--- a/modules/govuk/manifests/apps/email_alert_api.pp
+++ b/modules/govuk/manifests/apps/email_alert_api.pp
@@ -99,6 +99,12 @@
 #   The ?prepared_statements= parameter to use in the DATABASE_URL.
 #   Default: undef
 #
+# [*nagios_memory_warning*]
+#   Memory use at which Nagios should generate a warning.
+#
+# [*nagios_memory_critical*]
+#   Memory use at which Nagios should generate a critical alert.
+#
 class govuk::apps::email_alert_api(
   $port = '3088',
   $enabled = false,
@@ -137,6 +143,8 @@ class govuk::apps::email_alert_api(
   $aws_region = 'eu-west-1',
   $email_archive_s3_bucket = undef,
   $email_archive_s3_enabled = undef,
+  $nagios_memory_warning = undef,
+  $nagios_memory_critical = undef,
 ) {
 
   $ensure = $enabled ? {
@@ -153,6 +161,8 @@ class govuk::apps::email_alert_api(
     health_check_path        => '/healthcheck',
     json_health_check        => true,
     unicorn_worker_processes => $unicorn_worker_processes,
+    nagios_memory_warning    => $nagios_memory_warning,
+    nagios_memory_critical   => $nagios_memory_critical,
   }
 
   include govuk_postgresql::client #installs libpq-dev package needed for pg gem


### PR DESCRIPTION
We've had a few restarts due to memory pressure today.  Email alert API tends to use in the region of 700MB, which is always skirting with the default warning level.

The boxes that this app sits on have plenty of free memory, so I'd like to increase the headroom.