### PR TITLE
Remove PagerDuty trigger for AWS Elasticache Redis

### DIFF
--- a/modules/monitoring/manifests/checks/cache_config.pp
+++ b/modules/monitoring/manifests/checks/cache_config.pp
@@ -31,7 +31,6 @@ define monitoring::checks::cache_config (
   ){
   icinga::check { "check_aws_cache_cpu-${title}":
     check_command       => "check_aws_cache_cpu!${region}!${cpu_warning}!${cpu_critical}!${::aws_stackname}-${title}",
-    use                 => 'govuk_urgent_priority',
     host_name           => $::fqdn,
     service_description => "${title} - AWS ElastiCache CPU Utilization",
     notes_url           => monitoring_docs_url(aws-cache-cpu),
@@ -40,7 +39,6 @@ define monitoring::checks::cache_config (
 
   icinga::check { "check_aws_cache_memory-${title}":
     check_command       => "check_aws_cache_memory!${region}!${memory_warning}!${memory_critical}!${::aws_stackname}-${title}",
-    use                 => 'govuk_urgent_priority',
     host_name           => $::fqdn,
     service_description => "${title} - AWS ElastiCache Memory Utilization",
     notes_url           => monitoring_docs_url(aws-cache-memory),


### PR DESCRIPTION
- These alerts have been configured analogous to prior VM alerts, as
Redis is now hosted in AWS Elasticache, there is nothing for GOV.UK to
action.