### PR TITLE
Delay before alerting on unicorn workers

### DIFF
--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -483,11 +483,12 @@ define govuk::app::config (
   if $app_type == 'rack' {
     include icinga::client::check_unicorn_workers
     @@icinga::check { "check_app_${title}_unicorn_workers_${::hostname}":
-      ensure              => $ensure,
-      check_command       => "check_nrpe!check_unicorn_workers!${title}",
-      service_description => "${title} does not have the expected number of unicorn workers",
-      host_name           => $::fqdn,
-      contact_groups      => $additional_check_contact_groups,
+      ensure                   => $ensure,
+      check_command            => "check_nrpe!check_unicorn_workers!${title}",
+      service_description      => "${title} does not have the expected number of unicorn workers",
+      host_name                => $::fqdn,
+      contact_groups           => $additional_check_contact_groups,
+      first_notification_delay => 2,
     }
     include icinga::client::check_unicorn_ruby_version
     @@icinga::check { "check_app_${title}_unicorn_ruby_version_${::hostname}":


### PR DESCRIPTION
Previously we notified about abnormal unicorn workers immediately,
which is often a false alarm and due to an app restart. This changes
the check to delay by 2 minutes (2 * check_interval), in the case
the check runs near the time of the restart.

Making this change increases the minimum alert delay to 2 minutes,
and the maximum alert delay to 7 minutes (default_interval + 2).
This seems like a reasonable compromise.