### PR TITLE
Increase memory thresholds for collections

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -469,8 +469,8 @@ govuk::apps::ckan::s3_aws_access_key_id: "%{hiera('s3_aws_access_key_id')}"
 govuk::apps::ckan::s3_aws_secret_access_key: "%{hiera('s3_aws_secret_access_key')}"
 
 govuk::apps::collections::unicorn_worker_processes: 4
-govuk::apps::collections::nagios_memory_warning: 1100
-govuk::apps::collections::nagios_memory_critical: 1300
+govuk::apps::collections::nagios_memory_warning: 1300
+govuk::apps::collections::nagios_memory_critical: 1500
 
 govuk::apps::collections_publisher::db_hostname: "mysql-primary"
 govuk::apps::collections_publisher::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"


### PR DESCRIPTION
Since upgrading to Ruby 2.7, we've seen this application restart a few times because of high memory, so these thresholds should prevent that from happening.