### PR TITLE
Stop having a double standard for origin 5xx

### DIFF
--- a/modules/router/manifests/nginx.pp
+++ b/modules/router/manifests/nginx.pp
@@ -141,27 +141,14 @@ class router::nginx (
   $graphite_5xx_target = "movingMedian(transformNull(stats.${::fqdn_metrics}.nginx_logs.www-origin.http_5xx,0),\"5min\")"
 
   @@icinga::check::graphite { "check_nginx_5xx_on_${::hostname}":
-    target              => $graphite_5xx_target,
-    warning             => 0.3,
-    critical            => 0.6,
-    use                 => 'govuk_urgent_priority',
-    from                => '8minutes',
-    desc                => '5xx rate for www-origin [in office hours]',
-    host_name           => $::fqdn,
-    notes_url           => monitoring_docs_url(high-nginx-5xx-rate),
-    notification_period => 'inoffice',
-  }
-
-  @@icinga::check::graphite { "check_nginx_5xx_on_${::hostname}_oncall":
-    target              => $graphite_5xx_target,
-    warning             => 0.5,
-    critical            => 0.9,
-    use                 => 'govuk_urgent_priority',
-    from                => '8minutes',
-    desc                => '5xx rate for www-origin [on call]',
-    host_name           => $::fqdn,
-    notes_url           => monitoring_docs_url(high-nginx-5xx-rate),
-    notification_period => 'oncall',
+    target    => $graphite_5xx_target,
+    warning   => 0.3,
+    critical  => 0.9,
+    use       => 'govuk_urgent_priority',
+    from      => '8minutes',
+    desc      => '5xx rate for www-origin',
+    host_name => $::fqdn,
+    notes_url => monitoring_docs_url(high-nginx-5xx-rate),
   }
 
   @@icinga::check::graphite { "check_nginx_requests_${::hostname}":


### PR DESCRIPTION
https://trello.com/c/2GcGSx2X/1020-fix-origin-5xx-alert-for-spikes

Previously we had two alerts for origin 5xx errors, with different
thresholds for in-hours vs. on-call. The importance of the site
being broken should not depend on the time of day, so this merges
the alerts together and thus unifies the thresholds:

- We take the lower threshold for the warning, to ensure we don't
lose visibility we have now. This won't apge anyone.

- We take the higher threshold for the critical, which is better
indicator that something is *definitely* broken.