### PR TITLE
Add Whitehall Admin to UptimeCollector

### DIFF
--- a/modules/monitoring/files/usr/local/bin/govuk_uptime_collector
+++ b/modules/monitoring/files/usr/local/bin/govuk_uptime_collector
@@ -9,9 +9,9 @@ require "time"
 require "statsd"
 
 class Collector
-  def initialize(service_name, environment, aws)
+  def initialize(service_details, environment, aws)
+    extract_service_details(service_details)
     @statsd = Statsd.new("127.0.0.1")
-    @service_name = service_name
     @environment = environment
     @aws = aws
   end
@@ -25,7 +25,13 @@ class Collector
 
 private
 
-  attr_reader :statsd, :service_name, :environment, :aws
+  attr_reader :statsd, :service_name, :environment, :aws, :healthcheck_path
+
+  def extract_service_details(details)
+    details = details.split(':')
+    @service_name = details[0]
+    @healthcheck_path = details[1] || 'healthcheck'
+  end
 
   def healthcheck_uri
     @healthcheck_uri ||= begin
@@ -33,7 +39,7 @@ private
         URI("https://#{service_name}.blue.integration.govuk.digital/healthcheck")
       else
         prefix = environment == "production" ? "#{service_name}" : "#{service_name}.#{environment}"
-        URI("https://#{prefix}.publishing.service.gov.uk/healthcheck")
+        URI("https://#{prefix}.publishing.service.gov.uk/#{healthcheck_path}")
       end
     end
   end
@@ -65,9 +71,9 @@ def main
   environment = ARGV[0]
   aws = ARGV[1] == 'true' ? true : false
 
-  ARGV[2..-1].each do |service_name|
+  ARGV[2..-1].each do |service_details|
     threads << Thread.new do
-      Collector.new(service_name, environment, aws).call
+      Collector.new(service_details, environment, aws).call
     end
   end
 

--- a/modules/monitoring/templates/govuk-uptime-collector.conf.erb
+++ b/modules/monitoring/templates/govuk-uptime-collector.conf.erb
@@ -6,4 +6,4 @@ respawn
 env RBENV_VERSION=2.6
 env PATH=/usr/lib/rbenv/shims:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
-exec govuk_uptime_collector <%= @environment %> <%= @aws %> content-store hmrc-manuals-api link-checker-api manuals-publisher publishing-api specialist-publisher travel-advice-publisher whitehall-admin
+exec govuk_uptime_collector <%= @environment %> <%= @aws %> content-store hmrc-manuals-api link-checker-api manuals-publisher publishing-api specialist-publisher travel-advice-publisher whitehall-admin:healthcheck/overdue

--- a/modules/monitoring/templates/govuk-uptime-collector.conf.erb
+++ b/modules/monitoring/templates/govuk-uptime-collector.conf.erb
@@ -6,4 +6,4 @@ respawn
 env RBENV_VERSION=2.6
 env PATH=/usr/lib/rbenv/shims:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
-exec govuk_uptime_collector <%= @environment %> <%= @aws %> content-store hmrc-manuals-api link-checker-api manuals-publisher publishing-api specialist-publisher travel-advice-publisher
+exec govuk_uptime_collector <%= @environment %> <%= @aws %> content-store hmrc-manuals-api link-checker-api manuals-publisher publishing-api specialist-publisher travel-advice-publisher whitehall-admin


### PR DESCRIPTION
Adds Whitehall Admin to the UptimeCollector, to allow uptime metrics to be reported via Grafana.

The WhitehallAdmin `healthcheck` endpoint is unexposed. However, the `healthcheck/overdue` endpoint is accessible. This PR alters the UptimeCollector to take an additional heathcheck path as part of the service argument and, if present, use this to ascertain service health. 

If none is given, it will use the standard `healthcheck` path. 

https://docs.publishing.service.gov.uk/manual/uptime-metrics.html

[Trello](https://trello.com/c/ct9qHnlt/1163-add-whitehall-to-uptime-dashboard)