### PR TITLE
Enable Slack notifications to #govuk-deploy when Puppet deployed

### DIFF
--- a/hieradata_aws/class/production/jenkins.yaml
+++ b/hieradata_aws/class/production/jenkins.yaml
@@ -104,7 +104,7 @@ govuk_jenkins::jobs::update_cdn_dictionaries::services:
   - performanceplatform
   - www
 
-govuk_jenkins::jobs::deploy_puppet::enable_slack_notifications: false
+govuk_jenkins::jobs::deploy_puppet::enable_slack_notifications: true
 govuk_jenkins::jobs::transition_import_hits::s3_bucket: govuk-production-transition-fastly-logs
 govuk_jenkins::jobs::user_monitor::enable_icinga_check: true
 

--- a/hieradata_aws/class/staging/jenkins.yaml
+++ b/hieradata_aws/class/staging/jenkins.yaml
@@ -96,4 +96,4 @@ govuk_jenkins::jobs::update_cdn_dictionaries::services:
   - performanceplatform
   - www
 
-govuk_jenkins::jobs::deploy_puppet::enable_slack_notifications: false
+govuk_jenkins::jobs::deploy_puppet::enable_slack_notifications: true


### PR DESCRIPTION
This used to be enabled. We believe the notifications were
disabled on AWS when we had Carrenza running, as this would have
meant two notifications each time and got noisy.