### PR TITLE
Add Cache ALB health check path

### DIFF
--- a/modules/router/templates/default-vhost.conf.erb
+++ b/modules/router/templates/default-vhost.conf.erb
@@ -7,6 +7,18 @@ server {
   }
 
   <%- if scope.lookupvar('::aws_migration') %>
+  # Health checks from ALB reuse Fastly __canary__ health check path
+  # and bypass authentication on Integration
+  location /_healthcheck_www {
+    proxy_pass http://varnish/__canary__;
+  }
+  location /_healthcheck_www-origin {
+    proxy_pass http://varnish/__canary__;
+  }
+  location /_healthcheck_assets-origin {
+    return 200;
+  }
+
   # Send the Strict-Transport-Security header
   include /etc/nginx/add-sts.conf;
   # Required for L7 ALB


### PR DESCRIPTION
Define location paths for application health checks from the public ALB.

We want to add the instance to the ALB `www` target group when Nginx, Varnish and
Router are up. We can achieve this with the `__canary__` endpoint. This endpoint
is not cached in Varnish.

`assets` traffic will be available as soon as Nginx is healthy.