### PR TITLE
Add EU funding form developers to email whitelist

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -336,9 +336,11 @@ govuk::apps::email_alert_api::unicorn_worker_processes: '8'
 # This list should be kept in sync with https://www.notifications.service.gov.uk/services/ecfc7e2f-5145-45a6-9413-5d9b6e813ea9/users
 govuk::apps::email_alert_api::email_address_override_whitelist:
   - govuk-email-courtesy-copies@digital.cabinet-office.gov.uk
+  - alex.jurubita@digital.cabinet-office.gov.uk
   - andy.maidment@digital.cabinet-office.gov.uk
   - ben.thorner@digital.cabinet-office.gov.uk
   - bevan.loon@digital.cabinet-office.gov.uk
+  - bruce.bolt@digital.cabinet-office.gov.uk
   - complaint@simulator.amazonses.com
   - conor.delahunty@digital.cabinet-office.gov.uk
   - deborah.chua@digital.cabinet-office.gov.uk
@@ -346,6 +348,7 @@ govuk::apps::email_alert_api::email_address_override_whitelist:
   - jennifer.allum@digital.cabinet-office.gov.uk
   - kevin.dew@digital.cabinet-office.gov.uk
   - leanne.cummings@digital.cabinet-office.gov.uk
+  - robert.bond@digital.cabinet-office.gov.uk
   - ruth.morris@digital.cabinet-office.gov.uk
   - steve.messer@digital.cabinet-office.gov.uk
   - tim.blair@digital.cabinet-office.gov.uk

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -472,9 +472,11 @@ govuk::apps::email_alert_api::unicorn_worker_processes: '8'
 # This list should be kept in sync with https://www.notifications.service.gov.uk/services/ecfc7e2f-5145-45a6-9413-5d9b6e813ea9/users
 govuk::apps::email_alert_api::email_address_override_whitelist:
   - govuk-email-courtesy-copies@digital.cabinet-office.gov.uk
+  - alex.jurubita@digital.cabinet-office.gov.uk
   - andy.maidment@digital.cabinet-office.gov.uk
   - ben.thorner@digital.cabinet-office.gov.uk
   - bevan.loon@digital.cabinet-office.gov.uk
+  - bruce.bolt@digital.cabinet-office.gov.uk
   - complaint@simulator.amazonses.com
   - conor.delahunty@digital.cabinet-office.gov.uk
   - deborah.chua@digital.cabinet-office.gov.uk
@@ -484,6 +486,7 @@ govuk::apps::email_alert_api::email_address_override_whitelist:
   - kevin.dew@digital.cabinet-office.gov.uk
   - leanne.cummings@digital.cabinet-office.gov.uk
   - michael.s.walker@digital.cabinet-office.gov.uk
+  - robert.bond@digital.cabinet-office.gov.uk
   - ruth.morris@digital.cabinet-office.gov.uk
   - steve.messer@digital.cabinet-office.gov.uk
   - tim.blair@digital.cabinet-office.gov.uk


### PR DESCRIPTION
We want to test out emails.