### PR TITLE
Improve the established tcpconns monitoring

### DIFF
--- a/modules/govuk/manifests/app.pp
+++ b/modules/govuk/manifests/app.pp
@@ -254,6 +254,16 @@
 #   which runs unicornherder.
 #   Default: true if app_type is 'rack' else false
 #
+# [*local_tcpconns_established_warning*]
+#   Warning value to use for the Icinga check on the number of
+#   established TCP connections to $port.
+#   Default: undef
+#
+# [*local_tcpconns_established_critical*]
+#   Critical value to use for the Icinga check on the number of
+#   established TCP connections to $port.
+#   Default: undef
+#
 define govuk::app (
   $app_type,
   $port = 0,
@@ -294,6 +304,8 @@ define govuk::app (
   $override_search_location = undef,
   $create_default_nginx_config = false,
   $monitor_unicornherder = undef,
+  $local_tcpconns_established_warning = undef,
+  $local_tcpconns_established_critical = undef,
 ) {
 
   if ! ($app_type in ['procfile', 'rack', 'bare']) {
@@ -335,44 +347,46 @@ define govuk::app (
   }
 
   govuk::app::config { $title:
-    ensure                           => $ensure,
-    require                          => Govuk::App::Package[$title],
-    app_type                         => $app_type,
-    command                          => $command,
-    create_pidfile                   => $create_pidfile,
-    domain                           => $app_domain,
-    port                             => $port,
-    vhost_aliases                    => $vhost_aliases,
-    vhost_full                       => $vhost_full,
-    vhost_protected                  => $vhost_protected,
-    vhost_ssl_only                   => $vhost_ssl_only,
-    nginx_extra_config               => $nginx_extra_config,
-    health_check_path                => $health_check_path,
-    expose_health_check              => $expose_health_check,
-    json_health_check                => $json_health_check,
-    health_check_service_template    => $health_check_service_template,
-    health_check_notification_period => $health_check_notification_period,
-    deny_framing                     => $deny_framing,
-    enable_nginx_vhost               => $enable_nginx_vhost,
-    nagios_memory_warning            => $nagios_memory_warning,
-    nagios_memory_critical           => $nagios_memory_critical,
-    alert_5xx_warning_rate           => $alert_5xx_warning_rate,
-    alert_5xx_critical_rate          => $alert_5xx_critical_rate,
-    unicorn_herder_timeout           => $unicorn_herder_timeout,
-    asset_pipeline                   => $asset_pipeline,
-    asset_pipeline_prefix            => $asset_pipeline_prefix,
-    depends_on_nfs                   => $depends_on_nfs,
-    read_timeout                     => $read_timeout,
-    sentry_dsn                       => $sentry_dsn,
-    proxy_http_version_1_1_enabled   => $proxy_http_version_1_1_enabled,
-    unicorn_worker_processes         => $unicorn_worker_processes,
-    cpu_warning                      => $cpu_warning,
-    cpu_critical                     => $cpu_critical,
-    collectd_process_regex           => $collectd_process_regex,
-    alert_when_threads_exceed        => $alert_when_threads_exceed,
-    override_search_location         => $override_search_location,
-    create_default_nginx_config      => $create_default_nginx_config,
-    monitor_unicornherder            => $monitor_unicornherder,
+    ensure                              => $ensure,
+    require                             => Govuk::App::Package[$title],
+    app_type                            => $app_type,
+    command                             => $command,
+    create_pidfile                      => $create_pidfile,
+    domain                              => $app_domain,
+    port                                => $port,
+    vhost_aliases                       => $vhost_aliases,
+    vhost_full                          => $vhost_full,
+    vhost_protected                     => $vhost_protected,
+    vhost_ssl_only                      => $vhost_ssl_only,
+    nginx_extra_config                  => $nginx_extra_config,
+    health_check_path                   => $health_check_path,
+    expose_health_check                 => $expose_health_check,
+    json_health_check                   => $json_health_check,
+    health_check_service_template       => $health_check_service_template,
+    health_check_notification_period    => $health_check_notification_period,
+    deny_framing                        => $deny_framing,
+    enable_nginx_vhost                  => $enable_nginx_vhost,
+    nagios_memory_warning               => $nagios_memory_warning,
+    nagios_memory_critical              => $nagios_memory_critical,
+    alert_5xx_warning_rate              => $alert_5xx_warning_rate,
+    alert_5xx_critical_rate             => $alert_5xx_critical_rate,
+    unicorn_herder_timeout              => $unicorn_herder_timeout,
+    asset_pipeline                      => $asset_pipeline,
+    asset_pipeline_prefix               => $asset_pipeline_prefix,
+    depends_on_nfs                      => $depends_on_nfs,
+    read_timeout                        => $read_timeout,
+    sentry_dsn                          => $sentry_dsn,
+    proxy_http_version_1_1_enabled      => $proxy_http_version_1_1_enabled,
+    unicorn_worker_processes            => $unicorn_worker_processes,
+    cpu_warning                         => $cpu_warning,
+    cpu_critical                        => $cpu_critical,
+    collectd_process_regex              => $collectd_process_regex,
+    alert_when_threads_exceed           => $alert_when_threads_exceed,
+    override_search_location            => $override_search_location,
+    create_default_nginx_config         => $create_default_nginx_config,
+    monitor_unicornherder               => $monitor_unicornherder,
+    local_tcpconns_established_warning  => $local_tcpconns_established_warning,
+    local_tcpconns_established_critical => $local_tcpconns_established_critical,
   }
 
   govuk::app::service { $title:

--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -336,35 +336,38 @@ define govuk::app::config (
     }
   }
 
-  collectd::plugin::tcpconn { "app-${title_underscore}":
-    ensure   => $ensure,
-    incoming => $port,
-    outgoing => $port,
-  }
-
-  if $local_tcpconns_established_warning == undef {
-    if $unicorn_worker_processes {
-      $local_tcpconns_warning = $unicorn_worker_processes
-    } else {
-      # This is the defualt in govuk_app_config for Unicorn worker processes
-      $local_tcpconns_warning = 2
+  if $port != 0 {
+    collectd::plugin::tcpconn { "app-${title_underscore}":
+      ensure   => $ensure,
+      incoming => $port,
+      outgoing => $port,
     }
-  }
-  if $local_tcpconns_established_critical == undef {
-    $local_tcpconns_critical = (
-      $local_tcpconns_warning + 2
-    )
-  } else {
-    $local_tcpconns_critical = $local_tcpconns_established_critical
-  }
 
-  @@icinga::check::graphite { "check_${title}_app_local_tcpconns_${::hostname}":
-    ensure    => $ensure,
-    target    => "${::fqdn_metrics}.tcpconns-${port}-local.tcp_connections-ESTABLISHED",
-    warning   => $local_tcpconns_warning,
-    critical  => $local_tcpconns_critical,
-    desc      => "Established connections for ${title_underscore} exceeds ${local_tcpconns_warning}",
-    host_name => $::fqdn,
+    if $local_tcpconns_established_warning == undef {
+      if $unicorn_worker_processes {
+        $local_tcpconns_warning = $unicorn_worker_processes
+      } else {
+        # This is the defualt in govuk_app_config for Unicorn worker
+        # processes
+        $local_tcpconns_warning = 2
+      }
+    }
+    if $local_tcpconns_established_critical == undef {
+      $local_tcpconns_critical = (
+        $local_tcpconns_warning + 2
+      )
+    } else {
+      $local_tcpconns_critical = $local_tcpconns_established_critical
+    }
+
+    @@icinga::check::graphite { "check_${title}_app_local_tcpconns_${::hostname}":
+      ensure    => $ensure,
+      target    => "${::fqdn_metrics}.tcpconns-${port}-local.tcp_connections-ESTABLISHED",
+      warning   => $local_tcpconns_warning,
+      critical  => $local_tcpconns_critical,
+      desc      => "Established connections for ${title_underscore} exceeds ${local_tcpconns_warning}",
+      host_name => $::fqdn,
+    }
   }
 
   @logrotate::conf { "govuk-${title}":

--- a/modules/govuk/manifests/apps/router.pp
+++ b/modules/govuk/manifests/apps/router.pp
@@ -41,13 +41,15 @@ class govuk::apps::router (
   }
 
   govuk::app { 'router':
-    app_type               => 'bare',
-    command                => './router',
-    port                   => $port,
-    enable_nginx_vhost     => $enable_nginx_vhost,
-    vhost_aliases          => $vhost_aliases,
-    nagios_memory_warning  => 900,
-    nagios_memory_critical => 1100,
+    app_type                            => 'bare',
+    command                             => './router',
+    port                                => $port,
+    enable_nginx_vhost                  => $enable_nginx_vhost,
+    vhost_aliases                       => $vhost_aliases,
+    nagios_memory_warning               => 900,
+    nagios_memory_critical              => 1100,
+    local_tcpconns_established_warning  => 150,
+    local_tcpconns_established_critical => 200,
   }
 
   # We can't pass `health_check_path` to `govuk::app` because it has the


### PR DESCRIPTION
These changes add the ability to specifically configure the local TCP connections warning and critical alerting thresholds, as well as configuring a custom value for the router.

Also, the TCP connection monitoring configuration is removed for services which don't listen on a port.