### PR TITLE
Add govuk-content-schemas manifest

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -24,6 +24,7 @@ node_class: &node_class
       - content-audit-tool
       - content-publisher
       - content-tagger
+      - govuk-content-schemas
       - hmrc-manuals-api
       - imminence
       - kibana
@@ -101,6 +102,7 @@ node_class: &node_class
       - govuk-crawler-worker
   publishing_api:
     apps:
+      - govuk-content-schemas
       - publishing-api
   router_backend:
     apps:

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -25,6 +25,7 @@ node_class: &node_class
       - content-data-api
       - content-publisher
       - content-tagger
+      - govuk-content-schemas
       - hmrc-manuals-api
       - imminence
       - kibana
@@ -106,6 +107,7 @@ node_class: &node_class
       - govuk_crawler_worker
   publishing_api:
     apps:
+      - govuk-content-schemas
       - publishing-api
   router_backend:
     apps:

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -21,6 +21,7 @@ node_class: &node_class
       - canary-backend
       - content-data-admin
       - content-data-api
+      - govuk-content-schemas
       - transition
       - imminence
       - kibana

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -21,6 +21,7 @@ node_class: &node_class
       - canary-backend
       - content-data-admin
       - content-data-api
+      - govuk-content-schemas
       - transition
       - imminence
       - kibana

--- a/modules/govuk/manifests/apps/govuk_content_schemas.pp
+++ b/modules/govuk/manifests/apps/govuk_content_schemas.pp
@@ -1,0 +1,21 @@
+# class: govuk::apps::govuk_content_schemas
+#
+# JSON schemas describing different types of content on GOV.UK.
+#
+# === Parameters
+#
+# [*directory*]
+#   The directory in which the govuk_content_schemas should be
+#   available.
+#
+class govuk::apps::govuk_content_schemas(
+  $directory = '/data/apps/govuk-content-schemas/current',
+) {
+  include icinga::client::check_directory_exists
+
+  @@icinga::check { "check_govuk_content_schemas_on_${::hostname}":
+    check_command       => "check_nrpe!check_directory_exists!${directory}",
+    service_description => 'govuk_content_schemas exists',
+    host_name           => $::fqdn,
+  }
+}

--- a/modules/icinga/files/etc/nagios/nrpe.d/check_directory_exists.cfg
+++ b/modules/icinga/files/etc/nagios/nrpe.d/check_directory_exists.cfg
@@ -1,0 +1,1 @@
+command[check_directory_exists]=/usr/lib/nagios/plugins/check_directory_exists $ARG1$

--- a/modules/icinga/files/usr/lib/nagios/plugins/check_directory_exists
+++ b/modules/icinga/files/usr/lib/nagios/plugins/check_directory_exists
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# Desc : Plugin to verify a directory dxists
+
+PROGNAME="$(basename "$0")"
+
+if [ "$1" = "" ]
+then
+  echo -e " Use : $PROGNAME <directory_name> -- Ex : $PROGNAME /etc \n "
+  exit 3
+fi
+
+if [ -d "$1" ]
+then
+  echo "OK - Directory $1 does exist"
+  exit 0
+else
+  echo "CRITICAL : Directory $1 does not exist"
+  exit 2
+fi

--- a/modules/icinga/manifests/client/check_directory_exists.pp
+++ b/modules/icinga/manifests/client/check_directory_exists.pp
@@ -1,0 +1,13 @@
+# == Class: icinga::client::check_directory_exists
+#
+# Install a Nagios plugin that can alert when a directory does not exist
+#
+class icinga::client::check_directory_exists {
+  @icinga::plugin { 'check_directory_exists':
+    source  => 'puppet:///modules/icinga/usr/lib/nagios/plugins/check_directory_exists',
+  }
+
+  @icinga::nrpe_config { 'check_directory_exists':
+    source => 'puppet:///modules/icinga/etc/nagios/nrpe.d/check_directory_exists.cfg',
+  }
+}


### PR DESCRIPTION
This adds an Icinga check to flag when the govuk-content-schemas
doesn't exist on a machine, as well as feeding in to the Deploy Node
Apps Jenkins job, so that the govuk-content-schemas is deployed when
nodes are rebuilt.