### PR TITLE
Remove redundant Carrenza hieradata for the Support app

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -103,7 +103,6 @@ task :check_consistency_between_aws_and_carrenza do
 
     govuk::apps::government-frontend::cpu_critical
     govuk::apps::government-frontend::cpu_warning
-    govuk::apps::support::ensure
     govuk::apps::whitehall::cpu_critical
     govuk::apps::whitehall::cpu_warning
     govuk::node::s_api_lb::api_servers

--- a/Rakefile
+++ b/Rakefile
@@ -280,6 +280,7 @@ task :check_consistency_between_aws_and_carrenza do
     govuk::apps::service_manual_publisher::db::lb_ip_range
     govuk::apps::service_manual_publisher::db::rds
     govuk::apps::service_manual_publisher::db_hostname
+    govuk::apps::support::aws_s3_bucket_name
     govuk::apps::support_api::aws_s3_bucket_name
     govuk::apps::support_api::db::allow_auth_from_lb
     govuk::apps::support_api::db::backend_ip_range

--- a/Rakefile
+++ b/Rakefile
@@ -281,6 +281,8 @@ task :check_consistency_between_aws_and_carrenza do
     govuk::apps::service_manual_publisher::db::rds
     govuk::apps::service_manual_publisher::db_hostname
     govuk::apps::support::aws_s3_bucket_name
+    govuk::apps::support::redis_host
+    govuk::apps::support::redis_port
     govuk::apps::support_api::aws_s3_bucket_name
     govuk::apps::support_api::db::allow_auth_from_lb
     govuk::apps::support_api::db::backend_ip_range

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -581,11 +581,6 @@ govuk::apps::static::unicorn_worker_processes: "8"
 govuk::apps::static::nagios_memory_warning: 1500
 govuk::apps::static::nagios_memory_critical: 1750
 
-govuk::apps::support::redis_host: "%{hiera('sidekiq_host')}"
-govuk::apps::support::redis_port: "%{hiera('sidekiq_port')}"
-govuk::apps::support::zendesk_anonymous_ticket_email: 'zd-api-public@digital.cabinet-office.gov.uk'
-govuk::apps::support::zendesk_client_username: 'zd-api-govt@digital.cabinet-office.gov.uk/token'
-
 govuk::apps::transition::postgresql_db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 govuk::apps::transition::db_hostname: "transition-postgresql-master-1.backend"
 govuk::apps::transition::redis_host: "%{hiera('sidekiq_host')}"

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -37,7 +37,6 @@ node_class: &node_class
       - sidekiq-monitoring
       - signon
       - specialist-publisher
-      - support
       - travel-advice-publisher
   bouncer:
     apps:

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1300,7 +1300,6 @@ hosts::production::backend::app_hostnames:
   - 'specialist-publisher'
   - 'specialist-publisher-rebuild'
   - 'specialist-publisher-rebuild-standalone'
-  - 'support'
   - 'transition'
   - 'travel-advice-publisher'
   - 'whitehall-admin'

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -219,7 +219,12 @@ govuk::apps::specialist_publisher::enable_procfile_worker: false
 govuk::apps::specialist_publisher::publish_pre_production_finders: true
 govuk::apps::specialist_publisher::mongodb_nodes: ['localhost']
 govuk::apps::specialist_publisher::mongodb_name: 'govuk_content_development'
+
 govuk::apps::support::enable_procfile_worker: false
+govuk::apps::support::redis_host: "%{hiera('sidekiq_host')}"
+govuk::apps::support::redis_port: "%{hiera('sidekiq_port')}"
+govuk::apps::support::zendesk_anonymous_ticket_email: 'zd-api-public@digital.cabinet-office.gov.uk'
+govuk::apps::support::zendesk_client_username: 'zd-api-govt@digital.cabinet-office.gov.uk/token'
 
 govuk::apps::support_api::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 govuk::apps::support_api::db_allow_prepared_statements: false

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -176,7 +176,6 @@ hosts::production::backend::app_hostnames:
   - 'specialist-publisher'
   - 'specialist-publisher-rebuild'
   - 'specialist-publisher-rebuild-standalone'
-  - 'support'
   - 'transition'
   - 'travel-advice-publisher'
   - 'whitehall-admin'

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -76,7 +76,6 @@ govuk::apps::publisher::email_group_business: 'publisher-alerts-business@digital
 govuk::apps::publisher::email_group_citizen: 'publisher-alerts-citizen@digital.cabinet-office.gov.uk'
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-production'
 govuk::apps::static::ga_universal_id: 'UA-26179049-1'
-govuk::apps::support::ensure: 'absent'
 govuk::apps::support::aws_s3_bucket_name: 'govuk-production-support-api-csvs'
 govuk::apps::travel_advice_publisher::enable_email_alerts: true
 govuk::apps::whitehall::cpu_warning: 400

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -76,7 +76,6 @@ govuk::apps::publisher::email_group_business: 'publisher-alerts-business@digital
 govuk::apps::publisher::email_group_citizen: 'publisher-alerts-citizen@digital.cabinet-office.gov.uk'
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-production'
 govuk::apps::static::ga_universal_id: 'UA-26179049-1'
-govuk::apps::support::aws_s3_bucket_name: 'govuk-production-support-api-csvs'
 govuk::apps::travel_advice_publisher::enable_email_alerts: true
 govuk::apps::whitehall::cpu_warning: 400
 govuk::apps::whitehall::cpu_critical: 600

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -40,7 +40,6 @@ govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-eve
 govuk::apps::short_url_manager::instance_name: 'staging'
 govuk::apps::signon::instance_name: 'staging'
 govuk::apps::static::ga_universal_id: 'UA-26179049-20'
-govuk::apps::support::aws_s3_bucket_name: 'govuk-staging-support-api-csvs'
 govuk::apps::travel_advice_publisher::enable_email_alerts: true
 govuk::apps::whitehall::cpu_warning: 400
 govuk::apps::whitehall::cpu_critical: 600

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -40,7 +40,6 @@ govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-eve
 govuk::apps::short_url_manager::instance_name: 'staging'
 govuk::apps::signon::instance_name: 'staging'
 govuk::apps::static::ga_universal_id: 'UA-26179049-20'
-govuk::apps::support::ensure: 'absent'
 govuk::apps::support::aws_s3_bucket_name: 'govuk-staging-support-api-csvs'
 govuk::apps::travel_advice_publisher::enable_email_alerts: true
 govuk::apps::whitehall::cpu_warning: 400


### PR DESCRIPTION
It's been migrated to AWS, so don't list it as running in Carrenza.