### PR TITLE
Enable rummager / search-api traffic replay for production

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -91,6 +91,9 @@ govuk::apps::travel_advice_publisher::enable_email_alerts: true
 govuk::apps::whitehall::cpu_warning: 400
 govuk::apps::whitehall::cpu_critical: 600
 
+govuk_search::gor::replay_target_hosts:
+  - 'search-api.production.govuk.digital'
+
 govuk::apps::rummager::enable_rummager: true
 
 govuk::deploy::actionmailer_enable_delivery: true

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -153,6 +153,8 @@ govuk::apps::support_api::pp_data_url: 'https://www.performance.service.gov.uk'
 govuk::apps::support_api::aws_s3_bucket_name: 'govuk-production-support-api-csvs'
 govuk::apps::travel_advice_publisher::enable_email_alerts: true
 
+govuk_search::gor::replay_target_hosts: []
+
 govuk::apps::rummager::enable_rummager: false
 
 govuk::deploy::aws_ses_smtp_host: 'email-smtp.eu-west-1.amazonaws.com'


### PR DESCRIPTION
[Trello card](https://trello.com/c/eoRlv32F/94-get-search-api-running-in-aws-production)