### PR TITLE
Use deploy home directory in govuk_app_console

### DIFF
--- a/modules/govuk_scripts/files/usr/local/bin/govuk_app_console
+++ b/modules/govuk_scripts/files/usr/local/bin/govuk_app_console
@@ -17,11 +17,11 @@ fi
 cd /var/apps/$1
 
 if [ -f bin/rails ]; then
-  sudo -u deploy govuk_setenv $1 bundle exec ./bin/rails console
+  sudo -u deploy -H govuk_setenv $1 bundle exec ./bin/rails console
 elif [ -f script/rails ]; then
-  sudo -u deploy govuk_setenv $1 bundle exec ./script/rails console
+  sudo -u deploy -H govuk_setenv $1 bundle exec ./script/rails console
 elif [ -f console ]; then
-  sudo -u deploy govuk_setenv $1 bundle exec ./console
+  sudo -u deploy -H govuk_setenv $1 bundle exec ./console
 else
   echo "I don't know how to run a console for $1"
   exit 1


### PR DESCRIPTION
In more recent versions of Ruby, the IRB console records a history of the commands by trying to write to a `~/.irb_history` file. Currently the way we run the console means the home directory is set the user who logged in, rather than the deploy user, meaning the file isn't writable:

```
peterhartshorn@ec2-production-blue-email_alert_api-ip-10-13-6-93:~$ govuk_app_console email-alert-api
`/home/peterhartshorn` is not writable.
Bundler will use `/tmp/user/1028/bundler20201014-2772-161lx322772' as your home directory temporarily.
I, [2020-10-14T11:47:23.624973 #2772]  INFO -- sentry: ** [Raven] Raven 3.0.4 ready to catch errors
Loading production environment (Rails 6.0.3.4)
bundler: failed to load command: ./bin/rails (./bin/rails)
Errno::EACCES: Permission denied @ rb_file_s_stat - /home/peterhartshorn/.irb_history
```

Using the `-H` option means the home directory will be set to `/home/deploy` which is the same user running the Rails console, and will therefore have access to write the history file.