### PR TITLE
Specify 1 attempt for PagerDuty drill

### DIFF
--- a/modules/monitoring/manifests/pagerduty_drill.pp
+++ b/modules/monitoring/manifests/pagerduty_drill.pp
@@ -41,11 +41,12 @@ class monitoring::pagerduty_drill (
     }
 
     @@icinga::check { "pagerduty_drill_on_${::hostname}":
-      check_command       => "check_nrpe!check_file_not_exists!${filename}",
-      use                 => 'govuk_urgent_priority',
-      service_description => 'PagerDuty test drill in progress',
-      host_name           => $::fqdn,
-      notes_url           => monitoring_docs_url(pagerduty),
+      check_command              => "check_nrpe!check_file_not_exists!${filename}",
+      use                        => 'govuk_urgent_priority',
+      service_description        => 'PagerDuty test drill in progress',
+      host_name                  => $::fqdn,
+      notes_url                  => monitoring_docs_url(pagerduty),
+      attempts_before_hard_state => 1,
     }
   }
 }


### PR DESCRIPTION
The PagerDuty drill works by triggering the creation of a file at 10:00 on a Wednesday then removing that file at 10:15. An Icinga check becomes critical when this file exists.

PagerDuty is alerted when this check becomes "hard". We are currently falling back to a default of 4 critical attempts before the alert is considered "hard", so occasionally PagerDuty will not be alerted if the 4 checks don't finish in the 15 minute period.

We should change this to 1 attempt before becoming "hard", so PagerDuty will always get alerted when this file is found after 10:00.