### PR TITLE
Remove backup jobs for publishing_api in Carrenza.

### DIFF
--- a/hieradata/node/postgresql-primary-1.backend.publishing.service.gov.uk.yaml
+++ b/hieradata/node/postgresql-primary-1.backend.publishing.service.gov.uk.yaml
@@ -11,7 +11,7 @@ govuk_env_sync::tasks:
     url: "govuk-production-database-backups"
     path: "postgresql-backend"
   "push_publishing_api_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "2"
     minute: "30"
     action: "push"

--- a/hieradata/node/postgresql-primary-1.backend.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/postgresql-primary-1.backend.staging.publishing.service.gov.uk.yaml
@@ -43,17 +43,6 @@ govuk_env_sync::tasks:
     temppath: "/var/lib/autopostgresqlbackup/email-alert-api_production"
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
-  "push_publishing_api_production_daily":
-    ensure: "absent"
-    hour: "2"
-    minute: "20"
-    action: "push"
-    dbms: "postgresql"
-    storagebackend: "s3"
-    database: "publishing_api_production"
-    temppath: "/var/lib/autopostgresqlbackup/publishing_api_production"
-    url: "govuk-staging-database-backups"
-    path: "postgresql-backend"
   "push_service-manual-publisher_production_daily":
     ensure: "absent"
     hour: "0"


### PR DESCRIPTION
These backup jobs need to go away as part of moving Publishing API to AWS.

https://github.com/alphagov/govuk-puppet/pull/9700 adds the corresponding backup job in AWS.