### PR TITLE
Add scheduled job for search-api rank evaluation

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -399,6 +399,7 @@ task :check_consistency_between_aws_and_carrenza do
     govuk_jenkins::jobs::data_sync_complete_production::signon_domains_to_migrate
     govuk_jenkins::jobs::search_fetch_analytics_data::cron_schedule
     govuk_jenkins::jobs::search_fetch_analytics_data::skip_page_traffic_load
+    govuk_jenkins::jobs::search_relevancy_rank_evaluation::cron_schedule
     govuk_jenkins::jobs::enhanced_ecommerce_search_api::cron_schedule
     govuk_jenkins::jobs::smokey::environment
     govuk_mysql::server::expire_log_days

--- a/hieradata_aws/class/integration/jenkins.yaml
+++ b/hieradata_aws/class/integration/jenkins.yaml
@@ -39,6 +39,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::search_api_reindex_with_new_schema
   - govuk_jenkins::jobs::search_test_spelling_suggestions
   - govuk_jenkins::jobs::search_generate_sitemaps
+  - govuk_jenkins::jobs::search_relevancy_rank_evaluation
   - govuk_jenkins::jobs::send_bulk_email
   - govuk_jenkins::jobs::signon_cron_rake_tasks
   - govuk_jenkins::jobs::smokey

--- a/hieradata_aws/class/production/jenkins.yaml
+++ b/hieradata_aws/class/production/jenkins.yaml
@@ -28,6 +28,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::search_api_index_checks
   - govuk_jenkins::jobs::search_api_reindex_with_new_schema
   - govuk_jenkins::jobs::search_generate_sitemaps
+  - govuk_jenkins::jobs::search_relevancy_rank_evaluation
   - govuk_jenkins::jobs::smokey
   - govuk_jenkins::jobs::smokey_deploy
   - govuk_jenkins::jobs::transition_import_dns

--- a/hieradata_aws/class/staging/jenkins.yaml
+++ b/hieradata_aws/class/staging/jenkins.yaml
@@ -24,6 +24,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::search_api_fetch_analytics_data
   - govuk_jenkins::jobs::search_api_index_checks
   - govuk_jenkins::jobs::search_api_reindex_with_new_schema
+  - govuk_jenkins::jobs::search_relevancy_rank_evaluation
   - govuk_jenkins::jobs::search_generate_sitemaps
   - govuk_jenkins::jobs::smokey
   - govuk_jenkins::jobs::smokey_deploy

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -136,6 +136,7 @@ govuk_jenkins::jobs::search_test_spelling_suggestions::cron_schedule: '0 10 * * 
 govuk_jenkins::jobs::search_api_fetch_analytics_data::skip_page_traffic_load: true
 govuk_jenkins::jobs::search_api_fetch_analytics_data::cron_schedule: '30 9 * * 1-5'
 
+govuk_jenkins::jobs::search_relevancy_rank_evaluation::cron_schedule: '45 */3 * * *' # every three hours
 # Integration doesn't have a mirror
 govuk_jenkins::jobs::update_cdn_dictionaries::allow_deploy_to_mirror: false
 

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -226,6 +226,8 @@ govuk_jenkins::jobs::deploy_emergency_banner::clear_cdn_cache: true
 govuk_jenkins::jobs::search_fetch_analytics_data::skip_page_traffic_load: true
 govuk_jenkins::jobs::search_fetch_analytics_data::cron_schedule: '30 8 * * 1-5'
 
+govuk_jenkins::jobs::search_relevancy_rank_evaluation::cron_schedule: '45 */3 * * *' # every three hours
+
 govuk_jenkins::jobs::smokey::environment: production_aws
 
 govuk_jenkins::jobs::data_sync_complete_production::signon_domains_to_migrate:

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -194,6 +194,8 @@ govuk_jenkins::jobs::network_config_deploy::environments:
 govuk_jenkins::jobs::search_fetch_analytics_data::skip_page_traffic_load: true
 govuk_jenkins::jobs::search_fetch_analytics_data::cron_schedule: '30 8 * * 1-5'
 
+govuk_jenkins::jobs::search_relevancy_rank_evaluation::cron_schedule: '45 */3 * * *' # every three hours
+
 govuk_jenkins::jobs::smokey::environment: staging_aws
 
 govuk_jenkins::jobs::data_sync_complete_staging::signon_domains_to_migrate:

