### PR TITLE
Update lots of gem versions in the Gemfile.lock

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source "https://rubygems.org"
 
+ruby '1.9.3'
+
 gem "rake"
 gem "puppet-syntax", '2.1.0'
 gem "puppet-lint", '2.0.0'
@@ -12,6 +14,8 @@ gem "rspec-puppet"
 # FIXME: There is some confusion about who should require who.
 # https://github.com/rodjek/rspec-puppet/issues/56
 gem 'puppetlabs_spec_helper', '1.0.1'
+# Workaround a Mocha incompatibility in puppetlabs_spec_helper
+gem 'mocha', '< 1.5.0'
 gem "webmock", "~> 1.20.0"
 gem "sshkey", "1.9.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,56 +10,47 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (2.2.8)
-    activemodel (4.1.8)
-      activesupport (= 4.1.8)
-      builder (~> 3.1)
-    activesupport (4.1.8)
-      i18n (~> 0.6, >= 0.6.9)
-      json (~> 1.7, >= 1.7.7)
-      minitest (~> 5.1)
-      thread_safe (~> 0.1)
-      tzinfo (~> 1.1)
-    addressable (2.3.7)
-    builder (3.2.2)
-    crack (0.4.2)
+    addressable (2.4.0)
+    crack (0.4.3)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
     facter (2.4.6)
-      CFPropertyList (~> 2.2.6)
-    faraday (0.9.0)
+    faraday (0.13.1)
       multipart-post (>= 1.2, < 3)
-    gpgme (2.0.8)
-      mini_portile (>= 0.5.0)
-    her (0.7.2)
-      activemodel (>= 3.0.0, < 4.2)
-      activesupport (>= 3.0.0, < 4.2)
-      faraday (>= 0.8, < 1.0)
-      multi_json (~> 1.7)
+    faraday_middleware (0.12.2)
+      faraday (>= 0.7.4, < 1.0)
+    fast_gettext (1.1.2)
+    gettext (3.2.9)
+      locale (>= 2.0.5)
+      text (>= 1.3.0)
+    gettext-setup (0.30)
+      fast_gettext (~> 1.1.0)
+      gettext (>= 3.0.2)
+      locale
+    gpgme (2.0.18)
+      mini_portile2 (~> 2.3)
     hiera (1.3.4)
       json_pure
-    hiera-eyaml (2.0.7)
+    hiera-eyaml (3.0.0)
       highline (~> 1.6.19)
-      trollop (~> 2.0)
+      optimist
     highline (1.6.21)
-    i18n (0.6.11)
-    json (1.8.6)
-    json_pure (1.8.3)
-    librarian (0.1.2)
-      highline
-      thor (~> 0.15)
-    librarian-puppet (2.0.0)
-      librarian (>= 0.1.2)
-      puppet_forge
+    json_pure (2.2.0)
+    librarian-puppet (2.2.3)
+      librarianp (>= 0.6.3)
+      puppet_forge (~> 2.1)
       rsync
+    librarianp (0.6.4)
+      thor (~> 0.15)
+    locale (2.1.2)
     metaclass (0.0.4)
-    mini_portile (0.6.2)
-    minitest (5.4.3)
-    mocha (1.1.0)
+    mini_portile2 (2.4.0)
+    minitar (0.8)
+    mocha (1.4.0)
       metaclass (~> 0.0.1)
-    multi_json (1.10.1)
     multipart-post (2.0.0)
-    parallel (1.12.1)
+    optimist (3.0.0)
+    parallel (1.13.0)
     parallel_tests (2.9.0)
       parallel
     puppet (3.8.5)
@@ -71,15 +62,19 @@ GEM
       puppet-lint (>= 1.0, < 3.0)
     puppet-syntax (2.1.0)
       rake
-    puppet_forge (1.0.3)
-      her (~> 0.6)
+    puppet_forge (2.2.9)
+      faraday (>= 0.9.0, < 0.14.0)
+      faraday_middleware (>= 0.9.0, < 0.13.0)
+      gettext-setup (~> 0.11)
+      minitar
+      semantic_puppet (~> 1.0)
     puppetlabs_spec_helper (1.0.1)
       mocha
       puppet-lint
       puppet-syntax
       rake
       rspec-puppet
-    rake (10.1.0)
+    rake (12.2.1)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -92,17 +87,15 @@ GEM
     rspec-mocks (3.8.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
-    rspec-puppet (2.7.2)
+    rspec-puppet (2.7.3)
       rspec
     rspec-support (3.8.0)
     rsync (1.0.9)
-    safe_yaml (1.0.4)
+    safe_yaml (1.0.5)
+    semantic_puppet (1.0.2)
     sshkey (1.9.0)
-    thor (0.19.1)
-    thread_safe (0.3.4)
-    trollop (2.1.2)
-    tzinfo (1.2.2)
-      thread_safe (~> 0.1)
+    text (1.3.1)
+    thor (0.20.3)
     webmock (1.20.4)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -115,6 +108,7 @@ DEPENDENCIES
   hiera (= 1.3.4)
   hiera-eyaml-gpg!
   librarian-puppet
+  mocha (< 1.5.0)
   parallel
   parallel_tests
   puppet (= 3.8.5)
@@ -126,3 +120,6 @@ DEPENDENCIES
   rspec-puppet
   sshkey (= 1.9.0)
   webmock (~> 1.20.0)
+
+RUBY VERSION
+   ruby 1.9.3p550


### PR DESCRIPTION
I added the Ruby version to the Gemfile as I think this might have got
Bundler to not install versions of the gems which don't work with
1.9.3.

I also ran this with Bundler 1.17.3, but I've removed the BUNDLED WITH
section from the Gemfile.lock to avoid older versions of Bundler
finding out and complaining.