### PR TITLE
Disable enhanced ecommerce data load

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -474,7 +474,6 @@ task :check_consistency_between_aws_and_carrenza do
     govuk_jenkins::jobs::search_fetch_analytics_data::skip_page_traffic_load
     govuk_jenkins::jobs::search_relevancy_rank_evaluation::cron_schedule
     govuk_jenkins::jobs::search_relevancy_metrics_etl::cron_schedule
-    govuk_jenkins::jobs::enhanced_ecommerce_search_api::cron_schedule
     govuk_jenkins::jobs::smokey::environment
     govuk_mysql::server::expire_log_days
     govuk_mysql::server::slow_query_log

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -193,8 +193,6 @@ govuk::apps::travel_advice_publisher::enable_email_alerts: true
 govuk_search::monitoring::es_port: '80'
 govuk_search::monitoring::es_host: 'vpc-blue-elasticsearch6-domain-2hnib7uydv3tgebhabx74gdelq.eu-west-1.es.amazonaws.com'
 
-govuk_jenkins::jobs::enhanced_ecommerce_search_api::cron_schedule: '0 6 * * 1-5' # Every weekday at 6am
-
 govuk::deploy::aws_ses_smtp_host: 'email-smtp.eu-west-1.amazonaws.com'
 govuk::deploy::config::errbit_environment_name: 'production'
 govuk::deploy::config::website_root: 'https://www.gov.uk'

--- a/modules/govuk_jenkins/templates/jobs/enhanced_ecommerce.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/enhanced_ecommerce.yaml.erb
@@ -16,8 +16,10 @@
               TARGET_APPLICATION=<%= @target_application %>
               MACHINE_CLASS=search
               RAKE_TASK=analytics:export_indexed_pages_to_google_analytics
+<% if @cron_schedule %>
     triggers:
         - timed: '<%= @cron_schedule %>'
+<% end %>
     publishers:
         - trigger-parameterized-builds:
             - project: Success_Passive_Check


### PR DESCRIPTION
This isn't needed on a schedule right now so we can remove the cron schedule. It'll be needed in future so I've kept the code here.