### PR TITLE
Fixes ElasticSearch import

### DIFF
--- a/development-vm/replication/sync-aws-elasticsearch.sh
+++ b/development-vm/replication/sync-aws-elasticsearch.sh
@@ -106,6 +106,7 @@ else
     \"type\": \"fs\",
     \"settings\": {
       \"compress\": true,
+      \"readonly\": true,
       \"location\": \"/usr/share/elasticsearch/import\"
     }
   }"


### PR DESCRIPTION
Without this, I was getting this error:

```
{"error":{"root_cause":[{"type":"exception","reason":"failed to create blob container"}],"type":"exception","reason":"failed to create blob container","caused_by":{"type":"access_denied_exception","reason":"/usr/share/elasticsearch/import/tests-cWu2-i6nTwaeYo7uWFiA9Q"}},"status":500} 
```

This error is because the imported data is owned by `root`, and then can't be acted upon by the `elasticsearch` user.

Trying to change ownership (`sudo docker exec elasticsearch chown -R elasticsearch /usr/share/elasticsearch/import/`) led to different errors (`chown: changing ownership of '/usr/share/elasticsearch/import/incompatible-snapshots': Operation not permitted`).

But we realised that ElasticSearch doesn't need to write/execute the data - it only needs to read it. So adding a `readonly` flag keeps ElasticSearch happy.