### PR TITLE
Increase the local-links-manager memory thresholds

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -592,8 +592,8 @@ govuk::apps::local_links_manager::db::lb_ip_range: "%{hiera('environment_ip_pref
 govuk::apps::local_links_manager::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::local_links_manager::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::local_links_manager::unicorn_worker_processes: "4"
-govuk::apps::local_links_manager::nagios_memory_warning: 1000
-govuk::apps::local_links_manager::nagios_memory_critical: 1500
+govuk::apps::local_links_manager::nagios_memory_warning: 1300
+govuk::apps::local_links_manager::nagios_memory_critical: 1800
 
 govuk::apps::mapit::enabled: true
 


### PR DESCRIPTION
To avoid alerts during deployments, the total memory usage for new and
old processes can be around 1200, so set the warning threshold
slightly higher than that.