### PR TITLE
rescheduling of content-publisher should be in AWS only

### DIFF
--- a/modules/backup/manifests/directory.pp
+++ b/modules/backup/manifests/directory.pp
@@ -17,8 +17,8 @@
 #   Default: undef
 #
 # [*ensure*]
-#   Determines where the backup is active or not
-#   Possible value are: 'present' or 'absent'
+#   Determines whether the backup is active or not
+#   Possible values are: 'present' or 'absent'
 #   Default = 'present'
 #
 define backup::directory (

--- a/modules/govuk_jenkins/templates/jobs/data_sync_complete_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/data_sync_complete_staging.yaml.erb
@@ -30,9 +30,11 @@
            <%- if @aws -%>
            # Queue up any whitehall scheduled editions that have been transferred across.
            ssh deploy@$(govuk_node_list -c whitehall_backend --single-node) 'cd /var/apps/whitehall ; govuk_setenv whitehall bundle exec rake publishing:scheduled:requeue_all_jobs'
-           <%- end -%>
+
            # Queue up any publisher scheduled editions that have been transferred across.
            ssh deploy@$(govuk_node_list -c backend --single-node) 'cd /var/apps/publisher ; govuk_setenv publisher bundle exec rake editions:requeue_scheduled_for_publishing'
+           <%- end -%>
+
     publishers:
       - trigger-parameterized-builds:
         - project: Success_Passive_Check


### PR DESCRIPTION
This is due to the AWS migration of content-publisher