### PR TITLE
Adjust the Content Data API database configuration

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -187,6 +187,8 @@ task :check_consistency_between_aws_and_carrenza do
     govuk::apps::content_data_api::rabbitmq_user
     govuk::apps::content_data_api::redis_host
     govuk::apps::content_data_api::redis_port
+    govuk::apps::content_data_api::db_name
+    govuk::apps::content_data_api::db_username
     govuk::apps::content_performance_manager::db::allow_auth_from_lb
     govuk::apps::content_performance_manager::db::lb_ip_range
     govuk::apps::content_performance_manager::db::rds

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -426,6 +426,12 @@ govuk::apps::content_data_api::rabbitmq_hosts:
 govuk::apps::content_data_api::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::content_data_api::redis_port: "%{hiera('sidekiq_port')}"
 
+# Temporarily match up the Content Data API and Content Performance
+# Manager database name and user, to make it easier to sync the
+# Content Performance Manager database over
+govuk::apps::content_data_api::db_name: "content_performance_manager_production"
+govuk::apps::content_data_api::db_username: "content_performance_manager"
+
 govuk::apps::content_performance_manager::rabbitmq_user: "content_performance_manager"
 govuk::apps::content_performance_manager::rabbitmq_password: "%{hiera('govuk::apps::content_performance_manager::rabbitmq::amqp_pass')}"
 govuk::apps::content_performance_manager::db_hostname: "warehouse-postgresql-primary"


### PR DESCRIPTION
Temporarily make the database name and user match up with the Content
Performance Manager. I'm hoping this will make it easier to sync the
Content Performance Manager database from where it currently resides,
to the new infrastructure for the Content Data API.

Once the new service is up and running, just prior to switching over
to it, we can rename the database, change the ownership, and remove
this configuration.