### PR TITLE
fix the integration jenkins lvm following resize

### DIFF
--- a/hieradata_aws/class/integration/jenkins.yaml
+++ b/hieradata_aws/class/integration/jenkins.yaml
@@ -48,3 +48,8 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::whitehall_publisher_notifications
 
 govuk_jenkins::jobs::deploy_cdn::enable_slack_notifications: true
+
+lv:
+  data:
+    pv: '/dev/nvme1n1'
+    vg: 'jenkins'


### PR DESCRIPTION
following the jenkins resize in integration, the machine have a nvme disk rather than a xvdf one. Therefore, we need to change the puppet config for Jenkins in integration for the proper disk.