### PR TITLE
Revert "Upgrade Jenkins 2.289.2 and Plugins"

### DIFF
--- a/hieradata_aws/class/integration/ci_master.yaml
+++ b/hieradata_aws/class/integration/ci_master.yaml
@@ -153,279 +153,245 @@ govuk_jenkins::plugins:
   analysis-core:
     version: '1.96'
   analysis-model-api:
-    version: '10.2.5'
+    version: '5.1.1'
   ansicolor:
-    version: '1.0.0'
+    version: '0.5.3'
   ant:
-    version: '1.11'
+    version: '1.9'
   antisamy-markup-formatter:
-    version: '2.1'
+    version: '1.5'
   apache-httpcomponents-client-4-api:
-    version: '4.5.13-1.0'
+    version: '4.5.5-3.0'
   authentication-tokens:
-    version: '1.4'
-  bootstrap4-api:
-    version: '4.6.0-3'
-  bootstrap5-api:
-    version: '5.0.1-2'
+    version: '1.3'
   bouncycastle-api:
-    version: '2.20'
+    version: '2.17'
   brakeman:
     version: '0.12'
   branch-api:
-    version: '2.6.4'
+    version: '2.0.21'
   build-name-setter:
-    version: '2.2.0'
+    version: '2.0.1'
   build-pipeline-plugin:
     version: '1.5.8'
-  caffeine-api:
-    version: '2.9.1-23.v51c4e2c879c8'
-  checks-api:
-    version: '1.7.0'
   cloudbees-folder:
-    version: '6.15'
+    version: '6.5.1'
   cobertura:
-    version: '1.16'
+    version: '1.13'
   code-coverage-api:
-    version: '1.4.0'
+    version: '1.0.11'
   command-launcher:
-    version: '1.6'
+    version: '1.3'
   conditional-buildstep:
-    version: '1.4.1'
+    version: '1.3.6'
   copyartifact:
-    version: '1.46.1'
-  credentials-binding:
-    version: '1.26'
+    version: '1.42.1'
   credentials:
-    version: '2.5'
-  data-tables-api:
-    version: '1.10.25-1'
+    version: '2.1.19'
+  credentials-binding:
+    version: '1.18'
   description-setter:
     version: '1.10'
   display-url-api:
-    version: '2.3.5'
+    version: '2.3.1'
   docker-commons:
-    version: '1.17'
+    version: '1.14'
   docker-workflow:
-    version: '1.26'
+    version: '1.18'
   durable-task:
-    version: '1.37'
-  echarts-api:
-    version: '5.1.2-2'
+    version: '1.29'
   envinject-api:
-    version: '1.7'
+    version: '1.5'
   envinject:
-    version: '2.4.0'
+    version: '2.1.6'
   external-monitor-job:
     version: '1.7'
   findbugs:
     version: '5.0.0'
-  font-awesome-api:
-    version: '5.15.3-3'
-  forensics-api:
-    version: '1.2.0'
   generic-webhook-trigger:
-    version: '1.74'
+    version: '1.67'
   git-client:
-    version: '3.7.2'
+    version: '2.7.7'
   git:
-    version: '4.7.2'
+    version: '3.10.0'
   github-api:
-    version: '1.123'
+    version: '1.95'
   github-branch-source:
-    version: '2.11.1'
+    version: '2.5.3'
   github:
-    version: '1.33.1'
+    version: '1.29.4'
   github-oauth:
-    version: '0.33'
+    version: '0.32'
   git-server:
-    version: '1.9'
+    version: '1.7'
   google-container-registry-auth:
     version: '0.3'
   google-oauth-plugin:
-    version: '1.0.6'
+    version: '0.8'
   gradle:
-    version: '1.36'
+    version: '1.32'
   greenballs:
-    version: '1.15.1'
+    version: '1.15'
   groovy:
-    version: '2.4'
+    version: '2.2'
   handlebars:
-    version: '3.0.8'
+    version: '1.1.1'
   htmlpublisher:
-    version: '1.25'
+    version: '1.18'
   icon-shim:
-    version: '3.0.0'
+    version: '2.0.3'
   jackson2-api:
-    version: '2.12.3'
+    version: '2.9.9'
   javadoc:
-    version: '1.6'
-  jdk-tool:
     version: '1.5'
+  jdk-tool:
+    version: '1.2'
   jenkinswalldisplay:
     version: '0.6.34'
-  jjwt-api:
-    version: '0.11.2-9.c8b45b8bb173'
-  jquery3-api:
-    version: '3.6.0-1'
   jquery-detached:
     version: '1.2.1'
   jquery:
-    version: '1.12.4-1'
+    version: '1.12.4-0'
   jquery-ui:
     version: '1.0.2'
   jsch:
