### PR TITLE
Remove redundant Local Links Manager Carrenza configuration

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -39,8 +39,6 @@ task :check_consistency_between_aws_and_carrenza do
     govuk::apps::email_alert_api::db_allow_prepared_statements
     govuk::apps::email_alert_api::db_port
     govuk::apps::info_frontend::vhost_aliases
-    govuk::apps::local_links_manager::db_allow_prepared_statements
-    govuk::apps::local_links_manager::db_port
     govuk::apps::publisher::email_group_business
     govuk::apps::publisher::email_group_citizen
     govuk::apps::publisher::email_group_dev
@@ -105,7 +103,6 @@ task :check_consistency_between_aws_and_carrenza do
     router::assets_origin::vhost_name
     router::draft_assets::vhost_name
 
-    govuk::apps::local_links_manager::ensure
     govuk::apps::government-frontend::cpu_critical
     govuk::apps::government-frontend::cpu_warning
     govuk::apps::support::ensure
@@ -156,8 +153,6 @@ task :check_consistency_between_aws_and_carrenza do
     backup::assets::backup_private_gpg_key_fingerprint
     backup::assets::jobs
     backup::offsite::jobs
-    govuk::apps::local_links_manager::local_links_manager_passive_checks
-    govuk::apps::local_links_manager::run_links_ga_export
     govuk::deploy::actionmailer_enable_delivery
     govuk::node::s_apt::real_ip_header
     govuk::node::s_backup::offsite_backups
@@ -243,10 +238,15 @@ task :check_consistency_between_aws_and_carrenza do
     govuk::apps::link_checker_api::redis_host
     govuk::apps::link_checker_api::redis_port
     govuk::apps::local_links_manager::db::allow_auth_from_lb
+    govuk::apps::local_links_manager::db::backend_ip_range
     govuk::apps::local_links_manager::db::lb_ip_range
     govuk::apps::local_links_manager::db::rds
+    govuk::apps::local_links_manager::db_hostname
     govuk::apps::local_links_manager::nagios_memory_critical
     govuk::apps::local_links_manager::nagios_memory_warning
+    govuk::apps::local_links_manager::redis_host
+    govuk::apps::local_links_manager::redis_port
+    govuk::apps::local_links_manager::unicorn_worker_processes
     govuk::apps::publisher::alert_hostname
     govuk::apps::publishing_api::db::allow_auth_from_lb
     govuk::apps::publishing_api::db::lb_ip_range

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -27,7 +27,6 @@ node_class: &node_class
       - govuk-content-schemas
       - hmrc-manuals-api
       - kibana
-      - local-links-manager
       - manuals-publisher
       - maslow
       - publisher

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1314,7 +1314,6 @@ hosts::production::backend::app_hostnames:
   - 'email-alert-api-public'
   - 'hmrc-manuals-api'
   - 'kibana'
-  - 'local-links-manager'
   - 'maslow'
   - 'manuals-publisher'
   - 'publisher'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -479,14 +479,6 @@ govuk::apps::info_frontend::enabled: true
 govuk::apps::info_frontend::vhost_aliases:
   - 'info-frontend'
 
-govuk::apps::local_links_manager::db_hostname: "postgresql-primary-1.backend"
-govuk::apps::local_links_manager::db_port: 6432
-govuk::apps::local_links_manager::db_allow_prepared_statements: false
-govuk::apps::local_links_manager::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
-govuk::apps::local_links_manager::redis_host: "%{hiera('sidekiq_host')}"
-govuk::apps::local_links_manager::redis_port: "%{hiera('sidekiq_port')}"
-govuk::apps::local_links_manager::unicorn_worker_processes: "4"
-
 govuk::apps::mapit::enabled: true
 
 govuk::apps::licencefinder::mongodb_nodes:

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -164,6 +164,14 @@ govuk::apps::link_checker_api::enable_procfile_worker: false
 govuk::apps::link_checker_api::enabled: true
 govuk::apps::link_checker_api::redis_host: "%{hiera('sidekiq_host')}"
 
+govuk::apps::local_links_manager::db_hostname: "postgresql-primary-1.backend"
+govuk::apps::local_links_manager::db_port: 6432
+govuk::apps::local_links_manager::db_allow_prepared_statements: false
+govuk::apps::local_links_manager::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
+govuk::apps::local_links_manager::redis_host: "%{hiera('sidekiq_host')}"
+govuk::apps::local_links_manager::redis_port: "%{hiera('sidekiq_port')}"
+govuk::apps::local_links_manager::unicorn_worker_processes: "4"
+
 govuk::apps::manuals_publisher::enable_procfile_worker: false
 govuk::apps::manuals_publisher::mongodb_nodes: ['localhost']
 govuk::apps::manuals_publisher::mongodb_name: 'manuals_publisher_development'

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -166,7 +166,6 @@ hosts::production::backend::app_hostnames:
   - 'email-alert-api-public'
   - 'hmrc-manuals-api'
   - 'kibana'
-  - 'local-links-manager'
   - 'maslow'
   - 'manuals-publisher'
   - 'publisher'

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -69,7 +69,6 @@ govuk::apps::email_alert_api::govuk_notify_template_id: 'cb633abc-6ae6-4843-ae6f
 govuk::apps::government-frontend::cpu_warning: 200
 govuk::apps::government-frontend::cpu_critical: 300
 govuk::apps::hmrc_manuals_api::publish_topics: false
-govuk::apps::local_links_manager::ensure: 'absent'
 govuk::apps::local_links_manager::local_links_manager_passive_checks: true
 govuk::apps::local_links_manager::run_links_ga_export: true
 govuk::apps::publisher::run_fact_check_fetcher: true

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -69,8 +69,6 @@ govuk::apps::email_alert_api::govuk_notify_template_id: 'cb633abc-6ae6-4843-ae6f
 govuk::apps::government-frontend::cpu_warning: 200
 govuk::apps::government-frontend::cpu_critical: 300
 govuk::apps::hmrc_manuals_api::publish_topics: false
-govuk::apps::local_links_manager::local_links_manager_passive_checks: true
-govuk::apps::local_links_manager::run_links_ga_export: true
 govuk::apps::publisher::run_fact_check_fetcher: true
 govuk::apps::publisher::fact_check_address_format: 'factcheck+production-{id}@alphagov.co.uk'
 govuk::apps::publisher::email_group_dev: 'govuk-dev@digital.cabinet-office.gov.uk'

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -34,7 +34,6 @@ govuk::apps::email_alert_frontend::subscription_management_enabled: true
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::government-frontend::cpu_warning: 200
 govuk::apps::government-frontend::cpu_critical: 300
-govuk::apps::local_links_manager::ensure: 'absent'
 govuk::apps::publisher::run_fact_check_fetcher: false
 govuk::apps::publisher::fact_check_address_format: 'factcheck+staging-{id}@alphagov.co.uk'
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-staging'

--- a/modules/govuk/manifests/node/s_postgresql_base.pp
+++ b/modules/govuk/manifests/node/s_postgresql_base.pp
@@ -11,7 +11,6 @@ class govuk::node::s_postgresql_base inherits govuk::node::s_base {
   include govuk::apps::content_publisher::db
   include govuk::apps::content_tagger::db
   include govuk::apps::email_alert_api::db
-  include govuk::apps::local_links_manager::db
   include govuk::apps::publishing_api::db
   include govuk::apps::service_manual_publisher::db
   include govuk::apps::support_api::db


### PR DESCRIPTION
The Local Links Manager has been running in AWS for a while now, so we don't need to keep the Carrenza configuration around.