### PR TITLE
Remove licensify SES credentials

### DIFF
--- a/hieradata/vagrant_credentials.yaml
+++ b/hieradata/vagrant_credentials.yaml
@@ -161,13 +161,6 @@ http_password: 'password'
 
 icinga::plugin::check_rabbitmq_consumers::monitoring_password: "%{hiera('govuk_rabbitmq::monitoring_password')}"
 
-licensify::apps::licensify::aws_ses_access_key: 'REDACTED'
-licensify::apps::licensify::aws_ses_secret_key: 'REDACTED'
-licensify::apps::licensify_admin::aws_ses_access_key: 'REDACTED'
-licensify::apps::licensify_admin::aws_ses_secret_key: 'REDACTED'
-licensify::apps::licensify_feed::aws_ses_access_key: 'REDACTED'
-licensify::apps::licensify_feed::aws_ses_secret_key: 'REDACTED'
-
 mysql_nagios: 'icAdipalapcebquoskurdibVufGuirWu'
 mysql_replica_password: 'YCnaJ5h42rTGqdpgCUct4EzjAfwQUkhN'
 mysql_root: 'T6J6wHjns2UdjVE1dLOu7BdIIq1NDVS9'

--- a/hieradata_aws/vagrant_credentials.yaml
+++ b/hieradata_aws/vagrant_credentials.yaml
@@ -164,13 +164,6 @@ http_password: 'password'
 
 icinga::plugin::check_rabbitmq_consumers::monitoring_password: "%{hiera('govuk_rabbitmq::monitoring_password')}"
 
-licensify::apps::licensify::aws_ses_access_key: 'REDACTED'
-licensify::apps::licensify::aws_ses_secret_key: 'REDACTED'
-licensify::apps::licensify_admin::aws_ses_access_key: 'REDACTED'
-licensify::apps::licensify_admin::aws_ses_secret_key: 'REDACTED'
-licensify::apps::licensify_feed::aws_ses_access_key: 'REDACTED'
-licensify::apps::licensify_feed::aws_ses_secret_key: 'REDACTED'
-
 mysql_nagios: 'icAdipalapcebquoskurdibVufGuirWu'
 mysql_replica_password: 'YCnaJ5h42rTGqdpgCUct4EzjAfwQUkhN'
 mysql_root: 'T6J6wHjns2UdjVE1dLOu7BdIIq1NDVS9'


### PR DESCRIPTION
Licensify sends emails using GOV.UK Notify, and these were only for development VM anyway. They're not referenced anywhere else in the app.