### PR TITLE
Use Capistrano's HOSTFILTER feature instead of rolling our own.

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
@@ -20,7 +20,7 @@
             export DEPLOY_TO="<%= @environment -%>"
             export DEPLOY_TASK="$DEPLOY_TASK"
             export TAG="$TAG"
-            export TARGET_MACHINES="$TARGET_MACHINES"
+            export HOSTFILTER="$TARGET_MACHINES"
             export ORGANISATION="<%= @environment -%>"
             export CI_DEPLOY_JENKINS_API_KEY="<%= @ci_deploy_jenkins_api_key -%>"
             export GRAPHITE_HOST="<%= @graphite_host -%>"
@@ -90,8 +90,9 @@
         - string:
             name: TARGET_MACHINES
             description: >
-              Use "all" to target all eligible servers or
-              provide a comma-delimited list of FQDN of the servers to deploy to.
+              Use "all" to target all eligible servers or provide a
+              comma-delimited list of FQDN of the servers to deploy to. Sets
+              the HOSTFILTER environment variable for Capistrano.
             default: all
         - bool:
             name: DEPLOY_FROM_AWS_CODECOMMIT


### PR DESCRIPTION
It turns out that Capistrano 2's `HOSTFILTER` feature does exactly what we've been trying to implement ourselves in our `TARGET_MACHINES` change. Specifically, it deploy to just the machines specified in `HOSTFILTER` and ignores any tasks for roles which the machine doesn't have.

The motivation for this is to fix deployments of Whitehall to single nodes, which happens when an EC2 instance goes away and when we scale up. This has been broken since Sep 2019 (#325). My previous attempt, #358, didn't solve the problem because Cap fails when a task has no applicable machines (for example `restart_backend` has no applicable machines when deploying to a `whitehall_frontend` machine).

There is a caveat to this, which is that `HOSTFILTER` appears to have been removed in Capistrano 3 and replaced with a similar `HOSTS` feature, which sadly doesn't do what we need; it tries to run all tasks on the specified hosts regardless of whether the tasks apply to the role or not.

So if for any reason we want to upgrade to Capistrano 3, we'd need to find an alternative solution. I don't imagine that's very likely though, given that we've been on Cap 2 for so many years.

Tested in Integration by making the same change manually on the Jenkins job temporarily.