### PR TITLE
Upgrade Mongo to 2.6 In AWS Staging

### DIFF
--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -331,6 +331,8 @@ licensify::apps::licensify_feed::environment: 'staging'
 licensify::apps::licensify::alert_5xx_warning_rate: 0.1
 licensify::apps::licensify::alert_5xx_critical_rate: 0.15
 
+mongodb::server::version: '2.4.9'
+
 monitoring::checks::aws_origin_domain: "staging.govuk.digital"
 monitoring::checks::whitehall_overdue_check_period: 'inoffice'
 monitoring::checks::sidekiq::enable_signon_check: false

--- a/modules/mongodb/manifests/server.pp
+++ b/modules/mongodb/manifests/server.pp
@@ -37,7 +37,9 @@ class mongodb::server (
   $syncpath = '/var/lib/mongo-sync'
 ) {
 
-  if ($::aws_environment == 'integration') or ( $::domain == 'backend.staging.publishing.service.gov.uk') {
+# This horrible if statement will be deleted once Mongo has been upgraded
+# in all environments
+  if ($::aws_environment == 'integration') or ($::aws_environment == 'staging') or ( $::domain == 'backend.staging.publishing.service.gov.uk') {
     $service_name = 'mongodb'
     $package_name = 'govuk-mongo'
     $config_filename = '/etc/mongodb.conf'


### PR DESCRIPTION
Upgrade Mongo to 2.6.12 from 2.4.9 in AWS Staging only.