### PR TITLE
Remove status updates check

### DIFF
--- a/modules/govuk/manifests/apps/email_alert_api/checks.pp
+++ b/modules/govuk/manifests/apps/email_alert_api/checks.pp
@@ -24,17 +24,6 @@ class govuk::apps::email_alert_api::checks(
       latency_critical => '5400'; # 90 minutes
   }
 
-  @@icinga::check::graphite { 'email-alert-api-delivery-attempt-status-update':
-    ensure    => $ensure,
-    host_name => $::fqdn,
-    target    => 'transformNull(divideSeries(keepLastValue(averageSeries(stats.gauges.govuk.app.email-alert-api.*.delivery_attempt.pending_status_total)), keepLastValue(averageSeries(stats.gauges.govuk.app.email-alert-api.*.delivery_attempt.total))),0)',
-    warning   => '0.166',
-    critical  => '0.25',
-    from      => '1hour',
-    desc      => 'email-alert-api - high number of delivery attempts have not received status updates',
-    notes_url => monitoring_docs_url(email-alert-api-delivery-attempts-status-updates),
-  }
-
   @@icinga::check::graphite { 'email-alert-api-warning-digest-runs':
     ensure    => $ensure,
     host_name => $::fqdn,


### PR DESCRIPTION
The reason for this is below:

Assume an email is sent when we have made a successful request to Notify
for them to send it. It is out-of-scope for us to care about whether an
email that we have requested to send, is ultimately delivered:

- Notify are quite capable of fixing their own problems.
- It is not practical for us to worry about individual email providers.

Trello:
https://trello.com/c/3UwK7bWe/484-stop-using-notify-status-updates-as-an-indicator-of-success