### PR TITLE
Add 'from' parameter to graphite graph links

### DIFF
--- a/modules/icinga/manifests/check/graphite.pp
+++ b/modules/icinga/manifests/check/graphite.pp
@@ -113,7 +113,7 @@ define icinga::check::graphite(
     }
 
     $action_url_real = "https://graphite.${app_domain}/render/?\
-width=${graph_width}&height=${graph_height}&colorList=red,orange,blue,green,purple,brown\
+width=${graph_width}&height=${graph_height}&from=-${from}&colorList=red,orange,blue,green,purple,brown\
 ${crit_line}${warn_line}\
 &target=${url_encoded_target}"
   } else {

--- a/modules/icinga/spec/defines/icinga__check__graphite_spec.rb
+++ b/modules/icinga/spec/defines/icinga__check__graphite_spec.rb
@@ -25,7 +25,7 @@ describe 'icinga::check::graphite', :type => :define do
         :check_command              => 'check_graphite_metric_args!sumSeries(zoo.*.tiger)!10!20!-F 5minutes ',
         :service_description        => 'number of animals in the zoo',
         :host_name                  => 'warden.zoo.tld',
-        :action_url                 => /^https:\/\/graphite\.environment\.example\.com\/render\/\?width=\d+&height=\d+&colorList=[a-z,]+&target=alias\(dashed\(constantLine\(20\)\),%22critical%22\)&target=alias\(dashed\(constantLine\(10\)\),%22warning%22\)&target=sumSeries\(zoo\.\*\.tiger\)$/,
+        :action_url                 => /^https:\/\/graphite\.environment\.example\.com\/render\/\?width=\d+&height=\d+&from=-5minutes&colorList=[a-z,]+&target=alias\(dashed\(constantLine\(20\)\),%22critical%22\)&target=alias\(dashed\(constantLine\(10\)\),%22warning%22\)&target=sumSeries\(zoo\.\*\.tiger\)$/,
         :attempts_before_hard_state => 1,
       )
     end
@@ -44,7 +44,7 @@ describe 'icinga::check::graphite', :type => :define do
     it 'should contain a nagios_check resource' do
       is_expected.to contain_icinga__check('count_tigers').with(
         :check_command              => 'check_graphite_metric_args!summarize(zoo.*.tiger,"5minutes","max",true)!10!20!-F 5minutes ',
-        :action_url                 => /^https:\/\/graphite\.environment\.example\.com\/render\/\?width=\d+&height=\d+&colorList=[a-z,]+&target=alias\(dashed\(constantLine\(20\)\),%22critical%22\)&target=alias\(dashed\(constantLine\(10\)\),%22warning%22\)&target=summarize\(zoo\.\*\.tiger,%225minutes%22,%22max%22,true\)$/,
+        :action_url                 => /^https:\/\/graphite\.environment\.example\.com\/render\/\?width=\d+&height=\d+&from=-5minutes&colorList=[a-z,]+&target=alias\(dashed\(constantLine\(20\)\),%22critical%22\)&target=alias\(dashed\(constantLine\(10\)\),%22warning%22\)&target=summarize\(zoo\.\*\.tiger,%225minutes%22,%22max%22,true\)$/,
       )
     end
   end
@@ -62,7 +62,7 @@ describe 'icinga::check::graphite', :type => :define do
     it 'should not contain warning line but should contain critical line in linked graph' do
       is_expected.to contain_icinga__check('count_tigers').with(
         :check_command => 'check_graphite_metric_args!sumSeries(zoo.*.tiger)!10:20!10.20!-F 5minutes ',
-        :action_url    => /^https:\/\/graphite\.environment\.example\.com\/render\/\?width=\d+&height=\d+&colorList=[a-z,]+&target=alias\(dashed\(constantLine\(10.20\)\),%22critical%22\)&target=sumSeries\(zoo\.\*\.tiger\)$/,
+        :action_url    => /^https:\/\/graphite\.environment\.example\.com\/render\/\?width=\d+&height=\d+&from=-5minutes&colorList=[a-z,]+&target=alias\(dashed\(constantLine\(10.20\)\),%22critical%22\)&target=sumSeries\(zoo\.\*\.tiger\)$/,
       )
     end
   end
@@ -106,7 +106,7 @@ describe 'icinga::check::graphite', :type => :define do
 
     it 'should contain a warning line and critical line' do
       is_expected.to contain_icinga__check('count_inverse_deer').with(
-        :action_url    => /^https:\/\/graphite\.environment\.example\.com\/render\/\?width=\d+&height=\d+&colorList=[a-z,]+&target=alias\(dashed\(constantLine\(40\)\),%22critical%22\)&target=alias\(dashed\(constantLine\(30\)\),%22warning%22\)&target=sumSeries\(zoo\.\*\.deer\)$/,
+        :action_url    => /^https:\/\/graphite\.environment\.example\.com\/render\/\?width=\d+&height=\d+&from=-23minutes&colorList=[a-z,]+&target=alias\(dashed\(constantLine\(40\)\),%22critical%22\)&target=alias\(dashed\(constantLine\(30\)\),%22warning%22\)&target=sumSeries\(zoo\.\*\.deer\)$/,
       )
     end
   end


### PR DESCRIPTION
The default graph currently displays the past 24 hours but most of our alerts only look at the past hour or so, which can make looking at graphite charts a bit confusing.

This updates the links so they render only the period that the alert refers to.