### PR TITLE
Update Data Sync Script to Automatically Use Correct DB User for Environment

### DIFF
--- a/modules/govuk_env_sync/files/govuk_env_sync.sh
+++ b/modules/govuk_env_sync/files/govuk_env_sync.sh
@@ -303,7 +303,12 @@ function restore_postgresql {
 }
 
 function  dump_mysql {
-  sudo -H mysqldump -u root --add-drop-database "${database}" | gzip > "${tempdir}/${filename}"
+  if [ "$AWS_DEFAULT_REGION" != '' ] ; then
+    DB_USER='aws_db_admin'
+  else
+    DB_USER='root'
+  fi
+  sudo -H mysqldump -u "$DB_USER" --add-drop-database "${database}" | gzip > "${tempdir}/${filename}"
 }
 
 function  restore_mysql {


### PR DESCRIPTION
We connect to AWS RDS instances using the "aws_db_admin" username, but we use "root"
for "carrenza/6DG". This change replaces the hardcoded usernames by checking
for the AWS_DEFAULT_REGION environmental variable and setting the database
user accordingly.