### PR TITLE
Condense similar application dashboards

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -908,59 +908,16 @@ grafana::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 grafana::dashboards::app_domain: "%{hiera('app_domain')}"
 grafana::dashboards::machine_suffix_metrics: ''
 grafana::dashboards::application_dashboards:
-  asset-manager:
-    show_sidekiq_graphs: true
-    has_workers: true
-  collections-publisher:
+  generic:
     show_sidekiq_graphs: true
     has_workers: true
   contacts:
     docs_name: 'contacts-admin'
-  content-audit-tool:
-    show_sidekiq_graphs: true
-    has_workers: true
-  content-publisher:
-    show_sidekiq_graphs: true
-    has_workers: true
-  content-tagger:
-    show_sidekiq_graphs: true
-    has_workers: true
-  email-alert-api:
-    show_sidekiq_graphs: true
-    has_workers: true
-  email-alert-service: {}
-  hmrc-manuals-api: {}
-  manuals-publisher:
-    show_sidekiq_graphs: true
-    has_workers: true
-  maslow: {}
-  publisher:
-    show_sidekiq_graphs: true
-    has_workers: true
   publishing-api:
     show_sidekiq_graphs: true
     has_workers: true
     instance_prefix: 'publishing_api'
     show_memcached: true
-  release: {}
-  search-admin: {}
-  service-manual-publisher: {}
-  short-url-manager: {}
-  sidekiq-monitoring: {}
-  signon:
-    show_sidekiq_graphs: true
-    has_workers: true
-  specialist-publisher:
-    show_sidekiq_graphs: true
-    has_workers: true
-  travel-advice-publisher:
-    show_sidekiq_graphs: true
-    has_workers: true
-  whitehall:
-    show_sidekiq_graphs: true
-    has_workers: true
-    error_threshold: 50
-    warning_threshold: 25
 
 grub2::recordfail_timeout: 5
 

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -980,10 +980,9 @@ grafana::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 grafana::dashboards::app_domain: "%{hiera('app_domain')}"
 grafana::dashboards::machine_suffix_metrics: ''
 grafana::dashboards::application_dashboards:
-  authenticating-proxy: {}
-  cache-clearing-service: {}
-  calculators: {}
-  calendars: {}
+  generic:
+    show_sidekiq_graphs: true
+    has_workers: true
   ckan:
     docs_name: 'ckanext-datagovuk'
     # No data in kibana
@@ -992,12 +991,6 @@ grafana::dashboards::application_dashboards:
   collections:
     instance_prefix: 'frontend'
     show_memcached: true
-  content-data-admin:
-    show_sidekiq_graphs: true
-    has_workers: true
-  content-data-api:
-    show_sidekiq_graphs: true
-    has_workers: true
   content-store:
     dependent_app_5xx_errors:
       - calendars
@@ -1012,35 +1005,22 @@ grafana::dashboards::application_dashboards:
       - publishing-api
       - smartanswers
       - whitehall-frontend
-  email-alert-frontend: {}
-  email-alert-api:
-    show_sidekiq_graphs: true
-    has_workers: true
-  email-alert-service: {}
-  feedback: {}
   finder-frontend:
     show_external_request_time: true
     show_memcached: true
     instance_prefix: 'calculators_frontend'
-  frontend: {}
-  government-frontend: {}
   imminence:
     dependent_app_5xx_errors:
       - frontend
     show_sidekiq_graphs: true
     has_workers: true
-  info-frontend: {}
   licencefinder:
     docs_name: 'licence-finder'
-  link-checker-api:
-    show_sidekiq_graphs: true
-    has_workers: true
   local-links-manager:
     dependent_app_5xx_errors:
       - frontend
     instance_prefix: 'backend'
     show_memcached: true
-  manuals-frontend: {}
   mapit:
     dependent_app_5xx_errors:
       - frontend
@@ -1053,8 +1033,6 @@ grafana::dashboards::application_dashboards:
     has_workers: true
     instance_prefix: 'publishing_api'
     show_memcached: true
-  router: {}
-  router-api: {}
   search-api:
     # search-api is a sinatra app
     show_controller_errors: false
