### PR TITLE
Don't have the bouncer machines set to 'urgent-priority'

### DIFF
--- a/hieradata_aws/class/production/bouncer.yaml
+++ b/hieradata_aws/class/production/bouncer.yaml
@@ -2,5 +2,3 @@
 
 govuk_bouncer::gor::enabled: true
 govuk_bouncer::gor::target: bouncer.blue.staging.govuk.digital
-
-icinga::client::contact_groups: 'urgent-priority'


### PR DESCRIPTION
As this means someone gets called when they fail or go away, even out
of hours. The process for removing traffic from the failed machine,
and bringing up a new one to replace it is entirely automated (which
is good!), so there's no need to call someone.