### PR TITLE
Use ensure_packages for jq

### DIFF
--- a/modules/govuk_env_sync/manifests/init.pp
+++ b/modules/govuk_env_sync/manifests/init.pp
@@ -10,9 +10,7 @@ class govuk_env_sync(
 
   include govuk_env_sync::lock_file
 
-  package { 'jq':
-    ensure => installed,
-  }
+  ensure_packages(['jq'])
 
   file { $conf_dir:
     ensure  => 'directory',

--- a/modules/monitoring/manifests/checks.pp
+++ b/modules/monitoring/manifests/checks.pp
@@ -19,9 +19,7 @@ class monitoring::checks (
   $http_password     = 'UNSET',
 ) {
 
-  package { 'jq':
-    ensure  => 'latest',
-  }
+  ensure_packages(['jq'])
 
   exec { 'install_boto':
         path    => ['/opt/python2.7/bin', '/usr/bin', '/usr/sbin'],


### PR DESCRIPTION
We have multiple package definitions for `jq` which causes a conflict. By using `ensure_packages` we can avoid this conflict: https://forge.puppet.com/puppetlabs/stdlib#ensure_packages