### PR TITLE
Move TARGET_MACHINES under TAG

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
@@ -84,15 +84,15 @@
                 - app:hard_restart
                 - app:migrate_and_hard_restart
         - string:
+            name: TAG
+            description: Git commit-ish (tag, branch name, commit hash) to deploy.
+            default: release
+        - string:
             name: TARGET_MACHINES
             description: >
               Use "all" to target all eligible servers or
               provide a comma-delimited list of FQDN of the servers to deploy to.
             default: all
-        - string:
-            name: TAG
-            description: Git commit-ish (tag, branch name, commit hash) to deploy.
-            default: release
         - bool:
             name: DEPLOY_FROM_AWS_CODECOMMIT
             default: false


### PR DESCRIPTION
It used to be the case that `TAG` was always under `DEPLOY_TASK` and since we've added the new `TARGET_MACHINES` field I've entered the branch I wanted to deploy into that field multiple times. Although this is just memory that I could get used to, I think it also makes sense to put the fields which are more likely to be used nearer the top. `TARGET_MACHINES` is very unlikely to be manually changed by a human when deploying an app whereas it's very common to change the `TAG`.