### PR TITLE
override and fix virtualenv_version fact

### DIFF
--- a/modules/govuk/lib/facter/virtualenv_version.rb
+++ b/modules/govuk/lib/facter/virtualenv_version.rb
@@ -1,0 +1,18 @@
+# Override the standard virtualenv_version fact definition since the newer 
+# version of virtualenv returns a different version string, i.e:
+# old versions return for example: 10.0.1 while newer versions return:
+# 20.4.7 from /opt/python2.7/lib/python2.7/site-packages/virtualenv/__init__.pyc
+
+Facter.add("virtualenv_version") do
+  has_weight 2000
+  setcode do
+    if Facter::Util::Resolution.which('virtualenv')
+      match=Facter::Util::Resolution.exec('virtualenv --version 2>&1').match(/^(\d+\.\d+\.?\d*).*$/)
+      if match.nil?
+        Facter::Util::Resolution.exec('virtualenv --version 2>&1').match(/^virtualenv (\d+\.\d+\.?\d*).*$/)[1]
+      else
+        match[0]
+      end
+    end
+  end
+end


### PR DESCRIPTION
`virualenv_version` factor uses the output of `virtualenv --version`.

Before the update to new python/pip, the output was only a version number e.g. `10.0.1`, now it is a longer text: e.g. `20.4.7 from /opt/python2.7/lib/python2.7/site-packages/virtualenv/__init__.pyc`

which the virtualenv_version factor cannot regex correctly.

Therefore, we modify the virtualenv factor to handle both scenarios.

A high weight is used for this version of `virtualenv_version` facter to take precedence over the standard broken default one.