### PR TITLE
Fix Mapit not starting correctly when a new instance spuns up

### DIFF
--- a/modules/govuk/manifests/apps/mapit.pp
+++ b/modules/govuk/manifests/apps/mapit.pp
@@ -117,16 +117,19 @@ class govuk::apps::mapit (
         value   => $django_secret_key;
   }
 
-  if ($::mapit_data_present == '0') {
+  if ($::mapit_data_present != '1') {
 
 
     file { '/etc/govuk/import_mapit_data.sh':
-      ensure => file,
-      source => 'puppet:///modules/govuk/etc/govuk/import_mapit_data.sh',
-
+      ensure  => file,
+      mode    => '0755',
+      source  => 'puppet:///modules/govuk/etc/govuk/import_mapit_data.sh',
+      require => Govuk_postgresql::Db['mapit'],
     }
+
     exec { 'populate mapit database':
       command => '/bin/bash /etc/govuk/import_mapit_data.sh 2>&1 | logger',
+      require => File['/etc/govuk/import_mapit_data.sh'],
     }
   }
 


### PR DESCRIPTION
This involves fixing the issue and workaround mentioned in the
[playbook](https://docs.publishing.service.gov.uk/manual/mapit-database-not-available.html)
so that Puppet can instantiate Mapit correctly on instance creation.

We included the database import [script](https://github.com/alphagov/mapit/blob/main/import-db-from-s3.sh)
into the `modules/govuk/files/etc/govuk/import_mapit_data.sh` so that
Puppet can prepare the instance fully before triggering Jenkins for
the final instantiation phase.