### PR TITLE
Fix missing params for nagios passive checks

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/check_sentry_errors.pp
+++ b/modules/govuk_jenkins/manifests/jobs/check_sentry_errors.pp
@@ -6,15 +6,15 @@ class govuk_jenkins::jobs::check_sentry_errors (
   $sentry_auth_token = undef,
   $app_domain = hiera('app_domain'),
 ) {
+  $check_name = 'check_sentry_errors'
+  $service_description = 'Report the number of errors in Sentry to Graphite'
+  $job_url = "https://deploy.${app_domain}/job/Check_Sentry_Errors/"
+
   file { '/etc/jenkins_jobs/jobs/check_sentry_errors.yaml':
     ensure  => present,
     content => template('govuk_jenkins/jobs/check_sentry_errors.yaml.erb'),
     notify  => Exec['jenkins_jobs_update'],
   }
-
-  $check_name = 'check_sentry_errors'
-  $service_description = 'Report the number of errors in Sentry to Graphite'
-  $job_url = "https://deploy.${app_domain}/job/Check_Sentry_Errors/"
 
   @@icinga::passive_check { "${check_name}_${::hostname}":
     service_description => $service_description,

--- a/modules/govuk_jenkins/manifests/jobs/publishing_api_archive_events.pp
+++ b/modules/govuk_jenkins/manifests/jobs/publishing_api_archive_events.pp
@@ -8,15 +8,15 @@
 class govuk_jenkins::jobs::publishing_api_archive_events(
   $app_domain = hiera('app_domain'),
 ) {
+  $check_name = 'publishing_api_archive_events'
+  $service_description = 'Periodically archive publishing-api events to S3'
+  $job_url = "https://deploy.${app_domain}/job/Publishing_API_Archive_Events/"
+
   file { '/etc/jenkins_jobs/jobs/publishing_api_archive_events.yaml':
     ensure  => present,
     content => template('govuk_jenkins/jobs/publishing_api_archive_events.yaml.erb'),
     notify  => Exec['jenkins_jobs_update'],
   }
-
-  $check_name = 'publishing_api_archive_events'
-  $service_description = 'Periodically archive publishing-api events to S3'
-  $job_url = "https://deploy.${app_domain}/job/Publishing_API_Archive_Events/"
 
   @@icinga::passive_check { "${check_name}_${::hostname}":
     service_description => $service_description,


### PR DESCRIPTION
    This ensures the params are set so they can be interpolated in the YAML
    file, which was previously rendered before they were set.