### PR TITLE
Remove unactionable Sidekiq queue size checks

### DIFF
--- a/modules/govuk/manifests/apps/email_alert_api/checks.pp
+++ b/modules/govuk/manifests/apps/email_alert_api/checks.pp
@@ -14,26 +14,18 @@ class govuk::apps::email_alert_api::checks(
       'email_generation_digest',
       'cleanup',
     ]:
-      size_warning     => '75000',
-      size_critical    => '100000',
       latency_warning  => '300', # 5 minutes
       latency_critical => '600'; # 10 minutes
 
     'delivery_immediate':
-      size_warning     => '150000',
-      size_critical    => '500000',
       latency_warning  => '1200', # 20 minutes
       latency_critical => '1800'; # 30 minutes
 
     'delivery_immediate_high':
-      size_warning     => '75000',
-      size_critical    => '100000',
       latency_warning  => '300', # 5 minutes
       latency_critical => '600'; # 10 minutes
 
     'delivery_digest':
-      size_warning     => '75000',
-      size_critical    => '100000',
       latency_warning  => '3600', # 60 minutes
       latency_critical => '5400'; # 90 minutes
   }

--- a/modules/govuk/manifests/apps/email_alert_api/sidekiq_queue_check.pp
+++ b/modules/govuk/manifests/apps/email_alert_api/sidekiq_queue_check.pp
@@ -12,12 +12,6 @@
 # [*title*]
 #   The name of the sidekiq queue to check.
 #
-# [*size_warning*]
-#   The number of messages on a queue to trigger a warning.
-#
-# [*size_critical*]
-#   The number of messages on a queue to trigger a critical alert.
-#
 # [*latency_warning*]
 #   The warning threshold for a sidekiq queue in minutes.
 #
@@ -25,23 +19,9 @@
 #   The critical threshold for a sidekiq queue in minutes.
 #
 define govuk::apps::email_alert_api::sidekiq_queue_check(
-  $size_warning,
-  $size_critical,
   $latency_warning,
   $latency_critical,
 ) {
-  icinga::check::graphite { "check_email_alert_api_${title}_queue_size":
-    target    => "transformNull(averageSeries(keepLastValue(stats.gauges.govuk.app.email-alert-api.*.workers.queues.${title}.enqueued)), 0)",
-    from      => '24hours',
-    # Take an average over the most recent 36 datapoints, which at 5
-    # seconds per datapoint is the last 3 minutes
-    args      => '--dropfirst -36',
-    warning   => $size_warning,
-    critical  => $size_critical,
-    desc      => "email-alert-api: high number of messages on ${title} sidekiq queue",
-    host_name => $::fqdn,
-    notes_url => monitoring_docs_url(email-alert-api-high-queue-size),
-  }
   icinga::check::graphite { "check_email_alert_api_${title}_queue_latency":
     target    => "transformNull(averageSeries(keepLastValue(stats.gauges.govuk.app.email-alert-api.*.workers.queues.${title}.latency)), 0)",
     from      => '15minutes',


### PR DESCRIPTION
https://trello.com/c/imXE6RlT/936-stop-alerting-for-email-queue-size

Related to: https://github.com/alphagov/govuk-developer-docs/pull/2672

Previously we would alert on the size of the Sidekiq queues, which
was a unique alert for Email Alert API. Since the size of the queue
simply represents the amount of work to do, it cannot be used to
detect a problem - latency is the critical metric here. This removes
all the alerts for the size of Sidekiq queues, which we can still
monitor with our existing Grafana dashboards.