### PR TITLE
Revert "Deploy search-api to AWS production and staging search nodes"

### DIFF
--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -95,7 +95,6 @@ node_class: &node_class
   search:
     apps:
       - rummager
-      - search-api
   whitehall_backend:
     apps:
       - whitehall

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -95,7 +95,6 @@ node_class: &node_class
   search:
     apps:
       - rummager
-      - search-api
   whitehall_backend:
     apps:
       - whitehall


### PR DESCRIPTION
Reverts alphagov/govuk-puppet#8750

The branch/ commit seems to block Puppet deployment rn, for some reason we are trying to revert for AWS migration