### PR TITLE
staging db_admin: (temporarily) disable pull_ckan_production_daily

### DIFF
--- a/hieradata_aws/class/staging/db_admin.yaml
+++ b/hieradata_aws/class/staging/db_admin.yaml
@@ -1,6 +1,6 @@
 govuk_env_sync::tasks:
   "pull_ckan_production_daily":
-    ensure: "present"
+    ensure: "disabled"
     hour: "3"
     minute: "15"
     action: "pull"


### PR DESCRIPTION
https://trello.com/c/ssYoWQnK

We don't want this interfering while we're testing a ckan migration on
staging.