### PR TITLE
Clarify value type for RDS free storage thresholds

### DIFF
--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_rds_storage
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_rds_storage
@@ -65,8 +65,8 @@ import datetime
 #################################
 parser = argparse.ArgumentParser()
 parser.add_argument("-r","--region", type=str, choices=['us-east-1','eu-west-1','eu-west-2'], help="AWS region to check")
-parser.add_argument("-w","--warning", type=float, help="Value(GB) at which to raise a warning alert (20.0)", default=20.0)
-parser.add_argument("-c","--critical", type=float, help="Percentage at which to raise a critical alert (10.0)", default=10.0)
+parser.add_argument("-w","--warning", type=float, help="Percentage of free space threshold for warning alert (20.0)", default=20.0)
+parser.add_argument("-c","--critical", type=float, help="Percentage of free space threshold for critical alert (10.0)", default=10.0)
 parser.add_argument("-i","--instanceid", type=str, help="Instanceid", default=0)
 args = parser.parse_args()
 
@@ -211,7 +211,7 @@ for item in data:
 average = average_bytes / (1024 * 1024 * 1024)
 
 # Calculate the percentage of free storage in comparison to the allocated storage.
-available_storage = 100 / float(allocated_storage) * float(average)
+percent_free = 100 / float(allocated_storage) * float(average)
 
 #########################################################
 # Print the output					#
@@ -220,11 +220,15 @@ available_storage = 100 / float(allocated_storage) * float(average)
 # 2) Convert the defined value to 'float' type.		#
 # 3) Compare the check vs actual.			#
 #########################################################
-if float(available_storage) < args.critical:
-  print "CRITICAL: Current AWS:RDS FreeStorageSpace for {} is {}GB.[{}% of {}GB] ".format(args.instanceid, average, available_storage, allocated_storage)
+if float(percent_free) < args.critical:
+  print "CRITICAL: Current AWS:RDS FreeStorageSpace for {} is {}GB.[{:.2f}% of {}GB] - threshold is {:.2f}%".format(
+    args.instanceid, average, percent_free, allocated_storage, args.critical
+  )
   sys.exit(2)
-elif float(available_storage) < args.warning:
-  print "WARNING: Current AWS:RDS FreeStorageSpace for {} is {}GB.[{}% of {}GB]".format(args.instanceid, average, available_storage, allocated_storage)
+elif float(percent_free) < args.warning:
+  print "WARNING: Current AWS:RDS FreeStorageSpace for {} is {}GB.[{:.2f}% of {}GB] - threshold is {:.2f}%".format(
+    args.instanceid, average, percent_free, allocated_storage, args.warning
+  )
   sys.exit(1)
 else:
-  print "OK: Current AWS:RDS FreeStorageSpace for {} is {}GB.[{}% of {}GB]".format(args.instanceid, average, available_storage, allocated_storage)
+  print "OK: Current AWS:RDS FreeStorageSpace for {} is {}GB.[{:.2f}% of {}GB]".format(args.instanceid, average, percent_free, allocated_storage)


### PR DESCRIPTION
The PR includes the following changes:
- updates the help text to state that the threshold arguments for critical and warning should be percentages.
- updates variable names to describe the percentage of free space.
- update output message to properly format percentages
- update output message to display existing thresholds