### PR TITLE
Update office start and end times

### DIFF
--- a/modules/monitoring/manifests/contacts.pp
+++ b/modules/monitoring/manifests/contacts.pp
@@ -50,9 +50,9 @@ class monitoring::contacts (
   validate_bool($notify_pager, $notify_slack, $notify_graphite)
 
   $midnight_day_start = '00:00'
-  $office_day_start = '08:30'
-  $midday = '11:00'
-  $office_day_end = '16:30'
+  $office_day_start = '09:30'
+  $midday = '12:00'
+  $office_day_end = '17:30'
   $midnight_day_end = '24:00'
 
   $all_day = "${midnight_day_start}-${midnight_day_end}"


### PR DESCRIPTION
We've gone back to GMT, so we need to change the times to match (https://docs.publishing.service.gov.uk/manual/change-in-hours-time-period-for-dst.html).

See 1f9c585 for more details.