### PR TITLE
Add a data sync for licensing-mongo

### DIFF
--- a/hieradata/class/staging/licensing_mongo.yaml
+++ b/hieradata/class/staging/licensing_mongo.yaml
@@ -1,0 +1,20 @@
+govuk_env_sync::tasks:
+  pull_licensify: &pull_licensify
+    ensure: present
+    hour: '5'
+    minute: '0'
+    action: push
+    dbms: mongo
+    storagebackend: s3
+    database: licensify
+    temppath: /var/lib/mongodb/.dumps
+    url: govuk-production-database-backups
+    path: mongo-licensing
+
+  pull_licensify_audit:
+    <<: *pull_licensify
+    database: licensify-audit
+
+  pull_licensify_refdata:
+    <<: *pull_licensify
+    database: licensify-refdata

--- a/hieradata/node/licensing-mongo-1.licensify.publishing.service.gov.uk.yaml
+++ b/hieradata/node/licensing-mongo-1.licensify.publishing.service.gov.uk.yaml
@@ -1,0 +1,20 @@
+govuk_env_sync::tasks:
+  push_licensify: &push_licensify
+    ensure: present
+    hour: '4'
+    minute: '0'
+    action: push
+    dbms: mongo
+    storagebackend: s3
+    database: licensify
+    temppath: /var/lib/mongodb/.dumps
+    url: govuk-production-database-backups
+    path: mongo-licensing
+
+  push_licensify_audit:
+    <<: *push_licensify
+    database: licensify-audit
+
+  push_licensify_refdata:
+    <<: *push_licensify
+    database: licensify-refdata

--- a/hieradata/node/licensing-mongo-1.licensify.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/licensing-mongo-1.licensify.staging.publishing.service.gov.uk.yaml
@@ -1,0 +1,20 @@
+govuk_env_sync::tasks:
+  push_licensify: &push_licensify
+    ensure: present
+    hour: '4'
+    minute: '0'
+    action: push
+    dbms: mongo
+    storagebackend: s3
+    database: licensify
+    temppath: /var/lib/mongodb/.dumps
+    url: govuk-staging-database-backups
+    path: mongo-licensing
+
+  push_licensify_audit:
+    <<: *push_licensify
+    database: licensify-audit
+
+  push_licensify_refdata:
+    <<: *push_licensify
+    database: licensify-refdata

--- a/hieradata_aws/class/integration/licensing_mongo.yaml
+++ b/hieradata_aws/class/integration/licensing_mongo.yaml
@@ -18,3 +18,23 @@ govuk_env_sync::tasks:
   push_licensify_refdata:
     <<: *push_licensify
     database: licensify-refdata
+
+  pull_licensify: &pull_licensify
+    ensure: present
+    hour: '5'
+    minute: '0'
+    action: pull
+    dbms: mongo
+    storagebackend: s3
+    database: licensify
+    temppath: /var/lib/mongodb/.dumps
+    url: govuk-staging-database-backups
+    path: mongo-licensing
+
+  pull_licensify_audit:
+    <<: *pull_licensify
+    database: licensify-audit
+
+  pull_licensify_refdata:
+    <<: *pull_licensify
+    database: licensify-refdata

--- a/hieradata_aws/class/integration/licensing_mongo.yaml
+++ b/hieradata_aws/class/integration/licensing_mongo.yaml
@@ -1,0 +1,20 @@
+govuk_env_sync::tasks:
+  push_licensify: &push_licensify
+    ensure: present
+    hour: '4'
+    minute: '0'
+    action: push
+    dbms: mongo
+    storagebackend: s3
+    database: licensify
+    temppath: /var/lib/mongodb/.dumps
+    url: govuk-integration-database-backups
+    path: mongo-licensing
+
+  push_licensify_audit:
+    <<: *push_licensify
+    database: licensify-audit
+
+  push_licensify_refdata:
+    <<: *push_licensify
+    database: licensify-refdata


### PR DESCRIPTION
This adds push tasks for licensing-mongo in all three environments, and then sets up a pull task in staging and integration.

[Trello Card](https://trello.com/c/6HxRehH6/1161-add-a-data-sync-for-licensify)