### PR TITLE
Add missing setenv_as to the Content Data Admin procfile worker

### DIFF
--- a/modules/govuk/manifests/apps/content_data_admin.pp
+++ b/modules/govuk/manifests/apps/content_data_admin.pp
@@ -191,6 +191,7 @@ class govuk::apps::content_data_admin (
   govuk::procfile::worker { "${app_name}-sidekiq":
     ensure         => $ensure,
     enable_service => $enable_procfile_worker,
+    setenv_as      => $app_name,
     process_regex  => 'sidekiq .* content-data ',
   }
 }


### PR DESCRIPTION
Previously, it was defaulting to content-data-admin-sidekiq, due to
the title change, but this doesn't exist. Therefore, pass through the
correct value explicitly.