### PR TITLE
Fix the Licensify CollectD process regexes

### DIFF
--- a/modules/licensify/manifests/apps/licensify.pp
+++ b/modules/licensify/manifests/apps/licensify.pp
@@ -16,7 +16,7 @@ class licensify::apps::licensify (
     require                        => File['/etc/licensing'],
     proxy_http_version_1_1_enabled => true,
     log_format_is_json             => true,
-    collectd_process_regex         => 'java -Duser.dir=/data/vhost/licensify.integration.publishing.service.gov.uk/licensify-.*',
+    collectd_process_regex         => 'java -Duser.dir=\/data\/vhost\/licensify\..*publishing\.service\.gov\.uk\/licensify-.*',
   }
 
   licensify::apps::envvars { 'licensify':

--- a/modules/licensify/manifests/apps/licensify_admin.pp
+++ b/modules/licensify/manifests/apps/licensify_admin.pp
@@ -16,7 +16,7 @@ class licensify::apps::licensify_admin(
     require                        => File['/etc/licensing'],
     proxy_http_version_1_1_enabled => true,
     log_format_is_json             => true,
-    collectd_process_regex         => 'java -Duser.dir=/data/vhost/licensify-admin.integration.publishing.service.gov.uk/licensify-admin-.*',
+    collectd_process_regex         => 'java -Duser.dir=\/data\/vhost\/licensify-admin\..*publishing\.service\.gov\.uk\/licensify-admin-.*',
   }
 
   licensify::apps::envvars { 'licensify-admin':

--- a/modules/licensify/manifests/apps/licensify_feed.pp
+++ b/modules/licensify/manifests/apps/licensify_feed.pp
@@ -16,7 +16,7 @@ class licensify::apps::licensify_feed(
     proxy_http_version_1_1_enabled => true,
     log_format_is_json             => true,
     health_check_path              => '/licence-management/feed/process-applications',
-    collectd_process_regex         => 'java -Duser.dir=/data/vhost/licensify-feed.integration.publishing.service.gov.uk/licensify-feed-.*',
+    collectd_process_regex         => 'java -Duser.dir=\/data\/vhost\/licensify-feed\..*publishing\.service\.gov\.uk\/licensify-feed-.*',
   }
 
   licensify::apps::envvars { 'licensify-feed':


### PR DESCRIPTION
These worked in Integration, but not in Staging or Production, as the
regexes were too specific to Integration. This commit changes them to
have wildcards where the environment can be specified, and also
escapes the forward slashes for neatness.