### PR TITLE
Set rummager Plek env var for AWS content store

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -195,6 +195,7 @@ task :check_consistency_between_aws_and_carrenza do
     govuk::apps::content_publisher::db::allow_auth_from_lb
     govuk::apps::content_publisher::db::lb_ip_range
     govuk::apps::content_publisher::db::rds
+    govuk::apps::content_store::plek_service_rummager_uri
     govuk::apps::content_store::plek_service_whitehall_frontend_uri
     govuk::apps::content_tagger::db::allow_auth_from_lb
     govuk::apps::content_tagger::db::lb_ip_range

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -123,6 +123,7 @@ govuk::apps::content_publisher::google_tag_manager_id: "GTM-NQXC4TG"
 govuk::apps::content_publisher::google_tag_manager_preview: "env-7"
 govuk::apps::content_store::performance_platform_big_screen_view_url: 'https://performance-platform-big-screen-view-production.cloudapps.digital'
 govuk::apps::content_store::performance_platform_spotlight_url: 'https://performance-platform-spotlight-production.cloudapps.digital'
+govuk::apps::content_store::plek_service_rummager_uri: 'https://rummager.publishing.service.gov.uk'
 govuk::apps::content_store::plek_service_whitehall_frontend_uri: 'https://whitehall-frontend.publishing.service.gov.uk'
 govuk::apps::email_alert_api::db::backend_ip_range: '10.13.3.0/24'
 govuk::apps::email_alert_api::email_archive_s3_bucket: 'govuk-production-email-alert-api-archive'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -124,6 +124,7 @@ govuk::apps::content_publisher::google_tag_manager_id: "GTM-NQXC4TG"
 govuk::apps::content_publisher::google_tag_manager_preview: "env-5"
 govuk::apps::content_store::performance_platform_big_screen_view_url: 'https://performance-platform-big-screen-view-staging.cloudapps.digital'
 govuk::apps::content_store::performance_platform_spotlight_url: 'https://performance-platform-spotlight-staging.cloudapps.digital'
+govuk::apps::content_store::plek_service_rummager_uri: 'https://rummager.staging.publishing.service.gov.uk'
 govuk::apps::content_store::plek_service_whitehall_frontend_uri: 'https://whitehall-frontend.staging.publishing.service.gov.uk'
 govuk::apps::email_alert_api::db::backend_ip_range: '10.12.3.0/24'
 govuk::apps::email_alert_api::email_archive_s3_bucket: 'govuk-staging-email-alert-api-archive'

--- a/modules/govuk/manifests/apps/content_store.pp
+++ b/modules/govuk/manifests/apps/content_store.pp
@@ -57,6 +57,10 @@
 # [*router_api_bearer_token*]
 #   The bearer token that will be used to authenticate with the router api
 #
+# [*plek_service_rummager_uri*]
+#   rummager URL envvar
+#   Default: undef
+#
 # [*plek_service_whitehall_frontend_uri*]
 #   whitehall-frontend URL envvar
 #   Default: undef
@@ -81,6 +85,7 @@ class govuk::apps::content_store(
   $oauth_secret = undef,
   $router_api_bearer_token = undef,
   $create_default_nginx_config = false,
+  $plek_service_rummager_uri = undef,
   $plek_service_whitehall_frontend_uri = undef,
 ) {
   $app_name = 'content-store'
@@ -145,6 +150,9 @@ class govuk::apps::content_store(
     "${title}-PERFORMANCEPLATFORM_SPOTLIGHT":
       varname => 'PLEK_SERVICE_SPOTLIGHT_URI',
       value   => $performance_platform_spotlight_url;
+    "${title}-RUMMAGER_URI":
+      varname => 'PLEK_SERVICE_RUMMAGER_URI',
+      value   => $plek_service_rummager_uri;
     "${title}-WHITEHALL_FRONTEND_URI":
       varname => 'PLEK_SERVICE_WHITEHALL_FRONTEND_URI',
       value   => $plek_service_whitehall_frontend_uri;


### PR DESCRIPTION
Rummager still lives in Carrenza.  Content Store uses Plek to work out
where the backends are, and updates Router API with this data.
Because the app domain has been changed in AWS staging, content items
served by Rummager are failing, eg:

- https://www.staging.publishing.service.gov.uk/sitemap.xml
- https://www.staging.publishing.service.gov.uk/api/search.json