### PR TITLE
Increase the threshold for high memory alert on licensify frontend

### DIFF
--- a/modules/licensify/manifests/apps/licensify.pp
+++ b/modules/licensify/manifests/apps/licensify.pp
@@ -17,8 +17,8 @@ class licensify::apps::licensify (
     proxy_http_version_1_1_enabled => true,
     log_format_is_json             => true,
     collectd_process_regex         => 'java -Duser.dir=\/data\/vhost\/licensify\..*publishing\.service\.gov\.uk\/licensify-.*',
-    nagios_memory_warning          => 900,
-    nagios_memory_critical         => 1000,
+    nagios_memory_warning          => 1350,
+    nagios_memory_critical         => 1500,
   }
 
   licensify::apps::envvars { 'licensify':

--- a/modules/licensify/manifests/apps/licensify_admin.pp
+++ b/modules/licensify/manifests/apps/licensify_admin.pp
@@ -17,8 +17,8 @@ class licensify::apps::licensify_admin(
     proxy_http_version_1_1_enabled => true,
     log_format_is_json             => true,
     collectd_process_regex         => 'java -Duser.dir=\/data\/vhost\/licensify-admin\..*publishing\.service\.gov\.uk\/licensify-admin-.*',
-    nagios_memory_warning          => 900,
-    nagios_memory_critical         => 1000,
+    nagios_memory_warning          => 1350,
+    nagios_memory_critical         => 1500,
   }
 
   licensify::apps::envvars { 'licensify-admin':


### PR DESCRIPTION
The memory memory on these machines has been increased to 2048M