### PR TITLE
add asset manager in AWS staging

### DIFF
--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -17,6 +17,7 @@ node_class: &node_class
       - asset_env_sync
   backend:
     apps:
+      - asset-manager
       - cache-clearing-service
       - canary-backend
       - content-data-admin


### PR DESCRIPTION
This is a dependency of whitehall which is being migrated from carrenza to aws in staging.