### PR TITLE
Increase number of workers for email-alert-api

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -437,7 +437,7 @@ govuk::apps::email_alert_api::db_port: 6432
 govuk::apps::email_alert_api::db_allow_prepared_statements: false
 govuk::apps::email_alert_api::nagios_memory_warning: 1200
 govuk::apps::email_alert_api::nagios_memory_critical: 1500
-govuk::apps::email_alert_api::unicorn_worker_processes: '4'
+govuk::apps::email_alert_api::unicorn_worker_processes: '8'
 # This list should be kept in sync with https://www.notifications.service.gov.uk/services/ecfc7e2f-5145-45a6-9413-5d9b6e813ea9/users
 govuk::apps::email_alert_api::email_address_override_whitelist:
   - govuk-email-courtesy-copies@digital.cabinet-office.gov.uk

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -483,7 +483,7 @@ govuk::apps::email_alert_api::db_allow_prepared_statements: false
 govuk::apps::email_alert_api::db_password: "%{hiera('govuk::apps::email_alert_api::db::password')}"
 govuk::apps::email_alert_api::nagios_memory_warning: 1200
 govuk::apps::email_alert_api::nagios_memory_critical: 1500
-govuk::apps::email_alert_api::unicorn_worker_processes: '4'
+govuk::apps::email_alert_api::unicorn_worker_processes: '8'
 # This list should be kept in sync with https://www.notifications.service.gov.uk/services/ecfc7e2f-5145-45a6-9413-5d9b6e813ea9/users
 govuk::apps::email_alert_api::email_address_override_whitelist:
   - govuk-email-courtesy-copies@digital.cabinet-office.gov.uk


### PR DESCRIPTION
This change increases the amount of workers for email-alert-api from 4
to 8 per machine, this should reduce the amount of icinga alert errors referring to
'Socket timeouts' which were starting to happen fairly regularly.