### PR TITLE
Extend data sync end time and shift back Email Alert API db sync

### DIFF
--- a/hieradata_aws/class/integration/db_admin.yaml
+++ b/hieradata_aws/class/integration/db_admin.yaml
@@ -34,8 +34,8 @@ govuk_env_sync::tasks:
     path: "postgresql-backend"
   "pull_email_alert_api_production_daily":
     ensure: "present"
-    hour: "3"
-    minute: "10"
+    hour: "1"
+    minute: "30"
     action: "pull"
     dbms: "postgresql"
     storagebackend: "s3"

--- a/hieradata_aws/class/production/db_admin.yaml
+++ b/hieradata_aws/class/production/db_admin.yaml
@@ -111,8 +111,8 @@ govuk_env_sync::tasks:
     path: "postgresql-backend"
   "push_email_alert_api_production_daily":
     ensure: "present"
-    hour: "0"
-    minute: "15"
+    hour: "23"
+    minute: "00"
     action: "push"
     dbms: "postgresql"
     storagebackend: "s3"

--- a/hieradata_aws/class/staging/db_admin.yaml
+++ b/hieradata_aws/class/staging/db_admin.yaml
@@ -111,8 +111,8 @@ govuk_env_sync::tasks:
     path: "postgresql-backend"
   "pull_email_alert_api_production_daily":
     ensure: "present"
-    hour: "3"
-    minute: "10"
+    hour: "1"
+    minute: "30"
     action: "pull"
     dbms: "postgresql"
     storagebackend: "s3"

--- a/modules/govuk_data_sync_in_progress/manifests/init.pp
+++ b/modules/govuk_data_sync_in_progress/manifests/init.pp
@@ -20,8 +20,8 @@ define govuk_data_sync_in_progress(
   $start_hour = 22
   $start_minute = 0
 
-  $finish_hour = 5
-  $finish_minute = 45
+  $finish_hour = 8
+  $finish_minute = 00
 
   if !defined(File[$fact_path]) {
     file { $fact_path:

--- a/modules/monitoring/manifests/contacts.pp
+++ b/modules/monitoring/manifests/contacts.pp
@@ -56,7 +56,7 @@ class monitoring::contacts (
   $midnight_day_end = '24:00'
   # This should match up with the govuk_data_sync_in_progress class
   $data_sync_start = '22:00'
-  $data_sync_end = '05:45'
+  $data_sync_end = '08:00'
 
   $all_day = "${midnight_day_start}-${midnight_day_end}"
   $office_day = "${office_day_start}-${office_day_end}"


### PR DESCRIPTION
Trello: https://trello.com/c/koo6gJov/355-increase-visibility-of-sentry-alerts-for-email-apps-and-services

This extends the time we consider a GOV.UK data sync to be in progress until 8:00 am UTC. This is to reflect that currently the data sync can go on past 7:00 and in that time produce a lot of errors for Sentry. 

To provide further buffer room this also moves the Email Alert API data syncs forward so that they risk less intersection with the deadline. From my investigation in AWS it doesn't look like the DB sync causes a noticeable performance impact in production when it is sending emails into the evening. 

When merged I plan to amend the developer docs.