### PR TITLE
Install chromedriver on all dev VMs

### DIFF
--- a/modules/govuk/manifests/node/s_development.pp
+++ b/modules/govuk/manifests/node/s_development.pp
@@ -13,6 +13,7 @@ class govuk::node::s_development (
   include base
 
   include assets::user
+  include ::chromdriver
   include clamav::run_fake_virus_scan
   include golang
   include govuk_apt::disable_pipelining


### PR DESCRIPTION
Previously we used the now-deprecated chromedriver-helper gem to install
chromedriver automatically for testing. This ensures it's installed as a
system binary, so that we no longer need to rely on the gem.