### PR TITLE
Force Router to reload all routes post datasync

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
@@ -19,6 +19,8 @@
             H 7 * * 1-5
     builders:
        - shell: |
+          # Update routes in Router
+          ssh deploy@$(govuk_node_list -c router_backend --single-node) 'cd /var/apps/router-api && govuk_setenv router-api bundle exec rake routes:reload'
            # Clear the Sidekiq queues to stop any residual 'stale' jobs running
            <%- if scope.lookupvar('::aws_migration') %>
            ssh deploy@$(govuk_node_list -c backend --single-node) 'redis-cli -h backend-redis flushall'

--- a/modules/govuk_jenkins/templates/jobs/data_sync_complete_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/data_sync_complete_staging.yaml.erb
@@ -21,6 +21,8 @@
           artifact-num-to-keep: 5
     builders:
        - shell: |
+           # Update routes in Router
+            ssh deploy@$(govuk_node_list -c router_backend --single-node) 'cd /var/apps/router-api && govuk_setenv router-api bundle exec rake routes:reload'
            <%- if !@aws && @signon_domains_to_migrate -%>
            # Fix signon application hostnames
            <%- @signon_domains_to_migrate.each do |domain| -%>


### PR DESCRIPTION
Depends on https://github.com/alphagov/router-api/pull/368.

After a data sync, many routes will have changed, and in fact are
correctly applied in Router API. However, we believe that Router
itself is not updated (at least until a route is changed on
Staging / Integration, whereupon it fixes itself).

More often than not, this goes by unnoticed, but being out of date
with the Router on Production can cause strange errors. For
[example][sentry], a redirect applied on Production but not
applied on Staging/Integration can cause taxonomy errors
("Tried to render a taxon page for content item that is not a
taxon") when the Production requests are
[shadowed to Staging][goreplay].

Therefore, this commit adds a call to a rake task in Router API
(introduced in https://github.com/alphagov/router-api/pull/368)
to manually reload Router's routes, to make sure that it is always
up to date.

[goreplay]: https://docs.publishing.service.gov.uk/manual/alerts/goreplay.html
[sentry]: https://sentry.io/organizations/govuk/issues/2122080074/?project=202213&query=is%3Aunresolved