### PR TITLE
Set unicorn timeout of all frontend apps to 15s

### DIFF
--- a/modules/govuk/manifests/node/s_calculators_frontend.pp
+++ b/modules/govuk/manifests/node/s_calculators_frontend.pp
@@ -29,6 +29,10 @@ class govuk::node::s_calculators_frontend inherits govuk::node::s_base {
     listen_ip  => '0.0.0.0',
   }
 
+  govuk_envvar {
+    'UNICORN_TIMEOUT': value => 15;
+  }
+
   # Only for testing
   if $::aws_environment == 'staging' {
     include govuk_splunk

--- a/modules/govuk/manifests/node/s_frontend.pp
+++ b/modules/govuk/manifests/node/s_frontend.pp
@@ -29,6 +29,10 @@ class govuk::node::s_frontend inherits govuk::node::s_base {
     listen_ip  => '0.0.0.0',
   }
 
+  govuk_envvar {
+    'UNICORN_TIMEOUT': value => 15;
+  }
+
   if ( ( $::aws_migration == 'frontend' ) and ($::aws_environment == 'staging') ) or ( ($::aws_migration == 'frontend' ) and ($::aws_environment == 'production') ) {
     $app_domain = hiera('app_domain')
 

--- a/modules/govuk/manifests/node/s_whitehall_frontend.pp
+++ b/modules/govuk/manifests/node/s_whitehall_frontend.pp
@@ -21,6 +21,10 @@ class govuk::node::s_whitehall_frontend inherits govuk::node::s_base {
     listen_ip  => '0.0.0.0',
   }
 
+  govuk_envvar {
+    'UNICORN_TIMEOUT': value => 15;
+  }
+
   if ($::aws_environment == 'staging') or ($::aws_environment == 'production') {
 
     govuk_envvar {


### PR DESCRIPTION
We use a 15s timeout for nginx, but the default unicorn timeout (60s).
This means that a slow request will be dropped by nginx but the
unicorn will keep working.  This means that a batch of slow requests
in quick succession can tie up all the unicorns.

---

[Trello card](https://trello.com/c/XUgnpLbM/119-action-item-fix-unicorn-worker-timeout)