### PR TITLE
Remove 'Nginx high conn writing - upstream indicator Check'

### DIFF
--- a/modules/govuk/manifests/node/s_bouncer.pp
+++ b/modules/govuk/manifests/node/s_bouncer.pp
@@ -17,15 +17,6 @@ class govuk::node::s_bouncer (
   include govuk::node::s_app_server
   include nginx
 
-  @@icinga::check::graphite { "check_nginx_connections_writing_${::hostname}":
-    target    => "${::fqdn_metrics}.nginx.nginx_connections-writing",
-    warning   => 150,
-    critical  => 250,
-    desc      => 'nginx high conn writing - upstream indicator',
-    host_name => $::fqdn,
-    notes_url => monitoring_docs_url(nginx-high-conn-writing-upstream-indicator-check),
-  }
-
   $warning_threshold = 1.2 * $minimum_request_rate
 
   @@icinga::check::graphite { "check_nginx_requests_${::hostname}":

--- a/modules/govuk/manifests/node/s_cache.pp
+++ b/modules/govuk/manifests/node/s_cache.pp
@@ -120,13 +120,4 @@ class govuk::node::s_cache (
     'allow-cache-clearing-from-all':
       port => 7999;
   }
-
-  @@icinga::check::graphite { "check_nginx_connections_writing_${::hostname}":
-    target    => "${::fqdn_metrics}.nginx.nginx_connections-writing",
-    warning   => 150,
-    critical  => 250,
-    desc      => 'nginx high conn writing - upstream indicator',
-    host_name => $::fqdn,
-    notes_url => monitoring_docs_url(nginx-high-conn-writing-upstream-indicator-check),
-  }
 }

--- a/modules/govuk/manifests/node/s_calculators_frontend.pp
+++ b/modules/govuk/manifests/node/s_calculators_frontend.pp
@@ -7,15 +7,6 @@ class govuk::node::s_calculators_frontend inherits govuk::node::s_base {
   # The catchall vhost throws a 500, except for healthcheck requests.
   nginx::config::vhost::default { 'default': }
 
-  @@icinga::check::graphite { "check_nginx_connections_writing_${::hostname}":
-    target    => "${::fqdn_metrics}.nginx.nginx_connections-writing",
-    warning   => 150,
-    critical  => 250,
-    desc      => 'nginx high conn writing - upstream indicator',
-    host_name => $::fqdn,
-    notes_url => monitoring_docs_url(nginx-high-conn-writing-upstream-indicator-check),
-  }
-
   include ::collectd::plugin::memcached
   class { 'memcached':
     max_memory => '12%',

--- a/modules/govuk/manifests/node/s_frontend.pp
+++ b/modules/govuk/manifests/node/s_frontend.pp
@@ -12,15 +12,6 @@ class govuk::node::s_frontend inherits govuk::node::s_base {
   # The catchall vhost throws a 500, except for healthcheck requests.
   nginx::config::vhost::default { 'default': }
 
-  @@icinga::check::graphite { "check_nginx_connections_writing_${::hostname}":
-    target    => "${::fqdn_metrics}.nginx.nginx_connections-writing",
-    warning   => 150,
-    critical  => 250,
-    desc      => 'nginx high conn writing - upstream indicator',
-    host_name => $::fqdn,
-    notes_url => monitoring_docs_url(nginx-high-conn-writing-upstream-indicator-check),
-  }
-
   include ::collectd::plugin::memcached
   class { 'memcached':
     max_memory => '12%',


### PR DESCRIPTION
It was added for an incident back in 2013 and it doesn't look like we've relied on its existence since then.

This means we can also remove a documentation page about it. See https://github.com/alphagov/govuk-developer-docs/pull/2492 for the original conversation.