### PR TITLE
Increase safe values of nagios memory warnings

### DIFF
--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -140,8 +140,8 @@ define govuk::app::config (
   }
 
   # Check memory thresholds are approximately right
-  validate_integer($nagios_memory_warning, 12000, 100)
-  validate_integer($nagios_memory_critical, 14000, 200)
+  validate_integer($nagios_memory_warning, 20000, 100)
+  validate_integer($nagios_memory_critical, 22000, 200)
 
   # Use the International System of Units (SI) value of 1 million bytes in a MB
   # as it makes it simpler to evaluate memory usage when looking at our

--- a/modules/govuk/spec/defines/govuk__app__config_spec.rb
+++ b/modules/govuk/spec/defines/govuk__app__config_spec.rb
@@ -247,7 +247,7 @@ describe 'govuk::app::config', :type => :define do
       })}
 
       it 'raises an error' do
-        is_expected.to raise_error(Puppet::Error, /Expected 111000 to be smaller or equal to 12000/)
+        is_expected.to raise_error(Puppet::Error, /Expected 111000 to be smaller or equal to 20000/)
       end
     end
   end


### PR DESCRIPTION
Some of our servers can take more than this limit. 

In https://github.com/alphagov/govuk-puppet/pull/10895 I bumped the search values, as I didn't want the warning to kick in until we'd used half of the machine memory. Unfortunately, this was higher than this limit, which was invisible until I hit production.

Resolves a puppet run error: 

> Error 400 on SERVER: validate_integer(): Expected 16000 to be smaller or equal to 12000, got 16000. at /usr/share/puppet/production/current/modules/govuk/manifests/app/config.pp:143

I _think_ this is an arbitrary limit, to try to ensure that we don't have too many zeroes.