### PR TITLE
Make AWS LB checks comprehensive

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -351,22 +351,62 @@ monitoring::checks::aws_iam_key::region: 'eu-west-1'
 monitoring::checks::aws_iam_key::max_aws_iam_key_age: 320
 
 monitoring::checks::lb::region: 'eu-west-1'
-monitoring::checks::lb::loadbalancers:
+monitoring::checks::lb::loadbalancers: # prefer "internal"
+  blue-apt-internal:
+    healthyhosts_warning: 0
+  blue-backend-internal:
+    healthyhosts_warning: 0
+    healthyhosts_ignore:
+      - backend-i-backdrop-admin # no idea what this is
+      - backend-i-content-performance-m # no idea what this is
+      - backend-i-event-store # no idea what this is
+      - backend-i-performanceplatform-a # no idea what this is
+      - blue-backend-internal-HTTP-80 # no idea what this is
+  blue-bouncer-internal: {}
+  blue-cache: {}
   blue-calculators-frontend-int: {}
+  blue-ckan-internal:
+    healthyhosts_warning: 0
+  blue-content-store-internal: {}
+  blue-db-admin:
+    healthyhosts_warning: 0
+  blue-deploy-internal:
+    healthyhosts_warning: 0
+  blue-docker-management-etcd:
+    healthyhosts_warning: 0
+  blue-draft-cache: {}
+  blue-draft-content-store-int: {}
   blue-draft-frontend-internal:
     healthyhosts_ignore:
-      - draft-fron-draft-finder-frontend
+      - draft-fron-draft-finder-frontend # no idea what this is
+  blue-email-alert-api-internal: {}
   blue-frontend-internal:
     healthyhosts_ignore:
-      - frontend-i-designprinciples
-      - frontend-i-spotlight
-  govuk-backend-public:
-    healthyhosts_ignore:
-      - backend-content-api
-      - backend-content-performance-m
-      - backend-kibana
-      - backend-policy-publisher
-  govuk-cache-public: {}
+      - frontend-i-designprinciples # no idea what this is
+      - frontend-i-spotlight # no idea what this is
+  blue-graphite-internal:
+    healthyhosts_warning: 0
+  blue-jumpbox:
+    healthyhosts_warning: 0
+  blue-licensify-frontend-internal: {}
+  blue-mapit-internal: {}
+  blue-monitoring:
+    healthyhosts_warning: 0
+  blue-publishing-api-internal: {}
+  blue-puppetmaster:
+    healthyhosts_warning: 0
+  blue-rabbitmq-internal: {}
+  blue-router-api: {}
+  blue-search: {}
+  blue-transition-db-admin:
+    healthyhosts_warning: 0
+  blue-whitehall-frontend: {}
+  govuk-static-public: {}
+  govuk-support-api-public:
+    healthyhosts_warning: 0
+  licensify-backend-internal:
+    healthyhosts_warning: 0
+  whitehall-backend-internal: {}
 
 monitoring::checks::cache::region: 'eu-west-1'
 monitoring::checks::smokey::environment: 'integration'

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -382,38 +382,60 @@ monitoring::checks::aws_iam_key::region: 'eu-west-1'
 monitoring::checks::aws_iam_key::max_aws_iam_key_age: 320
 
 monitoring::checks::lb::region: 'eu-west-1'
-monitoring::checks::lb::loadbalancers:
+monitoring::checks::lb::loadbalancers: # prefer "internal"
+  blue-apt-internal:
+    healthyhosts_warning: 0
+  blue-backend-internal:
+    healthyhosts_ignore:
+      - backend-i-backdrop-admin # no idea what this is
+      - backend-i-content-performance-m # no idea what this is
+      - backend-i-event-store # no idea what this is
+      - backend-i-performanceplatform-a # no idea what this is
+      - blue-backend-internal-HTTP-80 # no idea what this is
+  blue-bouncer-internal: {}
+  blue-cache: {}
   blue-calculators-frontend-int: {}
+  blue-ckan-internal:
+    healthyhosts_warning: 0
+  blue-content-store-internal: {}
+  blue-db-admin:
+    healthyhosts_warning: 0
+  blue-deploy-internal:
+    healthyhosts_warning: 0
+  blue-docker-management-etcd:
+    healthyhosts_warning: 0
+  blue-draft-cache: {}
+  blue-draft-content-store-int: {}
   blue-draft-frontend-internal:
     healthyhosts_ignore:
-      - draft-fron-draft-finder-frontend
+      - draft-fron-draft-finder-frontend # no idea what this is
+  blue-email-alert-api-internal: {}
   blue-frontend-internal:
     healthyhosts_ignore:
