### PR TITLE
use internal domain name for etcd endpoint

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1244,7 +1244,7 @@ unattended_reboot::cron_env_vars:
   - 'MAILTO=""'
 unattended_reboot::cron_hour: '0-5'
 unattended_reboot::etcd_endpoints:
-  - "http://etcd.%{hiera('app_domain')}:2379"
+  - "http://etcd.%{hiera('app_domain_internal')}:2379"
 
 unattended_upgrades::blacklist:
  - 'mysql-server.*'


### PR DESCRIPTION
etcd is used for holding machine reboot locks via locksmith, this has
not been working as the etcd endpoint was not reachable via the public
domain name. This switches it to use the internal domain so locksmith
can claim and release locks.