### PR TITLE
Remove some more repos from CI

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -532,7 +532,6 @@ govuk_ci::master::pipeline_jobs:
   asset_bom_removal-rails: {}
   backdrop-transactions-explorer-collector: {}
   deprecated_columns: {}
-  email-alert-monitoring: {}
   gds-api-adapters: {}
   gds-sso: {}
   gds_zendesk: {}
@@ -540,7 +539,6 @@ govuk_ci::master::pipeline_jobs:
   govuk_ab_testing: {}
   govuk_app_config: {}
   govuk-cdn-config: {}
-  govuk-content-schema-test-helpers: {}
   govuk-csp-forwarder: {}
   govuk-dummy_content_store: {}
   govuk_document_types: {}
@@ -549,14 +547,12 @@ govuk_ci::master::pipeline_jobs:
   govuk_message_queue_consumer: {}
   govuk-provisioning: {}
   govuk_publishing_components: {}
-  govuk-secrets: {}
   govuk_seed_crawler: {}
   govuk_schemas: {}
   govuk_sidekiq: {}
   govuk-taxonomy-supervised-learning: {}
   govuk_taxonomy_helpers: {}
   govuk_test: {}
-  govuk-user-reviewer: {}
   licensify:
     branches_to_exclude:
       - 'release*'
@@ -592,7 +588,6 @@ govuk_ci::master::pipeline_jobs:
   slimmer: {}
   smokey: {}
   special-route-publisher: {}
-  transition-config: {}
   ubuntu_unused_kernels:
     repo_owner: 'gds-operations'
   vcloud-core:


### PR DESCRIPTION
- `transition-config`, `govuk-secrets` `govuk-user-reviewer` and `email-alert-monitoring` use GitHub Actions for CI now.
- `govuk-content-schemas-test-helpers` is an archived repo.
