### PR TITLE
add option for puppet not to manage clamav running state

### DIFF
--- a/hieradata/node/ci-agent-5.ci.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/ci-agent-5.ci.integration.publishing.service.gov.uk.yaml
@@ -1,3 +1,7 @@
 ---
 govuk_containers::elasticsearch::primary::enable: false
 govuk_containers::elasticsearch::secondary::enable: false
+
+# prevents puppet stopping the service which is does by default as
+# clamav::use_service is set to false for it
+clamav::service::puppet_lifecycle_enable: false

--- a/modules/clamav/manifests/service.pp
+++ b/modules/clamav/manifests/service.pp
@@ -8,13 +8,22 @@
 #   Boolean indicating whether ClamAV should be set up
 #   with service resources and service monitoring.
 #
+# [*puppet_lifecycle_enable*]
+#   Boolean indicating whether ClamAV lifecycle: start, stop,
+#   restart is managed via puppet. Some instances do not need
+#   clamav to be running all the time.
+#   Default: true
+#
 class clamav::service (
-    $use_service
+    $use_service,
+    $puppet_lifecycle_enable = true
   ) {
 
-  service { ['clamav-freshclam', 'clamav-daemon']:
-    ensure => $use_service,
-    enable => $use_service,
+  if $puppet_lifecycle_enable {
+    service { ['clamav-freshclam', 'clamav-daemon']:
+      ensure => $use_service,
+      enable => $use_service,
+    }
   }
 
   if $use_service {


### PR DESCRIPTION
# Context

In some situations, clamav should only be set to run when its functionality
is needed. E.g. runninng licensify integration tests on the CI box.
Hence, we need to add an option for puppet to install clamav on the CI box
but not to manage its running state which will be managed by the
tasks which need clamav.

# Decisions
1. add option not to manage running state of clamav via puppet