### PR TITLE
Don't tell the Release app about node app deploys

### DIFF
--- a/modules/govuk_jenkins/templates/node_app_deploy.xml.erb
+++ b/modules/govuk_jenkins/templates/node_app_deploy.xml.erb
@@ -39,7 +39,8 @@
               <properties>TARGET_APPLICATION=<%= app %>
 DEPLOY_TASK=deploy:without_migrations
 TARGET_MACHINES=${TARGET_MACHINES}
-TAG=deployed-to-<%= @environment -%></properties>
+TAG=deployed-to-<%= @environment -%>
+NOTIFY_RELEASE_APP=false</properties>
             </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
           </configs>
           <projects>Deploy_App</projects>


### PR DESCRIPTION
When TAG isn't a TAG, but a branch the Release app doesn't really know
how to make sense of this.

Therefore, just avoid telling the Release app about this. This job is
used to fudge new machines in to the state of existing ones, so it
shouldn't be necessary to tell the Release app anything, as this job
isn't about changing what's released to a given environment.