### PR TITLE
Add LB healthcheck redirection apps

### DIFF
--- a/modules/govuk/manifests/apps/content_data_admin.pp
+++ b/modules/govuk/manifests/apps/content_data_admin.pp
@@ -127,6 +127,13 @@ class govuk::apps::content_data_admin (
     to => "https://content-data.${app_domain}/",
   }
 
+  if defined(Concat['/etc/nginx/lb_healthchecks.conf']) {
+    concat::fragment { "${app_name}_lb_healthcheck":
+      target  => '/etc/nginx/lb_healthchecks.conf',
+      content => "location /_healthcheck_${app_name} {\n  proxy_pass http://content-data-proxy/healthcheck;\n}\n",
+    }
+  }
+
   Govuk::App::Envvar {
     app            => $app_name,
     ensure         => $ensure,

--- a/modules/govuk/manifests/apps/kibana.pp
+++ b/modules/govuk/manifests/apps/kibana.pp
@@ -14,4 +14,11 @@ class govuk::apps::kibana(
   nginx::config::vhost::redirect { "${app_name}.${app_domain}":
     to => "https://logit.io/a/${logit_account}/s/${logit_environment}/kibana/access",
   }
+
+  if defined(Concat['/etc/nginx/lb_healthchecks.conf']) {
+    concat::fragment { 'kibana_lb_healthcheck':
+      target  => '/etc/nginx/lb_healthchecks.conf',
+      content => 'location /_healthcheck_kibana {\n  return 200;\n}\n',
+    }
+  }
 }


### PR DESCRIPTION
`kibana` and `content_data_admin` apps implement the `nginx::config::vhost::redirect`
class instead of the standard proxy one. The LB healthchecks that we configured in 1f6eec5
do not cover these special cases, and we need to add the application healthcheck endpoint
to make sure the app gets traffic from the loadbalancer.