### PR TITLE
Re-point env-sync alerts to specific support doc

### DIFF
--- a/modules/govuk_env_sync/manifests/task.pp
+++ b/modules/govuk_env_sync/manifests/task.pp
@@ -123,7 +123,6 @@ define govuk_env_sync::task(
     service_description => $service_desc,
     freshness_threshold => $threshold_secs,
     host_name           => $::fqdn,
-    notes_url           => 'https://docs.publishing.service.gov.uk/manual/govuk-env-sync.html',
+    notes_url           => monitoring_docs_url(data-sync),
   }
-
 }


### PR DESCRIPTION
Depends on: https://github.com/alphagov/govuk-developer-docs/pull/2368