### PR TITLE
Add a new user for Issy

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -194,6 +194,7 @@ users::usernames:
   - huwdiprose
   - ianjames
   - isabelllong
+  - issylong
   - jessicajones
   - jonathanhallam
   - jonathonshire

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -463,6 +463,7 @@ users::usernames:
   - huwdiprose
   - ianjames
   - isabelllong
+  - issylong
   - jessicajones
   - jonathanhallam
   - jonathonshire

--- a/hieradata_aws/training.yaml
+++ b/hieradata_aws/training.yaml
@@ -176,6 +176,7 @@ users::usernames:
   - felisialoukou
   - ianjames
   - isabelllong
+  - issylong
   - jessicajones
   - jonathanhallam
   - joskoetsier

--- a/modules/users/manifests/issylong.pp
+++ b/modules/users/manifests/issylong.pp
@@ -1,0 +1,8 @@
+# Creates the user issylong
+class users::issylong {
+  govuk_user { 'issylong':
+    fullname => 'Issy Long',
+    email    => 'issy.long@digital.cabinet-office.gov.uk',
+    ssh_key  => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDLyZe/GffE/Qg0oimCf8EBj3YFOX1+uPdNAauFC4JfAebwCpDd/jaXRDmPSG0648GTgacn67BNsQv9j8FwkY9vKugW7XKc+4lRJXWUpAx5WRnvncLS24ObbtvPbXyN+n8M1gq7iXa4f94R2+wmHLdsn5eojwDhxej5Si7EzbDsUmnl7L2hmiFCrwYV5cGZxnXQGAcagFpQrIFBDhBf1Ft27ZrH05dbnRrnbokofJGbwgWNmOGu4CGLoDcfsFddwtZSoT0IljGZ2Qx3OlhmZpicl6dSmi2XjXHuS+y1eA16clxOzDp3N9tu1NKHezDzWVzOemH5k/JFpKL8qN392HtSVGyobhU+ziSrxeVlEp2AtIxoMy1Lrl8qb+6lOnoDQMYIZNZ4/C+Y2mkY94sfLp/CuofHiiCk6FsgChOP/Rvb1+JWoAXLay9Xl7p5a890lgJ9wYnVWGmPPuUl0SWl1jyLaa7F+ej6QuRuVyGDSpGCmmhGg5PL7H5OVdsZTSlvOnaZmHSCZtOVfGWpo0ho6IyaVNO5w3/CiOOSDId8oquOl7riRFcTaGlKj1yH7z8G6jKcd08ureJNP4fVITKmP1BCOARiUU8g+SR4uociT9vIo0kHIFhq7E7OXIT7zxixi2IXUfka+vHr9qVOAd1fcfdsFbcNj2AA2qSR4nYLXtAU2Q== cardno:000609852840',
+  }
+}


### PR DESCRIPTION
- I'm switching away from my full name everywhere it's possible to.
- I tried to this in #9915 with my existing user, but the linter didn't
  like having the username different from the email address, and
  apparently it's impossible to change username without adding/removing.
- The removal of "isabelllong" will come in the next few days once this
  has deployed.