### PR TITLE
Update old comment in hieradata/vagrant.yaml

### DIFF
--- a/hieradata/vagrant.yaml
+++ b/hieradata/vagrant.yaml
@@ -1,5 +1,5 @@
 ---
-# These credentials apply only to vagrant machines created with https://github.com/alphagov/vagrant-govuk
+# This hieradata relates to the Vagrantfile in govuk-puppet
 
 app_domain: 'dev.gov.uk'
 


### PR DESCRIPTION
The repository this comment points to is archived, and I believe the
Vagrantfile now sits in govuk-puppet, but I'm not too sure.