### PR TITLE
Add Icinga checks for new content-publisher healthcheck endpoints

### DIFF
--- a/modules/govuk/manifests/apps/content_publisher.pp
+++ b/modules/govuk/manifests/apps/content_publisher.pp
@@ -135,17 +135,16 @@ class govuk::apps::content_publisher (
 
   # see modules/govuk/manifests/app.pp for more options
   govuk::app { $app_name:
-    ensure                  => $ensure,
-    app_type                => 'rack',
-    port                    => $port,
-    sentry_dsn              => $sentry_dsn,
-    vhost_ssl_only          => true,
-    health_check_path       => '/healthcheck', # must return HTTP 200 for an unauthenticated request
-    health_check_custom_doc => true,
-    json_health_check       => true,
-    deny_framing            => true,
-    asset_pipeline          => true,
-    nginx_extra_config      => 'client_max_body_size 500m;',
+    ensure             => $ensure,
+    app_type           => 'rack',
+    port               => $port,
+    sentry_dsn         => $sentry_dsn,
+    vhost_ssl_only     => true,
+    health_check_path  => '/healthcheck', # must return HTTP 200 for an unauthenticated request
+    json_health_check  => true,
+    deny_framing       => true,
+    asset_pipeline     => true,
+    nginx_extra_config => 'client_max_body_size 500m;',
   }
 
   Govuk::App::Envvar {

--- a/modules/monitoring/manifests/checks.pp
+++ b/modules/monitoring/manifests/checks.pp
@@ -23,6 +23,8 @@ class monitoring::checks (
   $signon_api_tokens_check_period = undef,
   $search_api_reranker_check_period = undef,
   $search_api_elasticsearch_diskspace_check_period = undef,
+  $content_publisher_active_storage_check_period = undef,
+  $content_publisher_government_data_check_period = undef,
 ) {
 
   ensure_packages(['jq'])
@@ -109,6 +111,21 @@ class monitoring::checks (
     service_description => 'elasticsearch diskspace is too low',
     host_name           => $::fqdn,
     check_period        => $search_api_elasticsearch_diskspace_check_period,
+  }
+
+  icinga::check { "content_publisher_active_storage_${::hostname}":
+    check_command       => "check_app_health!check_json_healthcheck!443 /healthcheck/active-storage content-publisher.${app_domain} https",
+    service_description => 'content-publisher active-storage check is not ok',
+    host_name           => $::fqdn,
+    check_period        => $content_publisher_active_storage_check_period,
+  }
+
+  icinga::check { "content_publisher_government_data_${::hostname}":
+    check_command       => "check_app_health!check_json_healthcheck!443 /healthcheck/government-data content-publisher.${app_domain} https",
+    service_description => 'content-publisher government data check is not ok',
+    host_name           => $::fqdn,
+    check_period        => $content_publisher_government_data_check_period,
+    notes_url           => monitoring_docs_url(content-publisher-government-data-check-not-ok),
   }
 
   # Used in template and icinga::check.


### PR DESCRIPTION
See
https://github.com/alphagov/content-publisher/pull/2302

---

[Trello card](https://trello.com/c/tl6RV1el/723-improve-govuk-healthchecks)