### PR TITLE
Enable CI -> Integration deployments for account-api

### DIFF
--- a/hieradata_aws/class/integration/ci_master.yaml
+++ b/hieradata_aws/class/integration/ci_master.yaml
@@ -1,6 +1,7 @@
 ---
 
 govuk_jenkins::jobs::deploy_app_downstream::applications:
+  account-api: {}
   asset-manager: {}
   authenticating-proxy: {}
   bouncer: {}


### PR DESCRIPTION
This is missing from the [setting up a new rails app checklist](https://docs.publishing.service.gov.uk/manual/setting-up-new-rails-app.html#puppet-dns-sentry-and-beyond)

---

[Trello card](https://trello.com/c/ZeAKl2SM/651-set-up-a-new-app)