### PR TITLE
Modify mongo cluster to use FQDN for nodes in production

### DIFF
--- a/hieradata_aws/class/production/mongo.yaml
+++ b/hieradata_aws/class/production/mongo.yaml
@@ -43,3 +43,8 @@ govuk_env_sync::tasks:
     temppath: "/var/lib/mongodb/.dumps"
     url: "govuk-production-database-backups"
     path: "mongo-normal"
+
+mongodb::server::replicaset_members:
+  'mongo-1.production.govuk-internal.digital':
+  'mongo-2.production.govuk-internal.digital':
+  'mongo-3.production.govuk-internal.digital':

--- a/hieradata_aws/class/production/rabbitmq.yaml
+++ b/hieradata_aws/class/production/rabbitmq.yaml
@@ -1,8 +1,0 @@
----
-
-govuk_rabbitmq::federation: 'yes'
-govuk_rabbitmq::federate::federation_user: 'root'
-govuk_rabbitmq::federate::federation_pass: "%{hiera('govuk_rabbitmq::root_password')}"
-govuk_rabbitmq::federate::upstream_servers: ['10.3.3.70', '10.3.3.71', '10.3.3.72']
-govuk_rabbitmq::federate::upstream_name: 'carrenza'
-govuk_rabbitmq::federate::federation_exchange: 'published_documents'

--- a/modules/govuk_rabbitmq/manifests/init.pp
+++ b/modules/govuk_rabbitmq/manifests/init.pp
@@ -54,16 +54,6 @@ class govuk_rabbitmq (
 
   }
 
-  if $federation {
-
-    # Temporary federation setup for the duration of the migration to AWS
-    # Remove once the migration is over
-    include govuk_rabbitmq::federate
-
-    # Temporary purging of queues not consumed during the migration to AWS
-    include govuk_rabbitmq::purge_queues
-  }
-
   rabbitmq_user { 'root':
     admin    => true,
     password => $root_password,


### PR DESCRIPTION
We need this to run the new platform based on ECS as it is unable
to resolve shortened host names.