-    version: '0.1.55.2'
+    version: '0.1.55'
   junit:
-    version: '1.51'
+    version: '1.27'
   ldap:
-    version: '2.7'
+    version: '1.20'
   lockable-resources:
-    version: '2.11'
+    version: '2.5'
   mailer:
-    version: '1.34'
+    version: '1.23'
   mapdb-api:
     version: '1.0.9.0'
   matrix-auth:
-    version: '2.6.7'
+    version: '2.3'
   matrix-project:
-    version: '1.19'
+    version: '1.14'
   maven-plugin:
-    version: '3.12'
+    version: '3.2'
   momentjs:
     version: '1.1.1'
   monitoring:
-    version: '1.87.0'
+    version: '1.77.0'
   naginator:
-    version: '1.18.1'
+    version: '1.18'
   next-build-number:
-    version: '1.6'
+    version: '1.5'
   nodelabelparameter:
-    version: '1.8.1'
+    version: '1.7.2'
   oauth-credentials:
-    version: '0.4'
-  okhttp-api:
-    version: '3.14.9'
+    version: '0.3'
   pam-auth:
-    version: '1.6'
+    version: '1.4.1'
   parameterized-trigger:
-    version: '2.41'
+    version: '2.35.2'
   pipeline-build-step:
-    version: '2.13'
+    version: '2.9'
   pipeline-graph-analysis:
-    version: '1.11'
+    version: '1.9'
   pipeline-input-step:
-    version: '2.12'
+    version: '2.10'
   pipeline-milestone-step:
-    version: '1.3.2'
+    version: '1.3.1'
   pipeline-model-api:
-    version: '1.8.5'
+    version: '1.3.8'
   pipeline-model-declarative-agent:
     version: '1.1.1'
   pipeline-model-definition:
-    version: '1.8.5'
+    version: '1.3.8'
   pipeline-model-extensions:
-    version: '1.8.5'
+    version: '1.3.8'
   pipeline-rest-api:
-    version: '2.19'
+    version: '2.11'
   pipeline-stage-step:
-    version: '2.5'
+    version: '2.3'
   pipeline-stage-tags-metadata:
-    version: '1.8.5'
+    version: '1.3.8'
   pipeline-stage-view:
-    version: '2.19'
+    version: '2.11'
   plain-credentials:
-    version: '1.7'
-  plugin-util-api:
-    version: '2.3.0'
-  popper2-api:
-    version: '2.5.4-2'
-  popper-api:
-    version: '1.16.1-2'
+    version: '1.5'
   rake:
     version: '1.8.0'
   rebuild:
-    version: '1.32'
+    version: '1.31'
   resource-disposer:
-    version: '0.16'
+    version: '0.12'
   role-strategy:
-    version: '3.1.1'
+    version: '2.11'
   ruby:
     version: '1.2'
   rubyMetrics:
     version: '1.6.5'
   run-condition:
-    version: '1.5'
+    version: '1.2'
   saferestart:
     version: '0.3'
   scm-api:
-    version: '2.6.4'
+    version: '2.4.1'
   script-security:
-    version: '1.77'
+    version: '1.60'
   simple-theme-plugin:
-    version: '0.6'
+    version: '0.5.1'
   sitemonitor:
     version: '0.6'
   slack:
-    version: '2.48'
-  snakeyaml-api:
-    version: '1.29.1'
+    version: '2.20'
   ssh-agent:
-    version: '1.23'
+    version: '1.17'
   ssh-credentials:
-    version: '1.19'
-  sshd:
-    version: '3.0.3'
-  ssh-slaves:
-    version: '1.32.0'
-  structs:
-    version: '1.23'
-  swarm:
-    version: '3.27'
-  text-finder:
     version: '1.16'
+  ssh-slaves:
+    version: '1.29.4'
+  structs:
+    version: '1.19'
+  swarm:
+    version: '3.17'
+  text-finder:
+    version: '1.11'
   throttle-concurrents:
-    version: '2.3'
+    version: '2.0.1'
   timestamper:
-    version: '1.13'
+    version: '1.9'
   token-macro:
-    version: '2.15'
-  trilead-api:
-    version: '1.0.13'
+    version: '2.8'
   versionnumber:
     version: '1.9'
   violations:
     version: '0.7.11'
   warnings-ng:
-    version: '9.3.0'
+    version: '5.1.0'
   warnings:
     version: '5.0.1'
   windows-slaves:
-    version: '1.8'
+    version: '1.4'
   workflow-aggregator:
-    version: '2.6'
+    version: '2.5'
   workflow-api:
-    version: '2.46'
+    version: '2.33'
   workflow-basic-steps:
-    version: '2.23'
+    version: '2.15'
   workflow-cps-global-lib:
