### PR TITLE
Add redirect for Leicestershire lockdown changes

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -497,6 +497,7 @@ task :check_consistency_between_aws_and_carrenza do
     monitoring::pagerduty_drill::enabled
     router::assets_origin::website_root
     router::nginx::robotstxt
+    router::nginx::website_root
     govuk::apps::govuk_crawler_worker::blacklist_paths
     govuk_awscloudwatch::apt_mirror_hostname
     govuk_awscloudwatch::apt_mirror_gpg_key_fingerprint

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1429,6 +1429,8 @@ router::nginx::robotstxt: |
   User-agent: Googlebot
   Disallow: /licence-finder/*
 
+router::nginx::website_root: "%{hiera('govuk::deploy::config::website_root')}"
+
 sidekiq_host: 'backend-redis'
 sidekiq_port: '6379'
 

--- a/modules/router/manifests/nginx.pp
+++ b/modules/router/manifests/nginx.pp
@@ -49,6 +49,9 @@
 #
 # Default: ''
 #
+# [*website_root*]
+#   The URL to the root of the main GOV.UK host for redirects
+#
 class router::nginx (
   $app_specific_static_asset_routes = {},
   $vhost_protected,
@@ -58,6 +61,7 @@ class router::nginx (
   $check_requests_warning = '@25',
   $check_requests_critical = '@10',
   $robotstxt = '',
+  $website_root = undef,
 ) {
   validate_array($rate_limit_tokens)
 

--- a/modules/router/templates/base.conf.erb
+++ b/modules/router/templates/base.conf.erb
@@ -37,4 +37,13 @@ server {
   include             /etc/nginx/router_include.conf;
 
   add_header X-Robots-Tag "noindex";
+
+  # Redirect for a draft document that was accidentally leaked to the publi
+  # with bypass authentication token.
+  #
+  # Added 30 June 2020 - if this is still hear 6 months later assume it's safe
+  # to remove.
+  if ($arg_token = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIzOTM0NjUzMi0zMTM5LTQ3MzgtYjI2Mi02NjYxMzIzMjY0MzEifQ.9Fd2ok0BMi7IEnMQF9xlMNzl57nYoiOpz-rdL8QuWNI") {
+    rewrite ^/(government/news/leicestershire-coronavirus-lockdown-areas-and-changes)$ <%= @website_root %>/$1? permanent;
+  }
 }


### PR DESCRIPTION
The draft link for this was posted onto twitter by a press organisation
making it rather public. As a temporary measure we are going to redirect
this URL with the token so that anyone following the link ends up on
live GOV.UK.

Once this URL is no-longer in the public domain and we have invalidated
the token we can then remove this redirect with the expectation that
future visitors are taken to a signon login page.