### PR TITLE
Suppress alerts about temporary Grafana dashboards

### DIFF
--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_grafana_dashboards
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_grafana_dashboards
@@ -8,7 +8,7 @@ while getopts ":h:" opt; do
   esac
 done
 
-DASHBOARDS=$(curl -s https://$GRAFANA_HOST/api/search | jq -c '.[]' | grep 'db/' | jq '.title')
+DASHBOARDS=$(curl -s https://$GRAFANA_HOST/api/search | jq -c '.[]' | grep 'db/' | jq '.title' | grep -v 'TEMPORARY')
 
 if [ -z "$DASHBOARDS" ]; then
   echo "OK: All dashboards are in version control"


### PR DESCRIPTION
https://trello.com/c/83FFtDCs/206-improve-email-grafana-dashboards

This allows people to experiment with new Grafana Dashboards, as
long as they are clearly marked as 'temporary'. Previously, it
would be unclear whether a dashboard was useful or maintained.