### PR TITLE
Fix link to the user monitor Jenkins job (now in AWS) from its alert

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/user_monitor.pp
+++ b/modules/govuk_jenkins/manifests/jobs/user_monitor.pp
@@ -32,7 +32,7 @@ class govuk_jenkins::jobs::user_monitor (
       service_description => $service_description,
       host_name           => $::fqdn,
       freshness_threshold => 5400, # 90 minutes
-      action_url          => "https://deploy.${app_domain}/job/user-monitor/",
+      action_url          => "https://deploy.${::aws_stackname}.${::aws_environment}.govuk.digital/job/user-monitor/",
       notes_url           => monitoring_docs_url(user-monitor);
   }
 }


### PR DESCRIPTION
- This was using `app_domain`, but that has been [set to publishing.service.gov.uk in the Production AWS hieradata](https://github.com/alphagov/govuk-puppet/blob/05ae00cf0ae0d211c8b0c091692be3d0afff366d/hieradata_aws/production.yaml#L2) after everything was assumed migrated. However, `deploy.publishing.service.gov.uk` is the (still live) Carrenza Production Jenkins, and the user monitor job there doesn't exist.
- The `deploy.production.govuk.digital` URL needs the stackname as well because otherwise GitHub authentication callbacks don't work and you have to click the Login button twice.
