### PR TITLE
Aggregate Icinga alert counts for faster reporting

### DIFF
--- a/modules/govuk/files/node/s_graphite/aggregation-rules.conf
+++ b/modules/govuk/files/node/s_graphite/aggregation-rules.conf
@@ -4,3 +4,6 @@ stats.<host>.nginx_logs.<vhost>.http_2xx (5) = sum stats.<host>.nginx_logs.<vhos
 stats.<host>.nginx_logs.<vhost>.http_3xx (5) = sum stats.<host>.nginx_logs.<vhost>.http_3[0-9][0-9]
 stats.<host>.nginx_logs.<vhost>.http_4xx (5) = sum stats.<host>.nginx_logs.<vhost>.http_4[0-9][0-9]
 stats.<host>.nginx_logs.<vhost>.http_5xx (5) = sum stats.<host>.nginx_logs.<vhost>.http_5[0-9][0-9]
+
+stats_counts.icinga.service_alert.<host>.*.<level> (60) = sum stats_counts.icinga.service_alert.<host>.<level>
+stats_counts.icinga.service_alert.*.*.<level> (60) = sum stats_counts.icinga.service_alert.<level>


### PR DESCRIPTION
This introduces two new metric namespaces so that we can easily see
the total number of alerts overall and per-machine. Currently, the
number of metrics is too great to compute this.