### PR TITLE
Add script to supervise initctl

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1173,6 +1173,8 @@ govuk_sudo::sudo_conf:
     content: 'deploy ALL=NOPASSWD:/usr/bin/varnishadm'
   deploy_govuk_unicorn_reload:
     content: 'deploy ALL=NOPASSWD:/usr/local/bin/govuk_unicorn_reload'
+  deploy_govuk_supervised_initctl:
+    content: 'deploy ALL=NOPASSWD:/usr/local/bin/govuk_supervised_initctl'
   icinga_init_ctl:
     content: 'nagios ALL=NOPASSWD:/sbin/initctl reload *'
   icinga_initctl_restart:

--- a/modules/govuk/files/usr/local/bin/govuk_supervised_initctl
+++ b/modules/govuk/files/usr/local/bin/govuk_supervised_initctl
@@ -1,0 +1,156 @@
+#!/bin/bash
+
+# This script is a wrapper around upstart initctl start/restart/reload
+# commands and is intended for applications/service that have their main
+# process in a pid file at /var/run/$service/app.pid - which is the case for
+# most GOV.UK applications
+#
+# The purpose of this script is to determine whether running `initctl
+# start|restart|reload` actually results in running processes with the old
+# one stopped. This is particularly to handle the case where upstart creates
+# a new process and it subsequently fails to boot. We handle this by waiting
+# a period of time before checking the process is running.
+#
+# This script is pretty heavily nuanced towards GOV.UK's use cases and quirks,
+# - it isn't intended to be a generic initctl wrapper for all use cases. I'm
+# convinced there are better ways to manage this problem that don't involve
+# this type of script, so I hope as GOV.UK moves into the future this script
+# becomes redundant.
+
+if [ "$#" -ne "2" ]; then
+  echo "Usage: sudo govuk_supervised_initctl <COMMAND> <SERVICE>"
+  exit 1
+fi
+
+set -eu
+
+status () {
+  echo "---> ${@}"
+}
+
+error () {
+  echo "ERROR: ${@}" >&2
+  exit 1
+}
+
+pid_running () {
+  ps -p ${@} &> /dev/null
+}
+
+command=$1
+service=$2
+pid_file=/var/run/$service/app.pid
+original_pid=""
+if [ -e $pid_file ]; then
+  original_pid=$(cat $pid_file)
+fi
+
+case $command in
+  start)
+    status "Checking if ${service} is running"
+
+    if [ ! -z $original_pid ] && pid_running $original_pid; then
+      if [[ $(initctl status $service) =~ "running" ]]; then
+        status "${service} is running"
+        exit 1
+      else
+        # Bail out in the unlikely event that Upstart thinks the process isn't
+        # running but there is a running pid for it.
+        error "${service} seems to be running outside of Upstart on process ${original_pid}"
+      fi
+    elif [[ $(initctl status $service) =~ "running" ]]; then
+      # Checking `initctl status` doesn't necessarily mean a GOV.UK service is
+      # running. For example, unicornherder processes have two PIDs: one for
+      # the parent "herder" process and one for the child "master" process; the
+      # former is tracked by Upstart, the latter by the pidfile. If Upstart believes
+      # the process is running it will need to be stopped before another attempt
+      # to start the service. This is a convenience to avoid manual intervention.
+      status "${service} is an inconsistent state, stopping before starting..."
+      initctl stop $service
+    else
+      status "${service} is not running, starting..."
+    fi
+
+    initctl start $service
+
+    sleep 10 # modest amount of time to check if the process is stable
+
+    if [ -e $pid_file ]; then
+      new_pid=$(cat $pid_file)
+    else
+      error "${service} hasn't started properly, there is no pid file at ${pid_file}"
+    fi
+
+    if pid_running $new_pid; then
+      status "${service} has started with process ${new_pid}"
+    else
+      error "${service} has failed to start"
+    fi
+    ;;
+  restart)
+    ([ ! -z $original_pid ] && pid_running $original_pid) || error "${service} is not running"
+
+    status "${service} is running with process ${original_pid}. Restarting..."
+
+    initctl restart $service
+
+    sleep 10 # modest amount of time to allow the restart to occur and new process to become stable
+
+    if [ -e $pid_file ]; then
+      new_pid=$(cat $pid_file)
+    else
+      error "${service} hasn't restarted properly, there is no pid file at ${pid_file}"
+    fi
+
+    if ! pid_running $new_pid; then
+      error "${service} failed to restart, a new process hasn't started"
+    elif pid_running $original_pid; then
+      error "${service} failed to restart, the old process (${original_pid}) hasn't exited"
+    else
+      status "${service} has restarted with process ${new_pid}"
+    fi
+    ;;
+  # This is intended for applications, such as Unicorn, where a reload signal
+  # results in the process referenced by the pid file being replaced with
+  # and the old process gradually terminated.
+  reload)
+    ([ ! -z $original_pid ] && pid_running $original_pid) || error "${service} is not running"
+
+    status "${service} is running with process ${original_pid}. Reloading..."
+    initctl reload $service
+
+    waiting_for=0
+    new_pid=""
+
+    while true; do
+      sleep 10
+      waiting_for=$(($waiting_for+10))
+      current_pid=$(cat $pid_file) || error "Couldn't establish the current pid"
+
+      if [ -z $new_pid ] && [ $original_pid -ne $current_pid ]; then
+        new_pid=$current_pid
+        status "New process ${new_pid} started"
+      fi
+
+      if ! pid_running $original_pid; then
+        status "Process ${original_pid} has exited"
+        break
+      # we expect 3 minutes to be amble time to allow an app to restart and
+      # if we reach this long a wait then something has gone wrong.
+      elif [ $waiting_for -gt 180 ]; then
+        error "Process ${original_pid} is still running after 3 minutes, something has gone wrong"
+      else
+        status "Waiting for processes to swap over"
+      fi
+    done
+
+    if pid_running $new_pid; then
+      status "Successfully reloaded ${service}"
+    else
+      error "The new process for ${service} doesn't appear to be running"
+    fi
+    ;;
+  *)
+    error "Unsupported command '${command}'. Only start, restart and reload are supported"
+    ;;
+esac

