### PR TITLE
Remove configuration no longer used by Email Alert API

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -198,7 +198,6 @@ task :check_consistency_between_aws_and_carrenza do
     govuk::apps::email_alert_api::db::rds
     govuk::apps::email_alert_api::db_hostname
     govuk::apps::email_alert_api::db_password
-    govuk::apps::email_alert_api::email_address_override_whitelist
     govuk::apps::email_alert_api::enabled
     govuk::apps::email_alert_api::govuk_notify_recipients
     govuk::apps::email_alert_api::govuk_notify_template_id

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -537,12 +537,6 @@ govuk::apps::email_alert_api::db_password: "%{hiera('govuk::apps::email_alert_ap
 govuk::apps::email_alert_api::nagios_memory_warning: 2400
 govuk::apps::email_alert_api::nagios_memory_critical: 3000
 govuk::apps::email_alert_api::unicorn_worker_processes: '10'
-# This list should be kept in sync with https://www.notifications.service.gov.uk/services/ecfc7e2f-5145-45a6-9413-5d9b6e813ea9/users
-govuk::apps::email_alert_api::email_address_override_whitelist:
-  - ben.thorner@digital.cabinet-office.gov.uk
-  - jessica.jones@digital.cabinet-office.gov.uk
-  - kevin.dew@digital.cabinet-office.gov.uk
-
 govuk::apps::email_alert_api::govuk_notify_recipients:
   - ben.thorner@digital.cabinet-office.gov.uk
   - jessica.jones@digital.cabinet-office.gov.uk

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -32,8 +32,6 @@ govuk::apps::content_publisher::govuk_notify_template_id: "759acac6-da53-4a19-b5
 govuk::apps::collections_publisher::govuk_notify_template_id: "759acac6-da53-4a19-b591-b7538c7c39de"
 govuk::apps::collections_publisher::publish_without_2i_email: "mainstream-publisher-notifications-integration@digital.cabinet-office.gov.uk"
 govuk::apps::email_alert_api::govuk_notify_template_id: '1fc69d3a-09a2-40f9-852b-03f6fcef5340'
-govuk::apps::email_alert_api::email_address_override: 'success@simulator.amazonses.com'
-govuk::apps::email_alert_api::email_address_override_whitelist_only: true
 govuk::apps::email_alert_frontend::subscription_management_enabled: true
 govuk::apps::feedback::govuk_notify_reply_to_id: 'fee22233-2f28-4b0b-8b6c-4410979f2275'
 govuk::apps::feedback::govuk_notify_template_id: 'eb9ba220-7d74-4aab-975a-bdbe718f69a3'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -162,8 +162,6 @@ govuk::apps::content_store::performance_platform_spotlight_url: 'https://perform
 
 govuk::apps::email_alert_api::db::backend_ip_range: '10.12.3.0/24'
 govuk::apps::email_alert_api::govuk_notify_template_id: '2844a647-6bf1-4b01-a25c-569d2cc00849'
-govuk::apps::email_alert_api::email_address_override: 'success@simulator.amazonses.com'
-govuk::apps::email_alert_api::email_address_override_whitelist_only: true
 govuk::apps::email_alert_frontend::subscription_management_enabled: true
 govuk::apps::feedback::govuk_notify_reply_to_id: 'd1f54751-80a8-420a-9077-d34c7d6cc734'
 govuk::apps::feedback::govuk_notify_template_id: '8a8d98c0-42c8-4f56-b61f-77c89417a171'

--- a/modules/govuk/manifests/apps/email_alert_api.pp
+++ b/modules/govuk/manifests/apps/email_alert_api.pp
@@ -43,9 +43,6 @@
 # [*govuk_notify_template_id*]
 #   Template ID for GOV.UK Notify
 #
-# [*govuk_notify_base_url*]
-#   Deprecated env var to switch notify environments.
-#
 # [*secret_key_base*]
 #   The key for Rails to use when signing/encrypting sessions.
 #
@@ -58,20 +55,6 @@
 # [*email_alert_auth_token*]
 #   Sets the secret token used for encrypting and decrypting messages shared
 #   between email alert applications
-#
-# [*email_service_provider*]
-#   Configure which provider to use for sending emails.
-#    PSUEDO - Don't actually send emails, instead just log them.
-#    NOTIFY - Use GOV.UK Notify to send the emails.
-#
-# [*email_address_override*]
-#   Configure all emails to be sent to this address instead.
-#
-# [*email_address_override_whitelist*]
-#   Allow a whitelist of email addresses that ignore the override option.
-#
-# [*email_address_override_whitelist_only*]
-#   Specify that only emails that are whitelisted should be sent out.
 #
 # [*unicorn_worker_processes*]
 #   The number of unicorn workers to run for an instance of this app
@@ -119,17 +102,12 @@ class govuk::apps::email_alert_api(
   $redis_port = undef,
   $sentry_dsn = undef,
   $govuk_notify_api_key = undef,
-  $govuk_notify_base_url = undef,
   $govuk_notify_recipients = undef,
   $govuk_notify_template_id = undef,
   $secret_key_base = undef,
   $oauth_id = undef,
   $oauth_secret = undef,
   $email_alert_auth_token = undef,
-  $email_service_provider = 'NOTIFY',
-  $email_address_override = undef,
-  $email_address_override_whitelist = undef,
-  $email_address_override_whitelist_only = false,
   $db_username = 'email-alert-api',
   $db_password = undef,
   $db_hostname = undef,
@@ -231,12 +209,6 @@ class govuk::apps::email_alert_api(
     "${title}-EMAIL_ALERT_AUTH_TOKEN":
         varname => 'EMAIL_ALERT_AUTH_TOKEN',
         value   => $email_alert_auth_token;
-    "${title}-EMAIL_SERVICE_PROVIDER":
-        varname => 'EMAIL_SERVICE_PROVIDER',
-        value   => $email_service_provider;
-    "${title}-EMAIL_ADDRESS_OVERRIDE":
-        varname => 'EMAIL_ADDRESS_OVERRIDE',
-        value   => $email_address_override;
     "${title}-AWS_ACCESS_KEY_ID":
         varname => 'AWS_ACCESS_KEY_ID',
         value   => $aws_access_key_id;
@@ -249,20 +221,6 @@ class govuk::apps::email_alert_api(
     "${title}-PUBLISHING_API_BEARER_TOKEN":
       varname => 'PUBLISHING_API_BEARER_TOKEN',
       value   => $publishing_api_bearer_token;
-  }
-
-  if $email_address_override_whitelist_only {
-    govuk::app::envvar { "${title}-EMAIL_ADDRESS_OVERRIDE_WHITELIST_ONLY":
-      varname => 'EMAIL_ADDRESS_OVERRIDE_WHITELIST_ONLY',
-      value   => 'yes';
-    }
-
-    if $email_address_override_whitelist {
-      govuk::app::envvar { "${title}-EMAIL_ADDRESS_OVERRIDE_WHITELIST":
-        varname => 'EMAIL_ADDRESS_OVERRIDE_WHITELIST',
-        value   => join($email_address_override_whitelist, ',');
-      }
-    }
   }
 
   if $govuk_notify_recipients {


### PR DESCRIPTION
Trello: https://trello.com/c/G35ncFfw/645-simplify-configuration-for-email-sending

This configuration is replaced in https://github.com/alphagov/email-alert-api/pull/1489 - I've marked this PR as a draft until that is merged and deployed.