### PR TITLE
Add ckan29 integration

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -152,6 +152,8 @@ deployable_applications: &deployable_applications
   cache-clearing-service: {}
   ckan:
     repository: 'ckanext-datagovuk'
+  ckan29:
+    repository: 'ckanext-datagovuk'
   collections: {}
   collections-publisher: {}
   contacts:

--- a/modules/govuk/manifests/apps/ckan/ckan_cronjob.pp
+++ b/modules/govuk/manifests/apps/ckan/ckan_cronjob.pp
@@ -1,0 +1,56 @@
+# == Define: govuk::apps::ckan::ckan_cronjob
+#
+# Creates a cronjob entry specifically for ckan commands
+#
+# === Parameters
+#
+# [*hour*]
+# [*minute*]
+# [*month*]
+# [*monthday*]
+# [*weekday*]
+# Same timing parameters as a normal cronjob
+#
+# [*ckan_command*]
+# CKAN command to run eg "archiver update"
+#
+# [*timeout*]
+# Duration after which to terminate command. See man 1 timeout for
+# possible values.
+#
+define govuk::apps::ckan::ckan_cronjob (
+  $ensure = present,
+  $hour = undef,
+  $minute = undef,
+  $month = undef,
+  $monthday = undef,
+  $weekday = undef,
+  $ckan_command = undef,
+  $timeout = undef,
+  $ckan_ini = '/var/ckan/ckan29.ini',
+) {
+  validate_string($ckan_command)
+
+  if $ckan_ini {
+    $ckan_config_arg = "-c ${ckan_ini}"
+  } else {
+    $ckan_config_arg = ''
+  }
+
+  if $timeout {
+    $timeout_cmd = "/usr/bin/timeout ${timeout}"
+  } else {
+    $timeout_cmd = ''
+  }
+
+  cron { $title:
+    ensure   => $ensure,
+    command  => "cd /var/apps/ckan; ${timeout_cmd} ./venv3/bin/ckan ${ckan_config_arg} ${ckan_command}",
+    user     => 'deploy',
+    hour     => $hour,
+    minute   => $minute,
+    month    => $month,
+    monthday => $monthday,
+    weekday  => $weekday,
+  }
+}

