### PR TITLE
Adds 50% target to dashboard

### DIFF
--- a/modules/grafana/files/dashboards/platform_health_Q2_20-21_bouncer_errors.json
+++ b/modules/grafana/files/dashboards/platform_health_Q2_20-21_bouncer_errors.json
@@ -6,7 +6,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "hideControls": false,
-  "id": 42,
+  "id": 43,
   "links": [],
   "refresh": false,
   "rows": [
@@ -46,6 +46,13 @@
               "fill": 0,
               "lines": true,
               "linewidth": 6
+            },
+            {
+              "alias": "Target",
+              "bars": false,
+              "fill": 0,
+              "lines": true,
+              "linewidth": 4
             }
           ],
           "spaceLength": 10,
@@ -61,6 +68,10 @@
             {
               "refId": "B",
               "target": "alias(movingAverage(summarize(stats.gauges.sentry-error-count-last-hour.bouncer, '1d', 'sum', true), '30d'), '30 day average')"
+            },
+            {
+              "refId": "C",
+              "target": "alias(constantLine(5500), 'Target')"
             }
           ],
           "thresholds": [],
@@ -145,5 +156,5 @@
   },
   "timezone": "",
   "title": "Platform Health - Q2 (20-21) Bouncer errors",
-  "version": 3
+  "version": 4
 }


### PR DESCRIPTION
This was the intention in https://github.com/alphagov/govuk-puppet/pull/10598, but it looks like it got missed somehow.

Before:

<img width="1440" alt="Screenshot 2020-08-27 at 09 12 51" src="https://user-images.githubusercontent.com/5111927/91415316-c7c22b80-e845-11ea-9fd2-58e4b6b99bfd.png">

After:

<img width="1440" alt="Screenshot 2020-08-27 at 09 12 25" src="https://user-images.githubusercontent.com/5111927/91415326-cc86df80-e845-11ea-8042-6ef1b7003d8b.png">

Trello: https://trello.com/c/rG9oDZLQ/2085-3-build-dashboard-showing-bouncer-errors