### PR TITLE
Only show Whitehall scheduled publications alert in production

### DIFF
--- a/modules/monitoring/manifests/checks.pp
+++ b/modules/monitoring/manifests/checks.pp
@@ -88,7 +88,7 @@ class monitoring::checks (
     require => Icinga::Plugin['check_http_timeout_noncrit'],
   }
 
-  if $::aws_migration {
+  if $::aws_migration and $::aws_environment == 'production' {
     icinga::check { "check_whitehall_scheduled_from_${::hostname}":
       check_command              => 'check_whitehall_scheduled',
       service_description        => 'scheduled publications in Whitehall not queued',


### PR DESCRIPTION
In https://github.com/alphagov/govuk-puppet/pull/10963, we added an alert for scheduled publications in Whitehall not being queued. This makes that alert only relevant in production.

Follow-up to Trello card: https://trello.com/c/UAbbL13x