### PR TITLE
target specific ci agent nodes

### DIFF
--- a/hiera_aws.yml
+++ b/hiera_aws.yml
@@ -1,5 +1,6 @@
 ---
 :hierarchy:
+  - 'class/%{::environment}/aws_hostname/%{::aws_hostname}'
   - 'class/%{::aws_stackname}/%{::environment}/%{::govuk_node_class}'
   - 'class/%{::aws_stackname}/%{::govuk_node_class}'
   - 'class/%{::environment}/%{::govuk_node_class}'

--- a/hieradata_aws/class/integration/aws_hostname/ci-agent-1.yaml
+++ b/hieradata_aws/class/integration/aws_hostname/ci-agent-1.yaml
@@ -1,0 +1,2 @@
+---
+mongodb::server::version: '2.6.12'

--- a/hieradata_aws/class/integration/aws_hostname/ci-agent-2.yaml
+++ b/hieradata_aws/class/integration/aws_hostname/ci-agent-2.yaml
@@ -1,0 +1,2 @@
+---
+mongodb::server::version: '2.6.12'

--- a/hieradata_aws/class/integration/aws_hostname/ci-agent-3.yaml
+++ b/hieradata_aws/class/integration/aws_hostname/ci-agent-3.yaml
@@ -1,0 +1,3 @@
+---
+
+mongodb::server::version: '2.6.12'

--- a/hieradata_aws/class/integration/aws_hostname/ci-agent-4.yaml
+++ b/hieradata_aws/class/integration/aws_hostname/ci-agent-4.yaml
@@ -1,0 +1,3 @@
+---
+
+postgresql::globals::version: '9.6'

--- a/hieradata_aws/class/integration/aws_hostname/ci-agent-5.yaml
+++ b/hieradata_aws/class/integration/aws_hostname/ci-agent-5.yaml
@@ -1,0 +1,7 @@
+---
+govuk_containers::elasticsearch::primary::enable: false
+govuk_containers::elasticsearch::secondary::enable: false
+
+# prevents puppet stopping the service which is does by default as
+# clamav::use_service is set to false for it
+clamav::service::puppet_lifecycle_enable: false

--- a/hieradata_aws/class/integration/aws_hostname/ci-agent-6.yaml
+++ b/hieradata_aws/class/integration/aws_hostname/ci-agent-6.yaml
@@ -1,0 +1,3 @@
+---
+govuk_containers::elasticsearch::primary::enable: false
+govuk_containers::elasticsearch::secondary::enable: false

--- a/hieradata_aws/class/integration/aws_hostname/ci-agent-7.yaml
+++ b/hieradata_aws/class/integration/aws_hostname/ci-agent-7.yaml
@@ -1,0 +1,7 @@
+---
+govuk_containers::elasticsearch::primary::enable: false
+govuk_containers::elasticsearch::secondary::enable: false
+
+govuk_solr::disable: true
+
+govuk_solr6::present: true

--- a/hieradata_aws/class/integration/aws_hostname/ci-agent-8.yaml
+++ b/hieradata_aws/class/integration/aws_hostname/ci-agent-8.yaml
@@ -1,0 +1,7 @@
+---
+govuk_containers::elasticsearch::primary::enable: false
+govuk_containers::elasticsearch::secondary::enable: false
+
+govuk_solr::disable: true
+
+govuk_solr6::present: true

--- a/modules/govuk_scripts/templates/govuk_node_list_aws.erb
+++ b/modules/govuk_scripts/templates/govuk_node_list_aws.erb
@@ -8,6 +8,7 @@ import string
 import sys
 import urllib
 import boto3
+import operator
 
 stackname = '<%= @aws_stackname -%>'
 region = '<%= @aws_region -%>'
@@ -40,9 +41,12 @@ def ec2_nodes(stackname, nodeclass=None):
     for reservation in reservations:
         instances = reservation['Instances']
         for instance in instances:
-            hosts.append((instance['PrivateDnsName']))
+            hostname = next(tag['Value'] for tag in instance['Tags'] if tag['Key'] == 'aws_hostname')
+            hosts.append((instance['PrivateDnsName'], hostname))
 
-    return(hosts)
+    hosts.sort(key=operator.itemgetter(1))
+    sorted_hosts = [host[0] for host in hosts]
+    return(sorted_hosts)
 
 def ec2_nodes_list_with_puppet_class(stackname):
     client = boto3.client('ec2', region_name=region)


### PR DESCRIPTION
Changes:
1. change puppet for specific aws ci_agent to receive a different configuration based on aws_hostname value. In carrenza, fqdn was used but this is not possible in AWS world.

2. change aws govuk_node_list to sort hosts based on aws_hostname value. In effect, this will probably affect only ci_agents.