### PR TITLE
Add an alert when we go above our Notify daily limit

### DIFF
--- a/modules/govuk/manifests/apps/email_alert_api/checks.pp
+++ b/modules/govuk/manifests/apps/email_alert_api/checks.pp
@@ -17,4 +17,13 @@ class govuk::apps::email_alert_api::checks(
   delivery_attempt_status_check { 'technical_failure':
     ensure => $technical_failure_ensure,
   }
+
+  @@icinga::check::graphite { 'email-alert-api-notify-email-send-request-success':
+    host_name => $::fqdn,
+    target    => 'summarize(sum(stats_counts.govuk.app.email-alert-api.*.notify.email_send_request.success),"1day")',
+    warning   => '3200000', # 4,000,000 * 0.8
+    critical  => '3600000', # 4,000,000 * 0.9
+    from      => '24hours',
+    desc      => 'High number of email send requests',
+  }
 }


### PR DESCRIPTION
I think the graphite query is correct but it's hard to know for sure until this is deployed to production because we sent very few emails in the other environments.

I also think we don't need to have the `summarize` method because the Icinga check will perform a sum over the `from` value (which is set to 24 hours) however without the `summarize` the linked to graph could be confusing as the individual numbers across the day will be far below the daily thresholds.

[Trello Card](https://trello.com/c/g9DDus4o/1531-3-set-up-an-alert-for-when-we-start-reaching-our-total-number-of-emails-for-the-day)