### PR TITLE
Stop keeping Icinga log archive forever

### DIFF
--- a/modules/icinga/manifests/config.pp
+++ b/modules/icinga/manifests/config.pp
@@ -57,15 +57,12 @@ class icinga::config (
   }
 
   if $::aws_migration {
-
-    file { '/var/lib/icinga/log':
-      ensure => directory,
-      owner  => 'nagios',
-      group  => 'adm',
-      mode   => '2755',
+    @logrotate::conf { 'icinga':
+      matches => '/var/log/icinga/*.log',
+      maxsize => '100M',
     }
 
-    file { '/var/lib/icinga/log/archives':
+    file { '/var/log/icinga':
       ensure => directory,
       owner  => 'nagios',
       group  => 'adm',

--- a/modules/icinga/templates/etc/icinga/icinga-aws.cfg.erb
+++ b/modules/icinga/templates/etc/icinga/icinga-aws.cfg.erb
@@ -11,7 +11,7 @@
 # for historical purposes.  This should be the first option specified 
 # in the config file!!!
 
-log_file=/var/lib/icinga/log/nagios.log
+log_file=/var/log/icinga/nagios.log
 
 # Commands definitions
 cfg_file=/etc/icinga/commands.cfg
@@ -260,7 +260,7 @@ event_broker_options=-1
 #	w	= Weekly rotation (midnight on Saturday evening)
 #	m	= Monthly rotation (midnight last day of month)
 
-log_rotation_method=d
+log_rotation_method=n
 
 
 
@@ -268,7 +268,7 @@ log_rotation_method=d
 # This is the directory where archived (rotated) log files should be 
 # placed (assuming you've chosen to do log rotation).
 
-log_archive_path=/var/lib/icinga/log/archives
+log_archive_path=/var/log/icinga
 
 
 


### PR DESCRIPTION
Previously we placed Icinga logs in an unintuitive place (/var/lib)
and relied on Icinga's inbuilt log rotation. Since Icinga's inbuilt
log rotation appears to keep archived logs forever, we were seeing
the monitoring machine disk filling up over time. This disables log
rotation within Icinga, and adds configuration to do it the same way
as all our other apps.