### PR TITLE
[Whitehall migration] Add a new override for whitehall-frontend

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -206,7 +206,6 @@ task :check_consistency_between_aws_and_carrenza do
     govuk::apps::content_store::nagios_memory_warning
     govuk::apps::content_store::performance_platform_big_screen_view_url
     govuk::apps::content_store::performance_platform_spotlight_url
-    govuk::apps::content_store::plek_service_whitehall_frontend_uri
     govuk::apps::content_store::unicorn_worker_processes
     govuk::apps::content_tagger::db::allow_auth_from_lb
     govuk::apps::content_tagger::db::lb_ip_range

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -129,7 +129,6 @@ govuk::apps::content_publisher::google_tag_manager_preview: "env-7"
 govuk::apps::content_publisher::govuk_notify_template_id: "e00e89f5-b622-4dcb-8f30-e6c70231a940"
 govuk::apps::content_store::performance_platform_big_screen_view_url: 'https://performance-platform-big-screen-view-production.cloudapps.digital'
 govuk::apps::content_store::performance_platform_spotlight_url: 'https://performance-platform-spotlight-production.cloudapps.digital'
-govuk::apps::content_store::plek_service_whitehall_frontend_uri: 'https://whitehall-frontend.publishing.service.gov.uk'
 
 govuk::apps::govuk_crawler_worker::blacklist_paths:
   - '/apply-for-a-licence'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -140,7 +140,6 @@ govuk::apps::content_publisher::email_address_override: "content-publisher-notif
 govuk::apps::content_publisher::govuk_notify_template_id: "112842bb-d8a4-4511-90de-57dc5c8f27ec"
 govuk::apps::content_store::performance_platform_big_screen_view_url: 'https://performance-platform-big-screen-view-staging.cloudapps.digital'
 govuk::apps::content_store::performance_platform_spotlight_url: 'https://performance-platform-spotlight-staging.cloudapps.digital'
-govuk::apps::content_store::plek_service_whitehall_frontend_uri: 'https://whitehall-frontend.staging.publishing.service.gov.uk'
 
 govuk::apps::email_alert_api::db::backend_ip_range: '10.12.3.0/24'
 govuk::apps::email_alert_api::email_archive_s3_bucket: 'govuk-staging-email-alert-api-archive'

--- a/modules/govuk/manifests/apps/content_store.pp
+++ b/modules/govuk/manifests/apps/content_store.pp
@@ -61,10 +61,6 @@
 #   rummager URL envvar
 #   Default: undef
 #
-# [*plek_service_whitehall_frontend_uri*]
-#   whitehall-frontend URL envvar
-#   Default: undef
-#
 
 class govuk::apps::content_store(
   $port = '3068',
@@ -86,7 +82,6 @@ class govuk::apps::content_store(
   $router_api_bearer_token = undef,
   $create_default_nginx_config = false,
   $plek_service_rummager_uri = undef,
-  $plek_service_whitehall_frontend_uri = undef,
 ) {
   $app_name = 'content-store'
 
@@ -153,8 +148,5 @@ class govuk::apps::content_store(
     "${title}-RUMMAGER_URI":
       varname => 'PLEK_SERVICE_RUMMAGER_URI',
       value   => $plek_service_rummager_uri;
-    "${title}-WHITEHALL_FRONTEND_URI":
-      varname => 'PLEK_SERVICE_WHITEHALL_FRONTEND_URI',
-      value   => $plek_service_whitehall_frontend_uri;
   }
 }

--- a/modules/govuk/manifests/deploy/config.pp
+++ b/modules/govuk/manifests/deploy/config.pp
@@ -121,7 +121,8 @@ class govuk::deploy::config(
     # 2. Whitehall is still in Carrenza Staging and Production.
     if ($::aws_environment == 'staging') or ($::aws_environment == 'production') {
       govuk_envvar {
-        'PLEK_SERVICE_WHITEHALL_ADMIN_URI': value  => "https://whitehall-admin.${app_domain}";
+        'PLEK_SERVICE_WHITEHALL_ADMIN_URI':    value  => "https://whitehall-admin.${app_domain}";
+        'PLEK_SERVICE_WHITEHALL_FRONTEND_URI': value  => "https://whitehall-frontend.${app_domain}";
       }
 
       # draft_content_store overrides PLEK_SERVICE_SIGNON_URI itself because it


### PR DESCRIPTION
Add a new plek override for whitehall-frontend

This will be ingested by the following apps to ensure access to the Worldwide API after the Whitehall AWS migration:

- Smartanswers
- Finder Frontend
- Contacts Admin