### PR TITLE
Enable larger attachments for Specialist Publisher

### DIFF
--- a/modules/govuk/manifests/apps/specialist_publisher.pp
+++ b/modules/govuk/manifests/apps/specialist_publisher.pp
@@ -131,7 +131,7 @@ class govuk::apps::specialist_publisher(
     health_check_path  => '/healthcheck',
     json_health_check  => true,
     log_format_is_json => true,
-    nginx_extra_config => 'client_max_body_size 500m;',
+    nginx_extra_config => template('govuk/specialist_publisher_nginx_extra.conf.erb'),
     asset_pipeline     => true,
   }
 

--- a/modules/govuk/templates/specialist_publisher_nginx_extra.conf.erb
+++ b/modules/govuk/templates/specialist_publisher_nginx_extra.conf.erb
@@ -1,0 +1,7 @@
+client_max_body_size 500m;
+
+# Extended timeout to allow the processing of large attachments
+location ~* attachments {
+  proxy_read_timeout 30s;
+  proxy_pass http://specialist-publisher-proxy;
+}


### PR DESCRIPTION
In addition to https://github.com/alphagov/specialist-publisher/pull/1847 this will enable users to upload larger attachments, who are currently seeing Nginx timeouts.

Ticket: https://govuk.zendesk.com/agent/tickets/4515218

This should save us time [manually scp-ing large files](https://docs.publishing.service.gov.uk/manual/manage-assets.html#large-attachments) to production for users.

It takes about 24s for Specialist Publisher to process the 250mb file on my fast connection (2.2mins in total, since Nginx buffers the file before proxying the request). For a good user experience we should probably add a note to the app saying 250mb is the max permitted size, since we'll likely see timeouts on larger files.