### PR TITLE
Update Redis cache CPU alert

### DIFF
--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_cache_cpu
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_cache_cpu
@@ -1,8 +1,8 @@
 #!/opt/python2.7/bin/python
 
 ##########################################################
-# This script will cpture and report on AWS ElastiCache #
-# CPUUtilization         	                         #
+# This script will capture and report on AWS ElastiCache #
+# EngineCPUUtilization         	                         #
 ##########################################################
 
 ###########################################################
@@ -12,7 +12,7 @@
 # 1) Check whether a valid AWS region is specified        #
 # 2) Check whether the redis instance ID provided exisits.#
 # 3) If 1 and 2 are correct, check whether the average    #
-#    CPUUtilization is in the WARNING or CRITICAL state.  #
+#    EngineCPUUtilization is in the WARNING or CRITICAL state.  #
 #    Else, mark the status as OK.                         #
 ###########################################################
 
@@ -45,7 +45,7 @@
 #                                                                             			#
 #                                                                             			#
 # The result should look like the example below.                              			#
-# OK: Current AWS:ElastiCache CPU Utilization for blue-backend-redis-002 is 0.666759284986 %	#
+# OK: Current AWS:ElastiCache Engine CPU Utilization for blue-backend-redis-002 is 0.666759284986 %	#
 #################################################################################################
 
 ####################
@@ -64,8 +64,8 @@ import datetime
 #################################
 parser = argparse.ArgumentParser()
 parser.add_argument("-r","--region", type=str, choices=['us-east-1','eu-west-1','eu-west-2'], help="AWS region to check")
-parser.add_argument("-w","--warning", type=float, help="Percentage at which to raise a warning alert (80)", default=80)
-parser.add_argument("-c","--critical", type=float, help="Percentage at which to raise a critical alert (90)", default=90)
+parser.add_argument("-w","--warning", type=float, help="Percentage at which to raise a warning alert (90)", default=90)
+parser.add_argument("-c","--critical", type=float, help="Percentage at which to raise a critical alert (95)", default=95)
 parser.add_argument("-i","--instanceid", type=str, help="Instanceid", default=0)
 args = parser.parse_args()
 
@@ -139,8 +139,8 @@ end = datetime.datetime.now()
 #          output (very important. Nagios will only take one result)   		        #
 # 'start'- This will pass the start time.                               		#
 # 'end'  - This will pass the end time.                                 		#
-# 'CPUUtilization' - This is the matric that we are asking for from     		#
-#                    CloudWatch.                                        		#
+# 'EngineCPUUtilization' - This is the metric that we are asking for from     		#
+#                          CloudWatch.                                        		#
 # 'AWS/AWS/ElastiCache' - This is the CloudWatch space/area where RDS stats reside. 	#
 # 'Average' - We are defining that we won't the average for the matric. 		#
 # 'CacheClusterId' - The unique identifier which we use to query. 			#
