### PR TITLE
Fix the NGinx port for the Content Data API Sidekiq monitoring

### DIFF
--- a/modules/govuk/templates/sidekiq_monitoring_nginx_config.conf.erb
+++ b/modules/govuk/templates/sidekiq_monitoring_nginx_config.conf.erb
@@ -35,7 +35,7 @@ server {
   }
 
   location /content-data-api {
-    proxy_pass http://localhost:3235;
+    proxy_pass http://localhost:3239;
   }
 
   location /content-publisher {


### PR DESCRIPTION
It needs to be the port for Sidekiq Monitoring, rather than the
Content Data API itself.