### PR TITLE
Fix statsd for govuk-uptime-collector

### DIFF
--- a/modules/monitoring/manifests/uptime_collector.pp
+++ b/modules/monitoring/manifests/uptime_collector.pp
@@ -15,8 +15,8 @@ class monitoring::uptime_collector (
   $environment = '',
   $aws = false,
 ) {
-  exec { 'install statsd into 2.5 rbenv':
-    environment => 'RBENV_VERSION=2.5',
+  exec { 'install statsd into 2.6 rbenv':
+    environment => 'RBENV_VERSION=2.6',
     path        => ['/usr/lib/rbenv/shims', '/usr/local/bin', '/usr/bin', '/bin'],
     command     => 'gem install statsd-ruby',
     unless      => 'gem list -i statsd-ruby',


### PR DESCRIPTION
govuk-uptime-collector is failing to start due to statsd not being available:

    Traceback (most recent call last):
            2: from /usr/local/bin/govuk_uptime_collector:9:in `<main>'
            1: from /usr/lib/rbenv/versions/2.6.6/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
    /usr/lib/rbenv/versions/2.6.6/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require': cannot load such file -- statsd (LoadError)

govuk-uptime-collector was changed to use ruby-2.6 in bc3de06, but this exec wasn't updated.  It must have only been working by coincidence: something else installed statsd in the 2.6 rbenv.

In 5e6fcf8, ruby-2.6 was changed to refer to ruby-2.6.6 from ruby-2.6.5, and this broke.

The same issue happened previously, when govuk-uptime-collector switched from ruby-2.3 to ruby-2.5: 04d97d6.