### PR TITLE
Add Nginx cache for Mapit

### DIFF
--- a/modules/govuk/manifests/app.pp
+++ b/modules/govuk/manifests/app.pp
@@ -143,6 +143,14 @@
 # possible number of "special cases". As such, use of this option is
 # discouraged, and it is included for backwards compatibility purposes only.
 #
+# [*nginx_cache*]
+# configuration to enable caching within ngnix
+#
+# This parameter can be used to set up a nginx cache and takes a hash with
+# values for the following keys: `key_name`, `key_size`, `max_age` and
+# `max_size`. Use of this option is discouraged.
+#
+# Default: {}
 #
 # [*nagios_memory_warning*]
 # memory use at which Nagios should generate a warning
@@ -286,6 +294,7 @@ define govuk::app (
   $vhost_protected = false,
   $vhost_ssl_only = false,
   $nginx_extra_config = '',
+  $nginx_cache = {},
   $alert_5xx_warning_rate = 0.05,
   $alert_5xx_critical_rate = 0.1,
   $nagios_memory_warning = undef,
@@ -364,6 +373,7 @@ define govuk::app (
     vhost_protected                     => $vhost_protected,
     vhost_ssl_only                      => $vhost_ssl_only,
     nginx_extra_config                  => $nginx_extra_config,
+    nginx_cache                         => $nginx_cache,
     health_check_path                   => $health_check_path,
     health_check_custom_doc             => $health_check_custom_doc,
     json_health_check                   => $json_health_check,

--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -82,6 +82,12 @@
 #   established TCP connections to $port.
 #   Default: undef
 #
+# [*nginx_cache*]
+#   This parameter can be used to set up a nginx cache and takes a hash with
+#   values for the following keys: `key_name`, `key_size`, `max_age` and
+#   `max_size`. Use of this option is discouraged.
+#   Default: {}
+#
 define govuk::app::config (
   $app_type,
   $domain,
@@ -93,6 +99,7 @@ define govuk::app::config (
   $vhost_protected = false,
   $vhost_ssl_only = false,
   $nginx_extra_config = '',
+  $nginx_cache = {},
   $health_check_path = 'NOTSET',
   $health_check_custom_doc = false,
   $json_health_check = false,
@@ -276,6 +283,7 @@ define govuk::app::config (
       app_port                       => $port,
       ssl_only                       => $vhost_ssl_only,
       nginx_extra_config             => $nginx_extra_config,
+      nginx_cache                    => $nginx_cache,
       deny_framing                   => $deny_framing,
       asset_pipeline                 => $asset_pipeline,
       asset_pipeline_prefixes        => $asset_pipeline_prefixes,

--- a/modules/govuk/manifests/app/nginx_vhost.pp
+++ b/modules/govuk/manifests/app/nginx_vhost.pp
@@ -25,6 +25,13 @@
 # [*nginx_extra_config*]
 #   A string containing additional nginx config
 #
+# [*nginx_cache*]
+#   Configuration to enable caching within ngnix
+#
+#   This parameter can be used to set up a nginx cache and takes a hash with
+#   values for the following keys: `key_name`, `key_size`, `max_age` and
+#   `max_size`. Use of this option is discouraged.
+#
 # [*deny_framing*]
 #   Boolean, whether nginx should instruct browsers to not allow framing the page
 #
@@ -73,6 +80,7 @@ define govuk::app::nginx_vhost (
   $protected_location = '/',
   $ssl_only = false,
   $nginx_extra_config = '',
+  $nginx_cache = {},
   $deny_framing = false,
   $deny_crawlers = false,
   $is_default_vhost = false,
@@ -120,5 +128,9 @@ define govuk::app::nginx_vhost (
     alert_5xx_critical_rate        => $alert_5xx_critical_rate,
     proxy_http_version_1_1_enabled => $proxy_http_version_1_1_enabled,
     http_host                      => $http_host,
+    cache_key_name                 => $nginx_cache['key_name'],
+    cache_key_size                 => $nginx_cache['key_size'],
+    cache_max_size                 => $nginx_cache['max_size'],
+    cache_max_age                  => $nginx_cache['max_age'],
   }
 }

--- a/modules/govuk/manifests/apps/mapit.pp
+++ b/modules/govuk/manifests/apps/mapit.pp
@@ -38,6 +38,12 @@ class govuk::apps::mapit (
       sentry_dsn                         => $sentry_dsn,
       monitor_unicornherder              => true,
       local_tcpconns_established_warning => 16,
+      nginx_cache                        => {
+        'key_name' => 'mapit_cache',
+        'key_size' => '50m',
+        'max_size' => '5g',
+        'max_age'  => '24h',
+      },
     }
 
     govuk_postgresql::db { 'mapit':

--- a/modules/icinga/templates/check_mapit.cfg.erb
+++ b/modules/icinga/templates/check_mapit.cfg.erb
@@ -1,9 +1,9 @@
 define command {
   command_name check_mapit
   <%- if scope.lookupvar('::aws_migration') %>
-  command_line /usr/lib/nagios/plugins/check_http -H mapit.<%= @app_domain_internal %> -u /postcode/W54XA -w1 -c2 -s 'E14000676' --ssl
+  command_line /usr/lib/nagios/plugins/check_http -H mapit.<%= @app_domain_internal %> -u /postcode/W54XA?nocache=true -w1 -c2 -s 'E14000676' --ssl
   <%- else %>
-  command_line /usr/lib/nagios/plugins/check_http -H mapit.<%= @app_domain %> -u /postcode/W54XA -w1 -c2 -s 'E14000676' --ssl
+  command_line /usr/lib/nagios/plugins/check_http -H mapit.<%= @app_domain %> -u /postcode/W54XA?nocache=true -w1 -c2 -s 'E14000676' --ssl
   <%- end %>
 
 }

--- a/modules/nginx/manifests/config/vhost/proxy.pp
+++ b/modules/nginx/manifests/config/vhost/proxy.pp
@@ -73,6 +73,20 @@
 #   Boolean, whether Nginx should serve a robots.txt that
 #   prevents crawlers from indexing the thing being proxied.
 #
+# [*cache_key_name*]
+#   String, the name of the ngnix cache key_zone. Setting this enables a ngnix
+#   cache.
+#
+# [*cache_key_size*]
+#   String, the size of the ngnix cache key_zone.
+#
+# [*cache_max_size*]
+#   String, the maximum size for the nginx cache.
+#
+# [*cache_max_age*]
+#   String, the maximum age of the nginx cache. Sets when items are invalidated
+#   and sets the Cache-Control max age header.
+#
 define nginx::config::vhost::proxy(
   $to,
   $to_ssl = false,
@@ -95,6 +109,10 @@ define nginx::config::vhost::proxy(
   $proxy_http_version_1_1_enabled = false,
   $http_host = undef,
   $deny_crawlers = false,
+  $cache_key_name = undef,
+  $cache_key_size = undef,
+  $cache_max_size = undef,
+  $cache_max_age = undef,
 ) {
   validate_re($ensure, '^(absent|present)$', 'Invalid ensure value')
 

--- a/modules/nginx/templates/proxy-vhost.conf
+++ b/modules/nginx/templates/proxy-vhost.conf
@@ -4,6 +4,10 @@ upstream <%= @name %>-proxy {
   <%- end -%>
 }
 
+<%- if @cache_key_name -%>
+proxy_cache_path /var/cache/nginx levels=1:2 keys_zone=<%= @cache_key_name %>:<%= @cache_key_size %> max_size=<%= @cache_max_size %> inactive=<%= @cache_max_age %> use_temp_path=off;
+<%- end -%>
+
 <%- if scope.lookupvar('::aws_migration') -%>
 # Set GOVUK-Request-Id if not set
 # See http://nginx.org/en/docs/http/ngx_http_perl_module.html
@@ -143,6 +147,13 @@ server {
   <%- end -%>
   location @app {
     proxy_pass <%= @to_proto -%><%= @name %>-proxy;
+    <%- if @cache_key_name -%>
+    proxy_cache <%= @cache_key_name %>;
+    proxy_ignore_headers Cache-Control;
+    proxy_cache_valid any <%= @cache_max_age %>;
+    proxy_cache_bypass $arg_nocache;
+    add_header X-Proxy-Cache $upstream_cache_status;
+    <%- end -%>
     <%= @extra_app_config %>
   }
 


### PR DESCRIPTION
This PR adds the ability to set a Ngnix cache for GOV.UK apps and enables it for the Mapit application.

Mapit as a backing service currently has no caching available and its underlying data is infrequently updated. Therefore subsequent same requests create unnecessary database look ups and overhead, which can add latency and lower capacity to user facing services such as the COVID Tiers postcode checker and the local transactions pages.

Initial investigation was done to see if cache could be done at an application level (Django) - however this involves a codebase change and is still pending with the original developers.

The query param `?no cache=true` can added to request to bypass the cache and used to make sure health checks are monitoring the underlying application rather than the cache.