### PR TITLE
Tune "overdue publications in Whitehall" Icinga/Nagios alert

### DIFF
--- a/modules/monitoring/manifests/checks.pp
+++ b/modules/monitoring/manifests/checks.pp
@@ -76,8 +76,8 @@ class monitoring::checks (
       action_url                 => "https://${whitehall_hostname}${whitehall_overdue_url}",
       event_handler              => 'publish_overdue_whitehall',
       check_period               => $whitehall_overdue_check_period,
-      attempts_before_hard_state => 2,
-      retry_interval             => 10,
+      attempts_before_hard_state => 10,
+      retry_interval             => 1,
     }
   }
 

--- a/modules/monitoring/manifests/checks.pp
+++ b/modules/monitoring/manifests/checks.pp
@@ -81,9 +81,6 @@ class monitoring::checks (
     }
   }
 
-  $warning_time = 5
-  $critical_time = 10
-
   icinga::check {'check_mapit_responding':
     check_command       => 'check_mapit',
     host_name           => $::fqdn,


### PR DESCRIPTION
Currently if we get a false positive for this alert (i.e. everything is fine, but Icinga thinks otherwise), it takes 10 minutes for Icinga to retry the check after raising a critical alert.

This change will make that retry occur after 1 minute, and retry 9 times (10 `max_check_attempts`) rather than just once (2 `max_check_attempts`).

Nagios docs: https://assets.nagios.com/downloads/nagioscore/docs/nagioscore/3/en/objectdefinitions.html