### PR TITLE
Shift email-alert-api Staging env_sync job to catch same day's backup.

### DIFF
--- a/hieradata_aws/class/staging/db_admin.yaml
+++ b/hieradata_aws/class/staging/db_admin.yaml
@@ -68,7 +68,7 @@ govuk_env_sync::tasks:
   "pull_email_alert_api_production_daily":
     ensure: "present"
     hour: "2"
-    minute: "35"
+    minute: "45"
     action: "pull"
     dbms: "postgresql"
     storagebackend: "s3"


### PR DESCRIPTION
Might as well have these line up; there is a small practical benefit to
the databases in Staging being from the same day.

Hopefully we can remove the need to adjust these timings at some
point in the not too distant future.