### PR TITLE
Remove Terraboard from the infrastructure

### DIFF
--- a/modules/govuk/manifests/node/s_monitoring.pp
+++ b/modules/govuk/manifests/node/s_monitoring.pp
@@ -58,7 +58,7 @@ class govuk::node::s_monitoring (
 
   # Only install Terraboard in AWS
   if $::aws_migration {
-    $terraboard_ensure = present
+    $terraboard_ensure = absent
   } else {
     $terraboard_ensure = absent
   }

--- a/modules/govuk_containers/manifests/terraboard.pp
+++ b/modules/govuk_containers/manifests/terraboard.pp
@@ -55,7 +55,7 @@ class govuk_containers::terraboard(
 
   # Only install Terraboard in AWS
   if $::aws_migration {
-    $terraboard_ensure = present
+    $terraboard_ensure = absent
     $terraboard_directory = directory
   } else {
     $terraboard_ensure = absent


### PR DESCRIPTION
- Terraboard was [introduced in 2018](https://github.com/alphagov/govuk-puppet/pull/8143) to help us track Terraform state between environments, to help with the AWS migration.

- Since then, it hasn't got much use - mostly, we don't remember it exists. It hasn't helped with the goal of keeping environments in sync if any of the recent [Terraform deploy diffs](https://ci-deploy.integration.publishing.service.gov.uk/job/Deploy_Terraform_GOVUK_AWS/) are anything to go by.

- It uses an old, unmaintained version of OAuth2 Proxy which we've had to build a [custom Docker image](https://github.com/alphagov/govuk-oauth2-proxy-docker/blob/master/Dockerfile) for. Both of these projects are now archived.

- There's [documentation on the required engineering work](https://github.com/alphagov/govuk-developer-docs/blob/5ce8d7bd10cdceb7b89309ae388a41016dd2ab64/source/manual/use-terraboard-to-monitor-terraform-state.html.md#docker-image-for-oauth2-proxy) to get us up to date and stop maintaining so much custom code. This has recently (2020) increased because [GitHub are deprecating the authentication APIs that v2.2.0 uses](https://developer.github.com/changes/2019-11-05-deprecated-passwords-and-authorizations-api/#authenticating-using-query-parameters) and will keep sending emails every three days until we stop using it.

- Doing that engineering work will - we hypothesize - cost more than the value that Terraboard currently provides. So, delete Terraboard. To add some weight to this, a recent poll that I did in Slack had most respondents on the item "is a Terraboard an upside down Hoverboard", indicating that most devs had never heard of it.

- Other considerations included: getting rid of OAuth2_Proxy because Terraboard is behind office IP restrictions on AWS. But: is Terraboard that valuable as a thing?