### PR TITLE
Remove monitoring of the licensify VPN

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1560,8 +1560,6 @@ monitoring::vpn_gateways::endpoints:
     address: "%{hiera('environment_ip_prefix')}.12.1"
   vpn_gateway_backend_dr:
     address: "%{hiera('environment_ip_prefix')}.11.1"
-  vpn_gateway_licensify:
-    address: "10.5.0.1"
   vpn_gateway_redirector_dr:
     address: "%{hiera('environment_ip_prefix')}.13.1"
   vpn_gateway_router_dr:


### PR DESCRIPTION
This VPN has been eratic, dropping and coming back on several
occasions. Decision was taken to stop monitoring it as it is
not critical to production and we will migrate licensify away
from UKCloud.