### PR TITLE
change to where staging s3 mirror bucket

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -330,6 +330,8 @@ task :check_consistency_between_aws_and_carrenza do
     monitoring::checks::sidekiq::enable_support_check
     monitoring::pagerduty_drill::enabled
     router::nginx::robotstxt
+    govuk::apps::govuk_crawler_worker::blacklist_paths
+    govuk_crawler::start_hour
   ]
 
   failed = false

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -134,6 +134,19 @@ govuk::apps::email_alert_api::email_address_override: 'success@simulator.amazons
 govuk::apps::email_alert_api::email_address_override_whitelist_only: true
 govuk::apps::email_alert_api::delivery_request_threshold: "3000"
 govuk::apps::email_alert_frontend::subscription_management_enabled: true
+
+govuk::apps::govuk_crawler_worker::blacklist_paths:
+  - '/apply-for-a-licence'
+  - '/business-finance-support-finder'
+  - '/drug-device-alerts.atom'
+  - '/drug-safety-update.atom'
+  - '/foreign-travel-advice.atom'
+  - '/government/announcements.atom'
+  - '/government/publications.atom'
+  - '/government/statistics.atom'
+  - '/licence-finder'
+  - '/search'
+
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::kibana::logit_environment: b13bfb70-e07a-473b-9903-02e806ebd045
 govuk::apps::link_checker_api::govuk_basic_auth_credentials: "%{hiera('http_username')}:%{hiera('http_password')}"
@@ -170,9 +183,10 @@ govuk_containers::terraboard::aws_bucket: 'govuk-terraform-steppingstone-staging
 govuk_containers::terraboard::oauth2_proxy_base_url: 'https://terraboard.staging.govuk.digital'
 
 govuk_crawler::seed_enable: true
+govuk_crawler::start_hour: 20
 govuk_crawler::sync_enable: true
 govuk_crawler::targets:
-  - 's3://govuk-staging-mirror-1/'
+  - 's3://govuk-staging-mirror/'
 
 govuk_jenkins::job_builder::environment: 'staging'
 

--- a/modules/govuk_crawler/manifests/config.pp
+++ b/modules/govuk_crawler/manifests/config.pp
@@ -37,11 +37,23 @@ class govuk_crawler::config (
     ensure  => present,
   }
 
-  file { "/etc/govuk/${env_name}/env.d/AWS_SECRET_ACCESS_KEY":
-    content => $aws_secret_key,
+  if $aws_secret_key {
+    file { "/etc/govuk/${env_name}/env.d/AWS_SECRET_ACCESS_KEY":
+      content => $aws_secret_key,
+    }
+  } else {
+    file { "/etc/govuk/${env_name}/env.d/AWS_SECRET_ACCESS_KEY":
+      ensure => 'absent',
+    }
   }
 
-  file { "/etc/govuk/${env_name}/env.d/AWS_ACCESS_KEY_ID":
-    content => $aws_access_key,
+  if $aws_access_key {
+    file { "/etc/govuk/${env_name}/env.d/AWS_ACCESS_KEY_ID":
+      content => $aws_access_key,
+    }
+  } else {
+    file { "/etc/govuk/${env_name}/env.d/AWS_ACCESS_KEY_ID":
+      ensure => 'absent',
+    }
   }
 }

--- a/modules/govuk_crawler/manifests/init.pp
+++ b/modules/govuk_crawler/manifests/init.pp
@@ -44,6 +44,12 @@
 #   The web site to be crawled, e.g. https://www.gov.uk
 #   Default: ''
 #
+# [*start_hour*]
+#   The hour at which the crawl starts
+#   Type: integer
+#   Range: 0-23
+#   Default: 6
+#
 # [*ssh_keys*]
 #   A hash of hostnames with ssh host keys and type of ssh host key.
 #   Default: {}
@@ -74,6 +80,7 @@ class govuk_crawler(
   $mirror_root,
   $seed_enable = false,
   $site_root = '',
+  $start_hour = 6,
   $ssh_keys = {},
   $ssh_private_key = '',
   $sync_enable = false,

--- a/modules/govuk_crawler/templates/seed-crawler-wrapper-cron.erb
+++ b/modules/govuk_crawler/templates/seed-crawler-wrapper-cron.erb
@@ -1,1 +1,1 @@
-0 6 * * * <%= @crawler_user %> /usr/bin/setlock -n <%= @seeder_lock_path %> <%= @seeder_script_wrapper_path %>
+0 <%= @start_hour %> * * * <%= @crawler_user %> /usr/bin/setlock -n <%= @seeder_lock_path %> <%= @seeder_script_wrapper_path %>


### PR DESCRIPTION
# Context

Mirror improvement project specifies that we need to sync with a s3 bucket in London rather than Ireland. Also 'government/uploads' and 'api' should be added to the crawler list of prefixes to crawl.

# Decisions
1. change where the aws staging environment saves the mirror to the new s3 bucket in london
2. make the crawler start time to be configurable
3. make the aws staging crawel start time to 20 00
4. if no aws_access_key and/or aws_secret_key specified, do not create the file
5. remove government/uploads and api in the crawling blacklist