--- a/modules/govuk/manifests/deploy/config.pp
+++ b/modules/govuk/manifests/deploy/config.pp
@@ -88,6 +88,12 @@ class govuk::deploy::config(
     mode   => '0755',
   }
 
+  file { '/usr/local/bin/govuk_supervised_initctl':
+    ensure => present,
+    source => 'puppet:///modules/govuk/usr/local/bin/govuk_supervised_initctl',
+    mode   => '0755',
+  }
+
   # govuk_setenv is a simple script that loads the environment for a GOV.UK
   # application and execs its arguments
   # daemontools provides envdir, used by govuk_setenv


### PR DESCRIPTION
Trello: https://trello.com/c/cwsh79vA/200-rollout-of-continuous-deployment

This adds a script to wrap around the calls made to "initctl start $app",
"initctl restart $app" and "initctl reload $app" as part of an
application deployment. This script adds the ability to monitor that
these calls result in a new process that is actually running and the old
process ending.

The motivation to add this is to support continuous deployment on
GOV.UK. In particular the need to know that a service is successfully
running after a restart [1]. I felt the most consistent way this could
be solved was by applying a wrapper command rather than modifying the
deployment scripts for services specifically. This wrapper is also
helpful for the other major GOV.UK app services as it will fail a
deployment if these fail to start which will mean we know of a problem
sooner.

I expect this to be applied by changing [2] from:

```
if fetch(:perform_hard_restart, false)
  run "sudo initctl start #{application} 2>/dev/null || sudo initctl restart #{application}"
else
  run "sudo initctl start #{application} 2>/dev/null || sudo govuk_unicorn_reload #{application}"
end
```
to:

```
if fetch(:perform_hard_restart, false)
  run "sudo govuk_supervised_initctl start #{application} || sudo govuk_supervised_initctl restart #{application}"
else
  run "sudo govuk_supervised_initctl start #{application} || sudo govuk_supervised_initctl reload #{application}"
end
```

I'm pretty convinced that this wrapper script is rather a nasty way to solve
these problems and I expect that it's probably resolved with better/newer
tools. It seems strange that upstart doesn't realise it started something
that failed instantly - maybe systemd knows how to deal with that? I hope
and expect this script to only live as long as we continue using Trusty.

Note this script supersedes govuk_unicorn_reload and once things are
migrated to this I will remove that.

[1]: https://github.com/alphagov/govuk-rfcs/blame/master/rfc-128-continuous-deployment.md#L143
[2]: https://github.com/alphagov/govuk-app-deployment/blob/e3f0bb339b60021fb0663aa9868cede064e8c1cd/recipes/ruby.rb#L20-L27