### PR TITLE
Remove unused gor commands

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/copy_data_from_production_to_aws.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_from_production_to_aws.yaml.erb
@@ -47,19 +47,9 @@
 
             set +e
 
-            echo "Disabling Gor traffic replay"
-            for box in $(govuk_node_list -C 'govuk_gor'); do
-              ssh deploy@${box} 'echo "true" > /etc/govuk/env.d/FACTER_data_sync_in_progress; sudo initctl stop gor';
-            done
-
             echo "Running Data Sync"
             bash sync production aws
             EXITCODE=$?
-
-            echo "Re-enabling Gor traffic replay"
-            for box in $(govuk_node_list -C 'govuk_gor'); do
-              ssh deploy@${box} 'echo "" > /etc/govuk/env.d/FACTER_data_sync_in_progress; sudo initctl start gor';
-            done
 
             exit $EXITCODE
     publishers:


### PR DESCRIPTION
This was missed in a previous commit, see https://github.com/alphagov/govuk-puppet/pull/9498/commits/1eecafa34ef9a3a7cb0a84a03294ea265f35b8c8