### PR TITLE
Remove publisher apps from backend_lb

### DIFF
--- a/modules/govuk/manifests/node/s_backend_lb.pp
+++ b/modules/govuk/manifests/node/s_backend_lb.pp
@@ -50,24 +50,12 @@ class govuk::node::s_backend_lb (
   }
 
   loadbalancer::balance { [
-    'collections-publisher',
-    'contacts-admin',
     'content-data',
     'content-data-admin',
     'content-data-api',
-    'content-publisher',
-    'content-tagger',
-    'manuals-publisher',
-    'maslow',
-    'publisher',
     'release',
-    'search-admin',
-    'service-manual-publisher',
     'signon',
-    'specialist-publisher',
-    'short-url-manager',
     'support',
-    'travel-advice-publisher',
     ]:
       servers => $backend_servers,
   }


### PR DESCRIPTION
Following the migration of the publisher apps to AWS we don't
need the carrenza load balancers to expect connections to these
apps.