### PR TITLE
Remove rabbitmq federation from carrenza to AWS in staging

### DIFF
--- a/hieradata/class/staging/rabbitmq.yaml
+++ b/hieradata/class/staging/rabbitmq.yaml
@@ -1,8 +1,0 @@
----
-
-govuk_rabbitmq::federation: 'yes'
-govuk_rabbitmq::federate::federation_user: 'root'
-govuk_rabbitmq::federate::federation_pass: "%{hiera('govuk_rabbitmq::root_password')}"
-govuk_rabbitmq::federate::upstream_servers: ['10.12.13.20', '10.12.14.20', '10.12.15.20']
-govuk_rabbitmq::federate::upstream_name: 'aws'
-govuk_rabbitmq::federate::federation_exchange: 'published_documents'


### PR DESCRIPTION
No longuer required following migration of publishing-api and
email alert in AWS.