### PR TITLE
Increase finder-frontend memory thresholds

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -410,8 +410,8 @@ govuk::apps::email_alert_service::rabbitmq::queue_size_critical_threshold: 25
 govuk::apps::email_alert_service::rabbitmq::queue_size_warning_threshold: 5
 
 govuk::apps::finder_frontend::enabled: true
-govuk::apps::finder_frontend::nagios_memory_warning: 2000
-govuk::apps::finder_frontend::nagios_memory_critical: 2500
+govuk::apps::finder_frontend::nagios_memory_warning: 2500
+govuk::apps::finder_frontend::nagios_memory_critical: 3500
 govuk::apps::finder_frontend::unicorn_worker_processes: "4"
 
 govuk::apps::frontend::nagios_memory_warning: 1200

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -497,8 +497,8 @@ govuk::apps::email_alert_service::rabbitmq::queue_size_critical_threshold: 25
 govuk::apps::email_alert_service::rabbitmq::queue_size_warning_threshold: 5
 
 govuk::apps::finder_frontend::enabled: true
-govuk::apps::finder_frontend::nagios_memory_warning: 2000
-govuk::apps::finder_frontend::nagios_memory_critical: 2500
+govuk::apps::finder_frontend::nagios_memory_warning: 2500
+govuk::apps::finder_frontend::nagios_memory_critical: 3500
 govuk::apps::finder_frontend::unicorn_worker_processes: "6"
 
 govuk::apps::frontend::nagios_memory_warning: 1200


### PR DESCRIPTION
A normal deploy of finder-frontend caused memory to go over 2500MB for a short period.  Icinga noticed the spike in memory and restarted the app on a few machines, due to high memory and we were left with 30 criticals (one per calculator_frontend machine).

The critical level for the [app restarts due to memory alert](https://alert.production.govuk.digital/cgi-bin/icinga/extinfo.cgi?type=2&host=ip-10-13-4-184.eu-west-1.compute.internal&service=finder-frontend+restarts+per+day+due+to+memory+usage) job is 10. We have 30 machines, so even though we didn't restart finder-frontend on all the machines, it was still enough to raise a critical alert.

We have enough headroom for this to be fine, but we should look at other approaches if we need to do this again