### PR TITLE
Merge master before running tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,10 +14,14 @@ node {
       govuk.checkoutFromGitHubWithSSH(REPOSITORY)
     }
 
+    stage("Merge master") {
+      govuk.mergeMasterBranch()
+    }
+
     stage("Bundle install") {
       govuk.bundleApp()
     }
-    
+
     stage("Check consistency between AWS and Carrenza") {
       govuk.runRakeTask('check_consistency_between_aws_and_carrenza')
     }


### PR DESCRIPTION
This matches the default behaviour of the `Jenkinsfile`s for our apps and it means that PRs won't need to be rebased against master manually.