### PR TITLE
Block finder-frontend cookies when feature flag is disabled

### DIFF
--- a/lib/puppet-lint/plugins/check_hiera.rb
+++ b/lib/puppet-lint/plugins/check_hiera.rb
@@ -69,6 +69,9 @@ PuppetLint.new_check(:hiera_explicit_lookup) do
     'wildcard_publishing_key',
     'www_crt',
     'www_key',
+
+    # accounts feature flag, a temporary thing
+    'govuk::apps::finder_frontend::feature_flag_accounts'
   ]
   def check
     tokens.select { |t| t.type == :NAME and t.value == 'hiera' }.each do |func_token|

--- a/modules/varnish/manifests/config.pp
+++ b/modules/varnish/manifests/config.pp
@@ -21,6 +21,7 @@ class varnish::config(
   include varnish::restart
 
   $app_domain  = hiera('app_domain')
+  $allow_finder_frontend_cookies = hiera('govuk::apps::finder_frontend::feature_flag_accounts', false)
 
   file { '/etc/default/varnish':
     ensure  => file,

--- a/modules/varnish/templates/default.vcl.erb
+++ b/modules/varnish/templates/default.vcl.erb
@@ -87,7 +87,7 @@ sub vcl_recv {
   #   - frontend (for sessions across funding registration form)
   #   - finder-frontend (for gov.uk accounts experiment on the transition checker)
   #   - smart answers coronavirus find support flow
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/transition-check" && req.url !~ "^/brexit-eu-funding" && req.url !~ "^/find-coronavirus-support/s")
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" <% if @allow_finder_frontend_cookies %>&& req.url !~ "^/transition-check" <% end %>&& req.url !~ "^/brexit-eu-funding" && req.url !~ "^/find-coronavirus-support/s")
   {
     unset req.http.Cookie;
   }
@@ -124,7 +124,7 @@ sub vcl_fetch {
 
   <% if @strip_cookies %>
   # Strip cookies from outbound requests. Corresponding rule in vcl_recv{}
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/transition-check" && req.url !~ "^/brexit-eu-funding" && req.url !~ "^/find-coronavirus-support/s") {
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" <% if @allow_finder_frontend_cookies %>&& req.url !~ "^/transition-check" <% end %>&& req.url !~ "^/brexit-eu-funding" && req.url !~ "^/find-coronavirus-support/s") {
     unset beresp.http.Set-Cookie;
   }
   <% end %>


### PR DESCRIPTION
Rails sets a session cookie on every request, even if there's nothing
to put in the session.  This harms cacheability of pages.  Since the
finder-frontend accounts stuff is hidden behind a feature flag, we
want disabling that feature flag to also disable the cookies.

This has the added benefit of sticking a reference to the feature flag
in this code, so we don't forget to remove it when the transition
checker eventually goes away.