### PR TITLE
Revert "Remove the parent relationship between licensify and vpn_licensify"

### DIFF
--- a/modules/icinga/manifests/client.pp
+++ b/modules/icinga/manifests/client.pp
@@ -48,7 +48,7 @@ class icinga::client (
     ],
   }
 
-  if ($::vdc =~ /^*_dr$/) {
+  if ($::vdc == 'licensify') or ($::vdc =~ /^*_dr$/) {
     $parents = "vpn_gateway_${::vdc}"
   } else {
     $parents = undef


### PR DESCRIPTION
Reverts alphagov/govuk-puppet#9398

This is creating too much of a headache due to the way puppet manages the icinga config