### PR TITLE
Remove Kibana from `backend` machines in all environments.

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -170,8 +170,6 @@ deployable_applications: &deployable_applications
   hmrc-manuals-api: {}
   imminence: {}
   info-frontend: {}
-  kibana:
-    repository: 'kibana-gds'
   licencefinder:
     repository: 'licence-finder'
   link-checker-api: {}


### PR DESCRIPTION
# What

Remove `Kibana` from `backend` machines in all environments.

# Why

We now use `logit` to provide this functionality so hosting our own is redundant.

Trello: https://trello.com/c/CDhl40nQ/1107-remove-kibana-as-a-target-app-from-jenkins-deployapp-job