### PR TITLE
remove asset manager from carrenza staging

### DIFF
--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -305,7 +305,6 @@ hosts::production::backend::hosts:
     ip: '10.2.11.31'
 
 hosts::production::backend::app_hostnames:
-  - 'asset-manager'
   - 'canary-backend'
   - 'collections-publisher'
   - 'contacts-admin'


### PR DESCRIPTION
This will ensure that apps in carrenza now uses the asset manager in AWS since the asset manager /etc/hosts entry has been removed from Carrenza staging instances.