### PR TITLE
Tweak email send attempts dashboard graph

### DIFF
--- a/modules/grafana/files/dashboards/email_alert_api_technical.json
+++ b/modules/grafana/files/dashboards/email_alert_api_technical.json
@@ -161,31 +161,26 @@
           "steppedLine": false,
           "targets": [
             {
-              "hide": true,
+              "hide": false,
               "refId": "A",
-              "target": "sumSeries(summarize(stats_counts.govuk.app.email-alert-api.*.notify.email_send_request.*, '30s', 'sum', false))",
+              "target": "alias(consolidateBy(sumSeries(summarize(stats_counts.govuk.app.email-alert-api.*.notify.email_send_request.*, '30s', 'sum', false)), 'max'), 'notify estimated rate')",
               "textEditor": false
             },
             {
-              "hide": true,
+              "hide": false,
               "refId": "C",
-              "target": "sumSeries(summarize(stats_counts.govuk.app.email-alert-api.*.send_email_worker.rate_limit_exceeded, '30s', 'sum', false))",
+              "target": "alias(consolidateBy(sumSeries(summarize(stats_counts.govuk.app.email-alert-api.*.pseudo.email_send_request, '30s', 'sum', false)), 'max'), 'pseudo estimated rate')",
               "textEditor": false
             },
             {
               "refId": "B",
               "target": "alias(constantLine(10500), 'per minute rate limit')"
-            },
-            {
-              "refId": "D",
-              "target": "alias(consolidateBy(sumSeries(#A, #C), 'sum'), 'per minute rate')",
-              "targetFull": "alias(consolidateBy(sumSeries(sumSeries(summarize(stats_counts.govuk.app.email-alert-api.*.notify.email_send_request.*, '30s', 'sum', false)), sumSeries(summarize(stats_counts.govuk.app.email-alert-api.*.send_email_worker.rate_limit_exceeded, '30s', 'sum', false))), 'sum'), 'per minute rate')"
             }
           ],
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Email Send Attempts (per 30s)",
+          "title": "Email Send Attempts",
           "tooltip": {
             "shared": true,
             "sort": 0,


### PR DESCRIPTION
Previously this had an additional metric to cope with sent email
stats being a combination of those successfully sent, and those
that were rate limited; this is no longer the case [1].

This also adds metrics for pseudo-sent emails, which are in the
majority in Integration and Staging, as well as:

- Removing the misleading graph title (the 30s is just a way to
approximate the per minute rate).

- Using a "max" consolidation, so the graph does not appear
alarming if the viewer zooms out the time range. Using "max" still
means we surface any worrying values.

[1]: https://github.com/alphagov/email-alert-api/commit/294ce78dd36b95347db551a580d69eeda932b229#diff-2117167ba6330613e0c2bfe4df9385ddfa9d6a2bdf363f4e72cc91222ff67d3aL47