### PR TITLE
Only run mongodb env_sync tasks on mongo master

### DIFF
--- a/modules/govuk_env_sync/files/govuk_env_sync.sh
+++ b/modules/govuk_env_sync/files/govuk_env_sync.sh
@@ -682,6 +682,11 @@ nagios_code=2
 
 case ${action} in
   push)
+    if [ "${dbms}" == "mongo" ] && [ "$(is_writable_mongo)" != "true" ]; then
+      trap - EXIT # remove the trap, as we do not want to send a nagios message in this case
+      log "This machine is not a mongo master. Skipping."
+      exit
+    fi
     create_tempdir
     create_timestamp
     set_filename


### PR DESCRIPTION
Utilise the same "is_writable_mongo" check for pushes as is currently
used for pulls. This check is scoped only if \$dbms is "mongo.

This will ensure that this task does not run on every one of the mongo
nodes, only on the master.
