### PR TITLE
Safelist package search after PII data is removed

### DIFF
--- a/modules/govuk/templates/ckan/nginx.conf.erb
+++ b/modules/govuk/templates/ckan/nginx.conf.erb
@@ -36,6 +36,18 @@ location /api/action/package_list {
   try_files $uri @app;
 }
 
+# Additional endpoints requested by users
+
+location /api/action/package_search {
+  try_files $uri @app;
+}
+
+location /api/3/action/package_search {
+  try_files $uri @app;
+}
+
+# CSW endpoint
+
 location /csw {
   <%- if @protected -%>
   deny all;


### PR DESCRIPTION
## What

Allow access to `/api/action/package_search` and `/api/3/action/package_search`

https://github.com/alphagov/ckanext-datagovuk/pull/197 was deployed which removed PII from package search and show endpoints.

## Reference

https://trello.com/c/GrO3ZtIR/1228-remove-personal-data-from-ckan-api-endpoints