### PR TITLE
Remove invalid characters from the $service_description

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/content_data_api.pp
+++ b/modules/govuk_jenkins/manifests/jobs/content_data_api.pp
@@ -15,7 +15,7 @@ class govuk_jenkins::jobs::content_data_api (
 ) {
 
   $check_name = 'etl-content-data-api'
-  $service_description = 'Content Data API ETL (Extract, transform, load)'
+  $service_description = 'Content Data API ETL [Extract - transform - load]'
   $job_url = "https://deploy.${app_domain}/job/content_data_api_import_etl_master_process/"
 
   file { '/etc/jenkins_jobs/jobs/content_data_api.yaml':


### PR DESCRIPTION
For the Content Data API Jenkins job. The regex in the icinga module
doesn't allow ( ) or , so switch to [ ] and -.