### PR TITLE
Set govuk_safe_to_reboot::can_reboot to 'no' for all classes

### DIFF
--- a/hieradata/class/api_mongo.yaml
+++ b/hieradata/class/api_mongo.yaml
@@ -1,6 +1,6 @@
 ---
 
-govuk_safe_to_reboot::can_reboot: 'overnight'
+govuk_safe_to_reboot::can_reboot: 'no'
 govuk_safe_to_reboot::reason: 'Secondaries will reboot overnight if cluster is healthy'
 
 lv:

--- a/hieradata/class/asset_slave.yaml
+++ b/hieradata/class/asset_slave.yaml
@@ -1,6 +1,6 @@
 ---
 
-govuk_safe_to_reboot::can_reboot: 'careful'
+govuk_safe_to_reboot::can_reboot: 'no'
 govuk_safe_to_reboot::reason: 'Check that offsite sync job is not running before rebooting'
 
 lv:

--- a/hieradata/class/backend_lb.yaml
+++ b/hieradata/class/backend_lb.yaml
@@ -1,6 +1,6 @@
 ---
 
-govuk_safe_to_reboot::can_reboot: overnight
+govuk_safe_to_reboot::can_reboot: 'no'
 govuk_safe_to_reboot::reason: >
   Traffic is balanced between backend-lb-1 and backend-lb-2.
 

--- a/hieradata/class/graphite.yaml
+++ b/hieradata/class/graphite.yaml
@@ -1,6 +1,6 @@
 ---
 
-govuk_safe_to_reboot::can_reboot: 'careful'
+govuk_safe_to_reboot::can_reboot: 'no'
 govuk_safe_to_reboot::reason: 'We lose stats and some alerting when this machine is down'
 
 lv:

--- a/hieradata/class/jumpbox.yaml
+++ b/hieradata/class/jumpbox.yaml
@@ -1,4 +1,4 @@
 ---
 
-govuk_safe_to_reboot::can_reboot: 'careful'
+govuk_safe_to_reboot::can_reboot: 'no'
 govuk_safe_to_reboot::reason: 'Warn connected users before rebooting'

--- a/hieradata/class/logs_redis.yaml
+++ b/hieradata/class/logs_redis.yaml
@@ -1,4 +1,4 @@
 ---
 
-govuk_safe_to_reboot::can_reboot: 'careful'
+govuk_safe_to_reboot::can_reboot: 'no'
 govuk_safe_to_reboot::reason: 'Check queue is empty first with: redis-cli llen logs '

--- a/hieradata/class/mongo.yaml
+++ b/hieradata/class/mongo.yaml
@@ -1,6 +1,6 @@
 ---
 
-govuk_safe_to_reboot::can_reboot: 'overnight'
+govuk_safe_to_reboot::can_reboot: 'no'
 govuk_safe_to_reboot::reason: 'Secondaries will reboot overnight if cluster is healthy'
 
 lv:

--- a/hieradata/class/monitoring.yaml
+++ b/hieradata/class/monitoring.yaml
@@ -2,7 +2,7 @@
 
 govuk_cdnlogs::log_dir: '/var/log/cdn'
 
-govuk_safe_to_reboot::can_reboot: 'overnight'
+govuk_safe_to_reboot::can_reboot: 'no'
 govuk_safe_to_reboot::reason: 'We lose alerting while this is down'
 
 icinga::client::checks::disk_space_warn: 12

--- a/hieradata/class/mysql_slave.yaml
+++ b/hieradata/class/mysql_slave.yaml
@@ -1,6 +1,6 @@
 ---
 
-govuk_safe_to_reboot::can_reboot: 'careful'
+govuk_safe_to_reboot::can_reboot: 'no'
 govuk_safe_to_reboot::reason: 'Applications normally read from slave-1 and should be switched before rebooting slave-1'
 
 lv:

--- a/hieradata/class/performance_mongo.yaml
+++ b/hieradata/class/performance_mongo.yaml
@@ -1,6 +1,6 @@
 ---
 
-govuk_safe_to_reboot::can_reboot: 'overnight'
+govuk_safe_to_reboot::can_reboot: 'no'
 govuk_safe_to_reboot::reason: 'Secondaries will reboot overnight if cluster is healthy'
 
 lv:

--- a/hieradata/class/rabbitmq.yaml
+++ b/hieradata/class/rabbitmq.yaml
@@ -3,7 +3,7 @@
 govuk::node::s_rabbitmq::apps_using_rabbitmq:
   - backdrop_write
 
-govuk_safe_to_reboot::can_reboot: 'careful'
+govuk_safe_to_reboot::can_reboot: 'no'
 govuk_safe_to_reboot::reason: 'rabbitmq-1 is a single point of failure for content-store, apps not resilient'
 
 lv:

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -798,6 +798,9 @@ govuk_sudo::sudo_conf:
 govuk_sysdig::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk_sysdig::ensure: 'absent'
 
+govuk_safe_to_reboot::can_reboot: 'no'
+govuk_safe_to_reboot::reason: 'Grub2 is broken, a reboot will break the machine'
+
 govuk_unattended_reboot::enabled: false
 govuk_unattended_reboot::mongodb::enabled: false
 

