### PR TITLE
Update ckan.ini to disable GA cookies

### DIFF
--- a/modules/govuk/templates/ckan/ckan.ini.erb
+++ b/modules/govuk/templates/ckan/ckan.ini.erb
@@ -69,7 +69,7 @@ ckan.auth.roles_that_cascade_to_sub_groups = admin
 ckan.valid_email_regexes = .gov.uk$ .nhs.uk$ .nhs.net$ .ac.uk$ .os.uk$ .mod.uk$ .police.uk$ .bl.uk$
 
 ## Google Analytics
-ckan.google_analytics_tracking_id = UA-10855508-1
+ckan.google_analytics_tracking_id = nil
 
 ## Search Settings
 


### PR DESCRIPTION
## What

We need to provide a cookie consent form before using cookies on CKAN, so for now just disable them.