### PR TITLE
Monitor web application firewall rules

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1135,6 +1135,8 @@ monitoring::checks::smokey::features:
     feature: mirror
   check_travel_advice:
     feature: travel_advice
+  check_web_application_firewall:
+    feature: waf
   check_whitehall:
     feature: whitehall
 


### PR DESCRIPTION
# Context

We monitor that the Web Application Firewall (WAF) rules
behaves the way they are expected to through
Smokey tests.

Hence, we put an icinga alert on the WAF smokey tests
to inform any deviation of the WAF rules.

# Decisions
1. enable `waf` smokey feature icinga monitoring 