### PR TITLE
Configure feedback to allow assets from www hostname

### DIFF
--- a/hieradata_aws/class/cache.yaml
+++ b/hieradata_aws/class/cache.yaml
@@ -24,6 +24,7 @@ router::nginx::app_specific_static_asset_routes:
   '/assets/calculators/': 'calculators'
   '/assets/collections/': 'collections'
   '/assets/email-alert-frontend/': 'email-alert-frontend'
+  '/assets/feedback/': 'feedback'
   '/assets/finder-frontend/': 'finder-frontend'
   '/assets/info-frontend/': 'info-frontend'
   '/assets/frontend/': 'frontend'

--- a/modules/govuk/manifests/apps/feedback.pp
+++ b/modules/govuk/manifests/apps/feedback.pp
@@ -45,7 +45,7 @@ class govuk::apps::feedback(
     health_check_path       => '/contact',
     log_format_is_json      => true,
     asset_pipeline          => true,
-    asset_pipeline_prefixes => [$app_name],
+    asset_pipeline_prefixes => ['feedback', 'assets/feedback'],
   }
 
   Govuk::App::Envvar {


### PR DESCRIPTION
Trello: https://trello.com/c/oNEtjIVp/99-serve-static-assets-from-www-hostname

This was missed in https://github.com/alphagov/govuk-puppet/pull/10385

This sets up assets/feedback as a path assets can be wrote to
for the feedback app. This then sets up that path in router to proxy
requests for that app. It doesn't set up a proxy in draft-router as
feedback only runs in the live stack.