### PR TITLE
staging govuk::apps::ckan: (temporarily) disable interfering processes

### DIFF
--- a/hieradata_aws/class/staging/ckan.yaml
+++ b/hieradata_aws/class/staging/ckan.yaml
@@ -4,3 +4,6 @@ govuk::apps::ckan::enabled: true
 
 govuk::apps::ckan::enable_harvester_fetch: false
 govuk::apps::ckan::enable_harvester_gather: false
+
+govuk::apps::ckan::cronjobs::enable: false
+govuk::apps::ckan::cronjobs::enable_solr_reindex: false

--- a/hieradata_aws/class/staging/ckan.yaml
+++ b/hieradata_aws/class/staging/ckan.yaml
@@ -1,3 +1,6 @@
 ---
 
 govuk::apps::ckan::enabled: true
+
+govuk::apps::ckan::enable_harvester_fetch: false
+govuk::apps::ckan::enable_harvester_gather: false

--- a/hieradata_aws/class/staging/ckan.yaml
+++ b/hieradata_aws/class/staging/ckan.yaml
@@ -1,6 +1,7 @@
 ---
 
 govuk::apps::ckan::enabled: true
+govuk::apps::ckan::blanket_redirect_url: https://staging.data.gov.uk/ckan_maintenance
 
 govuk::apps::ckan::enable_harvester_fetch: false
 govuk::apps::ckan::enable_harvester_gather: false


### PR DESCRIPTION
https://trello.com/c/ssYoWQnK

There are a few things we want to turn off while we reindex ckan during the 2.8 migration, and we'd rather puppet wasn't always trying to turn them back on.