### PR TITLE
disable smokey mirror checks

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1540,8 +1540,6 @@ monitoring::checks::smokey::features:
     feature: signon
   check_smartanswers:
     feature: smartanswers
-  check_static_mirrors:
-    feature: mirror
   check_travel_advice:
     feature: travel_advice
   check_whitehall:

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1128,8 +1128,6 @@ monitoring::checks::smokey::features:
     feature: signon
   check_smartanswers:
     feature: smartanswers
-  check_static_mirrors:
-    feature: mirror
   check_travel_advice:
     feature: travel_advice
   check_whitehall:


### PR DESCRIPTION
disable the smokey mirror checks because carrenza mirrors arebeing decommisioned.