### PR TITLE
Expose the number and percentage of rate-limited Sentry errors

### DIFF
--- a/modules/grafana/files/dashboards/sentry_errors_across_all_environments.json
+++ b/modules/grafana/files/dashboards/sentry_errors_across_all_environments.json
@@ -6,13 +6,250 @@
   "gnetId": null,
   "graphTooltip": 0,
   "hideControls": false,
-  "id": null,
+  "id": 13,
   "links": [],
   "refresh": false,
   "rows": [
     {
       "collapse": false,
       "height": 250,
+      "panels": [
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(50, 172, 45, 0.97)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(245, 54, 54, 0.9)"
+          ],
+          "datasource": "Graphite",
+          "description": "Errors reported to Sentry, including ones which were rejected (rate limited).",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 6,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 4,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "refId": "A",
+              "target": "summarize(sumSeries(groupByNode(stats.govuk.app.*.*.errors_occurred, 3, 'sum')), '1d', 'sum')",
+              "textEditor": true
+            }
+          ],
+          "thresholds": "",
+          "title": "Total app errors sent to Sentry",
+          "type": "singlestat",
+          "valueFontSize": "200%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "total"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(50, 172, 45, 0.97)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(245, 54, 54, 0.9)"
+          ],
+          "datasource": "Graphite",
+          "description": "Errors reported to Sentry but which were rate-limited.",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 8,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 4,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "refId": "A",
+              "target": "summarize(sumSeries(groupByNode(stats.govuk.app.*.*.error_reports_failed, 3, 'sum')), '1d', 'sum')",
+              "textEditor": true
+            }
+          ],
+          "thresholds": "",
+          "title": "Errors rejected by Sentry",
+          "type": "singlestat",
+          "valueFontSize": "200%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "total"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorValue": false,
+          "colors": [
+            "rgba(50, 172, 45, 0.97)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(245, 54, 54, 0.9)"
+          ],
+          "datasource": "Graphite",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 9,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "%",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 4,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "hide": false,
+              "refId": "A",
+              "target": "asPercent(summarize(sumSeries(groupByNode(stats.govuk.app.*.*.error_reports_failed, 3, 'sum')), '1d', 'sum'), summarize(sumSeries(groupByNode(stats.govuk.app.*.*.errors_occurred, 3, 'sum')), '1d', 'sum'))",
+              "textEditor": true
+            }
+          ],
+          "thresholds": "20,50",
+          "title": "Failure rate (rate limiting)",
+          "type": "singlestat",
+          "valueFontSize": "200%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "Stats for this environment",
+      "titleSize": "h3"
+    },
+    {
+      "collapse": false,
+      "height": 238,
       "panels": [
         {
           "aliasColors": {},
@@ -95,9 +332,9 @@
       "repeat": null,
       "repeatIteration": null,
       "repeatRowId": null,
-      "showTitle": false,
-      "title": "Dashboard Row",
-      "titleSize": "h6"
+      "showTitle": true,
+      "title": "Stats across all environments",
+      "titleSize": "h3"
     },
     {
       "collapse": false,
@@ -292,7 +529,10 @@
     "list": [
       {
         "allValue": "*",
-        "current": {},
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
         "datasource": "Graphite",
         "hide": 0,
         "includeAll": true,
@@ -380,7 +620,7 @@
     ]
   },
   "time": {
-    "from": "now-7d",
+    "from": "now-12h",
     "to": "now"
   },
   "timepicker": {
@@ -409,6 +649,6 @@
     ]
   },
   "timezone": "browser",
-  "title": "Sentry errors (across all environments)",
-  "version": 6
+  "title": "Sentry errors",
+  "version": 3
 }


### PR DESCRIPTION
A large number of errors that we send to Sentry are not persisted
due to us hitting a rate limit. I've added some stats to the
Sentry dashboard: https://grafana.blue.production.govuk.digital/dashboard/file/sentry_errors_across_all_environments.json?orgId=1

Currently in action on these temporary dashboards (to be deleted after merge):

- https://grafana.blue.staging.govuk.digital/dashboard/db/sentry-errors-temporary?orgId=1&from=now-12h&to=now
- https://grafana.blue.production.govuk.digital/dashboard/db/sentry-errors-temporary?orgId=1&from=now-24h&to=now

We're showing:

- Total app errors sent to Sentry
- Errors rejected by Sentry
- Failure rate (rate limiting)
  - ^ This is a percentage of the first two figures

These figures are environment specific, i.e. they will differ
between production and staging Grafana dashboards. For this reason,
I've renamed the dashboard and split it into environment-specific
and generic sections.

Example on Production:

<img width="1432" alt="Screenshot 2020-09-01 at 18 39 48" src="https://user-images.githubusercontent.com/5111927/91887308-8933d300-ec82-11ea-96a5-60bb18976ef3.png">

Example on Staging (which has a much bigger problem!):

<img width="1438" alt="Screenshot 2020-09-01 at 18 32 56" src="https://user-images.githubusercontent.com/5111927/91887336-9224a480-ec82-11ea-9680-b4bbf6b2f009.png">

Trello: https://trello.com/c/Svak0lna/2084-3-build-dashboard-showing-errors-not-making-it-into-sentry