### PR TITLE
Rename access limited filenames to redacted.pdf

### DIFF
--- a/modules/govuk_env_sync/files/govuk_env_sync.sh
+++ b/modules/govuk_env_sync/files/govuk_env_sync.sh
@@ -582,7 +582,25 @@ function postprocess_router {
     spotlight_proxy_domain="${unmigrated_source_domain}"
   fi
   mongo_backend_domain_manipulator "spotlight-proxy" "${spotlight_proxy_domain}"
+}
 
+function postprocess_govuk_assets_production {
+  setup_documentdb_credentials
+
+  mongo \
+    --host "${DOCUMENTDB_HOST}" \
+    --username "master" \
+    --password "${DOCUMENTDB_PASSWD}" \
+    --quiet \
+    --eval \
+      "db = db.getSiblingDB(\"${database}\"); \
+      db.assets.find({ access_limited: { \$exists: true, \$nin: [[], false] }, legacy_url_path: { \$exists: true } }) \
+        .forEach(function(asset) { \
+          splitPath = asset.legacy_url_path.split('/'); \
+          splitPath[splitPath.length - 1] = 'redacted.pdf'; \
+          asset.legacy_url_path = splitPath.join('/'); \
+          db.assets.save(asset); \
+        });"
 }
 
 function postprocess_database {
@@ -591,6 +609,7 @@ function postprocess_database {
     # re-using postprocess_router below is not a typo - the script checks $database to determine where to apply changes.
     draft_router) postprocess_router;;
     signon_production) postprocess_signon_production;;
+    govuk_assets_production) postprocess_govuk_assets_production;;
     *) log "No post processing needed for ${database}" ;;
   esac
 }


### PR DESCRIPTION
This matches [the behaviour of Whitehall](https://github.com/alphagov/whitehall/blob/a7c839bd80ac0dc535c979f89dd3657eff0c510b/script/scrub-database#L94) and means we can avoid unnecessary Sentry errors when Whitehall tries to communicate with Asset Manager with a different filename to the one known by Asset Manager.

[Trello Card](https://trello.com/c/33ZuT6D4/885-5-handle-access-limited-assets-in-asset-manager) ・ [Sentry issue](https://sentry.io/organizations/govuk/issues/617165767/)