### PR TITLE
Fix load balancer healthcheck for whitehall-admin.

### DIFF
--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -311,6 +311,16 @@ class govuk::apps::whitehall(
     ',
     }
 
+    # govuk::app::config doesn't automatically configure Whitehall's LB healthcheck
+    # because Whitehall sets $enable_nginx_vhost=false. We therefore need to
+    # configure the LB healthcheck explicitly.
+    if $::aws_migration {
+      concat::fragment { "${whitehall_admin_vhost_}_lb_healthcheck":
+        target  => '/etc/nginx/lb_healthchecks.conf',
+        content => "location /_healthcheck_${whitehall_admin_vhost_} {\n  proxy_pass http://${whitehall_admin_vhost_}-proxy${health_check_path};\n}\n",
+      }
+    }
+
     @filebeat::prospector { 'whitehall_scheduled_publishing_json_log':
       paths  => ['/var/apps/whitehall/log/production_scheduled_publishing.json.log'],
       fields => {'application' => 'whitehall'},


### PR DESCRIPTION
Plumb the healthcheck for `whitehall-admin` through the default vhost in
the nginx config.

The healthcheck needs to be accessible to the load balancer so that
traffic does not get routed to broken instances. The convention for the
URL paths of these healthchecks is defined in
https://github.com/alphagov/govuk-aws/blob/master/doc/architecture/decisions/0037-alb-health-checks.md

`govuk::apps::whitehall` needs some special-case config to achieve this
because it sets `enable_nginx_vhost=false` and does the nginx vhost
config itself, which means we don't get this for free from
`govuk::app::config`.