### PR TITLE
Add prometheus data source to Grafana

### DIFF
--- a/modules/grafana/manifests/datasources.pp
+++ b/modules/grafana/manifests/datasources.pp
@@ -61,6 +61,19 @@ class grafana::datasources(
     '2>/dev/null','|','grep',shellquote('{"message":"Data source not found"}'),
   ], ' ')
 
+  $prometheussourcejson = '{ "name":"Prometheus","type":"prometheus","url":"https://prometheus","access":"proxy" }'
+
+  $prometheussourceadd = shellquote([
+    'curl','-f',"http://${webapi_user}:${webapi_password}@127.0.0.1:3204/api/datasources",
+    '-X','POST','-H','Content-Type: application/json;charset=UTF-8',
+    '--data-binary',$prometheussourcejson,
+  ])
+
+  $prometheussourcemisses = join([
+    'curl',shellquote("http://${webapi_user}:${webapi_password}@127.0.0.1:3204/api/datasources/name/Prometheus"),
+    '2>/dev/null','|','grep',shellquote('{"message":"Data source not found"}'),
+  ], ' ')
+
   exec{'ensure-graphite-source':
     require => [Package['curl']],
     command => $graphitesourceadd,
@@ -72,4 +85,11 @@ class grafana::datasources(
     command => $elasticsearchsourceadd,
     onlyif  => $elasticsearchsourcemisses,
   }
+
+  exec{'ensure-prometheus-source':
+    require => [Package['curl']],
+    command => $prometheussourceadd,
+    onlyif  => $prometheussourcemisses,
+  }
+
 }


### PR DESCRIPTION
It looks like this can work the same way as graphite does - with
https://prometheus as the URL. This works because /etc/resolve.conf sets
a search path of integration.govuk-internal.digital.
prometheus.integration.govuk-internal.digital is a CNAME to
prometheus.blue.integration.govuk-internal.digital, which points to
Prometheus' internal load balancer.

I'm not sure how Grafana is happy making an HTTPS connection to this
URL, becauce the certificate is definitely not valid for
https://prometheus. But I've tested it and it seems happy (just as it is
with graphite), and not having to pass the URL in as a variable makes
our lives significantly simpler.