### PR TITLE
Add sidekiq-monitoring to Production AWS and Staging AWS

### DIFF
--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -26,6 +26,7 @@ node_class: &node_class
       - kibana
       - link-checker-api
       - local-links-manager
+      - sidekiq-monitoring
       - support
       - support-api
       - support_api_csv_env_sync

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -26,6 +26,7 @@ node_class: &node_class
       - kibana
       - link-checker-api
       - local-links-manager
+      - sidekiq-monitoring
       - support
       - support-api
       - support_api_csv_env_sync


### PR DESCRIPTION
We're running applications using Sidekiq in these environments, so it
makes sense to run sidekiq-monitoring here as well.

It's not going to work very well, as it's not aware what's running in
Carrenza, and what's running in AWS, but this might be more useful
than not running it in AWS entirely.