### PR TITLE
Fix removal mechanism for some publisher apps

### DIFF
--- a/modules/govuk/manifests/apps/collections_publisher.pp
+++ b/modules/govuk/manifests/apps/collections_publisher.pp
@@ -94,6 +94,11 @@ class govuk::apps::collections_publisher(
     deny_framing       => true,
   }
 
+  govuk::procfile::worker { $app_name:
+    ensure         => $ensure,
+    enable_service => $enable_procfile_worker,
+  }
+
   unless $ensure == 'absent' {
     Govuk::App::Envvar {
       app => $app_name,
@@ -137,8 +142,5 @@ class govuk::apps::collections_publisher(
       database => $db_name,
     }
 
-    govuk::procfile::worker { $app_name:
-      enable_service => $enable_procfile_worker,
-    }
   }
 }

--- a/modules/govuk/manifests/apps/content_tagger.pp
+++ b/modules/govuk/manifests/apps/content_tagger.pp
@@ -102,6 +102,11 @@ class govuk::apps::content_tagger(
     override_search_location => $override_search_location,
   }
 
+  govuk::procfile::worker { 'content-tagger':
+    ensure         => $ensure,
+    enable_service => $enable_procfile_worker,
+  }
+
   unless $ensure == 'absent' {
     Govuk::App::Envvar {
       app => $app_name,
@@ -144,8 +149,5 @@ class govuk::apps::content_tagger(
       database                  => $db_name,
     }
 
-    govuk::procfile::worker { 'content-tagger':
-      enable_service => $enable_procfile_worker,
-    }
   }
 }

--- a/modules/govuk/manifests/apps/hmrc_manuals_api.pp
+++ b/modules/govuk/manifests/apps/hmrc_manuals_api.pp
@@ -53,6 +53,17 @@ class govuk::apps::hmrc_manuals_api(
 
   validate_re($ensure, '^(present|absent)$', 'Invalid ensure value')
 
+  govuk::app { 'hmrc-manuals-api':
+    ensure                   => $ensure,
+    app_type                 => 'rack',
+    port                     => $port,
+    sentry_dsn               => $sentry_dsn,
+    vhost_ssl_only           => true,
+    health_check_path        => '/healthcheck',
+    log_format_is_json       => true,
+    override_search_location => $override_search_location,
+  }
+
   unless $ensure == 'absent' {
     Govuk::App::Envvar {
       app => 'hmrc-manuals-api',
@@ -86,14 +97,5 @@ class govuk::apps::hmrc_manuals_api(
         value   => $publishing_api_bearer_token,
     }
 
-    govuk::app { 'hmrc-manuals-api':
-      app_type                 => 'rack',
-      port                     => $port,
-      sentry_dsn               => $sentry_dsn,
-      vhost_ssl_only           => true,
-      health_check_path        => '/healthcheck',
-      log_format_is_json       => true,
-      override_search_location => $override_search_location,
-    }
   }
 }

--- a/modules/govuk/manifests/apps/search_admin.pp
+++ b/modules/govuk/manifests/apps/search_admin.pp
@@ -107,6 +107,11 @@ class govuk::apps::search_admin(
     override_search_location => $override_search_location,
   }
 
+  govuk::procfile::worker { $app_name:
+    ensure         => $ensure,
+    enable_service => $enable_procfile_worker,
+  }
+
   unless $ensure == 'absent' {
     Govuk::App::Envvar {
       app => $app_name,
@@ -115,10 +120,6 @@ class govuk::apps::search_admin(
     govuk::app::envvar::redis { $app_name:
       host => $redis_host,
       port => $redis_port,
-    }
-
-    govuk::procfile::worker { $app_name:
-      enable_service => $enable_procfile_worker,
     }
 
     govuk::app::envvar {

--- a/modules/govuk/manifests/apps/travel_advice_publisher.pp
+++ b/modules/govuk/manifests/apps/travel_advice_publisher.pp
@@ -133,6 +133,7 @@ class govuk::apps::travel_advice_publisher(
 
   validate_bool($enable_procfile_worker)
   govuk::procfile::worker { $app_name:
+    ensure         => $ensure,
     enable_service => $enable_procfile_worker,
   }
 


### PR DESCRIPTION
Some ensure instructions are never encountered when the app is
set to enabled=false, that's because those instructions are inside
a conditional loop that is skipped.
This move those instructions outside of the loop that they are
properly acted upon.