### PR TITLE
Add DocumentDB Hieradata to Cache and Draft Cache Machines

### DIFF
--- a/hieradata_aws/class/integration/cache.yaml
+++ b/hieradata_aws/class/integration/cache.yaml
@@ -1,3 +1,8 @@
 ---
 logrotate::conf::days_to_keep: 7
 nginx::logging::days_to_keep: 7
+
+govuk::apps::router::mongodb_username: "master"
+govuk::apps::router::mongodb_params: "ssl=true"
+govuk::apps::router::mongodb_nodes:
+  - 'documentdb-integration.cluster-ceu7s3y9xx35.eu-west-1.docdb.amazonaws.com'

--- a/hieradata_aws/class/integration/draft_cache.yaml
+++ b/hieradata_aws/class/integration/draft_cache.yaml
@@ -1,0 +1,11 @@
+---
+govuk::apps::router::mongodb_username: "master"
+govuk::apps::router::mongodb_params: "ssl=true"
+govuk::apps::router::mongodb_nodes:
+  - 'documentdb-integration.cluster-ceu7s3y9xx35.eu-west-1.docdb.amazonaws.com'
+
+govuk::apps::router_api::mongodb_password: "%{hiera('govuk::apps::router::mongodb_password')}"
+govuk::apps::router_api::mongodb_username: "master"
+govuk::apps::router_api::mongodb_params: "ssl=true"
+govuk::apps::router_api::mongodb_nodes:
+  - 'documentdb-integration.cluster-ceu7s3y9xx35.eu-west-1.docdb.amazonaws.com'

--- a/hieradata_aws/class/integration/router_backend.yaml
+++ b/hieradata_aws/class/integration/router_backend.yaml
@@ -21,3 +21,9 @@ govuk_env_sync::tasks:
     temppath: "/tmp/.dumps"
     url: "govuk-integration-database-backups"
     path: "mongo-router"
+
+govuk::apps::router_api::mongodb_password: "%{hiera('govuk::apps::router::mongodb_password')}"
+govuk::apps::router_api::mongodb_username: "master"
+govuk::apps::router_api::mongodb_params: "ssl=true"
+govuk::apps::router_api::mongodb_nodes:
+  - 'documentdb-integration.cluster-ceu7s3y9xx35.eu-west-1.docdb.amazonaws.com'

--- a/modules/govuk/manifests/app/envvar/mongodb_uri.pp
+++ b/modules/govuk/manifests/app/envvar/mongodb_uri.pp
@@ -35,13 +35,12 @@ define govuk::app::envvar::mongodb_uri (
 
   $hosts_string = join($hosts, ',')
 
-  $auth = ''
   if ($username != '') {
     $auth = "${username}:${password}@"
   }
 
   if ($params != '') {
-    $args = "?${args}"
+    $args = "?${params}"
   }
 
   govuk::app::envvar { "${title}-MONGODB_URI":

--- a/modules/govuk/spec/defines/govuk__app__envvar__mongodb_uri_spec.rb
+++ b/modules/govuk/spec/defines/govuk__app__envvar__mongodb_uri_spec.rb
@@ -17,6 +17,39 @@ describe 'govuk::app::envvar::mongodb_uri', :type => :define do
     end
   end
 
+  context "with username and password" do
+    let(:params) {{
+      :hosts => ["db-1.example.com", "db-2.example.com"],
+      :database => "foo_production",
+      :username => "jeff",
+      :password => "secret",
+    }}
+
+    it "constructs a MONGODB_URI env var with authentication" do
+      expect(subject).to contain_govuk__app__envvar('giraffe-MONGODB_URI')
+        .with_app('giraffe')
+        .with_varname('MONGODB_URI')
+        .with_value('mongodb://jeff:secret@db-1.example.com,db-2.example.com/foo_production')
+    end
+  end
+
+  context "with params" do
+    let(:params) {{
+      :hosts => ["db-1.example.com", "db-2.example.com"],
+      :database => "foo_production",
+      :username => "jeff",
+      :password => "secret",
+      :params => "ssl=true"
+    }}
+
+    it "constructs a MONGODB_URI env var with auth and ssl param" do
+      expect(subject).to contain_govuk__app__envvar('giraffe-MONGODB_URI')
+        .with_app('giraffe')
+        .with_varname('MONGODB_URI')
+        .with_value('mongodb://jeff:secret@db-1.example.com,db-2.example.com/foo_production?ssl=true')
+    end
+  end
+
   context "validating hosts" do
     let(:params) {{
       :database => "foo_production",


### PR DESCRIPTION
This extra hieradata is needed for the Router app to connect
to the AWS DocumentDB cluster.