### PR TITLE
Trello-2031: Cache Router Gor Replay

### DIFF
--- a/hieradata/class/staging/cache.yaml
+++ b/hieradata/class/staging/cache.yaml
@@ -1,1 +1,6 @@
 nscd::config::dns_cache: 'yes'
+
+router::gor::add_hosts: false
+router::gor::replay_targets:
+  'www-origin.integration.publishing.service.gov.uk': {}
+  'www-origin.production.govuk.digital': {}

--- a/hieradata/node/cache-1.router.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/cache-1.router.staging.publishing.service.gov.uk.yaml
@@ -1,8 +1,0 @@
----
-
-# NOTE: These values should not be changed lightly once set.
-#
-# If changed, the old host record must be cleaned up;
-router::gor::replay_targets:
-  'www-origin.integration.publishing.service.gov.uk':
-    ip: '31.210.245.98'

--- a/hieradata/node/cache-2.router.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/cache-2.router.staging.publishing.service.gov.uk.yaml
@@ -1,6 +1,0 @@
----
-
-router::gor::add_hosts: false
-router::gor::replay_targets:
-  'www-origin.blue.integration.govuk.digital': {}
-  'www-origin.blue.staging.govuk.digital': {}

--- a/hieradata/node/cache-3.router.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/cache-3.router.staging.publishing.service.gov.uk.yaml
@@ -1,6 +1,0 @@
----
-
-router::gor::add_hosts: false
-router::gor::replay_targets:
-  'www-origin.blue.integration.govuk.digital': {}
-  'www-origin.blue.staging.govuk.digital': {}

--- a/hieradata_aws/class/production/cache.yaml
+++ b/hieradata_aws/class/production/cache.yaml
@@ -1,0 +1,2 @@
+router::gor::replay_targets:
+  'www-origin.staging.govuk.digital': {}


### PR DESCRIPTION
In order to test AWS production we need to temporarily replay cache
router traffic to the AWS production cache routers.

The flow of the GOR routing would be as follows for the cache routers:
Carrenza Production -> Carrenza Staging (already in place)
Carrenza Staging -> Integration (already in place but tidying up config
in this commit)
Carrenza Staging -> AWS Production (Being put in place in this PR)
AWS Production -> AWS Staging (Being put in place in this PR)

also removing gor replay from Carrenza Staging to AWS Staging.

@ronocg <conor.glynn@digital.cabinet-office.gov.uk>