### PR TITLE
Change Varnish threading configuration

### DIFF
--- a/modules/varnish/templates/defaults.erb
+++ b/modules/varnish/templates/defaults.erb
@@ -37,10 +37,10 @@ VARNISH_ADMIN_LISTEN_ADDRESS=127.0.0.1
 VARNISH_ADMIN_LISTEN_PORT=6082
 
 # # The minimum number of worker threads to start
-VARNISH_MIN_THREADS=1
+VARNISH_MIN_THREADS=100
 
 # # The Maximum number of worker threads to start
-VARNISH_MAX_THREADS=1000
+VARNISH_MAX_THREADS=5000
 
 # # Idle timeout for worker threads
 VARNISH_THREAD_TIMEOUT=120


### PR DESCRIPTION
Increase the minimum number of threads, with the intention of being
able to handle spikes in traffic more easily.

Increase the max threads value to again hopefully better handle large
spikes in traffic. Note that the documentation I'm reading says 5000
is probably the highest this value should be set to [1].

1: https://book.varnish-software.com/3.0/Tuning.html#number-of-threads