### PR TITLE
Decrease time it takes to notice no processes

### DIFF
--- a/modules/govuk/manifests/procfile/worker.pp
+++ b/modules/govuk/manifests/procfile/worker.pp
@@ -95,6 +95,7 @@ define govuk::procfile::worker (
                             # (less than -1 processes)
         desc      => "No processes found for ${title_underscore}",
         host_name => $::fqdn,
+        from      => '30seconds',
       }
 
       if $alert_when_threads_exceed {


### PR DESCRIPTION
Since the number needs to go down to 0 for Icinga to consider there being no processes, it currently takes 5 minutes of the process being down for it to notice. This is because the number slowly goes from 1 to 0 over 5 minutes until it eventually hits 0. By decreasing the 5 minutes to 30 seconds, it should alert much sooner to this situation.

[Trello Card](https://trello.com/c/RPJrqeRE/947-add-alerts-for-when-harvesting-process-dies)