### PR TITLE
govuk::apps::ckan: add $blanket_redirect_url option

### DIFF
--- a/modules/govuk/manifests/apps/ckan.pp
+++ b/modules/govuk/manifests/apps/ckan.pp
@@ -11,6 +11,10 @@
 # [*pycsw_port*]
 #   What port should the PyCSW companion app run on?
 #
+# [*blanket_redirect_url*]
+#   If defined, all requests will be redirected to this absolute url. Useful
+#   for maintenance.
+#
 # [*db_hostname*]
 #   The postgres instance for CKAN to connect to
 #
@@ -57,6 +61,7 @@ class govuk::apps::ckan (
   $enabled                        = false,
   $port,
   $pycsw_port,
+  $blanket_redirect_url           = undef,
   $db_hostname                    = undef,
   $db_username                    = 'ckan',
   $db_password                    = 'foo',

--- a/modules/govuk/templates/ckan/nginx.conf.erb
+++ b/modules/govuk/templates/ckan/nginx.conf.erb
@@ -1,3 +1,7 @@
+<%- if @blanket_redirect_url -%>
+return 302 <%= @blanket_redirect_url %>;
+<%- end -%>
+
 # Guard against open redirects from CKAN for requests with paths like
 # the following, starting with two forward slashes and a trailing
 # slash: //www.gov.uk/


### PR DESCRIPTION
https://trello.com/c/WjOK9SKl/

As an alternative to https://github.com/alphagov/govuk-puppet/pull/10627, we'll just redirect everything to a maintenance page hosted elsewhere.