### PR TITLE
Switch to a different apt_mirror_hostname

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -193,7 +193,7 @@ deployable_applications: &deployable_applications
   travel-advice-publisher: {}
   whitehall: {}
 
-apt_mirror_hostname: 'apt.production.alphagov.co.uk'
+apt_mirror_hostname: 'apt.publishing.service.gov.uk'
 
 apt::apt_update_frequency: 'daily'
 apt::purge_preferences_d: true

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -207,7 +207,7 @@ deployable_applications: &deployable_applications
   travel-advice-publisher: {}
   whitehall: {}
 
-apt_mirror_hostname: 'apt.production.alphagov.co.uk'
+apt_mirror_hostname: 'apt.publishing.service.gov.uk'
 
 apt::apt_update_frequency: 'daily'
 apt::purge_preferences_d: true

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -814,7 +814,6 @@ hosts::backend_migration::hosts:
       - apt.cluster
       - gemstash.cluster
       - apt-1
-      - apt.production.alphagov.co.uk
   search-2.api.publishing.service.gov.uk:
     ip: 10.3.4.5
     host_aliases:

--- a/spec/fixtures/hieradata/common.yaml
+++ b/spec/fixtures/hieradata/common.yaml
@@ -1,7 +1,7 @@
 app_domain: 'environment.example.com'
 app_domain_internal: 'dev.govuk-internal.digital'
 
-apt_mirror_hostname: 'apt.production.alphagov.co.uk'
+apt_mirror_hostname: 'apt.publishing.service.gov.uk'
 
 backup::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 


### PR DESCRIPTION
This involves less redirection.

This change is motivated by the alphagov.co.uk domain name not
working, at least temporarily.