### PR TITLE
Configure Sidekiq & Redis for Content Publisher

### DIFF
--- a/development-vm/Procfile
+++ b/development-vm/Procfile
@@ -185,3 +185,4 @@ search-api-govuk-index-listener:  govuk_setenv search-api ./run_in.sh ../../sear
 search-api-bulk-reindex-listener: govuk_setenv search-api ./run_in.sh ../../search-api    bundle exec rake message_queue:bulk_insert_data_into_govuk
 # sidekiq-monitoring for search-api uses 3234
 content-data-api:      govuk_setenv content-data-api ./run_in.sh ../../content-data-api bundle exec rails server -p 3235
+# sidekiq-monitoring for content-publisher uses 3236

--- a/development-vm/Procfile
+++ b/development-vm/Procfile
@@ -186,3 +186,5 @@ search-api-bulk-reindex-listener: govuk_setenv search-api ./run_in.sh ../../sear
 # sidekiq-monitoring for search-api uses 3234
 content-data-api:      govuk_setenv content-data-api ./run_in.sh ../../content-data-api bundle exec rails server -p 3235
 # sidekiq-monitoring for content-publisher uses 3236
+# byebug web listener for content-publisher uses 3237
+# byebug sidekiq listener for content-publisher uses 3238

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -414,6 +414,8 @@ govuk::apps::content_publisher::db_allow_prepared_statements: false
 govuk::apps::content_publisher::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 govuk::apps::content_publisher::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
 govuk::apps::content_publisher::aws_region: "eu-west-1"
+govuk::apps::content_publisher::redis_host: "%{hiera('sidekiq_host')}"
+govuk::apps::content_publisher::redis_port: "%{hiera('sidekiq_port')}"
 
 govuk::apps::content_store::nagios_memory_warning: 2600
 govuk::apps::content_store::nagios_memory_critical: 2800
@@ -631,6 +633,8 @@ govuk::apps::sidekiq_monitoring::content_audit_tool_redis_host: "%{hiera('govuk:
 govuk::apps::sidekiq_monitoring::content_audit_tool_redis_port: "%{hiera('govuk::apps::content_audit_tool::redis_port')}"
 govuk::apps::sidekiq_monitoring::content_performance_manager_redis_host: "%{hiera('govuk::apps::content_performance_manager::redis_host')}"
 govuk::apps::sidekiq_monitoring::content_performance_manager_redis_port: "%{hiera('govuk::apps::content_performance_manager::redis_port')}"
+govuk::apps::sidekiq_monitoring::content_publisher_redis_host: "%{hiera('govuk::apps::content_publisher::redis_host')}"
+govuk::apps::sidekiq_monitoring::content_publisher_redis_port: "%{hiera('govuk::apps::content_publisher::redis_port')}"
 govuk::apps::sidekiq_monitoring::content_tagger_redis_host: "%{hiera('govuk::apps::content_tagger::redis_host')}"
 govuk::apps::sidekiq_monitoring::content_tagger_redis_port: "%{hiera('govuk::apps::content_tagger::redis_port')}"
 govuk::apps::sidekiq_monitoring::email_alert_api_redis_host: "%{hiera('govuk::apps::email_alert_api::redis_host')}"
@@ -1137,7 +1141,9 @@ grafana::dashboards::application_dashboards:
   content-performance-manager:
     show_sidekiq_graphs: true
     has_workers: true
-  content-publisher: {}
+  content-publisher:
+    show_sidekiq_graphs: true
+    has_workers: true
   content-store:
     dependent_app_5xx_errors:
       - calendars

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -449,6 +449,8 @@ govuk::apps::content_publisher::db::lb_ip_range: "%{hiera('environment_ip_prefix
 govuk::apps::content_publisher::db::rds: true
 govuk::apps::content_publisher::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
 govuk::apps::content_publisher::aws_region: "eu-west-1"
+govuk::apps::content_publisher::redis_host: "%{hiera('sidekiq_host')}"
+govuk::apps::content_publisher::redis_port: "%{hiera('sidekiq_port')}"
 
 govuk::apps::content_store::nagios_memory_warning: 2600
 govuk::apps::content_store::nagios_memory_critical: 2800
@@ -685,6 +687,8 @@ govuk::apps::sidekiq_monitoring::content_audit_tool_redis_host: "%{hiera('govuk:
 govuk::apps::sidekiq_monitoring::content_audit_tool_redis_port: "%{hiera('govuk::apps::content_audit_tool::redis_port')}"
 govuk::apps::sidekiq_monitoring::content_performance_manager_redis_host: "%{hiera('govuk::apps::content_performance_manager::redis_host')}"
 govuk::apps::sidekiq_monitoring::content_performance_manager_redis_port: "%{hiera('govuk::apps::content_performance_manager::redis_port')}"
