### PR TITLE
Manage aptly GPG key through puppet

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -46,6 +46,7 @@ task :check_consistency_between_aws_and_carrenza do
     govuk_containers::frontend::haproxy::wildcard_publishing_key
     govuk_jenkins::config::user_permissions
     govuk_jenkins::packages::sops::apt_mirror_hostname
+    govuk_jenkins::packages::sops::apt_mirror_gpg_key_fingerprint
     govuk_mysql::server::expire_log_days
     govuk_mysql::server::monitoring::master::plaintext_mysql_password
     govuk_mysql::server::monitoring::slave::plaintext_mysql_password
@@ -397,11 +398,14 @@ task :check_consistency_between_aws_and_carrenza do
     govuk::node::s_asset_base::alert_hostname
     govuk::node::s_base::log_remote
     govuk::node::s_gatling::apt_mirror_hostname
+    govuk::node::s_gatling::apt_mirror_gpg_key_fingerprint
     govuk::node::s_gatling::repo
     govuk::node::s_gatling::ssh_public_key
     govuk::node::s_gatling::ssh_private_key
     govuk::node::s_licensing_backend::apt_mirror_hostname
+    govuk::node::s_licensing_backend::apt_mirror_gpg_key_fingerprint
     govuk::node::s_licensing_frontend::apt_mirror_hostname
+    govuk::node::s_licensing_frontend::apt_mirror_gpg_key_fingerprint
     govuk::node::s_postgresql_primary::alert_hostname
     govuk::node::s_transition_db_admin::apt_mirror_hostname
     govuk_bundler::config::service
@@ -424,6 +428,7 @@ task :check_consistency_between_aws_and_carrenza do
     govuk_pgbouncer::admin::rds
     govuk_pgbouncer::db::lb_ip_range
     govuk_splunk::repos::apt_mirror_hostname
+    govuk_splunk::repos::apt_mirror_gpg_key_fingerprint
     govuk_unattended_reboot::alert_hostname
     icinga::client::config::allowed_hosts
     icinga::config::graphite_hostname

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -68,6 +68,7 @@ deployable_applications: &deployable_applications
   travel-advice-publisher: {}
 
 apt_mirror_hostname: 'apt.publishing.service.gov.uk'
+apt_mirror_fingerprint: '3803E444EB0235822AA36A66EC5FE1A937E3ACBB'
 
 apt::apt_update_frequency: 'daily'
 apt::purge_preferences_d: true
@@ -352,6 +353,8 @@ govuk_jenkins::packages::sops::apt_mirror_hostname: "%{hiera('apt_mirror_hostnam
 
 govuk::node::s_api_redis::allowed_api_ip_range: "%{hiera('environment_ip_prefix')}.4.0/24"
 govuk::node::s_api_redis::allowed_backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
+
+govuk::node::s_apt::private_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 govuk::node::s_asset_base::firewall_allow_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -68,7 +68,7 @@ deployable_applications: &deployable_applications
   travel-advice-publisher: {}
 
 apt_mirror_hostname: 'apt.publishing.service.gov.uk'
-apt_mirror_fingerprint: '3803E444EB0235822AA36A66EC5FE1A937E3ACBB'
+apt_mirror_gpg_key_fingerprint: '3803E444EB0235822AA36A66EC5FE1A937E3ACBB'
 
 apt::apt_update_frequency: 'daily'
 apt::purge_preferences_d: true
@@ -97,6 +97,7 @@ apt::sources:
     repos: 'main restricted universe multiverse'
 
 backup::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+backup::repo::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 base::packages::gems:
   ruby-shadow:
@@ -158,6 +159,7 @@ collectd::plugin::tcp::metrics:
   - 'PassiveOpens'
 
 collectd::package::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+collectd::package::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 collectd::plugin::docker::repo: "https://github.com/alphagov/docker-collectd-plugin.git"
 collectd::plugin::docker::commit: "e56ddb84536065786e0a55143faa8c6fc035c119"
 
@@ -206,6 +208,7 @@ filebeat::prospectors:
       application: 'apt'
 
 gdal::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+gdal::repo::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 govuk::apps::asset_manager::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
 govuk::apps::asset_manager::mongodb_nodes:
@@ -331,10 +334,12 @@ govuk::apps::travel_advice_publisher::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::travel_advice_publisher::redis_port: "%{hiera('sidekiq_port')}"
 
 govuk_awscli::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_awscli::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 govuk_beat::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 govuk_ci::agent::gcloud::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_ci::agent::gcloud::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 govuk::deploy::config::app_domain: "%{hiera('app_domain')}"
 govuk::deploy::config::asset_root: "https://assets.%{hiera('app_domain')}"
@@ -343,18 +348,23 @@ govuk::deploy::config::csp_report_uri: https://jhpno0hk6b.execute-api.eu-west-2.
 govuk::deploy::config::website_root: "https://www.%{hiera('app_domain')}"
 
 govuk_gor::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_gor::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 govuk_htpasswd::http_username: "%{hiera('http_username')}"
 
 govuk_jenkins::packages::gcloud::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_jenkins::packages::gcloud::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 govuk_jenkins::packages::govuk_python::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_jenkins::packages::govuk_python::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 govuk_jenkins::packages::terraform::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_jenkins::packages::terraform::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 govuk_jenkins::packages::sops::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_jenkins::packages::sops::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 govuk::node::s_api_redis::allowed_api_ip_range: "%{hiera('environment_ip_prefix')}.4.0/24"
 govuk::node::s_api_redis::allowed_backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 
-govuk::node::s_apt::private_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
+govuk::node::s_apt::private_gpg_key_fingerprint: "%{hiera('apt_mirror_gpg_key_fingerprint')}"
 
 govuk::node::s_asset_base::firewall_allow_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 
@@ -377,8 +387,10 @@ govuk::node::s_backend_lb::assets_carrenza_vhost_aliases:
 govuk::node::s_backend_lb::assets_carrenza_real_ip_header: "True-Client-Ip"
 
 govuk::node::s_db_admin::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk::node::s_db_admin::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 govuk::node::s_graphite::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk::node::s_graphite::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 govuk::node::s_mysql_master::aws_access_key_id: "%{hiera('govuk::node::s_mysql_backup::aws_access_key_id')}"
 govuk::node::s_mysql_master::aws_secret_access_key: "%{hiera('govuk::node::s_mysql_backup::aws_secret_access_key')}"
@@ -391,9 +403,13 @@ govuk::node::s_postgresql_standby::wale_private_gpg_key: "%{hiera('govuk::node::
 govuk::node::s_postgresql_standby::wale_private_gpg_key_fingerprint: "%{hiera('govuk::node::s_postgresql_primary::wale_private_gpg_key_fingerprint')}"
 
 govuk_postgresql::mirror::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_postgresql::mirror::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 govuk_ppa::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_ppa::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 govuk_prometheus::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_prometheus::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 govuk_prometheus_node_exporter::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_prometheus_node_exporter::repo::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 govuk_sshkeys::deployment_keys:
   github.com:
