### PR TITLE
Update Travel and "drug" checks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -426,7 +426,6 @@ task :check_consistency_between_aws_and_carrenza do
     govuk_jenkins::jobs::deploy_app::graphite_host
     govuk_jenkins::jobs::deploy_app::graphite_port
     govuk_jenkins::jobs::deploy_emergency_banner::clear_cdn_cache
-    govuk_jenkins::jobs::email_alert_check::email_addresses_to_check
     govuk_jenkins::jobs::passive_checks::alert_hostname
     govuk_pgbouncer::admin::rds
     govuk_pgbouncer::db::lb_ip_range

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -994,15 +994,6 @@ govuk_jenkins::config::github_api_uri: "https://api.github.com"
 govuk_jenkins::config::github_web_uri: "https://github.com"
 govuk_jenkins::jobs::deploy_app::app_domain: "%{hiera('app_domain')}"
 
-govuk_jenkins::jobs::email_alert_check::email_addresses_to_check: >-
-  govuk-email-courtesy-copies@digital.cabinet-office.gov.uk
-  ,
-  govuk-email-courtesy-copies@digital.cabinet-office.gov.uk
-  :
-  govuk_email_check@digital.cabinet-office.gov.uk
-  ,
-  gov.uk.email@notifications.service.gov.uk
-
 govuk_jenkins::jobs::passive_checks::alert_hostname: 'alert'
 
 govuk_jenkins::jobs::smokey::auth_username: "%{hiera('http_username')}"

--- a/modules/govuk_jenkins/manifests/jobs/email_alert_check.pp
+++ b/modules/govuk_jenkins/manifests/jobs/email_alert_check.pp
@@ -13,14 +13,8 @@
 # [*google_client_secret*]
 #   Google app client secret.
 #
