### PR TITLE
disable transition_db_admin custom backup in production

### DIFF
--- a/modules/govuk/manifests/node/s_transition_db_admin.pp
+++ b/modules/govuk/manifests/node/s_transition_db_admin.pp
@@ -17,11 +17,7 @@ class govuk::node::s_transition_db_admin(
   include govuk_env_sync
   include ::govuk::node::s_base
 
-  if ($::aws_environment == 'production' and $backup_s3_bucket) {
-    $ensure = 'present'
-  } else {
-    $ensure = 'absent'
-  }
+  $ensure = 'absent'
 
   apt::source { 'gof3r':
     ensure       => $ensure,


### PR DESCRIPTION
In previous [pr](https://github.com/alphagov/govuk-puppet/pull/9806), we disabled the `rds to s3` job in integration and staging because it was redundant with govuk_env_sync. This PR removes this redundant feature in production now we know there is no adverse effect.