### PR TITLE
Revert "Add redirect for Leicestershire lockdown changes"

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -497,7 +497,6 @@ task :check_consistency_between_aws_and_carrenza do
     monitoring::pagerduty_drill::enabled
     router::assets_origin::website_root
     router::nginx::robotstxt
-    router::nginx::website_root
     govuk::apps::govuk_crawler_worker::blacklist_paths
     govuk_awscloudwatch::apt_mirror_hostname
     govuk_awscloudwatch::apt_mirror_gpg_key_fingerprint

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1429,8 +1429,6 @@ router::nginx::robotstxt: |
   User-agent: Googlebot
   Disallow: /licence-finder/*
 
-router::nginx::website_root: "%{hiera('govuk::deploy::config::website_root')}"
-
 sidekiq_host: 'backend-redis'
 sidekiq_port: '6379'
 

--- a/modules/router/manifests/nginx.pp
+++ b/modules/router/manifests/nginx.pp
@@ -49,9 +49,6 @@
 #
 # Default: ''
 #
-# [*website_root*]
-#   The URL to the root of the main GOV.UK host for redirects
-#
 class router::nginx (
   $app_specific_static_asset_routes = {},
   $vhost_protected,
@@ -61,7 +58,6 @@ class router::nginx (
   $check_requests_warning = '@25',
   $check_requests_critical = '@10',
   $robotstxt = '',
-  $website_root = undef,
 ) {
   validate_array($rate_limit_tokens)
 

--- a/modules/router/templates/base.conf.erb
+++ b/modules/router/templates/base.conf.erb
@@ -37,13 +37,4 @@ server {
   include             /etc/nginx/router_include.conf;
 
   add_header X-Robots-Tag "noindex";
-
-  # Redirect for a draft document that was accidentally leaked to the publi
-  # with bypass authentication token.
-  #
-  # Added 30 June 2020 - if this is still here 6 months later assume it's safe
-  # to remove.
-  if ($arg_token = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIzOTM0NjUzMi0zMTM5LTQ3MzgtYjI2Mi02NjYxMzIzMjY0MzEifQ.9Fd2ok0BMi7IEnMQF9xlMNzl57nYoiOpz-rdL8QuWNI") {
-    rewrite ^/(government/news/leicestershire-coronavirus-lockdown-areas-and-changes)$ <%= @website_root %>/$1? permanent;
-  }
 }


### PR DESCRIPTION
This reverts commit 0ec4c1bf38c0b0cfab742a2a89b385f13d5b9379.

This redirect was added because the draft link was tweeted and was used
by many people. We've not had any requests for this link since June 30th
and it no longer returns a content page (it returns a redirect to
authenticate).

This supersedes https://github.com/alphagov/govuk-puppet/pull/10491, 
I had forgotten there was some more configuration added for this task.