### PR TITLE
Remove db_allow_prepared_statements

### DIFF
--- a/docs/adding-a-new-app.md
+++ b/docs/adding-a-new-app.md
@@ -72,10 +72,6 @@ If your app uses a database, include the `db_` parameters:
 #   The port of the database server to use in the DATABASE_URL.
 #   Default: undef
 #
-# [*db_allow_prepared_statements*]
-#   The ?prepared_statements= parameter to use in the DATABASE_URL.
-#   Default: undef
-#
 # [*db_name*]
 #   The database name to use for the DATABASE_URL environment variable
 #
@@ -95,7 +91,6 @@ class govuk::apps::my_app (
   $db_username = 'my-app',
   $db_hostname = undef,
   $db_port = undef,
-  $db_allow_prepared_statements = undef,
   $db_password = undef,
   $db_name = 'my-app_production',
 ) {
@@ -148,13 +143,12 @@ If your app uses a database, set the database URL:
 
 ```puppet
   govuk::app::envvar::database_url { $app_name:
-    type                      => 'postgresql',
-    username                  => $db_username,
-    password                  => $db_password,
-    host                      => $db_hostname,
-    port                      => $db_port,
-    allow_prepared_statements => $db_allow_prepared_statements,
-    database                  => $db_name,
+    type     => 'postgresql',
+    username => $db_username,
+    password => $db_password,
+    host     => $db_hostname,
+    port     => $db_port,
+    database => $db_name,
   }
 ```
 

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -289,7 +289,6 @@ govuk::apps::contacts::redis_port: "%{hiera('sidekiq_port')}"
 
 govuk::apps::content_publisher::db_hostname: "postgresql-primary-1.backend"
 govuk::apps::content_publisher::db_port: 6432
-govuk::apps::content_publisher::db_allow_prepared_statements: false
 govuk::apps::content_publisher::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 govuk::apps::content_publisher::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
 govuk::apps::content_publisher::aws_region: "eu-west-1"
@@ -298,7 +297,6 @@ govuk::apps::content_publisher::redis_port: "%{hiera('sidekiq_port')}"
 
 govuk::apps::content_tagger::db_hostname: "postgresql-primary-1.backend"
 govuk::apps::content_tagger::db_port: 6432
-govuk::apps::content_tagger::db_allow_prepared_statements: false
 govuk::apps::content_tagger::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 govuk::apps::content_tagger::enable_procfile_worker: true
 govuk::apps::content_tagger::redis_host: "%{hiera('sidekiq_host')}"
@@ -332,7 +330,6 @@ govuk::apps::service_manual_publisher::http_username: "%{hiera('http_username')}
 govuk::apps::service_manual_publisher::http_password: "%{hiera('http_password')}"
 
 govuk::apps::service_manual_publisher::db_port: 6432
-govuk::apps::service_manual_publisher::db_allow_prepared_statements: false
 govuk::apps::service_manual_publisher::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 
 govuk::apps::sidekiq_monitoring::asset_manager_redis_host: "%{hiera('govuk::apps::asset_manager::redis_host')}"

--- a/modules/govuk/manifests/app/envvar/database_url.pp
+++ b/modules/govuk/manifests/app/envvar/database_url.pp
@@ -24,10 +24,6 @@
 # [*port*]
 #   The database port.  If not given, no port is included in the URL.
 #
-# [*allow_prepared_statements*]
-#    Whether to allow prepared statements.  If not given, no
-#    prepared_statements parameter is included in the URL.
-#
 define govuk::app::envvar::database_url (
   $type,
   $username,
@@ -35,7 +31,6 @@ define govuk::app::envvar::database_url (
   $host,
   $database,
   $port = undef,
-  $allow_prepared_statements = undef,
 ) {
 
   if $port == undef {
@@ -44,16 +39,10 @@ define govuk::app::envvar::database_url (
     $host_and_port = "${host}:${port}"
   }
 
-  if $allow_prepared_statements == undef {
-    $query_string = ''
-  } else {
-    $query_string = "?prepared_statements=${allow_prepared_statements}"
-  }
-
   $escaped_password = inline_template('<%= CGI.escape(@password.to_s) %>')
   govuk::app::envvar { "${title}-DATABASE_URL":
     app     => $title,
     varname => 'DATABASE_URL',
-    value   => "${type}://${username}:${escaped_password}@${host_and_port}/${database}${query_string}",
+    value   => "${type}://${username}:${escaped_password}@${host_and_port}/${database}",
   }
 }

--- a/modules/govuk/manifests/apps/account_api.pp
+++ b/modules/govuk/manifests/apps/account_api.pp
@@ -34,10 +34,6 @@
 #   The port of the database server to use in the DATABASE_URL.
 #   Default: undef
 #
-# [*db_allow_prepared_statements*]
-#   The ?prepared_statements= parameter to use in the DATABASE_URL.
-#   Default: undef
-#
 # [*db_name*]
 #   The database name to use for the DATABASE_URL environment variable
 #
@@ -60,7 +56,6 @@ class govuk::apps::account_api (
   $db_username = 'account-api',
   $db_hostname = undef,
   $db_port = undef,
-  $db_allow_prepared_statements = undef,
   $db_password = undef,
   $db_name = 'account-api_production',
   $account_oauth_client_id = undef,
@@ -116,12 +111,11 @@ class govuk::apps::account_api (
   }
 
   govuk::app::envvar::database_url { $app_name:
-    type                      => 'postgresql',
-    username                  => $db_username,
-    password                  => $db_password,
-    host                      => $db_hostname,
-    port                      => $db_port,
-    allow_prepared_statements => $db_allow_prepared_statements,
-    database                  => $db_name,
+    type     => 'postgresql',
+    username => $db_username,
+    password => $db_password,
+    host     => $db_hostname,
+    port     => $db_port,
+    database => $db_name,
   }
 }

--- a/modules/govuk/manifests/apps/content_data_admin.pp
+++ b/modules/govuk/manifests/apps/content_data_admin.pp
@@ -82,17 +82,16 @@
 #
 class govuk::apps::content_data_admin (
   $port,
-  $enabled                      = true,
-  $secret_key_base              = undef,
-  $sentry_dsn                   = undef,
-  $oauth_id                     = undef,
-  $oauth_secret                 = undef,
-  $db_username                  = 'content_data_admin',
-  $db_hostname                  = undef,
-  $db_port                      = undef,
-  $db_allow_prepared_statements = undef,
-  $db_password                  = undef,
-  $db_name                      = 'content_data_admin_production',
+  $enabled = true,
+  $secret_key_base = undef,
+  $sentry_dsn = undef,
+  $oauth_id = undef,
+  $oauth_secret = undef,
+  $db_username = 'content_data_admin',
+  $db_hostname = undef,
+  $db_port = undef,
+  $db_password = undef,
+  $db_name = 'content_data_admin_production',
   $content_data_api_bearer_token = undef,
   $google_tag_manager_id = undef,
   $google_tag_manager_preview = undef,
@@ -194,13 +193,12 @@ class govuk::apps::content_data_admin (
   }
 
   govuk::app::envvar::database_url { $app_name:
-    type                      => 'postgresql',
-    username                  => $db_username,
-    password                  => $db_password,
-    host                      => $db_hostname,
-    port                      => $db_port,
-    database                  => $db_name,
-    allow_prepared_statements => $db_allow_prepared_statements,
+    type     => 'postgresql',
+    username => $db_username,
+    password => $db_password,
+    host     => $db_hostname,
+    port     => $db_port,
+    database => $db_name,
   }
 
   govuk::procfile::worker { $app_name:

--- a/modules/govuk/manifests/apps/content_publisher.pp
+++ b/modules/govuk/manifests/apps/content_publisher.pp
@@ -34,10 +34,6 @@
 #   The port of the database server to use in the DATABASE_URL.
 #   Default: undef
 #
-# [*db_allow_prepared_statements*]
-#   The ?prepared_statements= parameter to use in the DATABASE_URL.
-#   Default: undef
-#
 # [*db_name*]
 #   The database name to use for the DATABASE_URL environment variable
 #
@@ -111,7 +107,6 @@ class govuk::apps::content_publisher (
   $db_hostname = undef,
   $db_password = undef,
   $db_port = undef,
-  $db_allow_prepared_statements = undef,
   $db_name = 'content_publisher_production',
   $publishing_api_bearer_token = undef,
   $whitehall_bearer_token = undef,
@@ -219,13 +214,12 @@ class govuk::apps::content_publisher (
   }
 
   govuk::app::envvar::database_url { $app_name:
-    type                      => 'postgresql',
-    username                  => $db_username,
-    password                  => $db_password,
-    host                      => $db_hostname,
-    port                      => $db_port,
-    allow_prepared_statements => $db_allow_prepared_statements,
-    database                  => $db_name,
+    type     => 'postgresql',
+    username => $db_username,
+    password => $db_password,
+    host     => $db_hostname,
+    port     => $db_port,
+    database => $db_name,
   }
 
   govuk::procfile::worker { $app_name:

--- a/modules/govuk/manifests/apps/content_tagger.pp
+++ b/modules/govuk/manifests/apps/content_tagger.pp
@@ -30,10 +30,6 @@
 #   The port of the database server to use in the DATABASE_URL.
 #   Default: undef
 #
-# [*db_allow_prepared_statements*]
-#   The ?prepared_statements= parameter to use in the DATABASE_URL.
-#   Default: undef
-#
 # [*db_name*]
 #   The database name to use in the DATABASE_URL.
 #
@@ -75,7 +71,6 @@ class govuk::apps::content_tagger(
   $db_username = 'content_tagger',
   $db_password = undef,
   $db_port = undef,
-  $db_allow_prepared_statements = undef,
   $db_name = 'content_tagger_production',
   $oauth_id = '',
   $oauth_secret = '',
@@ -139,13 +134,12 @@ class govuk::apps::content_tagger(
     }
 
     govuk::app::envvar::database_url { $app_name:
-      type                      => 'postgresql',
-      username                  => $db_username,
-      password                  => $db_password,
-      host                      => $db_hostname,
-      port                      => $db_port,
-      allow_prepared_statements => $db_allow_prepared_statements,
-      database                  => $db_name,
+      type     => 'postgresql',
+      username => $db_username,
+      password => $db_password,
+      host     => $db_hostname,
+      port     => $db_port,
+      database => $db_name,
     }
 
   }

--- a/modules/govuk/manifests/apps/email_alert_api.pp
+++ b/modules/govuk/manifests/apps/email_alert_api.pp
@@ -73,10 +73,6 @@
 #   The port of the database server to use in the DATABASE_URL.
 #   Default: undef
 #
-# [*db_allow_prepared_statements*]
-#   The ?prepared_statements= parameter to use in the DATABASE_URL.
-#   Default: undef
-#
 # [*nagios_memory_warning*]
 #   Memory use at which Nagios should generate a warning.
 #
@@ -112,7 +108,6 @@ class govuk::apps::email_alert_api(
   $db_password = undef,
   $db_hostname = undef,
   $db_port = undef,
-  $db_allow_prepared_statements = undef,
   $db_name = 'email-alert-api_production',
   $unicorn_worker_processes = undef,
   $aws_access_key_id = undef,
@@ -158,13 +153,12 @@ class govuk::apps::email_alert_api(
   }
 
   govuk::app::envvar::database_url { 'email-alert-api':
-    type                      => 'postgresql',
-    username                  => $db_username,
-    password                  => $db_password,
-    host                      => $db_hostname,
-    port                      => $db_port,
-    allow_prepared_statements => $db_allow_prepared_statements,
-    database                  => $db_name,
+    type     => 'postgresql',
+    username => $db_username,
+    password => $db_password,
+    host     => $db_hostname,
+    port     => $db_port,
+    database => $db_name,
   }
 
   govuk::app::envvar::redis { 'email-alert-api':

--- a/modules/govuk/manifests/apps/link_checker_api.pp
+++ b/modules/govuk/manifests/apps/link_checker_api.pp
@@ -23,10 +23,6 @@
 #   The port of the database server to use in the DATABASE_URL.
 #   Default: undef
 #
-# [*db_allow_prepared_statements*]
-#   The ?prepared_statements= parameter to use in the DATABASE_URL.
-#   Default: undef
-#
 # [*enabled*]
 #   Whether the app is enabled.
 #   Default: false
@@ -79,7 +75,6 @@ class govuk::apps::link_checker_api (
   $db_username = 'link_checker_api',
   $db_password = undef,
   $db_port = undef,
-  $db_allow_prepared_statements = undef,
   $db_name = 'link_checker_api_production',
   $enabled = false,
   $enable_procfile_worker = true,
@@ -160,12 +155,11 @@ class govuk::apps::link_checker_api (
   }
 
   govuk::app::envvar::database_url { $app_name:
-    type                      => 'postgresql',
-    username                  => $db_username,
-    password                  => $db_password,
-    host                      => $db_hostname,
-    port                      => $db_port,
-    allow_prepared_statements => $db_allow_prepared_statements,
-    database                  => $db_name,
+    type     => 'postgresql',
+    username => $db_username,
+    password => $db_password,
+    host     => $db_hostname,
+    port     => $db_port,
+    database => $db_name,
   }
 }

--- a/modules/govuk/manifests/apps/local_links_manager.pp
+++ b/modules/govuk/manifests/apps/local_links_manager.pp
@@ -34,10 +34,6 @@
 #   The port of the database server to use in the DATABASE_URL.
 #   Default: undef
 #
-# [*db_allow_prepared_statements*]
-#   The ?prepared_statements= parameter to use in the DATABASE_URL.
-#   Default: undef
-#
 # [*db_name*]
 #   The database name to use in the DATABASE_URL.
 #
@@ -114,7 +110,6 @@ class govuk::apps::local_links_manager(
   $db_username = 'local_links_manager',
   $db_password = undef,
   $db_port = undef,
-  $db_allow_prepared_statements = undef,
   $db_name = 'local-links-manager_production',
   $redis_host = undef,
   $redis_port = undef,
@@ -236,12 +231,11 @@ class govuk::apps::local_links_manager(
   }
 
   govuk::app::envvar::database_url { $app_name:
-    type                      => 'postgresql',
-    username                  => $db_username,
-    password                  => $db_password,
-    host                      => $db_hostname,
-    port                      => $db_port,
-    allow_prepared_statements => $db_allow_prepared_statements,
-    database                  => $db_name,
+    type     => 'postgresql',
+    username => $db_username,
+    password => $db_password,
+    host     => $db_hostname,
+    port     => $db_port,
+    database => $db_name,
   }
 }

--- a/modules/govuk/manifests/apps/publishing_api.pp
+++ b/modules/govuk/manifests/apps/publishing_api.pp
@@ -58,10 +58,6 @@
 #   The port of the database server to use in the DATABASE_URL.
 #   Default: undef
 #
-# [*db_allow_prepared_statements*]
-#   The ?prepared_statements= parameter to use in the DATABASE_URL.
-#   Default: undef
-#
 # [*db_name*]
 #   The database name to use in the DATABASE_URL.
 #
@@ -134,7 +130,6 @@ class govuk::apps::publishing_api(
   $db_username = 'publishing_api',
   $db_password = undef,
   $db_port = undef,
-  $db_allow_prepared_statements = undef,
   $db_name = 'publishing_api_production',
   $redis_host = undef,
   $redis_port = undef,
@@ -255,13 +250,12 @@ class govuk::apps::publishing_api(
     }
 
     govuk::app::envvar::database_url { $app_name:
-      type                      => 'postgresql',
-      username                  => $db_username,
-      password                  => $db_password,
-      host                      => $db_hostname,
-      port                      => $db_port,
-      allow_prepared_statements => $db_allow_prepared_statements,
-      database                  => $db_name,
+      type     => 'postgresql',
+      username => $db_username,
+      password => $db_password,
+      host     => $db_hostname,
+      port     => $db_port,
+      database => $db_name,
     }
   }
 }

--- a/modules/govuk/manifests/apps/service_manual_publisher.pp
+++ b/modules/govuk/manifests/apps/service_manual_publisher.pp
@@ -20,10 +20,6 @@
 #   The port of the database server to use in the DATABASE_URL.
 #   Default: undef
 #
-# [*db_allow_prepared_statements*]
-#   The ?prepared_statements= parameter to use in the DATABASE_URL.
-#   Default: undef
-#
 # [*db_name*]
 #   The database name to use in the DATABASE_URL.
 #
@@ -68,7 +64,6 @@ class govuk::apps::service_manual_publisher(
   $ensure = 'present',
   $db_hostname = 'postgresql-primary-1.backend',
   $db_port = undef,
-  $db_allow_prepared_statements = undef,
   $db_name = 'service-manual-publisher_production',
   $db_password = undef,
   $db_username = 'service_manual_publisher',
@@ -141,13 +136,12 @@ class govuk::apps::service_manual_publisher(
     }
 
     govuk::app::envvar::database_url { $app_name:
-      type                      => 'postgresql',
-      username                  => $db_username,
-      password                  => $db_password,
-      host                      => $db_hostname,
-      port                      => $db_port,
-      allow_prepared_statements => $db_allow_prepared_statements,
-      database                  => $db_name,
+      type     => 'postgresql',
+      username => $db_username,
+      password => $db_password,
+      host     => $db_hostname,
+      port     => $db_port,
+      database => $db_name,
     }
   }
 }

--- a/modules/govuk/manifests/apps/support_api.pp
+++ b/modules/govuk/manifests/apps/support_api.pp
@@ -17,10 +17,6 @@
 #   The port of the database server to use in the DATABASE_URL.
 #   Default: undef
 #
-# [*db_allow_prepared_statements*]
-#   The ?prepared_statements= parameter to use in the DATABASE_URL.
-#   Default: undef
-#
 # [*db_name*]
 #   The database name to use in the DATABASE_URL.
 #
@@ -91,7 +87,6 @@ class govuk::apps::support_api(
   $ensure = 'present',
   $db_hostname = undef,
   $db_port = undef,
-  $db_allow_prepared_statements = undef,
   $db_name = undef,
   $db_password = undef,
   $db_username = undef,
@@ -192,13 +187,12 @@ class govuk::apps::support_api(
   }
 
   govuk::app::envvar::database_url { $app_name:
-    type                      => 'postgresql',
-    username                  => $db_username,
-    password                  => $db_password,
-    host                      => $db_hostname,
-    port                      => $db_port,
-    allow_prepared_statements => $db_allow_prepared_statements,
-    database                  => $db_name,
+    type     => 'postgresql',
+    username => $db_username,
+    password => $db_password,
+    host     => $db_hostname,
+    port     => $db_port,
+    database => $db_name,
   }
 
   include govuk_postgresql::client #installs libpq-dev package needed for pg gem


### PR DESCRIPTION
I think this was originally introduced for pgbouncer.  We're not using
pgbouncer in AWS, and so this parameter was unset for every app.  It's
a bunch of configuration doing nothing, so let's delete it.