### PR TITLE
Set env-2 for Content Publisher Tag Manager preview

### DIFF
--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -148,7 +148,7 @@ govuk::apps::content_publisher::aws_s3_bucket: "govuk-production-content-publish
 govuk::apps::content_publisher::enabled: true
 govuk::apps::content_publisher::google_tag_manager_auth: "sxvBI4QvwgTRX5e76vdIHA"
 govuk::apps::content_publisher::google_tag_manager_id: "GTM-NQXC4TG"
-govuk::apps::content_publisher::google_tag_manager_preview: "env-7"
+govuk::apps::content_publisher::google_tag_manager_preview: "env-2"
 govuk::apps::content_publisher::govuk_notify_template_id: "e00e89f5-b622-4dcb-8f30-e6c70231a940"
 govuk::apps::collections_publisher::govuk_notify_template_id: "e00e89f5-b622-4dcb-8f30-e6c70231a940"
 govuk::apps::collections_publisher::publish_without_2i_email: "mainstream-force-publishing-alerts@digital.cabinet-office.gov.uk"


### PR DESCRIPTION
My previous commit in 6839a9bb did not fix the tag manager 404 problem as it also needed the gtm_preview value that I didn't notice.

Before:

```
$ curl -sI https://www.googletagmanager.com/gtm.js\?id\=GTM-NQXC4TG\&gtm_cookies_win\=x\&gtm_auth\=sxvBI4QvwgTRX5e76vdIHA\&gtm_preview\=env-7 | grep HTTP
HTTP/2 404
```

After:

```
$ curl -sI https://www.googletagmanager.com/gtm.js\?id\=GTM-NQXC4TG\&gtm_cookies_win\=x\&gtm_auth\=sxvBI4QvwgTRX5e76vdIHA\&gtm_preview\=env-2 | grep HTTP
HTTP/2 200
```