### PR TITLE
Revert "Add datagovuk to deploy CDN config job"

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_cdn.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_cdn.yaml.erb
@@ -62,7 +62,6 @@
                 - tldredirect
                 - servicegovuk
                 - performanceplatform
-                - datagovuk
         - string:
             name: FASTLY_USER
             default: false


### PR DESCRIPTION
Reverts alphagov/govuk-puppet#8904

We've configured this using Terraform, see https://github.com/alphagov/govuk-aws/pull/875 for the replacement.