### PR TITLE
Fix UKCloud-AWS VPN test

### DIFF
--- a/modules/monitoring/manifests/checks.pp
+++ b/modules/monitoring/manifests/checks.pp
@@ -199,7 +199,7 @@ class monitoring::checks (
 
   if ($::aws_migration and $::aws_environment == 'production') {
     icinga::check { 'check_uk_cloud_vpn_up':
-      check_command       => 'check_uk_cloud_vpn!www.civicaepay.co.uk!/NottinghamXML/QueryPayments/QueryPayments.asmx',
+      check_command       => 'check_uk_cloud_vpn!www.civicaepay.co.uk!/ReadingXML/QueryPayments/QueryPayments.asmx',
       host_name           => $::fqdn,
       service_description => 'check that the VPN between UKCloud/Licensify and AWS is still up',
       notes_url           => monitoring_docs_url(vpn-down),


### PR DESCRIPTION
The current UKCloud-AWS VPN test checks the HTTP response code is 200.
The URL used was:
www.civicaepay.co.uk/NottinghamXML/QueryPayments/QueryPayments.asmx

This URL is no longer working.

A working URL is:
www.civicaepay.co.uk/ReadingXML/QueryPayments/QueryPayments.asmx

This was tested by running the check command on the AWS Production
monitoring machine and it giving a 200 response while it was bad
response when tried on AWS Integration monitoring machine