### PR TITLE
Only allow deploying CDN or updating CDN directories for applicable services

### DIFF
--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -32,6 +32,15 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::validate_published_dns
 
 govuk_jenkins::jobs::deploy_cdn::enable_slack_notifications: true
+govuk_jenkins::jobs::deploy_cdn::services:
+  - apt
+  - assets
+  - mirror
+  - performanceplatform
+  - servicegovuk
+  - tldredirect
+  - www
+
 govuk_jenkins::jobs::deploy_puppet::enable_slack_notifications: true
 govuk_jenkins::jobs::validate_published_dns::run_daily: true
 govuk_jenkins::jobs::user_monitor::enable_icinga_check: true

--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -41,6 +41,12 @@ govuk_jenkins::jobs::deploy_cdn::services:
   - tldredirect
   - www
 
+govuk_jenkins::jobs::update_cdn_dictionaries::services:
+  - assets
+  - mirror
+  - performanceplatform
+  - www
+
 govuk_jenkins::jobs::deploy_puppet::enable_slack_notifications: true
 govuk_jenkins::jobs::validate_published_dns::run_daily: true
 govuk_jenkins::jobs::user_monitor::enable_icinga_check: true

--- a/hieradata/class/staging/jenkins.yaml
+++ b/hieradata/class/staging/jenkins.yaml
@@ -31,4 +31,10 @@ govuk_jenkins::jobs::deploy_cdn::services:
   - performanceplatform
   - www
 
+govuk_jenkins::jobs::update_cdn_dictionaries::services:
+  - assets
+  - mirror
+  - performanceplatform
+  - www
+
 govuk_jenkins::jobs::deploy_puppet::enable_slack_notifications: true

--- a/hieradata/class/staging/jenkins.yaml
+++ b/hieradata/class/staging/jenkins.yaml
@@ -25,4 +25,10 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::validate_published_dns
 
 govuk_jenkins::jobs::deploy_cdn::enable_slack_notifications: true
+govuk_jenkins::jobs::deploy_cdn::services:
+  - assets
+  - mirror
+  - performanceplatform
+  - www
+
 govuk_jenkins::jobs::deploy_puppet::enable_slack_notifications: true

--- a/hieradata_aws/class/integration/jenkins.yaml
+++ b/hieradata_aws/class/integration/jenkins.yaml
@@ -52,6 +52,11 @@ govuk_jenkins::jobs::deploy_cdn::services:
   - performanceplatform
   - www
 
+govuk_jenkins::jobs::update_cdn_dictionaries::services:
+  - assets
+  - performanceplatform
+  - www
+
 lv:
   data:
     pv: '/dev/nvme1n1'

--- a/hieradata_aws/class/integration/jenkins.yaml
+++ b/hieradata_aws/class/integration/jenkins.yaml
@@ -47,6 +47,10 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::whitehall_publisher_notifications
 
 govuk_jenkins::jobs::deploy_cdn::enable_slack_notifications: true
+govuk_jenkins::jobs::deploy_cdn::services:
+  - assets
+  - performanceplatform
+  - www
 
 lv:
   data:

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -162,8 +162,6 @@ govuk_jenkins::jobs::search_api_reindex_with_new_schema::cron_schedule: '0 21 * 
 
 govuk_jenkins::jobs::search_relevancy_rank_evaluation::cron_schedule: '45 */3 * * *' # every three hours
 govuk_jenkins::jobs::search_relevancy_metrics_etl::cron_schedule: 'H 2,8,14,20 * * *' # every six hours
