### PR TITLE
Improve alerts for when an app is down

### DIFF
--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -460,10 +460,10 @@ define govuk::app::config (
     @@icinga::check::graphite { "check_${title_underscore}_app_process_count_${::hostname}":
       ensure       => $ensure,
       target       => "${::fqdn_metrics}.processes-app-${title_underscore}.ps_count.processes",
-      warning      => '@0', # WARN if there are 0 processes
-      critical     => '@-1', # Don't use the CRITICAL status for now
+      warning      => '@-1',
+      critical     => '@0',
       check_period => $check_period,
-      desc         => "No processes found for ${title_underscore}",
+      desc         => "${title_underscore} has no running processes",
       host_name    => $::fqdn,
       from         => '30seconds',
     }

--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -325,16 +325,6 @@ define govuk::app::config (
       ensure => $ensure,
       regex  => pick($collectd_process_regex, $default_collectd_process_regex),
     }
-    @@icinga::check::graphite { "check_${title_underscore}_app_process_count_${::hostname}":
-      ensure       => $ensure,
-      target       => "${::fqdn_metrics}.processes-app-${title_underscore}.ps_count.processes",
-      warning      => '@0', # WARN if there are 0 processes
-      critical     => '@-1', # Don't use the CRITICAL status for now
-      check_period => $check_period,
-      desc         => "No processes found for ${title_underscore}",
-      host_name    => $::fqdn,
-      from         => '30seconds',
-    }
     @@icinga::check::graphite { "check_${title}_app_cpu_usage${::hostname}":
       ensure         => $ensure,
       target         => "scale(sumSeries(${::fqdn_metrics}.processes-app-${title_underscore}.ps_cputime.*),0.0001)",
@@ -466,7 +456,19 @@ define govuk::app::config (
         contact_groups      => $additional_check_contact_groups,
       }
     }
+  } else {
+    @@icinga::check::graphite { "check_${title_underscore}_app_process_count_${::hostname}":
+      ensure       => $ensure,
+      target       => "${::fqdn_metrics}.processes-app-${title_underscore}.ps_count.processes",
+      warning      => '@0', # WARN if there are 0 processes
+      critical     => '@-1', # Don't use the CRITICAL status for now
+      check_period => $check_period,
+      desc         => "No processes found for ${title_underscore}",
+      host_name    => $::fqdn,
+      from         => '30seconds',
+    }
   }
+
   if ($app_type == 'rack') or $monitor_unicornherder {
     @@icinga::check { "check_app_${title}_unicornherder_up_${::hostname}":
       ensure              => $ensure,


### PR DESCRIPTION
https://trello.com/c/zrq6ih4v/528-investigate-removal-of-no-processes-found-for-x-for-apps-with-a-healthcheck

This makes a few changes to alerts we see when an app is down:

- Only alert on processes if healthcheck not supported
- Show a critical processes alert instead of a warning

Please see the commits for more details.