### PR TITLE
Add account-api

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -513,6 +513,12 @@ task :check_consistency_between_aws_and_carrenza do
     licensify::apps::licensify::environment
     licensify::apps::licensify_admin::environment
     licensify::apps::licensify_feed::environment
+    govuk::apps::account_api::db::allow_auth_from_lb
+    govuk::apps::account_api::db::backend_ip_range
+    govuk::apps::account_api::db::lb_ip_range
+    govuk::apps::account_api::db::rds
+    govuk::apps::account_api::db_hostname
+    govuk::apps::account_api::port
   ]
 
   failed = false

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -12,7 +12,8 @@ backup::mysql::alert_hostname: 'alert'
 
 node_class: &node_class
   account:
-    apps: []
+    apps:
+      - account-api
   asset_master:
     apps:
       - asset_env_sync
@@ -144,6 +145,7 @@ govuk_jenkins::deploy_all_apps::apps_on_nodes:
 # we don't need to explicitly declare the repository, but we
 # need to add an empty hash
 deployable_applications: &deployable_applications
+  account-api: {}
   asset-manager: {}
   authenticating-proxy: {}
   bouncer: {}
@@ -428,6 +430,7 @@ govuk::apps::content_data_api::port: 3235
 # content-data-admin sidekiq monitoring uses 3240
 # search-admin sidekiq monitoring uses 3241
 # sidekiq monitoring uses 3242
+govuk::apps::account_api::port: 3243
 
 govuk::apps::asset_manager::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
 govuk::apps::asset_manager::mongodb_nodes:
@@ -811,6 +814,11 @@ govuk::apps::transition::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::travel_advice_publisher::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::travel_advice_publisher::redis_port: "%{hiera('sidekiq_port')}"
 
+govuk::apps::account_api::db_hostname: "postgresql-primary"
+govuk::apps::account_api::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
+govuk::apps::account_api::db::allow_auth_from_lb: true
+govuk::apps::account_api::db::lb_ip_range: "%{hiera('environment_ip_prefix')}.0.0/16"
+
 govuk_awscli::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk_awscli::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
@@ -825,6 +833,7 @@ govuk::apps::local_links_manager::db::rds: true
 govuk::apps::publishing_api::db::rds: true
 govuk::apps::service_manual_publisher::db::rds: true
 govuk::apps::support_api::db::rds: true
+govuk::apps::account_api::db::rds: true
 govuk::apps::transition::postgresql_db::rds: true
 
 govuk_pgbouncer::admin::rds: true
@@ -1185,6 +1194,7 @@ grafana::repo::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint'
 grafana::dashboards::app_domain: "%{hiera('app_domain')}"
 grafana::dashboards::machine_suffix_metrics: ''
 grafana::dashboards::application_dashboards:
+  account-api: {}
   asset-manager:
     show_sidekiq_graphs: true
     has_workers: true

