### PR TITLE
govuk_solr: attempt #2 to add "disable" mode, which actually just stops & disables the jetty service

### DIFF
--- a/hieradata/node/ci-agent-7.ci.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/ci-agent-7.ci.integration.publishing.service.gov.uk.yaml
@@ -1,3 +1,5 @@
 ---
 govuk_containers::elasticsearch::primary::enable: false
 govuk_containers::elasticsearch::secondary::enable: false
+
+govuk_solr::disable: true

--- a/hieradata/node/ci-agent-8.ci.integration.publishing.service.gov.uk.yaml
+++ b/hieradata/node/ci-agent-8.ci.integration.publishing.service.gov.uk.yaml
@@ -1,3 +1,5 @@
 ---
 govuk_containers::elasticsearch::primary::enable: false
 govuk_containers::elasticsearch::secondary::enable: false
+
+govuk_solr::disable: true

--- a/modules/govuk_solr/manifests/config.pp
+++ b/modules/govuk_solr/manifests/config.pp
@@ -11,60 +11,77 @@
 # [*solr_home*]
 #   The home directory for solr.
 #
+# [*disable*]
+#   Whether to actually just stop/disable the jetty service
+#
 class govuk_solr::config (
   $jetty_user = undef,
   $solr_home = undef,
+  $disable = undef,
 ) {
 
-  file{"${solr_home}/current/conf":
-    ensure  => directory,
-  } ->
+  unless $disable {
+    file{"${solr_home}/current/conf":
+      ensure  => directory,
+    } ->
 
-  file{"${solr_home}/current/solr":
-    ensure  => directory,
-    owner   => $jetty_user,
-    group   => $jetty_user,
-    recurse => true,
-  } ->
+    file{"${solr_home}/current/solr":
+      ensure  => directory,
+      owner   => $jetty_user,
+      group   => $jetty_user,
+      recurse => true,
+    } ->
 
-  file {"${solr_home}/current/example/solr/collection1/conf/schema.xml":
-    ensure => file,
-    owner  => $jetty_user,
-    group  => $jetty_user,
-    source => 'puppet:///modules/govuk_solr/schema.xml',
-    notify => Service['jetty'],
-  } ->
+    file {"${solr_home}/current/example/solr/collection1/conf/schema.xml":
+      ensure => file,
+      owner  => $jetty_user,
+      group  => $jetty_user,
+      source => 'puppet:///modules/govuk_solr/schema.xml',
+      notify => Service['jetty'],
+    } ->
 
-  file {"${solr_home}/current/conf/jetty-logging.xml":
-    ensure => file,
-    owner  => $jetty_user,
-    group  => $jetty_user,
-    source => 'puppet:///modules/govuk_solr/jetty-logging.xml',
-    notify => Service['jetty'],
-  } ->
+    file {"${solr_home}/current/conf/jetty-logging.xml":
+      ensure => file,
+      owner  => $jetty_user,
+      group  => $jetty_user,
+      source => 'puppet:///modules/govuk_solr/jetty-logging.xml',
+      notify => Service['jetty'],
+    } ->
 
-  file {'/etc/default/jetty':
-    ensure  => file,
-    content => template('govuk_solr/jetty.erb'),
-    notify  => Service['jetty'],
-  } ->
+    file {'/etc/default/jetty':
+      ensure  => file,
+      content => template('govuk_solr/jetty.erb'),
+      notify  => Service['jetty'],
+    } ->
 
-  file {'/etc/init.d/jetty':
-    ensure  => file,
-    mode    => '0755',
-    content => template('govuk_solr/jetty.sh.erb'),
-    notify  => Service['jetty'],
-  } ->
+    file {'/etc/init.d/jetty':
+      ensure  => file,
+      mode    => '0755',
+      content => template('govuk_solr/jetty.sh.erb'),
+      notify  => Service['jetty'],
+    } ->
 
-  file {'/var/log/jetty':
-    ensure => directory,
-  } ->
+    file {'/var/log/jetty':
+      ensure => directory,
+    } ->
 
-  file {'/var/cache/jetty':
-    ensure => directory,
-  } ->
+    file {'/var/cache/jetty':
+      ensure => directory,
+      notify => Service['jetty'],
+    }
+  }
+
+  $service_ensure = $disable ? {
+    false => 'running',
+    true  => 'stopped',
+  }
+  $service_enable = $disable ? {
+    false => true,
+    true  => false,
+  }
 
   service {'jetty':
-    ensure => running,
+    ensure => $service_ensure,
+    enable => $service_enable,
   }
 }

--- a/modules/govuk_solr/manifests/init.pp
+++ b/modules/govuk_solr/manifests/init.pp
@@ -8,17 +8,22 @@ class govuk_solr (
   $jetty_host = '127.0.0.1',
   $jetty_port = '8983',
   $solr_home  = '/var/lib/solr',
+  $disable     = false,
 ) {
-
   ## === Variables === ##
   $required_packages = ['openjdk-7-jre']
   $java_home = '/usr/lib/jvm/java-7-openjdk-amd64/jre'
 
-  class{'govuk_solr::install':
-  } ~>
-
   class{'govuk_solr::config':
     jetty_user => $jetty_user,
     solr_home  => $solr_home,
+    disable    => $disable,
+  }
+
+  unless $disable {
+    class{'govuk_solr::install':
+    }
+
+    Class['govuk_solr::install'] ~>  Class['govuk_solr::config']
   }
 }


### PR DESCRIPTION
Let's try that again, shall we?

https://trello.com/c/zLLNaKtv

A re-spin of #10485 which moves the definitions of `$required_packages` and `$java_home` out of the conditional block, with the hopes that it will now be visible to `jetty.erb`.