### PR TITLE
Slightly drop the number of Content Store Unicorn workers

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -515,7 +515,7 @@ govuk::apps::content_publisher::redis_port: "%{hiera('sidekiq_port')}"
 
 govuk::apps::content_store::nagios_memory_warning: 4000
 govuk::apps::content_store::nagios_memory_critical: 5000
-govuk::apps::content_store::unicorn_worker_processes: "18"
+govuk::apps::content_store::unicorn_worker_processes: "15"
 
 govuk::apps::content_tagger::db_hostname: "postgresql-primary"
 govuk::apps::content_tagger::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"


### PR DESCRIPTION
18 is using a bit too much memory on the machine, and it's hopefully
not necessary to have that many workers, so reduce the number
slightly.