### PR TITLE
Set user agent for the govuk uptime collector

### DIFF
--- a/modules/monitoring/files/usr/local/bin/govuk_uptime_collector
+++ b/modules/monitoring/files/usr/local/bin/govuk_uptime_collector
@@ -53,7 +53,7 @@ private
     res = http.request(request)
 
     status_code = res.code.to_i
-    (200..299).include?(res.code.to_i)
+    (200..299).include? status_code
   end
 
   def statsd_key

--- a/modules/monitoring/files/usr/local/bin/govuk_uptime_collector
+++ b/modules/monitoring/files/usr/local/bin/govuk_uptime_collector
@@ -50,6 +50,7 @@ private
     http.read_timeout = 20
 
     request = Net::HTTP::Head.new(healthcheck_uri.request_uri)
+    request['User-Agent'] = 'govuk_uptime_collector'
     res = http.request(request)
 
     status_code = res.code.to_i


### PR DESCRIPTION
As currently, I think it uses Ruby, which isn't very disambiguating
for GOV.UK.