### PR TITLE
Use origin for search benchmark jobs

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/benchmark_search.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/benchmark_search.yaml.erb
@@ -23,11 +23,7 @@
         - shell: |
             bundle install --path "${HOME}/bundles/${JOB_NAME}";
             bundle exec bin/health_check --download
-            <%- if scope.lookupvar('::aws_migration') %>
-            bundle exec bin/health_check --json=https://search.<%= @app_domain_internal %>/search.json --type=<%= @test_type %> --auth="$AUTH_USERNAME:$AUTH_PASSWORD" --rate_limit_token=$RATE_LIMIT_TOKEN
-            <%- else %>
             bundle exec bin/health_check --json=https://www-origin.<%= @app_domain %>/api/search.json --type=<%= @test_type %> --auth="$AUTH_USERNAME:$AUTH_PASSWORD" --rate_limit_token=$RATE_LIMIT_TOKEN
-            <%- end %>
     triggers:
         - timed: '<%= @cron_schedule %>'
     publishers:


### PR DESCRIPTION
It's no longer possible to use origin on Carrenza production, but nor is
it possible to use the internal domain on AWS production, as the Search
API is not fully deployed yet. This switches the domain for AWS to be
origin in all environments, at least until the internal domain works.