### PR TITLE
Set HOSTFILTER only if TARGET_MACHINES is set.

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
@@ -20,7 +20,9 @@
             export DEPLOY_TO="<%= @environment -%>"
             export DEPLOY_TASK="$DEPLOY_TASK"
             export TAG="$TAG"
-            export HOSTFILTER="$TARGET_MACHINES"
+            if [ "${TARGET_MACHINES:-all}" != "all" ]; then
+              export HOSTFILTER="$TARGET_MACHINES"
+            fi
             export ORGANISATION="<%= @environment -%>"
             export CI_DEPLOY_JENKINS_API_KEY="<%= @ci_deploy_jenkins_api_key -%>"
             export GRAPHITE_HOST="<%= @graphite_host -%>"


### PR DESCRIPTION
Fixes bug introduced in #10146 which broke all-nodes deployments.

Tested by applying the change on the Integration Jenkins and running an all-nodes and a single-node deploy. In both cases it selected the right nodes as well as the job succeeding.

I also verified that the conditional does the right thing for `TARGET_MACHINES=""`, `TARGET_MACHINES=all` and `TARGET_MACHINES="foo, bar"`.