### PR TITLE
Add a Grafana dashboard showing Bouncer errors

### DIFF
--- a/modules/grafana/files/dashboards/platform_health_Q2_20-21_bouncer_errors.json
+++ b/modules/grafana/files/dashboards/platform_health_Q2_20-21_bouncer_errors.json
@@ -1,0 +1,163 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "hideControls": false,
+  "id": 42,
+  "links": [],
+  "refresh": false,
+  "rows": [
+    {
+      "collapse": false,
+      "height": "650px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": true,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Graphite",
+          "fill": 1,
+          "id": 1,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": false,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "30 day average",
+              "bars": false,
+              "fill": 0,
+              "lines": true,
+              "linewidth": 6
+            },
+            {
+              "alias": "Last 30 day average - 50% (target)",
+              "bars": false,
+              "fill": 0,
+              "lines": true,
+              "linewidth": 4
+            },
+            {
+              "alias": "Target",
+              "bars": false,
+              "fill": 0,
+              "lines": true,
+              "linewidth": 4
+            }
+          ],
+          "spaceLength": 10,
+          "span": 12,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "hide": false,
+              "refId": "A",
+              "target": "alias(summarize(stats.gauges.sentry-error-count-last-hour.bouncer, '1d', 'sum', false), 'Errors per day')"
+            },
+            {
+              "refId": "B",
+              "target": "alias(movingAverage(summarize(stats.gauges.sentry-error-count-last-hour.bouncer, '1d', 'sum', true), '30d'), '30 day average')"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": "Sentry error count per day",
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    }
+  ],
+  "schemaVersion": 14,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-90d",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Platform Health - Q2 (20-21) Bouncer errors",
+  "version": 2
+}

--- a/modules/grafana/files/dashboards/platform_health_Q2_20-21_bouncer_errors.json
+++ b/modules/grafana/files/dashboards/platform_health_Q2_20-21_bouncer_errors.json
@@ -115,8 +115,8 @@
     "list": []
   },
   "time": {
-    "from": "2019-10-06T23:00:00.000Z",
-    "to": "2019-11-30T00:00:00.000Z"
+    "from": "now-90d",
+    "to": "now"
   },
   "timepicker": {
     "refresh_intervals": [

--- a/modules/grafana/files/dashboards/platform_health_Q2_20-21_bouncer_errors.json
+++ b/modules/grafana/files/dashboards/platform_health_Q2_20-21_bouncer_errors.json
@@ -46,20 +46,6 @@
               "fill": 0,
               "lines": true,
               "linewidth": 6
-            },
-            {
-              "alias": "Last 30 day average - 50% (target)",
-              "bars": false,
-              "fill": 0,
-              "lines": true,
-              "linewidth": 4
-            },
-            {
-              "alias": "Target",
-              "bars": false,
-              "fill": 0,
-              "lines": true,
-              "linewidth": 4
             }
           ],
           "spaceLength": 10,
@@ -129,8 +115,8 @@
     "list": []
   },
   "time": {
-    "from": "now-90d",
-    "to": "now"
+    "from": "2019-10-06T23:00:00.000Z",
+    "to": "2019-11-30T00:00:00.000Z"
   },
   "timepicker": {
     "refresh_intervals": [
@@ -159,5 +145,5 @@
   },
   "timezone": "",
   "title": "Platform Health - Q2 (20-21) Bouncer errors",
-  "version": 2
+  "version": 3
 }

--- a/modules/grafana/files/dashboards/platform_health_Q3_19-20_whitehall_errors.json
+++ b/modules/grafana/files/dashboards/platform_health_Q3_19-20_whitehall_errors.json
@@ -6,7 +6,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "hideControls": false,
-  "id": null,
+  "id": 42,
   "links": [],
   "refresh": false,
   "rows": [
@@ -48,13 +48,6 @@
               "linewidth": 6
             },
             {
-              "alias": "Last 30 day average - 50% (target)",
-              "bars": false,
-              "fill": 0,
-              "lines": true,
-              "linewidth": 4
-            },
-            {
               "alias": "Target",
               "bars": false,
               "fill": 0,
@@ -70,20 +63,17 @@
             {
               "hide": false,
               "refId": "A",
-              "target": "alias(summarize(stats.gauges.sentry-error-count-last-hour.whitehall, '1d', 'sum', false), 'Errors per day')"
+              "target": "alias(summarize(stats.gauges.sentry-error-count-last-hour.bouncer, '1d', 'sum', false), 'Errors per day')"
             },
             {
               "refId": "B",
-              "target": "alias(movingAverage(summarize(stats.gauges.sentry-error-count-last-hour.whitehall, '1d', 'sum', true), '30d'), '30 day average')"
+              "target": "alias(movingAverage(summarize(stats.gauges.sentry-error-count-last-hour.bouncer, '1d', 'sum', true), '30d'), '30 day average')"
             },
             {
-              "hide": true,
+              "hide": false,
               "refId": "C",
-              "target": "alias(timeShift(scale(summarize(summarize(stats.gauges.sentry-error-count-last-hour.whitehall, '1d', 'sum', true), '30d', 'avg', false), 0.5), '30d'), 'Last 30 day average - 50% (target)')"
-            },
-            {
-              "refId": "D",
-              "target": "alias(constantLine(6000), 'Target')"
+              "target": "alias(constantLine(5500), 'Target')",
+              "textEditor": false
             }
           ],
           "thresholds": [],
