### PR TITLE
Proxy draft assets to their respective draft app

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -492,7 +492,6 @@ task :check_consistency_between_aws_and_carrenza do
     grafana::dashboards::machine_suffix_metrics
     monitoring::checks::sidekiq::enable_support_check
     monitoring::pagerduty_drill::enabled
-    router::nginx::app_specific_static_asset_routes
     router::nginx::robotstxt
     govuk::apps::govuk_crawler_worker::blacklist_paths
     govuk_awscloudwatch::apt_mirror_hostname

--- a/hieradata_aws/class/cache.yaml
+++ b/hieradata_aws/class/cache.yaml
@@ -19,3 +19,9 @@ varnish::environment_ip_prefix: "%{hiera('environment_ip_prefix')}"
 # Increase the maximum number of file descriptors usable by the router
 # A file descriptor is used per connection
 govuk::deploy::config::nofile_limit: 65536
+
+router::nginx::app_specific_static_asset_routes:
+  '/assets/collections/': 'collections'
+  '/assets/frontend/': 'frontend'
+  '/assets/government-frontend/': 'government-frontend'
+  '/assets/static/': 'static'

--- a/hieradata_aws/class/draft_cache.yaml
+++ b/hieradata_aws/class/draft_cache.yaml
@@ -24,7 +24,14 @@ govuk::apps::router_api::router_nodes_class: 'draft_cache'
 
 govuk::apps::router_api::vhost: 'draft-router-api'
 
+router::nginx::app_specific_static_asset_routes:
+  '/assets/collections/': 'draft-collections'
+  '/assets/frontend/': 'draft-frontend'
+  '/assets/government-frontend/': 'draft-government-frontend'
+  '/assets/static/': 'draft-static'
+
 router::nginx::check_requests_warning: '@0'
 router::nginx::check_requests_critical: '@0'
 
 varnish::environment_ip_prefix: "%{hiera('environment_ip_prefix')}"
+

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1380,12 +1380,6 @@ rabbitmq::config_stomp: true
 rcs::fsckfix: 'YES'
 rcs::tmptime: '7'
 
-router::nginx::app_specific_static_asset_routes:
-  '/assets/collections/': 'collections'
-  '/assets/frontend/': 'frontend'
-  '/assets/government-frontend/': 'government-frontend'
-  '/assets/static/': 'static'
-
 # Note: it's important that all targets here have matching host entries both in
 # production, and on the dev VM, otherwise nginx will fail to start.
 router::assets_origin::app_specific_static_asset_routes:


### PR DESCRIPTION
Previously all of the assets used in the draft stacks for frontend apps
were live ones and this relied on both the draft and live assets
generating the exact same signatures on assets.

With the switch from assets hostname to the www one any assets with
absolute URLs (including hosts) are producing slightly different assets
on draft and live stacks and thus have different signatures. This has
meant that assets have been 404ing.

I've moved this configuration to be at the class level to avoid
situations of forgetting to set this in draft stack and it working
nearly all the time based off the common configuration.