### PR TITLE
Rename references to govuk-secrets master branch

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_puppet.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_puppet.yaml.erb
@@ -5,13 +5,13 @@
         - git:
             url: git@github.com:alphagov/govuk-secrets.git
             per-build-tag: false
-            refspec: +refs/heads/master:refs/remotes/origin/master
+            refspec: +refs/heads/main:refs/remotes/origin/main
             shallow-clone: true
             wipe-workspace: false
             clean:
               before: true
             branches:
-              - master
+              - main
 
 - job:
     name: Deploy_Puppet


### PR DESCRIPTION
This branch has been renamed to `main` so we need to change this reference to continue Puppet deploys.