### PR TITLE
set the aws_region env variable in profile

### DIFF
--- a/modules/base/manifests/init.pp
+++ b/modules/base/manifests/init.pp
@@ -60,5 +60,10 @@ class base (
 
     include hosts::migration
     include govuk_prometheus_node_exporter
+
+    file { '/etc/profile.d/aws_config.sh':
+      ensure  => 'present',
+      content => template('base/aws_config.erb'),
+    }
   }
 }

--- a/modules/base/templates/aws_config.erb
+++ b/modules/base/templates/aws_config.erb
@@ -1,0 +1,2 @@
+# Set AWS specific environment settings
+export AWS_DEFAULT_REGION=<%= @aws_region %>

--- a/modules/base/templates/bashrc.erb
+++ b/modules/base/templates/bashrc.erb
@@ -87,8 +87,3 @@ alias l='ls -CF'
 
 # Use xvfb for DISPLAY, so that some integration tests can run
 export DISPLAY=:99
-
-<%- if scope.lookupvar('::aws_migration') %>
-# Set AWS specific environment settings
-export AWS_DEFAULT_REGION=<%= @aws_region %>
-<%- end -%>


### PR DESCRIPTION
the aws_region env variable should be set in profile rather than bashrc so that it is available for non-interactive user session.