### PR TITLE
Add ignore missing to email-alert-api check

### DIFF
--- a/modules/govuk/manifests/apps/email_alert_api/checks.pp
+++ b/modules/govuk/manifests/apps/email_alert_api/checks.pp
@@ -21,6 +21,7 @@ class govuk::apps::email_alert_api::checks(
   @@icinga::check::graphite { 'email-alert-api-notify-email-send-request-success':
     host_name => $::fqdn,
     target    => 'summarize(sum(stats_counts.govuk.app.email-alert-api.*.notify.email_send_request.success),"1day")',
+    args      => '--ignore-missing',
     warning   => '3200000', # 4,000,000 * 0.8
     critical  => '3600000', # 4,000,000 * 0.9
     from      => '3hours',


### PR DESCRIPTION
Similar to what we've done for the delivery attempt status checks, this should mean the alert doesn't error when there isn't any data.