### PR TITLE
fix python 3.6 install

### DIFF
--- a/hieradata_aws/class/ckan.yaml
+++ b/hieradata_aws/class/ckan.yaml
@@ -7,3 +7,5 @@ govuk::apps::ckan::enable_harvester_fetch: true
 govuk::apps::ckan::enable_harvester_gather: true
 
 govuk_solr6::present: false
+
+govuk_python::govuk_python_version: '3.6.12'

--- a/hieradata_aws/class/integration/ci_agent.yaml
+++ b/hieradata_aws/class/integration/ci_agent.yaml
@@ -14,6 +14,7 @@ govuk_ci::agent::gemstash_server: 'http://gemstash'
 govuk_containers::elasticsearch::secondary::enable: false
 postgresql::globals::version: '9.3'
 govuk_postgresql::server::enable_collectd: false
+govuk_python::govuk_python_version: '3.6.12'
 
 govuk_mysql::server::innodb_flush_log_at_trx_commit: 2
 govuk_mysql::server::innodb_buffer_pool_size_proportion: 0.05

--- a/modules/govuk_python/manifests/init.pp
+++ b/modules/govuk_python/manifests/init.pp
@@ -1,6 +1,6 @@
 # FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
 class govuk_python (
-  $govuk_python_version = '3.6.12',
+  $govuk_python_version = '2.7.14',
 ) {
 
   include govuk_python::apt_source


### PR DESCRIPTION
govuk_python needs to be set only on ci_agents and ckan to 3.6. In other places, we keep it on 2.7.14.