### PR TITLE
Silence Icinga warnings in integration on secondary mongo machines.

### DIFF
--- a/modules/govuk_env_sync/files/govuk_env_sync.sh
+++ b/modules/govuk_env_sync/files/govuk_env_sync.sh
@@ -683,19 +683,20 @@ nagios_code=2
 case ${action} in
   push)
     if [ "${dbms}" == "mongo" ] && [ "$(is_writable_mongo)" != "true" ]; then
-      trap - EXIT # remove the trap, as we do not want to send a nagios message in this case
       log "This machine is not a mongo master. Skipping."
-      exit
+    else
+      create_tempdir
+      create_timestamp
+      set_filename
+      "dump_${dbms}"
+      "push_${storagebackend}"
+      remove_tempdir
     fi
-    create_tempdir
-    create_timestamp
-    set_filename
-    "dump_${dbms}"
-    "push_${storagebackend}"
-    remove_tempdir
     ;;
   pull)
-    if [ "$("is_writable_${dbms}")" == 'true' ]; then
+    if [ "$("is_writable_${dbms}")" != "true" ]; then
+      log "${dbms} is not writeable. Skipping."
+    else
       create_tempdir
       "get_timestamp_${storagebackend}"
       set_filename


### PR DESCRIPTION
Icinga has been showing warnings in integration that the various push
and pull jobs managed by `govuk_env_sync` had not run recently enough.

The reason behind this is that the script was exiting whenever a job
tried to run on a non-master database machine, this resulted in the
script never sending a nagios `OK` to Icinga, causing the freshness
warnings to eventually trigger.

This change removes the exit condition and adds some logging, so
when the jobs attempt to run on the non-master machine they just skip
over that machine, and that event is logged, that way a nagios `OK` is
still sent, and the logging makes it obvious why the jobs don't appear
to do anything on a secondary machine, as they cannot without write
access.