### PR TITLE
Upgrade Job Builder to support newer plugins

### DIFF
--- a/modules/govuk_jenkins/manifests/job_builder.pp
+++ b/modules/govuk_jenkins/manifests/job_builder.pp
@@ -47,7 +47,7 @@ class govuk_jenkins::job_builder (
 #  }
 
   package { 'jenkins-job-builder':
-    ensure   => '3.0.1',
+    ensure   => '3.6.0',
     provider => pip3,
   }
 


### PR DESCRIPTION
Previously we upgraded the Slack plugin to utilise a new config
feature [1], but the job builder also needs to be updated so that
we generate the new form of config for the plugin. The docs for
the builder aren't clear about what changes were made in each
release, so I'm specifying the latest one [2].

[1]: 21263c5a1
[2]: https://pypi.org/project/jenkins-job-builder/#history