### PR TITLE
check_reboots_required: Make AWS hosts list formatting better

### DIFF
--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_reboots_required
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_reboots_required
@@ -17,7 +17,7 @@ def hostname_with_node_name(hostname, machines_names_hash)
   name = machines_names_hash[hostname]
 
   if name
-    "%s with hostname: %s" % [name, hostname]
+    "#{hostname} (#{name}))"
   else
     hostname
   end


### PR DESCRIPTION
- After we fixed the generation of this data, this was still a little verbose.

Before:

```
These hosts should reboot automatically overnight:
- router-backend-1 with hostname: ip-10-13-4-147.eu-west-1.compute.internal
```

After:

```
These hosts should reboot automatically overnight:
- ip-10-13-4-147.eu-west-1.compute.internal (router-backend-1)
```