### PR TITLE
Add NDCG metric

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -417,7 +417,7 @@ task :check_consistency_between_aws_and_carrenza do
     govuk_jenkins::jobs::search_fetch_analytics_data::cron_schedule
     govuk_jenkins::jobs::search_fetch_analytics_data::skip_page_traffic_load
     govuk_jenkins::jobs::search_relevancy_rank_evaluation::cron_schedule
-    govuk_jenkins::jobs::search_google_analytics_etl::cron_schedule
+    govuk_jenkins::jobs::search_relevancy_metrics_etl::cron_schedule
     govuk_jenkins::jobs::enhanced_ecommerce_search_api::cron_schedule
     govuk_jenkins::jobs::smokey::environment
     govuk_mysql::server::expire_log_days

--- a/hieradata_aws/class/integration/jenkins.yaml
+++ b/hieradata_aws/class/integration/jenkins.yaml
@@ -37,7 +37,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::search_test_spelling_suggestions
   - govuk_jenkins::jobs::search_generate_sitemaps
   - govuk_jenkins::jobs::search_relevancy_rank_evaluation
-  - govuk_jenkins::jobs::search_google_analytics_etl
+  - govuk_jenkins::jobs::search_relevancy_metrics_etl
   - govuk_jenkins::jobs::send_bulk_email
   - govuk_jenkins::jobs::signon_cron_rake_tasks
   - govuk_jenkins::jobs::smokey

--- a/hieradata_aws/class/production/jenkins.yaml
+++ b/hieradata_aws/class/production/jenkins.yaml
@@ -28,7 +28,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::search_api_reindex_with_new_schema
   - govuk_jenkins::jobs::search_generate_sitemaps
   - govuk_jenkins::jobs::search_relevancy_rank_evaluation
-  - govuk_jenkins::jobs::search_google_analytics_etl
+  - govuk_jenkins::jobs::search_relevancy_metrics_etl
   - govuk_jenkins::jobs::smokey
   - govuk_jenkins::jobs::smokey_deploy
   - govuk_jenkins::jobs::transition_import_dns

--- a/hieradata_aws/class/staging/jenkins.yaml
+++ b/hieradata_aws/class/staging/jenkins.yaml
@@ -24,7 +24,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::search_api_index_checks
   - govuk_jenkins::jobs::search_api_reindex_with_new_schema
   - govuk_jenkins::jobs::search_relevancy_rank_evaluation
-  - govuk_jenkins::jobs::search_google_analytics_etl
+  - govuk_jenkins::jobs::search_relevancy_metrics_etl
   - govuk_jenkins::jobs::search_generate_sitemaps
   - govuk_jenkins::jobs::smokey
   - govuk_jenkins::jobs::smokey_deploy

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -140,7 +140,7 @@ govuk_jenkins::jobs::search_api_fetch_analytics_data::skip_page_traffic_load: tr
 govuk_jenkins::jobs::search_api_fetch_analytics_data::cron_schedule: '30 9 * * 1-5'
 
 govuk_jenkins::jobs::search_relevancy_rank_evaluation::cron_schedule: '45 */3 * * *' # every three hours
-govuk_jenkins::jobs::search_google_analytics_etl::cron_schedule: 'H 2,8,14,20 * * *' # every six hours
+govuk_jenkins::jobs::search_relevancy_metrics_etl::cron_schedule: 'H 2,8,14,20 * * *' # every six hours
 # Integration doesn't have a mirror
 govuk_jenkins::jobs::update_cdn_dictionaries::allow_deploy_to_mirror: false
 

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -239,7 +239,7 @@ govuk_jenkins::jobs::search_fetch_analytics_data::skip_page_traffic_load: true
 govuk_jenkins::jobs::search_fetch_analytics_data::cron_schedule: '30 8 * * 1-5'
 
 govuk_jenkins::jobs::search_relevancy_rank_evaluation::cron_schedule: '45 */3 * * *' # every three hours
-govuk_jenkins::jobs::search_google_analytics_etl::cron_schedule: 'H 0,6,12,18 * * *' # every six hours
+govuk_jenkins::jobs::search_relevancy_metrics_etl::cron_schedule: 'H 0,6,12,18 * * *' # every six hours
 
 govuk_jenkins::jobs::smokey::environment: production_aws
 

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -211,7 +211,7 @@ govuk_jenkins::jobs::search_fetch_analytics_data::skip_page_traffic_load: true
 govuk_jenkins::jobs::search_fetch_analytics_data::cron_schedule: '30 8 * * 1-5'
 
 govuk_jenkins::jobs::search_relevancy_rank_evaluation::cron_schedule: '45 */3 * * *' # every three hours
-govuk_jenkins::jobs::search_google_analytics_etl::cron_schedule: 'H 1,7,13,19 * * *' # every six hours
+govuk_jenkins::jobs::search_relevancy_metrics_etl::cron_schedule: 'H 1,7,13,19 * * *' # every six hours
 
 govuk_jenkins::jobs::smokey::environment: staging_aws
 

