### PR TITLE
Reconfigure alerts for 5xx to avoid spikes

### DIFF
--- a/modules/monitoring/manifests/edge.pp
+++ b/modules/monitoring/manifests/edge.pp
@@ -13,13 +13,26 @@ class monitoring::edge (
 ) {
 
   if $enabled {
-    icinga::check::graphite { "fastly_5xx_rate_on_${::hostname}":
-      target    => "movingMedian(transformNull(${::fqdn_metrics}.cdn_fastly-govuk.requests-status_5xx,0),\"5min\")",
+    $graphite_5xx_warning_target = "movingMedian(transformNull(${::fqdn_metrics}.cdn_fastly-govuk.requests-status_5xx,0),\"5min\")"
+    $graphite_5xx_critical_target = "movingMedian(transformNull(${::fqdn_metrics}.cdn_fastly-govuk.requests-status_5xx,0),\"10min\")"
+
+    icinga::check::graphite { "fastly_5xx_rate_on_${::hostname}_warning":
+      target    => $graphite_5xx_warning_target,
       desc      => 'Fastly error rate for GOV.UK',
       warning   => 0.05,
+      critical  => 999999, # the metric for this alert is only used for warnings
+      host_name => $::fqdn,
+      from      => '8minutes', # average over three 5 min windows
+      notes_url => monitoring_docs_url(fastly-error-rate),
+    }
+
+    icinga::check::graphite { "fastly_5xx_rate_on_${::hostname}":
+      target    => $graphite_5xx_critical_target,
+      desc      => 'Fastly error rate for GOV.UK',
+      warning   => 0.1, # the metric for this alert is only used for criticals
       critical  => 0.1,
       host_name => $::fqdn,
-      from      => '5minutes',
+      from      => '13minutes', # average of three 10 min windows
       notes_url => monitoring_docs_url(fastly-error-rate),
     }
   }

--- a/modules/router/manifests/nginx.pp
+++ b/modules/router/manifests/nginx.pp
@@ -138,11 +138,8 @@ class router::nginx (
     require => File['/usr/share/nginx/www'],
   }
 
-  $graphite_5xx_warning_target = "movingMedian(transformNull(stats.${::fqdn_metrics}.nginx_logs.www-origin.http_5xx,0),\"5min\")"
-  $graphite_5xx_critical_target = "movingMedian(transformNull(stats.${::fqdn_metrics}.nginx_logs.www-origin.http_5xx,0),\"10min\")"
-
   @@icinga::check::graphite { "check_nginx_5xx_on_${::hostname}_warning":
-    target              => $graphite_5xx_target_warning,
+    target              => "movingMedian(transformNull(stats.${::fqdn_metrics}.nginx_logs.www-origin.http_5xx,0),\"5min\")",
     warning             => 0.3,
     critical            => 9999999, # the metric for this alert is only used for warnings
     from                => '8minutes', # average over three 5 min windows
@@ -153,27 +150,14 @@ class router::nginx (
   }
 
   @@icinga::check::graphite { "check_nginx_5xx_on_${::hostname}_critical":
-    target              => $graphite_5xx_target_critical,
-    warning             => 0.6, # the metric for this alert is only used for criticals
-    critical            => 0.6,
-    use                 => 'govuk_urgent_priority',
-    from                => '13minutes', # average over three 10 min windows
-    desc                => '5xx rate for www-origin [in office hours]',
-    host_name           => $::fqdn,
-    notes_url           => monitoring_docs_url(high-nginx-5xx-rate),
-    notification_period => 'inoffice',
-  }
-
-  @@icinga::check::graphite { "check_nginx_5xx_on_${::hostname}_oncall":
-    target              => $graphite_5xx_target_critical,
-    warning             => 0.5,
-    critical            => 0.9,
-    use                 => 'govuk_urgent_priority',
-    from                => '13minutes', # average over three 10 min windows
-    desc                => '5xx rate for www-origin [on call]',
-    host_name           => $::fqdn,
-    notes_url           => monitoring_docs_url(high-nginx-5xx-rate),
-    notification_period => 'oncall',
+    target    => "movingMedian(transformNull(stats.${::fqdn_metrics}.nginx_logs.www-origin.http_5xx,0),\"10min\")",
+    warning   => 0.9, # the metric for this alert is only used for criticals
+    critical  => 0.9,
+    use       => 'govuk_urgent_priority',
+    from      => '13minutes', # average over three 10 min windows
+    desc      => '5xx rate for www-origin',
+    host_name => $::fqdn,
+    notes_url => monitoring_docs_url(high-nginx-5xx-rate),
   }
 
   @@icinga::check::graphite { "check_nginx_requests_${::hostname}":


### PR DESCRIPTION
https://trello.com/c/2GcGSx2X/1020-fix-origin-5xx-alert-for-spikes

This PR does three, potentially controversial things:

- Increases the averaging windows for 5xx alerts to 10 minutes
- Introduces new 5xx warning alerts with less averaging on them
- Removes the double standard we had for out-of-hours 5xx alerts

All of this is done with the aim of reducing the number of false
alarms we get on 2ndline, while also ensuring we have some early
warnings of potential issues with GOV.UK. CRITICAL alerts should
be reserved for things that are *definitely broken*.