### PR TITLE
Remove Plek override for Licensify in Production.

### DIFF
--- a/modules/govuk/manifests/deploy/config.pp
+++ b/modules/govuk/manifests/deploy/config.pp
@@ -121,22 +121,16 @@ class govuk::deploy::config(
       'GOVUK_APP_DOMAIN_EXTERNAL':  value => $app_domain;
     }
 
-    # 1. Licensify Production is in UKCloud, so Production apps in AWS must use
-    # the external domain name to connect to Licensify. Licensify Staging and
-    # Integration are in AWS, so Plek already does the right thing by default
-    # in those environments.
-    #
-    # 2. Publishing and Email Alert API still in Carrenza Production but
-    #    migrated in AWS staging
+    # 1. Publishing API and Email Alert API still in Carrenza Production but
+    #    migrated in AWS Staging.
     if $::aws_environment == 'production' {
       govuk_envvar {
-        'PLEK_SERVICE_LICENSIFY_URI': value => "https://licensify.${licensify_app_domain}";
         'PLEK_SERVICE_EMAIL_ALERT_API_URI': value  => "https://email-alert-api.${app_domain}";
         'PLEK_SERVICE_PUBLISHING_API_URI': value  => "https://publishing-api.${app_domain}";
       }
     }
 
-    # publishing_api, email_alert_api and whitehall_admin are still in Carrenza staging and production.
+    # 1. Whitehall Admin is still in Carrenza Staging and Production.
     if ($::aws_environment == 'staging') or ($::aws_environment == 'production') {
       govuk_envvar {
         'PLEK_SERVICE_WHITEHALL_ADMIN_URI': value  => "https://whitehall-admin.${app_domain}";


### PR DESCRIPTION
This, in conjunction with #9859 and alphagov/govuk-dns-config#382,
switches traffic to the new AWS deployment of Licensify in Production.