### PR TITLE
Forbid access to internal Signon API

### DIFF
--- a/modules/govuk/manifests/apps/signon.pp
+++ b/modules/govuk/manifests/apps/signon.pp
@@ -92,6 +92,7 @@ class govuk::apps::signon(
   govuk::app { $app_name:
     app_type                   => 'rack',
     port                       => $port,
+    nginx_extra_config         => template('govuk/signon_extra_nginx_config.conf.erb'),
     sentry_dsn                 => $sentry_dsn,
     vhost_ssl_only             => true,
     health_check_path          => '/healthcheck',

--- a/modules/govuk/templates/signon_extra_nginx_config.conf.erb
+++ b/modules/govuk/templates/signon_extra_nginx_config.conf.erb
@@ -1,0 +1,3 @@
+location ~ /api/v1(.*) {
+  return 403;
+}


### PR DESCRIPTION
We will be adding an internal API to Signon at /api in this PR: alphagov/signon#1617.

This introduces an L7 firewall to restrict public access to this API.