### PR TITLE
Remove the code that (un)installed the gds-nagios-plugins package

### DIFF
--- a/modules/monitoring/manifests/client.pp
+++ b/modules/monitoring/manifests/client.pp
@@ -11,12 +11,6 @@ class monitoring::client (
   include collectd
   include collectd::plugin::tcp
 
-  exec { 'gds-nagios-plugins':
-    path    => ['/usr/local/bin', '/usr/bin', '/bin'],
-    command => 'pip uninstall -y setuptools-pep8 gds-nagios-plugins || true',
-    require => Package['update-notifier-common'],
-  }
-
   class { 'statsd':
     graphite_hostname => $graphite_hostname,
   }


### PR DESCRIPTION
- Now that Puppet has run everywhere with the changes from 43e4afebe -
  to uninstall the `gds-nagios-plugins` package - we can remove the
  `exec` that did that.