### PR TITLE
Upgrade gdal to 2.4.4

### DIFF
--- a/hieradata_aws/class/integration/ci_agent.yaml
+++ b/hieradata_aws/class/integration/ci_agent.yaml
@@ -9,7 +9,7 @@ clamav::use_service: false
 
 govuk_ci::agent::postgresql::mapit_role_password: 'mapit'
 govuk_ci::agent::postgresql::email_alert_api_role_password: 'email-alert-api'
-govuk_ci::agent::gdal_version: "1.11.5"
+govuk_ci::agent::gdal_version: "2.4.4"
 govuk_ci::agent::gemstash_server: 'http://gemstash'
 govuk_containers::elasticsearch::secondary::enable: false
 postgresql::globals::version: '9.6'

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -576,7 +576,7 @@ govuk::apps::manuals_publisher::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::manuals_publisher::nagios_memory_warning: 1000
 govuk::apps::manuals_publisher::nagios_memory_critical: 1200
 
-govuk::apps::mapit::gdal_version: "1.11.5"
+govuk::apps::mapit::gdal_version: "2.4.4"
 
 govuk::apps::publisher::alert_hostname: 'alert'
 govuk::apps::publisher::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"

--- a/modules/govuk_ci/manifests/agent.pp
+++ b/modules/govuk_ci/manifests/agent.pp
@@ -13,7 +13,7 @@
 class govuk_ci::agent(
   $master_ssh_key = undef,
   $gemstash_server = 'http://gemstash.cluster',
-  $gdal_version =  '1.11.5',
+  $gdal_version =  '2.4.4',
 ) {
   include ::govuk_java::openjdk8::jre
   include ::govuk_java::openjdk8::jdk


### PR DESCRIPTION
This will allow us to upgrade Mapit to use Django 3.0.

As there is no gdal 2.4.4 package for Ubuntu Trusty, we've compiled and hosted our own, which is covered by https://github.com/alphagov/packager/pull/189.  This has been uploaded to our `apt` server and can be seen at https://apt.publishing.service.gov.uk/gdal/dists/stable/main/binary-amd64/Packages.

Trello card: https://trello.com/c/oxWQqFGA