### PR TITLE
re-attempts puppet passive check update if fail

### DIFF
--- a/modules/puppet/templates/puppet_passive_check_update
+++ b/modules/puppet/templates/puppet_passive_check_update
@@ -1,5 +1,24 @@
 #!/bin/bash
 OUTPUT=`/usr/lib/nagios/plugins/check_puppet_agent`
 CODE=$?
-printf "<%= @ipaddress_eth0 %>\tpuppet last run errors\t$CODE\t$OUTPUT\n" | /usr/sbin/send_nsca -H <%= @alert_hostname %>
-exit $?
+
+max_retries=10
+retries_count=0
+
+while [ $retries_count -lt $max_retries ]
+do
+
+  printf "<%= @ipaddress_eth0 %>\tpuppet last run errors\t$CODE\t$OUTPUT\n" | \
+    /usr/sbin/send_nsca -H <%= @alert_hostname %> || \
+    restore_failed=$?
+
+  if [ -z "${restore_failed:-}" ]; then
+    exit 0
+  fi
+
+  retries_count=$((retries_count+1))
+  sleep $((retries_count * 20))
+
+done
+
+exit "${restore_failed}"


### PR DESCRIPTION
# Context

After the puppet cronjob on each machine runs, the puppet status is sent to the monitoring machine. This is a one shot this. We want to build resilience by having retries.

# Decisions
1. retries with backoff to report the state of the puppet run to icinga/monitoring box