### PR TITLE
Configuration for frontend apps to have assets on www host

### DIFF
--- a/hieradata_aws/class/cache.yaml
+++ b/hieradata_aws/class/cache.yaml
@@ -25,6 +25,7 @@ router::nginx::app_specific_static_asset_routes:
   '/assets/collections/': 'collections'
   '/assets/email-alert-frontend/': 'email-alert-frontend'
   '/assets/finder-frontend/': 'finder-frontend'
+  '/assets/info-frontend/': 'info-frontend'
   '/assets/frontend/': 'frontend'
   '/assets/government-frontend/': 'government-frontend'
   '/assets/static/': 'static'

--- a/hieradata_aws/class/cache.yaml
+++ b/hieradata_aws/class/cache.yaml
@@ -30,4 +30,5 @@ router::nginx::app_specific_static_asset_routes:
   '/assets/government-frontend/': 'government-frontend'
   '/assets/licencefinder/': 'licencefinder'
   '/assets/manuals-frontend/': 'manuals-frontend'
+  '/assets/service-manual-frontend/': 'service-manual-frontend'
   '/assets/static/': 'static'

--- a/hieradata_aws/class/cache.yaml
+++ b/hieradata_aws/class/cache.yaml
@@ -31,4 +31,5 @@ router::nginx::app_specific_static_asset_routes:
   '/assets/licencefinder/': 'licencefinder'
   '/assets/manuals-frontend/': 'manuals-frontend'
   '/assets/service-manual-frontend/': 'service-manual-frontend'
+  '/assets/smartanswers/': 'smartanswers'
   '/assets/static/': 'static'

--- a/hieradata_aws/class/cache.yaml
+++ b/hieradata_aws/class/cache.yaml
@@ -23,6 +23,7 @@ govuk::deploy::config::nofile_limit: 65536
 router::nginx::app_specific_static_asset_routes:
   '/assets/calculators/': 'calculators'
   '/assets/collections/': 'collections'
+  '/assets/email-alert-frontend/': 'email-alert-frontend'
   '/assets/frontend/': 'frontend'
   '/assets/government-frontend/': 'government-frontend'
   '/assets/static/': 'static'

--- a/hieradata_aws/class/cache.yaml
+++ b/hieradata_aws/class/cache.yaml
@@ -24,6 +24,7 @@ router::nginx::app_specific_static_asset_routes:
   '/assets/calculators/': 'calculators'
   '/assets/collections/': 'collections'
   '/assets/email-alert-frontend/': 'email-alert-frontend'
+  '/assets/finder-frontend/': 'finder-frontend'
   '/assets/frontend/': 'frontend'
   '/assets/government-frontend/': 'government-frontend'
   '/assets/static/': 'static'

--- a/hieradata_aws/class/cache.yaml
+++ b/hieradata_aws/class/cache.yaml
@@ -21,6 +21,7 @@ varnish::environment_ip_prefix: "%{hiera('environment_ip_prefix')}"
 govuk::deploy::config::nofile_limit: 65536
 
 router::nginx::app_specific_static_asset_routes:
+  '/assets/calculators/': 'calculators'
   '/assets/collections/': 'collections'
   '/assets/frontend/': 'frontend'
   '/assets/government-frontend/': 'government-frontend'

--- a/hieradata_aws/class/cache.yaml
+++ b/hieradata_aws/class/cache.yaml
@@ -33,3 +33,4 @@ router::nginx::app_specific_static_asset_routes:
   '/assets/service-manual-frontend/': 'service-manual-frontend'
   '/assets/smartanswers/': 'smartanswers'
   '/assets/static/': 'static'
+  '/assets/whitehall/': 'whitehall-frontend'

--- a/hieradata_aws/class/cache.yaml
+++ b/hieradata_aws/class/cache.yaml
@@ -29,4 +29,5 @@ router::nginx::app_specific_static_asset_routes:
   '/assets/frontend/': 'frontend'
   '/assets/government-frontend/': 'government-frontend'
   '/assets/licencefinder/': 'licencefinder'
+  '/assets/manuals-frontend/': 'manuals-frontend'
   '/assets/static/': 'static'

--- a/hieradata_aws/class/cache.yaml
+++ b/hieradata_aws/class/cache.yaml
@@ -28,4 +28,5 @@ router::nginx::app_specific_static_asset_routes:
   '/assets/info-frontend/': 'info-frontend'
   '/assets/frontend/': 'frontend'
   '/assets/government-frontend/': 'government-frontend'