--- a/modules/govuk/manifests/apps/ckan/cronjobs29.pp
+++ b/modules/govuk/manifests/apps/ckan/cronjobs29.pp
@@ -1,0 +1,142 @@
+# == Class: govuk::apps::ckan::cronjobs29
+#
+# [*ckan_port*]
+#   The port CKAN is running on.
+#
+# [*pycsw_config*]
+#   The location of the PyCSW configuration file.
+#
+# [*enable*]
+#   Allows disabling of all ckan cronjobs
+#   Default: true
+#
+# [*enable_solr_reindex*]
+#   Enable automatic Solr reindexing, this is useful to run after the data
+#   sync. Requires $enable to be true.
+#   Default: false
+#
+class govuk::apps::ckan::cronjobs29(
+  $ckan_port,
+  $pycsw_config,
+  $enable              = true,
+  $enable_solr_reindex = false,
+) {
+  if ($enable_solr_reindex and !$enable) {
+    fail "Can't \$enable_solr_reindex without \$enable"
+  }
+
+  $ensure = $enable ? {
+    true  => 'present',
+    false => 'absent',
+  }
+
+  govuk::apps::ckan::ckan_cronjob { 'Find a Tender harvester stop existing processes':
+    ensure       => $ensure,
+    ckan_command => 'harvester job-abort find-tender-data-harvest',
+    hour         => '2',
+    minute       => '25',
+  }
+
+  govuk::apps::ckan::ckan_cronjob { 'Find a Tender harvester run':
+    ensure       => $ensure,
+    ckan_command => 'harvester run-test find-tender-data-harvest',
+    hour         => '2',
+    minute       => '30',
+  }
+
+  govuk::apps::ckan::ckan_cronjob { 'Contract Finder harvester stop existing processes':
+    ensure       => $ensure,
+    ckan_command => 'harvester job-abort contracts-finder-ocds-data-harvest',
+    hour         => '5',
+    minute       => '25',
+  }
+
+  govuk::apps::ckan::ckan_cronjob { 'Contract Finder harvester run':
+    ensure       => $ensure,
+    ckan_command => 'harvester run-test contracts-finder-ocds-data-harvest',
+    hour         => '5',
+    minute       => '30',
+  }
+
+  govuk::apps::ckan::ckan_cronjob { 'Environment Agency harvester stop existing processes':
+    ensure       => $ensure,
+    ckan_command => 'harvester job-abort environment-agency-data-sharing-platform',
+    weekday      => '5',
+    hour         => '15',
+    minute       => '55',
+  }
+
+  govuk::apps::ckan::ckan_cronjob { 'Environment Agency harvester run':
+    ensure       => $ensure,
+    ckan_command => 'harvester run-test environment-agency-data-sharing-platform',
+    weekday      => '5',
+    hour         => '16',
+    minute       => '0',
+  }
+
+  govuk::apps::ckan::ckan_cronjob { 'Vale of White Horse harvester stop existing processes':
+    ensure       => $ensure,
+    ckan_command => 'harvester job-abort vale-of-white-horse-district-council-2',
+    weekday      => '5',
+    hour         => '16',
+    minute       => '10',
+  }
+
+  govuk::apps::ckan::ckan_cronjob { 'Vale of White Horse harvester run':
+    ensure       => $ensure,
+    ckan_command => 'harvester run-test vale-of-white-horse-district-council-2',
+    weekday      => '5',
+    hour         => '16',
+    minute       => '15',
+  }
+
+  govuk::apps::ckan::ckan_cronjob { 'South Oxfordshire harvester stop existing processes':
+    ensure       => $ensure,
+    ckan_command => 'harvester job-abort south-oxfordshire-district-council-2',
+    weekday      => '5',
+    hour         => '16',
+    minute       => '25',
+  }
+
+  govuk::apps::ckan::ckan_cronjob { 'South Oxfordshire harvester run':
+    ensure       => $ensure,
+    ckan_command => 'harvester run-test south-oxfordshire-district-council-2',
+    weekday      => '5',
+    hour         => '16',
+    minute       => '30',
+  }
+
+  govuk::apps::ckan::ckan_cronjob { 'harvester run':
+    ensure       => $ensure,
+    ckan_command => 'harvester run',
+    minute       => '*/5',
+    # timeout shorter than repeat period to prevent stalling runs stacking up
+    timeout      => '4m',
+  }
+
+  govuk::apps::ckan::ckan_cronjob { 'harvester cleanup':
+    ensure       => $ensure,
+    ckan_command => 'harvester clean-harvest-log',
+    hour         => '2',
+  }
+
+  $ensure_solr_reindex = $enable_solr_reindex ? {
+    true  => 'present',
+    false => 'absent',
+  }
+
+  govuk::apps::ckan::ckan_cronjob { 'index missing packages':
+    ensure       => $ensure_solr_reindex,
+    ckan_command => 'search-index rebuild -o',
+    hour         => '4',
+    minute       => '0',
+  }
+
+  govuk::apps::ckan::ckan_cronjob { 'pycsw load':
+    ensure       => $ensure,
+    ckan_command => "ckan-pycsw load -p ${pycsw_config} -u http://localhost:${ckan_port}",
+    hour         => '6',
+    minute       => '0',
+    ckan_ini     => false,
+  }
+}

