### PR TITLE
Add a docs reminder message for Gatling users

### DIFF
--- a/modules/govuk/manifests/node/s_gatling.pp
+++ b/modules/govuk/manifests/node/s_gatling.pp
@@ -80,8 +80,6 @@ class govuk::node::s_gatling (
     }
   }
 
-
-
   # install the JRE and JDK on the Gatling instance
   include ::govuk_java::openjdk8::jre
   include ::govuk_java::openjdk8::jdk

--- a/modules/govuk/manifests/node/s_gatling.pp
+++ b/modules/govuk/manifests/node/s_gatling.pp
@@ -40,8 +40,10 @@ class govuk::node::s_gatling (
     groups   => ['admin', 'deploy', 'adm', 'www-data' ],
   }
 
+  $home = '/home/gatling'
+
   if $ssh_private_key and $ssh_public_key {
-    file { '/home/gatling/.ssh/id_rsa.pub':
+    file { "${home}/.ssh/id_rsa.pub":
       content => "ssh-rsa ${ssh_public_key}",
       mode    => '0644',
       owner   => 'gatling',
@@ -49,7 +51,7 @@ class govuk::node::s_gatling (
       require => User['gatling'],
     }
 
-    file { '/home/gatling/.ssh/id_rsa':
+    file { "${home}/.ssh/id_rsa":
       content => $ssh_private_key,
       mode    => '0600',
       owner   => 'gatling',
@@ -58,7 +60,7 @@ class govuk::node::s_gatling (
     }
 
     # repository where GOV.UK stores its load tests
-    vcsrepo { '/home/gatling/govuk-load-testing':
+    vcsrepo { "${home}/govuk-load-testing":
       ensure   => present,
       provider => git,
       source   => $repo,
@@ -69,7 +71,7 @@ class govuk::node::s_gatling (
     }
   } else {
     # repository where GOV.UK stores its load tests
-    vcsrepo { '/home/gatling/govuk-load-testing':
+    vcsrepo { "${home}/govuk-load-testing":
       ensure   => present,
       provider => git,
       source   => $repo,

--- a/modules/govuk/manifests/node/s_gatling.pp
+++ b/modules/govuk/manifests/node/s_gatling.pp
@@ -113,4 +113,12 @@ class govuk::node::s_gatling (
   nginx::config::site { 'gatling_service':
     content => template('govuk/node/s_gatling/gatling_cluster_vhost.conf.erb'),
   }
+
+  file { "${home}/.bashrc":
+    content => template('govuk/node/s_gatling/bashrc.erb'),
+    mode    => '0644',
+    owner   => 'gatling',
+    group   => 'gatling',
+    require => User['gatling'],
+  }
 }

--- a/modules/govuk/templates/node/s_gatling/bashrc.erb
+++ b/modules/govuk/templates/node/s_gatling/bashrc.erb
@@ -1,0 +1,6 @@
+echo "---------------------------------------------------------"
+echo "👋 Welcome to Gatling!"
+echo "⚠️ Don't forget to upload your results and command to S3:"
+echo "    https://github.com/alphagov/govuk-load-testing/blob/master/docs/uploading.md"
+echo "🔎 Results can be found at: <%= @root_dir %>"
+echo "---------------------------------------------------------"


### PR DESCRIPTION
This should help users to remember to upload their results and command they used.

[Trello Card](https://trello.com/c/hLcXe1zf/1249-2-define-a-way-to-store-gatling-run-commands-for-each-test)