### PR TITLE
Stop puppet managing /data/uploads/publisher

### DIFF
--- a/modules/govuk/manifests/apps/publisher.pp
+++ b/modules/govuk/manifests/apps/publisher.pp
@@ -138,11 +138,6 @@ class govuk::apps::publisher(
     content => template('govuk/local_authority_import_check.erb'),
   }
 
-  file { ['/data/uploads/publisher', '/data/uploads/publisher/reports']:
-    ensure => directory,
-    mode   => '0775',
-  }
-
   govuk::procfile::worker { $app_name:
     enable_service => $enable_procfile_worker,
   }


### PR DESCRIPTION
Following migration of asset-manager to aws the backend machines
don't have the assets user anymore, this break puppet.
As a short term fix we remove management of the problematic dir
and files. Long term we'll move them to another location.