### PR TITLE
disable backup of mongodb to s3 on ci agents

### DIFF
--- a/hieradata_aws/class/integration/ci_agent.yaml
+++ b/hieradata_aws/class/integration/ci_agent.yaml
@@ -1,4 +1,5 @@
 ---
+mongodb::aws_backup:ensure: 'absent'
 mongodb::server::version: '3.2.7'
 mongodb::server::development: true
 mongodb::server::replicaset_members:


### PR DESCRIPTION
This is not done in carrenza and hence, should not be done in AWS