### PR TITLE
Remove Rummager RabbitMQ configuration from AWS Prod and AWS Staging

### DIFF
--- a/hieradata_aws/class/rabbitmq.yaml
+++ b/hieradata_aws/class/rabbitmq.yaml
@@ -1,7 +1,6 @@
 ---
 
 govuk::node::s_rabbitmq::apps_using_rabbitmq:
-  - rummager
   - content_data_api
   - cache_clearing_service
   - search_api


### PR DESCRIPTION
It's being migrated to AWS under the new Search API name, so the
Rummager configuration is unnecessary.