### PR TITLE
Enable CD for Manuals Publisher

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1123,6 +1123,7 @@ govuk_jenkins::jobs::deploy_app_downstream::applications:
   government-frontend: {}
   info-frontend: {}
   manuals-frontend: {}
+  manuals-publisher: {}
   publisher: {}
   smartanswers:
     repository: 'smart-answers'


### PR DESCRIPTION
Dependent on:

- https://github.com/alphagov/smokey/pull/756
- https://github.com/alphagov/govuk-saas-config/pull/72
- https://github.com/alphagov/govuk-docker/pull/441
- https://github.com/alphagov/manuals-publisher/pull/1688
- https://github.com/alphagov/manuals-publisher/pull/1689