### PR TITLE
Updates Node from v6 to v10

### DIFF
--- a/hieradata/common.trusty.yaml
+++ b/hieradata/common.trusty.yaml
@@ -43,4 +43,4 @@ base::esm::esm_password: "%{hiera('base::esm::esm_trusty_password')}"
 
 govuk_ppa::repo_ensure: 'present'
 
-nodejs::version: '6.14.3-1nodesource1'
+nodejs::version: '10.15.3-1nodesource1'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1562,7 +1562,7 @@ nginx::package::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 nginx::package::nginx_version: "1.14.0-1~trusty"
 
 nodejs::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
-nodejs::version: '6.14.3-1nodesource1'
+nodejs::version: '10.15.3-1nodesource1'
 
 ntp::server_list:
   - 'ntp.ubuntu.com'

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1176,7 +1176,7 @@ nginx::package::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 nginx::package::nginx_version: "1.14.0-1~trusty"
 
 nodejs::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
-nodejs::version: '6.14.3-1nodesource1'
+nodejs::version: '10.15.3-1nodesource1'
 
 ntp::server_list:
   - 'ntp.ubuntu.com'

--- a/modules/govuk/manifests/node/s_apt.pp
+++ b/modules/govuk/manifests/node/s_apt.pp
@@ -79,7 +79,7 @@ class govuk::node::s_apt (
       release  => 'precise',
       key      => 'ABF5BD827BD9BF62';
     'nodejs':
-      location => 'https://deb.nodesource.com/node_6.x',
+      location => 'https://deb.nodesource.com/node_10.x',
       release  => 'trusty',
       repos    => ['main'],
       key      => '68576280';


### PR DESCRIPTION
Node v10 is in LTS, and there are a number of NPM packages that specify a Node environment of at least V8.

Therefore we should move away from v6.

Depended on by https://github.com/alphagov/finder-frontend/pull/1125.