### PR TITLE
Fix physical volume identifier for mirror ebs

### DIFF
--- a/hieradata_aws/class/mirrorer.yaml
+++ b/hieradata_aws/class/mirrorer.yaml
@@ -8,7 +8,7 @@ icinga::client::checks::disk_time_critical: 250 # milliseconds
 
 lv:
   worker:
-    pv: '/dev/xvdf'
+    pv: '/dev/nvme1n1'
     vg: 'crawler'
 
 mount:


### PR DESCRIPTION
- The naming scheme for additional ebs volume devices has changed since
we last deployed mirrorer
- This will allow to run puppet / install the crawler app as expected

solo: @schmie