### PR TITLE
Remove unused Ruby versions

### DIFF
--- a/modules/govuk_rbenv/manifests/all.pp
+++ b/modules/govuk_rbenv/manifests/all.pp
@@ -22,7 +22,6 @@ class govuk_rbenv::all (
   }
 
   $ruby_versions = [
-    '2.4.5',
     '2.5.1',
     '2.5.3',
     '2.6.1',
@@ -34,9 +33,6 @@ class govuk_rbenv::all (
   }
 
   # These aliases resolve .ruby-version 2.x to an installed Ruby version.
-  rbenv::alias { '2.4':
-    to_version => '2.4.5',
-  }
   rbenv::alias { '2.5':
     to_version => '2.5.3',
   }

--- a/modules/govuk_rbenv/manifests/all.pp
+++ b/modules/govuk_rbenv/manifests/all.pp
@@ -22,7 +22,6 @@ class govuk_rbenv::all (
   }
 
   $ruby_versions = [
-    '2.4.4',
     '2.4.5',
     '2.5.1',
     '2.5.3',

--- a/modules/govuk_rbenv/manifests/all.pp
+++ b/modules/govuk_rbenv/manifests/all.pp
@@ -22,7 +22,6 @@ class govuk_rbenv::all (
   }
 
   $ruby_versions = [
-    '2.5.1',
     '2.5.3',
     '2.6.1',
     '2.6.3',

--- a/modules/govuk_rbenv/manifests/all.pp
+++ b/modules/govuk_rbenv/manifests/all.pp
@@ -22,7 +22,6 @@ class govuk_rbenv::all (
   }
 
   $ruby_versions = [
-    '2.6.1',
     '2.6.3',
   ]
 

--- a/modules/govuk_rbenv/manifests/all.pp
+++ b/modules/govuk_rbenv/manifests/all.pp
@@ -22,7 +22,6 @@ class govuk_rbenv::all (
   }
 
   $ruby_versions = [
-    '2.5.3',
     '2.6.1',
     '2.6.3',
   ]
@@ -32,9 +31,6 @@ class govuk_rbenv::all (
   }
 
   # These aliases resolve .ruby-version 2.x to an installed Ruby version.
-  rbenv::alias { '2.5':
-    to_version => '2.5.3',
-  }
   rbenv::alias { '2.6':
     to_version => '2.6.3',
   }

--- a/modules/monitoring/templates/govuk-uptime-collector.conf.erb
+++ b/modules/monitoring/templates/govuk-uptime-collector.conf.erb
@@ -3,7 +3,7 @@ description "govuk-uptime-collector"
 start on runlevel [2345]
 respawn
 
-env RBENV_VERSION=2.5
+env RBENV_VERSION=2.6
 env PATH=/usr/lib/rbenv/shims:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 exec govuk_uptime_collector <%= @environment %> <%= @aws %> content-store hmrc-manuals-api link-checker-api manuals-publisher publishing-api specialist-publisher travel-advice-publisher


### PR DESCRIPTION
It looks like the only version of Ruby we're using in production is 2.6.3.

These were checked using:

```
fab [aws_]production puppet_class:govuk_rbenv::all rbenv.version_in_use:<version>
```

This should save a little bit of disk space.