### PR TITLE
Enable 'search' alias for search-api in AWS prod/staging

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -95,6 +95,7 @@ govuk_search::gor::replay_target_hosts:
   - 'https://search-api.production.govuk.digital'
 
 govuk::apps::rummager::enable_rummager: true
+govuk::apps::search_api::rummager_enable: true
 
 govuk::deploy::actionmailer_enable_delivery: true
 

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -67,6 +67,7 @@ govuk::apps::search_admin::override_search_location: 'https://search-api.staging
 govuk::apps::whitehall::override_search_location: 'https://search-api.staging.govuk.digital'
 
 govuk::apps::rummager::enable_rummager: true
+govuk::apps::search_api::rummager_enable: true
 
 govuk::deploy::aws_ses_smtp_host: 'email-smtp.eu-west-1.amazonaws.com'
 govuk::deploy::config::errbit_environment_name: 'staging'

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -158,6 +158,7 @@ govuk_search::gor::port: 3233
 govuk_search::gor::replay_target_hosts: []
 
 govuk::apps::rummager::enable_rummager: false
+govuk::apps::search_api::rummager_enable: false
 
 govuk::deploy::aws_ses_smtp_host: 'email-smtp.eu-west-1.amazonaws.com'
 govuk::deploy::config::errbit_environment_name: 'production'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -167,6 +167,7 @@ govuk::apps::search_admin::override_search_location: NULL
 govuk::apps::whitehall::override_search_location: NULL
 
 govuk::apps::rummager::enable_rummager: false
+govuk::apps::search_api::rummager_enable: false
 
 govuk::deploy::aws_ses_smtp_host: 'email-smtp.eu-west-1.amazonaws.com'
 govuk::deploy::config::errbit_environment_name: 'staging'


### PR DESCRIPTION
This is needed for the traffic replay from Carrenza, which is sent to the host 'search.publishing.service.gov.uk'.

---

[Trello card](https://trello.com/c/eoRlv32F/94-get-search-api-running-in-aws-production)