### PR TITLE
Increase attempts_before_hard_state for the procfile worker memory

### DIFF
--- a/modules/govuk/manifests/procfile/worker.pp
+++ b/modules/govuk/manifests/procfile/worker.pp
@@ -127,7 +127,7 @@ define govuk::procfile::worker (
         host_name                  => $::fqdn,
         event_handler              => "govuk_procfile_worker_high_memory!${service_name}",
         notes_url                  => monitoring_docs_url(high-memory-for-application),
-        attempts_before_hard_state => 2,
+        attempts_before_hard_state => 10,
       }
 
       if $alert_when_threads_exceed {


### PR DESCRIPTION
This is a new check and event handler, so wait a while before
considering memory usage a failure.

In the case of Sidekiq specifically, it's probably good to wait a
while after Sidekiq has used a load of memory to increase the chance
that the job that caused the increased memory usage has finished.