### PR TITLE
Quadruple the unicorn workers for finder_frontend in staging.

### DIFF
--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -167,7 +167,13 @@ govuk::apps::email_alert_api::govuk_notify_recipients:
 govuk::apps::email_alert_frontend::subscription_management_enabled: true
 govuk::apps::feedback::govuk_notify_reply_to_id: 'd1f54751-80a8-420a-9077-d34c7d6cc734'
 govuk::apps::feedback::govuk_notify_template_id: '8a8d98c0-42c8-4f56-b61f-77c89417a171'
+
 govuk::apps::finder_frontend::plek_account_manager_uri: 'https://www.account.staging.publishing.service.gov.uk'
+# https://github.com/alphagov/govuk-aws-data/pull/827
+govuk::apps::finder_frontend::unicorn_worker_processes: 24
+govuk::apps::finder_frontend::nagios_memory_warning: 10000
+govuk::apps::finder_frontend::nagios_memory_critical: 14000
+
 govuk::apps::frontend::govuk_notify_template_id: '2844a647-6bf1-4b01-a25c-569d2cc00849'
 govuk::apps::govuk_crawler_worker::disable_during_data_sync: true
 govuk::apps::hmrc_manuals_api::publish_topics: false

--- a/modules/govuk/manifests/apps/finder_frontend.pp
+++ b/modules/govuk/manifests/apps/finder_frontend.pp
@@ -58,19 +58,20 @@ class govuk::apps::finder_frontend(
 
   if $enabled {
     govuk::app { 'finder-frontend':
-      app_type                 => 'rack',
-      port                     => $port,
-      sentry_dsn               => $sentry_dsn,
-      health_check_path        => '/healthcheck.json',
-      json_health_check        => true,
-      log_format_is_json       => true,
-      asset_pipeline           => true,
-      asset_pipeline_prefixes  => ['assets/finder-frontend'],
-      nagios_memory_warning    => $nagios_memory_warning,
-      nagios_memory_critical   => $nagios_memory_critical,
-      unicorn_worker_processes => $unicorn_worker_processes,
-      cpu_warning              => 175,
-      cpu_critical             => 225,
+      app_type                       => 'rack',
+      port                           => $port,
+      sentry_dsn                     => $sentry_dsn,
+      health_check_path              => '/healthcheck.json',
+      json_health_check              => true,
+      log_format_is_json             => true,
+      asset_pipeline                 => true,
+      asset_pipeline_prefixes        => ['assets/finder-frontend'],
+      nagios_memory_warning          => $nagios_memory_warning,
+      nagios_memory_critical         => $nagios_memory_critical,
+      alert_when_file_handles_exceed => 4000,
+      unicorn_worker_processes       => $unicorn_worker_processes,
+      cpu_warning                    => 175,
+      cpu_critical                   => 225,
     }
   }
 


### PR DESCRIPTION
Also proportionally increase the thresholds for the Icinga memory "alerts", because these have some bizarre automation attached to them which helpfully kills the application process when the alert fires.

See alphagov/govuk-aws-data#827 for context.