### PR TITLE
Remove pointless warning for incomplete digest run

### DIFF
--- a/modules/govuk/manifests/apps/email_alert_api/checks.pp
+++ b/modules/govuk/manifests/apps/email_alert_api/checks.pp
@@ -24,17 +24,6 @@ class govuk::apps::email_alert_api::checks(
       latency_critical => '5400'; # 90 minutes
   }
 
-  @@icinga::check::graphite { 'email-alert-api-warning-digest-runs':
-    ensure    => $ensure,
-    host_name => $::fqdn,
-    target    => 'transformNull(keepLastValue(averageSeries(stats.gauges.govuk.app.email-alert-api.*.digest_runs.warning_total)))',
-    warning   => '0',
-    critical  => '100000000',
-    from      => '1hour',
-    desc      => 'email-alert-api - incomplete digest runs - warning',
-    notes_url => monitoring_docs_url(email-alert-api-incomplete-digest-runs),
-  }
-
   @@icinga::check::graphite { 'email-alert-api-unprocessed-content-changes':
     ensure    => $ensure,
     host_name => $::fqdn,


### PR DESCRIPTION
https://trello.com/c/seBH6Dhz/470-update-warning-critical-digest-runs-check

This alert seems to go off every day. Since digest runs are not
time-critical, it barely makes sense to warn for them, especially
since we're about to add code to ensure they self-heal [1]. A
critical alert is ample for getting a human to intervene.

[1]: https://github.com/alphagov/email-alert-api/pull/1405