### PR TITLE
Don't call people out-of-hours for ElastiCache CPU/Memory use

### DIFF
--- a/modules/monitoring/manifests/checks/cache_config.pp
+++ b/modules/monitoring/manifests/checks/cache_config.pp
@@ -31,7 +31,6 @@ define monitoring::checks::cache_config (
   ){
   icinga::check { "check_aws_cache_cpu-${title}":
     check_command       => "check_aws_cache_cpu!${region}!${cpu_warning}!${cpu_critical}!${::aws_stackname}-${title}",
-    use                 => 'govuk_urgent_priority',
     host_name           => $::fqdn,
     service_description => "${title} - AWS ElastiCache CPU Utilization",
     notes_url           => monitoring_docs_url(aws-cache-cpu),
@@ -40,7 +39,6 @@ define monitoring::checks::cache_config (
 
   icinga::check { "check_aws_cache_memory-${title}":
     check_command       => "check_aws_cache_memory!${region}!${memory_warning}!${memory_critical}!${::aws_stackname}-${title}",
-    use                 => 'govuk_urgent_priority',
     host_name           => $::fqdn,
     service_description => "${title} - AWS ElastiCache Memory Utilization",
     notes_url           => monitoring_docs_url(aws-cache-memory),


### PR DESCRIPTION
- This was introduced in d87d7ecda41ff40eb02fb33c20595b1418c93205.
- It called someone out of hours last night, when there was nothing they
  could do. We only want to call on actionable things.
- We had a similar problem with RDS, and we bumped the severity down in e6a83283eb5ad910efeb097131dbe4c5b02c2d5f.