### PR TITLE
Override EBS device name in integration to reflect new instance type for mapit

### DIFF
--- a/hieradata_aws/class/integration/mapit.yaml
+++ b/hieradata_aws/class/integration/mapit.yaml
@@ -1,0 +1,4 @@
+lv:
+  data:
+    pv: '/dev/nvme1n1'
+    vg: 'postgresql'


### PR DESCRIPTION
Mapit instances are being downsized from t2.medium to t3.micro in integration,
which results in the block device for its EBS volume changing from xvdf to
nvme1n1. Unfortunately the underlying block device name is currently required by
the Puppet LVM config.