### PR TITLE
Don't manage the release app database on Carrenza

### DIFF
--- a/modules/govuk/manifests/node/s_mysql_master.pp
+++ b/modules/govuk/manifests/node/s_mysql_master.pp
@@ -35,7 +35,6 @@ class govuk::node::s_mysql_master (
   class { [
     'govuk::apps::collections_publisher::db',
     'govuk::apps::contacts::db',
-    'govuk::apps::release::db',
     'govuk::apps::search_admin::db',
     'govuk::apps::signon::db',
     ]:


### PR DESCRIPTION
As the app now runs in AWS. The management of the database in AWS is
donen through Puppet on the db_admin machine.