### PR TITLE
Fix RDS alarms for Content Data API

### DIFF
--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -257,8 +257,6 @@ monitoring::pagerduty_drill::enabled: true
 
 
 monitoring::checks::rds::servers:
-   - 'content-data-api-postgresql-primary'
-   - 'content-data-api-postgresql-standby'
    - 'postgresql-primary'
    - 'postgresql-standby'
    - 'transition-postgresql-primary'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -248,8 +248,6 @@ monitoring::contacts::slack_username: 'Staging (AWS)'
 
 
 monitoring::checks::rds::servers:
-   - 'content-data-api-postgresql-primary'
-   - 'content-data-api-postgresql-standby'
    - 'postgresql-primary'
    - 'postgresql-standby'
    - 'transition-postgresql-primary'

--- a/modules/govuk/manifests/apps/content_data_api/db.pp
+++ b/modules/govuk/manifests/apps/content_data_api/db.pp
@@ -19,14 +19,14 @@ class govuk::apps::content_data_api::db (
   @@monitoring::checks::rds_config { 'content-data-api-postgresql-primary':
     memory_warning   => 2,
     memory_critical  => 1,
-    storage_warning  => 500,
-    storage_critical => 250,
+    storage_warning  => 50,
+    storage_critical => 25,
   }
 
   @@monitoring::checks::rds_config { 'content-data-api-postgresql-standby':
     memory_warning   => 2,
     memory_critical  => 1,
-    storage_warning  => 500,
-    storage_critical => 250,
+    storage_warning  => 50,
+    storage_critical => 25,
   }
 }


### PR DESCRIPTION
This PR includes the following changes:
- removes extra config in hieradata for staging and production environments.
- changes thresholds to be percentages, rather than GB of free space.