### PR TITLE
Add a job to populate_missing_data_etl

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -681,6 +681,7 @@ govuk_jenkins::jobs::smokey::signon_password: "%{hiera('smokey_signon_password')
 
 govuk_jenkins::jobs::run_rake_task::applications: *deployable_applications
 govuk_jenkins::jobs::deploy_app::applications: *deployable_applications
+govuk_jenkins::jobs::populate_missing_data_etl::rerun_rake_etl_master_process_cron_schedule: '0 3 * * *'
 
 govuk_jenkins::jobs::deploy_app_downstream::applications:
   <<: *deployable_applications

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -879,6 +879,7 @@ govuk_jenkins::packages::govuk_python::apt_mirror_gpg_key_fingerprint: "%{hiera(
 
 govuk_jenkins::jobs::deploy_app::graphite_host: "graphite.%{hiera('app_domain_internal')}"
 govuk_jenkins::jobs::deploy_app::graphite_port: '443'
+govuk_jenkins::jobs::populate_missing_data_etl::rerun_rake_etl_master_process_cron_schedule: '0 3 * * *'
 
 govuk_jenkins::deploy_all_apps::deploy_environment: "%{hiera('govuk_jenkins::job_builder::environment')}"
 

--- a/modules/govuk_jenkins/manifests/jobs/populate_missing_data_etl.pp
+++ b/modules/govuk_jenkins/manifests/jobs/populate_missing_data_etl.pp
@@ -1,0 +1,9 @@
+class govuk_jenkins::jobs:: (
+  $rerun_rake_etl_master_process_cron_schedule = undef,
+) {
+  file { '/etc/jenkins_jobs/jobs/populate_missing_data_etl.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/populate_missing_data_etl.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+}

--- a/modules/govuk_jenkins/templates/jobs/populate_missing_data_etl.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/populate_missing_data_etl.yaml.erb
@@ -1,0 +1,23 @@
+---
+- job:
+    name: rerun_content_data_api_import_etl_master_process
+    display-name: Content Data API - rerun ETL master
+    project-type: freestyle
+    description: "<p>Rerun the etl:master rake task to populate missing data.</p>"
+    builders:
+      - trigger-builds:
+          - project: run-rake-task
+            block: true
+            predefined-parameters: |
+              TARGET_APPLICATION=content-data-api
+              MACHINE_CLASS=backend
+              RAKE_TASK=etl:rerun_master[<% "#{2.days.ago.strftime('%F')}, #{2.days.ago.strftime('%F')}"%>]
+    wrappers:
+      - ansicolor:
+          colormap: xterm
+  <% if @rerun_rake_etl_master_process_cron_schedule %>
+    triggers:
+      - timed: <%= @rerun_rake_etl_master_process_cron_schedule %>
+  <% end %>
+    logrotate:
+        daysToKeep: 365


### PR DESCRIPTION
This adds a job to populate the data that has been
potentially missed by the current ETL job in content_data_api.
It does this by fetching the data for the day before yesterday as this
as this data could have been missed by the (main ETL job)[https://deploy.blue.production.govuk.digital/job/content_data_api_import_etl_master_process/]
, due there being (a potential delay in GA of 24-48 hours)[https://support.google.com/analytics/answer/1070983?hl=en#:~:text=Data%20processing%20latency,for%20up%20to%20two%20days]