### PR TITLE
Stop alerting while we wait for Fastly 5xx data

### DIFF
--- a/modules/monitoring/manifests/edge.pp
+++ b/modules/monitoring/manifests/edge.pp
@@ -14,7 +14,7 @@ class monitoring::edge (
 
   if $enabled {
     icinga::check::graphite { "fastly_5xx_rate_on_${::hostname}":
-      target    => "movingMedian(${::fqdn_metrics}.cdn_fastly-govuk.requests-status_5xx,\"5min\")",
+      target    => "movingMedian(transformNull(${::fqdn_metrics}.cdn_fastly-govuk.requests-status_5xx,0),\"5min\")",
       desc      => 'Fastly error rate for GOV.UK',
       warning   => 0.05,
       critical  => 0.1,


### PR DESCRIPTION
https://trello.com/c/hMEpThYg/1026-fix-unknown-alert-for-fastly-5xx

Previously we saw periodic UNKNOWN alerts for this, despite the
data being available on manually checking. This avoids alerting
when the status is not clearly unknown.