### PR TITLE
Fix app error codes dashboard

### DIFF
--- a/modules/grafana/files/dashboards/application_http_error_codes.json
+++ b/modules/grafana/files/dashboards/application_http_error_codes.json
@@ -56,12 +56,8 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "groupByNode(stats.frontend-*.nginx_logs.*.http_4xx, 3, \"sumSeries\")",
+              "target": "groupByNode(stats.*frontend-*.nginx_logs.*.http_4xx, 3, \"sumSeries\")",
               "refId": "A"
-            },
-            {
-              "target": "groupByNode(stats.{calculators,draft-email-campaign,draft,email-campaign,performance,whitehall}-frontend-*.nginx_logs.*.http_4xx, 3, \"sumSeries\")",
-              "refId": "B"
             }
           ],
           "title": "4XX by Application",
@@ -142,12 +138,8 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "groupByNode(stats.frontend-*.nginx_logs.*.http_5xx, 3, \"sumSeries\")",
+              "target": "groupByNode(stats.*frontend-*.nginx_logs.*.http_5xx, 3, \"sumSeries\")",
               "refId": "A"
-            },
-            {
-              "target": "groupByNode(stats.{calculators,draft-email-campaign,draft,email-campaign,performance,whitehall}-frontend-*.nginx_logs.*.http_5xx, 3, \"sumSeries\")",
-              "refId": "B"
             }
           ],
           "title": "5XX by Application",


### PR DESCRIPTION
https://grafana.blue.production.govuk.digital/dashboard/file/application_http_error_codes.json?refresh=1m&orgId=1 is missing a bunch of apps

This dashboard was originally made for our Carrenza setup but only partly works on AWS at present because the machine names have underscores where they previously had hyphens, so what would have matched: `calculators-frontend-*` will now need to match `calculators_frontend-*`.

As a result, only apps that are on `frontend` boxes are currently displayed on  https://grafana.blue.production.govuk.digital/dashboard/file/application_http_error_codes.json

We were also referencing machine types that don't exist any more (performance, email-campaign), so using a more general wild card should fix much of this.

With any luck and a following wind, this should still work for the remaining frontend apps (whitehall) on Carrenza: https://grafana.publishing.service.gov.uk/dashboard/file/application_http_error_codes.json