### PR TITLE
allow defined logrotate to lookup hiera

### DIFF
--- a/lib/puppet-lint/plugins/check_hiera.rb
+++ b/lib/puppet-lint/plugins/check_hiera.rb
@@ -49,6 +49,11 @@ PuppetLint.new_check(:hiera_explicit_lookup) do
     # metrics
     'govuk_logging::logstream::metrics_only',
 
+    # Provides ability to set the logrotate configuration parameter without
+    # re-factoring classes and defined resources already using logrotate defined
+    # resource
+    'logrotate::conf::days_to_keep',
+
     # Allow sharing of asset_manager_uploaded_assets_routes array between assets-origin and draft-assets
     # nginx virtual host configuration
     'router::assets_origin::asset_manager_uploaded_assets_routes',

--- a/modules/logrotate/manifests/conf.pp
+++ b/modules/logrotate/manifests/conf.pp
@@ -45,7 +45,7 @@
 #
 define logrotate::conf (
   $matches,
-  $days_to_keep = '31',
+  $days_to_keep = hiera('logrotate::conf::days_to_keep', '31'),
   $ensure = 'present',
   $user = undef,
   $group = undef,


### PR DESCRIPTION
# Context

if the defined logrotate is able to lookup hiera, it is possible to modify the configuration in the hiera rather than pass the value at instantiation of the defined resource. This is a hack since the class and other defined types of logrotate should have exposed the logrotate parameters for configuration.

# Decisions
1. allow logrotate to look up days_to_keep parameter from hiera directly
2. add as an exception the direct hiera lookup above