### PR TITLE
Add CH API Key env var to Smart Answers

### DIFF
--- a/modules/govuk/manifests/apps/smartanswers.pp
+++ b/modules/govuk/manifests/apps/smartanswers.pp
@@ -51,6 +51,9 @@
 # [*zendesk_client_username*]
 #   Username for connection to GDS zendesk client.
 #
+# [*companies_house_api_key*]
+#   API key to access the Companies House API
+#
 class govuk::apps::smartanswers(
   $vhost = 'smartanswers',
   $port,
@@ -65,6 +68,7 @@ class govuk::apps::smartanswers(
   $unicorn_worker_processes = undef,
   $zendesk_client_password = undef,
   $zendesk_client_username = undef,
+  $companies_house_api_key = undef,
 ) {
   Govuk::App::Envvar {
     app => 'smartanswers',
@@ -102,6 +106,9 @@ class govuk::apps::smartanswers(
     "${title}-ZENDESK_CLIENT_USERNAME":
       varname => 'ZENDESK_CLIENT_USERNAME',
       value   => $zendesk_client_username;
+    "${title}-COMPANIES_HOUSE_API_KEY":
+      varname => 'COMPANIES_HOUSE_API_KEY',
+      value   => $companies_house_api_key;
   }
 
   govuk::app { 'smartanswers':


### PR DESCRIPTION
This adds an environment variable to be used as the API key for accessing the Companies House API. This is needed by the "Next steps for your business" flow.