### PR TITLE
Add subscription contents Icinga checks

### DIFF
--- a/modules/govuk/manifests/apps/email_alert_api/checks.pp
+++ b/modules/govuk/manifests/apps/email_alert_api/checks.pp
@@ -33,4 +33,24 @@ class govuk::apps::email_alert_api::checks(
     from      => '1hour',
     desc      => 'email-alert-api - high number of delivery attempts have not received status updates',
   }
+
+  @@icinga::check::graphite { 'email-alert-api-warning-subscription-contents':
+    ensure    => $ensure,
+    host_name => $::fqdn,
+    target    => 'transformNull((keepLastValue(stats.gauges.govuk.email-alert-api.subscription_contents.warning_total))',
+    warning   => '1',
+    from      => '1hour',
+    desc      => 'email-alert-api - unprocessed subscription contents',
+    notes_url => monitoring_docs_url(email-alert-api-unprocessed-subscription-contents),
+  }
+
+  @@icinga::check::graphite { 'email-alert-api-critical-subscription-contents':
+    ensure    => $ensure,
+    host_name => $::fqdn,
+    target    => 'keepLastValue(stats.gauges.govuk.email-alert-api.subscription_contents.critical_total)',
+    critical  => '1',
+    from      => '1hour',
+    desc      => 'email-alert-api - unprocessed subscription contents',
+    notes_url => monitoring_docs_url(email-alert-api-unprocessed-subscription-contents),
+  }
 }


### PR DESCRIPTION
This adds Icinga checks that monitor the number of `email-alert-api`
subscription contents that have a `critical` and `warning` latency
(created more than `x` minutes ago but their associated emails have
not been sent out). They are not machine specific and the data used
lives in stats/gauges/govuk/email-alert-api in Graphite.

We will be alerted if either of these values are bigger than 0.

Related PR: https://github.com/alphagov/email-alert-api/pull/1096
Trello card: https://trello.com/c/dtdY0kAK/1606-5-extract-the-subscriptioncontents-check-from-the-healthcheck-endpoint-in-email-alert-api-to-a-separate-icinga-check