### PR TITLE
Sync Licensify database from Prod to AWS Staging and Integration.

### DIFF
--- a/hieradata_aws/class/integration/db_admin.yaml
+++ b/hieradata_aws/class/integration/db_admin.yaml
@@ -241,20 +241,22 @@ govuk_env_sync::tasks:
     temppath: "/tmp/whitehall_production"
     url: "govuk-integration-database-backups"
     path: "mysql-backend"
-  "pull_licensify_integration_daily": &pull_licensify
-    ensure: absent
-    hour: '4'
-    minute: '0'
-    action: pull
-    dbms: documentdb
-    storagebackend: s3
-    database: licensify
-    temppath: /var/lib/documentdb/.dumps
-    url: govuk-staging-database-backups
-    path: mongo-licensing
-  "pull_licensify_audit_integration_daily":
+  "pull_licensify_staging_daily": &pull_licensify
+    ensure: "present"
+    hour: "5"
+    minute: "45"
+    action: "pull"
+    dbms: "documentdb"
+    storagebackend: "s3"
+    database: "licensify"
+    temppath: "/tmp/licensify_staging"
+    url: "govuk-staging-database-backups"
+    path: "mongo-licensing"
+  "pull_licensify_audit_staging_daily":
     <<: *pull_licensify
-    database: licensify-audit
-  "pull_licensify_refdata_integration_daily":
+    database: "licensify-audit"
+    hour: "6"
+    minute: "0"
+  "pull_licensify_refdata_staging_daily":
     <<: *pull_licensify
-    database: licensify-refdata
+    database: "licensify-refdata"

--- a/hieradata_aws/class/staging/db_admin.yaml
+++ b/hieradata_aws/class/staging/db_admin.yaml
@@ -87,3 +87,22 @@ govuk_env_sync::tasks:
     temppath: "/tmp/support_contacts_production"
     url: "govuk-production-database-backups"
     path: "postgresql-backend"
+  "pull_licensify_production_daily": &pull_licensify
+    ensure: "present"
+    hour: "4"
+    minute: "45"
+    action: "pull"
+    dbms: "documentdb"
+    storagebackend: "s3"
+    database: "licensify"
+    temppath: "/tmp/licensify_production"
+    url: "govuk-production-database-backups"
+    path: "mongo-licensing"
+  "pull_licensify_audit_production_daily":
+    <<: *pull_licensify
+    database: "licensify-audit"
+    hour: "5"
+    minute: "0"
+  "pull_licensify_refdata_production_daily":
+    <<: *pull_licensify
+    database: "licensify-refdata"


### PR DESCRIPTION
Now that the production database contains no records which can't be
imported into DocumentDB, we want to sync the production data to the
other two environments.

 - AWS Staging pulls from UKCloud Prod.
 - AWS Integration pulls from UKCloud Staging (which pulls from UKCloud Prod).

The timing is intended to line up approximately with the backups from
UKCloud, which happen at 04:00. The idea is that the restores happen
(hopefully) after the backups have completed and we avoid a day's
unnecessary delay.