### PR TITLE
Update the search-api index size metric names (take 2)

### DIFF
--- a/modules/monitoring/manifests/checks.pp
+++ b/modules/monitoring/manifests/checks.pp
@@ -177,7 +177,7 @@ class monitoring::checks (
     $keep_last_value_limit = '132'
 
     icinga::check::graphite { 'check_search_api_govuk_index_size_changed':
-      target              => "absolute(diffSeries(keepLastValue(stats.gauges.govuk.app.search-api.cluster_A.govuk_index.docs.count,${keep_last_value_limit}), timeShift(keepLastValue(stats.gauges.govuk.app.search-api.cluster_A.govuk_index.docs.count,${keep_last_value_limit}), \"7d\")))",
+      target              => "absolute(diffSeries(keepLastValue(stats.gauges.govuk.app.search-api.cluster_A.govuk_index.docs.total,${keep_last_value_limit}), timeShift(keepLastValue(stats.gauges.govuk.app.search-api.cluster_A.govuk_index.docs.total,${keep_last_value_limit}), \"7d\")))",
       warning             => 3000,
       critical            => 10000,
       desc                => 'search-api govuk index size has significantly increased/decreased over the last 7 days',
@@ -191,7 +191,7 @@ class monitoring::checks (
 
     # Government is comparable to the govuk index.
     icinga::check::graphite { 'check_search_api_government_index_size_changed':
-      target              => "absolute(diffSeries(keepLastValue(stats.gauges.govuk.app.search-api.cluster_A.government_index.docs.count,${keep_last_value_limit}), timeShift(keepLastValue(stats.gauges.govuk.app.search-api.cluster_A.government_index.docs.count,${keep_last_value_limit}), \"7d\")))",
+      target              => "absolute(diffSeries(keepLastValue(stats.gauges.govuk.app.search-api.cluster_A.government_index.docs.total,${keep_last_value_limit}), timeShift(keepLastValue(stats.gauges.govuk.app.search-api.cluster_A.government_index.docs.total,${keep_last_value_limit}), \"7d\")))",
       warning             => 2500,
       critical            => 8000,
       desc                => 'search-api government index size has significantly increased/decreased over the last 7 days',
@@ -205,7 +205,7 @@ class monitoring::checks (
 
     # Detailed is smaller than the other indexes (about 4500 documents)
     icinga::check::graphite { 'check_search_api_detailed_index_size_changed':
-      target              => "absolute(diffSeries(keepLastValue(stats.gauges.govuk.app.search-api.cluster_A.detailed_index.docs.count,${keep_last_value_limit}), timeShift(keepLastValue(stats.gauges.govuk.app.search-api.cluster_A.detailed_index.docs.count,${keep_last_value_limit}), \"7d\")))",
+      target              => "absolute(diffSeries(keepLastValue(stats.gauges.govuk.app.search-api.cluster_A.detailed_index.docs.total,${keep_last_value_limit}), timeShift(keepLastValue(stats.gauges.govuk.app.search-api.cluster_A.detailed_index.docs.total,${keep_last_value_limit}), \"7d\")))",
       warning             => 100,
       critical            => 500,
       desc                => 'search-api detailed index size has significantly increased/decreased over the last 7 days',


### PR DESCRIPTION
Re-do the changes from [1] that were removed in [2].

1: https://github.com/alphagov/govuk-puppet/commit/6ba88463c67770f7aef2b16ee0af86a5bf167ead
2: https://github.com/alphagov/govuk-puppet/commit/9811d5b0331c58872680229f6ee48d4ad7d4a335

Metrics ending in `.count` are usually used for timers in StatsD, and
there is some specific Graphite storage aggregation configuration for
them [3].

This change updates the use of the metrics to match the new name [4].

3: https://github.com/alphagov/govuk-puppet/blob/master/modules/govuk/files/node/s_graphite/storage-aggregation.conf#L35-L40
```
[count]
pattern = \.count$
aggregationMethod = sum
xFilesFactor = 0.1
```

4: https://github.com/alphagov/search-api/pull/1577