### PR TITLE
Migrate Validate_DNS Jenkins job to AWS production

### DIFF
--- a/hieradata_aws/class/production/jenkins.yaml
+++ b/hieradata_aws/class/production/jenkins.yaml
@@ -81,6 +81,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::transition_import_hits
   - govuk_jenkins::jobs::transition_load_site_config
   - govuk_jenkins::jobs::user_monitor
+  - govuk_jenkins::jobs::validate_published_dns
   - govuk_jenkins::jobs::whitehall_publisher_notifications
   - govuk_jenkins::jobs::whitehall_run_broken_link_checker
 
@@ -88,3 +89,6 @@ govuk_jenkins::jobs::deploy_cdn::enable_slack_notifications: false
 govuk_jenkins::jobs::deploy_puppet::enable_slack_notifications: false
 govuk_jenkins::jobs::transition_import_hits::s3_bucket: govuk-production-transition-fastly-logs
 govuk_jenkins::jobs::user_monitor::enable_icinga_check: true
+
+govuk_jenkins::jobs::validate_published_dns::app_domain: blue.production.govuk.digital
+govuk_jenkins::jobs::validate_published_dns::run_daily: true


### PR DESCRIPTION
Following on from #10772, we migrate Validate_DNS Jenkins job to AWS production
since Carrenza Production is being decommissioned.

Ref:
1. [Trello Card 1](https://trello.com/c/C9DZ7UzK/3896-migrate-validatedns-jenkins-to-aws-production)
2. #10772
3. [Trello Card 2](https://trello.com/c/ti7AGfnE/3894-move-jenkins-deploy-dns-to-aws-production)