### PR TITLE
Add a script to monitor unicornherder reloads

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1184,6 +1184,8 @@ govuk_sudo::sudo_conf:
     content: 'deploy ALL=NOPASSWD:/etc/init.d/varnish'
   deploy_varnishadm:
     content: 'deploy ALL=NOPASSWD:/usr/bin/varnishadm'
+  deploy_govuk_unicorn_reload:
+    content: 'deploy ALL=NOPASSWD:/usr/local/bin/govuk_unicorn_reload'
   icinga_init_ctl:
     content: 'nagios ALL=NOPASSWD:/sbin/initctl reload *'
   icinga_initctl_restart:

--- a/modules/govuk/files/usr/local/bin/govuk_unicorn_reload
+++ b/modules/govuk/files/usr/local/bin/govuk_unicorn_reload
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+# This script is a wrapper around the upstart reload command intended for a
+# an application that is run via unicornherder.
+#
+# This script supervises the termination and creation of the processes
+# unicornherder manages. This is so that we can know when a deployment of
+# an application has flipped from the previous version to the new version,
+# which can be used to determine when it is safe to test a new deployment
+# of an app.
+
+if [ "$#" -ne "1" ]; then
+  echo "Usage: sudo govuk_unicorn_reload <APP_NAME>"
+  exit 1
+fi
+
+set -eu
+
+status () {
+  echo "---> ${@}"
+}
+
+error () {
+  echo "ERROR: ${@}" >&2
+  exit 1
+}
+
+pid_running () {
+  ps -p ${@} &> /dev/null
+}
+
+read_pid () {
+  cat /var/run/${@}/app.pid
+}
+
+app=$1
+
+status "Checking ${app} is running"
+
+if [ -e "/var/run/${app}/app.pid" ]; then
+  old_pid=$(read_pid $app)
+else
+  error "No pid file at /var/run/${app}/app.pid"
+fi
+
+pid_running $old_pid || error "Process ${old_pid} doesn't appear to be running"
+
+status "${app} is running with process ${old_pid}. Reloading..."
+initctl reload $app
+
+waiting_for=0
+new_pid=""
+
+while true; do
+  sleep 10
+  waiting_for=$(($waiting_for+10))
+  current_pid=$(read_pid $app) || error "Couldn't establish the current pid"
+
+  if [ -z $new_pid ] && [ $old_pid -ne $current_pid ]; then
+    new_pid=$current_pid
+    status "New process ${new_pid} started"
+  fi
+
+  if ! $(pid_running $old_pid); then
+    status "Process ${old_pid} has exited"
+    break
+  elif [ $waiting_for -gt 180 ]; then
+    error "Process ${old_pid} is still running after 3 minutes, something has gone wrong"
+  else
+    status "Waiting for processes to swap over"
+  fi
+done
+
+if $(pid_running $new_pid); then
+  status "Successfully reloaded ${app}"
+else
+  error "The new process for ${app} doesn't appear to be running"
+fi

--- a/modules/govuk/manifests/deploy/config.pp
+++ b/modules/govuk/manifests/deploy/config.pp
@@ -78,6 +78,16 @@ class govuk::deploy::config(
     mode   => '0755',
   }
 
+  # govuk_unicorn_reload is a wrapper around the upstart command to reload
+  # unicorn following a deploy. It supervises the reloading to delay confirming
+  # a reload as complete until the new process is running and the old one is
+  # stopped.
+  file { '/usr/local/bin/govuk_unicorn_reload':
+    ensure => present,
+    source => 'puppet:///modules/govuk/usr/local/bin/govuk_unicorn_reload',
+    mode   => '0755',
+  }
+
   # govuk_setenv is a simple script that loads the environment for a GOV.UK
   # application and execs its arguments
   # daemontools provides envdir, used by govuk_setenv


### PR DESCRIPTION
Trello: https://trello.com/c/oPNhsGl3/536-investigate-delaying-an-app-deployment-until-the-app-has-restarted-to-avoid-false-smokey-builds

We reload Ruby apps, following a deployment, by using upstart to reload
a unicornherder [1] process. This reload creates a new unicorn process
with new workers initialised, after a period of overlap - where the old
and new unicorn processes serve requests - the old process is
terminated.

The problem with this functionality is that we lack visibility of when
a new version of an app is available. We know that we told it to
reload and we expect that some point in the next couple of minutes the
app will be available. This has led to incidents where we've triggered
smoke tests following the deploy of a broken app, but we've been unaware
the app was broken because the smoke tests ran against the old,
non-broken, version of the app.

To counter this problem this commit introduces a wrapper script for
unicornherder reloading. This script monitors whether a new process is
created and when the old one is removed. This was done as a separate
script to unicornherder as there didn't seem a simple synchronous way
to communicate with the process (our existing communication is via signals
which are an asynchronous medium).

The script is expected to be run by a superuser as per the existing reload
commands [2]. To support this I've added in permissions for the deploy user
to be able to run this script with sudo.

There's a couple of parts to the script that we may consider needing to
parameterise should a need arise. It expects the pid file to be in a
consistent location matching the name of the service and it expects the
restarts to complete within 3 minutes.

I wrote this in bash as it seemed to be the most common approach we have
for wrapper scripts and this avoids the dependency version/concerns that
would be the case in Ruby.

Trying this out on a deploy you get the following output:

