### PR TITLE
Wait before alerting about high memory

### DIFF
--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -346,7 +346,7 @@ define govuk::app::config (
     }
     @@icinga::check::graphite { "check_${title}_app_mem_usage${::hostname}":
       ensure                     => $ensure,
-      target                     => "${::fqdn_metrics}.processes-app-${title_underscore}.ps_rss",
+      target                     => "movingMedian(${::fqdn_metrics}.processes-app-${title_underscore}.ps_rss,\"5min\")",
       warning                    => $nagios_memory_warning_real,
       critical                   => $nagios_memory_critical_real,
       desc                       => "high memory for ${title} app",


### PR DESCRIPTION
https://trello.com/b/M7UzqXpk/govuk-2nd-line

The event handler of this check should automatically fix it, so we
only need to see the alert if it's be unable to do so.