### PR TITLE
Remove app restarts/day alert

### DIFF
--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -336,17 +336,6 @@ define govuk::app::config (
       attempts_before_hard_state => 3,
       contact_groups             => $additional_check_contact_groups,
     }
-    @@icinga::check::graphite { "check_${title}_app_memory_restarts${::hostname}":
-      ensure         => $ensure,
-      target         => "summarize(transformNull(stats_counts.govuk.app.${title}.memory_restarts,0),\"1d\",\"sum\",false)",
-      args           => '--ignore-missing',
-      from           => '1days',
-      warning        => 4,
-      critical       => 10 ,
-      desc           => "${title} restarts per day due to memory usage",
-      host_name      => $::fqdn,
-      contact_groups => $additional_check_contact_groups,
-    }
     if $alert_when_threads_exceed {
       @@icinga::check::graphite { "check_${title}_app_thread_count_${::hostname}":
         ensure                     => $ensure,


### PR DESCRIPTION
## Problem

We have 44 warning alerts in production, most of which are for "manuals-frontend restarts per day due to memory usage".

This sounds scary and important, especially when [looking at the graph](https://graphite.production.govuk.digital/render/?width=1000&height=600&from=-1days&colorList=red,orange,blue,green,purple,brown&target=alias(dashed(constantLine(10)),%22critical%22)&target=alias(dashed(constantLine(4)),%22warning%22)&target=summarize(transformNull(stats_counts.govuk.app.manuals-frontend.memory_restarts,0),%221d%22,%22sum%22,false)), which shows restarts going up and to the right, until you actually look at what triggers the alert.

Changing the summarized window that we alert on to 5 minutes shows the situation [is not scary at all](https://graphite.production.govuk.digital/render/?width=1000&height=600&from=-1days&colorList=red,orange,blue,green,purple,brown&target=alias(dashed(constantLine(10)),%22critical%22)&target=alias(dashed(constantLine(4)),%22warning%22)&target=summarize(transformNull(stats_counts.govuk.app.manuals-frontend.memory_restarts,0),%225min%22,%22sum%22,false)). The app, which we run across 39 machines, has restarted 8 times since 00:00 this morning (about once an hour). There are no recorded instances of this impacting end users. However, this alert is distracting us from other tasks.

## Solution

This alert doesn't add value so let's remove it.

We should not alert on app restarts due to OOM. We should alert on symptoms affecting end users, since we'll need to alert on those anyway. App restarts is an interesting metric, but not necessarily a cause for any issues, and not actionable unless it is impacting users.

An alternative would be to modify the alert so we hear only when we're restarting a lot (e.g. changing the restart window we check to ~3min). This is sub-optimal since we are assuming this is the rate at which users would notice, and therefore we should just alert on the symptom users experience (e.g. 5xx rate).