### PR TITLE
Configure a Procfile worker for short-url-manager

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -255,7 +255,6 @@ govuk::apps::publisher::email_group_business: 'govuk-dev@digital.cabinet-office.
 govuk::apps::publisher::email_group_citizen: 'govuk-dev@digital.cabinet-office.gov.uk'
 govuk::apps::publisher::email_group_force_publish_alerts: 'test-mainstream-force-publishing-alerts@digital.cabinet-office.gov.uk'
 
-
 govuk::apps::short_url_manager::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::short_url_manager::redis_port: "%{hiera('sidekiq_port')}"
 

--- a/hieradata/development.yaml
+++ b/hieradata/development.yaml
@@ -247,6 +247,7 @@ govuk::apps::search_api::rabbitmq::enable_publishing_listener: true
 
 govuk::apps::signon::enable_procfile_worker: false
 govuk::apps::smartanswers::expose_govspeak: true
+govuk::apps::short_url_manager::enable_procfile_worker: false
 govuk::apps::short_url_manager::mongodb_name: 'short_url_manager_development'
 govuk::apps::short_url_manager::mongodb_nodes: ['localhost']
 govuk::apps::sidekiq_monitoring::nginx_location: '/var/govuk/sidekiq-monitoring/public'

--- a/modules/govuk/manifests/apps/short_url_manager.pp
+++ b/modules/govuk/manifests/apps/short_url_manager.pp
@@ -61,6 +61,10 @@
 # [*govuk_notify_template_id*]
 #   The template ID used to send email via GOV.UK Notify.
 #
+# [*enable_procfile_worker*]
+#   Whether to enable the procfile worker
+#   Default: true
+#
 class govuk::apps::short_url_manager(
   $sentry_dsn = undef,
   $instance_name = undef,
@@ -77,6 +81,7 @@ class govuk::apps::short_url_manager(
   $secret_key_base = undef,
   $govuk_notify_api_key = undef,
   $govuk_notify_template_id = undef,
+  $enable_procfile_worker = true,
 ) {
 
   $app_name = 'short-url-manager'
@@ -136,5 +141,9 @@ class govuk::apps::short_url_manager(
       varname => 'INSTANCE_NAME',
       value   => $instance_name,
     }
+  }
+
+  govuk::procfile::worker { $app_name:
+    enable_service => $enable_procfile_worker,
   }
 }


### PR DESCRIPTION
We're going to start using Sidekiq to send emails so we need to make sure the Procfile worker runs.

https://github.com/alphagov/short-url-manager/pull/459 adds Sidekiq configuration to the app itself.

[Trello Card](https://trello.com/c/6FJKUWIs/1794-3-short-url-manager-use-notify-instead-of-amazon-ses)