@@ -596,10 +612,12 @@ govuk_containers::frontend::haproxy::wildcard_publishing_key: "%{hiera('wildcard
 
 govuk_docker::version: "17.09.0~ce-0~ubuntu"
 govuk_docker::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_docker::repo::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 govuk_java::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 govuk_jenkins::package::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_jenkins::package::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 govuk_jenkins::config::github_api_uri: "https://api.github.com"
 govuk_jenkins::config::github_web_uri: "https://github.com"
 govuk_jenkins::jobs::deploy_app::app_domain: "%{hiera('app_domain')}"
@@ -705,12 +723,15 @@ govuk_mysql::server::expire_log_days: 3
 govuk_mysql::server::monitoring::master::plaintext_mysql_password: "%{hiera('mysql_nagios')}"
 govuk_mysql::server::monitoring::slave::plaintext_mysql_password: "%{hiera('mysql_nagios')}"
 govuk_mysql::xtrabackup::packages::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_mysql::xtrabackup::packages::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 govuk_postgresql::server::configure_env_sync_user: true
 
 govuk_rabbitmq::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_rabbitmq::repo::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 govuk_rbenv::all::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_rbenv::all::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 govuk_sudo::sudo_conf:
   deploy_docker_image:
@@ -753,6 +774,7 @@ govuk_unattended_reboot::monitoring_basic_auth:
   password: "%{hiera('http_password')}"
 
 grafana::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+grafana::repo::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 grafana::dashboards::app_domain: "%{hiera('app_domain')}"
 grafana::dashboards::machine_suffix_metrics: ''
 grafana::dashboards::application_dashboards:
@@ -1033,6 +1055,7 @@ limits::entries:
     hard: 2048
 
 mongodb::repository::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+mongodb::repository::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 mongodb::server::version: '2.4.9'
 
 monitoring::checks::aws_origin_domain: 'dev.govuk.digital'
@@ -1102,9 +1125,11 @@ monitoring::vpn_gateways::endpoints:
 mysql::client::package_ensure: 'present'
 
 nginx::package::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+nginx::package::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 nginx::package::nginx_version: "1.14.0-1~trusty"
 
 nodejs::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+nodejs::repo::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 nodejs::version: '6.14.3-1nodesource1'
 
 ntp::server_list:
@@ -1126,6 +1151,7 @@ puppet::master::puppetdb_version: '2.0.0-1puppetlabs1'
 puppet::puppetdb::database_password: ''
 
 puppet::repository::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+puppet::repository::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 rabbitmq::delete_guest_user: true
 rabbitmq::config_stomp: true
@@ -1219,7 +1245,9 @@ sidekiq_port: '6379'
 ssh::config::allow_users_enable: true
 
 statsd::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+statsd::repo::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 govuk_unattended_reboot::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_unattended_reboot::repo::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 unattended_reboot::cron_env_vars:
   - 'MAILTO=""'
@@ -1238,3 +1266,4 @@ unattended_upgrades::origins:
 unicornherder::version: '0.1.0'
 
 yarn::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+yarn::repo::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -211,6 +211,7 @@ deployable_applications: &deployable_applications
   whitehall: {}
 
 apt_mirror_hostname: 'apt.publishing.service.gov.uk'
+apt_mirror_fingerprint: '3803E444EB0235822AA36A66EC5FE1A937E3ACBB'
 
 apt::apt_update_frequency: 'daily'
 apt::purge_preferences_d: true
@@ -802,6 +803,7 @@ govuk::node::s_api_redis::allowed_backend_ip_range: "%{hiera('environment_ip_pre
 
 govuk::node::s_apt::apt_service: 'apt'
 govuk::node::s_apt::gemstash_service: 'gemstash'
+govuk::node::s_apt::private_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 govuk::node::s_asset_base::alert_hostname: 'alert'
 govuk::node::s_asset_base::firewall_allow_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -124,6 +124,7 @@ govuk::node::s_base::node_apps:
   <<: *node_class
 
 govuk::node::s_graphite::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk::node::s_graphite::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 govuk_java::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
@@ -211,7 +212,7 @@ deployable_applications: &deployable_applications
   whitehall: {}
 
 apt_mirror_hostname: 'apt.publishing.service.gov.uk'
-apt_mirror_fingerprint: '3803E444EB0235822AA36A66EC5FE1A937E3ACBB'
+apt_mirror_gpg_key_fingerprint: '3803E444EB0235822AA36A66EC5FE1A937E3ACBB'
 
 apt::apt_update_frequency: 'daily'
 apt::purge_preferences_d: true
@@ -240,6 +241,7 @@ apt::sources:
     repos: 'main restricted universe multiverse'
 
 backup::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+backup::repo::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 base::packages::gems:
   ruby-shadow:
@@ -302,6 +304,7 @@ collectd::plugin::tcp::metrics:
   - 'PassiveOpens'
 
 collectd::package::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+collectd::package::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 collectd::plugin::docker::repo: "https://github.com/alphagov/docker-collectd-plugin.git"
 collectd::plugin::docker::commit: "e56ddb84536065786e0a55143faa8c6fc035c119"
 
@@ -354,6 +357,7 @@ filebeat::prospectors:
       application: 'apt'
 
 gdal::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+gdal::repo::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 govuk::apps::asset_manager::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
 govuk::apps::asset_manager::mongodb_nodes:
@@ -758,6 +762,7 @@ govuk::apps::travel_advice_publisher::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::travel_advice_publisher::redis_port: "%{hiera('sidekiq_port')}"
 
 govuk_awscli::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_awscli::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 govuk::apps::content_data_api::db::rds: true
 govuk::apps::content_tagger::db::rds: true
@@ -775,6 +780,7 @@ govuk_pgbouncer::db::lb_ip_range: "%{hiera('environment_ip_prefix')}.0.0/16"
 govuk_beat::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 govuk_ci::agent::gcloud::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_ci::agent::gcloud::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 govuk::deploy::config::app_domain: "%{hiera('app_domain')}"
 govuk::deploy::config::asset_root: "https://assets.%{hiera('app_domain')}"
@@ -786,12 +792,16 @@ govuk::deploy::sync::jenkins_domain: "deploy.%{hiera('app_domain_internal')}"
 govuk::deploy::sync::auth_token: "%{hiera('govuk_jenkins::deploy_all_apps::auth_token')}"
 
 govuk_gor::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_gor::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 govuk_htpasswd::http_username: "%{hiera('http_username')}"
 
 govuk_jenkins::packages::gcloud::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_jenkins::packages::gcloud::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 govuk_jenkins::packages::terraform::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_jenkins::packages::terraform::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 govuk_jenkins::packages::govuk_python::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_jenkins::packages::govuk_python::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 govuk_jenkins::jobs::deploy_app::graphite_host: "graphite.%{hiera('app_domain_internal')}"
 govuk_jenkins::jobs::deploy_app::graphite_port: '443'
@@ -803,7 +813,7 @@ govuk::node::s_api_redis::allowed_backend_ip_range: "%{hiera('environment_ip_pre
 
 govuk::node::s_apt::apt_service: 'apt'
 govuk::node::s_apt::gemstash_service: 'gemstash'
