### PR TITLE
Remove hosts entries for Whitehall and Asset Manager in Staging.

### DIFF
--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -260,7 +260,6 @@ hosts::production::backend::hosts:
     ip: '10.2.11.31'
 
 hosts::production::backend::app_hostnames:
-  - 'asset-manager'
   - 'canary-backend'
   - 'collections-publisher'
   - 'contacts-admin'

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -233,14 +233,6 @@ hosts::production::backend::hosts:
     ip: '10.2.3.50'
   redis-2:
     ip: '10.2.3.51'
-  whitehall-backend-1:
-    ip: '10.2.3.25'
-  whitehall-backend-2:
-    ip: '10.2.3.26'
-  whitehall-backend-3:
-    ip: '10.2.3.27'
-  whitehall-backend-4:
-    ip: '10.2.3.28'
   whitehall-mysql-backup-1:
     ip: '10.2.3.34'
     legacy_aliases:
@@ -279,15 +271,8 @@ hosts::production::backend::app_hostnames:
   - 'specialist-publisher-rebuild'
   - 'specialist-publisher-rebuild-standalone'
   - 'travel-advice-publisher'
-  - 'whitehall-admin'
 
 hosts::production::frontend::hosts:
-  whitehall-frontend-1:
-    ip: '10.2.2.5'
-  whitehall-frontend-2:
-    ip: '10.2.2.6'
-  whitehall-frontend-3:
-    ip: '10.2.2.10'
   frontend-lb-1:
     ip: '10.2.2.101'
   frontend-lb-2:


### PR DESCRIPTION
Remove `/etc/hosts` entries (in Carrenza) for Asset Manager, the Whitehall apps and the Whitehall machines.

There are some more entries which could be removed (for example for the Whitehall databases in Carrenza Staging) but that is better left until after the migration is completed so as not to complicate rolling back/forward in Staging after this if we have to.