### PR TITLE
Double allowed Sidekiq memory for email-alert-api

### DIFF
--- a/modules/govuk/manifests/apps/email_alert_api.pp
+++ b/modules/govuk/manifests/apps/email_alert_api.pp
@@ -176,6 +176,8 @@ class govuk::apps::email_alert_api(
     ensure                    => $ensure,
     enable_service            => $enable_procfile_worker,
     alert_when_threads_exceed => 100,
+    memory_warning_threshold  => 4000,
+    memory_critical_threshold => 8000,
   }
 
   Govuk::App::Envvar {


### PR DESCRIPTION
https://trello.com/c/Vix9NgA1/224-investigate-increasing-memory-for-email-alert-api-workers-to-reduce-the-frequency-of-restarts-and-lost-work

Previously we significantly increased the allocated memory for
email-alert-api instances in production [1] in an attempt to
reduce the frequency of worker restarts, which have a tendancy
to lose the work that was being processed (e.g. content changes).
Unfortunately this yielded no improvement, because it's actually
Icinga's thresholds that are triggering the restarts (i.e. not
the allocated memory on the machine). Since the allocated memory
is mostly unused, it should be safe to allow Sidekiq to use more
of it, without impacting other processes. This doubles the max
memory for Sidekiq workers to reduce the frequency of restarts.

[1]: https://github.com/alphagov/govuk-aws/pull/1310