### PR TITLE
add server name to nginx config ci master in AWS

### DIFF
--- a/modules/govuk/templates/node/s_ci_master/jenkins.conf.erb
+++ b/modules/govuk/templates/node/s_ci_master/jenkins.conf.erb
@@ -2,6 +2,7 @@ server {
 
   <%- if scope.lookupvar('::aws_migration') %>
   listen 80;
+  server_name ci.*;
   proxy_set_header Host $http_host;
   <%- else %>
   listen 443 ssl;


### PR DESCRIPTION
This is now needed because of PR: https://github.com/alphagov/govuk-aws/pull/1342