### PR TITLE
Support AWS on Whitehall SLIs dashboard

### DIFF
--- a/modules/grafana/files/dashboards/whitehall-slis.json
+++ b/modules/grafana/files/dashboards/whitehall-slis.json
@@ -68,20 +68,20 @@
                 }
               ],
               "refId": "A",
-              "target": "hitcount(sumSeries(stats.whitehall-backend-*.nginx_logs.*.http_*), '1h')",
+              "target": "hitcount(sumSeries(stats.whitehall*backend-*.nginx_logs.*.http_*), '1h')",
               "textEditor": true,
               "timeField": "@timestamp"
             },
             {
               "hide": true,
               "refId": "B",
-              "target": "hitcount(sumSeries(stats.whitehall-backend-*.nginx_logs.*.http_{2*,3*,4*}), '1h')",
+              "target": "hitcount(sumSeries(stats.whitehall*backend-*.nginx_logs.*.http_{2*,3*,4*}), '1h')",
               "textEditor": true
             },
             {
               "refId": "C",
               "target": "alias(transformNull(asPercent(#B, #A), 100), 'Percentage non-5xx requests')",
-              "targetFull": "alias(transformNull(asPercent(hitcount(sumSeries(stats.whitehall-backend-*.nginx_logs.*.http_{2*,3*,4*}), '1h'), hitcount(sumSeries(stats.whitehall-backend-*.nginx_logs.*.http_*), '1h')), 100), 'Percentage non-5xx requests')",
+              "targetFull": "alias(transformNull(asPercent(hitcount(sumSeries(stats.whitehall*backend-*.nginx_logs.*.http_{2*,3*,4*}), '1h'), hitcount(sumSeries(stats.whitehall*backend-*.nginx_logs.*.http_*), '1h')), 100), 'Percentage non-5xx requests')",
               "textEditor": true
             }
           ],


### PR DESCRIPTION
In AWS the Whitehall Backend machines are called `whitehall_backend-*` whereas in Carrenza they are named `whitehall-backend-*`. I've changed the Graphite query to support both `-` and `_` as the separator character.

[Trello Card](https://trello.com/c/3sMDtJHP/1511-5-show-an-sli-how-available-is-whitehall-to-publishers)