### PR TITLE
Improve errors when the name of the app is wrong

### DIFF
--- a/modules/govuk_scripts/files/usr/local/bin/govuk_app_console
+++ b/modules/govuk_scripts/files/usr/local/bin/govuk_app_console
@@ -25,11 +25,11 @@ else
 fi
 
 if [ -f bin/rails ]; then
-  sudo -u deploy -H govuk_setenv $1 bundle exec ./bin/rails console
+  sudo -u deploy -H govuk_setenv "$1" bundle exec ./bin/rails console
 elif [ -f script/rails ]; then
-  sudo -u deploy -H govuk_setenv $1 bundle exec ./script/rails console
+  sudo -u deploy -H govuk_setenv "$1" bundle exec ./script/rails console
 elif [ -f console ]; then
-  sudo -u deploy -H govuk_setenv $1 bundle exec ./console
+  sudo -u deploy -H govuk_setenv "$1" bundle exec ./console
 else
   echo "I don't know how to run a console for $1"
   exit 1

--- a/modules/govuk_scripts/files/usr/local/bin/govuk_app_console
+++ b/modules/govuk_scripts/files/usr/local/bin/govuk_app_console
@@ -14,7 +14,15 @@ if [ "$#" -ne "1" ] || [ "$1" = "-h" ]; then
   exit 1
 fi
 
-cd /var/apps/$1
+if [ -d "/var/apps/$1" ]; then
+  cd "/var/apps/$1"
+else
+  echo "Could not find application $1. Are you sure you're looking at the right machine?"
+  echo "The applications on this machine are:"
+  echo ""
+  ls -1 /var/apps/
+  exit 1
+fi
 
 if [ -f bin/rails ]; then
   sudo -u deploy -H govuk_setenv $1 bundle exec ./bin/rails console

--- a/modules/govuk_scripts/files/usr/local/bin/govuk_app_dbconsole
+++ b/modules/govuk_scripts/files/usr/local/bin/govuk_app_dbconsole
@@ -24,9 +24,9 @@ else
 fi
 
 if [ -f bin/rails ]; then
-  sudo -u deploy govuk_setenv $1 bundle exec ./bin/rails dbconsole -p
+  sudo -u deploy govuk_setenv "$1" bundle exec ./bin/rails dbconsole -p
 elif [ -f script/rails ]; then
-  sudo -u deploy govuk_setenv $1 bundle exec ./script/rails dbconsole -p
+  sudo -u deploy govuk_setenv "$1" bundle exec ./script/rails dbconsole -p
 else
   echo "I don't know how to run a console for $1"
   exit 1

--- a/modules/govuk_scripts/files/usr/local/bin/govuk_app_dbconsole
+++ b/modules/govuk_scripts/files/usr/local/bin/govuk_app_dbconsole
@@ -13,7 +13,15 @@ if [ "$#" -ne "1" ] || [ "$1" = "-h" ]; then
   exit 1
 fi
 
-cd /var/apps/$1
+if [ -d "/var/apps/$1" ]; then
+  cd "/var/apps/$1"
+else
+  echo "Could not find application $1. Are you sure you're looking at the right machine?"
+  echo "The applications on this machine are:"
+  echo ""
+  ls -1 /var/apps/
+  exit 1
+fi
 
 if [ -f bin/rails ]; then
   sudo -u deploy govuk_setenv $1 bundle exec ./bin/rails dbconsole -p


### PR DESCRIPTION
Error messages for this use case used to say:

```
cd: can't cd to /var/apps/content_store
```

Now they'll say:

```
Could not find application content_store. Are you sure you're looking at the right machine?
The applications on this machine are:

...
content-store
...
```

