### PR TITLE
Enable healthcheck in Staging and Production

### DIFF
--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -111,7 +111,6 @@ govuk::apps::content_store::mongodb_name: 'content_store_development'
 govuk::apps::content_performance_manager::rabbitmq_user: 'content_performance_manager'
 govuk::apps::content_performance_manager::rabbitmq_hosts: ['localhost']
 govuk::apps::content_performance_manager::rabbitmq::amqp_pass: 'content_performance_manager'
-govuk::apps::content_performance_manager::etl_healthcheck_enabled: true
 govuk::apps::content_performance_manager::etl_healthcheck_enabled_from_hour: '14'
 govuk::apps::content_publisher::enabled: true
 govuk::apps::content_tagger::enable_procfile_worker: false

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -20,7 +20,6 @@ govuk::apps::ckan::cronjobs::enable_solr_reindex: true
 govuk::apps::content_data_admin::google_tag_manager_auth: 'wFyiBTovFhDv5qMe_LXt7Q'
 govuk::apps::content_data_admin::google_tag_manager_preview: 'env-7'
 govuk::apps::content_data_admin::google_tag_manager_id: 'GTM-NZG8SF2'
-govuk::apps::content_performance_manager::etl_healthcheck_enabled: true
 govuk::apps::content_performance_manager::etl_healthcheck_enabled_from_hour: '14'
 govuk::apps::content_publisher::aws_s3_bucket: "govuk-integration-content-publisher-activestorage"
 govuk::apps::content_publisher::google_tag_manager_auth: "xTPyDeRcMiXFWvscgkLowg"

--- a/modules/govuk/manifests/apps/content_data_api.pp
+++ b/modules/govuk/manifests/apps/content_data_api.pp
@@ -20,7 +20,7 @@
 #
 # [*etl_healthcheck_enabled*]
 #   Enables or disables the ETL checks via the healthcheck endpoint
-#   Default: false
+#   Default: true
 #
 # [*etl_healthcheck_enabled_from_hour*]
 #   The hour of the day where ETL healthcheck alerts are enabled
@@ -89,7 +89,7 @@ class govuk::apps::content_data_api(
   $db_password = undef,
   $db_username = 'content_data_api',
   $enable_procfile_worker = true,
-  $etl_healthcheck_enabled = false,
+  $etl_healthcheck_enabled = true,
   $etl_healthcheck_enabled_from_hour = undef,
   $google_analytics_govuk_view_id = undef,
   $google_client_email = undef,

--- a/modules/govuk/manifests/apps/content_performance_manager.pp
+++ b/modules/govuk/manifests/apps/content_performance_manager.pp
@@ -20,7 +20,7 @@
 #
 # [*etl_healthcheck_enabled*]
 #   Enables or disables the ETL checks via the healthcheck endpoint
-#   Default: false
+#   Default: true
 #
 # [*etl_healthcheck_enabled_from_hour*]
 #   The hour of the day where ETL healthcheck alerts are enabled
@@ -89,7 +89,7 @@ class govuk::apps::content_performance_manager(
   $db_password = undef,
   $db_username = 'content_performance_manager',
   $enable_procfile_worker = true,
-  $etl_healthcheck_enabled = false,
+  $etl_healthcheck_enabled = true,
   $etl_healthcheck_enabled_from_hour = undef,
   $google_analytics_govuk_view_id = undef,
   $google_client_email = undef,


### PR DESCRIPTION
This enables the endpoint that returns a JSON with the status of the
application. It is currently copied over to `content_data_api` because we are in
the process to rename `content_performance_manager` to `content_data_api`