### PR TITLE
puppet does not allow variable reassignment

### DIFF
--- a/modules/icinga/manifests/check/graphite.pp
+++ b/modules/icinga/manifests/check/graphite.pp
@@ -100,9 +100,11 @@ define icinga::check::graphite(
   }
 
   if $action_url == undef {
-    $app_domain = hiera('app_domain')
+    
     if $::aws_migration {
       $app_domain = hiera('app_domain_internal')
+    } else {
+      $app_domain = hiera('app_domain')
     }
 
     $action_url_real = "https://graphite.${app_domain}/render/?\

--- a/modules/icinga/manifests/check/graphite.pp
+++ b/modules/icinga/manifests/check/graphite.pp
@@ -100,7 +100,7 @@ define icinga::check::graphite(
   }
 
   if $action_url == undef {
-    
+
     if $::aws_migration {
       $app_domain = hiera('app_domain_internal')
     } else {


### PR DESCRIPTION
# Context

A change was made in the graphite puppet code to reassign the variable `app_domain` to `app_domain_internal` when in AWS. Unfortunately puppet does not allow variable reassignment.
The variable is set at initialisation.

# Decisions
1. fix the logic so that the variable `app_domain` is set only one.