### PR TITLE
Ignore missing timeseries on the rest of the 429 alerts.

### DIFF
--- a/modules/govuk/manifests/node/s_backend_lb.pp
+++ b/modules/govuk/manifests/node/s_backend_lb.pp
@@ -184,6 +184,7 @@ class govuk::node::s_backend_lb (
 
     @@icinga::check::graphite { "check_nginx_429_assets_on_${::hostname}":
       target              => $graphite_429_target,
+      args                => '--ignore-missing',
       warning             => 3,
       critical            => 5,
       from                => '5minutes',

--- a/modules/router/manifests/assets_origin.pp
+++ b/modules/router/manifests/assets_origin.pp
@@ -68,6 +68,7 @@ class router::assets_origin(
 
   @@icinga::check::graphite { "check_nginx_429_assets_on_${::hostname}":
     target              => $graphite_429_target,
+    args                => '--ignore-missing',
     warning             => 3,
     critical            => 5,
     from                => '5minutes',


### PR DESCRIPTION
This avoids false `UNKNOWN` alerts when new instances come up, since
429s are (or at least should be) rare and the timeseries doesn't get
created until the first 429 response happens.

This change was already made to one of the alerts a month ago, but
I missed these other copies of the alert. See the original PR for
more context: https://github.com/alphagov/govuk-puppet/pull/9421