### PR TITLE
Update the search-api index size metric names (again)

### DIFF
--- a/modules/grafana/templates/dashboards_aws/_index_size.json.erb
+++ b/modules/grafana/templates/dashboards_aws/_index_size.json.erb
@@ -50,17 +50,17 @@
         "targets": [
           {
             "refId": "A",
-            "target": "alias(diffSeries(keepLastValue(stats.gauges.govuk.app.search-api.cluster_A.<%= index_name %>_index.docs.count,252), timeShift(keepLastValue(stats.gauges.govuk.app.search-api.cluster_A.<%= index_name %>_index.docs.count,252), '7d')),'Change')",
+            "target": "alias(diffSeries(keepLastValue(stats.gauges.govuk.app.search-api.cluster_A.<%= index_name %>_index.docs.total,252), timeShift(keepLastValue(stats.gauges.govuk.app.search-api.cluster_A.<%= index_name %>_index.docs.total,252), '7d')),'Change')",
             "textEditor": true
           },
           {
             "refId": "B",
-            "target": "alias(keepLastValue(stats.gauges.govuk.app.search-api.cluster_A.<%= index_name %>_index.docs.count,252),'Index size')",
+            "target": "alias(keepLastValue(stats.gauges.govuk.app.search-api.cluster_A.<%= index_name %>_index.docs.total,252),'Index size')",
             "textEditor": true
           },
           {
             "refId": "C",
-            "target": "alias(timeShift(keepLastValue(stats.gauges.govuk.app.search-api.cluster_A.<%= index_name %>_index.docs.count,252), '7d'),'Index size (last week)')",
+            "target": "alias(timeShift(keepLastValue(stats.gauges.govuk.app.search-api.cluster_A.<%= index_name %>_index.docs.total,252), '7d'),'Index size (last week)')",
             "textEditor": true
           }
         ],
@@ -111,17 +111,17 @@
         "targets": [
           {
             "refId": "C",
-            "target": "alias(diffSeries(keepLastValue(stats.gauges.govuk.app.search-api.cluster_A.<%= index_name %>_index.docs.count,252), timeShift(keepLastValue(stats.gauges.govuk.app.search-api.cluster_A.<%= index_name %>_index.docs.count,252), '7d')),'Change')",
+            "target": "alias(diffSeries(keepLastValue(stats.gauges.govuk.app.search-api.cluster_A.<%= index_name %>_index.docs.total,252), timeShift(keepLastValue(stats.gauges.govuk.app.search-api.cluster_A.<%= index_name %>_index.docs.total,252), '7d')),'Change')",
             "textEditor": true
           },
           {
             "refId": "A",
-            "target": "alias(keepLastValue(stats.gauges.govuk.app.search-api.cluster_A.<%= index_name %>_index.docs.count,252), 'Index size')",
+            "target": "alias(keepLastValue(stats.gauges.govuk.app.search-api.cluster_A.<%= index_name %>_index.docs.total,252), 'Index size')",
             "textEditor": true
           },
           {
             "refId": "B",
-            "target": "alias(timeShift(keepLastValue(stats.gauges.govuk.app.search-api.cluster_A.<%= index_name %>_index.docs.count,252),'7d'), 'Index size (last week)')",
+            "target": "alias(timeShift(keepLastValue(stats.gauges.govuk.app.search-api.cluster_A.<%= index_name %>_index.docs.total,252),'7d'), 'Index size (last week)')",
             "textEditor": true
           }
         ],


### PR DESCRIPTION
Repeat the changes in 6ba88463c67770f7aef2b16ee0af86a5bf167ead.

Metrics ending in `.count` are usually used for timers in StatsD, and
there is some specific Graphite storage aggregation configuration for
them [1].

This change updates the use of the metrics to match the new name [2].

1: https://github.com/alphagov/govuk-puppet/blob/master/modules/govuk/files/node/s_graphite/storage-aggregation.conf#L35-L40
```
[count]
pattern = \.count$
aggregationMethod = sum
xFilesFactor = 0.1
```

2: https://github.com/alphagov/search-api/pull/1577