### PR TITLE
Shorten from period of email-alert-api request check

### DIFF
--- a/modules/govuk/manifests/apps/email_alert_api/checks.pp
+++ b/modules/govuk/manifests/apps/email_alert_api/checks.pp
@@ -23,7 +23,7 @@ class govuk::apps::email_alert_api::checks(
     target    => 'summarize(sum(stats_counts.govuk.app.email-alert-api.*.notify.email_send_request.success),"1day")',
     warning   => '3200000', # 4,000,000 * 0.8
     critical  => '3600000', # 4,000,000 * 0.9
-    from      => '24hours',
+    from      => '3hours',
     desc      => 'High number of email send requests',
   }
 }


### PR DESCRIPTION
Because we `summarize` the values over the last 24 hours, we only need to check a more recent time, and if you look back 24 hours we end up summing the results for today and yesterday (unless you're looking exactly at midnight).

I picked 3 hours because it matches this similar check added to look over a value summarised over a day: https://github.com/alphagov/govuk-puppet/commit/40bb96834c57c003287d048cb840769fb8aca39d

[Trello Card](https://trello.com/c/g9DDus4o/1531-3-set-up-an-alert-for-when-we-start-reaching-our-total-number-of-emails-for-the-day)