### PR TITLE
Increase finder-frontend unicorn workers in Staging

### DIFF
--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -165,6 +165,7 @@ govuk::apps::email_alert_api::email_address_override: 'success@simulator.amazons
 govuk::apps::email_alert_api::email_address_override_whitelist_only: true
 govuk::apps::email_alert_api::delivery_request_threshold: "3000"
 govuk::apps::email_alert_frontend::subscription_management_enabled: true
+govuk::apps::finder_frontend::unicorn_worker_processes: "12"
 govuk::apps::frontend::govuk_notify_template_id: '2844a647-6bf1-4b01-a25c-569d2cc00849'
 govuk::apps::govuk_crawler_worker::disable_during_data_sync: true
 govuk::apps::hmrc_manuals_api::publish_topics: false


### PR DESCRIPTION
For load-testing we are doubling the amount of finder-frontend unicorn workers from 6 to 12 in Staging, as the calculators-frontend machines appear to have ample memory

[Trello](https://trello.com/c/J93Fjhxk/1874-increase-the-unicorn-worker-processes-for-finder-frontend-in-staging)