### PR TITLE
Govuk env sync support documentdb

### DIFF
--- a/hieradata_aws/class/integration/db_admin.yaml
+++ b/hieradata_aws/class/integration/db_admin.yaml
@@ -241,3 +241,20 @@ govuk_env_sync::tasks:
     temppath: "/tmp/whitehall_production"
     url: "govuk-integration-database-backups"
     path: "mysql-backend"
+  "pull_licensify_integration_daily": &pull_licensify
+    ensure: absent
+    hour: '4'
+    minute: '0'
+    action: pull
+    dbms: documentdb
+    storagebackend: s3
+    database: licensify
+    temppath: /var/lib/documentdb/.dumps
+    url: govuk-staging-database-backups
+    path: mongo-licensing
+  "pull_licensify_audit_integration_daily":
+    <<: *pull_licensify
+    database: licensify-audit
+  "pull_licensify_refdata_integration_daily":
+    <<: *pull_licensify
+    database: licensify-refdata

--- a/modules/govuk/manifests/node/s_db_admin.pp
+++ b/modules/govuk/manifests/node/s_db_admin.pp
@@ -62,6 +62,13 @@ class govuk::node::s_db_admin(
     ensure  => latest,
   }
 
+  file { '/var/lib/documentdb':
+    ensure => directory,
+    owner  => 'govuk-backup',
+    group  => 'govuk-backup',
+    mode   => '0750',
+  }
+
   apt::source { 'gof3r':
     ensure       => $ensure,
     location     => "http://${apt_mirror_hostname}/gof3r",

--- a/modules/govuk_env_sync/manifests/documentdb_auth.pp
+++ b/modules/govuk_env_sync/manifests/documentdb_auth.pp
@@ -1,0 +1,55 @@
+# == Class: govuk_env_sync::licensify_documentdb_auth
+#
+# Provide the AWS DocumentDB authentication
+# information to envdir
+#
+# === Parameters:
+#
+# [*host*]
+#   The hostname and port pair to be used to contact Licensify DocumentDB
+#   Format: address:port
+#   Type: string
+#   Default= undef
+#
+# [*password*]
+#   The password to access the Licensify DocumentDB
+#   Type: string of 8-100 characters
+#   Default= undef
+#
+define govuk_env_sync::documentdb_auth(
+  $host = undef,
+  $password = undef,
+){
+
+  $user = $govuk_env_sync::user
+  $conf_dir = $govuk_env_sync::conf_dir
+  $title_normalized = regsubst(upcase($title), '-', '_', 'G')
+
+  # only put the host file if $password is set
+  if $host {
+    file { "${conf_dir}/env.d/${title_normalized}_DOCUMENTDB_HOST":
+    content => $host,
+    owner   => $user,
+    group   => $user,
+    mode    => '0640',
+    }
+  } else {
+    file { "${conf_dir}/env.d/${title_normalized}_DOCUMENTDB_HOST":
+      ensure => 'absent',
+    }
+  }
+
+  # only put the password file if $password is set
+  if $password {
+    file { "${conf_dir}/env.d/${title_normalized}_DOCUMENTDB_PASSWD":
+      content => $password,
+      owner   => $user,
+      group   => $user,
+      mode    => '0640',
+    }
+  } else {
+    file { "${conf_dir}/env.d/${title_normalized}_DOCUMENTDB_PASSWD":
+      ensure => 'absent',
+    }
+  }
+}

--- a/modules/govuk_env_sync/manifests/init.pp
+++ b/modules/govuk_env_sync/manifests/init.pp
@@ -6,6 +6,7 @@ class govuk_env_sync(
   $user = 'govuk-backup',
   $conf_dir = '/etc/govuk_env_sync',
   $aws_region = 'eu-west-1',
+  $document_db_credentials = undef,
 ) {
 
   include govuk_env_sync::lock_file
@@ -23,4 +24,8 @@ class govuk_env_sync(
   }
 
   create_resources(govuk_env_sync::task, $tasks)
+
+  if $document_db_credentials {
+    create_resources(govuk_env_sync::documentdb_auth, $document_db_credentials)
+  }
 }

--- a/modules/govuk_env_sync/manifests/task.pp
+++ b/modules/govuk_env_sync/manifests/task.pp
@@ -1,6 +1,6 @@
 # == Custom resource type: govuk_env_sync::task
 #
-# Creates a configuration file and cron-job, parameterising the govuk_env_sync.sh 
+# Creates a configuration file and cron-job, parameterising the govuk_env_sync.sh
 # from data provided in hieradata govuk_env_sync::tasks:
 #
 # [*hour*]


### PR DESCRIPTION
# Context

mongodb is being replaced by documentdb in AWS so govuk_env_sync show have support for it

While we lay the configuration to pull licensify from staging daily is there, this is
not yet activated because the data is contains some incompatible record.
They have been tested to work in integration.

Further testing for licensify-audit is required as it sometimes fail if an app
recreates a collection which the govuk_env_sync is trying to do so too.

# Decisions
1. add a new type of database `documentdb` support for govuk_env_sync
2. add ability for govuk_env_sync to read the documentdb credential for the database that it is restoring from its env variable.
3. lay the config for the integration to pull data from staging s3 bucket

Secrets for this PR: https://github.com/alphagov/govuk-secrets/pull/783