### PR TITLE
Remove Rob Bond and Ruth Morris

### DIFF
--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -168,7 +168,6 @@ govuk::apps::email_alert_api::email_address_override_whitelist:
   - jos.koetsier@digital.cabinet-office.gov.uk
   - kevin.dew@digital.cabinet-office.gov.uk
   - leanne.cummings@digital.cabinet-office.gov.uk
-  - robert.bond@digital.cabinet-office.gov.uk
   - ruth.morris@digital.cabinet-office.gov.uk
   - steve.messer@digital.cabinet-office.gov.uk
   - tim.blair@digital.cabinet-office.gov.uk

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -168,7 +168,6 @@ govuk::apps::email_alert_api::email_address_override_whitelist:
   - jos.koetsier@digital.cabinet-office.gov.uk
   - kevin.dew@digital.cabinet-office.gov.uk
   - leanne.cummings@digital.cabinet-office.gov.uk
-  - ruth.morris@digital.cabinet-office.gov.uk
   - steve.messer@digital.cabinet-office.gov.uk
   - tim.blair@digital.cabinet-office.gov.uk
   - thomas.leese@digital.cabinet-office.gov.uk

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -481,7 +481,6 @@ govuk::apps::email_alert_api::email_address_override_whitelist:
   - kevin.dew@digital.cabinet-office.gov.uk
   - leanne.cummings@digital.cabinet-office.gov.uk
   - michael.s.walker@digital.cabinet-office.gov.uk
-  - robert.bond@digital.cabinet-office.gov.uk
   - ruth.morris@digital.cabinet-office.gov.uk
   - steve.messer@digital.cabinet-office.gov.uk
   - tim.blair@digital.cabinet-office.gov.uk

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -481,7 +481,6 @@ govuk::apps::email_alert_api::email_address_override_whitelist:
   - kevin.dew@digital.cabinet-office.gov.uk
   - leanne.cummings@digital.cabinet-office.gov.uk
   - michael.s.walker@digital.cabinet-office.gov.uk
-  - ruth.morris@digital.cabinet-office.gov.uk
   - steve.messer@digital.cabinet-office.gov.uk
   - tim.blair@digital.cabinet-office.gov.uk
   - thomas.leese@digital.cabinet-office.gov.uk


### PR DESCRIPTION
Rob no longer works on GOV.UK and so doesn't need to be in the email
whitelist

Ruth has moved onto bigger and better things.