### PR TITLE
Remove some GTM configuration for Content Data Admin

### DIFF
--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -117,9 +117,7 @@ govuk::apps::ckan::ckan_site_url: 'https://ckan.publishing.service.gov.uk'
 govuk::apps::ckan::s3_bucket_name: "datagovuk-production-ckan-organogram"
 govuk::apps::ckan::s3_aws_region_name: "eu-west-1"
 govuk::apps::content_data_admin::content_performance_manager_uri: "https://content-data-api.%{hiera('app_domain_internal')}/"
-govuk::apps::content_data_admin::google_tag_manager_auth: 'bcb35jL0VPLO8b6W2rJXyA'
 govuk::apps::content_data_admin::google_tag_manager_id: 'GTM-NZG8SF2'
-govuk::apps::content_data_admin::google_tag_manager_preview: 'env-8'
 govuk::apps::content_data_admin::aws_csv_export_bucket_name: 'govuk-production-content-data-csvs'
 govuk::apps::content_data_api::etl_healthcheck_enabled_from_hour: '9'
 govuk::apps::content_publisher::aws_s3_bucket: "govuk-production-content-publisher-activestorage"


### PR DESCRIPTION
These shouldn't be set in Production, and for some reason, are set in
AWS, but not Carrenza.