### PR TITLE
Enable Continuous Deployment for account-api

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1107,6 +1107,7 @@ govuk_jenkins::jobs::run_rake_task::applications: *deployable_applications
 govuk_jenkins::jobs::deploy_app::applications: *deployable_applications
 
 govuk_jenkins::jobs::deploy_app_downstream::applications:
+  account-api: {}
   authenticating-proxy: {}
   bouncer: {}
   collections: {}


### PR DESCRIPTION
account-api meets our criteria for continuous deployment, it has:

- a smokey test ensuring that it's up and healthy,
- line coverage of 95%+,
- and contract tests in gds-api-adapters.

---

[Trello card](https://trello.com/c/tx4jnjVa/682-enable-continuous-deployment-for-account-api)