### PR TITLE
Install tfenv on AWS Integration Jenkins

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/deploy_terraform_govuk_aws.pp
+++ b/modules/govuk_jenkins/manifests/jobs/deploy_terraform_govuk_aws.pp
@@ -8,5 +8,6 @@ class govuk_jenkins::jobs::deploy_terraform_govuk_aws {
   }
 
   include ::govuk_jenkins::packages::terraform
+  include ::govuk_jenkins::packages::tfenv
   include ::govuk_jenkins::packages::sops
 }

--- a/modules/govuk_jenkins/manifests/packages/tfenv.pp
+++ b/modules/govuk_jenkins/manifests/packages/tfenv.pp
@@ -1,0 +1,19 @@
+# == Class: govuk_jenkins::packages::tfenv
+#
+# Installs tfenv https://github.com/tfutils/tfenv
+# to manage multiple versions of terraform installed concurrently on the system
+#
+# === Parameters
+#
+# [*terraform_versions*]
+#   The list of terraform versions to be installed
+#
+#
+class govuk_jenkins::packages::tfenv (
+  $terraform_versions = ['0.11.14', '0.13.6'],
+){
+
+  include ::tfenv
+  ::tfenv::terraform { $terraform_versions: }
+
+}

--- a/modules/tfenv/manifests/init.pp
+++ b/modules/tfenv/manifests/init.pp
@@ -1,0 +1,44 @@
+# == Class: tfenv
+#
+class tfenv(
+  $install_dir          = '/opt/tfenv',
+  $tfenv_git_repo       = 'https://github.com/tfutils/tfenv',
+  $tfenv_revision       = 'v2.0.0',
+) {
+
+  $packages = [
+    git,
+    unzip,
+  ]
+
+  ensure_packages($packages, {'ensure' => 'present'})
+
+  file { $install_dir:
+    ensure  => directory,
+    owner   => 'jenkins',
+    group   => 'jenkins',
+    mode    => '0755',
+    require => Package[$packages],
+  }
+  -> vcsrepo { $install_dir:
+    ensure   => present,
+    provider => git,
+    revision => $tfenv_revision,
+    source   => $tfenv_git_repo,
+    user     => 'jenkins',
+    group    => 'jenkins',
+  }
+
+  file { '/usr/local/bin/tfenv':
+    ensure  => link,
+    target  => "${install_dir}/bin/tfenv",
+    require => Vcsrepo[$install_dir],
+  }
+
+  file { '/usr/local/bin/terraform':
+    ensure  => link,
+    target  => "${install_dir}/bin/terraform",
+    require => Vcsrepo[$install_dir],
+  }
+
+}

--- a/modules/tfenv/manifests/terraform.pp
+++ b/modules/tfenv/manifests/terraform.pp
@@ -1,0 +1,17 @@
+# == Define: tfenv::terraform
+#
+define tfenv::terraform (
+  $version = $title,
+) {
+  if ! defined(Class['tfenv']) {
+    fail('You must include the tfenv base class before using any tfenv defined resources')
+  }
+
+  $install_path = $::tfenv::install_dir
+
+  exec { "Install terraform version ${version}":
+    command => "tfenv install ${version}",
+    path    => '/usr/bin:/usr/sbin:/bin:/usr/local/bin',
+    unless  => "test -d ${install_path}/versions/${version}",
+  }
+}


### PR DESCRIPTION
We install tfenv on AWS Integration Jenkins so that Terraform 0.11.14 (current) and 0.13.6 (new) can co-exist on the same system.

We need Terraform 0.13.6 because some of its new features is needed for adding new functionality in govuk-aws infra-security project.

Ref:
1. [trello card](https://trello.com/c/kkFNCkop/335-give-2ndline-iam-admin-access-to-aws)

Co-Authored-By: Karl Baker <karlbaker02@users.noreply.github.com>