### PR TITLE
Add staging exception for whitehall

### DIFF
--- a/modules/govuk_env_sync/files/govuk_env_sync.sh
+++ b/modules/govuk_env_sync/files/govuk_env_sync.sh
@@ -560,8 +560,8 @@ function postprocess_router {
   fi
   mongo_backend_domain_manipulator "licensify" "${licensify_domain}"
 
-  # whitehall has been migrated in only integration so far
-  if [ "${aws_environment}" == "integration" ]; then
+  # whitehall has been migrated in only integration and staging so far
+  if [ "${aws_environment}" == "integration" ] || [ "${aws_environment}" == "staging" ]; then
     whitehall_domain="${local_domain}"
   else
     whitehall_domain="${unmigrated_source_domain}"


### PR DESCRIPTION
Whitehall has now been migrated, so when syncing the environments, give it an AWS domain