### PR TITLE
Remove static from /etc/hosts

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1576,7 +1576,6 @@ hosts::production::frontend::app_hostnames:
   - 'service-manual'
   - 'service-manual-frontend'
   - 'smartanswers'
-  - 'static'
   - 'whitehall-frontend'
   - 'draft-whitehall-frontend'
 

--- a/modules/router/spec/classes/router__assets_origin_spec.rb
+++ b/modules/router/spec/classes/router__assets_origin_spec.rb
@@ -59,13 +59,13 @@ describe "router::assets_origin", :type => :class do
       let(:facts) {{ :environment => 'production' }}
       let(:pre_condition) { "include hosts::production" }
 
-      it "should have host entries for each route target" do
-        asset_manager_uploaded_assets_routes.each do |_path|
-          hostname = "static.publishing.service.gov.uk"
-          message = "asset_manager_uploaded_assets_routes point at non-existent host '#{hostname}' in production"
-          expect(all_hostnames).to include(hostname), message
-        end
-      end
+#      it "should have host entries for each route target" do
+#        asset_manager_uploaded_assets_routes.each do |_path|
+#          hostname = "static.publishing.service.gov.uk"
+#          message = "asset_manager_uploaded_assets_routes point at non-existent host '#{hostname}' in production"
+#          expect(all_hostnames).to include(hostname), message
+#        end
+#      end
     end
 
     context "on the dev VM" do


### PR DESCRIPTION
  static has been migrated to AWS, we now resolve the location
of static using normal DNS.