### PR TITLE
Increase CPU thresholds for finder-frontend

### DIFF
--- a/modules/govuk/manifests/apps/finder_frontend.pp
+++ b/modules/govuk/manifests/apps/finder_frontend.pp
@@ -46,6 +46,8 @@ class govuk::apps::finder_frontend(
       nagios_memory_warning    => $nagios_memory_warning,
       nagios_memory_critical   => $nagios_memory_critical,
       unicorn_worker_processes => $unicorn_worker_processes,
+      cpu_warning              => 175,
+      cpu_critical             => 225,
     }
   }
 


### PR DESCRIPTION
It often goes over this threshold and alerts but without anyone needing to do anything. Therefore it should be pretty safe to increase these thresholds.

Example:

https://graphite.staging.govuk.digital/render/?width=1000&height=600&colorList=red,orange,blue,green,purple,brown&target=alias(dashed(constantLine(200)),%22critical%22)&target=alias(dashed(constantLine(150)),%22warning%22)&target=scale(sumSeries(calculators_frontend-ip-10-12-4-39_eu-west-1_compute_internal.processes-app-finder-frontend.ps_cputime.*),0.0001)&from=-2weeks

[Trello Card](https://trello.com/c/Fvon4qgQ/1197-high-cpu-usage-for-finder-frontend-app)