### PR TITLE
Upgrade seed crawler gem to 3.0.0

### DIFF
--- a/modules/govuk/manifests/node/s_mirrorer.pp
+++ b/modules/govuk/manifests/node/s_mirrorer.pp
@@ -11,6 +11,7 @@ class govuk::node::s_mirrorer inherits govuk::node::s_base {
   include govuk_crawler
   include govuk_rabbitmq
   include nginx
+  include ::govuk_rbenv::all
 
   include ::govuk_docker
   include ::govuk_containers::redis

--- a/modules/govuk_crawler/manifests/init.pp
+++ b/modules/govuk_crawler/manifests/init.pp
@@ -141,7 +141,7 @@ class govuk_crawler(
 
   # This explicitly requires 'base::packages' so that nokogiri will build
   package { 'govuk_seed_crawler':
-        ensure   => '2.1.0',
+        ensure   => '3.0.0',
         provider => system_gem,
         require  => Class['base::packages'],
   }

--- a/modules/govuk_crawler/templates/seed-crawler-wrapper.erb
+++ b/modules/govuk_crawler/templates/seed-crawler-wrapper.erb
@@ -20,7 +20,7 @@ trap send_nsca EXIT
 
 export GOVUK_CRAWLER_AMQP_PASS='<%= @amqp_pass %>'
 
-OUTPUT=`<%= @seeder_script_path %> <%= @seeder_script_args %>`
+OUTPUT=`rbenv shell 2.6.3 && <%= @seeder_script_path %> <%= @seeder_script_args %>`
 
 logger -p local3.info -t seed-crawler-wrapper "$OUTPUT"
 


### PR DESCRIPTION
This also installs the Ruby version 2.6.3 which is required by the gem.