### PR TITLE
Clean up Carrenza Email Alert API configuration

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -101,7 +101,6 @@ task :check_consistency_between_aws_and_carrenza do
     govuk::apps::whitehall::cpu_warning
     govuk::node::s_api_lb::api_servers
     govuk::node::s_backend_lb::backend_servers
-    govuk::node::s_backend_lb::email_alert_api_backend_servers
     govuk::node::s_backend_lb::perfplat_public_app_domain
     govuk::node::s_backend_lb::publishing_api_backend_servers
     govuk::node::s_backend_lb::whitehall_backend_servers

--- a/Rakefile
+++ b/Rakefile
@@ -36,8 +36,6 @@ task :check_consistency_between_aws_and_carrenza do
     govuk::apps::content_publisher::db::backend_ip_range
     govuk::apps::content_tagger::db_allow_prepared_statements
     govuk::apps::content_tagger::db_port
-    govuk::apps::email_alert_api::db_allow_prepared_statements
-    govuk::apps::email_alert_api::db_port
     govuk::apps::publisher::email_group_business
     govuk::apps::publisher::email_group_citizen
     govuk::apps::publisher::email_group_dev
@@ -214,8 +212,24 @@ task :check_consistency_between_aws_and_carrenza do
     govuk::apps::govuk_crawler_worker::nagios_memory_warning
     govuk::apps::govuk_crawler_worker::disable_during_data_sync
     govuk::apps::email_alert_api::db::allow_auth_from_lb
+    govuk::apps::email_alert_api::db::backend_ip_range
     govuk::apps::email_alert_api::db::lb_ip_range
     govuk::apps::email_alert_api::db::rds
+    govuk::apps::email_alert_api::db_hostname
+    govuk::apps::email_alert_api::db_password
+    govuk::apps::email_alert_api::delivery_request_threshold
+    govuk::apps::email_alert_api::email_address_override
+    govuk::apps::email_alert_api::email_address_override_whitelist
+    govuk::apps::email_alert_api::email_address_override_whitelist_only
+    govuk::apps::email_alert_api::email_archive_s3_bucket
+    govuk::apps::email_alert_api::email_archive_s3_enabled
+    govuk::apps::email_alert_api::enabled
+    govuk::apps::email_alert_api::govuk_notify_template_id
+    govuk::apps::email_alert_api::nagios_memory_critical
+    govuk::apps::email_alert_api::nagios_memory_warning
+    govuk::apps::email_alert_api::redis_host
+    govuk::apps::email_alert_api::redis_port
+    govuk::apps::email_alert_api::unicorn_worker_processes
     govuk::apps::email_alert_frontend::subscription_management_enabled
     govuk::apps::email_alert_service::enabled
     govuk::apps::finder_frontend::enabled

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -885,9 +885,6 @@ grafana::dashboards::application_dashboards:
   content-tagger:
     show_sidekiq_graphs: true
     has_workers: true
-  email-alert-api:
-    show_sidekiq_graphs: true
-    has_workers: true
   email-alert-service: {}
   hmrc-manuals-api: {}
   manuals-publisher:

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -291,42 +291,6 @@ govuk::apps::content_tagger::enable_procfile_worker: true
 govuk::apps::content_tagger::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::content_tagger::redis_port: "%{hiera('sidekiq_port')}"
 
