### PR TITLE
Add Transition App to hieradata_aws - Fix For Issue 1827

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -113,6 +113,9 @@ node_class: &node_class
   search:
     apps:
       - search-api
+  transition:
+    apps:
+      - transition
   whitehall_backend:
     apps:
       - whitehall


### PR DESCRIPTION
Some of the SSH commands in the Developer Documentation are broken.
The original issue can be seen here:
https://github.com/alphagov/govuk-developer-docs/issues/1827

This PR Fixed the problem with the smartanswers documentation:
https://github.com/alphagov/govuk-developer-docs/pull/1859

This PR fixes the issue with the transition documentation:
https://docs.publishing.service.gov.uk/apps/transition.html
The transition app was missing from hieradata_aws/common.yaml
this PR adds it.

Fixes #1827