### PR TITLE
Safelist format_autocomplete API endpoint

### DIFF
--- a/modules/govuk/templates/ckan/nginx.conf.erb
+++ b/modules/govuk/templates/ckan/nginx.conf.erb
@@ -22,6 +22,10 @@
     # Used for: ckan_v26_package_sync job
     "/action/package_show",
 
+    # Used by: datagovuk_publish
+    # Used for: determining filetype
+    "/2/util/resource/format_autocomplete",
+
     # Additional endpoints requested by users
     "/action/package_search",
     "/action/package_list",


### PR DESCRIPTION
Allow access to the format_autocomplete API endpoint, used to determine file format when adding a file to a dataset

[Trello card](https://trello.com/c/1ybUoeaU/1346-1-whitelist-yet-another-ckan-api-endpoint)