### PR TITLE
add the publishing apps to AWS production

### DIFF
--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -20,17 +20,30 @@ node_class: &node_class
       - asset-manager
       - cache-clearing-service
       - canary-backend
+      - contacts
       - content-data-admin
       - content-data-api
-      - transition
+      - content-publisher
+      - content-tagger
+      - collections-publisher
+      - hmrc-manuals-api
       - imminence
+      - manuals-publisher
+      - maslow
+      - publisher
       - link-checker-api
       - local-links-manager
       - release
+      - search-admin
+      - service-manual-publisher
+      - short-url-manager
       - sidekiq-monitoring
+      - specialist-publisher
       - support
       - support-api
       - support_api_csv_env_sync
+      - transition
+      - travel-advice-publisher
   bouncer:
     apps:
       - bouncer


### PR DESCRIPTION
This is needed for the migration of the publishing apps from Carrrenza Production to AWS Production