### PR TITLE
Whitehall requests dashboard for Platform Health goal

### DIFF
--- a/modules/grafana/files/dashboards/platform-health-whitehall-frontend-requests.json
+++ b/modules/grafana/files/dashboards/platform-health-whitehall-frontend-requests.json
@@ -1,0 +1,161 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "hideControls": false,
+  "id": 150,
+  "links": [],
+  "rows": [
+    {
+      "collapse": false,
+      "height": "650px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": true,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Graphite",
+          "fill": 1,
+          "id": 1,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": false,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "30 day average",
+              "bars": false,
+              "fill": 0,
+              "lines": true,
+              "linewidth": 5
+            },
+            {
+              "alias": "Target",
+              "bars": false,
+              "fill": 0,
+              "lines": true,
+              "linewidth": 4
+            }
+          ],
+          "spaceLength": 10,
+          "span": 12,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "refId": "A",
+              "target": "alias(summarize(sumSeries(stats_counts.whitehall-frontend-*.whitehall.http_{2*,3*}), '1d', 'sum', false), 'Requests per day')",
+              "textEditor": false
+            },
+            {
+              "refId": "B",
+              "target": "alias(movingAverage(summarize(sumSeries(stats_counts.whitehall-frontend-*.whitehall.http_{2*,3*}), '1d', 'sum', false), '30d'), '30 day average')",
+              "textEditor": false
+            },
+            {
+              "refId": "C",
+              "target": "alias(constantLine(750000), 'Target')",
+              "textEditor": false
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    }
+  ],
+  "schemaVersion": 14,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-90d",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Platform Health - Whitehall Frontend Requests",
+  "version": 2
+}

--- a/modules/grafana/files/dashboards/platform_health_Q3_19-20_whitehall_errors.json
+++ b/modules/grafana/files/dashboards/platform_health_Q3_19-20_whitehall_errors.json
@@ -167,6 +167,6 @@
     ]
   },
   "timezone": "",
-  "title": "Platform Health: Q3 (19-20) Whitehall errors",
+  "title": "Platform Health - Q3 (19-20) Whitehall errors",
   "version": 4
 }


### PR DESCRIPTION
This is related to a goal Platform Health have this year to reduce the average number of requests being served by Whitehall Frontend.

I decided to put it in its own dashboard because there didn't seem to be an existing dashboard which was appropriate as this dashboard is very specific to a Platform Health goal. It's also similar to the existing goal-based dashboard we have: https://grafana.publishing.service.gov.uk/dashboard/file/platform_health_Q3_19-20_whitehall_errors.json

<img width="1440" alt="Screenshot 2020-01-08 at 10 58 47" src="https://user-images.githubusercontent.com/510498/71973518-0b105100-3207-11ea-98df-2a295f9fa2f0.png">