### PR TITLE
Pin sentry-raven gem version to 2.13.0

### DIFF
--- a/modules/puppet/manifests/puppetserver/sentry.pp
+++ b/modules/puppet/manifests/puppetserver/sentry.pp
@@ -4,7 +4,7 @@
 # Sentry DSN in /etc/puppet/sentry.conf.
 #
 class puppet::puppetserver::sentry {
-  exec { '/usr/bin/puppetserver gem install sentry-raven':
+  exec { '/usr/bin/puppetserver gem install sentry-raven --version "= 2.13.0"':
     unless  => '/usr/bin/puppetserver gem list | /bin/grep sentry-raven',
   }
 

--- a/modules/puppet/spec/classes/puppet__puppetserver__sentry_spec.rb
+++ b/modules/puppet/spec/classes/puppet__puppetserver__sentry_spec.rb
@@ -12,7 +12,7 @@ describe 'puppet::puppetserver::sentry', :type => :class do
   Puppet.settings[:confdir] = '/etc/puppet'
 
   it do
-    is_expected.to contain_exec('/usr/bin/puppetserver gem install sentry-raven')
+	  is_expected.to contain_exec('/usr/bin/puppetserver gem install sentry-raven --version "= 2.13.0"')
     is_expected.to contain_file('/etc/puppet/sentry.conf').with_content('dsn=rspec dsn')
   end
 end


### PR DESCRIPTION
Last version of sentry-raven (3.0.0) has a dependency on faraday
(>= 1.0), faraday in turn as a dependency on ruby >= 2.3 which we
cannot fullfill on trusty.
This pins sentry-raven to the last version that can run on Trusty
with ruby >= 1.9