### PR TITLE
Change the device name for apt after updating type

### DIFF
--- a/hieradata_aws/class/integration/apt.yaml
+++ b/hieradata_aws/class/integration/apt.yaml
@@ -1,0 +1,14 @@
+---
+
+govuk::node::s_apt::root_dir: '/mnt/apt'
+
+lv:
+  data:
+    pv: '/dev/nvme1n1'
+    vg: 'apt'
+
+mount:
+  /mnt/apt:
+    disk: '/dev/mapper/apt-data'
+    govuk_lvm: 'data'
+    mountoptions: 'defaults'


### PR DESCRIPTION
- After switching from T2 to T3 instance_type, the default device name of root
file systems and EBS resources changes from xdvX to nvmeXnY.

- Without this change new instances come up without usable disks

solo: @schmie