### PR TITLE
Fix low rate limit due to broken GitHub Auth

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_app_downstream.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_app_downstream.yaml.erb
@@ -42,11 +42,10 @@
           esac
 
           # Check release to deploy is genuine and we're not going backwards
-          GITHUB_AUTH="-H 'Authorization: token $GITHUB_API_TOKEN'"
           GITHUB_API="https://api.github.com/repos/alphagov/$REPO"
 
-          LATEST_TAGS=$(curl $GITHUB_AUTH -s "$GITHUB_API/tags?per_page=1")
-          LATEST_MASTER=$(curl $GITHUB_AUTH -s "$GITHUB_API/commits?per_page=1")
+          LATEST_TAGS=$(curl -H "Authorization: token $GITHUB_API_TOKEN" -s "$GITHUB_API/tags?per_page=1")
+          LATEST_MASTER=$(curl -H "Authorization: token $GITHUB_API_TOKEN" -s "$GITHUB_API/commits?per_page=1")
 
           LATEST_MASTER_SHA=$(echo "$LATEST_MASTER" | jq '.[].sha' | head -1)
           LATEST_TAG_SHA=$(echo "$LATEST_TAGS" | jq '.[].commit.sha' | head -1)


### PR DESCRIPTION
https://trello.com/c/9FQp21SD/185-investigate-authenticated-github-requests-in-deployappdownstream

Previously we used a shell variable to set the Authorization header
for the two GitHub requests we make to verify the integrity of a
requested tag, before deploying it downstream. Unfortunately, Jenkins
redacts the API token after the command is run, so the variable
literally contained "[******]". This inlines the use of the secret
token in the commands that require it.