### PR TITLE
no need to change back licensify router url after aws migration

### DIFF
--- a/modules/govuk_env_sync/files/govuk_env_sync.sh
+++ b/modules/govuk_env_sync/files/govuk_env_sync.sh
@@ -548,14 +548,6 @@ function postprocess_router {
       function(b) { b.backend_url = b.backend_url.replace(\".${source_domain}\", \".${local_domain}\"); \
     db.backends.save(b); } ); "
 
-  # licensify has been migrated in only integration so far
-  if [ "${aws_environment}" == "integration" ]; then
-    licensify_domain="${local_domain}"
-  else
-    licensify_domain="${unmigrated_source_domain}"
-  fi
-  mongo_backend_domain_manipulator "licensify" "${licensify_domain}"
-
   # whitehall has been migrated in only integration so far
   if [ "${aws_environment}" == "integration" ]; then
     whitehall_domain="${local_domain}"


### PR DESCRIPTION
# Context

Before licensify was migrated to AWS, there was a need to do a revert of the backend_url for it during router backup restore because the restore rewrote all the backend_urls to point to AWS. Since licensify is now migrated to AWS, there is no need for that.

# Decisions
1. Do not revert the licensify backend_url to Carrenza/UKCloud during router database restore.