### PR TITLE
Allow /sign-in/callback to set cookies

### DIFF
--- a/modules/varnish/templates/default.vcl.erb
+++ b/modules/varnish/templates/default.vcl.erb
@@ -85,7 +85,7 @@ sub vcl_recv {
   #   - email-alert-frontend (for subscription management)
   #   - frontend (for sessions across funding registration form)
   #   - smart answers coronavirus find support flow
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/brexit-eu-funding" && req.url !~ "^/find-coronavirus-support")
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/brexit-eu-funding" && req.url !~ "^/find-coronavirus-support" && req.url !~ "^/sign-in/callback")
   {
     unset req.http.Cookie;
   }
@@ -122,7 +122,7 @@ sub vcl_fetch {
 
   <% if @strip_cookies %>
   # Strip cookies from outbound requests. Corresponding rule in vcl_recv{}
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/brexit-eu-funding" && req.url !~ "^/find-coronavirus-support") {
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/brexit-eu-funding" && req.url !~ "^/find-coronavirus-support" && req.url !~ "^/sign-in/callback") {
     unset beresp.http.Set-Cookie;
   }
   <% end %>


### PR DESCRIPTION
This is so we can set the cookies_policy when a user signs in, if they
have persisted a cookie consent to their account.