### PR TITLE
Create a Jenkins job to query Athena CDN logs

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -447,6 +447,8 @@ task :check_consistency_between_aws_and_carrenza do
     govuk_cdnlogs::bouncer_monitoring_enabled
     govuk_cdnlogs::critical_cdn_freshness
     govuk_cdnlogs::warning_cdn_freshness
+    govuk_jenkins::jobs::athena_fastly_logs_check::databases
+    govuk_jenkins::jobs::athena_fastly_logs_check::s3_results_bucket
     govuk_jenkins::jobs::data_sync_complete_production::signon_domains_to_migrate
     govuk_jenkins::jobs::search_fetch_analytics_data::cron_schedule
     govuk_jenkins::jobs::search_fetch_analytics_data::skip_page_traffic_load

--- a/hieradata_aws/class/integration/jenkins.yaml
+++ b/hieradata_aws/class/integration/jenkins.yaml
@@ -6,6 +6,7 @@ govuk_jenkins::config::theme_text_colour: 'white'
 govuk_jenkins::config::theme_environment_name: 'AWS Integration'
 
 govuk_jenkins::job_builder::jobs:
+  - govuk_jenkins::jobs::athena_fastly_logs_check
   - govuk_jenkins::jobs::clear_frontend_memcache
   - govuk_jenkins::jobs::clear_template_cache
   - govuk_jenkins::jobs::clear_varnish_cache

--- a/hieradata_aws/class/production/jenkins.yaml
+++ b/hieradata_aws/class/production/jenkins.yaml
@@ -1,5 +1,6 @@
 ---
 govuk_jenkins::job_builder::jobs:
+  - govuk_jenkins::jobs::athena_fastly_logs_check
   - govuk_jenkins::jobs::bouncer_cdn
   - govuk_jenkins::jobs::check_sentry_errors
   - govuk_jenkins::jobs::clear_cdn_cache

--- a/hieradata_aws/class/staging/jenkins.yaml
+++ b/hieradata_aws/class/staging/jenkins.yaml
@@ -7,6 +7,7 @@ govuk_jenkins::config::theme_text_colour: 'black'
 govuk_jenkins::config::theme_environment_name: 'AWS Staging'
 
 govuk_jenkins::job_builder::jobs:
+  - govuk_jenkins::jobs::athena_fastly_logs_check
   - govuk_jenkins::jobs::clear_frontend_memcache
   - govuk_jenkins::jobs::clear_template_cache
   - govuk_jenkins::jobs::clear_varnish_cache

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -116,6 +116,7 @@ govuk_cdnlogs::bouncer_monitoring_enabled: false
 govuk_jenkins::job_builder::environment: 'integration'
 govuk_jenkins::config::executors: '8'
 
+govuk_jenkins::jobs::athena_fastly_logs_check::s3_results_bucket: 'govuk-integration-fastly-logs-monitoring'
 govuk_jenkins::jobs::content_data_api::rake_etl_master_process_cron_schedule: '0 13 * * *'
 
 govuk_jenkins::jobs::content_publisher_whitehall_import::enable_slack_notifications: true

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -240,6 +240,8 @@ govuk_jenkins::config::theme_environment_name: 'AWS Production'
 
 govuk_jenkins::job_builder::environment: 'production'
 
+govuk_jenkins::jobs::athena_fastly_logs_check::s3_results_bucket: 'govuk-production-fastly-logs-monitoring'
+govuk_jenkins::jobs::athena_fastly_logs_check::databases: ['govuk_www', 'govuk_assets', 'bouncer']
 govuk_jenkins::jobs::content_data_api::rake_etl_master_process_cron_schedule: '0 7 * * *'
 
 govuk_jenkins::jobs::deploy_emergency_banner::clear_cdn_cache: true

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -202,6 +202,7 @@ govuk_crawler::targets:
 
 govuk_jenkins::job_builder::environment: 'staging'
 
+govuk_jenkins::jobs::athena_fastly_logs_check::s3_results_bucket: 'govuk-staging-fastly-logs-monitoring'
 govuk_jenkins::jobs::content_data_api::rake_etl_master_process_cron_schedule: '0 11 * * *'
 
 govuk_jenkins::jobs::network_config_deploy::environments:

