### PR TITLE
Enable CD for Support

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1129,6 +1129,7 @@ govuk_jenkins::jobs::deploy_app_downstream::applications:
   service-manual-publisher: {}
   smartanswers:
     repository: 'smart-answers'
+  support: {}
   travel-advice-publisher: {}
 
 govuk_jenkins::jobs::deploy_lambda_app::lambda_apps:


### PR DESCRIPTION
Dependent on:

- alphagov/support#863
- alphagov/smokey#807
- alphagov/support#864
- alphagov/govuk-saas-config#88

https://trello.com/c/YPh5Epuc/2433-5-enable-continuous-deployment-for-support-app