### PR TITLE
Revert "Increase frontend app 5xx thresholds"

### DIFF
--- a/modules/govuk/manifests/apps/finder_frontend.pp
+++ b/modules/govuk/manifests/apps/finder_frontend.pp
@@ -49,8 +49,6 @@ class govuk::apps::finder_frontend(
       nagios_memory_critical   => $nagios_memory_critical,
       unicorn_worker_processes => $unicorn_worker_processes,
       override_search_location => $override_search_location,
-      alert_5xx_warning_rate   => 0.1,
-      alert_5xx_critical_rate  => 0.2,
     }
   }
 

--- a/modules/govuk/manifests/apps/government_frontend.pp
+++ b/modules/govuk/manifests/apps/government_frontend.pp
@@ -69,7 +69,5 @@ class govuk::apps::government_frontend(
     cpu_critical             => $cpu_critical,
     nagios_memory_warning    => $nagios_memory_warning,
     nagios_memory_critical   => $nagios_memory_critical,
-    alert_5xx_warning_rate   => 0.2,
-    alert_5xx_critical_rate  => 0.3,
   }
 }

--- a/modules/govuk/manifests/apps/manuals_frontend.pp
+++ b/modules/govuk/manifests/apps/manuals_frontend.pp
@@ -30,16 +30,14 @@ class govuk::apps::manuals_frontend(
   $secret_key_base = undef,
 ) {
   govuk::app { 'manuals-frontend':
-    app_type                => 'rack',
-    port                    => $port,
-    sentry_dsn              => $sentry_dsn,
-    asset_pipeline          => true,
-    asset_pipeline_prefix   => 'manuals-frontend',
-    vhost                   => $vhost,
-    health_check_path       => '/healthcheck',
-    json_health_check       => true,
-    alert_5xx_warning_rate  => 0.1,
-    alert_5xx_critical_rate => 0.2,
+    app_type              => 'rack',
+    port                  => $port,
+    sentry_dsn            => $sentry_dsn,
+    asset_pipeline        => true,
+    asset_pipeline_prefix => 'manuals-frontend',
+    vhost                 => $vhost,
+    health_check_path     => '/healthcheck',
+    json_health_check     => true,
   }
 
   Govuk::App::Envvar {

--- a/modules/govuk/manifests/apps/smartanswers.pp
+++ b/modules/govuk/manifests/apps/smartanswers.pp
@@ -94,8 +94,8 @@ class govuk::apps::smartanswers(
     vhost                    => $vhost,
     nagios_memory_warning    => $nagios_memory_warning,
     nagios_memory_critical   => $nagios_memory_critical,
-    alert_5xx_warning_rate   => 0.2,
-    alert_5xx_critical_rate  => 0.3,
+    alert_5xx_warning_rate   => 0.001,
+    alert_5xx_critical_rate  => 0.005,
     repo_name                => 'smart-answers',
     unicorn_worker_processes => $unicorn_worker_processes,
   }


### PR DESCRIPTION
Reverts alphagov/govuk-puppet#8651

The AWS migration has now finished so talking to the content-store should result in fewer timeouts. We increased the thresholds temporarily while this was going on but now that it's over we can put these thresholds back to the levels we were on before.

[Trello Card](https://trello.com/c/1UC0sMaz/386-revert-https-githubcom-alphagov-govuk-puppet-pull-8651)