### PR TITLE
use default python for icinga alert scripts

### DIFF
--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_cache_cpu
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_cache_cpu
@@ -1,4 +1,4 @@
-#!/opt/python2.7/bin/python
+#!/usr/bin/python2.7
 
 ##########################################################
 # This script will capture and report on AWS ElastiCache #

--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_cache_memory
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_cache_memory
@@ -1,4 +1,4 @@
-#!/opt/python2.7/bin/python
+#!/usr/bin/python2.7
 
 ##########################################################
 # This script will cpture and report on AWS ElastiCache #

--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_rds_cpu
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_rds_cpu
@@ -1,4 +1,4 @@
-#!/opt/python2.7/bin/python
+#!/usr/bin/python2.7
 
 ##################################################
 # This script will capture and report on AWS RDS #

--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_rds_memory
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_rds_memory
@@ -1,4 +1,4 @@
-#!/opt/python2.7/bin/python
+#!/usr/bin/python2.7
 
 ##################################################
 # This script will capture and report on AWS RDS #

--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_rds_storage
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_aws_rds_storage
@@ -1,4 +1,4 @@
-#!/opt/python2.7/bin/python
+#!/usr/bin/python2.7
 
 ##################################################
 # This script will capture and report on AWS RDS #

--- a/modules/monitoring/manifests/checks.pp
+++ b/modules/monitoring/manifests/checks.pp
@@ -24,13 +24,13 @@ class monitoring::checks (
 
   exec { 'install_boto':
         path    => ['/opt/python2.7/bin', '/usr/bin', '/usr/sbin'],
-        command => '/opt/python2.7/bin/pip install boto',
+        command => 'pip install boto',
         require => Class['::govuk_jenkins::packages::govuk_python'],
   }
 
   exec { 'install_boto3':
         path    => ['/opt/python2.7/bin', '/usr/bin', '/usr/sbin'],
-        command => '/opt/python2.7/bin/pip install boto3',
+        command => 'pip install boto3',
         require => Class['::govuk_jenkins::packages::govuk_python'],
   }
 


### PR DESCRIPTION
This is a side effect of govuk-python being used to install python 3.6. See #10915