### PR TITLE
Use OAuth access token instead of service account

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_dns.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_dns.yaml.erb
@@ -27,10 +27,6 @@
             colormap: xterm
         - build-name:
             name: '${ENV,var="PROVIDERS"} ${ENV,var="ZONE"} ${ENV,var="ACTION"}'
-        - credentials-binding:
-            - text:
-               credential-id: <%= @gce_credential_id %>
-               variable: GOOGLE_CREDENTIALS
     builders:
         - shell: |
             export GOOGLE_PROJECT=<%= @gce_project_id %>
@@ -67,6 +63,17 @@
             name: AWS_SESSION_TOKEN
             default: false
             description: This is required for all providers
+        - password:
+            name: GOOGLE_OAUTH_ACCESS_TOKEN
+            default: false
+            description: |
+              This is required for the GCP provider
+
+              Generate a token with using the gcloud CLI (https://cloud.google.com/sdk/docs/quickstart#mac)
+
+              gcloud config set project <%= @gce_project_id %>
+              gcloud auth login --brief
+              gcloud auth print-access-token
         - choice:
             name: ACTION
             description: Choose whether to plan (default) or apply


### PR DESCRIPTION
The GOOGLE_CREDENTIALS key we were using before was a long-lived
credential with access to administer DNS.

We try to avoid giving Jenkins long lived tokens with high levels of
privilege. There are a few reasons why it's bad:

- The token is set to expire in the year 9999. A disgruntled former
  employee could steal this token and use it later.
- Using the service account complicates auditing who made a change to
  DNS - it just shows up as Jenkins in the GCP audit logs.
- Jenkins itself could be compromised (e.g. due to a bad plugin). If it
  always has access to privileged tokens, that could lead to an
  escalation.

For AWS, we have a pattern of pasting short lived STS credentials into
Jenkins.

Now that we've updated the GCP terraform provider to a version which
supports GOOGLE_OAUTH_ACCESS_TOKEN we can do the same thing for Google.

This requires that everyone who needs to make changes to DNS has the
`gcloud` CLI installed.

If this is approved, further work will be needed to:

- [ ] Update the documentation on how to deploy DNS
- [ ] Update the on-call checklist to make it clear that you need to have `gcloud` set up
- [ ] Email all the engineers on 2ndline to make them aware of the requirement to have `gcloud` set up
- [x] Update the GDS CLI (which has a function where it can fill in the form in Jenkins for you)

https://trello.com/c/LasnNuz4/561-rationalise-use-of-gcp-credentials-eg-for-dns-deployments