### PR TITLE
Amend Publishing-Api Data Sync for Staging

### DIFF
--- a/hieradata_aws/class/staging/db_admin.yaml
+++ b/hieradata_aws/class/staging/db_admin.yaml
@@ -74,7 +74,7 @@ govuk_env_sync::tasks:
     storagebackend: "s3"
     database: "publishing_api_production"
     temppath: "/tmp/publishing_api_production"
-    url: "govuk-staging-database-backups"
+    url: "govuk-integration-database-backups"
     path: "postgresql-backend"
   "pull_support_contacts_production_daily":
     ensure: "present"


### PR DESCRIPTION
Pull data from Integration rather than Staging
Environment for testing (we are having trouble restoring old dumps
from Staging and Integration contains more recent data).