### PR TITLE
Remove the broken process_regex from the Content Data API

### DIFF
--- a/modules/govuk/manifests/apps/content_data_api.pp
+++ b/modules/govuk/manifests/apps/content_data_api.pp
@@ -128,7 +128,6 @@ class govuk::apps::content_data_api(
     enable_service => $enable_procfile_worker,
     setenv_as      => $app_name,
     process_type   => 'default-worker',
-    process_regex  => 'sidekiq content-data-api ',
   }
 
   govuk::procfile::worker { "${app_name}-publishing-api-consumer":


### PR DESCRIPTION
The default value will work in this case. This regex doesn't work as
it doesn't contain the version.