### PR TITLE
Upgrade the node repo to 12.x

### DIFF
--- a/modules/govuk/manifests/node/s_apt.pp
+++ b/modules/govuk/manifests/node/s_apt.pp
@@ -79,7 +79,7 @@ class govuk::node::s_apt (
       release  => 'trusty',
       key      => 'ABF5BD827BD9BF62';
     'nodejs':
-      location => 'https://deb.nodesource.com/node_6.x',
+      location => 'https://deb.nodesource.com/node_12.x',
       release  => 'trusty',
       repos    => ['main'],
       key      => '68576280';


### PR DESCRIPTION
This is done to provide us with access to nodejs releases that are
current (our current release, 6, reached EOL in 2019). Previously we
blocked from upgrading node due to Statsd, however this was resolved by
the work in: https://github.com/alphagov/govuk-puppet/pull/9855 where
statsd was upgraded. Statsd is currently compatible with versions of
node up-to 14.

Nodesource, who provide this package, officially don't support trusty
anymore for Node versions > 8 (which reached end-of-life Jan 2020).
However they do continue to publish node packages and do state that
these may have compatibility issues. For us the impact of this is
essentially checking that using node 12 works for us. This shouldn't be
too hard because our only production code using node is statsd.

Obviously, this isn't an ideal situation. However from my tests on a
resurrected Dev VM. I was able to install Node 12 fine from trusty and
run node JS dependencies that require Node 10. It strikes me as better
to take the compatibility risk than it is is to let all our node tooling
rot.

This PR itself does not actually do the upgrade it just makes the repo
available so the package can be available. I'll plan to carefully
monitor the actual install process to try determine if there are
problems.