### PR TITLE
Remove redundant subscription content alerts

### DIFF
--- a/modules/govuk/manifests/apps/email_alert_api/checks.pp
+++ b/modules/govuk/manifests/apps/email_alert_api/checks.pp
@@ -72,20 +72,6 @@ class govuk::apps::email_alert_api::checks(
     notes_url => monitoring_docs_url(email-alert-api-delivery-attempts-status-updates),
   }
 
-  # We are only interested in the `warning` state but `critical` is also required
-  # for valid Icinga check configuration. Setting it to a high value that won't be
-  # reached allows us to get round this issue
-  @@icinga::check::graphite { 'email-alert-api-warning-subscription-contents':
-    ensure    => $ensure,
-    host_name => $::fqdn,
-    target    => 'transformNull(keepLastValue(averageSeries(stats.gauges.govuk.app.email-alert-api.*.subscription_contents.warning_total)))',
-    warning   => '0',
-    critical  => '100000000',
-    from      => '15minutes',
-    desc      => 'email-alert-api - unprocessed subscription contents - warning',
-    notes_url => monitoring_docs_url(email-alert-api-unprocessed-subscription-contents),
-  }
-
   @@icinga::check::graphite { 'email-alert-api-warning-content-changes':
     ensure    => $ensure,
     host_name => $::fqdn,
@@ -117,20 +103,6 @@ class govuk::apps::email_alert_api::checks(
     from      => '1hour',
     desc      => 'email-alert-api - unprocessed messages - warning',
     notes_url => monitoring_docs_url(email-alert-api-unprocessed-messages),
-  }
-
-  # We are only interested in the `critical` state but `warning` is also required
-  # for valid Icinga check configuration. Both states are set to 0 but `critical`
-  # takes precedence and allows us to get round this issue
-  @@icinga::check::graphite { 'email-alert-api-critical-subscription-contents':
-    ensure    => $ensure,
-    host_name => $::fqdn,
-    target    => 'transformNull(keepLastValue(averageSeries(stats.gauges.govuk.app.email-alert-api.*.subscription_contents.critical_total)))',
-    warning   => '0',
-    critical  => '0',
-    from      => '15minutes',
-    desc      => 'email-alert-api - unprocessed subscription contents - critical',
-    notes_url => monitoring_docs_url(email-alert-api-unprocessed-subscription-contents),
   }
 
   @@icinga::check::graphite { 'email-alert-api-critical-content-changes':


### PR DESCRIPTION
https://trello.com/c/uX2eKt7z/337-investigate-resolve-the-deadlock-issue-with-processing-content-changes

Previously we created SubscriptionContent records before actual
Email records, with the risk of stopping part way through and
not having emails to send. Recently we inverted this process, so
that SubscriptionContent and Email records are created in the
same transaction [1]. This removes unprocessed SubscriptionContent
alerts, since it's no longer possible for them to fire.

[1]: https://github.com/alphagov/email-alert-api/pull/1284