### PR TITLE
Correct check_aws_quota template  file reference

### DIFF
--- a/modules/monitoring/manifests/checks/ses.pp
+++ b/modules/monitoring/manifests/checks/ses.pp
@@ -37,7 +37,7 @@ class monitoring::checks::ses (
     }
 
     icinga::check_config { 'check_aws_quota':
-      content => template('icinga/check_http_icinga.cfg.erb'),
+      content => template('monitoring/check_aws_quota.cfg.erb'),
       require => File['/usr/lib/nagios/plugins/check_aws_quota'],
     }
 


### PR DESCRIPTION
On service start, Icinga on the monitoring machines is erroring with
`Warning: Duplicate definition found for command 'check_http_port'`.

I suspect this is because the template file in the ses check is
referencing `icinga/check_http_icinga.cfg.erb` and this in turn is
creating the file on disk named `check_aws_quota.cfg` with duplicate
content to the file name `check_http_icinga.cfg`. This file defines the
`check_http_port` command (as well as various others) and since there
are now two files defining the same command, Icinga errors.

I think that instead, the ses check should reference the
`check_aws_quota.cfg.erb` template.