### PR TITLE
add email alert api node in AWS staging and production

### DIFF
--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -67,6 +67,10 @@ node_class: &node_class
       - service-manual-frontend
       - smartanswers
       - static
+  email_alert_api:
+    apps:
+      - email-alert-api
+      - email-alert-service
   frontend:
     apps:
       - canary-frontend

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -67,6 +67,10 @@ node_class: &node_class
       - service-manual-frontend
       - smartanswers
       - static
+  email_alert_api:
+    apps:
+      - email-alert-api
+      - email-alert-service
   frontend:
     apps:
       - canary-frontend


### PR DESCRIPTION
In preparation for the migration of the email alert api service to AWS, we activate the email alert api node in AWS staging and production.