### PR TITLE
Remove the parent relationship between licensify and vpn_licensify

### DIFF
--- a/modules/icinga/manifests/client.pp
+++ b/modules/icinga/manifests/client.pp
@@ -48,7 +48,7 @@ class icinga::client (
     ],
   }
 
-  if ($::vdc == 'licensify') or ($::vdc =~ /^*_dr$/) {
+  if ($::vdc =~ /^*_dr$/) {
     $parents = "vpn_gateway_${::vdc}"
   } else {
     $parents = undef


### PR DESCRIPTION
We have now removed the licensify vpn from monitoring.