### PR TITLE
Switch Mapit to use PostGIS 2.4

### DIFF
--- a/hieradata_aws/class/integration/ci_agent.yaml
+++ b/hieradata_aws/class/integration/ci_agent.yaml
@@ -13,7 +13,7 @@ govuk_ci::agent::gdal_version: "1.11.5"
 govuk_ci::agent::gemstash_server: 'http://gemstash'
 govuk_containers::elasticsearch::secondary::enable: false
 postgresql::globals::version: '9.6'
-postgresql::globals::postgis_version: '2.5'
+postgresql::globals::postgis_version: '2.4'
 govuk_postgresql::server::enable_collectd: false
 govuk_python::govuk_python_version: '3.6.12'
 

--- a/hieradata_aws/class/integration/mapit.yaml
+++ b/hieradata_aws/class/integration/mapit.yaml
@@ -1,4 +1,4 @@
-postgresql::globals::postgis_version: '2.5'
+postgresql::globals::postgis_version: '2.4'
 
 lv:
   data:


### PR DESCRIPTION
We incorrectly upgraded CI and integration to use PostGIS 2.5 in a [previous PR](https://github.com/alphagov/govuk-puppet/pull/10935).  Additionally `postgresql-9.6-postgis-2.5` is not available in our apt server.  We actually need `postgresql-9.6-postgis-2.4`.

Trello card: https://trello.com/c/hirdtB41