### PR TITLE
Memcached bridge network

### DIFF
--- a/modules/govuk_containers/manifests/memcached.pp
+++ b/modules/govuk_containers/manifests/memcached.pp
@@ -28,7 +28,6 @@ class govuk_containers::memcached(
   }
 
   ::docker::run { 'memcached':
-    net              => 'host',
     ports            => ['11211:11211'],
     image            => $image_name,
     require          => Docker::Image[$image_name],

--- a/modules/govuk_containers/manifests/memcached.pp
+++ b/modules/govuk_containers/manifests/memcached.pp
@@ -15,7 +15,7 @@
 #
 class govuk_containers::memcached(
   $image_name = 'memcached',
-  $image_version = '1.4.36-alpine',
+  $image_version = '1.5.16-alpine',
   $max_memory    = 1024
 ) {
 


### PR DESCRIPTION
Memcached doesnt need to be exposed to the outside world. This is the setting that elasticsearch has and so should probably be acceptable here.

https://docs.docker.com/network/bridge/

Running the memcached container  with the --net host option leads to an immediate error:
exit status 16:
```
/usr/bin/docker: Error response from daemon: oci runtime error: container_linux.go:265:
starting container process caused "process_linux.go:270: running exec setns process for
init caused \"exit status 16\"".
```