### PR TITLE
add licensify environment hiera for aws integration

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -84,6 +84,10 @@ licensify::apps::configfile::performance_platform_service_url: 'https://www.inte
 licensify::apps::configfile::is_master_node: 'true'
 licensify::apps::licensify::alert_5xx_warning_rate: 0.1
 licensify::apps::licensify::alert_5xx_critical_rate: 0.15
+licensify::apps::licensify::environment: 'integration'
+licensify::apps::licensify_admin::environment: 'integration'
+licensify::apps::licensify_feed::environment: 'integration'
+
 
 govuk_search::monitoring::es_port: '80'
 govuk_search::monitoring::es_host: 'elasticsearch5.blue.integration.govuk-internal.digital'


### PR DESCRIPTION
# Context

For the licensify testing in AWS integration, there is a need for licensify bucket environment hiera for aws integration because otherwise, the licensify apps in integration do not have the full path of the AWS s3 bucket to store the application.

# Decisions
1. set the relevant hiera