### PR TITLE
parametise the licensing config file to accept database authentication

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -55,10 +55,10 @@ govuk::apps::url_arbiter::db::backend_ip_range: '10.1.3.0/24'
 govuk::apps::whitehall::basic_auth_credentials: "%{hiera('http_username')}:%{hiera('http_password')}"
 govuk::apps::whitehall::highlight_words_to_avoid: true
 
-licensify::apps::configfile::mongo_database_hosts: 'licensing-mongo-1,licensing-mongo-2,licensing-mongo-3'
 licensify::apps::configfile::mongo_database_reference_name: 'licensify-refdata'
 licensify::apps::configfile::mongo_database_audit_name: 'licensify-audit'
 licensify::apps::configfile::mongo_database_slaveok: 'false'
+licensify::apps::configfile::mongo_database_auth_enabled: true
 licensify::apps::configfile::places_api_url: 'http://places-api:9700/places'
 licensify::apps::configfile::feed_actor: 'true'
 licensify::apps::configfile::oauth_callback_url_override: 'https://licensify-admin.integration.publishing.service.gov.uk/licence-management/admin/oauth'

--- a/modules/licensify/manifests/apps/configfile.pp
+++ b/modules/licensify/manifests/apps/configfile.pp
@@ -2,11 +2,39 @@
 #
 # Creates the config file which is common to all three Licensify apps.
 #
+# TODO: document all the parameters
+#
+# # === Parameters
+#
+# [*mongo_database_hosts*]
+#   List of addresses for the Licencify Mongodb/DocumentdDB instances
+#   Type: array of string
+#   Default: []
+#
+# [*mongo_database_auth_enabled*]
+#   State whether to use a username and password to access the
+#   Mongodb/DocumentDB instances
+#   Type: boolean
+#   Default: false
+#
+# [*mongo_database_auth_username*]
+#   Username to access the Mongodb/DocumentDB instances
+#   Type: string
+#   Default: ''
+#
+# [*mongo_database_auth_password*]
+#   Password to access the Mongodb/DocumentDB instances
+#   Type: string
+#   Default: ''
+#
 class licensify::apps::configfile(
-  $mongo_database_hosts = undef,
+  $mongo_database_hosts = [],
   $mongo_database_reference_name = undef,
   $mongo_database_audit_name = undef,
   $mongo_database_slaveok = undef,
+  $mongo_database_auth_enabled = false,
+  $mongo_database_auth_username = '',
+  $mongo_database_auth_password = '',
   $places_api_url = undef,
   $feed_actor = undef,
   $oauth_callback_url_override = undef,

--- a/modules/licensify/templates/gds-licensing-config.properties.erb
+++ b/modules/licensify/templates/gds-licensing-config.properties.erb
@@ -1,9 +1,12 @@
 # This config file is common to all three Licensify apps within a given
 # environment. It gets included in each app's individual config file.
 
-mongo.database.hosts=<%= @mongo_database_hosts %>
+mongo.database.hosts=<%= @mongo_database_hosts.join(',') %>
 mongo.database.reference.name=<%= @mongo_database_reference_name %>
 mongo.database.audit.name=<%= @mongo_database_audit_name %>
+mongo.database.auth.enabled=<%= @mongo_database_auth_enabled %>
+mongo.database.auth.username=<%= @mongo_database_auth_username %>
+mongo.database.auth.password=<%= @mongo_database_auth_password %>
 
 mongo.database.slaveok=<%= @mongo_database_slaveok %>
 places.api.url=<%= @places_api_url %>
@@ -50,4 +53,3 @@ performance.platform.service.url=<%= @performance_platform_service_url %>
 notify.key.api=<%= @notify_key_api %>
 
 is.master.node=<%= @is_master_node %>
-


### PR DESCRIPTION
# Context

In AWS, the licensify apps use documentDB which compulsory requires a username and password.

# Deci sions
1. add the option to configure the app to use a specified username and password for the database if the database authentication is enabled in the config.

Data part of PR: https://github.com/alphagov/govuk-secrets/pull/780