### PR TITLE
Stop monitoring the Kibana redirect.

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -355,6 +355,7 @@ monitoring::checks::lb::loadbalancers:
       - backend-content-api
       - backend-content-performance-m
       - backend-docs
+      - backend-kibana
       - backend-policy-publisher
   govuk-cache-public: {}
 

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -346,6 +346,7 @@ monitoring::checks::lb::loadbalancers:
       - backend-content-tagger
       - backend-docs
       - backend-hmrc-manuals-api
+      - backend-kibana
       - backend-manuals-publisher
       - backend-maslow
       - backend-policy-publisher

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -325,6 +325,7 @@ monitoring::checks::lb::loadbalancers:
       - backend-content-tagger
       - backend-docs
       - backend-hmrc-manuals-api
+      - backend-kibana
       - backend-manuals-publisher
       - backend-maslow
       - backend-policy-publisher


### PR DESCRIPTION
This is the redirect from kibana.*.publishing.service.gov.uk to LogIt. The redirect is no longer in use and the app which serves it is being decommissioned because it breaks spinning up new `backend` instances and isn't worth fixing.

Exclude it from the [AWS LB Healthy Hosts](https://alert.staging.govuk.digital/cgi-bin/icinga/status.cgi?search_string=govuk-backend-public) alert so that that alert (which covers lots of other services) can continue to be used while we finish removing the config for the Kibana redirect.

This exclusion is only needed until we finish removing `backend-kibana` from the load balancer configs.