### PR TITLE
Use default version of solr (6.6.2) on prod

### DIFF
--- a/hieradata_aws/class/production/ckan.yaml
+++ b/hieradata_aws/class/production/ckan.yaml
@@ -2,7 +2,6 @@
 
 govuk_solr::disable: true
 govuk_solr6::present: true
-govuk_solr6::version: 6.4.2-1
 
 govuk::apps::ckan::solr_core: ckan
 govuk::apps::ckan::solr_core_configset: ckan28


### PR DESCRIPTION
## What

Upgrade solr in production to the default solr version now that it seems stable and has been working in Staging for a number of days without any issues.