### PR TITLE
Increase max upload size for Content Publisher

### DIFF
--- a/modules/govuk/manifests/apps/content_publisher.pp
+++ b/modules/govuk/manifests/apps/content_publisher.pp
@@ -135,14 +135,15 @@ class govuk::apps::content_publisher (
 
   # see modules/govuk/manifests/app.pp for more options
   govuk::app { $app_name:
-    ensure            => $ensure,
-    app_type          => 'rack',
-    port              => $port,
-    sentry_dsn        => $sentry_dsn,
-    vhost_ssl_only    => true,
-    health_check_path => '/healthcheck', # must return HTTP 200 for an unauthenticated request
-    deny_framing      => true,
-    asset_pipeline    => true,
+    ensure             => $ensure,
+    app_type           => 'rack',
+    port               => $port,
+    sentry_dsn         => $sentry_dsn,
+    vhost_ssl_only     => true,
+    health_check_path  => '/healthcheck', # must return HTTP 200 for an unauthenticated request
+    deny_framing       => true,
+    asset_pipeline     => true,
+    nginx_extra_config => 'client_max_body_size 500m;',
   }
 
   Govuk::App::Envvar {


### PR DESCRIPTION
https://trello.com/c/pqCfFrI1/873-support-upload-of-large-file-attachments

Previously this app was limited to uploads of 20M in size. Users who
exceed this limit would get a generic 413 error, which we want to avoid
until we have a more complete understanding of the user needs around
limits for different kinds of upload.