### PR TITLE
Make downstream deploys conditional on Smokey

### DIFF
--- a/hieradata/integration.yaml
+++ b/hieradata/integration.yaml
@@ -105,6 +105,7 @@ govuk::node::s_mysql_master::s3_bucket_name: "%{hiera('govuk::node::s_mysql_back
 govuk::node::s_whitehall_backend::sync_mirror: true
 
 govuk_jenkins::jobs::deploy_app_downstream::deploy_url: 'deploy.integration.publishing.service.gov.uk'
+govuk_jenkins::jobs::deploy_app_downstream::smokey_pre_check: false
 
 govuk_postgresql::server::standby::pgpassfile_enabled: true
 

--- a/modules/govuk_jenkins/manifests/jobs/deploy_app_downstream.pp
+++ b/modules/govuk_jenkins/manifests/jobs/deploy_app_downstream.pp
@@ -25,6 +25,7 @@ class govuk_jenkins::jobs::deploy_app_downstream (
   $jenkins_downstream_api_password = undef,
   $deploy_url = undef,
   $github_api_token = undef,
+  $smokey_pre_check = true,
 ) {
   file { '/etc/jenkins_jobs/jobs/deploy_app_downstream.yaml':
     ensure  => present,

--- a/modules/govuk_jenkins/templates/jobs/deploy_app_downstream.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_app_downstream.yaml.erb
@@ -9,6 +9,15 @@
           days-to-keep: 30
           artifact-num-to-keep: 5
     builders:
+      <% if @smokey_pre_check %>
+      - shell: |
+          # Wait for any app restarts to complete before running Smokey
+          sleep 60
+      - trigger-builds:
+          - project: Smokey
+            current-parameters: true
+            block: true
+      <% end %>
       - shell: |
           # Workaround for our inconsistent repo vs. deployment naming
           case "$TARGET_APPLICATION" in


### PR DESCRIPTION
https://trello.com/c/TUB9OGWD/152-prepare-and-run-a-beta-trial-of-continuous-deployment

Depends on: https://github.com/alphagov/smokey/pull/675

Note that CI (Carrenza Integration) does not run Smokey.

## Example output

```
Started by user Ben Thorner
Rebuilds build #3
[EnvInject] - Loading node environment variables.
Building in workspace /var/lib/jenkins/workspace/Deploy_App_Downstream
[Deploy_App_Downstream] $ /bin/sh -xe /tmp/jenkins118727357565754587.sh
+ sleep 60
Waiting for the completion of Smokey
Smokey #19714 completed. Result was SUCCESS
Build step 'Trigger/call builds on other projects' changed build result to SUCCESS
[Deploy_App_Downstream] $ /bin/sh -xe /tmp/jenkins1434944363544085598.sh
+ REPO=smart-answers
...
```