### PR TITLE
Check dockerised elasticsearch is running via TCP

### DIFF
--- a/modules/govuk_containers/files/nrpe_check_dockerised_elasticsearch_responding.cfg
+++ b/modules/govuk_containers/files/nrpe_check_dockerised_elasticsearch_responding.cfg
@@ -1,0 +1,1 @@
+command[check_dockerised_elasticsearch_responding]=/usr/lib/nagios/plugins/check_tcp -H 127.0.0.1 -p $ARG1$ -w 5 -c 10

--- a/modules/govuk_containers/manifests/elasticsearch.pp
+++ b/modules/govuk_containers/manifests/elasticsearch.pp
@@ -38,10 +38,13 @@ class govuk_containers::elasticsearch(
     volumes => ['esdata5:/usr/share/elasticsearch/data', 'dataimport:/usr/share/elasticsearch/import', '/etc/elasticsearch-docker.yml:/usr/share/elasticsearch/config/elasticsearch.yml'],
   }
 
-  @@icinga::check { "check_elasticsearch_running_${::hostname}":
-    check_command       => 'check_nrpe!check_proc_running!elasticsearch',
-    service_description => 'dockerised elasticsearch running',
+  @icinga::nrpe_config { 'check_dockerised_elasticsearch_responding':
+    source => 'puppet:///modules/govuk_containers/nrpe_check_dockerised_elasticsearch_responding.cfg',
+  }
+
+  @@icinga::check { 'check_dockerised_elasticsearch_responding':
+    check_command       => "check_nrpe!check_dockerised_elasticsearch_responding!${elasticsearch_port}",
+    service_description => 'dockerised elasticsearch port not responding',
     host_name           => $::fqdn,
-    notes_url           => monitoring_docs_url(check-process-running),
   }
 }


### PR DESCRIPTION
I couldn't get the check_proc_running check to pick up the dockerised
elasticsearch, so this does the next best (arguably even better)
thing.

---

[Trello card](https://trello.com/c/1jHfm7X9/702-fix-es-alerts-in-ci)