### PR TITLE
Updates Email Alert Metrics dashboard

### DIFF
--- a/modules/grafana/files/dashboards/email_alert_api.json
+++ b/modules/grafana/files/dashboards/email_alert_api.json
@@ -174,7 +174,7 @@
             },
             {
               "refId": "B",
-              "target": "alias(constantLine(10800), 'per minute rate limit')"
+              "target": "alias(constantLine(10500), 'per minute rate limit')"
             },
             {
               "refId": "D",

--- a/modules/grafana/files/dashboards/email_alert_api.json
+++ b/modules/grafana/files/dashboards/email_alert_api.json
@@ -39,7 +39,7 @@
       "height": 196,
       "panels": [
         {
-          "content": "   - [Sidekiq](/dashboard/file/sidekiq.json?refresh=1m&orgId=1&var-Application=email-alert-api&var-Queues=All&from=now-3h&to=now)\n   - [Machine stats](/dashboard/file/machine.json?refresh=1m&orgId=1&var-hostname=email-alert-api*&var-cpmetrics=cpu-system&var-cpmetrics=cpu-user&var-filesystem=All&var-disk=All&var-tcpconnslocal=All&var-tcpconnsremote=All)\n   - [Postgres stats](/dashboard/file/aws-rds.json?orgId=1&var-region=eu-west-1&var-dbinstanceidentifier=blue-postgresql-primary&from=now-1h&to=now)",
+          "content": "   - [Sidekiq](/dashboard/file/sidekiq.json?refresh=1m&orgId=1&var-Application=email-alert-api&var-Queues=All&from=now-3h&to=now)\n   - [Machine stats](/dashboard/file/machine.json?refresh=1m&orgId=1&var-hostname=email_alert_api*&var-cpmetrics=cpu-system&var-cpmetrics=cpu-user&var-filesystem=All&var-disk=All&var-tcpconnslocal=All&var-tcpconnsremote=All)\n   - [Postgres stats](/dashboard/file/aws-rds.json?orgId=1&var-region=eu-west-1&var-dbinstanceidentifier=blue-postgresql-primary&from=now-1h&to=now)\n   - [Notify status page](https://status.notifications.service.gov.uk/)   \n   - [Sentry](https://sentry.io/organizations/govuk/issues/?environment=production&project=202220&statsPeriod=6h)",
           "id": 7,
           "links": [],
           "mode": "markdown",
@@ -185,7 +185,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Notify Emails Sent (per 30s)",
+          "title": "Email Send Attempts (per 30s)",
           "tooltip": {
             "shared": true,
             "sort": 0,


### PR DESCRIPTION
Updates the dashboard with the following:

* fixes link to email-alert-api machines dashboard
* adds link to Notify status page
* adds link to Sentry for email-alert-api
* Updates 'Notify Emails Sent' dashboard name to be more representative of
  what the graph is actually showing & updates the rate limit to be more realistic.

Trello:
https://trello.com/c/U4IPak1a/357-consolidate-and-improve-grafana-dashboards