### PR TITLE
Fix Account SLOs need a critical threshold

### DIFF
--- a/modules/monitoring/manifests/checks/accounts_slos.pp
+++ b/modules/monitoring/manifests/checks/accounts_slos.pp
@@ -12,6 +12,8 @@ class monitoring::checks::accounts_slos (
   if $enabled {
     # Warn when error rate exeeds 1% in any 10 minute rolling window
     $alert_warning_high_http_error_rate = 0.01
+    # Turns out puppet gets sad when we don't have a critical, so set it so something impossible.
+    $critical_warning_high_http_error_rate = 2
 
     $http_bad_metric = 'sumSeries(transformNull(stats_counts.*.nginx_logs.account-api.http_{422,5*}))'
     $http_all_metric = 'sumSeries(transformNull(stats_counts.*.nginx_logs.account-api.http_*))'
@@ -20,6 +22,7 @@ class monitoring::checks::accounts_slos (
       target         => "divideSeries(integral(${http_bad_metric}), integral(${http_all_metric}))",
       from           => '10mins',
       warning        => $alert_warning_high_http_error_rate,
+      critical       => $critical_warning_high_http_error_rate,
       desc           => 'HTTP Error on GOV.UK Accounts has exceeded an acceptable threshold across the last 10 minutes',
       notes_url      => monitoring_docs_url(slo-rate-checks-account),
       host_name      => $::fqdn,
@@ -31,11 +34,14 @@ class monitoring::checks::accounts_slos (
 
     # Warn when more than 1% of requests are 'too slow' in any 10 minute rolling window
     $alert_warning_slow_http_response_rate = 0.01
+    # Turns out puppet gets sad when we don't have a critical, so set it so something impossible.
+    $alert_critical_slow_http_response_rate = 2
 
     @@icinga::check::graphite { 'check_slo_latency_rate_10_min_accounts':
       target         => "divideSeries(integral(${latency_bad_metric}), integral(${latency_all_metric}))",
       from           => '10mins',
       warning        => $alert_warning_slow_http_response_rate,
+      critical       => $alert_critical_slow_http_response_rate,
       desc           => 'Latency on GOV.UK Accounts has exceeded an acceptable threshold across the last 10 minutes',
       notes_url      => monitoring_docs_url(slo-rate-checks-account),
       host_name      => $::fqdn,


### PR DESCRIPTION
In commit x looks like I made puppet really sad.

```
Error: Could not retrieve catalog from remote server: Error 400 on
SERVER: Must pass critical to
Icinga::Check::Graphite[check_slo_error_rate_10_min_accounts] at
/usr/share/puppet/production/current/modules/monitoring/manifests/checks/accounts_slos.pp:27

Warning: Not using cache on failed catalog Error: Could not retrieve
catalog; skipping run
```

I believe this is because i had the bright idea to only set this up as a
warning. Mostly because it's an alert as an SLO early warning, and
critical seemed a bit alarmist.

So I've added a critical status as if we exceed 10% of an error budget
in a rolling 10 minute window. That'd be 10 times worse than the
warning, so seems fair.