### PR TITLE
Point production content-store to search-api

### DIFF
--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -129,7 +129,7 @@ govuk::apps::content_publisher::google_tag_manager_preview: "env-7"
 govuk::apps::content_publisher::govuk_notify_template_id: "e00e89f5-b622-4dcb-8f30-e6c70231a940"
 govuk::apps::content_store::performance_platform_big_screen_view_url: 'https://performance-platform-big-screen-view-production.cloudapps.digital'
 govuk::apps::content_store::performance_platform_spotlight_url: 'https://performance-platform-spotlight-production.cloudapps.digital'
-govuk::apps::content_store::plek_service_rummager_uri: 'https://rummager.publishing.service.gov.uk'
+govuk::apps::content_store::plek_service_rummager_uri: 'https://search-api.production.govuk-internal.digital'
 govuk::apps::content_store::plek_service_whitehall_frontend_uri: 'https://whitehall-frontend.publishing.service.gov.uk'
 govuk::apps::email_alert_api::db::backend_ip_range: '10.13.3.0/24'
 govuk::apps::email_alert_api::email_archive_s3_bucket: 'govuk-production-email-alert-api-archive'


### PR DESCRIPTION
The register_backends rake task will need running after this is
deployed, which will then update router to direct things rendered by
rummager (which is the public search API and the sitemaps) to
search-api.

---

[Trello card](https://trello.com/c/fQuWFX1y/103-point-public-search-api-and-sitemaps-to-search-api)