### PR TITLE
add option to exclude dumping mysql tables in govuk_env_sync

### DIFF
--- a/hieradata/node/mysql-backup-1.backend.publishing.service.gov.uk.yaml
+++ b/hieradata/node/mysql-backup-1.backend.publishing.service.gov.uk.yaml
@@ -43,3 +43,16 @@ govuk_env_sync::tasks:
     temppath: "/home/govuk-backup/tmp_dumps/signon_production"
     url: "govuk-production-database-backups"
     path: "mysql"
+  # testing signon backup with excluded tables
+  "push_trimmed_signon_production_daily":
+    ensure: "present"
+    hour: "0"
+    minute: "40"
+    action: "push"
+    dbms: "mysql"
+    storagebackend: "s3"
+    database: "signon_production"
+    temppath: "/tmp/signon_production"
+    url: "govuk-staging-database-backups"
+    excluded_tables: "__event_logs_old,event_logs,lhma_2019_04_30_10_36_45_946_event_logs,lhma_2019_06_18_13_31_49_199_event_logs"
+    path: "mysql/trimmed"

--- a/hieradata_aws/class/staging/db_admin.yaml
+++ b/hieradata_aws/class/staging/db_admin.yaml
@@ -287,6 +287,7 @@ govuk_env_sync::tasks:
     temppath: "/tmp/search_admin_production"
     url: "govuk-staging-database-backups"
     path: "mysql"
+  # testing signon backup with excluded tables
   "pull_signon_production_daily":
     ensure: "present"
     hour: "1"
@@ -297,7 +298,20 @@ govuk_env_sync::tasks:
     database: "signon_production"
     temppath: "/tmp/signon_production"
     url: "govuk-production-database-backups"
-    path: "mysql"
+    path: "mysql/trimmed"
+  # testing signon backup with excluded tables
+  "push_signon_production_daily":
+    ensure: "absent" #was used for testing
+    hour: "1"
+    minute: "30"
+    action: "push"
+    dbms: "mysql"
+    storagebackend: "s3"
+    database: "signon_production"
+    temppath: "/tmp/signon_production"
+    url: "govuk-staging-database-backups"
+    excluded_tables: "__event_logs_old,event_logs,lhma_2019_04_30_10_36_45_946_event_logs,lhma_2019_06_18_13_31_49_199_event_logs"
+    path: "mysql/trimmed"
   # The push_whitehall_staging_daily job redacts the Staging Whitehall database
   # in-place before dumping it to S3. Integration then pulls the redacted copy.
   # The pull_whitehall_production_daily job then overwrites Staging with the

--- a/modules/govuk_env_sync/manifests/task.pp
+++ b/modules/govuk_env_sync/manifests/task.pp
@@ -55,6 +55,11 @@
 #   files/transformation_sql directory of the govuk_env_sync Puppet module.
 #   Default: ''
 #
+# [*excluded_tables*]
+#   Optional comma-delimited list of tables to be excluded from the backup (i.e. push)
+#   Only works for mysql for now.
+#   Default: ''
+#
 define govuk_env_sync::task(
   $hour,
   $minute,
@@ -68,6 +73,7 @@ define govuk_env_sync::task(
   $ensure = 'present',
   $transformation_sql_filename = '',
   $pre_dump_transformation_sql_filename = '',
+  $excluded_tables = '',
 ) {
   $general_ensure = $ensure ? {
     'disabled' => 'absent',

--- a/modules/govuk_env_sync/templates/govuk_env_sync_job.conf.erb
+++ b/modules/govuk_env_sync/templates/govuk_env_sync_job.conf.erb
@@ -11,3 +11,6 @@ transformation_sql_file="<%= scope['govuk_env_sync::conf_dir'] %>/transformation
 <% if pre_dump_transformation_sql_filename != '' %>
 pre_dump_transformation_sql_file="<%= scope['govuk_env_sync::conf_dir'] %>/transformation_sql/<%= @pre_dump_transformation_sql_filename %>"
 <% end %>
+<% if excluded_tables != '' %>
+excluded_tables="<%= @excluded_tables %>"
+<% end %>


### PR DESCRIPTION
add option to exclude dumping mysql tables in govuk_env_sync. We are testing on signon database because this is the use case candidate for this new feature.