### PR TITLE
Copy the production hieradata for the Local Links Manager to AWS

### DIFF
--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -138,6 +138,10 @@ govuk::apps::email_alert_api::email_archive_s3_enabled: false
 govuk::apps::email_alert_api::govuk_notify_template_id: '76d21ce7-54c3-4fb7-8830-ba3b79287985'
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::link_checker_api::govuk_basic_auth_credentials: "%{hiera('http_username')}:%{hiera('http_password')}"
+
+govuk::apps::local_links_manager::local_links_manager_passive_checks: true
+govuk::apps::local_links_manager::run_links_ga_export: true
+
 govuk::apps::publisher::run_fact_check_fetcher: false
 govuk::apps::publisher::fact_check_address_format: 'factcheck+production-{id}@alphagov.co.uk'
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-production'


### PR DESCRIPTION
This configuration was added to Carrenza, but I assume the service
reverted to using the defaults (false in both cases) when it was
migrated to AWS.

I'm assuming both of these two things are still relevant. I can't see
any evidence of them being intentionally turned off, so we should
probably just turn them back on.