### PR TITLE
Add further GDAL dependencies

### DIFF
--- a/modules/govuk_ci/manifests/agent.pp
+++ b/modules/govuk_ci/manifests/agent.pp
@@ -82,6 +82,8 @@ class govuk_ci::agent(
   $deb_packages = [
     'jq',
     'libfreetype6-dev', # govuk-taxonomy-supervised-learning
+    'libhdf4-0-alt',
+    'libnetcdf-dev',
     'shellcheck',
   ]
 


### PR DESCRIPTION
libnetcdf-dev and libhdf4-0-alt are both required to run GDAL 2.4.4 which is used by Mapit.

Trello card: https://trello.com/c/BE3TN7De