### PR TITLE
Fix missing region for exported RDS alarms

### DIFF
--- a/modules/monitoring/manifests/checks/rds.pp
+++ b/modules/monitoring/manifests/checks/rds.pp
@@ -53,6 +53,8 @@ class monitoring::checks::rds (
       monitoring::checks::rds_config { $servers:
         region => $region,
       }
-      Monitoring::Checks::Rds_config <<| |>>
+      Monitoring::Checks::Rds_config <<| |>> {
+        region => $region,
+      }
     }
 }


### PR DESCRIPTION
This fixes a bug whereby the RDS monitoring for exported resources are missing a region.