### PR TITLE
do not deploy puppet from AWS CI to old Carrenza CI

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_puppet_downstream.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_puppet_downstream.yaml.erb
@@ -11,11 +11,6 @@
       - shell: |
           JSON="{\"parameter\": [{\"name\": \"TAG\", \"value\": \"$TAG\"}], \"\": \"\"}"
 
-          # Deploy to downstream environment
-          CRUMB=$(curl https://<%= @jenkins_downstream_api_user %>:<%= @jenkins_downstream_api_password %>@<%= @deploy_url %>/crumbIssuer/api/json | jq --raw-output '. | .crumb')
-
-          curl -f -H "Jenkins-Crumb:$CRUMB" -XPOST https://<%= @jenkins_downstream_api_user %>:<%= @jenkins_downstream_api_password %>@<%= @deploy_url %>/job/Deploy_Puppet/build -d token=<%= @puppet_auth_token %> --data-urlencode json="$JSON"
-
           # Deploy to AWS downstream environment
           CRUMB=$(curl https://<%= @jenkins_downstream_aws_api_user %>:<%= @jenkins_downstream_aws_api_password %>@<%= @aws_deploy_url %>/crumbIssuer/api/json | jq --raw-output '. | .crumb')
 


### PR DESCRIPTION
old carrenza CI is no longer in used and also there is a firewall on the Carrenza CI side which prevents automated deployment from AWS CI