### PR TITLE
Create release app dashboard in AWS

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -802,7 +802,6 @@ grafana::dashboards::application_dashboards:
   publisher:
     show_sidekiq_graphs: true
     has_workers: true
-  release: {}
   search-admin: {}
   service-manual-publisher: {}
   short-url-manager: {}

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1043,6 +1043,7 @@ grafana::dashboards::application_dashboards:
     has_workers: true
     instance_prefix: 'publishing_api'
     show_memcached: true
+  release: {}
   router: {}
   router-api: {}
   search-api:


### PR DESCRIPTION
The release app is now in AWS, so we need to shift the dashboard over.