### PR TITLE
Stop obsessing about established connections

### DIFF
--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -411,7 +411,7 @@ define govuk::app::config (
 
     @@icinga::check::graphite { "check_${title}_app_local_tcpconns_${::hostname}":
       ensure         => $ensure,
-      target         => "${::fqdn_metrics}.tcpconns-${port}-local.tcp_connections-ESTABLISHED",
+      target         => "movingMedian(${::fqdn_metrics}.tcpconns-${port}-local.tcp_connections-ESTABLISHED,\"5min\")",
       warning        => $local_tcpconns_warning,
       critical       => $local_tcpconns_critical,
       desc           => "Established connections for ${title_underscore} exceeds ${local_tcpconns_warning}",


### PR DESCRIPTION
https://trello.com/c/ouFzMhCw/1021-stop-obsessing-over-established-connections-for-our-apps

Previously we alerted as soon as the established connections exceeded
the configured threshold, which has lead to lots of flashing alerts.
While it's important to know if an app is receiving more requests than
it can handle, this is only a problem if it's sustained, so we should
apply some averaging to reflect that.