### PR TITLE
Add elasticsearch B cluster as envvar

### DIFF
--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -183,6 +183,7 @@ govuk::apps::router_api::enable_running_in_draft_mode::mongodb_name: 'draft_rout
 govuk::apps::router_api::enable_running_in_draft_mode::mongodb_nodes: ['localhost']
 govuk::apps::router_api::enable_running_in_draft_mode::router_nodes: ['localhost:3134']
 govuk::apps::search_api::elasticsearch_hosts: 'http://localhost:9200'
+govuk::apps::search_api::elasticsearch_b_uri: 'http://localhost:9200'
 govuk::apps::search_api::enable_procfile_worker: false
 govuk::apps::search_api::rabbitmq_hosts: ['localhost']
 govuk::apps::search_api::rabbitmq_user: 'search-api'

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -41,6 +41,8 @@ govuk::apps::kibana::logit_environment: 2694f14b-6519-4607-81f2-8a2130e5aaec
 govuk::apps::link_checker_api::govuk_basic_auth_credentials: "%{hiera('http_username')}:%{hiera('http_password')}"
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-integration'
 govuk::apps::publishing_api::content_api_prototype: true
+# TODO: move this to common, once we have ES6 in all environments
+govuk::apps::search_api::elasticsearch_b_uri: 'http://elasticsearch6'
 govuk::apps::short_url_manager::instance_name: 'integration'
 govuk::apps::signon::instance_name: 'integration'
 govuk::apps::smartanswers::expose_govspeak: true
@@ -362,7 +364,7 @@ users::usernames:
   - richardmorton
   - rochtrinque
   - rubenarakelyan
-  - samuelculley 
+  - samuelculley
   - seanrankine
   - sebastianschmieschek
   - sebastianszypowicz

--- a/modules/govuk/manifests/apps/search_api.pp
+++ b/modules/govuk/manifests/apps/search_api.pp
@@ -93,6 +93,7 @@ class govuk::apps::search_api(
   $nagios_memory_critical = undef,
   $spelling_dependencies = 'present',
   $elasticsearch_hosts = undef,
+  $elasticsearch_b_uri = undef,
   $sitemap_generation_time = '1.10am',
   $unicorn_worker_processes = undef,
   $oauth_id = undef,
@@ -187,6 +188,11 @@ class govuk::apps::search_api(
   govuk::app::envvar { "${title}-ELASTICSEARCH_URI":
     varname => 'ELASTICSEARCH_URI',
     value   => $elasticsearch_hosts,
+  }
+
+  govuk::app::envvar { "${title}-ELASTICSEARCH_B_URI":
+    varname => 'ELASTICSEARCH_B_URI',
+    value   => $elasticsearch_b_uri,
   }
 
   govuk::app::envvar { "${title}-ELASTICSEARCH_HOSTS":


### PR DESCRIPTION
This will enable us to have search-api talk to elasticsearch6
(currently available on integration machines).

Trello: https://trello.com/c/uTsa3fpt/745.

We only have this in integration right now, as prod and staging don't have the 'B' cluster running yet.