### PR TITLE
 Point draft frontend apps at live search

### DIFF
--- a/modules/govuk/manifests/node/s_draft_frontend.pp
+++ b/modules/govuk/manifests/node/s_draft_frontend.pp
@@ -25,11 +25,11 @@ class govuk::node::s_draft_frontend() inherits govuk::node::s_base {
 
   govuk_envvar {
     'PLEK_HOSTNAME_PREFIX': value => 'draft-';
+    'PLEK_SERVICE_EMAIL_ALERT_API_URI': value => "https://email-alert-api.${plek_uri_domain_override}";
     'PLEK_SERVICE_IMMINENCE_URI': value => "https://imminence.${app_domain}";
     'PLEK_SERVICE_LOCAL_LINKS_MANAGER_URI': value => "https://local-links-manager.${app_domain}";
-    'PLEK_SERVICE_MAPIT_URI': value     => "https://mapit.${app_domain_internal}";
-    'PLEK_SERVICE_EMAIL_ALERT_API_URI': value  => "https://email-alert-api.${plek_uri_domain_override}";
-    'PLEK_SERVICE_WHITEHALL_ADMIN_URI': value  => "https://whitehall-admin.${app_domain_internal}";
+    'PLEK_SERVICE_MAPIT_URI': value => "https://mapit.${app_domain_internal}";
+    'PLEK_SERVICE_WHITEHALL_ADMIN_URI': value => "https://whitehall-admin.${app_domain_internal}";
   }
 
   unless $::aws_migration {

--- a/modules/govuk/manifests/node/s_draft_frontend.pp
+++ b/modules/govuk/manifests/node/s_draft_frontend.pp
@@ -29,6 +29,7 @@ class govuk::node::s_draft_frontend() inherits govuk::node::s_base {
     'PLEK_SERVICE_IMMINENCE_URI': value => "https://imminence.${app_domain}";
     'PLEK_SERVICE_LOCAL_LINKS_MANAGER_URI': value => "https://local-links-manager.${app_domain}";
     'PLEK_SERVICE_MAPIT_URI': value => "https://mapit.${app_domain_internal}";
+    'PLEK_SERVICE_SEARCH_URI': value => "https://search.${app_domain_internal}";
     'PLEK_SERVICE_WHITEHALL_ADMIN_URI': value => "https://whitehall-admin.${app_domain_internal}";
   }
 


### PR DESCRIPTION
We currently don't run a search instance in the draft stack which means that users see internal server errors when they navigate to pages which require search.

There [is a plan to eventually run a draft search instance](https://github.com/alphagov/govuk-rfcs/blob/master/rfc-086-draft-stack-rummager.md) but for now as we don't have that, it's better that users see out of date information rather than an error page.

[Trello Card](https://trello.com/c/Xu6XqyJW/1150-epic-define-explicit-plekservicesearch-uris-for-apps-in-the-draft-stack)