### PR TITLE
Remove Plek search overrides from AWS

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -133,6 +133,11 @@ task :check_consistency_between_aws_and_carrenza do
     mongodb::s3backup::backup::s3_bucket
     mongodb::s3backup::backup::s3_bucket_daily
 
+    govuk::apps::content_tagger::override_search_location
+    govuk::apps::hmrc_manuals_api::override_search_location
+    govuk::apps::search_admin::override_search_location
+    govuk::apps::whitehall::override_search_location
+
     _
     backup::assets::backup_private_gpg_key_fingerprint
     backup::assets::jobs

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -91,11 +91,8 @@ govuk::apps::travel_advice_publisher::enable_email_alerts: true
 govuk::apps::whitehall::cpu_warning: 400
 govuk::apps::whitehall::cpu_critical: 600
 
-govuk::apps::collections::override_search_location: NULL
 govuk::apps::content_tagger::override_search_location: 'https://search-api.production.govuk.digital'
 govuk::apps::hmrc_manuals_api::override_search_location: 'https://search-api.production.govuk.digital'
-govuk::apps::licencefinder::override_search_location: NULL
-govuk::apps::finder_frontend::override_search_location: NULL
 govuk::apps::search_admin::override_search_location: 'https://search-api.production.govuk.digital'
 govuk::apps::whitehall::override_search_location: 'https://search-api.production.govuk.digital'
 

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -56,11 +56,8 @@ govuk::apps::travel_advice_publisher::enable_email_alerts: true
 govuk::apps::whitehall::cpu_warning: 400
 govuk::apps::whitehall::cpu_critical: 600
 
-govuk::apps::collections::override_search_location: NULL
 govuk::apps::content_tagger::override_search_location: 'https://search-api.staging.govuk.digital'
-govuk::apps::finder_frontend::override_search_location: NULL
 govuk::apps::hmrc_manuals_api::override_search_location: 'https://search-api.staging.govuk.digital'
-govuk::apps::licencefinder::override_search_location: NULL
 govuk::apps::search_admin::override_search_location: 'https://search-api.staging.govuk.digital'
 govuk::apps::whitehall::override_search_location: 'https://search-api.staging.govuk.digital'
 

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -60,16 +60,6 @@ govuk_search::gor::port: 3233
 govuk_search::monitoring::es_port: '80'
 govuk_search::monitoring::es_host: 'elasticsearch5.blue.integration.govuk-internal.digital'
 
-govuk::apps::content_store::plek_service_rummager_uri: 'https://search-api.integration.govuk-internal.digital'
-govuk::apps::collections::override_search_location: 'https://search-api.integration.govuk-internal.digital'
-govuk::apps::content_store::override_search_location: 'https://search-api.integration.govuk-internal.digital'
-govuk::apps::content_tagger::override_search_location: 'https://search-api.integration.govuk-internal.digital'
-govuk::apps::finder_frontend::override_search_location: 'https://search-api.integration.govuk-internal.digital'
-govuk::apps::hmrc_manuals_api::override_search_location: 'https://search-api.integration.govuk-internal.digital'
-govuk::apps::licencefinder::override_search_location: 'https://search-api.integration.govuk-internal.digital'
-govuk::apps::search_admin::override_search_location: 'https://search-api.integration.govuk-internal.digital'
-govuk::apps::whitehall::override_search_location: 'https://search-api.integration.govuk-internal.digital'
-
 govuk::deploy::aws_ses_smtp_host: 'email-smtp.eu-west-1.amazonaws.com'
 govuk::deploy::config::errbit_environment_name: "integration-%{hiera('stackname')}-aws"
 govuk::deploy::config::licensify_app_domain: 'integration.publishing.service.gov.uk'

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -125,7 +125,6 @@ govuk::apps::content_publisher::google_tag_manager_preview: "env-7"
 govuk::apps::content_publisher::govuk_notify_template_id: "e00e89f5-b622-4dcb-8f30-e6c70231a940"
 govuk::apps::content_store::performance_platform_big_screen_view_url: 'https://performance-platform-big-screen-view-production.cloudapps.digital'
 govuk::apps::content_store::performance_platform_spotlight_url: 'https://performance-platform-spotlight-production.cloudapps.digital'
-govuk::apps::content_store::plek_service_rummager_uri: 'https://search-api.production.govuk-internal.digital'
 govuk::apps::content_store::plek_service_whitehall_frontend_uri: 'https://whitehall-frontend.publishing.service.gov.uk'
 
 govuk::apps::email_alert_service::enabled: false
