### PR TITLE
And instance_prefix for grafana to show up memcached stats

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1196,6 +1196,7 @@ grafana::dashboards::application_dashboards:
     show_memcached: true
     instance_prefix: 'calculators_frontend'
   frontend:
+    instance_prefix: 'frontend'
     show_memcached: true
   government-frontend: {}
   hmrc-manuals-api: {}

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -242,6 +242,7 @@ grafana::dashboards::application_dashboards:
     show_memcached: true
     instance_prefix: 'calculators_frontend'
   frontend:
+    instance_prefix: 'frontend'
     show_memcached: true
   government-frontend: {}
   hmrc-manuals-api: {}


### PR DESCRIPTION
- Looks like instance_prefix is required to get data to show up, as
  apps can live on instances that do not share their name.