### PR TITLE
Fix DDoSDetected alert to fire when and only when DDoS is detected.

### DIFF
--- a/modules/monitoring/files/etc/nagios3/conf.d/check_cloudwatch.cfg
+++ b/modules/monitoring/files/etc/nagios3/conf.d/check_cloudwatch.cfg
@@ -1,4 +1,4 @@
 define command {
     command_name check_cloudwatch
-    command_line /usr/lib/nagios/plugins/check_cloudwatch --namespace=$ARG1$ --region=$ARG2$ --metric=$ARG3$ --statistics=Maximum --mins=1440 --namespace-prefix=AWS --warning=$ARG4$ --critical=$ARG5$ --agg-dimensions
+    command_line /usr/lib/nagios/plugins/check_cloudwatch --namespace=$ARG1$ --region=$ARG2$ --metric=$ARG3$ --statistics=Maximum --mins=1440 --namespace-prefix=AWS --warning=$ARG4$ --critical=$ARG5$ --agg-dimensions $ARG6$
 }

--- a/modules/monitoring/manifests/checks.pp
+++ b/modules/monitoring/manifests/checks.pp
@@ -146,7 +146,7 @@ class monitoring::checks (
 
   if $::aws_migration {
     icinga::check { 'check_ddos_detected':
-      check_command       => 'check_cloudwatch!DDoSProtection!eu-west-1!DDoSDetected!1!1' ,
+      check_command       => 'check_cloudwatch!DDoSProtection!eu-west-1!DDoSDetected!0.99!0.99!--default=0',
       host_name           => $::fqdn,
       service_description => 'check AWS DDOS report',
       notes_url           => monitoring_docs_url(ddosdetected),


### PR DESCRIPTION
The DDoSDetected alert was broken in two ways:

  1. When the DDoSDetected CloudWatch metric was 1 (that is, when AWS
     detects a DDoS), the alert would not fire because it was doing a
     floating-point comparison between two almost-but-not-quite
     identical representations of approximately 1.0.
  2. When no DDoS activity had been detected for more than a day (which
     appears to be the hard-coded time window for all of our CloudWatch
     Icinga alerts), the alert would fire as `UNKNOWN` because the alert
     didn't know what to do when no data points were returned.