### PR TITLE
Convert integer ports to strings

### DIFF
--- a/modules/govuk/manifests/apps/ckan.pp
+++ b/modules/govuk/manifests/apps/ckan.pp
@@ -164,7 +164,7 @@ class govuk::apps::ckan (
         value   => $bulk_worker_processes;
       "${title}-PYCSW_PORT":
         varname => 'PYCSW_PORT',
-        value   => $pycsw_port;
+        value   => "${pycsw_port}"; # lint:ignore:only_variable_string
       "${title}-PYCSW_CONFIG":
         varname => 'PYCSW_CONFIG',
         value   => $pycsw_config;

--- a/modules/govuk/manifests/apps/govuk_crawler_worker.pp
+++ b/modules/govuk/manifests/apps/govuk_crawler_worker.pp
@@ -77,7 +77,7 @@ class govuk::apps::govuk_crawler_worker (
       'CRAWLER_THREADS':
         value => $crawler_threads;
       'HTTP_PORT':
-        value => $port;
+        value => "${port}"; # lint:ignore:only_variable_string
       'REDIS_ADDRESS':
         value => '127.0.0.1:6379';
       'REDIS_KEY_PREFIX':


### PR DESCRIPTION
The environment variable Puppet class expects the values to be a string, so we need to convert the port number into a string.

This is similar to what was already done for apps: https://github.com/alphagov/govuk-puppet/blob/3b04e9dbe6b874bb1b035e1d1c3aef46a9b2fc0a/modules/govuk/manifests/app/config.pp#L185

This was missed in #10364.