### PR TITLE
Always tell Slack that Smokey has failed

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/smokey.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/smokey.yaml.erb
@@ -9,6 +9,7 @@
 
 - job:
     name: Smokey
+    description: Task to run the smoke tests after each deploy.
     display-name: Smokey
     project-type: freestyle
     scm:
@@ -32,7 +33,7 @@
           notify-unstable: false
           notify-failure: true
           notify-backtonormal: true
-          notify-repeatedfailure: false
+          notify-repeatedfailure: true
           include-test-summary: false
           room: <%= @slack_room %>
           include-custom-message: true


### PR DESCRIPTION
We currently only tell Slack that Smokey has failed the first time it does so. This means developers deploying potentially won't know that they're change has broken the site.

Follow up to the [CDN caching incident](https://docs.google.com/document/d/148RRa-7-H5UNGWvc95dNMXP72pBhrkRNXn2yhdEGLnA/edit#).