### PR TITLE
Updates the JavaScript MIME type to the the one standardised in RFC4329.

### DIFF
--- a/modules/nginx/files/etc/nginx/mime.types
+++ b/modules/nginx/files/etc/nginx/mime.types
@@ -4,7 +4,7 @@ types {
 	text/xml				xml rss;
 	image/gif				gif;
 	image/jpeg				jpeg jpg;
-	application/x-javascript		js;
+	application/javascript		js;
 	application/atom+xml			atom;
 
 	text/csv				csv;

--- a/modules/nginx/files/etc/nginx/mime.types
+++ b/modules/nginx/files/etc/nginx/mime.types
@@ -4,7 +4,7 @@ types {
 	text/xml				xml rss;
 	image/gif				gif;
 	image/jpeg				jpeg jpg;
-	application/javascript		js;
+	application/javascript			js;
 	application/atom+xml			atom;
 
 	text/csv				csv;


### PR DESCRIPTION
The current MIME type for JavaScript is set to `application/x-javascript`:
```
< HTTP/1.1 200 OK
< Content-Type: application/x-javascript
< Server: nginx
```

According to the now standardised [RFC 4329](http://www.rfc-editor.org/rfc/rfc4329.txt) this should be `application/javascript`. More information about this can be seen in this [SO comment](https://stackoverflow.com/a/4101763).
