### PR TITLE
add deploy_licensify jobs to aws environments

### DIFF
--- a/hieradata_aws/class/integration/jenkins.yaml
+++ b/hieradata_aws/class/integration/jenkins.yaml
@@ -17,6 +17,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::deploy_cdn
   - govuk_jenkins::jobs::deploy_dns
   - govuk_jenkins::jobs::deploy_emergency_banner
+  - govuk_jenkins::jobs::deploy_licensify
   - govuk_jenkins::jobs::deploy_puppet
   - govuk_jenkins::jobs::deploy_router_data
   - govuk_jenkins::jobs::enhanced_ecommerce_search_api

--- a/hieradata_aws/class/production/jenkins.yaml
+++ b/hieradata_aws/class/production/jenkins.yaml
@@ -16,6 +16,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::content_data_api
   - govuk_jenkins::jobs::deploy_app
   - govuk_jenkins::jobs::deploy_emergency_banner
+  - govuk_jenkins::jobs::deploy_licensify
   - govuk_jenkins::jobs::deploy_puppet
   - govuk_jenkins::jobs::enhanced_ecommerce_search_api
   - govuk_jenkins::jobs::passive_checks

--- a/hieradata_aws/class/staging/jenkins.yaml
+++ b/hieradata_aws/class/staging/jenkins.yaml
@@ -14,6 +14,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::data_sync
   - govuk_jenkins::jobs::deploy_app
   - govuk_jenkins::jobs::deploy_emergency_banner
+  - govuk_jenkins::jobs::deploy_licensify
   - govuk_jenkins::jobs::deploy_puppet
   - govuk_jenkins::jobs::mongo_data_sync
   - govuk_jenkins::jobs::passive_checks


### PR DESCRIPTION
# Context

For the migration of licensify from UKCloud to AWS, the aws jenkins should have the functionality to deploy the licensify app.

This PR does not include the automated deployment via deploy_node_apps

# Decisions
1. add the `deploy_licensify` job to the 3 aws environments