### PR TITLE
Fixes for aws-iam-key-age check

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -332,6 +332,7 @@ monitoring::checks::sidekiq::enable_support_check: false
 monitoring::checks::pingdom::enable: false
 monitoring::checks::ses::region: 'eu-west-1'
 monitoring::checks::rds::region: 'eu-west-1'
+monitoring::checks::aws_iam_key::enabled: true
 monitoring::checks::aws_iam_key::region: 'eu-west-1'
 
 monitoring::checks::lb::region: 'eu-west-1'

--- a/modules/monitoring/manifests/checks/aws_iam_key.pp
+++ b/modules/monitoring/manifests/checks/aws_iam_key.pp
@@ -21,9 +21,9 @@ class monitoring::checks::aws_iam_key (
   $access_key = undef,
   $secret_key = undef,
   $enabled = true,
+  $max_aws_iam_key_age = 90,
 ) {
   if $enabled and $::aws_migration {
-    $max_age = 365
 
     exec { 'install aws-sdk-iam into rbenv':
       path    => ['/usr/lib/rbenv/shims', '/usr/local/bin', '/usr/bin', '/bin'],
@@ -44,8 +44,8 @@ class monitoring::checks::aws_iam_key (
       check_command       => 'check_aws_iam_key_age',
       use                 => 'govuk_normal_priority',
       host_name           => $::fqdn,
-      check_interval      => 43200,
-      service_description => 'At least 1 AWS IAM Key is older then max_age days and needs rotating',
+      check_interval      => 12h,
+      service_description => "At least 1 AWS IAM Key is older then ${max_aws_iam_key_age} days and needs rotating",
       notes_url           => monitoring_docs_url(rotate-old-aws-iam-key),
       require             => Icinga::Check_config['check_aws_iam_key_age'],
     }

--- a/modules/monitoring/manifests/checks/aws_iam_key.pp
+++ b/modules/monitoring/manifests/checks/aws_iam_key.pp
@@ -20,7 +20,7 @@ class monitoring::checks::aws_iam_key (
   $region = undef,
   $access_key = undef,
   $secret_key = undef,
-  $enabled = true,
+  $enabled = false,
   $max_aws_iam_key_age = 90,
 ) {
   if $enabled and $::aws_migration {

--- a/modules/monitoring/manifests/checks/aws_iam_key.pp
+++ b/modules/monitoring/manifests/checks/aws_iam_key.pp
@@ -25,8 +25,14 @@ class monitoring::checks::aws_iam_key (
   if $enabled and $::aws_migration {
     $max_age = 365
 
+    exec { 'install aws-sdk-iam into rbenv':
+      path    => ['/usr/lib/rbenv/shims', '/usr/local/bin', '/usr/bin', '/bin'],
+      command => 'gem install aws-sdk-iam',
+      unless  => 'gem list -i aws-sdk-iam',
+    }
+
     icinga::plugin { 'check_aws_iam_key_age':
-      source  => 'puppet:///modules/monitoring/usr/lib/nagios/plugins/check_aws_iam_key_age',
+      source => 'puppet:///modules/monitoring/usr/lib/nagios/plugins/check_aws_iam_key_age',
     }
 
     icinga::check_config { 'check_aws_iam_key_age':

--- a/modules/monitoring/templates/check_aws_iam_key_age.cfg.erb
+++ b/modules/monitoring/templates/check_aws_iam_key_age.cfg.erb
@@ -1,4 +1,4 @@
 define command {
     command_name check_aws_iam_key_age
-    command_line /usr/lib/nagios/plugins/check_aws_aws_iam_key_age --key <%= @access_key %> --secret <%= @secret_key %> --region <%= @region %> --days <%= @max_age %>
+    command_line /usr/lib/nagios/plugins/check_aws_aws_iam_key_age --key <%= @access_key %> --secret <%= @secret_key %> --region <%= @region %> --days <%= @max_aws_iam_key_age %>
 }


### PR DESCRIPTION
* Install the `aws-sdk-iam'` gem
* Rename max_age to max_aws_iam_key_age and default to 90 days
* Only check in the AWS integration environment