### PR TITLE
Remove Carrenza Link Checker API hieradata

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -108,7 +108,6 @@ task :check_consistency_between_aws_and_carrenza do
     router::draft_assets::vhost_name
 
     govuk::apps::imminence::ensure
-    govuk::apps::link_checker_api::ensure
     govuk::apps::local_links_manager::ensure
     govuk::apps::government-frontend::cpu_critical
     govuk::apps::government-frontend::cpu_warning

--- a/Rakefile
+++ b/Rakefile
@@ -39,8 +39,6 @@ task :check_consistency_between_aws_and_carrenza do
     govuk::apps::email_alert_api::db_allow_prepared_statements
     govuk::apps::email_alert_api::db_port
     govuk::apps::info_frontend::vhost_aliases
-    govuk::apps::link_checker_api::db_allow_prepared_statements
-    govuk::apps::link_checker_api::db_port
     govuk::apps::local_links_manager::db_allow_prepared_statements
     govuk::apps::local_links_manager::db_port
     govuk::apps::publisher::email_group_business
@@ -233,6 +231,10 @@ task :check_consistency_between_aws_and_carrenza do
     govuk::apps::link_checker_api::db::allow_auth_from_lb
     govuk::apps::link_checker_api::db::lb_ip_range
     govuk::apps::link_checker_api::db::rds
+    govuk::apps::link_checker_api::db::backend_ip_range
+    govuk::apps::link_checker_api::db_hostname
+    govuk::apps::link_checker_api::redis_host
+    govuk::apps::link_checker_api::redis_port
     govuk::apps::local_links_manager::db::allow_auth_from_lb
     govuk::apps::local_links_manager::db::lb_ip_range
     govuk::apps::local_links_manager::db::rds

--- a/Rakefile
+++ b/Rakefile
@@ -262,6 +262,8 @@ task :check_consistency_between_aws_and_carrenza do
     govuk::apps::sidekiq_monitoring::content_data_admin_redis_port
     govuk::apps::sidekiq_monitoring::content_data_api_redis_host
     govuk::apps::sidekiq_monitoring::content_data_api_redis_port
+    govuk::apps::sidekiq_monitoring::link_checker_api_redis_host
+    govuk::apps::sidekiq_monitoring::link_checker_api_redis_port
     govuk::apps::sidekiq_monitoring::search_api_redis_host
     govuk::apps::sidekiq_monitoring::search_api_redis_port
     govuk::apps::search_api::elasticsearch_hosts

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -427,9 +427,6 @@ govuk::apps::link_checker_api::db_hostname: "postgresql-primary-1.backend"
 govuk::apps::link_checker_api::db_port: 6432
 govuk::apps::link_checker_api::db_allow_prepared_statements: false
 govuk::apps::link_checker_api::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
-# Hardcoded to redis-2 to improve performance
-# This setting is overridden in `development.yaml`
-govuk::apps::link_checker_api::redis_host: "redis-2.backend"
 govuk::apps::link_checker_api::redis_port: "%{hiera('sidekiq_port')}"
 
 govuk::apps::manuals_publisher::redis_host: "%{hiera('sidekiq_host')}"

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -563,8 +563,6 @@ govuk::apps::sidekiq_monitoring::email_alert_api_redis_host: "%{hiera('govuk::ap
 govuk::apps::sidekiq_monitoring::email_alert_api_redis_port: "%{hiera('govuk::apps::email_alert_api::redis_port')}"
 govuk::apps::sidekiq_monitoring::imminence_redis_host: "%{hiera('govuk::apps::imminence::redis_host')}"
 govuk::apps::sidekiq_monitoring::imminence_redis_port: "%{hiera('govuk::apps::imminence::redis_port')}"
-govuk::apps::sidekiq_monitoring::link_checker_api_redis_host: "%{hiera('govuk::apps::link_checker_api::redis_host')}"
-govuk::apps::sidekiq_monitoring::link_checker_api_redis_port: "%{hiera('govuk::apps::link_checker_api::redis_port')}"
 govuk::apps::sidekiq_monitoring::manuals_publisher_redis_host: "%{hiera('govuk::apps::manuals_publisher::redis_host')}"
 govuk::apps::sidekiq_monitoring::manuals_publisher_redis_port: "%{hiera('govuk::apps::manuals_publisher::redis_port')}"
 govuk::apps::sidekiq_monitoring::publisher_redis_host: "%{hiera('govuk::apps::publisher::redis_host')}"

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -423,12 +423,6 @@ govuk::apps::government_frontend::nagios_memory_warning: 2500
 govuk::apps::government_frontend::nagios_memory_critical: 2800
 govuk::apps::government_frontend::unicorn_worker_processes: "8"
 
