### PR TITLE
Tweaks to prometheus configuration

### DIFF
--- a/modules/govuk_prometheus/files/etc/prometheus/prometheus.yml
+++ b/modules/govuk_prometheus/files/etc/prometheus/prometheus.yml
@@ -27,3 +27,6 @@ scrape_configs:
     ec2_sd_configs:
       - region: "eu-west-1"
         port: 9080
+        filters:
+        - name: instance-state-name
+          values: [ running ]

--- a/modules/govuk_prometheus/files/etc/prometheus/prometheus.yml
+++ b/modules/govuk_prometheus/files/etc/prometheus/prometheus.yml
@@ -30,3 +30,12 @@ scrape_configs:
         filters:
         - name: instance-state-name
           values: [ running ]
+  - job_name: 'prometheus'
+    ec2_sd_configs:
+      - region: "eu-west-1"
+        port: 9090
+        filters:
+        - name: instance-state-name
+          values: [ running ]
+        - name: tag:aws_migration
+          values: [ prometheus ]

--- a/modules/govuk_prometheus/files/etc/prometheus/prometheus.yml
+++ b/modules/govuk_prometheus/files/etc/prometheus/prometheus.yml
@@ -23,7 +23,7 @@ rule_files:
 
 # A scrape configuration for ec2 instances
 scrape_configs:
-  - job_name: 'ec2'
+  - job_name: 'node'
     ec2_sd_configs:
       - region: "eu-west-1"
         port: 9080


### PR DESCRIPTION
## don't try to scrape stopped instances

There are some stopped gatling boxes in production, which prometheus
is trying to scrape.  This means that they appear as "down" targets in
prometheus.

I think Prometheus maybe shouldn't try to scrape instances that are
known to be stopped?

Those gatling boxes are a bit weird in any case; they don't have the
same tags as the other boxes in that environment.

## scrape prometheus metrics

Prometheus exposes metrics about itself.  We should scrape them.

This uses ec2_sd_configs to scrape only instances which have tag
`aws_migration` set to `prometheus`.