### PR TITLE
Fix missing URL for Deploy_App_Downstream job

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -104,6 +104,8 @@ govuk::node::s_mysql_backup::s3_bucket_name: 'govuk-mysql-xtrabackups-integratio
 govuk::node::s_mysql_master::s3_bucket_name: "%{hiera('govuk::node::s_mysql_backup::s3_bucket_name')}"
 govuk::node::s_whitehall_backend::sync_mirror: true
 
+govuk_jenkins::jobs::deploy_app_downstream::deploy_url: 'deploy.integration.publishing.service.gov.uk'
+
 govuk_postgresql::server::standby::pgpassfile_enabled: true
 
 govuk_sudo::sudo_conf:


### PR DESCRIPTION
Previously this used to be hard-coded in the 'integration_deploy'
job, because it only ran on CI.