### PR TITLE
Raise memory thresholds for static

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -691,8 +691,8 @@ govuk::apps::smokey::rate_limit_token: "%{hiera('smokey_rate_limit_token')}"
 govuk::apps::static::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::static::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::static::unicorn_worker_processes: "8"
-govuk::apps::static::nagios_memory_warning: 1050
-govuk::apps::static::nagios_memory_critical: 1200
+govuk::apps::static::nagios_memory_warning: 1500
+govuk::apps::static::nagios_memory_critical: 1750
 
 govuk::apps::support::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::support::redis_port: "%{hiera('sidekiq_port')}"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -736,8 +736,8 @@ govuk::apps::smokey::rate_limit_token: "%{hiera('smokey_rate_limit_token')}"
 govuk::apps::static::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::static::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::static::unicorn_worker_processes: "8"
-govuk::apps::static::nagios_memory_warning: 1050
-govuk::apps::static::nagios_memory_critical: 1200
+govuk::apps::static::nagios_memory_warning: 1500
+govuk::apps::static::nagios_memory_critical: 1750
 
 govuk::apps::support::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::support::redis_port: "%{hiera('sidekiq_port')}"


### PR DESCRIPTION
Static seems to be settling at a level just below the warning line.  Last night this resulted in a restart cycle (due to exceeding the critical level) that took a while to settle down.

We're generally more relaxed about having strict thresholds on memory thresholds these days as we have alerts on whether apps are actually working.

There's not a massive amount of free memory on these machines, but we'll be moving to AWS very soon.