### PR TITLE
Fix permissions on mirror_root for crawler_work

### DIFF
--- a/modules/govuk/manifests/apps/govuk_crawler_worker.pp
+++ b/modules/govuk/manifests/apps/govuk_crawler_worker.pp
@@ -97,6 +97,7 @@ class govuk::apps::govuk_crawler_worker (
       mode   => '0755',
       owner  => 'deploy',
       group  => 'deploy',
+      recurse => true,
     }
 
     if $disable_during_data_sync and $::data_sync_in_progress {


### PR DESCRIPTION
The permissions for the mirror_root (/mnt/crawler_worker) on the mirrorer
machines can sometimes change through normal work and break the mirror
synchronisation cronjob.

This occurs because linux users are non-determiniscally provisioned via
puppet, meaning that UserA on one machine might have an uid and gid of
1025:1025, whereas another machine UserA might be 1040:1040.  As the
mirror_root (/mnt/crawler_worker) is actually mounted from a seperate
persistent EBS volume, the file permissions from the original machine
which created the files and directories, will not work on other machines
which subsequently use the EBS volume.

To solve this problem the ownership of the mirror_root directory, with
all child directories and files, need to be reset after the mirror
machine is respun.  This could be either done manually after a respin,
or managed by puppet - which this PR does.

By recursively changing the ownership on the mirror_root it will fix
the problem.  The time taken to apply this change is ~30sec when all
directories and files need changing after a respin, and only <1sec on
subsequent runs.