### PR TITLE
Stop cloning govuk-app-deployment-secrets

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
@@ -32,14 +32,11 @@
               export AWS_REGION=eu-west-2
               export GIT_ORIGIN_PREFIX="ssh://git-codecommit.${AWS_REGION}.amazonaws.com/v1/repos"
               export APP_DEPLOYMENT_GIT_URL="${GIT_ORIGIN_PREFIX}/govuk-app-deployment"
-              export APP_DEPLOYMENT_SECRET_GIT_URL="${GIT_ORIGIN_PREFIX}/govuk-app-deployment-secrets"
             else
               export APP_DEPLOYMENT_GIT_URL="git@github.com:alphagov/govuk-app-deployment.git"
-              export APP_DEPLOYMENT_SECRET_GIT_URL="git@github.com:alphagov/govuk-app-deployment-secrets.git"
             fi
 
             git clone ${APP_DEPLOYMENT_GIT_URL} --branch master --single-branch --depth 1 ./
-            git clone ${APP_DEPLOYMENT_SECRET_GIT_URL} --branch master --single-branch --depth 1 ./secrets
             ./jenkins.sh
     publishers:
         - trigger:


### PR DESCRIPTION
Trello: https://trello.com/c/T2ibAO7v

`govuk-app-deployment` is no longer copying shared_config from `govuk-app-deployment-secrets`
so it no longer needs to be cloned.