### PR TITLE
Set gor port for production AWS search-api

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -271,6 +271,8 @@ task :check_consistency_between_aws_and_carrenza do
     puppet::puppetserver::puppetdb_version
     stackname
 
+    govuk_search::gor::port
+
     govuk::apps::ckan::s3_aws_region_name
     govuk::apps::ckan::s3_bucket_name
     govuk::apps::content_store::app_domain

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -153,6 +153,8 @@ govuk::apps::support_api::pp_data_url: 'https://www.performance.service.gov.uk'
 govuk::apps::support_api::aws_s3_bucket_name: 'govuk-production-support-api-csvs'
 govuk::apps::travel_advice_publisher::enable_email_alerts: true
 
+govuk_search::gor::port: 3233
+
 govuk_search::gor::replay_target_hosts: []
 
 govuk::apps::rummager::enable_rummager: false


### PR DESCRIPTION
[Trello card](https://trello.com/c/eoRlv32F/94-get-search-api-running-in-aws-production)