### PR TITLE
add licensify apps to deploy_node_apps job

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -131,7 +131,13 @@ govuk_java::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 govuk_jenkins::deploy_all_apps::apps_on_nodes:
   <<: *node_class
-
+  licensing_frontend:
+    apps:
+      - licensify
+  licensing_backend:
+    apps:
+      - licensify-admin
+      - licensify-feed
 
 # If the repository name is the same as the application name
 # we don't need to explicitly declare the repository, but we


### PR DESCRIPTION
# Context

Licensify is being migrated to AWS, hence there is a need to add the licensify apps as being deployable by the deploy_node_apps jobs.

# Decisions
1. add the licensify apps in the list of deploy_node_apps jobs. 


Co-Authored-By: Chris <sengi@users.noreply.github.com>