### PR TITLE
Add Missing Publisher Hieradata to AWS Production

### DIFF
--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -181,6 +181,9 @@ govuk::apps::local_links_manager::run_links_ga_export: true
 govuk::apps::publisher::fact_check_address_format: 'factcheck+production-{id}@alphagov.co.uk'
 govuk::apps::publisher::fact_check_reply_to_id: '792923cb-fa07-4dce-a4c5-e6320bd19c17'
 govuk::apps::publisher::fact_check_reply_to_address: 'factcheck+production@alphagov.co.uk'
+govuk::apps::publisher::email_group_dev: 'govuk-dev@digital.cabinet-office.gov.uk'
+govuk::apps::publisher::email_group_business: 'publisher-alerts-business@digital.cabinet-office.gov.uk'
+govuk::apps::publisher::email_group_citizen: 'publisher-alerts-citizen@digital.cabinet-office.gov.uk'
 govuk::apps::publisher::email_group_force_publish_alerts: 'mainstream-force-publishing-alerts@digital.cabinet-office.gov.uk'
 govuk::apps::publisher::govuk_notify_template_id: "e00e89f5-b622-4dcb-8f30-e6c70231a940"
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-production'


### PR DESCRIPTION
We are migrating the Publishing Apps to AWS Production
and need to ensure the same hieradata is present in both.