### PR TITLE
Remove Icinga count metric

### DIFF
--- a/modules/icinga/templates/notify_graphite.erb
+++ b/modules/icinga/templates/notify_graphite.erb
@@ -125,27 +125,23 @@ Statsd.configure(
   options.fetch(:statsd_port, 8125),
 )
 
-state = options[:command_type] == "host" ? options[:host_state] : options[:service_state]
+namespace = if options[:command_type] == "host"
+              "icinga.host_alert.#{options[:host_display_name]}"
+            else
+              "icinga.service_alert.#{options[:host_display_name]}.#{options[:service_desc]}"
+            end
 
-count_namespace = if options[:command_type] == "host"
-                    "icinga.host_alert.#{options[:host_display_name]}.#{state}"
-                  else
-                    "icinga.service_alert.#{options[:host_display_name]}.#{options[:service_desc]}.#{state}"
-                  end
+state = if options[:command_type] == "host"
+          options[:host_state]
+        else
+          options[:service_state]
+        end
 
-Statsd.increment(count_namespace)
-
-state_namespace = if options[:command_type] == "host"
-                    "icinga.host_alert.#{options[:host_display_name]}"
-                  else
-                    "icinga.service_alert.#{options[:host_display_name]}.#{options[:service_desc]}"
-                  end
-
-STATE_GAUGE_VALUES = {
+GAUGE_VALUES = {
   "ok" => 0,
   "unknown" => 1,
   "warning" => 2,
   "critical" => 3,
 }
 
-Statsd.gauge(state_namespace, STATE_GAUGE_VALUES.fetch(state))
+Statsd.gauge(namespace, GAUGE_VALUES.fetch(state))


### PR DESCRIPTION
It's currently unclear exactly what the value of this metric is because the data coming back to Graphite isn't an integer count. It seems to end up going in steps of 0.2 and we're not sure why.

Although this is possibly a configuration issue with Graphite or Icinga, we don't actually need this metric anyway because all the information you need can be calculated from the gauge metric we recently added.

I also think it doesn't make sense to use an `increment` here because this script is only called on a state change, so it becomes slightly misleading as it's not a count of the number of alerts, and more of a count on the number of times an alert changes state (which, although useful, might not be what people first expect).

[Trello Card](https://trello.com/c/bfdR0C4c/1202-5-make-counts-for-icinga-notifications-in-graphite-accurate)