### PR TITLE
Remove incorrect external domains

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -561,9 +561,6 @@ hosts::production::router::hosts:
     ip: '10.3.1.254'
     legacy_aliases:
       - 'cache'
-      - "www.%{hiera('app_domain')}"
-      - "www-origin.%{hiera('app_domain')}"
-      - "assets-origin.%{hiera('app_domain')}"
     service_aliases:
       - 'cache'
       - 'router'

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -516,9 +516,6 @@ hosts::production::router::hosts:
     ip: '10.2.1.254'
     legacy_aliases:
       - 'cache'
-      - "www.%{hiera('app_domain')}"
-      - "www-origin.%{hiera('app_domain')}"
-      - "assets-origin.%{hiera('app_domain')}"
     service_aliases:
       - 'cache'
       - 'router'

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -538,7 +538,6 @@ hosts::backend_migration::hosts:
       - cache.cluster
       - router.cluster
       - cache
-      - assets-origin.publishing.service.gov.uk
   # monitoring-1.management.publishing.service.gov.uk:
   #   ip: 10.3.0.20
   #   host_aliases:

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -481,7 +481,6 @@ hosts::backend_migration::hosts:
       - cache.cluster
       - router.cluster
       - cache
-      - assets-origin.staging.publishing.service.gov.uk
   draft-cache-1.router.staging.publishing.service.gov.uk:
     ip: 10.2.1.200
     host_aliases:


### PR DESCRIPTION
These are configured to point to the cache machines but this is no longer correct post migration and instead we should route these through the normal internet.

This is a continuation of https://github.com/alphagov/govuk-puppet/pull/9051.

This fixes problems like this:

```
thomasleese@staging-jenkins-1:~$ curl https://assets-origin.staging.publishing.service.gov.uk
curl: (35) Unknown SSL protocol error in connection to assets-origin.staging.publishing.service.gov.uk:443

thomasleese@staging-backend-1:~$ curl https://www.staging.publishing.service.gov.uk
curl: (35) Unknown SSL protocol error in connection to www.staging.publishing.service.gov.uk:443
```

The Smokey tests are currently failing because they can't access assets-origin and this should also fix that.

[Trello Card](https://trello.com/c/euhCSxFr/771-upgrade-to-the-latest-libssl-for-when-fastly-switches-off-tls-10)