### PR TITLE
Increase read timeout for imminence

### DIFF
--- a/modules/govuk/manifests/apps/imminence.pp
+++ b/modules/govuk/manifests/apps/imminence.pp
@@ -88,6 +88,7 @@ class govuk::apps::imminence(
     nagios_memory_warning    => $nagios_memory_warning,
     nagios_memory_critical   => $nagios_memory_critical,
     unicorn_worker_processes => $unicorn_worker_processes,
+    read_timeout             => 60,
   }
 
   govuk::app::envvar {


### PR DESCRIPTION
There have been reports of imminence timing out and returning a 504 error when updating data. Increasing the timeout (from the default of 15 seconds to 60 seconds) should allow these large files to be processed before the user sees an error.

Zendesk ticket: https://govuk.zendesk.com/agent/tickets/4101871