### PR TITLE
Fall back to rubygems if gem is not in gemstash

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,5 +121,5 @@ DEPENDENCIES
   sshkey (= 1.9.0)
   webmock (~> 1.20.0)
 
-RUBY VERSION
-   ruby 1.9.3p550
+BUNDLED WITH
+   1.17.3

--- a/modules/govuk_bundler/templates/bundle_config.erb
+++ b/modules/govuk_bundler/templates/bundle_config.erb
@@ -1,4 +1,3 @@
 ---
-# FIXME: Once all bundler versions are > 1.12.x i.e. ruby > 2.x
-# BUNDLE_MIRROR__HTTPS://RUBYGEMS.ORG.FALLBACK_TIMEOUT: 'true'
+BUNDLE_MIRROR__HTTPS://RUBYGEMS__ORG/__FALLBACK_TIMEOUT: 'true'
 BUNDLE_MIRROR__HTTPS://RUBYGEMS.ORG: <%= @server %>/

--- a/modules/govuk_rbenv/manifests/init.pp
+++ b/modules/govuk_rbenv/manifests/init.pp
@@ -14,7 +14,7 @@ class govuk_rbenv {
 
   unless $::lsbdistcodename == 'xenial' {
     rbenv::version { '1.9.3-p550':
-      bundler_version  => '1.7.4',
+      bundler_version  => '1.17.3',
       install_gem_docs => false,
     }
     rbenv::alias { '1.9.3':


### PR DESCRIPTION
... or if our gemstash goes down for some reason.

Pretty sure we're on > 1.12.x everywhere now, and if not this will force
us to fix it.

Note that the name of this config setting is slightly different to the
one in the comment - `/__FALLBACK...` instead of `.FALLBACK`. This is
what I get in my `~/.bundle/config` if I run `bundle config mirror.https://rubygems.org.fallback_timeout true`,
which is what the docs say I should do to set this flag.