### PR TITLE
Use transformNull in the delivery attempt status Icinga check

### DIFF
--- a/modules/govuk/manifests/apps/email_alert_api/delivery_attempt_status_check.pp
+++ b/modules/govuk/manifests/apps/email_alert_api/delivery_attempt_status_check.pp
@@ -18,7 +18,7 @@ define govuk::apps::email_alert_api::delivery_attempt_status_check(
   @@icinga::check::graphite { "email-alert-api-delivery-attempt-${title}":
     ensure    => $ensure,
     host_name => $::fqdn,
-    target    => "sum(stats_counts.govuk.app.email-alert-api.*.delivery_attempt.status.${title})",
+    target    => "transformNull(sum(stats_counts.govuk.app.email-alert-api.*.delivery_attempt.status.${title}),0)",
     args      => '--ignore-missing',
     warning   => '0.5',
     critical  => '1',


### PR DESCRIPTION
For the Email Alert API. This means that when the metric exists, but
there's no data, the check won't fail. I previously tried adding
--ignore-missing to the args, but I think this just means the check
doesn't fail if the metric is missing, not present but with no data
points.