### PR TITLE
Rename Whitehall database restore job for consistency.

### DIFF
--- a/hieradata_aws/class/production/db_admin.yaml
+++ b/hieradata_aws/class/production/db_admin.yaml
@@ -171,7 +171,7 @@ govuk_env_sync::tasks:
     <<: *pull_licensify
     ensure: "disabled"
     database: "licensify-audit"
-  "pull_mysql_whitehall_production_daily":
+  "pull_whitehall_production_daily":
     ensure: "disabled"
     hour: "0"
     minute: "00"


### PR DESCRIPTION
The govuk_env_sync restore job for the Whitehall MySQL database was the
only one with _mysql in its name. None of the others have the name of
the DBMS in the job name. Since this is something which we may need to
use under pressure in a disaster recovery scenario, let's make it
consistent with the other job names.