### PR TITLE
Store Icinga service states as a Gauge statistic

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -569,7 +569,6 @@ licensify::apps::licensify_feed::environment: 'production'
 monitoring::checks::aws_origin_domain: "production.govuk.digital"
 monitoring::checks::ses::region: us-east-1
 monitoring::checks::smokey::environment: 'production'
-monitoring::contacts::notify_graphite: true
 monitoring::contacts::notify_pager: true
 monitoring::contacts::notify_slack: true
 monitoring::contacts::slack_channel: '#govuk-alerts'

--- a/hieradata/staging_disaster_recovery.yaml
+++ b/hieradata/staging_disaster_recovery.yaml
@@ -15,7 +15,6 @@ govuk::deploy::config::website_root: 'https://www.gov.uk'
 # Remove `router::nginx::robotstxt` from staging config
 
 monitoring::checks::ses::region: us-east-1
-monitoring::contacts::notify_graphite: true
 monitoring::contacts::notify_pager: true
 monitoring::edge::enabled: true
 monitoring::pagerduty_drill::enabled: true

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -330,7 +330,6 @@ monitoring::checks::lb::loadbalancers:
   govuk-cache-public: {}
 
 monitoring::checks::cache::region: 'eu-west-1'
-monitoring::contacts::notify_graphite: true
 monitoring::contacts::notify_pager: true
 monitoring::contacts::notify_slack: true
 monitoring::contacts::slack_channel: '#govuk-alerts'

--- a/modules/icinga/templates/notify_graphite.erb
+++ b/modules/icinga/templates/notify_graphite.erb
@@ -1,53 +1,54 @@
 #!/usr/bin/env ruby
 
-require 'optparse'
-require 'socket'
+require "optparse"
+require "socket"
 
 options = {}
 
 OptionParser.new do |opt|
-  opt.banner = 'Send Icinga alert metrics to StatsD'
-  opt.separator 'Options'
+  opt.banner = "Send Icinga alert metrics to StatsD"
+  opt.separator "Options"
 
-  opt.on('-h', '--hostname Hostname', 'Host display name') do |host_display_name|
+  opt.on("-h", "--hostname Hostname", "Host display name") do |host_display_name|
     options[:host_display_name] = host_display_name
   end
 
-  opt.on('-s', '--hoststate Hoststate', 'Host state') do |host_state|
+  opt.on("-s", "--hoststate Hoststate", "Host state") do |host_state|
     options[:host_state] = host_state
   end
 
-  opt.on('-d', '--service-desc Servicedesc', 'Service description') do |service_desc|
+  opt.on("-d", "--service-desc Servicedesc", "Service description") do |service_desc|
     options[:service_desc] = service_desc
   end
 
-  opt.on('-n', '--service-state Servicestate', 'Service state') do |service_state|
+  opt.on("-n", "--service-state Servicestate", "Service state") do |service_state|
     options[:service_state] = service_state
   end
 
-  opt.on('-c', '--command-type Commandtype', 'Command type (host/service)') do |command_type|
+  opt.on("-c", "--command-type Commandtype", "Command type (host/service)") do |command_type|
     options[:command_type] = command_type
   end
 
-  opt.on('-z', '--statsd-host Statsdhost', 'StatsD host') do |statsd_host|
+  opt.on("-z", "--statsd-host Statsdhost", "StatsD host") do |statsd_host|
     options[:statsd_host] = statsd_host
   end
 
-  opt.on('-p', '--statsd-port Statsdport', 'StatsD port') do |statsd_port|
+  opt.on("-p", "--statsd-port Statsdport", "StatsD port") do |statsd_port|
     options[:statsd_port] = statsd_port
   end
 end.parse!
 
 class Statsd
   @@config = {}
+
   def self.configure(host, port)
     @@config = {
-      :host => host,
-      :port => port
+      host: host,
+      port: port,
     }
   end
 
-  def self.timing(stat, time, sample_rate=1)
+  def self.timing(stat, time, sample_rate = 1)
     # Log timing information
     # > require 'ruby_example'
     # > Statsd.timing('some.time', 500)
