### PR TITLE
Clone host ~/.gitconfig into VM

### DIFF
--- a/development-vm/Vagrantfile
+++ b/development-vm/Vagrantfile
@@ -105,6 +105,8 @@ Vagrant.configure("2") do |config|
     config.vm.synced_folder "../..", "/var/govuk", :type => :nfs
   end
 
+  config.vm.provision "file", source: "~/.gitconfig", destination: "~/.gitconfig"
+
   config = common_config(config)
 
   # See Vagrantfile.localconfig.example for instructions on


### PR DESCRIPTION
Copies your host machine `.gitconfig` so that you don't have to set the values globally & manually.

It means you can `vagrant ssh` and then `git pull` and everything "just works".

NB we have instructions for setting this manually, which should be removed post-merge:
https://docs.publishing.service.gov.uk/manual/get-started.html\#set-your-git-username-and-email