### PR TITLE
Fix running the deploy docs script

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_docs.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_docs.yaml.erb
@@ -4,7 +4,6 @@
     scm:
       - git:
           url: git@github.com:alphagov/govuk-developer-docs.git
-          basedir: govuk-developer-docs
           branches:
             - master
 - job:


### PR DESCRIPTION
`basedir` clones the repo into a subdirectory, which means the shell script won't work.

