### PR TITLE
Aws licensify build clean

### DIFF
--- a/modules/licensify/manifests/build_clean.pp
+++ b/modules/licensify/manifests/build_clean.pp
@@ -3,8 +3,14 @@ define licensify::build_clean {
 
   $app_domain = hiera('app_domain')
 
+  if $::aws_migration {
+    $clean_cmd = "ls -dt1 '/data/vhost/${title}/releases/'* | tail -n +11 | while read dir; do rm -rf \"\${dir}\"; done"
+  } else {
+    $clean_cmd = "ls -dt1 '/data/vhost/${title}.${app_domain}/${title}'-* | tail -n +11 | while read dir; do rm -rf \"\${dir}\"; done"
+  }
+
   cron { "licensify-build-clean-${title}":
-    command => "ls -dt1 '/data/vhost/${title}.${app_domain}/${title}'-* | tail -n +11 | while read dir; do rm -rf \"\${dir}\"; done",
+    command => $clean_cmd,
     user    => 'deploy',
     require => User['deploy'],
     hour    => '*/6',


### PR DESCRIPTION
# Context

AWS licensify app releases are sym linked to /data/vhost/<app_name>/releases/ and therefore the clean build cron should act there

# Decisions
1. change the clean directory for AWS licensify apps