### PR TITLE
Fix ES6 port in CI

### DIFF
--- a/modules/govuk_containers/manifests/elasticsearch/primary.pp
+++ b/modules/govuk_containers/manifests/elasticsearch/primary.pp
@@ -16,12 +16,6 @@ class govuk_containers::elasticsearch::primary(
   $ensure  = 'absent',
   $enable  = true,
 ) {
-  # todo: remove absent things
-  ::docker::run { 'elasticsearch':
-    ensure => 'absent',
-    image  => "elasticsearch:${version}",
-  }
-
   if $enable {
     ::govuk_containers::elasticsearch { 'primary':
       ensure             => $ensure,

--- a/modules/govuk_containers/manifests/elasticsearch/primary.pp
+++ b/modules/govuk_containers/manifests/elasticsearch/primary.pp
@@ -11,9 +11,9 @@
 #   The port (outside the container) to use for elasticsearch.
 #
 class govuk_containers::elasticsearch::primary(
-  $version = '5.6.15',
+  $version = '6.7.2',
   $port    = '9200',
-  $ensure  = 'absent',
+  $ensure  = 'present',
   $enable  = true,
 ) {
   if $enable {

--- a/modules/govuk_containers/manifests/elasticsearch/secondary.pp
+++ b/modules/govuk_containers/manifests/elasticsearch/secondary.pp
@@ -11,9 +11,9 @@
 #   The port (outside the container) to use for elasticsearch.
 #
 class govuk_containers::elasticsearch::secondary(
-  $version = '6.7.2',
+  $version = '5.6.15',
   $port    = '9201',
-  $ensure  = 'present',
+  $ensure  = 'absent',
   $enable  = true,
 ) {
   if $enable {


### PR DESCRIPTION
We need ES6 to be on port 9200.  While I'm at it, I swapped around the "primary" and "secondary" - so we don't have an enabled secondary and a disabled primary.