### PR TITLE
Reflect Email Alert API worker rename

### DIFF
--- a/modules/grafana/files/dashboards/email_alert_api.json
+++ b/modules/grafana/files/dashboards/email_alert_api.json
@@ -359,7 +359,7 @@
             {
               "hide": false,
               "refId": "F",
-              "target": "aliasByNode(consolidateBy(sumSeries(summarize(stats_counts.govuk.app.email-alert-api.*.workers.ProcessContentChangeAndGenerateEmailsWorker.failure, '$Interval', 'sum', false)), 'sum'), 7)",
+              "target": "aliasByNode(consolidateBy(sumSeries(summarize(stats_counts.govuk.app.email-alert-api.*.workers.ProcessContentChangeWorker.failure, '$Interval', 'sum', false)), 'sum'), 7)",
               "textEditor": false
             },
             {
@@ -439,12 +439,12 @@
           "targets": [
             {
               "refId": "B",
-              "target": "aliasByNode(consolidateBy(maxSeries(summarize(stats.timers.govuk.app.email-alert-api.*.workers.ProcessContentChangeAndGenerateEmailsWorker.processing_time.upper, '$Interval', 'max', false)), 'max'), 9)",
+              "target": "aliasByNode(consolidateBy(maxSeries(summarize(stats.timers.govuk.app.email-alert-api.*.workers.ProcessContentChangeWorker.processing_time.upper, '$Interval', 'max', false)), 'max'), 9)",
               "textEditor": false
             },
             {
               "refId": "A",
-              "target": "aliasByNode(consolidateBy(averageSeries(summarize(stats.timers.govuk.app.email-alert-api.*.workers.ProcessContentChangeAndGenerateEmailsWorker.processing_time.mean, '$Interval', 'avg', false)), 'average'), 9)",
+              "target": "aliasByNode(consolidateBy(averageSeries(summarize(stats.timers.govuk.app.email-alert-api.*.workers.ProcessContentChangeWorker.processing_time.mean, '$Interval', 'avg', false)), 'average'), 9)",
               "textEditor": false
             }
           ],


### PR DESCRIPTION
We've renamed the ProcessContentChangeAndGenerateEmailsWorker to
ProcessContentChangeWorker, this change reflects that in the dashboards.

We could change these to use ProcessContentChange*Worker to capture both
(as I've done on a temporary board) current name and old name. However,
since these dashboards only serve to provide a somewhat short term view
of the apps health it seems a superfluous step for the long term.