### PR TITLE
Adjust time gor is disabled

### DIFF
--- a/modules/govuk_gor/manifests/init.pp
+++ b/modules/govuk_gor/manifests/init.pp
@@ -52,7 +52,7 @@ class govuk_gor(
   cron { 'stop_gor':
     command => "echo 'true' > ${data_sync_fact_path}; sudo initctl stop gor",
     user    => 'deploy',
-    hour    => 23,
+    hour    => 22,
     minute  => 0,
   }
 


### PR DESCRIPTION
Having deployed https://github.com/alphagov/govuk-puppet/pull/9489/commits/8cea6d6380c55561f63ba15627b06f14a0629cf8
and reviewing the Grafana graphs, it looks like we can reduce more
errors by adjusting traffic replay to stop an hour earlier.

Trello card: https://trello.com/c/tfBZywz4/1188-disable-the-traffic-replay-to-integration-and-staging-during-data-replication