### PR TITLE
Enable Continuous Deployment for Content Publisher

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1127,6 +1127,7 @@ govuk_jenkins::jobs::deploy_app::applications: *deployable_applications
 
 govuk_jenkins::jobs::deploy_app_downstream::applications:
   authenticating-proxy: {}
+  content-publisher: {}
   finder-frontend: {}
   government-frontend: {}
   info-frontend: {}


### PR DESCRIPTION
https://trello.com/c/ILpSOFhq/201-enable-cd-for-quick-win-and-possible-quick-win-apps

This app meets all the safety checks required by RFC 128, based on
the audit [1], and after adding a new healthcheck for AWS S3 [2].

Dependencies:

- https://github.com/alphagov/smokey/pull/749
- https://github.com/alphagov/content-publisher/pull/2207
- https://github.com/alphagov/govuk-saas-config/pull/70

As well as some follow-up tasks:

- Backfill the PR template as a comment on existing PRs.
- Add a note in the Release app to warn about the change.

[1]: https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128/compatibility.md
[2]: https://github.com/alphagov/content-publisher/pull/2204