### PR TITLE
govuk::apps::ckan: add $blanket_redirect_skip_key argument

### DIFF
--- a/modules/govuk/manifests/apps/ckan.pp
+++ b/modules/govuk/manifests/apps/ckan.pp
@@ -15,6 +15,10 @@
 #   If defined, all requests will be redirected to this absolute url. Useful
 #   for maintenance.
 #
+# [*blanket_redirect_skip_key*]
+#   A request supplying this value under the header x-ckan-skip-blanket-redirect-key will
+#   be allowed to skip the blanket redirect (e.g. to allow for testing).
+#
 # [*db_hostname*]
 #   The postgres instance for CKAN to connect to
 #
@@ -62,6 +66,7 @@ class govuk::apps::ckan (
   $port,
   $pycsw_port,
   $blanket_redirect_url           = undef,
+  $blanket_redirect_skip_key      = undef,
   $db_hostname                    = undef,
   $db_username                    = 'ckan',
   $db_password                    = 'foo',

--- a/modules/govuk/templates/ckan/nginx.conf.erb
+++ b/modules/govuk/templates/ckan/nginx.conf.erb
@@ -1,5 +1,11 @@
 <%- if @blanket_redirect_url -%>
-return 302 <%= @blanket_redirect_url %>;
+<%- if @blanket_redirect_skip_key -%>
+if ($http_x_ckan_skip_blanket_redirect_key != "<%= @blanket_redirect_skip_key %>") {
+<%- end -%>
+  return 302 <%= @blanket_redirect_url %>;
+<%- if @blanket_redirect_skip_key -%>
+}
+<%- end -%>
 <%- end -%>
 
 # Guard against open redirects from CKAN for requests with paths like


### PR DESCRIPTION
https://trello.com/c/WjOK9SKl

Ken wants a way to access the site during maintenance, so honor the magic header `x-ckan-skip-blanket-redirect-key: ` (dat name!) if it matches a certain value. Value should be provided through govuk-secrets.

This might not be the best way of doing this, but it's probably the simplest as it doesn't involve lists of trusted IPs, `x-forwarded-for` complications, basic auth dialogs popping up for normal visitors etc...