### PR TITLE
add mongodb shell and tools to licensing_frontend

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -692,6 +692,10 @@ govuk::node::s_db_admin::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 govuk::node::s_graphite::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
+govuk::node::s_licensing_backend::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+
+govuk::node::s_licensing_frontend::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+
 govuk::node::s_licensify_lb::backend_app_servers:
   - 'licensing-backend-1.licensify'
   - 'licensing-backend-2.licensify'

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -829,6 +829,10 @@ govuk::node::s_gatling::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 govuk::node::s_graphite::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
+govuk::node::s_licensing_backend::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+
+govuk::node::s_licensing_frontend::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+
 govuk::node::s_licensify_lb::backend_app_servers:
   - 'licensing-backend'
   - 'licensing-backend'

--- a/modules/govuk/manifests/node/s_db_admin.pp
+++ b/modules/govuk/manifests/node/s_db_admin.pp
@@ -37,6 +37,22 @@ class govuk::node::s_db_admin(
     $ensure = 'absent'
   }
 
+  apt::source { 'mongodb32':
+    location     => "http://${apt_mirror_hostname}/mongodb3.2",
+    release      => 'trusty-mongodb-org-3.2',
+    architecture => $::architecture,
+    repos        => 'multiverse',
+    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+  }
+
+  package { 'mongodb-org-shell':
+    ensure  => latest,
+  }
+
+  package { 'mongodb-org-tools':
+    ensure  => latest,
+  }
+
   apt::source { 'gof3r':
     ensure       => $ensure,
     location     => "http://${apt_mirror_hostname}/gof3r",

--- a/modules/govuk/manifests/node/s_licensing_backend.pp
+++ b/modules/govuk/manifests/node/s_licensing_backend.pp
@@ -2,7 +2,14 @@
 #
 # Sets up app servers for the licensing backend
 #
-class govuk::node::s_licensing_backend inherits govuk::node::s_base {
+# === Parameters:
+#
+# [*apt_mirror_hostname*]
+#   The hostname of the local aptly mirror.
+#
+class govuk::node::s_licensing_backend (
+  $apt_mirror_hostname,
+) inherits govuk::node::s_base {
   include clamav
 
   include govuk_java::openjdk8::jdk
@@ -24,4 +31,20 @@ class govuk::node::s_licensing_backend inherits govuk::node::s_base {
   }
 
   include nginx
+
+  apt::source { 'mongodb32':
+    location     => "http://${apt_mirror_hostname}/mongodb3.2",
+    release      => 'trusty-mongodb-org-3.2',
+    architecture => $::architecture,
+    repos        => 'multiverse',
+    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+  }
+
+  package { 'mongodb-org-shell':
+    ensure  => latest,
+  }
+
+  package { 'mongodb-org-tools':
+    ensure  => latest,
+  }
 }

--- a/modules/govuk/manifests/node/s_licensing_frontend.pp
+++ b/modules/govuk/manifests/node/s_licensing_frontend.pp
@@ -2,7 +2,14 @@
 #
 # Sets up app servers for the licensing frontend
 #
-class govuk::node::s_licensing_frontend inherits govuk::node::s_base {
+# === Parameters:
+#
+# [*apt_mirror_hostname*]
+#   The hostname of the local aptly mirror.
+#
+class govuk::node::s_licensing_frontend (
+  $apt_mirror_hostname,
+) inherits govuk::node::s_base {
   include clamav
 
   include govuk_java::openjdk8::jdk
@@ -22,4 +29,20 @@ class govuk::node::s_licensing_frontend inherits govuk::node::s_base {
   }
 
   include nginx
+
+  apt::source { 'mongodb32':
+    location     => "http://${apt_mirror_hostname}/mongodb3.2",
+    release      => 'trusty-mongodb-org-3.2',
+    architecture => $::architecture,
+    repos        => 'multiverse',
+    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+  }
+
+  package { 'mongodb-org-shell':
+    ensure  => latest,
+  }
+
+  package { 'mongodb-org-tools':
+    ensure  => latest,
+  }
 }


### PR DESCRIPTION
# Context

As part of the AWS migration of licensify, there is a need for some mongodb tools on the licensing machines as well as the db_admin machines.

# Decisions
1. install mongodb shell and tools on the licensing_frontend, licensing_backend and db_admin