### PR TITLE
Update CDN jobs to accept an API key

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/bouncer_cdn.pp
+++ b/modules/govuk_jenkins/manifests/jobs/bouncer_cdn.pp
@@ -4,23 +4,18 @@
 #
 # === Parameters
 #
-# [*cdn_password_encrypted*]
-#   Password for the `$cdn_username` account. This password
-#   must be encrypted by Jenkins before passing it in as a
-#   parameter. You can do this by taking the plaintext password,
+# [*api_key*]
+#   API key for our account. This must be encrypted by Jenkins before passing
+#   it in as a parameter. You can do this by taking the plaintext password,
 #   adding it as a password parameter in Jenkins and taking the
 #   result from the `config.xml` file.
 #
-# [*cdn_service_id*]
+# [*service_id*]
 #   CDN service ID.
 #
-# [*cdn_username*]
-#   Username for an account with our CDN provider.
-#
 class govuk_jenkins::jobs::bouncer_cdn (
-  $cdn_password_encrypted = undef,
-  $cdn_service_id = undef,
-  $cdn_username = undef,
+  $api_key = undef,
+  $service_id = undef,
   $app_domain = hiera('app_domain'),
 ) {
 

--- a/modules/govuk_jenkins/templates/jobs/bouncer_cdn.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/bouncer_cdn.yaml.erb
@@ -24,8 +24,7 @@
         numToKeep: 20
     builders:
         - shell: |
-            export FASTLY_USER=<%= @cdn_username %>
-            export FASTLY_SERVICE_ID=<%= @cdn_service_id %>
+            export FASTLY_SERVICE_ID=<%= @service_id %>
             FASTLY_DEBUG=TRUE ./deploy-bouncer.sh
     publishers:
         - trigger-parameterized-builds:
@@ -47,10 +46,10 @@
             colormap: xterm
     parameters:
         - password:
-            name: FASTLY_PASS
-            description: Password for an account with our CDN provider
-            <%- if @cdn_password_encrypted -%>
-            default: <%= @cdn_password_encrypted %>
+            name: FASTLY_API_KEY
+            description: API key for an account with our CDN provider
+            <%- if @api_key -%>
+            default: <%= @api_key %>
             <%- end -%>
         - string:
             name: APP_DOMAIN

--- a/modules/govuk_jenkins/templates/jobs/deploy_cdn.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_cdn.yaml.erb
@@ -66,8 +66,5 @@
                 - performanceplatform
                 - mirror
         - string:
-            name: FASTLY_USER
-            default: false
-        - password:
-            name: FASTLY_PASS
+            name: FASTLY_API_KEY
             default: false

--- a/modules/govuk_jenkins/templates/jobs/update_cdn_dictionaries.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/update_cdn_dictionaries.yaml.erb
@@ -58,8 +58,5 @@
                 - PLEASE CHOOSE ONE
                 - www
         - string:
-            name: FASTLY_USER
-            default: false
-        - password:
-            name: FASTLY_PASS
+            name: FASTLY_API_KEY
             default: false


### PR DESCRIPTION
It looks like we can no longer use usernames/passwords for authenticating with the Fastly API.

Depends on https://github.com/alphagov/govuk-cdn-config/pull/166 and https://github.com/alphagov/govuk-secrets/pull/748.

[Trello Card](https://trello.com/c/19Gc1KkK/1109-fix-auth-issue-for-cdn-deploy-bouncer-configs-job-in-prod)