--- a/hieradata/node/api-mongo-4.api.publishing.service.gov.uk.yaml
+++ b/hieradata/node/api-mongo-4.api.publishing.service.gov.uk.yaml
@@ -1,2 +1,2 @@
-govuk_safe_to_reboot::can_reboot: 'overnight'
+govuk_safe_to_reboot::can_reboot: 'no'
 govuk_safe_to_reboot::reason: 'DR node: only used in the event of a disaster'

--- a/hieradata/node/api-mongo-4.api.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/api-mongo-4.api.staging.publishing.service.gov.uk.yaml
@@ -1,2 +1,2 @@
-govuk_safe_to_reboot::can_reboot: 'overnight'
+govuk_safe_to_reboot::can_reboot: 'no'
 govuk_safe_to_reboot::reason: 'DR node: only used in the event of a disaster'

--- a/hieradata/node/api-postgresql-standby-2.api.publishing.service.gov.uk.yaml
+++ b/hieradata/node/api-postgresql-standby-2.api.publishing.service.gov.uk.yaml
@@ -1,2 +1,2 @@
-govuk_safe_to_reboot::can_reboot: 'overnight'
+govuk_safe_to_reboot::can_reboot: 'no'
 govuk_safe_to_reboot::reason: 'DR node: only used in the event of a disaster'

--- a/hieradata/node/api-postgresql-standby-2.api.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/api-postgresql-standby-2.api.staging.publishing.service.gov.uk.yaml
@@ -1,2 +1,2 @@
-govuk_safe_to_reboot::can_reboot: 'overnight'
+govuk_safe_to_reboot::can_reboot: 'no'
 govuk_safe_to_reboot::reason: 'DR node: only used in the event of a disaster'

--- a/hieradata/node/asset-slave-2.backend.publishing.service.gov.uk.yaml
+++ b/hieradata/node/asset-slave-2.backend.publishing.service.gov.uk.yaml
@@ -1,4 +1,4 @@
 govuk::node::s_asset_base::push_attachments_to_s3: true
 govuk::node::s_asset_base::s3_bucket: 'govuk-attachments-production'
-govuk_safe_to_reboot::can_reboot: 'overnight'
+govuk_safe_to_reboot::can_reboot: 'no'
 govuk_safe_to_reboot::reason: 'DR node: only used in the event of a disaster'

--- a/hieradata/node/asset-slave-2.backend.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/asset-slave-2.backend.staging.publishing.service.gov.uk.yaml
@@ -1,2 +1,2 @@
-govuk_safe_to_reboot::can_reboot: 'overnight'
+govuk_safe_to_reboot::can_reboot: 'no'
 govuk_safe_to_reboot::reason: 'DR node: only used in the event of a disaster'

--- a/hieradata/node/docker-management-1.management.publishing.service.gov.uk.yaml
+++ b/hieradata/node/docker-management-1.management.publishing.service.gov.uk.yaml
@@ -1,2 +1,2 @@
-govuk_safe_to_reboot::can_reboot: 'careful'
+govuk_safe_to_reboot::can_reboot: 'no'
 govuk_safe_to_reboot::reason: 'safe to reboot while no other unattended reboot underway'

--- a/hieradata/node/docker-management-1.management.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/docker-management-1.management.staging.publishing.service.gov.uk.yaml
@@ -1,2 +1,2 @@
-govuk_safe_to_reboot::can_reboot: 'careful'
+govuk_safe_to_reboot::can_reboot: 'no'
 govuk_safe_to_reboot::reason: 'safe to reboot while no other unattended reboot underway'

--- a/hieradata/node/mysql-slave-3.backend.publishing.service.gov.uk.yaml
+++ b/hieradata/node/mysql-slave-3.backend.publishing.service.gov.uk.yaml
@@ -1,2 +1,2 @@
-govuk_safe_to_reboot::can_reboot: 'overnight'
+govuk_safe_to_reboot::can_reboot: 'no'
 govuk_safe_to_reboot::reason: 'DR node: only used in the event of a disaster'

--- a/hieradata/node/mysql-slave-3.backend.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/mysql-slave-3.backend.staging.publishing.service.gov.uk.yaml
@@ -1,2 +1,2 @@
-govuk_safe_to_reboot::can_reboot: 'overnight'
+govuk_safe_to_reboot::can_reboot: 'no'
 govuk_safe_to_reboot::reason: 'DR node: only used in the event of a disaster'

--- a/hieradata/node/postgresql-standby-2.backend.publishing.service.gov.uk.yaml
+++ b/hieradata/node/postgresql-standby-2.backend.publishing.service.gov.uk.yaml
@@ -1,2 +1,2 @@
-govuk_safe_to_reboot::can_reboot: 'overnight'
+govuk_safe_to_reboot::can_reboot: 'no'
 govuk_safe_to_reboot::reason: 'DR node: only used in the event of a disaster'