@@ -138,8 +128,8 @@
     "list": []
   },
   "time": {
-    "from": "2019-10-06T23:00:00.000Z",
-    "to": "2019-11-30T00:00:00.000Z"
+    "from": "now-90d",
+    "to": "now"
   },
   "timepicker": {
     "refresh_intervals": [
@@ -167,6 +157,6 @@
     ]
   },
   "timezone": "",
-  "title": "Platform Health - Q3 (19-20) Whitehall errors",
+  "title": "Platform Health - Q2 (20-21) Bouncer errors",
   "version": 4
 }

--- a/modules/grafana/files/dashboards/platform_health_Q3_19-20_whitehall_errors.json
+++ b/modules/grafana/files/dashboards/platform_health_Q3_19-20_whitehall_errors.json
@@ -6,7 +6,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "hideControls": false,
-  "id": 42,
+  "id": null,
   "links": [],
   "refresh": false,
   "rows": [
@@ -48,6 +48,13 @@
               "linewidth": 6
             },
             {
+              "alias": "Last 30 day average - 50% (target)",
+              "bars": false,
+              "fill": 0,
+              "lines": true,
+              "linewidth": 4
+            },
+            {
               "alias": "Target",
               "bars": false,
               "fill": 0,
@@ -63,17 +70,20 @@
             {
               "hide": false,
               "refId": "A",
-              "target": "alias(summarize(stats.gauges.sentry-error-count-last-hour.bouncer, '1d', 'sum', false), 'Errors per day')"
+              "target": "alias(summarize(stats.gauges.sentry-error-count-last-hour.whitehall, '1d', 'sum', false), 'Errors per day')"
             },
             {
               "refId": "B",
-              "target": "alias(movingAverage(summarize(stats.gauges.sentry-error-count-last-hour.bouncer, '1d', 'sum', true), '30d'), '30 day average')"
+              "target": "alias(movingAverage(summarize(stats.gauges.sentry-error-count-last-hour.whitehall, '1d', 'sum', true), '30d'), '30 day average')"
             },
             {
-              "hide": false,
+              "hide": true,
               "refId": "C",
-              "target": "alias(constantLine(5500), 'Target')",
-              "textEditor": false
+              "target": "alias(timeShift(scale(summarize(summarize(stats.gauges.sentry-error-count-last-hour.whitehall, '1d', 'sum', true), '30d', 'avg', false), 0.5), '30d'), 'Last 30 day average - 50% (target)')"
+            },
+            {
+              "refId": "D",
+              "target": "alias(constantLine(6000), 'Target')"
             }
           ],
           "thresholds": [],
@@ -128,8 +138,8 @@
     "list": []
   },
   "time": {
-    "from": "now-90d",
-    "to": "now"
+    "from": "2019-10-06T23:00:00.000Z",
+    "to": "2019-11-30T00:00:00.000Z"
   },
   "timepicker": {
     "refresh_intervals": [
@@ -157,6 +167,6 @@
     ]
   },
   "timezone": "",
-  "title": "Platform Health - Q2 (20-21) Bouncer errors",
+  "title": "Platform Health - Q3 (19-20) Whitehall errors",
   "version": 4
 }


### PR DESCRIPTION
This is to help measure the impact of Platform Health team work to reduce Bouncer errors. I've added a target of 50% of the current 30 day average.

[Trello](https://trello.com/c/rG9oDZLQ/2085-3-build-dashboard-showing-bouncer-errors)