### PR TITLE
Scope email-alert-api checks to Carrenza

### DIFF
--- a/modules/monitoring/manifests/checks.pp
+++ b/modules/monitoring/manifests/checks.pp
@@ -46,7 +46,9 @@ class monitoring::checks (
   include monitoring::checks::cloudwatch
   include monitoring::checks::aws_iam_key
 
-  include govuk::apps::email_alert_api::checks
+  if $::aws_migration == undef {
+    include govuk::apps::email_alert_api::checks
+  }
 
   $app_domain = hiera('app_domain')
 


### PR DESCRIPTION
We're currently getting an 'UNKNOWN' alert about this check in
AWS production. The production migration for email-alert-api isn't
imminent, so it seems best to scope this check for the time being.