### PR TITLE
Add build-user-vars to Deploy_Puppet

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_puppet.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_puppet.yaml.erb
@@ -69,6 +69,7 @@
             colormap: xterm
         - build-name:
             name: '#${BUILD_NUMBER} ${ENV,var="TAG"}'
+        - build-user-vars
         - timestamps:
     parameters:
         - string:


### PR DESCRIPTION
This will stop puppet deploys showing up as "unknown user" in the
release app.