### PR TITLE
gemstash: Reduce cache expiration time

### DIFF
--- a/modules/govuk_containers/files/gemstash/config.yml
+++ b/modules/govuk_containers/files/gemstash/config.yml
@@ -1,0 +1,3 @@
+:cache_type: memory
+:cache_max_size: 500
+:cache_expiration: 1200

--- a/modules/govuk_containers/manifests/gemstash.pp
+++ b/modules/govuk_containers/manifests/gemstash.pp
@@ -20,6 +20,11 @@ class govuk_containers::gemstash(
     ensure => directory,
   }
 
+  file { '/var/lib/gemstash/config.yml':
+    ensure  => present,
+    content => file('govuk_containers/gemstash/config.yml'),
+  }
+
   ::docker::image { $gemstash_image:
     ensure    => 'present',
     require   => Class['govuk_docker'],


### PR DESCRIPTION
- According to [Gemstash's docs about caching](https://github.com/rubygems/gemstash/blob/master/docs/gemstash-customize.7.md#cache), we were just using the default values and had therefore seemingly never configured a config file.
- We're having to hit "Rebuild" on a lot of CI jobs when Dependabot raises PRs, because the first time, bundler fails to find the new version of the gem.
- We hypothesise that this is because Gemstash is not fetching new gems quickly enough.
- The default Gemstash cache expiration is 1800 seconds (30 minutes). Let's see what reducing it to 1200 seconds (20 minutes) does to improve things - if anything.

Entirely untested as yet, and my Puppet is very rusty. ☘️

https://trello.com/c/vGsljeMG/1376-5-get-gemstash-to-update-more-frequently