### PR TITLE
Change FASTLY_API_KEY to a password parameter

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_cdn.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_cdn.yaml.erb
@@ -65,6 +65,6 @@
                 - servicegovuk
                 - performanceplatform
                 - mirror
-        - string:
+        - password:
             name: FASTLY_API_KEY
             default: false

--- a/modules/govuk_jenkins/templates/jobs/update_cdn_dictionaries.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/update_cdn_dictionaries.yaml.erb
@@ -60,6 +60,6 @@
                 <% if @allow_deploy_to_mirror %>
                 - mirror
                 <% end %>
-        - string:
+        - password:
             name: FASTLY_API_KEY
             default: false


### PR DESCRIPTION
This ensures the value won't be accessible from old jobs.