### PR TITLE
Add interest cohort permission policy

### DIFF
--- a/modules/nginx/files/etc/nginx/add-permissions-policy.conf
+++ b/modules/nginx/files/etc/nginx/add-permissions-policy.conf
@@ -1,0 +1,1 @@
+add_header Permissions-Policy interest-cohort=();

--- a/modules/nginx/templates/proxy-vhost.conf
+++ b/modules/nginx/templates/proxy-vhost.conf
@@ -52,6 +52,8 @@ server {
   # Send the Strict-Transport-Security header
   include /etc/nginx/add-sts.conf;
 
+  include /etc/nginx/add-permissions-policy.conf;
+
   <%- if port == 443 -%>
   listen              443 ssl<%= $is_default_vhost ? " default_server" : "" %>;
   ssl_certificate     /etc/nginx/ssl/<%= @name %>.crt;


### PR DESCRIPTION
Add header to our Nginx config to set the permission policy header such
that `interest-cohort=()`. This follows on from [RFC 142]((https://github.com/alphagov/govuk-rfcs/blob/main/rfc-142-add-interest-cohort-permssion-policy-header.md)

Co-authored-by: Richard Towers <richard.towers@digital.cabinet-office.gov.uk>
Co-authored-by: Himal Mandalia <himal.mandalia@digital.cabinet-office.gov.uk>