### PR TITLE
Improve clearing out old Graphite data in AWS

### DIFF
--- a/modules/govuk/templates/node/s_graphite/remove_old_whisper_data.erb
+++ b/modules/govuk/templates/node/s_graphite/remove_old_whisper_data.erb
@@ -14,6 +14,14 @@ for dir in $whisper_dir/*; do
     rm -rf $dir;
   fi
 done
+
+for dir in stats/timers stats_counts; do
+  find "$whisper_dir/$dir" -maxdepth 1 -name "*ip-*" -type d -print0 | while IFS= read -r -d '' dir; do
+    if [[ ! -z $dir && -z "$(find $dir -mtime -56)" && $? -eq 0 ]]; then
+      rm -rf "$dir";
+    fi
+  done
+done
 <% end -%>
 
 # Delete empty directories


### PR DESCRIPTION
There's already support for deleting the directories with metrics from
collectd relating to a single machine, but inside the stats and
stats_counts namespaces, there are plenty of old machine specific
metrics.

Use the distinctive "ip-" string in the name to identify the
directories that likely contain machine specific metrics, then delete
them if they haven't been updated in around 8 weeks.

As some dashboards and Icinga checks aggregate the metrics stored per
machine, I'm uncertain what the impact will be of deleting more recent
metrics, which is why I've gone with 8 weeks.