--- a/modules/govuk_jenkins/manifests/jobs/search_relevancy_rank_evaluation.pp
+++ b/modules/govuk_jenkins/manifests/jobs/search_relevancy_rank_evaluation.pp
@@ -1,0 +1,36 @@
+# == Class: govuk_jenkins::jobs::search_relevancy_rank_evaluation
+#
+# A Jenkins job to periodically run search_relevancy_rank_evaluation.
+# This monitoring job sends the results of a rake task to graphite.
+#
+# === Parameters:
+#
+# [*cron_schedule *]
+#   The cron schedule to specify how often this task will run
+#   Default: undef
+#
+class govuk_jenkins::jobs::search_relevancy_rank_evaluation (
+  $cron_schedule = undef,
+  $app_domain = hiera('app_domain'),
+) {
+
+  $check_name = 'search-relevancy-rank-evaluation'
+  $service_description = 'Search Relevancy Rank Evaluation'
+  $job_url = "https://deploy.${::aws_environment}.govuk.digital/job/search_relevancy_rank_evaluation/"
+
+  file { '/etc/jenkins_jobs/jobs/search_relevancy_rank_evaluation.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/search_relevancy_rank_evaluation.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+
+  if $cron_schedule {
+    @@icinga::passive_check { "${check_name}_${::hostname}":
+      service_description => $service_description,
+      host_name           => $::fqdn,
+      freshness_threshold => 86400,
+      action_url          => $job_url,
+      contact_groups      => ['slack-channel-search-team'],
+    }
+  }
+}

--- a/modules/govuk_jenkins/templates/jobs/search_relevancy_rank_evaluation.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/search_relevancy_rank_evaluation.yaml.erb
@@ -1,0 +1,37 @@
+---
+- job:
+    name: search_relevancy_rank_evaluation
+    display-name: Search Relevancy Rank Evaluation
+    project-type: freestyle
+    description: "<p>Runs a search-api rake task debug:rank_evaluation.</p>
+    <p>Get in touch with the search team for more details.</p>"
+    builders:
+      - trigger-builds:
+          - project: run-rake-task
+            block: true
+            predefined-parameters: |
+              TARGET_APPLICATION=search-api
+              MACHINE_CLASS=search
+              RAKE_TASK='SEND_TO_GRAPHITE=true debug:ranking_evaluation'
+    wrappers:
+      - ansicolor:
+          colormap: xterm
+  <% if @rake_etl_master_process_cron_schedule %>
+    triggers:
+      - timed: <%= @cron_schedule %>
+  <% end %>
+    logrotate:
+        numToKeep: 10
+    publishers:
+      - trigger-parameterized-builds:
+          - project: Success_Passive_Check
+            condition: 'SUCCESS'
+            predefined-parameters: |
+                NSCA_CHECK_DESCRIPTION=<%= @service_description %>
+                NSCA_OUTPUT=<%= @service_description %> success
+          - project: Failure_Passive_Check
+            condition: 'FAILED'
+            predefined-parameters: |
+                NSCA_CHECK_DESCRIPTION=<%= @service_description %>
+                NSCA_OUTPUT=<%= @service_description %> failed
+                NSCA_CODE=2

--- a/modules/monitoring/manifests/contacts.pp
+++ b/modules/monitoring/manifests/contacts.pp
@@ -206,4 +206,20 @@ class monitoring::contacts (
       members     => ['slack_data_informed'],
     }
   }
+
+  # Search Team
+  if $slack_webhook_url {
+    icinga::slack_contact { 'slack_search_team':
+      slack_webhook_url      => $slack_webhook_url,
+      slack_channel          => '#govuk-searchandnav',
+      slack_username         => $slack_username,
+      icinga_status_cgi_url  => $slack_icinga_status_cgi_url,
+      icinga_extinfo_cgi_url => $slack_icinga_extinfo_cgi_url,
+    }
+
+    icinga::contact_group { 'slack-channel-search-team':
+      group_alias => 'Contact #govuk-searchandnav',
+      members     => ['slack_search_team'],
+    }
+  }
 }


### PR DESCRIPTION
This will run a search rake task every 3 hours. The rake task populates graphite with the ranking evaluation scores for a bunch of queries that we have relevancy judgements for.

These scores are reported in the search relevancy dashboard, allowing the search team to monitor search relevancy over time.

This also adds a contact group for the search team, so alerts will go to our Slack channel.

Trello: https://trello.com/c/9qZqdAXs