### PR TITLE
Configure content publisher healthcheck endpoint

### DIFF
--- a/modules/govuk/manifests/apps/content_publisher.pp
+++ b/modules/govuk/manifests/apps/content_publisher.pp
@@ -146,6 +146,7 @@ class govuk::apps::content_publisher (
     sentry_dsn         => $sentry_dsn,
     vhost_ssl_only     => true,
     health_check_path  => '/healthcheck', # must return HTTP 200 for an unauthenticated request
+    json_health_check  => true,
     deny_framing       => true,
     asset_pipeline     => true,
     nginx_extra_config => 'client_max_body_size 500m;',


### PR DESCRIPTION
Trello - https://trello.com/c/FaHAEajH/1318-alert-2ndline-when-we-have-no-cached-data-on-governments

https://github.com/alphagov/content-publisher/pull/1748 iterated content publishers healthcheck endpoint. It now returns a json response that should be reflected in puppet.