### PR TITLE
Use a relative redirect for the crown logo

### DIFF
--- a/modules/govuk/templates/static_extra_nginx_config.conf.erb
+++ b/modules/govuk/templates/static_extra_nginx_config.conf.erb
@@ -8,6 +8,7 @@ location = /static/a {
 
 # 1stline use this URL in their zendesk template
 location = /static/gov.uk_logotype_crown.png {
+  absolute_redirect off;
   return 301 /media/5c810ef4ed915d43e50ce260/gov.uk_logotype_crown.png;
 }
 


### PR DESCRIPTION
Tested in staging, it should *finally* be good.

---

By default nginx includes the hostname in the redirect, which in our case is some internal name which doesn't work externally.  Switching off the absolute_redirect directive makes redirects relative:

http://nginx.org/en/docs/http/ngx_http_core_module.html#absolute_redirect