### PR TITLE
Add Access to Shared Document DB Credentials to Remaining Publishing Apps

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -286,7 +286,16 @@ task :check_consistency_between_aws_and_carrenza do
     govuk::apps::local_links_manager::unicorn_worker_processes
     govuk::apps::mapit::enabled
     govuk::apps::mapit::gdal_version
+    govuk::apps::manuals_publisher::mongodb_nodes
+    govuk::apps::manuals_publisher::mongodb_username
+    govuk::apps::manuals_publisher::mongodb_password
+    govuk::apps::maslow::mongodb_nodes
+    govuk::apps::maslow::mongodb_username
+    govuk::apps::maslow::mongodb_password
     govuk::apps::publisher::alert_hostname
+    govuk::apps::publisher::mongodb_nodes
+    govuk::apps::publisher::mongodb_username
+    govuk::apps::publisher::mongodb_password
     govuk::apps::publishing_api::content_store
     govuk::apps::publishing_api::db::allow_auth_from_lb
     govuk::apps::publishing_api::db::backend_ip_range
@@ -343,6 +352,9 @@ task :check_consistency_between_aws_and_carrenza do
     govuk::apps::service_manual_publisher::db::lb_ip_range
     govuk::apps::service_manual_publisher::db::rds
     govuk::apps::service_manual_publisher::db_hostname
+    govuk::apps::short_url_manager::mongodb_nodes
+    govuk::apps::short_url_manager::mongodb_username
+    govuk::apps::short_url_manager::mongodb_password
     govuk::apps::specialist_publisher::aws_s3_bucket_name
     govuk::apps::support::aws_s3_bucket_name
     govuk::apps::support::redis_host
@@ -366,6 +378,9 @@ task :check_consistency_between_aws_and_carrenza do
     govuk::apps::transition::postgresql_db::rds
     govuk::apps::transition::redis_host
     govuk::apps::transition::redis_port
+    govuk::apps::travel_advice_publisher::mongodb_nodes
+    govuk::apps::travel_advice_publisher::mongodb_username
+    govuk::apps::travel_advice_publisher::mongodb_password
     govuk::deploy::setup::gemstash_server
     govuk::deploy::sync::auth_token
     govuk::deploy::sync::jenkins_domain

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -156,8 +156,17 @@ govuk::apps::govuk_crawler_worker::disable_during_data_sync: true
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::licencefinder::elasticsearch_uri: 'https://vpc-blue-elasticsearch6-domain-uibh77cu2kiudtl76uhseobfzq.eu-west-1.es.amazonaws.com'
 govuk::apps::link_checker_api::govuk_basic_auth_credentials: "%{hiera('http_username')}:%{hiera('http_password')}"
+govuk::apps::manuals_publisher::mongodb_nodes: "%{hiera('govuk::apps::asset_manager::mongodb_nodes')}"
+govuk::apps::manuals_publisher::mongodb_username: "%{hiera('govuk::apps::asset_manager::mongodb_username')}"
+govuk::apps::manuals_publisher::mongodb_password: "%{hiera('govuk::apps::asset_manager::mongodb_password')}"
+govuk::apps::maslow::mongodb_nodes: "%{hiera('govuk::apps::asset_manager::mongodb_nodes')}"
+govuk::apps::maslow::mongodb_username: "%{hiera('govuk::apps::asset_manager::mongodb_username')}"
+govuk::apps::maslow::mongodb_password: "%{hiera('govuk::apps::asset_manager::mongodb_password')}"
 govuk::apps::publisher::run_fact_check_fetcher: false
 govuk::apps::publisher::fact_check_address_format: 'factcheck+staging-{id}@alphagov.co.uk'
+govuk::apps::publisher::mongodb_nodes: "%{hiera('govuk::apps::asset_manager::mongodb_nodes')}"
+govuk::apps::publisher::mongodb_username: "%{hiera('govuk::apps::asset_manager::mongodb_username')}"
+govuk::apps::publisher::mongodb_password: "%{hiera('govuk::apps::asset_manager::mongodb_password')}"
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-staging'
 govuk::apps::router::sentry_environment: 'staging'
 govuk::apps::search_api::elasticsearch_hosts: 'https://vpc-blue-elasticsearch6-domain-uibh77cu2kiudtl76uhseobfzq.eu-west-1.es.amazonaws.com'
