### PR TITLE
Add cron jobs to manage gor during data sync

### DIFF
--- a/modules/govuk_gor/manifests/init.pp
+++ b/modules/govuk_gor/manifests/init.pp
@@ -41,10 +41,26 @@ class govuk_gor(
 
   validate_bool($enable)
 
-  file { '/etc/govuk/env.d/FACTER_data_sync_in_progress':
+  $data_sync_fact_path = '/etc/govuk/env.d/FACTER_data_sync_in_progress'
+
+  file { $data_sync_fact_path:
     ensure  => present,
     owner   => 'deploy',
     require => Class['govuk::deploy'],
+  }
+
+  cron { 'stop_gor':
+    command => "echo 'true' > ${data_sync_fact_path}; sudo initctl stop gor",
+    user    => 'deploy',
+    hour    => 23,
+    minute  => 0,
+  }
+
+  cron { 'start_gor':
+    command => "echo '' > ${$data_sync_fact_path}; sudo initctl start gor;",
+    user    => 'deploy',
+    hour    => 5,
+    minute  => 45,
   }
 
   if $enable and ! $::data_sync_in_progress {


### PR DESCRIPTION
We manage traffic replay with our puppet class `govuk_gor`, which
we would like to be disabled when our `govuk_env_sync` data sync
`pull` jobs happen. They currently take place between 23:15 and 5:30.

Setting the Puppet `data_sync_in_progress` fact to `true` ensures
that Puppet does not try to run traffic replay until all the data
sync jobs have completed. This should reduce noise and unnecessary
errors appearing in Sentry.

Trello card: https://trello.com/c/tfBZywz4/1188-disable-the-traffic-replay-to-integration-and-staging-during-data-replication