### PR TITLE
Handle deploying govuk-content-schemas as part of deploy all apps

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -45,6 +45,8 @@ node_class: &node_class
       - support_api_csv_env_sync
       - transition
       - travel-advice-publisher
+    non_apps:
+      - govuk-content-schemas
   bouncer:
     apps:
       - bouncer
@@ -107,6 +109,8 @@ node_class: &node_class
   publishing_api:
     apps:
       - publishing-api
+    non_apps:
+      - govuk-content-schemas
   router_backend:
     apps:
       - router-api
@@ -129,7 +133,6 @@ govuk_java::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 govuk_jenkins::deploy_all_apps::apps_on_nodes:
   <<: *node_class
-
 
 # If the repository name is the same as the application name
 # we don't need to explicitly declare the repository, but we

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -30,6 +30,8 @@ node_class: &node_class
       - support
       - support-api
       - support_api_csv_env_sync
+    non_apps:
+      - govuk-content-schemas
   bouncer:
     apps:
       - bouncer

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -30,6 +30,8 @@ node_class: &node_class
       - support
       - support-api
       - support_api_csv_env_sync
+    non_apps:
+      - govuk-content-schemas
   bouncer:
     apps:
       - bouncer

--- a/modules/govuk_jenkins/manifests/deploy_all_apps.pp
+++ b/modules/govuk_jenkins/manifests/deploy_all_apps.pp
@@ -14,8 +14,8 @@
 # [*user*]
 #   Which user Jenkins runs as.
 #
-# [*apps_on_nodes*]
-#   A hash containing the node classes, and which apps run on them.
+# [*deploys_on_nodes*]
+#   A hash containing the node classes, and which deploys to run on them.
 #
 # [*deploy_environment*]
 #   The environment to deploy to. This is important as we use it to find out

--- a/modules/govuk_jenkins/manifests/node_app_deploy.pp
+++ b/modules/govuk_jenkins/manifests/node_app_deploy.pp
@@ -11,18 +11,23 @@
 # [*user*]
 #   User that Jenkins runs as.
 #
-# [*apps_to_deploy*]
+# [*apps*]
 #   An array of apps to deploy for a given node.
+#
+# [*non_apps*]
+#   An array of non-apps to deploy for a given node.
 #
 define govuk_jenkins::node_app_deploy (
   $project_dir,
   $user = 'jenkins',
   $apps = [],
+  $non_apps = [],
   $environment = 'development',
   $auth_token = '',
 ) {
 
   validate_array($apps)
+  validate_array($non_apps)
 
   # FIXME: These are apps which are only created by Puppet rather than
   # deployed through Jenkins. They should be moved elsewhere in the future
@@ -34,7 +39,8 @@ define govuk_jenkins::node_app_deploy (
     'support_api_csv_env_sync',
   ]
 
-  unless empty($apps) {
+
+  unless empty($apps) and empty($non_apps) {
     File {
       owner => $user,
       group => $user,

--- a/modules/govuk_jenkins/spec/defines/govuk_jenkins__node_app_deploy_spec.rb
+++ b/modules/govuk_jenkins/spec/defines/govuk_jenkins__node_app_deploy_spec.rb
@@ -6,8 +6,11 @@ describe 'govuk_jenkins::node_app_deploy', :type => :define do
 
   let (:default_params) {{
     :project_dir    => '/path/to/dir',
-    :apps    => [
+    :apps           => [
       'super-furry-cat',
+    ],
+    :non_apps       => [
+      'non-app-hairless-cat',
     ]
   }}
 
@@ -16,6 +19,7 @@ describe 'govuk_jenkins::node_app_deploy', :type => :define do
     it { should contain_file('/path/to/dir/jobs/my_node_class').with_ensure('directory') }
 
     it { should contain_file('/path/to/dir/jobs/my_node_class/config.xml').with_content(/TARGET_APPLICATION=super-furry-cat/) }
+    it { should contain_file('/path/to/dir/jobs/my_node_class/config.xml').with_content(/TARGET_APPLICATION=non-app-hairless-cat/) }
     it { should contain_file('/path/to/dir/jobs/my_node_class/config.xml').without_content(/authToken/) }
   end
   context 'with auth token' do

--- a/modules/govuk_jenkins/templates/node_app_deploy.xml.erb
+++ b/modules/govuk_jenkins/templates/node_app_deploy.xml.erb
@@ -21,8 +21,7 @@
   <builders>
     <hudson.plugins.parameterizedtrigger.TriggerBuilder plugin="parameterized-trigger@2.35.1">
       <configs>
-        <%- @apps.each do |app| -%>
-        <%- next if @blacklist.include?(app) -%>
+        <%- (@apps + @non_apps - @blacklist).each do |app| -%>
         <hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig>
           <configs>
             <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>


### PR DESCRIPTION
GOV.UK Content Schemas is a somewhat special example where we have code
that is deployed to GOV.UK infrastructure but it isn't an app that runs
so it lacks a puppet manifest. This code is deployed by the deploy app
Jenkins job and is something that needs to occur when a node is built
for the first time.

The code that defines which apps run on a node class is the same as that
which is used to define which projects are deployed. This makes it
problematic to define that content schemas should be deployed to
certain nodes, without having it also treated as an app that should
run on the node.

To work around this I set up the concept of non_apps that is part of the
definition for projects on a particular node. I'm not particular pleased
with myself for that name and anticipate it may raise a WTF, I like to
think though that it's the concept of the project that is a bit strange
and that the syntax for defining it consistent with the oddness that is
already present.

This was added after the node instances were destroyed in integration
and when re-built the Publishing API was no longer operating correctly.

/cc @jstandring-gds this is to fix the issue we hit yesterday where the box didn't start correctly.