--- a/hieradata/node/postgresql-standby-2.backend.staging.publishing.service.gov.uk.yaml
+++ b/hieradata/node/postgresql-standby-2.backend.staging.publishing.service.gov.uk.yaml
@@ -1,2 +1,2 @@
-govuk_safe_to_reboot::can_reboot: 'overnight'
+govuk_safe_to_reboot::can_reboot: 'no'
 govuk_safe_to_reboot::reason: 'DR node: only used in the event of a disaster'

--- a/hieradata_aws/class/docker_management.yaml
+++ b/hieradata_aws/class/docker_management.yaml
@@ -1,2 +1,2 @@
-govuk_safe_to_reboot::can_reboot: 'careful'
+govuk_safe_to_reboot::can_reboot: 'no'
 govuk_safe_to_reboot::reason: 'safe to reboot while no other unattended reboot underway'

--- a/hieradata_aws/class/mongo.yaml
+++ b/hieradata_aws/class/mongo.yaml
@@ -1,5 +1,5 @@
 ---
-govuk_safe_to_reboot::can_reboot: 'overnight'
+govuk_safe_to_reboot::can_reboot: 'no'
 govuk_safe_to_reboot::reason: 'Secondaries will reboot overnight if cluster is healthy'
 
 mongodb::server::oplog_size: 14392 # 14 * 1024

--- a/hieradata_aws/class/mongo_api.yaml
+++ b/hieradata_aws/class/mongo_api.yaml
@@ -1,5 +1,5 @@
 ---
-govuk_safe_to_reboot::can_reboot: 'overnight'
+govuk_safe_to_reboot::can_reboot: 'no'
 govuk_safe_to_reboot::reason: 'Secondaries will reboot overnight if cluster is healthy'
 
 mongodb::server::oplog_size: 14392 # 14 * 1024

--- a/hieradata_aws/class/production/cache.yaml
+++ b/hieradata_aws/class/production/cache.yaml
@@ -8,5 +8,5 @@ router::gor::http_disallow_url:
   - 'apply-for-a-licence/payment'
   - 'apply-for-a-licence/redirect'
   - 'apply-for-a-licence/uploaded'
-govuk_safe_to_reboot::can_reboot: 'careful'
+govuk_safe_to_reboot::can_reboot: 'no'
 govuk_safe_to_reboot::reason: 'Handles requests, traffic should be drained before restarting'

--- a/hieradata_aws/class/production/graphite.yaml
+++ b/hieradata_aws/class/production/graphite.yaml
@@ -1,2 +1,2 @@
-govuk_safe_to_reboot::can_reboot: 'careful'
+govuk_safe_to_reboot::can_reboot: 'no'
 govuk_safe_to_reboot::reason: 'We lose stats and some alerting when this machine is down'

--- a/hieradata_aws/class/rabbitmq.yaml
+++ b/hieradata_aws/class/rabbitmq.yaml
@@ -9,7 +9,7 @@ govuk::node::s_rabbitmq::apps_using_rabbitmq:
 
 govuk_rabbitmq::aws_clustering: true
 
-govuk_safe_to_reboot::can_reboot: 'careful'
+govuk_safe_to_reboot::can_reboot: 'no'
 govuk_safe_to_reboot::reason: 'rabbitmq-1 is a single point of failure for content-store, apps not resilient'
 
 rabbitmq::config_kernel_variables:

--- a/hieradata_aws/class/router_backend.yaml
+++ b/hieradata_aws/class/router_backend.yaml
@@ -7,7 +7,7 @@ govuk::apps::router_api::mongodb_nodes:
 
 govuk::apps::router_api::router_nodes_class: 'cache'
 
-govuk_safe_to_reboot::can_reboot: 'overnight'
+govuk_safe_to_reboot::can_reboot: 'no'
 govuk_safe_to_reboot::reason: 'Secondaries will reboot overnight if cluster is healthy'
 
 mongodb::server::replicaset_members:

--- a/hieradata_aws/class/whitehall_frontend.yaml
+++ b/hieradata_aws/class/whitehall_frontend.yaml
@@ -6,5 +6,5 @@ govuk::apps::whitehall::nagios_memory_critical: 12884
 govuk::apps::whitehall::vhost: 'whitehall-frontend'
 govuk::apps::whitehall::vhost_protected: false
 
-govuk_safe_to_reboot::can_reboot: 'overnight'
+govuk_safe_to_reboot::can_reboot: 'no'
 govuk_safe_to_reboot::reason: 'Whitehall application is slow to start, recommend rebooting a single node at a time'

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1061,6 +1061,9 @@ govuk_sudo::sudo_conf:
 govuk_splunk::repos::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk_splunk::repos::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
+govuk_safe_to_reboot::can_reboot: 'no'
+govuk_safe_to_reboot::reason: 'Grub2 is broken, a reboot will break the machine'
+
 govuk_unattended_reboot::alert_hostname: 'alert'
 govuk_unattended_reboot::enabled: false
 govuk_unattended_reboot::mongodb::enabled: false


### PR DESCRIPTION
We want to ensure all machines are marked as unsafe to reboot. There is currently a problem with grub2 breaking which in turn prevents a machine from rebooting.

