### PR TITLE
Set higher memory thresholds for the Local Links Manager

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -237,6 +237,8 @@ task :check_consistency_between_aws_and_carrenza do
     govuk::apps::local_links_manager::db::allow_auth_from_lb
     govuk::apps::local_links_manager::db::lb_ip_range
     govuk::apps::local_links_manager::db::rds
+    govuk::apps::local_links_manager::nagios_memory_critical
+    govuk::apps::local_links_manager::nagios_memory_warning
     govuk::apps::publisher::alert_hostname
     govuk::apps::publishing_api::db::allow_auth_from_lb
     govuk::apps::publishing_api::db::lb_ip_range

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -577,6 +577,8 @@ govuk::apps::local_links_manager::db::lb_ip_range: "%{hiera('environment_ip_pref
 govuk::apps::local_links_manager::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::local_links_manager::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::local_links_manager::unicorn_worker_processes: "4"
+govuk::apps::local_links_manager::nagios_memory_warning: 1000
+govuk::apps::local_links_manager::nagios_memory_critical: 1500
 
 govuk::apps::mapit::enabled: true
 


### PR DESCRIPTION
It's frequently exceeding the default warning threshold (of 700), so
increase it a bit, as the backend machines look to have sufficient
memory.