### PR TITLE
Set PYTHONPATH variable to new python version 2.7.14

### DIFF
--- a/modules/govuk_envsys/files/etc/environment
+++ b/modules/govuk_envsys/files/etc/environment
@@ -1,3 +1,4 @@
 PATH="/opt/python2.7/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games"
+PYTHONPATH='/opt/python2.7/lib/python2.7/site-packages/'
 LC_ALL=en_GB.UTF-8
 TZ=UTC


### PR DESCRIPTION
There is a case when we need to call the old 2.7.6 python because
some libraries were compiled against it.
See: https://github.com/alphagov/govuk-puppet/commit/8eeaddc6fe07b2305b24400d9934d752bcc4a78a

This creates a problem because modules are now installed in
/opt/python2.7/lib/python2.7/site-packages/, and so are missing
as viewed from 2.7.6.
This set a common path for python modules.