### PR TITLE
Add an accounts feature flag to collections

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -151,6 +151,7 @@ task :check_consistency_between_aws_and_carrenza do
     govuk::apps::ckan::redis_port
     govuk::apps::ckan::s3_aws_access_key_id
     govuk::apps::ckan::s3_aws_secret_access_key
+    govuk::apps::collections::feature_flag_accounts
     govuk::apps::collections::unicorn_worker_processes
     govuk::apps::collections::nagios_memory_critical
     govuk::apps::collections::nagios_memory_warning

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -39,6 +39,7 @@ govuk::apps::email_alert_api::email_address_override_whitelist_only: true
 govuk::apps::email_alert_frontend::subscription_management_enabled: true
 govuk::apps::feedback::govuk_notify_reply_to_id: 'fee22233-2f28-4b0b-8b6c-4410979f2275'
 govuk::apps::feedback::govuk_notify_template_id: 'eb9ba220-7d74-4aab-975a-bdbe718f69a3'
+govuk::apps::collections::feature_flag_accounts: false
 govuk::apps::finder_frontend::feature_flag_accounts: false
 govuk::apps::finder_frontend::plek_account_manager_uri: 'https://www.account.staging.publishing.service.gov.uk'
 govuk::apps::frontend::govuk_notify_template_id: '1fc69d3a-09a2-40f9-852b-03f6fcef5340'

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -191,6 +191,7 @@ govuk::apps::email_alert_api::email_archive_s3_enabled: true
 govuk::apps::email_alert_api::govuk_notify_template_id: 'cb633abc-6ae6-4843-ae6f-82ca500b6de2'
 govuk::apps::feedback::govuk_notify_reply_to_id: 'e8b2d8a6-db5f-4346-9fbd-49b16b531e1c'
 govuk::apps::feedback::govuk_notify_template_id: '54168fa9-3946-4860-a2f8-27ddbb14babe'
+govuk::apps::collections::feature_flag_accounts: false
 govuk::apps::finder_frontend::feature_flag_accounts: false
 govuk::apps::finder_frontend::plek_account_manager_uri: 'https://www.account.publishing.service.gov.uk'
 govuk::apps::frontend::govuk_notify_template_id: 'cb633abc-6ae6-4843-ae6f-82ca500b6de2'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -170,6 +170,7 @@ govuk::apps::email_alert_api::email_address_override_whitelist_only: true
 govuk::apps::email_alert_frontend::subscription_management_enabled: true
 govuk::apps::feedback::govuk_notify_reply_to_id: 'd1f54751-80a8-420a-9077-d34c7d6cc734'
 govuk::apps::feedback::govuk_notify_template_id: '8a8d98c0-42c8-4f56-b61f-77c89417a171'
+govuk::apps::collections::feature_flag_accounts: true
 govuk::apps::finder_frontend::feature_flag_accounts: true
 govuk::apps::finder_frontend::plek_account_manager_uri: 'https://www.account.staging.publishing.service.gov.uk'
 govuk::apps::frontend::govuk_notify_template_id: '2844a647-6bf1-4b01-a25c-569d2cc00849'

--- a/modules/govuk/manifests/apps/collections.pp
+++ b/modules/govuk/manifests/apps/collections.pp
@@ -34,6 +34,9 @@
 # [*email_alert_api_bearer_token*]
 #   Bearer token for communication with the email-alert-api
 #
+# [*feature_flag_accounts*]
+#   Feature flag to switch GOV.UK Accounts on or off for the Transition Checker
+#
 class govuk::apps::collections(
   $vhost = 'collections',
   $port,
@@ -43,6 +46,7 @@ class govuk::apps::collections(
   $nagios_memory_warning = undef,
   $nagios_memory_critical = undef,
   $email_alert_api_bearer_token = undef,
+  $feature_flag_accounts = false,
 ) {
   govuk::app { 'collections':
     app_type                 => 'rack',
@@ -63,6 +67,11 @@ class govuk::apps::collections(
     app => 'collections',
   }
 
+  $feature_flag_accounts_var = $feature_flag_accounts ? {
+                true    => 'enabled',
+                default => undef
+        }
+
   govuk::app::envvar {
     "${title}-EMAIL_ALERT_API_BEARER_TOKEN":
         varname => 'EMAIL_ALERT_API_BEARER_TOKEN',
@@ -70,5 +79,8 @@ class govuk::apps::collections(
     "${title}-SECRET_KEY_BASE":
         varname => 'SECRET_KEY_BASE',
         value   => $secret_key_base;
+    "${title}-FEATURE-FLAG-ACCOUNTS":
+        varname => 'FEATURE_FLAG_ACCOUNTS',
+        value   => $feature_flag_accounts_var;
   }
 }


### PR DESCRIPTION
We want to display a different header on /transition and
/transition-check when accounts are enabled.  /transition is rendered
by collections.

---

[Trello card](https://trello.com/c/vdZrgBRy/363-make-changes-to-transition-for-trial-launch)