### PR TITLE
Update Slack plugin

### DIFF
--- a/hieradata_aws/class/jenkins.yaml
+++ b/hieradata_aws/class/jenkins.yaml
@@ -194,7 +194,7 @@ govuk_jenkins::plugins:
   simple-theme-plugin:
     version: '0.5.1'
   slack:
-    version: '2.20'
+    version: '2.23'
   ssh-credentials:
     version: '1.16'
   ssh-slaves:


### PR DESCRIPTION
This is the minimum version required to make use of the option that
notifies for *every* failure [1][2].

[1]: https://docs.openstack.org/infra/jenkins-job-builder/publishers.html#publishers.slack
[2]: https://github.com/alphagov/govuk-puppet/pull/10601/files#diff-08576b3b01ce0e49e5ed583cba9316d8ba0825c2632d983f13e34684c620b45cR98