### PR TITLE
remove the licensify hosts entries in carrenza/ukcloud

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -152,11 +152,6 @@ hosts::production::ip_backend_lb: '10.1.3.254'
 hosts::production::ip_bouncer: '31.210.245.101'
 hosts::production::ip_draft_api_lb: '10.1.4.253'
 hosts::production::ip_frontend_lb: '10.1.2.254'
-hosts::production::licensify_hosts:
-  licensify.integration.publishing.service.gov.uk:
-    ip: '31.210.245.116'
-  licensify-admin.integration.publishing.service.gov.uk:
-    ip: '31.210.245.117'
 
 hosts::production::backend::app_hostnames:
   - 'asset-manager'

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -191,11 +191,6 @@ hosts::production::ip_backend_lb: '10.2.3.254'
 hosts::production::ip_bouncer: '37.26.91.5'
 hosts::production::ip_draft_api_lb: '10.2.4.253'
 hosts::production::ip_frontend_lb: '10.2.2.254'
-hosts::production::licensify_hosts:
-  licensify.staging.publishing.service.gov.uk:
-    ip: '37.26.91.8'
-  licensify-admin.staging.publishing.service.gov.uk:
-    ip: '37.26.91.8'
 
 hosts::production::api::hosts:
   api-1:


### PR DESCRIPTION
# Context

These entries need to be removed as licensify is now migrated to AWS in staging and integration environment. Any host should use the AWS DNS service to get these IP addresses rather than use the host entries.

# Decisions
1. remove licensify from hosts file for Carrenza/UKCloud integration and staging