### PR TITLE
Increase the memory thresholds for the Content Store

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -436,8 +436,8 @@ govuk::apps::content_publisher::aws_region: "eu-west-1"
 govuk::apps::content_publisher::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::content_publisher::redis_port: "%{hiera('sidekiq_port')}"
 
-govuk::apps::content_store::nagios_memory_warning: 2600
-govuk::apps::content_store::nagios_memory_critical: 2800
+govuk::apps::content_store::nagios_memory_warning: 3000
+govuk::apps::content_store::nagios_memory_critical: 3800
 govuk::apps::content_store::unicorn_worker_processes: "12"
 
 govuk::apps::content_tagger::db_hostname: "postgresql-primary"


### PR DESCRIPTION
It's frequently (multiple times a day across all machines) exceeding
the warning threshold for memory usage. The machines it's running on
have memory to spare (they have 8GB), so increase the threshold to see
if the memory usage stabilises.