### PR TITLE
Fix incorrect push/pull for licensing

### DIFF
--- a/hieradata/class/staging/licensing_mongo.yaml
+++ b/hieradata/class/staging/licensing_mongo.yaml
@@ -3,7 +3,7 @@ govuk_env_sync::tasks:
     ensure: present
     hour: '5'
     minute: '0'
-    action: push
+    action: pull
     dbms: mongo
     storagebackend: s3
     database: licensify


### PR DESCRIPTION
Staging should be pulling from the production bucket, not pushing to the production bucket.

[Trello Card](https://trello.com/c/6HxRehH6/1161-add-a-data-sync-for-licensify)