### PR TITLE
Upgrade kernel in Carrenza to Xenial LTS

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -49,7 +49,7 @@ backup::offsite::jobs:
     # No encryption because of size and sensitivity
 
 base::shell::shell_prompt_string: 'production'
-base::supported_kernel::enabled: false
+base::supported_kernel::enabled: true
 
 environment_ip_prefix: '10.3'
 


### PR DESCRIPTION
- Carrenza production is currently running kernel 3.16x
- Extended Security Maintenance is only available for either 3.13
(Trusty vanilla) or 4.4 (Xenial backport)
- We go for 4.4 to hopefully minimise hardware support issues (knowledge
of why we were running 3.16 in the first place is lost.)

solo: @schmie