### PR TITLE
Fix reboot locking for unattended reboots

### DIFF
--- a/hieradata/node/docker-management-1.management.publishing.service.gov.uk.yaml
+++ b/hieradata/node/docker-management-1.management.publishing.service.gov.uk.yaml
@@ -1,0 +1,2 @@
+govuk_safe_to_reboot::can_reboot: 'careful'
+govuk_safe_to_reboot::reason: 'safe to reboot while no other unattended reboot underway'

--- a/hieradata/node/docker-management-1.management.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/docker-management-1.management.staging.publishing.service.gov.uk.yaml
@@ -1,0 +1,2 @@
+govuk_safe_to_reboot::can_reboot: 'careful'
+govuk_safe_to_reboot::reason: 'safe to reboot while no other unattended reboot underway'

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -588,3 +588,5 @@ router::nginx::robotstxt: |
 
 mongodb::s3backup::backup::s3_bucket: 'govuk-mongodb-backup-s3-staging'
 mongodb::s3backup::backup::s3_bucket_daily: 'govuk-mongodb-backup-s3-daily-staging'
+
+unattended_reboot::cron_hour: "*"

--- a/hieradata_aws/class/docker_management.yaml
+++ b/hieradata_aws/class/docker_management.yaml
@@ -1,0 +1,2 @@
+govuk_safe_to_reboot::can_reboot: 'careful'
+govuk_safe_to_reboot::reason: 'safe to reboot while no other unattended reboot underway'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -1111,3 +1111,5 @@ hosts::backend_migration::hosts:
     host_aliases:
       - ckan-1.backend
       - ckan-1
+
+unattended_reboot::cron_hour: "*"

