### PR TITLE
Disable cache_clearing_service in Carrenza

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -343,6 +343,7 @@ govuk::apps::cache_clearing_service::enabled: false
 govuk::apps::cache_clearing_service::nagios_memory_warning: 2750
 govuk::apps::cache_clearing_service::nagios_memory_critical: 3000
 govuk::apps::cache_clearing_service::puppetdb_node_url: 'http://puppetdb.cluster/v2/nodes'
+govuk::apps::cache_clearing_service::rabbitmq::enabled: false
 govuk::apps::cache_clearing_service::rabbitmq_hosts:
   - rabbitmq-1.backend
   - rabbitmq-2.backend

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -339,7 +339,7 @@ govuk::apps::bouncer::nagios_memory_warning: 1400
 govuk::apps::bouncer::nagios_memory_critical: 1500
 govuk::apps::bouncer::unicorn_worker_processes: "8"
 
-govuk::apps::cache_clearing_service::enabled: true
+govuk::apps::cache_clearing_service::enabled: false
 govuk::apps::cache_clearing_service::nagios_memory_warning: 2750
 govuk::apps::cache_clearing_service::nagios_memory_critical: 3000
 govuk::apps::cache_clearing_service::puppetdb_node_url: 'http://puppetdb.cluster/v2/nodes'

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -15,6 +15,8 @@ govuk::deploy::setup::ssh_keys:
 
 govuk::app::nginx_vhost::asset_pipeline_enabled: false
 
+govuk::apps::cache_clearing_service::enabled: true
+
 govuk::node::s_development::apps:
   - 'asset_manager'
   - 'authenticating_proxy'

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -16,6 +16,7 @@ govuk::deploy::setup::ssh_keys:
 govuk::app::nginx_vhost::asset_pipeline_enabled: false
 
 govuk::apps::cache_clearing_service::enabled: true
+govuk::apps::cache_clearing_service::rabbitmq::enabled: true
 
 govuk::node::s_development::apps:
   - 'asset_manager'

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -369,6 +369,7 @@ govuk::apps::bouncer::unicorn_worker_processes: "8"
 govuk::apps::cache_clearing_service::enabled: true
 govuk::apps::cache_clearing_service::nagios_memory_warning: 2750
 govuk::apps::cache_clearing_service::nagios_memory_critical: 3000
+govuk::apps::cache_clearing_service::rabbitmq::enabled: true
 govuk::apps::cache_clearing_service::rabbitmq_hosts: [rabbitmq]
 govuk::apps::cache_clearing_service::rabbitmq::queue_size_critical_threshold: 100000
 govuk::apps::cache_clearing_service::rabbitmq::queue_size_warning_threshold: 80000


### PR DESCRIPTION
This service has been migrated to AWS

solo: @schmie