### PR TITLE
Add some extra logging to xtrabackup_s3_base

### DIFF
--- a/modules/govuk_mysql/templates/usr/local/bin/xtrabackup_s3_base.erb
+++ b/modules/govuk_mysql/templates/usr/local/bin/xtrabackup_s3_base.erb
@@ -21,8 +21,12 @@ trap nagios_passive EXIT
 # Set a new backup date
 date +%Y%m%d-%H%M%S > /var/lib/mysql/xtrabackup_date
 
+echo "xtrabackup_s3_base: Running innobackupex and writing output to latest/$TMPNAME"
+
 # Copy the latest backup into a temporary filename
 innobackupex --extra-lsndir='/var/lib/mysql/' --encrypt=AES256 --encrypt-key="<%= @encryption_key %>" --stream=xbstream --compress . | envdir /etc/mysql/xtrabackup/env.d /usr/local/bin/gof3r put --endpoint s3-<%= @aws_region -%>.amazonaws.com -b <%= @s3_bucket_name %> -k latest/$TMPNAME
+
+echo "xtrabackup_s3_base: Finished running innobackupex"
 
 # If a previous backup exists then move it to an archive directory
 envdir /etc/mysql/xtrabackup/env.d /usr/local/bin/aws s3 mv s3://<%= @s3_bucket_name %>/latest/base.xbcrypt s3://<%= @s3_bucket_name %>/$(cat /var/lib/mysql/xtrabackup_date)/base.xbcrypt >/dev/null || echo "No previous backup found for archiving"


### PR DESCRIPTION
It's failing sometimes at the moment, so add some extra information to
the output so it's easier to work out which file in S3 was being
written to, and whether it finished running innobackupex.