### PR TITLE
Declare second Sidekiq worker (solely for sending emails)

### DIFF
--- a/modules/govuk/manifests/apps/email_alert_api.pp
+++ b/modules/govuk/manifests/apps/email_alert_api.pp
@@ -151,6 +151,15 @@ class govuk::apps::email_alert_api(
     memory_critical_threshold => 10000,
   }
 
+  govuk::procfile::worker {'email-alert-api-send-email':
+    ensure                    => $ensure,
+    enable_service            => $enable_procfile_worker,
+    process_type              => 'send_email_worker',
+    alert_when_threads_exceed => 100,
+    memory_warning_threshold  => 8000,
+    memory_critical_threshold => 10000,
+  }
+
   Govuk::App::Envvar {
     ensure          => $ensure,
     app             => 'email-alert-api',


### PR DESCRIPTION
Depends on https://github.com/alphagov/email-alert-api/pull/1534.

This `govuk::procfile::worker` declaration refers to the new
sidekiq_send_email.yml config in Email Alert API, introduced in
https://github.com/alphagov/email-alert-api/pull/1534

This is largely a copy and paste of the existing declaration above it,
but with a new name, which becomes the `$title` used throughout the
`govuk::procfile::worker` class (and also lends itself to the service
name we use in commands like `service {SERVICE_NAME} start`):
https://github.com/alphagov/govuk-puppet/blob/fbbecba00f5e4a06bed1c48b34445d7e4235c0fd/modules%2Fgovuk%2Fmanifests%2Fprocfile%2Fworker.pp

I also needed to pass `process_type => 'send_email_worker'` so that it knows
which worker to instantiate. I took inspiration from prior art in govuk-puppet
([1]) for Content Data API, whose process is called 'default-worker'
rather than 'worker' ([2]). We also used to have multiple workers in
the (now retired) Content Audit Tool ([3] and [4]), for which I remember
having to fix the regex on my first 2nd line shift ([5]). I don't think
we need to specify a custom process regex for this addition.

[1]: https://github.com/alphagov/govuk-puppet/blob/7e6a90da615e1094df305a367418139a76de0f8d/modules%2Fgovuk%2Fmanifests%2Fapps%2Fcontent_data_api.pp#L147-L152
[2]: https://github.com/alphagov/content-data-api/blob/2df29c27f2e715b07f5b8758519bb0d01ebdf6ff/Procfile#L1
[3]: https://github.com/alphagov/content-audit-tool/commit/6edc4e488dd8d7347517f5818ad977d9755fba01#diff-0a99231995da379e7aebabe76c9d849a23737a42c3b3a8994043e2aa80958424
[4]: https://github.com/alphagov/govuk-puppet/blob/e335930e21814e7aa27efa7e8f4e5360796091e9/modules/govuk/manifests/apps/content_audit_tool.pp#L96-L106
[5]: https://github.com/alphagov/content-audit-tool/pull/306

Trello: https://trello.com/c/52YiPQ3y/2273-investigate-splitting-queues-to-send-email-onto-a-different-set-of-workers