### PR TITLE
Specify memory warning thresholds for govuk_crawler_worker

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -224,6 +224,8 @@ task :check_consistency_between_aws_and_carrenza do
     govuk::apps::content_tagger::db::allow_auth_from_lb
     govuk::apps::content_tagger::db::lb_ip_range
     govuk::apps::content_tagger::db::rds
+    govuk::apps::govuk_crawler_worker::nagios_memory_critical
+    govuk::apps::govuk_crawler_worker::nagios_memory_warning
     govuk::apps::email_alert_api::db::allow_auth_from_lb
     govuk::apps::email_alert_api::db::lb_ip_range
     govuk::apps::email_alert_api::db::rds

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -553,6 +553,9 @@ govuk::apps::govuk_crawler_worker::root_urls:
   - "https://assets.%{hiera('app_domain')}"
   - "https://www.%{hiera('app_domain')}"
 
+govuk::apps::govuk_crawler_worker::nagios_memory_critical: 1750
+govuk::apps::govuk_crawler_worker::nagios_memory_warning: 1500
+
 govuk::apps::imminence::mongodb_nodes:
   - 'mongo-1'
   - 'mongo-2'

--- a/modules/govuk/manifests/apps/govuk_crawler_worker.pp
+++ b/modules/govuk/manifests/apps/govuk_crawler_worker.pp
@@ -41,6 +41,12 @@
 #   Sets the header "Rate-Limit-Token" which ensures that the crawler is
 #   whitelisted by the rate limiting function (receiving 429 status)
 #
+# [*nagios_memory_warning*]
+#   Memory use at which Nagios should generate a warning.
+#
+# [*nagios_memory_critical*]
+#   Memory use at which Nagios should generate a critical alert.
+#
 class govuk::apps::govuk_crawler_worker (
   $airbrake_api_key = '',
   $airbrake_endpoint = '',
@@ -54,6 +60,8 @@ class govuk::apps::govuk_crawler_worker (
   $port = '3074',
   $root_urls = [],
   $rate_limit_token = undef,
+  $nagios_memory_warning = undef,
+  $nagios_memory_critical = undef,
 ) {
   validate_array($blacklist_paths, $root_urls)
 
@@ -103,11 +111,13 @@ class govuk::apps::govuk_crawler_worker (
     }
 
     govuk::app { 'govuk_crawler_worker':
-      app_type           => 'bare',
-      log_format_is_json => true,
-      port               => $port,
-      command            => './govuk_crawler_worker -json',
-      health_check_path  => '/healthcheck',
+      app_type               => 'bare',
+      log_format_is_json     => true,
+      port                   => $port,
+      command                => './govuk_crawler_worker -json',
+      health_check_path      => '/healthcheck',
+      nagios_memory_warning  => $nagios_memory_warning,
+      nagios_memory_critical => $nagios_memory_critical,
     }
 
     include govuk::apps::govuk_crawler_worker::rabbitmq


### PR DESCRIPTION
The memory usage in production for `govuk_crawler_worker` is regularly above the default critical threshold for memory usage, whilst there is plenty of free memory available on the `mirrorer` machine.

This PR increases the thresholds for alerting on this application.

Recent memory usage:
<img width="1139" alt="Screen Shot 2019-07-05 at 10 33 07" src="https://user-images.githubusercontent.com/6329861/60713162-730c7480-9f10-11e9-9703-ce035464db64.png">
