### PR TITLE
Fix smokey test issues

### DIFF
--- a/modules/govuk/manifests/node/s_monitoring.pp
+++ b/modules/govuk/manifests/node/s_monitoring.pp
@@ -21,7 +21,6 @@ class govuk::node::s_monitoring (
   include ::govuk_docker
   include ::govuk_containers::terraboard
   include govuk_rbenv::all
-  include ::chromedriver
   include ::selenium
   include ::govuk_cdnlogs
   include monitoring

--- a/modules/monitoring/manifests/checks/smokey.pp
+++ b/modules/monitoring/manifests/checks/smokey.pp
@@ -25,7 +25,7 @@ class monitoring::checks::smokey (
     ensure     => present,
     name       => 'smokey',
     managehome => true,
-    shell      => '/bin/false',
+    shell      => '/bin/bash',
     system     => true,
   }
 

--- a/modules/monitoring/templates/smokey-loop.conf
+++ b/modules/monitoring/templates/smokey-loop.conf
@@ -1,7 +1,5 @@
 description "Smokey loop outputs JSON which is consumed by monitoring"
 
-setuid smokey
-
 # Run in a continuous loop. `respawn` catches non-zero exit codes. Whereas
 # `and stopped` catches normal exits. The default `respawn limit` will
 # prevent this from spinning if the script is broken.
@@ -11,7 +9,7 @@ respawn limit unlimited
 
 kill timeout 240
 
-exec /opt/smokey/tests_json_output.sh /tmp/smokey.json.tmp <%= @environment %>
+exec sudo -u /opt/smokey/tests_json_output.sh /tmp/smokey.json.tmp <%= @environment %>
 
 post-stop script
     mv /tmp/smokey.json.tmp /tmp/smokey.json


### PR DESCRIPTION
    Previously we installed a system version of chromedriver, which
    conflicted with our use of the webdrivers gem. This stops puppet trying
    to manage chromedriver and lets webdrivers do it instead.
    
    Previously we iterated the upstart config for the smokey-loop service to
    use 'setuid' instead of 'sudo -u', which doesn't seem to work. This
    reverts the use of 'setuid' back to 'sudo -u' and enables a login shell
    for the smokey user to better facilitate debugging.