### PR TITLE
Remove some confusing node_class hieradata

### DIFF
--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -67,10 +67,6 @@ node_class: &node_class
       - service-manual-frontend
       - smartanswers
       - static
-  email_alert_api:
-    apps:
-      - email-alert-api
-      - email-alert-service
   frontend:
     apps:
       - canary-frontend
@@ -89,21 +85,12 @@ node_class: &node_class
   mirrorer:
     apps:
       - govuk-crawler-worker
-  publishing_api:
-    apps:
-      - publishing-api
   router_backend:
     apps:
       - router-api
   search:
     apps:
       - search-api
-  whitehall_backend:
-    apps:
-      - whitehall
-  whitehall_frontend:
-    apps:
-      - whitehall
 
 govuk::node::s_base::node_apps:
   <<: *node_class

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -67,10 +67,6 @@ node_class: &node_class
       - service-manual-frontend
       - smartanswers
       - static
-  email_alert_api:
-    apps:
-      - email-alert-api
-      - email-alert-service
   frontend:
     apps:
       - canary-frontend
@@ -89,21 +85,12 @@ node_class: &node_class
   mirrorer:
     apps:
       - govuk-crawler-worker
-  publishing_api:
-    apps:
-      - publishing-api
   router_backend:
     apps:
       - router-api
   search:
     apps:
       - search-api
-  whitehall_backend:
-    apps:
-      - whitehall
-  whitehall_frontend:
-    apps:
-      - whitehall
 
 govuk::node::s_base::node_apps:
   <<: *node_class


### PR DESCRIPTION
From AWS Staging and AWS Production. This configuration suggests that
there are publishing_api, email_alert_api, whitehall_backend and
whitehall_frontend machines in these environments, and that we're
running applications on them.

This is confusing, as these machines do not exist, so the applications
cannot be running on them.

As I don't know when this will likely change, lets remove the
configuration so that the hieradata overall is simpler.