### PR TITLE
disable active mirror crawling AWS integration

### DIFF
--- a/hieradata_aws/class/integration/mirrorer.yaml
+++ b/hieradata_aws/class/integration/mirrorer.yaml
@@ -1,0 +1,4 @@
+---
+govuk::apps::govuk_crawler_worker::enabled: true
+govuk_crawler::seed_enable: false
+govuk_crawler::sync_enable: false

--- a/modules/govuk_crawler/manifests/init.pp
+++ b/modules/govuk_crawler/manifests/init.pp
@@ -139,6 +139,13 @@ class govuk_crawler(
     owner  => $crawler_user,
   }
 
+  package { 'ffi':
+    ensure   => '1.10.0',
+    provider => 'system_gem',
+    require  => Class['base::packages'],
+    before   => Package['govuk_seed_crawler'],
+  }
+
   # This explicitly requires 'base::packages' so that nokogiri will build
   package { 'govuk_seed_crawler':
         ensure   => '2.0.1',


### PR DESCRIPTION
# Context

we switch off active mirror crawling in AWS integration to save money. We still keeps the instance because it is needed in the deployment pipeline of govuk_crawler_worker.

We had to install ffi to a specific version because otherwise govuk-crawler wants to install a ffi version which requires ruby >= 2.0

# Decisions
1. switch off cron jobs linked with active crawling
2. pin the ffi gem to 1.10.0 version