### PR TITLE
Remove GOVUK_ASSET_HOST environment variable

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -638,7 +638,6 @@ govuk_containers::app::config::global_envvars:
   - "SENTRY_CURRENT_ENV=%{hiera('govuk::deploy::config::errbit_environment_name')}"
   - "GOVUK_APP_DOMAIN=%{hiera('app_domain')}"
   - "GOVUK_APP_DOMAIN_EXTERNAL=%{hiera('app_domain')}"
-  - "GOVUK_ASSET_HOST=%{hiera('govuk::deploy::config::asset_root')}"
   - "GOVUK_ASSET_ROOT=%{hiera('govuk::deploy::config::asset_root')}"
   - "GOVUK_WEBSITE_ROOT=%{hiera('govuk::deploy::config::website_root')}"
 

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -970,7 +970,6 @@ govuk_containers::app::config::global_envvars:
   - "SENTRY_CURRENT_ENV=%{hiera('govuk::deploy::config::errbit_environment_name')}-%{hiera('stackname')}-aws"
   - "GOVUK_APP_DOMAIN=%{hiera('app_domain_internal')}"
   - "GOVUK_APP_DOMAIN_EXTERNAL=%{hiera('app_domain')}"
-  - "GOVUK_ASSET_HOST=%{hiera('govuk::deploy::config::asset_root')}"
   - "GOVUK_ASSET_ROOT=%{hiera('govuk::deploy::config::asset_root')}"
   - "GOVUK_WEBSITE_ROOT=%{hiera('govuk::deploy::config::website_root')}"
 

--- a/modules/govuk/manifests/deploy/config.pp
+++ b/modules/govuk/manifests/deploy/config.pp
@@ -111,7 +111,6 @@ class govuk::deploy::config(
 
     'ERRBIT_ENVIRONMENT_NAME': value   => $errbit_environment_name;
     'SENTRY_CURRENT_ENV': value        => $errbit_environment_name;
-    'GOVUK_ASSET_HOST': value          => $asset_root;
     'GOVUK_ASSET_ROOT': value          => $asset_root;
     'GOVUK_WEBSITE_ROOT': value        => $website_root;
     'GOVUK_CSP_REPORT_ONLY': value     => $csp_report_only_value;


### PR DESCRIPTION
Trello: https://trello.com/c/oNEtjIVp/99-serve-static-assets-from-www-hostname

This environment variable is no longer used anywhere. Once removed we're
free from ever wondering what the difference between GOVUK_ASSET_HOST
and GOVUK_ASSET_ROOT is anymore.