### PR TITLE
Increase max thread count critical warning threshold for cache-clearing-service

### DIFF
--- a/modules/govuk/manifests/app.pp
+++ b/modules/govuk/manifests/app.pp
@@ -237,6 +237,10 @@
 # [*collectd_process_regex*]
 #   Regex to use to identify the process.
 #
+# [*alert_when_threads_exceed*]
+#   If set, alert using Icinga if the number of threads exceeds the value specified.
+#   Default: 100
+#
 # [*override_search_location*]
 #   Alternative hostname to use for Plek("search") and Plek("rummager")
 #
@@ -280,6 +284,7 @@ define govuk::app (
   $cpu_warning = 150,
   $cpu_critical = 200,
   $collectd_process_regex = undef,
+  $alert_when_threads_exceed = 100,
   $override_search_location = undef,
   $create_default_nginx_config = false,
 ) {
@@ -357,6 +362,7 @@ define govuk::app (
     cpu_warning                      => $cpu_warning,
     cpu_critical                     => $cpu_critical,
     collectd_process_regex           => $collectd_process_regex,
+    alert_when_threads_exceed        => $alert_when_threads_exceed,
     override_search_location         => $override_search_location,
     create_default_nginx_config      => $create_default_nginx_config,
   }

--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -84,7 +84,7 @@ define govuk::app::config (
   $cpu_warning = 150,
   $cpu_critical = 200,
   $collectd_process_regex = undef,
-  $alert_when_threads_exceed = 100,
+  $alert_when_threads_exceed = undef,
   $override_search_location = undef,
   $create_default_nginx_config = false,
 ) {

--- a/modules/govuk/manifests/apps/cache_clearing_service.pp
+++ b/modules/govuk/manifests/apps/cache_clearing_service.pp
@@ -56,14 +56,15 @@ class govuk::apps::cache_clearing_service (
   $app_name = 'cache-clearing-service'
 
   govuk::app { $app_name:
-    ensure                 => $ensure,
-    app_type               => 'bare',
-    enable_nginx_vhost     => false,
-    sentry_dsn             => $sentry_dsn,
-    command                => 'bundle exec foreman start',
-    collectd_process_regex => 'cache-clearing-service/.*rake message_queue:consumer',
-    nagios_memory_warning  => $nagios_memory_warning,
-    nagios_memory_critical => $nagios_memory_critical,
+    ensure                    => $ensure,
+    app_type                  => 'bare',
+    enable_nginx_vhost        => false,
+    sentry_dsn                => $sentry_dsn,
+    command                   => 'bundle exec foreman start',
+    collectd_process_regex    => 'cache-clearing-service/.*rake message_queue:consumer',
+    nagios_memory_warning     => $nagios_memory_warning,
+    nagios_memory_critical    => $nagios_memory_critical,
+    alert_when_threads_exceed => 250,
   }
 
   Govuk::App::Envvar {


### PR DESCRIPTION
This raises a critical alert regularly (almost every day). Cache clearing service [intentionally creates a new thread](https://github.com/alphagov/cache-clearing-service/blob/master/app/processor.rb#L16) per content item path it needs to process. So to my mind it's not surprising we see spikes when we run this service, given that a single translated piece of content will have n locale paths. It only takes ~3 pieces of translated content being updated to raise this error. So I don't think it's necessarily a bad thing, probably memory is a more important thing for us to worry about.

This will override the [default set here](https://github.com/alphagov/govuk-puppet/pull/8010). 250 was chosen since this was the peak from this week. Please correct me if I've misunderstood something here. 