### PR TITLE
add govuk_solr6: add new module to install solr 6.x from custom debian package

### DIFF
--- a/hieradata/class/ci_agent.yaml
+++ b/hieradata/class/ci_agent.yaml
@@ -16,6 +16,8 @@ govuk_mysql::server::innodb_flush_log_at_trx_commit: 2
 govuk_mysql::server::innodb_buffer_pool_size_proportion: 0.05
 govuk_mysql::server::query_cache_size: 0
 
+govuk_solr6::present: false
+
 lv:
   data:
     pv: '/dev/sdb1'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -768,6 +768,9 @@ govuk_rabbitmq::repo::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_finge
 govuk_rbenv::all::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk_rbenv::all::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
+govuk_solr6::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_solr6::repo::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
+
 govuk_sudo::sudo_conf:
   deploy_docker_image:
     content: 'deploy ALL=NOPASSWD:/usr/bin/docker image *'

--- a/hieradata/node/ci-agent-7.ci.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/ci-agent-7.ci.integration.publishing.service.gov.uk.yaml
@@ -3,3 +3,5 @@ govuk_containers::elasticsearch::primary::enable: false
 govuk_containers::elasticsearch::secondary::enable: false
 
 govuk_solr::disable: true
+
+govuk_solr6::present: true

--- a/hieradata/node/ci-agent-8.ci.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/ci-agent-8.ci.integration.publishing.service.gov.uk.yaml
@@ -3,3 +3,5 @@ govuk_containers::elasticsearch::primary::enable: false
 govuk_containers::elasticsearch::secondary::enable: false
 
 govuk_solr::disable: true
+
+govuk_solr6::present: true

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1036,6 +1036,9 @@ govuk_rabbitmq::repo::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_finge
 govuk_rbenv::all::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk_rbenv::all::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
+govuk_solr6::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_solr6::repo::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
+
 govuk_sudo::sudo_conf:
   deploy_docker_image:
     content: 'deploy ALL=NOPASSWD:/usr/bin/docker image *'

--- a/modules/govuk_ci/manifests/agent/solr.pp
+++ b/modules/govuk_ci/manifests/agent/solr.pp
@@ -6,4 +6,6 @@ class govuk_ci::agent::solr {
 
   include ::govuk_solr
 
+  include ::govuk_solr6
+
 }

--- a/modules/govuk_solr6/manifests/init.pp
+++ b/modules/govuk_solr6/manifests/init.pp
@@ -1,0 +1,33 @@
+# == Class: govuk_solr6
+#
+# Installs solr 6.x using custom deb package, enables and starts
+# service.
+#
+# === Parameters:
+#
+# [*present*]
+#   Whether package should _actually_ be present.
+#
+class govuk_solr6 (
+  $present = true,
+) {
+  $package_ensure = $present ? {
+    false => absent,
+    true  => present,
+  }
+
+  include govuk_solr6::repo
+
+  package { 'solr':
+    ensure => $package_ensure,
+  }
+
+  if $present {
+    service { 'solr':
+      ensure => running,
+      enable => true,
+    }
+
+    Package['solr'] ~> Service['solr']
+  }
+}

--- a/modules/govuk_solr6/manifests/repo.pp
+++ b/modules/govuk_solr6/manifests/repo.pp
@@ -1,0 +1,22 @@
+# == Class: govuk_solr6::repo
+#
+# === Parameters:
+#
+# [*apt_mirror_hostname*]
+#   Hostname to use for the APT mirror.
+#
+# [*apt_mirror_gpg_key_fingerprint*]
+#   Fingerprint to use for the APT mirror.
+#
+class govuk_solr6::repo (
+  $apt_mirror_hostname,
+  $apt_mirror_gpg_key_fingerprint,
+) {
+  apt::source { 'solr':
+    location     => "http://${apt_mirror_hostname}/solr",
+    release      => $::lsbdistcodename,
+    architecture => $::architecture,
+    repos        => 'main',
+    key          => $apt_mirror_gpg_key_fingerprint,
+  }
+}


### PR DESCRIPTION
https://trello.com/c/nyR51ZeI

Designed to allow control of *actual* presence via `$present` parameter. Made `$present` on ci machines 7 and 8 to begin with, which have `govuk_solr` disabled.

~Requires openjdk8, which calls for a little dance with `govuk_java` to enforce that.~
