### PR TITLE
add default nginx config for AWS ci master

### DIFF
--- a/modules/govuk/manifests/node/s_ci_master.pp
+++ b/modules/govuk/manifests/node/s_ci_master.pp
@@ -15,4 +15,12 @@ class govuk::node::s_ci_master inherits govuk::node::s_base {
     content => template('govuk/node/s_ci_master/jenkins.conf.erb'),
     require => Nginx::Config::Ssl['jenkins'],
   }
+
+  if $::aws_migration {
+    # Close connection if vhost not known
+    nginx::config::vhost::default { 'default':
+      status         => '444',
+      status_message => '',
+    }
+  }
 }


### PR DESCRIPTION
This is needed for ALB listener healthcheck. Taken from jenkins config