### PR TITLE
remove the `rds to s3` scripts on db_admin

### DIFF
--- a/modules/govuk/manifests/node/s_db_admin.pp
+++ b/modules/govuk/manifests/node/s_db_admin.pp
@@ -31,7 +31,12 @@ class govuk::node::s_db_admin(
   include ::govuk::node::s_base
   include govuk_env_sync
 
-  if $backup_s3_bucket {
+  # disable the backups of rds to s3 because these are not working, should use
+  # govuk_env_sync. We don't remove it in production in case of dependencies
+  # used by other tasks running on db_admin.
+  if ($::aws_environment != 'production') {
+    $ensure = 'absent'
+  } elsif ($backup_s3_bucket) {
     $ensure = 'present'
   } else {
     $ensure = 'absent'


### PR DESCRIPTION
disable the `rds to s3` scripts in staging and integragtion because these are not working, should use
govuk_env_sync. We don't remove it in production in case of dependencies
used by other tasks running on db_admin.