### PR TITLE
Allow non-rack based apps to monitor unicornherder

### DIFF
--- a/modules/govuk/manifests/app.pp
+++ b/modules/govuk/manifests/app.pp
@@ -248,6 +248,12 @@
 #   Create the default.conf site in nginx
 #   Default: false
 #
+# [*monitor_unicornherder*]
+#   Whether to set up Icinga alerts that monitor unicornherder. This is true if
+#   the app_type is set to 'rack' but this is useful if your app uses a Procfile
+#   which runs unicornherder.
+#   Default: true if app_type is 'rack' else false
+#
 define govuk::app (
   $app_type,
   $port = 0,
@@ -287,6 +293,7 @@ define govuk::app (
   $alert_when_threads_exceed = 100,
   $override_search_location = undef,
   $create_default_nginx_config = false,
+  $monitor_unicornherder = undef,
 ) {
 
   if ! ($app_type in ['procfile', 'rack', 'bare']) {
@@ -365,6 +372,7 @@ define govuk::app (
     alert_when_threads_exceed        => $alert_when_threads_exceed,
     override_search_location         => $override_search_location,
     create_default_nginx_config      => $create_default_nginx_config,
+    monitor_unicornherder            => $monitor_unicornherder,
   }
 
   govuk::app::service { $title:

--- a/modules/govuk/manifests/apps/mapit.pp
+++ b/modules/govuk/manifests/apps/mapit.pp
@@ -27,13 +27,14 @@ class govuk::apps::mapit (
 ) {
   if $enabled {
     govuk::app { 'mapit':
-      app_type           => 'procfile',
-      create_pidfile     => false,
-      port               => $port,
-      vhost_ssl_only     => true,
-      health_check_path  => '/',
-      log_format_is_json => false,
-      sentry_dsn         => $sentry_dsn;
+      app_type              => 'procfile',
+      create_pidfile        => false,
+      port                  => $port,
+      vhost_ssl_only        => true,
+      health_check_path     => '/',
+      log_format_is_json    => false,
+      sentry_dsn            => $sentry_dsn,
+      monitor_unicornherder => true,
     }
 
     govuk_postgresql::db { 'mapit':


### PR DESCRIPTION
Some apps, such as mapit, are configured to be Procfile based apps but use unicornherder as their main web process.

[Trello Card](https://trello.com/c/5dck6lSA/927-figure-out-why-staging-mapit-isnt-deploying-cleanly-%F0%9F%A6%84)