-      - frontend-i-designprinciples
-      - frontend-i-spotlight
-  govuk-backend-public:
-    healthyhosts_ignore:
-      - backend-collections-publisher
-      - backend-contacts-admin
-      - backend-content-api
-      - backend-content-audit-tool
-      - backend-content-performance-m
-      - backend-content-publisher
-      - backend-content-tagger
-      - backend-hmrc-manuals-api
-      - backend-kibana
-      - backend-manuals-publisher
-      - backend-maslow
-      - backend-policy-publisher
-      - backend-publisher
-      - backend-release
-      - backend-search-admin
-      - backend-service-manual-publis
-      - backend-short-url-manager
-      - backend-signon
-      - backend-specialist-publisher
-      - backend-travel-advice-publish
-  govuk-cache-public: {}
+      - frontend-i-designprinciples # no idea what this is
+      - frontend-i-spotlight # no idea what this is
+  blue-graphite-internal:
+    healthyhosts_warning: 0
+  blue-jumpbox:
+    healthyhosts_warning: 0
+  blue-licensify-frontend-internal: {}
+  blue-mapit-internal: {}
+  blue-monitoring:
+    healthyhosts_warning: 0
+  blue-publishing-api-internal: {}
+  blue-puppetmaster:
+    healthyhosts_warning: 0
+  blue-rabbitmq-internal: {}
+  blue-router-api: {}
+  blue-search: {}
+  blue-transition-db-admin:
+    healthyhosts_warning: 0
+  blue-whitehall-frontend: {}
+  govuk-static-public: {}
+  govuk-support-api-public: {}
+  licensify-backend-internal:
+    healthyhosts_warning: 0
+  whitehall-backend-internal: {}
 
 monitoring::checks::cache::region: 'eu-west-1'
 monitoring::contacts::notify_pager: true

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -367,38 +367,60 @@ monitoring::checks::aws_iam_key::region: 'eu-west-1'
 monitoring::checks::aws_iam_key::max_aws_iam_key_age: 320
 
 monitoring::checks::lb::region: 'eu-west-1'
-monitoring::checks::lb::loadbalancers:
+monitoring::checks::lb::loadbalancers: # prefer "internal"
+  blue-apt-internal:
+    healthyhosts_warning: 0
+  blue-backend-internal:
+    healthyhosts_ignore:
+      - backend-i-backdrop-admin # no idea what this is
+      - backend-i-content-performance-m # no idea what this is
+      - backend-i-event-store # no idea what this is
+      - backend-i-performanceplatform-a # no idea what this is
+      - blue-backend-internal-HTTP-80 # no idea what this is
+  blue-bouncer-internal: {}
+  blue-cache: {}
   blue-calculators-frontend-int: {}
+  blue-ckan-internal:
+    healthyhosts_warning: 0
+  blue-content-store-internal: {}
+  blue-db-admin:
+    healthyhosts_warning: 0
+  blue-deploy-internal:
+    healthyhosts_warning: 0
+  blue-docker-management-etcd:
+    healthyhosts_warning: 0
+  blue-draft-cache: {}
+  blue-draft-content-store-int: {}
   blue-draft-frontend-internal:
     healthyhosts_ignore:
-      - draft-fron-draft-finder-frontend
+      - draft-fron-draft-finder-frontend # no idea what this is
+  blue-email-alert-api-internal: {}
   blue-frontend-internal:
     healthyhosts_ignore:
-      - frontend-i-designprinciples
-      - frontend-i-spotlight
-  govuk-backend-public:
-    healthyhosts_ignore:
-      - backend-collections-publisher
-      - backend-contacts-admin
-      - backend-content-api
-      - backend-content-audit-tool
-      - backend-content-performance-m
-      - backend-content-publisher
-      - backend-content-tagger
-      - backend-hmrc-manuals-api
-      - backend-kibana
-      - backend-manuals-publisher
-      - backend-maslow
-      - backend-policy-publisher
-      - backend-publisher
-      - backend-release
-      - backend-search-admin
-      - backend-service-manual-publis
-      - backend-short-url-manager
-      - backend-signon
-      - backend-specialist-publisher
-      - backend-travel-advice-publish
-  govuk-cache-public: {}
+      - frontend-i-designprinciples # no idea what this is
+      - frontend-i-spotlight # no idea what this is
+  blue-graphite-internal:
+    healthyhosts_warning: 0
+  blue-jumpbox:
+    healthyhosts_warning: 0
+  blue-licensify-frontend-internal: {}
+  blue-mapit-internal: {}
+  blue-monitoring:
+    healthyhosts_warning: 0
+  blue-publishing-api-internal: {}
+  blue-puppetmaster:
+    healthyhosts_warning: 0
+  blue-rabbitmq-internal: {}
+  blue-router-api: {}
+  blue-search: {}
+  blue-transition-db-admin:
+    healthyhosts_warning: 0
+  blue-whitehall-frontend: {}
+  govuk-static-public: {}
+  govuk-support-api-public: {}
+  licensify-backend-internal:
+    healthyhosts_warning: 0
+  whitehall-backend-internal: {}
 
 monitoring::checks::cache::region: 'eu-west-1'
 monitoring::contacts::notify_slack: true


### PR DESCRIPTION
https://trello.com/c/U25eoIJN/497-add-a-aws-lb-check-specific-for-emailalertapi

Previously we had a small number of checks for the health of AWS
load balancers, which were incorrectly excluding some hosts, and
had no consistency in choice between internal/external/public

This replaces the current config to represent all of the services
that are load balanced. While we should see other alerts when
individual apps/machines are down, these alerts have the benefit
of also testing the network between the machines. Recently, we
were not alerted in good time when Email Alert API failed to start,
and this should go some way to addressing that, while making the
alerting less arbitrary for all other services.

Where multiple LBs exist for a service, I've used "internal" ones
for consistency, and because the "external" vs. "public" naming
is unclear, and some "-public" LBs appear to be redundant.

Where an Application LB (ALB) is checked, some of the individual
target groups also appear to be redundant. I've excluded these with
a comment to avoid someone thinking this is "correct".

Some LBs are intentionally only associated with a single instance.
In this case, we will only see a critical alert.