### PR TITLE
Add icinga check status updates for delivery attempts in email-alert-api

### DIFF
--- a/modules/govuk/manifests/apps/email_alert_api/checks.pp
+++ b/modules/govuk/manifests/apps/email_alert_api/checks.pp
@@ -5,6 +5,7 @@
 class govuk::apps::email_alert_api::checks(
   $internal_failure = true,
   $technical_failure = true,
+  $ensure = present,
 ) {
   $internal_failure_ensure = $internal_failure ? { true => present, false => absent }
 
@@ -26,5 +27,15 @@ class govuk::apps::email_alert_api::checks(
     critical  => '3600000', # 4,000,000 * 0.9
     from      => '3hours',
     desc      => 'High number of email send requests',
+  }
+
+  @@icinga::check::graphite { 'email-alert-api-delivery-attempt-status-update':
+    ensure    => $ensure,
+    host_name => $::fqdn,
+    target    => 'divideSeries(keepLastValue(stats.gauges.govuk.email-alert-api.delivery_attempt.pending_status_total), keepLastValue(stats.gauges.govuk.email-alert-api.delivery_attempt.total))',
+    warning   => '0.166',
+    critical  => '0.25',
+    from      => '1hour',
+    desc      => 'High number of delivery attempts have not received status updates',
   }
 }

--- a/modules/govuk/manifests/apps/email_alert_api/checks.pp
+++ b/modules/govuk/manifests/apps/email_alert_api/checks.pp
@@ -3,20 +3,15 @@
 # Various Icinga checks for Email Alert API.
 #
 class govuk::apps::email_alert_api::checks(
-  $internal_failure = true,
-  $technical_failure = true,
   $ensure = present,
 ) {
-  $internal_failure_ensure = $internal_failure ? { true => present, false => absent }
 
   delivery_attempt_status_check { 'internal_failure':
-    ensure => $internal_failure_ensure,
+    ensure => $ensure,
   }
 
-  $technical_failure_ensure = $technical_failure ? { true => present, false => absent }
-
   delivery_attempt_status_check { 'technical_failure':
-    ensure => $technical_failure_ensure,
+    ensure => $ensure,
   }
 
   @@icinga::check::graphite { 'email-alert-api-notify-email-send-request-success':


### PR DESCRIPTION
We are no longer using a healthcheck to monitor the status of delivery
attempts created within the past hour in email-alert-api.

This Icinga check is not machine specific and the data used lives in
stats/gauges/govuk/email-alert-api in Graphite. We can use Graphite's
`divideSeries` function to calculate the proportion of delivery
attempts that are still in `pending` status.
See https://graphite.readthedocs.io/en/latest/functions.html#graphite.render.functions.divideSeries
for more information.

The threshold values have been taken from the original healthcheck,
see https://github.com/alphagov/email-alert-api/pull/1074/files

Related PRs:
alphagov/email-alert-api#1073

[trello](https://trello.com/c/hPiOuVko/1581-5-extract-the-statusupdates-check-from-the-healthcheck-endpoint-in-email-alert-api-to-a-separate-icinga-check)