### PR TITLE
Add http_x_forwarded_for to NGINX log_format

### DIFF
--- a/modules/nginx/templates/etc/nginx/nginx.conf.erb
+++ b/modules/nginx/templates/etc/nginx/nginx.conf.erb
@@ -38,7 +38,8 @@ http {
       '"$http_referer" "$http_user_agent" '
       '$request_time $upstream_response_time '
       '$gzip_ratio $sent_http_x_cache $sent_http_location $http_host '
-      '$ssl_protocol $ssl_cipher';
+      '$ssl_protocol $ssl_cipher '
+      '$http_x_forwarded_for';
 
     log_format json_event '{ "@timestamp": "$time_iso8601", '
                          '"remote_addr": "$remote_addr", '
@@ -66,7 +67,8 @@ http {
                          '"govuk_abtest_educationnavigation": "$http_govuk_abtest_educationnavigation", '
                          '"varnish_id": "$http_x_varnish", '
                          '"ssl_protocol": "$ssl_protocol", '
-                         '"ssl_cipher": "$ssl_cipher" }';
+			 '"ssl_cipher": "$ssl_cipher", '
+			 '"http_x_forwarded_for": "$http_x_forwarded_for" }';
 
     access_log  /var/log/nginx/access.log timed_combined;
     access_log  /var/log/nginx/json.event.access.log json_event;


### PR DESCRIPTION
- Cyber require visibility of request IPs, e.g. for publishing services
- Adding globally as X_Forwarded_For headers will be present across AWS