### PR TITLE
Fix the time period and quotes for the memory restarts check

### DIFF
--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -352,8 +352,9 @@ define govuk::app::config (
     }
     @@icinga::check::graphite { "check_${title}_app_memory_restarts${::hostname}":
       ensure         => $ensure,
-      target         => "summarize(stats_counts.govuk.app.${title}.memory_restarts, '1d', 'sum', false)",
+      target         => "summarize(stats_counts.govuk.app.${title}.memory_restarts,\"1d\",\"sum\",false)",
       args           => '--ignore-missing',
+      from           => '2days',
       warning        => 4,
       critical       => 6,
       desc           => 'Restarts per day due to excessive memory usage',


### PR DESCRIPTION
The single quotes were potentially causing issues with the check, as
the whole target is quoted. Also increase the time period, as that was
also leading to Graphite returning an error.