### PR TITLE
Do more testing on the NGinx configuration

### DIFF
--- a/modules/nginx/manifests/config.pp
+++ b/modules/nginx/manifests/config.pp
@@ -42,6 +42,10 @@ class nginx::config (
     content => template('nginx/etc/nginx/nginx.conf.erb'),
   }
 
+  exec { 'nginx_configtest':
+    command => '/etc/init.d/nginx configtest',
+  }
+
   file { '/etc/nginx/blockips.conf':
     ensure  => present,
     content => template('nginx/etc/nginx/blockips.conf.erb'),


### PR DESCRIPTION
Currently, it's possible for govuk-puppet to set NGinx up with invalid
configuration, but this not to cause govuk-puppet to always fail. I'm
guessing that govuk-puppet may fail when it restarts the service, but
then succeeds on subsequent runs.

NGinx is important, and testing the configuration doesn't take a long
amount of time, so do this on every run. Ideally there'd be a neater
way of doing this with Puppet, but I don't know of one.