### PR TITLE
Set an X-Robots-Tag noindex header for draft-origin and draft-assets

### DIFF
--- a/modules/router/templates/base.conf.erb
+++ b/modules/router/templates/base.conf.erb
@@ -20,10 +20,21 @@ server {
 }
 
 server {
-  server_name         www.* www-origin.* draft-origin.*;
+  server_name         www.* www-origin.*;
   listen 80;
   # Send the Strict-Transport-Security header
   include             /etc/nginx/add-sts.conf;
 
   include             /etc/nginx/router_include.conf;
+}
+
+server {
+  server_name         draft-origin.*;
+  listen 80;
+  # Send the Strict-Transport-Security header
+  include             /etc/nginx/add-sts.conf;
+
+  include             /etc/nginx/router_include.conf;
+
+  add_header X-Robots-Tag "noindex";
 }

--- a/modules/router/templates/draft-assets.conf.erb
+++ b/modules/router/templates/draft-assets.conf.erb
@@ -20,6 +20,7 @@ server {
   proxy_set_header X-Forwarded-Server $host;
   proxy_set_header X-Forwarded-Host $host;
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  add_header X-Robots-Tag "noindex";
 
 <% if @real_ip_header != '' -%>
   # use an unspoofable header from an upstream cdn or l7 load balancer.


### PR DESCRIPTION
Prevent draft content and assets from appearing in external search
engines.

[Trello](https://trello.com/c/qwy7ggkc/1985-3-set-an-x-robots-tag-noindex-header-for-draft-origin-draft-assets-and-whitehall-admin)