### PR TITLE
Fix misleading 'check_proc_running' alert messages

### DIFF
--- a/modules/collectd/manifests/service.pp
+++ b/modules/collectd/manifests/service.pp
@@ -10,7 +10,7 @@ class collectd::service {
 
   @@icinga::check { "check_collectd_running_${::hostname}":
     check_command       => 'check_nrpe!check_proc_running!collectd',
-    service_description => 'collectd system statistics daemon',
+    service_description => 'collectd system statistics daemon not running',
     host_name           => $::fqdn,
     notes_url           => monitoring_docs_url(check-process-running),
   }

--- a/modules/filebeat/manifests/service.pp
+++ b/modules/filebeat/manifests/service.pp
@@ -16,7 +16,7 @@ class filebeat::service {
   @@icinga::check { "check_filebeat_running_${::hostname}":
     ensure              => $check_ensure,
     check_command       => 'check_nrpe!check_proc_running!filebeat',
-    service_description => 'filebeat running',
+    service_description => 'filebeat not running',
     host_name           => $::fqdn,
     notes_url           => monitoring_docs_url(check-process-running),
   }

--- a/modules/govuk/manifests/node/s_graphite.pp
+++ b/modules/govuk/manifests/node/s_graphite.pp
@@ -58,14 +58,14 @@ class govuk::node::s_graphite (
 
   @@icinga::check { "check_carbon_cache_running_on_${::hostname}":
     check_command       => 'check_nrpe!check_proc_running!carbon-cache.py',
-    service_description => 'carbon-cache running',
+    service_description => 'carbon-cache not running',
     host_name           => $::fqdn,
     notes_url           => monitoring_docs_url(check-process-running),
   }
 
   @@icinga::check { "check_carbon_aggregator_running_on_${::hostname}":
     check_command       => 'check_nrpe!check_proc_running!carbon-aggregat',
-    service_description => 'carbon-aggregator running',
+    service_description => 'carbon-aggregator not running',
     host_name           => $::fqdn,
     notes_url           => monitoring_docs_url(check-process-running),
   }

--- a/modules/govuk_containers/manifests/etcd.pp
+++ b/modules/govuk_containers/manifests/etcd.pp
@@ -30,7 +30,7 @@ class govuk_containers::etcd {
 
   @@icinga::check { "check_etcd_running_${::hostname}":
     check_command       => 'check_nrpe!check_proc_running!etcd',
-    service_description => 'etcd running',
+    service_description => 'etcd not running',
     host_name           => $::fqdn,
     notes_url           => monitoring_docs_url(check-process-running),
   }

--- a/modules/govuk_containers/manifests/gemstash.pp
+++ b/modules/govuk_containers/manifests/gemstash.pp
@@ -42,7 +42,7 @@ class govuk_containers::gemstash(
 
   @@icinga::check { "check_gemstash_running_${::hostname}":
     check_command       => 'check_nrpe!check_proc_running!gemstash',
-    service_description => 'gemstash running',
+    service_description => 'gemstash not running',
     host_name           => $::fqdn,
     notes_url           => monitoring_docs_url(check-process-running),
   }

--- a/modules/govuk_containers/manifests/memcached.pp
+++ b/modules/govuk_containers/manifests/memcached.pp
@@ -37,7 +37,7 @@ class govuk_containers::memcached(
 
   @@icinga::check { "check_memcached_running_${::hostname}":
     check_command       => 'check_nrpe!check_proc_running!memcached',
-    service_description => 'memcached running',
+    service_description => 'memcached not running',
     host_name           => $::fqdn,
     notes_url           => monitoring_docs_url(check-process-running),
   }

--- a/modules/govuk_containers/manifests/redis.pp
+++ b/modules/govuk_containers/manifests/redis.pp
@@ -43,7 +43,7 @@ class govuk_containers::redis(
 
   @@icinga::check { "check_redis_running_${::hostname}":
     check_command       => 'check_nrpe!check_proc_running!redis-server',
-    service_description => 'redis running',
+    service_description => 'redis not running',
     host_name           => $::fqdn,
     notes_url           => monitoring_docs_url(check-process-running),
   }

--- a/modules/govuk_docker/manifests/init.pp
+++ b/modules/govuk_docker/manifests/init.pp
@@ -55,7 +55,7 @@ class govuk_docker (
 
   @@icinga::check { "check_dockerd_running_${::hostname}":
     check_command       => 'check_nrpe!check_proc_running!dockerd',
-    service_description => 'dockerd running',
+    service_description => 'dockerd not running',
     host_name           => $::fqdn,
     notes_url           => monitoring_docs_url(check-process-running),
   }

--- a/modules/govuk_gor/manifests/init.pp
+++ b/modules/govuk_gor/manifests/init.pp
@@ -86,7 +86,7 @@ class govuk_gor(
     check_command       => 'check_nrpe!check_proc_running!goreplay',
     check_period        => 'not_data_sync',
     host_name           => $::fqdn,
-    service_description => 'gor running',
+    service_description => 'gor not running',
     notes_url           => monitoring_docs_url(gor),
   }
 }

--- a/modules/govuk_monit/manifests/init.pp
+++ b/modules/govuk_monit/manifests/init.pp
@@ -11,7 +11,7 @@ class govuk_monit(
 
   @@icinga::check { "check_monit_running_${::hostname}":
     check_command       => 'check_nrpe!check_proc_running!monit',
-    service_description => 'monit running',
+    service_description => 'monit not running',
     host_name           => $::fqdn,
     notes_url           => monitoring_docs_url(check-process-running),
   }

--- a/modules/govuk_prometheus/manifests/init.pp
+++ b/modules/govuk_prometheus/manifests/init.pp
@@ -50,7 +50,7 @@ class govuk_prometheus (
 
   @@icinga::check { "check_prometheus_running_${::hostname}":
     check_command       => 'check_nrpe!check_proc_running!prometheus',
-    service_description => 'prometheus running',
+    service_description => 'prometheus not running',
     host_name           => $::fqdn,
     notes_url           => monitoring_docs_url(check-process-running),
   }

--- a/modules/govuk_prometheus_node_exporter/manifests/init.pp
+++ b/modules/govuk_prometheus_node_exporter/manifests/init.pp
@@ -19,7 +19,7 @@ class govuk_prometheus_node_exporter {
 
   @@icinga::check { "check_prometheus_node_exporter_running_${::hostname}":
     check_command       => 'check_nrpe!check_proc_running!node_exporter',
-    service_description => 'prometheus_node_exporter running',
+    service_description => 'prometheus_node_exporter not running',
     host_name           => $::fqdn,
     notes_url           => monitoring_docs_url(check-process-running),
   }

--- a/modules/govuk_splunk/manifests/init.pp
+++ b/modules/govuk_splunk/manifests/init.pp
@@ -155,7 +155,7 @@ class govuk_splunk(
 
   @@icinga::check { "check_splunk_running_${::hostname}":
     check_command       => 'check_nrpe!check_proc_running!splunkd',
-    service_description => 'splunk universal forwarder running',
+    service_description => 'splunk universal forwarder not running',
     host_name           => $::fqdn,
     notes_url           => monitoring_docs_url(check-process-running),
   }


### PR DESCRIPTION
Some of our alerts were down as 'X not running', as opposed to
'X running'. When the alert happens, the 'Service' message we
see in Icinga/Nagstamon is the 'X running'/'X not running'
message. It's a little confusing to see 'X running' as an alert
when the issue is that it ISN'T running.