### PR TITLE
Monitor latency on email delivery_* and send_email_* queues

### DIFF
--- a/modules/govuk/manifests/apps/email_alert_api/checks.pp
+++ b/modules/govuk/manifests/apps/email_alert_api/checks.pp
@@ -7,6 +7,7 @@ class govuk::apps::email_alert_api::checks(
 ) {
 
   sidekiq_queue_check {
+    # Legacy queues: to be removed once replaced
     'delivery_transactional':
       latency_warning  => '300', # 5 minutes
       latency_critical => '600'; # 10 minutes
@@ -20,6 +21,23 @@ class govuk::apps::email_alert_api::checks(
       latency_critical => '600'; # 10 minutes
 
     'delivery_digest':
+      latency_warning  => '3600', # 60 minutes
+      latency_critical => '5400'; # 90 minutes
+
+    # These replace the delivery_* queues
+    'send_email_transactional':
+      latency_warning  => '300', # 5 minutes
+      latency_critical => '600'; # 10 minutes
+
+    'send_email_immediate':
+      latency_warning  => '1200', # 20 minutes
+      latency_critical => '1800'; # 30 minutes
+
+    'send_email_immediate_high':
+      latency_warning  => '300', # 5 minutes
+      latency_critical => '600'; # 10 minutes
+
+    'send_email_digest':
       latency_warning  => '3600', # 60 minutes
       latency_critical => '5400'; # 90 minutes
   }


### PR DESCRIPTION
Trello: https://trello.com/c/Xd47oJKZ/535-remove-the-deliveryattempt-model

In https://github.com/alphagov/email-alert-api/pull/1438 we are renaming
these queues. This sets up monitoring for the new queues so we can
transfer seamlessly to the new metrics as the app changes.

This should be deployed at a time close to the Email Alert API change as
they will show as pending alerts until Email Alert API starts writing
this data to graphite.