### PR TITLE
Use HTTPS for search traffic replay in staging

### DIFF
--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -53,7 +53,7 @@ govuk::apps::whitehall::cpu_warning: 400
 govuk::apps::whitehall::cpu_critical: 600
 
 govuk_search::gor::replay_target_hosts:
-  - 'search-api.staging.govuk.digital'
+  - 'https://search-api.staging.govuk.digital'
 
 govuk::deploy::aws_ses_smtp_host: 'email-smtp.eu-west-1.amazonaws.com'
 govuk::deploy::config::errbit_environment_name: 'staging'


### PR DESCRIPTION
The load balancer into search-api in AWS only permits HTTPS traffic over port 443.  This update makes that explicit.

Trello card: https://trello.com/c/YU9bS9jR/76-get-search-api-running-in-aws-staging