### PR TITLE
Remove the performance_platform_data_sync from the jobs list

### DIFF
--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -25,7 +25,6 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::monitor_taxonomy_health
   - govuk_jenkins::jobs::network_config_deploy
   - govuk_jenkins::jobs::passive_checks
-  - govuk_jenkins::jobs::performance_platform_data_sync
   - govuk_jenkins::jobs::publication_delay_report
   - govuk_jenkins::jobs::publish_special_routes
   - govuk_jenkins::jobs::record_taxonomy_metrics


### PR DESCRIPTION
As the job definition was removed in
84865c57247fe9e04dfb0e7aed231153a1a8c27b.