### PR TITLE
Convert check_json_healthcheck to Python 3

### DIFF
--- a/modules/icinga/files/usr/lib/nagios/plugins/check_json_healthcheck
+++ b/modules/icinga/files/usr/lib/nagios/plugins/check_json_healthcheck
@@ -1,6 +1,7 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
-"""Query an app's healthcheck endpoint.
+"""
+Query an app's healthcheck endpoint.
 
 Some of our apps are now following this convention for their healthcheck
 information:
@@ -24,14 +25,12 @@ protocol(optional) as arguments:
 
 """
 
-from __future__ import print_function
-
 from contextlib import closing
 import json
 from socket import timeout
 import sys
-from urllib2 import urlopen, Request, HTTPError
-from urlparse import urlunparse
+from urllib.request import urlopen, Request, HTTPError
+from urllib.parse import urlunparse
 
 
 OK, WARNING, CRITICAL, UNKNOWN = 0, 1, 2, 3


### PR DESCRIPTION
This changes the script so it runs under Python 3. The script itself could be refactored to make it easier to read but that's for a separate PR.

Tested by running the command locally:

```sh
$ ./check_json_healthcheck 80 /healthcheck email-alert-api.publishing.service.gov.uk
```

[Trello Card](https://trello.com/c/q1I4grHw/1222-upgrade-checkjsonhealthcheck-to-python-3)