### PR TITLE
Fix the apps_using_rabbitmq value for the Content Data API

### DIFF
--- a/hieradata_aws/class/rabbitmq.yaml
+++ b/hieradata_aws/class/rabbitmq.yaml
@@ -5,7 +5,7 @@ govuk::node::s_rabbitmq::apps_using_rabbitmq:
   - email_alert_service
   - publishing_api
   - rummager
-  - content-data-api
+  - content_data_api
   - content_performance_manager
   - cache_clearing_service
   - search_api


### PR DESCRIPTION
The value relates to the Puppet class, so it needs to have
underscores, rather than dashes.