### PR TITLE
Remove -1 from psql import to get import working

### DIFF
--- a/modules/govuk_env_sync/files/govuk_env_sync.sh
+++ b/modules/govuk_env_sync/files/govuk_env_sync.sh
@@ -305,7 +305,13 @@ function restore_postgresql {
   fi
 
   sudo createdb -U aws_db_admin -h "${db_hostname}" --no-password "${database}"
-  pg_stderr=$(zcat "${tempdir}/${filename}.dump" | sudo psql -U aws_db_admin -h "${db_hostname}" -1 --no-password -d "${database}" 2>&1)
+
+  single_transaction='-1'
+  if [ "${database}" == 'ckan_production' ]; then
+    single_transaction=''
+  fi
+
+  pg_stderr=$(zcat "${tempdir}/${filename}.dump" | sudo psql -U aws_db_admin -h "${db_hostname}" "${single_transaction}" --no-password -d "${database}" 2>&1)
   rm "${tempdir}/${filename}.dump"
 
   if [ "$DB_OWNER" != '' ] ; then


### PR DESCRIPTION
## What

Postgres sync from production CKAN postgres is failing which means that CKAN staging is down slowing down deployments.

To get it working we removed -1 from the psql args which means that rather than a single transaction the import will be done over multiple transactions.

The impact of this is that it takes a little bit longer for the import and there is a potential for corrupt data if another process is running against the staging postgres.

It's probably ok as the sync happens overnight so there should be no processes running and its only staging.