### PR TITLE
Add Generic Webhooks plugin for CI master Jenkins

### DIFF
--- a/hieradata/class/ci_master.yaml
+++ b/hieradata/class/ci_master.yaml
@@ -133,6 +133,8 @@ govuk_jenkins::plugins:
     version: '1.7'
   findbugs:
     version: '5.0.0'
+  generic-webhook-trigger:
+    version: '1.67'
   git-client:
     version: '2.7.7'
   git:


### PR DESCRIPTION
This plugin is needed to use trigger application deployments from GitHub Actions. We are in the process for moving continuous integration to GitHub Actions. A part of this requires triggering automatic deployments to successful build of the master branch. This plugin enables Jenkins to subscribe to incoming webhooks from successful GitHub Action builds and trigger the "Deploy_App_Downstream" job to deploy the application.