### PR TITLE
Remove redirect for leicestershire coronavirus

### DIFF
--- a/modules/router/templates/base.conf.erb
+++ b/modules/router/templates/base.conf.erb
@@ -37,13 +37,4 @@ server {
   include             /etc/nginx/router_include.conf;
 
   add_header X-Robots-Tag "noindex";
-
-  # Redirect for a draft document that was accidentally leaked to the publi
-  # with bypass authentication token.
-  #
-  # Added 30 June 2020 - if this is still here 6 months later assume it's safe
-  # to remove.
-  if ($arg_token = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIzOTM0NjUzMi0zMTM5LTQ3MzgtYjI2Mi02NjYxMzIzMjY0MzEifQ.9Fd2ok0BMi7IEnMQF9xlMNzl57nYoiOpz-rdL8QuWNI") {
-    rewrite ^/(government/news/leicestershire-coronavirus-lockdown-areas-and-changes)$ <%= @website_root %>/$1? permanent;
-  }
 }


### PR DESCRIPTION
Trello: https://trello.com/c/IQ26eiaW/240-make-content-publisher-use-changing-auth-bypass-tokens

This redirect was added because the draft link was tweeted and was used
by many people. We've not had any requests for this link since June 30th
and it no longer returns a content page (it returns a redirect to
authenticate)