### PR TITLE
Add Smart Answers Broken Links Report Jenkins job

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -459,6 +459,7 @@ task :check_consistency_between_aws_and_carrenza do
     govuk_jenkins::jobs::search_fetch_analytics_data::skip_page_traffic_load
     govuk_jenkins::jobs::search_relevancy_rank_evaluation::cron_schedule
     govuk_jenkins::jobs::search_relevancy_metrics_etl::cron_schedule
+    govuk_jenkins::jobs::smart_answers_broken_links_report::cron_schedule
     govuk_jenkins::jobs::smokey::environment
     govuk_mysql::server::expire_log_days
     govuk_mysql::server::slow_query_log

--- a/hieradata_aws/class/integration/jenkins.yaml
+++ b/hieradata_aws/class/integration/jenkins.yaml
@@ -39,6 +39,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::search_relevancy_metrics_etl
   - govuk_jenkins::jobs::send_bulk_email
   - govuk_jenkins::jobs::signon_cron_rake_tasks
+  - govuk_jenkins::jobs::smart_answers_broken_links_report
   - govuk_jenkins::jobs::smokey
   - govuk_jenkins::jobs::smokey_deploy
   - govuk_jenkins::jobs::update_cdn_dictionaries

--- a/hieradata_aws/class/production/jenkins.yaml
+++ b/hieradata_aws/class/production/jenkins.yaml
@@ -75,6 +75,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::search_relevancy_metrics_etl
   - govuk_jenkins::jobs::send_bulk_email
   - govuk_jenkins::jobs::signon_cron_rake_tasks
+  - govuk_jenkins::jobs::smart_answers_broken_links_report
   - govuk_jenkins::jobs::sync_assets_s3
   - govuk_jenkins::jobs::smokey
   - govuk_jenkins::jobs::smokey_deploy

--- a/hieradata_aws/class/staging/jenkins.yaml
+++ b/hieradata_aws/class/staging/jenkins.yaml
@@ -76,6 +76,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::search_relevancy_metrics_etl
   - govuk_jenkins::jobs::search_generate_sitemaps
   - govuk_jenkins::jobs::send_bulk_email
+  - govuk_jenkins::jobs::smart_answers_broken_links_report
   - govuk_jenkins::jobs::smokey
   - govuk_jenkins::jobs::smokey_deploy
   - govuk_jenkins::jobs::transition_load_site_config

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -304,6 +304,8 @@ govuk_jenkins::jobs::signon_cron_rake_tasks::rake_organisations_fetch_frequency:
 govuk_jenkins::jobs::signon_cron_rake_tasks::rake_users_suspend_inactive_frequency: '0 4 * * *'
 govuk_jenkins::jobs::signon_cron_rake_tasks::rake_users_send_suspension_reminders_frequency: '0 6 * * *'
 
+govuk_jenkins::jobs::smart_answers_broken_links_report::cron_schedule: '30 1 1,15 * *' # every 1st and 15th of the month at 1:30 AM
+
 govuk_jenkins::jobs::smokey::environment: production_aws
 
 govuk_jenkins::jobs::data_sync_complete_production::signon_domains_to_migrate:

--- a/modules/govuk_jenkins/manifests/jobs/smart_answers_broken_links_report.pp
+++ b/modules/govuk_jenkins/manifests/jobs/smart_answers_broken_links_report.pp
@@ -1,0 +1,34 @@
+# == Class: govuk_jenkins::jobs::smart_answers_broken_links_report
+#
+# A Jenkins job to periodically run smart_answers_broken_links_report.
+# This monitoring job sends the results of a rake task to graphite.
+#
+# === Parameters:
+#
+# [*cron_schedule *]
+#   The cron schedule to specify how often this task will run
+#   Default: undef
+#
+class govuk_jenkins::jobs::smart_answers_broken_links_report (
+  $cron_schedule = undef,
+  $app_domain = hiera('app_domain'),
+) {
+  $check_name = 'smart-answers-broken-links-report'
+  $service_description = 'Smart Answers Broken Links Report'
+  $job_url = "https://deploy.blue.${::aws_environment}.govuk.digital/job/smart_answers_broken_links_report/"
+
+  file { '/etc/jenkins_jobs/jobs/smart_answers_broken_links_report.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/smart_answers_broken_links_report.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+
+  if $cron_schedule {
+    @@icinga::passive_check { "${check_name}_${::hostname}":
+      service_description => $service_description,
+      host_name           => $::fqdn,
+      freshness_threshold => 86400,
+      action_url          => $job_url,
+    }
+  }
+}

--- a/modules/govuk_jenkins/templates/jobs/smart_answers_broken_links_report.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/smart_answers_broken_links_report.yaml.erb
@@ -1,0 +1,36 @@
+---
+- job:
+    name: smart_answers_broken_links_report
+    display-name: Smart Answers Broken Links Report
+    project-type: freestyle
+    description: "<p>Searches Smart Answer flows for broken links, by quering link checker api and sends a report to zendesk</p>"
+    builders:
+      - trigger-builds:
+          - project: run-rake-task
+            block: true
+            predefined-parameters: |
+              TARGET_APPLICATION=smartanswers
+              MACHINE_CLASS=calculators_frontend
+              RAKE_TASK=links:send_report[govuk-coronavirus-nsv@govuk.zendesk.com]
+    wrappers:
+      - ansicolor:
+          colormap: xterm
+  <% if @cron_schedule %>
+    triggers:
+      - timed: <%= @cron_schedule %>
+  <% end %>
+    logrotate:
+        numToKeep: 10
+    publishers:
+      - trigger-parameterized-builds:
+          - project: Success_Passive_Check
+            condition: 'SUCCESS'
+            predefined-parameters: |
+                NSCA_CHECK_DESCRIPTION=<%= @service_description %>
+                NSCA_OUTPUT=<%= @service_description %> success
+          - project: Failure_Passive_Check
+            condition: 'FAILED'
+            predefined-parameters: |
+                NSCA_CHECK_DESCRIPTION=<%= @service_description %>
+                NSCA_OUTPUT=<%= @service_description %> failed
+                NSCA_CODE=2


### PR DESCRIPTION
This is a scheduled jenkins job to run the broken links rake task in Smart Answers twice a month. This report is sent to Zendesk to make the content team aware of any broken links with in Smart Answers flows.