### PR TITLE
Stop using arrays for exec's 'command' attribute

### DIFF
--- a/modules/govuk_scripts/manifests/init.pp
+++ b/modules/govuk_scripts/manifests/init.pp
@@ -43,9 +43,9 @@ class govuk_scripts {
     # Make sure boto3 is installed for Python3 as required by govuk_node_list_aws
     exec { 'check_boto':
       path    => ['/usr/bin', '/usr/sbin'],
-      command => ['/usr/bin/pip3 install boto3'],
+      command => '/usr/bin/pip3 install boto3',
       require => Class['base::packages'],
-      unless  => ['test -d /usr/local/lib/python3.4/dist-packages/boto3'],
+      unless  => 'test -d /usr/local/lib/python3.4/dist-packages/boto3',
     }
 
     $app_domain_internal = hiera('app_domain_internal')

--- a/modules/monitoring/manifests/checks.pp
+++ b/modules/monitoring/manifests/checks.pp
@@ -21,13 +21,13 @@ class monitoring::checks (
 
   exec { 'install_boto':
         path    => ['/opt/python2.7/bin', '/usr/bin', '/usr/sbin'],
-        command => ['/opt/python2.7/bin/pip install boto'],
+        command => '/opt/python2.7/bin/pip install boto',
         require => Class['::govuk_jenkins::packages::govuk_python'],
   }
 
   exec { 'install_boto3':
         path    => ['/opt/python2.7/bin', '/usr/bin', '/usr/sbin'],
-        command => ['/opt/python2.7/bin/pip install boto3'],
+        command => '/opt/python2.7/bin/pip install boto3',
         require => Class['::govuk_jenkins::packages::govuk_python'],
   }
 


### PR DESCRIPTION
The exec resource's 'command' parameter expects a string, not an array. We get
away this this in Puppet 3.x, but won't in 4.x

Give the 'unless' attribute the same treatment