### PR TITLE
fix puppet cronjob to avoid conflict with puppetserver restart

### DIFF
--- a/modules/puppet/manifests/cronjob.pp
+++ b/modules/puppet/manifests/cronjob.pp
@@ -12,13 +12,19 @@ class puppet::cronjob (
 ) {
 
   if $enabled {
-    $first = fqdn_rand(30)
-    $second = $first + 30
+    if ((! $::aws_migration) and ($::fqdn =~ /^puppetmaster/)) or
+      (($::aws_migration) and ($::aws_migration =~ /^puppetmaster/)) {
+      $first_run = 0
+      $second_run = 30
+    } else {
+      $first_run = 5 + fqdn_rand(21)
+      $second_run = 35 + fqdn_rand(21)
+    }
 
     cron { 'puppet':
       ensure  => present,
       user    => 'root',
-      minute  => [$first, $second],
+      minute  => [$first_run, $second_run],
       command => '/usr/local/bin/govuk_puppet',
       require => File['/usr/local/bin/govuk_puppet'],
     }

--- a/modules/puppet/manifests/puppetserver/config.pp
+++ b/modules/puppet/manifests/puppetserver/config.pp
@@ -23,7 +23,7 @@ class puppet::puppetserver::config {
   file_line { 'default_puppetserver':
     ensure => present,
     path   => '/etc/default/puppetserver',
-    line   => inline_template("JAVA_ARGS=\"${java_args}\"\n"),
+    line   => inline_template("JAVA_ARGS=\"${java_args}\""),
     match  => '^JAVA_ARGS=',
   }
 


### PR DESCRIPTION
# Context

1. Puppet server restarts every 30 mins and if it is not fully functional before other nodes request their puppet manifest, the other nodes will show a puppet error in icinga. In order to solve this issue, we want to have a minimum delay of 5 minutes between when the puppetserver restarts and the first node requests its manifest from the puppet server.

2. Puppet module uses a "file_line" puppet function to ensure that the JAVA_ARG parameter is properly populated in `/etc/default/puppetserver` config file. There is a `\n` value in the line parameter value of file_line. The use of `\n` in the line parameter causes the loss of idempotency (see https://stackoverflow.com/questions/38539178/check-and-add-multiple-lines-in-puppet)

# Decisons
1. fix the puppet cron logic to fit the above scenario
2. remove the `\n` to maintain idempotency (was tested that puppet still changes file if needed).