### PR TITLE
Enable account-api in staging and production

### DIFF
--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -12,6 +12,9 @@ cron::daily_hour: 6
 environment_ip_prefix: '10.13'
 
 node_class: &node_class
+  account:
+    apps:
+      - account-api
   asset_master:
     apps:
       - asset_env_sync

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -12,6 +12,9 @@ cron::daily_hour: 6
 environment_ip_prefix: '10.12'
 
 node_class: &node_class
+  account:
+    apps:
+      - account-api
   asset_master:
     apps:
       - asset_env_sync


### PR DESCRIPTION
These two override the node classes, rather than inheriting from
common.yaml.  So in fact the "common" value is only used for
integration.

Well, this explains why we don't have an alerts for a non-running
account-api in those environments...

---

[Trello card](https://trello.com/c/ZeAKl2SM/651-set-up-a-new-app)