### PR TITLE
Modify mongo cluster to use FQDN for nodes in production

### DIFF
--- a/hieradata_aws/class/production/mongo.yaml
+++ b/hieradata_aws/class/production/mongo.yaml
@@ -43,3 +43,8 @@ govuk_env_sync::tasks:
     temppath: "/var/lib/mongodb/.dumps"
     url: "govuk-production-database-backups"
     path: "mongo-normal"
+
+mongodb::server::replicaset_members:
+  'mongo-1.production.govuk-internal.digital':
+  'mongo-2.production.govuk-internal.digital':
+  'mongo-3.production.govuk-internal.digital':


### PR DESCRIPTION
We need this to run the new platform based on ECS as it is unable
to resolve shortened host names.