### PR TITLE
Fixes the list of jobs required after content-tagger migration

### DIFF
--- a/hieradata_aws/class/production/jenkins.yaml
+++ b/hieradata_aws/class/production/jenkins.yaml
@@ -50,8 +50,8 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::deploy_app
   - govuk_jenkins::jobs::deploy_emergency_banner
   - govuk_jenkins::jobs::deploy_puppet
-  - govuk_jenkins::jobs::record_taxonomy_metrics
-  - govuk_jenkins::jobs::remove_emergency_banner
+  - govuk_jenkins::jobs::govuk_taxonomy_supervised_learning
+  - govuk_jenkins::jobs::monitor_taxonomy_health
   - govuk_jenkins::jobs::email_alert_check
   - govuk_jenkins::jobs::enhanced_ecommerce_search_api
   - govuk_jenkins::jobs::passive_checks


### PR DESCRIPTION
content-tagger has been migrated to AWS