### PR TITLE
Remove Host Entries For Email Alert API In Carrenza Staging

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1147,8 +1147,6 @@ hosts::production::backend::app_hostnames:
   - 'content-publisher'
   - 'content-tagger'
   - 'docs'
-  - 'email-alert-api'
-  - 'email-alert-api-public'
   - 'hmrc-manuals-api'
   - 'kibana'
   - 'maslow'


### PR DESCRIPTION
Remove Host Entries For Email Alert Service In Carrenza Staging

This is part of the migration process to AWS.