### PR TITLE
Asset host follow-up work

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -492,6 +492,7 @@ task :check_consistency_between_aws_and_carrenza do
     grafana::dashboards::machine_suffix_metrics
     monitoring::checks::sidekiq::enable_support_check
     monitoring::pagerduty_drill::enabled
+    router::assets_origin::website_root
     router::nginx::robotstxt
     govuk::apps::govuk_crawler_worker::blacklist_paths
     govuk_awscloudwatch::apt_mirror_hostname

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -440,7 +440,6 @@ govuk::node::s_asset_base::firewall_allow_ip_range: "%{hiera('environment_ip_pre
 # production, and on the dev VM, otherwise nginx will fail to start.
 govuk::node::s_backend_lb::app_specific_static_asset_routes:
   '/asset-manager': "asset-manager"
-  '/government/assets/': "whitehall-frontend"
 govuk::node::s_backend_lb::asset_manager_uploaded_assets_routes:
   - '/government/uploads/'
   - '/media/'
@@ -1183,24 +1182,6 @@ resolvconf::nameservers:
 
 resolvconf::options:
    - 'single-request-reopen'
-
-# Note: it's important that all targets here have matching host entries both in
-# production, and on the dev VM, otherwise nginx will fail to start.
-router::assets_origin::app_specific_static_asset_routes:
-  '/asset-manager': "asset-manager"
-  '/calculators/': "calculators"
-  '/collections/': "collections"
-  '/email-alert-frontend/': "email-alert-frontend"
-  '/feedback/': "feedback"
-  '/finder-frontend/': "finder-frontend"
-  '/frontend/': "frontend"
-  '/government/assets/': "whitehall-frontend"
-  '/government-frontend/': "government-frontend"
-  '/info-frontend/': "info-frontend"
-  '/manuals-frontend/': "manuals-frontend"
-  '/licencefinder/': "licencefinder"
-  '/service-manual-frontend/': "service-manual-frontend"
-  '/smartanswers/': "smartanswers"
 
 router::assets_origin::whitehall_uploaded_assets_routes:
   - '/government/placeholder'

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -896,7 +896,6 @@ govuk::node::s_base::log_remote: false
 
 govuk::node::s_backend_lb::app_specific_static_asset_routes:
   '/asset-manager': "asset-manager"
-  '/government/assets/': "whitehall-frontend"
 govuk::node::s_backend_lb::asset_manager_uploaded_assets_routes:
   - '/government/uploads/'
   - '/media/'
@@ -1379,24 +1378,6 @@ rabbitmq::config_stomp: true
 
 rcs::fsckfix: 'YES'
 rcs::tmptime: '7'
-
-# Note: it's important that all targets here have matching host entries both in
-# production, and on the dev VM, otherwise nginx will fail to start.
-router::assets_origin::app_specific_static_asset_routes:
-  '/asset-manager': "asset-manager"
-  '/calculators/': "calculators"
-  '/collections/': "collections"
-  '/email-alert-frontend/': "email-alert-frontend"
-  '/feedback/': "feedback"
-  '/finder-frontend/': "finder-frontend"
-  '/frontend/': "frontend"
-  '/government/assets/': "whitehall-frontend"
-  '/government-frontend/': "government-frontend"
-  '/info-frontend/': "info-frontend"
-  '/manuals-frontend/': "manuals-frontend"
-  '/licencefinder/': "licencefinder"
-  '/service-manual-frontend/': "service-manual-frontend"
-  '/smartanswers/': "smartanswers"
 
 router::assets_origin::whitehall_uploaded_assets_routes:
   - '/government/placeholder'

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1411,6 +1411,8 @@ router::assets_origin::vhost_aliases:
   - 'assets.publishing.service.gov.uk'
   - 'assets.production.govuk.digital'
 
+router::assets_origin::website_root: "%{hiera('govuk::deploy::config::website_root')}"
+
 router::nginx::check_requests_warning: '@10'
 router::nginx::check_requests_critical: '@8'
 router::nginx::robotstxt: |

