### PR TITLE
Retire calendars (step 1)

### DIFF
--- a/development-vm/Pinfile
+++ b/development-vm/Pinfile
@@ -11,7 +11,6 @@ process :backdrop_write
 process :bouncer
 process :'cache-clearing-service'
 process :calculators => [:static, :'content-store']
-process :calendars => [:static, :'content-store']
 process :collections => [:static, :'content-store', :'search-api']
 process :'collections-publisher' => [:'publishing-api', :'collections-publisher-worker', :'link-checker-api']
 process :'collections-publisher-worker'
@@ -51,7 +50,7 @@ process :'manuals-publisher' => [:'asset-manager', :'publishing-api', :'link-che
 process :'manuals-publisher-worker' => [:'publishing-api']
 process :mapit
 process :maslow
-process :publisher => [:'publishing-api', 'publisher-worker', :calendars, :'link-checker-api'] # for some requests also uses: mapit
+process :publisher => [:'publishing-api', 'publisher-worker', :'link-checker-api'] # for some requests also uses: mapit
 process :'publishing-api-read' => [:'publishing-api-web']
 process :'publishing-api' => [:'publishing-api-web', :'content-store', :'draft-content-store', :'router-api', :'draft-router-api', :'publishing-api-worker']
 process :'publishing-api-worker' => [:'content-store', :'router-api']

--- a/development-vm/Procfile
+++ b/development-vm/Procfile
@@ -8,7 +8,7 @@ frontend-worker:       govuk_setenv frontend              ./run_in.sh ../../fron
 # planner used port 3007
 # rummager used port 3009
 smartanswers:          govuk_setenv smartanswers          ./run_in.sh ../../smart-answers  bundle exec rails server -p 3010
-calendars:             govuk_setenv calendars             ./run_in.sh ../../calendars      bundle exec rails server -p 3011
+# calendars used port 3011
 static:                govuk_setenv static                ./run_in.sh ../../static         bundle exec rails server -p 3013
 licencefinder:         govuk_setenv licencefinder         ./run_in.sh ../../licence-finder bundle exec rails server -p 3014
 # migratorator used port 3015

--- a/development-vm/alphagov_repos
+++ b/development-vm/alphagov_repos
@@ -1,7 +1,6 @@
 asset-manager
 cache-clearing-service
 calculators
-calendars
 collections
 collections-publisher
 contacts-admin

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -426,7 +426,6 @@ govuk_ci::master::pipeline_jobs:
   bouncer: {}
   cache-clearing-service: {}
   calculators: {}
-  calendars: {}
   collections: {}
   content-store: {}
   email-alert-api: {}
@@ -623,7 +622,6 @@ govuk_jenkins::jobs::integration_deploy::applications:
   bouncer: {}
   cache-clearing-service: {}
   calculators: {}
-  calendars: {}
   ckan:
     repository: 'ckanext-datagovuk'
   collections: {}

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -153,7 +153,6 @@ deployable_applications: &deployable_applications
   bouncer: {}
   cache-clearing-service: {}
   calculators: {}
-  calendars: {}
   ckan:
     repository: 'ckanext-datagovuk'
   collections: {}
@@ -1002,7 +1001,6 @@ grafana::dashboards::application_dashboards:
   authenticating-proxy: {}
   cache-clearing-service: {}
   calculators: {}
-  calendars: {}
   ckan:
     docs_name: 'ckanext-datagovuk'
     # No data in kibana
@@ -1024,7 +1022,6 @@ grafana::dashboards::application_dashboards:
     has_workers: true
   content-store:
     dependent_app_5xx_errors:
-      - calendars
       - collections
       - contacts
       - email-alert-frontend
@@ -1126,7 +1123,6 @@ grafana::dashboards::application_dashboards:
     has_workers: true
   static:
     dependent_app_5xx_errors:
-      - calendars
       - collections
       - contacts
       - email-alert-frontend
@@ -1269,7 +1265,6 @@ rcs::tmptime: '7'
 router::assets_origin::app_specific_static_asset_routes:
   '/asset-manager': "asset-manager"
   '/calculators/': "calculators"
-  '/calendars/': "calendars"
   '/collections/': "collections"
   '/email-alert-frontend/': "email-alert-frontend"
   '/feedback/': "feedback"

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -186,7 +186,6 @@ grafana::dashboards::application_dashboards:
   authenticating-proxy: {}
   cache-clearing-service: {}
   calculators: {}
-  calendars: {}
   ckan:
     docs_name: 'ckanext-datagovuk'
     # No data in kibana
@@ -211,7 +210,6 @@ grafana::dashboards::application_dashboards:
     has_workers: true
   content-store:
     dependent_app_5xx_errors:
-      - calendars
       - collections
       - contacts
       - email-alert-frontend
@@ -310,7 +308,6 @@ grafana::dashboards::application_dashboards:
     has_workers: true
   static:
     dependent_app_5xx_errors:
-      - calendars
       - collections
       - contacts
       - email-alert-frontend

--- a/modules/govuk/manifests/apps/calendars.pp
+++ b/modules/govuk/manifests/apps/calendars.pp
@@ -29,6 +29,7 @@ class govuk::apps::calendars(
   $app_name = 'calendars'
 
   govuk::app { $app_name:
+    ensure                => 'absent',
     app_type              => 'rack',
     port                  => $port,
     sentry_dsn            => $sentry_dsn,
@@ -36,23 +37,5 @@ class govuk::apps::calendars(
     log_format_is_json    => true,
     asset_pipeline        => true,
     asset_pipeline_prefix => 'calendars',
-  }
-
-  Govuk::App::Envvar {
-    app => $app_name,
-  }
-
-  govuk::app::envvar {
-    "${title}-PUBLISHING_API_BEARER_TOKEN":
-        varname => 'PUBLISHING_API_BEARER_TOKEN',
-        value   => $publishing_api_bearer_token;
-  }
-
-  if $secret_key_base {
-    govuk::app::envvar {
-      "${title}-SECRET_KEY_BASE":
-        varname => 'SECRET_KEY_BASE',
-        value   => $secret_key_base;
-    }
   }
 }


### PR DESCRIPTION
Kibana says the only requests to calendars (since I fixed the routing issue yesterday) are for hotlinked assets, most of which are 404ing anyway.

After this has been deployed and run, tearing down the app on all the machines, the remaining config can be removed.

---

[Trello card](https://trello.com/c/SKT4BnIQ/1953-retire-the-calendars-app-%F0%9F%8D%90)