### PR TITLE
Fix subscription contents Icinga checks

### DIFF
--- a/modules/govuk/manifests/apps/email_alert_api/checks.pp
+++ b/modules/govuk/manifests/apps/email_alert_api/checks.pp
@@ -34,23 +34,31 @@ class govuk::apps::email_alert_api::checks(
     desc      => 'email-alert-api - high number of delivery attempts have not received status updates',
   }
 
+  # We are only interested in the `warning` state but `critical` is also required
+  # for valid Icinga check configuration. Setting it to a high value that won't be
+  # reached allows us to get round this issue
   @@icinga::check::graphite { 'email-alert-api-warning-subscription-contents':
     ensure    => $ensure,
     host_name => $::fqdn,
-    target    => 'transformNull((keepLastValue(stats.gauges.govuk.email-alert-api.subscription_contents.warning_total))',
-    warning   => '1',
+    target    => 'transformNull(keepLastValue(stats.gauges.govuk.email-alert-api.subscription_contents.warning_total))',
+    warning   => '0',
+    critical  => '100000000',
     from      => '1hour',
-    desc      => 'email-alert-api - unprocessed subscription contents',
+    desc      => 'email-alert-api - unprocessed subscription contents - warning',
     notes_url => monitoring_docs_url(email-alert-api-unprocessed-subscription-contents),
   }
 
+  # We are only interested in the `critical` state but `warning` is also required
+  # for valid Icinga check configuration. Both states are set to 0 but `critical`
+  # takes precedence and allows us to get round this issue
   @@icinga::check::graphite { 'email-alert-api-critical-subscription-contents':
     ensure    => $ensure,
     host_name => $::fqdn,
-    target    => 'keepLastValue(stats.gauges.govuk.email-alert-api.subscription_contents.critical_total)',
-    critical  => '1',
+    target    => 'transformNull(keepLastValue(stats.gauges.govuk.email-alert-api.subscription_contents.critical_total))',
+    warning   => '0',
+    critical  => '0',
     from      => '1hour',
-    desc      => 'email-alert-api - unprocessed subscription contents',
+    desc      => 'email-alert-api - unprocessed subscription contents - critical',
     notes_url => monitoring_docs_url(email-alert-api-unprocessed-subscription-contents),
   }
 }


### PR DESCRIPTION
It appears that the checks require both `warning` and `critical`
arguments. Setting them to a value that won't be hit to bypass
this issue.

Also a small fix to one of the targets which was originally missed.

https://trello.com/c/dtdY0kAK/1606-5-extract-the-subscriptioncontents-check-from-the-healthcheck-endpoint-in-email-alert-api-to-a-separate-icinga-check