### PR TITLE
Enable Continuous Deployment for Collections Publisher

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1118,6 +1118,7 @@ govuk_jenkins::jobs::deploy_app::applications: *deployable_applications
 govuk_jenkins::jobs::deploy_app_downstream::applications:
   authenticating-proxy: {}
   bouncer: {}
+  collections-publisher: {}
   content-data-admin: {}
   content-data-api: {}
   content-publisher: {}


### PR DESCRIPTION
I believe the [appropriate criteria](https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#safety-checks) has been met by:

- https://github.com/alphagov/govuk-saas-config/pull/79
- https://github.com/alphagov/smokey/pull/764
- https://github.com/alphagov/collections-publisher/pull/1199 and https://github.com/alphagov/collections-publisher/pull/1203

Trello: https://trello.com/c/ILpSOFhq/201-enable-cd-for-quick-win-and-possible-quick-win-apps