### PR TITLE
Safelist ckan api/3/action/organization_show

### DIFF
--- a/modules/govuk/templates/ckan/nginx.conf.erb
+++ b/modules/govuk/templates/ckan/nginx.conf.erb
@@ -14,6 +14,12 @@ location /api/3/action/organization_list {
 }
 
 # Used by: datagovuk_publish
+# Used for: ckan_v26_ckan_org_sync
+location /api/3/action/organization_show {
+  try_files $uri @app;
+}
+
+# Used by: datagovuk_publish
 # Used for: ckan_v26_package_sync job
 location /api/3/search/dataset {
   try_files $uri @app;
@@ -33,6 +39,10 @@ location /api/action/organization_list {
 }
 
 location /api/action/package_list {
+  try_files $uri @app;
+}
+
+location /api/action/organization_show {
   try_files $uri @app;
 }
 


### PR DESCRIPTION
## What

Allow traffic on `organisation_show` endpoint.

## Why

This will allow ckan_v26_ckan_org_sync to be restarted.

## Reference 

https://trello.com/c/ukgvMRf4/1246-remove-users-block-from-ckan-api-organizationshow-endpoint