### PR TITLE
Tweak how timeouts are handled for the xtrabackup jobs

### DIFF
--- a/modules/govuk_mysql/manifests/xtrabackup/backup.pp
+++ b/modules/govuk_mysql/manifests/xtrabackup/backup.pp
@@ -100,14 +100,14 @@ define govuk_mysql::xtrabackup::backup (
   }
 
   cron::crondotdee { 'xtrabackup_s3_base':
-    command => '/usr/bin/timeout 1h /usr/bin/setlock -N /var/run/mysql_xtrabackup /usr/local/bin/xtrabackup_s3_base',
+    command => '/usr/bin/setlock -N /var/run/mysql_xtrabackup /usr/bin/timeout 1h /usr/local/bin/xtrabackup_s3_base',
     hour    => $base_backup_cron_hour,
     minute  => $base_backup_cron_minute,
     mailto  => $mailto,
   }
 
   cron::crondotdee { 'xtrabackup_s3_incremental':
-    command => '/usr/bin/timeout 30m /usr/bin/setlock -n /var/run/mysql_xtrabackup /usr/local/bin/xtrabackup_s3_incremental',
+    command => '/usr/bin/setlock -n /var/run/mysql_xtrabackup /usr/bin/timeout 30m /usr/local/bin/xtrabackup_s3_incremental',
     hour    => '*',
     minute  => "*/${incremental_backup_cron_interval}",
     mailto  => $mailto,


### PR DESCRIPTION
Cron runs the commands at set times, but the backup doesn't start
until the lock has been acquired. So, move the timeout command to
after the lock has been acquired so that the timeout is for just the
backup running, not acquiring the lock also.