### PR TITLE
Add a Jenkins job to sync S3 assets between environments.

### DIFF
--- a/hieradata_aws/class/production/jenkins.yaml
+++ b/hieradata_aws/class/production/jenkins.yaml
@@ -25,6 +25,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::search_generate_sitemaps
   - govuk_jenkins::jobs::search_relevancy_rank_evaluation
   - govuk_jenkins::jobs::search_relevancy_metrics_etl
+  - govuk_jenkins::jobs::sync_assets_s3
   - govuk_jenkins::jobs::smokey
   - govuk_jenkins::jobs::smokey_deploy
   - govuk_jenkins::jobs::transition_import_dns

--- a/modules/govuk_jenkins/manifests/jobs/sync_assets_s3.pp
+++ b/modules/govuk_jenkins/manifests/jobs/sync_assets_s3.pp
@@ -1,0 +1,25 @@
+# == Class: govuk_jenkins::jobs::sync_assets_s3
+#
+# Sync assets from Production to Staging/Integration. Intended to run only from
+# Production.
+#
+class govuk_jenkins::jobs::sync_assets_s3 (
+  $app_domain = hiera('app_domain'),
+) {
+  $check_name = 'sync_assets_s3_from_prod_to_staging_and_integration'
+  $job_url = "https://deploy.${app_domain}/job/sync_assets_s3/"
+  $service_description = 'Sync assets in S3 from Production to Staging and Integration'
+
+  file { '/etc/jenkins_jobs/jobs/sync_assets_s3.yaml':
+    content => template('govuk_jenkins/jobs/sync_assets_s3.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+
+  @@icinga::passive_check { "${check_name}_${::hostname}":
+    service_description => $service_description,
+    host_name           => $::fqdn,
+    freshness_threshold => 115200,
+    action_url          => $job_url,
+    notes_url           => monitoring_docs_url(data-sync),
+  }
+}

--- a/modules/govuk_jenkins/templates/jobs/sync_assets_s3.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/sync_assets_s3.yaml.erb
@@ -1,0 +1,36 @@
+---
+- job:
+    name: sync_assets_s3
+    display-name: <%= @service_description %>
+    project-type: freestyle
+    description: >
+      Synchronises the assets S3 buckets for Staging and Integration with the
+      Production one, by running aws s3 sync from the Production db_admin
+      machine. Syncs deletions as well as additions.
+    logrotate:
+      numToKeep: 10
+    properties:
+      - build-discarder:
+          days-to-keep: 30
+          artifact-num-to-keep: 5
+    triggers:
+      - timed: |
+          TZ=Europe/London
+          H 2 * * 1-5
+    builders:
+      - shell: |
+          set -x
+          db_admin_host="$(govuk_node_list -c db_admin --single-node)"
+          ssh "deploy@${db_admin_host}" aws s3 sync --acl bucket-owner-full-control --no-progress --delete s3://govuk-assets-production s3://govuk-assets-staging
+          ssh "deploy@${db_admin_host}" aws s3 sync --acl bucket-owner-full-control --no-progress --delete s3://govuk-assets-production s3://govuk-assets-integration
+    publishers:
+      - trigger-parameterized-builds:
+        - project: Success_Passive_Check
+          condition: 'SUCCESS'
+          predefined-parameters: |
+            NSCA_CHECK_DESCRIPTION=<%= @service_description %>
+            NSCA_OUTPUT=<%= @service_description %> success
+        - project: Failure_Passive_Check
+          condition: 'FAILED'
+          predefined-parameters: |
+            NSCA_CHECK_DESCRIPTION=<%= @service_description %>


### PR DESCRIPTION
This is intended to replace the assets sync in alphagov/env-sync-and-backup which currently runs as part of the `copy_data_to_integration` and `copy_data_to_staging` Jenkins jobs.

The new job runs in AWS and consists of two `aws s3 sync` commands on the Prod db_admin machine (instead of a complex set of shell scripts).

Running on the Prod db_admin machine avoids granting cross-environment permissions.

Keeping the sync as a Jenkins job preserves visibility and lets us reuse the existing monitoring scaffolding for now.

Considered using [govuk_env_sync], but `aws s3 sync` doesn't really fit into govuk_env_sync's push/pull model. Also, this job doesn't warrant the complexity of invoking a shell script.

#### Related PRs

* alphagov/govuk-aws#1266 makes the necessary permissions changes. 
* alphagov/env-sync-and-backup#165 removes the old `assets` sync job from alphagov/env-sync-and-backup.

[govuk_env_sync]: https://docs.publishing.service.gov.uk/manual/govuk-env-sync.html