### PR TITLE
Overrides the process regex to look for custom tag

### DIFF
--- a/modules/govuk/manifests/apps/content_audit_tool.pp
+++ b/modules/govuk/manifests/apps/content_audit_tool.pp
@@ -107,12 +107,14 @@ class govuk::apps::content_audit_tool(
     enable_service => $enable_procfile_worker,
     setenv_as      => $app_name,
     process_type   => 'google-analytics-worker',
+    process_regex  => 'sidekiq .* content-audit-tool\/google-analytics-worker .*',
   }
 
   govuk::procfile::worker { "${app_name}-publishing-api-worker":
     enable_service => $enable_procfile_worker,
     setenv_as      => $app_name,
     process_type   => 'publishing-api-worker',
+    process_regex  => 'sidekiq .* content-audit-tool\/publishing-api-worker .*',
   }
 
   govuk::app::envvar {


### PR DESCRIPTION
Trello card: https://trello.com/c/r4s5HkdF/

We've had to pass a custom '--tag' to sidekiq so that it names our
process. Previously, process would simply be 'sidekiq 5.2.5 content-audit-tool [0 of x]',
which doesn't tell us which of the workers it is.

Now, output will be 'sidekiq 5.2.5 content-audit-tool/google-analytics-worker [0 of x]'
(for example), which gives us a very regexable process name.

To be merged with https://github.com/alphagov/content-audit-tool/pull/306.