### PR TITLE
Read mongo collections using printjson

### DIFF
--- a/modules/govuk_env_sync/files/govuk_env_sync.sh
+++ b/modules/govuk_env_sync/files/govuk_env_sync.sh
@@ -182,8 +182,8 @@ function is_writable_mysql {
 }
 
 function dump_mongo {
-  IFS=',' read -r -a collections <<< \
-          "$(mongo --quiet --eval 'rs.slaveOk(); db.getCollectionNames();' "localhost/$database")"
+  readarray -t collections < \
+    <(mongo --quiet --eval 'rs.slaveOk(); printjson(db.getCollectionNames());' "localhost/$database" | jq -r '.[]')
 
   for collection in "${collections[@]}"
   do

--- a/modules/govuk_env_sync/manifests/init.pp
+++ b/modules/govuk_env_sync/manifests/init.pp
@@ -10,6 +10,10 @@ class govuk_env_sync(
 
   include govuk_env_sync::lock_file
 
+  package { 'jq':
+    ensure => installed,
+  }
+
   file { $conf_dir:
     ensure  => 'directory',
     recurse => true,


### PR DESCRIPTION
The format of db.getCollectionNames() has changed between versions of Mongo. In Mongo 2 you get back a string delimited by a comma but in Mongo 3 you get a full JSON array as a string. By using `printjson` we can make the format the same on both versions.

I've tested this on Mongo version 3.2.7 and 2.4.9.

Working examples:

```
thomasleese@production-licensing-mongo-1:~$ readarray -t a < <(mongo --quiet --eval 'rs.slaveOk(); printjson(db.getCollectionNames());' "localhost/licensify" | jq -r '.[]')
thomasleese@production-licensing-mongo-1:~$ declare -p a
declare -a a='([0]="applications" [1]="audit" ...)'

thomasleese@staging-mongo-1:~$ readarray -t a < <(mongo --quiet --eval 'rs.slaveOk(); printjson(db.getCollectionNames());' "localhost/govuk_content_production" | jq -r '.[]')
thomasleese@staging-mongo-1:~$ declare -p a
declare -a a='([0]="artefacts" [1]="contacts" ...)'
```

[Trello Card](https://trello.com/c/6HxRehH6/1161-add-a-data-sync-for-licensify)