### PR TITLE
Duplicate OAUTH_* env vars with GDS_SSO prefixed equivalents

### DIFF
--- a/docs/adding-a-new-app.md
+++ b/docs/adding-a-new-app.md
@@ -91,6 +91,12 @@ class govuk::apps::myapp (
     "${title}-SECRET_KEY_BASE":
       varname        => 'SECRET_KEY_BASE',
       value          => $secret_key_base;
+    "${title}-GDS_SSO_OAUTH_ID":
+      varname        => 'GDS_SSO_OAUTH_ID',
+      value          => $oauth_id;
+    "${title}-GDS_SSO_OAUTH_SECRET":
+      varname        => 'GDS_SSO_OAUTH_SECRET',
+      value          => $oauth_secret;
     "${title}-OAUTH_ID":
       varname        => 'OAUTH_ID',
       value          => $oauth_id;

--- a/modules/govuk/manifests/apps/asset_manager.pp
+++ b/modules/govuk/manifests/apps/asset_manager.pp
@@ -114,6 +114,12 @@ class govuk::apps::asset_manager(
     }
 
     govuk::app::envvar {
+      "${title}-GDS_SSO_OAUTH_ID":
+        varname => 'GDS_SSO_OAUTH_ID',
+        value   => $oauth_id;
+      "${title}-GDS_SSO_OAUTH_SECRET":
+        varname => 'GDS_SSO_OAUTH_SECRET',
+        value   => $oauth_secret;
       "${title}-OAUTH_ID":
         varname => 'OAUTH_ID',
         value   => $oauth_id;

--- a/modules/govuk/manifests/apps/authenticating_proxy.pp
+++ b/modules/govuk/manifests/apps/authenticating_proxy.pp
@@ -83,6 +83,12 @@ class govuk::apps::authenticating_proxy(
   }
 
   govuk::app::envvar {
+    "${title}-GDS_SSO_OAUTH_ID":
+      varname => 'GDS_SSO_OAUTH_ID',
+      value   => $oauth_id;
+    "${title}-GDS_SSO_OAUTH_SECRET":
+      varname => 'GDS_SSO_OAUTH_SECRET',
+      value   => $oauth_secret;
     "${title}-OAUTH_ID":
       varname => 'OAUTH_ID',
       value   => $oauth_id;

--- a/modules/govuk/manifests/apps/authenticating_proxy.pp
+++ b/modules/govuk/manifests/apps/authenticating_proxy.pp
@@ -78,35 +78,22 @@ class govuk::apps::authenticating_proxy(
     }
   }
 
-  if $oauth_id != undef {
-    govuk::app::envvar { "${title}-OAUTH_ID":
-      app     => $app_name,
+  Govuk::App::Envvar {
+    app => $app_name,
+  }
+
+  govuk::app::envvar {
+    "${title}-OAUTH_ID":
       varname => 'OAUTH_ID',
-      value   => $oauth_id,
-    }
-  }
-
-  if $oauth_secret != undef {
-    govuk::app::envvar { "${title}-OAUTH_SECRET":
-      app     => $app_name,
+      value   => $oauth_id;
+    "${title}-OAUTH_SECRET":
       varname => 'OAUTH_SECRET',
-      value   => $oauth_secret,
-    }
-  }
-
-  if $secret_key_base != undef {
-    govuk::app::envvar { "${title}-SECRET_KEY_BASE":
-      app     => $app_name,
+      value   => $oauth_secret;
+    "${title}-SECRET_KEY_BASE":
       varname => 'SECRET_KEY_BASE',
-      value   => $secret_key_base,
-    }
-  }
-
-  if $jwt_auth_secret != undef {
-    govuk::app::envvar { "${title}-JWT_AUTH_SECRET":
-      app     => $app_name,
+      value   => $secret_key_base;
+    "${title}-JWT_AUTH_SECRET":
       varname => 'JWT_AUTH_SECRET',
       value   => $jwt_auth_secret,
-    }
   }
 }

--- a/modules/govuk/manifests/apps/collections_publisher.pp
+++ b/modules/govuk/manifests/apps/collections_publisher.pp
@@ -129,6 +129,12 @@ class govuk::apps::collections_publisher(
     }
 
     govuk::app::envvar {
+      "${title}-GDS_SSO_OAUTH_ID":
+        varname => 'GDS_SSO_OAUTH_ID',
+        value   => $oauth_id;
+      "${title}-GDS_SSO_OAUTH_SECRET":
+        varname => 'GDS_SSO_OAUTH_SECRET',
+        value   => $oauth_secret;
       "${title}-OAUTH_ID":
         varname => 'OAUTH_ID',
         value   => $oauth_id;

--- a/modules/govuk/manifests/apps/contacts.pp
+++ b/modules/govuk/manifests/apps/contacts.pp
@@ -133,6 +133,12 @@ class govuk::apps::contacts(
         app     => $app_name,
         varname => 'PUBLISHING_API_BEARER_TOKEN',
         value   => $publishing_api_bearer_token;
+      "${title}-GDS_SSO_OAUTH_ID":
+        varname => 'GDS_SSO_OAUTH_ID',
+        value   => $oauth_id;
+      "${title}-GDS_SSO_OAUTH_SECRET":
+        varname => 'GDS_SSO_OAUTH_SECRET',
+        value   => $oauth_secret;
       "${title}-OAUTH_ID":
         varname => 'OAUTH_ID',
         value   => $oauth_id;

--- a/modules/govuk/manifests/apps/content_data_admin.pp
+++ b/modules/govuk/manifests/apps/content_data_admin.pp
@@ -150,6 +150,12 @@ class govuk::apps::content_data_admin (
     "${title}-SECRET_KEY_BASE":
       varname => 'SECRET_KEY_BASE',
       value   => $secret_key_base;
+    "${title}-GDS_SSO_OAUTH_ID":
+      varname => 'GDS_SSO_OAUTH_ID',
+      value   => $oauth_id;
+    "${title}-GDS_SSO_OAUTH_SECRET":
+      varname => 'GDS_SSO_OAUTH_SECRET',
+      value   => $oauth_secret;
     "${title}-OAUTH_ID":
       varname => 'OAUTH_ID',
       value   => $oauth_id;

--- a/modules/govuk/manifests/apps/content_data_api.pp
+++ b/modules/govuk/manifests/apps/content_data_api.pp
@@ -175,6 +175,12 @@ class govuk::apps::content_data_api(
     "${title}-GOOGLE_CLIENT_EMAIL":
       varname => 'GOOGLE_CLIENT_EMAIL',
       value   => $google_client_email;
+    "${title}-GDS_SSO_OAUTH_ID":
+      varname => 'GDS_SSO_OAUTH_ID',
+      value   => $oauth_id;
+    "${title}-GDS_SSO_OAUTH_SECRET":
+      varname => 'GDS_SSO_OAUTH_SECRET',
+      value   => $oauth_secret;
     "${title}-OAUTH_ID":
       varname => 'OAUTH_ID',
       value   => $oauth_id;

--- a/modules/govuk/manifests/apps/content_publisher.pp
+++ b/modules/govuk/manifests/apps/content_publisher.pp
@@ -163,6 +163,12 @@ class govuk::apps::content_publisher (
     "${title}-SECRET_KEY_BASE":
       varname => 'SECRET_KEY_BASE',
       value   => $secret_key_base;
+    "${title}-GDS_SSO_OAUTH_ID":
+      varname => 'GDS_SSO_OAUTH_ID',
+      value   => $oauth_id;
+    "${title}-GDS_SSO_OAUTH_SECRET":
+      varname => 'GDS_SSO_OAUTH_SECRET',
+      value   => $oauth_secret;
     "${title}-OAUTH_ID":
       varname => 'OAUTH_ID',
       value   => $oauth_id;

--- a/modules/govuk/manifests/apps/content_store.pp
+++ b/modules/govuk/manifests/apps/content_store.pp
@@ -128,6 +128,12 @@ class govuk::apps::content_store(
     "${title}-DEFAULT_TTL":
       varname => 'DEFAULT_TTL',
       value   => $default_ttl;
+    "${title}-GDS_SSO_OAUTH_ID":
+      varname => 'GDS_SSO_OAUTH_ID',
+      value   => $oauth_id;
+    "${title}-GDS_SSO_OAUTH_SECRET":
+      varname => 'GDS_SSO_OAUTH_SECRET',
+      value   => $oauth_secret;
     "${title}-OAUTH_ID":
       varname => 'OAUTH_ID',
       value   => $oauth_id;

--- a/modules/govuk/manifests/apps/content_tagger.pp
+++ b/modules/govuk/manifests/apps/content_tagger.pp
@@ -125,6 +125,12 @@ class govuk::apps::content_tagger(
     }
 
     govuk::app::envvar {
+      "${title}-GDS_SSO_OAUTH_ID":
+        varname => 'GDS_SSO_OAUTH_ID',
+        value   => $oauth_id;
+      "${title}-GDS_SSO_OAUTH_SECRET":
+        varname => 'GDS_SSO_OAUTH_SECRET',
+        value   => $oauth_secret;
       "${title}-OAUTH_ID":
         varname => 'OAUTH_ID',
         value   => $oauth_id;

--- a/modules/govuk/manifests/apps/email_alert_api.pp
+++ b/modules/govuk/manifests/apps/email_alert_api.pp
@@ -225,6 +225,12 @@ class govuk::apps::email_alert_api(
     "${title}-SECRET_KEY_BASE":
         varname => 'SECRET_KEY_BASE',
         value   => $secret_key_base;
+    "${title}-GDS_SSO_OAUTH_ID":
+        varname => 'GDS_SSO_OAUTH_ID',
+        value   => $oauth_id;
+    "${title}-GDS_SSO_OAUTH_SECRET":
+        varname => 'GDS_SSO_OAUTH_SECRET',
+        value   => $oauth_secret;
     "${title}-OAUTH_ID":
         varname => 'OAUTH_ID',
         value   => $oauth_id;

--- a/modules/govuk/manifests/apps/hmrc_manuals_api.pp
+++ b/modules/govuk/manifests/apps/hmrc_manuals_api.pp
@@ -86,6 +86,12 @@ class govuk::apps::hmrc_manuals_api(
     }
 
     govuk::app::envvar {
+      "${title}-GDS_SSO_OAUTH_ID":
+        varname => 'GDS_SSO_OAUTH_ID',
+        value   => $oauth_id;
+      "${title}-GDS_SSO_OAUTH_SECRET":
+        varname => 'GDS_SSO_OAUTH_SECRET',
+        value   => $oauth_secret;
       "${title}-OAUTH_ID":
         varname => 'OAUTH_ID',
         value   => $oauth_id;

--- a/modules/govuk/manifests/apps/imminence.pp
+++ b/modules/govuk/manifests/apps/imminence.pp
@@ -92,6 +92,12 @@ class govuk::apps::imminence(
   }
 
   govuk::app::envvar {
+    "${title}-GDS_SSO_OAUTH_ID":
+      varname => 'GDS_SSO_OAUTH_ID',
+      value   => $oauth_id;
+    "${title}-GDS_SSO_OAUTH_SECRET":
+      varname => 'GDS_SSO_OAUTH_SECRET',
+      value   => $oauth_secret;
     "${title}-OAUTH_ID":
       varname => 'OAUTH_ID',
       value   => $oauth_id;

--- a/modules/govuk/manifests/apps/link_checker_api.pp
+++ b/modules/govuk/manifests/apps/link_checker_api.pp
@@ -115,6 +115,12 @@ class govuk::apps::link_checker_api (
   }
 
   govuk::app::envvar {
+    "${title}-GDS_SSO_OAUTH_ID":
+      varname => 'GDS_SSO_OAUTH_ID',
+      value   => $oauth_id;
+    "${title}-GDS_SSO_OAUTH_SECRET":
+      varname => 'GDS_SSO_OAUTH_SECRET',
+      value   => $oauth_secret;
     "${title}-OAUTH_ID":
       varname => 'OAUTH_ID',
       value   => $oauth_id;

--- a/modules/govuk/manifests/apps/local_links_manager.pp
+++ b/modules/govuk/manifests/apps/local_links_manager.pp
@@ -181,6 +181,12 @@ class govuk::apps::local_links_manager(
     "${title}-SECRET_KEY_BASE":
       varname => 'SECRET_KEY_BASE',
       value   => $secret_key_base;
+    "${title}-GDS_SSO_OAUTH_ID":
+      varname => 'GDS_SSO_OAUTH_ID',
+      value   => $oauth_id;
+    "${title}-GDS_SSO_OAUTH_SECRET":
+      varname => 'GDS_SSO_OAUTH_SECRET',
+      value   => $oauth_secret;
     "${title}-OAUTH_ID":
       varname => 'OAUTH_ID',
       value   => $oauth_id;

--- a/modules/govuk/manifests/apps/manuals_publisher.pp
+++ b/modules/govuk/manifests/apps/manuals_publisher.pp
@@ -144,6 +144,12 @@ class govuk::apps::manuals_publisher(
       "${title}-EMAIL_ALERT_API_BEARER_TOKEN":
         varname => 'EMAIL_ALERT_API_BEARER_TOKEN',
         value   => $email_alert_api_bearer_token;
+      "${title}-GDS_SSO_OAUTH_ID":
+        varname => 'GDS_SSO_OAUTH_ID',
+        value   => $oauth_id;
+      "${title}-GDS_SSO_OAUTH_SECRET":
+        varname => 'GDS_SSO_OAUTH_SECRET',
+        value   => $oauth_secret;
       "${title}-OAUTH_ID":
         varname => 'OAUTH_ID',
         value   => $oauth_id;

--- a/modules/govuk/manifests/apps/maslow.pp
+++ b/modules/govuk/manifests/apps/maslow.pp
@@ -83,6 +83,12 @@ class govuk::apps::maslow(
       "${title}-PUBLISHING_API_BEARER_TOKEN":
         varname => 'PUBLISHING_API_BEARER_TOKEN',
         value   => $publishing_api_bearer_token;
+      "${title}-GDS_SSO_OAUTH_ID":
+        varname => 'GDS_SSO_OAUTH_ID',
+        value   => $oauth_id;
+      "${title}-GDS_SSO_OAUTH_SECRET":
+        varname => 'GDS_SSO_OAUTH_SECRET',
+        value   => $oauth_secret;
       "${title}-OAUTH_ID":
         varname => 'OAUTH_ID',
         value   => $oauth_id;

--- a/modules/govuk/manifests/apps/publisher.pp
+++ b/modules/govuk/manifests/apps/publisher.pp
@@ -209,6 +209,12 @@ class govuk::apps::publisher(
       "${title}-SECRET_KEY_BASE":
         varname => 'SECRET_KEY_BASE',
         value   => $secret_key_base;
+      "${title}-GDS_SSO_OAUTH_ID":
+        varname => 'GDS_SSO_OAUTH_ID',
+        value   => $oauth_id;
+      "${title}-GDS_SSO_OAUTH_SECRET":
+        varname => 'GDS_SSO_OAUTH_SECRET',
+        value   => $oauth_secret;
       "${title}-OAUTH_ID":
         varname => 'OAUTH_ID',
         value   => $oauth_id;

--- a/modules/govuk/manifests/apps/publishing_api.pp
+++ b/modules/govuk/manifests/apps/publishing_api.pp
@@ -217,6 +217,12 @@ class govuk::apps::publishing_api(
       "${title}-SUPPRESS_DRAFT_STORE_502_ERROR":
         varname => 'SUPPRESS_DRAFT_STORE_502_ERROR',
         value   => $suppress_draft_store_502_error;
+      "${title}-GDS_SSO_OAUTH_ID":
+        varname => 'GDS_SSO_OAUTH_ID',
+        value   => $oauth_id;
+      "${title}-GDS_SSO_OAUTH_SECRET":
+        varname => 'GDS_SSO_OAUTH_SECRET',
+        value   => $oauth_secret;
       "${title}-OAUTH_ID":
         varname => 'OAUTH_ID',
         value   => $oauth_id;

--- a/modules/govuk/manifests/apps/release.pp
+++ b/modules/govuk/manifests/apps/release.pp
@@ -76,6 +76,12 @@ class govuk::apps::release(
   }
 
   govuk::app::envvar {
+    "${title}-GDS_SSO_OAUTH_ID":
+      varname => 'GDS_SSO_OAUTH_ID',
+      value   => $oauth_id;
+    "${title}-GDS_SSO_OAUTH_SECRET":
+      varname => 'GDS_SSO_OAUTH_SECRET',
+      value   => $oauth_secret;
     "${title}-OAUTH_ID":
       varname => 'OAUTH_ID',
       value   => $oauth_id;

--- a/modules/govuk/manifests/apps/router_api.pp
+++ b/modules/govuk/manifests/apps/router_api.pp
@@ -76,6 +76,12 @@ class govuk::apps::router_api(
     "${title}-SECRET_KEY_BASE":
       varname => 'SECRET_KEY_BASE',
       value   => $secret_key_base;
+    "${title}-GDS_SSO_OAUTH_ID":
+      varname => 'GDS_SSO_OAUTH_ID',
+      value   => $oauth_id;
+    "${title}-GDS_SSO_OAUTH_SECRET":
+      varname => 'GDS_SSO_OAUTH_SECRET',
+      value   => $oauth_secret;
     "${title}-OAUTH_ID":
       varname => 'OAUTH_ID',
       value   => $oauth_id;

--- a/modules/govuk/manifests/apps/search_admin.pp
+++ b/modules/govuk/manifests/apps/search_admin.pp
@@ -7,7 +7,7 @@
 #
 # [*ensure*]
 #   Allow govuk app to be removed.
-#   
+#
 # [*db_hostname*]
 #   The hostname of the database server to use in the DATABASE_URL.
 #
@@ -126,6 +126,12 @@ class govuk::apps::search_admin(
       "${title}-PUBLISHING_API_BEARER_TOKEN":
         varname => 'PUBLISHING_API_BEARER_TOKEN',
         value   => $publishing_api_bearer_token;
+      "${title}-GDS_SSO_OAUTH_ID":
+        varname => 'GDS_SSO_OAUTH_ID',
+        value   => $oauth_id;
+      "${title}-GDS_SSO_OAUTH_SECRET":
+        varname => 'GDS_SSO_OAUTH_SECRET',
+        value   => $oauth_secret;
       "${title}-OAUTH_ID":
         varname => 'OAUTH_ID',
         value   => $oauth_id;

--- a/modules/govuk/manifests/apps/search_api.pp
+++ b/modules/govuk/manifests/apps/search_api.pp
@@ -219,21 +219,12 @@ class govuk::apps::search_api(
     "${title}-UNICORN_TIMEOUT":
       varname => 'UNICORN_TIMEOUT',
       value   => $unicorn_timeout;
-  }
-
-  govuk::app::envvar {
     "${title}-PUBLISHING_API_BEARER_TOKEN":
       varname => 'PUBLISHING_API_BEARER_TOKEN',
       value   => $publishing_api_bearer_token;
-  }
-
-  govuk::app::envvar {
     "${title}-EMAIL_ALERT_API_BEARER_TOKEN":
       varname => 'EMAIL_ALERT_API_BEARER_TOKEN',
       value   => $email_alert_api_bearer_token;
-  }
-
-  govuk::app::envvar {
     "${title}-GOOGLE_ANALYTICS_GOVUK_VIEW_ID":
       varname => 'GOOGLE_ANALYTICS_GOVUK_VIEW_ID',
       value   => $google_analytics_govuk_view_id;
@@ -255,35 +246,18 @@ class govuk::apps::search_api(
     "${title}-GOOGLE_EXPORT_WEB_PROPERTY_ID":
       varname => 'GOOGLE_EXPORT_WEB_PROPERTY_ID',
       value   => $google_export_web_property_id;
-  }
-
-  govuk::app::envvar { "${title}-ELASTICSEARCH_URI":
-    varname => 'ELASTICSEARCH_URI',
-    value   => $elasticsearch_hosts,
-  }
-
-  if $elasticsearch_b_uri != 'null' {
-    govuk::app::envvar { "${title}-ELASTICSEARCH_B_URI":
-      varname => 'ELASTICSEARCH_B_URI',
-      value   => $elasticsearch_b_uri,
-    }
-  }
-
-  govuk::app::envvar { "${title}-ELASTICSEARCH_HOSTS":
-    varname => 'ELASTICSEARCH_HOSTS',
-    value   => $elasticsearch_hosts,
-  }
-
-  govuk::app::envvar {
+    "${title}-ELASTICSEARCH_URI":
+      varname => 'ELASTICSEARCH_URI',
+      value   => $elasticsearch_hosts;
+    "${title}-ELASTICSEARCH_HOSTS":
+      varname => 'ELASTICSEARCH_HOSTS',
+      value   => $elasticsearch_hosts;
     "${title}-OAUTH_ID":
       varname => 'OAUTH_ID',
       value   => $oauth_id;
     "${title}-OAUTH_SECRET":
       varname => 'OAUTH_SECRET',
       value   => $oauth_secret;
-  }
-
-  govuk::app::envvar {
     "${title}-AWS_REGION":
       varname => 'AWS_REGION',
       value   => $aws_region;
@@ -293,9 +267,6 @@ class govuk::apps::search_api(
     "${title}-AWS_S3_SITEMAPS_BUCKET_NAME":
       varname => 'AWS_S3_SITEMAPS_BUCKET_NAME',
       value   => $sitemaps_bucket_name;
-  }
-
-  govuk::app::envvar {
     "${title}-ENABLE_LTR":
       varname => 'ENABLE_LTR',
       value   => bool2str($enable_learning_to_rank);
@@ -305,5 +276,12 @@ class govuk::apps::search_api(
     "${title}-TENSORFLOW_SAGEMAKER_VARIANTS":
       varname => 'TENSORFLOW_SAGEMAKER_VARIANTS',
       value   => $tensorflow_sagemaker_variants;
+  }
+
+  if $elasticsearch_b_uri != 'null' {
+    govuk::app::envvar { "${title}-ELASTICSEARCH_B_URI":
+      varname => 'ELASTICSEARCH_B_URI',
+      value   => $elasticsearch_b_uri,
+    }
   }
 }

--- a/modules/govuk/manifests/apps/search_api.pp
+++ b/modules/govuk/manifests/apps/search_api.pp
@@ -252,6 +252,12 @@ class govuk::apps::search_api(
     "${title}-ELASTICSEARCH_HOSTS":
       varname => 'ELASTICSEARCH_HOSTS',
       value   => $elasticsearch_hosts;
+    "${title}-GDS_SSO_OAUTH_ID":
+      varname => 'GDS_SSO_OAUTH_ID',
+      value   => $oauth_id;
+    "${title}-GDS_SSO_OAUTH_SECRET":
+      varname => 'GDS_SSO_OAUTH_SECRET',
+      value   => $oauth_secret;
     "${title}-OAUTH_ID":
       varname => 'OAUTH_ID',
       value   => $oauth_id;

--- a/modules/govuk/manifests/apps/search_api.pp
+++ b/modules/govuk/manifests/apps/search_api.pp
@@ -135,7 +135,6 @@ class govuk::apps::search_api(
   $nagios_memory_critical = undef,
   $spelling_dependencies = 'present',
   $elasticsearch_hosts = undef,
-  $elasticsearch_b_uri = undef,
   $unicorn_worker_processes = undef,
   $oauth_id = undef,
   $oauth_secret = undef,
@@ -282,12 +281,5 @@ class govuk::apps::search_api(
     "${title}-TENSORFLOW_SAGEMAKER_VARIANTS":
       varname => 'TENSORFLOW_SAGEMAKER_VARIANTS',
       value   => $tensorflow_sagemaker_variants;
-  }
-
-  if $elasticsearch_b_uri != 'null' {
-    govuk::app::envvar { "${title}-ELASTICSEARCH_B_URI":
-      varname => 'ELASTICSEARCH_B_URI',
-      value   => $elasticsearch_b_uri,
-    }
   }
 }

--- a/modules/govuk/manifests/apps/service_manual_publisher.pp
+++ b/modules/govuk/manifests/apps/service_manual_publisher.pp
@@ -107,6 +107,12 @@ class govuk::apps::service_manual_publisher(
     }
 
     govuk::app::envvar {
+      "${title}-GDS_SSO_OAUTH_ID":
+        varname => 'GDS_SSO_OAUTH_ID',
+        value   => $oauth_id;
+      "${title}-GDS_SSO_OAUTH_SECRET":
+        varname => 'GDS_SSO_OAUTH_SECRET',
+        value   => $oauth_secret;
       "${title}-OAUTH_ID":
         varname => 'OAUTH_ID',
         value   => $oauth_id;

--- a/modules/govuk/manifests/apps/short_url_manager.pp
+++ b/modules/govuk/manifests/apps/short_url_manager.pp
@@ -112,6 +112,12 @@ class govuk::apps::short_url_manager(
     }
 
     govuk::app::envvar {
+      "${title}-GDS_SSO_OAUTH_ID":
+        varname => 'GDS_SSO_OAUTH_ID',
+        value   => $oauth_id;
+      "${title}-GDS_SSO_OAUTH_SECRET":
+        varname => 'GDS_SSO_OAUTH_SECRET',
+        value   => $oauth_secret;
       "${title}-OAUTH_ID":
         varname => 'OAUTH_ID',
         value   => $oauth_id;

--- a/modules/govuk/manifests/apps/specialist_publisher.pp
+++ b/modules/govuk/manifests/apps/specialist_publisher.pp
@@ -181,6 +181,12 @@ client_max_body_size 500m;
       "${title}-ASSET_MANAGER_BEARER_TOKEN":
       varname => 'ASSET_MANAGER_BEARER_TOKEN',
       value   => $asset_manager_bearer_token;
+      "${title}-GDS_SSO_OAUTH_ID":
+      varname => 'GDS_SSO_OAUTH_ID',
+      value   => $oauth_id;
+      "${title}-GDS_SSO_OAUTH_SECRET":
+      varname => 'GDS_SSO_OAUTH_SECRET',
+      value   => $oauth_secret;
       "${title}-OAUTH_ID":
       varname => 'OAUTH_ID',
       value   => $oauth_id;

--- a/modules/govuk/manifests/apps/support.pp
+++ b/modules/govuk/manifests/apps/support.pp
@@ -127,6 +127,12 @@ class govuk::apps::support(
     "${title}-EMERGENCY_CONTACT_DETAILS":
       varname => 'EMERGENCY_CONTACT_DETAILS',
       value   => $emergency_contact_details_json;
+    "${title}-GDS_SSO_OAUTH_ID":
+      varname => 'GDS_SSO_OAUTH_ID',
+      value   => $oauth_id;
+    "${title}-GDS_SSO_OAUTH_SECRET":
+      varname => 'GDS_SSO_OAUTH_SECRET',
+      value   => $oauth_secret;
     "${title}-OAUTH_ID":
       varname => 'OAUTH_ID',
       value   => $oauth_id;

--- a/modules/govuk/manifests/apps/support_api.pp
+++ b/modules/govuk/manifests/apps/support_api.pp
@@ -133,6 +133,12 @@ class govuk::apps::support_api(
   }
 
   govuk::app::envvar {
+    "${title}-GDS_SSO_OAUTH_ID":
+      varname => 'GDS_SSO_OAUTH_ID',
+      value   => $oauth_id;
+    "${title}-GDS_SSO_OAUTH_SECRET":
+      varname => 'GDS_SSO_OAUTH_SECRET',
+      value   => $oauth_secret;
     "${title}-OAUTH_ID":
       varname => 'OAUTH_ID',
       value   => $oauth_id;

--- a/modules/govuk/manifests/apps/transition.pp
+++ b/modules/govuk/manifests/apps/transition.pp
@@ -123,6 +123,12 @@ class govuk::apps::transition(
 
     if $secret_key_base {
       govuk::app::envvar {
+        "${title}-GDS_SSO_OAUTH_ID":
+          varname => 'GDS_SSO_OAUTH_ID',
+          value   => $oauth_id;
+        "${title}-GDS_SSO_OAUTH_SECRET":
+          varname => 'GDS_SSO_OAUTH_SECRET',
+          value   => $oauth_secret;
         "${title}-OAUTH_ID":
           varname => 'OAUTH_ID',
           value   => $oauth_id;

--- a/modules/govuk/manifests/apps/travel_advice_publisher.pp
+++ b/modules/govuk/manifests/apps/travel_advice_publisher.pp
@@ -146,6 +146,12 @@ class govuk::apps::travel_advice_publisher(
       "${title}-ASSET_MANAGER_BEARER_TOKEN":
         varname => 'ASSET_MANAGER_BEARER_TOKEN',
         value   => $asset_manager_bearer_token;
+      "${title}-GDS_SSO_OAUTH_ID":
+        varname => 'GDS_SSO_OAUTH_ID',
+        value   => $oauth_id;
+      "${title}-GDS_SSO_OAUTH_SECRET":
+        varname => 'GDS_SSO_OAUTH_SECRET',
+        value   => $oauth_secret;
       "${title}-OAUTH_ID":
         varname => 'OAUTH_ID',
         value   => $oauth_id;

--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -366,6 +366,12 @@ class govuk::apps::whitehall(
       "${title}-KEY_SPACE_LIMIT":
         varname => 'KEY_SPACE_LIMIT',
         value   => $admin_key_space_limit;
+      "${title}-GDS_SSO_OAUTH_ID":
+        varname => 'GDS_SSO_OAUTH_ID',
+        value   => $oauth_id;
+      "${title}-GDS_SSO_OAUTH_SECRET":
+        varname => 'GDS_SSO_OAUTH_SECRET',
+        value   => $oauth_secret;
       "${title}-OAUTH_ID":
         varname => 'OAUTH_ID',
         value   => $oauth_id;


### PR DESCRIPTION
This change is made to allow the transition of GOV.UK apps from OAUTH_* env vars to GDS_SSO_OAUTH_* ones where their purpose is clearer. This adds duplicate ones prefixed with GDS_SSO_* so that apps can seamlessly transition to the prefixed equivalent. Once all apps are switched over I can then delete the ones without a prefix.

This PR also cleans up the env var setting for Authenticating Proxy and Search API, which were a bit unconventional. It's easier to review this commit by commit.

This is a precursor for: https://github.com/alphagov/gds-sso/pull/242