### PR TITLE
Improve Whitehall Icinga checks

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -349,8 +349,7 @@ monitoring::checks::rds::region: 'eu-west-1'
 monitoring::checks::aws_iam_key::enabled: true
 monitoring::checks::aws_iam_key::region: 'eu-west-1'
 monitoring::checks::aws_iam_key::max_aws_iam_key_age: 320
-monitoring::checks::whitehall::overdue_check_period: "never"
-monitoring::checks::whitehall::scheduled_check_period: "never"
+monitoring::checks::whitehall::check_period: "never"
 
 monitoring::checks::lb::region: 'eu-west-1'
 monitoring::checks::lb::loadbalancers: # prefer "internal"

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -344,13 +344,13 @@ grafana::dashboards::application_dashboards:
 mongodb::backup::mongo_backup_node: 'localhost'
 
 monitoring::checks::aws_origin_domain: "integration.govuk.digital"
-monitoring::checks::whitehall_overdue_check_period: 'never'
-monitoring::checks::whitehall_scheduled_check_period: 'never'
 monitoring::checks::sidekiq::enable_support_check: false
 monitoring::checks::rds::region: 'eu-west-1'
 monitoring::checks::aws_iam_key::enabled: true
 monitoring::checks::aws_iam_key::region: 'eu-west-1'
 monitoring::checks::aws_iam_key::max_aws_iam_key_age: 320
+monitoring::checks::whitehall::overdue_check_period: "never"
+monitoring::checks::whitehall::scheduled_check_period: "never"
 
 monitoring::checks::lb::region: 'eu-west-1'
 monitoring::checks::lb::loadbalancers: # prefer "internal"

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -370,8 +370,7 @@ monitoring::checks::rds::region: 'eu-west-1'
 monitoring::checks::aws_iam_key::enabled: true
 monitoring::checks::aws_iam_key::region: 'eu-west-1'
 monitoring::checks::aws_iam_key::max_aws_iam_key_age: 320
-monitoring::checks::whitehall::overdue_check_period: "never"
-monitoring::checks::whitehall::scheduled_check_period: "never"
+monitoring::checks::whitehall::check_period: "never"
 
 monitoring::checks::lb::region: 'eu-west-1'
 monitoring::checks::lb::loadbalancers: # prefer "internal"

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -364,14 +364,14 @@ licensify::apps::licensify::alert_5xx_critical_rate: 0.15
 
 monitoring::checks::aws_origin_domain: "staging.govuk.digital"
 monitoring::checks::signon_api_tokens_check_period: 'never'
-monitoring::checks::whitehall_overdue_check_period: 'never'
-monitoring::checks::whitehall_scheduled_check_period: 'never'
 monitoring::checks::sidekiq::enable_signon_check: false
 monitoring::checks::sidekiq::enable_support_check: false
 monitoring::checks::rds::region: 'eu-west-1'
 monitoring::checks::aws_iam_key::enabled: true
 monitoring::checks::aws_iam_key::region: 'eu-west-1'
 monitoring::checks::aws_iam_key::max_aws_iam_key_age: 320
+monitoring::checks::whitehall::overdue_check_period: "never"
+monitoring::checks::whitehall::scheduled_check_period: "never"
 
 monitoring::checks::lb::region: 'eu-west-1'
 monitoring::checks::lb::loadbalancers: # prefer "internal"

