### PR TITLE
define licensify jenkins deploy node app

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -130,6 +130,8 @@ govuk::node::s_graphite::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 govuk_java::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
+# Licensify is a special case because it is not a regular govuk app
+# so we only define a Jenkins deploy node app job for it.
 govuk_jenkins::deploy_all_apps::apps_on_nodes:
   <<: *node_class
   licensing_frontend:

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -99,8 +99,17 @@ node_class: &node_class
 govuk::node::s_base::node_apps:
   <<: *node_class
 
+# Licensify is a special case because it is not a regular govuk app
+# so we only define a Jenkins deploy node app job for it.
 govuk_jenkins::deploy_all_apps::apps_on_nodes:
   <<: *node_class
+  licensing_frontend:
+    apps:
+      - licensify
+  licensing_backend:
+    apps:
+      - licensify-admin
+      - licensify-feed
 
 govuk::apps::asset_manager::aws_s3_bucket_name: 'govuk-assets-production'
 govuk::apps::asset_manager::aws_region: 'eu-west-1'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -110,8 +110,17 @@ node_class: &node_class
 govuk::node::s_base::node_apps:
   <<: *node_class
 
+# Licensify is a special case because it is not a regular govuk app
+# so we only define a Jenkins deploy app job for it.
 govuk_jenkins::deploy_all_apps::apps_on_nodes:
   <<: *node_class
+  licensing_frontend:
+    apps:
+      - licensify
+  licensing_backend:
+    apps:
+      - licensify-admin
+      - licensify-feed
 
 govuk::apps::asset_manager::aws_s3_bucket_name: 'govuk-assets-staging'
 govuk::apps::asset_manager::aws_region: 'eu-west-1'


### PR DESCRIPTION
Licensify is a special case because it is not a regular govuk app
so we only define a Jenkins deploy node app job for it.