### PR TITLE
Bump unicornherder to 0.2.1

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1234,7 +1234,7 @@ unattended_upgrades::origins:
  - "%{::lsbdistid} stable"
  - "%{::lsbdistid} %{::lsbdistcodename}-security"
 
-unicornherder::version: '0.1.0'
+unicornherder::version: '0.2.1'
 
 yarn::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 yarn::repo::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1603,7 +1603,7 @@ unattended_upgrades::origins:
  - "%{::lsbdistid} stable"
  - "%{::lsbdistid} %{::lsbdistcodename}-security"
 
-unicornherder::version: '0.1.0'
+unicornherder::version: '0.2.1'
 
 yarn::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 yarn::repo::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"


### PR DESCRIPTION
Unicornherder 0.2.0  has a new mechanism to wait for workers [1] which
reduces the amount of time we spend with two versions of an application
running during deployments. It will reduce this overlap time from 2
minutes to 30 seconds.

When I started working on this I hoped that we could nearly erase the
need for a waiting period (the 30 seconds), and this seemed to be the case
for an application like Whitehall that is preloaded by unicorn before
forking processes. However I found that because most apps are not
preloaded they need some time for the Rails application to start in the
new worker processes. If we discover that apps are exceeding this 30
second mark we should consider switching them to be preloaded.

In general there's a number of advantages to preloading an app such as
reduced memory usage, better indication of an error as the unicorn
master will fail and a nicer start-up - however there are considerations
to make about socket sharing. Therefore it's not something I'm going to
pursue at the moment but we could consider this later.

[1]: https://github.com/gds-operations/unicornherder/pull/35