### PR TITLE
Fix fact check email alert again

### DIFF
--- a/modules/govuk/manifests/apps/publisher/unprocessed_emails_count_check.pp
+++ b/modules/govuk/manifests/apps/publisher/unprocessed_emails_count_check.pp
@@ -15,7 +15,7 @@ class govuk::apps::publisher::unprocessed_emails_count_check(
   @@icinga::check::graphite { 'check_publisher_unprocessed_fact_check_emails':
     ensure    => $ensure,
     host_name => $::fqdn,
-    target    => 'transformNull(stats.gauges.govuk.app.publisher.*.unprocessed_emails.count,0)',
+    target    => 'summarize(stats.gauges.govuk.app.publisher.*.unprocessed_emails.count,"5min","max")',
     warning   => '0',
     critical  => '0.1',
     from      => '1hour',


### PR DESCRIPTION
Previously we modified this alert in an attempt to make sure it
would trigger despite the additional averaging applied by Icinga
[1]. The alert does now trigger, but the averaging still means it
only triggers at a warning level. This is another attempt to get
the alert firing at a CRITICAL level, using "summarize" to get a
moving maximum of the metric that will mean the set of datapoints
to average will exceed the CRITICAL threshold.

Note that the CRITICAL threshold still needs to be lower than one,
as the averaging applied by Icinga can still be slightly less than
this, due to the windowing leaving a "gap on the end".

[1]: https://github.com/alphagov/govuk-puppet/pull/10824

## Before

<img width="996" alt="Screenshot 2020-11-06 at 11 29 40" src="https://user-images.githubusercontent.com/9029009/98361403-62e43800-2023-11eb-80a4-eaddc26bb6a1.png">


## After

<img width="999" alt="Screenshot 2020-11-06 at 11 28 49" src="https://user-images.githubusercontent.com/9029009/98361365-4fd16800-2023-11eb-9f55-86ae297b9a92.png">
