### PR TITLE
govuk::apps::ckan: add a maintenance_mode

### DIFF
--- a/modules/govuk/manifests/apps/ckan.pp
+++ b/modules/govuk/manifests/apps/ckan.pp
@@ -55,6 +55,7 @@
 #
 class govuk::apps::ckan (
   $enabled                        = false,
+  $maintenance_mode               = false,
   $port,
   $pycsw_port,
   $db_hostname                    = undef,
@@ -187,6 +188,8 @@ class govuk::apps::ckan (
         varname => 'PYCSW_CONFIG',
         value   => $pycsw_config;
     }
+
+    include maintenance
 
     govuk::app::nginx_vhost { 'ckan':
       vhost              => 'ckan',

--- a/modules/govuk/manifests/apps/ckan.pp
+++ b/modules/govuk/manifests/apps/ckan.pp
@@ -55,7 +55,7 @@
 #
 class govuk::apps::ckan (
   $enabled                        = false,
-  $maintenance_mode               = false,
+  $maintenance_mode               = true,
   $port,
   $pycsw_port,
   $db_hostname                    = undef,

--- a/modules/govuk/manifests/apps/ckan/maintenance.pp
+++ b/modules/govuk/manifests/apps/ckan/maintenance.pp
@@ -1,0 +1,18 @@
+# == Class: govuk::apps::ckan::maintenance
+#
+# Ensure the machine has a static copy of the scheduled maintenance
+# html page.
+#
+class govuk::apps::ckan::maintenance {
+  file { '/usr/share/nginx/www':
+    ensure  => directory,
+    mode    => '0755',
+    owner   => 'deploy',
+    group   => 'deploy',
+    require => Class['nginx::package'],
+  }
+
+  router::errorpage { 'scheduled_maintenance':
+    require => File['/usr/share/nginx/www'],
+  }
+}

--- a/modules/govuk/templates/ckan/nginx.conf.erb
+++ b/modules/govuk/templates/ckan/nginx.conf.erb
@@ -17,7 +17,7 @@ location = /scheduled-maintenance {
 # that this config is injected into specifies a number of `location`s itself that
 # we wouldn't otherwise be able to override.
 absolute_redirect off;
-rewrite ^/(?!(scheduled-maintenance))$ /scheduled-maintenance redirect;
+rewrite ^/(?!(scheduled-maintenance)).*$ /scheduled-maintenance redirect;
 <%- end -%>
 
 # Guard against open redirects from CKAN for requests with paths like

--- a/modules/govuk/templates/ckan/nginx.conf.erb
+++ b/modules/govuk/templates/ckan/nginx.conf.erb
@@ -1,3 +1,25 @@
+
+<%- if @maintenance_mode -%>
+error_page 503 /scheduled_maintenance.html;
+
+location = /scheduled_maintenance.html {
+  root /usr/share/nginx/www;
+}
+location = /scheduled-maintenance {
+  return 503;
+}
+
+# doing an internal redirect from within a `server` block like this will cause
+# `error_page` to be ignored and an ugly error page to be returned. to get
+# around this, we have to do an *external* redirect to the error page (for
+# any request that *isn't* already requesting the error page, obviously).
+# we *have* to do the redirect from the `server` block because the base template
+# that this config is injected into specifies a number of `location`s itself that
+# we wouldn't otherwise be able to override.
+absolute_redirect off;
+rewrite ^/(?!(scheduled-maintenance))$ /scheduled-maintenance redirect;
+<%- end -%>
+
 # Guard against open redirects from CKAN for requests with paths like
 # the following, starting with two forward slashes and a trailing
 # slash: //www.gov.uk/


### PR DESCRIPTION
https://trello.com/c/WjOK9SKl

The fetching of the static error page is heavily cribbed from how the loadbalancer does this, and the actual redirection mechanism is depressingly complex due to how the nginx conf *outside* of govuk::apps:ckan's control is organized. Hopefully I've commented it enough to make some sense though.