### PR TITLE
Install go 1.12.1

### DIFF
--- a/modules/golang/manifests/init.pp
+++ b/modules/golang/manifests/init.pp
@@ -11,7 +11,7 @@ class golang {
     require        => Class['govuk_ppa'],
   }
 
-  goenv::version { ['1.7.1', '1.9.1']: }
+  goenv::version { ['1.7.1', '1.9.1', '1.12.1']: }
 
   package { ['godep']:
     ensure  => latest,


### PR DESCRIPTION
This version is used by https://github.com/alphagov/govuk-csp-forwarder.