### PR TITLE
Upgrade ckan 2.9 (Only merge after CKAN redirection to maintenance page)

### DIFF
--- a/modules/govuk/manifests/apps/ckan.pp
+++ b/modules/govuk/manifests/apps/ckan.pp
@@ -170,7 +170,7 @@ class govuk::apps::ckan (
       process_regex  => 'pycsw\.wsgi',
     }
 
-    class { 'cronjobs29':
+    class { 'cronjobs':
       ckan_port    => $port,
       pycsw_config => $pycsw_config,
     }

--- a/modules/govuk/manifests/apps/ckan.pp
+++ b/modules/govuk/manifests/apps/ckan.pp
@@ -97,25 +97,14 @@ class govuk::apps::ckan (
   $ckan_home = '/var/ckan'
   $pycsw_config = "${ckan_home}/pycsw.cfg"
 
-  if ($::aws_environment == 'integration') {
-    $ckan_ini  = "${ckan_home}/ckan29.ini"
-    $who_ini = "${ckan_home}/who29.ini"
-    $govuk_ckan_ini = 'govuk/ckan/ckan29.ini.erb'
-    $govuk_who_ini = 'govuk/ckan/who29.ini.erb'
-    $collectd_process_regex = '\/gunicorn .* \/var\/ckan\/ckan29\.ini'
-    $fetch_process_regex = '\/python \.\/venv3\/bin\/ckan -c \/var\/ckan\/ckan29\.ini harvester fetch-consumer'
-    $gather_process_regex = '\/python \.\/venv3\/bin\/ckan -c \/var\/ckan\/ckan29\.ini harvester gather-consumer'
-    $pycsw_cmd = 'ckan ckan-pycsw'
-  } else {
-    $ckan_ini  = "${ckan_home}/ckan.ini"
-    $who_ini = "${ckan_home}/who.ini"
-    $govuk_ckan_ini = 'govuk/ckan/ckan.ini.erb'
-    $govuk_who_ini = 'govuk/ckan/who.ini.erb'
-    $collectd_process_regex = '\/gunicorn .* \/var\/ckan\/ckan\.ini'
-    $fetch_process_regex = '\/python \.\/venv\/bin\/paster --plugin=ckanext-harvest harvester fetch\_consumer'
-    $gather_process_regex = '\/python \.\/venv\/bin\/paster --plugin=ckanext-harvest harvester gather\_consumer'
-    $pycsw_cmd = 'paster --plugin=ckanext-spatial ckan-pycsw'
-  }
+  $ckan_ini = "${ckan_home}/ckan29.ini"
+  $who_ini = "${ckan_home}/who29.ini"
+  $govuk_ckan_ini = 'govuk/ckan/ckan29.ini.erb'
+  $govuk_who_ini = 'govuk/ckan/who29.ini.erb'
+  $collectd_process_regex = '\/gunicorn .* \/var\/ckan\/ckan29\.ini'
+  $fetch_process_regex = '\/python \.\/venv3\/bin\/ckan -c \/var\/ckan\/ckan29\.ini harvester fetch-consumer'
+  $gather_process_regex = '\/python \.\/venv3\/bin\/ckan -c \/var\/ckan\/ckan29\.ini harvester gather-consumer'
+  $pycsw_cmd = 'ckan ckan-pycsw'
 
   $request_timeout = 60
 
@@ -181,16 +170,9 @@ class govuk::apps::ckan (
       process_regex  => 'pycsw\.wsgi',
     }
 
-    if ($::aws_environment == 'integration') {
-      class { 'cronjobs29':
-        ckan_port    => $port,
-        pycsw_config => $pycsw_config,
-      }
-    } else {
-      class { 'cronjobs':
-        ckan_port    => $port,
-        pycsw_config => $pycsw_config,
-      }
+    class { 'cronjobs29':
+      ckan_port    => $port,
+      pycsw_config => $pycsw_config,
     }
 
     Govuk::App::Envvar {
@@ -282,7 +264,7 @@ class govuk::apps::ckan (
       group   => 'deploy',
     }
 
-    $ckan_bin = '/var/apps/ckan/venv/bin'
+    $ckan_bin = '/var/apps/ckan/venv3/bin'
     $pycsw_tables_created = "${ckan_home}/pycsw_tables_created.tmp"
 
     exec { 'setup_pycsw_tables':

--- a/modules/govuk/manifests/apps/ckan/cronjobs.pp
+++ b/modules/govuk/manifests/apps/ckan/cronjobs.pp
@@ -30,106 +30,94 @@ class govuk::apps::ckan::cronjobs(
     false => 'absent',
   }
 
-  govuk::apps::ckan::paster_cronjob { 'Find a Tender harvester stop existing processes':
-    ensure         => $ensure,
-    paster_command => 'harvester job_abort find-tender-data-harvest',
-    plugin         => 'ckanext-harvest',
-    hour           => '2',
-    minute         => '25',
+  govuk::apps::ckan::ckan_cronjob { 'Find a Tender harvester stop existing processes':
+    ensure       => $ensure,
+    ckan_command => 'harvester job-abort find-tender-data-harvest',
+    hour         => '2',
+    minute       => '25',
   }
 
-  govuk::apps::ckan::paster_cronjob { 'Find a Tender harvester run':
-    ensure         => $ensure,
-    paster_command => 'harvester run_test find-tender-data-harvest',
-    plugin         => 'ckanext-harvest',
-    hour           => '2',
-    minute         => '30',
+  govuk::apps::ckan::ckan_cronjob { 'Find a Tender harvester run':
+    ensure       => $ensure,
+    ckan_command => 'harvester run-test find-tender-data-harvest',
+    hour         => '2',
+    minute       => '30',
   }
 
-  govuk::apps::ckan::paster_cronjob { 'Contract Finder harvester stop existing processes':
-    ensure         => $ensure,
-    paster_command => 'harvester job_abort contracts-finder-ocds-data-harvest',
-    plugin         => 'ckanext-harvest',
-    hour           => '5',
-    minute         => '25',
+  govuk::apps::ckan::ckan_cronjob { 'Contract Finder harvester stop existing processes':
+    ensure       => $ensure,
+    ckan_command => 'harvester job-abort contracts-finder-ocds-data-harvest',
+    hour         => '5',
+    minute       => '25',
   }
 
-  govuk::apps::ckan::paster_cronjob { 'Contract Finder harvester run':
-    ensure         => $ensure,
-    paster_command => 'harvester run_test contracts-finder-ocds-data-harvest',
-    plugin         => 'ckanext-harvest',
-    hour           => '5',
-    minute         => '30',
+  govuk::apps::ckan::ckan_cronjob { 'Contract Finder harvester run':
+    ensure       => $ensure,
+    ckan_command => 'harvester run-test contracts-finder-ocds-data-harvest',
+    hour         => '5',
+    minute       => '30',
   }
 
-  govuk::apps::ckan::paster_cronjob { 'Environment Agency harvester stop existing processes':
-    ensure         => 'absent',
-    paster_command => 'harvester job_abort environment-agency-data-sharing-platform',
-    plugin         => 'ckanext-harvest',
-    weekday        => '5',
-    hour           => '13',
-    minute         => '55',
+  govuk::apps::ckan::ckan_cronjob { 'Environment Agency harvester stop existing processes':
+    ensure       => $ensure,
+    ckan_command => 'harvester job-abort environment-agency-data-sharing-platform',
+    weekday      => '5',
+    hour         => '15',
+    minute       => '55',
   }
 
-  govuk::apps::ckan::paster_cronjob { 'Environment Agency harvester run':
-    ensure         => 'absent',
-    paster_command => 'harvester run_test environment-agency-data-sharing-platform',
-    plugin         => 'ckanext-harvest',
-    weekday        => '5',
-    hour           => '14',
-    minute         => '0',
+  govuk::apps::ckan::ckan_cronjob { 'Environment Agency harvester run':
+    ensure       => $ensure,
+    ckan_command => 'harvester run-test environment-agency-data-sharing-platform',
+    weekday      => '5',
+    hour         => '16',
+    minute       => '0',
   }
 
-  govuk::apps::ckan::paster_cronjob { 'Vale of White Horse harvester stop existing processes':
-    ensure         => $ensure,
-    paster_command => 'harvester job_abort vale-of-white-horse-district-council-2',
-    plugin         => 'ckanext-harvest',
-    weekday        => '5',
-    hour           => '16',
-    minute         => '10',
+  govuk::apps::ckan::ckan_cronjob { 'Vale of White Horse harvester stop existing processes':
+    ensure       => $ensure,
+    ckan_command => 'harvester job-abort vale-of-white-horse-district-council-2',
+    weekday      => '5',
+    hour         => '16',
+    minute       => '10',
   }
 
-  govuk::apps::ckan::paster_cronjob { 'Vale of White Horse harvester run':
-    ensure         => $ensure,
-    paster_command => 'harvester run_test vale-of-white-horse-district-council-2',
-    plugin         => 'ckanext-harvest',
-    weekday        => '5',
-    hour           => '16',
-    minute         => '15',
+  govuk::apps::ckan::ckan_cronjob { 'Vale of White Horse harvester run':
+    ensure       => $ensure,
+    ckan_command => 'harvester run-test vale-of-white-horse-district-council-2',
+    weekday      => '5',
+    hour         => '16',
+    minute       => '15',
   }
 
-  govuk::apps::ckan::paster_cronjob { 'South Oxfordshire harvester stop existing processes':
-    ensure         => $ensure,
-    paster_command => 'harvester job_abort south-oxfordshire-district-council-2',
-    plugin         => 'ckanext-harvest',
-    weekday        => '5',
-    hour           => '16',
-    minute         => '25',
+  govuk::apps::ckan::ckan_cronjob { 'South Oxfordshire harvester stop existing processes':
+    ensure       => $ensure,
+    ckan_command => 'harvester job-abort south-oxfordshire-district-council-2',
+    weekday      => '5',
+    hour         => '16',
+    minute       => '25',
   }
 
-  govuk::apps::ckan::paster_cronjob { 'South Oxfordshire harvester run':
-    ensure         => $ensure,
-    paster_command => 'harvester run_test south-oxfordshire-district-council-2',
-    plugin         => 'ckanext-harvest',
-    weekday        => '5',
-    hour           => '16',
-    minute         => '30',
+  govuk::apps::ckan::ckan_cronjob { 'South Oxfordshire harvester run':
+    ensure       => $ensure,
+    ckan_command => 'harvester run-test south-oxfordshire-district-council-2',
+    weekday      => '5',
+    hour         => '16',
+    minute       => '30',
   }
 
-  govuk::apps::ckan::paster_cronjob { 'harvester run':
-    ensure         => $ensure,
-    paster_command => 'harvester run',
-    plugin         => 'ckanext-harvest',
-    minute         => '*/5',
+  govuk::apps::ckan::ckan_cronjob { 'harvester run':
+    ensure       => $ensure,
+    ckan_command => 'harvester run',
+    minute       => '*/5',
     # timeout shorter than repeat period to prevent stalling runs stacking up
-    timeout        => '4m',
+    timeout      => '4m',
   }
 
-  govuk::apps::ckan::paster_cronjob { 'harvester cleanup':
-    ensure         => $ensure,
-    paster_command => 'harvester clean_harvest_log',
-    plugin         => 'ckanext-harvest',
-    hour           => '2',
+  govuk::apps::ckan::ckan_cronjob { 'harvester cleanup':
+    ensure       => $ensure,
+    ckan_command => 'harvester clean-harvest-log',
+    hour         => '2',
   }
 
   $ensure_solr_reindex = $enable_solr_reindex ? {
@@ -137,20 +125,18 @@ class govuk::apps::ckan::cronjobs(
     false => 'absent',
   }
 
-  govuk::apps::ckan::paster_cronjob { 'index missing packages':
-    ensure         => $ensure_solr_reindex,
-    paster_command => 'search-index rebuild -o',
-    plugin         => 'ckan',
-    hour           => '4',
-    minute         => '0',
+  govuk::apps::ckan::ckan_cronjob { 'index missing packages':
+    ensure       => $ensure_solr_reindex,
+    ckan_command => 'search-index rebuild -o',
+    hour         => '4',
+    minute       => '0',
   }
 
-  govuk::apps::ckan::paster_cronjob { 'pycsw load':
-    ensure         => $ensure,
-    paster_command => "ckan-pycsw load -p ${pycsw_config} -u http://localhost:${ckan_port}",
-    plugin         => 'ckanext-spatial',
-    hour           => '6',
-    minute         => '0',
-    ckan_ini       => false,
+  govuk::apps::ckan::ckan_cronjob { 'pycsw load':
+    ensure       => $ensure,
+    ckan_command => "ckan-pycsw load -p ${pycsw_config} -u http://localhost:${ckan_port}",
+    hour         => '6',
+    minute       => '0',
+    ckan_ini     => false,
   }
 }


### PR DESCRIPTION
## What

Update config files for CKAN 2.9 and update cronjobs with new ccommands for Staging and Production stacks.

## Reference 

https://trello.com/c/DZJFi8z5/2613-create-prs-to-prep-for-29-upgrade