### PR TITLE
Bump finder-frontend worker processes

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -66,6 +66,11 @@ govuk::apps::email_alert_api::db::backend_ip_range: '10.3.3.0/24'
 govuk::apps::email_alert_api::email_archive_s3_bucket: 'govuk-production-email-alert-api-archive'
 govuk::apps::email_alert_api::email_archive_s3_enabled: true
 govuk::apps::email_alert_api::govuk_notify_template_id: 'cb633abc-6ae6-4843-ae6f-82ca500b6de2'
+
+govuk::apps::finder_frontend::nagios_memory_warning: 4000
+govuk::apps::finder_frontend::nagios_memory_critical: 5000
+govuk::apps::finder_frontend::unicorn_worker_processes: "12"
+
 govuk::apps::government-frontend::cpu_warning: 200
 govuk::apps::government-frontend::cpu_critical: 300
 govuk::apps::hmrc_manuals_api::publish_topics: false

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -31,6 +31,11 @@ govuk::apps::email_alert_api::email_address_override: 'success@simulator.amazons
 govuk::apps::email_alert_api::email_address_override_whitelist_only: true
 govuk::apps::email_alert_api::delivery_request_threshold: "3000"
 govuk::apps::email_alert_frontend::subscription_management_enabled: true
+
+govuk::apps::finder_frontend::nagios_memory_warning: 4000
+govuk::apps::finder_frontend::nagios_memory_critical: 5000
+govuk::apps::finder_frontend::unicorn_worker_processes: "12"
+
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::imminence::ensure: 'absent'
 govuk::apps::government-frontend::cpu_warning: 200

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -136,6 +136,11 @@ govuk::apps::email_alert_api::email_archive_s3_bucket: 'govuk-production-email-a
 # This shouldn't be enabled at the same time we have carrenza s3 export enabled unless they have separate buckets
 govuk::apps::email_alert_api::email_archive_s3_enabled: false
 govuk::apps::email_alert_api::govuk_notify_template_id: '76d21ce7-54c3-4fb7-8830-ba3b79287985'
+
+govuk::apps::finder_frontend::nagios_memory_warning: 4000
+govuk::apps::finder_frontend::nagios_memory_critical: 5000
+govuk::apps::finder_frontend::unicorn_worker_processes: "12"
+
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::kibana::logit_environment: 283f08f6-d117-48df-9667-c4aa492b81f9
 govuk::apps::link_checker_api::govuk_basic_auth_credentials: "%{hiera('http_username')}:%{hiera('http_password')}"

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -135,6 +135,10 @@ govuk::apps::email_alert_api::email_address_override_whitelist_only: true
 govuk::apps::email_alert_api::delivery_request_threshold: "3000"
 govuk::apps::email_alert_frontend::subscription_management_enabled: true
 
+govuk::apps::finder_frontend::nagios_memory_warning: 4000
+govuk::apps::finder_frontend::nagios_memory_critical: 5000
+govuk::apps::finder_frontend::unicorn_worker_processes: "12"
+
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::kibana::logit_environment: b13bfb70-e07a-473b-9903-02e806ebd045
 govuk::apps::link_checker_api::govuk_basic_auth_credentials: "%{hiera('http_username')}:%{hiera('http_password')}"


### PR DESCRIPTION
6 worker process on finder-frontend uses about 1.4GB at normal running. We'll need to bump the instance size to maybe a c5.2xlarge to get a better processor and more memory before we deploy
this.

We could perhaps scale down the number of machines a little too :-)