### PR TITLE
Update s3md to newer release

### DIFF
--- a/modules/govuk/manifests/node/s_asset_base.pp
+++ b/modules/govuk/manifests/node/s_asset_base.pp
@@ -210,7 +210,7 @@ class govuk::node::s_asset_base (
   if $s3_bucket {
 
     package { 's3cmd':
-      ensure   => 'present',
+      ensure   => '2.0',
       provider => 'pip',
     }
 


### PR DESCRIPTION
s3cmd is used by push_attachments_to_s3.sh on asset-slave-2.

Timeout errors are occuring, which stop the push running to completion.  Version 2.0.2 of s3cmd has fixed a bug causing timeout errors.

Fixing s3cmd to this specfic release so we are not affected by future breaking changes.

Trello card: https://trello.com/c/i4isNg22/604-asset-slave-2backend-push-attachments-to-s3