### PR TITLE
Remove backdrop from our deploy infrastructure

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -42,10 +42,6 @@ govuk::node::s_base::node_apps:
 # need to add an empty hash
 deployable_applications: &deployable_applications
   asset-manager: {}
-  backdrop-read:
-    repository: 'backdrop'
-  backdrop-write:
-    repository: 'backdrop'
   collections-publisher: {}
   contacts:
     repository: 'contacts-admin'

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -145,10 +145,6 @@ govuk_jenkins::deploy_all_apps::apps_on_nodes:
 deployable_applications: &deployable_applications
   asset-manager: {}
   authenticating-proxy: {}
-  backdrop-read:
-    repository: 'backdrop'
-  backdrop-write:
-    repository: 'backdrop'
   bouncer: {}
   cache-clearing-service: {}
   calculators: {}


### PR DESCRIPTION
While this app is still provisioned on our infrastructure, we have
been instructed to only deploy it using the legacy alphagov-deployment
repo. This removes 'backdrop-read' and 'backdrop-write' from the list
in the Deploy_App job, since we must not deploy it this way. Note this
is a Python repo, so also has no 'rake' tasks.