### PR TITLE
Add Icinga check for freshness of GOV.UK Fastly CDN logs in S3.

### DIFF
--- a/modules/monitoring/files/etc/nagios3/conf.d/check_cdn_log_s3_freshness.cfg
+++ b/modules/monitoring/files/etc/nagios3/conf.d/check_cdn_log_s3_freshness.cfg
@@ -1,0 +1,4 @@
+define command {
+    command_name check_cdn_log_s3_freshness
+    command_line /usr/lib/nagios/plugins/check_cdn_log_s3_freshness $ARG1$
+}

--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_cdn_log_s3_freshness
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_cdn_log_s3_freshness
@@ -19,16 +19,21 @@ For help on command-line options:
     check_cdn_log_s3_freshness -h
 
 Example usage for testing the script:
-    check_cdn_log_s3_freshness -e staging -t 2020-01-31T17:00
+    check_cdn_log_s3_freshness -e staging -F 2020-01-31T17:00
 
 Example usage in production:
-    check_cdn_log_s3_freshness -e production -l govuk_www -c 1
+    check_cdn_log_s3_freshness -e production -l govuk_www -c 60
+
+Doctest doesn't work when the module filename doesn't end in .py, so in order
+to run doctest you have to rename the file and then run:
+    python3 -m check_cdn_log_s3_freshness.py
 """
 
 import argparse
 import datetime
 import enum
 import logging
+import posixpath
 import sys
 
 import boto3
@@ -46,8 +51,12 @@ def fromisoformat(s):
 
     This is only meant for passing in a fake time from the command-line when
     testing. Would use datetime.fromisoformat, but we're stuck on Python 3.4.
+
+    Example:
+    >>> fromisoformat('2020-01-30T22:00')
+    datetime.datetime(2020, 1, 30, 22, 0, tzinfo=datetime.timezone.utc)
     """
-    return datetime.datetime.strptime(s, '%Y-%m-%dT%H:%M')
+    return datetime.datetime.strptime(s + '+0000', '%Y-%m-%dT%H:%M%z')
 
 
 def parse_args():
@@ -57,10 +66,10 @@ def parse_args():
                         help='Environment to check: integration, staging, production.')
     parser.add_argument('-l', '--log_type', default='govuk_assets',
                         help='Which logs to check: govuk_assets, govuk_www.')
