### PR TITLE
Enable email technical and internal failure checks in AWS

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -214,8 +214,6 @@ task :check_consistency_between_aws_and_carrenza do
     govuk::apps::govuk_crawler_worker::nagios_memory_critical
     govuk::apps::govuk_crawler_worker::nagios_memory_warning
     govuk::apps::govuk_crawler_worker::disable_during_data_sync
-    govuk::apps::email_alert_api::checks::internal_failure
-    govuk::apps::email_alert_api::checks::technical_failure
     govuk::apps::email_alert_api::db::allow_auth_from_lb
     govuk::apps::email_alert_api::db::lb_ip_range
     govuk::apps::email_alert_api::db::rds

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -151,8 +151,6 @@ govuk::apps::email_alert_api::email_archive_s3_bucket: 'govuk-production-email-a
 # This shouldn't be enabled at the same time we have carrenza s3 export enabled unless they have separate buckets
 govuk::apps::email_alert_api::email_archive_s3_enabled: false
 govuk::apps::email_alert_api::govuk_notify_template_id: 'cb633abc-6ae6-4843-ae6f-82ca500b6de2'
-govuk::apps::email_alert_api::checks::internal_failure: false
-govuk::apps::email_alert_api::checks::technical_failure: false
 govuk::apps::frontend::govuk_notify_template_id: 'cb633abc-6ae6-4843-ae6f-82ca500b6de2'
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::licencefinder::elasticsearch_uri: 'https://vpc-blue-elasticsearch6-domain-2hnib7uydv3tgebhabx74gdelq.eu-west-1.es.amazonaws.com'


### PR DESCRIPTION
- These were added in f6de137f75525438d467759a141a4f5276880e10 and disabled because email-alert-api wasn't in AWS in 0bcbe1a25ed81d41fc4e8e2aa8690465019e50a1.
- We want these now that email-alert-api is in AWS.
- We only need hieradata to override the default `true` (enabled) values.