### PR TITLE
Use more specific env var name for search sitemaps bucket

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -327,8 +327,8 @@ task :check_consistency_between_aws_and_carrenza do
     govuk::apps::search_api::redis_port
     govuk::apps::search_api::elasticsearch_hosts
     govuk::apps::search_api::unicorn_worker_processes
-    govuk::apps::search_api::bucket_name
     govuk::apps::search_api::relevancy_bucket_name
+    govuk::apps::search_api::sitemaps_bucket_name
     govuk::apps::search_api::enable_learning_to_rank
     govuk::apps::search_api::tensorflow_models_directory
     govuk::apps::search_api::tensorflow_serving_ip

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -44,9 +44,9 @@ govuk::apps::link_checker_api::govuk_basic_auth_credentials: "%{hiera('http_user
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-integration'
 govuk::apps::publishing_api::content_api_prototype: true
 govuk::apps::router::sentry_environment: 'integration'
-govuk::apps::search_api::bucket_name: 'govuk-integration-sitemaps'
 govuk::apps::search_api::elasticsearch_hosts: 'https://vpc-blue-elasticsearch6-domain-uolbxqjhkiqmg5w3gg7gio5sty.eu-west-1.es.amazonaws.com'
 govuk::apps::search_api::relevancy_bucket_name: 'govuk-integration-search-relevancy'
+govuk::apps::search_api::sitemaps_bucket_name: 'govuk-integration-sitemaps'
 govuk::apps::search_api::enable_learning_to_rank: true
 govuk::apps::search_api::tensorflow_models_directory: '/data/vhost/tensorflow-models'
 govuk::apps::search_api::tensorflow_serving_ip: '0.0.0.0'

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -162,9 +162,9 @@ govuk::apps::publisher::run_fact_check_fetcher: false
 govuk::apps::publisher::fact_check_address_format: 'factcheck+production-{id}@alphagov.co.uk'
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-production'
 govuk::apps::router::sentry_environment: 'production'
-govuk::apps::search_api::bucket_name: 'govuk-production-sitemaps'
 govuk::apps::search_api::elasticsearch_hosts: 'https://vpc-blue-elasticsearch6-domain-2hnib7uydv3tgebhabx74gdelq.eu-west-1.es.amazonaws.com'
 govuk::apps::search_api::relevancy_bucket_name: 'govuk-production-search-relevancy'
+govuk::apps::search_api::sitemaps_bucket_name: 'govuk-production-sitemaps'
 govuk::apps::search_api::tensorflow_models_directory: '/data/vhost/tensorflow-models'
 govuk::apps::search_api::tensorflow_serving_ip: '0.0.0.0'
 govuk::apps::search_api::enable_learning_to_rank: true

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -160,9 +160,9 @@ govuk::apps::publisher::run_fact_check_fetcher: false
 govuk::apps::publisher::fact_check_address_format: 'factcheck+staging-{id}@alphagov.co.uk'
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-staging'
 govuk::apps::router::sentry_environment: 'staging'
-govuk::apps::search_api::bucket_name: 'govuk-staging-sitemaps'
 govuk::apps::search_api::elasticsearch_hosts: 'https://vpc-blue-elasticsearch6-domain-uibh77cu2kiudtl76uhseobfzq.eu-west-1.es.amazonaws.com'
 govuk::apps::search_api::relevancy_bucket_name: 'govuk-staging-search-relevancy'
+govuk::apps::search_api::sitemaps_bucket_name: 'govuk-staging-sitemaps'
 govuk::apps::search_api::enable_learning_to_rank: true
 govuk::apps::search_api::tensorflow_models_directory: '/data/vhost/tensorflow-models'
 govuk::apps::search_api::tensorflow_serving_ip: '0.0.0.0'

--- a/modules/govuk/manifests/apps/search_api.pp
+++ b/modules/govuk/manifests/apps/search_api.pp
@@ -88,15 +88,15 @@
 # [*oauth_secret*]
 #   The OAuth secret used to authenticate the app to GOV.UK Signon (in govuk-secrets)
 #
-# [*bucket_name*]
-#   The S3 bucket to serve sitemaps from and store them in
-#
 # [*aws_region*]
 #   The AWS region of the S3 bucket.
 #   Default: eu-west-1
 #
 # [*relevancy_bucket_name*]
 #   The S3 bucket for search relevancy data - e.g. relevancy judgements
+#
+# [*sitemaps_bucket_name*]
+#   The S3 bucket to serve sitemaps from and store them in
 #
 # [*enable_learning_to_rank*]
 #   A feature flag to enable learning to rank in an environment.
@@ -140,8 +140,8 @@ class govuk::apps::search_api(
   $unicorn_worker_processes = undef,
   $oauth_id = undef,
   $oauth_secret = undef,
-  $bucket_name = undef,
   $relevancy_bucket_name = undef,
+  $sitemaps_bucket_name = undef,
   $aws_region = 'eu-west-1',
   $enable_learning_to_rank = false,
   $tensorflow_models_directory = undef,
@@ -275,19 +275,20 @@ class govuk::apps::search_api(
       value   => $oauth_secret;
   }
 
+  # todo: remove AWS_S3_BUCKET_NAME when search-api has been changed to use AWS_S3_SITEMAPS_BUCKET_NAME
   govuk::app::envvar {
     "${title}-AWS_S3_BUCKET_NAME":
       varname => 'AWS_S3_BUCKET_NAME',
-      value   => $bucket_name;
+      value   => $sitemaps_bucket_name;
     "${title}-AWS_REGION":
       varname => 'AWS_REGION',
       value   => $aws_region;
-  }
-
-  govuk::app::envvar {
     "${title}-AWS_S3_RELEVANCY_BUCKET_NAME":
       varname => 'AWS_S3_RELEVANCY_BUCKET_NAME',
       value   => $relevancy_bucket_name;
+    "${title}-AWS_S3_SITEMAPS_BUCKET_NAME":
+      varname => 'AWS_S3_SITEMAPS_BUCKET_NAME',
+      value   => $sitemaps_bucket_name;
   }
 
   govuk::app::envvar {


### PR DESCRIPTION
It's been bothering me that we have two S3 buckets used for search,
one of which has a specific name and one of which has a generic name.

---

[Trello card](https://trello.com/c/99NdZbBk/1265-rename-sitemaps-bucket-env-var)