### PR TITLE
Change the order of operations in govuk_env_sync restore_postgresql

### DIFF
--- a/modules/govuk_env_sync/files/govuk_env_sync.sh
+++ b/modules/govuk_env_sync/files/govuk_env_sync.sh
@@ -290,6 +290,8 @@ function restore_postgresql {
     db_hostname='postgresql-primary'
   fi
 
+  pg_restore "${tempdir}/${filename}" | sed '/^COMMENT\ ON\ EXTENSION\ plpgsql/d' | gzip > "${tempdir}/${filename}.dump"
+
 # Checking if the database already exist
 # If it does we will drop the database
   DB_OWNER=''
@@ -301,7 +303,6 @@ function restore_postgresql {
      sudo dropdb -U aws_db_admin -h "${db_hostname}" --no-password "${database}"
   fi
 
-  pg_restore "${tempdir}/${filename}" | sed '/^COMMENT\ ON\ EXTENSION\ plpgsql/d' | gzip > "${tempdir}/${filename}.dump"
   sudo createdb -U aws_db_admin -h "${db_hostname}" --no-password "${database}"
   pg_stderr=$(zcat "${tempdir}/${filename}" | sudo psql -U aws_db_admin -h "${db_hostname}" -1 --no-password -d "${database}" 2>&1)
   rm "${tempdir}/${filename}.dump"


### PR DESCRIPTION
Move the pg_restore step before the dropdb step, as this takes a
while, and doing it before dropping the database reduces the chance
that govuk-puppet will run and re-create the database after it's been
dropped, but before govuk_env_sync tries to create it.