### PR TITLE
Stop PostgreSQL running on the Content Data API DB Admin machines

### DIFF
--- a/modules/govuk/manifests/node/s_content_data_api_db_admin.pp
+++ b/modules/govuk/manifests/node/s_content_data_api_db_admin.pp
@@ -65,6 +65,10 @@ class govuk::node::s_content_data_api_db_admin(
   class { '::postgresql::server':
     default_connect_settings => $default_connect_settings,
     service_manage           => false,
+  } ->
+
+  service { 'postgresql':
+    ensure  => stopped,
   }
 
   include ::govuk_postgresql::server::not_slave


### PR DESCRIPTION
This service is only running because of limitations with getting the
Puppet PostgreSQL module to manage PostgreSQL running within AWS's RDS
service.

Therefore, to try and avoid confusion, and a redundant service
running, specify that the service should be stopped.