### PR TITLE
Enable Continuous Deployment for 5 more apps

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1018,6 +1018,11 @@ govuk_jenkins::jobs::deploy_app_downstream::applications:
   smartanswers:
     repository: 'smart-answers'
   publishing-api: {}
+  travel-advice-publisher: {}
+  government-frontend: {}
+  finder-frontend: {}
+  collections: {}
+  publisher: {}
 
 govuk_jenkins::jobs::deploy_lambda_app::lambda_apps:
   - 'email_alert_notifications'


### PR DESCRIPTION
https://trello.com/c/vFPSSGb7/175-activate-continuous-deployment-for-5-more-apps

Depends on: https://github.com/alphagov/smokey/pull/708

This is consistent with the rollout plan for this feature.