### PR TITLE
Remove hieradata for the calculators frontend machine from Carrenza

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -232,6 +232,9 @@ task :check_consistency_between_aws_and_carrenza do
     govuk::apps::imminence::unicorn_worker_processes
     govuk::apps::sidekiq_monitoring::imminence_redis_host
     govuk::apps::sidekiq_monitoring::imminence_redis_port
+    govuk::apps::smartanswers::nagios_memory_critical
+    govuk::apps::smartanswers::nagios_memory_warning
+    govuk::apps::smartanswers::unicorn_worker_processes
     govuk::apps::link_checker_api::db::allow_auth_from_lb
     govuk::apps::link_checker_api::db::lb_ip_range
     govuk::apps::link_checker_api::db::rds

--- a/Rakefile
+++ b/Rakefile
@@ -112,7 +112,6 @@ task :check_consistency_between_aws_and_carrenza do
     govuk::node::s_backend_lb::publishing_api_backend_servers
     govuk::node::s_backend_lb::whitehall_backend_servers
     govuk::node::s_backend_lb::whitehall_frontend_servers
-    govuk::node::s_frontend_lb::calculators_frontend_servers
     govuk::node::s_frontend_lb::draft_frontend_servers
     govuk::node::s_frontend_lb::frontend_servers
     govuk::node::s_frontend_lb::whitehall_frontend_servers

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -524,10 +524,6 @@ govuk::apps::specialist_publisher::nagios_memory_critical: 1200
 govuk::apps::specialist_publisher::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::specialist_publisher::redis_port: "%{hiera('sidekiq_port')}"
 
-govuk::apps::smartanswers::nagios_memory_warning: 4000
-govuk::apps::smartanswers::nagios_memory_critical: 4500
-govuk::apps::smartanswers::unicorn_worker_processes: "4"
-
 govuk::apps::smokey::http_username: "%{hiera('http_username')}"
 govuk::apps::smokey::http_password: "%{hiera('http_password')}"
 govuk::apps::smokey::smokey_signon_email: "%{hiera('smokey_signon_email')}"

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -38,13 +38,6 @@ node_class: &node_class
       - signon
       - specialist-publisher
       - travel-advice-publisher
-  calculators_frontend:
-    apps:
-      - calculators
-      - calendars
-      - finder-frontend
-      - licencefinder
-      - smartanswers
   draft_frontend:
     apps:
       - collections

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1269,14 +1269,6 @@ hosts::production::ci::hosts:
     ip: '10.1.6.28'
 
 hosts::production::frontend::hosts:
-  calculators-frontend-1:
-    ip: '10.1.2.11'
-  calculators-frontend-2:
-    ip: '10.1.2.12'
-  # FIXME: This machine doesn't exist, but this host entry
-  # is depended upon by s_api_elasticsearch. We should fix that.
-  calculators-frontend-3:
-    ip: '10.1.2.13'
   docker-frontend-1:
     ip: '10.1.2.31'
   docker-frontend-2:

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -101,9 +101,6 @@ govuk::node::s_backend_lb::publishing_api_backend_servers:
 govuk::node::s_backend_lb::perfplat_public_app_domain: 'preview.performance.service.gov.uk'
 govuk::node::s_backup::offsite_backups: true
 govuk::node::s_bouncer::minimum_request_rate: 0.1
-govuk::node::s_frontend_lb::calculators_frontend_servers:
-  - 'calculators-frontend-1.frontend'
-  - 'calculators-frontend-2.frontend'
 govuk::node::s_frontend_lb::draft_frontend_servers:
   - 'draft-frontend-1.frontend'
   - 'draft-frontend-2.frontend'

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -397,12 +397,6 @@ hosts::production::backend::hosts:
     ip: '10.3.11.31'
 
 hosts::production::frontend::hosts:
-  calculators-frontend-1:
-    ip: '10.3.2.11'
-  calculators-frontend-2:
-    ip: '10.3.2.12'
-  calculators-frontend-3:
-    ip: '10.3.2.13'
   frontend-1:
     ip: '10.3.2.2'
   frontend-2:

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -159,10 +159,6 @@ govuk::node::s_backend_lb::perfplat_public_app_domain: 'performance.service.gov.
 govuk::node::s_backup::offsite_backups: true
 
 govuk::node::s_cache::real_ip_header: 'True-Client-Ip'
-govuk::node::s_frontend_lb::calculators_frontend_servers:
-  - 'calculators-frontend-1.frontend'
-  - 'calculators-frontend-2.frontend'
-  - 'calculators-frontend-3.frontend'
 govuk::node::s_frontend_lb::draft_frontend_servers:
   - 'draft-frontend-1.frontend'
   - 'draft-frontend-2.frontend'

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -135,10 +135,6 @@ govuk::node::s_backend_lb::whitehall_frontend_servers:
   - 'whitehall-frontend-2.frontend'
   - 'whitehall-frontend-3.frontend'
 govuk::node::s_backend_lb::perfplat_public_app_domain: 'staging.performance.service.gov.uk'
-govuk::node::s_frontend_lb::calculators_frontend_servers:
-  - 'calculators-frontend-1.frontend'
-  - 'calculators-frontend-2.frontend'
-  - 'calculators-frontend-3.frontend'
 govuk::node::s_frontend_lb::draft_frontend_servers:
   - 'draft-frontend-1.frontend'
   - 'draft-frontend-2.frontend'

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -350,12 +350,6 @@ hosts::production::backend::app_hostnames:
   - 'whitehall-admin'
 
 hosts::production::frontend::hosts:
-  calculators-frontend-1:
-    ip: '10.2.2.11'
-  calculators-frontend-2:
-    ip: '10.2.2.12'
-  calculators-frontend-3:
-    ip: '10.2.2.13'
   frontend-1:
     ip: '10.2.2.2'
   frontend-2:

--- a/hieradata/vagrant.yaml
+++ b/hieradata/vagrant.yaml
@@ -67,9 +67,6 @@ govuk::node::s_backend_lb::publishing_api_backend_servers:
 
 govuk::node::s_cache::real_ip_header: 'X-Forwarded-For'
 
-govuk::node::s_frontend_lb::calculators_frontend_servers:
-  - 'calculators-frontend-1.frontend'
-  - 'calculators-frontend-2.frontend'
 govuk::node::s_frontend_lb::draft_frontend_servers:
   - 'draft-frontend-1.frontend'
   - 'draft-frontend-2.frontend'

--- a/modules/govuk/manifests/node/s_frontend_lb.pp
+++ b/modules/govuk/manifests/node/s_frontend_lb.pp
@@ -1,6 +1,5 @@
 # FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
 class govuk::node::s_frontend_lb (
-  $calculators_frontend_servers,
   $draft_frontend_servers,
   $frontend_servers,
   $whitehall_frontend_servers,
@@ -38,14 +37,6 @@ class govuk::node::s_frontend_lb (
       'static',
     ]:
       servers       => $frontend_servers;
-    [
-      'calculators',
-      'calendars',
-      'finder-frontend',
-      'licencefinder',
-      'smartanswers',
-    ]:
-      servers       => $calculators_frontend_servers;
     [
       'whitehall-frontend',
       'draft-whitehall-frontend',


### PR DESCRIPTION
As calculators_frontend is now running in AWS.