### PR TITLE
Speed up the Deploy Terraform GOVUK AWS Jenkins job

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_terraform_govuk_aws.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_terraform_govuk_aws.yaml.erb
@@ -4,6 +4,10 @@
     scm:
         - git:
             url: git@github.com:alphagov/govuk-aws.git
+            shallow-clone: true
+            wipe-workspace: false
+            clean:
+              before: true
             branches:
                 - master
 - job:


### PR DESCRIPTION
By using a shallow clone, and not wiping the workspace. Instead, clean
the workspace before starting jobs.