### PR TITLE
Update and fix configuration for LB Nginx health checks

### DIFF
--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -299,7 +299,7 @@ define govuk::app::config (
     if defined(Concat['/etc/nginx/lb_healthchecks.conf']) and $health_check_path != 'NOTSET' {
       concat::fragment { "${title}_lb_healthcheck":
         target  => '/etc/nginx/lb_healthchecks.conf',
-        content => "  location /_healthcheck_${title} {\n    proxy_pass http://${title}-proxy${health_check_path};\n  }\n",
+        content => "location /_healthcheck_${vhost_full} {\n  proxy_pass http://${vhost_full}-proxy${health_check_path};\n}\n",
       }
     }
   }

--- a/modules/govuk/manifests/node/s_backend.pp
+++ b/modules/govuk/manifests/node/s_backend.pp
@@ -43,7 +43,7 @@ class govuk::node::s_backend inherits govuk::node::s_base {
     concat { '/etc/nginx/lb_healthchecks.conf':
       ensure => present,
     }
-    $extra_config = 'include /etc/nginx/lb_healthchecks.conf'
+    $extra_config = 'include /etc/nginx/lb_healthchecks.conf;'
   } else {
     $extra_config = ''
   }


### PR DESCRIPTION
Fix 1f6eec5

The upstream proxy does not exist in certain cases, for instance, contacts-admin
is being configured as contacts-proxy. We need to pass the correct variable.

Add missing `;`