### PR TITLE
Check the application memory twice before the check fails hard

### DIFF
--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -336,15 +336,16 @@ define govuk::app::config (
       contact_groups => $additional_check_contact_groups,
     }
     @@icinga::check::graphite { "check_${title}_app_mem_usage${::hostname}":
-      ensure         => $ensure,
-      target         => "${::fqdn_metrics}.processes-app-${title_underscore}.ps_rss",
-      warning        => $nagios_memory_warning_real,
-      critical       => $nagios_memory_critical_real,
-      desc           => "high memory for ${title} app",
-      host_name      => $::fqdn,
-      event_handler  => "govuk_app_high_memory!${title}",
-      notes_url      => monitoring_docs_url(high-memory-for-application),
-      contact_groups => $additional_check_contact_groups,
+      ensure                     => $ensure,
+      target                     => "${::fqdn_metrics}.processes-app-${title_underscore}.ps_rss",
+      warning                    => $nagios_memory_warning_real,
+      critical                   => $nagios_memory_critical_real,
+      desc                       => "high memory for ${title} app",
+      host_name                  => $::fqdn,
+      event_handler              => "govuk_app_high_memory!${title}",
+      notes_url                  => monitoring_docs_url(high-memory-for-application),
+      attempts_before_hard_state => 2,
+      contact_groups             => $additional_check_contact_groups,
     }
     if $alert_when_threads_exceed {
       @@icinga::check::graphite { "check_${title}_app_thread_count_${::hostname}":


### PR DESCRIPTION
Icinga has a distinction between soft and hard states for
checks. Setting the attempts_before_hard_state value to 2 (rather than
the default, 1) will mean Icinga won't notify about memory issues
until it's rechecked the memory for the app.

This'll hopefully avoid spurious notifications where the application
is being deployed, and naturally uses more memory for a short amount
of time.

This change was specifically motivated by seeing notifications for
this check for the Signon app.