### PR TITLE
Make branch a parameter in Deploy_CDN job

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_cdn.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_cdn.yaml.erb
@@ -5,7 +5,7 @@
         - git:
             url: git@github.com:alphagov/govuk-cdn-config.git
             branches:
-              - master
+              - $GOVUK_CDN_CONFIG_BRANCH
             wipe-workspace: true
             clean:
                 after: true
@@ -64,3 +64,7 @@
         - password:
             name: FASTLY_API_KEY
             default: false
+        - string:
+            name: GOVUK_CDN_CONFIG_BRANCH
+            description: Branch of govuk-cdn-config to use.
+            default: master


### PR DESCRIPTION
This makes it easier to test out branches of govuk-cdn-config, without having to change the definition of the Jenkins job.