### PR TITLE
Remove Calculators from Smokey loop

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -423,8 +423,6 @@ monitoring::checks::smokey::features:
     feature: benchmarking
   check_caching:
     feature: caching
-  check_calculators:
-    feature: calculators
   check_collections:
     feature: collections
   check_contacts:


### PR DESCRIPTION
We are retiring calculators.

Related PR - https://github.com/alphagov/smokey/pull/797

Trello card: https://trello.com/c/4Sz5s78X/2400-epic-retire-the-calculators-app