### PR TITLE
Pin psutil to version 5.4.7

### DIFF
--- a/modules/unicornherder/manifests/init.pp
+++ b/modules/unicornherder/manifests/init.pp
@@ -10,8 +10,13 @@
 class unicornherder (
       $version = 'present'
   ){
+  package { 'psutil':
+    ensure   => '5.4.7',
+    provider => 'pip',
+  }
   package { 'unicornherder':
     ensure   => $version,
     provider => 'pip',
+    require  => Package['psutil'],
   }
 }


### PR DESCRIPTION
psutil is installed through pip as a dependency of unicornherder.
However the last version of psutil doesn't install correctly with
the version of pip that we have on trusty.
This pins psutil to a version that install correctly on trusty.