### PR TITLE
Remove Search team from metric fetch failure contact groups

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/search_relevancy_metrics_etl.pp
+++ b/modules/govuk_jenkins/manifests/jobs/search_relevancy_metrics_etl.pp
@@ -30,7 +30,6 @@ class govuk_jenkins::jobs::search_relevancy_metrics_etl (
       host_name           => $::fqdn,
       freshness_threshold => 86400,
       action_url          => $job_url,
-      contact_groups      => ['slack-channel-search-team'],
     }
   }
 }

--- a/modules/govuk_jenkins/manifests/jobs/search_relevancy_rank_evaluation.pp
+++ b/modules/govuk_jenkins/manifests/jobs/search_relevancy_rank_evaluation.pp
@@ -29,7 +29,6 @@ class govuk_jenkins::jobs::search_relevancy_rank_evaluation (
       host_name           => $::fqdn,
       freshness_threshold => 86400,
       action_url          => $job_url,
-      contact_groups      => ['slack-channel-search-team'],
     }
   }
 }


### PR DESCRIPTION
When search metrics fetches do not succeed within a certain time,
this triggers an Icinga alert 'freshness threshold exceeded'.

Since there is no longer a Search team it makes sense to not send
these alerts to a Slack channel. They will continue to appear in
Icinga.