### PR TITLE
Increase the default number of Jenkins executors to 8

### DIFF
--- a/hieradata/class/integration/jenkins.yaml
+++ b/hieradata/class/integration/jenkins.yaml
@@ -1,6 +1,4 @@
 ---
-govuk_jenkins::config::executors: '8'
-
 govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::deploy_puppet
   - govuk_jenkins::jobs::deploy_terraform_govuk_aws

--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -1,6 +1,4 @@
 ---
-govuk_jenkins::config::executors: '8'
-
 govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::build_offsite_backup
   - govuk_jenkins::jobs::check_cdn_ip_ranges

--- a/hieradata/class/staging/jenkins.yaml
+++ b/hieradata/class/staging/jenkins.yaml
@@ -1,6 +1,4 @@
 ---
-govuk_jenkins::config::executors: '8'
-
 govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::copy_data_from_staging_to_aws
   - govuk_jenkins::jobs::data_sync_complete_staging

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -115,7 +115,6 @@ govuk_cdnlogs::govuk_monitoring_enabled: false
 govuk_cdnlogs::bouncer_monitoring_enabled: false
 
 govuk_jenkins::job_builder::environment: 'integration'
-govuk_jenkins::config::executors: '8'
 
 govuk_jenkins::jobs::athena_fastly_logs_check::s3_results_bucket: 'govuk-integration-fastly-logs-monitoring'
 govuk_jenkins::jobs::content_data_api::rake_etl_master_process_cron_schedule: '0 13 * * *'

--- a/hieradata_aws/training.yaml
+++ b/hieradata_aws/training.yaml
@@ -82,7 +82,6 @@ govuk_cdnlogs::govuk_monitoring_enabled: false
 govuk_cdnlogs::bouncer_monitoring_enabled: false
 
 govuk_jenkins::job_builder::environment: 'training'
-govuk_jenkins::config::executors: '8'
 
 govuk_jenkins::jobs::content_data_api::rake_etl_master_process_cron_schedule: '0 13 * * *'
 

--- a/modules/govuk_jenkins/manifests/config.pp
+++ b/modules/govuk_jenkins/manifests/config.pp
@@ -109,7 +109,7 @@ class govuk_jenkins::config (
   $manage_config = true,
   $version = $govuk_jenkins::version,
   $create_agent_role = false,
-  $executors = '4',
+  $executors = '8',
   $agent_tcp_port = '0',
   $csrf_version = true,
   $markup_formatter_version = '1.5',


### PR DESCRIPTION
The intent here is to increase the number of executors for the Deploy
Jenkins in Production on the AWS side from 4 to 8, but rather than
overriding the default in one more place, lets just change the default
to 8.