### PR TITLE
Rate limit specific high-impact Google Apps script

### DIFF
--- a/modules/govuk/templates/node/s_backend_lb/rate-limiting.conf.erb
+++ b/modules/govuk/templates/node/s_backend_lb/rate-limiting.conf.erb
@@ -26,3 +26,14 @@ limit_req_zone $post_limit_req zone=contact:5m rate=6r/m;
 # Return 429 (Too Many Requests) instead of the default 503.
 limit_req_status 429;
 limit_conn_status 429;
+
+# Create a rate limiting zone that handles limiting excessive load from 
+# all Google-App-Script calls.
+map $http_user_agent $script_limit {
+  default "";
+  ~*(Google-Apps-Script) $http_user_agent;
+}
+
+limit_req_zone $script_limit zone=rate:30m rate=10r/s;
+limit_req_zone $script_limit zone=performance:5m rate=5r/s;
+limit_conn_zone $script_limit zone=connections:10m;

--- a/modules/router/templates/rate-limiting.conf.erb
+++ b/modules/router/templates/rate-limiting.conf.erb
@@ -26,3 +26,14 @@ limit_req_zone $post_limit_req zone=contact:5m rate=6r/m;
 # Return 429 (Too Many Requests) instead of the default 503.
 limit_req_status 429;
 limit_conn_status 429;
+
+# Create a rate limiting zone that handles limiting excessive load from
+# all Google-App-Script calls.
+map $http_user_agent $script_limit {
+  default "";
+  ~*(Google-Apps-Script) $http_user_agent;
+}
+
+limit_req_zone $script_limit zone=rate:30m rate=10r/s;
+limit_req_zone $script_limit zone=performance:5m rate=5r/s;
+limit_conn_zone $script_limit zone=connections:10m;


### PR DESCRIPTION
We are seeing spikes of load on the search-api as a specific
GApps script makes up to multiple thousands of requests over a couple of
minutes. The script is using multiple IPs and thus bypassing our
conventional load limiting.

However they all share the same app type in the user agent header, which
allows us to track which requests are being made from this one source.

Unfortunately this event is regular enough that we have decided to take
direct action.

This pull request attempts to create a zone that handles
Google-Apps-Script user agents specifically, to avoid such high spikes
from third parties.

Trello card on search board: https://trello.com/c/4bjhI0QU/1456-investigate-rate-limiting-google-apps-scripts