### PR TITLE
Fix search-api metric names in Grafana and Icinga

### DIFF
--- a/modules/grafana/templates/dashboards_aws/_index_size.json.erb
+++ b/modules/grafana/templates/dashboards_aws/_index_size.json.erb
@@ -50,17 +50,17 @@
         "targets": [
           {
             "refId": "A",
-            "target": "alias(diffSeries(keepLastValue(stats.gauges.govuk.app.search-api.<%= index_name %>_index.docs.total,252), timeShift(keepLastValue(stats.gauges.govuk.app.search-api.<%= index_name %>_index.docs.total,252), '7d')),'Change')",
+            "target": "alias(diffSeries(keepLastValue(stats.gauges.govuk.app.search-api.cluster_A.<%= index_name %>_index.docs.count,252), timeShift(keepLastValue(stats.gauges.govuk.app.search-api.cluster_A.<%= index_name %>_index.docs.count,252), '7d')),'Change')",
             "textEditor": true
           },
           {
             "refId": "B",
-            "target": "alias(keepLastValue(stats.gauges.govuk.app.search-api.<%= index_name %>_index.docs.total,252),'Index size')",
+            "target": "alias(keepLastValue(stats.gauges.govuk.app.search-api.cluster_A.<%= index_name %>_index.docs.count,252),'Index size')",
             "textEditor": true
           },
           {
             "refId": "C",
-            "target": "alias(timeShift(keepLastValue(stats.gauges.govuk.app.search-api.<%= index_name %>_index.docs.total,252), '7d'),'Index size (last week)')",
+            "target": "alias(timeShift(keepLastValue(stats.gauges.govuk.app.search-api.cluster_A.<%= index_name %>_index.docs.count,252), '7d'),'Index size (last week)')",
             "textEditor": true
           }
         ],
@@ -111,17 +111,17 @@
         "targets": [
           {
             "refId": "C",
-            "target": "alias(diffSeries(keepLastValue(stats.gauges.govuk.app.search-api.<%= index_name %>_index.docs.total,252), timeShift(keepLastValue(stats.gauges.govuk.app.search-api.<%= index_name %>_index.docs.total,252), '7d')),'Change')",
+            "target": "alias(diffSeries(keepLastValue(stats.gauges.govuk.app.search-api.cluster_A.<%= index_name %>_index.docs.count,252), timeShift(keepLastValue(stats.gauges.govuk.app.search-api.cluster_A.<%= index_name %>_index.docs.count,252), '7d')),'Change')",
             "textEditor": true
           },
           {
             "refId": "A",
-            "target": "alias(keepLastValue(stats.gauges.govuk.app.search-api.<%= index_name %>_index.docs.total,252), 'Index size')",
+            "target": "alias(keepLastValue(stats.gauges.govuk.app.search-api.cluster_A.<%= index_name %>_index.docs.count,252), 'Index size')",
             "textEditor": true
           },
           {
             "refId": "B",
-            "target": "alias(timeShift(keepLastValue(stats.gauges.govuk.app.search-api.<%= index_name %>_index.docs.total,252),'7d'), 'Index size (last week)')",
+            "target": "alias(timeShift(keepLastValue(stats.gauges.govuk.app.search-api.cluster_A.<%= index_name %>_index.docs.count,252),'7d'), 'Index size (last week)')",
             "textEditor": true
           }
         ],

--- a/modules/monitoring/manifests/checks.pp
+++ b/modules/monitoring/manifests/checks.pp
@@ -177,7 +177,7 @@ class monitoring::checks (
     $keep_last_value_limit = '132'
 
     icinga::check::graphite { 'check_search_api_govuk_index_size_changed':
-      target              => "absolute(diffSeries(keepLastValue(stats.gauges.govuk.app.search-api.govuk_index.docs.total,${keep_last_value_limit}), timeShift(keepLastValue(stats.gauges.govuk.app.search-api.govuk_index.docs.total,${keep_last_value_limit}), \"7d\")))",
+      target              => "absolute(diffSeries(keepLastValue(stats.gauges.govuk.app.search-api.cluster_A.govuk_index.docs.count,${keep_last_value_limit}), timeShift(keepLastValue(stats.gauges.govuk.app.search-api.cluster_A.govuk_index.docs.count,${keep_last_value_limit}), \"7d\")))",
       warning             => 3000,
       critical            => 10000,
       desc                => 'search-api govuk index size has significantly increased/decreased over the last 7 days',
@@ -191,7 +191,7 @@ class monitoring::checks (
 
     # Government is comparable to the govuk index.
     icinga::check::graphite { 'check_search_api_government_index_size_changed':
-      target              => "absolute(diffSeries(keepLastValue(stats.gauges.govuk.app.search-api.government_index.docs.total,${keep_last_value_limit}), timeShift(keepLastValue(stats.gauges.govuk.app.search-api.government_index.docs.total,${keep_last_value_limit}), \"7d\")))",
+      target              => "absolute(diffSeries(keepLastValue(stats.gauges.govuk.app.search-api.cluster_A.government_index.docs.count,${keep_last_value_limit}), timeShift(keepLastValue(stats.gauges.govuk.app.search-api.cluster_A.government_index.docs.count,${keep_last_value_limit}), \"7d\")))",
       warning             => 2500,
       critical            => 8000,
       desc                => 'search-api government index size has significantly increased/decreased over the last 7 days',
@@ -205,7 +205,7 @@ class monitoring::checks (
 
     # Detailed is smaller than the other indexes (about 4500 documents)
     icinga::check::graphite { 'check_search_api_detailed_index_size_changed':
-      target              => "absolute(diffSeries(keepLastValue(stats.gauges.govuk.app.search-api.detailed_index.docs.total,${keep_last_value_limit}), timeShift(keepLastValue(stats.gauges.govuk.app.search-api.detailed_index.docs.total,${keep_last_value_limit}), \"7d\")))",
+      target              => "absolute(diffSeries(keepLastValue(stats.gauges.govuk.app.search-api.cluster_A.detailed_index.docs.count,${keep_last_value_limit}), timeShift(keepLastValue(stats.gauges.govuk.app.search-api.cluster_A.detailed_index.docs.count,${keep_last_value_limit}), \"7d\")))",
       warning             => 100,
       critical            => 500,
       desc                => 'search-api detailed index size has significantly increased/decreased over the last 7 days',


### PR DESCRIPTION
In https://github.com/alphagov/search-api/pull/1569/files#diff-083eeb7a1599f2e1049dd88a094efa20R211, the metric names were changes to include the cluster (`cluster_A` or `cluster_B`), and the `.total` metric was renamed to `.count`.