### PR TITLE
Set up Content Security Policy common environment variables

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -673,9 +673,11 @@ govuk_beat::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 govuk_ci::agent::gcloud::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
-govuk::deploy::config::asset_root: "https://assets.%{hiera('app_domain')}"
-govuk::deploy::config::website_root: "https://www.%{hiera('app_domain')}"
 govuk::deploy::config::app_domain: "%{hiera('app_domain')}"
+govuk::deploy::config::asset_root: "https://assets.%{hiera('app_domain')}"
+govuk::deploy::config::csp_report_only: true
+govuk::deploy::config::csp_report_uri: https://jhpno0hk6b.execute-api.eu-west-2.amazonaws.com/production
+govuk::deploy::config::website_root: "https://www.%{hiera('app_domain')}"
 
 govuk_gor::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -27,6 +27,8 @@ base::supported_kernel::enabled: true
 clamav::use_service: false
 
 govuk::deploy::config::asset_root: 'http://assets-origin.dev.gov.uk'
+govuk::deploy::config::csp_report_only: false
+govuk::deploy::config::csp_report_uri: null
 govuk::deploy::config::website_root: 'http://www.dev.gov.uk'
 govuk::deploy::setup::ssh_keys:
     development_user: SEVIRUhFSEVIIFRoaXMgaXMgbm90IGEgcmVhbCBrZXkgYnV0IEknbSBnb2luZyB0byBtYWtlIGl0IGxvb2sgbGlrZSBpdCdzIG9uZSBqdXN0IHRvIHJlYWxseSBhbm5veSB5b3UhCg==

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -775,9 +775,11 @@ govuk_beat::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 govuk_ci::agent::gcloud::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
-govuk::deploy::config::asset_root: "https://assets.%{hiera('app_domain')}"
-govuk::deploy::config::website_root: "https://www.%{hiera('app_domain')}"
 govuk::deploy::config::app_domain: "%{hiera('app_domain')}"
+govuk::deploy::config::asset_root: "https://assets.%{hiera('app_domain')}"
+govuk::deploy::config::csp_report_only: true
+govuk::deploy::config::csp_report_uri: https://jhpno0hk6b.execute-api.eu-west-2.amazonaws.com/production
+govuk::deploy::config::website_root: "https://www.%{hiera('app_domain')}"
 govuk::deploy::setup::gemstash_server: 'http://gemstash'
 govuk::deploy::sync::jenkins_domain: "deploy.%{hiera('app_domain_internal')}"
 govuk::deploy::sync::auth_token: "%{hiera('govuk_jenkins::deploy_all_apps::auth_token')}"

--- a/modules/govuk/manifests/deploy/config.pp
+++ b/modules/govuk/manifests/deploy/config.pp
@@ -25,6 +25,12 @@
 # [*licensify_app_domain*]
 #   The app domain for Licensify hosts, which are different in AWS.
 #
+# [*csp_report_only*]
+#   Whether to report content security policy violations rather than block them
+#
+# [*csp_report_uri*]
+#   The URI to report any content security policy violations too
+#
 class govuk::deploy::config(
   $asset_root,
   $errbit_environment_name = '',
@@ -32,6 +38,8 @@ class govuk::deploy::config(
   $website_root,
   $app_domain,
   $licensify_app_domain = undef,
+  $csp_report_only = false,
+  $csp_report_uri = undef,
 ){
 
   limits::limits { 'deploy_nofile':
@@ -84,6 +92,11 @@ class govuk::deploy::config(
     require => File['/etc/govuk'],
   }
 
+  $csp_report_only_value = $csp_report_only ? {
+    true => 'yes',
+    default => undef,
+  }
+
   govuk_envvar {
     'GOVUK_ENV': value => $govuk_env;
     'NODE_ENV': value => $govuk_env;
@@ -95,6 +108,8 @@ class govuk::deploy::config(
     'GOVUK_ASSET_HOST': value          => $asset_root;
     'GOVUK_ASSET_ROOT': value          => $asset_root;
     'GOVUK_WEBSITE_ROOT': value        => $website_root;
+    'GOVUK_CSP_REPORT_ONLY': value     => $csp_report_only_value;
+    'GOVUK_CSP_REPORT_URI': value      => $csp_report_uri;
   }
 
   if $::aws_migration {

--- a/modules/govuk_envvar/manifests/init.pp
+++ b/modules/govuk_envvar/manifests/init.pp
@@ -8,7 +8,7 @@
 # need to restart an application before it picks up a changed environment
 # variable.
 
-define govuk_envvar ($value = undef, $envdir = '/etc/govuk/env.d', $varname = $title) {
+define govuk_envvar ($value = '', $envdir = '/etc/govuk/env.d', $varname = $title) {
 
   file { "${envdir}/${varname}":
     content => $value,

--- a/modules/govuk_envvar/spec/defines/govuk_envvar_spec.rb
+++ b/modules/govuk_envvar/spec/defines/govuk_envvar_spec.rb
@@ -1,0 +1,22 @@
+require_relative '../../../../spec_helper'
+
+describe 'govuk_envvar', :type => :define do
+  context 'with a value' do
+    let(:title) { 'GOVUK_POET_FULL_NAME' }
+    let(:params) { { :value => 'Robert Burns' } }
+
+    it 'writes the value to disk' do
+      is_expected.to contain_file('/etc/govuk/env.d/GOVUK_POET_FULL_NAME')
+                 .with_content('Robert Burns')
+    end
+  end
+
+  context 'without a value' do
+    let(:title) { 'GOVUK_POET_FULL_NAME' }
+
+    it 'writes an empty value to disk' do
+      is_expected.to contain_file('/etc/govuk/env.d/GOVUK_POET_FULL_NAME')
+                 .with_content('')
+    end
+  end
+end


### PR DESCRIPTION
This sets up environment variables for the content security policy.
These are set in govuk::deploy::config as this is a place where they can
easily be configured in a global way, whereas if they're set within
govuk::app we'll need to set them up for each app individually.

These environment variables are intended to replace hardcoded logic in
the code [1]. The expectation is that we may want groups of apps to have
different report uri values (e.g. frontend and backend) so may well set
up values for these at node level hieradata.

If apps need to customise their approach to these they can set up their
own environment variables.

Finally, worth noting that if/when we want to remove these env vars
we'll need to add an ensure absent to govuk_envvar::init. If we just
delete these from the code puppet won't do anything to them.

[1]: https://github.com/alphagov/govuk_app_config/blob/f0fa82e2d8a73449efabd2414d93264a31afdf75/lib/govuk_app_config/govuk_content_security_policy.rb#L131-L136