### PR TITLE
modify email alert api plek entry for aws staging

### DIFF
--- a/modules/govuk/manifests/deploy/config.pp
+++ b/modules/govuk/manifests/deploy/config.pp
@@ -126,7 +126,7 @@ class govuk::deploy::config(
     # Integration are in AWS, so Plek already does the right thing by default
     # in those environments.
     #
-    # 2. Publishing API is still in Carrenza Production for now.
+    # 2. Publishing API and Email Alert API are still in Carrenza Production for now.
     #
     # 3. Signon is still in Carrenza for Staging and Production.
     #
@@ -134,13 +134,13 @@ class govuk::deploy::config(
       govuk_envvar {
         'PLEK_SERVICE_LICENSIFY_URI': value => "https://licensify.${licensify_app_domain}";
         'PLEK_SERVICE_PUBLISHING_API_URI': value  => "https://publishing-api.${app_domain}";
+        'PLEK_SERVICE_EMAIL_ALERT_API_URI': value  => "https://email-alert-api.${app_domain}";
       }
     }
 
-    # email_alert_api and whitehall_admin are still in Carrenza staging and production.
+    # whitehall_admin are still in Carrenza staging and production.
     if ($::aws_environment == 'staging') or ($::aws_environment == 'production') {
       govuk_envvar {
-        'PLEK_SERVICE_EMAIL_ALERT_API_URI': value  => "https://email-alert-api.${app_domain}";
         'PLEK_SERVICE_WHITEHALL_ADMIN_URI': value  => "https://whitehall-admin.${app_domain}";
       }
       # draft_content_store overrides PLEK_SERVICE_SIGNON_URI itself because it


### PR DESCRIPTION
As part of the migration of email alert api to AWS, the plek entry in AWS staging which points consumers of email alert api to carrenza must be removed. We keep it for AWS production.