### PR TITLE
Update copy data job params to match reality

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
@@ -99,12 +99,12 @@
             choices:
                 - all
                 - assets
+                - attachments
                 - content-publisher
                 - mongo-api
-                - mongo-exceptions
-                - mongo-licensify
                 - mongo-normal
-                - mongo-router
                 - mysql-normal
+                - mysql-whitehall
                 - postgresql-backend
                 - postgresql-transition
+                - support-api-csvs

--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_staging.yaml.erb
@@ -101,14 +101,14 @@
             choices:
                 - all
                 - assets
+                - attachments
                 - content-publisher
                 - mongo-api
-                - mongo-exceptions
                 - mongo-licensify
                 - mongo-normal
                 - mongo-pp
-                - mongo-router
                 - mysql-normal
                 - mysql-whitehall
                 - postgresql-backend
                 - postgresql-transition
+                - support-api-csvs


### PR DESCRIPTION
This updates the available env-sync-and-backup jobs for the copy data
Jenkins jobs so that they match those available for that environment.