### PR TITLE
Add AWS credentials to Content Data Admin

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -57,6 +57,7 @@ govuk::apps::asset_manager::aws_s3_bucket_name: 'govuk-assets-production'
 govuk::apps::asset_manager::aws_region: 'eu-west-1'
 govuk::apps::ckan::ckan_site_url: 'https://ckan.publishing.service.gov.uk'
 govuk::apps::content_data_admin::google_tag_manager_id: 'GTM-NZG8SF2'
+govuk::apps::content_data_admin::aws_csv_export_bucket_name: 'govuk-production-content-data-csvs'
 govuk::apps::content_performance_manager::etl_healthcheck_enabled_from_hour: '9'
 govuk::apps::content_publisher::aws_s3_bucket: "govuk-production-content-publisher-activestorage"
 govuk::apps::content_publisher::google_tag_manager_auth: "sxvBI4QvwgTRX5e76vdIHA"

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -20,6 +20,7 @@ govuk::apps::ckan::cronjobs::enable_solr_reindex: true
 govuk::apps::content_data_admin::google_tag_manager_auth: 'xcAlGBhKTIeO6y_JhmEapQ'
 govuk::apps::content_data_admin::google_tag_manager_id: 'GTM-NZG8SF2'
 govuk::apps::content_data_admin::google_tag_manager_preview: 'env-5'
+govuk::apps::content_data_admin::aws_csv_export_bucket_name: 'govuk-staging-content-data-csvs'
 govuk::apps::content_performance_manager::etl_healthcheck_enabled_from_hour: '12'
 govuk::apps::content_publisher::aws_s3_bucket: "govuk-staging-content-publisher-activestorage"
 govuk::apps::content_publisher::google_tag_manager_auth: "QaRG0YPL6_pwZdxCbyMXPQ"

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -20,6 +20,7 @@ govuk::apps::ckan::cronjobs::enable_solr_reindex: true
 govuk::apps::content_data_admin::google_tag_manager_auth: 'wFyiBTovFhDv5qMe_LXt7Q'
 govuk::apps::content_data_admin::google_tag_manager_preview: 'env-7'
 govuk::apps::content_data_admin::google_tag_manager_id: 'GTM-NZG8SF2'
+govuk::apps::content_data_admin::aws_csv_export_bucket_name: 'govuk-integration-content-data-csvs'
 govuk::apps::content_performance_manager::etl_healthcheck_enabled_from_hour: '14'
 govuk::apps::content_publisher::aws_s3_bucket: "govuk-integration-content-publisher-activestorage"
 govuk::apps::content_publisher::google_tag_manager_auth: "xTPyDeRcMiXFWvscgkLowg"

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -119,6 +119,7 @@ govuk::apps::ckan::s3_aws_region_name: "eu-west-1"
 govuk::apps::content_data_admin::google_tag_manager_auth: 'bcb35jL0VPLO8b6W2rJXyA'
 govuk::apps::content_data_admin::google_tag_manager_id: 'GTM-NZG8SF2'
 govuk::apps::content_data_admin::google_tag_manager_preview: 'env-8'
+govuk::apps::content_data_admin::aws_csv_export_bucket_name: 'govuk-production-content-data-csvs'
 govuk::apps::content_data_api::etl_healthcheck_enabled_from_hour: '9'
 govuk::apps::content_publisher::aws_s3_bucket: "govuk-production-content-publisher-activestorage"
 govuk::apps::content_publisher::google_tag_manager_auth: "O0DrItJxJeQ5Q2W6YCZzvw"

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -120,6 +120,7 @@ govuk::apps::ckan::cronjobs::enable_solr_reindex: true
 govuk::apps::content_data_admin::google_tag_manager_auth: 'xcAlGBhKTIeO6y_JhmEapQ'
 govuk::apps::content_data_admin::google_tag_manager_id: 'GTM-NZG8SF2'
 govuk::apps::content_data_admin::google_tag_manager_preview: 'env-5'
+govuk::apps::content_data_admin::aws_csv_export_bucket_name: 'govuk-staging-content-data-csvs'
 govuk::apps::content_data_api::etl_healthcheck_enabled_from_hour: '12'
 govuk::apps::content_publisher::aws_s3_bucket: "govuk-staging-content-publisher-activestorage"
 govuk::apps::content_publisher::google_tag_manager_auth: "QaRG0YPL6_pwZdxCbyMXPQ"

--- a/modules/govuk/manifests/apps/content_data_admin.pp
+++ b/modules/govuk/manifests/apps/content_data_admin.pp
@@ -62,6 +62,18 @@
 #   Whether to enable the procfile worker
 #   Default: true
 #
+# [*aws_access_key_id*]
+#   The Access Key ID for AWS to access S3 buckets.
+#
+# [*aws_secret_access_key*]
+#   The Secret Access Key for AWS to access S3 buckets.
+#
+# [*aws_region*]
+#   The Region for AWS to access S3 buckets.
+#
+# [*aws_csv_export_bucket_name*]
+#   The S3 Bucket used for csv exports.
+#
 class govuk::apps::content_data_admin (
   $port                         = '3230',
   $enabled                      = true,
@@ -82,6 +94,10 @@ class govuk::apps::content_data_admin (
   $redis_host = undef,
   $redis_port = undef,
   $enable_procfile_worker = true,
+  $aws_access_key_id = undef,
+  $aws_secret_access_key = undef,
+  $aws_region = 'eu-west-1',
+  $aws_csv_export_bucket_name = undef,
 ) {
   $app_name = 'content-data-admin'
 
@@ -123,14 +139,26 @@ class govuk::apps::content_data_admin (
       varname => 'CONTENT_PERFORMANCE_MANAGER_BEARER_TOKEN',
       value   => $content_performance_manager_bearer_token;
     "${title}-GOOGLE_TAG_MANAGER_ID":
-        varname => 'GOOGLE_TAG_MANAGER_ID',
-        value   => $google_tag_manager_id;
+      varname => 'GOOGLE_TAG_MANAGER_ID',
+      value   => $google_tag_manager_id;
     "${title}-GOOGLE_TAG_MANAGER_PREVIEW":
-        varname => 'GOOGLE_TAG_MANAGER_PREVIEW',
-        value   => $google_tag_manager_preview;
+      varname => 'GOOGLE_TAG_MANAGER_PREVIEW',
+      value   => $google_tag_manager_preview;
     "${title}-GOOGLE_TAG_MANAGER_AUTH":
-        varname => 'GOOGLE_TAG_MANAGER_AUTH',
-        value   => $google_tag_manager_auth;
+      varname => 'GOOGLE_TAG_MANAGER_AUTH',
+      value   => $google_tag_manager_auth;
+    "${title}-AWS_ACCESS_KEY_ID":
+      varname => 'AWS_ACCESS_KEY_ID',
+      value   => $aws_access_key_id;
+    "${title}-AWS_SECRET_ACCESS_KEY":
+      varname => 'AWS_SECRET_ACCESS_KEY',
+      value   => $aws_secret_access_key;
+    "${title}-AWS_REGION":
+      varname => 'AWS_REGION',
+      value   => $aws_region;
+    "${title}-AWS_CSV_EXPORT_BUCKET_NAME":
+      varname => 'AWS_CSV_EXPORT_BUCKET_NAME',
+      value   => $aws_csv_export_bucket_name;
   }
 
   govuk::app::envvar::redis { $app_name:


### PR DESCRIPTION
Add AWS credentials so content data admin has permissions to access S3 to store CSV files for users to download.