### PR TITLE
Remove ineffective gor commands

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_staging.yaml.erb
@@ -49,19 +49,9 @@
 
             set +e
 
-            echo "Disabling Gor traffic replay"
-            for box in $(govuk_node_list -C 'govuk_gor'); do
-              ssh deploy@${box} 'echo "true" > /etc/govuk/env.d/FACTER_data_sync_in_progress; sudo initctl stop gor';
-            done
-
             echo "Running Data Sync"
             bash sync production staging
             EXITCODE=$?
-
-            echo "Re-enabling Gor traffic replay"
-            for box in $(govuk_node_list -C 'govuk_gor'); do
-              ssh deploy@${box} 'echo "" > /etc/govuk/env.d/FACTER_data_sync_in_progress; sudo initctl start gor';
-            done
 
             exit $EXITCODE
     publishers:

--- a/modules/govuk_jenkins/templates/jobs/copy_licensify_data_to_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_licensify_data_to_staging.yaml.erb
@@ -36,19 +36,9 @@
 
             set +e
 
-            echo "Disabling Gor traffic replay"
-            for box in $(govuk_node_list -C 'govuk_gor'); do
-              ssh deploy@${box} 'echo "true" > /etc/govuk/env.d/FACTER_data_sync_in_progress; sudo initctl stop gor';
-            done
-
             echo "Running Data Sync"
             bash sync production staging
             EXITCODE=$?
-
-            echo "Re-enabling Gor traffic replay"
-            for box in $(govuk_node_list -C 'govuk_gor'); do
-              ssh deploy@${box} 'echo "" > /etc/govuk/env.d/FACTER_data_sync_in_progress; sudo initctl start gor';
-            done
 
             exit $EXITCODE
     publishers:


### PR DESCRIPTION
This was possibly working before the frontend machines migrated to
AWS, but as they are no longer in Carrenza running
`govuk_node_list -C 'govuk_gor'` does not return anything.

Trello card: https://trello.com/c/tfBZywz4/1188-disable-the-traffic-replay-to-integration-and-staging-during-data-replication