### PR TITLE
Retire content audit tool (1 of 2)

### DIFF
--- a/development-vm/Pinfile
+++ b/development-vm/Pinfile
@@ -16,7 +16,6 @@ process :collections => [:static, :'content-store', :'search-api']
 process :'collections-publisher' => [:'publishing-api', :'collections-publisher-worker', :'link-checker-api']
 process :'collections-publisher-worker'
 process :'contacts-admin' => [:'publishing-api', :whitehall]
-process :'content-audit-tool' => [:'publishing-api-read', :'content-audit-tool-sidekiq-google-analytics', :'content-audit-tool-sidekiq-publishing-api']
 process :'content-data' =>[:'content-data-api', :'content-data-sidekiq-default']
 process :'content-data-api' => [:'publishing-api', :'content-data-api-sidekiq-default', :'content-data-api-publishing-api-consumer', 'content-data-api-bulk-import-publishing-api-consumer', 'content-store']
 process :'content-publisher' => [:'publishing-api', :'asset-manager']

--- a/development-vm/Procfile
+++ b/development-vm/Procfile
@@ -156,13 +156,9 @@ link-checker-api-sidekiq:             govuk_setenv link-checker-api            .
 # sidekiq-monitoring for specialist-publisher uses port 3210
 # sidekiq-monitoring's web frontend listens on port 3211 and proxies requests per app to other ports (defined elsewhere in this file)
 publishing-components:                govuk_setenv publishing-components       ./run_in.sh ../../govuk_publishing_components bundle exec foreman start
-content-audit-tool: govuk_setenv content-audit-tool ./run_in.sh ../../content-audit-tool bundle exec rails server -p 3213
 # sidekiq-monitoring for manuals-publisher uses port 3214
 # sidekiq-monitoring for support-api uses port 3215
 # sidekiq-monitoring for collections-publisher uses 3216
-content-audit-tool-sidekiq-google-analytics:  govuk_setenv content-audit-tool ./run_in.sh ../../content-audit-tool bundle exec sidekiq -C ./config/sidekiq/google_analytics.yml
-content-audit-tool-sidekiq-publishing-api:  govuk_setenv content-audit-tool ./run_in.sh ../../content-audit-tool bundle exec sidekiq -C ./config/sidekiq/publishing_api.yml
-# sidekiq-monitoring for content-audit-tool uses port 3217
 # organisations-publisher used port 3218
 # organisations-publisher sidekiq-monitoring used port 3219
 # ckan uses port 3220

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -58,7 +58,6 @@ deployable_applications: &deployable_applications
   collections-publisher: {}
   contacts:
     repository: 'contacts-admin'
-  content-audit-tool: {}
   content-publisher: {}
   content-tagger: {}
   feedback: {}

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -801,9 +801,6 @@ grafana::dashboards::application_dashboards:
     has_workers: true
   contacts:
     docs_name: 'contacts-admin'
-  content-audit-tool:
-    show_sidekiq_graphs: true
-    has_workers: true
   content-publisher:
     show_sidekiq_graphs: true
     has_workers: true

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -21,7 +21,6 @@ node_class: &node_class
       - canary-backend
       - collections-publisher
       - contacts
-      - content-audit-tool
       - content-publisher
       - content-tagger
       - hmrc-manuals-api
@@ -969,7 +968,6 @@ hosts::production::backend::app_hostnames:
   - 'canary-backend'
   - 'collections-publisher'
   - 'contacts-admin'
-  - 'content-audit-tool'
   - 'content-publisher'
   - 'content-tagger'
   - 'docs'

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -130,7 +130,6 @@ hosts::production::backend::app_hostnames:
   - 'canary-backend'
   - 'collections-publisher'
   - 'contacts-admin'
-  - 'content-audit-tool'
   - 'content-publisher'
   - 'content-tagger'
   - 'docs'

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -196,7 +196,6 @@ hosts::production::backend::app_hostnames:
   - 'canary-backend'
   - 'collections-publisher'
   - 'contacts-admin'
-  - 'content-audit-tool'
   - 'content-publisher'
   - 'content-tagger'
   - 'docs'

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -264,7 +264,6 @@ hosts::production::backend::app_hostnames:
   - 'canary-backend'
   - 'collections-publisher'
   - 'contacts-admin'
-  - 'content-audit-tool'
   - 'content-publisher'
   - 'content-tagger'
   - 'docs'

--- a/hieradata_aws/class/integration/db_admin.yaml
+++ b/hieradata_aws/class/integration/db_admin.yaml
@@ -89,7 +89,7 @@ govuk_env_sync::tasks:
     url: "govuk-integration-database-backups"
     path: "postgresql-backend"
   "push_content_audit_tool_production_integration_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "1"
     minute: "30"
     action: "push"

--- a/hieradata_aws/class/training/db_admin.yaml
+++ b/hieradata_aws/class/training/db_admin.yaml
@@ -55,7 +55,7 @@ govuk_env_sync::tasks:
     url: "govuk-integration-database-backups"
     path: "postgresql-backend"
   "pull_content_audit_tool_training_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "3"
     minute: "30"
     action: "pull"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -21,7 +21,6 @@ node_class: &node_class
       - canary-backend
       - collections-publisher
       - contacts
