### PR TITLE
Bump the Search API file open threshold

### DIFF
--- a/modules/govuk/manifests/apps/search_api.pp
+++ b/modules/govuk/manifests/apps/search_api.pp
@@ -153,22 +153,23 @@ class govuk::apps::search_api(
   }
 
   govuk::app { 'search-api':
-    app_type                 => 'rack',
-    port                     => $port,
-    sentry_dsn               => $sentry_dsn,
-    health_check_path        => '/healthcheck',
-    health_check_custom_doc  => true,
-    json_health_check        => true,
+    app_type                       => 'rack',
+    port                           => $port,
+    sentry_dsn                     => $sentry_dsn,
+    health_check_path              => '/healthcheck',
+    health_check_custom_doc        => true,
+    json_health_check              => true,
 
-    vhost_aliases            => ['search'],
+    vhost_aliases                  => ['search'],
 
-    log_format_is_json       => true,
-    nginx_extra_config       => '
+    log_format_is_json             => true,
+    nginx_extra_config             => '
     client_max_body_size 500m;
     ',
-    nagios_memory_warning    => $nagios_memory_warning,
-    nagios_memory_critical   => $nagios_memory_critical,
-    unicorn_worker_processes => $unicorn_worker_processes,
+    nagios_memory_warning          => $nagios_memory_warning,
+    nagios_memory_critical         => $nagios_memory_critical,
+    unicorn_worker_processes       => $unicorn_worker_processes,
+    alert_when_file_handles_exceed => 4000,
   }
 
   govuk::app::envvar::rabbitmq { 'search-api':


### PR DESCRIPTION
By default Icinga will raise a critical alert if the number of open file
handles for an app exceeds 500. By doubling the number of Search API
workers we soon hit that number.

From investigating, it doesn't seem that hitting that number is actually
representative of a problem. The user is allowed to have 16,384 files
open and it runs very few processes. I've therefore pushed it up to
4000. This number seems high enough that we won't see any sign of this
alert unless there is a huge increase in file usage. It is still rather
arbitrary - it reaching 4000 files is only a problem if there are other
processes by that user also opening lots of files. So I'm not really
sure if it's a very helpful alert to have.