### PR TITLE
Disable rummager in AWS Staging

### DIFF
--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -62,6 +62,8 @@ govuk::apps::licencefinder::override_search_location: NULL
 govuk::apps::search_admin::override_search_location: 'https://search-api.staging.govuk.digital'
 govuk::apps::whitehall::override_search_location: 'https://search-api.staging.govuk.digital'
 
+govuk::apps::rummager::enable_rummager: true
+
 govuk::deploy::aws_ses_smtp_host: 'email-smtp.eu-west-1.amazonaws.com'
 govuk::deploy::config::errbit_environment_name: 'staging'
 govuk::deploy::setup::ssh_keys:

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -159,6 +159,8 @@ govuk::apps::licencefinder::override_search_location: 'https://search-api.stagin
 govuk::apps::search_admin::override_search_location: NULL
 govuk::apps::whitehall::override_search_location: NULL
 
+govuk::apps::rummager::enable_rummager: false
+
 govuk::deploy::aws_ses_smtp_host: 'email-smtp.eu-west-1.amazonaws.com'
 govuk::deploy::config::errbit_environment_name: 'staging'
 govuk::deploy::config::licensify_app_domain: 'staging.publishing.service.gov.uk'


### PR DESCRIPTION
This app has been deployed alongside search-api, however it is not needed in this environment.  Since it cannot connect to Elasticsearch 2, the error logs are becoming huge and consuming the machine's entire disk space.

Trello card: https://trello.com/c/SPGs4yeO/80-staging-application-switchover