### PR TITLE
Remove All Publishing App Related Backup Push Jobs From Carrenza Production

### DIFF
--- a/hieradata/class/production/mongo.yaml
+++ b/hieradata/class/production/mongo.yaml
@@ -1,6 +1,6 @@
 govuk_env_sync::tasks:
   "push_maslow_production":
-    ensure: "present"
+    ensure: "absent"
     hour: "1"
     minute: "21"
     action: "push"
@@ -11,7 +11,7 @@ govuk_env_sync::tasks:
     url: "govuk-production-database-backups"
     path: "mongo-normal"
   "push_publisher_production":
-    ensure: "present"
+    ensure: "absent"
     hour: "1"
     minute: "25"
     action: "push"
@@ -22,7 +22,7 @@ govuk_env_sync::tasks:
     url: "govuk-production-database-backups"
     path: "mongo-normal"
   "push_short_url_manager_production":
-    ensure: "present"
+    ensure: "absent"
     hour: "1"
     minute: "29"
     action: "push"
@@ -33,7 +33,7 @@ govuk_env_sync::tasks:
     url: "govuk-production-database-backups"
     path: "mongo-normal"
   "push_travel_advice_publisher_production":
-    ensure: "present"
+    ensure: "absent"
     hour: "1"
     minute: "33"
     action: "push"
@@ -44,7 +44,7 @@ govuk_env_sync::tasks:
     url: "govuk-production-database-backups"
     path: "mongo-normal"
   "push_govuk_content_production":
-    ensure: "present"
+    ensure: "absent"
     hour: "2"
     minute: "51"
     action: "push"

--- a/hieradata/node/mysql-backup-1.backend.publishing.service.gov.uk.yaml
+++ b/hieradata/node/mysql-backup-1.backend.publishing.service.gov.uk.yaml
@@ -1,6 +1,6 @@
 govuk_env_sync::tasks:
   "push_collections_publisher_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "0"
     minute: "12"
     action: "push"
@@ -11,7 +11,7 @@ govuk_env_sync::tasks:
     url: "govuk-production-database-backups"
     path: "mysql"
   "push_contacts_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "0"
     minute: "14"
     action: "push"
@@ -22,7 +22,7 @@ govuk_env_sync::tasks:
     url: "govuk-production-database-backups"
     path: "mysql"
   "push_search_admin_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "0"
     minute: "18"
     action: "push"

--- a/hieradata/node/postgresql-standby-1.backend.publishing.service.gov.uk.yaml
+++ b/hieradata/node/postgresql-standby-1.backend.publishing.service.gov.uk.yaml
@@ -1,6 +1,6 @@
 govuk_env_sync::tasks:
   "push_content_tagger_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "0"
     minute: "6"
     action: "push"
@@ -11,7 +11,7 @@ govuk_env_sync::tasks:
     url: "govuk-production-database-backups"
     path: "postgresql-backend"
   "push_service-manual-publisher_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "0"
     minute: "36"
     action: "push"
@@ -22,7 +22,7 @@ govuk_env_sync::tasks:
     url: "govuk-production-database-backups"
     path: "postgresql-backend"
   "push_content_publisher_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "0"
     minute: "45"
     action: "push"


### PR DESCRIPTION
These are no longer necessary once the migration is complete.