### PR TITLE
Remove x-ray sampling rate for rummager

### DIFF
--- a/modules/govuk/manifests/apps/rummager.pp
+++ b/modules/govuk/manifests/apps/rummager.pp
@@ -244,9 +244,6 @@ class govuk::apps::rummager(
       "${title}-OAUTH_SECRET":
         varname => 'OAUTH_SECRET',
         value   => $oauth_secret;
-      "${title}-XRAY_SAMPLE_RATE":
-        varname => 'XRAY_SAMPLE_RATE',
-        value   => '1.0';
     }
   }
 }


### PR DESCRIPTION
This shouldn't have been included since we don't need to sample 100% of rummager requests.