### PR TITLE
Remove performance platform smokey checks

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1428,8 +1428,6 @@ monitoring::checks::smokey::features:
     feature: manuals_frontend
   check_mirror:
     feature: mirror
-  check_performance_platform:
-    feature: performance_platform
   check_public_api:
     feature: public_api
   check_publishing_tools:


### PR DESCRIPTION
The performance platform was retired, and the smokey
tests were removed: https://github.com/alphagov/smokey/pull/800.

This removes the Icinga check for the removed tests.