### PR TITLE
Fix CDN cache clearing for emergency banner

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/clear_cdn_cache.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/clear_cdn_cache.yaml.erb
@@ -34,8 +34,8 @@
           )
 
           for node in `govuk_node_list -c cache`; do
-            for hostname in hostnames; do
-              for path in paths; do
+            for hostname in "${hostnames[@]}"; do
+              for path in "${paths[@]}"; do
                 ssh deploy@$node "curl -s -X PURGE $hostname$path"
               done
             done


### PR DESCRIPTION
The CDN cache did not clear when we deployed the emergency banner on 9 April 2021, and [the Jenkins job failed](https://deploy.blue.production.govuk.digital/job/clear-cdn-cache/5/console).

If appears we were trying to clear the cache of `hostnamespaths` which appears to have been caused by not treating the variables hostnames and paths as arrays.

This was probably never caught before as this task has never been run in production (as far as I am aware).