### PR TITLE
Make Publishing Apps Absent From Carrenza Staging

### DIFF
--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -44,6 +44,20 @@ govuk::apps::static::ga_universal_id: 'UA-26179049-20'
 govuk::apps::travel_advice_publisher::enable_email_alerts: true
 govuk::apps::whitehall::govuk_notify_template_id: "112842bb-d8a4-4511-90de-57dc5c8f27ec"
 
+govuk::apps::contacts::ensure: 'absent'
+govuk::apps::collections_publisher::ensure: 'absent'
+govuk::apps::content_publisher::ensure: 'absent'
+govuk::apps::content_tagger::ensure: 'absent'
+govuk::apps::hmrc_manuals_api::ensure: 'absent'
+govuk::apps::manuals_publisher::ensure: 'absent'
+govuk::apps::maslow::ensure: 'absent'
+govuk::apps::publisher::ensure: 'absent'
+govuk::apps::search_admin::ensure: 'absent'
+govuk::apps::service_manual_publisher::ensure: 'absent'
+govuk::apps::short_url_manager::ensure: 'absent'
+govuk::apps::specialist_publisher::ensure: 'absent'
+govuk::apps::travel_advice_publisher::ensure: 'absent'
+
 govuk::apps::content_tagger::override_search_location: 'https://search-api.staging.govuk.digital'
 govuk::apps::hmrc_manuals_api::override_search_location: 'https://search-api.staging.govuk.digital'
 govuk::apps::search_admin::override_search_location: 'https://search-api.staging.govuk.digital'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -217,6 +217,20 @@ govuk::apps::travel_advice_publisher::mongodb_username: "%{hiera('govuk::apps::a
 govuk::apps::travel_advice_publisher::mongodb_password: "%{hiera('govuk::apps::asset_manager::mongodb_password')}"
 govuk::apps::whitehall::govuk_notify_template_id: "112842bb-d8a4-4511-90de-57dc5c8f27ec"
 
+govuk::apps::contacts::ensure: 'present'
+govuk::apps::collections_publisher::ensure: 'present'
+govuk::apps::content_publisher::ensure: 'present'
+govuk::apps::content_tagger::ensure: 'present'
+govuk::apps::hmrc_manuals_api::ensure: 'present'
+govuk::apps::manuals_publisher::ensure: 'present'
+govuk::apps::maslow::ensure: 'present'
+govuk::apps::publisher::ensure: 'present'
+govuk::apps::search_admin::ensure: 'present'
+govuk::apps::service_manual_publisher::ensure: 'present'
+govuk::apps::short_url_manager::ensure: 'present'
+govuk::apps::specialist_publisher::ensure: 'present'
+govuk::apps::travel_advice_publisher::ensure: 'present'
+
 govuk_search::monitoring::es_port: '80'
 govuk_search::monitoring::es_host: 'vpc-blue-elasticsearch6-domain-uibh77cu2kiudtl76uhseobfzq.eu-west-1.es.amazonaws.com'
 


### PR DESCRIPTION
The Publishing Apps have now been moved to the AWS Staging
environment and can be removed from Carrenza. The other
related hiera will be cleaned up at a later date.

This commit removes the following apps from the Carrenza Backend Machines
Collections Publisher
Contacts
Search Admin
Service Manual Publisher
Content Tagger
Content Publisher
Publisher
Manuals Publisher
Short Url Manager
Specialist Publisher
HMRC manuals api
Maslow
Travel Advice Publisher