### PR TITLE
Partially revert "Remove frontend app_hostnames list"

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -69,6 +69,7 @@ task :check_consistency_between_aws_and_carrenza do
     hosts::production::backend::hosts
     hosts::production::ci::hosts
     hosts::production::external_licensify
+    hosts::production::frontend::app_hostnames
     hosts::production::frontend::hosts
     hosts::production::ip_api_lb
     hosts::production::ip_backend_lb

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1206,6 +1206,10 @@ hosts::production::frontend::hosts:
 
 hosts::production::external_licensify: true
 
+hosts::production::frontend::app_hostnames:
+  - 'whitehall-frontend'
+  - 'draft-whitehall-frontend'
+
 hosts::production::licensify::hosts:
   licensify-lb-1:
     ip: '10.5.0.101'


### PR DESCRIPTION
I think routing requests through the backend-lb machines on the
Carrenza side of Production is broken because the entries for
whitehall-frontend are missing from the /etc/hosts file. Restoring the
whitehall-frontend entries here should make the /etc/hosts file
correct.

This seems to be breaking requests for new assets for Whitehall.

This partially reverts commit
005c0a6c84b25073c55d1ca7d6e789344fd0026e.