### PR TITLE
Report HTTP errors as critical for healthchecks

### DIFF
--- a/modules/icinga/files/usr/lib/nagios/plugins/check_json_healthcheck
+++ b/modules/icinga/files/usr/lib/nagios/plugins/check_json_healthcheck
@@ -49,7 +49,7 @@ def report(exit_code, message, detail_message=None):
 
 def report_error(message):
     """Report an error running this check, then exit."""
-    report(UNKNOWN, message)
+    report(STATUSES.index("critical"), message)
 
 
 def handle_exception(exc_type, exception, traceback):

--- a/modules/icinga/files/usr/lib/nagios/plugins/check_json_healthcheck
+++ b/modules/icinga/files/usr/lib/nagios/plugins/check_json_healthcheck
@@ -33,8 +33,6 @@ from urllib.request import urlopen, Request, HTTPError
 from urllib.parse import urlunparse
 
 
-OK, WARNING, CRITICAL, UNKNOWN = 0, 1, 2, 3
-
 STATUSES = ["ok", "warning", "critical", "unknown"]
 
 
@@ -54,7 +52,7 @@ def report_error(message):
 
 def handle_exception(exc_type, exception, traceback):
     """Report uncaught exceptions to Nagios as UNKNOWN (exit code 3)."""
-    report(UNKNOWN, "unhandled exception: %s" % (exception,))
+    report(STATUSES.index("unknown"), "unhandled exception: %s" % (exception,))
 
 
 def url_from_arguments(arguments):


### PR DESCRIPTION
https://trello.com/c/DyNP0Env/496-update-the-healthcheck-icinga-alert-timeout-status-to-be-critical-rather-than-unknown

Previously we missed a healthcheck alert for Email Alert API due to the app
being down, which manifested as an unknown "timeout" error. This raises the
profile of HTTP errors to critical, since these also reflect the health of
the app being checked. Please see the commits for more details.

## Before

<img width="1075" alt="Screenshot 2020-09-03 at 16 37 36" src="https://user-images.githubusercontent.com/9029009/92137265-dc359380-ee04-11ea-9840-f5cc7126f298.png">


## After

<img width="1067" alt="Screenshot 2020-09-03 at 16 44 58" src="https://user-images.githubusercontent.com/9029009/92137285-df308400-ee04-11ea-8603-6f05fa67ee92.png">
