### PR TITLE
Add a Icinga check for the CollectD process

### DIFF
--- a/modules/collectd/manifests/service.pp
+++ b/modules/collectd/manifests/service.pp
@@ -7,4 +7,11 @@ class collectd::service {
     ensure  => running,
     restart => "/etc/init.d/collectd restart || { pkill -9 collectd; ps aux | grep '/usr/lib/collectd/file_handles.sh' | awk '{{print \$2}}' | xargs kill -9 ;/etc/init.d/collectd start; }",
   }
+
+  @@icinga::check { "check_collectd_running_${::hostname}":
+    check_command       => 'check_nrpe!check_proc_running!collectd',
+    service_description => 'collectd system statistics daemon',
+    host_name           => $::fqdn,
+    notes_url           => monitoring_docs_url(check-process-running),
+  }
 }


### PR DESCRIPTION
Sometimes, this isn't running when it should be, and there's no
explicit check for this yet.