### PR TITLE
Add google domain verification file

### DIFF
--- a/modules/router/templates/assets_origin.conf.erb
+++ b/modules/router/templates/assets_origin.conf.erb
@@ -121,4 +121,8 @@ server {
     proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://static.<%= @app_domain %>;
     <%- end %>
   }
+
+  location /googlec908b3bc32386239.html {
+    return 200 'google-site-verification: googlec908b3bc32386239.html';
+  }
 }


### PR DESCRIPTION
This file is necessary to verify ownership of
assets.publishing.service.gov.uk for Google Search Console.

[Trello](https://trello.com/c/2zhVXzBJ/1299-5-verify-ownership-of-assetspublishingservicegovuk-for-google-search-console)