### PR TITLE
Add link to docs for sitemap info

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/search_generate_sitemaps.pp
+++ b/modules/govuk_jenkins/manifests/jobs/search_generate_sitemaps.pp
@@ -20,6 +20,6 @@ class govuk_jenkins::jobs::search_generate_sitemaps{
     host_name           => $::fqdn,
     freshness_threshold => 129600,
     action_url          => $job_url,
-    notes_url           => monitoring_docs_url(runs-rake-task-search-api)
+    notes_url           => monitoring_docs_url(runs-rake-task-search-api),
   }
 }

--- a/modules/govuk_jenkins/manifests/jobs/search_generate_sitemaps.pp
+++ b/modules/govuk_jenkins/manifests/jobs/search_generate_sitemaps.pp
@@ -20,6 +20,6 @@ class govuk_jenkins::jobs::search_generate_sitemaps{
     host_name           => $::fqdn,
     freshness_threshold => 129600,
     action_url          => $job_url,
-    notes_url           => 'https://docs.publishing.service.gov.uk/manual/alerts/runs-rake-task-search-api.html'
+    notes_url           => monitoring_docs_url(runs-rake-task-search-api)
   }
 }

--- a/modules/govuk_jenkins/manifests/jobs/search_generate_sitemaps.pp
+++ b/modules/govuk_jenkins/manifests/jobs/search_generate_sitemaps.pp
@@ -20,5 +20,6 @@ class govuk_jenkins::jobs::search_generate_sitemaps{
     host_name           => $::fqdn,
     freshness_threshold => 129600,
     action_url          => $job_url,
+    notes_url           => 'https://docs.publishing.service.gov.uk/manual/alerts/runs-rake-task-search-api.html'
   }
 }


### PR DESCRIPTION
The alert should have the link to the docs for this showing up and not rely on a dev to search for it manually.