### PR TITLE
Check AWS IAM Key age

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -170,6 +170,7 @@ monitoring::checks::aws_origin_domain: "integration.govuk.digital"
 monitoring::checks::sidekiq::enable_signon_check: false
 monitoring::checks::pingdom::enable: false
 monitoring::checks::ses::region: eu-west-1
+monitoring::checks::aws_iam_key::region: 'eu-west-1'
 monitoring::checks::smokey::environment: 'integration'
 monitoring::checks::smokey::disable_during_data_sync: true
 monitoring::uptime_collector::environment: 'integration'

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -443,6 +443,7 @@ licensify::apps::licensify_feed::environment: 'production'
 
 monitoring::checks::aws_origin_domain: "production.govuk.digital"
 monitoring::checks::ses::region: us-east-1
+monitoring::checks::aws_iam_key::region: 'eu-west-1'
 monitoring::checks::smokey::environment: 'production'
 monitoring::contacts::notify_pager: true
 monitoring::contacts::notify_slack: true

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -409,6 +409,7 @@ licensify::apps::licensify::alert_5xx_critical_rate: 0.15
 monitoring::checks::aws_origin_domain: "staging.govuk.digital"
 monitoring::checks::whitehall_overdue_check_period: 'inoffice'
 monitoring::checks::ses::region: eu-west-1
+monitoring::checks::aws_iam_key::region: 'eu-west-1'
 monitoring::checks::smokey::environment: 'staging'
 monitoring::checks::smokey::disable_during_data_sync: true
 monitoring::uptime_collector::environment: 'staging'

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -332,6 +332,7 @@ monitoring::checks::sidekiq::enable_support_check: false
 monitoring::checks::pingdom::enable: false
 monitoring::checks::ses::region: 'eu-west-1'
 monitoring::checks::rds::region: 'eu-west-1'
+monitoring::checks::aws_iam_key::region: 'eu-west-1'
 
 monitoring::checks::lb::region: 'eu-west-1'
 monitoring::checks::lb::loadbalancers:

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -307,6 +307,7 @@ monitoring::checks::datagovuk_publish::host: 'publish-data-beta-production.cloud
 monitoring::checks::sidekiq::enable_signon_check: false
 monitoring::checks::ses::region: 'eu-west-1'
 monitoring::checks::rds::region: 'eu-west-1'
+monitoring::checks::aws_iam_key::region: 'eu-west-1'
 
 monitoring::checks::lb::region: 'eu-west-1'
 monitoring::checks::lb::loadbalancers:

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -283,6 +283,7 @@ monitoring::checks::sidekiq::enable_signon_check: false
 monitoring::checks::sidekiq::enable_support_check: false
 monitoring::checks::ses::region: 'eu-west-1'
 monitoring::checks::rds::region: 'eu-west-1'
+monitoring::checks::aws_iam_key::region: 'eu-west-1'
 
 monitoring::checks::lb::region: 'eu-west-1'
 monitoring::checks::lb::loadbalancers:

--- a/hieradata_aws/training.yaml
+++ b/hieradata_aws/training.yaml
@@ -146,6 +146,7 @@ monitoring::checks::pingdom::enable: false
 monitoring::checks::ses::region: 'eu-west-2'
 monitoring::checks::rds::region: 'eu-west-2'
 monitoring::checks::cache::region: 'eu-west-2'
+monitoring::checks::aws_iam_key::region: 'eu-west-2'
 monitoring::checks::smokey::environment: 'training'
 monitoring::checks::smokey::disable_during_data_sync: true
 monitoring::uptime_collector::environment: 'training'

