### PR TITLE
Add python3.6 and install on CKAN machines and CI agents

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -746,6 +746,9 @@ govuk_rbenv::all::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerpri
 govuk_solr6::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk_solr6::repo::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
+govuk_python3::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_python3::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
+
 govuk_sudo::sudo_conf:
   deploy_docker_image:
     content: 'deploy ALL=NOPASSWD:/usr/bin/docker image *'

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1153,6 +1153,9 @@ govuk_rbenv::all::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerpri
 govuk_solr6::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk_solr6::repo::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
+govuk_python3::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_python3::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
+
 govuk_sudo::sudo_conf:
   deploy_docker_image:
     content: 'deploy ALL=NOPASSWD:/usr/bin/docker image *'

--- a/modules/govuk/manifests/node/s_ckan.pp
+++ b/modules/govuk/manifests/node/s_ckan.pp
@@ -18,6 +18,7 @@ class govuk::node::s_ckan inherits govuk::node::s_base {
     both       => 1024,
   }
 
+  include govuk_python3
   include govuk_python
   include nginx
   include postgresql::lib::devel

--- a/modules/govuk_ci/manifests/agent.pp
+++ b/modules/govuk_ci/manifests/agent.pp
@@ -42,6 +42,7 @@ class govuk_ci::agent(
   include ::govuk_jenkins::user
   include ::govuk_rbenv::all
   include ::govuk_python
+  include ::govuk_python3
   include ::govuk_sysdig
   include ::govuk_testing_tools
   include ::yarn

--- a/modules/govuk_jenkins/manifests/packages/govuk_python.pp
+++ b/modules/govuk_jenkins/manifests/packages/govuk_python.pp
@@ -25,10 +25,13 @@ class govuk_jenkins::packages::govuk_python (
     key          => $apt_mirror_gpg_key_fingerprint,
   }
 
-  package { 'govuk-python':
-    ensure  => $govuk_python_version,
-    require => Apt::Source['govuk-python'],
-  }
+  ensure_packages(
+    ['govuk-python'],
+    {
+      ensure  => $govuk_python_version,
+      require => Apt::Source['govuk-python'],
+    }
+  )
 
   package { 'govuk-python-setuptools':
     ensure  => $govuk_python_setuptools_version,

--- a/modules/govuk_python3/manifests/init.pp
+++ b/modules/govuk_python3/manifests/init.pp
@@ -1,0 +1,26 @@
+# == Class: govuk_python3
+#
+# Install python3 package
+#
+class govuk_python3 (
+  $govuk_python_version = '3.6.12',
+  $apt_mirror_hostname,
+  $apt_mirror_gpg_key_fingerprint,
+) {
+
+  apt::source { 'govuk-python3':
+    location     => "http://${apt_mirror_hostname}/govuk-python",
+    release      => 'stable',
+    architecture => $::architecture,
+    repos        => 'main',
+    key          => $apt_mirror_gpg_key_fingerprint,
+  }
+
+  ensure_packages(
+    ['govuk-python'],
+    {
+      ensure  => $govuk_python_version,
+      require => Apt::Source['govuk-python3'],
+    }
+  )
+}


### PR DESCRIPTION
## What

Make python 3.6.12 package available on CKAN and CI agents so that CKAN 2.9 can run on python 3.6.12

## Reference 

https://trello.com/c/VrPqMpYM/2286-enable-the-ci-test-pipeline-to-run-against-ckan-29-on-python-3-on-a-particular-agent