### PR TITLE
Downgrade user monitor alert to a warning

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/user_monitor.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/user_monitor.yaml.erb
@@ -38,6 +38,7 @@
           predefined-parameters: |
             NSCA_CHECK_DESCRIPTION=<%= @service_description %>
             NSCA_OUTPUT=<%= @service_description %> failed
+            NSCA_CODE=1
     wrappers:
         - ansicolor:
             colormap: xterm


### PR DESCRIPTION
https://trello.com/c/GcK55Cdp/1033-downgrade-user-reviewer-alert

This check for this alert does not mean that something is broken,
as we often have a period where a user is being added/removed from
GitHub, during which govuk-user-reviewer is out-of-sync.