### PR TITLE
Reduce collections response timeout from 15 seconds to 1 second

### DIFF
--- a/modules/govuk/manifests/apps/collections.pp
+++ b/modules/govuk/manifests/apps/collections.pp
@@ -56,6 +56,7 @@ class govuk::apps::collections(
     json_health_check        => true,
     log_format_is_json       => true,
     asset_pipeline           => true,
+    read_timeout             => 1,
     asset_pipeline_prefixes  => ['assets/collections'],
     vhost                    => $vhost,
     nagios_memory_warning    => $nagios_memory_warning,


### PR DESCRIPTION
Nginx proxy_read_timeout for collections will be reduced to 1s.

The intent is to bail out on slow requests. Currently 99th percentile for collections is >1s.