### PR TITLE
Remove Tom W from GOV.UK ssh authorised-keys.

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -533,7 +533,6 @@ users::usernames:
   - suganyasivaskantharajah
   - thomasleese
   - timblair
-  - tomwhitwell
   - vitaliemogoreanu
   - williamfranklin
 

--- a/modules/users/manifests/tomwhitwell.pp
+++ b/modules/users/manifests/tomwhitwell.pp
@@ -1,6 +1,7 @@
 # Creates the tomwhitwell user
 class users::tomwhitwell {
   govuk_user { 'tomwhitwell':
+    ensure   => absent,
     fullname => 'Tom Whitwell',
     email    => 'tom.whitwell@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILb/0/9cf3s7x+LlOC+4xWJ0ogzWUInOeZCBHRqhxqoD tom.whitwell@digital.cabinet-office.gov.uk',


### PR DESCRIPTION
Tom W is no longer on RE GOV.UK and went to PaaS team and not Replatforming. He's also no longer on the oncall rota, so no longer needs access to GOV.UK AWS.

Rollout plan: the usual: merge, deploy Puppet in integration+staging, wait half an hour and see if it doesn't break, roll to prod.

See also alphagov/govuk-aws-data#813 and alphagov/govuk-user-reviewer#484.