### PR TITLE
Install ruby-2.6.6 everywhere

### DIFF
--- a/modules/govuk_rbenv/manifests/all.pp
+++ b/modules/govuk_rbenv/manifests/all.pp
@@ -28,6 +28,7 @@ class govuk_rbenv::all (
   $ruby_versions = [
     '2.6.3',
     '2.6.5',
+    '2.6.6',
     '2.7.0',
   ]
 
@@ -37,7 +38,7 @@ class govuk_rbenv::all (
 
   # These aliases resolve .ruby-version 2.x to an installed Ruby version.
   rbenv::alias { '2.6':
-    to_version => '2.6.5',
+    to_version => '2.6.6',
   }
 
   rbenv::alias { '2.7':


### PR DESCRIPTION
The aptly GPG change worked, so publishing new packages is working again.

---

[Trello card](https://trello.com/c/tUhr4Cw9/1885-3-upgrade-ruby-to-version-266-in-govuk-repos)