### PR TITLE
Fix the trend line on the Platform Health Whitehall errors dashboard

### DIFF
--- a/modules/grafana/files/dashboards/platform_health_Q3_19-20_whitehall_errors.json
+++ b/modules/grafana/files/dashboards/platform_health_Q3_19-20_whitehall_errors.json
@@ -74,7 +74,7 @@
             },
             {
               "refId": "B",
-              "target": "alias(summarize(summarize(stats.gauges.sentry-error-count-last-hour.whitehall, '1d', 'sum', true), '30d', 'avg', true), '30 day average')"
+              "target": "alias(movingAverage(summarize(stats.gauges.sentry-error-count-last-hour.whitehall, '1d', 'sum', true), '30d'), '30 day average')"
             },
             {
               "hide": true,


### PR DESCRIPTION
Previously each of the data points represented the 30 day average, but
at the mid point of a potentially incomplete 30 day window. This is
far to open to interpretation.

Rather than that, use the movingAverage function to show the 30 day
moving average, which results in more datapoints, but something that I
think is easier to interpret.

## Before

![image](https://user-images.githubusercontent.com/1130010/68776099-6ec33700-0627-11ea-9a25-f881dde75dd0.png)

## After

![image](https://user-images.githubusercontent.com/1130010/68776121-77b40880-0627-11ea-99de-12db1bbb3fad.png)
