### PR TITLE
start push of email alert api earlier in production

### DIFF
--- a/hieradata_aws/class/production/db_admin.yaml
+++ b/hieradata_aws/class/production/db_admin.yaml
@@ -111,8 +111,8 @@ govuk_env_sync::tasks:
     path: "postgresql-backend"
   "push_email_alert_api_production_daily":
     ensure: "present"
-    hour: "2"
-    minute: "40"
+    hour: "0"
+    minute: "15"
     action: "push"
     dbms: "postgresql"
     storagebackend: "s3"


### PR DESCRIPTION
Based on analysis of the govuk_env_sync database backup to S3, email alert api takes more than 1 hour to backup to S3 in production.

09/06: 61 minutes
08/06: 63 minutes
07/06: 64 minutes
06/06: 69 minutes
05/06: 67 minutes
04/09: 68 minutes
03/09: 72 minutes
02/09: 76 minutes

Therefore, we start the backup earlier so that production S3 bucket is updated before the restoration in staging and integration. It should be noted that integration is restored from production because its anonymisation script deletes data more than 1 day old.