### PR TITLE
Fix check_puppetdb_ssh_host_keys script

### DIFF
--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_puppetdb_ssh_host_keys
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_puppetdb_ssh_host_keys
@@ -3,6 +3,7 @@ import json
 import base64
 import hashlib
 import string
+import sys
 import urllib
 import urllib2
 


### PR DESCRIPTION
Need to import sys as per error in alert logs:
NameError: global name 'sys' is not defined