-govuk::apps::email_alert_api::enabled: true
-govuk::apps::email_alert_api::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
-govuk::apps::email_alert_api::redis_host: "%{hiera('sidekiq_host')}"
-govuk::apps::email_alert_api::redis_port: "%{hiera('sidekiq_port')}"
-govuk::apps::email_alert_api::db_hostname: 'postgresql-primary-1.backend'
-govuk::apps::email_alert_api::db_password: "%{hiera('govuk::apps::email_alert_api::db::password')}"
-govuk::apps::email_alert_api::db_port: 6432
-govuk::apps::email_alert_api::db_allow_prepared_statements: false
-govuk::apps::email_alert_api::nagios_memory_warning: 2400
-govuk::apps::email_alert_api::nagios_memory_critical: 3000
-govuk::apps::email_alert_api::unicorn_worker_processes: '8'
-# This list should be kept in sync with https://www.notifications.service.gov.uk/services/ecfc7e2f-5145-45a6-9413-5d9b6e813ea9/users
-govuk::apps::email_alert_api::email_address_override_whitelist:
-  - govuk-email-courtesy-copies@digital.cabinet-office.gov.uk
-  - alex.jurubita@digital.cabinet-office.gov.uk
-  - andy.maidment@digital.cabinet-office.gov.uk
-  - ben.thorner@digital.cabinet-office.gov.uk
-  - bevan.loon@digital.cabinet-office.gov.uk
-  - bruce.bolt@digital.cabinet-office.gov.uk
-  - camille.descartes@digital.cabinet-office.gov.uk
-  - chris.banks@digital.cabinet-office.gov.uk
-  - complaint@simulator.amazonses.com
-  - conor.delahunty@digital.cabinet-office.gov.uk
-  - deborah.chua@digital.cabinet-office.gov.uk
-  - edward.kerry@digital.cabinet-office.gov.uk
-  - jennifer.allum@digital.cabinet-office.gov.uk
-  - jos.koetsier@digital.cabinet-office.gov.uk
-  - kevin.dew@digital.cabinet-office.gov.uk
-  - leanne.cummings@digital.cabinet-office.gov.uk
-  - robert.bond@digital.cabinet-office.gov.uk
-  - ruth.morris@digital.cabinet-office.gov.uk
-  - steve.messer@digital.cabinet-office.gov.uk
-  - tim.blair@digital.cabinet-office.gov.uk
-  - thomas.leese@digital.cabinet-office.gov.uk
-  - tom.whitwell@digital.cabinet-office.gov.uk
-
 govuk::apps::email_alert_service::enabled: true
 govuk::apps::email_alert_service::enable_unpublishing_queue_consumer: true
 govuk::apps::email_alert_service::rabbitmq_hosts:

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1080,8 +1080,6 @@ hosts::production::backend::app_hostnames:
   - 'content-publisher'
   - 'content-tagger'
   - 'docs'
-  - 'email-alert-api'
-  - 'email-alert-api-public'
   - 'hmrc-manuals-api'
   - 'kibana'
   - 'maslow'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -37,10 +37,6 @@ node_class: &node_class
       - signon
       - specialist-publisher
       - travel-advice-publisher
-  email_alert_api:
-    apps:
-      - email-alert-api
-      - email-alert-service
   publishing_api:
     apps:
       - govuk-content-schemas

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -66,7 +66,6 @@ deployable_applications: &deployable_applications
   content-audit-tool: {}
   content-publisher: {}
   content-tagger: {}
-  email-alert-api: {}
   email-alert-service: {}
   feedback: {}
   govuk-content-schemas: {}

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -525,6 +525,7 @@ govuk_ci::master::pipeline_jobs:
   calendars: {}
   collections: {}
   content-store: {}
+  email-alert-api: {}
   email-alert-frontend: {}
   finder-frontend: {}
   frontend: {}

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -989,12 +989,6 @@ hosts::production::backend::hosts:
     ip: '10.1.3.111'
   docker-backend-2:
     ip: '10.1.3.112'
-  email-alert-api-1:
-    ip: '10.1.3.40'
-  email-alert-api-2:
-    ip: '10.1.3.41'
-  email-alert-api-3:
-    ip: '10.1.3.42'
   mongo-1:
     ip: '10.1.3.6'
     service_aliases:

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -141,7 +141,41 @@ govuk::apps::content_data_api::rabbitmq::amqp_pass: 'content_data_api'
 govuk::apps::content_data_api::rabbitmq_password: "%{hiera('govuk::apps::content_data_api::rabbitmq::amqp_pass')}"
 govuk::apps::content_publisher::enabled: true
 govuk::apps::content_tagger::enable_procfile_worker: false
+
+govuk::apps::email_alert_api::enabled: true
 govuk::apps::email_alert_api::enable_procfile_worker: false
