### PR TITLE
Add the Content Data apps back to the Integration Deploy Jenkins job

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -938,7 +938,11 @@ govuk_jenkins::jobs::smokey::signon_password: "%{hiera('smokey_signon_password')
 govuk_jenkins::jobs::run_rake_task::applications: *deployable_applications
 govuk_jenkins::jobs::deploy_app::applications: *deployable_applications
 
-govuk_jenkins::jobs::integration_deploy::applications: *deployable_applications
+govuk_jenkins::jobs::integration_deploy::applications:
+  <<: *deployable_applications
+  # Include applications that have been migrated to AWS
+  content-data-admin: {}
+  content-data-api: {}
 
 govuk_jenkins::jobs::deploy_lambda_app::lambda_apps:
   - 'email_alert_notifications'


### PR DESCRIPTION
These were removed (e.g. [1] from the `deployable_applications` list
in the Carrenza side hieradata, as they're no longer running in
Carrenza.

1: 5c729768f6277d9ad716d3faa411a3c19fa5afd9

However, they still need to be present in the Integration Deploy job,
as this is actually deploying in the Integration environment running
in AWS.

This should resolve the failing master branch builds for these
applications.