### PR TITLE
Fix `./update-pip.sh` command

### DIFF
--- a/development-vm/single-update-pip.sh
+++ b/development-vm/single-update-pip.sh
@@ -4,8 +4,6 @@ set -e
 
 . ./support_functions.sh
 
-DIRECTORY='.venv'
-
 cd "$(dirname "$0")"
 
 REPO="$1"
@@ -15,20 +13,17 @@ cd "../../$REPO"
 if [ -f lock ]; then
   warn "skipped because 'lock' file exists"
 else
-  virtualenv -q "$DIRECTORY"
   echo "Updating $REPO..."
   outputfile=$(mktemp -t update-pip.XXXXXX)
   trap "rm -f '$outputfile'" EXIT
 
-  . $DIRECTORY/bin/activate
-
-  if ! pip install --upgrade setuptools >"$outputfile" 2>&1; then
+  if ! pip install --user --upgrade setuptools >"$outputfile" 2>&1; then
     error "failed to upgrade setuptools with pip output:"
     cat "$outputfile"
     exit 1
   fi
 
-  if pip install -r requirements.txt >"$outputfile" 2>&1; then
+  if pip install --user -r requirements.txt >"$outputfile" 2>&1; then
     ok "ok"
   else
     error "failed to install dependencies with pip output:"


### PR DESCRIPTION
Previously, command failed with this:

```
Updating fabric-scripts...
fabric-scripts                            failed to upgrade setuptools with pip output:
Traceback (most recent call last):
  File "/var/govuk/fabric-scripts/.venv/bin/pip", line 6, in <module>
    from pip._internal import main
  File "/var/govuk/fabric-scripts/.venv/local/lib/python2.7/site-packages/pip/_internal/__init__.py", line 40, in <module>
    from pip._internal.cli.autocompletion import autocomplete
  File "/var/govuk/fabric-scripts/.venv/local/lib/python2.7/site-packages/pip/_internal/cli/autocompletion.py", line 8, in <module>
    from pip._internal.cli.main_parser import create_main_parser
  File "/var/govuk/fabric-scripts/.venv/local/lib/python2.7/site-packages/pip/_internal/cli/main_parser.py", line 8, in <module>
    from pip._internal.cli import cmdoptions
  File "/var/govuk/fabric-scripts/.venv/local/lib/python2.7/site-packages/pip/_internal/cli/cmdoptions.py", line 22, in <module>
    from pip._internal.utils.hashes import STRONG_HASHES
  File "/var/govuk/fabric-scripts/.venv/local/lib/python2.7/site-packages/pip/_internal/utils/hashes.py", line 10, in <module>
    from pip._internal.utils.misc import read_chunks
  File "/var/govuk/fabric-scripts/.venv/local/lib/python2.7/site-packages/pip/_internal/utils/misc.py", line 25, in <module>
    from pip._vendor.six.moves import input, shlex_quote
ImportError: cannot import name shlex_quote
```

Attempts to run these in the dev VM - as per the instructions (https://docs.publishing.service.gov.uk/manual/get-started.html#5-set-up-your-apps) - led to the same error on the `pip install` command:

```
dev$ cd /var/govuk/fabric-scripts
dev$ virtualenv .venv
dev$ source .venv/bin/activate
dev$ pip install --upgrade setuptools
dev$ pip install -r requirements.txt
```

Removing the virtualenv abstraction, and changing pip install to a local install (`--user`) fixed the installation for me.