### PR TITLE
Add search-api dashboard panels for suggestion latencies

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1065,6 +1065,8 @@ grafana::dashboards::application_dashboards:
     rows:
       - - reranker_latency_vs_request_count
       - - reranker_errors
+      - - completion_latency_vs_request_count
+        - spelling_latency_vs_request_count
     show_controller_errors: false
     show_response_times: true
     show_sidekiq_graphs: true

--- a/modules/grafana/templates/dashboards/application_dashboard_panels/_completion_latency_vs_request_count.json.erb
+++ b/modules/grafana/templates/dashboards/application_dashboard_panels/_completion_latency_vs_request_count.json.erb
@@ -1,0 +1,84 @@
+{
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "Graphite",
+    "description": "",
+    "fill": 1,
+    "id": 16,
+    "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [
+        {
+            "alias": "Upper 90 latency",
+            "yaxis": 2
+        }
+    ],
+    "spaceLength": 10,
+    "span": 6,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+        {
+            "refId": "B",
+            "target": "alias(groupByNode(stats.govuk.app.search-api.ip-*.suggest.completion, 5, 'sum'), 'Requests')",
+            "textEditor": false
+        },
+        {
+            "refId": "A",
+            "target": "alias(groupByNode(stats.timers.govuk.app.search-api.ip-*.suggest.completion.upper_90, 6, 'avg'), 'Upper 90 latency')",
+            "textEditor": false
+        }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeShift": null,
+    "title": "Completion suggestion count vs latency",
+    "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+    },
+    "yaxes": [
+        {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+        },
+        {
+            "format": "ms",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+        }
+    ]
+}

--- a/modules/grafana/templates/dashboards/application_dashboard_panels/_spelling_latency_vs_request_count.json.erb
+++ b/modules/grafana/templates/dashboards/application_dashboard_panels/_spelling_latency_vs_request_count.json.erb
@@ -1,0 +1,84 @@
+{
+    "aliasColors": {},
+    "bars": false,
+    "dashLength": 10,
+    "dashes": false,
+    "datasource": "Graphite",
+    "description": "",
+    "fill": 1,
+    "id": 17,
+    "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+    },
+    "lines": true,
+    "linewidth": 1,
+    "links": [],
+    "nullPointMode": "null",
+    "percentage": false,
+    "pointradius": 5,
+    "points": false,
+    "renderer": "flot",
+    "seriesOverrides": [
+        {
+            "alias": "Upper 90 latency",
+            "yaxis": 2
+        }
+    ],
+    "spaceLength": 10,
+    "span": 6,
+    "stack": false,
+    "steppedLine": false,
+    "targets": [
+        {
+            "refId": "B",
+            "target": "alias(groupByNode(stats.govuk.app.search-api.ip-*.suggest.spelling, 5, 'sum'), 'Requests')",
+            "textEditor": false
+        },
+        {
+            "refId": "A",
+            "target": "alias(groupByNode(stats.timers.govuk.app.search-api.ip-*.suggest.spelling.upper_90, 6, 'avg'), 'Upper 90 latency')",
+            "textEditor": false
+        }
+    ],
+    "thresholds": [],
+    "timeFrom": null,
+    "timeShift": null,
+    "title": "Spelling suggestion count vs latency",
+    "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+    },
+    "type": "graph",
+    "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+    },
+    "yaxes": [
+        {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+        },
+        {
+            "format": "ms",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+        }
+    ]
+}


### PR DESCRIPTION
<img width="1899" alt="Screenshot 2020-01-30 at 12 19 16" src="https://user-images.githubusercontent.com/75235/73449854-0b11f580-435c-11ea-96ad-82c409cc5628.png">

---

[Trello card](https://trello.com/c/tffuATtg/1331-add-graphite-metrics-for-title-suggest-requests)