### PR TITLE
Validate that loadbalancer::balance is configured with servers

### DIFF
--- a/modules/loadbalancer/manifests/balance.pp
+++ b/modules/loadbalancer/manifests/balance.pp
@@ -53,6 +53,9 @@ define loadbalancer::balance(
     $read_timeout = 15,
     $maintenance_mode = false,
 ) {
+  if empty($servers) {
+    fail("NGinx can't load balance for ${vhost} without any servers")
+  }
 
   $vhost_suffix = hiera('app_domain')
   $vhost_real = "${vhost}.${vhost_suffix}"


### PR DESCRIPTION
Without some servers, the NGinx validation will fail. This follows on
from some issues cleaning up the CKAN configuration on the Carrenza
side of Production and Staging.