### PR TITLE
Increase the warning memory threshold for the Router

### DIFF
--- a/modules/govuk/manifests/apps/router.pp
+++ b/modules/govuk/manifests/apps/router.pp
@@ -73,7 +73,7 @@ class govuk::apps::router (
     port                                => $port,
     enable_nginx_vhost                  => $enable_nginx_vhost,
     vhost_aliases                       => $vhost_aliases,
-    nagios_memory_warning               => 1100,
+    nagios_memory_warning               => 1500,
     nagios_memory_critical              => 2500,
     sentry_dsn                          => $sentry_dsn,
     alert_when_file_handles_exceed      => 2000,


### PR DESCRIPTION
It looks like we're starting to come up against this now, probably
just because the routing table is getting gradually bigger.