### PR TITLE
Remove AWS_S3_BUCKET_NAME for search-api

### DIFF
--- a/modules/govuk/manifests/apps/search_api.pp
+++ b/modules/govuk/manifests/apps/search_api.pp
@@ -275,11 +275,7 @@ class govuk::apps::search_api(
       value   => $oauth_secret;
   }
 
-  # todo: remove AWS_S3_BUCKET_NAME when search-api has been changed to use AWS_S3_SITEMAPS_BUCKET_NAME
   govuk::app::envvar {
-    "${title}-AWS_S3_BUCKET_NAME":
-      varname => 'AWS_S3_BUCKET_NAME',
-      value   => $sitemaps_bucket_name;
     "${title}-AWS_REGION":
       varname => 'AWS_REGION',
       value   => $aws_region;


### PR DESCRIPTION
Don't merge this until https://github.com/alphagov/search-api/pull/1904 has been deployed.

---

[Trello card](https://trello.com/c/99NdZbBk/1265-rename-sitemaps-bucket-env-var)