### PR TITLE
Remove redundant Mapit config for integration

### DIFF
--- a/hieradata_aws/class/integration/mapit.yaml
+++ b/hieradata_aws/class/integration/mapit.yaml
@@ -1,9 +1,0 @@
----
-
-postgresql::globals::version: '9.6'
-postgresql::globals::postgis_version: '3.1.1'
-
-lv:
-  data:
-    pv: '/dev/nvme1n1'
-    vg: 'postgresql'


### PR DESCRIPTION
This the integration parameters are set to the same values as the default parameters in [hieradata_aws/class/mapit.yaml](https://github.com/alphagov/govuk-puppet/blob/master/hieradata_aws/class/mapit.yaml). Removing this file as its unnecessary and potentially confusing.