### PR TITLE
Set new memory thresholds for search-api

### DIFF
--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -216,6 +216,8 @@ govuk::apps::search_api::sitemaps_bucket_name: 'govuk-production-sitemaps'
 govuk::apps::search_api::tensorflow_sagemaker_endpoint: 'govuk-production-search-ltr-endpoint'
 govuk::apps::search_api::enable_learning_to_rank: true
 govuk::apps::search_api::unicorn_worker_processes: "18"
+govuk::apps::search_api::nagios_memory_warning: 16000
+govuk::apps::search_api::nagios_memory_critical: 19000
 govuk::apps::service_manual_publisher::govuk_notify_template_id: "e00e89f5-b622-4dcb-8f30-e6c70231a940"
 govuk::apps::short_url_manager::govuk_notify_template_id: "e00e89f5-b622-4dcb-8f30-e6c70231a940"
 govuk::apps::short_url_manager::instance_name: 'production'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -201,6 +201,8 @@ govuk::apps::search_api::sitemaps_bucket_name: 'govuk-staging-sitemaps'
 govuk::apps::search_api::enable_learning_to_rank: true
 govuk::apps::search_api::tensorflow_sagemaker_endpoint: 'govuk-staging-search-ltr-endpoint'
 govuk::apps::search_api::unicorn_worker_processes: "18"
+govuk::apps::search_api::nagios_memory_warning: 9000
+govuk::apps::search_api::nagios_memory_critical: 10000
 govuk::apps::service_manual_publisher::govuk_notify_template_id: "112842bb-d8a4-4511-90de-57dc5c8f27ec"
 govuk::apps::short_url_manager::govuk_notify_template_id: "112842bb-d8a4-4511-90de-57dc5c8f27ec"
 govuk::apps::short_url_manager::instance_name: 'staging'


### PR DESCRIPTION
We're using a lot more unicorns now. I've set production with more headroom as the machine type is a lot larger and we expect to bump the number of unicorn workers there soon.