### PR TITLE
Switch the AWS Production deploy Jenkins colour scheme

### DIFF
--- a/hieradata_aws/class/production/jenkins.yaml
+++ b/hieradata_aws/class/production/jenkins.yaml
@@ -1,11 +1,4 @@
 ---
-govuk_jenkins::config::banner_string: 'AWS Production'
-govuk_jenkins::config::banner_colour_background: '#005EA5'
-govuk_jenkins::config::banner_colour_text: 'white'
-govuk_jenkins::config::theme_colour: '#005EA5'
-govuk_jenkins::config::theme_text_colour: 'white'
-govuk_jenkins::config::theme_environment_name: 'AWS Production'
-
 govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::bouncer_cdn
   - govuk_jenkins::jobs::check_sentry_errors


### PR DESCRIPTION
To match that of the Carrenza Production Deploy Jenkins, this matches
Staging which uses the same colours for Carrenza and AWS.

Also remove redundant hieradata, which overrides the settings in
production.yaml with the same value.

## Preview before
![jenkins-before](https://user-images.githubusercontent.com/1130010/71680949-54821b80-2d83-11ea-8a7f-79c549111adc.png)

## Preview after
![jenkins-after](https://user-images.githubusercontent.com/1130010/71680956-5b109300-2d83-11ea-97da-487a0078c9ca.png)
