### PR TITLE
Configure Jenkins GitHub servers via puppet

### DIFF
--- a/modules/govuk_ci/files/github-plugin-configuration.xml
+++ b/modules/govuk_ci/files/github-plugin-configuration.xml
@@ -1,0 +1,14 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<github-plugin-configuration plugin="github@1.29.4">
+  <configs>
+    <github-server-config>
+      <apiUrl>https://api.github.com</apiUrl>
+      <manageHooks>false</manageHooks>
+      <credentialsId>github-token-govuk-ci</credentialsId>
+      <clientCacheSize>20</clientCacheSize>
+    </github-server-config>
+  </configs>
+  <hookSecretConfig>
+    <credentialsId></credentialsId>
+  </hookSecretConfig>
+</github-pluginconfiguration>

--- a/modules/govuk_ci/manifests/master.pp
+++ b/modules/govuk_ci/manifests/master.pp
@@ -47,6 +47,15 @@ class govuk_ci::master (
   # Add pipeline jobs from applications hash in Hieradata
   create_resources(govuk_ci::job, $pipeline_jobs)
 
+  # Only add this configuration for CI master Jenkins instances
+  file { '/var/lib/jenkins/github-plugin-configuration.xml':
+    ensure => file,
+    owner  => 'jenkins',
+    group  => 'jenkins',
+    source => 'puppet:///modules/govuk_ci/github-plugin-configuration.xml',
+    notify => Class['Govuk_jenkins::Reload'],
+  }
+
   ufw::allow {'jenkins-slave-to-jenkins-master-on-tcp':
     port  => '32768:65535',
     proto => 'tcp',


### PR DESCRIPTION
This configuration was previously managed by the UI which meant that it
broke when CI was moved to another location. This is a configuration
file that we only want on CI master instance - as this is the only box
with the credential - therefore I configured this in govuk_ci rather
than govuk_jenkins.

The credential this relies on, github-token-govuk-ci, doesn't seem to be
managed by Puppet. However I can see that this
is already a convention for this project with similar tokens referenced
in modules/govuk_ci/templates/application_build_job.xml.erb and
modules/govuk_jenkins/templates/config/org.jenkinsci.plugins.workflow.libs.GlobalLibraries.xml