### PR TITLE
Revert "Fix exposed user list from ckan"

### DIFF
--- a/modules/govuk/manifests/apps/ckan.pp
+++ b/modules/govuk/manifests/apps/ckan.pp
@@ -146,16 +146,6 @@ class govuk::apps::ckan (
         value   => $bulk_worker_processes;
     }
 
-    govuk::app { 'ckan':
-      enable_nginx_vhost => false,
-    }
-
-    govuk::app::nginx_vhost { 'ckan':
-      vhost       => 'ckan',
-      app_port    => $port,
-      hidden_path => ['/api/3/action/user_list'],
-    }
-
     file { $ckan_home:
       ensure => directory,
       owner  => 'deploy',


### PR DESCRIPTION
Reverts alphagov/govuk-puppet#9447

`hidden_path` should be `hidden_paths`