### PR TITLE
Remove unprefixed OAuth environment variables

### DIFF
--- a/docs/adding-a-new-app.md
+++ b/docs/adding-a-new-app.md
@@ -23,10 +23,10 @@ Create a new file in `modules/govuk/manifests/apps` named `my_app.pp`:
 #   The app-specific URL used by Sentry to report exceptions (in govuk-secrets)
 #
 # [*oauth_id*]
-#   The OAuth ID used to identify the app to GOV.UK Signon (in govuk-secrets)
+#   The OAuth ID used by GDS-SSO to identify the app to GOV.UK Signon (in govuk-secrets)
 #
 # [*oauth_secret*]
-#   The OAuth secret used to authenticate the app to GOV.UK Signon (in govuk-secrets)
+#   The OAuth secret used by GDS-SSO to authenticate the app to GOV.UK Signon (in govuk-secrets)
 #
 # [*db_hostname*]
 #   The hostname of the database server to use for in DATABASE_URL environment variable

--- a/docs/adding-a-new-app.md
+++ b/docs/adding-a-new-app.md
@@ -17,16 +17,16 @@ Create a new file in `modules/govuk/manifests/apps` named `my_app.pp`:
 #   Whether to install or uninstall the app. Defaults to true (install on all enviroments)
 #
 # [*secret_key_base*]
-#   The key for Rails to use when signing/encrypting sessions (in govuk-secrets)
+#   The key for Rails to use when signing/encrypting sessions
 #
 # [*sentry_dsn*]
-#   The app-specific URL used by Sentry to report exceptions (in govuk-secrets)
+#   The app-specific URL used by Sentry to report exceptions
 #
 # [*oauth_id*]
-#   The OAuth ID used by GDS-SSO to identify the app to GOV.UK Signon (in govuk-secrets)
+#   The OAuth ID used by GDS-SSO to identify the app to GOV.UK Signon
 #
 # [*oauth_secret*]
-#   The OAuth secret used by GDS-SSO to authenticate the app to GOV.UK Signon (in govuk-secrets)
+#   The OAuth secret used by GDS-SSO to authenticate the app to GOV.UK Signon
 #
 # [*db_hostname*]
 #   The hostname of the database server to use for in DATABASE_URL environment variable

