### PR TITLE
Run email-alert-api Postgres backup from primary instead of standby.

### DIFF
--- a/hieradata/node/postgresql-primary-1.backend.publishing.service.gov.uk.yaml
+++ b/hieradata/node/postgresql-primary-1.backend.publishing.service.gov.uk.yaml
@@ -1,8 +1,20 @@
 govuk_env_sync::tasks:
+  "push_email_alert_api_production_daily":
+    ensure: "present"
+    hour: "2"
+    minute: "01"
+    action: "push"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "email-alert-api_production"
+    temppath: "/var/lib/autopostgresqlbackup/email-alert-api_production"
+    url: "govuk-production-database-backups"
+    path: "postgresql-backend"
+govuk_env_sync::tasks:
   "push_publishing_api_production_daily":
     ensure: "present"
     hour: "2"
-    minute: "20"
+    minute: "30"
     action: "push"
     dbms: "postgresql"
     storagebackend: "s3"

--- a/hieradata/node/postgresql-standby-1.backend.publishing.service.gov.uk.yaml
+++ b/hieradata/node/postgresql-standby-1.backend.publishing.service.gov.uk.yaml
@@ -1,6 +1,6 @@
 govuk_env_sync::tasks:
   "push_email_alert_api_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "2"
     minute: "05"
     action: "push"


### PR DESCRIPTION
Unfortunately the `govuk_env_sync` backup does not run reliably from the
standby. While it is possible in principle to work around this, the
extra complexity, effort and risk involved is unlikely to be worth it
seeing as we anticipate moving from self-hosted Postgres to RDS within
a matter of months.

Also tweak the timings slightly so that the email-alert-api backup is less
likely to overlap with the publishing-api backup.