+govuk::apps::email_alert_api::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
+govuk::apps::email_alert_api::redis_host: "%{hiera('sidekiq_host')}"
+govuk::apps::email_alert_api::redis_port: "%{hiera('sidekiq_port')}"
+govuk::apps::email_alert_api::db_hostname: 'postgresql-primary-1.backend'
+govuk::apps::email_alert_api::db_password: "%{hiera('govuk::apps::email_alert_api::db::password')}"
+govuk::apps::email_alert_api::db_port: 6432
+govuk::apps::email_alert_api::db_allow_prepared_statements: false
+# This list should be kept in sync with https://www.notifications.service.gov.uk/services/ecfc7e2f-5145-45a6-9413-5d9b6e813ea9/users
+govuk::apps::email_alert_api::email_address_override_whitelist:
+  - govuk-email-courtesy-copies@digital.cabinet-office.gov.uk
+  - alex.jurubita@digital.cabinet-office.gov.uk
+  - andy.maidment@digital.cabinet-office.gov.uk
+  - ben.thorner@digital.cabinet-office.gov.uk
+  - bevan.loon@digital.cabinet-office.gov.uk
+  - bruce.bolt@digital.cabinet-office.gov.uk
+  - camille.descartes@digital.cabinet-office.gov.uk
+  - chris.banks@digital.cabinet-office.gov.uk
+  - complaint@simulator.amazonses.com
+  - conor.delahunty@digital.cabinet-office.gov.uk
+  - deborah.chua@digital.cabinet-office.gov.uk
+  - edward.kerry@digital.cabinet-office.gov.uk
+  - jennifer.allum@digital.cabinet-office.gov.uk
+  - jos.koetsier@digital.cabinet-office.gov.uk
+  - kevin.dew@digital.cabinet-office.gov.uk
+  - leanne.cummings@digital.cabinet-office.gov.uk
+  - robert.bond@digital.cabinet-office.gov.uk
+  - ruth.morris@digital.cabinet-office.gov.uk
+  - steve.messer@digital.cabinet-office.gov.uk
+  - tim.blair@digital.cabinet-office.gov.uk
+  - thomas.leese@digital.cabinet-office.gov.uk
+  - tom.whitwell@digital.cabinet-office.gov.uk
+
 govuk::apps::email_alert_service::rabbitmq_hosts: ['localhost']
 govuk::apps::email_alert_service::rabbitmq::queue_size_critical_threshold: 25
 govuk::apps::email_alert_service::rabbitmq::queue_size_warning_threshold: 5

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -140,8 +140,6 @@ hosts::production::backend::app_hostnames:
   - 'content-publisher'
   - 'content-tagger'
   - 'docs'
-  - 'email-alert-api'
-  - 'email-alert-api-public'
   - 'hmrc-manuals-api'
   - 'kibana'
   - 'maslow'

--- a/hieradata/node/postgresql-primary-1.backend.publishing.service.gov.uk.yaml
+++ b/hieradata/node/postgresql-primary-1.backend.publishing.service.gov.uk.yaml
@@ -1,15 +1,4 @@
 govuk_env_sync::tasks:
-  "push_email_alert_api_production_daily":
-    ensure: "absent"
-    hour: "2"
-    minute: "01"
-    action: "push"
-    dbms: "postgresql"
-    storagebackend: "s3"
-    database: "email-alert-api_production"
-    temppath: "/var/lib/autopostgresqlbackup/email-alert-api_production"
-    url: "govuk-production-database-backups"
-    path: "postgresql-backend"
   "push_publishing_api_production_daily":
     ensure: "absent"
     hour: "2"

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -257,12 +257,6 @@ hosts::production::backend::hosts:
     ip: '10.3.3.111'
   docker-backend-2:
     ip: '10.3.3.112'
-  email-alert-api-1:
-    ip: '10.3.3.40'
-  email-alert-api-2:
-    ip: '10.3.3.41'
-  email-alert-api-3:
-    ip: '10.3.3.42'
   mongo-1:
     ip: '10.3.3.6'
     service_aliases:

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -60,10 +60,6 @@ govuk::apps::content_publisher::google_tag_manager_auth: "sxvBI4QvwgTRX5e76vdIHA
 govuk::apps::content_publisher::google_tag_manager_id: "GTM-NQXC4TG"
 govuk::apps::content_publisher::google_tag_manager_preview: "env-2"
 govuk::apps::content_publisher::govuk_notify_template_id: "e00e89f5-b622-4dcb-8f30-e6c70231a940"
-govuk::apps::email_alert_api::db::backend_ip_range: '10.3.3.0/24'
-govuk::apps::email_alert_api::email_archive_s3_bucket: 'govuk-production-email-alert-api-archive'
-govuk::apps::email_alert_api::email_archive_s3_enabled: false
-govuk::apps::email_alert_api::govuk_notify_template_id: 'cb633abc-6ae6-4843-ae6f-82ca500b6de2'
 govuk::apps::government-frontend::cpu_warning: 200
 govuk::apps::government-frontend::cpu_critical: 300
 govuk::apps::hmrc_manuals_api::publish_topics: false

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -132,10 +132,6 @@ govuk::node::s_backend_lb::backend_servers:
   - 'backend-1.backend'
   - 'backend-2.backend'
   - 'backend-3.backend'
