### PR TITLE
Add Icinga checks for technical and internal failures

### DIFF
--- a/modules/govuk/manifests/apps/email_alert_api/checks.pp
+++ b/modules/govuk/manifests/apps/email_alert_api/checks.pp
@@ -1,0 +1,8 @@
+# == Class: govuk::apps::email_alert_api:checks
+#
+# Various Icinga checks for Email Alert API.
+#
+class govuk::apps::email_alert_api::checks {
+  delivery_attempt_status_check { 'internal_failure': }
+  delivery_attempt_status_check { 'technical_failure': }
+}

--- a/modules/govuk/manifests/apps/email_alert_api/delivery_attempt_status_check.pp
+++ b/modules/govuk/manifests/apps/email_alert_api/delivery_attempt_status_check.pp
@@ -1,0 +1,21 @@
+# == Define: govuk::apps::email_alert_api::delivery_attempt_status_check
+#
+# Creates an Icinga check which checks Graphite for high numbers of delivery
+# attempts with a specifc status.
+#
+# === Parameters
+#
+# [*title*]
+#   The status of the delivery attempts to look for.
+#
+define govuk::apps::email_alert_api::delivery_attempt_status_check() {
+  @@icinga::check::graphite { "email-alert-api-delivery-attempt-${title}":
+    host_name => $::fqdn,
+    target    => "sum(stats.govuk.app.email-alert-api.*.delivery_attempt.status.${title})",
+    warning   => '0.5',
+    critical  => '1',
+    from      => '1hour',
+    desc      => "High number of ${title} delivery attempts",
+    notes_url => monitoring_docs_url(email-alert-api-delivery-attempt-status),
+  }
+}

--- a/modules/monitoring/manifests/checks.pp
+++ b/modules/monitoring/manifests/checks.pp
@@ -45,6 +45,8 @@ class monitoring::checks (
   include monitoring::checks::lb
   include monitoring::checks::cloudwatch
 
+  include govuk::apps::email_alert_api::checks
+
   $app_domain = hiera('app_domain')
 
   if $app_domain != 'integration.publishing.service.gov.uk' {


### PR DESCRIPTION
This adds Icinga checks for high numbers of delivery attempts with a technical or internal failure.

Previously we would check for this using a healthcheck in email-alert-api but this has a number of problems:

- The healthchecks are no longer machine specific, meaning they can't be used correctly by the load balancer to decide where to send traffic.
- The healthchecks have ended up doing a lot of work (including database queries) which slow themselves down but also put unnecessary load on the database.
- In Icinga, a single healthcheck problem in email-alert-api ends up being duplicated for each machine which can be confusing.

These checks work slightly differently to the existing ones in email-alert-api because they work on an absolute number of failures rather than a proportion. This is why I've chosen to have very low thresholds which we can change in the future if we think these are too low.

The number of technical and internal failures while the app is running normally is already very low:

https://graphite.publishing.service.gov.uk/render/?width=1053&height=487&_salt=1572948737.847&from=-1hours&target=sum(stats.govuk.app.email-alert-api.*.delivery_attempt.status.technical_failure)&target=sum(stats.govuk.app.email-alert-api.*.delivery_attempt.status.internal_failure)

[Trello Card](https://trello.com/c/abNGpq1l/1480-5-extract-the-technicalfailures-check-from-the-healthcheck-endpoint-in-email-alert-api-to-a-separate-icinga-check)