### PR TITLE
Disable Faulty Carrenza Production to AWS Staging Sync of Manuals Publisher Database

### DIFF
--- a/hieradata_aws/class/staging/db_admin.yaml
+++ b/hieradata_aws/class/staging/db_admin.yaml
@@ -305,7 +305,7 @@ govuk_env_sync::tasks:
     url: "govuk-production-database-backups"
     path: "mongo-normal"
   "pull_govuk_content_production":
-    ensure: "present"
+    ensure: "disabled"
     hour: "3"
     minute: "20"
     action: "pull"


### PR DESCRIPTION
Due to an incompatibility between DocumentDB and Mongo 2.6 the govuk_env_sync
job is failing to restore the Manuals Publisher database in Staging AWS. The sync job errors
with "error running create command: Field 'create' is currently not supported"
We are temporarily disabling the sync for Manuals Publisher to stop the AWS
Staging Manuals Publisher database being wiped every night by the failed sync,
but we will ensure this is fixed before the migration.