### PR TITLE
Add healthcheck alert for datagovuk_publish

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -62,6 +62,7 @@ govuk::apps::content_publisher::google_tag_manager_preview: "env-2"
 govuk::apps::content_publisher::govuk_notify_template_id: "e00e89f5-b622-4dcb-8f30-e6c70231a940"
 govuk::apps::content_store::performance_platform_big_screen_view_url: 'https://performance-platform-big-screen-view-production.cloudapps.digital'
 govuk::apps::content_store::performance_platform_spotlight_url: 'https://performance-platform-spotlight-production.cloudapps.digital'
+govuk::apps::datagovuk_publish::host: 'publish-data-beta-production.cloudapps.digital'
 govuk::apps::email_alert_api::db::backend_ip_range: '10.3.3.0/24'
 govuk::apps::email_alert_api::email_archive_s3_bucket: 'govuk-production-email-alert-api-archive'
 govuk::apps::email_alert_api::email_archive_s3_enabled: true

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -23,6 +23,7 @@ govuk::apps::content_publisher::email_address_override: "content-publisher-notif
 govuk::apps::content_publisher::govuk_notify_template_id: "112842bb-d8a4-4511-90de-57dc5c8f27ec"
 govuk::apps::content_store::performance_platform_big_screen_view_url: 'https://performance-platform-big-screen-view-staging.cloudapps.digital'
 govuk::apps::content_store::performance_platform_spotlight_url: 'https://performance-platform-spotlight-staging.cloudapps.digital'
+govuk::apps::datagovuk_publish::host: 'publish-data-beta-staging.cloudapps.digital'
 govuk::apps::email_alert_api::db::backend_ip_range: '10.2.3.0/24'
 govuk::apps::email_alert_api::email_archive_s3_bucket: 'govuk-staging-email-alert-api-archive'
 govuk::apps::email_alert_api::email_archive_s3_enabled: true

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -85,6 +85,9 @@ node_class: &node_class
   mirrorer:
     apps:
       - govuk-crawler-worker
+  monitoring:
+    apps:
+      - datagovuk_publish
   router_backend:
     apps:
       - router-api
@@ -115,6 +118,7 @@ govuk::apps::content_store::performance_platform_big_screen_view_url: 'https://p
 govuk::apps::content_store::performance_platform_spotlight_url: 'https://performance-platform-spotlight-production.cloudapps.digital'
 govuk::apps::content_store::plek_service_whitehall_frontend_uri: 'https://whitehall-frontend.publishing.service.gov.uk'
 
+govuk::apps::datagovuk_publish::host: 'publish-data-beta-production.cloudapps.digital'
 govuk::apps::email_alert_service::enabled: false
 govuk::apps::email_alert_service::rabbitmq::ensure: 'absent'
 govuk::apps::email_alert_api::db::backend_ip_range: '10.13.3.0/24'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -85,6 +85,9 @@ node_class: &node_class
   mirrorer:
     apps:
       - govuk-crawler-worker
+  monitoring:
+    apps:
+      - datagovuk_publish
   router_backend:
     apps:
       - router-api
@@ -119,6 +122,7 @@ govuk::apps::content_store::performance_platform_big_screen_view_url: 'https://p
 govuk::apps::content_store::performance_platform_spotlight_url: 'https://performance-platform-spotlight-staging.cloudapps.digital'
 govuk::apps::content_store::plek_service_whitehall_frontend_uri: 'https://whitehall-frontend.staging.publishing.service.gov.uk'
 
+govuk::apps::datagovuk_publish::host: 'publish-data-beta-staging.cloudapps.digital'
 govuk::apps::email_alert_service::enabled: false
 govuk::apps::email_alert_service::rabbitmq::ensure: 'absent'
 govuk::apps::email_alert_api::db::backend_ip_range: '10.12.3.0/24'

--- a/modules/govuk/manifests/apps/datagovuk_publish.pp
+++ b/modules/govuk/manifests/apps/datagovuk_publish.pp
@@ -31,11 +31,10 @@
 # reports the app's status as OK.
 #
 
