### PR TITLE
Increase unicorn restart alert delay to 5 mins

### DIFF
--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -485,7 +485,7 @@ define govuk::app::config (
       service_description      => "${title} does not have the expected number of unicorn workers",
       host_name                => $::fqdn,
       contact_groups           => $additional_check_contact_groups,
-      first_notification_delay => 2,
+      first_notification_delay => 5,
     }
     include icinga::client::check_unicorn_ruby_version
     @@icinga::check { "check_app_${title}_unicorn_ruby_version_${::hostname}":


### PR DESCRIPTION
https://trello.com/c/7oUAIh0I/580-app-does-not-have-the-expected-number-of-unicorn-workers

Previously we added a 2 minute delay for this alert, since it takes
some time for a restart to complete. It turns out the delay has not
been very effective, since the restart time for some apps can exceed
2 minutes. We only want this alert to appear when there is definitely
a problem. This increases the alert delay to 5 minutes, after which
time we expect any app to have finished restarting.

Icinga docs: https://assets.nagios.com/downloads/nagioscore/docs/nagioscore/3/en/objectdefinitions.html

## Example of restart taking longer than 2 minutes

<img width="788" alt="Screenshot 2020-07-23 at 16 53 24" src="https://user-images.githubusercontent.com/9029009/88308550-117a9c00-cd05-11ea-971b-12d57f5d1180.png">
