### PR TITLE
Bump memory threshold for local-links-manager

### DIFF
--- a/modules/govuk/manifests/apps/local_links_manager.pp
+++ b/modules/govuk/manifests/apps/local_links_manager.pp
@@ -137,7 +137,9 @@ class govuk::apps::local_links_manager(
     sentry_dsn               => $sentry_dsn,
     vhost_ssl_only           => true,
     health_check_path        => '/healthcheck',
-    unicorn_worker_processes =>  $unicorn_worker_processes,
+    unicorn_worker_processes => $unicorn_worker_processes,
+    nagios_memory_warning    => 800,
+    nagios_memory_critical   => 900,
   }
 
   Govuk::App::Envvar {


### PR DESCRIPTION
Previously this was hovering near the 700M threshold, and appears to
consistently exceed it following a Ruby 2.7 upgrade [1]. This bumps
the threshold by 100M in all environments, to (hopefully) fix the alert.

[1]: https://github.com/alphagov/local-links-manager/pull/707