### PR TITLE
Keep Performance Mongo Machines on Mongo 2.4.9

### DIFF
--- a/hieradata/class/performance_mongo.yaml
+++ b/hieradata/class/performance_mongo.yaml
@@ -33,6 +33,7 @@ mount:
     govuk_lvm: 's3backups'
     mountoptions: 'defaults'
 
+mongodb::server::version: '2.4.9'
 mongodb::server::oplog_size: 7168 # 7 * 1024
 mongodb::server::replicaset_members:
   'performance-mongo-1':


### PR DESCRIPTION
We are upgrading the other mongo machines in Carrenza Production to
2.6.12. However we are not yet sure that Performance Platform can
handle the upgrade without error, so we are leaving it at mongo 2.4.9
for the time being.