### PR TITLE
Remove burst=0 from nginx rule

### DIFF
--- a/modules/router/templates/router_include.conf.erb
+++ b/modules/router/templates/router_include.conf.erb
@@ -82,7 +82,7 @@ location ~ ^/contact/govuk(/(|service-feedback(/)?|problem_reports(/)?|foi(/)?|p
 }
 
 location ~ ^/email/subscriptions/verify$ {
-  limit_req zone=email burst=0 nodelay;
+  limit_req zone=email nodelay;
   proxy_pass http://varnish;
 }
 


### PR DESCRIPTION
This causes an error as nginx doesn't allow a burst of zero "invalid
burst rate "burst=0" in /etc/nginx/router_include.conf:188"

According to the nginx docs [1] the default is 0 so omitting this value
will have the intended effect of setting this to 0.

We plan to remove this rule once we're happy with https://github.com/alphagov/govuk-puppet/pull/10472
however until then it seems prudent to resolve this error.

[1]: http://nginx.org/en/docs/http/ngx_http_limit_req_module.html#limit_req