### PR TITLE
Upgrade Mongo to 2.6 In Integration

### DIFF
--- a/modules/mongodb/manifests/repository.pp
+++ b/modules/mongodb/manifests/repository.pp
@@ -31,6 +31,14 @@ class mongodb::repository(
       key          => $apt_mirror_gpg_key_fingerprint,
     }
 
+    apt::source { 'govuk-mongo':
+      location     => "http://${apt_mirror_hostname}/govuk-mongo",
+      release      => 'stable',
+      repos        => 'main',
+      architecture => $::architecture,
+      key          => $apt_mirror_gpg_key_fingerprint,
+    }
+
     apt::source { 'mongodb3.2':
       location     => "http://${apt_mirror_hostname}/mongodb3.2",
       release      => 'trusty-mongodb-org-3.2',

--- a/modules/mongodb/manifests/server.pp
+++ b/modules/mongodb/manifests/server.pp
@@ -37,16 +37,23 @@ class mongodb::server (
   $syncpath = '/var/lib/mongo-sync'
 ) {
 
-  if versioncmp($version, '3.0.0') >= 0 {
-    $service_name = 'mongod'
-    $package_name = 'mongodb-org'
-    $config_filename = '/etc/mongod.conf'
-    $template_name = 'mongod.conf.erb'
-  } else {
+  if $::aws_environment == 'integration' {
     $service_name = 'mongodb'
-    $package_name = 'mongodb-10gen'
+    $package_name = 'govuk-mongo'
     $config_filename = '/etc/mongodb.conf'
     $template_name = 'mongodb.conf'
+  } else {
+    if versioncmp($version, '3.0.0') >= 0 {
+      $service_name = 'mongod'
+      $package_name = 'mongodb-org'
+      $config_filename = '/etc/mongod.conf'
+      $template_name = 'mongod.conf.erb'
+    } else {
+      $service_name = 'mongodb'
+      $package_name = 'mongodb-10gen'
+      $config_filename = '/etc/mongodb.conf'
+      $template_name = 'mongodb.conf'
+    }
   }
 
   validate_bool($development)


### PR DESCRIPTION
Add govuk-mongo 2.6.12 to AWS Integration.
Upgrade Mongo to 2.6.12 from 2.4.9 in AWS Integration only.