### PR TITLE
Revert "Update healthcheck path for Government Frontend"

### DIFF
--- a/modules/govuk/manifests/apps/government_frontend.pp
+++ b/modules/govuk/manifests/apps/government_frontend.pp
@@ -60,7 +60,7 @@ class govuk::apps::government_frontend(
     port                     => $port,
     sentry_dsn               => $sentry_dsn,
     vhost_ssl_only           => true,
-    health_check_path        => '/government/case-studies/example-case-studies-eu-citizens-rights-in-the-uk',
+    health_check_path        => '/healthcheck',
     asset_pipeline           => true,
     asset_pipeline_prefix    => 'government-frontend',
     vhost                    => $vhost,


### PR DESCRIPTION
Switch back to using /healthcheck, as using a item of content doesn't
seem appropriate for a healthcheck. I'm unsure what the behaviour of
Icinga, and the AWS load balancers will be if this item of content is
moved (resulting in a redirect), or unpublished (maybe resulting in a
gone response).

I think the motivation at the time was to have the healthcheck cover
more of the applications functionality, but the way to do that is
improve the healthcheck to cover more of the health of the
application.

This reverts commit dc67b8bfe3eabfc5a2a4ed470266d043b6532b5e.