### PR TITLE
force restart of collectd if stucked

### DIFF
--- a/modules/collectd/manifests/service.pp
+++ b/modules/collectd/manifests/service.pp
@@ -5,5 +5,6 @@
 class collectd::service {
   service { 'collectd':
     ensure  => running,
+    restart => '/etc/init.d/collectd restart || { pkill -9 collectdmon; /etc/init.d/collectd start; }',
   }
 }


### PR DESCRIPTION
# Context

Sometimes, puppet can't do a service refresh for collectd. Hence, we propose to kill collectd if service refresh fails.

# Decisions
1. if service refresh fails, force kill collectdmon (which will kill collectd) and restart it.

