### PR TITLE
Raise Icinga alerts instead of emailing 2nd line

### DIFF
--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -5,6 +5,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::bouncer_cdn_redirect
   - govuk_jenkins::jobs::build_offsite_backup
   - govuk_jenkins::jobs::check_cdn_ip_ranges
+  - govuk_jenkins::jobs::check_github_ip_ranges
   - govuk_jenkins::jobs::check_pingdom_ip_ranges
   - govuk_jenkins::jobs::check_sentry_errors
   - govuk_jenkins::jobs::content_audit_tool

--- a/modules/govuk_jenkins/manifests/jobs/check_cdn_ip_ranges.pp
+++ b/modules/govuk_jenkins/manifests/jobs/check_cdn_ip_ranges.pp
@@ -3,7 +3,9 @@
 # Create a jenkins-job-builder config file for checking that CDN
 # IP ranges are configured correctly.
 #
-class govuk_jenkins::jobs::check_cdn_ip_ranges {
+class govuk_jenkins::jobs::check_cdn_ip_ranges(
+  $app_domain = hiera('app_domain'),
+) {
   file { '/etc/jenkins_jobs/jobs/check_cdn_ip_ranges.yaml':
     ensure  => present,
     content => template('govuk_jenkins/jobs/check_cdn_ip_ranges.yaml.erb'),

--- a/modules/govuk_jenkins/manifests/jobs/check_cdn_ip_ranges.pp
+++ b/modules/govuk_jenkins/manifests/jobs/check_cdn_ip_ranges.pp
@@ -9,4 +9,15 @@ class govuk_jenkins::jobs::check_cdn_ip_ranges {
     content => template('govuk_jenkins/jobs/check_cdn_ip_ranges.yaml.erb'),
     notify  => Exec['jenkins_jobs_update'],
   }
+
+  $check_name = 'check_cdn_ip_ranges'
+  $service_description = 'Compare the IP ranges that Fastly publishes against the ranges configured in govuk-provisioning'
+  $job_url = "https://deploy.${app_domain}/job/Check_CDN_IP_Ranges/"
+
+  @@icinga::passive_check { "${check_name}_${::hostname}":
+    service_description => $service_description,
+    host_name           => $::fqdn,
+    freshness_threshold => 104400,
+    action_url          => $job_url,
+  }
 }

--- a/modules/govuk_jenkins/manifests/jobs/check_github_ip_ranges.pp
+++ b/modules/govuk_jenkins/manifests/jobs/check_github_ip_ranges.pp
@@ -9,4 +9,15 @@ class govuk_jenkins::jobs::check_github_ip_ranges {
     content => template('govuk_jenkins/jobs/check_github_ip_ranges.yaml.erb'),
     notify  => Exec['jenkins_jobs_update'],
   }
+
+  $check_name = 'check_github_ip_ranges'
+  $service_description = 'Compare the IP ranges that GitHub publishes against the ranges configured in govuk-provisioning'
+  $job_url = "https://deploy.${app_domain}/job/Check_GitHub_IP_Ranges/"
+
+  @@icinga::passive_check { "${check_name}_${::hostname}":
+    service_description => $service_description,
+    host_name           => $::fqdn,
+    freshness_threshold => 104400,
+    action_url          => $job_url,
+  }
 }

--- a/modules/govuk_jenkins/manifests/jobs/check_github_ip_ranges.pp
+++ b/modules/govuk_jenkins/manifests/jobs/check_github_ip_ranges.pp
@@ -3,7 +3,9 @@
 # Create a jenkins-job-builder config file for checking that GitHub
 # IP ranges are configured correctly.
 #
-class govuk_jenkins::jobs::check_github_ip_ranges {
+class govuk_jenkins::jobs::check_github_ip_ranges(
+  $app_domain = hiera('app_domain'),
+) {
   file { '/etc/jenkins_jobs/jobs/check_github_ip_ranges.yaml':
     ensure  => present,
     content => template('govuk_jenkins/jobs/check_github_ip_ranges.yaml.erb'),

--- a/modules/govuk_jenkins/manifests/jobs/check_pingdom_ip_ranges.pp
+++ b/modules/govuk_jenkins/manifests/jobs/check_pingdom_ip_ranges.pp
@@ -9,4 +9,15 @@ class govuk_jenkins::jobs::check_pingdom_ip_ranges {
     content => template('govuk_jenkins/jobs/check_pingdom_ip_ranges.yaml.erb'),
     notify  => Exec['jenkins_jobs_update'],
   }
+
+  $check_name = 'check_pingdom_ip_ranges'
+  $service_description = 'Compare the IP ranges that Pingdom publishes against the ranges configured in govuk-provisioning'
+  $job_url = "https://deploy.${app_domain}/job/Check_Pingdom_IP_Ranges/"
+
+  @@icinga::passive_check { "${check_name}_${::hostname}":
+    service_description => $service_description,
+    host_name           => $::fqdn,
+    freshness_threshold => 104400,
+    action_url          => $job_url,
+  }
 }

--- a/modules/govuk_jenkins/manifests/jobs/check_pingdom_ip_ranges.pp
+++ b/modules/govuk_jenkins/manifests/jobs/check_pingdom_ip_ranges.pp
@@ -3,7 +3,9 @@
 # Create a jenkins-job-builder config file for checking that Pingdom
 # IP ranges are configured correctly.
 #
-class govuk_jenkins::jobs::check_pingdom_ip_ranges {
+class govuk_jenkins::jobs::check_pingdom_ip_ranges(
+  $app_domain = hiera('app_domain'),
+) {
   file { '/etc/jenkins_jobs/jobs/check_pingdom_ip_ranges.yaml':
     ensure  => present,
     content => template('govuk_jenkins/jobs/check_pingdom_ip_ranges.yaml.erb'),

--- a/modules/govuk_jenkins/manifests/jobs/check_sentry_errors.pp
+++ b/modules/govuk_jenkins/manifests/jobs/check_sentry_errors.pp
@@ -10,4 +10,15 @@ class govuk_jenkins::jobs::check_sentry_errors (
     content => template('govuk_jenkins/jobs/check_sentry_errors.yaml.erb'),
     notify  => Exec['jenkins_jobs_update'],
   }
+
+  $check_name = 'check_sentry_errors'
+  $service_description = 'Report the number of errors in Sentry to Graphite'
+  $job_url = "https://deploy.${app_domain}/job/Check_Sentry_Errors/"
+
+  @@icinga::passive_check { "${check_name}_${::hostname}":
+    service_description => $service_description,
+    host_name           => $::fqdn,
+    freshness_threshold => 104400,
+    action_url          => $job_url,
+  }
 }

--- a/modules/govuk_jenkins/manifests/jobs/check_sentry_errors.pp
+++ b/modules/govuk_jenkins/manifests/jobs/check_sentry_errors.pp
@@ -4,6 +4,7 @@
 #
 class govuk_jenkins::jobs::check_sentry_errors (
   $sentry_auth_token = undef,
+  $app_domain = hiera('app_domain'),
 ) {
   file { '/etc/jenkins_jobs/jobs/check_sentry_errors.yaml':
     ensure  => present,

--- a/modules/govuk_jenkins/manifests/jobs/publishing_api_archive_events.pp
+++ b/modules/govuk_jenkins/manifests/jobs/publishing_api_archive_events.pp
@@ -11,4 +11,15 @@ class govuk_jenkins::jobs::publishing_api_archive_events {
     content => template('govuk_jenkins/jobs/publishing_api_archive_events.yaml.erb'),
     notify  => Exec['jenkins_jobs_update'],
   }
+
+  $check_name = 'publishing_api_archive_events'
+  $service_description = 'Periodically archive publishing-api events to S3'
+  $job_url = "https://deploy.${app_domain}/job/Publishing_API_Archive_Events/"
+
+  @@icinga::passive_check { "${check_name}_${::hostname}":
+    service_description => $service_description,
+    host_name           => $::fqdn,
+    freshness_threshold => 104400,
+    action_url          => $job_url,
+  }
 }

--- a/modules/govuk_jenkins/manifests/jobs/publishing_api_archive_events.pp
+++ b/modules/govuk_jenkins/manifests/jobs/publishing_api_archive_events.pp
@@ -5,7 +5,9 @@
 #
 # === Parameters:
 #
-class govuk_jenkins::jobs::publishing_api_archive_events {
+class govuk_jenkins::jobs::publishing_api_archive_events(
+  $app_domain = hiera('app_domain'),
+) {
   file { '/etc/jenkins_jobs/jobs/publishing_api_archive_events.yaml':
     ensure  => present,
     content => template('govuk_jenkins/jobs/publishing_api_archive_events.yaml.erb'),

--- a/modules/govuk_jenkins/manifests/jobs/validate_published_dns.pp
+++ b/modules/govuk_jenkins/manifests/jobs/validate_published_dns.pp
@@ -14,4 +14,15 @@ class govuk_jenkins::jobs::validate_published_dns (
     content => template('govuk_jenkins/jobs/validate_published_dns.yaml.erb'),
     notify  => Exec['jenkins_jobs_update'],
   }
+
+  $check_name = 'validate_published_dns'
+  $service_description = 'Check that the published DNS records match those in the govuk-dns-config repo'
+  $job_url = "https://deploy.${app_domain}/job/Validate_published_DNS/"
+
+  @@icinga::passive_check { "${check_name}_${::hostname}":
+    service_description => $service_description,
+    host_name           => $::fqdn,
+    freshness_threshold => 104400,
+    action_url          => $job_url,
+  }
 }

--- a/modules/govuk_jenkins/manifests/jobs/validate_published_dns.pp
+++ b/modules/govuk_jenkins/manifests/jobs/validate_published_dns.pp
@@ -8,6 +8,7 @@
 #
 class govuk_jenkins::jobs::validate_published_dns (
   $run_daily = false,
+  $app_domain = hiera('app_domain'),
 ){
   file { '/etc/jenkins_jobs/jobs/validate_published_dns.yaml':
     ensure  => present,

--- a/modules/govuk_jenkins/templates/jobs/build_offsite_backup.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/build_offsite_backup.yaml.erb
@@ -23,9 +23,6 @@
     builders:
         - shell: |
             ./vcloud/box/carrenza/jenkins.sh
-    publishers:
-        - email:
-            recipients: 2nd-line-support@digital.cabinet-office.gov.uk
     parameters:
         - string:
             name: VCLOUD_USER

--- a/modules/govuk_jenkins/templates/jobs/check_cdn_ip_ranges.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/check_cdn_ip_ranges.yaml.erb
@@ -10,9 +10,9 @@
 
 - job:
     name: Check_CDN_IP_Ranges
-    display-name: Check_CDN_IP_Ranges
+    display-name: Check CDN IP Ranges
     project-type: freestyle
-    description: "This job compares the IP ranges that Fastly publishes against the ranges configured in govuk-provisioning and errors if they don't match."
+    description: "This job compares the IP ranges that Fastly publishes against the ranges configured in govuk-provisioning and errors if they don't match. Also see https://docs.publishing.service.gov.uk/manual/cdn.html#fastly39s-ip-ranges"
     properties:
         - build-discarder:
             days-to-keep: 30
@@ -26,8 +26,17 @@
             bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
             bundle exec ./tools/cdn_ips.rb production_carrenza
     publishers:
-        - email:
-            recipients: 2nd-line-support@digital.cabinet-office.gov.uk
+        - trigger-parameterized-builds:
+            - project: Success_Passive_Check
+              condition: 'SUCCESS'
+              predefined-parameters: |
+                  NSCA_CHECK_DESCRIPTION=<%= @service_description %>
+                  NSCA_OUTPUT=<%= @service_description %> success
+            - project: Failure_Passive_Check
+              condition: 'FAILED'
+              predefined-parameters: |
+                  NSCA_CHECK_DESCRIPTION=<%= @service_description %>
+                  NSCA_OUTPUT=<%= @service_description %> failed
     triggers:
         - timed: |
             TZ=Europe/London

--- a/modules/govuk_jenkins/templates/jobs/check_github_ip_ranges.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/check_github_ip_ranges.yaml.erb
@@ -10,7 +10,7 @@
 
 - job:
     name: Check_GitHub_IP_Ranges
-    display-name: Check_GitHub_IP_Ranges
+    display-name: Check GitHub IP Ranges
     project-type: freestyle
     description: "This job compares the IP ranges that GitHub publishes against the ranges configured in govuk-provisioning and errors if they don't match."
     properties:
@@ -26,8 +26,17 @@
             bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
             bundle exec ./tools/github_ips.rb
     publishers:
-        - email:
-            recipients: 2nd-line-support@digital.cabinet-office.gov.uk
+        - trigger-parameterized-builds:
+            - project: Success_Passive_Check
+              condition: 'SUCCESS'
+              predefined-parameters: |
+                  NSCA_CHECK_DESCRIPTION=<%= @service_description %>
+                  NSCA_OUTPUT=<%= @service_description %> success
+            - project: Failure_Passive_Check
+              condition: 'FAILED'
+              predefined-parameters: |
+                  NSCA_CHECK_DESCRIPTION=<%= @service_description %>
+                  NSCA_OUTPUT=<%= @service_description %> failed
     triggers:
         - timed: |
             TZ=Europe/London

--- a/modules/govuk_jenkins/templates/jobs/check_pingdom_ip_ranges.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/check_pingdom_ip_ranges.yaml.erb
@@ -10,7 +10,7 @@
 
 - job:
     name: Check_Pingdom_IP_Ranges
-    display-name: Check_Pingdom_IP_Ranges
+    display-name: Check Pingdom IP Ranges
     project-type: freestyle
     description: "This job compares the IP ranges that Pingdom publishes against the ranges configured in govuk-provisioning and errors if they don't match."
     properties:
@@ -25,7 +25,16 @@
         - shell: |
             ruby tools/pingdom_ips.rb
     publishers:
-        - email:
-            recipients: 2nd-line-support@digital.cabinet-office.gov.uk
+        - trigger-parameterized-builds:
+            - project: Success_Passive_Check
+              condition: 'SUCCESS'
+              predefined-parameters: |
+                  NSCA_CHECK_DESCRIPTION=<%= @service_description %>
+                  NSCA_OUTPUT=<%= @service_description %> success
+            - project: Failure_Passive_Check
+              condition: 'FAILED'
+              predefined-parameters: |
+                  NSCA_CHECK_DESCRIPTION=<%= @service_description %>
+                  NSCA_OUTPUT=<%= @service_description %> failed
     triggers:
         - timed: 'H H * * 1'

--- a/modules/govuk_jenkins/templates/jobs/check_sentry_errors.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/check_sentry_errors.yaml.erb
@@ -27,8 +27,17 @@
             bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
             bundle exec rake run
     publishers:
-        - email:
-            recipients: 2nd-line-support@digital.cabinet-office.gov.uk
+        - trigger-parameterized-builds:
+            - project: Success_Passive_Check
+              condition: 'SUCCESS'
+              predefined-parameters: |
+                  NSCA_CHECK_DESCRIPTION=<%= @service_description %>
+                  NSCA_OUTPUT=<%= @service_description %> success
+            - project: Failure_Passive_Check
+              condition: 'FAILED'
+              predefined-parameters: |
+                  NSCA_CHECK_DESCRIPTION=<%= @service_description %>
+                  NSCA_OUTPUT=<%= @service_description %> failed
     triggers:
         - timed: |
             TZ=Europe/London

--- a/modules/govuk_jenkins/templates/jobs/content_audit_tool.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/content_audit_tool.yaml.erb
@@ -15,9 +15,6 @@
     wrappers:
       - ansicolor:
           colormap: xterm
-    publishers:
-      - email:
-          recipients: govuk-ci-notifications@digital.cabinet-office.gov.uk
   <% if @rake_import_all_content_items_frequency %>
     triggers:
       - timed: <%= @rake_import_all_content_items_frequency %>
@@ -44,9 +41,6 @@
     wrappers:
       - ansicolor:
           colormap: xterm
-    publishers:
-      - email:
-          recipients: govuk-ci-notifications@digital.cabinet-office.gov.uk
   <% if @rake_import_all_ga_metrics_frequency %>
     triggers:
       - timed: <%= @rake_import_all_ga_metrics_frequency %>

--- a/modules/govuk_jenkins/templates/jobs/content_data_api.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/content_data_api.yaml.erb
@@ -15,9 +15,6 @@
     wrappers:
       - ansicolor:
           colormap: xterm
-    publishers:
-      - email:
-          recipients: govuk-ci-notifications@digital.cabinet-office.gov.uk
   <% if @rake_etl_master_process_cron_schedule %>
     triggers:
       - timed: <%= @rake_etl_master_process_cron_schedule %>
@@ -37,4 +34,3 @@
                 NSCA_CHECK_DESCRIPTION=<%= @service_description %>
                 NSCA_OUTPUT=<%= @service_description %> failed
                 NSCA_CODE=2
-

--- a/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
@@ -44,5 +44,3 @@
                 TARGET_APPLICATION=whitehall
                 MACHINE_CLASS=whitehall_backend
                 RAKE_TASK=publishing:scheduled:requeue_all_jobs
-        - email:
-            recipients: govuk-ci-notifications@digital.cabinet-office.gov.uk

--- a/modules/govuk_jenkins/templates/jobs/data_sync_complete_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/data_sync_complete_staging.yaml.erb
@@ -25,6 +25,3 @@
            ssh deploy@$(govuk_node_list -c whitehall_backend --single-node) 'cd /var/apps/whitehall ; govuk_setenv whitehall bundle exec rake publishing:scheduled:requeue_all_jobs'
            # Queue up any publisher scheduled editions that have been transferred across.
            ssh deploy@$(govuk_node_list -c backend --single-node) 'cd /var/apps/publisher ; govuk_setenv publisher bundle exec rake editions:requeue_scheduled_for_publishing'
-    publishers:
-        - email:
-            recipients: govuk-ci-notifications@digital.cabinet-office.gov.uk

--- a/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
@@ -46,9 +46,6 @@
             regexp: "DOCKER TAG FAILED"
             also-check-console-output: true
             unstable-if-found: true
-        - email:
-            recipients: govuk-ci-notifications@digital.cabinet-office.gov.uk
-            send-to-individuals: true
     wrappers:
         - workspace-cleanup
         - ansicolor:

--- a/modules/govuk_jenkins/templates/jobs/deploy_licensify.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_licensify.yaml.erb
@@ -34,8 +34,6 @@
         - trigger:
             project: Smokey
             condition: 'SUCCESS'
-        - email:
-            recipients: govuk-ci-notifications@digital.cabinet-office.gov.uk
     wrappers:
         - ansicolor:
             colormap: xterm

--- a/modules/govuk_jenkins/templates/jobs/integration_app_deploy.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/integration_app_deploy.yaml.erb
@@ -38,6 +38,3 @@
         - description-setter:
             regexp: ""
             description: "$TARGET_APPLICATION $TAG"
-        - email:
-            recipients: govuk-ci-notifications@digital.cabinet-office.gov.uk
-            send-to-individuals: true

--- a/modules/govuk_jenkins/templates/jobs/integration_licensify_deploy.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/integration_licensify_deploy.yaml.erb
@@ -17,7 +17,3 @@
     wrappers:
         - ansicolor:
             colormap: xterm
-    publishers:
-        - email:
-            recipients: govuk-ci-notifications@digital.cabinet-office.gov.uk
-            send-to-individuals: false

--- a/modules/govuk_jenkins/templates/jobs/integration_router_data_deploy.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/integration_router_data_deploy.yaml.erb
@@ -23,7 +23,3 @@
             name: TAG
             description: 'Git tag/committish to deploy.'
             default: 'release'
-    publishers:
-        - email:
-            recipients: govuk-ci-notifications@digital.cabinet-office.gov.uk
-            send-to-individuals: true

--- a/modules/govuk_jenkins/templates/jobs/publishing_api_archive_events.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/publishing_api_archive_events.yaml.erb
@@ -1,7 +1,7 @@
 ---
 - job:
     name: Publishing_API_Archive_Events
-    display-name: Publishing_API_Archive_Events
+    display-name: "Publishing API: Archive events"
     project-type: freestyle
     description: "This job periodically archives publishing API events to S3"
     properties:
@@ -23,6 +23,14 @@
             TZ=Europe/London
             H 5 * * 0
     publishers:
-        - email:
-            recipients: 2nd-line-support@digital.cabinet-office.gov.uk
-            send-to-individuals: true
+        - trigger-parameterized-builds:
+            - project: Success_Passive_Check
+              condition: 'SUCCESS'
+              predefined-parameters: |
+                  NSCA_CHECK_DESCRIPTION=<%= @service_description %>
+                  NSCA_OUTPUT=<%= @service_description %> success
+            - project: Failure_Passive_Check
+              condition: 'FAILED'
+              predefined-parameters: |
+                  NSCA_CHECK_DESCRIPTION=<%= @service_description %>
+                  NSCA_OUTPUT=<%= @service_description %> failed

--- a/modules/govuk_jenkins/templates/jobs/signon_cron_rake_tasks.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/signon_cron_rake_tasks.yaml.erb
@@ -12,9 +12,6 @@
                 TARGET_APPLICATION=signon
                 MACHINE_CLASS=backend
                 RAKE_TASK=oauth_access_grants:delete_expired
-    publishers:
-        - email:
-            recipients: govuk-ci-notifications@digital.cabinet-office.gov.uk
     triggers:
       - timed: <%= @rake_oauth_access_grants_delete_expired_frequency %>
     logrotate:
@@ -36,9 +33,6 @@
                 TARGET_APPLICATION=signon
                 MACHINE_CLASS=backend
                 RAKE_TASK=organisations:fetch
-    publishers:
-        - email:
-            recipients: govuk-ci-notifications@digital.cabinet-office.gov.uk
     triggers:
       - timed: <%= @rake_organisations_fetch_frequency %>
     logrotate:
@@ -56,9 +50,6 @@
                 TARGET_APPLICATION=signon
                 MACHINE_CLASS=backend
                 RAKE_TASK=users:suspend_inactive
-    publishers:
-        - email:
-            recipients: govuk-ci-notifications@digital.cabinet-office.gov.uk
     triggers:
       - timed: <%= @rake_users_suspend_inactive_frequency %>
         logrotate:
@@ -76,9 +67,6 @@
                 TARGET_APPLICATION=signon
                 MACHINE_CLASS=backend
                 RAKE_TASK=users:send_suspension_reminders
-    publishers:
-        - email:
-            recipients: govuk-ci-notifications@digital.cabinet-office.gov.uk
     triggers:
       - timed: <%= @rake_users_send_suspension_reminders_frequency %>
         logrotate:

--- a/modules/govuk_jenkins/templates/jobs/validate_published_dns.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/validate_published_dns.yaml.erb
@@ -46,8 +46,17 @@
             description: Set the zonefile to test
     <% if @run_daily %>
     publishers:
-        - email:
-            recipients: 2nd-line-support@digital.cabinet-office.gov.uk
+        - trigger-parameterized-builds:
+            - project: Success_Passive_Check
+              condition: 'SUCCESS'
+              predefined-parameters: |
+                  NSCA_CHECK_DESCRIPTION=<%= @service_description %>
+                  NSCA_OUTPUT=<%= @service_description %> success
+            - project: Failure_Passive_Check
+              condition: 'FAILED'
+              predefined-parameters: |
+                  NSCA_CHECK_DESCRIPTION=<%= @service_description %>
+                  NSCA_OUTPUT=<%= @service_description %> failed
     triggers:
         - timed: '@midnight'
     <% end %>

--- a/modules/govuk_jenkins/templates/jobs/whitehall_publisher_notifications.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/whitehall_publisher_notifications.yaml.erb
@@ -12,9 +12,6 @@
                 TARGET_APPLICATION=whitehall
                 MACHINE_CLASS=whitehall_backend
                 RAKE_TASK=publisher_notifications:send
-    publishers:
-        - email:
-            recipients: govuk-ci-notifications@digital.cabinet-office.gov.uk
     triggers:
         - timed: |
             TZ=Europe/London

--- a/modules/govuk_jenkins/templates/jobs/whitehall_run_broken_link_checker.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/whitehall_run_broken_link_checker.yaml.erb
@@ -24,8 +24,6 @@
         - ansicolor:
             colormap: xterm
     publishers:
-        - email:
-            recipients: govuk-ci-notifications@digital.cabinet-office.gov.uk
         - trigger-parameterized-builds:
             - project: success_passive_check
               condition: 'SUCCESS'


### PR DESCRIPTION
There are currently a number of Jenkins jobs that email 2nd line when they fail - presumably so 2nd line can fix the issue. I think this is wrong, because a lot of people are subscribed to the mailing list, so in the majority of cases the recipient will not have to do anything.

In this PR we:

- remove all email notifications to 2nd line and replace them with Icinga alerts
- remove all notifications to `govuk-ci-notifications@digital.cabinet-office.gov.uk`, because that address has been unmonitored for a long time

After this PR it is outlawed to create new email alerts! 🚓 

Comments welcome! 