### PR TITLE
integration db_admin govuk_env_sync::tasks: add pull_ckan_production task

### DIFF
--- a/hieradata_aws/class/integration/db_admin.yaml
+++ b/hieradata_aws/class/integration/db_admin.yaml
@@ -10,6 +10,17 @@ govuk_env_sync::tasks:
     temppath: "/tmp/content_data_admin_production_pull"
     url: "govuk-production-database-backups"
     path: "postgresql-backend"
+  "pull_ckan_production":
+    ensure: "disabled"
+    hour: "0"
+    minute: "0"
+    action: "pull"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "ckan_production"
+    temppath: "/tmp/ckan_production_pull"
+    url: "govuk-production-database-backups"
+    path: "postgresql-backend"
   "push_ckan_integration_daily":
     ensure: "present"
     hour: "23"


### PR DESCRIPTION
"disabled" so it can only be run manually. Integration ckan's database hasn't been refreshed in quite a while it seems.