### PR TITLE
Listen to port 80 for Sidekiq Monitoring's Nginx

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -250,7 +250,6 @@ govuk::apps::manuals_publisher::port: 3205
 govuk::apps::link_checker_api::port: 3208
 # link-checker-api sidekiq monitoring uses 3209
 # specialist-publisher sidekiq monitoring uses 3210
-govuk::apps::sidekiq_monitoring::port: 3211
 govuk::apps::publishing_components::port: 3212
 # manuals-publisher sidekiq monitoring uses 3214
 # support-api sidekiq monitoring uses 3215

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -413,7 +413,6 @@ govuk::apps::manuals_publisher::port: 3205
 govuk::apps::link_checker_api::port: 3208
 # link-checker-api sidekiq monitoring uses 3209
 # specialist-publisher sidekiq monitoring uses 3210
-govuk::apps::sidekiq_monitoring::port: 3211
 govuk::apps::publishing_components::port: 3212
 # manuals-publisher sidekiq monitoring uses 3214
 # support-api sidekiq monitoring uses 3215

--- a/modules/govuk/manifests/apps/sidekiq_monitoring.pp
+++ b/modules/govuk/manifests/apps/sidekiq_monitoring.pp
@@ -3,11 +3,6 @@
 # App to monitor Sidekiq for multiple GOV.UK apps.
 #
 # === Parameters
-# [*port*]
-#   Port that the sidekiq monitoring web frontend listens
-#   on and proxies requests to the individual app sidekiq
-#   interfaces.
-#
 # [*nginx_location*]
 #   Path on the server where the public folder of the
 #   sidekiq-monitoring app can be found.
@@ -182,7 +177,6 @@
 #   Default: undef
 #
 class govuk::apps::sidekiq_monitoring (
-  $port,
   $nginx_location = undef,
   $asset_manager_redis_host = undef,
   $asset_manager_redis_port = undef,

--- a/modules/govuk/templates/sidekiq_monitoring_nginx_config.conf.erb
+++ b/modules/govuk/templates/sidekiq_monitoring_nginx_config.conf.erb
@@ -5,7 +5,7 @@ server {
   server_name <%= @full_domain %>;
   <%- end %>
 
-  listen <%= @port %>;
+  listen 80;
 
   proxy_connect_timeout 1s;
   proxy_read_timeout 15s;


### PR DESCRIPTION
Previously Nginx listened on port 3211 and proxied requests to various
ports depending on the application being requested in the path. We want
to change this to the default Nginx port (80) so we can route requests
to the application via DNS.

Trello:
https://trello.com/c/m8O8dC41/2414-add-dns-for-sidekiq-monitoring