### PR TITLE
Remove govuk-content-schemas from backend boxes

### DIFF
--- a/hieradata/class/backend.yaml
+++ b/hieradata/class/backend.yaml
@@ -5,6 +5,8 @@ govuk::apps::contacts::db_hostname: 'mysql-master-1.backend'
 govuk::apps::contacts::db_username: 'contacts'
 govuk::apps::contacts::db_password: "%{hiera('govuk::apps::contacts::db::mysql_contacts_admin')}"
 
+govuk::apps::govuk_content_schemas::ensure: absent
+
 govuk::apps::manuals_publisher::mongodb_name: 'govuk_content_production'
 govuk::apps::manuals_publisher::mongodb_nodes:
   - 'mongo-1.backend'

--- a/hieradata_aws/class/backend.yaml
+++ b/hieradata_aws/class/backend.yaml
@@ -8,6 +8,8 @@ govuk::apps::contacts::db_password: "%{hiera('govuk::apps::contacts::db::mysql_c
 govuk::apps::email_alert_api::enabled: false
 govuk::apps::email_alert_service::enabled: false
 
+govuk::apps::govuk_content_schemas::ensure: absent
+
 govuk::apps::manuals_publisher::mongodb_name: 'govuk_content_production'
 govuk::apps::manuals_publisher::mongodb_nodes:
   - 'mongo-1'

--- a/modules/govuk/manifests/apps/govuk_content_schemas.pp
+++ b/modules/govuk/manifests/apps/govuk_content_schemas.pp
@@ -4,17 +4,31 @@
 #
 # === Parameters
 #
+# [*ensure*]
+#   Allow schemas to be removed.
+#
 # [*directory*]
 #   The directory in which the govuk_content_schemas should be
-#   available.
+#   deployed.
 #
 class govuk::apps::govuk_content_schemas(
-  $directory = '/data/apps/govuk-content-schemas/current',
+  $ensure = present,
+  $directory = '/data/apps/govuk-content-schemas',
 ) {
   include icinga::client::check_directory_exists
 
+  if $ensure == absent {
+    file { $directory:
+      ensure => absent,
+      force  => true,
+    }
+  }
+
+  $current_directory = "${directory}/current"
+
   @@icinga::check { "check_govuk_content_schemas_on_${::hostname}":
-    check_command       => "check_nrpe!check_directory_exists!${directory}",
+    ensure              => $ensure,
+    check_command       => "check_nrpe!check_directory_exists!${current_directory}",
     service_description => 'govuk_content_schemas exists',
     host_name           => $::fqdn,
   }


### PR DESCRIPTION
Trello: https://trello.com/c/zHm2B8VX/1242-present-organisation-political-status-from-whitehall-to-publishing-api

These files are removed from backend machines to get around a problem. Ever since the migration of Publishing API to AWS we have not been able to deploy govuk-content-schemas since they are [deployed to backend and publishing-api](https://github.com/alphagov/govuk-app-deployment/blob/c1d210e37b402df4377e5146d31bfb433f78dc65/govuk-content-schemas/config/deploy.rb#L3) machine classes and this will fail when trying in a carrenza environment as the publishing-api machines aren't available which causes problems and confusion.

From my research no applications other than Publishing API actually use the schemas in production and I believe the only reason we put these on both backend and publishing-api boxes is to facilitate Publishing API being migrated between these machines.

Things I've done to check usage of this:

- Check Gemfiles of apps: I ran `find ~/govuk -name Gemfile | xargs grep 'govuk_schemas' -B 5` and could see the gem was only depended outside a test environment in Publishing API and govuk-content-schemas
- Check end-to-end tests: the govuk-content-schemas mount is only used by Publishing API, Mainstream Publisher and Content Store. Only Mainstream Publisher is on backend which only uses [schemas for tests](https://github.com/alphagov/publisher/blame/a0e19e84fd3f63fba17913c4fc255e0f8ea453cd/README.md#L54)

@cbaines and @thomasleese can you think of anything I might have missed or any reasons why govuk-content-schemas are required on backend boxes?

/cc @sengi 