### PR TITLE
Add scss-lint-govuk repository to Jenkins CI

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -670,6 +670,7 @@ govuk_ci::master::pipeline_jobs:
   rails_translation_manager: {}
   router-data: {}
   rubocop-govuk: {}
+  scss-lint-govuk: {}
   seal: {}
   search-api: {}
   shared_mustache: {}


### PR DESCRIPTION
[scss-lint-govuk](https://github.com/alphagov/scss-lint-govuk) is a newly created repository and needs to be added to the Jenkins CI.