### PR TITLE
configure aws production crawler for weekend-test

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -339,6 +339,8 @@ task :check_consistency_between_aws_and_carrenza do
     router::nginx::robotstxt
     govuk::apps::govuk_crawler_worker::blacklist_paths
     govuk_crawler::start_hour
+    govuk_crawler::days
+    govuk::apps::govuk_crawler_worker::crawler_threads
   ]
 
   failed = false

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -115,6 +115,20 @@ govuk::apps::content_store::performance_platform_big_screen_view_url: 'https://p
 govuk::apps::content_store::performance_platform_spotlight_url: 'https://performance-platform-spotlight-production.cloudapps.digital'
 govuk::apps::content_store::plek_service_whitehall_frontend_uri: 'https://whitehall-frontend.publishing.service.gov.uk'
 
+govuk::apps::govuk_crawler_worker::blacklist_paths:
+  - '/apply-for-a-licence'
+  - '/business-finance-support-finder'
+  - '/drug-device-alerts.atom'
+  - '/drug-safety-update.atom'
+  - '/foreign-travel-advice.atom'
+  - '/government/announcements.atom'
+  - '/government/publications.atom'
+  - '/government/statistics.atom'
+  - '/licence-finder'
+  - '/search'
+
+govuk::apps::govuk_crawler_worker::crawler_threads: 32
+
 govuk::apps::email_alert_service::enabled: false
 govuk::apps::email_alert_service::rabbitmq::ensure: 'absent'
 govuk::apps::email_alert_api::db::backend_ip_range: '10.13.3.0/24'
@@ -163,12 +177,14 @@ govuk_containers::terraboard::aws_bucket: 'govuk-terraform-steppingstone-product
 govuk_containers::terraboard::oauth2_proxy_base_url: 'https://terraboard.production.govuk.digital'
 
 govuk_crawler::seed_enable: true
+govuk_crawler::days: 'FRI'
+govuk_crawler::start_hour: 20
 govuk_crawler::sync_enable: true
 govuk_crawler::site_root: 'https://www.gov.uk'
 govuk_crawler::targets:
   - 'mirror-rsync@mirror0.mirror.provider1.production.govuk.service.gov.uk'
   - 'mirror-rsync@mirror1.mirror.provider1.production.govuk.service.gov.uk'
-  - 's3://govuk-mirror-production/'
+  - 's3://govuk-production-mirror/'
 
 govuk::apps::govuk_crawler_worker::root_urls:
   - 'https://assets.digital.cabinet-office.gov.uk/'

--- a/modules/govuk/manifests/apps/govuk_crawler_worker.pp
+++ b/modules/govuk/manifests/apps/govuk_crawler_worker.pp
@@ -20,6 +20,11 @@
 # [*blacklist_paths*]
 #   A list of paths that the crawler worker should not crawl
 #
+# [*crawler_threads*]
+#   The number of threads for the crawler worker
+#   Type: integer
+#   Default: 4
+#
 # [*enabled*]
 #   Whether the app should be enabled
 #
@@ -43,6 +48,7 @@ class govuk::apps::govuk_crawler_worker (
   $amqp_host = 'localhost',
   $amqp_pass = 'guest',
   $blacklist_paths = [],
+  $crawler_threads = 4,
   $enabled   = false,
   $mirror_root = '/mnt/crawler_worker',
   $port = '3074',
@@ -71,6 +77,8 @@ class govuk::apps::govuk_crawler_worker (
         value => 'govuk_crawler_queue';
       'BLACKLIST_PATHS':
         value => join($blacklist_paths, ',');
+      'CRAWLER_THREADS':
+        value => $crawler_threads;
       'HTTP_PORT':
         value => $port;
       'REDIS_ADDRESS':

--- a/modules/govuk_crawler/manifests/init.pp
+++ b/modules/govuk_crawler/manifests/init.pp
@@ -32,6 +32,12 @@
 #   User that the synchronisation cron job runs as.
 #   Default: 'govuk-crawler'
 #
+# [*days*]
+#   The days at which the crawl runs
+#   Type: string, comma delimited specific days or every day using *
+#   Range: SUN, MON, TUE, WED, THU, FRI, SAT
+#   Default: '*'
+#
 # [*mirror_root*]
 #   The directory where crawled content is stored.
 #   Mandatory parameter
@@ -77,6 +83,7 @@ class govuk_crawler(
   $amqp_user = 'govuk_crawler_worker',
   $amqp_vhost = '/',
   $crawler_user = 'govuk-crawler',
+  $days = '*',
   $mirror_root,
   $seed_enable = false,
   $site_root = '',

--- a/modules/govuk_crawler/templates/seed-crawler-wrapper-cron.erb
+++ b/modules/govuk_crawler/templates/seed-crawler-wrapper-cron.erb
@@ -1,1 +1,1 @@
-0 <%= @start_hour %> * * * <%= @crawler_user %> /usr/bin/setlock -n <%= @seeder_lock_path %> <%= @seeder_script_wrapper_path %>
+0 <%= @start_hour %> * * <%= @days %> <%= @crawler_user %> /usr/bin/setlock -n <%= @seeder_lock_path %> <%= @seeder_script_wrapper_path %>


### PR DESCRIPTION
Following specs for production crawler:
1. add the option to specify the days when the crawler is scheduled to run
2. run crawler at 20 00 on friday, will change to daily on Monday after check that crawler finishes within 24 hours
3. add option to specify the number of crawler threads
4. set the number of crawler threads to 32 because mirrorer instance has 16 vpcu compare to 2 before
5. set the s3 bucket to the new one