### PR TITLE
Switch ckan integration to govuk_solr6

### DIFF
--- a/hieradata_aws/class/ckan.yaml
+++ b/hieradata_aws/class/ckan.yaml
@@ -5,3 +5,5 @@ govuk::apps::ckan::priority_worker_processes: '1'
 govuk::apps::ckan::bulk_worker_processes: '4'
 govuk::apps::ckan::enable_harvester_fetch: true
 govuk::apps::ckan::enable_harvester_gather: true
+
+govuk_solr6::present: false

--- a/hieradata_aws/class/integration/ckan.yaml
+++ b/hieradata_aws/class/integration/ckan.yaml
@@ -1,0 +1,7 @@
+---
+
+govuk_solr::disable: true
+govuk_solr6::present: true
+
+govuk::apps::ckan::solr_core: ckan
+govuk::apps::ckan::solr_core_configset: ckan28

--- a/modules/govuk/manifests/apps/ckan.pp
+++ b/modules/govuk/manifests/apps/ckan.pp
@@ -29,6 +29,20 @@
 # [*redis_port*]
 #   The Redis port that CKAN should use
 #
+# [*solr_host*]
+#   The Solr host that CKAN should use
+#
+# [*solr_port*]
+#   The Solr port that CKAN should use
+#
+# [*solr_core*]
+#   The Solr core that CKAN should use. This will be provisioned if it doesn't
+#   already exist, and if left undef, ckan will expect to use a single-core
+#   Solr.
+#
+# [*solr_core_configset*]
+#   The configset name to use when provisioning $solr_core
+#
 # [*secret*]
 #   The secret token that CKAN uses for session encryption
 #
@@ -49,6 +63,10 @@ class govuk::apps::ckan (
   $db_name                        = 'ckan_production',
   $redis_host                     = undef,
   $redis_port                     = '6379',
+  $solr_host                      = '127.0.0.1',
+  $solr_port                      = '8983',
+  $solr_core                      = undef,
+  $solr_core_configset            = undef,
   $secret                         = undef,
   $ckan_site_url                  = undef,
   $gunicorn_worker_processes      = '1',
@@ -222,6 +240,14 @@ class govuk::apps::ckan (
     exec { 'setup_pycsw_tables':
       command => "${ckan_bin}/paster --plugin=ckanext-spatial ckan-pycsw setup -p ${pycsw_config} && sudo touch ${pycsw_tables_created}",
       creates => $pycsw_tables_created,
+    }
+
+    if ($solr_core != undef) {
+      govuk_solr6::core { $solr_core:
+        solr_host => $solr_host,
+        solr_port => $solr_port,
+        configset => $solr_core_configset,
+      }
     }
   }
 }

--- a/modules/govuk/manifests/node/s_ckan.pp
+++ b/modules/govuk/manifests/node/s_ckan.pp
@@ -21,7 +21,12 @@ class govuk::node::s_ckan inherits govuk::node::s_base {
   include govuk_python
   include nginx
   include postgresql::lib::devel
-  include govuk_java::openjdk7::jdk
+  include govuk_java::openjdk8::jre
+  include govuk_java::openjdk8::jdk
+  class { 'govuk_java::set_defaults':
+    jdk => 'openjdk8',
+    jre => 'openjdk8',
+  }
   include govuk_solr
 
   package { 'libgeos-c1':

--- a/modules/govuk/manifests/node/s_ckan.pp
+++ b/modules/govuk/manifests/node/s_ckan.pp
@@ -28,6 +28,7 @@ class govuk::node::s_ckan inherits govuk::node::s_base {
     jre => 'openjdk8',
   }
   include govuk_solr
+  include govuk_solr6
 
   package { 'libgeos-c1':
     ensure => latest,

--- a/modules/govuk/templates/ckan/ckan.ini.erb
+++ b/modules/govuk/templates/ckan/ckan.ini.erb
@@ -74,7 +74,7 @@ ckan.google_analytics_tracking_id = nil
 ## Search Settings
 
 ckan.site_id = dgu
-solr_url = http://127.0.0.1:8983/solr
+solr_url = <%= "http://#{@solr_host}:#{@solr_port}/solr" %><%= @solr_core == nil ? "" : "/#{@solr_core}" %>
 
 ## CORS Settings
 


### PR DESCRIPTION
https://trello.com/c/OxoHouSW

This:
 - gives the `ckan` app the ability to work with multicore solr and provision a solr core in such cases.
 - adds the `govuk_solr6` module to `s_ckan` instance classes, though doesn't _enable_ it by default.
 - goes on to enable `govuk_solr6` and disable `govuk_solr` for the integration `ckan`.

This needs to be released hand-in-hand with an app release of the `ckanext-datagovuk` `master-2.8` branch, because the 2.7 branch hasn't been patched to work with multicore solr.