### PR TITLE
Upgrade to unicornherder 0.1.0

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1904,7 +1904,7 @@ unattended_upgrades::origins:
  - "%{::lsbdistid} stable"
  - "%{::lsbdistid} %{::lsbdistcodename}-security"
 
-unicornherder::version: '0.0.8'
+unicornherder::version: '0.1.0'
 
 yarn::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1396,7 +1396,7 @@ unattended_upgrades::origins:
  - "%{::lsbdistid} stable"
  - "%{::lsbdistid} %{::lsbdistcodename}-security"
 
-unicornherder::version: '0.0.8'
+unicornherder::version: '0.1.0'
 
 yarn::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 


### PR DESCRIPTION
This includes a fix for running gunicorn with unicornherder.

https://github.com/gds-operations/unicornherder/pull/32

[Trello Card](https://trello.com/c/5dck6lSA/927-figure-out-why-staging-mapit-isnt-deploying-cleanly-%F0%9F%A6%84)