### PR TITLE
Properly remove backend_lb::publishing_api_backend_servers

### DIFF
--- a/hieradata/vagrant.yaml
+++ b/hieradata/vagrant.yaml
@@ -61,9 +61,6 @@ govuk::node::s_backend_lb::whitehall_backend_servers:
 govuk::node::s_backend_lb::whitehall_frontend_servers:
   - 'whitehall-frontend-1.frontend'
   - 'whitehall-frontend-2.frontend'
-govuk::node::s_backend_lb::publishing_api_backend_servers:
-  - 'publishing-api-1.backend'
-  - 'publishing-api-2.backend'
 
 govuk::node::s_cache::real_ip_header: 'X-Forwarded-For'
 

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -154,8 +154,6 @@ govuk::node::s_backend_lb::backend_servers:
   - 'backend'
 govuk::node::s_backend_lb::whitehall_backend_servers:
   - 'whitehall-backend'
-govuk::node::s_backend_lb::publishing_api_backend_servers:
-  - 'publishing-api'
 govuk::node::s_bouncer::minimum_request_rate: 0.1
 govuk::node::s_cache::real_ip_header: 'X-Forwarded-For'
 govuk::node::s_cache::protect_cache_servers: true

--- a/hieradata_aws/training.yaml
+++ b/hieradata_aws/training.yaml
@@ -118,8 +118,6 @@ govuk::node::s_backend_lb::backend_servers:
   - 'backend'
 govuk::node::s_backend_lb::whitehall_backend_servers:
   - 'whitehall-backend'
-govuk::node::s_backend_lb::publishing_api_backend_servers:
-  - 'publishing-api'
 govuk::node::s_bouncer::minimum_request_rate: 0.1
 govuk::node::s_cache::real_ip_header: 'X-Forwarded-For'
 govuk::node::s_cache::protect_cache_servers: true

--- a/hieradata_aws/vagrant.yaml
+++ b/hieradata_aws/vagrant.yaml
@@ -56,9 +56,6 @@ govuk::node::s_backend_lb::whitehall_backend_servers:
 govuk::node::s_backend_lb::whitehall_frontend_servers:
   - 'whitehall-frontend-1.frontend'
   - 'whitehall-frontend-2.frontend'
-govuk::node::s_backend_lb::publishing_api_backend_servers:
-  - 'publishing-api-1.backend'
-  - 'publishing-api-2.backend'
 
 govuk::node::s_cache::real_ip_header: 'X-Forwarded-For'
 

--- a/modules/govuk/manifests/node/s_backend_lb.pp
+++ b/modules/govuk/manifests/node/s_backend_lb.pp
@@ -13,9 +13,6 @@
 # [*whitehall_backend_servers*]
 #   An array of whitehall backend app servers
 #
-# [*publishing_api_backend_servers*]
-#   An array of publishing-api backend app servers
-#
 # [*maintenance_mode*]
 #   Whether the backend should be taken offline in nginx
 #
@@ -26,7 +23,6 @@ class govuk::node::s_backend_lb (
   $perfplat_public_app_domain = 'performance.service.gov.uk',
   $backend_servers,
   $whitehall_backend_servers,
-  $publishing_api_backend_servers,
   $whitehall_frontend_servers,
   $aws_egress_nat_ips,
   $maintenance_mode = false,
@@ -90,11 +86,6 @@ class govuk::node::s_backend_lb (
     ]:
       deny_crawlers => true,
       servers       => $whitehall_backend_servers,
-  }
-
-  loadbalancer::balance { 'publishing-api':
-      aws_egress_nat_ips => $aws_egress_nat_ips,
-      servers            => $publishing_api_backend_servers,
   }
 
   loadbalancer::balance { [


### PR DESCRIPTION
Some of the configuration was previously removed, but the parameter
needs removing as well, as it's mandatory.

The publishing_api_backend_servers parameter isn't relevant any
longer, as the Publishing API has been migrated to AWS, which doesn't
use the backend_lb node, as it uses AWS services for load balancing.