### PR TITLE
Set a template id and api key for service-manual-publisher to use gov.uk notify

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -52,6 +52,7 @@ govuk::apps::publisher::email_group_dev: 'govuk-dev@digital.cabinet-office.gov.u
 govuk::apps::publisher::email_group_business: 'publisher-alerts-business@digital.cabinet-office.gov.uk'
 govuk::apps::publisher::email_group_citizen: 'publisher-alerts-citizen@digital.cabinet-office.gov.uk'
 govuk::apps::publisher::email_group_force_publish_alerts: 'mainstream-force-publishing-alerts@digital.cabinet-office.gov.uk'
+govuk::apps::service_manual_publisher::govuk_notify_template_id: "e00e89f5-b622-4dcb-8f30-e6c70231a940"
 govuk::apps::short_url_manager::govuk_notify_template_id: 'e00e89f5-b622-4dcb-8f30-e6c70231a940'
 govuk::apps::specialist_publisher::aws_region: 'eu-west-1'
 govuk::apps::specialist_publisher::aws_s3_bucket_name: 'govuk-production-specialist-publisher-csvs'

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -24,6 +24,7 @@ govuk::apps::content_publisher::govuk_notify_template_id: "112842bb-d8a4-4511-90
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::publisher::run_fact_check_fetcher: false
 govuk::apps::publisher::fact_check_address_format: 'factcheck+staging-{id}@alphagov.co.uk'
+govuk::apps::service_manual_publisher::govuk_notify_template_id: "112842bb-d8a4-4511-90de-57dc5c8f27ec"
 govuk::apps::short_url_manager::instance_name: 'staging'
 govuk::apps::short_url_manager::govuk_notify_template_id: '112842bb-d8a4-4511-90de-57dc5c8f27ec'
 govuk::apps::signon::instance_name: 'staging'

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -50,6 +50,7 @@ govuk::apps::search_api::relevancy_bucket_name: 'govuk-integration-search-releva
 govuk::apps::search_api::sitemaps_bucket_name: 'govuk-integration-sitemaps'
 govuk::apps::search_api::enable_learning_to_rank: true
 govuk::apps::search_api::tensorflow_sagemaker_endpoint: 'govuk-integration-search-ltr-endpoint'
+govuk::apps::service_manual_publisher::govuk_notify_template_id: "759acac6-da53-4a19-b591-b7538c7c39de"
 govuk::apps::short_url_manager::govuk_notify_template_id: "759acac6-da53-4a19-b591-b7538c7c39de"
 govuk::apps::short_url_manager::instance_name: 'integration'
 govuk::apps::signon::instance_name: 'integration'

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -177,6 +177,7 @@ govuk::apps::search_api::sitemaps_bucket_name: 'govuk-production-sitemaps'
 govuk::apps::search_api::tensorflow_sagemaker_endpoint: 'govuk-production-search-ltr-endpoint'
 govuk::apps::search_api::tensorflow_sagemaker_variants: 'hippo,elephant'
 govuk::apps::search_api::enable_learning_to_rank: true
+govuk::apps::service_manual_publisher::govuk_notify_template_id: "e00e89f5-b622-4dcb-8f30-e6c70231a940"
 govuk::apps::short_url_manager::govuk_notify_template_id: "e00e89f5-b622-4dcb-8f30-e6c70231a940"
 govuk::apps::short_url_manager::instance_name: 'production'
 govuk::apps::specialist_publisher::aws_region: 'eu-west-1'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -189,6 +189,7 @@ govuk::apps::search_api::sitemaps_bucket_name: 'govuk-staging-sitemaps'
 govuk::apps::search_api::enable_learning_to_rank: true
 govuk::apps::search_api::tensorflow_sagemaker_endpoint: 'govuk-staging-search-ltr-endpoint'
 govuk::apps::search_api::tensorflow_sagemaker_variants: 'hippo,elephant'
+govuk::apps::service_manual_publisher::govuk_notify_template_id: "112842bb-d8a4-4511-90de-57dc5c8f27ec"
 govuk::apps::short_url_manager::govuk_notify_template_id: "112842bb-d8a4-4511-90de-57dc5c8f27ec"
 govuk::apps::short_url_manager::instance_name: 'staging'
 govuk::apps::short_url_manager::mongodb_nodes: "%{hiera('govuk::apps::asset_manager::mongodb_nodes')}"

--- a/modules/govuk/manifests/apps/service_manual_publisher.pp
+++ b/modules/govuk/manifests/apps/service_manual_publisher.pp
@@ -55,6 +55,12 @@
 #   The http basic auth password when running on integration.
 #   Default: undef
 #
+# [*govuk_notify_api_key*]
+#   The API key used to send email via GOV.UK Notify.
+#
+# [*govuk_notify_template_id*]
+#   The template ID used to send email via GOV.UK Notify.
+#
 class govuk::apps::service_manual_publisher(
   $db_hostname = 'postgresql-primary-1.backend',
   $db_port = undef,
@@ -71,6 +77,8 @@ class govuk::apps::service_manual_publisher(
   $asset_manager_bearer_token = undef,
   $http_username = undef,
   $http_password = undef,
+  $govuk_notify_api_key = undef,
+  $govuk_notify_template_id = undef,
 ) {
 
   include govuk_postgresql::client #installs libpq-dev package needed for pg gem
@@ -109,6 +117,12 @@ class govuk::apps::service_manual_publisher(
     "${title}-HTTP_PASSWORD":
       varname => 'HTTP_PASSWORD',
       value   => $http_password;
+    "${title}-GOVUK_NOTIFY_API_KEY":
+      varname => 'GOVUK_NOTIFY_API_KEY',
+      value   => $govuk_notify_api_key;
+    "${title}-GOVUK_NOTIFY_TEMPLATE_ID":
+      varname => 'GOVUK_NOTIFY_TEMPLATE_ID',
+      value   => $govuk_notify_template_id;
   }
 
   if $secret_key_base != undef {


### PR DESCRIPTION
Required for https://github.com/alphagov/service-manual-publisher/pull/775 (will also need the API key adding to the secrets).

https://trello.com/c/eraJ8WC2/1821-5-service-manual-publisher-use-notify-instead-of-ses