### PR TITLE
Limit collection of interface stats

### DIFF
--- a/modules/collectd/files/etc/collectd/conf.d/default.conf
+++ b/modules/collectd/files/etc/collectd/conf.d/default.conf
@@ -4,11 +4,19 @@ LoadPlugin syslog
 	LogLevel info
 </Plugin>
 
+LoadPlugin interface
+
+<Plugin Interface>
+ Interface "lo"
+ Interface "/^veth/"
+ Interface "/^tun[0-9]+/"
+ IgnoreSelected "true"
+</Plugin>
+
 LoadPlugin cpu
 LoadPlugin df
 LoadPlugin disk
 LoadPlugin entropy
-LoadPlugin interface
 LoadPlugin load
 LoadPlugin memory
 LoadPlugin swap


### PR DESCRIPTION
https://trello.com/c/OUzLQlrp/1029-fix-integration-graphite-filling-up

Previously we collected stats for all interfaces, which lead to a
massive increase in data stored for our CI agents, due to their
extensive use of (Docker) veth interfaces. Since we only really
need stats about the physical interfaces, this applies filtering
to the plugin config [1] to restrict the data collected.

[1]: https://collectd.org/documentation/manpages/collectd.conf.5.shtml#plugin_interface