### PR TITLE
Update CI agent Solr schema

### DIFF
--- a/hieradata_aws/class/integration/ci_agent.yaml
+++ b/hieradata_aws/class/integration/ci_agent.yaml
@@ -24,6 +24,7 @@ govuk_sysdig::ensure: 'absent'
 
 govuk_solr::disable: true
 govuk_solr6::present: true
+govuk_solr6::schema: 'ckan28.schema-6.6.2.xml'
 
 lv:
   data:


### PR DESCRIPTION
## What

Update the schema to drop the element `defaultSearchField` as this is causing a problem with Solr 6.6.2