### PR TITLE
Set an X-Robots-Tag noindex header on draft-cache machines

### DIFF
--- a/modules/router/templates/router_include.conf.erb
+++ b/modules/router/templates/router_include.conf.erb
@@ -78,7 +78,9 @@ location / {
   <%= scope.function_template(['router/fragments/_basic_auth.erb']) -%>
 
   add_header Link "<https://assets.<%= @app_domain %>>; rel=preconnect; crossorigin";
-
+  <% if @aws_migration == 'draft_cache' -%>
+  add_header X-Robots-Tag "noindex";
+  <% end -%>
   # HTML verification for DWP YouTube channel
   location = /dla-ending/google6db9c061ce178960.html {
     add_header Content-Type text/html;


### PR DESCRIPTION
This is to stop search engines indexing our draft content and is related to https://github.com/alphagov/govuk-puppet/pull/10395
