### PR TITLE
Run Search GA data load every six hours

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -421,6 +421,7 @@ task :check_consistency_between_aws_and_carrenza do
     govuk_jenkins::jobs::search_fetch_analytics_data::cron_schedule
     govuk_jenkins::jobs::search_fetch_analytics_data::skip_page_traffic_load
     govuk_jenkins::jobs::search_relevancy_rank_evaluation::cron_schedule
+    govuk_jenkins::jobs::search_google_analytics_etl::cron_schedule
     govuk_jenkins::jobs::enhanced_ecommerce_search_api::cron_schedule
     govuk_jenkins::jobs::smokey::environment
     govuk_mysql::server::expire_log_days

--- a/hieradata_aws/class/integration/jenkins.yaml
+++ b/hieradata_aws/class/integration/jenkins.yaml
@@ -40,6 +40,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::search_test_spelling_suggestions
   - govuk_jenkins::jobs::search_generate_sitemaps
   - govuk_jenkins::jobs::search_relevancy_rank_evaluation
+  - govuk_jenkins::jobs::search_google_analytics_etl
   - govuk_jenkins::jobs::send_bulk_email
   - govuk_jenkins::jobs::signon_cron_rake_tasks
   - govuk_jenkins::jobs::smokey

--- a/hieradata_aws/class/production/jenkins.yaml
+++ b/hieradata_aws/class/production/jenkins.yaml
@@ -29,6 +29,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::search_api_reindex_with_new_schema
   - govuk_jenkins::jobs::search_generate_sitemaps
   - govuk_jenkins::jobs::search_relevancy_rank_evaluation
+  - govuk_jenkins::jobs::search_google_analytics_etl
   - govuk_jenkins::jobs::smokey
   - govuk_jenkins::jobs::smokey_deploy
   - govuk_jenkins::jobs::transition_import_dns

--- a/hieradata_aws/class/staging/jenkins.yaml
+++ b/hieradata_aws/class/staging/jenkins.yaml
@@ -25,6 +25,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::search_api_index_checks
   - govuk_jenkins::jobs::search_api_reindex_with_new_schema
   - govuk_jenkins::jobs::search_relevancy_rank_evaluation
+  - govuk_jenkins::jobs::search_google_analytics_etl
   - govuk_jenkins::jobs::search_generate_sitemaps
   - govuk_jenkins::jobs::smokey
   - govuk_jenkins::jobs::smokey_deploy

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -138,6 +138,7 @@ govuk_jenkins::jobs::search_api_fetch_analytics_data::skip_page_traffic_load: tr
 govuk_jenkins::jobs::search_api_fetch_analytics_data::cron_schedule: '30 9 * * 1-5'
 
 govuk_jenkins::jobs::search_relevancy_rank_evaluation::cron_schedule: '45 */3 * * *' # every three hours
+govuk_jenkins::jobs::search_google_analytics_etl::cron_schedule: 'H */6 * * *' # every six hours
 # Integration doesn't have a mirror
 govuk_jenkins::jobs::update_cdn_dictionaries::allow_deploy_to_mirror: false
 

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -227,6 +227,7 @@ govuk_jenkins::jobs::search_fetch_analytics_data::skip_page_traffic_load: true
 govuk_jenkins::jobs::search_fetch_analytics_data::cron_schedule: '30 8 * * 1-5'
 
 govuk_jenkins::jobs::search_relevancy_rank_evaluation::cron_schedule: '45 */3 * * *' # every three hours
+govuk_jenkins::jobs::search_google_analytics_etl::cron_schedule: 'H */6 * * *' # every six hours
 
 govuk_jenkins::jobs::smokey::environment: production_aws
 

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -196,6 +196,7 @@ govuk_jenkins::jobs::search_fetch_analytics_data::skip_page_traffic_load: true
 govuk_jenkins::jobs::search_fetch_analytics_data::cron_schedule: '30 8 * * 1-5'
 
 govuk_jenkins::jobs::search_relevancy_rank_evaluation::cron_schedule: '45 */3 * * *' # every three hours
+govuk_jenkins::jobs::search_google_analytics_etl::cron_schedule: 'H */6 * * *' # every six hours
 
 govuk_jenkins::jobs::smokey::environment: staging_aws
 

--- a/modules/govuk_jenkins/manifests/jobs/search_google_analytics_etl.pp
+++ b/modules/govuk_jenkins/manifests/jobs/search_google_analytics_etl.pp
@@ -1,0 +1,37 @@
+# == Class: govuk_jenkins::jobs::search_google_analytics_etl
+#
+# A Jenkins job to periodically load Google Analytics data into graphite,
+# using a rake task in Search API. The data is displayed in the Search Relevancy
+# grafana dashboard.
+#
+# === Parameters:
+#
+# [*cron_schedule *]
+#   The cron schedule to specify how often this task will run
+#   Default: undef
+#
+class govuk_jenkins::jobs::search_google_analytics_etl (
+  $cron_schedule = undef,
+  $app_domain = hiera('app_domain'),
+) {
+
+  $check_name = 'search-google-analytics-etl'
+  $service_description = 'Search Google Analytics ETL'
+  $job_url = "https://deploy.${::aws_environment}.govuk.digital/job/search_google_analytics_etl/"
+
+  file { '/etc/jenkins_jobs/jobs/search_google_analytics_etl.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/search_google_analytics_etl.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+
+  if $cron_schedule {
+    @@icinga::passive_check { "${check_name}_${::hostname}":
+      service_description => $service_description,
+      host_name           => $::fqdn,
+      freshness_threshold => 86400,
+      action_url          => $job_url,
+      contact_groups      => ['slack-channel-search-team'],
+    }
+  }
+}

--- a/modules/govuk_jenkins/templates/jobs/search_google_analytics_etl.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/search_google_analytics_etl.yaml.erb
@@ -1,0 +1,39 @@
+---
+- job:
+    name: search_google_analytics_etl
+    display-name: Search Google Analytics ETL
+    project-type: freestyle
+    description: "<p>Runs a Search API rake task relevancy:send_ga_data_to_graphite.</p>
+    <p>The rake task extracts GA data and loads it into Graphite.</p>
+    <p>This is a monitoring task. It is safe to re-run in-hours.</p>
+    <p>Get in touch with the search team for more details.</p>"
+    builders:
+      - trigger-builds:
+          - project: run-rake-task
+            block: true
+            predefined-parameters: |
+              TARGET_APPLICATION=search-api
+              MACHINE_CLASS=search
+              RAKE_TASK=relevancy:send_ga_data_to_graphite SEND_TO_GRAPHITE=true
+    wrappers:
+      - ansicolor:
+          colormap: xterm
+  <% if @cron_schedule %>
+    triggers:
+      - timed: <%= @cron_schedule %>
+  <% end %>
+    logrotate:
+        numToKeep: 10
+    publishers:
+      - trigger-parameterized-builds:
+          - project: Success_Passive_Check
+            condition: 'SUCCESS'
+            predefined-parameters: |
+                NSCA_CHECK_DESCRIPTION=<%= @service_description %>
+                NSCA_OUTPUT=<%= @service_description %> success
+          - project: Failure_Passive_Check
+            condition: 'FAILED'
+            predefined-parameters: |
+                NSCA_CHECK_DESCRIPTION=<%= @service_description %>
+                NSCA_OUTPUT=<%= @service_description %> failed
+                NSCA_CODE=2


### PR DESCRIPTION
This will load click through data in all environments from GA into graphite every six hours.

Search team will get notified if it fails. Same as the last one: https://github.com/alphagov/govuk-puppet/pull/9741

Trello: https://trello.com/c/wiMR3foo/1095