### PR TITLE
Disable Datasync on Training for the following databases:

### DIFF
--- a/hieradata_aws/class/training/db_admin.yaml
+++ b/hieradata_aws/class/training/db_admin.yaml
@@ -143,7 +143,7 @@ govuk_env_sync::tasks:
     url: "govuk-integration-database-backups"
     path: "postgresql-backend"
   "pull_publishing_api_training_daily":
-    ensure: "present"
+    ensure: "disabled"
     hour: "5"
     minute: "0"
     action: "pull"
@@ -220,7 +220,7 @@ govuk_env_sync::tasks:
     url: "govuk-integration-database-backups"
     path: "mysql-backend"
   "pull_signon_training_daily":
-    ensure: "present"
+    ensure: "disabled"
     hour: "2"
     minute: "15"
     action: "pull"
@@ -231,7 +231,7 @@ govuk_env_sync::tasks:
     url: "govuk-integration-database-backups"
     path: "mysql-backend"
   "pull_whitehall_training_daily":
-    ensure: "present"
+    ensure: "disabled"
     hour: "3"
     minute: "45"
     action: "pull"

--- a/hieradata_aws/class/training/mongo.yaml
+++ b/hieradata_aws/class/training/mongo.yaml
@@ -1,6 +1,6 @@
 govuk_env_sync::tasks:
   "pull_content_store_daily_training":
-    ensure: "present"
+    ensure: "disabled"
     hour: "1"
     minute: "16"
     action: "pull"
@@ -11,7 +11,7 @@ govuk_env_sync::tasks:
     url: "govuk-integration-database-backups"
     path: "mongo-api"
   "pull_draft_content_store_daily_training":
-    ensure: "present"
+    ensure: "disabled"
     hour: "1"
     minute: "16"
     action: "pull"


### PR DESCRIPTION
signon
whitehall
content_store
publishing_api

The datasync for the Training environment does not need to happen every night,
and may break some functionality by overwriting settings in Whitehall.