### PR TITLE
Increase the memory monitoring thresholds for Sidekiq monitoring

### DIFF
--- a/modules/govuk/manifests/apps/sidekiq_monitoring.pp
+++ b/modules/govuk/manifests/apps/sidekiq_monitoring.pp
@@ -243,6 +243,8 @@ class govuk::apps::sidekiq_monitoring (
     enable_nginx_vhost     => false,
     hasrestart             => true,
     collectd_process_regex => '/data/apps/sidekiq-monitoring/shared/bundle/ruby/.*/bin/rackup .*',
+    nagios_memory_warning  => 1500,
+    nagios_memory_critical => 1600,
   }
 
   govuk::app::envvar::redis{


### PR DESCRIPTION
The CollectD process plugin has only just been configured correctly,
so this is something that's only now appearing.

The memory usage seems to be significantly higher in AWS, compared to
Carrenza. I'm not sure why this is, but this higher threshold reflects
the current usage in AWS.