### PR TITLE
Downgrade Jenkins Job Builder to 3.1.0

### DIFF
--- a/modules/govuk_jenkins/manifests/job_builder.pp
+++ b/modules/govuk_jenkins/manifests/job_builder.pp
@@ -47,7 +47,7 @@ class govuk_jenkins::job_builder (
 #  }
 
   package { 'jenkins-job-builder':
-    ensure   => '3.6.0',
+    ensure   => '3.1.0',
     provider => pip3,
   }
 


### PR DESCRIPTION
Previously we upgraded this in order to generate compatible config
for the new version of the Slack plugin [1]. However, experimenting
shows that builder versions above 3.1.0 hang on the CI Jenkins machine.

While the builder does run very slowly on CI Jenkins anyway, since
it seems to iterate over every single (branch) build, new versions
just hang and don't produce any console output, which indicates the
code is more fundamentally broken.

This downgrades future installs of the builder to 3.1.0, which
fortunately still supports the new config for the Slack plugin.

[1]: 874cf1212