### PR TITLE
Add Sentry auth token to user monitor job

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/user_monitor.pp
+++ b/modules/govuk_jenkins/manifests/jobs/user_monitor.pp
@@ -9,6 +9,7 @@
 #
 class govuk_jenkins::jobs::user_monitor (
   $github_token = undef,
+  $sentry_auth_token = undef,
   $app_domain = hiera('app_domain'),
   $enable_icinga_check = false,
 ) {

--- a/modules/govuk_jenkins/templates/jobs/user_monitor.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/user_monitor.yaml.erb
@@ -24,6 +24,7 @@
             artifact-num-to-keep: 5
     builders:
         - shell: |
+            export SENTRY_AUTH_TOKEN=<%= @sentry_auth_token %>
             bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
             bundle exec rake run
     publishers:


### PR DESCRIPTION
This is in preparation of setting up an additional check in
govuk-user-reviewer to compare the list of Sentry members to our
lists in https://github.com/alphagov/govuk-user-reviewer/tree/master/config
Once this is set up we can set the token in Jenkin's UI.