### PR TITLE
Fix Permissions Errors For Splunk Log Directory

### DIFF
--- a/modules/govuk_splunk/manifests/init.pp
+++ b/modules/govuk_splunk/manifests/init.pp
@@ -52,6 +52,14 @@ class govuk_splunk(
     require => Apt::Source['splunk'],
   }
 
+  file {'/opt/splunkforwarder/var':
+    ensure  => directory,
+    owner   => 'splunk',
+    group   => 'splunk',
+    mode    => '0710',
+    require => Package['splunkforwarder'],
+  }
+
   package { 'acl':
     ensure  => latest,
   }


### PR DESCRIPTION
New Calculator Frontend boxes are created
with incorrect permissions on the
/opt/splunkforwarder/var directory this prevents
Splunk from writing to the logs and causes an error.
This PR fixes this issue.