### PR TITLE
Enable account authentication for email-alert-frontend in staging

### DIFF
--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -168,6 +168,7 @@ govuk::apps::email_alert_api::govuk_notify_template_id: '2844a647-6bf1-4b01-a25c
 govuk::apps::email_alert_api::govuk_notify_recipients:
   - email-alert-api-staging@digital.cabinet-office.gov.uk
 govuk::apps::email_alert_frontend::subscription_management_enabled: true
+govuk::apps::email_alert_frontend::account_auth_enabled: true
 govuk::apps::feedback::govuk_notify_reply_to_id: 'd1f54751-80a8-420a-9077-d34c7d6cc734'
 govuk::apps::feedback::govuk_notify_template_id: '8a8d98c0-42c8-4f56-b61f-77c89417a171'
 

--- a/modules/govuk/manifests/apps/email_alert_frontend.pp
+++ b/modules/govuk/manifests/apps/email_alert_frontend.pp
@@ -43,6 +43,9 @@
 # [*subscription_management_enabled*]
 #   Whether the subscription management interface is enabled.
 #
+# [*account_auth_enabled*]
+#   Whether users can log in with their GOV.UK Account.
+#
 class govuk::apps::email_alert_frontend(
   $vhost = 'email-alert-frontend',
   $port,
@@ -54,6 +57,7 @@ class govuk::apps::email_alert_frontend(
   $email_alert_api_bearer_token = undef,
   $email_alert_auth_token = undef,
   $subscription_management_enabled = false,
+  $account_auth_enabled = false,
 ) {
   $app_name = 'email-alert-frontend'
 
@@ -96,6 +100,13 @@ class govuk::apps::email_alert_frontend(
     govuk::app::envvar { "${title}-SUBSCRIPTION_MANAGEMENT_ENABLED":
       varname => 'SUBSCRIPTION_MANAGEMENT_ENABLED',
       value   => 'yes';
+    }
+  }
+
+  if $account_auth_enabled {
+    govuk::app::envvar { "${title}-FEATURE_FLAG_GOVUK_ACCOUNT":
+      varname => 'FEATURE_FLAG_GOVUK_ACCOUNT',
+      value   => 'enabled';
     }
   }
 }


### PR DESCRIPTION
See also https://github.com/alphagov/email-alert-frontend/pull/1076

---

[Trello card](https://trello.com/c/H0gos8kf/873-backend-work-to-allow-logging-in-to-email-alert-frontend-with-an-account)