### PR TITLE
Add search relevancy bucket envvar

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -276,6 +276,7 @@ task :check_consistency_between_aws_and_carrenza do
     govuk::apps::search_api::elasticsearch_hosts
     govuk::apps::search_api::unicorn_worker_processes
     govuk::apps::search_api::bucket_name
+    govuk::apps::search_api::relevancy_bucket_name
     govuk::apps::sidekiq_monitoring::content_data_admin_redis_host
     govuk::apps::sidekiq_monitoring::content_data_admin_redis_port
     govuk::apps::sidekiq_monitoring::content_data_api_redis_host

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -43,6 +43,7 @@ govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-eve
 govuk::apps::publishing_api::content_api_prototype: true
 govuk::apps::router::sentry_environment: 'integration'
 govuk::apps::search_api::bucket_name: 'govuk-integration-sitemaps'
+govuk::apps::search_api::relevancy_bucket_name: 'govuk-integration-search-relevancy'
 govuk::apps::short_url_manager::instance_name: 'integration'
 govuk::apps::signon::instance_name: 'integration'
 govuk::apps::smartanswers::expose_govspeak: true

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -152,6 +152,7 @@ govuk::apps::publisher::fact_check_address_format: 'factcheck+production-{id}@al
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-production'
 govuk::apps::router::sentry_environment: 'production'
 govuk::apps::search_api::bucket_name: 'govuk-production-sitemaps'
+govuk::apps::search_api::relevancy_bucket_name: 'govuk-production-search-relevancy'
 govuk::apps::short_url_manager::instance_name: 'production'
 govuk::apps::static::ga_universal_id: 'UA-26179049-1'
 govuk::apps::support::zendesk_anonymous_ticket_email: 'zd-api-public@digital.cabinet-office.gov.uk'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -146,6 +146,7 @@ govuk::apps::publisher::fact_check_address_format: 'factcheck+staging-{id}@alpha
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-staging'
 govuk::apps::router::sentry_environment: 'staging'
 govuk::apps::search_api::bucket_name: 'govuk-staging-sitemaps'
+govuk::apps::search_api::relevancy_bucket_name: 'govuk-staging-search-relevancy'
 govuk::apps::short_url_manager::instance_name: 'staging'
 govuk::apps::signon::instance_name: 'staging'
 govuk::apps::static::ga_universal_id: 'UA-26179049-20'

--- a/modules/govuk/manifests/apps/search_api.pp
+++ b/modules/govuk/manifests/apps/search_api.pp
@@ -87,6 +87,10 @@
 #   The AWS region of the S3 bucket.
 #   Default: eu-west-1
 #
+# [*relevancy_bucket_name*]
+#   The S3 bucket for search relevancy data - e.g. relevancy judgements
+#
+
 class govuk::apps::search_api(
   $rabbitmq_user,
   $port = '3233',
@@ -115,6 +119,7 @@ class govuk::apps::search_api(
   $oauth_id = undef,
   $oauth_secret = undef,
   $bucket_name = undef,
+  $relevancy_bucket_name = undef,
   $aws_region = 'eu-west-1',
 ) {
   $app_name = 'search-api'
@@ -247,4 +252,9 @@ class govuk::apps::search_api(
       value   => $aws_region;
   }
 
+  govuk::app::envvar {
+    "${title}-AWS_S3_RELEVANCY_BUCKET_NAME":
+      varname => 'AWS_S3_RELEVANCY_BUCKET_NAME',
+      value   => $relevancy_bucket_name;
+  }
 }


### PR DESCRIPTION
Search API will use this bucket for search relevancy jobs (e.g. rank evaluation using CSVs in the bucket).

The bucket already exists in the required environments.

https://trello.com/c/xys5Wp6o