### PR TITLE
Show dashboard hosts below process count graphs

### DIFF
--- a/modules/grafana/templates/dashboards/application_dashboard_panels/_processor_count.json.erb
+++ b/modules/grafana/templates/dashboards/application_dashboard_panels/_processor_count.json.erb
@@ -2,7 +2,7 @@
   "aliasColors": {},
   "bars": false,
   "datasource": "Graphite",
-  "description": "Shows the process count for <%= @app_name %> backend machines. During deployment the number of processes should double and then return to normal. Code should be tested once the old processes have been killed.",
+  "description": "Shows the process count for <%= @app_name %> machines. During deployment the number of processes should double and then return to normal. Code should be tested once the old processes have been killed.",
   "fill": 0,
   "grid": {
     "threshold1": null,
@@ -20,7 +20,7 @@
     "total": false,
     "values": true,
     "alignAsTable": true,
-    "rightSide": true
+    "rightSide": false
   },
   "lines": true,
   "linewidth": 1,


### PR DESCRIPTION
Now we've migrated, the hostnames have gone from (for example)
`frontend-1_frontend` to `frontend-ip-xx-xx-xx-xxx_eu-west-1_cmopute_internal`
the lengthening of the hostname means that the space for the graph is much
constrained.  If we move them to below the graph, there's room for everything.

This affects dashboards like https://grafana.blue.staging.govuk.digital/dashboard/file/frontend.json

(Also removed a misplaced word from the description)