### PR TITLE
Change transition-config branch to main

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/transition_load_site_config.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/transition_load_site_config.yaml.erb
@@ -5,7 +5,7 @@
         - git:
             url: git@github.com:alphagov/transition-config.git
             branches:
-              - master
+              - main
 
 - job:
     name: Transition_load_site_config


### PR DESCRIPTION
I'd like to rename the branch from `master`, and this will be a required change to support that.