### PR TITLE
Licensify

### DIFF
--- a/hieradata_aws/class/licensing_backend.yaml
+++ b/hieradata_aws/class/licensing_backend.yaml
@@ -1,0 +1,8 @@
+---
+licensify::apps::certs::services_to_notify:
+  - licensify-admin
+  - licensify-feed
+
+licensify::apps::configfile::services_to_notify:
+  - licensify-admin
+  - licensify-feed

--- a/hieradata_aws/class/licensing_frontend.yaml
+++ b/hieradata_aws/class/licensing_frontend.yaml
@@ -1,0 +1,6 @@
+---
+licensify::apps::certs::services_to_notify:
+  - licensify
+
+licensify::apps::configfile::services_to_notify:
+  - licensify

--- a/modules/licensify/manifests/apps/certs.pp
+++ b/modules/licensify/manifests/apps/certs.pp
@@ -1,0 +1,45 @@
+# == Class: licensify::apps::certs
+#
+# Creates the appropriate certificates for licensify apps to work properly.
+#
+#
+# === Parameters
+#
+# [*java_cacerts*]
+#   CA certificates for JAVA
+#   Type: base64
+#   Default: undef
+#
+# [*licensing_cacerts*]
+#   CA certificates for Licensify Apps
+#   Type: base64
+#   Default: undef
+#
+# [*services_to_notify*]
+#   list of services to notify when the certs file are modified
+#   Type: array of string name of services
+#   Default: undef
+#
+class licensify::apps::certs(
+  $java_cacerts = undef,
+  $licensing_cacerts = undef,
+  $services_to_notify = [],
+){
+    file { '/etc/licensing/cacerts_java8':
+      ensure  => file,
+      content => base64('decode',$java_cacerts),
+      mode    => '0644',
+      owner   => 'deploy',
+      group   => 'deploy',
+      notify  => Service[$services_to_notify],
+    }
+
+    file { '/etc/licensing/cacerts_licensing':
+      ensure  => file,
+      content => base64('decode',$licensing_cacerts),
+      mode    => '0644',
+      owner   => 'deploy',
+      group   => 'deploy',
+      notify  => Service[$services_to_notify],
+    }
+}

--- a/modules/licensify/manifests/apps/configfile.pp
+++ b/modules/licensify/manifests/apps/configfile.pp
@@ -37,6 +37,7 @@ class licensify::apps::configfile(
   $performance_platform_service_url = undef,
   $notify_key_api = undef,
   $is_master_node = true,
+  $services_to_notify = [],
 ) {
   file { '/etc/licensing/gds-licensing-config.properties':
     ensure  => file,
@@ -44,5 +45,6 @@ class licensify::apps::configfile(
     mode    => '0644',
     owner   => 'deploy',
     group   => 'deploy',
+    notify  => Service[$services_to_notify],
   }
 }

--- a/modules/licensify/manifests/apps/licensify.pp
+++ b/modules/licensify/manifests/apps/licensify.pp
@@ -73,13 +73,17 @@ class licensify::apps::licensify (
     # On AWS we need Puppet to create the app's config files (whereas on
     # Carrenza/UKCloud the deploy.sh script copies them verbatim from the
     # legacy alphagov-deployments private repo).
+
     include licensify::apps::configfile
+    include licensify::apps::certs
+
     file { '/etc/licensing/gds-licensify-config.conf':
       ensure  => file,
       content => template('licensify/gds-licensify-config.conf.erb'),
       mode    => '0644',
       owner   => 'deploy',
       group   => 'deploy',
+      notify  => Service['licensify'],
     }
   }
 

--- a/modules/licensify/manifests/apps/licensify_admin.pp
+++ b/modules/licensify/manifests/apps/licensify_admin.pp
@@ -67,13 +67,17 @@ class licensify::apps::licensify_admin(
     # On AWS we need Puppet to create the app's config files (whereas on
     # Carrenza/UKCloud the deploy.sh script copies them verbatim from the
     # legacy alphagov-deployments private repo).
+
     include licensify::apps::configfile
+    include licensify::apps::certs
+
     file { '/etc/licensing/gds-licensify-admin-config.conf':
       ensure  => file,
       content => template('licensify/gds-licensify-admin-config.conf.erb'),
       mode    => '0644',
       owner   => 'deploy',
       group   => 'deploy',
+      notify  => Service['licensify-admin'],
     }
   }
 }

--- a/modules/licensify/manifests/apps/licensify_feed.pp
+++ b/modules/licensify/manifests/apps/licensify_feed.pp
@@ -73,13 +73,17 @@ class licensify::apps::licensify_feed(
     # On AWS we need Puppet to create the app's config files (whereas on
     # Carrenza/UKCloud the deploy.sh script copies them verbatim from the
     # legacy alphagov-deployments private repo).
+
     include licensify::apps::configfile
+    include licensify::apps::certs
+
     file { '/etc/licensing/gds-licensify-feed-config.conf':
       ensure  => file,
       content => template('licensify/gds-licensify-feed-config.conf.erb'),
       mode    => '0644',
       owner   => 'deploy',
       group   => 'deploy',
+      notify  => Service['licensify-feed'],
     }
   }
 }


### PR DESCRIPTION
# Context

As part of the AWS migration of licensify, we need to find a way to put the certs required onto the licensing nodes. This was done by the deprecated alphagov_deployment in UKCloud. Here, it is done by hiera.

Another fix of this PR is to restart the relevant licensify app if one of its dependent config file has changed.

The secret counterpart of this PR is: https://github.com/alphagov/govuk-secrets/pull/775

# Decisions
1. lay down the `cacert_java8` and `cacert_licensing` via puppet and stored in secret hiera in base64.
2. add the functionality to restart apps when their dependent config files has changed. This is would have been done by the deprecated alphagov_deployment

# Notes
The reference to an array does not seem to work using the functionality `alias` in the hiera version that we have.