### PR TITLE
Increase memory thresholds for Router and Signon

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -669,8 +669,8 @@ govuk::apps::signon::db_username: 'signon'
 govuk::apps::signon::redis_url: "redis://redis-1.backend:6379/0"
 govuk::apps::signon::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::signon::redis_port: "%{hiera('sidekiq_port')}"
-govuk::apps::signon::nagios_memory_warning: 900
-govuk::apps::signon::nagios_memory_critical: 1000
+govuk::apps::signon::nagios_memory_warning: 1100
+govuk::apps::signon::nagios_memory_critical: 1200
 govuk::apps::signon::unicorn_worker_processes: "4"
 
 govuk::apps::specialist_publisher::enabled: true

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -732,8 +732,8 @@ govuk::apps::signon::db_username: 'signon'
 govuk::apps::signon::redis_url: "redis://backend-redis:6379/0"
 govuk::apps::signon::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::signon::redis_port: "%{hiera('sidekiq_port')}"
-govuk::apps::signon::nagios_memory_warning: 900
-govuk::apps::signon::nagios_memory_critical: 1000
+govuk::apps::signon::nagios_memory_warning: 1100
+govuk::apps::signon::nagios_memory_critical: 1200
 govuk::apps::signon::unicorn_worker_processes: "4"
 
 govuk::apps::specialist_publisher::enabled: true

--- a/modules/govuk/manifests/apps/router.pp
+++ b/modules/govuk/manifests/apps/router.pp
@@ -46,8 +46,8 @@ class govuk::apps::router (
     port                   => $port,
     enable_nginx_vhost     => $enable_nginx_vhost,
     vhost_aliases          => $vhost_aliases,
-    nagios_memory_warning  => 750,
-    nagios_memory_critical => 900,
+    nagios_memory_warning  => 900,
+    nagios_memory_critical => 1100,
   }
 
   # We can't pass `health_check_path` to `govuk::app` because it has the


### PR DESCRIPTION
We often see these alerts about memory thresholds for these apps. It doesn't appear to be causing any problems except having noisy alerts so we can increase them.