### PR TITLE
Restore access to the postgres user for the govuk_env_sync.sh script

### DIFF
--- a/modules/govuk_env_sync/manifests/sync_script.pp
+++ b/modules/govuk_env_sync/manifests/sync_script.pp
@@ -6,7 +6,7 @@ class govuk_env_sync::sync_script {
   sudo::conf {
     'govuk-env-sync-commands':
       ensure  => 'present',
-      content => 'govuk-backup ALL=NOPASSWD:/usr/bin/psql,/usr/bin/createdb,/usr/bin/dropdb,/usr/bin/dropuser,/usr/bin/pg_restore,/usr/bin/mysql,/usr/bin/mysqldump,/usr/bin/pg_dump';
+      content => 'govuk-backup ALL=(root,postgres) NOPASSWD:/usr/bin/psql,/usr/bin/createdb,/usr/bin/dropdb,/usr/bin/dropuser,/usr/bin/pg_restore,/usr/bin/mysql,/usr/bin/mysqldump,/usr/bin/pg_dump';
   }
 
   # sync script


### PR DESCRIPTION
The sudoers config was changed, but access to the postgres user was
missed, so restore access so commands like pg_dump can be run.