### PR TITLE
Updates reference to rabbitmq doc

### DIFF
--- a/modules/govuk_rabbitmq/manifests/monitor_messages.pp
+++ b/modules/govuk_rabbitmq/manifests/monitor_messages.pp
@@ -43,7 +43,7 @@ define govuk_rabbitmq::monitor_messages (
       check_command       => "check_nrpe!check_rabbitmq_messages!${rabbitmq_hostname} ${rabbitmq_admin_port} ${rabbitmq_queue} ${rabbitmq_user} ${critical_threshold} ${warning_threshold}",
       service_description => "Check that messages are being processed in rabbitmq queue ${rabbitmq_queue}",
       host_name           => $::fqdn,
-      notes_url           => monitoring_docs_url(rabbitmq-no-consumers-consuming),
+      notes_url           => monitoring_docs_url(rabbitmq-high-number-of-unprocessed-messages),
     }
   }
 }


### PR DESCRIPTION
The doc has changed names [here][related_pr].

Dependant on:
[related_pr]

Trello:
https://trello.com/c/0OHZT3cq/458-investigate-rabbitmq-and-improve-the-documentation

[related_pr]: https://github.com/alphagov/govuk-developer-docs/pull/2751