### PR TITLE
Improve the smokey-loop upstart service

### DIFF
--- a/modules/monitoring/templates/smokey-loop.conf
+++ b/modules/monitoring/templates/smokey-loop.conf
@@ -1,9 +1,19 @@
 description "Smokey loop outputs JSON which is consumed by monitoring"
 
+setuid smokey
+setgid smokey
+
 # Run in a continuous loop. `respawn` catches non-zero exit codes. Whereas
 # `and stopped` catches normal exits. The default `respawn limit` will
 # prevent this from spinning if the script is broken.
 start on runlevel [2345] and stopped $UPSTART_JOB
 respawn
+respawn limit unlimited
 
-exec sudo -u smokey /opt/smokey/tests_json_output.sh /tmp/smokey.json <%= @environment %>
+kill timeout 240
+
+exec /opt/smokey/tests_json_output.sh /tmp/smokey.json.tmp integration
+
+post-stop script
+    mv /tmp/smokey.json.tmp /tmp/smokey.json
+end script


### PR DESCRIPTION
Currently, as /opt/smokey/tests_json_output.sh is a bash script, when
the service stops, that bash script is stopped, but the actual
cucumber process keeps running. Bash is not a process manager.

Instead, better use upstart to avoid this issue. Use setuid and setgid
rather than sudo, set respawn limit as this service should always
respawn, and a long kill timeout to let cucumber exit
gracefully. Also, add a post-stop script (that runs after each
respawn) to move the output to the proper location.

These changes match up with changes in Smokey to the
tests_json_output.sh script.