### PR TITLE
Change feedback notify api key

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -224,6 +224,7 @@ task :check_consistency_between_aws_and_carrenza do
     govuk::apps::email_alert_service::rabbitmq::queue_size_warning_threshold
     govuk::apps::email_alert_service::rabbitmq_hosts
     govuk::apps::email_alert_service::redis_host
+    govuk::apps::feedback::govuk_notify_template_id
     govuk::apps::finder_frontend::enabled
     govuk::apps::finder_frontend::nagios_memory_critical
     govuk::apps::finder_frontend::nagios_memory_warning

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -38,6 +38,7 @@ govuk::apps::email_alert_api::email_address_override: 'success@simulator.amazons
 govuk::apps::email_alert_api::email_address_override_whitelist_only: true
 govuk::apps::email_alert_api::delivery_request_threshold: "3000"
 govuk::apps::email_alert_frontend::subscription_management_enabled: true
+govuk::apps::feedback::govuk_notify_template_id: 'eb9ba220-7d74-4aab-975a-bdbe718f69a3'
 govuk::apps::frontend::govuk_notify_template_id: '1fc69d3a-09a2-40f9-852b-03f6fcef5340'
 govuk::apps::govuk_crawler_worker::enabled: false
 govuk::apps::govuk_crawler_worker::disable_during_data_sync: true

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -188,6 +188,7 @@ govuk::apps::email_alert_api::email_archive_s3_bucket: 'govuk-production-email-a
 # This shouldn't be enabled at the same time we have carrenza s3 export enabled unless they have separate buckets
 govuk::apps::email_alert_api::email_archive_s3_enabled: true
 govuk::apps::email_alert_api::govuk_notify_template_id: 'cb633abc-6ae6-4843-ae6f-82ca500b6de2'
+govuk::apps::feedback::govuk_notify_template_id: '54168fa9-3946-4860-a2f8-27ddbb14babe'
 govuk::apps::frontend::govuk_notify_template_id: 'cb633abc-6ae6-4843-ae6f-82ca500b6de2'
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::licencefinder::elasticsearch_uri: 'https://vpc-blue-elasticsearch6-domain-2hnib7uydv3tgebhabx74gdelq.eu-west-1.es.amazonaws.com'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -169,6 +169,7 @@ govuk::apps::email_alert_api::email_address_override: 'success@simulator.amazons
 govuk::apps::email_alert_api::email_address_override_whitelist_only: true
 govuk::apps::email_alert_api::delivery_request_threshold: "3000"
 govuk::apps::email_alert_frontend::subscription_management_enabled: true
+govuk::apps::feedback::govuk_notify_template_id: '8a8d98c0-42c8-4f56-b61f-77c89417a171'
 govuk::apps::frontend::govuk_notify_template_id: '2844a647-6bf1-4b01-a25c-569d2cc00849'
 govuk::apps::govuk_crawler_worker::disable_during_data_sync: true
 govuk::apps::hmrc_manuals_api::publish_topics: false

--- a/modules/govuk/manifests/apps/feedback.pp
+++ b/modules/govuk/manifests/apps/feedback.pp
@@ -20,7 +20,7 @@
 # [*support_api_bearer_token*]
 #   The bearer token to allow this app to submit anonymous feedback to the Support API.
 #
-# [*survey_notify_service_api_key*]
+# [*govuk_notify_api_key*]
 #   The API key to allow this app to talk to GOV.UK Notify and send emails
 #   to people who want to sign up to take a survey
 #
@@ -35,6 +35,7 @@ class govuk::apps::feedback(
   $google_client_email = undef,
   $google_private_key = undef,
   $survey_notify_service_api_key = undef,
+  $govuk_notify_api_key = undef,
 ) {
   $app_name = 'feedback'
 
@@ -103,6 +104,13 @@ class govuk::apps::feedback(
     govuk::app::envvar { "${title}-SURVEY_NOTIFY_SERVICE_API_KEY":
       varname => 'SURVEY_NOTIFY_SERVICE_API_KEY',
       value   => $survey_notify_service_api_key,
+    }
+  }
+
+  if $govuk_notify_api_key != undef {
+    govuk::app::envvar { "${title}-GOVUK_NOTIFY_API_KEY":
+      varname => 'GOVUK_NOTIFY_API_KEY',
+      value   => $govuk_notify_api_key,
     }
   }
 }

--- a/modules/govuk/manifests/apps/feedback.pp
+++ b/modules/govuk/manifests/apps/feedback.pp
@@ -24,6 +24,9 @@
 #   The API key to allow this app to talk to GOV.UK Notify and send emails
 #   to people who want to sign up to take a survey
 #
+# [*govuk_notify_template_id*]
+#   Template ID for GOV.UK Notify
+#
 class govuk::apps::feedback(
   $port,
   $sentry_dsn = undef,
@@ -36,6 +39,7 @@ class govuk::apps::feedback(
   $google_private_key = undef,
   $survey_notify_service_api_key = undef,
   $govuk_notify_api_key = undef,
+  $govuk_notify_template_id = undef,
 ) {
   $app_name = 'feedback'
 
@@ -111,6 +115,13 @@ class govuk::apps::feedback(
     govuk::app::envvar { "${title}-GOVUK_NOTIFY_API_KEY":
       varname => 'GOVUK_NOTIFY_API_KEY',
       value   => $govuk_notify_api_key,
+    }
+  }
+
+  if $govuk_notify_template_id != undef {
+    govuk::app::envvar { "${title}-GOVUK_NOTIFY_TEMPLATE_ID":
+        varname => 'GOVUK_NOTIFY_TEMPLATE_ID',
+        value   => $govuk_notify_template_id,
     }
   }
 }


### PR DESCRIPTION
The Feedback application sends e-mails to users who sign up to GOV.UK surveys via Notify.

We are changing the Notify service. 

As part of this we are changing the variable name for the Notify API key to be in line with other applications.

As the previous implementation had only one service across environments the email template ID was hard-coded into the Feedback application. The new implementation has a distinct service for each environment, so the email template ID is added as an environment variable.

When this change has been deployed, a subsequent PR will remove the old value of `survey_notify_service_api_key`.

[trello](https://trello.com/c/zs2mHfAM/2061-3-feedback-app-uses-its-own-notify-account)