### PR TITLE
Reset finder frontend

### DIFF
--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -165,7 +165,6 @@ govuk::apps::email_alert_api::email_address_override: 'success@simulator.amazons
 govuk::apps::email_alert_api::email_address_override_whitelist_only: true
 govuk::apps::email_alert_api::delivery_request_threshold: "3000"
 govuk::apps::email_alert_frontend::subscription_management_enabled: true
-govuk::apps::finder_frontend::unicorn_worker_processes: "12"
 govuk::apps::frontend::govuk_notify_template_id: '2844a647-6bf1-4b01-a25c-569d2cc00849'
 govuk::apps::govuk_crawler_worker::disable_during_data_sync: true
 govuk::apps::hmrc_manuals_api::publish_topics: false

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -165,8 +165,6 @@ govuk::apps::email_alert_api::email_address_override: 'success@simulator.amazons
 govuk::apps::email_alert_api::email_address_override_whitelist_only: true
 govuk::apps::email_alert_api::delivery_request_threshold: "3000"
 govuk::apps::email_alert_frontend::subscription_management_enabled: true
-govuk::apps::finder_frontend::nagios_memory_critical: 4500
-govuk::apps::finder_frontend::nagios_memory_warning: 3500
 govuk::apps::finder_frontend::unicorn_worker_processes: "12"
 govuk::apps::frontend::govuk_notify_template_id: '2844a647-6bf1-4b01-a25c-569d2cc00849'
 govuk::apps::govuk_crawler_worker::disable_during_data_sync: true


### PR DESCRIPTION
During some load-testing we increased the number of unicorn-workers and memory-warning thresholds for finder-frontend in aws-staging. The values will now revert to those set in [common.yaml](https://github.com/alphagov/govuk-puppet/blob/1e952e4187fc41c89c8f97d8a586363ad95d982f/hieradata_aws/common.yaml#L503)

These values were increased in
https://github.com/alphagov/govuk-puppet/pull/10277
https://github.com/alphagov/govuk-puppet/pull/10275

[trello](https://trello.com/c/WdqXwhpH/1864-3-scale-down-staging-after-loadtesting)