### PR TITLE
Remove empty .1 log files before rotating

### DIFF
--- a/modules/logrotate/templates/logrotate.conf.erb
+++ b/modules/logrotate/templates/logrotate.conf.erb
@@ -36,4 +36,9 @@
   <%- if @maxsize -%>
   maxsize <%= @maxsize %>
   <%- end -%>
+  firstaction
+    # Remove empty .1 log files. There seems to be an issue where logrotate
+    # will refuse to rotate the logs if an empty .1 log file exists.
+    find <%= @matches %>* -wholename '/var/log/*' -name '*.1' -size 0 -delete
+  endscript
 }


### PR DESCRIPTION
There seems to be a problem with logrotate whereby it will refuse to rotate the log files if an empty `.1` log file exists. This leads to increase disk space being used by log files and can cause the disk to fill up.

This fix should mean that all empty `.1` log files are deleted before logrotate runs which should allow it to finish successfully.

```
thomasleese@production-backend-1:~$ find /var/log -name '*.1' -size 0
/var/log/content-performance-manager/procfile_publishing-api-consumer.err.log.1
/var/log/content-performance-manager/upstart.err.log.1
/var/log/content-performance-manager/upstart.out.log.1
/var/log/content-performance-manager/procfile_publishing-api-consumer.out.log.1
/var/log/content-performance-manager/procfile_default-worker.out.log.1
/var/log/content-publisher/app.err.log.1
/var/log/content-publisher/app.out.log.1
/var/log/content-publisher/procfile_worker.out.log.1
/var/log/content-publisher/upstart.err.log.1
/var/log/content-publisher/procfile_worker.err.log.1
/var/log/publisher/procfile_worker.err.log.1
/var/log/search-admin/upstart.err.log.1
/var/log/sidekiq-monitoring/app.out.log.1
/var/log/signon/upstart.err.log.1
/var/log/specialist-publisher/procfile_worker.err.log.1
/var/log/travel-advice-publisher/procfile_worker.err.log.1
```

```
thomasleese@production-backend-1:~$ sudo logrotate -v -f /etc/logrotate.d/govuk-content-publisher
copying /var/log/content-publisher/upstart.err.log to /var/log/content-publisher/upstart.err.log.1
error: error creating output file /var/log/content-publisher/upstart.err.log.1: File exists
```

[Trello Card](https://trello.com/c/X6CLAvb1/150-fix-log-rotation)