### PR TITLE
Fix Licensify URL used by Draft Frontend.

### DIFF
--- a/modules/govuk/manifests/node/s_draft_frontend.pp
+++ b/modules/govuk/manifests/node/s_draft_frontend.pp
@@ -25,6 +25,7 @@ class govuk::node::s_draft_frontend() inherits govuk::node::s_base {
     'PLEK_HOSTNAME_PREFIX': value => 'draft-';
     'PLEK_SERVICE_IMMINENCE_URI': value => "https://imminence.${app_domain}";
     'PLEK_SERVICE_LOCAL_LINKS_MANAGER_URI': value => "https://local-links-manager.${app_domain}";
+    'PLEK_SERVICE_LICENSIFY_URI': value => "https://licensify.${app_domain_internal}";
     'PLEK_SERVICE_MAPIT_URI': value => "https://mapit.${app_domain_internal}";
     'PLEK_SERVICE_SEARCH_URI': value => "https://search.${app_domain_internal}";
   }


### PR DESCRIPTION
`draft-frontend` sets `PLEK_HOSTNAME_PREFIX` to prepend `draft-` to the
URLs of its dependencies, so that it uses the special "draft" versions
of those dependencies. Some of these dependencies, including Licensify,
don't have special draft versions. The URLs for those services are
overridden back to their original values by setting
`PLEK_SERVICE_..._URI`.

This adds back the missing override for Licensify, so that
`draft-frontend` doesn't use the `draft-` prefix when connecting to
Licensify.