### PR TITLE
Update email alert api token for pentesting on staging

### DIFF
--- a/modules/govuk_env_sync/files/transformation_sql/enable_staging_only_signon_accounts.sql
+++ b/modules/govuk_env_sync/files/transformation_sql/enable_staging_only_signon_accounts.sql
@@ -9,3 +9,9 @@ WHERE email IN (
   'tirath.rai@digital.cabinet-office.gov.uk',
   'pentestapiuser@alphagov.co.uk'
 );
+
+UPDATE oauth_access_tokens
+INNER JOIN users
+  ON oauth_access_tokens.resource_owner_id = users.id
+SET revoked_at = NULL
+WHERE users.email = "pentestapiuser@alphagov.co.uk";

--- a/modules/govuk_env_sync/files/transformation_sql/enable_staging_only_signon_accounts.sql
+++ b/modules/govuk_env_sync/files/transformation_sql/enable_staging_only_signon_accounts.sql
@@ -6,5 +6,6 @@ SET suspended_at = NULL,
 WHERE email IN (
   'ovas.iqbal@digital.cabinet-office.gov.uk',
   'samuel.pritchard@digital.cabinet-office.gov.uk',
-  'tirath.rai@digital.cabinet-office.gov.uk'
+  'tirath.rai@digital.cabinet-office.gov.uk',
+  'pentestapiuser@alphagov.co.uk'
 );


### PR DESCRIPTION
Pentesters need a bearer token for email-alert-api to carry out their work.

We've create a user and associated bearer token in Signon and subsequently suspended the user and revoked the token.

These will be persisted to staging during the normal data sync, but to minimise manual intervention, we also want to unsuspend the api user and reinstate the bearer token.

Add the pentest user to the existing SQL script to unsuspend the user and also add an extra SQL clause to reinstate the bearer token.