### PR TITLE
Fix purging rummager cronjobs

### DIFF
--- a/modules/govuk_rabbitmq/manifests/purge_queues.pp
+++ b/modules/govuk_rabbitmq/manifests/purge_queues.pp
@@ -29,7 +29,10 @@ class govuk_rabbitmq::purge_queues {
     user    => 'root',
   }
   cron::crondotdee { 'purge_rummager_govuk_index':
-    ensure => 'absent',
+    ensure  => 'absent',
+    command => undef,
+    hour    => undef,
+    minute  => undef,
   }
   cron::crondotdee { 'purge_search_api_to_be_indexed':
     command => '/usr/sbin/rabbitmqctl purge_queue search_api_to_be_indexed > /dev/null 2>&1',
@@ -38,6 +41,9 @@ class govuk_rabbitmq::purge_queues {
     user    => 'root',
   }
   cron::crondotdee { 'purge_rummager_to_be_indexed':
-    ensure => 'absent',
+    ensure  => 'absent',
+    command => undef,
+    hour    => undef,
+    minute  => undef,
   }
 }


### PR DESCRIPTION
The command, hour, and minute are required even when removing the job.