--- a/modules/govuk/manifests/apps/account_api.pp
+++ b/modules/govuk/manifests/apps/account_api.pp
@@ -1,0 +1,104 @@
+# == Class: govuk::apps::account_api
+#
+# Read more: https://github.com/alphagov/account-api
+#
+# === Parameters
+# [*port*]
+#   What port the app should run on.
+#
+# [*enabled*]
+#   Whether to install or uninstall the app. Defaults to true (install on all enviroments)
+#
+# [*secret_key_base*]
+#   The key for Rails to use when signing/encrypting sessions
+#
+# [*sentry_dsn*]
+#   The app-specific URL used by Sentry to report exceptions
+#
+# [*oauth_id*]
+#   The OAuth ID used by GDS-SSO to identify the app to GOV.UK Signon
+#
+# [*oauth_secret*]
+#   The OAuth secret used by GDS-SSO to authenticate the app to GOV.UK Signon
+#
+# [*db_hostname*]
+#   The hostname of the database server to use for in DATABASE_URL environment variable
+#
+# [*db_username*]
+#   The username to use for the DATABASE_URL environment variable
+#
+# [*db_password*]
+#   The password to use for the DATABASE_URL environment variable
+#
+# [*db_port*]
+#   The port of the database server to use in the DATABASE_URL.
+#   Default: undef
+#
+# [*db_allow_prepared_statements*]
+#   The ?prepared_statements= parameter to use in the DATABASE_URL.
+#   Default: undef
+#
+# [*db_name*]
+#   The database name to use for the DATABASE_URL environment variable
+#
+class govuk::apps::account_api (
+  $port,
+  $enabled = true,
+  $secret_key_base = undef,
+  $sentry_dsn = undef,
+  $oauth_id = undef,
+  $oauth_secret = undef,
+  $db_username = 'account-api',
+  $db_hostname = undef,
+  $db_port = undef,
+  $db_allow_prepared_statements = undef,
+  $db_password = undef,
+  $db_name = 'account-api_production',
+) {
+  $app_name = 'account-api'
+
+  $ensure = $enabled ? {
+    true  => 'present',
+    false => 'absent',
+  }
+
+  # see modules/govuk/manifests/app.pp for more options
+  govuk::app { $app_name:
+    ensure            => $ensure,
+    app_type          => 'rack',
+    port              => $port,
+    sentry_dsn        => $sentry_dsn,
+    vhost_ssl_only    => true,
+    health_check_path => '/healthcheck', # must return HTTP 200 for an unauthenticated request
+    deny_framing      => true,
+    asset_pipeline    => true,
+  }
+
+  Govuk::App::Envvar {
+    app               => $app_name,
+    ensure            => $ensure,
+    notify_service    => $enabled,
+  }
+
+  govuk::app::envvar {
+    "${title}-SECRET_KEY_BASE":
+      varname => 'SECRET_KEY_BASE',
+      value   => $secret_key_base;
+    "${title}-GDS_SSO_OAUTH_ID":
+      varname => 'GDS_SSO_OAUTH_ID',
+      value   => $oauth_id;
+    "${title}-GDS_SSO_OAUTH_SECRET":
+      varname => 'GDS_SSO_OAUTH_SECRET',
+      value   => $oauth_secret;
+  }
+
+  govuk::app::envvar::database_url { $app_name:
+    type                      => 'postgresql',
+    username                  => $db_username,
+    password                  => $db_password,
+    host                      => $db_hostname,
+    port                      => $db_port,
+    allow_prepared_statements => $db_allow_prepared_statements,
+    database                  => $db_name,
+  }
+}

--- a/modules/govuk/manifests/apps/account_api/db.pp
+++ b/modules/govuk/manifests/apps/account_api/db.pp
@@ -1,0 +1,46 @@
+# == Class: govuk::apps::account_api::db
+#
+# === Parameters
+#
+# [*backend_ip_range*]
+#   Backend IP addresses to allow access to the database.
+#
+# [*allow_auth_from_lb*]
+#   Whether to allow this user to authenticate for this database from
+#   the load balancer using its password.
+#   Default: false
+#
+# [*lb_ip_range*]
+#   Network range for the load balancer.
+#
+# [*rds*]
+#   Whether to use RDS i.e. when running on AWS
+#
+# [*username*]
+#   The DB instance username.
+#
+# [*password*]
+#   The DB instance password.
+#
+# [*db_name*]
+#   The DB instance name.
+#
+class govuk::apps::account_api::db (
+  $backend_ip_range = '10.3.0.0/16',
+  $allow_auth_from_lb = false,
+  $lb_ip_range = undef,
+  $rds = false,
+  $username = 'account-api',
+  $password = undef,
+  $db_name = 'account-api_production',
+) {
+  govuk_postgresql::db { $db_name:
+    user                    => $username,
+    password                => $password,
+    allow_auth_from_backend => true,
+    backend_ip_range        => $backend_ip_range,
+    allow_auth_from_lb      => $allow_auth_from_lb,
+    lb_ip_range             => $lb_ip_range,
+    rds                     => $rds,
+  }
+}

--- a/modules/govuk/manifests/node/s_db_admin.pp
+++ b/modules/govuk/manifests/node/s_db_admin.pp
@@ -114,6 +114,7 @@ class govuk::node::s_db_admin(
   class { '::govuk_postgresql::client': }
 
   # include all PostgreSQL classes that create databases and users
+  -> class { '::govuk::apps::account_api::db': }
   -> class { '::govuk::apps::content_data_admin::db': }
   -> class { '::govuk::apps::content_publisher::db': }
   -> class { '::govuk::apps::content_tagger::db': }


### PR DESCRIPTION
This is to prepare the servers for account-api. I followed [govuk-puppet's documentation][0] as suggested in our [Set up a new Rails application][1].

[0]: https://github.com/alphagov/govuk-puppet/blob/master/docs/adding-a-new-app.md#including-the-app-on-machines
[1]: https://docs.publishing.service.gov.uk/manual/setting-up-new-rails-app.html#puppet-dns-sentry-and-beyond

Trello card: https://trello.com/c/ZeAKl2SM/651-set-up-a-new-app