### PR TITLE
Revert "Enable Learning To Rank in staging and integration"

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -296,7 +296,6 @@ task :check_consistency_between_aws_and_carrenza do
     govuk::apps::search_api::unicorn_worker_processes
     govuk::apps::search_api::bucket_name
     govuk::apps::search_api::relevancy_bucket_name
-    govuk::apps::search_api::enable_learning_to_rank
     govuk::apps::sidekiq_monitoring::content_data_admin_redis_host
     govuk::apps::sidekiq_monitoring::content_data_admin_redis_port
     govuk::apps::sidekiq_monitoring::content_data_api_redis_host

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -47,7 +47,6 @@ govuk::apps::router::sentry_environment: 'integration'
 govuk::apps::search_api::bucket_name: 'govuk-integration-sitemaps'
 govuk::apps::search_api::elasticsearch_hosts: 'https://vpc-blue-elasticsearch6-domain-uolbxqjhkiqmg5w3gg7gio5sty.eu-west-1.es.amazonaws.com'
 govuk::apps::search_api::relevancy_bucket_name: 'govuk-integration-search-relevancy'
-govuk::apps::search_api::enable_learning_to_rank: true
 govuk::apps::short_url_manager::instance_name: 'integration'
 govuk::apps::signon::instance_name: 'integration'
 govuk::apps::smartanswers::expose_govspeak: true

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -165,7 +165,6 @@ govuk::apps::router::sentry_environment: 'staging'
 govuk::apps::search_api::bucket_name: 'govuk-staging-sitemaps'
 govuk::apps::search_api::elasticsearch_hosts: 'https://vpc-blue-elasticsearch6-domain-uibh77cu2kiudtl76uhseobfzq.eu-west-1.es.amazonaws.com'
 govuk::apps::search_api::relevancy_bucket_name: 'govuk-staging-search-relevancy'
-govuk::apps::search_api::enable_learning_to_rank: true
 govuk::apps::short_url_manager::instance_name: 'staging'
 govuk::apps::signon::instance_name: 'staging'
 govuk::apps::static::ga_universal_id: 'UA-26179049-20'

--- a/modules/govuk/manifests/apps/search_api.pp
+++ b/modules/govuk/manifests/apps/search_api.pp
@@ -94,9 +94,6 @@
 # [*relevancy_bucket_name*]
 #   The S3 bucket for search relevancy data - e.g. relevancy judgements
 #
-# [*enable_learning_to_rank*]
-#   A feature flag to enable learning to rank in an environment.
-#
 
 class govuk::apps::search_api(
   $rabbitmq_user,
@@ -129,7 +126,6 @@ class govuk::apps::search_api(
   $bucket_name = undef,
   $relevancy_bucket_name = undef,
   $aws_region = 'eu-west-1',
-  $enable_learning_to_rank = undef,
 ) {
   $app_name = 'search-api'
 
@@ -268,11 +264,5 @@ class govuk::apps::search_api(
     "${title}-AWS_S3_RELEVANCY_BUCKET_NAME":
       varname => 'AWS_S3_RELEVANCY_BUCKET_NAME',
       value   => $relevancy_bucket_name;
-  }
-
-  govuk::app::envvar {
-    "${title}-ENABLE_LTR":
-      varname => 'ENABLE_LTR',
-      value   => $enable_learning_to_rank;
   }
 }


### PR DESCRIPTION
Reverts alphagov/govuk-puppet#9899

This isn't quite right because it tries to write an environment variable as a boolean which is not allowed:

> true is not a string.  It looks to be a TrueClass

I need to check out search-api to ensure that the logic to run LTR is correct if we supply strings to this, so will revert for the moment.