+govuk::apps::sidekiq_monitoring::content_publisher_redis_host: "%{hiera('govuk::apps::content_publisher::redis_host')}"
+govuk::apps::sidekiq_monitoring::content_publisher_redis_port: "%{hiera('govuk::apps::content_publisher::redis_port')}"
 govuk::apps::sidekiq_monitoring::content_tagger_redis_host: "%{hiera('govuk::apps::content_tagger::redis_host')}"
 govuk::apps::sidekiq_monitoring::content_tagger_redis_port: "%{hiera('govuk::apps::content_tagger::redis_port')}"
 govuk::apps::sidekiq_monitoring::email_alert_api_redis_host: "%{hiera('govuk::apps::email_alert_api::redis_host')}"
@@ -1052,7 +1056,9 @@ grafana::dashboards::application_dashboards:
   content-performance-manager:
     show_sidekiq_graphs: true
     has_workers: true
-  content-publisher: {}
+  content-publisher:
+    show_sidekiq_graphs: true
+    has_workers: true
   content-store:
     dependent_app_5xx_errors:
       - calendars

--- a/modules/govuk/manifests/apps/content_publisher.pp
+++ b/modules/govuk/manifests/apps/content_publisher.pp
@@ -75,6 +75,14 @@
 #   The bearer token to use when communicating with Asset Manager.
 #   Default: undef
 #
+# [*redis_host*]
+#   Redis host for Sidekiq.
+#   Default: undef
+#
+# [*redis_port*]
+#   Redis port for Sidekiq.
+#   Default: undef
+#
 class govuk::apps::content_publisher (
   $port = '3221',
   $enabled = true,
@@ -98,6 +106,8 @@ class govuk::apps::content_publisher (
   $google_tag_manager_preview = undef,
   $google_tag_manager_auth = undef,
   $asset_manager_bearer_token = undef,
+  $redis_host = undef,
+  $redis_port = undef,
 ) {
   $app_name = 'content-publisher'
 
@@ -164,6 +174,11 @@ class govuk::apps::content_publisher (
     "${title}-ASSET_MANAGER_BEARER_TOKEN":
         varname => 'ASSET_MANAGER_BEARER_TOKEN',
         value   => $asset_manager_bearer_token;
+  }
+
+  govuk::app::envvar::redis { $app_name:
+    host => $redis_host,
+    port => $redis_port,
   }
 
   if $::govuk_node_class !~ /^development$/ {

--- a/modules/govuk/manifests/apps/sidekiq_monitoring.pp
+++ b/modules/govuk/manifests/apps/sidekiq_monitoring.pp
@@ -46,6 +46,14 @@
 #   Redis port for Content Performance Manager Sidekiq.
 #   Default: undef
 #
+# [*content_publisher_redis_host*]
+#   Redis host for Content Publisher Sidekiq.
+#   Default: undef
+#
+# [*content_publisher_redis_port*]
+#   Redis port for Content Publisher Sidekiq.
+#   Default: undef
+#
 # [*content_tagger_redis_host*]
 #   Redis host for Content Tagger Sidekiq.
 #   Default: undef
@@ -177,6 +185,8 @@ class govuk::apps::sidekiq_monitoring (
   $content_audit_tool_redis_port = undef,
   $content_performance_manager_redis_host = undef,
   $content_performance_manager_redis_port = undef,
+  $content_publisher_redis_host = undef,
+  $content_publisher_redis_port = undef,
   $content_tagger_redis_host = undef,
   $content_tagger_redis_port = undef,
   $email_alert_api_redis_host = undef,
@@ -254,6 +264,11 @@ class govuk::apps::sidekiq_monitoring (
       prefix => 'content_performance_manager',
       host   => $content_performance_manager_redis_host,
       port   => $content_performance_manager_redis_port;
+
+    "${app_name}_content_publisher":
+      prefix => 'content_publisher',
+      host   => $content_publisher_redis_host,
+      port   => $content_publisher_redis_port;
 
     "${app_name}_content_tagger":
       prefix => 'content_tagger',

--- a/modules/govuk/templates/sidekiq_monitoring_nginx_config.conf.erb
+++ b/modules/govuk/templates/sidekiq_monitoring_nginx_config.conf.erb
@@ -34,6 +34,10 @@ server {
     proxy_pass http://localhost:3207;
   }
 
+  location /content-publisher {
+    proxy_pass http://localhost:3236;
+  }
+
   location /content-tagger {
     proxy_pass http://localhost:3125;
   }


### PR DESCRIPTION
For https://trello.com/c/rXTLvzSu/685-scheduling-is-sent-to-the-publishing-api