```
18:03:30   * executing `deploy:restart'
18:03:30   * executing "sudo initctl start email-alert-api 2>/dev/null || sudo govuk_unicorn_reload email-alert-api"
18:03:30     servers: ["ip-10-1-5-9.eu-west-1.compute.internal", "ip-10-1-6-234.eu-west-1.compute.internal"]
18:03:30     [ip-10-1-5-9.eu-west-1.compute.internal] executing command
18:03:30 *** [err :: ip-10-1-5-9.eu-west-1.compute.internal] ---> Checking email-alert-api is running
18:03:30 *** [err :: ip-10-1-5-9.eu-west-1.compute.internal] ---> email-alert-api is running with process 26011. Reloading...
18:03:40 *** [err :: ip-10-1-5-9.eu-west-1.compute.internal] ---> New process 26718 started
18:03:40 *** [err :: ip-10-1-5-9.eu-west-1.compute.internal] ---> Waiting for processes to swap over
18:03:50 *** [err :: ip-10-1-5-9.eu-west-1.compute.internal] ---> Waiting for processes to swap over
18:04:00 *** [err :: ip-10-1-5-9.eu-west-1.compute.internal] ---> Waiting for processes to swap over
18:04:10 *** [err :: ip-10-1-5-9.eu-west-1.compute.internal] ---> Process 26011 has exited
18:04:10 *** [err :: ip-10-1-5-9.eu-west-1.compute.internal] ---> Successfully reloaded email-alert-api
18:04:10     command finished in 40145ms
18:04:10     [ip-10-1-6-234.eu-west-1.compute.internal] executing command
18:04:10 *** [err :: ip-10-1-6-234.eu-west-1.compute.internal] ---> Checking email-alert-api is running
18:04:10 *** [err :: ip-10-1-6-234.eu-west-1.compute.internal] ---> email-alert-api is running with process 29454. Reloading...
18:04:20 *** [err :: ip-10-1-6-234.eu-west-1.compute.internal] ---> New process 30188 started
18:04:20 *** [err :: ip-10-1-6-234.eu-west-1.compute.internal] ---> Waiting for processes to swap over
18:04:30 *** [err :: ip-10-1-6-234.eu-west-1.compute.internal] ---> Waiting for processes to swap over
18:04:40 *** [err :: ip-10-1-6-234.eu-west-1.compute.internal] ---> Waiting for processes to swap over
18:04:50 *** [err :: ip-10-1-6-234.eu-west-1.compute.internal] ---> Process 29454 has exited
18:04:50 *** [err :: ip-10-1-6-234.eu-west-1.compute.internal] ---> Successfully reloaded email-alert-api
18:04:50     command finished in 40112ms
```

We can also configure the task to run in parallel to speed up the
process:

```
19:14:16   * executing `deploy:restart'
19:14:16   * executing "sudo initctl start email-alert-api 2>/dev/null || sudo govuk_unicorn_reload email-alert-api"
19:14:16     servers: ["ip-10-1-5-9.eu-west-1.compute.internal", "ip-10-1-6-234.eu-west-1.compute.internal"]
19:14:16     [ip-10-1-6-234.eu-west-1.compute.internal] executing command
19:14:16     [ip-10-1-5-9.eu-west-1.compute.internal] executing command
19:14:16 *** [err :: ip-10-1-6-234.eu-west-1.compute.internal] ---> Checking email-alert-api is running
19:14:16 *** [err :: ip-10-1-5-9.eu-west-1.compute.internal] ---> Checking email-alert-api is running
19:14:16 *** [err :: ip-10-1-6-234.eu-west-1.compute.internal] ---> email-alert-api is running with process 30188. Reloading...
19:14:16 *** [err :: ip-10-1-5-9.eu-west-1.compute.internal] ---> email-alert-api is running with process 26718. Reloading...
19:14:26 *** [err :: ip-10-1-5-9.eu-west-1.compute.internal] ---> New process 533 started
19:14:26 *** [err :: ip-10-1-6-234.eu-west-1.compute.internal] ---> New process 4064 started
19:14:26 *** [err :: ip-10-1-5-9.eu-west-1.compute.internal] ---> Waiting for processes to swap over
19:14:26 *** [err :: ip-10-1-6-234.eu-west-1.compute.internal] ---> Waiting for processes to swap over
19:14:36 *** [err :: ip-10-1-5-9.eu-west-1.compute.internal] ---> Waiting for processes to swap over
19:14:36 *** [err :: ip-10-1-6-234.eu-west-1.compute.internal] ---> Waiting for processes to swap over
19:14:46 *** [err :: ip-10-1-5-9.eu-west-1.compute.internal] ---> Waiting for processes to swap over
19:14:46 *** [err :: ip-10-1-6-234.eu-west-1.compute.internal] ---> Waiting for processes to swap over
19:14:56 *** [err :: ip-10-1-5-9.eu-west-1.compute.internal] ---> Process 26718 has exited
19:14:56 *** [err :: ip-10-1-6-234.eu-west-1.compute.internal] ---> Process 30188 has exited
19:14:56 *** [err :: ip-10-1-5-9.eu-west-1.compute.internal] ---> Successfully reloaded email-alert-api
19:14:56 *** [err :: ip-10-1-6-234.eu-west-1.compute.internal] ---> Successfully reloaded email-alert-api
19:14:56     command finished in 40172ms
```

[1]: https://github.com/gds-operations/unicornherder
[2]: https://github.com/alphagov/govuk-app-deployment/blob/96e15410ed5bbd3fe2a5e209dae2d5e55c119ef2/recipes/ruby.rb#L26