### PR TITLE
Use instance prefix in process metric target

### DIFF
--- a/modules/grafana/templates/dashboards/application_dashboard_panels/_processor_count.json.erb
+++ b/modules/grafana/templates/dashboards/application_dashboard_panels/_processor_count.json.erb
@@ -58,7 +58,7 @@
         }
       ],
       "refId": "A",
-      "target": "aliasByNode(*.processes-app-<%= @app_name %>.ps_count.processes,0)",
+      "target": "aliasByNode(<%= @instance_prefix %>-*.processes-app-<%= @app_name %>.ps_count.processes,0)",
       "textEditor": true,
       "timeField": "@timestamp"
     },


### PR DESCRIPTION
I'm wondering if this will make process metrics faster to load.