### PR TITLE
git rm .puppet-lint.rc

### DIFF
--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,1 +1,0 @@
---no-140chars-check


### PR DESCRIPTION
- We already have [code to specify this setting in `lib/tasks/lint.rake`](https://github.com/alphagov/govuk-puppet/blob/master/lib/tasks/lint.rake#L9) which [is run by CI](https://github.com/alphagov/govuk-puppet/blob/master/Jenkinsfile#L43-L45) whenever we push commits, and ourselves via pre-commit (if people have that enabled). We don't need to keep this config file around.
