### PR TITLE
prevent linux_4.4.0-143 kernel from being installed

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1898,6 +1898,8 @@ unattended_reboot::etcd_endpoints:
 
 unattended_upgrades::blacklist:
  - 'mysql-server.*'
+ - 'linux.*4.4.0-143.*'
+ 
 unattended_upgrades::mail_to: 'machine.email@digital.cabinet-office.gov.uk'
 unattended_upgrades::origins:
  - "%{::lsbdistid} stable"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1058,7 +1058,7 @@ grafana::dashboards::application_dashboards:
   content-audit-tool:
     show_sidekiq_graphs: true
     has_workers: true
-  content-data-admin: 
+  content-data-admin:
     show_sidekiq_graphs: true
     has_workers: true
   content-performance-manager:
@@ -1392,6 +1392,8 @@ unattended_reboot::etcd_endpoints:
 
 unattended_upgrades::blacklist:
  - 'mysql-server.*'
+ - 'linux.*4.4.0-143.*'
+ 
 unattended_upgrades::mail_to: 'machine.email@digital.cabinet-office.gov.uk'
 unattended_upgrades::origins:
  - "%{::lsbdistid} stable"


### PR DESCRIPTION
# Context

When linux_4.4.0-143 kernel is installed, these leads to a lot of puppet issues installing other dependencies. We have manually cleared this kernel from the box and now we are blacklisting this kernel from the unattended upgrade.

# Decisions
1. blacklist `linux_4.4.0-143 kernel` in unattended upgrades