### PR TITLE
Configure logrotate to be stricter

### DIFF
--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -326,7 +326,7 @@ define govuk::app::config (
   @logrotate::conf { "govuk-${title}":
     ensure  => $ensure,
     matches => "/var/log/${title}/*.log",
-    maxsize => '500M',
+    maxsize => '100M',
   }
 
   @logrotate::conf { "govuk-${title}-rack":
@@ -334,7 +334,7 @@ define govuk::app::config (
     matches => "/data/vhost/${vhost_full}/shared/log/*.log",
     user    => 'deploy',
     group   => 'deploy',
-    maxsize => '500M',
+    maxsize => '100M',
   }
 
   if $health_check_path != 'NOTSET' {

--- a/modules/govuk/manifests/node/s_base.pp
+++ b/modules/govuk/manifests/node/s_base.pp
@@ -105,6 +105,7 @@ class govuk::node::s_base (
 
   @logrotate::conf { 'govuk-logs':
     matches => '/var/log/govuk/*.log',
+    maxsize => '250M',
   }
 
   # whoopsie is the ubuntu crash reporter. We don't want to be running any

--- a/modules/govuk_env_sync/manifests/log.pp
+++ b/modules/govuk_env_sync/manifests/log.pp
@@ -20,6 +20,7 @@ class govuk_env_sync::log {
     delaycompress => true,
     copytruncate  => false,
     create        => "644 ${govuk_env_sync::user} ${govuk_env_sync::user}",
+    maxsize       => '100M',
   }
 
 }

--- a/modules/govuk_search/manifests/gor.pp
+++ b/modules/govuk_search/manifests/gor.pp
@@ -51,6 +51,7 @@ class govuk_search::gor (
 
     @logrotate::conf { 'govuk_search_logs':
       matches => "${output_path}/*.log",
+      maxsize => '100M',
     }
 
     $output_file = "${output_path}/%Y%m%d.log"

--- a/modules/mongodb/manifests/backup.pp
+++ b/modules/mongodb/manifests/backup.pp
@@ -80,6 +80,7 @@ class mongodb::backup(
     delaycompress => true,
     copytruncate  => false,
     create        => '644 root root',
+    maxsize       => '250M',
   }
 
   if $enabled_real {

--- a/modules/nginx/manifests/logging.pp
+++ b/modules/nginx/manifests/logging.pp
@@ -15,7 +15,6 @@ class nginx::logging (
     days_to_keep    => $days_to_keep,
     copytruncate    => false,
     create          => '0640 www-data adm',
-    delaycompress   => true,
     prerotate       => 'if [ -d /etc/logrotate.d/httpd-prerotate ]; then run-parts /etc/logrotate.d/httpd-prerotate; fi',
     postrotate      => '[ ! -f /var/run/nginx.pid ] || kill -USR1 `cat /var/run/nginx.pid`',
     rotate_if_empty => true,

--- a/modules/nginx/manifests/logging.pp
+++ b/modules/nginx/manifests/logging.pp
@@ -19,6 +19,7 @@ class nginx::logging (
     postrotate      => '[ ! -f /var/run/nginx.pid ] || kill -USR1 `cat /var/run/nginx.pid`',
     rotate_if_empty => true,
     sharedscripts   => true,
+    maxsize         => '500M',
   }
 
   nginx::log {


### PR DESCRIPTION
Recently a few times the log files have been too big, filled up the disk and caused the apps to break and serve 5xx errors. These commits attempt to reduce the size of our logs by having a stricter logrotate configuration, and therefore means we will lose logs quicker. However, our logs are exported to Logit/Kibana which means they don't really need to be kept on the machines for very long.

[Trello Card](https://trello.com/c/EGdUaq91/917-automate-the-deletion-of-log-files-if-disk-space-is-running-low)