### PR TITLE
Fix Content Data API Overiew dashboard

### DIFF
--- a/modules/grafana/files/dashboards/content-data-overview.json
+++ b/modules/grafana/files/dashboards/content-data-overview.json
@@ -64,7 +64,7 @@
                   "field": "@timestamp",
                   "id": "2",
                   "settings": {
-                    "interval": "auto",
+                    "interval": "5m",
                     "min_doc_count": 0,
                     "trimEdges": 0
                   },
@@ -160,7 +160,7 @@
                   "field": "@timestamp",
                   "id": "2",
                   "settings": {
-                    "interval": "auto",
+                    "interval": "5m",
                     "min_doc_count": 0,
                     "trimEdges": 0
                   },
@@ -198,7 +198,7 @@
                   "field": "@timestamp",
                   "id": "2",
                   "settings": {
-                    "interval": "auto",
+                    "interval": "5m",
                     "min_doc_count": 0,
                     "trimEdges": 0
                   },
@@ -294,7 +294,7 @@
                   "field": "@timestamp",
                   "id": "2",
                   "settings": {
-                    "interval": "auto",
+                    "interval": "5m",
                     "min_doc_count": 0,
                     "trimEdges": 0
                   },
@@ -332,7 +332,7 @@
                   "field": "@timestamp",
                   "id": "2",
                   "settings": {
-                    "interval": "auto",
+                    "interval": "5m",
                     "min_doc_count": 0,
                     "trimEdges": 0
                   },
@@ -376,7 +376,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             },
             {
@@ -602,7 +602,7 @@
                   "type": "max"
                 }
               ],
-              "query": "application: content-data-api AND duration: { 2000 TO * }",
+              "query": "application: content-data-api AND duration: { 1000 TO * }",
               "refId": "A",
               "timeField": "@timestamp"
             }
@@ -610,7 +610,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Slowest response times for endpoints",
+          "title": "Endpoints with <1s latency",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -832,7 +832,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "Cloudwatch",
+          "datasource": "CloudWatch",
           "fill": 1,
           "id": 10,
           "legend": {
@@ -917,7 +917,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "Cloudwatch",
+          "datasource": "CloudWatch",
           "fill": 1,
           "id": 12,
           "legend": {
@@ -1001,7 +1001,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "Cloudwatch",
+          "datasource": "CloudWatch",
           "decimals": 2,
           "fill": 1,
           "id": 13,
@@ -1098,7 +1098,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "Cloudwatch",
+          "datasource": "CloudWatch",
           "fill": 1,
           "id": 15,
           "legend": {
@@ -1183,7 +1183,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "Cloudwatch",
+          "datasource": "CloudWatch",
           "fill": 1,
           "id": 16,
           "legend": {
@@ -1267,7 +1267,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "Cloudwatch",
+          "datasource": "CloudWatch",
           "decimals": 2,
           "fill": 1,
           "id": 17,


### PR DESCRIPTION
This PR includes the following changes:
- Fixed CloudWatch data source that had been incorrectly titled in capitalised. 
- Tweaked the of request rate displayed.
- Lower threshold of long latency requests to 1s