### PR TITLE
Fix govuk_env_sync checking an unset environment variable

### DIFF
--- a/modules/govuk_env_sync/files/govuk_env_sync.sh
+++ b/modules/govuk_env_sync/files/govuk_env_sync.sh
@@ -303,7 +303,7 @@ function restore_postgresql {
 }
 
 function  dump_mysql {
-  if [ ! -z "${AWS_DEFAULT_REGION:-}" ] ; then
+  if [ ! -z "${AWS_REGION:-}" ] ; then
     DB_USER='aws_db_admin'
   else
     DB_USER='root'


### PR DESCRIPTION
AWS_REGION is set by govuk-puppet, AWS_DEFAULT_REGION isn't set (it is
mentioned in the global bashrc, but that doesn't have any effect
here).