### PR TITLE
add licensify apps to deploy_app jenkins job

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -180,6 +180,9 @@ deployable_applications: &deployable_applications
   info-frontend: {}
   licencefinder:
     repository: 'licence-finder'
+  licensify: {}
+  licensify-admin: {}
+  licensify-feed: {}
   link-checker-api: {}
   local-links-manager: {}
   manuals-frontend: {}


### PR DESCRIPTION
# Context

Licensify is being migrated to AWS, hence there is a need to add the licensify apps as being deployable by the deploy_app jobs.

# Decisions
1. add the licensify apps in the list of deploy_app jobs. 

Co-Authored-By: Chris <sengi@users.noreply.github.com>