### PR TITLE
add the ability to update dictionary for mirror vcl service

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/update_cdn_dictionaries.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/update_cdn_dictionaries.yaml.erb
@@ -57,6 +57,7 @@
             choices:
                 - PLEASE CHOOSE ONE
                 - www
+                - mirror
         - string:
             name: FASTLY_API_KEY
             default: false


### PR DESCRIPTION
# Context

Since mirror vcl is a close match of www vcl, mirror vcl needs also the ability for its dictionary to be updated or else it would fail. This PR adds this option.

# Decisions
1. add `mirror` option to the update_dictionaries Jenkins job