### PR TITLE
Update HSTS header check

### DIFF
--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_hsts_headers
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_hsts_headers
@@ -30,7 +30,7 @@ try:
     args = parser.parse_args()
 
     url      = args.url
-    expected = "max-age={0}".format(args.maxage)
+    expected = "max-age={0}; preload".format(args.maxage)
 
     if args.username:
         if args.password:
@@ -50,4 +50,3 @@ try:
         ok("Expected Strict-Transport-Security header on {0} to be {1} and found: {2}".format(url, expected, sts_header))
 except Exception, e:
     unknown("Unknown error: {0}".format(e))
-


### PR DESCRIPTION
This was updated in https://github.com/alphagov/govuk-puppet/pull/8774

This is currently alerting: https://alert.publishing.service.gov.uk/cgi-bin/icinga/extinfo.cgi?type=2&host=monitoring-1.management.publishing.service.gov.uk&service=Strict-Transport-Security+headers