### PR TITLE
Fix quantities of Sentry errors reported in Grafana

### DIFF
--- a/modules/grafana/files/dashboards/sentry_errors_across_all_environments.json
+++ b/modules/grafana/files/dashboards/sentry_errors_across_all_environments.json
@@ -6,7 +6,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "hideControls": false,
-  "id": 47,
+  "id": 16,
   "links": [],
   "refresh": false,
   "rows": [
@@ -72,11 +72,12 @@
           "targets": [
             {
               "refId": "A",
-              "target": "summarize(sumSeries(groupByNode(stats.govuk.app.*.*.errors_occurred, 3, 'sum')), '1d', 'sum')",
+              "target": "hitcount(sumSeries(groupByNode(stats.govuk.app.*.*.errors_occurred, 2, 'sum')), '1d')",
               "textEditor": true
             }
           ],
           "thresholds": "",
+          "timeFrom": null,
           "title": "Total app errors sent to Sentry",
           "type": "singlestat",
           "valueFontSize": "200%",
@@ -146,8 +147,8 @@
           "tableColumn": "",
           "targets": [
             {
-              "refId": "A",
-              "target": "summarize(sumSeries(groupByNode(stats.govuk.app.*.*.error_reports_failed, 3, 'sum')), '1d', 'sum')",
+              "refId": "B",
+              "target": "hitcount(sumSeries(groupByNode(stats.govuk.app.*.*.error_reports_failed, 2, 'sum')), '1d')",
               "textEditor": true
             }
           ],
@@ -220,13 +221,12 @@
           "tableColumn": "",
           "targets": [
             {
-              "hide": false,
-              "refId": "A",
-              "target": "asPercent(summarize(sumSeries(groupByNode(stats.govuk.app.*.*.error_reports_failed, 3, 'sum')), '1d', 'sum'), summarize(sumSeries(groupByNode(stats.govuk.app.*.*.errors_occurred, 3, 'sum')), '1d', 'sum'))",
+              "refId": "B",
+              "target": "asPercent(hitcount(sumSeries(groupByNode(stats.govuk.app.*.*.error_reports_failed, 2, 'sum')), '1d') , hitcount(sumSeries(groupByNode(stats.govuk.app.*.*.errors_occurred, 2, 'sum')), '1d'))",
               "textEditor": true
             }
           ],
-          "thresholds": "20,50",
+          "thresholds": "5, 20",
           "title": "Failure rate (rate limiting)",
           "type": "singlestat",
           "valueFontSize": "200%",
@@ -291,18 +291,13 @@
           "steppedLine": false,
           "targets": [
             {
-              "refId": "A",
-              "target": "alias(summarize(sumSeries(groupByNode(stats.govuk.app.*.*.errors_occurred, 3, 'sum')), '1d', 'sum'), 'Errors per day')",
-              "textEditor": true
-            },
-            {
-              "refId": "B",
-              "target": "alias(movingAverage(summarize(sumSeries(groupByNode(stats.govuk.app.*.*.errors_occurred, 3, 'sum')), '1d', 'sum'), '30d'), '30 day average')",
+              "refId": "C",
+              "target": "alias(hitcount(groupByNode(stats.govuk.app.*.*.errors_occurred, 2, 'sum'), '1d'), \"Errors per day\")",
               "textEditor": true
             }
           ],
           "thresholds": [],
-          "timeFrom": "now-90d",
+          "timeFrom": "now-30d",
           "timeShift": null,
           "title": "Errors sent to Sentry",
           "tooltip": {
@@ -381,18 +376,13 @@
           "steppedLine": false,
           "targets": [
             {
-              "refId": "A",
-              "target": "alias(summarize(sumSeries(groupByNode(stats.govuk.app.*.*.error_reports_failed, 3, 'sum')), '1d', 'sum'), 'Errors rate-limited per day')",
-              "textEditor": true
-            },
-            {
               "refId": "B",
-              "target": "alias(movingAverage(summarize(sumSeries(groupByNode(stats.govuk.app.*.*.error_reports_failed, 3, 'sum')), '1d', 'sum'), '30d'), '30 day average')",
+              "target": "alias(hitcount(groupByNode(stats.govuk.app.*.*.error_reports_failed, 2, 'sum'), '1d'), \"Errors rate-limited per day\")",
               "textEditor": true
             }
           ],
           "thresholds": [],
-          "timeFrom": "now-90d",
+          "timeFrom": "now-30d",
           "timeShift": null,
           "title": "Errors rate-limited by Sentry",
           "tooltip": {
@@ -809,7 +799,7 @@
   },
   "time": {
     "from": "now/d",
-    "to": "now/d"
+    "to": "now"
   },
   "timepicker": {
     "refresh_intervals": [


### PR DESCRIPTION
The previous dashboard under-reported the number of Sentry errors
by about 80%, as Graphite uses "events per second for the time
interval, usually 5 seconds. This means that a value of 0.2
represents a single event in a 5 second interval". See
https://docs.publishing.service.gov.uk/manual/graphite-and-deployment-dashboards.html#hitcount

Using `hitcount` converts the time interval data into what we
expect, i.e. an integer value representing the number of events
in the given time period.

I've also taken the opportunity to remove the '30 day average'
line, which isn't hugely useful, and to reduce the time scale from
90 days to 30, which is almost as useful and is more performant.

Now that we've brought the rate-limiting down, I've set stricter
thresholds of rate-limit too, so we need fewer errors to be rate
limited before 'Failure rate' is highlighted orange or red.

The differences can be seen below. Note that the values are all
roughly 5 times higher than previously, confirming that we were
lacking a `hitcount`.

## Production

### Before

![prod-before](https://user-images.githubusercontent.com/5111927/98029099-ec6aee80-1e06-11eb-8ec5-4d2680113c7d.png)

### After

![prod-after](https://user-images.githubusercontent.com/5111927/98029095-ebd25800-1e06-11eb-8c1c-9e24639a4f7e.png)

## Staging

### Before

![staging-before](https://user-images.githubusercontent.com/5111927/98029104-ed038500-1e06-11eb-9ae8-74f0f06f0237.png)

### After

![staging after](https://user-images.githubusercontent.com/5111927/98029621-b24e1c80-1e07-11eb-8d66-a5f5e2b1dca3.png)
