### PR TITLE
Add govuk-content-schemas to backend boxes to remove them

### DIFF
--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -21,6 +21,7 @@ node_class: &node_class
       - canary-backend
       - content-data-admin
       - content-data-api
+      - govuk-content-schemas
       - transition
       - imminence
       - kibana

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -22,6 +22,7 @@ node_class: &node_class
       - canary-backend
       - content-data-admin
       - content-data-api
+      - govuk-content-schemas
       - transition
       - imminence
       - kibana


### PR DESCRIPTION
This somewhat paradoxical change is done because at the moment
govuk-content-schemas is deployed to both boxes [1] and thus
govuk-content-schemas exists on these AWS boxes despite not being
defined as an application through puppet.