### PR TITLE
Add a safety check to unattended reboots

### DIFF
--- a/modules/govuk_unattended_reboot/templates/etc/unattended-reboot/check/00_safety.erb
+++ b/modules/govuk_unattended_reboot/templates/etc/unattended-reboot/check/00_safety.erb
@@ -4,6 +4,11 @@ if ! [[ "$(/usr/local/bin/govuk_setenv default /usr/bin/printenv SAFE_TO_REBOOT)
   exit 1
 fi
 
+# Don't reboot while the machine is still provisioning
+if [ ! -f /var/lib/cloud/instance/boot-finished ]; then
+  exit 1
+fi
+
 # Don't reboot while logrotate is running
 if /usr/bin/pgrep "logrotate" > /dev/null; then
   exit 1


### PR DESCRIPTION
Wait for a machine to finish provisioning before allowing reboot.
We test the presence of /var/lib/instance/boot-finished as it is
created once has finished initializing and running the user-data
snippets.