### PR TITLE
Clean up references to disused gds-operations GitHub org.

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -58,7 +58,7 @@ mod 'puppetlabs/postgresql',
   :git => 'git://github.com/alphagov/puppetlabs-postgresql.git',
   :ref => '2b30e3e1cbb2772bee848d802f6f00cc790a2947'
 mod 'gdsoperations/aptly',
-  :git => 'git://github.com/gds-operations/puppet-aptly.git',
+  :git => 'git://github.com/alphagov/puppet-aptly.git',
   :ref => '143919794c96450ef887dc757cea002345161870'
 
 # Our modules on the Forge.

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -140,7 +140,7 @@ GIT
       puppetlabs-stdlib (>= 3.0.0)
 
 GIT
-  remote: git://github.com/gds-operations/puppet-aptly.git
+  remote: git://github.com/alphagov/puppet-aptly.git
   ref: 143919794c96450ef887dc757cea002345161870
   sha: 143919794c96450ef887dc757cea002345161870
   specs:

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -567,22 +567,7 @@ govuk_ci::master::pipeline_jobs:
   slimmer: {}
   smokey: {}
   special-route-publisher: {}
-  ubuntu_unused_kernels:
-    repo_owner: 'gds-operations'
-  vcloud-core:
-    repo_owner: 'gds-operations'
-  vcloud-edge_gateway:
-    repo_owner: 'gds-operations'
-  vcloud-launcher:
-    repo_owner: 'gds-operations'
-  vcloud-net_launcher:
-    repo_owner: 'gds-operations'
-  vcloud-tools:
-    repo_owner: 'gds-operations'
-  vcloud-tools-tester:
-    repo_owner: 'gds-operations'
-  vcloud-walker:
-    repo_owner: 'gds-operations'
+  ubuntu_unused_kernels: {}
 
 govuk_ci::master::ci_agents:
   ci-agent-1:

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1034,22 +1034,7 @@ govuk_ci::master::pipeline_jobs:
   slimmer: {}
   smokey: {}
   special-route-publisher: {}
-  ubuntu_unused_kernels:
-    repo_owner: 'gds-operations'
-  vcloud-core:
-    repo_owner: 'gds-operations'
-  vcloud-edge_gateway:
-    repo_owner: 'gds-operations'
-  vcloud-launcher:
-    repo_owner: 'gds-operations'
-  vcloud-net_launcher:
-    repo_owner: 'gds-operations'
-  vcloud-tools:
-    repo_owner: 'gds-operations'
-  vcloud-tools-tester:
-    repo_owner: 'gds-operations'
-  vcloud-walker:
-    repo_owner: 'gds-operations'
+  ubuntu_unused_kernels: {}
 
 govuk_ci::master::ci_agents:
   ci-agent-1:

--- a/lib/tasks/yaml_syntax.rake
+++ b/lib/tasks/yaml_syntax.rake
@@ -1,6 +1,6 @@
 # Note that this task is not intended for Hiera YAML files,
 # which are already checked by the puppet-syntax gem:
-# https://github.com/gds-operations/puppet-syntax/blob/49f7d4d1125cd9c671511fe3e727ff4c2f38fb04/lib/puppet-syntax/hiera.rb
+# https://github.com/voxpupuli/puppet-syntax/blob/49f7d4d1125cd9c671511fe3e727ff4c2f38fb04/lib/puppet-syntax/hiera.rb
 #
 # Rather, this is intended to check YAML contained in files
 # or templates that we use in our Puppet modules.


### PR DESCRIPTION
- All the non-archived repos in github.com/gds-operations have been transferred to github.com/alphagov (including `puppet-aptly` and `ubuntu_unused_kernels`) so update refs to point at alphagov for those.
- The `vcloud-*` repos were archived a long time ago, so just remove refs to those.

[GitHub's transfer process](https://docs.github.com/en/github/administering-a-repository/transferring-a-repository) preserves pretty much everything and even redirects the old URLs, so this change is really just for tidiness rather than a necessity. Everything's already working fine with the redirects. I've checked that the committish refs here are still valid on the transferred repos.