### PR TITLE
Increase the licensify 5xx thresholds in Integration

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -195,6 +195,8 @@ icinga::client::check_cputype::cputype: 'amd'
 licensify::apps::licensify_admin::environment: 'integration'
 licensify::apps::licensify::environment: 'integration'
 licensify::apps::licensify_feed::environment: 'integration'
+licensify::apps::licensify::alert_5xx_warning_rate: 0.1
+licensify::apps::licensify::alert_5xx_critical_rate: 0.15
 
 monitoring::ci_environment: true
 monitoring::checks::aws_origin_domain: "integration.govuk.digital"

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -81,6 +81,8 @@ licensify::apps::configfile::scheduled_virus_scan_cron_expression: '0 0 16 * * ?
 licensify::apps::configfile::performance_data_sender_cron_expression: '0 0 1 * * ?'
 licensify::apps::configfile::performance_platform_service_url: 'https://www.integration.performance.service.gov.uk/data/licensing/application'
 licensify::apps::configfile::is_master_node: 'true'
+licensify::apps::licensify::alert_5xx_warning_rate: 0.1
+licensify::apps::licensify::alert_5xx_critical_rate: 0.15
 
 govuk_search::monitoring::es_port: '80'
 govuk_search::monitoring::es_host: 'elasticsearch5.blue.integration.govuk-internal.digital'


### PR DESCRIPTION
Same reason as d132947d0cd80d932249f5398a1aaa1241899e61, we're seeing
a problem where the 5xx alert often triggers. We think this is related
to the app not handling errors properly.

Unfortunately it's unlikely we'll be able to prioritise work in this
area any time soon so increase the thresholds to stop it alerting.