### PR TITLE
Patch Jenkins token-macro plugin

### DIFF
--- a/hieradata/class/jenkins.yaml
+++ b/hieradata/class/jenkins.yaml
@@ -194,7 +194,7 @@ govuk_jenkins::plugins:
   timestamper:
     version: '1.9'
   token-macro:
-    version: '2.7'
+    version: '2.8'
   translation:
     version: '1.16'
   versionnumber:

--- a/hieradata_aws/class/jenkins.yaml
+++ b/hieradata_aws/class/jenkins.yaml
@@ -210,7 +210,7 @@ govuk_jenkins::plugins:
   timestamper:
     version: '1.9'
   token-macro:
-    version: '2.7'
+    version: '2.8'
   translation:
     version: '1.16'
   versionnumber:


### PR DESCRIPTION
Jenkins has just detected new plugin versions as we rolled out an update. The
token-macro patch fixes an XML External Entity processing vulnerability.