### PR TITLE
setup database syncs for AWS Staging assets manager

### DIFF
--- a/hieradata/node/mongo-2.backend.publishing.service.gov.uk.yaml
+++ b/hieradata/node/mongo-2.backend.publishing.service.gov.uk.yaml
@@ -1,3 +1,16 @@
 mongodb::backup::s3_backups: true
 mongodb::s3backup::cron::realtime_hour: '*'
 mongodb::s3backup::cron::realtime_minute: '*/30'
+
+govuk_env_sync::tasks:
+  "push_govuk_assets_production":
+    ensure: "present"
+    hour: "1"
+    minute: "00"
+    action: "push"
+    dbms: "mongo"
+    storagebackend: "s3"
+    database: "govuk_assets_production"
+    temppath: "/var/lib/s3backup/.dumps"
+    url: "govuk-production-database-backups"
+    path: "mongo-normal"

--- a/hieradata_aws/class/integration/db_admin.yaml
+++ b/hieradata_aws/class/integration/db_admin.yaml
@@ -260,3 +260,14 @@ govuk_env_sync::tasks:
   "pull_licensify_refdata_staging_daily":
     <<: *pull_licensify
     database: "licensify-refdata"
+  "pull_govuk_assets_production":
+    ensure: "present"
+    hour: "2"
+    minute: "00"
+    action: "pull"
+    dbms: "documentdb"
+    storagebackend: "s3"
+    database: "govuk_assets_production"
+    temppath: "/tmp/govuk_assets_production"
+    url: "govuk-production-database-backups"
+    path: "mongo-normal"


### PR DESCRIPTION
In order to try the migration of mongodb to documentdb for assets-manager, we need to configure the govuk_env_sync to:
1. push assets database from Carrenza production to the right S3 bucket
2. pull assets database in (1) from S3 to the documentdb cluster

This [PR](https://github.com/alphagov/govuk-secrets/pull/829) is also needed so that govuk_env_sync has access to the documentdb cluster.