### PR TITLE
Fix Grafana dashboards using rabbitMQ metrics

### DIFF
--- a/modules/grafana/files/dashboards/rabbitmq.json
+++ b/modules/grafana/files/dashboards/rabbitmq.json
@@ -67,15 +67,15 @@
           "targets": [
             {
               "refId": "A",
-              "target": "alias(rabbitmq_%2F.exchanges-$Exchanges.confirm_details-rate, 'confirm rate')"
+              "target": "alias(rabbitmq_default.exchanges-$Exchanges.confirm_details-rate, 'confirm rate')"
             },
             {
               "refId": "B",
-              "target": "alias(rabbitmq_%2F.exchanges-$Exchanges.publish_in_details-rate, 'publish (in) rate')"
+              "target": "alias(rabbitmq_default.exchanges-$Exchanges.publish_in_details-rate, 'publish (in) rate')"
             },
             {
               "refId": "C",
-              "target": "alias(rabbitmq_%2F.exchanges-$Exchanges.publish_out_details-rate, 'publish (out) rate')"
+              "target": "alias(rabbitmq_default.exchanges-$Exchanges.publish_out_details-rate, 'publish (out) rate')"
             }
           ],
           "thresholds": [],
@@ -173,32 +173,32 @@
           "targets": [
             {
               "refId": "D",
-              "target": "alias(rabbitmq_%2F.queues-$Queues.messages_ready, 'messages ready')"
+              "target": "alias(rabbitmq_default.queues-$Queues.messages_ready, 'messages ready')"
             },
             {
               "refId": "E",
-              "target": "alias(rabbitmq_%2F.queues-$Queues.messages_unacknowledged, 'messages unacknowledged')"
+              "target": "alias(rabbitmq_default.queues-$Queues.messages_unacknowledged, 'messages unacknowledged')"
             },
             {
               "hide": false,
               "refId": "A",
-              "target": "alias(rabbitmq_%2F.queues-$Queues.publish_details-rate, 'publish')",
+              "target": "alias(rabbitmq_default.queues-$Queues.publish_details-rate, 'publish')",
               "textEditor": false
             },
             {
               "hide": false,
               "refId": "B",
-              "target": "alias(rabbitmq_%2F.queues-$Queues.ack_details-rate, 'ack')"
+              "target": "alias(rabbitmq_default.queues-$Queues.ack_details-rate, 'ack')"
             },
             {
               "hide": false,
               "refId": "C",
-              "target": "alias(rabbitmq_%2F.queues-$Queues.deliver_details-rate, 'deliver')"
+              "target": "alias(rabbitmq_default.queues-$Queues.deliver_details-rate, 'deliver')"
             },
             {
               "hide": false,
               "refId": "F",
-              "target": "alias(rabbitmq_%2F.queues-$Queues.redeliver_details-rate, 'redeliver')"
+              "target": "alias(rabbitmq_default.queues-$Queues.redeliver_details-rate, 'redeliver')"
             }
           ],
           "thresholds": [],
@@ -261,7 +261,7 @@
         "multi": true,
         "name": "Queues",
         "options": [],
-        "query": "rabbitmq_%2F.queues-*",
+        "query": "rabbitmq_default.queues-*",
         "refresh": 1,
         "regex": "/queues-(.*)/",
         "sort": 1,
@@ -281,7 +281,7 @@
         "multi": true,
         "name": "Exchanges",
         "options": [],
-        "query": "rabbitmq_%2F.exchanges-*",
+        "query": "rabbitmq_default.exchanges-*",
         "refresh": 1,
         "regex": "/exchanges-(.*)/",
         "sort": 1,

--- a/modules/grafana/files/dashboards_aws/search_api_elasticsearch.json
+++ b/modules/grafana/files/dashboards_aws/search_api_elasticsearch.json
@@ -318,7 +318,7 @@
             {
               "hide": false,
               "refId": "B",
-              "target": "rabbitmq_%2F.queues-search_api*.messages_*",
+              "target": "rabbitmq_default.queues-search_api*.messages_*",
               "textEditor": true
             }
           ],
@@ -395,7 +395,7 @@
           "targets": [
             {
               "refId": "A",
-              "target": "rabbitmq_%2F.queues-search_api*.deliver_details-rate",
+              "target": "rabbitmq_default.queues-search_api*.deliver_details-rate",
               "textEditor": false
             }
           ],

--- a/modules/grafana/files/dashboards_aws/search_api_queues.json
+++ b/modules/grafana/files/dashboards_aws/search_api_queues.json
@@ -209,7 +209,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "alias(consolidateBy(summarize(rabbitmq_%2F.queues-search_api_to_be_indexed.messages_ready, '10s', 'max'), 'max'), 'Unprocessed')",
+              "target": "alias(consolidateBy(summarize(rabbitmq_default.queues-search_api_to_be_indexed.messages_ready, '10s', 'max'), 'max'), 'Unprocessed')",
               "refId": "A"
             }
           ],


### PR DESCRIPTION
After updating the collectd-rabbitmq plugin to 1.20.0 the root key is now `rabbitmq_default` instead of `rabbitmq_%2F`. This updates Grafana dashboards to use the correct root key.