### PR TITLE
Change ALB www checks to use __varnish_check__

### DIFF
--- a/modules/router/templates/default-vhost.conf.erb
+++ b/modules/router/templates/default-vhost.conf.erb
@@ -6,14 +6,14 @@ server {
     proxy_pass http://varnish;
   }
 
-  # Health checks from ALB reuse Fastly __canary__ health check path
-  # and bypass authentication on Integration
   location /_healthcheck_www {
-    proxy_pass http://varnish/__canary__;
+    proxy_pass http://varnish/__varnish_check__;
   }
+
   location /_healthcheck_www-origin {
-    proxy_pass http://varnish/__canary__;
+    proxy_pass http://varnish/__varnish_check__;
   }
+
   location /_healthcheck_assets-origin {
     return 200;
   }


### PR DESCRIPTION
This replaces the previous use of the __canary__ endpoint which is
intended for Pingdom to ascertain that GOV.UK origin is up. This is done
as part of work to simplify the __canary__ endpoints so their purpose
can be understood. Part of this is untangling areas like this where
we've mixed up the purpose of __canary__ being a means to inform Pingdom
that GOV.UK Origin can serve requests and as a healthcheck mechanism for
internal load balancers.

I've opted for these healthchecks to use the __varnish_check__ endpoint
which determines that varnish is running and can serve requests. It may
prove that we want this healthcheck to go further and also determine
that router is able to serve a response. To do this a healthcheck
functionality should be added to router. However, this checking varnish
seems more elaborate than the other checks in this file where nginx is
just returning 200.