### PR TITLE
Make publishing-api in AWS Staging/Prod use Signon in Carrenza.

### DIFF
--- a/modules/govuk/manifests/node/s_publishing_api.pp
+++ b/modules/govuk/manifests/node/s_publishing_api.pp
@@ -32,6 +32,16 @@ class govuk::node::s_publishing_api inherits govuk::node::s_base {
     $extra_config = ''
   }
 
+  if ($::aws_environment == 'staging') or ($::aws_environment == 'production') {
+    # For AWS staging and production, use the external domain name when
+    # constructing the URI for talking to Signon. This is needed while Signon
+    # is still in Carrenza.
+    $app_domain = hiera('app_domain')
+    govuk_envvar {
+      'PLEK_SERVICE_SIGNON_URI': value => "https://signon.${app_domain}";
+    }
+  }
+
   # If we miss all the apps, throw a 500 to be caught by the cache nginx
   nginx::config::vhost::default { 'default':
     extra_config => $extra_config,


### PR DESCRIPTION
Publishing API in Staging and Prod is being migrated to AWS but Signon
will remain in Carrenza for the time being. We therefore need to
override the Plek service discovery config so that Publishing API can
talk to Signon from the new Staging and Prod environments.

We accomplish this by using the external domain name when constructing
the URI for publishing-api to talk to Signon. This can be removed once
Signon is moved to AWS.