### PR TITLE
Remove Kibana App From Backend Machines in AWS

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -28,7 +28,6 @@ node_class: &node_class
       - content-tagger
       - hmrc-manuals-api
       - imminence
-      - kibana
       - link-checker-api
       - local-links-manager
       - manuals-publisher

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -23,7 +23,6 @@ node_class: &node_class
       - content-data-api
       - transition
       - imminence
-      - kibana
       - link-checker-api
       - local-links-manager
       - sidekiq-monitoring

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -24,7 +24,6 @@ node_class: &node_class
       - content-data-api
       - transition
       - imminence
-      - kibana
       - link-checker-api
       - local-links-manager
       - sidekiq-monitoring


### PR DESCRIPTION
This appears to be breaking app deployment, and is unused.