### PR TITLE
Actually mount the data volume on Prometheus nodes.

### DIFF
--- a/hieradata_aws/class/prometheus.yaml
+++ b/hieradata_aws/class/prometheus.yaml
@@ -1,0 +1,12 @@
+---
+
+lv:
+  data:
+    pv: '/dev/nvme1n1'
+    vg: 'prometheus'
+
+mount:
+  /data:
+    disk: '/dev/mapper/prometheus-data'
+    govuk_lvm: 'data'
+    mountoptions: 'defaults'


### PR DESCRIPTION
Prometheus nodes have an EBS volume attached, but wasn't being used.
This mounts it in the appropriate place.

Block device name is correct provided this is merged along with https://github.com/alphagov/govuk-aws/pull/1134.