### PR TITLE
Add envvar for publisher force publish alerts

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -262,6 +262,7 @@ govuk::apps::publisher::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::publisher::email_group_dev: 'govuk-dev@digital.cabinet-office.gov.uk'
 govuk::apps::publisher::email_group_business: 'govuk-dev@digital.cabinet-office.gov.uk'
 govuk::apps::publisher::email_group_citizen: 'govuk-dev@digital.cabinet-office.gov.uk'
+govuk::apps::publisher::email_group_force_publish_alerts: 'test-mainstream-force-publishing-alerts@digital.cabinet-office.gov.uk'
 
 
 govuk::apps::short_url_manager::redis_host: "%{hiera('sidekiq_host')}"

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -68,6 +68,7 @@ govuk::apps::publisher::fact_check_address_format: 'factcheck+production-{id}@al
 govuk::apps::publisher::email_group_dev: 'govuk-dev@digital.cabinet-office.gov.uk'
 govuk::apps::publisher::email_group_business: 'publisher-alerts-business@digital.cabinet-office.gov.uk'
 govuk::apps::publisher::email_group_citizen: 'publisher-alerts-citizen@digital.cabinet-office.gov.uk'
+govuk::apps::publisher::email_group_force_publish_alerts: 'mainstream-force-publishing-alerts@digital.cabinet-office.gov.uk'
 govuk::apps::specialist_publisher::aws_region: 'eu-west-1'
 govuk::apps::specialist_publisher::aws_s3_bucket_name: 'govuk-production-specialist-publisher-csvs'
 govuk::apps::travel_advice_publisher::enable_email_alerts: true

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -527,6 +527,7 @@ govuk::apps::publisher::alert_hostname: 'alert'
 govuk::apps::publisher::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
 govuk::apps::publisher::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::publisher::redis_port: "%{hiera('sidekiq_port')}"
+govuk::apps::publisher::email_group_force_publish_alerts: 'test-mainstream-force-publishing-alerts@digital.cabinet-office.gov.uk'
 
 govuk::apps::short_url_manager::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::short_url_manager::redis_port: "%{hiera('sidekiq_port')}"

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -167,6 +167,7 @@ govuk::apps::local_links_manager::run_links_ga_export: true
 
 govuk::apps::publisher::run_fact_check_fetcher: false
 govuk::apps::publisher::fact_check_address_format: 'factcheck+production-{id}@alphagov.co.uk'
+govuk::apps::publisher::email_group_force_publish_alerts: 'mainstream-force-publishing-alerts@digital.cabinet-office.gov.uk'
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-production'
 govuk::apps::router::sentry_environment: 'production'
 govuk::apps::search_api::elasticsearch_hosts: 'https://vpc-blue-elasticsearch6-domain-2hnib7uydv3tgebhabx74gdelq.eu-west-1.es.amazonaws.com'

--- a/modules/govuk/manifests/apps/publisher.pp
+++ b/modules/govuk/manifests/apps/publisher.pp
@@ -72,6 +72,9 @@
 # [*email_group_citizen*]
 #   The email address to use citizen alerts
 #
+# [*email_group_force_publish_alerts*]
+#   The email address to use for skip review alerts
+#
 # [*link_checker_api_secret_token*]
 #   The Link Checker API secret token.
 #   Default: undef
@@ -102,6 +105,7 @@ class govuk::apps::publisher(
     $email_group_dev = undef,
     $email_group_business = undef,
     $email_group_citizen = undef,
+    $email_group_force_publish_alerts = undef,
     $link_checker_api_secret_token = undef,
     $link_checker_api_bearer_token = undef,
   ) {
@@ -203,6 +207,9 @@ class govuk::apps::publisher(
     "${title}-EMAIL_GROUP_CITIZEN":
       varname => 'EMAIL_GROUP_CITIZEN',
       value   => $email_group_citizen;
+    "${title}-EMAIL_GROUP_FORCE_PUBLISH_ALERTS":
+      varname => 'EMAIL_GROUP_FORCE_PUBLISH_ALERTS',
+      value   => $email_group_force_publish_alerts;
     "${title}-LINK_CHECKER_API_SECRET_TOKEN":
         varname => 'LINK_CHECKER_API_SECRET_TOKEN',
         value   => $link_checker_api_secret_token;


### PR DESCRIPTION
Adds the envvar for the email address used in the force publishing alerts on publisher.

https://trello.com/c/jUuJwRLW