-govuk::node::s_apt::private_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
+govuk::node::s_apt::private_gpg_key_fingerprint: "%{hiera('apt_mirror_gpg_key_fingerprint')}"
 
 govuk::node::s_asset_base::alert_hostname: 'alert'
 govuk::node::s_asset_base::firewall_allow_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
@@ -827,10 +837,12 @@ govuk::node::s_backend_lb::assets_carrenza_vhost_aliases:
 govuk::node::s_backend_lb::assets_carrenza_real_ip_header: "True-Client-Ip"
 
 govuk::node::s_db_admin::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk::node::s_db_admin::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 govuk::node::s_content_data_api_db_admin::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 govuk::node::s_gatling::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk::node::s_gatling::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 govuk::node::s_gatling::repo: 'git@github.com:alphagov/govuk-load-testing.git'
 govuk::node::s_gatling::ssh_public_key: "%{hiera('govuk_jenkins::ssh_key::public_key')}"
 govuk::node::s_gatling::ssh_private_key: "%{hiera('govuk_jenkins::ssh_key::private_key')}"
@@ -838,8 +850,10 @@ govuk::node::s_gatling::ssh_private_key: "%{hiera('govuk_jenkins::ssh_key::priva
 govuk::node::s_graphite::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 govuk::node::s_licensing_backend::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk::node::s_licensing_backend::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 govuk::node::s_licensing_frontend::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk::node::s_licensing_frontend::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 govuk::node::s_mysql_master::aws_access_key_id: "%{hiera('govuk::node::s_mysql_backup::aws_access_key_id')}"
 govuk::node::s_mysql_master::aws_secret_access_key: "%{hiera('govuk::node::s_mysql_backup::aws_secret_access_key')}"
@@ -853,9 +867,13 @@ govuk::node::s_transition_db_admin::apt_mirror_hostname: "%{hiera('apt_mirror_ho
 govuk_bundler::config::service: 'http://gemstash'
 
 govuk_postgresql::mirror::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_postgresql::mirror::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 govuk_prometheus_node_exporter::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_prometheus_node_exporter::repo::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 govuk_prometheus::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_prometheus::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 govuk_ppa::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_ppa::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 govuk_sshkeys::deployment_keys:
   github.com:
@@ -895,8 +913,10 @@ govuk_crawler::site_root: "https://www.%{hiera('app_domain')}"
 
 govuk_docker::version: "17.09.0~ce-0~ubuntu"
 govuk_docker::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_docker::repo::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 govuk_jenkins::package::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_jenkins::package::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 govuk_jenkins::config::github_api_uri: "https://api.github.com"
 govuk_jenkins::config::github_web_uri: "https://github.com"
 govuk_jenkins::jobs::deploy_app::app_domain: "%{hiera('app_domain')}"
@@ -927,12 +947,15 @@ govuk_jenkins::jobs::deploy_lambda_app::lambda_apps:
   - 'email_alert_notifications'
 
 govuk_mysql::xtrabackup::packages::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_mysql::xtrabackup::packages::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 govuk_postgresql::server::configure_env_sync_user: true
 
 govuk_rabbitmq::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_rabbitmq::repo::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 govuk_rbenv::all::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_rbenv::all::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 govuk_sudo::sudo_conf:
   deploy_docker_image:
@@ -957,6 +980,7 @@ govuk_sudo::sudo_conf:
     content: 'ubuntu ALL=(ALL) NOPASSWD:ALL'
 
 govuk_splunk::repos::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_splunk::repos::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 govuk_unattended_reboot::alert_hostname: 'alert'
 govuk_unattended_reboot::enabled: true
@@ -967,6 +991,7 @@ govuk_unattended_reboot::monitoring_basic_auth:
   password: "%{hiera('http_password')}"
 
 grafana::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+grafana::repo::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 grafana::dashboards::app_domain: "%{hiera('app_domain')}"
 grafana::dashboards::machine_suffix_metrics: ''
 grafana::dashboards::application_dashboards:
@@ -1155,6 +1180,7 @@ limits::entries:
 
 mongodb::backup::alert_hostname: 'alert'
 mongodb::repository::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+mongodb::repository::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 mongodb::server::version: '2.4.9'
 
 monitoring::checks::aws_origin_domain: 'dev.govuk.digital'
@@ -1207,9 +1233,11 @@ monitoring::uptime_collector::aws: true
 mysql::client::package_ensure: 'present'
 
 nginx::package::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+nginx::package::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 nginx::package::nginx_version: "1.14.0-1~trusty"
 
 nodejs::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+nodejs::repo::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 nodejs::version: '6.14.3-1nodesource1'
 
 ntp::server_list:
@@ -1228,6 +1256,7 @@ puppet::puppetdb::database_password: ''
 puppet::monitoring::alert_hostname: 'alert'
 
 puppet::repository::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+puppet::repository::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 rabbitmq::delete_guest_user: true
 rabbitmq::config_stomp: true
@@ -1300,7 +1329,9 @@ sidekiq_port: '6379'
 ssh::config::allow_users_enable: true
 
 statsd::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+statsd::repo::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 govuk_unattended_reboot::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_unattended_reboot::repo::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 unattended_reboot::cron_env_vars:
   - 'MAILTO=""'
@@ -1319,3 +1350,4 @@ unattended_upgrades::origins:
 unicornherder::version: '0.1.0'
 
 yarn::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+yarn::repo::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"

--- a/modules/backup/manifests/repo.pp
+++ b/modules/backup/manifests/repo.pp
@@ -7,13 +7,17 @@
 #  [*apt_mirror_hostname*]
 #    The hostname of the local aptly mirror.
 #
+#  [*apt_mirror_gpg_key_fingerprint*]
+#    The fingerprint of the local aptly mirror.
+#
 class backup::repo (
   $apt_mirror_hostname,
+  $apt_mirror_gpg_key_fingerprint,
 ) {
   apt::source { 'duplicity':
     location     => "http://${apt_mirror_hostname}/duplicity",
     release      => $::lsbdistcodename,
     architecture => $::architecture,
-    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+    key          => $apt_mirror_gpg_key_fingerprint,
   }
 }

--- a/modules/collectd/manifests/package.pp
+++ b/modules/collectd/manifests/package.pp
@@ -13,10 +13,14 @@
 # [*apt_mirror_hostname*]
 #   The hostname of the local aptly mirror.
 #
