### PR TITLE
Complete Staging sync after it's actually finished

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/data_sync_complete_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/data_sync_complete_staging.yaml.erb
@@ -13,7 +13,7 @@
     triggers:
       - timed: |
           TZ=Europe/London
-          30 3 * * *
+          H 7 * * 1-5
     <%- end %>
     properties:
       - build-discarder:


### PR DESCRIPTION
https://trello.com/c/EtiHksj2/952-fix-whitehall-healthcheck-alerts-on-staging-due-to-scheduled-docs

Related to: 367c6fb5d684c228ca7bcb96a8a45397d58c48a4

Previously we were seeing warnings in Staging about scheduled docs
not being published, which are fixed by simply running this job
manually. This changes the trigger time so that the job runs when
the synced data to 'complete' is more likely to be present.