### PR TITLE
Add unprocessed emails count check

### DIFF
--- a/modules/govuk/manifests/apps/publisher/unprocessed_emails_count_check.pp
+++ b/modules/govuk/manifests/apps/publisher/unprocessed_emails_count_check.pp
@@ -1,0 +1,25 @@
+# == Define: govuk::apps::publisher::unprocessed_emails_count_check
+#
+# Creates an Icinga check which checks Graphite for the number of unprocessed
+# fact-check emails.
+#
+# === Parameters
+#
+# [*ensure*]
+#   Whether to enable the check.
+#   Default: present
+#
+class govuk::apps::publisher::unprocessed_emails_count_check(
+  $ensure = present,
+) {
+  @@icinga::check::graphite { 'check_publisher_unprocessed_fact_check_emails':
+    ensure    => $ensure,
+    host_name => $::fqdn,
+    target    => 'transformNull(averageSeries(keepLastValue(stats.gauges.govuk.app.publisher.*.unprocessed_emails.count)))',
+    warning   => '1',
+    critical  => '2',
+    from      => '1hour',
+    desc      => 'publisher - unprocessed fact-check emails are present',
+    notes_url => monitoring_docs_url(publisher-unprocessed-fact-check-emails),
+  }
+}

--- a/modules/monitoring/manifests/checks.pp
+++ b/modules/monitoring/manifests/checks.pp
@@ -47,6 +47,7 @@ class monitoring::checks (
 
   if $::aws_migration {
     include govuk::apps::email_alert_api::checks
+    include govuk::apps::publisher::unprocessed_emails_count_check
   }
 
   $app_domain = hiera('app_domain')


### PR DESCRIPTION
This adds a check for the number of emails present in the fact-check
inbox. Those emails should be automatically processed and deleted.
We want to be notified if the inbox contains emails because that means
they were either not processed or not deleted and we want to investigate
the reason behind it.

I set the warning level to 1 email and the critical level to 2 emails.
This is completely arbitrary and we can change it in the future.

Related PR: https://github.com/alphagov/publisher/pull/1301

Trello card: https://trello.com/c/NbgFTMR4/2022-5-alert-on-fact-check-replies-that-werent-parsed