### PR TITLE
Add Pablo Manrubia back to .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -143,6 +143,7 @@ Nick Colley <nick.colley@digital.cabinet-office.gov.uk> <nickcolley7@gmail.com>
 Nick Colley <nick.colley@digital.cabinet-office.gov.uk> <nickcolley@gds0257.local>
 Nick Stenning <nick.stenning@digital.cabinet-office.gov.uk> <nick@whiteink.com>
 Oliver Byford <oliver.byford@digital.cabinet-office.gov.uk> <o@byford.org>
+Pablo Manrubia <pablo.manrubia@digital.cabinet-office.gov.uk> <pmanrubia@gmail.com>
 Paul Bowsher <paul.bowsher@digital.cabinet-office.gov.uk> <paul.bowsher@gmail.com>
 Paul Downey <paul.downey@whatfettle.com> <psd@whatfettle.com>
 Paulo Schneider <pschneid@thoughtworks.com> <paulo.schneider@gmail.com>


### PR DESCRIPTION
As pointed out by Chris Baines, keeping the entry means that
the commit history can be viewed in a more consistent way.