### PR TITLE
Add MySQL pentester account

### DIFF
--- a/modules/govuk_mysql/manifests/server.pp
+++ b/modules/govuk_mysql/manifests/server.pp
@@ -126,6 +126,8 @@ class govuk_mysql::server (
 
   class { 'govuk_mysql::server::debian_sys_maint': }
 
+  class { 'govuk_mysql::server::pentester': }
+
   class { 'govuk_mysql::server::firewall':
     require => Class['mysql::server'],
   }

--- a/modules/govuk_mysql/manifests/server/pentester.pp
+++ b/modules/govuk_mysql/manifests/server/pentester.pp
@@ -1,0 +1,25 @@
+# == Class: govuk_mysql::server::pentester
+#
+# Class to control the pentester user for mysql.
+#
+# === Parameters
+#
+# [*mysql_pentester*]
+#   A password for the pentester user
+#
+class govuk_mysql::server::pentester (
+  $enabled = false,
+  $mysql_pentester = '',
+){
+  $ensure = $enabled ? {
+    true  => 'present',
+    false => 'absent',
+  }
+
+  govuk_mysql::user { 'pentester@localhost':
+    ensure        => $ensure,
+    password_hash => mysql_password($mysql_pentester),
+    table         => '*.*',
+    privileges    => 'ALL',
+  }
+}


### PR DESCRIPTION
This commit adds a new MySQL account with permissions for all databases and tables, to be used for pentesting. It is disabled by default and can be enabled on a per-environment basis.