### PR TITLE
Add a new "account" machine class

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -11,6 +11,8 @@ app_domain_internal: '%{::aws_stackname}.govuk-internal.digital'
 backup::mysql::alert_hostname: 'alert'
 
 node_class: &node_class
+  account:
+    apps: []
   asset_master:
     apps:
       - asset_env_sync

--- a/modules/govuk/manifests/node/s_account.pp
+++ b/modules/govuk/manifests/node/s_account.pp
@@ -1,0 +1,19 @@
+# == Class: govuk::node::s_account
+#
+# Account machine definition. Accounts machines are used for running
+# the Account API application which implements authentication and
+# attribute storage.
+#
+class govuk::node::s_account inherits govuk::node::s_base {
+
+  include govuk::node::s_app_server
+
+  include nginx
+
+  # The catchall vhost throws a 500, except for healthcheck requests.
+  nginx::config::vhost::default { 'default': }
+
+  govuk_envvar {
+    'UNICORN_TIMEOUT': value => 15;
+  }
+}

--- a/modules/hosts/manifests/purge.pp
+++ b/modules/hosts/manifests/purge.pp
@@ -15,13 +15,14 @@ class hosts::purge {
   # Specifically for hosts that exist as a node class but do not use the Govuk_host defined type
   # eg hosts that are only present in AWS
   $whitelist = [
+    'account-1',
     'db-admin-1',
     'email-alert-api-postgresql',
-    'publishing-api-postgresql-1',
+    'gatling-1',
     'mongo-api-1',
     'prometheus-1',
+    'publishing-api-postgresql-1',
     'search-1',
-    'gatling-1',
   ]
 
   if ! ($::hostname in $whitelist) {


### PR DESCRIPTION
Account machines are used for running the Account API application
which implements authentication and attribute storage.  Or, they will,
when the app has been created.

---

[Trello card](https://trello.com/c/IEbDGe2x/634-set-up-a-new-machine-class)