### PR TITLE
Remove ordering constraint in primary ES container

### DIFF
--- a/modules/govuk_containers/manifests/elasticsearch/primary.pp
+++ b/modules/govuk_containers/manifests/elasticsearch/primary.pp
@@ -19,7 +19,7 @@ class govuk_containers::elasticsearch::primary(
   ::docker::run { 'elasticsearch':
     ensure => 'absent',
     image  => "elasticsearch:${version}",
-  } ->
+  }
 
   ::govuk_containers::elasticsearch { 'primary':
     ensure             => $ensure,


### PR DESCRIPTION
There's a dependency cycle on CI, so just let puppet figure it out.

If it fails to start the new container because it hasn't stopped the old one yet,
a second run of puppet will address that.