### PR TITLE
Remove Asset Manager data sync job from Carrenza Staging.

### DIFF
--- a/hieradata/node/mongo-1.backend.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/mongo-1.backend.staging.publishing.service.gov.uk.yaml
@@ -44,7 +44,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mongo-normal"
   "push_govuk_assets_production":
-    ensure: "present"
+    ensure: "absent"
     hour: "1"
     minute: "41"
     action: "push"


### PR DESCRIPTION
This job should no longer exist since Asset Manager was migrated to AWS.