### PR TITLE
Add AWS Cloudwatch Module

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -493,6 +493,8 @@ task :check_consistency_between_aws_and_carrenza do
     monitoring::pagerduty_drill::enabled
     router::nginx::robotstxt
     govuk::apps::govuk_crawler_worker::blacklist_paths
+    govuk_awscloudwatch::apt_mirror_hostname
+    govuk_awscloudwatch::apt_mirror_gpg_key_fingerprint
     govuk_crawler::start_hour
     govuk_crawler::days
     govuk::apps::govuk_crawler_worker::crawler_threads

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -763,6 +763,9 @@ govuk::apps::travel_advice_publisher::redis_port: "%{hiera('sidekiq_port')}"
 govuk_awscli::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk_awscli::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
+govuk_awscloudwatch::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_awscloudwatch::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
+
 govuk::apps::content_data_api::db::rds: true
 govuk::apps::content_tagger::db::rds: true
 govuk::apps::email_alert_api::db::rds: true

--- a/modules/govuk/manifests/node/s_frontend.pp
+++ b/modules/govuk/manifests/node/s_frontend.pp
@@ -8,6 +8,7 @@ class govuk::node::s_frontend inherits govuk::node::s_base {
   include govuk::node::s_app_server
 
   include nginx
+  include govuk_awscloudwatch
 
   # The catchall vhost throws a 500, except for healthcheck requests.
   nginx::config::vhost::default { 'default': }

--- a/modules/govuk_awscloudwatch/manifests/init.pp
+++ b/modules/govuk_awscloudwatch/manifests/init.pp
@@ -1,0 +1,31 @@
+# == Class: govuk_awscloudwatch
+#
+# Installs the Apt repo for the AWS Cloudwatch package, and installs the AWS Cloudwatch from the Apt repo
+#
+# === Parameters:
+#
+# [*apt_mirror_hostname*]
+#   The hostname of the Apt mirror containing the awscloudwatch repo
+#
+# [*apt_mirror_gpg_key_fingerprint*]
+#   The fingerprint of the Apt mirror containing the awscloudwatch repo
+#
+class govuk_awscloudwatch (
+  $apt_mirror_hostname,
+  $apt_mirror_gpg_key_fingerprint,
+)
+{
+  apt::source { 'awscloudwatch':
+    ensure       => present,
+    location     => "http://${apt_mirror_hostname}/awscloudwatch",
+    release      => 'stable',
+    repos        => 'main',
+    architecture => $::architecture,
+    key          => $apt_mirror_gpg_key_fingerprint,
+  }
+
+  package { 'amazon-cloudwatch-agent':
+    ensure  => present,
+    require => Apt::Source['awscloudwatch'],
+  }
+}


### PR DESCRIPTION
To be deployed on frontend machines. Cyber have asked for this to
allow them to produce more detailed logs.