### PR TITLE
Remove govuk-developer-docs repo from Jenkins CI

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -473,7 +473,6 @@ govuk_ci::master::pipeline_jobs:
   govuk-content-schema-test-helpers: {}
   govuk-csp-forwarder: {}
   govuk-dummy_content_store: {}
-  govuk-developer-docs: {}
   govuk_document_types: {}
   govuk-guix: {}
   govuk-jenkinslib: {}


### PR DESCRIPTION
- It builds with GitHub Actions as of https://github.com/alphagov/govuk-developer-docs/pull/2497.