### PR TITLE
Add an Icinga check for expiring signon API tokens

### DIFF
--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -362,6 +362,7 @@ licensify::apps::licensify::alert_5xx_warning_rate: 0.1
 licensify::apps::licensify::alert_5xx_critical_rate: 0.15
 
 monitoring::checks::aws_origin_domain: "staging.govuk.digital"
+monitoring::checks::signon_api_tokens_check_period: 'never'
 monitoring::checks::whitehall_overdue_check_period: 'never'
 monitoring::checks::whitehall_scheduled_check_period: 'never'
 monitoring::checks::sidekiq::enable_signon_check: false

--- a/modules/govuk/manifests/apps/signon.pp
+++ b/modules/govuk/manifests/apps/signon.pp
@@ -95,7 +95,6 @@ class govuk::apps::signon(
     sentry_dsn               => $sentry_dsn,
     vhost_ssl_only           => true,
     health_check_path        => '/healthcheck',
-    health_check_custom_doc  => true,
     json_health_check        => true,
     asset_pipeline           => true,
     deny_framing             => true,

--- a/modules/monitoring/manifests/checks.pp
+++ b/modules/monitoring/manifests/checks.pp
@@ -20,6 +20,7 @@ class monitoring::checks (
   $whitehall_overdue_check_period = undef,
   $whitehall_scheduled_check_period = undef,
   $content_data_api_check_period  = undef,
+  $signon_api_tokens_check_period = undef,
 ) {
 
   ensure_packages(['jq'])
@@ -83,6 +84,14 @@ class monitoring::checks (
     check_period               => $content_data_api_check_period,
     attempts_before_hard_state => 5,
     retry_interval             => 1,
+  }
+
+  icinga::check { "signon_api_tokens_${::hostname}":
+    check_command       => "check_app_health!check_json_healthcheck!443 /healthcheck/api-tokens signon.${app_domain} https",
+    service_description => 'expiring API tokens in Signon',
+    host_name           => $::fqdn,
+    notes_url           => monitoring_docs_url(expiring-api-tokens-in-signon),
+    check_period        => $signon_api_tokens_check_period,
   }
 
   # Used in template and icinga::check.


### PR DESCRIPTION
See https://github.com/alphagov/signon/pull/1620

---

[Trello card](https://trello.com/c/tl6RV1el/723-improve-govuk-healthchecks)