### PR TITLE
Remove an obsolete `ensure => "absent"`.

### DIFF
--- a/modules/govuk/manifests/node/s_base.pp
+++ b/modules/govuk/manifests/node/s_base.pp
@@ -119,11 +119,6 @@ class govuk::node::s_base (
     ensure => absent,
   }
 
-  # Old RDS-only cert bundle, superseded by rds-combined-ca-bundle.pem.
-  file { '/etc/ssl/certs/rds_cacert.pem':
-    ensure  => absent,
-  }
-
   file { '/etc/ssl/certs/rds-combined-ca-bundle.pem':
     ensure => present,
     owner  => 'root',


### PR DESCRIPTION
The removal of the old `rds_cacert.pem` cert bundle has rolled out
everywhere, so that config is no longer needed.