### PR TITLE
remove mongo backups carrenza

### DIFF
--- a/hieradata/class/backup.yaml
+++ b/hieradata/class/backup.yaml
@@ -7,6 +7,7 @@ govuk::node::s_backup::directories:
     directory: /var/lib/automongodbbackup/
     fq_dn: mongo-1.backend.%{hiera('app_domain')}
     priority: '001'
+    ensure: 'absent'
   backup_mysql_backups_mysql_backup_1:
     directory: /var/lib/automysqlbackup/
     fq_dn: mysql-backup-1.backend.%{hiera('app_domain')}

--- a/hieradata/class/production/backup.yaml
+++ b/hieradata/class/production/backup.yaml
@@ -3,6 +3,7 @@ govuk::node::s_backup::directories:
     directory: /var/lib/automongodbbackup/
     fq_dn: mongo-1.backend.%{hiera('app_domain')}
     priority: '001'
+    ensure: 'absent'
   backup_mongodb_backups_performance_mongo:
     directory: /var/lib/automongodbbackup/
     fq_dn: performance-mongo-1.api.%{hiera('app_domain')}

--- a/modules/backup/manifests/directory.pp
+++ b/modules/backup/manifests/directory.pp
@@ -16,11 +16,17 @@
 #
 #   Default: undef
 #
+# [*ensure*]
+#   Determines where the backup is active or not
+#   Possible value are: 'present' or 'absent'
+#   Default = 'present'
+#
 define backup::directory (
     $directory,
     $fq_dn,
     $priority = undef,
     $alert_hostname = 'alert.cluster',
+    $ensure = 'present',
 ) {
     $sanitised_dir  = regsubst($directory, '/', '_', 'G')
     $threshold_secs = 28 * (60 * 60)
@@ -34,11 +40,13 @@ define backup::directory (
     }
 
     file { $filename:
+        ensure  => $ensure,
         content => template('backup/directory.erb'),
         mode    => '0755',
     }
 
     @@icinga::passive_check { "check_backup-${fq_dn}-${sanitised_dir}-${::hostname}":
+      ensure              => $ensure,
       service_description => $service_desc,
       host_name           => $::fqdn,
       freshness_threshold => $threshold_secs,


### PR DESCRIPTION
Do not backup mongo dbs in carrenza as they have been removed with the AWS migration