### PR TITLE
Update queue latency check

### DIFF
--- a/modules/govuk/manifests/apps/email_alert_api/checks.pp
+++ b/modules/govuk/manifests/apps/email_alert_api/checks.pp
@@ -7,6 +7,10 @@ class govuk::apps::email_alert_api::checks(
 ) {
 
   sidekiq_queue_check {
+    'delivery_transactional':
+      latency_warning  => '300', # 5 minutes
+      latency_critical => '600'; # 10 minutes
+
     'delivery_immediate':
       latency_warning  => '1200', # 20 minutes
       latency_critical => '1800'; # 30 minutes

--- a/modules/govuk/manifests/apps/email_alert_api/checks.pp
+++ b/modules/govuk/manifests/apps/email_alert_api/checks.pp
@@ -7,15 +7,6 @@ class govuk::apps::email_alert_api::checks(
 ) {
 
   sidekiq_queue_check {
-    [
-      'process_and_generate_emails',
-      'default',
-      'email_generation_digest',
-      'cleanup',
-    ]:
-      latency_warning  => '300', # 5 minutes
-      latency_critical => '600'; # 10 minutes
-
     'delivery_immediate':
       latency_warning  => '1200', # 20 minutes
       latency_critical => '1800'; # 30 minutes


### PR DESCRIPTION
Stop checking certain queues and start monitoring the delivery_transactional queue.

More info in the Trello card:
https://trello.com/c/HwvZx0V9/456-update-the-queue-latency-check