### PR TITLE
Remove sleep before running smoke tests

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_app_downstream.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_app_downstream.yaml.erb
@@ -10,9 +10,6 @@
           artifact-num-to-keep: 5
     builders:
       <% if @smokey_pre_check %>
-      - shell: |
-          # Wait for any app restarts to complete before running Smokey
-          sleep 60
       - trigger-builds:
           - project: Smokey
             current-parameters: true


### PR DESCRIPTION
Trello: https://trello.com/c/oPNhsGl3/536-investigate-delaying-an-app-deployment-until-the-app-has-restarted-to-avoid-false-smokey-builds

This is marked as a draft until https://github.com/alphagov/govuk-app-deployment/pull/409 is merged

With unicorn reloads now being supervised [1] we no longer need to sleep
and Smokey tests can run as soon as the deploy is successful.

[1]: https://github.com/alphagov/govuk-app-deployment/pull/409