### PR TITLE
Add reranker metrics to search-api dashboard in integration

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -278,6 +278,9 @@ grafana::dashboards::application_dashboards:
   router-api: {}
   search-api:
     # search-api is a sinatra app
+    rows:
+      - - reranker_latency_vs_request_count
+      - - reranker_errors
     show_controller_errors: false
     show_response_times: true
     show_sidekiq_graphs: true


### PR DESCRIPTION
I missed this in f9233faa728168ac5d6801f4ce648038ca59cb6a.