### PR TITLE
Add Zendesk credentials to Smart Answers

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -245,6 +245,7 @@ task :check_consistency_between_aws_and_carrenza do
     govuk::apps::smartanswers::nagios_memory_critical
     govuk::apps::smartanswers::nagios_memory_warning
     govuk::apps::smartanswers::unicorn_worker_processes
+    govuk::apps::smartanswers::zendesk_client_username
     govuk::apps::static::plek_account_manager_uri
     govuk::apps::static::ga_universal_id
     govuk::apps::static::nagios_memory_critical

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -800,6 +800,7 @@ govuk::apps::specialist_publisher::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::smartanswers::nagios_memory_warning: 4000
 govuk::apps::smartanswers::nagios_memory_critical: 4500
 govuk::apps::smartanswers::unicorn_worker_processes: "4"
+govuk::apps::smartanswers::zendesk_client_username: 'zd-api-govt@digital.cabinet-office.gov.uk/token'
 
 govuk::apps::smokey::http_username: "%{hiera('http_username')}"
 govuk::apps::smokey::http_password: "%{hiera('http_password')}"

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -220,6 +220,7 @@ govuk::apps::search_api::enable_learning_to_rank: true
 govuk::apps::service_manual_publisher::govuk_notify_template_id: "e00e89f5-b622-4dcb-8f30-e6c70231a940"
 govuk::apps::short_url_manager::govuk_notify_template_id: "e00e89f5-b622-4dcb-8f30-e6c70231a940"
 govuk::apps::short_url_manager::instance_name: 'production'
+govuk::apps::smartanswers::zendesk_client_username: 'zd-api-govt@digital.cabinet-office.gov.uk/token'
 govuk::apps::specialist_publisher::aws_region: 'eu-west-1'
 govuk::apps::specialist_publisher::aws_s3_bucket_name: 'govuk-production-specialist-publisher-csvs'
 govuk::apps::specialist_publisher::enabled: true

--- a/modules/govuk/manifests/apps/smartanswers.pp
+++ b/modules/govuk/manifests/apps/smartanswers.pp
@@ -45,6 +45,12 @@
 # [*unicorn_worker_processes*]
 #   The number of unicorn workers to run for an instance of this app
 #
+# [*zendesk_client_password*]
+#   Password for connection to GDS zendesk client.
+#
+# [*zendesk_client_username*]
+#   Username for connection to GDS zendesk client.
+#
 class govuk::apps::smartanswers(
   $vhost = 'smartanswers',
   $port,
@@ -57,6 +63,8 @@ class govuk::apps::smartanswers(
   $nagios_memory_critical = undef,
   $secret_key_base = undef,
   $unicorn_worker_processes = undef,
+  $zendesk_client_password = undef,
+  $zendesk_client_username = undef,
 ) {
   Govuk::App::Envvar {
     app => 'smartanswers',
@@ -88,6 +96,12 @@ class govuk::apps::smartanswers(
     "${title}-SECRET_KEY_BASE":
       varname => 'SECRET_KEY_BASE',
       value   => $secret_key_base;
+    "${title}-ZENDESK_CLIENT_PASSWORD":
+      varname => 'ZENDESK_CLIENT_PASSWORD',
+      value   => $zendesk_client_password;
+    "${title}-ZENDESK_CLIENT_USERNAME":
+      varname => 'ZENDESK_CLIENT_USERNAME',
+      value   => $zendesk_client_username;
   }
 
   govuk::app { 'smartanswers':


### PR DESCRIPTION
This adds two environment variables from Smart Answers to represent the Zendesk credentials They are need by the broken links rake task as it sends a report to Zendesk to be triaged by content support.