### PR TITLE
Increase email alert api memory thresholds

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -431,8 +431,8 @@ govuk::apps::email_alert_api::db_hostname: 'postgresql-primary-1.backend'
 govuk::apps::email_alert_api::db_password: "%{hiera('govuk::apps::email_alert_api::db::password')}"
 govuk::apps::email_alert_api::db_port: 6432
 govuk::apps::email_alert_api::db_allow_prepared_statements: false
-govuk::apps::email_alert_api::nagios_memory_warning: 1200
-govuk::apps::email_alert_api::nagios_memory_critical: 1500
+govuk::apps::email_alert_api::nagios_memory_warning: 2400
+govuk::apps::email_alert_api::nagios_memory_critical: 3000
 govuk::apps::email_alert_api::unicorn_worker_processes: '8'
 # This list should be kept in sync with https://www.notifications.service.gov.uk/services/ecfc7e2f-5145-45a6-9413-5d9b6e813ea9/users
 govuk::apps::email_alert_api::email_address_override_whitelist:

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -479,8 +479,8 @@ govuk::apps::email_alert_api::db_hostname: 'db-admin'
 govuk::apps::email_alert_api::db_port: 6432
 govuk::apps::email_alert_api::db_allow_prepared_statements: false
 govuk::apps::email_alert_api::db_password: "%{hiera('govuk::apps::email_alert_api::db::password')}"
-govuk::apps::email_alert_api::nagios_memory_warning: 1200
-govuk::apps::email_alert_api::nagios_memory_critical: 1500
+govuk::apps::email_alert_api::nagios_memory_warning: 2400
+govuk::apps::email_alert_api::nagios_memory_critical: 3000
 govuk::apps::email_alert_api::unicorn_worker_processes: '8'
 # This list should be kept in sync with https://www.notifications.service.gov.uk/services/ecfc7e2f-5145-45a6-9413-5d9b6e813ea9/users
 govuk::apps::email_alert_api::email_address_override_whitelist:


### PR DESCRIPTION
We often have alerts (warnings & criticals) for high memory usage in
email-alert-api machines. This alerts usually result in no action taken
because we have plenty of memory available.

This will increase the thresholds at which we will be alerted so to
avoid a) luttering our monitors b) distract us from more important
alerts.

Look at this Grafana dashboard that shows total memory + memory
used/buffered/cached since 2019-01-01 to see why these new values make
sense:
https://grafana.publishing.service.gov.uk/dashboard/file/machine.json?orgId=1&var-hostname=email-alert-api-1_backend&var-cpmetrics=cpu-system&var-cpmetrics=cpu-user&var-filesystem=All&var-disk=All&var-tcpconnslocal=All&var-tcpconnsremote=All&panelId=2&fullscreen&from=1546300800000&to=1556108108079

![grafana_email_alert_api_machine](https://user-images.githubusercontent.com/14851208/56659208-6d82ea80-6694-11e9-97a5-20d34dcdb9d0.png)
