### PR TITLE
Update Smokey checks

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1553,42 +1553,50 @@ monitoring::contacts::slack_icinga_status_cgi_url: "https://alert.%{hiera('app_d
 monitoring::contacts::slack_icinga_extinfo_cgi_url: "https://alert.%{hiera('app_domain')}/cgi-bin/icinga/extinfo.cgi"
 
 monitoring::checks::smokey::features:
-  check_cache:
-    feature: caching
-  check_calendars:
-    feature: calendars
-  check_contacts:
-    feature: contacts
+  check_ab_testing:
+    feature: ab_testing
+  check_assets:
+    feature: assets
+  check_benchmarking:
+    feature: benchmarking
+  check_collections:
+    feature: collections
+  check_content_data_admin:
+    feature: content_data_admin
   check_csv_preview:
     feature: csv_preview
   check_draft_environment:
     feature: draft_environment
-  check_frontend:
-    feature: frontend
-  check_government_frontend:
-    feature: government_frontend
-  check_licencefinder:
-    feature: licencefinder
+  check_email_signup:
+    feature: email_signup
+  check_feedback:
+    feature: feedback
+  check_finder_frontend:
+    feature: finder_frontend
+  check_foreign_travel_advice:
+    feature: foreign_travel_advice
+  check_gov_uk:
+    feature: gov_uk
+  check_gov_uk_redirect:
+    feature: gov_uk_redirect
+  check_licence_finder:
+    feature: licence_finder
   check_licensing:
     feature: licensing
-  check_publishing:
-    feature: mainstream_publishing_tools
-  check_router:
-    feature: router
-  check_search:
-    feature: search
+  check_manuals_frontend:
+    feature: manuals_frontend
+  check_performance_platform:
+    feature: performance_platform
+  check_public_api:
+    feature: public_api
+  check_publishing_tools:
+    feature: publishing_tools
   check_service_manual:
     feature: service_manual
   check_signon:
     feature: signon
-  check_smartanswers:
-    feature: smartanswers
-  check_static_mirrors:
-    feature: mirror
-  check_travel_advice:
-    feature: travel_advice
-  check_whitehall:
-    feature: whitehall
+  check_transition:
+    feature: transition
 
 monitoring::vpn_gateways::endpoints:
   vpn_gateway_api_dr:

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1105,75 +1105,25 @@ monitoring::contacts::slack_icinga_status_cgi_url: "https://alert.%{::aws_enviro
 monitoring::contacts::slack_icinga_extinfo_cgi_url: "https://alert.%{::aws_environment}.govuk.digital/cgi-bin/icinga/status.cgi"
 
 monitoring::checks::smokey::features:
-  check_ab_testing:
-    feature: ab_testing
-  check_assets:
-    feature: assets
-  check_cache:
+  check_caching:
     feature: caching
-  check_benchmarking:
-    feature: benchmarking
-  check_calculators:
-    feature: calculators
   check_calendars:
     feature: calendars
-  check_collections:
-    feature: collections
   check_contacts:
     feature: contacts
-  check_content_data_admin:
-    feature: content_data_admin
-  check_data_gov_uk:
-    feature: data_gov_uk
-  check_draft_environment:
-    feature: draft_environment
-  check_email_signup:
-    feature: email_signup
-  check_finder_frontend:
-    feature: finder_frontend
-  check_feedback:
-    feature: feedback
-  check_foreign_travel_advice:
-    feature: foreign_travel_advice
   check_frontend:
     feature: frontend
   check_government_frontend:
     feature: government_frontend
-  check_govuk_redirect:
-    feature: govuk_redirect
-  check_govuk:
-    feature: govuk
-  check_info_frontend:
-    feature: info_frontend
-  check_licencefinder:
-    feature: licencefinder
-  check_licensing:
-    feature: licensing
-  check_publishing:
-    feature: mainstream_publishing_tools
-  check_manuals_frontend:
-    feature: manuals_frontend
-  check_performance_platform:
-    feature: performance_platform
-  check_public_api:
-    feature: public_api
-  check_publishing_tools:
-    feature: publishing_tools
+  check_mirror:
+    feature: mirror
   check_router:
     feature: router
   check_search:
     feature: search
-  check_signon:
-    feature: signon
   check_smartanswers:
     feature: smartanswers
-  check_static_mirrors:
-    feature: mirror
-  check_transition:
-    feature: transition
-  check_travel_advice:
-    feature: travel_advice
-  check_web_application_firewall:
+  check_waf:
     feature: waf
   check_whitehall:
     feature: whitehall

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -330,6 +330,77 @@ monitoring::checks::smokey::environment: 'integration'
 monitoring::uptime_collector::environment: 'integration'
 monitoring::contacts::slack_username: 'Integration'
 
+monitoring::checks::smokey::features:
+  check_ab_testing:
+    feature: ab_testing
+  check_assets:
+    feature: assets
+  check_benchmarking:
+    feature: benchmarking
+  check_caching:
+    feature: caching
+  check_calculators:
+    feature: calculators
+  check_calendars:
+    feature: calendars
+  check_collections:
+    feature: collections
+  check_contacts:
+    feature: contacts
+  check_content_data_admin:
+    feature: content_data_admin
+  check_csv_preview:
+    feature: csv_preview
+  check_data_gov_uk:
+    feature: data_gov_uk
+  check_draft_environment:
+    feature: draft_environment
+  check_email_signup:
+    feature: email_signup
+  check_feedback:
+    feature: feedback
+  check_finder_frontend:
+    feature: finder_frontend
+  check_foreign_travel_advice:
+    feature: foreign_travel_advice
+  check_frontend:
+    feature: frontend
+  check_govuk:
+    feature: govuk
+  check_govuk_redirect:
+    feature: govuk_redirect
+  check_government_frontend:
+    feature: government_frontend
+  check_info_frontend:
+    feature: info_frontend
+  check_licence_finder:
+    feature: licence_finder
+  check_licensing:
+    feature: licensing
+  check_manuals_frontend:
+    feature: manuals_frontend
+  check_mirror:
+    feature: mirror
+  check_performance_platform:
+    feature: performance_platform
+  check_public_api:
+    feature: public_api
+  check_publishing_tools:
+    feature: publishing_tools
+  check_router:
+    feature: router
+  check_search:
+    feature: search
+  check_signon:
+    feature: signon
+  check_smartanswers:
+    feature: smartanswers
+  check_transition:
+    feature: transition
+  check_waf:
+    feature: waf
+  check_whitehall:
+    feature: whitehall
 
 postfix::smarthost:
   - 'email-smtp.eu-west-1.amazonaws.com:587'


### PR DESCRIPTION
Merging https://github.com/alphagov/smokey/pull/570 has exposed that our checks configured in Puppet do not match the checks we have set up in Smokey.

This PR updates our Icinga configuration so that Carrenza features run in Carrenza, AWS features run in AWS and all the features in Integration.

This should mean Icinga runs the same checks as the various Smokey Jenkins jobs run, and it will match our configuration there: https://github.com/alphagov/smokey/blob/master/config/cucumber.yml

[Trello Card](https://trello.com/c/jpFVXZth/1146-make-icinga-generate-unknown-result-on-missing-feature-file)