### PR TITLE
Downgrade Whitehall link check alert to warning

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/whitehall_run_broken_link_checker.pp
+++ b/modules/govuk_jenkins/manifests/jobs/whitehall_run_broken_link_checker.pp
@@ -16,9 +16,10 @@ class govuk_jenkins::jobs::whitehall_run_broken_link_checker {
   }
 
   @@icinga::passive_check { "${job_slug}_${::hostname}":
-    service_description => $service_description,
-    host_name           => $::fqdn,
-    freshness_threshold => 32 * 86400,
-    action_url          => $job_url,
+    service_description   => $service_description,
+    host_name             => $::fqdn,
+    freshness_threshold   => 32 * 86400,
+    freshness_alert_level => 'warning',
+    action_url            => $job_url,
   }
 }


### PR DESCRIPTION
This Icinga alert informs us that the rake task to check for broken links in Whitehall failed. This is not a critical alert, since there is very little user impact if this fails to run. Therefore downgrading from 'critical' to 'warning'.