### PR TITLE
adjust python packages so that docker plugin of collectd works

### DIFF
--- a/modules/collectd/manifests/plugin/docker.pp
+++ b/modules/collectd/manifests/plugin/docker.pp
@@ -31,9 +31,23 @@ class collectd::plugin::docker(
   # seems to be fixed in puppet 4: https://tickets.puppetlabs.com/browse/PUP-1073
   exec { 'pip install docker':
     path    => ['/usr/local/bin', '/usr/bin', '/bin'],
-    command => 'pip install "docker<=2.6.1"',
+    command => 'pip install "docker==2.7.0"',
     notify  => Class['collectd::service'],
-    unless  => 'pip list | grep "docker (2.6.1)"',
+    unless  => 'pip list | grep "docker (2.7.0)"',
+  }
+
+  exec { 'pip install urllib3':
+    path    => ['/usr/local/bin', '/usr/bin', '/bin'],
+    command => 'pip install "urllib3==1.25.3"',
+    notify  => Class['collectd::service'],
+    unless  => 'pip list | grep "urllib3 (1.25.3)"',
+  }
+
+  exec { 'pip install requests':
+    path    => ['/usr/local/bin', '/usr/bin', '/bin'],
+    command => 'pip install "requests==2.22.0"',
+    notify  => Class['collectd::service'],
+    unless  => 'pip list | grep "requests (2.22.0)"',
   }
 
   package { 'docker-py':

--- a/modules/govuk_rabbitmq/manifests/init.pp
+++ b/modules/govuk_rabbitmq/manifests/init.pp
@@ -20,7 +20,12 @@ class govuk_rabbitmq (
 
   if $::aws_migration {
     package { 'urllib3':
-      ensure   => '1.7.1',
+      ensure   => '1.25.3',
+      provider => pip,
+    }
+
+    package { 'requests':
+      ensure   => '2.22.0',
       provider => pip,
     }
   }


### PR DESCRIPTION
# Context

The docker plugin of collectd was not working on the mirrorer machines in AWS leading to several icinga unknown alerts. The root cause of this issue is that docker and urllib3 python libraries were too old. Hence, we update these now. Requests python library had also to be updated.

# Decisions
1. pin the following python libararies: docker==2.7.0, urllib3==1.25.3, and requests==2.22.0  