### PR TITLE
Add govuk_personalisation to pipeline jobs

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -940,6 +940,7 @@ govuk_ci::master::pipeline_jobs:
   govuk-guix: {}
   govuk-jenkinslib: {}
   govuk_message_queue_consumer: {}
+  govuk_personalisation: {}
   govuk-provisioning: {}
   govuk_publishing_components: {}
   govuk_seed_crawler: {}


### PR DESCRIPTION
This adds the new [`govuk_personalisation` gem][0] to the list of
automatically deployed apps in `govuk_ci::master::pipeline_jobs`.
This is so that Jenkins will pick it up and push to RubyGems.

Trello card: https://trello.com/c/9jEm7dwr/775-make-a-gem-for-shared-personalisation-code

[0]: https://github.com/alphagov/govuk_personalisation/