### PR TITLE
Fix check scripts' `nagios_*` methods to be useable

### DIFF
--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_apt_security_updates
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_apt_security_updates
@@ -3,11 +3,31 @@ import string
 import subprocess
 import sys
 
-from plugins.output import (CheckException,
-                            nagios_ok,
-                            nagios_warning,
-                            nagios_critical,
-                            nagios_message)
+class CheckException(Exception):
+    def __init__(self, message, severity):
+        Exception.__init__(self, message)
+        self.severity = severity
+
+
+def nagios_message(message, exitcode):
+    """Format a Nagios message and exit"""
+    print message
+    sys.exit(exitcode)
+
+
+def nagios_ok(message):
+    """Nagios OK message"""
+    raise CheckException("OK: %s" % message, 0)
+
+
+def nagios_warning(message):
+    """Nagios WARNING message"""
+    raise CheckException("WARNING: %s" % message, 1)
+
+
+def nagios_critical(message):
+    """Nagios CRITICAL message"""
+    raise CheckException("CRITICAL: %s" % message, 2)
 
 
 def parse_output(apt_check_output):

--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_reboot_required
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_reboot_required
@@ -9,13 +9,36 @@ import os
 import re
 import sys
 
-from plugins.output import (CheckException,
-                            nagios_ok,
-                            nagios_warning,
-                            nagios_critical,
-                            nagios_unknown,
-                            nagios_message)
+class CheckException(Exception):
+    def __init__(self, message, severity):
+        Exception.__init__(self, message)
+        self.severity = severity
 
+
+def nagios_message(message, exitcode):
+    """Format a Nagios message and exit"""
+    print message
+    sys.exit(exitcode)
+
+
+def nagios_ok(message):
+    """Nagios OK message"""
+    raise CheckException("OK: %s" % message, 0)
+
+
+def nagios_warning(message):
+    """Nagios WARNING message"""
+    raise CheckException("WARNING: %s" % message, 1)
+
+
+def nagios_critical(message):
+    """Nagios CRITICAL message"""
+    raise CheckException("CRITICAL: %s" % message, 2)
+
+
+def nagios_unknown(message):
+    """Nagios UNKNOWN message"""
+    raise CheckException("UNKNOWN: %s" % message, 3)
 
 def dpkg_log_lines(log_files):
     """Parse the package install logs into a list of lines"""


### PR DESCRIPTION
- In `alphagov/nagios-scripts`, the output functions were [extracted
  into their own module that was
  `import`ed](https://github.com/alphagov/nagios-plugins/commit/1ec7bdc5eb816a90bf4ffb37c7e5ae73ce303702).
- We need those functions in each script (we can refactor it later to be
  better?) for the outputs to work.