### PR TITLE
Add production check for Whitehall unenqueued scheduled documents

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -344,6 +344,7 @@ mongodb::backup::mongo_backup_node: 'localhost'
 
 monitoring::checks::aws_origin_domain: "integration.govuk.digital"
 monitoring::checks::whitehall_overdue_check_period: 'never'
+monitoring::checks::whitehall_scheduled_check_period: 'never'
 monitoring::checks::sidekiq::enable_support_check: false
 monitoring::checks::rds::region: 'eu-west-1'
 monitoring::checks::aws_iam_key::enabled: true

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -366,6 +366,7 @@ licensify::apps::licensify::alert_5xx_critical_rate: 0.15
 
 monitoring::checks::aws_origin_domain: "staging.govuk.digital"
 monitoring::checks::whitehall_overdue_check_period: 'never'
+monitoring::checks::whitehall_scheduled_check_period: 'never'
 monitoring::checks::sidekiq::enable_signon_check: false
 monitoring::checks::sidekiq::enable_support_check: false
 monitoring::checks::rds::region: 'eu-west-1'

--- a/modules/monitoring/templates/check_whitehall_scheduled.cfg.erb
+++ b/modules/monitoring/templates/check_whitehall_scheduled.cfg.erb
@@ -1,0 +1,4 @@
+define command {
+  command_name check_whitehall_scheduled
+  command_line /usr/lib/nagios/plugins/check_http_timeout_noncrit --useragent="check_http_timeout_noncrit/whitehall_scheduled" -S -H <%= @whitehall_hostname %> -u '<%= @whitehall_scheduled_url %>' -a <%= @http_username %>:<%= @http_password %> -s '{"unenqueued_scheduled_editions":0}'
+}


### PR DESCRIPTION
In alphagov/whitehall#6001, we added an endpoint to check for the number of scheduled editions that have not been queued in Sidekiq.

We already have this data included in the Whitehall app check, but this is shown in Icinga for every host (rather than once  
suggests the entire app is critical, rather than one part. This will be removed later to ensure continuity.

Trello card: https://trello.com/c/UAbbL13x