### PR TITLE
Update collectd-rabbitmq plugin 1.5.0 -> 1.20.0

### DIFF
--- a/modules/collectd/manifests/plugin/rabbitmq.pp
+++ b/modules/collectd/manifests/plugin/rabbitmq.pp
@@ -13,7 +13,7 @@ class collectd::plugin::rabbitmq (
   ){
 
   @package { 'collectd-rabbitmq':
-    ensure   => '1.5.0',
+    ensure   => '1.20.0',
     provider => pip,
   }
 


### PR DESCRIPTION
Updates the [collectd-rabbitmq plugin](https://github.com/nytimes/collectd-rabbitmq) from v1.5.0 to v1.20.0. 

Useful as now collects metrics about consumers (https://github.com/nytimes/collectd-rabbitmq/commit/6bc15f595dca43d8786ef54b52b443131c37a95e)