### PR TITLE
Add GitHub token for deploy lag badger

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/run_deploy_lag_badger.pp
+++ b/modules/govuk_jenkins/manifests/jobs/run_deploy_lag_badger.pp
@@ -2,7 +2,15 @@
 #
 # Create a file on disk that can be parsed by jenkins-job-builder
 #
-class govuk_jenkins::jobs::run_deploy_lag_badger {
+# === Parameters
+#
+# [*github_token*]
+#   A GitHub access token with permission to access private repos
+#
+class govuk_jenkins::jobs::run_deploy_lag_badger (
+  $github_token = undef,
+) {
+
   file { '/etc/jenkins_jobs/jobs/run_deploy_lag_badger.yaml':
     ensure  => present,
     content => template('govuk_jenkins/jobs/run_deploy_lag_badger.yaml.erb'),

--- a/modules/govuk_jenkins/templates/jobs/run_deploy_lag_badger.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/run_deploy_lag_badger.yaml.erb
@@ -32,3 +32,10 @@
     wrappers:
       - ansicolor:
           colormap: xterm
+      - inject-passwords:
+          global: false
+          mask-password-params: true
+          job-passwords:
+            - name: GITHUB_TOKEN
+              password:
+                '<%= @github_token %>'


### PR DESCRIPTION
This commit adds a GitHub token to the deploy lag badger so it doesn’t get rate limited.