### PR TITLE
Set up RabbitMQ for account-api

### DIFF
--- a/hieradata_aws/class/integration/rabbitmq.yaml
+++ b/hieradata_aws/class/integration/rabbitmq.yaml
@@ -1,6 +1,7 @@
 ---
 
 govuk::node::s_rabbitmq::apps_using_rabbitmq:
+  - account_api
   - backdrop_write
   - email_alert_service
   - publishing_api

--- a/hieradata_aws/class/rabbitmq.yaml
+++ b/hieradata_aws/class/rabbitmq.yaml
@@ -1,6 +1,7 @@
 ---
 
 govuk::node::s_rabbitmq::apps_using_rabbitmq:
+  - account_api
   - content_data_api
   - cache_clearing_service
   - publishing_api

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -777,6 +777,8 @@ govuk::apps::account_api::db_hostname: "postgresql-primary"
 govuk::apps::account_api::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 govuk::apps::account_api::db::allow_auth_from_lb: true
 govuk::apps::account_api::db::lb_ip_range: "%{hiera('environment_ip_prefix')}.0.0/16"
+govuk::apps::account_api::rabbitmq::enabled: true
+govuk::apps::account_api::rabbitmq_hosts: [rabbitmq]
 
 govuk_awscli::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk_awscli::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"

--- a/modules/govuk/manifests/apps/account_api/rabbitmq.pp
+++ b/modules/govuk/manifests/apps/account_api/rabbitmq.pp
@@ -1,0 +1,97 @@
+# == Class: govuk::apps::account_api::rabbitmq
+#
+# Permissions for account-api to read messages from
+# the publishing API's AMQP exchange.
+#
+# This sets up the user, and permits read/write/configure
+# to the queue, and read-only to the exchange.
+#
+# === Parameters
+#
+# [*amqp_user*]
+#   The RabbitMQ username (default: 'account_api')
+#
+# [*amqp_pass*]
+#   The RabbitMQ password.
+#
+# [*amqp_exchange*]
+#   The RabbitMQ exchange to read from (default: 'published_documents')
+#
+# [*amqp_queue*]
+#   The RabbitMQ queue to set up for workers of this type to read from
+#   (default: 'account_api')
+#
+class govuk::apps::account_api::rabbitmq (
+  $enabled = false,
+  $amqp_user  = 'account_api',
+  $amqp_pass = 'account_api',
+  $amqp_exchange = 'published_documents',
+  $amqp_queue = 'account_api',
+) {
+  $ensure = $enabled ? {
+    true  => 'present',
+    false => 'absent',
+  }
+
+  govuk_rabbitmq::queue_with_binding { $amqp_queue:
+    ensure        => $ensure,
+    amqp_exchange => $amqp_exchange,
+    amqp_queue    => $amqp_queue,
+    routing_key   => '*.major',
+    durable       => true,
+  }
+
+  rabbitmq_binding { "binding_minor_${amqp_exchange}@${amqp_queue}@/":
+    ensure           => $ensure,
+    name             => "${amqp_exchange}@${amqp_queue}@minor@/",
+    user             => 'root',
+    password         => $::govuk_rabbitmq::root_password,
+    destination_type => 'queue',
+    routing_key      => '*.minor',
+    arguments        => {},
+    require          => Govuk_rabbitmq::Queue_with_binding[$amqp_queue],
+  }
+
+  rabbitmq_binding { "binding_republish_${amqp_exchange}@${amqp_queue}@/":
+    ensure           => $ensure,
+    name             => "${amqp_exchange}@${amqp_queue}@republish@/",
+    user             => 'root',
+    password         => $::govuk_rabbitmq::root_password,
+    destination_type => 'queue',
+    routing_key      => '*.republish',
+    arguments        => {},
+    require          => Govuk_rabbitmq::Queue_with_binding[$amqp_queue],
+  }
+
+  rabbitmq_binding { "binding_unpublish_${amqp_exchange}@${amqp_queue}@/":
+    ensure           => $ensure,
+    name             => "${amqp_exchange}@${amqp_queue}@unpublish@/",
+    user             => 'root',
+    password         => $::govuk_rabbitmq::root_password,
+    destination_type => 'queue',
+    routing_key      => '*.unpublish',
+    arguments        => {},
+    require          => Govuk_rabbitmq::Queue_with_binding[$amqp_queue],
+  }
+
+  govuk_rabbitmq::consumer { $amqp_user:
+    ensure               => $ensure,
+    amqp_pass            => $amqp_pass,
+    read_permission      => "^${amqp_queue}\$",
+    write_permission     => "^\$",
+    configure_permission => "^\$",
+  }
+
+  # todo: remove these expiration times when we have account-api set up
+  # and processing the queues properly.
+  rabbitmq_policy { "${amqp_queue}-ttl@/":
+    pattern    => $amqp_queue,
+    priority   => 0,
+    applyto    => 'queues',
+    definition => {
+      'ha-mode'      => 'all',
+      'ha-sync-mode' => 'automatic',
+      'message-ttl'  => 300000, # 5 minutes
+    },
+  }
+}


### PR DESCRIPTION
We want account-api to listen to publishing updates from RabbitMQ so
that we can update a user's saved pages when content gets updated.

For example, if we want to show the titles of the pages a user has
saved, we could do that by:

1. Querying content-store every time the user requests the list
2. Doing (1), but caching the results for a while
3. Querying content-store when the page is first saved, and updating
   local state when updates occur.

We're going for (3).  (1) introduces O(n) extra network requests; (2)
does the same, unless we have a long cache time, in which case we risk
showing stale data.  (3) introduces one extra network request when we
save a page, but no additional requests when the list is retrieved
and, while at risk of stale state, we can bound that risk by adopting
an SLO if we observe problems.

This commit is based on the cache-clearing-service RabbitMQ config.

---

[Trello card](https://trello.com/c/8EadgviV/772-get-account-api-consuming-publishing-messages-from-rabbitmq)