### PR TITLE
Add email alert service workflow queue

### DIFF
--- a/modules/govuk/manifests/apps/email_alert_service/rabbitmq.pp
+++ b/modules/govuk/manifests/apps/email_alert_service/rabbitmq.pp
@@ -35,6 +35,7 @@ class govuk::apps::email_alert_service::rabbitmq (
   $amqp_exchange = 'published_documents',
   $amqp_major_change_queue = 'email_alert_service',
   $amqp_unpublishing_queue = 'email_unpublishing',
+  $amqp_workflow_queue = 'email_alert_service_workflow',
   $queue_size_critical_threshold,
   $queue_size_warning_threshold,
 ) {
@@ -69,10 +70,25 @@ class govuk::apps::email_alert_service::rabbitmq (
     warning_threshold  => $queue_size_warning_threshold,
   } ->
 
+  govuk_rabbitmq::queue_with_binding { $amqp_workflow_queue:
+    amqp_exchange => $amqp_exchange,
+    amqp_queue    => $amqp_workflow_queue,
+    routing_key   => '*.workflow.#',
+    durable       => true,
+  } ->
+
+  govuk_rabbitmq::monitor_messages {"${amqp_workflow_queue}_message_monitoring":
+    ensure             => present,
+    rabbitmq_hostname  => 'localhost',
+    rabbitmq_queue     => $amqp_workflow_queue,
+    critical_threshold => $queue_size_critical_threshold,
+    warning_threshold  => $queue_size_warning_threshold,
+  } ->
+
   govuk_rabbitmq::consumer { $amqp_user:
     amqp_pass            => $amqp_pass,
-    read_permission      => "^(amq\\.gen.*|${amqp_major_change_queue}|${amqp_unpublishing_queue}|${amqp_exchange})\$",
-    write_permission     => "^(amq\\.gen.*|${amqp_major_change_queue}|${amqp_unpublishing_queue})\$",
-    configure_permission => "^(amq\\.gen.*|${amqp_major_change_queue}|${amqp_unpublishing_queue})\$",
+    read_permission      => "^(amq\\.gen.*|${amqp_major_change_queue}|${amqp_unpublishing_queue}|${amqp_workflow_queue}|${amqp_exchange})\$",
+    write_permission     => "^(amq\\.gen.*|${amqp_major_change_queue}|${amqp_unpublishing_queue}|${amqp_workflow_queue})\$",
+    configure_permission => "^(amq\\.gen.*|${amqp_major_change_queue}|${amqp_unpublishing_queue}|${amqp_workflow_queue})\$",
   }
 }

--- a/modules/govuk/manifests/apps/email_alert_service/rabbitmq_test_permissions.pp
+++ b/modules/govuk/manifests/apps/email_alert_service/rabbitmq_test_permissions.pp
@@ -30,6 +30,7 @@ class govuk::apps::email_alert_service::rabbitmq_test_permissions (
   $amqp_exchange = 'email_alert_service_published_documents_test_exchange',
   $amqp_major_change_queue = 'email_alert_service_published_documents_test_queue',
   $amqp_unpublishing_queue = 'email_alert_service_unpublishing_documents_test_queue',
+  $amqp_workflow_queue = 'email_alert_service_workflow_test_queue',
 ) {
 
   govuk_rabbitmq::exchange { "${amqp_exchange}@/":
@@ -51,10 +52,17 @@ class govuk::apps::email_alert_service::rabbitmq_test_permissions (
     durable       => true,
   } ->
 
+  govuk_rabbitmq::queue_with_binding { $amqp_workflow_queue:
+    amqp_exchange => $amqp_exchange,
+    amqp_queue    => $amqp_workflow_queue,
+    routing_key   => '*.workflow.#',
+    durable       => true,
+  } ->
+
   govuk_rabbitmq::consumer { $amqp_user:
     amqp_pass            => $amqp_pass,
-    read_permission      => "^(amq\\.gen.*|${amqp_major_change_queue}|${amqp_unpublishing_queue}|${amqp_exchange})\$",
-    write_permission     => "^(amq\\.gen.*|${amqp_major_change_queue}|${amqp_unpublishing_queue}|${amqp_exchange})\$",
-    configure_permission => "^(amq\\.gen.*|${amqp_major_change_queue}|${amqp_unpublishing_queue})\$",
+    read_permission      => "^(amq\\.gen.*|${amqp_major_change_queue}|${amqp_unpublishing_queue}|${amqp_workflow_queue}|${amqp_exchange})\$",
+    write_permission     => "^(amq\\.gen.*|${amqp_major_change_queue}|${amqp_unpublishing_queue}|${amqp_workflow_queue}|${amqp_exchange})\$",
+    configure_permission => "^(amq\\.gen.*|${amqp_major_change_queue}|${amqp_unpublishing_queue}|${amqp_workflow_queue})\$",
   }
 }


### PR DESCRIPTION
https://trello.com/c/0wiO10tC/327-email-trigger-mechanism-for-new-content-tagger-process

[See RFC here](https://github.com/alphagov/govuk-rfcs/blob/2cc32ae534d0f30f9702401a31ccd69f73bc4706/rfc-102-add-notification-workflow.md) and [Publishing API PR here](https://github.com/alphagov/publishing-api/pull/1482)