### PR TITLE
Increase licensify 5xx rate in staging

### DIFF
--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -522,6 +522,8 @@ hosts::production::router::hosts:
 licensify::apps::licensify_admin::environment: 'staging'
 licensify::apps::licensify::environment: 'staging'
 licensify::apps::licensify_feed::environment: 'staging'
+licensify::apps::licensify::alert_5xx_warning_rate: 0.1
+licensify::apps::licensify::alert_5xx_critical_rate: 0.15
 
 monitoring::checks::aws_origin_domain: "staging.govuk.digital"
 monitoring::checks::sidekiq::enable_support_check: false

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -222,6 +222,8 @@ grafana::dashboards::machine_suffix_metrics: '_staging'
 licensify::apps::licensify_admin::environment: 'staging'
 licensify::apps::licensify::environment: 'staging'
 licensify::apps::licensify_feed::environment: 'staging'
+licensify::apps::licensify::alert_5xx_warning_rate: 0.1
+licensify::apps::licensify::alert_5xx_critical_rate: 0.15
 
 monitoring::checks::aws_origin_domain: "staging.govuk.digital"
 monitoring::checks::datagovuk_publish::ensure: 'present'

--- a/modules/licensify/manifests/apps/licensify.pp
+++ b/modules/licensify/manifests/apps/licensify.pp
@@ -43,6 +43,8 @@ class licensify::apps::licensify (
   $environment = '',
   $application_secret = undef,
   $ws_accept_any_certificate = false,
+  $alert_5xx_warning_rate = 0.05,
+  $alert_5xx_critical_rate = 0.1,
 ) inherits licensify::apps::base {
 
   govuk::app { 'licensify':
@@ -56,6 +58,8 @@ class licensify::apps::licensify (
     collectd_process_regex         => 'java -Duser.dir=\/data\/vhost\/licensify\..*publishing\.service\.gov\.uk\/licensify-.*',
     nagios_memory_warning          => 1350,
     nagios_memory_critical         => 1500,
+    alert_5xx_warning_rate         => $alert_5xx_warning_rate,
+    alert_5xx_critical_rate        => $alert_5xx_critical_rate,
   }
 
   licensify::apps::envvars { 'licensify':


### PR DESCRIPTION
We're seeing a problem where the 5xx alert often triggers in staging. We think this is related to the app not handling errors properly.

Unfortunately it's unlikely we'll be able to prioritise work in this area any time soon so I thought it was best to increase the thresholds to stop it alerting.

[Trello Card](https://trello.com/c/meGHQtfV/618-%F0%9F%93%88-licensify-staging-frontend-5xx-rate-too-high)