### PR TITLE
Drop the memory threshold for Search API Sidekiq

### DIFF
--- a/modules/govuk/manifests/apps/search_api.pp
+++ b/modules/govuk/manifests/apps/search_api.pp
@@ -186,7 +186,7 @@ class govuk::apps::search_api(
 
   govuk::procfile::worker { 'search-api':
     enable_service            => $enable_procfile_worker,
-    memory_warning_threshold  => 1000,
+    memory_warning_threshold  => 800,
     memory_critical_threshold => 1500,
   }
 


### PR DESCRIPTION
It's using up a bit too much of the system memory, which is causing
Puppet to fail. This should have Icinga restart it, freeing up enough
memory for Puppet.