### PR TITLE
Enable the ETL process for the Content Data API in AWS

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -247,6 +247,7 @@ task :check_consistency_between_aws_and_carrenza do
     govuk_elasticsearch::open_firewall_from_all
     govuk_jenkins::deploy_all_apps::apps_on_nodes
     govuk_jenkins::deploy_all_apps::deploy_environment
+    govuk_jenkins::jobs::content_data_api::rake_etl_master_process_cron_schedule
     govuk_jenkins::jobs::deploy_app::graphite_host
     govuk_jenkins::jobs::deploy_app::graphite_port
     govuk_jenkins::jobs::deploy_emergency_banner::clear_cdn_cache

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -79,6 +79,8 @@ govuk_elasticsearch::dump::run_es_dump_hour: '9'
 govuk_jenkins::job_builder::environment: 'integration'
 govuk_jenkins::config::executors: '8'
 
+govuk_jenkins::jobs::content_data_api::rake_etl_master_process_cron_schedule: '0 13 * * *'
+
 govuk_jenkins::jobs::content_performance_manager::rake_etl_master_process_cron_schedule: '0 13 * * *'
 
 govuk_jenkins::jobs::content_publisher_whitehall_import::enable_slack_notifications: true

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -195,6 +195,8 @@ govuk_elasticsearch::dump::run_es_dump_hour: '4'
 
 govuk_jenkins::job_builder::environment: 'production'
 
+govuk_jenkins::jobs::content_data_api::rake_etl_master_process_cron_schedule: '0 7 * * *'
+
 govuk_jenkins::jobs::deploy_emergency_banner::clear_cdn_cache: true
 
 govuk_jenkins::jobs::search_fetch_analytics_data::skip_page_traffic_load: true

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -195,6 +195,8 @@ govuk_elasticsearch::dump::run_es_dump_hour: '4'
 
 govuk_jenkins::job_builder::environment: 'staging'
 
+govuk_jenkins::jobs::content_data_api::rake_etl_master_process_cron_schedule: '0 11 * *'
+
 govuk_jenkins::jobs::network_config_deploy::environments:
   - 'carrenza-staging'
   - 'carrenza-staging-dr'


### PR DESCRIPTION
The Content Data API is the new name for the Content Performance
Manager, and at the same time, the application is being migrated to
AWS.

This commit enables the regular ETL process, which is run through the
Deploy Jenkins in each environment.