### PR TITLE
Set mapit to warn at 16 TCP connections instead of 2

### DIFF
--- a/modules/govuk/manifests/apps/mapit.pp
+++ b/modules/govuk/manifests/apps/mapit.pp
@@ -27,16 +27,17 @@ class govuk::apps::mapit (
 ) {
   if $enabled {
     govuk::app { 'mapit':
-      app_type               => 'procfile',
-      create_pidfile         => false,
-      port                   => $port,
-      vhost_ssl_only         => true,
-      health_check_path      => '/',
-      nagios_memory_warning  => 1200,
-      nagios_memory_critical => 2000,
-      log_format_is_json     => false,
-      sentry_dsn             => $sentry_dsn,
-      monitor_unicornherder  => true,
+      app_type                           => 'procfile',
+      create_pidfile                     => false,
+      port                               => $port,
+      vhost_ssl_only                     => true,
+      health_check_path                  => '/',
+      nagios_memory_warning              => 1200,
+      nagios_memory_critical             => 2000,
+      log_format_is_json                 => false,
+      sentry_dsn                         => $sentry_dsn,
+      monitor_unicornherder              => true,
+      local_tcpconns_established_warning => 16,
     }
 
     govuk_postgresql::db { 'mapit':


### PR DESCRIPTION
Trello: https://trello.com/c/Gu97ssQ3/730-load-testing-for-local-transaction-pages

This is to reflect that Mapit has 16 workers available for it [1],
however Icinga is configured to alert when it hits 2 TCP connections as
this is the default [2]. This results in this alerting despite the numbers
being within the level Mapit supports.

[1]: https://github.com/alphagov/mapit/commit/794c4f3660b6d7a5def9a74244e1d27df15fbf3e
[2]: https://github.com/alphagov/govuk-puppet/blob/196a5aeb85280bfe7a514eb00f20fa67cd4e0180/modules/govuk/manifests/app/config.pp#L376-L380