### PR TITLE
Revert "[#64462242] Move ssl_session_* settings to http{}"

### DIFF
--- a/modules/nginx/files/etc/nginx/ssl.conf
+++ b/modules/nginx/files/etc/nginx/ssl.conf
@@ -6,10 +6,8 @@ proxy_set_header          X-Forwarded-Ssl on;
 ssl_protocols             TLSv1 TLSv1.1 TLSv1.2;
 ssl_ciphers               HIGH:!ADH:!kEDH:!aNULL;
 ssl_prefer_server_ciphers on;
-
-# FIXME: SSL session cache directives have been moved to nginx.conf as
-# a workaround for http://trac.nginx.org/nginx/ticket/235
-
+ssl_session_cache         shared:SSL:10m;
+ssl_session_timeout       5m;
 # max-age=31536000 commits to using HSTS for one year
 # NB: www.gov.uk is on the Chromium (and hence Mozilla) HSTS preload list
 #     http://src.chromium.org/viewvc/chrome?view=revision&revision=168524

--- a/modules/nginx/templates/etc/nginx/nginx.conf.erb
+++ b/modules/nginx/templates/etc/nginx/nginx.conf.erb
@@ -88,12 +88,6 @@ http {
     gzip_types          text/css text/xml application/x-javascript application/atom+xml text/plain;
     gzip_vary           on;
 
-    # SSL session cache options moved here as a workaround to Nginx bug:
-    # http://trac.nginx.org/nginx/ticket/235
-    # FIXME: Move back to ssl.conf once bug is fixed
-    ssl_session_cache         shared:SSL:10m;
-    ssl_session_timeout       5m;
-
     include /etc/nginx/conf.d/*.conf;
     include /etc/nginx/sites-enabled/*;
 }


### PR DESCRIPTION
This reverts commit 245078c979eff2bda8662a571e6cc9410bf93a5c.

The referenced bug is now fixed:

Bug: https://trac.nginx.org/nginx/ticket/235
Fix: https://trac.nginx.org/nginx/changeset/97f102a13f3373ed27d1d0d8f78ac9af8d88a0ff/nginx

Fix with release tags: https://github.com/nginx/nginx/commit/a6befbb40f801a68f451c349bc02bc27762e68b7#diff-0584d16332cf0d6dd9adb990a3c76a0c

It is fixed in our current versions of nginx (1.14 and present).