### PR TITLE
Revert "Prevent CKAN sync between production and staging"

### DIFF
--- a/hieradata_aws/class/staging/db_admin.yaml
+++ b/hieradata_aws/class/staging/db_admin.yaml
@@ -1,6 +1,6 @@
 govuk_env_sync::tasks:
   "pull_ckan_production_daily":
-    ensure: "absent"
+    ensure: "present"
     hour: "3"
     minute: "15"
     action: "pull"


### PR DESCRIPTION
Reverts alphagov/govuk-puppet#9918

## What

This allows the sync between production and staging to start again wiping out any users created by for pentesting purposes in Staging.

## Reference 

https://trello.com/c/1SkasC0m/1597-prep-work-for-pentesting-on-dgu-stack