### PR TITLE
Upgrade PostGIS to 3.1.1 for Mapit

### DIFF
--- a/hieradata_aws/class/integration/ci_agent.yaml
+++ b/hieradata_aws/class/integration/ci_agent.yaml
@@ -13,7 +13,7 @@ govuk_ci::agent::gdal_version: "2.4.4"
 govuk_ci::agent::gemstash_server: 'http://gemstash'
 govuk_containers::elasticsearch::secondary::enable: false
 postgresql::globals::version: '9.6'
-postgresql::globals::postgis_version: '2.4'
+postgresql::globals::postgis_version: '3.1.1'
 govuk_postgresql::server::enable_collectd: false
 govuk_python::govuk_python_version: '3.6.12'
 

--- a/hieradata_aws/class/integration/mapit.yaml
+++ b/hieradata_aws/class/integration/mapit.yaml
@@ -1,4 +1,4 @@
-postgresql::globals::postgis_version: '2.4'
+postgresql::globals::postgis_version: '3.1.1'
 
 lv:
   data:

--- a/modules/govuk/manifests/node/s_apt.pp
+++ b/modules/govuk/manifests/node/s_apt.pp
@@ -140,6 +140,7 @@ class govuk::node::s_apt (
   aptly::repo { 'jenkins-agent': }
   aptly::repo { 'locksmithctl': }
   aptly::repo { 'logstash': }
+  aptly::repo { 'postgis': }
   aptly::repo { 'rbenv-ruby': }
   aptly::repo { 'rbenv-ruby-xenial':
     distribution => 'xenial',

--- a/modules/govuk_ci/manifests/agent.pp
+++ b/modules/govuk_ci/manifests/agent.pp
@@ -74,6 +74,8 @@ class govuk_ci::agent(
   $deb_packages = [
     'jq',
     'libfreetype6-dev', # govuk-taxonomy-supervised-learning
+    'libgeos-dev',
+    'libproj-dev',
     'shellcheck',
   ]
 

--- a/modules/govuk_postgresql/manifests/mirror.pp
+++ b/modules/govuk_postgresql/manifests/mirror.pp
@@ -13,5 +13,12 @@ class govuk_postgresql::mirror (
       architecture => $::architecture,
       key          => $apt_mirror_gpg_key_fingerprint,
     }
+
+    apt::source { 'postgis':
+      location     => "http://${apt_mirror_hostname}/postgis",
+      release      => $::lsbdistcodename,
+      architecture => $::architecture,
+      key          => $apt_mirror_gpg_key_fingerprint,
+    }
   }
 }


### PR DESCRIPTION
[We have built our own version of PostGIS](https://github.com/alphagov/packager/pull/190) which includes a version of GDAL that is supported by Django 3.

We now need to start using that build in CI and integration.

This has fixed the issue with PostGIS in the CI build (compare https://ci.integration.publishing.service.gov.uk/job/mapit/job/pull-mysociety-changes-upstream/69/console to https://ci.integration.publishing.service.gov.uk/job/mapit/job/pull-mysociety-changes-upstream/67/console).  There are still failures, but they are not related to being unable to load PostGIS.

Trello card: https://trello.com/c/BE3TN7De