### PR TITLE
Add proxy configuration for assets-carrenza to backend-lb

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -763,6 +763,24 @@ govuk::node::s_api_redis::allowed_backend_ip_range: "%{hiera('environment_ip_pre
 
 govuk::node::s_asset_base::firewall_allow_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 
+# Note: it's important that all targets here have matching host entries both in
+# production, and on the dev VM, otherwise nginx will fail to start.
+govuk::node::s_backend_lb::app_specific_static_asset_routes:
+  '/asset-manager': "asset-manager"
+  '/government/assets/': "whitehall-frontend"
+govuk::node::s_backend_lb::asset_manager_uploaded_assets_routes:
+  - '/government/uploads/'
+  - '/media/'
+govuk::node::s_backend_lb::whitehall_uploaded_assets_routes:
+  - '/government/placeholder'
+  - '~ ^/government/uploads/system/uploads/attachment_data/file/[0-9]+/.*/preview$'
+govuk::node::s_backend_lb::assets_carrenza_vhost_name: "assets-carrenza.%{hiera('app_domain')}"
+govuk::node::s_backend_lb::draft_assets_carrenza_vhost_name: "draft-assets-carrenza.%{hiera('app_domain')}"
+govuk::node::s_backend_lb::assets_carrenza_vhost_aliases:
+  - 'assets.digital.cabinet-office.gov.uk'
+  - 'assets.publishing.service.gov.uk'
+govuk::node::s_backend_lb::assets_carrenza_real_ip_header: "True-Client-Ip"
+
 govuk::node::s_db_admin::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 govuk::node::s_graphite::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -818,6 +818,22 @@ govuk::node::s_asset_base::firewall_allow_ip_range: "%{hiera('environment_ip_pre
 
 govuk::node::s_base::log_remote: false
 
+govuk::node::s_backend_lb::app_specific_static_asset_routes:
+  '/asset-manager': "asset-manager"
+  '/government/assets/': "whitehall-frontend"
+govuk::node::s_backend_lb::asset_manager_uploaded_assets_routes:
+  - '/government/uploads/'
+  - '/media/'
+govuk::node::s_backend_lb::whitehall_uploaded_assets_routes:
+  - '/government/placeholder'
+  - '~ ^/government/uploads/system/uploads/attachment_data/file/[0-9]+/.*/preview$'
+govuk::node::s_backend_lb::assets_carrenza_vhost_name: "assets-carrenza.%{hiera('app_domain')}"
+govuk::node::s_backend_lb::draft_assets_carrenza_vhost_name: "draft-assets-carrenza.%{hiera('app_domain')}"
+govuk::node::s_backend_lb::assets_carrenza_vhost_aliases:
+  - 'assets.digital.cabinet-office.gov.uk'
+  - 'assets.publishing.service.gov.uk'
+govuk::node::s_backend_lb::assets_carrenza_real_ip_header: "True-Client-Ip"
+
 govuk::node::s_db_admin::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 govuk::node::s_email_alert_api_db_admin::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"

