### PR TITLE
Update package py-dateutil resource in collectd docker

### DIFF
--- a/modules/collectd/manifests/plugin/docker.pp
+++ b/modules/collectd/manifests/plugin/docker.pp
@@ -16,16 +16,6 @@ class collectd::plugin::docker(
 ) {
   include ::collectd
 
-  $dependencies = [
-    'py-dateutil<=2.2',
-  ]
-
-  package { $dependencies:
-    ensure   => 'present',
-    provider => 'pip',
-    notify   => Class['collectd::service'],
-  }
-
   # This has to be installed via exec rather than a package as the namespace
   # conflicts with the different (but same name) docker package. This issue
   # seems to be fixed in puppet 4: https://tickets.puppetlabs.com/browse/PUP-1073
@@ -50,6 +40,12 @@ class collectd::plugin::docker(
     unless  => 'pip list | grep "requests (2.22.0)"',
   }
 
+  package { 'py-dateutil':
+    ensure   => '2.2',
+    provider => 'pip',
+    notify   => Class['collectd::service'],
+  }
+
   package { 'docker-py':
     ensure   => 'absent',
     provider => 'pip',
@@ -66,6 +62,6 @@ class collectd::plugin::docker(
 
   @collectd::plugin { 'docker':
     content => template('collectd/etc/collectd/conf.d/docker.conf.erb'),
-    require => Package[$dependencies],
+    require => Package['py-dateutil'],
   }
 }


### PR DESCRIPTION
On the ci Jenkins machines, Puppet keeps reinstalling the package
py-dateutil on every run. It might be that it's not able to determine
the current version vs the version required. There are a few bugs in
the package pip provider, might be a proble of running an old version of
Puppet.

In other cases, we enforce the version of the pip package with the
`ensure` parameter, instead of the resource name. We can try this
to see if we stop the reinstallations.