### PR TITLE
Adds govukcli to PATH

### DIFF
--- a/modules/govuk/files/etc/profile.d/govukcli.sh
+++ b/modules/govuk/files/etc/profile.d/govukcli.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+export PATH="$PATH:/var/govuk/govuk-aws/tools/govukcli"

--- a/modules/govuk/manifests/node/s_development.pp
+++ b/modules/govuk/manifests/node/s_development.pp
@@ -56,6 +56,12 @@ class govuk::node::s_development (
     source => 'puppet:///modules/govuk/etc/profile.d/govuk-guix.sh',
   }
 
+  file { '/etc/profile.d/govukcli.sh':
+    ensure => present,
+    mode   => '0755',
+    source => 'puppet:///modules/govuk/etc/profile.d/govukcli.sh',
+  }
+
   # Install additional bash completions.
   package { 'bash-completion':
     ensure  => present,


### PR DESCRIPTION
We have documentation that makes you do this manually. We
should change this documentation after merge:

https://docs.publishing.service.gov.uk/manual/get-ssh-access.html#3-access-remote-environments