### PR TITLE
Reduce time period for memory restarts alert

### DIFF
--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -351,7 +351,7 @@ define govuk::app::config (
       ensure         => $ensure,
       target         => "summarize(transformNull(stats_counts.govuk.app.${title}.memory_restarts,0),\"1d\",\"sum\",false)",
       args           => '--ignore-missing',
-      from           => '2days',
+      from           => '3hours',
       warning        => 4,
       critical       => 10 ,
       desc           => 'Restarts per day due to excessive memory usage',


### PR DESCRIPTION
This was increased to 2days because it was causing Graphite to return an error. This won't happen now, since I guess transformNull is now being used?

This won't make alerts go away if restarts are still happening, but will prevent alerts from the previous day continuing to show up in Icinga.

Before: (threshold passed by old issues)

<img width="1014" alt="Screen Shot 2019-09-11 at 11 36 58" src="https://user-images.githubusercontent.com/8124374/64690556-990e4200-d488-11e9-8806-069b262d8c42.png">


After: (no issues)

<img width="1014" alt="Screen Shot 2019-09-11 at 11 37 09" src="https://user-images.githubusercontent.com/8124374/64690562-9b709c00-d488-11e9-89f8-564ff0174057.png">
