### PR TITLE
Use live URL when draft is missing

### DIFF
--- a/modules/govuk/manifests/node/s_draft_content_store.pp
+++ b/modules/govuk/manifests/node/s_draft_content_store.pp
@@ -10,9 +10,12 @@ class govuk::node::s_draft_content_store() inherits govuk::node::s_base {
   include govuk::node::s_content_store
 
   $app_domain = hiera('app_domain')
+  $app_domain_internal = hiera('app_domain_internal')
 
   govuk_envvar {
     'PLEK_HOSTNAME_PREFIX': value => 'draft-';
     'PLEK_SERVICE_SIGNON_URI': value => "https://signon.${app_domain}";
+    'PLEK_SERVICE_FEEDBACK_URI': value => "https://feedback.${app_domain_internal}";
+    'PLEK_SERVICE_INFO_FRONTEND_URI': value => "https://info-frontend.${app_domain_internal}";
   }
 }


### PR DESCRIPTION
`draft-content-store` sets `PLEK_HOSTNAME_PREFIX` to prepend `draft-` to the
URIs of its dependencies, so that it uses the special "draft" versions
of those dependencies. Two of these dependencies draft-info-frontend and
draft-feedback, have been causing errors since their draft version is
is missing.

To prevent the errors we overridden the URIs to their live
versions in draft-content-store.

Trello card: https://trello.com/c/LNbGiOcM/1898-5-investigate-an-interesting-sentry-error-relating-to-the-router