### PR TITLE
Update Python version to 3.5 in govuk_python module

### DIFF
--- a/modules/govuk_python/manifests/init.pp
+++ b/modules/govuk_python/manifests/init.pp
@@ -9,5 +9,5 @@ class govuk_python {
 
   Class['python::install'] -> Package <| provider == 'pip' and ensure != absent |>
 
-  ensure_packages(['python3', 'python3-dev'])
+  ensure_packages(['python3.5', 'python3.5-dev', 'python3-dev'])
 }


### PR DESCRIPTION
This will install `Python 3.5.2` on the CI agent machines and others
that include the `govuk_python` modules (such as `mapit` and `ckan`).

This is currently blocking some of our branches from building
successfully as they require `Python 3.5 or later`.

Trello card: https://trello.com/c/lR6qMIm1/1780-5-upgrade-to-a-supported-python-version