### PR TITLE
Remove Tim Blair and Stephen Harker

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -533,10 +533,8 @@ users::usernames:
   - simonhughesdon
   - stephenford
   - stephengrier
-  - stephenharker
   - suganyasivaskantharajah
   - thomasleese
-  - timblair
   - vitaliemogoreanu
   - williamfranklin
 

--- a/modules/users/manifests/stephenharker.pp
+++ b/modules/users/manifests/stephenharker.pp
@@ -1,9 +1,0 @@
-# Creates the stephenharker user
-class users::stephenharker {
-  govuk_user { 'stephenharker':
-    ensure   => absent,
-    fullname => 'Stephen Harker',
-    email    => 'stephen.harker@digital.cabinet-office.gov.uk',
-    ssh_key  => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC7ctK3AiOjlVc/B1ECkueKBoj9z/ty5tbzaGTosie4o1tSd2vG6JRhIkGywBDbpGTEOtkCVGbgXkSsgm/7qD9kmfp/hMw11+C9aiVNcUQACXZmeUziitv4xTONVETebaNxzsS/0rdR8fRsxVuO1eX+Cr3F+ZogOpNLMOJDVd2nqUwiqgieomNqTTJU9jtRiabh/BddbvdRbAzZahY5owNT0kjqUmJcA86F0Phn0cjwQDhMsunsAa6pYnfIi/z9R1/kUE+XxKStrJRauQAXnWOXsV/7oacDtOD70rDfyLKfNDA475Q69sMdC8XFi35QrHpI5KsLtTSTKo2Y0IZBaQ4Iv2tr47Gb4zpNcez4fPHhW/1Ia+G32V/keAD3dPGE/0R7vDq4uX+udLle/oTWd+j0dr0HelZ3aqD9gNZAivRe9bKjtSPefEQD4dGPshCMP516BTb0NW1bWQLD2Qnzw9BQgh1lDDlGW0XblYAwKIZJq/KrLiMwXmv0XHcKCG41G3/JbQrXWOP0D4BnJ7nlLrUIj6ug/zk528+kMOudfbSZQwLJX/AKQ/7Dt5MGPLR8r1XSPIDoMUlrc9iBaN6tbz1J5CqGrLyMGQahP6yjRISZzgFwp9plkj87H76ApGNmRE7PnXTUMBj7/OgksrCsrj6DkOkbyeBKkudodXEkWol9AQ== stephenharker@gds5125.local',
-  }
-}

--- a/modules/users/manifests/timblair.pp
+++ b/modules/users/manifests/timblair.pp
@@ -1,9 +1,0 @@
-# Creates the timblair user
-class users::timblair {
-  govuk_user { 'timblair':
-    ensure   => absent,
-    fullname => 'Tim Blair',
-    email    => 'tim.blair@digital.cabinet-office.gov.uk',
-    ssh_key  => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDr06u0UM5mYAAGoPYS0CciLjGKlk48LxK7NQIIq6KmoaNG8OmbZA4NhEWQZS5n+6ffSl6s7g2t5QO+Js+/Lib/lRhAbtI0U1x2FkwLfJdBTBLTAAUHMm1xRtuGs/NImzGwWQO6zDjID8H+6dWhZZTAMOCgYsyGLm1k/QRWFVgkgASrJZN4ybvqsZlPlGT5oi0JuV+b3120AtUW1DkzXiYr3KExxP2P1nsJEp563EomcTvpK/eo/ChRbjBYGZX/JykhtArKj8oTKgSSEwz9UgBqlKDmnC2hSyejhuQmZJ5JiKa9Bj9mx4XmpKELCY5wNg2Cct8dRF98DEQ6Xo6kMg9KM2HOoqFJyAoBtxVumRLZW0nRA3YiAqE0qJ4daxaSg4T3ktkuEA0AtUYnH+SNBseDuZRDTNaBhhzf06rp1WGCm11R4jpklqs93uOC1QedpidtHBgj+3QASSo6aGb3xnF6xLw+IuaMuUdG+T3eJtF4qqLH4dK8n75errSPpe2UM2sbxyBjDJo6lFDBZ8JUzBaJToHuXqKUxT1RUtsXIL7Skd15Zb2S3rpKRMjm5HVJBNPUK5F/9GRI7lvREZqPy0miJ6mCqm/ICvttOH126BgWaetANg0VCIgG+JjV6ZbZz5zOA9942gi7n3Tta1lBdb7C7zldX5DdH53c/fYYyxRj+Q== tim.blair@digital.cabinet-office.gov.uk',
-  }
-}


### PR DESCRIPTION
Following https://github.com/alphagov/govuk-puppet/pull/10984 which
has now been deployed, we can now remove the manifest files and
from the Integration users.

Trello cards:
https://trello.com/c/djydeAa7/1099-leaver-tim-blair-%F0%9F%98%AD
https://trello.com/c/WyTZ6obE/1100-leaver-stephen-harker