### PR TITLE
Fix Icinga job URLs for machines on AWS

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/bouncer_cdn.pp
+++ b/modules/govuk_jenkins/manifests/jobs/bouncer_cdn.pp
@@ -27,9 +27,7 @@ class govuk_jenkins::jobs::bouncer_cdn (
   }
 
   $check_name = 'bouncer-cdn-configuration'
-
-  # FIXME: go back to using $app_domain once we have a single Icinga instance in AWS
-  $job_url = "https://deploy.${::aws_environment}.govuk.digital/job/Bouncer_CDN/"
+  $job_url = "https://deploy.blue.${::aws_environment}.govuk.digital/job/Bouncer_CDN/"
 
   @@icinga::passive_check { "${check_name}_${::hostname}":
     service_description => $service_description,

--- a/modules/govuk_jenkins/manifests/jobs/content_data_api.pp
+++ b/modules/govuk_jenkins/manifests/jobs/content_data_api.pp
@@ -13,10 +13,9 @@ class govuk_jenkins::jobs::content_data_api (
   $rake_etl_master_process_cron_schedule = undef,
   $app_domain = hiera('app_domain'),
 ) {
-
   $check_name = 'etl-content-data-api'
   $service_description = 'Content Data API ETL [Extract - transform - load]'
-  $job_url = "https://deploy.${::aws_environment}.govuk.digital/job/content_data_api_import_etl_master_process/"
+  $job_url = "https://deploy.blue.${::aws_environment}.govuk.digital/job/content_data_api_import_etl_master_process/"
 
   file { '/etc/jenkins_jobs/jobs/content_data_api.yaml':
     ensure  => present,

--- a/modules/govuk_jenkins/manifests/jobs/enhanced_ecommerce_search_api.pp
+++ b/modules/govuk_jenkins/manifests/jobs/enhanced_ecommerce_search_api.pp
@@ -9,10 +9,9 @@ class govuk_jenkins::jobs::enhanced_ecommerce_search_api (
   $rate_limit_token = undef,
   $cron_schedule = undef
 ) {
-
   $job_name = 'enhanced_ecommerce_search_api'
   $service_description = 'Enhanced Ecommerce ETL from Search API to Google Analytics'
-  $job_url = "https://deploy.${app_domain}/job/enhanced_ecommerce_search_api/"
+  $job_url = "https://deploy.blue.${::aws_environment}.govuk.digital/job/${job_name}/"
   $target_application = 'search-api'
 
   file { '/etc/jenkins_jobs/jobs/enhanced_ecommerce_search_api.yaml':

--- a/modules/govuk_jenkins/manifests/jobs/search_api_fetch_analytics_data.pp
+++ b/modules/govuk_jenkins/manifests/jobs/search_api_fetch_analytics_data.pp
@@ -19,8 +19,7 @@ class govuk_jenkins::jobs::search_api_fetch_analytics_data (
     notify  => Exec['jenkins_jobs_update'],
   }
 
-  # FIXME: go back to using $app_domain once we have a single Icinga instance in AWS
-  $job_url = "https://deploy.${::aws_environment}.govuk.digital/job/${job_name}"
+  $job_url = "https://deploy.blue.${::aws_environment}.govuk.digital/job/${job_name}/"
 
   @@icinga::passive_check { "${check_name}_${::hostname}":
     service_description => $service_description,

--- a/modules/govuk_jenkins/manifests/jobs/search_generate_sitemaps.pp
+++ b/modules/govuk_jenkins/manifests/jobs/search_generate_sitemaps.pp
@@ -7,7 +7,7 @@ class govuk_jenkins::jobs::search_generate_sitemaps{
 
   $service_description = 'Runs a rake task on Search API that generates the sitemap files'
   $job_slug = 'search_generate_sitemaps'
-  $job_url = "https://deploy.${::aws_environment}.govuk.digital/job/${job_slug}"
+  $job_url = "https://deploy.blue.${::aws_environment}.govuk.digital/job/${job_slug}/"
 
   file { '/etc/jenkins_jobs/jobs/search_generate_sitemaps.yaml':
     ensure  => present,

--- a/modules/govuk_jenkins/manifests/jobs/search_relevancy_metrics_etl.pp
+++ b/modules/govuk_jenkins/manifests/jobs/search_relevancy_metrics_etl.pp
@@ -14,10 +14,9 @@ class govuk_jenkins::jobs::search_relevancy_metrics_etl (
   $cron_schedule = undef,
   $app_domain = hiera('app_domain'),
 ) {
-
   $check_name = 'search-relevancy-metrics-etl'
   $service_description = 'Search Relevancy Metrics ETL'
-  $job_url = "https://deploy.${::aws_environment}.govuk.digital/job/search_relevancy_metrics_etl/"
+  $job_url = "https://deploy.blue.${::aws_environment}.govuk.digital/job/search_relevancy_metrics_etl/"
 
   file { '/etc/jenkins_jobs/jobs/search_relevancy_metrics_etl.yaml':
     ensure  => present,

--- a/modules/govuk_jenkins/manifests/jobs/search_relevancy_rank_evaluation.pp
+++ b/modules/govuk_jenkins/manifests/jobs/search_relevancy_rank_evaluation.pp
@@ -13,10 +13,9 @@ class govuk_jenkins::jobs::search_relevancy_rank_evaluation (
   $cron_schedule = undef,
   $app_domain = hiera('app_domain'),
 ) {
-
   $check_name = 'search-relevancy-rank-evaluation'
   $service_description = 'Search Relevancy Rank Evaluation'
-  $job_url = "https://deploy.${::aws_environment}.govuk.digital/job/search_relevancy_rank_evaluation/"
+  $job_url = "https://deploy.blue.${::aws_environment}.govuk.digital/job/search_relevancy_rank_evaluation/"
 
   file { '/etc/jenkins_jobs/jobs/search_relevancy_rank_evaluation.yaml':
     ensure  => present,

--- a/modules/govuk_jenkins/manifests/jobs/transition_import_hits.pp
+++ b/modules/govuk_jenkins/manifests/jobs/transition_import_hits.pp
@@ -21,8 +21,7 @@ class govuk_jenkins::jobs::transition_import_hits(
 
   $check_name = 'transition-import-hits'
 
-  # FIXME: go back to using $app_domain once we have a single Icinga instance in AWS
-  $job_url = "https://deploy.${::aws_environment}.govuk.digital/job/transition_import_hits/"
+  $job_url = "https://deploy.blue.${::aws_environment}.govuk.digital/job/transition_import_hits/"
 
   @@icinga::passive_check { "${check_name}_${::hostname}":
     service_description => $service_description,

--- a/modules/monitoring/manifests/client/apt.pp
+++ b/modules/monitoring/manifests/client/apt.pp
@@ -13,7 +13,7 @@ class monitoring::client::apt {
     attempts_before_hard_state => 24, # Wait 24hrs to allow unattended-upgrades to run first
     check_interval             => 60, # Save cycles, apt-get update only runs every 30m
     retry_interval             => 60,
-    notes_url                  => monitoring_docs_url(rebooting-machines),
+    notes_url                  => 'https://docs.publishing.service.gov.uk/manual/rebooting-machines.html',
   }
 
   @icinga::nrpe_config { 'check_reboot_required':


### PR DESCRIPTION
The old method of simply setting:
`"https://deploy.${::aws_environment}.govuk.digital/job/${job_slug}"`

...did not seem to work as the authors intended. This would create
a job URL like:

> https://deploy.production.govuk.digital/job/search_generate_sitemaps

...whereas it should be:

> https://deploy.blue.production.govuk.digital/job/search_generate_sitemaps/