### PR TITLE
Disable govuk_crawler_worker during the data sync

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -216,6 +216,7 @@ task :check_consistency_between_aws_and_carrenza do
     govuk::apps::govuk_crawler_worker::root_urls
     govuk::apps::govuk_crawler_worker::nagios_memory_critical
     govuk::apps::govuk_crawler_worker::nagios_memory_warning
+    govuk::apps::govuk_crawler_worker::disable_during_data_sync
     govuk::apps::email_alert_api::db::allow_auth_from_lb
     govuk::apps::email_alert_api::db::lb_ip_range
     govuk::apps::email_alert_api::db::rds

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -37,6 +37,7 @@ govuk::apps::email_alert_api::delivery_request_threshold: "3000"
 govuk::apps::email_alert_frontend::subscription_management_enabled: true
 govuk::apps::frontend::govuk_notify_template_id: '1fc69d3a-09a2-40f9-852b-03f6fcef5340'
 govuk::apps::govuk_crawler_worker::enabled: false
+govuk::apps::govuk_crawler_worker::disable_during_data_sync: true
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
 govuk::apps::link_checker_api::govuk_basic_auth_credentials: "%{hiera('http_username')}:%{hiera('http_password')}"
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-integration'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -139,6 +139,7 @@ govuk::apps::email_alert_api::email_address_override_whitelist_only: true
 govuk::apps::email_alert_api::delivery_request_threshold: "3000"
 govuk::apps::email_alert_frontend::subscription_management_enabled: true
 govuk::apps::frontend::govuk_notify_template_id: '2844a647-6bf1-4b01-a25c-569d2cc00849'
+govuk::apps::govuk_crawler_worker::disable_during_data_sync: true
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::link_checker_api::govuk_basic_auth_credentials: "%{hiera('http_username')}:%{hiera('http_password')}"
 govuk::apps::publisher::run_fact_check_fetcher: false

--- a/hieradata_aws/vagrant_credentials.yaml
+++ b/hieradata_aws/vagrant_credentials.yaml
@@ -43,7 +43,6 @@ govuk::apps::content_tagger::db_password: "%{hiera('govuk::apps::content_tagger:
 govuk::apps::content_tagger::db::password: '6bab0d694abaabc64f4b40fcd7e51'
 govuk::apps::email_alert_api::db::password: '8WB3h7RXohmTvmU7bmmDK4ppsd8BU7Ki'
 
-govuk::apps::govuk_crawler_worker::airbrake_api_key: 'lxHeeE3VknbR7nlZ51QnUfKcxd7iuIcSe25r'
 govuk::apps::link_checker_api::db::password: 'r8I6kP13TypUPiCR4izTImbaF7Li/Oh4VZFTSYR3j7A='
 govuk::apps::link_checker_api::db_password: "%{hiera('govuk::apps::link_checker_api::db::password')}"
 govuk::apps::local_links_manager::db::password: 'a192e3fcb901b069aa6c45438faecdc48b30f8a6'

--- a/modules/govuk/manifests/app.pp
+++ b/modules/govuk/manifests/app.pp
@@ -268,6 +268,11 @@
 #   established TCP connections to $port.
 #   Default: undef
 #
+# [*enable_service*]
+#   Whether to include the service definition. Set this to false if you want
+#   to manage the service separately.
+#   Default: true
+#
 define govuk::app (
   $app_type,
   $port = 0,
@@ -311,6 +316,7 @@ define govuk::app (
   $monitor_unicornherder = undef,
   $local_tcpconns_established_warning = undef,
   $local_tcpconns_established_critical = undef,
+  $enable_service = true,
 ) {
 
   if ! ($app_type in ['procfile', 'rack', 'bare']) {
@@ -395,10 +401,12 @@ define govuk::app (
     local_tcpconns_established_critical => $local_tcpconns_established_critical,
   }
 
-  govuk::app::service { $title:
-    ensure     => $ensure,
-    hasrestart => $hasrestart,
-    subscribe  => Class['govuk::deploy'],
+  if $enable_service {
+    govuk::app::service { $title:
+      ensure     => $ensure,
+      hasrestart => $hasrestart,
+      subscribe  => Class['govuk::deploy'],
+    }
   }
 
   @filebeat::prospector { "${title}-upstart-out":

--- a/modules/govuk/manifests/apps/govuk_crawler_worker.pp
+++ b/modules/govuk/manifests/apps/govuk_crawler_worker.pp
@@ -5,15 +5,6 @@
 #
 # === Parameters
 #
-# [*airbrake_api_key*]
-#   API key to use to connect to the exception notification service
-#
-# [*airbrake_endpoint*]
-#   Location to send exception notifications to over HTTP
-#
-# [*airbrake_env*]
-#   Environment to set for exception notification
-#
 # [*amqp_pass*]
 #   Password for the app to use to connect to a message queue exchange
 #
@@ -48,9 +39,6 @@
 #   Memory use at which Nagios should generate a critical alert.
 #
 class govuk::apps::govuk_crawler_worker (
-  $airbrake_api_key = '',
-  $airbrake_endpoint = '',
-  $airbrake_env = '',
   $amqp_host = 'localhost',
   $amqp_pass = 'guest',
   $blacklist_paths = [],
@@ -71,12 +59,6 @@ class govuk::apps::govuk_crawler_worker (
     }
 
     govuk::app::envvar {
-      'AIRBRAKE_API_KEY':
-        value => $airbrake_api_key;
-      'AIRBRAKE_ENDPOINT':
-        value => $airbrake_endpoint;
-      'AIRBRAKE_ENV':
-        value => $airbrake_env;
       'AMQP_ADDRESS':
         value => "amqp://govuk_crawler_worker:${amqp_pass}@${amqp_host}:5672/";
       'AMQP_EXCHANGE':

--- a/modules/govuk/manifests/apps/govuk_crawler_worker.pp
+++ b/modules/govuk/manifests/apps/govuk_crawler_worker.pp
@@ -53,9 +53,11 @@ class govuk::apps::govuk_crawler_worker (
 ) {
   validate_array($blacklist_paths, $root_urls)
 
+  $app_name = 'govuk_crawler_worker'
+
   if $enabled {
     Govuk::App::Envvar {
-      app => 'govuk_crawler_worker',
+      app => $app_name,
     }
 
     govuk::app::envvar {
@@ -92,7 +94,7 @@ class govuk::apps::govuk_crawler_worker (
       group  => 'deploy',
     }
 
-    govuk::app { 'govuk_crawler_worker':
+    govuk::app { $app_name:
       app_type               => 'bare',
       log_format_is_json     => true,
       port                   => $port,


### PR DESCRIPTION
We see a lot of 5xx errors in staging while the data sync is happening because the databases aren't ready to receive requests.

This uses the `govuk_data_sync_in_progress` class that was added in 2a08e23f50d6fe6662029a3b029b648c02a8360f.

I've also removed the old Airbrake configuration.

[Trello Card](https://trello.com/c/O5pIyTn2/1457-3-avoid-the-staging-govuk-crawler-worker-from-crawling-between-2300-and-0100-hours)