### PR TITLE
Fix the app-worker process count alert

### DIFF
--- a/modules/govuk/manifests/procfile/worker.pp
+++ b/modules/govuk/manifests/procfile/worker.pp
@@ -89,9 +89,10 @@ define govuk::procfile::worker (
       @@icinga::check::graphite { "check_${title_underscore}_app_worker_process_count_${::hostname}":
         # Make the process count negative, as I don't think the
         # check-graphite command can handle checking for a low value.
-        target    => "scale(${::fqdn_metrics}.processes-app-worker-${title_underscore}.ps_count.processes,-1)",
-        warning   => -1, # WARN if there are 0 processes (more than -1, with the negative metric)
-        critical  => 0, # Don't use the CRITICAL status for now
+        target    => "${::fqdn_metrics}.processes-app-worker-${title_underscore}.ps_count.processes",
+        warning   => '@0', # WARN if there are 0 processes
+        critical  => '@-1', # Don't use the CRITICAL status for now
+                            # (less than -1 processes)
         desc      => "No processes found for ${title_underscore}",
         host_name => $::fqdn,
       }


### PR DESCRIPTION
Turns out that by using `@` you can alert on low values [1], so switch
to using this approach. This resolves an issue where the default
minimum of 0 was causing alerts for things with 1 or more processes.

1: https://github.com/dbroeglin/nagios_check/blob/5e09f22b2a5030a1f7aa641bd9474f84d0f208a5/lib/nagios_check/range.rb#L3-L19