### PR TITLE
Change Environment Agency harvest job cron time

### DIFF
--- a/modules/govuk/manifests/apps/ckan/cronjobs.pp
+++ b/modules/govuk/manifests/apps/ckan/cronjobs.pp
@@ -67,7 +67,7 @@ class govuk::apps::ckan::cronjobs(
     paster_command => 'harvester job_abort environment-agency-data-sharing-platform',
     plugin         => 'ckanext-harvest',
     weekday        => '5',
-    hour           => '15',
+    hour           => '13',
     minute         => '55',
   }
 
@@ -76,7 +76,7 @@ class govuk::apps::ckan::cronjobs(
     paster_command => 'harvester run_test environment-agency-data-sharing-platform',
     plugin         => 'ckanext-harvest',
     weekday        => '5',
-    hour           => '16',
+    hour           => '14',
     minute         => '0',
   }
 


### PR DESCRIPTION
We've had a request to change the harvest time from 5pm to 3pm:
https://govuk.zendesk.com/agent/tickets/4603384

Given that these cron jobs are only in place because the automated
runs fail, there is no particular time of day we need to adhere to,
so it is fine to bring this forward a couple of hours. See the
original commit eead57eab4d784122e3087b8e0fe35aa16053a16.

NB our machines are on UTC time, so 14:00 UTC is 15:00 BST.