### PR TITLE
Pick a random minute in the hour to generate sitemaps

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/search_generate_sitemaps.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/search_generate_sitemaps.yaml.erb
@@ -19,7 +19,7 @@
     triggers:
         - timed: |
             TZ=Europe/London
-            0 2 * * *
+            H 2 * * *
     wrappers:
         - ansicolor:
             colormap: xterm


### PR DESCRIPTION
Jenkins caught this:

> Spread load evenly by using ‘H 2 * * *’ rather than ‘0 2 * * *’

We've previously wondered if we were making Jenkins too busy at
certain times of day, so this seems reasonable.