### PR TITLE
Disable the check_signon_queue_sizes Icinga check where unnecessary

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -316,6 +316,7 @@ task :check_consistency_between_aws_and_carrenza do
     monitoring::checks::lb::loadbalancers
     monitoring::checks::rds::servers
     monitoring::client::alert_hostname
+    monitoring::checks::sidekiq::enable_signon_check
     monitoring::client::graphite_hostname
     monitoring::uptime_collector::aws
     nginx_enable_ssl

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -195,6 +195,7 @@ licensify::apps::licensify::alert_5xx_critical_rate: 0.15
 
 monitoring::ci_environment: true
 monitoring::checks::aws_origin_domain: "integration.govuk.digital"
+monitoring::checks::sidekiq::enable_signon_check: false
 monitoring::checks::sidekiq::enable_support_check: false
 monitoring::checks::pingdom::enable: false
 monitoring::checks::ses::region: eu-west-1

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -291,6 +291,7 @@ licensify::apps::licensify_feed::environment: 'production'
 monitoring::checks::aws_origin_domain: "production.govuk.digital"
 monitoring::checks::datagovuk_publish::ensure: 'present'
 monitoring::checks::datagovuk_publish::host: 'publish-data-beta-production.cloudapps.digital'
+monitoring::checks::sidekiq::enable_signon_check: false
 monitoring::checks::sidekiq::enable_support_check: false
 monitoring::checks::ses::region: 'eu-west-1'
 monitoring::checks::rds::region: 'eu-west-1'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -269,6 +269,7 @@ licensify::apps::licensify::alert_5xx_critical_rate: 0.15
 monitoring::checks::aws_origin_domain: "staging.govuk.digital"
 monitoring::checks::datagovuk_publish::ensure: 'present'
 monitoring::checks::datagovuk_publish::host: 'publish-data-beta-staging.cloudapps.digital'
+monitoring::checks::sidekiq::enable_signon_check: false
 monitoring::checks::sidekiq::enable_support_check: false
 monitoring::checks::ses::region: 'eu-west-1'
 monitoring::checks::rds::region: 'eu-west-1'


### PR DESCRIPTION
As Signon runs on the Carrenza side of Production, Staging and in
Integration (which is mainly in AWS), disable the check in the other
locations.

This should resolve the check appearing as UNKNOWN where Signon isn't
running.