### PR TITLE
Fix Integration data sync for email-alert-api after AWS migration.

### DIFF
--- a/hieradata_aws/class/integration/db_admin.yaml
+++ b/hieradata_aws/class/integration/db_admin.yaml
@@ -32,6 +32,18 @@ govuk_env_sync::tasks:
     temppath: "/tmp/content_data_admin_production_push"
     url: "govuk-integration-database-backups"
     path: "postgresql-backend"
+  "pull_email_alert_api_production_daily":
+    ensure: "present"
+    hour: "3"
+    minute: "10"
+    action: "pull"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "email-alert-api_production"
+    temppath: "/tmp/email-alert-api_production"
+    url: "govuk-production-database-backups"
+    path: "postgresql-backend"
+    transformation_sql_filename: "anonymise_email_addresses.sql"
   "push_local-links-manager_integration_daily":
     ensure: "present"
     hour: "3"

--- a/modules/govuk_env_sync/files/govuk_env_sync.sh
+++ b/modules/govuk_env_sync/files/govuk_env_sync.sh
@@ -14,12 +14,10 @@ set -o errtrace
 #     'push' or 'pull' relative to storage backend (e.g. push to S3)
 #
 #   D) dbms
-
 #     Database management system / data source (One of: mongo,
 #     elasticsearch,postgresql,mysql)
 #     This is used to construct script names called, e.g. dump_mongo
 #     If dbms is elasticsearch, storagebackend must be elasticsearch
-
 #
 #   S) storagebackend
 #     Storage backend (One of: s3,elasticsearch)

