### PR TITLE
Revert "Rate limit specific high-impact Google Apps script"

### DIFF
--- a/modules/govuk/templates/node/s_backend_lb/rate-limiting.conf.erb
+++ b/modules/govuk/templates/node/s_backend_lb/rate-limiting.conf.erb
@@ -26,14 +26,3 @@ limit_req_zone $post_limit_req zone=contact:5m rate=6r/m;
 # Return 429 (Too Many Requests) instead of the default 503.
 limit_req_status 429;
 limit_conn_status 429;
-
-# Create a rate limiting zone that handles limiting excessive load from 
-# all Google-App-Script calls.
-map $http_user_agent $script_limit {
-  default "";
-  ~*(Google-Apps-Script) $http_user_agent;
-}
-
-limit_req_zone $script_limit zone=rate:30m rate=10r/s;
-limit_req_zone $script_limit zone=performance:5m rate=5r/s;
-limit_conn_zone $script_limit zone=connections:10m;

--- a/modules/router/templates/rate-limiting.conf.erb
+++ b/modules/router/templates/rate-limiting.conf.erb
@@ -26,14 +26,3 @@ limit_req_zone $post_limit_req zone=contact:5m rate=6r/m;
 # Return 429 (Too Many Requests) instead of the default 503.
 limit_req_status 429;
 limit_conn_status 429;
-
-# Create a rate limiting zone that handles limiting excessive load from
-# all Google-App-Script calls.
-map $http_user_agent $script_limit {
-  default "";
-  ~*(Google-Apps-Script) $http_user_agent;
-}
-
-limit_req_zone $script_limit zone=rate:30m rate=10r/s;
-limit_req_zone $script_limit zone=performance:5m rate=5r/s;
-limit_conn_zone $script_limit zone=connections:10m;


### PR DESCRIPTION
```
Notice: /Stage[main]/Nginx::Config/Exec[nginx_configtest]/returns: nginx: [emerg] limit_req_zone "rate" is already bound to key "$limit_req" in /etc/nginx/conf.d/rate-limiting.conf:43
Notice: /Stage[main]/Nginx::Config/Exec[nginx_configtest]/returns: nginx: configuration file /etc/nginx/nginx.conf test failed
```

I'm not too sure what the needed change is here - is it just changing the "zone=30m" to something else like "ua_zone=30m"?  Reverting for now.

Reverts alphagov/govuk-puppet#10278