### PR TITLE
Enable email-alert and publishing-api dashboards in AWS.

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1018,6 +1018,10 @@ grafana::dashboards::application_dashboards:
       - smartanswers
       - whitehall-frontend
   email-alert-frontend: {}
+  email-alert-api:
+    show_sidekiq_graphs: true
+    has_workers: true
+  email-alert-service: {}
   feedback: {}
   finder-frontend:
     show_external_request_time: true

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1053,6 +1053,11 @@ grafana::dashboards::application_dashboards:
     # No data in kibana
     show_controller_errors: false
     show_slow_requests: false
+  publishing-api:
+    show_sidekiq_graphs: true
+    has_workers: true
+    instance_prefix: 'publishing_api'
+    show_memcached: true
   router: {}
   router-api: {}
   search-api:


### PR DESCRIPTION
These services are already migrated to AWS in Staging and will be migrated in Production in the coming weeks. This enables us to continue to use the app dashboards during and after the migration.