### PR TITLE
Disable unattended reboots

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -798,8 +798,8 @@ govuk_sudo::sudo_conf:
 govuk_sysdig::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk_sysdig::ensure: 'absent'
 
-govuk_unattended_reboot::enabled: true
-govuk_unattended_reboot::mongodb::enabled: true
+govuk_unattended_reboot::enabled: false
+govuk_unattended_reboot::mongodb::enabled: false
 
 govuk_unattended_reboot::monitoring_basic_auth:
   username: "%{hiera('http_username')}"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1062,8 +1062,8 @@ govuk_splunk::repos::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk_splunk::repos::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 govuk_unattended_reboot::alert_hostname: 'alert'
-govuk_unattended_reboot::enabled: true
-govuk_unattended_reboot::mongodb::enabled: true
+govuk_unattended_reboot::enabled: false
+govuk_unattended_reboot::mongodb::enabled: false
 
 govuk_unattended_reboot::monitoring_basic_auth:
   username: "%{hiera('http_username')}"


### PR DESCRIPTION
We need to disable the unattended reboots, the ubuntu servers have a bad version of grub2 installed which breaks grub, which means that should a machine reboot that it will not come back online.

Grub2 was updated to address a vulnerability.

broken in:   `2.02~beta2-9ubuntu1.20`
we're using:  `2.02~beta2-9ubuntu1.21`

It is supposedly fixed in v2.06

Further details: https://wiki.ubuntu.com/SecurityTeam/KnowledgeBase/GRUB2SecureBootBypass#Fixed_versions