### PR TITLE
Add csw endpoint to ckan publisher stack

### DIFF
--- a/modules/govuk/manifests/apps/ckan.pp
+++ b/modules/govuk/manifests/apps/ckan.pp
@@ -177,7 +177,7 @@ class govuk::apps::ckan (
       owner   => 'deploy',
       group   => 'deploy',
       notify  => Service['ckan'],
-    }
+    } ->
 
     file { "${ckan_home}/default":
       ensure => directory,

--- a/modules/govuk/manifests/apps/ckan.pp
+++ b/modules/govuk/manifests/apps/ckan.pp
@@ -8,6 +8,9 @@
 # [*port*]
 #   What port should the app run on?
 #
+# [*pycsw_port*]
+#   What port should the PyCSW companion app run on?
+#
 # [*db_hostname*]
 #   The postgres instance for CKAN to connect to
 #
@@ -39,6 +42,7 @@
 class govuk::apps::ckan (
   $enabled                        = false,
   $port                           = '3220',
+  $pycsw_port                     = '3221',
   $db_hostname                    = undef,
   $db_username                    = 'ckan',
   $db_password                    = 'foo',
@@ -64,6 +68,7 @@ class govuk::apps::ckan (
 ) {
   $ckan_home = '/var/ckan'
   $ckan_ini  = "${ckan_home}/ckan.ini"
+  $pycsw_config = "${ckan_home}/pycsw.cfg"
 
   $request_timeout = 60
 
@@ -120,7 +125,18 @@ class govuk::apps::ckan (
       process_regex  => '\/python \.\/venv\/bin\/paster --plugin=ckanext-harvest harvester gather\_consumer',
     }
 
-    include govuk::apps::ckan::cronjobs
+    govuk::procfile::worker { 'pycsw_web':
+      ensure         => present,
+      setenv_as      => 'ckan',
+      enable_service => running,
+      process_type   => 'pycsw_web',
+      process_regex  => 'pycsw_wsgi',
+    }
+
+    class { 'cronjobs':
+      ckan_port    => $port,
+      pycsw_config => $pycsw_config,
+    }
 
     Govuk::App::Envvar {
       app => 'ckan',
@@ -145,6 +161,12 @@ class govuk::apps::ckan (
       "${title}-BULK_WORKER_PROCESSES":
         varname => 'BULK_WORKER_PROCESSES',
         value   => $bulk_worker_processes;
+      "${title}-PYCSW_PORT":
+        varname => 'PYCSW_PORT',
+        value   => $pycsw_port;
+      "${title}-PYCSW_CONFIG":
+        varname => 'PYCSW_CONFIG',
+        value   => $pycsw_config;
     }
 
     govuk::app::nginx_vhost { 'ckan':
@@ -183,6 +205,21 @@ class govuk::apps::ckan (
       ensure => directory,
       owner  => 'deploy',
       group  => 'deploy',
+    } ->
+
+    file { $pycsw_config:
+      ensure  => file,
+      content => template('govuk/ckan/pycsw.cfg.erb'),
+      owner   => 'deploy',
+      group   => 'deploy',
+    }
+
+    $ckan_bin = '/var/apps/ckan/venv/bin'
+    $pycsw_tables_created = "${ckan_home}/pycsw_tables_created.tmp"
+
+    exec { 'setup_pycsw_tables':
+      command => "${ckan_bin}/paster --plugin=ckanext-spatial ckan-pycsw setup -p ${pycsw_config} && sudo touch ${pycsw_tables_created}",
+      creates => $pycsw_tables_created,
     }
   }
 }

--- a/modules/govuk/manifests/apps/ckan/cronjobs.pp
+++ b/modules/govuk/manifests/apps/ckan/cronjobs.pp
@@ -1,14 +1,21 @@
 # == Class: govuk::apps::ckan::cronjobs
 #
+# [*ckan_port*]
+#   The port CKAN is running on.
+#
+# [*pycsw_config*]
+#   The location of the PyCSW configuration file.
+#
 # [*enable_solr_reindex*]
 #   Enable automatic Solr reindexing, this is useful to run after the data
 #   sync.
 #   Default: false
 #
 class govuk::apps::ckan::cronjobs(
+  $ckan_port,
+  $pycsw_config,
   $enable_solr_reindex = false,
 ) {
-
   govuk::apps::ckan::paster_cronjob { 'harvester run':
     paster_command => 'harvester run',
     plugin         => 'ckanext-harvest',
@@ -34,4 +41,11 @@ class govuk::apps::ckan::cronjobs(
     minute         => '0',
   }
 
+  govuk::apps::ckan::paster_cronjob { 'pycsw load':
+    paster_command => "ckan-pycsw load -p ${pycsw_config} -u http://localhost:${ckan_port}",
+    plugin         => 'ckanext-spatial',
+    hour           => '6',
+    minute         => '0',
+    ckan_ini       => undef,
+  }
 }

--- a/modules/govuk/manifests/apps/ckan/cronjobs.pp
+++ b/modules/govuk/manifests/apps/ckan/cronjobs.pp
@@ -30,7 +30,7 @@ class govuk::apps::ckan::cronjobs(
     ensure         => $ensure_solr_reindex,
     paster_command => 'search-index rebuild -o',
     plugin         => 'ckan',
-    hour           => '7',
+    hour           => '4',
     minute         => '0',
   }
 

--- a/modules/govuk/manifests/apps/ckan/paster_cronjob.pp
+++ b/modules/govuk/manifests/apps/ckan/paster_cronjob.pp
@@ -26,13 +26,19 @@ define govuk::apps::ckan::paster_cronjob (
   $weekday = undef,
   $plugin = undef,
   $paster_command = undef,
+  $ckan_ini = '/var/ckan/ckan.ini',
 ) {
-
   validate_string($plugin, $paster_command)
+
+  if $ckan_ini {
+    $ckan_config_arg = "--config=${ckan_ini}"
+  } else {
+    $ckan_config_arg = ''
+  }
 
   cron { $title:
     ensure   => $ensure,
-    command  => "cd /var/apps/ckan; ./venv/bin/paster --plugin=${plugin} ${paster_command} --config=/var/ckan/ckan.ini",
+    command  => "cd /var/apps/ckan; ./venv/bin/paster --plugin=${plugin} ${paster_command} ${ckan_config_arg}",
     user     => 'deploy',
     hour     => $hour,
     minute   => $minute,

--- a/modules/govuk/templates/ckan/nginx.conf.erb
+++ b/modules/govuk/templates/ckan/nginx.conf.erb
@@ -35,3 +35,23 @@ location /api/action/organization_list {
 location /api/action/package_list {
   try_files $uri @app;
 }
+
+location /csw {
+  <%- if @protected -%>
+  deny all;
+  auth_basic            "Enter the GOV.UK username/password (not your personal username/password)";
+  auth_basic_user_file  /etc/govuk.htpasswd;
+  satisfy any;
+  <%- end -%>
+
+  proxy_pass            http://localhost:<%= @pycsw_port %>;
+  proxy_set_header      Host             $host;
+  proxy_set_header      X-Real-IP        $remote_addr;
+  proxy_set_header      X-Forwarded-For  $proxy_add_x_forwarded_for;
+  proxy_set_header      X-Client-Verify  SUCCESS;
+  proxy_set_header      X-Client-DN      $ssl_client_s_dn;
+  proxy_set_header      X-SSL-Subject    $ssl_client_s_dn;
+  proxy_set_header      X-SSL-Issuer     $ssl_client_i_dn;
+  proxy_read_timeout    1800;
+  proxy_connect_timeout 1800;
+}

--- a/modules/govuk/templates/ckan/pycsw.cfg.erb
+++ b/modules/govuk/templates/ckan/pycsw.cfg.erb
@@ -1,0 +1,54 @@
+[server]
+home=/var/ckan
+url=http://localhost:<%= @pycsw_port %>/csw
+mimetype=application/xml; charset=UTF-8
+encoding=UTF-8
+language=en-GB
+maxrecords=10
+loglevel=INFO
+logfile=/var/log/ckan/pycsw.log
+gzip_compresslevel=9
+profiles=apiso
+
+[manager]
+transactions=false
+allowed_ips=127.0.0.1
+
+[metadata:main]
+identification_title=pycsw Geospatial Catalogue
+identification_abstract=pycsw is an OGC CSW server implementation written in Python
+identification_keywords=catalogue,discovery,metadata
+identification_keywords_type=theme
+identification_fees=None
+identification_accessconstraints=None
+provider_name=data.gov.uk
+provider_url=https://data.gov.uk/
+contact_name=Government Digital Service
+contact_position=Position Title
+contact_address=Mailing Address
+contact_city=City
+contact_stateorprovince=Administrative Area
+contact_postalcode=Zip or Postal Code
+contact_country=Country
+contact_phone=+xx-xxx-xxx-xxxx
+contact_fax=+xx-xxx-xxx-xxxx
+contact_email=you@example.org
+contact_url=https://data.gov.uk/support
+contact_hours=Hours of Service
+contact_instructions=During hours of service.  Off on weekends.
+contact_role=pointOfContact
+
+[repository]
+database=<%= "postgresql://#{@db_username}:#{@db_password}@#{@db_hostname}/#{@db_name}"%>
+table=records
+
+[metadata:inspire]
+enabled=true
+languages_supported=eng,gre
+default_language=eng
+date=YYYY-MM-DD
+gemet_keywords=Utility and governmental services
+conformity_service=notEvaluated
+contact_name=Government Digital Service
+contact_email=Email Address
+temp_extent=YYYY-MM-DD/YYYY-MM-DD


### PR DESCRIPTION
This is dependant on https://github.com/alphagov/ckanext-datagovuk/pull/187 being deployed

## What

Adds an additional `csw` endpoint for the ckan publishing stack in order to allow users to get `csw` data which datagovuk users have reported as being missing from the migration in January.

There are a number of changes that can be checked after puppet has completed the steps to set up `pycsw`:

- a cronjob will run to load data into the `pycsw` database, this will run at 6 each morning after the SOLR reindex
  - you could ssh onto the box and run `crontab -l` to check that the job is available and running at 6
  - if you want to also check if the job will run then extract the command out from `crontab` and run it on the terminal otherwise the numbers when checking the `csw` should be populated the next day and stay in sync with `ckan` database every day
  - the job takes about 4 hours to complete on 27,000 datasets, after the initial load each daily load should only take a few minutes.

- nginx update to allow `csw` to be accessible
  - after the cronjob has run some results should appear when going to https://ckan.integration.publishing.service.gov.uk/csw?service=CSW&version=2.0.2&request=GetRecords&typenames=csw:Record&elementsetname=brief

## Reference 

https://trello.com/c/RudwUlvN/1157-update-govuk-puppet-to-deploy-ckan-with-pycsw