### PR TITLE
Remove redundant logging

### DIFF
--- a/modules/nginx/templates/etc/nginx/nginx.conf.erb
+++ b/modules/nginx/templates/etc/nginx/nginx.conf.erb
@@ -64,7 +64,6 @@ http {
                          '"govuk_request_id": "$http_govuk_request_id", '
                          '"govuk_original_url": "$http_govuk_original_url", '
                          '"govuk_dependency_resolution_source_content_id": "$http_govuk_dependency_resolution_source_content_id", '
-                         '"govuk_abtest_educationnavigation": "$http_govuk_abtest_educationnavigation", '
                          '"varnish_id": "$http_x_varnish", '
                          '"ssl_protocol": "$ssl_protocol", '
 			 '"ssl_cipher": "$ssl_cipher", '


### PR DESCRIPTION
[In ancient times](https://www.youtube.com/watch?v=qAXzzHM8zLw),
Hundreds of years before the dawn of history
Lived a strange race of people, the Finding Things team

No one knows who they were or what they were doing
But their legacy remains
Hewn into the living rock, of govuk-puppet

---

I think this header was logged as part of the initial AB test on GOV.UK.
The Fastly config has long since disappeared, but we're still recording empty values for a header that is no longer present and sending them to logstash (and paying for them in Kibana).