-      - content-audit-tool
       - content-data-admin
       - content-data-api
       - content-publisher

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -160,7 +160,6 @@ deployable_applications: &deployable_applications
   collections-publisher: {}
   contacts:
     repository: 'contacts-admin'
-  content-audit-tool: {}
   content-data-admin: {}
   content-data-api: {}
   content-publisher: {}

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -192,9 +192,6 @@ grafana::dashboards::application_dashboards:
     has_workers: true
   contacts:
     docs_name: 'contacts-admin'
-  content-audit-tool:
-    show_sidekiq_graphs: true
-    has_workers: true
   content-data-admin:
     show_sidekiq_graphs: true
     has_workers: true

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -339,7 +339,6 @@ monitoring::checks::lb::loadbalancers:
       - backend-collections-publisher
       - backend-contacts-admin
       - backend-content-api
-      - backend-content-audit-tool
       - backend-content-performance-m
       - backend-content-publisher
       - backend-content-tagger

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -319,7 +319,6 @@ monitoring::checks::lb::loadbalancers:
       - backend-collections-publisher
       - backend-contacts-admin
       - backend-content-api
-      - backend-content-audit-tool
       - backend-content-performance-m
       - backend-content-publisher
       - backend-content-tagger

--- a/modules/govuk/manifests/apps/content_audit_tool.pp
+++ b/modules/govuk/manifests/apps/content_audit_tool.pp
@@ -92,6 +92,7 @@ class govuk::apps::content_audit_tool(
   $app_name = 'content-audit-tool'
 
   govuk::app { $app_name:
+    ensure            => 'absent',
     app_type          => 'rack',
     port              => $port,
     sentry_dsn        => $sentry_dsn,

--- a/modules/govuk/manifests/apps/sidekiq_monitoring.pp
+++ b/modules/govuk/manifests/apps/sidekiq_monitoring.pp
@@ -30,14 +30,6 @@
 #   Redis port for Collections Publisher Sidekiq.
 #   Default: undef
 #
-# [*content_audit_tool_redis_host*]
-#   Redis host for Content Audit Tool Sidekiq.
-#   Default: undef
-#
-# [*content_audit_tool_redis_port*]
-#   Redis port for Content Audit Tool Sidekiq.
-#   Default: undef
-#
 # [*content_data_admin_redis_host*]
 #   Redis host for Content Data Admin Sidekiq.
 #   Default: undef
@@ -181,8 +173,6 @@ class govuk::apps::sidekiq_monitoring (
   $asset_manager_redis_port = undef,
   $collections_publisher_redis_host = undef,
   $collections_publisher_redis_port = undef,
-  $content_audit_tool_redis_host = undef,
-  $content_audit_tool_redis_port = undef,
   $content_data_admin_redis_host = undef,
   $content_data_admin_redis_port = undef,
   $content_data_api_redis_host = undef,
@@ -257,11 +247,6 @@ class govuk::apps::sidekiq_monitoring (
       prefix => 'collections_publisher',
       host   => $collections_publisher_redis_host,
       port   => $collections_publisher_redis_port;
-
-    "${app_name}_content_audit_tool":
-      prefix => 'content_audit_tool',
-      host   => $content_audit_tool_redis_host,
-      port   => $content_audit_tool_redis_port;
 
     "${app_name}_content_data_admin":
       prefix => 'content_data_admin',

--- a/modules/govuk/manifests/node/s_backend_lb.pp
+++ b/modules/govuk/manifests/node/s_backend_lb.pp
@@ -52,7 +52,6 @@ class govuk::node::s_backend_lb (
   loadbalancer::balance { [
     'collections-publisher',
     'contacts-admin',
-    'content-audit-tool',
     'content-data',
     'content-data-admin',
     'content-data-api',

--- a/modules/govuk/templates/sidekiq_monitoring_nginx_config.conf.erb
+++ b/modules/govuk/templates/sidekiq_monitoring_nginx_config.conf.erb
@@ -26,10 +26,6 @@ server {
     proxy_pass http://localhost:3216;
   }
 
-  location /content-audit-tool {
-    proxy_pass http://localhost:3217;
-  }
-
   location /content-data-admin {
     proxy_pass http://localhost:3240;
   }

--- a/modules/govuk_jenkins/manifests/jobs/content_audit_tool.pp
+++ b/modules/govuk_jenkins/manifests/jobs/content_audit_tool.pp
@@ -19,7 +19,7 @@ class govuk_jenkins::jobs::content_audit_tool (
   $rake_import_all_ga_metrics_frequency = undef,
 ) {
   file { '/etc/jenkins_jobs/jobs/content_audit_tool.yaml':
-    ensure  => present,
+    ensure  => absent,
     content => template('govuk_jenkins/jobs/content_audit_tool.yaml.erb'),
     notify  => Exec['jenkins_jobs_update'],
   }


### PR DESCRIPTION
Content Audit Tool is a legacy application created before Content Data. It was used to help tag content - it shared a codebase with Content Performance Manager.

It is being retired as it should no longer be used, to clean up references to it in our codebase, and remove the need for developers to maintain it.

[Trello](https://trello.com/c/V6bXwwtx/1700-3-retire-content-audit-app)