### PR TITLE
Try to stop Puppet restarting Icinga all the time

### DIFF
--- a/modules/icinga/manifests/config.pp
+++ b/modules/icinga/manifests/config.pp
@@ -53,7 +53,8 @@ class icinga::config (
   file { '/var/lib/icinga/retention.dat':
     ensure => present,
     owner  => 'nagios',
-    group  => 'www-data',
+    group  => undef,
+    mode   => undef,
   }
 
   if $::aws_migration {


### PR DESCRIPTION
Puppet is currently restarting Icinga every half an hour, because it
changes something about the /var/lib/icinga/retention.dat file. On
Carrenza, I'm seeing Puppet change the mode from 0600 to 0644 each
time, and on AWS environments the group changes from nagios to
www-data.

Because the behaviour doesn't seem to be consistent, I think trying to
convince Puppet not to care about the group and mode is best, as
Icinga (or something else) seems to be changing these values anyway
when the service restarts.

I'm also very dubious why this resource was introduced. The reasoning
given in [1] is that the Debian package doesn't contain the file, but
this makes sense, as the Debian package wouldn't contain the state
information for Icinga...

1: 9c764e0b2c22de99643ae70cb08b46b039f0be5e