### PR TITLE
Federate rabbitmq from Carrenza

### DIFF
--- a/hieradata/class/production/rabbitmq.yaml
+++ b/hieradata/class/production/rabbitmq.yaml
@@ -2,6 +2,6 @@
 
 govuk_rabbitmq::federate::federation_user: 'root'
 govuk_rabbitmq::federate::federation_pass: "%{hiera('govuk_rabbitmq::root_password')}"
-govuk_rabbitmq::federate::upstream_servers: ['10.3.3.70', '10.3.3.71', '10.3.3.72']
-govuk_rabbitmq::federate::upstream_name: 'carrenza'
+govuk_rabbitmq::federate::upstream_servers: ['10.13.13.20', '10.13.14.20', '10.13.15.20']
+govuk_rabbitmq::federate::upstream_name: 'aws'
 govuk_rabbitmq::federate::federation_exchange: 'published_documents'

--- a/hieradata/class/staging/rabbitmq.yaml
+++ b/hieradata/class/staging/rabbitmq.yaml
@@ -2,6 +2,6 @@
 
 govuk_rabbitmq::federate::federation_user: 'root'
 govuk_rabbitmq::federate::federation_pass: "%{hiera('govuk_rabbitmq::root_password')}"
-govuk_rabbitmq::federate::upstream_servers: ['10.3.3.70', '10.3.3.71', '10.3.3.72']
-govuk_rabbitmq::federate::upstream_name: 'carrenza'
+govuk_rabbitmq::federate::upstream_servers: ['10.12.13.20', '10.12.14.20', '10.12.15.20']
+govuk_rabbitmq::federate::upstream_name: 'aws'
 govuk_rabbitmq::federate::federation_exchange: 'published_documents'

--- a/hieradata_aws/class/staging/rabbitmq.yaml
+++ b/hieradata_aws/class/staging/rabbitmq.yaml
@@ -3,4 +3,5 @@
 govuk_rabbitmq::federate::federation_user: 'root'
 govuk_rabbitmq::federate::federation_pass: "%{hiera('govuk_rabbitmq::root_password')}"
 govuk_rabbitmq::federate::upstream_servers: ['10.2.3.70', '10.2.3.71', '10.2.3.72']
+govuk_rabbitmq::federate::upstream_name: 'carrenza'
 govuk_rabbitmq::federate::federation_exchange: 'published_documents'

--- a/modules/govuk_rabbitmq/manifests/federate.pp
+++ b/modules/govuk_rabbitmq/manifests/federate.pp
@@ -13,6 +13,9 @@
 # [*upstream_servers*]
 #   The upstream rabbitmq servers to federate to.
 #
+# [*upstream_name*]
+#   Designation of the upstream rabbitmq cluster to federate to.
+#
 # [*federation_exchange*]
 #   The exchange to federate.
 #
@@ -24,6 +27,7 @@ class govuk_rabbitmq::federate (
   $federation_user,
   $federation_pass,
   $upstream_servers,
+  $upstream_name,
   $federation_exchange,
   $max_hops = 1,
 ) {
@@ -34,7 +38,7 @@ class govuk_rabbitmq::federate (
       ensure => present,
     }
     exec { 'rabbitmq parameters':
-      command => "rabbitmqctl set_parameter federation-upstream carrenza '{\"uri\": [ \"amqp://${federation_user}:${federation_pass}@${upstream_servers[0]}\", \"amqp://${federation_user}:${federation_pass}@${upstream_servers[1]}\",\"amqp://${federation_user}:${federation_pass}@${upstream_servers[2]}\" ], \"max-hops\": ${max_hops}}'",
+      command => "rabbitmqctl set_parameter federation-upstream ${upstream_name} '{\"uri\": [ \"amqp://${federation_user}:${federation_pass}@${upstream_servers[0]}\", \"amqp://${federation_user}:${federation_pass}@${upstream_servers[1]}\",\"amqp://${federation_user}:${federation_pass}@${upstream_servers[2]}\" ], \"max-hops\": ${max_hops}}'",
       unless  => 'rabbitmqctl list_parameters | grep -qE federation',
       path    => ['/bin','/sbin','/usr/bin','/usr/sbin'],
       require => Rabbitmq_plugin['rabbitmq_federation'],

--- a/modules/govuk_rabbitmq/manifests/init.pp
+++ b/modules/govuk_rabbitmq/manifests/init.pp
@@ -51,7 +51,9 @@ class govuk_rabbitmq (
       ensure => present,
     }
 
-  if ($::aws_environment == 'staging') or ($::aws_environment == 'production') {
+  }
+
+  if ($::aws_environment == 'staging') or ($::aws_environment == 'production') or ($::environment == 'staging') or ($::environment == 'production'){
 
     # Temporary federation setup for the duration of the migration to AWS
     # Remove once the migration is over
@@ -61,7 +63,6 @@ class govuk_rabbitmq (
     include govuk_rabbitmq::purge_queues
   }
 
-  }
   rabbitmq_user { 'root':
     admin    => true,
     password => $root_password,


### PR DESCRIPTION
For the AWS migration we create a federation from Carrenza.
This make the federation going both ways, services should then be
able to use rabbitmq from carremza or AWS.