### PR TITLE
fix router staging for licensify

### DIFF
--- a/modules/govuk_env_sync/files/govuk_env_sync.sh
+++ b/modules/govuk_env_sync/files/govuk_env_sync.sh
@@ -548,6 +548,13 @@ function postprocess_router {
       function(b) { b.backend_url = b.backend_url.replace(\".${source_domain}\", \".${local_domain}\"); \
     db.backends.save(b); } ); "
 
+  # licensify has been migrated in only integration and staging so far,
+  # remove this once production is migrated too.
+  if [ "${aws_environment}" == "integration" ] || [ "${aws_environment}" == "staging" ]; then
+    licensify_domain="${local_domain}"
+  fi
+  mongo_backend_domain_manipulator "licensify" "${licensify_domain}"
+
   # whitehall has been migrated in only integration so far
   if [ "${aws_environment}" == "integration" ]; then
     whitehall_domain="${local_domain}"


### PR DESCRIPTION
Revert PR: https://github.com/alphagov/govuk-puppet/pull/9592 and continue the custom rewritting of the licensify backend url for integration and staging. This is due to production not being migrated yet.