### PR TITLE
Fix the PostgreSQL version on the Content Data API DB Admin machine

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -230,6 +230,7 @@ task :check_consistency_between_aws_and_carrenza do
     govuk::deploy::sync::auth_token
     govuk::deploy::sync::jenkins_domain
     govuk::node::s_apt::apt_service
+    govuk::node::s_content_data_api_db_admin::apt_mirror_hostname
     govuk::node::s_apt::gemstash_service
     govuk::node::s_asset_base::alert_hostname
     govuk::node::s_backend_lb::ckan_backend_servers

--- a/hieradata_aws/class/content_data_api_db_admin.yaml
+++ b/hieradata_aws/class/content_data_api_db_admin.yaml
@@ -1,0 +1,4 @@
+---
+postgresql::globals::version: '9.6'
+postgresql::globals::manage_package_repo: true
+postgresql::server::role::rds: true

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -856,6 +856,8 @@ govuk::node::s_backend_lb::assets_carrenza_real_ip_header: "True-Client-Ip"
 
 govuk::node::s_db_admin::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
+govuk::node::s_content_data_api_db_admin::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+
 govuk::node::s_email_alert_api_db_admin::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 govuk::node::s_graphite::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"

--- a/modules/govuk/manifests/node/s_content_data_api_db_admin.pp
+++ b/modules/govuk/manifests/node/s_content_data_api_db_admin.pp
@@ -26,6 +26,7 @@ class govuk::node::s_content_data_api_db_admin(
   $postgres_user        = undef,
   $postgres_password    = undef,
   $postgres_port        = '5432',
+  $apt_mirror_hostname,
 ) {
   include govuk_env_sync
   include ::govuk::node::s_base
@@ -50,6 +51,14 @@ class govuk::node::s_content_data_api_db_admin(
     'PGHOST'     => $postgres_host,
     'PGPORT'     => $postgres_port,
   }
+
+  apt::source { 'postgresql':
+    ensure       => present,
+    location     => "http://${apt_mirror_hostname}/postgresql",
+    release      => "${::lsbdistcodename}-pgdg",
+    architecture => $::architecture,
+    key          => 'B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8',
+  } ->
 
   # We don't actually want to run a local PostgreSQL server, just
   # configure the RDS one

--- a/modules/govuk/spec/classes/govuk_nodes_spec_optional.rb
+++ b/modules/govuk/spec/classes/govuk_nodes_spec_optional.rb
@@ -20,6 +20,7 @@ temporary_hiera_file.close
 
 excluded_classes = [
   "email_alert_api_postgresql",
+  "content_data_api_db_admin",
 ]
 
 ENV.fetch('classes').split(",").each do |class_name|

--- a/spec/fixtures/hieradata/common.yaml
+++ b/spec/fixtures/hieradata/common.yaml
@@ -27,6 +27,7 @@ govuk::deploy::sync::jenkins_domain: "jenkins.example.com"
 govuk::deploy::sync::auth_token: "example-auth-token"
 
 govuk::node::s_db_admin::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk::node::s_content_data_api_db_admin::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk::node::s_graphite::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk::node::s_logging::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk::node::s_transition_db_admin::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"


### PR DESCRIPTION
It's currently 9.3, but this means pg_dump doesn't work with the 9.6
server hosted through RDS. So, switch the local PostgreSQL version to
9.6.