### PR TITLE
Add account-manager Plek env var to finder-frontend

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -544,6 +544,7 @@ govuk::apps::finder_frontend::enabled: true
 govuk::apps::finder_frontend::unicorn_worker_processes: "6"
 
 govuk::apps::frontend::elections_api_url: "https://api.electoralcommission.org.uk/api/v1"
+govuk::apps::frontend::plek_account_manager_uri: "%{hiera('govuk::apps::account_api::plek_account_manager_uri')}"
 govuk::apps::frontend::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::frontend::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::frontend::unicorn_worker_processes: "4"
@@ -753,6 +754,7 @@ govuk::apps::smokey::smokey_govuk_account_password: "%{hiera('smokey_govuk_accou
 govuk::apps::smokey::smokey_bearer_token: "%{hiera('smokey_bearer_token')}"
 govuk::apps::smokey::rate_limit_token: "%{hiera('smokey_rate_limit_token')}"
 
+govuk::apps::static::plek_account_manager_uri: "%{hiera('govuk::apps::account_api::plek_account_manager_uri')}"
 govuk::apps::static::asset_host: "%{hiera('govuk::deploy::config::website_root')}"
 govuk::apps::static::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::static::redis_port: "%{hiera('sidekiq_port')}"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -542,6 +542,7 @@ govuk::apps::email_alert_service::rabbitmq::queue_size_warning_threshold: 5
 
 govuk::apps::finder_frontend::enabled: true
 govuk::apps::finder_frontend::unicorn_worker_processes: "6"
+govuk::apps::finder_frontend::plek_account_manager_uri: "%{hiera('govuk::apps::account_api::plek_account_manager_uri')}"
 
 govuk::apps::frontend::elections_api_url: "https://api.electoralcommission.org.uk/api/v1"
 govuk::apps::frontend::plek_account_manager_uri: "%{hiera('govuk::apps::account_api::plek_account_manager_uri')}"

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -41,7 +41,6 @@ govuk::apps::email_alert_frontend::account_confirm_email_url: "https://www.accou
 govuk::apps::email_alert_frontend::account_change_email_url: "https://www.account.staging.publishing.service.gov.uk/account/manage"
 govuk::apps::feedback::govuk_notify_reply_to_id: 'fee22233-2f28-4b0b-8b6c-4410979f2275'
 govuk::apps::feedback::govuk_notify_template_id: 'eb9ba220-7d74-4aab-975a-bdbe718f69a3'
-govuk::apps::frontend::plek_account_manager_uri: 'https://www.account.staging.publishing.service.gov.uk'
 govuk::apps::frontend::govuk_notify_template_id: '1fc69d3a-09a2-40f9-852b-03f6fcef5340'
 govuk::apps::frontend::memcache_servers: 'frontend-memcached:11211'
 govuk::apps::frontend::feature_flag_save_a_page: true
@@ -77,7 +76,6 @@ govuk::apps::specialist_publisher::aws_region: 'eu-west-1'
 govuk::apps::specialist_publisher::aws_s3_bucket_name: 'govuk-integration-specialist-publisher-csvs'
 govuk::apps::specialist_publisher::publish_pre_production_finders: true
 govuk::apps::specialist_publisher::govuk_notify_template_id: "759acac6-da53-4a19-b591-b7538c7c39de"
-govuk::apps::static::plek_account_manager_uri: 'https://www.account.staging.publishing.service.gov.uk'
 govuk::apps::static::ga_universal_id: 'UA-26179049-22'
 govuk::apps::support::aws_s3_bucket_name: 'govuk-integration-support-api-csvs'
 govuk::apps::support_api::aws_s3_bucket_name: 'govuk-integration-support-api-csvs'

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -198,7 +198,6 @@ govuk::apps::feedback::govuk_notify_template_id: '54168fa9-3946-4860-a2f8-27ddbb
 # https://docs.google.com/document/d/1kdRhmMUIyNZQmgo4FvXswJaDN2CWS2vlH9PVu21a68k/edit#
 govuk::apps::finder_frontend::unicorn_worker_processes: 48
 
