### PR TITLE
Don't trigger downstream deploys in production

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -380,3 +380,5 @@ postfix::rewrite_mail_list: 'machine.email.carrenza'
 
 mongodb::s3backup::backup::s3_bucket: 'govuk-mongodb-backup-s3-production'
 mongodb::s3backup::backup::s3_bucket_daily: 'govuk-mongodb-backup-s3-daily-production'
+
+govuk_jenkins::jobs::deploy_app::deploy_downstream: false

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -432,3 +432,5 @@ postfix::rewrite_mail_domain: 'digital.cabinet-office.gov.uk'
 postfix::rewrite_mail_list: 'machine.email.carrenza'
 
 nginx::config::stack_network_prefix: '10.13.0'
+
+govuk_jenkins::jobs::deploy_app::deploy_downstream: false

--- a/modules/govuk_jenkins/manifests/jobs/deploy_app.pp
+++ b/modules/govuk_jenkins/manifests/jobs/deploy_app.pp
@@ -20,6 +20,9 @@
 # [*enable_slack_notifications*]
 #   Set to true to post details of a deployment into a Slack channel
 #
+# [*deploy_downstream*]
+#   Set to true to trigger downstream deployments for supported apps
+#
 # [*deploy_downstream_applications*]
 #   A hash of applications supported for downstream deployment
 #
@@ -32,6 +35,7 @@ class govuk_jenkins::jobs::deploy_app (
   $graphite_port = '80',
   $notify_release_app = true,
   $enable_slack_notifications = true,
+  $deploy_downstream = true,
   $deploy_downstream_applications = hiera('govuk_jenkins::jobs::deploy_app_downstream::applications'),
 ) {
   if $::aws_migration {

--- a/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
@@ -42,7 +42,7 @@
 
             git clone ${APP_DEPLOYMENT_GIT_URL} --branch master --single-branch --depth 1 ./
             ./jenkins.sh
-        <% if @deploy_downstream_applications.any? %>
+        <% if @deploy_downstream %>
         - conditional-step:
             condition-kind: and
             condition-operands:


### PR DESCRIPTION
https://trello.com/c/xz9cz8Si/164-activate-continuous-deployment

Previously we tried to use the list of downstream applications as
a proxy for this behaviour, forgetting this is set commonly for all
environments, to avoid duplication. Since it would be surprising to
override it in production, this adds an explicit flag to disable
downstream deployment triggers in production.