### PR TITLE
Revert "Only fail downstream deploy if action required"

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_app_downstream.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_app_downstream.yaml.erb
@@ -20,7 +20,7 @@
 
           if $DEPLOY_FREEZE; then
             echo "This application is under a deploy freeze in Release app. Aborting"
-            exit 0 # Don't alert about predictable failures
+            exit 1
           fi
       <% if @smokey_pre_check %>
       - shell: |
@@ -53,12 +53,12 @@
 
           if [ "$LATEST_TAG_NAME" != "\"$TAG\"" ]; then
             echo "The TAG parameter does not match the latest release. Aborting."
-            exit 0 # Don't alert about unactionable failures
+            exit 1
           fi
 
           if [ "$LATEST_TAG_SHA" != "$LATEST_MASTER_SHA" ]; then
             echo "The TAG to deploy is supserseded, or not on master. Aborting."
-            exit 0 # Don't alert about unactionable failures
+            exit 1
           fi
       - shell: |
           # Deploy to downstream environment


### PR DESCRIPTION
https://trello.com/b/kmruvfMm/govuk-developer-tools

Reverts alphagov/govuk-puppet#10588

Unfortunately Jenkins continues executing later job stages 
when an earlier stage returns an exit status of "0", so this is 
not a valid strategy for gracefully aborting a job. We need to 
rethink how we can maintain the integrity checks of the CD 
pipeline, while also only alerting if action is required.