### PR TITLE
enable integration releases to be notified

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/integration_licensify_deploy.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/integration_licensify_deploy.yaml.erb
@@ -19,6 +19,8 @@
                 {"name": "TAG", "value": "$TAG"},
                 {"name": "TARGET_APPLICATION", "value": "$TARGET_APPLICATION"},
                 {"name": "DEPLOY_TASK", "value": "deploy"},
+                {"name": "NOTIFY_RELEASE_APP", "value": "true"},
+                {"name": "SLACK_NOTIFICATIONS", "value": "true"},
               ]}
           EOF
 


### PR DESCRIPTION
integration releases should be notified in both the release app and in slack as other app releases do.