### PR TITLE
Create govuk-search-relevance-tool job for running tests

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -526,6 +526,7 @@ govuk_ci::master::pipeline_jobs:
   govuk_message_queue_consumer: {}
   govuk-provisioning: {}
   govuk_publishing_components: {}
+  govuk-search-relevance-tool: {}
   govuk_seed_crawler: {}
   govuk_schemas: {}
   govuk_sidekiq: {}


### PR DESCRIPTION
We have a number of Dependabot PRs (https://github.com/alphagov/govuk-search-relevance-tool/pulls)
which are waiting on Jenkins CI responses and never receiving a response, since no job exists.