### PR TITLE
Remove AWS parameter from the uptime collector

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1414,8 +1414,6 @@ monitoring::checks::mirror::gcp_mirror_sync_transfer_job_auth_json: "%{hiera('mo
 monitoring::gcloud::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 monitoring::gcloud::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
-monitoring::uptime_collector::aws: true
-
 # FIXME: this has been added to avoid a bug until we move to v3 of the module
 mysql::client::package_ensure: 'present'
 

--- a/modules/monitoring/files/usr/local/bin/govuk_uptime_collector
+++ b/modules/monitoring/files/usr/local/bin/govuk_uptime_collector
@@ -9,11 +9,10 @@ require "time"
 require "statsd"
 
 class Collector
-  def initialize(service_details, environment, aws)
+  def initialize(service_details, environment)
     extract_service_details(service_details)
     @statsd = Statsd.new("127.0.0.1")
     @environment = environment
-    @aws = aws
   end
 
   def call
@@ -25,7 +24,7 @@ class Collector
 
 private
 
-  attr_reader :statsd, :service_name, :environment, :aws, :healthcheck_path
+  attr_reader :statsd, :service_name, :environment, :healthcheck_path
 
   def extract_service_details(details)
     details = details.split(':')
@@ -34,14 +33,7 @@ private
   end
 
   def healthcheck_uri
-    @healthcheck_uri ||= begin
-      if aws
-        URI("https://#{service_name}.#{environment}.govuk.digital/healthcheck/live")
-      else
-        prefix = environment == "production" ? "#{service_name}" : "#{service_name}.#{environment}"
-        URI("https://#{prefix}.publishing.service.gov.uk/#{healthcheck_path}")
-      end
-    end
+    @healthcheck_uri ||= URI("https://#{service_name}.#{environment}.govuk.digital/healthcheck/live")
   end
 
   def check_service_up
@@ -70,11 +62,10 @@ def main
   threads = []
 
   environment = ARGV[0]
-  aws = ARGV[1] == 'true' ? true : false
 
-  ARGV[2..-1].each do |service_details|
+  ARGV[1..-1].each do |service_details|
     threads << Thread.new do
-      Collector.new(service_details, environment, aws).call
+      Collector.new(service_details, environment).call
     end
   end
 

--- a/modules/monitoring/manifests/uptime_collector.pp
+++ b/modules/monitoring/manifests/uptime_collector.pp
@@ -8,13 +8,7 @@
 #   The environment the uptime collecting is running in. For example:
 #     production, integration or staging.
 #
-# [*aws*]
-#   Optional. True or false, depending on whether we're running in AWS or not.
-
-class monitoring::uptime_collector (
-  $environment = '',
-  $aws = false,
-) {
+class monitoring::uptime_collector($environment = '') {
   exec { 'install statsd into 2.6 rbenv':
     environment => 'RBENV_VERSION=2.6',
     path        => ['/usr/lib/rbenv/shims', '/usr/local/bin', '/usr/bin', '/bin'],

--- a/modules/monitoring/templates/govuk-uptime-collector.conf.erb
+++ b/modules/monitoring/templates/govuk-uptime-collector.conf.erb
@@ -6,4 +6,4 @@ respawn
 env RBENV_VERSION=2.6
 env PATH=/usr/lib/rbenv/shims:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
-exec govuk_uptime_collector <%= @environment %> <%= @aws %> content-store hmrc-manuals-api link-checker-api manuals-publisher publishing-api specialist-publisher travel-advice-publisher whitehall-admin:healthcheck/overdue
+exec govuk_uptime_collector <%= @environment %> content-store hmrc-manuals-api link-checker-api manuals-publisher publishing-api specialist-publisher travel-advice-publisher whitehall-admin:healthcheck/overdue


### PR DESCRIPTION
We no longer need this parameter as we don't run in a non-AWS environment. This follows on from #11043.