### PR TITLE
Revert "Upgrade to graphite-1.0.0"

### DIFF
--- a/modules/govuk/files/node/s_graphite/graphite_carbon_service.patch
+++ b/modules/govuk/files/node/s_graphite/graphite_carbon_service.patch
@@ -1,0 +1,22 @@
+From 2cc77752383288c27c4623a659cd0a76ef95b5a9 Mon Sep 17 00:00:00 2001
+From: Jean Raby <jean@raby.sh>
+Date: Mon, 5 Jan 2015 12:18:32 -0500
+Subject: [PATCH] Wire state.events to events (not state)
+
+---
+ lib/carbon/service.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/carbon/service.py b/lib/carbon/service.py
+index be00876..7124450 100644
+--- a/lib/carbon/service.py
++++ b/lib/carbon/service.py
+@@ -24,7 +24,7 @@
+ from carbon.log import carbonLogObserver
+ from carbon.exceptions import CarbonConfigException
+ 
+-state.events = state
++state.events = events
+ 
+ 
+ class CarbonRootService(MultiService):

--- a/modules/govuk/manifests/node/s_graphite.pp
+++ b/modules/govuk/manifests/node/s_graphite.pp
@@ -24,7 +24,7 @@ class govuk::node::s_graphite (
   $apt_mirror_gpg_key_fingerprint,
 ) inherits govuk::node::s_base {
   class { 'graphite':
-    version                    => '1.0.0',
+    version                    => '0.9.13',
     port                       => '33333',
     worker_processes           => 4,
     carbon_aggregator          => true,
@@ -35,10 +35,25 @@ class govuk::node::s_graphite (
     require                    => Govuk_mount[$graphite_path],
   }
 
-  exec { 'migrate graphite database':
-    command => "env PYTHONPATH=${graphite_path}/webapp ${graphite_path}/bin/django-admin.py migrate --noinput --settings=graphite.settings --run-syncdb",
+  # FIXME: Remove this patch when Graphite is upgraded past 0.9.13
+  # This patch is https://github.com/graphite-project/carbon/pull/351 - the bug
+  # that this fixes was released as part of 0.9.13 which breaks all of our
+  # carbon-aggregator metrics.
+  $service_py = "${graphite_path}/lib/carbon/service.py"
+  $service_patch = "${graphite_path}/graphite_carbon_service.patch"
+  $service_patched_md5 = '0559bf74463b14f4070e3cf8a2584fff'
+  file { $service_patch:
+    ensure => file,
+    source => 'puppet:///modules/govuk/node/s_graphite/graphite_carbon_service.patch',
+  }
+  exec { 'patch graphite 0.9.13 carbon':
+    command => "/usr/bin/patch -b ${service_py} ${service_patch}",
+    unless  => "/usr/bin/md5sum ${service_py} | /bin/grep -qsw ${service_patched_md5}",
     notify  => Class['graphite::service'],
-    require => Class['graphite::install'],
+    require => [
+      Class['graphite::install'],
+      File[$service_patch],
+    ],
   }
 
   @@icinga::check { "check_carbon_cache_running_on_${::hostname}":


### PR DESCRIPTION
Reverts alphagov/govuk-puppet#11064

Upgrading whisper seems to involve copying all of `/opt/graphite` into `/tmp`, but `/tmp` is on a partition far smaller than `/opt/graphite`, so it runs out of space and fails.

Not sure how to debug this.  Maybe upgrading pip would help, since our version of pip is so old, but this seems like a rabbit hole.

In addition, we're soon going to be unable to install Python packages at all: https://status.python.org/incidents/hzmjhqsdjqgb