### PR TITLE
Set a prefix for fact check emails in Publisher

### DIFF
--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -29,6 +29,7 @@ govuk::apps::publisher::email_group_dev: 'mainstream-publisher-notifications-sta
 govuk::apps::publisher::email_group_business: 'mainstream-publisher-notifications-staging@digital.cabinet-office.gov.uk'
 govuk::apps::publisher::email_group_citizen: 'mainstream-publisher-notifications-staging@digital.cabinet-office.gov.uk'
 govuk::apps::publisher::email_group_force_publish_alerts: 'mainstream-publisher-notifications-staging@digital.cabinet-office.gov.uk'
+govuk::apps::publisher::fact_check_subject_prefix: 'staging'
 govuk::apps::search_admin::govuk_notify_template_id: '112842bb-d8a4-4511-90de-57dc5c8f27ec'
 govuk::apps::service_manual_publisher::govuk_notify_template_id: "112842bb-d8a4-4511-90de-57dc5c8f27ec"
 govuk::apps::short_url_manager::instance_name: 'staging'

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -47,6 +47,7 @@ govuk::apps::publisher::email_group_dev: 'mainstream-publisher-notifications-int
 govuk::apps::publisher::email_group_business: 'mainstream-publisher-notifications-integration@digital.cabinet-office.gov.uk'
 govuk::apps::publisher::email_group_citizen: 'mainstream-publisher-notifications-integration@digital.cabinet-office.gov.uk'
 govuk::apps::publisher::email_group_force_publish_alerts: 'mainstream-publisher-notifications-integration@digital.cabinet-office.gov.uk'
+govuk::apps::publisher::fact_check_subject_prefix: 'dev'
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-integration'
 govuk::apps::publishing_api::content_api_prototype: true
 govuk::apps::router::sentry_environment: 'integration'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -186,6 +186,7 @@ govuk::apps::publisher::email_group_dev: 'mainstream-publisher-notifications-sta
 govuk::apps::publisher::email_group_business: 'mainstream-publisher-notifications-staging@digital.cabinet-office.gov.uk'
 govuk::apps::publisher::email_group_citizen: 'mainstream-publisher-notifications-staging@digital.cabinet-office.gov.uk'
 govuk::apps::publisher::email_group_force_publish_alerts: 'mainstream-publisher-notifications-staging@digital.cabinet-office.gov.uk'
+govuk::apps::publisher::fact_check_subject_prefix: 'staging'
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-staging'
 govuk::apps::router::sentry_environment: 'staging'
 govuk::apps::search_admin::govuk_notify_template_id: "112842bb-d8a4-4511-90de-57dc5c8f27ec"

--- a/modules/govuk/manifests/apps/publisher.pp
+++ b/modules/govuk/manifests/apps/publisher.pp
@@ -116,6 +116,7 @@ class govuk::apps::publisher(
     $oauth_secret = undef,
     $run_fact_check_fetcher = false,
     $fact_check_address_format = undef,
+    $fact_check_subject_prefix = undef,
     $fact_check_username = undef,
     $fact_check_password = undef,
     $email_group_dev = undef,
@@ -212,6 +213,9 @@ class govuk::apps::publisher(
     "${title}-FACT_CHECK_ADDRESS_FORMAT":
       varname => 'FACT_CHECK_ADDRESS_FORMAT',
       value   => $fact_check_address_format;
+    "${title}-FACT_CHECK_SUBJECT_PREFIX":
+      varname => 'FACT_CHECK_SUBJECT_PREFIX',
+      value   => $fact_check_subject_prefix;
     "${title}-FACT_CHECK_USERNAME":
       varname => 'FACT_CHECK_USERNAME',
       value   => $fact_check_username;


### PR DESCRIPTION
This is blank for production. Integration is set to 'dev' to match current behaviour with reply-to addresses; this is actually the default but being explicit seemed to be preferable.

https://trello.com/c/MR3jrlX2/1878-5-publisher-replace-ses-in-email-receipt-workflow-%F0%9F%8D%90
