### PR TITLE
minimum fix to get deploy_node_apps to work for govuk_crawler_worker

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -103,7 +103,7 @@ node_class: &node_class
       - mapit
   mirrorer:
     apps:
-      - govuk-crawler-worker
+      - govuk_crawler_worker
   publishing_api:
     apps:
       - publishing-api

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -84,7 +84,7 @@ node_class: &node_class
       - mapit
   mirrorer:
     apps:
-      - govuk-crawler-worker
+      - govuk_crawler_worker
   router_backend:
     apps:
       - router-api

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -84,7 +84,7 @@ node_class: &node_class
       - mapit
   mirrorer:
     apps:
-      - govuk-crawler-worker
+      - govuk_crawler_worker
   router_backend:
     apps:
       - router-api


### PR DESCRIPTION
# Context

When a new mirrorer comes up, the Jenkins "Deploy Node Apps" jobs is responsible to install the apps on the machine. Unfortunately the crawler app is named "govuk_crawler_worker" rather than the standard "govuk-crawler-worker" and therefore, when the app name is passed to the Jenkins "Deploy App", there is no app named "govuk-crawler-worker".

See: https://deploy.blue.production.govuk.digital/job/Deploy_Node_Apps/job/mirrorer/4/

# Decisions
1. change the hieradata to use "govuk_crawler_worker"