### PR TITLE
Further drop memory thresholds for the Search API procfile worker

### DIFF
--- a/modules/govuk/manifests/apps/search_api.pp
+++ b/modules/govuk/manifests/apps/search_api.pp
@@ -186,8 +186,8 @@ class govuk::apps::search_api(
 
   govuk::procfile::worker { 'search-api':
     enable_service            => $enable_procfile_worker,
-    memory_warning_threshold  => 1250,
-    memory_critical_threshold => 2000,
+    memory_warning_threshold  => 1000,
+    memory_critical_threshold => 1500,
   }
 
   govuk::procfile::worker { 'search-api-publishing-queue-listener':


### PR DESCRIPTION
This seems to be using up a significant portion of the 4GB of memory
which the machine has. As Sidekiq is in play here, restarting it will
probably free up memory, so have Icinga do that earlier.