### PR TITLE
Move Whitehall Jenkins jobs to AWS.

### DIFF
--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -28,7 +28,6 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::record_taxonomy_metrics
   - govuk_jenkins::jobs::record_superfluous_taggings_metrics
   - govuk_jenkins::jobs::run_rake_task
-  - govuk_jenkins::jobs::run_whitehall_data_migrations
   - govuk_jenkins::jobs::send_bulk_email
   - govuk_jenkins::jobs::signon_cron_rake_tasks
   - govuk_jenkins::jobs::smokey
@@ -37,8 +36,6 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::update_cdn_dictionaries
   - govuk_jenkins::jobs::user_monitor
   - govuk_jenkins::jobs::validate_published_dns
-  - govuk_jenkins::jobs::whitehall_publisher_notifications
-  - govuk_jenkins::jobs::whitehall_run_broken_link_checker
 
 govuk_jenkins::jobs::deploy_cdn::enable_slack_notifications: true
 govuk_jenkins::jobs::deploy_puppet::enable_slack_notifications: true

--- a/hieradata/class/staging/jenkins.yaml
+++ b/hieradata/class/staging/jenkins.yaml
@@ -20,15 +20,12 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::record_superfluous_taggings_metrics
   - govuk_jenkins::jobs::record_taxonomy_metrics
   - govuk_jenkins::jobs::run_rake_task
-  - govuk_jenkins::jobs::run_whitehall_data_migrations
   - govuk_jenkins::jobs::send_bulk_email
   - govuk_jenkins::jobs::smokey
   - govuk_jenkins::jobs::smokey_deploy
   - govuk_jenkins::jobs::update_cdn_dictionaries
   - govuk_jenkins::jobs::user_monitor
   - govuk_jenkins::jobs::validate_published_dns
-  - govuk_jenkins::jobs::whitehall_publisher_notifications
-
 
 govuk_jenkins::jobs::deploy_cdn::enable_slack_notifications: true
 govuk_jenkins::jobs::deploy_puppet::enable_slack_notifications: true

--- a/hieradata_aws/class/production/jenkins.yaml
+++ b/hieradata_aws/class/production/jenkins.yaml
@@ -18,6 +18,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::publishing_api_archive_events
   - govuk_jenkins::jobs::remove_emergency_banner
   - govuk_jenkins::jobs::run_rake_task
+  - govuk_jenkins::jobs::run_whitehall_data_migrations
   - govuk_jenkins::jobs::search_api_fetch_analytics_data
   - govuk_jenkins::jobs::search_api_index_checks
   - govuk_jenkins::jobs::search_api_reindex_with_new_schema
@@ -29,7 +30,8 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::transition_import_dns
   - govuk_jenkins::jobs::transition_import_hits
   - govuk_jenkins::jobs::transition_load_site_config
-
+  - govuk_jenkins::jobs::whitehall_publisher_notifications
+  - govuk_jenkins::jobs::whitehall_run_broken_link_checker
 
 govuk_jenkins::jobs::deploy_cdn::enable_slack_notifications: false
 govuk_jenkins::jobs::deploy_puppet::enable_slack_notifications: false

--- a/hieradata_aws/class/staging/jenkins.yaml
+++ b/hieradata_aws/class/staging/jenkins.yaml
@@ -19,6 +19,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::publish_special_routes
   - govuk_jenkins::jobs::remove_emergency_banner
   - govuk_jenkins::jobs::run_rake_task
+  - govuk_jenkins::jobs::run_whitehall_data_migrations
   - govuk_jenkins::jobs::search_api_fetch_analytics_data
   - govuk_jenkins::jobs::search_api_index_checks
   - govuk_jenkins::jobs::search_api_reindex_with_new_schema
@@ -27,6 +28,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::search_generate_sitemaps
   - govuk_jenkins::jobs::smokey
   - govuk_jenkins::jobs::smokey_deploy
+  - govuk_jenkins::jobs::whitehall_publisher_notifications
 
 govuk_jenkins::jobs::deploy_cdn::enable_slack_notifications: false
 govuk_jenkins::jobs::deploy_puppet::enable_slack_notifications: false

--- a/modules/govuk_jenkins/manifests/jobs/delete_redis_uniquejobs.pp
+++ b/modules/govuk_jenkins/manifests/jobs/delete_redis_uniquejobs.pp
@@ -1,4 +1,4 @@
-# == Class: govuk_jenkins::jobs::whitehall_publisher_notifications
+# == Class: govuk_jenkins::jobs::delete_redis_uniquejobs
 #
 # Create a jenkins job to periodically remove redis uniquejobs key
 #


### PR DESCRIPTION
These jobs no longer work in Carrenza/6dg since Whitehall was migrated to AWS.

Also fix a copypasto in an unrelated docstring which wrongly referred to Whitehall (found while searching for references to these Jenkins jobs).