### PR TITLE
Move 'Configure GitHub Repos' job to production

### DIFF
--- a/hieradata_aws/class/integration/jenkins.yaml
+++ b/hieradata_aws/class/integration/jenkins.yaml
@@ -10,7 +10,6 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::clear_frontend_memcache
   - govuk_jenkins::jobs::clear_template_cache
   - govuk_jenkins::jobs::clear_varnish_cache
-  - govuk_jenkins::jobs::configure_github_repos
   - govuk_jenkins::jobs::content_data_api
   - govuk_jenkins::jobs::data_sync_complete_integration
   - govuk_jenkins::jobs::deploy_app

--- a/hieradata_aws/class/production/jenkins.yaml
+++ b/hieradata_aws/class/production/jenkins.yaml
@@ -46,6 +46,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::clear_frontend_memcache
   - govuk_jenkins::jobs::clear_template_cache
   - govuk_jenkins::jobs::clear_varnish_cache
+  - govuk_jenkins::jobs::configure_github_repos
   - govuk_jenkins::jobs::content_data_api
   - govuk_jenkins::jobs::deploy_app
   - govuk_jenkins::jobs::deploy_emergency_banner


### PR DESCRIPTION
It doesn't quite make sense for this job to run in integration as it performs tasks against our production repos.

Depends on https://github.com/alphagov/govuk-secrets/pull/1005.