### PR TITLE
Add AWS applications dashboards for Asset Manager And Whitehall

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -980,6 +980,9 @@ grafana::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 grafana::dashboards::app_domain: "%{hiera('app_domain')}"
 grafana::dashboards::machine_suffix_metrics: ''
 grafana::dashboards::application_dashboards:
+  asset-manager:
+    show_sidekiq_graphs: true
+    has_workers: true
   authenticating-proxy: {}
   cache-clearing-service: {}
   calculators: {}

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1091,6 +1091,11 @@ grafana::dashboards::application_dashboards:
   transition:
     show_sidekiq_graphs: true
     has_workers: true
+  whitehall:
+    show_sidekiq_graphs: true
+    has_workers: true
+    error_threshold: 50
+    warning_threshold: 25
 
 grub2::recordfail_timeout: 5
 


### PR DESCRIPTION
It's running in AWS in Staging and so we need the dashboard to be able to do deploys easily. I copied the values from the old Carrenza dashboards.