### PR TITLE
do not use govuk_node_list --with-puppet-class in carrenza because no such option exist

### DIFF
--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_reboots_required
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_reboots_required
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 
 def create_machines_hash
+  return {} unless File.exist? '/etc/facter/facts.d/aws_environment.txt'
+
   machines_names_hash = Hash.new
 
   `/usr/local/bin/govuk_node_list --with-puppet-class`.each_line do |machine|


### PR DESCRIPTION
# Context

The icinga reboot alert check was changed to be more informative in AWS but this should not happen in Carrenza because the `govuk_node_list --with-puppet-class` does not work in Carrenza. 

# Decisions
1. modify icinga reboot alert ruby script to not call `govuk_node_list --with-puppet-class`