### PR TITLE
Disable internal and technical failures in AWS production

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -219,6 +219,8 @@ task :check_consistency_between_aws_and_carrenza do
     govuk::apps::govuk_crawler_worker::nagios_memory_critical
     govuk::apps::govuk_crawler_worker::nagios_memory_warning
     govuk::apps::govuk_crawler_worker::disable_during_data_sync
+    govuk::apps::email_alert_api::checks::internal_failure
+    govuk::apps::email_alert_api::checks::technical_failure
     govuk::apps::email_alert_api::db::allow_auth_from_lb
     govuk::apps::email_alert_api::db::lb_ip_range
     govuk::apps::email_alert_api::db::rds

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -140,6 +140,8 @@ govuk::apps::email_alert_api::email_archive_s3_bucket: 'govuk-production-email-a
 # This shouldn't be enabled at the same time we have carrenza s3 export enabled unless they have separate buckets
 govuk::apps::email_alert_api::email_archive_s3_enabled: false
 govuk::apps::email_alert_api::govuk_notify_template_id: 'cb633abc-6ae6-4843-ae6f-82ca500b6de2'
+govuk::apps::email_alert_api::checks::internal_failure: false
+govuk::apps::email_alert_api::checks::technical_failure: false
 govuk::apps::frontend::govuk_notify_template_id: 'cb633abc-6ae6-4843-ae6f-82ca500b6de2'
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::link_checker_api::govuk_basic_auth_credentials: "%{hiera('http_username')}:%{hiera('http_password')}"

--- a/modules/govuk/manifests/apps/email_alert_api/checks.pp
+++ b/modules/govuk/manifests/apps/email_alert_api/checks.pp
@@ -2,7 +2,19 @@
 #
 # Various Icinga checks for Email Alert API.
 #
-class govuk::apps::email_alert_api::checks {
-  delivery_attempt_status_check { 'internal_failure': }
-  delivery_attempt_status_check { 'technical_failure': }
+class govuk::apps::email_alert_api::checks(
+  $internal_failure = true,
+  $technical_failure = true,
+) {
+  $internal_failure_ensure = $internal_failure ? { true => present, false => absent }
+
+  delivery_attempt_status_check { 'internal_failure':
+    ensure => $internal_failure_ensure,
+  }
+
+  $technical_failure_ensure = $technical_failure ? { true => present, false => absent }
+
+  delivery_attempt_status_check { 'technical_failure':
+    ensure => $technical_failure_ensure,
+  }
 }

--- a/modules/govuk/manifests/apps/email_alert_api/delivery_attempt_status_check.pp
+++ b/modules/govuk/manifests/apps/email_alert_api/delivery_attempt_status_check.pp
@@ -5,11 +5,18 @@
 #
 # === Parameters
 #
+# [*ensure*]
+#   Whether to enable the check.
+#   Default: present
+#
 # [*title*]
 #   The status of the delivery attempts to look for.
 #
-define govuk::apps::email_alert_api::delivery_attempt_status_check() {
+define govuk::apps::email_alert_api::delivery_attempt_status_check(
+  $ensure = present,
+) {
   @@icinga::check::graphite { "email-alert-api-delivery-attempt-${title}":
+    ensure    => $ensure,
     host_name => $::fqdn,
     target    => "sum(stats.govuk.app.email-alert-api.*.delivery_attempt.status.${title})",
     warning   => '0.5',


### PR DESCRIPTION
Email Alert API is currently not running in AWS production.

[Trello Card](https://trello.com/c/abNGpq1l/1480-5-extract-the-technicalfailures-check-from-the-healthcheck-endpoint-in-email-alert-api-to-a-separate-icinga-check)