### PR TITLE
Add Redis env vars for Email Alert Frontend

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -220,6 +220,8 @@ task :check_consistency_between_aws_and_carrenza do
     govuk::apps::email_alert_api::redis_host
     govuk::apps::email_alert_api::redis_port
     govuk::apps::email_alert_api::unicorn_worker_processes
+    govuk::apps::email_alert_frontend::redis_host
+    govuk::apps::email_alert_frontend::redis_port
     govuk::apps::email_alert_frontend::subscription_management_enabled
     govuk::apps::email_alert_service::enable_unpublishing_queue_consumer
     govuk::apps::email_alert_service::enabled

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -567,6 +567,9 @@ govuk::apps::email_alert_api::email_address_override_whitelist:
   - tom.whitwell@digital.cabinet-office.gov.uk
   - vanita.barrett@digital.cabinet-office.gov.uk
 
+govuk::apps::email_alert_frontend::redis_host: "%{hiera('sidekiq_host')}"
+govuk::apps::email_alert_frontend::redis_port: "%{hiera('sidekiq_port')}"
+
 govuk::apps::email_alert_service::enabled: true
 govuk::apps::email_alert_service::enable_unpublishing_queue_consumer: true
 govuk::apps::email_alert_service::rabbitmq_hosts:

--- a/modules/govuk/manifests/apps/email_alert_frontend.pp
+++ b/modules/govuk/manifests/apps/email_alert_frontend.pp
@@ -19,6 +19,14 @@
 #   The bearer token to use when communicating with Publishing API.
 #   Default: undef
 #
+# [*redis_host*]
+#   Hostname of the Redis service
+#   Default: undef
+#
+# [*redis_port*]
+#   Port of the Redis service
+#   Default: undef
+#
 # [*secret_key_base*]
 #   The key for Rails to use when signing/encrypting sessions.
 #
@@ -39,13 +47,17 @@ class govuk::apps::email_alert_frontend(
   $vhost = 'email-alert-frontend',
   $port,
   $publishing_api_bearer_token = undef,
+  $redis_host = undef,
+  $redis_port = undef,
   $secret_key_base = undef,
   $sentry_dsn = undef,
   $email_alert_api_bearer_token = undef,
   $email_alert_auth_token = undef,
   $subscription_management_enabled = false,
 ) {
-  govuk::app { 'email-alert-frontend':
+  $app_name = 'email-alert-frontend'
+
+  govuk::app { $app_name:
     app_type                => 'rack',
     port                    => $port,
     sentry_dsn              => $sentry_dsn,
@@ -56,8 +68,13 @@ class govuk::apps::email_alert_frontend(
     json_health_check       => true,
   }
 
+  govuk::app::envvar::redis { $app_name:
+    host => $redis_host,
+    port => $redis_port,
+  }
+
   Govuk::App::Envvar {
-    app => 'email-alert-frontend',
+    app => $app_name,
   }
 
   govuk::app::envvar {


### PR DESCRIPTION
This provides Email Alert Frontend with the necessary information to
communicate with the backend redis instance. We are adding this in so
that Email Alert Frontend can use Redis as a distributed cache for rate
limiting across the Email Alert Frontend apps.