### PR TITLE
Fix indentation in docs deploy jenkins job

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_docs.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_docs.yaml.erb
@@ -27,7 +27,7 @@
           artifact-num-to-keep: 5
     builders:
       - shell: |
-        ./bin/deploy-to-s3
+          ./bin/deploy-to-s3
     publishers:
       - trigger-parameterized-builds:
         - project: Success_Passive_Check


### PR DESCRIPTION
I would've thought this was picked up by the tests, but it isn't.

I've confirmed the YAML is valid now with:

```
 @tijmenb ~/govuk/govuk-puppet on fix-indentation-for-jenkins-job $ irb
irb(main):001:0> require 'yaml'
=> true
irb(main):002:0> YAML.load_file("modules/govuk_jenkins/templates/jobs/deploy_docs.yaml.erb")
=> [{"scm"=>{"name"=>"govuk-developer-docs-repo",
"scm"=>[{"git"=>{"url"=>"git@github.com:alphagov/govuk-developer-docs.gi
t", "basedir"=>"govuk-developer-docs", "branches"=>["master"]}}]}},
...
```