### PR TITLE
Push staging ES backup to integration after pulling from production

### DIFF
--- a/hieradata_aws/class/staging/search.yaml
+++ b/hieradata_aws/class/staging/search.yaml
@@ -1,7 +1,10 @@
+# the "pull" is intentionally before the "push", so both integration
+# and staging will be based on the same production snapshot (rather
+# than integration being a day behind).
 govuk_env_sync::tasks:
   "pull_es_everything_daily":
     ensure: "present"
-    hour: "2"
+    hour: "1"
     minute: "24"
     action: "pull"
     dbms: "elasticsearch5"
@@ -12,7 +15,7 @@ govuk_env_sync::tasks:
     path: "elasticsearch5"
   "push_es_everything_daily":
     ensure: "present"
-    hour: "1"
+    hour: "2"
     minute: "24"
     action: "push"
     dbms: "elasticsearch5"


### PR DESCRIPTION
At the moment, staging is based on production data from day (now-1)
and integration is based on staging data from day (now-1), so
integration is 2 days behind production.  By flipping the order of the
staging push & pull, integration will be based on the same production
snapshot as staging.

We don't want to give integration access to the govuk-production
snapshot repository, because then integration could *write* to the
production bucket, and an error in the env sync configuration could
result in production restoring data generated from integration.