### PR TITLE
Only check enhanced_ecommerce_search_api if it runs regularly

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/enhanced_ecommerce_search_api.pp
+++ b/modules/govuk_jenkins/manifests/jobs/enhanced_ecommerce_search_api.pp
@@ -21,7 +21,13 @@ class govuk_jenkins::jobs::enhanced_ecommerce_search_api (
     notify  => Exec['jenkins_jobs_update'],
   }
 
+  $check_ensure = $cron_schedule ? {
+    undef   => absent,
+    default => present,
+  }
+
   @@icinga::passive_check { "${job_name}_${::hostname}":
+    ensure              => $check_ensure,
     service_description => $service_description,
     host_name           => $::fqdn,
     freshness_threshold => 104400,


### PR DESCRIPTION
This alert is currently failing in integration because the job doesn't run regularly, so we can remove this check.

The acknowledgement of this alert currently says: "We stopped running this job in integration since it was unnecessary." (https://github.com/alphagov/govuk-puppet/pull/9479)

https://alert.integration.publishing.service.gov.uk/cgi-bin/icinga/extinfo.cgi?type=2&host=ip-10-1-6-88.eu-west-1.compute.internal&service=Enhanced+Ecommerce+ETL+from+Search+API+to+Google+Analytics