### PR TITLE
Include statsd::repo unconditionally

### DIFF
--- a/hieradata/common.xenial.yaml
+++ b/hieradata/common.xenial.yaml
@@ -13,5 +13,3 @@ nodejs::version: '4.2.6~dfsg-1ubuntu4.1'
 puppet::package::facter_version: '2.4.6-1'
 puppet::package::hiera_version: '2.0.0-2'
 puppet::package::puppet_version: '3.8.5-2'
-
-statsd::manage_repo_class: true

--- a/modules/statsd/manifests/init.pp
+++ b/modules/statsd/manifests/init.pp
@@ -19,7 +19,7 @@ class statsd(
     require => Class['nodejs'],
   }
 
-  file { '/etc/statsd.conf':
+  file { '/etc/statsd/config.js':
     content => template('statsd/etc/statsd.conf.erb'),
     require => Package['statsd'],
     notify  => Service['statsd'],
@@ -27,7 +27,7 @@ class statsd(
 
   service { 'statsd':
     ensure  => running,
-    require => [Package['statsd'], File['/etc/statsd.conf']],
+    require => [Package['statsd'], File['/etc/statsd/config.js']],
   }
 
   @@icinga::check { "check_statsd_upstart_up_${::hostname}":

--- a/modules/statsd/manifests/init.pp
+++ b/modules/statsd/manifests/init.pp
@@ -7,24 +7,12 @@
 # [*graphite_hostname*]
 #   Graphite hostname
 #
-# [*manage_repo_class*]
-#   Whether to use a separate repository to install Statsd
-#   Default: false (use 'govuk_ppa' repository)
-#
 class statsd(
   $graphite_hostname,
-  $manage_repo_class = false,
 ) {
 
-  validate_bool($manage_repo_class)
-
   include nodejs
-
-  if $manage_repo_class {
-    include statsd::repo
-  } else {
-    include govuk_ppa
-  }
+  include statsd::repo
 
   package { 'statsd':
     ensure  => 'latest',

--- a/modules/statsd/manifests/repo.pp
+++ b/modules/statsd/manifests/repo.pp
@@ -12,7 +12,7 @@ class statsd::repo(
 ) {
   apt::source { 'statsd':
     location     => "http://${apt_mirror_hostname}/statsd",
-    release      => $::lsbdistcodename,
+    release      => 'stable',
     architecture => $::architecture,
     key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
   }

--- a/modules/statsd/spec/classes/statsd_spec.rb
+++ b/modules/statsd/spec/classes/statsd_spec.rb
@@ -9,6 +9,6 @@ describe 'statsd', :type => :class do
     it { is_expected.to contain_package('statsd') }
     it { is_expected.to contain_service('statsd') }
 
-    it { is_expected.to contain_file('/etc/statsd.conf').with_content(/ graphiteHost: "graphite.example.com"$/) }
+    it { is_expected.to contain_file('/etc/statsd/config.js').with_content(/ graphiteHost: "graphite.example.com"$/) }
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/GeQ5dfid/229-upgrade-statsd-and-node

We want all machines to be able to use statsd::repo so this removes the
condition around it.