### PR TITLE
Add specific RDS monitoring thresholds for Content Data API

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1138,8 +1138,6 @@ monitoring::checks::cache::servers:
   - 'backend-redis-002'
 
 monitoring::checks::rds::servers:
-   - 'content-data-api-postgresql-primary'
-   - 'content-data-api-postgresql-standby'
    - 'postgresql-primary'
    - 'postgresql-standby'
    - 'transition-postgresql-primary'

--- a/modules/govuk/manifests/apps/content_data_api/db.pp
+++ b/modules/govuk/manifests/apps/content_data_api/db.pp
@@ -15,4 +15,18 @@ class govuk::apps::content_data_api::db (
     extensions          => ['plpgsql'],
     enable_in_pgbouncer => false,
   }
+
+  @@monitoring::checks::rds_config { 'content-data-api-postgresql-primary':
+    memory_warning   => 2,
+    memory_critical  => 1,
+    storage_warning  => 500,
+    storage_critical => 250,
+  }
+
+  @@monitoring::checks::rds_config { 'content-data-api-postgresql-standby':
+    memory_warning   => 2,
+    memory_critical  => 1,
+    storage_warning  => 500,
+    storage_critical => 250,
+  }
 }

--- a/modules/monitoring/manifests/checks/rds.pp
+++ b/modules/monitoring/manifests/checks/rds.pp
@@ -53,5 +53,6 @@ class monitoring::checks::rds (
       monitoring::checks::rds_config { $servers:
         region => $region,
       }
+      Monitoring::Checks::Rds_config <<| |>>
     }
 }


### PR DESCRIPTION
This allows RDS monitoring threshold to be set specific to each app using exported resources. We are also changing the thresholds of the Content Data API. As it is a larger database with greater rate of change, thresholds are increased so alerts occur sooner.