### PR TITLE
Remove conditional owner for /data/uploads/publisher

### DIFF
--- a/modules/govuk/manifests/apps/publisher.pp
+++ b/modules/govuk/manifests/apps/publisher.pp
@@ -138,17 +138,9 @@ class govuk::apps::publisher(
     content => template('govuk/local_authority_import_check.erb'),
   }
 
-  if $::aws_migration {
-    $data_dir_user = 'deploy'
-  } else {
-    $data_dir_user = 'assets'
-  }
-
   file { ['/data/uploads/publisher', '/data/uploads/publisher/reports']:
     ensure => directory,
     mode   => '0775',
-    owner  => $data_dir_user,
-    group  => $data_dir_user,
   }
 
   govuk::procfile::worker { $app_name:


### PR DESCRIPTION
Following migration of whitehall and asset-manager to AWS we still
 have the /data/uploads/publisher dir left on the NFS share.
However the assets user do not exist anymore on the backend
machines. We remove this bit of code setting the owner as a
temporary measure to fix puppet on the backend machines.
Long term solution will be to move the files in
/data/uploads/publisher somewhere else.