### PR TITLE
Reconcile jenkins jobs for aws

### DIFF
--- a/hieradata_aws/class/integration/jenkins.yaml
+++ b/hieradata_aws/class/integration/jenkins.yaml
@@ -27,6 +27,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::passive_checks
   - govuk_jenkins::jobs::publication_delay_report
   - govuk_jenkins::jobs::publish_special_routes
+  - govuk_jenkins::jobs::record_superfluous_taggings_metrics
   - govuk_jenkins::jobs::record_taxonomy_metrics
   - govuk_jenkins::jobs::remove_emergency_banner
   - govuk_jenkins::jobs::run_deploy_lag_badger

--- a/hieradata_aws/class/integration/jenkins.yaml
+++ b/hieradata_aws/class/integration/jenkins.yaml
@@ -46,10 +46,12 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::update_cdn_dictionaries
   - govuk_jenkins::jobs::transition_load_site_config
   - govuk_jenkins::jobs::user_monitor
+  - govuk_jenkins::jobs::validate_published_dns
   - govuk_jenkins::jobs::whitehall_publisher_notifications
   - govuk_jenkins::jobs::whitehall_run_broken_link_checker
 
 govuk_jenkins::jobs::deploy_cdn::enable_slack_notifications: true
+govuk_jenkins::jobs::validate_published_dns::run_daily: true
 
 lv:
   data:

--- a/hieradata_aws/class/integration/jenkins.yaml
+++ b/hieradata_aws/class/integration/jenkins.yaml
@@ -7,6 +7,7 @@ govuk_jenkins::config::theme_environment_name: 'AWS Integration'
 
 govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::athena_fastly_logs_check
+  - govuk_jenkins::jobs::bouncer_cdn
   - govuk_jenkins::jobs::clear_frontend_memcache
   - govuk_jenkins::jobs::clear_template_cache
   - govuk_jenkins::jobs::clear_varnish_cache

--- a/hieradata_aws/class/integration/jenkins.yaml
+++ b/hieradata_aws/class/integration/jenkins.yaml
@@ -8,6 +8,7 @@ govuk_jenkins::config::theme_environment_name: 'AWS Integration'
 govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::athena_fastly_logs_check
   - govuk_jenkins::jobs::bouncer_cdn
+  - govuk_jenkins::jobs::check_cdn_ip_ranges
   - govuk_jenkins::jobs::clear_frontend_memcache
   - govuk_jenkins::jobs::clear_template_cache
   - govuk_jenkins::jobs::clear_varnish_cache

--- a/hieradata_aws/class/integration/jenkins.yaml
+++ b/hieradata_aws/class/integration/jenkins.yaml
@@ -47,6 +47,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::transition_load_site_config
   - govuk_jenkins::jobs::user_monitor
   - govuk_jenkins::jobs::whitehall_publisher_notifications
+  - govuk_jenkins::jobs::whitehall_run_broken_link_checker
 
 govuk_jenkins::jobs::deploy_cdn::enable_slack_notifications: true
 

--- a/hieradata_aws/class/production/jenkins.yaml
+++ b/hieradata_aws/class/production/jenkins.yaml
@@ -54,6 +54,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::enhanced_ecommerce_search_api
   - govuk_jenkins::jobs::monitor_taxonomy_health
   - govuk_jenkins::jobs::passive_checks
+  - govuk_jenkins::jobs::publication_delay_report
   - govuk_jenkins::jobs::publish_special_routes
   - govuk_jenkins::jobs::publishing_api_archive_events
   - govuk_jenkins::jobs::remove_emergency_banner

--- a/hieradata_aws/class/production/jenkins.yaml
+++ b/hieradata_aws/class/production/jenkins.yaml
@@ -77,6 +77,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::transition_import_dns
   - govuk_jenkins::jobs::transition_import_hits
   - govuk_jenkins::jobs::transition_load_site_config
