### PR TITLE
Stop setting the router_nodes_class variable

### DIFF
--- a/hieradata_aws/class/draft_cache.yaml
+++ b/hieradata_aws/class/draft_cache.yaml
@@ -20,8 +20,6 @@ govuk::apps::router::mongodb_nodes:
   - 'router-backend-2'
   - 'router-backend-3'
 
-govuk::apps::router_api::router_nodes_class: 'draft_cache'
-
 govuk::apps::router_api::vhost: 'draft-router-api'
 
 router::nginx::app_specific_static_asset_routes:

--- a/hieradata_aws/class/router_backend.yaml
+++ b/hieradata_aws/class/router_backend.yaml
@@ -5,8 +5,6 @@ govuk::apps::router_api::mongodb_nodes:
   - 'router-backend-2'
   - 'router-backend-3'
 
-govuk::apps::router_api::router_nodes_class: 'cache'
-
 govuk_safe_to_reboot::can_reboot: 'overnight'
 govuk_safe_to_reboot::reason: 'Secondaries will reboot overnight if cluster is healthy'
 


### PR DESCRIPTION
This PR stops the setting of the `router_nodes_class` variable for the `draft_cache` and `router_backend` machine classes. Router is being changed to self-update routes from MongoDB rather than having Router API inform it when to update routes; no longer setting these variables in Puppet is part of a wider set of changes to allow this to happen.