### PR TITLE
Bump search-api unicorns to 48 per machine

### DIFF
--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -222,7 +222,7 @@ govuk::apps::search_api::relevancy_bucket_name: 'govuk-production-search-relevan
 govuk::apps::search_api::sitemaps_bucket_name: 'govuk-production-sitemaps'
 govuk::apps::search_api::tensorflow_sagemaker_endpoint: 'govuk-production-search-ltr-endpoint'
 govuk::apps::search_api::enable_learning_to_rank: true
-govuk::apps::search_api::unicorn_worker_processes: "36"
+govuk::apps::search_api::unicorn_worker_processes: "48"
 govuk::apps::service_manual_publisher::govuk_notify_template_id: "e00e89f5-b622-4dcb-8f30-e6c70231a940"
 govuk::apps::short_url_manager::govuk_notify_template_id: "e00e89f5-b622-4dcb-8f30-e6c70231a940"
 govuk::apps::short_url_manager::instance_name: 'production'


### PR DESCRIPTION
I want to reduce the number of machines we have in production as it's costing us money. Staging has 36 unicorns running on machines with half the CPU and RAM of those in production and seems fine when dealing with replayed production traffic.

The machines are under low load, and there's plenty of headroom in terms of CPU and memory used. [Example machine on Grafana](https://grafana.production.govuk.digital/dashboard/file/machine.json?refresh=1m&orgId=1&var-hostname=search-ip-10-13-5-135_eu-west-1_compute_internal&var-cpmetrics=All&var-filesystem=All&var-disk=All&var-tcpconnslocal=All&var-tcpconnsremote=All&from=now-2d&to=now)

This app is not particularly CPU intensive as it offloads most things to Elasticsearch or SageMaker, and does some processing of results on the way back through.

I propose to ratchet this up in stages (reducing the number of machines as we go), to potentially halve the number of machines eventually while retaining our pool of workers.