### PR TITLE
Prevent duplicate resource creation

### DIFF
--- a/modules/govuk/manifests/apps/ckan/db.pp
+++ b/modules/govuk/manifests/apps/ckan/db.pp
@@ -17,6 +17,7 @@
 #   Network range for the load balancer.
 #
 class govuk::apps::ckan::db (
+  $user = 'ckan',
   $password,
   $backend_ip_range = '10.3.0.0/16',
   $allow_auth_from_lb = false,
@@ -28,7 +29,7 @@ class govuk::apps::ckan::db (
   }
 
   govuk_postgresql::db { 'ckan_production':
-    user                    => 'ckan',
+    user                    => $user,
     password                => $password,
     allow_auth_from_backend => true,
     backend_ip_range        => $backend_ip_range,
@@ -39,7 +40,7 @@ class govuk::apps::ckan::db (
   }
 
   govuk_postgresql::db { 'ckan_pycsw_production':
-    user                    => 'ckan',
+    user                    => $user,
     password                => $password,
     allow_auth_from_backend => true,
     backend_ip_range        => $backend_ip_range,

--- a/modules/govuk_postgresql/manifests/db.pp
+++ b/modules/govuk_postgresql/manifests/db.pp
@@ -158,9 +158,13 @@ define govuk_postgresql::db (
     }
   } else {
     if (!empty($extensions)) {
-      postgresql::server::extension { $extensions:
-        ensure   => present,
-        database => $db_name,
+      # this only checks the first extension which is sufficient for 
+      # ckan_pycsw_production as its only got 1 extension
+      if ! defined(Postgresql::Server::Extension[$extensions[0]]) {
+        postgresql::server::extension { $extensions:
+          ensure   => present,
+          database => $db_name,
+        }
       }
     }
   }

--- a/modules/govuk_postgresql/manifests/db.pp
+++ b/modules/govuk_postgresql/manifests/db.pp
@@ -102,11 +102,13 @@ define govuk_postgresql::db (
     }
 
     if $rds {
-      @govuk_postgresql::rds_sql { $user:
-        rds_root_user => $rds_root_user,
-        tag           => 'govuk_postgresql::server::not_slave',
-        before        => Postgresql::Server::Db[$db_name],
-        require       => Postgresql::Server::Role[$user],
+      if ! defined(Govuk_postgresql::Rds_sql[$user]) {
+        @govuk_postgresql::rds_sql { $user:
+          rds_root_user => $rds_root_user,
+          tag           => 'govuk_postgresql::server::not_slave',
+          before        => Postgresql::Server::Db[$db_name],
+          require       => Postgresql::Server::Role[$user],
+        }
       }
     }
 


### PR DESCRIPTION
## What

Checks are in place to ensure that the user and PG extension are not created multiple times.

Slight caveat in the check on extensions is that it will only check against the first extension which is ok as the database that needs `postgis` installed, `ckan_pycsw_production` only has 1 extension requirement. 

Alternatively we could remove the extension requirement from `ckan_pycsw_production` as `ckan_production` already has that requirement.