--- a/modules/govuk_env_sync/files/govuk_env_sync.sh
+++ b/modules/govuk_env_sync/files/govuk_env_sync.sh
@@ -366,8 +366,7 @@ function filtered_postgresql_restore {
 }
 
 function restore_postgresql {
-  # Check which postgres instance the database needs to restore into
-  # (content-data-api, transition, or postgresql).
+  # Determine source Postgres hostname based on database name.
   if [ "${database}" == 'transition_production' ]; then
     db_hostname='transition-postgresql-primary'
   elif [ "${database}" == 'content_performance_manager_production' ]; then
@@ -378,8 +377,7 @@ function restore_postgresql {
     db_hostname='postgresql-primary'
   fi
 
-# Checking if the database already exist
-# If it does we will drop the database
+  # Drop the target database if it already exists.
   DB_OWNER=''
   if sudo psql -U aws_db_admin -h "${db_hostname}" --no-password --list --quiet --tuples-only | awk '{print $1}' | grep -v "|" | grep -qw "${database}"; then
      log "Database ${database} exists, we will drop it before continuing"

--- a/modules/govuk_env_sync/files/transformation_sql/anonymise_email_addresses.sql
+++ b/modules/govuk_env_sync/files/transformation_sql/anonymise_email_addresses.sql
@@ -1,0 +1,46 @@
+-- This SQL file anonymises email addresses in the email-alert-api database.
+--
+-- It tries to preserve structure so that multiple occurences of the same address
+-- are mapped to the same anonymous address.
+--
+-- It runs when we copy data to Integration via govuk_env_sync:
+-- https://docs.publishing.service.gov.uk/manual/govuk-env-sync.html
+--
+-- Please make changes to this script in
+-- https://github.com/alphagov/email-alert-api/blob/master/lib/data_hygiene/anonymise_email_addresses.sql
+-- where it is tested. Then copy it to the govuk-puppet repository.
+
+-- Deletes all emails that are older than 1 day old.
+DELETE FROM emails
+WHERE created_at < current_timestamp - interval '1 day';
+
+-- Create a table to store all email addresses.
+CREATE TABLE addresses (id SERIAL, address VARCHAR NOT NULL);
+
+-- Copy all email addresses into the table.
+-- Ignore nulled out subscriber addresses.
+INSERT INTO addresses (address)
+  SELECT address FROM subscribers WHERE address IS NOT NULL
+  UNION DISTINCT
+  SELECT address FROM emails;
+
+-- Index the table so we can efficiently lookup addresses.
+CREATE UNIQUE INDEX addresses_index ON addresses (address);
+
+-- Set subscribers.address from the auto-incremented id in addresses table.
+UPDATE subscribers s
+SET address = CONCAT('anonymous-', a.id, '@example.com')
+FROM addresses a
+WHERE a.address = s.address;
+
+-- Set emails.address from the auto-incremented id in addresses table.
+UPDATE emails e
+SET address = CONCAT('anonymous-', a.id, '@example.com'),
+subject = REPLACE(e.subject, e.address, CONCAT('anonymous-', a.id, '@example.com')),
+body = REPLACE(e.body, e.address, CONCAT('anonymous-', a.id, '@example.com'))
+FROM addresses a
+WHERE a.address = e.address;
+
+-- Clean up by deleting the addresses table and its index.
+DROP INDEX addresses_index;
+DROP TABLE addresses;

--- a/modules/govuk_env_sync/manifests/sync_script.pp
+++ b/modules/govuk_env_sync/manifests/sync_script.pp
@@ -18,4 +18,14 @@ class govuk_env_sync::sync_script {
     source => 'puppet:///modules/govuk_env_sync/govuk_env_sync.sh',
   }
 
+  # Data-scrubbing SQL scripts. These are dependencies of the sync script.
+  file { "${govuk_env_sync::conf_dir}/transformation_sql":
+    ensure       => 'directory',
+    recurse      => true,
+    mode         => '0644',
+    owner        => 'root',
+    group        => 'root',
+    sourceselect => 'all',
+    source       => 'puppet:///modules/govuk_env_sync/transformation_sql',
+  }
 }

--- a/modules/govuk_env_sync/manifests/task.pp
+++ b/modules/govuk_env_sync/manifests/task.pp
@@ -67,7 +67,7 @@ define govuk_env_sync::task(
 
   file { "${govuk_env_sync::conf_dir}/${title}.cfg":
     ensure  => $config_ensure,
-    mode    => '0755',
+    mode    => '0644',
     owner   => $govuk_env_sync::user,
     group   => $govuk_env_sync::user,
     content => template('govuk_env_sync/govuk_env_sync_job.conf.erb'),

--- a/modules/govuk_env_sync/manifests/task.pp
+++ b/modules/govuk_env_sync/manifests/task.pp
@@ -39,6 +39,14 @@
 #   One of 'present', 'disabled' or 'absent' to control the task.
 #   Default: 'present'
 #
+# [*transformation_sql_filename*]
+#   Optional filename of a SQL script to run as part of the restore transaction
+#   after the data has been loaded. This is intended for scrubbing user data
+#   when restoring to the Integration environment. The corresponding file must
+#   exist in the files/transformation_sql directory of the govuk_env_sync
+#   Puppet module.
+#   Default: ''
+#
 define govuk_env_sync::task(
   $hour,
   $minute,
@@ -50,6 +58,7 @@ define govuk_env_sync::task(
   $url,
   $path,
   $ensure = 'present',
+  $transformation_sql_filename = '',
 ) {
   $general_ensure = $ensure ? {
     'disabled' => 'absent',

--- a/modules/govuk_env_sync/templates/govuk_env_sync_job.conf.erb
+++ b/modules/govuk_env_sync/templates/govuk_env_sync_job.conf.erb
@@ -5,3 +5,6 @@ temppath="<%= @temppath %>"
 database="<%= @database %>"
 url="<%= @url %>"
 path="<%= @path %>"
+<% if transformation_sql_filename != '' %>
+transformation_sql_file="<%= scope['govuk_env_sync::conf_dir'] %>/transformation_sql/<%= @transformation_sql_filename %>"
+<% end %>


### PR DESCRIPTION
This allows existing data scrubbing scripts to be added to the `files/transformation_sql` directory in the govuk_env_sync Puppet module. These are then referred to in arguments to the task resource and passed to the govuk_env_sync shell script.

email-alert-api is the first database to use this.

Tested in Integration with email-alert-api.

### How to review this

There are many ways that this could potentially be improved, but we've promised to get a working solution by the end of this week so please focus on catching errors and pointing out anything which is wrong or misleading. Other suggestions are welcome but will probably not be addressed in this PR. Thanks!