### PR TITLE
Add AWS Cloudwatch Repo

### DIFF
--- a/modules/govuk/manifests/node/s_apt.pp
+++ b/modules/govuk/manifests/node/s_apt.pp
@@ -122,6 +122,7 @@ class govuk::node::s_apt (
 
   aptly::repo { 'awscli': }
   aptly::repo { 'collectd': }
+  aptly::repo { 'awscloudwatch': }
   aptly::repo { 'elastic-beats': }
   aptly::repo { 'etcdctl': }
   aptly::repo { 'govuk-gatling': }


### PR DESCRIPTION
Cyber would like this installed on the Frontend instances to assist with
more advanced logging. More information about this task is available here:
https://trello.com/c/dEXpyFCD/3492-cyber-cloudwatch-logs-on-frontend-machine

AWS Documentation:
https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Install-CloudWatch-Agent.html