-# [*emails_that_should_receive_drug_alerts*]
-#   Email addresses subscribed to drug alerts.
-#
-# [*emails_that_should_receive_travel_advice_alerts*]
-#   Email addresses subscribed to travel advice alerts.
-#
-# [*emails_that_should_send_alerts*]
-#   Email addresses that send alerts.
+# [*email_addresses_to_check*]
+#   Email addresses to check.
 #
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
@@ -29,8 +23,6 @@ class govuk_jenkins::jobs::email_alert_check (
   $google_oauth_credentials = undef,
   $google_client_id = undef,
   $google_client_secret = undef,
-  $emails_that_should_receive_drug_alerts = undef,
-  $emails_that_should_receive_travel_advice_alerts = undef,
   $email_addresses_to_check = undef,
   $app_domain = hiera('app_domain'),
   $sentry_dsn = undef,

--- a/modules/govuk_jenkins/manifests/jobs/email_alert_check.pp
+++ b/modules/govuk_jenkins/manifests/jobs/email_alert_check.pp
@@ -13,9 +13,6 @@
 # [*google_client_secret*]
 #   Google app client secret.
 #
-# [*email_addresses_to_check*]
-#   Email addresses to check.
-#
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
@@ -23,7 +20,6 @@ class govuk_jenkins::jobs::email_alert_check (
   $google_oauth_credentials = undef,
   $google_client_id = undef,
   $google_client_secret = undef,
-  $email_addresses_to_check = undef,
   $app_domain = hiera('app_domain'),
   $sentry_dsn = undef,
 ) {

--- a/modules/govuk_jenkins/manifests/jobs/email_alert_check.pp
+++ b/modules/govuk_jenkins/manifests/jobs/email_alert_check.pp
@@ -28,17 +28,17 @@ class govuk_jenkins::jobs::email_alert_check (
   $sentry_dsn = undef,
 ) {
 
-  $drug_check_name = 'email_alert_check'
-  $drug_service_description = 'Email alert check'
-  $drug_job_url = "https://deploy.blue.${::aws_environment}.govuk.digital/job/email-alert-check/"
+  $medical_safety_check_name = 'medical_safety_email_alert_check'
+  $medical_safety_service_description = 'Medical Safety Email alert check'
+  $medical_safety_job_url = "https://deploy.blue.${::aws_environment}.govuk.digital/job/medical-safety-email-alert-check/"
   $travel_advice_check_name = 'travel_advice_email_alert_check'
   $travel_advice_service_description = 'Travel Advice email alert check'
   $travel_advice_job_url = "https://deploy.blue.${::aws_environment}.govuk.digital/job/travel-advice-email-alert-check/"
 
   file {
-    '/etc/jenkins_jobs/jobs/drug_email_alert_check.yaml':
+    '/etc/jenkins_jobs/jobs/medical_safety_email_alert_check.yaml':
       ensure  => present,
-      content => template('govuk_jenkins/jobs/drug_email_alert_check.yaml.erb'),
+      content => template('govuk_jenkins/jobs/medical_safety_email_alert_check.yaml.erb'),
       notify  => Exec['jenkins_jobs_update'];
     '/etc/jenkins_jobs/jobs/travel_advice_email_alert_check.yaml':
       ensure  => present,
@@ -47,13 +47,13 @@ class govuk_jenkins::jobs::email_alert_check (
   }
 
   @@icinga::passive_check {
-    "${drug_check_name}_${::hostname}":
-      service_description     => $drug_service_description,
+    "${medical_safety_check_name}_${::hostname}":
+      service_description     => $medical_safety_service_description,
       host_name               => $::fqdn,
       freshness_threshold     => 5400, # 90 minutes
       freshness_alert_level   => 'critical',
       freshness_alert_message => 'Jenkins job has stopped running or is unstable',
-      action_url              => $drug_job_url,
+      action_url              => $medical_safety_job_url,
       notes_url               => monitoring_docs_url(email-alerts);
     "${travel_advice_check_name}_${::hostname}":
       service_template        => 'govuk_urgent_priority',

--- a/modules/govuk_jenkins/templates/jobs/drug_email_alert_check.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/drug_email_alert_check.yaml.erb
@@ -57,9 +57,6 @@
               - name: GOOGLE_CLIENT_SECRET
                 password:
                   '<%= @google_client_secret %>'
-              - name: EMAILS_THAT_SHOULD_RECEIVE_DRUG_ALERTS
-                password:
-                  '<%= @emails_that_should_receive_drug_alerts %>'
               - name: EMAIL_ADDRESSES_TO_CHECK
                 password: '<%= @email_addresses_to_check %>'
               - name: SENTRY_DSN

--- a/modules/govuk_jenkins/templates/jobs/medical_safety_email_alert_check.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/medical_safety_email_alert_check.yaml.erb
@@ -1,9 +1,8 @@
----
 - job:
-    name: email-alert-check
-    display-name: EmailAlertCheck
+    name: medical-safety-email-alert-check
+    display-name: MedicalSafetyEmailAlertCheck
     project-type: freestyle
-    description: "This job checks if drug device email alerts have been emailed"
+    description: "This job checks if medical safety email alerts have been emailed"
     logrotate:
         numToKeep: 100
     triggers:
@@ -34,13 +33,13 @@
         - project: Success_Passive_Check
           condition: 'SUCCESS'
           predefined-parameters: |
-            NSCA_CHECK_DESCRIPTION=<%= @drug_service_description %>
-            NSCA_OUTPUT=<%= @drug_service_description %> success
+            NSCA_CHECK_DESCRIPTION=<%= @medical_safety_service_description %>
+            NSCA_OUTPUT=<%= @medical_safety_service_description %> success
         - project: Failure_Passive_Check
           condition: 'FAILED'
           predefined-parameters: |
-            NSCA_CHECK_DESCRIPTION=<%= @drug_service_description %>
-            NSCA_OUTPUT=<%= @drug_service_description %> failed
+            NSCA_CHECK_DESCRIPTION=<%= @medical_safety_service_description %>
+            NSCA_OUTPUT=<%= @medical_safety_service_description %> failed
     wrappers:
         - ansicolor:
             colormap: xterm

--- a/modules/govuk_jenkins/templates/jobs/medical_safety_email_alert_check.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/medical_safety_email_alert_check.yaml.erb
@@ -56,8 +56,6 @@
               - name: GOOGLE_CLIENT_SECRET
                 password:
                   '<%= @google_client_secret %>'
-              - name: EMAIL_ADDRESSES_TO_CHECK
-                password: '<%= @email_addresses_to_check %>'
               - name: SENTRY_DSN
                 password:
                   '<%= @sentry_dsn %>'

--- a/modules/govuk_jenkins/templates/jobs/medical_safety_email_alert_check.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/medical_safety_email_alert_check.yaml.erb
@@ -22,7 +22,7 @@
 
               cd email-alert-monitoring
               bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
-              bundle exec rake run
+              bundle exec rake run_medical_alerts
             unstable-return: 1
     publishers:
       - text-finder:

--- a/modules/govuk_jenkins/templates/jobs/travel_advice_email_alert_check.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/travel_advice_email_alert_check.yaml.erb
@@ -57,9 +57,6 @@
               - name: GOOGLE_CLIENT_SECRET
                 password:
                   '<%= @google_client_secret %>'
-              - name: EMAILS_THAT_SHOULD_RECEIVE_TRAVEL_ADVICE_ALERTS
-                password:
-                  '<%= @emails_that_should_receive_travel_advice_alerts %>'
               - name: EMAIL_ADDRESSES_TO_CHECK
                 password: '<%= @email_addresses_to_check %>'
               - name: SENTRY_DSN

--- a/modules/govuk_jenkins/templates/jobs/travel_advice_email_alert_check.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/travel_advice_email_alert_check.yaml.erb
@@ -57,8 +57,6 @@
               - name: GOOGLE_CLIENT_SECRET
                 password:
                   '<%= @google_client_secret %>'
-              - name: EMAIL_ADDRESSES_TO_CHECK
-                password: '<%= @email_addresses_to_check %>'
               - name: SENTRY_DSN
                 password:
                   '<%= @sentry_dsn %>'


### PR DESCRIPTION
Updates the naming of our "drug" alert to be more reflective of what it actually does. 

These were known as drug alerts or drug device alerts from this check
but from looking at their document type and what Specialist Publisher
(publishing app) calls them then I concluded they should be referred to
as Medical Safety alerts.

Also removes some unused legacy variables and moves the setting of the checks 
email addresses to the monitoring application (email-alert-monitoring).

Related PR:
https://github.com/alphagov/govuk-secrets/pull/1037

Depends on:
https://github.com/alphagov/email-alert-monitoring/pull/67

Trello:
https://trello.com/c/kfZC9tes/455-improve-drug-and-travel-advice-checks