### PR TITLE
Fix the govuk_env_sync::conf_dir being declared twice

### DIFF
--- a/modules/govuk_env_sync/manifests/aws_auth.pp
+++ b/modules/govuk_env_sync/manifests/aws_auth.pp
@@ -12,7 +12,7 @@ class govuk_env_sync::aws_auth(
   $aws_region = $govuk_env_sync::aws_region
   $app_domain_internal = hiera('app_domain_internal')
 
-  file { [$conf_dir,"${conf_dir}/env.d"]:
+  file { "${conf_dir}/env.d":
     ensure => directory,
     owner  => $user,
     group  => $user,

--- a/modules/govuk_env_sync/manifests/init.pp
+++ b/modules/govuk_env_sync/manifests/init.pp
@@ -15,6 +15,9 @@ class govuk_env_sync(
     recurse => true,
     purge   => true,
     force   => true,
+    owner   => $user,
+    group   => $user,
+    mode    => '0770',
   }
 
   create_resources(govuk_env_sync::task, $tasks)


### PR DESCRIPTION
Copy the owner, group and mode values from the aws_auth class to the
govuk_env_sync class, and remove the $conf_dir management from the
aws_auth class.