--- a/modules/govuk_env_sync/manifests/task.pp
+++ b/modules/govuk_env_sync/manifests/task.pp
@@ -82,7 +82,7 @@ define govuk_env_sync::task(
 
   $synccommand = shellquote([
     '/usr/bin/ionice','-c','2','-n','6',
-    '/usr/bin/setlock','/etc/unattended-reboot/no-reboot/govuk_env_sync',
+    '/usr/local/bin/with_reboot_lock',
     '/usr/bin/envdir',"${govuk_env_sync::conf_dir}/env.d",
     '/usr/local/bin/govuk_env_sync.sh','-f',"${govuk_env_sync::conf_dir}/${title}.cfg",
     ])

--- a/modules/govuk_jenkins/templates/jobs/data_sync.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/data_sync.yaml.erb
@@ -16,7 +16,7 @@
             if [ ! -z $SYNC_CONFIGFILE]; then ARG_CONFIGFILE="-f ${SYNC_CONFIGFILE}";fi
             if [ ! -z $SYNC_TIMESTAMP]; then ARG_TIMESTAMP="-t ${SYNC_TIMESTAMP}";fi
             ssh deploy@${SYNC_HOST} \
-            "/usr/bin/setlock /etc/unattended-reboot/no-reboot/govuk_env_sync \
+            "/usr/local/bin/with_reboot_lock \
              /usr/bin/envdir /etc/govuk_env_sync/env.d \
              sudo -u govuk-backup /usr/local/bin/govuk_env_sync.sh \
              ${ARG_CONFIGFILE} \

--- a/modules/govuk_jenkins/templates/jobs/mongo_data_sync.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/mongo_data_sync.yaml.erb
@@ -20,7 +20,7 @@
           # If the member is a master, then intiate data-sync.
           for member in ${members[@]}; do
             if $(ssh deploy@${member} "mongo --quiet --host "$member" --eval 'rs.isMaster().ismaster'"); then
-              ssh deploy@${member} "/usr/bin/setlock /etc/unattended-reboot/no-reboot/govuk_env_sync /usr/bin/envdir /etc/govuk_env_sync/env.d /usr/local/bin/govuk_env_sync.sh -f /etc/govuk_env_sync/pull_api_mongo_daily.cfg"
+              ssh deploy@${member} "/usr/local/bin/with_reboot_lock /usr/bin/envdir /etc/govuk_env_sync/env.d /usr/local/bin/govuk_env_sync.sh -f /etc/govuk_env_sync/pull_api_mongo_daily.cfg"
 
               # Exit once completed.
               exit $EXITCODE

--- a/modules/govuk_unattended_reboot/manifests/init.pp
+++ b/modules/govuk_unattended_reboot/manifests/init.pp
@@ -46,6 +46,9 @@ class govuk_unattended_reboot (
   $config_directory = '/etc/unattended-reboot'
   $check_scripts_directory = "${config_directory}/check"
 
+  $app_domain_internal = hiera('app_domain_internal','')
+  $fqdn = $::fqdn
+
   $node_class_search_phrase = regsubst($::govuk_node_class, '_', '-')
   $icinga_url = "https://${alert_hostname}/cgi-bin/icinga/status.cgi?search_string=%5E${node_class_search_phrase}-[0-9]&allunhandledproblems&jsonoutput"
 
@@ -93,6 +96,15 @@ class govuk_unattended_reboot (
     owner   => 'root',
     group   => 'root',
     content => template('govuk_unattended_reboot/03_no_reboot.erb'),
+  }
+
+  file { '/usr/local/bin/with_reboot_lock':
+    ensure  => $file_ensure,
+    path    => '/usr/local/bin/with_reboot_lock',
+    mode    => '0755',
+    owner   => 'root',
+    group   => 'root',
+    content => template('govuk_unattended_reboot/usr/local/bin/with_reboot_lock.erb'),
   }
 
   file { '/usr/local/bin/check_icinga':

--- a/modules/govuk_unattended_reboot/spec/classes/govuk_unattended_reboot_spec.rb
+++ b/modules/govuk_unattended_reboot/spec/classes/govuk_unattended_reboot_spec.rb
@@ -18,6 +18,7 @@ describe 'govuk_unattended_reboot', :type => :class do
     it { is_expected.to contain_file("#{check_scripts_directory}").with_ensure('directory') }
     it { is_expected.to contain_file("#{check_scripts_directory}/00_safety").with_ensure('present') }
     it { is_expected.to contain_file("#{check_scripts_directory}/01_alerts").with_ensure('present') }
+    it { is_expected.to contain_file('/usr/local/bin/with_reboot_lock').with_ensure('present') }
 
     it "correctly formats the node class when querying Icinga" do
       is_expected.to contain_file('/etc/unattended-reboot/check/01_alerts').with_content(/status.cgi\?search_string=%5Echocolate-factory-\[0-9\]&/)
@@ -35,5 +36,6 @@ describe 'govuk_unattended_reboot', :type => :class do
     it { is_expected.to contain_file("#{check_scripts_directory}").with_ensure('absent') }
     it { is_expected.to contain_file("#{check_scripts_directory}/00_safety").with_ensure('absent') }
     it { is_expected.to contain_file("#{check_scripts_directory}/01_alerts").with_ensure('absent') }
+    it { is_expected.to contain_file('/usr/local/bin/with_reboot_lock').with_ensure('absent') }
   end
 end

--- a/modules/govuk_unattended_reboot/templates/usr/local/bin/with_reboot_lock.erb
+++ b/modules/govuk_unattended_reboot/templates/usr/local/bin/with_reboot_lock.erb
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -eu
+
+lock_file="<%= @lock_dir %>/reboot_lock"
+
+function lock() {
+  while [ -f $lock_file ]; do
+    sleep 30
+    echo "waiting for $lock_file to be released..."
+  done
+  touch $lock_file
+}
+
+function unlock() {
+  rm -f $lock_file
+}
+
+lock
+trap "unlock" EXIT
+
+"${@}"


### PR DESCRIPTION
# What

* fixes the scripts that attempt to use locksmith so unattended reboots work again
* allows unattended reboots to occur during the day for staging

# why

because we want unattended reboots to work

# context

we have seen that setlock is being used in a way that is isn't quite
designed to (expected that a lock file gets deleted after free - when it
actually uses an exclusive write lock on the file not the file itself).

to avoid these issues and enable unatteneded upgrades we intend to replace uses of setlock with a simpler file-based lock (which is what the reboot check scripts expect)

we also noticed problems with the scripts that were attempting to use the wrong etcd endpoint