### PR TITLE
Tweak the count metric on the Sidekiq Job Run Time dashboard

### DIFF
--- a/modules/grafana/files/dashboards/sidekiq_job_run_time.json
+++ b/modules/grafana/files/dashboards/sidekiq_job_run_time.json
@@ -85,7 +85,7 @@
                   "type": "percentiles"
                 }
               ],
-              "query": "tags: sidekiq AND @fields.worker:$Worker",
+              "query": "tags: sidekiq AND @fields.worker:$Worker AND @status:done",
               "refId": "A",
               "timeField": "@timestamp"
             },


### PR DESCRIPTION
Only count the log lines for done jobs, as this is more representative
of the rate which jobs are being processed.