--- a/modules/govuk_jenkins/manifests/jobs/athena_fastly_logs_check.pp
+++ b/modules/govuk_jenkins/manifests/jobs/athena_fastly_logs_check.pp
@@ -1,0 +1,51 @@
+# == Class: govuk_jenkins::jobs::athena_fastly_logs_check
+#
+# Create a file on disk that can be parsed by jenkins-job-builder
+#
+# === Parameters
+#
+# [*aws_access_key_id*]
+#   Access key id for user who can read from Athena and write to the bucket
+#
+# [*aws_secret_access_key*]
+#   Secret access key for the above user
+#
+# [*aws_region*]
+#   The region athena is running in
+#
+# [*databases*]
+#   An array of fastly logs databases to check for results
+#
+# [*s3_results_bucket*]
+#   An S3 bucket where the query results can be written too
+#
+class govuk_jenkins::jobs::athena_fastly_logs_check (
+  $aws_access_key_id = undef,
+  $aws_secret_access_key = undef,
+  $aws_region = 'eu-west-1',
+  $databases = ['govuk_www', 'govuk_assets'],
+  $s3_results_bucket = undef,
+) {
+  if $::aws_migration and ($::aws_environment != 'integration') {
+    $hosting_env_domain = "blue.${::aws_environment}.govuk.digital"
+  }
+  else {
+    $hosting_env_domain = hiera('app_domain')
+  }
+
+  $jenkins_url = "https://deploy.${hosting_env_domain}/job/athena-fastly-logs-check/"
+  $jenkins_service_description = "Athena has recent results for fasty_logs \${DATABASE}"
+
+  file {
+    '/etc/jenkins_jobs/jobs/athena_fastly_logs_check.yaml':
+      ensure  => present,
+      content => template('govuk_jenkins/jobs/athena_fastly_logs_check.yaml.erb'),
+      notify  => Exec['jenkins_jobs_update'];
+  }
+
+  govuk_jenkins::jobs::athena_fastly_logs_check::icinga_database_check {
+    $databases:
+      jenkins_url         => $jenkins_url,
+      service_description => $jenkins_service_description,
+  }
+}

--- a/modules/govuk_jenkins/manifests/jobs/athena_fastly_logs_check/icinga_database_check.pp
+++ b/modules/govuk_jenkins/manifests/jobs/athena_fastly_logs_check/icinga_database_check.pp
@@ -1,0 +1,36 @@
+# == Define: govuk_jenkins::jobs::athena_fastly_logs_check::icinga_database_check
+#
+# Definition used to iterate through an array of database names and set-up
+# Icinga passive checks for each one of these.
+#
+# This should only have to exist as a seperate defined resource until the
+# eventual day that we upgrade Puppet to allow the future syntax where we
+# can iterate through the array.
+#
+# === Parameters
+#
+# [*jenkins_url*]
+#
+# A URL to the Jenkins job which is linked to by this alert. This URL will
+# be given a query string to filter the jobs listed to only those for this
+# particular database.
+#
+# [*service_description*]
+#
+# The description that is shown in Icinga for this check. It is expected to
+# have a variable interpolated of $DATABASE, this is replaced for the database
+# name that is under check.
+define govuk_jenkins::jobs::athena_fastly_logs_check::icinga_database_check (
+  $jenkins_url = undef,
+  $service_description = undef,
+) {
+  @@icinga::passive_check {
+    "athena_fastly_logs_check_${name}_${::hostname}":
+      service_description     => regsubst($service_description, '\$\{DATABASE\}', $name),
+      host_name               => $::fqdn,
+      freshness_threshold     => 86400, # 24 hours
+      freshness_alert_level   => 'warning',
+      freshness_alert_message => 'Jenkins job has stopped running or is unstable',
+      action_url              => "${jenkins_url}?search=${name}",
+  }
+}

