### PR TITLE
Set an ASSET_HOST env var for Whitehall Frontend

### DIFF
--- a/hieradata_aws/class/whitehall_frontend.yaml
+++ b/hieradata_aws/class/whitehall_frontend.yaml
@@ -1,4 +1,5 @@
 ---
+govuk::apps::whitehall::asset_host: "%{hiera('govuk::deploy::config::website_root')}"
 govuk::apps::whitehall::configure_frontend: true
 govuk::apps::whitehall::nagios_memory_warning: 10737
 govuk::apps::whitehall::nagios_memory_critical: 12884

--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -22,6 +22,10 @@
 #   Rack limit for how many form parameters it will parse.
 #   Default: undef
 #
+# [*asset_host*]
+#   The URL that will be used as a prefix for whitehall assets.
+#   Default: undef
+#
 # [*asset_manager_bearer_token*]
 #   The bearer token to use when communicating with Asset Manager.
 #   Default: undef
@@ -149,6 +153,7 @@ class govuk::apps::whitehall(
   $admin_db_username = undef,
   $admin_key_space_limit = undef,
   $asset_manager_bearer_token = undef,
+  $asset_host = undef,
   $basic_auth_credentials = undef,
   $configure_frontend = false,
   $configure_admin = false,
@@ -404,6 +409,14 @@ class govuk::apps::whitehall(
     "${title}-RUMMAGER_BEARER_TOKEN":
       varname => 'RUMMAGER_BEARER_TOKEN',
       value   => $rummager_bearer_token;
+  }
+
+  if $asset_host != undef {
+    govuk::app::envvar {
+      "${title}-ASSET_HOST":
+        varname => 'ASSET_HOST',
+        value   => $asset_host;
+    }
   }
 
   if $basic_auth_credentials != undef {


### PR DESCRIPTION
Trello: https://trello.com/c/oNEtjIVp/99-serve-static-assets-from-www-hostname

Whitehall frontend has the surprising characteristic that it can be
served from two different hosts: www.gov.uk and
assets.publishing.service.gov.uk. The latter of which is used in the
case of CSV previews (Example [1]), at least until RFC 122 [2] is
implemented. Because of this serving a relative path to assets will fail
when the hostname changes.

To resolve this I've decided to set the asset host absolutely on
Whitehall frontend to the web root. Normally in this situation we'd also
have to set a draft asset host too, but since Whitehall draft is just
the same app proxied this isn't necessary.

[1]: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/887009/exrates-monthly-0620.csv/preview
[2]: https://github.com/alphagov/govuk-rfcs/blob/master/rfc-122-csv-preview.md