### PR TITLE
fix puppet reboot

### DIFF
--- a/modules/puppet/manifests/puppetdb.pp
+++ b/modules/puppet/manifests/puppetdb.pp
@@ -81,6 +81,15 @@ class puppet::puppetdb (
     notify  => Service['puppetdb'],
   }
 
+  file_line { 'initd_puppetdb':
+    ensure  => present,
+    path    => '/etc/init.d/puppetdb',
+    line    => "\t-XX:OnOutOfMemoryError='kill -9 %p; /etc/init.d/puppetdb restart; /etc/init.d/puppetserver restart' \$JAVA_ARGS \\",
+    match   => '-XX:OnOutOfMemoryError=',
+    require => Package['puppetdb'],
+    notify  => Service['puppetdb'],
+  }
+
   file_line { 'default_puppetdb':
     ensure  => present,
     path    => '/etc/default/puppetdb',
@@ -120,4 +129,3 @@ class puppet::puppetdb (
     matches => '/var/log/puppetdb/*.log',
   }
 }
-

--- a/modules/puppet/manifests/puppetserver/config.pp
+++ b/modules/puppet/manifests/puppetserver/config.pp
@@ -27,6 +27,13 @@ class puppet::puppetserver::config {
     match  => '^JAVA_ARGS=',
   }
 
+  file_line { 'initd_puppetserver':
+    ensure => present,
+    path   => '/etc/init.d/puppetserver',
+    line   => 'EXEC="$JAVA_BIN -XX:OnOutOfMemoryError=\"kill -9 %p; /etc/init.d/puppetdb restart; /etc/init.d/puppetserver restart\" -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/$NAME -Djava.security.egd=/dev/urandom $JAVA_ARGS"',
+    match  => '^EXEC=\"\$JAVA_BIN -XX:OnOutOfMemoryError=',
+  }
+
   # Track checksums and reload `puppetmaster` service when they change. This
   # is still pretty non-deterministic because it requires a `puppet agent`
   # run on the master after deployment and then a wait for `unicornherder`


### PR DESCRIPTION
# Context

On out-of-memory error in puppet, the java vm should restart puppet.
This should be done in the init.d file of puppetserver and puppetdb
because right now the default behavior there is to kill puppet
on out-of-memory error.

# Decisions
1. Modify the /etc/init.d/puppetserver and /etc/init.d/puppetdb to change the behaviour on out of memory.
2. a second piece of work is to use a separate mechanism to resprawn the puppet on (to be done)