### PR TITLE
Fix Grafana Dashboard alert

### DIFF
--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_grafana_dashboards
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_grafana_dashboards
@@ -10,7 +10,7 @@ done
 
 DASHBOARDS=$(curl -s https://$GRAFANA_HOST/api/search | jq -c '.[]' | grep 'db/' | jq '.title')
 
-if [ ${#DASHBOARDS[@]} -eq 0 ]; then
+if [ -z "$DASHBOARDS" ]; then
   echo "OK: All dashboards are in version control"
   exit 0
 fi

--- a/modules/monitoring/manifests/checks/grafana_dashboards.pp
+++ b/modules/monitoring/manifests/checks/grafana_dashboards.pp
@@ -4,6 +4,7 @@
 class monitoring::checks::grafana_dashboards (
 ) {
   $app_domain_internal = hiera('app_domain_internal')
+  $app_domain = hiera('app_domain')
 
   icinga::plugin { 'check_grafana_dashboards':
     source => 'puppet:///modules/monitoring/usr/lib/nagios/plugins/check_grafana_dashboards',
@@ -22,6 +23,6 @@ class monitoring::checks::grafana_dashboards (
     service_description => 'At least 1 Grafana dashboard is not in version control',
     require             => Icinga::Check_config['check_grafana_dashboards'],
     notes_url           => monitoring_docs_url(grafana-dashboards),
-    action_url          => "https://grafana.${app_domain_internal}",
+    action_url          => "https://grafana.${app_domain}",
   }
 }


### PR DESCRIPTION
This fixes the alert to stop it mis-firing when all dashboards
are in version control. It also fixes the action URL domain.