### PR TITLE
Increase the Publishing API memory check thresholds

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -528,8 +528,8 @@ govuk::apps::publishing_api::redis_host: "redis-2.backend"
 govuk::apps::publishing_api::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::publishing_api::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 govuk::apps::publishing_api::govuk_content_schemas_path: '/data/apps/govuk-content-schemas/current'
-govuk::apps::publishing_api::nagios_memory_warning: 2000
-govuk::apps::publishing_api::nagios_memory_critical: 2500
+govuk::apps::publishing_api::nagios_memory_warning: 2500
+govuk::apps::publishing_api::nagios_memory_critical: 3000
 
 govuk::apps::release::db_hostname: "master.mysql"
 govuk::apps::release::db_username: "release"


### PR DESCRIPTION
The number of Unicorn workers was increased in [1], which looks to
have led to more memory being used (which seems to make
sense). Currently, the application is frequently being restarted by
Icinga, as the memory usage often exceeds the warning threshold.

To account for the increased memory usage, increase the
thresholds. Due to the application being frequently restarted, I'm not
sure what this should be set to, so just increase it a little bit.

1: c22812716cbdecd53367cf544d05dd3017d915ef


## Publishing API restarts over the last 3 months

![publishing-api-restarts-last-3-months](https://user-images.githubusercontent.com/1130010/62948193-d75a0800-bddb-11e9-9784-ae11869823a7.png)

## Publishing API memory usage over the last 3 months

![publishing-api-memory-usage-last-3-months](https://user-images.githubusercontent.com/1130010/62948294-ff496b80-bddb-11e9-8e2c-95a80cdfd358.png)
