### PR TITLE
Properly remove Erin's access

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -501,6 +501,7 @@ users::usernames:
   - duncangarmonsway
   - edwardkerry
   - ericyoung
+  - erinrajstaniland
   - fredericfrancois
   - grahamlewis
   - huwdiprose

--- a/modules/users/manifests/erinrajstaniland.pp
+++ b/modules/users/manifests/erinrajstaniland.pp
@@ -1,6 +1,7 @@
 # Creates erinrajstaniland user
 class users::erinrajstaniland {
   govuk_user { 'erinrajstaniland':
+    ensure   => absent,
     fullname => 'Erin Raj-Staniland',
     email    => 'erin.raj-staniland@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMcNbnQbVVQAse1UUD8OD/HuKQJ2Divi6scGvNKfL4ai erin.raj-staniland@digital.cabinet-office.gov.uk',


### PR DESCRIPTION
Just deleting the user from the list isn't enough, we need to `ensure => absent` the user manifest for Puppet to actually delete the user.