### PR TITLE
Remove search-api index size checks

### DIFF
--- a/modules/monitoring/manifests/checks.pp
+++ b/modules/monitoring/manifests/checks.pp
@@ -49,7 +49,6 @@ class monitoring::checks (
 
   include icinga::plugin::check_http_timeout_noncrit
 
-  # START whitehall
   # Used in template and icinga::check.
   $whitehall_hostname    = "whitehall-admin.${app_domain}"
   $whitehall_overdue_url = '/healthcheck/overdue'
@@ -70,7 +69,6 @@ class monitoring::checks (
     attempts_before_hard_state => 2,
     retry_interval             => 10,
   }
-  # END whitehall
 
   $warning_time = 5
   $critical_time = 10
@@ -81,7 +79,6 @@ class monitoring::checks (
     service_description => 'mapit not responding to postcode query',
   }
 
-  # START ssl certificate checks
   if $::aws_migration {
     # migration of the www-origin.*.publishing.service.gov.uk to AWS is now complete
     icinga::check { 'check_www_cert_valid_at_origin':
@@ -130,9 +127,7 @@ class monitoring::checks (
     service_description => "check the STAR.${app_domain} TLS certificate is valid and not due to expire",
     notes_url           => monitoring_docs_url(renew-tls-certificate),
   }
-  # END ssl certificate checks
 
-  # START DNS checks
   icinga::check_config { 'check_dig_cloudflare':
     source  => 'puppet:///modules/monitoring/etc/nagios3/conf.d/check_dig_cloudflare.cfg',
   }
@@ -142,73 +137,6 @@ class monitoring::checks (
     host_name           => $::fqdn,
     service_description => 'check www.gov.uk DNS record',
     require             => Icinga::Check_config['check_dig_cloudflare'],
-  }
-  # END DNS checks
-
-  if $::aws_migration {
-    # START search
-
-    # On average 326 new documents were created per day in 2017, in total.
-    # The govuk index will only receive a fraction of these until we start
-    # indexing whitehall content in it.
-    #
-    # These metrics are reported from a rake task, run every 10 minutes
-    # by Jenkins. Assuming Graphite is keeping metrics in 5 second
-    # intervals, there should be a 120 interval gap (600 seconds / 5)
-    # between measurements on average.
-
-    # Drop all but the last minute of data (assuming 5 second intervals)
-    $drop_first = '-12'
-
-    # Smooth out the data by using keepLastValue, with a limit of 132
-    # intervals, which is 10 minutes, plus a minute of padding to avoid
-    # any spurious alerts from late arriving metrics. It's important to
-    # set a limit here so that if the metrics are missing, then the
-    # alerts will fire.
-    $keep_last_value_limit = '132'
-
-    icinga::check::graphite { 'check_search_api_govuk_index_size_changed':
-      target              => "absolute(diffSeries(keepLastValue(stats.gauges.govuk.app.search-api.cluster_A.govuk_index.docs.total,${keep_last_value_limit}), timeShift(keepLastValue(stats.gauges.govuk.app.search-api.cluster_A.govuk_index.docs.total,${keep_last_value_limit}), \"7d\")))",
-      warning             => 3000,
-      critical            => 10000,
-      desc                => 'search-api govuk index size has significantly increased/decreased over the last 7 days',
-      host_name           => $::fqdn,
-      notification_period => 'inoffice',
-      action_url          => "https://grafana.${::aws_environment}.govuk.digital/dashboard/file/search_api_index_size.json",
-      notes_url           => monitoring_docs_url(search-api-index-size-change),
-      from                => '25minutes',
-      args                => "--dropfirst ${drop_first}",
-    }
-
-    # Government is comparable to the govuk index.
-    icinga::check::graphite { 'check_search_api_government_index_size_changed':
-      target              => "absolute(diffSeries(keepLastValue(stats.gauges.govuk.app.search-api.cluster_A.government_index.docs.total,${keep_last_value_limit}), timeShift(keepLastValue(stats.gauges.govuk.app.search-api.cluster_A.government_index.docs.total,${keep_last_value_limit}), \"7d\")))",
-      warning             => 2500,
-      critical            => 8000,
-      desc                => 'search-api government index size has significantly increased/decreased over the last 7 days',
-      host_name           => $::fqdn,
-      notification_period => 'inoffice',
-      action_url          => "https://grafana.${::aws_environment}.govuk.digital/dashboard/file/search_api_index_size.json",
-      notes_url           => monitoring_docs_url(search-api-index-size-change),
-      from                => '25minutes',
-      args                => "--dropfirst ${drop_first}",
-    }
-
-    # Detailed is smaller than the other indexes (about 4500 documents)
-    icinga::check::graphite { 'check_search_api_detailed_index_size_changed':
-      target              => "absolute(diffSeries(keepLastValue(stats.gauges.govuk.app.search-api.cluster_A.detailed_index.docs.total,${keep_last_value_limit}), timeShift(keepLastValue(stats.gauges.govuk.app.search-api.cluster_A.detailed_index.docs.total,${keep_last_value_limit}), \"7d\")))",
-      warning             => 100,
-      critical            => 500,
-      desc                => 'search-api detailed index size has significantly increased/decreased over the last 7 days',
-      host_name           => $::fqdn,
-      notification_period => 'inoffice',
-      action_url          => "https://grafana.${::aws_environment}.govuk.digital/dashboard/file/search_api_index_size.json",
-      notes_url           => monitoring_docs_url(search-api-index-size-change),
-      from                => '25minutes',
-      args                => "--dropfirst ${drop_first}",
-    }
-
-    # END search
   }
 
   # In AWS this is liable to happen more often as machines come and go


### PR DESCRIPTION
Previously we had somewhat flakey checks about an increase/decrease in
our search index sizes. In the first place, it's unclear why we would
want an alert for *increases* in search index size, as surely this is a
'good' thing. Secondly, there seems to be no documentation as to why
these alerts exist, as the original commit is simply 'WIP'.

Commit ref: 7df31ce08c0d802b7e376a9f5684f4e308b6f6c9