### PR TITLE
Remove postfix

### DIFF
--- a/modules/postfix/manifests/config.pp
+++ b/modules/postfix/manifests/config.pp
@@ -21,6 +21,7 @@
 #   The mail user/list name to use in the rewrite rules
 #
 class postfix::config(
+  $ensure = present,
   $smarthost,
   $smarthost_user,
   $smarthost_pass,
@@ -29,11 +30,12 @@ class postfix::config(
 ) {
 
   file { '/etc/mailname':
-    ensure  => present,
+    ensure  => $ensure,
     content => "${::fqdn}\n",
   }
 
   file { '/etc/postfix/main.cf':
+    ensure  => $ensure,
     content => template('postfix/etc/postfix/main.cf.erb'),
     notify  => Service[postfix],
     require => File['/etc/mailname'],
@@ -42,14 +44,17 @@ class postfix::config(
   if $smarthost {
 
     postfix::postmapfile { 'outbound_rewrites':
+      ensure  => $ensure,
       content => template('postfix/etc/postfix/outbound_rewrites.erb'),
     }
     postfix::postmapfile { 'local_remote_rewrites':
+      ensure  => $ensure,
       content => template('postfix/etc/postfix/local_remote_rewrites.erb'),
     }
 
     if ($smarthost_user and $smarthost_pass) {
       postfix::postmapfile { 'sasl_passwd':
+        ensure  => $ensure,
         content => template('postfix/etc/postfix/sasl_passwd.erb'),
       }
     }

--- a/modules/postfix/manifests/init.pp
+++ b/modules/postfix/manifests/init.pp
@@ -31,13 +31,16 @@ class postfix (
 ) {
 
   anchor { 'postfix::begin':
+    ensure => absent,
     notify => Class['postfix::service'];
   }
   class { 'postfix::package':
+    ensure => absent,
     require => Anchor['postfix::begin'],
     notify  => Class['postfix::service'];
   }
   class { 'postfix::config':
+    ensure => absent,
     smarthost           => $smarthost,
     smarthost_user      => $smarthost_user,
     smarthost_pass      => $smarthost_pass,
@@ -46,8 +49,11 @@ class postfix (
     require             => Class['postfix::package'],
     notify              => Class['postfix::service'];
   }
-  class { 'postfix::service': }
+  class { 'postfix::service':
+    ensure => absent,
+  }
   anchor { 'postfix::end':
+    ensure => absent,
     require => Class['postfix::service'],
   }
 

--- a/modules/postfix/manifests/package.pp
+++ b/modules/postfix/manifests/package.pp
@@ -2,8 +2,8 @@
 #
 # Manage the postfix package
 #
-class postfix::package {
+class postfix::package($ensure = installed) {
   package { 'postfix':
-    ensure => installed,
+    ensure  => $ensure,
   }
 }

--- a/modules/postfix/manifests/postmapfile.pp
+++ b/modules/postfix/manifests/postmapfile.pp
@@ -1,18 +1,19 @@
 # FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
 define postfix::postmapfile(
+  $ensure = present,
   $content,
 ) {
   $filename = "/etc/postfix/${title}"
 
   Package['postfix']
   -> file { $filename:
-    ensure  => present,
+    ensure  => $ensure,
     mode    => '0644',
     content => $content,
   }
   ~> exec { "postmap_${title}":
+    ensure      => $ensure,
     command     => "/usr/sbin/postmap ${filename}",
     refreshonly => true,
   }
 }
-

--- a/modules/postfix/manifests/service.pp
+++ b/modules/postfix/manifests/service.pp
@@ -2,9 +2,9 @@
 #
 # Manage the postfix service
 #
-class postfix::service {
+class postfix::service($ensure = running) {
   service { 'postfix':
-    ensure  => running,
+    ensure  => $ensure,
     require => Class['postfix::package'],
   }
 }


### PR DESCRIPTION
Postfix is an SMTP server that allows processes on the machine to send emails and they get relayed to an external SMTP server. It was added in ff718d1 and further updated in acb7fe8 to use SES.

It seems to be using old credentials in the HMGGDS AWS account which we want to switch off. Rather than getting new credentials, I'm thinking it might be easier to remove `postfix` from our machines.

Since adding Postfix in 2013, our applications have changed quite a bit and they're now using GOV.UK Notify directly to send emails via an HTTP API. I'm not sure what else we could be sending through Postfix, perhaps some system emails, but as far as I can tell they're not being read by anybody and we don't seem to have any documentation that explains how we use Postfix.

## Alternatives

- Remove just the "Smarthost" part of Postfix. This seems to be the part which relays messages to SES, so perhaps we could just remove this part.
- Switch Postfix to use SES credentials not in HMGGDS.