### PR TITLE
Add option to monitor rabbitmq consumers

### DIFF
--- a/modules/govuk/manifests/apps/content_data_api/rabbitmq.pp
+++ b/modules/govuk/manifests/apps/content_data_api/rabbitmq.pp
@@ -48,11 +48,12 @@ class govuk::apps::content_data_api::rabbitmq (
   }
 
   govuk_rabbitmq::queue_with_binding { $amqp_dead_letter_queue:
-    ensure        => 'present',
-    amqp_exchange => $amqp_dlx,
-    amqp_queue    => $amqp_dead_letter_queue,
-    routing_key   => '#',
-    durable       => true,
+    ensure            => 'present',
+    amqp_exchange     => $amqp_dlx,
+    amqp_queue        => $amqp_dead_letter_queue,
+    routing_key       => '#',
+    durable           => true,
+    monitor_consumers => false,
   }
 
   rabbitmq_policy { 'content_data_api-dlx@/':


### PR DESCRIPTION
This makes the icinga alarm to monitor consumer optional. This is required as not all queues will have consumers attached at all times. This allows us to remove unnecessary and noise alerts from Icinga.