### PR TITLE
Remove redundant Carrenza hieradata for the Support API

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -46,8 +46,6 @@ task :check_consistency_between_aws_and_carrenza do
     govuk::apps::publishing_api::db_port
     govuk::apps::service_manual_publisher::db_allow_prepared_statements
     govuk::apps::service_manual_publisher::db_port
-    govuk::apps::support_api::db_allow_prepared_statements
-    govuk::apps::support_api::db_port
     govuk::node::s_logging::apt_mirror_hostname
     govuk_ci::agent::master_ssh_key
     govuk_ci::master::ci_agents
@@ -285,9 +283,16 @@ task :check_consistency_between_aws_and_carrenza do
     govuk::apps::service_manual_publisher::db_hostname
     govuk::apps::support_api::aws_s3_bucket_name
     govuk::apps::support_api::db::allow_auth_from_lb
+    govuk::apps::support_api::db::backend_ip_range
     govuk::apps::support_api::db::lb_ip_range
     govuk::apps::support_api::db::rds
+    govuk::apps::support_api::db_hostname
+    govuk::apps::support_api::db_name
+    govuk::apps::support_api::db_password
+    govuk::apps::support_api::db_username
     govuk::apps::support_api::pp_data_url
+    govuk::apps::support_api::redis_host
+    govuk::apps::support_api::redis_port
     govuk::apps::support_api::zendesk_anonymous_ticket_email
     govuk::apps::transition::db_password
     govuk::apps::transition::postgresql_db::rds

--- a/Rakefile
+++ b/Rakefile
@@ -283,9 +283,12 @@ task :check_consistency_between_aws_and_carrenza do
     govuk::apps::service_manual_publisher::db::lb_ip_range
     govuk::apps::service_manual_publisher::db::rds
     govuk::apps::service_manual_publisher::db_hostname
+    govuk::apps::support_api::aws_s3_bucket_name
     govuk::apps::support_api::db::allow_auth_from_lb
     govuk::apps::support_api::db::lb_ip_range
     govuk::apps::support_api::db::rds
+    govuk::apps::support_api::pp_data_url
+    govuk::apps::support_api::zendesk_anonymous_ticket_email
     govuk::apps::transition::db_password
     govuk::apps::transition::postgresql_db::rds
     govuk::deploy::setup::gemstash_server

--- a/Rakefile
+++ b/Rakefile
@@ -106,7 +106,6 @@ task :check_consistency_between_aws_and_carrenza do
     govuk::apps::government-frontend::cpu_critical
     govuk::apps::government-frontend::cpu_warning
     govuk::apps::support::ensure
-    govuk::apps::support_api::ensure
     govuk::apps::whitehall::cpu_critical
     govuk::apps::whitehall::cpu_warning
     govuk::node::s_api_lb::api_servers

--- a/Rakefile
+++ b/Rakefile
@@ -276,6 +276,8 @@ task :check_consistency_between_aws_and_carrenza do
     govuk::apps::sidekiq_monitoring::link_checker_api_redis_port
     govuk::apps::sidekiq_monitoring::search_api_redis_host
     govuk::apps::sidekiq_monitoring::search_api_redis_port
+    govuk::apps::sidekiq_monitoring::support_api_redis_host
+    govuk::apps::sidekiq_monitoring::support_api_redis_port
     govuk::apps::search_api::elasticsearch_hosts
     govuk::apps::service_manual_publisher::db::allow_auth_from_lb
     govuk::apps::service_manual_publisher::db::lb_ip_range

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1314,7 +1314,6 @@ hosts::production::backend::app_hostnames:
   - 'specialist-publisher-rebuild'
   - 'specialist-publisher-rebuild-standalone'
   - 'support'
-  - 'support-api'
   - 'transition'
   - 'travel-advice-publisher'
   - 'whitehall-admin'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -435,8 +435,6 @@ govuk::apps::publisher::email_group_citizen: 'govuk-dev@digital.cabinet-office.g
 govuk::apps::short_url_manager::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::short_url_manager::redis_port: "%{hiera('sidekiq_port')}"
 
-govuk::apps::support_api::zendesk_client_username: 'zd-api-govt@digital.cabinet-office.gov.uk/token'
-
 govuk::apps::whitehall::admin_db_hostname: whitehall-master.mysql
 govuk::apps::whitehall::admin_key_space_limit: '262144'
 govuk::apps::whitehall::admin_db_name: whitehall_production
