### PR TITLE
Increase freshness threshold for publishing_api_archive_events

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/publishing_api_archive_events.pp
+++ b/modules/govuk_jenkins/manifests/jobs/publishing_api_archive_events.pp
@@ -21,7 +21,7 @@ class govuk_jenkins::jobs::publishing_api_archive_events(
   @@icinga::passive_check { "${check_name}_${::hostname}":
     service_description => $service_description,
     host_name           => $::fqdn,
-    freshness_threshold => 104400,
+    freshness_threshold => (1 + (7 * 24)) * 60 * 60, # one week plus 1 hour
     action_url          => $job_url,
   }
 }


### PR DESCRIPTION
This job runs weekly, so the freshness threshold should be at least a week otherwise it alerts us unnecessarily.