### PR TITLE
Expose arbitrarily hidden healthchecks

### DIFF
--- a/modules/govuk/manifests/app.pp
+++ b/modules/govuk/manifests/app.pp
@@ -64,16 +64,6 @@
 #   By default the alert doc will be "app-healthcheck-not-ok".
 #   Set to true to change this to "<app>-app-healthcheck-not-ok".
 #
-# [*expose_health_check*]
-# whether to expose the health check to the proxy.
-#
-# In some apps, such as bouncer, this must be exposed so load balancers know
-# whether to send requests to a particular server; in other apps, such as
-# publisher, this must not be exposed, because then it would provide an
-# uncached, unauthenticated, publicly accessible point of access into the
-# state of our admin systems.
-#
-#
 # [*json_health_check*]
 # whether the app's health check is exposed as JSON.
 #
@@ -288,7 +278,6 @@ define govuk::app (
   $log_format_is_json = false,
   $health_check_path = 'NOTSET',
   $health_check_custom_doc = undef,
-  $expose_health_check = true,
   $json_health_check = false,
   $health_check_service_template = 'govuk_regular_service',
   $health_check_notification_period = undef,
@@ -382,7 +371,6 @@ define govuk::app (
     nginx_extra_config                  => $nginx_extra_config,
     health_check_path                   => $health_check_path,
     health_check_custom_doc             => $health_check_custom_doc,
-    expose_health_check                 => $expose_health_check,
     json_health_check                   => $json_health_check,
     health_check_service_template       => $health_check_service_template,
     health_check_notification_period    => $health_check_notification_period,

--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -99,7 +99,6 @@ define govuk::app::config (
   $nginx_extra_config = '',
   $health_check_path = 'NOTSET',
   $health_check_custom_doc = false,
-  $expose_health_check = true,
   $json_health_check = false,
   $health_check_service_template = 'govuk_regular_service',
   $health_check_notification_period = undef,
@@ -273,16 +272,6 @@ define govuk::app::config (
   }
 
   if $enable_nginx_vhost {
-
-    if $expose_health_check {
-      $hidden_paths = []
-    } else {
-      if $health_check_path == 'NOTSET' {
-        fail('Cannot hide an unset health check path')
-      }
-      $hidden_paths = [$health_check_path]
-    }
-
     # Expose this application from nginx
     govuk::app::nginx_vhost { $title:
       ensure                         => $ensure,
@@ -295,7 +284,7 @@ define govuk::app::config (
       deny_framing                   => $deny_framing,
       asset_pipeline                 => $asset_pipeline,
       asset_pipeline_prefixes        => $asset_pipeline_prefixes,
-      hidden_paths                   => $hidden_paths,
+      hidden_paths                   => [],
       read_timeout                   => $read_timeout,
       alert_5xx_warning_rate         => $alert_5xx_warning_rate,
       alert_5xx_critical_rate        => $alert_5xx_critical_rate,

--- a/modules/govuk/manifests/apps/finder_frontend.pp
+++ b/modules/govuk/manifests/apps/finder_frontend.pp
@@ -62,7 +62,6 @@ class govuk::apps::finder_frontend(
       port                     => $port,
       sentry_dsn               => $sentry_dsn,
       health_check_path        => '/healthcheck.json',
-      expose_health_check      => false,
       json_health_check        => true,
       log_format_is_json       => true,
       asset_pipeline           => true,

--- a/modules/govuk/manifests/apps/search_api.pp
+++ b/modules/govuk/manifests/apps/search_api.pp
@@ -158,7 +158,6 @@ class govuk::apps::search_api(
     sentry_dsn               => $sentry_dsn,
     health_check_path        => '/healthcheck',
     health_check_custom_doc  => true,
-    expose_health_check      => false,
     json_health_check        => true,
 
     vhost_aliases            => ['search'],

--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -226,7 +226,6 @@ class govuk::apps::whitehall(
     log_format_is_json       => true,
     health_check_path        => $health_check_path,
     health_check_custom_doc  => true,
-    expose_health_check      => false,
     json_health_check        => true,
     depends_on_nfs           => true,
     enable_nginx_vhost       => false,

--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -298,7 +298,6 @@ class govuk::apps::whitehall(
       deny_crawlers           => true,
       asset_pipeline          => true,
       asset_pipeline_prefixes => ['assets/whitehall'],
-      hidden_paths            => [$health_check_path],
       nginx_extra_config      => '
       proxy_set_header X-Sendfile-Type X-Accel-Redirect;
 
@@ -319,13 +318,6 @@ class govuk::apps::whitehall(
       # permissions.
       location /auth/gds {
         auth_basic off;
-        try_files $uri @app;
-      }
-
-      # Don\'t block access to the overdue healthcheck page.  Icinga needs to be
-      # able to access this from the monitoring machine.
-      # This is necessary because "/healthcheck*" is blocked by the hidden_paths option above.
-      location /healthcheck/overdue {
         try_files $uri @app;
       }
     ',

--- a/modules/govuk/spec/defines/govuk__app__spec.rb
+++ b/modules/govuk/spec/defines/govuk__app__spec.rb
@@ -45,37 +45,6 @@ describe 'govuk::app', :type => :define do
     it { is_expected.to raise_error(Puppet::Error, /Invalid \$command parameter/) }
   end
 
-  context 'health check hidden' do
-    let(:params) do
-      {
-        :app_type => 'rack',
-        :port => '8000',
-        :health_check_path => '/healthcheck',
-        :expose_health_check => false,
-      }
-    end
-
-    it "should hide the healthcheck paths" do
-      is_expected.to contain_govuk__app__nginx_vhost('giraffe').with(
-        'hidden_paths' => ['/healthcheck']
-      )
-    end
-  end
-
-  context 'health check path not provided, health check hidden' do
-    let(:params) do
-      {
-        :app_type => 'rack',
-        :port => 8000,
-        :expose_health_check => false,
-      }
-    end
-
-    it "should fail to compile" do
-      is_expected.to raise_error(Puppet::Error, /Cannot hide/)
-    end
-  end
-
   context 'with ensure' do
     context 'ensure => absent' do
       let(:params) {{


### PR DESCRIPTION
https://trello.com/c/ILpSOFhq/201-enable-cd-for-quick-win-and-possible-quick-win-apps

Previously we noted that the majority of our apps expose their
healthcheck endpoint [1], with the original concern for not
doing so being vague and not representative of the defaults in
place. Of the three apps that still had their healthcheck route
hidden, none of the commits make any mention of this or suggest
why the endpoint should be treated specially. In addition, two
of the three apps aren't even resolvable externally. This removes
the functionality to hide the healthcheck route and thus exposes
it for three inconsistent apps.

[1]: a91df2aa30d20a2a099b9bf843d1c8c159dfe4d2