### PR TITLE
Fix kibana, content-data-admin lb healthcheck resources

### DIFF
--- a/modules/govuk/manifests/apps/content_data_admin.pp
+++ b/modules/govuk/manifests/apps/content_data_admin.pp
@@ -127,8 +127,8 @@ class govuk::apps::content_data_admin (
     to => "https://content-data.${app_domain}/",
   }
 
-  if defined(Concat['/etc/nginx/lb_healthchecks.conf']) {
-    concat::fragment { "${app_name}_lb_healthcheck":
+  if ( $::aws_migration and ($::aws_environment == 'integration') ) {
+    concat::fragment { "${app_name}_redir_lb_healthcheck":
       target  => '/etc/nginx/lb_healthchecks.conf',
       content => "location /_healthcheck_${app_name} {\n  proxy_pass http://content-data-proxy/healthcheck;\n}\n",
     }

--- a/modules/govuk/manifests/apps/kibana.pp
+++ b/modules/govuk/manifests/apps/kibana.pp
@@ -15,10 +15,10 @@ class govuk::apps::kibana(
     to => "https://logit.io/a/${logit_account}/s/${logit_environment}/kibana/access",
   }
 
-  if defined(Concat['/etc/nginx/lb_healthchecks.conf']) {
+  if ( $::aws_migration and ($::aws_environment == 'integration') ) {
     concat::fragment { 'kibana_lb_healthcheck':
       target  => '/etc/nginx/lb_healthchecks.conf',
-      content => 'location /_healthcheck_kibana {\n  return 200;\n}\n',
+      content => "location /_healthcheck_kibana {\n  return 200;\n}\n",
     }
   }
 }


### PR DESCRIPTION
Fix 0c83d1c

The healthcheck configurations are not being created,
`defined(Concat['/etc/nginx/lb_healthchecks.conf'])` is not evaluating as `true`.
It might be evaluated before the resource is created in the s_backend manifest
(the function depends on the order parse of the config).

It should be OK to create the concat fragments in any case, so we are just
going to evaluate if we are on the Integration environment and remove the
conditional when we need to promote to the rest of environments.

Other fixes are the need of `"` to parse `\n` correctly, and avoid a duplicated
`concat::fragment` resource name in `content_data_admin.pp`.