### PR TITLE
Disallow Googlebot from crawling licence-finder

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1243,6 +1243,11 @@ router::nginx::robotstxt: |
   User-agent: MS Search 6.0 Robot
   Disallow: /
 
+  # Google's crawler was sending requests for each variation of query param for the sectors page of licence-finder
+  # resulting in millions of requests a day.
+  User-agent: Googlebot
+  Disallow: /licence-finder/*
+
 sidekiq_host: 'redis-1.backend'
 sidekiq_port: '6379'
 


### PR DESCRIPTION
We need to do this as Googlebot is spamming licence-finder with millions
of requests a day. We initially tried [rate limiting by IP](https://github.com/alphagov/govuk-puppet/pull/10401) but the variation of IP addresses google uses renders this approach ineffective as the limit is never reached per single IP address.

Google is trying to index every variation of the licence-finder search
results (different query param per variation) which is resulting in a
lot of requests putting strain on the app and our general infrastructure.

Me and @AlanGabbianelli have discussed this and think it's fine to disallow google
from indexing these pages as the main licence-finder start page will
still be indexed. This comes off a suggestion from Jonathan Nichols.

User agent requests for licence-finder: [Grafana](https://grafana.blue.production.govuk.digital/dashboard/file/requests_by_user_agent.json?orgId=1&var-Applications=licencefinder&from=1590577054000&to=1591700254079) & [Kibana](https://kibana.logit.io/s/2dd89c13-a0ed-4743-9440-825e2e52329e/app/kibana#/discover?_g=()&_a=(columns:!(_source),index:'*-*',interval:auto,query:(query_string:(query:'http_user_agent:%22Mozilla%2F5.0%20(Linux;%20Android%206.0.1;%20Nexus%205X%20Build%2FMMB29P)%20AppleWebKit%2F537.36%20(KHTML,%20like%20Gecko)%20Chrome%2F80.0.3987.92%20Mobile%20Safari%2F537.36%20(compatible;%20Googlebot%2F2.1;%20%2Bhttp:%2F%2Fwww.google.com%2Fbot.html)%22%20AND%20application:%20licencefinder-json.event.access')),sort:!('@timestamp',desc)))

