### PR TITLE
Add LB health check for canary-frontend

### DIFF
--- a/modules/govuk/manifests/apps/canary_frontend.pp
+++ b/modules/govuk/manifests/apps/canary_frontend.pp
@@ -18,6 +18,13 @@ class govuk::apps::canary_frontend {
         }
       ",
     }
+
+    if $::aws_environment == 'integration' {
+      concat::fragment { 'canary-frontend_lb_healthcheck':
+        target  => '/etc/nginx/lb_healthchecks.conf',
+        content => "location /_healthcheck_canary-frontend {\n  return 200;\n}\n",
+      }
+    }
   } else {
     nginx::config::site { "canary-frontend.${app_domain}":
       content => "


### PR DESCRIPTION
canary-frontend doesn't implement the govuk::app class, we need
to add the LB health check path manually.