### PR TITLE
add mirror to the Jenkins CDN deployment job

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_cdn.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_cdn.yaml.erb
@@ -62,6 +62,7 @@
                 - tldredirect
                 - servicegovuk
                 - performanceplatform
+                - mirror
         - string:
             name: FASTLY_USER
             default: false


### PR DESCRIPTION
# Context

We now have a new VCL/fastly service to test the mirrors
and therefore we need to add the `mirror` option in the
Jenkins CDN deployment job.

# Decisions
1. add `mirror` option to Jenkins CDN deployment job