### PR TITLE
Increase search-api memory thresholds to match rummager

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -722,6 +722,8 @@ govuk::apps::travel_advice_publisher::redis_port: "%{hiera('sidekiq_port')}"
 # dummy configuration for search-api, because all keys in
 # hieradata_aws/common.yaml have to be in hieradata/common.yaml as
 # well (even though search-api isn't deployable here):
+govuk::apps::search_api::nagios_memory_warning: 4600
+govuk::apps::search_api::nagios_memory_critical: 4900
 govuk::apps::search_api::rabbitmq_hosts: []
 govuk::apps::search_api::enable_bulk_reindex_listener: false
 govuk::apps::search_api::enable_publishing_listener: false

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -651,9 +651,8 @@ govuk::apps::rummager::redis_port: '6379'
 govuk::apps::rummager::elasticsearch_hosts: 'http://rummager-elasticsearch:9200'
 govuk::apps::rummager::unicorn_worker_processes: "6"
 
-# todo: enable when it seems to be working
-# govuk::apps::search_api::nagios_memory_warning: 4600
-# govuk::apps::search_api::nagios_memory_critical: 4900
+govuk::apps::search_api::nagios_memory_warning: 4600
+govuk::apps::search_api::nagios_memory_critical: 4900
 govuk::apps::search_api::enable_bulk_reindex_listener: true
 govuk::apps::search_api::enable_publishing_listener: true
 govuk::apps::search_api::enable_govuk_index_listener: true


### PR DESCRIPTION
The memory alert thresholds for `search-api` were temporarily reverted to the app default for testing.  They can now be returned to match the value used by `rummager`.

Trello card: https://trello.com/c/DoCkaNft/84-explore-high-memory-usage-by-search-api