### PR TITLE
Clear up the default memory display on the Machine dashboard

### DIFF
--- a/modules/grafana/files/dashboards/machine.json
+++ b/modules/grafana/files/dashboards/machine.json
@@ -226,7 +226,7 @@
           "datasource": "Graphite",
           "editable": true,
           "error": false,
-          "fill": 1,
+          "fill": 0,
           "grid": {},
           "id": 2,
           "legend": {
@@ -249,12 +249,13 @@
           "seriesOverrides": [
             {
               "alias": "Total",
-              "color": "#890F02",
-              "fill": 0
+              "color": "#890F02"
             },
             {
               "alias": "Used",
-              "color": "#629E51"
+              "color": "#629E51",
+              "linewidth": 3,
+              "fill": 2
             },
             {
               "alias": "Buffered",
@@ -271,16 +272,16 @@
           "steppedLine": false,
           "targets": [
             {
+              "refId": "A",
+              "target": "alias($hostname.memory.memory-used, 'Used')"
+            },
+            {
               "refId": "C",
               "target": "alias($hostname.memory.memory-buffered, 'Buffered')"
             },
             {
               "refId": "B",
               "target": "alias($hostname.memory.memory-cached, 'Cached')"
-            },
-            {
-              "refId": "A",
-              "target": "alias($hostname.memory.memory-used, 'Used')"
             },
             {
               "refId": "D",


### PR DESCRIPTION
It's too easy to confuse the cached memory for used. So, change the
default fill to 0, move the used proportion to the bottom,
specifically add fill, and make the line thicker.

# Before
![before](https://user-images.githubusercontent.com/1130010/54351091-9ef4a900-4646-11e9-82f4-502c084ae637.png)

# After
![after](https://user-images.githubusercontent.com/1130010/54351096-a5832080-4646-11e9-9868-fc4707904a4f.png)
