### PR TITLE
Add data sync staging to AWS staging for publishing-api test

### DIFF
--- a/hieradata_aws/class/staging/db_admin.yaml
+++ b/hieradata_aws/class/staging/db_admin.yaml
@@ -65,6 +65,17 @@ govuk_env_sync::tasks:
     temppath: "/tmp/content_data_admin_production_push"
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
+  "pull_publishing-api_production_daily":
+    ensure: "present"
+    hour: "3"
+    minute: "45"
+    action: "pull"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "publishing-api_production"
+    temppath: "/tmp/publishing-api_production"
+    url: "govuk-staging-database-backups"
+    path: "postgresql-backend"
   "pull_support_contacts_production_daily":
     ensure: "present"
     hour: "2"


### PR DESCRIPTION
We aim to pull an old publishing-api dataset into AWS staging for
testing.
This will need cleaning up as part of post-migration work.