### PR TITLE
Attempt to fix the s_content_data_api_db_admin class

### DIFF
--- a/modules/govuk/manifests/node/s_content_data_api_db_admin.pp
+++ b/modules/govuk/manifests/node/s_content_data_api_db_admin.pp
@@ -6,16 +6,20 @@
 # === Parameters
 #
 # [*postgresql_host*]
-#   The hostname to put in the .pgpass file.
+#   Hostname of the RDS database to use.
+#   Default: undef
 #
 # [*postgresql_user*]
-#   The user to put in the .pgpass file.
+#   The PostgreSQL user to use for admisistering the database.
+#   Default: undef
 #
 # [*postgresql_password*]
-#   The password to put in the .pgpass file.
+#   The password corresponding to the above `postgresql_user`.
+#   Default: undef
 #
 # [*postgresql_port*]
-#   The port to put in the .pgpass file.
+#   The port with which to connect to the `postgresql_host`.
+#   Default: '5432'
 #
 class govuk::node::s_content_data_api_db_admin(
   $postgresql_host        = undef,
@@ -33,6 +37,29 @@ class govuk::node::s_content_data_api_db_admin(
     mode    => '0600',
     content => "${postgresql_host}:5432:*:${postgresql_user}:${postgresql_password}",
   }
+
+  # Unfortunately, the prior art for configuring db-admin style
+  # machines seems to involve a redundant PostgreSQL service, just to
+  # satisfy the Puppet module used to configure PostgreSQL running on
+  # the RDS instance. Some of the below configuration relates to this.
+
+  # Connect to the RDS instance when performing Puppet operations
+  $default_connect_settings = {
+    'PGUSER'     => $postgresql_user,
+    'PGPASSWORD' => $postgresql_password,
+    'PGHOST'     => $postgresql_host,
+    'PGPORT'     => $postgresql_port,
+  }
+
+  # We don't actually want to run a local PostgreSQL server, just
+  # configure the RDS one
+  class { '::postgresql::server':
+    default_connect_settings => $default_connect_settings,
+    package_ensure           => absent,
+    service_manage           => false,
+  }
+
+  include ::govuk_postgresql::server::not_slave
 
   # Ensure the client class is installed
   class { '::govuk_postgresql::client': } ->


### PR DESCRIPTION
Puppet is currently failing due to this error. I had attempted to keep
the configuration quite minimal to avoid the redundant PostgreSQL
service running on the DB Admin machine, but this hasn't worked out
yet.

This commits adds some more configuration taken from the other DB
Admin classes, which hopefully will allow Puppet to run, and maybe
avoid running a PostgreSQL service as well.

1:

Invalid relationship: Postgresql_psql[Add plpgsql extension to content_performance_manager_production] { require => Postgresql::Server::Database[content_performance_manager_production] }, because Postgresql::Server::Database[content_performance_manager_production] doesn't seem to be in the catalog