### PR TITLE
Add an env_sync pull job for release in aws staging

### DIFF
--- a/hieradata/node/mysql-backup-1.backend.publishing.service.gov.uk.yaml
+++ b/hieradata/node/mysql-backup-1.backend.publishing.service.gov.uk.yaml
@@ -1,0 +1,12 @@
+govuk_env_sync::tasks:
+  "push_release_production_daily":
+    ensure: "present"
+    hour: "0"
+    minute: "16"
+    action: "push"
+    dbms: "mysql"
+    storagebackend: "s3"
+    database: "release_production"
+    temppath: "/home/govuk-backup/tmp_dumps/release_production"
+    url: "govuk-production-database-backups"
+    path: "mysql"

--- a/hieradata_aws/class/staging/db_admin.yaml
+++ b/hieradata_aws/class/staging/db_admin.yaml
@@ -144,6 +144,17 @@ govuk_env_sync::tasks:
     temppath: "/tmp/whitehall_production"
     url: "govuk-production-database-backups"
     path: "mysql"
+  "pull_release_production_daily":
+    ensure: "present"
+    hour: "2"
+    minute: "15"
+    action: "pull"
+    dbms: "mysql"
+    storagebackend: "s3"
+    database: "release_production"
+    temppath: "/tmp/release_production"
+    url: "govuk-production-database-backups"
+    path: "mysql"
   "pull_govuk_assets_production":
     ensure: "present"
     hour: "2"


### PR DESCRIPTION
This is cribbed from:
https://github.com/alphagov/govuk-puppet/blob/5877b0fe9e925b4eedee410eb2932df0c573a4a2/hieradata_aws/class/training/db_admin.yaml#L178-L188

and will ingest the backups created in production by:

https://github.com/alphagov/govuk-puppet/blob/7621c13cc81103ea851d3e719f8a56025a71aaf4/hieradata/node/mysql-backup-1.backend.publishing.service.gov.uk.yaml#L2-L12