### PR TITLE
Remove email signup rate-limting

### DIFF
--- a/modules/router/templates/rate-limiting.conf.erb
+++ b/modules/router/templates/rate-limiting.conf.erb
@@ -22,7 +22,6 @@ map "$http_Rate_Limit_Token:$request_method" $post_limit_req {
 }
 
 limit_req_zone $post_limit_req zone=contact:5m rate=6r/m;
-limit_req_zone $post_limit_req zone=email:5m rate=3r/m;
 
 # Return 429 (Too Many Requests) instead of the default 503.
 limit_req_status 429;

--- a/modules/router/templates/router_include.conf.erb
+++ b/modules/router/templates/router_include.conf.erb
@@ -81,11 +81,6 @@ location ~ ^/contact/govuk(/(|service-feedback(/)?|problem_reports(/)?|foi(/)?|p
   proxy_pass http://varnish;
 }
 
-location ~ ^/email/subscriptions/verify$ {
-  limit_req zone=email nodelay;
-  proxy_pass http://varnish;
-}
-
 location / {
   <%= scope.function_template(['router/fragments/_basic_auth.erb']) -%>
 


### PR DESCRIPTION
We've decided that this may be a bit too aggressive and may lead users
on a shared IP addresses to get surprising responses. Since we have a
different approach in https://github.com/alphagov/email-alert-frontend/pull/832
we're going to remove this for now and rely on the new approach.