### PR TITLE
Set up sidekiq for account-api

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -432,6 +432,7 @@ govuk::apps::content_data_api::port: 3235
 # search-admin sidekiq monitoring uses 3241
 # sidekiq monitoring uses 3242
 govuk::apps::account_api::port: 3243
+# account-api sidekiq monitoring uses 3244
 
 govuk::apps::asset_manager::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
 govuk::apps::asset_manager::mongodb_nodes:
@@ -680,6 +681,8 @@ govuk::apps::service_manual_publisher::db::backend_ip_range: "%{hiera('environme
 govuk::apps::service_manual_publisher::db::allow_auth_from_lb: true
 govuk::apps::service_manual_publisher::db::lb_ip_range: "%{hiera('environment_ip_prefix')}.0.0/16"
 
+govuk::apps::sidekiq_monitoring::account_api_redis_host: "%{hiera('govuk::apps::account_api::redis_host')}"
+govuk::apps::sidekiq_monitoring::account_api_redis_port: "%{hiera('govuk::apps::account_api::redis_port')}"
 govuk::apps::sidekiq_monitoring::asset_manager_redis_host: "%{hiera('govuk::apps::asset_manager::redis_host')}"
 govuk::apps::sidekiq_monitoring::asset_manager_redis_port: "%{hiera('govuk::apps::asset_manager::redis_port')}"
 govuk::apps::sidekiq_monitoring::collections_publisher_redis_host: "%{hiera('govuk::apps::collections_publisher::redis_host')}"
@@ -786,6 +789,8 @@ govuk::apps::account_api::db::lb_ip_range: "%{hiera('environment_ip_prefix')}.0.
 govuk::apps::account_api::enable_publishing_queue_listener: true
 govuk::apps::account_api::rabbitmq::enabled: true
 govuk::apps::account_api::rabbitmq_hosts: [rabbitmq]
+govuk::apps::account_api::redis_host: "%{hiera('sidekiq_host')}"
+govuk::apps::account_api::redis_port: "%{hiera('sidekiq_port')}"
 
 govuk_awscli::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk_awscli::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
@@ -1158,7 +1163,9 @@ grafana::repo::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint'
 grafana::dashboards::app_domain: "%{hiera('app_domain')}"
 grafana::dashboards::machine_suffix_metrics: ''
 grafana::dashboards::application_dashboards:
-  account-api: {}
+  account-api:
+    show_sidekiq_graphs: true
+    has_workers: true
   asset-manager:
     show_sidekiq_graphs: true
     has_workers: true

--- a/modules/govuk/manifests/apps/account_api.pp
+++ b/modules/govuk/manifests/apps/account_api.pp
@@ -52,6 +52,10 @@
 #   RabbitMQ password.
 #   Default 'account_api'
 #
+# [*enable_procfile_worker*]
+#   Run the sidekiq worker.
+#   Default: false
+#
 # [*enable_publishing_queue_listener*]
 #   Run the worker which processes publishing updates.
 #   Default: false
@@ -71,6 +75,14 @@
 # [*session_signing_key*]
 #   Secret key to sign user session data with
 #
+# [*redis_host*]
+#   Redis host for Sidekiq.
+#   Default: undef
+#
+# [*redis_port*]
+#   Redis port for Sidekiq.
+#   Default: undef
+#
 class govuk::apps::account_api (
   $port,
   $enabled = true,
@@ -87,12 +99,15 @@ class govuk::apps::account_api (
   $rabbitmq_hosts = ['localhost'],
   $rabbitmq_user = 'account_api',
   $rabbitmq_password = 'account_api',
+  $enable_procfile_worker = false,
   $enable_publishing_queue_listener = false,
   $account_oauth_client_id = undef,
   $account_oauth_client_secret = undef,
   $plek_account_manager_uri = undef,
   $email_alert_api_bearer_token = undef,
   $session_signing_key = undef,
+  $redis_host = undef,
+  $redis_port = undef,
 ) {
   $app_name = 'account-api'
 
@@ -156,7 +171,18 @@ class govuk::apps::account_api (
     password => $rabbitmq_password,
   }
 
+  govuk::app::envvar::redis { 'account-api':
+    host => $redis_host,
+    port => $redis_port,
+  }
+
+  govuk::procfile::worker {'account-api':
+    ensure         => $ensure,
+    enable_service => $enable_procfile_worker,
+  }
+
   govuk::procfile::worker { 'account-api-publishing-queue-listener':
+    ensure         => $ensure,
     setenv_as      => $app_name,
     enable_service => $enable_publishing_queue_listener,
     process_type   => 'publishing-queue-listener',

--- a/modules/govuk/manifests/apps/sidekiq_monitoring.pp
+++ b/modules/govuk/manifests/apps/sidekiq_monitoring.pp
@@ -8,6 +8,14 @@
 #   sidekiq-monitoring app can be found.
 #   Default: /data/vhost/{value based on app name and domain}/current/public
 #
+# [*account_api_redis_host*]
+#   Redis host for Account API Sidekiq.
+#   Default: undef
+#
+# [*account_api_redis_port*]
+#   Redis port for Account API Sidekiq.
+#   Default: undef
+#
 # [*asset_manager_redis_host*]
 #   Redis host for Asset Manager Sidekiq.
 #   Default: undef
@@ -178,6 +186,8 @@
 #
 class govuk::apps::sidekiq_monitoring (
   $nginx_location = undef,
+  $account_api_redis_host = undef,
+  $account_api_redis_port = undef,
   $asset_manager_redis_host = undef,
   $asset_manager_redis_port = undef,
   $collections_publisher_redis_host = undef,
@@ -261,6 +271,11 @@ class govuk::apps::sidekiq_monitoring (
   }
 
   govuk::app::envvar::redis{
+    "${app_name}_account_api":
+      prefix => 'account_api',
+      host   => $account_api_redis_host,
+      port   => $account_api_redis_port;
+
     "${app_name}_asset_manager":
       prefix => 'asset_manager',
       host   => $asset_manager_redis_host,

--- a/modules/govuk/templates/sidekiq_monitoring_nginx_config.conf.erb
+++ b/modules/govuk/templates/sidekiq_monitoring_nginx_config.conf.erb
@@ -18,6 +18,10 @@ server {
     proxy_pass http://localhost:3242;
   }
 
+  location /account-api {
+    proxy_pass http://localhost:3244;
+  }
+
   location /asset-manager {
     proxy_pass http://localhost:3038;
   }


### PR DESCRIPTION
We're setting up sidekiq for account-api, which means we need to set
up redis env vars for it first.  When this commit has been deployed,
we can deploy account-api with the new worker code, and then deploy a
second puppet change to enable the worker.

This commit also sets up sidekiq-monitoring and the application
dashboard.  Those won't have any metrics to show until the worker is
enabled though.

---

[Trello card](https://trello.com/c/uRW8OS61/907-move-expired-authrequest-deletion-to-sidekiq)