### PR TITLE
Fix imminence being absent in the Dev VM

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -508,7 +508,6 @@ govuk::apps::govuk_crawler_worker::root_urls:
   - "https://assets.%{hiera('app_domain')}"
   - "https://www.%{hiera('app_domain')}"
 
-govuk::apps::imminence::ensure: 'absent'
 govuk::apps::imminence::mongodb_nodes:
   - 'mongo-1.backend'
   - 'mongo-2.backend'

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -69,6 +69,7 @@ govuk::apps::email_alert_api::govuk_notify_template_id: 'cb633abc-6ae6-4843-ae6f
 govuk::apps::government-frontend::cpu_warning: 200
 govuk::apps::government-frontend::cpu_critical: 300
 govuk::apps::hmrc_manuals_api::publish_topics: false
+govuk::apps::imminence::ensure: 'absent'
 govuk::apps::kibana::logit_environment: 0ea55710-075b-4eab-bfc3-475f28cdd0c3
 govuk::apps::local_links_manager::local_links_manager_passive_checks: true
 govuk::apps::local_links_manager::run_links_ga_export: true

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -32,6 +32,7 @@ govuk::apps::email_alert_api::email_address_override_whitelist_only: true
 govuk::apps::email_alert_api::delivery_request_threshold: "3000"
 govuk::apps::email_alert_frontend::subscription_management_enabled: true
 govuk::apps::hmrc_manuals_api::publish_topics: false
+govuk::apps::imminence::ensure: 'absent'
 govuk::apps::government-frontend::cpu_warning: 200
 govuk::apps::government-frontend::cpu_critical: 300
 govuk::apps::kibana::logit_environment: d414187a-2796-4ea7-9b9a-d40c341646d6


### PR DESCRIPTION
The development-vm uses the Carrenza hieradata, so you have to be
careful to not remove things from it when removing them from Carrenza
Production and Carrenza Staging. I wasn't that careful with Imminence,
so this change fixes that.