### PR TITLE
Increase the default nproc limit to 2048 on mirror AWS prod

### DIFF
--- a/hieradata_aws/class/production/mirrorer.yaml
+++ b/hieradata_aws/class/production/mirrorer.yaml
@@ -1,0 +1,16 @@
+limits::entries:
+  'default_core':
+    ensure: 'present'
+    user: '*'
+    limit_type: 'core'
+    both: 0
+  'default_nproc':
+    ensure: 'present'
+    user: '*'
+    limit_type: 'nproc'
+    hard: 2048
+  'default_nofile':
+    ensure: 'present'
+    user: '*'
+    limit_type: 'nofile'
+    hard: 2048


### PR DESCRIPTION
  We have plenty of vCPU on this machine, so we can use more threads.