### PR TITLE
Use PostGIS 2.5 for Mapit

### DIFF
--- a/hieradata_aws/class/integration/ci_agent.yaml
+++ b/hieradata_aws/class/integration/ci_agent.yaml
@@ -13,6 +13,7 @@ govuk_ci::agent::gdal_version: "1.11.5"
 govuk_ci::agent::gemstash_server: 'http://gemstash'
 govuk_containers::elasticsearch::secondary::enable: false
 postgresql::globals::version: '9.6'
+postgresql::globals::postgis_version: '2.5'
 govuk_postgresql::server::enable_collectd: false
 govuk_python::govuk_python_version: '3.6.12'
 

--- a/hieradata_aws/class/integration/mapit.yaml
+++ b/hieradata_aws/class/integration/mapit.yaml
@@ -1,4 +1,4 @@
-postgresql::globals::postgis_version: '2.2'
+postgresql::globals::postgis_version: '2.5'
 
 lv:
   data:


### PR DESCRIPTION
This makes two changes to the use of PostGIS for Mapit:
- Updates the version in integration to 2.5.
- Actually specifies a version for CI.  When Postgres 3.6 was installed on these instances, PostGIS wasn't activated as the relevant package wasn't installed.

Trello card: https://trello.com/c/hirdtB41