### PR TITLE
Move the email alert check jenkins job to AWS

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -397,6 +397,7 @@ task :check_consistency_between_aws_and_carrenza do
     govuk_jenkins::jobs::deploy_app::graphite_host
     govuk_jenkins::jobs::deploy_app::graphite_port
     govuk_jenkins::jobs::deploy_emergency_banner::clear_cdn_cache
+    govuk_jenkins::jobs::email_alert_check::email_addresses_to_check
     govuk_jenkins::jobs::passive_checks::alert_hostname
     govuk_pgbouncer::admin::rds
     govuk_pgbouncer::db::lb_ip_range

--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -19,7 +19,6 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::deploy_docs
   - govuk_jenkins::jobs::deploy_lambda_app
   - govuk_jenkins::jobs::deploy_puppet
-  - govuk_jenkins::jobs::email_alert_check
   - govuk_jenkins::jobs::govuk_navigation_link_analysis
   - govuk_jenkins::jobs::govuk_taxonomy_supervised_learning
   - govuk_jenkins::jobs::launch_vms

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -660,15 +660,6 @@ govuk_jenkins::config::github_api_uri: "https://api.github.com"
 govuk_jenkins::config::github_web_uri: "https://github.com"
 govuk_jenkins::jobs::deploy_app::app_domain: "%{hiera('app_domain')}"
 
-govuk_jenkins::jobs::email_alert_check::email_addresses_to_check: >-
-  govuk-email-courtesy-copies@digital.cabinet-office.gov.uk
-  ,
-  govuk-email-courtesy-copies@digital.cabinet-office.gov.uk
-  :
-  govuk_email_check@digital.cabinet-office.gov.uk
-  ,
-  gov.uk.email@notifications.service.gov.uk
-
 govuk_jenkins::jobs::search_test_spelling_suggestions::auth_username: "%{hiera('http_username')}"
 govuk_jenkins::jobs::search_test_spelling_suggestions::auth_password: "%{hiera('http_password')}"
 

--- a/hieradata_aws/class/production/jenkins.yaml
+++ b/hieradata_aws/class/production/jenkins.yaml
@@ -10,6 +10,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::deploy_app
   - govuk_jenkins::jobs::deploy_emergency_banner
   - govuk_jenkins::jobs::deploy_puppet
+  - govuk_jenkins::jobs::email_alert_check
   - govuk_jenkins::jobs::enhanced_ecommerce_search_api
   - govuk_jenkins::jobs::passive_checks
   - govuk_jenkins::jobs::publish_special_routes


### PR DESCRIPTION
This makes more sense, as the Email Alert API is also in AWS. It's
also one less thing in Carrenza.
