### PR TITLE
Use bowl to start up content data apps

### DIFF
--- a/development-vm/Pinfile
+++ b/development-vm/Pinfile
@@ -17,8 +17,8 @@ process :'collections-publisher' => [:'publishing-api', :'collections-publisher-
 process :'collections-publisher-worker'
 process :'contacts-admin' => [:'publishing-api', :whitehall]
 process :'content-audit-tool' => [:'publishing-api-read', :'content-audit-tool-sidekiq-google-analytics', :'content-audit-tool-sidekiq-publishing-api']
-process :'content-data' =>[:'content-performance-manager', :'content-data-sidekiq-default']
-process :'content-performance-manager' => [:'publishing-api', :'content-performance-manager-sidekiq-default', :'content-performance-manager-publishing-api-consumer', 'content-performance-manager-bulk-import-publishing-api-consumer', 'content-store']
+process :'content-data' =>[:'content-data-api', :'content-data-sidekiq-default']
+process :'content-data-api' => [:'publishing-api', :'content-data-api-sidekiq-default', :'content-data-api-publishing-api-consumer', 'content-data-api-bulk-import-publishing-api-consumer', 'content-store']
 process :'content-publisher' => [:'publishing-api', :'asset-manager']
 process :'content-store'
 # Example usage: bowl [your-app] dummy-content-store --without content-store

--- a/development-vm/Procfile
+++ b/development-vm/Procfile
@@ -182,7 +182,11 @@ search-api-publishing-listener:   govuk_setenv search-api ./run_in.sh ../../sear
 search-api-govuk-index-listener:  govuk_setenv search-api ./run_in.sh ../../search-api    bundle exec rake message_queue:insert_data_into_govuk
 search-api-bulk-reindex-listener: govuk_setenv search-api ./run_in.sh ../../search-api    bundle exec rake message_queue:bulk_insert_data_into_govuk
 # sidekiq-monitoring for search-api uses 3234
-content-data-api:      govuk_setenv content-data-api ./run_in.sh ../../content-data-api bundle exec rails server -p 3235
+content-data-api:      govuk_setenv content-data-api ./run_in.sh ../../content-performance-manager bundle exec rails server -p 3235
+
+content-data-api-publishing-api-consumer: govuk_setenv content-data-api ./run_in.sh ../../content-performance-manager bundle exec rake publishing_api:consumer
+content-data-api-bulk-import-publishing-api-consumer: govuk_setenv content-data-api ./run_in.sh ../../content-performance-manager bundle exec rake publishing_api:bulk_import_consumer
+content-data-api-sidekiq-default:  govuk_setenv content-data-api ./run_in.sh ../../content-performance-manager bundle exec sidekiq -C ./config/sidekiq/default.yml
 # sidekiq-monitoring for content-publisher uses 3236
 # byebug web listener for content-publisher uses 3237
 # byebug sidekiq listener for content-publisher uses 3238

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -34,8 +34,7 @@ govuk::node::s_development::apps:
   - 'contacts'
   - 'content_audit_tool'
   - 'content_data_api'
-  - 'content_performance_manager'
-  - 'content_performance_manager::rabbitmq'
+  - 'content_data_api::rabbitmq'
   - 'content_publisher'
   - 'content_store'
   - 'content_store::enable_running_in_draft_mode'
@@ -103,11 +102,13 @@ govuk::apps::ckan::priority_worker_processes: '1'
 govuk::apps::ckan::bulk_worker_processes: '1'
 govuk::apps::collections_publisher::enable_procfile_worker: false
 govuk::apps::contacts::extra_aliases: ['contacts-admin']
+govuk::apps::content_data_admin::enabled: true
 govuk::apps::content_store::mongodb_nodes: ['localhost']
 govuk::apps::content_store::mongodb_name: 'content_store_development'
-govuk::apps::content_performance_manager::rabbitmq_user: 'content_performance_manager'
-govuk::apps::content_performance_manager::rabbitmq_hosts: ['localhost']
-govuk::apps::content_performance_manager::rabbitmq::amqp_pass: 'content_performance_manager'
+govuk::apps::content_data_api::rabbitmq_user: 'content_data_api'
+govuk::apps::content_data_api::rabbitmq_hosts: ['localhost']
+govuk::apps::content_data_api::rabbitmq::amqp_pass: 'content_data_api'
+govuk::apps::content_data_api::rabbitmq_password: "%{hiera('govuk::apps::content_data_api::rabbitmq::amqp_pass')}"
 govuk::apps::content_publisher::enabled: true
 govuk::apps::content_tagger::enable_procfile_worker: false
 govuk::apps::email_alert_api::enable_procfile_worker: false
@@ -262,7 +263,6 @@ hosts::development::apps:
   - 'contacts-admin'
   - 'content-data-admin'
   - 'content-data-api'
-  - 'content-performance-manager'
   - 'content-publisher'
   - 'content-store'
   - 'content-tagger'


### PR DESCRIPTION
- Replace references to content-performance-manager to content-data-api
- Set up development environment for content-data-api when running govuk_puppet