### PR TITLE
Add slack notification for deploy downstream failure

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/deploy_app_downstream.pp
+++ b/modules/govuk_jenkins/manifests/jobs/deploy_app_downstream.pp
@@ -30,7 +30,13 @@ class govuk_jenkins::jobs::deploy_app_downstream (
   $github_api_token = undef,
   $smokey_pre_check = true,
   $release_app_bearer_token = undef,
+  $slack_channel = '#govuk-developers',
+  $slack_credential_id = 'slack-notification-token',
+  $slack_team_domain = 'gds',
+  $app_domain = hiera('app_domain')
 ) {
+  $slack_build_server_url = "https://deploy.${app_domain}/"
+
   file { '/etc/jenkins_jobs/jobs/deploy_app_downstream.yaml':
     ensure  => present,
     content => template('govuk_jenkins/jobs/deploy_app_downstream.yaml.erb'),

--- a/modules/govuk_jenkins/templates/jobs/deploy_app_downstream.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_app_downstream.yaml.erb
@@ -91,3 +91,12 @@
         - description-setter:
             regexp: ""
             description: "$TARGET_APPLICATION $TAG"
+        - slack:
+            team-domain: <%= @slack_team_domain %>
+            auth-token-id: <%= @slack_credential_id %>
+            auth-token-credential-id: <%= @slack_credential_id %>
+            build-server-url: <%= @slack_build_server_url %>
+            notify-failure: true
+            room: <%= @slack_channel %>
+            include-custom-message: true
+            custom-message: "Automatic deployment failed for $TARGET_APPLICATION $TAG"


### PR DESCRIPTION
Currently we are not notified if the automatic deployment job "Deploy App Downstream" fails. This change we make Jenkins send a slack message to the #govuk-developers group on first failure.