### PR TITLE
Bump alpine Docker image version of Gemstash

### DIFF
--- a/modules/govuk_containers/files/gemstash/Dockerfile
+++ b/modules/govuk_containers/files/gemstash/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.3
+FROM alpine:3.6.5
 LABEL maintainer="govuk-role-platform-accounts-members@digital.cabinet-office.gov.uk" \
       description="Runs a Gemstash server on top of Alpine" \
       version="0.1.0"

--- a/modules/govuk_containers/files/gemstash/Dockerfile
+++ b/modules/govuk_containers/files/gemstash/Dockerfile
@@ -22,8 +22,8 @@ RUN apk update \
         linux-headers \
         make \
         ncurses-dev \
-        openssl \
-        openssl-dev \
+        libressl \
+        libressl-dev \
         procps \
         readline-dev \
         ruby \


### PR DESCRIPTION
- There is a security vulnerability in the Alpine version used in the
Gemstash Dockerfile
- https://alpinelinux.org/posts/Docker-image-vulnerability-CVE-2019-5021.html

solo: @schmie