### PR TITLE
Remove Healthchecks annotation from Grafana dashboards

### DIFF
--- a/modules/grafana/templates/dashboards/application_dashboard_template.json.erb
+++ b/modules/grafana/templates/dashboards/application_dashboard_template.json.erb
@@ -74,17 +74,6 @@
         "iconColor": "rgb(225, 251, 0)",
         "name": "Restarts",
         "target": "substr(stats.govuk.app.<%= @app_name %>.restarts,3,5)"
-      },
-      {
-        "datasource": "Graphite",
-        "enable": true,
-        "hide": false,
-        "iconColor": "rgb(255, 0, 224)",
-        "limit": 100,
-        "name": "Healthchecks",
-        "showIn": 0,
-        "target": "aliasSub(aliasSub(stats.icinga.service_alert.*.<%= @app_name %>_app_healthcheck.{critical,warning}, \"stats.icinga.service_alert.\", \"Health on \"), \".<%= @app_name %>_app_healthcheck.\", \": \")",
-        "type": "alert"
       }
     ]
   },


### PR DESCRIPTION
This annotation doesn't seem to work; it's not a useful query. Removing it should reduce the number of requests made to Graphite.