### PR TITLE
Revert "Remove Publishing-api from /etc/hosts"

### DIFF
--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -366,6 +366,7 @@ hosts::production::backend::app_hostnames:
   - 'maslow'
   - 'manuals-publisher'
   - 'publisher'
+  - 'publishing-api'
   - 'search-admin'
   - 'service-manual-publisher'
   - 'short-url-manager'


### PR DESCRIPTION
Reverts alphagov/govuk-puppet#9673
Re-testing migration of Publishing-API in staging