### PR TITLE
Add configuration for healthchecks that use https

### DIFF
--- a/modules/icinga/files/etc/nagios/nrpe.d/check_json_healthcheck.cfg
+++ b/modules/icinga/files/etc/nagios/nrpe.d/check_json_healthcheck.cfg
@@ -1,1 +1,1 @@
-command[check_json_healthcheck]=/usr/lib/nagios/plugins/check_json_healthcheck $ARG1$ $ARG2$
+command[check_json_healthcheck]=/usr/lib/nagios/plugins/check_json_healthcheck $ARG1$ $ARG2$ $ARG3$ $ARG4

--- a/modules/icinga/files/usr/lib/nagios/plugins/check_json_healthcheck
+++ b/modules/icinga/files/usr/lib/nagios/plugins/check_json_healthcheck
@@ -17,9 +17,10 @@ information:
         }
     }
 
-This script can be invoked with the healthcheck port, path and host as arguments:
+This script can be invoked with the healthcheck port, path, host(optional) and
+protocol(optional) as arguments:
 
-    check_json_healthcheck 3000 /healthcheck host_path
+    check_json_healthcheck 3000 /healthcheck host_path https
 
 """
 
@@ -61,8 +62,9 @@ def url_from_arguments(arguments):
     """Construct a health check URL from command-line arguments.
 
     The first argument should be the port; the second argument the healthcheck
-    path; the third is the host. The healthcheck is assumed to be on localhost
-    and over HTTP.
+    path; the third is the host; fourth is the protocol.
+    The host and protocol is optional, if it's not specified the default is localhost
+    over HTTP.
 
     """
     check_port = int(arguments[0])
@@ -73,8 +75,13 @@ def url_from_arguments(arguments):
     except IndexError:
         check_host = 'localhost'
 
+    try:
+        protocol = arguments[3]
+    except IndexError:
+        protocol = 'http'
+
     return urlunparse((
-        "http",
+        protocol,
         "%s:%d" % (check_host, check_port),
         check_path,
         None,  # params

--- a/modules/monitoring/manifests/checks/datagovuk_publish.pp
+++ b/modules/monitoring/manifests/checks/datagovuk_publish.pp
@@ -14,6 +14,7 @@
 class monitoring::checks::datagovuk_publish(
   $ensure = 'absent',
   $host   = undef,
+  $protocol = 'https'
 ) {
   include icinga::client::check_json_healthcheck
 
@@ -24,7 +25,7 @@ class monitoring::checks::datagovuk_publish(
 
   @@icinga::check { 'check_datagovuk_publish_healthcheck':
     ensure              => $ensure,
-    check_command       => "check_app_health!check_json_healthcheck!${port} ${health_check_path} ${host}",
+    check_command       => "check_app_health!check_json_healthcheck!${port} ${health_check_path} ${host} ${protocol}",
     service_description => $healthcheck_desc,
     use                 => 'govuk_regular_service',
     host_name           => $::fqdn,


### PR DESCRIPTION
The `datagovuk_publish` app's host uses `https` and is on the Paas,
 the rest of our gov.uk apps use `http` and is served internally.

The `check_json_healthcheck` now has an additional parameter to
accept a protocol, if one isn't specified it defaults to `http`.