### PR TITLE
Configure Tensorflow Serving docker container

### DIFF
--- a/modules/govuk/manifests/node/s_search.pp
+++ b/modules/govuk/manifests/node/s_search.pp
@@ -11,6 +11,10 @@ class govuk::node::s_search inherits govuk::node::s_base {
 
   include nginx
 
+  include ::govuk_docker
+
+  include ::govuk_containers::tensorflow_serving
+
   # The catchall vhost throws a 500, except for healthcheck requests.
   nginx::config::vhost::default { 'default': }
 

--- a/modules/govuk_containers/manifests/tensorflow_serving.pp
+++ b/modules/govuk_containers/manifests/tensorflow_serving.pp
@@ -28,7 +28,7 @@ class govuk_containers::tensorflow_serving(
 
   file { '/tensorflow-models':
     ensure => directory,
-  }
+  } ->
 
   ::docker::run { 'tensorflow/serving':
     ports            => ['8501:8501'],

--- a/modules/govuk_containers/manifests/tensorflow_serving.pp
+++ b/modules/govuk_containers/manifests/tensorflow_serving.pp
@@ -10,13 +10,9 @@
 # [*image_version*]
 #   The docker image version to use.
 #
-# [*max_memory*]
-#   The maximum amount of memory Tensorflow Serving should allocate
-#
 class govuk_containers::tensorflow_serving(
   $image_name = 'tensorflow/serving',
   $image_version = 'latest',
-  $max_memory    = 1024,
   $model_name = 'ltr'
 ) {
 
@@ -34,8 +30,7 @@ class govuk_containers::tensorflow_serving(
     ports            => ['8501:8501'],
     image            => $image_name,
     require          => Docker::Image[$image_name],
-    extra_parameters => ['-P', '-v', '/tensorflow-models:/models'],
-    command          => "-m ${max_memory} -e MODEL_NAME=${model_name}",
+    extra_parameters => ['-P', '-v', '/tensorflow-models:/models', "-e MODEL_NAME=${model_name}"],
   }
 
   @@icinga::check { "check_tensorflow_serving_running_${::hostname}":

--- a/modules/govuk_containers/manifests/tensorflow_serving.pp
+++ b/modules/govuk_containers/manifests/tensorflow_serving.pp
@@ -26,11 +26,15 @@ class govuk_containers::tensorflow_serving(
     image_tag => $image_version,
   }
 
+  file { '/tensorflow-models':
+    ensure => directory,
+  }
+
   ::docker::run { 'tensorflow/serving':
     ports            => ['8501:8501'],
     image            => $image_name,
     require          => Docker::Image[$image_name],
-    extra_parameters => ['-P'],
+    extra_parameters => ['-P', '-v', '/tensorflow-models:/models'],
     command          => "-m ${max_memory} -e MODEL_NAME=${model_name}",
   }
 

--- a/modules/govuk_containers/manifests/tensorflow_serving.pp
+++ b/modules/govuk_containers/manifests/tensorflow_serving.pp
@@ -1,0 +1,43 @@
+# == Class: govuk_containers::tensorflow_serving
+#
+# Install and run a dockerised Tensorflow server
+#
+# === Parameters
+#
+# [*image_name*]
+#   Docker image name to use for the container.
+#
+# [*image_version*]
+#   The docker image version to use.
+#
+# [*max_memory*]
+#   The maximum amount of memory Tensorflow Serving should allocate
+#
+class govuk_containers::tensorflow_serving(
+  $image_name = 'tensorflow/serving',
+  $image_version = 'latest',
+  $max_memory    = 1024,
+  $model_name = 'ltr'
+) {
+
+  ::docker::image { $image_name:
+    ensure    => 'present',
+    require   => Class['govuk_docker'],
+    image_tag => $image_version,
+  }
+
+  ::docker::run { 'tensorflow/serving':
+    ports            => ['8501:8501'],
+    image            => $image_name,
+    require          => Docker::Image[$image_name],
+    extra_parameters => ['-P'],
+    command          => "-m ${max_memory} -e MODEL_NAME=${model_name}",
+  }
+
+  @@icinga::check { "check_tensorflow_serving_running_${::hostname}":
+    check_command       => 'check_nrpe!check_proc_running!tensorflow_serving',
+    service_description => 'Tensorflow Serving running',
+    host_name           => $::fqdn,
+    notes_url           => monitoring_docs_url(check-process-running),
+  }
+}


### PR DESCRIPTION
The aim here is to Puppet-ify running a TensorFlow Serving container, namely the following command:

```
docker run -t --rm -p 8501:8501 \
    -v "$EXPORT_PATH/$LATEST:/models/ltr/1" \
    -e MODEL_NAME=ltr \
    tensorflow/serving
```

@barrucadu Do you have any pointers as to how we can mount the volume?

Paired with @bilbof 

Card: https://trello.com/c/HaeILDIG/1166-add-dockerised-model-to-search-machines