### PR TITLE
Add memcached stats to grafana for Frontend

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1209,7 +1209,8 @@ grafana::dashboards::application_dashboards:
         - search_api_request_time
     show_memcached: true
     instance_prefix: 'calculators_frontend'
-  frontend: {}
+  frontend:
+    show_memcached: true
   government-frontend: {}
   hmrc-manuals-api: {}
   imminence:


### PR DESCRIPTION
## What
Following https://github.com/alphagov/frontend/pull/2708 we would like to see memcached stats on Grafana.