### PR TITLE
Fix exposed user list from ckan

### DIFF
--- a/modules/govuk/manifests/apps/ckan.pp
+++ b/modules/govuk/manifests/apps/ckan.pp
@@ -146,6 +146,16 @@ class govuk::apps::ckan (
         value   => $bulk_worker_processes;
     }
 
+    govuk::app { 'ckan':
+      enable_nginx_vhost => false,
+    }
+
+    govuk::app::nginx_vhost { 'ckan':
+      vhost       => 'ckan',
+      app_port    => $port,
+      hidden_path => ['/api/3/action/user_list'],
+    }
+
     file { $ckan_home:
       ensure => directory,
       owner  => 'deploy',


### PR DESCRIPTION
This fixes a publicly exposed user list endpoint from CKAN. The user list contains potentially sensitive information such as names and email hashes. We've added a nginx rules to hide the path from vhost config.