### PR TITLE
need to add localhost as server name to ci master nginx

### DIFF
--- a/modules/govuk/templates/node/s_ci_master/jenkins.conf.erb
+++ b/modules/govuk/templates/node/s_ci_master/jenkins.conf.erb
@@ -2,7 +2,7 @@ server {
 
   <%- if scope.lookupvar('::aws_migration') %>
   listen 80;
-  server_name ci.*;
+  server_name ci.* localhost;
   proxy_set_header Host $http_host;
   <%- else %>
   listen 443 ssl;


### PR DESCRIPTION
This follows from PR: https://github.com/alphagov/govuk-aws/pull/1342 and we need jenkins to respond to localhost since the icinga check uses localhost as nameserver.