--- a/modules/govuk/manifests/apps/calculators.pp
+++ b/modules/govuk/manifests/apps/calculators.pp
@@ -31,7 +31,7 @@ class govuk::apps::calculators(
     health_check_path       => '/child-benefit-tax-calculator/main',
     log_format_is_json      => true,
     asset_pipeline          => true,
-    asset_pipeline_prefixes => ['calculators', 'assets/calculators'],
+    asset_pipeline_prefixes => ['assets/calculators'],
   }
 
   Govuk::App::Envvar {

--- a/modules/govuk/manifests/apps/collections.pp
+++ b/modules/govuk/manifests/apps/collections.pp
@@ -51,7 +51,7 @@ class govuk::apps::collections(
     health_check_path        => '/topic/oil-and-gas',
     log_format_is_json       => true,
     asset_pipeline           => true,
-    asset_pipeline_prefixes  => ['collections', 'assets/collections'],
+    asset_pipeline_prefixes  => ['assets/collections'],
     vhost                    => $vhost,
     nagios_memory_warning    => $nagios_memory_warning,
     nagios_memory_critical   => $nagios_memory_critical,

--- a/modules/govuk/manifests/apps/email_alert_frontend.pp
+++ b/modules/govuk/manifests/apps/email_alert_frontend.pp
@@ -50,7 +50,7 @@ class govuk::apps::email_alert_frontend(
     port                    => $port,
     sentry_dsn              => $sentry_dsn,
     asset_pipeline          => true,
-    asset_pipeline_prefixes => ['email-alert-frontend', 'assets/email-alert-frontend'],
+    asset_pipeline_prefixes => ['assets/email-alert-frontend'],
     vhost                   => $vhost,
     health_check_path       => '/healthcheck',
     json_health_check       => true,

--- a/modules/govuk/manifests/apps/feedback.pp
+++ b/modules/govuk/manifests/apps/feedback.pp
@@ -45,7 +45,7 @@ class govuk::apps::feedback(
     health_check_path       => '/contact',
     log_format_is_json      => true,
     asset_pipeline          => true,
-    asset_pipeline_prefixes => ['feedback', 'assets/feedback'],
+    asset_pipeline_prefixes => ['assets/feedback'],
   }
 
   Govuk::App::Envvar {

--- a/modules/govuk/manifests/apps/finder_frontend.pp
+++ b/modules/govuk/manifests/apps/finder_frontend.pp
@@ -42,7 +42,7 @@ class govuk::apps::finder_frontend(
       json_health_check        => true,
       log_format_is_json       => true,
       asset_pipeline           => true,
-      asset_pipeline_prefixes  => ['finder-frontend', 'assets/finder-frontend'],
+      asset_pipeline_prefixes  => ['assets/finder-frontend'],
       nagios_memory_warning    => $nagios_memory_warning,
       nagios_memory_critical   => $nagios_memory_critical,
       unicorn_worker_processes => $unicorn_worker_processes,

--- a/modules/govuk/manifests/apps/frontend.pp
+++ b/modules/govuk/manifests/apps/frontend.pp
@@ -79,7 +79,7 @@ class govuk::apps::frontend(
     health_check_path        => '/',
     log_format_is_json       => true,
     asset_pipeline           => true,
-    asset_pipeline_prefixes  => ['frontend', 'assets/frontend'],
+    asset_pipeline_prefixes  => ['assets/frontend'],
     nagios_memory_warning    => $nagios_memory_warning,
     nagios_memory_critical   => $nagios_memory_critical,
     vhost                    => $vhost,

--- a/modules/govuk/manifests/apps/government_frontend.pp
+++ b/modules/govuk/manifests/apps/government_frontend.pp
@@ -70,7 +70,7 @@ class govuk::apps::government_frontend(
     vhost_ssl_only           => true,
     health_check_path        => '/healthcheck',
     asset_pipeline           => true,
-    asset_pipeline_prefixes  => ['government-frontend', 'assets/government-frontend'],
+    asset_pipeline_prefixes  => ['assets/government-frontend'],
     vhost                    => $vhost,
     unicorn_worker_processes => $unicorn_worker_processes,
     cpu_warning              => $cpu_warning,

--- a/modules/govuk/manifests/apps/info_frontend.pp
+++ b/modules/govuk/manifests/apps/info_frontend.pp
@@ -39,7 +39,7 @@ class govuk::apps::info_frontend(
     vhost_aliases           => $vhost_aliases,
     log_format_is_json      => true,
     asset_pipeline          => true,
-    asset_pipeline_prefixes => ['info-frontend', 'assets/info-frontend'],
+    asset_pipeline_prefixes => ['assets/info-frontend'],
     health_check_path       => '/healthcheck',
     json_health_check       => true,
   }

--- a/modules/govuk/manifests/apps/licencefinder.pp
+++ b/modules/govuk/manifests/apps/licencefinder.pp
@@ -47,7 +47,7 @@ class govuk::apps::licencefinder(
     health_check_path       => '/licence-finder/sectors',
     log_format_is_json      => true,
     asset_pipeline          => true,
-    asset_pipeline_prefixes => ['licencefinder', 'assets/licencefinder'],
+    asset_pipeline_prefixes => ['assets/licencefinder'],
     repo_name               => 'licence-finder',
   }
 

--- a/modules/govuk/manifests/apps/manuals_frontend.pp
+++ b/modules/govuk/manifests/apps/manuals_frontend.pp
@@ -33,7 +33,7 @@ class govuk::apps::manuals_frontend(
     port                    => $port,
     sentry_dsn              => $sentry_dsn,
     asset_pipeline          => true,
-    asset_pipeline_prefixes => ['manuals-frontend', 'assets/manuals-frontend'],
+    asset_pipeline_prefixes => ['assets/manuals-frontend'],
     vhost                   => $vhost,
     health_check_path       => '/healthcheck',
     json_health_check       => true,

--- a/modules/govuk/manifests/apps/service_manual_frontend.pp
+++ b/modules/govuk/manifests/apps/service_manual_frontend.pp
@@ -42,7 +42,7 @@ class govuk::apps::service_manual_frontend(
       vhost_ssl_only          => true,
       health_check_path       => '/healthcheck',
       asset_pipeline          => true,
-      asset_pipeline_prefixes => ['service-manual-frontend', 'assets/service-manual-frontend'],
+      asset_pipeline_prefixes => ['assets/service-manual-frontend'],
       vhost                   => $vhost,
     }
 

--- a/modules/govuk/manifests/apps/smartanswers.pp
+++ b/modules/govuk/manifests/apps/smartanswers.pp
@@ -89,7 +89,7 @@ class govuk::apps::smartanswers(
     health_check_path        => '/pay-leave-for-parents/y',
     log_format_is_json       => true,
     asset_pipeline           => true,
-    asset_pipeline_prefixes  => ['smartanswers', 'assets/smartanswers'],
+    asset_pipeline_prefixes  => ['assets/smartanswers'],
     vhost                    => $vhost,
     nagios_memory_warning    => $nagios_memory_warning,
     nagios_memory_critical   => $nagios_memory_critical,

--- a/modules/govuk/manifests/apps/static.pp
+++ b/modules/govuk/manifests/apps/static.pp
@@ -82,7 +82,7 @@ class govuk::apps::static(
     log_format_is_json       => true,
     nginx_extra_config       => template('govuk/static_extra_nginx_config.conf.erb'),
     asset_pipeline           => true,
-    asset_pipeline_prefixes  => [$app_name, 'assets/static'],
+    asset_pipeline_prefixes  => ['assets/static'],
     vhost                    => $vhost,
     unicorn_worker_processes => $unicorn_worker_processes,
     nagios_memory_warning    => $nagios_memory_warning,

--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -251,7 +251,7 @@ class govuk::apps::whitehall(
       protected               => $vhost_protected,
       app_port                => $port,
       asset_pipeline          => true,
-      asset_pipeline_prefixes => ['government/assets', 'assets/whitehall'],
+      asset_pipeline_prefixes => ['assets/whitehall'],
     }
 
     # govuk::app::config doesn't automatically configure Whitehall's LB healthcheck
@@ -290,7 +290,7 @@ class govuk::apps::whitehall(
       deny_framing            => true,
       deny_crawlers           => true,
       asset_pipeline          => true,
-      asset_pipeline_prefixes => ['government/assets', 'assets/whitehall'],
+      asset_pipeline_prefixes => ['assets/whitehall'],
       hidden_paths            => [$health_check_path],
       nginx_extra_config      => '
       proxy_set_header X-Sendfile-Type X-Accel-Redirect;

--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -348,17 +348,10 @@ class govuk::apps::whitehall(
       memory_critical_threshold => 14000,
     }
 
-    # NOTE. The GOVUK_ASSET_ROOT environment variable uses a protocol relative
-    # URL so assets in admin are on the same domain but work in production and
-    # development. (This is needed for IE8)
     govuk::app::envvar {
       "${title}-ASSET_MANAGER_BEARER_TOKEN":
         varname => 'ASSET_MANAGER_BEARER_TOKEN',
         value   => $asset_manager_bearer_token;
-      "${title}-GOVUK_ASSET_ROOT":
-        app     => $app_name,
-        varname => 'GOVUK_ASSET_ROOT',
-        value   => "//whitehall-admin.${app_domain}";
       "${title}-HIGHLIGHT_WORDS_TO_AVOID":
         varname => 'HIGHLIGHT_WORDS_TO_AVOID',
         value   => bool2str($highlight_words_to_avoid);

--- a/modules/govuk/templates/node/s_backend_lb/assets-carrenza.conf.erb
+++ b/modules/govuk/templates/node/s_backend_lb/assets-carrenza.conf.erb
@@ -95,21 +95,13 @@ server {
   }
   <%- end -%>
 
-  <%- if scope.lookupvar('::aws_migration') %>
-  set $upstream_static <%= @upstream_ssl ? 'https' : 'http' %>://static.<%= @app_domain %>;
-  <%- end %>
-  location = /static/a {
-    <%- if scope.lookupvar('::aws_migration') %>
-    proxy_pass $upstream_static;
-    <%- else %>
-    proxy_pass <%= @upstream_ssl ? 'https' : 'http' %>://static.<%= @app_domain %>;
-    <%- end %>
-  }
-
   location /__canary__ {
     return 200;
   }
 
+  <%- if scope.lookupvar('::aws_migration') %>
+  set $upstream_static <%= @upstream_ssl ? 'https' : 'http' %>://static.<%= @app_domain %>;
+  <%- end %>
   location / {
     <%- if scope.lookupvar('::aws_migration') %>
     proxy_pass $upstream_static;

--- a/modules/govuk/templates/static_extra_nginx_config.conf.erb
+++ b/modules/govuk/templates/static_extra_nginx_config.conf.erb
@@ -1,11 +1,3 @@
-location = /static/a {
-  expires -1;
-  add_header Last-Modified "";
-
-  default_type text/plain;
-  return 200 '';
-}
-
 # 1stline use this URL in their zendesk template
 location = /static/gov.uk_logotype_crown.png {
   absolute_redirect off;

--- a/modules/router/manifests/assets_origin.pp
+++ b/modules/router/manifests/assets_origin.pp
@@ -23,6 +23,9 @@
 # [*vhost_name*]
 #   Primary vhost that assets should be served on at origin
 #
+# [*website_root*]
+#   The URL to the root of the main GOV.UK host for redirects
+#
 class router::assets_origin(
   $app_specific_static_asset_routes = {},
   $asset_manager_uploaded_assets_routes = [],
@@ -30,6 +33,7 @@ class router::assets_origin(
   $real_ip_header = '',
   $vhost_aliases = [],
   $vhost_name = 'assets-origin',
+  $website_root = undef,
 ) {
   validate_array($vhost_aliases)
 

--- a/modules/router/manifests/assets_origin.pp
+++ b/modules/router/manifests/assets_origin.pp
@@ -4,9 +4,6 @@
 #
 # === Parameters
 #
-# [*app_specific_static_asset_routes*]
-#   Hash of paths => vhost_names.  Each entry will be added as a route in the vhost
-#
 # [*asset_manager_uploaded_assets_routes*]
 #   Hash of paths => vhost_names.  Each entry will be added as a route in the vhost
 #
@@ -27,7 +24,6 @@
 #   The URL to the root of the main GOV.UK host for redirects
 #
 class router::assets_origin(
-  $app_specific_static_asset_routes = {},
   $asset_manager_uploaded_assets_routes = [],
   $whitehall_uploaded_assets_routes = [],
   $real_ip_header = '',

--- a/modules/router/templates/assets_origin.conf.erb
+++ b/modules/router/templates/assets_origin.conf.erb
@@ -78,10 +78,6 @@ server {
   <%- end -%>
 
   set $upstream_static <%= @upstream_ssl ? 'https' : 'http' %>://static.<%= @app_domain %>;
-  location = /static/a {
-    proxy_pass $upstream_static;
-  }
-
   location /__canary__ {
     proxy_pass $upstream_static;
   }

--- a/modules/router/templates/assets_origin.conf.erb
+++ b/modules/router/templates/assets_origin.conf.erb
@@ -37,6 +37,10 @@ server {
   add_header "Access-Control-Allow-Methods" "GET, OPTIONS";
   add_header "Access-Control-Allow-Headers" "origin, authorization";
 
+  <%- if @website_root -%>
+  rewrite ^/government/assets/(.*)$ <%= @website_root %>/assets/whitehall/$1 permanent;
+  <%- end -%>
+
   location /government/uploads/system/uploads/consultation_response_form/ {
     add_header Cache-Control "public";
     expires 1y;

--- a/modules/router/templates/assets_origin.conf.erb
+++ b/modules/router/templates/assets_origin.conf.erb
@@ -47,13 +47,6 @@ server {
     rewrite ^/government/uploads/system/uploads/consultation_response_form/(.*)$ /government/uploads/system/uploads/consultation_response_form_data/$1;
   }
 
-  <%- @app_specific_static_asset_routes.each do |alias_path, vhost_name| -%>
-  set $upstream_<%= vhost_name.delete "-" %> <%= @upstream_ssl ? 'https' : 'http' %>://<%= vhost_name %>.<%= @app_domain %>;
-  location <%= alias_path %> {
-    proxy_pass $upstream_<%= vhost_name.delete "-" %>;
-  }
-  <%- end -%>
-
   set $upstream_asset_manager <%= @upstream_ssl ? 'https' : 'http' %>://asset-manager.<%= @app_domain %>;
   <%- @asset_manager_uploaded_assets_routes.each do |path| -%>
   location <%= path %> {

--- a/modules/router/templates/router_include.conf.erb
+++ b/modules/router/templates/router_include.conf.erb
@@ -33,6 +33,14 @@ location ~ ^\/[A-Z]+[A-Z\W\d]+$ {
   rewrite ^(.*)$ https://$host$uri_lowercase permanent;
 }
 
+# Rewrite the path of legacy Whitehall assets.
+# Whitehall writes paths to the applications assets inside content items, which
+# can make it very hard to change the URL. This rewrites any request to
+# /government/assets/* to the new path of /assets/whitehall. A redirect isn't
+# used because there are lots of these and this would cause a substantial
+# number of extra requests.
+rewrite ^/government/assets/(.*)$ /assets/whitehall/$1;
+
 <%- @app_specific_static_asset_routes.each do |alias_path, vhost_name| -%>
 <%- proxy_host = "#{vhost_name}.#{@app_domain_internal}" -%>
 <%- upstream = "$upstream_#{vhost_name.delete('-')}" -%>

--- a/modules/router/templates/router_include.conf.erb
+++ b/modules/router/templates/router_include.conf.erb
@@ -85,7 +85,6 @@ location ~ ^/contact/govuk(/(|service-feedback(/)?|problem_reports(/)?|foi(/)?|p
 location / {
   <%= scope.function_template(['router/fragments/_basic_auth.erb']) -%>
 
-  add_header Link "<https://assets.<%= @app_domain %>>; rel=preconnect; crossorigin";
   <% if @aws_migration == 'draft_cache' -%>
   add_header X-Robots-Tag "noindex";
   <% end -%>


### PR DESCRIPTION
Trello: https://trello.com/c/oNEtjIVp/99-serve-static-assets-from-www-hostname

This is a bunch of work to reflect that all GOV.UK frontend apps are now serving their assets from the www hostname now.

This does a number of things:

- Sets up a redirect from `https://assets.publishing.service.gov.uk/government/assets/*` to `https://www.gov.uk/assets/whitehall/*` - this is to support old requests (for example [this fraction url](https://assets.publishing.service.gov.uk/government/assets/fractions/1_3-689f5cee5978bfc8ef949d84f5f35d67c0cabf76173bfece3f165a7341e4a0e3.png))
- Sets up an nginx rewrite for /government/assets/* to /assets/whitehall/* - we have a lot of these (see any publication, for example [the HTML icon](https://www.gov.uk/government/publications/national-curriculum-in-england-mathematics-programmes-of-study)) and I was surprised they even worked at all
- Removes a path for our own analytics that we never built
- Removes Whitehall's customisation of ASSET_ROOT env var as this isn't used anymore
- Removes a HTTP preconnect header to connect to the assets hostname for faster asset loading, not needed now the assets are served off www
- Removes setting the legacy asset paths for each frontend app
- Removes the configuration to proxy assets via the assets hostname

More info in the commits.