### PR TITLE
configure puppet to allow Carrenza Trusty puppetmaster

### DIFF
--- a/hieradata/common.trusty.yaml
+++ b/hieradata/common.trusty.yaml
@@ -1,0 +1,9 @@
+---
+govuk_ppa::repo_ensure: 'present'
+
+govuk_unattended_reboot::manage_repo_class: true
+
+icinga::client::host_ipaddress: "%{::ipaddress}"
+
+nodejs::version: '6.14.3-1nodesource1'
+statsd::manage_repo_class: true

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -479,12 +479,13 @@ hosts::production::management::hosts:
     legacy_aliases:
       - "deploy.%{hiera('app_domain')}"
   puppetmaster-1:
-    ip: '10.2.0.5'
+    ip: '10.2.0.6'
     legacy_aliases:
       - 'puppet'
     service_aliases:
       - 'puppet'
       - 'puppetdb'
+      - 'puppetmaster-2'
   monitoring-1:
     ip: '10.2.0.20'
     legacy_aliases:

--- a/modules/govuk/manifests/node/s_puppetmaster.pp
+++ b/modules/govuk/manifests/node/s_puppetmaster.pp
@@ -3,7 +3,9 @@
 class govuk::node::s_puppetmaster inherits govuk::node::s_base {
   if $::aws_migration {
     include puppet::puppetserver
+  } elsif ($::lsbdistcodename == 'trusty') {
+      include puppet::puppetserver
   } else {
-    include puppet::master
+      include puppet::master
   }
 }

--- a/modules/puppet/manifests/puppetserver/generate_cert.pp
+++ b/modules/puppet/manifests/puppetserver/generate_cert.pp
@@ -1,6 +1,12 @@
 # FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
 class puppet::puppetserver::generate_cert {
-  exec { "/usr/bin/puppet cert generate ${::aws_instanceid}":
-    creates => "/etc/puppet/ssl/ca/signed/${::aws_instanceid}.pem",
+  if $::aws_migration {
+    exec { "/usr/bin/puppet cert generate ${::aws_instanceid}":
+      creates => "/etc/puppet/ssl/ca/signed/${::aws_instanceid}.pem",
+    }
+  } else {
+    exec { "/usr/bin/puppet cert generate ${::fqdn}":
+      creates => "/etc/puppet/ssl/ca/signed/${::fqdn}.pem",
+    }
   }
 }


### PR DESCRIPTION
# Context

We want to deploy Trusty Puppetmaster in Carrenza environment.

# Decisions
1. specify the `common.trusty.xml` hiera to define how puppet should be configured on a Carrenza trusty machine
2. allow Carrenza trusty servers to install the puppetserver rather than the puppetmaster (for precise machines)
3. puppetserver module on carrenza will generate certs based on fqdn rather than skipping certificate generation.
4. swap the puppermaster IP address to the new one in the hiera
5. add puppetmaster-2 in the hiera as an alias for puppetmaster-1 because the new puppetmaster will have name puppetmaster-2 and avoid puppet complaining about it not being there.