### PR TITLE
Upgrade postgresql to 9.6 on ci agents

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -587,13 +587,13 @@ govuk_ci::master::pipeline_jobs:
 govuk_ci::master::ci_agents:
   ci-agent-1:
     agent_hostname: 'ci-agent-1.ci'
-    labels: 'mongodb-2.4 ci-agent-1 elasticsearch-6.7 terraform postgresql-9.3'
+    labels: 'mongodb-2.4 ci-agent-1 elasticsearch-6.7 terraform postgresql-9.6'
   ci-agent-2:
     agent_hostname: 'ci-agent-2.ci'
-    labels: 'mongodb-2.4 ci-agent-2 elasticsearch-6.7 terraform postgresql-9.3'
+    labels: 'mongodb-2.4 ci-agent-2 elasticsearch-6.7 terraform postgresql-9.6'
   ci-agent-3:
     agent_hostname: 'ci-agent-3.ci'
-    labels: 'mongodb-2.4 ci-agent-3 elasticsearch-6.7 terraform postgresql-9.3'
+    labels: 'mongodb-2.4 ci-agent-3 elasticsearch-6.7 terraform postgresql-9.6'
   ci-agent-4:
     agent_hostname: 'ci-agent-4.ci'
     labels: 'mongodb-3.2 ci-agent-4 elasticsearch-6.7 terraform postgresql-9.6'

--- a/hieradata_aws/class/integration/ci_agent.yaml
+++ b/hieradata_aws/class/integration/ci_agent.yaml
@@ -12,7 +12,7 @@ govuk_ci::agent::postgresql::email_alert_api_role_password: 'email-alert-api'
 govuk_ci::agent::gdal_version: "1.11.5"
 govuk_ci::agent::gemstash_server: 'http://gemstash'
 govuk_containers::elasticsearch::secondary::enable: false
-postgresql::globals::version: '9.3'
+postgresql::globals::version: '9.6'
 govuk_postgresql::server::enable_collectd: false
 govuk_python::govuk_python_version: '3.6.12'
 

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1053,13 +1053,13 @@ govuk_ci::master::pipeline_jobs:
 govuk_ci::master::ci_agents:
   ci-agent-1:
     agent_hostname: ci-agent-1.blue.%{hiera('app_domain_internal')}
-    labels: 'mongodb-2.4 ci-agent-1 elasticsearch-6.7 terraform postgresql-9.3'
+    labels: 'mongodb-2.4 ci-agent-1 elasticsearch-6.7 terraform postgresql-9.6'
   ci-agent-2:
     agent_hostname: ci-agent-2.blue.%{hiera('app_domain_internal')}
-    labels: 'mongodb-2.4 ci-agent-2 elasticsearch-6.7 terraform postgresql-9.3'
+    labels: 'mongodb-2.4 ci-agent-2 elasticsearch-6.7 terraform postgresql-9.6'
   ci-agent-3:
     agent_hostname: ci-agent-3.blue.%{hiera('app_domain_internal')}
-    labels: 'mongodb-2.4 ci-agent-3 elasticsearch-6.7 terraform postgresql-9.3'
+    labels: 'mongodb-2.4 ci-agent-3 elasticsearch-6.7 terraform postgresql-9.6'
   ci-agent-4:
     agent_hostname: ci-agent-4.blue.%{hiera('app_domain_internal')}
     labels: 'mongodb-3.2 ci-agent-4 elasticsearch-6.7 terraform postgresql-9.6'


### PR DESCRIPTION
## What

Upgrade postgres on CI agents to 9.6 so that CKAN 2.9 tests can pass.

## Reference

https://trello.com/c/VrPqMpYM/2286-enable-the-ci-test-pipeline-to-run-against-ckan-29-on-python-3