### PR TITLE
Enable CD for bouncer

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1121,6 +1121,7 @@ govuk_jenkins::jobs::deploy_app::applications: *deployable_applications
 
 govuk_jenkins::jobs::deploy_app_downstream::applications:
   authenticating-proxy: {}
+  bouncer: {}
   content-publisher: {}
   finder-frontend: {}
   government-frontend: {}


### PR DESCRIPTION
I believe the [appropriate criteria](https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#safety-checks) have been met by https://github.com/alphagov/bouncer/pull/278 and https://github.com/alphagov/smokey/pull/747.

Trello: https://trello.com/c/ILpSOFhq/201-enable-cd-for-quick-win-and-possible-quick-win-apps