### PR TITLE
Upgrade to nodejs 12.28

### DIFF
--- a/hieradata/common.trusty.yaml
+++ b/hieradata/common.trusty.yaml
@@ -43,4 +43,4 @@ base::esm::esm_password: "%{hiera('base::esm::esm_trusty_password')}"
 
 govuk_ppa::repo_ensure: 'present'
 
-nodejs::version: '6.14.3-1nodesource1'
+nodejs::version: '12.18.2-1nodesource1'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1122,7 +1122,7 @@ nginx::package::nginx_version: "1.14.0-1~trusty"
 
 nodejs::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 nodejs::repo::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
-nodejs::version: '6.14.3-1nodesource1'
+nodejs::version: '12.18.2-1nodesource1'
 
 ntp::server_list:
   - 'ntp.ubuntu.com'

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1362,7 +1362,7 @@ nginx::package::nginx_version: "1.14.0-1~trusty"
 
 nodejs::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 nodejs::repo::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
-nodejs::version: '6.14.3-1nodesource1'
+nodejs::version: '12.18.2-1nodesource1'
 
 ntp::server_list:
   - 'ntp.ubuntu.com'


### PR DESCRIPTION
This shouldn't be merged until https://github.com/alphagov/govuk-puppet/pull/10512 is deployed to prod and some testing of this branch has occurred. I've marked it draft until then.

This brings us up to the current LTS version of Node, which will
hopefully buy us some time to sort out trusty so that it can be easier
to install future versions of Node.

From my testing node12 seems to work fine on our trusty machines,
despite lack of official support from nodesource. Because of this it
will be a delicate process deploying this to ensure it doesn't break
statsd.