### PR TITLE
Remove DEPLOY_TASK param for downstream deploys

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_app_downstream.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_app_downstream.yaml.erb
@@ -63,7 +63,7 @@
           fi
       - shell: |
           # Deploy to downstream environment
-          JSON="{\"parameter\": [{\"name\": \"TARGET_APPLICATION\", \"value\": \"$TARGET_APPLICATION\"}, {\"name\": \"TAG\", \"value\": \"$TAG\"}, {\"name\": \"DEPLOY_TASK\", \"value\": \"$DEPLOY_TASK\"}, {\"name\": \"NOTIFY_RELEASE_APP\", \"value\": \"true\"}, {\"name\": \"SLACK_NOTIFICATIONS\", \"value\": \"true\"}], \"\": \"\"}"
+          JSON="{\"parameter\": [{\"name\": \"TARGET_APPLICATION\", \"value\": \"$TARGET_APPLICATION\"}, {\"name\": \"TAG\", \"value\": \"$TAG\"}, {\"name\": \"DEPLOY_TASK\", \"value\": \"deploy\"}, {\"name\": \"NOTIFY_RELEASE_APP\", \"value\": \"true\"}, {\"name\": \"SLACK_NOTIFICATIONS\", \"value\": \"true\"}], \"\": \"\"}"
           CRUMB=$(curl https://<%= @jenkins_downstream_api_user %>:<%= @jenkins_downstream_api_password %>@<%= @deploy_url %>/crumbIssuer/api/json | jq --raw-output '. | .crumb')
           curl -f -H "Jenkins-Crumb:$CRUMB" -XPOST https://<%= @jenkins_downstream_api_user %>:<%= @jenkins_downstream_api_password %>@<%= @deploy_url %>/job/Deploy_App/build --data-urlencode json="$JSON"
     wrappers:
@@ -77,13 +77,6 @@
         - string:
             name: TAG
             description: 'Git tag/committish to deploy.'
-        - choice:
-            name: DEPLOY_TASK
-            description: 'Task to run (available as $DEPLOY_TASK to deploy.sh and passed explicitly to Capistrano).'
-            choices:
-              - deploy
-              - deploy:migrations
-              - deploy:setup
     publishers:
         - description-setter:
             regexp: ""


### PR DESCRIPTION
https://trello.com/c/xz9cz8Si/164-activate-continuous-deployment

This should only be set to "deploy". Note that our deploy scripts
will automatically run migrations unless specified not to, in
which case we should not be using this job anyway.