### PR TITLE
Prevent CKAN sync between production and staging

### DIFF
--- a/hieradata_aws/class/staging/db_admin.yaml
+++ b/hieradata_aws/class/staging/db_admin.yaml
@@ -1,6 +1,6 @@
 govuk_env_sync::tasks:
   "pull_ckan_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "3"
     minute: "15"
     action: "pull"


### PR DESCRIPTION
## What

To allow pentesters to work on our staging stack we need to ensure that any users we create for them are not wiped out after the daily sync. So stopping the sync should ensure that they can use the same user until they finish their pentesting.

## Why

We would need to create a pentest user every day unless we turn off the data sync