### PR TITLE
Increase the number of Email Alert API Unicorn workers

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -460,7 +460,7 @@ govuk::apps::email_alert_api::db_hostname: "postgresql-primary"
 govuk::apps::email_alert_api::db_password: "%{hiera('govuk::apps::email_alert_api::db::password')}"
 govuk::apps::email_alert_api::nagios_memory_warning: 2400
 govuk::apps::email_alert_api::nagios_memory_critical: 3000
-govuk::apps::email_alert_api::unicorn_worker_processes: '8'
+govuk::apps::email_alert_api::unicorn_worker_processes: '10'
 # This list should be kept in sync with https://www.notifications.service.gov.uk/services/ecfc7e2f-5145-45a6-9413-5d9b6e813ea9/users
 govuk::apps::email_alert_api::email_address_override_whitelist:
   - govuk-email-courtesy-copies@digital.cabinet-office.gov.uk


### PR DESCRIPTION
From 8 to 10, which is a 25% increase. We're getting more traffic from
Notify now regarding delivery receipts. The machines have spare memory
and CPU time, so increasing the number of Unicorn workers should help
with processing requests.