### PR TITLE
Expose /healthcheck endpoint for publisher

### DIFF
--- a/modules/govuk/manifests/apps/publisher.pp
+++ b/modules/govuk/manifests/apps/publisher.pp
@@ -142,18 +142,17 @@ class govuk::apps::publisher(
   validate_re($ensure, '^(present|absent)$', 'Invalid ensure value')
 
   govuk::app { $app_name:
-    ensure              => $ensure,
-    app_type            => 'rack',
-    port                => $port,
-    sentry_dsn          => $sentry_dsn,
-    vhost_ssl_only      => true,
-    health_check_path   => '/healthcheck',
-    expose_health_check => false,
-    json_health_check   => true,
-    log_format_is_json  => true,
-    asset_pipeline      => true,
-    deny_framing        => true,
-    nginx_extra_config  => '
+    ensure             => $ensure,
+    app_type           => 'rack',
+    port               => $port,
+    sentry_dsn         => $sentry_dsn,
+    vhost_ssl_only     => true,
+    health_check_path  => '/healthcheck',
+    json_health_check  => true,
+    log_format_is_json => true,
+    asset_pipeline     => true,
+    deny_framing       => true,
+    nginx_extra_config => '
     proxy_set_header X-Sendfile-Type X-Accel-Redirect;
     proxy_set_header X-Accel-Mapping /var/apps/publisher/reports/=/raw/;
 


### PR DESCRIPTION
https://trello.com/c/vFPSSGb7/175-activate-continuous-deployment-for-5-more-apps

The original reasoning for hiding this endpoint [1] has been superseded
by many other publishing apps, which expose this endpoint [2][3].

[1]: https://github.com/alphagov/govuk-puppet/commit/7b18de8a9a4a046798ee8204a38a762dac395fd4
[2]: https://github.com/alphagov/govuk-puppet/commit/ffe22090729a8a1ea72d580925b2e4695e8ff3c0#diff-ebf0b64802b614154eb3e90a9a8f5ff4R61
[3]: https://github.com/alphagov/govuk-puppet/commit/d37875f12882666918ae436adb126dfbcd69ef50#diff-0311ac08466d9b3be654cc68f14474e8R79