### PR TITLE
Enable sync between production and staging (Merge after upgrade)

### DIFF
--- a/hieradata_aws/class/integration/db_admin.yaml
+++ b/hieradata_aws/class/integration/db_admin.yaml
@@ -11,7 +11,7 @@ govuk_env_sync::tasks:
     url: "govuk-production-database-backups"
     path: "postgresql-backend"
   "pull_ckan_production":
-    ensure: "disabled"
+    ensure: "enabled"
     hour: "0"
     minute: "0"
     action: "pull"


### PR DESCRIPTION
## What

Enable sync between Production and Staging so that Staging can be used to test out issues.

## Reference 

https://trello.com/c/DZJFi8z5/2613-create-prs-to-prep-for-29-upgrade