### PR TITLE
Enable CD for Email Alert Frontend

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1121,6 +1121,7 @@ govuk_jenkins::jobs::deploy_app_downstream::applications:
   content-data-admin: {}
   content-data-api: {}
   content-publisher: {}
+  email-alert-frontend: {}
   finder-frontend: {}
   government-frontend: {}
   hmrc-manuals-api: {}


### PR DESCRIPTION
We want to enable CD for Email Alert Frontend now we've met the CD
requirements found stated in the [RFC]. We've achieved this by creating
a test for [smokey] and by [updating the app's healthcheck].

Dependant on:

- [x]  https://github.com/alphagov/smokey/pull/763 

- [x] https://github.com/alphagov/email-alert-frontend/pull/936

- [x] https://github.com/alphagov/govuk-saas-config/pull/78

[RFC]: https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#safety-checks
[smokey]: https://github.com/alphagov/smokey/pull/763
[updating the app's healthcheck]: https://github.com/alphagov/email-alert-frontend/pull/936
