### PR TITLE
Sync and restyle Sidekiq job count

### DIFF
--- a/modules/grafana/files/dashboards/sidekiq_job_run_time.json
+++ b/modules/grafana/files/dashboards/sidekiq_job_run_time.json
@@ -43,7 +43,9 @@
           "seriesOverrides": [
             {
               "alias": "Count",
+              "dashes": true,
               "fill": 0,
+              "linewidth": 2,
               "yaxis": 2
             }
           ],
@@ -93,7 +95,7 @@
                   "field": "@timestamp",
                   "id": "2",
                   "settings": {
-                    "interval": "1m",
+                    "interval": "$Interval",
                     "min_doc_count": 0,
                     "trimEdges": 0
                   },


### PR DESCRIPTION
https://trello.com/c/epDHdjIe/311-test-increasing-database-connections-and-workers

Previously the line showing the count of processed Sidekiq jobs used
a different interval to the other lines on the graph, which lead to
confusion since the points on the graph were being aggregated over
different time intervals. This fixes that.

After fixing the time interval, it's hard to distinguish the job count
line from the lines showing the job times. This restyles the line so
it's clear that it represents a different kind of series.

## Before

<img width="849" alt="Screenshot 2020-06-03 at 11 12 58" src="https://user-images.githubusercontent.com/9029009/83625063-47b06080-a58b-11ea-9a2d-847f7030dc97.png">

## After

<img width="835" alt="Screenshot 2020-06-03 at 11 13 27" src="https://user-images.githubusercontent.com/9029009/83625080-4da64180-a58b-11ea-9976-cbcf676d4403.png">
