### PR TITLE
Upgrade Mongo On CI Agents 1 - 3

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1039,7 +1039,7 @@ limits::entries:
 
 mongodb::repository::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 mongodb::repository::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
-mongodb::server::version: '2.4.9'
+mongodb::server::version: '2.6.12'
 
 monitoring::checks::aws_origin_domain: 'dev.govuk.digital'
 monitoring::checks::http_username: "%{hiera('http_username')}"

--- a/hieradata/node/ci-agent-1.ci.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/ci-agent-1.ci.integration.publishing.service.gov.uk.yaml
@@ -1,2 +1,2 @@
 ---
-mongodb::server::version: '2.4.9'
+mongodb::server::version: '2.6.12'

--- a/hieradata/node/ci-agent-2.ci.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/ci-agent-2.ci.integration.publishing.service.gov.uk.yaml
@@ -1,2 +1,2 @@
 ---
-mongodb::server::version: '2.4.9'
+mongodb::server::version: '2.6.12'

--- a/hieradata/node/ci-agent-3.ci.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/ci-agent-3.ci.integration.publishing.service.gov.uk.yaml
@@ -1,3 +1,3 @@
 ---
 
-mongodb::server::version: '2.4.9'
+mongodb::server::version: '2.6.12'

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -376,4 +376,3 @@ postfix::rewrite_mail_list: 'machine.email.carrenza'
 
 mongodb::s3backup::backup::s3_bucket: 'govuk-mongodb-backup-s3-production'
 mongodb::s3backup::backup::s3_bucket_daily: 'govuk-mongodb-backup-s3-daily-production'
-mongodb::server::version: '2.6.12'

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -366,6 +366,5 @@ router::nginx::robotstxt: |
 
 mongodb::s3backup::backup::s3_bucket: 'govuk-mongodb-backup-s3-staging'
 mongodb::s3backup::backup::s3_bucket_daily: 'govuk-mongodb-backup-s3-daily-staging'
-mongodb::server::version: '2.6.12'
 
 unattended_reboot::cron_hour: "*"

--- a/modules/mongodb/manifests/server.pp
+++ b/modules/mongodb/manifests/server.pp
@@ -37,28 +37,21 @@ class mongodb::server (
   $syncpath = '/var/lib/mongo-sync'
 ) {
 
-# These conditionals will be removed after the Publishing Apps migration when we
-# will shutdown the self hosted mongo instances. For now mongo 2.6 is running
-# in: AWS Integration, AWS Staging, Carrenza Staging, Carrenza Production, AWS Production.
-
-  if ($::aws_environment == 'integration') or ($::aws_environment == 'staging') or ($::aws_environment == 'production') or ( $::domain == 'backend.staging.publishing.service.gov.uk') or ($::domain == 'backend.publishing.service.gov.uk') {
-
+  if versioncmp($version, '3.0.0') >= 0 {
+    $service_name = 'mongod'
+    $package_name = 'mongodb-org'
+    $config_filename = '/etc/mongod.conf'
+    $template_name = 'mongod.conf.erb'
+  } elsif $version == '2.6.12' {
     $service_name = 'mongodb'
     $package_name = 'govuk-mongo'
     $config_filename = '/etc/mongodb.conf'
     $template_name = 'mongodb.conf'
   } else {
-    if versioncmp($version, '3.0.0') >= 0 {
-      $service_name = 'mongod'
-      $package_name = 'mongodb-org'
-      $config_filename = '/etc/mongod.conf'
-      $template_name = 'mongod.conf.erb'
-    } else {
-      $service_name = 'mongodb'
-      $package_name = 'mongodb-10gen'
-      $config_filename = '/etc/mongodb.conf'
-      $template_name = 'mongodb.conf'
-    }
+    $service_name = 'mongodb'
+    $package_name = 'mongodb-10gen'
+    $config_filename = '/etc/mongodb.conf'
+    $template_name = 'mongodb.conf'
   }
 
   validate_bool($development)


### PR DESCRIPTION
Upgrade Mongo to 2.6 from 2.4.9 on ci_agent machines 1 - 3. This
is a necessary step towards migrating the remaining publishing apps
currently using Mongo databases from Carrenza to AWS. We will be updating the apps
to use DocumentDB which is incompatible with versions of Mongo below 3.6. We 
are upgrading the CI Agent Machines to bring the versions inline with the versions
used in all other environments. For more information please see this trello card:
https://trello.com/c/YXXu4s5c/3422-fix-mongo-documentdb-errors