### PR TITLE
Add Functionality to Automatically Populate Mapit Databases

### DIFF
--- a/modules/govuk/files/etc/govuk/import_mapit_data.sh
+++ b/modules/govuk/files/etc/govuk/import_mapit_data.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+function stop_mapit_services () {
+  # Stop Mapit Services
+  sudo service nginx stop
+  # Stop mapit and collectd which are using the Mapit database so that we can drop it
+  sudo service mapit stop
+  sudo service collectd stop
+  # # Make sure that cached mapit responses are cleared when the database is updated
+  sudo service memcached restart
+}
+
+function restart_mapit_services () {
+  # Restart Mapit Services
+  sudo service collectd start
+  sudo service mapit start
+  sudo service nginx start
+}
+
+stop_mapit_services
+# This script needs to run as a user that can sudo to become the postgres
+# user.  It's easiest if this is passwordless, so we can't use the deploy user
+# who can't sudo without a password
+# Run 'govuk_setenv mapit ./import-db-from-s3.sh' from the '/var/apps/mapit' as
+
+cd /var/apps/mapit && govuk_setenv mapit ./import-db-from-s3.sh
+restart_mapit_services

--- a/modules/govuk/lib/facter/mapit_data_present.rb
+++ b/modules/govuk/lib/facter/mapit_data_present.rb
@@ -1,0 +1,9 @@
+# Facter fact to check if a mapit node needs to import the database of postcodes
+# It does this by running an psql query that checks for the same postcode as the
+# health check.
+
+Facter.add("mapit_data_present") do
+  setcode do
+    Facter::Core::Execution.execute("sudo -u postgres psql -qAt mapit -c \"select count(*) from mapit_postcode WHERE postcode = 'SW1A1AA'\" 2>/dev/null")
+  end
+end

--- a/modules/govuk/manifests/apps/mapit.pp
+++ b/modules/govuk/manifests/apps/mapit.pp
@@ -81,4 +81,18 @@ class govuk::apps::mapit (
         varname => 'DJANGO_SECRET_KEY',
         value   => $django_secret_key;
   }
+
+  if ($::mapit_data_present == '0') {
+
+
+    file { '/etc/govuk/import_mapit_data.sh':
+      ensure => file,
+      source => 'puppet:///modules/govuk/etc/govuk/import_mapit_data.sh',
+
+    }
+    exec { 'populate mapit database':
+      command => '/bin/bash /etc/govuk/import_mapit_data.sh 2>&1 | logger',
+    }
+  }
+
 }


### PR DESCRIPTION
At the moment new mapit nodes need their databases to be manually
populated by running this fabric script:
https://github.com/alphagov/fabric-scripts/blob/master/mapit.py
This PR fixes the problem by setting a puppet fact to check if the database is
empty and performing an import if needed.