### PR TITLE
Remove specialist guide pingdom check

### DIFF
--- a/modules/monitoring/manifests/checks/pingdom.pp
+++ b/modules/monitoring/manifests/checks/pingdom.pp
@@ -25,8 +25,6 @@ class monitoring::checks::pingdom (
       check_id => 662465;
     'smart_answer':
       check_id => 489560;
-    'specialist':
-      check_id => 662460;
     'mirror_S3':
       check_id => 2777110;
     'mirror_S3_replica':
@@ -62,13 +60,6 @@ class monitoring::checks::pingdom (
       use                 => 'govuk_high_priority',
       host_name           => $::fqdn,
       service_description => 'Pingdom smartanswers check',
-    }
-
-    icinga::check { 'check_pingdom_specialist':
-      check_command       => 'run_pingdom_specialist_check',
-      use                 => 'govuk_high_priority',
-      host_name           => $::fqdn,
-      service_description => 'Pingdom specialist guides check',
     }
 
     icinga::check { 'check_pingdom_mirror_S3':


### PR DESCRIPTION
This pingdom check was removed as it was checking a URL that was long
redirected and no longer an accurate test that specialist guides are up.
We no longer have the concept of specialist guides with them split
between specialist documents and manuals.