### PR TITLE
Increase workers for backdrop_read

### DIFF
--- a/modules/govuk/manifests/apps/backdrop_read.pp
+++ b/modules/govuk/manifests/apps/backdrop_read.pp
@@ -23,7 +23,7 @@ class govuk::apps::backdrop_read (
     govuk::app { $app_name:
       app_type           => 'bare',
       port               => $port,
-      command            => "./venv/bin/gunicorn backdrop.read.api:app --bind 127.0.0.1:${port} --workers 4 --timeout 30",
+      command            => "./venv/bin/gunicorn backdrop.read.api:app --bind 127.0.0.1:${port} --workers 8 --timeout 30",
       vhost_ssl_only     => true,
       health_check_path  => '/_status',
       log_format_is_json => true,

--- a/modules/govuk/manifests/apps/backdrop_read.pp
+++ b/modules/govuk/manifests/apps/backdrop_read.pp
@@ -21,12 +21,13 @@ class govuk::apps::backdrop_read (
     $port = '3101'
 
     govuk::app { $app_name:
-      app_type           => 'bare',
-      port               => $port,
-      command            => "./venv/bin/gunicorn backdrop.read.api:app --bind 127.0.0.1:${port} --workers 8 --timeout 30",
-      vhost_ssl_only     => true,
-      health_check_path  => '/_status',
-      log_format_is_json => true,
+      app_type                           => 'bare',
+      port                               => $port,
+      command                            => "./venv/bin/gunicorn backdrop.read.api:app --bind 127.0.0.1:${port} --workers 8 --timeout 30",
+      vhost_ssl_only                     => true,
+      health_check_path                  => '/_status',
+      log_format_is_json                 => true,
+      local_tcpconns_established_warning => 8,
     }
 
     Govuk::App::Envvar {


### PR DESCRIPTION
We're seeing lots of connections occasionally to backdrop_read, the
user agent is node-XMLHttpRequest, which I'm guessing means the
Performance Platform.

The api machines look like they have enough RAM to allow for more
workers, so double the number. This'll help to avoid requests queuing
up during busy periods.

