### PR TITLE
Remove Signon Plek Override In AWS

### DIFF
--- a/modules/govuk/manifests/deploy/config.pp
+++ b/modules/govuk/manifests/deploy/config.pp
@@ -126,19 +126,6 @@ class govuk::deploy::config(
       'GOVUK_APP_DOMAIN_EXTERNAL':  value => $app_domain;
     }
 
-    # 1. Signon is still in Carrenza Staging and Production.
-    if ($::aws_environment == 'staging') or ($::aws_environment == 'production') {
-      # draft_content_store overrides PLEK_SERVICE_SIGNON_URI itself because it
-      # uses PLEK_HOSTNAME_PREFIX and therefore has to avoid prefixing the
-      # signon URL with 'draft-'. We therefore mustn't override it here, otherwise
-      # we're duplicating the resource.
-      unless $::govuk_node_class == 'draft_content_store' {
-        govuk_envvar {
-          'PLEK_SERVICE_SIGNON_URI': value => "https://signon.${app_domain}";
-        }
-      }
-    }
-
   } else {
     govuk_envvar {
       'GOVUK_APP_DOMAIN':           value => $app_domain;


### PR DESCRIPTION
This override was added during the migration from AWS to Carrenza, to ensure
that apps hosted by different providers would still be able to communicate with
Signon.

Now that all apps are in AWS, we want them to use the internal load balancer to
connect to Signon. To do this, we must ensure they have
signon.production.govuk-internal.digital set as their Signon URL.

This is an incident action item, you can find more information about this here:
https://docs.google.com/document/d/1npjn9yQ0z_p9ie2RBikt-VpigJWoAz76pgHwNOMlZKM/edit#