### PR TITLE
Create RabbitMQ users for publishing_api and email_alert_api in AWS.

### DIFF
--- a/hieradata_aws/class/rabbitmq.yaml
+++ b/hieradata_aws/class/rabbitmq.yaml
@@ -3,6 +3,8 @@
 govuk::node::s_rabbitmq::apps_using_rabbitmq:
   - content_data_api
   - cache_clearing_service
+  - publishing_api
+  - email_alert_service
   - search_api
 
 govuk_rabbitmq::aws_clustering: true

--- a/hieradata_aws/class/staging/rabbitmq.yaml
+++ b/hieradata_aws/class/staging/rabbitmq.yaml
@@ -1,11 +1,5 @@
 ---
 
-govuk::node::s_rabbitmq::apps_using_rabbitmq:
-  - content_data_api
-  - cache_clearing_service
-  - publishing_api
-  - search_api
-
 govuk_rabbitmq::federation: 'yes'
 govuk_rabbitmq::federate::federation_user: 'root'
 govuk_rabbitmq::federate::federation_pass: "%{hiera('govuk_rabbitmq::root_password')}"


### PR DESCRIPTION
These apps are moving to AWS and so we need their RabbitMQ users to exist in all AWS environments.