### PR TITLE
Fix the Content Data Admin procfile monitoring

### DIFF
--- a/modules/govuk/manifests/apps/content_data_admin.pp
+++ b/modules/govuk/manifests/apps/content_data_admin.pp
@@ -188,7 +188,9 @@ class govuk::apps::content_data_admin (
     }
   }
 
-  govuk::procfile::worker { $app_name:
+  govuk::procfile::worker { "${app_name}-sidekiq":
+    ensure         => $ensure,
     enable_service => $enable_procfile_worker,
+    process_regex  => 'sidekiq .*  content-data ',
   }
 }


### PR DESCRIPTION
Make the name more specific by adding -sidekiq. Also pass through
$ensure, and customise the process_regex so that it picks up the
process.