### PR TITLE
Revert "Grant GOV.UK ITHC GitHub group access to Jenkins"

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -56,9 +56,6 @@ govuk_jenkins::config::user_permissions:
     user: 'alphagov*GOV.UK'
     permissions: *jenkins_admin_permission_list
   -
-    user: 'alphagov*GOV.UK ITHC'
-    permissions: *jenkins_admin_permission_list
-  -
     user: 'anonymous'
     permissions:
       - 'hudson.model.Hudson.Read'

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -55,29 +55,6 @@ govuk_jenkins::config::theme_colour: '#ffbf47'
 govuk_jenkins::config::theme_text_colour: 'black'
 govuk_jenkins::config::theme_environment_name: 'Staging'
 
-govuk_jenkins::config::user_permissions:
-  -
-    user: 'alphagov*GOV.UK ITHC'
-    permissions:
-      - 'hudson.model.Hudson.Administer'
-      - 'hudson.model.Hudson.Read'
-      - 'hudson.model.Hudson.RunScripts'
-      - 'hudson.model.Item.Build'
-      - 'hudson.model.Item.Cancel'
-      - 'hudson.model.Item.Configure'
-      - 'hudson.model.Item.Create'
-      - 'hudson.model.Item.Delete'
-      - 'hudson.model.Item.Discover'
-      - 'hudson.model.Item.Read'
-      - 'hudson.model.Item.Workspace'
-      - 'hudson.model.Run.Delete'
-      - 'hudson.model.Run.Update'
-      - 'hudson.model.View.Configure'
-      - 'hudson.model.View.Create'
-      - 'hudson.model.View.Delete'
-      - 'hudson.model.View.Read'
-      - 'hudson.scm.SCM.Tag'
-
 govuk_jenkins::job_builder::environment: 'staging'
 
 govuk_jenkins::jobs::network_config_deploy::environments:


### PR DESCRIPTION
This breaks Jenkins by removing all other permissions. In other words it overrides the entire list of existing permissions with just the ITHC-related ones.

The problem didn't manifest until today, because the Puppet agent had been disabled on the Carrenza Staging Jenkins box since October and forgotten about.

Reverts alphagov/govuk-puppet#9910.