### PR TITLE
Remove duplicate aws in check_aws_iam_key_age command

### DIFF
--- a/modules/monitoring/templates/check_aws_iam_key_age.cfg.erb
+++ b/modules/monitoring/templates/check_aws_iam_key_age.cfg.erb
@@ -1,4 +1,4 @@
 define command {
     command_name check_aws_iam_key_age
-    command_line /usr/lib/nagios/plugins/check_aws_aws_iam_key_age --key <%= @access_key %> --secret <%= @secret_key %> --region <%= @region %> --days <%= @max_aws_iam_key_age %>
+    command_line /usr/lib/nagios/plugins/check_aws_iam_key_age --key <%= @access_key %> --secret <%= @secret_key %> --region <%= @region %> --days <%= @max_aws_iam_key_age %>
 }


### PR DESCRIPTION
`check_aws_aws_iam_key_age` isn't the right name...