### PR TITLE
Handle Python 3 bytes encoding manually

### DIFF
--- a/modules/icinga/files/usr/lib/nagios/plugins/check_json_healthcheck
+++ b/modules/icinga/files/usr/lib/nagios/plugins/check_json_healthcheck
@@ -155,7 +155,7 @@ if __name__ == "__main__":
 
     try:
         with closing(urlopen(json_request(check_url), timeout=20)) as response:
-            healthcheck_info = HealthCheckInfo(json.load(response))
+            healthcheck_info = HealthCheckInfo(json.loads(response.read().decode('UTF-8')))
     except HTTPError as e:
         report_error("healthcheck returned HTTP error %d" % (e.code,))
     except timeout:


### PR DESCRIPTION
This feature was added in Python 3.6 which we're not running so we have to decode manually: https://docs.python.org/3/whatsnew/3.6.html#json