### PR TITLE
Fix licensify master deploy

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -809,7 +809,14 @@ govuk_ci::master::pipeline_jobs:
   govuk_taxonomy_helpers: {}
   govuk_test: {}
   govuk-user-reviewer: {}
-  licensify: {}
+  licensify:
+    branches_to_exclude:
+      - 'release*'
+      - 'deployed-to-integration'
+      - 'deployed-to-staging'
+      - 'integration'
+      - 'staging'
+      - 'production'
   omniauth-gds: {}
   optic14n: {}
   performanceplatform-client.py: {}

--- a/modules/govuk_jenkins/templates/jobs/integration_licensify_deploy.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/integration_licensify_deploy.yaml.erb
@@ -10,7 +10,7 @@
           artifact-num-to-keep: 5
     builders:
       - shell: |
-          JSON="{\"parameter\": [{\"name\": \"BETA_PAYMENT_ACCOUNTS\", \"value\": \"false\"}, {\"name\": \"artefact_number\", \"value\": \"$artefact_number\"}, {\"name\": \"app_version\", \"value\": \"$app_version\"}, {\"name\": \"CI_JOB_NAME\", \"value\": \"Licensify\"}, {\"name\": \"ARTIFACT_PATH\", \"value\": \"target/universal\"}], \"\": \"\"}"
+          JSON="{\"parameter\": [{\"name\": \"BETA_PAYMENT_ACCOUNTS\", \"value\": \"false\"}, {\"name\": \"artefact_number\", \"value\": \"$artefact_number\"}, {\"name\": \"app_version\", \"value\": \"$app_version\"}, {\"name\": \"CI_JOB_NAME\", \"value\": \"master\"}, {\"name\": \"ARTIFACT_PATH\", \"value\": \"target/universal\"}], \"\": \"\"}"
 
           # Deploy to integration environment
           curl -v -f -XPOST https://<%= @jenkins_integration_api_user %>:<%= @jenkins_integration_api_password %>@ci-deploy.integration.publishing.service.gov.uk/job/Licensify_Deploy/build --data-urlencode json="$JSON"


### PR DESCRIPTION
# Context

Various fixes for  Licensify master deploy to integration

# Decisions

1. Need to use `master` as CI_JOB_NAME which is an alias for branch name
2. wildcard `release` branches/tags to be skipped for building.
   This is needed so that when master branch is tagged, no additional
   build in Jenkins is triggered.

Tested as a branch in carrenza integration