### PR TITLE
Redirect publisher route to organization (Only merge after CKAN 2.9 upgraded)

### DIFF
--- a/modules/govuk/templates/ckan/nginx.conf.erb
+++ b/modules/govuk/templates/ckan/nginx.conf.erb
@@ -71,6 +71,11 @@ location /api/3<%= path %> {
 }
 <% end %>
 
+# Redirect publisher to organization for CKAN 2.9 in case it has been bookmarked
+location ~ "^\/publisher(.*)" {
+  return 301 /organization$1$query_string;
+}
+
 location /csw {
   <%- if @protected -%>
   deny all;


### PR DESCRIPTION
## What

CKAN 2.9 doesn't have the publisher route, so rewrite any urls going to publisher to go to organization instead

## Reference

https://trello.com/c/DZJFi8z5/2613-create-prs-to-prep-for-29-upgrade
