### PR TITLE
Remove calendars /etc/hosts entries in carrenza

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1546,7 +1546,6 @@ hosts::production::external_licensify: true
 
 hosts::production::frontend::app_hostnames:
   - 'calculators'
-  - 'calendars'
   - 'canary-frontend'
   - 'collections'
   - 'draft-collections'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1820,7 +1820,6 @@ resolvconf::options:
 router::assets_origin::app_specific_static_asset_routes:
   '/asset-manager': "asset-manager"
   '/calculators/': "calculators"
-  '/calendars/': "calendars"
   '/collections/': "collections"
   '/email-alert-frontend/': "email-alert-frontend"
   '/feedback/': "feedback"


### PR DESCRIPTION
- The publisher app needs to talk to the calendars frontend app
- Calendars frontend is now living in AWS and name resolution is done
over DNS
- Routing is done via private LB

solo: @schmie