### PR TITLE
Add a jenkins task to publish a single special route

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/publish_special_routes.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/publish_special_routes.yaml.erb
@@ -32,3 +32,30 @@
     wrappers:
         - ansicolor:
             colormap: xterm
+
+- job:
+    name: Publish_Single_Special_Route
+    display-name: "Publish single special route"
+    project-type: freestyle
+    description: "Publish single special route to the Publishing API"
+    properties:
+        - build-discarder:
+            days-to-keep: 30
+            artifact-num-to-keep: 5
+        - github:
+            url: https://github.com/alphagov/special-route-publisher/
+    scm:
+      - special-route-publisher_Publish_Special_Routes
+    builders:
+        - shell: |
+            export GOVUK_APP_DOMAIN=<%= @app_domain %>
+            export PUBLISHING_API_BEARER_TOKEN=<%= @publishing_api_bearer_token %>
+            bundle install --path "${HOME}/bundles/${JOB_NAME}"
+            bundle exec rake publish_one_special_route["${BASE_PATH}"]
+    wrappers:
+        - ansicolor:
+            colormap: xterm
+    parameters:
+      - string:
+          name: BASE_PATH
+          description: The base path of the route to be published


### PR DESCRIPTION
Trello: https://trello.com/c/EUGVdXmo/834-publish-local-lockdown-finder-content-item
Related to: https://github.com/alphagov/special-route-publisher/pull/117

# What?
Special-route-publisher only exists to be run as a jenkins task, so it doesn't need deploying after changes are merged.
This PR adds a task to allow people to publish a specific route, rather than all of them.

# Note to reviewer

This job needs to allow users to pass a base path as a parameter. I _think_ this is how to do it.

