### PR TITLE
Use govuk::app::service in govuk_crawler_worker

### DIFF
--- a/modules/govuk/manifests/app.pp
+++ b/modules/govuk/manifests/app.pp
@@ -268,10 +268,10 @@
 #   established TCP connections to $port.
 #   Default: undef
 #
-# [*enable_service*]
-#   Whether to include the service definition. Set this to false if you want
-#   to manage the service separately.
-#   Default: true
+# [*ensure_service*]
+#   The ensure value passed to the service. You can use this to configure the
+#   app but stop the service from running.
+#   Default: running
 #
 define govuk::app (
   $app_type,
@@ -316,7 +316,7 @@ define govuk::app (
   $monitor_unicornherder = undef,
   $local_tcpconns_established_warning = undef,
   $local_tcpconns_established_critical = undef,
-  $enable_service = true,
+  $ensure_service = running,
 ) {
 
   if ! ($app_type in ['procfile', 'rack', 'bare']) {
@@ -401,12 +401,10 @@ define govuk::app (
     local_tcpconns_established_critical => $local_tcpconns_established_critical,
   }
 
-  if $enable_service {
-    govuk::app::service { $title:
-      ensure     => $ensure,
-      hasrestart => $hasrestart,
-      subscribe  => Class['govuk::deploy'],
-    }
+  govuk::app::service { $title:
+    ensure     => $ensure_service,
+    hasrestart => $hasrestart,
+    subscribe  => Class['govuk::deploy'],
   }
 
   @filebeat::prospector { "${title}-upstart-out":

--- a/modules/govuk/manifests/app/service.pp
+++ b/modules/govuk/manifests/app/service.pp
@@ -1,10 +1,9 @@
 # FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
 define govuk::app::service (
-  $ensure = 'present',
+  $ensure = running,
   $hasrestart = false,
 ) {
-
-  $enable_service = hiera('govuk_app_enable_services', true)
+  $enable_services = hiera('govuk_app_enable_services', true)
 
   if $ensure == 'absent' {
     # Stop the app if it's running.
@@ -16,15 +15,16 @@ define govuk::app::service (
       before  => File["/etc/init/${title}.conf"],
     }
   } else {
+    if $enable_services {
+      $service_ensure = $ensure
+    } else {
+      $service_ensure = stopped
+    }
+
     service { $title:
+      ensure     => $service_ensure,
       provider   => 'upstart',
       hasrestart => $hasrestart,
     }
-    if $enable_service {
-      Service[$title] {
-        ensure => running
-      }
-    }
   }
-
 }


### PR DESCRIPTION
This reverts e51007b5314896c622d505cec1dc0f88c879a6e2 with an ensure_service parameter which can be used to configure whether the service should be running.

[Trello Card](https://trello.com/c/O5pIyTn2/1457-3-avoid-the-staging-govuk-crawler-worker-from-crawling-between-2300-and-0100-hours)