### PR TITLE
Fix setting cookies for /find-coronavirus-support

### DIFF
--- a/modules/varnish/templates/default.vcl.erb
+++ b/modules/varnish/templates/default.vcl.erb
@@ -85,7 +85,7 @@ sub vcl_recv {
   #   - email-alert-frontend (for subscription management)
   #   - frontend (for sessions across funding registration form)
   #   - smart answers coronavirus find support flow
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/brexit-eu-funding" && req.url !~ "^/find-coronavirus-support/s")
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/brexit-eu-funding" && req.url !~ "^/find-coronavirus-support")
   {
     unset req.http.Cookie;
   }
@@ -122,7 +122,7 @@ sub vcl_fetch {
 
   <% if @strip_cookies %>
   # Strip cookies from outbound requests. Corresponding rule in vcl_recv{}
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/brexit-eu-funding" && req.url !~ "^/find-coronavirus-support/s") {
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/brexit-eu-funding" && req.url !~ "^/find-coronavirus-support") {
     unset beresp.http.Set-Cookie;
   }
   <% end %>


### PR DESCRIPTION
This service is provided by Smart Answers and require cookies to work. Previously routes to /find-coronavirus-support were prefixed with /s/, however this has since been changes to no longer require the prefix slug. This commit prevents cookies from being stripped from requests without the /s/ prefix.