### PR TITLE
Revert fix for search-api jobs

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/search_api_fetch_analytics_data.pp
+++ b/modules/govuk_jenkins/manifests/jobs/search_api_fetch_analytics_data.pp
@@ -4,16 +4,10 @@
 #
 class govuk_jenkins::jobs::search_api_fetch_analytics_data (
   $ga_auth_password = undef,
-
+  $app_domain = hiera('app_domain'),
   $skip_page_traffic_load = false,
   $cron_schedule = '5 4 * * *',
 ) {
-
-  if $::aws_migration {
-    $app_domain = hiera('app_domain_internal')
-  } else {
-    $app_domain = hiera('app_domain')
-  }
 
   $job_name = 'search-api-fetch-analytics-data'
   $check_name = 'search-api-fetch-analytics-data'

--- a/modules/govuk_jenkins/manifests/jobs/search_benchmark.pp
+++ b/modules/govuk_jenkins/manifests/jobs/search_benchmark.pp
@@ -6,13 +6,12 @@ class govuk_jenkins::jobs::search_benchmark (
   $auth_username = undef,
   $auth_password = undef,
   $rate_limit_token = undef,
+  $app_domain = hiera('app_domain'),
   $cron_schedule = '30 4 * * *'
 ) {
 
   if $::aws_migration {
-    $app_domain = hiera('app_domain_internal')
-  } else {
-    $app_domain = hiera('app_domain')
+    $app_domain_internal = hiera('app_domain_internal')
   }
 
   $test_type = 'results'

--- a/modules/govuk_jenkins/manifests/jobs/search_test_spelling_suggestions.pp
+++ b/modules/govuk_jenkins/manifests/jobs/search_test_spelling_suggestions.pp
@@ -6,13 +6,12 @@ class govuk_jenkins::jobs::search_test_spelling_suggestions (
   $auth_username = undef,
   $auth_password = undef,
   $rate_limit_token = undef,
+  $app_domain = hiera('app_domain'),
   $cron_schedule = '0 5 * * *'
 ) {
 
   if $::aws_migration {
-    $app_domain = hiera('app_domain_internal')
-  } else {
-    $app_domain = hiera('app_domain')
+    $app_domain_internal = hiera('app_domain_internal')
   }
 
   $test_type = 'suggestions'


### PR DESCRIPTION
There was a PR to try and fix this issue: https://github.com/alphagov/govuk-puppet/pull/9286/files#diff-d95168455f49c769e97f46ac57172922R5. This triggered a Bouncer incident and was partially reverted here https://github.com/alphagov/govuk-puppet/pull/9298/files

There are still alerts for the search-api jobs affected, so reverting the changes.

Trello card https://trello.com/c/cLjpzFHq/628-fix-the-cdn-deploy-bouncer-config-job