### PR TITLE
Disable integration data for Whitehall content

### DIFF
--- a/hieradata_aws/class/integration/db_admin.yaml
+++ b/hieradata_aws/class/integration/db_admin.yaml
@@ -232,7 +232,7 @@ govuk_env_sync::tasks:
     url: "govuk-integration-database-backups"
     path: "mysql-backend"
   "pull_whitehall_staging_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "1"
     minute: "30"
     action: "pull"
@@ -274,7 +274,7 @@ govuk_env_sync::tasks:
     hour: "6"
     minute: "30"
   "pull_publishing_api_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "2"
     minute: "40"
     action: "pull"
@@ -286,7 +286,7 @@ govuk_env_sync::tasks:
     path: "postgresql-backend"
     transformation_sql_filename: "sanitise_publishing_api_production.sql"
   "pull_govuk_assets_production":
-    ensure: "present"
+    ensure: "absent"
     hour: "3"
     minute: "30"
     action: "pull"

--- a/hieradata_aws/class/integration/mongo.yaml
+++ b/hieradata_aws/class/integration/mongo.yaml
@@ -1,6 +1,6 @@
 govuk_env_sync::tasks:
   "pull_content_store_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "4"
     minute: "16"
     action: "pull"
@@ -11,7 +11,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mongo-api"
   "pull_draft_content_store_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "4"
     minute: "16"
     action: "pull"

--- a/hieradata_aws/class/integration/router_backend.yaml
+++ b/hieradata_aws/class/integration/router_backend.yaml
@@ -1,6 +1,6 @@
 govuk_env_sync::tasks:
   "pull_router_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "3"
     minute: "24"
     action: "pull"
@@ -11,7 +11,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mongo-router"
   "pull_draft_router_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "3"
     minute: "45"
     action: "pull"

--- a/hieradata_aws/class/integration/search.yaml
+++ b/hieradata_aws/class/integration/search.yaml
@@ -1,6 +1,6 @@
 govuk_env_sync::tasks:
   "pull_es6_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "3"
     minute: "24"
     action: "pull"

--- a/modules/govuk_jenkins/manifests/jobs/copy_data_to_integration.pp
+++ b/modules/govuk_jenkins/manifests/jobs/copy_data_to_integration.pp
@@ -23,7 +23,7 @@ class govuk_jenkins::jobs::copy_data_to_integration (
   $slack_build_server_url = "https://deploy.${app_domain}/"
 
   file { '/etc/jenkins_jobs/jobs/copy_data_to_integration.yaml':
-    ensure  => present,
+    ensure  => absent,
     content => template('govuk_jenkins/jobs/copy_data_to_integration.yaml.erb'),
     notify  => Exec['jenkins_jobs_update'],
   }


### PR DESCRIPTION
https://trello.com/c/XZkgqF1R/856-10-to-11-march-budget-2020-homepage-update-no-integration-wipe-or-whitehall-backend-updates

Based on: https://github.com/alphagov/govuk-puppet/commit/804a62c2879f71e8d2c33b8ffd55b095cc6255c6

This disables parts of the prod/staging -> integration sync, so that
the environment remains unchagned while the budget is being prepared.

While the DB sync for Whitehall is now done via govuk_env_sync, the
associated assets are still handled via env-sync-and-backup, so it's
still necesssary to disable the copy_data_to_integration job.