-    version: '2.21'
-  workflow-cps:
-    version: '2.92'
-  workflow-durable-task-step:
-    version: '2.39'
-  workflow-job:
-    version: '2.41'
-  workflow-multibranch:
-    version: '2.26'
-  workflow-scm-step:
     version: '2.13'
+  workflow-cps:
+    version: '2.70'
+  workflow-durable-task-step:
+    version: '2.28'
+  workflow-job:
+    version: '2.32'
+  workflow-multibranch:
+    version: '2.21'
+  workflow-scm-step:
+    version: '2.9'
   workflow-step-api:
-    version: '2.23'
+    version: '2.20'
   workflow-support:
-    version: '3.8'
+    version: '3.3'
   ws-cleanup:
-    version: '0.39'
+    version: '0.37'
 
 lv:
   data:

--- a/hieradata_aws/class/jenkins.yaml
+++ b/hieradata_aws/class/jenkins.yaml
@@ -56,218 +56,184 @@ govuk_jenkins::plugins:
   ace-editor:
     version: '1.1'
   ansicolor:
-    version: '1.0.0'
+    version: '0.5.3'
   ant:
-    version: '1.11'
+    version: '1.9'
   antisamy-markup-formatter:
-    version: '2.1'
+    version: '1.5'
   apache-httpcomponents-client-4-api:
-    version: '4.5.13-1.0'
+    version: '4.5.5-3.0'
   badge:
     version: '1.8'
-  bootstrap4-api:
-    version: '4.6.0-3'
-  bootstrap5-api:
-    version: '5.0.1-2'
   bouncycastle-api:
-    version: '2.20'
+    version: '2.17'
   branch-api:
-    version: '2.6.4'
+    version: '2.0.21'
   build-name-setter:
-    version: '2.2.0'
+    version: '2.0.1'
   build-pipeline-plugin:
     version: '1.5.8'
   build-token-root:
-    version: '1.7'
+    version: '1.4'
   build-user-vars-plugin:
-    version: '1.7'
+    version: '1.5'
   build-with-parameters:
-    version: '1.5.1'
-  caffeine-api:
-    version: '2.9.1-23.v51c4e2c879c8'
-  checks-api:
-    version: '1.7.0'
+    version: '1.4'
   cloudbees-folder:
-    version: '6.15'
+    version: '6.5.1'
   command-launcher:
-    version: '1.6'
+    version: '1.3'
   conditional-buildstep:
-    version: '1.4.1'
+    version: '1.3.6'
   copyartifact:
-    version: '1.46.1'
-  credentials-binding:
-    version: '1.27'
+    version: '1.42.1'
   credentials:
-    version: '2.5'
+    version: '2.1.19'
+  credentials-binding:
+    version: '1.18'
   cvs:
-    version: '2.19'
+    version: '2.14'
   description-setter:
     version: '1.10'
   display-url-api:
-    version: '2.3.5'
+    version: '2.3.1'
   downstream-buildview:
     version: '1.9'
   durable-task:
-    version: '1.37'
-  echarts-api:
-    version: '5.1.2-2'
+    version: '1.29'
   email-ext:
-    version: '2.83'
+    version: '2.66'
   envinject-api:
-    version: '1.7'
+    version: '1.5'
   envinject:
-    version: '2.4.0'
+    version: '2.1.6'
   external-monitor-job:
     version: '1.7'
-  font-awesome-api:
-    version: '5.15.3-3'
   git-client:
-    version: '3.7.2'
+    version: '2.7.7'
   git:
-    version: '4.7.2'
+    version: '3.10.0'
   github-api:
-    version: '1.123'
+    version: '1.95'
   github-branch-source:
-    version: '2.11.1'
+    version: '2.5.3'
   github:
-    version: '1.33.1'
+    version: '1.29.4'
   github-oauth:
-    version: '0.33'
+    version: '0.32'
   google-oauth-plugin:
-    version: '1.0.6'
+    version: '0.8'
   gradle:
-    version: '1.37.1'
+    version: '1.32'
   greenballs:
-    version: '1.15.1'
+    version: '1.15'
   groovy-postbuild:
-    version: '2.5'
+    version: '2.4.3'
   icon-shim:
-    version: '3.0.0'
+    version: '2.0.3'
   instant-messaging:
-    version: '1.42'
+    version: '1.35'
   ircbot:
-    version: '2.36'
+    version: '2.30'
   jackson2-api:
-    version: '2.12.3'
+    version: '2.9.9'
   javadoc:
-    version: '1.6'
-  jdk-tool:
     version: '1.5'
-  jjwt-api:
-    version: '0.11.2-9.c8b45b8bb173'
-  jquery3-api:
-    version: '3.6.0-1'
+  jdk-tool:
+    version: '1.2'
   jquery-detached:
     version: '1.2.1'
   jquery:
