### PR TITLE
Add healthcheck route for Sidekiq monitoring

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -321,6 +321,8 @@ task :check_consistency_between_aws_and_carrenza do
     govuk::apps::sidekiq_monitoring::link_checker_api_redis_port
     govuk::apps::sidekiq_monitoring::publishing_api_redis_host
     govuk::apps::sidekiq_monitoring::publishing_api_redis_port
+    govuk::apps::sidekiq_monitoring::redis_host
+    govuk::apps::sidekiq_monitoring::redis_port
     govuk::apps::sidekiq_monitoring::search_api_redis_host
     govuk::apps::sidekiq_monitoring::search_api_redis_port
     govuk::apps::sidekiq_monitoring::support_api_redis_host

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -735,6 +735,8 @@ govuk::apps::sidekiq_monitoring::publisher_redis_host: "%{hiera('govuk::apps::pu
 govuk::apps::sidekiq_monitoring::publisher_redis_port: "%{hiera('govuk::apps::publisher::redis_port')}"
 govuk::apps::sidekiq_monitoring::publishing_api_redis_host: "%{hiera('govuk::apps::publishing_api::redis_host')}"
 govuk::apps::sidekiq_monitoring::publishing_api_redis_port: "%{hiera('govuk::apps::publishing_api::redis_port')}"
+govuk::apps::sidekiq_monitoring::redis_host: "%{hiera('sidekiq_host')}"
+govuk::apps::sidekiq_monitoring::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::sidekiq_monitoring::search_admin_redis_host: "%{hiera('govuk::apps::search_admin::redis_host')}"
 govuk::apps::sidekiq_monitoring::search_admin_redis_port: "%{hiera('govuk::apps::search_admin::redis_port')}"
 govuk::apps::sidekiq_monitoring::search_api_redis_host: "%{hiera('govuk::apps::search_api::redis_host')}"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -430,6 +430,7 @@ govuk::apps::content_data_api::port: 3235
 # content-data-api sidekiq monitoring uses 3239
 # content-data-admin sidekiq monitoring uses 3240
 # search-admin sidekiq monitoring uses 3241
+# sidekiq monitoring uses 3242
 
 govuk::apps::asset_manager::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
 govuk::apps::asset_manager::mongodb_nodes:

--- a/modules/govuk/manifests/apps/sidekiq_monitoring.pp
+++ b/modules/govuk/manifests/apps/sidekiq_monitoring.pp
@@ -109,6 +109,14 @@
 #   Redis port for Publishing API Sidekiq.
 #   Default: undef
 #
+# [*redis_host*]
+#   Redis host for Sidekiq Monitoring Sidekiq.
+#   Default: undef
+#
+# [*redis_port*]
+#   Redis port for Sidekiq Monitoring Sidekiq.
+#   Default: undef
+#
 # [*search_admin_redis_host*]
 #   Redis host for Search Admin Sidekiq.
 #   Default: undef
@@ -200,6 +208,8 @@ class govuk::apps::sidekiq_monitoring (
   $publisher_redis_port = undef,
   $publishing_api_redis_host = undef,
   $publishing_api_redis_port = undef,
+  $redis_host = undef,
+  $redis_port = undef,
   $search_admin_redis_host = undef,
   $search_admin_redis_port = undef,
   $search_api_redis_host = undef,
@@ -234,6 +244,12 @@ class govuk::apps::sidekiq_monitoring (
 
   Govuk::App::Envvar::Redis {
     app => $app_name,
+  }
+
+  govuk::app::envvar::redis { $app_name:
+    prefix => 'sidekiq_monitoring',
+    host   => $redis_host,
+    port   => $redis_port,
   }
 
   govuk::app { $app_name:

--- a/modules/govuk/templates/sidekiq_monitoring_nginx_config.conf.erb
+++ b/modules/govuk/templates/sidekiq_monitoring_nginx_config.conf.erb
@@ -18,6 +18,10 @@ server {
     try_files $uri/index.html $uri.html $uri @app;
   }
 
+  location /healthcheck {
+    proxy_pass http://localhost:3242;
+  }
+
   location /asset-manager {
     proxy_pass http://localhost:3038;
   }


### PR DESCRIPTION
Related PR:
https://github.com/alphagov/sidekiq-monitoring/pull/71

Trello:
https://trello.com/c/C1cWKFAb/2392-5-enable-continuous-deployment-for-sidekiq-monitoring