### PR TITLE
set log retention on search machines to 7 days

### DIFF
--- a/hieradata_aws/class/integration/search.yaml
+++ b/hieradata_aws/class/integration/search.yaml
@@ -21,3 +21,6 @@ govuk_env_sync::tasks:
     temppath: "/tmp/es_snapshot_everything"
     url: "govuk-integration"
     path: "elasticsearch5"
+
+logrotate::conf::days_to_keep: 7
+nginx::logging::days_to_keep: 7

--- a/hieradata_aws/class/production/search.yaml
+++ b/hieradata_aws/class/production/search.yaml
@@ -10,3 +10,6 @@ govuk_env_sync::tasks:
     temppath: "/tmp/es_snapshot_everything"
     url: "govuk-production"
     path: "elasticsearch5"
+
+logrotate::conf::days_to_keep: 7
+nginx::logging::days_to_keep: 7

--- a/hieradata_aws/class/staging/search.yaml
+++ b/hieradata_aws/class/staging/search.yaml
@@ -21,3 +21,6 @@ govuk_env_sync::tasks:
     temppath: "/tmp/es_snapshot_everything"
     url: "govuk-staging"
     path: "elasticsearch5"
+
+logrotate::conf::days_to_keep: 7
+nginx::logging::days_to_keep: 7


### PR DESCRIPTION
We only need to keep the logs for 7 days for this machine type (checked with app developer) and this will reduce the disk space use that we currently have.