### PR TITLE
Ensure Python 3 is installed

### DIFF
--- a/modules/govuk/manifests/node/s_mapit.pp
+++ b/modules/govuk/manifests/node/s_mapit.pp
@@ -18,6 +18,8 @@ class govuk::node::s_mapit inherits govuk::node::s_base {
   ->
   class { 'govuk_postgresql::server::standalone': }
 
+  include govuk_python
+
   include collectd::plugin::memcached
   class { 'memcached':
     max_memory => '12%',

--- a/modules/govuk_ci/manifests/agent.pp
+++ b/modules/govuk_ci/manifests/agent.pp
@@ -43,6 +43,7 @@ class govuk_ci::agent(
   include ::govuk_jenkins::pipeline
   include ::govuk_jenkins::user
   include ::govuk_rbenv::all
+  include ::govuk_python
   include ::govuk_sysdig
   include ::govuk_testing_tools
   include ::yarn
@@ -65,7 +66,6 @@ class govuk_ci::agent(
   $deb_packages = [
     'jq',
     'libfreetype6-dev', # govuk-taxonomy-supervised-learning
-    'python3-dev', # govuk-taxonomy-supervised-learning
     'shellcheck',
   ]
 

--- a/modules/govuk_python/manifests/init.pp
+++ b/modules/govuk_python/manifests/init.pp
@@ -8,4 +8,6 @@ class govuk_python {
   }
 
   Class['python::install'] -> Package <| provider == 'pip' and ensure != absent |>
+
+  ensure_packages(['python3', 'python3-dev', 'python3-venv'])
 }


### PR DESCRIPTION
This shouldn't actually change any live behaviour because Python 3 comes pre-installed on Ubuntu but it's good to be explicit that we are now using Python 3 and require it.

We can't use the [Puppet Python module](https://github.com/voxpupuli/puppet-python) because it's written as a class and [classes are singletons in Puppet](https://github.com/voxpupuli/puppet-python/issues/79).

Apparently my former self predicted this moment...

<img width="770" alt="Screenshot 2019-11-06 at 11 58 19" src="https://user-images.githubusercontent.com/510498/68296530-bdebf380-008c-11ea-8290-76c9e4580fd9.png">

[Trello Card](https://trello.com/c/DzbcRdub/1501-5-deploy-mapit-using-python-3)