### PR TITLE
Remove unactionable high load alert

### DIFF
--- a/modules/icinga/manifests/client/checks.pp
+++ b/modules/icinga/manifests/client/checks.pp
@@ -87,13 +87,6 @@ class icinga::client::checks (
     $grafana = "grafana.${app_domain}"
   }
 
-  @@icinga::check { "check_load_${::hostname}":
-    check_command       => 'check_nrpe_1arg!check_load',
-    service_description => 'high load on',
-    host_name           => $::fqdn,
-    action_url          => "https://${grafana}/dashboard/file/machine.json?refresh=1m&orgId=1&var-hostname=${::fqdn_metrics}",
-  }
-
   if $::aws_migration {
     @icinga::nrpe_config { 'check_ssh_local':
       source => 'puppet:///modules/icinga/etc/nagios/nrpe.d/check_ssh_local.cfg',


### PR DESCRIPTION
This alert does not signify a definite problem: it's OK for a machine
to be under high load for a period of time, if that happens to be when
we have a lot of work to do. If high load really is a problem, it should
manifest in other, objective alerts. This removes the alert, on the
basis that this data is already available in our monitoring dashboards.