### PR TITLE
Fix using default datasource on dashboard

### DIFF
--- a/modules/grafana/files/dashboards/email_alert_api_product.json
+++ b/modules/grafana/files/dashboards/email_alert_api_product.json
@@ -19,7 +19,7 @@
           "bars": true,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "Graphite",
           "fill": 1,
           "id": 3,
           "legend": {
@@ -117,7 +117,7 @@
           "bars": true,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "Graphite",
           "fill": 1,
           "id": 1,
           "legend": {
@@ -193,7 +193,7 @@
           "bars": true,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "Graphite",
           "fill": 1,
           "id": 2,
           "legend": {
@@ -383,5 +383,5 @@
   },
   "timezone": "browser",
   "title": "Email Alert API Product",
-  "version": 19
+  "version": 20
 }


### PR DESCRIPTION
https://trello.com/c/hTAPWQfE/360-chart-email-backlog-by-publishing-app-and-document-type-in-grafana

This causes unexpected behaviour in Integration, which doesn't have
a default datasource set. In general, we should not rely on the default.