### PR TITLE
Include surrogate keys for immutable assets

### DIFF
--- a/modules/govuk/templates/asset_pipeline_extra_nginx_conf.erb
+++ b/modules/govuk/templates/asset_pipeline_extra_nginx_conf.erb
@@ -10,6 +10,7 @@
     location ~ "-[0-9a-f]{32,}\." {
       expires max;
       add_header Cache-Control "public, immutable";
+      add_header Surrogate-Key "assets assets-<%= @vhost %>";
 
       # Set CORS allow origin for fonts only
       location ~* \.(eot|otf|ttf|woff|woff2)$ {


### PR DESCRIPTION
As these assets are cached for perpetuity it is hard to make any changes
to how the CDN hosts them without needing to manually purge lots of
assets from the CDN or purge the entire CDN.

This was a problem we hit when enabling Brotli compression at the CDN,
where we were faced with this challenge of purging everything or a lot
of manual purges.

In order to try avoid this problem in future a surrogate key is being
set for both all application assets (assets) or an individual
applications ones based on the vhost (assets-government-frontend). These
surrogate keys can be used to purge a grouping of files from a Fastly
cache [1]. Thus, should we need to purge all assets (or an applications
assets), from the Fastly cache it will be a simple operation.

This is only applied to assets with a max expires time as these are the
items that are hard to remove from a cache, other times (with more
manageable cache times such as 30 mins) will clear by themselves in that
time frame.

[1]: https://docs.fastly.com/en/guides/getting-started-with-surrogate-keys