### PR TITLE
Run email-alert-api backups from AWS instead of Carrenza.

### DIFF
--- a/hieradata/node/postgresql-primary-1.backend.publishing.service.gov.uk.yaml
+++ b/hieradata/node/postgresql-primary-1.backend.publishing.service.gov.uk.yaml
@@ -1,6 +1,6 @@
 govuk_env_sync::tasks:
   "push_email_alert_api_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "2"
     minute: "01"
     action: "push"

--- a/hieradata/node/postgresql-primary-1.backend.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/postgresql-primary-1.backend.staging.publishing.service.gov.uk.yaml
@@ -32,17 +32,6 @@ govuk_env_sync::tasks:
     temppath: "/var/lib/autopostgresqlbackup/content_tagger_production"
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
-  "push_email-alert-api_production_daily":
-    ensure: "absent"
-    hour: "1"
-    minute: "12"
-    action: "push"
-    dbms: "postgresql"
-    storagebackend: "s3"
-    database: "email-alert-api_production"
-    temppath: "/var/lib/autopostgresqlbackup/email-alert-api_production"
-    url: "govuk-staging-database-backups"
-    path: "postgresql-backend"
   "push_service-manual-publisher_production_daily":
     ensure: "absent"
     hour: "0"

--- a/hieradata_aws/class/production/db_admin.yaml
+++ b/hieradata_aws/class/production/db_admin.yaml
@@ -21,6 +21,17 @@ govuk_env_sync::tasks:
     temppath: "/tmp/content_data_admin_production_push"
     url: "govuk-production-database-backups"
     path: "postgresql-backend"
+  "push_email_alert_api_production_daily":
+    ensure: "present"
+    hour: "2"
+    minute: "40"
+    action: "push"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "email-alert-api_production"
+    temppath: "/tmp/email-alert-api_production"
+    url: "govuk-production-database-backups"
+    path: "postgresql-backend"
   "push_local-links-manager_production_daily":
     ensure: "present"
     hour: "3"

--- a/hieradata_aws/class/staging/db_admin.yaml
+++ b/hieradata_aws/class/staging/db_admin.yaml
@@ -67,8 +67,8 @@ govuk_env_sync::tasks:
     path: "postgresql-backend"
   "pull_email_alert_api_production_daily":
     ensure: "present"
-    hour: "2"
-    minute: "45"
+    hour: "3"
+    minute: "10"
     action: "pull"
     dbms: "postgresql"
     storagebackend: "s3"


### PR DESCRIPTION
Now that email-alert-api is in AWS, run the nightly backups from there and disable the backup jobs in Carrenza.

Also rejig the timings so that the Staging sync should still catch the same night's Prod backup.