### PR TITLE
Add Jenkins job for deploying the developer docs

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/deploy_docs.pp
+++ b/modules/govuk_jenkins/manifests/jobs/deploy_docs.pp
@@ -1,0 +1,26 @@
+# == Class: govuk_jenkins::jobs::deploy_docs
+#
+# Create a file on disk that can be parsed by jenkins-job-builder
+#
+class govuk_jenkins::jobs::deploy_docs (
+  $github_token = undef,
+  $aws_access_key_id = undef,
+  $aws_secret_access_key = undef,
+  $app_domain = hiera('app_domain'),
+) {
+  $service_description = 'Deploy the developer docs to S3'
+
+  file { '/etc/jenkins_jobs/jobs/deploy_docs.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/deploy_docs.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+
+  @@icinga::passive_check {
+    "deploy_developer_docs_${::hostname}":
+      service_description => $service_description,
+      host_name           => $::fqdn,
+      freshness_threshold => 5400, # 90 minutes
+      action_url          => "https://deploy.${app_domain}/job/deploy-developer-docs/";
+  }
+}

--- a/modules/govuk_jenkins/templates/jobs/deploy_docs.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_docs.yaml.erb
@@ -1,0 +1,55 @@
+---
+- scm:
+    name: govuk-developer-docs-repo
+    scm:
+      - git:
+          url: git@github.com:alphagov/govuk-developer-docs.git
+          basedir: govuk-developer-docs
+          branches:
+            - master
+- job:
+    name: deploy-developer-docs
+    display-name: Deploy GOV.UK developer docs
+    project-type: freestyle
+    description: |
+      Builds and publishes the GOV.UK developer docs. Does so every hour so
+      that changes in other repos are picked up.
+    scm:
+      - govuk-developer-docs-repo
+    logrotate:
+      numToKeep: 10
+      artifactDaysToKeep: 3
+    triggers:
+      - timed: '0 9-19 * * 1-5' # Between 9am and 7pm on weekdays
+    properties:
+      - build-discarder:
+          days-to-keep: 30
+          artifact-num-to-keep: 5
+    builders:
+      - shell: |
+        ./bin/deploy-to-s3
+    publishers:
+      - trigger-parameterized-builds:
+        - project: Success_Passive_Check
+          condition: 'SUCCESS'
+          predefined-parameters: |
+            NSCA_CHECK_DESCRIPTION=<%= @service_description %>
+            NSCA_OUTPUT=<%= @service_description %> success
+        - project: Failure_Passive_Check
+          condition: 'FAILED'
+          predefined-parameters: |
+            NSCA_CHECK_DESCRIPTION=<%= @service_description %>
+            NSCA_OUTPUT=<%= @service_description %> failed
+    wrappers:
+      - ansicolor:
+          colormap: xterm
+      - inject-passwords:
+          global: false
+          mask-password-params: true
+          job-passwords:
+            - name: GITHUB_TOKEN
+              password: '<%= @github_token %>'
+            - name: AWS_ACCESS_KEY_ID
+              password: '<%= @aws_access_key_id %>'
+            - name: AWS_SECRET_ACCESS_KEY
+              password: '<%= @aws_secret_access_key %>'


### PR DESCRIPTION
The job to build and deploy the developer docs is currently managed manually in Jenkins. This is of course bad, but I never got around to doing it the right way.

Managing it in puppet is better because it's versioned, we can keep the secrets outside of the logs, and we get Icinga alerts when the build fails.

Before this is merged I'll have to add the GitHub/AWS credentials to govuk-secrets.