### PR TITLE
swap mongo tools & shell 3.2 for 4.1 version

### DIFF
--- a/modules/govuk/manifests/node/s_apt.pp
+++ b/modules/govuk/manifests/node/s_apt.pp
@@ -66,6 +66,10 @@ class govuk::node::s_apt (
       location => 'https://repo.mongodb.org/apt/ubuntu',
       release  => 'trusty/mongodb-org/3.2',
       key      => 'EA312927';
+    'mongodb4.1':
+        location => 'https://repo.mongodb.org/apt/ubuntu',
+        release  => 'trusty/mongodb-org/4.1',
+        key      => '058F8B6B';
     'nginx':
       location => 'https://nginx.org/packages/ubuntu/',
       release  => 'trusty',

--- a/modules/govuk/manifests/node/s_db_admin.pp
+++ b/modules/govuk/manifests/node/s_db_admin.pp
@@ -38,8 +38,17 @@ class govuk::node::s_db_admin(
   }
 
   apt::source { 'mongodb32':
+    ensure       => 'absent',
     location     => "http://${apt_mirror_hostname}/mongodb3.2",
     release      => 'trusty-mongodb-org-3.2',
+    architecture => $::architecture,
+    repos        => 'multiverse',
+    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+  }
+
+  apt::source { 'mongodb41':
+    location     => "http://${apt_mirror_hostname}/mongodb4.1",
+    release      => 'trusty-mongodb-org-4.1',
     architecture => $::architecture,
     repos        => 'multiverse',
     key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',

--- a/modules/govuk/manifests/node/s_licensing_backend.pp
+++ b/modules/govuk/manifests/node/s_licensing_backend.pp
@@ -33,8 +33,17 @@ class govuk::node::s_licensing_backend (
   include nginx
 
   apt::source { 'mongodb32':
+    ensure       => 'absent',
     location     => "http://${apt_mirror_hostname}/mongodb3.2",
     release      => 'trusty-mongodb-org-3.2',
+    architecture => $::architecture,
+    repos        => 'multiverse',
+    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+  }
+
+  apt::source { 'mongodb41':
+    location     => "http://${apt_mirror_hostname}/mongodb4.1",
+    release      => 'trusty-mongodb-org-4.1',
     architecture => $::architecture,
     repos        => 'multiverse',
     key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',

--- a/modules/govuk/manifests/node/s_licensing_frontend.pp
+++ b/modules/govuk/manifests/node/s_licensing_frontend.pp
@@ -31,8 +31,17 @@ class govuk::node::s_licensing_frontend (
   include nginx
 
   apt::source { 'mongodb32':
+    ensure       => 'absent',
     location     => "http://${apt_mirror_hostname}/mongodb3.2",
     release      => 'trusty-mongodb-org-3.2',
+    architecture => $::architecture,
+    repos        => 'multiverse',
+    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+  }
+
+  apt::source { 'mongodb41':
+    location     => "http://${apt_mirror_hostname}/mongodb4.1",
+    release      => 'trusty-mongodb-org-4.1',
     architecture => $::architecture,
     repos        => 'multiverse',
     key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',


### PR DESCRIPTION
We need the mongo tools & shell version 4.1 because the earlier version 3.2 has an issue with mongorestore --drop option which is needed by govuk_env_sync when interacting with AWS documentDB