### PR TITLE
Fix XML error

### DIFF
--- a/modules/govuk_ci/files/github-plugin-configuration.xml
+++ b/modules/govuk_ci/files/github-plugin-configuration.xml
@@ -11,4 +11,4 @@
   <hookSecretConfig>
     <credentialsId></credentialsId>
   </hookSecretConfig>
-</github-pluginconfiguration>
+</github-plugin-configuration>


### PR DESCRIPTION
This was missing an hyphen. I don't think this fix will actually do
much bar stopping a warning when the app starts.