### PR TITLE
Change cron schedule for Search GA ETL

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -138,7 +138,7 @@ govuk_jenkins::jobs::search_api_fetch_analytics_data::skip_page_traffic_load: tr
 govuk_jenkins::jobs::search_api_fetch_analytics_data::cron_schedule: '30 9 * * 1-5'
 
 govuk_jenkins::jobs::search_relevancy_rank_evaluation::cron_schedule: '45 */3 * * *' # every three hours
-govuk_jenkins::jobs::search_google_analytics_etl::cron_schedule: 'H */6 * * *' # every six hours
+govuk_jenkins::jobs::search_google_analytics_etl::cron_schedule: 'H 2,8,14,20 * * *' # every six hours
 # Integration doesn't have a mirror
 govuk_jenkins::jobs::update_cdn_dictionaries::allow_deploy_to_mirror: false
 

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -229,7 +229,7 @@ govuk_jenkins::jobs::search_fetch_analytics_data::skip_page_traffic_load: true
 govuk_jenkins::jobs::search_fetch_analytics_data::cron_schedule: '30 8 * * 1-5'
 
 govuk_jenkins::jobs::search_relevancy_rank_evaluation::cron_schedule: '45 */3 * * *' # every three hours
-govuk_jenkins::jobs::search_google_analytics_etl::cron_schedule: 'H */6 * * *' # every six hours
+govuk_jenkins::jobs::search_google_analytics_etl::cron_schedule: 'H 0,6,12,18 * * *' # every six hours
 
 govuk_jenkins::jobs::smokey::environment: production_aws
 

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -196,7 +196,7 @@ govuk_jenkins::jobs::search_fetch_analytics_data::skip_page_traffic_load: true
 govuk_jenkins::jobs::search_fetch_analytics_data::cron_schedule: '30 8 * * 1-5'
 
 govuk_jenkins::jobs::search_relevancy_rank_evaluation::cron_schedule: '45 */3 * * *' # every three hours
-govuk_jenkins::jobs::search_google_analytics_etl::cron_schedule: 'H */6 * * *' # every six hours
+govuk_jenkins::jobs::search_google_analytics_etl::cron_schedule: 'H 1,7,13,19 * * *' # every six hours
 
 govuk_jenkins::jobs::smokey::environment: staging_aws
 


### PR DESCRIPTION
We were seeing rate limit exceeded errors for this job.

This runs the jobs at different times depending on the environment. All environments share the same quota, so by spreading the requests out a bit we should see fewer rate limit errors.

We also have a fix to handle the rate limit error: https://github.com/alphagov/search-api/pull/1771

https://trello.com/c/F5o5NPSq/1111-handle-hitting-rate-limit-for-google-analytics-etl