### PR TITLE
Upgrade to Brakeman 4.6 or above

### DIFF
--- a/modules/govuk_testing_tools/manifests/init.pp
+++ b/modules/govuk_testing_tools/manifests/init.pp
@@ -17,7 +17,7 @@ class govuk_testing_tools {
   }
 
   package { 'brakeman':
-    ensure   => 'installed',
+    ensure   => '~> 4.6',
     provider => system_gem,
   }
 }


### PR DESCRIPTION
Currently we're running Brakeman 4.5.0 because that's the version that was installed at the time. Since then there is a newer version of Brakeman (4.6.1). By changing the string to `~> 4.6` we can ensure that we have the latest 4.x version but we'll need to manually intervene if we want version 5 (when it comes out).

[Trello Card](https://trello.com/c/qocdsaLD/1367-look-into-why-brakeman-occasionally-fails-on-test-runs)