### PR TITLE
Update reference to search-api's master branch

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/search_fetch_analytics_data.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/search_fetch_analytics_data.yaml.erb
@@ -18,7 +18,7 @@
       <p>More information:</p>
       <ul>
         <li><a href='https://github.com/alphagov/search-analytics'>alphagov/search-analytics on GitHub</a></li>
-        <li><a href='https://github.com/alphagov/<%= @target_application %>/blob/master/doc/popularity.md'>Docs on Search</a></li>
+        <li><a href='https://github.com/alphagov/<%= @target_application %>/blob/main/docs/popularity.md'>Docs on Search</a></li>
       </ul>
     scm:
         - <%= @job_name %>


### PR DESCRIPTION
- master has been renamed to main.
https://trello.com/c/OkCi3698/234-brexit-content-and-product