### PR TITLE
Switch the gor running check to the 'inoffice' period

### DIFF
--- a/modules/govuk_gor/manifests/init.pp
+++ b/modules/govuk_gor/manifests/init.pp
@@ -80,6 +80,7 @@ class govuk_gor(
   @@icinga::check { "check_gor_running_${::hostname}":
     ensure              => $nagios_ensure,
     check_command       => 'check_nrpe!check_proc_running!goreplay',
+    check_period        => 'inoffice',
     host_name           => $::fqdn,
     service_description => 'gor running',
     notes_url           => monitoring_docs_url(gor),


### PR DESCRIPTION
We disable gor overnight, so change the check to only check during the
'inoffice' period, so that it doesn't fail overnight.