### PR TITLE
Prevent auto-reboot for monitoring machines

### DIFF
--- a/hieradata_aws/class/monitoring.yaml
+++ b/hieradata_aws/class/monitoring.yaml
@@ -1,5 +1,8 @@
 ---
 
+govuk_safe_to_reboot::can_reboot: 'careful'
+govuk_safe_to_reboot::reason: 'We lose alerting when this machine is down'
+
 govuk_cdnlogs::log_dir: '/var/log/cdn'
 
 icinga::client::checks::disk_space_warn: 12


### PR DESCRIPTION
https://trello.com/c/loHkCXV8/1024-stop-monitoring-machine-from-rebooting-overnight-manual-only

Previously we risked losing alerts if the auto-reboot failed overnight,
so we wouldn't get notified of critical issues with the platform. In
addition, the auto-reboot (at midnight) coincides with the other jobs
like data sync, so we get a load of alerts the next day because the
job was unable to post its status to Icinga. This changes the reboot
settings so that they must be done manually.