### PR TITLE
Remove monitoring for the Content Data API PostgreSQL standby

### DIFF
--- a/modules/govuk/manifests/apps/content_data_api/db.pp
+++ b/modules/govuk/manifests/apps/content_data_api/db.pp
@@ -22,11 +22,4 @@ class govuk::apps::content_data_api::db (
     storage_warning  => 50,
     storage_critical => 25,
   }
-
-  @@monitoring::checks::rds_config { 'content-data-api-postgresql-standby':
-    memory_warning   => 2,
-    memory_critical  => 1,
-    storage_warning  => 50,
-    storage_critical => 25,
-  }
 }


### PR DESCRIPTION
This is no longer necessary, as the RDS instance is being removed due
to not being used.