### PR TITLE
Update Email Alert Api latency check values

### DIFF
--- a/modules/govuk/manifests/apps/email_alert_api/checks.pp
+++ b/modules/govuk/manifests/apps/email_alert_api/checks.pp
@@ -13,21 +13,21 @@ class govuk::apps::email_alert_api::checks(
                           'cleanup']:
     size_warning     => '75000',
     size_critical    => '100000',
-    latency_warning  => '5',
-    latency_critical => '10',
+    latency_warning  => '300', # 5 minutes
+    latency_critical => '600', # 10 minutes
     ;
                         [ 'delivery_immediate_high',
                           'delivery_immediate']:
     size_warning     => '75000',
     size_critical    => '100000',
-    latency_warning  => '2.5',
-    latency_critical => '5',
+    latency_warning  => '150', # 2.5 minutes
+    latency_critical => '300', # 5 minutes
     ;
                         [ 'delivery_digest']:
     size_warning     => '75000',
     size_critical    => '100000',
-    latency_warning  => '90',
-    latency_critical => '60',
+    latency_warning  => '3600', # 60 minutes
+    latency_critical => '5400', # 90 minutes
     ;
   }
 


### PR DESCRIPTION
We are seeing many alerts for high latency on Email Alert API sidekiq queues, where no action is needed.

A few months ago we moved these [alerts from the email-alert-api healthcheck](https://github.com/alphagov/email-alert-api/pull/1116) into [govuk-puppet for a more granulised view.](https://github.com/alphagov/govuk-puppet/pull/10069/files)

The latency valued were originally in multiples of 60 seconds, but we updated the values to only the multiplier, leading to alerts firing with just seconds of latency. This PR changes the latency values to trigger warnings after minutes rather than seconds.

[trello](https://trello.com/c/S0vrUm8H/1769-review-email-alert-api-thresholds-days-25)