### PR TITLE
Re-point manuals for unprocessed alerts

### DIFF
--- a/modules/govuk/manifests/apps/email_alert_api/checks.pp
+++ b/modules/govuk/manifests/apps/email_alert_api/checks.pp
@@ -32,7 +32,7 @@ class govuk::apps::email_alert_api::checks(
     critical  => '0',
     from      => '15minutes',
     desc      => 'email-alert-api - unprocessed content changes older than 2 hours',
-    notes_url => monitoring_docs_url(email-alert-api-unprocessed-content-changes),
+    notes_url => monitoring_docs_url(email-alert-api-unprocessed-work),
   }
 
   @@icinga::check::graphite { 'email-alert-api-critical-digest-runs':
@@ -43,7 +43,7 @@ class govuk::apps::email_alert_api::checks(
     critical  => '0',
     from      => '15minutes',
     desc      => 'email-alert-api - incomplete digest runs older than 2 hours',
-    notes_url => monitoring_docs_url(email-alert-api-incomplete-digest-runs),
+    notes_url => monitoring_docs_url(email-alert-api-unprocessed-work),
   }
 
   @@icinga::check::graphite { 'email-alert-api-unprocessed-messages':
@@ -54,6 +54,6 @@ class govuk::apps::email_alert_api::checks(
     critical  => '0',
     from      => '15minutes',
     desc      => 'email-alert-api - unprocessed messages older than 2 hours',
-    notes_url => monitoring_docs_url(email-alert-api-unprocessed-messages),
+    notes_url => monitoring_docs_url(email-alert-api-unprocessed-work),
   }
 }


### PR DESCRIPTION
https://trello.com/c/seBH6Dhz/470-update-warning-critical-digest-runs-check

Depends on: https://github.com/alphagov/govuk-developer-docs/pull/2802

This reflects that we've combined the documentation for these alerts
into a single manual, since the context / actions are very similar.