### PR TITLE
Handle Carrenza and AWS in nodes_spec_optional

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1179,6 +1179,7 @@ postgresql::lib::devel::link_pg_config: false
 postgresql::globals::version: '9.3'
 
 puppet::puppetserver::puppetdb_version: '2.0.0-1puppetlabs1'
+puppet::puppetdb::database_password: ''
 
 puppet::monitoring::alert_hostname: 'alert'
 

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -6,6 +6,7 @@ nginx_enable_ssl: false
 
 stackname: "%{::aws_stackname}"
 app_domain: "%{::aws_stackname}.govuk.internal"
+app_domain_internal: '%{::aws_stackname}.govuk-internal.digital'
 
 backup::mysql::alert_hostname: 'alert'
 

--- a/hieradata_aws/vagrant.yaml
+++ b/hieradata_aws/vagrant.yaml
@@ -1,0 +1,191 @@
+---
+# This hieradata relates to the Vagrantfile in govuk-puppet
+
+app_domain: 'dev.gov.uk'
+
+backup::offsite::monitoring::offsite_fqdn: backup.gov.uk
+backup::offsite::monitoring::offsite_hostname: backup0.provider0
+backup::offsite::monitoring::monitor_cdn_logs_disk: true
+
+assets::ssh_authorized_key::key: 'AAAAB3NzaC1yc2EAAAADAQABAAAAYQDCIfGHdqJj9IMkdwXtieDW15ZnR9GAqcnUwjQOMvySEst54705ekxcKwjRFTaYmawlifQTOgFDPkMwp72s2Zd+0ZiR7lfSzBQctbCptS/SgTNNltvplVt8nUbz9H0jLy8='
+assets::ssh_private_key::key: |
+  -----BEGIN RSA PRIVATE KEY-----
+  MIIBygIBAAJhAMIh8Yd2omP0gyR3Be2J4NbXlmdH0YCpydTCNA4y/JISy3njvTl6
+  TFwrCNEVNpiZrCWJ9BM6AUM+QzCnvazZl37RmJHuV9LMFBy1sKm1L9KBM02W2+mV
+  W3ydRvP0fSMvLwIDAQABAmBJXgqp52v32rC1V0YmP7V5fICbB8lllsVwYvTJaPuL
+  OQ8tQaSB1HaHXrw2SI4ZnfmIszZjgn6vMkX6sJ3ZJ24GjEwMnLQerkLjvQRVLkDz
+  akBdiSIEELnOKBb11MJ9QAECMQDhJk6Y8ijOaY8bPollNE/+Srlp4HT+/QkS+Os1
+  5GSQyjxbgwJ0hKNZ5+K/ktNjsoECMQDcu6KYyHv+k/0Lle64tRTAwDrY6ihVG24T
+  qSx1Rvk2rycnj43o9vFd5KK83B6lqa8CMDXHVqLFxOV45UvWpi7cTfcplhwqFwgJ
+  HK/BcT1QLo0/ISeipWV7gSEqeEjWI1P/AQIwRQgpgb6xiJyfts/dKMb5Bo8X2F7i
+  3jsF4gA2dzcLGZ8Nj8HFj+Yq9kJa4tW0f/rhAjEA2RpJoFDSBgqOrQlWvbv0emGC
+  /LeZ4erY43uylcslv0IdeARWGNLw7x8dq++QO530
+  -----END RSA PRIVATE KEY-----
+
+base::shell::shell_prompt_string: 'dev'
+base::supported_kernel::enabled: true
+
+govuk::deploy::aws_ses_smtp_host: 'email-smtp.aws.example.com'
+govuk::deploy::config::errbit_environment_name: 'vagrant'
+govuk::deploy::config::asset_root: 'http://static.dev.gov.uk'
+govuk::deploy::config::website_root: 'http://www.dev.gov.uk'
+govuk::deploy::sync::jenkins_domain: "jenkins.example.com"
+govuk::deploy::sync::auth_token: "example-auth-token"
+govuk::node::s_backend_lb::aws_egress_nat_ips:
+  - '1.1.1.1'
+  - '1.1.1.2'
+  - '1.1.1.3'
+govuk_beat::enable: false
+
+govuk_lvm::no_op: true
+
+govuk_mount::no_op: true
+
+govuk::deploy::setup::gemstash_server: 'https://rubygems.org'
+
+govuk::node::s_api_lb::api_servers:
+  - "api-1.api"
+  - "api-2.api"
+govuk::node::s_api_lb::content_store_servers:
+  - "content-store-1.api"
+  - "content-store-2.api"
+govuk::node::s_api_lb::draft_content_store_servers:
+  - "draft-content-store-1.api"
+  - "draft-content-store-2.api"
+govuk::node::s_api_lb::mapit_servers:
+  - "mapit-1.api"
+govuk::node::s_asset_base::firewall_allow_ip_range: '127.0.0.1'
+govuk::node::s_backend_lb::backend_servers:
+  - 'backend-1.backend'
+  - 'backend-2.backend'
+govuk::node::s_backend_lb::email_alert_api_backend_servers:
+  - 'email-alert-api-1.backend'
+  - 'email-alert-api-2.backend'
+govuk::node::s_backend_lb::whitehall_backend_servers:
+  - 'whitehall-backend-1.backend'
+  - 'whitehall-backend-2.backend'
+govuk::node::s_backend_lb::whitehall_frontend_servers:
+  - 'whitehall-frontend-1.frontend'
+  - 'whitehall-frontend-2.frontend'
+govuk::node::s_backend_lb::publishing_api_backend_servers:
+  - 'publishing-api-1.backend'
+  - 'publishing-api-2.backend'
+
+govuk::node::s_cache::real_ip_header: 'X-Forwarded-For'
+
+govuk::node::s_frontend_lb::calculators_frontend_servers:
+  - 'calculators-frontend-1.frontend'
+  - 'calculators-frontend-2.frontend'
+govuk::node::s_frontend_lb::draft_frontend_servers:
+  - 'draft-frontend-1.frontend'
+  - 'draft-frontend-2.frontend'
+govuk::node::s_frontend_lb::frontend_servers:
+  - 'frontend-1.frontend'
+  - 'frontend-2.frontend'
+govuk::node::s_frontend_lb::whitehall_frontend_servers:
+  - 'whitehall-frontend-1.frontend'
+  - 'whitehall-frontend-2.frontend'
+
+govuk_jenkins::job_builder::jobs:
+  - govuk_jenkins::jobs::data_sync_complete_staging
+  - govuk_jenkins::jobs::deploy_app
+  - govuk_jenkins::jobs::run_rake_task
+  - govuk_jenkins::jobs::deploy_cdn
+  - govuk_jenkins::jobs::deploy_licensify
+  - govuk_jenkins::jobs::deploy_puppet
+  - govuk_jenkins::jobs::deploy_router_data
+  - govuk_jenkins::jobs::launch_vms
+  - govuk_jenkins::jobs::network_config_deploy
+  - govuk_jenkins::jobs::passive_checks
+  - govuk_jenkins::jobs::publish_special_routes
+  - govuk_jenkins::jobs::run_whitehall_data_migrations
+  - govuk_jenkins::jobs::smokey
+  - govuk_jenkins::jobs::smokey_deploy
+  - govuk_jenkins::jobs::update_cdn_dictionaries
+govuk_jenkins::job_builder::environment: 'dev'
+
+govuk_jenkins::jobs::network_config_deploy::environments:
+  - foo
+
+govuk_postgresql::monitoring::password: password
+
+govuk_postgresql::server::snakeoil_ssl_certificate: |
+  -----BEGIN CERTIFICATE-----
+  MIIB7jCCAZgCCQCQITrBr1+9DjANBgkqhkiG9w0BAQUFADB+MQswCQYDVQQGEwJH
+  QjEQMA4GA1UECAwHRW5nbGFuZDEPMA0GA1UEBwwGTG9uZG9uMQwwCgYDVQQKDANH
+  RFMxDzANBgNVBAsMBkdPVi5VSzEtMCsGA1UEAwwkcHVwcGV0bWFzdGVyLTEubWFu
+  YWdlbWVudC5kZXYuZ292LnVrMB4XDTE1MTIwMzExNDYxMFoXDTE2MTIwMjExNDYx
+  MFowfjELMAkGA1UEBhMCR0IxEDAOBgNVBAgMB0VuZ2xhbmQxDzANBgNVBAcMBkxv
+  bmRvbjEMMAoGA1UECgwDR0RTMQ8wDQYDVQQLDAZHT1YuVUsxLTArBgNVBAMMJHB1
+  cHBldG1hc3Rlci0xLm1hbmFnZW1lbnQuZGV2Lmdvdi51azBcMA0GCSqGSIb3DQEB
+  AQUAA0sAMEgCQQDYSfBySdDJWuNCdvfFMWSQ4eIAFwFEje+K+Deb1h/WSnWWaBrF
+  f5AzVJh+pm1DFGDNpZ/yLNxd5N76Ix5w6zKbAgMBAAEwDQYJKoZIhvcNAQEFBQAD
+  QQDGXjnP4BXnhm6wYDUq5eqev0zKLaujJSqE2XTJFL2hM0DHa3hSXyFDIsHgtKl7
+  GHKnbfMYUKo2s/jBYlWBZQx6
+  -----END CERTIFICATE-----
+
+govuk_postgresql::server::snakeoil_ssl_key: |
+  -----BEGIN RSA PRIVATE KEY-----
+  MIIBOwIBAAJBANhJ8HJJ0Mla40J298UxZJDh4gAXAUSN74r4N5vWH9ZKdZZoGsV/
+  kDNUmH6mbUMUYM2ln/Is3F3k3vojHnDrMpsCAwEAAQJAYUxR2HgQbqRuW7X9HD5u
+  CSc0benrbhWTzyZ+jaIzzEf6b3iLlbgvdkt8jiFXJ5ZCGaiEw0pKQ0KUbIGWQiKR
+  QQIhAP3fDAOm5U49wRwGJSI84X9VAjiDbmxX72BzDzkMZ8mrAiEA2ho4BzoUEtb3
+  0pg8DxWSvyfcd3+QG4n9RvZy/RDMqtECIQCJogTXbgHfGye4U7SKDUuLRsD/dnHF
+  Fx9VwMs9+HXEJQIhANlG73Q7ps3R/Jd/c62vVz86LceafG0C/iCY2ptEBjFRAiA2
+  vxBODhF5cvyO/S2jUuvApGU4dU2KULT5Dv3/Lh/Otg==
+  -----END RSA PRIVATE KEY-----
+
+govuk_postgresql::wal_e::backup::enabled: true
+
+ssh::config::allow_users:
+  - 'assets'
+  - 'vagrant'
+
+users::usernames:
+  - null_user
+
+mongodb::backup::s3_backups: true
+mongodb::s3backup::cron::realtime_hour: '*'
+mongodb::s3backup::cron::realtime_minute: '*/30'
+mongodb::s3backup::backup::s3_bucket: 'example-s3-bucket'
+mongodb::s3backup::backup::s3_bucket_daily: 'example-s3-bucket-daily'
+# Randomly generated GPG key. Generate your own and encrypt
+# this key when using against real data
+mongodb::s3backup::backup::private_gpg_key: |
+  -----BEGIN PGP PRIVATE KEY BLOCK-----
+  Version: GnuPG v1
+
+  lQH+BFcOBVsBBACyaMMZhxpGSpGxea/Cko6vanVKHQrzPRKcg5Mw2wErypZ3cxsV
+  8Mbtw9gG5RFxfHICThc6VzXZctrSmSY48zcvrC2aj4Z3oIdu6ZLqz50ZNEfauHuT
+  9ydtSq7pFLg8v40DBmHeqpElPC3LsOrBWgpRB9u6E91m1a7Cy5waTKpU0QARAQAB
+  /gMDArVorwaqKoL3YKq9V4NQi4nLSJYruqsW279TgoIYtalgbSriaiObSqeKCjIr
+  M4EkYonNHX5PQNTzXPVQTiVGcUbX++y4F4/cMkbtaE97UDIBnVcW1N/E6DvF3ov5
+  jRbGersaW+COEA86Sy0VT/BeA4ktxgvdLdlMwzGjRD7wiwHnpIQENQzqsAR6LesQ
+  b0M2+cZOtGKa896dDh4/MWP1ScKWCeTAp64rN+lFP0hmrG8yhvtrs4zrBqIoLWn9
+  ZBR1MgWktFy5SyZfho/LJ3SE+VBy58XNCiaUXsmyX7kH/rmgub8eTNhuG9OE2Ulz
+  KYFpO2SmUluRsPmrlrnWrsr86CdMV9Cn2WozyMi8gmtYY4NC/xiwguJ3GSKMP7ca
+  TaiA7AkonB7y19qml3LpYcknfv2vY1GaxnJogUkq75Nb6zBEDXJrP35A1LfCjwRq
+  +WuzqDHi6M1fswkP/u31mr5PRtRLcENs0LBm5Rz4iIHEtCVIdW1tIERpbmdlciA8
+  aHVtbS5kaW5nZXJAZXhhbXBsZS5jb20+iL4EEwECACgFAlcOBVsCGwMFCRLMAwAG
+  CwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJELYLUObb4ur/zOcD/j7c8UxeJUif
+  Y1q5zR/lrJF8PGIosf6qEQhMUJXciezkIsWx2xcCBMndAYCWGCsYvmkSEdqCTEtg
+  2rdF6iRLo4BeNA6pHOL0LtOdPOFBGXX/sxpN+Ehhvy71eAeS5RZo78CWNVOCaS0z
+  uw8T4ZScQTQG6CbcbjEGoMrRC/SlBHNQnQH+BFcOBVsBBADAHMSaawcGV6BRSMLf
+  BoR0BM+cMz46vvfldD2Io+Pwfl0qNeb9MNTK42Zm4GJjMY6IIUYrJAs66l/a1K+i
+  5XQN1afZtleHjfQLK+RAO2v4JJhlsKrVK8tpPsby+jnJZH+qr+Op10wxZQqKdzNz
+  g3eJCTm1vC8h3TFhkExM5xXSQwARAQAB/gMDArVorwaqKoL3YCBWqJ2k04dCf+pf
+  XDYrd44ZyXntH6UC4DUBdaeU7XgUA+hRx6p9z3OWBYelXAGi3O4HTIqHMJrWGgXy
+  uEoQEnknQx5DwTcfk2JdK2yU8gNIsU6m2kvTSu9hAWHRXQtf4opotWbNhEyhZRXc
+  XVdjLt6VXf+xNBZL0Tnyo2X725eJUROb5/wbjSt0ciN7A+iR8w1zbexvVjXSkvLp
+  W9fbVd6M+6lqkqCrkAZtaavRqI1JuRc6sVKwrJGe7gv7ZuRVhxil1s8vj0OQpG+4
+  ScTrjfW8atrWrkpQGbvP3gCkznsfF2SqzxLnkm7kq09fJtu1Z5sN/FPE3h7xmZ8+
+  Ne4HRbM2O2SAGKvtHKvs/tJ0ihDEMk8yNTF9CpvVq3pIcXwI/wd2129cgrZGr0i6
+  Dw1ahVCBzO2sjmQ14g9WJOQE65r8eTzMZvRVL3/+b674uqO1KkTpULChxlYC/KDZ
+  AdmkctfoixaIiKUEGAECAA8FAlcOBVsCGwwFCRLMAwAACgkQtgtQ5tvi6v8YFgP+
+  KMdz0WhCeMy5gHKOwDQ5QiN+yTz4wSVbn8iI4bqA8+FFYKdZDu5DTVKkAfZl84+n
+  TKUTpBkgafLTB+CSmFBYuFT/r4M+5JVrVy5cBqeEspY3OmpjcsZHIrBkoF+naJQV
+  Ez/E3CEAE2MU6kwYzOv/IR8DRQJmdJDAp/KXrBi9y9A=
+  =iGOp
+  -----END PGP PRIVATE KEY BLOCK-----
+
+mongodb::s3backup::backup::private_gpg_key_fingerprint: 'CB77872D51ADD27CF75BD63CB60B50E6DBE2EAFF'

