### PR TITLE
Remove GDAL 1 from Mapit

### DIFF
--- a/modules/govuk/manifests/apps/mapit.pp
+++ b/modules/govuk/manifests/apps/mapit.pp
@@ -66,6 +66,10 @@ class govuk::apps::mapit (
       ensure => present,
     }
 
+    package { 'libgdal1h':
+      ensure => 'absent',
+    }
+
     # Install postgrest developments dependencies
     include postgresql::lib::devel
 


### PR DESCRIPTION
We should be using GDAL 2.4.4 but are still installing GDAL 1 on
the Mapit machines.
Ensuring this package is set to `absent` should prevent it from
being installed.

Trello card: https://trello.com/c/BE3TN7De/2344-8-fix-gdal-and-postgis-issue-for-mapit-in-ci-%F0%9F%8D%90