### PR TITLE
Rewrite publisher route to organization (Only merge in after CKAN 2.9 released)

### DIFF
--- a/modules/govuk/templates/ckan/nginx.conf.erb
+++ b/modules/govuk/templates/ckan/nginx.conf.erb
@@ -71,6 +71,11 @@ location /api/3<%= path %> {
 }
 <% end %>
 
+# Rewrite publisher to organization for CKAN 2.9 in case it has been bookmarked
+location /publisher {
+  rewrite ^(.*)/publisher(/.*)?$ $1/organization$2 last;
+}
+
 location /csw {
   <%- if @protected -%>
   deny all;


### PR DESCRIPTION
## What

CKAN 2.9 doesn't have the publisher route, so rewrite any urls going to publisher to go to organization instead.
