### PR TITLE
Clean Up Datasync Jobs After Signon Migration

### DIFF
--- a/hieradata/node/mysql-backup-1.backend.publishing.service.gov.uk.yaml
+++ b/hieradata/node/mysql-backup-1.backend.publishing.service.gov.uk.yaml
@@ -33,7 +33,7 @@ govuk_env_sync::tasks:
     url: "govuk-production-database-backups"
     path: "mysql"
   "push_signon_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "0"
     minute: "20"
     action: "push"
@@ -45,7 +45,7 @@ govuk_env_sync::tasks:
     path: "mysql"
   # testing signon backup with excluded tables
   "push_trimmed_signon_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "0"
     minute: "40"
     action: "push"

--- a/hieradata/node/mysql-backup-1.backend.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/mysql-backup-1.backend.staging.publishing.service.gov.uk.yaml
@@ -33,7 +33,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mysql"
   "push_signon_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "1"
     minute: "20"
     action: "push"

--- a/hieradata_aws/class/production/db_admin.yaml
+++ b/hieradata_aws/class/production/db_admin.yaml
@@ -285,17 +285,17 @@ govuk_env_sync::tasks:
     temppath: "/tmp/short_url_manager_production"
     url: "govuk-production-database-backups"
     path: "mongo-normal"
-  "pull_signon_production_daily":
-    ensure: "disabled"
-    hour: "1"
+  "push_signon_production_daily":
+    ensure: "present"
+    hour: "0"
     minute: "30"
-    action: "pull"
+    action: "push"
     dbms: "mysql"
     storagebackend: "s3"
     database: "signon_production"
     temppath: "/tmp/signon_production"
     url: "govuk-production-database-backups"
-    path: "mysql/trimmed"
+    path: "mysql"
   "push_support-contacts_production_daily":
     ensure: "present"
     hour: "2"

--- a/hieradata_aws/class/staging/db_admin.yaml
+++ b/hieradata_aws/class/staging/db_admin.yaml
@@ -287,7 +287,6 @@ govuk_env_sync::tasks:
     temppath: "/tmp/search_admin_production"
     url: "govuk-staging-database-backups"
     path: "mysql"
-  # testing signon backup with excluded tables
   "pull_signon_production_daily":
     ensure: "present"
     hour: "1"
@@ -298,25 +297,7 @@ govuk_env_sync::tasks:
     database: "signon_production"
     temppath: "/tmp/signon_production"
     url: "govuk-production-database-backups"
-    path: "mysql/trimmed"
-  # testing signon backup with excluded tables
-  "push_signon_production_daily":
-    ensure: "absent" #was used for testing
-    hour: "1"
-    minute: "30"
-    action: "push"
-    dbms: "mysql"
-    storagebackend: "s3"
-    database: "signon_production"
-    temppath: "/tmp/signon_production"
-    url: "govuk-staging-database-backups"
-    excluded_tables: "__event_logs_old,event_logs,lhma_2019_04_30_10_36_45_946_event_logs,lhma_2019_06_18_13_31_49_199_event_logs"
-    path: "mysql/trimmed"
-  # The push_whitehall_staging_daily job redacts the Staging Whitehall database
-  # in-place before dumping it to S3. Integration then pulls the redacted copy.
-  # The pull_whitehall_production_daily job then overwrites Staging with the
-  # latest data from Production, so Staging remains unredacted. Staging has the
-  # unredacted data because it helps when debugging content-related issues.
+    path: "mysql"
   "push_whitehall_staging_daily":
     ensure: "present"
     hour: "0"


### PR DESCRIPTION
Delete unnecessary backup jobs from Carrenza.
Clean up experimental jobs in AWS and add correct ones.