### PR TITLE
Reduce the bouncer minimum request rate

### DIFF
--- a/modules/govuk/manifests/node/s_bouncer.pp
+++ b/modules/govuk/manifests/node/s_bouncer.pp
@@ -10,7 +10,7 @@
 #   we would expect to see.
 #
 class govuk::node::s_bouncer (
-  $minimum_request_rate = 5,
+  $minimum_request_rate = 3,
 ) inherits govuk::node::s_base {
 
   include govuk_bouncer::gor


### PR DESCRIPTION
With the changed healthcheck configuration in the Fastly VCL, less
healthcheck requests are being sent, so drop this accordingly.