### PR TITLE
`ensure => absent` account-api rabbitmq expiration policy

### DIFF
--- a/modules/govuk/manifests/apps/account_api/rabbitmq.pp
+++ b/modules/govuk/manifests/apps/account_api/rabbitmq.pp
@@ -85,6 +85,7 @@ class govuk::apps::account_api::rabbitmq (
   # todo: remove these expiration times when we have account-api set up
   # and processing the queues properly.
   rabbitmq_policy { "${amqp_queue}-ttl@/":
+    ensure     => absent,
     pattern    => $amqp_queue,
     priority   => 0,
     applyto    => 'queues',

--- a/modules/govuk/manifests/apps/search_api/rabbitmq.pp
+++ b/modules/govuk/manifests/apps/search_api/rabbitmq.pp
@@ -71,18 +71,4 @@ class govuk::apps::search_api::rabbitmq (
     write_permission     => "^(amq\\.gen.*|search_api_to_be_indexed|search_api_govuk_index)\$",
     configure_permission => "^(amq\\.gen.*|search_api_to_be_indexed|search_api_govuk_index)\$",
   }
-
-  # todo: remove these expiration times when we have search-api set up
-  # and processing the queues properly.
-  rabbitmq_policy { 'search_api-ttl@/':
-    ensure     => absent,
-    pattern    => 'search_api*',
-    priority   => 0,
-    applyto    => 'queues',
-    definition => {
-      'ha-mode'      => 'all',
-      'ha-sync-mode' => 'automatic',
-      'message-ttl'  => 300000, # 5 minutes
-    },
-  }
 }


### PR DESCRIPTION
The procfile worker is running and consuming messages now.

Also delete an `absent`ed policy for search-api.