### PR TITLE
Enable CD for cache clearing service

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1052,6 +1052,7 @@ govuk_jenkins::jobs::deploy_app_downstream::applications:
   account-api: {}
   authenticating-proxy: {}
   bouncer: {}
+  cache-clearing-service: {}
   collections: {}
   collections-publisher: {}
   content-data-admin: {}


### PR DESCRIPTION
Trello: https://trello.com/c/29b0FSiU/2496-3-enable-continuous-deployment-for-cache-clearing-service

Dependant on:

- https://github.com/alphagov/govuk-developer-docs/pull/3096
- https://github.com/alphagov/govuk-saas-config/pull/93
- https://github.com/alphagov/cache-clearing-service/pull/357