### PR TITLE
Handle consumers without channels in check_rabbitmq_consumers

### DIFF
--- a/modules/icinga/files/usr/lib/nagios/plugins/check_rabbitmq_consumers
+++ b/modules/icinga/files/usr/lib/nagios/plugins/check_rabbitmq_consumers
@@ -83,6 +83,7 @@ class RabbitMQCheck:
         return [
             details["channel_details"]["name"]
             for details in self.consumer_details_for_queue()
+            if "name" in details["channel_details"]
         ]
 
     def channel_idle_time(self, channel):


### PR DESCRIPTION
Currently in Integration, we're seeing consumers without channels. So
some entries in `self.consumer_details_for_queue()` have `[]` for
`details["channel_details"]`.

To avoid erroring out, check if `"name"` exists in
`details["channel_details"]`.