### PR TITLE
Make the content_performance_manager_production daily pull absent

### DIFF
--- a/hieradata_aws/class/production/content_data_api_db_admin.yaml
+++ b/hieradata_aws/class/production/content_data_api_db_admin.yaml
@@ -1,7 +1,7 @@
 govuk_env_sync::tasks:
   # Temporary task to pull data from Carrenza production
   "pull_content_performance_manager_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "2"
     minute: "0"
     action: "pull"


### PR DESCRIPTION
The database is now over in AWS, and the app seems to be working, so
let's separate Carrenza and AWS so we can see if they're behaving the
same.