### PR TITLE
Install Ruby 2.6.3

### DIFF
--- a/modules/govuk_rbenv/manifests/all.pp
+++ b/modules/govuk_rbenv/manifests/all.pp
@@ -27,7 +27,7 @@ class govuk_rbenv::all (
     '2.5.1',
     '2.5.3',
     '2.6.1',
-    '2.6.2',
+    '2.6.3',
   ]
 
   govuk_rbenv::install_ruby_version { $ruby_versions:
@@ -42,6 +42,6 @@ class govuk_rbenv::all (
     to_version => '2.5.3',
   }
   rbenv::alias { '2.6':
-    to_version => '2.6.2',
+    to_version => '2.6.3',
   }
 }


### PR DESCRIPTION
This follows on from 2c4d5ae4e3e2440cc8888acae8fc66bfed3ad5ef as we've discovered that a newer version of Ruby has already been released.

[Trello Card](https://trello.com/c/HgcuyAyI/945-upgrade-to-ruby-262)