### PR TITLE
Reduces alert time after run/message has processed

### DIFF
--- a/modules/govuk/manifests/apps/email_alert_api/checks.pp
+++ b/modules/govuk/manifests/apps/email_alert_api/checks.pp
@@ -31,7 +31,7 @@ class govuk::apps::email_alert_api::checks(
     warning   => '0',
     critical  => '0',
     from      => '15minutes',
-    desc      => 'email-alert-api - unprocessed content changes older than 120 minutes',
+    desc      => 'email-alert-api - unprocessed content changes older than 2 hours',
     notes_url => monitoring_docs_url(email-alert-api-unprocessed-content-changes),
   }
 
@@ -42,7 +42,7 @@ class govuk::apps::email_alert_api::checks(
     warning   => '0',
     critical  => '0',
     from      => '15minutes',
-    desc      => 'email-alert-api - incomplete digest runs - critical',
+    desc      => 'email-alert-api - incomplete digest runs older than 2 hours',
     notes_url => monitoring_docs_url(email-alert-api-incomplete-digest-runs),
   }
 
@@ -53,7 +53,7 @@ class govuk::apps::email_alert_api::checks(
     warning   => '0',
     critical  => '0',
     from      => '15minutes',
-    desc      => 'email-alert-api - unprocessed messages older than 120 minutes',
+    desc      => 'email-alert-api - unprocessed messages older than 2 hours',
     notes_url => monitoring_docs_url(email-alert-api-unprocessed-messages),
   }
 }

--- a/modules/govuk/manifests/apps/email_alert_api/checks.pp
+++ b/modules/govuk/manifests/apps/email_alert_api/checks.pp
@@ -41,7 +41,7 @@ class govuk::apps::email_alert_api::checks(
     target    => 'transformNull(keepLastValue(averageSeries(stats.gauges.govuk.app.email-alert-api.*.digest_runs.critical_total)))',
     warning   => '0',
     critical  => '0',
-    from      => '1hour',
+    from      => '15minutes',
     desc      => 'email-alert-api - incomplete digest runs - critical',
     notes_url => monitoring_docs_url(email-alert-api-incomplete-digest-runs),
   }
@@ -52,7 +52,7 @@ class govuk::apps::email_alert_api::checks(
     target    => 'transformNull(keepLastValue(averageSeries(stats.gauges.govuk.app.email-alert-api.*.messages.unprocessed_total)))',
     warning   => '0',
     critical  => '0',
-    from      => '1hour',
+    from      => '15minutes',
     desc      => 'email-alert-api - unprocessed messages older than 120 minutes',
     notes_url => monitoring_docs_url(email-alert-api-unprocessed-messages),
   }


### PR DESCRIPTION
An hour seems excessive and creates noise on 2nd line when everything
is fine and dandy.

Related PR:
https://github.com/alphagov/email-alert-api/pull/1421