### PR TITLE
Drop the proportion of system memory used by Varnish for caching

### DIFF
--- a/modules/govuk/manifests/node/s_cache.pp
+++ b/modules/govuk/manifests/node/s_cache.pp
@@ -92,7 +92,7 @@ class govuk::node::s_cache (
   }
 
   # The storage size for the cache, excluding per object and static overheads
-  $varnish_storage_size_pre = floor($::memorysize_mb * 0.70 - 3072)
+  $varnish_storage_size_pre = floor($::memorysize_mb * 0.60 - 3072)
 
   # Ensure that there's some varnish storage in small environments (eg, vagrant).
   if $varnish_storage_size_pre < 100 {


### PR DESCRIPTION
The Cache Clearing Service making requests to Varnish seems to
increase the amount of memory it's using, which comes close to using
all of the memory on the machine.

Therefore, drop the proportion of memory Varnish should use for
caching.