### PR TITLE
revert back to common crawler blacklist for staging

### DIFF
--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -131,18 +131,6 @@ govuk::apps::email_alert_api::email_address_override_whitelist_only: true
 govuk::apps::email_alert_api::delivery_request_threshold: "3000"
 govuk::apps::email_alert_frontend::subscription_management_enabled: true
 
-govuk::apps::govuk_crawler_worker::blacklist_paths:
-  - '/apply-for-a-licence'
-  - '/business-finance-support-finder'
-  - '/drug-device-alerts.atom'
-  - '/drug-safety-update.atom'
-  - '/foreign-travel-advice.atom'
-  - '/government/announcements.atom'
-  - '/government/publications.atom'
-  - '/government/statistics.atom'
-  - '/licence-finder'
-  - '/search'
-
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::kibana::logit_environment: b13bfb70-e07a-473b-9903-02e806ebd045
 govuk::apps::link_checker_api::govuk_basic_auth_credentials: "%{hiera('http_username')}:%{hiera('http_password')}"


### PR DESCRIPTION
# Context

The crawler in AWS staging was set to include government/uploads but with the new version of the crawler, too many web pages are downloaded and disk was not enlarged and will not be to save money.

# Decisions
1. Revert the AWS Staging crawler back to the original list.