### PR TITLE
Split up out of hours and in hours machines

### DIFF
--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_reboots_required
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_reboots_required
@@ -65,10 +65,16 @@ if safe_machines.length + unsafe_machines.length == 0
 else
   puts 'Some hosts need to be rebooted to apply updates'
 
-  if unsafe_machines.length > 0
+  if out_of_hours_unsafe_machines.length > 0
     puts "\n"
-    puts 'These hosts need to be rebooted manually:'
-    print_hostnames(unsafe_machines, machines_names_hash)
+    puts 'These hosts need to be rebooted manually out of hours:'
+    print_hostnames(out_of_hours_unsafe_machines, machines_names_hash)
+  end
+
+  if in_hours_unsafe_machines.length > 0
+    puts "\n"
+    puts 'These hosts need to be rebooted manually in hours:'
+    print_hostnames(in_hours_unsafe_machines, machines_names_hash)
   end
 
   if safe_machines.length > 0

--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_reboots_required
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_reboots_required
@@ -21,7 +21,13 @@ def hostname_with_node_name(hostname, machines_names_hash)
   else
     hostname
   end
+end
 
+def print_hostnames(hostnames, machines_names_hash)
+  hostnames.sort.each do |hostname|
+    hydrated_name = hostname_with_node_name(hostname, machines_names_hash)
+    puts "- #{hydrated_name}"
+  end
 end
 
 all_machines = `/usr/local/bin/govuk_node_list`.split("\n")
@@ -58,21 +64,18 @@ if safe_machines.length + unsafe_machines.length == 0
   exit 0
 else
   puts 'Some hosts need to be rebooted to apply updates'
+
   if unsafe_machines.length > 0
     puts "\n"
     puts 'These hosts need to be rebooted manually:'
-    unsafe_machines.sort.each do |hostname|
-      hydrated_name = hostname_with_node_name(hostname, machines_names_hash)
-      puts "- #{hydrated_name}"
-    end
+    print_hostnames(unsafe_machines, machines_names_hash)
   end
+
   if safe_machines.length > 0
     puts "\n"
     puts "These hosts should reboot automatically overnight (you'll need to manually step down any primary MongoDB machines):"
-    safe_machines.sort.each do |hostname|
-      hydrated_name = hostname_with_node_name(hostname, machines_names_hash)
-      puts "- #{hydrated_name}"
-    end
+    print_hostnames(safe_machines, machines_names_hash)
   end
+
   exit 1
 end

--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_reboots_required
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_reboots_required
@@ -26,7 +26,9 @@ end
 
 all_machines = `/usr/local/bin/govuk_node_list`.split("\n")
 
-unsafe_machines = `/usr/local/bin/govuk_node_list --puppet-class govuk_safe_to_reboot::careful,govuk_safe_to_reboot::no`.split("\n")
+out_of_hours_unsafe_machines = `/usr/local/bin/govuk_node_list --puppet-class govuk_safe_to_reboot::no`.split("\n")
+in_hours_unsafe_machines = `/usr/local/bin/govuk_node_list --puppet-class govuk_safe_to_reboot::careful`.split("\n")
+unsafe_machines = out_of_hours_unsafe_machines + in_hours_unsafe_machines
 safe_machines = `/usr/local/bin/govuk_node_list --puppet-class govuk_safe_to_reboot::yes,govuk_safe_to_reboot::overnight`.split("\n")
 
 machines_names_hash = create_machines_hash


### PR DESCRIPTION
Some machines need to be rebooted manually, but within that some machines can be rebooted in hours and some have to be rebooted out of hours.

At the moment the alert doesn't provide that distinction so this makes it easier to see what needs to be done.