-govuk::apps::link_checker_api::db_hostname: "postgresql-primary-1.backend"
-govuk::apps::link_checker_api::db_port: 6432
-govuk::apps::link_checker_api::db_allow_prepared_statements: false
-govuk::apps::link_checker_api::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
-govuk::apps::link_checker_api::redis_port: "%{hiera('sidekiq_port')}"
-
 govuk::apps::manuals_publisher::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::manuals_publisher::redis_port: "%{hiera('sidekiq_port')}"
 

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -28,7 +28,6 @@ node_class: &node_class
       - hmrc-manuals-api
       - imminence
       - kibana
-      - link-checker-api
       - local-links-manager
       - manuals-publisher
       - maslow

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1340,7 +1340,6 @@ hosts::production::backend::app_hostnames:
   - 'hmrc-manuals-api'
   - 'imminence'
   - 'kibana'
-  - 'link-checker-api'
   - 'local-links-manager'
   - 'maslow'
   - 'manuals-publisher'

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -151,9 +151,16 @@ govuk::apps::imminence::enable_procfile_worker: false
 govuk::apps::imminence::redis_host: 'localhost'
 govuk::apps::licencefinder::mongodb_nodes: ['localhost']
 govuk::apps::manuals_frontend::enable_running_in_draft_mode::content_store: 'http://draft-content-store.dev.gov.uk'
+
+govuk::apps::link_checker_api::db_hostname: "postgresql-primary-1.backend"
+govuk::apps::link_checker_api::db_port: 6432
+govuk::apps::link_checker_api::db_allow_prepared_statements: false
+govuk::apps::link_checker_api::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
+govuk::apps::link_checker_api::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::link_checker_api::enable_procfile_worker: false
 govuk::apps::link_checker_api::enabled: true
 govuk::apps::link_checker_api::redis_host: "%{hiera('sidekiq_host')}"
+
 govuk::apps::manuals_publisher::enable_procfile_worker: false
 govuk::apps::manuals_publisher::mongodb_nodes: ['localhost']
 govuk::apps::manuals_publisher::mongodb_name: 'manuals_publisher_development'

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -167,7 +167,6 @@ hosts::production::backend::app_hostnames:
   - 'hmrc-manuals-api'
   - 'imminence'
   - 'kibana'
-  - 'link-checker-api'
   - 'local-links-manager'
   - 'maslow'
   - 'manuals-publisher'

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -70,7 +70,6 @@ govuk::apps::government-frontend::cpu_warning: 200
 govuk::apps::government-frontend::cpu_critical: 300
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::imminence::ensure: 'absent'
-govuk::apps::link_checker_api::ensure: 'absent'
 govuk::apps::local_links_manager::ensure: 'absent'
 govuk::apps::local_links_manager::local_links_manager_passive_checks: true
 govuk::apps::local_links_manager::run_links_ga_export: true

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -35,7 +35,6 @@ govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::imminence::ensure: 'absent'
 govuk::apps::government-frontend::cpu_warning: 200
 govuk::apps::government-frontend::cpu_critical: 300
-govuk::apps::link_checker_api::ensure: 'absent'
 govuk::apps::link_checker_api::govuk_basic_auth_credentials: "%{hiera('http_username')}:%{hiera('http_password')}"
 govuk::apps::local_links_manager::ensure: 'absent'
 govuk::apps::publisher::run_fact_check_fetcher: false

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -35,7 +35,6 @@ govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::imminence::ensure: 'absent'
 govuk::apps::government-frontend::cpu_warning: 200
 govuk::apps::government-frontend::cpu_critical: 300
-govuk::apps::link_checker_api::govuk_basic_auth_credentials: "%{hiera('http_username')}:%{hiera('http_password')}"
 govuk::apps::local_links_manager::ensure: 'absent'
 govuk::apps::publisher::run_fact_check_fetcher: false
 govuk::apps::publisher::fact_check_address_format: 'factcheck+staging-{id}@alphagov.co.uk'

--- a/modules/govuk/manifests/node/s_postgresql_base.pp
+++ b/modules/govuk/manifests/node/s_postgresql_base.pp
@@ -11,7 +11,6 @@ class govuk::node::s_postgresql_base inherits govuk::node::s_base {
   include govuk::apps::content_publisher::db
   include govuk::apps::content_tagger::db
   include govuk::apps::email_alert_api::db
-  include govuk::apps::link_checker_api::db
   include govuk::apps::local_links_manager::db
   include govuk::apps::publishing_api::db
   include govuk::apps::service_manual_publisher::db


### PR DESCRIPTION
This follows on from the migration of the Link Checker API to AWS, removing the configuration that's associated with Carrenza.

This is just configuration cleanup, and shouldn't actually effect the behaviour of Puppet.