### PR TITLE
reduce the no. of days log kept for integration email-alert-api

### DIFF
--- a/hieradata_aws/class/integration/email_alert_api.yaml
+++ b/hieradata_aws/class/integration/email_alert_api.yaml
@@ -1,0 +1,3 @@
+---
+logrotate::conf::days_to_keep: 7
+nginx::logging::days_to_keep: 7


### PR DESCRIPTION
The no. of days log kept for email-alert-api in AWS integration should be reduced to 7 because there is a lack of space and integration doesn't need that long logging.