### PR TITLE
Add Specialist Publisher `aws_s3_bucket_name` hieradata to Carrenza

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -69,6 +69,7 @@ govuk::apps::publisher::email_group_dev: 'govuk-dev@digital.cabinet-office.gov.u
 govuk::apps::publisher::email_group_business: 'publisher-alerts-business@digital.cabinet-office.gov.uk'
 govuk::apps::publisher::email_group_citizen: 'publisher-alerts-citizen@digital.cabinet-office.gov.uk'
 govuk::apps::specialist_publisher::aws_region: 'eu-west-1'
+govuk::apps::specialist_publisher::aws_s3_bucket_name: 'govuk-production-specialist-publisher-csvs'
 govuk::apps::travel_advice_publisher::enable_email_alerts: true
 govuk::apps::whitehall::cpu_warning: 400
 govuk::apps::whitehall::cpu_critical: 600

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -27,6 +27,7 @@ govuk::apps::publisher::fact_check_address_format: 'factcheck+staging-{id}@alpha
 govuk::apps::short_url_manager::instance_name: 'staging'
 govuk::apps::signon::instance_name: 'staging'
 govuk::apps::specialist_publisher::aws_region: 'eu-west-1'
+govuk::apps::specialist_publisher::aws_s3_bucket_name: 'govuk-staging-specialist-publisher-csvs'
 govuk::apps::static::ga_universal_id: 'UA-26179049-20'
 govuk::apps::travel_advice_publisher::enable_email_alerts: true
 govuk::apps::whitehall::cpu_warning: 400


### PR DESCRIPTION
- Specialist Publisher runs in Carrenza still.
- We tested the S3 bucket functionality in integration, which is AWS.
- It [broke](https://sentry.io/organizations/govuk/issues/1521921065/?environment=staging&referrer=alert_email) when deployed to Staging as we missed some hieradata.