### PR TITLE
Revert "Revert "Update queue latency check""

### DIFF
--- a/modules/govuk/manifests/apps/email_alert_api/checks.pp
+++ b/modules/govuk/manifests/apps/email_alert_api/checks.pp
@@ -7,12 +7,7 @@ class govuk::apps::email_alert_api::checks(
 ) {
 
   sidekiq_queue_check {
-    [
-      'process_and_generate_emails',
-      'default',
-      'email_generation_digest',
-      'cleanup',
-    ]:
+    'delivery_transactional':
       latency_warning  => '300', # 5 minutes
       latency_critical => '600'; # 10 minutes
 


### PR DESCRIPTION
This PR reverts the revert...

Reverts alphagov/govuk-puppet#10582

The original PR in all its glory can be found [here](https://github.com/alphagov/govuk-puppet/pull/10574). This was reverted to clear the puppet pipeline for an emergency deploy.
