### PR TITLE
Allow monitoring ip address to access Whitehall-admin healthcheck

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -116,6 +116,7 @@ task :check_consistency_between_aws_and_carrenza do
     govuk::apps::support_api::ensure
     govuk::apps::whitehall::cpu_critical
     govuk::apps::whitehall::cpu_warning
+    govuk::apps::whitehall::monitoring_ip
     govuk::node::s_api_lb::api_servers
     govuk::node::s_api_lb::content_store_servers
     govuk::node::s_api_lb::draft_content_store_servers

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -456,6 +456,7 @@ govuk::apps::whitehall::db_name: whitehall_production
 govuk::apps::whitehall::db_password: "%{hiera('govuk::apps::whitehall::db::mysql_whitehall')}"
 govuk::apps::whitehall::db_username: whitehall_fe
 govuk::apps::whitehall::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
+govuk::apps::whitehall::monitoring_ip: "%{hiera('hosts::production::management::hosts.monitoring-1.ip')}"
 govuk::apps::whitehall::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::whitehall::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::whitehall::procfile_worker_process_count: 2

--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -303,6 +303,7 @@ class govuk::apps::whitehall(
       location ${health_check_path} {
         allow 10.2.0.20;
         deny all;
+        try_files \$uri @app;
       }
 
       # Don't block access to the overdue healthcheck page.  Icinga needs to be

--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -302,6 +302,7 @@ class govuk::apps::whitehall(
       # Updated version
       location ${health_check_path} {
         allow 10.2.0.20;
+        allow 172.17.0.1;
         deny all;
         try_files \$uri @app;
       }

--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -198,7 +198,6 @@ class govuk::apps::whitehall(
     sentry_dsn               => $sentry_dsn,
     log_format_is_json       => true,
     health_check_path        => $health_check_path,
-    expose_health_check      => false,
     json_health_check        => true,
     depends_on_nfs           => true,
     enable_nginx_vhost       => false,
@@ -238,6 +237,7 @@ class govuk::apps::whitehall(
       protected             => $vhost_protected,
       app_port              => $port,
       asset_pipeline        => true,
+      hidden_paths          => [$health_check_path],
       asset_pipeline_prefix => 'government/assets',
     }
 
@@ -301,7 +301,7 @@ class govuk::apps::whitehall(
       # This is only useful for Carrenza, as AWS will not provide static IPs.
       # Updated version
       location ${health_check_path} {
-        allow ${monitoring_ip};
+        allow 10.2.0.20;
         deny all;
       }
 

--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -299,6 +299,7 @@ class govuk::apps::whitehall(
       # Restrict access to the healthcheck page. Grafana needs to be
       # able to access this from the monitoring machine. All other requests are blocked.
       # This is only useful for Carrenza, as AWS will not provide static IPs.
+      # Updated version
       location ${health_check_path} {
         allow ${monitoring_ip};
         deny all;

--- a/spec/fixtures/hieradata/common.yaml
+++ b/spec/fixtures/hieradata/common.yaml
@@ -98,6 +98,8 @@ hosts::production::backend::hosts:
   whitehall-backend-1:
     ip: '10.3.0.25'
 hosts::production::management::hosts:
+  monitoring-1:
+    ip: '10.3.0.20'
   apt-1:
     ip: '10.1.0.75'
   cache-1:


### PR DESCRIPTION
We would like to add Whitehall healthcheck reporting to a Grafana dashbaord.

Currently we block all access to Whitehall-admins `/healthcheck` path. This PR will grant access to the monitoring machine.

This will only work whilst still hosting on Carrenza; after moving to AWS we will not be able to rely on a static IP address and will need to consider a longer term solution.
