### PR TITLE
Add Staging and Integration "push" actions for the Content Data API

### DIFF
--- a/hieradata_aws/class/integration/content_data_api_db_admin.yaml
+++ b/hieradata_aws/class/integration/content_data_api_db_admin.yaml
@@ -12,3 +12,16 @@ govuk_env_sync::tasks:
     temppath: "/tmp/content_data_api_production"
     url: "govuk-production-database-backups"
     path: "content-data-api-postgresql"
+  "push_content_data_api_production_daily":
+    ensure: "present"
+    hour: "9"
+    minute: "0"
+    action: "push"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    # Use the old database name for consistency while still working on
+    # the migration for the Content Performance Manager
+    database: "content_performance_manager_production"
+    temppath: "/tmp/content_data_api_production"
+    url: "govuk-integration-database-backups"
+    path: "content-data-api-postgresql"

--- a/hieradata_aws/class/staging/content_data_api_db_admin.yaml
+++ b/hieradata_aws/class/staging/content_data_api_db_admin.yaml
@@ -12,3 +12,16 @@ govuk_env_sync::tasks:
     temppath: "/tmp/content_data_api_production"
     url: "govuk-production-database-backups"
     path: "content-data-api-postgresql"
+  "push_content_data_api_production_daily":
+    ensure: "present"
+    hour: "9"
+    minute: "0"
+    action: "push"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    # Use the old database name for consistency while still working on
+    # the migration for the Content Performance Manager
+    database: "content_performance_manager_production"
+    temppath: "/tmp/content_data_api_production"
+    url: "govuk-staging-database-backups"
+    path: "content-data-api-postgresql"


### PR DESCRIPTION
These are useful for testing, and also the Integration push can be
used for local development data.

These tasks start at 9, as the production backup should have been
restored by then.