### PR TITLE
Update dashboards parameter CI Integration

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -145,7 +145,7 @@ govuk_sudo::sudo_conf:
 govuk_ppa::path: 'preview'
 
 grafana::dashboards::machine_suffix_metrics: '_integration'
-grafana::dashboards::application_dashboards: []
+grafana::dashboards::application_dashboards: {}
 
 hosts::production::ip_api_lb: '10.1.4.254'
 hosts::production::ip_backend_lb: '10.1.3.254'


### PR DESCRIPTION
Update 5c8587b

Puppet complains in the graphite-1 machine in CI Integration environment:

```
create_resources(): second argument must be a hash at
/usr/share/puppet/production/current/modules/grafana/manifests/dashboards.pp:39
on node graphite-1.management.integration.publishing.service.gov.uk
```