### PR TITLE
Add link to Datasync with govuk_env_sync docs

### DIFF
--- a/modules/govuk_env_sync/manifests/task.pp
+++ b/modules/govuk_env_sync/manifests/task.pp
@@ -105,6 +105,7 @@ define govuk_env_sync::task(
     service_description => $service_desc,
     freshness_threshold => $threshold_secs,
     host_name           => $::fqdn,
+    notes_url           => 'https://docs.publishing.service.gov.uk/manual/govuk-env-sync.html',
   }
 
 }


### PR DESCRIPTION
Adds a link to the Datasync with govuk_env_sync docs to the "GOV.UK environment sync" icinga alerts.

This has been hard-coded for now, rather than using `monitoring_docs_url` because the docs live under `manual` and not `manual/alerts` like the rest of the docs for the other alerts.