### PR TITLE
Add Sentry monitor Jenkins job

### DIFF
--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -6,6 +6,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::build_offsite_backup
   - govuk_jenkins::jobs::check_cdn_ip_ranges
   - govuk_jenkins::jobs::check_pingdom_ip_ranges
+  - govuk_jenkins::jobs::check_sentry_errors
   - govuk_jenkins::jobs::clear_cdn_cache
   - govuk_jenkins::jobs::clear_frontend_memcache
   - govuk_jenkins::jobs::clear_template_cache

--- a/hieradata_aws/class/production/jenkins.yaml
+++ b/hieradata_aws/class/production/jenkins.yaml
@@ -7,6 +7,7 @@ govuk_jenkins::config::theme_text_colour: 'white'
 govuk_jenkins::config::theme_environment_name: 'AWS Production'
 
 govuk_jenkins::job_builder::jobs:
+  - govuk_jenkins::jobs::check_sentry_errors
   - govuk_jenkins::jobs::deploy_app
   - govuk_jenkins::jobs::deploy_puppet
   - govuk_jenkins::jobs::passive_checks

--- a/modules/govuk_jenkins/manifests/jobs/check_sentry_errors.pp
+++ b/modules/govuk_jenkins/manifests/jobs/check_sentry_errors.pp
@@ -1,0 +1,13 @@
+# == Class: govuk_jenkins::jobs::check_sentry_errors
+#
+# Create a file on disk that can be parsed by jenkins-job-builder
+#
+class govuk_jenkins::jobs::check_sentry_errors (
+  $sentry_auth_token = undef,
+) {
+  file { '/etc/jenkins_jobs/jobs/check_sentry_errors.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/check_sentry_errors.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+}

--- a/modules/govuk_jenkins/templates/jobs/check_sentry_errors.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/check_sentry_errors.yaml.erb
@@ -1,0 +1,35 @@
+---
+- scm:
+    name: check-sentry-errors
+    scm:
+        - git:
+            url: git@github.com:alphagov/govuk-sentry-monitor.git
+            branches:
+              - master
+            wipe-workspace: false
+
+- job:
+    name: Check_Sentry_Errors
+    display-name: Check Sentry Errors
+    project-type: freestyle
+    description: "This job reports the number of errors in Sentry to Graphite."
+    properties:
+        - build-discarder:
+            days-to-keep: 30
+            artifact-num-to-keep: 5
+        - github:
+            url: https://github.com/alphagov/govuk-sentry-monitor/
+    scm:
+      - check-sentry-errors
+    builders:
+        - shell: |
+            export SENTRY_AUTH_TOKEN=<%= @sentry_auth_token %>
+            bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
+            bundle exec rake run
+    publishers:
+        - email:
+            recipients: 2nd-line-support@digital.cabinet-office.gov.uk
+    triggers:
+        - timed: |
+            TZ=Europe/London
+            */15 * * * *


### PR DESCRIPTION
This job was previously manually created in Carrenza only.