### PR TITLE
Bump "high number of emails" alert to reflect new Notify limits

### DIFF
--- a/modules/govuk/manifests/apps/email_alert_api/checks.pp
+++ b/modules/govuk/manifests/apps/email_alert_api/checks.pp
@@ -48,8 +48,8 @@ class govuk::apps::email_alert_api::checks(
     host_name => $::fqdn,
     target    => 'summarize(sum(stats_counts.govuk.app.email-alert-api.*.notify.email_send_request.success),"1day")',
     args      => '--ignore-missing',
-    warning   => '3200000', # 4,000,000 * 0.8
-    critical  => '3600000', # 4,000,000 * 0.9
+    warning   => '8000000', # 10,000,000 * 0.8
+    critical  => '9000000', # 10,000,000 * 0.9
     from      => '3hours',
     desc      => 'email-alert-api - high number of email send requests',
   }

--- a/modules/govuk/manifests/apps/email_alert_api/checks.pp
+++ b/modules/govuk/manifests/apps/email_alert_api/checks.pp
@@ -46,7 +46,7 @@ class govuk::apps::email_alert_api::checks(
 
   @@icinga::check::graphite { 'email-alert-api-notify-email-send-request-success':
     host_name => $::fqdn,
-    target    => 'summarize(sum(stats_counts.govuk.app.email-alert-api.*.notify.email_send_request.success),"1day")',
+    target    => 'summarize(groupByNode(consolidateBy(stats_counts.govuk.app.email-alert-api.*.notify.email_send_request.*, "sum"), 1, "sum"), "1d", "sum", false)',
     args      => '--ignore-missing',
     warning   => '8000000', # 10,000,000 * 0.8
     critical  => '9000000', # 10,000,000 * 0.9


### PR DESCRIPTION
- We sent 5 million emails yesterday, so we bumped our Notify limit to
  10 million.