### PR TITLE
Significantly increase Email Alert API latency alerts

### DIFF
--- a/modules/govuk/manifests/apps/email_alert_api/checks.pp
+++ b/modules/govuk/manifests/apps/email_alert_api/checks.pp
@@ -12,16 +12,16 @@ class govuk::apps::email_alert_api::checks(
       latency_critical => '600'; # 10 minutes
 
     'send_email_immediate':
-      latency_warning  => '1200', # 20 minutes
-      latency_critical => '1800'; # 30 minutes
+      latency_warning  => '43200', # 12 hours
+      latency_critical => '86400'; # 24 hours
 
     'send_email_immediate_high':
-      latency_warning  => '300', # 5 minutes
-      latency_critical => '600'; # 10 minutes
+      latency_warning  => '10800', # 3 hours
+      latency_critical => '86400'; # 24 hours
 
     'send_email_digest':
-      latency_warning  => '3600', # 60 minutes
-      latency_critical => '5400'; # 90 minutes
+      latency_warning  => '43200', # 12 hours
+      latency_critical => '86400'; # 24 hours
   }
 
   @@icinga::check::graphite { 'email-alert-api-unprocessed-content-changes':


### PR DESCRIPTION
Trello: https://trello.com/c/il1TsI3e/658-tweak-alert-latency-thresholds-for-email-alert-api-sidekiq-queues

In the past these alerts have been prone to alerting when the system is
busy, yet healthy, resulting in it being unclear whether a support engineer
should take any action. This has lead to these alerts being largely
ignored.

This commit changes the tolerance of latency to be significantly
greater. We chose these numbers by considering what the effects to users
are and what could cause the alert. The numbers are purposely high to
reduce the risk, as much as possible, that these alerts go off when the
system is busy yet otherwise healthy. We reflected, as there are no
guarantees or assurances of the time frame that emails would be sent in,
that in most cases getting an email delayed by hours is not a big concern.
Thus these alerts are based around the concern of what happens if these
queues get so big that the system is perpetually backed up. This is why 24
hours was chosen as a critical level as reaching this point would indicate
that the queue has not been worked through even when the system is quiet
(night time and/or out of office hours).

As there is a high priority queue, and that we expect work on that to be
completed quicker, the warning alert for that is much lower than
the other queues. This is so that we find out quicker for this queue than
there is significant latency. Three hours was chosen as this seemed a
reasonable amount of time to allow for a lot of email to send. We know
in the past that this queue can become quite backlogged if there is a
lot of concurrent Travel Advice publishing, so this is chosen to
hopefully cater for most regular publishing scenarios.

These changes were due to be made as part of a broader strategy to
evolve the Email Alert API alerting, however these unfortunately have
been paused due to the team being paused. The changes in this commit
were intended to be paired with much closer monitoring of individual
workers for failures, so that these alerts only act as a secondary
layer once systemic failure is ruled out. Since that hasn't occurred
it means this leaves the system alerting is somewhat vulnerable to not
alerting quickly if there is systemic failure. However, I'm not sure the
previous iteration of these alerts helped this much.