### PR TITLE
Add new fallback error pages in Static

### DIFF
--- a/modules/router/manifests/nginx.pp
+++ b/modules/router/manifests/nginx.pp
@@ -129,7 +129,7 @@ class router::nginx (
     require => File['/usr/share/nginx/www'],
   }
 
-  router::errorpage {['400', '403', '404','406','410','422','500','503','504']:
+  router::errorpage {['400', '401', '403', '404', '405', '406', '410', '422', '429', '500', '503', '504']:
     require => File['/usr/share/nginx/www'],
   }
 

--- a/modules/router/templates/router_include.conf.erb
+++ b/modules/router/templates/router_include.conf.erb
@@ -79,12 +79,16 @@ location / {
 }
 
 error_page 400 /400.html;
+error_page 401 /401.html;
 error_page 403 /403.html;
-error_page 404 401 /404.html;
+error_page 404 /404.html;
+error_page 405 /405.html;
 error_page 406 /406.html;
 error_page 410 /410.html;
 error_page 422 /422.html;
-error_page 500 502 /500.html;
+error_page 429 /429.html;
+error_page 500 /500.html;
+error_page 502 /502.html;
 error_page 503 /503.html;
 error_page 504 /504.html;
 
@@ -100,6 +104,10 @@ location /400.html {
   root /usr/share/nginx/www;
   internal;
 }
+location /401.html {
+  root /usr/share/nginx/www;
+  internal;
+}
 location /403.html {
   root /usr/share/nginx/www;
   internal;
@@ -108,6 +116,10 @@ location /404.html {
   # Set Cache-Control headers on 404 pages since we overide those set by apps.
   # So that we dont fall through to the default provided by the CDN.
   add_header Cache-Control "public, max-age=<%= @page_ttl_404 -%>" always;
+  root /usr/share/nginx/www;
+  internal;
+}
+location /405.html {
   root /usr/share/nginx/www;
   internal;
 }
@@ -120,6 +132,10 @@ location /410.html {
   internal;
 }
 location /422.html {
+  root /usr/share/nginx/www;
+  internal;
+}
+location /429.html {
   root /usr/share/nginx/www;
   internal;
 }


### PR DESCRIPTION
https://trello.com/c/Uzpw1bDA/243-document-how-error-pages-work-on-govuk

This adds support to render a new set of fallback error pages that
are available in Static, which will override the previous Slimmer
'500 Internal Server Error' content shown for these error codes,
and allow us to remove this redundant layer of error handling.

This also removes the DRY-ing up of some error codes (404 -> 401,
502 -> 500), so that each error page can be customised in Static.

Reference: https://github.com/alphagov/static/pull/2167