### PR TITLE
Change the delivery attempt status check to use stats_counts

### DIFF
--- a/modules/govuk/manifests/apps/email_alert_api/delivery_attempt_status_check.pp
+++ b/modules/govuk/manifests/apps/email_alert_api/delivery_attempt_status_check.pp
@@ -18,7 +18,7 @@ define govuk::apps::email_alert_api::delivery_attempt_status_check(
   @@icinga::check::graphite { "email-alert-api-delivery-attempt-${title}":
     ensure    => $ensure,
     host_name => $::fqdn,
-    target    => "sum(stats.govuk.app.email-alert-api.*.delivery_attempt.status.${title})",
+    target    => "sum(stats_counts.govuk.app.email-alert-api.*.delivery_attempt.status.${title})",
     args      => '--ignore-missing',
     warning   => '0.5',
     critical  => '1',


### PR DESCRIPTION
Rather than stats. There's data showing up in both places in Graphite,
but as this is a counter, I believe this is where the data should be
being written to, and read from.