### PR TITLE
Fix Hieradata

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1544,7 +1544,7 @@ monitoring::checks::smokey::features:
     feature: signon
   check_smartanswers:
     feature: smartanswers
-  check_static_mirrors:	
+  check_static_mirrors:
     feature: mirror
   check_travel_advice:
     feature: travel_advice

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1128,7 +1128,7 @@ monitoring::checks::smokey::features:
     feature: signon
   check_smartanswers:
     feature: smartanswers
-  check_static_mirrors:	
+  check_static_mirrors:
     feature: mirror
   check_travel_advice:
     feature: travel_advice


### PR DESCRIPTION
Fix a3d986c, a TAB character was added by mistake and it's causing
client errors:

```
Could not retrieve catalog from remote server: Error 400 on SERVER: Error from DataBinding
'hiera' while looking up ... found character #011 '\t(TAB)' that cannot start any token.
(Do not use \t(TAB) for indentation)
```