### PR TITLE
Enable govuk_env_sync on licensing-mongo machines

### DIFF
--- a/modules/govuk/manifests/node/s_licensing_mongo.pp
+++ b/modules/govuk/manifests/node/s_licensing_mongo.pp
@@ -4,6 +4,7 @@
 #
 class govuk::node::s_licensing_mongo inherits govuk::node::s_base {
   include mongodb::server
+  include govuk_env_sync
 
   collectd::plugin::tcpconn { 'mongo':
     incoming => 27017,


### PR DESCRIPTION
This is required for the env sync tasks added in ae7726cb1bb85c38aeb992dc57318e89ffd872be to work.

[Trello Card](https://trello.com/c/6HxRehH6/1161-add-a-data-sync-for-licensify)