### PR TITLE
Change NGinx configuration for the Content Data app

### DIFF
--- a/modules/govuk/manifests/apps/content_data_admin.pp
+++ b/modules/govuk/manifests/apps/content_data_admin.pp
@@ -118,11 +118,18 @@ class govuk::apps::content_data_admin (
     app_type          => 'rack',
     port              => $port,
     sentry_dsn        => $sentry_dsn,
+    vhost             => 'content-data',
     vhost_ssl_only    => true,
     health_check_path => '/healthcheck', # must return HTTP 200 for an unauthenticated request
     deny_framing      => true,
     asset_pipeline    => true,
     read_timeout      => 60,
+  }
+
+  # Redirect for the old domain
+  $app_domain = hiera('app_domain')
+  nginx::config::vhost::redirect { "content-data-admin.${app_domain}":
+    to => "https://content-data.${app_domain}/",
   }
 
   Govuk::App::Envvar {

--- a/modules/govuk/manifests/node/s_backend_lb.pp
+++ b/modules/govuk/manifests/node/s_backend_lb.pp
@@ -69,6 +69,7 @@ class govuk::node::s_backend_lb (
     'collections-publisher',
     'contacts-admin',
     'content-audit-tool',
+    'content-data',
     'content-data-admin',
     'content-data-api',
     'content-performance-manager',


### PR DESCRIPTION
These changes are intended to be deployed when the Content Data app is
migrated to AWS. This coensides with the domain name changing from
`content-data-admin.` to `content-data.`.

For a smoother transition, this change configures NGinx to redirect
from the old URL to the new URL. To make this possible, the vhost for
the app NGinx configuration is changed.

Initially, the redirect will be served from Carrenza, but in the
longer term, the necessary DNS and infrastructure changes should be
made so that this redirect is served from AWS.