### PR TITLE
Add GCP icinga alert

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -415,6 +415,10 @@ task :check_consistency_between_aws_and_carrenza do
     monitoring::checks::cache::servers
     monitoring::checks::lb::region
     monitoring::checks::lb::loadbalancers
+    monitoring::checks::mirror::enabled
+    monitoring::checks::mirror::gcp_mirror_sync_project_id
+    monitoring::checks::mirror::gcp_mirror_sync_transfer_job_auth_json
+    monitoring::checks::mirror::gcp_mirror_sync_transfer_job_name
     monitoring::checks::rds::servers
     monitoring::client::alert_hostname
     monitoring::checks::sidekiq::enable_signon_check

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1062,6 +1062,8 @@ monitoring::checks::http_password: "%{hiera('http_password')}"
 monitoring::checks::sidekiq::enable_support_check: false
 monitoring::contacts::slack_icinga_status_cgi_url: "https://alert.%{hiera('app_domain')}/cgi-bin/icinga/status.cgi"
 monitoring::contacts::slack_icinga_extinfo_cgi_url: "https://alert.%{hiera('app_domain')}/cgi-bin/icinga/extinfo.cgi"
+monitoring::gcloud::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+monitoring::gcloud::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 monitoring::vpn_gateways::endpoints:
   vpn_gateway_api_dr:

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1454,6 +1454,13 @@ monitoring::checks::rds::servers:
    - 'mysql-primary'
    - 'mysql-replica'
 
+monitoring::checks::mirror::gcp_mirror_sync_project_id: "%{hiera('monitoring::gcp_mirror_sync_project_id')}"
+monitoring::checks::mirror::gcp_mirror_sync_transfer_job_auth_json: "%{hiera('monitoring::gcp_mirror_sync_transfer_job_auth_json')}"
+monitoring::checks::mirror::gcp_mirror_sync_transfer_job_name: "%{hiera('monitoring::gcp_mirror_sync_transfer_job_name')}"
+
+monitoring::gcloud::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+monitoring::gcloud::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
+
 monitoring::uptime_collector::aws: true
 
 # FIXME: this has been added to avoid a bug until we move to v3 of the module

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -387,6 +387,7 @@ licensify::apps::licensify::environment: 'production'
 licensify::apps::licensify_feed::environment: 'production'
 
 monitoring::checks::aws_origin_domain: "production.govuk.digital"
+monitoring::checks::mirror::enabled: true
 monitoring::checks::sidekiq::enable_signon_check: false
 monitoring::checks::rds::region: 'eu-west-1'
 monitoring::checks::aws_iam_key::enabled: true
@@ -456,7 +457,6 @@ monitoring::contacts::slack_channel: '#govuk-alerts'
 monitoring::contacts::slack_username: 'Production (AWS)'
 monitoring::edge::enabled: true
 monitoring::pagerduty_drill::enabled: true
-
 
 monitoring::checks::rds::servers:
    - 'postgresql-primary'

--- a/modules/monitoring/files/etc/nagios3/conf.d/check_mirror_file_sync.cfg
+++ b/modules/monitoring/files/etc/nagios3/conf.d/check_mirror_file_sync.cfg
@@ -1,0 +1,4 @@
+define command {
+  command_name check_mirror_file_sync
+  command_line /usr/lib/nagios/plugins/check_mirror_file_sync --google_application_credentials_file_path=$ARG1$ --gcp_project_id=$ARG2$ --transfer_job_name=$ARG3$
+}

