### PR TITLE
Add a timed trigger for data_sync_complete_integration

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
@@ -13,6 +13,10 @@
       - build-discarder:
           days-to-keep: 30
           artifact-num-to-keep: 5
+    triggers:
+      - timed: |
+            TZ=Europe/London
+            H 7 * * 1-5
     builders:
        - shell: |
            # Clear the Sidekiq queues to stop any residual 'stale' jobs running


### PR DESCRIPTION
- The Data_sync_complete job is supposed to run on the integration Jenkins after the
Copy_data_to_integration completes on the production Jenkins. It cleans
up some files and queues and removes a number of warnings/criticals for
Whitehall and publisher in integration.

- There is some race condition in place which requires a re-run of the
Data_sync_complete job in the morning in order to get Whitehall queues
in working order.

- As a workaround, this commit adds a timed trigger to the job to avoid
the need for manual interaction to silence alarms.

solo: @schmie