### PR TITLE
licensify is built on ci integration rather than ci dev

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/deploy_licensify.pp
+++ b/modules/govuk_jenkins/manifests/jobs/deploy_licensify.pp
@@ -4,11 +4,11 @@
 #
 # === Parameters
 #
-# [*ci_new_jenkins_api_key*]
+# [*ci_deploy_jenkins_api_key*]
 #   API key to download build artefacts from CI servers
 #
 class govuk_jenkins::jobs::deploy_licensify (
-  $ci_new_jenkins_api_key = undef,
+  $ci_deploy_jenkins_api_key = undef,
 ) {
   file { '/etc/jenkins_jobs/jobs/deploy_licensify.yaml':
     ensure  => present,

--- a/modules/govuk_jenkins/templates/jobs/deploy_licensify.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_licensify.yaml.erb
@@ -23,7 +23,7 @@
             cd "$WORKSPACE"
             curl -X POST -H 'Content-type: application/json' --data "{'text': ':govuk-${ORGANISATION}::mega: Build \`${BUILD_DISPLAY_NAME}\` of <https://github.com/alphagov/licensify|licensify> is being deployed to *${ORGANISATION}*', 'channel': '#govuk-deploy', 'link_names': 1, 'username': 'Badger', 'icon_emoji': ':badger:'}" "${BADGER_SLACK_WEBHOOK_URL}"
             echo "Grabbing Build ${artefact_number} Artifacts from Jenkins"
-            CI_BASE_URL="https://licensify:<%= @ci_new_jenkins_api_key -%>@ci.dev.publishing.service.gov.uk/job/${CI_JOB_NAME}/${artefact_number}/artifact"
+            CI_BASE_URL="https://ci_alphagov:<%= @ci_deploy_jenkins_api_key -%>@ci.integration.publishing.service.gov.uk/job/licensify/job/${CI_JOB_NAME}/${artefact_number}/artifact"
             curl -O -k "${CI_BASE_URL}/backend/${ARTIFACT_PATH}/backend-${app_version}.zip"
             curl -O -k "${CI_BASE_URL}/feed/${ARTIFACT_PATH}/feed-${app_version}.zip"
             curl -O -k "${CI_BASE_URL}/frontend/${ARTIFACT_PATH}/frontend-${app_version}.zip"
@@ -40,12 +40,10 @@
         - build-name:
             name: '${BUILD_NUMBER}/${ENV,var="CI_JOB_NAME"}/${ENV,var="artefact_number"}'
     parameters:
-        - choice:
+        - string:
             name: CI_JOB_NAME
-            choices:
-                - 'Licensify'
-                - 'Licensify_Branches'
-            description: Which job on CI Jenkins to fetch the artifact from
+            default: 'master'
+            description: Which job (i.e. branch name) on CI Jenkins to fetch the artifact from
         - string:
             name: artefact_number
             description: This is the build number from CI Jenkins


### PR DESCRIPTION
# Context

Since licensify is now built on CI rather than CI-dev, modify the deploy-licensify jenkins job to take this into account.

# Decisions
1. change the url uses by the jenkins job to retrieve the artefacts from the CI box
2. change the credential hiera key to keep uniformity with deploy_app and also `licensify` user does not exist on CI box