### PR TITLE
Set higher memory thresholds for Mapit

### DIFF
--- a/modules/govuk/manifests/apps/mapit.pp
+++ b/modules/govuk/manifests/apps/mapit.pp
@@ -27,14 +27,16 @@ class govuk::apps::mapit (
 ) {
   if $enabled {
     govuk::app { 'mapit':
-      app_type              => 'procfile',
-      create_pidfile        => false,
-      port                  => $port,
-      vhost_ssl_only        => true,
-      health_check_path     => '/',
-      log_format_is_json    => false,
-      sentry_dsn            => $sentry_dsn,
-      monitor_unicornherder => true,
+      app_type               => 'procfile',
+      create_pidfile         => false,
+      port                   => $port,
+      vhost_ssl_only         => true,
+      health_check_path      => '/',
+      nagios_memory_warning  => 1200,
+      nagios_memory_critical => 2000,
+      log_format_is_json     => false,
+      sentry_dsn             => $sentry_dsn,
+      monitor_unicornherder  => true,
     }
 
     govuk_postgresql::db { 'mapit':


### PR DESCRIPTION
It usually uses ~680MB of memory, but this rises during
deployments. The default warning threshold is 700, and the machines in
Production have ~4GB of memory, most of which is unused. Therefore,
increase the thresholds to avoid failing checks during deployments.