### PR TITLE
Fix faulty reload for cache-clearing-service

### DIFF
--- a/modules/govuk/manifests/apps/cache_clearing_service.pp
+++ b/modules/govuk/manifests/apps/cache_clearing_service.pp
@@ -60,7 +60,7 @@ class govuk::apps::cache_clearing_service (
     app_type                  => 'bare',
     enable_nginx_vhost        => false,
     sentry_dsn                => $sentry_dsn,
-    command                   => './bin/cache_clearing_service',
+    command                   => 'bundle exec foreman start',
     collectd_process_regex    => 'cache-clearing-service/.*rake message_queue:consumer',
     nagios_memory_warning     => $nagios_memory_warning,
     nagios_memory_critical    => $nagios_memory_critical,


### PR DESCRIPTION
https://trello.com/c/R0ECIpcb/988-high-memory-for-cache-clearing-service-app

Previously the command for this service involved running a custom
script that would fail to respond to a SIGHUP, leaving the child
processes running e.g. when Icinga tries to stop it running out of
memory. Since the purpose of the script was just to capture a small
amount of logging output, this removes it from the chain in favour
of a simpler command with no surprising behaviours.