### PR TITLE
Send staging emails to Amazon SES

### DIFF
--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -26,7 +26,7 @@ govuk::apps::email_alert_api::email_archive_s3_bucket: 'govuk-staging-email-aler
 govuk::apps::email_alert_api::email_archive_s3_enabled: true
 govuk::apps::email_alert_api::govuk_notify_template_id: '2844a647-6bf1-4b01-a25c-569d2cc00849'
 govuk::apps::email_alert_api::email_address_override: 'success@simulator.amazonses.com'
-govuk::apps::email_alert_api::email_address_override_whitelist_only: true
+govuk::apps::email_alert_api::email_address_override_whitelist_only: false
 govuk::apps::email_alert_api::delivery_request_threshold: "3000"
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::publisher::run_fact_check_fetcher: false


### PR DESCRIPTION
Removes whitelist only mode for staging, thus emails
in staging environment will be sent to Amazon SES, allowing
us to try changes to email-alert-api in staging with
realistic timings and get a better idea of what a load on
staging does to metrics