### PR TITLE
Add SENTRY_ENVIRONMENT envvar for router

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -243,6 +243,7 @@ task :check_consistency_between_aws_and_carrenza do
     govuk::apps::publishing_api::db::allow_auth_from_lb
     govuk::apps::publishing_api::db::lb_ip_range
     govuk::apps::publishing_api::db::rds
+    govuk::apps::router::sentry_environment
     govuk::apps::search_api::elasticsearch_b_uri
     govuk::apps::search_api::nagios_memory_warning
     govuk::apps::search_api::nagios_memory_critical

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -41,6 +41,7 @@ govuk::apps::kibana::logit_environment: 2694f14b-6519-4607-81f2-8a2130e5aaec
 govuk::apps::link_checker_api::govuk_basic_auth_credentials: "%{hiera('http_username')}:%{hiera('http_password')}"
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-integration'
 govuk::apps::publishing_api::content_api_prototype: true
+govuk::apps::router::sentry_environment: 'integration'
 govuk::apps::short_url_manager::instance_name: 'integration'
 govuk::apps::signon::instance_name: 'integration'
 govuk::apps::smartanswers::expose_govspeak: true

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -142,6 +142,7 @@ govuk::apps::link_checker_api::govuk_basic_auth_credentials: "%{hiera('http_user
 govuk::apps::publisher::run_fact_check_fetcher: false
 govuk::apps::publisher::fact_check_address_format: 'factcheck+production-{id}@alphagov.co.uk'
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-production'
+govuk::apps::router::sentry_environment: 'production'
 govuk::apps::short_url_manager::instance_name: 'production'
 govuk::apps::static::ga_universal_id: 'UA-26179049-1'
 govuk::apps::support::zendesk_anonymous_ticket_email: 'zd-api-public@digital.cabinet-office.gov.uk'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -137,6 +137,7 @@ govuk::apps::link_checker_api::govuk_basic_auth_credentials: "%{hiera('http_user
 govuk::apps::publisher::run_fact_check_fetcher: false
 govuk::apps::publisher::fact_check_address_format: 'factcheck+staging-{id}@alphagov.co.uk'
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-staging'
+govuk::apps::router::sentry_environment: 'staging'
 govuk::apps::short_url_manager::instance_name: 'staging'
 govuk::apps::signon::instance_name: 'staging'
 govuk::apps::static::ga_universal_id: 'UA-26179049-20'

--- a/hieradata_aws/training.yaml
+++ b/hieradata_aws/training.yaml
@@ -41,6 +41,7 @@ govuk::apps::kibana::logit_environment: 2694f14b-6519-4607-81f2-8a2130e5aaec
 govuk::apps::link_checker_api::govuk_basic_auth_credentials: "%{hiera('http_username')}:%{hiera('http_password')}"
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-training'
 govuk::apps::publishing_api::content_api_prototype: true
+govuk::apps::router::sentry_environment: 'training'
 govuk::apps::short_url_manager::instance_name: 'training'
 govuk::apps::signon::instance_name: 'training'
 govuk::apps::smartanswers::expose_govspeak: true

--- a/modules/govuk/manifests/apps/router.pp
+++ b/modules/govuk/manifests/apps/router.pp
@@ -3,6 +3,9 @@
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
+# [*sentry_environment*]
+#   The environment to be sent with Sentry exceptions
+#
 
 class govuk::apps::router (
   $port = '3054',
@@ -15,6 +18,7 @@ class govuk::apps::router (
   $mongodb_password = '',
   $mongodb_params = '',
   $sentry_dsn = undef,
+  $sentry_environment = undef,
 
   # These are only overridden in the dev VM to allow www.dev.gov.uk to go through the router.
   $enable_nginx_vhost = false,
@@ -55,6 +59,9 @@ class govuk::apps::router (
     "${title}-ROUTER_BACKEND_HEADER_TIMEOUT":
       value   => '20s',
       varname => 'ROUTER_BACKEND_HEADER_TIMEOUT';
+    "${title}-ROUTER_BACKEND_SENTRY_ENVIRONMENT":
+      value   => $sentry_environment,
+      varname => 'SENTRY_ENVIRONMENT';
   }
 
   govuk::app { 'router':


### PR DESCRIPTION
Sentry's Go client library wants this variable, but it needs to be provided.

https://github.com/getsentry/sentry-go/blob/master/client.go#L120

This'll get picked up once we merge this in https://github.com/alphagov/router/pull/139/files#diff-ff7d1df66169af56df56b4a5e6a1d516R120.