### PR TITLE
Use the shared frontend memcached server for Frontend

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -41,6 +41,7 @@ govuk::apps::feedback::govuk_notify_reply_to_id: 'fee22233-2f28-4b0b-8b6c-441097
 govuk::apps::feedback::govuk_notify_template_id: 'eb9ba220-7d74-4aab-975a-bdbe718f69a3'
 govuk::apps::frontend::plek_account_manager_uri: 'https://www.account.staging.publishing.service.gov.uk'
 govuk::apps::frontend::govuk_notify_template_id: '1fc69d3a-09a2-40f9-852b-03f6fcef5340'
+govuk::apps::frontend::memcache_servers: 'frontend-memcached:11211'
 govuk::apps::govuk_crawler_worker::enabled: false
 govuk::apps::govuk_crawler_worker::disable_during_data_sync: true
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true

--- a/modules/govuk/manifests/apps/frontend.pp
+++ b/modules/govuk/manifests/apps/frontend.pp
@@ -52,6 +52,9 @@
 # [*plek_account_manager_uri*]
 #   Path to the GOV.UK Account Manager
 #
+# [*memcache_servers*]
+#   URL of a shared memcache cluster.
+#
 class govuk::apps::frontend(
   $vhost = 'frontend',
   $port,
@@ -67,6 +70,7 @@ class govuk::apps::frontend(
   $govuk_notify_api_key = undef,
   $govuk_notify_template_id = undef,
   $plek_account_manager_uri = undef,
+  $memcache_servers = undef,
 ) {
   $app_name = 'frontend'
 
@@ -107,7 +111,12 @@ class govuk::apps::frontend(
     "${title}-PLEK-ACCOUNT-MANAGER-URI":
         varname => 'PLEK_SERVICE_ACCOUNT_MANAGER_URI',
         value   => $plek_account_manager_uri;
-  }
+    # MEMCACHE_SERVERS is used by "Dalli", our memcached client gem
+    # https://github.com/petergoldstein/dalli/blob/1fbef3c/lib/dalli/client.rb#L35
+    "${title}-MEMCACHE_SERVERS":
+        varname => 'MEMCACHE_SERVERS',
+        value   => $memcache_servers;
+}
 
   if $secret_key_base != undef {
     govuk::app::envvar {


### PR DESCRIPTION
We would like to use the shared AWS elasticache node for caching
on frontend. We will be adding a new election look up service to
frontend, and memcached will allow for better performance. Adding the
env var $memcache_servers to Integration to begin with.
Related PR: https://github.com/alphagov/frontend/pull/2708