### PR TITLE
Addition to grafana panel

### DIFF
--- a/modules/grafana/templates/dashboards/application_dashboard_panels/_registry_request_time.json.erb
+++ b/modules/grafana/templates/dashboards/application_dashboard_panels/_registry_request_time.json.erb
@@ -19,6 +19,10 @@
     {
       "refId": "D",
       "target": "alias(maxSeries(stats.timers.govuk.app.<%= @app_name %>.*.registries.world_locations.request_time.upper_90), 'World Locations')"
+    },
+    {
+      "refId": "E",
+      "target": "alias(maxSeries(stats.timers.govuk.app.<%= @app_name %>.*.registries.full_topic_taxonomy.request_time.upper_90), 'Full Topic Taxonomy')"
     }
   ],
   "datasource": "Graphite",


### PR DESCRIPTION
Adds a new registry(full topic taxonomy) to the registry request time panel, on the grafana dashboard for finder frontend. 

<img width="482" alt="Screen Shot 2019-06-13 at 15 55 15" src="https://user-images.githubusercontent.com/17908089/59443321-aff2b900-8df3-11e9-908d-1361a8a6e220.png">

[trello](https://trello.com/c/XTODr8sm/784-create-new-topic-registry-in-finder-frontend-m) 
