### PR TITLE
Retry success_passive_check commands until successful

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/success_passive_check.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/success_passive_check.yaml.erb
@@ -14,7 +14,9 @@
       - shell: |
           IPADDRESS=$(facter ipaddress_eth0)
           NSCA_CODE=0
-          printf "$IPADDRESS\t$NSCA_CHECK_DESCRIPTION\t$NSCA_CODE\t$NSCA_OUTPUT\n" | /usr/sbin/send_nsca -H <%= @alert_hostname %> >/dev/null
+          until printf "$IPADDRESS\t$NSCA_CHECK_DESCRIPTION\t$NSCA_CODE\t$NSCA_OUTPUT\n" | /usr/sbin/send_nsca -H <%= @alert_hostname %>; do
+            sleep 1
+          done
     wrappers:
         - ansicolor:
             colormap: xterm


### PR DESCRIPTION
Icinga is reporting some jobs to have the status 'freshness threshold exceeded',
for some jobs which have succeeded. This indicates that the success_passive_check
is not successfully telling Icinga that the job has succeeded.

This retries the success_passive_check until it passes. We could also resend the
message a bunch of times.

If we were not moving away form Icinga soon, we could check out this rewrite of
send_nsca which might be more reliable: https://github.com/Yelp/send_nsca.