### PR TITLE
Add infrequent Icinga alert for ad-hoc dashboards

### DIFF
--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_old_grafana_dashboards
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_old_grafana_dashboards
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+while getopts ":h:" opt; do
+  case ${opt} in
+    h )
+      GRAFANA_HOST=$OPTARG
+      ;;
+  esac
+done
+
+DASHBOARDS=$(curl -s https://$GRAFANA_HOST/api/search | jq -c '.[]' | grep 'db/' | jq '.title')
+
+if [ ${#DASHBOARDS[@]} -eq 0 ]; then
+  echo "OK: All dashboards are in version control"
+  exit 0
+fi
+
+echo "WARNING: there are dashboards that aren't in version control"
+printf '%s\n' "${DASHBOARDS[@]}"
+exit 1

--- a/modules/monitoring/manifests/checks.pp
+++ b/modules/monitoring/manifests/checks.pp
@@ -45,6 +45,7 @@ class monitoring::checks (
   include monitoring::checks::lb
   include monitoring::checks::cloudwatch
   include monitoring::checks::aws_iam_key
+  include monitoring::checks::grafana_dashboards
 
   include govuk::apps::email_alert_api::checks
 

--- a/modules/monitoring/manifests/checks/grafana_dashboards.pp
+++ b/modules/monitoring/manifests/checks/grafana_dashboards.pp
@@ -1,0 +1,27 @@
+# == Class: monitoring::checks::grafana_dashboards
+#
+# Single Nagios alert for Grafana dashboards that aren't in version control
+class monitoring::checks::grafana_dashboards (
+) {
+  $app_domain_internal = hiera('app_domain_internal')
+
+  icinga::plugin { 'check_grafana_dashboards':
+    source => 'puppet:///modules/monitoring/usr/lib/nagios/plugins/check_grafana_dashboards',
+  }
+
+  icinga::check_config { 'check_grafana_dashboards':
+    content => template('monitoring/check_grafana_dashboards.cfg.erb'),
+    require => File['/usr/lib/nagios/plugins/check_grafana_dashboards'],
+  }
+
+  icinga::check { 'check_grafana_dashboards':
+    check_command       => 'check_grafana_dashboards',
+    use                 => 'govuk_normal_priority',
+    host_name           => $::fqdn,
+    check_interval      => 7d,
+    service_description => 'At least 1 Grafana dashboard is not in version control',
+    require             => Icinga::Check_config['check_grafana_dashboards'],
+    notes_url           => monitoring_docs_url(grafana-dashboards),
+    action_url          => "https://grafana.${app_domain_internal}",
+  }
+}

--- a/modules/monitoring/templates/check_grafana_dashboards.cfg.erb
+++ b/modules/monitoring/templates/check_grafana_dashboards.cfg.erb
@@ -1,0 +1,4 @@
+define command {
+    command_name check_grafana_dashboards
+    command_line /usr/lib/nagios/plugins/check_grafana_dashboards -h "grafana.<%= @app_domain_internal %>"
+}


### PR DESCRIPTION
    This adds a new alert to check if there are any ad-hoc dashboards in
    the Grafana instance associated with the environment. Such dashboards
    aren't in version control, tend to be temporary, and accumulate over
    time. Having this alert will motivate us to clean them up - currently
    our dashboard landscape is quite confusing, because there are so many.

If we like this and want to merge, we should first actually cleanup all the old dashboards identified by this alert, so we don't show the alert unnecessarily.

- [x] fix monitoring -> grafana connectivity
- [ ] cleanup dashboards not in code
- [x] write documentation to go with alert