### PR TITLE
Remove unused fields_prefix

### DIFF
--- a/modules/grafana/manifests/dashboards/application_dashboard.pp
+++ b/modules/grafana/manifests/dashboards/application_dashboard.pp
@@ -24,12 +24,6 @@
 # [*error_threshold*]
 #   Point at which count turns `red` in the error count table data
 #
-# [*fields_prefix*]
-#   Add the prefix to Elasticsearch queries. Depending on the version of logstasher
-#   some applications do not include the @fields prefix. Add this prefix by default,
-#   with the option to override with a blank field for apps that use a different
-#   configuration of the logstasher gem.
-#
 # [*instance_prefix*]
 #   Used for metrics that are named based on the instance name rather than the
 #   application. For example, calculators_frontend vs finder_frontend.
@@ -50,7 +44,6 @@ define grafana::dashboards::application_dashboard (
   $show_elasticsearch_stats = false,
   $show_external_request_time = false,
   $show_memcached = false,
-  $fields_prefix = '',
   $instance_prefix = '',
   $sentry_environment = $::govuk::deploy::config::errbit_environment_name,
 

--- a/modules/grafana/templates/dashboards/application_dashboard_panels/_errors_by_controller_action.json.erb
+++ b/modules/grafana/templates/dashboards/application_dashboard_panels/_errors_by_controller_action.json.erb
@@ -39,7 +39,7 @@
       "bucketAggs": [
         {
           "fake": true,
-          "field": "<%= @fields_prefix -%>controller",
+          "field": "controller",
           "id": "3",
           "settings": {
             "order": "desc",
@@ -50,7 +50,7 @@
         },
         {
           "fake": true,
-          "field": "<%= @fields_prefix -%>action",
+          "field": "action",
           "id": "4",
           "settings": {
             "order": "desc",
@@ -78,7 +78,7 @@
           "type": "count"
         }
       ],
-      "query": "application:<%= @app_name %> AND <%= @fields_prefix -%>status:[ 500 TO 599 ]",
+      "query": "application:<%= @app_name %> AND status:[ 500 TO 599 ]",
       "refId": "A",
       "target": "",
       "timeField": "@timestamp"

--- a/modules/grafana/templates/dashboards/application_dashboard_panels/_response_times.json.erb
+++ b/modules/grafana/templates/dashboards/application_dashboard_panels/_response_times.json.erb
@@ -51,7 +51,7 @@
       "dsType": "elasticsearch",
       "metrics": [
         {
-          "field": "<%= @fields_prefix -%>duration",
+          "field": "duration",
           "id": "1",
           "meta": {},
           "settings": {

--- a/modules/grafana/templates/dashboards/application_dashboard_panels/_response_times_by_controller_action.json.erb
+++ b/modules/grafana/templates/dashboards/application_dashboard_panels/_response_times_by_controller_action.json.erb
@@ -39,7 +39,7 @@
       "bucketAggs": [
         {
           "fake": true,
-          "field": "<%= @fields_prefix -%>controller",
+          "field": "controller",
           "id": "3",
           "settings": {
             "order": "desc",
@@ -50,7 +50,7 @@
         },
         {
           "fake": true,
-          "field": "<%= @fields_prefix -%>action",
+          "field": "action",
           "id": "4",
           "settings": {
             "order": "desc",
@@ -73,7 +73,7 @@
       "dsType": "elasticsearch",
       "metrics": [
         {
-          "field": "<%= @fields_prefix -%>duration",
+          "field": "duration",
           "id": "1",
           "meta": {},
           "settings": {

--- a/modules/grafana/templates/dashboards/publishing_api_overview.json.erb
+++ b/modules/grafana/templates/dashboards/publishing_api_overview.json.erb
@@ -69,14 +69,14 @@
               "dsType": "elasticsearch",
               "metrics": [
                 {
-                  "field": "<%= @fields_prefix -%>duration",
+                  "field": "duration",
                   "id": "1",
                   "meta": {},
                   "settings": {},
                   "type": "max"
                 }
               ],
-              "query": "application:publishing-api* AND <%= @fields_prefix -%>method:GET",
+              "query": "application:publishing-api* AND method:GET",
               "refId": "A",
               "timeField": "@timestamp",
               "hide": false
@@ -98,14 +98,14 @@
               "dsType": "elasticsearch",
               "metrics": [
                 {
-                  "field": "<%= @fields_prefix -%>duration",
+                  "field": "duration",
                   "id": "3",
                   "meta": {},
                   "settings": {},
                   "type": "max"
                 }
               ],
-              "query": "application:publishing-api* AND <%= @fields_prefix -%>request:\"*/v2/content*\" AND <%= @fields_prefix -%>method:GET",
+              "query": "application:publishing-api* AND request:\"*/v2/content*\" AND method:GET",
               "refId": "B",
               "timeField": "@timestamp"
             },
@@ -126,14 +126,14 @@
               "dsType": "elasticsearch",
               "metrics": [
                 {
-                  "field": "<%= @fields_prefix -%>duration",
+                  "field": "duration",
                   "id": "3",
                   "meta": {},
                   "settings": {},
                   "type": "max"
                 }
               ],
-              "query": "application:publishing-api* AND <%= @fields_prefix -%>request:\"*/v2/links*\" AND <%= @fields_prefix -%>method:GET",
+              "query": "application:publishing-api* AND request:\"*/v2/links*\" AND method:GET",
               "refId": "C",
               "timeField": "@timestamp"
             },
@@ -156,14 +156,14 @@
               "hide": false,
               "metrics": [
                 {
-                  "field": "<%= @fields_prefix -%>duration",
+                  "field": "duration",
                   "id": "3",
                   "meta": {},
                   "settings": {},
                   "type": "max"
                 }
               ],
-              "query": "application:publishing-api* AND <%= @fields_prefix -%>request:\"*/v2/linkables*\" AND <%= @fields_prefix -%>method:GET",
+              "query": "application:publishing-api* AND request:\"*/v2/linkables*\" AND method:GET",
               "refId": "D",
               "timeField": "@timestamp"
             },
@@ -184,14 +184,14 @@
               "dsType": "elasticsearch",
               "metrics": [
                 {
-                  "field": "<%= @fields_prefix -%>duration",
+                  "field": "duration",
                   "id": "1",
                   "meta": {},
                   "settings": {},
                   "type": "max"
                 }
               ],
-              "query": "application:publishing-api* AND <%= @fields_prefix -%>request:\"*/v2/linked*\" AND <%= @fields_prefix -%>method:GET",
+              "query": "application:publishing-api* AND request:\"*/v2/linked*\" AND method:GET",
               "refId": "E",
               "timeField": "@timestamp"
             },
@@ -212,14 +212,14 @@
               "dsType": "elasticsearch",
               "metrics": [
                 {
-                  "field": "<%= @fields_prefix -%>duration",
+                  "field": "duration",
                   "id": "1",
                   "meta": {},
                   "settings": {},
                   "type": "max"
                 }
               ],
-              "query": "application:publishing-api* AND <%= @fields_prefix -%>request:\"*/v2/expanded-links*\" AND <%= @fields_prefix -%>method:GET",
+              "query": "application:publishing-api* AND request:\"*/v2/expanded-links*\" AND method:GET",
               "refId": "F",
               "timeField": "@timestamp",
               "hide": false
@@ -241,14 +241,14 @@
               "dsType": "elasticsearch",
               "metrics": [
                 {
-                  "field": "<%= @fields_prefix -%>duration",
+                  "field": "duration",
                   "id": "1",
                   "meta": {},
                   "settings": {},
                   "type": "max"
                 }
               ],
-              "query": "application:publishing-api* AND <%= @fields_prefix -%>request:\"*/v2/editions*\" AND <%= @fields_prefix -%>method:GET",
+              "query": "application:publishing-api* AND request:\"*/v2/editions*\" AND method:GET",
               "refId": "G",
               "timeField": "@timestamp",
               "hide": false
@@ -342,14 +342,14 @@
               "dsType": "elasticsearch",
               "metrics": [
                 {
-                  "field": "<%= @fields_prefix -%>duration",
+                  "field": "duration",
                   "id": "3",
                   "meta": {},
                   "settings": {},
                   "type": "max"
                 }
               ],
-              "query": "application:publishing-api* AND <%= @fields_prefix -%>method:(POST,PUT,DELETE,PATCH)",
+              "query": "application:publishing-api* AND method:(POST,PUT,DELETE,PATCH)",
               "refId": "A",
               "timeField": "@timestamp"
             },
@@ -370,14 +370,14 @@
               "dsType": "elasticsearch",
               "metrics": [
                 {
-                  "field": "<%= @fields_prefix -%>duration",
+                  "field": "duration",
                   "id": "3",
                   "meta": {},
                   "settings": {},
                   "type": "max"
                 }
               ],
-              "query": "application:publishing-api* AND <%= @fields_prefix -%>request:\"*/v2/content*\" AND <%= @fields_prefix -%>method:PUT",
+              "query": "application:publishing-api* AND request:\"*/v2/content*\" AND method:PUT",
               "refId": "B",
               "timeField": "@timestamp"
             },
@@ -398,14 +398,14 @@
               "dsType": "elasticsearch",
               "metrics": [
                 {
-                  "field": "<%= @fields_prefix -%>duration",
+                  "field": "duration",
                   "id": "3",
                   "meta": {},
                   "settings": {},
                   "type": "max"
                 }
               ],
-              "query": "application:publishing-api* AND <%= @fields_prefix -%>request:\"*/v2/links/*\" AND <%= @fields_prefix -%>method:PATCH",
+              "query": "application:publishing-api* AND request:\"*/v2/links/*\" AND method:PATCH",
               "refId": "C",
               "timeField": "@timestamp"
             },
@@ -426,14 +426,14 @@
               "dsType": "elasticsearch",
               "metrics": [
                 {
-                  "field": "<%= @fields_prefix -%>duration",
+                  "field": "duration",
                   "id": "3",
                   "meta": {},
                   "settings": {},
                   "type": "max"
                 }
               ],
-              "query": "application:publishing-api* AND <%= @fields_prefix -%>request:\"*/v2/content/*\" AND <%= @fields_prefix -%>request:\"*/publish*\" AND <%= @fields_prefix -%>method:POST",
+              "query": "application:publishing-api* AND request:\"*/v2/content/*\" AND request:\"*/publish*\" AND method:POST",
               "refId": "D",
               "timeField": "@timestamp",
               "hide": false
@@ -455,14 +455,14 @@
               "dsType": "elasticsearch",
               "metrics": [
                 {
-                  "field": "<%= @fields_prefix -%>duration",
+                  "field": "duration",
                   "id": "1",
                   "meta": {},
                   "settings": {},
                   "type": "max"
                 }
               ],
-              "query": "application:publishing-api* AND <%= @fields_prefix -%>request:\"*/v2/content/*\" AND <%= @fields_prefix -%>request:\"*/unpublish*\" AND <%= @fields_prefix -%>method:POST",
+              "query": "application:publishing-api* AND request:\"*/v2/content/*\" AND request:\"*/unpublish*\" AND method:POST",
               "refId": "E",
               "timeField": "@timestamp"
             },
@@ -483,14 +483,14 @@
               "dsType": "elasticsearch",
               "metrics": [
                 {
-                  "field": "<%= @fields_prefix -%>duration",
+                  "field": "duration",
                   "id": "1",
                   "meta": {},
                   "settings": {},
                   "type": "max"
                 }
               ],
-              "query": "application:publishing-api* AND <%= @fields_prefix -%>request:\"*/v2/content/*\" AND <%= @fields_prefix -%>request:\"*/discard-draft*\" AND <%= @fields_prefix -%>method:POST",
+              "query": "application:publishing-api* AND request:\"*/v2/content/*\" AND request:\"*/discard-draft*\" AND method:POST",
               "refId": "F",
               "timeField": "@timestamp"
             }
@@ -599,7 +599,7 @@
                   "type": "count"
                 }
               ],
-              "query": "application:publishing-api* AND <%= @fields_prefix -%>status:[400 TO 509]",
+              "query": "application:publishing-api* AND status:[400 TO 509]",
               "refId": "A",
               "timeField": "@timestamp"
             },
@@ -625,7 +625,7 @@
                   "type": "count"
                 }
               ],
-              "query": "application:publishing-api* AND <%= @fields_prefix -%>status:[400 TO 509] AND <%= @fields_prefix -%>method:GET",
+              "query": "application:publishing-api* AND status:[400 TO 509] AND method:GET",
               "refId": "B",
               "timeField": "@timestamp"
             },
@@ -651,7 +651,7 @@
                   "type": "count"
                 }
               ],
-              "query": "application:publishing-api* AND <%= @fields_prefix -%>status:[400 TO 509] AND <%= @fields_prefix -%>method:(POST,PUT,PATCH,DELETE)",
+              "query": "application:publishing-api* AND status:[400 TO 509] AND method:(POST,PUT,PATCH,DELETE)",
               "refId": "C",
               "timeField": "@timestamp"
             }


### PR DESCRIPTION
This was used when we had some logstasher log fields prefixed with `@fields` (so `@fields.duration`, `@fields.action`, `@fields.controller` etc.), and some which have no prefix.

We started fixing this and trying to align on having no prefix back in Jan 2018 (https://github.com/alphagov/govuk-puppet/pull/6658). This should now be complete as of https://github.com/alphagov/search-api/pull/42, so we can remove references to the prefix that allows us to manage the convergence.

cc @surminus 