### PR TITLE
Changing solr version to investigate ckan core

### DIFF
--- a/hieradata_aws/class/production/ckan.yaml
+++ b/hieradata_aws/class/production/ckan.yaml
@@ -2,6 +2,7 @@
 
 govuk_solr::disable: true
 govuk_solr6::present: true
+govuk_solr6::version: 6.4.2-1
 
 govuk::apps::ckan::solr_core: ckan
 govuk::apps::ckan::solr_core_configset: ckan28

--- a/hieradata_aws/class/staging/ckan.yaml
+++ b/hieradata_aws/class/staging/ckan.yaml
@@ -2,6 +2,7 @@
 
 govuk_solr::disable: true
 govuk_solr6::present: true
+govuk_solr6::version: 6.4.2-1
 
 govuk::apps::ckan::solr_core: ckan
 govuk::apps::ckan::solr_core_configset: ckan28


### PR DESCRIPTION
6.6.2 is having some issues with the defaultSearchField element, so reverting back to previous version to get it running