### PR TITLE
Delete the tempdir on exit to avoid filling up space

### DIFF
--- a/modules/govuk_env_sync/files/govuk_env_sync.sh
+++ b/modules/govuk_env_sync/files/govuk_env_sync.sh
@@ -143,6 +143,9 @@ function remove_tempdir {
   rm -rf "${tempdir}"
 }
 
+# Delete temp directory on exit to avoid filling up space
+trap remove_tempdir EXIT
+
 function set_filename {
   filename="${timestamp}-${database}.gz"
 }


### PR DESCRIPTION
Often we see a situation where the sync fails to run but leaves around all the temporary files. This means that the second attempt of running the sync also fails because there is no more space available for the temp files. Instead, we can always delete the temp directory when the sync script exits. These files aren't often used for debugging so it shouldn't cause to many problems.

[Trello Card](https://trello.com/c/AU6ZjAat/919-improve-temp-file-purging-process-on-ckan-staging)