### PR TITLE
Add govuk-python3 package to CI agents and CKAN servers

### DIFF
--- a/hieradata_aws/class/ckan.yaml
+++ b/hieradata_aws/class/ckan.yaml
@@ -8,4 +8,5 @@ govuk::apps::ckan::enable_harvester_gather: true
 
 govuk_solr6::present: false
 
-govuk_python::govuk_python_version: '3.6.12'
+govuk_python::govuk_python_version: '2.7.14'
+govuk_python3::govuk_python_version: '3.6.12'

--- a/hieradata_aws/class/integration/ci_agent.yaml
+++ b/hieradata_aws/class/integration/ci_agent.yaml
@@ -16,6 +16,7 @@ postgresql::globals::version: '9.6'
 postgresql::globals::postgis_version: '3.1.1'
 govuk_postgresql::server::enable_collectd: false
 govuk_python::govuk_python_version: '2.7.14'
+govuk_python3::govuk_python_version: '3.6.12'
 
 govuk_mysql::server::innodb_flush_log_at_trx_commit: 2
 govuk_mysql::server::innodb_buffer_pool_size_proportion: 0.05

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1098,6 +1098,9 @@ govuk_solr6::repo::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerpr
 govuk_python::apt_source::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk_python::apt_source::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
+govuk_python3::apt_source::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_python3::apt_source::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
+
 govuk_sudo::sudo_conf:
   deploy_docker_image:
     content: 'deploy ALL=NOPASSWD:/usr/bin/docker image *'

--- a/modules/govuk/manifests/node/s_ckan.pp
+++ b/modules/govuk/manifests/node/s_ckan.pp
@@ -19,6 +19,7 @@ class govuk::node::s_ckan inherits govuk::node::s_base {
   }
 
   include govuk_python
+  include govuk_python3
   include nginx
   include postgresql::lib::devel
   include govuk_java::openjdk8::jre

--- a/modules/govuk_ci/manifests/agent.pp
+++ b/modules/govuk_ci/manifests/agent.pp
@@ -50,6 +50,7 @@ class govuk_ci::agent(
   include ::govuk_jenkins::user
   include ::govuk_rbenv::all
   include ::govuk_python
+  include ::govuk_python3
   include ::govuk_sysdig
   include ::govuk_testing_tools
   include ::yarn

--- a/modules/govuk_python/manifests/init.pp
+++ b/modules/govuk_python/manifests/init.pp
@@ -4,12 +4,7 @@ class govuk_python (
 ) {
 
   include govuk_python::apt_source
-
-  class { '::python':
-    pip        => 'present',
-    dev        => 'present',
-    virtualenv => 'present',
-  }
+  include govuk_python::python
 
   Class['python::install'] -> Package <| provider == 'pip' and ensure != absent |>
 

--- a/modules/govuk_python/manifests/python.pp
+++ b/modules/govuk_python/manifests/python.pp
@@ -1,0 +1,13 @@
+# == Class: govuk_python::python
+#
+# govuk-python python
+#
+class govuk_python::python {
+
+  class { '::python':
+    pip        => 'present',
+    dev        => 'present',
+    virtualenv => 'present',
+  }
+
+}

--- a/modules/govuk_python3/manifests/apt_source.pp
+++ b/modules/govuk_python3/manifests/apt_source.pp
@@ -1,0 +1,17 @@
+# == Class: govuk_python::apt_source
+#
+# govuk-python apt source
+#
+class govuk_python3::apt_source (
+  $apt_mirror_hostname,
+  $apt_mirror_gpg_key_fingerprint,
+) {
+
+  apt::source { 'govuk-python3':
+    location     => "http://${apt_mirror_hostname}/govuk-python3",
+    release      => 'stable',
+    architecture => $::architecture,
+    repos        => 'main',
+    key          => $apt_mirror_gpg_key_fingerprint,
+  }
+}

--- a/modules/govuk_python3/manifests/init.pp
+++ b/modules/govuk_python3/manifests/init.pp
@@ -1,0 +1,25 @@
+# FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
+class govuk_python3 (
+  $govuk_python_version = '3.6.12',
+) {
+
+  include govuk_python3::apt_source
+
+  class { '::python':
+    pip        => 'present',
+    dev        => 'present',
+    virtualenv => 'present',
+  }
+
+  Class['python::install'] -> Package <| provider == 'pip' and ensure != absent |>
+
+  ensure_packages(['python3.5', 'python3.5-dev', 'python3-dev'])
+
+  ensure_packages(
+    ['govuk-python3'],
+    {
+      ensure  => $govuk_python_version,
+      require => Apt::Source['govuk-python3'],
+    }
+  )
+}

--- a/modules/govuk_python3/manifests/init.pp
+++ b/modules/govuk_python3/manifests/init.pp
@@ -4,12 +4,7 @@ class govuk_python3 (
 ) {
 
   include govuk_python3::apt_source
-
-  class { '::python':
-    pip        => 'present',
-    dev        => 'present',
-    virtualenv => 'present',
-  }
+  include govuk_python::python
 
   Class['python::install'] -> Package <| provider == 'pip' and ensure != absent |>
 


### PR DESCRIPTION
## What

As its not possible to deploy python 2.7.14 and python 3.6.12 using the same package name govuk-python, a new package was created govuk-python3 to allow both python packages to be deployed on a machine.