### PR TITLE
Add content-data-api entries to monitoring::checks::rds::servers

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1155,6 +1155,8 @@ monitoring::checks::cache::servers:
   - 'backend-redis-002'
 
 monitoring::checks::rds::servers:
+   - 'content-data-api-postgresql-primary'
+   - 'content-data-api-postgresql-standby'
    - 'postgresql-primary'
    - 'postgresql-standby'
    - 'transition-postgresql-primary'

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -253,6 +253,8 @@ monitoring::pagerduty_drill::enabled: true
 
 
 monitoring::checks::rds::servers:
+   - 'content-data-api-postgresql-primary'
+   - 'content-data-api-postgresql-standby'
    - 'postgresql-primary'
    - 'postgresql-standby'
    - 'transition-postgresql-primary'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -248,6 +248,8 @@ monitoring::contacts::slack_username: 'Staging (AWS)'
 
 
 monitoring::checks::rds::servers:
+   - 'content-data-api-postgresql-primary'
+   - 'content-data-api-postgresql-standby'
    - 'postgresql-primary'
    - 'postgresql-standby'
    - 'transition-postgresql-primary'


### PR DESCRIPTION
These are new RDS instances used by the Content Data API.