### PR TITLE
Fix Varnish cache banning

### DIFF
--- a/modules/varnish/templates/default.vcl.erb
+++ b/modules/varnish/templates/default.vcl.erb
@@ -94,7 +94,7 @@ sub vcl_recv {
     if (!client.ip ~ purge_acl) {
       error 405 "Not allowed";
     } else {
-      ban("obj.http.url == " + req.url);
+      ban("obj.http.x-url == " + req.url);
       error 200 "Purged";
     }
   }


### PR DESCRIPTION
The correct ban variable name to use is 'obj.http.x-url' not 'obj.http.url'. The other occurrences in this file are correctly set to `obj.http.x-url`. See the document on how to perform Varnish banning for further information: https://varnish-cache.org/docs/3.0/tutorial/purging.html#bans

It looks like this hasn't been working for a while now. I tested this in staging and it works like it should work with this change:

```bash
$ sudo varnishadm 'ban.list'
1553862858.289870  5661 	obj.http.url == /jobsearch

$ curl http://ip-10-12-4-102.eu-west-1.compute.internal:7999/jobsearch -v -s > /dev/null
< Age: 253
< X-Cache: HIT

$ sudo varnishadm "ban obj.http.x-url == /jobsearch"

$ curl http://ip-10-12-4-102.eu-west-1.compute.internal:7999/jobsearch -v -s > /dev/null
< Age: 0
< X-Cache: MISS

$ sudo varnishadm 'ban.list'
1553862913.369866   360 	obj.http.x-url == /jobsearch
1553862858.289870  5661 	obj.http.url == /jobsearch

$ curl http://ip-10-12-4-102.eu-west-1.compute.internal:7999/jobsearch -v -s > /dev/null
< Age: 1
< X-Cache: HIT
```

[Trello Card](https://trello.com/c/ZKejC0br/899-investigate-cache-clearing-the-homepage)