### PR TITLE
Prevent rate limiting for Deploy_App_Downstream

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/deploy_app_downstream.pp
+++ b/modules/govuk_jenkins/manifests/jobs/deploy_app_downstream.pp
@@ -16,11 +16,15 @@
 # [*deploy_url*]
 #   The URL of the downstream Jenkins.
 #
+# [*github_api_token*]
+#   The API token used to avoid rate limiting for GitHub API calls.
+#
 class govuk_jenkins::jobs::deploy_app_downstream (
   $applications = undef,
   $jenkins_downstream_api_user = undef,
   $jenkins_downstream_api_password = undef,
   $deploy_url = undef,
+  $github_api_token = undef,
 ) {
   file { '/etc/jenkins_jobs/jobs/deploy_app_downstream.yaml':
     ensure  => present,

--- a/modules/govuk_jenkins/templates/jobs/deploy_app_downstream.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_app_downstream.yaml.erb
@@ -20,7 +20,7 @@
           esac
 
           # Check release to deploy is genuine and we're not going backwards
-          GITHUB_API="https://api.github.com/repos/alphagov/$REPO"
+          GITHUB_API="-H 'Authorization: token <%= @github_api_token %>' https://api.github.com/repos/alphagov/$REPO"
           LATEST_TAGS=$(curl -s "$GITHUB_API/tags?per_page=1")
           LATEST_MASTER_SHA=$(curl -s "$GITHUB_API/commits?per_page=1" | jq '.[].sha' | head -1)
           LATEST_TAG_SHA=$(echo "$LATEST_TAGS" | jq '.[].commit.sha' | head -1)


### PR DESCRIPTION
https://trello.com/c/fq2LN9bl/153-rewrite-the-deploy-to-integration-job-so-it-can-be-used-for-cd

Depends on: https://github.com/alphagov/govuk-secrets/pull/977

Previously we queried the unauthenticated API for GitHub, at the
risk of these requests failing if we deploy too many apps at once.
This adds an API token to authenticate these requests and raise the
rate limit. We will create the token in the govuk-ci GitHub account.