### PR TITLE
Upgrade Mapit to use PostgreSQL 9.6

### DIFF
--- a/hieradata_aws/class/integration/mapit.yaml
+++ b/hieradata_aws/class/integration/mapit.yaml
@@ -1,3 +1,4 @@
+postgresql::globals::version: '9.6'
 postgresql::globals::postgis_version: '3.1.1'
 
 lv:


### PR DESCRIPTION
We had a mismatch between the CI and integration version of PostgreSQL used for Mapit.  CI was using 9.6 but integration was using 9.3.

Now we have built our own version of PostGIS (to include the latest GDAL library), we need to also upgrade PostgreSQL so the dependency can be installed.

Trello card: https://trello.com/c/BE3TN7De