### PR TITLE
Monitor application restarts due to memory usage

### DIFF
--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -346,6 +346,15 @@ define govuk::app::config (
       notes_url      => monitoring_docs_url(high-memory-for-application),
       contact_groups => $additional_check_contact_groups,
     }
+    @@icinga::check::graphite { "check_${title}_app_memory_restarts${::hostname}":
+      ensure         => $ensure,
+      target         => "summarize(stats_counts.govuk.app.${title}.memory_restarts, '1d', 'sum', false)",
+      warning        => 4,
+      critical       => 6,
+      desc           => 'Restarts per day due to excessive memory usage',
+      host_name      => $::fqdn,
+      contact_groups => $additional_check_contact_groups,
+    }
     if $alert_when_threads_exceed {
       @@icinga::check::graphite { "check_${title}_app_thread_count_${::hostname}":
         ensure         => $ensure,


### PR DESCRIPTION
Icinga will restart applications when they exceed the warning memory
usage. This has the potential to hide issues with application memory
usage, as the application can be repeatedly restarted.

If an application is being repeatedly restarted, it could be that the
memory usage profile has changed, and either that needs investigating
or the check threshold needs adjusting accordingly.

This commit adds a new check to spot when this is happening, by
looking at the number of times an application has been restarted on
the current day.

I've been looking at this as the Publishing API looks to be in this
situation currently, and is being restarted ~5 times a day (across all
machines).


## Restarts for the Publishing API over the last 3 months

![publishing-api-restarts-last-3-months](https://user-images.githubusercontent.com/1130010/62948157-c5786500-bddb-11e9-97f7-f5c9faa75ae3.png)
