### PR TITLE
Change default dockerised elasticsearch port to 9200

### DIFF
--- a/development-vm/replication/sync-aws-elasticsearch.sh
+++ b/development-vm/replication/sync-aws-elasticsearch.sh
@@ -17,7 +17,7 @@ fi
 
 shift $((OPTIND-1))
 
-LOCAL_ES_HOST="http://localhost:9205/"
+LOCAL_ES_HOST="http://localhost:9200/"
 LOCAL_ARCHIVE_PATH="${DIR}/elasticsearch"
 
 status "Starting search index replication from AWS"
@@ -102,7 +102,7 @@ else
   sudo docker cp "/var/govuk/govuk-puppet/development-vm/replication/${LOCAL_ARCHIVE_PATH}/." elasticsearch:/usr/share/elasticsearch/import/
 
   # setup the snapshot details on the server
-  curl localhost:9205/_snapshot/snapshots -X PUT -d "{
+  curl localhost:9200/_snapshot/snapshots -X PUT -d "{
     \"type\": \"fs\",
     \"settings\": {
       \"compress\": true,
@@ -111,10 +111,10 @@ else
   }"
 
   # get the snapshot name
-  SNAPSHOT_NAME=$(curl localhost:9205/_snapshot/snapshots/_all | ruby -e 'require "json"; STDOUT << (JSON.parse(STDIN.read)["snapshots"].map { |a| a["snapshot"] }.sort.last)')
+  SNAPSHOT_NAME=$(curl localhost:9200/_snapshot/snapshots/_all | ruby -e 'require "json"; STDOUT << (JSON.parse(STDIN.read)["snapshots"].map { |a| a["snapshot"] }.sort.last)')
 
   # restore the snapshot
-  curl "localhost:9205/_snapshot/snapshots/${SNAPSHOT_NAME}/_restore?wait_for_completion=true" -X POST
+  curl "localhost:9200/_snapshot/snapshots/${SNAPSHOT_NAME}/_restore?wait_for_completion=true" -X POST
 
   status ""
   status "Remove alises from old indices and archiving"

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -153,7 +153,7 @@ govuk::apps::router_api::router_nodes: ['localhost:3055']
 govuk::apps::router_api::enable_running_in_draft_mode::mongodb_name: 'draft_router'
 govuk::apps::router_api::enable_running_in_draft_mode::mongodb_nodes: ['localhost']
 govuk::apps::router_api::enable_running_in_draft_mode::router_nodes: ['localhost:3134']
-govuk::apps::search_api::elasticsearch_hosts: 'http://localhost:9205'
+govuk::apps::search_api::elasticsearch_hosts: 'http://localhost:9200'
 govuk::apps::search_api::enable_procfile_worker: false
 govuk::apps::search_api::rabbitmq_hosts: ['localhost']
 govuk::apps::search_api::rabbitmq_user: 'search-api'

--- a/modules/govuk_ci/manifests/agent/elasticsearch.pp
+++ b/modules/govuk_ci/manifests/agent/elasticsearch.pp
@@ -4,8 +4,5 @@
 #
 class govuk_ci::agent::elasticsearch {
   include ::govuk_docker
-
-  class { '::govuk_containers::elasticsearch':
-    elasticsearch_port => '9200',
-  }
+  include ::govuk_containers::elasticsearch
 }

--- a/modules/govuk_containers/manifests/elasticsearch.pp
+++ b/modules/govuk_containers/manifests/elasticsearch.pp
@@ -16,7 +16,7 @@
 class govuk_containers::elasticsearch(
   $image_name = 'elastic/elasticsearch',
   $image_version = '5.6.15',
-  $elasticsearch_port = '9205',
+  $elasticsearch_port = '9200',
 ) {
 
   file { '/etc/elasticsearch-docker.yml':


### PR DESCRIPTION
We used 9205 because there was a non-dockerised ES listening on that port, but now that is gone.