### PR TITLE
Update Mapit to use Python 3.6

### DIFF
--- a/hieradata_aws/class/mapit.yaml
+++ b/hieradata_aws/class/mapit.yaml
@@ -11,3 +11,4 @@ mount:
     mountoptions: 'defaults'
 
 govuk_postgresql::server::listen_addresses: localhost
+govuk_python::govuk_python_version: '3.6.12'


### PR DESCRIPTION
We [upgraded the Python used in CI to be Python 3.6](https://github.com/alphagov/govuk-puppet/commit/64fe47f435a049ac348a9ec6b296b29baa5cbe55#diff-c4a319376e182c98cdaf96574876b36ea7a793955d0fdc2499bcb72340def948R17), which is required for Mapit to run Django 3. However we didn't do this for the Mapit machines themselves.

Trello card: https://trello.com/c/rm2WTeqk