### PR TITLE
Unset releaseapp_host_org in Production

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -138,7 +138,6 @@ task :check_consistency_between_aws_and_carrenza do
     govuk_jenkins::jobs::signon_cron_rake_tasks::rake_users_suspend_inactive_frequency
     govuk_postgresql::backup::auto_postgresql_backup_hour
     govuk_postgresql::backup::auto_postgresql_backup_minute
-    hosts::production::releaseapp_host_org
   ]
 
   # Keys that are AWS-only

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -160,7 +160,6 @@ hosts::production::ip_backend_lb: '10.3.3.254'
 hosts::production::ip_bouncer: '37.26.90.219'
 hosts::production::ip_draft_api_lb: '10.3.4.253'
 hosts::production::ip_frontend_lb: '10.3.2.254'
-hosts::production::releaseapp_host_org: true
 
 hosts::production::api::hosts:
   api-1:


### PR DESCRIPTION
I'm not sure exactly why this is here, but now that the Release app is
running in AWS, I think this is leading to a /etc/hosts entry for
release.publishing.service.gov.uk, which means that deployments in
Carrenza are still being recorded in the Release app running in
Carrenza.