### PR TITLE
Increase the unicorn worker processes for collections

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -175,6 +175,7 @@ task :check_consistency_between_aws_and_carrenza do
     govuk::apps::ckan::db::rds
     govuk::apps::ckan::s3_aws_access_key_id
     govuk::apps::ckan::s3_aws_secret_access_key
+    govuk::apps::collections::unicorn_worker_processes
     govuk::apps::collections::nagios_memory_critical
     govuk::apps::collections::nagios_memory_warning
     govuk::apps::content_audit_tool::db::allow_auth_from_lb

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -395,6 +395,7 @@ govuk::apps::ckan::gunicorn_worker_processes: "8"
 govuk::apps::ckan::s3_aws_access_key_id: "%{hiera('s3_aws_access_key_id')}"
 govuk::apps::ckan::s3_aws_secret_access_key: "%{hiera('s3_aws_secret_access_key')}"
 
+govuk::apps::collections::unicorn_worker_processes: 4
 govuk::apps::collections::nagios_memory_warning: 900
 govuk::apps::collections::nagios_memory_critical: 1000
 

--- a/modules/govuk/manifests/apps/collections.pp
+++ b/modules/govuk/manifests/apps/collections.pp
@@ -11,6 +11,10 @@
 # [*port*]
 #   What port should the app run on?
 #
+# [*unicorn_worker_processes*]
+#   The number of unicorn worker processes to run
+#   Default: undef
+#
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
@@ -33,6 +37,7 @@
 class govuk::apps::collections(
   $vhost = 'collections',
   $port = '3070',
+  $unicorn_worker_processes = undef,
   $secret_key_base = undef,
   $sentry_dsn = undef,
   $nagios_memory_warning = undef,
@@ -40,16 +45,17 @@ class govuk::apps::collections(
   $email_alert_api_bearer_token = undef,
 ) {
   govuk::app { 'collections':
-    app_type               => 'rack',
-    port                   => $port,
-    health_check_path      => '/topic/oil-and-gas',
-    log_format_is_json     => true,
-    asset_pipeline         => true,
-    asset_pipeline_prefix  => 'collections',
-    vhost                  => $vhost,
-    nagios_memory_warning  => $nagios_memory_warning,
-    nagios_memory_critical => $nagios_memory_critical,
-    sentry_dsn             => $sentry_dsn,
+    app_type                 => 'rack',
+    port                     => $port,
+    unicorn_worker_processes => $unicorn_worker_processes,
+    health_check_path        => '/topic/oil-and-gas',
+    log_format_is_json       => true,
+    asset_pipeline           => true,
+    asset_pipeline_prefix    => 'collections',
+    vhost                    => $vhost,
+    nagios_memory_warning    => $nagios_memory_warning,
+    nagios_memory_critical   => $nagios_memory_critical,
+    sentry_dsn               => $sentry_dsn,
   }
 
   Govuk::App::Envvar {


### PR DESCRIPTION
As we're seeing warnings about more than 2 established connections to
collections. The frontend machine seems to have enough memory, so
increase the number of workers.