### PR TITLE
Allow cookies for coronavirus find support

### DIFF
--- a/modules/varnish/templates/default.vcl.erb
+++ b/modules/varnish/templates/default.vcl.erb
@@ -85,7 +85,9 @@ sub vcl_recv {
   #   - Licensing
   #   - email-alert-frontend (for subscription management)
   #   - frontend (for sessions across funding registration form)
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/brexit-eu-funding") {
+  #   - smart answers coronavirus find support flow
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/brexit-eu-funding" && req.url !~ "^/find-coronavirus-support/s")
+  {
     unset req.http.Cookie;
   }
   <% end %>
@@ -121,7 +123,7 @@ sub vcl_fetch {
 
   <% if @strip_cookies %>
   # Strip cookies from outbound requests. Corresponding rule in vcl_recv{}
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/brexit-eu-funding") {
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/brexit-eu-funding" && req.url !~ "^/find-coronavirus-support/s") {
     unset beresp.http.Set-Cookie;
   }
   <% end %>


### PR DESCRIPTION
Add inbound and outbound exception for the smart answers coronavirus find support flow as it uses cookie-based sessions to manage state.