### PR TITLE
Add rate limiting tokens to assets-carrenza

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -763,6 +763,11 @@ govuk::node::s_api_redis::allowed_backend_ip_range: "%{hiera('environment_ip_pre
 
 govuk::node::s_asset_base::firewall_allow_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 
+# Note: it's important that all targets here have matching host entries both in
+# production, and on the dev VM, otherwise nginx will fail to start.
+govuk::node::s_backend_lb::app_specific_static_asset_routes:
+  '/asset-manager': "asset-manager"
+  '/government/assets/': "whitehall-frontend"
 govuk::node::s_backend_lb::asset_manager_uploaded_assets_routes:
   - '/government/uploads/'
   - '/media/'

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -818,6 +818,9 @@ govuk::node::s_asset_base::firewall_allow_ip_range: "%{hiera('environment_ip_pre
 
 govuk::node::s_base::log_remote: false
 
+govuk::node::s_backend_lb::app_specific_static_asset_routes:
+  '/asset-manager': "asset-manager"
+  '/government/assets/': "whitehall-frontend"
 govuk::node::s_backend_lb::asset_manager_uploaded_assets_routes:
   - '/government/uploads/'
   - '/media/'

--- a/modules/govuk/manifests/node/s_backend_lb.pp
+++ b/modules/govuk/manifests/node/s_backend_lb.pp
@@ -173,6 +173,10 @@ class govuk::node::s_backend_lb (
   }
 
   if ! $::aws_migration {
+    nginx::conf { 'rate-limiting':
+      content => template('govuk/node/s_backend_lb/rate-limiting.conf.erb'),
+    }
+
     # Custom vhost to proxy assets-origin to asset-manager and whitehall in Carrenza
     validate_array($assets_carrenza_vhost_aliases)
 

--- a/modules/govuk/templates/node/s_backend_lb/assets-carrenza.conf.erb
+++ b/modules/govuk/templates/node/s_backend_lb/assets-carrenza.conf.erb
@@ -47,6 +47,19 @@ server {
     rewrite ^/government/uploads/system/uploads/consultation_response_form/(.*)$ /government/uploads/system/uploads/consultation_response_form_data/$1;
   }
 
+  <%- @app_specific_static_asset_routes.each do |alias_path, vhost_name| -%>
+  <%- if scope.lookupvar('::aws_migration') %>
+  set $upstream_<%= vhost_name.delete "-" %> <%= @upstream_ssl ? 'https' : 'http' %>://<%= vhost_name %>.<%= @app_domain %>;
+  <%- end %>
+  location <%= alias_path %> {
+    <%- if scope.lookupvar('::aws_migration') %>
+    proxy_pass $upstream_<%= vhost_name.delete "-" %>;
+    <%- else %>
+    proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://<%= vhost_name %>.<%= @app_domain %>;
+    <%- end %>
+  }
+  <%- end -%>
+
   <%- if scope.lookupvar('::aws_migration') %>
   set $upstream_asset_manager <%= @upstream_ssl ? 'https' : 'http' %>://asset-manager.<%= @app_domain %>;
   <%- end %>

--- a/modules/govuk/templates/node/s_backend_lb/rate-limiting.conf.erb
+++ b/modules/govuk/templates/node/s_backend_lb/rate-limiting.conf.erb
@@ -1,0 +1,28 @@
+# Bypass rate limiting with `Rate-Limit-Token` headers.
+map $http_Rate_Limit_Token $limit_req {
+  default $binary_remote_addr;
+<%- @rate_limit_tokens.each do |token| -%>
+  <%= token -%> "";
+<%- end -%>
+}
+
+limit_req_zone $limit_req zone=rate:30m rate=10r/s;
+limit_req_zone $limit_req zone=performance:5m rate=5r/s;
+limit_conn_zone $limit_req zone=connections:10m;
+
+# Create another rate limiting zone that only limits POST requests
+# this allows us to limit restful routes where we use one url with
+# GET to render a form and with POST to submit it
+map "$http_Rate_Limit_Token:$request_method" $post_limit_req {
+  <%- @rate_limit_tokens.each do |token| -%>
+    <%= token -%>:POST "";
+  <%- end -%>
+  ~:POST$          $binary_remote_addr;
+  default    "";
+}
+
+limit_req_zone $post_limit_req zone=contact:5m rate=6r/m;
+
+# Return 429 (Too Many Requests) instead of the default 503.
+limit_req_status 429;
+limit_conn_status 429;


### PR DESCRIPTION
- We are aiming to re-route asset-manager traffic from AWS frontends to
asset-manager

- For this we re-work the config formerly found on the cache boxes -
including rate-limiting tokens for the fastly facing connections

solo: @schmie