### PR TITLE
adjust the govuk_env_sync for licensify in AWS

### DIFF
--- a/hieradata_aws/class/integration/db_admin.yaml
+++ b/hieradata_aws/class/integration/db_admin.yaml
@@ -255,8 +255,9 @@ govuk_env_sync::tasks:
   "pull_licensify_audit_staging_daily":
     <<: *pull_licensify
     database: "licensify-audit"
-    hour: "6"
-    minute: "0"
+    ensure: "absent"
   "pull_licensify_refdata_staging_daily":
     <<: *pull_licensify
     database: "licensify-refdata"
+    hour: "6"
+    minute: "30"

--- a/hieradata_aws/class/integration/licensing_mongo.yaml
+++ b/hieradata_aws/class/integration/licensing_mongo.yaml
@@ -1,6 +1,6 @@
 govuk_env_sync::tasks:
   push_licensify: &push_licensify
-    ensure: present
+    ensure: absent
     hour: '4'
     minute: '0'
     action: push

--- a/hieradata_aws/class/staging/db_admin.yaml
+++ b/hieradata_aws/class/staging/db_admin.yaml
@@ -117,6 +117,22 @@ govuk_env_sync::tasks:
   "pull_licensify_refdata_production_daily":
     <<: *pull_licensify
     database: "licensify-refdata"
+  "push_licensify_staging_daily": &push_licensify_staging
+    ensure: "present"
+    hour: "5"
+    minute: "15"
+    action: "push"
+    dbms: "documentdb"
+    storagebackend: "s3"
+    database: "licensify"
+    temppath: "/tmp/licensify_staging"
+    url: "govuk-staging-database-backups"
+    path: "mongo-licensing"
+  "push_licensify_refdata_staging_daily":
+    <<: *push_licensify_staging
+    database: "licensify-refdata"
+    hour: "5"
+    minute: "45"
   "pull_mysql_whitehall_production_daily":
     ensure: "present"
     hour: "3"


### PR DESCRIPTION
Changes made:

1. stop backing up integration licensify db because there is no training environment to pull from anymore.

2. start pushing the staging licensify db which for some reason was not being done. This will ensure integration is up to date because it pulls from the staging s3 bucket