### PR TITLE
Ramp up to 38 search-api unicorns in staging

### DIFF
--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -200,7 +200,7 @@ govuk::apps::search_api::relevancy_bucket_name: 'govuk-staging-search-relevancy'
 govuk::apps::search_api::sitemaps_bucket_name: 'govuk-staging-sitemaps'
 govuk::apps::search_api::enable_learning_to_rank: true
 govuk::apps::search_api::tensorflow_sagemaker_endpoint: 'govuk-staging-search-ltr-endpoint'
-govuk::apps::search_api::unicorn_worker_processes: "18"
+govuk::apps::search_api::unicorn_worker_processes: "36"
 govuk::apps::search_api::nagios_memory_warning: 9000
 govuk::apps::search_api::nagios_memory_critical: 10000
 govuk::apps::service_manual_publisher::govuk_notify_template_id: "112842bb-d8a4-4511-90de-57dc5c8f27ec"


### PR DESCRIPTION
Search-api is IO bound, so it's not using [anything like 25% CPU](https://grafana.staging.govuk.digital/dashboard/file/machine.json?refresh=1m&orgId=1&var-hostname=search*&var-cpmetrics=All&var-filesystem=All&var-disk=All&var-tcpconnslocal=All&var-tcpconnsremote=All). We have plenty of spare memory capacity too.

If this goes OK, then we'll do the same in production.

We've previously raised the [file handles limit](https://github.com/alphagov/govuk-puppet/blob/d6c773c2a4d0c5a86882426a3d43ab4076a0aae8/modules/govuk/manifests/apps/search_api.pp#L172) and the [memory alert limits](https://github.com/alphagov/govuk-puppet/blob/9375c4a92bb7df04fda037b0898672e87bc87510/hieradata_aws/staging.yaml#L203), and I think these should still be fine.