### PR TITLE
Enable CD on short_url_manager

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1126,6 +1126,7 @@ govuk_jenkins::jobs::deploy_app_downstream::applications:
   manuals-frontend: {}
   manuals-publisher: {}
   publisher: {}
+  short-url-manager: {}
   smartanswers:
     repository: 'smart-answers'
   travel-advice-publisher: {}


### PR DESCRIPTION
After meeting the requirements of:
[Improving healthchecks](https://github.com/alphagov/short-url-manager/pull/544)
[Adding Smokey healthcheck tests](https://github.com/alphagov/smokey/pull/760)
[And requiring prod access to merge PRs](https://github.com/alphagov/govuk-saas-config/pull/76)

This app should be ready to be continuously deployed

Co-Authored-By: Edward Kerry <edward.kerry@digital.cabinet-office.gov.uk>