@@ -1066,8 +1044,6 @@ grafana::dashboards::application_dashboards:
       - collections
       - finder-frontend
       - whitehall-frontend
-  service-manual-frontend: {}
-  sidekiq-monitoring: {}
   smartanswers:
     docs_name: 'smart-answers'
   static:
@@ -1082,15 +1058,6 @@ grafana::dashboards::application_dashboards:
       - manuals-frontend
       - smartanswers
       - whitehall-frontend
-  support:
-    show_sidekiq_graphs: true
-    has_workers: true
-  support-api:
-    show_sidekiq_graphs: true
-    has_workers: true
-  transition:
-    show_sidekiq_graphs: true
-    has_workers: true
 
 grub2::recordfail_timeout: 5
 

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -170,13 +170,9 @@ govuk_ppa::path: 'preview'
 
 grafana::dashboards::machine_suffix_metrics: '_integration'
 grafana::dashboards::application_dashboards:
-  asset-manager:
+  generic:
     show_sidekiq_graphs: true
     has_workers: true
-  authenticating-proxy: {}
-  cache-clearing-service: {}
-  calculators: {}
-  calendars: {}
   ckan:
     docs_name: 'ckanext-datagovuk'
     # No data in kibana
@@ -185,23 +181,8 @@ grafana::dashboards::application_dashboards:
   collections:
     instance_prefix: 'frontend'
     show_memcached: true
-  collections-publisher:
-    show_sidekiq_graphs: true
-    has_workers: true
   contacts:
     docs_name: 'contacts-admin'
-  content-audit-tool:
-    show_sidekiq_graphs: true
-    has_workers: true
-  content-data-admin:
-    show_sidekiq_graphs: true
-    has_workers: true
-  content-data-api:
-    show_sidekiq_graphs: true
-    has_workers: true
-  content-publisher:
-    show_sidekiq_graphs: true
-    has_workers: true
   content-store:
     dependent_app_5xx_errors:
       - calendars
@@ -216,42 +197,22 @@ grafana::dashboards::application_dashboards:
       - publishing-api
       - smartanswers
       - whitehall-frontend
-  content-tagger:
-    show_sidekiq_graphs: true
-    has_workers: true
-  email-alert-api:
-    show_sidekiq_graphs: true
-    has_workers: true
-  email-alert-frontend: {}
-  email-alert-service: {}
-  feedback: {}
   finder-frontend:
     show_external_request_time: true
     show_memcached: true
     instance_prefix: 'calculators_frontend'
-  frontend: {}
-  government-frontend: {}
-  hmrc-manuals-api: {}
   imminence:
     dependent_app_5xx_errors:
       - frontend
     show_sidekiq_graphs: true
     has_workers: true
-  info-frontend: {}
   licencefinder:
     docs_name: 'licence-finder'
-  link-checker-api:
-    show_sidekiq_graphs: true
-    has_workers: true
   local-links-manager:
     dependent_app_5xx_errors:
       - frontend
     instance_prefix: 'backend'
     show_memcached: true
-  manuals-frontend: {}
-  manuals-publisher:
-    show_sidekiq_graphs: true
-    has_workers: true
   mapit:
     dependent_app_5xx_errors:
       - frontend
@@ -259,18 +220,11 @@ grafana::dashboards::application_dashboards:
     # No data in kibana
     show_controller_errors: false
     show_slow_requests: false
-  maslow: {}
-  publisher:
-    show_sidekiq_graphs: true
-    has_workers: true
   publishing-api:
     show_sidekiq_graphs: true
     has_workers: true
     instance_prefix: 'publishing_api'
     show_memcached: true
-  release: {}
-  router: {}
-  router-api: {}
   search-api:
     # search-api is a sinatra app
     show_controller_errors: false
@@ -282,19 +236,8 @@ grafana::dashboards::application_dashboards:
       - collections
       - finder-frontend
       - whitehall-frontend
