### PR TITLE
Enable email-alert-api S3 archiving in AWS and disable in Carrenza.

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -62,7 +62,7 @@ govuk::apps::content_publisher::google_tag_manager_preview: "env-2"
 govuk::apps::content_publisher::govuk_notify_template_id: "e00e89f5-b622-4dcb-8f30-e6c70231a940"
 govuk::apps::email_alert_api::db::backend_ip_range: '10.3.3.0/24'
 govuk::apps::email_alert_api::email_archive_s3_bucket: 'govuk-production-email-alert-api-archive'
-govuk::apps::email_alert_api::email_archive_s3_enabled: true
+govuk::apps::email_alert_api::email_archive_s3_enabled: false
 govuk::apps::email_alert_api::govuk_notify_template_id: 'cb633abc-6ae6-4843-ae6f-82ca500b6de2'
 govuk::apps::government-frontend::cpu_warning: 200
 govuk::apps::government-frontend::cpu_critical: 300

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -149,7 +149,7 @@ govuk::apps::govuk_crawler_worker::crawler_threads: '32'
 govuk::apps::email_alert_api::db::backend_ip_range: '10.13.3.0/24'
 govuk::apps::email_alert_api::email_archive_s3_bucket: 'govuk-production-email-alert-api-archive'
 # This shouldn't be enabled at the same time we have carrenza s3 export enabled unless they have separate buckets
-govuk::apps::email_alert_api::email_archive_s3_enabled: false
+govuk::apps::email_alert_api::email_archive_s3_enabled: true
 govuk::apps::email_alert_api::govuk_notify_template_id: 'cb633abc-6ae6-4843-ae6f-82ca500b6de2'
 govuk::apps::frontend::govuk_notify_template_id: 'cb633abc-6ae6-4843-ae6f-82ca500b6de2'
 govuk::apps::hmrc_manuals_api::publish_topics: false


### PR DESCRIPTION
This re-enables email archiving to S3 since the migration to AWS.

Ideally we should have switched this a bit sooner after the migration.