### PR TITLE
[DO NOT MERGE] modify the puppermaster ip to the new one and add puppetmaster-2 entry

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -514,12 +514,15 @@ hosts::production::management::hosts:
     legacy_aliases:
       - "deploy.%{hiera('app_domain')}"
   puppetmaster-1:
-    ip: '10.3.0.5'
+    ip: '10.3.0.6'
     legacy_aliases:
       - 'puppet'
     service_aliases:
       - 'puppet'
       - 'puppetdb'
+      - "puppetmaster-2.%{hiera('app_domain')}"
+  puppetmaster-2:
+    ip: '10.3.0.6'
   monitoring-1:
     ip: '10.3.0.20'
     legacy_aliases:


### PR DESCRIPTION
# Context

In order to deploy the new trusty puppetmaster, we need to modify the IP of the puppetmaster hiera to point new one. This PR should be used for bootstrapping the new puppetmaster and should not be deployed on the old puppetmaster.

# Decisions
1. modify the carrenza production hiera to achieve the above.