### PR TITLE
transition_load_site_config: Use the master branch of `alphagov/transition-config`

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/transition_load_site_config.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/transition_load_site_config.yaml.erb
@@ -5,7 +5,7 @@
         - git:
             url: git@github.com:alphagov/transition-config.git
             branches:
-              - release
+              - master
 
 - job:
     name: Transition_load_site_config


### PR DESCRIPTION
(Before we start, please note that this is the Transition Tool kind of Transition, not the Brexit kind of Transition.)

- We maintain release tags, via Jenkins, for this application. They were reset a few times in the past due to some Jenkins misconfigurations.  In our move to GitHub Actions, release tags are difficult. To add pointlessness, we don't use the _numbered_ release tags for anything as far as I can tell for the transition-config repo.
- This job, for example, reads from `release`. It changes so little these days that we can simplify things by pulling changes from master and a) save ourselves a hop in Jenkins-land and b) save ourselves some complexity of thinking about the future of these things.
- "But what if we deploy bad code," people ask. CI runs on branches and PRs and will catch invalid YAML. And this job runs on a schedule which is unlikely to be just after we merge something and the `master` CI hasn't run. Yes, it'll still pull from `master` whatever the outcome of the CI run, but we do that for plenty of other things too.
