### PR TITLE
[do not merge] Use search-api /healthcheck endpoint for checks

### DIFF
--- a/modules/govuk/manifests/apps/search_api.pp
+++ b/modules/govuk/manifests/apps/search_api.pp
@@ -108,7 +108,9 @@ class govuk::apps::search_api(
     app_type                 => 'rack',
     port                     => $port,
     sentry_dsn               => $sentry_dsn,
-    health_check_path        => '/search?q=search_healthcheck',
+    health_check_path        => '/healthcheck',
+    expose_health_check      => false,
+    json_health_check        => true,
 
     vhost_aliases            => ['search'],
 


### PR DESCRIPTION
**Note**: This should be merged after https://github.com/alphagov/search-api/pull/1538 and we are happy that the endpoint is working OK.

This will make Icinga check the JSON response of the `/healthcheck` endpoint that will be added to the search-api.

Trello: https://trello.com/c/cNvfdZfU/372