-# Integration doesn't have a mirror
-govuk_jenkins::jobs::update_cdn_dictionaries::allow_deploy_to_mirror: false
 
 govuk_jenkins::ssh_key::public_key: 'AAAAB3NzaC1yc2EAAAADAQABAAACAQDQBl40cv64wBa1zEG3dIOwsTTcJsMybZW0nPmCLBqS9/xzv4WoW5VzvID6yrSlg5XfX1Qxq8FmFGIDaAhb1fna2Z05EAC1Jh8EnCSFK8Q6NaUGxlyYoHRD06kZI8ZdAj3Ct8Hsqa0YaWKa/vSIWKIRtboVKm6SMbNxcLwQ04AG2zP2wtnGpyDKBPZol/L3jxVExx1B2lIww0drSKNFKQzM9kijZyAmhu8ocClNl19Rv86q44v0PcDIv5hkW5bEbsavTghnLNXad2dmiSP5Se68NscumyboetuG+o0lOFbFjuHk8NaXklOWiFZxJaJXiOVLihXHVhpDcuXEzwNoOKhYEzA06vHBVXbngBuEsgns/Hgpz4we2H4y4k9w9eJ4rKNhTvrfAzcYzEsnmhbNtQMZaLbqKnWBt2+X6lKTYUBpnUWXwLMaAb5dqEqD+LGiDxcfJ4b6UctSR7+CF29gRChwv0HUO1NdiVzZ2AMrqsYp9QtCWnfNipveGZl9Rqox3JSt4u/+7+I9xw0d8bFp8xCPxan78eMu42i3jNm4qcbbXGvPU6WFP0htjZZ8S0Fq7Dss4AbADrLxwepW8n7E+PozZRjH2P7TgmZ+wQXS6aUNHdgDeYsv5070NYK33wuE2f9GNVuN35/5ImB9PuyxDNSdHIPXTABMOZk7fVQUqXLCRw=='
 

--- a/modules/govuk_jenkins/manifests/jobs/deploy_cdn.pp
+++ b/modules/govuk_jenkins/manifests/jobs/deploy_cdn.pp
@@ -5,6 +5,7 @@
 class govuk_jenkins::jobs::deploy_cdn(
   $app_domain = hiera('app_domain'),
   $enable_slack_notifications = false,
+  $services = [],
 ) {
 
   $environment_variables = $govuk_jenkins::environment_variables

--- a/modules/govuk_jenkins/manifests/jobs/update_cdn_dictionaries.pp
+++ b/modules/govuk_jenkins/manifests/jobs/update_cdn_dictionaries.pp
@@ -5,6 +5,7 @@
 class govuk_jenkins::jobs::update_cdn_dictionaries(
   $app_domain = hiera('app_domain'),
   $allow_deploy_to_mirror = true,
+  $services = [],
 ) {
 
   $environment_variables = $govuk_jenkins::environment_variables

--- a/modules/govuk_jenkins/templates/jobs/deploy_cdn.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_cdn.yaml.erb
@@ -58,13 +58,9 @@
             name: vhost
             choices:
                 - PLEASE CHOOSE ONE
-                - www
-                - assets
-                - apt
-                - tldredirect
-                - servicegovuk
-                - performanceplatform
-                - mirror
+                <%- @services.each do |service| -%>
+                - <%= service %>
+                <%- end -%>
         - password:
             name: FASTLY_API_KEY
             default: false

--- a/modules/govuk_jenkins/templates/jobs/update_cdn_dictionaries.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/update_cdn_dictionaries.yaml.erb
@@ -56,10 +56,9 @@
             name: vhost
             choices:
                 - PLEASE CHOOSE ONE
-                - www
-                <% if @allow_deploy_to_mirror %>
-                - mirror
-                <% end %>
+                <%- @services.each do |service| -%>
+                - <%= service %>
+                <%- end -%>
         - password:
             name: FASTLY_API_KEY
             default: false


### PR DESCRIPTION
The GOV.UK CDN config can now update dictionaries in www, assets, performanceplatform and mirror services. To reflect this change we need to add more services to the select field for updating CDN directories. When I looked at this I realised we were in a situation where `deploy_cdn` job allowed deploying to services that don't exist in the corresponding environment, whereas `update_cdn_dictionaries` only allowed deploying to applicable services. I've now configured them both to only have applicable services.