### PR TITLE
Add Carrenza targets to mirrorer in AWS

### DIFF
--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -177,12 +177,22 @@ govuk_crawler::seed_enable: true
 govuk_crawler::sync_enable: true
 govuk_crawler::site_root: 'https://www.gov.uk'
 govuk_crawler::targets:
+  - 'mirror-rsync@mirror0.mirror.provider1.production.govuk.service.gov.uk'
+  - 'mirror-rsync@mirror1.mirror.provider1.production.govuk.service.gov.uk'
   - 's3://govuk-mirror-production/'
 
 govuk::apps::govuk_crawler_worker::root_urls:
   - 'https://assets.digital.cabinet-office.gov.uk/'
   - "https://assets.%{hiera('app_domain')}/"
   - 'https://www.gov.uk/'
+
+govuk_crawler::ssh_keys:
+  mirror0.mirror.provider1.production.govuk.service.gov.uk:
+    key: 'AAAAB3NzaC1yc2EAAAADAQABAAABAQC1VVHvPeBh8MoAEBTLpO9Xj/s5s+rqe4AN61HTzu4hGpYIB4sv+j8VHzHVHVmhP31gl9xaIiv+7BI8AstuGWPiehOIgTR+ufKyvnr1msHO59dM5Vht5i2ZVVB5WF/MphTfGT4vO3RDAZGvZXUaasBxOqqE6jrp4jF5d8WFV44mzE5PqqhAodiBGyfKDcd0gzuQhGpOsafYAy4+E+OlIbcX3LvTZyZdrC5va0l5LSVxstJjUjTSw85/m1pjSYBPMLc50T0M5SYA79G2yPaPYqux5YpA+D/0qnWlNQfR7MQdo3XO4ZGqRyjSn9/WcYsyn5KVivRd+Id6Jw8x0MwPzIVJ'
+    type: 'ssh-rsa'
+  mirror1.mirror.provider1.production.govuk.service.gov.uk:
+    key: 'AAAAB3NzaC1yc2EAAAADAQABAAABAQDHi69quH4i1jY4uVLuIYOoUi7yc+6/fJjDKJciWIIgyH1rCSGtTXrfcJQHQKxKEyndQ+LoUs8krImD9CtzQTvoqdXYKu+XgpjqiZ5HfQhx55ZoMCXnx9vqCwGtx2LwH4PaBZRvsNJbbY+sG3W13eXkgwQnIcI2FgGpDDJQ9lfxSNzt6jMJQuvAhhDrKtZEsA56AznPIRd1mIHmuZ6gILBzJmDw5EIpqQhSb4+NrNTNnGxHyFkZISTMG0mx9lRtlyS1SMZVoPJQbShSEScKMXRlacrpkiNOTvrGDrhsLjTUtT5g1bo4XMFRubReAwFCeTZI0Qv1Bvpzj8V9c8B4+p6b'
+    type: 'ssh-rsa'
 
 govuk_jenkins::config::banner_colour_background: '#df3034'
 govuk_jenkins::config::banner_colour_text: 'white'


### PR DESCRIPTION
- These (Carrenza) used to be the primary mirrors

- We continue to use old mirrors in the interim while moving to GCP asa
secondary

- Only S3 mirror was configured in AWS

solo: @schmie