### PR TITLE
Disable X-Ray

### DIFF
--- a/modules/govuk/manifests/node/s_base.pp
+++ b/modules/govuk/manifests/node/s_base.pp
@@ -118,4 +118,8 @@ class govuk::node::s_base (
   user { 'ubuntu':
     ensure => absent,
   }
+
+  govuk_envvar {
+    'GOVUK_APP_CONFIG_DISABLE_XRAY': value => '1';
+  }
 }


### PR DESCRIPTION
Nobody is actually using this, and we accidentally caused a problem
with it recently, so just disable it for now.

---

[Trello card](https://trello.com/c/KFYROIKs/198-find-out-whether-its-viable-to-turn-x-ray-off)