### PR TITLE
Add splunk module to cache

### DIFF
--- a/modules/govuk/manifests/node/s_cache.pp
+++ b/modules/govuk/manifests/node/s_cache.pp
@@ -43,6 +43,7 @@ class govuk::node::s_cache (
 
   include govuk_htpasswd
   include nscd
+  include govuk_splunk
 
   unless ( 'ip-10-12-4' in $::hostname ) and ( $::aws_migration == 'cache' ) and ( $::aws_environment == 'staging' ) {
     include router::gor

--- a/modules/govuk_splunk/manifests/init.pp
+++ b/modules/govuk_splunk/manifests/init.pp
@@ -82,6 +82,41 @@ class govuk_splunk(
                 ],
   }
 
+  file { '/opt/splunkforwarder/etc/apps/govuk_frontend/':
+    ensure => directory,
+    owner  => 'splunk',
+    group  => 'splunk',
+    mode   => '0600',
+  }
+
+  file { '/opt/splunkforwarder/etc/apps/govuk_frontend/default/':
+    ensure => directory,
+    owner  => 'splunk',
+    group  => 'splunk',
+    mode   => '0600',
+  }
+
+  file { '/opt/splunkforwarder/etc/apps/':
+    ensure => directory,
+    owner  => 'splunk',
+    group  => 'splunk',
+    mode   => '0600',
+  }
+
+  file { '/opt/splunkforwarder/etc/apps/govuk_cache/':
+    ensure => directory,
+    owner  => 'splunk',
+    group  => 'splunk',
+    mode   => '0600',
+  }
+
+  file { '/opt/splunkforwarder/etc/apps/govuk_cache/default/':
+    ensure => directory,
+    owner  => 'splunk',
+    group  => 'splunk',
+    mode   => '0600',
+  }
+
   file {'/opt/splunkforwarder/etc/apps/100_gds_splunkcloud/default/gds_server.pem':
     ensure  => file,
     owner   => 'splunk',

--- a/modules/govuk_splunk/manifests/init.pp
+++ b/modules/govuk_splunk/manifests/init.pp
@@ -82,6 +82,13 @@ class govuk_splunk(
                 ],
   }
 
+  file { '/opt/splunkforwarder/etc/apps/':
+    ensure => directory,
+    owner  => 'splunk',
+    group  => 'splunk',
+    mode   => '0600',
+  }
+
   file { '/opt/splunkforwarder/etc/apps/govuk_frontend/':
     ensure => directory,
     owner  => 'splunk',

--- a/modules/govuk_splunk/templates/opt/splunkforwarder/etc/apps/govuk_cache/default/inputs.conf
+++ b/modules/govuk_splunk/templates/opt/splunkforwarder/etc/apps/govuk_cache/default/inputs.conf
@@ -1,0 +1,3 @@
+[monitor:///var/log/router/*.log]
+sourcetype = govuk_cache_router
+index = govuk_cache_staging


### PR DESCRIPTION
This PR is to help Cyber monitor the logs in the cache machines.

Trello: https://trello.com/c/OsPfVq9q/1943-5-spike-into-getting-logs-into-splunk-pipeline-%F0%9F%8D%90