### PR TITLE
Update dependencies for Mapit class

### DIFF
--- a/hieradata_aws/class/integration/mapit.yaml
+++ b/hieradata_aws/class/integration/mapit.yaml
@@ -1,3 +1,5 @@
+---
+
 postgresql::globals::version: '9.6'
 postgresql::globals::postgis_version: '3.1.1'
 

--- a/hieradata_aws/class/mapit.yaml
+++ b/hieradata_aws/class/mapit.yaml
@@ -12,3 +12,6 @@ mount:
 
 govuk_postgresql::server::listen_addresses: localhost
 govuk_python::govuk_python_version: '3.6.12'
+
+postgresql::globals::version: '9.6'
+postgresql::globals::postgis_version: '3.1.1'


### PR DESCRIPTION
We have previously updated the Mapit dependencies in CI (https://github.com/alphagov/govuk-puppet/pull/10937, https://github.com/alphagov/govuk-puppet/pull/10939, https://github.com/alphagov/govuk-puppet/pull/10942, https://github.com/alphagov/govuk-puppet/pull/10943, https://github.com/alphagov/govuk-puppet/pull/10944 and https://github.com/alphagov/govuk-puppet/pull/10945). This makes those same changes to the Mapit machines for other environments.

Trello card: https://trello.com/c/rm2WTeqk