### PR TITLE
Enable X-Frame-Options everywhere

### DIFF
--- a/docs/adding-a-new-app.md
+++ b/docs/adding-a-new-app.md
@@ -77,7 +77,7 @@ class govuk::apps::myapp (
     sentry_dsn        => $sentry_dsn,
     vhost_ssl_only    => true,
     health_check_path => '/healthcheck', # must return HTTP 200 for an unauthenticated request
-    deny_framing      => true,
+    frame_options     => 'deny',
     asset_pipeline    => true,
   }
 

--- a/modules/govuk/manifests/app.pp
+++ b/modules/govuk/manifests/app.pp
@@ -92,12 +92,12 @@
 #   Additional contact groups to pass to the icinga::checks for this
 #   application.
 #
-# [*deny_framing*]
-# should we allow this app to be framed
-#
-# If set to true, the nginx fronting the app will set the X-Frame-Options
-# header in such a way as to deny framing in clients that support the header.
-#
+# [*frame_options*]
+#   The value that the X-Frame-Options HTTP header should be set to.
+#   Defaults to 'deny', which disallows all framing of the app by
+#   compliant browsers. Can also be set to 'sameorigin' to allow
+#   framing by pages on the same hostname, or an empty string to allow
+#   all framing (not recommended).
 #
 # [*enable_nginx_vhost*]
 # should this app be fronted by nginx?
