### PR TITLE
Correctly specify the environment in the smokey-loop service

### DIFF
--- a/modules/monitoring/templates/smokey-loop.conf
+++ b/modules/monitoring/templates/smokey-loop.conf
@@ -12,7 +12,7 @@ respawn limit unlimited
 
 kill timeout 240
 
-exec /opt/smokey/tests_json_output.sh /tmp/smokey.json.tmp integration
+exec /opt/smokey/tests_json_output.sh /tmp/smokey.json.tmp <%= @environment %>
 
 post-stop script
     mv /tmp/smokey.json.tmp /tmp/smokey.json


### PR DESCRIPTION
This should be a variable, but was incorrectly changed to a value.