### PR TITLE
check_apt_security_updates, check_reboot_required: Fix running these!

### DIFF
--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_apt_security_updates
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_apt_security_updates
@@ -103,3 +103,6 @@ def main():
     except Exception as e:
         # Catching all other exceptions
         nagios_message("Exception: %s" % e, 3)
+
+if __name__ == '__main__':
+    main()

--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_reboot_required
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_reboot_required
@@ -152,3 +152,6 @@ def main():
     except Exception as e:
         # Catching all other exceptions
         nagios_message("Exception: %s" % e, 3)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
- Oops. I broke these in February in d45682a8427c71a1ea7c42857fe6de59f39fb452. As we were investigating Replatforming things, I had a sudden thought that I'd not seen any Icinga noise for a while on these fronts.
- This fixes them, by writing Python properly because now they're standalone scripts and not imported from elsewhere.