--- a/modules/govuk_jenkins/manifests/jobs/search_relevancy_metrics_etl.pp
+++ b/modules/govuk_jenkins/manifests/jobs/search_relevancy_metrics_etl.pp
@@ -1,6 +1,6 @@
-# == Class: govuk_jenkins::jobs::search_google_analytics_etl
+# == Class: govuk_jenkins::jobs::search_relevancy_metrics_etl
 #
-# A Jenkins job to periodically load Google Analytics data into graphite,
+# A Jenkins job to periodically load search relevancy metrics into graphite,
 # using a rake task in Search API. The data is displayed in the Search Relevancy
 # grafana dashboard.
 #
@@ -10,18 +10,18 @@
 #   The cron schedule to specify how often this task will run
 #   Default: undef
 #
-class govuk_jenkins::jobs::search_google_analytics_etl (
+class govuk_jenkins::jobs::search_relevancy_metrics_etl (
   $cron_schedule = undef,
   $app_domain = hiera('app_domain'),
 ) {
 
-  $check_name = 'search-google-analytics-etl'
-  $service_description = 'Search Google Analytics ETL'
-  $job_url = "https://deploy.${::aws_environment}.govuk.digital/job/search_google_analytics_etl/"
+  $check_name = 'search-relevancy-metrics-etl'
+  $service_description = 'Search Relevancy Metrics ETL'
+  $job_url = "https://deploy.${::aws_environment}.govuk.digital/job/search_relevancy_metrics_etl/"
 
-  file { '/etc/jenkins_jobs/jobs/search_google_analytics_etl.yaml':
+  file { '/etc/jenkins_jobs/jobs/search_relevancy_metrics_etl.yaml':
     ensure  => present,
-    content => template('govuk_jenkins/jobs/search_google_analytics_etl.yaml.erb'),
+    content => template('govuk_jenkins/jobs/search_relevancy_metrics_etl.yaml.erb'),
     notify  => Exec['jenkins_jobs_update'],
   }
 

--- a/modules/govuk_jenkins/templates/jobs/search_relevancy_metrics_etl.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/search_relevancy_metrics_etl.yaml.erb
@@ -1,10 +1,11 @@
 ---
 - job:
-    name: search_google_analytics_etl
-    display-name: Search Google Analytics ETL
+    name: search_relevancy_metrics_etl
+    display-name: Search Relevancy Metrics ETL
     project-type: freestyle
-    description: "<p>Runs a Search API rake task relevancy:send_ga_data_to_graphite.</p>
-    <p>The rake task extracts GA data and loads it into Graphite.</p>
+    description: "<p>Runs a Search API rake task relevancy:send_metrics_to_graphite.</p>
+    <p>This rake task loads search relevancy metrics into Graphite, such as
+    click-through-rates from Google Analytics and NDCG.</p>
     <p>This is a monitoring task. It is safe to re-run in-hours.</p>
     <p>Get in touch with the search team for more details.</p>"
     builders:
@@ -14,7 +15,7 @@
             predefined-parameters: |
               TARGET_APPLICATION=search-api
               MACHINE_CLASS=search
-              RAKE_TASK=relevancy:send_ga_data_to_graphite SEND_TO_GRAPHITE=true
+              RAKE_TASK=relevancy:send_metrics_to_graphite SEND_TO_GRAPHITE=true
     wrappers:
       - ansicolor:
           colormap: xterm

--- a/modules/grafana/files/dashboards/search_relevancy.json
+++ b/modules/grafana/files/dashboards/search_relevancy.json
@@ -187,6 +187,96 @@
       "showTitle": true,
       "title": "Rank evaluation - how are we doing against our relevancy judgements?",
       "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 250,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Graphite",
+          "description": "Average normalised discounted cumulative gain (nDCG) for a set of manual relevancy judgements",
+          "fill": 1,
+          "id": 7,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 1,
+          "points": true,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": ""
+            }
+          ],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": true,
+          "targets": [
+            {
+              "refId": "A",
+              "target": "aliasByNode(stats.gauges.govuk.app.search-api.relevancy.ndcg.*, 7)",
+              "textEditor": true
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "NDCG",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
     }
   ],
   "schemaVersion": 14,


### PR DESCRIPTION
This add [NDCG](https://en.wikipedia.org/wiki/Discounted_cumulative_gain) (a ranking metric) as a metric to the search relevancy dashboard.

It also adapts an existing job search-google-analytics-etl, that does a similar thing, expanding it to include other relevancy metrics that need to be etl'd to graphite. This new job will call a Search API rake task relevancy:send_metrics_to_graphite, introduced in alphagov/search-api#1841.

Should be merged after https://github.com/alphagov/search-api/pull/1841 is deployed.