### PR TITLE
Add GDAL dependency

### DIFF
--- a/modules/govuk_ci/manifests/agent.pp
+++ b/modules/govuk_ci/manifests/agent.pp
@@ -85,6 +85,7 @@ class govuk_ci::agent(
     'libhdf4-0-alt',
     'libnetcdf-dev',
     'shellcheck',
+    'unixodbc-dev',
   ]
 
   $deb_absent_packages = [


### PR DESCRIPTION
unixodbc-dev is also required to run GDAL 2.4.4 which is used by
Mapit.

Trello card: https://trello.com/c/BE3TN7De/2344-8-fix-gdal-and-postgis-issue-for-mapit-in-ci-%F0%9F%8D%90