### PR TITLE
Fix missing release app token in CI

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/deploy_app_downstream.pp
+++ b/modules/govuk_jenkins/manifests/jobs/deploy_app_downstream.pp
@@ -19,6 +19,9 @@
 # [*github_api_token*]
 #   The API token used to avoid rate limiting for GitHub API calls.
 #
+# [*release_app_bearer_token*]
+#   The API token used to query the release app for deploy freezes.
+#
 class govuk_jenkins::jobs::deploy_app_downstream (
   $applications = undef,
   $jenkins_downstream_api_user = undef,
@@ -26,6 +29,7 @@ class govuk_jenkins::jobs::deploy_app_downstream (
   $deploy_url = undef,
   $github_api_token = undef,
   $smokey_pre_check = true,
+  $release_app_bearer_token = undef,
 ) {
   file { '/etc/jenkins_jobs/jobs/deploy_app_downstream.yaml':
     ensure  => present,

--- a/modules/govuk_jenkins/templates/jobs/deploy_app_downstream.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_app_downstream.yaml.erb
@@ -13,7 +13,7 @@
           # Check for deploy freeze set in Release App
           APPLICATION_METADATA=$(curl -s \
             -H "Accept: application/json" \
-            -H "Authorization: Bearer $RELEASE_APP_NOTIFICATION_BEARER_TOKEN" \
+            -H "Authorization: Bearer $RELEASE_APP_BEARER_TOKEN" \
             "https://release.publishing.service.gov.uk/applications/$TARGET_APPLICATION")
 
           DEPLOY_FREEZE=$(echo "$APPLICATION_METADATA" | jq .deploy_freeze)
@@ -42,7 +42,7 @@
           esac
 
           # Check release to deploy is genuine and we're not going backwards
-          GITHUB_AUTH="-H 'Authorization: token <%= @github_api_token %>'"
+          GITHUB_AUTH="-H 'Authorization: token $GITHUB_API_TOKEN'"
           GITHUB_API="https://api.github.com/repos/alphagov/$REPO"
 
           LATEST_TAGS=$(curl $GITHUB_AUTH -s "$GITHUB_API/tags?per_page=1")
@@ -69,6 +69,16 @@
     wrappers:
         - ansicolor:
             colormap: xterm
+        - inject-passwords:
+            global: false
+            mask-password-params: true
+            job-passwords:
+              - name: GITHUB_API_TOKEN
+                password:
+                  '<%= @github_api_token %>'
+              - name: RELEASE_APP_BEARER_TOKEN
+                password:
+                  '<%= @release_app_bearer_token %>'
     parameters:
         - choice:
             name: TARGET_APPLICATION


### PR DESCRIPTION
https://trello.com/c/JwvD6oaQ/167-add-deploy-freeze-check-to-deploy-downstream-job

Depends on: https://github.com/alphagov/govuk-secrets/pull/998

Previously we added an HTTP API call to the production release app
to abort downstream deploys if they are meant to be frozen. These
jobs are failing in CI because the environment variable used to get
the bearer token is missing. It's unclear where it comes from.

This ensures the variable is explicitly passed to the job, and moves
it and the other GitHub secret into a wrapper, so they are not exposed
in the console output of the job.