### PR TITLE
Remove the Taxonomy Supervised Learning Pipeline Jenkins trigger

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/govuk_taxonomy_supervised_learning.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/govuk_taxonomy_supervised_learning.yaml.erb
@@ -17,10 +17,6 @@
       numToKeep: 20
     scm:
       - govuk-taxonomy-supervised-learning
-    triggers:
-        - timed: |
-            TZ=Europe/London
-            H 2 * * 1-5
     properties:
         - build-discarder:
             days-to-keep: 30


### PR DESCRIPTION
To stop it running automatically, as I don't believe there's any need
for it to run automatically at the moment.