### PR TITLE
during the router db restore in integration, migrate licensify backend

### DIFF
--- a/modules/govuk_env_sync/files/govuk_env_sync.sh
+++ b/modules/govuk_env_sync/files/govuk_env_sync.sh
@@ -539,8 +539,11 @@ function postprocess_router {
       function(b) { b.backend_url = b.backend_url.replace(\".${source_domain}\", \".${local_domain}\"); \
     db.backends.save(b); } ); "
 
-  licensify_domain="${unmigrated_source_domain}"
-  mongo_backend_domain_manipulator "licensify" "${licensify_domain}"
+  # licensify has been migrated in only integration so far
+  if [ "${aws_environment}" != "integration" ]; then
+    licensify_domain="${unmigrated_source_domain}"
+    mongo_backend_domain_manipulator "licensify" "${licensify_domain}"
+  fi
 
   whitehall_domain="${unmigrated_source_domain}"
   mongo_backend_domain_manipulator "whitehall-frontend" "${whitehall_domain}"


### PR DESCRIPTION
During the router db restore in AWS integration, the licensify backend should be modified to reflect that it has been migrated to AWS.