### PR TITLE
Prometheus to scrape router metrics in integration

### DIFF
--- a/modules/govuk_prometheus/files/etc/prometheus/prometheus.yml
+++ b/modules/govuk_prometheus/files/etc/prometheus/prometheus.yml
@@ -49,3 +49,19 @@ scrape_configs:
         target_label: aws_migration
       - source_labels: [__meta_ec2_tag_aws_hostname]
         target_label: aws_hostname
+  - job_name: 'router'
+    ec2_sd_configs:
+      - region: "eu-west-1"
+        port: 3055
+        filters:
+        - name: instance-state-name
+          values: [ running ]
+        - name: tag:aws_migration
+          values: [ cache ]
+        - name: tag:aws_environment
+          values: [ integration ]
+    relabel_configs:
+      - source_labels: [__meta_ec2_tag_aws_migration]
+        target_label: aws_migration
+      - source_labels: [__meta_ec2_tag_aws_hostname]
+        target_label: aws_hostname


### PR DESCRIPTION
What
---

We have [instrumented the router application](https://github.com/alphagov/router/pull/148)

We want prometheus to scrape it in integration, as this is where we will deploy our instrumented build of router

This PR adds a job to Prometheus, representing the router app. The job will exist in all environments but the service discovery will only find instances in the integration environment.

How to review
---

~code~ YAML review

Go into the AWS console in integration and verify that the cache box ec2 instances have the following tags:
- `aws_migration` `cache`
- `aws_environment` `integration`