### PR TITLE
Remove redundant Search API jobs from AWS staging

### DIFF
--- a/hieradata_aws/class/staging/jenkins.yaml
+++ b/hieradata_aws/class/staging/jenkins.yaml
@@ -13,9 +13,6 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::passive_checks
   - govuk_jenkins::jobs::publish_special_routes
   - govuk_jenkins::jobs::run_rake_task
-  - govuk_jenkins::jobs::search_api_fetch_analytics_data
-  - govuk_jenkins::jobs::search_api_index_checks
-  - govuk_jenkins::jobs::search_api_reindex_with_new_schema
   - govuk_jenkins::jobs::smokey
   - govuk_jenkins::jobs::smokey_deploy
   - govuk_jenkins::jobs::data_sync


### PR DESCRIPTION
Having these jobs only makes sense after this app has been deployed to
staging in AWS.