### PR TITLE
Swap order of integration elasticsearch push/pull

### DIFF
--- a/hieradata_aws/class/integration/search.yaml
+++ b/hieradata_aws/class/integration/search.yaml
@@ -1,7 +1,7 @@
 govuk_env_sync::tasks:
   "pull_es_everything_daily":
     ensure: "present"
-    hour: "4"
+    hour: "3"
     minute: "24"
     action: "pull"
     dbms: "elasticsearch5"
@@ -12,7 +12,7 @@ govuk_env_sync::tasks:
     path: "elasticsearch5"
   "push_es_everything_daily":
     ensure: "present"
-    hour: "3"
+    hour: "4"
     minute: "24"
     action: "push"
     dbms: "elasticsearch5"


### PR DESCRIPTION
Similar to the staging change (b3ded64), this is so that data
available to the dev VM will only be one day behind production, rather
than two as it currently is (it was three before the staging change).