### PR TITLE
Cleanup some obsolete keys after migration of publisher apps

### DIFF
--- a/hieradata/class/backend.yaml
+++ b/hieradata/class/backend.yaml
@@ -1,46 +1,5 @@
 ---
 
-govuk::apps::contacts::vhost: contacts-admin
-govuk::apps::contacts::db_hostname: 'mysql-master-1.backend'
-govuk::apps::contacts::db_username: 'contacts'
-govuk::apps::contacts::db_password: "%{hiera('govuk::apps::contacts::db::mysql_contacts_admin')}"
-
-govuk::apps::manuals_publisher::mongodb_name: 'govuk_content_production'
-govuk::apps::manuals_publisher::mongodb_nodes:
-  - 'mongo-1.backend'
-  - 'mongo-2.backend'
-  - 'mongo-3.backend'
-
-govuk::apps::maslow::mongodb_name: 'maslow_production'
-govuk::apps::maslow::mongodb_nodes:
-  - 'mongo-1.backend'
-  - 'mongo-2.backend'
-  - 'mongo-3.backend'
-
-govuk::apps::publisher::mongodb_name: 'govuk_content_production'
-govuk::apps::publisher::mongodb_nodes:
-  - 'mongo-1.backend'
-  - 'mongo-2.backend'
-  - 'mongo-3.backend'
-
-govuk::apps::short_url_manager::mongodb_name: 'short_url_manager_production'
-govuk::apps::short_url_manager::mongodb_nodes:
-  - 'mongo-1.backend'
-  - 'mongo-2.backend'
-  - 'mongo-3.backend'
-
-govuk::apps::specialist_publisher::mongodb_name: 'govuk_content_production'
-govuk::apps::specialist_publisher::mongodb_nodes:
-  - 'mongo-1.backend'
-  - 'mongo-2.backend'
-  - 'mongo-3.backend'
-
-govuk::apps::travel_advice_publisher::mongodb_name: 'travel_advice_publisher_production'
-govuk::apps::travel_advice_publisher::mongodb_nodes:
-  - 'mongo-1.backend'
-  - 'mongo-2.backend'
-  - 'mongo-3.backend'
-
 lv:
   data:
     pv: '/dev/sdb1'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -282,59 +282,12 @@ govuk::apps::asset_manager::nagios_memory_critical: 2750
 
 govuk::apps::authenticating_proxy::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
 
-govuk::apps::collections_publisher::db_hostname: "mysql-master-1.backend"
-govuk::apps::collections_publisher::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
-govuk::apps::collections_publisher::redis_host: "%{hiera('sidekiq_host')}"
-govuk::apps::collections_publisher::redis_port: "%{hiera('sidekiq_port')}"
-
-govuk::apps::contacts::redis_host: "%{hiera('sidekiq_host')}"
-govuk::apps::contacts::redis_port: "%{hiera('sidekiq_port')}"
-
-govuk::apps::content_publisher::db_hostname: "postgresql-primary-1.backend"
-govuk::apps::content_publisher::db_port: 6432
-govuk::apps::content_publisher::db_allow_prepared_statements: false
-govuk::apps::content_publisher::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
-govuk::apps::content_publisher::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
-govuk::apps::content_publisher::aws_region: "eu-west-1"
-govuk::apps::content_publisher::redis_host: "%{hiera('sidekiq_host')}"
-govuk::apps::content_publisher::redis_port: "%{hiera('sidekiq_port')}"
-
-govuk::apps::content_tagger::db_hostname: "postgresql-primary-1.backend"
-govuk::apps::content_tagger::db_port: 6432
-govuk::apps::content_tagger::db_allow_prepared_statements: false
-govuk::apps::content_tagger::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
-govuk::apps::content_tagger::enable_procfile_worker: true
-govuk::apps::content_tagger::redis_host: "%{hiera('sidekiq_host')}"
-govuk::apps::content_tagger::redis_port: "%{hiera('sidekiq_port')}"
-
-govuk::apps::manuals_publisher::redis_host: "%{hiera('sidekiq_host')}"
-govuk::apps::manuals_publisher::redis_port: "%{hiera('sidekiq_port')}"
-
-govuk::apps::publisher::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
-govuk::apps::publisher::redis_host: "%{hiera('sidekiq_host')}"
-govuk::apps::publisher::redis_port: "%{hiera('sidekiq_port')}"
-
-govuk::apps::short_url_manager::redis_host: "%{hiera('sidekiq_host')}"
-govuk::apps::short_url_manager::redis_port: "%{hiera('sidekiq_port')}"
 
 govuk::apps::licencefinder::mongodb_nodes:
   - 'mongo-1.backend'
   - 'mongo-2.backend'
   - 'mongo-3.backend'
 
