### PR TITLE
Enable finder-frontend extra grafana panels on AWS

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1076,7 +1076,10 @@ grafana::dashboards::application_dashboards:
     has_workers: true
   email-alert-frontend: {}
   feedback: {}
-  finder-frontend: {}
+  finder-frontend:
+    show_external_request_time: true
+    show_memcached: true
+    instance_prefix: 'calculators_frontend'
   frontend: {}
   government-frontend: {}
   hmrc-manuals-api: {}


### PR DESCRIPTION
We're only showing this on Carrenza at the moment, and the app has now been moved to AWS.