### PR TITLE
Update solr to 6.6.2

### DIFF
--- a/modules/govuk_solr6/manifests/init.pp
+++ b/modules/govuk_solr6/manifests/init.pp
@@ -8,12 +8,16 @@
 # [*present*]
 #   Whether package should _actually_ be present.
 #
+# [*version*]
+#   Default version is 6.6.2, can be overridden if needed
+#
 class govuk_solr6 (
   $present = true,
+  $version = '6.6.2'
 ) {
   $package_ensure = $present ? {
     false => absent,
-    true  => present,
+    true  => $version,
   }
 
   include govuk_solr6::repo


### PR DESCRIPTION
## What 

Upgrade solr to 6.6.2 where it is present, as some machines do not need to have solr installed.