### PR TITLE
Remove REDIS_HOST and REDIS_PORT env vars

### DIFF
--- a/modules/govuk/manifests/app/envvar/redis.pp
+++ b/modules/govuk/manifests/app/envvar/redis.pp
@@ -1,6 +1,6 @@
 # == Define: govuk::app::envvar::redis
 #
-# Defines Redis env vars for an app.
+# Defines Redis env var for an app.
 #
 # === Parameters
 #
@@ -29,17 +29,9 @@ define govuk::app::envvar::redis (
     app => pick($app, $title),
   }
 
-  $host_key = join(delete_undef_values([$prefix, 'redis', 'host']), '_')
-  $port_key = join(delete_undef_values([$prefix, 'redis', 'port']), '_')
   $url_key  = join(delete_undef_values([$prefix, 'redis', 'url']), '_')
 
   govuk::app::envvar {
-    "${title}-${host_key}":
-      varname => upcase($host_key),
-      value   => $host;
-    "${title}-${port_key}":
-      varname => upcase($port_key),
-      value   => $port;
     "${title}-${url_key}":
       varname => upcase($url_key),
       value   => "redis://${host}:${port}";

--- a/modules/govuk/spec/defines/govuk__app__envvar__redis_spec.rb
+++ b/modules/govuk/spec/defines/govuk__app__envvar__redis_spec.rb
@@ -6,20 +6,6 @@ describe 'govuk::app::envvar::redis', :type => :define do
   context 'with empty parameters' do
     let(:params) { {} }
 
-    it 'sets the Redis host to 127.0.0.1 by default' do
-      is_expected.to contain_govuk__app__envvar("#{title}-redis_host")
-                       .with_app(title)
-                       .with_varname('REDIS_HOST')
-                       .with_value('127.0.0.1')
-    end
-
-    it 'sets the Redis port to 6379 by default' do
-      is_expected.to contain_govuk__app__envvar("#{title}-redis_port")
-                       .with_app(title)
-                       .with_varname('REDIS_PORT')
-                       .with_value('6379')
-    end
-
     it 'sets a Redis URL with the default values' do
       is_expected.to contain_govuk__app__envvar("#{title}-redis_url")
                        .with_app(title)
@@ -33,20 +19,6 @@ describe 'govuk::app::envvar::redis', :type => :define do
     let(:port) { '1234' }
     let(:params) { { host: host, port: port } }
 
-    it 'sets the Redis host' do
-      is_expected.to contain_govuk__app__envvar("#{title}-redis_host")
-                       .with_app(title)
-                       .with_varname('REDIS_HOST')
-                       .with_value(host)
-    end
-
-    it 'sets the Redis port' do
-      is_expected.to contain_govuk__app__envvar("#{title}-redis_port")
-                       .with_app(title)
-                       .with_varname('REDIS_PORT')
-                       .with_value(port)
-    end
-
     it 'sets a Redis URL' do
       is_expected.to contain_govuk__app__envvar("#{title}-redis_url")
                        .with_app(title)
@@ -59,16 +31,6 @@ describe 'govuk::app::envvar::redis', :type => :define do
     let(:app) { 'enclosure' }
     let(:params) { { app: app } }
 
-    it 'uses that app when setting the host variable' do
-      is_expected.to contain_govuk__app__envvar("#{title}-redis_host")
-                       .with_app(app)
-    end
-
-    it 'uses that app when setting the port variable' do
-      is_expected.to contain_govuk__app__envvar("#{title}-redis_port")
-                       .with_app(app)
-    end
-
     it 'uses that app when setting the url variable' do
       is_expected.to contain_govuk__app__envvar("#{title}-redis_url")
                        .with_app(app)
@@ -77,18 +39,6 @@ describe 'govuk::app::envvar::redis', :type => :define do
 
   context 'white a prefix' do
     let(:params) { { prefix: 'zoo' } }
-
-    it 'adds a prefix to the host variable' do
-      is_expected.to contain_govuk__app__envvar("#{title}-zoo_redis_host")
-                       .with_app(title)
-                       .with_varname('ZOO_REDIS_HOST')
-    end
-
-    it 'adds a prefix to the port variable' do
-      is_expected.to contain_govuk__app__envvar("#{title}-zoo_redis_port")
-                       .with_app(title)
-                       .with_varname('ZOO_REDIS_PORT')
-    end
 
     it 'adds a prefix to the url variable' do
       is_expected.to contain_govuk__app__envvar("#{title}-zoo_redis_url")


### PR DESCRIPTION
Trello: https://trello.com/c/dXud4WIt/206-inconsistent-redisurl-config

No GOV.UK apps need these anymore as they all operate with REDIS_URL values.

This is a re-application of https://github.com/alphagov/govuk-puppet/commit/7c9aefc3a09b661289dd55c7a3011f2435608757 after reverting it the first time.