### PR TITLE
Add search count & latency to app dashboard

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1053,7 +1053,8 @@ grafana::dashboards::application_dashboards:
     rows:
       - - reranker_latency_vs_request_count
       - - reranker_errors
-      - - completion_latency_vs_request_count
+      - - search_latency_vs_request_count
+        - completion_latency_vs_request_count
         - spelling_latency_vs_request_count
     show_controller_errors: false
     show_response_times: true

--- a/modules/grafana/templates/dashboards/application_dashboard_panels/_completion_latency_vs_request_count.json.erb
+++ b/modules/grafana/templates/dashboards/application_dashboard_panels/_completion_latency_vs_request_count.json.erb
@@ -31,7 +31,7 @@
         }
     ],
     "spaceLength": 10,
-    "span": 6,
+    "span": 4,
     "stack": false,
     "steppedLine": false,
     "targets": [

--- a/modules/grafana/templates/dashboards/application_dashboard_panels/_search_latency_vs_request_count.json.erb
+++ b/modules/grafana/templates/dashboards/application_dashboard_panels/_search_latency_vs_request_count.json.erb
@@ -6,7 +6,7 @@
     "datasource": "Graphite",
     "description": "",
     "fill": 1,
-    "id": 17,
+    "id": 18,
     "legend": {
         "avg": false,
         "current": false,
@@ -37,19 +37,19 @@
     "targets": [
         {
             "refId": "B",
-            "target": "alias(groupByNode(stats.govuk.app.search-api.ip-*.suggest.spelling, 5, 'sum'), 'Requests')",
+            "target": "alias(groupByNode(stats.govuk.app.search-api.ip-*.search_query, 5, 'sum'), 'Requests')",
             "textEditor": false
         },
         {
             "refId": "A",
-            "target": "alias(groupByNode(stats.timers.govuk.app.search-api.ip-*.suggest.spelling.upper_90, 6, 'avg'), 'Upper 90 latency')",
+            "target": "alias(groupByNode(stats.timers.govuk.app.search-api.ip-*.elasticsearch.raw_search.upper_90, 6, 'avg'), 'Upper 90 latency')",
             "textEditor": false
         }
     ],
     "thresholds": [],
     "timeFrom": null,
     "timeShift": null,
-    "title": "Spelling suggestion count vs latency",
+    "title": "Search count vs latency",
     "tooltip": {
         "shared": true,
         "sort": 0,


### PR DESCRIPTION
This was in the now-deleted "search / elasticsearch slis" dashboard.