### PR TITLE
Set an X-Robots-Tag header when denying access to crawlers

### DIFF
--- a/modules/govuk/manifests/apps/ckan.pp
+++ b/modules/govuk/manifests/apps/ckan.pp
@@ -178,6 +178,7 @@ class govuk::apps::ckan (
       hidden_paths       => ['/api/'],
       read_timeout       => $request_timeout,
       nginx_extra_config => template('govuk/ckan/nginx.conf.erb'),
+      deny_crawlers      => true,
     }
 
     file { $ckan_home:

--- a/modules/loadbalancer/templates/nginx_balance.conf.erb
+++ b/modules/loadbalancer/templates/nginx_balance.conf.erb
@@ -77,6 +77,8 @@ server {
   }
 
   <%- if @deny_crawlers -%>
+  add_header X-Robots-Tag "noindex";
+
   location = /robots.txt {
     add_header content-type text/plain;
     return 200 'User-agent: *\nDisallow: /';

--- a/modules/loadbalancer/templates/nginx_balance_no_ssl.conf.erb
+++ b/modules/loadbalancer/templates/nginx_balance_no_ssl.conf.erb
@@ -60,6 +60,8 @@ server {
   }
 
   <%- if @deny_crawlers -%>
+  add_header X-Robots-Tag "noindex";
+
   location = /robots.txt {
     add_header content-type text/plain;
     return 200 'User-agent: *\nDisallow: /';
@@ -80,7 +82,7 @@ server {
     allow 10.0.0.0/8;
     allow 127.0.0.1;
     deny all;
-    <%- end -%> 
+    <%- end -%>
     include includes/maintenance.conf;
     if ($maintenance = 1) {
       error_page 503 /scheduled_maintenance.html;

--- a/modules/nginx/templates/proxy-vhost.conf
+++ b/modules/nginx/templates/proxy-vhost.conf
@@ -95,7 +95,10 @@ server {
   <%- if @deny_framing -%>
   add_header X-Frame-Options DENY;
   <%- end -%>
+
   <%- if scope.lookupvar('::aws_migration') and @deny_crawlers -%>
+  add_header X-Robots-Tag "noindex";
+
   location = /robots.txt {
     add_header content-type text/plain;
     return 200 'User-agent: *\nDisallow: /';

--- a/modules/nginx/templates/static-vhost.conf
+++ b/modules/nginx/templates/static-vhost.conf
@@ -69,7 +69,10 @@ server {
   <%- if @deny_framing -%>
   add_header X-Frame-Options DENY;
   <%- end -%>
+
   <%- if scope.lookupvar('::aws_migration') and @deny_crawlers -%>
+  add_header X-Robots-Tag "noindex";
+
   location = /robots.txt {
     add_header content-type text/plain;
     return 200 'User-agent: *\nDisallow: /';


### PR DESCRIPTION
This is another way of not allowing search engines crawlers from crawling the site. Crucially, it removes the pages from search results if they are linked to, even if the domain has a `robots.txt` file which would ordinarily disallow the crawler.

See https://support.google.com/webmasters/answer/6062608?hl=en&ref_topic=6061961&visit_id=637278233305826665-2774335487&rd=1 for more information on the different ways of denying access to a crawler.

Also disallow crawler access to CKAN.

There is a potential caveat with this solution that [Nginx will reset any existing server `add_header` directives, if one is added to a `location` block](https://www.peterbe.com/plog/be-very-careful-with-your-add_header-in-nginx). This could be a problem in the future but for now it works for CKAN (which was the intention behind this work), I noticed a few places where we've already got `add_header` in the `server` block so I figure it's fine to continue that pattern.

[Trello Card](https://trello.com/c/m7dCrq9k/2021-3-set-an-x-robots-tag-noindex-header-for-ckanpublishingservicegovuk)