### PR TITLE
remove unattended manager repo class for trusty

### DIFF
--- a/hieradata/common.trusty.yaml
+++ b/hieradata/common.trusty.yaml
@@ -1,7 +1,4 @@
 ---
 govuk_ppa::repo_ensure: 'present'
 
-govuk_unattended_reboot::manage_repo_class: true
-
 nodejs::version: '6.14.3-1nodesource1'
-statsd::manage_repo_class: true


### PR DESCRIPTION
# Context

This cause errors for locksmithd and statsd packages in carrenza because the govuk apt does not contain these packages for trusty

# Decisions
1. Delete line from puppet trusty common hiera config in carrenza