### PR TITLE
Increase manual publishers memory threshold

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -308,6 +308,8 @@ govuk::apps::content_tagger::redis_port: "%{hiera('sidekiq_port')}"
 
 govuk::apps::manuals_publisher::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::manuals_publisher::redis_port: "%{hiera('sidekiq_port')}"
+govuk::apps::manuals_publisher::nagios_memory_warning: 1000
+govuk::apps::manuals_publisher::nagios_memory_critical: 1200
 
 govuk::apps::publisher::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
 govuk::apps::publisher::redis_host: "%{hiera('sidekiq_host')}"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -602,6 +602,8 @@ govuk::apps::link_checker_api::redis_port: "%{hiera('sidekiq_port')}"
 
 govuk::apps::manuals_publisher::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::manuals_publisher::redis_port: "%{hiera('sidekiq_port')}"
+govuk::apps::manuals_publisher::nagios_memory_warning: 1000
+govuk::apps::manuals_publisher::nagios_memory_critical: 1200
 
 govuk::apps::mapit::gdal_version: "1.11.5"
 

--- a/modules/govuk/manifests/apps/manuals_publisher.pp
+++ b/modules/govuk/manifests/apps/manuals_publisher.pp
@@ -71,6 +71,12 @@
 #   The bearer token that will be used to authenticate with link-checker-api
 #   Default: undef
 #
+# [*nagios_memory_warning*]
+#   The threshold that memory must be reached to be triggered as a warning
+#
+# [*nagios_memory_critical*]
+#   The threshold that memory must be reached to be triggered as a critical issue
+#
 class govuk::apps::manuals_publisher(
   $ensure = 'present',
   $port,
@@ -90,19 +96,23 @@ class govuk::apps::manuals_publisher(
   $secret_key_base = undef,
   $link_checker_api_secret_token = undef,
   $link_checker_api_bearer_token = undef,
+  $nagios_memory_warning = undef,
+  $nagios_memory_critical = undef,
 ) {
   $app_name = 'manuals-publisher'
 
   validate_re($ensure, '^(present|absent)$', 'Invalid ensure value')
 
   govuk::app { $app_name:
-    ensure             => $ensure,
-    app_type           => 'rack',
-    port               => $port,
-    sentry_dsn         => $sentry_dsn,
-    health_check_path  => '/healthcheck',
-    log_format_is_json => true,
-    nginx_extra_config => 'client_max_body_size 500m;',
+    ensure                 => $ensure,
+    app_type               => 'rack',
+    port                   => $port,
+    sentry_dsn             => $sentry_dsn,
+    health_check_path      => '/healthcheck',
+    log_format_is_json     => true,
+    nginx_extra_config     => 'client_max_body_size 500m;',
+    nagios_memory_warning  => $nagios_memory_warning,
+    nagios_memory_critical => $nagios_memory_critical,
   }
 
   govuk::procfile::worker {'manuals-publisher':


### PR DESCRIPTION
After a busy morning of publishing manuals publisher got into a state of
rebooting frequently (~25 times) as the app kept crossing the memory
thresholds. The thresholds atm are the [default] of 700/800.

Increasing the threshold will give the app some more leeway before restarting. 
We've approx ~10gb of space on each backend machine so the increase
should be fine.

### Current memory thresholds
<img width="1033" alt="Screenshot 2020-10-05 at 16 33 58" src="https://user-images.githubusercontent.com/24479188/95100079-a3048200-0728-11eb-96bb-16a51c938136.png">

[default]: https://github.com/alphagov/govuk-puppet/blob/master/modules/govuk/manifests/app/config.pp#L111-L112
