### PR TITLE
Revert "Remove output piping from cache clearing service command"

### DIFF
--- a/modules/govuk/manifests/apps/cache_clearing_service.pp
+++ b/modules/govuk/manifests/apps/cache_clearing_service.pp
@@ -60,7 +60,7 @@ class govuk::apps::cache_clearing_service (
     app_type                  => 'bare',
     enable_nginx_vhost        => false,
     sentry_dsn                => $sentry_dsn,
-    command                   => 'bundle exec foreman start',
+    command                   => './bin/cache_clearing_service',
     collectd_process_regex    => 'cache-clearing-service/.*rake message_queue:consumer',
     nagios_memory_warning     => $nagios_memory_warning,
     nagios_memory_critical    => $nagios_memory_critical,


### PR DESCRIPTION
This reverts commit 4b905096a67b0dbf7741e91065ec84182a89d6d6.

Based on some testing on integration, it looks like this is now working. The only time I've been able to cause the workers to be left behind is by sending them a `SIGKILL` signal to the foreman process.