### PR TITLE
allow govuk-load-testing to be fetched over ssh

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -284,6 +284,9 @@ task :check_consistency_between_aws_and_carrenza do
     govuk::node::s_asset_base::alert_hostname
     govuk::node::s_base::log_remote
     govuk::node::s_gatling::apt_mirror_hostname
+    govuk::node::s_gatling::repo
+    govuk::node::s_gatling::ssh_public_key
+    govuk::node::s_gatling::ssh_private_key
     govuk::node::s_postgresql_primary::alert_hostname
     govuk_bundler::config::service
     govuk_containers::apps::router::envvars

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -830,6 +830,9 @@ govuk::node::s_content_data_api_db_admin::apt_mirror_hostname: "%{hiera('apt_mir
 govuk::node::s_email_alert_api_db_admin::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 govuk::node::s_gatling::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk::node::s_gatling::repo: 'git@github.com:alphagov/govuk-load-testing.git'
+govuk::node::s_gatling::ssh_public_key: "%{hiera('govuk_jenkins::ssh_key::public_key')}"
+govuk::node::s_gatling::ssh_private_key: "%{hiera('govuk_jenkins::ssh_key::private_key')}"
 
 govuk::node::s_graphite::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 

--- a/modules/govuk/manifests/node/s_gatling.pp
+++ b/modules/govuk/manifests/node/s_gatling.pp
@@ -16,13 +16,21 @@
 #  The version of the repository where GOV.UK defines its load tests
 #  Default = 'master'
 #
+# [*ssh_public_key*]
+#  ssh public key of user which has access to govuk-load-testing repo
+#  Default = undef
 #
+# [*ssh_private_key*]
+#  ssh private key of user which has access to govuk-load-testing repo
+#  Default = undef
 #
 class govuk::node::s_gatling (
   $root_dir            = '/usr/local/bin/gatling/results',
   $repo                = 'https://github.com/alphagov/govuk-load-testing.git',
   $commit              = 'master',
   $apt_mirror_hostname = undef,
+  $ssh_public_key      = undef,
+  $ssh_private_key     = undef,
 ) inherits govuk::node::s_base {
 
   # User used to run Gatling
@@ -30,6 +38,24 @@ class govuk::node::s_gatling (
     fullname => 'GOV.UK Gatling',
     email    => 'webops@digital.cabinet-office.gov.uk',
     groups   => ['admin', 'deploy', 'adm', 'www-data' ],
+  }
+
+  if $ssh_private_key and $ssh_public_key {
+    file { '/home/gatling/.ssh/id_rsa.pub':
+      content => "ssh-rsa ${ssh_public_key}",
+      mode    => '0644',
+      owner   => 'gatling',
+      group   => 'gatling',
+      require => User['gatling'],
+    }
+
+    file { '/home/gatling/.ssh/id_rsa':
+      content => $ssh_private_key,
+      mode    => '0600',
+      owner   => 'gatling',
+      group   => 'gatling',
+      require => User['gatling'],
+    }
   }
 
   # repository where GOV.UK stores its load tests


### PR DESCRIPTION
This repo allows govuk-load-tesing to be fetched over ssh compared to https only previously.