### PR TITLE
Wait even longer to alert about established conns

### DIFF
--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -416,6 +416,7 @@ define govuk::app::config (
       critical       => $local_tcpconns_critical,
       desc           => "Established connections for ${title_underscore} exceeds ${local_tcpconns_warning}",
       host_name      => $::fqdn,
+      from           => '15minutes',
       notes_url      => monitoring_docs_url(established-connections-exceed),
       contact_groups => $additional_check_contact_groups,
     }


### PR DESCRIPTION
https://trello.com/c/7QA5eAoC/483-do-an-audit-to-check-for-any-more-work-to-do-on-alerts-epic

Previously we applied a moving median average to the metric for this
alert, in order to filter out spikes [1]. However, it's still possible
to get false alarms due to temporary load that lasts a few minutes,
but doesn't represent an issue: the app recovers when as the load dies
down. This extends the data window for this alert from 5 minutes (the
default) to 15 minutes, reduced using a mean average [2].

Mean averaging is preferable because it's more responsive to increases
in the underlying metric. This means we get warnings earlier than if we
instead extended the existing median window to 15 minutes. Using the
combination of averages seems to be the best compromise:

- A 5 minute median average to remove one-off spikes
- A 15 minute mean average of that, to dampen short bursts

[1]: https://github.com/alphagov/govuk-puppet/pull/10804
[2]: https://github.com/pyr/check-graphite#how-it-works

## Before

<img width="820" alt="Screenshot 2020-11-04 at 12 28 42" src="https://user-images.githubusercontent.com/9029009/98111965-4d430700-1e99-11eb-92f2-aa8ee386aacf.png">

## After

Note how the time to reach a "warning" level is similar, but the overall max value is dampened.

<img width="982" alt="Screenshot 2020-11-04 at 12 29 13" src="https://user-images.githubusercontent.com/9029009/98112007-5df37d00-1e99-11eb-98ed-7b52dbf59c15.png">

## Raw

<img width="757" alt="Screenshot 2020-11-04 at 12 29 43" src="https://user-images.githubusercontent.com/9029009/98112052-6f3c8980-1e99-11eb-9187-e7a5d56407b9.png">

## Extended Median (alt)

Note how the overall values are much lower than with a mean average (above). Another perspective: it takes longer to reach a threshold value.

<img width="834" alt="Screenshot 2020-11-04 at 12 30 12" src="https://user-images.githubusercontent.com/9029009/98112100-81b6c300-1e99-11eb-9c31-e91f7d69be47.png">
