### PR TITLE
Add missing parameters to CKAN Nginx vhost

### DIFF
--- a/modules/govuk/manifests/apps/ckan.pp
+++ b/modules/govuk/manifests/apps/ckan.pp
@@ -149,8 +149,11 @@ class govuk::apps::ckan (
 
     govuk::app::nginx_vhost { 'ckan':
       vhost              => 'ckan',
+      protected          => $vhost_protected,
+      ssl_only           => true,
       app_port           => $port,
       hidden_paths       => ['/api/'],
+      read_timeout       => $request_timeout,
       nginx_extra_config => template('govuk/ckan/nginx.conf.erb'),
     }
 


### PR DESCRIPTION
When we pulled the vhost out into a separate resource, some of the custom configuration options had been lost. This is because usually the `govuk::app::config` class creates the Nginx vhost and automatically passes they custom options down into the resource.

Most notable is the `read_timeout` which I think may have prevented users from uploading large data sets (organograms), and `protected` which means we lost our normal integration password protection for CKAN.