### PR TITLE
Correct content-publisher tag manager auth

### DIFF
--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -146,7 +146,7 @@ govuk::apps::content_data_api::etl_healthcheck_enabled_from_hour: '9'
 govuk::apps::contacts::enabled: true
 govuk::apps::content_publisher::aws_s3_bucket: "govuk-production-content-publisher-activestorage"
 govuk::apps::content_publisher::enabled: true
-govuk::apps::content_publisher::google_tag_manager_auth: "O0DrItJxJeQ5Q2W6YCZzvw"
+govuk::apps::content_publisher::google_tag_manager_auth: "sxvBI4QvwgTRX5e76vdIHA"
 govuk::apps::content_publisher::google_tag_manager_id: "GTM-NQXC4TG"
 govuk::apps::content_publisher::google_tag_manager_preview: "env-7"
 govuk::apps::content_publisher::govuk_notify_template_id: "e00e89f5-b622-4dcb-8f30-e6c70231a940"


### PR DESCRIPTION
This was broken when Content Publisher was migrated to AWS because the hieradata hadn't been kept in sync since https://github.com/alphagov/govuk-puppet/commit/ec10d676c7ba97d9b1d0e7c585e957f64fbb8389 was merged.