### PR TITLE
fix mapit lvm setup in training

### DIFF
--- a/hieradata_aws/class/training/mapit.yaml
+++ b/hieradata_aws/class/training/mapit.yaml
@@ -1,0 +1,5 @@
+---
+lv:
+  data:
+    pv: '/dev/nvme1n1'
+    vg: 'postgresql'


### PR DESCRIPTION
# Context

Mapit classes is set up to use t3.micro and no longer uses xvdf disks.

# Decisions
1. modify the mapit hieradata for training to use the correct disk type