### PR TITLE
pull whitehall production db to AWS staging

### DIFF
--- a/hieradata_aws/class/staging/db_admin.yaml
+++ b/hieradata_aws/class/staging/db_admin.yaml
@@ -117,3 +117,14 @@ govuk_env_sync::tasks:
   "pull_licensify_refdata_production_daily":
     <<: *pull_licensify
     database: "licensify-refdata"
+  "pull_mysql_whitehall_production_daily":
+    ensure: "present"
+    hour: "3"
+    minute: "00"
+    action: "pull"
+    dbms: "mysql"
+    storagebackend: "s3"
+    database: "whitehall_production"
+    temppath: "/tmp/whitehall_production"
+    url: "govuk-production-database-backups"
+    path: "mysql"


### PR DESCRIPTION
This is done in preparation to the migration of whitehall to AWS Staging.