### PR TITLE
Note "automatically" in "these hosts should reboot overnight":

### DIFF
--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_reboots_required
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_reboots_required
@@ -66,7 +66,7 @@ else
   end
   if safe_machines.length > 0
     puts "\n"
-    puts 'These hosts should reboot overnight:'
+    puts 'These hosts should reboot automatically overnight:'
     safe_machines.sort.each do |hostname|
       hydrated_name = hostname_with_node_name(hostname, machines_names_hash)
       puts "- #{hydrated_name}"


### PR DESCRIPTION
- As someone doing on-call out-of-hours reboots for the first time,
  bleary-eyed early this morning, it wasn't entirely clear to me that
  the overnight hosts were automatic from the existing wording.