### PR TITLE
Set Plek context for backend machines in AWS

### DIFF
--- a/modules/govuk/manifests/node/s_backend.pp
+++ b/modules/govuk/manifests/node/s_backend.pp
@@ -52,4 +52,13 @@ class govuk::node::s_backend inherits govuk::node::s_base {
     max_memory => '12%',
     listen_ip  => '0.0.0.0',
   }
+
+  # Set Plek for AWS to Carrenza communication
+  if ( ( $::aws_migration == 'backend' ) and ($::aws_environment == 'staging') ) or ( ($::aws_migration == 'backend' ) and ($::aws_environment == 'production') ) {
+    $app_domain = hiera('app_domain')
+
+    govuk_envvar {
+      'PLEK_SERVICE_PUBLISHING_API_URI': value  => "https://publishing-api.${app_domain}";
+    }
+  }
 }


### PR DESCRIPTION
Whilst `backend` apps will be located in AWS, `publishing-api`
remain in Carrenza.

This updates the Plek environment variable overrides so these
services can still be accessed by `backend` apps.

[Trello card](https://trello.com/c/HPOb08N2/69-change-business-activity-title-to-organisation-activity-in-zendesk-ticket-generated-by-support-form)