-    version: '1.12.4-1'
+    version: '1.12.4-0'
   jquery-ui:
     version: '1.0.2'
   jsch:
-    version: '0.1.55.2'
+    version: '0.1.55'
   junit:
-    version: '1.51'
+    version: '1.27'
   ldap:
-    version: '2.7'
+    version: '1.20'
   mailer:
-    version: '1.34'
+    version: '1.23'
   mapdb-api:
     version: '1.0.9.0'
   matrix-auth:
-    version: '2.6.7'
+    version: '2.3'
   matrix-project:
-    version: '1.19'
+    version: '1.14'
   maven-plugin:
-    version: '3.12'
+    version: '3.2'
   nodelabelparameter:
-    version: '1.8.1'
+    version: '1.7.2'
   oauth-credentials:
-    version: '0.4'
-  okhttp-api:
-    version: '3.14.9'
+    version: '0.3'
   pam-auth:
-    version: '1.6'
+    version: '1.4.1'
   parameterized-scheduler:
-    version: '1.0'
+    version: '0.6.3'
   parameterized-trigger:
-    version: '2.41'
+    version: '2.35.2'
   plain-credentials:
-    version: '1.7'
-  plugin-util-api:
-    version: '2.3.0'
-  popper2-api:
-    version: '2.5.4-2'
-  popper-api:
-    version: '1.16.1-2'
+    version: '1.5'
   rake:
     version: '1.8.0'
   rebuild:
-    version: '1.32'
+    version: '1.31'
   resource-disposer:
-    version: '0.16'
+    version: '0.12'
   role-strategy:
-    version: '3.1.1'
+    version: '2.11'
   run-condition:
-    version: '1.5'
-  saml:
-    version: '2.0.7'
+    version: '1.2'
   sbt:
     version: '1.5'
   scm-api:
-    version: '2.6.4'
+    version: '2.4.1'
   scm-sync-configuration:
     version: '0.0.10'
   script-security:
-    version: '1.77'
+    version: '1.60'
   show-build-parameters:
     version: '1.0'
   simple-theme-plugin:
-    version: '0.7'
+    version: '0.5.1'
   slack:
-    version: '2.48'
-  snakeyaml-api:
-    version: '1.29.1'
+    version: '2.23'
   ssh-credentials:
-    version: '1.19'
-  sshd:
-    version: '3.0.4'
-  ssh-slaves:
-    version: '1.32.0'
-  structs:
-    version: '1.23'
-  subversion:
-    version: '2.14.4'
-  text-finder:
     version: '1.16'
+  ssh-slaves:
+    version: '1.29.4'
+  structs:
+    version: '1.19'
+  subversion:
+    version: '2.12.1'
+  text-finder:
+    version: '1.11'
   timestamper:
-    version: '1.13'
+    version: '1.9'
   token-macro:
-    version: '2.15'
+    version: '2.8'
   translation:
     version: '1.16'
-  trilead-api:
-    version: '1.0.13'
   versionnumber:
     version: '1.9'
   windows-slaves:
-    version: '1.8'
+    version: '1.4'
   workflow-api:
-    version: '2.46'
-  workflow-basic-steps:
-    version: '2.23'
+    version: '2.33'
   workflow-cps:
-    version: '2.92'
+    version: '2.70'
   workflow-durable-task-step:
-    version: '2.39'
+    version: '2.28'
   workflow-job:
-    version: '2.41'
+    version: '2.32'
   workflow-multibranch:
-    version: '2.26'
+    version: '2.21'
   workflow-scm-step:
-    version: '2.13'
+    version: '2.9'
   workflow-step-api:
-    version: '2.24'
+    version: '2.20'
   workflow-support:
-    version: '3.8'
+    version: '3.3'
   ws-cleanup:
-    version: '0.39'
+    version: '0.37'

--- a/modules/govuk_jenkins/manifests/init.pp
+++ b/modules/govuk_jenkins/manifests/init.pp
@@ -48,7 +48,7 @@ class govuk_jenkins (
   $plugins = {},
   $ssh_private_key = undef,
   $ssh_public_key = undef,
-  $version = '2.289.2',
+  $version = '2.164.3',
   $jenkins_api_user = 'jenkins_api_user',
   $jenkins_api_token = '',
   $jenkins_user = 'jenkins',


### PR DESCRIPTION
Reverts alphagov/govuk-puppet#11206, as it caused an error on Deploy Integration:

> <img width="1119" alt="Screenshot 2021-07-21 at 10 03 30" src="https://user-images.githubusercontent.com/5111927/126462528-5537f833-aeef-44d8-adc1-3f942c2ecdc4.png">

Trello: https://trello.com/c/pCKvKF2J/2583-upgrade-jenkins-plugins-to-versions-without-security-vulnerabilities-5
