### PR TITLE
Add icinga notes link for Athena Fastly logs check

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/athena_fastly_logs_check/icinga_database_check.pp
+++ b/modules/govuk_jenkins/manifests/jobs/athena_fastly_logs_check/icinga_database_check.pp
@@ -32,5 +32,6 @@ define govuk_jenkins::jobs::athena_fastly_logs_check::icinga_database_check (
       freshness_alert_level   => 'warning',
       freshness_alert_message => 'Jenkins job has stopped running or is unstable',
       action_url              => "${jenkins_url}?search=${name}",
+      notes_url               => monitoring_docs_url(athena-fastly-logs-check),
   }
 }


### PR DESCRIPTION
Trello: https://trello.com/c/93jgKiUX/1329-set-up-a-smoke-test-that-athena-is-still-operating-on-new-data

This is to help 2nd line were these alerts to be raised.