### PR TITLE
Use elasticsearch 5.6 on all CI agents

### DIFF
--- a/hieradata/class/ci_agent.yaml
+++ b/hieradata/class/ci_agent.yaml
@@ -22,7 +22,7 @@ govuk_mysql::server::query_cache_size: 0
 # clear expected behaviour.
 govuk_elasticsearch::backup_enabled: false
 govuk_elasticsearch::minimum_master_nodes: '1'
-govuk_elasticsearch::version: '2.4.6'
+govuk_elasticsearch::version: '5.6.14'
 govuk_elasticsearch::number_of_replicas: '0'
 
 icinga::client::check_cputype::cputype: 'intel'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -926,13 +926,13 @@ govuk_ci::master::ci_agents:
     labels: 'mongodb-2.4 ci-agent-1 elasticsearch-5.6 terraform postgresql-9.3'
   ci-agent-2:
     agent_hostname: 'ci-agent-2.ci'
-    labels: 'mongodb-2.4 ci-agent-2 elasticsearch-2.4 terraform postgresql-9.3'
+    labels: 'mongodb-2.4 ci-agent-2 elasticsearch-5.6 terraform postgresql-9.3'
   ci-agent-3:
     agent_hostname: 'ci-agent-3.ci'
-    labels: 'mongodb-2.4 ci-agent-3 elasticsearch-2.4 terraform postgresql-9.3'
+    labels: 'mongodb-2.4 ci-agent-3 elasticsearch-5.6 terraform postgresql-9.3'
   ci-agent-4:
     agent_hostname: 'ci-agent-4.ci'
-    labels: 'mongodb-3.2 ci-agent-4 elasticsearch-2.4 terraform postgresql-9.6'
+    labels: 'mongodb-3.2 ci-agent-4 elasticsearch-5.6 terraform postgresql-9.6'
   ci-agent-5:
     agent_hostname: 'ci-agent-5.ci'
     exclusive: true

--- a/hieradata/node/ci-agent-1.ci.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/ci-agent-1.ci.integration.publishing.service.gov.uk.yaml
@@ -1,4 +1,2 @@
 ---
 mongodb::server::version: '2.4.9'
-
-govuk_elasticsearch::version: '5.6.14'


### PR DESCRIPTION
[Trello card](https://trello.com/c/3Olm4qop/668-use-elasticsearch-56-on-all-ci-agents)