### PR TITLE
Migration: Gor Replay for Integration

### DIFF
--- a/hieradata_aws/class/staging/cache.yaml
+++ b/hieradata_aws/class/staging/cache.yaml
@@ -1,0 +1,4 @@
+---
+router::gor::add_hosts: false
+router::gor::replay_targets:
+  'www-origin.integration.publishing.service.gov.uk': {}

--- a/modules/govuk/manifests/node/s_cache.pp
+++ b/modules/govuk/manifests/node/s_cache.pp
@@ -42,8 +42,11 @@ class govuk::node::s_cache (
 ) inherits govuk::node::s_base {
 
   include govuk_htpasswd
-  include router::gor
   include nscd
+
+  unless ( 'ip-10-12-4' in $::hostname ) and ( $::aws_migration == 'cache' ) and ( $::aws_environment == 'staging' ) {
+    include router::gor
+  }
 
   # Increase the maximum number of file descriptors usable by the router
   # A file descriptor is used per connection


### PR DESCRIPTION
We will soon be migrating the cache router services from carrenza to aws
for staging and production.

So in order to continue having traffic in integration we will need to
replay the aws staging cache router traffic to integration.

This will need to be merged at migration time, when the cache routers
are turned off in carrenza.

We only want to replay traffic from 2 cache nodes in staging to
Integration, as there are only 2 cache nodes in Integration and we do
not want to overload.

@ronocg <conor.glynn@digital.cabinet-office.gov.uk>