### PR TITLE
Remove space between task parameters

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/publish_special_routes.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/publish_special_routes.yaml.erb
@@ -87,7 +87,7 @@
             export GOVUK_APP_DOMAIN=<%= @app_domain %>
             export PUBLISHING_API_BEARER_TOKEN=<%= @publishing_api_bearer_token %>
             bundle install --path "${HOME}/bundles/${JOB_NAME}"
-            bundle exec rake unpublish_one_special_route["${BASE_PATH}", "${ALTERNATIVE_PATH}"]
+            bundle exec rake unpublish_one_special_route["${BASE_PATH}","${ALTERNATIVE_PATH}"]
     wrappers:
         - ansicolor:
             colormap: xterm


### PR DESCRIPTION
Trello: https://trello.com/c/XjIYqQ55

# What's changed?

Remove the space between task parameters in the "Unpublish single special route" job.

# Why?

The "Unpublish single special route" job fails in Jenkins with the
following error [1]:

```
+ bundle exec rake unpublish_one_special_route[/find-coronavirus-local-restrictions, /guidance/national-lockdown-stay-at-home]
rake aborted!
Don't know how to build task 'unpublish_one_special_route[/find-coronavirus-local-restrictions,' (See the list of available tasks with `rake --tasks`)
```

I think this might be related to the space between the parameters. The
only other task that multiple params, is the emergency
banner job, and that doesn't have any spaces [2].

Removing the space allow the job to pass in integration [3].

[1]: https://deploy.integration.publishing.service.gov.uk/job/Unpublish_Single_Special_Route/4/console
[2]: https://github.com/alphagov/govuk-puppet/blob/57cc29472ed5429bda246dcde0b4c830c9dbc10c/modules/govuk_jenkins/templates/jobs/deploy_emergency_banner.yaml.erb#L30
[3]: https://deploy.integration.publishing.service.gov.uk/job/Unpublish_Single_Special_Route/9/console