### PR TITLE
parallel pg_restore

### DIFF
--- a/modules/govuk_env_sync/files/govuk_env_sync.sh
+++ b/modules/govuk_env_sync/files/govuk_env_sync.sh
@@ -360,7 +360,7 @@ function dump_postgresql {
 }
 
 function output_restore_sql {
-  pg_restore "${dumpfile}" | sed -r "${sed_cmds}"
+  pg_restore -j 2 "${dumpfile}" | sed -r "${sed_cmds}"
   if [ "${transformation_sql_file:-}" ]; then
     # pg_dump/pg_restore sets search_path to ''. Reset it to the default so
     # that the transform script doesn't need to prefix table names with


### PR DESCRIPTION
attempt to speed up the psql restore through concurrent restore jobs, see ref:  https://www.postgresql.org/docs/9.3/app-pgrestore.html

We keep the value at 2 because db_admin machines have at least 2 cpu cores in all environment.