### PR TITLE
Add link to documentation for Icinga check

### DIFF
--- a/modules/govuk/manifests/apps/email_alert_api/checks.pp
+++ b/modules/govuk/manifests/apps/email_alert_api/checks.pp
@@ -32,6 +32,7 @@ class govuk::apps::email_alert_api::checks(
     critical  => '0.25',
     from      => '1hour',
     desc      => 'email-alert-api - high number of delivery attempts have not received status updates',
+    notes_url => monitoring_docs_url(email-alert-api-delivery-attempts-status-update),
   }
 
   # We are only interested in the `warning` state but `critical` is also required


### PR DESCRIPTION
This adds a link to the documentation, see https://github.com/alphagov/govuk-developer-docs/pull/2206