### PR TITLE
Update email used to send smart answers broken link report to zendesk

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/smart_answers_broken_links_report.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/smart_answers_broken_links_report.yaml.erb
@@ -11,7 +11,7 @@
             predefined-parameters: |
               TARGET_APPLICATION=smartanswers
               MACHINE_CLASS=calculators_frontend
-              RAKE_TASK=links:send_report[govuk-coronavirus-nsv@govuk.zendesk.com]
+              RAKE_TASK=links:send_report[govuk-smart-answers@digital.cabinet-office.gov.uk]
     wrappers:
       - ansicolor:
           colormap: xterm


### PR DESCRIPTION
Address was previously that of the zendesk entity to which the report was being sent. That caused errors. It is being replaced with a google group email address govuk-smart-answers@digital.cabinet-office.gov.uk