### PR TITLE
Increase thesholds for imminence memory usage alerts

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -664,8 +664,8 @@ govuk::apps::imminence::mongodb_nodes:
   - 'mongo-3'
 govuk::apps::imminence::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::imminence::redis_port: "%{hiera('sidekiq_port')}"
-govuk::apps::imminence::nagios_memory_warning: 1200
-govuk::apps::imminence::nagios_memory_critical: 1400
+govuk::apps::imminence::nagios_memory_warning: 2400
+govuk::apps::imminence::nagios_memory_critical: 2800
 govuk::apps::imminence::unicorn_worker_processes: "8"
 
 govuk::apps::info_frontend::enabled: true


### PR DESCRIPTION
Doubling the thresholds as previous doubled the number of worker, which expectedly increases memory usage.