### PR TITLE
Fix Jenkins Slack plugin configuration

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/content_publisher_whitehall_import.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/content_publisher_whitehall_import.yaml.erb
@@ -30,11 +30,11 @@
           notify-start: false
           notify-success: true
           notify-aborted: false
-          notify-notbuilt: false
+          notify-not-built: false
           notify-unstable: false
           notify-failure: true
-          notify-backtonormal: true
-          notify-repeatedfailure: true
+          notify-back-to-normal: true
+          notify-repeated-failure: true
           include-test-summary: false
           room: <%= @slack_room %>
       <% end %>

--- a/modules/govuk_jenkins/templates/jobs/copy_attachments_to_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_attachments_to_integration.yaml.erb
@@ -58,11 +58,11 @@
           notify-start: false
           notify-success: true
           notify-aborted: true
-          notify-notbuilt: true
+          notify-not-built: true
           notify-unstable: false
           notify-failure: true
-          notify-backtonormal: false
-          notify-repeatedfailure: false
+          notify-back-to-normal: false
+          notify-repeated-failure: false
           include-test-summary: false
           room: <%= @slack_room %>
       <% end %>

--- a/modules/govuk_jenkins/templates/jobs/copy_attachments_to_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_attachments_to_staging.yaml.erb
@@ -58,11 +58,11 @@
           notify-start: false
           notify-success: true
           notify-aborted: true
-          notify-notbuilt: true
+          notify-not-built: true
           notify-unstable: false
           notify-failure: true
-          notify-backtonormal: false
-          notify-repeatedfailure: false
+          notify-back-to-normal: false
+          notify-repeated-failure: false
           include-test-summary: false
           room: <%= @slack_room %>
       <% end %>

--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
@@ -80,11 +80,11 @@
           notify-start: false
           notify-success: true
           notify-aborted: true
-          notify-notbuilt: true
+          notify-not-built: true
           notify-unstable: false
           notify-failure: true
-          notify-backtonormal: false
-          notify-repeatedfailure: false
+          notify-back-to-normal: false
+          notify-repeated-failure: false
           include-test-summary: false
           room: <%= @slack_room %>
       <% end %>

--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_staging.yaml.erb
@@ -92,11 +92,11 @@
           notify-start: false
           notify-success: true
           notify-aborted: true
-          notify-notbuilt: true
+          notify-not-built: true
           notify-unstable: false
           notify-failure: true
-          notify-backtonormal: false
-          notify-repeatedfailure: false
+          notify-back-to-normal: false
+          notify-repeated-failure: false
           include-test-summary: false
           room: <%= @slack_room %>
       <% end %>

--- a/modules/govuk_jenkins/templates/jobs/deploy_cdn.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_cdn.yaml.erb
@@ -37,11 +37,11 @@
           notify-start: false
           notify-success: true
           notify-aborted: true
-          notify-notbuilt: true
+          notify-not-built: true
           notify-unstable: false
           notify-failure: true
-          notify-backtonormal: false
-          notify-repeatedfailure: false
+          notify-back-to-normal: false
+          notify-repeated-failure: false
           include-test-summary: false
           room: <%= @slack_room %>
       <% end %>

--- a/modules/govuk_jenkins/templates/jobs/deploy_puppet.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_puppet.yaml.erb
@@ -56,11 +56,11 @@
             notify-start: true
             notify-success: true
             notify-aborted: true
-            notify-notbuilt: true
+            notify-not-built: true
             notify-unstable: false
             notify-failure: true
-            notify-backtonormal: false
-            notify-repeatedfailure: false
+            notify-back-to-normal: false
+            notify-repeated-failure: false
             include-test-summary: false
             room: <%= @slack_room %>
         <%- end -%>

--- a/modules/govuk_jenkins/templates/jobs/scrape_icinga_alerts_for_dashboard_metrics.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/scrape_icinga_alerts_for_dashboard_metrics.yaml.erb
@@ -44,11 +44,11 @@
           notify-start: false
           notify-success: true
           notify-aborted: false
-          notify-notbuilt: false
+          notify-not-built: false
           notify-unstable: false
           notify-failure: true
-          notify-backtonormal: true
-          notify-repeatedfailure: true
+          notify-back-to-normal: true
+          notify-repeated-failure: true
           include-test-summary: false
           room: <%= @slack_room %>
       <% end %>

--- a/modules/govuk_jenkins/templates/jobs/smokey.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/smokey.yaml.erb
@@ -29,11 +29,11 @@
           notify-start: false
           notify-success: false
           notify-aborted: true
-          notify-notbuilt: true
+          notify-not-built: true
           notify-unstable: false
           notify-failure: true
-          notify-backtonormal: true
-          notify-repeatedfailure: true
+          notify-back-to-normal: true
+          notify-repeated-failure: true
           include-test-summary: false
           room: <%= @slack_room %>
           include-custom-message: true

--- a/modules/govuk_jenkins/templates/jobs/update_cdn_dictionaries.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/update_cdn_dictionaries.yaml.erb
@@ -36,11 +36,11 @@
           notify-start: false
           notify-success: true
           notify-aborted: true
-          notify-notbuilt: true
+          notify-not-built: true
           notify-unstable: false
           notify-failure: true
-          notify-backtonormal: false
-          notify-repeatedfailure: false
+          notify-back-to-normal: false
+          notify-repeated-failure: false
           include-test-summary: false
           room: <%= @slack_room %>
       - trigger:


### PR DESCRIPTION
In https://github.com/alphagov/govuk-puppet/pull/9291 I was trying to make Slack notify for all failures. The job was deployed, but the setting wasn't changed in Jenkins ("Notify First Failure Only" was still checked).

It seems like the name for multiword config attributes is wrong, and has been since the first introduction (https://github.com/alphagov/govuk-puppet/pull/5206).

The Slack publisher docs for jenkins job builder says that to use hyphens for the options:

https://docs.openstack.org/infra/jenkins-job-builder/publishers.html

> notify-back-to-normal (bool) – Send notification when job is succeeding again after being unstable or failed (>=2.0). (default false)
> notify-repeated-failure (bool) – Send notification when job fails successively (previous build was also a failure) (>=2.0). (default false)