### PR TITLE
Avoid re-queuing schedule jobs in Whitehall

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -344,7 +344,7 @@ grafana::dashboards::application_dashboards:
 mongodb::backup::mongo_backup_node: 'localhost'
 
 monitoring::checks::aws_origin_domain: "integration.govuk.digital"
-monitoring::checks::whitehall_overdue_check_period: 'inoffice'
+monitoring::checks::whitehall_overdue_check_period: 'never'
 monitoring::checks::sidekiq::enable_support_check: false
 monitoring::checks::rds::region: 'eu-west-1'
 monitoring::checks::aws_iam_key::enabled: true

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -359,7 +359,7 @@ licensify::apps::licensify::alert_5xx_warning_rate: 0.1
 licensify::apps::licensify::alert_5xx_critical_rate: 0.15
 
 monitoring::checks::aws_origin_domain: "staging.govuk.digital"
-monitoring::checks::whitehall_overdue_check_period: 'inoffice'
+monitoring::checks::whitehall_overdue_check_period: 'never'
 monitoring::checks::sidekiq::enable_signon_check: false
 monitoring::checks::sidekiq::enable_support_check: false
 monitoring::checks::rds::region: 'eu-west-1'

--- a/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
@@ -31,8 +31,6 @@
            ssh deploy@$(govuk_node_list -c backend --single-node) 'cd /var/apps/signon && OLD_DOMAIN=publishing.service.gov.uk NEW_DOMAIN=integration.publishing.service.gov.uk govuk_setenv signon bundle exec rake applications:migrate_domain'
            ssh deploy@$(govuk_node_list -c backend --single-node) 'cd /var/apps/signon && OLD_DOMAIN=performance.service.gov.uk NEW_DOMAIN=integration.performance.service.gov.uk govuk_setenv signon bundle exec rake applications:migrate_domain'
            ssh deploy@$(govuk_node_list -c backend --single-node) 'cd /var/apps/signon && OLD_DOMAIN=-production.cloudapps.digital NEW_DOMAIN=-integration.cloudapps.digital govuk_setenv signon bundle exec rake applications:migrate_domain'
-           # Queue up any whitehall scheduled editions that have been transferred across.
-           ssh deploy@$(govuk_node_list -c whitehall_backend --single-node) 'cd /var/apps/whitehall ; govuk_setenv whitehall bundle exec rake publishing:scheduled:requeue_all_jobs'
            # Queue up any publisher scheduled editions that have been transferred across.
            ssh deploy@$(govuk_node_list -c backend --single-node) 'cd /var/apps/publisher ; govuk_setenv publisher bundle exec rake editions:requeue_scheduled_for_publishing'
     publishers:

--- a/modules/govuk_jenkins/templates/jobs/data_sync_complete_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/data_sync_complete_staging.yaml.erb
@@ -28,9 +28,6 @@
            <%- end -%>
            <%- end -%>
            <%- if @aws -%>
-           # Queue up any whitehall scheduled editions that have been transferred across.
-           ssh deploy@$(govuk_node_list -c whitehall_backend --single-node) 'cd /var/apps/whitehall ; govuk_setenv whitehall bundle exec rake publishing:scheduled:requeue_all_jobs'
-
            # Queue up any publisher scheduled editions that have been transferred across.
            ssh deploy@$(govuk_node_list -c backend --single-node) 'cd /var/apps/publisher ; govuk_setenv publisher bundle exec rake editions:requeue_scheduled_for_publishing'
            <%- end -%>


### PR DESCRIPTION
Jobs that are scheduled on Production get synced overnight to
Staging. The code deleted in this commit would queue up the
schedule workers for all of the scheduled editions in Whitehall.

For editions scheduled for publishing on a date past the day
of the data sync, this was pointless - the workers would be
continually removed and re-queued every day until the publish
happens.

For editions scheduled for publishing on the day of the data sync,
we regularly see issues to do with the redaction process in
govuk_env_sync. If the edition is access limited, its attachments
get [renamed to 'redacted.pdf'](https://github.com/alphagov/govuk-puppet/blob/9f78205dfd9f09fd9396b5d97b4e487844262219/modules/govuk_env_sync/files/govuk_env_sync.sh#L654)
and then at time of publishing Whitehall intercepts lots of
'Asset not found' errors from Asset Manager, as it can no longer
find the asset by its `legacy_url_path`. Consequently, the
edition would be published on Staging but all of its assets
would be unavailable (404 response).

I did consider that we could edit Whitehall's
[`requeue_all_jobs` Rake task](https://github.com/alphagov/whitehall/blob/7157de36d5bda3c634be7fc0b410244e1e655d5d/lib/tasks/scheduled_publishing.rake#L73-L88)
to only re-queue the scheduling of editions which are not
access-limited. However then we're in a confusing situation where
sometimes production-scheduled editions get published on Staging
and sometimes they don't.

Removing this re-queuing code doesn't break _manual_ scheduling
on Staging; if a developer needs to test out scheduling an edition,
they can do so and it will still work. The only impact of this
change is that documents scheduled on Production don't get
published on their schedule date on Staging. This is only a
temporary situation for the edition too as it would fix itself
at the next data sync.

Finally, the code for this re-queuing was
[added in 2015](https://github.com/alphagov/govuk-puppet/blame/63f7b63dca7fd34e322f47ed593993678d7080b6/modules/govuk_jenkins/templates/jobs/staging/data_sync_complete.yaml.erb)
with little explanation as to its benefit. It's quite possible
there is no real 'user need' for this feature.

Trello: https://trello.com/c/RethzUSW/2088-5-fix-assetmanagerservicehelperassetnotfound-errors-on-staging-integration