### PR TITLE
Deploy publishing-api and govuk-content-schemas in AWS Prod.

### DIFF
--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -89,6 +89,10 @@ node_class: &node_class
   mirrorer:
     apps:
       - govuk_crawler_worker
+  publishing_api:
+    apps:
+      - govuk-content-schemas
+      - publishing-api
   router_backend:
     apps:
       - router-api


### PR DESCRIPTION
This is needed in preparation for the upcoming migration.