@@ -168,6 +177,9 @@ govuk::apps::search_api::tensorflow_models_directory: '/data/vhost/tensorflow-mo
 govuk::apps::search_api::tensorflow_serving_ip: '0.0.0.0'
 govuk::apps::search_api::tensorflow_sagemaker_endpoint: 'govuk-staging-search-ltr-endpoint'
 govuk::apps::short_url_manager::instance_name: 'staging'
+govuk::apps::short_url_manager::mongodb_nodes: "%{hiera('govuk::apps::asset_manager::mongodb_nodes')}"
+govuk::apps::short_url_manager::mongodb_username: "%{hiera('govuk::apps::asset_manager::mongodb_username')}"
+govuk::apps::short_url_manager::mongodb_password: "%{hiera('govuk::apps::asset_manager::mongodb_password')}"
 govuk::apps::signon::instance_name: 'staging'
 govuk::apps::specialist_publisher::aws_region: 'eu-west-1'
 govuk::apps::specialist_publisher::aws_s3_bucket_name: 'govuk-staging-specialist-publisher-csvs'
@@ -176,6 +188,9 @@ govuk::apps::support::aws_s3_bucket_name: 'govuk-staging-support-api-csvs'
 govuk::apps::support_api::pp_data_url: 'https://www.staging.performance.service.gov.uk'
 govuk::apps::support_api::aws_s3_bucket_name: 'govuk-staging-support-api-csvs'
 govuk::apps::travel_advice_publisher::enable_email_alerts: true
+govuk::apps::travel_advice_publisher::mongodb_nodes: "%{hiera('govuk::apps::asset_manager::mongodb_nodes')}"
+govuk::apps::travel_advice_publisher::mongodb_username: "%{hiera('govuk::apps::asset_manager::mongodb_username')}"
+govuk::apps::travel_advice_publisher::mongodb_password: "%{hiera('govuk::apps::asset_manager::mongodb_password')}"
 
 govuk_search::monitoring::es_port: '80'
 govuk_search::monitoring::es_host: 'vpc-blue-elasticsearch6-domain-uibh77cu2kiudtl76uhseobfzq.eu-west-1.es.amazonaws.com'

--- a/modules/govuk/manifests/apps/manuals_publisher.pp
+++ b/modules/govuk/manifests/apps/manuals_publisher.pp
@@ -30,6 +30,14 @@
 #   The mongo database to be used. Overriden in development
 #   to be 'manuals_publisher_development'.
 #
+# [*mongodb_username*]
+#   The username to use when logging to the MongoDB database,
+#   only needed if the app uses documentdb rather than mongodb
+#
+# [*mongodb_password*]
+#   The password to use when logging to the MongoDB database
+#   only needed if the app uses documentdb rather than mongodb
+#
 # [*oauth_id*]
 #   Sets the OAuth ID for using GDS-SSO
 #   Default: undef
