### PR TITLE
Remove more apps from CI

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -473,10 +473,8 @@ govuk_ci::master::pipeline_jobs:
   govuk-content-schema-test-helpers: {}
   govuk-csp-forwarder: {}
   govuk-dummy_content_store: {}
-  govuk-dependencies: {}
   govuk-developer-docs: {}
   govuk_document_types: {}
-  govuk-docker: {}
   govuk-guix: {}
   govuk-jenkinslib: {}
   govuk_message_queue_consumer: {}

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -460,18 +460,13 @@ govuk_ci::master::pipeline_jobs:
   # Other repositories
   asset_bom_removal-rails: {}
   backdrop-transactions-explorer-collector: {}
-  bulk-merger: {}
   deprecated_columns: {}
   email-alert-monitoring: {}
-  gapy: {}
   gds-api-adapters: {}
-  gds-scala-common: {}
   gds-sso: {}
   gds_zendesk: {}
   govspeak: {}
   govuk-app-deployment: {}
-  govuk-aws: {}
-  govuk_admin_template: {}
   govuk_ab_testing: {}
   govuk_app_config: {}
   govuk-cdn-config: {}
@@ -484,7 +479,6 @@ govuk_ci::master::pipeline_jobs:
   govuk-docker: {}
   govuk-guix: {}
   govuk-jenkinslib: {}
-  govuk-lint: {}
   govuk_message_queue_consumer: {}
   govuk-provisioning: {}
   govuk_publishing_components: {}


### PR DESCRIPTION
- `govuk-aws` is [entirely on GitHub Actions](https://github.com/alphagov/govuk-aws/pull/1286).
- The `bulk-merger` [doesn't have any tests](https://github.com/alphagov/bulk-merger/commit/2f04890e90ab48d39da81106044d4f3688826320).
- The rest of these deletions are archived repos that are no longer deployed.

Follows on from #10315.
