### PR TITLE
Increase Signon memory thresholds

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -369,8 +369,8 @@ govuk::apps::signon::db_username: 'signon'
 govuk::apps::signon::redis_url: "redis://redis-1.backend:6379/0"
 govuk::apps::signon::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::signon::redis_port: "%{hiera('sidekiq_port')}"
-govuk::apps::signon::nagios_memory_warning: 1100
-govuk::apps::signon::nagios_memory_critical: 1200
+govuk::apps::signon::nagios_memory_warning: 1300
+govuk::apps::signon::nagios_memory_critical: 1450
 govuk::apps::signon::unicorn_worker_processes: "4"
 
 govuk::apps::specialist_publisher::enabled: true

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -785,8 +785,8 @@ govuk::apps::signon::db_username: 'signon'
 govuk::apps::signon::redis_url: "redis://backend-redis:6379/0"
 govuk::apps::signon::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::signon::redis_port: "%{hiera('sidekiq_port')}"
-govuk::apps::signon::nagios_memory_warning: 1100
-govuk::apps::signon::nagios_memory_critical: 1200
+govuk::apps::signon::nagios_memory_warning: 1300
+govuk::apps::signon::nagios_memory_critical: 1450
 govuk::apps::signon::unicorn_worker_processes: "4"
 
 govuk::apps::specialist_publisher::enabled: true


### PR DESCRIPTION
We're seeing that Signon is now using consistently higher memory than before with Ruby 2.7, so this increases the threshold to match what we're seeing.