### PR TITLE
Revert "Revert "Remove Publishing-api from /etc/hosts""

### DIFF
--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -366,7 +366,6 @@ hosts::production::backend::app_hostnames:
   - 'maslow'
   - 'manuals-publisher'
   - 'publisher'
-  - 'publishing-api'
   - 'search-admin'
   - 'service-manual-publisher'
   - 'short-url-manager'


### PR DESCRIPTION
Reverts alphagov/govuk-puppet#9685
Testing AWS migration of Publishing-API