### PR TITLE
Ensure that we have the full database name for the timestamp

### DIFF
--- a/modules/govuk_env_sync/files/govuk_env_sync.sh
+++ b/modules/govuk_env_sync/files/govuk_env_sync.sh
@@ -331,7 +331,7 @@ function pull_s3 {
 
 function get_timestamp_s3 {
   timestamp="$(aws s3 ls "s3://${url}/${path}/" \
-  | grep "\\-${database}" | tail -1 \
+  | grep "\\-${database}\." | tail -1 \
   | grep -o '[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}T[0-9]\{2\}:[0-9]\{2\}:[0-9]\{2\}')"
 }
 


### PR DESCRIPTION
By requiring that we see a full stop after the database name we can be sure that've captured the entire database name and not just a prefix. The full stop comes from the first part of the extension.

We need this because some database names are fully included in other database names, for example licensify and licensify-refdata.

Right now, getting the timestamp for licensify results in the timestamp for licensify-refdata:

```bash
$ envdir /etc/govuk_env_sync/env.d aws s3 ls s3://govuk-production-database-backups/mongo-licensing/ | grep "\\-licensify" | tail -1
2019-08-08 04:22:41   11795010 2019-08-08T04:22:26-licensify-refdata.gz
```

With the full stop:

```bash
$ envdir /etc/govuk_env_sync/env.d aws s3 ls s3://govuk-production-database-backups/mongo-licensing/ | grep "\\-licensify\." | tail -1
2019-08-08 04:21:44 2100524798 2019-08-08T04:17:13-licensify.gz
```