-    parser.add_argument('-c', '--critical_age_hours', type=int, default=1,
-                        help='If the newest logs are older than this many hours, '
+    parser.add_argument('-c', '--critical_age_minutes', type=int, default=60,
+                        help='If the newest logs are older than this many minutes, '
                              'return CRITICAL status.')
-    parser.add_argument('-t', '--time', type=fromisoformat,
+    parser.add_argument('-F', '--fake_time', type=fromisoformat,
                         help='For testing purposes, use the given time as if it\'s the current '
                              'time. Requires the format YYYY-MM-DDTHH:MM. Assumes UTC.')
     parser.add_argument('-v', '--verbose', action='count',
@@ -76,45 +85,74 @@ def get_s3_bucket(env):
     return s3.Bucket(bucket_name)
 
 
-def get_prefix(log_type, critical_age_hours, fake_time=None):
+def get_prefix(log_type, query_time):
     """Return the S3 prefix to be searched for log files, based on the time."""
-    max_age = datetime.timedelta(hours=critical_age_hours)
-    now = fake_time or datetime.datetime.now(datetime.timezone.utc)  # TZ-aware datetime in UTC.
-    query_time = now - max_age  # Oldest acceptable last_modified time for logs.
-    time_prefix = query_time.strftime('year=%Y/month=%m/date=%d/%Y-%m-%dT%H')
-    logging.info('Time is %s%s', query_time.isoformat(),
-                 ' (overridden for testing)' if fake_time else '')
+    time_prefix = query_time.strftime('year=%Y/month=%m/date=%d/')
     return '%s/%s' % (log_type, time_prefix)
 
 
-def logs_new_enough(s3_objs):
-    """True if there are new enough logs in the given listing, False otherwise."""
-    # For now, we just check that there were logs within the right hour.
-    # Could improve precision by parsing the timestamp in the filename and
-    # comparing that against the threshold, but that's probably not warranted
-    # unless we really care about having better precision that +/- an hour.
-    obj_count = sum(1 for _ in s3_objs)
-    logging.info('Found %d log chunks.', obj_count)
-    return obj_count > 0
+def date_from_filename(filename):
+    """Returns a UTC datetime parsed from the given Fastly log filename.
+
+    Example:
+    >>> date_from_filename('2020-01-30T22:00:00.000-DXdcYBSfUdJyVvwbPcAn.log.gz')
+    datetime.datetime(2020, 1, 30, 22, 0, tzinfo=datetime.timezone.utc)
+    """
+    date_string = filename.split('.')[0] + '+0000'
+    return datetime.datetime.strptime(date_string, '%Y-%m-%dT%H:%M:%S%z')
 
 
-def exit_status_for_icinga(s3_objs):
-    """Return the appropriate exit status, based on whether the logs are up-to-date."""
-    if logs_new_enough(s3_objs):
+def objs_with_prefix(bucket, log_type, query_time):
+    """Return a list of S3 objects for the given day's CDN logs.
+
+    The list is returned in ascending order by S3 key (path).
+    """
+    prefix = get_prefix(log_type, query_time)
+    # S3 guarantees to return objects in ascending key order based on the UTF-8
+    # binary representation of the key. Unfortunately the server-side filtering
+    # is quite limited; we can't specify the sort order or the sort key.
+    objs = list(bucket.objects.filter(Prefix=prefix))
+    logging.info('Found %s files with prefix %s',
+                 'no' if not objs else len(objs), prefix)
+    return objs
+
+
+def status_for_icinga(s3_objs, threshold_datetime):
+    """Given a list of files and a threshold, return the check result.
+
+    s3_objs is assumed to be in ascending order by filename.
+    """
+    if not s3_objs:
+        return IcingaStatus.CRITICAL
+    last_filename = posixpath.basename(s3_objs[-1].key)
+    logging.info('Newest log file (based on filename) is %s', last_filename)
+    file_datetime = date_from_filename(last_filename)
+    logging.info('Newest log time parsed from filename is %s', file_datetime.isoformat())
+    if file_datetime >= threshold_datetime:
         return IcingaStatus.OK
     return IcingaStatus.CRITICAL
 
 
 def main():
+    """Entry point for check_cdn_log_s3_freshness. See module docstring."""
     args = parse_args()
     logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO)
 
-    bucket = get_s3_bucket(args.env)
-    prefix = get_prefix(args.log_type, args.critical_age_hours, fake_time=args.time)
-    logging.info('Listing S3 bucket for prefix %s', prefix)
-    listing = bucket.objects.filter(Prefix=prefix)
+    max_age = datetime.timedelta(minutes=args.critical_age_minutes)
+    now = args.fake_time or datetime.datetime.now(datetime.timezone.utc)
+    oldest_acceptable_time = now - max_age
+    logging.info('Current time is %s%s.',
+                 'overridden for testing to ' if args.fake_time else '',
+                 now.isoformat())
+    logging.info('Looking for log filenames dated %s or newer.',
+                 oldest_acceptable_time.isoformat())
 
-    status = exit_status_for_icinga(listing)
+    bucket = get_s3_bucket(args.env)
+    s3_objs = objs_with_prefix(bucket, args.log_type, oldest_acceptable_time)
+    if now.day != oldest_acceptable_time.day:
+        s3_objs += objs_with_prefix(bucket, args.log_type, now)
+
+    status = status_for_icinga(s3_objs, oldest_acceptable_time)
     print(status.name)
     sys.exit(status)
 

--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_cdn_log_s3_freshness
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_cdn_log_s3_freshness
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""
+Icinga check for freshness of GOV.UK Fastly CDN logs in S3.
+
+Checks whether there are sufficiently recent files in the
+govuk-{env}-fastly-logs S3 bucket, making use of the naming scheme of the logs
+in order to avoid listing the entire bucket (which contains many thousands of
+objects).
+
+Needs to work with Python 3.4 (because we're stuck on Trusty for now and don't
+want to install extra dependencies because this is for monitoring), so no f''
+strings for example :(
+
+The S3 object names look like, for example:
+
+govuk_assets/year=2020/month=01/date=30/2020-01-30T22:00:00.000-DXdcYBSfUdJyVvwbPcAn.log.gz
+
+For help on command-line options:
+    check_cdn_log_s3_freshness -h
+
+Example usage for testing the script:
+    check_cdn_log_s3_freshness -e staging -t 2020-01-31T17:00
+
+Example usage in production:
+    check_cdn_log_s3_freshness -e production -l govuk_www -c 1
+"""
+
+import argparse
+import datetime
+import enum
+import logging
+import sys
+
+import boto3
+
+
+class IcingaStatus(enum.IntEnum):
+    """Exit statuses for Icinga checks."""
+    OK = 0
+    WARNING = 1
+    CRITICAL = 2
+
+
+def fromisoformat(s):
+    """Parse a string YYYY-MM-DDTHH:MM and return a datetime. Assumes UTC.
+
+    This is only meant for passing in a fake time from the command-line when
+    testing. Would use datetime.fromisoformat, but we're stuck on Python 3.4.
+    """
+    return datetime.datetime.strptime(s, '%Y-%m-%dT%H:%M')
+
+
+def parse_args():
+    """Return an argparse.Namespace populated with command-line args."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-e', '--env', default='production',
+                        help='Environment to check: integration, staging, production.')
+    parser.add_argument('-l', '--log_type', default='govuk_assets',
+                        help='Which logs to check: govuk_assets, govuk_www.')
+    parser.add_argument('-c', '--critical_age_hours', type=int, default=1,
+                        help='If the newest logs are older than this many hours, '
+                             'return CRITICAL status.')
+    parser.add_argument('-t', '--time', type=fromisoformat,
+                        help='For testing purposes, use the given time as if it\'s the current '
+                             'time. Requires the format YYYY-MM-DDTHH:MM. Assumes UTC.')
+    parser.add_argument('-v', '--verbose', action='count',
+                        help='Show DEBUG log messages.')
+    return parser.parse_args()
+
+
+def get_s3_bucket(env):
+    """Given the environment name, return the boto S3 resource for the bucket."""
+    s3 = boto3.resource('s3')
+    bucket_name = 'govuk-%s-fastly-logs' % env
+    logging.info('S3 bucket name: %s', bucket_name)
+    return s3.Bucket(bucket_name)
+
+
+def get_prefix(log_type, critical_age_hours, fake_time=None):
+    """Return the S3 prefix to be searched for log files, based on the time."""
+    max_age = datetime.timedelta(hours=critical_age_hours)
+    now = fake_time or datetime.datetime.now(datetime.timezone.utc)  # TZ-aware datetime in UTC.
+    query_time = now - max_age  # Oldest acceptable last_modified time for logs.
+    time_prefix = query_time.strftime('year=%Y/month=%m/date=%d/%Y-%m-%dT%H')
+    logging.info('Time is %s%s', query_time.isoformat(),
+                 ' (overridden for testing)' if fake_time else '')
+    return '%s/%s' % (log_type, time_prefix)
+
+
+def logs_new_enough(s3_objs):
+    """True if there are new enough logs in the given listing, False otherwise."""
+    # For now, we just check that there were logs within the right hour.
+    # Could improve precision by parsing the timestamp in the filename and
+    # comparing that against the threshold, but that's probably not warranted
+    # unless we really care about having better precision that +/- an hour.
+    obj_count = sum(1 for _ in s3_objs)
+    logging.info('Found %d log chunks.', obj_count)
+    return obj_count > 0
+
+
+def exit_status_for_icinga(s3_objs):
+    """Return the appropriate exit status, based on whether the logs are up-to-date."""
+    if logs_new_enough(s3_objs):
+        return IcingaStatus.OK
+    return IcingaStatus.CRITICAL
+
+
+def main():
+    args = parse_args()
+    logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO)
+
+    bucket = get_s3_bucket(args.env)
+    prefix = get_prefix(args.log_type, args.critical_age_hours, fake_time=args.time)
+    logging.info('Listing S3 bucket for prefix %s', prefix)
+    listing = bucket.objects.filter(Prefix=prefix)
+
+    status = exit_status_for_icinga(listing)
+    print(status.name)
+    sys.exit(status)
+
+if __name__ == '__main__':
+    main()

--- a/modules/monitoring/manifests/checks.pp
+++ b/modules/monitoring/manifests/checks.pp
@@ -163,24 +163,24 @@ class monitoring::checks (
       require             => Package['jq'],
     }
 
-    $cdn_log_age_threshold_hours = $::aws_environment ? {
-      'production' => 1,
+    $cdn_log_age_threshold_mins = $::aws_environment ? {
+      'production' => 60,
       # Staging and Integration don't produce any logs between 22:00 and 04:00
       # when traffic replay isn't running. Fastly doesn't send us empty files.
-      default      => 6,
+      default      => 390,
     }
     icinga::check { 'check_cdn_log_s3_freshness_assets':
-      check_command       => "check_cdn_log_s3_freshness!-e ${::aws_environment} -l govuk_assets -c ${cdn_log_age_threshold_hours}",
+      check_command       => "check_cdn_log_s3_freshness!-e ${::aws_environment} -l govuk_assets -c ${cdn_log_age_threshold_mins}",
       host_name           => $::fqdn,
-      service_description => "check that Fastly logs from ${cdn_log_age_threshold_hours}h ago appear in s3://govuk-${::aws_environment}-fastly-logs/govuk_assets",
+      service_description => "check that Fastly logs from ${cdn_log_age_threshold_mins}m ago appear in s3://govuk-${::aws_environment}-fastly-logs/govuk_assets",
       notes_url           => monitoring_docs_url(cdn-log-freshness),
       check_interval      => 60,
       retry_interval      => 5,
     }
     icinga::check { 'check_cdn_log_s3_freshness_www':
-      check_command       => "check_cdn_log_s3_freshness!-e ${::aws_environment} -l govuk_www -c ${cdn_log_age_threshold_hours}",
+      check_command       => "check_cdn_log_s3_freshness!-e ${::aws_environment} -l govuk_www -c ${cdn_log_age_threshold_mins}",
       host_name           => $::fqdn,
-      service_description => "check that Fastly logs from ${cdn_log_age_threshold_hours}h ago appear in s3://govuk-${::aws_environment}-fastly-logs/govuk_www",
+      service_description => "check that Fastly logs from ${cdn_log_age_threshold_mins}m ago appear in s3://govuk-${::aws_environment}-fastly-logs/govuk_www",
       notes_url           => monitoring_docs_url(cdn-log-freshness),
       check_interval      => 60,
       retry_interval      => 5,

--- a/modules/monitoring/manifests/checks.pp
+++ b/modules/monitoring/manifests/checks.pp
@@ -185,6 +185,17 @@ class monitoring::checks (
       check_interval      => 60,
       retry_interval      => 5,
     }
+    # Bouncer logs are in Production only.
+    if $::aws_environment == 'production' {
+      icinga::check { 'check_cdn_log_s3_freshness_bouncer':
+        check_command       => "check_cdn_log_s3_freshness!-e ${::aws_environment} -l bouncer -c ${cdn_log_age_threshold_mins}",
+        host_name           => $::fqdn,
+        service_description => "check that Fastly logs from ${cdn_log_age_threshold_mins}m ago appear in s3://govuk-${::aws_environment}-fastly-logs/bouncer",
+        notes_url           => monitoring_docs_url(cdn-log-freshness),
+        check_interval      => 60,
+        retry_interval      => 5,
+      }
+    }
   }
 
   if ($::aws_migration and $::aws_environment == 'production') {

--- a/modules/monitoring/manifests/checks.pp
+++ b/modules/monitoring/manifests/checks.pp
@@ -45,6 +45,7 @@ class monitoring::checks (
   include monitoring::checks::cloudwatch
   include monitoring::checks::aws_iam_key
   include monitoring::checks::grafana_dashboards
+  include monitoring::checks::cdn_logs
 
   if $::aws_migration {
     include govuk::apps::email_alert_api::checks
@@ -160,6 +161,29 @@ class monitoring::checks (
       check_interval      => 30,
       retry_interval      => 30,
       require             => Package['jq'],
+    }
+
+    $cdn_log_age_threshold_hours = $::aws_environment ? {
+      'production' => 1,
+      # Staging and Integration don't produce any logs between 22:00 and 04:00
+      # when traffic replay isn't running. Fastly doesn't send us empty files.
+      default      => 6,
+    }
+    icinga::check { 'check_cdn_log_s3_freshness_assets':
+      check_command       => "check_cdn_log_s3_freshness!-e ${::aws_environment} -l govuk_assets -c ${cdn_log_age_threshold_hours}",
+      host_name           => $::fqdn,
+      service_description => "check that Fastly logs from ${cdn_log_age_threshold_hours}h ago appear in s3://govuk-${::aws_environment}-fastly-logs/govuk_assets",
+      notes_url           => monitoring_docs_url(cdn-log-freshness),
+      check_interval      => 60,
+      retry_interval      => 5,
+    }
+    icinga::check { 'check_cdn_log_s3_freshness_www':
+      check_command       => "check_cdn_log_s3_freshness!-e ${::aws_environment} -l govuk_www -c ${cdn_log_age_threshold_hours}",
+      host_name           => $::fqdn,
+      service_description => "check that Fastly logs from ${cdn_log_age_threshold_hours}h ago appear in s3://govuk-${::aws_environment}-fastly-logs/govuk_www",
+      notes_url           => monitoring_docs_url(cdn-log-freshness),
+      check_interval      => 60,
+      retry_interval      => 5,
     }
   }
 

--- a/modules/monitoring/manifests/checks/cdn_logs.pp
+++ b/modules/monitoring/manifests/checks/cdn_logs.pp
@@ -1,0 +1,21 @@
+# == Class: monitoring::checks::cdn_logs
+#
+# Icinga alerts for Fastly CDN logs.
+#
+# === Parameters
+#
+# [*enabled*]
+#   Whether to install the alerts.
+#
+class monitoring::checks::cdn_logs (
+      $enabled = true,
+    ) {
+
+    icinga::plugin { 'check_cdn_log_s3_freshness':
+        source  => 'puppet:///modules/monitoring/usr/lib/nagios/plugins/check_cdn_log_s3_freshness',
+    }
+
+    icinga::check_config { 'check_cdn_log_s3_freshness':
+        source  => 'puppet:///modules/monitoring/etc/nagios3/conf.d/check_cdn_log_s3_freshness.cfg',
+    }
+}


### PR DESCRIPTION
### What

* Add an Icinga check which runs hourly and checks whether there are sufficiently up-to-date log files under the S3 prefix(es) for the relevant day(s).
* The check is based on the date/time encoded into the filename, rather than the modification time of the file.
* The S3 bucket contains on the order of 1M objects, so we don't really want to list the entire bucket all the time.
* Install checks for `govuk_assets`, `govuk_www` and `bouncer` logs.

### Why

If Fastly logs aren't making it into S3, we can't fix the gap by reprocessing. We therefore want to know about the issue as soon as reasonably possible (while avoiding false alarms).

This was prompted by an incident where the Fastly->Glue->Athena CDN logs pipeline was broken by a change to the log format.

### Alternatives considered

Since we're planning on switching to Prometheus soon, it would be nice to do at least the metrics side of this in Prometheus and have just a stub check to make the alert appear in Icinga until the switchover. While that would be the ideal outcome, I think to do it justice would require configuring a bunch of things for the first time (like setting up the necessary gubbins to build and deploy a fork of a third party Prometheus exporter) — so I'm inclined to start with this simple Icinga check and iterate from there. I'm fine with this being a short-lived thing.

The logic of the check is very basic: it just looks for any files with the prefix corresponding to the previous hour (or however many hours back it's configured to look). I think this is probably good enough, but we could make it more precise by parsing the timestamp out of the filenames we find. The downside of that would be that there's slightly more to go wrong with the check (for example if the form of the filenames were to change).

### Related PRs
* Permissions change to enable this to work: alphagov/govuk-aws#1244
* Playbook entry: alphagov/govuk-developer-docs#2285