### PR TITLE
Reduce CKAN alert thresholds

### DIFF
--- a/modules/govuk/manifests/apps/ckan.pp
+++ b/modules/govuk/manifests/apps/ckan.pp
@@ -115,6 +115,8 @@ class govuk::apps::ckan (
       local_tcpconns_established_warning => $gunicorn_worker_processes,
       sentry_dsn                         => $sentry_dsn,
       enable_nginx_vhost                 => false,
+      alert_5xx_warning_rate             => 0.02,
+      alert_5xx_critical_rate            => 0.05,
     }
 
     $toggled_priority_ensure = $priority_worker_processes ? {


### PR DESCRIPTION
In a recent incident CKAN was down but because traffic to the app was low we didn't get alert until significant numbers of users started using the app.

The current default critical threshold is 0.1, and during the incident the error rate reached 0.13 at 10:22, which was 8 hours after CKAN stopped working.

<img width="1235" alt="Screenshot 2020-10-22 at 15 59 20" src="https://user-images.githubusercontent.com/510498/96890459-92217380-147f-11eb-800a-ed3123571a88.png">

(Note that Icinga runs on UTC.)

[Incident report](https://docs.google.com/document/d/1gnDZr7II7AG_uvFq4HZwsazpXZ1QymOcFG-QnY8N0vE/edit?ts=5f917842)