### PR TITLE
Fix an incorrect message & skip host key verification in reboot-cache-instances.sh

### DIFF
--- a/tools/reboot-cache-instances.sh
+++ b/tools/reboot-cache-instances.sh
@@ -60,7 +60,7 @@ echo "Waiting for requests to complete... 30 seconds"
 sleep 30
 
 echo "Rebooting instance via ssh"
-gds govuk connect ssh -e "$govuk_env" "$instance_private_dns_name" "sudo shutdown -r now"
+gds govuk connect ssh -e "$govuk_env" "$instance_private_dns_name" -- -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "sudo shutdown -r now"
 
 echo "Rebooted, waiting for instance to come back up..."
 sleep 10
@@ -68,7 +68,7 @@ sleep 10
 aws ec2 wait instance-status-ok --instance-ids "$instance_id"
 
 function appStatusCode {
-  gds govuk connect ssh -e "$govuk_env" "$instance_private_dns_name" "curl -s -o /dev/null -w '%{http_code}' localhost:80/_healthcheck_www"
+  gds govuk connect ssh -e "$govuk_env" "$instance_private_dns_name" -- -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "curl -s -o /dev/null -w '%{http_code}' localhost:80/_healthcheck_www"
 }
 
 until [ "$(appStatusCode)" == "200" ]

--- a/tools/reboot-cache-instances.sh
+++ b/tools/reboot-cache-instances.sh
@@ -56,7 +56,7 @@ do
   sleep 3
 done
 
-echo "Waiting for requests to complete... one minute"
+echo "Waiting for requests to complete... 30 seconds"
 sleep 30
 
 echo "Rebooting instance via ssh"


### PR DESCRIPTION
If the user hasn't connected to the instance before, they'll be
prompted to confirm the host key.  Even worse, if they *have*
connected to the instance befoe, but it's been recycled (and so has a
new host key), SSH will reject the connection!

Since these instances are (in principle) ephemeral, and not the
permanent VMs of previous Carrenza days, then the host key is
unimportant.

By skipping host key verification, this script is a bit less
interactive.