### PR TITLE
Make Absent Any Publishing Apps Related govuk_env_sync Jobs From Carrenza Staging

### DIFF
--- a/hieradata/node/mongo-1.backend.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/mongo-1.backend.staging.publishing.service.gov.uk.yaml
@@ -1,6 +1,6 @@
 govuk_env_sync::tasks:
   "push_maslow_production":
-    ensure: "present"
+    ensure: "absent"
     hour: "1"
     minute: "21"
     action: "push"
@@ -11,7 +11,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mongo-normal"
   "push_publisher_production":
-    ensure: "present"
+    ensure: "absent"
     hour: "1"
     minute: "21"
     action: "push"
@@ -22,7 +22,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mongo-normal"
   "push_short_url_manager_production":
-    ensure: "present"
+    ensure: "absent"
     hour: "1"
     minute: "21"
     action: "push"
@@ -33,7 +33,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mongo-normal"
   "push_travel_advice_publisher_production":
-    ensure: "present"
+    ensure: "absent"
     hour: "1"
     minute: "21"
     action: "push"
@@ -55,7 +55,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mongo-normal"
   "push_govuk_content_production":
-    ensure: "present"
+    ensure: "absent"
     hour: "2"
     minute: "51"
     action: "push"

--- a/hieradata/node/postgresql-primary-1.backend.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/postgresql-primary-1.backend.staging.publishing.service.gov.uk.yaml
@@ -11,7 +11,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "push_content_tagger_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "0"
     minute: "6"
     action: "push"
@@ -22,7 +22,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "push_service-manual-publisher_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "0"
     minute: "4"
     action: "push"


### PR DESCRIPTION
These are no longer necessary, as the Publishing Apps have now been set up
in AWS Staging.