### PR TITLE
Remove /etc/hosts entries for Licensify in Production.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -127,7 +127,6 @@ task :check_consistency_between_aws_and_carrenza do
     govuk_jenkins::config::theme_text_colour
     govuk_postgresql::server::standby::pgpassfile_enabled
     hosts::production::ip_bouncer
-    hosts::production::licensify_hosts
     mongodb::s3backup::backup::s3_bucket
     mongodb::s3backup::backup::s3_bucket_daily
 

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -176,11 +176,6 @@ hosts::production::ip_backend_lb: '10.3.3.254'
 hosts::production::ip_bouncer: '37.26.90.219'
 hosts::production::ip_draft_api_lb: '10.3.4.253'
 hosts::production::ip_frontend_lb: '10.3.2.254'
-hosts::production::licensify_hosts:
-  licensify.publishing.service.gov.uk:
-    ip: '37.26.90.230'
-  licensify-admin.publishing.service.gov.uk:
-    ip: '37.26.90.233'
 hosts::production::releaseapp_host_org: true
 
 hosts::production::api::hosts:


### PR DESCRIPTION
This is part of the switchover from UKCloud to AWS.