### PR TITLE
Add search-api dashboard to Carrenza

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1169,6 +1169,15 @@ grafana::dashboards::application_dashboards:
     show_memcached: true
   release: {}
   router-api: {}
+  search-api:
+    # search-api isn't in carrenza, but we need the dashboard to exist
+    # for the release app
+    show_controller_errors: false
+    show_response_times: false
+    show_sidekiq_graphs: false
+    show_slow_requests: false
+    has_workers: false
+    dependent_app_5xx_errors: []
   search-admin: {}
   service-manual-frontend: {}
   service-manual-publisher: {}


### PR DESCRIPTION
This is needed because the release app checks if the Carrenza
dashboard exists before generating links (which then use the correct
domain).  It can't check the AWS dashboard exists, because Carrenza
backend can't talk to AWS grafana.