### PR TITLE
Bump finder-frontend unicorn workers to 6

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -506,7 +506,7 @@ govuk::apps::email_alert_service::rabbitmq::queue_size_warning_threshold: 5
 govuk::apps::finder_frontend::enabled: true
 govuk::apps::finder_frontend::nagios_memory_warning: 2000
 govuk::apps::finder_frontend::nagios_memory_critical: 2500
-govuk::apps::finder_frontend::unicorn_worker_processes: "4"
+govuk::apps::finder_frontend::unicorn_worker_processes: "6"
 
 govuk::apps::frontend::nagios_memory_warning: 1200
 govuk::apps::frontend::nagios_memory_critical: 1400


### PR DESCRIPTION
We're seeing finder-frontend timeouts, even of the healthcheck which is just a static response.  This suggests that finder-frontend can't respond in a timely manner to the volume of requests it's receiving.

Increasing the number of workers will increase the number of requests to search-api, which is a concern, but search-api is using more workers than rummager was, so it can cope with a bit more load.