### PR TITLE
Update pagerduty manual page URL

### DIFF
--- a/modules/monitoring/manifests/pagerduty_drill.pp
+++ b/modules/monitoring/manifests/pagerduty_drill.pp
@@ -45,7 +45,7 @@ class monitoring::pagerduty_drill (
       use                 => 'govuk_urgent_priority',
       service_description => 'PagerDuty test drill in progress',
       host_name           => $::fqdn,
-      notes_url           => monitoring_docs_url(pagerduty-drill),
+      notes_url           => monitoring_docs_url(pagerduty),
     }
   }
 }


### PR DESCRIPTION
PagerDuty docs are now found at
https://docs.publishing.service.gov.uk/manual/pagerduty.html