### PR TITLE
Limit range of keepLastValue in Sidekiq latency alerts

### DIFF
--- a/modules/monitoring/manifests/checks/sidekiq.pp
+++ b/modules/monitoring/manifests/checks/sidekiq.pp
@@ -58,7 +58,7 @@ class monitoring::checks::sidekiq (
 
   if $enable_publishing_api_check {
     icinga::check::graphite { 'check_publishing_api_downstream_high_queue_latency':
-      target    => 'transformNull(averageSeries(keepLastValue(stats.gauges.govuk.app.publishing-api.*.workers.queues.downstream_high.latency)), 0)',
+      target    => 'transformNull(averageSeries(keepLastValue(stats.gauges.govuk.app.publishing-api.*.workers.queues.downstream_high.latency, 36)), 0)',
       from      => '24hours',
       args      => '--dropfirst -36',
       warning   => 45,
@@ -70,7 +70,7 @@ class monitoring::checks::sidekiq (
 
   if $enable_search_api_check {
     icinga::check::graphite { 'check_search_api_default_queue_latency':
-      target    => 'transformNull(averageSeries(keepLastValue(stats.gauges.govuk.app.search-api.*.workers.queues.default.latency)), 0)',
+      target    => 'transformNull(averageSeries(keepLastValue(stats.gauges.govuk.app.search-api.*.workers.queues.default.latency, 36)), 0)',
       from      => '24hours',
       args      => '--dropfirst -36',
       warning   => 30,
@@ -81,7 +81,7 @@ class monitoring::checks::sidekiq (
     }
 
     icinga::check::graphite { 'check_search_api_bulk_queue_latency':
-      target    => 'transformNull(averageSeries(keepLastValue(stats.gauges.govuk.app.search-api.*.workers.queues.bulk.latency)), 0)',
+      target    => 'transformNull(averageSeries(keepLastValue(stats.gauges.govuk.app.search-api.*.workers.queues.bulk.latency, 36)), 0)',
       from      => '24hours',
       args      => '--dropfirst -36',
       warning   => 300,


### PR DESCRIPTION
This was introduced in b0b17be:

> Now that statsd isn't repeating the last know values, use the
> keepLastValue function in graphite to smooth out the series for the
> monitoring targets.

However, since Sidekiq stops reporting latency when the queue empties,
I don't think this is quite right.  We should only keep the last value
a few minutes (I've gone for 36 datapoints, or 3 minutes here) to
smooth out the graph, but we don't want to keep it for the full 24
hours.

Currently, we have an issue where the search-api bulk latency alert is
triggered every morning and then never goes away.  Why?  Because once
a day we trigger a large batch of bulk jobs, which then run to
completion.  Since there are no more bulk jobs running, Sidekiq stops
reporting the latency, and so the `keepLastValue` makes it look like
we're constantly running at the latency of the last-to-complete job -
even though that job may have completed hours ago and the queue has
been empty since!

We don't see this problem with the other latency alerts, because those
queues don't have the same usage pattern of hitting the alert
threshold and then not running any more jobs.

---

The new metric (blue line) compared to the old (green line):

<img width="1747" alt="Screenshot 2021-05-18 at 13 56 58" src="https://user-images.githubusercontent.com/75235/118654964-01c2cb80-b7e1-11eb-9a9d-eaddca07c348.png">

---

[Trello card](https://trello.com/c/q7UtaRb4/1145-search-api-bulk-queue-latency-unexpectedly-large)