### PR TITLE
Reorder Notify success and failure metrics

### DIFF
--- a/modules/grafana/files/dashboards/email_alert_api.json
+++ b/modules/grafana/files/dashboards/email_alert_api.json
@@ -712,12 +712,12 @@
             {
               "hide": false,
               "refId": "C",
-              "target": "aliasByNode(consolidateBy(sumSeries(stats_counts.govuk.app.email-alert-api.*.notify.email_send_request.failure), 'sum'), 6, 7)"
+              "target": "aliasByNode(consolidateBy(sumSeries(stats_counts.govuk.app.email-alert-api.*.notify.email_send_request.success), 'sum'), 6, 7)"
             },
             {
               "hide": false,
               "refId": "D",
-              "target": "aliasByNode(consolidateBy(sumSeries(stats_counts.govuk.app.email-alert-api.*.notify.email_send_request.success), 'sum'), 6, 7)"
+              "target": "aliasByNode(consolidateBy(sumSeries(stats_counts.govuk.app.email-alert-api.*.notify.email_send_request.failure), 'sum'), 6, 7)"
             }
           ],
           "thresholds": [],


### PR DESCRIPTION
Change the order of the metrics on the `Notify email send requests` graph so that `success` is shown as green, not yellow. Otherwise it's confusing. 

[Trello card](https://trello.com/c/IA06kUww/1961-reorder-metrics-on-email-alert-api-metrics-dashboard)

**Before**
![Before](https://user-images.githubusercontent.com/2922630/81542556-be7f8280-936c-11ea-9de7-f966c8d1fecc.png)

**After**
![After](https://user-images.githubusercontent.com/2922630/81542593-d35c1600-936c-11ea-9dbf-6d65b5b811f5.png)


