### PR TITLE
Cleanup: remove disused user class for Tom W.

### DIFF
--- a/modules/users/manifests/tomwhitwell.pp
+++ b/modules/users/manifests/tomwhitwell.pp
@@ -1,9 +1,0 @@
-# Creates the tomwhitwell user
-class users::tomwhitwell {
-  govuk_user { 'tomwhitwell':
-    ensure   => absent,
-    fullname => 'Tom Whitwell',
-    email    => 'tom.whitwell@digital.cabinet-office.gov.uk',
-    ssh_key  => 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILb/0/9cf3s7x+LlOC+4xWJ0ogzWUInOeZCBHRqhxqoD tom.whitwell@digital.cabinet-office.gov.uk',
-  }
-}


### PR DESCRIPTION
See #10864.

Rollout: this needs to wait until #10864 and alphagov/govuk-secrets#1095 are in prod.