### PR TITLE
Duplicate rummager dashboards for search-api

### DIFF
--- a/modules/grafana/files/dashboards_aws/detailed_search_api_queues.json
+++ b/modules/grafana/files/dashboards_aws/detailed_search_api_queues.json
@@ -1,0 +1,276 @@
+{
+  "id": null,
+  "title": "Search API search indexing dashboard - details",
+  "originalTitle": "Search API search indexing dashboard - details",
+  "tags": [],
+  "style": "dark",
+  "timezone": "utc",
+  "editable": true,
+  "hideControls": false,
+  "sharedCrosshair": false,
+  "rows": [
+    {
+      "collapse": false,
+      "editable": true,
+      "height": "400px",
+      "panels": [
+        {
+          "aliasColors": {
+            "Accepted": "#00C200",
+            "Ignored": "#FF9900"
+          },
+          "bars": true,
+          "grid": {
+            "threshold1": null,
+            "threshold2": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "id": 1,
+          "lines": false,
+          "nullPointMode": "null as zero",
+          "span": 4,
+          "steppedLine": false,
+          "targets": [
+            {
+              "target": "alias(consolidateBy(summarize(stats_counts.govuk.app.search-api.message_queue.indexer.accepted, '1minute', 'sum'), 'max'), 'Accepted')",
+              "refId": "A"
+            },
+            {
+              "target": "alias(consolidateBy(summarize(stats_counts.govuk.app.search-api.message_queue.indexer.rejected, '1minute', 'sum'), 'max'), 'Ignored')",
+              "refId": "B"
+            }
+          ],
+          "title": "Message processor status counts",
+          "tooltip": {
+            "shared": false,
+            "value_type": "individual",
+            "msResolution": true
+          },
+          "type": "graph",
+          "yaxes": [
+            {
+              "show": true,
+              "min": 0,
+              "format": "short",
+              "label": "Messages per minute"
+            },
+            {
+              "show": true,
+              "format": "short"
+            }
+          ],
+          "xaxis": {
+            "show": true
+          },
+          "datasource": "Graphite",
+          "renderer": "flot",
+          "fill": 1,
+          "linewidth": 2,
+          "points": false,
+          "pointradius": 5,
+          "stack": false,
+          "percentage": false,
+          "legend": {
+            "show": true,
+            "values": false,
+            "min": false,
+            "max": false,
+            "current": false,
+            "total": false,
+            "avg": false
+          },
+          "timeFrom": null,
+          "timeShift": null,
+          "seriesOverrides": []
+        },
+        {
+          "aliasColors": {
+            "Failure": "#EE0000",
+            "Success": "#00C200"
+          },
+          "bars": true,
+          "grid": {
+            "threshold1": null,
+            "threshold2": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "id": 2,
+          "lines": false,
+          "nullPointMode": "null as zero",
+          "span": 4,
+          "steppedLine": false,
+          "targets": [
+            {
+              "target": "alias(consolidateBy(summarize(stats_counts.govuk.app.search-api.workers.Indexer.BulkIndexWorker.success, '1minute', 'sum'), 'max'), 'Success')",
+              "refId": "A"
+            },
+            {
+              "target": "alias(consolidateBy(summarize(stats_counts.govuk.app.search-api.workers.Indexer.BulkIndexWorker.failure, '1minute', 'sum'), 'max'), 'Failure')",
+              "refId": "B"
+            }
+          ],
+          "title": "Sidekiq BulkIndexWorker activity (search indexing)",
+          "tooltip": {
+            "shared": false,
+            "value_type": "individual",
+            "msResolution": true
+          },
+          "type": "graph",
+          "yaxes": [
+            {
+              "show": true,
+              "min": 0,
+              "format": "short",
+              "label": "Messages per minute"
+            },
+            {
+              "show": true,
+              "format": "short"
+            }
+          ],
+          "xaxis": {
+            "show": true
+          },
+          "datasource": "Graphite",
+          "renderer": "flot",
+          "fill": 1,
+          "linewidth": 2,
+          "points": false,
+          "pointradius": 5,
+          "stack": false,
+          "percentage": false,
+          "legend": {
+            "show": true,
+            "values": false,
+            "min": false,
+            "max": false,
+            "current": false,
+            "total": false,
+            "avg": false
+          },
+          "timeFrom": null,
+          "timeShift": null,
+          "seriesOverrides": []
+        },
+        {
+          "aliasColors": {
+            "Failure": "#EE0000",
+            "Success": "#00C200"
+          },
+          "bars": true,
+          "grid": {
+            "threshold1": null,
+            "threshold2": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "id": 3,
+          "lines": false,
+          "nullPointMode": "null as zero",
+          "span": 4,
+          "steppedLine": false,
+          "targets": [
+            {
+              "target": "alias(consolidateBy(summarize(stats_counts.govuk.app.search-api.workers.Indexer.DeleteWorker.success, '1minute', 'sum'), 'max'), 'Success')",
+              "refId": "A"
+            },
+            {
+              "target": "alias(consolidateBy(summarize(stats_counts.govuk.app.search-api.workers.Indexer.DeleteWorker.failure, '1minute', 'sum'), 'max'), 'Failure')",
+              "refId": "B"
+            }
+          ],
+          "title": "Sidekiq DeleteWorker activity (search indexing)",
+          "tooltip": {
+            "shared": false,
+            "value_type": "individual",
+            "msResolution": true
+          },
+          "type": "graph",
+          "yaxes": [
+            {
+              "show": true,
+              "min": 0,
+              "format": "short",
+              "label": "Messages per minute"
+            },
+            {
+              "show": true,
+              "format": "short"
+            }
+          ],
+          "xaxis": {
+            "show": true
+          },
+          "datasource": "Graphite",
+          "renderer": "flot",
+          "fill": 1,
+          "linewidth": 2,
+          "points": false,
+          "pointradius": 5,
+          "stack": false,
+          "percentage": false,
+          "legend": {
+            "show": true,
+            "values": false,
+            "min": false,
+            "max": false,
+            "current": false,
+            "total": false,
+            "avg": false
+          },
+          "timeFrom": null,
+          "timeShift": null,
+          "seriesOverrides": []
+        }
+      ],
+      "title": "Row"
+    }
+  ],
+  "time": {
+    "from": "now-2h",
+    "to": "now"
+  },
+  "timepicker": {
+    "collapse": false,
+    "enable": true,
+    "notice": false,
+    "now": true,
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "status": "Stable",
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ],
+    "type": "timepicker"
+  },
+  "templating": {
+    "list": []
+  },
+  "annotations": {
+    "list": []
+  },
+  "refresh": "5s",
+  "schemaVersion": 12,
+  "version": 0,
+  "links": []
+}

--- a/modules/grafana/files/dashboards_aws/search_api_elasticsearch.json
+++ b/modules/grafana/files/dashboards_aws/search_api_elasticsearch.json
@@ -1,0 +1,727 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "hideControls": false,
+  "id": 48,
+  "links": [],
+  "refresh": false,
+  "rows": [
+    {
+      "collapse": false,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Graphite",
+          "fill": 1,
+          "id": 15,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "refId": "A",
+              "target": "divideSeries(sumSeries(*search-*.curl_json-elasticsearch.counter-indices_search_query_time_in_millis),sumSeries(*search-*.curl_json-elasticsearch.counter-indices_search_query_total))",
+              "textEditor": true
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Per-second mean ElasticSearch query duration",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "dtdurationms",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Graphite",
+          "fill": 1,
+          "id": 16,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "refId": "A",
+              "target": "divideSeries(sumSeries(*search-*.curl_json-elasticsearch.counter-indices_search_fetch_time_in_millis),sumSeries(*search-*.curl_json-elasticsearch.counter-indices_search_fetch_total))",
+              "textEditor": true
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Per-second mean ElasticSearch fetch duration",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "dtdurationms",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "New row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Graphite",
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {},
+          "id": 2,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "refId": "A",
+              "target": "aliasByNode(stats_counts.govuk.app.search-api.*.elasticsearch.*,4,6)",
+              "textEditor": true
+            },
+            {
+              "hide": true,
+              "refId": "B",
+              "target": "stats_counts.govuk.app.search-api.govuk_index.elasticsearch.delete",
+              "textEditor": true
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "ElasticSearch index activity",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Graphite",
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {},
+          "id": 4,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "refId": "A",
+              "target": "stats_counts.govuk.app.search-api.message_queue.indexer.*",
+              "textEditor": true
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Link update message queue activity",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "New row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Graphite",
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {},
+          "id": 5,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "hide": false,
+              "refId": "B",
+              "target": "rabbitmq_%2F.queues-search_api*.messages_*",
+              "textEditor": true
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Rabbit MQ messages pending",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Graphite",
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {},
+          "id": 14,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "refId": "A",
+              "target": "rabbitmq_%2F.queues-search_api*.deliver_details-rate",
+              "textEditor": false
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Rabbit MQ message delivery rate (per second)",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "New row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Graphite",
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {},
+          "id": 6,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 12,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "refId": "A",
+              "target": "groupByNode(stats.*.nginx_logs.finder-frontend*.http_5xx, 3, 'sum')",
+              "textEditor": true
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Finder frontend 5xxs",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "New row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Graphite",
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {},
+          "id": 3,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 12,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "refId": "A",
+              "target": "stats.*.nginx_logs.search-api_publishing_service_gov_uk.http_5xx",
+              "textEditor": true
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Search API 5xx responses",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "New row",
+      "titleSize": "h6"
+    }
+  ],
+  "schemaVersion": 14,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "browser",
+  "title": "Search API / ElasticSearch Activity",
+  "version": 0
+}

--- a/modules/grafana/files/dashboards_aws/search_api_queues.json
+++ b/modules/grafana/files/dashboards_aws/search_api_queues.json
@@ -1,0 +1,363 @@
+{
+  "id": null,
+  "title": "Search API search indexing dashboard",
+  "originalTitle": "Search API search indexing dashboard",
+  "tags": [],
+  "style": "dark",
+  "timezone": "utc",
+  "editable": true,
+  "hideControls": false,
+  "sharedCrosshair": false,
+  "rows": [
+    {
+      "collapse": false,
+      "editable": true,
+      "height": "400px",
+      "panels": [
+        {
+          "aliasColors": {
+            "Discarded": "#FF7100",
+            "Error": "#EE0000",
+            "Retried": "#FF9900",
+            "Success": "#00C200"
+          },
+          "bars": true,
+          "grid": {
+            "threshold1": null,
+            "threshold2": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "id": 1,
+          "lines": false,
+          "nullPointMode": "null as zero",
+          "span": 6,
+          "steppedLine": false,
+          "targets": [
+            {
+              "target": "alias(consolidateBy(summarize(stats_counts.govuk.app.search-api.search_api_to_be_indexed.uncaught_exception, '1minute', 'sum'), 'max'), 'Error')",
+              "refId": "A"
+            },
+            {
+              "target": "alias(consolidateBy(summarize(stats_counts.govuk.app.search-api.search_api_to_be_indexed.discarded, '1minute', 'sum'), 'max'), 'Discarded')",
+              "refId": "B"
+            },
+            {
+              "target": "alias(consolidateBy(summarize(stats_counts.govuk.app.search-api.search_api_to_be_indexed.retried, '1minute', 'sum'), 'max'), 'Retried')",
+              "refId": "C"
+            },
+            {
+              "target": "alias(consolidateBy(summarize(stats_counts.govuk.app.search-api.search_api_to_be_indexed.acked, '1minute', 'sum'), 'max'), 'Success')",
+              "refId": "D"
+            }
+          ],
+          "title": "Publishing queue consumer activity (RabbitMQ)",
+          "tooltip": {
+            "shared": false,
+            "value_type": "individual",
+            "msResolution": true
+          },
+          "type": "graph",
+          "yaxes": [
+            {
+              "show": true,
+              "min": 0,
+              "format": "short",
+              "label": "Messages per minute"
+            },
+            {
+              "show": true,
+              "format": "short"
+            }
+          ],
+          "xaxis": {
+            "show": true
+          },
+          "datasource": "Graphite",
+          "renderer": "flot",
+          "fill": 1,
+          "linewidth": 2,
+          "points": false,
+          "pointradius": 5,
+          "stack": false,
+          "percentage": false,
+          "legend": {
+            "show": true,
+            "values": false,
+            "min": false,
+            "max": false,
+            "current": false,
+            "total": false,
+            "avg": false
+          },
+          "timeFrom": null,
+          "timeShift": null,
+          "seriesOverrides": []
+        },
+        {
+          "aliasColors": {
+            "Failure": "#EE0000",
+            "Success": "#00C200"
+          },
+          "bars": true,
+          "grid": {
+            "threshold1": null,
+            "threshold2": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "id": 2,
+          "lines": false,
+          "nullPointMode": "null as zero",
+          "span": 6,
+          "steppedLine": false,
+          "targets": [
+            {
+              "target": "alias(consolidateBy(summarize(stats_counts.govuk.app.search-api.workers.Indexer.AmendWorker.success, '1minute', 'sum'), 'max'), 'Success')",
+              "refId": "A"
+            },
+            {
+              "target": "alias(consolidateBy(summarize(stats_counts.govuk.app.search-api.workers.Indexer.AmendWorker.failure, '1minute', 'sum'), 'max'), 'Failure')",
+              "refId": "B"
+            }
+          ],
+          "title": "Sidekiq AmendWorker activity (search indexing)",
+          "type": "graph",
+          "yaxes": [
+            {
+              "show": true,
+              "min": 0,
+              "format": "short",
+              "label": "Messages per minute"
+            },
+            {
+              "show": true,
+              "format": "short"
+            }
+          ],
+          "xaxis": {
+            "show": true
+          },
+          "datasource": "Graphite",
+          "renderer": "flot",
+          "fill": 1,
+          "linewidth": 2,
+          "points": false,
+          "pointradius": 5,
+          "stack": false,
+          "percentage": false,
+          "legend": {
+            "show": true,
+            "values": false,
+            "min": false,
+            "max": false,
+            "current": false,
+            "total": false,
+            "avg": false
+          },
+          "tooltip": {
+            "value_type": "cumulative",
+            "shared": true,
+            "msResolution": true
+          },
+          "timeFrom": null,
+          "timeShift": null,
+          "seriesOverrides": []
+        }
+      ],
+      "title": "Row"
+    },
+    {
+      "collapse": false,
+      "editable": true,
+      "height": "200px",
+      "panels": [
+        {
+          "aliasColors": {
+            "Unprocessed": "#0662D9"
+          },
+          "bars": false,
+          "datasource": "Graphite",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {
+            "threshold1": null,
+            "threshold2": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "id": 3,
+          "legend": {
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 3,
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "target": "alias(consolidateBy(summarize(rabbitmq_%2F.queues-search_api_to_be_indexed.messages_ready, '10s', 'max'), 'max'), 'Unprocessed')",
+              "refId": "A"
+            }
+          ],
+          "title": "Publishing queue size (RabbitMQ)",
+          "tooltip": {
+            "shared": false,
+            "value_type": "cumulative",
+            "msResolution": true
+          },
+          "type": "graph",
+          "yaxes": [
+            {
+              "show": true,
+              "min": 0,
+              "format": "short",
+              "label": "message count"
+            },
+            {
+              "show": true,
+              "format": "short"
+            }
+          ],
+          "xaxis": {
+            "show": true
+          },
+          "timeFrom": null,
+          "timeShift": null,
+          "seriesOverrides": []
+        },
+        {
+          "aliasColors": {
+            "Enqueued": "#0662D9",
+            "Retry Set": "#BA43A9"
+          },
+          "bars": false,
+          "datasource": "Graphite",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {
+            "threshold1": null,
+            "threshold2": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "id": 4,
+          "legend": {
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 3,
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "target": "alias(consolidateBy(summarize(stats.gauges.govuk.app.search-api.*.workers.enqueued, '10s', 'max'), 'max'), 'Enqueued')",
+              "refId": "A"
+            },
+            {
+              "target": "alias(consolidateBy(summarize(stats.gauges.govuk.app.search-api.*.workers.retry_set_size, '10s', 'max'), 'max'), 'Retry Set')",
+              "refId": "B"
+            }
+          ],
+          "title": "Sidekiq queue size",
+          "tooltip": {
+            "shared": false,
+            "value_type": "cumulative",
+            "msResolution": true
+          },
+          "type": "graph",
+          "yaxes": [
+            {
+              "show": true,
+              "min": 0,
+              "format": "short",
+              "label": "message count"
+            },
+            {
+              "show": true,
+              "format": "short"
+            }
+          ],
+          "xaxis": {
+            "show": true
+          },
+          "timeFrom": null,
+          "timeShift": null,
+          "seriesOverrides": []
+        }
+      ],
+      "title": "Row"
+    }
+  ],
+  "time": {
+    "from": "now-2h",
+    "to": "now"
+  },
+  "timepicker": {
+    "collapse": false,
+    "enable": true,
+    "notice": false,
+    "now": true,
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "status": "Stable",
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ],
+    "type": "timepicker"
+  },
+  "templating": {
+    "list": []
+  },
+  "annotations": {
+    "list": []
+  },
+  "refresh": "5s",
+  "schemaVersion": 12,
+  "version": 0,
+  "links": []
+}

--- a/modules/grafana/manifests/dashboards.pp
+++ b/modules/grafana/manifests/dashboards.pp
@@ -50,6 +50,10 @@ class grafana::dashboards (
       "${dashboard_directory}/aws-elb-classic-load-balancer.json": source => 'puppet:///modules/grafana/dashboards_aws/aws-elb-classic-load-balancer.json';
       "${dashboard_directory}/aws-rds.json": source => 'puppet:///modules/grafana/dashboards_aws/aws-rds.json';
       "${dashboard_directory}/aws-s3.json": source => 'puppet:///modules/grafana/dashboards_aws/aws-s3.json';
+      "${dashboard_directory}/detailed_search_api_queues.json": source => 'puppet:///modules/grafana/dashboards_aws/detailed_search_api_queues.json';
+      "${dashboard_directory}/search_api_elasticsearch.json": source => 'puppet:///modules/grafana/dashboards_aws/search_api_elasticsearch.json';
+      "${dashboard_directory}/search_api_queues.json": source => 'puppet:///modules/grafana/dashboards_aws/search_api_queues.json';
+      "${dashboard_directory}/search_api_index_size.json": content => template('grafana/dashboards_aws/search_api_index_size.json.erb');
     }
   }
 }

