### PR TITLE
Clean up Carrneza hieradata with respect to Bouncer

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -172,7 +172,11 @@ task :check_consistency_between_aws_and_carrenza do
   # Keys that are AWS-only
   AWS_ONLY_KEYS = %w[
     backup::mysql::alert_hostname
+    govuk::apps::bouncer::db_hostname
+    govuk::apps::bouncer::nagios_memory_critical
+    govuk::apps::bouncer::nagios_memory_warning
     govuk::apps::bouncer::postgresql_role::rds
+    govuk::apps::bouncer::unicorn_worker_processes
     govuk::apps::ckan::ckan_site_url
     govuk::apps::ckan::cronjobs::enable_solr_reindex
     govuk::apps::ckan::db::allow_auth_from_lb

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -299,11 +299,6 @@ govuk::apps::asset_manager::nagios_memory_critical: 2750
 
 govuk::apps::authenticating_proxy::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
 
-govuk::apps::bouncer::db_hostname: "transition-postgresql-slave-1.backend"
-govuk::apps::bouncer::nagios_memory_warning: 1400
-govuk::apps::bouncer::nagios_memory_critical: 1500
-govuk::apps::bouncer::unicorn_worker_processes: "8"
-
 govuk::apps::cache_clearing_service::enabled: false
 govuk::apps::cache_clearing_service::nagios_memory_warning: 2750
 govuk::apps::cache_clearing_service::nagios_memory_critical: 3000

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -38,9 +38,6 @@ node_class: &node_class
       - signon
       - specialist-publisher
       - travel-advice-publisher
-  bouncer:
-    apps:
-      - bouncer
   cache:
     apps:
       - router


### PR DESCRIPTION
Bouncer was migrated to AWS, and the machines in Carrenza were turned off, so we no longer need this hieradata.