### PR TITLE
[DO NOT MERGE YET , SIGON MIGRATION] add signon to AWS Production backend

### DIFF
--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -38,6 +38,7 @@ node_class: &node_class
       - service-manual-publisher
       - short-url-manager
       - sidekiq-monitoring
+      - signon
       - specialist-publisher
       - support
       - support-api


### PR DESCRIPTION
Done as part of the migration to AWS of signon app