### PR TITLE
Add Kelvin Gan to notification email recipients

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -486,6 +486,7 @@ govuk::apps::email_alert_api::email_address_override_whitelist:
   - jennifer.allum@digital.cabinet-office.gov.uk
   - jos.koetsier@digital.cabinet-office.gov.uk
   - kevin.dew@digital.cabinet-office.gov.uk
+  - kelvin.gan@digital.cabinet-office.gov.uk
   - laurent.curau@digital.cabinet-office.gov.uk
   - leanne.cummings@digital.cabinet-office.gov.uk
   - michael.s.walker@digital.cabinet-office.gov.uk


### PR DESCRIPTION
This is needed as a member of the team on GOV.UK working on
email alerts.

https://trello.com/c/Azwahpgq