--- a/modules/govuk/templates/ckan/ckan29.ini.erb
+++ b/modules/govuk/templates/ckan/ckan29.ini.erb
@@ -1,0 +1,240 @@
+#
+# CKAN - Pylons configuration
+#
+# These are some of the configuration options available for your CKAN
+# instance. Check the documentation in 'doc/configuration.rst' or at the
+# following URL for a description of what they do and the full list of
+# available options:
+#
+# http://docs.ckan.org/en/latest/maintaining/configuration.html
+#
+# The %(here)s variable will be replaced with the parent directory of this file
+#
+
+[DEFAULT]
+
+# WARNING: *THIS SETTING MUST BE SET TO FALSE ON A PRODUCTION ENVIRONMENT*
+debug = false
+
+[server:main]
+use = egg:gunicorn#main
+bind = 127.0.0.1:3220
+preload = true
+errorlog = /var/log/ckan/app29.err.log
+
+[app:main]
+use = egg:ckan
+full_stack = true
+cache_dir = /tmp/%(ckan.site_id)s/
+beaker.session.key = ckan
+# Expire login sessions after 30 days (shown in seconds)
+beaker.session.cookie_expires = 2592000
+beaker.session.secret = <%= @secret%>
+app_instance_uuid = fdee5057-84ad-4b96-804a-d8c2dc027721
+
+who.config_file = %(here)s/who29.ini
+who.log_level = warning
+who.log_file = %(cache_dir)s/who29_log.ini
+who.secure = True
+
+## Database Settings
+sqlalchemy.url = <%= "postgresql://#{@db_username}:#{@db_password}@#{@db_hostname}/#{@db_name}"%>
+
+#ckan.datastore.write_url = postgresql://ckan_default:pass@localhost/datastore_default
+#ckan.datastore.read_url = postgresql://datastore_default:pass@localhost/datastore_default
+
+# PostgreSQL' full-text search parameters
+ckan.datastore.default_fts_lang = english
+ckan.datastore.default_fts_index_method = gist
+
+## Site Settings
+
+ckan.site_url = <%= @ckan_site_url %>
+ckan.use_pylons_response_cleanup_middleware = true
+
+## Authorization Settings
+
+ckan.auth.anon_create_dataset = false
+ckan.auth.create_unowned_dataset = false
+ckan.auth.create_dataset_if_not_in_organization = false
+ckan.auth.user_create_groups = false
+ckan.auth.user_create_organizations = true
+ckan.auth.user_delete_groups = false
+ckan.auth.user_delete_organizations = true
+ckan.auth.create_user_via_api = true
+ckan.auth.create_user_via_web = true
+ckan.auth.roles_that_cascade_to_sub_groups = admin
+
+## User Account Creation Setting
+ckan.valid_email_regexes = .gov.uk$ .nhs.uk$ .nhs.net$ .ac.uk$ .os.uk$ .mod.uk$ .police.uk$ .bl.uk$
+
+## Google Analytics
+ckan.google_analytics_tracking_id = nil
+
+## Search Settings
+
+ckan.site_id = dgu
+solr_url = <%= "http://#{@solr_host}:#{@solr_port}/solr" %><%= @solr_core == nil ? "" : "/#{@solr_core}" %>
+ckan.group_and_organization_list_max = 2000
+
+## CORS Settings
+
+# If cors.origin_allow_all is true, all origins are allowed.
+# If false, the cors.origin_whitelist is used.
+ckan.cors.origin_allow_all = true
+# cors.origin_whitelist is a space separated list of allowed domains.
+# ckan.cors.origin_whitelist = http://example1.com http://example2.com
+
+
+## Plugins Settings
+
+# Note: Add ``datastore`` to enable the CKAN DataStore
+#       Add ``datapusher`` to enable DataPusher
+#       Add ``resource_proxy`` to enable resorce proxying and get around the
+#       same origin policy
+ckan.plugins = datagovuk_publisher_form datagovuk dcat harvest ckan_harvester dcat_rdf_harvester dcat_json_harvester dcat_json_interface spatial_metadata spatial_query spatial_harvest_metadata_api gemini_csw_harvester gemini_waf_harvester gemini_doc_harvester inventory_harvester
+
+# These are marked as legacy harvesters
+# gemini_csw_harvester gemini_doc_harvester gemini_waf_harvester
+
+# This needs fixing
+# inventory_harvester
+
+## S3 Settings
+ckan.datagovuk.s3_aws_access_key_id = <%= @s3_aws_access_key_id%>
+ckan.datagovuk.s3_aws_secret_access_key = <%= @s3_aws_secret_access_key%>
+ckan.datagovuk.s3_bucket_name = <%= @s3_bucket_name%>
+ckan.datagovuk.s3_url_prefix = https://s3-<%= @s3_aws_region_name%>.amazonaws.com/<%= @s3_bucket_name%>/
+ckan.datagovuk.s3_aws_region_name = <%= @s3_aws_region_name%>
+
+# Harvesting settings
+ckan.harvest.mq.type = redis
+ckan.harvest.mq.hostname = <%= @redis_host%>
+ckan.harvest.mq.port = <%= @redis_port%>
+ckan.harvest.mq.redis_db = 2 
+# 12 hours timeout
+ckan.harvest.timeout = 720
+
+ckan.redis.url = redis://<%= @redis_host%>:<%= @redis_port%>/1
+
+ckan.spatial.validator.profiles = iso19139eden,constraints-1.4,gemini2-1.3
+ckan.spatial.validator.reject = true
+ckan.spatial.validator.use_default_tag_schema = true
+ckan.spatial.srid = 4258
+
+# Define which views should be created by default
+# (plugins must be loaded in ckan.plugins)
+# ckan.views.default_views = image_view text_view recline_view
+
+## Front-End Settings
+ckan.site_title = data.gov.uk
+ckan.site_description = Data publisher
+ckan.favicon = /images/icons/ckan.ico
+ckan.gravatar_default = identicon
+ckan.preview.direct = png jpg gif
+ckan.preview.loadable = html htm rdf+xml owl+xml xml n3 n-triples turtle plain atom csv tsv rss txt json
+ckan.display_timezone = server
+
+# package_hide_extras = for_search_index_only
+package_edit_return_url = <%= @ckan_site_url%>/dataset/<NAME>?utm_source=ckan
+package_new_return_url = <%= @ckan_site_url%>/dataset/<NAME>?utm_source=ckan
+#ckan.recaptcha.version = 1
+#ckan.recaptcha.publickey =
+#ckan.recaptcha.privatekey =
+#licenses_group_url = http://licenses.opendefinition.org/licenses/groups/ckan.json
+# ckan.template_footer_end =
+
+
+## Internationalisation Settings
+ckan.locale_default = en_GB
+ckan.locale_order = en_GB
+ckan.locales_offered = en_GB
+ckan.locales_filtered_out = en_US
+ckan.i18n_directory = /var/apps/ckan/ckanext/datagovuk/
+
+## Feeds Settings
+
+ckan.feeds.authority_name =
+ckan.feeds.date =
+ckan.feeds.author_name =
+ckan.feeds.author_link =
+
+## Storage Settings
+
+ckan.storage_path = /var/ckan/default
+ckan.max_resource_size = 50
+#ckan.max_image_size = 2
+
+## Datapusher settings
+
+# Make sure you have set up the DataStore
+
+#ckan.datapusher.formats = csv xls xlsx tsv application/csv application/vnd.ms-excel application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+#ckan.datapusher.url = http://127.0.0.1:8800/
+
+# Resource Proxy settings
+# Preview size limit, default: 1MB
+#ckan.resource_proxy.max_file_size = 1048576
+# Size of chunks to read/write.
+#ckan.resource_proxy.chunk_size = 4096
+
+## Activity Streams Settings
+
+#ckan.activity_streams_enabled = true
+#ckan.activity_list_limit = 31
+#ckan.activity_streams_email_notifications = true
+#ckan.email_notifications_since = 2 days
+ckan.hide_activity_from_users = %(ckan.site_id)s
+
+
+## Email settings
+
+#email_to = you@yourdomain.com
+#error_email_from = paste@localhost
+smtp.server = <%= @smtp_hostname %>
+smtp.starttls = True
+smtp.user = <%= @smtp_username %>
+smtp.password = <%= @smtp_password %>
+smtp.mail_from = team@data.gov.uk
+
+
+## Logging configuration
+[loggers]
+keys = root, ckan, ckanext
+
+[handlers]
+keys = console, file
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARNING
+handlers = console, file
+
+[logger_ckan]
+level = INFO
+handlers = console, file
+qualname = ckan
+propagate = 0
+
+[logger_ckanext]
+level = DEBUG
+handlers = console, file
+qualname = ckanext
+propagate = 0
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[handler_file]
+class = logging.handlers.RotatingFileHandler
+args = ("/var/log/ckan/ckan29.log", "a", 20000000, 9)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(asctime)s %(levelname)-5.5s [%(name)s] %(message)s

