### PR TITLE
Remove Elasticsearch 5 from CI

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -867,16 +867,16 @@ govuk_ci::master::pipeline_jobs:
 govuk_ci::master::ci_agents:
   ci-agent-1:
     agent_hostname: 'ci-agent-1.ci'
-    labels: 'mongodb-2.4 ci-agent-1 elasticsearch-5.6 elasticsearch-6.7 terraform postgresql-9.3'
+    labels: 'mongodb-2.4 ci-agent-1 elasticsearch-6.7 terraform postgresql-9.3'
   ci-agent-2:
     agent_hostname: 'ci-agent-2.ci'
-    labels: 'mongodb-2.4 ci-agent-2 elasticsearch-5.6 elasticsearch-6.7 terraform postgresql-9.3'
+    labels: 'mongodb-2.4 ci-agent-2 elasticsearch-6.7 terraform postgresql-9.3'
   ci-agent-3:
     agent_hostname: 'ci-agent-3.ci'
-    labels: 'mongodb-2.4 ci-agent-3 elasticsearch-5.6 elasticsearch-6.7 terraform postgresql-9.3'
+    labels: 'mongodb-2.4 ci-agent-3 elasticsearch-6.7 terraform postgresql-9.3'
   ci-agent-4:
     agent_hostname: 'ci-agent-4.ci'
-    labels: 'mongodb-3.2 ci-agent-4 elasticsearch-5.6 elasticsearch-6.7 terraform postgresql-9.6'
+    labels: 'mongodb-3.2 ci-agent-4 elasticsearch-6.7 terraform postgresql-9.6'
   ci-agent-5:
     agent_hostname: 'ci-agent-5.ci'
     exclusive: true

--- a/hieradata_aws/class/training/search.yaml
+++ b/hieradata_aws/class/training/search.yaml
@@ -13,6 +13,17 @@ govuk_env_sync::tasks:
     temppath: "/tmp/elasticsearch_everything"
     url: "govuk-integration"
     path: "elasticsearch5"
+  "pull_es6_daily":
+    ensure: "present"
+    hour: "1"
+    minute: "24"
+    action: "pull"
+    dbms: "elasticsearch"
+    storagebackend: "elasticsearch"
+    database: "elasticsearch6"
+    temppath: "/tmp/elasticsearch_everything"
+    url: "govuk-production"
+    path: "elasticsearch6"
 
 logrotate::conf::days_to_keep: 7
 nginx::logging::days_to_keep: 7

--- a/modules/govuk/manifests/node/s_apt.pp
+++ b/modules/govuk/manifests/node/s_apt.pp
@@ -46,10 +46,6 @@ class govuk::node::s_apt (
       release  => 'trusty',
       repos    => ['stable'],
       key      => '9DC858229FC7DD38854AE2D88D81803C0EBFCD88';
-    'elasticsearch-5.x':
-      location => 'https://artifacts.elastic.co/packages/5.x/apt',
-      release  => 'stable',
-      key      => '46095ACC8548582C1A2699A9D27D666CD88E42B4';
     'govuk-ppa-trusty':
       location => 'http://ppa.launchpad.net/gds/govuk/ubuntu',
       release  => 'trusty',

--- a/modules/govuk_containers/manifests/elasticsearch/primary.pp
+++ b/modules/govuk_containers/manifests/elasticsearch/primary.pp
@@ -13,7 +13,7 @@
 class govuk_containers::elasticsearch::primary(
   $version = '5.6.15',
   $port    = '9200',
-  $ensure  = 'present',
+  $ensure  = 'absent',
   $enable  = true,
 ) {
   # todo: remove absent things


### PR DESCRIPTION
This pull request aims to remove or reroute Elasticsearch 5 calls from the CI stack as part of our migration to ES6.

Trello: https://trello.com/c/zDmQgHQp/1039-remove-es5-from-govuk-docker-publishing-e2e-tests-and-ci