### PR TITLE
Add new unprocessable entity fallback page

### DIFF
--- a/modules/router/manifests/nginx.pp
+++ b/modules/router/manifests/nginx.pp
@@ -129,7 +129,7 @@ class router::nginx (
     require => File['/usr/share/nginx/www'],
   }
 
-  router::errorpage {['400', '403', '404','406','410','500','503','504']:
+  router::errorpage {['400', '403', '404','406','410','422','500','503','504']:
     require => File['/usr/share/nginx/www'],
   }
 

--- a/modules/router/templates/router_include.conf.erb
+++ b/modules/router/templates/router_include.conf.erb
@@ -83,6 +83,7 @@ error_page 403 /403.html;
 error_page 404 401 /404.html;
 error_page 406 /406.html;
 error_page 410 /410.html;
+error_page 422 /422.html;
 error_page 500 502 /500.html;
 error_page 503 /503.html;
 error_page 504 /504.html;
@@ -115,6 +116,10 @@ location /406.html {
   internal;
 }
 location /410.html {
+  root /usr/share/nginx/www;
+  internal;
+}
+location /422.html {
   root /usr/share/nginx/www;
   internal;
 }


### PR DESCRIPTION
https://trello.com/c/Uzpw1bDA/243-document-how-error-pages-work-on-govuk

Depends on: https://github.com/alphagov/static/pull/2161

Previously we relied on individual apps catching a 422 response and
rendering a 200 error page. While this is a good strategy because it
allows the app to help the user in context, it's still possible for
that 422 edge cases exist that are not handled by the app [1]. This
adds a new, generic 422 error page, as a fallback in these scenarios.

[1]: https://github.com/alphagov/email-alert-frontend/pull/743