### PR TITLE
Migrate CDN Jenkins jobs to AWS Production

### DIFF
--- a/hieradata_aws/class/production/jenkins.yaml
+++ b/hieradata_aws/class/production/jenkins.yaml
@@ -49,6 +49,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::configure_github_repos
   - govuk_jenkins::jobs::content_data_api
   - govuk_jenkins::jobs::deploy_app
+  - govuk_jenkins::jobs::deploy_cdn
   - govuk_jenkins::jobs::deploy_dns
   - govuk_jenkins::jobs::deploy_emergency_banner
   - govuk_jenkins::jobs::deploy_puppet
@@ -80,12 +81,28 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::transition_import_dns
   - govuk_jenkins::jobs::transition_import_hits
   - govuk_jenkins::jobs::transition_load_site_config
+  - govuk_jenkins::jobs::update_cdn_dictionaries
   - govuk_jenkins::jobs::user_monitor
   - govuk_jenkins::jobs::validate_published_dns
   - govuk_jenkins::jobs::whitehall_publisher_notifications
   - govuk_jenkins::jobs::whitehall_run_broken_link_checker
 
-govuk_jenkins::jobs::deploy_cdn::enable_slack_notifications: false
+govuk_jenkins::jobs::deploy_cdn::enable_slack_notifications: true
+govuk_jenkins::jobs::deploy_cdn::services:
+  - apt
+  - assets
+  - mirror
+  - performanceplatform
+  - servicegovuk
+  - tldredirect
+  - www
+
+govuk_jenkins::jobs::update_cdn_dictionaries::services:
+  - assets
+  - mirror
+  - performanceplatform
+  - www
+
 govuk_jenkins::jobs::deploy_puppet::enable_slack_notifications: false
 govuk_jenkins::jobs::transition_import_hits::s3_bucket: govuk-production-transition-fastly-logs
 govuk_jenkins::jobs::user_monitor::enable_icinga_check: true


### PR DESCRIPTION
As part of the shutdown of Carrenza Production, we need to migrate the
CDN Jenkins jobs to AWS Production.

We use the same list of CDN services for these jobs as in Carrenza
Production.

Future work will include testing the jobs, updating the docs and then
remove the old jobs from Carrenza Production.

Refs:
1. [Trello Card](https://trello.com/c/L3325c8c/3900-migrate-cdn-jenkins-jobs-to-aws-production)