### PR TITLE
Apply lb_healthchecks.conf nginx config on all relevant boxes in AWS.

### DIFF
--- a/modules/govuk/manifests/node/s_backend.pp
+++ b/modules/govuk/manifests/node/s_backend.pp
@@ -37,20 +37,8 @@ class govuk::node::s_backend inherits govuk::node::s_base {
 
   include nginx
 
-  if $::aws_migration {
-    concat { '/etc/nginx/lb_healthchecks.conf':
-      ensure => present,
-      before => Nginx::Config::Vhost::Default['default'],
-    }
-    $extra_config = 'include /etc/nginx/lb_healthchecks.conf;'
-  } else {
-    $extra_config = ''
-  }
-
-  # If we miss all the apps, throw a 500 to be caught by the cache nginx
-  nginx::config::vhost::default { 'default':
-    extra_config => $extra_config,
-  }
+  # The catchall vhost throws a 500, except for healthcheck requests.
+  nginx::config::vhost::default { 'default': }
 
   if $::aws_migration {
     include icinga::client::check_pings

--- a/modules/govuk/manifests/node/s_calculators_frontend.pp
+++ b/modules/govuk/manifests/node/s_calculators_frontend.pp
@@ -4,20 +4,8 @@ class govuk::node::s_calculators_frontend inherits govuk::node::s_base {
 
   include nginx
 
-  if $::aws_migration {
-    concat { '/etc/nginx/lb_healthchecks.conf':
-      ensure => present,
-      before => Nginx::Config::Vhost::Default['default'],
-    }
-    $extra_config = 'include /etc/nginx/lb_healthchecks.conf;'
-  } else {
-    $extra_config = ''
-  }
-
-  # If we miss all the apps, throw a 500 to be caught by the cache nginx
-  nginx::config::vhost::default { 'default':
-    extra_config => $extra_config,
-  }
+  # The catchall vhost throws a 500, except for healthcheck requests.
+  nginx::config::vhost::default { 'default': }
 
   @@icinga::check::graphite { "check_nginx_connections_writing_${::hostname}":
     target    => "${::fqdn_metrics}.nginx.nginx_connections-writing",

--- a/modules/govuk/manifests/node/s_email_alert_api.pp
+++ b/modules/govuk/manifests/node/s_email_alert_api.pp
@@ -22,20 +22,8 @@ class govuk::node::s_email_alert_api inherits govuk::node::s_base {
 
   include nginx
 
-  if $::aws_migration {
-    concat { '/etc/nginx/lb_healthchecks.conf':
-      ensure => present,
-      before => Nginx::Config::Vhost::Default['default'],
-    }
-    $extra_config = 'include /etc/nginx/lb_healthchecks.conf;'
-  } else {
-    $extra_config = ''
-  }
-
-  # If we miss all the apps, throw a 500 to be caught by the cache nginx
-  nginx::config::vhost::default { 'default':
-    extra_config => $extra_config,
-  }
+  # The catchall vhost throws a 500, except for healthcheck requests.
+  nginx::config::vhost::default { 'default': }
 
   # Ensure memcached is available to backend nodes
   include collectd::plugin::memcached

--- a/modules/govuk/manifests/node/s_frontend.pp
+++ b/modules/govuk/manifests/node/s_frontend.pp
@@ -9,20 +9,8 @@ class govuk::node::s_frontend inherits govuk::node::s_base {
 
   include nginx
 
-  if $::aws_migration {
-    concat { '/etc/nginx/lb_healthchecks.conf':
-      ensure => present,
-      before => Nginx::Config::Vhost::Default['default'],
-    }
-    $extra_config = 'include /etc/nginx/lb_healthchecks.conf;'
-  } else {
-    $extra_config = ''
-  }
-
-  # If we miss all the apps, throw a 500 to be caught by the cache nginx
-  nginx::config::vhost::default { 'default':
-    extra_config => $extra_config,
-  }
+  # The catchall vhost throws a 500, except for healthcheck requests.
+  nginx::config::vhost::default { 'default': }
 
   @@icinga::check::graphite { "check_nginx_connections_writing_${::hostname}":
     target    => "${::fqdn_metrics}.nginx.nginx_connections-writing",

--- a/modules/govuk/manifests/node/s_publishing_api.pp
+++ b/modules/govuk/manifests/node/s_publishing_api.pp
@@ -22,16 +22,6 @@ class govuk::node::s_publishing_api inherits govuk::node::s_base {
 
   include nginx
 
-  if $::aws_migration {
-    concat { '/etc/nginx/lb_healthchecks.conf':
-      ensure => present,
-      before => Nginx::Config::Vhost::Default['default'],
-    }
-    $extra_config = 'include /etc/nginx/lb_healthchecks.conf;'
-  } else {
-    $extra_config = ''
-  }
-
   if ($::aws_environment == 'staging') or ($::aws_environment == 'production') {
     # For AWS staging and production, use the external domain name when
     # constructing the URI for talking to Signon. This is needed while Signon
@@ -42,10 +32,8 @@ class govuk::node::s_publishing_api inherits govuk::node::s_base {
     }
   }
 
-  # If we miss all the apps, throw a 500 to be caught by the cache nginx
-  nginx::config::vhost::default { 'default':
-    extra_config => $extra_config,
-  }
+  # The catchall vhost throws a 500, except for healthcheck requests.
+  nginx::config::vhost::default { 'default': }
 
   # Ensure memcached is available to backend nodes
   include collectd::plugin::memcached

--- a/modules/govuk/manifests/node/s_search.pp
+++ b/modules/govuk/manifests/node/s_search.pp
@@ -11,20 +11,8 @@ class govuk::node::s_search inherits govuk::node::s_base {
 
   include nginx
 
-  if $::aws_migration {
-    concat { '/etc/nginx/lb_healthchecks.conf':
-      ensure => present,
-      before => Nginx::Config::Vhost::Default['default'],
-    }
-    $extra_config = 'include /etc/nginx/lb_healthchecks.conf;'
-  } else {
-    $extra_config = ''
-  }
-
-  # If we miss all the apps, throw a 500 to be caught by the cache nginx
-  nginx::config::vhost::default { 'default':
-    extra_config => $extra_config,
-  }
+  # The catchall vhost throws a 500, except for healthcheck requests.
+  nginx::config::vhost::default { 'default': }
 
   # Data sync for managed elasticsearch
   if $::aws_migration {

--- a/modules/govuk/manifests/node/s_whitehall_backend.pp
+++ b/modules/govuk/manifests/node/s_whitehall_backend.pp
@@ -12,7 +12,7 @@ class govuk::node::s_whitehall_backend (
   # Package required in order to use PDFKit
   ensure_packages(['wkhtmltopdf'])
 
-  # If we miss all the apps, throw a 500 to be caught by the cache nginx
+  # The catchall vhost throws a 500, except for healthcheck requests.
   nginx::config::vhost::default { 'default': }
 
   if $sync_mirror {

--- a/modules/nginx/manifests/config/vhost/default.pp
+++ b/modules/nginx/manifests/config/vhost/default.pp
@@ -33,6 +33,17 @@ define nginx::config::vhost::default(
     certtype => $ssl_certtype,
   }
 
+  # On AWS, we create an (initially empty) lb_healthchecks.conf and hook it
+  # into the default vhost config. App classes add healthcheck routes to that
+  # file so that ALBs can reach an app's healthcheck without the ability to
+  # specify the Host header.
+  # See https://github.com/alphagov/govuk-aws/blob/master/doc/architecture/decisions/0037-alb-health-checks.md
+  if $::aws_migration {
+    concat { '/etc/nginx/lb_healthchecks.conf':
+      ensure => present,
+    }
+  }
+
   nginx::config::site { $title:
     content => template('nginx/default-vhost.conf'),
   }

--- a/modules/nginx/templates/default-vhost.conf
+++ b/modules/nginx/templates/default-vhost.conf
@@ -7,6 +7,7 @@ server {
   location = /_healthcheck {
     return 200;
   }
+  include /etc/nginx/lb_healthchecks.conf;
   <%- end %>
   location / {
     return <%= @status %> <%= @status_message %>;


### PR DESCRIPTION
Currently there is a blob of copypasta on 7 node classes which use
`lb_healthchecks.conf`, but it needs to be everywhere on AWS because of
https://github.com/alphagov/govuk-aws/blob/master/doc/architecture/decisions/0037-alb-health-checks.md

This factors out the copypasta and paves the way for us to fix the LB
healthcheck config for other apps on AWS which are not currently
configured properly, particularly `whitehall-admin`.

With this change, an app should only need to pass `$health_check_path` to
`govuk::app::config` in order for its LB healthcheck to be mapped correctly on the
default vhost.