### PR TITLE
Fix dumping the CPM database in AWS Production

### DIFF
--- a/modules/govuk_env_sync/files/govuk_env_sync.sh
+++ b/modules/govuk_env_sync/files/govuk_env_sync.sh
@@ -241,7 +241,11 @@ function  dump_postgresql {
   if [ "${database}" == 'transition_production' ]; then
     db_hostname='transition-postgresql-primary'
   elif [ "${database}" == 'content_performance_manager_production' ]; then
-    db_hostname='warehouse-postgresql-primary'
+    if [ -e "/etc/facter/facts.d/aws_environment.txt" ]; then
+      db_hostname='content-data-api-postgresql-primary'
+    else
+      db_hostname='warehouse-postgresql-primary'
+    fi
   elif [ "${database}" == 'content_data_api_production' ]; then
     db_hostname='content-data-api-postgresql-primary'
   else


### PR DESCRIPTION
The DB hostname needs to be different from Carrenza, so add a if
statement in.

This complexity can be removed once the Content Performance Manager is
migrated to AWS.