### PR TITLE
Fix other references to healthcheck docs

### DIFF
--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -465,7 +465,7 @@ define govuk::app::config (
         check_period        => $check_period,
         service_description => "${title} app healthcheck",
         host_name           => $::fqdn,
-        notes_url           => monitoring_docs_url(app-healthcheck-failed),
+        notes_url           => monitoring_docs_url(app-healthcheck-not-ok),
         contact_groups      => $additional_check_contact_groups,
       }
     }

--- a/modules/govuk/manifests/apps/router.pp
+++ b/modules/govuk/manifests/apps/router.pp
@@ -88,7 +88,7 @@ class govuk::apps::router (
     check_command       => "check_app_health!check_app_up!${api_port} ${api_healthcheck}",
     service_description => 'router app healthcheck',
     host_name           => $::fqdn,
-    notes_url           => monitoring_docs_url(app-healthcheck-failed),
+    notes_url           => monitoring_docs_url(app-healthcheck-not-ok),
   }
 
   govuk_logging::logstream { 'router-error-json-log':


### PR DESCRIPTION
https://trello.com/c/zrq6ih4v/528-investigate-removal-of-no-processes-found-for-x-for-apps-with-a-healthcheck

Previously we only updated the JSON-specific healthcheck reference
after renaming / rewriting the asssociated doc. This corrects the
reference for non-JSON healthchecks, which are still compatible
with the guidelines at the top of the doc.