### PR TITLE
Add back some prematurely-removed Whitehall hosts entries.

### DIFF
--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -233,6 +233,14 @@ hosts::production::backend::hosts:
     ip: '10.2.3.50'
   redis-2:
     ip: '10.2.3.51'
+  whitehall-backend-1:
+    ip: '10.2.3.25'
+  whitehall-backend-2:
+    ip: '10.2.3.26'
+  whitehall-backend-3:
+    ip: '10.2.3.27'
+  whitehall-backend-4:
+    ip: '10.2.3.28'
   whitehall-mysql-backup-1:
     ip: '10.2.3.34'
     legacy_aliases:
@@ -273,6 +281,12 @@ hosts::production::backend::app_hostnames:
   - 'travel-advice-publisher'
 
 hosts::production::frontend::hosts:
+  whitehall-frontend-1:
+    ip: '10.2.2.5'
+  whitehall-frontend-2:
+    ip: '10.2.2.6'
+  whitehall-frontend-3:
+    ip: '10.2.2.10'
   frontend-lb-1:
     ip: '10.2.2.101'
   frontend-lb-2:


### PR DESCRIPTION
These are the entries for the machines rather than the apps. We don't
want to remove these on migration day because it breaks Puppet on those
Carrenza Whitehall machines and makes it difficult to connect to them
from the jumpbox (because these hosts entries are how the names get
resolved on the jumpbox).

These names should instead be removed after the migration, as a cleanup
task.