### PR TITLE
Tear down rummager in all environments (AWS and Carrenza)

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -176,7 +176,6 @@ deployable_applications: &deployable_applications
   release: {}
   router: {}
   router-api: {}
-  rummager: {}
   search-admin: {}
   service-manual-frontend: {}
   service-manual-publisher: {}
@@ -561,6 +560,9 @@ govuk::apps::local_links_manager::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::local_links_manager::unicorn_worker_processes: "4"
 
 govuk::apps::mapit::enabled: true
+
+govuk::apps::rummager::enable_rummager: false
+govuk::apps::search_api::rummager_enable: false
 
 govuk::apps::rummager::rabbitmq_hosts:
   - rabbitmq-1.backend

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -69,8 +69,6 @@ govuk::node::s_development::apps:
   - 'router::enable_running_in_draft_mode'
   - 'router_api'
   - 'router_api::enable_running_in_draft_mode'
-  - 'rummager'
-  - 'rummager::rabbitmq'
   - 'search_api'
   - 'search_api::rabbitmq'
   - 'search_admin'
@@ -162,6 +160,9 @@ govuk::apps::search_api::elasticsearch_hosts: 'http://localhost:9205'
 govuk::apps::search_api::enable_procfile_worker: false
 govuk::apps::search_api::rabbitmq_hosts: ['localhost']
 govuk::apps::search_api::redis_host: 'localhost'
+
+govuk::apps::rummager::enable_rummager: false
+govuk::apps::search_api::rummager_enable: false
 
 govuk::apps::signon::enable_procfile_worker: false
 govuk::apps::smartanswers::expose_govspeak: true
@@ -302,7 +303,6 @@ hosts::development::apps:
   - 'release'
   - 'router-api'
   - 'router'
-  - 'rummager'
   - 'search-api'
   - 'search'
   - 'search-admin'

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -99,9 +99,6 @@ govuk::apps::finder_frontend::override_search_location: NULL
 govuk::apps::search_admin::override_search_location: 'https://search-api.production.govuk.digital'
 govuk::apps::whitehall::override_search_location: 'https://search-api.production.govuk.digital'
 
-govuk::apps::rummager::enable_rummager: true
-govuk::apps::search_api::rummager_enable: true
-
 govuk::deploy::actionmailer_enable_delivery: true
 
 govuk::deploy::aws_ses_smtp_host: 'email-smtp.us-east-1.amazonaws.com'

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -66,9 +66,6 @@ govuk::apps::licencefinder::override_search_location: NULL
 govuk::apps::search_admin::override_search_location: 'https://search-api.staging.govuk.digital'
 govuk::apps::whitehall::override_search_location: 'https://search-api.staging.govuk.digital'
 
-govuk::apps::rummager::enable_rummager: true
-govuk::apps::search_api::rummager_enable: true
-
 govuk::deploy::aws_ses_smtp_host: 'email-smtp.eu-west-1.amazonaws.com'
 govuk::deploy::config::errbit_environment_name: 'staging'
 govuk::deploy::setup::ssh_keys:

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -189,7 +189,6 @@ deployable_applications: &deployable_applications
   release: {}
   router: {}
   router-api: {}
-  rummager: {}
   search-api: {}
   search-admin: {}
   service-manual-frontend: {}
@@ -604,6 +603,9 @@ govuk::apps::local_links_manager::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::local_links_manager::unicorn_worker_processes: "4"
 
 govuk::apps::mapit::enabled: true
+
+govuk::apps::rummager::enable_rummager: false
+govuk::apps::search_api::rummager_enable: false
 
 govuk::apps::rummager::rabbitmq_hosts:
   - rabbitmq

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -70,9 +70,6 @@ govuk::apps::licencefinder::override_search_location: 'https://search-api.integr
 govuk::apps::search_admin::override_search_location: 'https://search-api.integration.govuk-internal.digital'
 govuk::apps::whitehall::override_search_location: 'https://search-api.integration.govuk-internal.digital'
 
-govuk::apps::rummager::enable_rummager: false
-govuk::apps::search_api::rummager_enable: false
-
 govuk::deploy::aws_ses_smtp_host: 'email-smtp.eu-west-1.amazonaws.com'
 govuk::deploy::config::errbit_environment_name: "integration-%{hiera('stackname')}-aws"
 govuk::deploy::config::licensify_app_domain: 'integration.publishing.service.gov.uk'

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -169,9 +169,6 @@ govuk::apps::finder_frontend::override_search_location: 'https://search-api.prod
 govuk::apps::search_admin::override_search_location: NULL
 govuk::apps::whitehall::override_search_location: NULL
 
-govuk::apps::rummager::enable_rummager: false
-govuk::apps::search_api::rummager_enable: false
-
 govuk::deploy::aws_ses_smtp_host: 'email-smtp.eu-west-1.amazonaws.com'
 govuk::deploy::config::errbit_environment_name: 'production'
 govuk::deploy::config::website_root: 'https://www.gov.uk'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -172,9 +172,6 @@ govuk::apps::licencefinder::override_search_location: 'https://search-api.stagin
 govuk::apps::search_admin::override_search_location: NULL
 govuk::apps::whitehall::override_search_location: NULL
 
-govuk::apps::rummager::enable_rummager: false
-govuk::apps::search_api::rummager_enable: false
-
 govuk::deploy::aws_ses_smtp_host: 'email-smtp.eu-west-1.amazonaws.com'
 govuk::deploy::config::errbit_environment_name: 'staging'
 govuk::deploy::config::licensify_app_domain: 'staging.publishing.service.gov.uk'


### PR DESCRIPTION
This should remove the rummager app and all of its related components (rabbitmq stuff, etc).  When we're happy that that has worked, the rummager hieradata and puppet can be removed.

---

[Trello card](https://trello.com/c/nABGyw0B/653-%F0%9F%92%80-remove-rummager-%F0%9F%92%80)