### PR TITLE
Don't check performance platform or mirrors in staging

### DIFF
--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -532,6 +532,52 @@ monitoring::contacts::notify_slack: true
 monitoring::contacts::slack_channel: '#govuk-alerts-staging'
 monitoring::contacts::slack_username: 'Staging (Carrenza)'
 
+monitoring::checks::smokey::features:
+  check_ab_testing:
+    feature: ab_testing
+  check_assets:
+    feature: assets
+  check_benchmarking:
+    feature: benchmarking
+  check_collections:
+    feature: collections
+  check_content_data_admin:
+    feature: content_data_admin
+  check_csv_preview:
+    feature: csv_preview
+  check_draft_environment:
+    feature: draft_environment
+  check_email_sign_up:
+    feature: email_sign_up
+  check_feedback:
+    feature: feedback
+  check_finder_frontend:
+    feature: finder_frontend
+  check_foreign_travel_advice:
+    feature: foreign_travel_advice
+  check_gov_uk:
+    feature: gov_uk
+  check_gov_uk_redirect:
+    feature: gov_uk_redirect
+  check_licence_finder:
+    feature: licence_finder
+  check_licensing:
+    feature: licensing
+  check_manuals_frontend:
+    feature: manuals_frontend
+  check_performance_platform:
+    feature: performance_platform
+  check_public_api:
+    feature: public_api
+  check_publishing_tools:
+    feature: publishing_tools
+  check_service_manual:
+    feature: service_manual
+  check_signon:
+    feature: signon
+  check_transition:
+    feature: transition
+
 postfix::smarthost:
   - 'email-smtp.us-east-1.amazonaws.com:587'
   - 'ses-smtp-prod-335357831.us-east-1.elb.amazonaws.com:587'

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -565,8 +565,6 @@ monitoring::checks::smokey::features:
     feature: licensing
   check_manuals_frontend:
     feature: manuals_frontend
-  check_performance_platform:
-    feature: performance_platform
   check_public_api:
     feature: public_api
   check_publishing_tools:

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -291,8 +291,6 @@ monitoring::checks::smokey::features:
     feature: frontend
   check_government_frontend:
     feature: government_frontend
-  check_mirror:
-    feature: mirror
   check_router:
     feature: router
   check_search:

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -280,6 +280,29 @@ monitoring::checks::rds::servers:
 
 
 monitoring::checks::smokey::environment: 'staging_aws'
+monitoring::checks::smokey::features:
+  check_caching:
+    feature: caching
+  check_calendars:
+    feature: calendars
+  check_contacts:
+    feature: contacts
+  check_frontend:
+    feature: frontend
+  check_government_frontend:
+    feature: government_frontend
+  check_mirror:
+    feature: mirror
+  check_router:
+    feature: router
+  check_search:
+    feature: search
+  check_smartanswers:
+    feature: smartanswers
+  check_waf:
+    feature: waf
+  check_whitehall:
+    feature: whitehall
 
 monitoring::uptime_collector::environment: 'staging'
 


### PR DESCRIPTION
All the Smokey tests for these features [are marked as `@notstaging`](https://github.com/alphagov/smokey/search?q=notstaging&unscoped_q=notstaging) which means that no tests run and we get an unknown alert in staging.

[Trello Card](https://trello.com/c/jpFVXZth/1146-make-icinga-generate-unknown-result-on-missing-feature-file)