### PR TITLE
Add govuk_app_dbconsole

### DIFF
--- a/modules/govuk_scripts/files/usr/local/bin/govuk_app_dbconsole
+++ b/modules/govuk_scripts/files/usr/local/bin/govuk_app_dbconsole
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+#
+# govuk_app_dbconsole: opens a database console for a specified application
+#
+# Currently supports Rails apps
+#
+
+set -eu
+
+if [ "$#" -ne "1" ] || [ "$1" = "-h" ]; then
+  echo "Usage: govuk_app_dbconsole app_name" >&2
+  exit 1
+fi
+
+cd /var/apps/$1
+
+if [ -f bin/rails ]; then
+  sudo -u deploy govuk_setenv $1 bundle exec ./bin/rails dbconsole -p
+elif [ -f script/rails ]; then
+  sudo -u deploy govuk_setenv $1 bundle exec ./script/rails dbconsole -p
+else
+  echo "I don't know how to run a console for $1"
+  exit 1
+fi

--- a/modules/govuk_scripts/manifests/init.pp
+++ b/modules/govuk_scripts/manifests/init.pp
@@ -8,6 +8,13 @@ class govuk_scripts {
     mode   => '0755',
   }
 
+  # govuk_app_console: opens a database console for a specified application
+  file { '/usr/local/bin/govuk_app_dbconsole':
+    ensure => present,
+    source => 'puppet:///modules/govuk_scripts/usr/local/bin/govuk_app_dbconsole',
+    mode   => '0755',
+  }
+
   # govuk_check_security_upgrades list packages which need a security upgrade
   file { '/usr/local/bin/govuk_check_security_upgrades':
     ensure => present,


### PR DESCRIPTION
Very similar to govuk_app_console, except it opens a database
console (e.g. psql), rather than irb.

This is especially useful now that RDS is in use, which can make it
harder to connect to the relevant database.