### PR TITLE
Add Go versions 1.11.13 & 1.13

### DIFF
--- a/modules/golang/manifests/init.pp
+++ b/modules/golang/manifests/init.pp
@@ -11,7 +11,7 @@ class golang {
     require        => Class['govuk_ppa'],
   }
 
-  goenv::version { ['1.7.1', '1.9.1', '1.12.1', '1.12.9']: }
+  goenv::version { ['1.7.1', '1.9.1', '1.11.13', '1.12.1', '1.12.9', '1.13']: }
 
   package { ['godep']:
     ensure  => latest,


### PR DESCRIPTION
Go versions 1.11 and up are still supported. We want to upgrade
the version of go we use gradually, so this adds a couple of
versions for that reason. The aim is to get from 1.9 to 1.13 via
1.11 and 1.12. We saw issues with 1.12 which led to reverting the
upgrade (https://github.com/alphagov/router/pull/142), so we'll try
1.11 first.