### PR TITLE
Modify mongo cluster to use FQDN for nodes in staging

### DIFF
--- a/hieradata_aws/class/staging/mongo.yaml
+++ b/hieradata_aws/class/staging/mongo.yaml
@@ -76,3 +76,8 @@ govuk_env_sync::tasks:
     temppath: "/var/lib/mongodb/.dumps"
     url: "govuk-staging-database-backups"
     path: "mongo-normal"
+
+mongodb::server::replicaset_members:
+  'mongo-1.staging.govuk-internal.digital':
+  'mongo-2.staging.govuk-internal.digital':
+  'mongo-3.staging.govuk-internal.digital':


### PR DESCRIPTION
We need this to run the new platform based on ECS as it is unable
to resolve shortened host names.