### PR TITLE
Update search metrics for finders

### DIFF
--- a/modules/grafana/templates/dashboards/application_dashboard_panels/_search_api_request_time.json.erb
+++ b/modules/grafana/templates/dashboards/application_dashboard_panels/_search_api_request_time.json.erb
@@ -6,11 +6,11 @@
   "targets": [
     {
       "refId": "A",
-      "target": "alias(maxSeries(stats.timers.govuk.app.<%= @app_name %>.*.rummager.site_search.upper_90), 'Site Search')"
+      "target": "alias(maxSeries(stats.timers.govuk.app.<%= @app_name %>.*.rummager.finder_search.upper_90), 'Single search')"
     },
     {
       "refId": "B",
-      "target": "alias(maxSeries(stats.timers.govuk.app.<%= @app_name %>.*.rummager.finder_batch_search.upper_90), 'Finder Batch Search')"
+      "target": "alias(maxSeries(stats.timers.govuk.app.<%= @app_name %>.*.rummager.finder_batch_search.upper_90), 'Batch search')"
     }
   ],
   "datasource": "Graphite",


### PR DESCRIPTION
The `rummager.site_search` metric is no longer used because we retired site search.  

We still want to track searches to the standard search endpoint though, and this new value matches the id used in https://github.com/alphagov/finder-frontend/pull/1044