+  - govuk_jenkins::jobs::user_monitor
   - govuk_jenkins::jobs::whitehall_publisher_notifications
   - govuk_jenkins::jobs::whitehall_run_broken_link_checker
 

--- a/hieradata_aws/class/production/jenkins.yaml
+++ b/hieradata_aws/class/production/jenkins.yaml
@@ -52,6 +52,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::deploy_puppet
   - govuk_jenkins::jobs::email_alert_check
   - govuk_jenkins::jobs::enhanced_ecommerce_search_api
+  - govuk_jenkins::jobs::monitor_taxonomy_health
   - govuk_jenkins::jobs::passive_checks
   - govuk_jenkins::jobs::publish_special_routes
   - govuk_jenkins::jobs::publishing_api_archive_events

--- a/hieradata_aws/class/production/jenkins.yaml
+++ b/hieradata_aws/class/production/jenkins.yaml
@@ -51,6 +51,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::deploy_app
   - govuk_jenkins::jobs::deploy_docs
   - govuk_jenkins::jobs::deploy_emergency_banner
+  - govuk_jenkins::jobs::deploy_lambda_app
   - govuk_jenkins::jobs::deploy_puppet
   - govuk_jenkins::jobs::email_alert_check
   - govuk_jenkins::jobs::enhanced_ecommerce_search_api

--- a/hieradata_aws/class/production/jenkins.yaml
+++ b/hieradata_aws/class/production/jenkins.yaml
@@ -58,6 +58,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::publication_delay_report
   - govuk_jenkins::jobs::publish_special_routes
   - govuk_jenkins::jobs::publishing_api_archive_events
+  - govuk_jenkins::jobs::record_superfluous_taggings_metrics
   - govuk_jenkins::jobs::remove_emergency_banner
   - govuk_jenkins::jobs::run_rake_task
   - govuk_jenkins::jobs::run_whitehall_data_migrations

--- a/hieradata_aws/class/production/jenkins.yaml
+++ b/hieradata_aws/class/production/jenkins.yaml
@@ -53,6 +53,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::deploy_puppet
   - govuk_jenkins::jobs::email_alert_check
   - govuk_jenkins::jobs::enhanced_ecommerce_search_api
+  - govuk_jenkins::jobs::govuk_taxonomy_supervised_learning
   - govuk_jenkins::jobs::monitor_taxonomy_health
   - govuk_jenkins::jobs::passive_checks
   - govuk_jenkins::jobs::publication_delay_report

--- a/hieradata_aws/class/production/jenkins.yaml
+++ b/hieradata_aws/class/production/jenkins.yaml
@@ -48,6 +48,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::clear_varnish_cache
   - govuk_jenkins::jobs::content_data_api
   - govuk_jenkins::jobs::deploy_app
+  - govuk_jenkins::jobs::deploy_docs
   - govuk_jenkins::jobs::deploy_emergency_banner
   - govuk_jenkins::jobs::deploy_puppet
   - govuk_jenkins::jobs::email_alert_check

--- a/hieradata_aws/class/production/jenkins.yaml
+++ b/hieradata_aws/class/production/jenkins.yaml
@@ -59,6 +59,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::publish_special_routes
   - govuk_jenkins::jobs::publishing_api_archive_events
   - govuk_jenkins::jobs::record_superfluous_taggings_metrics
+  - govuk_jenkins::jobs::record_taxonomy_metrics
   - govuk_jenkins::jobs::remove_emergency_banner
   - govuk_jenkins::jobs::run_rake_task
   - govuk_jenkins::jobs::run_whitehall_data_migrations

--- a/hieradata_aws/class/production/jenkins.yaml
+++ b/hieradata_aws/class/production/jenkins.yaml
@@ -47,6 +47,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::clear_template_cache
   - govuk_jenkins::jobs::clear_varnish_cache
   - govuk_jenkins::jobs::content_data_api
+  - govuk_jenkins::jobs::delete_redis_uniquejobs
   - govuk_jenkins::jobs::deploy_app
   - govuk_jenkins::jobs::deploy_docs
   - govuk_jenkins::jobs::deploy_emergency_banner

