### PR TITLE
remove hardcoded path from s3cmd

### DIFF
--- a/modules/govuk/templates/node/s_asset_base/attachments-s3-env-sync.sh.erb
+++ b/modules/govuk/templates/node/s_asset_base/attachments-s3-env-sync.sh.erb
@@ -18,4 +18,4 @@ if [ ! "$DIRECTORY_TO_SYNC" ]; then
  usage
 fi
 
-envdir /etc/govuk/aws/env.d /usr/local/bin/s3cmd sync --skip-existing --delete-removed  "s3://<%= @s3_bucket -%>$DIRECTORY_TO_SYNC/" "$DIRECTORY_TO_SYNC/"
+envdir /etc/govuk/aws/env.d s3cmd sync --skip-existing --delete-removed  "s3://<%= @s3_bucket -%>$DIRECTORY_TO_SYNC/" "$DIRECTORY_TO_SYNC/"

--- a/modules/govuk/templates/node/s_asset_base/copy-attachments-to-slaves.sh.erb
+++ b/modules/govuk/templates/node/s_asset_base/copy-attachments-to-slaves.sh.erb
@@ -41,7 +41,7 @@ for FILELIST in $(find $FILELIST_DIR -type f); do
       fi
     done
     <% if @s3_bucket && @process_uploaded_attachments_to_s3 %>
-      if envdir /etc/govuk/aws/env.d /usr/local/bin/s3cmd --server-side-encryption put "$FILENAME" "s3://<%= @s3_bucket -%>${FILENAME}"; then
+      if envdir /etc/govuk/aws/env.d s3cmd --server-side-encryption put "$FILENAME" "s3://<%= @s3_bucket -%>${FILENAME}"; then
         logger -t copy_attachments_to_slaves "File ${FILENAME} copied to S3 (<%= @s3_bucket -%>)"
       else
         logger -t copy_attachments_to_slaves "File ${FILENAME} failed to copy to S3 (<%= @s3_bucket -%>)"

--- a/modules/govuk/templates/node/s_asset_base/push-attachments-to-s3.sh.erb
+++ b/modules/govuk/templates/node/s_asset_base/push-attachments-to-s3.sh.erb
@@ -32,7 +32,7 @@ if [ ! "$DIRECTORY_TO_COPY" ]; then
  usage
 fi
 
-if envdir /etc/govuk/aws/env.d /usr/local/bin/s3cmd --cache-file=/tmp/s3cmd_attachments.cache --server-side-encryption sync --exclude="lost+found" --exclude="asset-manager" --skip-existing --delete-removed "$DIRECTORY_TO_COPY/" "s3://<%= @s3_bucket -%>$DIRECTORY_TO_COPY/"; then
+if envdir /etc/govuk/aws/env.d s3cmd --cache-file=/tmp/s3cmd_attachments.cache --server-side-encryption sync --exclude="lost+found" --exclude="asset-manager" --skip-existing --delete-removed "$DIRECTORY_TO_COPY/" "s3://<%= @s3_bucket -%>$DIRECTORY_TO_COPY/"; then
   echo "Attachments copied to S3 (<%= @s3_bucket -%>) successfully"
 else
   echo "Attachments errored while copying to S3 (<%= @s3_bucket -%>)"

--- a/modules/govuk_crawler/templates/govuk_sync_mirror.erb
+++ b/modules/govuk_crawler/templates/govuk_sync_mirror.erb
@@ -55,7 +55,7 @@ for TARGET in ${TARGETS}; do
   if [[ $TARGET = s3://* ]]; then
     # With s3cmd sync, target needs to end with /
     if [[ ! $(echo ${TARGET} | egrep '/$') ]] ; then TARGET="${TARGET}/" ; fi
-    CMD="/usr/local/bin/govuk_setenv s3_sync_mirror /usr/local/bin/s3cmd sync --no-mime-magic --guess-mime-type --no-preserve --cache-file=/tmp/s3cmd_mirror_sync.cache --exclude=\"lost+found\" ${MIRROR_ROOT}/ ${TARGET}"
+    CMD="/usr/local/bin/govuk_setenv s3_sync_mirror s3cmd sync --no-mime-magic --guess-mime-type --no-preserve --cache-file=/tmp/s3cmd_mirror_sync.cache --exclude=\"lost+found\" ${MIRROR_ROOT}/ ${TARGET}"
   else
     CMD="rsync -az --exclude 'lost+found' ${MIRROR_ROOT}/. ${TARGET}:/srv/mirror_data"
   fi

--- a/modules/mongodb/templates/mongodb-backup-s3.erb
+++ b/modules/mongodb/templates/mongodb-backup-s3.erb
@@ -51,9 +51,9 @@ printf "COMPRESSION AND ENCRYPTION FINISHED IN: ${TIME}s\n"
 TIME="$(date +%s)"
 if [[ $1 == "daily" ]]; then
 
-    /usr/bin/envdir <%= @env_dir %>/env.d /usr/local/bin/s3cmd put $BACKUP_DIR/mongodump-* s3://$S3_BUCKET_DAILY --quiet
+    /usr/bin/envdir <%= @env_dir %>/env.d s3cmd put $BACKUP_DIR/mongodump-* s3://$S3_BUCKET_DAILY --quiet
 else
-    /usr/bin/envdir <%= @env_dir %>/env.d /usr/local/bin/s3cmd put $BACKUP_DIR/mongodump-* s3://$S3_BUCKET --quiet
+    /usr/bin/envdir <%= @env_dir %>/env.d s3cmd put $BACKUP_DIR/mongodump-* s3://$S3_BUCKET --quiet
 fi
 TIME="$(($(date +%s)-TIME))"
 printf "BACKUP UPLOADED IN: ${TIME}s\n"

--- a/modules/mongodb/templates/mongodb-restore-s3.erb
+++ b/modules/mongodb/templates/mongodb-restore-s3.erb
@@ -20,8 +20,8 @@ housekeeping
 
 TIME="$(date +%s)"
 # Download and decrypt most recent backup
-LATEST_BACKUP=`/usr/bin/envdir <%= @env_dir %>/env.d /usr/local/bin/s3cmd ls s3://${S3_BUCKET}/mongodump* | /usr/bin/tail -1 | /usr/bin/awk '{print $4}'`
-/usr/bin/envdir <%= @env_dir %>/env.d /usr/local/bin/s3cmd get --force "$LATEST_BACKUP"
+LATEST_BACKUP=`/usr/bin/envdir <%= @env_dir %>/env.d s3cmd ls s3://${S3_BUCKET}/mongodump* | /usr/bin/tail -1 | /usr/bin/awk '{print $4}'`
+/usr/bin/envdir <%= @env_dir %>/env.d s3cmd get --force "$LATEST_BACKUP"
 
 # Enter the passphrase to unlock the gpg secret key
 /bin/echo "Enter gpg Passphrase: "
@@ -41,4 +41,3 @@ TIME="$(date +%s)"
 
 TIME="$(($(date +%s)-TIME))"
 /usr/bin/printf "RESTORE COMPLETED IN: ${TIME}s\n"
-


### PR DESCRIPTION
With the new version of python 2 installed, the python2 pip binaries are in located in `/opt/python2.7/bin` and therefore, we should not hardcode the `s3cmd` path.   `/opt/python2.7/bin` is already on the default PATH env variable.

Ref:
1. #11131
2. #11123