### PR TITLE
Change Ecommerce scheduled job to import data into GA

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -352,6 +352,7 @@ task :check_consistency_between_aws_and_carrenza do
     govuk_jenkins::jobs::data_sync_complete_production::signon_domains_to_migrate
     govuk_jenkins::jobs::search_fetch_analytics_data::cron_schedule
     govuk_jenkins::jobs::search_fetch_analytics_data::skip_page_traffic_load
+    govuk_jenkins::jobs::enhanced_ecommerce_search_api::cron_schedule
     govuk_jenkins::jobs::smokey::environment
     govuk_mysql::server::expire_log_days
     govuk_mysql::server::slow_query_log

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -97,8 +97,6 @@ govuk_jenkins::jobs::deploy_dns::gce_project_id: 'govuk-integration'
 govuk_jenkins::jobs::search_benchmark::cron_schedule: '30 9 * * 1-5'
 govuk_jenkins::jobs::search_test_spelling_suggestions::cron_schedule: '0 10 * * 1-5'
 
-govuk_jenkins::jobs::enhanced_ecommerce_search_api::cron_schedule: '30 9 * * 1-5'
-
 govuk_jenkins::jobs::search_api_fetch_analytics_data::skip_page_traffic_load: true
 govuk_jenkins::jobs::search_api_fetch_analytics_data::cron_schedule: '30 9 * * 1-5'
 

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -156,6 +156,8 @@ govuk::apps::travel_advice_publisher::enable_email_alerts: true
 govuk_search::monitoring::es_port: '80'
 govuk_search::monitoring::es_host: 'elasticsearch5.blue.production.govuk-internal.digital'
 
+govuk_jenkins::jobs::enhanced_ecommerce_search_api::cron_schedule: '0 6 * * 1-5' # Every weekday at 6am
+
 govuk::deploy::aws_ses_smtp_host: 'email-smtp.eu-west-1.amazonaws.com'
 govuk::deploy::config::errbit_environment_name: 'production'
 govuk::deploy::config::website_root: 'https://www.gov.uk'

--- a/hieradata_aws/training.yaml
+++ b/hieradata_aws/training.yaml
@@ -107,8 +107,6 @@ govuk_jenkins::jobs::deploy_dns::gce_project_id: 'govuk-training'
 govuk_jenkins::jobs::search_benchmark::cron_schedule: '30 9 * * 1-5'
 govuk_jenkins::jobs::search_test_spelling_suggestions::cron_schedule: '0 10 * * 1-5'
 
-govuk_jenkins::jobs::enhanced_ecommerce_search_api::cron_schedule: '30 9 * * 1-5'
-
 govuk_jenkins::jobs::search_api_fetch_analytics_data::skip_page_traffic_load: true
 govuk_jenkins::jobs::search_api_fetch_analytics_data::cron_schedule: '30 9 * * 1-5'
 

--- a/modules/govuk_jenkins/manifests/jobs/enhanced_ecommerce_search_api.pp
+++ b/modules/govuk_jenkins/manifests/jobs/enhanced_ecommerce_search_api.pp
@@ -7,11 +7,11 @@ class govuk_jenkins::jobs::enhanced_ecommerce_search_api (
   $auth_username = undef,
   $auth_password = undef,
   $rate_limit_token = undef,
-  $cron_schedule = '0 5 * * *'
+  $cron_schedule = undef
 ) {
 
   $job_name = 'enhanced_ecommerce_search_api'
-  $service_description = 'Export Enhanced Ecommerce data from Search API'
+  $service_description = 'Enhanced Ecommerce ETL from Search API to Google Analytics'
   $job_url = "https://deploy.${app_domain}/job/enhanced_ecommerce_search_api/"
   $target_application = 'search-api'
 

--- a/modules/govuk_jenkins/templates/jobs/enhanced_ecommerce.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/enhanced_ecommerce.yaml.erb
@@ -15,13 +15,7 @@
             predefined-parameters: |
               TARGET_APPLICATION=<%= @target_application %>
               MACHINE_CLASS=search
-              RAKE_TASK="analytics:create_data_import_csv[/data/export/enhanced_ecommerce]"
-          - project: run-rake-task
-            block: true
-            predefined-parameters: |
-              TARGET_APPLICATION=<%= @target_application %>
-              MACHINE_CLASS=search
-              RAKE_TASK="analytics:delete_old_files[/data/export/enhanced_ecommerce,10]"
+              RAKE_TASK=analytics:export_indexed_pages_to_google_analytics
     triggers:
         - timed: '<%= @cron_schedule %>'
     publishers:


### PR DESCRIPTION
This changes the existing ecommerce job to use a new rake task `analytics:export_indexed_pages_to_google_analytics`.

This exports data from Search API indices and imports it into Google Analytics. The scheduled job will be run in production only.

The job can still be run in integration for testing purposes, but doesn't run on a schedule.

Trello: https://trello.com/c/xJP8a5KE/905