### PR TITLE
Set default govuk-jenkinslib branch to main

### DIFF
--- a/modules/govuk_jenkins/manifests/pipeline.pp
+++ b/modules/govuk_jenkins/manifests/pipeline.pp
@@ -19,7 +19,7 @@ class govuk_jenkins::pipeline (
       'org'             => 'alphagov',
       'repository'      => 'govuk-jenkinslib',
       'implicit_load'   => false,
-      'default_version' => 'master',
+      'default_version' => 'main',
     },
   }
 

--- a/modules/govuk_jenkins/spec/classes/jenkins__pipeline_spec.rb
+++ b/modules/govuk_jenkins/spec/classes/jenkins__pipeline_spec.rb
@@ -5,7 +5,7 @@ describe 'govuk_jenkins::pipeline', :type => :class do
     it { is_expected.to contain_file('/var/lib/jenkins/org.jenkinsci.plugins.workflow.libs.GlobalLibraries.xml').with_content(/<name>govuk<\/name/) }
     it { is_expected.to contain_file('/var/lib/jenkins/org.jenkinsci.plugins.workflow.libs.GlobalLibraries.xml').with_content(/<repoOwner>alphagov<\/repoOwner>/) }
     it { is_expected.to contain_file('/var/lib/jenkins/org.jenkinsci.plugins.workflow.libs.GlobalLibraries.xml').with_content(/<repository>govuk-jenkinslib<\/repository>/) }
-    it { is_expected.to contain_file('/var/lib/jenkins/org.jenkinsci.plugins.workflow.libs.GlobalLibraries.xml').with_content(/<defaultVersion>master<\/defaultVersion>/) }
+    it { is_expected.to contain_file('/var/lib/jenkins/org.jenkinsci.plugins.workflow.libs.GlobalLibraries.xml').with_content(/<defaultVersion>main<\/defaultVersion>/) }
     it { is_expected.to contain_file('/var/lib/jenkins/org.jenkinsci.plugins.workflow.libs.GlobalLibraries.xml').with_content(/<implicit>false<\/implicit>/) }
   end
 end


### PR DESCRIPTION
Once the branch has been renamed, we'll need to deploy this to all our environments.

[Trello Card](https://trello.com/c/xVhGGzOE/225-change-default-branch-to-main)