### PR TITLE
reduce the days to keep logs on Staging cache

### DIFF
--- a/hieradata_aws/class/staging/cache.yaml
+++ b/hieradata_aws/class/staging/cache.yaml
@@ -1,4 +1,6 @@
 ---
+logrotate::conf::days_to_keep: “7”
+nginx::logging::days_to_keep: “7”
 router::gor::add_hosts: false
 router::gor::replay_targets:
   'www-origin.integration.publishing.service.gov.uk': {}


### PR DESCRIPTION
# Context

The number of days for which logs are kept on the cache machines are too long and can cause disk full issues.

# Decisions
1. reduce the number of days for which to keep logs to 7 days.