### PR TITLE
Move 'Send Bulk Email' job into AWS

### DIFF
--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -24,7 +24,6 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::record_taxonomy_metrics
   - govuk_jenkins::jobs::record_superfluous_taggings_metrics
   - govuk_jenkins::jobs::run_rake_task
-  - govuk_jenkins::jobs::send_bulk_email
   - govuk_jenkins::jobs::signon_cron_rake_tasks
   - govuk_jenkins::jobs::smokey
   - govuk_jenkins::jobs::smokey_deploy

--- a/hieradata/class/staging/jenkins.yaml
+++ b/hieradata/class/staging/jenkins.yaml
@@ -18,7 +18,6 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::record_superfluous_taggings_metrics
   - govuk_jenkins::jobs::record_taxonomy_metrics
   - govuk_jenkins::jobs::run_rake_task
-  - govuk_jenkins::jobs::send_bulk_email
   - govuk_jenkins::jobs::smokey
   - govuk_jenkins::jobs::smokey_deploy
   - govuk_jenkins::jobs::update_cdn_dictionaries

--- a/hieradata_aws/class/production/jenkins.yaml
+++ b/hieradata_aws/class/production/jenkins.yaml
@@ -64,6 +64,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::search_generate_sitemaps
   - govuk_jenkins::jobs::search_relevancy_rank_evaluation
   - govuk_jenkins::jobs::search_relevancy_metrics_etl
+  - govuk_jenkins::jobs::send_bulk_email
   - govuk_jenkins::jobs::sync_assets_s3
   - govuk_jenkins::jobs::smokey
   - govuk_jenkins::jobs::smokey_deploy

--- a/hieradata_aws/class/staging/jenkins.yaml
+++ b/hieradata_aws/class/staging/jenkins.yaml
@@ -65,6 +65,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::search_relevancy_rank_evaluation
   - govuk_jenkins::jobs::search_relevancy_metrics_etl
   - govuk_jenkins::jobs::search_generate_sitemaps
+  - govuk_jenkins::jobs::send_bulk_email
   - govuk_jenkins::jobs::smokey
   - govuk_jenkins::jobs::smokey_deploy
   - govuk_jenkins::jobs::whitehall_publisher_notifications


### PR DESCRIPTION
It looks like this was missed in the AWS migration and it currently doesn't work in Carrenza (https://deploy.staging.publishing.service.gov.uk/job/send-bulk-email/2/console).