### PR TITLE
add puppetmaster-2 at top of the tree to avoid "Unable to find Govuk_…

### DIFF
--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -485,7 +485,9 @@ hosts::production::management::hosts:
     service_aliases:
       - 'puppet'
       - 'puppetdb'
-      - 'puppetmaster-2'
+      - "puppetmaster-2.%{hiera('app_domain')}"
+  puppetmaster-2:
+    ip: '10.2.0.6'
   monitoring-1:
     ip: '10.2.0.20'
     legacy_aliases:


### PR DESCRIPTION
# Context

Puppet upgrade from precise to trusty in Carrenza Staging. Need to add puppetmaster-2 to the list of hosts to avoid puppet error "Unable to find Govuk_…host[puppetmaster-2]".

# Decisions
1. add puppetmaster-2 to the list of hosts