### PR TITLE
Fix the CollectD process regex for Sidekiq monitoring

### DIFF
--- a/modules/govuk/manifests/apps/sidekiq_monitoring.pp
+++ b/modules/govuk/manifests/apps/sidekiq_monitoring.pp
@@ -238,10 +238,11 @@ class govuk::apps::sidekiq_monitoring (
   }
 
   govuk::app { $app_name:
-    app_type           => 'bare',
-    command            => 'bundle exec foreman start',
-    enable_nginx_vhost => false,
-    hasrestart         => true,
+    app_type               => 'bare',
+    command                => 'bundle exec foreman start',
+    enable_nginx_vhost     => false,
+    hasrestart             => true,
+    collectd_process_regex => '/data/apps/sidekiq-monitoring/shared/bundle/ruby/.*/bin/rackup .*',
   }
 
   govuk::app::envvar::redis{


### PR DESCRIPTION
This doesn't quite catch all the metrics, as the foreman master is
missing, but it does at least catch the processes serving Sidekiq
Monitoring.