### PR TITLE
Allow cookies for EU Funding Registration form

### DIFF
--- a/modules/varnish/templates/default.vcl.erb
+++ b/modules/varnish/templates/default.vcl.erb
@@ -84,7 +84,8 @@ sub vcl_recv {
   # With the exception of:
   #   - Licensing
   #   - email-alert-frontend (for subscription management)
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email") {
+  #   - frontend (for sessions across funding registration form)
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/brexit-eu-funding") {
     unset req.http.Cookie;
   }
   <% end %>
@@ -120,7 +121,7 @@ sub vcl_fetch {
 
   <% if @strip_cookies %>
   # Strip cookies from outbound requests. Corresponding rule in vcl_recv{}
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email") {
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/brexit-eu-funding") {
     unset beresp.http.Set-Cookie;
   }
   <% end %>


### PR DESCRIPTION
The EU Funding Registration form (rendered by frontend at `/brexit-eu-funding/*`) requires cookies to retain user responses between question steps.  Cookies are therefore being enabled for those requests.

Trello card: https://trello.com/c/Y9BVrkrl