### PR TITLE
Remove pg bouncer from db_admin servers

### DIFF
--- a/modules/govuk/manifests/node/s_db_admin.pp
+++ b/modules/govuk/manifests/node/s_db_admin.pp
@@ -140,8 +140,6 @@ class govuk::node::s_db_admin(
   # Ensure the client class is installed
   class { '::govuk_postgresql::client': } ->
 
-  class { '::govuk_pgbouncer': } ->
-
   # include all PostgreSQL classes that create databases and users
   class { '::govuk::apps::content_audit_tool::db': } ->
   class { '::govuk::apps::content_data_admin::db': } ->


### PR DESCRIPTION
Apps in AWS now talk directly to RDS.

Merge after https://github.com/alphagov/govuk-puppet/pull/9226 is deployed.

https://trello.com/c/XJDsLgE6/1006-remove-pgbouncer-in-aws