### PR TITLE
Support running only app-specific scenarios

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/smokey.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/smokey.yaml.erb
@@ -29,6 +29,10 @@
             predefined-parameters: |
                 NSCA_CHECK_DESCRIPTION=<%= @service_description %>
                 NSCA_OUTPUT=<%= @service_description %> failed
+    parameters:
+      - string:
+          name: TARGET_APPLICATION
+          description: Application to target (optional).
     builders:
       - shell: |
           set +x

--- a/modules/govuk_jenkins/templates/jobs/smokey.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/smokey.yaml.erb
@@ -33,7 +33,6 @@
       - shell: |
           set +x
           export TARGET_PLATFORM=<%= @environment %>
-          export MYTASK=<%= @smokey_task %>
           set -x
           ./jenkins.sh
     wrappers:


### PR DESCRIPTION
https://trello.com/c/VdbPVqto/154-support-running-only-smokey-tests-that-are-relevant-to-an-app

Depends on: https://github.com/alphagov/smokey/pull/668

This adds an optional string parameter that will be used by the
'jenkins.sh' script in Smokey to only run scenarios with a tag that
matches, noting that many scenarios are not relevant to a given app.
We need this feature to support Continuous Deployment, so that deploys
are not blocked by unrelated failures.