### PR TITLE
lower puppet memory usage

### DIFF
--- a/modules/puppet/manifests/puppetserver/config.pp
+++ b/modules/puppet/manifests/puppetserver/config.pp
@@ -1,7 +1,7 @@
 # FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
 class puppet::puppetserver::config {
 
-  $java_args = '-Xms12g -Xmx12g -XX:MaxPermSize=1g'
+  $java_args = '-Xms10g -Xmx10g -XX:MaxPermSize=1g'
 
   file {'/etc/puppet/puppetdb.conf':
     content => template('puppet/etc/puppet/puppetdb.conf.erb'),


### PR DESCRIPTION
# Context

Before, it was thought that giving more memory to puppetserver will solve the out-of-memory issue but it didn't. Now we use monit to restart the puppetserver if it is out-of-memory and stops. Hence, we can lower the memory allocated to puppetserver and avoid to be within 5% of memory usage on the virtual machine.

# Decisions

1. lower puppetserver allocated memory to a more reasonable 10gb compared to current 12gb