### PR TITLE
Remove redundant email archive env vars

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -199,8 +199,6 @@ task :check_consistency_between_aws_and_carrenza do
     govuk::apps::email_alert_api::db_hostname
     govuk::apps::email_alert_api::db_password
     govuk::apps::email_alert_api::email_address_override_whitelist
-    govuk::apps::email_alert_api::email_archive_s3_bucket
-    govuk::apps::email_alert_api::email_archive_s3_enabled
     govuk::apps::email_alert_api::enabled
     govuk::apps::email_alert_api::govuk_notify_recipients
     govuk::apps::email_alert_api::govuk_notify_template_id

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -31,8 +31,6 @@ govuk::apps::content_publisher::email_address_override: "content-publisher-notif
 govuk::apps::content_publisher::govuk_notify_template_id: "759acac6-da53-4a19-b591-b7538c7c39de"
 govuk::apps::collections_publisher::govuk_notify_template_id: "759acac6-da53-4a19-b591-b7538c7c39de"
 govuk::apps::collections_publisher::publish_without_2i_email: "mainstream-publisher-notifications-integration@digital.cabinet-office.gov.uk"
-govuk::apps::email_alert_api::email_archive_s3_bucket: 'govuk-integration-email-alert-api-archive'
-govuk::apps::email_alert_api::email_archive_s3_enabled: true
 govuk::apps::email_alert_api::govuk_notify_template_id: '1fc69d3a-09a2-40f9-852b-03f6fcef5340'
 govuk::apps::email_alert_api::email_address_override: 'success@simulator.amazonses.com'
 govuk::apps::email_alert_api::email_address_override_whitelist_only: true

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -185,9 +185,6 @@ govuk::apps::govuk_crawler_worker::blacklist_paths:
 govuk::apps::govuk_crawler_worker::crawler_threads: '32'
 
 govuk::apps::email_alert_api::db::backend_ip_range: '10.13.3.0/24'
-govuk::apps::email_alert_api::email_archive_s3_bucket: 'govuk-production-email-alert-api-archive'
-# This shouldn't be enabled at the same time we have carrenza s3 export enabled unless they have separate buckets
-govuk::apps::email_alert_api::email_archive_s3_enabled: true
 govuk::apps::email_alert_api::govuk_notify_template_id: 'cb633abc-6ae6-4843-ae6f-82ca500b6de2'
 govuk::apps::email_alert_api::govuk_notify_recipients: '*'
 govuk::apps::feedback::govuk_notify_reply_to_id: 'e8b2d8a6-db5f-4346-9fbd-49b16b531e1c'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -161,9 +161,6 @@ govuk::apps::content_store::performance_platform_big_screen_view_url: 'https://p
 govuk::apps::content_store::performance_platform_spotlight_url: 'https://performance-platform-spotlight-staging.cloudapps.digital'
 
 govuk::apps::email_alert_api::db::backend_ip_range: '10.12.3.0/24'
-govuk::apps::email_alert_api::email_archive_s3_bucket: 'govuk-staging-email-alert-api-archive'
-# This shouldn't be enabled at the same time we have carrenza s3 export enabled unless they have separate buckets
-govuk::apps::email_alert_api::email_archive_s3_enabled: false
 govuk::apps::email_alert_api::govuk_notify_template_id: '2844a647-6bf1-4b01-a25c-569d2cc00849'
 govuk::apps::email_alert_api::email_address_override: 'success@simulator.amazonses.com'
 govuk::apps::email_alert_api::email_address_override_whitelist_only: true

--- a/modules/govuk/manifests/apps/email_alert_api.pp
+++ b/modules/govuk/manifests/apps/email_alert_api.pp
@@ -86,13 +86,6 @@
 #   The AWS region which is used for AWS Services
 #   default: eu-west-1
 #
-# [*email_archive_s3_bucket*]
-#   An S3 bucket in the specified AWS region which can be used to write the
-#   archived data too
-#
-# [*email_archive_s3_enabled*]
-#   Whether or not to perform S3 archiving in the current environment
-#
 # [*db_port*]
 #   The port of the database server to use in the DATABASE_URL.
 #   Default: undef
@@ -147,8 +140,6 @@ class govuk::apps::email_alert_api(
   $aws_access_key_id = undef,
   $aws_secret_access_key = undef,
   $aws_region = 'eu-west-1',
-  $email_archive_s3_bucket = undef,
-  $email_archive_s3_enabled = undef,
   $nagios_memory_warning = undef,
   $nagios_memory_critical = undef,
   $publishing_api_bearer_token = undef,
@@ -255,9 +246,6 @@ class govuk::apps::email_alert_api(
     "${title}-AWS_REGION":
         varname => 'AWS_REGION',
         value   => $aws_region;
-    "${title}-EMAIL_ARCHIVE_S3_BUCKET":
-        varname => 'EMAIL_ARCHIVE_S3_BUCKET',
-        value   => $email_archive_s3_bucket;
     "${title}-PUBLISHING_API_BEARER_TOKEN":
       varname => 'PUBLISHING_API_BEARER_TOKEN',
       value   => $publishing_api_bearer_token;
@@ -286,13 +274,6 @@ class govuk::apps::email_alert_api(
     govuk::app::envvar { "${title}-GOVUK_NOTIFY_RECIPIENTS":
       varname => 'GOVUK_NOTIFY_RECIPIENTS',
       value   => $recipients;
-    }
-  }
-
-  if $email_archive_s3_enabled {
-    govuk::app::envvar { "${title}-EMAIL_ARCHIVE_S3_ENABLED":
-      varname => 'EMAIL_ARCHIVE_S3_ENABLED',
-      value   => 'yes';
     }
   }
 


### PR DESCRIPTION
https://trello.com/c/UMGXUk5R/654-retire-archiving-emails

These are no longer used [1].

[1]: https://github.com/alphagov/email-alert-api/pull/1486