### PR TITLE
Update Mapit pv name to /dev/nvme1n1 

### DIFF
--- a/hieradata_aws/class/integration/mapit.yaml
+++ b/hieradata_aws/class/integration/mapit.yaml
@@ -5,5 +5,5 @@ postgresql::globals::postgis_version: '3.1.1'
 
 lv:
   data:
-    pv: '/dev/xvdf'
+    pv: '/dev/nvme1n1'
     vg: 'postgresql'

--- a/hieradata_aws/class/mapit.yaml
+++ b/hieradata_aws/class/mapit.yaml
@@ -1,7 +1,7 @@
 ---
 lv:
   data:
-    pv: '/dev/xvdf'
+    pv: '/dev/nvme1n1'
     vg: 'postgresql'
 
 mount:


### PR DESCRIPTION
We've updated the default instance type to c5.2xlarge. These instance type rename attached EBS volumes to nvme1n1. This updates the PV configuration to select the correct device name.

https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html