### PR TITLE
Restore Icinga Slack notifications

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -575,6 +575,10 @@ monitoring::checks::ses::region: us-east-1
 monitoring::checks::smokey::environment: 'production'
 monitoring::contacts::notify_graphite: true
 monitoring::contacts::notify_pager: true
+monitoring::contacts::notify_slack: true
+monitoring::contacts::slack_channel: '#govuk-alerts'
+monitoring::contacts::slack_username: 'Carrenza Production'
+monitoring::contacts::slack_alert_url: "https://alert.%{hiera('app_domain')}/cgi-bin/icinga/status.cgi"
 monitoring::edge::enabled: true
 monitoring::uptime_collector::environment: 'production'
 

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -258,6 +258,10 @@ monitoring::checks::rds::region: 'eu-west-1'
 monitoring::checks::cache::region: 'eu-west-1'
 monitoring::contacts::notify_graphite: true
 monitoring::contacts::notify_pager: true
+monitoring::contacts::notify_slack: true
+monitoring::contacts::slack_channel: '#govuk-alerts'
+monitoring::contacts::slack_username: 'AWS Production'
+monitoring::contacts::slack_alert_url: "https://alert.%{hiera('app_domain')}/cgi-bin/icinga/status.cgi"
 monitoring::edge::enabled: true
 monitoring::pagerduty_drill::enabled: true
 

--- a/modules/icinga/manifests/config/slack.pp
+++ b/modules/icinga/manifests/config/slack.pp
@@ -1,7 +1,7 @@
 # FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
 class icinga::config::slack {
   package {'icinga-slack-webhook':
-    ensure   => '1.0.1',
+    ensure   => '2.0.0',
     provider => 'pip',
   }
 }

--- a/modules/icinga/manifests/slack_contact.pp
+++ b/modules/icinga/manifests/slack_contact.pp
@@ -1,7 +1,6 @@
 # FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
 define icinga::slack_contact (
-  $slack_subdomain,
-  $slack_token,
+  $slack_webhook_url,
   $slack_channel,
   $slack_username = 'Icinga',
   $nagios_cgi_url = 'https://example.org/cgi-bin/icinga/status.cgi'

--- a/modules/icinga/templates/slack_contact.cfg.erb
+++ b/modules/icinga/templates/slack_contact.cfg.erb
@@ -1,6 +1,6 @@
 define contact {
        contact_name                             <%= @name %>
-       alias                                    <%= @slack_subdomain %>.slack.com/<%= @slack_channel %>
+       alias                                    gds.slack.com/<%= @slack_channel %>
        service_notification_period              24x7
        host_notification_period                 24x7
        service_notification_options             w,c,r,f
@@ -12,11 +12,11 @@ define contact {
 # 'notify-host-by-slack' command definition
 define command{
     command_name    notify-host-by-slack
-    command_line    /usr/local/bin/icinga_slack_webhook_notify -s <%= @slack_subdomain %> -t <%= @slack_token %> -c '<%= @slack_channel %>' -U '<%= @slack_username %>' -m '$HOSTDISPLAYNAME$ is $HOSTSTATE$' -H '$HOSTDISPLAYNAME$' -A '$HOSTACTIONURL$' -N '$HOSTNOTESURL$' -S '<%= @nagios_cgi_url %>'
+    command_line    /usr/local/bin/icinga_slack_webhook_notify -u <%= @slack_webhook_url %> -c '<%= @slack_channel %>' -U '<%= @slack_username %>' -m '$HOSTDISPLAYNAME$ is $HOSTSTATE$' -H '$HOSTDISPLAYNAME$' -A '$HOSTACTIONURL$' -N '$HOSTNOTESURL$' -S '<%= @nagios_cgi_url %>'
 }
 
 # 'notify-service-by-slack' command definition
 define command{
     command_name    notify-service-by-slack
-    command_line    /usr/local/bin/icinga_slack_webhook_notify -s <%= @slack_subdomain %> -t <%= @slack_token %> -c '<%= @slack_channel %>' -U '<%= @slack_username %>' -m '$SERVICEDESC$' -H '$HOSTDISPLAYNAME$' -A '$SERVICEACTIONURL$' -N '$SERVICENOTESURL$' -L $SERVICESTATE$ -S '<%= @nagios_cgi_url %>'
+    command_line    /usr/local/bin/icinga_slack_webhook_notify -t <%= @slack_webhook_url %> -c '<%= @slack_channel %>' -U '<%= @slack_username %>' -m '$SERVICEDESC$' -H '$HOSTDISPLAYNAME$' -A '$SERVICEACTIONURL$' -N '$SERVICENOTESURL$' -L $SERVICESTATE$ -S '<%= @nagios_cgi_url %>'
 }

--- a/modules/monitoring/spec/classes/contacts_spec.rb
+++ b/modules/monitoring/spec/classes/contacts_spec.rb
@@ -35,6 +35,25 @@ describe 'monitoring::contacts', :type => :class do
       []
   end
 
+  context 'notify_pager => true, notify_slack => true, slack creds' do
+    let(:params) {{
+      :notify_pager       => true,
+      :notify_slack       => true,
+      :slack_webhook_url  => 'peach',
+      :slack_channel      => 'pear',
+    }}
+
+    it { is_expected.to contain_icinga__slack_contact('slack_notification').with(
+      :slack_webhook_url => 'peach',
+      :slack_channel     => 'pear',
+    )}
+
+    it_should_behave_like 'configured contact groups',
+      ['slack_notification', 'pagerduty_24x7'],
+      ['slack_notification'],
+      ['slack_notification']
+  end
+
   context 'notify_graphite => true' do
     let(:params) {{
       :notify_graphite => true,


### PR DESCRIPTION
These may be useful in making people more aware of when alerts occur.

I'm also looking at this as a way of making alerts more visible to
specific teams, but I want to get something rough and general working
first.

This has worked in the past, but I think probably broke when the Slack
instance changed, or the Slack API changed.

This depends on https://github.com/alphagov/govuk-secrets/pull/696