-govuk::apps::search_admin::db_name: 'search_admin_production'
-govuk::apps::search_admin::db_hostname: 'master.mysql'
-govuk::apps::search_admin::db_password: "%{hiera('govuk::apps::search_admin::db::mysql_search_admin')}"
-govuk::apps::search_admin::db_username: 'search_admin'
-govuk::apps::search_admin::redis_host: "%{hiera('sidekiq_host')}"
-govuk::apps::search_admin::redis_port: "%{hiera('sidekiq_port')}"
-
-govuk::apps::service_manual_publisher::http_username: "%{hiera('http_username')}"
-govuk::apps::service_manual_publisher::http_password: "%{hiera('http_password')}"
-
-govuk::apps::service_manual_publisher::db_port: 6432
-govuk::apps::service_manual_publisher::db_allow_prepared_statements: false
-govuk::apps::service_manual_publisher::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 
 govuk::apps::sidekiq_monitoring::asset_manager_redis_host: "%{hiera('govuk::apps::asset_manager::redis_host')}"
 govuk::apps::sidekiq_monitoring::asset_manager_redis_port: "%{hiera('govuk::apps::asset_manager::redis_port')}"
@@ -372,21 +325,12 @@ govuk::apps::signon::nagios_memory_warning: 1100
 govuk::apps::signon::nagios_memory_critical: 1200
 govuk::apps::signon::unicorn_worker_processes: "4"
 
-govuk::apps::specialist_publisher::enabled: true
-govuk::apps::specialist_publisher::nagios_memory_warning: 1100
-govuk::apps::specialist_publisher::nagios_memory_critical: 1200
-govuk::apps::specialist_publisher::redis_host: "%{hiera('sidekiq_host')}"
-govuk::apps::specialist_publisher::redis_port: "%{hiera('sidekiq_port')}"
-
 govuk::apps::smokey::http_username: "%{hiera('http_username')}"
 govuk::apps::smokey::http_password: "%{hiera('http_password')}"
 govuk::apps::smokey::smokey_signon_email: "%{hiera('smokey_signon_email')}"
 govuk::apps::smokey::smokey_signon_password: "%{hiera('smokey_signon_password')}"
 govuk::apps::smokey::smokey_bearer_token: "%{hiera('smokey_bearer_token')}"
 govuk::apps::smokey::rate_limit_token: "%{hiera('smokey_rate_limit_token')}"
-
-govuk::apps::travel_advice_publisher::redis_host: "%{hiera('sidekiq_host')}"
-govuk::apps::travel_advice_publisher::redis_port: "%{hiera('sidekiq_port')}"
 
 govuk_awscli::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk_awscli::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
@@ -966,23 +910,8 @@ hosts::production::backend::hosts:
 hosts::production::backend::app_hostnames:
   - 'asset-manager'
   - 'canary-backend'
-  - 'collections-publisher'
-  - 'contacts-admin'
-  - 'content-publisher'
-  - 'content-tagger'
   - 'docs'
-  - 'hmrc-manuals-api'
-  - 'maslow'
-  - 'manuals-publisher'
-  - 'publisher'
-  - 'search-admin'
-  - 'service-manual-publisher'
-  - 'short-url-manager'
   - 'signon'
-  - 'specialist-publisher'
-  - 'specialist-publisher-rebuild'
-  - 'specialist-publisher-rebuild-standalone'
-  - 'travel-advice-publisher'
 
 hosts::production::ci::hosts:
   ci-master-1:

--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -38,35 +38,8 @@ environment_ip_prefix: '10.3'
 
 govuk::apps::asset_manager::aws_s3_bucket_name: 'govuk-assets-production'
 govuk::apps::asset_manager::aws_region: 'eu-west-1'
