### PR TITLE
Remove migrated Carrenza Production DNS Jenkins jobs

### DIFF
--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -6,7 +6,6 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::check_sentry_errors
   - govuk_jenkins::jobs::deploy_app
   - govuk_jenkins::jobs::deploy_cdn
-  - govuk_jenkins::jobs::deploy_dns
   - govuk_jenkins::jobs::deploy_lambda_app
   - govuk_jenkins::jobs::deploy_puppet
   - govuk_jenkins::jobs::govuk_navigation_link_analysis
@@ -17,7 +16,6 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::smokey
   - govuk_jenkins::jobs::smokey_deploy
   - govuk_jenkins::jobs::update_cdn_dictionaries
-  - govuk_jenkins::jobs::validate_published_dns
 
 govuk_jenkins::jobs::deploy_cdn::enable_slack_notifications: true
 govuk_jenkins::jobs::deploy_cdn::services:


### PR DESCRIPTION
Following on from #10772 and #10780 where we migrated the `deploy_dns`
and `validate_published_dns`, we need to remove these jobs from the
Carrenza Production Jenkins.

All tests have been run, e.g.
1. [deploy_dns](https://deploy.blue.production.govuk.digital/job/Deploy_DNS/)
2. [validate_published_dns](https://deploy.blue.production.govuk.digital/job/Validate_published_DNS/)

Refs:
1. [deploy_dns trello card](https://trello.com/c/ti7AGfnE/3894-move-jenkins-deploy-dns-to-aws-production)
2. [validate_published_dns trello card](https://trello.com/c/C9DZ7UzK/3896-migrate-validatedns-jenkins-to-aws-production)