### PR TITLE
Set a higher threshold for asset-manager threads

### DIFF
--- a/modules/govuk/manifests/apps/asset_manager.pp
+++ b/modules/govuk/manifests/apps/asset_manager.pp
@@ -87,20 +87,21 @@ class govuk::apps::asset_manager(
     $deny_framing = false
 
     govuk::app { $app_name:
-      app_type                 => 'rack',
-      port                     => $port,
-      sentry_dsn               => $sentry_dsn,
-      vhost_ssl_only           => true,
-      health_check_path        => '/healthcheck',
-      log_format_is_json       => true,
-      deny_framing             => $deny_framing,
-      depends_on_nfs           => true,
-      nginx_extra_config       => template('govuk/asset_manager_extra_nginx_config.conf.erb'),
-      unicorn_worker_processes => $unicorn_worker_processes,
-      nagios_memory_warning    => $nagios_memory_warning,
-      nagios_memory_critical   => $nagios_memory_critical,
-      cpu_warning              => 350,
-      cpu_critical             => 400,
+      app_type                  => 'rack',
+      port                      => $port,
+      sentry_dsn                => $sentry_dsn,
+      vhost_ssl_only            => true,
+      health_check_path         => '/healthcheck',
+      log_format_is_json        => true,
+      deny_framing              => $deny_framing,
+      depends_on_nfs            => true,
+      nginx_extra_config        => template('govuk/asset_manager_extra_nginx_config.conf.erb'),
+      unicorn_worker_processes  => $unicorn_worker_processes,
+      alert_when_threads_exceed => 165,
+      nagios_memory_warning     => $nagios_memory_warning,
+      nagios_memory_critical    => $nagios_memory_critical,
+      cpu_warning               => 350,
+      cpu_critical              => 400,
     }
 
     govuk::app::envvar {


### PR DESCRIPTION
Around 162 threads seem to be in use during deployments, so set the
threshold just higher than that.