### PR TITLE
Set up Smokey env vars for GOV.UK Account tests

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -741,6 +741,8 @@ govuk::apps::smokey::http_username: "%{hiera('http_username')}"
 govuk::apps::smokey::http_password: "%{hiera('http_password')}"
 govuk::apps::smokey::smokey_signon_email: "%{hiera('smokey_signon_email')}"
 govuk::apps::smokey::smokey_signon_password: "%{hiera('smokey_signon_password')}"
+govuk::apps::smokey::smokey_govuk_account_email: "%{hiera('smokey_govuk_account_email')}"
+govuk::apps::smokey::smokey_govuk_account_password: "%{hiera('smokey_govuk_account_password')}"
 govuk::apps::smokey::smokey_bearer_token: "%{hiera('smokey_bearer_token')}"
 govuk::apps::smokey::rate_limit_token: "%{hiera('smokey_rate_limit_token')}"
 
@@ -1050,6 +1052,8 @@ govuk_jenkins::jobs::smokey::auth_password: "%{hiera('http_password')}"
 govuk_jenkins::jobs::smokey::smokey_bearer_token: "%{hiera('smokey_bearer_token')}"
 govuk_jenkins::jobs::smokey::signon_email: "%{hiera('smokey_signon_email')}"
 govuk_jenkins::jobs::smokey::signon_password: "%{hiera('smokey_signon_password')}"
+govuk_jenkins::jobs::smokey::smokey_govuk_account_email: "%{hiera('smokey_govuk_account_email')}"
+govuk_jenkins::jobs::smokey::smokey_govuk_account_password: "%{hiera('smokey_govuk_account_password')}"
 
 govuk_jenkins::jobs::run_rake_task::applications: *deployable_applications
 govuk_jenkins::jobs::deploy_app::applications: *deployable_applications

--- a/modules/govuk/manifests/apps/smokey.pp
+++ b/modules/govuk/manifests/apps/smokey.pp
@@ -19,6 +19,12 @@
 # [*smokey_signon_password*]
 #   Password for $smokey_signon_email
 #
+# [*smokey_govuk_account_email*]
+#   Email address to login to GOV.UK Accounts as a smoke test user
+#
+# [*smokey_govuk_account_password*]
+#   Password for $smokey_govuk_account_email
+#
 # [*smokey_bearer_token*]
 #   Bearer token for something
 #
@@ -28,6 +34,8 @@ class govuk::apps::smokey (
   $rate_limit_token = undef,
   $smokey_signon_email = undef,
   $smokey_signon_password = undef,
+  $smokey_govuk_account_email = undef,
+  $smokey_govuk_account_password = undef,
   $smokey_bearer_token = undef,
 ){
   $app = 'smokey'
@@ -50,6 +58,8 @@ class govuk::apps::smokey (
     'RATE_LIMIT_TOKEN':         value => $rate_limit_token;
     'SIGNON_EMAIL':             value => $smokey_signon_email;
     'SIGNON_PASSWORD':          value => $smokey_signon_password;
+    'GOVUK_ACCOUNT_EMAIL':      value => $smokey_govuk_account_email;
+    'GOVUK_ACCOUNT_PASSWORD':   value => $smokey_govuk_account_password;
     'DBUS_SESSION_BUS_ADDRESS': value => 'disabled:';
   }
 


### PR DESCRIPTION
We're creating a test user for Smokey to log in with, to confirm that
deploys don't break the log in journey.

---

[Trello card](https://trello.com/c/a1mlNSkg/849-add-a-smoke-test-for-signing-in-from-the-checker-results-page)