### PR TITLE
Fix not alerting about security updates

### DIFF
--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_apt_security_updates
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_apt_security_updates
@@ -79,15 +79,15 @@ and a critical at the second number of updates
 def main():
     try:
         if len(sys.argv) >= 3:
-            warning = sys.argv[2]
-            critical = sys.argv[1]
+            warning = int(sys.argv[2])
+            critical = int(sys.argv[1])
         elif len(sys.argv) == 2:
             if sys.argv[1] == "-h":
                 print usage_message
                 sys.exit(0)
             else:
-                warning = sys.argv[1]
-                critical = sys.argv[1]
+                warning = int(sys.argv[1])
+                critical = int(sys.argv[1])
         else:
             warning = 0
             critical = 0


### PR DESCRIPTION
https://trello.com/c/5JpkmLwB/940-fix-not-alerting-about-outstanding-security-updates

Previously we were passing "0 0" to the command line, with each "0"
having type "string", which we were then comparing with an integer.
This fixes the argument parsing so that the warning/critical '>='
comparison works.