### PR TITLE
This check should run everywhere, so reenable it inside AWS

### DIFF
--- a/modules/monitoring/manifests/checks.pp
+++ b/modules/monitoring/manifests/checks.pp
@@ -154,19 +154,16 @@ class monitoring::checks (
     }
   }
 
-  # In AWS this is liable to happen more often as machines come and go
-  unless $::aws_migration {
-    icinga::check_config { 'check_puppetdb_ssh_host_keys':
-      source  => 'puppet:///modules/monitoring/etc/nagios3/conf.d/check_puppetdb_ssh_host_keys.cfg',
-      require => Class['monitoring::client'],
-    }
+  icinga::check_config { 'check_puppetdb_ssh_host_keys':
+    source  => 'puppet:///modules/monitoring/etc/nagios3/conf.d/check_puppetdb_ssh_host_keys.cfg',
+    require => Class['monitoring::client'],
+  }
 
-    icinga::check { "check_puppetdb_ssh_host_keys_from_${::hostname}":
-      check_command       => 'check_puppetdb_ssh_host_keys',
-      service_description => 'duplicate SSH host keys',
-      host_name           => $::fqdn,
-      notes_url           => monitoring_docs_url(duplicate-ssh-host-keys),
-      require             => Icinga::Check_config['check_puppetdb_ssh_host_keys'],
-    }
+  icinga::check { "check_puppetdb_ssh_host_keys_from_${::hostname}":
+    check_command       => 'check_puppetdb_ssh_host_keys',
+    service_description => 'duplicate SSH host keys',
+    host_name           => $::fqdn,
+    notes_url           => monitoring_docs_url(duplicate-ssh-host-keys),
+    require             => Icinga::Check_config['check_puppetdb_ssh_host_keys'],
   }
 }


### PR DESCRIPTION
This check currently only runs in Carrenza and it should either run in both
or not at all. We're going to enable it in all environments and see how it behaves
and then have a follow up discussion about killing it everywhere.