### PR TITLE
Fix the hardcoded $ensure value in govuk::apps::support_api

### DIFF
--- a/modules/govuk/manifests/apps/support_api.pp
+++ b/modules/govuk/manifests/apps/support_api.pp
@@ -114,7 +114,7 @@ class govuk::apps::support_api(
   $app_name = 'support-api'
 
   govuk::app { $app_name:
-    ensure             => 'present',
+    ensure             => $ensure,
     app_type           => 'rack',
     port               => $port,
     sentry_dsn         => $sentry_dsn,


### PR DESCRIPTION
This should use the $ensure parameter for the class.