### PR TITLE
Activate Continuous Deployment

### DIFF
--- a/lib/puppet-lint/plugins/check_hiera.rb
+++ b/lib/puppet-lint/plugins/check_hiera.rb
@@ -58,6 +58,10 @@ PuppetLint.new_check(:hiera_explicit_lookup) do
     # nginx virtual host configuration
     'router::assets_origin::asset_manager_uploaded_assets_routes',
 
+    # Allow deploy_app.pp to share knowledge about the applications supported
+    # by deploy_app_downstream. This will become redundant once all apps support Continuous Deployment.
+    'govuk_jenkins::jobs::deploy_app_downstream::applications',
+
     'mysql_replica_password',
     'mysql_root',
     'nginx_enable_ssl',

--- a/modules/govuk_jenkins/manifests/jobs/deploy_app.pp
+++ b/modules/govuk_jenkins/manifests/jobs/deploy_app.pp
@@ -18,7 +18,10 @@
 #   release version.
 #
 # [*enable_slack_notifications*]
-#   Set to true to post details of a deployment into a Slack channel.
+#   Set to true to post details of a deployment into a Slack channel
+#
+# [*deploy_downstream_applications*]
+#   A hash of applications supported for downstream deployment
 #
 class govuk_jenkins::jobs::deploy_app (
   $app_domain = undef,
@@ -29,6 +32,7 @@ class govuk_jenkins::jobs::deploy_app (
   $graphite_port = '80',
   $notify_release_app = true,
   $enable_slack_notifications = true,
+  $deploy_downstream_applications = hiera('govuk_jenkins::jobs::deploy_app_downstream::applications'),
 ) {
   if $::aws_migration {
     $aws_deploy = true

--- a/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
@@ -42,6 +42,30 @@
 
             git clone ${APP_DEPLOYMENT_GIT_URL} --branch master --single-branch --depth 1 ./
             ./jenkins.sh
+        - conditional-step:
+            condition-kind: and
+            condition-operands:
+              # Only trigger downstream deploy for "deploy" tasks
+              - condition-kind: strings-match
+                condition-string1: "$DEPLOY_TASK"
+                condition-string2: "deploy"
+              # Only trigger downstream deploy for "release_123" tags
+              - condition-kind: regex-match
+                regex: "release_.*"
+                label: "$TAG"
+              # Only trigger downstream deploy for support apps
+              - condition-kind: or
+                condition-operands:
+                  <% @deploy_downstream_applications.keys.each do |app| %>
+                  - condition-kind: strings-match
+                    condition-string1: "$TARGET_APPLICATION"
+                    condition-string2: "<%= app %>"
+                  <% end %>
+                  - condition-kind: never # until we have multiple apps
+            steps:
+              - trigger-builds:
+                  - project: Deploy_App_Downstream
+                    current-parameters: true
     publishers:
         - trigger:
             project: Smokey


### PR DESCRIPTION
https://trello.com/c/xz9cz8Si/164-activate-continuous-deployment

This adds a conditional step to the Deploy_App job, which will trigger
a downstream deploy for a standard "deploy" build of a specific release
tag of a supported app. Adding all these conditionals means we avoid
triggering invalid builds of the Deploy_App_Downstream job, which would
look alarming if someone views the job logs.

Note that merging a PR always triggers a standard "deploy" build [1],
so we should avoid triggering a downstream deployment for other deploy
tasks; most apps will automatically run migrations as part of "deploy".

[1]: https://github.com/alphagov/govuk-jenkinslib/blob/b5af39d69a14c94bcecb770f7bba40b0ec672af7/vars/govuk.groovy#L134