### PR TITLE
Back up publishing api database in AWS production

### DIFF
--- a/hieradata_aws/class/production/db_admin.yaml
+++ b/hieradata_aws/class/production/db_admin.yaml
@@ -32,6 +32,17 @@ govuk_env_sync::tasks:
     temppath: "/tmp/local-links-manager_production"
     url: "govuk-production-database-backups"
     path: "postgresql-backend"
+  "push_publishing_api_production_daily":
+    ensure: "present"
+    hour: "2"
+    minute: "00"
+    action: "push"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "publishing_api_production"
+    temppath: "/tmp/publishing_api_production"
+    url: "govuk-production-database-backups"
+    path: "postgresql-backend"
   "push_link-checker-api_production_daily":
     ensure: "present"
     hour: "3"


### PR DESCRIPTION
After the migration of Publishing API from Carrenza to AWS, we want to regularly back up the Publishing API database in AWS production to S3.