### PR TITLE
Disable rummager in AWS Production

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -91,6 +91,8 @@ govuk::apps::travel_advice_publisher::enable_email_alerts: true
 govuk::apps::whitehall::cpu_warning: 400
 govuk::apps::whitehall::cpu_critical: 600
 
+govuk::apps::rummager::enable_rummager: true
+
 govuk::deploy::actionmailer_enable_delivery: true
 
 govuk::deploy::aws_ses_smtp_host: 'email-smtp.us-east-1.amazonaws.com'

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -153,6 +153,8 @@ govuk::apps::support_api::pp_data_url: 'https://www.performance.service.gov.uk'
 govuk::apps::support_api::aws_s3_bucket_name: 'govuk-production-support-api-csvs'
 govuk::apps::travel_advice_publisher::enable_email_alerts: true
 
+govuk::apps::rummager::enable_rummager: false
+
 govuk::deploy::aws_ses_smtp_host: 'email-smtp.eu-west-1.amazonaws.com'
 govuk::deploy::config::errbit_environment_name: 'production'
 govuk::deploy::config::website_root: 'https://www.gov.uk'


### PR DESCRIPTION
This app does not need to be provisioned in AWS Production.  We saw large numbers of errors being logged when this was provisioned in AWS Staging.