### PR TITLE
Stop restarting rsyslog unnecessarily

### DIFF
--- a/modules/govuk_cdnlogs/manifests/init.pp
+++ b/modules/govuk_cdnlogs/manifests/init.pp
@@ -84,14 +84,19 @@ class govuk_cdnlogs (
     require => File['/etc/logrotate.cdn_logs_hourly.conf'],
   }
 
+  $check_rsyslog_status_bouncer_ensure = $bouncer_monitoring_enabled ? {
+    true    => present,
+    default => absent,
+  }
+
   file { '/usr/local/bin/check_rsyslog_status_bouncer':
-    ensure  => present,
+    ensure  => $check_rsyslog_status_bouncer_ensure,
     mode    => '0755',
     content => template('govuk_cdnlogs/usr/local/bin/check_rsyslog_status_bouncer.sh.erb'),
   }
 
   cron { 'check_rsyslog_status_bouncer':
-    ensure      => present,
+    ensure      => $check_rsyslog_status_bouncer_ensure,
     environment => ["MAILTO=''"],
     minute      => '*/5',
     command     => '/usr/local/bin/check_rsyslog_status_bouncer',

--- a/spec/fixtures/hieradata/common.yaml
+++ b/spec/fixtures/hieradata/common.yaml
@@ -39,7 +39,7 @@ govuk_app_enable_services: false
 govuk_beat::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 govuk_cdnlogs::govuk_monitoring_enabled: false
-govuk_cdnlogs::bouncer_monitoring_enabled: falseA
+govuk_cdnlogs::bouncer_monitoring_enabled: false
 
 govuk_docker::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 


### PR DESCRIPTION
The bouncer CDN log is only present on a minority of the monitoring
machines, and where it's not present, rsyslog is currently restarted
every 5 minutes. Why, I don't know, but it's not going to magically
make the file appear.

Make this slightly less awful by removing this cron job from the
monitoring machines where bouncer monitoring isn't enabled (as I guess
that means the log file shouldn't be present).