-  search-admin: {}
-  service-manual-frontend: {}
-  service-manual-publisher: {}
-  short-url-manager: {}
-  sidekiq-monitoring: {}
-  signon:
-    show_sidekiq_graphs: true
-    has_workers: true
   smartanswers:
     docs_name: 'smart-answers'
-  specialist-publisher:
-    show_sidekiq_graphs: true
-    has_workers: true
   static:
     dependent_app_5xx_errors:
       - calendars
@@ -307,23 +250,6 @@ grafana::dashboards::application_dashboards:
       - manuals-frontend
       - smartanswers
       - whitehall-frontend
-  support:
-    show_sidekiq_graphs: true
-    has_workers: true
-  support-api:
-    show_sidekiq_graphs: true
-    has_workers: true
-  transition:
-    show_sidekiq_graphs: true
-    has_workers: true
-  travel-advice-publisher:
-    show_sidekiq_graphs: true
-    has_workers: true
-  whitehall:
-    show_sidekiq_graphs: true
-    has_workers: true
-    error_threshold: 50
-    warning_threshold: 25
 
 mongodb::backup::mongo_backup_node: 'localhost'
 

--- a/modules/grafana/manifests/dashboards/application_dashboard.pp
+++ b/modules/grafana/manifests/dashboards/application_dashboard.pp
@@ -29,7 +29,6 @@
 #   application. For example, calculators_frontend vs finder_frontend.
 #
 define grafana::dashboards::application_dashboard (
-  $app_name = $title,
   $docs_name = $title,
   $dashboard_directory = undef,
   $app_domain = undef,
@@ -47,6 +46,12 @@ define grafana::dashboards::application_dashboard (
   $sentry_environment = $::govuk::deploy::config::errbit_environment_name,
 
 ) {
+  if $title == 'generic' {
+    $app_name = '$Application'
+  } else {
+    $app_name = $title
+  }
+
   if $has_workers {
     $worker_row = [['worker_failures', 'worker_successes']]
   } else {
@@ -131,7 +136,7 @@ define grafana::dashboards::application_dashboard (
   )
 
   file {
-    "${dashboard_directory}/${app_name}.json":
+    "${dashboard_directory}/${title}.json":
     notify  => Service['grafana-server'],
     content => template('grafana/dashboards/application_dashboard_template.json.erb');
   }

--- a/modules/grafana/templates/dashboards/application_dashboard_template.json.erb
+++ b/modules/grafana/templates/dashboards/application_dashboard_template.json.erb
@@ -1,12 +1,42 @@
 {
   "id": 29,
-  "title": "Application dashboard - <%= @app_name %>",
+  "title": "Application dashboard - <%= @title %>",
   "tags": [],
   "style": "dark",
   "timezone": "browser",
   "editable": true,
   "hideControls": false,
   "sharedCrosshair": false,
+  <% if $title == 'generic' %>
+    "templating": {
+      "list": [
+        {
+          "allValue": null,
+          "current": {
+            "tags": [],
+            "text": "asset-manager",
+            "value": "asset-manager"
+          },
+          "datasource": "Graphite",
+          "hide": 0,
+          "includeAll": false,
+          "label": null,
+          "multi": false,
+          "name": "Application",
+          "options": [],
+          "query": "*.processes-app-*",
+          "refresh": 1,
+          "regex": "/processes-app-(.*)/",
+          "sort": 0,
+          "tagValuesQuery": "",
+          "tags": [],
+          "tagsQuery": "",
+          "type": "query",
+          "useTags": false
+        }
+      ]
+    },
+  <% end %>
   "rows": [
     <% @panel_partials.each_with_index do |row, i| %>
       <%= ',' if i > 0 %> {


### PR DESCRIPTION
This condenses some of the application dashboards into a single
'generic' dashboard with a template variable, the aim being to
eventually move out the remaining custom behaviours into tailored
dashboards for the few apps that need them:

   - Some apps, like static, benefit from showing errors of other
apps that dependend upon it
   - Some apps, like finder-frontend, show memcached stats with a
specific 'instance prefix'

The docs URLs also vary for some applications e.g. 'smartanswers'
vs. 'smart-answers'. We could remove this link if it's not useful.