### PR TITLE
Disable the procfile worker memory check

### DIFF
--- a/modules/govuk/manifests/procfile/worker.pp
+++ b/modules/govuk/manifests/procfile/worker.pp
@@ -120,6 +120,7 @@ define govuk::procfile::worker (
       $memory_critical_threshold_bytes = $memory_critical_threshold * $si_megabyte
 
       @@icinga::check::graphite { "check_${title_underscore}_app_worker_mem_usage${::hostname}":
+        ensure                     => absent, # TODO The event handler isn't working properly yet
         target                     => "${::fqdn_metrics}.processes-app-worker-${title_underscore}.ps_rss",
         warning                    => $memory_warning_threshold_bytes,
         critical                   => $memory_critical_threshold_bytes,


### PR DESCRIPTION
The intent of adding the check was to get Icinga to restart the
service when lots of memory was being used, therefore avoiding failing
checks. However, the event handler doesn't currently work, as the
service sitting above the procfile workers doesn't support the reload
action.

Therefore, disable this check until the event handler can be fixed.