@@ -69,6 +77,8 @@ class govuk::apps::manuals_publisher(
   $sentry_dsn = undef,
   $mongodb_nodes,
   $mongodb_name,
+  $mongodb_username = '',
+  $mongodb_password = '',
   $oauth_id = undef,
   $oauth_secret = undef,
   $publishing_api_bearer_token = undef,
@@ -100,6 +110,8 @@ class govuk::apps::manuals_publisher(
   govuk::app::envvar::mongodb_uri { $app_name:
     hosts    => $mongodb_nodes,
     database => $mongodb_name,
+    username => $mongodb_username,
+    password => $mongodb_password,
   }
 
   govuk::app::envvar::redis { $app_name:

--- a/modules/govuk/manifests/apps/maslow.pp
+++ b/modules/govuk/manifests/apps/maslow.pp
@@ -12,6 +12,14 @@
 #   The mongo database to be used. Overriden in development
 #   to be 'content_store_development'.
 #
+# [*mongodb_username*]
+#   The username to use when logging to the MongoDB database,
+#   only needed if the app uses documentdb rather than mongodb
+#
+# [*mongodb_password*]
+#   The password to use when logging to the MongoDB database
+#   only needed if the app uses documentdb rather than mongodb
+#
 # [*publishing_api_bearer_token*]
 #   The bearer token to use when communicating with Publishing API.
 #   Default: undef
@@ -33,6 +41,8 @@ class govuk::apps::maslow(
   $port = '3053',
   $mongodb_nodes,
   $mongodb_name,
+  $mongodb_username = '',
+  $mongodb_password = '',
   $publishing_api_bearer_token = undef,
   $secret_key_base = undef,
   $sentry_dsn = undef,
@@ -57,6 +67,8 @@ class govuk::apps::maslow(
   govuk::app::envvar::mongodb_uri { $app_name:
     hosts    => $mongodb_nodes,
     database => $mongodb_name,
+    username => $mongodb_username,
+    password => $mongodb_password,
   }
 
   govuk::app::envvar {

--- a/modules/govuk/manifests/apps/publisher.pp
+++ b/modules/govuk/manifests/apps/publisher.pp
@@ -26,6 +26,14 @@
 # [*mongodb_name*]
 #   The Mongo database to be used.
 #
+# [*mongodb_username*]
+#   The username to use when logging to the MongoDB database,
+#   only needed if the app uses documentdb rather than mongodb
+#
+# [*mongodb_password*]
+#   The password to use when logging to the MongoDB database
+#   only needed if the app uses documentdb rather than mongodb
+#
 # [*mongodb_nodes*]
 #   Array of hostnames for the mongo cluster to use.
 #
@@ -91,6 +99,8 @@ class govuk::apps::publisher(
     $secret_key_base = undef,
     $mongodb_name = undef,
     $mongodb_nodes = undef,
+    $mongodb_username = '',
+    $mongodb_password = '',
     $redis_host = undef,
     $redis_port = undef,
     $jwt_auth_secret = undef,
@@ -150,6 +160,8 @@ class govuk::apps::publisher(
     govuk::app::envvar::mongodb_uri { $app_name:
       hosts    => $mongodb_nodes,
       database => $mongodb_name,
+      username => $mongodb_username,
+      password => $mongodb_password,
     }
   }
 

--- a/modules/govuk/manifests/apps/short_url_manager.pp
+++ b/modules/govuk/manifests/apps/short_url_manager.pp
@@ -18,6 +18,14 @@
 #   Array of hostnames for the mongo cluster to use.
 #   Default: undef
 #
+# [*mongodb_username*]
+#   The username to use when logging to the MongoDB database,
+#   only needed if the app uses documentdb rather than mongodb
+#
+# [*mongodb_password*]
+#   The password to use when logging to the MongoDB database
+#   only needed if the app uses documentdb rather than mongodb
+#
 # [*oauth_id*]
 #   Sets the OAuth ID for using GDS-SSO
 #   Default: undef
@@ -52,6 +60,8 @@ class govuk::apps::short_url_manager(
   $instance_name = undef,
   $mongodb_name = undef,
   $mongodb_nodes = undef,
+  $mongodb_username = '',
+  $mongodb_password = '',
   $oauth_id = undef,
   $oauth_secret = undef,
   $publishing_api_bearer_token = undef,
@@ -91,6 +101,8 @@ class govuk::apps::short_url_manager(
   govuk::app::envvar::mongodb_uri { $app_name:
     hosts    => $mongodb_nodes,
     database => $mongodb_name,
+    username => $mongodb_username,
+    password => $mongodb_password,
   }
 
   govuk::app::envvar::redis { $app_name:

--- a/modules/govuk/manifests/apps/travel_advice_publisher.pp
+++ b/modules/govuk/manifests/apps/travel_advice_publisher.pp
@@ -25,6 +25,14 @@
 # [*mongodb_nodes*]
 #   Array of hostnames for the mongo cluster to use.
 #
+# [*mongodb_username*]
+#   The username to use when logging to the MongoDB database,
+#   only needed if the app uses documentdb rather than mongodb
+#
+# [*mongodb_password*]
+#   The password to use when logging to the MongoDB database
+#   only needed if the app uses documentdb rather than mongodb
+#
 # [*oauth_id*]
 #   Sets the OAuth ID
 #
@@ -71,6 +79,8 @@ class govuk::apps::travel_advice_publisher(
   $sentry_dsn = undef,
   $mongodb_name = undef,
   $mongodb_nodes = undef,
+  $mongodb_username = '',
+  $mongodb_password = '',
   $oauth_id = undef,
   $oauth_secret = undef,
   $port = '3035',
@@ -105,6 +115,8 @@ class govuk::apps::travel_advice_publisher(
     govuk::app::envvar::mongodb_uri { $app_name:
       hosts    => $mongodb_nodes,
       database => $mongodb_name,
+      username => $mongodb_username,
+      password => $mongodb_password,
     }
   }
 


### PR DESCRIPTION
This forms part of the work to migrate the remaining publishing apps to AWS.