### PR TITLE
[DO NOT MERGE]Make Publishing Apps Absent From Carrenza Production

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -63,6 +63,20 @@ govuk::apps::specialist_publisher::govuk_notify_template_id: "e00e89f5-b622-4dcb
 govuk::apps::travel_advice_publisher::enable_email_alerts: true
 govuk::apps::whitehall::govuk_notify_template_id: "e00e89f5-b622-4dcb-8f30-e6c70231a940"
 
+govuk::apps::contacts::ensure: 'absent'
+govuk::apps::collections_publisher::ensure: 'absent'
+govuk::apps::content_publisher::ensure: 'absent'
+govuk::apps::content_tagger::ensure: 'absent'
+govuk::apps::hmrc_manuals_api::ensure: 'absent'
+govuk::apps::manuals_publisher::ensure: 'absent'
+govuk::apps::maslow::ensure: 'absent'
+govuk::apps::publisher::ensure: 'absent'
+govuk::apps::search_admin::ensure: 'absent'
+govuk::apps::service_manual_publisher::ensure: 'absent'
+govuk::apps::short_url_manager::ensure: 'absent'
+govuk::apps::specialist_publisher::ensure: 'absent'
+govuk::apps::travel_advice_publisher::ensure: 'absent'
+
 govuk::apps::content_tagger::override_search_location: 'https://search-api.production.govuk.digital'
 govuk::apps::hmrc_manuals_api::override_search_location: 'https://search-api.production.govuk.digital'
 govuk::apps::search_admin::override_search_location: 'https://search-api.production.govuk.digital'

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -151,6 +151,20 @@ govuk::apps::content_publisher::govuk_notify_template_id: "e00e89f5-b622-4dcb-8f
 govuk::apps::content_store::performance_platform_big_screen_view_url: 'https://performance-platform-big-screen-view-production.cloudapps.digital'
 govuk::apps::content_store::performance_platform_spotlight_url: 'https://performance-platform-spotlight-production.cloudapps.digital'
 
+govuk::apps::contacts::ensure: 'present'
+govuk::apps::collections_publisher::ensure: 'present'
+govuk::apps::content_publisher::ensure: 'present'
+govuk::apps::content_tagger::ensure: 'present'
+govuk::apps::hmrc_manuals_api::ensure: 'present'
+govuk::apps::manuals_publisher::ensure: 'present'
+govuk::apps::maslow::ensure: 'present'
+govuk::apps::publisher::ensure: 'present'
+govuk::apps::search_admin::ensure: 'present'
+govuk::apps::service_manual_publisher::ensure: 'present'
+govuk::apps::short_url_manager::ensure: 'present'
+govuk::apps::specialist_publisher::ensure: 'present'
+govuk::apps::travel_advice_publisher::ensure: 'present'
+
 govuk::apps::govuk_crawler_worker::blacklist_paths:
   - '/apply-for-a-licence'
   - '/business-finance-support-finder'


### PR DESCRIPTION
The Publishing Apps have now been moved to the AWS Production
environment and can be removed from Carrenza. The other
related hiera will be cleaned up at a later date.

This commit removes the following apps from the Carrenza Backend Machines
Collections Publisher
Contacts
Search Admin
Service Manual Publisher
Content Tagger
Content Publisher
Publisher
Manuals Publisher
Short Url Manager
Specialist Publisher
HMRC manuals api
Maslow
Travel Advice Publisher