### PR TITLE
monit monitoring and restart of puppetserver and puppetdb

### DIFF
--- a/modules/govuk_monit/manifests/init.pp
+++ b/modules/govuk_monit/manifests/init.pp
@@ -1,0 +1,18 @@
+# == Class: govuk_monit
+#
+# Install and run Monit process supervisor
+#
+#
+class govuk_monit(
+) {
+  package { 'monit':
+    ensure  => latest,
+  }
+
+  @@icinga::check { "check_monit_running_${::hostname}":
+    check_command       => 'check_nrpe!check_proc_running!monit',
+    service_description => 'monit running',
+    host_name           => $::fqdn,
+    notes_url           => monitoring_docs_url(check-process-running),
+  }
+}

--- a/modules/puppet/files/etc/monit/conf.d/puppetdb
+++ b/modules/puppet/files/etc/monit/conf.d/puppetdb
@@ -1,0 +1,6 @@
+check process puppetdb with pidfile /var/run/puppetdb.pid
+   start program = "/etc/init.d/puppetdb start"
+   stop  program = "/etc/init.d/puppetdb stop"
+   if failed port 8081 type tcp then restart
+   if failed port 8080 type tcp then restart
+   if does not exist then restart

--- a/modules/puppet/files/etc/monit/conf.d/puppetserver
+++ b/modules/puppet/files/etc/monit/conf.d/puppetserver
@@ -1,0 +1,5 @@
+check process puppetserver with pidfile /var/run/puppetserver.pid
+   start program = "/etc/init.d/puppetserver start"
+   stop  program = "/etc/init.d/puppetserver stop"
+   if failed port 8140 type tcp then restart
+   if does not exist then restart

--- a/modules/puppet/manifests/puppetserver/package.pp
+++ b/modules/puppet/manifests/puppetserver/package.pp
@@ -5,6 +5,8 @@
 class puppet::puppetserver::package {
   require '::govuk_java::openjdk7::jre'
 
+  include govuk_monit
+
   package { 'puppetserver':
     ensure => 'latest',
   }

--- a/modules/puppet/manifests/puppetserver/service.pp
+++ b/modules/puppet/manifests/puppetserver/service.pp
@@ -1,6 +1,25 @@
 # FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
 class puppet::puppetserver::service {
   service { 'puppetserver':
+    ensure => running,
+    notify => File['/etc/monit/conf.d/puppetserver', '/etc/monit/conf.d/puppetdb'],
+  }
+
+  file { '/etc/monit/conf.d/puppetserver':
+    ensure => present,
+    source => 'puppet:///modules/puppet/etc/monit/conf.d/puppetserver',
+    mode   => '0660',
+    notify => Service['monit'],
+  }
+
+  file { '/etc/monit/conf.d/puppetdb':
+    ensure => present,
+    source => 'puppet:///modules/puppet/etc/monit/conf.d/puppetdb',
+    mode   => '0660',
+    notify => Service['monit'],
+  }
+
+  service { 'monit':
     ensure   => running,
   }
 

--- a/modules/puppet/spec/classes/puppet__puppetserver__package_spec.rb
+++ b/modules/puppet/spec/classes/puppet__puppetserver__package_spec.rb
@@ -3,4 +3,3 @@ require_relative '../../../../spec_helper'
 describe 'puppet::puppetserver::package', :type => :class do
   it { is_expected.to contain_package('puppetserver') }
 end
-

--- a/modules/puppet/spec/classes/puppet__puppetserver__sentry_spec.rb
+++ b/modules/puppet/spec/classes/puppet__puppetserver__sentry_spec.rb
@@ -16,4 +16,3 @@ describe 'puppet::puppetserver::sentry', :type => :class do
     is_expected.to contain_file('/etc/puppet/sentry.conf').with_content('dsn=rspec dsn')
   end
 end
-


### PR DESCRIPTION
# Context

Since puppetserver and/or puppetdb are unreliable, we use monit
to monitor these 2 processes and restarts them if needed.

Note: monit will monitor process at 2-minute interval

# Decisions
1. add govuk_monit package and install it in puppetserver module
2. add monit config files after puppetserver is installed and running.
3. reload monit service 