### PR TITLE
Trello-2031: Gor Replay for Integraion

### DIFF
--- a/hieradata/class/staging/cache.yaml
+++ b/hieradata/class/staging/cache.yaml
@@ -1,6 +1,1 @@
 nscd::config::dns_cache: 'yes'
-
-router::gor::add_hosts: false
-router::gor::replay_targets:
-  'www-origin.integration.publishing.service.gov.uk': {}
-  'www-origin.production.govuk.digital': {}

--- a/hieradata/node/cache-1.router.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/cache-1.router.staging.publishing.service.gov.uk.yaml
@@ -1,0 +1,3 @@
+router::gor::add_hosts: false
+router::gor::replay_targets:
+  'www-origin.production.govuk.digital': {}

--- a/hieradata/node/cache-2.router.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/cache-2.router.staging.publishing.service.gov.uk.yaml
@@ -1,0 +1,4 @@
+router::gor::add_hosts: false
+router::gor::replay_targets:
+  'www-origin.integration.publishing.service.gov.uk': {}
+  'www-origin.production.govuk.digital': {}

--- a/hieradata/node/cache-3.router.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/cache-3.router.staging.publishing.service.gov.uk.yaml
@@ -1,0 +1,4 @@
+router::gor::add_hosts: false
+router::gor::replay_targets:
+  'www-origin.integration.publishing.service.gov.uk': {}
+  'www-origin.production.govuk.digital': {}


### PR DESCRIPTION
Gor replay was recently changed, but because the instances are a lower
spec in integration only 2 carrenza staging instances should replay
traffic into integration.

@ronocg <conor.glynn@digital.cabinet-office.gov.uk>