### PR TITLE
Stop Whitehall Overdue Publications Alert Showing In AWS Icinga

### DIFF
--- a/modules/monitoring/manifests/checks.pp
+++ b/modules/monitoring/manifests/checks.pp
@@ -61,16 +61,18 @@ class monitoring::checks (
     require => Icinga::Plugin['check_http_timeout_noncrit'],
   }
 
-  icinga::check { "check_whitehall_overdue_from_${::hostname}":
-    check_command              => 'check_whitehall_overdue',
-    service_description        => 'overdue publications in Whitehall',
-    use                        => 'govuk_urgent_priority',
-    host_name                  => $::fqdn,
-    notes_url                  => monitoring_docs_url(whitehall-scheduled-publishing),
-    action_url                 => "https://${whitehall_hostname}${whitehall_overdue_url}",
-    event_handler              => 'publish_overdue_whitehall',
-    attempts_before_hard_state => 2,
-    retry_interval             => 10,
+  if $::aws_migration == undef {
+    icinga::check { "check_whitehall_overdue_from_${::hostname}":
+      check_command              => 'check_whitehall_overdue',
+      service_description        => 'overdue publications in Whitehall',
+      use                        => 'govuk_urgent_priority',
+      host_name                  => $::fqdn,
+      notes_url                  => monitoring_docs_url(whitehall-scheduled-publishing),
+      action_url                 => "https://${whitehall_hostname}${whitehall_overdue_url}",
+      event_handler              => 'publish_overdue_whitehall',
+      attempts_before_hard_state => 2,
+      retry_interval             => 10,
+    }
   }
 
   $warning_time = 5


### PR DESCRIPTION
Whitehall is currently running only in Carrenza, so having this
alert appear on the AWS Icinga dashboards can be
misleading/confusing. This PR confines the alert to the Icinga
Carrenza Icinga dashboards only.