### PR TITLE
Adding custom PYTHONPATH var when running collectd

### DIFF
--- a/modules/collectd/files/etc/default/collectd
+++ b/modules/collectd/files/etc/default/collectd
@@ -1,0 +1,21 @@
+# /etc/default/collectd
+
+# 0: start collectd on boot, 1: do not start collectd on boot
+# default: 0
+DISABLE=0
+
+# 0: start collectd in stand-alone mode, 1: monitor collectd using collectdmon
+# default: 1
+USE_COLLECTDMON=1
+
+# number of seconds to wait for collectd to shut down
+# default: 30
+MAXWAIT=30
+
+# 0: do not enable core-files, 1: enable core-files ... if collectd crashes
+# default: 0
+ENABLE_COREFILES=0
+
+# Fetch python modules in the newer version of python in use since we had to update pip
+# See https://github.com/alphagov/govuk-puppet/pull/11122
+export PYTHONPATH='/opt/python2.7/lib/python2.7/site-packages/'

--- a/modules/collectd/manifests/config.pp
+++ b/modules/collectd/manifests/config.pp
@@ -42,4 +42,8 @@ class collectd::config {
   # Always collect basic processlist info.
   include ::collectd::plugin::processes
   include ::collectd::plugin::tcpconns
+
+file { '/etc/default/collectd':
+    source => 'puppet:///modules/collectd/etc/default/collectd',
+  }
 }


### PR DESCRIPTION
collectd needs to run python 2.7.6 because it was compiled against
 this version of python.

To fix a problem with pip we are now using python 2.7.14, see :
https://github.com/alphagov/govuk-puppet/pull/11122

However this creates a problem for collectd when trying to load
python modules since it looks for them in the 2.7.6 directory and
not the 2.7.14 where they are not installed.

We modify PYTHONPATH for the benefit of collectd to fix this.