-govuk::apps::content_publisher::aws_s3_bucket: "govuk-production-content-publisher-activestorage"
-govuk::apps::content_publisher::google_tag_manager_auth: "sxvBI4QvwgTRX5e76vdIHA"
-govuk::apps::content_publisher::google_tag_manager_id: "GTM-NQXC4TG"
-govuk::apps::content_publisher::google_tag_manager_preview: "env-2"
-govuk::apps::content_publisher::govuk_notify_template_id: "e00e89f5-b622-4dcb-8f30-e6c70231a940"
-govuk::apps::collections_publisher::govuk_notify_template_id: "e00e89f5-b622-4dcb-8f30-e6c70231a940"
-govuk::apps::collections_publisher::publish_without_2i_email: "mainstream-force-publishing-alerts@digital.cabinet-office.gov.uk"
-govuk::apps::contacts::enabled: false
-govuk::apps::content_publisher::enabled: false
 govuk::apps::government-frontend::cpu_warning: 200
 govuk::apps::government-frontend::cpu_critical: 300
-govuk::apps::hmrc_manuals_api::publish_topics: false
-govuk::apps::publisher::fact_check_address_format: 'factcheck+production-{id}@alphagov.co.uk'
-govuk::apps::publisher::fact_check_reply_to_id: '792923cb-fa07-4dce-a4c5-e6320bd19c17'
-govuk::apps::publisher::fact_check_reply_to_address: 'factcheck+production@alphagov.co.uk'
-govuk::apps::publisher::email_group_dev: 'govuk-dev@digital.cabinet-office.gov.uk'
-govuk::apps::publisher::email_group_business: 'publisher-alerts-business@digital.cabinet-office.gov.uk'
-govuk::apps::publisher::email_group_citizen: 'publisher-alerts-citizen@digital.cabinet-office.gov.uk'
-govuk::apps::publisher::email_group_force_publish_alerts: 'mainstream-force-publishing-alerts@digital.cabinet-office.gov.uk'
-govuk::apps::publisher::govuk_notify_template_id: "e00e89f5-b622-4dcb-8f30-e6c70231a940"
-govuk::apps::search_admin::govuk_notify_template_id: "e00e89f5-b622-4dcb-8f30-e6c70231a940"
-govuk::apps::service_manual_publisher::govuk_notify_template_id: "e00e89f5-b622-4dcb-8f30-e6c70231a940"
-govuk::apps::short_url_manager::govuk_notify_template_id: 'e00e89f5-b622-4dcb-8f30-e6c70231a940'
-govuk::apps::specialist_publisher::aws_region: 'eu-west-1'
-govuk::apps::specialist_publisher::aws_s3_bucket_name: 'govuk-production-specialist-publisher-csvs'
-govuk::apps::specialist_publisher::enabled: false
-govuk::apps::specialist_publisher::govuk_notify_template_id: "e00e89f5-b622-4dcb-8f30-e6c70231a940"
-govuk::apps::travel_advice_publisher::enable_email_alerts: false
-govuk::apps::travel_advice_publisher::enable_procfile_worker: false
 govuk::apps::whitehall::govuk_notify_template_id: "e00e89f5-b622-4dcb-8f30-e6c70231a940"
 
 govuk::apps::contacts::ensure: 'absent'
@@ -83,9 +56,6 @@ govuk::apps::short_url_manager::ensure: 'absent'
 govuk::apps::specialist_publisher::ensure: 'absent'
 govuk::apps::travel_advice_publisher::ensure: 'absent'
 
-govuk::apps::content_tagger::override_search_location: 'https://search-api.production.govuk.digital'
-govuk::apps::hmrc_manuals_api::override_search_location: 'https://search-api.production.govuk.digital'
-govuk::apps::search_admin::override_search_location: 'https://search-api.production.govuk.digital'
 
 govuk::deploy::actionmailer_enable_delivery: true
 

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -15,38 +15,8 @@ environment_ip_prefix: '10.2'
 
 govuk::apps::asset_manager::aws_s3_bucket_name: 'govuk-assets-staging'
 govuk::apps::asset_manager::aws_region: 'eu-west-1'
