### PR TITLE
Make Upstart more lenient to harvesting restarts

### DIFF
--- a/modules/govuk/manifests/apps/ckan.pp
+++ b/modules/govuk/manifests/apps/ckan.pp
@@ -115,6 +115,7 @@ class govuk::apps::ckan (
       setenv_as      => 'ckan',
       enable_service => $enable_harvester_fetch,
       process_type   => 'harvester_fetch_consumer',
+      respawn_count  => 15,
     }
 
     govuk::procfile::worker { 'harvester_gather_consumer':

--- a/modules/govuk/manifests/procfile/worker.pp
+++ b/modules/govuk/manifests/procfile/worker.pp
@@ -38,6 +38,8 @@ define govuk::procfile::worker (
   $setenv_as = $title,
   $process_count = 1,
   $alert_when_threads_exceed = 50,
+  $respawn_count = 5,
+  $respawn_timeout = 20,
 ) {
   validate_re($ensure, '^(present|absent)$', '$ensure must be "present" or "absent"')
 

--- a/modules/govuk/templates/procfile-worker_child.conf.erb
+++ b/modules/govuk/templates/procfile-worker_child.conf.erb
@@ -4,8 +4,9 @@ instance $INDEX
 
 respawn
 
-# If the app respawns more than 5 times in 20 seconds, it has deeper problems
-# and should be killed off.
-respawn limit 5 20
+# If the app respawns more than <%= @respawn_count %> times in
+# <%= @respawn_timeout %> seconds, it has deeper problems and should be
+# killed off.
+respawn limit <%= @respawn_count %> <%= @respawn_timeout %>
 
 exec govuk_setenv <%= @setenv_as %> govuk_run_procfile_worker <%= @process_type %>


### PR DESCRIPTION
We often see the harvesting process crash due to a bug in the code. After restarting, it will proceed with the next item in the harvesting queue and continue normally. However, sometimes we see that there are lots of harvesting jobs which cause the process to crash grouped together in the queue. This causes Upstart to think the harvesting process isn't working properly and stops restarting it.

Until we have sufficient alerting about this process we can tell Upstart to be more lenient when decided whether the process has died or not and make it more likely to be restarted.

I picked the number of 15 because it felt right, we may have to tweak that number if the process is still not being restarted.

[Trello Card](https://trello.com/c/07jTJBX5/823-make-ckan-harvesting-restart-when-it-fails)