### PR TITLE
Increase the number of max db connections

### DIFF
--- a/hieradata/class/production/postgresql_primary.yaml
+++ b/hieradata/class/production/postgresql_primary.yaml
@@ -1,1 +1,1 @@
-govuk_postgresql::server::max_connections: 300
+govuk_postgresql::server::max_connections: 400


### PR DESCRIPTION
This is to cope with the increased number of sidekiq workers introduced
in https://github.com/alphagov/email-alert-api/pull/998