### PR TITLE
ssl expiry verification after AWS migration

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1706,6 +1706,7 @@ limits::entries:
 mongodb::repository::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 mongodb::server::version: '2.4.9'
 
+monitoring::checks::aws_origin_domain: 'dev.govuk.digital'
 monitoring::checks::http_username: "%{hiera('http_username')}"
 monitoring::checks::http_password: "%{hiera('http_password')}"
 

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -205,6 +205,7 @@ licensify::apps::licensify::environment: 'integration'
 licensify::apps::licensify_feed::environment: 'integration'
 
 monitoring::ci_environment: true
+monitoring::checks::aws_origin_domain: "integration.govuk.digital"
 monitoring::checks::sidekiq::enable_support_check: false
 monitoring::checks::pingdom::enable: false
 monitoring::checks::ses::region: eu-west-1

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -599,6 +599,7 @@ licensify::apps::licensify_admin::environment: 'production'
 licensify::apps::licensify::environment: 'production'
 licensify::apps::licensify_feed::environment: 'production'
 
+monitoring::checks::aws_origin_domain: "production.govuk.digital"
 monitoring::checks::mirror::enabled: true
 monitoring::checks::ses::region: us-east-1
 monitoring::checks::smokey::environment: 'production'

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -558,6 +558,7 @@ licensify::apps::licensify_admin::environment: 'staging'
 licensify::apps::licensify::environment: 'staging'
 licensify::apps::licensify_feed::environment: 'staging'
 
+monitoring::checks::aws_origin_domain: "staging.govuk.digital"
 monitoring::checks::sidekiq::enable_support_check: false
 monitoring::checks::ses::region: eu-west-1
 monitoring::checks::smokey::environment: 'staging'

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1223,6 +1223,7 @@ mongodb::backup::alert_hostname: 'alert'
 mongodb::repository::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 mongodb::server::version: '2.4.9'
 
+monitoring::checks::aws_origin_domain: 'dev.govuk.digital'
 monitoring::checks::http_username: "%{hiera('http_username')}"
 monitoring::checks::http_password: "%{hiera('http_password')}"
 monitoring::client::alert_hostname: 'alert'

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -152,6 +152,7 @@ grafana::dashboards::machine_suffix_metrics: '_integration'
 
 mongodb::backup::mongo_backup_node: 'localhost'
 
+monitoring::checks::aws_origin_domain: "integration.govuk.digital"
 monitoring::checks::sidekiq::enable_support_check: false
 monitoring::checks::pingdom::enable: false
 monitoring::checks::ses::region: 'eu-west-1'

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -229,6 +229,7 @@ licensify::apps::licensify_admin::environment: 'production'
 licensify::apps::licensify::environment: 'production'
 licensify::apps::licensify_feed::environment: 'production'
 
+monitoring::checks::aws_origin_domain: "production.govuk.digital"
 monitoring::checks::sidekiq::enable_support_check: false
 monitoring::checks::ses::region: 'eu-west-1'
 monitoring::checks::rds::region: 'eu-west-1'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -225,6 +225,7 @@ licensify::apps::licensify_admin::environment: 'staging'
 licensify::apps::licensify::environment: 'staging'
 licensify::apps::licensify_feed::environment: 'staging'
 
+monitoring::checks::aws_origin_domain: "staging.govuk.digital"
 monitoring::checks::sidekiq::enable_support_check: false
 monitoring::checks::ses::region: 'eu-west-1'
 monitoring::checks::rds::region: 'eu-west-1'


### PR DESCRIPTION
# Context

After the AWS migration of the cache machines, the monitoring of the SSL certificates expiry should be adjusted.

# Decisions
The monitoring of:
1. www-origin.*.publishing.service.gov.uk should be done on AWS monitoring boxes only since these addresses are now pointing there.
2. www-origin.*.govuk.digital are also needed
3. www.staging.publishing.service.gov.uk should happen in AWS only