### PR TITLE
Prepend "blue" to staging and production environment

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/smokey.pp
+++ b/modules/govuk_jenkins/manifests/jobs/smokey.pp
@@ -25,8 +25,8 @@ class govuk_jenkins::jobs::smokey (
     require => Class['govuk::apps::smokey'],
   }
 
-  if $::aws_migration {
-    $hosting_env_domain = "${::aws_environment}.govuk.digital"
+  if $::aws_migration and ($::aws_environment != 'integration') {
+    $hosting_env_domain = "blue.${::aws_environment}.govuk.digital"
   }
   else {
     $hosting_env_domain = $app_domain


### PR DESCRIPTION
for links to the smokey job.

In Staging and Production AWS environments, the current url to navigate
directly to a job has to begin with `deploy.blue`.