### PR TITLE
Back up Publishing API Carrenza Prod to S3 via env_sync.

### DIFF
--- a/hieradata/node/postgresql-primary-1.backend.publishing.service.gov.uk.yaml
+++ b/hieradata/node/postgresql-primary-1.backend.publishing.service.gov.uk.yaml
@@ -1,0 +1,12 @@
+govuk_env_sync::tasks:
+  "push_publishing_api_production_daily":
+    ensure: "present"
+    hour: "2"
+    minute: "20"
+    action: "push"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "publishing_api_production"
+    temppath: "/var/lib/autopostgresqlbackup/publishing_api_production"
+    url: "govuk-production-database-backups"
+    path: "postgresql-backend"


### PR DESCRIPTION
This is needed in preparation for migrating Publishing API to AWS.
There is an existing, older backup job but this is more difficult to
restore into the AWS environment. Using govuk_env_sync simplifies the
migration process.