### PR TITLE
Point publisher apps towards shared-documentdb

### DIFF
--- a/hieradata_aws/class/backend.yaml
+++ b/hieradata_aws/class/backend.yaml
@@ -41,7 +41,7 @@ govuk::apps::specialist_publisher::mongodb_password: "%{hiera('shared_documentdb
 govuk::apps::travel_advice_publisher::mongodb_name: 'travel_advice_publisher_production'
 govuk::apps::travel_advice_publisher::mongodb_nodes:
   - 'shared-documentdb'
-govuk::apps::traveil_advice_publisher::mongodb_username: "%{hiera('shared_documentdb_user')}"
+govuk::apps::travel_advice_publisher::mongodb_username: "%{hiera('shared_documentdb_user')}"
 govuk::apps::travel_advice_publisher::mongodb_password: "%{hiera('shared_documentdb_password')}"
 
 govuk::deploy::setup::deploy_uid: 2899

--- a/hieradata_aws/class/backend.yaml
+++ b/hieradata_aws/class/backend.yaml
@@ -10,39 +10,39 @@ govuk::apps::email_alert_service::enabled: false
 
 govuk::apps::manuals_publisher::mongodb_name: 'govuk_content_production'
 govuk::apps::manuals_publisher::mongodb_nodes:
-  - 'mongo-1'
-  - 'mongo-2'
-  - 'mongo-3'
+  - 'shared-documentdb'
+govuk::apps::manuals_publisher::mongodb_username: "%{hiera('shared_documentdb_user')}"
+govuk::apps::manuals_publisher::mongodb_password: "%{hiera('shared_documentdb_password')}"
 
 govuk::apps::maslow::mongodb_name: 'maslow_production'
 govuk::apps::maslow::mongodb_nodes:
-  - 'mongo-1'
-  - 'mongo-2'
-  - 'mongo-3'
+  - 'shared-documentdb'
+govuk::apps::maslow::mongodb_username: "%{hiera('shared_documentdb_user')}"
+govuk::apps::maslow::mongodb_password: "%{hiera('shared_documentdb_password')}"
 
 govuk::apps::publisher::mongodb_name: 'govuk_content_production'
 govuk::apps::publisher::mongodb_nodes:
-  - 'mongo-1'
-  - 'mongo-2'
-  - 'mongo-3'
+  - 'shared-documentdb'
+govuk::apps::publisher::mongodb_username: "%{hiera('shared_documentdb_user')}"
+govuk::apps::publisher::mongodb_password: "%{hiera('shared_documentdb_password')}"
 
 govuk::apps::short_url_manager::mongodb_name: 'short_url_manager_production'
 govuk::apps::short_url_manager::mongodb_nodes:
-  - 'mongo-1'
-  - 'mongo-2'
-  - 'mongo-3'
+  - 'shared-documentdb'
+govuk::apps::short_url_manager::mongodb_username: "%{hiera('shared_documentdb_user')}"
+govuk::apps::short_url_manager::mongodb_password: "%{hiera('shared_documentdb_password')}"
 
 govuk::apps::specialist_publisher::mongodb_name: 'govuk_content_production'
 govuk::apps::specialist_publisher::mongodb_nodes:
-  - 'mongo-1'
-  - 'mongo-2'
-  - 'mongo-3'
+  - 'shared-documentdb'
+govuk::apps::specialist_publisher::mongodb_username: "%{hiera('shared_documentdb_user')}"
+govuk::apps::specialist_publisher::mongodb_password: "%{hiera('shared_documentdb_password')}"
 
 govuk::apps::travel_advice_publisher::mongodb_name: 'travel_advice_publisher_production'
 govuk::apps::travel_advice_publisher::mongodb_nodes:
-  - 'mongo-1'
-  - 'mongo-2'
-  - 'mongo-3'
+  - 'shared-documentdb'
+govuk::apps::traveil_advice_publisher::mongodb_username: "%{hiera('shared_documentdb_user')}"
+govuk::apps::travel_advice_publisher::mongodb_password: "%{hiera('shared_documentdb_password')}"
 
 govuk::deploy::setup::deploy_uid: 2899
 govuk::deploy::setup::deploy_gid: 2899


### PR DESCRIPTION
As part of the migration to AWS we move from a mongo cluster to
a Documentdb instance.