### PR TITLE
Simpler __canary__ endpoints for pingdom

### DIFF
--- a/modules/govuk/templates/node/s_backend_lb/assets-carrenza.conf.erb
+++ b/modules/govuk/templates/node/s_backend_lb/assets-carrenza.conf.erb
@@ -95,10 +95,6 @@ server {
   }
   <%- end -%>
 
-  location /__canary__ {
-    return 200;
-  }
-
   <%- if scope.lookupvar('::aws_migration') %>
   set $upstream_static <%= @upstream_ssl ? 'https' : 'http' %>://static.<%= @app_domain %>;
   <%- end %>

--- a/modules/govuk/templates/static_extra_nginx_config.conf.erb
+++ b/modules/govuk/templates/static_extra_nginx_config.conf.erb
@@ -4,12 +4,6 @@ location = /static/gov.uk_logotype_crown.png {
   return 301 /media/5c810ef4ed915d43e50ce260/gov.uk_logotype_crown.png;
 }
 
-location /__canary__ {
-  default_type application/json;
-  add_header cache-control "max-age=0, no-store, no-cache";
-  return 200 '{"message": "Tweet tweet"}\n';
-}
-
 location /robots.txt {
   expires 1w;
 }

--- a/modules/router/templates/assets_origin.conf.erb
+++ b/modules/router/templates/assets_origin.conf.erb
@@ -70,11 +70,16 @@ server {
   }
   <%- end -%>
 
-  set $upstream_static <%= @upstream_ssl ? 'https' : 'http' %>://static.<%= @app_domain %>;
+  # Endpoint that isn't cached, which is used to assert that an external
+  # service can receive a response from GOV.UK origin on assets hostname. It
+  # is intended for pingdom monitoring
   location /__canary__ {
-    proxy_pass $upstream_static;
+    default_type application/json;
+    add_header cache-control "max-age=0,no-store,no-cache";
+    return 200 '{"message": "Tweet tweet"}\n';
   }
 
+  set $upstream_static <%= @upstream_ssl ? 'https' : 'http' %>://static.<%= @app_domain %>;
   location / {
     proxy_pass $upstream_static;
   }

--- a/modules/router/templates/router_include.conf.erb
+++ b/modules/router/templates/router_include.conf.erb
@@ -26,6 +26,15 @@ access_log /var/log/nginx/lb-access.log timed_combined;
 access_log /var/log/nginx/lb-json.event.access.log json_event;
 error_log  /var/log/nginx/lb-error.log;
 
+# Endpoint that isn't cached, which is used to assert that an external
+# service can receive a response from GOV.UK origin on www hostname. It
+# is intended for pingdom monitoring
+location /__canary__ {
+  default_type application/json;
+  add_header cache-control "max-age=0,no-store,no-cache";
+  return 200 '{"message": "Tweet tweet"}\n';
+}
+
 # If slug contains no lowercase letters then lowercase it
 # eg www.gov.uk/GOVERNMENT/GUIDANCE -> www.gov.uk/government/guidance
 # eg WWW.GOV.UK/GOVERNMENT/GUIDANCE -> www.gov.uk/government/guidance


### PR DESCRIPTION
We use Pingdom to assert that our origin machines can serve content that is requested externally to our network (it is essentially an integration test that a different network can request Fastly, that Fastly can talk to our origin and our origin can produce a valid HTTP response).

Previous to this change our configuration of these  `__canary__` endpoints was rather complicated where a request was also proxied through router to a Frontend box and then proxied again to a Backend box. Doing all of this blurred the lines of what we were actually testing, and meant that this configuration was difficult to understand. In this change we move the `__canary__` endpoints to the Nginx instances that an external request will first reach which makes this a much clearer assertion that origin can return a request.

Edit: I've reduced the scope of this PR to maintain the existing nginx configuration for canary-backend and canary-frontend. This is because they are wrapped up in removing the DNS for them from terraform. After chatting with @camdesgov it seemed the best plan was to merge in replacement endpoints, then remove the DNS from terraform, then the nginx rules and finally the config 😌 .