### PR TITLE
Add health check annotation to app dashboards

### DIFF
--- a/modules/grafana/templates/dashboards/application_dashboard_template.json.erb
+++ b/modules/grafana/templates/dashboards/application_dashboard_template.json.erb
@@ -74,6 +74,17 @@
         "iconColor": "rgb(225, 251, 0)",
         "name": "Restarts",
         "target": "substr(stats.govuk.app.<%= @app_name %>.restarts,3,5)"
+      },
+      {
+        "datasource": "Graphite",
+        "enable": true,
+        "hide": false,
+        "iconColor": "rgb(255, 0, 224)",
+        "limit": 100,
+        "name": "Healthchecks",
+        "showIn": 0,
+        "target": "aliasSub(aliasSub(stats.icinga.service_alert.<%= @instance_prefix %>*.<%= @app_name %>_app_healthcheck.{critical,warning}, \"stats.icinga.service_alert.<%= @instance_prefix %>_\", \"Health on \"), \".<%= @app_name %>_app_healthcheck.\", \": \")",
+        "type": "alert"
       }
     ]
   },


### PR DESCRIPTION
This will add a vertical line (annotation) to app dashboards when the health of an app changes to critical or a warning state.

The text will be "Health on \<ip address\>: critical" for a critical alert.

One can toggle healthcheck annotations off but by default they will be on.

<img width="473" alt="alert" src="https://user-images.githubusercontent.com/8124374/65162752-a18aed80-da31-11e9-9780-37792e4905e9.png">

https://trello.com/c/mlQzhNtn