### PR TITLE
Fix datasource in volume graph

### DIFF
--- a/modules/grafana/files/dashboards/email_alert_api.json
+++ b/modules/grafana/files/dashboards/email_alert_api.json
@@ -1531,7 +1531,7 @@
           "bars": true,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "Graphite",
           "fill": 1,
           "id": 19,
           "legend": {


### PR DESCRIPTION
Not sure how the JSON export ended up with the datasource set to `null` but it needs to be set to `Graphite`.

Follows on from #10016.

[Trello Card](https://trello.com/c/IudFw8Od/1657-restore-volume-graph-on-email-alert-api-dashboard)