### PR TITLE
Update Graphite target for status update check

### DIFF
--- a/modules/govuk/manifests/apps/email_alert_api/checks.pp
+++ b/modules/govuk/manifests/apps/email_alert_api/checks.pp
@@ -27,7 +27,7 @@ class govuk::apps::email_alert_api::checks(
   @@icinga::check::graphite { 'email-alert-api-delivery-attempt-status-update':
     ensure    => $ensure,
     host_name => $::fqdn,
-    target    => 'divideSeries(keepLastValue(stats.gauges.govuk.email-alert-api.delivery_attempt.pending_status_total), keepLastValue(stats.gauges.govuk.email-alert-api.delivery_attempt.total))',
+    target    => 'transformNull(divideSeries(keepLastValue(stats.gauges.govuk.email-alert-api.delivery_attempt.pending_status_total), keepLastValue(stats.gauges.govuk.email-alert-api.delivery_attempt.total)),0)',
     warning   => '0.166',
     critical  => '0.25',
     from      => '1hour',


### PR DESCRIPTION
The value calculated is `pending_status_total`/`total`, when both
values are 0 this causes an `undefined` error and therefore there
are no valid points when this occurs. Applying the `TransformNull`
function means we can replace these values with `0` and have a
continuous stream of valid datapoints.

https://graphite.readthedocs.io/en/latest/functions.html#graphite.render.functions.transformNull