### PR TITLE
Add reply_to email IDs for Feedback's survey Notify integration

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -224,6 +224,7 @@ task :check_consistency_between_aws_and_carrenza do
     govuk::apps::email_alert_service::rabbitmq::queue_size_warning_threshold
     govuk::apps::email_alert_service::rabbitmq_hosts
     govuk::apps::email_alert_service::redis_host
+    govuk::apps::feedback::govuk_notify_reply_to_id
     govuk::apps::feedback::govuk_notify_template_id
     govuk::apps::finder_frontend::enabled
     govuk::apps::finder_frontend::nagios_memory_critical

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -38,6 +38,7 @@ govuk::apps::email_alert_api::email_address_override: 'success@simulator.amazons
 govuk::apps::email_alert_api::email_address_override_whitelist_only: true
 govuk::apps::email_alert_api::delivery_request_threshold: "3000"
 govuk::apps::email_alert_frontend::subscription_management_enabled: true
+govuk::apps::feedback::govuk_notify_reply_to_id: 'fee22233-2f28-4b0b-8b6c-4410979f2275'
 govuk::apps::feedback::govuk_notify_template_id: 'eb9ba220-7d74-4aab-975a-bdbe718f69a3'
 govuk::apps::frontend::govuk_notify_template_id: '1fc69d3a-09a2-40f9-852b-03f6fcef5340'
 govuk::apps::govuk_crawler_worker::enabled: false

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -188,6 +188,7 @@ govuk::apps::email_alert_api::email_archive_s3_bucket: 'govuk-production-email-a
 # This shouldn't be enabled at the same time we have carrenza s3 export enabled unless they have separate buckets
 govuk::apps::email_alert_api::email_archive_s3_enabled: true
 govuk::apps::email_alert_api::govuk_notify_template_id: 'cb633abc-6ae6-4843-ae6f-82ca500b6de2'
+govuk::apps::feedback::govuk_notify_reply_to_id: 'e8b2d8a6-db5f-4346-9fbd-49b16b531e1c'
 govuk::apps::feedback::govuk_notify_template_id: '54168fa9-3946-4860-a2f8-27ddbb14babe'
 govuk::apps::frontend::govuk_notify_template_id: 'cb633abc-6ae6-4843-ae6f-82ca500b6de2'
 govuk::apps::hmrc_manuals_api::publish_topics: false

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -169,6 +169,7 @@ govuk::apps::email_alert_api::email_address_override: 'success@simulator.amazons
 govuk::apps::email_alert_api::email_address_override_whitelist_only: true
 govuk::apps::email_alert_api::delivery_request_threshold: "3000"
 govuk::apps::email_alert_frontend::subscription_management_enabled: true
+govuk::apps::feedback::govuk_notify_reply_to_id: 'd1f54751-80a8-420a-9077-d34c7d6cc734'
 govuk::apps::feedback::govuk_notify_template_id: '8a8d98c0-42c8-4f56-b61f-77c89417a171'
 govuk::apps::frontend::govuk_notify_template_id: '2844a647-6bf1-4b01-a25c-569d2cc00849'
 govuk::apps::govuk_crawler_worker::disable_during_data_sync: true

--- a/modules/govuk/manifests/apps/feedback.pp
+++ b/modules/govuk/manifests/apps/feedback.pp
@@ -41,9 +41,9 @@ class govuk::apps::feedback(
   $google_client_email = undef,
   $google_private_key = undef,
   $survey_notify_service_api_key = undef,
-  $govuk_notify_api_key = undef,
-  $govuk_notify_template_id = undef,
-  $govuk_notify_reply_to_id = undef,
+  $govuk_notify_api_key,
+  $govuk_notify_template_id,
+  $govuk_notify_reply_to_id,
 ) {
   $app_name = 'feedback'
 
@@ -115,23 +115,18 @@ class govuk::apps::feedback(
     }
   }
 
-  if $govuk_notify_api_key != undef {
-    govuk::app::envvar { "${title}-GOVUK_NOTIFY_API_KEY":
-      varname => 'GOVUK_NOTIFY_API_KEY',
-      value   => $govuk_notify_api_key,
-    }
+  govuk::app::envvar { "${title}-GOVUK_NOTIFY_API_KEY":
+    varname => 'GOVUK_NOTIFY_API_KEY',
+    value   => $govuk_notify_api_key,
   }
 
-  if $govuk_notify_template_id != undef {
-    govuk::app::envvar { "${title}-GOVUK_NOTIFY_TEMPLATE_ID":
-        varname => 'GOVUK_NOTIFY_TEMPLATE_ID',
-        value   => $govuk_notify_template_id,
-    }
+  govuk::app::envvar { "${title}-GOVUK_NOTIFY_TEMPLATE_ID":
+      varname => 'GOVUK_NOTIFY_TEMPLATE_ID',
+      value   => $govuk_notify_template_id,
   }
-  if $govuk_notify_reply_to_id != undef {
-    govuk::app::envvar { "${title}-GOVUK_NOTIFY_REPLY_TO_ID":
-        varname => 'GOVUK_NOTIFY_REPLY_TO_ID',
-        value   => $govuk_notify_reply_to_id,
-    }
+
+  govuk::app::envvar { "${title}-GOVUK_NOTIFY_REPLY_TO_ID":
+      varname => 'GOVUK_NOTIFY_REPLY_TO_ID',
+      value   => $govuk_notify_reply_to_id,
   }
 }

--- a/modules/govuk/manifests/apps/feedback.pp
+++ b/modules/govuk/manifests/apps/feedback.pp
@@ -27,6 +27,9 @@
 # [*govuk_notify_template_id*]
 #   Template ID for GOV.UK Notify
 #
+# [*govuk_notify_reply_to_id*]
+#   Email address reply_to ID for GOV.UK Notify
+#
 class govuk::apps::feedback(
   $port,
   $sentry_dsn = undef,
@@ -40,6 +43,7 @@ class govuk::apps::feedback(
   $survey_notify_service_api_key = undef,
   $govuk_notify_api_key = undef,
   $govuk_notify_template_id = undef,
+  $govuk_notify_reply_to_id = undef,
 ) {
   $app_name = 'feedback'
 
@@ -122,6 +126,12 @@ class govuk::apps::feedback(
     govuk::app::envvar { "${title}-GOVUK_NOTIFY_TEMPLATE_ID":
         varname => 'GOVUK_NOTIFY_TEMPLATE_ID',
         value   => $govuk_notify_template_id,
+    }
+  }
+  if $govuk_notify_reply_to_id != undef {
+    govuk::app::envvar { "${title}-GOVUK_NOTIFY_REPLY_TO_ID":
+        varname => 'GOVUK_NOTIFY_REPLY_TO_ID',
+        value   => $govuk_notify_reply_to_id,
     }
   }
 }


### PR DESCRIPTION
This adds a `govuk_notify_reply_to_id` variable to Feedback that corresponds with an e-mail address in the Notify service that handles survey e-mails. This will make the reply_to address for these emails `govuksurvey@digital.cabinet-office.gov.uk`

[Trello](https://trello.com/c/zs2mHfAM/2061-3-feedback-app-uses-its-own-notify-account)
