### PR TITLE
install python 2.7.14 in base class

### DIFF
--- a/hieradata_aws/class/ckan.yaml
+++ b/hieradata_aws/class/ckan.yaml
@@ -8,5 +8,4 @@ govuk::apps::ckan::enable_harvester_gather: true
 
 govuk_solr6::present: false
 
-govuk_python::govuk_python_version: '2.7.14'
 govuk_python3::govuk_python_version: '3.6.12'

--- a/hieradata_aws/class/integration/ci_agent.yaml
+++ b/hieradata_aws/class/integration/ci_agent.yaml
@@ -15,7 +15,6 @@ govuk_containers::elasticsearch::secondary::enable: false
 postgresql::globals::version: '9.6'
 postgresql::globals::postgis_version: '3.1.1'
 govuk_postgresql::server::enable_collectd: false
-govuk_python::govuk_python_version: '2.7.14'
 govuk_python3::govuk_python_version: '3.6.12'
 
 govuk_mysql::server::innodb_flush_log_at_trx_commit: 2

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -878,6 +878,8 @@ govuk_prometheus::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerpri
 govuk_ppa::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk_ppa::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
+govuk_python::govuk_python_version: '2.7.14'
+
 govuk_sshkeys::deployment_keys:
   github.com:
     key: 'AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=='

--- a/modules/govuk/manifests/deploy.pp
+++ b/modules/govuk/manifests/deploy.pp
@@ -3,7 +3,6 @@ class govuk::deploy (
 ){
   include govuk_harden
   include govuk_logging
-  include govuk_python
   include unicornherder
 
   anchor { 'govuk::deploy::begin': }

--- a/modules/govuk/manifests/node/s_base.pp
+++ b/modules/govuk/manifests/node/s_base.pp
@@ -29,6 +29,7 @@ class govuk::node::s_base (
   include monitoring::client
   include postfix
   include rcs
+  include govuk_python
 
   $_node_class = $::aws_migration
 

--- a/modules/govuk/manifests/node/s_ckan.pp
+++ b/modules/govuk/manifests/node/s_ckan.pp
@@ -18,7 +18,6 @@ class govuk::node::s_ckan inherits govuk::node::s_base {
     both       => 1024,
   }
 
-  include govuk_python
   include govuk_python3
   include nginx
   include postgresql::lib::devel

--- a/modules/govuk/manifests/node/s_mapit.pp
+++ b/modules/govuk/manifests/node/s_mapit.pp
@@ -18,8 +18,6 @@ class govuk::node::s_mapit inherits govuk::node::s_base {
   ->
   class { 'govuk_postgresql::server::standalone': }
 
-  include govuk_python
-
   include collectd::plugin::memcached
   class { 'memcached':
     max_memory => '12%',

--- a/modules/govuk_ci/manifests/agent.pp
+++ b/modules/govuk_ci/manifests/agent.pp
@@ -49,7 +49,6 @@ class govuk_ci::agent(
   include ::govuk_jenkins::pipeline
   include ::govuk_jenkins::user
   include ::govuk_rbenv::all
-  include ::govuk_python
   include ::govuk_python3
   include ::govuk_sysdig
   include ::govuk_testing_tools


### PR DESCRIPTION
This is required since the default Trusty version of Pip is not SNI-compliant.

Ref:
1. [trello card](https://trello.com/c/zGBit7Av/2542-pip-is-broken-in-trusty)

Co-Authored-By: Chris Ashton <ChrisBAshton@users.noreply.github.com>