### PR TITLE
Preserve data dumps by default following replication script

### DIFF
--- a/development-vm/replication/README.md
+++ b/development-vm/replication/README.md
@@ -2,4 +2,7 @@
 
 Dumps are generated from production data in the early hours each day, and are then downloaded from S3.
 
+Dumps are large, and you may wish to delete them after the script has completed.
+To automatically delete dumps after the script has run(whether successful or not), use flag `-k`.
+
 For more information, see the guide in the developer docs on [replicating application data locally for development](https://docs.publishing.service.gov.uk/manual/replicate-app-data-locally.html).

--- a/development-vm/replication/README.md
+++ b/development-vm/replication/README.md
@@ -3,6 +3,6 @@
 Dumps are generated from production data in the early hours each day, and are then downloaded from S3.
 
 Dumps are large, and you may wish to delete them after the script has completed.
-To automatically delete dumps after the script has run(whether successful or not), use flag `-k`.
+To automatically delete dumps after the script has run(whether successful or not), use flag `-x`.
 
 For more information, see the guide in the developer docs on [replicating application data locally for development](https://docs.publishing.service.gov.uk/manual/replicate-app-data-locally.html).

--- a/development-vm/replication/common-args.sh
+++ b/development-vm/replication/common-args.sh
@@ -25,7 +25,7 @@ OPTIONS:
     -q       Skip MySQL import
     -e       Skip Elasticsearch import
     -t       Skip Mapit import
-    -k       Keep backups after import (will delete by default)
+    -k       Delete backups after import (will keep by default)
 
 EOF
 }
@@ -39,7 +39,7 @@ SKIP_ELASTIC=false
 SKIP_MAPIT=false
 RENAME_DATABASES=true
 DRY_RUN=false
-KEEP_BACKUPS=false
+KEEP_BACKUPS=true
 # By default, ignore large databases which are not useful when replicated.
 IGNORE="transition backdrop support_contacts draft_content_store imminence draft_router content_performance_manager ckan"
 
@@ -96,7 +96,7 @@ do
       SKIP_MAPIT=true
       ;;
     k )
-      KEEP_BACKUPS=true
+      KEEP_BACKUPS=false
       ;;
     * )
       usage

--- a/development-vm/replication/common-args.sh
+++ b/development-vm/replication/common-args.sh
@@ -25,7 +25,7 @@ OPTIONS:
     -q       Skip MySQL import
     -e       Skip Elasticsearch import
     -t       Skip Mapit import
-    -k       Delete backups after import (will keep by default)
+    -x       Delete backups after import (will keep by default)
 
 EOF
 }
@@ -55,7 +55,7 @@ function ignored() {
 }
 
 
-while getopts "hF:u:d:sri:onmpqetk" OPTION
+while getopts "hF:u:d:sri:onmpqetx" OPTION
 do
   case $OPTION in
     h )
@@ -95,7 +95,7 @@ do
     t )
       SKIP_MAPIT=true
       ;;
-    k )
+    x )
       KEEP_BACKUPS=false
       ;;
     * )

--- a/development-vm/replication/replicate-data-local.sh
+++ b/development-vm/replication/replicate-data-local.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-#
+# shellcheck disable=SC2086
+# shellcheck disable=SC2046
 # Fetch the most recent database dump files from production and restore locally.
 #
 

--- a/development-vm/replication/replicate-data-local.sh
+++ b/development-vm/replication/replicate-data-local.sh
@@ -41,3 +41,7 @@ if ! $DRY_RUN; then
 fi
 
 ok "Data replication complete"
+
+if $KEEP_BACKUPS; then
+  status "If no longer needed, delete backups from ${DIR}"
+fi

--- a/development-vm/replication/replicate-data-local.sh
+++ b/development-vm/replication/replicate-data-local.sh
@@ -1,25 +1,23 @@
-#!/usr/bin/env bash
-# shellcheck disable=SC2086
-# shellcheck disable=SC2046
+# !/usr/bin/env bash
 # Fetch the most recent database dump files from production and restore locally.
 #
 
 set -eu
 
-. $(dirname $0)/common-args.sh
-. $(dirname $0)/aws.sh
+. "$(dirname "$0")"/common-args.sh
+. "$(dirname "$0")"/aws.sh
 
 status "Running bundle install"
 bundle install --quiet
 
-$(dirname $0)/sync-aws-mysql.sh "$@" mysql-master
+"$(dirname "$0")"/sync-aws-mysql.sh "$@" mysql-master
 
-$(dirname $0)/sync-aws-mongo.sh "$@" mongo
-$(dirname $0)/sync-aws-mongo.sh "$@" router_backend
+"$(dirname "$0")"/sync-aws-mongo.sh "$@" mongo
+"$(dirname "$0")"/sync-aws-mongo.sh "$@" router_backend
 
-$(dirname $0)/sync-aws-postgresql.sh "$@" postgresql-primary-1
+"$(dirname "$0")"/sync-aws-postgresql.sh "$@" postgresql-primary-1
 
-$(dirname $0)/sync-aws-elasticsearch.sh "$@"
+"$(dirname "$0")"/sync-aws-elasticsearch.sh "$@"
 
 if ! ($SKIP_MONGO || $DRY_RUN); then
   status "Munging router backend hostnames for dev VM"
@@ -30,14 +28,14 @@ fi
 if ignored "mapit"; then
   status "Skipping mapit"
 else
-  $(dirname $0)/sync-mapit.sh
+  "$(dirname "$0")"/sync-mapit.sh
 fi
 
 
 if ! $DRY_RUN; then
   status "Munging Signon db tokens for dev VM"
-  if [[ -d $(dirname $0)/../../../signon ]]; then
-    cd $(dirname $0)/../../../signon && bundle install && bundle exec ruby script/make_oauth_work_in_dev
+  if [[ -d "$(dirname "$0")"/../../../signon ]]; then
+    cd "$(dirname "$0")"/../../../signon && bundle install && bundle exec ruby script/make_oauth_work_in_dev
   fi
 fi
 


### PR DESCRIPTION
Currently data dumps are automatically deleted following each sync script.
Should there be a failure at any point, they must all then be re-downloaded.
This can be extremely time consuming if experiencing issues with the VM.

This commit replaces the `-k` flag with `-x` to make the data dumps persist by default, and
only be automatically deleted if the flag is specified.

This will mean large amounts of data will be kept on developer's machines until manually deleted,
but will prevent having to re-download many GB's of data dumps should the VM import process fail.