### PR TITLE
Enable Continuous Deployment for HMRC Manuals API

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1121,6 +1121,7 @@ govuk_jenkins::jobs::deploy_app_downstream::applications:
   content-publisher: {}
   finder-frontend: {}
   government-frontend: {}
+  hmrc-manuals-api: {}
   info-frontend: {}
   manuals-frontend: {}
   manuals-publisher: {}


### PR DESCRIPTION
Dependent on:

- https://github.com/alphagov/smokey/pull/759
- https://github.com/alphagov/govuk-saas-config/pull/74
- https://github.com/alphagov/hmrc-manuals-api/pull/544