### PR TITLE
Remove Licensify VPN check everywhere but prod

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1577,8 +1577,6 @@ monitoring::vpn_gateways::endpoints:
     address: "%{hiera('environment_ip_prefix')}.12.1"
   vpn_gateway_backend_dr:
     address: "%{hiera('environment_ip_prefix')}.11.1"
-  vpn_gateway_licensify:
-    address: "10.5.0.1"
   vpn_gateway_redirector_dr:
     address: "%{hiera('environment_ip_prefix')}.13.1"
   vpn_gateway_router_dr:

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -564,6 +564,17 @@ monitoring::contacts::slack_channel: '#govuk-alerts'
 monitoring::contacts::slack_username: 'Production (Carrenza)'
 monitoring::edge::enabled: true
 monitoring::uptime_collector::environment: 'production'
+monitoring::vpn_gateways::endpoints:
+  vpn_gateway_api_dr:
+    address: "%{hiera('environment_ip_prefix')}.12.1"
+  vpn_gateway_backend_dr:
+    address: "%{hiera('environment_ip_prefix')}.11.1"
+  vpn_gateway_licensify:
+    address: "10.5.0.1"
+  vpn_gateway_redirector_dr:
+    address: "%{hiera('environment_ip_prefix')}.13.1"
+  vpn_gateway_router_dr:
+    address: "%{hiera('environment_ip_prefix')}.9.1"
 
 postfix::smarthost:
   - 'email-smtp.us-east-1.amazonaws.com:587'


### PR DESCRIPTION
- Work in Q2 has moved Licensify integration and staging into AWS,
removing the need for the VPN.
- The check `vpn_licensify_gateway` is now only required in production