### PR TITLE
remove the search api sidekiq monitoring in carrenza

### DIFF
--- a/modules/monitoring/manifests/checks/sidekiq.pp
+++ b/modules/monitoring/manifests/checks/sidekiq.pp
@@ -9,29 +9,24 @@
 class monitoring::checks::sidekiq (
   $enable_support_check = true,
 ) {
-  icinga::check::graphite { 'check_search_api_queue_latency':
-    target              => 'transformNull(keepLastValue(maxSeries(stats.gauges.govuk.app.search-api.*.workers.queues.default.latency)), 0)',
-    warning             => 2.5,
-    critical            => 15,
-    use                 => 'govuk_normal_priority',
-    # Use data from the last 24 hours, to avoid not getting any
-    # datapoints back.
-    from                => '24hours',
-    # Take an average over the most recent 36 datapoints, which at 5
-    # seconds per datapoint is the last 3 minutes
-    args                => '--dropfirst -36',
-    host_name           => $::fqdn,
-    desc                => 'Search API Sidekiq queue latency',
-    notification_period => 'inoffice',
-    notes_url           => monitoring_docs_url(search-api-queue-latency),
-  }
-  icinga::check::graphite { 'check_rummager_queue_latency':
-    ensure    => 'absent',
-    target    => undef,
-    desc      => undef,
-    warning   => undef,
-    critical  => undef,
-    host_name => undef,
+
+  if $::aws_migration {
+    icinga::check::graphite { 'check_search_api_queue_latency':
+      target              => 'transformNull(keepLastValue(maxSeries(stats.gauges.govuk.app.search-api.*.workers.queues.default.latency)), 0)',
+      warning             => 2.5,
+      critical            => 15,
+      use                 => 'govuk_normal_priority',
+      # Use data from the last 24 hours, to avoid not getting any
+      # datapoints back.
+      from                => '24hours',
+      # Take an average over the most recent 36 datapoints, which at 5
+      # seconds per datapoint is the last 3 minutes
+      args                => '--dropfirst -36',
+      host_name           => $::fqdn,
+      desc                => 'Search API Sidekiq queue latency',
+      notification_period => 'inoffice',
+      notes_url           => monitoring_docs_url(search-api-queue-latency),
+    }
   }
 
   icinga::check::graphite { 'check_signon_queue_sizes':


### PR DESCRIPTION
# Context

search api has been migrate to AWS and therefore, no search api icinga alerts should appear in the carrenza icinga boards

# Decisions
1. use an if case to remove search-api alerts from Carrenza monitoring