### PR TITLE
Increase memory alert thresholds for Staging finder-frontend

### DIFF
--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -165,6 +165,8 @@ govuk::apps::email_alert_api::email_address_override: 'success@simulator.amazons
 govuk::apps::email_alert_api::email_address_override_whitelist_only: true
 govuk::apps::email_alert_api::delivery_request_threshold: "3000"
 govuk::apps::email_alert_frontend::subscription_management_enabled: true
+govuk::apps::finder_frontend::nagios_memory_critical: 4500
+govuk::apps::finder_frontend::nagios_memory_warning: 3500
 govuk::apps::finder_frontend::unicorn_worker_processes: "12"
 govuk::apps::frontend::govuk_notify_template_id: '2844a647-6bf1-4b01-a25c-569d2cc00849'
 govuk::apps::govuk_crawler_worker::disable_during_data_sync: true


### PR DESCRIPTION
These alerts are triggering during load-testing and causing application
restarts.

Upping the warning threshold
2500 => 3500

and critical threshold
3500 => 4500