### PR TITLE
production govuk::apps::ckan: set blanket_redirect_url to put in maintenance mode

### DIFF
--- a/hieradata_aws/class/production/ckan.yaml
+++ b/hieradata_aws/class/production/ckan.yaml
@@ -1,3 +1,4 @@
 ---
 
 govuk::apps::ckan::enabled: true
+govuk::apps::ckan::blanket_redirect_url: https://data.gov.uk/ckan_maintenance


### PR DESCRIPTION
Don't want too many db modifications creeping in since last snapshot was taken.