### PR TITLE
Set search-api ES host to http://elasticsearch5 in all AWS envs

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -643,7 +643,7 @@ govuk::apps::search_api::rabbitmq_user: 'search-api'
 govuk::apps::search_api::redis_host: 'backend-redis'
 govuk::apps::search_api::redis_port: '6379'
 # todo: decide if we're self-hosting or using a managed elasticsearch (use a bogus value for now)
-govuk::apps::search_api::elasticsearch_hosts: 'http://localhost:9200'
+govuk::apps::search_api::elasticsearch_hosts: 'http://elasticsearch5'
 govuk::apps::search_api::unicorn_worker_processes: "6"
 
 govuk::apps::search_admin::db_name: 'search_admin_production'

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -38,7 +38,6 @@ govuk::apps::kibana::logit_environment: 2694f14b-6519-4607-81f2-8a2130e5aaec
 govuk::apps::link_checker_api::govuk_basic_auth_credentials: "%{hiera('http_username')}:%{hiera('http_password')}"
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-integration'
 govuk::apps::publishing_api::content_api_prototype: true
-govuk::apps::search_api::elasticsearch_hosts: 'http://elasticsearch5.blue.integration.govuk-internal.digital'
 govuk::apps::short_url_manager::instance_name: 'integration'
 govuk::apps::signon::instance_name: 'integration'
 govuk::apps::smartanswers::expose_govspeak: true


### PR DESCRIPTION
[Trello card](https://trello.com/c/YU9bS9jR/76-get-search-api-running-in-aws-staging)