### PR TITLE
Add Icinga checks for email-alert-api queue latency

### DIFF
--- a/modules/govuk/manifests/apps/email_alert_api/checks.pp
+++ b/modules/govuk/manifests/apps/email_alert_api/checks.pp
@@ -6,16 +6,28 @@ class govuk::apps::email_alert_api::checks(
   $ensure = present,
 ) {
 
-  sidekiq_queue_check { [ 'delivery_immediate_high',
-                          'delivery_immediate',
-                          'delivery_digest',
-                          'email_generation_immediate',
+  sidekiq_queue_check { [ 'email_generation_immediate',
                           'process_and_generate_emails',
                           'default',
                           'email_generation_digest',
                           'cleanup']:
-    size_warning  => '75000',
-    size_critical => '100000',
+    size_warning     => '75000',
+    size_critical    => '100000',
+    latency_warning  => '5',
+    latency_critical => '10',
+    ;
+                        [ 'delivery_immediate_high',
+                          'delivery_immediate']:
+    size_warning     => '75000',
+    size_critical    => '100000',
+    latency_warning  => '2.5',
+    latency_critical => '5',
+    ;
+                        [ 'delivery_digest']:
+    size_warning     => '75000',
+    size_critical    => '100000',
+    latency_warning  => '90',
+    latency_critical => '60',
     ;
   }
 

--- a/modules/govuk/manifests/apps/email_alert_api/sidekiq_queue_check.pp
+++ b/modules/govuk/manifests/apps/email_alert_api/sidekiq_queue_check.pp
@@ -1,4 +1,4 @@
-# == Define: govuk::apps::email_alert_api::sidekiq_queue_checks
+# == Define: govuk::apps::email_alert_api::sidekiq_queue_check
 #
 # Creates an Icinga check which checks Graphite for activity
 # on Sidekiq queues
@@ -18,9 +18,17 @@
 # [*size_critical*]
 #   The number of messages on a queue to trigger a critical alert.
 #
+# [*latency_warning*]
+#   The warning threshold for a sidekiq queue in minutes.
+#
+# [*latency_critical*]
+#   The critical threshold for a sidekiq queue in minutes.
+#
 define govuk::apps::email_alert_api::sidekiq_queue_check(
   $size_warning,
   $size_critical,
+  $latency_warning,
+  $latency_critical,
 ) {
   icinga::check::graphite { "check_email_alert_api_${title}_queue_size":
     target    => "transformNull(averageSeries(keepLastValue(stats.gauges.govuk.app.email-alert-api.*.workers.queues.${title}.enqueued)), 0)",
@@ -33,5 +41,15 @@ define govuk::apps::email_alert_api::sidekiq_queue_check(
     desc      => "email-alert-api: high number of messages on ${title} sidekiq queue",
     host_name => $::fqdn,
     notes_url => monitoring_docs_url(email-alert-api-high-queue-size),
+  }
+  icinga::check::graphite { "check_email_alert_api_${title}_queue_latency":
+    target    => "transformNull(averageSeries(keepLastValue(stats.gauges.govuk.app.email-alert-api.*.workers.queues.${title}.latency)), 0)",
+    from      => '1hour',
+    args      => '--ignore-missing',
+    warning   => $latency_warning,
+    critical  => $latency_critical,
+    desc      => "email-alert-api: high latency for ${title} sidekiq queue",
+    host_name => $::fqdn,
+    notes_url => monitoring_docs_url(email-alert-api-high-queue-latency),
   }
 }


### PR DESCRIPTION
This adds Icinga checks that monitor the latency of the various
Sidekiq queues we have in `email-alert-api`. The tresholds have
been taken from the healthcheck https://github.com/alphagov/email-alert-api/blob/master/app/models/healthcheck/queue_latency.rb The healthcheck will be removed once these checks are in place.

We also want to add other checks on the queues (such as retry size
and queue size), this has been written in a way that should reduce
a lot of duplication in the creation of multiple checks for each
queue.

Tested in integration:
<img width="309" alt="Screenshot 2020-01-17 at 14 56 34" src="https://user-images.githubusercontent.com/19667619/72621710-b1600300-3939-11ea-9d80-40b289bb9aea.png">

Trello card: https://trello.com/c/A4RfUXGG/1680-2-extract-the-queuelatency-check-from-the-healthcheck-endpoint-in-email-alert-api-to-a-separate-icinga-check