### PR TITLE
Remove package_ensure => absent from s_content_data_api_db_admin

### DIFF
--- a/modules/govuk/manifests/node/s_content_data_api_db_admin.pp
+++ b/modules/govuk/manifests/node/s_content_data_api_db_admin.pp
@@ -55,7 +55,6 @@ class govuk::node::s_content_data_api_db_admin(
   # configure the RDS one
   class { '::postgresql::server':
     default_connect_settings => $default_connect_settings,
-    package_ensure           => absent,
     service_manage           => false,
   }
 


### PR DESCRIPTION
Abusing the Puppet PostgreSQL module for RDS configuration requires
letting Puppet setup the DB Admin machine like it's the thing it's
configuring, but tricking it to connecting to the RDS instance for
some configuration.

I'm trying to avoid as much of this redundant and confusing setup on
the DB Admin machine as possible, but it's not going well. Puppet
seems to require the package being installed, as it's still trying to
ensure directories (like /var/lib/postgresql/9.3) exist, and trying
use the postgres user and group, and trying to change the
configuration.

This commit just changes the PostgreSQL server package to be
installed, which performs some of the setup the PostgreSQL Puppet
module implicitly depends on.