### PR TITLE
Test Backend AWS ALB rules per application

### DIFF
--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -291,6 +291,12 @@ define govuk::app::config (
       }
     }
 
+    if defined(Concat['/etc/nginx/lb_healthchecks.conf']) and $health_check_path != 'NOTSET' {
+      concat::fragment { "${title}_lb_healthcheck":
+        target  => '/etc/nginx/lb_healthchecks.conf',
+        content => "  location /_healthcheck_${title} {\n    proxy_pass http://${title}-proxy${health_check_path};\n  }\n",
+      }
+    }
   }
   $title_underscore = regsubst($title, '\.', '_', 'G')
 

--- a/modules/govuk/manifests/node/s_backend.pp
+++ b/modules/govuk/manifests/node/s_backend.pp
@@ -39,8 +39,19 @@ class govuk::node::s_backend inherits govuk::node::s_base {
 
   include nginx
 
+  if ( $::aws_migration and ($::aws_environment == 'integration') ) {
+    concat { '/etc/nginx/lb_healthchecks.conf':
+      ensure => present,
+    }
+    $extra_config = 'include /etc/nginx/lb_healthchecks.conf'
+  } else {
+    $extra_config = ''
+  }
+
   # If we miss all the apps, throw a 500 to be caught by the cache nginx
-  nginx::config::vhost::default { 'default': }
+  nginx::config::vhost::default { 'default':
+    extra_config => $extra_config,
+  }
 
   if $::aws_migration {
     include icinga::client::check_pings


### PR DESCRIPTION
Add extra configuration to the Nginx default listener to request the
application healthcheck on a specific location request.

To be used with https://github.com/alphagov/govuk-aws/pull/937