### PR TITLE
Avoid referring to nonexistent Licensify TLS certs on AWS.

### DIFF
--- a/modules/licensify/templates/licensify-upload-vhost-aws.conf
+++ b/modules/licensify/templates/licensify-upload-vhost-aws.conf
@@ -1,0 +1,28 @@
+upstream <%= @vhost_name %>-proxy {
+  server localhost:<%= @port%>;
+}
+
+server {
+  server_name <%= @vhost_name %>;
+  listen 80;
+
+  access_log /var/log/nginx/<%= @vhost_name %>-access.log timed_combined;
+  access_log /var/log/nginx/<%= @vhost_name %>-json.event.access.log json_event;
+  error_log /var/log/nginx/<%= @vhost_name %>-error.log;
+
+  default_type text/html;
+  charset UTF-8;
+
+  # Restricting this vhost to a post
+  if ($request_method !~ ^(POST)$ ) {
+     return 444;
+  }
+
+  # Handle larger upload sizes
+  client_max_body_size 100M;
+
+  location / {
+    auth_basic off;
+    proxy_pass http://<%= @vhost_name %>-proxy;
+  }
+}


### PR DESCRIPTION
This should fix Puppet failures on `licensing-frontend` VMs which were
caused by the nginx config for the `uploadlicence` app referring to a
TLS certificate file which isn't there.

In AWS, we terminate TLS at the load balancers (ALBs) rather than at
nginx on the app VMs. Most of the Puppet config already handles this
(via `nginx_enable_ssl` in Hiera) except for this piece of custom nginx
config in `licensing-frontend`.