### PR TITLE
Call on some application 5xx alerts

### DIFF
--- a/modules/govuk/manifests/app.pp
+++ b/modules/govuk/manifests/app.pp
@@ -170,6 +170,9 @@
 # [*alert_5xx_critical_rate*]
 # the 5xx error percentage that should generate a critical
 #
+# [*alert_notification_period*]
+#   The notification period of the alert, passed to govuk::app::config.
+#
 # [*unicorn_herder_timeout*]
 # the timeout (in seconds) period to wait for
 #
@@ -289,6 +292,7 @@ define govuk::app (
   $nginx_extra_config = '',
   $alert_5xx_warning_rate = 0.05,
   $alert_5xx_critical_rate = 0.1,
+  $alert_notification_period = undef,
   $nagios_memory_warning = undef,
   $nagios_memory_critical = undef,
   $unicorn_herder_timeout = undef,
@@ -376,6 +380,7 @@ define govuk::app (
     nagios_memory_critical              => $nagios_memory_critical,
     alert_5xx_warning_rate              => $alert_5xx_warning_rate,
     alert_5xx_critical_rate             => $alert_5xx_critical_rate,
+    alert_notification_period           => $alert_notification_period,
     unicorn_herder_timeout              => $unicorn_herder_timeout,
     asset_pipeline                      => $asset_pipeline,
     asset_pipeline_prefix               => $asset_pipeline_prefix,

--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -27,6 +27,9 @@
 # [*nagios_memory_critical*]
 #   Memory use, in MB, at which Nagios should generate a critical alert.
 #
+# [*alert_notification_period*]
+#   The notification period of the alert, passed to govuk::app::nginx_vhost.
+#
 # [*proxy_http_version_1_1_enabled*]
 #   Boolean, whether to enable HTTP/1.1 for proxying from the Nginx vhost
 #   to the app server.
@@ -94,6 +97,7 @@ define govuk::app::config (
   $nagios_memory_critical = 800,
   $alert_5xx_warning_rate = 0.05,
   $alert_5xx_critical_rate = 0.1,
+  $alert_notification_period = undef,
   $asset_pipeline = false,
   $asset_pipeline_prefix = 'assets',
   $ensure = 'present',
@@ -284,6 +288,7 @@ define govuk::app::config (
       read_timeout                   => $read_timeout,
       alert_5xx_warning_rate         => $alert_5xx_warning_rate,
       alert_5xx_critical_rate        => $alert_5xx_critical_rate,
+      alert_notification_period      => $alert_notification_period,
       proxy_http_version_1_1_enabled => $proxy_http_version_1_1_enabled,
     }
 

--- a/modules/govuk/manifests/app/nginx_vhost.pp
+++ b/modules/govuk/manifests/app/nginx_vhost.pp
@@ -58,6 +58,9 @@
 # [*alert_5xx_critical_rate*]
 #   The error percentage that triggers a critical alert
 #
+# [*alert_notification_period*]
+#   The notification period of the alert, passed to nginx::config::vhost::proxy.
+#
 # [*proxy_http_version_1_1_enabled*]
 #   Boolean, whether to enable HTTP/1.1 for proxying from the Nginx vhost
 #   to the app server.
@@ -81,6 +84,7 @@ define govuk::app::nginx_vhost (
   $ensure = 'present',
   $alert_5xx_warning_rate = 0.05,
   $alert_5xx_critical_rate = 0.1,
+  $alert_notification_period = undef,
   $proxy_http_version_1_1_enabled = false,
 ) {
 
@@ -114,6 +118,7 @@ define govuk::app::nginx_vhost (
     read_timeout                   => $read_timeout,
     alert_5xx_warning_rate         => $alert_5xx_warning_rate,
     alert_5xx_critical_rate        => $alert_5xx_critical_rate,
+    alert_notification_period      => $alert_notification_period,
     proxy_http_version_1_1_enabled => $proxy_http_version_1_1_enabled,
   }
 }

--- a/modules/govuk/manifests/apps/collections.pp
+++ b/modules/govuk/manifests/apps/collections.pp
@@ -40,16 +40,17 @@ class govuk::apps::collections(
   $email_alert_api_bearer_token = undef,
 ) {
   govuk::app { 'collections':
-    app_type               => 'rack',
-    port                   => $port,
-    health_check_path      => '/topic/oil-and-gas',
-    log_format_is_json     => true,
-    asset_pipeline         => true,
-    asset_pipeline_prefix  => 'collections',
-    vhost                  => $vhost,
-    nagios_memory_warning  => $nagios_memory_warning,
-    nagios_memory_critical => $nagios_memory_critical,
-    sentry_dsn             => $sentry_dsn,
+    app_type                  => 'rack',
+    port                      => $port,
+    health_check_path         => '/topic/oil-and-gas',
+    log_format_is_json        => true,
+    asset_pipeline            => true,
+    asset_pipeline_prefix     => 'collections',
+    vhost                     => $vhost,
+    nagios_memory_warning     => $nagios_memory_warning,
+    nagios_memory_critical    => $nagios_memory_critical,
+    sentry_dsn                => $sentry_dsn,
+    alert_notification_period => '24x7',
   }
 
   Govuk::App::Envvar {

--- a/modules/govuk/manifests/apps/email_alert_api.pp
+++ b/modules/govuk/manifests/apps/email_alert_api.pp
@@ -158,16 +158,17 @@ class govuk::apps::email_alert_api(
   }
 
   govuk::app { 'email-alert-api':
-    ensure                   => $ensure,
-    app_type                 => 'rack',
-    port                     => $port,
-    sentry_dsn               => $sentry_dsn,
-    log_format_is_json       => true,
-    health_check_path        => '/healthcheck',
-    json_health_check        => true,
-    unicorn_worker_processes => $unicorn_worker_processes,
-    nagios_memory_warning    => $nagios_memory_warning,
-    nagios_memory_critical   => $nagios_memory_critical,
+    ensure                    => $ensure,
+    app_type                  => 'rack',
+    port                      => $port,
+    sentry_dsn                => $sentry_dsn,
+    log_format_is_json        => true,
+    health_check_path         => '/healthcheck',
+    json_health_check         => true,
+    unicorn_worker_processes  => $unicorn_worker_processes,
+    nagios_memory_warning     => $nagios_memory_warning,
+    nagios_memory_critical    => $nagios_memory_critical,
+    alert_notification_period => '24x7',
   }
 
   include govuk_postgresql::client #installs libpq-dev package needed for pg gem

--- a/modules/govuk/manifests/apps/email_alert_frontend.pp
+++ b/modules/govuk/manifests/apps/email_alert_frontend.pp
@@ -46,14 +46,15 @@ class govuk::apps::email_alert_frontend(
   $subscription_management_enabled = false,
 ) {
   govuk::app { 'email-alert-frontend':
-    app_type              => 'rack',
-    port                  => $port,
-    sentry_dsn            => $sentry_dsn,
-    asset_pipeline        => true,
-    asset_pipeline_prefix => 'email-alert-frontend',
-    vhost                 => $vhost,
-    health_check_path     => '/healthcheck',
-    json_health_check     => true,
+    app_type                  => 'rack',
+    port                      => $port,
+    sentry_dsn                => $sentry_dsn,
+    asset_pipeline            => true,
+    asset_pipeline_prefix     => 'email-alert-frontend',
+    vhost                     => $vhost,
+    health_check_path         => '/healthcheck',
+    json_health_check         => true,
+    alert_notification_period => '24x7',
   }
 
   Govuk::App::Envvar {

--- a/modules/govuk/manifests/apps/finder_frontend.pp
+++ b/modules/govuk/manifests/apps/finder_frontend.pp
@@ -34,20 +34,21 @@ class govuk::apps::finder_frontend(
 
   if $enabled {
     govuk::app { 'finder-frontend':
-      app_type                 => 'rack',
-      port                     => $port,
-      sentry_dsn               => $sentry_dsn,
-      health_check_path        => '/healthcheck.json',
-      expose_health_check      => false,
-      json_health_check        => true,
-      log_format_is_json       => true,
-      asset_pipeline           => true,
-      asset_pipeline_prefix    => 'finder-frontend',
-      nagios_memory_warning    => $nagios_memory_warning,
-      nagios_memory_critical   => $nagios_memory_critical,
-      unicorn_worker_processes => $unicorn_worker_processes,
-      cpu_warning              => 175,
-      cpu_critical             => 225,
+      app_type                  => 'rack',
+      port                      => $port,
+      sentry_dsn                => $sentry_dsn,
+      health_check_path         => '/healthcheck.json',
+      expose_health_check       => false,
+      json_health_check         => true,
+      log_format_is_json        => true,
+      asset_pipeline            => true,
+      asset_pipeline_prefix     => 'finder-frontend',
+      nagios_memory_warning     => $nagios_memory_warning,
+      nagios_memory_critical    => $nagios_memory_critical,
+      unicorn_worker_processes  => $unicorn_worker_processes,
+      cpu_warning               => 175,
+      cpu_critical              => 225,
+      alert_notification_period => '24x7',
     }
   }
 

--- a/modules/nginx/manifests/config/vhost/proxy.pp
+++ b/modules/nginx/manifests/config/vhost/proxy.pp
@@ -62,6 +62,9 @@
 # [*alert_5xx_critical_rate*]
 #   The error percentage that triggers a critical alert
 #
+# [*alert_notification_period*]
+#   The notification period of the alert, passed to icinga::check::graphite.
+#
 # [*proxy_http_version_1_1_enabled*]
 #   Boolean, whether to enable HTTP/1.1 for proxying from the Nginx vhost
 #   to the app server.
@@ -92,6 +95,7 @@ define nginx::config::vhost::proxy(
   $ensure = 'present',
   $alert_5xx_warning_rate = 0.05,
   $alert_5xx_critical_rate = 0.1,
+  $alert_notification_period = undef,
   $proxy_http_version_1_1_enabled = false,
   $http_host = undef,
   $deny_crawlers = false,
@@ -149,14 +153,15 @@ define nginx::config::vhost::proxy(
   statsd::counter { "${counter_basename}.http_500": }
 
   @@icinga::check::graphite { "check_nginx_5xx_${title}_on_${::hostname}":
-    ensure    => $ensure,
-    target    => "transformNull(stats.${counter_basename}.http_5xx,0)",
-    warning   => $alert_5xx_warning_rate,
-    critical  => $alert_5xx_critical_rate,
-    from      => '3minutes',
-    desc      => "${title} nginx 5xx rate too high",
-    host_name => $::fqdn,
-    notes_url => monitoring_docs_url(nginx-5xx-rate-too-high-for-many-apps-boxes),
+    ensure              => $ensure,
+    target              => "transformNull(stats.${counter_basename}.http_5xx,0)",
+    warning             => $alert_5xx_warning_rate,
+    critical            => $alert_5xx_critical_rate,
+    from                => '3minutes',
+    desc                => "${title} nginx 5xx rate too high",
+    host_name           => $::fqdn,
+    notes_url           => monitoring_docs_url(nginx-5xx-rate-too-high-for-many-apps-boxes),
+    notification_period => $alert_notification_period,
   }
 
 }


### PR DESCRIPTION
This PR changes it so that PagerDuty gets triggered if email-alert-api, email-alert-frontend or finder-frontend have a 5xx rate that triggers a critical alert.