### PR TITLE
Start to remove terraform-docs package from Jenkins machines

### DIFF
--- a/modules/govuk_jenkins/manifests/packages/terraform_docs.pp
+++ b/modules/govuk_jenkins/manifests/packages/terraform_docs.pp
@@ -20,8 +20,7 @@ class govuk_jenkins::packages::terraform_docs (
   }
 
   package { 'terraform-docs':
-    ensure  => $version,
-    require => Apt::Source['terraform-docs'],
+    ensure  => absent,
   }
 
 }


### PR DESCRIPTION
- The check in govuk-aws for docs generation, for which this package was
  needed, was moved to Concourse in
  https://github.com/alphagov/govuk-aws/pull/1200.