### PR TITLE
Remove warning alerts 4 Messages & ContentChanges

### DIFF
--- a/modules/govuk/manifests/apps/email_alert_api/checks.pp
+++ b/modules/govuk/manifests/apps/email_alert_api/checks.pp
@@ -46,10 +46,10 @@ class govuk::apps::email_alert_api::checks(
     notes_url => monitoring_docs_url(email-alert-api-incomplete-digest-runs),
   }
 
-  @@icinga::check::graphite { 'email-alert-api-critical-content-changes':
+  @@icinga::check::graphite { 'email-alert-api-unprocessed-content-changes':
     ensure    => $ensure,
     host_name => $::fqdn,
-    target    => 'transformNull(keepLastValue(averageSeries(stats.gauges.govuk.app.email-alert-api.*.content_changes.critical_total)))',
+    target    => 'transformNull(keepLastValue(averageSeries(stats.gauges.govuk.app.email-alert-api.*.content_changes.unprocessed_total)))',
     warning   => '0',
     critical  => '0',
     from      => '15minutes',
@@ -68,10 +68,10 @@ class govuk::apps::email_alert_api::checks(
     notes_url => monitoring_docs_url(email-alert-api-incomplete-digest-runs),
   }
 
-  @@icinga::check::graphite { 'email-alert-api-critical-messages':
+  @@icinga::check::graphite { 'email-alert-api-unprocessed-messages':
     ensure    => $ensure,
     host_name => $::fqdn,
-    target    => 'transformNull(keepLastValue(averageSeries(stats.gauges.govuk.app.email-alert-api.*.messages.critical_total)))',
+    target    => 'transformNull(keepLastValue(averageSeries(stats.gauges.govuk.app.email-alert-api.*.messages.unprocessed_total)))',
     warning   => '0',
     critical  => '0',
     from      => '1hour',

--- a/modules/govuk/manifests/apps/email_alert_api/checks.pp
+++ b/modules/govuk/manifests/apps/email_alert_api/checks.pp
@@ -35,17 +35,6 @@ class govuk::apps::email_alert_api::checks(
     notes_url => monitoring_docs_url(email-alert-api-delivery-attempts-status-updates),
   }
 
-  @@icinga::check::graphite { 'email-alert-api-warning-content-changes':
-    ensure    => $ensure,
-    host_name => $::fqdn,
-    target    => 'transformNull(keepLastValue(averageSeries(stats.gauges.govuk.app.email-alert-api.*.content_changes.warning_total)))',
-    warning   => '0',
-    critical  => '100000000',
-    from      => '15minutes',
-    desc      => 'email-alert-api - unprocessed content changes older than 90 minutes',
-    notes_url => monitoring_docs_url(email-alert-api-unprocessed-content-changes),
-    }
-
   @@icinga::check::graphite { 'email-alert-api-warning-digest-runs':
     ensure    => $ensure,
     host_name => $::fqdn,
@@ -55,17 +44,6 @@ class govuk::apps::email_alert_api::checks(
     from      => '1hour',
     desc      => 'email-alert-api - incomplete digest runs - warning',
     notes_url => monitoring_docs_url(email-alert-api-incomplete-digest-runs),
-  }
-
-  @@icinga::check::graphite { 'email-alert-api-warning-messages':
-    ensure    => $ensure,
-    host_name => $::fqdn,
-    target    => 'transformNull(keepLastValue(averageSeries(stats.gauges.govuk.app.email-alert-api.*.messages.warning_total)))',
-    warning   => '0',
-    critical  => '100000000',
-    from      => '1hour',
-    desc      => 'email-alert-api - unprocessed messages older than 90 minutes',
-    notes_url => monitoring_docs_url(email-alert-api-unprocessed-messages),
   }
 
   @@icinga::check::graphite { 'email-alert-api-critical-content-changes':


### PR DESCRIPTION
Removes the warning alerts as they're superfluous and don't actually
give us any useful information.

This is especially true now we've merged in this [retry behaviour] PR.
We only want to raise a critical when the retry logic has run and
failed.

We should deploy this at the same time (just after) as https://github.com/alphagov/email-alert-api/pull/1358.

More info in the Trello card:
https://trello.com/c/BT5x4iAU/457-update-warning-critical-alerts-for-messages-and-content-changes

[retry behaviour]: https://github.com/alphagov/email-alert-api/pull/1318