@@ -157,11 +156,8 @@ govuk_search::gor::port: 3233
 govuk_search::monitoring::es_port: '80'
 govuk_search::monitoring::es_host: 'elasticsearch5.blue.production.govuk-internal.digital'
 
-govuk::apps::collections::override_search_location: 'https://search-api.production.govuk-internal.digital'
 govuk::apps::content_tagger::override_search_location: NULL
 govuk::apps::hmrc_manuals_api::override_search_location: NULL
-govuk::apps::licencefinder::override_search_location: 'https://search-api.production.govuk-internal.digital'
-govuk::apps::finder_frontend::override_search_location: 'https://search-api.production.govuk-internal.digital'
 govuk::apps::search_admin::override_search_location: NULL
 govuk::apps::whitehall::override_search_location: NULL
 

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -156,11 +156,6 @@ govuk_search::gor::port: 3233
 govuk_search::monitoring::es_port: '80'
 govuk_search::monitoring::es_host: 'elasticsearch5.blue.production.govuk-internal.digital'
 
-govuk::apps::content_tagger::override_search_location: NULL
-govuk::apps::hmrc_manuals_api::override_search_location: NULL
-govuk::apps::search_admin::override_search_location: NULL
-govuk::apps::whitehall::override_search_location: NULL
-
 govuk::deploy::aws_ses_smtp_host: 'email-smtp.eu-west-1.amazonaws.com'
 govuk::deploy::config::errbit_environment_name: 'production'
 govuk::deploy::config::website_root: 'https://www.gov.uk'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -161,11 +161,6 @@ govuk_search::gor::port: 3233
 govuk_search::monitoring::es_port: '80'
 govuk_search::monitoring::es_host: 'elasticsearch5.blue.production.govuk-internal.digital'
 
-govuk::apps::content_tagger::override_search_location: NULL
-govuk::apps::hmrc_manuals_api::override_search_location: NULL
-govuk::apps::search_admin::override_search_location: NULL
-govuk::apps::whitehall::override_search_location: NULL
-
 govuk::deploy::aws_ses_smtp_host: 'email-smtp.eu-west-1.amazonaws.com'
 govuk::deploy::config::errbit_environment_name: 'staging'
 govuk::deploy::config::licensify_app_domain: 'staging.publishing.service.gov.uk'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -129,7 +129,6 @@ govuk::apps::content_publisher::email_address_override: "content-publisher-notif
 govuk::apps::content_publisher::govuk_notify_template_id: "112842bb-d8a4-4511-90de-57dc5c8f27ec"
 govuk::apps::content_store::performance_platform_big_screen_view_url: 'https://performance-platform-big-screen-view-staging.cloudapps.digital'
 govuk::apps::content_store::performance_platform_spotlight_url: 'https://performance-platform-spotlight-staging.cloudapps.digital'
-govuk::apps::content_store::plek_service_rummager_uri: 'https://search-api.staging.govuk-internal.digital'
 govuk::apps::content_store::plek_service_whitehall_frontend_uri: 'https://whitehall-frontend.staging.publishing.service.gov.uk'
 
 govuk::apps::email_alert_service::enabled: false
@@ -162,11 +161,8 @@ govuk_search::gor::port: 3233
 govuk_search::monitoring::es_port: '80'
 govuk_search::monitoring::es_host: 'elasticsearch5.blue.production.govuk-internal.digital'
 
-govuk::apps::collections::override_search_location: 'https://search-api.staging.govuk-internal.digital'
 govuk::apps::content_tagger::override_search_location: NULL
-govuk::apps::finder_frontend::override_search_location: 'https://search-api.staging.govuk-internal.digital'
 govuk::apps::hmrc_manuals_api::override_search_location: NULL
-govuk::apps::licencefinder::override_search_location: 'https://search-api.staging.govuk-internal.digital'
 govuk::apps::search_admin::override_search_location: NULL
 govuk::apps::whitehall::override_search_location: NULL
 

--- a/modules/govuk/manifests/apps/collections.pp
+++ b/modules/govuk/manifests/apps/collections.pp
@@ -30,9 +30,6 @@
 # [*email_alert_api_bearer_token*]
 #   Bearer token for communication with the email-alert-api
 #
