### PR TITLE
Don't reboot cache machines automatically

### DIFF
--- a/hieradata_aws/class/cache.yaml
+++ b/hieradata_aws/class/cache.yaml
@@ -1,4 +1,8 @@
 ---
+
+govuk_safe_to_reboot::can_reboot: 'careful'
+govuk_safe_to_reboot::reason: 'Handles requests, traffic should be drained before restarting'
+
 govuk::apps::authenticating_proxy::mongodb_nodes:
   - 'router-backend-1'
   - 'router-backend-2'


### PR DESCRIPTION
To avoid failing requests, the cache machine that is to be rebooted
needs to be removed from the relevant AWS things (Target Groups, ELBs,
...). That doesn't happen automatically, so don't reboot the machines
automatically either.