### PR TITLE
Bump yarn to version 1.22.4

### DIFF
--- a/modules/yarn/manifests/init.pp
+++ b/modules/yarn/manifests/init.pp
@@ -5,10 +5,10 @@
 # === Parameters:
 #
 # [*version*]
-#   Version to install. Defaults to 'present' which will install latest version
+#   Version to install. Defaults to '1.22.4-1'
 #
 class yarn(
-  $version = 'present',
+  $version = '1.22.4-1',
 ) {
 
   class { '::yarn::repo': }


### PR DESCRIPTION
The present keyword only installs the latest version when there isn't a
version already installed. This tells puppet to install the particular
latest version.

Installing this resolves a warning Yarn is raising since Node was
upgraded to version 12.