### PR TITLE
Fix asset slave scripts not reporting errors

### DIFF
--- a/modules/govuk/templates/node/s_asset_base/copy-attachments-to-slaves.sh.erb
+++ b/modules/govuk/templates/node/s_asset_base/copy-attachments-to-slaves.sh.erb
@@ -37,6 +37,7 @@ for FILELIST in $(find $FILELIST_DIR -type f); do
         logger -t copy_attachments_to_slaves "File ${FILENAME} copied to ${NODE}"
       else
         logger -t copy_attachments_to_slaves "File ${FILENAME} failed to copy to ${NODE}"
+        STATUS=1
       fi
     done
     <% if @s3_bucket && @process_uploaded_attachments_to_s3 %>
@@ -44,15 +45,20 @@ for FILELIST in $(find $FILELIST_DIR -type f); do
         logger -t copy_attachments_to_slaves "File ${FILENAME} copied to S3 (<%= @s3_bucket -%>)"
       else
         logger -t copy_attachments_to_slaves "File ${FILENAME} failed to copy to S3 (<%= @s3_bucket -%>)"
+        STATUS=1
       fi
     <% end %>
   done
   rm -f $FILELIST
 done
 
-if [ $? == 0 ]; then
+if [ -z $STATUS ]; then
+  STATUS=0
+fi
+
+if [ $STATUS -eq 0 ]; then
   NAGIOS_CODE=0
   NAGIOS_MESSAGE="Copying attachments to asset slaves succeeded"
 fi
 
-exit $NAGIOS_CODE
+exit $STATUS

--- a/modules/govuk/templates/node/s_asset_base/copy-attachments.sh.erb
+++ b/modules/govuk/templates/node/s_asset_base/copy-attachments.sh.erb
@@ -37,14 +37,12 @@ for NODE in $ASSET_SLAVE_NODES; do
     logger -t copy_attachments "Attachments copied to $NODE successfully"
   else
     logger -t copy_attachments "Attachments errored while copying to $NODE"
+    STATUS=1
   fi
 done
 
-if [ $? == 0 ]
-  then
-    STATUS=0
-  else
-    STATUS=1
+if [ -z $STATUS ]; then
+  STATUS=0
 fi
 
 if [ $STATUS -eq 0 ]; then

--- a/modules/govuk/templates/node/s_asset_base/push-attachments-to-s3.sh.erb
+++ b/modules/govuk/templates/node/s_asset_base/push-attachments-to-s3.sh.erb
@@ -36,13 +36,11 @@ if envdir /etc/govuk/aws/env.d /usr/local/bin/s3cmd --cache-file=/tmp/s3cmd_atta
   echo "Attachments copied to S3 (<%= @s3_bucket -%>) successfully"
 else
   echo "Attachments errored while copying to S3 (<%= @s3_bucket -%>)"
+  STATUS=1
 fi
 
-if [ $? == 0 ]
-  then
-    STATUS=0
-  else
-    STATUS=1
+if [ -z $STATUS ]; then
+  STATUS=0
 fi
 
 if [ $STATUS -eq 0 ]; then


### PR DESCRIPTION
https://trello.com/c/QwzHPc3n/586-fix-asset-slave-scripts-not-reporting-failure

Previously we (re)set the nagios code to report based on the last
command run by the script, which was often not the command that failed
(e.g. an 'echo' to print out an error message). This changes the way we
set the exit status to ensure the status is assigned correctly on error.