### PR TITLE
Increase memory threshold for collections

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -470,8 +470,8 @@ govuk::apps::ckan::s3_aws_secret_access_key: "%{hiera('s3_aws_secret_access_key'
 
 govuk::apps::collections::feature_flag_accounts: true
 govuk::apps::collections::unicorn_worker_processes: 4
-govuk::apps::collections::nagios_memory_warning: 1300
-govuk::apps::collections::nagios_memory_critical: 1500
+govuk::apps::collections::nagios_memory_warning: 1500
+govuk::apps::collections::nagios_memory_critical: 1700
 
 govuk::apps::collections_publisher::db_hostname: "mysql-primary"
 govuk::apps::collections_publisher::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"


### PR DESCRIPTION
## What

Increase the threshold for memory usage alerts on collections. 

## Why

- Memory usage has increased on collections, possibly with the addition of the postcode checker.  
- The memory usage looks OK, so we can increase the threshold for now pending further investigation.
<img width="426" alt="Screenshot 2020-11-16 at 16 41 28" src="https://user-images.githubusercontent.com/17908089/99282794-10c5c280-282c-11eb-8ecb-57ca3dbdacfd.png">

[Trello](https://trello.com/c/1xN48CtV/1043-needs-investigation-collections-restarts-per-day-due-to-memory-usage)
