### PR TITLE
Remove transition checker cookies

### DIFF
--- a/modules/varnish/manifests/config.pp
+++ b/modules/varnish/manifests/config.pp
@@ -21,7 +21,6 @@ class varnish::config(
   include varnish::restart
 
   $app_domain  = hiera('app_domain')
-  $allow_finder_frontend_cookies = hiera('govuk::apps::finder_frontend::feature_flag_accounts', false)
 
   file { '/etc/default/varnish':
     ensure  => file,

--- a/modules/varnish/templates/default.vcl.erb
+++ b/modules/varnish/templates/default.vcl.erb
@@ -84,9 +84,8 @@ sub vcl_recv {
   #   - Licensing
   #   - email-alert-frontend (for subscription management)
   #   - frontend (for sessions across funding registration form)
-  #   - finder-frontend (for gov.uk accounts experiment on the transition checker)
   #   - smart answers coronavirus find support flow
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" <% if @allow_finder_frontend_cookies %>&& req.url !~ "^/transition-check" <% end %>&& req.url !~ "^/brexit-eu-funding" && req.url !~ "^/find-coronavirus-support/s")
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/brexit-eu-funding" && req.url !~ "^/find-coronavirus-support/s")
   {
     unset req.http.Cookie;
   }
@@ -123,7 +122,7 @@ sub vcl_fetch {
 
   <% if @strip_cookies %>
   # Strip cookies from outbound requests. Corresponding rule in vcl_recv{}
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" <% if @allow_finder_frontend_cookies %>&& req.url !~ "^/transition-check" <% end %>&& req.url !~ "^/brexit-eu-funding" && req.url !~ "^/find-coronavirus-support/s") {
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/brexit-eu-funding" && req.url !~ "^/find-coronavirus-support/s") {
     unset beresp.http.Set-Cookie;
   }
   <% end %>


### PR DESCRIPTION
**Merge this *after* https://github.com/alphagov/finder-frontend/pull/2445**

---

We are now passing the session information in custom headers, which
are hooked up to cookies on the Fastly side.

---

[Trello card](https://trello.com/c/uHdKokkS/643-switch-from-the-old-cookie-to-the-new-cookie)