### PR TITLE
Fix the process regex for backdrop

### DIFF
--- a/modules/govuk/manifests/apps/backdrop_write.pp
+++ b/modules/govuk/manifests/apps/backdrop_write.pp
@@ -51,6 +51,7 @@ class govuk::apps::backdrop_write (
     govuk::procfile::worker { 'backdrop-transformer':
       setenv_as      => $app_name,
       enable_service => $enable_procfile_worker,
+      process_regex  => 'backdrop\\.transformers\\.worker',
     }
 
     Govuk::App::Envvar {


### PR DESCRIPTION
```
thomasleese@production-api-1:/var/apps/backdrop-write$ cat Procfile
worker: venv/bin/celery -A backdrop.transformers.worker worker -l debug
```

```
thomasleese@production-api-1:/var/apps/backdrop-write$ ps aux | grep backdrop.transformers.worker
root     12415  0.0  0.1  55352  3248 ?        Ss   09:27   0:00 sudo -u deploy -E sh -c PATH=/usr/lib/rbenv/shims:$PATH exec  venv/bin/celery -A backdrop.transformers.worker worker -l debug 2>>'/var/log/backdrop-write/procfile_worker.err.log' 1>>'/var/log/backdrop-write/procfile_worker.out.log'
deploy   12442  0.1  1.6  96620 33496 ?        S    09:27   0:00 /data/apps/backdrop-write/shared/venv/bin/python venv/bin/celery -A backdrop.transformers.worker worker -l debug
deploy   12447  0.0  1.7 103756 35484 ?        S    09:27   0:00 /data/apps/backdrop-write/shared/venv/bin/python venv/bin/celery -A backdrop.transformers.worker worker -l debug
deploy   12448  0.0  1.7 103760 35476 ?        S    09:27   0:00 /data/apps/backdrop-write/shared/venv/bin/python venv/bin/celery -A backdrop.transformers.worker worker -l debug
```

I'm not sure why it only seems to have broken in the last week but this means the regex should correctly find the process now. If anyone has any suggestions for a better regex that would also be good.