### PR TITLE
Fetch a top-level "message" key from JSON healthcheck response

### DIFF
--- a/modules/icinga/files/usr/lib/nagios/plugins/check_json_healthcheck
+++ b/modules/icinga/files/usr/lib/nagios/plugins/check_json_healthcheck
@@ -135,8 +135,12 @@ class HealthCheckInfo(object):
 
         """
         checks = self._dict.get("checks", {})
-        return [" - ".join(self._check_parts(check_name, check_value))
-                for (check_name, check_value) in checks.items()]
+        messages = []
+        if self._dict.get("message"):
+            messages.append(self._dict.get("message"))
+        messages.extend([" - ".join(self._check_parts(check_name, check_value))
+                         for (check_name, check_value) in checks.items()])
+        return messages
 
     def _check_parts(self, check_name, check_value):
         parts = [check_name, check_value["status"]]

--- a/modules/icinga/files/usr/lib/nagios/plugins/test_json_healthcheck.py
+++ b/modules/icinga/files/usr/lib/nagios/plugins/test_json_healthcheck.py
@@ -67,6 +67,19 @@ class TestHealthCheckInfo(unittest.TestCase):
         self.assertEqual(hc.check_statuses,
                          ["foo - ok - All 12 foos look good"])
 
+    def test_includes_overall_message(self):
+        hc = HealthCheckInfo(
+            {
+                "status": "warning",
+                "message": "overall message",
+                "checks": {
+                    "foo": {"status": "ok", "message": "All 12 foos look good"}
+                }
+            }
+        )
+        self.assertEqual(hc.check_statuses,
+                         ["overall message", "foo - ok - All 12 foos look good"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Some things which were in the "checks" object are now moving to their
own endpoints, separate from the main app healthcheck.  This change is
so that these new endpoints can return just

    { "status": "ok", "message": "details" }

Rather than

    { "status": "ok", "checks":
      { "checkname": { "status": "ok", "message": "details" } }
    }

In particular, right now the new signon expiring API tokens check is
not reporting *which* tokens are expiring, because it is returning
that information in a top-level "message" key:

```
michaelswalker@ec2-integration-blue-backend-ip-10-1-5-36:~$ curl localhost:3016/healthcheck/api-tokens
{"message":"\n\nGOVUK Related Links User token for Publishing API expires in 53 days\n\n","status":"warning"}
```

<img width="395" alt="Screenshot 2021-04-20 at 12 21 02" src="https://user-images.githubusercontent.com/75235/115387668-e3ae7f00-a1d2-11eb-82b5-7528dd62ce57.png">

---

[Trello card](https://trello.com/c/tl6RV1el/723-improve-govuk-healthchecks)