### PR TITLE
Replace instance_prefix with * in healthcheck query

### DIFF
--- a/modules/grafana/templates/dashboards/application_dashboard_template.json.erb
+++ b/modules/grafana/templates/dashboards/application_dashboard_template.json.erb
@@ -83,7 +83,7 @@
         "limit": 100,
         "name": "Healthchecks",
         "showIn": 0,
-        "target": "aliasSub(aliasSub(stats.icinga.service_alert.<%= @instance_prefix %>*.<%= @app_name %>_app_healthcheck.{critical,warning}, \"stats.icinga.service_alert.<%= @instance_prefix %>_\", \"Health on \"), \".<%= @app_name %>_app_healthcheck.\", \": \")",
+        "target": "aliasSub(aliasSub(stats.icinga.service_alert.*.<%= @app_name %>_app_healthcheck.{critical,warning}, \"stats.icinga.service_alert.\", \"Health on \"), \".<%= @app_name %>_app_healthcheck.\", \": \")",
         "type": "alert"
       }
     ]


### PR DESCRIPTION
Some applications don't have an instance_prefix, so we can just use '*' in these circumstances to fetch the data for healthcheck annotations.