### PR TITLE
fix icinga monitoring about AWS ci agents alive/connected

### DIFF
--- a/modules/icinga/files/usr/lib/nagios/plugins/check_jenkins_agent
+++ b/modules/icinga/files/usr/lib/nagios/plugins/check_jenkins_agent
@@ -11,7 +11,13 @@ then
   exit 3
 fi
 
-if /usr/bin/curl -sk 'https://localhost:443/computer/api/json' \
+if [ -e "/etc/facter/facts.d/aws_environment.txt" ]; then
+  URL='http://localhost:80/computer/api/json'
+else
+  URL='https://localhost:443/computer/api/json'
+fi
+
+if /usr/bin/curl -sk "${URL}" \
    | /usr/bin/jq ".computer[] | select(.displayName==\"${1}\")" \
    | /usr/bin/jq "{offline}" \
    | /bin/grep -q "false"


### PR DESCRIPTION
In AWS, the ssl termination is at the load balancer and hence, the icinga plugin needs to use port 80 with localhost rather than 443.