### PR TITLE
Add volume graph to email-alert-api dashboard

### DIFF
--- a/modules/grafana/files/dashboards/email_alert_api.json
+++ b/modules/grafana/files/dashboards/email_alert_api.json
@@ -1393,6 +1393,7 @@
               "target": "aliasByNode(removeBelowValue(maxSeries(summarize(stats_counts.govuk.app.email-alert-api.*.workers.DailyDigestInitiatorWorker.success, '1h', 'max', false)), 1), 6)"
             }
           ],
+          "thresholds": [],
           "timeFrom": "7d",
           "timeShift": null,
           "title": "Digest Runs",
@@ -1477,6 +1478,7 @@
               "target": "alias(sumSeries(stats.timers.govuk.app.email-alert-api.*.workers.DigestEmailGenerationWorker.processing_time.sum), 'email processing time')"
             }
           ],
+          "thresholds": [],
           "timeFrom": "7d",
           "timeShift": null,
           "title": "Digest Run (Duration)",
@@ -1518,6 +1520,110 @@
       "repeatRowId": null,
       "showTitle": true,
       "title": "Digest Runs",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": true,
+      "height": "300",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": true,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fill": 1,
+          "id": 19,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": false,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "30 day average",
+              "bars": false,
+              "fill": 0,
+              "lines": true,
+              "linewidth": 4,
+              "stack": false
+            }
+          ],
+          "spaceLength": 10,
+          "span": 12,
+          "stack": true,
+          "steppedLine": false,
+          "targets": [
+            {
+              "refId": "A",
+              "target": "alias(summarize(groupByNode(consolidateBy(stats_counts.govuk.app.email-alert-api.*.notify.email_send_request.success, 'sum'), 1, 'sum'), '1d', 'sum', false), 'Successes')",
+              "textEditor": true
+            },
+            {
+              "refId": "B",
+              "target": "alias(summarize(groupByNode(consolidateBy(stats_counts.govuk.app.email-alert-api.*.notify.email_send_request.failure, 'sum'), 1, 'sum'), '1d', 'sum', false), 'Failures')",
+              "textEditor": true
+            },
+            {
+              "refId": "C",
+              "target": "alias(movingAverage(groupByNode(summarize(consolidateBy(stats_counts.govuk.app.email-alert-api.*.notify.email_send_request.*, 'sum'), '1d', 'sum', false), 1, 'sum'), '30d'), '30 day average')",
+              "textEditor": true
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": "90d",
+          "timeShift": null,
+          "title": "Volume over 90 days",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "Volume",
       "titleSize": "h6"
     }
   ],


### PR DESCRIPTION
This adds a volume graph to the email-alert-api dashboard which is a copy of the one that used to exist before the rewrite in https://github.com/alphagov/govuk-puppet/pull/9854.

This was requested by our product manager and we decided not to put it in its own dashboard because it's only one graph.

To avoid the dashboard becoming overwhelmed with graphs, it appears at the bottom in a pre-collapsed section.

[Trello Card](https://trello.com/c/IudFw8Od/1657-restore-volume-graph-on-email-alert-api-dashboard)