--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_mirror_file_sync
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_mirror_file_sync
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+set -eou pipefail
+
+STATE_UNKNOWN=3
+
+function usage()
+{
+cat << EOF
+usage: $0 [options]
+
+This script checks the status of the latest transfer job operation which mirrors content from AWS to GCP. 
+It relies on the google-cloud-sdk to query the Google Storage Transfer Service API. This script is meant 
+for Nagios.
+
+OPTIONS:
+    -h or --help           Show this message
+
+    --google_application_credentials_file_path=x    Required: Enter the absolute file path to the Google application credentials file. This should a JSON file
+                                                    containing the private key and other credentials that can be used to assume a service account and are available
+                                                    to download upon the creation of a key pair. See https://cloud.google.com/docs/authentication/getting-started 
+                                                    for more details.
+
+    --gcp_project_id=x                              Required: Enter the GCP project id for the project which owns the Transfer Job specified in the transfer_job_name
+                                                    parameter. 
+
+    --transfer_job_name=x                           Required: Enter the Transfer Job name for the job which syncs mirror content to GCP. This can be found in the 
+                                                    configuration for the job. If the name starts with transferJobs/, omit this when entering this parameter.
+
+EOF
+}
+
+function error()
+{
+  echo -e "${1}"
+}
+
+
+#
+# Awesome parameter parsing, see https://stackoverflow.com/a/14203146
+#
+for i in "$@"; do
+case ${i} in
+  --google_application_credentials_file_path=* )
+    GOOGLE_APPLICATION_CREDENTIALS_FILE_PATH="${i#*=}"
+    shift
+    ;;
+
+  --gcp_project_id=* )
+    GCP_PROJECT_ID="${i#*=}"
+    shift
+    ;;
+
+  --transfer_job_name=* )
+    TRANSFER_JOB_NAME="${i#*=}"
+    shift
+    ;;
+
+  help | --help | -h)
+    usage
+    exit ${STATE_UNKNOWN}
+    ;;
+
+  *)
+    error "Error, unknown parameter \"${i}\" given!"
+    echo
+    usage
+    exit ${STATE_UNKNOWN}
+    ;;
+  esac
+done
+
+#
+# Validation
+#
+
+if [[ "${GOOGLE_APPLICATION_CREDENTIALS_FILE_PATH}" == "" ]]; then
+    error "You have to supply the absolute file path for the Google credentials file"
+    usage
+    exit ${STATE_UNKNOWN}
+fi
+
+if [[ "${GCP_PROJECT_ID}" == "" ]]; then
+    error "You have to supply a Google project id"
+    usage
+    exit ${STATE_UNKNOWN}
+fi
+
+if [[ "${TRANSFER_JOB_NAME}" == "" ]]; then
+    error "You have to supply a transfer job name"
+    usage
+    exit ${STATE_UNKNOWN}
+fi
+
+export GOOGLE_APPLICATION_CREDENTIALS="$GOOGLE_APPLICATION_CREDENTIALS_FILE_PATH"
+
+GCP_TRANSFER_SERVICE_TOKEN=$(gcloud auth application-default print-access-token)
+
+latest_operation_name=$(curl --header "Content-Type: application/json" \
+  --header "Authorization: Bearer $GCP_TRANSFER_SERVICE_TOKEN" \
+  --request GET "https://storagetransfer.googleapis.com/v1/transferJobs/$TRANSFER_JOB_NAME?projectId=$GCP_PROJECT_ID" \
+  | jq -r '.latestOperationName')
+
+latest_operation_details=$(curl --header "Content-Type: application/json" \
+  --header "Authorization: Bearer $GCP_TRANSFER_SERVICE_TOKEN" \
+  --request GET "https://storagetransfer.googleapis.com/v1/$latest_operation_name")
+
+status=$(echo $latest_operation_details | jq -r '.metadata.status')
+
+if [[ "$status" == "SUCCESS" ]]; then
+  finish_datetime=$(echo "$latest_operation_details" | jq -r '.metadata.endTime')
+  echo "Mirror files successfully synced to GCP at $finish_datetime"
+  exit 0
+fi
+
+echo "A non-success result was returned - see GCP Storage Transfer Service console for more information."
+echo "Failed operation: $latest_operation_name"
+exit 1

--- a/modules/monitoring/manifests/checks/mirror.pp
+++ b/modules/monitoring/manifests/checks/mirror.pp
@@ -8,14 +8,56 @@
 #   Can be used to disable checks/alerts for a given environment.
 #   Default: false
 #
