### PR TITLE
Enable continuous deployment on content-data-admin

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1118,6 +1118,7 @@ govuk_jenkins::jobs::deploy_app::applications: *deployable_applications
 govuk_jenkins::jobs::deploy_app_downstream::applications:
   authenticating-proxy: {}
   bouncer: {}
+  content-data-admin: {}
   content-publisher: {}
   finder-frontend: {}
   government-frontend: {}


### PR DESCRIPTION
The [criteria for enabling CD](https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#safety-checks) have been met.

These are the PRs involved:
 - https://github.com/alphagov/smokey/pull/757
 - https://github.com/alphagov/govuk-saas-config/pull/75
 - https://github.com/alphagov/content-data-admin/pull/890
 - https://github.com/alphagov/content-data-admin/pull/891

 Trello: https://trello.com/c/ILpSOFhq/201-enable-cd-for-quick-win-and-possible-quick-win-apps