### PR TITLE
Add icinga checks for email-alert-api content changes

### DIFF
--- a/modules/govuk/manifests/apps/email_alert_api/checks.pp
+++ b/modules/govuk/manifests/apps/email_alert_api/checks.pp
@@ -48,6 +48,17 @@ class govuk::apps::email_alert_api::checks(
     notes_url => monitoring_docs_url(email-alert-api-unprocessed-subscription-contents),
   }
 
+    @@icinga::check::graphite { 'email-alert-api-warning-content-changes':
+    ensure    => $ensure,
+    host_name => $::fqdn,
+    target    => 'transformNull(stats.gauges.govuk.email-alert-api.content_changes.warning_total)',
+    warning   => '0',
+    critical  => '100000000',
+    from      => '1hour',
+    desc      => 'email-alert-api - unprocessed content changes',
+    notes_url => monitoring_docs_url(email-alert-api-unprocessed-content-changes),
+  }
+
   # We are only interested in the `critical` state but `warning` is also required
   # for valid Icinga check configuration. Both states are set to 0 but `critical`
   # takes precedence and allows us to get round this issue
@@ -60,5 +71,16 @@ class govuk::apps::email_alert_api::checks(
     from      => '1hour',
     desc      => 'email-alert-api - unprocessed subscription contents - critical',
     notes_url => monitoring_docs_url(email-alert-api-unprocessed-subscription-contents),
+  }
+
+  @@icinga::check::graphite { 'email-alert-api-critical-content-changes':
+    ensure    => $ensure,
+    host_name => $::fqdn,
+    target    => 'transformNull(stats.gauges.govuk.email-alert-api.content_changes.critical_total)',
+    warning   => '0',
+    critical  => '0',
+    from      => '1hour',
+    desc      => 'email-alert-api - unprocessed content changes',
+    notes_url => monitoring_docs_url(email-alert-api-unprocessed-content-changes),
   }
 }

--- a/modules/govuk/manifests/apps/email_alert_api/checks.pp
+++ b/modules/govuk/manifests/apps/email_alert_api/checks.pp
@@ -51,7 +51,7 @@ class govuk::apps::email_alert_api::checks(
     @@icinga::check::graphite { 'email-alert-api-warning-content-changes':
     ensure    => $ensure,
     host_name => $::fqdn,
-    target    => 'transformNull(stats.gauges.govuk.email-alert-api.content_changes.warning_total)',
+    target    => 'transformNull(keepLastValue(stats.gauges.govuk.email-alert-api.content_changes.warning_total))',
     warning   => '0',
     critical  => '100000000',
     from      => '1hour',
@@ -76,7 +76,7 @@ class govuk::apps::email_alert_api::checks(
   @@icinga::check::graphite { 'email-alert-api-critical-content-changes':
     ensure    => $ensure,
     host_name => $::fqdn,
-    target    => 'transformNull(stats.gauges.govuk.email-alert-api.content_changes.critical_total)',
+    target    => 'transformNull(keepLastValue(stats.gauges.govuk.email-alert-api.content_changes.critical_total))',
     warning   => '0',
     critical  => '0',
     from      => '1hour',


### PR DESCRIPTION
Two new Icinga checks, warning and critical, for more refined reporting on unprocessed content changes in `email-alert-api`. Alerts will trigger if either value exceeds 0.

This is part of work to slim down the `email-alert-api-healthcheck-not-ok` alert, making individual alerts which are not machine-specific. Data lives in `stats/gauges/govuk/email-alert-api` in Graphite.

[Trello](https://trello.com/c/c6mWg9jP/1627-3-extract-the-contentchanges-check-from-the-healthcheck-endpoint-in-email-alert-api-to-a-separate-icinga-check)