--- a/hieradata_aws/class/staging/jenkins.yaml
+++ b/hieradata_aws/class/staging/jenkins.yaml
@@ -62,6 +62,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::passive_checks
   - govuk_jenkins::jobs::publication_delay_report
   - govuk_jenkins::jobs::publish_special_routes
+  - govuk_jenkins::jobs::record_superfluous_taggings_metrics
   - govuk_jenkins::jobs::remove_emergency_banner
   - govuk_jenkins::jobs::run_rake_task
   - govuk_jenkins::jobs::run_whitehall_data_migrations

--- a/hieradata_aws/class/staging/jenkins.yaml
+++ b/hieradata_aws/class/staging/jenkins.yaml
@@ -58,6 +58,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::deploy_emergency_banner
   - govuk_jenkins::jobs::deploy_puppet
   - govuk_jenkins::jobs::enhanced_ecommerce_search_api
+  - govuk_jenkins::jobs::govuk_taxonomy_supervised_learning
   - govuk_jenkins::jobs::monitor_taxonomy_health
   - govuk_jenkins::jobs::passive_checks
   - govuk_jenkins::jobs::publication_delay_report

--- a/hieradata_aws/class/staging/jenkins.yaml
+++ b/hieradata_aws/class/staging/jenkins.yaml
@@ -47,6 +47,7 @@ govuk_jenkins::config::user_permissions:
 
 govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::athena_fastly_logs_check
+  - govuk_jenkins::jobs::bouncer_cdn
   - govuk_jenkins::jobs::clear_frontend_memcache
   - govuk_jenkins::jobs::clear_template_cache
   - govuk_jenkins::jobs::clear_varnish_cache

--- a/hieradata_aws/class/staging/jenkins.yaml
+++ b/hieradata_aws/class/staging/jenkins.yaml
@@ -78,6 +78,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::smokey
   - govuk_jenkins::jobs::smokey_deploy
   - govuk_jenkins::jobs::transition_load_site_config
+  - govuk_jenkins::jobs::user_monitor
   - govuk_jenkins::jobs::whitehall_publisher_notifications
   - govuk_jenkins::jobs::whitehall_run_broken_link_checker
 

--- a/hieradata_aws/class/staging/jenkins.yaml
+++ b/hieradata_aws/class/staging/jenkins.yaml
@@ -59,6 +59,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::deploy_puppet
   - govuk_jenkins::jobs::monitor_taxonomy_health
   - govuk_jenkins::jobs::passive_checks
+  - govuk_jenkins::jobs::publication_delay_report
   - govuk_jenkins::jobs::publish_special_routes
   - govuk_jenkins::jobs::remove_emergency_banner
   - govuk_jenkins::jobs::run_rake_task

--- a/hieradata_aws/class/staging/jenkins.yaml
+++ b/hieradata_aws/class/staging/jenkins.yaml
@@ -53,6 +53,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::clear_varnish_cache
   - govuk_jenkins::jobs::content_data_api
   - govuk_jenkins::jobs::data_sync_complete_staging
+  - govuk_jenkins::jobs::delete_redis_uniquejobs
   - govuk_jenkins::jobs::deploy_app
   - govuk_jenkins::jobs::deploy_app_downstream
   - govuk_jenkins::jobs::deploy_emergency_banner

--- a/hieradata_aws/class/staging/jenkins.yaml
+++ b/hieradata_aws/class/staging/jenkins.yaml
@@ -57,6 +57,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::deploy_app_downstream
   - govuk_jenkins::jobs::deploy_emergency_banner
   - govuk_jenkins::jobs::deploy_puppet
+  - govuk_jenkins::jobs::enhanced_ecommerce_search_api
   - govuk_jenkins::jobs::monitor_taxonomy_health
   - govuk_jenkins::jobs::passive_checks
   - govuk_jenkins::jobs::publication_delay_report

