### PR TITLE
Allow planning Terraform destroy operations

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_terraform_govuk_aws.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_terraform_govuk_aws.yaml.erb
@@ -61,6 +61,7 @@
             choices:
                 - plan
                 - apply
+                - plan (destroy)
                 - destroy
         - choice:
             name: ENVIRONMENT


### PR DESCRIPTION
As it's good to get an idea of what's going to be destroyed, before
going ahead and destroying things.

This relates to a corresponding change in the jenkins.sh script in the
govuk-aws repository.

https://github.com/alphagov/govuk-aws/pull/952