### PR TITLE
Ensure Sentry Puppet resources are removed prior to deletion

### DIFF
--- a/modules/puppet/manifests/master/package.pp
+++ b/modules/puppet/manifests/master/package.pp
@@ -35,7 +35,7 @@ class puppet::master::package(
   }
 
   package { 'sentry-raven':
-    ensure   => '2.2.0',
+    ensure   => absent,
     provider => 'system_gem',
   }
 

--- a/modules/puppet/manifests/puppetserver/sentry.pp
+++ b/modules/puppet/manifests/puppetserver/sentry.pp
@@ -4,12 +4,8 @@
 # Sentry DSN in /etc/puppet/sentry.conf.
 #
 class puppet::puppetserver::sentry {
-  exec { '/usr/bin/puppetserver gem install sentry-raven --version "= 2.13.0"':
-    unless  => '/usr/bin/puppetserver gem list | /bin/grep sentry-raven',
-  }
-
   file { "${settings::confdir}/sentry.conf":
-    ensure  => present,
+    ensure  => absent,
     owner   => 'puppet',
     group   => 'puppet',
     mode    => '0400',

--- a/modules/puppet/spec/classes/puppet__puppetserver__sentry_spec.rb
+++ b/modules/puppet/spec/classes/puppet__puppetserver__sentry_spec.rb
@@ -12,7 +12,6 @@ describe 'puppet::puppetserver::sentry', :type => :class do
   Puppet.settings[:confdir] = '/etc/puppet'
 
   it do
-	  is_expected.to contain_exec('/usr/bin/puppetserver gem install sentry-raven --version "= 2.13.0"')
     is_expected.to contain_file('/etc/puppet/sentry.conf').with_content('dsn=rspec dsn')
   end
 end

--- a/modules/puppet/templates/etc/puppet/puppet.conf.erb
+++ b/modules/puppet/templates/etc/puppet/puppet.conf.erb
@@ -20,7 +20,7 @@ certname = <%= scope.lookupvar('::aws_instanceid') %>
 <%- end -%>
 
 [master]
-reports = store,sentry
+reports = store
 report = true
 storeconfigs = true
 storeconfigs_backend = puppetdb
@@ -37,5 +37,5 @@ autosign = /etc/puppet/certsigner.rb
 <%- end -%>
 
 [agent]
-report = true
+report = false
 configtimeout = 600


### PR DESCRIPTION
In #10919, we're removing Sentry error-reporting for failed Puppet builds,
but all this does is tell Puppet not to manage those resources
anymore. It doesn't actually remove them.

We need to tell Puppet to remove the resources before we can
safely remove the resource configurations.

See https://serverfault.com/questions/455657/how-to-revert-a-configuration-with-puppet

Trello: https://trello.com/c/1pAh0QpK/2294-3-remove-govuk-puppet-project-from-sentry

Co-authored-by: Thomas Leese <thomas.leese@digital.cabinet-office.gov.uk>