### PR TITLE
Use a different NTP server pool for Nagios check

### DIFF
--- a/modules/icinga/templates/etc/nagios/nrpe.cfg.erb
+++ b/modules/icinga/templates/etc/nagios/nrpe.cfg.erb
@@ -214,7 +214,7 @@ command[check_zombie_procs]=/usr/lib/nagios/plugins/check_procs -w 5 -c 10 -s Z
 command[check_total_procs]=/usr/lib/nagios/plugins/check_procs -w 1300 -c 1650
 command[check_puppet_agent]=/usr/lib/nagios/plugins/check_puppet_agent
 command[check_rw_rootfs]=/usr/lib/nagios/plugins/check_rw_rootfs
-command[check_ntp_time]=/usr/lib/nagios/plugins/check_ntp_time -4 -q -H ntp.ubuntu.com -w 2 -c 3
+command[check_ntp_time]=/usr/lib/nagios/plugins/check_ntp_time -4 -q -H uk.pool.ntp.org -w 2 -c 3
 
 # The following examples allow user-supplied arguments and can
 # only be used if the NRPE daemon was compiled with support for


### PR DESCRIPTION
ntp.ubuntu.com is being unreliable, but this check is meant to be
independent of the system NTP settings, so we can use any server.