### PR TITLE
Expose GOVUK_DATA_SYNC_PERIOD ENV variable for govuk_app_config

### DIFF
--- a/modules/govuk/lib/puppet/parser/functions/data_sync_times.rb
+++ b/modules/govuk/lib/puppet/parser/functions/data_sync_times.rb
@@ -1,0 +1,38 @@
+module Puppet::Parser::Functions
+  newfunction(:data_sync_times, :type => :rvalue, :doc => <<-EOS
+Return information about the data sync times, depending on the argument passed
+    EOS
+  ) do |args|
+    start_hour = 22
+    start_minute = 0
+    finish_hour = 8
+	finish_minute = 0
+	expected_args = 1
+
+    if args.size != expected_args
+      raise ArgumentError, "data_sync_times: Wrong number of arguments " +
+      "(given #{args.size}, expected #{expected_args})"
+    end
+
+    type = args[0]
+
+    case type
+    when 'time_range'
+      "#{start_hour}:#{start_minute}-#{finish_hour}:#{finish_minute}"
+    when 'start_time'
+      "#{start_hour}:#{start_minute}"
+    when 'start_hour'
+      start_hour
+    when 'start_minute'
+      start_minute
+    when 'finish_time'
+      "#{finish_hour}:#{finish_minute}"
+    when 'finish_hour'
+      finish_hour
+    when 'finish_minute'
+      finish_minute
+    else
+      raise ArgumentError, "data_sync_times: Unknown argument #{type}"
+    end
+  end
+end

--- a/modules/govuk/manifests/deploy/config.pp
+++ b/modules/govuk/manifests/deploy/config.pp
@@ -129,7 +129,7 @@ class govuk::deploy::config(
 
   if $::aws_migration and ($::aws_environment != 'production') {
     govuk_envvar {
-      'GOVUK_DATA_SYNC_PERIOD': value => '22:00-8:00'; # This should match up with the govuk_data_sync_in_progress class
+      'GOVUK_DATA_SYNC_PERIOD': value => data_sync_times('time_range');
     }
   }
 

--- a/modules/govuk/manifests/deploy/config.pp
+++ b/modules/govuk/manifests/deploy/config.pp
@@ -127,6 +127,12 @@ class govuk::deploy::config(
     'GOVUK_CSP_REPORT_URI': value      => $csp_report_uri;
   }
 
+  if $::aws_migration and ($::aws_environment != 'production') {
+    govuk_envvar {
+      'GOVUK_DATA_SYNC_PERIOD': value => '22:00-8:00'; # This should match up with the govuk_data_sync_in_progress class
+    }
+  }
+
   if $::aws_migration {
     $app_domain_internal = hiera('app_domain_internal')
 

--- a/modules/govuk_data_sync_in_progress/manifests/init.pp
+++ b/modules/govuk_data_sync_in_progress/manifests/init.pp
@@ -17,12 +17,6 @@ define govuk_data_sync_in_progress(
 ) {
   $fact_path = '/etc/govuk/env.d/FACTER_data_sync_in_progress'
 
-  $start_hour = 22
-  $start_minute = 0
-
-  $finish_hour = 8
-  $finish_minute = 00
-
   if !defined(File[$fact_path]) {
     file { $fact_path:
       ensure  => present,
@@ -35,8 +29,8 @@ define govuk_data_sync_in_progress(
     cron { 'data_sync_started':
       command => "echo 'true' > ${fact_path}",
       user    => 'deploy',
-      hour    => $start_hour,
-      minute  => $start_minute,
+      hour    => data_sync_times('start_hour'),
+      minute  => data_sync_times('start_minute'),
     }
   }
 
@@ -44,8 +38,8 @@ define govuk_data_sync_in_progress(
     cron { 'data_sync_finished':
       command => "echo '' > ${$fact_path}",
       user    => 'deploy',
-      hour    => $finish_hour,
-      minute  => $finish_minute,
+      hour    => data_sync_times('finish_hour'),
+      minute  => data_sync_times('finish_minute'),
     }
   }
 
@@ -53,8 +47,8 @@ define govuk_data_sync_in_progress(
     cron { "data_sync_started_${title}":
       command => $start_command,
       user    => 'deploy',
-      hour    => $start_hour,
-      minute  => $start_minute,
+      hour    => data_sync_times('start_hour'),
+      minute  => data_sync_times('start_minute'),
     }
   }
 
@@ -62,8 +56,8 @@ define govuk_data_sync_in_progress(
     cron { "data_sync_finished_${title}":
       command => $finish_command,
       user    => 'deploy',
-      hour    => $finish_hour,
-      minute  => $finish_minute,
+      hour    => data_sync_times('finish_hour'),
+      minute  => data_sync_times('finish_minute'),
     }
   }
 }

--- a/modules/monitoring/manifests/contacts.pp
+++ b/modules/monitoring/manifests/contacts.pp
@@ -54,9 +54,8 @@ class monitoring::contacts (
   $midday = '11:00'
   $office_day_end = '16:30'
   $midnight_day_end = '24:00'
-  # This should match up with the govuk_data_sync_in_progress class
-  $data_sync_start = '22:00'
-  $data_sync_end = '08:00'
+  $data_sync_start = data_sync_times('start_time')
+  $data_sync_end = data_sync_times('finish_time')
 
   $all_day = "${midnight_day_start}-${midnight_day_end}"
   $office_day = "${office_day_start}-${office_day_end}"


### PR DESCRIPTION
This is to enable https://github.com/alphagov/govuk_app_config/pull/160,
which ignores certain exceptions if they occur during the data
sync period. We want to set this via Puppet so that it is DRY and
configured in only one place.

Trello: https://trello.com/c/rAlvGlSp/2123-5-ignore-data-sync-errors-in-govukappconfig