### PR TITLE
Add Content Data Admin to Sidekiq Monitoring

### DIFF
--- a/development-vm/Procfile
+++ b/development-vm/Procfile
@@ -176,6 +176,7 @@ content-publisher: govuk_setenv content-publisher ./run_in.sh ../../content-publ
 # Smokey BrowserMob Proxy uses ports 3222-3229
 content-data-admin: govuk_setenv content-data-admin ./run_in.sh ../../content-data-admin bundle exec unicorn -c config/unicorn.rb -p 3230
 content-data-admin-sidekiq-default: govuk_setenv content-data-admin ./run_in.sh ../../content-data-admin bundle exec sidekiq -C ./config/sidekiq.yml
+# sidekiq-monitoring for content-data-admin uses port 3240
 draft-smartanswers: govuk_setenv draft-smartanswers ./run_in.sh ../../smart-answers bundle exec rails server -p 3231 -P tmp/pids/draft-smartanswers.pid
 # content-publisher has reserved 3232 for webpack-dev-server
 cache-clearing-service: govuk_setenv cache-clearing-service ./run_in.sh ../../cache-clearing-service bundle exec bin/cache_clearing_service

--- a/modules/govuk/manifests/apps/sidekiq_monitoring.pp
+++ b/modules/govuk/manifests/apps/sidekiq_monitoring.pp
@@ -39,11 +39,11 @@
 #   Default: undef
 #
 # [*content_data_admin_redis_host*]
-#   Redis host for Content Performance Manager Sidekiq.
+#   Redis host for Content Data Admin Sidekiq.
 #   Default: undef
 #
 # [*content_data_admin_redis_port*]
-#   Redis port for Content Performance Manager Sidekiq.
+#   Redis port for Content Data Admin Sidekiq.
 #   Default: undef
 #
 # [*content_performance_manager_redis_host*]

--- a/modules/govuk/templates/sidekiq_monitoring_nginx_config.conf.erb
+++ b/modules/govuk/templates/sidekiq_monitoring_nginx_config.conf.erb
@@ -30,6 +30,10 @@ server {
     proxy_pass http://localhost:3217;
   }
 
+  location /content-data-admin {
+    proxy_pass http://localhost:3240;
+  }
+
   location /content-performance-manager {
     proxy_pass http://localhost:3207;
   }


### PR DESCRIPTION
This adds missing configuration for Sidekiq monitoring to follow content data admin's Sidekiq workers.