### PR TITLE
ci master needs a different jenkins password

### DIFF
--- a/hieradata_aws/class/integration/ci_master.yaml
+++ b/hieradata_aws/class/integration/ci_master.yaml
@@ -143,6 +143,8 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::deploy_puppet_downstream
   - govuk_jenkins::jobs::build_fpm_package
 
+govuk_jenkins::jobs::deploy_app_downstream::jenkins_downstream_api_password: "%{hiera('govuk_jenkins::jobs::deploy_app_downstream::ci_jenkins_downstream_api_password')}"
+
 jenkins::params::default_plugins: []
 
 govuk_jenkins::plugins:


### PR DESCRIPTION
there is a conflict between ci master and jenkins in terms of hiera: govuk_jenkins::jobs::deploy_app_downstream::jenkins_downstream_api_password

so this attempts to solve this issue.