### PR TITLE
Run ES 5.6 on port 9200 and ES 6.7 on port 9201 in CI and the dev VM

### DIFF
--- a/development-vm/replication/sync-aws-elasticsearch.sh
+++ b/development-vm/replication/sync-aws-elasticsearch.sh
@@ -99,7 +99,7 @@ else
   status "Restoring data into Elasticsearch for $index_names"
 
   # put the snapshot in the docker container
-  sudo docker cp "/var/govuk/govuk-puppet/development-vm/replication/${LOCAL_ARCHIVE_PATH}/." elasticsearch:/usr/share/elasticsearch/import/
+  sudo docker cp "/var/govuk/govuk-puppet/development-vm/replication/${LOCAL_ARCHIVE_PATH}/." elastic-elasticsearch-5.6.15:/usr/share/elasticsearch/import/
 
   # setup the snapshot details on the server
   curl localhost:9200/_snapshot/snapshots -X PUT -d "{

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -838,16 +838,16 @@ govuk_ci::master::pipeline_jobs:
 govuk_ci::master::ci_agents:
   ci-agent-1:
     agent_hostname: 'ci-agent-1.ci'
-    labels: 'mongodb-2.4 ci-agent-1 elasticsearch-6.7 terraform postgresql-9.3'
+    labels: 'mongodb-2.4 ci-agent-1 elasticsearch-5.6 elasticsearch-6.7 terraform postgresql-9.3'
   ci-agent-2:
     agent_hostname: 'ci-agent-2.ci'
-    labels: 'mongodb-2.4 ci-agent-2 elasticsearch-5.6 terraform postgresql-9.3'
+    labels: 'mongodb-2.4 ci-agent-2 elasticsearch-5.6 elasticsearch-6.7 terraform postgresql-9.3'
   ci-agent-3:
     agent_hostname: 'ci-agent-3.ci'
-    labels: 'mongodb-2.4 ci-agent-3 elasticsearch-5.6 terraform postgresql-9.3'
+    labels: 'mongodb-2.4 ci-agent-3 elasticsearch-5.6 elasticsearch-6.7 terraform postgresql-9.3'
   ci-agent-4:
     agent_hostname: 'ci-agent-4.ci'
-    labels: 'mongodb-3.2 ci-agent-4 elasticsearch-5.6 terraform postgresql-9.6'
+    labels: 'mongodb-3.2 ci-agent-4 elasticsearch-5.6 elasticsearch-6.7 terraform postgresql-9.6'
   ci-agent-5:
     agent_hostname: 'ci-agent-5.ci'
     exclusive: true

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -185,7 +185,7 @@ govuk::apps::router_api::enable_running_in_draft_mode::mongodb_name: 'draft_rout
 govuk::apps::router_api::enable_running_in_draft_mode::mongodb_nodes: ['localhost']
 govuk::apps::router_api::enable_running_in_draft_mode::router_nodes: ['localhost:3134']
 govuk::apps::search_api::elasticsearch_hosts: 'http://localhost:9200'
-govuk::apps::search_api::elasticsearch_b_uri: 'http://localhost:9200'
+govuk::apps::search_api::elasticsearch_b_uri: 'http://localhost:9201'
 govuk::apps::search_api::enable_procfile_worker: false
 govuk::apps::search_api::rabbitmq_hosts: ['localhost']
 govuk::apps::search_api::rabbitmq_user: 'search-api'

--- a/hieradata/node/ci-agent-1.ci.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/ci-agent-1.ci.integration.publishing.service.gov.uk.yaml
@@ -1,4 +1,2 @@
 ---
-govuk_containers::elasticsearch::primary::image_version: '6.7.2'
-
 mongodb::server::version: '2.4.9'

--- a/hieradata/node/ci-agent-1.ci.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/ci-agent-1.ci.integration.publishing.service.gov.uk.yaml
@@ -1,4 +1,4 @@
 ---
