### PR TITLE
Update pycsw.cfg with correct url

### DIFF
--- a/modules/govuk/templates/ckan/pycsw.cfg.erb
+++ b/modules/govuk/templates/ckan/pycsw.cfg.erb
@@ -1,6 +1,6 @@
 [server]
 home=/var/ckan
-url=http://localhost:<%= @pycsw_port %>/csw
+url=<%= @ckan_site_url %>/csw
 mimetype=application/xml; charset=UTF-8
 encoding=UTF-8
 language=en-GB


### PR DESCRIPTION
## What 

The response from the `/csw` endpoint is generating `http://localhost` in the XML response when it should be the CKAN site url. CSW harvesting should work after the correct site is set.

This has been tested on integration and is working as expected.

## Reference 

https://trello.com/c/zsSsXoid/1688-fix-csw-endpoint-to-allow-it-to-be-harvested
