### PR TITLE
[DO NOT MERGE] Remove old RDS-only cert bundle.

### DIFF
--- a/modules/govuk/manifests/node/s_base.pp
+++ b/modules/govuk/manifests/node/s_base.pp
@@ -119,6 +119,11 @@ class govuk::node::s_base (
     ensure => absent,
   }
 
+  # Old RDS-only cert bundle, superseded by rds-combined-ca-bundle.pem.
+  file { '/etc/ssl/certs/rds_cacert.pem':
+    ensure  => absent,
+  }
+
   file { '/etc/ssl/certs/rds-combined-ca-bundle.pem':
     ensure => present,
     owner  => 'root',


### PR DESCRIPTION
[DO NOT MERGE] until alphagov/router-api#269 goes to Production.

Once alphagov/router-api#269 is in Production, `rds_cacert.pem` will no longer be in use. Remove it to avoid any potential confusion.

The replacement cert bundle (which is a superset of this one) was added in #9839.