### PR TITLE
Remove rabbitmq federation from AWS to Carrenza in staging

### DIFF
--- a/hieradata_aws/class/staging/rabbitmq.yaml
+++ b/hieradata_aws/class/staging/rabbitmq.yaml
@@ -1,8 +1,0 @@
----
-
-govuk_rabbitmq::federation: 'yes'
-govuk_rabbitmq::federate::federation_user: 'root'
-govuk_rabbitmq::federate::federation_pass: "%{hiera('govuk_rabbitmq::root_password')}"
-govuk_rabbitmq::federate::upstream_servers: ['10.2.3.70', '10.2.3.71', '10.2.3.72']
-govuk_rabbitmq::federate::upstream_name: 'carrenza'
-govuk_rabbitmq::federate::federation_exchange: 'published_documents'


### PR DESCRIPTION
No longuer required following migration of publishing-api and
email alert in AWS.