### PR TITLE
Disable pager-duty notification in carrenza production

### DIFF
--- a/hieradata/production.yaml
+++ b/hieradata/production.yaml
@@ -349,7 +349,7 @@ monitoring::checks::aws_iam_key::region: 'eu-west-1'
 monitoring::checks::aws_iam_key::max_aws_iam_key_age: 90
 monitoring::checks::smokey::environment: 'production'
 monitoring::checks::smokey::ensure: 'absent'
-monitoring::contacts::notify_pager: true
+monitoring::contacts::notify_pager: false
 monitoring::contacts::notify_slack: true
 monitoring::contacts::slack_channel: '#govuk-alerts'
 monitoring::contacts::slack_username: 'Production (Carrenza)'


### PR DESCRIPTION
The only thing still running in carrenza production is performance
 platform. This service will not be monitored out of hours.