### PR TITLE
Fix regex escaping for puppet 3.x

### DIFF
--- a/modules/govuk/manifests/apps/backdrop_write.pp
+++ b/modules/govuk/manifests/apps/backdrop_write.pp
@@ -51,7 +51,7 @@ class govuk::apps::backdrop_write (
     govuk::procfile::worker { 'backdrop-transformer':
       setenv_as      => $app_name,
       enable_service => $enable_procfile_worker,
-      process_regex  => 'backdrop\\.transformers\\.worker',
+      process_regex  => 'backdrop\.transformers\.worker',
     }
 
     Govuk::App::Envvar {


### PR DESCRIPTION
In puppet 3.x a backslash in a single string is a literal backslash. This changed in puppet 4.x onwards but since we're using an old version of Puppet we need to use only a single backslash.

Following on from #8968.