### PR TITLE
Make the cache-clearing-service deployable from CI

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -942,6 +942,7 @@ govuk_jenkins::jobs::deploy_app::applications: *deployable_applications
 govuk_jenkins::jobs::integration_deploy::applications:
   <<: *deployable_applications
   # Include applications that have been migrated to AWS
+  cache-clearing-service: {}
   content-data-admin: {}
   content-data-api: {}
 


### PR DESCRIPTION
Currently, builds of the master branch are failing, as the
cache-clearing-service isn't an option in the Deploy App job. This
change should fix that.