### PR TITLE
Remove DNS Admins team as an auth source for Jenkins

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -732,9 +732,6 @@ govuk_jenkins::config::user_permissions:
     user: 'alphagov*GOV.UK Production'
     permissions: *jenkins_admin_permission_list
   -
-    user: 'alphagov*GOV.UK DNS Administrators'
-    permissions: *jenkins_admin_permission_list
-  -
     user: 'anonymous'
     permissions:
       - 'hudson.model.Hudson.Read'


### PR DESCRIPTION
- This team was used for RE people not on GOV.UK to Deploy DNS, when we needed to because Verify domains were configured in GOV.UK DNS, deployed via Jenkins.
- Now that that doesn't happen any more (https://github.com/alphagov/govuk-aws-data/pull/773, https://github.com/alphagov/govuk-secrets/pull/1055), we don't need this team and this config.
