### PR TITLE
Make "puppet last run errors" alert show as Critical.

### DIFF
--- a/modules/puppet/manifests/monitoring.pp
+++ b/modules/puppet/manifests/monitoring.pp
@@ -23,9 +23,10 @@ class puppet::monitoring (
   $app_domain = hiera('app_domain')
 
   @@icinga::passive_check { "check_puppet_${::hostname}":
-    service_description => 'puppet last run errors',
-    host_name           => $::fqdn,
-    freshness_threshold => 7200,
-    notes_url           => monitoring_docs_url(puppet-last-run-errors),
+    service_description   => 'puppet last run errors',
+    host_name             => $::fqdn,
+    freshness_threshold   => 7200,
+    freshness_alert_level => 'critical',
+    notes_url             => monitoring_docs_url(puppet-last-run-errors),
   }
 }


### PR DESCRIPTION
We keep disabling Puppet agent on machines and then forgetting about it.
This has led to several mini-incidents over the last few months and has
caused problems when migrating apps to AWS. The warning alerts tend to
be ignored (understandably) and so mistakes are left unchecked.

On one occasion a Puppet agent was left disabled for several months on a
Jenkins box and this led to CI breaking horribly when Puppet was
re-enabled, because in the meantime someone had merged a Puppet PR
containing a mistake which removed all permissions from the Jenkins
config. The PR appeared fine when it was tested, because the machine
which it affected never ran the Puppet agent.

It therefore appears that we've been ignoring this alert, but it does
actually require action. Let's see if making it show up under the
Critical alerts section helps.