### PR TITLE
Remove Transition app reference from Carrenza

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -42,7 +42,6 @@ node_class: &node_class
       - specialist-publisher
       - support
       - support-api
-      - transition
       - support_api_csv_env_sync
       - travel-advice-publisher
   bouncer:
@@ -319,8 +318,6 @@ filebeat::prospectors:
       application: 'apt'
 
 gdal::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
-
-govuk::apps::transition::ensure: 'absent'
 
 govuk::apps::asset_manager::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
 govuk::apps::asset_manager::mongodb_nodes:

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -347,8 +347,6 @@ filebeat::prospectors:
 
 gdal::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
-govuk::apps::transition::ensure: 'present'
-
 govuk::apps::asset_manager::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
 govuk::apps::asset_manager::mongodb_nodes:
   - 'mongo-1'


### PR DESCRIPTION
In commit 242c814 we ensure the Transition resources are removed
from the backend machines in Carrenza. This has now been applied on
Carrenza Staging and Production, so we can now remove the application
from the backend app list.