### PR TITLE
Fix only expecting 1 backend node on Integration

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -355,7 +355,6 @@ monitoring::checks::lb::loadbalancers: # prefer "internal"
   blue-apt-internal:
     healthyhosts_warning: 0
   blue-backend-internal:
-    healthyhosts_warning: 0
     healthyhosts_ignore:
       - backend-i-backdrop-admin # no idea what this is
       - backend-i-content-performance-m # no idea what this is


### PR DESCRIPTION
https://trello.com/c/U25eoIJN/497-add-a-aws-lb-check-specific-for-emailalertapi

This was mistakenly changed without realising Integration is actually
broken - we're missing 1 backend node, out of 2.