### PR TITLE
Set default search operator to AND not OR

### DIFF
--- a/modules/govuk_solr6/files/6.6.2/solrconfig.xml
+++ b/modules/govuk_solr6/files/6.6.2/solrconfig.xml
@@ -725,7 +725,7 @@
       <str name="echoParams">explicit</str>
       <int name="rows">10</int>
       <str name="df">text</str>
-      <str name="q.op">OR</str>
+      <str name="q.op">AND</str>
     </lst>
     <!-- In addition to defaults, "appends" params can be specified
          to identify values which should be appended to the list of


### PR DESCRIPTION
## What

Original schema has AND not OR as the default operator -

Original schema is based on 6.4.2 schema - https://github.com/alphagov/govuk-puppet/blob/master/modules/govuk_solr6/files/6.4.2-1/ckan28.schema.xml#L167