### PR TITLE
Return synthetic response for assets canary

### DIFF
--- a/modules/govuk/templates/node/s_backend_lb/assets-carrenza.conf.erb
+++ b/modules/govuk/templates/node/s_backend_lb/assets-carrenza.conf.erb
@@ -107,11 +107,7 @@ server {
   }
 
   location /__canary__ {
-    <%- if scope.lookupvar('::aws_migration') %>
-    proxy_pass $upstream_static;
-    <%- else %>
-    proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://static.<%= @app_domain %>;
-    <%- end %>
+    return 200;
   }
 
   location / {


### PR DESCRIPTION
This command changes the nginx configuration for the backend load balancers in Carrenza to return a synthetic HTTP 200 response for the assets canary endpoint, which is used by Fastly to determine the health of the `assets-carrenza` host. The static instance it currently points to no longer exists in Carrenza as it has been migrated to AWS.