### PR TITLE
revert production to daily and keep original blacklist

### DIFF
--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -115,18 +115,6 @@ govuk::apps::content_store::performance_platform_big_screen_view_url: 'https://p
 govuk::apps::content_store::performance_platform_spotlight_url: 'https://performance-platform-spotlight-production.cloudapps.digital'
 govuk::apps::content_store::plek_service_whitehall_frontend_uri: 'https://whitehall-frontend.publishing.service.gov.uk'
 
-govuk::apps::govuk_crawler_worker::blacklist_paths:
-  - '/apply-for-a-licence'
-  - '/business-finance-support-finder'
-  - '/drug-device-alerts.atom'
-  - '/drug-safety-update.atom'
-  - '/foreign-travel-advice.atom'
-  - '/government/announcements.atom'
-  - '/government/publications.atom'
-  - '/government/statistics.atom'
-  - '/licence-finder'
-  - '/search'
-
 govuk::apps::govuk_crawler_worker::crawler_threads: '32'
 
 govuk::apps::email_alert_service::enabled: false
@@ -177,7 +165,7 @@ govuk_containers::terraboard::aws_bucket: 'govuk-terraform-steppingstone-product
 govuk_containers::terraboard::oauth2_proxy_base_url: 'https://terraboard.production.govuk.digital'
 
 govuk_crawler::seed_enable: true
-govuk_crawler::days: 'FRI'
+govuk_crawler::days: '*'
 govuk_crawler::start_hour: 20
 govuk_crawler::sync_enable: true
 govuk_crawler::site_root: 'https://www.gov.uk'


### PR DESCRIPTION
# Context

In order to make the mirrors be more in sync with origin, we are reverting to daily crawling at 20 00 GMT and keeping the original blacklist

# Decisions
1. use cron `*` for daily crawling
2. remove production blacklist to fallback to default blacklist which doesn't include government/uploads