### PR TITLE
Remove rubocop-govuk from Jenkins CI

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -524,9 +524,7 @@ govuk_ci::master::pipeline_jobs:
   rack-logstasher: {}
   rails_translation_manager: {}
   router-data: {}
-  rubocop-govuk: {}
   scss-lint-govuk: {}
-  seal: {}
   search-api: {}
   shared_mustache: {}
   slimmer: {}


### PR DESCRIPTION
This is now built with GitHub Actions.