### PR TITLE
Report Icinga alert states as separate metrics

### DIFF
--- a/modules/icinga/templates/notify_graphite.erb
+++ b/modules/icinga/templates/notify_graphite.erb
@@ -125,23 +125,16 @@ Statsd.configure(
   options.fetch(:statsd_port, 8125),
 )
 
-namespace = if options[:command_type] == "host"
-              "icinga.host_alert.#{options[:host_display_name]}"
-            else
-              "icinga.service_alert.#{options[:host_display_name]}.#{options[:service_desc]}"
-            end
-
 state = if options[:command_type] == "host"
           options[:host_state]
         else
           options[:service_state]
         end
 
-GAUGE_VALUES = {
-  "ok" => 0,
-  "unknown" => 1,
-  "warning" => 2,
-  "critical" => 3,
-}
+namespace = if options[:command_type] == "host"
+              "icinga.host_alert.#{options[:host_display_name]}.#{state}"
+            else
+              "icinga.service_alert.#{options[:host_display_name]}.#{options[:service_desc]}.#{state}"
+            end
 
-Statsd.gauge(namespace, GAUGE_VALUES.fetch(state))
+Statsd.increment(namespace)


### PR DESCRIPTION
Previously we reported the state of an alert as the value of the
associated metric, which makes little sense as alert states are
not a "quantity". Using a gauge makes it hard to visualise the
resulting stats, because any aggregation on them will conflate
different states for the alert. This changes the approach for
alert metrics by reporting each state of the alert as its own
metric, so that we can distinguish between them.