### PR TITLE
reducing whitehall proc to reduce memory in training

### DIFF
--- a/hieradata_aws/class/training/whitehall.yaml
+++ b/hieradata_aws/class/training/whitehall.yaml
@@ -1,0 +1,2 @@
+---
+govuk::apps::whitehall::procfile_worker_process_count: 1


### PR DESCRIPTION
m5.large instances of whitehall backend is crashing all the time. Might be due to excessive memory usage. This is awkward as the instance size do work in integration.