### PR TITLE
Remove CDN Logs code properly

### DIFF
--- a/modules/govuk/manifests/node/s_monitoring.pp
+++ b/modules/govuk/manifests/node/s_monitoring.pp
@@ -21,6 +21,7 @@ class govuk::node::s_monitoring (
   include ::govuk_docker
   include govuk_rbenv::all
   include ::selenium
+  include ::govuk_cdnlogs
   include monitoring
   include collectd::plugin::icinga
   include govuk_java::openjdk8::jre


### PR DESCRIPTION
- It turns out that in https://github.com/alphagov/govuk-puppet/pull/10126 I did everything right except for removing the `include ::govuk_cdnlogs`. This mistake meant that none of the `ensure => absent`s actually worked.
- Thankfully, we've not cleaned up those `ensure => absent`s yet so we can reinstate this line and have everything remove.