### PR TITLE
Revert "remove whitehall frontend plek for AWS Staging content store"

### DIFF
--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -141,6 +141,7 @@ govuk::apps::content_publisher::email_address_override: "content-publisher-notif
 govuk::apps::content_publisher::govuk_notify_template_id: "112842bb-d8a4-4511-90de-57dc5c8f27ec"
 govuk::apps::content_store::performance_platform_big_screen_view_url: 'https://performance-platform-big-screen-view-staging.cloudapps.digital'
 govuk::apps::content_store::performance_platform_spotlight_url: 'https://performance-platform-spotlight-staging.cloudapps.digital'
+govuk::apps::content_store::plek_service_whitehall_frontend_uri: 'https://whitehall-frontend.staging.publishing.service.gov.uk'
 
 govuk::apps::email_alert_api::db::backend_ip_range: '10.12.3.0/24'
 govuk::apps::email_alert_api::email_archive_s3_bucket: 'govuk-staging-email-alert-api-archive'


### PR DESCRIPTION
Reverts alphagov/govuk-puppet#9888

Testing rollback of Whitehall/Assets migration in Staging.