### PR TITLE
Fix real ip haeders for assets nginx 

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -774,6 +774,7 @@ govuk::node::s_backend_lb::draft_assets_carrenza_vhost_name: "draft-assets-carre
 govuk::node::s_backend_lb::assets_carrenza_vhost_aliases:
   - 'assets.digital.cabinet-office.gov.uk'
   - 'assets.publishing.service.gov.uk'
+govuk::node::s_backend_lb::assets_carrenza_real_ip_header: "True-Client-Ip"
 
 govuk::node::s_db_admin::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -829,6 +829,7 @@ govuk::node::s_backend_lb::draft_assets_carrenza_vhost_name: "draft-assets-carre
 govuk::node::s_backend_lb::assets_carrenza_vhost_aliases:
   - 'assets.digital.cabinet-office.gov.uk'
   - 'assets.publishing.service.gov.uk'
+govuk::node::s_backend_lb::assets_carrenza_real_ip_header: "True-Client-Ip"
 
 govuk::node::s_db_admin::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 

--- a/modules/govuk/templates/node/s_backend_lb/assets-carrenza.conf.erb
+++ b/modules/govuk/templates/node/s_backend_lb/assets-carrenza.conf.erb
@@ -20,10 +20,10 @@ server {
   proxy_set_header X-Forwarded-Server $host;
   proxy_set_header X-Forwarded-Host $host;
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-<% if @real_ip_header != '' -%>
+<% if @assets_carrenza_real_ip_header != '' -%>
 
   # use an unspoofable header from an upstream cdn or l7 load balancer.
-  real_ip_header <%= @real_ip_header -%>;
+  real_ip_header <%= @assets_carrenza_real_ip_header -%>;
   real_ip_recursive on;
   set_real_ip_from 0.0.0.0/0;
 

--- a/modules/govuk/templates/node/s_backend_lb/draft-assets-carrenza.conf.erb
+++ b/modules/govuk/templates/node/s_backend_lb/draft-assets-carrenza.conf.erb
@@ -25,9 +25,9 @@ server {
   proxy_set_header X-Forwarded-Host $host;
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
-<% if @real_ip_header != '' -%>
+<% if @assets_carrenza_real_ip_header != '' -%>
   # use an unspoofable header from an upstream cdn or l7 load balancer.
-  real_ip_header <%= @real_ip_header -%>;
+  real_ip_header <%= @assets_carrenza_real_ip_header -%>;
   real_ip_recursive on;
   set_real_ip_from 0.0.0.0/0;
 


### PR DESCRIPTION
- We were missing a RealIP header parameter for the assets backend-lb config
- This caused Puppet to fail on the machine

solo: @schmie