### PR TITLE
Make branch a parameter in Deploy Terraform Govuk AWS

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_terraform_govuk_aws.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_terraform_govuk_aws.yaml.erb
@@ -9,7 +9,7 @@
             clean:
               before: true
             branches:
-                - master
+              - $BRANCH
 - job:
     name: Deploy_Terraform_GOVUK_AWS
     display-name: Deploy_Terraform_GOVUK_AWS
@@ -86,3 +86,7 @@
             name: TERRAFORM_VERSION
             description: Version of Terraform to run against. Leave blank for default.
             default: false
+        - string:
+            name: BRANCH
+            description: Branch of govuk-aws to use.
+            default: master


### PR DESCRIPTION
This makes it easier to test out branches of govuk-aws, without having
to change the definition of the Jenkins job.