### PR TITLE
Fix broken provisioning for Jenkins

### DIFF
--- a/hieradata_aws/class/jenkins.yaml
+++ b/hieradata_aws/class/jenkins.yaml
@@ -50,6 +50,8 @@ govuk_jenkins::config::user_permissions:
       - 'hudson.model.Item.Build'
       - 'hudson.model.Item.Read'
 
+jenkins::params::default_plugins: []
+
 govuk_jenkins::plugins:
   ace-editor:
     version: '1.1'
@@ -85,6 +87,8 @@ govuk_jenkins::plugins:
     version: '1.3.6'
   copyartifact:
     version: '1.42.1'
+  credentials:
+    version: '2.1.19'
   credentials-binding:
     version: '1.18'
   cvs:


### PR DESCRIPTION
Previously we applied this same change for CI Jenkins [1].

[1]: https://github.com/alphagov/govuk-puppet/commit/31ff8bfab00bc1ad160e9ef29254943cb575557b#diff-b37901140d98466ceb6ea10b5a77a2b5a29ef97829d59c8f050fd24792490dceR78