### PR TITLE
Revert "remove asset manager from carrenza staging"

### DIFF
--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -328,6 +328,7 @@ hosts::production::backend::hosts:
     ip: '10.2.11.31'
 
 hosts::production::backend::app_hostnames:
+  - 'asset-manager'
   - 'canary-backend'
   - 'collections-publisher'
   - 'contacts-admin'


### PR DESCRIPTION
Reverts alphagov/govuk-puppet#9870

Testing rollback of Whitehall/Assets migration in Staging.