### PR TITLE
Make gcp mirror sync script resilient

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -418,7 +418,6 @@ task :check_consistency_between_aws_and_carrenza do
     monitoring::checks::mirror::enabled
     monitoring::checks::mirror::gcp_mirror_sync_project_id
     monitoring::checks::mirror::gcp_mirror_sync_transfer_job_auth_json
-    monitoring::checks::mirror::gcp_mirror_sync_transfer_job_name
     monitoring::checks::rds::servers
     monitoring::client::alert_hostname
     monitoring::checks::sidekiq::enable_signon_check

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1458,7 +1458,6 @@ monitoring::checks::rds::servers:
 
 monitoring::checks::mirror::gcp_mirror_sync_project_id: "%{hiera('monitoring::gcp_mirror_sync_project_id')}"
 monitoring::checks::mirror::gcp_mirror_sync_transfer_job_auth_json: "%{hiera('monitoring::gcp_mirror_sync_transfer_job_auth_json')}"
-monitoring::checks::mirror::gcp_mirror_sync_transfer_job_name: "%{hiera('monitoring::gcp_mirror_sync_transfer_job_name')}"
 
 monitoring::gcloud::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 monitoring::gcloud::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"

--- a/modules/monitoring/files/etc/nagios3/conf.d/check_mirror_file_sync.cfg
+++ b/modules/monitoring/files/etc/nagios3/conf.d/check_mirror_file_sync.cfg
@@ -1,4 +1,4 @@
 define command {
   command_name check_mirror_file_sync
-  command_line /usr/lib/nagios/plugins/check_mirror_file_sync --google_application_credentials_file_path=$ARG1$ --gcp_project_id=$ARG2$ --transfer_job_name=$ARG3$
+  command_line /usr/lib/nagios/plugins/check_mirror_file_sync --google_application_credentials_file_path=$ARG1$ --gcp_project_id=$ARG2$
 }

--- a/modules/monitoring/files/usr/lib/nagios/plugins/check_mirror_file_sync
+++ b/modules/monitoring/files/usr/lib/nagios/plugins/check_mirror_file_sync
@@ -20,12 +20,8 @@ OPTIONS:
                                                     to download upon the creation of a key pair. See https://cloud.google.com/docs/authentication/getting-started 
                                                     for more details.
 
-    --gcp_project_id=x                              Required: Enter the GCP project id for the project which owns the Transfer Job specified in the transfer_job_name
+    --gcp_project_id=x                              Required: Enter the GCP project id for the project which owns the Transfer Job.
                                                     parameter. 
-
-    --transfer_job_name=x                           Required: Enter the Transfer Job name for the job which syncs mirror content to GCP. This can be found in the 
-                                                    configuration for the job. If the name starts with transferJobs/, omit this when entering this parameter.
-
 EOF
 }
 
@@ -47,11 +43,6 @@ case ${i} in
 
   --gcp_project_id=* )
     GCP_PROJECT_ID="${i#*=}"
-    shift
-    ;;
-
-  --transfer_job_name=* )
-    TRANSFER_JOB_NAME="${i#*=}"
     shift
     ;;
 
@@ -85,19 +76,19 @@ if [[ "${GCP_PROJECT_ID}" == "" ]]; then
     exit ${STATE_UNKNOWN}
 fi
 
-if [[ "${TRANSFER_JOB_NAME}" == "" ]]; then
-    error "You have to supply a transfer job name"
-    usage
-    exit ${STATE_UNKNOWN}
-fi
-
 export GOOGLE_APPLICATION_CREDENTIALS="$GOOGLE_APPLICATION_CREDENTIALS_FILE_PATH"
 
 GCP_TRANSFER_SERVICE_TOKEN=$(gcloud auth application-default print-access-token)
 
-latest_operation_name=$(curl --header "Content-Type: application/json" \
+transferJobs=$(curl --silent --header "Content-Type: application/json" \
   --header "Authorization: Bearer $GCP_TRANSFER_SERVICE_TOKEN" \
-  --request GET "https://storagetransfer.googleapis.com/v1/transferJobs/$TRANSFER_JOB_NAME?projectId=$GCP_PROJECT_ID" \
+  --request GET "https://storagetransfer.googleapis.com/v1/transferJobs?filter=%7B%22projectId%22%3A%22$GCP_PROJECT_ID%22%7D")
+
+job_name=$(echo $transferJobs | jq -c -r '.transferJobs[] | select(.description | contains("$GCP_PROJECT_ID")) | .latestOperationName')
+
+latest_operation_name=$(curl --silent --header "Content-Type: application/json" \
+  --header "Authorization: Bearer $GCP_TRANSFER_SERVICE_TOKEN" \
+  --request GET "https://storagetransfer.googleapis.com/v1/transferJobs/$job_name?projectId=$GCP_PROJECT_ID" \
   | jq -r '.latestOperationName')
 
 latest_operation_details=$(curl --header "Content-Type: application/json" \

--- a/modules/monitoring/manifests/checks/mirror.pp
+++ b/modules/monitoring/manifests/checks/mirror.pp
@@ -16,15 +16,10 @@
 #   Sets the auth JSON required by the Google SDK.
 #   Required if enabled=true.
 #
-# [*gcp_mirror_sync_transfer_job_name*]
-#   Sets the transfer job name which controls the mirror sync.
-#   Required if enabled=true.
-#
 class monitoring::checks::mirror (
   $enabled = false,
   $gcp_mirror_sync_project_id = undef,
   $gcp_mirror_sync_transfer_job_auth_json = undef,
-  $gcp_mirror_sync_transfer_job_name = undef,
 ) {
   icinga::check_config { 'mirror_age':
     source => 'puppet:///modules/monitoring/etc/nagios3/conf.d/check_mirror_age.cfg',
@@ -51,7 +46,7 @@ class monitoring::checks::mirror (
     }
 
     icinga::check { 'check_mirror_file_sync':
-      check_command       => "check_mirror_file_sync!${google_application_credentials_file_path}!${gcp_mirror_sync_project_id}!${gcp_mirror_sync_transfer_job_name}",
+      check_command       => "check_mirror_file_sync!${google_application_credentials_file_path}!${gcp_mirror_sync_project_id}",
       service_description => 'Check status of latest GCP mirror sync job',
       use                 => 'govuk_normal_priority',
       check_interval      => 1440,


### PR DESCRIPTION
This PR gets the GCP mirror transfer job name from the Storage Transfer API. The reason for this change is because when we change the Terraform for the job and redeploy it, a new Transfer Job is created by GCP, meaning we'd have to go and change secrets to the new job name; this isn't sustainable and instead a better way is to look up the job when we do the Icinga check.