-class govuk::apps::datagovuk_publish {
+class govuk::apps::datagovuk_publish($host) {
   include icinga::client::check_json_healthcheck
 
   $port                             = 80
-  $host                             = 'publish-data-beta.cloudapps.digital'
   $ensure                           = 'present'
   $title                            = 'datagovuk_publish'
   $healthcheck_desc                 = "${title} app healthcheck not ok"

--- a/modules/govuk/manifests/apps/datagovuk_publish.pp
+++ b/modules/govuk/manifests/apps/datagovuk_publish.pp
@@ -46,7 +46,7 @@ class govuk::apps::datagovuk_publish {
 
   @@icinga::check { "check_app_${title}_healthcheck_on_${::hostname}":
     ensure              => $ensure,
-    check_command       => "check_nrpe!check_json_healthcheck!${port} ${health_check_path} ${host}",
+    check_command       => "check_app_health!check_json_healthcheck!${port} ${health_check_path} ${host}",
     service_description => $healthcheck_desc,
     use                 => $health_check_service_template,
     notification_period => $health_check_notification_period,

--- a/modules/govuk/manifests/apps/datagovuk_publish.pp
+++ b/modules/govuk/manifests/apps/datagovuk_publish.pp
@@ -1,0 +1,56 @@
+# == Define: govuk::app::datagovuk_publish
+#
+# This is the publishing component of data.gov.uk
+#
+# === Parameters
+#
+# [*ensure*]
+# allow govuk app to be removed.
+#
+# [*health_check_path*]
+# path at which to check the status of the application.
+#
+# This is used to export health checks to ensure the application is running
+# correctly.
+#
+# [*health_check_service_template*]
+#   The title of a `Icinga::Service_template` from which the
+#   healthcheck check should inherit.
+#
+# [*health_check_notification_period*]
+#   The title of a `Icinga::Timeperiod` resource to be used by the
+#   healthcheck.
+#
+# [*json_health_check*]
+# whether the app's health check is exposed as JSON.
+#
+# Some of our apps are adopting a JSON-based healthcheck convention, where
+# there is an overall `status` field that summarises the health of the app,
+# and a `checks` dictionary with the results of individual app-level checks.
+# Setting this to true will add a monitoring check that the healthcheck
+# reports the app's status as OK.
+#
+
+class govuk::apps::datagovuk_publish {
+  include icinga::client::check_json_healthcheck
+
+  $port                             = 80
+  $host                             = 'publish-data-beta.cloudapps.digital'
+  $ensure                           = 'present'
+  $title                            = 'datagovuk_publish'
+  $healthcheck_desc                 = "${title} app healthcheck not ok"
+  $healthcheck_opsmanual            = regsubst($healthcheck_desc, ' ', '-', 'G')
+  $health_check_path                = '/healthcheck'
+  $health_check_service_template    = 'govuk_regular_service'
+  $health_check_notification_period = undef
+
+  @@icinga::check { "check_app_${title}_healthcheck_on_${::hostname}":
+    ensure              => $ensure,
+    check_command       => "check_nrpe!check_json_healthcheck!${port} ${health_check_path} ${host}",
+    service_description => $healthcheck_desc,
+    use                 => $health_check_service_template,
+    notification_period => $health_check_notification_period,
+    host_name           => $::fqdn,
+    notes_url           => monitoring_docs_url($healthcheck_opsmanual),
+  }
+}


### PR DESCRIPTION
We currently don't have any healthchecks set up for `datagovuk_publish`.

This healthcheck configuration uses the `check_json_healthcheck`,
as it is being output as json in `datagovuk_publish`.

Related PRs:
https://github.com/alphagov/govuk-puppet/pull/9140
https://github.com/alphagov/datagovuk_publish/pull/740

Trello card: https://trello.com/c/ba8SOqEM/960-add-an-icinga-alert-to-notify-us-if-any-of-the-scheduled-dgu-sync-jobs-are-disabled

Co-Authored-By: Callum Knights <callum.knights@digital.cabinet-office.gov.uk>
Co-Authored-By: Alan Gabbianelli <alan.gabbianelli@digital.cabinet-office.gov.uk>