### PR TITLE
Fix the icinga-slack-webhook to be installed with pip3

### DIFF
--- a/modules/icinga/manifests/config/slack.pp
+++ b/modules/icinga/manifests/config/slack.pp
@@ -2,6 +2,6 @@
 class icinga::config::slack {
   package {'icinga-slack-webhook':
     ensure   => '2.0.0',
-    provider => 'pip',
+    provider => pip3,
   }
 }


### PR DESCRIPTION
Hopefully this will generate an entrypoint that uses Python 3 (rather
than Python 2).