### PR TITLE
Add reranker metrics to application dashboard

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1021,7 +1021,10 @@ grafana::dashboards::application_dashboards:
   email-alert-service: {}
   feedback: {}
   finder-frontend:
-    show_external_request_time: true
+    rows:
+      - - content_store_request_time
+        - registry_request_time
+        - search_api_request_time
     show_memcached: true
     instance_prefix: 'calculators_frontend'
   frontend: {}
@@ -1059,6 +1062,9 @@ grafana::dashboards::application_dashboards:
   router-api: {}
   search-api:
     # search-api is a sinatra app
+    rows:
+      - - reranker_latency_vs_request_count
+      - - reranker_errors
     show_controller_errors: false
     show_response_times: true
     show_sidekiq_graphs: true

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -228,7 +228,10 @@ grafana::dashboards::application_dashboards:
   email-alert-service: {}
   feedback: {}
   finder-frontend:
-    show_external_request_time: true
+    rows:
+      - - content_store_request_time
+        - registry_request_time
+        - search_api_request_time
     show_memcached: true
     instance_prefix: 'calculators_frontend'
   frontend: {}

--- a/modules/grafana/templates/dashboards/application_dashboard_panels/_reranker_errors.json.erb
+++ b/modules/grafana/templates/dashboards/application_dashboard_panels/_reranker_errors.json.erb
@@ -1,0 +1,78 @@
+{
+  "aliasColors": {},
+  "bars": false,
+  "dashLength": 10,
+  "dashes": false,
+  "datasource": "Graphite",
+  "fill": 1,
+  "id": 14,
+  "legend": {
+    "avg": false,
+    "current": false,
+    "max": false,
+    "min": false,
+    "show": true,
+    "total": false,
+    "values": false
+  },
+  "lines": true,
+  "linewidth": 1,
+  "links": [],
+  "nullPointMode": "null",
+  "percentage": false,
+  "pointradius": 5,
+  "points": false,
+  "renderer": "flot",
+  "seriesOverrides": [],
+  "spaceLength": 10,
+  "span": 12,
+  "stack": false,
+  "steppedLine": false,
+  "targets": [
+    {
+      "refId": "A",
+      "target": "aliasByMetric(stats.govuk.app.search-api.learn_to_rank.errors.Aws.SageMakerRuntime.Errors.*)",
+      "textEditor": false
+    },
+    {
+      "refId": "B",
+      "target": "aliasByMetric(stats.govuk.app.search-api.learn_to_rank.errors.Errno.*)",
+      "textEditor": false
+    }
+  ],
+  "thresholds": [],
+  "timeFrom": null,
+  "timeShift": null,
+  "title": "Reranker errors",
+  "tooltip": {
+    "shared": true,
+    "sort": 0,
+    "value_type": "individual"
+  },
+  "type": "graph",
+  "xaxis": {
+    "buckets": null,
+    "mode": "time",
+    "name": null,
+    "show": true,
+    "values": []
+  },
+  "yaxes": [
+    {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+    },
+    {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+    }
+  ]
+}

--- a/modules/grafana/templates/dashboards/application_dashboard_panels/_reranker_latency_vs_request_count.json.erb
+++ b/modules/grafana/templates/dashboards/application_dashboard_panels/_reranker_latency_vs_request_count.json.erb
@@ -1,0 +1,84 @@
+{
+  "aliasColors": {},
+  "bars": false,
+  "dashLength": 10,
+  "dashes": false,
+  "datasource": "Graphite",
+  "description": "",
+  "fill": 1,
+  "id": 13,
+  "legend": {
+    "avg": false,
+    "current": false,
+    "max": false,
+    "min": false,
+    "show": true,
+    "total": false,
+    "values": false
+  },
+  "lines": true,
+  "linewidth": 1,
+  "links": [],
+  "nullPointMode": "null",
+  "percentage": false,
+  "pointradius": 5,
+  "points": false,
+  "renderer": "flot",
+  "seriesOverrides": [
+    {
+      "alias": "Reranker upper 90 latency",
+      "yaxis": 2
+    }
+  ],
+  "spaceLength": 10,
+  "span": 12,
+  "stack": false,
+  "steppedLine": false,
+  "targets": [
+    {
+      "refId": "B",
+      "target": "alias(groupByNode(stats.govuk.app.search-api.ip-*.results_reranked, 5, 'sum'), 'Results reranked')",
+      "textEditor": false
+    },
+    {
+      "refId": "A",
+      "target": "alias(groupByNode(stats.timers.govuk.app.search-api.ip-*.reranker.fetch_scores.upper_90, 6, 'avg'), 'Reranker upper 90 latency')",
+      "textEditor": false
+    }
+  ],
+  "thresholds": [],
+  "timeFrom": null,
+  "timeShift": null,
+  "title": "Reranker req count vs latency",
+  "tooltip": {
+    "shared": true,
+    "sort": 0,
+    "value_type": "individual"
+  },
+  "type": "graph",
+  "xaxis": {
+    "buckets": null,
+    "mode": "time",
+    "name": null,
+    "show": true,
+    "values": []
+  },
+  "yaxes": [
+    {
+      "format": "short",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+    },
+    {
+      "format": "ms",
+      "label": null,
+      "logBase": 1,
+      "max": null,
+      "min": null,
+      "show": true
+    }
+  ]
+}


### PR DESCRIPTION
This will add Learning To Rank metrics to the search-api dashboard.

The first commit is a refactor to enable us to add application-specific rows in a more flexible way
to application dashboards.

https://trello.com/c/j81uvC6i/1256-add-graphs-to-search-api-app-dashboard-for-learn-to-rank-rerankings-and-error-rate