-govuk_containers::elasticsearch::image_version: '6.7.2'
+govuk_containers::elasticsearch::primary::image_version: '6.7.2'
 
 mongodb::server::version: '2.4.9'

--- a/hieradata/node/ci-agent-5.ci.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/ci-agent-5.ci.integration.publishing.service.gov.uk.yaml
@@ -1,0 +1,3 @@
+---
+govuk_containers::elasticsearch::primary::ensure: 'absent'
+govuk_containers::elasticsearch::secondary::ensure: 'absent'

--- a/hieradata/node/ci-agent-6.ci.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/ci-agent-6.ci.integration.publishing.service.gov.uk.yaml
@@ -1,0 +1,3 @@
+---
+govuk_containers::elasticsearch::primary::ensure: 'absent'
+govuk_containers::elasticsearch::secondary::ensure: 'absent'

--- a/hieradata/node/ci-agent-7.ci.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/ci-agent-7.ci.integration.publishing.service.gov.uk.yaml
@@ -1,0 +1,3 @@
+---
+govuk_containers::elasticsearch::primary::ensure: 'absent'
+govuk_containers::elasticsearch::secondary::ensure: 'absent'

--- a/hieradata/node/ci-agent-8.ci.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/ci-agent-8.ci.integration.publishing.service.gov.uk.yaml
@@ -1,0 +1,3 @@
+---
+govuk_containers::elasticsearch::primary::ensure: 'absent'
+govuk_containers::elasticsearch::secondary::ensure: 'absent'

--- a/modules/govuk/manifests/node/s_development.pp
+++ b/modules/govuk/manifests/node/s_development.pp
@@ -80,7 +80,7 @@ class govuk::node::s_development (
   }
 
   include ::govuk_docker
-  include ::govuk_containers::elasticsearch
+  include ::govuk_containers::elasticsearch::primary
 
   include nginx
 

--- a/modules/govuk/manifests/node/s_development.pp
+++ b/modules/govuk/manifests/node/s_development.pp
@@ -81,6 +81,7 @@ class govuk::node::s_development (
 
   include ::govuk_docker
   include ::govuk_containers::elasticsearch::primary
+  include ::govuk_containers::elasticsearch::secondary
 
   include nginx
 

--- a/modules/govuk_ci/manifests/agent/elasticsearch.pp
+++ b/modules/govuk_ci/manifests/agent/elasticsearch.pp
@@ -4,5 +4,5 @@
 #
 class govuk_ci::agent::elasticsearch {
   include ::govuk_docker
-  include ::govuk_containers::elasticsearch
+  include ::govuk_containers::elasticsearch::primary
 }

--- a/modules/govuk_ci/manifests/agent/elasticsearch.pp
+++ b/modules/govuk_ci/manifests/agent/elasticsearch.pp
@@ -5,4 +5,5 @@
 class govuk_ci::agent::elasticsearch {
   include ::govuk_docker
   include ::govuk_containers::elasticsearch::primary
+  include ::govuk_containers::elasticsearch::secondary
 }

--- a/modules/govuk_containers/manifests/elasticsearch.pp
+++ b/modules/govuk_containers/manifests/elasticsearch.pp
@@ -47,13 +47,4 @@ class govuk_containers::elasticsearch(
     service_description => 'dockerised elasticsearch port not responding',
     host_name           => $::fqdn,
   }
-
-  # todo: remove
-  @@icinga::check { "check_elasticsearch_running_${::hostname}":
-    ensure              => 'absent',
-    check_command       => 'check_nrpe!check_proc_running!elasticsearch',
-    service_description => 'dockerised elasticsearch running',
-    notes_url           => monitoring_docs_url(check-process-running),
-    host_name           => $::fqdn,
-  }
 }

--- a/modules/govuk_containers/manifests/elasticsearch.pp
+++ b/modules/govuk_containers/manifests/elasticsearch.pp
@@ -1,4 +1,4 @@
-# == Class: govuk_containers::elasticsearch
+# == Resource: govuk_containers::elasticsearch
 #
 # Install and run a dockerised Elasticsearch server
 #
