### PR TITLE
Correctly set Publisher report permissions

### DIFF
--- a/modules/govuk/manifests/apps/publisher.pp
+++ b/modules/govuk/manifests/apps/publisher.pp
@@ -258,4 +258,11 @@ class govuk::apps::publisher(
         value   => $govuk_notify_template_id;
     }
   }
+
+  file { '/data/uploads/publisher/reports':
+    ensure => 'directory',
+    owner  => 'deploy',
+    group  => 'deploy',
+    mode   => '0770',
+  }
 }


### PR DESCRIPTION
The reports for publisher are run by a user that does not have write access to the output directory, and it seems only to work for reports where there's an existing report file owned by the right user. This corrects that.

https://trello.com/c/fhtbsEgu/2528-create-a-mainstream-url-report-which-shows-all-urls