-govuk::apps::content_publisher::aws_s3_bucket: "govuk-staging-content-publisher-activestorage"
-govuk::apps::content_publisher::google_tag_manager_auth: "QaRG0YPL6_pwZdxCbyMXPQ"
-govuk::apps::content_publisher::google_tag_manager_id: "GTM-NQXC4TG"
-govuk::apps::content_publisher::google_tag_manager_preview: "env-5"
-govuk::apps::content_publisher::email_address_override: "content-publisher-notifications-staging@digital.cabinet-office.gov.uk"
-govuk::apps::contacts::enabled: false
-govuk::apps::content_publisher::enabled: false
-govuk::apps::content_publisher::govuk_notify_template_id: "112842bb-d8a4-4511-90de-57dc5c8f27ec"
-govuk::apps::collections_publisher::govuk_notify_template_id: "112842bb-d8a4-4511-90de-57dc5c8f27ec"
-govuk::apps::collections_publisher::publish_without_2i_email: "mainstream-publisher-notifications-staging@digital.cabinet-office.gov.uk"
-govuk::apps::hmrc_manuals_api::publish_topics: false
-govuk::apps::publisher::fact_check_address_format: 'factcheck+staging-{id}@alphagov.co.uk'
-govuk::apps::publisher::govuk_notify_template_id: "112842bb-d8a4-4511-90de-57dc5c8f27ec"
-govuk::apps::publisher::email_group_dev: 'mainstream-publisher-notifications-staging@digital.cabinet-office.gov.uk'
-govuk::apps::publisher::email_group_business: 'mainstream-publisher-notifications-staging@digital.cabinet-office.gov.uk'
-govuk::apps::publisher::email_group_citizen: 'mainstream-publisher-notifications-staging@digital.cabinet-office.gov.uk'
-govuk::apps::publisher::email_group_force_publish_alerts: 'mainstream-publisher-notifications-staging@digital.cabinet-office.gov.uk'
-govuk::apps::publisher::fact_check_subject_prefix: 'staging'
-govuk::apps::publisher::fact_check_reply_to_id: '88f713ff-7de0-43a6-8221-8721bedd103c'
-govuk::apps::publisher::fact_check_reply_to_address: 'govuk-fact-check-staging@digital.cabinet-office.gov.uk'
-govuk::apps::search_admin::govuk_notify_template_id: '112842bb-d8a4-4511-90de-57dc5c8f27ec'
-govuk::apps::service_manual_publisher::govuk_notify_template_id: "112842bb-d8a4-4511-90de-57dc5c8f27ec"
-govuk::apps::short_url_manager::instance_name: 'staging'
-govuk::apps::short_url_manager::govuk_notify_template_id: '112842bb-d8a4-4511-90de-57dc5c8f27ec'
 govuk::apps::signon::instance_name: 'staging'
-govuk::apps::specialist_publisher::aws_region: 'eu-west-1'
-govuk::apps::specialist_publisher::aws_s3_bucket_name: 'govuk-staging-specialist-publisher-csvs'
-govuk::apps::specialist_publisher::enabled: false
-govuk::apps::specialist_publisher::govuk_notify_template_id: "112842bb-d8a4-4511-90de-57dc5c8f27ec"
 govuk::apps::static::ga_universal_id: 'UA-26179049-20'
-govuk::apps::travel_advice_publisher::enable_email_alerts: false
-govuk::apps::travel_advice_publisher::enable_procfile_worker: false
 govuk::apps::whitehall::govuk_notify_template_id: "112842bb-d8a4-4511-90de-57dc5c8f27ec"
 
 govuk::apps::contacts::ensure: 'absent'
@@ -63,9 +33,6 @@ govuk::apps::short_url_manager::ensure: 'absent'
 govuk::apps::specialist_publisher::ensure: 'absent'
 govuk::apps::travel_advice_publisher::ensure: 'absent'
 
-govuk::apps::content_tagger::override_search_location: 'https://search-api.staging.govuk.digital'
-govuk::apps::hmrc_manuals_api::override_search_location: 'https://search-api.staging.govuk.digital'
-govuk::apps::search_admin::override_search_location: 'https://search-api.staging.govuk.digital'
 
 govuk::deploy::aws_ses_smtp_host: 'email-smtp.eu-west-1.amazonaws.com'
 govuk::deploy::config::errbit_environment_name: 'staging'
@@ -276,23 +243,8 @@ hosts::production::backend::hosts:
 
 hosts::production::backend::app_hostnames:
   - 'canary-backend'
-  - 'collections-publisher'
-  - 'contacts-admin'
-  - 'content-publisher'
-  - 'content-tagger'
   - 'docs'
-  - 'hmrc-manuals-api'
-  - 'maslow'
-  - 'manuals-publisher'
-  - 'publisher'
-  - 'search-admin'
-  - 'service-manual-publisher'
-  - 'short-url-manager'
   - 'signon'
-  - 'specialist-publisher'
-  - 'specialist-publisher-rebuild'
-  - 'specialist-publisher-rebuild-standalone'
-  - 'travel-advice-publisher'
 
 hosts::production::frontend::hosts:
   whitehall-frontend-1:


### PR DESCRIPTION
Publisher apps have been migrated to AWS and those keys are no
longer needed.