### PR TITLE
Stop panicking about short CDN blips

### DIFF
--- a/modules/monitoring/manifests/edge.pp
+++ b/modules/monitoring/manifests/edge.pp
@@ -14,7 +14,7 @@ class monitoring::edge (
 
   if $enabled {
     icinga::check::graphite { "fastly_5xx_rate_on_${::hostname}":
-      target    => "${::fqdn_metrics}.cdn_fastly-govuk.requests-status_5xx",
+      target    => movingMedian("${::fqdn_metrics}.cdn_fastly-govuk.requests-status_5xx", '5min'),
       desc      => 'Fastly error rate for GOV.UK',
       warning   => 0.05,
       critical  => 0.1,


### PR DESCRIPTION
Previously we alerted for a short-lived spike in CDN 5xx rates,
which is unactionable. This smoothes out the spikes to avoid alerting
when there is no action to take.