### PR TITLE
Try to fix chromedriver hanging on chrome

### DIFF
--- a/modules/govuk/manifests/apps/smokey.pp
+++ b/modules/govuk/manifests/apps/smokey.pp
@@ -44,12 +44,13 @@ class govuk::apps::smokey (
   }
 
   govuk::app::envvar {
-    'AUTH_PASSWORD':    value => $http_password;
-    'AUTH_USERNAME':    value => $http_username;
-    'BEARER_TOKEN':     value => $smokey_bearer_token;
-    'RATE_LIMIT_TOKEN': value => $rate_limit_token;
-    'SIGNON_EMAIL':     value => $smokey_signon_email;
-    'SIGNON_PASSWORD':  value => $smokey_signon_password;
+    'AUTH_PASSWORD':            value => $http_password;
+    'AUTH_USERNAME':            value => $http_username;
+    'BEARER_TOKEN':             value => $smokey_bearer_token;
+    'RATE_LIMIT_TOKEN':         value => $rate_limit_token;
+    'SIGNON_EMAIL':             value => $smokey_signon_email;
+    'SIGNON_PASSWORD':          value => $smokey_signon_password;
+    'DBUS_SESSION_BUS_ADDRESS': value => 'disabled:';
   }
 
   if $::aws_migration {


### PR DESCRIPTION
Recently we saw the smokey tests were hanging on production (AWS). On
investigating the issue, we found that chrome was failing to respond to
Chromedriver commands. The interaction between chromedriver and Chrome
is done in the context of a session [1]; we were able to get the active
session ID by doing an 'strace' of the chrome/driver processes.

curl -d '{"url":"https://www.google.com"}' http://localhost:9515/session/27f4262ab044392b05138540055a8fd6/url

This provided some clarity on the reason for the smokey tests hanging,
and lead to the following issue, which suggests the issue is related to
'dbus': https://github.com/SeleniumHQ/docker-selenium/issues/87. While
this seems to be part of the main Chromium distribution [3], it's not
clear if this has made it into Chrome itself.

This trials implementing the suggested fix for the smokey process.

References
==========

[1] https://www.pawangaria.com/post/automation/browser-automation-from-command-line/
[2] https://chromium.googlesource.com/chromium/src/+/2fc330d0b93d4bfd7bd04b9fdd3102e529901f91%5E%21/
[3] https://chromium.googlesource.com/chromium/src/+/refs/heads/master/services/service_manager/embedder/main.cc#274