### PR TITLE
Add email variables to specific env for publisher

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -254,10 +254,6 @@ govuk::apps::manuals_publisher::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::publisher::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
 govuk::apps::publisher::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::publisher::redis_port: "%{hiera('sidekiq_port')}"
-govuk::apps::publisher::email_group_dev: 'govuk-dev@digital.cabinet-office.gov.uk'
-govuk::apps::publisher::email_group_business: 'govuk-dev@digital.cabinet-office.gov.uk'
-govuk::apps::publisher::email_group_citizen: 'govuk-dev@digital.cabinet-office.gov.uk'
-govuk::apps::publisher::email_group_force_publish_alerts: 'test-mainstream-force-publishing-alerts@digital.cabinet-office.gov.uk'
 
 govuk::apps::short_url_manager::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::short_url_manager::redis_port: "%{hiera('sidekiq_port')}"

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -25,6 +25,10 @@ govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::publisher::run_fact_check_fetcher: false
 govuk::apps::publisher::fact_check_address_format: 'factcheck+staging-{id}@alphagov.co.uk'
 govuk::apps::publisher::govuk_notify_template_id: "112842bb-d8a4-4511-90de-57dc5c8f27ec"
+govuk::apps::publisher::email_group_dev: 'mainstream-publisher-notifications-staging@digital.cabinet-office.gov.uk'
+govuk::apps::publisher::email_group_business: 'mainstream-publisher-notifications-staging@digital.cabinet-office.gov.uk'
+govuk::apps::publisher::email_group_citizen: 'mainstream-publisher-notifications-staging@digital.cabinet-office.gov.uk'
+govuk::apps::publisher::email_group_force_publish_alerts: 'mainstream-publisher-notifications-staging@digital.cabinet-office.gov.uk'
 govuk::apps::search_admin::govuk_notify_template_id: '112842bb-d8a4-4511-90de-57dc5c8f27ec'
 govuk::apps::service_manual_publisher::govuk_notify_template_id: "112842bb-d8a4-4511-90de-57dc5c8f27ec"
 govuk::apps::short_url_manager::instance_name: 'staging'

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -535,7 +535,6 @@ govuk::apps::publisher::alert_hostname: 'alert'
 govuk::apps::publisher::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
 govuk::apps::publisher::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::publisher::redis_port: "%{hiera('sidekiq_port')}"
-govuk::apps::publisher::email_group_force_publish_alerts: 'test-mainstream-force-publishing-alerts@digital.cabinet-office.gov.uk'
 
 govuk::apps::short_url_manager::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::short_url_manager::redis_port: "%{hiera('sidekiq_port')}"

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -43,6 +43,10 @@ govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
 govuk::apps::licencefinder::elasticsearch_uri: 'https://vpc-blue-elasticsearch6-domain-uolbxqjhkiqmg5w3gg7gio5sty.eu-west-1.es.amazonaws.com'
 govuk::apps::link_checker_api::govuk_basic_auth_credentials: "%{hiera('http_username')}:%{hiera('http_password')}"
 govuk::apps::publisher::govuk_notify_template_id: "759acac6-da53-4a19-b591-b7538c7c39de"
+govuk::apps::publisher::email_group_dev: 'mainstream-publisher-notifications-integration@digital.cabinet-office.gov.uk'
+govuk::apps::publisher::email_group_business: 'mainstream-publisher-notifications-integration@digital.cabinet-office.gov.uk'
+govuk::apps::publisher::email_group_citizen: 'mainstream-publisher-notifications-integration@digital.cabinet-office.gov.uk'
+govuk::apps::publisher::email_group_force_publish_alerts: 'mainstream-publisher-notifications-integration@digital.cabinet-office.gov.uk'
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-integration'
 govuk::apps::publishing_api::content_api_prototype: true
 govuk::apps::router::sentry_environment: 'integration'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -182,6 +182,10 @@ govuk::apps::publisher::mongodb_nodes: "%{hiera('govuk::apps::asset_manager::mon
 govuk::apps::publisher::mongodb_username: "%{hiera('govuk::apps::asset_manager::mongodb_username')}"
 govuk::apps::publisher::mongodb_password: "%{hiera('govuk::apps::asset_manager::mongodb_password')}"
 govuk::apps::publisher::govuk_notify_template_id: "112842bb-d8a4-4511-90de-57dc5c8f27ec"
+govuk::apps::publisher::email_group_dev: 'mainstream-publisher-notifications-staging@digital.cabinet-office.gov.uk'
+govuk::apps::publisher::email_group_business: 'mainstream-publisher-notifications-staging@digital.cabinet-office.gov.uk'
+govuk::apps::publisher::email_group_citizen: 'mainstream-publisher-notifications-staging@digital.cabinet-office.gov.uk'
+govuk::apps::publisher::email_group_force_publish_alerts: 'mainstream-publisher-notifications-staging@digital.cabinet-office.gov.uk'
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-staging'
 govuk::apps::router::sentry_environment: 'staging'
 govuk::apps::search_admin::govuk_notify_template_id: "112842bb-d8a4-4511-90de-57dc5c8f27ec"


### PR DESCRIPTION
This commit adds environment specific variables for mainstream
publisher's email groups. We only want to allow one email group to be
used per development environment as notify (email provider we're
switching to) has a finite amount of addresses we can use.

I also removed
`govuk::apps::publisher::email_group_force_publish_alerts:
'test-mainstream-force-publishing-alerts@digital.cabinet-office.gov.uk'`
as I'm not sure why it exists as no google group is set up with that
address nor is the address mentioned in the publisher repo.

Trello:
https://trello.com/c/AqUPUuiF/1917-send-publisher-emails-to-a-google-group-in-integration-and-staging