### PR TITLE
Sort the values in the tooltip for the NGinx Logs Grafana dashboard

### DIFF
--- a/modules/grafana/files/dashboards/nginx_logs.json
+++ b/modules/grafana/files/dashboards/nginx_logs.json
@@ -83,7 +83,8 @@
           "tooltip": {
             "msResolution": true,
             "shared": true,
-            "value_type": "cumulative"
+            "value_type": "cumulative",
+            "sort": 2
           },
           "type": "graph",
           "xaxis": {


### PR DESCRIPTION
So that the higher values appear at the top, as this makes it easier
to read.

![Screenshot from 2019-04-10 15-12-59](https://user-images.githubusercontent.com/1130010/55886182-cb92d680-5b9a-11e9-8065-4000a3f921d3.png)
