### PR TITLE
Clean up the NGinx proxies on the monitoring machine to graphite

### DIFF
--- a/modules/govuk/manifests/node/s_monitoring.pp
+++ b/modules/govuk/manifests/node/s_monitoring.pp
@@ -37,9 +37,18 @@ class govuk::node::s_monitoring (
   }
 
   if ! $::aws_migration {
-    nginx::config::vhost::proxy { 'graphite':
+    nginx::config::vhost::proxy { 'graphite-proxy':
       to           => ['graphite.cluster'],
-      aliases      => ['graphite.*', 'grafana', 'grafana.*'],
+      aliases      => ['graphite.*'],
+      ssl_only     => true,
+      ssl_certtype => 'wildcard_publishing',
+      protected    => false,
+      root         => '/dev/null',
+    }
+
+    nginx::config::vhost::proxy { 'grafana-proxy':
+      to           => ['graphite.cluster'],
+      aliases      => ['grafana', 'grafana.*'],
       ssl_only     => true,
       ssl_certtype => 'wildcard_publishing',
       protected    => false,


### PR DESCRIPTION
Probably because of internal/external IP address reasons, developer
access to Grafana and Graphite is routed through NGinx on the
monitoring machine (as well as NGinx on the graphite machine).

As the name for the proxy is `graphite`, the logs are pretty
muddled. There are logs for internal and external access to Graphite
on the graphite machine, and logs for access to Grafana (which aren't
pushed to Logit) also on the graphite machine. In addition to this,
there is another set of logs for NGinx on the monitoring machine which
cover external access to both graphite and grafana. This is super
confusing, especially with the Icinga checks, as when the `graphite
nginx 5xx rate too high` check fails, this could actually mean there
are 5xx responses coming from Grafana, not Graphite.

Migrating to AWS is the proper solution to this, but that hasn't
happened yet.... so as a improved workaround, split the proxy in two,
with one set of configuration and logs for proxying requests to
Graphite, and another for Grafana.