### PR TITLE
Switch the gor_running check to ues the not_data_sync timeperiod

### DIFF
--- a/modules/govuk_gor/manifests/init.pp
+++ b/modules/govuk_gor/manifests/init.pp
@@ -80,7 +80,7 @@ class govuk_gor(
   @@icinga::check { "check_gor_running_${::hostname}":
     ensure              => $nagios_ensure,
     check_command       => 'check_nrpe!check_proc_running!goreplay',
-    check_period        => 'inoffice',
+    check_period        => 'not_data_sync',
     host_name           => $::fqdn,
     service_description => 'gor running',
     notes_url           => monitoring_docs_url(gor),


### PR DESCRIPTION
Now that this exists, this is a more precise reflection of when gor is
expected to be running, and when we expect it not to be running.