### PR TITLE
Add LB app health checks to Integration frontend and draft-frontend

### DIFF
--- a/modules/govuk/manifests/node/s_frontend.pp
+++ b/modules/govuk/manifests/node/s_frontend.pp
@@ -11,8 +11,19 @@ class govuk::node::s_frontend inherits govuk::node::s_base {
 
   include nginx
 
+  if ( $::aws_migration and ($::aws_environment == 'integration') ) {
+    concat { '/etc/nginx/lb_healthchecks.conf':
+      ensure => present,
+    }
+    $extra_config = 'include /etc/nginx/lb_healthchecks.conf;'
+  } else {
+    $extra_config = ''
+  }
+
   # If we miss all the apps, throw a 500 to be caught by the cache nginx
-  nginx::config::vhost::default { 'default': }
+  nginx::config::vhost::default { 'default':
+    extra_config => $extra_config,
+  }
 
   @@icinga::check::graphite { "check_nginx_connections_writing_${::hostname}":
     target    => "${::fqdn_metrics}.nginx.nginx_connections-writing",


### PR DESCRIPTION
Same as 1f6eec5, add extra configuration to frontend and draft-frontend
node classes to add location blocks for each application health check path.
This path is used by ALBs.

For now we are testing this feature in Integration.