### PR TITLE
Fix the Icinga Slack notification commands

### DIFF
--- a/modules/icinga/templates/slack_contact.cfg.erb
+++ b/modules/icinga/templates/slack_contact.cfg.erb
@@ -15,11 +15,11 @@ define contact {
 }
 
 define command{
-    command_name    <%= notify_service_command %>
+    command_name    <%= notify_host_command %>
     command_line    /usr/local/bin/icinga_slack_webhook_notify -u <%= @slack_webhook_url %> -c '<%= @slack_channel %>' -U '<%= @slack_username %>' -m '$HOSTDISPLAYNAME$ is $HOSTSTATE$' -H '$HOSTDISPLAYNAME$' -A '$HOSTACTIONURL$' -N '$HOSTNOTESURL$' -S '<%= @nagios_cgi_url %>'
 }
 
 define command{
-    command_name    <%= notify_host_command %>
+    command_name    <%= notify_service_command %>
     command_line    /usr/local/bin/icinga_slack_webhook_notify -u <%= @slack_webhook_url %> -c '<%= @slack_channel %>' -U '<%= @slack_username %>' -m '$SERVICEDESC$' -H '$HOSTDISPLAYNAME$' -A '$SERVICEACTIONURL$' -N '$SERVICENOTESURL$' -L $SERVICESTATE$ -S '<%= @nagios_cgi_url %>'
 }


### PR DESCRIPTION
When the variables for the command names got put in, the host and
service command got flipped around. This fixes the issue.