### PR TITLE
Create publishing_api RabbitMQ user in AWS Staging

### DIFF
--- a/hieradata_aws/class/staging/rabbitmq.yaml
+++ b/hieradata_aws/class/staging/rabbitmq.yaml
@@ -1,5 +1,11 @@
 ---
 
+govuk::node::s_rabbitmq::apps_using_rabbitmq:
+  - content_data_api
+  - cache_clearing_service
+  - publishing_api
+  - search_api
+
 govuk_rabbitmq::federation: 'yes'
 govuk_rabbitmq::federate::federation_user: 'root'
 govuk_rabbitmq::federate::federation_pass: "%{hiera('govuk_rabbitmq::root_password')}"


### PR DESCRIPTION
publishing_api needs to be included in apps_using_rabbitmq in order for its RabbitMQ-related config to get applied. This explains why the user wasn't being created in AWS.

The magic inclusion happens here:
https://github.com/alphagov/govuk-puppet/blob/b588e4ade996e97b8975e69cb00800521fff4a48/modules/govuk/manifests/node/s_rabbitmq.pp#L17

The publishing-api config which wasn't previous being applied to the RabbitMQ nodes is:
https://github.com/alphagov/govuk-puppet/blob/master/modules/govuk/manifests/apps/publishing_api/rabbitmq.pp