### PR TITLE
Add rubocop-govuk repository to Jenkins CI

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -669,6 +669,7 @@ govuk_ci::master::pipeline_jobs:
   rack-logstasher: {}
   rails_translation_manager: {}
   router-data: {}
+  rubocop-govuk: {}
   seal: {}
   search-api: {}
   shared_mustache: {}


### PR DESCRIPTION
[rubocop-govuk](https://github.com/alphagov/rubocop-govuk) is a newly created repository and needs to be added to the Jenkins CI.