### PR TITLE
Increase Email Alert API worker memory allowance

### DIFF
--- a/modules/govuk/manifests/apps/email_alert_api.pp
+++ b/modules/govuk/manifests/apps/email_alert_api.pp
@@ -176,8 +176,8 @@ class govuk::apps::email_alert_api(
     ensure                    => $ensure,
     enable_service            => $enable_procfile_worker,
     alert_when_threads_exceed => 100,
-    memory_warning_threshold  => 4000,
-    memory_critical_threshold => 8000,
+    memory_warning_threshold  => 8000,
+    memory_critical_threshold => 10000,
   }
 
   Govuk::App::Envvar {


### PR DESCRIPTION
https://trello.com/c/Vix9NgA1/224-investigate-increasing-memory-for-email-alert-api-workers-to-reduce-the-frequency-of-restarts-and-lost-work

Previously we doubled the allowance, without realising that we
trigger a worker restart on the 'warning' threshold, as opposed
to the critical one [1]. Since we want the worker to be able to use
up to 8GB of RAM, this increases the thresholds still further to
actually allow this without forcing a worker restart.

[1]: https://github.com/alphagov/govuk-puppet/blob/master/modules/monitoring/files/usr/local/bin/event_handlers/govuk_procfile_worker_high_memory.sh