### PR TITLE
Try alternative fix for Slack notifications

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_app_downstream.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_app_downstream.yaml.erb
@@ -92,7 +92,8 @@
             auth-token-id: <%= @slack_credential_id %>
             auth-token-credential-id: <%= @slack_credential_id %>
             build-server-url: <%= @slack_build_server_url %>
-            notify-every-failure: true
+            notify-failure: true
+            notify-repeated-failure: true
             room: "<%= @slack_channel %>"
             include-custom-message: true
             custom-message: "Automatic deployment failed for $TARGET_APPLICATION $TAG"


### PR DESCRIPTION
Previously we attempted to fix Slack notifications by upgrading the
Slack plugin [1], but for some reason the job builder still won't
generate the necessary config to make use of it. Since we can still
achieve the desired affect with the legacy config, this switches to
using that form, so we get notified about every failure.

[1]: 7b457741b