### PR TITLE
Add Terraform 0.11.15 to installed versions.

### DIFF
--- a/modules/govuk_jenkins/manifests/packages/tfenv.pp
+++ b/modules/govuk_jenkins/manifests/packages/tfenv.pp
@@ -10,7 +10,7 @@
 #
 #
 class govuk_jenkins::packages::tfenv (
-  $terraform_versions = ['0.11.14', '0.13.6'],
+  $terraform_versions = ['0.11.14', '0.11.15', '0.13.6'],
 ){
 
   include ::tfenv


### PR DESCRIPTION
For some reason we have preinstall specific Terraform versions via Puppet even though we're using tfenv to install them and we're specifying versions in .terraform-version files in the govuk-aws Terraform repo.

Just changing the version number in .terraform-version causes tfenv to fail with a permissions error, so this change is definitely necessary with the current setup.

We need to upgrade to the latest patch release of TF 0.11 in order to be able to use recent versions of Terraform providers, because Hashicorp has a new signing certificate which older versions of Terraform don't recognise.