### PR TITLE
Route the app-specific healthcheck through to whitehall-frontend.

### DIFF
--- a/modules/govuk/manifests/node/s_whitehall_frontend.pp
+++ b/modules/govuk/manifests/node/s_whitehall_frontend.pp
@@ -9,6 +9,9 @@ class govuk::node::s_whitehall_frontend inherits govuk::node::s_base {
 
   $app_domain = hiera('app_domain')
 
+  # The catchall vhost throws a 500, except for healthcheck requests.
+  nginx::config::vhost::default { 'default': }
+
   nginx::config::vhost::redirect { "whitehall.${app_domain}":
     to => "https://whitehall-frontend.${app_domain}/",
   }


### PR DESCRIPTION
This is to provide a meaningful load balancer healthcheck.

Whitehall is a special case because it doesn't use some of the
nginx-related functionality of `govuk::app`. This just makes the minimal
reasonable change to get the healthcheck working rather than refactoring
Whitehall's Puppet class to take full advantage of `govuk::app`, while
keeping things as similar as possible to other apps / node classes.

See https://github.com/alphagov/govuk-aws/blob/master/doc/architecture/decisions/0037-alb-health-checks.md