### PR TITLE
Remove unnecessary account env vars

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -470,7 +470,6 @@ govuk::apps::ckan::gunicorn_worker_processes: "8"
 govuk::apps::ckan::s3_aws_access_key_id: "%{hiera('s3_aws_access_key_id')}"
 govuk::apps::ckan::s3_aws_secret_access_key: "%{hiera('s3_aws_secret_access_key')}"
 
-govuk::apps::collections::feature_flag_accounts: true
 govuk::apps::collections::unicorn_worker_processes: 8
 govuk::apps::collections::nagios_memory_warning: 3000
 govuk::apps::collections::nagios_memory_critical: 3400
@@ -551,7 +550,6 @@ govuk::apps::email_alert_service::rabbitmq::queue_size_critical_threshold: 25
 govuk::apps::email_alert_service::rabbitmq::queue_size_warning_threshold: 5
 
 govuk::apps::finder_frontend::enabled: true
-govuk::apps::finder_frontend::feature_flag_accounts: true
 govuk::apps::finder_frontend::nagios_memory_warning: 2500
 govuk::apps::finder_frontend::nagios_memory_critical: 3500
 govuk::apps::finder_frontend::unicorn_worker_processes: "6"

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -39,7 +39,6 @@ govuk::apps::email_alert_api::govuk_notify_recipients:
 govuk::apps::email_alert_frontend::subscription_management_enabled: true
 govuk::apps::feedback::govuk_notify_reply_to_id: 'fee22233-2f28-4b0b-8b6c-4410979f2275'
 govuk::apps::feedback::govuk_notify_template_id: 'eb9ba220-7d74-4aab-975a-bdbe718f69a3'
-govuk::apps::finder_frontend::plek_account_manager_uri: 'https://www.account.staging.publishing.service.gov.uk'
 govuk::apps::frontend::plek_account_manager_uri: 'https://www.account.staging.publishing.service.gov.uk'
 govuk::apps::frontend::govuk_notify_template_id: '1fc69d3a-09a2-40f9-852b-03f6fcef5340'
 govuk::apps::govuk_crawler_worker::enabled: false

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -193,7 +193,6 @@ govuk::apps::email_alert_api::govuk_notify_recipients: '*'
 govuk::apps::feedback::govuk_notify_reply_to_id: 'e8b2d8a6-db5f-4346-9fbd-49b16b531e1c'
 govuk::apps::feedback::govuk_notify_template_id: '54168fa9-3946-4860-a2f8-27ddbb14babe'
 
-govuk::apps::finder_frontend::plek_account_manager_uri: 'https://www.account.publishing.service.gov.uk'
 # https://docs.google.com/document/d/1kdRhmMUIyNZQmgo4FvXswJaDN2CWS2vlH9PVu21a68k/edit#
 govuk::apps::finder_frontend::unicorn_worker_processes: 24
 govuk::apps::finder_frontend::nagios_memory_warning: 10000

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -171,7 +171,6 @@ govuk::apps::email_alert_frontend::subscription_management_enabled: true
 govuk::apps::feedback::govuk_notify_reply_to_id: 'd1f54751-80a8-420a-9077-d34c7d6cc734'
 govuk::apps::feedback::govuk_notify_template_id: '8a8d98c0-42c8-4f56-b61f-77c89417a171'
 
-govuk::apps::finder_frontend::plek_account_manager_uri: 'https://www.account.staging.publishing.service.gov.uk'
 # https://github.com/alphagov/govuk-aws-data/pull/827
 govuk::apps::finder_frontend::unicorn_worker_processes: 24
 govuk::apps::finder_frontend::nagios_memory_warning: 10000

--- a/lib/puppet-lint/plugins/check_hiera.rb
+++ b/lib/puppet-lint/plugins/check_hiera.rb
@@ -69,9 +69,6 @@ PuppetLint.new_check(:hiera_explicit_lookup) do
     'wildcard_publishing_key',
     'www_crt',
     'www_key',
-
-    # accounts feature flag, a temporary thing
-    'govuk::apps::finder_frontend::feature_flag_accounts'
   ]
   def check
     tokens.select { |t| t.type == :NAME and t.value == 'hiera' }.each do |func_token|

--- a/modules/govuk/manifests/apps/collections.pp
+++ b/modules/govuk/manifests/apps/collections.pp
@@ -34,9 +34,6 @@
 # [*email_alert_api_bearer_token*]
 #   Bearer token for communication with the email-alert-api
 #
