### PR TITLE
 Increase ClamAV size limits to match upload size limits

### DIFF
--- a/modules/clamav/files/etc/clamd.conf
+++ b/modules/clamav/files/etc/clamd.conf
@@ -16,8 +16,8 @@ ScanOLE2 yes
 OLE2BlockMacros no
 ScanPDF yes
 ScanMail yes
-MaxScanSize 100M
-MaxFileSize 30M
+MaxScanSize 250M
+MaxFileSize 105M
 
 # Explicitly set to avoid libpam-tmpdir if started from a login shell and
 # without the use of `/usr/sbin/service`, as Puppet does.

--- a/modules/licensify/templates/licensify-upload-vhost-aws.conf
+++ b/modules/licensify/templates/licensify-upload-vhost-aws.conf
@@ -18,7 +18,11 @@ server {
      return 444;
   }
 
-  # Handle larger upload sizes
+  # Handle larger upload sizes.
+  #
+  # WARNING: If you increase this, also increase the limits in
+  #          modules/clamav/files/etc/clamd.conf accordingly.
+  #
   client_max_body_size 100M;
 
   location / {

--- a/modules/licensify/templates/licensify-upload-vhost.conf
+++ b/modules/licensify/templates/licensify-upload-vhost.conf
@@ -28,7 +28,11 @@ server {
      return 444;
   }
 
-  # Handle larger upload sizes
+  # Handle larger upload sizes.
+  #
+  # WARNING: If you increase this, also increase the limits in
+  #          modules/clamav/files/etc/clamd.conf accordingly.
+  #
   client_max_body_size 100M;
 
   location / {


### PR DESCRIPTION
As of b7a26a2, we increased the max upload size in nginx from 30 to 100
MB. This increases clamd's size limits accordingly.

The 5 MB margin is to account for the ambiguity as to whether nginx's
"M" suffix refers to powers of 2 or powers of 10. (I wasn't able to find
an authoritative answer to this.)