### PR TITLE
Fix setting slack channel for CD failure notification

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_app_downstream.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_app_downstream.yaml.erb
@@ -97,6 +97,6 @@
             auth-token-credential-id: <%= @slack_credential_id %>
             build-server-url: <%= @slack_build_server_url %>
             notify-failure: true
-            room: <%= @slack_channel %>
+            room: "<%= @slack_channel %>"
             include-custom-message: true
             custom-message: "Automatic deployment failed for $TARGET_APPLICATION $TAG"


### PR DESCRIPTION
The slack channel was being interpreted as a comment because it begins with `#` character. Quoting explicits sets the value as a string.