### PR TITLE
remove Copy_Licensify_Data_to_Staging

### DIFF
--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -11,7 +11,6 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::copy_attachments_to_staging
   - govuk_jenkins::jobs::copy_data_to_integration
   - govuk_jenkins::jobs::copy_data_to_staging
-  - govuk_jenkins::jobs::copy_licensify_data_to_staging
   - govuk_jenkins::jobs::copy_sanitised_whitehall_database
   - govuk_jenkins::jobs::delete_redis_uniquejobs
   - govuk_jenkins::jobs::deploy_app


### PR DESCRIPTION
This is no longer needed since licensify has been migrated to AWS for staging environment.