-govuk::node::s_backend_lb::email_alert_api_backend_servers:
-  - 'email-alert-api-1.backend'
-  - 'email-alert-api-2.backend'
-  - 'email-alert-api-3.backend'
 govuk::node::s_backend_lb::publishing_api_backend_servers:
   - 'publishing-api-1.backend'
   - 'publishing-api-2.backend'

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -21,13 +21,6 @@ govuk::apps::content_publisher::google_tag_manager_id: "GTM-NQXC4TG"
 govuk::apps::content_publisher::google_tag_manager_preview: "env-5"
 govuk::apps::content_publisher::email_address_override: "content-publisher-notifications-staging@digital.cabinet-office.gov.uk"
 govuk::apps::content_publisher::govuk_notify_template_id: "112842bb-d8a4-4511-90de-57dc5c8f27ec"
-govuk::apps::email_alert_api::db::backend_ip_range: '10.2.3.0/24'
-govuk::apps::email_alert_api::email_archive_s3_bucket: 'govuk-staging-email-alert-api-archive'
-govuk::apps::email_alert_api::email_archive_s3_enabled: true
-govuk::apps::email_alert_api::govuk_notify_template_id: '2844a647-6bf1-4b01-a25c-569d2cc00849'
-govuk::apps::email_alert_api::email_address_override: 'success@simulator.amazonses.com'
-govuk::apps::email_alert_api::email_address_override_whitelist_only: true
-govuk::apps::email_alert_api::delivery_request_threshold: "3000"
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::publisher::run_fact_check_fetcher: false
 govuk::apps::publisher::fact_check_address_format: 'factcheck+staging-{id}@alphagov.co.uk'

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -229,12 +229,6 @@ hosts::production::backend::hosts:
     ip: '10.2.3.111'
   docker-backend-2:
     ip: '10.2.3.112'
-  email-alert-api-1:
-    ip: '10.2.3.40'
-  email-alert-api-2:
-    ip: '10.2.3.41'
-  email-alert-api-3:
-    ip: '10.2.3.42'
   mongo-1:
     ip: '10.2.3.6'
     service_aliases:

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -132,10 +132,6 @@ govuk::node::s_backend_lb::backend_servers:
   - 'backend-1.backend'
   - 'backend-2.backend'
   - 'backend-3.backend'
-govuk::node::s_backend_lb::email_alert_api_backend_servers:
-  - 'email-alert-api-1.backend'
-  - 'email-alert-api-2.backend'
-  - 'email-alert-api-3.backend'
 govuk::node::s_backend_lb::publishing_api_backend_servers:
   - 'publishing-api-1.backend'
   - 'publishing-api-2.backend'

--- a/lib/tasks/spec.rake
+++ b/lib/tasks/spec.rake
@@ -16,6 +16,7 @@ CARRENZA_EXCLUDED_NODE_CLASSES = %w[
   draft_cache
   draft_content_store
   draft_frontend
+  email_alert_api
   email_alert_api_db_admin
   frontend
   gatling

--- a/modules/govuk/manifests/node/s_backend_lb.pp
+++ b/modules/govuk/manifests/node/s_backend_lb.pp
@@ -13,9 +13,6 @@
 # [*whitehall_backend_servers*]
 #   An array of whitehall backend app servers
 #
-# [*email_alert_api_backend_servers*]
-#   An array of email-alert-api backend app servers
-#
 # [*publishing_api_backend_servers*]
 #   An array of publishing-api backend app servers
 #
@@ -29,7 +26,6 @@ class govuk::node::s_backend_lb (
   $perfplat_public_app_domain = 'performance.service.gov.uk',
   $backend_servers,
   $whitehall_backend_servers,
-  $email_alert_api_backend_servers,
   $publishing_api_backend_servers,
   $whitehall_frontend_servers,
   $aws_egress_nat_ips,
@@ -94,15 +90,6 @@ class govuk::node::s_backend_lb (
     ]:
       deny_crawlers => true,
       servers       => $whitehall_backend_servers,
-  }
-
-  loadbalancer::balance { 'email-alert-api':
-      aws_egress_nat_ips => $aws_egress_nat_ips,
-      servers            => $email_alert_api_backend_servers,
-  }
-
-  loadbalancer::balance { 'email-alert-api-public':
-      servers       => $email_alert_api_backend_servers,
   }
 
   loadbalancer::balance { 'publishing-api':


### PR DESCRIPTION
As the Email Alert API has now been migrated to AWS.