### PR TITLE
Remove limit prom router discovery to integration

### DIFF
--- a/modules/govuk_prometheus/files/etc/prometheus/prometheus.yml
+++ b/modules/govuk_prometheus/files/etc/prometheus/prometheus.yml
@@ -58,8 +58,6 @@ scrape_configs:
           values: [ running ]
         - name: tag:aws_migration
           values: [ cache ]
-        - name: tag:aws_environment
-          values: [ integration ]
     relabel_configs:
       - source_labels: [__meta_ec2_tag_aws_migration]
         target_label: aws_migration


### PR DESCRIPTION
What
----

We only asked prometheus to discover router apps in integration

We think this is ready for prime time now, so we are removing the restriction

Now Prometheus will discover and scrape all router app instances

How to review
---

Code review

Read https://github.com/alphagov/router/pull/148/