### PR TITLE
Stop smokey-loop while the data sync is in progress

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -192,6 +192,7 @@ monitoring::checks::sidekiq::enable_support_check: false
 monitoring::checks::pingdom::enable: false
 monitoring::checks::ses::region: eu-west-1
 monitoring::checks::smokey::environment: 'integration'
+monitoring::checks::smokey::disable_during_data_sync: true
 monitoring::uptime_collector::environment: 'integration'
 monitoring::contacts::slack_username: 'CI'
 

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -504,6 +504,7 @@ monitoring::checks::aws_origin_domain: "staging.govuk.digital"
 monitoring::checks::sidekiq::enable_support_check: false
 monitoring::checks::ses::region: eu-west-1
 monitoring::checks::smokey::environment: 'staging'
+monitoring::checks::smokey::disable_during_data_sync: true
 monitoring::uptime_collector::environment: 'staging'
 monitoring::contacts::notify_slack: true
 monitoring::contacts::slack_channel: '#govuk-alerts-staging'

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -361,6 +361,7 @@ monitoring::checks::lb::loadbalancers:
 
 monitoring::checks::cache::region: 'eu-west-1'
 monitoring::checks::smokey::environment: 'integration'
+monitoring::checks::smokey::disable_during_data_sync: true
 monitoring::uptime_collector::environment: 'integration'
 monitoring::contacts::slack_username: 'Integration'
 

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -324,6 +324,7 @@ monitoring::checks::rds::servers:
 
 
 monitoring::checks::smokey::environment: 'staging_aws'
+monitoring::checks::smokey::disable_during_data_sync: true
 monitoring::checks::smokey::features:
   check_caching:
     feature: caching

--- a/hieradata_aws/training.yaml
+++ b/hieradata_aws/training.yaml
@@ -160,6 +160,7 @@ monitoring::checks::ses::region: 'eu-west-2'
 monitoring::checks::rds::region: 'eu-west-2'
 monitoring::checks::cache::region: 'eu-west-2'
 monitoring::checks::smokey::environment: 'training'
+monitoring::checks::smokey::disable_during_data_sync: true
 monitoring::uptime_collector::environment: 'training'
 
 postfix::smarthost:

--- a/modules/govuk_data_sync_in_progress/manifests/init.pp
+++ b/modules/govuk_data_sync_in_progress/manifests/init.pp
@@ -1,0 +1,69 @@
+# == Class: govuk_data_sync_in_progress
+#
+# Configure the `data_sync_in_progress` fact and optionally allows commands
+# to run when the data sync starts and finishes.
+#
+# === Parameters
+#
+# [*start_command*]
+#   Command to run when the data sync starts.
+#
+# [*finish_command*]
+#   Command to run when the data sync finishes.
+#
+define govuk_data_sync_in_progress(
+  $start_command = undef,
+  $finish_command = undef
+) {
+  $fact_path = '/etc/govuk/env.d/FACTER_data_sync_in_progress'
+
+  $start_hour = 22
+  $start_minute = 0
+
+  $finish_hour = 5
+  $finish_minute = 45
+
+  if !defined(File[$fact_path]) {
+    file { $fact_path:
+      ensure  => present,
+      owner   => 'deploy',
+      require => Class['govuk::deploy'],
+    }
+  }
+
+  if !defined(Cron['data_sync_started']) {
+    cron { 'data_sync_started':
+      command => "echo 'true' > ${fact_path}",
+      user    => 'deploy',
+      hour    => $start_hour,
+      minute  => $start_minute,
+    }
+  }
+
+  if !defined(Cron['data_sync_finished']) {
+    cron { 'data_sync_finished':
+      command => "echo '' > ${$fact_path}",
+      user    => 'deploy',
+      hour    => $finish_hour,
+      minute  => $finish_minute,
+    }
+  }
+
+  if $start_command {
+    cron { "data_sync_started_${title}":
+      command => $start_command,
+      user    => 'deploy',
+      hour    => $start_hour,
+      minute  => $start_minute,
+    }
+  }
+
+  if $finish_command {
+    cron { "data_sync_finished_${title}":
+      command => $finish_command,
+      user    => 'deploy',
+      hour    => $finish_hour,
+      minute  => $finish_minute,
+    }
+  }
+}

--- a/modules/govuk_gor/manifests/init.pp
+++ b/modules/govuk_gor/manifests/init.pp
@@ -41,26 +41,9 @@ class govuk_gor(
 
   validate_bool($enable)
 
-  $data_sync_fact_path = '/etc/govuk/env.d/FACTER_data_sync_in_progress'
-
-  file { $data_sync_fact_path:
-    ensure  => present,
-    owner   => 'deploy',
-    require => Class['govuk::deploy'],
-  }
-
-  cron { 'stop_gor':
-    command => "echo 'true' > ${data_sync_fact_path}; sudo initctl stop gor",
-    user    => 'deploy',
-    hour    => 22,
-    minute  => 0,
-  }
-
-  cron { 'start_gor':
-    command => "echo '' > ${$data_sync_fact_path}; sudo initctl start gor;",
-    user    => 'deploy',
-    hour    => 5,
-    minute  => 45,
+  govuk_data_sync_in_progress { 'gor':
+    start_command  => 'sudo initctl stop gor',
+    finish_command => 'sudo initctl start gor',
   }
 
   if $enable and ! $::data_sync_in_progress {

--- a/modules/icinga/manifests/check_feature.pp
+++ b/modules/icinga/manifests/check_feature.pp
@@ -1,24 +1,31 @@
 # FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
-define icinga::check_feature ($feature, $notes_url = undef) {
+define icinga::check_feature(
+  $feature,
+  $ensure = present,
+  $notes_url = undef
+) {
   icinga::check_feature_w_prio { "check_feature_${feature}_urgent":
+    ensure    => $ensure,
     feature   => $feature,
     prio      => 'urgent',
     notes_url => $notes_url,
   }
   icinga::check_feature_w_prio { "check_feature_${feature}_high":
+    ensure    => $ensure,
     feature   => $feature,
     prio      => 'high',
     notes_url => $notes_url,
   }
   icinga::check_feature_w_prio { "check_feature_${feature}_normal":
+    ensure    => $ensure,
     feature   => $feature,
     prio      => 'normal',
     notes_url => $notes_url,
   }
   icinga::check_feature_w_prio { "check_feature_${feature}_low":
+    ensure    => $ensure,
     feature   => $feature,
     prio      => 'low',
     notes_url => $notes_url,
   }
 }
-

--- a/modules/icinga/manifests/check_feature_w_prio.pp
+++ b/modules/icinga/manifests/check_feature_w_prio.pp
@@ -16,9 +16,11 @@
 define icinga::check_feature_w_prio (
   $feature,
   $prio,
+  $ensure = present,
   $notes_url = undef,
 ) {
   icinga::check { "check_feature_${feature}_${prio}_checker":
+    ensure              => $ensure,
     check_command       => "run_smokey_tests!${feature}!${prio}",
     use                 => "govuk_${prio}_priority",
     service_description => "Run ${feature} ${prio} priority tests",


### PR DESCRIPTION
This follows on from https://github.com/alphagov/govuk-puppet/pull/9489 to disable smokey-loop while the data sync is happening.

This is because it makes a lot of requests to Whitehall while it's not in a state that can recieve requests.

[Trello Card](https://trello.com/c/7Ar7u9e6/819-stop-smokey-running-overnight-on-staging-and-integration)