### PR TITLE
Safelist the /harvestobject API endpoint

### DIFF
--- a/modules/govuk/templates/ckan/nginx.conf.erb
+++ b/modules/govuk/templates/ckan/nginx.conf.erb
@@ -26,6 +26,10 @@
     # Used for: determining filetype
     "/2/util/resource/format_autocomplete",
 
+    # Used by: datagovuk_find
+    # Used for: addtional metadata links for datasets
+    "/2/rest/harvestobject",
+
     # Additional endpoints requested by users
     "/action/package_search",
     "/action/package_list",


### PR DESCRIPTION
## What

Open up the `/2/rest/harvestobject` endpoint to allow users to view additional metadata provided by publishers.

[Trello](https://trello.com/c/UjdaXCoE/1373-additional-metadata-links-not-working-for-any-dgu-dataset)