### PR TITLE
Correct URL of search api job

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/search_generate_sitemaps.pp
+++ b/modules/govuk_jenkins/manifests/jobs/search_generate_sitemaps.pp
@@ -7,7 +7,7 @@ class govuk_jenkins::jobs::search_generate_sitemaps{
 
   $service_description = 'Runs a rake task on Search API that generates the sitemap files'
   $job_slug = 'search_generate_sitemaps'
-  $job_url = "https://deploy.${app_domain}/job/${job_slug}"
+  $job_url = "https://deploy.${::aws_environment}.govuk.digital/job/${job_slug}"
 
   file { '/etc/jenkins_jobs/jobs/search_generate_sitemaps.yaml':
     ensure  => present,


### PR DESCRIPTION
This is now in AWS, needs a new URL