### PR TITLE
Stop sending Smokey failures to Slack

### DIFF
--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -53,5 +53,4 @@ govuk_jenkins::job_builder::jobs:
 govuk_jenkins::jobs::deploy_cdn::enable_slack_notifications: true
 govuk_jenkins::jobs::deploy_puppet::enable_slack_notifications: true
 govuk_jenkins::jobs::scrape_icinga_alerts_for_dashboard_metrics::run_monthly: true
-govuk_jenkins::jobs::smokey::enable_slack_notifications: true
 govuk_jenkins::jobs::validate_published_dns::run_daily: true

--- a/hieradata/class/staging/jenkins.yaml
+++ b/hieradata/class/staging/jenkins.yaml
@@ -36,4 +36,3 @@ govuk_jenkins::job_builder::jobs:
 
 govuk_jenkins::jobs::deploy_cdn::enable_slack_notifications: true
 govuk_jenkins::jobs::deploy_puppet::enable_slack_notifications: true
-govuk_jenkins::jobs::smokey::enable_slack_notifications: true

--- a/hieradata_aws/class/production/jenkins.yaml
+++ b/hieradata_aws/class/production/jenkins.yaml
@@ -36,5 +36,4 @@ govuk_jenkins::job_builder::jobs:
 
 govuk_jenkins::jobs::deploy_cdn::enable_slack_notifications: false
 govuk_jenkins::jobs::deploy_puppet::enable_slack_notifications: false
-govuk_jenkins::jobs::smokey::enable_slack_notifications: false
 govuk_jenkins::jobs::transition_import_hits::s3_bucket: govuk-production-transition-fastly-logs

--- a/hieradata_aws/class/staging/jenkins.yaml
+++ b/hieradata_aws/class/staging/jenkins.yaml
@@ -28,4 +28,3 @@ govuk_jenkins::job_builder::jobs:
 
 govuk_jenkins::jobs::deploy_cdn::enable_slack_notifications: false
 govuk_jenkins::jobs::deploy_puppet::enable_slack_notifications: false
-govuk_jenkins::jobs::smokey::enable_slack_notifications: false

--- a/hieradata_aws/class/training/jenkins.yaml
+++ b/hieradata_aws/class/training/jenkins.yaml
@@ -24,4 +24,3 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::smokey_deploy
 
 govuk_jenkins::jobs::deploy_puppet::enable_slack_notifications: false
-govuk_jenkins::jobs::smokey::enable_slack_notifications: false

--- a/modules/govuk_jenkins/manifests/jobs/smokey.pp
+++ b/modules/govuk_jenkins/manifests/jobs/smokey.pp
@@ -4,22 +4,14 @@
 #
 # === Parameters
 #
