### PR TITLE
Stop tests running concurrently on the same Jenkins build node

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,9 @@ node {
     }
 
     stage("Spec tests") {
-      govuk.runRakeTask('all_but_lint')
+      lock("govuk-puppet-$NODE_NAME-test") {
+        govuk.runRakeTask('all_but_lint')
+      }
     }
 
     stage("Lint check") {


### PR DESCRIPTION
govuk-puppet builds seem to hang if the tests run at the same time on
a build node. To avoid this, use a lock to force the tests to run
sequentially.