### PR TITLE
Remove unused directory created by govuk_env_sync.

### DIFF
--- a/modules/govuk/manifests/node/s_db_admin.pp
+++ b/modules/govuk/manifests/node/s_db_admin.pp
@@ -53,13 +53,6 @@ class govuk::node::s_db_admin(
     ensure  => latest,
   }
 
-  file { '/var/lib/documentdb':
-    ensure => directory,
-    owner  => 'govuk-backup',
-    group  => 'govuk-backup',
-    mode   => '0750',
-  }
-
   $alert_hostname = 'alert'
 
   ### MySQL ###


### PR DESCRIPTION
govuk_env_sync was creating `/var/lib/documentdb` but this is no
longer referred to anywhere, so stop creating it.

Removing the Puppet resource in one go rather than setting to `ensure:
absent` because there are only a handful of machines affected and it
therefore saves time to remove the directory manually than roll out two
Puppet releases.