### PR TITLE
fix plek env variable

### DIFF
--- a/modules/govuk/manifests/node/s_draft_frontend.pp
+++ b/modules/govuk/manifests/node/s_draft_frontend.pp
@@ -23,12 +23,10 @@ class govuk::node::s_draft_frontend() inherits govuk::node::s_base {
 
   govuk_envvar {
     'PLEK_HOSTNAME_PREFIX': value => 'draft-';
-    'PLEK_SERVICE_EMAIL_ALERT_API_URI': value => "https://email-alert-api.${plek_uri_domain_override}";
     'PLEK_SERVICE_IMMINENCE_URI': value => "https://imminence.${app_domain}";
     'PLEK_SERVICE_LOCAL_LINKS_MANAGER_URI': value => "https://local-links-manager.${app_domain}";
     'PLEK_SERVICE_MAPIT_URI': value => "https://mapit.${app_domain_internal}";
     'PLEK_SERVICE_SEARCH_URI': value => "https://search.${app_domain_internal}";
-    'PLEK_SERVICE_WHITEHALL_ADMIN_URI': value => "https://whitehall-admin.${app_domain_internal}";
   }
 
   unless $::aws_migration {


### PR DESCRIPTION
whitehall_api and email alert api plek entries are now managed in govuk/manifests/deploy/config.pp. We need to remove these here or otherwise, the resource will be duplicated.