### PR TITLE
Add ckan.harvest.timeout setting to ckan.ini

### DIFF
--- a/modules/govuk/templates/ckan/ckan.ini.erb
+++ b/modules/govuk/templates/ckan/ckan.ini.erb
@@ -111,6 +111,7 @@ ckan.harvest.mq.type = redis
 ckan.harvest.mq.hostname = <%= @redis_host%>
 ckan.harvest.mq.port = <%= @redis_port%>
 ckan.harvest.mq.redis_db = 1
+ckan.harvest.timeout = 720  # 12 hours
 
 ckan.redis.url = redis://<%= @redis_host%>:<%= @redis_port%>/1
 


### PR DESCRIPTION
## What

Add harvest timeout setting to stop long running harvest jobs

Set CKAN harvest timeout to 12 hours, normally harvest jobs should take no longer than 1 hour but there may be some jobs which take much longer. As some harvest sources have daily schedules 12 hours is probably enough time for a job to complete and to enable the job to be restarted the next day if it does time out.