### PR TITLE
Delete `govuk_cdnlogs` code as it's superseded by AWS S3 and Athena

### DIFF
--- a/modules/govuk/manifests/node/s_monitoring.pp
+++ b/modules/govuk/manifests/node/s_monitoring.pp
@@ -22,7 +22,6 @@ class govuk::node::s_monitoring (
   include ::govuk_containers::terraboard
   include govuk_rbenv::all
   include ::selenium
-  include ::govuk_cdnlogs
   include monitoring
   include collectd::plugin::icinga
   include govuk_java::openjdk8::jre

--- a/modules/govuk_cdnlogs/manifests/init.pp
+++ b/modules/govuk_cdnlogs/manifests/init.pp
@@ -30,8 +30,8 @@
 
 class govuk_cdnlogs (
   $log_dir,
-  $govuk_monitoring_enabled = true,
-  $bouncer_monitoring_enabled = true,
+  $govuk_monitoring_enabled = false,
+  $bouncer_monitoring_enabled = false,
   $warning_cdn_freshness = 1800,
   $critical_cdn_freshness = 3600,
   $server_key,
@@ -47,14 +47,14 @@ class govuk_cdnlogs (
   $crt_file = '/etc/ssl/rsyslog.crt'
 
   file { $key_file:
-    ensure  => file,
+    ensure  => absent,
     mode    => '0400',
     owner   => 'root',
     content => $server_key,
     notify  => Class['rsyslog::service'],
   }
   file { $crt_file:
-    ensure  => file,
+    ensure  => absent,
     mode    => '0400',
     owner   => 'root',
     content => $server_crt,
@@ -73,12 +73,12 @@ class govuk_cdnlogs (
   }
 
   file { '/etc/logrotate.cdn_logs_hourly.conf':
-    ensure  => file,
+    ensure  => absent,
     content => template('govuk_cdnlogs/etc/logrotate.cdn_logs_hourly.conf.erb'),
   }
 
   file { '/etc/cron.hourly/cdn_logs_rotate':
-    ensure  => file,
+    ensure  => absent,
     source  => 'puppet:///modules/govuk_cdnlogs/etc/cron.hourly/cdn_logs_rotate',
     mode    => '0744',
     require => File['/etc/logrotate.cdn_logs_hourly.conf'],
@@ -129,7 +129,7 @@ class govuk_cdnlogs (
   }
 
   file { $log_dir:
-    ensure => directory,
+    ensure => absent,
     owner  => 'root',
     group  => 'deploy',
     mode   => '0775',


### PR DESCRIPTION
- Pulling these from Fastly into files on disk was superseded in [2018](https://github.com/alphagov/govuk-rfcs/pull/93).
- This code and its docs were rediscovered in https://github.com/alphagov/govuk-developer-docs/pull/2285#issuecomment-582373234 and it was confusing.

This is draft because a) I'm not sure I've got everything and b) should we do this?