### PR TITLE
Fix the -s and -F options in govuk_env_sync.

### DIFF
--- a/modules/govuk_env_sync/files/govuk_env_sync.sh
+++ b/modules/govuk_env_sync/files/govuk_env_sync.sh
@@ -600,7 +600,7 @@ usage() {
   exit 0
 }
 
-while getopts "f:a:D:S:T:d:u:p:t:h" opt
+while getopts "f:a:D:S:T:d:u:p:s:F:t:h" opt
 do
   case "$opt" in
     f) configfile="$OPTARG";


### PR DESCRIPTION
Fix the `-s` and `-F` options by adding missing chars to getopts.

I forgot to add these in #9922 and #10163 respectively.

I don't think we actually use any of these command-line options so perhaps we should remove them. For now, let's just make them work though.