### PR TITLE
Only fail downstream deploy if action required

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_app_downstream.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_app_downstream.yaml.erb
@@ -20,7 +20,7 @@
 
           if $DEPLOY_FREEZE; then
             echo "This application is under a deploy freeze in Release app. Aborting"
-            exit 1
+            exit 0 # Don't alert about predictable failures
           fi
       <% if @smokey_pre_check %>
       - shell: |
@@ -53,12 +53,12 @@
 
           if [ "$LATEST_TAG_NAME" != "\"$TAG\"" ]; then
             echo "The TAG parameter does not match the latest release. Aborting."
-            exit 1
+            exit 0 # Don't alert about unactionable failures
           fi
 
           if [ "$LATEST_TAG_SHA" != "$LATEST_MASTER_SHA" ]; then
             echo "The TAG to deploy is supserseded, or not on master. Aborting."
-            exit 1
+            exit 0 # Don't alert about unactionable failures
           fi
       - shell: |
           # Deploy to downstream environment


### PR DESCRIPTION
https://trello.com/c/Xa6d8HuJ/179-add-slack-govuk-developers-for-first-failures-of-the-deployappdownstream-job

Previously we marked a build of the Deploy_App_Downstream job as
failed if the goal of the job was not met (to trigger a deploy in
a downstream environment). Since adding Slack notifications, we've
had a number of false positive messages, due to predictable or
unactionable failures. While the goal of the job is not met, the
overall goal of the Continuous Deployment pipeline is:

- We only deploy the latest release of the repo (as we would manually)
- We do not deploy anything if there is a deploy freeze

This switches the exit status for predictable or unactionable failures,
so a build of the job only fails when action is required.