### PR TITLE
set the number days to keep the cdn logs

### DIFF
--- a/modules/govuk_cdnlogs/manifests/init.pp
+++ b/modules/govuk_cdnlogs/manifests/init.pp
@@ -24,6 +24,9 @@
 #   0: do not expect encrypted connection
 #   1: expect encrypted connection
 #
+# [*days_to_keep*]
+#   The number of days to keep the logs, default is 2 days
+#
 
 class govuk_cdnlogs (
   $log_dir,
@@ -35,6 +38,7 @@ class govuk_cdnlogs (
   $server_crt,
   $use_tls = '1' ,
   $service_port_map,
+  $days_to_keep = 2,
 ) {
   validate_hash($service_port_map)
   $ports = join(values($service_port_map), ',')

--- a/modules/govuk_cdnlogs/spec/classes/govuk_cdnlogs_spec.rb
+++ b/modules/govuk_cdnlogs/spec/classes/govuk_cdnlogs_spec.rb
@@ -103,7 +103,7 @@ ruleset\(name="cdn-giraffe"\) \{
       it 'should rotate the giraffe logs hourly' do
         is_expected.to contain_file('/etc/logrotate.cdn_logs_hourly.conf')
           .with_content(%r{^/tmp/logs/cdn-giraffe\.log$})
-          .with_content(/rotate 1/)
+          .with_content(/rotate 2/)
       end
 
       it 'should rotate the elephant logs hourly' do

--- a/modules/govuk_cdnlogs/templates/etc/logrotate.cdn_logs_hourly.conf.erb
+++ b/modules/govuk_cdnlogs/templates/etc/logrotate.cdn_logs_hourly.conf.erb
@@ -8,7 +8,8 @@ to_rotate_hourly.map { |name| "#{ @log_dir }/cdn-#{ name }.log" }.join("\n")
 
 {
   su root deploy
-  rotate 1
+  daily
+  rotate <%= @days_to_keep %>
   dateext
   dateformat -%Y%m%d-%s
   compress


### PR DESCRIPTION
# Context

The CDN logs in AWS monitoring machine should be limited to only a few days because the long term storage of the logs are in S3 and the logs in AWS monitoring machine is to get live logs from fastly to debug the website.

# Decisions
1. rotate the logs on a daily basis and keep them for up to 2 days