### PR TITLE
Revert "Remove redundant jenkins jobs for Search API"

### DIFF
--- a/hieradata_aws/class/production/jenkins.yaml
+++ b/hieradata_aws/class/production/jenkins.yaml
@@ -16,12 +16,16 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::deploy_app
   - govuk_jenkins::jobs::deploy_emergency_banner
   - govuk_jenkins::jobs::deploy_puppet
+  - govuk_jenkins::jobs::enhanced_ecommerce_search_api
   - govuk_jenkins::jobs::passive_checks
   - govuk_jenkins::jobs::publish_special_routes
   - govuk_jenkins::jobs::remove_emergency_banner
   - govuk_jenkins::jobs::run_rake_task
   - govuk_jenkins::jobs::search_benchmark
   - govuk_jenkins::jobs::search_test_spelling_suggestions
+  - govuk_jenkins::jobs::search_api_fetch_analytics_data
+  - govuk_jenkins::jobs::search_api_index_checks
+  - govuk_jenkins::jobs::search_api_reindex_with_new_schema
   - govuk_jenkins::jobs::smokey
   - govuk_jenkins::jobs::smokey_deploy
   - govuk_jenkins::jobs::transition_load_all_data


### PR DESCRIPTION
This reverts commit 83326c6cd6170d3bacb16401d4bcce587f8eac1b.

---

[Trello card](https://trello.com/c/4IDZXpb3/96-enable-search-jenkins-jobs)