### PR TITLE
Remove setgid smokey from smokey-loop.conf

### DIFF
--- a/modules/monitoring/templates/smokey-loop.conf
+++ b/modules/monitoring/templates/smokey-loop.conf
@@ -1,7 +1,6 @@
 description "Smokey loop outputs JSON which is consumed by monitoring"
 
 setuid smokey
-setgid smokey
 
 # Run in a continuous loop. `respawn` catches non-zero exit codes. Whereas
 # `and stopped` catches normal exits. The default `respawn limit` will


### PR DESCRIPTION
This doesn't work on all monitoring machines, as the smokey group
doesn't exist. This probably only worked on Integration as it had been
manually added, so just specify setuid.