@@ -588,16 +586,6 @@ govuk::apps::support::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::support::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::support::zendesk_anonymous_ticket_email: 'zd-api-public@digital.cabinet-office.gov.uk'
 govuk::apps::support::zendesk_client_username: 'zd-api-govt@digital.cabinet-office.gov.uk/token'
-
-govuk::apps::support_api::db_name: 'support_contacts_production'
-govuk::apps::support_api::db_hostname: 'postgresql-primary-1.backend'
-govuk::apps::support_api::db_port: 6432
-govuk::apps::support_api::db_allow_prepared_statements: false
-govuk::apps::support_api::db_password: "%{hiera('govuk::apps::support_api::db::password')}"
-govuk::apps::support_api::db_username: 'support_contacts'
-govuk::apps::support_api::redis_host: "%{hiera('sidekiq_host')}"
-govuk::apps::support_api::redis_port: "%{hiera('sidekiq_port')}"
-govuk::apps::support_api::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 
 govuk::apps::transition::postgresql_db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 govuk::apps::transition::db_hostname: "transition-postgresql-master-1.backend"

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -38,8 +38,6 @@ node_class: &node_class
       - signon
       - specialist-publisher
       - support
-      - support-api
-      - support_api_csv_env_sync
       - travel-advice-publisher
   bouncer:
     apps:

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -543,8 +543,6 @@ govuk::apps::sidekiq_monitoring::signon_redis_host: "%{hiera('govuk::apps::signo
 govuk::apps::sidekiq_monitoring::signon_redis_port: "%{hiera('govuk::apps::signon::redis_port')}"
 govuk::apps::sidekiq_monitoring::specialist_publisher_redis_host: "%{hiera('govuk::apps::specialist_publisher::redis_host')}"
 govuk::apps::sidekiq_monitoring::specialist_publisher_redis_port: "%{hiera('govuk::apps::specialist_publisher::redis_port')}"
-govuk::apps::sidekiq_monitoring::support_api_redis_host: "%{hiera('govuk::apps::support_api::redis_host')}"
-govuk::apps::sidekiq_monitoring::support_api_redis_port: "%{hiera('govuk::apps::support_api::redis_port')}"
 govuk::apps::sidekiq_monitoring::transition_redis_host: "%{hiera('govuk::apps::transition::redis_host')}"
 govuk::apps::sidekiq_monitoring::transition_redis_port: "%{hiera('govuk::apps::transition::redis_port')}"
 govuk::apps::sidekiq_monitoring::travel_advice_publisher_redis_host: "%{hiera('govuk::apps::travel_advice_publisher::redis_host')}"

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -220,7 +220,19 @@ govuk::apps::specialist_publisher::publish_pre_production_finders: true
 govuk::apps::specialist_publisher::mongodb_nodes: ['localhost']
 govuk::apps::specialist_publisher::mongodb_name: 'govuk_content_development'
 govuk::apps::support::enable_procfile_worker: false
+
+govuk::apps::support_api::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
+govuk::apps::support_api::db_allow_prepared_statements: false
+govuk::apps::support_api::db_hostname: 'postgresql-primary-1.backend'
+govuk::apps::support_api::db_name: 'support_contacts_production'
+govuk::apps::support_api::db_password: "%{hiera('govuk::apps::support_api::db::password')}"
+govuk::apps::support_api::db_port: 6432
+govuk::apps::support_api::db_username: 'support_contacts'
 govuk::apps::support_api::enable_procfile_worker: false
+govuk::apps::support_api::redis_host: "%{hiera('sidekiq_host')}"
+govuk::apps::support_api::redis_port: "%{hiera('sidekiq_port')}"
+govuk::apps::support_api::zendesk_client_username: 'zd-api-govt@digital.cabinet-office.gov.uk/token'
+
 govuk::apps::transition::enable_procfile_worker: false
 govuk::apps::travel_advice_publisher::enable_email_alerts: true
 govuk::apps::travel_advice_publisher::enable_procfile_worker: false

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -177,7 +177,6 @@ hosts::production::backend::app_hostnames:
   - 'specialist-publisher-rebuild'
   - 'specialist-publisher-rebuild-standalone'
   - 'support'
