### PR TITLE
remove unneccesary backups in for licensity in staging

### DIFF
--- a/hieradata/node/licensing-mongo-1.licensify.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/licensing-mongo-1.licensify.staging.publishing.service.gov.uk.yaml
@@ -1,6 +1,6 @@
 govuk_env_sync::tasks:
   push_licensify: &push_licensify
-    ensure: present
+    ensure: absent
     hour: '4'
     minute: '0'
     action: push

--- a/hieradata/node/licensing-mongo-2.licensify.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/licensing-mongo-2.licensify.staging.publishing.service.gov.uk.yaml
@@ -1,6 +1,1 @@
-mongodb::backup::s3_backups: true
-mongodb::s3backup::cron::realtime_hour:
- - 5
- - 14
- - 19
-mongodb::s3backup::cron::realtime_minute: '0'
+mongodb::backup::enabled: false


### PR DESCRIPTION
Licensify staging has been migrated to AWS so switch off govuk_env_sync in UKCloud Staging for licensity. In addition, switcth off  `automongodbbackup` for licensify because govuk_env_sync is used.