### PR TITLE
Remove enable_email_alerts setting

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -66,7 +66,6 @@ govuk::apps::specialist_publisher::aws_region: 'eu-west-1'
 govuk::apps::specialist_publisher::aws_s3_bucket_name: 'govuk-production-specialist-publisher-csvs'
 govuk::apps::specialist_publisher::enabled: false
 govuk::apps::specialist_publisher::govuk_notify_template_id: "e00e89f5-b622-4dcb-8f30-e6c70231a940"
-govuk::apps::travel_advice_publisher::enable_email_alerts: false
 govuk::apps::travel_advice_publisher::enable_procfile_worker: false
 govuk::apps::whitehall::govuk_notify_template_id: "e00e89f5-b622-4dcb-8f30-e6c70231a940"
 

--- a/hieradata/staging.yaml
+++ b/hieradata/staging.yaml
@@ -46,7 +46,6 @@ govuk::apps::specialist_publisher::aws_s3_bucket_name: 'govuk-staging-specialist
 govuk::apps::specialist_publisher::enabled: false
 govuk::apps::specialist_publisher::govuk_notify_template_id: "112842bb-d8a4-4511-90de-57dc5c8f27ec"
 govuk::apps::static::ga_universal_id: 'UA-26179049-20'
-govuk::apps::travel_advice_publisher::enable_email_alerts: false
 govuk::apps::travel_advice_publisher::enable_procfile_worker: false
 govuk::apps::whitehall::govuk_notify_template_id: "112842bb-d8a4-4511-90de-57dc5c8f27ec"
 

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -76,7 +76,6 @@ govuk::apps::static::ga_universal_id: 'UA-26179049-22'
 govuk::apps::support::aws_s3_bucket_name: 'govuk-integration-support-api-csvs'
 govuk::apps::support_api::aws_s3_bucket_name: 'govuk-integration-support-api-csvs'
 govuk::apps::support_api::govuk_notify_template_id: "759acac6-da53-4a19-b591-b7538c7c39de"
-govuk::apps::travel_advice_publisher::enable_email_alerts: true
 govuk::apps::travel_advice_publisher::show_historical_edition_link: true
 govuk::apps::url_arbiter::db::backend_ip_range: '10.1.3.0/24'
 govuk::apps::whitehall::basic_auth_credentials: "%{hiera('http_username')}:%{hiera('http_password')}"

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -230,7 +230,6 @@ govuk::apps::support_api::zendesk_anonymous_ticket_email: 'zd-api-public@digital
 govuk::apps::support_api::pp_data_url: 'https://www.performance.service.gov.uk'
 govuk::apps::support_api::aws_s3_bucket_name: 'govuk-production-support-api-csvs'
 govuk::apps::support_api::govuk_notify_template_id: "e00e89f5-b622-4dcb-8f30-e6c70231a940"
-govuk::apps::travel_advice_publisher::enable_email_alerts: true
 govuk::apps::travel_advice_publisher::enable_procfile_worker: true
 govuk::apps::whitehall::govuk_notify_template_id: "e00e89f5-b622-4dcb-8f30-e6c70231a940"
 govuk::apps::whitehall::aws_s3_bucket_name: 'govuk-production-whitehall-csvs'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -218,7 +218,6 @@ govuk::apps::support::aws_s3_bucket_name: 'govuk-staging-support-api-csvs'
 govuk::apps::support_api::pp_data_url: 'https://www.staging.performance.service.gov.uk'
 govuk::apps::support_api::aws_s3_bucket_name: 'govuk-staging-support-api-csvs'
 govuk::apps::support_api::govuk_notify_template_id: "112842bb-d8a4-4511-90de-57dc5c8f27ec"
-govuk::apps::travel_advice_publisher::enable_email_alerts: true
 govuk::apps::travel_advice_publisher::enable_procfile_worker: true
 govuk::apps::travel_advice_publisher::mongodb_nodes: "%{hiera('govuk::apps::asset_manager::mongodb_nodes')}"
 govuk::apps::travel_advice_publisher::mongodb_username: "%{hiera('govuk::apps::asset_manager::mongodb_username')}"

--- a/modules/govuk/manifests/apps/travel_advice_publisher.pp
+++ b/modules/govuk/manifests/apps/travel_advice_publisher.pp
@@ -11,10 +11,6 @@
 #   The bearer token to use when communicating with Asset Manager.
 #   Default: undef
 #
-# [*enable_email_alerts*]
-#   Send email alerts via the email-alert-api
-#   Default: false
-#
 # [*enable_procfile_worker*]
 #   Enables the sidekiq background worker.
 #   Default: true
@@ -77,7 +73,6 @@
 class govuk::apps::travel_advice_publisher(
   $ensure = 'present',
   $asset_manager_bearer_token = undef,
-  $enable_email_alerts = false,
   $enable_procfile_worker = true,
   $sentry_dsn = undef,
   $mongodb_name = undef,
@@ -118,15 +113,6 @@ class govuk::apps::travel_advice_publisher(
     govuk::app::envvar {
       "${title}-SHOW_HISTORICAL_EDITION_LINK":
         varname => 'SHOW_HISTORICAL_EDITION_LINK',
-        value   => '1';
-    }
-  }
-
-  validate_bool($enable_email_alerts)
-  if ($enable_email_alerts) {
-    govuk::app::envvar {
-      "${title}-SEND_EMAIL_ALERTS":
-        varname => 'SEND_EMAIL_ALERTS',
         value   => '1';
     }
   }


### PR DESCRIPTION
We've removed the setting from Travel Advice Publisher so we no longer need to be setting this environment variable via Puppet. We can't think of a good reason that we still need this configuration since the application should behave the same in all environments.

See https://github.com/alphagov/travel-advice-publisher/pull/934 for the related change in Travel Advice Publisher.