### PR TITLE
Limit requests for new email subscriptions

### DIFF
--- a/modules/router/templates/rate-limiting.conf.erb
+++ b/modules/router/templates/rate-limiting.conf.erb
@@ -22,6 +22,7 @@ map "$http_Rate_Limit_Token:$request_method" $post_limit_req {
 }
 
 limit_req_zone $post_limit_req zone=contact:5m rate=6r/m;
+limit_req_zone $post_limit_req zone=email:5m rate=3r/m;
 
 # Return 429 (Too Many Requests) instead of the default 503.
 limit_req_status 429;

--- a/modules/router/templates/router_include.conf.erb
+++ b/modules/router/templates/router_include.conf.erb
@@ -81,6 +81,10 @@ location ~ ^/contact/govuk(/(|service-feedback(/)?|problem_reports(/)?|foi(/)?|p
   proxy_pass http://varnish;
 }
 
+location ~ ^/email/subscriptions/verify$ {
+  limit_req zone=email burst=0 nodelay;
+  proxy_pass http://varnish;
+}
 
 location / {
   <%= scope.function_template(['router/fragments/_basic_auth.erb']) -%>


### PR DESCRIPTION
    This applies a rate limit to the specific request that causes
    subscription confirmation emails to be sent. At the moment, we
    are seeing a high number of bot-like requests to this endpoint.
    The limit is based on the one used for /contact/* paths, after
    realising we can only specify a per-minute granularity:
    
    - 6 requests per minute (360 per hour)
    - burst of 0, since we want to have a hard limit
    
    Note that the lack of shared knowledge between the nginx machines,
    coupled with the round robin load balancing between them means the
    actual rate limit will be slightly higher, based on the number of
    cache machines we have and the load balancing behaviour. Currently,
    the worst  case limit is 6 * 9 per minute (3240 per hour).