### PR TITLE
Increase licensify thresholds for 3 apps

### DIFF
--- a/modules/licensify/manifests/apps/licensify.pp
+++ b/modules/licensify/manifests/apps/licensify.pp
@@ -17,6 +17,8 @@ class licensify::apps::licensify (
     proxy_http_version_1_1_enabled => true,
     log_format_is_json             => true,
     collectd_process_regex         => 'java -Duser.dir=\/data\/vhost\/licensify\..*publishing\.service\.gov\.uk\/licensify-.*',
+    nagios_memory_warning          => 900,
+    nagios_memory_critical         => 1000,
   }
 
   licensify::apps::envvars { 'licensify':

--- a/modules/licensify/manifests/apps/licensify_admin.pp
+++ b/modules/licensify/manifests/apps/licensify_admin.pp
@@ -17,6 +17,8 @@ class licensify::apps::licensify_admin(
     proxy_http_version_1_1_enabled => true,
     log_format_is_json             => true,
     collectd_process_regex         => 'java -Duser.dir=\/data\/vhost\/licensify-admin\..*publishing\.service\.gov\.uk\/licensify-admin-.*',
+    nagios_memory_warning          => 900,
+    nagios_memory_critical         => 1000,
   }
 
   licensify::apps::envvars { 'licensify-admin':

--- a/modules/licensify/manifests/apps/licensify_feed.pp
+++ b/modules/licensify/manifests/apps/licensify_feed.pp
@@ -17,6 +17,8 @@ class licensify::apps::licensify_feed(
     log_format_is_json             => true,
     health_check_path              => '/licence-management/feed/process-applications',
     collectd_process_regex         => 'java -Duser.dir=\/data\/vhost\/licensify-feed\..*publishing\.service\.gov\.uk\/licensify-feed-.*',
+    nagios_memory_warning          => 1400,
+    nagios_memory_critical         => 1500,
   }
 
   licensify::apps::envvars { 'licensify-feed':


### PR DESCRIPTION
The CollectD process plugin has only just been configured correctly,
so memory threshold alerts are something that are only now appearing.

I've looked at the traffic on Grafana and set thresholds for all 3 related
licensify apps based on these.

![Screen Shot 2019-06-07 at 10 22 03](https://user-images.githubusercontent.com/5111927/59095208-cdb1b100-890f-11e9-9570-bd7687149e94.png)