--- a/docs/adding-a-new-app.md
+++ b/docs/adding-a-new-app.md
@@ -97,12 +97,6 @@ class govuk::apps::myapp (
     "${title}-GDS_SSO_OAUTH_SECRET":
       varname        => 'GDS_SSO_OAUTH_SECRET',
       value          => $oauth_secret;
-    "${title}-OAUTH_ID":
-      varname        => 'OAUTH_ID',
-      value          => $oauth_id;
-    "${title}-OAUTH_SECRET":
-      varname        => 'OAUTH_SECRET',
-      value          => $oauth_secret;
   }
 
   govuk::app::envvar::database_url { $app_name:

--- a/modules/govuk/manifests/apps/asset_manager.pp
+++ b/modules/govuk/manifests/apps/asset_manager.pp
@@ -16,9 +16,9 @@
 #   The URL used by Sentry to report exceptions
 #
 # [*oauth_id*]
-#   Sets the OAuth ID
+#   The OAuth ID used by GDS-SSO to identify the app to GOV.UK Signon
 # [*oauth_secret*]
-#   Sets the OAuth Secret Key
+#   The OAuth secret used by GDS-SSO to authenticate the app to GOV.UK Signon
 # [*secret_key_base*]
 #   The key for Rails to use when signing/encrypting sessions.
 # [*jwt_auth_secret*]

--- a/modules/govuk/manifests/apps/asset_manager.pp
+++ b/modules/govuk/manifests/apps/asset_manager.pp
@@ -120,12 +120,6 @@ class govuk::apps::asset_manager(
       "${title}-GDS_SSO_OAUTH_SECRET":
         varname => 'GDS_SSO_OAUTH_SECRET',
         value   => $oauth_secret;
-      "${title}-OAUTH_ID":
-        varname => 'OAUTH_ID',
-        value   => $oauth_id;
-      "${title}-OAUTH_SECRET":
-        varname => 'OAUTH_SECRET',
-        value   => $oauth_secret;
     }
 
     govuk::app::envvar::redis { $app_name:

--- a/modules/govuk/manifests/apps/authenticating_proxy.pp
+++ b/modules/govuk/manifests/apps/authenticating_proxy.pp
@@ -23,10 +23,10 @@
 #   Default: undef
 #
 # [*oauth_id*]
-#   Sets the OAuth ID
+#   The OAuth ID used by GDS-SSO to identify the app to GOV.UK Signon
 #
 # [*oauth_secret*]
-#   Sets the OAuth Secret Key
+#   The OAuth secret used by GDS-SSO to authenticate the app to GOV.UK Signon
 #
 # [*secret_key_base*]
 #   Used to set the app ENV var SECRET_KEY_BASE which is used to configure

--- a/modules/govuk/manifests/apps/authenticating_proxy.pp
+++ b/modules/govuk/manifests/apps/authenticating_proxy.pp
@@ -89,12 +89,6 @@ class govuk::apps::authenticating_proxy(
     "${title}-GDS_SSO_OAUTH_SECRET":
       varname => 'GDS_SSO_OAUTH_SECRET',
       value   => $oauth_secret;
-    "${title}-OAUTH_ID":
-      varname => 'OAUTH_ID',
-      value   => $oauth_id;
-    "${title}-OAUTH_SECRET":
-      varname => 'OAUTH_SECRET',
-      value   => $oauth_secret;
     "${title}-SECRET_KEY_BASE":
       varname => 'SECRET_KEY_BASE',
       value   => $secret_key_base;

--- a/modules/govuk/manifests/apps/ckan.pp
+++ b/modules/govuk/manifests/apps/ckan.pp
@@ -59,7 +59,7 @@
 #   Default: undef
 #
 # [*sentry_dsn*]
-#   The app-specific URL used by Sentry to report exceptions (in govuk-secrets)
+#   The app-specific URL used by Sentry to report exceptions
 #
 class govuk::apps::ckan (
   $enabled                        = false,

--- a/modules/govuk/manifests/apps/collections_publisher.pp
+++ b/modules/govuk/manifests/apps/collections_publisher.pp
@@ -17,12 +17,11 @@
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
-#
 # [*oauth_id*]
-#   Sets the OAuth ID used by gds-sso
+#   The OAuth ID used by GDS-SSO to identify the app to GOV.UK Signon
 #
 # [*oauth_secret*]
-#   Sets the OAuth Secret Key used by gds-sso
+#   The OAuth secret used by GDS-SSO to authenticate the app to GOV.UK Signon
 #
 # [*enable_procfile_worker*]
 #   Whether to enable the procfile worker

--- a/modules/govuk/manifests/apps/collections_publisher.pp
+++ b/modules/govuk/manifests/apps/collections_publisher.pp
@@ -136,8 +136,8 @@ class govuk::apps::collections_publisher(
         varname => 'GDS_SSO_OAUTH_SECRET',
         value   => $oauth_secret;
       "${title}-LINK_CHECKER_API_BEARER_TOKEN":
-          varname => 'LINK_CHECKER_API_BEARER_TOKEN',
-          value   => $link_checker_api_bearer_token;
+        varname => 'LINK_CHECKER_API_BEARER_TOKEN',
+        value   => $link_checker_api_bearer_token;
       "${title}-PUBLISHING_API_BEARER_TOKEN":
         varname => 'PUBLISHING_API_BEARER_TOKEN',
         value   => $publishing_api_bearer_token;

--- a/modules/govuk/manifests/apps/collections_publisher.pp
+++ b/modules/govuk/manifests/apps/collections_publisher.pp
@@ -135,12 +135,6 @@ class govuk::apps::collections_publisher(
       "${title}-GDS_SSO_OAUTH_SECRET":
         varname => 'GDS_SSO_OAUTH_SECRET',
         value   => $oauth_secret;
-      "${title}-OAUTH_ID":
-        varname => 'OAUTH_ID',
-        value   => $oauth_id;
-      "${title}-OAUTH_SECRET":
-        varname => 'OAUTH_SECRET',
-        value   => $oauth_secret;
       "${title}-LINK_CHECKER_API_BEARER_TOKEN":
           varname => 'LINK_CHECKER_API_BEARER_TOKEN',
           value   => $link_checker_api_bearer_token;

--- a/modules/govuk/manifests/apps/contacts.pp
+++ b/modules/govuk/manifests/apps/contacts.pp
@@ -22,11 +22,11 @@
 #   Default: contacts-admin
 #
 # [*oauth_id*]
-#   Sets the OAuth ID for using GDS-SSO
+#   The OAuth ID used by GDS-SSO to identify the app to GOV.UK Signon
 #   Default: undef
 #
 # [*oauth_secret*]
-#   Sets the OAuth Secret Key for using GDS-SSO
+#   The OAuth secret used by GDS-SSO to authenticate the app to GOV.UK Signon
 #   Default: undef
 #
 # [*port*]

--- a/modules/govuk/manifests/apps/contacts.pp
+++ b/modules/govuk/manifests/apps/contacts.pp
@@ -139,12 +139,6 @@ class govuk::apps::contacts(
       "${title}-GDS_SSO_OAUTH_SECRET":
         varname => 'GDS_SSO_OAUTH_SECRET',
         value   => $oauth_secret;
-      "${title}-OAUTH_ID":
-        varname => 'OAUTH_ID',
-        value   => $oauth_id;
-      "${title}-OAUTH_SECRET":
-        varname => 'OAUTH_SECRET',
-        value   => $oauth_secret;
       "${title}-SECRET_KEY_BASE":
         varname => 'SECRET_KEY_BASE',
         value   => $secret_key_base;

--- a/modules/govuk/manifests/apps/content_data_admin.pp
+++ b/modules/govuk/manifests/apps/content_data_admin.pp
@@ -10,10 +10,10 @@
 #   Whether to install or uninstall the app. Defaults to true (install on all enviroments)
 #
 # [*secret_key_base*]
-#   The key for Rails to use when signing/encrypting sessions (in govuk-secrets)
+#   The key for Rails to use when signing/encrypting sessions
 #
 # [*sentry_dsn*]
-#   The app-specific URL used by Sentry to report exceptions (in govuk-secrets)
+#   The app-specific URL used by Sentry to report exceptions
 #
 # [*oauth_id*]
 #   The OAuth ID used by GDS-SSO to identify the app to GOV.UK Signon

--- a/modules/govuk/manifests/apps/content_data_admin.pp
+++ b/modules/govuk/manifests/apps/content_data_admin.pp
@@ -16,10 +16,10 @@
 #   The app-specific URL used by Sentry to report exceptions (in govuk-secrets)
 #
 # [*oauth_id*]
-#   The OAuth ID used to identify the app to GOV.UK Signon (in govuk-secrets)
+#   The OAuth ID used by GDS-SSO to identify the app to GOV.UK Signon
 #
 # [*oauth_secret*]
-#   The OAuth secret used to authenticate the app to GOV.UK Signon (in govuk-secrets)
+#   The OAuth secret used by GDS-SSO to authenticate the app to GOV.UK Signon
 #
 # [*db_hostname*]
 #   The hostname of the database server to use for in DATABASE_URL environment variable

--- a/modules/govuk/manifests/apps/content_data_admin.pp
+++ b/modules/govuk/manifests/apps/content_data_admin.pp
@@ -156,12 +156,6 @@ class govuk::apps::content_data_admin (
     "${title}-GDS_SSO_OAUTH_SECRET":
       varname => 'GDS_SSO_OAUTH_SECRET',
       value   => $oauth_secret;
-    "${title}-OAUTH_ID":
-      varname => 'OAUTH_ID',
-      value   => $oauth_id;
-    "${title}-OAUTH_SECRET":
-      varname => 'OAUTH_SECRET',
-      value   => $oauth_secret;
     "${title}-CONTENT_DATA_API_BEARER_TOKEN":
       varname => 'CONTENT_DATA_API_BEARER_TOKEN',
       value   => $content_data_api_bearer_token;

--- a/modules/govuk/manifests/apps/content_data_api.pp
+++ b/modules/govuk/manifests/apps/content_data_api.pp
@@ -181,12 +181,6 @@ class govuk::apps::content_data_api(
     "${title}-GDS_SSO_OAUTH_SECRET":
       varname => 'GDS_SSO_OAUTH_SECRET',
       value   => $oauth_secret;
-    "${title}-OAUTH_ID":
-      varname => 'OAUTH_ID',
-      value   => $oauth_id;
-    "${title}-OAUTH_SECRET":
-      varname => 'OAUTH_SECRET',
-      value   => $oauth_secret;
     "${title}-PUBLISHING_API_BEARER_TOKEN":
       varname => 'PUBLISHING_API_BEARER_TOKEN',
       value   => $publishing_api_bearer_token;

--- a/modules/govuk/manifests/apps/content_data_api.pp
+++ b/modules/govuk/manifests/apps/content_data_api.pp
@@ -39,11 +39,11 @@
 #   Default: undef
 #
 # [*oauth_id*]
-#   Sets the OAuth ID for using GDS-SSO
+#   The OAuth ID used by GDS-SSO to identify the app to GOV.UK Signon
 #   Default: undef
 #
 # [*oauth_secret*]
-#   Sets the OAuth Secret Key for using GDS-SSO
+#   The OAuth secret used by GDS-SSO to authenticate the app to GOV.UK Signon
 #   Default: undef
 #
 # [*port*]

--- a/modules/govuk/manifests/apps/content_publisher.pp
+++ b/modules/govuk/manifests/apps/content_publisher.pp
@@ -169,12 +169,6 @@ class govuk::apps::content_publisher (
     "${title}-GDS_SSO_OAUTH_SECRET":
       varname => 'GDS_SSO_OAUTH_SECRET',
       value   => $oauth_secret;
-    "${title}-OAUTH_ID":
-      varname => 'OAUTH_ID',
-      value   => $oauth_id;
-    "${title}-OAUTH_SECRET":
-      varname => 'OAUTH_SECRET',
-      value   => $oauth_secret;
     "${title}-PUBLISHING_API_BEARER_TOKEN":
       varname => 'PUBLISHING_API_BEARER_TOKEN',
       value   => $publishing_api_bearer_token;

--- a/modules/govuk/manifests/apps/content_publisher.pp
+++ b/modules/govuk/manifests/apps/content_publisher.pp
@@ -10,10 +10,10 @@
 #   Whether to install the app. Don't change the default (false) until production-ready
 #
 # [*secret_key_base*]
-#   The key for Rails to use when signing/encrypting sessions (in govuk-secrets)
+#   The key for Rails to use when signing/encrypting sessions
 #
 # [*sentry_dsn*]
-#   The app-specific URL used by Sentry to report exceptions (in govuk-secrets)
+#   The app-specific URL used by Sentry to report exceptions
 #
 # [*oauth_id*]
 #   The OAuth ID used by GDS-SSO to identify the app to GOV.UK Signon

--- a/modules/govuk/manifests/apps/content_publisher.pp
+++ b/modules/govuk/manifests/apps/content_publisher.pp
@@ -16,10 +16,10 @@
 #   The app-specific URL used by Sentry to report exceptions (in govuk-secrets)
 #
 # [*oauth_id*]
-#   The OAuth ID used to identify the app to GOV.UK Signon (in govuk-secrets)
+#   The OAuth ID used by GDS-SSO to identify the app to GOV.UK Signon
 #
 # [*oauth_secret*]
-#   The OAuth secret used to authenticate the app to GOV.UK Signon (in govuk-secrets)
+#   The OAuth secret used by GDS-SSO to authenticate the app to GOV.UK Signon
 #
 # [*db_hostname*]
 #   The hostname of the database server to use for in DATABASE_URL environment variable

--- a/modules/govuk/manifests/apps/content_store.pp
+++ b/modules/govuk/manifests/apps/content_store.pp
@@ -49,10 +49,10 @@
 #   The number of unicorn workers to run for an instance of this app
 #
 # [*oauth_id*]
-#   The OAuth ID used to identify the app to GOV.UK Signon (in govuk-secrets)
+#   The OAuth ID used by GDS-SSO to identify the app to GOV.UK Signon
 #
 # [*oauth_secret*]
-#   The OAuth secret used to authenticate the app to GOV.UK Signon (in govuk-secrets)
+#   The OAuth secret used by GDS-SSO to authenticate the app to GOV.UK Signon
 #
 # [*router_api_bearer_token*]
 #   The bearer token that will be used to authenticate with the router api

--- a/modules/govuk/manifests/apps/content_store.pp
+++ b/modules/govuk/manifests/apps/content_store.pp
@@ -134,12 +134,6 @@ class govuk::apps::content_store(
     "${title}-GDS_SSO_OAUTH_SECRET":
       varname => 'GDS_SSO_OAUTH_SECRET',
       value   => $oauth_secret;
-    "${title}-OAUTH_ID":
-      varname => 'OAUTH_ID',
-      value   => $oauth_id;
-    "${title}-OAUTH_SECRET":
-      varname => 'OAUTH_SECRET',
-      value   => $oauth_secret;
     "${title}-PUBLISHING_API_BEARER_TOKEN":
       varname => 'PUBLISHING_API_BEARER_TOKEN',
       value   => $publishing_api_bearer_token;

--- a/modules/govuk/manifests/apps/content_tagger.pp
+++ b/modules/govuk/manifests/apps/content_tagger.pp
@@ -17,7 +17,6 @@
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
-#
 # [*db_hostname*]
 #   The hostname of the database server to use in the DATABASE_URL.
 #
@@ -39,10 +38,10 @@
 #   The database name to use in the DATABASE_URL.
 #
 # [*oauth_id*]
-#   Sets the OAuth ID
+#   The OAuth ID used by GDS-SSO to identify the app to GOV.UK Signon
 #
 # [*oauth_secret*]
-#   Sets the OAuth Secret Key
+#   The OAuth secret used by GDS-SSO to authenticate the app to GOV.UK Signon
 #
 # [*email_alert_api_bearer_token*]
 #   The bearer token to use when communicating with the email-alert-api.

--- a/modules/govuk/manifests/apps/content_tagger.pp
+++ b/modules/govuk/manifests/apps/content_tagger.pp
@@ -131,12 +131,6 @@ class govuk::apps::content_tagger(
       "${title}-GDS_SSO_OAUTH_SECRET":
         varname => 'GDS_SSO_OAUTH_SECRET',
         value   => $oauth_secret;
-      "${title}-OAUTH_ID":
-        varname => 'OAUTH_ID',
-        value   => $oauth_id;
-      "${title}-OAUTH_SECRET":
-        varname => 'OAUTH_SECRET',
-        value   => $oauth_secret;
       "${title}-EMAIL_ALERT_API_BEARER_TOKEN":
         varname => 'EMAIL_ALERT_API_BEARER_TOKEN',
         value   => $email_alert_api_bearer_token;

--- a/modules/govuk/manifests/apps/email_alert_api.pp
+++ b/modules/govuk/manifests/apps/email_alert_api.pp
@@ -45,10 +45,10 @@
 #   The key for Rails to use when signing/encrypting sessions.
 #
 # [*oauth_id*]
-#   Sets the OAuth ID
+#   The OAuth ID used by GDS-SSO to identify the app to GOV.UK Signon
 #
 # [*oauth_secret*]
-#   Sets the OAuth Secret Key
+#   The OAuth secret used by GDS-SSO to authenticate the app to GOV.UK Signon
 #
 # [*email_alert_auth_token*]
 #   Sets the secret token used for encrypting and decrypting messages shared

--- a/modules/govuk/manifests/apps/email_alert_api.pp
+++ b/modules/govuk/manifests/apps/email_alert_api.pp
@@ -231,12 +231,6 @@ class govuk::apps::email_alert_api(
     "${title}-GDS_SSO_OAUTH_SECRET":
         varname => 'GDS_SSO_OAUTH_SECRET',
         value   => $oauth_secret;
-    "${title}-OAUTH_ID":
-        varname => 'OAUTH_ID',
-        value   => $oauth_id;
-    "${title}-OAUTH_SECRET":
-        varname => 'OAUTH_SECRET',
-        value   => $oauth_secret;
     "${title}-EMAIL_ALERT_AUTH_TOKEN":
         varname => 'EMAIL_ALERT_AUTH_TOKEN',
         value   => $email_alert_auth_token;

--- a/modules/govuk/manifests/apps/hmrc_manuals_api.pp
+++ b/modules/govuk/manifests/apps/hmrc_manuals_api.pp
@@ -92,12 +92,6 @@ class govuk::apps::hmrc_manuals_api(
       "${title}-GDS_SSO_OAUTH_SECRET":
         varname => 'GDS_SSO_OAUTH_SECRET',
         value   => $oauth_secret;
-      "${title}-OAUTH_ID":
-        varname => 'OAUTH_ID',
-        value   => $oauth_id;
-      "${title}-OAUTH_SECRET":
-        varname => 'OAUTH_SECRET',
-        value   => $oauth_secret;
       "${title}-PUBLISHING_API_BEARER_TOKEN":
         varname => 'PUBLISHING_API_BEARER_TOKEN',
         value   => $publishing_api_bearer_token,

--- a/modules/govuk/manifests/apps/hmrc_manuals_api.pp
+++ b/modules/govuk/manifests/apps/hmrc_manuals_api.pp
@@ -20,11 +20,11 @@
 #   The URL used by Sentry to report exceptions
 #
 # [*oauth_id*]
-#   Sets the OAuth ID for using GDS-SSO
+#   The OAuth ID used by GDS-SSO to identify the app to GOV.UK Signon
 #   Default: undef
 #
 # [*oauth_secret*]
-#   Sets the OAuth Secret Key for using GDS-SSO
+#   The OAuth secret used by GDS-SSO to authenticate the app to GOV.UK Signon
 #   Default: undef
 #
 # [*publish_topics*]

--- a/modules/govuk/manifests/apps/imminence.pp
+++ b/modules/govuk/manifests/apps/imminence.pp
@@ -98,12 +98,6 @@ class govuk::apps::imminence(
     "${title}-GDS_SSO_OAUTH_SECRET":
       varname => 'GDS_SSO_OAUTH_SECRET',
       value   => $oauth_secret;
-    "${title}-OAUTH_ID":
-      varname => 'OAUTH_ID',
-      value   => $oauth_id;
-    "${title}-OAUTH_SECRET":
-      varname => 'OAUTH_SECRET',
-      value   => $oauth_secret;
   }
 
   govuk::app::envvar::redis { $app_name:

--- a/modules/govuk/manifests/apps/imminence.pp
+++ b/modules/govuk/manifests/apps/imminence.pp
@@ -27,10 +27,10 @@
 #   The name of the MongoDB database to use
 #
 # [*oauth_id*]
-#   Sets the OAuth ID
+#   The OAuth ID used by GDS-SSO to identify the app to GOV.UK Signon
 #
 # [*oauth_secret*]
-#   Sets the OAuth Secret Key
+#   The OAuth secret used by GDS-SSO to authenticate the app to GOV.UK Signon
 #
 # [*redis_host*]
 #   Redis host for Sidekiq.

--- a/modules/govuk/manifests/apps/link_checker_api.pp
+++ b/modules/govuk/manifests/apps/link_checker_api.pp
@@ -44,11 +44,10 @@
 #   Default: undef
 #
 # [*oauth_id*]
-# The Oauth ID used to identify the app to GOV.UK Signon (in govuk-secrets)
+#   The OAuth ID used by GDS-SSO to identify the app to GOV.UK Signon
 #
 # [*oauth_secret*]
-# The Oauth secret used to authenticate the app to GOV.UK Signon (in govuk-secrets)
-#
+#   The OAuth secret used by GDS-SSO to authenticate the app to GOV.UK Signon
 #
 # [*port*]
 #   The port that it is served on.

--- a/modules/govuk/manifests/apps/link_checker_api.pp
+++ b/modules/govuk/manifests/apps/link_checker_api.pp
@@ -121,12 +121,6 @@ class govuk::apps::link_checker_api (
     "${title}-GDS_SSO_OAUTH_SECRET":
       varname => 'GDS_SSO_OAUTH_SECRET',
       value   => $oauth_secret;
-    "${title}-OAUTH_ID":
-      varname => 'OAUTH_ID',
-      value   => $oauth_id;
-    "${title}-OAUTH_SECRET":
-      varname => 'OAUTH_SECRET',
-      value   => $oauth_secret;
   }
 
   govuk::procfile::worker { $app_name:

--- a/modules/govuk/manifests/apps/local_links_manager.pp
+++ b/modules/govuk/manifests/apps/local_links_manager.pp
@@ -42,11 +42,11 @@
 #   The database name to use in the DATABASE_URL.
 #
 # [*oauth_id*]
-#   Sets the OAuth ID for using GDS-SSO
+#   The OAuth ID used by GDS-SSO to identify the app to GOV.UK Signon
 #   Default: undef
 #
 # [*oauth_secret*]
-#   Sets the OAuth Secret Key for using GDS-SSO
+#   The OAuth secret used by GDS-SSO to authenticate the app to GOV.UK Signon
 #   Default: undef
 #
 # [*redis_host*]

--- a/modules/govuk/manifests/apps/local_links_manager.pp
+++ b/modules/govuk/manifests/apps/local_links_manager.pp
@@ -187,12 +187,6 @@ class govuk::apps::local_links_manager(
     "${title}-GDS_SSO_OAUTH_SECRET":
       varname => 'GDS_SSO_OAUTH_SECRET',
       value   => $oauth_secret;
-    "${title}-OAUTH_ID":
-      varname => 'OAUTH_ID',
-      value   => $oauth_id;
-    "${title}-OAUTH_SECRET":
-      varname => 'OAUTH_SECRET',
-      value   => $oauth_secret;
     "${title}-PUBLISHING_API_BEARER_TOKEN":
       varname => 'PUBLISHING_API_BEARER_TOKEN',
       value   => $publishing_api_bearer_token;

--- a/modules/govuk/manifests/apps/manuals_publisher.pp
+++ b/modules/govuk/manifests/apps/manuals_publisher.pp
@@ -150,12 +150,6 @@ class govuk::apps::manuals_publisher(
       "${title}-GDS_SSO_OAUTH_SECRET":
         varname => 'GDS_SSO_OAUTH_SECRET',
         value   => $oauth_secret;
-      "${title}-OAUTH_ID":
-        varname => 'OAUTH_ID',
-        value   => $oauth_id;
-      "${title}-OAUTH_SECRET":
-        varname => 'OAUTH_SECRET',
-        value   => $oauth_secret;
       "${title}-PUBLISHING_API_BEARER_TOKEN":
         varname => 'PUBLISHING_API_BEARER_TOKEN',
         value   => $publishing_api_bearer_token;

--- a/modules/govuk/manifests/apps/manuals_publisher.pp
+++ b/modules/govuk/manifests/apps/manuals_publisher.pp
@@ -41,11 +41,11 @@
 #   only needed if the app uses documentdb rather than mongodb
 #
 # [*oauth_id*]
-#   Sets the OAuth ID for using GDS-SSO
+#   The OAuth ID used by GDS-SSO to identify the app to GOV.UK Signon
 #   Default: undef
 #
 # [*oauth_secret*]
-#   Sets the OAuth Secret Key for using GDS-SSO
+#   The OAuth secret used by GDS-SSO to authenticate the app to GOV.UK Signon
 #   Default: undef
 #
 # [*publishing_api_bearer_token*]

--- a/modules/govuk/manifests/apps/maslow.pp
+++ b/modules/govuk/manifests/apps/maslow.pp
@@ -33,12 +33,11 @@
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
-#
 # [*oauth_id*]
-#   The application's OAuth ID from Signon
+#   The OAuth ID used by GDS-SSO to identify the app to GOV.UK Signon#
 #
 # [*oauth_secret*]
-#   The application's OAuth Secret from Signon
+#   The OAuth secret used by GDS-SSO to authenticate the app to GOV.UK Signon
 #
 class govuk::apps::maslow(
   $ensure = 'present',

--- a/modules/govuk/manifests/apps/maslow.pp
+++ b/modules/govuk/manifests/apps/maslow.pp
@@ -89,12 +89,6 @@ class govuk::apps::maslow(
       "${title}-GDS_SSO_OAUTH_SECRET":
         varname => 'GDS_SSO_OAUTH_SECRET',
         value   => $oauth_secret;
-      "${title}-OAUTH_ID":
-        varname => 'OAUTH_ID',
-        value   => $oauth_id;
-      "${title}-OAUTH_SECRET":
-        varname => 'OAUTH_SECRET',
-        value   => $oauth_secret;
       "${title}-SECRET_KEY_BASE":
         varname => 'SECRET_KEY_BASE',
         value   => $secret_key_base;

--- a/modules/govuk/manifests/apps/prometheus.pp
+++ b/modules/govuk/manifests/apps/prometheus.pp
@@ -1,7 +1,5 @@
 # == Class: govuk::apps::prometheus
 #
-# Read more: https://github.com/alphagov/myapp
-#
 # === Parameters
 # [*port*]
 #   What port should the app run on?
@@ -9,51 +7,9 @@
 # [*enabled*]
 #   Whether to install or uninstall the app. Defaults to true (install on all enviroments)
 #
-# [*secret_key_base*]
-#   The key for Rails to use when signing/encrypting sessions (in govuk-secrets)
-#
-# [*sentry_dsn*]
-#   The app-specific URL used by Sentry to report exceptions (in govuk-secrets)
-#
-# [*oauth_id*]
-#   The OAuth ID used to identify the app to GOV.UK Signon (in govuk-secrets)
-#
-# [*oauth_secret*]
-#   The OAuth secret used to authenticate the app to GOV.UK Signon (in govuk-secrets)
-#
-# [*db_hostname*]
-#   The hostname of the database server to use for in DATABASE_URL environment variable
-#
-# [*db_username*]
-#   The username to use for the DATABASE_URL environment variable
-#
-# [*db_password*]
-#   The password to use for the DATABASE_URL environment variable
-#
-# [*db_port*]
-#   The port of the database server to use in the DATABASE_URL.
-#   Default: undef
-#
-# [*db_allow_prepared_statements*]
-#   The ?prepared_statements= parameter to use in the DATABASE_URL.
-#   Default: undef
-#
-# [*db_name*]
-#   The database name to use for the DATABASE_URL environment variable
-#
 class govuk::apps::prometheus (
   $port = 9090,
   $enabled = false,
-  $secret_key_base = undef,
-  $sentry_dsn = undef,
-  $oauth_id = undef,
-  $oauth_secret = undef,
-  $db_username = undef,
-  $db_hostname = undef,
-  $db_port = undef,
-  $db_allow_prepared_statements = undef,
-  $db_password = undef,
-  $db_name = undef,
 ) {
   $app_name = 'prometheus'
 

--- a/modules/govuk/manifests/apps/publisher.pp
+++ b/modules/govuk/manifests/apps/publisher.pp
@@ -215,12 +215,6 @@ class govuk::apps::publisher(
       "${title}-GDS_SSO_OAUTH_SECRET":
         varname => 'GDS_SSO_OAUTH_SECRET',
         value   => $oauth_secret;
-      "${title}-OAUTH_ID":
-        varname => 'OAUTH_ID',
-        value   => $oauth_id;
-      "${title}-OAUTH_SECRET":
-        varname => 'OAUTH_SECRET',
-        value   => $oauth_secret;
       "${title}-FACT_CHECK_ADDRESS_FORMAT":
         varname => 'FACT_CHECK_ADDRESS_FORMAT',
         value   => $fact_check_address_format;

--- a/modules/govuk/manifests/apps/publisher.pp
+++ b/modules/govuk/manifests/apps/publisher.pp
@@ -55,10 +55,10 @@
 #   The URL used by Sentry to report exceptions
 #
 # [*oauth_id*]
-#   The application's OAuth ID from Signon
+#   The OAuth ID used by GDS-SSO to identify the app to GOV.UK Signon
 #
 # [*oauth_secret*]
-#   The application's OAuth Secret from Signon
+#   The OAuth secret used by GDS-SSO to authenticate the app to GOV.UK Signon
 #
 # [*fact_check_address_format*]
 #   The address format used for sending fact checks

--- a/modules/govuk/manifests/apps/publishing_api.pp
+++ b/modules/govuk/manifests/apps/publishing_api.pp
@@ -223,12 +223,6 @@ class govuk::apps::publishing_api(
       "${title}-GDS_SSO_OAUTH_SECRET":
         varname => 'GDS_SSO_OAUTH_SECRET',
         value   => $oauth_secret;
-      "${title}-OAUTH_ID":
-        varname => 'OAUTH_ID',
-        value   => $oauth_id;
-      "${title}-OAUTH_SECRET":
-        varname => 'OAUTH_SECRET',
-        value   => $oauth_secret;
       "${title}-GOVUK_CONTENT_SCHEMAS_PATH":
         varname => 'GOVUK_CONTENT_SCHEMAS_PATH',
         value   => $govuk_content_schemas_path;

--- a/modules/govuk/manifests/apps/publishing_api.pp
+++ b/modules/govuk/manifests/apps/publishing_api.pp
@@ -78,10 +78,10 @@
 #   Default: true
 #
 # [*oauth_id*]
-#   Sets the OAuth ID
+#   The OAuth ID used by GDS-SSO to identify the app to GOV.UK Signon
 #
 # [*oauth_secret*]
-#   Sets the OAuth Secret Key
+#   The OAuth secret used by GDS-SSO to authenticate the app to GOV.UK Signon
 #
 # [*rabbitmq_hosts*]
 #   RabbitMQ hosts to connect to.

--- a/modules/govuk/manifests/apps/release.pp
+++ b/modules/govuk/manifests/apps/release.pp
@@ -31,11 +31,11 @@
 # [*github_access_token*]
 #   The access token to use when accessing the Github API.
 #
-# [*oauth_secret*]
-#   Sets the OAuth Secret Key
+# [*oauth_id*]
+#   The OAuth ID used by GDS-SSO to identify the app to GOV.UK Signon
 #
 # [*oauth_secret*]
-#   Sets the OAuth Secret Key
+#   The OAuth secret used by GDS-SSO to authenticate the app to GOV.UK Signon
 #
 class govuk::apps::release(
   $port,

--- a/modules/govuk/manifests/apps/release.pp
+++ b/modules/govuk/manifests/apps/release.pp
@@ -82,12 +82,6 @@ class govuk::apps::release(
     "${title}-GDS_SSO_OAUTH_SECRET":
       varname => 'GDS_SSO_OAUTH_SECRET',
       value   => $oauth_secret;
-    "${title}-OAUTH_ID":
-      varname => 'OAUTH_ID',
-      value   => $oauth_id;
-    "${title}-OAUTH_SECRET":
-      varname => 'OAUTH_SECRET',
-      value   => $oauth_secret;
     "${title}-GITHUB_USERNAME":
       varname => 'GITHUB_USERNAME',
       value   => $github_username;

--- a/modules/govuk/manifests/apps/router_api.pp
+++ b/modules/govuk/manifests/apps/router_api.pp
@@ -82,12 +82,6 @@ class govuk::apps::router_api(
     "${title}-GDS_SSO_OAUTH_SECRET":
       varname => 'GDS_SSO_OAUTH_SECRET',
       value   => $oauth_secret;
-    "${title}-OAUTH_ID":
-      varname => 'OAUTH_ID',
-      value   => $oauth_id;
-    "${title}-OAUTH_SECRET":
-      varname => 'OAUTH_SECRET',
-      value   => $oauth_secret;
   }
 
   govuk::app::envvar::mongodb_uri { $app_name:

--- a/modules/govuk/manifests/apps/router_api.pp
+++ b/modules/govuk/manifests/apps/router_api.pp
@@ -24,7 +24,6 @@
 # [*secret_key_base*]
 #   The key for Rails to use when signing/encrypting sessions.
 #
-#
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
@@ -33,10 +32,10 @@
 #   after app deployment. Acceptable formats are "cache" or "cache,draft_cache"
 #
 # [*oauth_id*]
-#   The OAuth ID used to identify the app to GOV.UK Signon (in govuk-secrets)
+#   The OAuth ID used by GDS-SSO to identify the app to GOV.UK Signon
 #
 # [*oauth_secret*]
-#   The OAuth secret used to authenticate the app to GOV.UK Signon (in govuk-secrets)
+#   The OAuth secret used by GDS-SSO to authenticate the app to GOV.UK Signon
 #
 
 class govuk::apps::router_api(

--- a/modules/govuk/manifests/apps/search_admin.pp
+++ b/modules/govuk/manifests/apps/search_admin.pp
@@ -31,11 +31,11 @@
 #   Default: undef
 #
 # [*oauth_id*]
-#   Sets the OAuth ID for using GDS-SSO
+#   The OAuth ID used by GDS-SSO to identify the app to GOV.UK Signon
 #   Default: undef
 #
 # [*oauth_secret*]
-#   Sets the OAuth Secret Key for using GDS-SSO
+#   The OAuth secret used by GDS-SSO to authenticate the app to GOV.UK Signon
 #   Default: undef
 #
 # [*secret_key_base*]

--- a/modules/govuk/manifests/apps/search_admin.pp
+++ b/modules/govuk/manifests/apps/search_admin.pp
@@ -132,12 +132,6 @@ class govuk::apps::search_admin(
       "${title}-GDS_SSO_OAUTH_SECRET":
         varname => 'GDS_SSO_OAUTH_SECRET',
         value   => $oauth_secret;
-      "${title}-OAUTH_ID":
-        varname => 'OAUTH_ID',
-        value   => $oauth_id;
-      "${title}-OAUTH_SECRET":
-        varname => 'OAUTH_SECRET',
-        value   => $oauth_secret;
       "${title}-RUMMAGER_BEARER_TOKEN":
         varname => 'RUMMAGER_BEARER_TOKEN',
         value   => $rummager_bearer_token;

--- a/modules/govuk/manifests/apps/search_api.pp
+++ b/modules/govuk/manifests/apps/search_api.pp
@@ -82,10 +82,10 @@
 #   The number of unicorn workers to run for an instance of this app
 #
 # [*oauth_id*]
-#   The OAuth ID used to identify the app to GOV.UK Signon (in govuk-secrets)
+#   The OAuth ID used by GDS-SSO to identify the app to GOV.UK Signon
 #
 # [*oauth_secret*]
-#   The OAuth secret used to authenticate the app to GOV.UK Signon (in govuk-secrets)
+#   The OAuth secret used by GDS-SSO to authenticate the app to GOV.UK Signon
 #
 # [*aws_region*]
 #   The AWS region of the S3 bucket.

--- a/modules/govuk/manifests/apps/search_api.pp
+++ b/modules/govuk/manifests/apps/search_api.pp
@@ -257,12 +257,6 @@ class govuk::apps::search_api(
     "${title}-GDS_SSO_OAUTH_SECRET":
       varname => 'GDS_SSO_OAUTH_SECRET',
       value   => $oauth_secret;
-    "${title}-OAUTH_ID":
-      varname => 'OAUTH_ID',
-      value   => $oauth_id;
-    "${title}-OAUTH_SECRET":
-      varname => 'OAUTH_SECRET',
-      value   => $oauth_secret;
     "${title}-AWS_REGION":
       varname => 'AWS_REGION',
       value   => $aws_region;

--- a/modules/govuk/manifests/apps/service_manual_publisher.pp
+++ b/modules/govuk/manifests/apps/service_manual_publisher.pp
@@ -113,12 +113,6 @@ class govuk::apps::service_manual_publisher(
       "${title}-GDS_SSO_OAUTH_SECRET":
         varname => 'GDS_SSO_OAUTH_SECRET',
         value   => $oauth_secret;
-      "${title}-OAUTH_ID":
-        varname => 'OAUTH_ID',
-        value   => $oauth_id;
-      "${title}-OAUTH_SECRET":
-        varname => 'OAUTH_SECRET',
-        value   => $oauth_secret;
       "${title}-PUBLISHING_API_BEARER_TOKEN":
         varname => 'PUBLISHING_API_BEARER_TOKEN',
         value   => $publishing_api_bearer_token;

--- a/modules/govuk/manifests/apps/service_manual_publisher.pp
+++ b/modules/govuk/manifests/apps/service_manual_publisher.pp
@@ -31,10 +31,10 @@
 #   The URL used by Sentry to report exceptions
 #
 # [*oauth_id*]
-#   Sets the OAuth ID
+#   The OAuth ID used by GDS-SSO to identify the app to GOV.UK Signon
 #
 # [*oauth_secret*]
-#   Sets the OAuth Secret Key
+#   The OAuth secret used by GDS-SSO to authenticate the app to GOV.UK Signon
 #
 # [*port*]
 #   The port that the app is served on.

--- a/modules/govuk/manifests/apps/short_url_manager.pp
+++ b/modules/govuk/manifests/apps/short_url_manager.pp
@@ -118,12 +118,6 @@ class govuk::apps::short_url_manager(
       "${title}-GDS_SSO_OAUTH_SECRET":
         varname => 'GDS_SSO_OAUTH_SECRET',
         value   => $oauth_secret;
-      "${title}-OAUTH_ID":
-        varname => 'OAUTH_ID',
-        value   => $oauth_id;
-      "${title}-OAUTH_SECRET":
-        varname => 'OAUTH_SECRET',
-        value   => $oauth_secret;
       "${title}-PUBLISHING_API_BEARER_TOKEN":
         varname => 'PUBLISHING_API_BEARER_TOKEN',
         value   => $publishing_api_bearer_token;

--- a/modules/govuk/manifests/apps/short_url_manager.pp
+++ b/modules/govuk/manifests/apps/short_url_manager.pp
@@ -30,11 +30,11 @@
 #   only needed if the app uses documentdb rather than mongodb
 #
 # [*oauth_id*]
-#   Sets the OAuth ID for using GDS-SSO
+#   The OAuth ID used by GDS-SSO to identify the app to GOV.UK Signon
 #   Default: undef
 #
 # [*oauth_secret*]
-#   Sets the OAuth Secret Key for using GDS-SSO
+#   The OAuth secret used by GDS-SSO to authenticate the app to GOV.UK Signon
 #   Default: undef
 #
 # [*publishing_api_bearer_token*]

--- a/modules/govuk/manifests/apps/specialist_publisher.pp
+++ b/modules/govuk/manifests/apps/specialist_publisher.pp
@@ -187,12 +187,6 @@ client_max_body_size 500m;
       "${title}-GDS_SSO_OAUTH_SECRET":
       varname => 'GDS_SSO_OAUTH_SECRET',
       value   => $oauth_secret;
-      "${title}-OAUTH_ID":
-      varname => 'OAUTH_ID',
-      value   => $oauth_id;
-      "${title}-OAUTH_SECRET":
-      varname => 'OAUTH_SECRET',
-      value   => $oauth_secret;
       "${title}-PUBLISHING_API_BEARER_TOKEN":
       varname => 'PUBLISHING_API_BEARER_TOKEN',
       value   => $publishing_api_bearer_token;

--- a/modules/govuk/manifests/apps/specialist_publisher.pp
+++ b/modules/govuk/manifests/apps/specialist_publisher.pp
@@ -38,11 +38,11 @@
 #   only needed if the app uses documentdb rather than mongodb
 #
 # [*oauth_id*]
-#   Sets the OAuth ID for using GDS-SSO
+#   The OAuth ID used by GDS-SSO to identify the app to GOV.UK Signon
 #   Default: undef
 #
 # [*oauth_secret*]
-#   Sets the OAuth Secret Key for using GDS-SSO
+#   The OAuth secret used by GDS-SSO to authenticate the app to GOV.UK Signon
 #   Default: undef
 #
 # [*publish_pre_production_finders*]

--- a/modules/govuk/manifests/apps/support.pp
+++ b/modules/govuk/manifests/apps/support.pp
@@ -133,12 +133,6 @@ class govuk::apps::support(
     "${title}-GDS_SSO_OAUTH_SECRET":
       varname => 'GDS_SSO_OAUTH_SECRET',
       value   => $oauth_secret;
-    "${title}-OAUTH_ID":
-      varname => 'OAUTH_ID',
-      value   => $oauth_id;
-    "${title}-OAUTH_SECRET":
-      varname => 'OAUTH_SECRET',
-      value   => $oauth_secret;
     "${title}-SUPPORT_API_BEARER_TOKEN":
       varname => 'SUPPORT_API_BEARER_TOKEN',
       value   => $support_api_bearer_token;

--- a/modules/govuk/manifests/apps/support.pp
+++ b/modules/govuk/manifests/apps/support.pp
@@ -19,10 +19,10 @@
 #   The URL used by Sentry to report exceptions
 #
 # [*oauth_id*]
-#   Sets the OAuth ID
+#   The OAuth ID used by GDS-SSO to identify the app to GOV.UK Signon
 #
 # [*oauth_secret*]
-#   Sets the OAuth Secret Key
+#   The OAuth secret used by GDS-SSO to authenticate the app to GOV.UK Signon
 #
 # [*port*]
 #   The port that publishing API is served on.

--- a/modules/govuk/manifests/apps/support_api.pp
+++ b/modules/govuk/manifests/apps/support_api.pp
@@ -139,12 +139,6 @@ class govuk::apps::support_api(
     "${title}-GDS_SSO_OAUTH_SECRET":
       varname => 'GDS_SSO_OAUTH_SECRET',
       value   => $oauth_secret;
-    "${title}-OAUTH_ID":
-      varname => 'OAUTH_ID',
-      value   => $oauth_id;
-    "${title}-OAUTH_SECRET":
-      varname => 'OAUTH_SECRET',
-      value   => $oauth_secret;
     "${title}-PP_DATA_BEARER_TOKEN":
       varname => 'PP_DATA_BEARER_TOKEN',
       value   => $pp_data_bearer_token;

--- a/modules/govuk/manifests/apps/support_api.pp
+++ b/modules/govuk/manifests/apps/support_api.pp
@@ -38,10 +38,10 @@
 #   The URL used by Sentry to report exceptions
 #
 # [*oauth_id*]
-# The Oauth ID used to identify the app to GOV.UK Signon (in govuk-secrets)
+#   The OAuth ID used by GDS-SSO to identify the app to GOV.UK Signon
 #
 # [*oauth_secret*]
-# The Oauth secret used to authenticate the app to GOV.UK Signon (in govuk-secrets)
+#   The OAuth secret used by GDS-SSO to authenticate the app to GOV.UK Signon
 #
 # [*port*]
 #   The port where the Rails app is running.

--- a/modules/govuk/manifests/apps/transition.pp
+++ b/modules/govuk/manifests/apps/transition.pp
@@ -129,12 +129,6 @@ class govuk::apps::transition(
         "${title}-GDS_SSO_OAUTH_SECRET":
           varname => 'GDS_SSO_OAUTH_SECRET',
           value   => $oauth_secret;
-        "${title}-OAUTH_ID":
-          varname => 'OAUTH_ID',
-          value   => $oauth_id;
-        "${title}-OAUTH_SECRET":
-          varname => 'OAUTH_SECRET',
-          value   => $oauth_secret;
         "${title}-SECRET_KEY_BASE":
           varname => 'SECRET_KEY_BASE',
           value   => $secret_key_base;

--- a/modules/govuk/manifests/apps/transition.pp
+++ b/modules/govuk/manifests/apps/transition.pp
@@ -15,10 +15,10 @@
 #   Default: true
 #
 # [*oauth_id*]
-#   The Signon OAuth identifier for this app
+#   The OAuth ID used by GDS-SSO to identify the app to GOV.UK Signon
 #
 # [*oauth_secret*]
-#   The Signon OAuth secret for this app
+#   The OAuth secret used by GDS-SSO to authenticate the app to GOV.UK Signon
 #
 # [*redis_host*]
 #   Redis host for Sidekiq.

--- a/modules/govuk/manifests/apps/travel_advice_publisher.pp
+++ b/modules/govuk/manifests/apps/travel_advice_publisher.pp
@@ -33,10 +33,10 @@
 #   only needed if the app uses documentdb rather than mongodb
 #
 # [*oauth_id*]
-#   Sets the OAuth ID
+#   The OAuth ID used by GDS-SSO to identify the app to GOV.UK Signon
 #
 # [*oauth_secret*]
-#   Sets the OAuth Secret Key
+#   The OAuth secret used by GDS-SSO to authenticate the app to GOV.UK Signon
 #
 # [*port*]
 #   The port that publishing API is served on.

--- a/modules/govuk/manifests/apps/travel_advice_publisher.pp
+++ b/modules/govuk/manifests/apps/travel_advice_publisher.pp
@@ -152,12 +152,6 @@ class govuk::apps::travel_advice_publisher(
       "${title}-GDS_SSO_OAUTH_SECRET":
         varname => 'GDS_SSO_OAUTH_SECRET',
         value   => $oauth_secret;
-      "${title}-OAUTH_ID":
-        varname => 'OAUTH_ID',
-        value   => $oauth_id;
-      "${title}-OAUTH_SECRET":
-        varname => 'OAUTH_SECRET',
-        value   => $oauth_secret;
       "${title}-PUBLISHING_API_BEARER_TOKEN":
         varname => 'PUBLISHING_API_BEARER_TOKEN',
         value   => $publishing_api_bearer_token;

--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -372,12 +372,6 @@ class govuk::apps::whitehall(
       "${title}-GDS_SSO_OAUTH_SECRET":
         varname => 'GDS_SSO_OAUTH_SECRET',
         value   => $oauth_secret;
-      "${title}-OAUTH_ID":
-        varname => 'OAUTH_ID',
-        value   => $oauth_id;
-      "${title}-OAUTH_SECRET":
-        varname => 'OAUTH_SECRET',
-        value   => $oauth_secret;
       "${title}-LINK_CHECKER_API_SECRET_TOKEN":
         varname => 'LINK_CHECKER_API_SECRET_TOKEN',
         value   => $link_checker_api_secret_token;

--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -376,8 +376,8 @@ class govuk::apps::whitehall(
         varname => 'LINK_CHECKER_API_SECRET_TOKEN',
         value   => $link_checker_api_secret_token;
       "${title}-LINK_CHECKER_API_BEARER_TOKEN":
-          varname => 'LINK_CHECKER_API_BEARER_TOKEN',
-          value   => $link_checker_api_bearer_token;
+        varname => 'LINK_CHECKER_API_BEARER_TOKEN',
+        value   => $link_checker_api_bearer_token;
       "${title}-GOVUK_NOTIFY_API_KEY":
         varname => 'GOVUK_NOTIFY_API_KEY',
         value   => $govuk_notify_api_key;

--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -63,11 +63,11 @@
 #   Memory use at which Nagios should generate a critical alert.
 #
 # [*oauth_id*]
-#   Sets the OAuth ID for using GDS-SSO
+#   The OAuth ID used by GDS-SSO to identify the app to GOV.UK Signon
 #   Default: undef
 #
 # [*oauth_secret*]
-#   Sets the OAuth Secret Key for using GDS-SSO
+#   The OAuth secret used by GDS-SSO to authenticate the app to GOV.UK Signon
 #   Default: undef
 #
 # [*port*]


### PR DESCRIPTION
In https://github.com/alphagov/govuk-puppet/pull/10832 we duplicated the OAuth environment variables to transition to a [renaming](https://github.com/alphagov/gds-sso/pull/242) without downtime. All these apps have now been deployed to use the new environment variable naming so the old environment variables can be removed. This PR removes them all.

It also does some clean-up on the documentation of the oauth_id and oauth_secret variables for consistency, with a couple of tangential fixes thrown in (sorry).

More info in the commits.