--- a/modules/govuk/templates/ckan/who29.ini.erb
+++ b/modules/govuk/templates/ckan/who29.ini.erb
@@ -1,0 +1,37 @@
+[plugin:auth_tkt]
+use = ckan.lib.repoze_plugins.auth_tkt:make_plugin 
+# If no secret key is defined here, beaker.session.secret will be used
+#secret = somesecret
+
+[plugin:friendlyform]
+use = ckan.lib.repoze_plugins.friendly_form:FriendlyFormPlugin
+login_form_url= /user/login
+login_handler_path = /login_generic
+logout_handler_path = /user/logout
+rememberer_name = auth_tkt
+post_login_url = /user/logged_in
+post_logout_url = /user/logged_out
+charset = utf-8
+
+#[plugin:basicauth]
+#use = repoze.who.plugins.basicauth:make_plugin
+#realm = 'CKAN'
+
+[general]
+request_classifier = repoze.who.classifiers:default_request_classifier
+challenge_decider = repoze.who.classifiers:default_challenge_decider
+
+[identifiers]
+plugins =
+    friendlyform;browser
+    auth_tkt
+
+[authenticators]
+plugins =
+    auth_tkt
+    ckanext.datagovuk.lib.authenticator:UsernamePasswordAuthenticator
+
+[challengers]
+plugins =
+    friendlyform;browser
+#   basicauth

--- a/modules/govuk/templates/ckan/wsgi.py
+++ b/modules/govuk/templates/ckan/wsgi.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+
+import os
+from ckan.config.middleware import make_app
+from ckan.cli import CKANConfigLoader
+from logging.config import fileConfig as loggingFileConfig
+config_filepath = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), u'ckan29.ini')
+abspath = os.path.join(os.path.dirname(os.path.abspath(__file__)))
+loggingFileConfig(config_filepath)
+config = CKANConfigLoader(config_filepath).get_config()
+application = make_app(config)


### PR DESCRIPTION
## What

Deploy CKAN 2.9 settings and necessary files onto Integration and startup worker processes.

The intention is to leave CKAN 2.9 running on Integration for a week to see if there are any issues running harvest jobs or with the GUI or managing users / datasets / harvest sources.

## Reference 

https://trello.com/c/GZP41t9N/2553-deploy-ckan-29-onto-integration