### PR TITLE
Only raise 'active keys' warning if keys are active

### DIFF
--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_iam_key_age
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_iam_key_age
@@ -86,7 +86,7 @@ begin
     iam.list_access_keys(user_name: user.user_name).access_key_metadata.each do |key|
       age = (Date.today - key.create_date.to_date).to_i
       puts "#{key.access_key_id}: #{key.create_date.to_date}" if options[:debug]
-      if age >= options[:days]
+      if age >= options[:days] && key.status == "Active"
         failed_keys << "#{user.user_name} (#{age} days)"
       end
     end


### PR DESCRIPTION
Currently we raise a warning for all keys older than 90 days.
However, we haven't been checking if keys are actually active;
old keys aren't an issue if they're inactive.

We often inactivate a key while checking if the newly
created key is being used correctly. It would be nice if the
alert didn't continue while we're in that middle state (which can
last for several days).