### PR TITLE
Set up a GOVUK_NOTIFY_RECIPIENTS env var for Email Alert API

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -202,6 +202,7 @@ task :check_consistency_between_aws_and_carrenza do
     govuk::apps::email_alert_api::email_archive_s3_bucket
     govuk::apps::email_alert_api::email_archive_s3_enabled
     govuk::apps::email_alert_api::enabled
+    govuk::apps::email_alert_api::govuk_notify_recipients
     govuk::apps::email_alert_api::govuk_notify_template_id
     govuk::apps::email_alert_api::nagios_memory_critical
     govuk::apps::email_alert_api::nagios_memory_warning

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -539,34 +539,9 @@ govuk::apps::email_alert_api::nagios_memory_critical: 3000
 govuk::apps::email_alert_api::unicorn_worker_processes: '10'
 # This list should be kept in sync with https://www.notifications.service.gov.uk/services/ecfc7e2f-5145-45a6-9413-5d9b6e813ea9/users
 govuk::apps::email_alert_api::email_address_override_whitelist:
-  - govuk-email-courtesy-copies@digital.cabinet-office.gov.uk
-  - alan.gabbianelli@digital.cabinet-office.gov.uk
-  - alex.jurubita@digital.cabinet-office.gov.uk
-  - andy.maidment@digital.cabinet-office.gov.uk
   - ben.thorner@digital.cabinet-office.gov.uk
-  - bevan.loon@digital.cabinet-office.gov.uk
-  - bruce.bolt@digital.cabinet-office.gov.uk
-  - camille.descartes@digital.cabinet-office.gov.uk
-  - chris.banks@digital.cabinet-office.gov.uk
-  - complaint@simulator.amazonses.com
-  - conor.delahunty@digital.cabinet-office.gov.uk
-  - deborah.chua@digital.cabinet-office.gov.uk
-  - dilwoar.hussain@digital.cabinet-office.gov.uk
-  - edward.kerry@digital.cabinet-office.gov.uk
-  - huw.diprose@digital.cabinet-office.gov.uk
-  - jennifer.allum@digital.cabinet-office.gov.uk
   - jessica.jones@digital.cabinet-office.gov.uk
   - kevin.dew@digital.cabinet-office.gov.uk
-  - kelvin.gan@digital.cabinet-office.gov.uk
-  - leanne.cummings@digital.cabinet-office.gov.uk
-  - michael.s.walker@digital.cabinet-office.gov.uk
-  - neil.hayes@digital.cabinet-office.gov.uk
-  - sean.rankine@digital.cabinet-office.gov.uk
-  - steve.messer@digital.cabinet-office.gov.uk
-  - tim.blair@digital.cabinet-office.gov.uk
-  - thomas.leese@digital.cabinet-office.gov.uk
-  - tom.whitwell@digital.cabinet-office.gov.uk
-  - vanita.barrett@digital.cabinet-office.gov.uk
 
 govuk::apps::email_alert_frontend::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::email_alert_frontend::redis_port: "%{hiera('sidekiq_port')}"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -543,6 +543,11 @@ govuk::apps::email_alert_api::email_address_override_whitelist:
   - jessica.jones@digital.cabinet-office.gov.uk
   - kevin.dew@digital.cabinet-office.gov.uk
 
+govuk::apps::email_alert_api::govuk_notify_recipients:
+  - ben.thorner@digital.cabinet-office.gov.uk
+  - jessica.jones@digital.cabinet-office.gov.uk
+  - kevin.dew@digital.cabinet-office.gov.uk
+
 govuk::apps::email_alert_frontend::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::email_alert_frontend::redis_port: "%{hiera('sidekiq_port')}"
 

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -189,6 +189,7 @@ govuk::apps::email_alert_api::email_archive_s3_bucket: 'govuk-production-email-a
 # This shouldn't be enabled at the same time we have carrenza s3 export enabled unless they have separate buckets
 govuk::apps::email_alert_api::email_archive_s3_enabled: true
 govuk::apps::email_alert_api::govuk_notify_template_id: 'cb633abc-6ae6-4843-ae6f-82ca500b6de2'
+govuk::apps::email_alert_api::govuk_notify_recipients: '*'
 govuk::apps::feedback::govuk_notify_reply_to_id: 'e8b2d8a6-db5f-4346-9fbd-49b16b531e1c'
 govuk::apps::feedback::govuk_notify_template_id: '54168fa9-3946-4860-a2f8-27ddbb14babe'
 govuk::apps::finder_frontend::plek_account_manager_uri: 'https://www.account.publishing.service.gov.uk'

--- a/modules/govuk/manifests/apps/email_alert_api.pp
+++ b/modules/govuk/manifests/apps/email_alert_api.pp
@@ -35,6 +35,11 @@
 # [*govuk_notify_api_key*]
 #   API key for integration with GOV.UK Notify for sending emails
 #
+# [*govuk_notify_recipients*]
+#   Indicates email addresses that will receive emails from Notify. This can
+#   can be a string of "*" to indicate everyone or it can be an email address
+#   or an array of email addressses.
+#
 # [*govuk_notify_template_id*]
 #   Template ID for GOV.UK Notify
 #
@@ -122,6 +127,7 @@ class govuk::apps::email_alert_api(
   $sentry_dsn = undef,
   $govuk_notify_api_key = undef,
   $govuk_notify_base_url = undef,
+  $govuk_notify_recipients = undef,
   $govuk_notify_template_id = undef,
   $secret_key_base = undef,
   $oauth_id = undef,
@@ -268,6 +274,18 @@ class govuk::apps::email_alert_api(
         varname => 'EMAIL_ADDRESS_OVERRIDE_WHITELIST',
         value   => join($email_address_override_whitelist, ',');
       }
+    }
+  }
+
+  if $govuk_notify_recipients {
+    $recipients = is_array($govuk_notify_recipients) ? {
+      true  => join($govuk_notify_recipients, ','),
+      false => $govuk_notify_recipients
+    }
+
+    govuk::app::envvar { "${title}-GOVUK_NOTIFY_RECIPIENTS":
+      varname => 'GOVUK_NOTIFY_RECIPIENTS',
+      value   => $recipients;
     }
   }
 


### PR DESCRIPTION
Trello: https://trello.com/c/G35ncFfw/645-simplify-configuration-for-email-sending

This first reduces the number of people who are configured to receive integration/staging email notifications to just developers in the GOV.UK Notifications and Transitions teams.

It then adds an environment variable `GOVUK_NOTIFY_RECIPIENTS` which is intended to help Email Alert API transition from a rather complicated configuration system (provider, whitelist, whitelist_only etc) to a much simpler one. It also offers the first step towards removing the whitelist terminology.

Once Email Alert API has been updated to use this new environment variable I'll come back and clean up. I didn't see much value in leaving comments in the code to explain what is legacy or not as there would be quite a lot to comment on and I expect it won't be long until they're removed.