### PR TITLE
Enable daily push of router and licence-finder db in AWS

### DIFF
--- a/hieradata_aws/class/production/mongo.yaml
+++ b/hieradata_aws/class/production/mongo.yaml
@@ -65,9 +65,9 @@ govuk_env_sync::tasks:
     temppath: "/var/lib/mongodb/.dumps"
     url: "govuk-production-database-backups"
     path: "mongo-api"
-  "pull_licence_finder_production":
-    ensure: "absent"
-    hour: "2"
+  "push_licence_finder_production":
+    ensure: "present"
+    hour: "0"
     minute: "21"
     action: "pull"
     dbms: "mongo"

--- a/hieradata_aws/class/production/router_backend.yaml
+++ b/hieradata_aws/class/production/router_backend.yaml
@@ -1,7 +1,7 @@
 govuk_env_sync::tasks:
-  "pull_router_daily":
-    ensure: "absent"
-    hour: "1"
+  "push_router_daily":
+    ensure: "present"
+    hour: "0"
     minute: "24"
     action: "pull"
     dbms: "mongo"
@@ -10,9 +10,9 @@ govuk_env_sync::tasks:
     temppath: "/tmp/.dumps"
     url: "govuk-production-database-backups"
     path: "mongo-router"
-  "pull_draft_router_daily":
-    ensure: "absent"
-    hour: "1"
+  "push_draft_router_daily":
+    ensure: "present"
+    hour: "0"
     minute: "45"
     action: "pull"
     dbms: "mongo"


### PR DESCRIPTION
  Migration of router-backend and licence-finder in AWS is now
complete