### PR TITLE
Remove the govuk-content-schemas where it was incorrectly added

### DIFF
--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -21,7 +21,6 @@ node_class: &node_class
       - canary-backend
       - content-data-admin
       - content-data-api
-      - govuk-content-schemas
       - transition
       - imminence
       - kibana

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -21,7 +21,6 @@ node_class: &node_class
       - canary-backend
       - content-data-admin
       - content-data-api
-      - govuk-content-schemas
       - transition
       - imminence
       - kibana


### PR DESCRIPTION
This app, which currently just sets up Icinga configuration was added
in error to the backend machines in the AWS side of Production and
Staging.