### PR TITLE
Correctly set ownership for the reports directory

### DIFF
--- a/modules/govuk/manifests/apps/publisher.pp
+++ b/modules/govuk/manifests/apps/publisher.pp
@@ -263,6 +263,6 @@ class govuk::apps::publisher(
     ensure => 'directory',
     owner  => 'deploy',
     group  => 'deploy',
-    mode   => '0770',
+    mode   => '0775',
   }
 }


### PR DESCRIPTION
In #11161 the permissions were set as non-world-readable which makes the reports inaccessible to the webserver; this fixes that.

https://trello.com/c/fhtbsEgu/2528-create-a-mainstream-url-report-which-shows-all-urls
