### PR TITLE
Increase queue size for Carbon Cache/Relay/Aggregator

### DIFF
--- a/modules/govuk/files/node/s_graphite/carbon.conf
+++ b/modules/govuk/files/node/s_graphite/carbon.conf
@@ -265,7 +265,7 @@ DESTINATIONS = 127.0.0.1:2004
 # This defines the maximum "message size" between carbon daemons.
 # You shouldn't need to tune this unless you really know what you're doing.
 MAX_DATAPOINTS_PER_MESSAGE = 500
-MAX_QUEUE_SIZE = 10000
+MAX_QUEUE_SIZE = 20000
 
 # This is the percentage that the queue must be empty before it will accept
 # more messages.  For a larger site, if the queue is very large it makes sense
@@ -274,7 +274,7 @@ MAX_QUEUE_SIZE = 10000
 # to allow stats to start flowing when you've cleared the queue to 95% since
 # you should have space to accommodate the next minute's worth of stats
 # even before the relay incrementally clears more of the queue
-QUEUE_LOW_WATERMARK_PCT = 0.8
+QUEUE_LOW_WATERMARK_PCT = 0.9
 
 # Set this to False to drop datapoints when any send queue (sending datapoints
 # to a downstream carbon daemon) hits MAX_QUEUE_SIZE. If this is True (the
@@ -337,7 +337,7 @@ REPLICATION_FACTOR = 1
 # for a single destination. Once this limit is hit, we will
 # stop accepting new data if USE_FLOW_CONTROL is True, otherwise
 # we will drop any subsequently received datapoints.
-MAX_QUEUE_SIZE = 10000
+MAX_QUEUE_SIZE = 20000
 
 # Set this to False to drop datapoints when any send queue (sending datapoints
 # to a downstream carbon daemon) hits MAX_QUEUE_SIZE. If this is True (the


### PR DESCRIPTION
We are seeing warnings that say the carbon aggregator queue is hitting
its maximum size, initiating a backoff, and and causing stats to be
discarded from graphite.  This PR increases the queue size between for
cache, relay and aggregator whilst also changes the low water
threshold, which should prevent the backoff mechanism from initiating as
quickly.

It is unclear if these values are appropriate and they will likely need
tweaking as we get a better sense of volume of stats.

```
tail -n 2 /var/log/upstart/carbon-aggregator.log
23/03/2021 15:08:52 :: [clients] CarbonClientFactory(127.0.0.1:2024:None) send queue is full (10000 datapoints)
23/03/2021 15:08:52 :: [clients] CarbonClientProtocol(127.0.0.1:2024:None) send queue has space available
```