### PR TITLE
reduce log on cache machines to 7 days

### DIFF
--- a/hieradata_aws/class/integration/cache.yaml
+++ b/hieradata_aws/class/integration/cache.yaml
@@ -1,0 +1,3 @@
+---
+logrotate::conf::days_to_keep: 7
+nginx::logging::days_to_keep: 7

--- a/hieradata_aws/class/production/cache.yaml
+++ b/hieradata_aws/class/production/cache.yaml
@@ -1,3 +1,6 @@
+---
+logrotate::conf::days_to_keep: 7
+nginx::logging::days_to_keep: 7
 router::gor::add_hosts: false
 router::gor::replay_targets:
   'www-origin.staging.govuk.digital': {}


### PR DESCRIPTION
# Context

The number of days for which logs are kept on the cache machines in AWS production and integration are too long and can cause disk full issues.

# Decisions
1. reduce the number of days for which to keep logs to 7 days.