### PR TITLE
Fix the trend panel on the Sentry errors dashboard

### DIFF
--- a/modules/grafana/files/dashboards/sentry_errors_across_all_environments.json
+++ b/modules/grafana/files/dashboards/sentry_errors_across_all_environments.json
@@ -52,13 +52,13 @@
           "targets": [
             {
               "refId": "A",
-              "target": "aliasByNode(summarize(stats.gauges.sentry-error-count-last-hour.$Applications, '$TrendInterval', 'avg', false), 3)"
+              "target": "aliasByNode(summarize(stats.gauges.sentry-error-count-last-hour.$Applications, '$TrendInterval', 'sum', false), 3)"
             }
           ],
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Trend (average over $TrendInterval)",
+          "title": "Trend (total each $TrendInterval)",
           "tooltip": {
             "shared": true,
             "sort": 2,
@@ -318,7 +318,7 @@
           "text": "auto",
           "value": "$__auto_interval"
         },
-        "hide": 2,
+        "hide": 0,
         "label": null,
         "name": "TrendInterval",
         "options": [


### PR DESCRIPTION
Previously, it was displaying the average number of errors per hour,
but the title of the panel was "Trend (average over 1d)", which was
completely wrong :(

Now it's summing the errors in an interval, and it's now possible to
change the interval. The title of the panel has also been updated.