### PR TITLE
fix deploy uid/gid for deploy user in mirrorer machine

### DIFF
--- a/hieradata_aws/class/mirrorer.yaml
+++ b/hieradata_aws/class/mirrorer.yaml
@@ -13,3 +13,6 @@ mount:
     disk: '/dev/mapper/crawler-worker'
     govuk_lvm: 'worker'
     mountoptions: 'defaults'
+
+govuk::deploy::setup::deploy_uid: 2899
+govuk::deploy::setup::deploy_gid: 2899

--- a/modules/govuk/manifests/apps/govuk_crawler_worker.pp
+++ b/modules/govuk/manifests/apps/govuk_crawler_worker.pp
@@ -84,12 +84,15 @@ class govuk::apps::govuk_crawler_worker (
         value => $rate_limit_token;
     }
 
+    # Do not set recurse on this directory as it consists of a hundreds of GBs
+    # of small files and will cause puppet to be take a long time to finish
+    # running and may cause the Mirrorer instance to fail first instantiation.
+    # Instead we set the uid and gid of `deploy` to be the same always via hiera
     file { $mirror_root:
-      ensure  => directory,
-      mode    => '0755',
-      owner   => 'deploy',
-      group   => 'deploy',
-      recurse => true,
+      ensure => directory,
+      mode   => '0755',
+      owner  => 'deploy',
+      group  => 'deploy',
     }
 
     if $disable_during_data_sync and $::data_sync_in_progress {


### PR DESCRIPTION
Do not set recurse on the mirror directory as it consists of a hundreds of GBs
of small files and will cause puppet to be take a long time to finish
running and may cause the Mirrorer instance to fail first instantiation.
Instead we set the uid and gid of `deploy` to be the same always via hiera.