### PR TITLE
govuk_solr6: add (multi-valued) `harvest` field to ckan28 schema

### DIFF
--- a/modules/govuk_solr6/files/ckan28.schema.xml
+++ b/modules/govuk_solr6/files/ckan28.schema.xml
@@ -138,6 +138,8 @@ schema. In this case the version should be set to the next CKAN version number.
     <field name="resources_accessed_total" type="int" indexed="true" stored="false"/>
     <field name="resources_accessed_recent" type="int" indexed="true" stored="false"/>
 
+    <field name="harvest" type="text" indexed="true" stored="true" multiValued="true"/>
+
     <field name="metadata_created" type="date" indexed="true" stored="true" multiValued="false"/>
     <field name="metadata_modified" type="date" indexed="true" stored="true" multiValued="false"/>
 


### PR DESCRIPTION
https://trello.com/c/OxoHouSW

The exact origins of the requirement for this are unclear, but this mirrors what was previously done in https://github.com/alphagov/datagovuk_ckan_deployment/pull/63. Without this, our current database fails to be reindexed as we have many packages with apparently multi-valued `harvest` fields.

My guess is this is related to https://github.com/ckan/ckanext-harvest/issues/91 (whose ultimate solution, https://github.com/ckan/ckanext-spatial/pull/58 seems to be to squash the multiple values into a single string) and somewhere along the line we picked up a bunch of non-compliant data which we never migrated to this squashed form. Could the answer be to just squash all of these multi-valued `harvest` entries down to strings? Don't know, but this isn't the time to do that investigation.

This new schema will, of course, only be applied to newly created cores.