### PR TITLE
fix service description which does not meet regex validation

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/content_data_api.pp
+++ b/modules/govuk_jenkins/manifests/jobs/content_data_api.pp
@@ -15,7 +15,7 @@ class govuk_jenkins::jobs::content_data_api (
 ) {
 
   $check_name = 'etl-content-data-api'
-  $service_description = 'Content Data API ETL (Extract, transform, load)'
+  $service_description = 'Content Data API Extract Transform Load'
   $job_url = "https://deploy.${app_domain}/job/content_data_api_import_etl_master_process/"
 
   file { '/etc/jenkins_jobs/jobs/content_data_api.yaml':


### PR DESCRIPTION
# Context

The service description for one of the icinga alert of content-data-api does not meet validation by regex and therefore causing puppet to fail to run on the monitoring boxes in AWS Staging and Production.

# Decisions
1. fix the service description