### PR TITLE
Install docker on standalone jenkins instances

### DIFF
--- a/modules/govuk/manifests/node/s_jenkins.pp
+++ b/modules/govuk/manifests/node/s_jenkins.pp
@@ -61,4 +61,29 @@ class govuk::node::s_jenkins (
 
   # Required for a job that issues Jenkins Crumbs
   ensure_packages(['jq'])
+
+  # can't use the collectd plugin because the installation conflicts
+  # with some other python packages on the agent
+  class { '::govuk_docker':
+    docker_users           => ['jenkins'],
+    enable_collectd_plugin => false,
+  }
+
+  cron::crondotdee { 'docker_system_prune_dangling' :
+    hour    => '*',
+    minute  => 0,
+    command => 'docker system prune -f --filter="until=1h"',
+  }
+
+  cron::crondotdee { 'docker_system_prune_all' :
+    hour    => 4,
+    minute  => 30,
+    command => 'docker system prune -a -f --filter="until=48h"',
+  }
+
+  cron::crondotdee { 'docker_volume_prune' :
+    hour    => '*',
+    minute  => 5,
+    command => 'docker volume prune -f',
+  }
 }

--- a/modules/govuk_docker/manifests/init.pp
+++ b/modules/govuk_docker/manifests/init.pp
@@ -12,13 +12,21 @@
 #   Pin a version to use
 #   Default is present
 #
+# [*enable_collectd_plugin*]
+#   Enable the collectd plugin
+#   Default is true
+#
 class govuk_docker (
   $docker_users = [],
   $version = 'present',
+  $enable_collectd_plugin = true,
 ){
   validate_array($docker_users)
 
-  include ::collectd::plugin::docker
+  if $enable_collectd_plugin {
+    include ::collectd::plugin::docker
+  }
+
   include govuk_docker::repo
 
   class {'::docker':


### PR DESCRIPTION
This is useful for the search-analytics job, which has recently
started failing because the version of pip we have on the jenkins
instances is so old, it can't install some of its dependencies.

An alternative would be updating pip.  This probably has updating
Python as a pre-requisite, so both would need to be packaged for
Ubuntu 14.04.  We might then discover incompatibilities, where there
are other things running which have broken with a newer version of
Python.

Containers are a nice solution to this: jobs can specify the versions
of dependencies they need, different jobs can use different versions,
and we don't need to manually package stuff.

---

With this PR applied, fixing the search-analytics job is simple: https://github.com/alphagov/search-analytics/compare/msw/dockerise-nightly-run