### PR TITLE
Remove enough ES5 stuff so that things don't break when we delete it

### DIFF
--- a/hieradata_aws/class/integration/search.yaml
+++ b/hieradata_aws/class/integration/search.yaml
@@ -1,6 +1,6 @@
 govuk_env_sync::tasks:
   "pull_es_everything_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "3"
     minute: "24"
     action: "pull"
@@ -11,7 +11,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging"
     path: "elasticsearch5"
   "push_es_everything_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "4"
     minute: "24"
     action: "push"

--- a/hieradata_aws/class/production/search.yaml
+++ b/hieradata_aws/class/production/search.yaml
@@ -1,6 +1,6 @@
 govuk_env_sync::tasks:
   "push_es_everything_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "0"
     minute: "20"
     action: "push"

--- a/hieradata_aws/class/staging/search.yaml
+++ b/hieradata_aws/class/staging/search.yaml
@@ -3,7 +3,7 @@
 # than integration being a day behind).
 govuk_env_sync::tasks:
   "pull_es_everything_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "1"
     minute: "24"
     action: "pull"
@@ -14,7 +14,7 @@ govuk_env_sync::tasks:
     url: "govuk-production"
     path: "elasticsearch5"
   "push_es_everything_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "2"
     minute: "24"
     action: "push"

--- a/hieradata_aws/class/training/search.yaml
+++ b/hieradata_aws/class/training/search.yaml
@@ -3,7 +3,7 @@
 # than integration being a day behind).
 govuk_env_sync::tasks:
   "pull_es_everything_daily_integration":
-    ensure: "present"
+    ensure: "absent"
     hour: "3"
     minute: "24"
     action: "pull"

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -90,7 +90,7 @@ licensify::apps::licensify_feed::environment: 'integration'
 
 
 govuk_search::monitoring::es_port: '80'
-govuk_search::monitoring::es_host: 'elasticsearch5.blue.integration.govuk-internal.digital'
+govuk_search::monitoring::es_host: 'elasticsearch6.blue.integration.govuk-internal.digital'
 
 govuk::deploy::aws_ses_smtp_host: 'email-smtp.eu-west-1.amazonaws.com'
 govuk::deploy::config::errbit_environment_name: "integration-%{hiera('stackname')}-aws"

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -155,7 +155,7 @@ govuk::apps::support_api::aws_s3_bucket_name: 'govuk-production-support-api-csvs
 govuk::apps::travel_advice_publisher::enable_email_alerts: true
 
 govuk_search::monitoring::es_port: '80'
-govuk_search::monitoring::es_host: 'elasticsearch5.blue.production.govuk-internal.digital'
+govuk_search::monitoring::es_host: 'elasticsearch6.blue.production.govuk-internal.digital'
 
 govuk_jenkins::jobs::enhanced_ecommerce_search_api::cron_schedule: '0 6 * * 1-5' # Every weekday at 6am
 

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -151,7 +151,7 @@ govuk::apps::support_api::aws_s3_bucket_name: 'govuk-staging-support-api-csvs'
 govuk::apps::travel_advice_publisher::enable_email_alerts: true
 
 govuk_search::monitoring::es_port: '80'
-govuk_search::monitoring::es_host: 'elasticsearch5.blue.production.govuk-internal.digital'
+govuk_search::monitoring::es_host: 'elasticsearch6.blue.production.govuk-internal.digital'
 
 govuk::deploy::aws_ses_smtp_host: 'email-smtp.eu-west-1.amazonaws.com'
 govuk::deploy::config::errbit_environment_name: 'staging'

--- a/hieradata_aws/training.yaml
+++ b/hieradata_aws/training.yaml
@@ -56,7 +56,7 @@ govuk::apps::whitehall::basic_auth_credentials: "%{hiera('http_username')}:%{hie
 govuk::apps::whitehall::highlight_words_to_avoid: true
 
 govuk_search::monitoring::es_port: '80'
-govuk_search::monitoring::es_host: 'elasticsearch5.training.govuk-internal.digital'
+govuk_search::monitoring::es_host: 'elasticsearch6.training.govuk-internal.digital'
 
 govuk::apps::content_store::plek_service_rummager_uri: 'https://search-api.training.govuk-internal.digital'
 govuk::apps::collections::override_search_location: 'https://search-api.training.govuk-internal.digital'

--- a/modules/govuk_search/manifests/prune.pp
+++ b/modules/govuk_search/manifests/prune.pp
@@ -9,10 +9,6 @@
 # [*es_repo*]
 #   The Elasticsearch snapshot repository.
 #
-# [*es5_address*]
-#   Hostname and port of the Elasticsearch 5 server.
-#   Default: elasticsearch5:80
-#
 # [*es6_address*]
 #   Hostname and port of the Elasticsearch 6 server.
 #
@@ -30,7 +26,6 @@
 #
 class govuk_search::prune (
   $es_repo = undef,
-  $es5_address = 'elasticsearch5:80',
   $es6_address = undef,
   $cron_hour = 6,
   $cron_minute = 0,
@@ -38,11 +33,6 @@ class govuk_search::prune (
 ){
 
   if $es_repo {
-    if $es5_address {
-      $es5_ensure = 'present'
-    } else {
-      $es5_ensure = 'absent'
-    }
     if $es6_address {
       $es6_ensure = 'present'
     } else {
@@ -51,7 +41,6 @@ class govuk_search::prune (
 
     ensure_packages(['jq'])
   } else {
-    $es5_ensure = 'absent'
     $es6_ensure = 'absent'
   }
 
@@ -69,7 +58,7 @@ class govuk_search::prune (
   }
 
   file { '/usr/local/bin/es5-prune-snapshots':
-    ensure  => $es5_ensure,
+    ensure  => 'absent',
     content => template('govuk_search/es5-prune-snapshots.erb'),
     mode    => '0755',
   }
@@ -81,7 +70,7 @@ class govuk_search::prune (
   }
 
   cron::crondotdee { 'es5-prune-snapshots':
-    ensure  => $es5_ensure,
+    ensure  => 'absent',
     command => '/usr/local/bin/es5-prune-snapshots',
     hour    => $cron_hour,
     minute  => $cron_minute,


### PR DESCRIPTION
There's other stuff lying around, like the docker container on the CI agents, and the (unused) A-cluster environment variable, but we can do a more comprehensive review of puppet later.

---

[Trello card](https://trello.com/c/ab0U3yr1/1038-destroy-es5)