### PR TITLE
Improve how the deploy nofile limit is increased for cache machines

### DIFF
--- a/hieradata_aws/class/cache.yaml
+++ b/hieradata_aws/class/cache.yaml
@@ -18,4 +18,4 @@ varnish::environment_ip_prefix: "%{hiera('environment_ip_prefix')}"
 
 # Increase the maximum number of file descriptors usable by the router
 # A file descriptor is used per connection
-govuk::deploy::config: 65536
+govuk::deploy::config::nofile_limit: 65536

--- a/hieradata_aws/class/cache.yaml
+++ b/hieradata_aws/class/cache.yaml
@@ -15,3 +15,7 @@ govuk::apps::router::mongodb_nodes:
   - 'router-backend-3'
 
 varnish::environment_ip_prefix: "%{hiera('environment_ip_prefix')}"
+
+# Increase the maximum number of file descriptors usable by the router
+# A file descriptor is used per connection
+govuk::deploy::config: 65536

--- a/modules/govuk/manifests/deploy/config.pp
+++ b/modules/govuk/manifests/deploy/config.pp
@@ -28,6 +28,14 @@
 # [*csp_report_uri*]
 #   The URI to report any content security policy violations too
 #
+# [*nofile_limit*]
+#   Limit for the number of open files for the deploy domain.
+#   Default: 16384
+#
+# [*nproc_limit*]
+#   Limit for the number of processes for the deploy domain.
+#   Default: 2048
+
 class govuk::deploy::config(
   $asset_root,
   $errbit_environment_name = '',
@@ -36,20 +44,22 @@ class govuk::deploy::config(
   $app_domain,
   $csp_report_only = false,
   $csp_report_uri = undef,
+  $nofile_limit = 16384,
+  $nproc_limit = 2048,
 ){
 
   limits::limits { 'deploy_nofile':
     ensure     => present,
     user       => 'deploy',
     limit_type => 'nofile',
-    both       => 16384,
+    both       => $nofile_limit,
   }
 
   limits::limits { 'deploy_nproc':
     ensure     => present,
     user       => 'deploy',
     limit_type => 'nproc',
-    both       => 2048,
+    both       => $nproc_limit,
   }
 
   file { '/etc/govuk/unicorn.rb':

--- a/modules/govuk/manifests/node/s_cache.pp
+++ b/modules/govuk/manifests/node/s_cache.pp
@@ -48,10 +48,8 @@ class govuk::node::s_cache (
     include router::gor
   }
 
-  # Increase the maximum number of file descriptors usable by the router
-  # A file descriptor is used per connection
   limits::limits { 'deploy_nofile_router':
-    ensure     => present,
+    ensure     => absent,
     user       => 'deploy',
     limit_type => 'nofile',
     both       => 65536,


### PR DESCRIPTION
Rather than having two configuration files with different values for the same parameter, they'll just be one file with the intended value.