### PR TITLE
Remove config for govuk-content-schemas on backend class

### DIFF
--- a/hieradata/class/backend.yaml
+++ b/hieradata/class/backend.yaml
@@ -5,8 +5,6 @@ govuk::apps::contacts::db_hostname: 'mysql-master-1.backend'
 govuk::apps::contacts::db_username: 'contacts'
 govuk::apps::contacts::db_password: "%{hiera('govuk::apps::contacts::db::mysql_contacts_admin')}"
 
-govuk::apps::govuk_content_schemas::ensure: absent
-
 govuk::apps::manuals_publisher::mongodb_name: 'govuk_content_production'
 govuk::apps::manuals_publisher::mongodb_nodes:
   - 'mongo-1.backend'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -24,7 +24,6 @@ node_class: &node_class
       - content-audit-tool
       - content-publisher
       - content-tagger
-      - govuk-content-schemas
       - hmrc-manuals-api
       - kibana
       - manuals-publisher

--- a/hieradata_aws/class/backend.yaml
+++ b/hieradata_aws/class/backend.yaml
@@ -8,8 +8,6 @@ govuk::apps::contacts::db_password: "%{hiera('govuk::apps::contacts::db::mysql_c
 govuk::apps::email_alert_api::enabled: false
 govuk::apps::email_alert_service::enabled: false
 
-govuk::apps::govuk_content_schemas::ensure: absent
-
 govuk::apps::manuals_publisher::mongodb_name: 'govuk_content_production'
 govuk::apps::manuals_publisher::mongodb_nodes:
   - 'mongo-1'

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -26,7 +26,6 @@ node_class: &node_class
       - content-data-api
       - content-publisher
       - content-tagger
-      - govuk-content-schemas
       - hmrc-manuals-api
       - imminence
       - kibana

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -21,7 +21,6 @@ node_class: &node_class
       - canary-backend
       - content-data-admin
       - content-data-api
-      - govuk-content-schemas
       - transition
       - imminence
       - kibana

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -22,7 +22,6 @@ node_class: &node_class
       - canary-backend
       - content-data-admin
       - content-data-api
-      - govuk-content-schemas
       - transition
       - imminence
       - kibana


### PR DESCRIPTION
Now that the code has run in all environments to remove
govuk-content-schemas from backend machines we can now remove the
configuration from puppet.

Follows on from: https://github.com/alphagov/govuk-puppet/pull/9952, https://github.com/alphagov/govuk-puppet/pull/9940 and https://github.com/alphagov/govuk-app-deployment/pull/342