### PR TITLE
Add a proxy pass for draft-feedback assets to live feedback

### DIFF
--- a/hieradata_aws/class/draft_cache.yaml
+++ b/hieradata_aws/class/draft_cache.yaml
@@ -27,6 +27,7 @@ govuk::apps::router_api::vhost: 'draft-router-api'
 router::nginx::app_specific_static_asset_routes:
   '/assets/collections/': 'draft-collections'
   '/assets/email-alert-frontend/': 'draft-email-alert-frontend'
+  '/assets/feedback/': 'feedback'
   '/assets/frontend/': 'draft-frontend'
   '/assets/government-frontend/': 'draft-government-frontend'
   '/assets/manuals-frontend/': 'draft-manuals-frontend'


### PR DESCRIPTION
Trello: https://trello.com/c/oNEtjIVp/99-serve-static-assets-from-www-hostname

Feedback is a rather unusual app in the gov.uk draft stack where it
proxies directly to the live stack application rather than raising
errors.

This sets up a proxy pass for feedbacks draft assets so they can be
served on the draft stack.