### PR TITLE
fix regex for licensify in aws

### DIFF
--- a/modules/licensify/manifests/apps/licensify.pp
+++ b/modules/licensify/manifests/apps/licensify.pp
@@ -47,6 +47,12 @@ class licensify::apps::licensify (
   $alert_5xx_critical_rate = 0.1,
 ) inherits licensify::apps::base {
 
+  if $::aws_migration {
+    $collectd_process_regex = 'java -Duser.dir=\/data\/vhost\/licensify\/.*'
+  } else {
+    $collectd_process_regex = 'java -Duser.dir=\/data\/vhost\/licensify\..*publishing\.service\.gov\.uk\/licensify-.*'
+  }
+
   govuk::app { 'licensify':
     app_type                       => 'procfile',
     port                           => $port,
@@ -55,7 +61,7 @@ class licensify::apps::licensify (
     require                        => File['/etc/licensing'],
     proxy_http_version_1_1_enabled => true,
     log_format_is_json             => true,
-    collectd_process_regex         => 'java -Duser.dir=\/data\/vhost\/licensify\..*publishing\.service\.gov\.uk\/licensify-.*',
+    collectd_process_regex         => $collectd_process_regex,
     nagios_memory_warning          => 1350,
     nagios_memory_critical         => 1500,
     alert_5xx_warning_rate         => $alert_5xx_warning_rate,

--- a/modules/licensify/manifests/apps/licensify_admin.pp
+++ b/modules/licensify/manifests/apps/licensify_admin.pp
@@ -39,6 +39,12 @@ class licensify::apps::licensify_admin(
   $application_secret = undef,
 ) inherits licensify::apps::base {
 
+  if $::aws_migration {
+    $collectd_process_regex = 'java -Duser.dir=\/data\/vhost\/licensify-admin\/.*'
+  } else {
+    $collectd_process_regex = 'java -Duser.dir=\/data\/vhost\/licensify-admin\..*publishing\.service\.gov\.uk\/licensify-admin-.*'
+  }
+
   govuk::app { 'licensify-admin':
     app_type                       => 'procfile',
     port                           => $port,
@@ -47,7 +53,7 @@ class licensify::apps::licensify_admin(
     require                        => File['/etc/licensing'],
     proxy_http_version_1_1_enabled => true,
     log_format_is_json             => true,
-    collectd_process_regex         => 'java -Duser.dir=\/data\/vhost\/licensify-admin\..*publishing\.service\.gov\.uk\/licensify-admin-.*',
+    collectd_process_regex         => $collectd_process_regex,
     nagios_memory_warning          => 1350,
     nagios_memory_critical         => 1500,
   }

--- a/modules/licensify/manifests/apps/licensify_feed.pp
+++ b/modules/licensify/manifests/apps/licensify_feed.pp
@@ -44,6 +44,12 @@ class licensify::apps::licensify_feed(
   $ws_accept_any_certificate = false,
 ) inherits licensify::apps::base {
 
+  if $::aws_migration {
+    $collectd_process_regex = 'java -Duser.dir=\/data\/vhost\/licensify-feed\/.*'
+  } else {
+    $collectd_process_regex = 'java -Duser.dir=\/data\/vhost\/licensify-feed\..*publishing\.service\.gov\.uk\/licensify-feed-.*'
+  }
+
   govuk::app { 'licensify-feed':
     app_type                       => 'procfile',
     port                           => $port,
@@ -52,7 +58,7 @@ class licensify::apps::licensify_feed(
     proxy_http_version_1_1_enabled => true,
     log_format_is_json             => true,
     health_check_path              => '/licence-management/feed/process-applications',
-    collectd_process_regex         => 'java -Duser.dir=\/data\/vhost\/licensify-feed\..*publishing\.service\.gov\.uk\/licensify-feed-.*',
+    collectd_process_regex         => $collectd_process_regex,
     nagios_memory_warning          => 1400,
     nagios_memory_critical         => 1500,
   }


### PR DESCRIPTION
# Context

The regex for process count of licensify apps in AWS is
unsuitable because licensify apps are located in another
directory which does not use domain name.

This PR will fix the alerts related to not 0 licensify process apps in icinga too.

# Decisions
1. have different licensify process count regex depending on whether in Carrenza or AWS