--- a/modules/govuk/manifests/node/s_backend_lb.pp
+++ b/modules/govuk/manifests/node/s_backend_lb.pp
@@ -42,6 +42,14 @@ class govuk::node::s_backend_lb (
   $search_servers = [],
   $ckan_backend_servers = [],
   $maintenance_mode = false,
+  $app_specific_static_asset_routes = {},
+  $asset_manager_uploaded_assets_routes = [],
+  $whitehall_uploaded_assets_routes = [],
+  $assets_carrenza_real_ip_header = '',
+  $assets_carrenza_vhost_aliases = [],
+  $assets_carrenza_vhost_name = 'assets-carrenza',
+  $draft_assets_carrenza_vhost_name = 'draft-assets-carrenza',
+  $assets_carrenza_rate_limit_tokens = [],
 ){
   include govuk::node::s_base
   include loadbalancer
@@ -163,5 +171,60 @@ class govuk::node::s_backend_lb (
   nginx::config::vhost::proxy { "content-performance-api.${app_domain}" :
     to        => ['alphagov.github.io'],
     protected => false,
+  }
+
+  if ! $::aws_migration {
+    nginx::conf { 'rate-limiting':
+      content => template('govuk/node/s_backend_lb/rate-limiting.conf.erb'),
+    }
+
+    # Custom vhost to proxy assets-origin to asset-manager and whitehall in Carrenza
+    validate_array($assets_carrenza_vhost_aliases)
+
+    $enable_ssl = hiera('nginx_enable_ssl', true)
+
+    $upstream_ssl = $enable_ssl
+
+    # suspect we want `protected => false` here
+    # once appropriate firewalling is in place?
+    nginx::config::site { $assets_carrenza_vhost_name:
+      content => template('govuk/node/s_backend_lb/assets-carrenza.conf.erb'),
+    }
+
+    nginx::config::ssl { $assets_carrenza_vhost_name:
+      certtype => 'wildcard_publishing',
+    }
+
+    nginx::log {
+      "${assets_carrenza_vhost_name}-json.event.access.log":
+        json          => true,
+        logstream     => present,
+        statsd_metric => "${::fqdn_metrics}.nginx_logs.assets-carrenza.http_%{status}",
+        statsd_timers => [{metric => "${::fqdn_metrics}.nginx_logs.assets-carrenza.time_request",
+                            value => 'request_time'}];
+      "${assets_carrenza_vhost_name}-error.log":
+        logstream => present;
+    }
+
+    $graphite_429_target = "transformNull(stats.${::fqdn_metrics}.nginx_logs.assets-carrenza.http_429,0)"
+
+    @@icinga::check::graphite { "check_nginx_429_assets_on_${::hostname}":
+      target              => $graphite_429_target,
+      warning             => 3,
+      critical            => 5,
+      from                => '5minutes',
+      desc                => '429 rate for assets-carrenza [in office hours]',
+      host_name           => $::fqdn,
+      notes_url           => monitoring_docs_url(nginx-429-too-many-requests),
+      notification_period => 'inoffice',
+    }
+    # Custom vhost to proxy draft-assets-origin to asset-manager and whitehall in Carrenza
+    nginx::config::site { $draft_assets_carrenza_vhost_name:
+      content => template('govuk/node/s_backend_lb/draft-assets-carrenza.conf.erb'),
+    }
+
+    nginx::config::ssl { $draft_assets_carrenza_vhost_name:
+      certtype => 'wildcard_publishing',
+    }
   }
 }

--- a/modules/govuk/templates/node/s_backend_lb/assets-carrenza.conf.erb
+++ b/modules/govuk/templates/node/s_backend_lb/assets-carrenza.conf.erb
@@ -1,0 +1,124 @@
+server {
+  <%- if scope.lookupvar('::aws_migration') %>
+  server_name <%= @assets_carrenza_vhost_name -%> <%= @assets_carrenza_vhost_name -%>.* <%= @assets_carrenza_vhost_aliases.join(' ') -%>;
+  <%- else %>
+  server_name <%= @assets_carrenza_vhost_name -%> <%= @assets_carrenza_vhost_aliases.join(' ') -%>;
+  <%- end %>
+  listen 80;
+<% if @enable_ssl -%>
+  rewrite ^/(.*) https://$host/$1 permanent;
+}
+
+server {
+  server_name <%= @assets_carrenza_vhost_name -%> <%= @assets_carrenza_vhost_aliases.join(' ') -%>;
+  listen              443 ssl;
+  ssl_certificate     /etc/nginx/ssl/<%= @assets_carrenza_vhost_name -%>.crt;
+  ssl_certificate_key /etc/nginx/ssl/<%= @assets_carrenza_vhost_name -%>.key;
+  include             /etc/nginx/ssl.conf;
+<% end -%>
+  proxy_set_header X-Real-IP $remote_addr;
+  proxy_set_header X-Forwarded-Server $host;
+  proxy_set_header X-Forwarded-Host $host;
+  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+<% if @assets_carrenza_real_ip_header != '' -%>
+
+  # use an unspoofable header from an upstream cdn or l7 load balancer.
+  real_ip_header <%= @assets_carrenza_real_ip_header -%>;
+  real_ip_recursive on;
+  set_real_ip_from 0.0.0.0/0;
+
+  # Limit requests and connections based on $remote_addr.
+  # NB: This may not be accurate if there is a L3 load balancer upstream and
+  # real_ip_header cannot be set!
+  limit_req zone=rate burst=10 nodelay;
+  limit_conn connections 10;
+<% end -%>
+
+  access_log /var/log/nginx/<%= @assets_carrenza_vhost_name -%>-json.event.access.log json_event;
+  error_log /var/log/nginx/<%= @assets_carrenza_vhost_name -%>-error.log;
+
+  add_header "Access-Control-Allow-Origin" "*";
+  add_header "Access-Control-Allow-Methods" "GET, OPTIONS";
+  add_header "Access-Control-Allow-Headers" "origin, authorization";
+
+  location /government/uploads/system/uploads/consultation_response_form/ {
+    add_header Cache-Control "public";
+    expires 1y;
+    rewrite ^/government/uploads/system/uploads/consultation_response_form/(.*)$ /government/uploads/system/uploads/consultation_response_form_data/$1;
+  }
+
+  <%- @app_specific_static_asset_routes.each do |alias_path, assets_carrenza_vhost_name| -%>
+  <%- if scope.lookupvar('::aws_migration') %>
+  set $upstream_<%= assets_carrenza_vhost_name.delete "-" %> <%= @upstream_ssl ? 'https' : 'http' %>://<%= assets_carrenza_vhost_name %>.<%= @app_domain %>;
+  <%- end %>
+  location <%= alias_path %> {
+    <%- if scope.lookupvar('::aws_migration') %>
+    proxy_pass $upstream_<%= assets_carrenza_vhost_name.delete "-" %>;
+    <%- else %>
+    proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://<%= assets_carrenza_vhost_name %>.<%= @app_domain %>;
+    <%- end %>
+  }
+  <%- end -%>
+
+  <%- if scope.lookupvar('::aws_migration') %>
+  set $upstream_asset_manager <%= @upstream_ssl ? 'https' : 'http' %>://asset-manager.<%= @app_domain %>;
+  <%- end %>
+  <%- @asset_manager_uploaded_assets_routes.each do |path| -%>
+  location <%= path %> {
+    # Explicitly re-include Strict-Transport-Security header, this
+    # forces nginx not to clear Cache-Control headers further up the
+    # stack.
+    include /etc/nginx/add-sts.conf;
+
+    add_header "Access-Control-Allow-Origin" "*";
+    add_header "Access-Control-Allow-Methods" "GET, OPTIONS";
+    add_header "Access-Control-Allow-Headers" "origin, authorization";
+
+    <%- if scope.lookupvar('::aws_migration') %>
+    proxy_pass $upstream_asset_manager;
+    <%- else %>
+    proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://asset-manager.<%= @app_domain %>;
+    <%- end %>
+  }
+  <%- end -%>
+
+  <%- if scope.lookupvar('::aws_migration') %>
+  set $upstream_whitehall <%= @upstream_ssl ? 'https' : 'http' %>://whitehall-frontend.<%= @app_domain %>;
+  <%- end %>
+  <%- @whitehall_uploaded_assets_routes.each do |path| -%>
+  location <%= path %> {
+    <%- if scope.lookupvar('::aws_migration') %>
+    proxy_pass $upstream_whitehall;
+    <%- else %>
+    proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://whitehall-frontend.<%= @app_domain %>;
+    <%- end %>
+  }
+  <%- end -%>
+
+  <%- if scope.lookupvar('::aws_migration') %>
+  set $upstream_static <%= @upstream_ssl ? 'https' : 'http' %>://static.<%= @app_domain %>;
+  <%- end %>
+  location = /static/a {
+    <%- if scope.lookupvar('::aws_migration') %>
+    proxy_pass $upstream_static;
+    <%- else %>
+    proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://static.<%= @app_domain %>;
+    <%- end %>
+  }
+
+  location /__canary__ {
+    <%- if scope.lookupvar('::aws_migration') %>
+    proxy_pass $upstream_static;
+    <%- else %>
+    proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://static.<%= @app_domain %>;
+    <%- end %>
+  }
+
+  location / {
+    <%- if scope.lookupvar('::aws_migration') %>
+    proxy_pass $upstream_static;
+    <%- else %>
+    proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://static.<%= @app_domain %>;
+    <%- end %>
+  }
+}

--- a/modules/govuk/templates/node/s_backend_lb/draft-assets-carrenza.conf.erb
+++ b/modules/govuk/templates/node/s_backend_lb/draft-assets-carrenza.conf.erb
@@ -1,0 +1,72 @@
+server {
+  <%- if scope.lookupvar('::aws_migration') %>
+  server_name <%= @draft_assets_carrenza_vhost_name %> <%= @draft_assets_carrenza_vhost_name %>.*;
+  # Send the Strict-Transport-Security header
+  include /etc/nginx/add-sts.conf;
+  <%- else %>
+  server_name <%= @draft_assets_carrenza_vhost_name %>;
+  <%- end %>
+
+  listen 80;
+<% if @enable_ssl -%>
+  rewrite ^/(.*) https://$host/$1 permanent;
+}
+
+server {
+  server_name <%= @draft_assets_carrenza_vhost_name -%>;
+  listen              443 ssl;
+  ssl_certificate     /etc/nginx/ssl/<%= @draft_assets_carrenza_vhost_name -%>.crt;
+  ssl_certificate_key /etc/nginx/ssl/<%= @draft_assets_carrenza_vhost_name -%>.key;
+  include             /etc/nginx/ssl.conf;
+<% end -%>
+
+  proxy_set_header X-Real-IP $remote_addr;
+  proxy_set_header X-Forwarded-Server $host;
+  proxy_set_header X-Forwarded-Host $host;
+  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+<% if @assets_carrenza_real_ip_header != '' -%>
+  # use an unspoofable header from an upstream cdn or l7 load balancer.
+  real_ip_header <%= @assets_carrenza_real_ip_header -%>;
+  real_ip_recursive on;
+  set_real_ip_from 0.0.0.0/0;
+
+  # Limit requests and connections based on $remote_addr.
+  # NB: This may not be accurate if there is a L3 load balancer upstream and
+  # real_ip_header cannot be set!
+  limit_req zone=rate burst=10 nodelay;
+  limit_conn connections 10;
+<% end -%>
+
+  access_log /var/log/nginx/<%= @draft_assets_carrenza_vhost_name %>-json.event.access.log json_event;
+  error_log /var/log/nginx/<%= @draft_assets_carrenza_vhost_name %>-error.log;
+
+  add_header "Access-Control-Allow-Origin" "*";
+  add_header "Access-Control-Allow-Methods" "GET, OPTIONS";
+  add_header "Access-Control-Allow-Headers" "origin, authorization";
+
+  # Avoid falling through to the default host if none of our locations match
+  location / {
+    return 404;
+  }
+  <%- if scope.lookupvar('::aws_migration') %>
+  set $upstream_asset_manager <%= @upstream_ssl ? 'https' : 'http' %>://asset-manager.<%= @app_domain %>;
+  <%- end %>
+  location /auth/ {
+    <%- if scope.lookupvar('::aws_migration') %>
+    proxy_pass $upstream_asset_manager;
+    <%- else %>
+    proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://asset-manager.<%= @app_domain %>;
+    <%- end %>
+  }
+
+  <%- @asset_manager_uploaded_assets_routes.each do |path| -%>
+  location <%= path %> {
+    <%- if scope.lookupvar('::aws_migration') %>
+    proxy_pass $upstream_asset_manager;
+    <%- else %>
+    proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://asset-manager.<%= @app_domain %>;
+    <%- end %>
+  }
+  <%- end -%>
+}

--- a/modules/govuk/templates/node/s_backend_lb/rate-limiting.conf.erb
+++ b/modules/govuk/templates/node/s_backend_lb/rate-limiting.conf.erb
@@ -1,0 +1,28 @@
+# Bypass rate limiting with `Rate-Limit-Token` headers.
+map $http_Rate_Limit_Token $limit_req {
+  default $binary_remote_addr;
+<%- @assets_carrenza_rate_limit_tokens.each do |token| -%>
+  <%= token -%> "";
+<%- end -%>
+}
+
+limit_req_zone $limit_req zone=rate:30m rate=10r/s;
+limit_req_zone $limit_req zone=performance:5m rate=5r/s;
+limit_conn_zone $limit_req zone=connections:10m;
+
+# Create another rate limiting zone that only limits POST requests
+# this allows us to limit restful routes where we use one url with
+# GET to render a form and with POST to submit it
+map "$http_Rate_Limit_Token:$request_method" $post_limit_req {
+  <%- @assets_carrenza_rate_limit_tokens.each do |token| -%>
+    <%= token -%>:POST "";
+  <%- end -%>
+  ~:POST$          $binary_remote_addr;
+  default    "";
+}
+
+limit_req_zone $post_limit_req zone=contact:5m rate=6r/m;
+
+# Return 429 (Too Many Requests) instead of the default 503.
+limit_req_status 429;
+limit_conn_status 429;


### PR DESCRIPTION
- We are aiming to re-route asset-manager traffic from AWS frontends to
asset-manager

- For this we re-work the config formerly found on the cache boxes -
including rate-limiting tokens for the fastly facing connections

solo: @schmie