### PR TITLE
Add Icinga check for email-alert-api sidekiq retry queue size

### DIFF
--- a/modules/govuk/manifests/apps/email_alert_api/checks.pp
+++ b/modules/govuk/manifests/apps/email_alert_api/checks.pp
@@ -31,6 +31,11 @@ class govuk::apps::email_alert_api::checks(
     ;
   }
 
+  sidekiq_retry_size_check { 'retry_set_size':
+    retry_size_warning  => '40000',
+    retry_size_critical => '50000',
+  }
+
   delivery_attempt_status_check { 'internal_failure':
     ensure => $ensure,
   }

--- a/modules/govuk/manifests/apps/email_alert_api/sidekiq_retry_size_check.pp
+++ b/modules/govuk/manifests/apps/email_alert_api/sidekiq_retry_size_check.pp
@@ -1,0 +1,37 @@
+# == Define: govuk::apps::email_alert_api::sidekiq_retry_size_check
+#
+# Creates an Icinga check which checks Graphite for number of messages
+# on Sidekiq retry queues
+#
+# === Parameters
+#
+# [*ensure*]
+#   Whether to enable the check.
+#   Default: present
+#
+# [*title*]
+#   The name of the sidekiq queue to check - retry_set_size.
+#
+# [*retry_size_warning*]
+#   The number of messages on retry queue to trigger a warning.
+#
+# [*retry_size_critical*]
+#   The number of messages on retry queue to trigger a critical alert.
+#
+define govuk::apps::email_alert_api::sidekiq_retry_size_check(
+  $retry_size_warning,
+  $retry_size_critical,
+) {
+  icinga::check::graphite { "check_email_alert_api_${title}":
+    target    => 'transformNull(averageSeries(keepLastValue(stats.gauges.govuk.app.email-alert-api.*.workers.retry_set_size)), 0)',
+    from      => '24hours',
+    # Take an average over the most recent 36 datapoints, which at 5
+    # seconds per datapoint is the last 3 minutes
+    args      => '--dropfirst -36',
+    warning   => $retry_size_warning,
+    critical  => $retry_size_critical,
+    desc      => 'email-alert-api: high number of messages on sidekiq retry queue',
+    host_name => $::fqdn,
+    notes_url => monitoring_docs_url(email-alert-api-high-retry-queue-size),
+  }
+}


### PR DESCRIPTION
This adds Icinga checks that monitor the number of messages currently on the
Sidekiq retry queues we have in email-alert-api. The thresholds have
been taken from the [healthcheck](https://github.com/alphagov/email-alert-api/blob/master/app/models/healthcheck/retry_size.rb)

The healthcheck will be [removed](https://github.com/alphagov/email-alert-api/pull/1118) once these checks are in place.

<img width="463" alt="Screenshot 2020-01-22 at 12 13 07" src="https://user-images.githubusercontent.com/13475227/72893317-a37ef900-3d10-11ea-9304-a2a31e846170.png">

[Trello](https://trello.com/c/EfKW5u1T/1682-2-extract-the-retrysize-check-from-the-healthcheck-endpoint-in-email-alert-api-to-a-separate-icinga-check)