### PR TITLE
Increase asset-manager nginx timeout to 60 seconds

### DIFF
--- a/modules/govuk/manifests/apps/asset_manager.pp
+++ b/modules/govuk/manifests/apps/asset_manager.pp
@@ -111,6 +111,7 @@ class govuk::apps::asset_manager(
       nagios_memory_critical    => $nagios_memory_critical,
       cpu_warning               => 350,
       cpu_critical              => 400,
+      read_timeout              => 60,
     }
 
     govuk::app::envvar {


### PR DESCRIPTION
We are finding that large documents uploaed to Whitehall are not being uploaded to Asset Manager.  This appears to be due to a `GdsApi::TimedOutException` in the execution of [`AssetManagerCreateWhitehallAssetWorker`](http://github.com/alphagov/whitehall/blob/c2d69e9ab8ff8e8e0cdeefd7d1a5856316dfac6f/app/workers/asset_manager_create_whitehall_asset_worker.rb#L1), which uploads the asset from the Whitehall machine to Asset Manager [using a multipart POST request](https://github.com/alphagov/gds-api-adapters/blob/e0c9fc1b03dc47c5d70d7f72f8a7154a24a7fbda/lib/gds_api/asset_manager.rb#L129).  Therefore increasing this from the [default 15s](https://github.com/alphagov/govuk-puppet/blob/9da822c3bb38e6565e7835e66ecadc43cb35f025/modules/govuk/manifests/app.pp#L211-L213) to 60s.

Trello card: https://trello.com/c/R2z5S45l