-# [*enable_slack_notifications*]
-#   Whether slack should be notified about this job
-#
 # [*environment*]
 #   The environment which is running Smokey. Used to build the rake task.
 #
 class govuk_jenkins::jobs::smokey (
-  $enable_slack_notifications = false,
   $environment = 'production',
 ) {
   $smokey_task = "test:${environment}"
   $app_domain = hiera('app_domain')
-
-  $slack_team_domain = 'gds'
-  $slack_room = 'govuk-2ndline'
-  $slack_build_server_url = "https://deploy.${app_domain}/"
 
   include govuk::apps::smokey
 

--- a/modules/govuk_jenkins/manifests/jobs/smokey.pp
+++ b/modules/govuk_jenkins/manifests/jobs/smokey.pp
@@ -23,10 +23,20 @@ class govuk_jenkins::jobs::smokey (
 
   include govuk::apps::smokey
 
+  $service_description = 'Smokey'
+
   file { '/etc/jenkins_jobs/jobs/smokey.yaml':
     ensure  => present,
     content => template('govuk_jenkins/jobs/smokey.yaml.erb'),
     notify  => Exec['jenkins_jobs_update'],
     require => Class['govuk::apps::smokey'],
+  }
+
+  $job_url = "https://deploy.${app_domain}/job/smokey/"
+
+  @@icinga::passive_check { "smokey_${::hostname}":
+    service_description => $service_description,
+    host_name           => $::fqdn,
+    action_url          => $job_url,
   }
 }

--- a/modules/govuk_jenkins/templates/jobs/smokey.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/smokey.yaml.erb
@@ -2,10 +2,9 @@
 - scm:
     name: smokey_Smokey
     scm:
-        - git:
-            url: git@github.com:alphagov/smokey.git
-            branches:
-              - master
+      - git:
+          url: git@github.com:alphagov/smokey.git
+          branches: [master]
 
 - job:
     name: Smokey
@@ -39,14 +38,13 @@
           include-custom-message: true
           custom-message: ':govuk-<%= @environment %>:'
     <% end %>
-
     builders:
-        - shell: |
-            set +x
-            export TARGET_PLATFORM=<%= @environment %>
-            export MYTASK=<%= @smokey_task %>
-            set -x
-            ./jenkins.sh
+      - shell: |
+          set +x
+          export TARGET_PLATFORM=<%= @environment %>
+          export MYTASK=<%= @smokey_task %>
+          set -x
+          ./jenkins.sh
     wrappers:
-        - ansicolor:
-            colormap: xterm
+      - ansicolor:
+          colormap: xterm

--- a/modules/govuk_jenkins/templates/jobs/smokey.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/smokey.yaml.erb
@@ -17,27 +17,38 @@
       - build-discarder:
           days-to-keep: 30
           artifact-num-to-keep: 5
-    <% if @enable_slack_notifications %>
     publishers:
-      - slack:
-          team-domain: <%= @slack_team_domain %>
-          auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN']%>
-          auth-token-id: slack-token
-          auth-token-credential-id: slack-token
-          build-server-url: <%= @slack_build_server_url %>
-          notify-start: false
-          notify-success: false
-          notify-aborted: true
-          notify-not-built: true
-          notify-unstable: false
-          notify-failure: true
-          notify-back-to-normal: true
-          notify-repeated-failure: true
-          include-test-summary: false
-          room: <%= @slack_room %>
-          include-custom-message: true
-          custom-message: ':govuk-<%= @environment %>:'
-    <% end %>
+      <% if @enable_slack_notifications %>
+        - slack:
+            team-domain: <%= @slack_team_domain %>
+            auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN']%>
+            auth-token-id: slack-token
+            auth-token-credential-id: slack-token
+            build-server-url: <%= @slack_build_server_url %>
+            notify-start: false
+            notify-success: false
+            notify-aborted: true
+            notify-not-built: true
+            notify-unstable: false
+            notify-failure: true
+            notify-back-to-normal: true
+            notify-repeated-failure: true
+            include-test-summary: false
+            room: <%= @slack_room %>
+            include-custom-message: true
+            custom-message: ':govuk-<%= @environment %>:'
+      <% end %>
+      - trigger-parameterized-builds:
+          - project: Success_Passive_Check
+            condition: SUCCESS
+            predefined-parameters: |
+                NSCA_CHECK_DESCRIPTION=<%= @service_description %>
+                NSCA_OUTPUT=<%= @service_description %> success
+          - project: Failure_Passive_Check
+            condition: FAILED
+            predefined-parameters: |
+                NSCA_CHECK_DESCRIPTION=<%= @service_description %>
+                NSCA_OUTPUT=<%= @service_description %> failed
     builders:
       - shell: |
           set +x

--- a/modules/govuk_jenkins/templates/jobs/smokey.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/smokey.yaml.erb
@@ -18,26 +18,6 @@
           days-to-keep: 30
           artifact-num-to-keep: 5
     publishers:
-      <% if @enable_slack_notifications %>
-        - slack:
-            team-domain: <%= @slack_team_domain %>
-            auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN']%>
-            auth-token-id: slack-token
-            auth-token-credential-id: slack-token
-            build-server-url: <%= @slack_build_server_url %>
-            notify-start: false
-            notify-success: false
-            notify-aborted: true
-            notify-not-built: true
-            notify-unstable: false
-            notify-failure: true
-            notify-back-to-normal: true
-            notify-repeated-failure: true
-            include-test-summary: false
-            room: <%= @slack_room %>
-            include-custom-message: true
-            custom-message: ':govuk-<%= @environment %>:'
-      <% end %>
       - trigger-parameterized-builds:
           - project: Success_Passive_Check
             condition: SUCCESS


### PR DESCRIPTION
Over the last week or so Platform Health have been working to get all our Smokey failures visible in Icinga. https://github.com/alphagov/govuk-puppet/pull/9404 https://github.com/alphagov/smokey/pull/570

Now that this is the case, I propose that we can remove the Slack notifications when Smokey fails. I often find that they cause unnecessary disruption during a conversation (I realise this wouldn't happen if they were green more often, but currently they are often red). I think what also tends to happen is that because they appear and then more conversation happens they become easy to forget and then you're not aware that Smokey has failed. In the past we've gone many many months without even noticing that they were red.

By putting them in Icinga, we have constant visibility over their state. If Smokey is failing, there will be a critical alert for that, and we would be expected to fix it to get the environment green again.