### PR TITLE
Temporarily re-add the 'marksutton' user

### DIFF
--- a/modules/users/manifests/chrisfarmiloe.pp
+++ b/modules/users/manifests/chrisfarmiloe.pp
@@ -1,0 +1,6 @@
+# Creates the chrisfarmiloe user - temporarily - so we can remove their home dir
+class users::chrisfarmiloe {
+  govuk_user { 'chrisfarmiloe':
+    ensure   => absent,
+  }
+}

--- a/modules/users/manifests/isabelllong.pp
+++ b/modules/users/manifests/isabelllong.pp
@@ -1,0 +1,6 @@
+# Creates the isabelllong user - temporarily - so we can remove their home dir
+class users::isabelllong {
+  govuk_user { 'isabelllong':
+    ensure   => absent,
+  }
+}

--- a/modules/users/manifests/marksutton.pp
+++ b/modules/users/manifests/marksutton.pp
@@ -1,0 +1,6 @@
+# Creates the marksutton user - temporarily - so we can remove their home dir
+class users::marksutton {
+  govuk_user { 'marksutton':
+    ensure   => absent,
+  }
+}

--- a/modules/users/manifests/sebastianschmieschek.pp
+++ b/modules/users/manifests/sebastianschmieschek.pp
@@ -1,0 +1,6 @@
+# Creates the sebastianschmieschek user - temporarily - so we can remove their home dir
+class users::sebastianschmieschek {
+  govuk_user { 'sebastianschmieschek':
+    ensure   => absent,
+  }
+}

--- a/modules/users/spec/classes/users_spec.rb
+++ b/modules/users/spec/classes/users_spec.rb
@@ -23,7 +23,7 @@ def user_list
   Dir.glob("#{class_dir}/*.pp").collect { |user_manifest|
     user_manifest.gsub(/^#{class_dir}\/(.+)\.pp$/, '\1')
   }.delete_if { |username|
-    username == 'init' or username == 'null_user'
+    username == 'init' or username == 'null_user' or %w[chrisfarmiloe isabelllong marksutton sebastianschmieschek].include?(username)
   }
 end
 


### PR DESCRIPTION
Mark got removed in #10878, a little too quickly: we hadn't yet
applied an `ensure => absent` to their class as per the 'Remove
a user from Puppet' instructions:
https://docs.publishing.service.gov.uk/manual/removing-a-user-from-puppet.html

I can see that they still have a home directory on at least one
backend class machine on Integration, so we need to do a little
housekeeping. We'll temporarily add the user back to Puppet with
an `ensure => absent` instruction. The other properties don't seem
to be required:
https://github.com/alphagov/govuk-puppet/blob/master/modules/govuk_user/manifests/init.pp

When this is merged and Puppet is deployed, we should see the home
directory removed, and we can then revert this commit.

While I'm here, I spotted two other orphaned home directories on
Integration, so am applying the same fix to those users too.

Trello: https://trello.com/c/7ySrimBF/1058-leaver-mark-sutton