### PR TITLE
Bump the asset-manager CPU warning threshold

### DIFF
--- a/modules/govuk/manifests/apps/asset_manager.pp
+++ b/modules/govuk/manifests/apps/asset_manager.pp
@@ -99,7 +99,7 @@ class govuk::apps::asset_manager(
       unicorn_worker_processes => $unicorn_worker_processes,
       nagios_memory_warning    => $nagios_memory_warning,
       nagios_memory_critical   => $nagios_memory_critical,
-      cpu_warning              => 300,
+      cpu_warning              => 350,
       cpu_critical             => 400,
     }
 


### PR DESCRIPTION
As when asset-manager is busy, the value seems to be ~330. It seems to
be working fine when under load, so up the threshold a bit.