### PR TITLE
Set preload for Strict-Transport-Security header

### DIFF
--- a/modules/nginx/files/map-sts.conf
+++ b/modules/nginx/files/map-sts.conf
@@ -6,5 +6,5 @@
 # If the header is not set by upstream, then $sts_default will be set
 # and later uses in add_header will be effective.
 map $upstream_http_strict_transport_security $sts_default {
- '' "max-age=31536000";
+ '' "max-age=31536000; preload";
 }


### PR DESCRIPTION
This commit sets the `preload` flag for the `Strict-Transport-Security` HTTP header. This signals to browsers that the domain should be added to the HSTS preload list that is shipped with most modern browsers.