### PR TITLE
Add alert to detect dead nodes in a cluster

### DIFF
--- a/modules/govuk_rabbitmq/manifests/monitoring.pp
+++ b/modules/govuk_rabbitmq/manifests/monitoring.pp
@@ -12,6 +12,11 @@ class govuk_rabbitmq::monitoring (
     require => Icinga::Plugin['check_http_timeout_noncrit'],
   }
 
+  @icinga::nrpe_config { 'check_rabbitmq_dead_nodes':
+    content => template('govuk_rabbitmq/check_rabbitmq_dead_nodes.cfg.erb'),
+    require => Icinga::Plugin['check_http_timeout_noncrit'],
+  }
+
   @@icinga::check { "check_rabbitmq_running_${::hostname}":
     check_command       => 'check_nrpe!check_proc_running!rabbitmq-server',
     service_description => 'rabbitmq-server not running',
@@ -23,6 +28,13 @@ class govuk_rabbitmq::monitoring (
     check_command       => 'check_nrpe_1arg!check_rabbitmq_network_partition',
     service_description => 'RabbitMQ network partition has occurred',
     host_name           => $::fqdn,
+  }
+
+  @@icinga::check { "check_rabbitmq_dead_nodes_${::hostname}":
+    check_command       => 'check_nrpe_1arg!check_rabbitmq_dead_nodes',
+    service_description => 'RabbitMQ has dead nodes in its cluster',
+    host_name           => $::fqdn,
+    notes_url           => monitoring_docs_url(rabbitmq-dead-nodes),
   }
 
   @@icinga::check { "check_rabbitmq_watermark_${::hostname}":

--- a/modules/govuk_rabbitmq/templates/check_rabbitmq_dead_nodes.cfg.erb
+++ b/modules/govuk_rabbitmq/templates/check_rabbitmq_dead_nodes.cfg.erb
@@ -1,0 +1,1 @@
+command[check_rabbitmq_dead_nodes]=/usr/lib/nagios/plugins/check_http_timeout_noncrit -a '<%= @monitoring_user %>:<%= @monitoring_password %>' -I '127.0.0.1' -p 15672 -u '/api/nodes' -r '"running":false' --invert-regex


### PR DESCRIPTION
https://trello.com/c/Di1wXCVM/1025-fix-not-being-able-to-reboot-rabbitmq-machines

Related to: https://github.com/alphagov/govuk-developer-docs/pull/2841

This ensures we become aware when a node exists in the RabbitMQ
cluster, but the underlying machine is gone, which can happen
when AWS automatically regenerates our VMs. While this state is
not an immediate issue, it will prevent safe reboots.