### PR TITLE
[Apply after #10796 is tested] Remove Migrated Carrenza Production CDN Jenkins jobs

### DIFF
--- a/hieradata/class/production/jenkins.yaml
+++ b/hieradata/class/production/jenkins.yaml
@@ -5,7 +5,6 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::check_github_ip_ranges
   - govuk_jenkins::jobs::check_sentry_errors
   - govuk_jenkins::jobs::deploy_app
-  - govuk_jenkins::jobs::deploy_cdn
   - govuk_jenkins::jobs::deploy_lambda_app
   - govuk_jenkins::jobs::deploy_puppet
   - govuk_jenkins::jobs::govuk_navigation_link_analysis
@@ -15,23 +14,6 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::run_rake_task
   - govuk_jenkins::jobs::smokey
   - govuk_jenkins::jobs::smokey_deploy
-  - govuk_jenkins::jobs::update_cdn_dictionaries
-
-govuk_jenkins::jobs::deploy_cdn::enable_slack_notifications: true
-govuk_jenkins::jobs::deploy_cdn::services:
-  - apt
-  - assets
-  - mirror
-  - performanceplatform
-  - servicegovuk
-  - tldredirect
-  - www
-
-govuk_jenkins::jobs::update_cdn_dictionaries::services:
-  - assets
-  - mirror
-  - performanceplatform
-  - www
 
 govuk_jenkins::jobs::deploy_puppet::enable_slack_notifications: true
 govuk_jenkins::jobs::validate_published_dns::run_daily: true


### PR DESCRIPTION
Following on from #10796 and [docs pr]
(https://github.com/alphagov/govuk-developer-docs/pull/2833) where we
migrated the Carrenza Production CDN Jenkins job to AWS Production,
it is time to delete these redundant jobs in Carrenza Production.

Refs:
1. [Trello Card](https://trello.com/c/L3325c8c/3900-migrate-cdn-jenkins-jobs-to-aws-production)