### PR TITLE
Add datagovuk to deploy CDN config job

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_cdn.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_cdn.yaml.erb
@@ -62,6 +62,7 @@
                 - tldredirect
                 - servicegovuk
                 - performanceplatform
+                - datagovuk
         - string:
             name: FASTLY_USER
             default: false


### PR DESCRIPTION
We want to add some custom vcl to Data.gov.uk. In order to be able to
deploy the vcl, we need to add an option to the Jenkins job that deploys
our CDN configs. This commit adds the `datagovuk` option to the drop
down presented in Jenkins.