### PR TITLE
Fix links to search-api-analytics and content-data jobs

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/search_api_fetch_analytics_data.pp
+++ b/modules/govuk_jenkins/manifests/jobs/search_api_fetch_analytics_data.pp
@@ -8,11 +8,9 @@ class govuk_jenkins::jobs::search_api_fetch_analytics_data (
   $skip_page_traffic_load = false,
   $cron_schedule = '5 4 * * *',
 ) {
-
   $job_name = 'search-api-fetch-analytics-data'
   $check_name = 'search-api-fetch-analytics-data'
   $service_description = 'Fetch analytics data for Search API'
-  $job_url = "https://deploy.${app_domain}/job/${job_name}/"
   $target_application = 'search-api'
 
   file { '/etc/jenkins_jobs/jobs/search_api_fetch_analytics_data.yaml':
@@ -20,6 +18,9 @@ class govuk_jenkins::jobs::search_api_fetch_analytics_data (
     content => template('govuk_jenkins/jobs/search_fetch_analytics_data.yaml.erb'),
     notify  => Exec['jenkins_jobs_update'],
   }
+
+  # FIXME: go back to using $app_domain once we have a single Icinga instance in AWS
+  $job_url = "https://deploy.${::aws_environment}.govuk.digital/job/${job_name}"
 
   @@icinga::passive_check { "${check_name}_${::hostname}":
     service_description => $service_description,


### PR DESCRIPTION
The warning in Icinga AWS Production / AWS Staging was linking to Carrenza Jenkins and returning a 404.

This commit changes the URL to be hard coded to the AWS URL as there
currently isn't an easy way of constructing that URL programatically.

I've based this on what was done for https://github.com/alphagov/govuk-puppet/pull/8935