### PR TITLE
Don't replay Licensify traffic which assumes transactional state.

### DIFF
--- a/hieradata_aws/class/production/cache.yaml
+++ b/hieradata_aws/class/production/cache.yaml
@@ -4,3 +4,7 @@ nginx::logging::days_to_keep: 7
 router::gor::add_hosts: false
 router::gor::replay_targets:
   'www-origin.staging.govuk.digital': {}
+router::gor::http_disallow_url:
+  - 'apply-for-a-licence/payment'
+  - 'apply-for-a-licence/redirect'
+  - 'apply-for-a-licence/uploaded'

--- a/hieradata_aws/class/staging/cache.yaml
+++ b/hieradata_aws/class/staging/cache.yaml
@@ -4,3 +4,7 @@ nginx::logging::days_to_keep: 7
 router::gor::add_hosts: false
 router::gor::replay_targets:
   'www-origin.integration.publishing.service.gov.uk': {}
+router::gor::http_disallow_url:
+  - 'apply-for-a-licence/payment'
+  - 'apply-for-a-licence/redirect'
+  - 'apply-for-a-licence/uploaded'

--- a/modules/router/manifests/gor.pp
+++ b/modules/router/manifests/gor.pp
@@ -15,7 +15,8 @@ class router::gor (
   $replay_targets = {},
   $add_hosts = true,
   $input_raw = '127.0.0.1:7999',
-  $http_set_header = 'X-Forwarded-Host:'
+  $http_set_header = 'X-Forwarded-Host:',
+  $http_disallow_url = []
 ) {
   validate_hash($replay_targets)
 
@@ -47,6 +48,7 @@ class router::gor (
         'GET', 'HEAD', 'OPTIONS',
       ],
       '-http-set-header'   => $http_set_header,
+      '-http-disallow-url' => $http_disallow_url,
     },
     envvars => {
       'GODEBUG' => 'netdns=go',

--- a/modules/router/manifests/gor.pp
+++ b/modules/router/manifests/gor.pp
@@ -11,6 +11,13 @@
 #   Whether to add the target IP to the hosts file or not.
 #   Default: true
 #
+# [*http_disallow_url*]
+#   List of regular expressions for excluding URLs from traffic replay. These
+#   are partial matches (that is, the regexs are not implicitly anchored to the
+#   start and end of the string) and are matched against the full URL including
+#   the domain. For example, ["/foo", "/bar"] would exclude "gov.uk/blah/foo/x"
+#   and "gov.uk/bars/".
+#
 class router::gor (
   $replay_targets = {},
   $add_hosts = true,

--- a/modules/router/spec/classes/router__gor_spec.rb
+++ b/modules/router/spec/classes/router__gor_spec.rb
@@ -11,6 +11,7 @@ describe 'router::gor', :type => :class do
     '-input-raw'          => '127.0.0.1:7999',
     '-http-allow-method'  => %w{GET HEAD OPTIONS},
     '-http-set-header'    => 'X-Forwarded-Host:',
+    '-http-disallow-url'  => [],
   }}
 
   context 'no targets defined (disabled)' do


### PR DESCRIPTION
Certain GET requests to Licensify (that is, certain paths under
www.gov.uk/apply-for-a-licence/) only make sense after the licence
application record has been created in the database. This happens via a
POST request which we intentionally exclude from traffic replay.

It therefore doesn't make sense to replay these requests - it isn't a
meaningful way to test those paths. The replayed requests cause errors
(because the expected state is missing from the database) and clutter up
the Staging logs with stacktraces, which frustrates debugging and could
mask other problems.