### PR TITLE
Fix removing Release from Carrenza

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -306,10 +306,6 @@ task :check_consistency_between_aws_and_carrenza do
     govuk::apps::publishing_api::redis_host
     govuk::apps::publishing_api::redis_port
     govuk::apps::publishing_api::unicorn_worker_processes
-    govuk::apps::release::db_hostname
-    govuk::apps::release::db_password
-    govuk::apps::release::db_username
-    govuk::apps::release::github_username
     govuk::apps::router::sentry_environment
     govuk::apps::search_api::nagios_memory_warning
     govuk::apps::search_api::nagios_memory_critical

--- a/Rakefile
+++ b/Rakefile
@@ -31,6 +31,7 @@ task :check_consistency_between_aws_and_carrenza do
     govuk::apps::content_publisher::db::backend_ip_range
     govuk::apps::content_tagger::db_allow_prepared_statements
     govuk::apps::content_tagger::db_port
+    govuk::apps::release::enabled
     govuk::apps::publisher::email_group_business
     govuk::apps::publisher::email_group_citizen
     govuk::apps::publisher::email_group_dev

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -265,6 +265,7 @@ govuk::apps::licencefinder::mongodb_nodes:
   - 'mongo-2.backend'
   - 'mongo-3.backend'
 
+govuk::apps::release::enabled: false
 govuk::apps::release::db_hostname: "master.mysql"
 govuk::apps::release::db_username: "release"
 govuk::apps::release::db_password: "%{hiera('govuk::apps::release::db::mysql_release')}"

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -265,6 +265,11 @@ govuk::apps::licencefinder::mongodb_nodes:
   - 'mongo-2.backend'
   - 'mongo-3.backend'
 
+govuk::apps::release::db_hostname: "master.mysql"
+govuk::apps::release::db_username: "release"
+govuk::apps::release::db_password: "%{hiera('govuk::apps::release::db::mysql_release')}"
+govuk::apps::release::github_username: "govuk-ci"
+
 govuk::apps::search_admin::db_name: 'search_admin_production'
 govuk::apps::search_admin::db_hostname: 'master.mysql'
 govuk::apps::search_admin::db_password: "%{hiera('govuk::apps::search_admin::db::mysql_search_admin')}"

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -26,6 +26,7 @@ node_class: &node_class
       - manuals-publisher
       - maslow
       - publisher
+      - release
       - search-admin
       - service-manual-publisher
       - short-url-manager

--- a/modules/govuk/manifests/apps/release.pp
+++ b/modules/govuk/manifests/apps/release.pp
@@ -40,6 +40,7 @@
 #
 class govuk::apps::release(
   $port = '3036',
+  $enabled = true,
   $sentry_dsn = undef,
   $secret_key_base = undef,
   $db_hostname = undef,
@@ -53,7 +54,13 @@ class govuk::apps::release(
 ) {
   $app_name = 'release'
 
+  $ensure = $enabled ? {
+    true  => 'present',
+    false => 'absent',
+  }
+
   govuk::app { $app_name:
+    ensure             => $ensure,
     app_type           => 'rack',
     port               => $port,
     sentry_dsn         => $sentry_dsn,
@@ -64,7 +71,8 @@ class govuk::apps::release(
   }
 
   Govuk::App::Envvar {
-    app => $app_name,
+    app    => $app_name,
+    ensure => $ensure,
   }
 
   govuk::app::envvar {


### PR DESCRIPTION
With some of https://github.com/alphagov/govuk-puppet/pull/10176 , I skipped ahead a bit. These changes actually have Puppet clean up the machines, after which the govuk-puppet configuration can be cleaned up.