### PR TITLE
Add and update MIME types for woff and woff2

### DIFF
--- a/modules/nginx/files/etc/nginx/mime.types
+++ b/modules/nginx/files/etc/nginx/mime.types
@@ -33,7 +33,6 @@ types {
 	application/vnd.google-earth.kmz	kmz;
 	application/x-7z-compressed		7z;
 	application/x-cocoa			cco;
-	application/x-font-woff    		woff;
 	application/x-java-archive-diff		jardiff;
 	application/x-java-jnlp-file		jnlp;
 	application/x-makeself			run;
@@ -75,6 +74,9 @@ types {
 	audio/ogg				oga ogg spx;
 	audio/x-realaudio			ra;
 	audio/webm				weba;
+	
+	font/woff    		                woff;
+	font/woff2                              woff2;
 
 	video/3gpp				3gpp 3gp;
 	video/mp4				mp4;


### PR DESCRIPTION
I am somewhat guessing that this is the right place to make this change.

woff files are currently served as `application/x-font-woff`:

```
curl -sI 'https://assets.publishing.service.gov.uk/static/fonts/v1-458f8ea81c-light-048b93884a1b51d20f2a3140541d450cb6b82c6c2cf69128ea1d09fdd9699f30.woff' | grep -Fi 'Content-Type'
Content-Type: application/x-font-woff
```

According to https://www.iana.org/assignments/media-types/font/woff, the 'existing registration `application/font-woff` is deprecated in favor of `font/woff`.

woff2 files are currently being serve as text/plain:

```
$ curl -sI 'https://assets.publishing.service.gov.uk/static/fonts/v1-f38ad40456-light-b98fe790388f58c950f2bed1ca8ad02fa168d6effa7aae7cb7fee81e51183f46.woff2' | grep -Fi 'Content-Type'
Content-Type: text/plain
```

According to https://www.iana.org/assignments/media-types/font/woff2, these file types should be served as `font/woff2`.