### PR TITLE
Add --ignore-missing to the delivery_attempt_status_check

### DIFF
--- a/modules/govuk/manifests/apps/email_alert_api/delivery_attempt_status_check.pp
+++ b/modules/govuk/manifests/apps/email_alert_api/delivery_attempt_status_check.pp
@@ -19,6 +19,7 @@ define govuk::apps::email_alert_api::delivery_attempt_status_check(
     ensure    => $ensure,
     host_name => $::fqdn,
     target    => "sum(stats.govuk.app.email-alert-api.*.delivery_attempt.status.${title})",
+    args      => '--ignore-missing',
     warning   => '0.5',
     critical  => '1',
     from      => '1hour',


### PR DESCRIPTION
For the Email Alert API. This'll mean that when there's no data,
because there are no failures to count, then the check won't fail.