### PR TITLE
Set asset manager plek override for Smokey

### DIFF
--- a/modules/govuk/manifests/apps/smokey.pp
+++ b/modules/govuk/manifests/apps/smokey.pp
@@ -51,4 +51,10 @@ class govuk::apps::smokey (
     'SIGNON_EMAIL':     value => $smokey_signon_email;
     'SIGNON_PASSWORD':  value => $smokey_signon_password;
   }
+
+  if $::aws_migration {
+    govuk::app::envvar {
+      'PLEK_SERVICE_ASSET_MANAGER_URI': value => "https://asset-manager.${app_domain}";
+    }
+  }
 }


### PR DESCRIPTION
Trello: https://trello.com/c/LtCsBme7/581-smokey-tests-are-flakey-again

Smokey tests in AWS staging and production are failing because they are
trying to access Asset Manager over an internal URI: https://asset-manager.production.govuk-internal.digital/assets/513a0efbed915d425e000002

This sets an environment variable that overrides Plek with the URI for
asset manager.