### PR TITLE
Enable Continuous Deployment for content-data-api

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1119,6 +1119,7 @@ govuk_jenkins::jobs::deploy_app_downstream::applications:
   authenticating-proxy: {}
   bouncer: {}
   content-data-admin: {}
+  content-data-api: {}
   content-publisher: {}
   finder-frontend: {}
   government-frontend: {}


### PR DESCRIPTION
Criteria for enabling continuous deployment has been met by

[Enhanced content-data-api healthchecks](https://github.com/alphagov/content-data-api/pull/1557)
[Smokey test](https://github.com/alphagov/smokey/pull/758)

Co-authored-by: Rebecca Pearce rebecca.pearce@digital.cabinet-office.gov.uk