### PR TITLE
Exclude ESM from apt:sources for development-vm

### DIFF
--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -1,6 +1,24 @@
 ---
 app_domain: 'dev.gov.uk'
 
+apt::sources:
+  ubuntu:
+    location: 'http://gb.archive.ubuntu.com/ubuntu/'
+    release: '%{::lsbdistcodename}'
+    repos: 'main restricted universe multiverse'
+  ubuntu-updates:
+    location: 'http://gb.archive.ubuntu.com/ubuntu/'
+    release: '%{::lsbdistcodename}-updates'
+    repos: 'main restricted universe multiverse'
+  ubuntu-backports:
+    location: 'http://gb.archive.ubuntu.com/ubuntu/'
+    release: '%{::lsbdistcodename}-backports'
+    repos: 'main restricted universe multiverse'
+  ubuntu-security:
+    location: 'http://gb.archive.ubuntu.com/ubuntu/'
+    release: '%{::lsbdistcodename}-security'
+    repos: 'main restricted universe multiverse'
+
 assets::mount_asset_master: false
 
 base::shell::shell_prompt_string: 'dev'


### PR DESCRIPTION
- ESM for extended Ubuntu Trusty support was recently added as Trusty is EOL
and support by Canonical is now paid-for
- We cannot currently add the Canonical credetials for ESM access to the
development-vm as our support contract is per machine.
- This caused Puppet errors on development-vm deployment
- Decision: Simply remove ESM repos from development-vm hieradata

solo: @schmie