### PR TITLE
DO-NOT-MERGE -  Migration: Gor Replay for Integration

### DIFF
--- a/hieradata_aws/class/staging/cache.yaml
+++ b/hieradata_aws/class/staging/cache.yaml
@@ -1,0 +1,4 @@
+---
+router::gor::add_hosts: false
+router::gor::replay_targets:
+  'www-origin.integration.publishing.service.gov.uk': {}


### PR DESCRIPTION
We will soon be migrating the cache router services from carrenza to aws
for staging and production.

So in order to continue having traffic in integration we will need to
replay the aws staging cache router traffic to integration.

This will need to be merged at migration time, when the cache routers
are turned off in carrenza.

@ronocg <conor.glynn@digital.cabinet-office.gov.uk>