### PR TITLE
Enable Sidekiq for Content Data Admin

### DIFF
--- a/development-vm/Pinfile
+++ b/development-vm/Pinfile
@@ -17,7 +17,7 @@ process :'collections-publisher' => [:'publishing-api', :'collections-publisher-
 process :'collections-publisher-worker'
 process :'contacts-admin' => [:'publishing-api', :whitehall]
 process :'content-audit-tool' => [:'publishing-api-read', :'content-audit-tool-sidekiq-google-analytics', :'content-audit-tool-sidekiq-publishing-api']
-process :'content-data-admin' =>[:'content-performance-manager']
+process :'content-data-admin' =>[:'content-performance-manager', :'content-data-admin-sidekiq-default']
 process :'content-performance-manager' => [:'publishing-api', :'content-performance-manager-sidekiq-default', :'content-performance-manager-publishing-api-consumer', 'content-performance-manager-bulk-import-publishing-api-consumer', 'content-store']
 process :'content-publisher' => [:'publishing-api', :'asset-manager']
 process :'content-store'

--- a/development-vm/Procfile
+++ b/development-vm/Procfile
@@ -175,6 +175,7 @@ content-audit-tool-sidekiq-publishing-api:  govuk_setenv content-audit-tool ./ru
 content-publisher: govuk_setenv content-publisher ./run_in.sh ../../content-publisher bundle exec foreman start -f Procfile.dev
 # Smokey BrowserMob Proxy uses ports 3222-3229
 content-data-admin: govuk_setenv content-data-admin ./run_in.sh ../../content-data-admin bundle exec unicorn -c config/unicorn.rb -p 3230
+content-data-admin-sidekiq-default: govuk_setenv content-data-admin ./run_in.sh ../../content-data-admin bundle exec sidekiq -C ./config/sidekiq.yml
 draft-smartanswers: govuk_setenv draft-smartanswers ./run_in.sh ../../smart-answers bundle exec rails server -p 3231 -P tmp/pids/draft-smartanswers.pid
 # content-publisher has reserved 3232 for webpack-dev-server
 cache-clearing-service: govuk_setenv cache-clearing-service ./run_in.sh ../../cache-clearing-service bundle exec bin/cache_clearing_service

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -392,6 +392,8 @@ govuk::apps::content_data_admin::db_hostname: "postgresql-primary-1.backend"
 govuk::apps::content_data_admin::db_port: 6432
 govuk::apps::content_data_admin::db_allow_prepared_statements: false
 govuk::apps::content_data_admin::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
+govuk::apps::content_data_admin::redis_host: "%{hiera('sidekiq_host')}"
+govuk::apps::content_data_admin::redis_port: "%{hiera('sidekiq_port')}"
 
 govuk::apps::content_performance_manager::rabbitmq_user: "content_performance_manager"
 govuk::apps::content_performance_manager::rabbitmq_password: "%{hiera('govuk::apps::content_performance_manager::rabbitmq::amqp_pass')}"
@@ -625,6 +627,8 @@ govuk::apps::sidekiq_monitoring::collections_publisher_redis_host: "%{hiera('gov
 govuk::apps::sidekiq_monitoring::collections_publisher_redis_port: "%{hiera('govuk::apps::collections_publisher::redis_port')}"
 govuk::apps::sidekiq_monitoring::content_audit_tool_redis_host: "%{hiera('govuk::apps::content_audit_tool::redis_host')}"
 govuk::apps::sidekiq_monitoring::content_audit_tool_redis_port: "%{hiera('govuk::apps::content_audit_tool::redis_port')}"
+govuk::apps::sidekiq_monitoring::content_data_admin_redis_host: "%{hiera('govuk::apps::content_data_admin::redis_host')}"
+govuk::apps::sidekiq_monitoring::content_data_admin_redis_port: "%{hiera('govuk::apps::content_data_admin::redis_port')}"
 govuk::apps::sidekiq_monitoring::content_performance_manager_redis_host: "%{hiera('govuk::apps::content_performance_manager::redis_host')}"
 govuk::apps::sidekiq_monitoring::content_performance_manager_redis_port: "%{hiera('govuk::apps::content_performance_manager::redis_port')}"
 govuk::apps::sidekiq_monitoring::content_publisher_redis_host: "%{hiera('govuk::apps::content_publisher::redis_host')}"
@@ -1131,7 +1135,9 @@ grafana::dashboards::application_dashboards:
   content-audit-tool:
     show_sidekiq_graphs: true
     has_workers: true
-  content-data-admin: {}
+  content-data-admin:
+    show_sidekiq_graphs: true
+    has_workers: true
   content-performance-manager:
     show_sidekiq_graphs: true
     has_workers: true

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -416,6 +416,8 @@ govuk::apps::content_data_admin::db::backend_ip_range: "%{hiera('environment_ip_
 govuk::apps::content_data_admin::db::allow_auth_from_lb: true
 govuk::apps::content_data_admin::db::lb_ip_range: "%{hiera('environment_ip_prefix')}.0.0/16"
 govuk::apps::content_data_admin::db::rds: true
+govuk::apps::content_data_admin::redis_host: "%{hiera('sidekiq_host')}"
+govuk::apps::content_data_admin::redis_port: "%{hiera('sidekiq_port')}"
 
 govuk::apps::content_data_api::rabbitmq_user: "content_data_api"
 govuk::apps::content_data_api::rabbitmq_password: "%{hiera('govuk::apps::content_data_api::rabbitmq::amqp_pass')}"
@@ -680,6 +682,8 @@ govuk::apps::sidekiq_monitoring::collections_publisher_redis_host: "%{hiera('gov
 govuk::apps::sidekiq_monitoring::collections_publisher_redis_port: "%{hiera('govuk::apps::collections_publisher::redis_port')}"
 govuk::apps::sidekiq_monitoring::content_audit_tool_redis_host: "%{hiera('govuk::apps::content_audit_tool::redis_host')}"
 govuk::apps::sidekiq_monitoring::content_audit_tool_redis_port: "%{hiera('govuk::apps::content_audit_tool::redis_port')}"
+govuk::apps::sidekiq_monitoring::content_data_admin_redis_host: "%{hiera('govuk::apps::content_data_admin::redis_host')}"
+govuk::apps::sidekiq_monitoring::content_data_admin_redis_port: "%{hiera('govuk::apps::content_data_admin::redis_port')}"
 govuk::apps::sidekiq_monitoring::content_performance_manager_redis_host: "%{hiera('govuk::apps::content_performance_manager::redis_host')}"
 govuk::apps::sidekiq_monitoring::content_performance_manager_redis_port: "%{hiera('govuk::apps::content_performance_manager::redis_port')}"
 govuk::apps::sidekiq_monitoring::content_publisher_redis_host: "%{hiera('govuk::apps::content_publisher::redis_host')}"
@@ -1047,7 +1051,9 @@ grafana::dashboards::application_dashboards:
   content-audit-tool:
     show_sidekiq_graphs: true
     has_workers: true
-  content-data-admin: {}
+  content-data-admin: 
+    show_sidekiq_graphs: true
+    has_workers: true
   content-performance-manager:
     show_sidekiq_graphs: true
     has_workers: true

--- a/modules/govuk/manifests/apps/content_data_admin.pp
+++ b/modules/govuk/manifests/apps/content_data_admin.pp
@@ -50,6 +50,14 @@
 # [*google_tag_manager_auth*]
 #   The identifier of an environment for Google Tag Manager
 #
+# [*redis_host*]
+#   Redis host for Sidekiq.
+#   Default: undef
+#
+# [*redis_port*]
+#   Redis port for Sidekiq.
+#   Default: undef
+#
 class govuk::apps::content_data_admin (
   $port                         = '3230',
   $enabled                      = true,
@@ -67,6 +75,8 @@ class govuk::apps::content_data_admin (
   $google_tag_manager_id = undef,
   $google_tag_manager_preview = undef,
   $google_tag_manager_auth = undef,
+  $redis_host = undef,
+  $redis_port = undef,
 ) {
   $app_name = 'content-data-admin'
 
@@ -116,6 +126,11 @@ class govuk::apps::content_data_admin (
     "${title}-GOOGLE_TAG_MANAGER_AUTH":
         varname => 'GOOGLE_TAG_MANAGER_AUTH',
         value   => $google_tag_manager_auth;
+  }
+
+  govuk::app::envvar::redis { $app_name:
+    host => $redis_host,
+    port => $redis_port,
   }
 
   if $::govuk_node_class !~ /^development$/ {

--- a/modules/govuk/manifests/apps/sidekiq_monitoring.pp
+++ b/modules/govuk/manifests/apps/sidekiq_monitoring.pp
@@ -38,6 +38,14 @@
 #   Redis port for Content Audit Tool Sidekiq.
 #   Default: undef
 #
+# [*content_data_admin_redis_host*]
+#   Redis host for Content Performance Manager Sidekiq.
+#   Default: undef
+#
+# [*content_data_admin_redis_port*]
+#   Redis port for Content Performance Manager Sidekiq.
+#   Default: undef
+#
 # [*content_performance_manager_redis_host*]
 #   Redis host for Content Performance Manager Sidekiq.
 #   Default: undef
@@ -183,6 +191,8 @@ class govuk::apps::sidekiq_monitoring (
   $collections_publisher_redis_port = undef,
   $content_audit_tool_redis_host = undef,
   $content_audit_tool_redis_port = undef,
+  $content_data_admin_redis_host = undef,
+  $content_data_admin_redis_port = undef,
   $content_performance_manager_redis_host = undef,
   $content_performance_manager_redis_port = undef,
   $content_publisher_redis_host = undef,
@@ -259,6 +269,11 @@ class govuk::apps::sidekiq_monitoring (
       prefix => 'content_audit_tool',
       host   => $content_audit_tool_redis_host,
       port   => $content_audit_tool_redis_port;
+
+    "${app_name}_content_data_admin":
+      prefix => 'content_data_admin',
+      host   => $content_data_admin_redis_host,
+      port   => $content_data_admin_redis_port;
 
     "${app_name}_content_performance_manager":
       prefix => 'content_performance_manager',


### PR DESCRIPTION
This enables Sidekiq for the content-data-admin, by allow access to Redis connection environment variables. This also adds config to the development VM to start a Sidekiq worker with content data.