### PR TITLE
Add EC2 tags to prometheus targets

### DIFF
--- a/modules/govuk_prometheus/files/etc/prometheus/prometheus.yml
+++ b/modules/govuk_prometheus/files/etc/prometheus/prometheus.yml
@@ -30,6 +30,9 @@ scrape_configs:
         filters:
         - name: instance-state-name
           values: [ running ]
+    relabel_configs:
+      - action: labelmap
+        regex: __meta_ec2_tag_(.+)
   - job_name: 'prometheus'
     ec2_sd_configs:
       - region: "eu-west-1"
@@ -39,3 +42,6 @@ scrape_configs:
           values: [ running ]
         - name: tag:aws_migration
           values: [ prometheus ]
+    relabel_configs:
+      - action: labelmap
+        regex: __meta_ec2_tag_(.+)


### PR DESCRIPTION
Currently, we can't tell which node exporter is running on which
instance very easily.

This commit uses the magic `labelmap` action to add all EC2 instance
tags as target labels to the targets, so that we can much more easily
see what instance type it is.