### PR TITLE
Focus on sustained 5xx for origin

### DIFF
--- a/modules/router/manifests/nginx.pp
+++ b/modules/router/manifests/nginx.pp
@@ -138,14 +138,14 @@ class router::nginx (
     require => File['/usr/share/nginx/www'],
   }
 
-  $graphite_5xx_target = "transformNull(stats.${::fqdn_metrics}.nginx_logs.www-origin.http_5xx,0)"
+  $graphite_5xx_target = "movingMedian(transformNull(stats.${::fqdn_metrics}.nginx_logs.www-origin.http_5xx,0),\"5min\")"
 
   @@icinga::check::graphite { "check_nginx_5xx_on_${::hostname}":
     target              => $graphite_5xx_target,
     warning             => 0.3,
     critical            => 0.6,
     use                 => 'govuk_urgent_priority',
-    from                => '3minutes',
+    from                => '8minutes',
     desc                => '5xx rate for www-origin [in office hours]',
     host_name           => $::fqdn,
     notes_url           => monitoring_docs_url(high-nginx-5xx-rate),


### PR DESCRIPTION
Previously we would alert for 5xx spikes, which are generally
unactionable (they resolve by themselves). This applies a 5 minute
moving median average to the metric for this alert, which matches
the behaviour of the 5xx alert for individual app proxies.

I've also made the "from" values the same between the in-office and
on-call alerts, as it's unclear why these should be different.