### PR TITLE
Increase memory thresholds for Local Links Manager

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -675,8 +675,8 @@ govuk::apps::local_links_manager::db::lb_ip_range: "%{hiera('environment_ip_pref
 govuk::apps::local_links_manager::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::local_links_manager::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::local_links_manager::unicorn_worker_processes: "4"
-govuk::apps::local_links_manager::nagios_memory_warning: 1300
-govuk::apps::local_links_manager::nagios_memory_critical: 1800
+govuk::apps::local_links_manager::nagios_memory_warning: 1600
+govuk::apps::local_links_manager::nagios_memory_critical: 2200
 
 govuk::apps::mapit::enabled: true
 


### PR DESCRIPTION
This PR increases the memory thresholds for Local Links Manager, for both warning and critical. The reason for this bump in the thresholds is after upgrading Local Links Manager to Ruby 2.7.1 (from Ruby 2.6.6), which generally results in more memory being consumed. This has been investigated by the Rails upgrade team and seems to be genuine (rather than a memory leak etc), so this PR is bumping the thresholds by around 20%, equal to the amount that memory consumption has increased, in order to keep the same (but now increased) baselines.