### PR TITLE
Fix the process_regex for the Content Data API default_worker

### DIFF
--- a/modules/govuk/manifests/apps/content_data_api.pp
+++ b/modules/govuk/manifests/apps/content_data_api.pp
@@ -128,6 +128,7 @@ class govuk::apps::content_data_api(
     enable_service => $enable_procfile_worker,
     setenv_as      => $app_name,
     process_type   => 'default-worker',
+    process_regex  => "sidekiq .* ${app_name} ",
   }
 
   govuk::procfile::worker { "${app_name}-publishing-api-consumer":


### PR DESCRIPTION
The process name is [1], but the default process_regex is [2],
therefore, change the process_regex so that CollectD correctly picks
up the processes.

1: `sidekiq 5.2.5 content-data-api [0 of 6 busy]`
2: `sidekiq .* content-data-api-default-worker(.*\\.gov\\.uk)? `