### PR TITLE
Remove the 'high disk time' alert.

### DIFF
--- a/hieradata/class/api_mongo.yaml
+++ b/hieradata/class/api_mongo.yaml
@@ -51,8 +51,3 @@ mongodb::server::replicaset_members:
   'api-mongo-4':
     hidden: true
     priority: 0
-
-icinga::client::checks::disk_time_window_minutes: 10
-
-icinga::client::checks::disk_time_warn: 350 # milliseconds
-icinga::client::checks::disk_time_critical: 450 # milliseconds

--- a/hieradata/class/backup.yaml
+++ b/hieradata/class/backup.yaml
@@ -28,9 +28,6 @@ govuk::node::s_backup::directories:
     fq_dn: graphite-1.management.%{hiera('app_domain')}
     priority: '004'
 
-icinga::client::checks::disk_time_warn: 750 # milliseconds
-icinga::client::checks::disk_time_critical: 1000 # milliseconds
-
 lv:
   data:
     pv:

--- a/hieradata/class/graphite.yaml
+++ b/hieradata/class/graphite.yaml
@@ -3,9 +3,6 @@
 govuk_safe_to_reboot::can_reboot: 'careful'
 govuk_safe_to_reboot::reason: 'We lose stats and some alerting when this machine is down'
 
-icinga::client::checks::disk_time_warn: 280 # milliseconds
-icinga::client::checks::disk_time_critical: 400 # milliseconds
-
 lv:
   data:
     pv:

--- a/hieradata/class/mongo.yaml
+++ b/hieradata/class/mongo.yaml
@@ -3,8 +3,6 @@
 govuk_safe_to_reboot::can_reboot: 'overnight'
 govuk_safe_to_reboot::reason: 'Secondaries will reboot overnight if cluster is healthy'
 
-icinga::client::checks::disk_time_window_minutes: 10
-
 lv:
   mongodb:
     pv:

--- a/hieradata_aws/class/backup.yaml
+++ b/hieradata_aws/class/backup.yaml
@@ -36,9 +36,6 @@ govuk::node::s_backup::directories:
     fq_dn: graphite-1.management.%{hiera('app_domain')}
     priority: '004'
 
-icinga::client::checks::disk_time_warn: 750 # milliseconds
-icinga::client::checks::disk_time_critical: 1000 # milliseconds
-
 lv:
   data:
     pv:

--- a/hieradata_aws/class/graphite.yaml
+++ b/hieradata_aws/class/graphite.yaml
@@ -3,9 +3,6 @@
 govuk_safe_to_reboot::can_reboot: 'careful'
 govuk_safe_to_reboot::reason: 'We lose stats and some alerting when this machine is down'
 
-icinga::client::checks::disk_time_warn: 280 # milliseconds
-icinga::client::checks::disk_time_critical: 400 # milliseconds
-
 lv:
   data:
     pv:

--- a/hieradata_aws/class/integration/asset_master.yaml
+++ b/hieradata_aws/class/integration/asset_master.yaml
@@ -1,2 +1,0 @@
-icinga::client::checks::disk_time_warn: 350 # milliseconds
-icinga::client::checks::disk_time_critical: 450 # milliseconds

--- a/hieradata_aws/class/mirrorer.yaml
+++ b/hieradata_aws/class/mirrorer.yaml
@@ -3,9 +3,6 @@ govuk_crawler::mirror_root: '/mnt/crawler_worker'
 
 govuk::apps::govuk_crawler_worker::amqp_host: "%{hiera('govuk_crawler::amqp_host')}"
 
-icinga::client::checks::disk_time_warn: 150 # milliseconds
-icinga::client::checks::disk_time_critical: 250 # milliseconds
-
 lv:
   worker:
     pv: '/dev/nvme1n1'

--- a/hieradata_aws/class/mongo.yaml
+++ b/hieradata_aws/class/mongo.yaml
@@ -2,8 +2,6 @@
 govuk_safe_to_reboot::can_reboot: 'overnight'
 govuk_safe_to_reboot::reason: 'Secondaries will reboot overnight if cluster is healthy'
 
-icinga::client::checks::disk_time_window_minutes: 10
-
 mongodb::server::oplog_size: 14392 # 14 * 1024
 mongodb::server::replicaset_members:
   'mongo-1':

--- a/hieradata_aws/class/mongo_api.yaml
+++ b/hieradata_aws/class/mongo_api.yaml
@@ -2,8 +2,6 @@
 govuk_safe_to_reboot::can_reboot: 'overnight'
 govuk_safe_to_reboot::reason: 'Secondaries will reboot overnight if cluster is healthy'
 
-icinga::client::checks::disk_time_window_minutes: 10
-
 mongodb::server::oplog_size: 14392 # 14 * 1024
 mongodb::server::replicaset_members:
   'mongo-api-1':


### PR DESCRIPTION
This is a [cause-based-alert] and has not proved useful. We have disk time
graphs on dashboards.

In the unlikely event that this leads to a gap in our alerting coverage,
that gap should be filled by adding an alert on the user-facing response
time rather than alerting on an internal detail like disk I/O time.

[cause-based-alert]: https://docs.google.com/document/d/199PqyG3UsyXlwieHaqbGiWVa8eMWi8zzAn0YfcApr8Q/preview#heading=h.6ammb5h32uqq