-govuk::apps::frontend::plek_account_manager_uri: 'https://www.account.publishing.service.gov.uk'
 govuk::apps::frontend::govuk_notify_template_id: 'cb633abc-6ae6-4843-ae6f-82ca500b6de2'
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::licencefinder::elasticsearch_uri: 'https://vpc-blue-elasticsearch6-domain-2hnib7uydv3tgebhabx74gdelq.eu-west-1.es.amazonaws.com'
@@ -233,7 +232,6 @@ govuk::apps::specialist_publisher::aws_region: 'eu-west-1'
 govuk::apps::specialist_publisher::aws_s3_bucket_name: 'govuk-production-specialist-publisher-csvs'
 govuk::apps::specialist_publisher::enabled: true
 govuk::apps::specialist_publisher::govuk_notify_template_id: "e00e89f5-b622-4dcb-8f30-e6c70231a940"
-govuk::apps::static::plek_account_manager_uri: 'https://www.account.publishing.service.gov.uk'
 govuk::apps::static::ga_universal_id: 'UA-26179049-1'
 govuk::apps::support::zendesk_anonymous_ticket_email: 'zd-api-public@digital.cabinet-office.gov.uk'
 govuk::apps::support::zendesk_client_username: 'zd-api-govt@digital.cabinet-office.gov.uk/token'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -177,7 +177,6 @@ govuk::apps::feedback::govuk_notify_template_id: '8a8d98c0-42c8-4f56-b61f-77c894
 # https://github.com/alphagov/govuk-aws-data/pull/827
 govuk::apps::finder_frontend::unicorn_worker_processes: 24
 
-govuk::apps::frontend::plek_account_manager_uri: 'https://www.account.staging.publishing.service.gov.uk'
 govuk::apps::frontend::govuk_notify_template_id: '2844a647-6bf1-4b01-a25c-569d2cc00849'
 govuk::apps::frontend::feature_flag_save_a_page: true
 govuk::apps::government_frontend::feature_flag_save_a_page: true
@@ -224,7 +223,6 @@ govuk::apps::specialist_publisher::aws_region: 'eu-west-1'
 govuk::apps::specialist_publisher::aws_s3_bucket_name: 'govuk-staging-specialist-publisher-csvs'
 govuk::apps::specialist_publisher::enabled: true
 govuk::apps::specialist_publisher::govuk_notify_template_id: "112842bb-d8a4-4511-90de-57dc5c8f27ec"
-govuk::apps::static::plek_account_manager_uri: 'https://www.account.staging.publishing.service.gov.uk'
 govuk::apps::static::ga_universal_id: 'UA-26179049-20'
 govuk::apps::support::aws_s3_bucket_name: 'govuk-staging-support-api-csvs'
 govuk::apps::support_api::pp_data_url: 'https://www.staging.performance.service.gov.uk'

--- a/modules/govuk/manifests/apps/finder_frontend.pp
+++ b/modules/govuk/manifests/apps/finder_frontend.pp
@@ -18,6 +18,9 @@
 # [*account_api_bearer_token*]
 #   Bearer token for communication with the account-api
 #
+# [*plek_account_manager_uri*]
+#   Path to the GOV.UK Account Manager
+#
 class govuk::apps::finder_frontend(
   $port,
   $enabled = false,
@@ -26,6 +29,7 @@ class govuk::apps::finder_frontend(
   $email_alert_api_bearer_token = undef,
   $account_api_bearer_token = undef,
   $unicorn_worker_processes = undef,
+  $plek_account_manager_uri = undef,
 ) {
 
   if $enabled {
@@ -59,6 +63,8 @@ class govuk::apps::finder_frontend(
     "${title}-SECRET_KEY_BASE":
         varname => 'SECRET_KEY_BASE',
         value   => $secret_key_base;
+    "${title}-PLEK-ACCOUNT-MANAGER-URI":
+        varname => 'PLEK_SERVICE_ACCOUNT_MANAGER_URI',
+        value   => $plek_account_manager_uri;
   }
-
 }


### PR DESCRIPTION
We want to show a notice at the top of the Transition Checker results
page prompting the user to confirm their email address if they haven't
already, and so we need to know the URL of the account-manager so that
we can link to the "send a new confirmation" page.

See also https://github.com/alphagov/finder-frontend/pull/2585

---

[Trello card](https://trello.com/c/JuzRNvA4/832-remove-the-email-signup-from-the-transition-checker-registration-journey)