### PR TITLE
use mongo3.6 for licensing machines

### DIFF
--- a/modules/govuk/manifests/node/s_apt.pp
+++ b/modules/govuk/manifests/node/s_apt.pp
@@ -66,10 +66,10 @@ class govuk::node::s_apt (
       location => 'https://repo.mongodb.org/apt/ubuntu',
       release  => 'trusty/mongodb-org/3.2',
       key      => 'EA312927';
-    'mongodb4.1':
+    'mongodb3.6':
         location => 'https://repo.mongodb.org/apt/ubuntu',
-        release  => 'trusty/mongodb-org/4.1',
-        key      => '058F8B6B';
+        release  => 'trusty/mongodb-org/3.6',
+        key      => '91FA4AD5';
     'nginx':
       location => 'https://nginx.org/packages/ubuntu/',
       release  => 'trusty',

--- a/modules/govuk/manifests/node/s_db_admin.pp
+++ b/modules/govuk/manifests/node/s_db_admin.pp
@@ -37,18 +37,18 @@ class govuk::node::s_db_admin(
     $ensure = 'absent'
   }
 
-  apt::source { 'mongodb32':
+  apt::source { 'mongodb41':
     ensure       => 'absent',
-    location     => "http://${apt_mirror_hostname}/mongodb3.2",
-    release      => 'trusty-mongodb-org-3.2',
+    location     => "http://${apt_mirror_hostname}/mongodb4.1",
+    release      => 'trusty-mongodb-org-4.1',
     architecture => $::architecture,
     repos        => 'multiverse',
     key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
   }
 
-  apt::source { 'mongodb41':
-    location     => "http://${apt_mirror_hostname}/mongodb4.1",
-    release      => 'trusty-mongodb-org-4.1',
+  apt::source { 'mongodb36':
+    location     => "http://${apt_mirror_hostname}/mongodb3.6",
+    release      => 'trusty-mongodb-org-3.6',
     architecture => $::architecture,
     repos        => 'multiverse',
     key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',

--- a/modules/govuk/manifests/node/s_licensing_backend.pp
+++ b/modules/govuk/manifests/node/s_licensing_backend.pp
@@ -32,18 +32,18 @@ class govuk::node::s_licensing_backend (
 
   include nginx
 
-  apt::source { 'mongodb32':
+  apt::source { 'mongodb41':
     ensure       => 'absent',
-    location     => "http://${apt_mirror_hostname}/mongodb3.2",
-    release      => 'trusty-mongodb-org-3.2',
+    location     => "http://${apt_mirror_hostname}/mongodb4.1",
+    release      => 'trusty-mongodb-org-4.1',
     architecture => $::architecture,
     repos        => 'multiverse',
     key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
   }
 
-  apt::source { 'mongodb41':
-    location     => "http://${apt_mirror_hostname}/mongodb4.1",
-    release      => 'trusty-mongodb-org-4.1',
+  apt::source { 'mongodb36':
+    location     => "http://${apt_mirror_hostname}/mongodb3.6",
+    release      => 'trusty-mongodb-org-3.6',
     architecture => $::architecture,
     repos        => 'multiverse',
     key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',

--- a/modules/govuk/manifests/node/s_licensing_frontend.pp
+++ b/modules/govuk/manifests/node/s_licensing_frontend.pp
@@ -30,18 +30,18 @@ class govuk::node::s_licensing_frontend (
 
   include nginx
 
-  apt::source { 'mongodb32':
+  apt::source { 'mongodb41':
     ensure       => 'absent',
-    location     => "http://${apt_mirror_hostname}/mongodb3.2",
-    release      => 'trusty-mongodb-org-3.2',
+    location     => "http://${apt_mirror_hostname}/mongodb4.1",
+    release      => 'trusty-mongodb-org-4.1',
     architecture => $::architecture,
     repos        => 'multiverse',
     key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
   }
 
-  apt::source { 'mongodb41':
-    location     => "http://${apt_mirror_hostname}/mongodb4.1",
-    release      => 'trusty-mongodb-org-4.1',
+  apt::source { 'mongodb36':
+    location     => "http://${apt_mirror_hostname}/mongodb3.6",
+    release      => 'trusty-mongodb-org-3.6',
     architecture => $::architecture,
     repos        => 'multiverse',
     key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',


### PR DESCRIPTION
# Context

Using mongo 3.6 for licensing machines because documentdb is developed against that version.
See webpage: https://aws.amazon.com/documentdb/

# Decisions
1. swap mongo 4.1 (previously mistakenly selected) for mongo 3.6