### PR TITLE
Remove check for high user logins

### DIFF
--- a/modules/icinga/manifests/client/checks.pp
+++ b/modules/icinga/manifests/client/checks.pp
@@ -89,12 +89,6 @@ class icinga::client::checks (
     }
   }
 
-  @@icinga::check { "check_users_${::hostname}":
-    check_command       => 'check_nrpe_1arg!check_users',
-    service_description => 'high user logins',
-    host_name           => $::fqdn,
-  }
-
   @@icinga::check { "check_zombies_${::hostname}":
     check_command       => 'check_nrpe_1arg!check_zombie_procs',
     service_description => 'high zombie procs',


### PR DESCRIPTION
This check was added a long time ago, and it's not clear why. Removing
as there doesn't seem to be any value in having it.