### PR TITLE
add signon cron jobs to AWS staging jenkins

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -542,6 +542,12 @@ task :check_consistency_between_aws_and_carrenza do
     licensify::apps::licensify::environment
     licensify::apps::licensify_admin::environment
     licensify::apps::licensify_feed::environment
+
+    govuk_jenkins::jobs::signon_cron_rake_tasks::configure_jobs
+    govuk_jenkins::jobs::signon_cron_rake_tasks::rake_oauth_access_grants_delete_expired_frequency
+    govuk_jenkins::jobs::signon_cron_rake_tasks::rake_organisations_fetch_frequency
+    govuk_jenkins::jobs::signon_cron_rake_tasks::rake_users_send_suspension_reminders_frequency
+    govuk_jenkins::jobs::signon_cron_rake_tasks::rake_users_suspend_inactive_frequency
   ]
 
   failed = false

--- a/hieradata_aws/class/staging/jenkins.yaml
+++ b/hieradata_aws/class/staging/jenkins.yaml
@@ -72,6 +72,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::search_relevancy_metrics_etl
   - govuk_jenkins::jobs::search_generate_sitemaps
   - govuk_jenkins::jobs::send_bulk_email
+  - govuk_jenkins::jobs::signon_cron_rake_tasks
   - govuk_jenkins::jobs::smokey
   - govuk_jenkins::jobs::smokey_deploy
   - govuk_jenkins::jobs::whitehall_publisher_notifications

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -278,6 +278,12 @@ govuk_jenkins::jobs::search_relevancy_metrics_etl::cron_schedule: 'H 1,7,13,19 *
 
 govuk_jenkins::jobs::smokey::environment: staging_aws
 
+govuk_jenkins::jobs::signon_cron_rake_tasks::configure_jobs: true
+govuk_jenkins::jobs::signon_cron_rake_tasks::rake_oauth_access_grants_delete_expired_frequency: '0 12 * * 0'
+govuk_jenkins::jobs::signon_cron_rake_tasks::rake_organisations_fetch_frequency: '0 3 * * *'
+govuk_jenkins::jobs::signon_cron_rake_tasks::rake_users_suspend_inactive_frequency: '0 4 * * *'
+govuk_jenkins::jobs::signon_cron_rake_tasks::rake_users_send_suspension_reminders_frequency: '0 6 * * *'
+
 govuk_jenkins::jobs::data_sync_complete_staging::signon_domains_to_migrate:
   -
     old: publishing.service.gov.uk


### PR DESCRIPTION
This is done as part of the AWS migration of Signon.