@@ -13,36 +13,41 @@
 # [*elasticsearch_port*]
 #   The port (outside the container) to use for elasticsearch.
 #
-class govuk_containers::elasticsearch(
+define govuk_containers::elasticsearch(
   $image_name = 'elastic/elasticsearch',
   $image_version = '5.6.15',
   $elasticsearch_port = '9200',
+  $ensure = 'present',
 ) {
 
-  file { '/etc/elasticsearch-docker.yml':
-    ensure  => present,
+  file { "/etc/elasticsearch-docker-${image_version}.yml":
+    ensure  => $ensure,
     content => template('govuk_containers/elasticsearch.yml'),
   }
 
-  ::docker::image { $image_name:
-    ensure    => 'present',
+  ::docker::image { "${image_name}:${image_version}":
+    ensure    => $ensure,
     require   => Class['govuk_docker'],
+    image     => $image_name,
     image_tag => $image_version,
   }
 
-  ::docker::run { 'elasticsearch':
+  ::docker::run { "${image_name}:${image_version}":
+    ensure  => $ensure,
     ports   => ["${elasticsearch_port}:9200"],
     image   => "${image_name}:${image_version}",
-    require => [Docker::Image[$image_name], File['/etc/elasticsearch-docker.yml']],
+    require => [Docker::Image["${image_name}:${image_version}"], File["/etc/elasticsearch-docker-${image_version}.yml"]],
     env     => ['"ES_JAVA_OPTS=-Xms512m -Xmx512m"', 'discovery.type=single-node', 'xpack.security.enabled=false'],
-    volumes => ['esdata5:/usr/share/elasticsearch/data', 'dataimport:/usr/share/elasticsearch/import', '/etc/elasticsearch-docker.yml:/usr/share/elasticsearch/config/elasticsearch.yml'],
+    volumes => ['/usr/share/elasticsearch/data', '/usr/share/elasticsearch/import', "/etc/elasticsearch-docker-${image_version}.yml:/usr/share/elasticsearch/config/elasticsearch.yml"],
   }
 
-  @icinga::nrpe_config { 'check_dockerised_elasticsearch_responding':
+  @icinga::nrpe_config { "check_dockerised_elasticsearch_${image_version}_responding":
+    ensure => $ensure,
     source => 'puppet:///modules/govuk_containers/nrpe_check_dockerised_elasticsearch_responding.cfg',
   }
 
-  @@icinga::check { "check_dockerised_elasticsearch_responding_${::hostname}":
+  @@icinga::check { "check_dockerised_elasticsearch_${image_version}_responding_${::hostname}":
+    ensure              => $ensure,
     check_command       => "check_nrpe!check_dockerised_elasticsearch_responding!${elasticsearch_port}",
     service_description => 'dockerised elasticsearch port not responding',
     host_name           => $::fqdn,

--- a/modules/govuk_containers/manifests/elasticsearch/primary.pp
+++ b/modules/govuk_containers/manifests/elasticsearch/primary.pp
@@ -1,0 +1,41 @@
+# == Class: govuk_containers::elasticsearch::primary
+#
+# Install and run a dockerised Elasticsearch server
+#
+# === Parameters
+#
+# [*version*]
+#   The docker image version to use.
+#
+# [*port*]
+#   The port (outside the container) to use for elasticsearch.
+#
+class govuk_containers::elasticsearch::primary(
+  $version = '5.6.15',
+  $port    = '9200',
+  $ensure  = 'present',
+) {
+  ::govuk_containers::elasticsearch { 'primary':
+    ensure             => $ensure,
+    image_version      => $version,
+    elasticsearch_port => $port,
+  }
+
+  # todo: remove
+  ::docker::run { 'elasticsearch':
+    ensure => 'absent',
+    image  => "elasticsearch:${version}",
+  }
+
+  @icinga::nrpe_config { 'check_dockerised_elasticsearch_responding':
+    ensure => 'absent',
+    source => 'puppet:///modules/govuk_containers/nrpe_check_dockerised_elasticsearch_responding.cfg',
+  }
+
+  @@icinga::check { "check_dockerised_elasticsearch_responding_${::hostname}":
+    ensure              => 'absent',
+    check_command       => "check_nrpe!check_dockerised_elasticsearch_responding!${port}",
+    service_description => 'dockerised elasticsearch port not responding',
+    host_name           => $::fqdn,
+  }
+}

--- a/modules/govuk_containers/manifests/elasticsearch/primary.pp
+++ b/modules/govuk_containers/manifests/elasticsearch/primary.pp
@@ -15,16 +15,16 @@ class govuk_containers::elasticsearch::primary(
   $port    = '9200',
   $ensure  = 'present',
 ) {
+  # todo: remove absent things
+  ::docker::run { 'elasticsearch':
+    ensure => 'absent',
+    image  => "elasticsearch:${version}",
+  } ->
+
   ::govuk_containers::elasticsearch { 'primary':
     ensure             => $ensure,
     image_version      => $version,
     elasticsearch_port => $port,
-  }
-
-  # todo: remove
-  ::docker::run { 'elasticsearch':
-    ensure => 'absent',
-    image  => "elasticsearch:${version}",
   }
 
   @icinga::nrpe_config { 'check_dockerised_elasticsearch_responding':

--- a/modules/govuk_containers/manifests/elasticsearch/secondary.pp
+++ b/modules/govuk_containers/manifests/elasticsearch/secondary.pp
@@ -1,0 +1,23 @@
+# == Class: govuk_containers::elasticsearch::secondary
+#
+# Install and run a dockerised Elasticsearch server
+#
+# === Parameters
+#
+# [*version*]
+#   The docker image version to use.
+#
+# [*port*]
+#   The port (outside the container) to use for elasticsearch.
+#
+class govuk_containers::elasticsearch::secondary(
+  $version = '6.7.2',
+  $port    = '9201',
+  $ensure  = 'present'
+) {
+  ::govuk_containers::elasticsearch { 'secondary':
+    ensure             => $ensure,
+    image_version      => $version,
+    elasticsearch_port => $port,
+  }
+}


### PR DESCRIPTION
This is so we can test the dual-ES set-up we're going for for the 5->6 migration.

```
vagrant@development:~$ curl localhost:9200
{
  "name" : "jAi3R7x",
  "cluster_name" : "docker-cluster",
  "cluster_uuid" : "uGKOVk9bQxuuDO3v5_lGSQ",
  "version" : {
    "number" : "5.6.15",
    "build_hash" : "fe7575a",
    "build_date" : "2019-02-13T16:21:45.880Z",
    "build_snapshot" : false,
    "lucene_version" : "6.6.1"
  },
  "tagline" : "You Know, for Search"
}
vagrant@development:~$ curl localhost:9201
{
  "name" : "QF9TNCN",
  "cluster_name" : "docker-cluster",
  "cluster_uuid" : "iJCsBuwKQaKnlay7ZZcRfA",
  "version" : {
    "number" : "6.7.2",
    "build_flavor" : "default",
    "build_type" : "docker",
    "build_hash" : "56c6e48",
    "build_date" : "2019-04-29T09:05:50.290371Z",
    "build_snapshot" : false,
    "lucene_version" : "7.7.0",
    "minimum_wire_compatibility_version" : "5.6.0",
    "minimum_index_compatibility_version" : "5.0.0"
  },
  "tagline" : "You Know, for Search"
}
```

I checked ci-agent-1 and it had plenty of free resources, so adding one more container should be fine.  However I've disabled the containers on ci-agent-{5..8} because those agents run the e2e tests and resources can be tight.

---

[Trello card](https://trello.com/c/uTsa3fpt/745-make-search-api-talk-to-both-es5-and-es6-%F0%9F%8D%90-m)