-# [*feature_flag_accounts*]
-#   Feature flag to switch GOV.UK Accounts on or off for the Transition Checker
-#
 # [*memcache_servers*]
 #   URL of a shared memcache cluster.
 #
@@ -49,7 +46,6 @@ class govuk::apps::collections(
   $nagios_memory_warning = undef,
   $nagios_memory_critical = undef,
   $email_alert_api_bearer_token = undef,
-  $feature_flag_accounts = false,
   $memcache_servers = undef,
 ) {
   govuk::app { 'collections':
@@ -71,11 +67,6 @@ class govuk::apps::collections(
     app => 'collections',
   }
 
-  $feature_flag_accounts_var = $feature_flag_accounts ? {
-                true    => 'enabled',
-                default => undef
-        }
-
   govuk::app::envvar {
     "${title}-EMAIL_ALERT_API_BEARER_TOKEN":
         varname => 'EMAIL_ALERT_API_BEARER_TOKEN',
@@ -83,9 +74,6 @@ class govuk::apps::collections(
     "${title}-SECRET_KEY_BASE":
         varname => 'SECRET_KEY_BASE',
         value   => $secret_key_base;
-    "${title}-FEATURE-FLAG-ACCOUNTS":
-        varname => 'FEATURE_FLAG_ACCOUNTS',
-        value   => $feature_flag_accounts_var;
     # MEMCACHE_SERVERS is used by "Dalli", our memcached client gem
     # https://github.com/petergoldstein/dalli/blob/1fbef3c/lib/dalli/client.rb#L35
     "${title}-MEMCACHE_SERVERS":

--- a/modules/govuk/manifests/apps/finder_frontend.pp
+++ b/modules/govuk/manifests/apps/finder_frontend.pp
@@ -24,18 +24,6 @@
 # [*account_api_bearer_token*]
 #   Bearer token for communication with the account-api
 #
-# [*account_oauth_client_id*]
-#   Client ID for the Transition Checker in GOV.UK Account Manager
-#
-# [*account_oauth_client_secret*]
-#   Client secret for the Transition Checker in GOV.UK Account Manager
-#
-# [*feature_flag_accounts*]
-#   Feature flag to switch GOV.UK Accounts on or off for the Transition Checker
-#
-# [*plek_account_manager_uri*]
-#   Path to the GOV.UK Account Manager
-#
 class govuk::apps::finder_frontend(
   $port,
   $enabled = false,
@@ -46,10 +34,6 @@ class govuk::apps::finder_frontend(
   $email_alert_api_bearer_token = undef,
   $account_api_bearer_token = undef,
   $unicorn_worker_processes = undef,
-  $account_oauth_client_id = undef,
-  $account_oauth_client_secret = undef,
-  $feature_flag_accounts = false,
-  $plek_account_manager_uri = undef,
 ) {
 
   if $enabled {
@@ -75,11 +59,6 @@ class govuk::apps::finder_frontend(
     app => 'finder-frontend',
   }
 
-  $feature_flag_accounts_var = $feature_flag_accounts ? {
-                true    => 'enabled',
-                default => undef
-        }
-
   govuk::app::envvar {
     "${title}-ACCOUNT_API_BEARER_TOKEN":
         varname => 'ACCOUNT_API_BEARER_TOKEN',
@@ -90,18 +69,6 @@ class govuk::apps::finder_frontend(
     "${title}-SECRET_KEY_BASE":
         varname => 'SECRET_KEY_BASE',
         value   => $secret_key_base;
-    "${title}-ACCOUNT-OAUTH-CLIENT-ID":
-        varname => 'GOVUK_ACCOUNT_OAUTH_CLIENT_ID',
-        value   => $account_oauth_client_id;
-    "${title}-ACCOUNT-OAUTH-CLIENT-SECRET":
-        varname => 'GOVUK_ACCOUNT_OAUTH_CLIENT_SECRET',
-        value   => $account_oauth_client_secret;
-    "${title}-FEATURE-FLAG-ACCOUNTS":
-        varname => 'FEATURE_FLAG_ACCOUNTS',
-        value   => $feature_flag_accounts_var;
-    "${title}-PLEK-ACCOUNT-MANAGER-URI":
-        varname => 'PLEK_SERVICE_ACCOUNT_MANAGER_URI',
-        value   => $plek_account_manager_uri;
   }
 
 }


### PR DESCRIPTION
We still need the `plek_account_manager_uri` for frontend (because it
can redirect a user to the account-manager) and for static (because it
shows a header link to the account-manager), but these vars can be
removed from collections and finder-frontend.