### PR TITLE
Add authenticated Docker registry for AWS Staging and Prod

### DIFF
--- a/modules/govuk_docker/manifests/init.pp
+++ b/modules/govuk_docker/manifests/init.pp
@@ -36,7 +36,7 @@ class govuk_docker (
     manage_kernel               => false,
   }
 
-  if $::aws_environment == 'integration'{
+  if (($::aws_environment == 'integration') or ($::aws_environment == 'staging') or ($::aws_environment == 'production')) {
     include ::docker::registry_auth
   }
 


### PR DESCRIPTION
We enableid authenticated puppet docker registry for the AWS Integration
environment. This is to mitigated against the new Docker limits on
docker pulls for anonymous/unpaid accounts.  This has been successful
and will now be deployed to staging and production environments.

Tested by:
1. creating a private repo on docker hub and trying with puppet having installed this PR.

Ref:
1. [Trello Card](https://trello.com/c/M3zyF5kM/3898-identify-govuk-components-and-jenkins-jobs-which-pull-images-from-docker-hub-investigate-an-option-to-enable-authentication-for)