### PR TITLE
Fix Jenkins Slack notifier

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/content_publisher_whitehall_import.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/content_publisher_whitehall_import.yaml.erb
@@ -24,6 +24,8 @@
       - slack:
           team-domain: <%= @slack_team_domain %>
           auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN'] %>
+          auth-token-id: slack-token
+          auth-token-credential-id: slack-token
           build-server-url: <%= @slack_build_server_url %>
           notify-start: false
           notify-success: true

--- a/modules/govuk_jenkins/templates/jobs/copy_attachments_to_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_attachments_to_integration.yaml.erb
@@ -52,6 +52,8 @@
       - slack:
           team-domain: <%= @slack_team_domain %>
           auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN']%>
+          auth-token-id: slack-token
+          auth-token-credential-id: slack-token
           build-server-url: <%= @slack_build_server_url %>
           notify-start: false
           notify-success: true

--- a/modules/govuk_jenkins/templates/jobs/copy_attachments_to_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_attachments_to_staging.yaml.erb
@@ -52,6 +52,8 @@
       - slack:
           team-domain: <%= @slack_team_domain %>
           auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN']%>
+          auth-token-id: slack-token
+          auth-token-credential-id: slack-token
           build-server-url: <%= @slack_build_server_url %>
           notify-start: false
           notify-success: true

--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
@@ -74,6 +74,8 @@
       - slack:
           team-domain: <%= @slack_team_domain %>
           auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN']%>
+          auth-token-id: slack-token
+          auth-token-credential-id: slack-token
           build-server-url: <%= @slack_build_server_url %>
           notify-start: false
           notify-success: true

--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_staging.yaml.erb
@@ -86,6 +86,8 @@
       - slack:
           team-domain: <%= @slack_team_domain %>
           auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN']%>
+          auth-token-id: slack-token
+          auth-token-credential-id: slack-token
           build-server-url: <%= @slack_build_server_url %>
           notify-start: false
           notify-success: true

--- a/modules/govuk_jenkins/templates/jobs/deploy_cdn.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_cdn.yaml.erb
@@ -31,6 +31,8 @@
       - slack:
           team-domain: <%= @slack_team_domain %>
           auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN']%>
+          auth-token-id: slack-token
+          auth-token-credential-id: slack-token
           build-server-url: <%= @slack_build_server_url %>
           notify-start: false
           notify-success: true

--- a/modules/govuk_jenkins/templates/jobs/deploy_puppet.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_puppet.yaml.erb
@@ -50,6 +50,8 @@
         - slack:
             team-domain: <%= @slack_team_domain %>
             auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN']%>
+            auth-token-id: slack-token
+            auth-token-credential-id: slack-token
             build-server-url: <%= @slack_build_server_url %>
             notify-start: true
             notify-success: true

--- a/modules/govuk_jenkins/templates/jobs/scrape_icinga_alerts_for_dashboard_metrics.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/scrape_icinga_alerts_for_dashboard_metrics.yaml.erb
@@ -38,6 +38,8 @@
       - slack:
           team-domain: <%= @slack_team_domain %>
           auth-token: <%= @slack_auth_token %>
+          auth-token-id: slack-token
+          auth-token-credential-id: slack-token
           build-server-url: <%= @slack_build_server_url %>
           notify-start: false
           notify-success: true

--- a/modules/govuk_jenkins/templates/jobs/smokey.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/smokey.yaml.erb
@@ -22,6 +22,8 @@
       - slack:
           team-domain: <%= @slack_team_domain %>
           auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN']%>
+          auth-token-id: slack-token
+          auth-token-credential-id: slack-token
           build-server-url: <%= @slack_build_server_url %>
           notify-start: false
           notify-success: false

--- a/modules/govuk_jenkins/templates/jobs/update_cdn_dictionaries.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/update_cdn_dictionaries.yaml.erb
@@ -30,6 +30,8 @@
       - slack:
           team-domain: <%= @slack_team_domain %>
           auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN']%>
+          auth-token-id: slack-token
+          auth-token-credential-id: slack-token
           build-server-url: <%= @slack_build_server_url %>
           notify-start: false
           notify-success: true


### PR DESCRIPTION
The Jenkins Slack notifier plugin needs to read the Integration token from
a Jenkins Credential. It can be imported automatically from the job
configuration.