### PR TITLE
Removes call to Whitehall's 'requeue_all_jobs' Rake task

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
@@ -41,8 +41,3 @@
                 TARGET_APPLICATION=<%= app %>
                 DEPLOY_TASK=app:migrate_and_hard_restart
             <%- end -%>
-            - project: run-rake-task
-              predefined-parameters: |
-                TARGET_APPLICATION=whitehall
-                MACHINE_CLASS=whitehall_backend
-                RAKE_TASK=publishing:scheduled:requeue_all_jobs


### PR DESCRIPTION
I missed earlier, it should have been done as part of
https://github.com/alphagov/govuk-puppet/pull/10842

Trello: https://trello.com/c/RethzUSW/2088-5-fix-assetmanagerservicehelperassetnotfound-errors-on-staging-integration