### PR TITLE
Run 1, rather than 2 Sidekiq processes for Whitehall

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -451,7 +451,6 @@ govuk::apps::whitehall::db_username: whitehall_fe
 govuk::apps::whitehall::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
 govuk::apps::whitehall::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::whitehall::redis_port: "%{hiera('sidekiq_port')}"
-govuk::apps::whitehall::procfile_worker_process_count: 2
 
 govuk::apps::whitehall::db::whitehall_fe_password: "%{hiera('mysql_whitehall_frontend')}"
 

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -547,7 +547,6 @@ govuk::apps::whitehall::db_username: whitehall_fe
 govuk::apps::whitehall::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
 govuk::apps::whitehall::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::whitehall::redis_port: "%{hiera('sidekiq_port')}"
-govuk::apps::whitehall::procfile_worker_process_count: 2
 
 govuk::apps::whitehall::db::whitehall_fe_password: "%{hiera('mysql_whitehall_frontend')}"
 


### PR DESCRIPTION
I think this is more consistent with the behaviour for other apps. It
used to be that thread based concurrency wasn't used for Whitehall,
and instead many processes were used. Now we're using both thread and
process based concurrency, running 2 Sidekiq processes on each
machine, each using some number of threads.

To make the Whitehall behaviour more consistent with other apps,
switch to running one Sidekiq process per machine.

This will probalby reduce the potential throughput, but that can be
increased if necessary by increasing the number of threads.

The hieradata_aws change here is just to keep the hieradata
consistent, Whitehall isn't running in AWS yet, so it won't have any
affect.