### PR TITLE
Stop sync between Production and Staging CKAN

### DIFF
--- a/hieradata_aws/class/staging/db_admin.yaml
+++ b/hieradata_aws/class/staging/db_admin.yaml
@@ -1,6 +1,6 @@
 govuk_env_sync::tasks:
   "pull_ckan_production_daily":
-    ensure: "present"
+    ensure: "disabled"
     hour: "3"
     minute: "15"
     action: "pull"


### PR DESCRIPTION
## What

Whilst pentesting is happening stop the DB sync between production and staging as it could wipe out the pentest users on Staging.