### PR TITLE
Add govuk_env_sync configuration for the Content Data API

### DIFF
--- a/hieradata_aws/class/integration/content_data_api_db_admin.yaml
+++ b/hieradata_aws/class/integration/content_data_api_db_admin.yaml
@@ -1,0 +1,14 @@
+govuk_env_sync::tasks:
+  # Use the new Content Data API name here, to avoid issues with
+  # changing the name later
+  "pull_content_data_api_production_daily":
+    ensure: "present"
+    hour: "4"
+    minute: "0"
+    action: "pull"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "content_performance_manager_production"
+    temppath: "/tmp/content_data_api_production"
+    url: "govuk-production-database-backups"
+    path: "content-data-api-postgresql"

--- a/hieradata_aws/class/production/content_data_api_db_admin.yaml
+++ b/hieradata_aws/class/production/content_data_api_db_admin.yaml
@@ -1,0 +1,30 @@
+govuk_env_sync::tasks:
+  # Temporary task to pull data from Carrenza production
+  "pull_content_performance_manager_production_daily":
+    ensure: "present"
+    hour: "2"
+    minute: "0"
+    action: "pull"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    # Use the old database name for consistency while still working on
+    # the migration for the Content Performance Manager
+    database: "content_performance_manager_production"
+    temppath: "/tmp/content_performance_manager_production"
+    url: "govuk-production-database-backups"
+    path: "warehouse-postgresql"
+  # Use the new Content Data API name here, to avoid issues with
+  # changing the name later
+  "push_content_data_api_production_daily":
+    ensure: "present"
+    hour: "3"
+    minute: "0"
+    action: "push"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    # Use the old database name for consistency while still working on
+    # the migration for the Content Performance Manager
+    database: "content_performance_manager_production"
+    temppath: "/tmp/content_data_api_production"
+    url: "govuk-production-database-backups"
+    path: "content-data-api-postgresql"

--- a/hieradata_aws/class/staging/content_data_api_db_admin.yaml
+++ b/hieradata_aws/class/staging/content_data_api_db_admin.yaml
@@ -1,0 +1,14 @@
+govuk_env_sync::tasks:
+  # Use the new Content Data API name here, to avoid issues with
+  # changing the name later
+  "pull_content_data_api_production_daily":
+    ensure: "present"
+    hour: "4"
+    minute: "0"
+    action: "pull"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "content_performance_manager_production"
+    temppath: "/tmp/content_data_api_production"
+    url: "govuk-production-database-backups"
+    path: "content-data-api-postgresql"


### PR DESCRIPTION
The Content Data API is the new name for the Content Performance
Manager. At the same time as the name is being changed, the service is
also being migrated to AWS.

This commit adds both the data syncs to from AWS Production to AWS
Staging and Integration, but also a sync task to pull data from
Carrenza Production which is being used for the migration.

The govuk_env_sync script doesn't handle changing database ownership,
so to try and make the dual running situation easier, the Content Data
API in AWS is configured to use the
content_performance_manager_production database, and
content_performance_manager user. Immediately before switching to AWS,
the database can be renamed, and the ownership changed.