### PR TITLE
Fix ownership of purged X-Ray home directory

### DIFF
--- a/modules/govuk_aws_xray_daemon/manifests/init.pp
+++ b/modules/govuk_aws_xray_daemon/manifests/init.pp
@@ -56,10 +56,9 @@ class govuk_aws_xray_daemon (
       ensure  => purge,
       recurse => true,
       force   => true,
-      owner   => 'xray',
-      group   => 'xray',
+      owner   => 'nobody',
+      group   => 'nogroup',
       mode    => '0750',
-      require => User['xray'],
     }
   } else {
     file { '/home/xray':


### PR DESCRIPTION
```
Error: /Stage[main]/Govuk_aws_xray_daemon/File[/home/xray]: Failed to generate additional resources using 'eval_generate': undefined method `each' for nil:NilClass
Error: Invalid user: xray
Error: /Stage[main]/Govuk_aws_xray_daemon/File[/home/xray]/ensure: change from absent to link failed: Invalid user: xray
```

We'll get there eventually.