### PR TITLE
Make healthcheck timeouts create critical alerts

### DIFF
--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -380,7 +380,7 @@ define govuk::app::config (
   if $health_check_path != 'NOTSET' {
     @@icinga::check { "check_app_${title}_up_on_${::hostname}":
       ensure              => $ensure,
-      check_command       => "check_nrpe!check_app_up!${port} ${health_check_path}",
+      check_command       => "check_app_health!check_app_up!${port} ${health_check_path}",
       service_description => "${title} app healthcheck",
       host_name           => $::fqdn,
       notes_url           => monitoring_docs_url(app-healthcheck-failed),
@@ -393,7 +393,7 @@ define govuk::app::config (
 
       @@icinga::check { "check_app_${title}_healthcheck_on_${::hostname}":
         ensure              => $ensure,
-        check_command       => "check_nrpe!check_json_healthcheck!${port} ${health_check_path}",
+        check_command       => "check_app_health!check_json_healthcheck!${port} ${health_check_path}",
         service_description => $healthcheck_desc,
         use                 => $health_check_service_template,
         notification_period => $health_check_notification_period,

--- a/modules/govuk/manifests/apps/router.pp
+++ b/modules/govuk/manifests/apps/router.pp
@@ -56,7 +56,7 @@ class govuk::apps::router (
   # reverse proxy port, not the API port. Changing the port would lose us
   # TCP connection stats.
   @@icinga::check { "check_app_router_up_on_${::hostname}":
-    check_command       => "check_nrpe!check_app_up!${api_port} ${api_healthcheck}",
+    check_command       => "check_app_health!check_app_up!${api_port} ${api_healthcheck}",
     service_description => 'router app healthcheck',
     host_name           => $::fqdn,
     notes_url           => monitoring_docs_url(app-healthcheck-failed),

--- a/modules/govuk_containers/manifests/app.pp
+++ b/modules/govuk_containers/manifests/app.pp
@@ -95,7 +95,7 @@ define govuk_containers::app (
   if $healthcheck_path {
     @@icinga::check { "check_app_${title}_up_on_${::hostname}":
       ensure              => $ensure,
-      check_command       => "check_nrpe!check_app_up!${port} ${healthcheck_path}",
+      check_command       => "check_app_health!check_app_up!${port} ${healthcheck_path}",
       service_description => "${title} app healthcheck",
       host_name           => $::fqdn,
       notes_url           => monitoring_docs_url(app-healthcheck-failed),
@@ -108,7 +108,7 @@ define govuk_containers::app (
 
       @@icinga::check { "check_app_${title}_healthcheck_on_${::hostname}":
         ensure              => $ensure,
-        check_command       => "check_nrpe!check_json_healthcheck!${port} ${healthcheck_path}",
+        check_command       => "check_app_health!check_json_healthcheck!${port} ${healthcheck_path}",
         service_description => $healthcheck_desc,
         host_name           => $::fqdn,
         notes_url           => monitoring_docs_url($healthcheck_opsmanual),

--- a/modules/govuk_containers/manifests/apps/router.pp
+++ b/modules/govuk_containers/manifests/apps/router.pp
@@ -29,7 +29,7 @@ class govuk_containers::apps::router (
   # the API
   if $healthcheck_path {
     @@icinga::check { "check_app_router_up_on_${::hostname}":
-      check_command       => "check_nrpe!check_app_up!${api_port} ${healthcheck_path}",
+      check_command       => "check_app_health!check_app_up!${api_port} ${healthcheck_path}",
       service_description => 'router app healthcheck',
       host_name           => $::fqdn,
       notes_url           => monitoring_docs_url(app-healthcheck-failed),

--- a/modules/icinga/files/etc/nagios-plugins/config/check_nrpe.cfg
+++ b/modules/icinga/files/etc/nagios-plugins/config/check_nrpe.cfg
@@ -9,3 +9,10 @@ define command {
     command_name    check_nrpe_1arg
     command_line    /usr/lib/nagios/plugins/check_nrpe -H $HOSTADDRESS$ -t 20 -c $ARG1$ -u
 }
+
+# this command runs program $ARG1$ with arguments $ARG2$
+# it is for checking application health; timeouts should prompt critical alerts
+define command {
+    command_name    check_app_health
+    command_line    /usr/lib/nagios/plugins/check_nrpe -H $HOSTADDRESS$ -t 30 -c $ARG1$ -a $ARG2$
+}

--- a/modules/icinga/files/usr/lib/nagios/plugins/check_json_healthcheck
+++ b/modules/icinga/files/usr/lib/nagios/plugins/check_json_healthcheck
@@ -79,11 +79,11 @@ def url_from_arguments(arguments):
 
 def json_request(request_url):
     """Create a Request object suitable to pass into `urlopen`.
-    
+
     We can't just pass the URL itself into `urlopen`, because we need to add
     an explicit Accept header to be sure the apps we're checking will return a
     suitable response.
-    
+
     """
     return Request(request_url,
                    data=None,
@@ -118,11 +118,11 @@ class HealthCheckInfo(object):
     @property
     def check_statuses(self):
         """Return a list of strings summarising the status of each check.
-        
+
         For example:
-            
+
             ["sufficient_whizbangs - ok", "recently_dusted - warning"]
-        
+
         """
         checks = self._dict.get("checks", {})
         return [" - ".join(self._check_parts(check_name, check_value))
@@ -142,7 +142,7 @@ if __name__ == "__main__":
     check_url = url_from_arguments(sys.argv[1:])
 
     try:
-        with closing(urlopen(json_request(check_url), timeout=10)) as response:
+        with closing(urlopen(json_request(check_url), timeout=20)) as response:
             healthcheck_info = HealthCheckInfo(json.load(response))
     except HTTPError as e:
         report_error("healthcheck returned HTTP error %d" % (e.code,))


### PR DESCRIPTION
Currently healthcheck timeouts create UNKNOWN alerts.
This change intends to make them create CRITICAL alerts.

It also increases the timeout on healthchecks.

### Motivation

The motivation is to prevent healthcheck timeouts from passing by unnoticed, as they can indicate larger problems. For example, yesterday I simulated downtime for Redis in the integration environment, which created some unknown alerts, because Redis times out rather than erroring immediately. The timeout prevented critical alerts from appearing.

### Implementation

In the `check_app_health` command, we dont set the flag `-u`:

```
Usage: check_nrpe -H <host> [ -b <bindaddr> ] [-4] [-6] [-n] [-u] [-p <port>] [-t <timeout>] [-c <command>] [-a <arglist...>]

Options:
  ...
  -u         = Make socket timeouts return an UNKNOWN state instead of CRITICAL
```

This means timeouts will lead to critical alerts. The `check_app_health` command is now used by all healthchecks.

Timeouts for other requests will still prompt unknown alerts.

I am interested in others thoughts on this!

Trello: https://trello.com/c/Zj3YjqC5/564.