### PR TITLE
Point production content-tagger and hmrc-manuals-api to search-api

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -92,6 +92,8 @@ govuk::apps::whitehall::cpu_warning: 400
 govuk::apps::whitehall::cpu_critical: 600
 
 govuk::apps::collections::override_search_location: NULL
+govuk::apps::content_tagger::override_search_location: 'https://search-api.production.govuk.digital'
+govuk::apps::hmrc_manuals_api::override_search_location: 'https://search-api.production.govuk.digital'
 govuk::apps::licencefinder::override_search_location: NULL
 govuk::apps::finder_frontend::override_search_location: NULL
 

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -159,6 +159,8 @@ govuk_search::monitoring::es_port: '80'
 govuk_search::monitoring::es_host: 'elasticsearch5.blue.production.govuk-internal.digital'
 
 govuk::apps::collections::override_search_location: 'https://search-api.production.govuk-internal.digital'
+govuk::apps::content_tagger::override_search_location: NULL
+govuk::apps::hmrc_manuals_api::override_search_location: NULL
 govuk::apps::licencefinder::override_search_location: 'https://search-api.production.govuk-internal.digital'
 govuk::apps::finder_frontend::override_search_location: 'https://search-api.production.govuk-internal.digital'
 


### PR DESCRIPTION
These are publishing apps but they don't update search (well not directly, hmrc-manuals-api does so via the publishing-api).  So these can move independently of the publishing apps which *do* update search (whitehall and search-admin).

[Trello card](https://trello.com/c/tOVAFzpN/97-production-application-switchover)