### PR TITLE
[DO NOT MERGE] Remove Whitehall + Asset Manager from /etc/hosts in Carrenza.

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -192,7 +192,6 @@ hosts::production::api::hosts:
     ip: '10.3.12.31'
 
 hosts::production::backend::app_hostnames:
-  - 'asset-manager'
   - 'canary-backend'
   - 'collections-publisher'
   - 'contacts-admin'
@@ -212,7 +211,6 @@ hosts::production::backend::app_hostnames:
   - 'specialist-publisher-rebuild'
   - 'specialist-publisher-rebuild-standalone'
   - 'travel-advice-publisher'
-  - 'whitehall-admin'
 
 hosts::production::backend::hosts:
   asset-master-1:


### PR DESCRIPTION
This is for migrating these apps from Carrenza to AWS. These particular
hosts entries need to be deleted as part of the migration because
otherwise they shadow the names which clients in Carrenza will use to
connect to Whitehall / Asset Manager in AWS.

The hosts entries for the Whitehall / Asset Manager machines (as opposed
to the apps) must not be deleted as part of the migration but should be
removed afterwards along with the Puppet classes for Whitehall / Asset
Manager.

Based on and supersedes #9886 and #9887.