-# [*override_search_location*]
-#   Alternative hostname to use for Plek("search") and Plek("rummager")
-#
 class govuk::apps::collections(
   $vhost = 'collections',
   $port = '3070',
@@ -41,20 +38,18 @@ class govuk::apps::collections(
   $nagios_memory_warning = undef,
   $nagios_memory_critical = undef,
   $email_alert_api_bearer_token = undef,
-  $override_search_location = undef,
 ) {
   govuk::app { 'collections':
-    app_type                 => 'rack',
-    port                     => $port,
-    health_check_path        => '/topic/oil-and-gas',
-    log_format_is_json       => true,
-    asset_pipeline           => true,
-    asset_pipeline_prefix    => 'collections',
-    vhost                    => $vhost,
-    nagios_memory_warning    => $nagios_memory_warning,
-    nagios_memory_critical   => $nagios_memory_critical,
-    sentry_dsn               => $sentry_dsn,
-    override_search_location => $override_search_location,
+    app_type               => 'rack',
+    port                   => $port,
+    health_check_path      => '/topic/oil-and-gas',
+    log_format_is_json     => true,
+    asset_pipeline         => true,
+    asset_pipeline_prefix  => 'collections',
+    vhost                  => $vhost,
+    nagios_memory_warning  => $nagios_memory_warning,
+    nagios_memory_critical => $nagios_memory_critical,
+    sentry_dsn             => $sentry_dsn,
   }
 
   Govuk::App::Envvar {

--- a/modules/govuk/manifests/apps/finder_frontend.pp
+++ b/modules/govuk/manifests/apps/finder_frontend.pp
@@ -21,9 +21,6 @@
 # [*email_alert_api_bearer_token*]
 #   Bearer token for communication with the email-alert-api
 #
-# [*override_search_location*]
-#   Alternative hostname to use for Plek("search") and Plek("rummager")
-#
 class govuk::apps::finder_frontend(
   $port = '3062',
   $enabled = false,
@@ -33,7 +30,6 @@ class govuk::apps::finder_frontend(
   $secret_key_base = undef,
   $email_alert_api_bearer_token = undef,
   $unicorn_worker_processes = undef,
-  $override_search_location = undef,
 ) {
 
   if $enabled {
@@ -48,7 +44,6 @@ class govuk::apps::finder_frontend(
       nagios_memory_warning    => $nagios_memory_warning,
       nagios_memory_critical   => $nagios_memory_critical,
       unicorn_worker_processes => $unicorn_worker_processes,
-      override_search_location => $override_search_location,
     }
   }
 

--- a/modules/govuk/manifests/apps/licencefinder.pp
+++ b/modules/govuk/manifests/apps/licencefinder.pp
@@ -24,9 +24,6 @@
 #   The bearer token to use when communicating with Publishing API.
 #   Default: undef
 #
-# [*override_search_location*]
-#   Alternative hostname to use for Plek("search") and Plek("rummager")
-#
 class govuk::apps::licencefinder(
   $port = '3014',
   $sentry_dsn = undef,
@@ -34,21 +31,19 @@ class govuk::apps::licencefinder(
   $mongodb_name = 'licence_finder_production',
   $secret_key_base = undef,
   $publishing_api_bearer_token = undef,
-  $override_search_location = undef,
 ) {
 
   $app_name = 'licencefinder'
 
   govuk::app { $app_name:
-    app_type                 => 'rack',
-    port                     => $port,
-    sentry_dsn               => $sentry_dsn,
-    health_check_path        => '/licence-finder/sectors',
-    log_format_is_json       => true,
-    asset_pipeline           => true,
-    asset_pipeline_prefix    => 'licencefinder',
-    repo_name                => 'licence-finder',
-    override_search_location => $override_search_location,
+    app_type              => 'rack',
+    port                  => $port,
+    sentry_dsn            => $sentry_dsn,
+    health_check_path     => '/licence-finder/sectors',
+    log_format_is_json    => true,
+    asset_pipeline        => true,
+    asset_pipeline_prefix => 'licencefinder',
+    repo_name             => 'licence-finder',
   }
 
   if $::govuk_node_class !~ /^development$/ {


### PR DESCRIPTION
The hieradata can remain in place in Carrenza for now, it'll go away as those applications are migrated.

---

[Trello card](https://trello.com/c/cbKlxSo6/655-💀-remove-the-plek-environment-variables-from-aws-💀)