### PR TITLE
Prevent Jenkins rebooting during data sync jobs

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/copy_attachments_to_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_attachments_to_integration.yaml.erb
@@ -35,7 +35,7 @@
             cd "${WORKSPACE}"
 
             echo "Syncing attachments"
-            JOBLIST=attachments bash sync production integration
+            JOBLIST=attachments /usr/local/bin/with_reboot_lock bash sync production integration
     publishers:
       - trigger-parameterized-builds:
         - project: Success_Passive_Check

--- a/modules/govuk_jenkins/templates/jobs/copy_attachments_to_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_attachments_to_staging.yaml.erb
@@ -35,7 +35,7 @@
             cd "${WORKSPACE}"
 
             echo "Syncing attachments"
-            JOBLIST=attachments bash sync production staging
+            JOBLIST=attachments /usr/local/bin/with_reboot_lock bash sync production staging
     publishers:
       - trigger-parameterized-builds:
         - project: Success_Passive_Check

--- a/modules/govuk_jenkins/templates/jobs/copy_data_from_staging_to_aws.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_from_staging_to_aws.yaml.erb
@@ -48,7 +48,7 @@
             set +e
 
             echo "Running Data Sync"
-            bash sync staging aws-staging
+            /usr/local/bin/with_reboot_lock bash sync staging aws-staging
             EXITCODE=$?
 
             exit $EXITCODE

--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
@@ -51,7 +51,7 @@
             sed -i "s/PG_TR_DST_ENV_SYNC_PW=PLACEHOLDER/PG_TR_DST_ENV_SYNC_PW='<%= @pg_tr_dst_env_sync_pw %>'/" scripts/sync-transition-postgresql.sh
 
             echo "Syncing data"
-            bash sync production integration
+            /usr/local/bin/with_reboot_lock bash sync production integration
     publishers:
       - trigger-parameterized-builds:
         - project: Success_Passive_Check

--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_staging.yaml.erb
@@ -50,7 +50,7 @@
             set +e
 
             echo "Running Data Sync"
-            bash sync production staging
+            /usr/local/bin/with_reboot_lock bash sync production staging
             EXITCODE=$?
 
             exit $EXITCODE

--- a/modules/govuk_jenkins/templates/jobs/copy_licensify_data_to_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_licensify_data_to_staging.yaml.erb
@@ -37,7 +37,7 @@
             set +e
 
             echo "Running Data Sync"
-            bash sync production staging
+            /usr/local/bin/with_reboot_lock bash sync production staging
             EXITCODE=$?
 
             exit $EXITCODE

--- a/modules/govuk_jenkins/templates/jobs/copy_sanitised_whitehall_database.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_sanitised_whitehall_database.yaml.erb
@@ -34,7 +34,7 @@
 
             cd "$WORKSPACE/whitehall/"
             echo "Sanitising whitehall database"
-            ./sanitise-and-sync-db.sh "<%= @whitehall_mysql_password %>" "<%= @mysql_dst_root_pw %>"
+            /usr/local/bin/with_reboot_lock ./sanitise-and-sync-db.sh "<%= @whitehall_mysql_password %>" "<%= @mysql_dst_root_pw %>"
     publishers:
       - trigger-parameterized-builds:
         - project: Success_Passive_Check


### PR DESCRIPTION
This protects these jobs from Jenkins automatically doing an unattended reboot and killing them. This ensures the jobs complete, then Jenkins will reboot after they're done.