### PR TITLE
Increase the Whitehall procfile worker memory threshold

### DIFF
--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -331,7 +331,7 @@ class govuk::apps::whitehall(
       setenv_as                 => $app_name,
       enable_service            => $enable_procfile_worker,
       process_count             => $procfile_worker_process_count,
-      memory_warning_threshold  => 2000,
+      memory_warning_threshold  => 4000,
       memory_critical_threshold => 14000,
     }
 


### PR DESCRIPTION
The memory usage can shoot up very rapidly, so increase the threshold
a bit to give Icinga some time to notice that it's gone down before it
goes back up again.