### PR TITLE
fix docker trying to pull non-existing linux extra packages

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1898,8 +1898,7 @@ unattended_reboot::etcd_endpoints:
 
 unattended_upgrades::blacklist:
  - 'mysql-server.*'
- - 'linux.*4.4.0-143.*'
- 
+
 unattended_upgrades::mail_to: 'machine.email@digital.cabinet-office.gov.uk'
 unattended_upgrades::origins:
  - "%{::lsbdistid} stable"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1392,8 +1392,7 @@ unattended_reboot::etcd_endpoints:
 
 unattended_upgrades::blacklist:
  - 'mysql-server.*'
- - 'linux.*4.4.0-143.*'
- 
+
 unattended_upgrades::mail_to: 'machine.email@digital.cabinet-office.gov.uk'
 unattended_upgrades::origins:
  - "%{::lsbdistid} stable"

--- a/modules/govuk_docker/manifests/init.pp
+++ b/modules/govuk_docker/manifests/init.pp
@@ -25,6 +25,7 @@ class govuk_docker (
     docker_users                => $docker_users,
     use_upstream_package_source => false,
     version                     => $version,
+    manage_kernel               => false,
   }
 
   package { 'ctop':


### PR DESCRIPTION
# Context
Docker module should not manage the kernel on Ubuntu machines
because Ubuntu is already managed and this module does not
manage Ubuntu correctly because it is outdated and cannot
be updated because puppet version is too old.
See bug report: https://github.com/puppetlabs/puppetlabs-docker/issues/70

# Decisions
1. set docker module not to manage the kernel