### PR TITLE
Provision Elasticsearch 5.6.15 in the development VM

### DIFF
--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -159,6 +159,7 @@ govuk::apps::router_api::enable_running_in_draft_mode::router_nodes: ['localhost
 govuk::apps::rummager::enable_procfile_worker: false
 govuk::apps::rummager::rabbitmq_hosts: ['localhost']
 govuk::apps::rummager::redis_host: 'localhost'
+govuk::apps::search_api::elasticsearch_hosts: 'http://localhost:9205'
 govuk::apps::search_api::enable_procfile_worker: false
 govuk::apps::search_api::rabbitmq_hosts: ['localhost']
 govuk::apps::search_api::redis_host: 'localhost'

--- a/modules/govuk/manifests/node/s_development.pp
+++ b/modules/govuk/manifests/node/s_development.pp
@@ -82,6 +82,8 @@ class govuk::node::s_development (
     require                => Class['govuk_java::set_defaults'],
   }
 
+  include govuk_search::docker_elasticsearch
+
   include nginx
 
   nginx::config::vhost::default { 'default': }

--- a/modules/govuk_search/manifests/docker_elasticsearch.pp
+++ b/modules/govuk_search/manifests/docker_elasticsearch.pp
@@ -12,6 +12,11 @@ class govuk_search::docker_elasticsearch {
     content => template('govuk_search/elasticsearch-docker-compose.yml'),
   }
 
+  file { '/usr/share/docker/elasticsearch.yml':
+    ensure  => file,
+    content => template('govuk_search/elasticsearch.yml'),
+  }
+
   include ::govuk_docker
 
   class { '::docker::compose':

--- a/modules/govuk_search/manifests/docker_elasticsearch.pp
+++ b/modules/govuk_search/manifests/docker_elasticsearch.pp
@@ -1,0 +1,27 @@
+# == Class: govuk_search::docker
+#
+# Installs and configures Docker and Docker Compose
+class govuk_search::docker_elasticsearch {
+
+  file { '/usr/share/docker':
+    ensure => directory,
+  } ->
+
+  file { '/usr/share/docker/elasticsearch-docker-compose.yml':
+    ensure  => file,
+    content => template('govuk_search/elasticsearch-docker-compose.yml'),
+  }
+
+  include ::govuk_docker
+
+  class { '::docker::compose':
+    ensure  => present,
+    version => '1.7.0',
+  }
+
+  docker_compose { '/usr/share/docker/elasticsearch-docker-compose.yml':
+    ensure  => present,
+    require => File['/usr/share/docker/elasticsearch-docker-compose.yml'],
+  }
+
+}

--- a/modules/govuk_search/templates/elasticsearch-docker-compose.yml
+++ b/modules/govuk_search/templates/elasticsearch-docker-compose.yml
@@ -9,9 +9,13 @@ services:
       - xpack.security.enabled=false
     volumes:
       - esdata5:/usr/share/elasticsearch/data
+      - dataimport:/usr/share/elasticsearch/import
+      - /usr/share/docker/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml
     ports:
       - 9205:9200
 
 volumes:
   esdata5:
+    driver: local
+  dataimport:
     driver: local

--- a/modules/govuk_search/templates/elasticsearch-docker-compose.yml
+++ b/modules/govuk_search/templates/elasticsearch-docker-compose.yml
@@ -1,0 +1,17 @@
+version: '2'
+services:
+  elasticsearch5:
+    image: docker.elastic.co/elasticsearch/elasticsearch:5.6.15
+    container_name: elasticsearch5
+    environment:
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+    volumes:
+      - esdata5:/usr/share/elasticsearch/data
+    ports:
+      - 9205:9200
+
+volumes:
+  esdata5:
+    driver: local

--- a/modules/govuk_search/templates/elasticsearch.yml
+++ b/modules/govuk_search/templates/elasticsearch.yml
@@ -1,0 +1,5 @@
+cluster.name: "docker-cluster"
+network.host: 0.0.0.0
+
+discovery.zen.minimum_master_nodes: 1
+path.repo: ["/usr/share/elasticsearch/import"]


### PR DESCRIPTION
This PR provisions Elasticsearch 5.6 in the development VM, by means of a Docker container, with the service available at `localhost:9205`.  It does not remove Elasticsearch 2 (this will be removed later as part of the tidying up process).

The reason for dockerising Elasticsearch is that it would enable a smoother upgrade to Elasticsearch 6.x, which is not supported by our version of Puppet (3).

Data replication is also updated to pull from a new S3 bucket containing snapshots from the AWS Managed Elasticsearch 5 instance.

Not to be merged until ES 5.6 is released to production and ES 2 code is removed from Puppet.

Trello card: https://trello.com/c/uHuP699X/69-ensure-es-remains-working-in-the-dev-vm