### PR TITLE
Add back envvar for licensify

### DIFF
--- a/modules/govuk/manifests/deploy/config.pp
+++ b/modules/govuk/manifests/deploy/config.pp
@@ -119,6 +119,7 @@ class govuk::deploy::config(
       # By default traffic should route internally
       'GOVUK_APP_DOMAIN':           value => $app_domain_internal;
       'GOVUK_APP_DOMAIN_EXTERNAL':  value => $app_domain;
+      'PLEK_SERVICE_LICENSIFY_URI': value => "https://licensify.${licensify_app_domain}";
     }
 
     # 1. Publishing API and Email Alert API still in Carrenza Production but


### PR DESCRIPTION
Licensify is throwing an error when draft licence pages are previewed:

https://sentry.io/organizations/govuk/issues/1197445113/?environment=production&project=202225&query=is%3Aunresolved

I think this has happened because the config for Licensify was removed in this commit:
https://github.com/alphagov/govuk-puppet/commit/fec7765533f70bd72f3d9007bef8bd390b176a84#diff-64f0944084cf15c3cfedda16b5dacec8
as the draft-frontend only runs in AWS.

Licensify was migrated to the AWS last week, so the env var is being added back without the "only in Carrenza" guard clause.