### PR TITLE
Remove unactionable 429 alerts

### DIFF
--- a/modules/govuk/manifests/node/s_backend_lb.pp
+++ b/modules/govuk/manifests/node/s_backend_lb.pp
@@ -139,19 +139,6 @@ class govuk::node::s_backend_lb (
         logstream => present;
     }
 
-    $graphite_429_target = "transformNull(stats.${::fqdn_metrics}.nginx_logs.assets-carrenza.http_429,0)"
-
-    @@icinga::check::graphite { "check_nginx_429_assets_on_${::hostname}":
-      target              => $graphite_429_target,
-      args                => '--ignore-missing',
-      warning             => 3,
-      critical            => 5,
-      from                => '5minutes',
-      desc                => '429 rate for assets-carrenza [in office hours]',
-      host_name           => $::fqdn,
-      notes_url           => monitoring_docs_url(nginx-429-too-many-requests),
-      notification_period => 'inoffice',
-    }
     # Custom vhost to proxy draft-assets-origin to asset-manager and whitehall in Carrenza
     nginx::config::site { $draft_assets_carrenza_vhost_name:
       content => template('govuk/node/s_backend_lb/draft-assets-carrenza.conf.erb'),

--- a/modules/router/manifests/assets_origin.pp
+++ b/modules/router/manifests/assets_origin.pp
@@ -56,18 +56,4 @@ class router::assets_origin(
     "${vhost_name}-error.log":
       logstream => present;
   }
-
-  $graphite_429_target = "transformNull(stats.${::fqdn_metrics}.nginx_logs.assets-origin.http_429,0)"
-
-  @@icinga::check::graphite { "check_nginx_429_assets_on_${::hostname}":
-    target              => $graphite_429_target,
-    args                => '--ignore-missing',
-    warning             => 3,
-    critical            => 5,
-    from                => '5minutes',
-    desc                => '429 rate for assets-origin [in office hours]',
-    host_name           => $::fqdn,
-    notes_url           => monitoring_docs_url(nginx-429-too-many-requests),
-    notification_period => 'inoffice',
-  }
 }

--- a/modules/router/manifests/nginx.pp
+++ b/modules/router/manifests/nginx.pp
@@ -173,18 +173,4 @@ class router::nginx (
     notes_url           => monitoring_docs_url(nginx-requests-too-low),
     notification_period => 'inoffice',
   }
-
-  $graphite_429_target = "transformNull(stats.${::fqdn_metrics}.nginx_logs.www-origin.http_429,0)"
-
-  @@icinga::check::graphite { "check_nginx_429_www_on_${::hostname}":
-    target              => $graphite_429_target,
-    args                => '--ignore-missing',
-    warning             => 3,
-    critical            => 5,
-    from                => '5minutes',
-    desc                => '429 rate for www-origin [in office hours]',
-    host_name           => $::fqdn,
-    notes_url           => monitoring_docs_url(nginx-429-too-many-requests),
-    notification_period => 'inoffice',
-  }
 }


### PR DESCRIPTION
https://trello.com/c/0KX2kT9o/950-remove-unactionable-429-alerts

Rate limiting is an intentional feature of GOV.UK. We do not need
to alert when the feature is being used, which is all the docs say.

This was appearing on Integration.