### PR TITLE
Ignore missing application restart data for the Icinga check

### DIFF
--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -353,6 +353,7 @@ define govuk::app::config (
     @@icinga::check::graphite { "check_${title}_app_memory_restarts${::hostname}":
       ensure         => $ensure,
       target         => "summarize(stats_counts.govuk.app.${title}.memory_restarts, '1d', 'sum', false)",
+      args           => '--ignore-missing',
       warning        => 4,
       critical       => 6,
       desc           => 'Restarts per day due to excessive memory usage',


### PR DESCRIPTION
The data in Graphite will be missing if the application has never been
restarted due to using too much memory. Without this, the check is
UNKNOWN, but with this change it's OK.

This could mask the reporting breaking, but there's no easy way to
avoid that.