### PR TITLE
only exec install docker if not present

### DIFF
--- a/modules/collectd/manifests/plugin/docker.pp
+++ b/modules/collectd/manifests/plugin/docker.pp
@@ -33,6 +33,7 @@ class collectd::plugin::docker(
     path    => ['/usr/local/bin', '/usr/bin', '/bin'],
     command => 'pip install "docker<=2.6.1"',
     notify  => Class['collectd::service'],
+    unless  => 'pip list | grep "docker (2.6.1)"',
   }
 
   package { 'docker-py':


### PR DESCRIPTION
# Context

Docker is "reinstalled" at each puppet run via a puppet exec command. This is not desired because it causes collectd to refresh.

# Decisions
1. Only install docker if not present, i.e. only exec the command if docker is not present