### PR TITLE
Fix check reboots required script

### DIFF
--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_reboots_required
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_reboots_required
@@ -37,13 +37,11 @@ in_hours_unsafe_machines = `/usr/local/bin/govuk_node_list --puppet-class govuk_
 unsafe_machines = out_of_hours_unsafe_machines + in_hours_unsafe_machines
 safe_machines = `/usr/local/bin/govuk_node_list --puppet-class govuk_safe_to_reboot::yes,govuk_safe_to_reboot::overnight`.split("\n")
 
-machines_to_reboot = unsafe_machines + safe_machines
-
 machines_names_hash = create_machines_hash
 
 # Safety check that we haven't added other safe to reboot options
 # that we don't account for here.
-unchecked_machines = all_machines - machines_to_reboot
+unchecked_machines = all_machines - (unsafe_machines + safe_machines)
 
 if unchecked_machines.length > 0
   puts "Some machines have an unknown `govuk_safe_to_reboot` value (should be one of `careful`, `no`, `yes` or `overnight`):"
@@ -54,14 +52,14 @@ if unchecked_machines.length > 0
   exit 3
 end
 
-machines_to_reboot.each do |host_list|
+[unsafe_machines, safe_machines].each do |host_list|
   host_list.delete_if do |host|
     `/usr/lib/nagios/plugins/check_nrpe -H #{host} -t 20 -c check_reboot_required -u`
     $?.to_i == 0
   end
 end
 
-if machines_to_reboot.length == 0
+if safe_machines.length + unsafe_machines.length == 0
   puts 'No hosts need to be rebooted'
   exit 0
 else

--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_reboots_required
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_reboots_required
@@ -34,14 +34,13 @@ all_machines = `/usr/local/bin/govuk_node_list`.split("\n")
 
 out_of_hours_unsafe_machines = `/usr/local/bin/govuk_node_list --puppet-class govuk_safe_to_reboot::no`.split("\n")
 in_hours_unsafe_machines = `/usr/local/bin/govuk_node_list --puppet-class govuk_safe_to_reboot::careful`.split("\n")
-unsafe_machines = out_of_hours_unsafe_machines + in_hours_unsafe_machines
 safe_machines = `/usr/local/bin/govuk_node_list --puppet-class govuk_safe_to_reboot::yes,govuk_safe_to_reboot::overnight`.split("\n")
 
 machines_names_hash = create_machines_hash
 
 # Safety check that we haven't added other safe to reboot options
 # that we don't account for here.
-unchecked_machines = all_machines - (unsafe_machines + safe_machines)
+unchecked_machines = all_machines - (out_of_hours_unsafe_machines + in_hours_unsafe_machines + safe_machines)
 
 if unchecked_machines.length > 0
   puts "Some machines have an unknown `govuk_safe_to_reboot` value (should be one of `careful`, `no`, `yes` or `overnight`):"
@@ -52,14 +51,14 @@ if unchecked_machines.length > 0
   exit 3
 end
 
-[unsafe_machines, safe_machines].each do |host_list|
+[out_of_hours_unsafe_machines, in_hours_unsafe_machines, safe_machines].each do |host_list|
   host_list.delete_if do |host|
     `/usr/lib/nagios/plugins/check_nrpe -H #{host} -t 20 -c check_reboot_required -u`
     $?.to_i == 0
   end
 end
 
-if safe_machines.length + unsafe_machines.length == 0
+if safe_machines.length + out_of_hours_unsafe_machines.length + in_hours_unsafe_machines.length  == 0
   puts 'No hosts need to be rebooted'
   exit 0
 else


### PR DESCRIPTION
This reverts commit 71aaae7 and makes a further change.

Because of the way this code is structured, it modifies the lists before displaying the results. The `unsafe_machines` array was a copy of the two `out_of_hours_unsafe_machines` and `in_hours_unsafe_machines` arrays and therefore modifying it doesn't affect the original arrays.

This code could do with refactoring but I'll note that down for future work to get the alert working again.