### PR TITLE
Update references to the content-performance-manager repo

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -153,8 +153,7 @@ deployable_applications: &deployable_applications
     repository: 'contacts-admin'
   content-audit-tool: {}
   content-data-admin: {}
-  content-data-api:
-    repository: 'content-performance-manager'
+  content-data-api: {}
   content-publisher: {}
   content-store: {}
   content-tagger: {}

--- a/modules/govuk/manifests/apps/content_data_api.pp
+++ b/modules/govuk/manifests/apps/content_data_api.pp
@@ -1,6 +1,6 @@
 # == Class: govuk::apps::content_data_api
 #
-# App details at: https://github.com/alphagov/content-performance-manager
+# App details at: https://github.com/alphagov/content-data-api
 #
 # === Parameters
 #


### PR DESCRIPTION
This should be merged after the content-performance-manager GitHub
repository has been renamed.