### PR TITLE
Fix for Elastic Search Cluster Restore Error

### DIFF
--- a/modules/govuk_env_sync/files/govuk_env_sync.sh
+++ b/modules/govuk_env_sync/files/govuk_env_sync.sh
@@ -222,7 +222,7 @@ function restore_elasticsearch {
   curl -XDELETE "http://${database}/_all"
   /usr/bin/curl --connect-timeout 10 -sSf -XPOST "http://${database}/_snapshot/${url}/${snapshot_name}/_restore" || true
   /bin/sleep 1
-  /usr/bin/curl --connect-timeout 10 -sSf -XPOST "http://${database}/_cat/recovery" | grep -q "${snapshot_name}"
+  /usr/bin/curl --connect-timeout 10 -sSf -XGET "http://${database}/_cat/recovery" | grep -q "${snapshot_name}"
 }
 
 function  dump_postgresql {


### PR DESCRIPTION
Corrected the request type to fix the error. 
Zendesk ticket:
https://govuk.zendesk.com/agent/tickets/3777807

Original PR:
https://github.com/alphagov/govuk-puppet/pull/9494