@@ -280,7 +280,7 @@ define govuk::app (
   $health_check_service_template = 'govuk_regular_service',
   $health_check_notification_period = undef,
   $additional_check_contact_groups = undef,
-  $deny_framing = false,
+  $frame_options = 'deny',
   $enable_nginx_vhost = true,
   $vhost = undef,
   $vhost_aliases = [],
@@ -370,7 +370,7 @@ define govuk::app (
     health_check_service_template       => $health_check_service_template,
     health_check_notification_period    => $health_check_notification_period,
     additional_check_contact_groups     => $additional_check_contact_groups,
-    deny_framing                        => $deny_framing,
+    frame_options                       => $frame_options,
     enable_nginx_vhost                  => $enable_nginx_vhost,
     nagios_memory_warning               => $nagios_memory_warning,
     nagios_memory_critical              => $nagios_memory_critical,

--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -18,6 +18,13 @@
 #   Additional contact groups to pass to the icinga::checks for this
 #   application.
 #
+# [*frame_options*]
+#   The value that the X-Frame-Options HTTP header should be set to.
+#   Defaults to 'deny', which disallows all framing of the app by
+#   compliant browsers. Can also be set to 'sameorigin' to allow
+#   framing by pages on the same hostname, or an empty string to allow
+#   all framing (not recommended).
+#
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
@@ -87,7 +94,7 @@ define govuk::app::config (
   $health_check_service_template = 'govuk_regular_service',
   $health_check_notification_period = undef,
   $additional_check_contact_groups = undef,
-  $deny_framing = false,
+  $frame_options = 'deny',
   $enable_nginx_vhost = true,
   $unicorn_herder_timeout = 'NOTSET',
   $nagios_memory_warning = 700,
@@ -277,7 +284,7 @@ define govuk::app::config (
       app_port                       => $port,
       ssl_only                       => $vhost_ssl_only,
       nginx_extra_config             => $nginx_extra_config,
-      deny_framing                   => $deny_framing,
+      frame_options                  => $frame_options,
       asset_pipeline                 => $asset_pipeline,
       asset_pipeline_prefix          => $asset_pipeline_prefix,
       hidden_paths                   => $hidden_paths,

--- a/modules/govuk/manifests/app/nginx_vhost.pp
+++ b/modules/govuk/manifests/app/nginx_vhost.pp
@@ -25,8 +25,12 @@
 # [*nginx_extra_config*]
 #   A string containing additional nginx config
 #
-# [*deny_framing*]
-#   Boolean, whether nginx should instruct browsers to not allow framing the page
+# [*frame_options*]
+#   The value that the X-Frame-Options HTTP header should be set to.
+#   Defaults to 'deny', which disallows all framing of the app by
+#   compliant browsers. Can also be set to 'sameorigin' to allow
+#   framing by pages on the same hostname, or an empty string to allow
+#   all framing (not recommended).
 #
 # [*deny_crawlers*]
 #   Boolean, whether nginx should serve robots.txt
@@ -70,7 +74,7 @@ define govuk::app::nginx_vhost (
   $protected_location = '/',
   $ssl_only = false,
   $nginx_extra_config = '',
-  $deny_framing = false,
+  $frame_options = 'deny',
   $deny_crawlers = false,
   $is_default_vhost = false,
   $asset_pipeline = false,
@@ -106,7 +110,7 @@ define govuk::app::nginx_vhost (
     protected_location             => $protected_location,
     ssl_only                       => $ssl_only,
     extra_config                   => $nginx_extra_config_real,
-    deny_framing                   => $deny_framing,
+    frame_options                  => $frame_options,
     deny_crawlers                  => $deny_crawlers,
     is_default_vhost               => $is_default_vhost,
     hidden_paths                   => $hidden_paths,

--- a/modules/govuk/manifests/apps/asset_manager.pp
+++ b/modules/govuk/manifests/apps/asset_manager.pp
@@ -84,7 +84,7 @@ class govuk::apps::asset_manager(
 
     # The X-Frame-Options response header is set explicitly in the
     # relevant location blocks.
-    $deny_framing = false
+    $frame_options = 'deny'
 
     govuk::app { $app_name:
       app_type                 => 'rack',
@@ -93,7 +93,7 @@ class govuk::apps::asset_manager(
       vhost_ssl_only           => true,
       health_check_path        => '/healthcheck',
       log_format_is_json       => true,
-      deny_framing             => $deny_framing,
+      frame_options            => $frame_options,
       depends_on_nfs           => true,
       nginx_extra_config       => template('govuk/asset_manager_extra_nginx_config.conf.erb'),
       unicorn_worker_processes => $unicorn_worker_processes,

--- a/modules/govuk/manifests/apps/calculators.pp
+++ b/modules/govuk/manifests/apps/calculators.pp
@@ -33,6 +33,7 @@ class govuk::apps::calculators(
     log_format_is_json    => true,
     asset_pipeline        => true,
     asset_pipeline_prefix => 'calculators',
+    frame_options         => 'sameorigin',
   }
 
   Govuk::App::Envvar {

--- a/modules/govuk/manifests/apps/calendars.pp
+++ b/modules/govuk/manifests/apps/calendars.pp
@@ -36,6 +36,7 @@ class govuk::apps::calendars(
     log_format_is_json    => true,
     asset_pipeline        => true,
     asset_pipeline_prefix => 'calendars',
+    frame_options         => 'sameorigin',
   }
 
   Govuk::App::Envvar {

--- a/modules/govuk/manifests/apps/collections.pp
+++ b/modules/govuk/manifests/apps/collections.pp
@@ -50,6 +50,7 @@ class govuk::apps::collections(
     nagios_memory_warning  => $nagios_memory_warning,
     nagios_memory_critical => $nagios_memory_critical,
     sentry_dsn             => $sentry_dsn,
+    frame_options          => 'sameorigin',
   }
 
   Govuk::App::Envvar {

--- a/modules/govuk/manifests/apps/collections_publisher.pp
+++ b/modules/govuk/manifests/apps/collections_publisher.pp
@@ -85,7 +85,6 @@ class govuk::apps::collections_publisher(
     health_check_path  => '/',
     log_format_is_json => true,
     asset_pipeline     => true,
-    deny_framing       => true,
   }
 
   Govuk::App::Envvar {

--- a/modules/govuk/manifests/apps/contacts.pp
+++ b/modules/govuk/manifests/apps/contacts.pp
@@ -101,6 +101,7 @@ class govuk::apps::contacts(
       vhost_protected       => $vhost_protected,
       asset_pipeline        => true,
       asset_pipeline_prefix => 'contacts-assets',
+      frame_options         => 'sameorigin',
       vhost_aliases         => $extra_aliases,
       repo_name             => 'contacts-admin',
       nginx_extra_config    => '

--- a/modules/govuk/manifests/apps/content_data_admin.pp
+++ b/modules/govuk/manifests/apps/content_data_admin.pp
@@ -115,7 +115,6 @@ class govuk::apps::content_data_admin (
     vhost                           => 'content-data',
     vhost_ssl_only                  => true,
     health_check_path               => '/healthcheck', # must return HTTP 200 for an unauthenticated request
-    deny_framing                    => true,
     asset_pipeline                  => true,
     read_timeout                    => 60,
     additional_check_contact_groups => ['slack-channel-data-informed'],

--- a/modules/govuk/manifests/apps/content_publisher.pp
+++ b/modules/govuk/manifests/apps/content_publisher.pp
@@ -141,7 +141,6 @@ class govuk::apps::content_publisher (
     sentry_dsn         => $sentry_dsn,
     vhost_ssl_only     => true,
     health_check_path  => '/healthcheck', # must return HTTP 200 for an unauthenticated request
-    deny_framing       => true,
     asset_pipeline     => true,
     nginx_extra_config => 'client_max_body_size 500m;',
   }

--- a/modules/govuk/manifests/apps/content_tagger.pp
+++ b/modules/govuk/manifests/apps/content_tagger.pp
@@ -92,7 +92,6 @@ class govuk::apps::content_tagger(
     health_check_path        => '/healthcheck',
     log_format_is_json       => true,
     asset_pipeline           => true,
-    deny_framing             => false,
     sentry_dsn               => $sentry_dsn,
     override_search_location => $override_search_location,
   }

--- a/modules/govuk/manifests/apps/email_alert_frontend.pp
+++ b/modules/govuk/manifests/apps/email_alert_frontend.pp
@@ -54,6 +54,7 @@ class govuk::apps::email_alert_frontend(
     vhost                 => $vhost,
     health_check_path     => '/healthcheck',
     json_health_check     => true,
+    frame_options         => 'sameorigin',
   }
 
   Govuk::App::Envvar {

--- a/modules/govuk/manifests/apps/feedback.pp
+++ b/modules/govuk/manifests/apps/feedback.pp
@@ -46,6 +46,7 @@ class govuk::apps::feedback(
     log_format_is_json    => true,
     asset_pipeline        => true,
     asset_pipeline_prefix => $app_name,
+    frame_options         => 'sameorigin',
   }
 
   Govuk::App::Envvar {

--- a/modules/govuk/manifests/apps/finder_frontend.pp
+++ b/modules/govuk/manifests/apps/finder_frontend.pp
@@ -46,6 +46,7 @@ class govuk::apps::finder_frontend(
       nagios_memory_warning    => $nagios_memory_warning,
       nagios_memory_critical   => $nagios_memory_critical,
       unicorn_worker_processes => $unicorn_worker_processes,
+      frame_options            => 'sameorigin',
     }
   }
 

--- a/modules/govuk/manifests/apps/frontend.pp
+++ b/modules/govuk/manifests/apps/frontend.pp
@@ -71,6 +71,7 @@ class govuk::apps::frontend(
     nagios_memory_critical   => $nagios_memory_critical,
     vhost                    => $vhost,
     unicorn_worker_processes => $unicorn_worker_processes,
+    frame_options            => 'sameorigin',
   }
 
   govuk::app::envvar::redis { 'frontend':

--- a/modules/govuk/manifests/apps/government_frontend.pp
+++ b/modules/govuk/manifests/apps/government_frontend.pp
@@ -69,5 +69,6 @@ class govuk::apps::government_frontend(
     cpu_critical             => $cpu_critical,
     nagios_memory_warning    => $nagios_memory_warning,
     nagios_memory_critical   => $nagios_memory_critical,
+    frame_options            => 'sameorigin',
   }
 }

--- a/modules/govuk/manifests/apps/info_frontend.pp
+++ b/modules/govuk/manifests/apps/info_frontend.pp
@@ -43,6 +43,7 @@ class govuk::apps::info_frontend(
     asset_pipeline_prefix => 'info-frontend',
     health_check_path     => '/healthcheck',
     json_health_check     => true,
+    frame_options         => 'sameorigin',
   }
 
   Govuk::App::Envvar {

--- a/modules/govuk/manifests/apps/licencefinder.pp
+++ b/modules/govuk/manifests/apps/licencefinder.pp
@@ -49,6 +49,7 @@ class govuk::apps::licencefinder(
     asset_pipeline        => true,
     asset_pipeline_prefix => 'licencefinder',
     repo_name             => 'licence-finder',
+    frame_options         => 'sameorigin',
   }
 
   if $::govuk_node_class !~ /^development$/ {

--- a/modules/govuk/manifests/apps/manuals_frontend.pp
+++ b/modules/govuk/manifests/apps/manuals_frontend.pp
@@ -38,6 +38,7 @@ class govuk::apps::manuals_frontend(
     vhost                 => $vhost,
     health_check_path     => '/healthcheck',
     json_health_check     => true,
+    frame_options         => 'sameorigin',
   }
 
   Govuk::App::Envvar {

--- a/modules/govuk/manifests/apps/publisher.pp
+++ b/modules/govuk/manifests/apps/publisher.pp
@@ -118,7 +118,6 @@ class govuk::apps::publisher(
     json_health_check   => true,
     log_format_is_json  => true,
     asset_pipeline      => true,
-    deny_framing        => true,
     nginx_extra_config  => '
     proxy_set_header X-Sendfile-Type X-Accel-Redirect;
     proxy_set_header X-Accel-Mapping /var/apps/publisher/reports/=/raw/;

--- a/modules/govuk/manifests/apps/publishing_api.pp
+++ b/modules/govuk/manifests/apps/publishing_api.pp
@@ -172,7 +172,6 @@ class govuk::apps::publishing_api(
     unicorn_worker_processes         => $unicorn_worker_processes,
     json_health_check                => true,
     log_format_is_json               => true,
-    deny_framing                     => true,
     nagios_memory_warning            => $nagios_memory_warning,
     nagios_memory_critical           => $nagios_memory_critical,
   }

--- a/modules/govuk/manifests/apps/search_admin.pp
+++ b/modules/govuk/manifests/apps/search_admin.pp
@@ -70,7 +70,6 @@ class govuk::apps::search_admin(
     health_check_path        => '/queries',
     log_format_is_json       => true,
     asset_pipeline           => true,
-    deny_framing             => true,
     override_search_location => $override_search_location,
   }
 

--- a/modules/govuk/manifests/apps/service_manual_frontend.pp
+++ b/modules/govuk/manifests/apps/service_manual_frontend.pp
@@ -44,6 +44,7 @@ class govuk::apps::service_manual_frontend(
       asset_pipeline        => true,
       asset_pipeline_prefix => 'service-manual-frontend',
       vhost                 => $vhost,
+      frame_options         => 'sameorigin',
     }
 
     govuk::app::envvar {

--- a/modules/govuk/manifests/apps/signon.pp
+++ b/modules/govuk/manifests/apps/signon.pp
@@ -98,7 +98,6 @@ class govuk::apps::signon(
     health_check_path        => '/healthcheck',
     json_health_check        => true,
     asset_pipeline           => true,
-    deny_framing             => true,
     log_format_is_json       => true,
     nagios_memory_warning    => $nagios_memory_warning,
     nagios_memory_critical   => $nagios_memory_critical,

--- a/modules/govuk/manifests/apps/smartanswers.pp
+++ b/modules/govuk/manifests/apps/smartanswers.pp
@@ -98,5 +98,6 @@ class govuk::apps::smartanswers(
     alert_5xx_critical_rate  => 0.005,
     repo_name                => 'smart-answers',
     unicorn_worker_processes => $unicorn_worker_processes,
+    frame_options            => 'sameorigin',
   }
 }

--- a/modules/govuk/manifests/apps/static.pp
+++ b/modules/govuk/manifests/apps/static.pp
@@ -83,6 +83,7 @@ class govuk::apps::static(
     unicorn_worker_processes => $unicorn_worker_processes,
     nagios_memory_warning    => $nagios_memory_warning,
     nagios_memory_critical   => $nagios_memory_critical,
+    frame_options            => 'sameorigin',
   }
 
   Govuk::App::Envvar {

--- a/modules/govuk/manifests/apps/support.pp
+++ b/modules/govuk/manifests/apps/support.pp
@@ -104,6 +104,7 @@ class govuk::apps::support(
         deny    all;
       }',
     asset_pipeline     => true,
+    frame_options      => 'sameorigin',
   }
 
   govuk::procfile::worker { $app_name:

--- a/modules/govuk/manifests/apps/transition.pp
+++ b/modules/govuk/manifests/apps/transition.pp
@@ -95,7 +95,6 @@ class govuk::apps::transition(
     vhost_ssl_only     => true,
     health_check_path  => '/',
     log_format_is_json => true,
-    deny_framing       => true,
     asset_pipeline     => true,
   }
 

--- a/modules/govuk/manifests/apps/travel_advice_publisher.pp
+++ b/modules/govuk/manifests/apps/travel_advice_publisher.pp
@@ -94,7 +94,6 @@ class govuk::apps::travel_advice_publisher(
     json_health_check  => true,
     log_format_is_json => true,
     asset_pipeline     => true,
-    deny_framing       => true,
   }
 
   Govuk::App::Envvar {

--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -261,7 +261,6 @@ class govuk::apps::whitehall(
       app_port              => $port,
       protected             => $vhost_protected,
       protected_location    => '/government/admin/fact_check_requests/',
-      deny_framing          => true,
       deny_crawlers         => true,
       asset_pipeline        => true,
       asset_pipeline_prefix => 'government/assets',

--- a/modules/nginx/manifests/config/vhost/proxy.pp
+++ b/modules/nginx/manifests/config/vhost/proxy.pp
@@ -20,8 +20,12 @@
 # [*extra_app_config*]
 #   A string containing additional nginx config for the `app` location block
 #
-# [*deny_framing*]
-#   Boolean, whether nginx should instruct browsers to not allow framing the page
+# [*frame_options*]
+#   The value that the X-Frame-Options HTTP header should be set to.
+#   Defaults to 'deny', which disallows all framing of the app by
+#   compliant browsers. Can also be set to 'sameorigin' to allow
+#   framing by pages on the same hostname, or an empty string to allow
+#   all framing (not recommended).
 #
 # [*protected*]
 #   Boolean, whether or not the vhost should be protected with basic auth
@@ -79,7 +83,7 @@ define nginx::config::vhost::proxy(
   $aliases = [],
   $extra_config = '',
   $extra_app_config = '',
-  $deny_framing = false,
+  $frame_options = 'deny',
   $protected = true,
   $protected_location = '/',
   $root = "/data/vhost/${title}/current/public",

--- a/modules/nginx/manifests/config/vhost/static.pp
+++ b/modules/nginx/manifests/config/vhost/static.pp
@@ -14,8 +14,12 @@
 # [*extra_config*]
 #   A string containing additional nginx config
 #
-# [*deny_framing*]
-#   Boolean, whether nginx should instruct browsers to not allow framing the page
+# [*frame_options*]
+#   The value that the X-Frame-Options HTTP header should be set to.
+#   Defaults to 'deny', which disallows all framing of the app by
+#   compliant browsers. Can also be set to 'sameorigin' to allow
+#   framing by pages on the same hostname, or an empty string to allow
+#   all framing (not recommended).
 #
 # [*deny_crawlers*]
 #   Boolean, whether Nginx should serve a robots.txt that
@@ -38,7 +42,7 @@ define nginx::config::vhost::static(
   $aliases = [],
   $locations = {},
   $extra_config = '',
-  $deny_framing = false,
+  $frame_options = 'deny',
   $deny_crawlers = false,
   $logstream = present,
   $is_default_vhost = false,

--- a/modules/nginx/spec/defines/nginx__config__vhost__proxy_spec.rb
+++ b/modules/nginx/spec/defines/nginx__config__vhost__proxy_spec.rb
@@ -137,17 +137,31 @@ describe 'nginx::config::vhost::proxy', :type => :define do
 
   end
 
-  context 'with deny_framing true' do
+  context 'with frame_options set to "deny"' do
     let(:params) do
       {
         :to => ['a.internal'],
-        :deny_framing => true,
+        :frame_options => 'deny',
       }
     end
 
-    it 'should add the X-Frame-Options header' do
+    it 'should add the X-Frame-Options header with the DENY value' do
       is_expected.to contain_nginx__config__site('rabbit')
-        .with_content(/add_header X-Frame-Options/)
+        .with_content(/add_header X-Frame-Options DENY/)
+    end
+  end
+
+  context 'with frame_options set to "sameorigin"' do
+    let(:params) do
+      {
+        :to => ['a.internal'],
+        :frame_options => 'sameorigin',
+      }
+    end
+
+    it 'should add the X-Frame-Options header with the SAMEORIGIN value' do
+      is_expected.to contain_nginx__config__site('rabbit')
+        .with_content(/add_header X-Frame-Options SAMEORIGIN/)
     end
   end
 

--- a/modules/nginx/templates/proxy-vhost.conf
+++ b/modules/nginx/templates/proxy-vhost.conf
@@ -92,8 +92,10 @@ server {
   access_log <%= @logpath %>/<%= @json_access_log %> json_event;
   error_log <%= @logpath %>/<%= @error_log %>;
 
-  <%- if @deny_framing -%>
+  <%- if @frame_options == "deny" -%>
   add_header X-Frame-Options DENY;
+  <%- elsif @frame_options == "sameorigin" -%>
+  add_header X-Frame-Options SAMEORIGIN;
   <%- end -%>
   <%- if scope.lookupvar('::aws_migration') and @deny_crawlers -%>
   location = /robots.txt {

--- a/modules/nginx/templates/static-vhost.conf
+++ b/modules/nginx/templates/static-vhost.conf
@@ -66,8 +66,10 @@ server {
   access_log <%= @logpath %>/<%= @json_access_log %> json_event;
   error_log <%= @logpath %>/<%= @error_log %>;
 
-  <%- if @deny_framing -%>
+  <%- if @frame_options == "deny" -%>
   add_header X-Frame-Options DENY;
+  <%- elsif @frame_options == "sameorigin" -%>
+  add_header X-Frame-Options SAMEORIGIN;
   <%- end -%>
   <%- if scope.lookupvar('::aws_migration') and @deny_crawlers -%>
   location = /robots.txt {


### PR DESCRIPTION
This commit makes the `X-Frame-Options` HTTP header be set everywhere by default rather than just for publishing apps. This will prevent GOV.UK pages being framed by other sites and will reduce the possibility of clickjacking attempts in browsers that respect the header.