### PR TITLE
Always run Publisher fact check

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -46,7 +46,6 @@ govuk::apps::content_publisher::govuk_notify_template_id: "e00e89f5-b622-4dcb-8f
 govuk::apps::government-frontend::cpu_warning: 200
 govuk::apps::government-frontend::cpu_critical: 300
 govuk::apps::hmrc_manuals_api::publish_topics: false
-govuk::apps::publisher::run_fact_check_fetcher: true
 govuk::apps::publisher::fact_check_address_format: 'factcheck+production-{id}@alphagov.co.uk'
 govuk::apps::publisher::fact_check_reply_to_id: '792923cb-fa07-4dce-a4c5-e6320bd19c17'
 govuk::apps::publisher::fact_check_reply_to_address: 'factcheck+production@alphagov.co.uk'

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -22,7 +22,6 @@ govuk::apps::content_publisher::google_tag_manager_preview: "env-5"
 govuk::apps::content_publisher::email_address_override: "content-publisher-notifications-staging@digital.cabinet-office.gov.uk"
 govuk::apps::content_publisher::govuk_notify_template_id: "112842bb-d8a4-4511-90de-57dc5c8f27ec"
 govuk::apps::hmrc_manuals_api::publish_topics: false
-govuk::apps::publisher::run_fact_check_fetcher: false
 govuk::apps::publisher::fact_check_address_format: 'factcheck+staging-{id}@alphagov.co.uk'
 govuk::apps::publisher::govuk_notify_template_id: "112842bb-d8a4-4511-90de-57dc5c8f27ec"
 govuk::apps::publisher::email_group_dev: 'mainstream-publisher-notifications-staging@digital.cabinet-office.gov.uk'

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -165,7 +165,6 @@ govuk::apps::link_checker_api::govuk_basic_auth_credentials: "%{hiera('http_user
 govuk::apps::local_links_manager::local_links_manager_passive_checks: true
 govuk::apps::local_links_manager::run_links_ga_export: true
 
-govuk::apps::publisher::run_fact_check_fetcher: false
 govuk::apps::publisher::fact_check_address_format: 'factcheck+production-{id}@alphagov.co.uk'
 govuk::apps::publisher::fact_check_reply_to_id: '792923cb-fa07-4dce-a4c5-e6320bd19c17'
 govuk::apps::publisher::fact_check_reply_to_address: 'factcheck+production@alphagov.co.uk'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -175,7 +175,6 @@ govuk::apps::manuals_publisher::mongodb_password: "%{hiera('govuk::apps::asset_m
 govuk::apps::maslow::mongodb_nodes: "%{hiera('govuk::apps::asset_manager::mongodb_nodes')}"
 govuk::apps::maslow::mongodb_username: "%{hiera('govuk::apps::asset_manager::mongodb_username')}"
 govuk::apps::maslow::mongodb_password: "%{hiera('govuk::apps::asset_manager::mongodb_password')}"
-govuk::apps::publisher::run_fact_check_fetcher: false
 govuk::apps::publisher::fact_check_address_format: 'factcheck+staging-{id}@alphagov.co.uk'
 govuk::apps::publisher::mongodb_nodes: "%{hiera('govuk::apps::asset_manager::mongodb_nodes')}"
 govuk::apps::publisher::mongodb_username: "%{hiera('govuk::apps::asset_manager::mongodb_username')}"

--- a/modules/govuk/manifests/apps/publisher.pp
+++ b/modules/govuk/manifests/apps/publisher.pp
@@ -57,10 +57,6 @@
 # [*oauth_secret*]
 #   The application's OAuth Secret from Signon
 #
-# [*run_fact_check_fetcher*]
-#   Whether to perform fetches for fact checks
-#   Default: false
-#
 # [*fact_check_address_format*]
 #   The address format used for sending fact checks
 #
@@ -121,7 +117,6 @@ class govuk::apps::publisher(
     $sentry_dsn = undef,
     $oauth_id = undef,
     $oauth_secret = undef,
-    $run_fact_check_fetcher = false,
     $fact_check_address_format = undef,
     $fact_check_subject_prefix = undef,
     $fact_check_username = undef,
@@ -190,14 +185,6 @@ class govuk::apps::publisher(
 
   Govuk::App::Envvar {
     app => $app_name,
-  }
-
-  if $run_fact_check_fetcher {
-    govuk::app::envvar {
-      "${title}-RUN_FACT_CHECK_FETCHER":
-        varname => 'RUN_FACT_CHECK_FETCHER',
-        value   => '1';
-    }
   }
 
   govuk::app::envvar {


### PR DESCRIPTION
We've configured a custom email account in integration and staging, so it's safe to run the fact check in all environments.

Depends on https://github.com/alphagov/publisher/pull/1281.

[Trello Card](https://trello.com/c/IspoUGnj/1971-5-enable-fact-check-emails-in-integration-and-staging)