### PR TITLE
Add Icinga monitoring for established TCP connections to apps

### DIFF
--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -330,6 +330,22 @@ define govuk::app::config (
     outgoing => $port,
   }
 
+  if $unicorn_worker_processes {
+    $local_tcpconns_warning = $unicorn_worker_processes
+  } else {
+    $local_tcpconns_warning = 2 # This is the defualt in govuk_app_config
+  }
+  $local_tcpconns_critical = $local_tcpconns_warning + 2
+
+  @@icinga::check::graphite { "check_${title}_app_local_tcpconns_${::hostname}":
+    ensure    => $ensure,
+    target    => "${::fqdn_metrics}.tcpconns-${port}-local.tcp_connections-ESTABLISHED",
+    warning   => $local_tcpconns_warning,
+    critical  => $local_tcpconns_critical,
+    desc      => "Established connections for ${title_underscore} exceeds ${local_tcpconns_warning}",
+    host_name => $::fqdn,
+  }
+
   @logrotate::conf { "govuk-${title}":
     ensure  => $ensure,
     matches => "/var/log/${title}/*.log",


### PR DESCRIPTION
This should flag when requests are potentially being queued for
processing at the point of reaching Unicorn (or other similar things).

We've had issues with this for Finder Frontend recently, and this
seems to be the way to monitor if there's insufficient workers to
process all the requests. I'm not exactly sure why it's the
ESTABLISHED metric, but this correlates with timeout issues.

### 5xx errors for Finder Frontend (over the last 4 days)
![Screenshot from 2019-04-11 16-39-20](https://user-images.githubusercontent.com/1130010/55970945-10d50800-5c70-11e9-8c7e-f7ec3c27d749.png)
## Local TCP connections to the Finder Frontend port
![Screenshot from 2019-04-11 16-38-50](https://user-images.githubusercontent.com/1130010/55970943-10d50800-5c70-11e9-9e62-9675d84209ce.png)
### ESTABLISHED TCP connection count for the Finder Frontend port
![Screenshot from 2019-04-11 16-39-02](https://user-images.githubusercontent.com/1130010/55970944-10d50800-5c70-11e9-9151-e5709495eaca.png)
