### PR TITLE
Attempt to disable smokey-loop on the monitoring machines in Carrenza

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -66,6 +66,7 @@ task :check_consistency_between_aws_and_carrenza do
     hosts::production::redirector::hosts
     jenkins_admin_permission_list
     monitoring::checks::sidekiq::enable_support_check
+    monitoring::checks::smokey::ensure
     monitoring::vpn_gateways::endpoints
     postgresql_api_slave_addresses_dr
     postgresql_api_slave_addresses_live
@@ -441,6 +442,7 @@ task :check_consistency_between_aws_and_carrenza do
     monitoring::client::alert_hostname
     monitoring::checks::sidekiq::enable_signon_check
     monitoring::checks::smokey::features
+    monitoring::checks::smokey::disable_during_data_sync
     monitoring::client::graphite_hostname
     monitoring::uptime_collector::aws
     nginx_enable_ssl

--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -150,7 +150,7 @@ monitoring::checks::sidekiq::enable_signon_check: false
 monitoring::checks::pingdom::enable: false
 monitoring::checks::aws_iam_key::region: 'eu-west-1'
 monitoring::checks::smokey::environment: 'integration'
-monitoring::checks::smokey::disable_during_data_sync: true
+monitoring::checks::smokey::ensure: 'absent'
 monitoring::uptime_collector::environment: 'integration'
 monitoring::contacts::slack_username: 'CI'
 

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -350,6 +350,7 @@ monitoring::checks::aws_iam_key::enabled: false
 monitoring::checks::aws_iam_key::region: 'eu-west-1'
 monitoring::checks::aws_iam_key::max_aws_iam_key_age: 90
 monitoring::checks::smokey::environment: 'production'
+monitoring::checks::smokey::ensure: 'absent'
 monitoring::contacts::notify_pager: true
 monitoring::contacts::notify_slack: true
 monitoring::contacts::slack_channel: '#govuk-alerts'

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -347,7 +347,7 @@ monitoring::checks::aws_iam_key::enabled: false
 monitoring::checks::aws_iam_key::region: 'eu-west-1'
 monitoring::checks::aws_iam_key::max_aws_iam_key_age: 90
 monitoring::checks::smokey::environment: 'staging'
-monitoring::checks::smokey::disable_during_data_sync: true
+monitoring::checks::smokey::ensure: 'absent'
 monitoring::uptime_collector::environment: 'staging'
 monitoring::contacts::notify_slack: true
 monitoring::contacts::slack_channel: '#govuk-alerts-staging'

--- a/modules/monitoring/manifests/checks/smokey.pp
+++ b/modules/monitoring/manifests/checks/smokey.pp
@@ -6,12 +6,16 @@
 #
 # === Parameters
 #
+# [*ensure*]
+#   Whether to enable the smokey-loop service.
+#   Default: 'present'
 # [*features*]
 #   A hash of features that should be executed by Icinga.
 # [*environment*]
 #   String to pass to the tests_json_output.sh script, e.g. integration
 #
 class monitoring::checks::smokey (
+  $ensure = 'present',
   $features = {},
   $environment = '',
   $disable_during_data_sync = false,
@@ -23,7 +27,7 @@ class monitoring::checks::smokey (
   include govuk::apps::smokey
 
   user { 'smokey':
-    ensure     => present,
+    ensure     => $ensure,
     name       => 'smokey',
     managehome => true,
     shell      => '/bin/bash',
@@ -31,17 +35,22 @@ class monitoring::checks::smokey (
   }
 
   file { $service_file:
-    ensure  => present,
+    ensure  => $ensure,
     content => template('monitoring/smokey-loop.conf'),
     require => Class['govuk::apps::smokey'],
   }
 
-  if $disable_during_data_sync and $::data_sync_in_progress {
-    $service_ensure = stopped
-    $icinga_ensure = absent
+  if $ensure == 'present' {
+    if $disable_during_data_sync and $::data_sync_in_progress {
+      $service_ensure = stopped
+      $icinga_ensure = absent
+    } else {
+      $service_ensure = running
+      $icinga_ensure = present
+    }
   } else {
-    $service_ensure = running
-    $icinga_ensure = present
+    $service_ensure = absent
+    $icinga_ensure = absent
   }
 
   service { 'smokey-loop':


### PR DESCRIPTION
It's not needed any longer in Carrenza, so it would be useful to turn it off, to avoid any confusion about what it's doing.