### PR TITLE
Hide CKAN /revision path

### DIFF
--- a/modules/govuk/manifests/apps/ckan.pp
+++ b/modules/govuk/manifests/apps/ckan.pp
@@ -207,7 +207,7 @@ class govuk::apps::ckan (
       protected          => $vhost_protected,
       ssl_only           => true,
       app_port           => $port,
-      hidden_paths       => ['/api/'],
+      hidden_paths       => ['/api/', '/revision'],
       read_timeout       => $request_timeout,
       nginx_extra_config => template('govuk/ckan/nginx.conf.erb'),
       deny_crawlers      => true,


### PR DESCRIPTION
It contains information on users who have been removed and shouldn't be visible to the public.

[Trello Card](https://trello.com/c/TPzymMmJ/2205-3-block-access-to-revision-endpoint)