### PR TITLE
Enable the Content Data apps on AWS Staging and Production

### DIFF
--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -19,6 +19,8 @@ node_class: &node_class
     apps:
       - cache-clearing-service
       - canary-backend
+      - content-data-admin
+      - content-data-api
       - transition
       - imminence
       - kibana

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -19,6 +19,8 @@ node_class: &node_class
     apps:
       - cache-clearing-service
       - canary-backend
+      - content-data-admin
+      - content-data-api
       - transition
       - imminence
       - kibana


### PR DESCRIPTION
The plan is to host the Content Data Admin on AWS, along with the
Content Data API (the new name for the Content Performance Manager).