### PR TITLE
Rate limit /contact/govuk without trailing slash

### DIFF
--- a/modules/router/templates/router_include.conf.erb
+++ b/modules/router/templates/router_include.conf.erb
@@ -55,7 +55,7 @@ location ~ ^/performance/ {
 
 # This list of URLS should be kept in sync with the POST-able routes in the
 # feedback application
-location ~ ^/contact/govuk/(|service-feedback|problem_reports|foi|page_improvements|email-survey-signup|assisted-digital-survey-feedback)$ {
+location ~ ^/contact/govuk(/(|service-feedback|problem_reports|foi|page_improvements|email-survey-signup|assisted-digital-survey-feedback))?$ {
   limit_req zone=contact burst=4 nodelay;
   proxy_pass http://varnish;
 }


### PR DESCRIPTION
Currently the regular expression doesn't match against `/contact/govuk` because it requires a trailing slash. By introducing an optional group with a `/` at the beginning, we can make sure to match against both `/contact/govuk` and `/contact/govuk/`.

I'm not very familiar with regular expressions - there might be a better way of expressing this condition.

[Trello Card](https://trello.com/c/yYDYUuQi/1271-5-investigate-adding-rate-limiting-to-govuk-contact-govuk)