--- a/modules/grafana/templates/dashboards_aws/_index_size.json.erb
+++ b/modules/grafana/templates/dashboards_aws/_index_size.json.erb
@@ -1,0 +1,174 @@
+<% @index_names.each_with_index do |index_name, j| %>
+  <%= ',' if j > 0 %>{
+    "collapse": false,
+    "height": 250,
+    "panels": [
+      {
+        "columns": [
+          {
+            "text": "Current",
+            "value": "current"
+          }
+        ],
+        "datasource": "Graphite",
+        "fontSize": "100%",
+        "hideTimeOverride": true,
+        "id": <%= j * 2 %>,
+        "links": [],
+        "pageSize": null,
+        "scroll": true,
+        "showHeader": true,
+        "sort": {
+          "col": 0,
+          "desc": true
+        },
+        "span": 4,
+        "styles": [
+          {
+            "alias": "Time",
+            "dateFormat": "DD MMM YYYY",
+            "pattern": "Time",
+            "type": "date"
+          },
+          {
+            "alias": "",
+            "colorMode": null,
+            "colors": [
+              "rgba(245, 54, 54, 0.9)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(50, 172, 45, 0.97)"
+            ],
+            "decimals": 0,
+            "pattern": "/.*/",
+            "thresholds": [
+              ""
+            ],
+            "type": "number",
+            "unit": "none"
+          }
+        ],
+        "targets": [
+          {
+            "refId": "A",
+            "target": "alias(diffSeries(keepLastValue(stats.gauges.govuk.app.search-api.<%= index_name %>_index.docs.count,252), timeShift(keepLastValue(stats.gauges.govuk.app.search-api.<%= index_name %>_index.docs.count,252), '7d')),'Change')",
+            "textEditor": true
+          },
+          {
+            "refId": "B",
+            "target": "alias(keepLastValue(stats.gauges.govuk.app.search-api.<%= index_name %>_index.docs.count,252),'Index size')",
+            "textEditor": true
+          },
+          {
+            "refId": "C",
+            "target": "alias(timeShift(keepLastValue(stats.gauges.govuk.app.search-api.<%= index_name %>_index.docs.count,252), '7d'),'Index size (last week)')",
+            "textEditor": true
+          }
+        ],
+        "timeFrom": "5s",
+        "timeShift": null,
+        "title": "Change stats - <%= index_name %>",
+        "transform": "timeseries_aggregations",
+        "type": "table"
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "Graphite",
+        "fill": 1,
+        "hideTimeOverride": true,
+        "id": <%= 1 + (j * 2) %>,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null",
+        "percentage": false,
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [
+          {
+            "alias": "Change",
+            "color": "#BF1B00",
+            "linewidth": 5,
+            "yaxis": 2
+          }
+        ],
+        "spaceLength": 10,
+        "span": 8,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "refId": "C",
+            "target": "alias(diffSeries(keepLastValue(stats.gauges.govuk.app.search-api.<%= index_name %>_index.docs.count,252), timeShift(keepLastValue(stats.gauges.govuk.app.search-api.<%= index_name %>_index.docs.count,252), '7d')),'Change')",
+            "textEditor": true
+          },
+          {
+            "refId": "A",
+            "target": "alias(keepLastValue(stats.gauges.govuk.app.search-api.<%= index_name %>_index.docs.count,252), 'Index size')",
+            "textEditor": true
+          },
+          {
+            "refId": "B",
+            "target": "alias(timeShift(keepLastValue(stats.gauges.govuk.app.search-api.<%= index_name %>_index.docs.count,252),'7d'), 'Index size (last week)')",
+            "textEditor": true
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": "1d",
+        "timeShift": null,
+        "title": "<%= index_name %>",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "decimals": 0,
+            "format": "short",
+            "label": "Index Size",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "decimals": 0,
+            "format": "short",
+            "label": "Change (count)",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ]
+      }
+    ],
+    "repeat": null,
+    "repeatIteration": null,
+    "repeatRowId": null,
+    "showTitle": false,
+    "title": "Dashboard Row",
+    "titleSize": "h6"
+  }
+<% end %>

--- a/modules/grafana/templates/dashboards_aws/search_api_index_size.json.erb
+++ b/modules/grafana/templates/dashboards_aws/search_api_index_size.json.erb
@@ -1,0 +1,73 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "hideControls": false,
+  "id": 63,
+  "links": [],
+  "refresh": false,
+  "rows": [
+    {
+      "collapse": false,
+      "height": 250,
+      "panels": [
+        {
+          "content": "# Index change time periods\n\nWe only store the last 8 days of data in graphite in 5 second intervals (after this it is aggregated). \n\nWe can only view the last days worth of data, as we compare using a 7 day offset,  as 7 + 1 = 8, our maximum range of data.",
+          "id": 6,
+          "mode": "markdown",
+          "span": 12,
+          "title": "Panel Title",
+          "type": "text"
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    },
+    <%= scope.function_template(["grafana/dashboards/_index_size.json.erb"]) %>
+  ],
+  "schemaVersion": 14,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-7d",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Search API (Elasticsearch) index sizing",
+  "version": 1
+}


### PR DESCRIPTION
As search-api is deployed to AWS, these dashboards only exist in AWS.

---

[Trello card](https://trello.com/c/7xTSf5UI/73-update-grafana-dashboards-for-new-cluster)