### PR TITLE
Pull main branch from Smokey repo

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/smokey.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/smokey.yaml.erb
@@ -4,7 +4,7 @@
     scm:
       - git:
           url: git@github.com:alphagov/smokey.git
-          branches: [master]
+          branches: [main]
 
 - job:
     name: Smokey

--- a/modules/govuk_jenkins/templates/jobs/smokey_deploy.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/smokey_deploy.yaml.erb
@@ -5,7 +5,7 @@
         - git:
             url: git@github.com:alphagov/smokey.git
             branches:
-              - master
+              - main
 
 - job:
     name: Smokey_Deploy


### PR DESCRIPTION
Smokey is changing to use 'main' rather than 'master' as its default branch.

There are no difference between the branches: https://github.com/alphagov/smokey/compare/master...main

Once this puppet change has gone out I'll change the default branch for Smokey to be 'main' in the GitHub UI.