### PR TITLE
Fix the $service_ensure value when Smokey is absent

### DIFF
--- a/modules/monitoring/manifests/checks/smokey.pp
+++ b/modules/monitoring/manifests/checks/smokey.pp
@@ -49,7 +49,7 @@ class monitoring::checks::smokey (
       $icinga_ensure = present
     }
   } else {
-    $service_ensure = absent
+    $service_ensure = stopped
     $icinga_ensure = absent
   }
 


### PR DESCRIPTION
This should be either running or stopped.