### PR TITLE
Add a couple of missing apps to integration_deploy::applications

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -715,6 +715,7 @@ govuk_jenkins::jobs::integration_deploy::applications:
     repository: 'ckanext-datagovuk'
   collections: {}
   content-store: {}
+  email-alert-api: {}
   email-alert-frontend: {}
   finder-frontend: {}
   frontend: {}
@@ -729,6 +730,7 @@ govuk_jenkins::jobs::integration_deploy::applications:
   local-links-manager: {}
   manuals-frontend: {}
   mapit: {}
+  publishing-api: {}
   router: {}
   router-api: {}
   search-api: {}


### PR DESCRIPTION
These were removed from the Carrenza list of deployable applications,
but still need to be in this list, so that the Jenkins jobs running on
the CI Jenkins can trigger deployements in Integration (which is in
AWS).