### PR TITLE
Fix govuk_uptime_collector in AWS staging & prod

### DIFF
--- a/modules/monitoring/files/usr/local/bin/govuk_uptime_collector
+++ b/modules/monitoring/files/usr/local/bin/govuk_uptime_collector
@@ -36,7 +36,7 @@ private
   def healthcheck_uri
     @healthcheck_uri ||= begin
       if aws
-        URI("https://#{service_name}.blue.integration.govuk.digital/healthcheck")
+        URI("https://#{service_name}.blue.#{environment}.govuk.digital/healthcheck")
       else
         prefix = environment == "production" ? "#{service_name}" : "#{service_name}.#{environment}"
         URI("https://#{prefix}.publishing.service.gov.uk/#{healthcheck_path}")


### PR DESCRIPTION
We hardcoded the environment to `integration` in AWS which means we're
gathering wrong stats.  This doesn't matter right now because the apps
we check aren't running in AWS staging/prod, mostly; but it will
matter more when more of the publisher apps are moved.