### PR TITLE
Add splunk module to frontend

### DIFF
--- a/modules/govuk/manifests/node/s_frontend.pp
+++ b/modules/govuk/manifests/node/s_frontend.pp
@@ -9,6 +9,7 @@ class govuk::node::s_frontend inherits govuk::node::s_base {
 
   include nginx
   include govuk_awscloudwatch
+  include govuk_splunk
 
   # The catchall vhost throws a 500, except for healthcheck requests.
   nginx::config::vhost::default { 'default': }

--- a/modules/govuk_splunk/manifests/client.pp
+++ b/modules/govuk_splunk/manifests/client.pp
@@ -1,0 +1,14 @@
+# == Class: backup::client
+#
+# Configures a machine to use a user for splunk.
+#
+
+govuk_user { 'splunk':
+  fullname    => 'Slunk User',
+  email       => 'cyber.security@digital.cabinet-office.gov.uk',
+  groups      => ['splunk'],
+  purgegroups => true,
+}
+group { 'splunk':
+  ensure => $ensure,
+}

--- a/modules/govuk_splunk/manifests/init.pp
+++ b/modules/govuk_splunk/manifests/init.pp
@@ -84,14 +84,14 @@ class govuk_splunk(
 
   file { '/opt/splunkforwarder/etc/apps/govuk_frontend/':
     ensure => directory,
-    owner   => 'splunk',
+    owner  => 'splunk',
     group  => 'splunk',
     mode   => '0600',
   }
 
   file { '/opt/splunkforwarder/etc/apps/govuk_frontend/default/':
     ensure => directory,
-    owner   => 'splunk',
+    owner  => 'splunk',
     group  => 'splunk',
     mode   => '0600',
   }

--- a/modules/govuk_splunk/manifests/init.pp
+++ b/modules/govuk_splunk/manifests/init.pp
@@ -82,6 +82,20 @@ class govuk_splunk(
                 ],
   }
 
+  file { '/opt/splunkforwarder/etc/apps/govuk_frontend/':
+    ensure => directory,
+    owner   => 'splunk',
+    group  => 'splunk',
+    mode   => '0600',
+  }
+
+  file { '/opt/splunkforwarder/etc/apps/govuk_frontend/default/':
+    ensure => directory,
+    owner   => 'splunk',
+    group  => 'splunk',
+    mode   => '0600',
+  }
+
   file {'/opt/splunkforwarder/etc/apps/100_gds_splunkcloud/default/gds_server.pem':
     ensure  => file,
     owner   => 'splunk',

--- a/modules/govuk_splunk/manifests/init.pp
+++ b/modules/govuk_splunk/manifests/init.pp
@@ -34,15 +34,15 @@
 #
 #
 class govuk_splunk(
-  $gds_servers,
-  $gds_server_cert,
-  $gds_root_ca_cert,
-  $gds_password,
-  $gds_cname,
-  $cyber_servers,
-  $cyber_server_cert,
-  $cyber_root_ca_cert,
-  $cyber_cname,
+  $gds_servers = [],
+  $gds_server_cert = [],
+  $gds_root_ca_cert = [],
+  $gds_password = [],
+  $gds_cname = [],
+  $cyber_servers = [],
+  $cyber_server_cert = [],
+  $cyber_root_ca_cert = [],
+  $cyber_cname = [],
 ) {
 
   include govuk_splunk::repos

--- a/modules/govuk_splunk/templates/opt/splunkforwarder/etc/apps/govuk_frontend/default/inputs.conf
+++ b/modules/govuk_splunk/templates/opt/splunkforwarder/etc/apps/govuk_frontend/default/inputs.conf
@@ -1,3 +1,3 @@
-[monitor:///var/log/nginx/lb-access.log]
-source_type = misc_text
+[monitor:///var/log/nginx/*.log]
+sourcetype = misc_text
 index = test_data

--- a/modules/govuk_splunk/templates/opt/splunkforwarder/etc/apps/govuk_frontend/default/inputs.conf
+++ b/modules/govuk_splunk/templates/opt/splunkforwarder/etc/apps/govuk_frontend/default/inputs.conf
@@ -1,0 +1,3 @@
+[monitor:///var/log/nginx/lb-access.log]
+source_type = misc_text
+index = test_data

--- a/modules/govuk_splunk/templates/opt/splunkforwarder/etc/apps/govuk_frontend/default/inputs.conf
+++ b/modules/govuk_splunk/templates/opt/splunkforwarder/etc/apps/govuk_frontend/default/inputs.conf
@@ -1,3 +1,7 @@
-[monitor:///var/log/nginx/*.log]
-sourcetype = misc_text
-index = test_data
+[monitor:///var/log/nginx/*json.event.access.log]
+sourcetype = govuk_frontend_access
+index = govuk_frontend_staging
+
+[monitor:///var/log/nginx/*error.log]
+sourcetype = govuk_frontend_error
+index = govuk_frontend_staging


### PR DESCRIPTION
### How to add govuk_splunk module to a machine
1. Include the module into the box you want to monitor the logs for. In this instance, we are going to send logs from the frontend node to Splunk. 
2. Create the inputs file in the govuk_splunk module.
3. Add the path of the inputs.conf file and make sure it is present. 

Trello: https://trello.com/c/OsPfVq9q/1943-5-spike-into-getting-logs-into-splunk-pipeline-%F0%9F%8D%90