### PR TITLE
Improve Bouncer CDN alerting

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/bouncer_cdn.pp
+++ b/modules/govuk_jenkins/manifests/jobs/bouncer_cdn.pp
@@ -32,7 +32,6 @@ class govuk_jenkins::jobs::bouncer_cdn (
   @@icinga::passive_check { "${check_name}_${::hostname}":
     service_description => $service_description,
     host_name           => $::fqdn,
-    freshness_threshold => 104400,
     action_url          => $job_url,
   }
 }

--- a/modules/govuk_jenkins/manifests/jobs/bouncer_cdn.pp
+++ b/modules/govuk_jenkins/manifests/jobs/bouncer_cdn.pp
@@ -18,16 +18,18 @@ class govuk_jenkins::jobs::bouncer_cdn (
   $service_id = undef,
   $app_domain = hiera('app_domain'),
 ) {
-
-  $check_name = 'bouncer-cdn-configuration'
   $service_description = 'Configure Bouncer CDN service with transitioning sites'
-  $job_url = "https://deploy.${app_domain}/job/Bouncer_CDN/"
 
   file { '/etc/jenkins_jobs/jobs/bouncer_cdn.yaml':
     ensure  => present,
     content => template('govuk_jenkins/jobs/bouncer_cdn.yaml.erb'),
     notify  => Exec['jenkins_jobs_update'],
   }
+
+  $check_name = 'bouncer-cdn-configuration'
+
+  # FIXME: go back to using $app_domain once we have a single Icinga instance in AWS
+  $job_url = "https://deploy.${::aws_environment}.govuk.digital/job/Bouncer_CDN/"
 
   @@icinga::passive_check { "${check_name}_${::hostname}":
     service_description => $service_description,


### PR DESCRIPTION
This PR makes two changes to the alerting for the Bouncer CDN job:

- Removes the freshness threshold because the job doesn't run regularly.
- Use the AWS app domain to link to the job because it's not configured in Carrenza.

[Trello Card](https://trello.com/c/19Gc1KkK/1109-fix-auth-issue-for-cdn-deploy-bouncer-configs-job-in-prod)