### PR TITLE
production govuk::apps::ckan: (temporarily) disable interfering processes

### DIFF
--- a/hieradata_aws/class/production/ckan.yaml
+++ b/hieradata_aws/class/production/ckan.yaml
@@ -5,3 +5,6 @@ govuk::apps::ckan::blanket_redirect_url: https://data.gov.uk/ckan_maintenance
 
 govuk::apps::ckan::enable_harvester_fetch: false
 govuk::apps::ckan::enable_harvester_gather: false
+
+govuk::apps::ckan::cronjobs::enable: false
+govuk::apps::ckan::cronjobs::enable_solr_reindex: false

--- a/hieradata_aws/class/production/ckan.yaml
+++ b/hieradata_aws/class/production/ckan.yaml
@@ -2,3 +2,6 @@
 
 govuk::apps::ckan::enabled: true
 govuk::apps::ckan::blanket_redirect_url: https://data.gov.uk/ckan_maintenance
+
+govuk::apps::ckan::enable_harvester_fetch: false
+govuk::apps::ckan::enable_harvester_gather: false


### PR DESCRIPTION
https://trello.com/c/Ploo4Bxt

Akin to #10635, part of the migration process, there are a few things we want to turn off while we reindex ckan during the 2.8 migration, and we'd rather puppet wasn't always trying to turn them back on.