### PR TITLE
Remove calculators app

### DIFF
--- a/hieradata_aws/class/integration/ci_master.yaml
+++ b/hieradata_aws/class/integration/ci_master.yaml
@@ -5,7 +5,6 @@ govuk_jenkins::jobs::deploy_app_downstream::applications:
   authenticating-proxy: {}
   bouncer: {}
   cache-clearing-service: {}
-  calculators: {}
   ckan:
     repository: 'ckanext-datagovuk'
   collections: {}

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -149,7 +149,6 @@ deployable_applications: &deployable_applications
   authenticating-proxy: {}
   bouncer: {}
   cache-clearing-service: {}
-  calculators: {}
   ckan:
     repository: 'ckanext-datagovuk'
   collections: {}
@@ -943,7 +942,6 @@ govuk_ci::master::pipeline_jobs:
   authenticating-proxy: {}
   bouncer: {}
   cache-clearing-service: {}
-  calculators: {}
   collections: {}
   content-store: {}
   email-alert-api: {}

--- a/modules/govuk/manifests/apps/calculators.pp
+++ b/modules/govuk/manifests/apps/calculators.pp
@@ -25,6 +25,7 @@ class govuk::apps::calculators(
   $secret_key_base = undef,
 ) {
   govuk::app { 'calculators':
+    ensure                  => 'absent',
     app_type                => 'rack',
     port                    => $port,
     sentry_dsn              => $sentry_dsn,
@@ -32,18 +33,5 @@ class govuk::apps::calculators(
     log_format_is_json      => true,
     asset_pipeline          => true,
     asset_pipeline_prefixes => ['assets/calculators'],
-  }
-
-  Govuk::App::Envvar {
-    app => 'calculators',
-  }
-
-  govuk::app::envvar {
-    "${title}-PUBLISHING_API_BEARER_TOKEN":
-        varname => 'PUBLISHING_API_BEARER_TOKEN',
-        value   => $publishing_api_bearer_token;
-    "${title}-SECRET_KEY_BASE":
-        varname => 'SECRET_KEY_BASE',
-        value   => $secret_key_base;
   }
 }

--- a/modules/grafana/files/dashboards/application_health.json
+++ b/modules/grafana/files/dashboards/application_health.json
@@ -506,7 +506,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "aliasSub(groupByNode(stats.{calculators,draft-email-campaign,draft,email-campaign,performance,whitehall}-frontend-*.nginx_logs.*gov*.http_503,3,\"sum\"),\"_.*\",\"\")",
+              "target": "aliasSub(groupByNode(stats.{draft-email-campaign,draft,email-campaign,performance,whitehall}-frontend-*.nginx_logs.*gov*.http_503,3,\"sum\"),\"_.*\",\"\")",
               "refId": "A"
             },
             {

--- a/modules/grafana/files/dashboards/origin_health.json
+++ b/modules/grafana/files/dashboards/origin_health.json
@@ -605,7 +605,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "target": "maximumAbove(aliasSub(groupByNode(stats.{calculators,draft-email-campaign,draft,email-campaign,performance,whitehall}-frontend-*.nginx_logs.*gov*.http_500,3,\"sum\"),\"_.*\",\"\"),0)",
+              "target": "maximumAbove(aliasSub(groupByNode(stats.{draft-email-campaign,draft,email-campaign,performance,whitehall}-frontend-*.nginx_logs.*gov*.http_500,3,\"sum\"),\"_.*\",\"\"),0)",
               "refId": "A"
             },
             {


### PR DESCRIPTION
We are retiring Calculators. This is the first step to remove the application as per the [Remove app from puppet doc](https://docs.publishing.service.gov.uk/manual/retiring-an-application.html#1-remove-app-from-puppet)

Trello card: https://trello.com/c/4Sz5s78X/2400-epic-retire-the-calculators-app