### PR TITLE
Change Smokey environment in AWS

### DIFF
--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -190,7 +190,7 @@ govuk_jenkins::job_builder::environment: 'production'
 govuk_jenkins::jobs::search_fetch_analytics_data::skip_page_traffic_load: true
 govuk_jenkins::jobs::search_fetch_analytics_data::cron_schedule: '30 8 * * 1-5'
 
-govuk_jenkins::jobs::smokey::environment: production
+govuk_jenkins::jobs::smokey::environment: production_aws
 
 govuk_jenkins::jobs::data_sync_complete_production::signon_domains_to_migrate:
   -
@@ -245,7 +245,7 @@ monitoring::checks::rds::servers:
    - 'mysql-primary'
    - 'mysql-replica'
 
-monitoring::checks::smokey::environment: 'production'
+monitoring::checks::smokey::environment: 'production_aws'
 monitoring::uptime_collector::environment: 'production'
 
 postfix::smarthost:

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -184,7 +184,7 @@ govuk_jenkins::jobs::network_config_deploy::environments:
 govuk_jenkins::jobs::search_fetch_analytics_data::skip_page_traffic_load: true
 govuk_jenkins::jobs::search_fetch_analytics_data::cron_schedule: '30 8 * * 1-5'
 
-govuk_jenkins::jobs::smokey::environment: staging
+govuk_jenkins::jobs::smokey::environment: staging_aws
 
 govuk_jenkins::jobs::data_sync_complete_staging::signon_domains_to_migrate:
   -
@@ -238,7 +238,7 @@ monitoring::checks::rds::servers:
    - 'mysql-replica'
 
 
-monitoring::checks::smokey::environment: 'staging'
+monitoring::checks::smokey::environment: 'staging_aws'
 
 monitoring::uptime_collector::environment: 'staging'
 


### PR DESCRIPTION
This commit change the Smokey environments in AWS to `production_aws` and `staging_aws` respectively, which will then ignore Smokey tests that should not be run in AWS environments.