### PR TITLE
Remove `default` value of `release` for `Deploy_App` job

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
@@ -114,7 +114,6 @@
         - string:
             name: TAG
             description: Git commit-ish (tag, branch name, commit hash) to deploy.
-            default: release
         - string:
             name: TARGET_MACHINES
             description: >


### PR DESCRIPTION
The unnumbered `release` tag is a legacy thing that should not be
relied upon to always have the latest code:
https://github.com/alphagov/govuk-jenkinslib/blob/a5957a0cceb0aac4dc88aabd9497a5040e2dea17/vars/govuk.groovy#L708-L717

By having `release` as a default, we encourage developers to use
that as the canonical latest tag, where something like
`deployed-to-production` would be better. We probably shouldn't
set `deployed-to-production`, however, as running this on Production
itself would mean nothing new ever gets deployed.

Let the developer figure out the latest release number by checking
the Release app, which will complain about differences in environments
if `release` is deployed anyway (even if it happens to be the same 'latest' code):

![screenshot of Release app complaining about `release` vs `release_3743`](https://user-images.githubusercontent.com/5111927/115368809-5c0b4500-a1bf-11eb-9d8e-4d8f35724894.png)