--- a/modules/govuk_jenkins/templates/jobs/athena_fastly_logs_check.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/athena_fastly_logs_check.yaml.erb
@@ -1,0 +1,100 @@
+---
+- job:
+    name: athena-fastly-logs-check
+    display-name: Athena fastly_logs check
+    project-type: freestyle
+    description: 'Job to verify that Fastly CDN data is still queryable via Athena'
+    logrotate:
+        numToKeep: 100
+    triggers:
+        - parameterized-timer:
+            cron: |
+              # Jobs run at 11am, 3pm and 7pm these are timed to not collide
+              # with datasync on integration or staging. Note the parameterized
+              # scheduler plugin doesn't support timezones so these will run
+              # an hour earlier in BST
+              <%- @databases.each.with_index do |db, index| -%>
+              <%= index * 5 %> 11,15,19 * * * % DATABASE=<%= db %>
+              <%- end -%>
+    properties:
+        - build-discarder:
+            days-to-keep: 30
+            artifact-num-to-keep: 5
+    builders:
+        - shell: |
+            #!/usr/bin/env bash
+
+            # blow up on any errors, even going into pipes
+            set -e -o pipefail
+
+            region=<%= @aws_region %>
+            output_location="s3://<%= @s3_results_bucket %>/${DATABASE}/"
+            from_time=$(date -d '4 hours ago' '+%Y-%m-%d %H:%M')
+            query="SELECT COUNT(*) AS count FROM fastly_logs.${DATABASE} WHERE year=$(date +'%Y') AND month=$(date +'%m') AND date=$(date +'%d') AND request_received > TIMESTAMP '$from_time';"
+
+            echo "Querying for any DB records for the last 4 hours on $dn_name"
+            echo $query
+
+            # send query to athena, and receive JSON with an id within it to identify the query
+            query_execution_id=$(aws --region="$region" athena start-query-execution --query-string="$query" --result-configuration "OutputLocation=$output_location" | jq -r '.QueryExecutionId')
+
+            # continuously loop until Athena returns that the query is no longer queued or running
+            while true
+            do
+              execution=$(aws --region="$region" athena get-query-execution --query-execution-id "$query_execution_id")
+              status=$(echo "$execution" | jq -r '.QueryExecution.Status.State')
+              if [[ "$status" != "QUEUED" ]] && [[ "$status" != "RUNNING" ]]; then
+                break
+              fi
+              echo "Query is ${status}..."
+              sleep 1
+            done
+
+            echo "Query finished with status $status"
+
+            if [[ "$status" != "SUCCEEDED" ]]; then
+              # show the query and error message
+              echo $execution | jq -r '.QueryExecution.Query'
+              echo $execution | jq -r '.QueryExecution.Status.StateChangeReason'
+              exit 1
+            fi
+
+            # Now query is complete and successful retrieve the results
+            count=$(aws --region="$region" athena get-query-results --query-execution-id "$query_execution_id" | jq -r '.ResultSet.Rows[1].Data[0].VarCharValue')
+
+            if [[ "$count" -eq 0 ]]; then
+              echo "Returned 0 results - something is probably broken"
+              exit 1
+            else
+              echo "Returned $count results"
+            fi
+    publishers:
+        - trigger-parameterized-builds:
+            - project: Success_Passive_Check
+              condition: 'SUCCESS'
+              predefined-parameters: |
+                NSCA_CHECK_DESCRIPTION=<%= @jenkins_service_description %>
+                NSCA_OUTPUT=<%= @jenkins_service_description %> success
+            - project: Failure_Passive_Check
+              condition: 'FAILED'
+              predefined-parameters: |
+                NSCA_CHECK_DESCRIPTION=<%= @jenkins_service_description %>
+                NSCA_OUTPUT=<%= @jenkins_service_description %> failed
+    parameters:
+        - choice:
+            name: DATABASE
+            description: Which database to query
+            choices: <%= @databases %>
+    wrappers:
+        - ansicolor:
+            colormap: xterm
+        - inject-passwords:
+            global: false
+            mask-password-params: true
+            job-passwords:
+              - name: AWS_ACCESS_KEY_ID
+                password:
+                  '<%= @aws_access_key_id %>'
+              - name: AWS_SECRET_ACCESS_KEY
+                password:
+                  '<%= @aws_secret_access_key %>'


### PR DESCRIPTION
Trello: https://trello.com/c/93jgKiUX/1329-set-up-a-smoke-test-that-athena-is-still-operating-on-new-data

This is a scheduled task that is due to run in Jenkins 3 times a day to
verify that Athena has fresh data. This check is being added to monitor
that we are a) still receiving data, b) successfully indexing data and
c) said data is queryable. It is being added as a result of a situation
that occurred before Christmas where we discovered that Athena had not
been queryable for 6 weeks due to a JSON error.

This job intends to monitor the govuk_www and govuk_assets databases in
integration, staging and production. It also will monitor the bouncer
database in production only, as we do not have the same bouncer set-up
running in integration and staging.

In the integration and staging environments we have a regular flow of
traffic due to the gor traffic replay that runs from production. This
allows us to be confident that there will be fresh data in these
environments. The gor replay does however get paused during the nightly
data sync so there are periods from 10pm to 4am where there may be 0
traffic from these environments. The job timings are therefore set-up
to be respectful of this and to run 3 times a day at times close to
business hours. I also chose to do the exact same thing
in all 3 environments rather than configuring production different as I
value parity between environments and like to minimise the risk of
problems caused by configuration changes. These checks do run on the
predicate that it would be unheard of for the GOV.UK CDN to go 4 hours
without a request.

I chose to try make a single jenkins job serve for all 3 checks. I don't
think this is a particularly common approach for a GOV.UK Jenkins check
but it feels less messy that 2 or 3 near identical jobs (as is the case
with email alerts). This has meant a few niche techniques such as an
environment variable in the icinga check, linking to a Jenkins job with
a filter parameter and using the parameterized scheduler plugin.

In order to set-up Icinga passive checks for each database I've had to
create an additional defined resource so that we have means to iterate
through the array of databases [1]. Our linter also forced me to do
this in a new file. Hopefully in the not-too-distant future we can
replace this need for an additional defined resource with a loop in the
govuk_jenkins::jobs::athena_fastly_logs_check class.

I've this out on integration and it was successfully able to query both
databases and report health to icinga.

[1]: https://stackoverflow.com/a/13008766