### PR TITLE
Remove AWS production robots.txt override

### DIFF
--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -256,10 +256,6 @@ postfix::smarthost:
 postfix::rewrite_mail_domain: 'digital.cabinet-office.gov.uk'
 postfix::rewrite_mail_list: 'machine.email.carrenza'
 
-router::nginx::robotstxt: |
-  User-agent: *
-  Disallow: /
-
 nginx::config::stack_network_prefix: '10.13.0'
 
 govuk_datascrubber::ensure: 'latest'


### PR DESCRIPTION
The version in `common.yaml` will take over.