### PR TITLE
Stop pushing the performance_schema MySQL database

### DIFF
--- a/hieradata_aws/class/integration/db_admin.yaml
+++ b/hieradata_aws/class/integration/db_admin.yaml
@@ -198,7 +198,7 @@ govuk_env_sync::tasks:
     url: "govuk-integration-database-backups"
     path: "mysql-backend"
   "push_performance_schema_integration_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "0"
     minute: "30"
     action: "push"

--- a/hieradata_aws/class/training/db_admin.yaml
+++ b/hieradata_aws/class/training/db_admin.yaml
@@ -187,7 +187,7 @@ govuk_env_sync::tasks:
     url: "govuk-integration-database-backups"
     path: "mysql-backend"
   "pull_performance_schema_training_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "1"
     minute: "30"
     action: "pull"


### PR DESCRIPTION
As it's not a real database! It's monitoring information about MySQL
presented as a special database.