### PR TITLE
Add environment variables for Transition Checker to use GOV.UK Accounts

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -218,6 +218,8 @@ task :check_consistency_between_aws_and_carrenza do
     govuk::apps::feedback::govuk_notify_reply_to_id
     govuk::apps::feedback::govuk_notify_template_id
     govuk::apps::finder_frontend::enabled
+    govuk::apps::finder_frontend::feature_flag_accounts
+    govuk::apps::finder_frontend::plek_account_manager_uri
     govuk::apps::finder_frontend::nagios_memory_critical
     govuk::apps::finder_frontend::nagios_memory_warning
     govuk::apps::finder_frontend::unicorn_worker_processes

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -41,6 +41,7 @@ govuk::apps::email_alert_frontend::subscription_management_enabled: true
 govuk::apps::feedback::govuk_notify_reply_to_id: 'fee22233-2f28-4b0b-8b6c-4410979f2275'
 govuk::apps::feedback::govuk_notify_template_id: 'eb9ba220-7d74-4aab-975a-bdbe718f69a3'
 govuk::apps::finder_frontend::feature_flag_accounts: false
+govuk::apps::finder_frontend::plek_account_manager_uri: 'https://www.account.staging.publishing.service.gov.uk'
 govuk::apps::frontend::govuk_notify_template_id: '1fc69d3a-09a2-40f9-852b-03f6fcef5340'
 govuk::apps::govuk_crawler_worker::enabled: false
 govuk::apps::govuk_crawler_worker::disable_during_data_sync: true

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -40,6 +40,7 @@ govuk::apps::email_alert_api::delivery_request_threshold: "3000"
 govuk::apps::email_alert_frontend::subscription_management_enabled: true
 govuk::apps::feedback::govuk_notify_reply_to_id: 'fee22233-2f28-4b0b-8b6c-4410979f2275'
 govuk::apps::feedback::govuk_notify_template_id: 'eb9ba220-7d74-4aab-975a-bdbe718f69a3'
+govuk::apps::finder_frontend::feature_flag_accounts: false
 govuk::apps::frontend::govuk_notify_template_id: '1fc69d3a-09a2-40f9-852b-03f6fcef5340'
 govuk::apps::govuk_crawler_worker::enabled: false
 govuk::apps::govuk_crawler_worker::disable_during_data_sync: true

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -191,6 +191,7 @@ govuk::apps::email_alert_api::email_archive_s3_enabled: true
 govuk::apps::email_alert_api::govuk_notify_template_id: 'cb633abc-6ae6-4843-ae6f-82ca500b6de2'
 govuk::apps::feedback::govuk_notify_reply_to_id: 'e8b2d8a6-db5f-4346-9fbd-49b16b531e1c'
 govuk::apps::feedback::govuk_notify_template_id: '54168fa9-3946-4860-a2f8-27ddbb14babe'
+govuk::apps::finder_frontend::feature_flag_accounts: false
 govuk::apps::frontend::govuk_notify_template_id: 'cb633abc-6ae6-4843-ae6f-82ca500b6de2'
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::licencefinder::elasticsearch_uri: 'https://vpc-blue-elasticsearch6-domain-2hnib7uydv3tgebhabx74gdelq.eu-west-1.es.amazonaws.com'

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -192,6 +192,7 @@ govuk::apps::email_alert_api::govuk_notify_template_id: 'cb633abc-6ae6-4843-ae6f
 govuk::apps::feedback::govuk_notify_reply_to_id: 'e8b2d8a6-db5f-4346-9fbd-49b16b531e1c'
 govuk::apps::feedback::govuk_notify_template_id: '54168fa9-3946-4860-a2f8-27ddbb14babe'
 govuk::apps::finder_frontend::feature_flag_accounts: false
+govuk::apps::finder_frontend::plek_account_manager_uri: 'https://www.account.publishing.service.gov.uk'
 govuk::apps::frontend::govuk_notify_template_id: 'cb633abc-6ae6-4843-ae6f-82ca500b6de2'
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::licencefinder::elasticsearch_uri: 'https://vpc-blue-elasticsearch6-domain-2hnib7uydv3tgebhabx74gdelq.eu-west-1.es.amazonaws.com'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -171,6 +171,7 @@ govuk::apps::email_alert_api::delivery_request_threshold: "3000"
 govuk::apps::email_alert_frontend::subscription_management_enabled: true
 govuk::apps::feedback::govuk_notify_reply_to_id: 'd1f54751-80a8-420a-9077-d34c7d6cc734'
 govuk::apps::feedback::govuk_notify_template_id: '8a8d98c0-42c8-4f56-b61f-77c89417a171'
