### PR TITLE
Add specific rate limiting for licensify

### DIFF
--- a/modules/licensify/manifests/apps/licensify.pp
+++ b/modules/licensify/manifests/apps/licensify.pp
@@ -49,7 +49,15 @@ class licensify::apps::licensify (
   # limit_req_zone can't be used within a server block, so use a
   # conf.d file instead.
   nginx::conf { 'rate-limiting':
-    content => "limit_req_zone \$limit_req zone=licensing:1m rate=1r/s;\n",
+    content => "limit_req_zone \$binary_remote_addr zone=licensing:1m rate=1r/s;\n",
+  }
+
+  nginx::conf { 'real-ip-params':
+    content => "
+      real_ip_header True-Client-Ip;
+      real_ip_recursive on;
+      set_real_ip_from 0.0.0.0/0;
+    ",
   }
 
   govuk::app { 'licensify':

--- a/modules/licensify/manifests/apps/licensify.pp
+++ b/modules/licensify/manifests/apps/licensify.pp
@@ -45,6 +45,13 @@ class licensify::apps::licensify (
     $collectd_process_regex = 'java -Duser.dir=\/data\/vhost\/licensify\..*publishing\.service\.gov\.uk\/licensify-.*'
   }
 
+  # This is for the nginx_extra_config passed in to govuk::app. The
+  # limit_req_zone can't be used within a server block, so use a
+  # conf.d file instead.
+  nginx::conf { 'rate-limiting':
+    content => "limit_req_zone \$limit_req zone=licensing:1m rate=1r/s;\n",
+  }
+
   govuk::app { 'licensify':
     app_type                       => 'procfile',
     port                           => $port,

--- a/modules/licensify/templates/nginx_extra
+++ b/modules/licensify/templates/nginx_extra
@@ -9,3 +9,6 @@ location /api {
   allow all;
   auth_basic off;
 }
+
+limit_req_status 429;
+limit_req zone=licensing burst=40 nodelay;


### PR DESCRIPTION
The TurnitinBot seems to be making a few to many requests, the rate is
overall around 3 to 4 per second, which is seemingly too many for
licensify, but not enough to be caught by the rate limiting on the
cache machines.

Also, because there are currently 9 cache machines, it's hard to rate
limit there, as the limits have to be set per individual machine.

Therefore, do some rate limiting closer too the app, which should be
more effective as there are currently only two licensify-frontend
machines. Set a low limit of 1r/s so that the limit across the two
machines is around 2r/s, but set a large burst queue length of 40 so
that it takes quite a few requests in a short period of time for this
to start taking effect.