### PR TITLE
Revert "staging db_admin: (temporarily) disable pull_ckan_production_daily"

### DIFF
--- a/hieradata_aws/class/staging/db_admin.yaml
+++ b/hieradata_aws/class/staging/db_admin.yaml
@@ -1,6 +1,6 @@
 govuk_env_sync::tasks:
   "pull_ckan_production_daily":
-    ensure: "disabled"
+    ensure: "present"
     hour: "3"
     minute: "15"
     action: "pull"


### PR DESCRIPTION
## What

Reverts alphagov/govuk-puppet#10633

Now that CKAN 2.8 has been deployed and is working, allow the daily sync to happen