### PR TITLE
do not set elasticsearch_b_uri for training environment

### DIFF
--- a/hieradata_aws/class/training/search.yaml
+++ b/hieradata_aws/class/training/search.yaml
@@ -18,3 +18,5 @@ logrotate::conf::days_to_keep: 7
 nginx::logging::days_to_keep: 7
 
 govuk_search::prune::es_repo: "govuk-training"
+
+govuk::apps::search_api::elasticsearch_b_uri: "null"

--- a/modules/govuk/manifests/apps/search_api.pp
+++ b/modules/govuk/manifests/apps/search_api.pp
@@ -190,9 +190,11 @@ class govuk::apps::search_api(
     value   => $elasticsearch_hosts,
   }
 
-  govuk::app::envvar { "${title}-ELASTICSEARCH_B_URI":
-    varname => 'ELASTICSEARCH_B_URI',
-    value   => $elasticsearch_b_uri,
+  if $elasticsearch_b_uri != 'null' {
+    govuk::app::envvar { "${title}-ELASTICSEARCH_B_URI":
+      varname => 'ELASTICSEARCH_B_URI',
+      value   => $elasticsearch_b_uri,
+    }
   }
 
   govuk::app::envvar { "${title}-ELASTICSEARCH_HOSTS":


### PR DESCRIPTION
training environment does not have elasticsearch6, so this should be setup. Hence, this requires a code modification to ensure that when the `govuk::apps::search_api::elasticsearch_b_uri` param is undef, puppet will not set this param