### PR TITLE
part 2 of removal of the rds_to_s3 script in all environment

### DIFF
--- a/modules/govuk/manifests/node/s_db_admin.pp
+++ b/modules/govuk/manifests/node/s_db_admin.pp
@@ -15,7 +15,6 @@
 #
 class govuk::node::s_db_admin(
   $apt_mirror_hostname,
-  $backup_s3_bucket     = undef,
   $mysql_db_host        = undef,
   $mysql_db_password    = undef,
   $mysql_db_user        = undef,
@@ -32,15 +31,9 @@ class govuk::node::s_db_admin(
   include govuk_env_sync
 
   # disable the backups of rds to s3 because these are not working, should use
-  # govuk_env_sync. We don't remove it in production in case of dependencies
-  # used by other tasks running on db_admin.
-  if ($::aws_environment != 'production') {
-    $ensure = 'absent'
-  } elsif ($backup_s3_bucket) {
-    $ensure = 'present'
-  } else {
-    $ensure = 'absent'
-  }
+  # govuk_env_sync.
+
+  $ensure = 'absent'
 
   apt::source { 'mongodb41':
     ensure       => 'absent',


### PR DESCRIPTION
Since there is no obvious failures, we remove now the rds_to_s3 script and associated artefacts in all environment (already done in staging and integration), should affect production only).

Another PR will be done to remove the code from the s_db_admin.pp manifest.