### PR TITLE
Add env_sync jobs for email-alert-api from Carrenza Prod to AWS Staging.

### DIFF
--- a/hieradata/node/postgresql-standby-1.backend.publishing.service.gov.uk.yaml
+++ b/hieradata/node/postgresql-standby-1.backend.publishing.service.gov.uk.yaml
@@ -1,0 +1,12 @@
+govuk_env_sync::tasks:
+  "push_email_alert_api_production_daily":
+    ensure: "present"
+    hour: "2"
+    minute: "05"
+    action: "push"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "email-alert-api_production"
+    temppath: "/var/lib/autopostgresqlbackup/email-alert-api_production"
+    url: "govuk-production-database-backups"
+    path: "postgresql-backend"

--- a/hieradata_aws/class/staging/db_admin.yaml
+++ b/hieradata_aws/class/staging/db_admin.yaml
@@ -65,6 +65,17 @@ govuk_env_sync::tasks:
     temppath: "/tmp/content_data_admin_production_push"
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
+  "pull_email_alert_api_production_daily":
+    ensure: "present"
+    hour: "2"
+    minute: "35"
+    action: "pull"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "email-alert-api_production"
+    temppath: "/tmp/email-alert-api_production"
+    url: "govuk-production-database-backups"
+    path: "postgresql-backend"
   "pull_publishing_api_production_daily":
     ensure: "present"
     hour: "3"

--- a/modules/govuk_env_sync/files/govuk_env_sync.sh
+++ b/modules/govuk_env_sync/files/govuk_env_sync.sh
@@ -358,7 +358,7 @@ function filtered_postgresql_restore {
   fi
 
   local sed_commands
-  sed_commands='/^COMMENT ON EXTENSION plpgsql/d'
+  sed_commands='/^COMMENT ON EXTENSION/d'
   if [ "${database}" == 'publishing_api_production' ]; then
     sed_commands+='; s/(SCHEMA public (TO|FROM)) postgres/\1 aws_db_admin/g'
   fi

--- a/modules/govuk_env_sync/files/govuk_env_sync.sh
+++ b/modules/govuk_env_sync/files/govuk_env_sync.sh
@@ -359,9 +359,7 @@ function filtered_postgresql_restore {
 
   local sed_commands
   sed_commands='/^COMMENT ON EXTENSION/d'
-  if [ "${database}" == 'publishing_api_production' ]; then
-    sed_commands+='; s/(SCHEMA public (TO|FROM)) postgres/\1 aws_db_admin/g'
-  fi
+  sed_commands+='; s/(SCHEMA public (TO|FROM)) postgres/\1 aws_db_admin/g'
 
   pg_restore "${tempdir}/${filename}" \
     | sed -r "${sed_commands}" \


### PR DESCRIPTION
This keeps the new AWS Staging environment for email-alert-api in sync
with Prod by adding a govuk_env_sync cron job for nightly backups of the
email-alert-api Postgres database in Carrenza Production and nightly
restores of the same into AWS Staging.