### PR TITLE
Remove `blue.` from govuk_uptime_collector healthcheck URLs.

### DIFF
--- a/modules/monitoring/files/usr/local/bin/govuk_uptime_collector
+++ b/modules/monitoring/files/usr/local/bin/govuk_uptime_collector
@@ -36,7 +36,7 @@ private
   def healthcheck_uri
     @healthcheck_uri ||= begin
       if aws
-        URI("https://#{service_name}.blue.#{environment}.govuk.digital/healthcheck")
+        URI("https://#{service_name}.#{environment}.govuk.digital/healthcheck")
       else
         prefix = environment == "production" ? "#{service_name}" : "#{service_name}.#{environment}"
         URI("https://#{prefix}.publishing.service.gov.uk/#{healthcheck_path}")


### PR DESCRIPTION
Several reasons for doing this:

1. The `blue.` DNS names for the publisher apps are currently pointing
   at a classic ELB which isn't used for anything else. We want to get
   rid of this ELB because it's a liability. govuk_uptime_collector is
   the only legitimate client which is using this obsolete LB.
2. Makes govuk_uptime_collector measure apps via the same load balancer
   which other clients use. Right now, it's using a different LB than
   than everything else.
3. The blue/green stack idea is abandoned and we want to remove it in
   the near future, so this takes care of a bit of cleanup which we'll
   want to do in the near future anyway.
4. Removes an unnecessary indirection and slightly reduces complexity.