### PR TITLE
Remove delivery request threshold configuration for Email Alert API

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -36,7 +36,6 @@ govuk::apps::email_alert_api::email_archive_s3_enabled: true
 govuk::apps::email_alert_api::govuk_notify_template_id: '1fc69d3a-09a2-40f9-852b-03f6fcef5340'
 govuk::apps::email_alert_api::email_address_override: 'success@simulator.amazonses.com'
 govuk::apps::email_alert_api::email_address_override_whitelist_only: true
-govuk::apps::email_alert_api::delivery_request_threshold: "3000"
 govuk::apps::email_alert_frontend::subscription_management_enabled: true
 govuk::apps::feedback::govuk_notify_reply_to_id: 'fee22233-2f28-4b0b-8b6c-4410979f2275'
 govuk::apps::feedback::govuk_notify_template_id: 'eb9ba220-7d74-4aab-975a-bdbe718f69a3'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -167,7 +167,6 @@ govuk::apps::email_alert_api::email_archive_s3_enabled: false
 govuk::apps::email_alert_api::govuk_notify_template_id: '2844a647-6bf1-4b01-a25c-569d2cc00849'
 govuk::apps::email_alert_api::email_address_override: 'success@simulator.amazonses.com'
 govuk::apps::email_alert_api::email_address_override_whitelist_only: true
-govuk::apps::email_alert_api::delivery_request_threshold: "3000"
 govuk::apps::email_alert_frontend::subscription_management_enabled: true
 govuk::apps::feedback::govuk_notify_reply_to_id: 'd1f54751-80a8-420a-9077-d34c7d6cc734'
 govuk::apps::feedback::govuk_notify_template_id: '8a8d98c0-42c8-4f56-b61f-77c89417a171'

--- a/modules/govuk/manifests/apps/email_alert_api.pp
+++ b/modules/govuk/manifests/apps/email_alert_api.pp
@@ -68,9 +68,6 @@
 # [*email_address_override_whitelist_only*]
 #   Specify that only emails that are whitelisted should be sent out.
 #
-# [*delivery_request_threshold*]
-#   Configure the number of requests that the rate limit will allow to be made in one minute.
-#
 # [*unicorn_worker_processes*]
 #   The number of unicorn workers to run for an instance of this app
 #
@@ -134,7 +131,6 @@ class govuk::apps::email_alert_api(
   $email_address_override = undef,
   $email_address_override_whitelist = undef,
   $email_address_override_whitelist_only = false,
-  $delivery_request_threshold = undef,
   $db_username = 'email-alert-api',
   $db_password = undef,
   $db_hostname = undef,
@@ -272,13 +268,6 @@ class govuk::apps::email_alert_api(
         varname => 'EMAIL_ADDRESS_OVERRIDE_WHITELIST',
         value   => join($email_address_override_whitelist, ',');
       }
-    }
-  }
-
-  if $delivery_request_threshold {
-    govuk::app::envvar { "${title}-DELIVERY_REQUEST_THRESHOLD":
-      varname => 'DELIVERY_REQUEST_THRESHOLD',
-      value   => $delivery_request_threshold;
     }
   }
 


### PR DESCRIPTION
Trello: https://trello.com/c/Xd47oJKZ/535-remove-the-deliveryattempt-model

We send so few emails in staging and integration that this has no
practical effect. To simplify Email Alert API we're removing this lever
as it doesn't seem necessary or widely known.