### PR TITLE
Remove Publishing-api from /etc/hosts

### DIFF
--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -371,7 +371,6 @@ hosts::production::backend::app_hostnames:
   - 'maslow'
   - 'manuals-publisher'
   - 'publisher'
-  - 'publishing-api'
   - 'search-admin'
   - 'service-manual-publisher'
   - 'short-url-manager'


### PR DESCRIPTION
This is part of the migration work to move Publishing-api
to AWS.