--- a/modules/monitoring/manifests/checks.pp
+++ b/modules/monitoring/manifests/checks.pp
@@ -17,8 +17,6 @@ class monitoring::checks (
   $aws_origin_domain              = undef,
   $http_username                  = 'UNSET',
   $http_password                  = 'UNSET',
-  $whitehall_overdue_check_period = undef,
-  $whitehall_scheduled_check_period = undef,
   $content_data_api_check_period  = undef,
   $publisher_scheduled_publishing_check_period = undef,
   $signon_api_tokens_check_period = undef,
@@ -50,6 +48,7 @@ class monitoring::checks (
   include monitoring::checks::cloudwatch
   include monitoring::checks::grafana_dashboards
   include monitoring::checks::cdn_logs
+  include monitoring::checks::whitehall
 
   include govuk::apps::email_alert_api::checks
   include govuk::apps::publisher::unprocessed_emails_count_check
@@ -128,46 +127,6 @@ class monitoring::checks (
     host_name           => $::fqdn,
     check_period        => $content_publisher_government_data_check_period,
     notes_url           => monitoring_docs_url(content-publisher-government-data-check-not-ok),
-  }
-
-  # Used in template and icinga::check.
-  $whitehall_hostname    = "whitehall-admin.${app_domain}"
-  $whitehall_overdue_url = '/healthcheck/overdue'
-  $whitehall_scheduled_url = '/healthcheck/unenqueued_scheduled_editions'
-
-  icinga::check_config { 'whitehall_overdue':
-    content => template('monitoring/check_whitehall_overdue.cfg.erb'),
-    require => Icinga::Plugin['check_http_timeout_noncrit'],
-  }
-
-  icinga::check { "check_whitehall_overdue_from_${::hostname}":
-    check_command              => 'check_whitehall_overdue',
-    service_description        => 'overdue publications in Whitehall',
-    use                        => 'govuk_urgent_priority',
-    host_name                  => $::fqdn,
-    notes_url                  => monitoring_docs_url(whitehall-scheduled-publishing),
-    action_url                 => "https://${whitehall_hostname}${whitehall_overdue_url}",
-    event_handler              => 'publish_overdue_whitehall',
-    check_period               => $whitehall_overdue_check_period,
-    attempts_before_hard_state => 10,
-    retry_interval             => 1,
-  }
-
-  icinga::check_config { 'whitehall_scheduled':
-    content => template('monitoring/check_whitehall_scheduled.cfg.erb'),
-    require => Icinga::Plugin['check_http_timeout_noncrit'],
-  }
-
-  icinga::check { "check_whitehall_scheduled_from_${::hostname}":
-    check_command              => 'check_whitehall_scheduled',
-    service_description        => 'scheduled publications in Whitehall not queued',
-    use                        => 'govuk_urgent_priority',
-    host_name                  => $::fqdn,
-    notes_url                  => monitoring_docs_url(whitehall-scheduled-publishing),
-    action_url                 => "https://${whitehall_hostname}${whitehall_scheduled_url}",
-    check_period               => $whitehall_scheduled_check_period,
-    attempts_before_hard_state => 10,
-    retry_interval             => 1,
   }
 
   icinga::check {'check_mapit_responding':

--- a/modules/monitoring/manifests/checks.pp
+++ b/modules/monitoring/manifests/checks.pp
@@ -158,20 +158,17 @@ class monitoring::checks (
     require => Icinga::Plugin['check_http_timeout_noncrit'],
   }
 
-  if $::aws_environment == 'production' {
-    icinga::check { "check_whitehall_scheduled_from_${::hostname}":
-      check_command              => 'check_whitehall_scheduled',
-      service_description        => 'scheduled publications in Whitehall not queued',
-      use                        => 'govuk_urgent_priority',
-      host_name                  => $::fqdn,
-      notes_url                  => monitoring_docs_url(whitehall-scheduled-publishing),
-      action_url                 => "https://${whitehall_hostname}${whitehall_scheduled_url}",
-      check_period               => $whitehall_scheduled_check_period,
-      attempts_before_hard_state => 10,
-      retry_interval             => 1,
-    }
+  icinga::check { "check_whitehall_scheduled_from_${::hostname}":
+    check_command              => 'check_whitehall_scheduled',
+    service_description        => 'scheduled publications in Whitehall not queued',
+    use                        => 'govuk_urgent_priority',
+    host_name                  => $::fqdn,
+    notes_url                  => monitoring_docs_url(whitehall-scheduled-publishing),
+    action_url                 => "https://${whitehall_hostname}${whitehall_scheduled_url}",
+    check_period               => $whitehall_scheduled_check_period,
+    attempts_before_hard_state => 10,
+    retry_interval             => 1,
   }
-
 
   icinga::check {'check_mapit_responding':
     check_command       => 'check_mapit',

--- a/modules/monitoring/manifests/checks/whitehall.pp
+++ b/modules/monitoring/manifests/checks/whitehall.pp
@@ -4,16 +4,10 @@
 #
 # === Parameters
 #
-# [*overdue_check_period*]
-#   Icinga time period for the overdue documents check.
+# [*check_period*]
+#   Icinga time period for the checks.
 #
-# [*scheduled_check_period*]
-#   Icinga time period for the scheduled documents check.
-#
-class monitoring::checks::whitehall (
-  $overdue_check_period = undef,
-  $scheduled_check_period = undef,
-) {
+class monitoring::checks::whitehall ($check_period = undef) {
   $app_domain = hiera('app_domain')
 
   $whitehall_hostname = "whitehall-admin.${app_domain}"
@@ -33,7 +27,7 @@ class monitoring::checks::whitehall (
     notes_url                  => monitoring_docs_url(whitehall-scheduled-publishing),
     action_url                 => "https://${whitehall_hostname}${whitehall_overdue_url}",
     event_handler              => 'publish_overdue_whitehall',
-    check_period               => $overdue_check_period,
+    check_period               => $check_period,
     attempts_before_hard_state => 10,
     retry_interval             => 1,
   }
@@ -50,7 +44,7 @@ class monitoring::checks::whitehall (
     host_name                  => $::fqdn,
     notes_url                  => monitoring_docs_url(whitehall-scheduled-publishing),
     action_url                 => "https://${whitehall_hostname}${whitehall_scheduled_url}",
-    check_period               => $scheduled_check_period,
+    check_period               => $check_period,
     attempts_before_hard_state => 10,
     retry_interval             => 1,
   }

--- a/modules/monitoring/manifests/checks/whitehall.pp
+++ b/modules/monitoring/manifests/checks/whitehall.pp
@@ -1,0 +1,57 @@
+# == Class: monitoring::checks::whitehall
+#
+# Icinga checks for Whitehall.
+#
+# === Parameters
+#
+# [*overdue_check_period*]
+#   Icinga time period for the overdue documents check.
+#
+# [*scheduled_check_period*]
+#   Icinga time period for the scheduled documents check.
+#
+class monitoring::checks::whitehall (
+  $overdue_check_period = undef,
+  $scheduled_check_period = undef,
+) {
+  $app_domain = hiera('app_domain')
+
+  $whitehall_hostname = "whitehall-admin.${app_domain}"
+  $whitehall_overdue_url = '/healthcheck/overdue'
+  $whitehall_scheduled_url = '/healthcheck/unenqueued_scheduled_editions'
+
+  icinga::check_config { 'whitehall_overdue':
+    content => template('monitoring/check_whitehall_overdue.cfg.erb'),
+    require => Icinga::Plugin['check_http_timeout_noncrit'],
+  }
+
+  icinga::check { "check_whitehall_overdue_from_${::hostname}":
+    check_command              => 'check_whitehall_overdue',
+    service_description        => 'overdue publications in Whitehall',
+    use                        => 'govuk_urgent_priority',
+    host_name                  => $::fqdn,
+    notes_url                  => monitoring_docs_url(whitehall-scheduled-publishing),
+    action_url                 => "https://${whitehall_hostname}${whitehall_overdue_url}",
+    event_handler              => 'publish_overdue_whitehall',
+    check_period               => $overdue_check_period,
+    attempts_before_hard_state => 10,
+    retry_interval             => 1,
+  }
+
+  icinga::check_config { 'whitehall_scheduled':
+    content => template('monitoring/check_whitehall_scheduled.cfg.erb'),
+    require => Icinga::Plugin['check_http_timeout_noncrit'],
+  }
+
+  icinga::check { "check_whitehall_scheduled_from_${::hostname}":
+    check_command              => 'check_whitehall_scheduled',
+    service_description        => 'scheduled publications in Whitehall not queued',
+    use                        => 'govuk_urgent_priority',
+    host_name                  => $::fqdn,
+    notes_url                  => monitoring_docs_url(whitehall-scheduled-publishing),
+    action_url                 => "https://${whitehall_hostname}${whitehall_scheduled_url}",
+    check_period               => $scheduled_check_period,
+    attempts_before_hard_state => 10,
+    retry_interval             => 1,
+  }
+}


### PR DESCRIPTION
This improves how we configure the Whitehall Icinga checks, see individual commits for more details.

Originally, this PR came about from an investigation into why the `never` Icinga time period didn't seem to be working. I'm unable to reproduce the problem, and as far as I can tell the check period is working. See [this screenshot from Integration](https://alert.integration.publishing.service.gov.uk/cgi-bin/icinga/extinfo.cgi?type=2&host=ip-10-1-4-181.eu-west-1.compute.internal&service=overdue+publications+in+Whitehall) showing that the check hasn't occurred recently:

<img width="242" alt="Screenshot 2021-05-19 at 09 30 23" src="https://user-images.githubusercontent.com/510498/118781336-dc879900-b884-11eb-8f0d-a9b9359383b1.png">
<img width="275" alt="Screenshot 2021-05-19 at 09 30 19" src="https://user-images.githubusercontent.com/510498/118781332-dbef0280-b884-11eb-87ca-69ea7caa866a.png">

If the problem does re-occur we can continue to investigate, my suggestion would be to have an `$enabled` parameter, and in Integration/Staging it's set to `false` and the checks aren't created in the first place.

[Trello Card](https://trello.com/c/Tu6CDw6t/2491-investigate-fix-or-remove-puppet-scheduled-check-never-option-15-days)
