### PR TITLE
Remove redundant "check_load" plugin

### DIFF
--- a/modules/icinga/files/etc/nagios/nrpe.d/check_load.cfg
+++ b/modules/icinga/files/etc/nagios/nrpe.d/check_load.cfg
@@ -1,1 +1,0 @@
-command[check_load]=/usr/lib/nagios/plugins/check_load -r -w 3,2.5,2 -c 5,4,3


### PR DESCRIPTION
https://trello.com/c/Hat5jKK3/931-remove-the-high-load-on-alert

This got missed as part of: https://github.com/alphagov/govuk-puppet/pull/10527