### PR TITLE
Use 15-minute mean instead of 5-minute for RDS CPU alert.

### DIFF
--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_rds_cpu
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_rds_cpu
@@ -95,11 +95,11 @@ cw_conn = boto.ec2.cloudwatch.connect_to_region(args.region)
 
 ###########################################################
 # Define start and end times      			  #
-# Here we have give 5 minutes because that is the window  #
+# Here we have give 15 minutes because that is the window #
 # we are using to calculate the average.		  #
 # Note: The time should be in UTC format.		  #
 ###########################################################
-start = datetime.datetime.now() - datetime.timedelta(seconds=300)
+start = datetime.datetime.now() - datetime.timedelta(seconds=900)
 end = datetime.datetime.now()
 
 ####################################


### PR DESCRIPTION
This alert has led to some consternation recently and probably not on account of any actual user-visible issue. This should make the alert a bit less flaky.

There is a strong case for removing this alert altogether, but I'm proposing this as a (hopefully) less controversial stop-gap measure.