### PR TITLE
govuk_cdnlogs: Force the removal of `/var/log/cdn` directory

### DIFF
--- a/modules/govuk_cdnlogs/manifests/init.pp
+++ b/modules/govuk_cdnlogs/manifests/init.pp
@@ -130,6 +130,7 @@ class govuk_cdnlogs (
 
   file { $log_dir:
     ensure => absent,
+    force  => true,
     owner  => 'root',
     group  => 'deploy',
     mode   => '0775',


### PR DESCRIPTION
- Puppet won't allow you to delete a directory like you usually delete
  files, if it has things in it.