### PR TITLE
add editorconfig to default to 2 spacey mode

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# end the whitespace wars: https://editorconfig.org/
+
+[*]
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.pp]
+indent_style = space
+indent_size = 2
+
+[*.{rb,erb}]
+indent_style = space
+indent_size = 2
+


### PR DESCRIPTION
for those of us who work accross multiple projects that don't all share
the same whitespace preferences a .editorconfig file helps our editors
do the right thing.

https://editorconfig.org/