### PR TITLE
Reenable smokey mirror checks

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1544,6 +1544,8 @@ monitoring::checks::smokey::features:
     feature: signon
   check_smartanswers:
     feature: smartanswers
+  check_static_mirrors:	
+    feature: mirror
   check_travel_advice:
     feature: travel_advice
   check_whitehall:

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1128,6 +1128,8 @@ monitoring::checks::smokey::features:
     feature: signon
   check_smartanswers:
     feature: smartanswers
+  check_static_mirrors:	
+    feature: mirror
   check_travel_advice:
     feature: travel_advice
   check_whitehall:


### PR DESCRIPTION
Reenable Smokey mirror tests, previously disabled in e32b435

The new tests should now support S3 mirrors.