### PR TITLE
Disable traffic replay to Integration

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
@@ -50,8 +50,19 @@
             sed -i.bak "s/PG_TR_SRC_ENV_SYNC_PW=PLACEHOLDER/PG_TR_SRC_ENV_SYNC_PW='<%= @pg_src_env_sync_pw %>'/" scripts/sync-transition-postgresql.sh
             sed -i "s/PG_TR_DST_ENV_SYNC_PW=PLACEHOLDER/PG_TR_DST_ENV_SYNC_PW='<%= @pg_tr_dst_env_sync_pw %>'/" scripts/sync-transition-postgresql.sh
 
+            echo "Disabling Gor traffic replay"
+            for box in $(govuk_node_list -C 'govuk_gor'); do
+              ssh deploy@${box} 'echo "true" > /etc/govuk/env.d/FACTER_data_sync_in_progress; sudo initctl stop gor';
+            done
+
             echo "Syncing data"
             bash sync production integration
+
+            echo "Re-enabling Gor traffic replay"
+            for box in $(govuk_node_list -C 'govuk_gor'); do
+              ssh deploy@${box} 'echo "" > /etc/govuk/env.d/FACTER_data_sync_in_progress; sudo initctl start gor';
+            done
+
     publishers:
       - trigger-parameterized-builds:
         - project: Success_Passive_Check


### PR DESCRIPTION
...during data replication.

We are trying to reduce unnecessary Sentry errors, and one of those
ways is to disable traffic replay whilst the data sync is happening.

We manage traffic replay with our puppet class [`govuk_gor`](https://github.com/alphagov/govuk-puppet/blob/master/modules/govuk_gor/manifests/init.pp), setting
the Puppet `data_sync_in_progress` fact to `true` ensures that Puppet
does not try to run it until the data sync has completed.

Trello card: https://trello.com/c/tfBZywz4/1188-disable-the-traffic-replay-to-integration-and-staging-during-data-replication