### PR TITLE
Update CKAN ini to enable validation of tags

### DIFF
--- a/modules/govuk/templates/ckan/ckan.ini.erb
+++ b/modules/govuk/templates/ckan/ckan.ini.erb
@@ -118,6 +118,7 @@ ckan.redis.url = redis://<%= @redis_host%>:<%= @redis_port%>/1
 
 ckan.spatial.validator.profiles = iso19139eden,constraints-1.4,gemini2-1.3
 ckan.spatial.validator.reject = true
+ckan.spatial.validator.use_default_tag_schema = true
 ckan.spatial.srid = 4258
 
 # Define which views should be created by default


### PR DESCRIPTION
## What

Use the default CKAN tag schema so that invalid tags do not get ingested into CKAN causing problems updating datasets.

## Reference

https://trello.com/c/v4Xr9jgn/2007-5-validate-harvested-tags-upon-ingest