### PR TITLE
Use the standard HTTP response code when host is unknown.

### DIFF
--- a/modules/govuk/manifests/node/s_backend.pp
+++ b/modules/govuk/manifests/node/s_backend.pp
@@ -32,7 +32,7 @@ class govuk::node::s_backend inherits govuk::node::s_base {
 
   include nginx
 
-  # The catchall vhost throws a 500, except for healthcheck requests.
+  # The catchall vhost throws a 400, except for healthcheck requests.
   nginx::config::vhost::default { 'default': }
 
   # Ensure memcached is available to backend nodes

--- a/modules/govuk/manifests/node/s_calculators_frontend.pp
+++ b/modules/govuk/manifests/node/s_calculators_frontend.pp
@@ -4,7 +4,7 @@ class govuk::node::s_calculators_frontend inherits govuk::node::s_base {
 
   include nginx
 
-  # The catchall vhost throws a 500, except for healthcheck requests.
+  # The catchall vhost throws a 400, except for healthcheck requests.
   nginx::config::vhost::default { 'default': }
 
   @@icinga::check::graphite { "check_nginx_connections_writing_${::hostname}":

--- a/modules/govuk/manifests/node/s_content_store.pp
+++ b/modules/govuk/manifests/node/s_content_store.pp
@@ -8,7 +8,7 @@ class govuk::node::s_content_store inherits govuk::node::s_base {
   # In Staging environment, the content-store app will create its own default
   # vhost
   if ($::aws_environment != 'staging' and $::aws_environment != 'production') {
-    # If we miss all the apps, throw a 500 to be caught by the cache nginx
+    # If we miss all the apps, throw a 400 to be caught by the cache nginx
     nginx::config::vhost::default { 'default': }
   }
 }

--- a/modules/govuk/manifests/node/s_email_alert_api.pp
+++ b/modules/govuk/manifests/node/s_email_alert_api.pp
@@ -22,7 +22,7 @@ class govuk::node::s_email_alert_api inherits govuk::node::s_base {
 
   include nginx
 
-  # The catchall vhost throws a 500, except for healthcheck requests.
+  # The catchall vhost throws a 400, except for healthcheck requests.
   nginx::config::vhost::default { 'default': }
 
   # Ensure memcached is available to backend nodes

--- a/modules/govuk/manifests/node/s_frontend.pp
+++ b/modules/govuk/manifests/node/s_frontend.pp
@@ -9,7 +9,7 @@ class govuk::node::s_frontend inherits govuk::node::s_base {
 
   include nginx
 
-  # The catchall vhost throws a 500, except for healthcheck requests.
+  # The catchall vhost throws a 400, except for healthcheck requests.
   nginx::config::vhost::default { 'default': }
 
   @@icinga::check::graphite { "check_nginx_connections_writing_${::hostname}":

--- a/modules/govuk/manifests/node/s_publishing_api.pp
+++ b/modules/govuk/manifests/node/s_publishing_api.pp
@@ -22,7 +22,7 @@ class govuk::node::s_publishing_api inherits govuk::node::s_base {
 
   include nginx
 
-  # The catchall vhost throws a 500, except for healthcheck requests.
+  # The catchall vhost throws a 400, except for healthcheck requests.
   nginx::config::vhost::default { 'default': }
 
   # Ensure memcached is available to backend nodes

--- a/modules/govuk/manifests/node/s_router_backend.pp
+++ b/modules/govuk/manifests/node/s_router_backend.pp
@@ -9,6 +9,6 @@ class govuk::node::s_router_backend inherits govuk::node::s_base {
 
   include nginx
 
-  # If we miss all the apps, throw a 500 to be caught by the cache nginx
+  # If we miss all the apps, throw a 400 to be caught by the cache nginx
   nginx::config::vhost::default { 'default': }
 }

--- a/modules/govuk/manifests/node/s_search.pp
+++ b/modules/govuk/manifests/node/s_search.pp
@@ -13,7 +13,7 @@ class govuk::node::s_search inherits govuk::node::s_base {
 
   include ::govuk_docker
 
-  # The catchall vhost throws a 500, except for healthcheck requests.
+  # The catchall vhost throws a 400, except for healthcheck requests.
   nginx::config::vhost::default { 'default': }
 
   # Data sync for managed elasticsearch

--- a/modules/govuk/manifests/node/s_whitehall_backend.pp
+++ b/modules/govuk/manifests/node/s_whitehall_backend.pp
@@ -12,7 +12,7 @@ class govuk::node::s_whitehall_backend (
   # Package required in order to use PDFKit
   ensure_packages(['wkhtmltopdf'])
 
-  # The catchall vhost throws a 500, except for healthcheck requests.
+  # The catchall vhost throws a 400, except for healthcheck requests.
   nginx::config::vhost::default { 'default': }
 
   if $sync_mirror {

--- a/modules/govuk/manifests/node/s_whitehall_frontend.pp
+++ b/modules/govuk/manifests/node/s_whitehall_frontend.pp
@@ -9,7 +9,7 @@ class govuk::node::s_whitehall_frontend inherits govuk::node::s_base {
 
   $app_domain = hiera('app_domain')
 
-  # The catchall vhost throws a 500, except for healthcheck requests.
+  # The catchall vhost throws a 400, except for healthcheck requests.
   nginx::config::vhost::default { 'default': }
 
   nginx::config::vhost::redirect { "whitehall.${app_domain}":

--- a/modules/nginx/manifests/config/vhost/default.pp
+++ b/modules/nginx/manifests/config/vhost/default.pp
@@ -8,8 +8,9 @@
 #   Raw Nginx config lines to insert into the vhost config.
 #
 # [*status*]
-#   HTTP response code to return.
-#   Default: 500
+#   HTTP response code to return. This should be 400 according to
+#   https://tools.ietf.org/html/rfc7230#section-5.4
+#   Default: 400
 #
 # [*status_message*]
 #   HTTP response content to return.
@@ -21,7 +22,7 @@
 #
 define nginx::config::vhost::default(
   $extra_config = '',
-  $status = '500',
+  $status = '400',
   $status_message = "'{\"error\": \"Fell through to default vhost\"}\\n'",
   $ssl_certtype = 'wildcard_publishing',
 ) {

--- a/modules/nginx/spec/defines/nginx__config__vhost__default_spec.rb
+++ b/modules/nginx/spec/defines/nginx__config__vhost__default_spec.rb
@@ -4,10 +4,10 @@ describe 'nginx::config::vhost::default', :type => :define do
   let(:title) { 'donkey' }
 
   context 'with no params' do
-    it 'should install a default vhost that 500s' do
+    it 'should install a default vhost that returns 400' do
       is_expected.to contain_nginx__config__site('donkey')
         .with_content(/listen.*\s+default_server;/)
-        .with_content(/return\s+500/)
+        .with_content(/return\s+400/)
     end
   end
 

--- a/modules/nginx/templates/app-default-vhost.conf
+++ b/modules/nginx/templates/app-default-vhost.conf
@@ -12,6 +12,6 @@ server {
   }
 
   location / {
-    return 500 '{"error": "Fell through to default vhost"}\n';
+    return <%= @status %> '{"error": "Fell through to default vhost"}\n';
   }
 }


### PR DESCRIPTION
HTTP servers are supposed to send 400 Bad Request when the Host header has a bad field-value, not 500 Internal Server Error.

The practical reasons for this are:

 * A wrong host header field-value is an error on the part of the client, not the server, so it should be a 400 series response.
* A wrong host header is not a retryable error. The error code needs to indicate that the client should not resubmit the same request without modification.

https://tools.ietf.org/html/rfc7230#section-5.4