@@ -56,34 +57,33 @@ class Statsd
     Statsd.send(stats, sample_rate)
   end
 
-  def self.increment(stats, sample_rate=1)
+  def self.increment(stats, sample_rate = 1)
     # Increments one or more stats counters
     # > Statsd.increment('some.int')
     # > Statsd.increment('some.int',0.5)
     Statsd.update_stats(stats, 1, sample_rate)
   end
 
-  def self.decrement(stats, sample_rate=1)
+  def self.decrement(stats, sample_rate = 1)
     # Decrements one or more stats counters
     # > Statsd.decrement('some.int')
     Statsd.update_stats(stats, -1, sample_rate)
   end
 
-  def self.update_stats(stats, delta=1, sampleRate=1)
+  def self.update_stats(stats, delta = 1, sample_rate = 1)
     # Updates one or more stats counters by arbitrary amounts
     # > Statsd.update_stats('some.int',10)
-    stats = [stats] unless stats.kind_of?(Array)
+    stats = [stats] unless stats.is_a?(Array)
 
     data = {}
     stats.each do |stat|
       data[stat] = "#{delta}|c"
     end
 
-    Statsd.send(data, sampleRate)
+    Statsd.send(data, sample_rate)
   end
 
-
-  def self.send(data, sample_rate=1)
+  def self.send(data, sample_rate = 1)
     # Squirt the metrics over UDP
     if @@config[:host].nil? || @@config[:port].nil?
       raise ArgumentError.new("No configuration was specified")
@@ -113,18 +113,18 @@ end
 
 # Sanitize namespacing for Graphite
 options.each do |k, v|
-  options[k] = v.gsub(' ', '_').gsub('.', '_').downcase
+  options[k] = v.gsub(" ", "_").gsub(".", "_").downcase
 end
 
 Statsd.configure(
-  options.fetch(:statsd_host, 'localhost'),
-  options.fetch(:statsd_port, 8125)
+  options.fetch(:statsd_host, "localhost"),
+  options.fetch(:statsd_port, 8125),
 )
 
-if options[:command_type] == 'host'
-  namespace = "icinga.host_alert.#{options[:host_display_name]}.#{options[:host_state]}"
-else
-  namespace = "icinga.service_alert.#{options[:host_display_name]}.#{options[:service_desc]}.#{options[:service_state]}"
-end
+namespace = if options[:command_type] == "host"
+              "icinga.host_alert.#{options[:host_display_name]}.#{options[:host_state]}"
+            else
+              "icinga.service_alert.#{options[:host_display_name]}.#{options[:service_desc]}.#{options[:service_state]}"
+            end
 
 Statsd.increment(namespace)

--- a/modules/icinga/templates/notify_graphite.erb
+++ b/modules/icinga/templates/notify_graphite.erb
@@ -52,8 +52,12 @@ class Statsd
     # Log timing information
     # > require 'ruby_example'
     # > Statsd.timing('some.time', 500)
-    stats = {}
-    stats[stat] = "#{time}|ms"
+    stats = { stat => "#{time}|ms" }
+    Statsd.send(stats, sample_rate)
+  end
+
+  def self.gauge(stat, value, sample_rate = 1)
+    stats = { stat => "#{value}|g" }
     Statsd.send(stats, sample_rate)
   end
 
@@ -121,10 +125,27 @@ Statsd.configure(
   options.fetch(:statsd_port, 8125),
 )
 
-namespace = if options[:command_type] == "host"
-              "icinga.host_alert.#{options[:host_display_name]}.#{options[:host_state]}"
-            else
-              "icinga.service_alert.#{options[:host_display_name]}.#{options[:service_desc]}.#{options[:service_state]}"
-            end
+state = options[:command_type] == "host" ? options[:host_state] : options[:service_state]
 
