### PR TITLE
Move Whitehall and Asset Manager to AWS.

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -17,7 +17,6 @@ node_class: &node_class
       - asset_env_sync
   backend:
     apps:
-      - asset-manager
       - canary-backend
       - collections-publisher
       - contacts

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -188,7 +188,6 @@ hosts::production::api::hosts:
     ip: '10.3.12.31'
 
 hosts::production::backend::app_hostnames:
-  - 'asset-manager'
   - 'canary-backend'
   - 'collections-publisher'
   - 'contacts-admin'
@@ -207,7 +206,6 @@ hosts::production::backend::app_hostnames:
   - 'specialist-publisher-rebuild'
   - 'specialist-publisher-rebuild-standalone'
   - 'travel-advice-publisher'
-  - 'whitehall-admin'
 
 hosts::production::backend::hosts:
   asset-master-1:

--- a/modules/govuk/manifests/deploy/config.pp
+++ b/modules/govuk/manifests/deploy/config.pp
@@ -129,13 +129,6 @@ class govuk::deploy::config(
         }
       }
     }
-    # 2. Whitehall is still in Carrenza Production.
-    if $::aws_environment == 'production' {
-      govuk_envvar {
-        'PLEK_SERVICE_WHITEHALL_ADMIN_URI':    value  => "https://whitehall-admin.${app_domain}";
-        'PLEK_SERVICE_WHITEHALL_FRONTEND_URI': value  => "https://whitehall-frontend.${app_domain}";
-      }
-    }
 
   } else {
     govuk_envvar {


### PR DESCRIPTION
This is to be merged when we migrate Whitehall and Asset Manager to AWS.

* Remove Plek overrides for Whitehall. This makes apps in AWS use the `govuk-internal.digital` names for whitehall-frontend and whitehall-admin, instead of the `publishing.service.gov.uk` names.
* Remove `/etc/hosts` entries for Whitehall and Asset Manager. This allows clients in Carrenza to talk to these apps in AWS. (Otherwise the DNS names are shadowed by the hosts entries.)
* Remove `asset-manager` from the list of apps which get deployed to new `backend` instances in Carrenza. (This doesn't remove the app from existing machines, but we'll be doing so manually very soon after this gets merged.)

See individual commit messages for more detail.

Supersedes #10076, #9886 and #9887.