### PR TITLE
Add Whitehall back into Carrenza list of integration deployable applications

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -652,6 +652,7 @@ govuk_jenkins::jobs::integration_deploy::applications:
   support-api: {}
   support: {}
   transition: {}
+  whitehall: {}
 
 govuk_jenkins::jobs::deploy_lambda_app::lambda_apps:
   - 'email_alert_notifications'


### PR DESCRIPTION
Whitehall was removed from the Carrenza `govuk_jenkins::jobs::integration_deploy::applications` as part of #10178 (during AWS migration).

However, this list is used to populate the [`integration-app-deploy`](https://github.com/alphagov/govuk-puppet/blob/5bc6113e1339fc2dfa416f3dc2e8a79e828bff52/modules/govuk_jenkins/templates/jobs/integration_app_deploy.yaml.erb) Jenkins job, which runs in CI (still in Carrenza).  Therefore we were unable to deploy Whitehall to integration using this job.  A comment at the top of this list also states that migrated apps must be included here.

Adding this value back into the Carrenza hieradata.

Trello card: https://trello.com/c/62zGRrBS