### PR TITLE
Enable DCAT clean_tags

### DIFF
--- a/modules/govuk/templates/ckan/ckan.ini.erb
+++ b/modules/govuk/templates/ckan/ckan.ini.erb
@@ -113,6 +113,8 @@ ckan.harvest.mq.redis_db = 1
 
 ckan.redis.url = redis://<%= @redis_host%>:<%= @redis_port%>/1
 
+ckanext.dcat.clean_tags = true
+
 ckan.spatial.validator.profiles = iso19139eden,constraints-1.4,gemini2-1.3
 ckan.spatial.validator.reject = true
 ckan.spatial.srid = 4258


### PR DESCRIPTION
This prevents the harvesting process from crashing whenever it finds a dataset with an invalid tag.

This option was added in https://github.com/ckan/ckanext-dcat/pull/104 to fix problems like we're currently seeing in the harvesting process:

```
  File "/data/vhost/ckan/shared/venv/lib/python2.7/site-packages/ckanext/harvest/queue.py", line 425, in fetch_and_import_stages
    success_import = harvester.import_stage(obj)
  File "/data/vhost/ckan/shared/venv/lib/python2.7/site-packages/ckanext/dcat/harvesters/_json.py", line 282, in import_stage
    p.toolkit.get_action('package_update')(context, package_dict)
  File "/data/vhost/ckan/shared/venv/src/ckan/ckan/logic/__init__.py", line 457, in wrapped
    result = _action(context, data_dict, **kw)
  File "/data/vhost/ckan/shared/venv/src/ckan/ckan/logic/action/update.py", line 299, in package_update
    raise ValidationError(errors)
ckan.logic.ValidationError: {'tags': [u'Tag "Adults\' Services" must be alphanumeric characters or symbols: -_.', {}, {}, {}, {}, {}]}
```

[Trello Card](https://trello.com/c/oSTgv8l5/807-find-out-whether-rolling-back-harvesters-has-improved-the-situation)