### PR TITLE
Fix race condition in updating router_nodes_file.

### DIFF
--- a/modules/govuk/manifests/apps/router_api.pp
+++ b/modules/govuk/manifests/apps/router_api.pp
@@ -105,7 +105,7 @@ class govuk::apps::router_api(
     $router_nodes_file = '/etc/router_nodes'
 
     cron::crondotdee { 'update-router-nodes':
-      command => "/usr/local/bin/govuk_node_list -c ${router_nodes_class} | sed 's/$/:${router_port}/g' > ${router_nodes_file}",
+      command => "/usr/local/bin/govuk_node_list -c ${router_nodes_class} | sed 's/$/:${router_port}/g' > ${router_nodes_file}.new && [ -s ${router_nodes_file}.new ] && mv ${router_nodes_file}.new ${router_nodes_file}",
       hour    => '*',
       minute  => '*/5',
       mailto  => '""',


### PR DESCRIPTION
The cron job which updates the file of Router nodes for Router API to contact when a route changes was un-atomically clobbering the file, fetching the new list of nodes and then writing the new list to the file. This means there's typically a half-second window every 5 minutes where Router API will see an empty or incomplete node list.

Instead, have it create a new file and atomically move it into place.

While we're there, make it check for an empty list of nodes. It turns out govuk_node_list returns 0 (success) when querying for a nonexistent node class or a node class which contains no nodes. It's probably safer not to update the file if this happens.

This should only be a short-term fix until we implement a more sensible (and simpler) config reload mechanism for Router, likely based on a database watch / pubsub / change notification type of arrangement.

Tested: ran the command locally with the variables set in the shell, verified that it creates/updates the file with the expected output when router_nodes_class is set to an actual node class and that the file doesn't get updated when router_nodes_class is set to a nonexistent node class.

I plan to test further in integration after merge, by checking that the cron job still updates the file (and I'll roll back if it's broken of course).