### PR TITLE
Add user agent to whitehall overdue check

### DIFF
--- a/modules/icinga/templates/check_whitehall_overdue.cfg.erb
+++ b/modules/icinga/templates/check_whitehall_overdue.cfg.erb
@@ -1,4 +1,0 @@
-define command {
-  command_name check_whitehall_overdue
-  command_line /usr/lib/nagios/plugins/check_http -H whitehall-admin.<%= @app_domain %> -u '/healthcheck/overdue' -a <%= @http_username %>:<%= @http_password %> -s '{"overdue":0}'
-}

--- a/modules/monitoring/templates/check_whitehall_overdue.cfg.erb
+++ b/modules/monitoring/templates/check_whitehall_overdue.cfg.erb
@@ -1,4 +1,4 @@
 define command {
   command_name check_whitehall_overdue
-  command_line /usr/lib/nagios/plugins/check_http_timeout_noncrit -S -H <%= @whitehall_hostname %> -u '<%= @whitehall_overdue_url %>' -a <%= @http_username %>:<%= @http_password %> -s '{"overdue":0}'
+  command_line /usr/lib/nagios/plugins/check_http_timeout_noncrit --useragent="check_http_timeout_noncrit/whitehall_overdue" -S -H <%= @whitehall_hostname %> -u '<%= @whitehall_overdue_url %>' -a <%= @http_username %>:<%= @http_password %> -s '{"overdue":0}'
 }


### PR DESCRIPTION
Otherwise, I believe the requests are made with "Ruby" as the user
agent, which is a bit vague.