### PR TITLE
Import `check_apt_security_updates` from `alphagov/nagios-plugins`

### DIFF
--- a/modules/monitoring/files/etc/nagios/nrpe.d/check_apt_security_updates.cfg
+++ b/modules/monitoring/files/etc/nagios/nrpe.d/check_apt_security_updates.cfg
@@ -1,1 +1,1 @@
-command[check_apt_security_updates]=/usr/local/bin/check_apt_security_updates $ARG1$ $ARG2$
+command[check_apt_security_updates]=/usr/lib/nagios/plugins/check_apt_security_updates $ARG1$ $ARG2$

--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_apt_security_updates
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_apt_security_updates
@@ -1,0 +1,85 @@
+#!/usr/bin/env python2
+import string
+import subprocess
+import sys
+
+from plugins.output import (CheckException,
+                            nagios_ok,
+                            nagios_warning,
+                            nagios_critical,
+                            nagios_message)
+
+
+def parse_output(apt_check_output):
+    """
+    Parse the passed in apt_check_output. Expects a string of the format
+    '<int>;<int>'. The second of these two numbers is the number of security
+    updates. If, for instance, there are broken packages then apt_check_output
+    cannot be parsed as an int. This is assumed to be a critical
+    as it could imply broken packages.
+    """
+    packages_to_update = string.split(apt_check_output, ';')
+
+    try:
+        return (int(packages_to_update[0]),
+                int(packages_to_update[1]))
+    except ValueError:
+        nagios_critical("apt-check output was not an int. "
+                        "Returned '{}'".format(
+                            apt_check_output))
+
+
+def parse_apt_check(apt_check_output, critical, warning):
+    (_, security_updates) = parse_output(apt_check_output)
+
+    if security_updates >= critical:
+        nagios_critical("%s security updates need to be"
+                        "applied with 'apt-get dist-upgrade'"
+                        % security_updates)
+    elif security_updates >= warning:
+        nagios_warning("%s security updates need to be"
+                       "applied with 'apt-get dist-upgrade'"
+                       % security_updates)
+    else:
+        nagios_ok("All security updates applied")
+
+
+usage_message = """
+Usage: check_apt_security_updates [critical] [warning]
+
+Checks the number of outstanding security updates
+
+When given no arguments, the default threshold is 0 updates.
+One argument will raise a critical alert at that number of updates.
+Two arguments will raise a warning at the first number of updates
+and a critical at the second number of updates
+"""
+
+
+def main():
+    try:
+        if len(sys.argv) >= 3:
+            warning = sys.argv[2]
+            critical = sys.argv[1]
+        elif len(sys.argv) == 2:
+            if sys.argv[1] == "-h":
+                print usage_message
+                sys.exit(0)
+            else:
+                warning = sys.argv[1]
+                critical = sys.argv[1]
+        else:
+            warning = 0
+            critical = 0
+
+        proc = subprocess.Popen(['/usr/lib/update-notifier/apt-check'],
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.STDOUT)
+        apt_check_output = proc.stdout.read()
+        parse_apt_check(apt_check_output, critical, warning)
+
+    except CheckException as e:
+        nagios_message(e.message, e.severity)
+    except Exception as e:
+        # Catching all other exceptions
+        nagios_message("Exception: %s" % e, 3)

--- a/modules/monitoring/manifests/client/apt.pp
+++ b/modules/monitoring/manifests/client/apt.pp
@@ -1,11 +1,15 @@
 # FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
 class monitoring::client::apt {
-  @icinga::nrpe_config { 'check_apt_security_updates':
-    source => 'puppet:///modules/monitoring/etc/nagios/nrpe.d/check_apt_security_updates.cfg',
-  }
+
   @icinga::plugin { 'check_apt_security_updates':
-    ensure => absent,
+    source  => 'puppet:///modules/monitoring/usr/lib/nagios/plugins/check_apt_security_updates',
   }
+
+  @icinga::nrpe_config { 'check_apt_security_updates':
+    source  => 'puppet:///modules/monitoring/etc/nagios/nrpe.d/check_apt_security_updates.cfg',
+    require => Icinga::Plugin['check_apt_security_updates'],
+  }
+
   @@icinga::check { "check_apt_security_updates_${::hostname}":
     check_command              => 'check_nrpe!check_apt_security_updates!0 0',
     service_description        => 'outstanding security updates',


### PR DESCRIPTION
- This was in the alphagov/nagios-plugins repo, which not very many
  people either have permissions to, or realise is still used. We're going
  to archive that repo.