### PR TITLE
Add a missing * to rake_etl_master_process_cron_schedule

### DIFF
--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -196,7 +196,7 @@ govuk_elasticsearch::dump::run_es_dump_hour: '4'
 
 govuk_jenkins::job_builder::environment: 'staging'
 
-govuk_jenkins::jobs::content_data_api::rake_etl_master_process_cron_schedule: '0 11 * *'
+govuk_jenkins::jobs::content_data_api::rake_etl_master_process_cron_schedule: '0 11 * * *'
 
 govuk_jenkins::jobs::network_config_deploy::environments:
   - 'carrenza-staging'


### PR DESCRIPTION
In AWS Staging, for the Content Data API. Currently the schedule isn't
appearing, but hopefully this will fix it.