### PR TITLE
Revert "staging govuk::apps::ckan: (temporarily) disable harvester workers"

### DIFF
--- a/hieradata_aws/class/staging/ckan.yaml
+++ b/hieradata_aws/class/staging/ckan.yaml
@@ -9,8 +9,5 @@ govuk::apps::ckan::solr_core_configset: ckan28
 govuk::apps::ckan::enabled: true
 govuk::apps::ckan::blanket_redirect_url: https://staging.data.gov.uk/ckan_maintenance
 
-govuk::apps::ckan::enable_harvester_fetch: false
-govuk::apps::ckan::enable_harvester_gather: false
-
 govuk::apps::ckan::cronjobs::enable: false
 govuk::apps::ckan::cronjobs::enable_solr_reindex: false


### PR DESCRIPTION
https://trello.com/c/ssYoWQnK

Looks like we can't release without these in place because the deployment script tries to restart them.