### PR TITLE
Upgrade to chromedriver 74.0.3729.6

### DIFF
--- a/modules/chromedriver/manifests/init.pp
+++ b/modules/chromedriver/manifests/init.pp
@@ -7,7 +7,7 @@ class chromedriver {
 
   archive { '/tmp/chromedriver_linux64.zip':
     ensure       => 'present',
-    source       => 'https://chromedriver.storage.googleapis.com/2.40/chromedriver_linux64.zip',
+    source       => 'https://chromedriver.storage.googleapis.com/74.0.3729.6/chromedriver_linux64.zip',
     extract      => true,
     extract_path => '/usr/local/bin',
     cleanup      => true,


### PR DESCRIPTION
We're using version 2.40 of chromedriver and version 74 of chrome:

```
$ chromedriver --version
ChromeDriver 2.40.565383 (76257d1ab79276b2d53ee976b2c3e3b9f335cde7)
$ google-chrome --version
Google Chrome 74.0.3729.108
```

The chromedriver download page says

> If you are using Chrome version 74, please download ChromeDriver
> 74.0.3729.6

So we're way out of date.