### PR TITLE
Remove the `gds-nagios-plugins` package

### DIFF
--- a/modules/monitoring/manifests/client.pp
+++ b/modules/monitoring/manifests/client.pp
@@ -13,7 +13,7 @@ class monitoring::client (
 
   exec { 'gds-nagios-plugins':
     path    => ['/usr/local/bin', '/usr/bin', '/bin'],
-    command => 'pip install setuptools-pep8 gds-nagios-plugins==1.5.0 --index-url https://pypi.python.org/pypi',
+    command => 'pip uninstall -y setuptools-pep8 gds-nagios-plugins || true',
     require => Package['update-notifier-common'],
   }
 


### PR DESCRIPTION
- We've moved everything that used to be here out of
  alphagov/nagios-plugins and into the plugins directory of this repo.

This is draft because we need #10144 merged and deployed first.