### PR TITLE
Fix EBS mountpoint for Icinga Logs

### DIFF
--- a/hieradata_aws/class/monitoring.yaml
+++ b/hieradata_aws/class/monitoring.yaml
@@ -10,7 +10,7 @@ lv:
     vg: 'monitoring'
 
 mount:
-  /var/lib/icinga:
+  /var/log/icinga:
     disk: '/dev/mapper/monitoring-data'
     govuk_lvm: 'data'
     mountoptions: 'defaults'


### PR DESCRIPTION
The logs and archive should it on their own storage, this change mounts
the storage in to the correct place of /var/log/icinga.

Logs and archives are not stored within /var/lib/icinga and having it
mounted there is incorrect.