### PR TITLE
Stop Varnish from removing GOVUK-Request-Id

### DIFF
--- a/modules/varnish/templates/default.vcl.erb
+++ b/modules/varnish/templates/default.vcl.erb
@@ -19,7 +19,6 @@ acl purge_acl {
 }
 
 sub vcl_recv {
-  unset req.http.GOVUK-Request-Id;
   unset req.http.GOVUK-Original-Url;
   set req.http.GOVUK-Original-Url = req.url;
 


### PR DESCRIPTION
GOV.UK-Request-Id is now set by the CDN so there's no reason to remove it in the middle of the stack.