### PR TITLE
Limit CKAN to 1000 concurrent Postgres connections.

### DIFF
--- a/modules/govuk/manifests/apps/ckan/db.pp
+++ b/modules/govuk/manifests/apps/ckan/db.pp
@@ -31,6 +31,7 @@ class govuk::apps::ckan::db (
   govuk_postgresql::db { 'ckan_production':
     user                    => $user,
     password                => $password,
+    connection_limit        => '1000',
     allow_auth_from_backend => true,
     backend_ip_range        => $backend_ip_range,
     allow_auth_from_lb      => $allow_auth_from_lb,
@@ -42,6 +43,7 @@ class govuk::apps::ckan::db (
   govuk_postgresql::db { 'ckan_pycsw_production':
     user                    => $user,
     password                => $password,
+    connection_limit        => '1000',
     allow_auth_from_backend => true,
     backend_ip_range        => $backend_ip_range,
     allow_auth_from_lb      => $allow_auth_from_lb,

--- a/modules/govuk_postgresql/manifests/db.pp
+++ b/modules/govuk_postgresql/manifests/db.pp
@@ -25,6 +25,10 @@
 # differs from postgresql::server::db which has a default of 'postgres'
 # Default: $user
 #
+# [*connection_limit*]
+# An optional limit on concurrent connections for the user (role).
+# Default: '-1' (no limit)
+#
 # [*encoding*]
 # An optional database encoding.
 # Default: UTF8
@@ -64,6 +68,7 @@ define govuk_postgresql::db (
     $password,
     $database                = undef,
     $owner                   = undef,
+    $connection_limit        = '-1',
     $encoding                = 'UTF8',
     $extensions              = [],
     $allow_auth_from_backend = false,
@@ -96,9 +101,10 @@ define govuk_postgresql::db (
 
     if ! defined(Postgresql::Server::Role[$user]) {
         @postgresql::server::role { $user:
-            password_hash => $password_hash,
-            tag           => 'govuk_postgresql::server::not_slave',
-            rds           => $rds,
+            password_hash    => $password_hash,
+            tag              => 'govuk_postgresql::server::not_slave',
+            rds              => $rds,
+            connection_limit => $connection_limit,
         }
     }
 


### PR DESCRIPTION
CKAN has recently suffered three incidents where a reindexing job failed
in such as way as to accumulate thousands of concurrent connections to
the shared RDS Postgres, preventing other apps (as well as itself) from
connecting.

This limits the blast radius of such failures to CKAN indexing.

The CKAN / data.gov.uk front end (which runs in GOV.UK PaaS) is not
affected by this change.