### PR TITLE
Add another pv to the postgres-primary backup lv

### DIFF
--- a/hieradata/class/postgresql_primary.yaml
+++ b/hieradata/class/postgresql_primary.yaml
@@ -21,6 +21,7 @@ lv:
       - '/dev/sdg1'
       - '/dev/sdh1'
       - '/dev/sdj1'
+      - '/dev/sdk1'
     vg: 'backups'
   data:
     pv:


### PR DESCRIPTION
- Daily backups were consistently failing due to the backups reaching
the maximum size the filesystem allowed.
- Added 128G partition and manually extended the lvm managed backup
drive.
- Missed to add the change here in the first instance, which causes
Puppet to fail to run on the Postgresql-primary-1

@schmie