### PR TITLE
Avoid false 429 rate alerts when a new cache instance comes up.

### DIFF
--- a/modules/icinga/manifests/package.pp
+++ b/modules/icinga/manifests/package.pp
@@ -38,7 +38,7 @@ class icinga::package {
   Package['nagios-nrpe-plugin'] -> Class['nagios::remove']
 
   package { 'check_graphite':
-    ensure   => '0.2.2',
+    ensure   => '0.2.5',
     provider => 'system_gem',
   }
 

--- a/modules/router/manifests/nginx.pp
+++ b/modules/router/manifests/nginx.pp
@@ -173,6 +173,7 @@ class router::nginx (
 
   @@icinga::check::graphite { "check_nginx_429_www_on_${::hostname}":
     target              => $graphite_429_target,
+    args                => '--ignore-missing',
     warning             => 3,
     critical            => 5,
     from                => '5minutes',


### PR DESCRIPTION
When a new cache instance appears, the '429 rate' alert fires with UNKNOWN status.
This happens because the statsd metric doesn't get created until the first 429 response
happens (which doesn't and shouldn't normally happen), which leads to the check_graphite
command failing because it can't find the timeseries, leading to the UNKNOWN status and
alerts appearing on the Icinga dashboard.

`check_graphite` has an `--ignore_missing` option which does exactly what we want in
this particular case. That is, we want the check to succeed if there is no metric for
429 rate on a given router instance.

The `--ignore-missing` option was added in a more recent version of `check_graphite`
than the one presently installed, so we also update the version here.