--- a/hieradata_aws/class/staging/jenkins.yaml
+++ b/hieradata_aws/class/staging/jenkins.yaml
@@ -73,6 +73,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::send_bulk_email
   - govuk_jenkins::jobs::smokey
   - govuk_jenkins::jobs::smokey_deploy
+  - govuk_jenkins::jobs::transition_load_site_config
   - govuk_jenkins::jobs::whitehall_publisher_notifications
 
 govuk_jenkins::jobs::deploy_cdn::enable_slack_notifications: false

--- a/hieradata_aws/class/staging/jenkins.yaml
+++ b/hieradata_aws/class/staging/jenkins.yaml
@@ -57,6 +57,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::deploy_app_downstream
   - govuk_jenkins::jobs::deploy_emergency_banner
   - govuk_jenkins::jobs::deploy_puppet
+  - govuk_jenkins::jobs::monitor_taxonomy_health
   - govuk_jenkins::jobs::passive_checks
   - govuk_jenkins::jobs::publish_special_routes
   - govuk_jenkins::jobs::remove_emergency_banner

--- a/hieradata_aws/class/staging/jenkins.yaml
+++ b/hieradata_aws/class/staging/jenkins.yaml
@@ -79,6 +79,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::smokey_deploy
   - govuk_jenkins::jobs::transition_load_site_config
   - govuk_jenkins::jobs::whitehall_publisher_notifications
+  - govuk_jenkins::jobs::whitehall_run_broken_link_checker
 
 govuk_jenkins::jobs::deploy_cdn::enable_slack_notifications: false
 govuk_jenkins::jobs::deploy_puppet::enable_slack_notifications: false

--- a/hieradata_aws/class/staging/jenkins.yaml
+++ b/hieradata_aws/class/staging/jenkins.yaml
@@ -57,6 +57,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::deploy_app
   - govuk_jenkins::jobs::deploy_app_downstream
   - govuk_jenkins::jobs::deploy_emergency_banner
+  - govuk_jenkins::jobs::deploy_lambda_app
   - govuk_jenkins::jobs::deploy_puppet
   - govuk_jenkins::jobs::enhanced_ecommerce_search_api
   - govuk_jenkins::jobs::govuk_taxonomy_supervised_learning

--- a/hieradata_aws/class/staging/jenkins.yaml
+++ b/hieradata_aws/class/staging/jenkins.yaml
@@ -63,6 +63,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::publication_delay_report
   - govuk_jenkins::jobs::publish_special_routes
   - govuk_jenkins::jobs::record_superfluous_taggings_metrics
+  - govuk_jenkins::jobs::record_taxonomy_metrics
   - govuk_jenkins::jobs::remove_emergency_banner
   - govuk_jenkins::jobs::run_rake_task
   - govuk_jenkins::jobs::run_whitehall_data_migrations


### PR DESCRIPTION
This migrates and aligns the jenkins jobs from the old world in to AWS.

All jenkins jobs were compared between all environments on both platforms.  They were sanity checked and where appropriate copied across on the AWS equivalent environment.

Some jobs only need to run in one place per platform, the pattern is to run it on the AWS integration environment.

Only one jenkins job remains which will be migrated during Signon migration
- signon_cron_rake_tasks

Jobs Migrated:
- Add bouncer_cdn to aws staging and integration environments
- Add monitor_taxonomy_health to aws staging and production
- Add publication_delay_report to aws staging and production
- Add transition_load_site_config to aws staging
- Add deploy_docs to aws production
- Add enhanced_ecommerce_search_api to aws staging
- Add record_superfluous_taggings_metrics to aws envs
- Add record_taxonomy_metrics to aws staging and prod
- Add govuk_taxonomy_supervised_learning to aws staging & prod
- Add whitehall_run_broken_link_checker to aws int and staging
- Add user_monitor to aws staging and production
- Add validate_published_dns to AWS integration
- Add check_cdn_ip_ranges to AWS integration
- Add delete_redis_uniquejobs to aws staging and production
- Add deploy_lambda_app to aws staging and production