### PR TITLE
remove mirror ssl check

### DIFF
--- a/modules/monitoring/manifests/checks.pp
+++ b/modules/monitoring/manifests/checks.pp
@@ -130,15 +130,6 @@ class monitoring::checks (
     service_description => "check the STAR.${app_domain} TLS certificate is valid and not due to expire",
     notes_url           => monitoring_docs_url(renew-tls-certificate),
   }
-
-  # AWS cannot access mirror machines in Carrenza
-  unless $::aws_migration {
-    icinga::check { 'check_mirror_provider1_cert_valid':
-      check_command       => 'check_ssl_cert!www-origin.mirror.provider1.production.govuk.service.gov.uk!www-origin.mirror.provider1.production.govuk.service.gov.uk!30',
-      host_name           => $::fqdn,
-      service_description => 'check the provider1 mirror SSL certificate is valid and not due to expire',
-    }
-  }
   # END ssl certificate checks
 
   # START DNS checks


### PR DESCRIPTION
# Context

mirror ssl check is removed since mirrors in Carrenza are decommissioned. We will put another checks later for the ssl on the new secondary CDN

# Decisions
1. remove ssl check for mirror