### PR TITLE
licensify has been migrated to AWS where it uses deploy_node_app

### DIFF
--- a/hieradata/class/integration/jenkins.yaml
+++ b/hieradata/class/integration/jenkins.yaml
@@ -2,7 +2,6 @@
 govuk_jenkins::config::executors: '8'
 
 govuk_jenkins::job_builder::jobs:
-  - govuk_jenkins::jobs::deploy_licensify
   - govuk_jenkins::jobs::deploy_puppet
   - govuk_jenkins::jobs::deploy_terraform_govuk_aws
   - govuk_jenkins::jobs::launch_vms

--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -18,7 +18,6 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::deploy_dns
   - govuk_jenkins::jobs::deploy_docs
   - govuk_jenkins::jobs::deploy_lambda_app
-  - govuk_jenkins::jobs::deploy_licensify
   - govuk_jenkins::jobs::deploy_puppet
   - govuk_jenkins::jobs::deploy_router_data
   - govuk_jenkins::jobs::email_alert_check

--- a/hieradata/class/staging/jenkins.yaml
+++ b/hieradata/class/staging/jenkins.yaml
@@ -10,7 +10,6 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::deploy_cdn
   - govuk_jenkins::jobs::deploy_dns
   - govuk_jenkins::jobs::deploy_lambda_app
-  - govuk_jenkins::jobs::deploy_licensify
   - govuk_jenkins::jobs::deploy_puppet
   - govuk_jenkins::jobs::deploy_router_data
   - govuk_jenkins::jobs::govuk_taxonomy_supervised_learning

--- a/hieradata/vagrant.yaml
+++ b/hieradata/vagrant.yaml
@@ -82,7 +82,6 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::deploy_app
   - govuk_jenkins::jobs::run_rake_task
   - govuk_jenkins::jobs::deploy_cdn
-  - govuk_jenkins::jobs::deploy_licensify
   - govuk_jenkins::jobs::deploy_puppet
   - govuk_jenkins::jobs::deploy_router_data
   - govuk_jenkins::jobs::launch_vms

--- a/hieradata_aws/class/integration/jenkins.yaml
+++ b/hieradata_aws/class/integration/jenkins.yaml
@@ -17,7 +17,6 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::deploy_cdn
   - govuk_jenkins::jobs::deploy_dns
   - govuk_jenkins::jobs::deploy_emergency_banner
-  - govuk_jenkins::jobs::deploy_licensify
   - govuk_jenkins::jobs::deploy_puppet
   - govuk_jenkins::jobs::deploy_router_data
   - govuk_jenkins::jobs::enhanced_ecommerce_search_api

--- a/hieradata_aws/class/production/jenkins.yaml
+++ b/hieradata_aws/class/production/jenkins.yaml
@@ -16,7 +16,6 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::content_data_api
   - govuk_jenkins::jobs::deploy_app
   - govuk_jenkins::jobs::deploy_emergency_banner
-  - govuk_jenkins::jobs::deploy_licensify
   - govuk_jenkins::jobs::deploy_puppet
   - govuk_jenkins::jobs::enhanced_ecommerce_search_api
   - govuk_jenkins::jobs::passive_checks

--- a/hieradata_aws/class/staging/jenkins.yaml
+++ b/hieradata_aws/class/staging/jenkins.yaml
@@ -14,7 +14,6 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::data_sync
   - govuk_jenkins::jobs::deploy_app
   - govuk_jenkins::jobs::deploy_emergency_banner
-  - govuk_jenkins::jobs::deploy_licensify
   - govuk_jenkins::jobs::deploy_puppet
   - govuk_jenkins::jobs::mongo_data_sync
   - govuk_jenkins::jobs::passive_checks

--- a/hieradata_aws/vagrant.yaml
+++ b/hieradata_aws/vagrant.yaml
@@ -80,7 +80,6 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::deploy_app
   - govuk_jenkins::jobs::run_rake_task
   - govuk_jenkins::jobs::deploy_cdn
-  - govuk_jenkins::jobs::deploy_licensify
   - govuk_jenkins::jobs::deploy_puppet
   - govuk_jenkins::jobs::deploy_router_data
   - govuk_jenkins::jobs::launch_vms


### PR DESCRIPTION
licensify has been migrated to AWS where it uses deploy_node_app rather than the custom deploy_licensify