### PR TITLE
Double unicorn workers for finder-frontend in staging.

### DIFF
--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -168,6 +168,7 @@ govuk::apps::email_alert_frontend::subscription_management_enabled: true
 govuk::apps::feedback::govuk_notify_reply_to_id: 'd1f54751-80a8-420a-9077-d34c7d6cc734'
 govuk::apps::feedback::govuk_notify_template_id: '8a8d98c0-42c8-4f56-b61f-77c89417a171'
 govuk::apps::finder_frontend::plek_account_manager_uri: 'https://www.account.staging.publishing.service.gov.uk'
+govuk::apps::finder_frontend::unicorn_worker_processes: 12
 govuk::apps::frontend::govuk_notify_template_id: '2844a647-6bf1-4b01-a25c-569d2cc00849'
 govuk::apps::govuk_crawler_worker::disable_during_data_sync: true
 govuk::apps::hmrc_manuals_api::publish_topics: false


### PR DESCRIPTION
Aim is to utilise available RAM to increase the number of concurrent connections that we can handle during load spikes. We believe this has been a bottleneck previously.