### PR TITLE
Raise router nofile limit

### DIFF
--- a/modules/govuk/files/usr/local/bin/govuk_spinup
+++ b/modules/govuk/files/usr/local/bin/govuk_spinup
@@ -85,6 +85,10 @@ echo "GOVUK_APP_ROOT=${GOVUK_APP_ROOT}"
 echo "GOVUK_APP_RUN=${GOVUK_APP_RUN}"
 echo "GOVUK_APP_LOGROOT=${GOVUK_APP_LOGROOT}"
 
+if [ -n "$GOVUK_APP_ULIMIT_NOFILE" ]; then
+    ulimit -n "$GOVUK_APP_ULIMIT_NOFILE"
+fi
+
 set -x
 exec start-stop-daemon --start \
           --chuid "$GOVUK_USER:$GOVUK_GROUP" \

--- a/modules/govuk/manifests/apps/router.pp
+++ b/modules/govuk/manifests/apps/router.pp
@@ -62,6 +62,9 @@ class govuk::apps::router (
     "${title}-ROUTER_BACKEND_SENTRY_ENVIRONMENT":
       value   => $sentry_environment,
       varname => 'SENTRY_ENVIRONMENT';
+    "${title}-ROUTER_ULIMIT_NOFILE":
+      value   => 65536,
+      varname => 'GOVUK_APP_ULIMIT_NOFILE';
   }
 
   govuk::app { 'router':


### PR DESCRIPTION
The current approaches to this seem to be insufficient, `cat
/proc/.../limits` seems to report 1024.

Increasing the limit is important as the router uses files for TCP
connections, and we want it to be able to handle lots of connections
at once. I copied the value from the s_cache.pp file.

