### PR TITLE
remove carrenza production db sync tasks

### DIFF
--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -4,8 +4,6 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::check_cdn_ip_ranges
   - govuk_jenkins::jobs::check_github_ip_ranges
   - govuk_jenkins::jobs::check_sentry_errors
-  - govuk_jenkins::jobs::copy_data_to_integration
-  - govuk_jenkins::jobs::copy_data_to_staging
   - govuk_jenkins::jobs::deploy_app
   - govuk_jenkins::jobs::deploy_cdn
   - govuk_jenkins::jobs::deploy_dns
@@ -18,7 +16,6 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::run_rake_task
   - govuk_jenkins::jobs::smokey
   - govuk_jenkins::jobs::smokey_deploy
-  - govuk_jenkins::jobs::trigger_data_sync_complete
   - govuk_jenkins::jobs::update_cdn_dictionaries
   - govuk_jenkins::jobs::user_monitor
   - govuk_jenkins::jobs::validate_published_dns


### PR DESCRIPTION
This is because carrenza is being shutdown with migration to AWS