### PR TITLE
Add smokey check for remaining apps

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1109,6 +1109,8 @@ monitoring::checks::smokey::features:
     feature: assets
   check_cache:
     feature: caching
+  check_benchmarking:
+    feature: benchmarking
   check_calculators:
     feature: calculators
   check_calendars:

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1151,6 +1151,8 @@ monitoring::checks::smokey::features:
     feature: mainstream_publishing_tools
   check_manuals_frontend:
     feature: manuals_frontend
+  check_performance_platform:
+    feature: performance_platform
   check_public_api:
     feature: public_api
   check_publishing_tools:


### PR DESCRIPTION
The last 2 features not being checked were:

* benchmarking
* performance_platform

Now they've been added to AWS checks

Trello: https://trello.com/c/yVDGAwCc/1119-add-icinga-alerts-for-all-smokey-failures