### PR TITLE
Fallback to master branch for app-deployment

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
@@ -40,7 +40,7 @@
               export APP_DEPLOYMENT_GIT_URL="git@github.com:alphagov/govuk-app-deployment.git"
             fi
 
-            git clone ${APP_DEPLOYMENT_GIT_URL} --branch ${APP_DEPLOYMENT_BRANCH} --single-branch --depth 1 ./
+            git clone ${APP_DEPLOYMENT_GIT_URL} --branch ${APP_DEPLOYMENT_BRANCH:-master} --single-branch --depth 1 ./
             ./jenkins.sh
         <% if @deploy_downstream %>
         - conditional-step:


### PR DESCRIPTION
The APP_DEPLOYMENT_BRANCH environment variable is not consistently set
for all Jenkins runs of this job (I think it ends up always set when a
deploy is done through the UI but not set when a job is triggered via
API).

This change falls back to the default master branch if the env var is
not set.

This applies a fix for https://github.com/alphagov/govuk-puppet/pull/11017 which broke for any jobs that were triggered using:  https://github.com/alphagov/govuk-puppet/blob/a4644f42466a3590d2c2656aaaf4fb85e3c3085b/modules/govuk_jenkins/templates/jobs/deploy_app_downstream.yaml.erb#L62