### PR TITLE
disable mirror monitoring before decommissioning

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -180,7 +180,6 @@ task :check_consistency_between_aws_and_carrenza do
     govuk_postgresql::backup::auto_postgresql_backup_hour
     govuk_postgresql::backup::auto_postgresql_backup_minute
     hosts::production::releaseapp_host_org
-    monitoring::checks::mirror::enabled
   ]
 
   # Keys that are AWS-only

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -568,7 +568,6 @@ licensify::apps::licensify::environment: 'production'
 licensify::apps::licensify_feed::environment: 'production'
 
 monitoring::checks::aws_origin_domain: "production.govuk.digital"
-monitoring::checks::mirror::enabled: true
 monitoring::checks::ses::region: us-east-1
 monitoring::checks::smokey::environment: 'production'
 monitoring::contacts::notify_graphite: true

--- a/hieradata/staging_disaster_recovery.yaml
+++ b/hieradata/staging_disaster_recovery.yaml
@@ -14,7 +14,6 @@ govuk::deploy::config::website_root: 'https://www.gov.uk'
 
 # Remove `router::nginx::robotstxt` from staging config
 
-monitoring::checks::mirror::enabled: true
 monitoring::checks::ses::region: us-east-1
 monitoring::contacts::notify_graphite: true
 monitoring::contacts::notify_pager: true


### PR DESCRIPTION
# Context

The mirrors machine are no longer used so we need to disable mirror monitoring before decommissioning them.

# Decisions
1. Disable mirror monitoring