+govuk::apps::finder_frontend::feature_flag_accounts: false
 govuk::apps::frontend::govuk_notify_template_id: '2844a647-6bf1-4b01-a25c-569d2cc00849'
 govuk::apps::govuk_crawler_worker::disable_during_data_sync: true
 govuk::apps::hmrc_manuals_api::publish_topics: false

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -172,6 +172,7 @@ govuk::apps::email_alert_frontend::subscription_management_enabled: true
 govuk::apps::feedback::govuk_notify_reply_to_id: 'd1f54751-80a8-420a-9077-d34c7d6cc734'
 govuk::apps::feedback::govuk_notify_template_id: '8a8d98c0-42c8-4f56-b61f-77c89417a171'
 govuk::apps::finder_frontend::feature_flag_accounts: false
+govuk::apps::finder_frontend::plek_account_manager_uri: 'https://www.account.staging.publishing.service.gov.uk'
 govuk::apps::frontend::govuk_notify_template_id: '2844a647-6bf1-4b01-a25c-569d2cc00849'
 govuk::apps::govuk_crawler_worker::disable_during_data_sync: true
 govuk::apps::hmrc_manuals_api::publish_topics: false

--- a/modules/govuk/manifests/apps/finder_frontend.pp
+++ b/modules/govuk/manifests/apps/finder_frontend.pp
@@ -21,6 +21,24 @@
 # [*email_alert_api_bearer_token*]
 #   Bearer token for communication with the email-alert-api
 #
+# [*account_oauth_client_id*]
+#   Client ID for the Transition Checker in GOV.UK Account Manager
+#
+# [*account_oauth_client_secret*]
+#   Client secret for the Transition Checker in GOV.UK Account Manager
+#
+# [*account_jwt_key_uuid*]
+#   An arbitrary UUID (used to identify the JWT signing key for Transition Checker
+#
+# [*account_jwt_key_pem*]
+#   Private key used to sign the JWT for Transition Checker
+#
+# [*feature_flag_accounts*]
+#   Feature flag to switch GOV.UK Accounts on or off for the Transition Checker
+#
+# [*plek_account_manager_uri*]
+#   Path to the GOV.UK Account Manager
+#
 class govuk::apps::finder_frontend(
   $port,
   $enabled = false,
@@ -30,6 +48,12 @@ class govuk::apps::finder_frontend(
   $secret_key_base = undef,
   $email_alert_api_bearer_token = undef,
   $unicorn_worker_processes = undef,
+  $account_oauth_client_id = undef,
+  $account_oauth_client_secret = undef,
+  $account_jwt_key_uuid = undef,
+  $account_jwt_key_pem = undef,
+  $feature_flag_accounts = false,
+  $plek_account_manager_uri = undef,
 ) {
 
   if $enabled {
@@ -55,6 +79,11 @@ class govuk::apps::finder_frontend(
     app => 'finder-frontend',
   }
 
+  $feature_flag_accounts = $feature_flag_accounts ? {
+                true    => 'enabled',
+                default => undef
+        }
+
   govuk::app::envvar {
     "${title}-EMAIL_ALERT_API_BEARER_TOKEN":
         varname => 'EMAIL_ALERT_API_BEARER_TOKEN',
@@ -62,6 +91,24 @@ class govuk::apps::finder_frontend(
     "${title}-SECRET_KEY_BASE":
         varname => 'SECRET_KEY_BASE',
         value   => $secret_key_base;
+    "${title}-ACCOUNT-OAUTH-CLIENT-ID":
+        varname => 'GOVUK_ACCOUNT_OAUTH_CLIENT_ID',
+        value   => $account_oauth_client_id;
+    "${title}-ACCOUNT-OAUTH-CLIENT-SECRET":
+        varname => 'GOVUK_ACCOUNT_OAUTH_CLIENT_SECRET',
+        value   => $account_oauth_client_secret;
+    "${title}-ACCOUNT-JWT-KEY-UUID":
+        varname => 'GOVUK_ACCOUNT_JWT_KEY_UUID',
+        value   => $account_jwt_key_uuid;
+    "${title}-ACCOUNT-JWT-KEY-PEM":
+        varname => 'GOVUK_ACCOUNT_JWT_KEY_PEM',
+        value   => $account_jwt_key_pem;
+    "${title}-FEATURE-FLAG-ACCOUNTS":
+        varname => 'FEATURE_FLAG_ACCOUNTS',
+        value   => $feature_flag_accounts;
+    "${title}-PLEK-ACCOUNT-MANAGER-URI":
+        varname => 'PLEK_SERVICE_ACCOUNT_MANAGER_URI',
+        value   => $plek_account_manager_uri;
   }
 
 }


### PR DESCRIPTION
The Transition Checker will be the first live experiment for GOV.UK Accounts, therefore we need to set some environment variables to allow the checker (in `finder-frontend` to communicate with the account manager).

Note the feature flag is currently switched off in all environments.

Trello card: https://trello.com/c/CyOeHwIY