### PR TITLE
Add Jenkins job to republish organisation pages

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/publishing_api_republish_organisations.pp
+++ b/modules/govuk_jenkins/manifests/jobs/publishing_api_republish_organisations.pp
@@ -1,0 +1,15 @@
+# == Class: govuk_jenkins::jobs::publishing_api_republish_organisations
+#
+# Create a jenkins job to periodically run rake for the following tasks:
+# - represent_downstream:high_priority_document_type[:document_type]
+#
+# === Parameters:
+#
+
+class govuk_jenkins::jobs::publishing_api_republish_organisations{
+  file { '/etc/jenkins_jobs/jobs/publishing_api_republish_organisations.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/publishing_api_republish_organisations.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+}

--- a/modules/govuk_jenkins/templates/jobs/publishing_api_republish_organisations.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/publishing_api_republish_organisations.yaml.erb
@@ -1,0 +1,17 @@
+---
+- job:
+    name: publishing_api_republish_organisations_process
+    display-name: Publishing API - republish organisation pages
+    description: "This job republishes organisation pages using the represent_downstream:high_priority_document_type rake task"
+    builders:
+      - trigger-builds:
+        - project: run-rake-rask
+          block: true
+          predefined-parameters: |
+            TARGET_APPLICATION=publishing-api
+            MACHINE_CLASS=publishing_api
+            RAKE_TASK=represent_downstream:high_priority:document_type[organisation]
+    logrotate:
+        numToKeep: 10
+    triggers:
+      - timed: '*/15 * * * *' # every 15 minutes


### PR DESCRIPTION
This is in case we need to prioritise republishing organisation pages if 
there is a delay due to a large publishing queue. It is currently set to run every 
15 minutes.

As we do not know if we need to use it yet, we can add it to the list of Jenkins
 jobs later.

Related PR:  https://github.com/alphagov/publishing-api/pull/1663

Trello card: https://trello.com/c/uzKUr4WT/1613-3-make-sure-organisation-pages-show-people-changes-quickly-during-reshuffle