### PR TITLE
Fix data source for Icinga Alert dashboard

### DIFF
--- a/modules/grafana/files/dashboards/icinga_alerts.json
+++ b/modules/grafana/files/dashboards/icinga_alerts.json
@@ -269,7 +269,7 @@
           "bars": true,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "Graphite",
           "fill": 1,
           "id": 2,
           "legend": {


### PR DESCRIPTION
This is not defaulted in Integration, and we should avoid relying
on the choice of default data source in our dashboards.