### PR TITLE
Sort out the deployable applications config for Carrenza

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -120,62 +120,34 @@ govuk::node::s_base::node_apps:
 # need to add an empty hash
 deployable_applications: &deployable_applications
   asset-manager: {}
-  authenticating-proxy: {}
   backdrop-read:
     repository: 'backdrop'
   backdrop-write:
     repository: 'backdrop'
-  bouncer: {}
-  calculators: {}
-  calendars: {}
-  collections: {}
   collections-publisher: {}
   contacts:
     repository: 'contacts-admin'
   content-audit-tool: {}
   content-publisher: {}
-  content-store: {}
   content-tagger: {}
   email-alert-api: {}
-  email-alert-frontend: {}
   email-alert-service: {}
   feedback: {}
-  finder-frontend: {}
-  frontend: {}
-  government-frontend: {}
   govuk-content-schemas: {}
   govuk_crawler_worker: {}
   govuk-puppet: {}
   hmrc-manuals-api: {}
-  imminence: {}
-  info-frontend: {}
-  licencefinder:
-    repository: 'licence-finder'
-  link-checker-api: {}
-  local-links-manager: {}
-  manuals-frontend: {}
   manuals-publisher: {}
-  mapit: {}
   maslow: {}
   publisher: {}
   publishing-api: {}
   release: {}
-  router: {}
-  router-api: {}
   search-admin: {}
-  search-api: {}
-  service-manual-frontend: {}
   service-manual-publisher: {}
   short-url-manager: {}
   sidekiq-monitoring: {}
   signon: {}
-  smartanswers:
-    repository: 'smart-answers'
   specialist-publisher: {}
-  static: {}
-  support: {}
-  support-api: {}
-  transition: {}
   travel-advice-publisher: {}
   whitehall: {}
 
@@ -765,9 +737,37 @@ govuk_cdnlogs::service_port_map:
 govuk_ci::master::pipeline_jobs:
   <<: *deployable_applications
   # Applications migrated to AWS
+  authenticating-proxy: {}
+  bouncer: {}
   cache-clearing-service: {}
+  calculators: {}
+  calendars: {}
+  collections: {}
+  content-store: {}
+  email-alert-frontend: {}
+  finder-frontend: {}
+  frontend: {}
+  government-frontend: {}
+  imminence: {}
+  info-frontend: {}
   content-data-admin: {}
   content-data-api: {}
+  licencefinder:
+    repository: 'licence-finder'
+  link-checker-api: {}
+  local-links-manager: {}
+  manuals-frontend: {}
+  mapit: {}
+  router: {}
+  router-api: {}
+  search-api: {}
+  service-manual-frontend: {}
+  smartanswers:
+    repository: 'smart-answers'
+  static: {}
+  support-api: {}
+  support: {}
+  transition: {}
   # Other repositories
   asset_bom_removal-rails: {}
   backdrop-transactions-explorer-collector: {}
@@ -947,9 +947,37 @@ govuk_jenkins::jobs::deploy_app::applications: *deployable_applications
 govuk_jenkins::jobs::integration_deploy::applications:
   <<: *deployable_applications
   # Include applications that have been migrated to AWS
+  authenticating-proxy: {}
+  bouncer: {}
   cache-clearing-service: {}
+  calculators: {}
+  calendars: {}
+  collections: {}
+  content-store: {}
+  email-alert-frontend: {}
+  finder-frontend: {}
+  frontend: {}
+  government-frontend: {}
+  imminence: {}
+  info-frontend: {}
   content-data-admin: {}
   content-data-api: {}
+  licencefinder:
+    repository: 'licence-finder'
+  link-checker-api: {}
+  local-links-manager: {}
+  manuals-frontend: {}
+  mapit: {}
+  router: {}
+  router-api: {}
+  search-api: {}
+  service-manual-frontend: {}
+  smartanswers:
+    repository: 'smart-answers'
+  static: {}
+  support-api: {}
+  support: {}
+  transition: {}
 
 govuk_jenkins::jobs::deploy_lambda_app::lambda_apps:
   - 'email_alert_notifications'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -764,6 +764,11 @@ govuk_cdnlogs::service_port_map:
 
 govuk_ci::master::pipeline_jobs:
   <<: *deployable_applications
+  # Applications migrated to AWS
+  cache-clearing-service: {}
+  content-data-admin: {}
+  content-data-api: {}
+  # Other repositories
   asset_bom_removal-rails: {}
   backdrop-transactions-explorer-collector: {}
   bulk-merger: {}


### PR DESCRIPTION
More AWS migration cleanup. This should hopefully avoid errors in the future where the `integration_deploy` configuration isn't kept up to date, and clean up the configuration for the Carrenza side of Staging and Production, by removing applications that can't actually be deployed there.