### PR TITLE
Remove Mahmud Hussain access

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -514,7 +514,6 @@ users::usernames:
   - kentsang
   - kevindew
   - leenagupte
-  - mahmudhussain
   - matthewgregory
   - maxfroumentin
   - maxharden

--- a/modules/users/manifests/mahmudhussain.pp
+++ b/modules/users/manifests/mahmudhussain.pp
@@ -1,8 +1,0 @@
-# Creates mahmudhussain user
-class users::mahmudhussain {
-  govuk_user { 'mahmudhussain':
-    fullname => 'Mahmud Hussain',
-    email    => 'mahmud.hussain@digital.cabinet-office.gov.uk',
-    ssh_key  => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCx9sd0QWv6mbNVp6EYcZ0RWS3VBu3gRqt5EvJBscWnPrxcK265df0NXFFQ0HdNFVYybcfNw7wjBuz7WLUd8M3p3uWoZtoaQNq8fH5AxUC1yvQbOaFLFcFuOGOLvS+ej3CBns3OQ+r02kuZijYHVPbGFwjKJps2621gP6E3LWGuJMnf58GUu5TEte6jKDGhiIe/3/0dAhlv+epKa9kCmi+uRgKZoxZyucjsQ8LrdLuw1kIghJ04qkDiMqyCasG9omwsAdMbEDA6kj8IJpbJV7wX1e8KSCQZFy8d+OxwN+9FMkvly7ZpET2ABbw69Wj0kTs4g4gXX5wW6w35Zd6OX+asnQztL4sRaTkhtNCpSjuiIpIO09Rq7+V7shy16P5OAZS/EDA7XTtV/CGDE6Id2hccFzwqJBkPqaWwTHfWRbmXSJuqfiHDF+5nViOgkQGd0J2OLwxN/cKFPW5zo5Wj7RCbkowM2UVO19QsU7EXVrPWc/t+CfDSRgu+uAEJZbH6kmOsrhBXtdU35J46MY8nPQjHc0FHaiXA8mdrK4EDZ/y5dAGW2fyAlgf5lPk/kxeWAv8+c9yX3u3uIzsO//iQTpC3y0jZgpZYLN21ehoLtiZS/c1H/OR8CwhH2eW973C7RUO3UXPlLiAbtpvjJ6PUCQQbrIe9/nwlZvX5l8S3JGnqRQ== mahmud.hussain@digital.cabinet-office.gov.uk',
-  }
-}


### PR DESCRIPTION
He is temporarily moving to Cyber Security, so we're going to remove his access while he's not working on GOV.UK.

Depends on https://github.com/alphagov/govuk-secrets/pull/1156.