### PR TITLE
Make all apps in AWS Staging/Prod use Signon in Carrenza. 

### DIFF
--- a/modules/govuk/manifests/deploy/config.pp
+++ b/modules/govuk/manifests/deploy/config.pp
@@ -128,6 +128,8 @@ class govuk::deploy::config(
     #
     # 2. Publishing API is still in Carrenza Production for now.
     #
+    # 3. Signon is still in Carrenza for Staging and Production.
+    #
     if $::aws_environment == 'production' {
       govuk_envvar {
         'PLEK_SERVICE_LICENSIFY_URI': value => "https://licensify.${licensify_app_domain}";
@@ -137,10 +139,10 @@ class govuk::deploy::config(
 
     # email_alert_api and whitehall_admin are still in Carrenza staging and production.
     if ($::aws_environment == 'staging') or ($::aws_environment == 'production') {
-
       govuk_envvar {
         'PLEK_SERVICE_EMAIL_ALERT_API_URI': value  => "https://email-alert-api.${app_domain}";
         'PLEK_SERVICE_WHITEHALL_ADMIN_URI': value  => "https://whitehall-admin.${app_domain}";
+        'PLEK_SERVICE_SIGNON_URI': value => "https://signon.${app_domain}";
       }
     }
 

--- a/modules/govuk/manifests/deploy/config.pp
+++ b/modules/govuk/manifests/deploy/config.pp
@@ -142,7 +142,15 @@ class govuk::deploy::config(
       govuk_envvar {
         'PLEK_SERVICE_EMAIL_ALERT_API_URI': value  => "https://email-alert-api.${app_domain}";
         'PLEK_SERVICE_WHITEHALL_ADMIN_URI': value  => "https://whitehall-admin.${app_domain}";
-        'PLEK_SERVICE_SIGNON_URI': value => "https://signon.${app_domain}";
+      }
+      # draft_content_store overrides PLEK_SERVICE_SIGNON_URI itself because it
+      # uses PLEK_HOSTNAME_PREFIX and therefore has to avoid prefixing the
+      # signon URL with 'draft-'. We therefore mustn't override it here, otherwise
+      # we're duplicating the resource.
+      unless $::govuk_node_class == 'draft_content_store' {
+        govuk_envvar {
+          'PLEK_SERVICE_SIGNON_URI': value => "https://signon.${app_domain}";
+        }
       }
     }
 

--- a/modules/govuk/manifests/node/s_publishing_api.pp
+++ b/modules/govuk/manifests/node/s_publishing_api.pp
@@ -22,16 +22,6 @@ class govuk::node::s_publishing_api inherits govuk::node::s_base {
 
   include nginx
 
-  if ($::aws_environment == 'staging') or ($::aws_environment == 'production') {
-    # For AWS staging and production, use the external domain name when
-    # constructing the URI for talking to Signon. This is needed while Signon
-    # is still in Carrenza.
-    $app_domain = hiera('app_domain')
-    govuk_envvar {
-      'PLEK_SERVICE_SIGNON_URI': value => "https://signon.${app_domain}";
-    }
-  }
-
   # The catchall vhost throws a 500, except for healthcheck requests.
   nginx::config::vhost::default { 'default': }
 


### PR DESCRIPTION
This also necessarily involves some cleanup and a slight hack to avoid
duplicate definitions of `PLEK_SERVICE_SIGNON_URI`.