### PR TITLE
Update local links manager to use defined memory thresholds

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -675,8 +675,8 @@ govuk::apps::local_links_manager::db::lb_ip_range: "%{hiera('environment_ip_pref
 govuk::apps::local_links_manager::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::local_links_manager::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::local_links_manager::unicorn_worker_processes: "4"
-govuk::apps::local_links_manager::nagios_memory_warning: 1600
-govuk::apps::local_links_manager::nagios_memory_critical: 2200
+govuk::apps::local_links_manager::nagios_memory_warning: 960
+govuk::apps::local_links_manager::nagios_memory_critical: 1100
 
 govuk::apps::mapit::enabled: true
 

--- a/modules/govuk/manifests/apps/local_links_manager.pp
+++ b/modules/govuk/manifests/apps/local_links_manager.pp
@@ -98,6 +98,11 @@
 #   The external subdomain used by the app
 #   Default: undef
 #
+# [*nagios_memory_warning*]
+#   The threshold that memory must be reached to be triggered as a warning
+# [*nagios_memory_critical*]
+#   The threshold that memory must be reached to be triggered as a critical issue
+#
 class govuk::apps::local_links_manager(
   $ensure = 'present',
   $port,
@@ -126,6 +131,8 @@ class govuk::apps::local_links_manager(
   $run_links_ga_export = false,
   $unicorn_worker_processes = undef,
   $app_domain = undef,
+  $nagios_memory_warning = undef,
+  $nagios_memory_critical = undef,
 ) {
   $app_name = 'local-links-manager'
 
@@ -138,8 +145,8 @@ class govuk::apps::local_links_manager(
     vhost_ssl_only           => true,
     health_check_path        => '/healthcheck',
     unicorn_worker_processes => $unicorn_worker_processes,
-    nagios_memory_warning    => 800,
-    nagios_memory_critical   => 900,
+    nagios_memory_warning    => $nagios_memory_warning,
+    nagios_memory_critical   => $nagios_memory_critical,
   }
 
   Govuk::App::Envvar {


### PR DESCRIPTION
This PR updates local links manager to use defined memory thresholds from `hieradata_aws/common.yaml`, in addition to updating the values for these thresholds based on what was previously in `local_links_manager.pp` as well as from looking at the live memory the app is using.