### PR TITLE
Add eu-west-2 (London) aws region to monitoring module

### DIFF
--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_cache_cpu
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_cache_cpu
@@ -63,7 +63,7 @@ import datetime
 # Passing acceptable parameters #
 #################################
 parser = argparse.ArgumentParser()
-parser.add_argument("-r","--region", type=str, choices=['us-east-1','eu-west-1'], help="AWS region to check")
+parser.add_argument("-r","--region", type=str, choices=['us-east-1','eu-west-1','eu-west-2'], help="AWS region to check")
 parser.add_argument("-w","--warning", type=float, help="Percentage at which to raise a warning alert (80)", default=80)
 parser.add_argument("-c","--critical", type=float, help="Percentage at which to raise a critical alert (90)", default=90)
 parser.add_argument("-i","--instanceid", type=str, help="Instanceid", default=0)
@@ -101,7 +101,7 @@ except boto.exception.BotoServerError as err:
 #                'CacheClusters']						#
 # pprint.pprint(cluster_info)							#
 #										#
-# To view the details for a specific member, you can use index numbers. For 	#				
+# To view the details for a specific member, you can use index numbers. For 	#
 # example [0] is will match the first member. To do this, uncomment the two 	#
 # lines below and replace the number to suit your need.				#
 #										#

--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_cache_memory
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_cache_memory
@@ -64,7 +64,7 @@ import datetime
 # Passing acceptable parameters #
 #################################
 parser = argparse.ArgumentParser()
-parser.add_argument("-r","--region", type=str, choices=['us-east-1','eu-west-1'], help="AWS region to check")
+parser.add_argument("-r","--region", type=str, choices=['us-east-1','eu-west-1','eu-west-2'], help="AWS region to check")
 parser.add_argument("-w","--warning", type=float, help="Value(GB) at which to raise a warning alert (8.0)", default=8.0)
 parser.add_argument("-c","--critical", type=float, help="Value(GB) at which to raise a critical alert (9.0)", default=9.0)
 parser.add_argument("-i","--instanceid", type=str, help="Instanceid", default=0)
@@ -102,7 +102,7 @@ except boto.exception.BotoServerError as err:
 #                'CacheClusters']						#
 # pprint.pprint(cluster_info)							#
 #										#
-# To view the details for a specific member, you can use index numbers. For 	#				
+# To view the details for a specific member, you can use index numbers. For 	#
 # example [0] is will match the first member. To do this, uncomment the two 	#
 # lines below and replace the number to suit your need.				#
 #										#

--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_quota
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_quota
@@ -5,7 +5,7 @@ import boto.ses
 import sys
 
 parser = argparse.ArgumentParser()
-parser.add_argument("-r","--region", type=str, choices=['us-east-1','eu-west-1'], help="AWS region to check")
+parser.add_argument("-r","--region", type=str, choices=['us-east-1','eu-west-1','eu-west-2'], help="AWS region to check")
 parser.add_argument("-a","--access_key", type=str, help="AWS access key")
 parser.add_argument("-s","--secret_key", type=str, help="AWS secret key")
 parser.add_argument("-w","--warning", type=int, help="Percentage at which to raise a warning alert (30)", default=30)
@@ -63,5 +63,3 @@ except Exception as e:
     sys.exit(3)
 
 sys.exit(0)
-
-

--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_rds_cpu
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_rds_cpu
@@ -28,8 +28,8 @@
 # 1) AWS Regions. This is called with '-r'                                    #
 # 2) Icinga warning value. This is called with '-w'                           #
 # 3) Icinga critical vale. This is called with '-c'                           #
-# 4) The AWS RDS Instance name. This is called with '-i'                      # 
-#                                                                             # 
+# 4) The AWS RDS Instance name. This is called with '-i'                      #
+#                                                                             #
 # Test                                                                        #
 # ----                                                                        #
 # You can test this script by following the steps below.                      #
@@ -63,7 +63,7 @@ import datetime
 # Passing acceptable parameters #
 #################################
 parser = argparse.ArgumentParser()
-parser.add_argument("-r","--region", type=str, choices=['us-east-1','eu-west-1'], help="AWS region to check")
+parser.add_argument("-r","--region", type=str, choices=['us-east-1','eu-west-1','eu-west-2'], help="AWS region to check")
 parser.add_argument("-w","--warning", type=float, help="Percentage at which to raise a warning alert (80)", default=80)
 parser.add_argument("-c","--critical", type=float, help="Percentage at which to raise a critical alert (90)", default=90)
 parser.add_argument("-i","--instanceid", type=str, help="Instanceid", default=0)

--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_rds_memory
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_rds_memory
@@ -64,7 +64,7 @@ import boto3
 # Passing acceptable parameters #
 #################################
 parser = argparse.ArgumentParser()
-parser.add_argument("-r","--region", type=str, choices=['us-east-1','eu-west-1'], help="AWS region to check")
+parser.add_argument("-r","--region", type=str, choices=['us-east-1','eu-west-1','eu-west-2'], help="AWS region to check")
 parser.add_argument("-w","--warning", type=float, help="Value(GB) at which to raise a warning alert (2.0)", default=2.0)
 parser.add_argument("-c","--critical", type=float, help="Value(GB) at which to raise a critical alert (1.0)", default=1.0)
 parser.add_argument("-i","--instanceid", type=str, help="Instanceid", default=0)

--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_rds_storage
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_rds_storage
@@ -28,8 +28,8 @@
 # 1) AWS Regions. This is called with '-r'                                    #
 # 2) Icinga warning value. This is called with '-w'                           #
 # 3) Icinga critical vale. This is called with '-c'                           #
-# 4) The AWS RDS Instance name. This is called with '-i'                      # 
-#                                                                             # 
+# 4) The AWS RDS Instance name. This is called with '-i'                      #
+#                                                                             #
 # Test                                                                        #
 # ----                                                                        #
 # You can test this script by following the steps below.                      #
@@ -64,7 +64,7 @@ import datetime
 # Passing acceptable parameters #
 #################################
 parser = argparse.ArgumentParser()
-parser.add_argument("-r","--region", type=str, choices=['us-east-1','eu-west-1'], help="AWS region to check")
+parser.add_argument("-r","--region", type=str, choices=['us-east-1','eu-west-1','eu-west-2'], help="AWS region to check")
 parser.add_argument("-w","--warning", type=float, help="Value(GB) at which to raise a warning alert (20.0)", default=20.0)
 parser.add_argument("-c","--critical", type=float, help="Percentage at which to raise a critical alert (10.0)", default=10.0)
 parser.add_argument("-i","--instanceid", type=str, help="Instanceid", default=0)


### PR DESCRIPTION
This is needed so that the checks will work in the
new training environment, which has been created in
the eu-west-2 region.