### PR TITLE
Show a GOV.UK formatted page for 502 errors

### DIFF
--- a/modules/router/templates/router_include.conf.erb
+++ b/modules/router/templates/router_include.conf.erb
@@ -174,6 +174,10 @@ location /500.html {
   root /usr/share/nginx/www;
   internal;
 }
+location /502.html {
+  root /usr/share/nginx/www;
+  internal;
+}
 location /503.html {
   root /usr/share/nginx/www;
   internal;


### PR DESCRIPTION
We are [defining a file](https://github.com/alphagov/govuk-puppet/blob/97ccb8805ddf16610bc4fc6e3b22461d8716bde8/modules/router/templates/router_include.conf.erb#L122) to serve for 502 errors but do not have a `502.html` file.  Therefore 502 errors end up getting served as a 404 (since the error page cannot be found).  This change will serve the GOV.UK formatted error page that has been [added to `static`](https://github.com/alphagov/static/pull/2363/files).

This can be deployed once https://github.com/alphagov/static/pull/2363 has been merged.