### PR TITLE
Fix: RabbitMQ

### DIFF
--- a/modules/govuk/manifests/node/s_apt.pp
+++ b/modules/govuk/manifests/node/s_apt.pp
@@ -105,10 +105,6 @@ class govuk::node::s_apt (
       repos    => ['PC1'],
       release  => 'xenial',
       key      => 'EF8D349F';
-    'rabbitmq':
-      location => 'http://www.rabbitmq.com/debian',
-      release  => 'testing',
-      key      => '6026DFCA';
     'sysdig':
       location => 'http://download.draios.com/stable/deb',
       release  => 'stable-amd64/',
@@ -141,6 +137,7 @@ class govuk::node::s_apt (
   aptly::repo { 'locksmithctl': }
   aptly::repo { 'logstash': }
   aptly::repo { 'postgis': }
+  aptly::repo { 'rabbitmq': }
   aptly::repo { 'rbenv-ruby': }
   aptly::repo { 'rbenv-ruby-xenial':
     distribution => 'xenial',

--- a/modules/govuk_rabbitmq/manifests/init.pp
+++ b/modules/govuk_rabbitmq/manifests/init.pp
@@ -15,9 +15,7 @@ class govuk_rabbitmq (
     monitoring_password => $monitoring_password,
   }
 
-  if ! $::aws_migration {
-    include govuk_rabbitmq::repo
-  }
+  include govuk_rabbitmq::repo
 
   if $::aws_migration {
     package { 'urllib3':
@@ -31,7 +29,9 @@ class govuk_rabbitmq (
     }
   }
 
-  include '::rabbitmq'
+  class { 'rabbitmq':
+    manage_repos => false,
+  }
 
   rabbitmq_plugin { 'rabbitmq_stomp':
     ensure => present,

--- a/modules/govuk_rabbitmq/manifests/repo.pp
+++ b/modules/govuk_rabbitmq/manifests/repo.pp
@@ -12,9 +12,9 @@ class govuk_rabbitmq::repo (
   $apt_mirror_hostname,
   $apt_mirror_gpg_key_fingerprint,
 ) {
-  apt::source { 'rabbitmq':
+  apt::source { 'govuk-rabbitmq':
     location     => "http://${apt_mirror_hostname}/rabbitmq",
-    release      => 'testing',
+    release      => 'stable',
     architecture => $::architecture,
     key          => $apt_mirror_gpg_key_fingerprint,
   }


### PR DESCRIPTION
The version of RabbitMQ we use is no longer available from rabbitmq.com
and thus we can no longer mirror it using aptly.

The configuration being fixed worked in a way which was not ideal and
exposed us to risk.  Namely that there was uncontrolled upgrades to
RabbitMQ, and that it prevented us from re-building servers because the
repo that was used to install RabbitMQ no longer exists.

This PR:
- allows us to spin up new servers that use rabbitmq
- removes the old repo that aptly was trying (and failing) to mirror
- creates an aptly-managed rabbitmq stable/main repo on our central
  aptly server
- stops the old official rabbitmq puppet module from managing the
  rabbitmq repository, which is used by vms to install rabbitmq, because it
  incorrectly configures a rabbitmq.com repo that no longer exists
- essentially pegs the version of rabbitmq to 3.6.15-1 which is the
  last available version that has been tested and known to work across
  all services using rabbitmq.  A higher version might work, but that is
  for subsequent work.  Pegging is done by only presenting 3.6.15-1 as
  available in the aptly repo
- stops the unexpected upgrade of rabbitmq which could occur because the
  version installed by the old official puppet rabbitmq module would
  simply install the latest, meaning the version installed depended upon
  when the machine was spun up
- moves management of the rabbitmq repo from the old official rabbitmq
  module ::rabbitmq to being managed by govuk_rabbitmq::repo, thus aligning with our original
  intentions and configuration defined in hiera
- hosting the rabbitmq-server package on our aptly server

This PR goes hand in hand with the below  manual tasks that needed to be
done:
1. downloaded RabbitMQ-Server v3.6.15-1 from the official source https://github.com/rabbitmq/rabbitmq-server/releases/download/rabbitmq_v3_6_15/rabbitmq-server_3.6.15-1_all.deb
1. created the aptly-managed rabbitmq repository for stable/main
1. configured repository for trusty/main
1. added the .deb to the repository
1. published the repository

Future work:
- upgrade to later version of RabbitMQ
- install monitoring on the aptly server to detect when a mirroring
  action has failed