### PR TITLE
govuk::apps::ckan: add a `timeout` parameter to `paster_cronjob`, use for `harvester run`

### DIFF
--- a/modules/govuk/manifests/apps/ckan/cronjobs.pp
+++ b/modules/govuk/manifests/apps/ckan/cronjobs.pp
@@ -35,7 +35,7 @@ class govuk::apps::ckan::cronjobs(
     false => 'absent',
   }
 
-  govuk::apps::ckan::paster_cronjob { 'harvester reindex':
+  govuk::apps::ckan::paster_cronjob { 'index missing packages':
     ensure         => $ensure_solr_reindex,
     paster_command => 'search-index rebuild -o',
     plugin         => 'ckan',

--- a/modules/govuk/manifests/apps/ckan/cronjobs.pp
+++ b/modules/govuk/manifests/apps/ckan/cronjobs.pp
@@ -20,6 +20,8 @@ class govuk::apps::ckan::cronjobs(
     paster_command => 'harvester run',
     plugin         => 'ckanext-harvest',
     minute         => '*/5',
+    # timeout shorter than repeat period to prevent stalling runs stacking up
+    timeout        => '4m',
   }
 
   govuk::apps::ckan::paster_cronjob { 'harvester cleanup':

--- a/modules/govuk/manifests/apps/ckan/paster_cronjob.pp
+++ b/modules/govuk/manifests/apps/ckan/paster_cronjob.pp
@@ -17,6 +17,10 @@
 # [*paster_command*]
 # Paster command to run eg "archiver update"
 #
+# [*timeout*]
+# Duration after which to terminate command. See man 1 timeout for
+# possible values.
+#
 define govuk::apps::ckan::paster_cronjob (
   $ensure = present,
   $hour = undef,
@@ -26,6 +30,7 @@ define govuk::apps::ckan::paster_cronjob (
   $weekday = undef,
   $plugin = undef,
   $paster_command = undef,
+  $timeout = undef,
   $ckan_ini = '/var/ckan/ckan.ini',
 ) {
   validate_string($plugin, $paster_command)
@@ -36,9 +41,15 @@ define govuk::apps::ckan::paster_cronjob (
     $ckan_config_arg = ''
   }
 
+  if $timeout {
+    $timeout_cmd = "/usr/bin/timeout ${timeout}"
+  } else {
+    $timeout_cmd = ''
+  }
+
   cron { $title:
     ensure   => $ensure,
-    command  => "cd /var/apps/ckan; ./venv/bin/paster --plugin=${plugin} ${paster_command} ${ckan_config_arg}",
+    command  => "cd /var/apps/ckan; ${timeout_cmd} ./venv/bin/paster --plugin=${plugin} ${paster_command} ${ckan_config_arg}",
     user     => 'deploy',
     hour     => $hour,
     minute   => $minute,


### PR DESCRIPTION
https://trello.com/c/Yp9YzdEn

Set with a timeout period shorter than the cron repeat period, this should stop `harvester run` cronjobs stacking up on top of each other and saturating db connections if one of them hangs for some reason. This is still just a mitigation of one of the symptoms of a deadlocking problem I believe is in the harvest fetch consumer's db transaction handling.

Was originally going to use `flock` instead of `timeout`, but that alone would've just allowed a misbehaving `harvester run` run block out all others. I really don't _think_ there's a legitimate reason for `harvester run` to take any significant time...?