### PR TITLE
Increase max values for visualisation of "Notify Emails Sent (Today)"

### DIFF
--- a/modules/grafana/files/dashboards/email_alert_api.json
+++ b/modules/grafana/files/dashboards/email_alert_api.json
@@ -133,7 +133,7 @@
           "datasource": "Graphite",
           "format": "none",
           "gauge": {
-            "maxValue": 6000000,
+            "maxValue": 10000000,
             "minValue": 0,
             "show": true,
             "thresholdLabels": false,
@@ -183,7 +183,7 @@
               "textEditor": false
             }
           ],
-          "thresholds": "4000000,5000000",
+          "thresholds": "8000000,9000000",
           "timeFrom": "now/d",
           "timeShift": null,
           "title": "Notify Emails Sent (Today)",


### PR DESCRIPTION
- We've had our Notify limit bumped to 10 million emails per day, so we should increase the max value of this graph accordingly so it doesn't look too scary at current levels, plus make the thresholds for visualising warning and critical states match [the changes from earlier](https://github.com/alphagov/govuk-puppet/commit/28aba83254ac3524743a6f84b6733d1973dd77e0).

(I've already applied these changes in Production for my own peace of mind!)