### PR TITLE
Fix Router API Port

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -230,6 +230,7 @@ govuk::apps::bouncer::port: 3049
 govuk::apps::contacts::port: 3051
 govuk::apps::maslow::port: 3053
 govuk::apps::router::port: 3054
+govuk::apps::router::api_port: 3055
 govuk::apps::router_api::port: 3056
 govuk::apps::finder_frontend::port: 3062
 govuk::apps::specialist_publisher::port: 3064
@@ -329,8 +330,6 @@ govuk::apps::manuals_publisher::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::publisher::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
 govuk::apps::publisher::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::publisher::redis_port: "%{hiera('sidekiq_port')}"
-
-govuk::apps::router::api_port: "%{hiera('govuk::apps::router_api::port')}"
 
 govuk::apps::short_url_manager::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::short_url_manager::redis_port: "%{hiera('sidekiq_port')}"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -377,6 +377,7 @@ govuk::apps::bouncer::port: 3049
 govuk::apps::contacts::port: 3051
 govuk::apps::maslow::port: 3053
 govuk::apps::router::port: 3054
+govuk::apps::router::api_port: 3055
 govuk::apps::router_api::port: 3056
 govuk::apps::finder_frontend::port: 3062
 govuk::apps::specialist_publisher::port: 3064
@@ -609,8 +610,6 @@ govuk::apps::publisher::alert_hostname: 'alert'
 govuk::apps::publisher::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
 govuk::apps::publisher::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::publisher::redis_port: "%{hiera('sidekiq_port')}"
-
-govuk::apps::router::api_port: "%{hiera('govuk::apps::router_api::port')}"
 
 govuk::apps::short_url_manager::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::short_url_manager::redis_port: "%{hiera('sidekiq_port')}"


### PR DESCRIPTION
I had misunderstood what this argument was used for in 90e6b5146baa990f79fb50436e16829fbb2dc895. I thought the argument was the port of Router API, but it's actually the API port for Router, which is how Router API updates the routes in Router.