### PR TITLE
Increase the Icinga thread check threshold for the Content Store

### DIFF
--- a/modules/govuk/manifests/apps/content_store.pp
+++ b/modules/govuk/manifests/apps/content_store.pp
@@ -96,6 +96,7 @@ class govuk::apps::content_store(
     nagios_memory_warning       => $nagios_memory_warning,
     nagios_memory_critical      => $nagios_memory_critical,
     unicorn_worker_processes    => $unicorn_worker_processes,
+    alert_when_threads_exceed   => 155,
     create_default_nginx_config => $create_default_nginx_config,
   }
 


### PR DESCRIPTION
As it has more Unicorn workers now, so there are more than 100
threads (which is the default).