### PR TITLE
Set golang global_version as latest version

### DIFF
--- a/modules/golang/manifests/init.pp
+++ b/modules/golang/manifests/init.pp
@@ -11,7 +11,12 @@ class golang {
     require        => Class['govuk_ppa'],
   }
 
-  goenv::version { ['1.11.13', '1.12.1', '1.15.8']: }
+  goenv::version { [
+    '1.7.1',   # Used by alphagov/govuk_crawler_worker
+    '1.11.13', # Used by alphagov/router
+    '1.12.1',  # Used by alphagov/govuk-csp-forwarder
+    '1.15.8',  # Used by alphagov/router
+    ]: }
 
   package { ['godep']:
     ensure  => latest,

--- a/modules/golang/manifests/init.pp
+++ b/modules/golang/manifests/init.pp
@@ -7,11 +7,11 @@ class golang {
   include govuk_ppa
 
   class { 'goenv':
-    global_version => '1.9.1',
+    global_version => '1.15.8',
     require        => Class['govuk_ppa'],
   }
 
-  goenv::version { ['1.11.13', '1.15.8']: }
+  goenv::version { ['1.11.13', '1.12.1', '1.15.8']: }
 
   package { ['godep']:
     ensure  => latest,


### PR DESCRIPTION
Also re-adds 1.12.1 as this is used by the CSP Forwarder
https://github.com/alphagov/govuk-csp-forwarder