### PR TITLE
Revert " govuk_solr: add "remove" mode which will ensure a previous installation is removed"

### DIFF
--- a/hieradata/node/ci-agent-7.ci.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/ci-agent-7.ci.integration.publishing.service.gov.uk.yaml
@@ -1,5 +1,3 @@
 ---
 govuk_containers::elasticsearch::primary::enable: false
 govuk_containers::elasticsearch::secondary::enable: false
-
-govuk_solr::remove: true

--- a/hieradata/node/ci-agent-8.ci.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/ci-agent-8.ci.integration.publishing.service.gov.uk.yaml
@@ -1,5 +1,3 @@
 ---
 govuk_containers::elasticsearch::primary::enable: false
 govuk_containers::elasticsearch::secondary::enable: false
-
-govuk_solr::remove: true

--- a/modules/govuk_solr/manifests/config.pp
+++ b/modules/govuk_solr/manifests/config.pp
@@ -14,37 +14,21 @@
 class govuk_solr::config (
   $jetty_user = undef,
   $solr_home = undef,
-  $remove = undef,
 ) {
 
-  $ensure_dir = $remove ? {
-    false => directory,
-    true  => absent,
-  }
-
-  $ensure_file = $remove ? {
-    false => file,
-    true  => absent,
-  }
-
-  $ensure_service = $remove ? {
-    false => running,
-    true  => stopped,
-  }
-
   file{"${solr_home}/current/conf":
-    ensure  => $ensure_dir,
+    ensure  => directory,
   } ->
 
   file{"${solr_home}/current/solr":
-    ensure  => $ensure_dir,
+    ensure  => directory,
     owner   => $jetty_user,
     group   => $jetty_user,
     recurse => true,
   } ->
 
   file {"${solr_home}/current/example/solr/collection1/conf/schema.xml":
-    ensure => $ensure_file,
+    ensure => file,
     owner  => $jetty_user,
     group  => $jetty_user,
     source => 'puppet:///modules/govuk_solr/schema.xml',
@@ -52,7 +36,7 @@ class govuk_solr::config (
   } ->
 
   file {"${solr_home}/current/conf/jetty-logging.xml":
-    ensure => $ensure_file,
+    ensure => file,
     owner  => $jetty_user,
     group  => $jetty_user,
     source => 'puppet:///modules/govuk_solr/jetty-logging.xml',
@@ -60,27 +44,27 @@ class govuk_solr::config (
   } ->
 
   file {'/etc/default/jetty':
-    ensure  => $ensure_file,
+    ensure  => file,
     content => template('govuk_solr/jetty.erb'),
     notify  => Service['jetty'],
   } ->
 
   file {'/etc/init.d/jetty':
-    ensure  => $ensure_file,
+    ensure  => file,
     mode    => '0755',
     content => template('govuk_solr/jetty.sh.erb'),
     notify  => Service['jetty'],
   } ->
 
   file {'/var/log/jetty':
-    ensure => $ensure_dir,
+    ensure => directory,
   } ->
 
   file {'/var/cache/jetty':
-    ensure => $ensure_dir,
+    ensure => directory,
   } ->
 
   service {'jetty':
-    ensure => $ensure_service,
+    ensure => running,
   }
 }

--- a/modules/govuk_solr/manifests/init.pp
+++ b/modules/govuk_solr/manifests/init.pp
@@ -8,22 +8,17 @@ class govuk_solr (
   $jetty_host = '127.0.0.1',
   $jetty_port = '8983',
   $solr_home  = '/var/lib/solr',
-  $remove     = false,
 ) {
 
   ## === Variables === ##
-  unless $remove {
-    $required_packages = ['openjdk-7-jre']
-    $java_home = '/usr/lib/jvm/java-7-openjdk-amd64/jre'
-  }
+  $required_packages = ['openjdk-7-jre']
+  $java_home = '/usr/lib/jvm/java-7-openjdk-amd64/jre'
 
   class{'govuk_solr::install':
-    remove => $remove,
   } ~>
 
   class{'govuk_solr::config':
     jetty_user => $jetty_user,
     solr_home  => $solr_home,
-    remove     => $remove,
   }
 }

--- a/modules/govuk_solr/manifests/install.pp
+++ b/modules/govuk_solr/manifests/install.pp
@@ -13,45 +13,24 @@
 class govuk_solr::install (
   $version  = '4.3.1',
   $base_url = 'https://archive.apache.org/dist/lucene/solr/',
-  $remove = undef,
 ) {
 
-  $ensure_user = $remove ? {
-    false => present,
-    true  => absent,
-  }
-
-  $ensure_dir = $remove ? {
-    false => directory,
-    true  => absent,
-  }
-
-  $ensure_archive = $remove ? {
-    false => present,
-    true  => absent,
-  }
-
-  $ensure_link = $remove ? {
-    false => link,
-    true  => absent,
-  }
-
   user { 'solr':
-    ensure     => $ensure_user,
+    ensure     => present,
     home       => '/var/lib/solr',
     managehome => true,
     shell      => '/bin/bash',
   }
 
   file { '/var/lib/solr':
-    ensure  => $ensure_dir,
+    ensure  => 'directory',
     owner   => 'solr',
     group   => 'solr',
     require => User['solr'],
   }
 
   archive { 'solr':
-    ensure       => $ensure_archive,
+    ensure       => present,
     path         => '/tmp/solr.tgz',
     extract      => true,
     source       => "${base_url}${version}/solr-${version}.tgz",
@@ -64,7 +43,7 @@ class govuk_solr::install (
   }
 
   file { '/var/lib/solr/current':
-    ensure  => $ensure_link,
+    ensure  => 'link',
     target  => "/var/lib/solr/solr-${version}",
     require => Archive['solr'],
   }


### PR DESCRIPTION
Reverts alphagov/govuk-puppet#10485

This didn't apply cleanly - let's get the target machines back to their previous state before I try again.