### PR TITLE
Clear CDN cache in all environments for emergency banner

### DIFF
--- a/hieradata_aws/class/integration/jenkins.yaml
+++ b/hieradata_aws/class/integration/jenkins.yaml
@@ -7,6 +7,7 @@ govuk_jenkins::config::theme_environment_name: 'AWS Integration'
 
 govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::athena_fastly_logs_check
+  - govuk_jenkins::jobs::clear_cdn_cache
   - govuk_jenkins::jobs::clear_frontend_memcache
   - govuk_jenkins::jobs::clear_template_cache
   - govuk_jenkins::jobs::clear_varnish_cache

--- a/hieradata_aws/class/staging/jenkins.yaml
+++ b/hieradata_aws/class/staging/jenkins.yaml
@@ -47,6 +47,7 @@ govuk_jenkins::config::user_permissions:
 
 govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::athena_fastly_logs_check
+  - govuk_jenkins::jobs::clear_cdn_cache
   - govuk_jenkins::jobs::clear_frontend_memcache
   - govuk_jenkins::jobs::clear_template_cache
   - govuk_jenkins::jobs::clear_varnish_cache

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -137,6 +137,9 @@ govuk_jenkins::job_builder::environment: 'integration'
 govuk_jenkins::jobs::athena_fastly_logs_check::s3_results_bucket: 'govuk-integration-fastly-logs-monitoring'
 govuk_jenkins::jobs::content_data_api::rake_etl_main_process_cron_schedule: '0 13 * * *'
 
+govuk_jenkins::jobs::clear_cdn_cache::website_root_url: 'www.integration.publishing.service.gov.uk'
+govuk_jenkins::jobs::clear_cdn_cache::assets_root_url: 'assets.integration.publishing.service.gov.uk'
+
 govuk_jenkins::jobs::content_publisher_whitehall_import::enable_slack_notifications: true
 
 govuk_jenkins::jobs::deploy_app_downstream::deploy_url: 'deploy.blue.staging.govuk.digital'

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -295,7 +295,8 @@ govuk_jenkins::jobs::athena_fastly_logs_check::s3_results_bucket: 'govuk-product
 govuk_jenkins::jobs::athena_fastly_logs_check::databases: ['govuk_www', 'govuk_assets', 'bouncer']
 govuk_jenkins::jobs::content_data_api::rake_etl_main_process_cron_schedule: '0 7 * * *'
 
-govuk_jenkins::jobs::deploy_emergency_banner::clear_cdn_cache: true
+govuk_jenkins::jobs::clear_cdn_cache::website_root_url: 'www.gov.uk'
+govuk_jenkins::jobs::clear_cdn_cache::assets_root_url: 'assets.publishing.service.gov.uk'
 
 govuk_jenkins::jobs::search_fetch_analytics_data::skip_page_traffic_load: true
 govuk_jenkins::jobs::search_fetch_analytics_data::cron_schedule: '30 8 * * 1-5'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -272,6 +272,9 @@ govuk_jenkins::job_builder::environment: 'staging'
 govuk_jenkins::jobs::athena_fastly_logs_check::s3_results_bucket: 'govuk-staging-fastly-logs-monitoring'
 govuk_jenkins::jobs::content_data_api::rake_etl_main_process_cron_schedule: '0 11 * * *'
 
+govuk_jenkins::jobs::clear_cdn_cache::website_root_url: 'www.staging.publishing.service.gov.uk'
+govuk_jenkins::jobs::clear_cdn_cache::assets_root_url: 'assets.staging.publishing.service.gov.uk'
+
 govuk_jenkins::jobs::network_config_deploy::environments:
   - 'carrenza-staging'
   - 'carrenza-staging-dr'

--- a/modules/govuk_jenkins/manifests/jobs/clear_cdn_cache.pp
+++ b/modules/govuk_jenkins/manifests/jobs/clear_cdn_cache.pp
@@ -2,7 +2,10 @@
 #
 # Create a file on disk that can be parsed by jenkins-job-builder
 #
-class govuk_jenkins::jobs::clear_cdn_cache {
+class govuk_jenkins::jobs::clear_cdn_cache(
+  $website_root_url = nil,
+  $assets_root_url = nil,
+) {
   file { '/etc/jenkins_jobs/jobs/clear_cdn_cache.yaml':
     ensure  => present,
     content => template('govuk_jenkins/jobs/clear_cdn_cache.yaml.erb'),

--- a/modules/govuk_jenkins/manifests/jobs/deploy_emergency_banner.pp
+++ b/modules/govuk_jenkins/manifests/jobs/deploy_emergency_banner.pp
@@ -2,9 +2,7 @@
 #
 # Create a file on disk that can be parsed by jenkins-job-builder
 #
-class govuk_jenkins::jobs::deploy_emergency_banner(
-  $clear_cdn_cache = false,
-) {
+class govuk_jenkins::jobs::deploy_emergency_banner {
   file { '/etc/jenkins_jobs/jobs/deploy_emergency_banner.yaml':
     ensure  => present,
     content => template('govuk_jenkins/jobs/deploy_emergency_banner.yaml.erb'),

--- a/modules/govuk_jenkins/templates/jobs/clear_cdn_cache.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/clear_cdn_cache.yaml.erb
@@ -1,10 +1,10 @@
 ---
 - job:
     name: clear-cdn-cache
-    display-name: Clear production CDN cache
+    display-name: Clear CDN cache
     project-type: freestyle
     description: >
-      Clears the production CDN cache for the 10 most popular pages on GOV.UK.
+      Clears the CDN cache for the 10 most popular pages on GOV.UK.
     properties:
       - build-discarder:
           num-to-keep: 30
@@ -15,8 +15,8 @@
           set -ex
 
           declare -a hostnames=(
-            "www.gov.uk"
-            "assets.publishing.service.gov.uk"
+            "<%= @website_root_url -%>"
+            "<%= @assets_root_url -%>"
           )
 
           # 10 most popular pages based on GA 1-year stats

--- a/modules/govuk_jenkins/templates/jobs/deploy_emergency_banner.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_emergency_banner.yaml.erb
@@ -35,10 +35,8 @@
             block: true
           - project: clear-varnish-cache
             block: true
-      <%- if @clear_cdn_cache -%>
           - project: clear-cdn-cache
             block: true
-      <%- end -%>
     wrappers:
       - ansicolor:
           colormap: xterm

--- a/modules/govuk_jenkins/templates/jobs/remove_emergency_banner.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/remove_emergency_banner.yaml.erb
@@ -22,10 +22,8 @@
             block: true
           - project: clear-varnish-cache
             block: true
-      <%- if @clear_cdn_cache -%>
           - project: clear-cdn-cache
             block: true
-      <%- end -%>
     wrappers:
       - ansicolor:
           colormap: xterm


### PR DESCRIPTION
When the emergency banner is added or removed, we currently only clear the CDN cache in production. This is because the CDN was previously only used for production.

When the emergency banner was deployed for the first time on 9 April 2021, the cache clearing failed due to an error in the script. This was not picked up during the emergency banner drills on staging as the script had never run.

Now all environments are behind a CDN, we can safely clear the cache in all environments when deploying or removing the banner.

[Trello card](https://trello.com/c/RnVDIouI)