### PR TITLE
Try again to fix the mysql username

### DIFF
--- a/modules/govuk_env_sync/files/govuk_env_sync.sh
+++ b/modules/govuk_env_sync/files/govuk_env_sync.sh
@@ -303,7 +303,9 @@ function restore_postgresql {
 }
 
 function  dump_mysql {
-  if [ ! -z "${AWS_REGION:-}" ] ; then
+  # If the AWS_ACCESS_KEY_ID is unset, then we're running in
+  # AWS. Otherwise, we're running in Carrenza.
+  if [ -z "${AWS_ACCESS_KEY_ID:-}" ] ; then
     DB_USER='aws_db_admin'
   else
     DB_USER='root'


### PR DESCRIPTION
The AWS_REGION is actually set in AWS and Carrenza. The
AWS_ACCESS_KEY_ID isn't, so use this instead to tell what username to
use.