### PR TITLE
Increase default lookback time for Graphite alerts to 10m.

### DIFF
--- a/modules/icinga/manifests/check/graphite.pp
+++ b/modules/icinga/manifests/check/graphite.pp
@@ -47,7 +47,7 @@
 #
 # [*from*]
 #   Single string representing a time period passed to `check_graphite_args`.
-#   Default: '5minutes'
+#   Default: '10minutes'
 #
 # [*notes_url*]
 #   Passed to `icinga::check`. See there for documentation.
@@ -73,7 +73,7 @@ define icinga::check::graphite(
   $check_period = undef,
   $use  = undef,
   $args = '',
-  $from = '5minutes',
+  $from = '10minutes',
   $action_url = undef,
   $notes_url = undef,
   $ensure = 'present',


### PR DESCRIPTION
Our old single-threaded Carbon setup struggles under load and intermittently drops data points, causing Graphite-based Icinga alerts to flap in and out of "unknown" status.

While it would be good to fix the underlying problem, a few hours' investigation didn't reveal any clear root causes of the dropped Carbon data points. Increasing the default lookback window for the metric queries behind these Icinga alerts should significantly reduce the noise in the meantime.

I had a quick look through all of the Graphite/Carbon-based alerts that we currently have, and I didn't find anything important-looking that wasn't already providing a specific value for the `from` argument. So this basically only affects unactionable alerts like "CPU usage high" anyway. And besides, 10 minutes is still quite a short window for an alert query. Many of the existing alerts are already specifying 15m.