@@ -149,7 +149,7 @@ data = cw_conn.get_metric_statistics(
    300,
    start,
    end,
-   'CPUUtilization',
+   'EngineCPUUtilization',
    'AWS/ElastiCache',
    'Average',
    {'CacheClusterId': [args.instanceid]},
@@ -205,10 +205,10 @@ average = item["Average"]
 # 3) Compare the check vs actual.                       #
 #########################################################
 if float(average) > args.critical:
-  print "CRITICAL: Current AWS:ElastiCache CPU Utilization for {} is {} %".format(args.instanceid, average)
+  print "CRITICAL: Current AWS:ElastiCache Engine CPU Utilization for {} is {} %".format(args.instanceid, average)
   sys.exit(2)
 elif float(average) > args.warning:
-  print "WARNING: Current AWS:ElastiCache CPU Utilization for {} is {} %".format(args.instanceid, average)
+  print "WARNING: Current AWS:ElastiCache Engine CPU Utilization for {} is {} %".format(args.instanceid, average)
   sys.exit(1)
 else:
-  print "OK: Current AWS:ElastiCache CPU Utilization for {} is {} %".format(args.instanceid, average)
+  print "OK: Current AWS:ElastiCache Engine CPU Utilization for {} is {} %".format(args.instanceid, average)

--- a/modules/monitoring/manifests/checks/cache_config.pp
+++ b/modules/monitoring/manifests/checks/cache_config.pp
@@ -10,29 +10,29 @@
 # [*enabled*]
 #   Should we enable the monitoring check?
 #
-# [*cpu_warning*]
-#  This parameter defines the CPU usage percentage at which a warning is raised. 
+# [*engine_cpu_warning*]
+#  This parameter defines the engine CPU usage percentage at which a warning is raised.
 #
-# [*critical*]
-#  This parameter defines the CPU usage percentage at which a critcal alert is raised.
+# [*engine_cpu_critical*]
+#  This parameter defines the engine CPU usage percentage at which a critcal alert is raised.
 #
 # [*memory_warning]
 #  This parameter defines the amount of free memory in Gigabytes for which a warning alert will be raised.
 #
 # [*memory_critical]
-#  This parameter defines the amount of free memory in Gigabytes for which a critical alert will be raised. 
+#  This parameter defines the amount of free memory in Gigabytes for which a critical alert will be raised.
 #
 define monitoring::checks::cache_config (
   $region = undef,
-  $cpu_warning = 80,
-  $cpu_critical = 90,
+  $engine_cpu_warning = 90,
+  $engine_cpu_critical = 95,
   $memory_warning = 20,
   $memory_critical = 10,
   ){
   icinga::check { "check_aws_cache_cpu-${title}":
-    check_command       => "check_aws_cache_cpu!${region}!${cpu_warning}!${cpu_critical}!${::aws_stackname}-${title}",
+    check_command       => "check_aws_cache_cpu!${region}!${engine_cpu_warning}!${engine_cpu_critical}!${::aws_stackname}-${title}",
     host_name           => $::fqdn,
-    service_description => "${title} - AWS ElastiCache CPU Utilization",
+    service_description => "${title} - AWS ElastiCache Engine CPU Utilization",
     notes_url           => monitoring_docs_url(aws-cache-cpu),
     require             => Icinga::Check_config['check_aws_cache_cpu'],
   }


### PR DESCRIPTION
Previously the ElastiCache CPU Utilization alert wasn't really useful as
it would never fire due to the thresholds being too high (80% and 90%).

The reason being is that 'CPUUtilization' would return how much CPU each
Redis process is using as a percentage versus whats on the machine. As
each Redis process (replica and primary) can only use one CPU at a time
then the 'CPUUtilization' metric for each node will never cross 50% as
each machine has two CPUs.

The 'EngineCPUUtilization' metric however measures how much CPU the
Redis process is using out of what it actually has available instead of
whats on the machine. This gives a more realistic measurement on the CPU
usage of Redis.

The new thresholds seems reasonable - 90% warn and 95% critical
(averaged over 5 mins) as we've only briefly crossed the 90% threshold
(90.7% for the primary) once in the last 4 weeks under normal operating 
conditions in production.

These thresholds would've alerted us of the system struggling during a recent 
load test for Email Alert API as the system was using consistently 98%/99% 
of the 'engine' CPU for hours which went unnoticed.

## Production Redis Engine CPU usage over the last 4 weeks

<img width="1266" alt="Screenshot 2020-12-18 at 10 58 33" src="https://user-images.githubusercontent.com/24479188/102616883-2d596100-4130-11eb-9435-600732cf2595.png">

## Under a load test in Staging causing degraded performance 

<img width="954" alt="Screenshot 2020-12-18 at 12 27 30" src="https://user-images.githubusercontent.com/24479188/102616901-31857e80-4130-11eb-9987-e9db1d9497e2.png">
