### PR TITLE
Ignore Calculators in LB target group

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -364,7 +364,9 @@ monitoring::checks::lb::loadbalancers: # prefer "internal"
       - blue-backend-internal-HTTP-80 # no idea what this is
   blue-bouncer-internal: {}
   blue-cache: {}
-  blue-calculators-frontend-int: {}
+  blue-calculators-frontend-int:
+    healthyhosts_ignore:
+      - calculator-calculators
   blue-ckan-internal:
     healthyhosts_warning: 0
   blue-content-store-internal: {}

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -406,7 +406,9 @@ monitoring::checks::lb::loadbalancers: # prefer "internal"
       - blue-backend-internal-HTTP-80 # no idea what this is
   blue-bouncer-internal: {}
   blue-cache: {}
-  blue-calculators-frontend-int: {}
+  blue-calculators-frontend-int:
+    healthyhosts_ignore:
+      - calculator-calculators
   blue-ckan-internal:
     healthyhosts_warning: 0
   blue-content-store-internal: {}

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -386,7 +386,9 @@ monitoring::checks::lb::loadbalancers: # prefer "internal"
       - blue-backend-internal-HTTP-80 # no idea what this is
   blue-bouncer-internal: {}
   blue-cache: {}
-  blue-calculators-frontend-int: {}
+  blue-calculators-frontend-int:
+    healthyhosts_ignore:
+      - calculator-calculators
   blue-ckan-internal:
     healthyhosts_warning: 0
   blue-content-store-internal: {}


### PR DESCRIPTION
We have retired the Calculators app but the config hasn't been
updated in Terraform/AWS, which is leading to an Icinga alert
reporting the target group is unhealthy.

[This alert](https://alert.blue.production.govuk.digital/cgi-bin/icinga/extinfo.cgi?type=2&host=ip-10-13-5-163.eu-west-1.compute.internal&service=blue-calculators-frontend-int+-+AWS+LB+Healthy+Hosts) should go away by excluding the app from the checks
with the `healthyhosts_ignore` option.

For more information see https://docs.publishing.service.gov.uk/manual/alerts/aws-lb-healthyhosts.html

Trello card: https://trello.com/c/4Sz5s78X/2400-epic-retire-the-calculators-app