-Statsd.increment(namespace)
+count_namespace = if options[:command_type] == "host"
+                    "icinga.host_alert.#{options[:host_display_name]}.#{state}"
+                  else
+                    "icinga.service_alert.#{options[:host_display_name]}.#{options[:service_desc]}.#{state}"
+                  end
+
+Statsd.increment(count_namespace)
+
+state_namespace = if options[:command_type] == "host"
+                    "icinga.host_alert.#{options[:host_display_name]}"
+                  else
+                    "icinga.service_alert.#{options[:host_display_name]}.#{options[:service_desc]}"
+                  end
+
+STATE_GAUGE_VALUES = {
+  "ok" => 0,
+  "unknown" => 1,
+  "warning" => 2,
+  "critical" => 3,
+}
+
+Statsd.gauge(state_namespace, STATE_GAUGE_VALUES.fetch(state))

--- a/modules/monitoring/manifests/contacts.pp
+++ b/modules/monitoring/manifests/contacts.pp
@@ -40,7 +40,7 @@ class monitoring::contacts (
   $pagerduty_servicekey = '',
   $notify_pager = false,
   $notify_slack = false,
-  $notify_graphite = false,
+  $notify_graphite = true,
   $slack_channel = undef,
   $slack_username = 'Icinga',
   $slack_webhook_url = undef,

--- a/modules/monitoring/spec/classes/contacts_spec.rb
+++ b/modules/monitoring/spec/classes/contacts_spec.rb
@@ -17,9 +17,9 @@ describe 'monitoring::contacts', :type => :class do
     it { is_expected.not_to contain_icinga__slack_contact('slack_notification') }
 
     it_should_behave_like 'configured contact groups',
-      [],
-      [],
-      []
+      ['graphite_notification'],
+      ['graphite_notification'],
+      ['graphite_notification']
   end
 
   context 'notify_pager => true' do
@@ -30,9 +30,9 @@ describe 'monitoring::contacts', :type => :class do
     it { is_expected.not_to contain_icinga__slack_contact('slack_notification') }
 
     it_should_behave_like 'configured contact groups',
-      ['pagerduty_24x7'],
-      [],
-      []
+      ['graphite_notification', 'pagerduty_24x7'],
+      ['graphite_notification'],
+      ['graphite_notification']
   end
 
   context 'notify_pager => true, notify_slack => true, slack creds' do
@@ -49,21 +49,21 @@ describe 'monitoring::contacts', :type => :class do
     )}
 
     it_should_behave_like 'configured contact groups',
-      ['slack_notification', 'pagerduty_24x7'],
-      ['slack_notification'],
-      ['slack_notification']
+      ['graphite_notification', 'slack_notification', 'pagerduty_24x7'],
+      ['graphite_notification', 'slack_notification'],
+      ['graphite_notification', 'slack_notification']
   end
 
-  context 'notify_graphite => true' do
+  context 'notify_graphite => false' do
     let(:params) {{
-      :notify_graphite => true,
+      :notify_graphite => false,
     }}
 
-    it { is_expected.to contain_icinga__graphite_contact('graphite_notification') }
+    it { is_expected.to_not contain_icinga__graphite_contact('graphite_notification') }
 
     it_should_behave_like 'configured contact groups',
-      ['graphite_notification'],
-      ['graphite_notification'],
-      ['graphite_notification']
+      [],
+      [],
+      []
   end
 end


### PR DESCRIPTION
Send Icinga service states as a gauge statistic allowing us to quantitatively assess the state of the Icinga checks over time, which will help to set a baseline for the current state, and allow us to assess if the situation is improving.

The name of the new states will be:

```rb
"stats.gauges.icinga.host_alert.#{host}"
"stats.gauges.icinga.service_alert.#{host}.#{service}"
```

The values for each state are:

```rb
{
  "ok" => 0,
  "warning" => 1,
  "critical" => 2,
  "unknown" => 3,
}
```

Also enabled Graphite stats in all environments as it was previously restricted only to production.

[Trello Card](https://trello.com/c/9OlTpJO5/1203-5-store-the-state-of-icinga-checks-in-graphite)