### PR TITLE
Remove references to the Smokey calendars feature

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1194,8 +1194,6 @@ monitoring::contacts::slack_icinga_extinfo_cgi_url: "https://alert.%{::aws_envir
 monitoring::checks::smokey::features:
   check_caching:
     feature: caching
-  check_calendars:
-    feature: calendars
   check_contacts:
     feature: contacts
   check_frontend:

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -386,8 +386,6 @@ monitoring::checks::smokey::features:
     feature: caching
   check_calculators:
     feature: calculators
-  check_calendars:
-    feature: calendars
   check_collections:
     feature: collections
   check_contacts:

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -395,8 +395,6 @@ monitoring::checks::smokey::disable_during_data_sync: true
 monitoring::checks::smokey::features:
   check_caching:
     feature: caching
-  check_calendars:
-    feature: calendars
   check_contacts:
     feature: contacts
   check_frontend:


### PR DESCRIPTION
This was merged in to the frontend feature, as that's where the pages
have been moved to [1].

1: https://github.com/alphagov/smokey/pull/664/commits/5fe08bc1ac4bbb2e8f16a2a5a9553a240075a988