### PR TITLE
Add an env var to turn on unreleased features in collections-publisher

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -31,6 +31,7 @@ govuk::apps::content_publisher::email_address_override: "content-publisher-notif
 govuk::apps::content_publisher::govuk_notify_template_id: "759acac6-da53-4a19-b591-b7538c7c39de"
 govuk::apps::collections_publisher::govuk_notify_template_id: "759acac6-da53-4a19-b591-b7538c7c39de"
 govuk::apps::collections_publisher::publish_without_2i_email: "mainstream-publisher-notifications-integration@digital.cabinet-office.gov.uk"
+govuk::apps::collections_publisher::unreleased_features_enabled: true
 govuk::apps::email_alert_api::govuk_notify_template_id: '1fc69d3a-09a2-40f9-852b-03f6fcef5340'
 govuk::apps::email_alert_api::govuk_notify_recipients:
   - email-alert-api-integration@digital.cabinet-office.gov.uk

--- a/modules/govuk/manifests/apps/collections_publisher.pp
+++ b/modules/govuk/manifests/apps/collections_publisher.pp
@@ -68,6 +68,9 @@
 # [*publish_without_2i_email*]
 #   The email address which will receive publishing without 2i alerts.
 #
+# [*unreleased_features_enabled*]
+#   Whether unreleased features should be enabled
+#
 class govuk::apps::collections_publisher(
   $ensure = 'present',
   $port,
@@ -88,6 +91,7 @@ class govuk::apps::collections_publisher(
   $govuk_notify_api_key = undef,
   $govuk_notify_template_id = undef,
   $publish_without_2i_email = undef,
+  $unreleased_features_enabled = false,
 ) {
   $app_name = 'collections-publisher'
 
@@ -152,6 +156,14 @@ class govuk::apps::collections_publisher(
       "${title}-PUBLISH_WITHOUT_2I_EMAIL":
         varname => 'PUBLISH_WITHOUT_2I_EMAIL',
         value   => $publish_without_2i_email;
+    }
+
+    if $unreleased_features_enabled {
+      govuk::app::envvar {
+        "${title}-UNRELEASED_FEATURES":
+          varname => 'UNRELEASED_FEATURES',
+          value   => '1';
+      }
     }
 
     govuk::app::envvar::database_url { $app_name:


### PR DESCRIPTION
Add an env in collections-publisher to turn on unreleased features.

By default, unreleased features will be turned off in production, but turned on
in integration so that they can be tested.

Related to: https://github.com/alphagov/collections-publisher/pull/1192