### PR TITLE
Add ruby 2.7.2 to rbenv

### DIFF
--- a/modules/govuk_rbenv/manifests/all.pp
+++ b/modules/govuk_rbenv/manifests/all.pp
@@ -31,6 +31,7 @@ class govuk_rbenv::all (
     '2.6.6',
     '2.7.0',
     '2.7.1',
+    '2.7.2',
   ]
 
   govuk_rbenv::install_ruby_version { $ruby_versions:
@@ -43,6 +44,6 @@ class govuk_rbenv::all (
   }
 
   rbenv::alias { '2.7':
-    to_version => '2.7.1',
+    to_version => '2.7.2',
   }
 }


### PR DESCRIPTION
ruby 2.7.2 has now been uploaded to our aptly server so is available to
rbenv.

Also aliases 2.7.2 as the default for 2.7.