### PR TITLE
Increase finder-frontend unicorn workers

### DIFF
--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -194,7 +194,7 @@ govuk::apps::feedback::govuk_notify_reply_to_id: 'e8b2d8a6-db5f-4346-9fbd-49b16b
 govuk::apps::feedback::govuk_notify_template_id: '54168fa9-3946-4860-a2f8-27ddbb14babe'
 
 # https://docs.google.com/document/d/1kdRhmMUIyNZQmgo4FvXswJaDN2CWS2vlH9PVu21a68k/edit#
-govuk::apps::finder_frontend::unicorn_worker_processes: 24
+govuk::apps::finder_frontend::unicorn_worker_processes: 48
 
 govuk::apps::frontend::plek_account_manager_uri: 'https://www.account.publishing.service.gov.uk'
 govuk::apps::frontend::govuk_notify_template_id: 'cb633abc-6ae6-4843-ae6f-82ca500b6de2'


### PR DESCRIPTION
This will allow us to at least halve the number of calculators_frontend machines currently running. It's probable that we'll be able to switch the remaining ones to a general purpose compute type, as [load is negligible](https://grafana.production.govuk.digital/dashboard/file/machine.json?refresh=1m&orgId=1&var-hostname=calculators_frontend-ip-10-13-4-152_eu-west-1_compute_internal&var-cpmetrics=All&var-filesystem=All&var-disk=All&var-tcpconnslocal=All&var-tcpconnsremote=All&from=now-2d&to=now) at present.

It's a bit of a faff recreating instances, so I'd prefer to destroy some first to make the remaining job smaller.

The other apps on this machine type are licence-finder and smart-answers which haven't had their unicorn workers changed since the days of 3 frontend machines so I'm leaving them alone.