### PR TITLE
[DO NOT MERGE] Remove publishing apps from Carrenza Staging

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -18,21 +18,8 @@ node_class: &node_class
   backend:
     apps:
       - canary-backend
-      - collections-publisher
-      - contacts
-      - content-publisher
-      - content-tagger
-      - hmrc-manuals-api
-      - manuals-publisher
-      - maslow
-      - publisher
-      - search-admin
-      - service-manual-publisher
-      - short-url-manager
       - sidekiq-monitoring
       - signon
-      - specialist-publisher
-      - travel-advice-publisher
 
 govuk::node::s_base::node_apps:
   <<: *node_class


### PR DESCRIPTION
* Removes the relevant publishing app host entries from Carrenza Staging environment.
* This is part of the publishing apps migration.