### PR TITLE
Switch Email Alert API Notify recipients in integration and staging

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -537,10 +537,6 @@ govuk::apps::email_alert_api::db_password: "%{hiera('govuk::apps::email_alert_ap
 govuk::apps::email_alert_api::nagios_memory_warning: 2400
 govuk::apps::email_alert_api::nagios_memory_critical: 3000
 govuk::apps::email_alert_api::unicorn_worker_processes: '10'
-govuk::apps::email_alert_api::govuk_notify_recipients:
-  - ben.thorner@digital.cabinet-office.gov.uk
-  - jessica.jones@digital.cabinet-office.gov.uk
-  - kevin.dew@digital.cabinet-office.gov.uk
 
 govuk::apps::email_alert_frontend::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::email_alert_frontend::redis_port: "%{hiera('sidekiq_port')}"

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -32,6 +32,8 @@ govuk::apps::content_publisher::govuk_notify_template_id: "759acac6-da53-4a19-b5
 govuk::apps::collections_publisher::govuk_notify_template_id: "759acac6-da53-4a19-b591-b7538c7c39de"
 govuk::apps::collections_publisher::publish_without_2i_email: "mainstream-publisher-notifications-integration@digital.cabinet-office.gov.uk"
 govuk::apps::email_alert_api::govuk_notify_template_id: '1fc69d3a-09a2-40f9-852b-03f6fcef5340'
+govuk::apps::email_alert_api::govuk_notify_recipients:
+  - email-alert-api-integration@digital.cabinet-office.gov.uk
 govuk::apps::email_alert_frontend::subscription_management_enabled: true
 govuk::apps::feedback::govuk_notify_reply_to_id: 'fee22233-2f28-4b0b-8b6c-4410979f2275'
 govuk::apps::feedback::govuk_notify_template_id: 'eb9ba220-7d74-4aab-975a-bdbe718f69a3'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -162,6 +162,8 @@ govuk::apps::content_store::performance_platform_spotlight_url: 'https://perform
 
 govuk::apps::email_alert_api::db::backend_ip_range: '10.12.3.0/24'
 govuk::apps::email_alert_api::govuk_notify_template_id: '2844a647-6bf1-4b01-a25c-569d2cc00849'
+govuk::apps::email_alert_api::govuk_notify_recipients:
+  - email-alert-api-staging@digital.cabinet-office.gov.uk
 govuk::apps::email_alert_frontend::subscription_management_enabled: true
 govuk::apps::feedback::govuk_notify_reply_to_id: 'd1f54751-80a8-420a-9077-d34c7d6cc734'
 govuk::apps::feedback::govuk_notify_template_id: '8a8d98c0-42c8-4f56-b61f-77c89417a171'


### PR DESCRIPTION
Trello: https://trello.com/c/l4ahPmzS/644-switch-integration-staging-to-send-emails-to-a-google-group

This changes the addresses that can receive Notify emails to be Google
group addresses rather than individuals, this has been done to simplify
the management of recipients. Previously when someone wanted to test
Email Alert API email sending they would need to add their email into
Notify and into puppet before testing, with this change they can test
immediately by viewing the group and using the group email address for
their test mails.