### PR TITLE
Remove redundant jenkins job for Search API

### DIFF
--- a/hieradata_aws/class/production/jenkins.yaml
+++ b/hieradata_aws/class/production/jenkins.yaml
@@ -9,13 +9,9 @@ govuk_jenkins::config::theme_environment_name: 'AWS Production'
 govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::deploy_app
   - govuk_jenkins::jobs::deploy_puppet
-  - govuk_jenkins::jobs::enhanced_ecommerce_search_api
   - govuk_jenkins::jobs::passive_checks
   - govuk_jenkins::jobs::publish_special_routes
   - govuk_jenkins::jobs::run_rake_task
-  - govuk_jenkins::jobs::search_api_fetch_analytics_data
-  - govuk_jenkins::jobs::search_api_index_checks
-  - govuk_jenkins::jobs::search_api_reindex_with_new_schema
   - govuk_jenkins::jobs::smokey
   - govuk_jenkins::jobs::smokey_deploy
   - govuk_jenkins::jobs::transition_load_all_data


### PR DESCRIPTION
This job is redundant as Search API doesn't exist in AWS production. It
makes sense to put this job in after Search API is created in prod.