### PR TITLE
add python 2.7.14 bin path to /etc/environment file

### DIFF
--- a/modules/govuk_envsys/files/etc/environment
+++ b/modules/govuk_envsys/files/etc/environment
@@ -1,3 +1,3 @@
-PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games"
+PATH="/opt/python2.7/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games"
 LC_ALL=en_GB.UTF-8
 TZ=UTC


### PR DESCRIPTION
This is required following the installation of python 2.7.14 in #11123