### PR TITLE
Disable the Content Data Admin in Carrenza

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -29,6 +29,7 @@ task :check_consistency_between_aws_and_carrenza do
     govuk::apps::cache_clearing_service::puppetdb_node_url
     govuk::apps::ckan::db_allow_prepared_statements
     govuk::apps::ckan::db_port
+    govuk::apps::content_data_admin::enabled
     govuk::apps::content_performance_manager::etl_healthcheck_enabled_from_hour
     govuk::apps::content_publisher::db::backend_ip_range
     govuk::apps::info_frontend::vhost_aliases

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -384,6 +384,7 @@ govuk::apps::content_audit_tool::db::backend_ip_range: "%{hiera('environment_ip_
 govuk::apps::content_audit_tool::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::content_audit_tool::redis_port: "%{hiera('sidekiq_port')}"
 
+govuk::apps::content_data_admin::enabled: false
 govuk::apps::content_data_admin::db_hostname: "postgresql-primary-1.backend"
 govuk::apps::content_data_admin::db_port: 6432
 govuk::apps::content_data_admin::db_allow_prepared_statements: false


### PR DESCRIPTION
It's now running in AWS, so disable it in Carrenza so that the
configuration is removed.

Once this change has been deployed, the app can be removed from the
hieradata related to the backend machines in Carrenza.