### PR TITLE
Smooth out Icinga checks related to deployments

### DIFF
--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -344,7 +344,7 @@ define govuk::app::config (
       host_name                  => $::fqdn,
       event_handler              => "govuk_app_high_memory!${title}",
       notes_url                  => monitoring_docs_url(high-memory-for-application),
-      attempts_before_hard_state => 2,
+      attempts_before_hard_state => 3,
       contact_groups             => $additional_check_contact_groups,
     }
     @@icinga::check::graphite { "check_${title}_app_memory_restarts${::hostname}":
@@ -360,13 +360,14 @@ define govuk::app::config (
     }
     if $alert_when_threads_exceed {
       @@icinga::check::graphite { "check_${title}_app_thread_count_${::hostname}":
-        ensure         => $ensure,
-        target         => "${::fqdn_metrics}.processes-app-${title_underscore}.ps_count.threads",
-        warning        => $alert_when_threads_exceed,
-        critical       => $alert_when_threads_exceed,
-        desc           => "Thread count for ${title_underscore} exceeds ${alert_when_threads_exceed}",
-        host_name      => $::fqdn,
-        contact_groups => $additional_check_contact_groups,
+        ensure                     => $ensure,
+        target                     => "${::fqdn_metrics}.processes-app-${title_underscore}.ps_count.threads",
+        warning                    => $alert_when_threads_exceed,
+        critical                   => $alert_when_threads_exceed,
+        desc                       => "Thread count for ${title_underscore} exceeds ${alert_when_threads_exceed}",
+        host_name                  => $::fqdn,
+        attempts_before_hard_state => 3,
+        contact_groups             => $additional_check_contact_groups,
       }
     }
   }


### PR DESCRIPTION
For apps running with Unicorn, a deployment involves spawning new
threads, which take up more memory, and then shutting down the old
threads once the new ones are serving requests. This can take up to 2
minutes for some apps.

To avoid Icinga alerting during deployments, increase the
attempts_before_hard_state setting to 3 for both the memory and thread
count checks. A value of one will mean Icinga alerts immediately and a
value of 3 will mean that Icinga will wait a minute then check again,
then wait another minute and check again, and the check will only
enter a hard state if this 3rd check fails.

This should avoid these checks failing temporarily during deployments,
but still mean they appear when the application is using an abnormal
amount of memory or threads.