### PR TITLE
Add middleman-search to Jenkins portfolio

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -505,6 +505,7 @@ govuk_ci::master::pipeline_jobs:
       - 'integration'
       - 'staging'
       - 'production'
+  middleman-search: {}
   omniauth-gds: {}
   optic14n: {}
   performanceplatform-client.py: {}


### PR DESCRIPTION
This is so that we can publish the middleman-search-gds gem.
Depends on: https://github.com/alphagov/middleman-search/pull/7

This should only be merged if we decide not to proceed with https://github.com/alphagov/middleman-search/pull/6.