### PR TITLE
Reload router instead of restart

### DIFF
--- a/modules/govuk/manifests/app.pp
+++ b/modules/govuk/manifests/app.pp
@@ -200,6 +200,10 @@
 # specify if the app init script has a restart command
 # Default: false
 #
+# [*restart*]
+# override the command used to restart the service
+# Default: undef
+#
 # [*depends_on_nfs*]
 # Start the application after mounted filesystems. Some applications
 # depend on NFS shares for functionality. They should not start until the mounted
@@ -301,6 +305,7 @@ define govuk::app (
   $asset_pipeline_prefix = 'assets',
   $ensure = 'present',
   $hasrestart = false,
+  $restart = undef,
   $depends_on_nfs = false,
   $read_timeout = 15,
   $proxy_http_version_1_1_enabled = false,
@@ -404,6 +409,7 @@ define govuk::app (
   govuk::app::service { $title:
     ensure     => $ensure_service,
     hasrestart => $hasrestart,
+    restart    => $restart,
     subscribe  => Class['govuk::deploy'],
   }
 

--- a/modules/govuk/manifests/app/service.pp
+++ b/modules/govuk/manifests/app/service.pp
@@ -2,6 +2,7 @@
 define govuk::app::service (
   $ensure = running,
   $hasrestart = false,
+  $restart = undef,
 ) {
   $enable_services = hiera('govuk_app_enable_services', true)
 
@@ -25,6 +26,7 @@ define govuk::app::service (
       ensure     => $service_ensure,
       provider   => 'upstart',
       hasrestart => $hasrestart,
+      restart    => $restart,
     }
   }
 }

--- a/modules/govuk/manifests/apps/router.pp
+++ b/modules/govuk/manifests/apps/router.pp
@@ -75,6 +75,15 @@ class govuk::apps::router (
     sentry_dsn                          => $sentry_dsn,
     local_tcpconns_established_warning  => 150,
     local_tcpconns_established_critical => 200,
+
+    # We are overriding the restart command to use reload
+    # because the underlying application uses github.com/alext/tablecloth
+    # which re-execs the itself (the app, based on the path) when it receives a
+    # SIGHUP
+    #
+    # 'service $service reload' sends a SIGHUP instead of a SIGTERM which would
+    # cause downtime
+    restart => 'service router reload',
   }
 
   # We can't pass `health_check_path` to `govuk::app` because it has the

--- a/modules/govuk/spec/defines/govuk__app__service_spec.rb
+++ b/modules/govuk/spec/defines/govuk__app__service_spec.rb
@@ -1,0 +1,77 @@
+require_relative '../../../../spec_helper'
+
+describe 'govuk::app::service', :type => :define do
+  context 'when title is mysvc' do
+    let(:title) { 'mysvc' }
+
+    context 'when services are disabled' do
+      it { is_expected.to compile }
+
+      it do
+        is_expected.to contain_service('mysvc').with(
+          :ensure => 'stopped',
+          :provider => 'upstart',
+        )
+      end
+    end
+
+    context 'when services are enabled' do
+      let(:hiera_config) do
+        { 'govuk_app_enable_services' => true }
+      end
+
+      context 'with no params' do
+        let(:params) { {} }
+
+        it { is_expected.to compile }
+
+        it do
+          is_expected.to contain_service('mysvc').with(
+            :ensure => 'running',
+            :provider => 'upstart',
+            :hasrestart => false,
+            :restart => nil,
+          )
+        end
+      end
+
+      context 'with hasrestart override' do
+        let(:params) do
+          {
+            :hasrestart => true,
+          }
+        end
+
+        it { is_expected.to compile }
+
+        it do
+          is_expected.to contain_service('mysvc').with(
+            :ensure => 'running',
+            :provider => 'upstart',
+            :hasrestart => true,
+            :restart => nil,
+          )
+        end
+      end
+
+      context 'with restart override' do
+        let(:params) do
+          {
+            :restart => 'command-to-run-instead-of service mysvc restart',
+          }
+        end
+
+        it { is_expected.to compile }
+
+        it do
+          is_expected.to contain_service('mysvc').with(
+            :ensure => 'running',
+            :provider => 'upstart',
+            :hasrestart => false,
+            :restart => 'command-to-run-instead-of service mysvc restart',
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
What
---

`router` is a Go application which supports zero downtime restarts using [github.com/alext/tablecloth](github.com/alext/tablecloth), [see code](https://github.com/alphagov/router/blob/master/main.go#L74)

Its [deploy script](https://github.com/alphagov/govuk-app-deployment/blob/master/router/config/deploy.rb#L54) knows about this and reloads the app instead of stopping/starting or restarting it

However `govuk::app` has a bunch of definitions which notify `govuk::app::service` which by default restarts the service.

Allow govuk::app::service to take a restart which overrides the restart parameter in the Service

Then we can override the restart command for the router app to run `service router reload` instead, so that it is restarted in the zero downtime fashion as intended by the application authors.

Also add some specs for `govuk::app::service` to ensure no regressions

How to review
---

- Verify that `service router restart` causes 5XXs
- Verify that `service router reload` does not cause 5XXs
- Read the [documentation on Puppet's restart behaviour](https://puppet.com/docs/puppet/3.8/types/service.html#service-attribute-restart)
- Code review the change
- Code review the tests

Who can review
---

Not @tlwr

Someone with Puppet knowledge

Someone with Go knowledge (to review `router`'s code)