### PR TITLE
Change account SLO metric to use a movingMedian over 30s

### DIFF
--- a/modules/monitoring/manifests/checks/accounts_slos.pp
+++ b/modules/monitoring/manifests/checks/accounts_slos.pp
@@ -10,19 +10,15 @@ class monitoring::checks::accounts_slos (
   $enabled = true,
   ){
   if $enabled {
-    # Warn when error rate exeeds 1% in any 10 minute rolling window
-    $alert_warning_high_http_error_rate = 0.01
-    # Turns out puppet gets sad when we don't have a critical, so set it so something impossible.
-    $critical_warning_high_http_error_rate = 2
-
     $http_bad_metric = 'sumSeries(transformNull(stats_counts.*.nginx_logs.account-api.http_{422,5*}))'
     $http_all_metric = 'sumSeries(transformNull(stats_counts.*.nginx_logs.account-api.http_*))'
+    $alert_warning_high_http_error_rate = 0.01
 
     @@icinga::check::graphite { 'check_slo_error_rate_10_min_accounts':
-      target         => "divideSeries(integral(${http_bad_metric}),integral(${http_all_metric}))",
+      target         => "movingMedian(divideSeries(${http_bad_metric},${http_all_metric}),\"30s\")",
       from           => '10mins',
       warning        => $alert_warning_high_http_error_rate,
-      critical       => $critical_warning_high_http_error_rate,
+      critical       => 1,
       desc           => 'HTTP Error on GOV.UK Accounts has exceeded an acceptable threshold across the last 10 minutes',
       notes_url      => monitoring_docs_url(slo-rate-checks-account),
       host_name      => $::fqdn,
@@ -31,17 +27,13 @@ class monitoring::checks::accounts_slos (
 
     $latency_bad_metric = 'transformNull(offset(scale(removeBelowValue(maxSeries(stats.timers.*.nginx_logs.account-api.time_request.upper_90),0.850),0),1))'
     $latency_all_metric = 'offset(scale(transformNull(maxSeries(stats.timers.*.nginx_logs.account-api.time_request.upper_90)),0),1)'
-
-    # Warn when more than 1% of requests are 'too slow' in any 10 minute rolling window
     $alert_warning_slow_http_response_rate = 0.01
-    # Turns out puppet gets sad when we don't have a critical, so set it so something impossible.
-    $alert_critical_slow_http_response_rate = 2
 
     @@icinga::check::graphite { 'check_slo_latency_rate_10_min_accounts':
-      target         => "divideSeries(integral(${latency_bad_metric}),integral(${latency_all_metric}))",
+      target         => "movingMedian(divideSeries(${latency_bad_metric},${latency_all_metric}),\"30s\")",
       from           => '10mins',
       warning        => $alert_warning_slow_http_response_rate,
-      critical       => $alert_critical_slow_http_response_rate,
+      critical       => 1,
       desc           => 'Latency on GOV.UK Accounts has exceeded an acceptable threshold across the last 10 minutes',
       notes_url      => monitoring_docs_url(slo-rate-checks-account),
       host_name      => $::fqdn,


### PR DESCRIPTION
Using the total error rate,

    divideSeries(integral($errors),integral($all))

Is far too noisy, at least with the volume of traffic we get.  It
looks like every single slow request is triggering the alert, spamming
our channel.  We're nowhere near running out of error budget, so this
sensitivity is too much.

So to make it less noisy, I've changed the metric to use the average
SLO violation rate over 30 seconds.  This smooths out spikes, but will
still quickly detect a real issue.

I've also changed the critical threshold to 1, which improves the
graph scale.  So now we'll raise a critical if *every* request is
violating the SLO, whereas previously we wouldn't.  That seems a
pretty bad problem so I'm ok with that.