### PR TITLE
Add Remaining Publishing Apps To AWS Staging

### DIFF
--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -20,17 +20,29 @@ node_class: &node_class
       - asset-manager
       - cache-clearing-service
       - canary-backend
+      - contacts-admin
       - content-data-admin
       - content-data-api
-      - transition
+      - content-tagger
+      - collections-publisher
+      - hmrc-manuals-api
       - imminence
+      - manuals-publisher
+      - maslow
+      - publisher
       - link-checker-api
       - local-links-manager
       - release
+      - search-admin
+      - service-manual-publisher
+      - short-url-manager
       - sidekiq-monitoring
+      - specialist-publisher
       - support
       - support-api
       - support_api_csv_env_sync
+      - transition
+      - travel-advice-publisher
   bouncer:
     apps:
       - bouncer


### PR DESCRIPTION
This is part of the work to migrate the remaining publishing apps to AWS. We are adding the
following apps to AWS Staging so that we can begin testing them:
- collections-publisher
- contacts-admin
- content-tagger'
- hmrc-manuals-api
- maslow
- manuals-publisher
- publisher
- search-admin
- service-manual-publisher
- short-url-manager
- specialist-publisher
- travel-advice-publisher