### PR TITLE
removing psql comments to avoid psql restore errors

### DIFF
--- a/modules/govuk_env_sync/files/govuk_env_sync.sh
+++ b/modules/govuk_env_sync/files/govuk_env_sync.sh
@@ -283,7 +283,13 @@ function restore_postgresql {
      DB_OWNER=$(sudo psql -U aws_db_admin -h "${db_hostname}" --no-password --list --quiet --tuples-only | awk '{print $1 " " $3}'| grep -v "|" | grep -w "${database}" | awk '{print $2}')
      sudo dropdb -U aws_db_admin -h "${db_hostname}" --no-password "${database}"
   fi
-  pg_stderr=$(sudo pg_restore -U aws_db_admin -h "${db_hostname}" --create --no-password -d postgres "${tempdir}/${filename}" 2>&1)
+
+  pg_restore "${tempdir}/${filename}" -f "${tempdir}/${filename}.dump"
+  sed -i '/COMMENT\ ON\ EXTENSION\ plpgsql/d' "${tempdir}/${filename}.dump"
+  sudo createdb -U aws_db_admin -h "${db_hostname}" --no-password "${database}"
+  pg_stderr=$(sudo psql -U aws_db_admin -h "${db_hostname}" -1 --no-password -d "${database}" -f "${tempdir}/${filename}.dump" 2>&1)
+  rm "${tempdir}/${filename}.dump"
+
   if [ "$DB_OWNER" != '' ] ; then
      echo "GRANT ALL ON DATABASE \"$database\" TO \"$DB_OWNER\"" | sudo psql -U aws_db_admin -h "${db_hostname}" --no-password "${database}"
      echo "ALTER DATABASE \"$database\" OWNER TO \"$DB_OWNER\"" | sudo psql -U aws_db_admin -h "${db_hostname}" --no-password "${database}"

--- a/modules/govuk_env_sync/manifests/sync_script.pp
+++ b/modules/govuk_env_sync/manifests/sync_script.pp
@@ -6,7 +6,7 @@ class govuk_env_sync::sync_script {
   sudo::conf {
     'govuk-env-sync-commands':
       ensure  => 'present',
-      content => 'govuk-backup ALL=NOPASSWD:/usr/bin/psql,/usr/bin/dropdb,/usr/bin/dropuser,/usr/bin/pg_restore,/usr/bin/mysql,/usr/bin/mysqldump,/usr/bin/pg_dump';
+      content => 'govuk-backup ALL=NOPASSWD:/usr/bin/psql,/usr/bin/createdb,/usr/bin/dropdb,/usr/bin/dropuser,/usr/bin/pg_restore,/usr/bin/mysql,/usr/bin/mysqldump,/usr/bin/pg_dump';
   }
 
   # sync script


### PR DESCRIPTION
In order to enable psql restore to happen in a single transaction and hence avoid database corruption while restoring, there should be no errors during the restore process or otherwise, psql will roll back.

The sql restore process now:
1. converts the psql backup file in the format of custom type to plain type.
2. remove the offending psql statements which will cause error on restore
3. recreate the psql database to restore to
4. restore the contents of the psql database