### PR TITLE
Increase the tcpconns thresholds for the Router

### DIFF
--- a/modules/govuk/manifests/apps/router.pp
+++ b/modules/govuk/manifests/apps/router.pp
@@ -76,8 +76,8 @@ class govuk::apps::router (
     nagios_memory_warning               => 1100,
     nagios_memory_critical              => 2500,
     sentry_dsn                          => $sentry_dsn,
-    local_tcpconns_established_warning  => 150,
-    local_tcpconns_established_critical => 200,
+    local_tcpconns_established_warning  => 1000,
+    local_tcpconns_established_critical => 2000,
   }
 
   # We can't pass `health_check_path` to `govuk::app` because it has the


### PR DESCRIPTION
The file descriptor limit has been increased [1], and there's now some
evidence that the Router can handle 1000+ established connections, so
increase the thresholds to match.

1: a2360becd331fc099389fbcb1c39ff707571a368