### PR TITLE
Don't configure the monitoring machines with Docker

### DIFF
--- a/modules/govuk/manifests/node/s_monitoring.pp
+++ b/modules/govuk/manifests/node/s_monitoring.pp
@@ -18,7 +18,6 @@ class govuk::node::s_monitoring (
   validate_bool($enable_fastly_metrics, $offsite_backups)
 
   include google_chrome
-  include ::govuk_docker
   include govuk_rbenv::all
   include ::selenium
   include ::govuk_cdnlogs


### PR DESCRIPTION
This was only used for Terraboard, which wasn't really used, and
removed in [1]. I doubt Puppet will clean up Docker from the existing
machines, but I'm not to bothered about that.

1: 4ec33f5d8e08d6a0165071b478001b379fbb3356