### PR TITLE
Fix typo in path to check_reboot_required Nagios plugin script

### DIFF
--- a/modules/monitoring/manifests/client/apt.pp
+++ b/modules/monitoring/manifests/client/apt.pp
@@ -17,7 +17,7 @@ class monitoring::client::apt {
   }
 
   @icinga::plugin { 'check_reboot_required':
-    source  => 'puppet:///modules/icinga/usr/lib/nagios/plugins/check_reboot_required',
+    source  => 'puppet:///modules/monitoring/usr/lib/nagios/plugins/check_reboot_required',
   }
 
   @icinga::nrpe_config { 'check_reboot_required':


### PR DESCRIPTION
- Follow-up to d45682a because of
https://sentry.io/organizations/govuk/issues/1512657681/?environment=default&project=125252&query=is%3Aunresolved.