### PR TITLE
Stop checking Whitehall for overdue publications overnight in Integration and Staging

### DIFF
--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -407,6 +407,7 @@ licensify::apps::licensify::alert_5xx_warning_rate: 0.1
 licensify::apps::licensify::alert_5xx_critical_rate: 0.15
 
 monitoring::checks::aws_origin_domain: "staging.govuk.digital"
+monitoring::checks::whitehall_overdue_check_period: 'inoffice'
 monitoring::checks::ses::region: eu-west-1
 monitoring::checks::smokey::environment: 'staging'
 monitoring::checks::smokey::disable_during_data_sync: true

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -326,6 +326,7 @@ grafana::dashboards::application_dashboards:
 mongodb::backup::mongo_backup_node: 'localhost'
 
 monitoring::checks::aws_origin_domain: "integration.govuk.digital"
+monitoring::checks::whitehall_overdue_check_period: 'inoffice'
 monitoring::checks::sidekiq::enable_support_check: false
 monitoring::checks::pingdom::enable: false
 monitoring::checks::ses::region: 'eu-west-1'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -275,6 +275,7 @@ licensify::apps::licensify::alert_5xx_warning_rate: 0.1
 licensify::apps::licensify::alert_5xx_critical_rate: 0.15
 
 monitoring::checks::aws_origin_domain: "staging.govuk.digital"
+monitoring::checks::whitehall_overdue_check_period: 'inoffice'
 monitoring::checks::datagovuk_publish::ensure: 'present'
 monitoring::checks::datagovuk_publish::host: 'publish-data-beta-staging.cloudapps.digital'
 monitoring::checks::sidekiq::enable_signon_check: false

--- a/modules/icinga/manifests/check.pp
+++ b/modules/icinga/manifests/check.pp
@@ -24,6 +24,10 @@
 #   when passed by the exporting node, rather than lazily evaluated inside
 #   the define by the collecting node.
 #
+# [*check_period*]
+#   The title of a `Icinga::Timeperiod` resource describing when this
+#   service should be actively checked.
+#
 # [*notification_period*]
 #   The title of a `Icinga::Timeperiod` resource.
 #
@@ -59,6 +63,7 @@ define icinga::check (
   $ensure                     = 'present',
   $service_description        = undef,
   $check_command              = undef,
+  $check_period               = undef,
   $notification_period        = undef,
   $use                        = 'govuk_regular_service',
   $action_url                 = undef,

--- a/modules/icinga/templates/service.erb
+++ b/modules/icinga/templates/service.erb
@@ -15,6 +15,9 @@ define service {
 <%- if @attempts_before_hard_state -%>
         max_check_attempts        <%= @attempts_before_hard_state %>
 <%- end -%>
+<%- if @check_period -%>
+        check_period              <%= @check_period %>
+<%- end -%>
 <%- if @notification_period -%>
         notification_period       <%= @notification_period %>
 <%- end -%>

--- a/modules/monitoring/manifests/checks.pp
+++ b/modules/monitoring/manifests/checks.pp
@@ -14,9 +14,10 @@
 #   Password for $http_username
 #
 class monitoring::checks (
-  $aws_origin_domain = undef,
-  $http_username     = 'UNSET',
-  $http_password     = 'UNSET',
+  $aws_origin_domain              = undef,
+  $http_username                  = 'UNSET',
+  $http_password                  = 'UNSET',
+  $whitehall_overdue_check_period = undef,
 ) {
 
   ensure_packages(['jq'])
@@ -70,6 +71,7 @@ class monitoring::checks (
       notes_url                  => monitoring_docs_url(whitehall-scheduled-publishing),
       action_url                 => "https://${whitehall_hostname}${whitehall_overdue_url}",
       event_handler              => 'publish_overdue_whitehall',
+      check_period               => $whitehall_overdue_check_period,
       attempts_before_hard_state => 2,
       retry_interval             => 10,
     }


### PR DESCRIPTION
This check leads to errors when the Whitehall database is out of action, so only run the check in Staging and Integration in office hours.