### PR TITLE
Remove search_benchmark job

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/search_benchmark.pp
+++ b/modules/govuk_jenkins/manifests/jobs/search_benchmark.pp
@@ -10,6 +10,8 @@ class govuk_jenkins::jobs::search_benchmark (
   $cron_schedule = '30 4 * * *'
 ) {
 
+  # todo: delete this and relevant files/configuration
+
   if $::aws_migration {
     $app_domain_internal = hiera('app_domain_internal')
   }
@@ -20,7 +22,7 @@ class govuk_jenkins::jobs::search_benchmark (
   $job_url = "https://deploy.${app_domain}/job/search_benchmark/"
 
   file { '/etc/jenkins_jobs/jobs/search_benchmark.yaml':
-    ensure  => present,
+    ensure  => absent,
     content => template('govuk_jenkins/jobs/benchmark_search.yaml.erb'),
     notify  => Exec['jenkins_jobs_update'],
   }


### PR DESCRIPTION
This job runs the healthcheck script in search-performance-explorer.
That healthcheck uses a manually-generated set of test data[1] from
Google Analytics which needs to be periodically updated to remain of
value.  But nobody has updated this data since July 2018.

We're moving towards monitoring of query performance using
Elasticsearch's ranking evaluation API, which is not the approach this
benchmark takes, so introducing a process to regularly update the test
data isn't useful.  In which case, there's no point in keeping this
job.

[1] https://github.com/alphagov/search-performance-explorer/blob/master/data/click_model.json