### PR TITLE
Fix uses of $Aggregation on the Sidekiq Grafana dashboard

### DIFF
--- a/modules/grafana/files/dashboards/sidekiq.json
+++ b/modules/grafana/files/dashboards/sidekiq.json
@@ -492,7 +492,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Retry set size (max over $Aggregation)",
+          "title": "Retry set size (max over $Interval)",
           "tooltip": {
             "msResolution": true,
             "shared": false,
@@ -575,7 +575,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Failures (total over $Aggregation)",
+          "title": "Failures (total over $Interval)",
           "tooltip": {
             "shared": true,
             "sort": 2,


### PR DESCRIPTION
This template variable was renamed to $Interval at some point.