### PR TITLE
Enable CD for Service Manual Frontend

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1117,6 +1117,7 @@ govuk_jenkins::jobs::deploy_app_downstream::applications:
   manuals-publisher: {}
   publisher: {}
   short-url-manager: {}
+  service-manual-frontend: {}
   service-manual-publisher: {}
   smartanswers:
     repository: 'smart-answers'


### PR DESCRIPTION
Dependant on the other PRs contained within [this
ticket](https://trello.com/c/zu7IYR6C/2385-enable-continuous-deployment-for-service-manual-frontend).

Trello:
https://trello.com/c/zu7IYR6C/2385-enable-continuous-deployment-for-service-manual-frontend