### PR TITLE
Add DocumentDB Endpoints To AWS Production

### DIFF
--- a/hieradata_aws/class/production/backend.yaml
+++ b/hieradata_aws/class/production/backend.yaml
@@ -1,0 +1,37 @@
+---
+
+govuk::apps::manuals_publisher::mongodb_name: 'govuk_content_production'
+govuk::apps::manuals_publisher::mongodb_nodes:
+  - 'shared-documentdb'
+govuk::apps::manuals_publisher::mongodb_username: "%{hiera('shared_documentdb_user')}"
+govuk::apps::manuals_publisher::mongodb_password: "%{hiera('shared_documentdb_password')}"
+
+govuk::apps::maslow::mongodb_name: 'maslow_production'
+govuk::apps::maslow::mongodb_nodes:
+  - 'shared-documentdb'
+govuk::apps::maslow::mongodb_username: "%{hiera('shared_documentdb_user')}"
+govuk::apps::maslow::mongodb_password: "%{hiera('shared_documentdb_password')}"
+
+govuk::apps::publisher::mongodb_name: 'govuk_content_production'
+govuk::apps::publisher::mongodb_nodes:
+  - 'shared-documentdb'
+govuk::apps::publisher::mongodb_username: "%{hiera('shared_documentdb_user')}"
+govuk::apps::publisher::mongodb_password: "%{hiera('shared_documentdb_password')}"
+
+govuk::apps::short_url_manager::mongodb_name: 'short_url_manager_production'
+govuk::apps::short_url_manager::mongodb_nodes:
+  - 'shared-documentdb'
+govuk::apps::short_url_manager::mongodb_username: "%{hiera('shared_documentdb_user')}"
+govuk::apps::short_url_manager::mongodb_password: "%{hiera('shared_documentdb_password')}"
+
+govuk::apps::specialist_publisher::mongodb_name: 'govuk_content_production'
+govuk::apps::specialist_publisher::mongodb_nodes:
+  - 'shared-documentdb'
+govuk::apps::specialist_publisher::mongodb_username: "%{hiera('shared_documentdb_user')}"
+govuk::apps::specialist_publisher::mongodb_password: "%{hiera('shared_documentdb_password')}"
+
+govuk::apps::travel_advice_publisher::mongodb_name: 'travel_advice_publisher_production'
+govuk::apps::travel_advice_publisher::mongodb_nodes:
+  - 'shared-documentdb'
+govuk::apps::travel_advice_publisher::mongodb_username: "%{hiera('shared_documentdb_user')}"
+govuk::apps::travel_advice_publisher::mongodb_password: "%{hiera('shared_documentdb_password')}"


### PR DESCRIPTION
 These are needed to allow the following apps with Mongo databases to connect
 to DocumentDB after we migrate:
  publisher
  manuals-publisher
  short-url-manager
  specialist-publisher
  hmrc-manuals-api
  maslow
  travel-advice-publisher