### PR TITLE
Use cron resource to remove old whisper data

### DIFF
--- a/modules/govuk/manifests/node/s_graphite.pp
+++ b/modules/govuk/manifests/node/s_graphite.pp
@@ -101,10 +101,23 @@ class govuk::node::s_graphite (
 
   ## The way we generate graphite data with changing hostnames in AWS require a bit of clean up
   if $::aws_migration {
+    $remove_old_whisper_data_bin = '/usr/local/bin/remove-old-whisper-data'
+
     file { '/etc/cron.daily/remove_old_whisper_data':
+      ensure  => absent,
+    }
+
+    file { $remove_old_whisper_data_bin:
       ensure  => present,
       content => template('govuk/node/s_graphite/remove_old_whisper_data.erb'),
       mode    => '0755',
+    }
+
+    cron::crondotdee { 'remove-old-whisper-data':
+      command => $remove_old_whisper_data_bin,
+      hour    => 2,
+      minute  => 0,
+      require => File[$remove_old_whisper_data_bin],
     }
   }
 


### PR DESCRIPTION
This makes it easier to run the task manually because it can be a separate command and it means we can rely on Puppet to manage the cron job for us.

[Trello Card](https://trello.com/c/VugQy0iY/1210-3-improve-how-we-remove-old-graphite-data)