### PR TITLE
Add Icinga checks for email-alert-api messages

### DIFF
--- a/modules/govuk/manifests/apps/email_alert_api/checks.pp
+++ b/modules/govuk/manifests/apps/email_alert_api/checks.pp
@@ -70,6 +70,17 @@ class govuk::apps::email_alert_api::checks(
     notes_url => monitoring_docs_url(email-alert-api-incomplete-digest-runs),
   }
 
+  @@icinga::check::graphite { 'email-alert-api-warning-messages':
+    ensure    => $ensure,
+    host_name => $::fqdn,
+    target    => 'transformNull(keepLastValue(stats.gauges.govuk.email-alert-api.messages.warning_total))',
+    warning   => '0',
+    critical  => '100000000',
+    from      => '1hour',
+    desc      => 'email-alert-api - unprocessed messages - warning',
+    notes_url => monitoring_docs_url(email-alert-api-unprocessed-messages),
+  }
+
   # We are only interested in the `critical` state but `warning` is also required
   # for valid Icinga check configuration. Both states are set to 0 but `critical`
   # takes precedence and allows us to get round this issue
@@ -104,5 +115,16 @@ class govuk::apps::email_alert_api::checks(
     from      => '1hour',
     desc      => 'email-alert-api - incomplete digest runs - critical',
     notes_url => monitoring_docs_url(email-alert-api-incomplete-digest-runs),
+  }
+
+  @@icinga::check::graphite { 'email-alert-api-critical-messages':
+    ensure    => $ensure,
+    host_name => $::fqdn,
+    target    => 'transformNull(keepLastValue(stats.gauges.govuk.email-alert-api.messages.critical_total))',
+    warning   => '0',
+    critical  => '0',
+    from      => '1hour',
+    desc      => 'email-alert-api - unprocessed messages - critical',
+    notes_url => monitoring_docs_url(email-alert-api-unprocessed-messages),
   }
 }


### PR DESCRIPTION
This adds Icinga checks that monitor the number of unprocessed
messages in the `email-alert-api` that have a `crtical` and
`warning` latency (created more then `x` minutes ago but have
not been processed yet). They are not machine specific and the
data used lived in `stats/gauges/govuk/email-alert-api` in Graphite.

We will be alerted when either values are greater than `0`.

Related PRs: https://github.com/alphagov/email-alert-api/pull/1108
Trello card: https://trello.com/c/z3QoArLh/1661-5-extract-the-messages-check-from-the-healthcheck-endpoint-in-email-alert-api-to-a-separate-icinga-check

<img width="425" alt="Screenshot 2020-01-09 at 14 51 08" src="https://user-images.githubusercontent.com/19667619/72077651-82211480-32ef-11ea-8815-500deac13e1e.png">
