### PR TITLE
add no preserve to the options in s3cmd

### DIFF
--- a/modules/govuk_crawler/templates/govuk_sync_mirror.erb
+++ b/modules/govuk_crawler/templates/govuk_sync_mirror.erb
@@ -55,7 +55,7 @@ for TARGET in ${TARGETS}; do
   if [[ $TARGET = s3://* ]]; then
     # With s3cmd sync, target needs to end with /
     if [[ ! $(echo ${TARGET} | egrep '/$') ]] ; then TARGET="${TARGET}/" ; fi
-    CMD="/usr/local/bin/govuk_setenv s3_sync_mirror /usr/local/bin/s3cmd sync --cache-file=/tmp/s3cmd_mirror_sync.cache --exclude=\"lost+found\" ${MIRROR_ROOT}/ ${TARGET}"
+    CMD="/usr/local/bin/govuk_setenv s3_sync_mirror /usr/local/bin/s3cmd sync --no-preserve --cache-file=/tmp/s3cmd_mirror_sync.cache --exclude=\"lost+found\" ${MIRROR_ROOT}/ ${TARGET}"
   else
     CMD="rsync -az --exclude 'lost+found' ${MIRROR_ROOT}/. ${TARGET}:/srv/mirror_data"
   fi


### PR DESCRIPTION
# Context

This is needed so that the owner of the files uploaded does not appear as a s3 attributes.

# Decisions
1. use --no-preserve to prevent file owner to be uploaded to s3