### PR TITLE
Automatically run the CKAN reindex in staging and integration

### DIFF
--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -16,6 +16,7 @@ environment_ip_prefix: '10.2'
 govuk::apps::asset_manager::aws_s3_bucket_name: 'govuk-assets-staging'
 govuk::apps::asset_manager::aws_region: 'eu-west-1'
 govuk::apps::ckan::ckan_site_url: 'https://ckan.staging.publishing.service.gov.uk'
+govuk::apps::ckan::cronjobs::enable_solr_reindex: true
 govuk::apps::content_data_admin::google_tag_manager_auth: 'xcAlGBhKTIeO6y_JhmEapQ'
 govuk::apps::content_data_admin::google_tag_manager_id: 'GTM-NZG8SF2'
 govuk::apps::content_data_admin::google_tag_manager_preview: 'env-5'

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -16,6 +16,7 @@ govuk::apps::ckan::ckan_site_url: 'https://ckan.integration.publishing.service.g
 govuk::apps::ckan::s3_bucket_name: "datagovuk-integration-ckan-organogram"
 govuk::apps::ckan::s3_aws_region_name: "eu-west-1"
 govuk::apps::ckan::vhost_protected: true
+govuk::apps::ckan::cronjobs::enable_solr_reindex: true
 govuk::apps::content_data_admin::google_tag_manager_auth: 'wFyiBTovFhDv5qMe_LXt7Q'
 govuk::apps::content_data_admin::google_tag_manager_preview: 'env-7'
 govuk::apps::content_data_admin::google_tag_manager_id: 'GTM-NZG8SF2'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -113,6 +113,7 @@ govuk::apps::asset_manager::aws_region: 'eu-west-1'
 govuk::apps::ckan::ckan_site_url: 'https://ckan.staging.publishing.service.gov.uk'
 govuk::apps::ckan::s3_bucket_name: "datagovuk-staging-ckan-organogram"
 govuk::apps::ckan::s3_aws_region_name: "eu-west-1"
+govuk::apps::ckan::cronjobs::enable_solr_reindex: true
 govuk::apps::content_data_admin::google_tag_manager_auth: 'xcAlGBhKTIeO6y_JhmEapQ'
 govuk::apps::content_data_admin::google_tag_manager_id: 'GTM-NZG8SF2'
 govuk::apps::content_data_admin::google_tag_manager_preview: 'env-5'

--- a/modules/govuk/manifests/apps/ckan/cronjobs.pp
+++ b/modules/govuk/manifests/apps/ckan/cronjobs.pp
@@ -1,6 +1,13 @@
 # == Class: govuk::apps::ckan::cronjobs
 #
-class govuk::apps::ckan::cronjobs {
+# [*enable_solr_reindex*]
+#   Enable automatic Solr reindexing, this is useful to run after the data
+#   sync.
+#   Default: false
+#
+class govuk::apps::ckan::cronjobs(
+  $enable_solr_reindex = false,
+) {
 
   govuk::apps::ckan::paster_cronjob { 'harvester run':
     paster_command => 'harvester run',
@@ -12,6 +19,15 @@ class govuk::apps::ckan::cronjobs {
     paster_command => 'harvester clean_harvest_log',
     plugin         => 'ckanext-harvest',
     hour           => '2',
+  }
+
+  if $enable_solr_reindex {
+    govuk::apps::ckan::paster_cronjob { 'harvester reindex':
+      paster_command => 'search-index rebuild -o',
+      plugin         => 'ckan',
+      hour           => '7',
+      minute         => '0',
+    }
   }
 
 }

--- a/modules/govuk/manifests/apps/ckan/cronjobs.pp
+++ b/modules/govuk/manifests/apps/ckan/cronjobs.pp
@@ -21,13 +21,17 @@ class govuk::apps::ckan::cronjobs(
     hour           => '2',
   }
 
-  if $enable_solr_reindex {
-    govuk::apps::ckan::paster_cronjob { 'harvester reindex':
-      paster_command => 'search-index rebuild -o',
-      plugin         => 'ckan',
-      hour           => '7',
-      minute         => '0',
-    }
+  $ensure_solr_reindex = $enable_solr_reindex ? {
+    true  => 'present',
+    false => 'absent',
+  }
+
+  govuk::apps::ckan::paster_cronjob { 'harvester reindex':
+    ensure         => $ensure_solr_reindex,
+    paster_command => 'search-index rebuild -o',
+    plugin         => 'ckan',
+    hour           => '7',
+    minute         => '0',
   }
 
 }

--- a/modules/govuk/manifests/apps/ckan/paster_cronjob.pp
+++ b/modules/govuk/manifests/apps/ckan/paster_cronjob.pp
@@ -18,6 +18,7 @@
 # Paster command to run eg "archiver update"
 #
 define govuk::apps::ckan::paster_cronjob (
+  $ensure = present,
   $hour = undef,
   $minute = undef,
   $month = undef,
@@ -30,6 +31,7 @@ define govuk::apps::ckan::paster_cronjob (
   validate_string($plugin, $paster_command)
 
   cron { $title:
+    ensure   => $ensure,
     command  => "cd /var/apps/ckan; ./venv/bin/paster --plugin=${plugin} ${paster_command} --config=/var/ckan/ckan.ini",
     user     => 'deploy',
     hour     => $hour,

--- a/modules/govuk_env_sync/files/govuk_env_sync.sh
+++ b/modules/govuk_env_sync/files/govuk_env_sync.sh
@@ -369,19 +369,12 @@ function postprocess_router {
   mongo_backend_domain_manipulator "rummager" "${rummager_domain}"
 }
 
-function postprocess_ckan {
-  ckan=$(govuk_node_list -c ckan --single-node)
-  cmd="cd /var/apps/ckan && sudo -u deploy govuk_setenv ckan venv/bin/paster --plugin=ckan search-index rebuild -o -c /var/ckan/ckan.ini"
-  ssh "$ckan" '$cmd'
-}
-
 function postprocess_database {
   case "${database}" in
     router) postprocess_router;;
     # re-using postprocess_router below is not a typo - the script checks $database to determine where to apply changes.
     draft_router) postprocess_router;;
     signon_production) postprocess_signon_production;;
-    ckan_production) postprocess_ckan;;
     *) log "No post processing needed for ${database}" ;;
   esac
 }


### PR DESCRIPTION
This makes the CKAN reindex run daily in staging and integration to be the final step of the data sync.

After testing https://github.com/alphagov/govuk-puppet/pull/8737 on integration, I've come to the realisation that this also won't solve the problem because the CKAN machine needs access to the S3 bucket which contains the backups. It feels wrong to give the CKAN machine the same level as access to all the backups as the db_admin machine, for what is already a workaround the fact that the db_admin machine can't talk to the CKAN machine. Instead, a simpler, albeit less clean, solution is to run the reindex as a separate process unrelated to the database sync.

[Trello Card](https://trello.com/c/RiOpZ1qs/762-get-ckan-database-up-and-running-on-staging)