### PR TITLE
Return immediately and use -f for elasticsearch5 sync

### DIFF
--- a/modules/govuk_env_sync/files/govuk_env_sync.sh
+++ b/modules/govuk_env_sync/files/govuk_env_sync.sh
@@ -239,13 +239,13 @@ function restore_elasticsearch {
 
 function dump_elasticsearch5 {
   snapshot_name="$(echo "$filename" | sed 's/.gz//' | tr "[:upper:]" "[:lower:]")"
-  /usr/bin/curl --connect-timeout 10 -sS -XPUT "http://elasticsearch5/_snapshot/${url}/${snapshot_name}?wait_for_completion=true"
+  /usr/bin/curl --connect-timeout 10 -sSf -XPUT "http://elasticsearch5/_snapshot/${url}/${snapshot_name}"
 }
 
 function restore_elasticsearch5 {
   snapshot_name="${filename//.gz/}"
   curl -XDELETE 'http://elasticsearch5/_all'
-  /usr/bin/curl --connect-timeout 10 -sS -XPOST "http://elasticsearch5/_snapshot/${url}/${snapshot_name}/_restore?wait_for_completion=true"
+  /usr/bin/curl --connect-timeout 10 -sSf -XPOST "http://elasticsearch5/_snapshot/${url}/${snapshot_name}/_restore"
 }
 
 function  dump_postgresql {


### PR DESCRIPTION
Setting ?wait_for_completion causes curl to print the initial response
from the server, and then die a little later with an error about an
empty response.  So instead don't wait for completion, but fail
immediately if starting the snapshot/restore task fails.