### PR TITLE
Adds internal target group healthcheck proxy

### DIFF
--- a/modules/govuk/manifests/apps/sidekiq_monitoring.pp
+++ b/modules/govuk/manifests/apps/sidekiq_monitoring.pp
@@ -256,6 +256,11 @@ class govuk::apps::sidekiq_monitoring (
     nagios_memory_critical => 1900,
   }
 
+  concat::fragment { "${app_name}_lb_healthcheck":
+    target  => '/etc/nginx/lb_healthchecks.conf',
+    content => "location /_healthcheck_${app_name} {\n  proxy_pass http://localhost/healthcheck;\n  proxy_set_header Host ${app_name};\n}\n",
+  }
+
   govuk::app::envvar::redis{
     "${app_name}_asset_manager":
       prefix => 'asset_manager',


### PR DESCRIPTION
The internal target group is configured to request
'/_healthcheck-sidekiq-monitoring' for sidekiq monitorings healthcheck
so this adds a proxy to the actual endpoint.

### Target group config

<img width="1146" alt="Screenshot 2021-03-19 at 14 08 54" src="https://user-images.githubusercontent.com/24479188/111792859-9631b000-88bc-11eb-8500-7a1e9fcf2cb7.png">

### Example request (with this PR deployed)

```
peterhartshorn@ec2-integration-blue-backend-ip-10-1-4-11:~$ curl localhost/_healthcheck_sidekiq-monitoring
{"status":"ok","checks":{"redis_connectivity":{"status":"ok"}}}
```

Trello:
https://trello.com/c/m8O8dC41/2414-add-dns-for-sidekiq-monitoring