### PR TITLE
Ensure pingdom monitoring is absent

### DIFF
--- a/modules/icinga/manifests/config/pingdom.pp
+++ b/modules/icinga/manifests/config/pingdom.pp
@@ -6,12 +6,14 @@ class icinga::config::pingdom (
 ) {
 
   file { '/etc/pingdom.ini':
+    ensure  => 'absent',
     content => template('icinga/etc/pingdom.ini.erb'),
     owner   => 'nagios',
     mode    => '0400',
   }
 
   file { '/usr/local/bin/check_pingdom.py':
+    ensure => 'absent',
     source => 'puppet:///modules/icinga/usr/local/bin/check_pingdom.py',
     mode   => '0755',
   }

--- a/modules/monitoring/manifests/checks/pingdom.pp
+++ b/modules/monitoring/manifests/checks/pingdom.pp
@@ -33,6 +33,7 @@ class monitoring::checks::pingdom (
 
   if $enable {
     icinga::check { 'check_pingdom':
+      ensure              => 'absent',
       check_command       => 'run_pingdom_homepage_check',
       use                 => 'govuk_urgent_priority',
       host_name           => $::fqdn,
@@ -41,6 +42,7 @@ class monitoring::checks::pingdom (
     }
 
     icinga::check { 'check_pingdom_calendar':
+      ensure              => 'absent',
       check_command       => 'run_pingdom_calendar_check',
       use                 => 'govuk_high_priority',
       host_name           => $::fqdn,
@@ -48,6 +50,7 @@ class monitoring::checks::pingdom (
     }
 
     icinga::check { 'check_pingdom_search':
+      ensure              => 'absent',
       check_command       => 'run_pingdom_search_check',
       use                 => 'govuk_urgent_priority',
       host_name           => $::fqdn,
@@ -56,6 +59,7 @@ class monitoring::checks::pingdom (
     }
 
     icinga::check { 'check_pingdom_smart_answer':
+      ensure              => 'absent',
       check_command       => 'run_pingdom_smart_answer_check',
       use                 => 'govuk_high_priority',
       host_name           => $::fqdn,
@@ -63,6 +67,7 @@ class monitoring::checks::pingdom (
     }
 
     icinga::check { 'check_pingdom_mirror_S3':
+      ensure              => 'absent',
       check_command       => 'run_pingdom_mirror_S3_check',
       use                 => 'govuk_high_priority',
       host_name           => $::fqdn,
@@ -71,6 +76,7 @@ class monitoring::checks::pingdom (
     }
 
     icinga::check { 'check_pingdom_mirror_S3_replica':
+      ensure              => 'absent',
       check_command       => 'run_pingdom_mirror_S3_replica_check',
       use                 => 'govuk_high_priority',
       host_name           => $::fqdn,


### PR DESCRIPTION
This monitoring of Pingdom only monitored a few of the Pingdom checks we
have configured, since this isn't comprehensive (and has been this way
for a long time) it indicates we're not getting particularly high value
from it and so have chosen to remove it. This monitoring would have been
better if puppet was also provisioning the checks, but since the
management of them is done through the web interface this puppet code is
just another thing to remember.

This is part of wider work to try bring consistency to our Pingdom
configuration.