### PR TITLE
Rate limit per IP address for licencefinder

### DIFF
--- a/modules/govuk/manifests/apps/licencefinder.pp
+++ b/modules/govuk/manifests/apps/licencefinder.pp
@@ -42,12 +42,25 @@ class govuk::apps::licencefinder(
   govuk::app { $app_name:
     app_type                => 'rack',
     port                    => $port,
+    nginx_extra_config      => template('licencefinder/nginx_extra'),
     sentry_dsn              => $sentry_dsn,
     health_check_path       => '/licence-finder/sectors',
     log_format_is_json      => true,
     asset_pipeline          => true,
     asset_pipeline_prefixes => ['licencefinder', 'assets/licencefinder'],
     repo_name               => 'licence-finder',
+  }
+
+  nginx::conf { 'rate-limiting':
+    content => "limit_req_zone \$binary_remote_addr zone=licencefinder:1m rate=1r/s;\n",
+  }
+
+  nginx::conf { 'real-ip-params':
+    content => "
+      real_ip_header True-Client-Ip;
+      real_ip_recursive on;
+      set_real_ip_from 0.0.0.0/0;
+    ",
   }
 
   govuk::app::envvar::mongodb_uri { $app_name:

--- a/modules/licencefinder/templates/nginx_extra
+++ b/modules/licencefinder/templates/nginx_extra
@@ -1,0 +1,2 @@
+limit_req_status 429;
+limit_req zone=licencefinder burst=40 nodelay;


### PR DESCRIPTION
This PR is a result of trying to limit google's crawler bot activity for
our licencefinder app. We're currently experiencing around 175 r/s
consistently for variations of query string for the path
/licence-finder/sectors and this figure is rising day by day.

We will limit single IP addresses from requesting more than once a
second but with the flexibility of burst requests being allowed so we
don't throttle users who may for example refresh the page multiple times
in a second. This burst limit is set to 40, if the client consistently
requests more than once a second then they are throttled and a 429 is
returned. More info here -> https://www.nginx.com/blog/rate-limiting-nginx/

This 429 should tell the google bot to crawl less and reduce
the traffic to licencefinder.

This PR has taken inspiration from
https://github.com/alphagov/govuk-puppet/pull/10325/files.