### PR TITLE
gemstash: Expire the gem cache in 10 minutes rather than 20

### DIFF
--- a/modules/govuk_containers/files/gemstash/config.yml
+++ b/modules/govuk_containers/files/gemstash/config.yml
@@ -1,3 +1,3 @@
 :cache_type: memory
 :cache_max_size: 500
-:cache_expiration: 1200
+:cache_expiration: 600


### PR DESCRIPTION
- The changes we made in 1fe65f4780b4580205683e3f595238855306c085 to
  reduce Gemstash's cache time to 20 minutes weren't aggressive enough to
  fix the problem of releasing a new gem version, Dependabot detecting it
  and then us having to hit "Rebuild" on a bunch of Jenkins jobs.
- This decreases the cache time by a further ten minutes to see if that
  helps any more. It's easier than hitting rebuild on 50+ CI jobs.