### PR TITLE
Enable CD for authenticating-proxy

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1146,6 +1146,7 @@ govuk_jenkins::jobs::run_rake_task::applications: *deployable_applications
 govuk_jenkins::jobs::deploy_app::applications: *deployable_applications
 
 govuk_jenkins::jobs::deploy_app_downstream::applications:
+  authenticating-proxy: {}
   finder-frontend: {}
   government-frontend: {}
   info-frontend: {}


### PR DESCRIPTION
I believe the [appropriate criteria](https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#safety-checks) have been met since deploying https://github.com/alphagov/authenticating-proxy/pull/238 and https://github.com/alphagov/smokey/pull/740.