### PR TITLE
remove jenkins warehouse data sync

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/copy_data_to_integration.pp
+++ b/modules/govuk_jenkins/manifests/jobs/copy_data_to_integration.pp
@@ -8,7 +8,6 @@ class govuk_jenkins::jobs::copy_data_to_integration (
   $pg_src_env_sync_pw = undef,
   $pg_dst_env_sync_pw = undef,
   $pg_tr_dst_env_sync_pw = undef,
-  $pg_wh_dst_env_sync_pw = undef,
   $jenkins_api_user_password = undef,
   $enable_slack_notifications = true,
   $app_domain = hiera('app_domain'),

--- a/modules/govuk_jenkins/manifests/jobs/copy_data_to_staging.pp
+++ b/modules/govuk_jenkins/manifests/jobs/copy_data_to_staging.pp
@@ -7,7 +7,6 @@ class govuk_jenkins::jobs::copy_data_to_staging (
   $mysql_dst_root_pw = undef,
   $pg_src_env_sync_pw = undef,
   $pg_dst_env_sync_pw = undef,
-  $pg_wh_dst_env_sync_pw = undef,
   $jenkins_api_user_password = undef,
   $enable_slack_notifications = true,
   $app_domain = hiera('app_domain'),

--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
@@ -50,10 +50,6 @@
             sed -i.bak "s/PG_TR_SRC_ENV_SYNC_PW=PLACEHOLDER/PG_TR_SRC_ENV_SYNC_PW='<%= @pg_src_env_sync_pw %>'/" scripts/sync-transition-postgresql.sh
             sed -i "s/PG_TR_DST_ENV_SYNC_PW=PLACEHOLDER/PG_TR_DST_ENV_SYNC_PW='<%= @pg_tr_dst_env_sync_pw %>'/" scripts/sync-transition-postgresql.sh
 
-            echo "Putting in the real Warehouse Postgresql password"
-            sed -i.bak "s/PG_WH_SRC_ENV_SYNC_PW=PLACEHOLDER/PG_WH_SRC_ENV_SYNC_PW='<%= @pg_src_env_sync_pw %>'/" scripts/sync-warehouse-postgresql.sh
-            sed -i "s/PG_WH_DST_ENV_SYNC_PW=PLACEHOLDER/PG_WH_DST_ENV_SYNC_PW='<%= @pg_wh_dst_env_sync_pw %>'/" scripts/sync-warehouse-postgresql.sh
-
             echo "Syncing data"
             bash sync production integration
     publishers:
@@ -110,4 +106,3 @@
                 - mysql-normal
                 - postgresql-backend
                 - postgresql-transition
-                - postgresql-warehouse

--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_staging.yaml.erb
@@ -47,10 +47,6 @@
             sed -i.bak "s/PG_TR_SRC_ENV_SYNC_PW=PLACEHOLDER/PG_TR_SRC_ENV_SYNC_PW='<%= @pg_src_env_sync_pw %>'/" scripts/sync-transition-postgresql.sh
             sed -i "s/PG_TR_DST_ENV_SYNC_PW=PLACEHOLDER/PG_TR_DST_ENV_SYNC_PW='<%= @pg_dst_env_sync_pw %>'/" scripts/sync-transition-postgresql.sh
 
-            echo "Putting in the real Warehouse Postgresql password"
-            sed -i.bak "s/PG_WH_SRC_ENV_SYNC_PW=PLACEHOLDER/PG_WH_SRC_ENV_SYNC_PW='<%= @pg_src_env_sync_pw %>'/" scripts/sync-warehouse-postgresql.sh
-            sed -i "s/PG_WH_DST_ENV_SYNC_PW=PLACEHOLDER/PG_WH_DST_ENV_SYNC_PW='<%= @pg_wh_dst_env_sync_pw %>'/" scripts/sync-warehouse-postgresql.sh
-
             set +e
 
             echo "Disabling Gor traffic replay"
@@ -124,4 +120,3 @@
                 - mysql-whitehall
                 - postgresql-backend
                 - postgresql-transition
-                - postgresql-warehouse


### PR DESCRIPTION
# Context

This is postgresql wharehouse data sync no longer needed because the data sync is done via the govuk_env_sync python code that runs as a cron job on the database machines themselves.

This will hopefully solves the issues seen during the Jenkins jobs: Copy Data to Staging and Copy Data to integration

# Decisions
1. remove all postgresql wharehouse data sync from Jenkins in the puppet code