### PR TITLE
staging ckan: switch to govuk_solr6 

### DIFF
--- a/hieradata_aws/class/staging/ckan.yaml
+++ b/hieradata_aws/class/staging/ckan.yaml
@@ -4,3 +4,6 @@ govuk::apps::ckan::enabled: true
 
 govuk::apps::ckan::enable_harvester_fetch: false
 govuk::apps::ckan::enable_harvester_gather: false
+
+govuk::apps::ckan::cronjobs::enable: false
+govuk::apps::ckan::cronjobs::enable_solr_reindex: false

--- a/hieradata_aws/class/staging/ckan.yaml
+++ b/hieradata_aws/class/staging/ckan.yaml
@@ -1,3 +1,6 @@
 ---
 
 govuk::apps::ckan::enabled: true
+
+govuk::apps::ckan::enable_harvester_fetch: false
+govuk::apps::ckan::enable_harvester_gather: false

--- a/hieradata_aws/class/staging/ckan.yaml
+++ b/hieradata_aws/class/staging/ckan.yaml
@@ -1,6 +1,7 @@
 ---
 
 govuk::apps::ckan::enabled: true
+govuk::apps::ckan::blanket_redirect_url: https://staging.data.gov.uk/ckan_maintenance
 
 govuk::apps::ckan::enable_harvester_fetch: false
 govuk::apps::ckan::enable_harvester_gather: false

--- a/hieradata_aws/class/staging/ckan.yaml
+++ b/hieradata_aws/class/staging/ckan.yaml
@@ -1,5 +1,11 @@
 ---
 
+govuk_solr::disable: true
+govuk_solr6::present: true
+
+govuk::apps::ckan::solr_core: ckan
+govuk::apps::ckan::solr_core_configset: ckan28
+
 govuk::apps::ckan::enabled: true
 govuk::apps::ckan::blanket_redirect_url: https://staging.data.gov.uk/ckan_maintenance
 


### PR DESCRIPTION
This sits on top of the branch from #10635 because otherwise it will conflict. Merge that first.

https://trello.com/c/ssYoWQnK

This switch to `govuk_solr6` should pave the way for ckan 2.8 migration.