### PR TITLE
Remove the MHRA reverse proxy NGINX config

### DIFF
--- a/modules/govuk/manifests/apps/bouncer.pp
+++ b/modules/govuk/manifests/apps/bouncer.pp
@@ -170,18 +170,19 @@ class govuk::apps::bouncer(
   }
 
   nginx::config::site { 'www.mhra.gov.uk':
+    ensure  => absent,
     content => template('govuk/www.mhra.gov.uk_nginx.conf.erb'),
   }
 
   nginx::log {
     'www.mhra.gov.uk-json.event.access.log':
       json          => true,
-      logstream     => present,
+      logstream     => absent,
       statsd_metric => "${::fqdn_metrics}.nginx_logs.mhra_proxy.http_%{status}",
       statsd_timers => [{metric => "${::fqdn_metrics}.nginx_logs.mhra_proxy.time_request",
                           value => 'request_time'}];
     'www.mhra.gov.uk-error.log':
-      logstream     => present;
+      logstream     => absent;
   }
 
   if $::govuk_node_class !~ /^development$/ {


### PR DESCRIPTION
We are turning off the MHRA specific reverse proxy.

This ensures that www.mhra.gov.uk is absent from sites-available and
sites-enabled. It also (hopefully) ensures the associated log files are
absent.

Do not merge until we have the go ahead from MHRA on the zendesk ticket linked in the trello card.

[Trello](https://trello.com/c/v6DwqTy8/1640-3-remove-mhra-reverse-proxy)

Once this is merged and deployed and puppet has run on bouncer, we should merge and deploy:

* [ ] Subsequent [PR 9980](https://github.com/alphagov/govuk-puppet/pull/9980) (currently still in draft) to remove the code paths once this one is deployed and run on bouncer.
* [ ] Developer docs PR 2181](https://github.com/alphagov/govuk-developer-docs/pull/2181) to remove the special case mention in the docs.
