### PR TITLE
Use default time on response times panel

### DIFF
--- a/modules/grafana/templates/dashboards/application_dashboard_panels/_response_times.json.erb
+++ b/modules/grafana/templates/dashboards/application_dashboard_panels/_response_times.json.erb
@@ -71,7 +71,7 @@
       "timeField": "@timestamp"
     }
   ],
-  "timeFrom": "6h",
+  "timeFrom": null,
   "timeShift": null,
   "title": "Response Times",
   "tooltip": {


### PR DESCRIPTION
The response times panel is used on the [search-api dashboard](https://grafana.blue.staging.govuk.digital/dashboard/file/search-api.json).

The dashboard has a default time set to "Last 1 hour", which all the panels honour except this one, because it has an override time set.

I suspect this is just an oversight because it's not used on the "standard" rails dashboards.