### PR TITLE
Make $enable_rummager apply to the procfile workers

### DIFF
--- a/modules/govuk/manifests/apps/rummager.pp
+++ b/modules/govuk/manifests/apps/rummager.pp
@@ -170,17 +170,17 @@ class govuk::apps::rummager(
   }
 
   $toggled_ensure = $enable_publishing_listener ? {
-    true    => present,
+    true    => $rummager_ensure,
     default => absent,
   }
 
   $toggled_govuk_index_listener = $enable_govuk_index_listener ? {
-    true    => present,
+    true    => $rummager_ensure,
     default => absent,
   }
 
   $toggled_bulk_reindex_listener = $enable_bulk_reindex_listener ? {
-    true    => present,
+    true    => $rummager_ensure,
     default => absent,
   }
 


### PR DESCRIPTION
So that the related configuration and alerts are removed from the AWS
environments, where Rummager isn't running.