### PR TITLE
Fix gdal_version hieradata for CI agents

### DIFF
--- a/hieradata/class/ci_agent.yaml
+++ b/hieradata/class/ci_agent.yaml
@@ -8,7 +8,7 @@ clamav::use_service: false
 
 govuk_ci::agent::postgresql::mapit_role_password: 'mapit'
 govuk_ci::agent::postgresql::email_alert_api_role_password: 'email-alert-api'
-govuk_ci::agent::gdal_version: "%{hiera('govuk::apps::mapit::gdal_version')}"
+govuk_ci::agent::gdal_version: "1.11.5"
 postgresql::globals::version: '9.3'
 govuk_postgresql::server::enable_collectd: false
 


### PR DESCRIPTION
This is now a bit disjointed, as Mapit is running in AWS, and so the
AWS hieradata applies, but we still want a matching version of gdal on
the ci_agents in Carrenza.

As the reference no longer works, just hardcode the version. Hopefully
if this changes prior to migrating away from Carrenza, all the
instances of the version will be updated.