### PR TITLE
Specify http_host for CKAN

### DIFF
--- a/modules/govuk/manifests/app/nginx_vhost.pp
+++ b/modules/govuk/manifests/app/nginx_vhost.pp
@@ -62,6 +62,9 @@
 #   Boolean, whether to enable HTTP/1.1 for proxying from the Nginx vhost
 #   to the app server.
 #
+# [*http_host*]
+#   The HTTP `Host` header. Defaults to the HTTP host.
+#
 define govuk::app::nginx_vhost (
   $vhost,
   $app_port,
@@ -82,6 +85,7 @@ define govuk::app::nginx_vhost (
   $alert_5xx_warning_rate = 0.05,
   $alert_5xx_critical_rate = 0.1,
   $proxy_http_version_1_1_enabled = false,
+  $http_host = undef,
 ) {
 
   # added to whitelist in lib/puppet-lint/plugins/check_hiera.rb
@@ -115,5 +119,6 @@ define govuk::app::nginx_vhost (
     alert_5xx_warning_rate         => $alert_5xx_warning_rate,
     alert_5xx_critical_rate        => $alert_5xx_critical_rate,
     proxy_http_version_1_1_enabled => $proxy_http_version_1_1_enabled,
+    http_host                      => $http_host,
   }
 }

--- a/modules/govuk/manifests/apps/ckan.pp
+++ b/modules/govuk/manifests/apps/ckan.pp
@@ -198,6 +198,8 @@ class govuk::apps::ckan (
         value   => $pycsw_config;
     }
 
+    $app_domain = hiera('app_domain')
+
     govuk::app::nginx_vhost { 'ckan':
       vhost              => 'ckan',
       protected          => $vhost_protected,
@@ -207,6 +209,7 @@ class govuk::apps::ckan (
       read_timeout       => $request_timeout,
       nginx_extra_config => template('govuk/ckan/nginx.conf.erb'),
       deny_crawlers      => true,
+      http_host          => "ckan.${app_domain}",
     }
 
     file { $ckan_home:


### PR DESCRIPTION
This should fix a recent incident where there's an open redirect vulnerability in CKAN core. Unfortunately we can't upgrade to the version of CKAN where this is fixed, so the alternative is to require that the `Host` header cannot be modified.

The original fix in CKAN is https://github.com/ckan/ckan/commit/0a34afecc76b9cc8030098371b09fdfcd053356a.

[Trello Card](https://trello.com/c/oRVFNc2T/2107-5-investigate-fix-open-redirect-by-host-header-vulnerability-using-nginx) &middot; [Incident Report](https://docs.google.com/document/d/1w1Gp4wOFwSd5WanVS9jzUuyHuwSD3AmTY6qfN5DC9Xc/edit#)