### PR TITLE
Make ELASTICSEARCH_URI point to ES6

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -638,8 +638,7 @@ govuk::apps::search_api::rabbitmq::enable_publishing_listener: true
 govuk::apps::search_api::rabbitmq_user: 'search-api'
 govuk::apps::search_api::redis_host: 'backend-redis'
 govuk::apps::search_api::redis_port: '6379'
-# todo: decide if we're self-hosting or using a managed elasticsearch (use a bogus value for now)
-govuk::apps::search_api::elasticsearch_hosts: 'http://elasticsearch5'
+govuk::apps::search_api::elasticsearch_hosts: 'http://elasticsearch6'
 govuk::apps::search_api::unicorn_worker_processes: "9"
 
 govuk::apps::search_admin::db_name: 'search_admin_production'


### PR DESCRIPTION
This makes the A and B cluster environment variables refer to the same
place, but search-api has been deployed with the A cluster disabled,
so this is safe to do.

---

[Trello card](https://trello.com/c/KhQTxJz7/1040-tidy-the-mess-caused-by-retiring-es5)