### PR TITLE
Increase the email-alert-api procfile worker thread count threshold

### DIFF
--- a/modules/govuk/manifests/apps/email_alert_api.pp
+++ b/modules/govuk/manifests/apps/email_alert_api.pp
@@ -173,8 +173,9 @@ class govuk::apps::email_alert_api(
   include govuk_postgresql::client #installs libpq-dev package needed for pg gem
 
   govuk::procfile::worker {'email-alert-api':
-    ensure         => $ensure,
-    enable_service => $enable_procfile_worker,
+    ensure                    => $ensure,
+    enable_service            => $enable_procfile_worker,
+    alert_when_threads_exceed => 100,
   }
 
   Govuk::App::Envvar {


### PR DESCRIPTION
As Sidekiq for the Email Alert API looks to be using up to around ~90
threads when it's busy, so raise the alert threshold to just above
that.