### PR TITLE
fix canary backend health check

### DIFF
--- a/modules/govuk/manifests/apps/canary_backend.pp
+++ b/modules/govuk/manifests/apps/canary_backend.pp
@@ -23,6 +23,12 @@ class govuk::apps::canary_backend {
         }
       ",
     }
+
+    concat::fragment { 'canary-backend_lb_healthcheck':
+      target  => '/etc/nginx/lb_healthchecks.conf',
+      content => "location /_healthcheck_canary-backend {\n  proxy_pass http://localhost/healthcheck;\n  proxy_set_header Host canary-backend;\n}\n",
+    }
+
   } else {
     nginx::config::site { "canary-backend.${app_domain}":
       content => "


### PR DESCRIPTION
The canary backend health check is not working. Fortunately, AWS forwards traffic to all targets if all targets are unhealthy but when new backend machine come up, some backend are actually not healthy and caused pingdom to fail.