### PR TITLE
Add check for deploy freeze when triggering downstream deploy

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_app_downstream.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_app_downstream.yaml.erb
@@ -9,6 +9,19 @@
           days-to-keep: 30
           artifact-num-to-keep: 5
     builders:
+      - shell: |
+          # Check for deploy freeze set in Release App
+          APPLICATION_METADATA=$(curl -s \
+            -H "Accept: application/json" \
+            -H "Authorization: Bearer $RELEASE_APP_NOTIFICATION_BEARER_TOKEN" \
+            "https://release.publishing.service.gov.uk/applications/$TARGET_APPLICATION")
+
+          DEPLOY_FREEZE=$(echo "$APPLICATION_METADATA" | jq .deploy_freeze)
+
+          if $DEPLOY_FREEZE; then
+            echo "This application is under a deploy freeze in Release app. Aborting"
+            exit 1
+          fi
       <% if @smokey_pre_check %>
       - shell: |
           # Wait for any app restarts to complete before running Smokey


### PR DESCRIPTION
This adds a step to the Deploy_App_Downstream job to query the Release app and prevent deployments if the deploy freeze attribute is true.