### PR TITLE
Increase the read time for the Graphite NGinx proxy

### DIFF
--- a/modules/govuk/manifests/node/s_graphite.pp
+++ b/modules/govuk/manifests/node/s_graphite.pp
@@ -96,6 +96,7 @@ class govuk::node::s_graphite (
     root         => "${graphite_path}/webapp",
     aliases      => $graphite_aliases,
     protected    => false,
+    read_timeout => 30,
     extra_config => $cors_headers,
   }
 


### PR DESCRIPTION
To allow expensive queries more time to complete. This will hopefully
make looking at complex graphs in Grafana easier, with less 504
Gateway timeouts.