### PR TITLE
Configure CollectD to monitor the puppetserver

### DIFF
--- a/modules/puppet/manifests/puppetserver/service.pp
+++ b/modules/puppet/manifests/puppetserver/service.pp
@@ -3,4 +3,8 @@ class puppet::puppetserver::service {
   service { 'puppetserver':
     ensure   => running,
   }
+
+  collectd::plugin::process { 'service-puppetserver':
+    regex  => '\/usr\/share\/puppetserver\/puppet-server-release\.jar',
+  }
 }


### PR DESCRIPTION
It looks from the machine level metrics that all the memory is being
used up, but there's no specific monitoring of the processes. Having
some might be useful.