### PR TITLE
Fix Puppet error on Integration

### DIFF
--- a/modules/govuk_solr/manifests/config.pp
+++ b/modules/govuk_solr/manifests/config.pp
@@ -23,14 +23,14 @@ class govuk_solr::config (
   unless $disable {
     file{"${solr_home}/current/conf":
       ensure  => directory,
-    } ->
+    }
 
     file{"${solr_home}/current/solr":
       ensure  => directory,
       owner   => $jetty_user,
       group   => $jetty_user,
       recurse => true,
-    } ->
+    }
 
     file {"${solr_home}/current/example/solr/collection1/conf/schema.xml":
       ensure => file,
@@ -38,7 +38,7 @@ class govuk_solr::config (
       group  => $jetty_user,
       source => 'puppet:///modules/govuk_solr/schema.xml',
       notify => Service['jetty'],
-    } ->
+    }
 
     file {"${solr_home}/current/conf/jetty-logging.xml":
       ensure => file,
@@ -46,42 +46,32 @@ class govuk_solr::config (
       group  => $jetty_user,
       source => 'puppet:///modules/govuk_solr/jetty-logging.xml',
       notify => Service['jetty'],
-    } ->
+    }
 
     file {'/etc/default/jetty':
       ensure  => file,
       content => template('govuk_solr/jetty.erb'),
       notify  => Service['jetty'],
-    } ->
+    }
 
     file {'/etc/init.d/jetty':
       ensure  => file,
       mode    => '0755',
       content => template('govuk_solr/jetty.sh.erb'),
       notify  => Service['jetty'],
-    } ->
+    }
 
     file {'/var/log/jetty':
       ensure => directory,
-    } ->
+    }
 
     file {'/var/cache/jetty':
       ensure => directory,
       notify => Service['jetty'],
     }
-  }
 
-  $service_ensure = $disable ? {
-    false => 'running',
-    true  => 'stopped',
-  }
-  $service_enable = $disable ? {
-    false => true,
-    true  => false,
-  }
-
-  service {'jetty':
-    ensure => $service_ensure,
-    enable => $service_enable,
+    service {'jetty':
+      enable => 'running',
+    }
   }
 }


### PR DESCRIPTION
https://trello.com/c/sc2PLcNR/984-whos-fixing-me-ckan-upstart-not-up-in-integration

Error: /Stage[main]/Govuk_solr::Config/Service[jetty]: Could not evaluate: Could not find init script or upstart conf file for 'jetty'

Previously we still defined a 'service' resource even when the
associated init file was absent, which lead to an error. This
avoids defining the service unless its config is present, the
only downside being an attempt to remove disable jetty may leave
an old process running, which seems like a niche scenario.