### PR TITLE
Disable Sentry for Search API in test environment.

### DIFF
--- a/hieradata_aws/test.yaml
+++ b/hieradata_aws/test.yaml
@@ -1,0 +1,6 @@
+---
+# Disable Sentry in test env for Search API; see
+# https://trello.com/c/X1iGVbmo/269-stop-sending-so-many-errors-to-sentry
+# TODO: consider removing once the version of Search API deployed in test is
+# using govuk_app_config >= 2.6.0
+govuk::apps::search_api::sentry_dsn: ''


### PR DESCRIPTION
Search API in the test environment has been spamming Sentry and this has been inconveniencing developers. For example it's been continuously [sending about 6 Faraday::TimeoutError per hour](https://sentry.io/organizations/govuk/issues/1711334233/?environment=test-pink-aws).

Ideally we would just deploy the latest version of Search API into the test environment and it'd pick up the client-side environment filtering which went into version 2.6.0 of the govuk_app_config gem, but the Deploy_App Jenkins job is broken for Search API in the test environment because of a Ruby version issue (the job fails with `rbenv: version `2.7.2' is not installed`).

This assumes that setting the `SENTRY_DSN` environment variable to the empty string results in disabling the Sentry client without preventing the app from starting. Even if that's not the case and it breaks Search API in the test environment, that's not really a problem as we're not using it.

[Trello card](https://trello.com/c/X1iGVbmo/269-stop-sending-so-many-errors-to-sentry)

Tested: not tested, as it's probably quicker to just optimistically try it out unless someone spots a reason why this definitely won't work. The objective is just to stop the error spew with minimum effort.