### PR TITLE
Only configure Email Alert API checks in AWS

### DIFF
--- a/modules/monitoring/manifests/checks.pp
+++ b/modules/monitoring/manifests/checks.pp
@@ -47,7 +47,9 @@ class monitoring::checks (
   include monitoring::checks::aws_iam_key
   include monitoring::checks::grafana_dashboards
 
-  include govuk::apps::email_alert_api::checks
+  if $::aws_migration {
+    include govuk::apps::email_alert_api::checks
+  }
 
   $app_domain = hiera('app_domain')
 


### PR DESCRIPTION
As that's where the app runs. The Carrenza Graphite instance doesn't
have the data that these checks require.