### PR TITLE
Remove python3-venv

### DIFF
--- a/modules/govuk_python/manifests/init.pp
+++ b/modules/govuk_python/manifests/init.pp
@@ -9,5 +9,5 @@ class govuk_python {
 
   Class['python::install'] -> Package <| provider == 'pip' and ensure != absent |>
 
-  ensure_packages(['python3', 'python3-dev', 'python3-venv'])
+  ensure_packages(['python3', 'python3-dev'])
 }


### PR DESCRIPTION
This follows on from 0aa821bb411400622b7bc3679b73fdfdff52bb27 it turns out that this package doesn't actually exist.

I thought it did because I got an error message:

```
thomasleese@ci-integration-ci-agent-3:~$ python3 -m venv myvenv
The virtual environment was not created successfully because ensurepip is not
available.  On Debian/Ubuntu systems, you need to install the python3-venv
package using the following command.

    apt-get install python3-venv

You may need to use sudo with that command.  After installing the python3-venv
package, recreate your virtual environment.
```

```
thomasleese@ci-integration-ci-agent-3:~$ sudo apt-get install python3-venv
Reading package lists... Done
Building dependency tree       
Reading state information... Done
E: Unable to locate package python3-venv
```

But instead we can use the `virtualenv` command:

```
thomasleese@ci-integration-ci-agent-3:~$ virtualenv -p python3 venv
Running virtualenv with interpreter /usr/bin/python3
Using base prefix '/usr'
New python executable in venv/bin/python3
Also creating executable in venv/bin/python
Installing setuptools, pip...done.
```

More background on this issue can be found here: https://bugs.launchpad.net/ubuntu/+source/python3.4/+bug/1290847
https://askubuntu.com/questions/879437/ensurepip-is-disabled-in-debian-ubuntu-for-the-system-python