--- a/hieradata_aws/vagrant_credentials.yaml
+++ b/hieradata_aws/vagrant_credentials.yaml
@@ -1,0 +1,305 @@
+# These credentials apply only to vagrant machines created with https://github.com/alphagov/vagrant-govuk
+#
+# If you want to view/edit encrypted Hiera data in this file, you should use the Rake task to do so. See:
+# https://docs.publishing.service.gov.uk/manual/encrypted-hiera-data.html#encrypting-a-hiera-key
+---
+HIERA_EYAML_GPG_CHECK: ENC[GPG,hQIMA+Eyp2AHu3bMAQ/+MSiIkSkP0qienxjf9VsqgADkqqzycvEeOfFxeCCf5hC6SkosyK+6d1KEGsOBqlQU7jb50Yy5Ae+PGMupnByVgEfC2e6eAyvmSpvxe+5ParcNhI2TWCUGfx+WFvAM6mw2v3944Wz6mjpIiMha1XaiJqRMzGkx/TYKcbXA2RAu2MoGQxoFtplhPNUjABWmzks5rtdouWnqVWhw1eX4E9zgN2jd/13RaqiJEc6RRPVi+UrwRa75oXk6ZO9bN46pGNfjRAggLj/chuD8zHj7+z2Q01hsNs7Ds4nNSQ0uz+jNJgZ6K/1orAYIJHqk8e/kOUGdX+72BMLfKcEZz5hnfr/9yy4yXQk3Sv8yoD5JumP5RuCv72x54sCNrLtslH6ugxjczw4nlGINeDxWlqKCGa+FYAwPX1U2sMeUqUPu7MD1WHM43VJU//6GaGvpm9RkCYSl2rnzmIaaCMkT1Sa6l2yefTGrPPGwpJyExshXIFAqMTZUVfAlSZtedHS1OyR2f9WtL1Wp6RkZuFAR6WeqsHd9dXnNw/ed0sYM/gQfMFxtOfPquh1AyGr1A6ZVpXlcWEacgZfOEr0KGpKwdPV5IBImPqZC5/uFgphUkyM1CcmXmzrE5TCKM2J7kNDHdDdZWcGo70vSvfUrrDHnuuuGsswr1Gf7S5OEZNoPEuVjEkCOPaqFAQwDWfGuuzpTLTwBB/9KeyTI9cELRDKP9rlv9r814N8w6MThKrlQ8dBmq8ZWqxFXJFvUNZGGpdEjykMA15VYlRfZus+L8PuqbcwcJJNo9Y3mVjOYMGjQwFWIxpt5zJhclNMh4apo6ey1zg0dnF+bGYNk0ies49BXXoPTH7p+BS2ezt91h14OVwaN8Vb0Ztxi8pmK8sX/4q/nSOf/Xe7jhLa3WtOgbvR0SPBjCHz9O/YDWcPxFH9P5olkcQW493a1qUVVId5uTnxtPsNe/KYtIYGsJSZtFK6ytAo2Av7kMhQlQniMskrGNxNLaUThKB2+1H3J1Zkv8CyrzsU/hyFfKxDQ6NHa+7zcDf0GWksThQEMAzCRaMH90n2+AQf+MWpo/TGyleO/6ddt52tJ7EFdOUiaVMh1LG34lgzH+yEJihtdO0EouF6NgfMbRIvmhUKu/nhjDsUaXjFXLOAKucwFn1+9vmqOsnFyhHmp/uB/1CmFv53cwYSlnANPVKaPH4a9HA78HY5crdzjv2Hg083TX2a7cHrnFWmRUMUkl8JaeLNMFJiMAUPPGux4X0GhBZopNN6XzqI6GLboBNSSs0+a1PHT+GVOYIKE5FpTsHg7IpSfXhXZnm8u7Dr/bS5JgU/HWJCStt/R0Ctmf/cf2tJ6k95OKMNVi7XNwlWulxV7wGtuxN1027Xc2LXHJEjzetyK6tTsiFS6rXc2bEVLIYUBDAPK9ejoy9HLOwEH/379zz13nDSKt2somCPI3kPzRschXX4ApBGGtqMbWzVxvOdCwUf1qYZLXe486T6k9i+5PwUY3ybOQE0Bx1y4T0dHy0STbfJAfNDuL5YZY0fLBs8OYV9lftzco034dmthqzXjIx/WKEz/2h49aA39aKBpBoWUisegSwwg3v1cYAJN2Vmy/W3ucPh8ZPsIk4bJb1/vBwPGMS3KeeVEJ02cJIMdK7qeanSAAPh6FviMHEthV0wBo7tJ87fBf5mYoUGwvKlPBTTBCTW6FkEdy65CGVvoptVEHRfK57RZLwy6gYM9wFROKkz4olGYEpn407zAw9Wan/vut9Iv/dEXg2I7VgOFAgwDPG8UOYcD++ABEACQQRTvqTS4oJzggwT803qmMPDa9laKJQkVkJcqHaJYstaqT0UIwW0obB4rz0v5ktpbWsMb5YXVtu3QlyacYkKU9uCR4C35No52oihrUlcHqEoROKY1Xk2cpjf+ji5UnMYyHE3RRn7WVnP7jETW/WCh6LjlEQBZomP0BQgFLWyosaFOjqHc2H/WTEk0bnyhTkVYx4THVc3mcbzqe9PGNNgIZOEEK3x0msaFExAomNKwJbOOTpRRw7eRBzpHL7AvNIr8K8hmO4Nl1VhTwem1S54YXUycDQXMCrLeGGCUzPzDLk8e/U6QfndlTWUfdvvkDv7UOlDTOqlS5InVTEQKXxsn81RT2ur0A79bJUloBxGk+zKFQyNJQARSpvuX7SwhIyrcow9WXiYYiTADvAd6+NTVaHax8jilul87LgpjhPFWM4o6BQ8+hT+0CanX2uSRG82aA1Wf1gS++4M8BlBDV0TLV+JXjQ6PNpxaue9KEmzhd9Px0q4WGcSQ+eq+iNq81NZ+aLc6Dszx6dMuY4Nd3kXSMi0RFo7cELd/yRG1YMnaNe8SOT/HEXJQ75NtgpTZRjoG0X1G7yIL7hMoRrNsY2GlQGF5LKHRLP1MDOSb6cXgCFwlWq4xP4IoUU6vm3TqOq2nvOyQmNKUiGL4Xsz3d85nkCGTXPKjxoBQ5heyj0K9E4UCDAPCYJfa2spjFQEP/3ykVGN2slSIQF4ybsv1qytHpHTQGLHxOEOAMg2p+lx//mkKQIiqhvktSgKTpVtx3KYC7t3KWVM3+aR4idEF7lsgdLIuyMJqrAesqNzL1m+7LzU7daFV6IC+YYcw7PVb8b/V5zeMYiG5ivT2jjKlGt38iJVNHjg6VLqzw++sC/BteVSM1vkdfaiyjVkMe+TeKu+zGp6GnVdr307bZz4EgB1OgAloIpCo2SRy5hLn+lQt8Ib+cNdhPLS9a2TLvi4LqXJpTqXDhghvz30o8n+H6kVtcXQ0VNSFVOakhsth95wzCYKaoS4DqsqHMrpD2XNq2dazO1WVoBd4sCKqFVCyshTcT+NPirfqAlXXPM+tRVZx9EUP7nuiamLE8NSGK0BJ0STX5bU9D6cY5+oKFNC/CE3PD9z6rsE2oqELvOAhmVLOYJnO1rbFGz9yMsV/ijUGZP4FflngnOHclfHbs4jzoGpcQ2VCf1a0MFBw+cP1UpwXYmgM9Yb+GTvHcBoVSBH8JTDnnxXNweffo8KDn/npl87bhvPrLcSrGk12tJENXITKs6g9DZVvY4dMyVfRc4c1mJDcSaC7hgEA7r16a0RglbYtOJqPufiIqyLuyaCGjbFHzQQdC14UqcCQjUgVJB9GnMC3GKOLlkldryj1sxZf/9bk/wnkV7bD8VY4HQvmfihZhQIMA9jUb5so3dEiAQ/+KRx9gYm3snBG4yROX3FKKuxJXjLkfq3HjpstzlFkYqSIVUy86g24Ei2imYWF2mpDgzbXbFPJFVcrGfzOP864E3Hf7ISonTlidabo8t499zZYPzsiae/OyBtjXVBT5Vyl+8k/Q0EMhfWiTkMHk8gHbqbJVYXTwSCOY73Gq0fTQGewdKpI8Ja79pv16tsdcpXtaiVhsOU9vptH8BjT010GqqaTO0BWY+fPxCJM9Y0PgRMB9s+wtbhNJ2oDvgw+7laJ2SsMxQLp4DGSNLGEP2nUEaccXQ/zLdfPLl0FUIffHgl4egirpPFPdKL/665pfs2ow6RV0rO49A8IfJSGaQhaLNvGIezx7nQucNC4795QaYG2UPaGXnEUd5Wq1wL6eVWNBp2R4yEex1+IJM0vBvLxUJk3VsjMLjKm6487KNRt74gviTB6jjRIhGfTTSTUy/DXYaFQRhnPn93KEdjB5O1CyWPOyepsiBDpr61uozOC5lS6F4wedVw6NZ+eQf5u77oEgOn29SGE+uJtKn1zvOA1A+3KV9h2oxUGmcD4sCgNRHGuESs7yrSKinREnyNIi8Pj3+oQwcPYkp+H3lNkPeqHXRUuPnxToBJ7KdMXxaav54GRx1GAeOFCYb0gG2Mqh9njFMPlfKJmUE6ZKv+CWa7XQe+9PGdtfATSM35zLU2oRbqFAQwDMppluksYqeoBB/wNuJKJD0DGl4+NlRTJLZ+AGb2Gm0l4PT3/jVsBuyXJWU0ECXypAm+IcqcrF7nQ8PoehKCWvC51jGdgoASZG3pVtbfuG6Dci6xv5AvqQUvGMYWwh81bDX7zlyBl0+ElR0Td1NGCO1qlxURj4Y9nVAUxJeGSzLyPEbmd5bK3zADc3fsHSZFMIofyALc4Gx+hnO6Eo/fqvoC4ayM86iB24PxEKrMV/vagl5DU0GRLRIsWwB9jXJkdknpcjImH6G7d0Xw9Iz0TR2/wh1Onf98tPaqn9fcNrkHDtUyj62tUg3VxHWZNMCHpgS8FNXYWGFqvRriISMA1CC440lTM8QBRBGxmhQIMA3SUhpBFNqYfARAApd+eRlT2PQhANobIM8FpMuvSLGUiMPhEykexQCDgFucfDJIDVol796z6t4BBYkaqTVbvv722JNr3FZjduL0sifRG35KW7l7nK0P6v89/GVnR3LRBUoNI+AY06EF6DDGyqg43CuviZk03SgG8jUuqdi0Qs5oenCq0+TEc+SUAbyy6NP7xl+e4VawoKcPqRvNfoMBVBKEQKvJIDmmWcS3KvTmSWNLYw/qMfjVixeIYvIk/cxB2xgiPxRQsaI7wCyW+x+2Om50fQUAU2IiiRaCBqLFXRdRNunmFOEfR/1c8UhXvf9dJsBHmBJGARSr2o5I8/Ndadpe+rbg25QarfVfpC0kkk2np5sb2fcODyST/5mrzcof7nMy2CJCesDbZdjDEhZQ79ZX8wNkFHgtfQh6zj2OrYjZHvREu0R416BPj3IiQwyW8n+7jt/ju28CLhI+BBcEbJfozeHdshVm6bNcTbl7cr970iMvotF+IU5+Je9tyM5LpbRn3IVhgB0LNnFsHmw9iEVGQ32oCjPFF0aizfD7JC3jpRRR/KsgfE2tMTLWZEUswjmZXiJ27O+OWOn1EuNspALHP/HgoCtpkfbMrvDUl/moOCo5qW2WepyMO4V0OS1LJW7n5KtFEitVBGfQFMJI/CN9MwxEYDYTeizR1B2QuV3Hb4E3p8+2vyZqbtleFAgwDyMuRAjQ080EBD/wKVKOrtxLdBXUZzws6wdZFPx7Ikra4H0NRMcp311fySYWDy6SPf5eFDBT/3PCKh8SN8ufr13hU/11m7VcrIVH0KFsaZsy0IZ+aBIjISKqlQVMeiQdV5QQQc69zypZzAN3PFfsDHSEzHcIfuNVS814i1e+h0IXiMV/k6yawZt1fJjVgvU6yd7Zujy0nJTftOfQC4yPgqOzM1XHrbLHMcA6dU1Hq2EY1tbtRYtsPLgL5Hnit/Lt7dT3fawqZmInQrA9kG7N54CFfFlk3bMO96m3P8+8trWR2Pz1hiVy/RRq/EBJ7NYIlOapLXuCkUgjlqUkFDW9dqoPX0vVscETrtFonJkNku1RqO2nCZ9LVaRJ0gn/J1I6FbRgjUtVlzkek/Fplf0wA3LliR7Ly2Vk7UmSFcHnOrHIE1NEolZWdBF0L16qLlEDn0qa5XGrrdE1UvlyXkGOy0iTEGQGEJUMmDueC/sRleFPdjk3Udivk2nNQPfcjdoBLy7swESlyfuwoP0PIFD9vdYjm6zl5txPeKOVX8J+8RL+a5e0GdvnhisFrBq4lAXLTuGBdTGEhpregCzZEtHaKrxXIlQ7LiWFHvMO/dJk6a12d0S1OiLiwglw5dQ14WtZjwp4RI1CZBVs6pUXAMV1thnQjXSEcSBFBC1ndp0yJXFHwIaoyfZKkJpTWMYUCDANrEBmNmL2wSgEP/2XKA1Lws2sVJ8JFzpxzquUmMHKg0W/903qM1YQ4Gan6npZkVZyCMjF7naIlQpXPL3GM2pA8aFs/BN7lrb869j3r6qzh29XTmqG0CTkbp2RRfOZ8LUeWsy8X+AUxoxKxBqJc7i0ueiiE84FXdRjArHRR0mLcCs5dtsfYZdoyGUIw5U70KNKfcJbPCecBWA4Fn5PUNYsriUdPyNmIXQStjt+yrMt8ROXACzTx8LZ3OoqstBxgJOqUqzJLfTzvxX841epLAUpdclDmvWbrTWBLmjbRVwfT6/ZlW69R3Iyzupr5HSjb1Phu2nklA7XJpm+ukS/sicKBGOJM8dWr8kWsNIhPyVvCOmMEA2jpsoyfiufWV76Gtci/VlzrBzzR9pBxaVkKJ162+wYPhvd8dmGJXnHdXmcJ+NWJugqJZ9LuGYograuSIPabWmQncANAa2p1WyXJv8Sf5SaIlro9Dd1jclSaJdR+aL6k5QYLEj0S1SP8cS9Sz8V1yzR8bD6DlxhopJ+/ITY8wB+h7fyRYdnGxadLKPC0vHM8m4JJyBBXmE6teJSzk6lyt9ElK260qGgQqL4ya074/oE5+6+I3NVn67E+oNC/9rv6WdfPiZPVuVM+WyB8xfv1ZaaSb829vg4+/VpQngY3s1qmVJ1YNcPNb4ZuoHjggx9ivQAzlx3zz32/hQIMAxR+jm4ZZwIVAQ/9GGXAHR4Us4FdKM+adVD16CA3SClXYoijQYQEiXDQLh70MsnzbANPZ4l8Tz3QJoD8odgR+IjM06QyWjJ/wzPDfHN4MzHhxlRpOGJ1daB8z5U6gj33qFfrq385tywhpfIUjO7G+3ullGTJ7deTM8mLA/zWiLVEAp13SgQJQcCkcfiQ4tspzd1jxSfHiKwu/ogFV7aVqy2nmoV4okczJwpI2b0xu+CkTwV4xR8MIZQNTFKFkLXyVT9DxIEAy5N8T6nlgr+ilsVNwdx8RVstEveTf06Hn7t7N03fn80Lx+1DVhobSsMThfS/+c6o7PvJRKfp64bmD9iFiFZmdmHTQe8i/KKJa0c5Kxo/O55mrL5BhkCkihnUY19+QUTB/FKGg+C3fmmAY8G5gZD12ldt4A1Z5D7VIwF9umjrcNIbPseb+tDDuWpNwAOobvDW4PXI5rQnBaPCFdJ94G60a7vzUI7rcgzGaKN8e9oMp4eLyR1Ly3hj8mhQ98jp8E1e3kInnNV0478yUp0wdtxN5+oP+C2KxoJ0eVVI+doxyrTWNbLQPtbFk5/XBfcDmN0v6DsX1VEsdFP/tp3YfG/JrDxriBvTVSMQciCwS7T4QGqM+3ligtt3bPVXoU9u3ENJ0N1YwhjzJikA6FOOVu9CM1MqzHxt1eX8qrVV5kd52o4v6Gs6QjGFAQwDrN9RfkB1140BCACug1IyS3h12jc5iELkYut4RPnhuYYZaqThcLyLAPVz8mFtOLiPjVpgOBsatbFceya00FwfV6lVjhokEO9/qHlvR/30ZheTJtCTpeab2Wg2h10oQZWtVyUcQ/34YcGdrObSLJ7wk/57Q5cn6Cp+71e8FnjV/MclI6BQS+Frl34QwaSGyrwkQSXW/ttY4NiIodtEV/E5j+ioUzgTjjNdFlXqK75/hdrxljMRNxNdVWTS88JBYmtnWOQXXQlyibyXjd5fuN5S6WrTITgwgCczeu6c1gP1tSrwtunhJ8rb+sLsHIto0e9Gh1hv3bXE1UBGiqE57ylB0hL4zYFVEow55RJAhQIMA+aZGILj+9TqARAAryNPMlYBaYKhO6y7bpRxtXO02iGjs0+WF9idHCU5VeBQrdD+e4rYWtcoyyhpv9Wc6WJzFToqatihqIBpMzwGOeVoQ1Dp/Zi49YuNp8X81WKkfrx3cYOGjhexQACC/tNIzYOb2Lc7djklj6ViqUCbHd7d1dvMNtvHELzPR+U/+gRyJJO7D7NhZzUvHCu5nKmJwd5niRf9H6qRWWiK/TMXi/V6ziQtkXuG9Zjcx3pYI2UG9ZMNNLozBhd5rzfHGvX8hgRt++8AymwB22rInUn3KXmlnf+VPegQ9dSvL1Q0u9nheHCr7Zkch/7D6aZ5z4HC7CPx8QpCcndxorvDxlUdb6bLsxLhr9KAYq4fZ+Vm/CsidXduMzwlAUJj0lbG9ikKt/RRQpVVQIAfFMyFzS7DfHuHN0W1pRIdIFVZ1mRyQUSSmT9vP0Q+sZrtmv7GiKSo6p0HRQG19e5BfWgKs2I5V1Om2H4oDQOj7iWvFISc3iXoh4zvDZw33o9sCZA1pNF4EfTBarpINbc/x0Td0GXQbBSdYCSm5sTWPma6Q4czX9TqKyAxhuEWHIIbupk3aNaF5ZxFjfZDZQYXmPEGsZ7+LhanPxJ1biq/aeLWEFu59P5+AGjG+H7oCmGbHxMZHpG1iFYQNuREZCuwj5MO5wmowLhbZaWPhAYFvDDb0xqCXRjSTwE3kGKdEO7nedVwr/rdCFQf4LY1d/HNOMD1kDkoHobUyxh3XKi3L7v3ckTTnNuwaCJie/OUuPe98AkcGgHY8PNnckDuHextjio7XEemODo=]
+
+backup::client::backup_public_key: 'REDACTED'
+backup::server::backup_private_key: |
+  -----BEGIN RSA PRIVATE KEY-----
+  this
+  is
+  a
+  fake
+  key
+  across
+  many
+  lines
+  because
+  i
+  can
+  -----END RSA PRIVATE KEY-----
+
+collectd::plugin::postgresql::password: 'password'
+
+govuk::apps::bouncer::postgresql_role::password: 'sKnvsmsAEeviNNl3Ded90NzxoT7eFI6Qd1cOVmaA'
+govuk::apps::ckan::db::password: 'goh8Deev3peki7liuxool7mo'
+govuk::apps::ckan::db_password: "%{hiera('govuk::apps::ckan::db::password')}"
+govuk::apps::ckan::secret: "foobar"
+govuk::apps::collections_publisher::db::mysql_password: 'BeDrefCoopdevAynhagmimUmdicuvKas'
+govuk::apps::collections_publisher::db_password: "%{hiera('govuk::apps::collections_publisher::db::mysql_password')}"
+govuk::apps::contacts::db::mysql_contacts_frontend: 'DfM7oUW8Hsn9g23WZW3Hvv4wmr69deQX'
+govuk::apps::contacts::db::mysql_contacts_admin: 'DO7910Lz5ohJukmnvC6GrN3e4jtUP82l'
+govuk::apps::content_audit_tool::db::password: 'MDgTmQKvEAax4wgefQAZRNDTajkdtEVf'
+govuk::apps::content_audit_tool::db_password: "%{hiera('govuk::apps::content_audit_tool::db::password')}"
+govuk::apps::content_data_admin::db::password: 'FrkwKJGjLAjbznLtPhFjVy7YEonLKJTr'
+govuk::apps::content_data_admin::db_password: "%{hiera('govuk::apps::content_data_admin::db::password')}"
+govuk::apps::content_data_api::db_password: "%{hiera('govuk::apps::content_data_api::db::password')}"
+govuk::apps::content_data_api::db::password: 'jo6Kah0kuokaighoughePhooch1Eequu'
+govuk::apps::content_publisher::db::password: 'a7NnCu8JNPcKsYDFJpC3HpbxsdZYttMt'
+govuk::apps::content_publisher::db_password: "%{hiera('govuk::apps::content_publisher::db::password')}"
+govuk::apps::content_tagger::db_password: "%{hiera('govuk::apps::content_tagger::db::password')}"
+govuk::apps::content_tagger::db::password: '6bab0d694abaabc64f4b40fcd7e51'
+govuk::apps::email_alert_api::db::password: '8WB3h7RXohmTvmU7bmmDK4ppsd8BU7Ki'
+
+govuk::apps::govuk_crawler_worker::airbrake_api_key: 'lxHeeE3VknbR7nlZ51QnUfKcxd7iuIcSe25r'
+govuk::apps::link_checker_api::db::password: 'r8I6kP13TypUPiCR4izTImbaF7Li/Oh4VZFTSYR3j7A='
+govuk::apps::link_checker_api::db_password: "%{hiera('govuk::apps::link_checker_api::db::password')}"
+govuk::apps::local_links_manager::db::password: 'a192e3fcb901b069aa6c45438faecdc48b30f8a6'
+govuk::apps::local_links_manager::db_password: "%{hiera('govuk::apps::local_links_manager::db::password')}"
+govuk::apps::mapit::db_password: 'h2sBuU%M1859A0K*10VriyQwa$jGQkBKYYlAKNKh'
+govuk::apps::maslow::secret_key_base: 'a06f64da7e2fa4289722d21a8cbc9fdbc26510be9be2a48803d6dc95459a1a176f70425e6fb6597549b0b951b6a0cca5abe2f0155929e912ad251064eea267c8'
+govuk::apps::publishing_api::db_password: "%{hiera('govuk::apps::publishing_api::db::password')}"
+govuk::apps::publishing_api::db::password: 'jgt8923jg8923jg289jg2389fj2389fj3289j'
+govuk::apps::release::db::mysql_release: 'AlxLdicrdDEx20Yekkn4AXGAG2ksIQU1'
+govuk::apps::router_api::secret_key_base: '05ddf7c150a3c850705c86b270895d92a71779cdee752077c8d76d89fb657b018043e918bfc5abe8b914c1094158d9ffbb2264aa1301da5d2e6dde0995afd65d'
+govuk::apps::router_api::enable_running_in_draft_mode::secret_key_base: '05ddf7c150a3c850705c86b270895d92a71779cdee752077c8d76d89fb657b018043e918bfc5abe8b914c1094158d9ffbb2264aa1301da5d2e6dde0995afd65d'
+govuk::apps::search_admin::db::mysql_search_admin: 'KrafvoginjuxwycjiwegFaicsyecvi'
+govuk::apps::service_manual_publisher::db_password: "%{hiera('govuk::apps::service_manual_publisher::db::password')}"
+govuk::apps::service_manual_publisher::db::password: '3H3lpsZenSZAdI3zQGCAcdYEUTbcECvMtZ4VoK3v'
+govuk::apps::signon::devise_secret_key: '1e0310b9f18fc6ba34145829addcfd3f100c91f12e31ce071bd582981d44fc6ee1bd9a899e05e7cea9189aa54b6132eb36f4ade9c17b5535ba13bf5909b2a79e'
+govuk::apps::signon::db::mysql_signonotron: 'Yo68brC26TBdCf2NzCmwszv9UHtqbH8G'
+govuk::apps::support_api::db::password: '6ba55037a05b6d7061d5401305bd0c43'
+govuk::apps::transition::postgresql_db::password: 'ood8Michej4phaquuchi'
+govuk::apps::transition::db_password: 'ood8Michej4phaquuchi'
+govuk::apps::whitehall::db::mysql_whitehall_admin: 'lB2gKNzWLBt75P8qBEtKkkCapePqAvd2'
+
+govuk_cdnlogs::server_key: |
+  -----BEGIN RSA PRIVATE KEY-----
+  MIIEowIBAAKCAQEAqQGS8cE6fDexFazOlkWgiS2UbyYI2cVp5IUuU+ZmNpSpeKHm
+  SNtAEf/YP7gbCvnWbl+5ieTi/SN7IHTd4v4P57B5XHoTV3geh7HLXxbzcZnoC+VD
+  k0ezJ2ckdqXxB/c/AQjNytyV4GnATTLsNSh8TLg9quFZQPHm8cKVyl1caXWN4vKx
+  OkF1w4sSYa9fWKzQe+Ps50f/XhHSVmL/v3gKFs3PloNxg+0Pq9Tcoy04YI11wnto
+  lJooSXM1FMQMRFn6p4Dt98H4TDPzhacjlQdpwHHkyjiElqC09VOyI+a04B7Ozugy
+  zO9dgrzajUbGKcFaz+UvBMg4DniXIc0KHazoewIDAQABAoIBAQCTP7fTwtM+Hxe/
+  Fsz3yLpSStAk9zKG6qWUYSU4HGm57FSrsgN+PujXxd2XxsRpD7xwdh6lsjLC8wL4
+  CFq6xzj8WJmkpQftEc8n0xSqSMjalYnDs4Do9XN2RTtT1Mjoc9cFA7KpqP88g2b0
+  3AVJW3jRL0UreSPWnezlfvAbXLSDfGm4sC83ml28/2KYuZ2zynSvF88QZPrx5as5
+  aozbEjefRuPrOPUkrbCsrVA3BVt8N69E3y1I7PNPcPfh4Tr11aqYD41XscDsl8mu
+  nQOsAFDGLXEXQWqc/2P2bE7ryPZtVSSPu9BNNBMYze4aruDEU/g3st6lkqCViWcq
+  kJJ30U/BAoGBANqHO+Is3bRoCqs8Fh8K8UlWOHkrTLqsscJpMuJvDkUse8Sb7MX0
+  rK2gKKXgx109oqzHWPV/MeCy+2VD/i0DdtbwU619xxTfcaQg6CCt3/7ssZEH8D5s
+  Lk7H6CdIqb9Q+0GZrWY3WO8fmO8dNCOJXKm7LYsLgSMDuQI56BBZlgSpAoGBAMX8
+  dgQCv38vk9g3fsnYzkQopPyDBlF8BT4AbC5u7A/DSTkl5NcmAVvZEtM6KxhDtATE
+  xG7HdWNPpcc7Bg1YvGa+NwmIIjIbNmIWXWhCHMwWRkHpeT3xA9XJfmJqgkxGZxkx
+  SFtP5YQwviJiFI59pyaQf4QoZqvX+Ei5hQuEshaDAoGAE+qhXZLDPg8BcevPBFNF
+  /G4cRYbZvmXA6bwWxCZlAY71VMz1PnF3T3e6XKvo36mfauncRLur+xO079zLjKS1
+  Lw/GQJinDVL0E4ZgQaI3OQ+ve01i6v2HFu0HTpVDy0kBLVBpSlifBWQ21wwtVVPO
+  mzWRCAwrX9qWAQrwCJVxo8kCgYB6JoLhgpiHbeE3ezW8bwkDwFfaezRAvdW2JSiZ
+  lVILf58DpT+FBiu8cTdOHwtLkynT71qKRoFEXnWXb/ER9vd2JFFsjhMa+vMYnVfP
+  5UpDGFMMg3GMJ9EH66MQMUpmqOEfB+rue2LNpg0IxZ6NMzUXc/tYnFyMFVlX9S4C
+  p0IA5QKBgB+OqjnpxaQ2DuWhl3y0TYqScm/Yz7IsBmvsO+caTDtGvHWgdS/5oAKk
+  H9t6TbuK+Gq3gyao5Kqijwx6pYmZ2EGRg6Az0gMX6vUFZ+/M8Ot5K3x0a0OkU/6f
+  b94UN2GCqz46Cb1YwV+P7NTolctUt25wJiydC47gr2UwiGxK0nwL
+  -----END RSA PRIVATE KEY-----
+govuk_cdnlogs::server_crt: |
+  -----BEGIN CERTIFICATE-----
+  MIIEmzCCA4OgAwIBAgIJAMyXDZuB0sqxMA0GCSqGSIb3DQEBBQUAMIGPMQswCQYD
+  VQQGEwJHQjEPMA0GA1UECBMGTG9uZG9uMQ8wDQYDVQQHEwZMb25kb24xIzAhBgNV
+  BAoTGkdvdmVybm1lbnQgRGlnaXRhbCBTZXJ2aWNlMRswGQYDVQQLExJDRE4gbG9n
+  cyAtIFZhZ3JhbnQxHDAaBgNVBAMTE2xvZ3MtY2RuLmRldi5nb3YudWswHhcNMTQw
+  NDI5MTQxMjE5WhcNMTkwNDI5MTQxMjE5WjCBjzELMAkGA1UEBhMCR0IxDzANBgNV
+  BAgTBkxvbmRvbjEPMA0GA1UEBxMGTG9uZG9uMSMwIQYDVQQKExpHb3Zlcm5tZW50
+  IERpZ2l0YWwgU2VydmljZTEbMBkGA1UECxMSQ0ROIGxvZ3MgLSBWYWdyYW50MRww
+  GgYDVQQDExNsb2dzLWNkbi5kZXYuZ292LnVrMIIBIjANBgkqhkiG9w0BAQEFAAOC
+  AQ8AMIIBCgKCAQEAqQGS8cE6fDexFazOlkWgiS2UbyYI2cVp5IUuU+ZmNpSpeKHm
+  SNtAEf/YP7gbCvnWbl+5ieTi/SN7IHTd4v4P57B5XHoTV3geh7HLXxbzcZnoC+VD
+  k0ezJ2ckdqXxB/c/AQjNytyV4GnATTLsNSh8TLg9quFZQPHm8cKVyl1caXWN4vKx
+  OkF1w4sSYa9fWKzQe+Ps50f/XhHSVmL/v3gKFs3PloNxg+0Pq9Tcoy04YI11wnto
+  lJooSXM1FMQMRFn6p4Dt98H4TDPzhacjlQdpwHHkyjiElqC09VOyI+a04B7Ozugy
+  zO9dgrzajUbGKcFaz+UvBMg4DniXIc0KHazoewIDAQABo4H3MIH0MB0GA1UdDgQW
+  BBR3C+4Rr0ff6fzEXcWeEtFOCUXByDCBxAYDVR0jBIG8MIG5gBR3C+4Rr0ff6fzE
+  XcWeEtFOCUXByKGBlaSBkjCBjzELMAkGA1UEBhMCR0IxDzANBgNVBAgTBkxvbmRv
+  bjEPMA0GA1UEBxMGTG9uZG9uMSMwIQYDVQQKExpHb3Zlcm5tZW50IERpZ2l0YWwg
+  U2VydmljZTEbMBkGA1UECxMSQ0ROIGxvZ3MgLSBWYWdyYW50MRwwGgYDVQQDExNs
+  b2dzLWNkbi5kZXYuZ292LnVrggkAzJcNm4HSyrEwDAYDVR0TBAUwAwEB/zANBgkq
+  hkiG9w0BAQUFAAOCAQEAMGygvmghCjl016496fRGURl+BS8p3ftmWt+jtVFKWKu8
+  j1j4YmGNtcCiz9YvbcFD51c1Rhu4sYtH5Re7PtIuUVamZMV2jXV967TVKtAjICqs
+  gjPDIPhiAnTgTbQ7NvwmhutZOL+NM3/gAdM/j2F6MlAWXGir4/Smwbd46eUzvO3X
+  s1iAmA7i4W5wYZJaWPH2a9bHBJIiu48gwfpODtcuO9WtbU8CVUhdRDWyot+fEF7r
+  4EdkQJxYn93Zfmyv6d+os3pzuoYdw1p2qI4uBzgNPLqwAfg0rjUecxNRi079f8QC
+  SWxT6CtXBLz/pX7S1nkT58Anunp3H2jdt0P4llBxsA==
+  -----END CERTIFICATE-----
+
+govuk_ci::credentials::rubygems_api_key: 'rubygemskey'
+govuk_ci::credentials::pypi_username: 'pipyusername'
+govuk_ci::credentials::pypi_test_password: 'passwordtest'
+govuk_ci::credentials::pypi_live_password: 'passwordlive'
+
+govuk_ci::master::github_client_id: 'bellathecat'
+govuk_ci::master::github_client_secret_encrypted: 'sheisfurry'
+govuk_ci::master::jenkins_api_token: 'thisisatoken'
+
+govuk_ci::agent::master_ssh_key: 'key'
+
+govuk::deploy::aws_ses_smtp_username: 'a_username'
+govuk::deploy::aws_ses_smtp_password: 'a_password'
+
+govuk_htpasswd::http_users:
+  betademo: 'N04wQhwGA777s'
+  govuk:  '$apr1$S6ZNQMaM$K1QdclQvrI33AKAPui5Ft1'
+
+govuk_mysql::server::debian_sys_maint::mysql_debian_sys_maint: 'Pengeequ3Tee0eeFiex0Neeboo0laiMe'
+govuk_mysql::server::monitoring::collectd_mysql_password: 'password'
+
+govuk::node::s_postgresql_primary::standby_password: 'postgresql_replication_password'
+govuk::node::s_postgresql_standby::primary_password: "%{hiera('govuk::node::s_postgresql_primary::standby_password')}"
+
+govuk::node::s_postgresql_primary::aws_access_key_id: 'foo'
+govuk::node::s_postgresql_primary::aws_secret_access_key: 'bar'
+govuk::node::s_postgresql_primary::s3_bucket_url: 'bucket'
+govuk::node::s_postgresql_primary::wale_private_gpg_key: 'key'
+govuk::node::s_postgresql_primary::wale_private_gpg_key_fingerprint: 'AIFAED1POOX9MOA3THI9CIE0IEQU7ULAIWEI4SOF'
+
+govuk_jenkins::config::environment_variables:
+  ORGANISATION: development
+
+govuk_jenkins::github_client_id: client_id
+govuk_jenkins::github_client_secret_encrypted: client_secret
+govuk_jenkins::job_builder::jenkins_api_token: jenkins_api_token
+govuk_jenkins::jobs::deploy_app::auth_token: remote_deployment_token
+govuk_jenkins::jobs::deploy_puppet::auth_token: remote_deployment_token
+govuk_jenkins::ssh_key::private_key: |
+  In other environments, this should be replaced with a real private key
+govuk_jenkins::ssh_key::public_key: |
+  In other environments, this should be replaced with a real public key
+
+govuk_postgresql::env_sync_user::password: 'XB4MMvdTy0nU/AeoygnPuYGAabiSihUHif3BPP0SjIM='
+
+govuk_postgresql::wal_e::backup::aws_access_key_id: '123456789'
+govuk_postgresql::wal_e::backup::aws_secret_access_key: 'thisisafakekey'
+govuk_postgresql::wal_e::backup::s3_bucket_url: 's3://foo/bar'
+
+govuk_rabbitmq::monitoring_password: monitoring
+govuk_rabbitmq::root_password: root
+
+http_username: 'username'
+http_password: 'password'
+
+icinga::plugin::check_rabbitmq_consumers::monitoring_password: "%{hiera('govuk_rabbitmq::monitoring_password')}"
+
+licensify::apps::licensify::aws_ses_access_key: 'REDACTED'
+licensify::apps::licensify::aws_ses_secret_key: 'REDACTED'
+licensify::apps::licensify_admin::aws_ses_access_key: 'REDACTED'
+licensify::apps::licensify_admin::aws_ses_secret_key: 'REDACTED'
+licensify::apps::licensify_feed::aws_ses_access_key: 'REDACTED'
+licensify::apps::licensify_feed::aws_ses_secret_key: 'REDACTED'
+
+mysql_nagios: 'icAdipalapcebquoskurdibVufGuirWu'
+mysql_replica_password: 'YCnaJ5h42rTGqdpgCUct4EzjAfwQUkhN'
+mysql_root: 'T6J6wHjns2UdjVE1dLOu7BdIIq1NDVS9'
+mysql_whitehall_frontend: 'j853efpuopGcsvqV70JCcwoy0n3GSmNu'
+
+# This encrypted password was generated with `mkpasswd --method=sha-512` and a password of 'password'
+users::root_password_encrypted: '$6$gwBpG15Z0dCJ$.8BBgOp4zu6vOwxckV1RiQ73hz440NKY4TC/ViUELkDMhvfDfHyIiFg2guwKcmjsxd4AZLDz7Va3IUK4WCDn31'
+
+wildcard_publishing_certificate: |
+    -----BEGIN CERTIFICATE-----
+    MIID7TCCAtWgAwIBAgIJAMVuKOcew/ZlMA0GCSqGSIb3DQEBBQUAMFcxCzAJBgNV
+    BAYTAkdCMSkwJwYDVQQKEyBHT1YuVUsgRGV2ZWxvcG1lbnQgKHNlbGYtc2lnbmVk
+    KTEdMBsGA1UEAxQUKi5kZXYuYWxwaGFnb3YuY28udWswHhcNMTQwNDIyMTIxNDQ4
+    WhcNMjQwNDE5MTIxNDQ4WjBXMQswCQYDVQQGEwJHQjEpMCcGA1UEChMgR09WLlVL
+    IERldmVsb3BtZW50IChzZWxmLXNpZ25lZCkxHTAbBgNVBAMUFCouZGV2LmFscGhh
+    Z292LmNvLnVrMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtzWdoTKn
+    LLE7rPf7xvFMdiQOc88BStmaXgpLQNi35KKCu2umybPOlYoz+uSnrOinXS3v8iau
+    hv1DZq5YbC3w5HcN+jJRFj6kGyZwI87qHS7pBKw3KqhC4dyhppb3o+/lhTti/zkM
+    47ES0OoAkn0hISqe2ynpYFAnseVlyMNRCF/Ur3CNH6hZgGOV02rxy43GYrfe+/7q
+    LCkrDA6k7ZKbKJxIYSlPXCSOOs2uOTcV20pttMeOlCTpXh7gg7MjcJzA8G029Qcw
+    BXi66Dc13QoR96YLmIohSz5GCpZK09Iqww+qU/JqME/rUlotsWrRzmZ3vVw+oKsQ
+    1r91PVib43yHJQIDAQABo4G7MIG4MB0GA1UdDgQWBBRSP8vBeSDQJ85sROPKJcEQ
+    /g/EdzCBiAYDVR0jBIGAMH6AFFI/y8F5INAnzmxE48olwRD+D8R3oVukWTBXMQsw
+    CQYDVQQGEwJHQjEpMCcGA1UEChMgR09WLlVLIERldmVsb3BtZW50IChzZWxmLXNp
+    Z25lZCkxHTAbBgNVBAMUFCouZGV2LmFscGhhZ292LmNvLnVrggkAxW4o5x7D9mUw
+    DAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQUFAAOCAQEAqh8Kd46+cyOq2xHPP8S1
+    1PtLL5HtkZR4166ua8hsmMwxr/ynGKsvi5KtjrSzb+as3vt/L//3JZtRk0WXFwy1
+    txX4S5NwxNnCmdF2nNBfDvQayMuBiF5cn6Hg+Gu5pjuWybnv0bMyhfXvlipifJZQ
+    GKVXrIcqRZkbFgm3/Z8jGU+bz/Tk37PcAqWx3qStnOIhK+ApYujGpp3lFDmtnrjF
+    9wkcnAXMFDkmHT8y/r9auD0p8E58ts9McMMt8R4TcIdGVKVHaTlMNEeUjcmBpm63
+    aLtUxOkBrQyVJpayup+nkeJkiMTrcziGlSZKDzR62TvzyP2PjdRjLLFj/6PIwUVy
+    kQ==
+    -----END CERTIFICATE-----
+
+wildcard_publishing_key: |
+    -----BEGIN RSA PRIVATE KEY-----
+    MIIEpQIBAAKCAQEAtzWdoTKnLLE7rPf7xvFMdiQOc88BStmaXgpLQNi35KKCu2um
+    ybPOlYoz+uSnrOinXS3v8iauhv1DZq5YbC3w5HcN+jJRFj6kGyZwI87qHS7pBKw3
+    KqhC4dyhppb3o+/lhTti/zkM47ES0OoAkn0hISqe2ynpYFAnseVlyMNRCF/Ur3CN
+    H6hZgGOV02rxy43GYrfe+/7qLCkrDA6k7ZKbKJxIYSlPXCSOOs2uOTcV20pttMeO
+    lCTpXh7gg7MjcJzA8G029QcwBXi66Dc13QoR96YLmIohSz5GCpZK09Iqww+qU/Jq
+    ME/rUlotsWrRzmZ3vVw+oKsQ1r91PVib43yHJQIDAQABAoIBAQCgh4omxItWzbTM
+    Sj2Cg8vLeKxxLOClBSYNYFev6jS3UO3b6ueptLM+tGn3XILPLsv3CVlFhD9IaIG2
+    Zu1zXI3GocrNf2ktZJXGdFeuCI96IrBqN7ve1LBF11yM65rxOjKSGwcTOpngqDck
+    duUpdhqhRQcMYhzrF1Cwv5//2aQXAORvJziIjMrKHSMOnvG9UHQQNTMqr1EnmrBm
+    FIDYhUbZa4dpubWsv6QxuVyavr0GwVali8KvqVfPEjWFnyyZe4bj7h76DgwD10qQ
+    nVdJeiRHqO+PDhrTS+BNb+ml34/CE0OgUXErNvKKRzJfNfu4GoWub5gMe9TwPdWV
+    PvK+mVwBAoGBAOmWntoPpssErRzyxDd/liLYNV+O7eRhyqEuFGuc9OQzRTrLMwC3
+    oEp8wlQw9swQddD771JIrJiDcngZdDV6kGIWhLZIJTWPiUP0eI5Ieje8YxurZ1tC
+    oKNfo6LAz26S5f6CWQZttARPUHdIFewbIykvsFCpSf4hj6yENzb+WkBxAoGBAMjJ
+    l4gx3RewiEN4ksEEsygjimZ2HT0KJ++mdim1BSUGYIk/OJMW+eHNLU/QWZNO3i6P
+    LYIleCPO3AkDXk3uc4K7bak5oNPvQFviF1pM8PD6OMa7251Ma3mcrlzwYAInlv5C
+    WQtTujotFCQ6ya9/qgfTjPGfILpZOyu20+Un2Av1AoGAe6g28+1xOOyC0F5cLZ0n
+    V87pgmrh2RND98uzF70Bj4Ts01Ea8PhErOoa3gMFw8W6+SVF7mN2q0563MVs1ZrK
+    sIKHQxAyUoZn/kd/QqNvv+3E8bLthkxhSdupftFffoPZqcBLbLHKqLVsPZk1scYz
+    +Ou8BRd5ikUuD//2UvCXyqECgYEAlI6bABislX92gj0uj4MTrwoEt2SCo4vlGmoW
+    GSum38sFF+bfy+x++7Mb6GamL9h1iQtER3vDlPLTWBPW7WAUtNBKBZ/uv3/QJWt1
+    jclJp3HrGhcaGRrWlgb39ymeT1nNXNfoG/pZ2ftKYLfiS2fwfJPoP0lWJKoqnmBK
+    DM1bCxUCgYEA1ufYLRzhBg+G8OhIqGVHomGwFYH+WG9O55RWQP/5WzUOj0OBbcJG
+    Nuk9iPrsQshka6tdipdB2BLv3pVfbnruZc+AKOnlTxDtZg2y9dfWmV9ijDqmUns5
+    bIcipc38fdjMSxGVye4yxCpXaWsss6HxVed0ZVWhOkwvsW/j5QJ18Hk=
+    -----END RSA PRIVATE KEY-----
+
+www_crt: |
+    -----BEGIN CERTIFICATE-----
+    MIID7TCCAtWgAwIBAgIJAMVuKOcew/ZlMA0GCSqGSIb3DQEBBQUAMFcxCzAJBgNV
+    BAYTAkdCMSkwJwYDVQQKEyBHT1YuVUsgRGV2ZWxvcG1lbnQgKHNlbGYtc2lnbmVk
+    KTEdMBsGA1UEAxQUKi5kZXYuYWxwaGFnb3YuY28udWswHhcNMTQwNDIyMTIxNDQ4
+    WhcNMjQwNDE5MTIxNDQ4WjBXMQswCQYDVQQGEwJHQjEpMCcGA1UEChMgR09WLlVL
+    IERldmVsb3BtZW50IChzZWxmLXNpZ25lZCkxHTAbBgNVBAMUFCouZGV2LmFscGhh
+    Z292LmNvLnVrMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtzWdoTKn
+    LLE7rPf7xvFMdiQOc88BStmaXgpLQNi35KKCu2umybPOlYoz+uSnrOinXS3v8iau
+    hv1DZq5YbC3w5HcN+jJRFj6kGyZwI87qHS7pBKw3KqhC4dyhppb3o+/lhTti/zkM
+    47ES0OoAkn0hISqe2ynpYFAnseVlyMNRCF/Ur3CNH6hZgGOV02rxy43GYrfe+/7q
+    LCkrDA6k7ZKbKJxIYSlPXCSOOs2uOTcV20pttMeOlCTpXh7gg7MjcJzA8G029Qcw
+    BXi66Dc13QoR96YLmIohSz5GCpZK09Iqww+qU/JqME/rUlotsWrRzmZ3vVw+oKsQ
+    1r91PVib43yHJQIDAQABo4G7MIG4MB0GA1UdDgQWBBRSP8vBeSDQJ85sROPKJcEQ
+    /g/EdzCBiAYDVR0jBIGAMH6AFFI/y8F5INAnzmxE48olwRD+D8R3oVukWTBXMQsw
+    CQYDVQQGEwJHQjEpMCcGA1UEChMgR09WLlVLIERldmVsb3BtZW50IChzZWxmLXNp
+    Z25lZCkxHTAbBgNVBAMUFCouZGV2LmFscGhhZ292LmNvLnVrggkAxW4o5x7D9mUw
+    DAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQUFAAOCAQEAqh8Kd46+cyOq2xHPP8S1
+    1PtLL5HtkZR4166ua8hsmMwxr/ynGKsvi5KtjrSzb+as3vt/L//3JZtRk0WXFwy1
+    txX4S5NwxNnCmdF2nNBfDvQayMuBiF5cn6Hg+Gu5pjuWybnv0bMyhfXvlipifJZQ
+    GKVXrIcqRZkbFgm3/Z8jGU+bz/Tk37PcAqWx3qStnOIhK+ApYujGpp3lFDmtnrjF
+    9wkcnAXMFDkmHT8y/r9auD0p8E58ts9McMMt8R4TcIdGVKVHaTlMNEeUjcmBpm63
+    aLtUxOkBrQyVJpayup+nkeJkiMTrcziGlSZKDzR62TvzyP2PjdRjLLFj/6PIwUVy
+    kQ==
+    -----END CERTIFICATE-----
+
+www_key: |
+    -----BEGIN RSA PRIVATE KEY-----
+    MIIEpQIBAAKCAQEAtzWdoTKnLLE7rPf7xvFMdiQOc88BStmaXgpLQNi35KKCu2um
+    ybPOlYoz+uSnrOinXS3v8iauhv1DZq5YbC3w5HcN+jJRFj6kGyZwI87qHS7pBKw3
+    KqhC4dyhppb3o+/lhTti/zkM47ES0OoAkn0hISqe2ynpYFAnseVlyMNRCF/Ur3CN
+    H6hZgGOV02rxy43GYrfe+/7qLCkrDA6k7ZKbKJxIYSlPXCSOOs2uOTcV20pttMeO
+    lCTpXh7gg7MjcJzA8G029QcwBXi66Dc13QoR96YLmIohSz5GCpZK09Iqww+qU/Jq
+    ME/rUlotsWrRzmZ3vVw+oKsQ1r91PVib43yHJQIDAQABAoIBAQCgh4omxItWzbTM
+    Sj2Cg8vLeKxxLOClBSYNYFev6jS3UO3b6ueptLM+tGn3XILPLsv3CVlFhD9IaIG2
+    Zu1zXI3GocrNf2ktZJXGdFeuCI96IrBqN7ve1LBF11yM65rxOjKSGwcTOpngqDck
+    duUpdhqhRQcMYhzrF1Cwv5//2aQXAORvJziIjMrKHSMOnvG9UHQQNTMqr1EnmrBm
+    FIDYhUbZa4dpubWsv6QxuVyavr0GwVali8KvqVfPEjWFnyyZe4bj7h76DgwD10qQ
+    nVdJeiRHqO+PDhrTS+BNb+ml34/CE0OgUXErNvKKRzJfNfu4GoWub5gMe9TwPdWV
+    PvK+mVwBAoGBAOmWntoPpssErRzyxDd/liLYNV+O7eRhyqEuFGuc9OQzRTrLMwC3
+    oEp8wlQw9swQddD771JIrJiDcngZdDV6kGIWhLZIJTWPiUP0eI5Ieje8YxurZ1tC
+    oKNfo6LAz26S5f6CWQZttARPUHdIFewbIykvsFCpSf4hj6yENzb+WkBxAoGBAMjJ
+    l4gx3RewiEN4ksEEsygjimZ2HT0KJ++mdim1BSUGYIk/OJMW+eHNLU/QWZNO3i6P
+    LYIleCPO3AkDXk3uc4K7bak5oNPvQFviF1pM8PD6OMa7251Ma3mcrlzwYAInlv5C
+    WQtTujotFCQ6ya9/qgfTjPGfILpZOyu20+Un2Av1AoGAe6g28+1xOOyC0F5cLZ0n
+    V87pgmrh2RND98uzF70Bj4Ts01Ea8PhErOoa3gMFw8W6+SVF7mN2q0563MVs1ZrK
+    sIKHQxAyUoZn/kd/QqNvv+3E8bLthkxhSdupftFffoPZqcBLbLHKqLVsPZk1scYz
+    +Ou8BRd5ikUuD//2UvCXyqECgYEAlI6bABislX92gj0uj4MTrwoEt2SCo4vlGmoW
+    GSum38sFF+bfy+x++7Mb6GamL9h1iQtER3vDlPLTWBPW7WAUtNBKBZ/uv3/QJWt1
+    jclJp3HrGhcaGRrWlgb39ymeT1nNXNfoG/pZ2ftKYLfiS2fwfJPoP0lWJKoqnmBK
+    DM1bCxUCgYEA1ufYLRzhBg+G8OhIqGVHomGwFYH+WG9O55RWQP/5WzUOj0OBbcJG
+    Nuk9iPrsQshka6tdipdB2BLv3pVfbnruZc+AKOnlTxDtZg2y9dfWmV9ijDqmUns5
+    bIcipc38fdjMSxGVye4yxCpXaWsss6HxVed0ZVWhOkwvsW/j5QJ18Hk=
+    -----END RSA PRIVATE KEY-----

--- a/lib/tasks/spec.rake
+++ b/lib/tasks/spec.rake
@@ -5,6 +5,56 @@ require 'rspec/core/rake_task'
 desc "Use the basic rspec rake task with no options WARNING: slow"
 RSpec::Core::RakeTask.new(:rspec_basic_mode)
 
+CARRENZA_EXCLUDED_NODE_CLASSES = %w[
+  bouncer
+  cache
+  calculators_frontend
+  ckan
+  content_data_api_db_admin
+  content_store
+  db_admin
+  draft_content_store
+  draft_frontend
+  email_alert_api_db_admin
+  frontend
+  gatling
+  mapit
+  mirrorer
+  publishing_api_db_admin
+  router_backend
+  search
+  transition_db_admin
+  warehouse_db_admin
+]
+
+AWS_EXCLUDED_NODE_CLASSES = %w[
+  api_mongo
+  api_redis
+  ci_agent
+  ci_master
+  development
+  docker_backend
+  email_alert_api
+  email_alert_api_postgresql
+  licensing_mongo
+  mysql_backup
+  mysql_master
+  mysql_slave
+  performance_mongo
+  postgresql_primary
+  postgresql_standby
+  publishing_api_postgresql
+  redis
+  transition_postgresql_master
+  transition_postgresql_primary
+  transition_postgresql_slave
+  transition_postgresql_standby
+  whitehall_backend
+  whitehall_mysql_backup
+  whitehall_mysql_master
+  whitehall_mysql_slave
+]
+
 namespace :spec do
   desc "Run puppet specs normally (in parallel)."
   task :normal do
@@ -46,31 +96,43 @@ namespace :spec do
 
     node_classes = get_node_classes
 
+    carrenza_node_classes = node_classes - CARRENZA_EXCLUDED_NODE_CLASSES
+    aws_node_classes = node_classes - AWS_EXCLUDED_NODE_CLASSES
+
     NUM_PROCESSES = [
       Facter.value('processorcount').to_i,
-      node_classes.length
+      (
+        carrenza_node_classes.length +
+        aws_node_classes.length
+      )
     ].min
 
-    node_classes = node_classes.sort.each_slice(NUM_PROCESSES)
-
-    pids = []
-    spec_file = File.expand_path('../../../modules/govuk/spec/classes/govuk_nodes_spec_optional.rb', __FILE__)
-
-    1.upto(NUM_PROCESSES) do |p|
-      pids << Process.fork do
-        tmp_classes = node_classes.map { |group| group[p-1] }.compact
-
-        output, status = Open3.capture2e({'classes' => tmp_classes.join(",")}, 'rspec', spec_file)
-        $stderr.puts output
-        exit status.exitstatus
-      end
-    end
-
     exit_status = true
+    [
+      ['aws', aws_node_classes],
+      ['carrenza', carrenza_node_classes]
+    ].each do |(hosting, hosting_node_classes)|
+      pids = []
+      spec_file = File.expand_path('../../../modules/govuk/spec/classes/govuk_nodes_spec_optional.rb', __FILE__)
 
-    pids.each do |pid|
-      _, status = Process.wait2(pid)
-      exit_status = false unless status.success?
+      1.upto(NUM_PROCESSES) do |p|
+        pids << Process.fork do
+          tmp_classes = hosting_node_classes
+                          .sort
+                          .each_slice(NUM_PROCESSES)
+                          .map { |group| group[p-1] }
+                          .compact
+
+          output, status = Open3.capture2e({'classes' => tmp_classes.join(","), 'hosting' => hosting}, 'rspec', spec_file)
+          $stderr.puts output
+          exit status.exitstatus
+        end
+      end
+
+      pids.each do |pid|
+        _, status = Process.wait2(pid)
+        exit_status = false unless status.success?
+      end
     end
 
     raise "One or more nodes did not compile" unless exit_status

--- a/modules/govuk/spec/classes/govuk_nodes_spec_optional.rb
+++ b/modules/govuk/spec/classes/govuk_nodes_spec_optional.rb
@@ -26,11 +26,12 @@ excluded_classes = [
 ENV.fetch('classes').split(",").each do |class_name|
   node_hostname = class_name.tr("_", "-")
 
-  unless (excluded_classes.include?(class_name))
+  next if excluded_classes.include?(class_name)
 
-    describe "govuk::node::s_#{class_name}", :type => :class do
-      let(:node) { "#{node_hostname}-1.example.com" }
-      let(:facts) {{
+  describe "govuk::node::s_#{class_name}", :type => :class do
+    let(:node) { "#{node_hostname}-1.example.com" }
+    let(:facts) do
+      {
         :environment => (class_name =~ /^development$/ ? "development" : 'vagrant'),
         :concat_basedir => '/var/lib/puppet/concat/',
         :kernel => 'Linux',
@@ -38,24 +39,25 @@ ENV.fetch('classes').split(",").each do |class_name|
         :memorysize_mb => 3953.43,
         :aws_migration => (class_name =~ /db_admin/ ? true : false),
         :vdc => 'example',
-      }}
+      }
+    end
 
-      let(:hiera_config) { temporary_hiera_file.path }
+    let(:hiera_config) { temporary_hiera_file.path }
 
-      # Pull in some required bits from top-level site.pp
-      let(:pre_condition) { <<-EOT
+    # Pull in some required bits from top-level site.pp
+    let(:pre_condition) do
+      <<-EOT
         $govuk_node_class = "#{class_name}"
 
         $lv = hiera('lv',{})
         create_resources('govuk_lvm', $lv)
         $mount = hiera('mount',{})
         create_resources('govuk_mount', $mount)
-        EOT
-      }
+      EOT
+    end
 
-      it "should compile" do
-        expect { subject.call }.not_to raise_error
-      end
+    it "should compile" do
+      expect { subject.call }.not_to raise_error
     end
   end
 end

--- a/modules/govuk/spec/classes/govuk_nodes_spec_optional.rb
+++ b/modules/govuk/spec/classes/govuk_nodes_spec_optional.rb
@@ -8,25 +8,34 @@ require_relative '../../../../spec_helper'
 # filtering was not appropriate because the glob and loop below get
 # eagerly evaluated.
 
-standard_hiera_config = YAML.load_file(File.expand_path("../../../../../hiera.yml", __FILE__))
+hosting = ENV['hosting']
+case hosting
+when 'carrenza'
+  hiera_yml_name = 'hiera.yml'
+  datadir = 'hieradata'
+  aws_migration = false
+when 'aws'
+  hiera_yml_name = 'hiera_aws.yml'
+  datadir = 'hieradata_aws'
+  aws_migration = true
+else
+  raise "Unknown hosting: #{hosting}"
+end
 
-standard_hiera_config[:yaml][:datadir] = 'hieradata'
-standard_hiera_config[:eyaml][:datadir] = 'hieradata'
+standard_hiera_config = YAML.load_file(
+  File.expand_path("../../../../../#{hiera_yml_name}", __FILE__)
+)
+
+standard_hiera_config[:yaml][:datadir] = datadir
+standard_hiera_config[:eyaml][:datadir] = datadir
 standard_hiera_config[:eyaml][:gpg_gnupghome] = 'gpg'
 
 temporary_hiera_file = Tempfile.new('hiera_yml')
 temporary_hiera_file.write(standard_hiera_config.to_yaml)
 temporary_hiera_file.close
 
-excluded_classes = [
-  "email_alert_api_postgresql",
-  "content_data_api_db_admin",
-]
-
 ENV.fetch('classes').split(",").each do |class_name|
   node_hostname = class_name.tr("_", "-")
-
-  next if excluded_classes.include?(class_name)
 
   describe "govuk::node::s_#{class_name}", :type => :class do
     let(:node) { "#{node_hostname}-1.example.com" }
@@ -37,7 +46,7 @@ ENV.fetch('classes').split(",").each do |class_name|
         :kernel => 'Linux',
         :memorysize =>  '3.86 GB',
         :memorysize_mb => 3953.43,
-        :aws_migration => (class_name =~ /db_admin/ ? true : false),
+        :aws_migration => aws_migration,
         :vdc => 'example',
       }
     end
@@ -56,7 +65,7 @@ ENV.fetch('classes').split(",").each do |class_name|
       EOT
     end
 
-    it "should compile" do
+    it "should compile in #{hosting}" do
       expect { subject.call }.not_to raise_error
     end
   end


### PR DESCRIPTION
These changes start testing some node classes with AWS hieradata, they also stop testing some node classes with AWS hieradata.

The aim is twofold, better test coverage for AWS and less dependence between AWS specific configuration and the Carrenza hieradata for tests.