### PR TITLE
Remove redundant 'app_name app healthcheck' Icinga check

### DIFF
--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -415,14 +415,6 @@ define govuk::app::config (
   }
 
   if $health_check_path != 'NOTSET' {
-    @@icinga::check { "check_app_${title}_up_on_${::hostname}":
-      ensure              => $ensure,
-      check_command       => "check_app_health!check_app_up!${port} ${health_check_path}",
-      service_description => "${title} app healthcheck",
-      host_name           => $::fqdn,
-      notes_url           => monitoring_docs_url(app-healthcheck-failed),
-      contact_groups      => $additional_check_contact_groups,
-    }
     if $json_health_check {
       include icinga::client::check_json_healthcheck
 
@@ -437,6 +429,15 @@ define govuk::app::config (
         notification_period => $health_check_notification_period,
         host_name           => $::fqdn,
         notes_url           => monitoring_docs_url($healthcheck_opsmanual),
+        contact_groups      => $additional_check_contact_groups,
+      }
+    } else {
+      @@icinga::check { "check_app_${title}_up_on_${::hostname}":
+        ensure              => $ensure,
+        check_command       => "check_app_health!check_app_up!${port} ${health_check_path}",
+        service_description => "${title} app healthcheck",
+        host_name           => $::fqdn,
+        notes_url           => monitoring_docs_url(app-healthcheck-failed),
         contact_groups      => $additional_check_contact_groups,
       }
     }


### PR DESCRIPTION
From the Trello card, specific to `email-alert-api`:
- This icinga alert regularly makes a GET request to the `/healthcheck` endpoint in `email-alert-api` and checks that the app responds successfully.
- We don't need it as we already have the [`email-alert-api app healthcheck not ok` icinga
  alert](https://alert.publishing.service.gov.uk/cgi-bin/icinga/extinfo.cgi?type=2&host=email-alert-api-1.backend.publishing.service.gov.uk&service=email-alert-api+app+healthcheck+not+ok) that regularly makes GET requests to the same endpoint and if the response isn't successful, it fails.
- Having both is redundant because whenever `email-alert-api app healthcheck` fails, `email-alert-api app healthcheck not ok` fails too.

However:

- It was non-trivial to scope this to just `email-alert-api` when the same problem exists for all apps with /healthcheck routes.
- This change removes the 'app healthcheck' check in favour of the existing and all-encompassing 'app healthcheck not ok' check.

https://trello.com/c/ZDAY7kMs/1479-3-remove-the-redundant-email-alert-api-app-healthcheck-icinga-alert

---

My Puppet is very rusty. I hope this does what we think it does. Who knows! How bad can deleting some code be? 😬