### PR TITLE
Add 502 to list of pages copied to Nginx

### DIFF
--- a/modules/router/manifests/nginx.pp
+++ b/modules/router/manifests/nginx.pp
@@ -134,7 +134,7 @@ class router::nginx (
     require => File['/usr/share/nginx/www'],
   }
 
-  router::errorpage {['400', '401', '403', '404', '405', '406', '410', '422', '429', '500', '503', '504']:
+  router::errorpage {['400', '401', '403', '404', '405', '406', '410', '422', '429', '500', '502', '503', '504']:
     require => File['/usr/share/nginx/www'],
   }
 


### PR DESCRIPTION
The 502 page needs to be added here to tell router to download the HTML
file from Static and save it locally for nginx to serve from.

Currently we have a 502 page in Static that is available, and an nginx
directive to serve a 502.html from `/usr/share/nginx/www/`. This change
allows that 502.html to be populated.

Before this change was added:

```
kevindew@ec2-integration-blue-cache-ip-10-1-4-74:/etc/nginx$ curl -H "Host: www.gov.uk" -s http://localhost/test-error | head
<html>
<head><title>404 Not Found</title></head>
<body bgcolor="white">
<center><h1>404 Not Found</h1></center>
<hr><center>nginx</center>
</body>
</html>
```

After this change:

```
kevindew@ec2-integration-blue-cache-ip-10-1-5-124:/etc/nginx$ curl -H "Host: www.gov.uk" -s http://localhost/test-error | head

<!DOCTYPE html>
<!--[if lt IE 9]><html class="lte-ie8" lang="en"><![endif]-->
<!--[if gt IE 8]><!--><html lang="en"><!--<![endif]-->
  <head>
    <meta charset="utf-8">
    <title>Sorry, we&#39;re experiencing technical difficulties - GOV.UK</title>

    <!--[if gt IE 8]><!--><link rel="stylesheet" media="screen" href="https://www.integration.publishing.service.gov.uk/assets/static/govuk-template-b0d37b76a990d9cdcdca37a1522e4ac3ecd8f686c70e0ef6b0cbc5a0c704c7d4.css" /><!--<![endif]-->
    <!--[if IE 8]><link rel="stylesheet" media="screen" href="https://www.integration.publishing.service.gov.uk/assets/static/govuk-template-ie8-c5230c77e42a66d952cd3e46ff30d23afc70c3641123fd72a9772978e3afeec9.css" /><![endif]-->
```