### PR TITLE
install solr6 on all ci agents in AWS except ci agent 4

### DIFF
--- a/hieradata_aws/class/integration/aws_hostname/ci-agent-3.yaml
+++ b/hieradata_aws/class/integration/aws_hostname/ci-agent-3.yaml
@@ -1,3 +1,2 @@
 ---
-
 mongodb::server::version: '2.6.12'

--- a/hieradata_aws/class/integration/aws_hostname/ci-agent-4.yaml
+++ b/hieradata_aws/class/integration/aws_hostname/ci-agent-4.yaml
@@ -1,3 +1,5 @@
 ---
-
 postgresql::globals::version: '9.6'
+
+govuk_solr::disable: true
+govuk_solr6::present: false

--- a/hieradata_aws/class/integration/aws_hostname/ci-agent-7.yaml
+++ b/hieradata_aws/class/integration/aws_hostname/ci-agent-7.yaml
@@ -1,7 +1,3 @@
 ---
 govuk_containers::elasticsearch::primary::enable: false
 govuk_containers::elasticsearch::secondary::enable: false
-
-govuk_solr::disable: true
-
-govuk_solr6::present: true

--- a/hieradata_aws/class/integration/aws_hostname/ci-agent-8.yaml
+++ b/hieradata_aws/class/integration/aws_hostname/ci-agent-8.yaml
@@ -1,7 +1,3 @@
 ---
 govuk_containers::elasticsearch::primary::enable: false
 govuk_containers::elasticsearch::secondary::enable: false
-
-govuk_solr::disable: true
-
-govuk_solr6::present: true

--- a/hieradata_aws/class/integration/ci_agent.yaml
+++ b/hieradata_aws/class/integration/ci_agent.yaml
@@ -22,7 +22,8 @@ govuk_mysql::server::query_cache_size: 0
 govuk_sysdig::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk_sysdig::ensure: 'absent'
 
-govuk_solr6::present: false
+govuk_solr::disable: true
+govuk_solr6::present: true
 
 lv:
   data:


### PR DESCRIPTION
we don't install solr6 on ci agent 4 as postgres 9.6 is installed there.