### PR TITLE
Add alarm for msgs in content data dead letter queue

### DIFF
--- a/modules/govuk/manifests/apps/content_data_api/rabbitmq.pp
+++ b/modules/govuk/manifests/apps/content_data_api/rabbitmq.pp
@@ -129,4 +129,13 @@ class govuk::apps::content_data_api::rabbitmq (
     write_permission     => "^\$",
     configure_permission => "^\$",
   }
+
+  govuk_rabbitmq::monitor_messages {"${amqp_dead_letter_queue}_message_monitoring":
+    ensure             => 'present',
+    rabbitmq_hostname  => 'localhost',
+    rabbitmq_queue     => $amqp_dead_letter_queue,
+    critical_threshold => 100,
+    warning_threshold  => 10,
+    require            => Govuk_rabbitmq::Queue_with_binding[$amqp_dead_letter_queue],
+  }
 }


### PR DESCRIPTION
This adds Icinga alarms for the Content Data Letter queue. They will be raised if the queue length reaches passed the specified thresholds. 

We expect to have no and minimal message within this queue.