### PR TITLE
Add email alert api sidekiq queue length icinga check

### DIFF
--- a/modules/govuk/manifests/apps/email_alert_api/checks.pp
+++ b/modules/govuk/manifests/apps/email_alert_api/checks.pp
@@ -6,6 +6,19 @@ class govuk::apps::email_alert_api::checks(
   $ensure = present,
 ) {
 
+  sidekiq_queue_check { [ 'delivery_immediate_high',
+                          'delivery_immediate',
+                          'delivery_digest',
+                          'email_generation_immediate',
+                          'process_and_generate_emails',
+                          'default',
+                          'email_generation_digest',
+                          'cleanup']:
+    size_warning  => '75000',
+    size_critical => '100000',
+    ;
+  }
+
   delivery_attempt_status_check { 'internal_failure':
     ensure => $ensure,
   }

--- a/modules/govuk/manifests/apps/email_alert_api/sidekiq_queue_check.pp
+++ b/modules/govuk/manifests/apps/email_alert_api/sidekiq_queue_check.pp
@@ -1,0 +1,37 @@
+# == Define: govuk::apps::email_alert_api::sidekiq_queue_checks
+#
+# Creates an Icinga check which checks Graphite for activity
+# on Sidekiq queues
+#
+# === Parameters
+#
+# [*ensure*]
+#   Whether to enable the check.
+#   Default: present
+#
+# [*title*]
+#   The name of the sidekiq queue to check.
+#
+# [*size_warning*]
+#   The number of messages on a queue to trigger a warning.
+#
+# [*size_critical*]
+#   The number of messages on a queue to trigger a critical alert.
+#
+define govuk::apps::email_alert_api::sidekiq_queue_check(
+  $size_warning,
+  $size_critical,
+) {
+  icinga::check::graphite { "check_email_alert_api_${title}_queue_size":
+    target    => "transformNull(averageSeries(keepLastValue(stats.gauges.govuk.app.email-alert-api.*.workers.queues.${title}.enqueued)), 0)",
+    from      => '24hours',
+    # Take an average over the most recent 36 datapoints, which at 5
+    # seconds per datapoint is the last 3 minutes
+    args      => '--dropfirst -36',
+    warning   => $size_warning,
+    critical  => $size_critical,
+    desc      => "email-alert-api: high number of messages on ${title} sidekiq queue",
+    host_name => $::fqdn,
+    notes_url => monitoring_docs_url(email-alert-api-high-queue-size),
+  }
+}


### PR DESCRIPTION
This adds Icinga checks that monitor the number of messages currently on the various
Sidekiq queues we have in `email-alert-api`. The tresholds have
been taken from the healthcheck https://github.com/alphagov/email-alert-api/blob/master/app/models/healthcheck/queue_size.rb 

The healthcheck will be removed once these checks are in place.

# Checks in Icinga (integration)
<img width="383" alt="Screenshot 2020-01-17 at 14 40 20" src="https://user-images.githubusercontent.com/13475227/72620566-74930c80-3937-11ea-9f8f-506971f9c39b.png">

# Graphite Graph (integration)
<img width="999" alt="Screenshot 2020-01-17 at 14 40 35" src="https://user-images.githubusercontent.com/13475227/72620583-7bba1a80-3937-11ea-8dc4-ac92583cd0ec.png">

[Trello](https://trello.com/c/lyTVPild/1681-2-extract-the-queuesize-check-from-the-healthcheck-endpoint-in-email-alert-api-to-a-separate-icinga-check)