### PR TITLE
Cache by host as well as the path ("url")

### DIFF
--- a/modules/varnish/templates/default.vcl.erb
+++ b/modules/varnish/templates/default.vcl.erb
@@ -183,11 +183,6 @@ sub vcl_fetch {
   set beresp.http.x-url = req.url;
 }
 
-sub vcl_hash {
-  hash_data(req.url);
-  return(hash);
-}
-
 sub vcl_deliver {
   # Add a custom header to indicate whether we hit the cache or not
   if (obj.hits > 0) {


### PR DESCRIPTION
https://trello.com/c/vFPSSGb7/175-activate-continuous-deployment-for-5-more-apps

    Previously we only used the path of a request as the cache key,
    which leads to surprising outcomes, since the value of the cache
    is an absolute URL. This stops overriding the Varnish default [2],
    so we cache based on the host of the request, as well as the path.
    
    For example, if a request to 'www-origin/foo' return a redirect
    to 'www-origin/bar', we would cache this using '/foo' as the key;
    a subsequent reques to 'www/foo' would then return the cached
    redirect of 'www-origin/bar', instead of the correct redirect of
    'www/bar'. Issues caused by this:
    
    - In production, a cached 'www-origin' redirect would lead to a
    network error for users, since 'www-origin' is behind a firewall.
    
    - In integration, a cached 'www-origin' redirect would lead to a
    401 Unauthorized response, since it requires basic auth to access.
    
    We think this is likely the cause of many a transient Smokey test
    failing in Integration, in steps where we click on a button and
    get redirected. Note that Smokey, while does provide the required
    basic auth credentials, it only does this for the 'www' domain [1].
    
    [1]: https://varnish-cache.org/docs/3.0/reference/vcl.html
    [2]: https://github.com/alphagov/smokey/commit/d8847c4d03b0c416cf9f5d29607184acd566c4fd#diff-57013262a6cdf1f0f6cb2c64aa762c68R49

## Example of this problem in production

![Screenshot 2020-08-13 at 16 45 50](https://user-images.githubusercontent.com/9029009/90159144-de697c80-dd87-11ea-950f-f161714672f7.png)
