### PR TITLE
Add procfile workers for email alert service queue consumers

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -419,6 +419,8 @@ govuk::apps::email_alert_api::email_address_override_whitelist:
   - tijmen.brommet@digital.cabinet-office.gov.uk
 
 govuk::apps::email_alert_service::enabled: true
+govuk::apps::email_alert_service::message_queues::enable_unpublishing_queue_consumer: true
+govuk::apps::email_alert_service::message_queues::enable_major_change_queue_consumer: true
 govuk::apps::email_alert_service::rabbitmq_hosts:
   - rabbitmq-1.backend
   - rabbitmq-2.backend

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -420,7 +420,6 @@ govuk::apps::email_alert_api::email_address_override_whitelist:
 
 govuk::apps::email_alert_service::enabled: true
 govuk::apps::email_alert_service::message_queues::enable_unpublishing_queue_consumer: true
-govuk::apps::email_alert_service::message_queues::enable_major_change_queue_consumer: true
 govuk::apps::email_alert_service::rabbitmq_hosts:
   - rabbitmq-1.backend
   - rabbitmq-2.backend

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -484,7 +484,6 @@ govuk::apps::email_alert_api::email_address_override_whitelist:
 
 govuk::apps::email_alert_service::enabled: true
 govuk::apps::email_alert_service::message_queues::enable_unpublishing_queue_consumer: true
-govuk::apps::email_alert_service::message_queues::enable_major_change_queue_consumer: true
 govuk::apps::email_alert_service::rabbitmq_hosts:
   - rabbitmq
 govuk::apps::email_alert_service::redis_host: "%{hiera('sidekiq_host')}"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -483,6 +483,8 @@ govuk::apps::email_alert_api::email_address_override_whitelist:
   - tijmen.brommet@digital.cabinet-office.gov.uk
 
 govuk::apps::email_alert_service::enabled: true
+govuk::apps::email_alert_service::message_queues::enable_unpublishing_queue_consumer: true
+govuk::apps::email_alert_service::message_queues::enable_major_change_queue_consumer: true
 govuk::apps::email_alert_service::rabbitmq_hosts:
   - rabbitmq
 govuk::apps::email_alert_service::redis_host: "%{hiera('sidekiq_host')}"

--- a/modules/govuk/manifests/apps/email_alert_service.pp
+++ b/modules/govuk/manifests/apps/email_alert_service.pp
@@ -27,10 +27,6 @@
 # [*email_alert_api_bearer_token*]
 #   Bearer token for communication with the email-alert-api
 #
-# [*enable_major_change_queue_consumer*]
-#   Whether or not to configure the queue for the major change processor
-#   Default: false
-#
 # [*enable_unpublishing_queue_consumer*]
 #   Whether or not to configure the queue for the unpublishing processor
 #   Default: false
@@ -44,7 +40,6 @@ class govuk::apps::email_alert_service(
   $sentry_dsn = undef,
   $redis_host = undef,
   $email_alert_api_bearer_token = undef,
-  $enable_major_change_queue_consumer = false,
   $enable_unpublishing_queue_consumer = false
 ) {
 
@@ -53,21 +48,14 @@ class govuk::apps::email_alert_service(
     false => 'absent',
   }
 
-  $app_name = 'email_alert_service'
+  $app_name = 'email-alert-service'
 
   govuk::app { 'email-alert-service':
     ensure             => $ensure,
     app_type           => 'bare',
     enable_nginx_vhost => false,
     sentry_dsn         => $sentry_dsn,
-    command            => './bin/email_alert_service',
-  }
-
-  govuk::procfile::worker { 'email-alert-service-major-change-consumer':
-    setenv_as      => $app_name,
-    enable_service => $enable_major_change_queue_consumer,
-    process_type   => 'major_change_queue_consumer',
-    process_regex  => '\/rake message_queues:major_change_consumer',
+    command            => 'bundle exec rake message_queues:major_change_consumer',
   }
 
   govuk::procfile::worker { 'email-alert-service-unpublishing-queue-consumer':

--- a/modules/govuk/manifests/apps/email_alert_service.pp
+++ b/modules/govuk/manifests/apps/email_alert_service.pp
@@ -21,13 +21,21 @@
 #   RabbitMQ password.
 #   Default: email_alert_service
 #
-#
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
 # [*email_alert_api_bearer_token*]
 #   Bearer token for communication with the email-alert-api
 #
+# [*enable_major_change_queue_consumer*]
+#   Whether or not to configure the queue for the major change processor
+#   Default: false
+#
+# [*enable_unpublishing_queue_consumer*]
+#   Whether or not to configure the queue for the unpublishing processor
+#   Default: false
+#
+
 class govuk::apps::email_alert_service(
   $enabled = false,
   $rabbitmq_hosts = ['localhost'],
@@ -36,6 +44,8 @@ class govuk::apps::email_alert_service(
   $sentry_dsn = undef,
   $redis_host = undef,
   $email_alert_api_bearer_token = undef,
+  $enable_major_change_queue_consumer = false,
+  $enable_unpublishing_queue_consumer = false
 ) {
 
   $ensure = $enabled ? {
@@ -43,12 +53,28 @@ class govuk::apps::email_alert_service(
     false => 'absent',
   }
 
+  $app_name = 'email_alert_service'
+
   govuk::app { 'email-alert-service':
     ensure             => $ensure,
     app_type           => 'bare',
     enable_nginx_vhost => false,
     sentry_dsn         => $sentry_dsn,
     command            => './bin/email_alert_service',
+  }
+
+  govuk::procfile::worker { 'email-alert-service-major-change-consumer':
+    setenv_as      => $app_name,
+    enable_service => $enable_major_change_queue_consumer,
+    process_type   => 'major_change_queue_consumer',
+    process_regex  => '\/rake message_queues:major_change_consumer',
+  }
+
+  govuk::procfile::worker { 'email-alert-service-unpublishing-queue-consumer':
+    setenv_as      => $app_name,
+    enable_service => $enable_unpublishing_queue_consumer,
+    process_type   => 'unpublishing_queue_consumer',
+    process_regex  => '\/rake message_queues:unpublishing_consumer',
   }
 
   Govuk::App::Envvar {


### PR DESCRIPTION
The email-alert-service is being [modified to use the `govuk_message_queue_consumer` gem](https://github.com/alphagov/email-alert-service/pull/263). The gem relies on message queue connections being established via rake tasks in the Procfile.

This PR ensures that these rake tasks are run during app startup.

