### PR TITLE
Point the 'search' alias to search-api if rummager is disabled

### DIFF
--- a/modules/govuk/manifests/apps/rummager.pp
+++ b/modules/govuk/manifests/apps/rummager.pp
@@ -114,9 +114,12 @@ class govuk::apps::rummager(
   }
 
   if $enable_rummager {
+    $vhost_aliases = ['search']
     package { ['aspell', 'aspell-en', 'libaspell-dev']:
       ensure => $spelling_dependencies,
     }
+  } else {
+    $vhost_aliases = []
   }
 
   govuk::app { 'rummager':
@@ -128,7 +131,7 @@ class govuk::apps::rummager(
 
     # support search as an alias for ease of migration from old
     # cluster running in backend VDC.
-    vhost_aliases            => ['search'],
+    vhost_aliases            => $vhost_aliases,
 
     log_format_is_json       => true,
     nginx_extra_config       => '

--- a/modules/govuk/manifests/apps/search_api.pp
+++ b/modules/govuk/manifests/apps/search_api.pp
@@ -104,7 +104,10 @@ class govuk::apps::search_api(
 ) {
   $app_name = 'search-api'
 
-  if ! $rummager_enable {
+  if $rummager_enable {
+    $vhost_aliases = []
+  } else {
+    $vhost_aliases = ['search']
     package { ['aspell', 'aspell-en', 'libaspell-dev']:
       ensure => $spelling_dependencies,
     }
@@ -115,6 +118,8 @@ class govuk::apps::search_api(
     port                     => $port,
     sentry_dsn               => $sentry_dsn,
     health_check_path        => '/search?q=search_healthcheck',
+
+    vhost_aliases            => $vhost_aliases,
 
     log_format_is_json       => true,
     nginx_extra_config       => '


### PR DESCRIPTION
Yes, I managed to call the parameter `enable_rummager` for rummager and `rummager_enable` for search-api.

---

[Trello card](https://trello.com/c/yrq9hZmU/77-point-the-search-alias-to-search-api-if-rummager-is-disabled)