### PR TITLE
Enable LB app health checks on Staging

### DIFF
--- a/modules/govuk/manifests/apps/canary_frontend.pp
+++ b/modules/govuk/manifests/apps/canary_frontend.pp
@@ -19,7 +19,7 @@ class govuk::apps::canary_frontend {
       ",
     }
 
-    if $::aws_environment == 'integration' {
+    if $::aws_environment != 'production' {
       concat::fragment { 'canary-frontend_lb_healthcheck':
         target  => '/etc/nginx/lb_healthchecks.conf',
         content => "location /_healthcheck_canary-frontend {\n  return 200;\n}\n",

--- a/modules/govuk/manifests/apps/content_data_admin.pp
+++ b/modules/govuk/manifests/apps/content_data_admin.pp
@@ -127,7 +127,7 @@ class govuk::apps::content_data_admin (
     to => "https://content-data.${app_domain}/",
   }
 
-  if ( $::aws_migration and ($::aws_environment == 'integration') ) {
+  if ( $::aws_migration and ($::aws_environment != 'production') ) {
     concat::fragment { "${app_name}_redir_lb_healthcheck":
       target  => '/etc/nginx/lb_healthchecks.conf',
       content => "location /_healthcheck_${app_name} {\n  proxy_pass http://content-data-proxy/healthcheck;\n}\n",

--- a/modules/govuk/manifests/apps/kibana.pp
+++ b/modules/govuk/manifests/apps/kibana.pp
@@ -15,7 +15,7 @@ class govuk::apps::kibana(
     to => "https://logit.io/a/${logit_account}/s/${logit_environment}/kibana/access",
   }
 
-  if ( $::aws_migration and ($::aws_environment == 'integration') ) {
+  if ( $::aws_migration and ($::aws_environment != 'production') ) {
     concat::fragment { 'kibana_lb_healthcheck':
       target  => '/etc/nginx/lb_healthchecks.conf',
       content => "location /_healthcheck_kibana {\n  return 200;\n}\n",

--- a/modules/govuk/manifests/node/s_backend.pp
+++ b/modules/govuk/manifests/node/s_backend.pp
@@ -39,9 +39,10 @@ class govuk::node::s_backend inherits govuk::node::s_base {
 
   include nginx
 
-  if ( $::aws_migration and ($::aws_environment == 'integration') ) {
+  if ( $::aws_migration and ($::aws_environment != 'production') ) {
     concat { '/etc/nginx/lb_healthchecks.conf':
       ensure => present,
+      before => Nginx::Config::Vhost::Default['default'],
     }
     $extra_config = 'include /etc/nginx/lb_healthchecks.conf;'
   } else {

--- a/modules/govuk/manifests/node/s_calculators_frontend.pp
+++ b/modules/govuk/manifests/node/s_calculators_frontend.pp
@@ -6,9 +6,10 @@ class govuk::node::s_calculators_frontend inherits govuk::node::s_base {
 
   include nginx
 
-  if ( $::aws_migration and ($::aws_environment == 'integration') ) {
+  if ( $::aws_migration and ($::aws_environment != 'production') ) {
     concat { '/etc/nginx/lb_healthchecks.conf':
       ensure => present,
+      before => Nginx::Config::Vhost::Default['default'],
     }
     $extra_config = 'include /etc/nginx/lb_healthchecks.conf;'
   } else {

--- a/modules/govuk/manifests/node/s_frontend.pp
+++ b/modules/govuk/manifests/node/s_frontend.pp
@@ -11,9 +11,10 @@ class govuk::node::s_frontend inherits govuk::node::s_base {
 
   include nginx
 
-  if ( $::aws_migration and ($::aws_environment == 'integration') ) {
+  if ( $::aws_migration and ($::aws_environment != 'production') ) {
     concat { '/etc/nginx/lb_healthchecks.conf':
       ensure => present,
+      before => Nginx::Config::Vhost::Default['default'],
     }
     $extra_config = 'include /etc/nginx/lb_healthchecks.conf;'
   } else {


### PR DESCRIPTION
Deploy the application health check feature on Staging.

On Integration we had Nginx configtest errors temporary if
`/etc/nginx/lb_healthchecks.conf` wasn't created before the nginx conf
reloaded with the `include` statement. We are going to try to force
the `concat` resource to be created before the Nginx default vhost.