### PR TITLE
Actually add the deploy docs job to Jenkins

### DIFF
--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -18,6 +18,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::deploy_app
   - govuk_jenkins::jobs::deploy_cdn
   - govuk_jenkins::jobs::deploy_dns
+  - govuk_jenkins::jobs::deploy_docs
   - govuk_jenkins::jobs::deploy_lambda_app
   - govuk_jenkins::jobs::deploy_licensify
   - govuk_jenkins::jobs::deploy_puppet


### PR DESCRIPTION
I forgot to do this in https://github.com/alphagov/govuk-puppet/pull/9497. Without this, the job isn't actually added to Jenkins.