### PR TITLE
Exclude content-audit-tool LB target group from monitoring.

### DIFF
--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -338,6 +338,7 @@ monitoring::checks::lb::loadbalancers:
       - backend-collections-publisher
       - backend-contacts-admin
       - backend-content-api
+      - backend-content-audit-tool
       - backend-content-performance-m
       - backend-content-publisher
       - backend-content-tagger

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -317,6 +317,7 @@ monitoring::checks::lb::loadbalancers:
       - backend-collections-publisher
       - backend-contacts-admin
       - backend-content-api
+      - backend-content-audit-tool
       - backend-content-performance-m
       - backend-content-publisher
       - backend-content-tagger


### PR DESCRIPTION
content-audit-tool has been decommissioned, but removing the target
group config from the load balancers is hard because of Terraform
issues which will take time to resolve.

For now, exclude content-audit-tool from load balancer monitoring.