### PR TITLE
Disable harvest workers and set ckan maintenance redirect (Only merge when initiating CKAN 2.9 upgrade)

### DIFF
--- a/hieradata_aws/class/integration/ckan.yaml
+++ b/hieradata_aws/class/integration/ckan.yaml
@@ -3,5 +3,13 @@
 govuk_solr::disable: true
 govuk_solr6::present: true
 
+govuk::apps::ckan::blanket_redirect_url: https://find-data-beta-integration.cloudapps.digital/ckan_maintenance
+
+govuk::apps::ckan::enable_harvester_fetch: false
+govuk::apps::ckan::enable_harvester_gather: false
+
+govuk::apps::ckan::cronjobs::enable: false
+govuk::apps::ckan::cronjobs::enable_solr_reindex: false
+
 govuk::apps::ckan::solr_core: ckan
 govuk::apps::ckan::solr_core_configset: ckan28

--- a/hieradata_aws/class/production/ckan.yaml
+++ b/hieradata_aws/class/production/ckan.yaml
@@ -3,7 +3,16 @@
 govuk_solr::disable: true
 govuk_solr6::present: true
 
+govuk::apps::ckan::enabled: true
+
+govuk::apps::ckan::blanket_redirect_url: https://data.gov.uk/ckan_maintenance
+
+govuk::apps::ckan::enable_harvester_fetch: false
+govuk::apps::ckan::enable_harvester_gather: false
+
+govuk::apps::ckan::cronjobs::enable: false
+govuk::apps::ckan::cronjobs::enable_solr_reindex: false
+
 govuk::apps::ckan::solr_core: ckan
 govuk::apps::ckan::solr_core_configset: ckan28
 
-govuk::apps::ckan::enabled: true

--- a/hieradata_aws/class/staging/ckan.yaml
+++ b/hieradata_aws/class/staging/ckan.yaml
@@ -3,7 +3,15 @@
 govuk_solr::disable: true
 govuk_solr6::present: true
 
+govuk::apps::ckan::enabled: true
+
+govuk::apps::ckan::blanket_redirect_url: https://find-data-beta-staging.cloudapps.digital/ckan_maintenance
+
+govuk::apps::ckan::enable_harvester_fetch: false
+govuk::apps::ckan::enable_harvester_gather: false
+
+govuk::apps::ckan::cronjobs::enable: false
+govuk::apps::ckan::cronjobs::enable_solr_reindex: false
+
 govuk::apps::ckan::solr_core: ckan
 govuk::apps::ckan::solr_core_configset: ckan28
-
-govuk::apps::ckan::enabled: true


### PR DESCRIPTION
## What

Disable CKAN harvest workers and set the site wide redirect to the CKAN maintenance page.

## Reference 

https://trello.com/c/DZJFi8z5/2613-create-prs-to-prep-for-29-upgrade 