### PR TITLE
Extend retention on the Content Data API ETL master job

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/content_data_api.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/content_data_api.yaml.erb
@@ -20,7 +20,7 @@
       - timed: <%= @rake_etl_master_process_cron_schedule %>
   <% end %>
     logrotate:
-        numToKeep: 10
+        daysToKeep: 365
     publishers:
       - trigger-parameterized-builds:
           - project: Success_Passive_Check


### PR DESCRIPTION
As it's useful to see builds going back further than ~10 days.