### PR TITLE
create whitehall backup location on backup storage drive

### DIFF
--- a/modules/backup/manifests/server.pp
+++ b/modules/backup/manifests/server.pp
@@ -35,6 +35,12 @@ class backup::server (
           '/data/backups/archived']:
     ensure => directory,
     owner  => 'govuk-backup',
+    mode   => '0711',
+  }
+
+  file {'/data/backups/whitehall':
+    ensure => directory,
+    owner  => 'deploy',
     mode   => '0700',
   }
 


### PR DESCRIPTION
we create the /data/backups/whitehall directory for `env-sync-and-backup` to store the whitehall backups on the backup storage drive rather than the small primary drive of backup machine.