### PR TITLE
set ownership of /etc/postgresql on mapit to `postgres` user and group

### DIFF
--- a/modules/govuk/manifests/node/s_mapit.pp
+++ b/modules/govuk/manifests/node/s_mapit.pp
@@ -4,6 +4,16 @@ class govuk::node::s_mapit inherits govuk::node::s_base {
 
   include nginx
 
+  file { '/etc/postgresql':
+    ensure  => directory,
+    owner   => 'postgres',
+    group   => 'postgres',
+    mode    => '0755',
+    recurse => true,
+    require => Class['postgresql::server::install'],
+    before  => Class['postgresql::server::service'],
+  }
+
   Govuk_mount['/var/lib/postgresql']
   ->
   class { 'govuk_postgresql::server::standalone': }


### PR DESCRIPTION
# Context
When provisioning mapit machines in AWS, there is a puppet error linked with the wrong ownership of the '/etc/postgresql' directory.

# Decisions
1. set the ownership of '/etc/postgresql' directory to postgresql after postgresql is installed and before it is started.