### PR TITLE
Upgrade kernel to xenial backport in Carrenza staging

### DIFF
--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -7,7 +7,7 @@ app_domain_internal: 'staging.publishing.service.gov.uk'
 backup::server::backup_hour: 9
 
 base::shell::shell_prompt_string: 'staging'
-base::supported_kernel::enabled: false
+base::supported_kernel::enabled: true
 
 cron::daily_hour: 6
 


### PR DESCRIPTION
- We are currently running unsupported kernel 3.16.0-xxx in Carrenza
environments
- Upgrade to Xenial backport 4.4.0 appears more sensible than downgrade
to current Trusty 3.13.0
- We have to test effects on hw compatibility, but are already runnning
this kernel on a handful machines and have tested on a number more.

solo: @schmie