### PR TITLE
Only bundle when not dry run

### DIFF
--- a/development-vm/replication/replicate-data-local.sh
+++ b/development-vm/replication/replicate-data-local.sh
@@ -5,22 +5,22 @@
 
 set -eu
 
-. $(dirname $0)/common-args.sh
-. $(dirname $0)/aws.sh
+. "$(dirname "$0")/common-args.sh"
+. "$(dirname "$0")/aws.sh"
 
 if ! $DRY_RUN; then
   status "Running bundle install"
   bundle install --quiet
 fi
 
-$(dirname $0)/sync-aws-mysql.sh "$@" mysql-master
+"$(dirname "$0")/sync-aws-mysql.sh" "$@" mysql-master
 
-$(dirname $0)/sync-aws-mongo.sh "$@" mongo
-$(dirname $0)/sync-aws-mongo.sh "$@" router_backend
+"$(dirname "$0")/sync-aws-mongo.sh" "$@" mongo
+"$(dirname "$0")/sync-aws-mongo.sh" "$@" router_backend
 
-$(dirname $0)/sync-aws-postgresql.sh "$@" postgresql-primary-1
+"$(dirname "$0")/sync-aws-postgresql.sh" "$@" postgresql-primary-1
 
-$(dirname $0)/sync-aws-elasticsearch.sh "$@"
+"$(dirname "$0")/sync-aws-elasticsearch.sh" "$@"
 
 if ! ($SKIP_MONGO || $DRY_RUN); then
   status "Munging router backend hostnames for dev VM"
@@ -31,14 +31,14 @@ fi
 if ignored "mapit"; then
   status "Skipping mapit"
 else
-  $(dirname $0)/sync-mapit.sh
+  "$(dirname "$0")/sync-mapit.sh"
 fi
 
 
 if ! $DRY_RUN; then
   status "Munging Signon db tokens for dev VM"
-  if [[ -d $(dirname $0)/../../../signon ]]; then
-    cd $(dirname $0)/../../../signon && bundle install && bundle exec ruby script/make_oauth_work_in_dev
+  if [[ -d "$(dirname "$0")/../../../signon" ]]; then
+    cd "$(dirname "$0")/../../../signon" && bundle install && bundle exec ruby script/make_oauth_work_in_dev
   fi
 fi
 

--- a/development-vm/replication/replicate-data-local.sh
+++ b/development-vm/replication/replicate-data-local.sh
@@ -8,8 +8,10 @@ set -eu
 . $(dirname $0)/common-args.sh
 . $(dirname $0)/aws.sh
 
-status "Running bundle install"
-bundle install --quiet
+if ! $DRY_RUN; then
+  status "Running bundle install"
+  bundle install --quiet
+fi
 
 $(dirname $0)/sync-aws-mysql.sh "$@" mysql-master
 


### PR DESCRIPTION
We don't need to `bundle install` if we are simply downloading data because we aren't actually using any of the included gems in simply copying data down from S3.

A dry run only downloads data and is often run outside of the development VM. Currently, outside the VM, this is somewhat painful because we are using ruby 1.9.3 and we have to manually install an old version of bundler to get bundler to work. This often confuses developers new to GOV.UK and hinders the on-boarding and setting up of the development VM.

The [original intent](https://github.com/alphagov/govuk-puppet/commit/719323aa053f69672f453db3a217b6c72338179b) of running `bundle install` was to ensure `es_dump_restore` was installed on the dev vm because we were using it to load Elasticsearch data. I don't think we are actually using that anymore, but I've not been able to confirm yet because I'm having trouble actually completing an Elasticsearch replication. I think we will still need to `bundle install` on the dev vm to get `bowler` and `foreman`, but I've not confirmed that yet either.

I've captured the future work [here](https://trello.com/c/wBJKMb0J/532-investigate-whether-we-need-esdumprestore-in-the-govuk-puppet-development-vm-gemfile) and [here](https://trello.com/c/qmd5OFGj/533-investigate-the-need-for-bundle-install-during-replication).