### PR TITLE
Add Check For VPN Connectivity Between UK Cloud/Licensify and AWS - DO NOT MERGE UNTIL MIGRATION DAY

### DIFF
--- a/modules/icinga/files/etc/icinga/conf.d/check_uk_cloud_vpn.cfg
+++ b/modules/icinga/files/etc/icinga/conf.d/check_uk_cloud_vpn.cfg
@@ -1,0 +1,6 @@
+define command {
+  # ARG1 = Hostname to connect to (e.g. www.civicaepay.co.uk )
+  # ARG2 = The URI (e.g. /NottinghamXML/QueryPayments/QueryPayments.asmx )
+  command_name check_uk_cloud_vpn
+  command_line /usr/lib/nagios/plugins/check_http -H $ARG1$ -u '$ARG2$' -e '200' -S
+}

--- a/modules/monitoring/manifests/checks.pp
+++ b/modules/monitoring/manifests/checks.pp
@@ -161,6 +161,14 @@ class monitoring::checks (
     }
   }
 
+  if ($::aws_migration and $::aws_environment == 'production') {
+    icinga::check { 'check_uk_cloud_vpn_up':
+      check_command       => 'check_uk_cloud_vpn!www.civicaepay.co.uk!/NottinghamXML/QueryPayments/QueryPayments.asmx',
+      host_name           => $::fqdn,
+      service_description => 'check that the VPN between UKCloud/Licensify and AWS is still up',
+    }
+  }
+
   # In AWS this is liable to happen more often as machines come and go
   unless $::aws_migration {
     icinga::check_config { 'check_puppetdb_ssh_host_keys':


### PR DESCRIPTION
This check attempts to connect www.civicaepay.co.uk from the monitoring
machine in AWS. If it fails it will cause a critical alert.

The check uses the standard check_http plugin. More information about it is
available here:
https://www.monitoring-plugins.org/doc/man/check_http.html