### PR TITLE
Remove alias hosts for cache machine in Carrenza staging

### DIFF
--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -490,8 +490,6 @@ hosts::backend_migration::hosts:
       - cache.cluster
       - router.cluster
       - cache
-      - www.staging.publishing.service.gov.uk
-      - www-origin.staging.publishing.service.gov.uk
       - assets-origin.staging.publishing.service.gov.uk
   draft-cache-1.router.staging.publishing.service.gov.uk:
     ip: 10.2.1.200


### PR DESCRIPTION
- This host entry is confusing TLS testing in AWS/Fastly as clients are
attempting to talk to the Carrenza cache machine IP
- Related Platform Health ticket: https://trello.com/c/euhCSxFr/942-upgrade-to-the-latest-libssl-for-when-fastly-switches-off-tls-10

solo: @schmie