### PR TITLE
tempdir is unset for some workflow; hence causing unbound error

### DIFF
--- a/modules/govuk_env_sync/files/govuk_env_sync.sh
+++ b/modules/govuk_env_sync/files/govuk_env_sync.sh
@@ -136,7 +136,9 @@ function create_tempdir {
 }
 
 function remove_tempdir {
-  rm -rf "${tempdir}"
+  if [ ! -z "${tempdir:-}" ]; then
+    rm -rf "${tempdir}"
+  fi
 }
 
 function on_exit {


### PR DESCRIPTION
# Context

In the remove_tempdir, we should first check if the tempdir variable is set before deleting it because in some workflow, this is not set, e.g. during early exit. Unset variable causes unbound error if evaluated due to the `set -u` bash option.

# Decisions
1. check if variable is unbound/unset in such a way to prevent `set -u` from being triggered.