### PR TITLE
Update the CI agents to use python 2.7.14

### DIFF
--- a/hieradata_aws/class/integration/ci_agent.yaml
+++ b/hieradata_aws/class/integration/ci_agent.yaml
@@ -15,7 +15,7 @@ govuk_containers::elasticsearch::secondary::enable: false
 postgresql::globals::version: '9.6'
 postgresql::globals::postgis_version: '3.1.1'
 govuk_postgresql::server::enable_collectd: false
-govuk_python::govuk_python_version: '3.6.12'
+govuk_python::govuk_python_version: '2.7.14'
 
 govuk_mysql::server::innodb_flush_log_at_trx_commit: 2
 govuk_mysql::server::innodb_buffer_pool_size_proportion: 0.05


### PR DESCRIPTION
## What

This is needed to deploy CKAN 2.8 changes, python 3 was set up to be used for deployment of CKAN 2.9 and will be implemented at a later date as it is still undergoing development.