### PR TITLE
Fix NGinx configuration for the Content Data API Sidekiq Monitoring

### DIFF
--- a/modules/govuk/templates/sidekiq_monitoring_nginx_config.conf.erb
+++ b/modules/govuk/templates/sidekiq_monitoring_nginx_config.conf.erb
@@ -34,8 +34,8 @@ server {
     proxy_pass http://localhost:3240;
   }
 
-  location /content-performance-manager {
-    proxy_pass http://localhost:3207;
+  location /content-data-api {
+    proxy_pass http://localhost:3235;
   }
 
   location /content-publisher {


### PR DESCRIPTION
The Content Performance Manager has been renamed to the Content Data
API, so update the configuration accordingly.