### PR TITLE
Only alert for persistent 5xx errors

### DIFF
--- a/modules/licensify/manifests/apps/licensify.pp
+++ b/modules/licensify/manifests/apps/licensify.pp
@@ -134,7 +134,7 @@ class licensify::apps::licensify (
     target    => "movingMedian(transformNull(stats.${counter_basename}.http_5xx,0),\"5min\")",
     warning   => 0.05,
     critical  => 0.1,
-    from      => '5minutes',
+    from      => '15minutes',
     desc      => "${vhost_name} high nginx 5xx rate",
     host_name => $::fqdn,
     notes_url => monitoring_docs_url(high-nginx-5xx-rate),

--- a/modules/monitoring/manifests/edge.pp
+++ b/modules/monitoring/manifests/edge.pp
@@ -19,7 +19,7 @@ class monitoring::edge (
       warning   => 0.05,
       critical  => 0.1,
       host_name => $::fqdn,
-      from      => '5minutes',
+      from      => '15minutes',
       notes_url => monitoring_docs_url(fastly-error-rate),
     }
   }

--- a/modules/nginx/manifests/config/vhost/proxy.pp
+++ b/modules/nginx/manifests/config/vhost/proxy.pp
@@ -153,7 +153,7 @@ define nginx::config::vhost::proxy(
     target    => "movingMedian(transformNull(stats.${counter_basename}.http_5xx,0),\"5min\")",
     warning   => $alert_5xx_warning_rate,
     critical  => $alert_5xx_critical_rate,
-    from      => '5minutes',
+    from      => '15minutes',
     desc      => "${title} high nginx 5xx rate",
     host_name => $::fqdn,
     notes_url => monitoring_docs_url(high-nginx-5xx-rate),

--- a/modules/router/manifests/nginx.pp
+++ b/modules/router/manifests/nginx.pp
@@ -145,7 +145,7 @@ class router::nginx (
     warning   => 0.3,
     critical  => 0.9,
     use       => 'govuk_urgent_priority',
-    from      => '8minutes',
+    from      => '15minutes',
     desc      => '5xx rate for www-origin',
     host_name => $::fqdn,
     notes_url => monitoring_docs_url(high-nginx-5xx-rate),


### PR DESCRIPTION
https://trello.com/c/2GcGSx2X/1020-fix-origin-5xx-alert-for-spikes

Previously we applied a moving median average to various 5xx metrics,
which helps to dampen spikes over a short period. Icinga also does its
own (mean) averaging with the "from" param e.g. a "from" value of 8
means we average over three 5 min windows.

However, we can still get false alarms if we have a short period of high
5xx spikes. Increasing the window size is not ideal because this further
masks the data for the purpose of a warning. A compromise is to increase
the "from" value, so that we require more persistence for 5xx errors to
trigger a warning or a critical alert.

This increases the "from" param to 15 minutes for all 5xx alerts, so
that the windowed/de-spiked metric must either:

- Be higher over a shorter period of time; or
- Be over the threshold for a longer period of time