### PR TITLE
create a disabled job to pull publishing api in AWS production

### DIFF
--- a/hieradata_aws/class/production/db_admin.yaml
+++ b/hieradata_aws/class/production/db_admin.yaml
@@ -54,6 +54,17 @@ govuk_env_sync::tasks:
     temppath: "/tmp/"
     url: "govuk-production-database-backups"
     path: "postgresql-backend"
+  "pull_publishing_api_production_daily":
+    ensure: "disabled"
+    hour: "3"
+    minute: "45"
+    action: "pull"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "publishing_api_production"
+    temppath: "/tmp/publishing_api_production"
+    url: "govuk-production-database-backups"
+    path: "postgresql-backend"
   "pull_licensify_production":
     ensure: "disabled"
     hour: "1"


### PR DESCRIPTION
This will only be used during migration of publishing api to sync the publishing api in AWS production from the backup just performed in the migration from the Carrenza production