### PR TITLE
Add LB app healthchecks email_alert_api publishing_api search

### DIFF
--- a/modules/govuk/manifests/node/s_email_alert_api.pp
+++ b/modules/govuk/manifests/node/s_email_alert_api.pp
@@ -24,8 +24,20 @@ class govuk::node::s_email_alert_api inherits govuk::node::s_base {
 
   include nginx
 
+  if ( $::aws_migration and ($::aws_environment != 'production') ) {
+    concat { '/etc/nginx/lb_healthchecks.conf':
+      ensure => present,
+      before => Nginx::Config::Vhost::Default['default'],
+    }
+    $extra_config = 'include /etc/nginx/lb_healthchecks.conf;'
+  } else {
+    $extra_config = ''
+  }
+
   # If we miss all the apps, throw a 500 to be caught by the cache nginx
-  nginx::config::vhost::default { 'default': }
+  nginx::config::vhost::default { 'default':
+    extra_config => $extra_config,
+  }
 
   # Ensure memcached is available to backend nodes
   include collectd::plugin::memcached

--- a/modules/govuk/manifests/node/s_search.pp
+++ b/modules/govuk/manifests/node/s_search.pp
@@ -13,8 +13,20 @@ class govuk::node::s_search inherits govuk::node::s_base {
 
   include nginx
 
+  if ( $::aws_migration and ($::aws_environment != 'production') ) {
+    concat { '/etc/nginx/lb_healthchecks.conf':
+      ensure => present,
+      before => Nginx::Config::Vhost::Default['default'],
+    }
+    $extra_config = 'include /etc/nginx/lb_healthchecks.conf;'
+  } else {
+    $extra_config = ''
+  }
+
   # If we miss all the apps, throw a 500 to be caught by the cache nginx
-  nginx::config::vhost::default { 'default': }
+  nginx::config::vhost::default { 'default':
+    extra_config => $extra_config,
+  }
 
   # Data sync for managed elasticsearch
   if $::aws_migration {


### PR DESCRIPTION
Add a location in the default vhost of email_alert_api, publishing_api
and search to be used as application health check by L7 LBs if needed.