### PR TITLE
Rename the Content Performance Manager application dashboard

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1096,7 +1096,7 @@ grafana::dashboards::application_dashboards:
   content-data-admin:
     show_sidekiq_graphs: true
     has_workers: true
-  content-performance-manager:
+  content-data-api:
     show_sidekiq_graphs: true
     has_workers: true
   content-publisher:

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1038,7 +1038,7 @@ grafana::dashboards::application_dashboards:
   content-data-admin:
     show_sidekiq_graphs: true
     has_workers: true
-  content-performance-manager:
+  content-data-api:
     show_sidekiq_graphs: true
     has_workers: true
   content-publisher:


### PR DESCRIPTION
The Content Performance Manager is now known as the Content Data API.