### PR TITLE
Add search-api as a deployable application in common hiera

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -163,6 +163,7 @@ deployable_applications: &deployable_applications
   router: {}
   router-api: {}
   search-admin: {}
+  search-api: {}
   service-manual-frontend: {}
   service-manual-publisher: {}
   short-url-manager: {}


### PR DESCRIPTION
The deploy to integration task that is called during our Jenkins build
calls a downstream Jenkins job called `integration-app-deploy`
(https://github.com/alphagov/govuk-jenkinslib/blob/74e85e1afdd537bd9b24a1ecdf0dd36cb85f6130/vars/govuk.groovy#L729-L737).

This job runs on our ci box, which still sits in Carrenza. As such it
reads from common/hieradata.yml.

integration-app-deploy is really just a proxy that ends up calling
`Deploy_App` on our `deploy.integration` instance. The deploy instance
sits on our AWS infrastructure.

Add `search-api` as a deployable application in our common hieradata so
that Carrenza hosted CI instance considers `search-api` a valid
argument.