### PR TITLE
Make transition app absent in Carrenza

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -42,6 +42,7 @@ node_class: &node_class
       - specialist-publisher
       - support
       - support-api
+      - transition
       - support_api_csv_env_sync
       - travel-advice-publisher
   bouncer:
@@ -318,6 +319,8 @@ filebeat::prospectors:
       application: 'apt'
 
 gdal::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+
+govuk::apps::transition::ensure: 'absent'
 
 govuk::apps::asset_manager::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
 govuk::apps::asset_manager::mongodb_nodes:

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -347,6 +347,8 @@ filebeat::prospectors:
 
 gdal::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
+govuk::apps::transition::ensure: 'present'
+
 govuk::apps::asset_manager::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
 govuk::apps::asset_manager::mongodb_nodes:
   - 'mongo-1'


### PR DESCRIPTION
Update c7f3515

Transition has been migrated to AWS in staging/production. We need
to ensure the app resources are removed from the Carrenza machines
because there are cron jobs still trying to run tasks that are filling
disk space.