### PR TITLE
Add an $enable parameter to elasticsearch containers

### DIFF
--- a/hieradata/node/ci-agent-5.ci.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/ci-agent-5.ci.integration.publishing.service.gov.uk.yaml
@@ -1,3 +1,3 @@
 ---
-govuk_containers::elasticsearch::primary::ensure: 'absent'
-govuk_containers::elasticsearch::secondary::ensure: 'absent'
+govuk_containers::elasticsearch::primary::enable: false
+govuk_containers::elasticsearch::secondary::enable: false

--- a/hieradata/node/ci-agent-6.ci.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/ci-agent-6.ci.integration.publishing.service.gov.uk.yaml
@@ -1,3 +1,3 @@
 ---
-govuk_containers::elasticsearch::primary::ensure: 'absent'
-govuk_containers::elasticsearch::secondary::ensure: 'absent'
+govuk_containers::elasticsearch::primary::enable: false
+govuk_containers::elasticsearch::secondary::enable: false

--- a/hieradata/node/ci-agent-7.ci.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/ci-agent-7.ci.integration.publishing.service.gov.uk.yaml
@@ -1,3 +1,3 @@
 ---
-govuk_containers::elasticsearch::primary::ensure: 'absent'
-govuk_containers::elasticsearch::secondary::ensure: 'absent'
+govuk_containers::elasticsearch::primary::enable: false
+govuk_containers::elasticsearch::secondary::enable: false

--- a/hieradata/node/ci-agent-8.ci.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/ci-agent-8.ci.integration.publishing.service.gov.uk.yaml
@@ -1,3 +1,3 @@
 ---
-govuk_containers::elasticsearch::primary::ensure: 'absent'
-govuk_containers::elasticsearch::secondary::ensure: 'absent'
+govuk_containers::elasticsearch::primary::enable: false
+govuk_containers::elasticsearch::secondary::enable: false

--- a/modules/govuk_containers/manifests/elasticsearch/primary.pp
+++ b/modules/govuk_containers/manifests/elasticsearch/primary.pp
@@ -14,6 +14,7 @@ class govuk_containers::elasticsearch::primary(
   $version = '5.6.15',
   $port    = '9200',
   $ensure  = 'present',
+  $enable  = true,
 ) {
   # todo: remove absent things
   ::docker::run { 'elasticsearch':
@@ -21,10 +22,12 @@ class govuk_containers::elasticsearch::primary(
     image  => "elasticsearch:${version}",
   }
 
-  ::govuk_containers::elasticsearch { 'primary':
-    ensure             => $ensure,
-    image_version      => $version,
-    elasticsearch_port => $port,
+  if $enable {
+    ::govuk_containers::elasticsearch { 'primary':
+      ensure             => $ensure,
+      image_version      => $version,
+      elasticsearch_port => $port,
+    }
   }
 
   @icinga::nrpe_config { 'check_dockerised_elasticsearch_responding':

--- a/modules/govuk_containers/manifests/elasticsearch/secondary.pp
+++ b/modules/govuk_containers/manifests/elasticsearch/secondary.pp
@@ -13,11 +13,14 @@
 class govuk_containers::elasticsearch::secondary(
   $version = '6.7.2',
   $port    = '9201',
-  $ensure  = 'present'
+  $ensure  = 'present',
+  $enable  = true,
 ) {
-  ::govuk_containers::elasticsearch { 'secondary':
-    ensure             => $ensure,
-    image_version      => $version,
-    elasticsearch_port => $port,
+  if $enable {
+    ::govuk_containers::elasticsearch { 'secondary':
+      ensure             => $ensure,
+      image_version      => $version,
+      elasticsearch_port => $port,
+    }
   }
 }


### PR DESCRIPTION
Using ensure => absent on a service which was never installed in the
first place doesn't work with our version of puppet:

https://projects.puppetlabs.com/issues/17286
https://tickets.puppetlabs.com/browse/PUP-2188

This bug which doesn't appear in more recent versions of puppet, but
we're stuck with this ancient one for now.  So as a workaround just
don't include the govuk_container::elasticsearch definition on
ci-agent-{5..8}.