### PR TITLE
get environment variable for reboot_elasticache cron job

### DIFF
--- a/modules/govuk/manifests/node/s_db_admin.pp
+++ b/modules/govuk/manifests/node/s_db_admin.pp
@@ -225,7 +225,7 @@ class govuk::node::s_db_admin(
     cron::crondotdee { 'reboot-elasticache':
       hour    => 11,
       minute  => 0,
-      command => '/usr/bin/env python3 /usr/local/bin/reboot_elasticache.py >> /var/log/reboot_elasticache 2>&1',
+      command => '/usr/bin/env bash -l -exec "/usr/bin/env python3 /usr/local/bin/reboot_elasticache.py --log=INFO >> /var/log/reboot_elasticache 2>&1"',
       require => [ File['/usr/local/bin/reboot_elasticache.py'], Package['boto3'],],
     }
 


### PR DESCRIPTION
reboot_elasticache cron job requires requires the env variable AWS_DEFAULT_REGION specified in /etc/profile.d/aws_config.sh. This can be obtained via a interactive bash session