--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_iam_key_age
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_iam_key_age
@@ -1,0 +1,108 @@
+#!/usr/bin/env ruby
+
+require 'aws-sdk-iam'
+require 'optparse'
+
+options = {
+  debug: false,
+  days: 90,
+  exceptions: []
+}
+
+config = {
+  region: 'eu-west-1'
+}
+
+opt_parser = OptionParser.new do |opt|
+  opt.on('--exceptions user_name[,user_name]', 'which user_names do you wish to exclude?') do |exceptions|
+    options[:exceptions] = exceptions.split(',')
+  end
+
+  opt.on('--days days', 'how many days old can a key be?') do |days|
+    options[:days] = days.to_i
+  end
+
+  opt.on('-k', '--key key', 'specify your AWS key ID') do |key|
+    config[:access_key_id] = key unless key.empty?
+  end
+
+  opt.on('-s', '--secret secret', 'specify your AWS secret') do |secret|
+    config[:secret_access_key] = secret unless secret.empty?
+  end
+
+  opt.on('--region region', 'specify your region defaults to eu-west-1') do |region|
+    config[:region] = region unless region.empty?
+  end
+
+  opt.on('--role_arn role_arn', 'specify your role_arn if you want to assume a role') do |role_arn|
+    config[:role_arn] = role_arn unless role_arn.empty?
+  end
+
+  opt.on('--mfa_serial mfa_serial', 'specify your mfa_serial if you want to assume a role') do |mfa_serial|
+    config[:mfa_serial] = mfa_serial unless mfa_serial.empty?
+  end
+
+  opt.on('--token_code token_code', 'specify your token_code if you want to assume a role') do |token_code|
+    config[:token_code] = token_code unless token_code.empty?
+  end
+
+  opt.on('--debug', 'enable debug mode') do
+    options[:debug] = true
+  end
+
+  opt.on('-h', '--help', 'help') do
+    puts opt_parser
+    exit
+  end
+end
+
+opt_parser.parse!
+
+if options[:debug]
+  puts 'Options: ' + options.inspect
+  puts 'Config: ' + config.inspect
+end
+
+begin
+  iam_options = { region: config[:region] }
+  if config.key?(:role_arn)
+    iam_options[:credentials] = Aws::AssumeRoleCredentials.new(
+      client: Aws::STS::Client.new(region: config[:region]),
+      role_arn: config[:role_arn],
+      serial_number: config[:mfa_serial],
+      token_code: config[:token_code],
+      role_session_name: 'session-name'
+    )
+  end
+
+  iam = Aws::IAM::Client.new(iam_options)
+
+  failed_keys = []
+
+  iam.list_users.users.each do |user|
+    next if options[:exceptions].include? user.user_name
+
+    puts user.user_name if options[:debug]
+    iam.list_access_keys(user_name: user.user_name).access_key_metadata.each do |key|
+      age = (Date.today - key.create_date.to_date).to_i
+      puts "#{key.access_key_id}: #{key.create_date.to_date}" if options[:debug]
+      if age >= options[:days]
+        failed_keys << [key.access_key_id, age, user.user_name].join(' ')
+      end
+    end
+  end
+
+  unless failed_keys.empty?
+    puts "There are #{failed_keys.length} active keys older than #{options[:days]} days: "
+    puts failed_keys.join("\n")
+    exit 1
+  end
+rescue SystemExit
+  raise
+rescue Exception => e
+  puts 'Unexpected error: ' + e.message + ' <' + e.backtrace[0] + '>'
+  exit 2
+end
+
+puts 'No users with outdated keys found.'
+exit 1

--- a/modules/monitoring/manifests/checks.pp
+++ b/modules/monitoring/manifests/checks.pp
@@ -44,6 +44,7 @@ class monitoring::checks (
   include monitoring::checks::rds
   include monitoring::checks::lb
   include monitoring::checks::cloudwatch
+  include monitoring::checks::aws_iam_key
 
   $app_domain = hiera('app_domain')
 

--- a/modules/monitoring/manifests/checks/aws_iam_key.pp
+++ b/modules/monitoring/manifests/checks/aws_iam_key.pp
@@ -23,7 +23,7 @@ class monitoring::checks::aws_iam_key (
   $enabled = true,
 ) {
   if $enabled and $::aws_migration {
-    $max_age = 90
+    $max_age = 365
 
     icinga::plugin { 'check_aws_iam_key_age':
       source  => 'puppet:///modules/monitoring/usr/lib/nagios/plugins/check_aws_iam_key_age',

--- a/modules/monitoring/manifests/checks/aws_iam_key.pp
+++ b/modules/monitoring/manifests/checks/aws_iam_key.pp
@@ -1,0 +1,47 @@
+# == Class: monitoring::checks::aws_iam_key
+#
+# Single Nagios alert for iam key rotations being required in the environment
+#
+# === Parameters
+#
+# [*region*]
+#   Which SES region should be checked ['us-east-1','eu-west-1']
+#
+# [*access_key*]
+#   AWS access key to use
+#
+# [*secret_key*]
+#   AWS secret key to use
+#
+# [*enabled*]
+#   Should we enable the monitoring check?
+#
+class monitoring::checks::aws_iam_key (
+  $region = undef,
+  $access_key = undef,
+  $secret_key = undef,
+  $enabled = true,
+) {
+  if $enabled and $::aws_migration {
+    $max_age = 90
+
+    icinga::plugin { 'check_aws_iam_key_age':
+      source  => 'puppet:///modules/monitoring/usr/lib/nagios/plugins/check_aws_iam_key_age',
+    }
+
+    icinga::check_config { 'check_aws_iam_key_age':
+      content => template('monitoring/check_aws_iam_key_age.cfg.erb'),
+      require => File['/usr/lib/nagios/plugins/check_aws_iam_key_age'],
+    }
+
+    icinga::check { 'check_aws_iam_key_age':
+      check_command       => 'check_aws_iam_key_age',
+      use                 => 'govuk_normal_priority',
+      host_name           => $::fqdn,
+      check_interval      => 43200,
+      service_description => 'At least 1 AWS IAM Key is older then max_age days and needs rotating',
+      notes_url           => monitoring_docs_url(rotate-old-aws-iam-key),
+      require             => Icinga::Check_config['check_aws_iam_key_age'],
+    }
+  }
+}

--- a/modules/monitoring/templates/check_aws_iam_key_age.cfg.erb
+++ b/modules/monitoring/templates/check_aws_iam_key_age.cfg.erb
@@ -1,0 +1,4 @@
+define command {
+    command_name check_aws_iam_key_age
+    command_line /usr/lib/nagios/plugins/check_aws_aws_iam_key_age --key <%= @access_key %> --secret <%= @secret_key %> --region <%= @region %> --days <%= @max_age %>
+}


### PR DESCRIPTION
This alerts if AWS IAM Keys are older then 90 days. AWS Trusted Advisor recommends that IAM keys are rotated every 90 days, this alert will show keys that are older than this.