### PR TITLE
production ckan: switch to govuk_solr6

### DIFF
--- a/hieradata_aws/class/production/ckan.yaml
+++ b/hieradata_aws/class/production/ckan.yaml
@@ -1,5 +1,11 @@
 ---
 
+govuk_solr::disable: true
+govuk_solr6::present: true
+
+govuk::apps::ckan::solr_core: ckan
+govuk::apps::ckan::solr_core_configset: ckan28
+
 govuk::apps::ckan::enabled: true
 govuk::apps::ckan::blanket_redirect_url: https://data.gov.uk/ckan_maintenance
 


### PR DESCRIPTION
https://trello.com/c/Ploo4Bxt

Akin to #10636, This switch to govuk_solr6 should pave the way for ckan 2.8 migration.