### PR TITLE
Don't try to deploy "beyond production"

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
@@ -42,30 +42,32 @@
 
             git clone ${APP_DEPLOYMENT_GIT_URL} --branch master --single-branch --depth 1 ./
             ./jenkins.sh
-        - conditional-step:
-            condition-kind: and
-            condition-operands:
-              # Only trigger downstream deploy for "deploy" tasks
-              - condition-kind: strings-match
-                condition-string1: "$DEPLOY_TASK"
-                condition-string2: "deploy"
-              # Only trigger downstream deploy for "release_123" tags
-              - condition-kind: regex-match
-                regex: "release_.*"
-                label: "$TAG"
-              # Only trigger downstream deploy for support apps
-              - condition-kind: or
-                condition-operands:
-                  <% @deploy_downstream_applications.keys.each do |app| %>
-                  - condition-kind: strings-match
-                    condition-string1: "$TARGET_APPLICATION"
-                    condition-string2: "<%= app %>"
-                  <% end %>
-                  - condition-kind: never # until we have multiple apps
-            steps:
-              - trigger-builds:
-                  - project: Deploy_App_Downstream
-                    current-parameters: true
+        <% if @deploy_downstream_applications.any? %>
+          - conditional-step:
+              condition-kind: and
+              condition-operands:
+                # Only trigger downstream deploy for "deploy" tasks
+                - condition-kind: strings-match
+                  condition-string1: "$DEPLOY_TASK"
+                  condition-string2: "deploy"
+                # Only trigger downstream deploy for "release_123" tags
+                - condition-kind: regex-match
+                  regex: "release_.*"
+                  label: "$TAG"
+                # Only trigger downstream deploy for support apps
+                - condition-kind: or
+                  condition-operands:
+                    <% @deploy_downstream_applications.keys.each do |app| %>
+                    - condition-kind: strings-match
+                      condition-string1: "$TARGET_APPLICATION"
+                      condition-string2: "<%= app %>"
+                    <% end %>
+                    - condition-kind: never # until we have multiple apps
+              steps:
+                - trigger-builds:
+                    - project: Deploy_App_Downstream
+                      current-parameters: true
+        <% end %>
     publishers:
         - trigger:
             project: Smokey


### PR DESCRIPTION
https://trello.com/c/xz9cz8Si/164-activate-continuous-deployment

This changes the "Deploy_App" job to only trigger a downstream
deployment if this is possible for the environment. We can use
the configured list of apps to deploy downstream as a proxy for
this, since we set this per-environment (and not in production).