### PR TITLE
Change the way we resolve an hostname from an instance id

### DIFF
--- a/modules/govuk_scripts/templates/govuk_node_list_aws.erb
+++ b/modules/govuk_scripts/templates/govuk_node_list_aws.erb
@@ -95,7 +95,7 @@ def get_hostname_by_id(instance_id):
     client = boto3.client('ec2', region_name=region)
     response = client.describe_instances(InstanceIds=[instance_id])
     key = 'PrivateDnsName'
-    host = response['Reservations'][0]['Instances'][0]['NetworkInterfaces'][0]
+    host = response['Reservations'][0]['Instances'][0]
 
     if not key in host:
         print("The instance attribute {} does not exist".format(key))


### PR DESCRIPTION
The get_hostname_by_id function get the hostname of an instance
by looking up the value of the key 'PrivateDnsName' for the first
Interface of the instance.
For instances that have more than one interface this can return
unexpected results, it is also unnecessary as the instance has
itself a 'PrivateDnsName' key that will return the result we
expect.