### PR TITLE
Remove govuk-app-deployment from CI

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -465,7 +465,6 @@ govuk_ci::master::pipeline_jobs:
   gds-sso: {}
   gds_zendesk: {}
   govspeak: {}
-  govuk-app-deployment: {}
   govuk_ab_testing: {}
   govuk_app_config: {}
   govuk-cdn-config: {}


### PR DESCRIPTION
It builds with Github actions as of https://github.com/alphagov/govuk-app-deployment/pull/384

https://trello.com/c/PzpcnUdS/144-migrate-all-skipdeploytointegration-repos-ci-to-github-actions