### PR TITLE
Enable Continuous Deployment for Service Manual Publisher

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1129,6 +1129,7 @@ govuk_jenkins::jobs::deploy_app_downstream::applications:
   manuals-publisher: {}
   publisher: {}
   short-url-manager: {}
+  service-manual-publisher: {}
   smartanswers:
     repository: 'smart-answers'
   travel-advice-publisher: {}


### PR DESCRIPTION
Depends on:

https://github.com/alphagov/service-manual-publisher/pull/875
https://github.com/alphagov/govuk-saas-config/pull/77
https://github.com/alphagov/smokey/pull/761
https://github.com/alphagov/service-manual-publisher/pull/876