### PR TITLE
Check GitHub IP ranges Jenkins job

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/check_github_ip_ranges.pp
+++ b/modules/govuk_jenkins/manifests/jobs/check_github_ip_ranges.pp
@@ -1,0 +1,12 @@
+# == Class: govuk_jenkins::jobs::check_github_ip_ranges
+#
+# Create a jenkins-job-builder config file for checking that GitHub
+# IP ranges are configured correctly.
+#
+class govuk_jenkins::jobs::check_github_ip_ranges {
+  file { '/etc/jenkins_jobs/jobs/check_github_ip_ranges.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/check_github_ip_ranges.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+}

--- a/modules/govuk_jenkins/templates/jobs/check_github_ip_ranges.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/check_github_ip_ranges.yaml.erb
@@ -1,0 +1,34 @@
+---
+- scm:
+    name: govuk-provisioning_Check_GitHub_IP_Ranges
+    scm:
+        - git:
+            url: git@github.com:alphagov/govuk-provisioning.git
+            branches:
+              - master
+            wipe-workspace: false
+
+- job:
+    name: Check_GitHub_IP_Ranges
+    display-name: Check_GitHub_IP_Ranges
+    project-type: freestyle
+    description: "This job compares the IP ranges that GitHub publishes against the ranges configured in govuk-provisioning and errors if they don't match."
+    properties:
+        - build-discarder:
+            days-to-keep: 30
+            artifact-num-to-keep: 5
+        - github:
+            url: https://github.com/alphagov/govuk-provisioning/
+    scm:
+      - govuk-provisioning_Check_GitHub_IP_Ranges
+    builders:
+        - shell: |
+            bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
+            bundle exec ./tools/github_ips.rb
+    publishers:
+        - email:
+            recipients: 2nd-line-support@digital.cabinet-office.gov.uk
+    triggers:
+        - timed: |
+            TZ=Europe/London
+            H 3 * * *


### PR DESCRIPTION
This commit adds a new Jenkins job to run a script in the govuk-provisioning repo that checks our firewall confguration against the latest GitHub-published outbound IP ranges for webhooks.