### PR TITLE
Increase the number of Unicorn workers for the Publishing API

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -537,6 +537,7 @@ govuk::apps::licencefinder::mongodb_nodes:
   - 'mongo-2.backend'
   - 'mongo-3.backend'
 
+govuk::apps::publishing_api::unicorn_worker_processes: "8"
 govuk::apps::publishing_api::content_store: "https://content-store.%{hiera('app_domain')}"
 govuk::apps::publishing_api::db_hostname: "postgresql-primary-1.backend"
 govuk::apps::publishing_api::db_port: 6432

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -600,6 +600,7 @@ govuk::apps::licencefinder::mongodb_nodes:
   - 'mongo-2'
   - 'mongo-3'
 
+govuk::apps::publishing_api::unicorn_worker_processes: "8"
 govuk::apps::publishing_api::content_store: "https://content-store.%{hiera('app_domain')}"
 govuk::apps::publishing_api::db_hostname: "db-admin"
 govuk::apps::publishing_api::db_port: 6432

--- a/modules/govuk/manifests/apps/publishing_api.pp
+++ b/modules/govuk/manifests/apps/publishing_api.pp
@@ -37,6 +37,9 @@
 #   store running while testing unrelated features.
 #   Default: ''
 #
+# [*unicorn_worker_processes*]
+#   The number of unicorn workers to run for an instance of this app
+#
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
@@ -125,6 +128,7 @@ class govuk::apps::publishing_api(
   $draft_content_store_bearer_token = undef,
   $router_api_bearer_token = undef,
   $suppress_draft_store_502_error = '',
+  $unicorn_worker_processes = undef,
   $sentry_dsn = undef,
   $secret_key_base = undef,
   $db_hostname = undef,
@@ -165,6 +169,7 @@ class govuk::apps::publishing_api(
     health_check_path                => '/healthcheck',
     health_check_service_template    => 'govuk_urgent_priority',
     health_check_notification_period => '24x7',
+    unicorn_worker_processes         => $unicorn_worker_processes,
     json_health_check                => true,
     log_format_is_json               => true,
     deny_framing                     => true,


### PR DESCRIPTION
There seems to be peaks of activity, currently there are only 2
workers per machine, but there is plenty of RAM to run more.