+  '/assets/licencefinder/': 'licencefinder'
   '/assets/static/': 'static'

--- a/hieradata_aws/class/draft_cache.yaml
+++ b/hieradata_aws/class/draft_cache.yaml
@@ -30,6 +30,7 @@ router::nginx::app_specific_static_asset_routes:
   '/assets/frontend/': 'draft-frontend'
   '/assets/government-frontend/': 'draft-government-frontend'
   '/assets/manuals-frontend/': 'draft-manuals-frontend'
+  '/assets/service-manual-frontend/': 'draft-service-manual-frontend'
   '/assets/static/': 'draft-static'
 
 router::nginx::check_requests_warning: '@0'

--- a/hieradata_aws/class/draft_cache.yaml
+++ b/hieradata_aws/class/draft_cache.yaml
@@ -29,6 +29,7 @@ router::nginx::app_specific_static_asset_routes:
   '/assets/email-alert-frontend/': 'draft-email-alert-frontend'
   '/assets/frontend/': 'draft-frontend'
   '/assets/government-frontend/': 'draft-government-frontend'
+  '/assets/manuals-frontend/': 'draft-manuals-frontend'
   '/assets/static/': 'draft-static'
 
 router::nginx::check_requests_warning: '@0'

--- a/hieradata_aws/class/draft_cache.yaml
+++ b/hieradata_aws/class/draft_cache.yaml
@@ -31,6 +31,7 @@ router::nginx::app_specific_static_asset_routes:
   '/assets/government-frontend/': 'draft-government-frontend'
   '/assets/manuals-frontend/': 'draft-manuals-frontend'
   '/assets/service-manual-frontend/': 'draft-service-manual-frontend'
+  '/assets/smartanswers/': 'draft-smartanswers'
   '/assets/static/': 'draft-static'
 
 router::nginx::check_requests_warning: '@0'

--- a/hieradata_aws/class/draft_cache.yaml
+++ b/hieradata_aws/class/draft_cache.yaml
@@ -33,6 +33,7 @@ router::nginx::app_specific_static_asset_routes:
   '/assets/service-manual-frontend/': 'draft-service-manual-frontend'
   '/assets/smartanswers/': 'draft-smartanswers'
   '/assets/static/': 'draft-static'
+  '/assets/whitehall/': 'draft-whitehall-frontend'
 
 router::nginx::check_requests_warning: '@0'
 router::nginx::check_requests_critical: '@0'

--- a/hieradata_aws/class/draft_cache.yaml
+++ b/hieradata_aws/class/draft_cache.yaml
@@ -26,6 +26,7 @@ govuk::apps::router_api::vhost: 'draft-router-api'
 
 router::nginx::app_specific_static_asset_routes:
   '/assets/collections/': 'draft-collections'
+  '/assets/email-alert-frontend/': 'draft-email-alert-frontend'
   '/assets/frontend/': 'draft-frontend'
   '/assets/government-frontend/': 'draft-government-frontend'
   '/assets/static/': 'draft-static'

