### PR TITLE
Fix not raising a critical for timeouts

### DIFF
--- a/modules/icinga/files/usr/lib/nagios/plugins/check_json_healthcheck
+++ b/modules/icinga/files/usr/lib/nagios/plugins/check_json_healthcheck
@@ -156,8 +156,8 @@ if __name__ == "__main__":
             healthcheck_info = HealthCheckInfo(json.loads(response.read().decode('UTF-8')))
     except HTTPError as e:
         report_error("healthcheck returned HTTP error %d" % (e.code,))
-    except timeout:
-        report_error("healthcheck timed out")
+    except:
+        report_error(sys.exc_info()[1])
 
     if healthcheck_info.check_statuses:
         # Each status formatted as, for example, "foo_working: ok"


### PR DESCRIPTION
https://trello.com/c/zrq6ih4v/528-investigate-removal-of-no-processes-found-for-x-for-apps-with-a-healthcheck

Previously this was trying to match the exception against 'timeout'.
This fixes the handler to report the exception message e.g. 'conn
refused'.