### PR TITLE
Pass Notify reply-to IDs as environment variables to publisher

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -48,6 +48,7 @@ govuk::apps::government-frontend::cpu_critical: 300
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::publisher::run_fact_check_fetcher: true
 govuk::apps::publisher::fact_check_address_format: 'factcheck+production-{id}@alphagov.co.uk'
+govuk::apps::publisher::fact_check_reply_to_id: '792923cb-fa07-4dce-a4c5-e6320bd19c17'
 govuk::apps::publisher::email_group_dev: 'govuk-dev@digital.cabinet-office.gov.uk'
 govuk::apps::publisher::email_group_business: 'publisher-alerts-business@digital.cabinet-office.gov.uk'
 govuk::apps::publisher::email_group_citizen: 'publisher-alerts-citizen@digital.cabinet-office.gov.uk'

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -30,6 +30,7 @@ govuk::apps::publisher::email_group_business: 'mainstream-publisher-notification
 govuk::apps::publisher::email_group_citizen: 'mainstream-publisher-notifications-staging@digital.cabinet-office.gov.uk'
 govuk::apps::publisher::email_group_force_publish_alerts: 'mainstream-publisher-notifications-staging@digital.cabinet-office.gov.uk'
 govuk::apps::publisher::fact_check_subject_prefix: 'staging'
+govuk::apps::publisher::fact_check_reply_to_id: 'c07e5ba1-08fe-4080-acec-70e66f961c55'
 govuk::apps::search_admin::govuk_notify_template_id: '112842bb-d8a4-4511-90de-57dc5c8f27ec'
 govuk::apps::service_manual_publisher::govuk_notify_template_id: "112842bb-d8a4-4511-90de-57dc5c8f27ec"
 govuk::apps::short_url_manager::instance_name: 'staging'

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -167,6 +167,7 @@ govuk::apps::local_links_manager::run_links_ga_export: true
 
 govuk::apps::publisher::run_fact_check_fetcher: false
 govuk::apps::publisher::fact_check_address_format: 'factcheck+production-{id}@alphagov.co.uk'
+govuk::apps::publisher::fact_check_reply_to_id: '792923cb-fa07-4dce-a4c5-e6320bd19c17'
 govuk::apps::publisher::email_group_force_publish_alerts: 'mainstream-force-publishing-alerts@digital.cabinet-office.gov.uk'
 govuk::apps::publisher::govuk_notify_template_id: "e00e89f5-b622-4dcb-8f30-e6c70231a940"
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-production'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -186,6 +186,7 @@ govuk::apps::publisher::email_group_business: 'mainstream-publisher-notification
 govuk::apps::publisher::email_group_citizen: 'mainstream-publisher-notifications-staging@digital.cabinet-office.gov.uk'
 govuk::apps::publisher::email_group_force_publish_alerts: 'mainstream-publisher-notifications-staging@digital.cabinet-office.gov.uk'
 govuk::apps::publisher::fact_check_subject_prefix: 'staging'
+govuk::apps::publisher::fact_check_reply_to_id: 'c07e5ba1-08fe-4080-acec-70e66f961c55'
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-staging'
 govuk::apps::router::sentry_environment: 'staging'
 govuk::apps::search_admin::govuk_notify_template_id: "112842bb-d8a4-4511-90de-57dc5c8f27ec"

--- a/modules/govuk/manifests/apps/publisher.pp
+++ b/modules/govuk/manifests/apps/publisher.pp
@@ -71,6 +71,10 @@
 # [*fact_check_password*]
 #   The password to use for Basic Auth for fact check
 #
+# [*fact_check_reply_to_id*]
+#   The UUID (configured in Notify) for the reply-to address to be used on
+#   fact-check emails
+#
 # [*email_group_dev*]
 #   The email address to use dev alerts
 #
@@ -119,6 +123,7 @@ class govuk::apps::publisher(
     $fact_check_subject_prefix = undef,
     $fact_check_username = undef,
     $fact_check_password = undef,
+    $fact_check_reply_to_id = undef,
     $email_group_dev = undef,
     $email_group_business = undef,
     $email_group_citizen = undef,
@@ -222,6 +227,9 @@ class govuk::apps::publisher(
     "${title}-FACT_CHECK_PASSWORD":
       varname => 'FACT_CHECK_PASSWORD',
       value   => $fact_check_password;
+    "${title}-FACT_CHECK_REPLY_TO_ID":
+      varname => 'FACT_CHECK_REPLY_TO_ID',
+      value   => $fact_check_reply_to_id;
     "${title}-EMAIL_GROUP_DEV":
       varname => 'EMAIL_GROUP_DEV',
       value   => $email_group_dev;


### PR DESCRIPTION
Notify requires that reply-to addresses be explicitly configured in the dashboard and then specified by a UUID when sending a messsage. This passes those UUIDs (different for each address/environment combination) through to Publisher so that they can be used.

https://trello.com/c/Qy5yaTHt/1951-publisher-use-notify-instead-of-amazon-ses