### PR TITLE
Increase threshold for delivery_immediate queue alerts

### DIFF
--- a/modules/govuk/manifests/apps/email_alert_api/checks.pp
+++ b/modules/govuk/manifests/apps/email_alert_api/checks.pp
@@ -20,8 +20,8 @@ class govuk::apps::email_alert_api::checks(
       latency_critical => '600'; # 10 minutes
 
     'delivery_immediate':
-      size_warning     => '75000',
-      size_critical    => '100000',
+      size_warning     => '150000',
+      size_critical    => '500000',
       latency_warning  => '1200', # 20 minutes
       latency_critical => '1800'; # 30 minutes
 


### PR DESCRIPTION
Now we are sending a lot more email each day, there are busy times where this queue increases in size.  This results in critical alerts being triggered multiple times each day, despite there being no developer action to take unless this number continues to grow.

Therefore increasing the thresholds to something more realistic for the current volume of emails being sent.

The GOV.UK Notifications team are currently reviewing this alert and may decide to remove it, but for now this should remove most of the noise for 2nd line.