### PR TITLE
Add Ruby 2.7.3 and alias it for Ruby 2.7

### DIFF
--- a/modules/govuk_rbenv/manifests/all.pp
+++ b/modules/govuk_rbenv/manifests/all.pp
@@ -32,6 +32,7 @@ class govuk_rbenv::all (
     '2.7.0',
     '2.7.1',
     '2.7.2',
+    '2.7.3',
   ]
 
   govuk_rbenv::install_ruby_version { $ruby_versions:
@@ -44,6 +45,6 @@ class govuk_rbenv::all (
   }
 
   rbenv::alias { '2.7':
-    to_version => '2.7.2',
+    to_version => '2.7.3',
   }
 }


### PR DESCRIPTION
Ruby 2.7.3 is now [present in our aptly server][0] and available install
via rbenv.

Trello card: https://trello.com/c/9jEm7dwr/775-make-a-gem-for-shared-personalisation-code

[0]: https://apt.publishing.service.gov.uk/rbenv-ruby/pool/main/r/rbenv-ruby-2.7.3/