### PR TITLE
Bump search-api unicorn workers to 9 per node

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -664,7 +664,7 @@ govuk::apps::search_api::redis_host: 'backend-redis'
 govuk::apps::search_api::redis_port: '6379'
 # todo: decide if we're self-hosting or using a managed elasticsearch (use a bogus value for now)
 govuk::apps::search_api::elasticsearch_hosts: 'http://elasticsearch5'
-govuk::apps::search_api::unicorn_worker_processes: "6"
+govuk::apps::search_api::unicorn_worker_processes: "9"
 
 govuk::apps::search_admin::db_name: 'search_admin_production'
 govuk::apps::search_admin::db_hostname: 'mysql-primary'


### PR DESCRIPTION
We can currently handle 2 nodes * 6 workers simultaneous requests to
search-api (this is the same as rummager).  The AWS search machines
are currently using about 30% of each core and a little under half the
RAM, so that number can probably go up.

To avoid the risk of RAM exhaustion, we don't necessarily want to
double this to 12 without checking the effect of a smaller increase
first.