### PR TITLE
Add shared elasticache location for Mapit

### DIFF
--- a/hieradata_aws/class/mapit.yaml
+++ b/hieradata_aws/class/mapit.yaml
@@ -10,6 +10,8 @@ mount:
     govuk_lvm: 'data'
     mountoptions: 'defaults'
 
+govuk::apps::mapit::memcache_servers: 'mapit-memcached:11211'
+
 govuk_postgresql::server::listen_addresses: localhost
 govuk_python::govuk_python_version: '3.6.12'
 

--- a/modules/govuk/manifests/apps/mapit.pp
+++ b/modules/govuk/manifests/apps/mapit.pp
@@ -8,6 +8,9 @@
 # [*port*]
 #   What port should the app run on?
 #
+# [*memcache_servers*]
+#   The memcached location formatted <host>:<port>
+#
 # [*db_password*]
 #   The password for the mapit postgresql role
 #
@@ -30,6 +33,7 @@ class govuk::apps::mapit (
   $enabled = false,
   $port,
   $db_password,
+  $memcache_servers = undef,
   $django_secret_key = undef,
   $sentry_dsn = undef,
   $gdal_version,
@@ -105,6 +109,9 @@ class govuk::apps::mapit (
   }
 
   govuk::app::envvar {
+    "${title}-MEMCACHE_SERVERS":
+        varname => 'MEMCACHE_SERVERS',
+        value   => $memcache_servers;
     "${title}-DB_PASSWORD":
         varname => 'MAPIT_DB_PASS',
         value   => $db_password;


### PR DESCRIPTION
This adds a "MEMCACHE_SERVERS" environment variable to point Mapit it at a shared elasticached instance. This should double caching efficiency as we currently cache per instance. It will also allow us to pre-warm our cache more quickly without having to warm multiple caches.