### PR TITLE
Rename location of solr.in.sh

### DIFF
--- a/modules/govuk_solr6/manifests/config.pp
+++ b/modules/govuk_solr6/manifests/config.pp
@@ -5,7 +5,7 @@
 define govuk_solr6::config (
   $init_file = 'puppet:///modules/govuk_solr6/solr.in.sh',
 ) {
-  file {'/etc/init.d/solr.init.sh':
+  file {'/etc/default/solr.in.sh':
     ensure => file,
     mode   => '0755',
     source => $init_file,


### PR DESCRIPTION
It exists in `/etc/default`.