### PR TITLE
Don't replay traffic to /transition-check/login/callback

### DIFF
--- a/hieradata_aws/class/production/cache.yaml
+++ b/hieradata_aws/class/production/cache.yaml
@@ -8,5 +8,6 @@ router::gor::http_disallow_url:
   - 'apply-for-a-licence/payment'
   - 'apply-for-a-licence/redirect'
   - 'apply-for-a-licence/uploaded'
+  - 'transition-check/login/callback'
 govuk_safe_to_reboot::can_reboot: 'careful'
 govuk_safe_to_reboot::reason: 'Handles requests, traffic should be drained before restarting'

--- a/hieradata_aws/class/staging/cache.yaml
+++ b/hieradata_aws/class/staging/cache.yaml
@@ -8,3 +8,4 @@ router::gor::http_disallow_url:
   - 'apply-for-a-licence/payment'
   - 'apply-for-a-licence/redirect'
   - 'apply-for-a-licence/uploaded'
+  - 'transition-check/login/callback'


### PR DESCRIPTION
The account-manager redirects the user to this path, with some query
params, after logging in.  If the params are invalid, an error gets
thrown.

Replaying traffic to this endpoint is triggering a lot of spurious
errors, because production query params aren't valid in staging, not
staging query params valid in integration.

---

[Trello card](https://trello.com/c/JyYJTnxT/427-fix-staging-errors-caused-by-traffic-replay)
[Sentry error](https://sentry.io/organizations/govuk/issues/2006655453/?project=202224&query=is%3Aunresolved)