### PR TITLE
Set ckan_ini to false rather than undef

### DIFF
--- a/modules/govuk/manifests/apps/ckan/cronjobs.pp
+++ b/modules/govuk/manifests/apps/ckan/cronjobs.pp
@@ -46,6 +46,6 @@ class govuk::apps::ckan::cronjobs(
     plugin         => 'ckanext-spatial',
     hour           => '6',
     minute         => '0',
-    ckan_ini       => undef,
+    ckan_ini       => false,
   }
 }


### PR DESCRIPTION
## What

`undef` doesn't appear to prevent the extra ckan arg to be passed in, this causes the pycsw cronjob to fail.

Passing in `false` prevents the extra `ckan` config arg to be passed in which enables the `pycsw` data load to run.