### PR TITLE
Bump docker-compose version

### DIFF
--- a/modules/govuk_ci/manifests/agent/docker.pp
+++ b/modules/govuk_ci/manifests/agent/docker.pp
@@ -12,7 +12,7 @@ class govuk_ci::agent::docker {
   }
 
   class { '::docker::compose':
-    version => '1.17.1',
+    version => '1.22.0',
   }
 
   cron::crondotdee { 'docker_system_prune_dangling' :


### PR DESCRIPTION
This will allow us to run https://github.com/alphagov/govuk-docker on CI as suggested by https://github.com/alphagov/govuk-docker/pull/4#issuecomment-507390244.

https://trello.com/c/B0TSiqy5