### PR TITLE
Filebeat Configuration is not an Example

### DIFF
--- a/modules/filebeat/templates/filebeat.yml.erb
+++ b/modules/filebeat/templates/filebeat.yml.erb
@@ -1,9 +1,5 @@
-###################### Filebeat Configuration Example #########################
+######################### Filebeat Configuration ##############################
 
-# This file is an example configuration file highlighting only the most common
-# options. The filebeat.full.yml file from the same directory contains all the
-# supported options with more comments. You can use it as a reference.
-#
 # You can find the full configuration reference here:
 # https://www.elastic.co/guide/en/beats/filebeat/index.html
 


### PR DESCRIPTION
... so it shouldn't claim that it is. This could confuse people when
they're looking at the configuration that gets placed on servers (it
confused me...).