### PR TITLE
Use different reboot locks for different tasks

### DIFF
--- a/modules/govuk_env_sync/manifests/task.pp
+++ b/modules/govuk_env_sync/manifests/task.pp
@@ -100,7 +100,7 @@ define govuk_env_sync::task(
 
   $synccommand = shellquote([
     '/usr/bin/ionice','-c','2','-n','6',
-    '/usr/local/bin/with_reboot_lock',
+    '/usr/local/bin/with_reboot_lock', "env-sync_${title}",
     '/usr/bin/envdir',"${govuk_env_sync::conf_dir}/env.d",
     '/usr/local/bin/govuk_env_sync.sh','-f',"${govuk_env_sync::conf_dir}/${title}.cfg",
     ])

--- a/modules/govuk_jenkins/templates/jobs/copy_data_from_staging_to_aws.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_from_staging_to_aws.yaml.erb
@@ -48,7 +48,7 @@
             set +e
 
             echo "Running Data Sync"
-            /usr/local/bin/with_reboot_lock bash sync staging aws-staging
+            /usr/local/bin/with_reboot_lock env-sync-and-backup_Copy_Data_to_Staging bash sync staging aws-staging
             EXITCODE=$?
 
             exit $EXITCODE

--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_integration.yaml.erb
@@ -51,7 +51,7 @@
             sed -i "s/PG_TR_DST_ENV_SYNC_PW=PLACEHOLDER/PG_TR_DST_ENV_SYNC_PW='<%= @pg_tr_dst_env_sync_pw %>'/" scripts/sync-transition-postgresql.sh
 
             echo "Syncing data"
-            /usr/local/bin/with_reboot_lock bash sync production integration
+            /usr/local/bin/with_reboot_lock env-sync-and-backup_Copy_Data_to_Integration bash sync production integration
     publishers:
       - trigger-parameterized-builds:
         - project: Success_Passive_Check

--- a/modules/govuk_jenkins/templates/jobs/copy_data_to_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/copy_data_to_staging.yaml.erb
@@ -50,7 +50,7 @@
             set +e
 
             echo "Running Data Sync"
-            /usr/local/bin/with_reboot_lock bash sync production staging
+            /usr/local/bin/with_reboot_lock env-sync-and-backup_Copy_Data_to_Staging bash sync production staging
             EXITCODE=$?
 
             exit $EXITCODE

--- a/modules/govuk_unattended_reboot/templates/usr/local/bin/with_reboot_lock.erb
+++ b/modules/govuk_unattended_reboot/templates/usr/local/bin/with_reboot_lock.erb
@@ -3,7 +3,7 @@
 set -eu
 
 lock_file_name="$1"
-lock_file="<%= @lock_dir %>/$lock_file_name"
+lock_file="<%= @lock_dir %>/reboot_lock-${lock_file_name}"
 
 function lock() {
   while [ -f $lock_file ]; do

--- a/modules/govuk_unattended_reboot/templates/usr/local/bin/with_reboot_lock.erb
+++ b/modules/govuk_unattended_reboot/templates/usr/local/bin/with_reboot_lock.erb
@@ -2,7 +2,8 @@
 
 set -eu
 
-lock_file="<%= @lock_dir %>/reboot_lock"
+lock_file_name="$1"
+lock_file="<%= @lock_dir %>/$lock_file_name"
 
 function lock() {
   while [ -f $lock_file ]; do
@@ -18,5 +19,7 @@ function unlock() {
 
 lock
 trap "unlock" EXIT
+
+shift # Remove the lock file name from the arguments
 
 "${@}"


### PR DESCRIPTION
Previously, the with_reboot_lock script would attempt to create
/etc/unattended-reboot/no-reboot/reboot_lock when it didn't exist. I
think the intention was to avoid the machine from rebooting, but this
also has the effect of serialising anything using this script.

I'm been looking at the use of this for the govuk_env_sync cron
jobs. They don't need to run one after the other, but have been doing
due to this script.

Rather than using a single lock file, have the with_reboot_lock script
take the filename as the first argument. This commit also updates
where this script is used in govuk-puppet.