+# [*apt_mirror_gpg_key_fingerprint*]
+#   The fingerprint of the local aptly mirror.
+#
 class collectd::package (
   $collectd_version = '5.8.0.145.gca1cb27-1~trusty',
   $yajl_package = 'libyajl2',
   $apt_mirror_hostname,
+  $apt_mirror_gpg_key_fingerprint,
 ) {
   include govuk_ppa
 
@@ -25,7 +29,7 @@ class collectd::package (
     location     => "http://${apt_mirror_hostname}/collectd",
     release      => $::lsbdistcodename,
     architecture => $::architecture,
-    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+    key          => $apt_mirror_gpg_key_fingerprint,
   }
   # collectd contains only configuration files, which we're overriding anyway
   package { 'collectd':

--- a/modules/gdal/manifests/repo.pp
+++ b/modules/gdal/manifests/repo.pp
@@ -5,13 +5,17 @@
 # [*apt_mirror_hostname*]
 #   Hostname to use for the APT mirror.
 #
+# [*apt_mirror_gpg_key_fingerprint*]
+#   Fingerprint to use for the APT mirror.
+#
 class gdal::repo (
   $apt_mirror_hostname,
+  $apt_mirror_gpg_key_fingerprint,
 ) {
   apt::source { 'gdal':
     location     => "http://${apt_mirror_hostname}/gdal",
     release      => 'stable',
     architecture => $::architecture,
-    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+    key          => $apt_mirror_gpg_key_fingerprint,
   }
 }

--- a/modules/govuk/manifests/node/s_db_admin.pp
+++ b/modules/govuk/manifests/node/s_db_admin.pp
@@ -15,6 +15,7 @@
 #
 class govuk::node::s_db_admin(
   $apt_mirror_hostname,
+  $apt_mirror_gpg_key_fingerprint,
   $mysql_db_host        = undef,
   $mysql_db_password    = undef,
   $mysql_db_user        = undef,
@@ -34,7 +35,7 @@ class govuk::node::s_db_admin(
     release      => 'trusty-mongodb-org-4.1',
     architecture => $::architecture,
     repos        => 'multiverse',
-    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+    key          => $apt_mirror_gpg_key_fingerprint,
   }
 
   apt::source { 'mongodb36':
@@ -42,7 +43,7 @@ class govuk::node::s_db_admin(
     release      => 'trusty-mongodb-org-3.6',
     architecture => $::architecture,
     repos        => 'multiverse',
-    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+    key          => $apt_mirror_gpg_key_fingerprint,
   }
 
   package { 'mongodb-org-shell':

--- a/modules/govuk/manifests/node/s_gatling.pp
+++ b/modules/govuk/manifests/node/s_gatling.pp
@@ -25,12 +25,13 @@
 #  Default = undef
 #
 class govuk::node::s_gatling (
-  $root_dir            = '/usr/local/bin/gatling/results',
-  $repo                = 'https://github.com/alphagov/govuk-load-testing.git',
-  $commit              = 'master',
-  $apt_mirror_hostname = undef,
-  $ssh_public_key      = undef,
-  $ssh_private_key     = undef,
+  $root_dir                       = '/usr/local/bin/gatling/results',
+  $repo                           = 'https://github.com/alphagov/govuk-load-testing.git',
+  $commit                         = 'master',
+  $apt_mirror_hostname            = undef,
+  $apt_mirror_gpg_key_fingerprint = undef,
+  $ssh_public_key                 = undef,
+  $ssh_private_key                = undef,
 ) inherits govuk::node::s_base {
 
   # User used to run Gatling
@@ -93,7 +94,7 @@ class govuk::node::s_gatling (
     release      => 'trusty',
     architecture => $::architecture,
     repos        => 'main',
-    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+    key          => $apt_mirror_gpg_key_fingerprint,
   }
 
   package { 'govuk-gatling':

--- a/modules/govuk/manifests/node/s_graphite.pp
+++ b/modules/govuk/manifests/node/s_graphite.pp
@@ -13,11 +13,15 @@
 #  [*apt_mirror_hostname*]
 #    The hostname of the local aptly mirror.
 #
+#  [*apt_mirror_gpg_key_fingerprint*]
+#    The fingerprint of the local aptly mirror.
+#
 
 class govuk::node::s_graphite (
   $graphite_path = '/opt/graphite',
   $graphite_backup_hour = 23,
   $apt_mirror_hostname,
+  $apt_mirror_gpg_key_fingerprint,
 ) inherits govuk::node::s_base {
   class { 'graphite':
     version                    => '0.9.13',
@@ -122,7 +126,7 @@ class govuk::node::s_graphite (
       location     => "http://${apt_mirror_hostname}/whisper-backup",
       release      => $::lsbdistcodename,
       architecture => $::architecture,
-      key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+      key          => $apt_mirror_gpg_key_fingerprint,
     }
 
     package { 'whisper-backup':

--- a/modules/govuk/manifests/node/s_licensing_backend.pp
+++ b/modules/govuk/manifests/node/s_licensing_backend.pp
@@ -7,8 +7,12 @@
 # [*apt_mirror_hostname*]
 #   The hostname of the local aptly mirror.
 #
+# [*apt_mirror_gpg_key_fingerprint*]
+#   The fingerprint of the local aptly mirror.
+#
 class govuk::node::s_licensing_backend (
   $apt_mirror_hostname,
+  $apt_mirror_gpg_key_fingerprint,
 ) inherits govuk::node::s_base {
   include clamav
 
@@ -38,7 +42,7 @@ class govuk::node::s_licensing_backend (
     release      => 'trusty-mongodb-org-4.1',
     architecture => $::architecture,
     repos        => 'multiverse',
-    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+    key          => $apt_mirror_gpg_key_fingerprint,
   }
 
   apt::source { 'mongodb36':
@@ -46,7 +50,7 @@ class govuk::node::s_licensing_backend (
     release      => 'trusty-mongodb-org-3.6',
     architecture => $::architecture,
     repos        => 'multiverse',
-    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+    key          => $apt_mirror_gpg_key_fingerprint,
   }
 
   package { 'mongodb-org-shell':

--- a/modules/govuk/manifests/node/s_licensing_frontend.pp
+++ b/modules/govuk/manifests/node/s_licensing_frontend.pp
@@ -7,8 +7,12 @@
 # [*apt_mirror_hostname*]
 #   The hostname of the local aptly mirror.
 #
+# [*apt_mirror_gpg_key_fingerprint*]
+#   The fingerprint of the local aptly mirror.
+#
 class govuk::node::s_licensing_frontend (
   $apt_mirror_hostname,
+  $apt_mirror_gpg_key_fingerprint,
 ) inherits govuk::node::s_base {
   include clamav
 
@@ -36,7 +40,7 @@ class govuk::node::s_licensing_frontend (
     release      => 'trusty-mongodb-org-4.1',
     architecture => $::architecture,
     repos        => 'multiverse',
-    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+    key          => $apt_mirror_gpg_key_fingerprint,
   }
 
   apt::source { 'mongodb36':
@@ -44,7 +48,7 @@ class govuk::node::s_licensing_frontend (
     release      => 'trusty-mongodb-org-3.6',
     architecture => $::architecture,
     repos        => 'multiverse',
-    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+    key          => $apt_mirror_gpg_key_fingerprint,
   }
 
   package { 'mongodb-org-shell':

--- a/modules/govuk_awscli/manifests/init.pp
+++ b/modules/govuk_awscli/manifests/init.pp
@@ -7,8 +7,12 @@
 # [*apt_mirror_hostname*]
 #   The hostname of the Apt mirror containing the awscli repo
 #
+# [*apt_mirror_gpg_key_fingerprint*]
+#   The fingerprint of the Apt mirror containing the awscli repo
+#
 class govuk_awscli (
   $apt_mirror_hostname,
+  $apt_mirror_gpg_key_fingerprint,
 )
 {
   apt::source { 'awscli':
@@ -16,7 +20,7 @@ class govuk_awscli (
     location     => "http://${apt_mirror_hostname}/awscli",
     release      => $::lsbdistcodename,
     architecture => $::architecture,
-    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+    key          => $apt_mirror_gpg_key_fingerprint,
   }
 
   package { 'awscli':

--- a/modules/govuk_ci/manifests/agent/gcloud.pp
+++ b/modules/govuk_ci/manifests/agent/gcloud.pp
@@ -7,14 +7,18 @@
 # [*apt_mirror_hostname*]
 #   The hostname of an APT mirror
 #
+# [*apt_mirror_gpg_key_fingerprint*]
+#   The fingerprint of an APT mirror
+#
 class govuk_ci::agent::gcloud (
   $apt_mirror_hostname,
+  $apt_mirror_gpg_key_fingerprint,
 ){
   apt::source { 'google-cloud-sdk-trusty':
     location     => "http://${apt_mirror_hostname}/google-cloud-sdk-trusty",
     release      => 'stable',
     architecture => $::architecture,
-    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+    key          => $apt_mirror_gpg_key_fingerprint,
   }
 
   package { 'google-cloud-sdk':

--- a/modules/govuk_docker/manifests/repo.pp
+++ b/modules/govuk_docker/manifests/repo.pp
@@ -5,14 +5,18 @@
 # [*apt_mirror_hostname*]
 #   Hostname to use for the APT mirror.
 #
+# [*apt_mirror_gpg_key_fingerprint*]
+#   Fingerprint to use for the APT mirror.
+#
 class govuk_docker::repo (
   $apt_mirror_hostname,
+  $apt_mirror_gpg_key_fingerprint,
 ) {
   apt::source { 'docker':
     location     => "http://${apt_mirror_hostname}/docker",
     release      => $::lsbdistcodename,
     architecture => $::architecture,
     repos        => 'stable',
-    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+    key          => $apt_mirror_gpg_key_fingerprint,
   }
 }

--- a/modules/govuk_gor/manifests/init.pp
+++ b/modules/govuk_gor/manifests/init.pp
@@ -7,6 +7,9 @@
 # [*apt_mirror_hostname*]
 #   Hostname of the APT mirror to install Gor from
 #
+# [*apt_mirror_gpg_key_fingerprint*]
+#   Fingerprint of the APT mirror to install Gor from
+#
 # [*args*]
 #   Command-line arguments to pass to Gor executable, defaults to an empty hash
 #
@@ -29,11 +32,12 @@ class govuk_gor(
   $binary_path = '/usr/local/bin/goreplay',
   $envvars = {},
   $apt_mirror_hostname,
+  $apt_mirror_gpg_key_fingerprint,
 ) {
 
   apt::source { 'gor':
     location     => "http://${apt_mirror_hostname}/gor",
-    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+    key          => $apt_mirror_gpg_key_fingerprint,
     architecture => $::architecture,
   }
 

--- a/modules/govuk_jenkins/manifests/package.pp
+++ b/modules/govuk_jenkins/manifests/package.pp
@@ -8,6 +8,10 @@
 #   The hostname for the apt mirror to add to enable fetching specific
 #   packages
 #
+# [*apt_mirror_gpg_key_fingerprint*]
+#   The fingerprint for the apt mirror to add to enable fetching specific
+#   packages
+#
 # [*version*]
 #   Specify the version of Jenkins you wish to install
 #
@@ -19,6 +23,7 @@
 #
 class govuk_jenkins::package (
   $apt_mirror_hostname,
+  $apt_mirror_gpg_key_fingerprint,
   $version = $govuk_jenkins::version,
   $config  = {},
   $plugins = {},
@@ -32,7 +37,7 @@ class govuk_jenkins::package (
     location     => "http://${apt_mirror_hostname}/govuk-jenkins",
     release      => 'stable',
     architecture => $::architecture,
-    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+    key          => $apt_mirror_gpg_key_fingerprint,
   }
 
   class { 'govuk_java::set_defaults':

--- a/modules/govuk_jenkins/manifests/packages/gcloud.pp
+++ b/modules/govuk_jenkins/manifests/packages/gcloud.pp
@@ -7,15 +7,19 @@
 # [*apt_mirror_hostname*]
 #   The hostname of an APT mirror
 #
+# [*apt_mirror_gpg_key_fingerprint*]
+#   The fingerprint of an APT mirror
+#
 class govuk_jenkins::packages::gcloud (
   $apt_mirror_hostname,
+  $apt_mirror_gpg_key_fingerprint,
 ){
 
   apt::source { 'google-cloud-sdk-trusty':
     location     => "http://${apt_mirror_hostname}/google-cloud-sdk-trusty",
     release      => 'stable',
     architecture => $::architecture,
-    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+    key          => $apt_mirror_gpg_key_fingerprint,
   }
 
   package { ['kubectl', 'google-cloud-sdk']:

--- a/modules/govuk_jenkins/manifests/packages/govuk_python.pp
+++ b/modules/govuk_jenkins/manifests/packages/govuk_python.pp
@@ -7,18 +7,22 @@
 # [*apt_mirror_hostname*]
 #   The hostname of an APT mirror
 #
+# [*apt_mirror_gpg_key_fingerprint*]
+#   The fingerprint of an APT mirror
+#
 class govuk_jenkins::packages::govuk_python (
   $govuk_python_version = '2.7.14',
   $govuk_python_setuptools_version = '39.0.1',
   $govuk_python_pip_version = '10.0.1',
   $apt_mirror_hostname,
+  $apt_mirror_gpg_key_fingerprint,
 ){
 
   apt::source { 'govuk-python':
     location     => "http://${apt_mirror_hostname}/govuk-python",
     release      => 'stable',
     architecture => $::architecture,
-    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+    key          => $apt_mirror_gpg_key_fingerprint,
   }
 
   package { 'govuk-python':

--- a/modules/govuk_jenkins/manifests/packages/sops.pp
+++ b/modules/govuk_jenkins/manifests/packages/sops.pp
@@ -7,16 +7,20 @@
 # [*apt_mirror_hostname*]
 #   The hostname of an APT mirror
 #
+# [*apt_mirror_gpg_key_fingerprint*]
+#   The fingerprint of an APT mirror
+#
 class govuk_jenkins::packages::sops (
   $version = '3.0.2',
   $apt_mirror_hostname,
+  $apt_mirror_gpg_key_fingerprint,
 ){
 
   apt::source { 'sops':
     location     => "http://${apt_mirror_hostname}/sops",
     release      => 'stable',
     architecture => $::architecture,
-    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+    key          => $apt_mirror_gpg_key_fingerprint,
   }
 
   package { 'sops':

--- a/modules/govuk_jenkins/manifests/packages/terraform.pp
+++ b/modules/govuk_jenkins/manifests/packages/terraform.pp
@@ -7,16 +7,20 @@
 # [*apt_mirror_hostname*]
 #   The hostname of an APT mirror
 #
+# [*apt_mirror_gpg_key_fingerprint*]
+#   The fingerprint of an APT mirror
+#
 class govuk_jenkins::packages::terraform (
   $version = '0.11.14',
   $apt_mirror_hostname,
+  $apt_mirror_gpg_key_fingerprint,
 ){
 
   apt::source { 'terraform':
     location     => "http://${apt_mirror_hostname}/terraform",
     release      => $::lsbdistcodename,
     architecture => $::architecture,
-    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+    key          => $apt_mirror_gpg_key_fingerprint,
   }
 
   package { 'terraform':

--- a/modules/govuk_mysql/manifests/xtrabackup/packages.pp
+++ b/modules/govuk_mysql/manifests/xtrabackup/packages.pp
@@ -5,8 +5,12 @@
 # [*apt_mirror_hostname*]
 #   The hostname of an APT mirror
 #
+# [*apt_mirror_gpg_key_fingerprint*]
+#   The fingerprint of an APT mirror
+#
 class govuk_mysql::xtrabackup::packages (
   $apt_mirror_hostname,
+  $apt_mirror_gpg_key_fingerprint,
 ) {
   package { 'xtrabackup':
     ensure  => present,
@@ -28,7 +32,7 @@ class govuk_mysql::xtrabackup::packages (
     location     => "http://${apt_mirror_hostname}/percona",
     release      => $::lsbdistcodename,
     architecture => $::architecture,
-    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+    key          => $apt_mirror_gpg_key_fingerprint,
   }
 
   package { 'qpress':
@@ -39,7 +43,7 @@ class govuk_mysql::xtrabackup::packages (
     location     => "http://${apt_mirror_hostname}/gof3r",
     release      => $::lsbdistcodename,
     architecture => $::architecture,
-    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+    key          => $apt_mirror_gpg_key_fingerprint,
   }
 
   package { 'gof3r':

--- a/modules/govuk_postgresql/manifests/mirror.pp
+++ b/modules/govuk_postgresql/manifests/mirror.pp
@@ -4,13 +4,14 @@
 #
 class govuk_postgresql::mirror (
   $apt_mirror_hostname,
+  $apt_mirror_gpg_key_fingerprint,
 ) {
   if $::lsbdistcodename == 'trusty' {
     apt::source { 'postgresql':
       location     => "http://${apt_mirror_hostname}/postgresql",
       release      => "${::lsbdistcodename}-pgdg",
       architecture => $::architecture,
-      key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+      key          => $apt_mirror_gpg_key_fingerprint,
     }
   }
 }

--- a/modules/govuk_ppa/manifests/init.pp
+++ b/modules/govuk_ppa/manifests/init.pp
@@ -6,6 +6,10 @@
 #   Hostname to use for the APT mirror when setting up our PPA.
 #   Defaults to undefined because `$use_mirror` can be disabled.
 #
+# [*apt_mirror_gpg_key_fingerprint*]
+#   Fingerprint to use for the APT mirror when setting up our PPA.
+#   Defaults to undefined because `$use_mirror` can be disabled.
+#
 # [*path*]
 #   Path that constitutes the last part of the repository. This can be used
 #   to present a different snapshot to an environment, e.g. `integration`
@@ -23,6 +27,7 @@
 #
 class govuk_ppa (
   $apt_mirror_hostname = undef,
+  $apt_mirror_gpg_key_fingerprint = undef,
   $path = 'production',
   $repo_ensure = 'present',
   $use_mirror = true,
@@ -38,7 +43,7 @@ class govuk_ppa (
       ensure       => $repo_ensure,
       location     => "http://${apt_mirror_hostname}/govuk/ppa/${path}",
       architecture => $::architecture,
-      key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+      key          => $apt_mirror_gpg_key_fingerprint,
     }
   } else {
     apt::ppa { 'ppa:gds/govuk':

--- a/modules/govuk_prometheus/manifests/init.pp
+++ b/modules/govuk_prometheus/manifests/init.pp
@@ -4,6 +4,7 @@
 #
 class govuk_prometheus (
   $apt_mirror_hostname,
+  $apt_mirror_gpg_key_fingerprint,
 ) {
 
   include ::nginx
@@ -26,7 +27,7 @@ class govuk_prometheus (
     release      => 'stable',
     architecture => $::architecture,
     repos        => 'main',
-    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+    key          => $apt_mirror_gpg_key_fingerprint,
   }
 
   package { 'prometheus':

--- a/modules/govuk_prometheus_node_exporter/manifests/repo.pp
+++ b/modules/govuk_prometheus_node_exporter/manifests/repo.pp
@@ -10,14 +10,18 @@
 # [*apt_mirror_hostname*]
 #   Hostname to use for the APT mirror.
 #
+# [*apt_mirror_gpg_key_fingerprint*]
+#   Fingerprint to use for the APT mirror.
+#
 class govuk_prometheus_node_exporter::repo (
   $apt_mirror_hostname,
+  $apt_mirror_gpg_key_fingerprint,
 ) {
   apt::source { 'govuk-prometheus-node-exporter':
     location     => "http://${apt_mirror_hostname}/govuk-prometheus-node-exporter",
     release      => 'stable',
     architecture => $::architecture,
     repos        => 'main',
-    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+    key          => $apt_mirror_gpg_key_fingerprint,
   }
 }

--- a/modules/govuk_rabbitmq/manifests/repo.pp
+++ b/modules/govuk_rabbitmq/manifests/repo.pp
@@ -5,13 +5,17 @@
 # [*apt_mirror_hostname*]
 #   Hostname to use for the APT mirror.
 #
+# [*apt_mirror_gpg_key_fingerprint*]
+#   Fingerprint to use for the APT mirror.
+#
 class govuk_rabbitmq::repo (
   $apt_mirror_hostname,
+  $apt_mirror_gpg_key_fingerprint,
 ) {
   apt::source { 'rabbitmq':
     location     => "http://${apt_mirror_hostname}/rabbitmq",
     release      => 'testing',
     architecture => $::architecture,
-    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+    key          => $apt_mirror_gpg_key_fingerprint,
   }
 }

--- a/modules/govuk_rbenv/manifests/all.pp
+++ b/modules/govuk_rbenv/manifests/all.pp
@@ -8,8 +8,12 @@
 # [*apt_mirror_hostname*]
 #   Hostname of the APT mirror to install packages from
 #
+# [*apt_mirror_gpg_key_fingerprint*]
+#   Fingerprint of the APT mirror to install packages from
+#
 class govuk_rbenv::all (
   $apt_mirror_hostname,
+  $apt_mirror_gpg_key_fingerprint,
   $with_foreman = false,
 ) {
   include govuk_rbenv
@@ -18,7 +22,7 @@ class govuk_rbenv::all (
     location     => "http://${apt_mirror_hostname}/rbenv-ruby",
     release      => $::lsbdistcodename,
     architecture => $::architecture,
-    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+    key          => $apt_mirror_gpg_key_fingerprint,
   }
 
   $ruby_versions = [

--- a/modules/govuk_splunk/manifests/repos.pp
+++ b/modules/govuk_splunk/manifests/repos.pp
@@ -11,20 +11,24 @@
 # [*apt_mirror_hostname*]
 #   Hostname to use for the APT mirror.
 #
+# [*apt_mirror_gpg_key_fingerprint*]
+#   Fingerprint to use for the APT mirror.
+#
 class govuk_splunk::repos (
   $apt_mirror_hostname,
+  $apt_mirror_gpg_key_fingerprint,
 ) {
   apt::source { 'splunk':
     location     => "http://${apt_mirror_hostname}/splunk",
     release      => 'stable',
     architecture => $::architecture,
-    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+    key          => $apt_mirror_gpg_key_fingerprint,
   }
 
   apt::source { 'govuk-splunk-configurator':
     location     => "http://${apt_mirror_hostname}/govuk-splunk-configurator",
     release      => 'stable',
     architecture => $::architecture,
-    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+    key          => $apt_mirror_gpg_key_fingerprint,
   }
 }

--- a/modules/govuk_unattended_reboot/manifests/repo.pp
+++ b/modules/govuk_unattended_reboot/manifests/repo.pp
@@ -7,13 +7,17 @@
 # [*apt_mirror_hostname*]
 #   Hostname to use for the APT mirror.
 #
+# [*apt_mirror_gpg_key_fingerprint*]
+#   Fingerprint to use for the APT mirror.
+#
 class govuk_unattended_reboot::repo(
   $apt_mirror_hostname,
+  $apt_mirror_gpg_key_fingerprint,
 ) {
   apt::source { 'locksmithctl':
     location     => "http://${apt_mirror_hostname}/locksmithctl",
     release      => $::lsbdistcodename,
     architecture => $::architecture,
-    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+    key          => $apt_mirror_gpg_key_fingerprint,
   }
 }

--- a/modules/grafana/manifests/repo.pp
+++ b/modules/grafana/manifests/repo.pp
@@ -5,13 +5,17 @@
 # [*apt_mirror_hostname*]
 #   Hostname to use for the APT mirror.
 #
+# [*apt_mirror_gpg_key_fingerprint*]
+#   Fingerprint to use for the APT mirror.
+#
 class grafana::repo (
   $apt_mirror_hostname,
+  $apt_mirror_gpg_key_fingerprint,
 ) {
   apt::source { 'grafana':
     location     => "http://${apt_mirror_hostname}/grafana",
     release      => 'jessie',
     architecture => $::architecture,
-    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+    key          => $apt_mirror_gpg_key_fingerprint,
   }
 }

--- a/modules/mongodb/manifests/repository.pp
+++ b/modules/mongodb/manifests/repository.pp
@@ -8,6 +8,10 @@
 #   Hostname to use for the APT mirror.
 #   Defaults to undefined because `$use_mirror` can be disabled.
 #
+# [*apt_mirror_gpg_key_fingerprint*]
+#   Fingerprint to use for the APT mirror.
+#   Defaults to undefined because `$use_mirror` can be disabled.
+#
 # [*use_mirror*]
 #   Whether to use our mirror of the repo.
 #   Default: true
@@ -15,6 +19,7 @@
 class mongodb::repository(
   $use_mirror = true,
   $apt_mirror_hostname,
+  $apt_mirror_gpg_key_fingerprint,
 ) {
   validate_bool($use_mirror)
   if $use_mirror {
@@ -23,7 +28,7 @@ class mongodb::repository(
       release      => 'dist',
       repos        => '10gen',
       architecture => $::architecture,
-      key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+      key          => $apt_mirror_gpg_key_fingerprint,
     }
 
     apt::source { 'mongodb3.2':
@@ -31,7 +36,7 @@ class mongodb::repository(
       release      => 'trusty-mongodb-org-3.2',
       repos        => 'multiverse',
       architecture => $::architecture,
-      key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+      key          => $apt_mirror_gpg_key_fingerprint,
     }
 
   } else {

--- a/modules/nginx/manifests/package.pp
+++ b/modules/nginx/manifests/package.pp
@@ -4,8 +4,11 @@
 #
 # === Parameters
 #
-#  [*apt_mirror_hostname*]
-#    The hostname of the local aptly mirror.
+# [*apt_mirror_hostname*]
+#   The hostname of the local aptly mirror.
+#
+# [*apt_mirror_gpg_key_fingerprint*]
+#   The fingerprint of the local aptly mirror.
 #
 # [*nginx_version*]
 #   Which version of the nginx package to install. Default: 'present'
@@ -15,6 +18,7 @@
 #
 class nginx::package(
   $apt_mirror_hostname,
+  $apt_mirror_gpg_key_fingerprint,
   $nginx_version             = 'present',
   $nginx_module_perl_version = 'present',
 ) {
@@ -26,7 +30,7 @@ class nginx::package(
     release      => $::lsbdistcodename,
     architecture => $::architecture,
     repos        => 'nginx',
-    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+    key          => $apt_mirror_gpg_key_fingerprint,
   }
 
   if $::lsbdistcodename == 'precise' {
@@ -35,7 +39,7 @@ class nginx::package(
       release      => $::lsbdistcodename,
       architecture => $::architecture,
       repos        => 'nginx',
-      key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+      key          => $apt_mirror_gpg_key_fingerprint,
     }
   }
 

--- a/modules/nodejs/manifests/repo.pp
+++ b/modules/nodejs/manifests/repo.pp
@@ -8,13 +8,17 @@
 # [*apt_mirror_hostname*]
 #   Hostname to use for the APT mirror.
 #
+# [*apt_mirror_gpg_key_fingerprint*]
+#   Fingerprint to use for the APT mirror.
+#
 class nodejs::repo(
   $apt_mirror_hostname,
+  $apt_mirror_gpg_key_fingerprint,
 ) {
   apt::source { 'nodejs':
     location     => "http://${apt_mirror_hostname}/nodejs",
     release      => $::lsbdistcodename,
     architecture => $::architecture,
-    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+    key          => $apt_mirror_gpg_key_fingerprint,
   }
 }

--- a/modules/puppet/manifests/repository.pp
+++ b/modules/puppet/manifests/repository.pp
@@ -8,6 +8,10 @@
 #   Hostname to use for the APT mirror.
 #   Defaults to undefined because `$use_mirror` can be disabled.
 #
+# [*apt_mirror_gpg_key_fingerprint*]
+#   Fingerprint to use for the APT mirror.
+#   Defaults to undefined because `$use_mirror` can be disabled.
+#
 # [*use_mirror*]
 #   Whether to use our own mirror of the PuppetLabs repo. You may want to
 #   temporarily disable this if you're bringing up a new production
@@ -17,6 +21,7 @@
 class puppet::repository(
   $use_mirror = true,
   $apt_mirror_hostname,
+  $apt_mirror_gpg_key_fingerprint,
 ) {
   # This is installed by bootstrapping. `apt::source` takes its place.
   package { 'puppetlabs-release':
@@ -29,7 +34,7 @@ class puppet::repository(
       location     => "http://${apt_mirror_hostname}/puppetlabs-${::lsbdistcodename}",
       release      => $::lsbdistcodename,
       architecture => $::architecture,
-      key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+      key          => $apt_mirror_gpg_key_fingerprint,
     }
   } else {
     apt::source {'puppetlabs':

--- a/modules/statsd/manifests/repo.pp
+++ b/modules/statsd/manifests/repo.pp
@@ -7,13 +7,17 @@
 # [*apt_mirror_hostname*]
 #   Hostname to use for the APT mirror.
 #
+# [*apt_mirror_gpg_key_fingerprint*]
+#   Fingerprint to use for the APT mirror.
+#
 class statsd::repo(
   $apt_mirror_hostname,
+  $apt_mirror_gpg_key_fingerprint,
 ) {
   apt::source { 'statsd':
     location     => "http://${apt_mirror_hostname}/statsd",
     release      => 'stable',
     architecture => $::architecture,
-    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+    key          => $apt_mirror_gpg_key_fingerprint,
   }
 }

--- a/modules/yarn/manifests/repo.pp
+++ b/modules/yarn/manifests/repo.pp
@@ -7,14 +7,18 @@
 # [*apt_mirror_hostname*]
 #   Hostname to use for the APT mirror.
 #
+# [*apt_mirror_gpg_key_fingerprint*]
+#   Fingerprint to use for the APT mirror.
+#
 class yarn::repo(
   $apt_mirror_hostname = undef,
+  $apt_mirror_gpg_key_fingerprint = undef,
 ) {
   apt::source { 'yarn':
     location     => "http://${apt_mirror_hostname}/yarn",
     release      => 'stable',
     architecture => $::architecture,
     repos        => 'main',
-    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+    key          => $apt_mirror_gpg_key_fingerprint,
   }
 }

--- a/spec/fixtures/hieradata/common.yaml
+++ b/spec/fixtures/hieradata/common.yaml
@@ -2,11 +2,13 @@ app_domain: 'environment.example.com'
 app_domain_internal: 'dev.govuk-internal.digital'
 
 apt_mirror_hostname: 'apt.publishing.service.gov.uk'
-apt_mirror_fingerprint: '0000111122223333444455556666777788889999'
+apt_mirror_gpg_key_fingerprint: '0000111122223333444455556666777788889999'
 
 backup::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+backup::repo::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 collectd::package::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+collectd::package::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 collectd::plugin::postgresql::password: 'password'
 
 deployable_applications: &deployable_applications
@@ -14,12 +16,14 @@ deployable_applications: &deployable_applications
   content-store: {}
 
 gdal::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+gdal::repo::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 govuk::apps::router::mongodb_name: ['router']
 govuk::apps::router::mongodb_nodes: ['localhost']
 govuk::apps::authenticating_proxy::mongodb_nodes: ['localhost']
 
 govuk_ci::agent::gcloud::apt_mirror_hostname: 'apt.example.com'
+govuk_ci::agent::gcloud::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 govuk::deploy::config::asset_root: 'http://assets.example.com'
 govuk::deploy::config::website_root: 'http://www.example.com'
@@ -28,8 +32,10 @@ govuk::deploy::sync::jenkins_domain: "jenkins.example.com"
 govuk::deploy::sync::auth_token: "example-auth-token"
 
 govuk::node::s_db_admin::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk::node::s_db_admin::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 govuk::node::s_content_data_api_db_admin::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk::node::s_graphite::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk::node::s_graphite::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 govuk::node::s_logging::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk::node::s_transition_db_admin::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
@@ -43,14 +49,18 @@ govuk_cdnlogs::govuk_monitoring_enabled: false
 govuk_cdnlogs::bouncer_monitoring_enabled: false
 
 govuk_docker::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_docker::repo::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 govuk_gor::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_gor::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 govuk_java::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 
 govuk_awscli::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_awscli::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
-govuk_jenkins::package::apt_mirror_hostname: 'apt.example.com'
+govuk_jenkins::package::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_jenkins::package::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 govuk_jenkins::config::github_api_uri: foo
 govuk_jenkins::github_client_id: bar
@@ -63,31 +73,44 @@ govuk_jenkins::jobs::integration_deploy::applications: *deployable_applications
 govuk_jenkins::jobs::run_rake_task::applications: *deployable_applications
 
 govuk_jenkins::packages::gcloud::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_jenkins::packages::gcloud::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 govuk_jenkins::packages::govuk_python::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_jenkins::packages::govuk_python::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 govuk_jenkins::packages::terraform::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_jenkins::packages::terraform::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 govuk_jenkins::packages::sops::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_jenkins::packages::sops::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 govuk_mysql::xtrabackup::packages::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_mysql::xtrabackup::packages::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 govuk_postgresql::mirror::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_postgresql::mirror::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 govuk_postgresql::server::snakeoil_ssl_certificate: certificate
 govuk_postgresql::server::snakeoil_ssl_key: key
 
 govuk_postgresql::monitoring::password: password
 
 govuk_ppa::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_ppa::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 govuk_prometheus::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_prometheus::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 govuk_prometheus_node_exporter::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_prometheus_node_exporter::repo::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 govuk_rabbitmq::monitoring_password: 'rabbit_monitor'
 govuk_rabbitmq::root_password: 'rabbit_root'
-govuk_rabbitmq::repo::apt_mirror_hostname: 'rabbit_repo'
+govuk_rabbitmq::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_rabbitmq::repo::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 govuk_rbenv::all::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_rbenv::all::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 govuk_sysdig::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk_unattended_reboot::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_unattended_reboot::repo::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 grafana::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+grafana::repo::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 hosts::production::backend::hosts:
   whitehall-backend-1:
@@ -101,17 +124,21 @@ hosts::production::management::hosts:
     ip: '10.1.0.100'
 
 mongodb::repository::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+mongodb::repository::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 mongodb::s3backup::backup::private_gpg_key_fingerprint: 'CB77872D51ADD27CF75BD63CB60B50E6DBE2EAFF'
 
 # FIXME: this has been added to avoid a bug until we move to v3 of the module
 mysql::client::package_ensure: 'present'
 
 nginx::package::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+nginx::package::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 nginx::package::nginx_version: "1.14.0-1~trusty"
 
 nodejs::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+nodejs::repo::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 puppet::repository::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+puppet::repository::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 # if this is true then it conflicts with govuk_rabbit apt management
 rabbitmq::manage_repos: false
@@ -119,6 +146,7 @@ rabbitmq::manage_repos: false
 router::assets_origin::vhost_name: "assets-origin.%{hiera('app_domain')}"
 
 statsd::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+statsd::repo::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 users::pentest_machines: ['foo']
 users::pentest_usernames: ['andre_the_giant']

--- a/spec/fixtures/hieradata/common.yaml
+++ b/spec/fixtures/hieradata/common.yaml
@@ -2,6 +2,7 @@ app_domain: 'environment.example.com'
 app_domain_internal: 'dev.govuk-internal.digital'
 
 apt_mirror_hostname: 'apt.publishing.service.gov.uk'
+apt_mirror_fingerprint: '0000111122223333444455556666777788889999'
 
 backup::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 


### PR DESCRIPTION
The key was, as far as I can tell, manually added to the Carrenza apt-1 machine years ago.  It's not there in AWS.  So, we need to start managing this through puppet.

This PR has two changes:

1. Have s_apt take the key as hiera, and manage the keyring.
2. Change everything which hard-codes the fingerprint to use the one from hiera.

The current private key will need putting into secrets too.

---

[Trello card](https://trello.com/c/Y1Yg59D4/1891-get-aptly-gpg-key-working-in-aws)