### PR TITLE
Correct tensorflow process name

### DIFF
--- a/modules/govuk_containers/manifests/tensorflow_serving.pp
+++ b/modules/govuk_containers/manifests/tensorflow_serving.pp
@@ -34,7 +34,7 @@ class govuk_containers::tensorflow_serving(
   }
 
   @@icinga::check { "check_tensorflow_serving_running_${::hostname}":
-    check_command       => 'check_nrpe!check_proc_running!tensorflow_model_server',
+    check_command       => 'check_nrpe!check_proc_running!tensorflow_mode',
     service_description => 'Tensorflow Serving running',
     host_name           => $::fqdn,
     notes_url           => monitoring_docs_url(check-process-running),


### PR DESCRIPTION
Running
```
~$ /bin/ps axwo 'stat uid pid ppid vsz rss pcpu comm args' | grep tensorflow
Sl       0  9886  9824 808696 50060  0.1 tensorflow_mode tensorflow_model_server --port=8500 --rest_api_port=8501 --model_name=ltr --model_base_path=/models/ltr
```
reveals that the proc name is actually `tensorflow_mode`.

Running the nagios check manually on a search server against this process name actually works!

```
~$ sudo /usr/lib/nagios/plugins/check_procs -c 1: -C tensorflow_mode
PROCS OK: 1 process with command name 'tensorflow_mode' | procs=1;;1:;0;
```

We're all learning :-)