### PR TITLE
Change mapit pv to /dev/xvdf in integration

### DIFF
--- a/hieradata_aws/class/integration/mapit.yaml
+++ b/hieradata_aws/class/integration/mapit.yaml
@@ -2,5 +2,5 @@ postgresql::globals::postgis_version: '2.2'
 
 lv:
   data:
-    pv: '/dev/nvme1n1'
+    pv: '/dev/xvdf'
     vg: 'postgresql'


### PR DESCRIPTION
I've recycled the mapit machines in integration, and they all have a /dev/xvdf but no /dev/nvme1n1 ([like in production](https://github.com/alphagov/govuk-puppet/blob/master/hieradata_aws/class/mapit.yaml)).