### PR TITLE
Revert "Adding env-sync to carrenza production mongo instances"

### DIFF
--- a/hieradata/node/mongo-2.backend.publishing.service.gov.uk.yaml
+++ b/hieradata/node/mongo-2.backend.publishing.service.gov.uk.yaml
@@ -4,7 +4,7 @@ mongodb::s3backup::cron::realtime_minute: '*/30'
 
 govuk_env_sync::tasks:
   "push_govuk_assets_production":
-    ensure: "disabled"
+    ensure: "present"
     hour: "1"
     minute: "00"
     action: "push"


### PR DESCRIPTION
Revert #10148 because it does two unintended things:

* Makes the govuk_env_sync backup run in triplicate, simultaneously on all MongoDB nodes. It doesn't just run on the node that's currently the leader.
* Makes the old `mongodb::backup::s3_backups` backup job run on all three nodes as well. This also isn't supposed to happen.

It's ok for us not to run the govuk_env_sync job automatically from Carrenza because we've tested it several times now anyway. At this point, it's not worth enabling it as we'll only be turning it off again after the migration tomorrow.

This doesn't prevent us from running the backup job during the migration.

Reverts alphagov/govuk-puppet#10148