### PR TITLE
Add new config variable names

### DIFF
--- a/modules/govuk/templates/ckan/ckan.ini.erb
+++ b/modules/govuk/templates/ckan/ckan.ini.erb
@@ -105,6 +105,11 @@ ckan.datagovsg_s3_resources.s3_aws_secret_access_key = <%= @s3_aws_secret_access
 ckan.datagovsg_s3_resources.s3_bucket_name = <%= @s3_bucket_name%>
 ckan.datagovsg_s3_resources.s3_url_prefix = https://s3-<%= @s3_aws_region_name%>.amazonaws.com/<%= @s3_bucket_name%>/
 ckan.datagovsg_s3_resources.s3_aws_region_name = <%= @s3_aws_region_name%>
+ckan.datagovuk.s3_aws_access_key_id = <%= @s3_aws_access_key_id%>
+ckan.datagovuk.s3_aws_secret_access_key = <%= @s3_aws_secret_access_key%>
+ckan.datagovuk.s3_bucket_name = <%= @s3_bucket_name%>
+ckan.datagovuk.s3_url_prefix = https://s3-<%= @s3_aws_region_name%>.amazonaws.com/<%= @s3_bucket_name%>/
+ckan.datagovuk.s3_aws_region_name = <%= @s3_aws_region_name%>
 
 # Harvesting settings
 ckan.harvest.mq.type = redis


### PR DESCRIPTION
This adds the config variables for the new plugin, so that it's configured before the code which requires them is deployed; cf #10058 which will remove the old variables and the old plugin and be merged only after the code is deployed.