### PR TITLE
Fix Whitehall requests dashboard

### DIFF
--- a/modules/grafana/files/dashboards/platform-health-whitehall-frontend-requests.json
+++ b/modules/grafana/files/dashboards/platform-health-whitehall-frontend-requests.json
@@ -61,12 +61,12 @@
           "targets": [
             {
               "refId": "A",
-              "target": "alias(summarize(sumSeries(stats_counts.whitehall-frontend-*.whitehall.http_{2*,3*}), '1d', 'sum', false), 'Requests per day')",
+              "target": "alias(summarize(sumSeries(stats_counts.whitehall_frontend-*.whitehall.http_{2*,3*}), '1d', 'sum', false), 'Requests per day')",
               "textEditor": false
             },
             {
               "refId": "B",
-              "target": "alias(movingAverage(summarize(sumSeries(stats_counts.whitehall-frontend-*.whitehall.http_{2*,3*}), '1d', 'sum', false), '30d'), '30 day average')",
+              "target": "alias(movingAverage(summarize(sumSeries(stats_counts.whitehall_frontend-*.whitehall.http_{2*,3*}), '1d', 'sum', false), '30d'), '30 day average')",
               "textEditor": false
             },
             {


### PR DESCRIPTION
Since moving Whitehall to AWS, this dashboard has been broken because the machine classes have changed from having dashes to having underscores in their names.

[Trello Card](https://trello.com/c/z4IJrvSC/1787-fix-whitehall-frontend-requests-dashboard)