### PR TITLE
Set Plek context for search machines in AWS

### DIFF
--- a/modules/govuk/manifests/node/s_search.pp
+++ b/modules/govuk/manifests/node/s_search.pp
@@ -25,4 +25,14 @@ class govuk::node::s_search inherits govuk::node::s_base {
   if ! $::aws_migration {
     include govuk_elasticsearch::local_proxy
   }
+
+  # Set Plek for AWS to Carrenza communication
+  if ( ( $::aws_migration == 'search' ) and ($::aws_environment == 'staging') ) or ( ($::aws_migration == 'search' ) and ($::aws_environment == 'production') ) {
+    $app_domain = hiera('app_domain')
+
+    govuk_envvar {
+      'PLEK_SERVICE_EMAIL_ALERT_API_URI': value  => "https://email-alert-api.${app_domain}";
+      'PLEK_SERVICE_PUBLISHING_API_URI': value  => "https://publishing-api.${app_domain}";
+    }
+  }
 }


### PR DESCRIPTION
Whilst `search-api` will be located in AWS, `publishing-api` and `email-alert-api` remain in Carrenza.

This updates the Plek environment variable overrides so these services can still be accessed by `search-api`.

Trello card: https://trello.com/c/roOVfL9T/98-make-sure-emails-triggered-by-the-business-readiness-finder-will-continue-to-work