### PR TITLE
Mark Murilo as absent

### DIFF
--- a/modules/users/manifests/murilodalri.pp
+++ b/modules/users/manifests/murilodalri.pp
@@ -1,6 +1,7 @@
 # Create the murilodalri user
 class users::murilodalri {
   govuk_user { 'murilodalri':
+    ensure   => absent,
     fullname => 'Murilo Dal Ri',
     email    => 'murilo.dalri@digital.cabinet-office.gov.uk',
     ssh_key  => [


### PR DESCRIPTION
Murilo is on leave for ~6 weeks. According to [these docs](https://docs.publishing.service.gov.uk/manual/rules-for-getting-production-access.html#temporarily-revoking-access), we should remove his production access.