### PR TITLE
Remove logit redirect

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -424,8 +424,6 @@ govuk::apps::government_frontend::nagios_memory_warning: 2500
 govuk::apps::government_frontend::nagios_memory_critical: 2800
 govuk::apps::government_frontend::unicorn_worker_processes: "8"
 
-govuk::apps::kibana::logit_account: 1c6b2316-16e2-4ca5-a3df-ff18631b0e74
-
 govuk::apps::link_checker_api::db_hostname: "postgresql-primary-1.backend"
 govuk::apps::link_checker_api::db_port: 6432
 govuk::apps::link_checker_api::db_allow_prepared_statements: false

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -70,7 +70,6 @@ govuk::apps::government-frontend::cpu_warning: 200
 govuk::apps::government-frontend::cpu_critical: 300
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::imminence::ensure: 'absent'
-govuk::apps::kibana::logit_environment: 0ea55710-075b-4eab-bfc3-475f28cdd0c3
 govuk::apps::link_checker_api::ensure: 'absent'
 govuk::apps::local_links_manager::ensure: 'absent'
 govuk::apps::local_links_manager::local_links_manager_passive_checks: true

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -35,7 +35,6 @@ govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::imminence::ensure: 'absent'
 govuk::apps::government-frontend::cpu_warning: 200
 govuk::apps::government-frontend::cpu_critical: 300
-govuk::apps::kibana::logit_environment: d414187a-2796-4ea7-9b9a-d40c341646d6
 govuk::apps::link_checker_api::ensure: 'absent'
 govuk::apps::link_checker_api::govuk_basic_auth_credentials: "%{hiera('http_username')}:%{hiera('http_password')}"
 govuk::apps::local_links_manager::ensure: 'absent'

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -584,8 +584,6 @@ govuk::apps::imminence::unicorn_worker_processes: "4"
 
 govuk::apps::info_frontend::enabled: true
 
-govuk::apps::kibana::logit_account: 1c6b2316-16e2-4ca5-a3df-ff18631b0e74
-
 govuk::apps::local_links_manager::db_hostname: "postgresql-primary"
 govuk::apps::local_links_manager::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 govuk::apps::local_links_manager::db::allow_auth_from_lb: true

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -37,7 +37,6 @@ govuk::apps::email_alert_api::delivery_request_threshold: "3000"
 govuk::apps::email_alert_frontend::subscription_management_enabled: true
 govuk::apps::govuk_crawler_worker::enabled: false
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
-govuk::apps::kibana::logit_environment: 2694f14b-6519-4607-81f2-8a2130e5aaec
 govuk::apps::link_checker_api::govuk_basic_auth_credentials: "%{hiera('http_username')}:%{hiera('http_password')}"
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-integration'
 govuk::apps::publishing_api::content_api_prototype: true

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -137,7 +137,6 @@ govuk::apps::email_alert_api::email_archive_s3_bucket: 'govuk-production-email-a
 govuk::apps::email_alert_api::email_archive_s3_enabled: false
 govuk::apps::email_alert_api::govuk_notify_template_id: '76d21ce7-54c3-4fb7-8830-ba3b79287985'
 govuk::apps::hmrc_manuals_api::publish_topics: false
-govuk::apps::kibana::logit_environment: 283f08f6-d117-48df-9667-c4aa492b81f9
 govuk::apps::link_checker_api::govuk_basic_auth_credentials: "%{hiera('http_username')}:%{hiera('http_password')}"
 govuk::apps::publisher::run_fact_check_fetcher: false
 govuk::apps::publisher::fact_check_address_format: 'factcheck+production-{id}@alphagov.co.uk'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -136,7 +136,6 @@ govuk::apps::email_alert_api::delivery_request_threshold: "3000"
 govuk::apps::email_alert_frontend::subscription_management_enabled: true
 
 govuk::apps::hmrc_manuals_api::publish_topics: false
-govuk::apps::kibana::logit_environment: b13bfb70-e07a-473b-9903-02e806ebd045
 govuk::apps::link_checker_api::govuk_basic_auth_credentials: "%{hiera('http_username')}:%{hiera('http_password')}"
 govuk::apps::publisher::run_fact_check_fetcher: false
 govuk::apps::publisher::fact_check_address_format: 'factcheck+staging-{id}@alphagov.co.uk'

--- a/hieradata_aws/training.yaml
+++ b/hieradata_aws/training.yaml
@@ -37,7 +37,6 @@ govuk::apps::email_alert_api::delivery_request_threshold: "3000"
 govuk::apps::email_alert_frontend::subscription_management_enabled: true
 govuk::apps::govuk_crawler_worker::enabled: false
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
-govuk::apps::kibana::logit_environment: 2694f14b-6519-4607-81f2-8a2130e5aaec
 govuk::apps::link_checker_api::govuk_basic_auth_credentials: "%{hiera('http_username')}:%{hiera('http_password')}"
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-training'
 govuk::apps::publishing_api::content_api_prototype: true

--- a/modules/govuk/manifests/apps/kibana.pp
+++ b/modules/govuk/manifests/apps/kibana.pp
@@ -3,16 +3,12 @@
 # A redirect to point people to Kibana provided by Logit.
 # The URL sets the account and environment in a session.
 #
-class govuk::apps::kibana(
-  $logit_account = undef,
-  $logit_environment = undef,
-) {
-
+class govuk::apps::kibana {
   $app_name = 'kibana'
   $app_domain = hiera('app_domain')
 
   nginx::config::vhost::redirect { "${app_name}.${app_domain}":
-    to => "https://logit.io/a/${logit_account}/s/${logit_environment}/kibana/access",
+    to => 'https://docs.publishing.service.gov.uk/manual/logit.html',
   }
 
   if $::aws_migration {


### PR DESCRIPTION
We have been on a hosted kibana instance for a long time now and
probably don't need the redirect in place.