### PR TITLE
Add config for email_alert_api manual database restore.

### DIFF
--- a/hieradata_aws/class/production/db_admin.yaml
+++ b/hieradata_aws/class/production/db_admin.yaml
@@ -75,6 +75,15 @@ govuk_env_sync::tasks:
   # The pull_*_production configs below are not run automatically. The
   # ensure:disabled means that they are present on the db_admin machine but
   # without crontab entries. This allows for manual restores when needed.
+  "pull_email_alert_api_production":
+    ensure: "disabled"
+    action: "pull"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "email-alert-api_production"
+    temppath: "/tmp/email-alert-api_production"
+    url: "govuk-production-database-backups"
+    path: "postgresql-backend"
   "pull_licensify_production": &pull_licensify
     ensure: "disabled"
     action: "pull"

--- a/hieradata_aws/class/production/db_admin.yaml
+++ b/hieradata_aws/class/production/db_admin.yaml
@@ -54,17 +54,6 @@ govuk_env_sync::tasks:
     temppath: "/tmp/"
     url: "govuk-production-database-backups"
     path: "postgresql-backend"
-  "pull_publishing_api_production_daily":
-    ensure: "disabled"
-    hour: "3"
-    minute: "45"
-    action: "pull"
-    dbms: "postgresql"
-    storagebackend: "s3"
-    database: "publishing_api_production"
-    temppath: "/tmp/publishing_api_production"
-    url: "govuk-production-database-backups"
-    path: "postgresql-backend"
   "push_licensify_production": &push_licensify
     hour: "1"
     minute: "30"
@@ -83,12 +72,11 @@ govuk_env_sync::tasks:
     hour: "1"
     minute: "45"
     database: "licensify-audit"
-  # Install configs for Licensify restores but without cron entries.
-  # This allows for manual restores when needed.
+  # The pull_*_production configs below are not run automatically. The
+  # ensure:disabled means that they are present on the db_admin machine but
+  # without crontab entries. This allows for manual restores when needed.
   "pull_licensify_production": &pull_licensify
     ensure: "disabled"
-    hour: "1"
-    minute: "0"
     action: "pull"
     dbms: "documentdb"
     storagebackend: "s3"
@@ -104,3 +92,12 @@ govuk_env_sync::tasks:
     <<: *pull_licensify
     ensure: "disabled"
     database: "licensify-audit"
+  "pull_publishing_api_production":
+    ensure: "disabled"
+    action: "pull"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "publishing_api_production"
+    temppath: "/tmp/publishing_api_production"
+    url: "govuk-production-database-backups"
+    path: "postgresql-backend"


### PR DESCRIPTION
This is needed for the upcoming migration and for emergency restores after that.

Also clean up the existing manual restore configs for clarity. There should be no functional change except for the addition of the email-alert-api restore config.