### PR TITLE
Limit access to staging and production Jenkins

### DIFF
--- a/hieradata_aws/class/production/jenkins.yaml
+++ b/hieradata_aws/class/production/jenkins.yaml
@@ -1,4 +1,43 @@
 ---
+jenkins_admin_permission_list: &jenkins_admin_permission_list
+  - 'hudson.model.Hudson.Administer'
+  - 'hudson.model.Hudson.Read'
+  - 'hudson.model.Hudson.RunScripts'
+  - 'hudson.model.Item.Build'
+  - 'hudson.model.Item.Cancel'
+  - 'hudson.model.Item.Configure'
+  - 'hudson.model.Item.Create'
+  - 'hudson.model.Item.Delete'
+  - 'hudson.model.Item.Discover'
+  - 'hudson.model.Item.Read'
+  - 'hudson.model.Item.Workspace'
+  - 'hudson.model.Run.Delete'
+  - 'hudson.model.Run.Update'
+  - 'hudson.model.View.Configure'
+  - 'hudson.model.View.Create'
+  - 'hudson.model.View.Delete'
+  - 'hudson.model.View.Read'
+  - 'hudson.scm.SCM.Tag'
+
+govuk_jenkins::config::manage_permissions_github_teams: true
+govuk_jenkins::config::user_permissions:
+  -
+    user: 'jenkins_api_user'
+    permissions: *jenkins_admin_permission_list
+  -
+    user: 'alphagov*GOV.UK Production'
+    permissions: *jenkins_admin_permission_list
+  -
+    user: 'anonymous'
+    permissions:
+      - 'hudson.model.Hudson.Read'
+      - 'hudson.model.Item.Discover'
+  -
+    user: 'github'
+    permissions:
+      - 'hudson.model.Item.Build'
+      - 'hudson.model.Item.Read'
+
 govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::athena_fastly_logs_check
   - govuk_jenkins::jobs::bouncer_cdn

--- a/hieradata_aws/class/staging/jenkins.yaml
+++ b/hieradata_aws/class/staging/jenkins.yaml
@@ -6,6 +6,45 @@ govuk_jenkins::config::theme_colour: '#ffbf47'
 govuk_jenkins::config::theme_text_colour: 'black'
 govuk_jenkins::config::theme_environment_name: 'AWS Staging'
 
+jenkins_admin_permission_list: &jenkins_admin_permission_list
+  - 'hudson.model.Hudson.Administer'
+  - 'hudson.model.Hudson.Read'
+  - 'hudson.model.Hudson.RunScripts'
+  - 'hudson.model.Item.Build'
+  - 'hudson.model.Item.Cancel'
+  - 'hudson.model.Item.Configure'
+  - 'hudson.model.Item.Create'
+  - 'hudson.model.Item.Delete'
+  - 'hudson.model.Item.Discover'
+  - 'hudson.model.Item.Read'
+  - 'hudson.model.Item.Workspace'
+  - 'hudson.model.Run.Delete'
+  - 'hudson.model.Run.Update'
+  - 'hudson.model.View.Configure'
+  - 'hudson.model.View.Create'
+  - 'hudson.model.View.Delete'
+  - 'hudson.model.View.Read'
+  - 'hudson.scm.SCM.Tag'
+
+govuk_jenkins::config::manage_permissions_github_teams: true
+govuk_jenkins::config::user_permissions:
+  -
+    user: 'jenkins_api_user'
+    permissions: *jenkins_admin_permission_list
+  -
+    user: 'alphagov*GOV.UK Production'
+    permissions: *jenkins_admin_permission_list
+  -
+    user: 'anonymous'
+    permissions:
+      - 'hudson.model.Hudson.Read'
+      - 'hudson.model.Item.Discover'
+  -
+    user: 'github'
+    permissions:
+      - 'hudson.model.Item.Build'
+      - 'hudson.model.Item.Read'
+
 govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::athena_fastly_logs_check
   - govuk_jenkins::jobs::clear_frontend_memcache


### PR DESCRIPTION
Members of the GOV.UK github team should have access to integration
Jenkins.

Members of the GOV.UK Production github team should have access to
staging and production Jenkins.