### PR TITLE
Add AWS S3 configuration to whitehall

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -394,6 +394,7 @@ task :check_consistency_between_aws_and_carrenza do
     govuk::apps::whitehall::jwt_auth_secret
     govuk::apps::whitehall::redis_host
     govuk::apps::whitehall::redis_port
+    govuk::apps::whitehall::aws_s3_bucket_name
     govuk::deploy::setup::gemstash_server
     govuk::deploy::sync::auth_token
     govuk::deploy::sync::jenkins_domain

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -80,6 +80,7 @@ govuk::apps::url_arbiter::db::backend_ip_range: '10.1.3.0/24'
 govuk::apps::whitehall::basic_auth_credentials: "%{hiera('http_username')}:%{hiera('http_password')}"
 govuk::apps::whitehall::highlight_words_to_avoid: true
 govuk::apps::whitehall::govuk_notify_template_id: "759acac6-da53-4a19-b591-b7538c7c39de"
+govuk::apps::whitehall::aws_s3_bucket_name: 'govuk-integration-whitehall-csvs'
 
 licensify::apps::configfile::mongo_database_reference_name: 'licensify-refdata'
 licensify::apps::configfile::mongo_database_audit_name: 'licensify-audit'

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -231,6 +231,7 @@ govuk::apps::support_api::govuk_notify_template_id: "e00e89f5-b622-4dcb-8f30-e6c
 govuk::apps::travel_advice_publisher::enable_email_alerts: true
 govuk::apps::travel_advice_publisher::enable_procfile_worker: true
 govuk::apps::whitehall::govuk_notify_template_id: "e00e89f5-b622-4dcb-8f30-e6c70231a940"
+govuk::apps::whitehall::aws_s3_bucket_name: 'govuk-production-whitehall-csvs'
 
 govuk_search::monitoring::es_port: '80'
 govuk_search::monitoring::es_host: 'vpc-blue-elasticsearch6-domain-2hnib7uydv3tgebhabx74gdelq.eu-west-1.es.amazonaws.com'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -221,6 +221,7 @@ govuk::apps::travel_advice_publisher::mongodb_nodes: "%{hiera('govuk::apps::asse
 govuk::apps::travel_advice_publisher::mongodb_username: "%{hiera('govuk::apps::asset_manager::mongodb_username')}"
 govuk::apps::travel_advice_publisher::mongodb_password: "%{hiera('govuk::apps::asset_manager::mongodb_password')}"
 govuk::apps::whitehall::govuk_notify_template_id: "112842bb-d8a4-4511-90de-57dc5c8f27ec"
+govuk::apps::whitehall::aws_s3_bucket_name: 'govuk-staging-whitehall-csvs'
 
 govuk::apps::contacts::ensure: 'present'
 govuk::apps::collections_publisher::ensure: 'present'

--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -145,12 +145,6 @@
 # [*govuk_notify_template_id*]
 #   The template ID used to send email via GOV.UK Notify.
 #
-# [*aws_access_key_id*]
-#   The Access Key ID for AWS to access S3 buckets.
-#
-# [*aws_secret_access_key*]
-#   The Secret Access Key for AWS to access S3 buckets.
-#
 # [*aws_region*]
 #   The Region for AWS to access S3 buckets.
 #
@@ -201,8 +195,6 @@ class govuk::apps::whitehall(
   $backend_unicorn_worker_processes = 4,
   $govuk_notify_api_key = undef,
   $govuk_notify_template_id = undef,
-  $aws_access_key_id = undef,
-  $aws_secret_access_key = undef,
   $aws_region = 'eu-west-1',
   $aws_s3_bucket_name = undef,
 ) {
@@ -391,12 +383,6 @@ class govuk::apps::whitehall(
       "${title}-GOVUK_NOTIFY_TEMPLATE_ID":
         varname => 'GOVUK_NOTIFY_TEMPLATE_ID',
         value   => $govuk_notify_template_id;
-      "${title}-AWS_ACCESS_KEY_ID":
-        varname => 'AWS_ACCESS_KEY_ID',
-        value   => $aws_access_key_id;
-      "${title}-AWS_SECRET_ACCESS_KEY":
-        varname => 'AWS_SECRET_ACCESS_KEY',
-        value   => $aws_secret_access_key;
       "${title}-AWS_REGION":
         varname => 'AWS_REGION',
         value   => $aws_region;

--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -145,6 +145,17 @@
 # [*govuk_notify_template_id*]
 #   The template ID used to send email via GOV.UK Notify.
 #
+# [*aws_access_key_id*]
+#   The Access Key ID for AWS to access S3 buckets.
+#
+# [*aws_secret_access_key*]
+#   The Secret Access Key for AWS to access S3 buckets.
+#
+# [*aws_region*]
+#   The Region for AWS to access S3 buckets.
+#
+# [*aws_s3_bucket_name*]
+#   The S3 Bucket for AWS to access.
 
 class govuk::apps::whitehall(
   $admin_db_name = undef,
@@ -190,6 +201,10 @@ class govuk::apps::whitehall(
   $backend_unicorn_worker_processes = 4,
   $govuk_notify_api_key = undef,
   $govuk_notify_template_id = undef,
+  $aws_access_key_id = undef,
+  $aws_secret_access_key = undef,
+  $aws_region = 'eu-west-1',
+  $aws_s3_bucket_name = undef,
 ) {
 
   $app_name = 'whitehall'
@@ -376,6 +391,18 @@ class govuk::apps::whitehall(
       "${title}-GOVUK_NOTIFY_TEMPLATE_ID":
         varname => 'GOVUK_NOTIFY_TEMPLATE_ID',
         value   => $govuk_notify_template_id;
+      "${title}-AWS_ACCESS_KEY_ID":
+        varname => 'AWS_ACCESS_KEY_ID',
+        value   => $aws_access_key_id;
+      "${title}-AWS_SECRET_ACCESS_KEY":
+        varname => 'AWS_SECRET_ACCESS_KEY',
+        value   => $aws_secret_access_key;
+      "${title}-AWS_REGION":
+        varname => 'AWS_REGION',
+        value   => $aws_region;
+      "${title}-AWS_S3_BUCKET_NAME":
+        varname => 'AWS_S3_BUCKET_NAME',
+        value   => $aws_s3_bucket_name;
     }
 
     govuk::app::envvar::database_url { $app_name:


### PR DESCRIPTION
This is to allow exported files to be uploaded and sent as links instead of as email attachments, allowing migration to notify.

https://trello.com/c/5xKHcam8/2012-5-whitehall-replace-attachments-in-documentlistexport-so-that-notify-can-be-used