### PR TITLE
Update smokey checks per environment

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1542,6 +1542,8 @@ monitoring::checks::smokey::features:
     feature: router
   check_search:
     feature: search
+  check_service_manual:
+    feature: service_manual
   check_signon:
     feature: signon
   check_smartanswers:

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1524,6 +1524,8 @@ monitoring::checks::smokey::features:
     feature: calendars
   check_contacts:
     feature: contacts
+  check_csv_preview:
+    feature: csv_preview
   check_draft_environment:
     feature: draft_environment
   check_frontend:

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1518,8 +1518,6 @@ monitoring::contacts::slack_icinga_status_cgi_url: "https://alert.%{hiera('app_d
 monitoring::contacts::slack_icinga_extinfo_cgi_url: "https://alert.%{hiera('app_domain')}/cgi-bin/icinga/extinfo.cgi"
 
 monitoring::checks::smokey::features:
-  check_bouncer:
-    feature: bouncer
   check_cache:
     feature: caching
   check_calendars:

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1133,6 +1133,8 @@ monitoring::checks::smokey::features:
     feature: government_frontend
   check_govuk_redirect:
     feature: govuk_redirect
+  check_govuk:
+    feature: govuk
   check_licencefinder:
     feature: licencefinder
   check_licensing:

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1135,6 +1135,8 @@ monitoring::checks::smokey::features:
     feature: govuk_redirect
   check_govuk:
     feature: govuk
+  check_info_frontend:
+    feature: info_frontend
   check_licencefinder:
     feature: licencefinder
   check_licensing:

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1143,6 +1143,8 @@ monitoring::checks::smokey::features:
     feature: licensing
   check_publishing:
     feature: mainstream_publishing_tools
+  check_manuals_frontend:
+    feature: manuals_frontend
   check_router:
     feature: router
   check_search:

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1145,6 +1145,8 @@ monitoring::checks::smokey::features:
     feature: mainstream_publishing_tools
   check_manuals_frontend:
     feature: manuals_frontend
+  check_public_api:
+    feature: public_api
   check_router:
     feature: router
   check_search:

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1123,6 +1123,8 @@ monitoring::checks::smokey::features:
     feature: draft_environment
   check_email_signup:
     feature: email_signup
+  check_finder_frontend:
+    feature: finder_frontend
   check_feedback:
     feature: feedback
   check_frontend:

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1103,6 +1103,8 @@ monitoring::contacts::slack_icinga_status_cgi_url: "https://alert.%{::aws_enviro
 monitoring::contacts::slack_icinga_extinfo_cgi_url: "https://alert.%{::aws_environment}.govuk.digital/cgi-bin/icinga/status.cgi"
 
 monitoring::checks::smokey::features:
+  check_ab_testing:
+    feature: ab_testing
   check_assets:
     feature: assets
   check_cache:

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1131,6 +1131,8 @@ monitoring::checks::smokey::features:
     feature: frontend
   check_government_frontend:
     feature: government_frontend
+  check_govuk_redirect:
+    feature: govuk_redirect
   check_licencefinder:
     feature: licencefinder
   check_licensing:

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1129,6 +1129,8 @@ monitoring::checks::smokey::features:
     feature: finder_frontend
   check_feedback:
     feature: feedback
+  check_foreign_travel_advice:
+    feature: foreign_travel_advice
   check_frontend:
     feature: frontend
   check_government_frontend:

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1147,6 +1147,8 @@ monitoring::checks::smokey::features:
     feature: manuals_frontend
   check_public_api:
     feature: public_api
+  check_publishing_tools:
+    feature: publishing_tools
   check_router:
     feature: router
   check_search:

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1107,6 +1107,8 @@ monitoring::checks::smokey::features:
     feature: assets
   check_cache:
     feature: caching
+  check_calculators:
+    feature: calculators
   check_calendars:
     feature: calendars
   check_contacts:

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1105,8 +1105,6 @@ monitoring::contacts::slack_icinga_extinfo_cgi_url: "https://alert.%{::aws_envir
 monitoring::checks::smokey::features:
   check_assets:
     feature: assets
-  check_bouncer:
-    feature: bouncer
   check_cache:
     feature: caching
   check_calendars:

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1111,6 +1111,8 @@ monitoring::checks::smokey::features:
     feature: calculators
   check_calendars:
     feature: calendars
+  check_collections:
+    feature: collections
   check_contacts:
     feature: contacts
   check_content_data_admin:

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1159,6 +1159,8 @@ monitoring::checks::smokey::features:
     feature: smartanswers
   check_static_mirrors:
     feature: mirror
+  check_transition:
+    feature: transition
   check_travel_advice:
     feature: travel_advice
   check_web_application_firewall:

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1123,6 +1123,8 @@ monitoring::checks::smokey::features:
     feature: draft_environment
   check_email_signup:
     feature: email_signup
+  check_feedback:
+    feature: feedback
   check_frontend:
     feature: frontend
   check_government_frontend:


### PR DESCRIPTION
Add the remaining apps to AWS Icinga Smokey checks.

There are likely to be more cards generated by any failures of the Smokey tests.


Trello: https://trello.com/c/yVDGAwCc/1119-add-icinga-alerts-for-all-smokey-failures