### PR TITLE
Use govuk-python::app-source class

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -410,8 +410,6 @@ govuk_htpasswd::http_username: "%{hiera('http_username')}"
 
 govuk_jenkins::packages::gcloud::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk_jenkins::packages::gcloud::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
-govuk_jenkins::packages::govuk_python::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
-govuk_jenkins::packages::govuk_python::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 govuk_jenkins::packages::terraform::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk_jenkins::packages::terraform::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 govuk_jenkins::packages::sops::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
@@ -746,8 +744,8 @@ govuk_rbenv::all::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerpri
 govuk_solr6::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk_solr6::repo::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
-govuk_python3::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
-govuk_python3::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
+govuk_python::apt_source::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_python::apt_source::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 govuk_sudo::sudo_conf:
   deploy_docker_image:

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -852,8 +852,6 @@ govuk_jenkins::packages::gcloud::apt_mirror_hostname: "%{hiera('apt_mirror_hostn
 govuk_jenkins::packages::gcloud::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 govuk_jenkins::packages::terraform::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk_jenkins::packages::terraform::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
-govuk_jenkins::packages::govuk_python::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
-govuk_jenkins::packages::govuk_python::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 govuk_jenkins::packages::sops::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk_jenkins::packages::sops::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
@@ -1153,8 +1151,8 @@ govuk_rbenv::all::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerpri
 govuk_solr6::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk_solr6::repo::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
-govuk_python3::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
-govuk_python3::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
+govuk_python::apt_source::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_python::apt_source::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 govuk_sudo::sudo_conf:
   deploy_docker_image:

--- a/modules/govuk_jenkins/manifests/packages/govuk_python.pp
+++ b/modules/govuk_jenkins/manifests/packages/govuk_python.pp
@@ -14,16 +14,8 @@ class govuk_jenkins::packages::govuk_python (
   $govuk_python_version = '2.7.14',
   $govuk_python_setuptools_version = '39.0.1',
   $govuk_python_pip_version = '10.0.1',
-  $apt_mirror_hostname,
-  $apt_mirror_gpg_key_fingerprint,
 ){
-
-  apt::source { 'govuk-python':
-    location     => "http://${apt_mirror_hostname}/govuk-python",
-    release      => 'stable',
-    architecture => $::architecture,
-    key          => $apt_mirror_gpg_key_fingerprint,
-  }
+  include govuk_python::apt_source
 
   ensure_packages(
     ['govuk-python'],

--- a/modules/govuk_jenkins/spec/classes/jenkins__package_spec.rb
+++ b/modules/govuk_jenkins/spec/classes/jenkins__package_spec.rb
@@ -2,7 +2,6 @@ require_relative '../../../../spec_helper'
 
 describe 'govuk_jenkins::package', :type => :class do
   let(:params) {{
-    :apt_mirror_hostname => 'apt.example.com',
     :version             => '1.554.2',
   }}
 

--- a/modules/govuk_python/manifests/apt_source.pp
+++ b/modules/govuk_python/manifests/apt_source.pp
@@ -1,0 +1,17 @@
+# == Class: govuk_python::apt_source
+#
+# govuk-python apt source
+#
+class govuk_python::apt_source (
+  $apt_mirror_hostname,
+  $apt_mirror_gpg_key_fingerprint,
+) {
+
+  apt::source { 'govuk-python':
+    location     => "http://${apt_mirror_hostname}/govuk-python",
+    release      => 'stable',
+    architecture => $::architecture,
+    repos        => 'main',
+    key          => $apt_mirror_gpg_key_fingerprint,
+  }
+}

--- a/modules/govuk_python3/manifests/init.pp
+++ b/modules/govuk_python3/manifests/init.pp
@@ -4,23 +4,14 @@
 #
 class govuk_python3 (
   $govuk_python_version = '3.6.12',
-  $apt_mirror_hostname,
-  $apt_mirror_gpg_key_fingerprint,
 ) {
-
-  apt::source { 'govuk-python3':
-    location     => "http://${apt_mirror_hostname}/govuk-python",
-    release      => 'stable',
-    architecture => $::architecture,
-    repos        => 'main',
-    key          => $apt_mirror_gpg_key_fingerprint,
-  }
+  include govuk_python::apt_source
 
   ensure_packages(
     ['govuk-python'],
     {
       ensure  => $govuk_python_version,
-      require => Apt::Source['govuk-python3'],
+      require => Apt::Source['govuk-python'],
     }
   )
 }

--- a/spec/fixtures/hieradata/common.yaml
+++ b/spec/fixtures/hieradata/common.yaml
@@ -112,6 +112,9 @@ govuk_unattended_reboot::repo::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mir
 grafana::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 grafana::repo::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
+govuk_python::apt_source::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_python::apt_source::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
+
 hosts::production::backend::hosts:
   whitehall-backend-1:
     ip: '10.3.0.25'


### PR DESCRIPTION
## What

This fixes the installation of python3.6 on ci agents and the duplication of the `govuk-python` apt-source.

