### PR TITLE
Only have one Icinga check for user access

### DIFF
--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -35,3 +35,4 @@ govuk_jenkins::job_builder::jobs:
 govuk_jenkins::jobs::deploy_cdn::enable_slack_notifications: true
 govuk_jenkins::jobs::deploy_puppet::enable_slack_notifications: true
 govuk_jenkins::jobs::validate_published_dns::run_daily: true
+govuk_jenkins::jobs::user_monitor::enable_icinga_check: true

--- a/modules/govuk_jenkins/manifests/jobs/user_monitor.pp
+++ b/modules/govuk_jenkins/manifests/jobs/user_monitor.pp
@@ -10,6 +10,7 @@
 class govuk_jenkins::jobs::user_monitor (
   $github_token = undef,
   $app_domain = hiera('app_domain'),
+  $enable_icinga_check = false,
 ) {
 
   $service_description = 'Check that correct users have access'
@@ -20,8 +21,14 @@ class govuk_jenkins::jobs::user_monitor (
     notify  => Exec['jenkins_jobs_update'];
   }
 
+  $icinga_check_ensure = $enable_icinga_check ? {
+    true  => 'present',
+    false => 'absent'
+  }
+
   @@icinga::passive_check {
     "user_monitor_${::hostname}":
+      ensure              => $icinga_check_ensure,
       service_description => $service_description,
       host_name           => $::fqdn,
       freshness_threshold => 5400, # 90 minutes


### PR DESCRIPTION
Currently when the user monitor disagrees about something, there's an
Icinga check that fails on 3 Icinga instances. Normally it's useful
having Icinga checks in multiple environments for testing, but I think
the user monitor is an annoying exception.

Given the check fails so often, I don't think its worth keeping it
around in all three environments. I've left the Jenkins jobs, as it's
just the Icinga check I wanted to change.