### PR TITLE
Fix: Prometheus liveness check is /-/healthy not /-/live.

### DIFF
--- a/modules/govuk/manifests/apps/prometheus.pp
+++ b/modules/govuk/manifests/apps/prometheus.pp
@@ -26,7 +26,7 @@ class govuk::apps::prometheus (
   # the front end of the LB (unnecessarily confusing).
   concat::fragment { 'prometheus_lb_healthcheck_live':
     target  => '/etc/nginx/lb_healthchecks.conf',
-    content => "location /-/live {\n  proxy_pass http://prometheus-proxy/-/live;\n}\n",
+    content => "location /-/healthy {\n  proxy_pass http://prometheus-proxy/-/healthy;\n}\n",
   }
   concat::fragment { 'prometheus_lb_healthcheck_ready':
     target  => '/etc/nginx/lb_healthchecks.conf',


### PR DESCRIPTION
I messed this up in 9e32a54. We're not actively using this at the moment but might as well get it right.