### PR TITLE
Trello-2031: Set add_hosts to false for Gor

### DIFF
--- a/hieradata_aws/class/production/cache.yaml
+++ b/hieradata_aws/class/production/cache.yaml
@@ -1,2 +1,3 @@
+router::gor::add_hosts: false
 router::gor::replay_targets:
   'www-origin.staging.govuk.digital': {}


### PR DESCRIPTION
There is no need to add a real IP to the hosts file for gor.
Especially when the IPs are dynamic in AWS.
So setting router::gor::add_hosts to false.

@ronocg <conor.glynn@digital.cabinet-office.gov.uk>