### PR TITLE
Actually enable the Content Data API Jenkins job in AWS

### DIFF
--- a/hieradata_aws/class/integration/jenkins.yaml
+++ b/hieradata_aws/class/integration/jenkins.yaml
@@ -11,6 +11,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::clear_varnish_cache
   - govuk_jenkins::jobs::configure_github_repos
   - govuk_jenkins::jobs::content_performance_manager
+  - govuk_jenkins::jobs::content_data_api
   - govuk_jenkins::jobs::data_sync
   - govuk_jenkins::jobs::data_sync_complete_integration
   - govuk_jenkins::jobs::deploy_app

--- a/hieradata_aws/class/production/jenkins.yaml
+++ b/hieradata_aws/class/production/jenkins.yaml
@@ -12,6 +12,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::clear_frontend_memcache
   - govuk_jenkins::jobs::clear_template_cache
   - govuk_jenkins::jobs::clear_varnish_cache
+  - govuk_jenkins::jobs::content_data_api
   - govuk_jenkins::jobs::deploy_app
   - govuk_jenkins::jobs::deploy_emergency_banner
   - govuk_jenkins::jobs::deploy_puppet

--- a/hieradata_aws/class/staging/jenkins.yaml
+++ b/hieradata_aws/class/staging/jenkins.yaml
@@ -10,6 +10,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::clear_frontend_memcache
   - govuk_jenkins::jobs::clear_template_cache
   - govuk_jenkins::jobs::clear_varnish_cache
+  - govuk_jenkins::jobs::content_data_api
   - govuk_jenkins::jobs::deploy_app
   - govuk_jenkins::jobs::deploy_emergency_banner
   - govuk_jenkins::jobs::deploy_puppet


### PR DESCRIPTION
The Content Data API is the new name for the Content Performance
Manager, which is also being migrated to AWS.