### PR TITLE
Set up SageMaker environment variable in integration

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -50,6 +50,7 @@ govuk::apps::search_api::relevancy_bucket_name: 'govuk-integration-search-releva
 govuk::apps::search_api::enable_learning_to_rank: true
 govuk::apps::search_api::tensorflow_models_directory: '/data/vhost/tensorflow-models'
 govuk::apps::search_api::tensorflow_serving_ip: '0.0.0.0'
+govuk::apps::search_api::tensorflow_sagemaker_endpoint: 'govuk-integration-search-ltr-endpoint'
 govuk::apps::short_url_manager::instance_name: 'integration'
 govuk::apps::signon::instance_name: 'integration'
 govuk::apps::smartanswers::expose_govspeak: true

--- a/modules/govuk/manifests/apps/search_api.pp
+++ b/modules/govuk/manifests/apps/search_api.pp
@@ -107,6 +107,9 @@
 # [*tensorflow_serving_ip*]
 #   The IP address for the tensorflow serving API.
 #
+# [*tensorflow_sagemaker_endpoint*]
+#   The Amazon SageMaker endpoint serving the tensorflow model.
+#
 
 class govuk::apps::search_api(
   $rabbitmq_user,
@@ -143,6 +146,7 @@ class govuk::apps::search_api(
   $enable_learning_to_rank = false,
   $tensorflow_models_directory = undef,
   $tensorflow_serving_ip = undef,
+  $tensorflow_sagemaker_endpoint = undef,
 ) {
   $app_name = 'search-api'
 
@@ -296,5 +300,8 @@ class govuk::apps::search_api(
     "${title}-TENSORFLOW_SERVING_IP":
       varname => 'TENSORFLOW_SERVING_IP',
       value   => $tensorflow_serving_ip;
+    "${title}-TENSORFLOW_SAGEMAKER_ENDPOINT":
+      varname => 'TENSORFLOW_SAGEMAKER_ENDPOINT',
+      value   => $tensorflow_sagemaker_endpoint;
   }
 }


### PR DESCRIPTION
There's now a SageMaker endpoint running in integration.  There's a branch of search-api which will use it if an environment variable is set, so do that, and then try out the search-api branch.

---

[Trello card](https://trello.com/c/ugkVdcjW/1233-host-ltr-reranking-in-sagemaker)