### PR TITLE
Add email-alert-api bearer token variable for search-api

### DIFF
--- a/modules/govuk/manifests/apps/search_api.pp
+++ b/modules/govuk/manifests/apps/search_api.pp
@@ -35,6 +35,10 @@
 #   The bearer token to use when communicating with Publishing API.
 #   Default: undef
 #
+# [*email_alert_api_bearer_token*]
+#   The bearer token to use when communicating with Email Alert API.
+#   Default: undef
+#
 # [*rabbitmq_hosts*]
 #   RabbitMQ hosts to connect to.
 #   Default: localhost
@@ -88,6 +92,7 @@ class govuk::apps::search_api(
   $enable_publishing_listener = false,
   $sentry_dsn = undef,
   $publishing_api_bearer_token = undef,
+  $email_alert_api_bearer_token = undef,
   $rabbitmq_hosts = ['localhost'],
   $rabbitmq_password = 'search-api',
   $redis_host = undef,
@@ -183,6 +188,12 @@ class govuk::apps::search_api(
     "${title}-PUBLISHING_API_BEARER_TOKEN":
       varname => 'PUBLISHING_API_BEARER_TOKEN',
       value   => $publishing_api_bearer_token;
+  }
+
+  govuk::app::envvar {
+    "${title}-EMAIL_ALERT_API_BEARER_TOKEN":
+      varname => 'EMAIL_ALERT_API_BEARER_TOKEN',
+      value   => $email_alert_api_bearer_token;
   }
 
   govuk::app::envvar { "${title}-ELASTICSEARCH_URI":


### PR DESCRIPTION
[Trello card](https://trello.com/c/roOVfL9T/98-make-sure-emails-triggered-by-the-business-readiness-finder-will-continue-to-work)