### PR TITLE
Adding env-sync to carrenza production mongo instances

### DIFF
--- a/hieradata/class/production/mongo.yaml
+++ b/hieradata/class/production/mongo.yaml
@@ -4,7 +4,7 @@ mongodb::s3backup::cron::realtime_minute: '*/30'
 
 govuk_env_sync::tasks:
   "push_govuk_assets_production":
-    ensure: "present"
+    ensure: "disabled"
     hour: "1"
     minute: "00"
     action: "push"


### PR DESCRIPTION
This is needed to allow us to backup the asset manager db
to support carrenza to aws migration of this service

- adding to all nodes
- removing hiera data which put it only on one node

Pair: @camdesgov & @smford