### PR TITLE
remove carrenza mirror and update pingdom after mirror redesign

### DIFF
--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -182,8 +182,6 @@ govuk_crawler::start_hour: 20
 govuk_crawler::sync_enable: true
 govuk_crawler::site_root: 'https://www.gov.uk'
 govuk_crawler::targets:
-  - 'mirror-rsync@mirror0.mirror.provider1.production.govuk.service.gov.uk'
-  - 'mirror-rsync@mirror1.mirror.provider1.production.govuk.service.gov.uk'
   - 's3://govuk-production-mirror/'
 
 govuk::apps::govuk_crawler_worker::root_urls:

--- a/modules/monitoring/manifests/checks/pingdom.pp
+++ b/modules/monitoring/manifests/checks/pingdom.pp
@@ -27,8 +27,10 @@ class monitoring::checks::pingdom (
       check_id => 489560;
     'specialist':
       check_id => 662460;
-    'mirror_provider1':
-      check_id => 1297462;
+    'mirror_S3':
+      check_id => 2777110;
+    'mirror_S3_replica':
+      check_id => 5291414;
   }
 
   if $enable {
@@ -69,11 +71,20 @@ class monitoring::checks::pingdom (
       service_description => 'Pingdom specialist guides check',
     }
 
-    icinga::check { 'check_pingdom_mirror_provider1':
-      check_command       => 'run_pingdom_mirror_provider1_check',
+    icinga::check { 'check_pingdom_mirror_S3':
+      check_command       => 'run_pingdom_mirror_S3_check',
       use                 => 'govuk_high_priority',
       host_name           => $::fqdn,
-      service_description => 'Pingdom mirror provider1 check',
+      service_description => 'Pingdom mirror S3 check',
+      notes_url           => monitoring_docs_url(pingdom-mirror-check),
+    }
+
+    icinga::check { 'check_pingdom_mirror_S3_replica':
+      check_command       => 'run_pingdom_mirror_S3_replica_check',
+      use                 => 'govuk_high_priority',
+      host_name           => $::fqdn,
+      service_description => 'Pingdom mirror S3 replica check',
+      notes_url           => monitoring_docs_url(pingdom-mirror-check),
     }
   }
 }


### PR DESCRIPTION
# Context

Following the mirror redesign, we will no longer need the carrenza mirrors and therefore we stop syncing the mirrorer with the carrenza mirrors. As a consequence, we also stop monitoring the mirrors via pingdom.

Furthermore, we start monitoring the s3 buckets. Right now we can't monitor GCS bucket due to Pingdom plan restrictions.

# Decisions
1. remove the carrenza mirrors from the sync list
2. remove carrenza mirrors from the pingdom/icinga checks
3. add the s3 mirror and replica to the the pingdom/icinga checks