### PR TITLE
remove check pingdom ip range as carrenza mirror decommissioned

### DIFF
--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -5,7 +5,6 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::build_offsite_backup
   - govuk_jenkins::jobs::check_cdn_ip_ranges
   - govuk_jenkins::jobs::check_github_ip_ranges
-  - govuk_jenkins::jobs::check_pingdom_ip_ranges
   - govuk_jenkins::jobs::check_sentry_errors
   - govuk_jenkins::jobs::content_audit_tool
   - govuk_jenkins::jobs::copy_attachments_to_integration


### PR DESCRIPTION
# Context

Carrenza mirrors are decommissioned so there is no need to check the ping ip range to then update the carrenza vedge to allow pingdom probes to go through the firewall

# Decisions
1. remove pingdom checks in the list of carrrenza production jenkins jobs 