### PR TITLE
Fix Content Data Admin procfile worker name

### DIFF
--- a/modules/govuk/manifests/apps/content_data_admin.pp
+++ b/modules/govuk/manifests/apps/content_data_admin.pp
@@ -186,7 +186,7 @@ class govuk::apps::content_data_admin (
     }
   }
 
-  govuk::procfile::worker { "${app_name}-sidekiq":
+  govuk::procfile::worker { $app_name:
     ensure         => $ensure,
     enable_service => $enable_procfile_worker,
     setenv_as      => $app_name,


### PR DESCRIPTION
This renames the initctl procfile worker name from `content-data-admin-sidekiq-procfile-worker` to `content-data-admin-procfile-worker`. This is needed as the deploy scripts use the new name by default.