### PR TITLE
Upgrade Go version to 1.15.8 on Jenkins and CI Agent instances

### DIFF
--- a/modules/golang/manifests/init.pp
+++ b/modules/golang/manifests/init.pp
@@ -11,7 +11,7 @@ class golang {
     require        => Class['govuk_ppa'],
   }
 
-  goenv::version { ['1.7.1', '1.9.1', '1.11.13', '1.12.1', '1.12.9', '1.13']: }
+  goenv::version { ['1.11.13', '1.15.8']: }
 
   package { ['godep']:
     ensure  => latest,


### PR DESCRIPTION
Jenkins (Deploy & CI) run builds and tests for Router.

This removes some unused versions of Go, and adds the newest version - 1.11.13 and 1.15.8 should be the only versions in use by Router.