### PR TITLE
govuk_solr: reverse ::install/::config dependencies in $remove mode

### DIFF
--- a/modules/govuk_solr/manifests/config.pp
+++ b/modules/govuk_solr/manifests/config.pp
@@ -32,32 +32,34 @@ class govuk_solr::config (
     true  => stopped,
   }
 
-  file{"${solr_home}/current/conf":
-    ensure  => $ensure_dir,
-  } ->
+  unless $remove {
+    file{"${solr_home}/current/conf":
+        ensure  => $ensure_dir,
+    } ->
 
-  file{"${solr_home}/current/solr":
-    ensure  => $ensure_dir,
-    owner   => $jetty_user,
-    group   => $jetty_user,
-    recurse => true,
-  } ->
+    file{"${solr_home}/current/solr":
+        ensure  => $ensure_dir,
+        owner   => $jetty_user,
+        group   => $jetty_user,
+        recurse => true,
+    } ->
 
-  file {"${solr_home}/current/example/solr/collection1/conf/schema.xml":
-    ensure => $ensure_file,
-    owner  => $jetty_user,
-    group  => $jetty_user,
-    source => 'puppet:///modules/govuk_solr/schema.xml',
-    notify => Service['jetty'],
-  } ->
+    file {"${solr_home}/current/example/solr/collection1/conf/schema.xml":
+        ensure => $ensure_file,
+        owner  => $jetty_user,
+        group  => $jetty_user,
+        source => 'puppet:///modules/govuk_solr/schema.xml',
+        notify => Service['jetty'],
+    } ->
 
-  file {"${solr_home}/current/conf/jetty-logging.xml":
-    ensure => $ensure_file,
-    owner  => $jetty_user,
-    group  => $jetty_user,
-    source => 'puppet:///modules/govuk_solr/jetty-logging.xml',
-    notify => Service['jetty'],
-  } ->
+    file {"${solr_home}/current/conf/jetty-logging.xml":
+        ensure => $ensure_file,
+        owner  => $jetty_user,
+        group  => $jetty_user,
+        source => 'puppet:///modules/govuk_solr/jetty-logging.xml',
+        notify => Service['jetty'],
+    }
+  }
 
   file {'/etc/default/jetty':
     ensure  => $ensure_file,

--- a/modules/govuk_solr/manifests/init.pp
+++ b/modules/govuk_solr/manifests/init.pp
@@ -19,11 +19,17 @@ class govuk_solr (
 
   class{'govuk_solr::install':
     remove => $remove,
-  } ~>
+  }
 
   class{'govuk_solr::config':
     jetty_user => $jetty_user,
     solr_home  => $solr_home,
     remove     => $remove,
+  }
+
+  if $remove {
+    Class['govuk_solr::config'] ~> Class['govuk_solr::install']
+  } else {
+    Class['govuk_solr::install'] ~> Class['govuk_solr::config']
   }
 }


### PR DESCRIPTION
Followup to https://github.com/alphagov/govuk-puppet/pull/10485

This is to prevent puppet trying to e.g. remove the solr user before stopping the service.

Might this work?