### PR TITLE
Make the Link Checker API absent in Carrenza Prod and Staging

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -90,6 +90,7 @@ task :check_consistency_between_aws_and_carrenza do
     router::draft_assets::vhost_name
 
     govuk::apps::imminence::ensure
+    govuk::apps::link_checker_api::ensure
     govuk::apps::government-frontend::cpu_critical
     govuk::apps::government-frontend::cpu_warning
     govuk::apps::whitehall::cpu_critical

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -71,6 +71,7 @@ govuk::apps::government-frontend::cpu_critical: 300
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::imminence::ensure: 'absent'
 govuk::apps::kibana::logit_environment: 0ea55710-075b-4eab-bfc3-475f28cdd0c3
+govuk::apps::link_checker_api::ensure: 'absent'
 govuk::apps::local_links_manager::local_links_manager_passive_checks: true
 govuk::apps::local_links_manager::run_links_ga_export: true
 govuk::apps::publisher::run_fact_check_fetcher: true

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -36,6 +36,7 @@ govuk::apps::imminence::ensure: 'absent'
 govuk::apps::government-frontend::cpu_warning: 200
 govuk::apps::government-frontend::cpu_critical: 300
 govuk::apps::kibana::logit_environment: d414187a-2796-4ea7-9b9a-d40c341646d6
+govuk::apps::link_checker_api::ensure: 'absent'
 govuk::apps::link_checker_api::govuk_basic_auth_credentials: "%{hiera('http_username')}:%{hiera('http_password')}"
 govuk::apps::publisher::run_fact_check_fetcher: false
 govuk::apps::publisher::fact_check_address_format: 'factcheck+staging-{id}@alphagov.co.uk'


### PR DESCRIPTION
The Link Checker API is now running in AWS, but still running (but
should be unused) in Carrenza Production and Carrenza Staging.

This old, unused version of the app still runinng in Carrenza is
potentially confusing, and consumes some resources. Therefore, this
commit makes it absent.