### PR TITLE
Disable Icinga flap detection by default

### DIFF
--- a/modules/icinga/templates/etc/icinga/icinga-aws.cfg.erb
+++ b/modules/icinga/templates/etc/icinga/icinga-aws.cfg.erb
@@ -1063,7 +1063,7 @@ additional_freshness_latency=15
 # Values: 1 = enable flap detection
 #         0 = disable flap detection (default)
 
-enable_flap_detection=1
+enable_flap_detection=0
 
 
 

--- a/modules/icinga/templates/etc/icinga/icinga.cfg.erb
+++ b/modules/icinga/templates/etc/icinga/icinga.cfg.erb
@@ -1063,7 +1063,7 @@ additional_freshness_latency=15
 # Values: 1 = enable flap detection
 #         0 = disable flap detection (default)
 
-enable_flap_detection=1
+enable_flap_detection=0
 
 
 

--- a/modules/icinga/templates/service_template.cfg.erb
+++ b/modules/icinga/templates/service_template.cfg.erb
@@ -8,7 +8,7 @@ define service{
         check_freshness                 0       ; Default is to NOT check service 'freshness'
         notifications_enabled           1       ; Service notifications are enabled
         event_handler_enabled           1       ; Service event handler is enabled
-        flap_detection_enabled          1       ; Flap detection is enabled
+        flap_detection_enabled          0       ; Flap detection is disabled
         failure_prediction_enabled      1       ; Failure prediction is enabled
         process_perf_data               1       ; Process performance data
         retain_status_information       1       ; Retain status information across program restarts


### PR DESCRIPTION
This is an Icinga feature to suppress notifications when the state of
a service or host changes frequently.

As we're using notifications now to try and track Icinga states in
Graphite, missing the notifications due to a service flapping means
that the information in Graphite is often out of date. Disabling flap
detection should make the situation better.

We're also using notifications for Slack and PagerDuty. I don't expect
this change to impact PagerDuty, as flap detection doesn't really
apply to the few services that notify PagerDuty, for example for the
5xx rate on the cache machines, the data is being smoothed out through
Graphite. As for Slack, this might increase the number of messages,
but it'll be more representative, which should be more useful.