### PR TITLE
Only fail downstream deploys if action required

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_app_downstream.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_app_downstream.yaml.erb
@@ -29,7 +29,7 @@
 
           if $DEPLOY_FREEZE; then
             echo "This application is under a deploy freeze in Release app. Aborting"
-            exit 1
+            exit 0 # Don't alert about predictable failures
           fi
 
           # Workaround for our inconsistent repo vs. deployment naming
@@ -53,12 +53,12 @@
 
           if [ "$LATEST_TAG_NAME" != "\"$TAG\"" ]; then
             echo "The TAG parameter does not match the latest release. Aborting."
-            exit 1
+            exit 0 # Don't alert about predictable failures
           fi
 
           if [ "$LATEST_TAG_SHA" != "$LATEST_MASTER_SHA" ]; then
             echo "The TAG to deploy is supserseded, or not on master. Aborting."
-            exit 1
+            exit 0 # Don't alert about predictable failures
           fi
 
           # Deploy to downstream environment

--- a/modules/govuk_jenkins/templates/jobs/deploy_app_downstream.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_app_downstream.yaml.erb
@@ -95,7 +95,7 @@
             auth-token-id: <%= @slack_credential_id %>
             auth-token-credential-id: <%= @slack_credential_id %>
             build-server-url: <%= @slack_build_server_url %>
-            notify-failure: true
+            notify-every-failure: true
             room: "<%= @slack_channel %>"
             include-custom-message: true
             custom-message: "Automatic deployment failed for $TARGET_APPLICATION $TAG"

--- a/modules/govuk_jenkins/templates/jobs/deploy_app_downstream.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_app_downstream.yaml.erb
@@ -9,6 +9,15 @@
           days-to-keep: 30
           artifact-num-to-keep: 5
     builders:
+      <% if @smokey_pre_check %>
+      - shell: |
+          # Wait for any app restarts to complete before running Smokey
+          sleep 60
+      - trigger-builds:
+          - project: Smokey
+            current-parameters: true
+            block: true
+      <% end %>
       - shell: |
           # Check for deploy freeze set in Release App
           APPLICATION_METADATA=$(curl -s \
@@ -22,16 +31,7 @@
             echo "This application is under a deploy freeze in Release app. Aborting"
             exit 1
           fi
-      <% if @smokey_pre_check %>
-      - shell: |
-          # Wait for any app restarts to complete before running Smokey
-          sleep 60
-      - trigger-builds:
-          - project: Smokey
-            current-parameters: true
-            block: true
-      <% end %>
-      - shell: |
+
           # Workaround for our inconsistent repo vs. deployment naming
           case "$TARGET_APPLICATION" in
           <% @applications.keys.each do |app| %>
@@ -60,7 +60,7 @@
             echo "The TAG to deploy is supserseded, or not on master. Aborting."
             exit 1
           fi
-      - shell: |
+
           # Deploy to downstream environment
           JSON="{\"parameter\": [{\"name\": \"TARGET_APPLICATION\", \"value\": \"$TARGET_APPLICATION\"}, {\"name\": \"TAG\", \"value\": \"$TAG\"}, {\"name\": \"DEPLOY_TASK\", \"value\": \"deploy\"}, {\"name\": \"NOTIFY_RELEASE_APP\", \"value\": \"true\"}, {\"name\": \"SLACK_NOTIFICATIONS\", \"value\": \"true\"}], \"\": \"\"}"
           CRUMB=$(curl https://<%= @jenkins_downstream_api_user %>:<%= @jenkins_downstream_api_password %>@<%= @deploy_url %>/crumbIssuer/api/json | jq --raw-output '. | .crumb')


### PR DESCRIPTION
https://trello.com/c/Xa6d8HuJ/179-add-slack-govuk-developers-for-first-failures-of-the-deployappdownstream-job

    Previously we attempted to use a "0" exit status to silently abort
    this job when there are predictable failures. However, having the
    exit statements in separate shell steps from the final trigger means
    means the trigger (and other steps) are still executed [1]. This
    combines the shell steps together, so that we can gracefully fail
    the job (no Slack message) without triggering a deploy at the end.
    
    [1]: https://github.com/alphagov/govuk-puppet/pull/10600