### PR TITLE
Add dead letter queue for Content Data API

### DIFF
--- a/modules/govuk/manifests/apps/content_data_api/rabbitmq.pp
+++ b/modules/govuk/manifests/apps/content_data_api/rabbitmq.pp
@@ -17,22 +17,43 @@
 # [*amqp_exchange*]
 #   The RabbitMQ exchange to read from (default: 'published_documents')
 #
+# [*amqp_dlx*]
+#   The RabbitMQ dead letter exchange (default: 'content_data_api_dlx')
+#
 # [*amqp_queue*]
 #   The RabbitMQ queue to set up for workers of this type to read from
 #   (default: 'content_data_api')
 #
-# [*amqp_bulk_importing_queue]
+# [*amqp_bulk_importing_queue*]
 #   The RabbitMQ queue to set up for workers of this type to read from
 #   for bulk importer of content into the Content Data API
 #   (default: 'content_data_api_govuk_importer')
+#
+# [*amqp_dead_letter_queue*]
+#   The RabbitMQ queue to recieve unprocessed messages.
+#   (default: 'content_data_api_dead_letter_queue')
 #
 class govuk::apps::content_data_api::rabbitmq (
   $amqp_user  = 'content_data_api',
   $amqp_pass = undef,
   $amqp_exchange = 'published_documents',
+  $amqp_dlx = 'content_data_api_dlx',
   $amqp_queue = 'content_data_api',
-  $amqp_bulk_importing_queue = 'content_data_api_govuk_importer'
+  $amqp_bulk_importing_queue = 'content_data_api_govuk_importer',
+  $amqp_dead_letter_queue = 'content_data_api_dead_letter_queue'
 ) {
+
+  govuk_rabbitmq::exchange { "${amqp_dlx}@/":
+    type     => 'topic',
+  }
+
+  govuk_rabbitmq::queue_with_binding { $amqp_dead_letter_queue:
+    ensure        => 'present',
+    amqp_exchange => $amqp_dlx,
+    amqp_queue    => $amqp_dead_letter_queue,
+    routing_key   => '#',
+    durable       => true,
+  }
 
   govuk_rabbitmq::queue_with_binding { $amqp_queue:
     ensure        => 'present',
@@ -40,6 +61,9 @@ class govuk::apps::content_data_api::rabbitmq (
     amqp_queue    => $amqp_queue,
     routing_key   => '*.major',
     durable       => true,
+    arguments     => {
+      x-dead-letter-exchange => $amqp_dlx,
+    },
   }
 
   rabbitmq_binding { "binding_minor_${amqp_exchange}@${amqp_queue}@/":
@@ -88,6 +112,9 @@ class govuk::apps::content_data_api::rabbitmq (
     amqp_queue    => $amqp_bulk_importing_queue,
     routing_key   => '*.bulk.data-warehouse',
     durable       => true,
+    arguments     => {
+      x-dead-letter-exchange => "${amqp_dlx}@/",
+    },
   }
 
   govuk_rabbitmq::consumer { $amqp_user:

--- a/modules/govuk_rabbitmq/manifests/queue_with_binding.pp
+++ b/modules/govuk_rabbitmq/manifests/queue_with_binding.pp
@@ -34,12 +34,16 @@
 #   Queues can be durable or transient. Durable queues survive broker restart, transient queues do not.
 #   (default: true)
 #
+# [*arguments*]
+#   The hash of arguments to configure the queue.
+#
 define govuk_rabbitmq::queue_with_binding (
   $amqp_exchange,
   $amqp_queue,
   $routing_key,
   $durable = true,
-  $ensure = 'present'
+  $ensure = 'present',
+  $arguments = {}
 ) {
   validate_re($routing_key, '^.+$', '$routing_key must be non-empty')
   $amqp_user = $title
@@ -50,7 +54,7 @@ define govuk_rabbitmq::queue_with_binding (
     password    => $::govuk_rabbitmq::root_password,
     durable     => $durable,
     auto_delete => false,
-    arguments   => {},
+    arguments   => $arguments,
   } ->
   rabbitmq_binding { "binding_${routing_key}_${amqp_exchange}@${amqp_queue}@/":
     ensure           => $ensure,


### PR DESCRIPTION
This adds a dead letter queue in RabbitMQ for message which aren't able to be processed by Content Data API.