### PR TITLE
icinga client ip should not be specified for trusty

### DIFF
--- a/hieradata/common.trusty.yaml
+++ b/hieradata/common.trusty.yaml
@@ -3,7 +3,5 @@ govuk_ppa::repo_ensure: 'present'
 
 govuk_unattended_reboot::manage_repo_class: true
 
-icinga::client::host_ipaddress: "%{::ipaddress}"
-
 nodejs::version: '6.14.3-1nodesource1'
 statsd::manage_repo_class: true


### PR DESCRIPTION
# Context

The default behavior of the icinga::client module is to use the eth0 as the default network adapter and gets the default IP from that. Hence we want to keep that for trusty rather use the first facter non-lo interface which may not be eth0.

# Decisions
1. delete icinga::client::host_ipaddress hiera