### PR TITLE
Run content-data-api data syncs 4 hours earlier

### DIFF
--- a/hieradata_aws/class/integration/content_data_api_db_admin.yaml
+++ b/hieradata_aws/class/integration/content_data_api_db_admin.yaml
@@ -3,7 +3,7 @@ govuk_env_sync::tasks:
   # changing the name later
   "pull_content_data_api_production_daily":
     ensure: "present"
-    hour: "4"
+    hour: "0"
     minute: "0"
     action: "pull"
     dbms: "postgresql"
@@ -14,7 +14,7 @@ govuk_env_sync::tasks:
     path: "content-data-api-postgresql"
   "push_content_data_api_production_daily":
     ensure: "present"
-    hour: "9"
+    hour: "5"
     minute: "0"
     action: "push"
     dbms: "postgresql"

--- a/hieradata_aws/class/production/content_data_api_db_admin.yaml
+++ b/hieradata_aws/class/production/content_data_api_db_admin.yaml
@@ -3,7 +3,7 @@ govuk_env_sync::tasks:
   # changing the name later
   "push_content_data_api_production_daily":
     ensure: "present"
-    hour: "3"
+    hour: "23"
     minute: "0"
     action: "push"
     dbms: "postgresql"

--- a/hieradata_aws/class/staging/content_data_api_db_admin.yaml
+++ b/hieradata_aws/class/staging/content_data_api_db_admin.yaml
@@ -3,7 +3,7 @@ govuk_env_sync::tasks:
   # changing the name later
   "pull_content_data_api_production_daily":
     ensure: "present"
-    hour: "4"
+    hour: "0"
     minute: "0"
     action: "pull"
     dbms: "postgresql"
@@ -14,7 +14,7 @@ govuk_env_sync::tasks:
     path: "content-data-api-postgresql"
   "push_content_data_api_production_daily":
     ensure: "present"
-    hour: "9"
+    hour: "5"
     minute: "0"
     action: "push"
     dbms: "postgresql"


### PR DESCRIPTION
The data sync for this app takes a long time to complete and we're starting to [see Sentry errors](https://sentry.io/organizations/govuk/issues/1863595705/?cursor=0%3A700%3A0&project=1461890) appear in the morning after the [10pm-8am data sync ignore period](https://github.com/alphagov/govuk_app_config/pull/160).

[Trello Card](https://trello.com/c/w2VlrPXQ/2223-3-suppress-activerecordstatementinvalid-errors-in-content-data-api)