### PR TITLE
Add spotlight-proxy to the list of exception in router db

### DIFF
--- a/modules/govuk_env_sync/files/govuk_env_sync.sh
+++ b/modules/govuk_env_sync/files/govuk_env_sync.sh
@@ -367,6 +367,9 @@ function postprocess_router {
 
   rummager_domain="${source_domain}"
   mongo_backend_domain_manipulator "rummager" "${rummager_domain}"
+
+  spotlight_proxy_domain="${source_domain}"
+  mongo_backend_domain_manipulator "spotlight-proxy" "${spotlight_proxy_domain}"
 }
 
 function postprocess_database {


### PR DESCRIPTION
  We're not moving this route during the frontends migration to AWS.