### PR TITLE
Add apps to Icinga smokey checks

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1103,6 +1103,8 @@ monitoring::contacts::slack_icinga_status_cgi_url: "https://alert.%{::aws_enviro
 monitoring::contacts::slack_icinga_extinfo_cgi_url: "https://alert.%{::aws_environment}.govuk.digital/cgi-bin/icinga/status.cgi"
 
 monitoring::checks::smokey::features:
+  check_assets:
+    feature: assets
   check_bouncer:
     feature: bouncer
   check_cache:
@@ -1111,8 +1113,14 @@ monitoring::checks::smokey::features:
     feature: calendars
   check_contacts:
     feature: contacts
+  check_content_data_admin:
+    feature: content_data_admin
+  check_data_gov_uk:
+    feature: data_gov_uk
   check_draft_environment:
     feature: draft_environment
+  check_email_signup:
+    feature: email_signup
   check_frontend:
     feature: frontend
   check_government_frontend:

--- a/modules/govuk/manifests/apps/smokey.pp
+++ b/modules/govuk/manifests/apps/smokey.pp
@@ -53,7 +53,7 @@ class govuk::apps::smokey (
     'DBUS_SESSION_BUS_ADDRESS': value => 'disabled:';
   }
 
-  if $::aws_migration {
+  if ($::aws_environment == 'staging') or ($::aws_environment == 'production') {
     govuk::app::envvar {
       'PLEK_SERVICE_ASSET_MANAGER_URI': value => "https://asset-manager.${app_domain}";
     }


### PR DESCRIPTION
Alerts are not showing in Icinga when there are failures in the
following features:

* assets
* content_data_admin
* data_gov_uk
* email_signup

Adding them to monitoring:checks:smokey:features

Only adding them to hieradata_aws/common.yaml for now - will remove from 
hieradata/common.yaml once I've checked this is OK.

Trello: https://trello.com/c/yVDGAwCc/1119-add-icinga-alerts-for-all-smokey-failures