### PR TITLE
Fix rank eval scheduled job

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/search_relevancy_rank_evaluation.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/search_relevancy_rank_evaluation.yaml.erb
@@ -12,11 +12,11 @@
             predefined-parameters: |
               TARGET_APPLICATION=search-api
               MACHINE_CLASS=search
-              RAKE_TASK='SEND_TO_GRAPHITE=true debug:ranking_evaluation'
+              RAKE_TASK=debug:ranking_evaluation SEND_TO_GRAPHITE=true
     wrappers:
       - ansicolor:
           colormap: xterm
-  <% if @rake_etl_master_process_cron_schedule %>
+  <% if @cron_schedule %>
     triggers:
       - timed: <%= @cron_schedule %>
   <% end %>


### PR DESCRIPTION
The rake task shouldn't be wrapped in quotes, and the cron job had the wrong variable name.