### PR TITLE
Show line for queued digest emails

### DIFF
--- a/modules/grafana/files/dashboards/email_alert_api_technical.json
+++ b/modules/grafana/files/dashboards/email_alert_api_technical.json
@@ -548,6 +548,12 @@
               "refId": "C",
               "target": "aliasByNode(consolidateBy(maxSeries(summarize(stats.gauges.govuk.app.email-alert-api.*.workers.queues.send_email_immediate_high.enqueued, '$Interval', 'max', false)), 'max'), 8, 9)",
               "textEditor": false
+            },
+            {
+              "hide": false,
+              "refId": "D",
+              "target": "aliasByNode(consolidateBy(maxSeries(summarize(stats.gauges.govuk.app.email-alert-api.*.workers.queues.send_email_digest.enqueued, '$Interval', 'max', false)), 'max'), 8, 9)",
+              "textEditor": false
             }
           ],
           "thresholds": [],


### PR DESCRIPTION
These are on a separate queue to other emails, but nonetheless still
represent work the system is doing.