### PR TITLE
Remove the temporary sync task for the Content Data API

### DIFF
--- a/hieradata_aws/class/production/content_data_api_db_admin.yaml
+++ b/hieradata_aws/class/production/content_data_api_db_admin.yaml
@@ -1,18 +1,4 @@
 govuk_env_sync::tasks:
-  # Temporary task to pull data from Carrenza production
-  "pull_content_performance_manager_production_daily":
-    ensure: "absent"
-    hour: "2"
-    minute: "0"
-    action: "pull"
-    dbms: "postgresql"
-    storagebackend: "s3"
-    # Use the old database name for consistency while still working on
-    # the migration for the Content Performance Manager
-    database: "content_performance_manager_production"
-    temppath: "/tmp/content_performance_manager_production"
-    url: "govuk-production-database-backups"
-    path: "warehouse-postgresql"
   # Use the new Content Data API name here, to avoid issues with
   # changing the name later
   "push_content_data_api_production_daily":


### PR DESCRIPTION
This was used to move the database over from Carrenza, but now the
database in AWS is the one in use, so this task is no longer useful.