+# [*gcp_mirror_sync_project_id*]
+#   Sets the GCP project id to use for the transfer job.
+#   Required if enabled=true.
+#
+# [*gcp_mirror_sync_transfer_job_auth_json*]
+#   Sets the auth JSON required by the Google SDK.
+#   Required if enabled=true.
+#
+# [*gcp_mirror_sync_transfer_job_name*]
+#   Sets the transfer job name which controls the mirror sync.
+#   Required if enabled=true.
+#
 class monitoring::checks::mirror (
   $enabled = false,
+  $gcp_mirror_sync_project_id = undef,
+  $gcp_mirror_sync_transfer_job_auth_json = undef,
+  $gcp_mirror_sync_transfer_job_name = undef,
 ) {
   icinga::check_config { 'mirror_age':
     source => 'puppet:///modules/monitoring/etc/nagios3/conf.d/check_mirror_age.cfg',
   }
 
   if $enabled {
+    $google_application_credentials_file_path = '/etc/govuk/gcloud_auth.json'
+
+    file { $google_application_credentials_file_path:
+      ensure  => present,
+      content => $gcp_mirror_sync_transfer_job_auth_json,
+      mode    => '0755',
+      owner   => 'nagios',
+      group   => 'nagios',
+    }
+
+    icinga::plugin { 'check_mirror_file_sync':
+      source  => 'puppet:///modules/monitoring/usr/lib/nagios/plugins/check_mirror_file_sync',
+    }
+
+    icinga::check_config { 'mirror_file_sync':
+      source  => 'puppet:///modules/monitoring/etc/nagios3/conf.d/check_mirror_file_sync.cfg',
+      require => File[$google_application_credentials_file_path],
+    }
+
+    icinga::check { 'check_mirror_file_sync':
+      check_command       => "check_mirror_file_sync!${google_application_credentials_file_path}!${gcp_mirror_sync_project_id}!${gcp_mirror_sync_transfer_job_name}",
+      service_description => 'Check status of latest GCP mirror sync job',
+      use                 => 'govuk_normal_priority',
+      check_interval      => 1440,
+      host_name           => $::fqdn,
+    }
+
     $provider1_subdomain = 'mirror.provider1.production.govuk.service.gov.uk'
     $provider1_vhost     = "www-origin.${provider1_subdomain}"
 

--- a/modules/monitoring/manifests/gcloud.pp
+++ b/modules/monitoring/manifests/gcloud.pp
@@ -1,0 +1,28 @@
+## == Class: monitoring::gcloud
+#
+# Installs and configures Google Cloud SDK
+#
+# === Parameters
+#
+# [*apt_mirror_hostname*]
+#   The hostname of an APT mirror
+#
+# [*apt_mirror_gpg_key_fingerprint*]
+#   The fingerprint of an APT mirror
+#
+class monitoring::gcloud (
+  $apt_mirror_hostname,
+  $apt_mirror_gpg_key_fingerprint,
+){
+  apt::source { 'google-cloud-sdk-trusty':
+    location     => "http://${apt_mirror_hostname}/google-cloud-sdk-trusty",
+    release      => 'stable',
+    architecture => $::architecture,
+    key          => $apt_mirror_gpg_key_fingerprint,
+  }
+
+  package { 'google-cloud-sdk':
+    ensure  => 'present',
+    require => Apt::Source['google-cloud-sdk-trusty'],
+  }
+}

--- a/modules/monitoring/manifests/init.pp
+++ b/modules/monitoring/manifests/init.pp
@@ -23,6 +23,8 @@ class monitoring (
   include monitoring::contacts
   include monitoring::event_handlers
 
+  include monitoring::gcloud
+
   unless $ci_environment {
     # Monitoring server only.
     include monitoring::checks


### PR DESCRIPTION
This commit adds an Icinga check that will check daily whether the GCP
mirror sync has completed succesfully.

This check only applies to the production AWS account.

Trello: https://trello.com/c/Dr8OMcJg