### PR TITLE
Add a space after emoji

### DIFF
--- a/modules/govuk/templates/node/s_gatling/bashrc.erb
+++ b/modules/govuk/templates/node/s_gatling/bashrc.erb
@@ -1,6 +1,6 @@
 echo "---------------------------------------------------------"
 echo "👋 Welcome to Gatling!"
-echo "⚠️ Don't forget to upload your results and command to S3:"
+echo "⚠️  Don't forget to upload your results and command to S3:"
 echo "    https://github.com/alphagov/govuk-load-testing/blob/master/docs/uploading.md"
 echo "🔎 Results can be found at: <%= @root_dir %>"
 echo "---------------------------------------------------------"


### PR DESCRIPTION
The emoji seems to take up the area of the existing space and the alignment looks all wrong!

<img width="668" alt="Screen Shot 2019-09-09 at 07 48 54" src="https://user-images.githubusercontent.com/510498/64508834-50af2280-d2d6-11e9-8447-9636a8f6ef8c.png">
