### PR TITLE
Upgrade to govuk_seed_crawler 2.1.0

### DIFF
--- a/modules/govuk_crawler/manifests/init.pp
+++ b/modules/govuk_crawler/manifests/init.pp
@@ -139,13 +139,6 @@ class govuk_crawler(
     owner  => $crawler_user,
   }
 
-  package { 'ffi':
-    ensure   => '1.10.0',
-    provider => 'system_gem',
-    require  => Class['base::packages'],
-    before   => Package['govuk_seed_crawler'],
-  }
-
   # This explicitly requires 'base::packages' so that nokogiri will build
   package { 'govuk_seed_crawler':
         ensure   => '2.1.0',

--- a/modules/govuk_crawler/manifests/init.pp
+++ b/modules/govuk_crawler/manifests/init.pp
@@ -148,7 +148,7 @@ class govuk_crawler(
 
   # This explicitly requires 'base::packages' so that nokogiri will build
   package { 'govuk_seed_crawler':
-        ensure   => '2.0.1',
+        ensure   => '2.1.0',
         provider => system_gem,
         require  => Class['base::packages'],
   }


### PR DESCRIPTION
This upgrades to a more recent version of govuk_seed_crawler which should fix an issue where the mirror machine doesn't come up correctly.