### PR TITLE
install docker before associating docker group to directory

### DIFF
--- a/modules/govuk_containers/manifests/redis.pp
+++ b/modules/govuk_containers/manifests/redis.pp
@@ -20,9 +20,10 @@ class govuk_containers::redis(
 
   # store the state dumps here on the docker host
   file { '/srv/redis':
-    ensure => directory,
-    mode   => '0770',
-    group  => 'docker',
+    ensure  => directory,
+    mode    => '0770',
+    group   => 'docker',
+    require => Class['govuk_docker'],
   }
 
   ::docker::image { $image_name:


### PR DESCRIPTION
Mirrorer is breaking in production with error:
```
Error: Could not find group docker
Error: /Stage[main]/Govuk_containers::Redis/File[/srv/redis]/group: change from root to docker failed: Could not find group docker
```

This fixes the issue by installing `govuk_docker` (hence have the `docker` group) before giving `docker` group ownership of `/srv/redis` directory