### PR TITLE
Mark autopostgresqlbackup as absent

### DIFF
--- a/modules/govuk_postgresql/manifests/backup.pp
+++ b/modules/govuk_postgresql/manifests/backup.pp
@@ -31,7 +31,7 @@ class govuk_postgresql::backup (
   $auto_postgresql_backup_hour = 6,
   $auto_postgresql_backup_minute = 0,
   $alert_hostname = 'alert.cluster',
-  $ensure = 'present',
+  $ensure = 'absent',
 ) {
 
     $threshold_secs = 28 * 3600


### PR DESCRIPTION
It's not something we're actively using anymore so I don't think we need to keep it around. By keeping it around we have to deal with alerts and various other problems about it. Also, if we needed to restore from a backup in most cases we can now use RDS snapshots, and for any databases still left on Carrenza we can use WAL-E.

This matches with [the proposed strategy for backups](https://docs.google.com/document/d/1xLL5faE8ytScqofMqvBCNl1RIftr_VBcU3K6kcJ-7do/edit#heading=h.vowy6qkavbae) and it agrees with [our documentation which marks it as deprecated](https://docs.publishing.service.gov.uk/manual/postgresql-backups.html#autopostgresqlbackup).

Once this has been deployed across our machines, I'll open a follow up PR to remove the bits of code left in Puppet.