### PR TITLE
Add the node class for the Content Data API DB Admin machines

### DIFF
--- a/modules/govuk/manifests/apps/content_data_api/db.pp
+++ b/modules/govuk/manifests/apps/content_data_api/db.pp
@@ -6,7 +6,7 @@
 #   The DB instance password.
 #
 class govuk::apps::content_data_api::db (
-  $password,
+  $password = undef,
 ) {
   govuk_postgresql::db { 'content_performance_manager_production':
     user                => 'content_performance_manager',

--- a/modules/govuk/manifests/node/s_content_data_api_db_admin.pp
+++ b/modules/govuk/manifests/node/s_content_data_api_db_admin.pp
@@ -1,0 +1,42 @@
+# == Class: govuk_node::s_content_data_api_db_admin
+#
+# This machine class is used to administer the Content Data API
+# PostgreSQL RDS instances.
+#
+# === Parameters
+#
+# [*postgresql_host*]
+#   The hostname to put in the .pgpass file.
+#
+# [*postgresql_user*]
+#   The user to put in the .pgpass file.
+#
+# [*postgresql_password*]
+#   The password to put in the .pgpass file.
+#
+# [*postgresql_port*]
+#   The port to put in the .pgpass file.
+#
+class govuk::node::s_content_data_api_db_admin(
+  $postgresql_host        = undef,
+  $postgresql_user        = undef,
+  $postgresql_password    = undef,
+  $postgresql_port        = '5432',
+) {
+  include govuk_env_sync
+  include ::govuk::node::s_base
+
+  # This allows easy administration of the PostgreSQL backend:
+  # https://www.postgresql.org/docs/9.3/static/libpq-pgpass.html
+  file { '/root/.pgpass':
+    ensure  => present,
+    mode    => '0600',
+    content => "${postgresql_host}:5432:*:${postgresql_user}:${postgresql_password}",
+  }
+
+  # Ensure the client class is installed
+  class { '::govuk_postgresql::client': } ->
+
+  # include all PostgreSQL classes that create databases and users
+  class { '::govuk::apps::content_data_api::db': }
+}


### PR DESCRIPTION
The Content Data API is the new name for the Content Performance
Manager, this is the new machine to administer the database from.