### PR TITLE
Update Jenkins structs plugin to 1.20

### DIFF
--- a/hieradata/class/jenkins.yaml
+++ b/hieradata/class/jenkins.yaml
@@ -185,7 +185,7 @@ govuk_jenkins::plugins:
   ssh-slaves:
     version: '1.29.4'
   structs:
-    version: '1.19'
+    version: '1.20'
   subversion:
     version: '2.12.1'
   text-finder:

--- a/hieradata_aws/class/jenkins.yaml
+++ b/hieradata_aws/class/jenkins.yaml
@@ -200,7 +200,7 @@ govuk_jenkins::plugins:
   ssh-slaves:
     version: '1.29.4'
   structs:
-    version: '1.19'
+    version: '1.20'
   subversion:
     version: '2.12.1'
   text-finder:


### PR DESCRIPTION
I don't know how the main Jenkins version is managed, but when we tried
to spin up a new one we were seeing lots of jenkins plugin errors in
`/var/log/jenkins/jenkins.log`

Going to the Jenkins UI in the browser only showed the latest of these
errors (which was to do with the Github OAuth Credentials plugin), but
there was a whole stack of them in the log.

The error at the top of the stack said that the Credentials plugin
(note: not the GitHub one, just plan `Credentials`) required a `structs`
version of at least `1.20`. We were pinning `1.19`, which looks like a
smoking gun.

It doesn't look like we pin a version of the Credentials plugin in this
yaml file, so I'm guessing this got bumped and now it doesn't work with
our older version of `structs`.

I tested this fix by snowflaking it in the new test environment, and it
seemed to fix our main plugin issues. That should let us crack on with
the Jenkins token shuffle.