### PR TITLE
Ensure absent "dockerised elasticsearch running" alert

### DIFF
--- a/modules/govuk_containers/manifests/elasticsearch.pp
+++ b/modules/govuk_containers/manifests/elasticsearch.pp
@@ -47,4 +47,12 @@ class govuk_containers::elasticsearch(
     service_description => 'dockerised elasticsearch port not responding',
     host_name           => $::fqdn,
   }
+
+  # todo: remove
+  @@icinga::check { "check_elasticsearch_running_${::hostname}":
+    ensure              => 'absent',
+    check_command       => 'check_nrpe!check_proc_running!elasticsearch',
+    service_description => 'dockerised elasticsearch running',
+    notes_url           => monitoring_docs_url(check-process-running),
+  }
 }


### PR DESCRIPTION
I removed this alert, but it's still failing in Icinga.  Putting it
back to ensure-absent it.