### PR TITLE
remove signon hostname in /etc/hosts in staging carrenza

### DIFF
--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -288,7 +288,6 @@ hosts::production::backend::app_hostnames:
   - 'search-admin'
   - 'service-manual-publisher'
   - 'short-url-manager'
-  - 'signon'
   - 'specialist-publisher'
   - 'specialist-publisher-rebuild'
   - 'specialist-publisher-rebuild-standalone'


### PR DESCRIPTION
this is because signon has been migrated to AWS foir staging. We still want smokey to run in Carrenza because some Jenkins jobs trigger it upstream