### PR TITLE
Add training environment to the Jenkins deploy job

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_terraform_govuk_aws.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_terraform_govuk_aws.yaml.erb
@@ -71,6 +71,7 @@
                 - production
                 - test
                 - tools
+                - training
         - choice:
             name: STACKNAME
             description: Choose which stack to deploy into


### PR DESCRIPTION
# Context
This Jenkins job allows for terraform to be deployed to various environments.
We have a new environment for training that should also be included here.

# Decision

Add the training environment to the job config.