### PR TITLE
Upgrade Python Docker library to restore compatibility with Docker.

### DIFF
--- a/modules/collectd/manifests/plugin/docker.pp
+++ b/modules/collectd/manifests/plugin/docker.pp
@@ -21,9 +21,9 @@ class collectd::plugin::docker(
   # seems to be fixed in puppet 4: https://tickets.puppetlabs.com/browse/PUP-1073
   exec { 'pip install docker':
     path    => ['/usr/local/bin', '/usr/bin', '/bin'],
-    command => 'pip install "docker==2.7.0"',
+    command => 'pip install "docker>=4.1.0,<4.2"',
     notify  => Class['collectd::service'],
-    unless  => 'pip list | grep "docker (2.7.0)"',
+    unless  => 'pip list | grep "docker (4.1"',
   }
 
   exec { 'pip install urllib3':


### PR DESCRIPTION
Version 2.7 of the Python `docker` library is not compatible with
the 1.32 API of Docker 17.09.0-ce, which we're currently running.

The version incompatibility was causing `collectd` to log a warning
and fail to load the Docker plugin.

This might fix the problem where `collectd` uses 100% of a CPU on
the build machines, but it's too early to tell for sure.