### PR TITLE
Move the user monitor Jenkins job to run and alert in AWS

### DIFF
--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -17,7 +17,6 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::smokey
   - govuk_jenkins::jobs::smokey_deploy
   - govuk_jenkins::jobs::update_cdn_dictionaries
-  - govuk_jenkins::jobs::user_monitor
   - govuk_jenkins::jobs::validate_published_dns
 
 govuk_jenkins::jobs::deploy_cdn::enable_slack_notifications: true
@@ -38,4 +37,3 @@ govuk_jenkins::jobs::update_cdn_dictionaries::services:
 
 govuk_jenkins::jobs::deploy_puppet::enable_slack_notifications: true
 govuk_jenkins::jobs::validate_published_dns::run_daily: true
-govuk_jenkins::jobs::user_monitor::enable_icinga_check: true

--- a/hieradata/class/staging/jenkins.yaml
+++ b/hieradata/class/staging/jenkins.yaml
@@ -13,7 +13,6 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::smokey
   - govuk_jenkins::jobs::smokey_deploy
   - govuk_jenkins::jobs::update_cdn_dictionaries
-  - govuk_jenkins::jobs::user_monitor
   - govuk_jenkins::jobs::validate_published_dns
 
 govuk_jenkins::jobs::deploy_cdn::enable_slack_notifications: true

--- a/hieradata_aws/class/production/jenkins.yaml
+++ b/hieradata_aws/class/production/jenkins.yaml
@@ -79,9 +79,11 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::transition_import_dns
   - govuk_jenkins::jobs::transition_import_hits
   - govuk_jenkins::jobs::transition_load_site_config
+  - govuk_jenkins::jobs::user_monitor
   - govuk_jenkins::jobs::whitehall_publisher_notifications
   - govuk_jenkins::jobs::whitehall_run_broken_link_checker
 
 govuk_jenkins::jobs::deploy_cdn::enable_slack_notifications: false
 govuk_jenkins::jobs::deploy_puppet::enable_slack_notifications: false
 govuk_jenkins::jobs::transition_import_hits::s3_bucket: govuk-production-transition-fastly-logs
+govuk_jenkins::jobs::user_monitor::enable_icinga_check: true


### PR DESCRIPTION
- This was only configured to run in AWS Integration and Staging. The Production one - which we take as the source of truth - was only running in Carrenza. Since Carrenza is soon being turned off, I thought I'd save someone else some cleanup by moving it myself, because I got confused by not seeing it in AWS Production Jenkins and had to resort to running it locally manually to see if my changes worked.
- For something that ensures access to things for the right people, it's nice for this to be in the place that people look at regularly.
