### PR TITLE
`ensure => absent` search-api queue expiration policy

### DIFF
--- a/modules/govuk/manifests/apps/search_api/rabbitmq.pp
+++ b/modules/govuk/manifests/apps/search_api/rabbitmq.pp
@@ -75,6 +75,7 @@ class govuk::apps::search_api::rabbitmq (
   # todo: remove these expiration times when we have search-api set up
   # and processing the queues properly.
   rabbitmq_policy { 'search_api-ttl@/':
+    ensure     => absent,
     pattern    => 'search_api*',
     priority   => 0,
     applyto    => 'queues',


### PR DESCRIPTION
This has a "todo: remove" from when the search-api migration was
underway: fdb796e79af2dea12940636d5ada4c770e20d3d2.