### PR TITLE
Fix Content Publisher Data Sync Integration

### DIFF
--- a/hieradata_aws/class/integration/db_admin.yaml
+++ b/hieradata_aws/class/integration/db_admin.yaml
@@ -331,7 +331,7 @@ govuk_env_sync::tasks:
     path: "mysql"
   "pull_content_publisher_production_daily":
     ensure: "present"
-    hour: "2"
+    hour: "3"
     minute: "45"
     action: "pull"
     dbms: "postgresql"

--- a/hieradata_aws/class/staging/db_admin.yaml
+++ b/hieradata_aws/class/staging/db_admin.yaml
@@ -65,6 +65,17 @@ govuk_env_sync::tasks:
     temppath: "/tmp/content_data_admin_production_push"
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
+  "push_content_publisher_production_daily":
+    ensure: "present"
+    hour: "2"
+    minute: "45"
+    action: "push"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "content_publisher_production"
+    temppath: "/tmp/content_publisher_production"
+    url: "govuk-staging-database-backups"
+    path: "postgresql-backend"
   "pull_content_tagger_production_daily":
     ensure: "present"
     hour: "2"


### PR DESCRIPTION
Push data from Staging to S3 job was missing for Content Publisher, this
commit adds it.