### PR TITLE
Fix totals on Email Alert API dashboard

### DIFF
--- a/modules/grafana/files/dashboards/email_alert_api.json
+++ b/modules/grafana/files/dashboards/email_alert_api.json
@@ -104,7 +104,7 @@
           "targets": [
             {
               "refId": "A",
-              "target": "summarize(sumSeries(stats.govuk.app.email-alert-api.*.notify.email_send_request.*), '1min', 'sum', false)",
+              "target": "summarize(sumSeries(stats_counts.govuk.app.email-alert-api.*.notify.email_send_request.*), '1min', 'sum', false)",
               "textEditor": false
             }
           ],
@@ -179,7 +179,7 @@
           "targets": [
             {
               "refId": "A",
-              "target": "integral(groupByNode(stats.govuk.app.email-alert-api.*.notify.email_send_request.*, 1, 'sumSeries'))",
+              "target": "integral(groupByNode(stats_counts.govuk.app.email-alert-api.*.notify.email_send_request.*, 1, 'sumSeries'))",
               "textEditor": false
             }
           ],


### PR DESCRIPTION
These were showing the incorrect values as they are using statsd's
`stats.` value rather that `stats_counts`. stats is an aggregate value
of the rate per second where stats_counts is the actual total.