### PR TITLE
Fix govuk_env_sync backup cron job for email-alert-api.

### DIFF
--- a/hieradata/node/postgresql-primary-1.backend.publishing.service.gov.uk.yaml
+++ b/hieradata/node/postgresql-primary-1.backend.publishing.service.gov.uk.yaml
@@ -10,7 +10,6 @@ govuk_env_sync::tasks:
     temppath: "/var/lib/autopostgresqlbackup/email-alert-api_production"
     url: "govuk-production-database-backups"
     path: "postgresql-backend"
-govuk_env_sync::tasks:
   "push_publishing_api_production_daily":
     ensure: "present"
     hour: "2"


### PR DESCRIPTION
This was accidentally a no-op because of a hard-to-spot copy/paste
error.