### PR TITLE
Fix name of process to check

### DIFF
--- a/modules/govuk_containers/manifests/tensorflow_serving.pp
+++ b/modules/govuk_containers/manifests/tensorflow_serving.pp
@@ -34,7 +34,7 @@ class govuk_containers::tensorflow_serving(
   }
 
   @@icinga::check { "check_tensorflow_serving_running_${::hostname}":
-    check_command       => 'check_nrpe!check_proc_running!tensorflow_serving',
+    check_command       => 'check_nrpe!check_proc_running!tensorflow_model_server',
     service_description => 'Tensorflow Serving running',
     host_name           => $::fqdn,
     notes_url           => monitoring_docs_url(check-process-running),


### PR DESCRIPTION
`ps -ef | grep tensorflow` gives us "tensorflow_model_server" as the process
to monitor.

This hopefully fixes alerts such as [Tensorflow server running](https://alert.production.govuk.digital/cgi-bin/icinga/extinfo.cgi?type=2&host=ip-10-13-4-111.eu-west-1.compute.internal&service=Tensorflow+Serving+running)