### PR TITLE
Increase the Content Data API memory thresholds

### DIFF
--- a/modules/govuk/manifests/apps/content_data_api.pp
+++ b/modules/govuk/manifests/apps/content_data_api.pp
@@ -135,6 +135,8 @@ class govuk::apps::content_data_api(
     read_timeout                    => 60,
     additional_check_contact_groups => ['slack-channel-data-informed'],
     unicorn_worker_processes        => 4,
+    nagios_memory_warning           => 1200,
+    nagios_memory_critical          => 1500,
   }
 
   Govuk::App::Envvar {


### PR DESCRIPTION
Now that there are more workers than the default two, the default
memory thresholds aren't high enough.