### PR TITLE
Fix Postgis version to 2.2 for Mapit

### DIFF
--- a/hieradata_aws/class/integration/mapit.yaml
+++ b/hieradata_aws/class/integration/mapit.yaml
@@ -1,3 +1,5 @@
+postgresql::globals::postgis_version: '2.2'
+
 lv:
   data:
     pv: '/dev/nvme1n1'


### PR DESCRIPTION
Mapit uses Postgis version 2.2 . This fix ensures that is
the Postgis version that is installed when a new machine is
created.