### PR TITLE
Up totals for daily Email Alert API monitoring

### DIFF
--- a/modules/govuk/manifests/apps/email_alert_api/checks.pp
+++ b/modules/govuk/manifests/apps/email_alert_api/checks.pp
@@ -55,8 +55,8 @@ class govuk::apps::email_alert_api::checks(
     host_name => $::fqdn,
     target    => 'summarize(groupByNode(consolidateBy(stats_counts.govuk.app.email-alert-api.*.notify.email_send_request.*, "sum"), 1, "sum"), "1d", "sum", false)',
     args      => '--ignore-missing',
-    warning   => '8000000', # 10,000,000 * 0.8
-    critical  => '9000000', # 10,000,000 * 0.9
+    warning   => '20000000', # 25,000,000 * 0.8
+    critical  => '22500000', # 25,000,000 * 0.9
     from      => '3hours',
     desc      => 'email-alert-api - high number of email send requests',
   }

--- a/modules/grafana/files/dashboards/email_alert_api.json
+++ b/modules/grafana/files/dashboards/email_alert_api.json
@@ -133,7 +133,7 @@
           "datasource": "Graphite",
           "format": "none",
           "gauge": {
-            "maxValue": 10000000,
+            "maxValue": 25000000,
             "minValue": 0,
             "show": true,
             "thresholdLabels": false,
@@ -183,7 +183,7 @@
               "textEditor": false
             }
           ],
-          "thresholds": "8000000,9000000",
+          "thresholds": "20000000,22500000",
           "timeFrom": "now/d",
           "timeShift": null,
           "title": "Notify Emails Sent (Today)",


### PR DESCRIPTION
The previous limit of 10,000,000 no longer applies (and I believe this
was actually changed a while ago) instead GOV.UK no longer has it's own
individual limit but Notify does have a limit with SES of 30,000,000.

To reflect this I've upped the limits to reflect 25,000,000 as our
daily limit. Warning threshold is set at 80% of this, 20m, and critical
at 90%, 22.5m.