--- a/modules/govuk/manifests/apps/calculators.pp
+++ b/modules/govuk/manifests/apps/calculators.pp
@@ -31,7 +31,7 @@ class govuk::apps::calculators(
     health_check_path       => '/child-benefit-tax-calculator/main',
     log_format_is_json      => true,
     asset_pipeline          => true,
-    asset_pipeline_prefixes => ['calculators'],
+    asset_pipeline_prefixes => ['calculators', 'assets/calculators'],
   }
 
   Govuk::App::Envvar {

--- a/modules/govuk/manifests/apps/email_alert_frontend.pp
+++ b/modules/govuk/manifests/apps/email_alert_frontend.pp
@@ -50,7 +50,7 @@ class govuk::apps::email_alert_frontend(
     port                    => $port,
     sentry_dsn              => $sentry_dsn,
     asset_pipeline          => true,
-    asset_pipeline_prefixes => ['email-alert-frontend'],
+    asset_pipeline_prefixes => ['email-alert-frontend', 'assets/email-alert-frontend'],
     vhost                   => $vhost,
     health_check_path       => '/healthcheck',
     json_health_check       => true,

--- a/modules/govuk/manifests/apps/finder_frontend.pp
+++ b/modules/govuk/manifests/apps/finder_frontend.pp
@@ -42,7 +42,7 @@ class govuk::apps::finder_frontend(
       json_health_check        => true,
       log_format_is_json       => true,
       asset_pipeline           => true,
-      asset_pipeline_prefixes  => ['finder-frontend'],
+      asset_pipeline_prefixes  => ['finder-frontend', 'assets/finder-frontend'],
       nagios_memory_warning    => $nagios_memory_warning,
       nagios_memory_critical   => $nagios_memory_critical,
       unicorn_worker_processes => $unicorn_worker_processes,

--- a/modules/govuk/manifests/apps/info_frontend.pp
+++ b/modules/govuk/manifests/apps/info_frontend.pp
@@ -39,7 +39,7 @@ class govuk::apps::info_frontend(
     vhost_aliases           => $vhost_aliases,
     log_format_is_json      => true,
     asset_pipeline          => true,
-    asset_pipeline_prefixes => ['info-frontend'],
+    asset_pipeline_prefixes => ['info-frontend', 'assets/info-frontend'],
     health_check_path       => '/healthcheck',
     json_health_check       => true,
   }

--- a/modules/govuk/manifests/apps/licencefinder.pp
+++ b/modules/govuk/manifests/apps/licencefinder.pp
@@ -46,7 +46,7 @@ class govuk::apps::licencefinder(
     health_check_path       => '/licence-finder/sectors',
     log_format_is_json      => true,
     asset_pipeline          => true,
-    asset_pipeline_prefixes => ['licencefinder'],
+    asset_pipeline_prefixes => ['licencefinder', 'assets/licencefinder'],
     repo_name               => 'licence-finder',
   }
 

--- a/modules/govuk/manifests/apps/manuals_frontend.pp
+++ b/modules/govuk/manifests/apps/manuals_frontend.pp
@@ -33,7 +33,7 @@ class govuk::apps::manuals_frontend(
     port                    => $port,
     sentry_dsn              => $sentry_dsn,
     asset_pipeline          => true,
-    asset_pipeline_prefixes => ['manuals-frontend'],
+    asset_pipeline_prefixes => ['manuals-frontend', 'assets/manuals-frontend'],
     vhost                   => $vhost,
     health_check_path       => '/healthcheck',
     json_health_check       => true,

--- a/modules/govuk/manifests/apps/service_manual_frontend.pp
+++ b/modules/govuk/manifests/apps/service_manual_frontend.pp
@@ -42,7 +42,7 @@ class govuk::apps::service_manual_frontend(
       vhost_ssl_only          => true,
       health_check_path       => '/healthcheck',
       asset_pipeline          => true,
-      asset_pipeline_prefixes => ['service-manual-frontend'],
+      asset_pipeline_prefixes => ['service-manual-frontend', 'assets/service-manual-frontend'],
       vhost                   => $vhost,
     }
 

--- a/modules/govuk/manifests/apps/smartanswers.pp
+++ b/modules/govuk/manifests/apps/smartanswers.pp
@@ -89,7 +89,7 @@ class govuk::apps::smartanswers(
     health_check_path        => '/pay-leave-for-parents/y',
     log_format_is_json       => true,
     asset_pipeline           => true,
-    asset_pipeline_prefixes  => ['smartanswers'],
+    asset_pipeline_prefixes  => ['smartanswers', 'assets/smartanswers'],
     vhost                    => $vhost,
     nagios_memory_warning    => $nagios_memory_warning,
     nagios_memory_critical   => $nagios_memory_critical,

--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -245,7 +245,7 @@ class govuk::apps::whitehall(
       protected               => $vhost_protected,
       app_port                => $port,
       asset_pipeline          => true,
-      asset_pipeline_prefixes => ['government/assets'],
+      asset_pipeline_prefixes => ['government/assets', 'assets/whitehall'],
     }
 
     # govuk::app::config doesn't automatically configure Whitehall's LB healthcheck
@@ -286,7 +286,7 @@ class govuk::apps::whitehall(
       deny_framing            => true,
       deny_crawlers           => true,
       asset_pipeline          => true,
-      asset_pipeline_prefixes => ['government/assets'],
+      asset_pipeline_prefixes => ['government/assets', 'assets/whitehall'],
       hidden_paths            => [$health_check_path],
       nginx_extra_config      => '
       proxy_set_header X-Sendfile-Type X-Accel-Redirect;


### PR DESCRIPTION
Trello: https://trello.com/c/oNEtjIVp/99-serve-static-assets-from-www-hostname

Following on from https://github.com/alphagov/govuk-puppet/pull/10360 and https://github.com/alphagov/govuk-puppet/pull/10384 this applies configuration so all the remaining frontend applications can serve their assets from the www hostname.

This includes Whitehall which is done somewhat optimistically as resolving that application is going to be some work. The others all seem quite straight forward.