### PR TITLE
Add pentester account

### DIFF
--- a/modules/users/manifests/pentester.pp
+++ b/modules/users/manifests/pentester.pp
@@ -1,0 +1,8 @@
+# Creates the pentester user
+class users::pentester {
+  govuk_user { 'pentester':
+    fullname => 'Pentester',
+    email    => 'pentester@digital.cabinet-office.gov.uk',
+    ssh_key  => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDiOz98vgZDRvAk/+e0nBtVxi7dXFEHHRLeKa1Lgt7jw0mwyM5nO02DH1qu/2e2bn6edEJemLPJKwJP5sDve3VShCRo36brToJoM8DN8JM4aTNcW5G/GMR+pAfVMOM0rQX2Aw1sPT5mXHKi5Jyc1cJWa/vPUg3evpE7gPc9CcRwsNpKIuSQ3zEHqr0jSpSspSp0mdABecDydXmD0mynHJKVdxL/1u/Cda2uf3U+/zgCOTS3YQS9+uzyT+TGOKxxvt298JViWTbCN0lpt3ElaH3eD7ryF9pddyEiCdNNAaqZl1sES7P5+TbLXvnfKtVQmUPoUcCAt1Ah7ammg7eKyLOm8sMPkUqQAH6hJtDFd+ld+sOqZmVuJ/bFJlLeDS9c4GF6lF9KC5jtgUydS7LPeS6A/htx9o88AZtWPTDFQd8zlcwhJ4COUfQ7Xo7N5JYP8JBlR9QJJFB1Bb8L5+Q0CqzYvk+WCfvRbinC7oVSyMkWB0F1CGz+cn79O/h0/dRZ6Cbt1Tcwdo1XsTokI1dt1gwFrCudWgg1W9apmL1rbcIrQfrvijz/YpSuhgiBSazXSIXNWbAe5Ijkzyr1a0HzRcWMFG7hPhnD1ZPYe0dAlg6NWf/klnV7+gehAwpFdz9j5xO00redpHvy5rxXkuiqmCBm+dfkjGs7n8XUENgdkqWZiQ==',
+  }
+}


### PR DESCRIPTION
This commit adds a new account that will be used for pentesting GOV.UK.