### PR TITLE
Set the memory thresholds for CKAN

### DIFF
--- a/modules/govuk/manifests/apps/ckan.pp
+++ b/modules/govuk/manifests/apps/ckan.pp
@@ -73,6 +73,8 @@ class govuk::apps::ckan (
       log_format_is_json     => false,
       read_timeout           => $request_timeout,
       collectd_process_regex => '\/gunicorn .* \/var\/ckan\/ckan\.ini',
+      nagios_memory_warning  => 2400,
+      nagios_memory_critical => 2500,
     }
 
     $toggled_priority_ensure = $priority_worker_processes ? {


### PR DESCRIPTION
Now that the collectd_process_regex is set to a working value, we're
getting a real value for the memory used by CKAN. Turns out this is
around 2GB at the moment. I don't know if this is usual, but it seems
OK, so set the thresholds for alerting just higher than the current
value.