### PR TITLE
Revert "Pull licensing staging databases into integration"

### DIFF
--- a/hieradata_aws/class/integration/licensing_mongo.yaml
+++ b/hieradata_aws/class/integration/licensing_mongo.yaml
@@ -18,23 +18,3 @@ govuk_env_sync::tasks:
   push_licensify_refdata:
     <<: *push_licensify
     database: licensify-refdata
-
-  pull_licensify: &pull_licensify
-    ensure: present
-    hour: '5'
-    minute: '0'
-    action: pull
-    dbms: mongo
-    storagebackend: s3
-    database: licensify
-    temppath: /var/lib/mongodb/.dumps
-    url: govuk-staging-database-backups
-    path: mongo-licensing
-
-  pull_licensify_audit:
-    <<: *pull_licensify
-    database: licensify-audit
-
-  pull_licensify_refdata:
-    <<: *pull_licensify
-    database: licensify-refdata


### PR DESCRIPTION
This reverts commit 6a0576f7b040556279f316e8fbcbb220fce8c7de.

I've noticed that the data from staging will contain some payment records and various other potentially sensitive information. Until we know for sure we want this in integration, I thought it was best to not pull from staging into integration.

[Trello Card](https://trello.com/c/6HxRehH6/1161-add-a-data-sync-for-licensify)