### PR TITLE
Update the Jenkins Job Builder

### DIFF
--- a/modules/govuk_jenkins/manifests/job_builder.pp
+++ b/modules/govuk_jenkins/manifests/job_builder.pp
@@ -47,8 +47,8 @@ class govuk_jenkins::job_builder (
 #  }
 
   package { 'jenkins-job-builder':
-    ensure   => '2.0.3',
-    provider => pip,
+    ensure   => '3.0.1',
+    provider => pip3,
   }
 
   file { '/etc/jenkins_jobs':


### PR DESCRIPTION
Switch to a newer version, and also switch to using Python 3. I'm
wondering if this will avoid issues when working with unicode
characters in branch names.