### PR TITLE
Set 17 day freshness threshold on smart answer report

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/smart_answers_broken_links_report.pp
+++ b/modules/govuk_jenkins/manifests/jobs/smart_answers_broken_links_report.pp
@@ -27,7 +27,7 @@ class govuk_jenkins::jobs::smart_answers_broken_links_report (
     @@icinga::passive_check { "${check_name}_${::hostname}":
       service_description => $service_description,
       host_name           => $::fqdn,
-      freshness_threshold => 86400,
+      freshness_threshold => 1468800, # every 17 days
       action_url          => $job_url,
     }
   }


### PR DESCRIPTION
This runs every 15 days, so we want the freshness threshold to reflect that.