### PR TITLE
 Add permanent redirect for crown logo to asset-manager

### DIFF
--- a/modules/govuk/templates/node/s_backend_lb/assets-carrenza.conf.erb
+++ b/modules/govuk/templates/node/s_backend_lb/assets-carrenza.conf.erb
@@ -47,13 +47,6 @@ server {
     rewrite ^/government/uploads/system/uploads/consultation_response_form/(.*)$ /government/uploads/system/uploads/consultation_response_form_data/$1;
   }
 
-  # 1stline use this URL in their zendesk template
-  location /static/gov.uk_logotype_crown.png {
-    add_header Cache-Control "public";
-    expires 1y;
-    rewrite (.*) /media/5c810ef4ed915d43e50ce260/gov.uk_logotype_crown.png;
-  }
-
   <%- @app_specific_static_asset_routes.each do |alias_path, assets_carrenza_vhost_name| -%>
   <%- if scope.lookupvar('::aws_migration') %>
   set $upstream_<%= assets_carrenza_vhost_name.delete "-" %> <%= @upstream_ssl ? 'https' : 'http' %>://<%= assets_carrenza_vhost_name %>.<%= @app_domain %>;

--- a/modules/govuk/templates/static_extra_nginx_config.conf.erb
+++ b/modules/govuk/templates/static_extra_nginx_config.conf.erb
@@ -6,6 +6,11 @@ location = /static/a {
   return 200 '';
 }
 
+# 1stline use this URL in their zendesk template
+location = /static/gov.uk_logotype_crown.png {
+  return 301 /media/5c810ef4ed915d43e50ce260/gov.uk_logotype_crown.png;
+}
+
 location /__canary__ {
   default_type application/json;
   add_header cache-control "max-age=0, no-store, no-cache";


### PR DESCRIPTION
This redirect lives in the static config because this path is routed
to static.