### PR TITLE
Fix publishing-api queue latency check

### DIFF
--- a/modules/monitoring/manifests/checks/sidekiq.pp
+++ b/modules/monitoring/manifests/checks/sidekiq.pp
@@ -58,7 +58,7 @@ class monitoring::checks::sidekiq (
 
   if $enable_publishing_api_check {
     icinga::check::graphite { 'check_publishing_api_downstream_high_queue_latency':
-      target    => 'transformNull(averageSeries(keepLastValue(stats.gauges.govuk.app.publishing-api.*.workers.queues.downstream_high.enqueued)), 0)',
+      target    => 'transformNull(averageSeries(keepLastValue(stats.gauges.govuk.app.publishing-api.*.workers.queues.downstream_high.latency)), 0)',
       from      => '24hours',
       args      => '--dropfirst -36',
       warning   => 45,


### PR DESCRIPTION
I had accidentally used the `enqueued` metric, not the `latency`
metric.  So this would instead alert if there were more than 45
documents in the queue, which we surpass all the time.

See #11046

---

[Trello card](https://trello.com/c/tl6RV1el/723-improve-govuk-healthchecks)