### PR TITLE
Disable the Signon data sync complete tasks in AWS

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/data_sync_complete_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/data_sync_complete_staging.yaml.erb
@@ -21,7 +21,7 @@
           artifact-num-to-keep: 5
     builders:
        - shell: |
-           <%- if @signon_domains_to_migrate -%>
+           <%- if !@aws && @signon_domains_to_migrate -%>
            # Fix signon application hostnames
            <%- @signon_domains_to_migrate.each do |domain| -%>
            ssh deploy@$(govuk_node_list -c backend --single-node) 'cd /var/apps/signon && OLD_DOMAIN=<%= domain['old'] -%> NEW_DOMAIN=<%= domain['new'] -%> govuk_setenv signon bundle exec rake applications:migrate_domain'


### PR DESCRIPTION
As the app isn't deployed there yet, it's still running in Carrenza.