### PR TITLE
Disable account SLO alerts in integration

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -354,6 +354,7 @@ monitoring::checks::aws_iam_key::enabled: true
 monitoring::checks::aws_iam_key::region: 'eu-west-1'
 monitoring::checks::aws_iam_key::max_aws_iam_key_age: 320
 monitoring::checks::whitehall::check_period: "never"
+monitoring::checks::accounts_slos::enabled: false
 
 monitoring::checks::lb::region: 'eu-west-1'
 monitoring::checks::lb::loadbalancers: # prefer "internal"

--- a/modules/monitoring/manifests/checks/accounts_slos.pp
+++ b/modules/monitoring/manifests/checks/accounts_slos.pp
@@ -19,7 +19,7 @@ class monitoring::checks::accounts_slos (
     $http_all_metric = 'sumSeries(transformNull(stats_counts.*.nginx_logs.account-api.http_*))'
 
     @@icinga::check::graphite { 'check_slo_error_rate_10_min_accounts':
-      target         => "divideSeries(integral(${http_bad_metric}), integral(${http_all_metric}))",
+      target         => "divideSeries(integral(${http_bad_metric}),integral(${http_all_metric}))",
       from           => '10mins',
       warning        => $alert_warning_high_http_error_rate,
       critical       => $critical_warning_high_http_error_rate,
@@ -38,7 +38,7 @@ class monitoring::checks::accounts_slos (
     $alert_critical_slow_http_response_rate = 2
 
     @@icinga::check::graphite { 'check_slo_latency_rate_10_min_accounts':
-      target         => "divideSeries(integral(${latency_bad_metric}), integral(${latency_all_metric}))",
+      target         => "divideSeries(integral(${latency_bad_metric}),integral(${latency_all_metric}))",
       from           => '10mins',
       warning        => $alert_warning_slow_http_response_rate,
       critical       => $alert_critical_slow_http_response_rate,


### PR DESCRIPTION
There's not much traffic so these are pretty flappy.

Also remove a space from the metric targets, as I think it prevented
the metric from rendering properly when I clicked the "action" link in
the alert to see the graphite output.