-  - 'support-api'
   - 'transition'
   - 'travel-advice-publisher'
   - 'whitehall-admin'

--- a/hieradata/node/backend-1.backend.publishing.service.gov.uk.yaml
+++ b/hieradata/node/backend-1.backend.publishing.service.gov.uk.yaml
@@ -1,1 +1,0 @@
-govuk::apps::support_api_csv_env_sync::enabled: true

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -78,7 +78,6 @@ govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-eve
 govuk::apps::static::ga_universal_id: 'UA-26179049-1'
 govuk::apps::support::ensure: 'absent'
 govuk::apps::support::aws_s3_bucket_name: 'govuk-production-support-api-csvs'
-govuk::apps::support_api::ensure: 'absent'
 govuk::apps::support_api::pp_data_url: 'https://www.performance.service.gov.uk'
 govuk::apps::support_api::zendesk_anonymous_ticket_email: 'zd-api-public@digital.cabinet-office.gov.uk'
 govuk::apps::support_api::aws_s3_bucket_name: 'govuk-production-support-api-csvs'

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -78,9 +78,6 @@ govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-eve
 govuk::apps::static::ga_universal_id: 'UA-26179049-1'
 govuk::apps::support::ensure: 'absent'
 govuk::apps::support::aws_s3_bucket_name: 'govuk-production-support-api-csvs'
-govuk::apps::support_api::pp_data_url: 'https://www.performance.service.gov.uk'
-govuk::apps::support_api::zendesk_anonymous_ticket_email: 'zd-api-public@digital.cabinet-office.gov.uk'
-govuk::apps::support_api::aws_s3_bucket_name: 'govuk-production-support-api-csvs'
 govuk::apps::travel_advice_publisher::enable_email_alerts: true
 govuk::apps::whitehall::cpu_warning: 400
 govuk::apps::whitehall::cpu_critical: 600

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -42,8 +42,6 @@ govuk::apps::signon::instance_name: 'staging'
 govuk::apps::static::ga_universal_id: 'UA-26179049-20'
 govuk::apps::support::ensure: 'absent'
 govuk::apps::support::aws_s3_bucket_name: 'govuk-staging-support-api-csvs'
-govuk::apps::support_api::pp_data_url: 'https://www.staging.performance.service.gov.uk'
-govuk::apps::support_api::aws_s3_bucket_name: 'govuk-staging-support-api-csvs'
 govuk::apps::travel_advice_publisher::enable_email_alerts: true
 govuk::apps::whitehall::cpu_warning: 400
 govuk::apps::whitehall::cpu_critical: 600

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -42,7 +42,6 @@ govuk::apps::signon::instance_name: 'staging'
 govuk::apps::static::ga_universal_id: 'UA-26179049-20'
 govuk::apps::support::ensure: 'absent'
 govuk::apps::support::aws_s3_bucket_name: 'govuk-staging-support-api-csvs'
-govuk::apps::support_api::ensure: 'absent'
 govuk::apps::support_api::pp_data_url: 'https://www.staging.performance.service.gov.uk'
 govuk::apps::support_api::aws_s3_bucket_name: 'govuk-staging-support-api-csvs'
 govuk::apps::travel_advice_publisher::enable_email_alerts: true

--- a/modules/govuk/manifests/node/s_backend_lb.pp
+++ b/modules/govuk/manifests/node/s_backend_lb.pp
@@ -84,7 +84,6 @@ class govuk::node::s_backend_lb (
   loadbalancer::balance { [
       'asset-manager',
       'canary-backend',
-      'support-api',
     ]:
       internal_only => true,
       servers       => $backend_servers,

--- a/modules/govuk/manifests/node/s_postgresql_base.pp
+++ b/modules/govuk/manifests/node/s_postgresql_base.pp
@@ -13,7 +13,6 @@ class govuk::node::s_postgresql_base inherits govuk::node::s_base {
   include govuk::apps::email_alert_api::db
   include govuk::apps::publishing_api::db
   include govuk::apps::service_manual_publisher::db
-  include govuk::apps::support_api::db
 
   include govuk_postgresql::tuning
 


### PR DESCRIPTION
This will remove redundant monitoring from Carrenza, and generally make the configuration more reflective of reality as well as less complex.