### PR TITLE
Update most 10 popular paths to cache clear

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/clear_cdn_cache.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/clear_cdn_cache.yaml.erb
@@ -22,14 +22,14 @@
           # 10 most popular pages based on GA 1-year stats
           declare -a paths=(
             "/"
-            "/calculate-your-child-maintenance"
-            "/check-vehicle-tax"
-            "/get-information-about-a-company"
-            "/government/organisations/companies-house"
-            "/government/organisations/hm-revenue-customs"
-            "/search"
+            "/check-mot-history"
+            "/coronavirus"
+            "/get-coronavirus-test"
+            "/log-in-register-hmrc-online-services"
+            "/report-covid19-result"
+            "/search/all"
+            "/sign-in-universal-credit"
             "/sold-bought-vehicle"
-            "/state-pension-age"
             "/vehicle-tax"
           )
 


### PR DESCRIPTION
[Card in 2nd line trello](https://trello.com/c/JUZX5TiZ/1161-update-popular-paths-in-clear-cdn-cache-jobdraft)

Platform health have plans to make this dynamic. Alex has raised a PR that [reads the most popular over the last 2 weeks](https://github.com/alphagov/govuk-puppet/pull/11133) 
from search-api. I'm not sure whether that's been tested yet. It'll  probably need to include some other pages (like the homepage) that are very visible, but don't feature in [that list](https://www.gov.uk/search/all).