### PR TITLE
use api key rather that username/password for collectd to access fastly

### DIFF
--- a/modules/collectd/manifests/plugin/cdn_fastly.pp
+++ b/modules/collectd/manifests/plugin/cdn_fastly.pp
@@ -4,19 +4,15 @@
 #
 # === Parameters
 #
-# [*username*]
-#   Fastly username.
-#
-# [*password*]
-#   Fastly password.
+# [*api_key*]
+#   Api key used by Collectd to access Fastly API.
 #
 # [*services*]
 #   A hash of services. In the format:
 #   `{ 'friendly_name' => 'service_id', }`
 #
 class collectd::plugin::cdn_fastly (
-  $username,
-  $password,
+  $api_key,
   $services,
 ) {
   include collectd::plugin::python

--- a/modules/collectd/spec/classes/collectd__plugin__cdn_fastly_spec.rb
+++ b/modules/collectd/spec/classes/collectd__plugin__cdn_fastly_spec.rb
@@ -3,8 +3,7 @@ require_relative '../../../../spec_helper'
 describe "collectd::plugin::cdn_fastly", :type => :class do
   let(:pre_condition) { 'Collectd::Plugin <||>' }
   let(:params) {{
-    :username => 'Patrica',
-    :password => 'drowssap',
+    :api_key => 'Patrica',
     :services => {
       'test' => 1,
       'another_val' => 'some string',
@@ -26,8 +25,7 @@ describe "collectd::plugin::cdn_fastly", :type => :class do
   Import "collectd_cdn.fastly"
 
   <Module "collectd_cdn.fastly">
-    ApiUser "Patrica"
-    ApiPass "drowssap"
+    ApiKey "Patrica"
 
     <Service>
       Name "test"

--- a/modules/collectd/templates/etc/collectd/conf.d/cdn_fastly.conf.erb
+++ b/modules/collectd/templates/etc/collectd/conf.d/cdn_fastly.conf.erb
@@ -6,8 +6,7 @@
   Import "collectd_cdn.fastly"
 
   <Module "collectd_cdn.fastly">
-    ApiUser "<%= username -%>"
-    ApiPass "<%= password -%>"
+    ApiKey "<%= api_key -%>"
 
 <% @services.each_pair do |name, id| -%>
     <Service>


### PR DESCRIPTION
# Context

For some reason, the username/password method no longer works with fastly API for collectd plugin. We will now use the API key.

# Decision
1. change template of fastly collectd plugin config to accept API key rather than password/username
2. change collectd fastly plugin class to only take api_key parameter
