### PR TITLE
Fix govuk_env_sync not reporting status to nagios

### DIFF
--- a/modules/govuk_env_sync/files/govuk_env_sync.sh
+++ b/modules/govuk_env_sync/files/govuk_env_sync.sh
@@ -126,10 +126,6 @@ function nagios_passive {
 #
 trap 'report_error $LINENO' ERR
 
-# Trap exit signal to push state to icinga
-#
-trap nagios_passive EXIT
-
 function create_timestamp {
   timestamp="$(date +%Y-%m-%dT%H:%M:%S)"
 }
@@ -143,8 +139,12 @@ function remove_tempdir {
   rm -rf "${tempdir}"
 }
 
-# Delete temp directory on exit to avoid filling up space
-trap remove_tempdir EXIT
+function on_exit {
+  remove_tempdir
+  nagios_passive
+}
+
+trap on_exit EXIT
 
 function set_filename {
   filename="${timestamp}-${database}.gz"


### PR DESCRIPTION
Bash only allows one trap per signal, so we have to combine the two together into one function.

This follows on from #8967.