### PR TITLE
Make the datascrubber absent in AWS Production and AWS Staging

### DIFF
--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -280,11 +280,6 @@ postfix::rewrite_mail_list: 'machine.email.carrenza'
 
 nginx::config::stack_network_prefix: '10.13.0'
 
-govuk_datascrubber::ensure: 'latest'
-govuk_datascrubber::share_with:
-  - '210287912431'     # AWS integration
-govuk_datascrubber::s3_export_prefix: 's3://govuk-staging-database-backups/scrubbed'
-
 hosts::backend_migration::hosts:
   calculators-frontend-3.frontend.publishing.service.gov.uk:
     ip: 10.3.2.13

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -277,11 +277,6 @@ router::nginx::robotstxt: |
 
 nginx::config::stack_network_prefix: '10.12.0'
 
-govuk_datascrubber::ensure: 'latest'
-govuk_datascrubber::share_with:
-  - '210287912431'     # AWS integration
-govuk_datascrubber::s3_export_prefix: 's3://govuk-production-database-backups/scrubbed'
-
 hosts::backend_migration::hosts:
   cache-1.router.staging.publishing.service.gov.uk:
     ip: 10.2.1.2


### PR DESCRIPTION
It doesn't make sense to me to scrub data in either of these
environments, removing sensitive data has only ever been done for
Integration as far as I'm aware.

Also, I'm not aware that any of the relevant databases that could be
effected currently exist in either of these environments, and the
acknowledged alerts in Icinga seem to suggest this is the case as
well.