### PR TITLE
Fix Typo/Bug in Database Name

### DIFF
--- a/hieradata_aws/class/integration/db_admin.yaml
+++ b/hieradata_aws/class/integration/db_admin.yaml
@@ -237,7 +237,7 @@ govuk_env_sync::tasks:
     action: "push"
     dbms: "mysql"
     storagebackend: "s3"
-    database: "search_admin_production"
+    database: "signon_production"
     temppath: "/tmp/signon_production"
     url: "govuk-integration-database-backups"
     path: "mysql-backend"


### PR DESCRIPTION
The database name entered in the "push_signon_integration_daily"
section was incorrect. This commit updates it to the correct one.