### PR TITLE
Auto-retry search analytics job in 1 hour

### DIFF
--- a/hieradata/class/ci_master.yaml
+++ b/hieradata/class/ci_master.yaml
@@ -201,6 +201,8 @@ govuk_jenkins::plugins:
     version: '1.1.1'
   monitoring:
     version: '1.77.0'
+  naginator:
+    version: '1.18'
   next-build-number:
     version: '1.5'
   nodelabelparameter:

--- a/modules/govuk_jenkins/templates/jobs/search_fetch_analytics_data.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/search_fetch_analytics_data.yaml.erb
@@ -37,6 +37,9 @@
     triggers:
         - timed: '<%= @cron_schedule %>'
     publishers:
+        - naginator:
+            fixed-delay: 3600
+            max-failed-builds: 1
         - trigger-parameterized-builds:
             - project: Success_Passive_Check
               condition: 'SUCCESS'


### PR DESCRIPTION
https://trello.com/c/JCtcwfp5/942-auto-retry-search-analytics-job-so-2ndline-doesnt-do-it-manually

This adds the 'naginator' plugin so we can automatically retry a
failed build of the search-api-fetch-analytics-data job, which
can fail due to transient conditions, and currently requires
manually intervention by 2ndline to fix.

Docs reference: https://docs.openstack.org/infra/jenkins-job-builder/publishers.html#publishers

Example:

Traceback (most recent call last):
  File "/govuk-search-analytics/analytics_fetcher/support/ga_client.py", line 99, in _fetch_from_ga
    resp = self.oauth_client().query.get_raw_response(
  File "/govuk-search-analytics/gapy/client.py", line 235, in get_raw_response
    return self._service.data().ga().get(**kwargs).execute()
  File "/usr/local/lib/python3.8/site-packages/oauth2client/util.py", line 140, in positional_wrapper
    return wrapped(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/googleapiclient/http.py", line 729, in execute
    raise HttpError(resp, content, uri=self.uri)
googleapiclient.errors.HttpError: <HttpError 503 when requesting https://www.googleapis.com/analytics/v3/data/ga?start-index=100001&ids=ga%3A56562468&start-date=2020-07-20&end-date=2020-07-20&samplingLevel=HIGHER_PRECISION&max-results=10000&metrics=ga%3AuniquePageViews&dimensions=ga%3ApagePath%2Cga%3ApageTitle&sort=-ga%3AuniquePageViews&alt=json returned "There was a temporary error. Please try again later.">