### PR TITLE
ensure pip installed first

### DIFF
--- a/modules/collectd/manifests/plugin/docker.pp
+++ b/modules/collectd/manifests/plugin/docker.pp
@@ -24,6 +24,7 @@ class collectd::plugin::docker(
     command => 'pip install "docker>=4.1.0,<4.2"',
     notify  => Class['collectd::service'],
     unless  => 'pip list | grep "docker.*4.1"',
+    require => File['/usr/bin/pip'],
   }
 
   exec { 'pip install urllib3':
@@ -31,6 +32,7 @@ class collectd::plugin::docker(
     command => 'pip install "urllib3==1.25.3"',
     notify  => Class['collectd::service'],
     unless  => 'pip list | grep "urllib3.*1.25.3"',
+    require => File['/usr/bin/pip'],
   }
 
   exec { 'pip install requests':
@@ -38,6 +40,7 @@ class collectd::plugin::docker(
     command => 'pip install "requests==2.22.0"',
     notify  => Class['collectd::service'],
     unless  => 'pip list | grep "requests.*2.22.0"',
+    require => File['/usr/bin/pip'],
   }
 
   package { 'py-dateutil':

--- a/modules/govuk_containers/spec/classes/govuk_containers__gemstash_spec.rb
+++ b/modules/govuk_containers/spec/classes/govuk_containers__gemstash_spec.rb
@@ -1,7 +1,11 @@
 require_relative '../../../../spec_helper'
 
 describe 'govuk_containers::gemstash', :type => :class do
-  let(:pre_condition) { 'include ::govuk_docker' }
+  let(:pre_condition) { <<-EOS
+    include ::govuk_python
+    include ::govuk_docker
+    EOS
+  }
   it { is_expected.to compile }
 
   it { is_expected.to compile.with_all_deps }

--- a/modules/govuk_containers/spec/classes/govuk_containers__memcached_spec.rb
+++ b/modules/govuk_containers/spec/classes/govuk_containers__memcached_spec.rb
@@ -1,7 +1,11 @@
 require_relative '../../../../spec_helper'
 
 describe 'govuk_containers::memcached', :type => :class do
-  let(:pre_condition) { 'include ::govuk_docker' }
+  let(:pre_condition) { <<-EOS
+    include ::govuk_python
+    include ::govuk_docker
+    EOS
+  }
   it { is_expected.to compile }
 
   it { is_expected.to compile.with_all_deps }

--- a/modules/govuk_containers/spec/classes/govuk_containers__redis_spec.rb
+++ b/modules/govuk_containers/spec/classes/govuk_containers__redis_spec.rb
@@ -1,7 +1,11 @@
 require_relative '../../../../spec_helper'
 
 describe 'govuk_containers::redis', :type => :class do
-  let(:pre_condition) { 'include ::govuk_docker' }
+  let(:pre_condition) { <<-EOS
+    include ::govuk_python
+    include ::govuk_docker
+    EOS
+  }
   it { is_expected.to compile }
 
   it { is_expected.to compile.with_all_deps }


### PR DESCRIPTION
This PR ensures that pip is installed first before pip packages are installed via exec cmd. Before this was done only for pip packages installed by the puppet `package` utility with pip set as provider.