### PR TITLE
Remove fake celery workers for CKAN

### DIFF
--- a/modules/govuk/manifests/apps/ckan.pp
+++ b/modules/govuk/manifests/apps/ckan.pp
@@ -84,22 +84,6 @@ class govuk::apps::ckan (
       default => present,
     }
 
-    govuk::procfile::worker { 'celery_priority':
-      ensure         => $toggled_priority_ensure,
-      setenv_as      => 'ckan',
-      enable_service => $priority_worker_processes != '0',
-      process_type   => 'celery_priority',
-      process_count  => $priority_worker_processes,
-    }
-
-    govuk::procfile::worker { 'celery_bulk':
-      ensure         => $toggled_bulk_ensure,
-      setenv_as      => 'ckan',
-      enable_service => $bulk_worker_processes != '0',
-      process_type   => 'celery_bulk',
-      process_count  => $bulk_worker_processes,
-    }
-
     $toggled_harvester_fetch = $enable_harvester_fetch ? {
       true    => present,
       default => absent,


### PR DESCRIPTION
Since the migration the Procfile actually defined these workers as
native CKAN workers (using the 'ckan' plugin, not celery). But we've
also found that the workers aren't actually necessary, them having been
missing in production for 120 days(!). This implies they're redundant,
so we're removing them.