### PR TITLE
Remove extra space in the Content Data worker process_regex

### DIFF
--- a/modules/govuk/manifests/apps/content_data_admin.pp
+++ b/modules/govuk/manifests/apps/content_data_admin.pp
@@ -191,6 +191,6 @@ class govuk::apps::content_data_admin (
   govuk::procfile::worker { "${app_name}-sidekiq":
     ensure         => $ensure,
     enable_service => $enable_procfile_worker,
-    process_regex  => 'sidekiq .*  content-data ',
+    process_regex  => 'sidekiq .* content-data ',
   }
 }


### PR DESCRIPTION
This is causing the regex to not match the processes.