### PR TITLE
Re enable procfile worker memory checks

### DIFF
--- a/modules/govuk/manifests/procfile/worker.pp
+++ b/modules/govuk/manifests/procfile/worker.pp
@@ -120,13 +120,12 @@ define govuk::procfile::worker (
       $memory_critical_threshold_bytes = $memory_critical_threshold * $si_megabyte
 
       @@icinga::check::graphite { "check_${title_underscore}_app_worker_mem_usage${::hostname}":
-        ensure                     => absent, # TODO The event handler isn't working properly yet
         target                     => "${::fqdn_metrics}.processes-app-worker-${title_underscore}.ps_rss",
         warning                    => $memory_warning_threshold_bytes,
         critical                   => $memory_critical_threshold_bytes,
         desc                       => "high memory for ${service_name}",
         host_name                  => $::fqdn,
-        event_handler              => "govuk_app_high_memory!${service_name}",
+        event_handler              => "govuk_procfile_worker_high_memory!${service_name}",
         notes_url                  => monitoring_docs_url(high-memory-for-application),
         attempts_before_hard_state => 2,
       }

--- a/modules/icinga/manifests/client.pp
+++ b/modules/icinga/manifests/client.pp
@@ -76,4 +76,7 @@ class icinga::client (
     source => 'puppet:///modules/monitoring/usr/lib/nagios/plugins/reload_service',
   }
 
+  icinga::plugin { 'restart_service':
+    source => 'puppet:///modules/monitoring/usr/lib/nagios/plugins/restart_service',
+  }
 }

--- a/modules/icinga/templates/etc/nagios/nrpe.cfg.erb
+++ b/modules/icinga/templates/etc/nagios/nrpe.cfg.erb
@@ -223,6 +223,7 @@ command[check_ntp_time]=/usr/lib/nagios/plugins/check_ntp_time -4 -q -H uk.pool.
 # make sure you read the SECURITY file before doing this.
 
 command[reload_service]=/usr/lib/nagios/plugins/reload_service $ARG1$
+command[restart_service]=/usr/lib/nagios/plugins/restart_service $ARG1$
 #command[check_users]=/usr/lib/nagios/plugins/check_users -w $ARG1$ -c $ARG2$
 #command[check_load]=/usr/lib/nagios/plugins/check_load -w $ARG1$ -c $ARG2$
 #command[check_disk]=/usr/lib/nagios/plugins/check_disk -w $ARG1$ -c $ARG2$ -p $ARG3$

--- a/modules/monitoring/files/govuk_procfile_worker_high_memory.cfg
+++ b/modules/monitoring/files/govuk_procfile_worker_high_memory.cfg
@@ -1,0 +1,4 @@
+define command {
+  command_name govuk_procfile_worker_high_memory
+  command_line /usr/local/bin/event_handlers/govuk_procfile_worker_high_memory.sh $SERVICESTATE$ $SERVICESTATETYPE$ $HOSTADDRESS$ $ARG1$
+}

--- a/modules/monitoring/files/usr/lib/nagios/plugins/restart_service
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/restart_service
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#
+# Script that NRPE runs when it's notified by the monitoring machine
+# that an application has crossed the high memory threshold.
+#
+set -eu
+
+APPNAME=$1
+
+logger --tag govuk_icinga_event_handler "Restarting service ${APPNAME} because monitoring has detected it using too much memory"
+
+sudo /sbin/initctl restart ${APPNAME}
+
+echo "OK: Restarted ${APPNAME}"
+exit 0

--- a/modules/monitoring/files/usr/local/bin/event_handlers/govuk_procfile_worker_high_memory.sh
+++ b/modules/monitoring/files/usr/local/bin/event_handlers/govuk_procfile_worker_high_memory.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# Icinga event handler script for restarting an worker service on a
+# remote machine when it begins consuming too much memory.
+#
+
+SERVICESTATE=$1
+SERVICESTATETYPE=$2
+HOSTADDRESS=$3
+APPNAME=$4
+
+case "${SERVICESTATE}" in
+  OK)
+    # Service just came back up, so don't do anything
+    ;;
+  WARNING)
+    case "${SERVICESTATETYPE}" in
+      SOFT)
+        ;;
+      HARD)
+        logger --tag govuk_icinga_event_handler "Restarting worker ${APPNAME} on ${HOSTADDRESS} because it's using too much memory"
+        echo -n "govuk.app.${APPNAME}.memory_restarts:1|c" > /dev/udp/localhost/8125
+        /usr/lib/nagios/plugins/check_nrpe -H "${HOSTADDRESS}" -c restart_service -a "${APPNAME}"
+        ;;
+    esac
+    ;;
+  UNKNOWN)
+    ;;
+esac
+
+exit 0

--- a/modules/monitoring/manifests/event_handler/procfile_worker_high_memory.pp
+++ b/modules/monitoring/manifests/event_handler/procfile_worker_high_memory.pp
@@ -1,0 +1,17 @@
+# == Class: monitoring::event_handler::procfile_worker_high_memory
+#
+# Configure an Icinga event handler that restarts a GOV.UK procfile
+# worker service if it has triggered a high memory alert
+#
+class monitoring::event_handler::procfile_worker_high_memory () {
+
+  icinga::check_config { 'govuk_procfile_worker_high_memory':
+    source  => 'puppet:///modules/monitoring/govuk_procfile_worker_high_memory.cfg',
+    require => File['/usr/local/bin/event_handlers/govuk_procfile_worker_high_memory.sh'],
+  }
+
+  file { '/usr/local/bin/event_handlers/govuk_procfile_worker_high_memory.sh':
+    source => 'puppet:///modules/monitoring/usr/local/bin/event_handlers/govuk_procfile_worker_high_memory.sh',
+    mode   => '0755',
+  }
+}

--- a/modules/monitoring/manifests/event_handlers.pp
+++ b/modules/monitoring/manifests/event_handlers.pp
@@ -9,6 +9,7 @@ class monitoring::event_handlers () {
   }
 
   include monitoring::event_handler::app_high_memory
+  include monitoring::event_handler::procfile_worker_high_memory
   include monitoring::event_handler::publish_overdue_whitehall
 
 }


### PR DESCRIPTION
At first they didn't work as Sidekiq doesn't use less memory when asked to reload, but these changes should fix that.