### PR TITLE
Fix fact check alert not firing when it should

### DIFF
--- a/modules/govuk/manifests/apps/publisher/unprocessed_emails_count_check.pp
+++ b/modules/govuk/manifests/apps/publisher/unprocessed_emails_count_check.pp
@@ -15,9 +15,9 @@ class govuk::apps::publisher::unprocessed_emails_count_check(
   @@icinga::check::graphite { 'check_publisher_unprocessed_fact_check_emails':
     ensure    => $ensure,
     host_name => $::fqdn,
-    target    => 'transformNull(averageSeries(keepLastValue(stats.gauges.govuk.app.publisher.*.unprocessed_emails.count)))',
-    warning   => '1',
-    critical  => '2',
+    target    => 'transformNull(stats.gauges.govuk.app.publisher.*.unprocessed_emails.count,0)',
+    warning   => '0',
+    critical  => '0.1',
     from      => '1hour',
     desc      => 'publisher - unprocessed fact-check emails are present',
     notes_url => monitoring_docs_url(publisher-unprocessed-fact-check-emails),


### PR DESCRIPTION
Previously the "1" threshold for this alert failed to trigger due
to a windowing issue where the computed average was actually 0.958.
Since the averaging done by Icinga always means it will always take
some time for this alert to reach a value of "1" [1], this reduces
the threshold so we get alerted faster and more reliably.

Note that there is no need for a "warning" with this alert, since
it's highly unlikely to fix itself.

Note that the previous functions around the metric for this alert
were largely unnecessary:

- keepLastValue is redundant since we also have transformNull
- averageSeries is redundant since Icinga does this anyway [1]

[1]: https://github.com/pyr/check-graphite