### PR TITLE
Improve the AWS RabbitMQ configuration

### DIFF
--- a/hieradata_aws/class/integration/rabbitmq.yaml
+++ b/hieradata_aws/class/integration/rabbitmq.yaml
@@ -1,0 +1,11 @@
+---
+
+govuk::node::s_rabbitmq::apps_using_rabbitmq:
+  - backdrop_write
+  - email_alert_service
+  - publishing_api
+  - rummager
+  - content_data_api
+  - content_performance_manager
+  - cache_clearing_service
+  - search_api

--- a/hieradata_aws/class/rabbitmq.yaml
+++ b/hieradata_aws/class/rabbitmq.yaml
@@ -1,12 +1,8 @@
 ---
 
 govuk::node::s_rabbitmq::apps_using_rabbitmq:
-  - backdrop_write
-  - email_alert_service
-  - publishing_api
   - rummager
   - content_data_api
-  - content_performance_manager
   - cache_clearing_service
   - search_api
 


### PR DESCRIPTION
There are 3 AWS environments, Production, Staging and Integration. But
Production and Staging have a limited set of applications. Therefore,
specialise the RabbitMQ configuration accordingly.