### PR TITLE
Disable the crawler worker checks during the data sync

### DIFF
--- a/modules/govuk/manifests/app.pp
+++ b/modules/govuk/manifests/app.pp
@@ -92,6 +92,10 @@
 #   Additional contact groups to pass to the icinga::checks for this
 #   application.
 #
+# [*check_period*]
+#   The title of a `Icinga::Timeperiod` resource describing when Icinga
+#   checks relating to this app should run.
+#
 # [*deny_framing*]
 # should we allow this app to be framed
 #
@@ -290,6 +294,7 @@ define govuk::app (
   $health_check_service_template = 'govuk_regular_service',
   $health_check_notification_period = undef,
   $additional_check_contact_groups = undef,
+  $check_period = undef,
   $deny_framing = false,
   $enable_nginx_vhost = true,
   $vhost = undef,
@@ -382,6 +387,7 @@ define govuk::app (
     health_check_service_template       => $health_check_service_template,
     health_check_notification_period    => $health_check_notification_period,
     additional_check_contact_groups     => $additional_check_contact_groups,
+    check_period                        => $check_period,
     deny_framing                        => $deny_framing,
     enable_nginx_vhost                  => $enable_nginx_vhost,
     nagios_memory_warning               => $nagios_memory_warning,

--- a/modules/govuk/manifests/apps/govuk_crawler_worker.pp
+++ b/modules/govuk/manifests/apps/govuk_crawler_worker.pp
@@ -105,12 +105,18 @@ class govuk::apps::govuk_crawler_worker (
       $service_ensure = running
     }
 
+    $app_check_period = $disable_during_data_sync ? {
+      true    => 'not_data_sync',
+      default => '24x7',
+    }
+
     govuk::app { $app_name:
       app_type               => 'bare',
       log_format_is_json     => true,
       port                   => $port,
       command                => './govuk_crawler_worker -json',
       health_check_path      => '/healthcheck',
+      check_period           => $app_check_period,
       nagios_memory_warning  => $nagios_memory_warning,
       nagios_memory_critical => $nagios_memory_critical,
       ensure_service         => $service_ensure,

--- a/modules/icinga/manifests/check/graphite.pp
+++ b/modules/icinga/manifests/check/graphite.pp
@@ -32,6 +32,10 @@
 #   when passed by the exporting node, rather than lazily evaluated inside
 #   the define by the collecting node.
 #
+# [*check_period*]
+#   The title of a `Icinga::Timeperiod` resource describing when this
+#   service should be actively checked.
+#
 # [*use*]
 #   The title of a `Icinga::Service_template` resource which this service
 #   should inherit. The downstream default is `govuk_regular_service`
@@ -67,6 +71,7 @@ define icinga::check::graphite(
   $warning,
   $critical,
   $host_name,
+  $check_period = undef,
   $use  = undef,
   $args = '',
   $from = '5minutes',
@@ -120,6 +125,7 @@ ${crit_line}${warn_line}\
     check_command              => "${check_command}!${target}!${warning}!${critical}!${args_real}",
     service_description        => $desc,
     host_name                  => $host_name,
+    check_period               => $check_period,
     use                        => $use,
     action_url                 => $action_url_real,
     notes_url                  => $notes_url,

--- a/modules/monitoring/manifests/contacts.pp
+++ b/modules/monitoring/manifests/contacts.pp
@@ -54,6 +54,9 @@ class monitoring::contacts (
   $midday = '12:00'
   $office_day_end = '17:30'
   $midnight_day_end = '24:00'
+  # This should match up with the govuk_data_sync_in_progress class
+  $data_sync_start = '22:00'
+  $data_sync_end = '05:45'
 
   $all_day = "${midnight_day_start}-${midnight_day_end}"
   $office_day = "${office_day_start}-${office_day_end}"
@@ -61,6 +64,7 @@ class monitoring::contacts (
   $office_day_afternoon = "${midday}-${office_day_end}"
   $oncall_early_day = "${midnight_day_start}-${office_day_start}"
   $oncall_late_day = "${office_day_end}-${midnight_day_end}"
+  $not_data_sync = "${data_sync_end}-${data_sync_start}"
 
   icinga::timeperiod { '24x7':
     timeperiod_alias => '24 Hours A Day, 7 Days A Week',
@@ -100,6 +104,17 @@ class monitoring::contacts (
     thu              => "${oncall_early_day},${oncall_late_day}",
     fri              => "${oncall_early_day},${oncall_late_day}",
     sat              => $all_day,
+  }
+
+  icinga::timeperiod { 'not_data_sync':
+    timeperiod_alias => 'Not when data syncs could be taking place',
+    sun              => $not_data_sync,
+    mon              => $not_data_sync,
+    tue              => $not_data_sync,
+    wed              => $not_data_sync,
+    thu              => $not_data_sync,
+    fri              => $not_data_sync,
+    sat              => $not_data_sync,
   }
 
   icinga::timeperiod { 'never':


### PR DESCRIPTION
This'll avoid the checks failing overnight, when the service is stopped due to the data sync.

