### PR TITLE
Fix statsd app logging

### DIFF
--- a/modules/govuk/manifests/app.pp
+++ b/modules/govuk/manifests/app.pp
@@ -429,13 +429,13 @@ define govuk::app (
     logfile       => "/var/log/${title}/app.out.log",
     tags          => ['application'],
     fields        => {'application' => $title},
-    statsd_metric => "${statsd_timer_prefix}.http_%{@field.status}",
+    statsd_metric => "${statsd_timer_prefix}.http_%{status}",
     statsd_timers => [{metric => "${statsd_timer_prefix}.time_duration",
-                        value => '@fields.duration'},
+                        value => 'duration'},
                       {metric => "${statsd_timer_prefix}.time_db",
-                        value => '@fields.db'},
+                        value => 'db'},
                       {metric => "${statsd_timer_prefix}.time_view",
-                        value => '@fields.view'}],
+                        value => 'view'}],
         }
 
   @filebeat::prospector { "${title}-app-out":
@@ -475,13 +475,13 @@ define govuk::app (
       logfile       => $log_path,
       tags          => ['stdout', 'application'],
       fields        => {'application' => $title},
-      statsd_metric => "${statsd_timer_prefix}.http_%{@field.status}",
+      statsd_metric => "${statsd_timer_prefix}.http_%{status}",
       statsd_timers => [{metric => "${statsd_timer_prefix}.time_duration",
-                          value => '@fields.duration'},
+                          value => 'duration'},
                         {metric => "${statsd_timer_prefix}.time_db",
-                          value => '@fields.db'},
+                          value => 'db'},
                         {metric => "${statsd_timer_prefix}.time_view",
-                          value => '@fields.view'}],
+                          value => 'view'}],
     }
 
     @filebeat::prospector { "${title}-production-log":


### PR DESCRIPTION
The metric part of this probably never worked because `@field.status` is a typo and should've been `@fields.status`, but the timers will have stopped working for Whitehall (and other apps?) in May 2017 when logstasher was upgraded to version 1, removing the `@fields` prefix from the JSON logging.

Note that the logs themselves do work, but the statsd metrics (request timings etc) do not.

https://trello.com/c/8JceXkqD/1007-investigate-whitehall-log-processing

Bibliography:
https://docs.google.com/document/d/18bxyrWu1UQeZtIYTBxOQkn9sQbKFEz_gQIlXE-MtjRg/edit#
https://github.com/alphagov/tagalog/blob/master/tagalog/shipper/statsd.py#L36
https://github.com/alphagov/whitehall/commit/01a9c43337#diff-8b7db4d5cc4b8f6dc8feb7030baa2478L30
https://github.com/alphagov/rack-logstasher/pull/10
https://github.com/shadabahmed/logstasher/pull/54
