### PR TITLE
Amend Publishing-API data-sync to Pull Data From Production

### DIFF
--- a/hieradata_aws/class/staging/db_admin.yaml
+++ b/hieradata_aws/class/staging/db_admin.yaml
@@ -74,7 +74,7 @@ govuk_env_sync::tasks:
     storagebackend: "s3"
     database: "publishing_api_production"
     temppath: "/tmp/publishing_api_production"
-    url: "govuk-integration-database-backups"
+    url: "govuk-production-database-backups"
     path: "postgresql-backend"
   "pull_support_contacts_production_daily":
     ensure: "present"


### PR DESCRIPTION
Publishing-api production data is now being pushed to AWS S3
so we can enable pull from production again. This is part of
the work to migrate Publishing-API to AWS.