### PR TITLE
Up memory threshold

### DIFF
--- a/modules/govuk/manifests/apps/sidekiq_monitoring.pp
+++ b/modules/govuk/manifests/apps/sidekiq_monitoring.pp
@@ -258,8 +258,8 @@ class govuk::apps::sidekiq_monitoring (
     enable_nginx_vhost     => false,
     hasrestart             => true,
     collectd_process_regex => '/data/apps/sidekiq-monitoring/shared/bundle/ruby/.*/bin/rackup .*',
-    nagios_memory_warning  => 1650,
-    nagios_memory_critical => 1800,
+    nagios_memory_warning  => 1750,
+    nagios_memory_critical => 1900,
   }
 
   govuk::app::envvar::redis{


### PR DESCRIPTION
Sidekiq Monitoring is using slightly more memory due to adding an extra
rack server for the healthcheck, this seems to be causing the app to
frequently restart as the memory warning boundary is being crossed triggering the auto restart behaviour: [1](https://github.com/alphagov/govuk-puppet/blob/master/modules/monitoring/files/usr/local/bin/event_handlers/govuk_app_high_memory.sh).

Trello:
https://trello.com/c/C1cWKFAb/2392-5-enable-continuous-deployment-for-sidekiq-monitoring