### PR TITLE
Fix typo in RabbitMQ permissions

### DIFF
--- a/modules/govuk/manifests/apps/email_alert_service/rabbitmq.pp
+++ b/modules/govuk/manifests/apps/email_alert_service/rabbitmq.pp
@@ -62,7 +62,7 @@ class govuk::apps::email_alert_service::rabbitmq (
     ensure               => $ensure,
     amqp_pass            => $amqp_pass,
     read_permission      => "^(amq\\.gen.*|${amqp_major_change_queue}|${amqp_exchange})\$",
-    write_permission     => "^(amq\\.gen.*|${amqp_major_change_queue}\$",
-    configure_permission => "^(amq\\.gen.*|${amqp_major_change_queue}\$",
+    write_permission     => "^(amq\\.gen.*|${amqp_major_change_queue})\$",
+    configure_permission => "^(amq\\.gen.*|${amqp_major_change_queue})\$",
   }
 }


### PR DESCRIPTION
https://trello.com/c/fbmVmwG3/666-remove-the-undocumented-taxon-unpublish-redirect-feature

Introduced in: 9d1a19be7