### PR TITLE
Increase memory thresholds for Asset Manager

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -276,8 +276,8 @@ govuk::apps::asset_manager::mongodb_nodes:
 govuk::apps::asset_manager::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::asset_manager::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::asset_manager::unicorn_worker_processes: "16"
-govuk::apps::asset_manager::nagios_memory_warning: 2500
-govuk::apps::asset_manager::nagios_memory_critical: 2750
+govuk::apps::asset_manager::nagios_memory_warning: 3000
+govuk::apps::asset_manager::nagios_memory_critical: 3300
 
 govuk::apps::authenticating_proxy::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
 

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -437,8 +437,8 @@ govuk::apps::asset_manager::mongodb_nodes:
 govuk::apps::asset_manager::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::asset_manager::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::asset_manager::unicorn_worker_processes: "16"
-govuk::apps::asset_manager::nagios_memory_warning: 2500
-govuk::apps::asset_manager::nagios_memory_critical: 2750
+govuk::apps::asset_manager::nagios_memory_warning: 3000
+govuk::apps::asset_manager::nagios_memory_critical: 3300
 
 govuk::apps::authenticating_proxy::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
 


### PR DESCRIPTION
This PR increases the memory thresholds for Asset Manager, for both warning and critical. The reason for this bump in the thresholds is after upgrading Asset Manager to Ruby 2.7.1 (from Ruby 2.6.6), which generally results in more memory being consumed. This has been investigated by the Rails upgrade team and seems to be genuine (rather than a memory leak etc), so this PR is bumping the thresholds by 20%, equal to the amount that memory consumption has increased, in order to keep the same (but now increased) baselines.