### PR TITLE
Increase warning threshold

### DIFF
--- a/modules/govuk/manifests/apps/search_api.pp
+++ b/modules/govuk/manifests/apps/search_api.pp
@@ -184,7 +184,7 @@ class govuk::apps::search_api(
 
   govuk::procfile::worker { 'search-api':
     enable_service            => $enable_procfile_worker,
-    memory_warning_threshold  => 800,
+    memory_warning_threshold  => 1000,
     memory_critical_threshold => 1500,
   }
 


### PR DESCRIPTION
increase warning threshold for the search api worker from 800 to 1000 to 
prevent too many warning in icinga