### PR TITLE
set extended govuk crawling daily for production

### DIFF
--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -177,7 +177,7 @@ govuk_containers::terraboard::aws_bucket: 'govuk-terraform-steppingstone-product
 govuk_containers::terraboard::oauth2_proxy_base_url: 'https://terraboard.production.govuk.digital'
 
 govuk_crawler::seed_enable: true
-govuk_crawler::days: 'FRI'
+govuk_crawler::days: '*'
 govuk_crawler::start_hour: 20
 govuk_crawler::sync_enable: true
 govuk_crawler::site_root: 'https://www.gov.uk'


### PR DESCRIPTION
# Context

Now that the mirrorer was bumped up and the extended govuk crawling was tested to be 12 hours, we can run govuk_crawler daily.

# Decisions
1. set the extended crawling to daily 