### PR TITLE
Replace a very prominent mention of the Ops Manual

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_puppet.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_puppet.yaml.erb
@@ -24,7 +24,7 @@
         <p style="font-size:18px">
           <strong>You may need to wait up to 30 minutes before your changes will be reflected.</strong><br>
           This job only deploys the latest Puppet code, it doesn't trigger a Puppet run.<br>
-          For more information, refer to the <a href="https://docs.publishing.service.gov.uk/manual/deploy-puppet.html#convergence">'Deploying Puppet' page in the Ops Manual</a>.
+          For more information, read the <a href="https://docs.publishing.service.gov.uk/manual/deploy-puppet.html#convergence">'Deploying Puppet' docs page</a>.
         </p>
     <%- if @auth_token -%>
     auth-token: <%= @auth_token %>


### PR DESCRIPTION
- This has been here for a very long time. Even though it links to the right place - the Developer Docs - the mention of "Ops Manual" threw me off every time.