### PR TITLE
restart puppet on memory error

### DIFF
--- a/modules/puppet/templates/puppetdb/upstart.conf.erb
+++ b/modules/puppet/templates/puppetdb/upstart.conf.erb
@@ -18,7 +18,7 @@ script
                          --startas /usr/bin/java \
                          -- \
                          <%= @java_args %> \
-                         -XX:OnOutOfMemoryError="kill -9 %p" \
+                         -XX:OnOutOfMemoryError="kill -9 %p; /etc/init.d/puppetdb restart; /etc/init.d/puppetserver restart" \
                          -jar /usr/share/puppetdb/puppetdb.jar \
                          services -c /etc/puppetdb/conf.d \
                          >> /var/log/puppetdb/upstart.out.log \


### PR DESCRIPTION
# Context

Puppetmaster fails occasionally in AWS with out of memory error. It is not yet known why this is happening. In the mean time, it would be great if puppetmaster is restarted by itself rather than have a manual intervention by a RE.

# Decisions
1. Use a JVM option to restart puppetmaster on out of memory error. A better way would be to get an independent mechanism to supervise puppet such as supervidord