### PR TITLE
Fix Icinga Graphite URLs in AWS

### DIFF
--- a/modules/icinga/manifests/check/graphite.pp
+++ b/modules/icinga/manifests/check/graphite.pp
@@ -100,9 +100,9 @@ define icinga::check::graphite(
   }
 
   if $action_url == undef {
-
     if $::aws_migration {
-      $app_domain = hiera('app_domain_internal')
+      # temporary solution while we have two Icinga instances
+      $app_domain = "${::aws_environment}.govuk.digital"
     } else {
       $app_domain = hiera('app_domain')
     }


### PR DESCRIPTION
By using app_domain_internal we can't access it externally, but by using app_domain we end up with the Carrenza version of Graphite. While we have two versions of Graphite and Icinga, we need a custom configuration for AWS. We can't easily use Hieradata here because this is a definition and not a class meaning that we would need an entry each time it's used, so I decided instead to hard code the app domain since it's only temporary.

[Trello Card](https://trello.com/c/d1N41XW7/905-make-graphite-links-in-aws-icinga-work)