### PR TITLE
Upgrade Mongo to 2.6.12 In Carrenza Staging

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -110,6 +110,7 @@ task :check_consistency_between_aws_and_carrenza do
     hosts::production::ip_bouncer
     mongodb::s3backup::backup::s3_bucket
     mongodb::s3backup::backup::s3_bucket_daily
+    mongodb::server::version
 
     govuk::apps::content_tagger::override_search_location
     govuk::apps::hmrc_manuals_api::override_search_location

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -408,5 +408,6 @@ router::nginx::robotstxt: |
 
 mongodb::s3backup::backup::s3_bucket: 'govuk-mongodb-backup-s3-staging'
 mongodb::s3backup::backup::s3_bucket_daily: 'govuk-mongodb-backup-s3-daily-staging'
+mongodb::server::version: '2.6.12'
 
 unattended_reboot::cron_hour: "*"

--- a/modules/mongodb/manifests/server.pp
+++ b/modules/mongodb/manifests/server.pp
@@ -37,7 +37,7 @@ class mongodb::server (
   $syncpath = '/var/lib/mongo-sync'
 ) {
 
-  if $::aws_environment == 'integration' {
+  if ($::aws_environment == 'integration') or ( $::domain == 'backend.staging.publishing.service.gov.uk') {
     $service_name = 'mongodb'
     $package_name = 'govuk-mongo'
     $config_filename = '/etc/mongodb.conf'


### PR DESCRIPTION
Upgrade Mongo from 2.4.9 to 2.6.12 in Carrenza Staging