### PR TITLE
Remove redundant check for no processes

### DIFF
--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -325,16 +325,6 @@ define govuk::app::config (
       ensure => $ensure,
       regex  => pick($collectd_process_regex, $default_collectd_process_regex),
     }
-    @@icinga::check::graphite { "check_${title_underscore}_app_process_count_${::hostname}":
-      ensure       => $ensure,
-      target       => "${::fqdn_metrics}.processes-app-${title_underscore}.ps_count.processes",
-      warning      => '@0', # WARN if there are 0 processes
-      critical     => '@-1', # Don't use the CRITICAL status for now
-      check_period => $check_period,
-      desc         => "No processes found for ${title_underscore}",
-      host_name    => $::fqdn,
-      from         => '30seconds',
-    }
     @@icinga::check::graphite { "check_${title}_app_cpu_usage${::hostname}":
       ensure         => $ensure,
       target         => "scale(sumSeries(${::fqdn_metrics}.processes-app-${title_underscore}.ps_cputime.*),0.0001)",


### PR DESCRIPTION
https://trello.com/c/zrq6ih4v/528-investigate-removal-of-no-processes-found-for-x-for-apps-with-a-healthcheck

This check was introduced to check we were collecting process metrics
for each app [1]. We don't universally check the metrics we collect,
and we have no evidence to suggest this particular metric is a problem.
Note that we have an equivalent check for upstart, which also links
to the same documentation as this alert.

[1]: cd199c36ee642b2b02310259da949ff33ea3a6cc