### PR TITLE
GOV.UK Account SLO error rate Alerts

### DIFF
--- a/modules/monitoring/manifests/checks.pp
+++ b/modules/monitoring/manifests/checks.pp
@@ -49,6 +49,7 @@ class monitoring::checks (
   include monitoring::checks::grafana_dashboards
   include monitoring::checks::cdn_logs
   include monitoring::checks::whitehall
+  include monitoring::checks::accounts_slos
 
   include govuk::apps::email_alert_api::checks
   include govuk::apps::publisher::unprocessed_emails_count_check

--- a/modules/monitoring/manifests/checks/accounts_slos.pp
+++ b/modules/monitoring/manifests/checks/accounts_slos.pp
@@ -1,0 +1,45 @@
+# == Class: monitoring::checks::accounts_slos
+#
+# Nagios alerts for Account Team SLOs
+#
+# === Parameters
+#
+# [*enabled*]
+#   This variable enables to define whether to perform Account SLO checks. [This is set to 'true' by default.]
+class monitoring::checks::accounts_slos (
+  $enabled = true,
+  ){
+  if $enabled {
+    # Warn when error rate exeeds 1% in any 10 minute rolling window
+    $alert_warning_high_http_error_rate = 0.01
+
+    $http_bad_metric = 'sumSeries(transformNull(stats_counts.*.nginx_logs.account-api.http_{422,5*}))'
+    $http_all_metric = 'sumSeries(transformNull(stats_counts.*.nginx_logs.account-api.http_*))'
+
+    @@icinga::check::graphite { 'check_slo_error_rate_10_min_accounts':
+      target         => "divideSeries(integral(${http_bad_metric}), integral(${http_all_metric}))",
+      from           => '10mins',
+      warning        => $alert_warning_high_http_error_rate,
+      desc           => 'HTTP Error on GOV.UK Accounts has exceeded an acceptable threshold across the last 10 minutes',
+      notes_url      => monitoring_docs_url(slo-rate-checks-account),
+      host_name      => $::fqdn,
+      contact_groups => ['slack-channel-accounts-tech'],
+  }
+
+    $latency_bad_metric = 'transformNull(offset(scale(removeBelowValue(maxSeries(stats.timers.*.nginx_logs.account-api.time_request.upper_90),0.850),0),1))'
+    $latency_all_metric = 'offset(scale(transformNull(maxSeries(stats.timers.*.nginx_logs.account-api.time_request.upper_90)),0),1)'
+
+    # Warn when more than 1% of requests are 'too slow' in any 10 minute rolling window
+    $alert_warning_slow_http_response_rate = 0.01
+
+    @@icinga::check::graphite { 'check_slo_latency_rate_10_min_accounts':
+      target         => "divideSeries(integral(${latency_bad_metric}), integral(${latency_all_metric}))",
+      from           => '10mins',
+      warning        => $alert_warning_slow_http_response_rate,
+      desc           => 'Latency on GOV.UK Accounts has exceeded an acceptable threshold across the last 10 minutes',
+      notes_url      => monitoring_docs_url(slo-rate-checks-account),
+      host_name      => $::fqdn,
+      contact_groups => ['slack-channel-accounts-tech'],
+    }
+  }
+}

--- a/modules/monitoring/manifests/contacts.pp
+++ b/modules/monitoring/manifests/contacts.pp
@@ -236,4 +236,20 @@ class monitoring::contacts (
       members     => ['slack_search_team'],
     }
   }
+
+  # Accounts Team
+  if $slack_webhook_url {
+    icinga::slack_contact { 'slack_accounts_tech':
+      slack_webhook_url      => $slack_webhook_url,
+      slack_channel          => '#govuk-accounts-tech',
+      slack_username         => $slack_username,
+      icinga_status_cgi_url  => $slack_icinga_status_cgi_url,
+      icinga_extinfo_cgi_url => $slack_icinga_extinfo_cgi_url,
+    }
+
+    icinga::contact_group { 'slack-channel-accounts-tech':
+      group_alias => 'Contact #govuk-accounts-tech',
+      members     => ['slack_accounts_tech'],
+    }
+  }
 }


### PR DESCRIPTION
[Trello](https://trello.com/c/Crj6Z5SW/841-add-slack-alerts-for-when-we-drop-to-50-and-25-remaining-error-budget)

Adds:
- A contact group for GOV.UK accoutns so we can alert to our tech slack channel
- Adds two alerts related to early warning on our SLOs.

The basic gist of the alerts is, our over all target is less than 1% "bad" or "slow" HTTP responses over a 4 week window.
So these take a sample of the last rolling 10 mins. If we start seeing error rates exceeding 1%, warn our team 