### PR TITLE
Log Varnish as JSON

### DIFF
--- a/modules/varnish/files/etc/default/varnishncsa
+++ b/modules/varnish/files/etc/default/varnishncsa
@@ -6,3 +6,4 @@
 #
 # NCSA log format, to be used by HTTP log analyzers
 VARNISHNCSA_ENABLED=1
+DAEMON_OPTS="${DAEMON_OPTS} -F {\"timestamp\":\"%{%Y-%m-%dT%H:%M:%S%z}t\",\"remote_user\":\"%u\",\"http_x_forwarded_for\":\"%{X-Forwarded-For}i\",\"hit_miss\":\"%{Varnish:hitmiss}x\",\"bytes\":%b,\"duration_usec\":%D,\"status\":%s,\"request\":\"%r\",\"http_host\":\"%{host}i\",\"request_method\":\"%m\",\"time_first_byte\":\"%{Varnish:time_firstbyte}x\",\"handling\":\"%{Varnish:handling}x\",\"http_referrer\":\"%{Referrer}i\",\"http_user_agent\":\"%{User-agent}i\",\"govuk_request_id\":\"%{GOVUK-Request-Id}i\"}"

--- a/modules/varnish/manifests/monitoring.pp
+++ b/modules/varnish/manifests/monitoring.pp
@@ -20,6 +20,7 @@ class varnish::monitoring {
   @filebeat::prospector { 'varnishncsa':
     paths  => ['/var/log/varnish/varnishncsa.log'],
     fields => {'application' => 'varnish'},
+    json   => true,
   }
 
   @@icinga::check { "check_varnish_running_${::hostname}":


### PR DESCRIPTION
Use JSON logging to give better visibility in the ELK Stack, also log GOVUK-Request-Id to enable request tracking.

An example log line
```json
{
  "timestamp": "2020-12-16T15:04:01+0000",
  "remote_user": "",
  "http_x_forwarded_for": "34.253.57.8, 157.52.119.43, 34.253.57.8, 34.253.57.8, 34.253.57.8, 18.202.183.143, 34.253.57.8",
  "hit_miss": "miss",
  "bytes": 10861,
  "duration_usec": 0.080122,
  "status": 200,
  "request": "GET http://www-origin.integration.publishing.service.gov.uk/licence-finder?smokey_cachebust=0.8989075376209948 HTTP/1.0",
  "http_host": "www-origin.integration.publishing.service.gov.uk",
  "request_method": "GET",
  "time_first_byte": "0.078780890",
  "handling": "miss",
  "http_referrer": "-",
  "http_user_agent": "Smokey Test / Ruby",
  "govuk_request_id": "ef70b84c-ea01-40f1-8772-1bd3cab2c235"
}
  ```

and how it's rendered in Kibana

```json
{
  "_index": "filebeat-2020.12.16",
  "_type": "log",
  "_id": "AXZsFFwi3GD2wQuo8PRF",
  "_version": 1,
  "_score": null,
  "_source": {
    "request": "GET http://www-origin.integration.publishing.service.gov.uk/licence-finder?smokey_cachebust=0.8989075376209948 HTTP/1.0",
    "govuk_request_id": "ef70b84c-ea01-40f1-8772-1bd3cab2c235",
    "source": "/var/log/varnish/varnishncsa.log",
    "request_method": "GET",
    "type": "log",
    "http_host": "www-origin.integration.publishing.service.gov.uk",
    "http_user_agent": "Smokey Test / Ruby",
    "remote_user": "",
    "beat": {
      "hostname": "ip-10-1-4-74",
      "name": "ip-10-1-4-74.eu-west-1.compute.internal",
      "version": "5.1.2"
    },
    "@version": "1",
    "host": "ip-10-1-4-74",
    "timestamp": "2020-12-16T15:04:01+0000",
    "hit_miss": "miss",
    "offset": 392502141,
    "duration_usec": 0.080122,
    "input_type": "log",
    "time_first_byte": "0.078780890",
    "tags": [
      "beats_input_raw_event"
    ],
    "@timestamp": "2020-12-16T15:04:01.319Z",
    "application": "varnish",
    "bytes": 10861,
    "http_x_forwarded_for": "34.253.57.8, 157.52.119.43, 34.253.57.8, 34.253.57.8, 34.253.57.8, 18.202.183.143, 34.253.57.8",
    "http_referrer": "-",
    "handling": "miss",
    "status": 200
  },
  "fields": {
    "@timestamp": [
      1608131041319
    ]
  },
  "sort": [
    1608131041319
  ]
}
```