### PR TITLE
Revert "Set PYTHONPATH variable to new python version 2.7.14"

### DIFF
--- a/modules/govuk_envsys/files/etc/environment
+++ b/modules/govuk_envsys/files/etc/environment
@@ -1,4 +1,3 @@
 PATH="/opt/python2.7/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games"
-PYTHONPATH='/opt/python2.7/lib/python2.7/site-packages/'
 LC_ALL=en_GB.UTF-8
 TZ=UTC


### PR DESCRIPTION
Reverts alphagov/govuk-puppet#11151

This seems to be breaking python 3 commands, which is breaking Puppet deployments:

```
michaelswalker@ec2-integration-blue-jenkins-ip-10-1-6-88:~$ aws
Traceback (most recent call last):
  File "/usr/bin/aws", line 19, in <module>
    import awscli.clidriver
  File "/opt/awscli/lib/python3.4/site-packages/awscli/clidriver.py", line 17, in <module>
    import botocore.session
  File "/opt/python2.7/lib/python2.7/site-packages/botocore/session.py", line 29, in <module>
    import botocore.configloader
  File "/opt/python2.7/lib/python2.7/site-packages/botocore/configloader.py", line 19, in <module>
    from botocore.compat import six
  File "/opt/python2.7/lib/python2.7/site-packages/botocore/compat.py", line 28, in <module>
    from urllib3 import exceptions
ImportError: No module named 'urllib3'
michaelswalker@ec2-integration-blue-jenkins-ip-10-1-6-88:~$ unset PYTHONPATH
michaelswalker@ec2-integration-blue-jenkins-ip-10-1-6-88:~$ aws
usage: aws [options] <command> <subcommand> [<subcommand> ...] [parameters]
To see help text, you can run:

  aws help
  aws <command> help
  aws <command> <subcommand> help
aws: error: the following arguments are required: command
```

See also this failed deploy: https://deploy.integration.publishing.service.gov.uk/job/Deploy_Puppet/3810/console