### PR TITLE
Fix `govuk_node_list --with-puppet-class` to show all the hosts

### DIFF
--- a/modules/govuk_scripts/templates/govuk_node_list_aws.erb
+++ b/modules/govuk_scripts/templates/govuk_node_list_aws.erb
@@ -55,21 +55,21 @@ def ec2_nodes_list_with_puppet_class(stackname):
                )
 
     reservations = response['Reservations']
-    for reservation in reservations:
-        instances = reservation['Instances']
 
-    return [
-        "%s:%s" % (
-            instance['PrivateDnsName'],
-            next(
-                filter(
-                    lambda t: t['Key'] == 'aws_hostname',
-                    instance['Tags']
-                )
-            )['Value']
-        )
-        for instance in list(instances)
-    ]
+    hostname_and_puppet_class = []
+
+    for reservation in reservations:
+        for instance in list(reservation['Instances']):
+            hostname_and_puppet_class.append("%s:%s" % (
+                instance['PrivateDnsName'],
+                next(
+                    filter(
+                        lambda t: t['Key'] == 'aws_hostname',
+                        instance['Tags']
+                    )
+                )['Value']))
+
+    return hostname_and_puppet_class
 
 def ec2_classes(stackname):
     client = boto3.client('ec2', region_name=region)

--- a/modules/govuk_scripts/templates/govuk_node_list_aws.erb
+++ b/modules/govuk_scripts/templates/govuk_node_list_aws.erb
@@ -59,15 +59,10 @@ def ec2_nodes_list_with_puppet_class(stackname):
     hostname_and_puppet_class = []
 
     for reservation in reservations:
-        for instance in list(reservation['Instances']):
-            hostname_and_puppet_class.append("%s:%s" % (
-                instance['PrivateDnsName'],
-                next(
-                    filter(
-                        lambda t: t['Key'] == 'aws_hostname',
-                        instance['Tags']
-                    )
-                )['Value']))
+        for instance in reservation['Instances']:
+            private_dns_name = instance['PrivateDnsName']
+            hostname = next(tag['Value'] for tag in instance['Tags'] if tag['Key'] == 'aws_hostname')
+            hostname_and_puppet_class.append("{private_dns_name}:{hostname}".format(private_dns_name=private_dns_name, hostname=hostname))
 
     return hostname_and_puppet_class
 


### PR DESCRIPTION
- We were doing on-call out of hours reboots this morning and noticed
  that on the AWS side none of the AWS hostnames made any sense. "It
  would be nice if the reboot check could show what class of machine
  that is". This would avoid us having to login to the AWS Console,
  search the EC2 section for the hostname and _then_ check against the
  reboots doc.
- Turns out this will already work, but only if the
  `govuk_node_list` command it relies on works properly itself.
- Before, the `--with-puppet-class` function wasn't iterating through
  the instances properly as the `return` statement was returning the
  first instance it found (in all my testing, either `mongo-1` or
  `whitehall-backend-1`). This fixes it so that rather than:

```
$ govuk_node_list --with-puppet-class
ip-10-1-6-48.eu-west-1.compute.internal:whitehall-backend-1
$
```

  it returns all the values:

```
$ govuk_node_list --with-puppet-class
[...]
ip-10-1-6-231.eu-west-1.compute.internal:content-store-1
ip-10-1-6-45.eu-west-1.compute.internal:draft-cache-1
ip-10-1-6-185.eu-west-1.compute.internal:cache-1
ip-10-1-6-4.eu-west-1.compute.internal:rabbitmq
ip-10-1-6-48.eu-west-1.compute.internal:whitehall-backend-1
$
```

https://trello.com/c/dw9iaOBM/1676-improve-reboot-required-icinga-check-wording