### PR TITLE
Fix all the Icinga -> Jenkins links

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -7,6 +7,7 @@ nginx_enable_ssl: false
 stackname: "%{::aws_stackname}"
 app_domain: "%{::aws_stackname}.govuk.internal"
 app_domain_internal: '%{::aws_stackname}.govuk-internal.digital'
+deploy_jenkins_domain: "deploy.%{::aws_stackname}.%{::aws_environment}.govuk.digital"
 
 backup::mysql::alert_hostname: 'alert'
 

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -1,6 +1,7 @@
 ---
 app_domain: "integration.publishing.service.gov.uk"
 app_domain_internal: "integration.govuk-internal.digital"
+deploy_jenkins_domain: "deploy.integration.publishing.service.gov.uk"
 
 base::shell::shell_prompt_string: 'integration'
 base::supported_kernel::enabled: false

--- a/lib/puppet-lint/plugins/check_hiera.rb
+++ b/lib/puppet-lint/plugins/check_hiera.rb
@@ -30,6 +30,11 @@ PuppetLint.new_check(:hiera_explicit_lookup) do
     # Used in AWS, will be used everywhere eventually ;)
     'app_domain_internal',
 
+    # We have different hostname structure for Jenkins deploy in integration
+    # and other environments, can be removed if we resolve integration being
+    # special
+    'deploy_jenkins_domain',
+
     # disk noops due to defined classes not doing magical hiera lookups
     'govuk_mount::no_op',
     'govuk_lvm::no_op',

--- a/modules/govuk_jenkins/manifests/jobs/athena_fastly_logs_check.pp
+++ b/modules/govuk_jenkins/manifests/jobs/athena_fastly_logs_check.pp
@@ -26,14 +26,8 @@ class govuk_jenkins::jobs::athena_fastly_logs_check (
   $databases = ['govuk_www', 'govuk_assets'],
   $s3_results_bucket = undef,
 ) {
-  if ($::aws_environment != 'integration') {
-    $hosting_env_domain = "blue.${::aws_environment}.govuk.digital"
-  }
-  else {
-    $hosting_env_domain = hiera('app_domain')
-  }
-
-  $jenkins_url = "https://deploy.${hosting_env_domain}/job/athena-fastly-logs-check/"
+  $deploy_jenkins_domain = hiera('deploy_jenkins_domain')
+  $jenkins_url = "https://${deploy_jenkins_domain}/job/athena-fastly-logs-check/"
   $jenkins_service_description = "Athena has recent results for fastly_logs \${DATABASE}"
 
   file {

--- a/modules/govuk_jenkins/manifests/jobs/bouncer_cdn.pp
+++ b/modules/govuk_jenkins/manifests/jobs/bouncer_cdn.pp
@@ -27,7 +27,8 @@ class govuk_jenkins::jobs::bouncer_cdn (
   }
 
   $check_name = 'bouncer-cdn-configuration'
-  $job_url = "https://deploy.blue.${::aws_environment}.govuk.digital/job/Bouncer_CDN/"
+  $deploy_jenkins_domain = hiera('deploy_jenkins_domain')
+  $job_url = "https://${deploy_jenkins_domain}/job/Bouncer_CDN/"
 
   @@icinga::passive_check { "${check_name}_${::hostname}":
     service_description => $service_description,

--- a/modules/govuk_jenkins/manifests/jobs/bouncer_cdn.pp
+++ b/modules/govuk_jenkins/manifests/jobs/bouncer_cdn.pp
@@ -16,7 +16,6 @@
 class govuk_jenkins::jobs::bouncer_cdn (
   $api_key = undef,
   $service_id = undef,
-  $app_domain = hiera('app_domain'),
 ) {
   $service_description = 'Configure Bouncer CDN service with transitioning sites'
 

--- a/modules/govuk_jenkins/manifests/jobs/check_cdn_ip_ranges.pp
+++ b/modules/govuk_jenkins/manifests/jobs/check_cdn_ip_ranges.pp
@@ -3,12 +3,11 @@
 # Create a jenkins-job-builder config file for checking that CDN
 # IP ranges are configured correctly.
 #
-class govuk_jenkins::jobs::check_cdn_ip_ranges(
-  $app_domain = hiera('app_domain'),
-) {
+class govuk_jenkins::jobs::check_cdn_ip_ranges {
   $check_name = 'check_cdn_ip_ranges'
   $service_description = 'Compare the IP ranges that Fastly publishes against the ranges configured in govuk-provisioning'
-  $job_url = "https://deploy.${app_domain}/job/Check_CDN_IP_Ranges/"
+  $deploy_jenkins_domain = hiera('deploy_jenkins_domain')
+  $job_url = "https://${deploy_jenkins_domain}/job/Check_CDN_IP_Ranges/"
 
   file { '/etc/jenkins_jobs/jobs/check_cdn_ip_ranges.yaml':
     ensure  => present,

--- a/modules/govuk_jenkins/manifests/jobs/check_github_ip_ranges.pp
+++ b/modules/govuk_jenkins/manifests/jobs/check_github_ip_ranges.pp
@@ -3,12 +3,11 @@
 # Create a jenkins-job-builder config file for checking that GitHub
 # IP ranges are configured correctly.
 #
-class govuk_jenkins::jobs::check_github_ip_ranges(
-  $app_domain = hiera('app_domain'),
-) {
+class govuk_jenkins::jobs::check_github_ip_ranges {
   $check_name = 'check_github_ip_ranges'
   $service_description = 'Compare the IP ranges that GitHub publishes against the ranges configured in govuk-provisioning'
-  $job_url = "https://deploy.${app_domain}/job/Check_GitHub_IP_Ranges/"
+  $deploy_jenkins_domain = hiera('deploy_jenkins_domain')
+  $job_url = "https://${deploy_jenkins_domain}/job/Check_GitHub_IP_Ranges/"
 
   file { '/etc/jenkins_jobs/jobs/check_github_ip_ranges.yaml':
     ensure  => present,

--- a/modules/govuk_jenkins/manifests/jobs/check_sentry_errors.pp
+++ b/modules/govuk_jenkins/manifests/jobs/check_sentry_errors.pp
@@ -4,7 +4,6 @@
 #
 class govuk_jenkins::jobs::check_sentry_errors (
   $sentry_auth_token = undef,
-  $app_domain = hiera('app_domain'),
 ) {
   $check_name = 'check_sentry_errors'
   $service_description = 'Report the number of errors in Sentry to Graphite'
@@ -15,14 +14,8 @@ class govuk_jenkins::jobs::check_sentry_errors (
     notify  => Exec['jenkins_jobs_update'],
   }
 
-  if ($::aws_environment != 'integration') {
-    $hosting_env_domain = "blue.${::aws_environment}.govuk.digital"
-  }
-  else {
-    $hosting_env_domain = $app_domain
-  }
-
-  $job_url = "https://deploy.${hosting_env_domain}/job/Check_Sentry_Errors/"
+  $deploy_jenkins_domain = hiera('deploy_jenkins_domain')
+  $job_url = "https://${deploy_jenkins_domain}/job/Check_Sentry_Errors/"
 
   @@icinga::passive_check { "${check_name}_${::hostname}":
     service_description => $service_description,

--- a/modules/govuk_jenkins/manifests/jobs/content_data_api.pp
+++ b/modules/govuk_jenkins/manifests/jobs/content_data_api.pp
@@ -15,7 +15,8 @@ class govuk_jenkins::jobs::content_data_api (
 ) {
   $check_name = 'etl-content-data-api'
   $service_description = 'Content Data API ETL [Extract - transform - load]'
-  $job_url = "https://deploy.blue.${::aws_environment}.govuk.digital/job/content_data_api_import_etl_main_process/"
+  $deploy_jenkins_domain = hiera('deploy_jenkins_domain')
+  $job_url = "https://${deploy_jenkins_domain}/job/content_data_api_import_etl_main_process/"
 
   file { '/etc/jenkins_jobs/jobs/content_data_api.yaml':
     ensure  => present,

--- a/modules/govuk_jenkins/manifests/jobs/content_data_api.pp
+++ b/modules/govuk_jenkins/manifests/jobs/content_data_api.pp
@@ -11,7 +11,6 @@
 #
 class govuk_jenkins::jobs::content_data_api (
   $rake_etl_main_process_cron_schedule = undef,
-  $app_domain = hiera('app_domain'),
 ) {
   $check_name = 'etl-content-data-api'
   $service_description = 'Content Data API ETL [Extract - transform - load]'

--- a/modules/govuk_jenkins/manifests/jobs/content_data_api_re_run.pp
+++ b/modules/govuk_jenkins/manifests/jobs/content_data_api_re_run.pp
@@ -11,7 +11,6 @@
 #
 class govuk_jenkins::jobs::content_data_api_re_run (
   $re_run_rake_etl_main_process_cron_schedule,
-  $app_domain = hiera('app_domain'),
 ) {
 
   file { '/etc/jenkins_jobs/jobs/content_data_api_re_run.yaml':

--- a/modules/govuk_jenkins/manifests/jobs/deploy_app_downstream.pp
+++ b/modules/govuk_jenkins/manifests/jobs/deploy_app_downstream.pp
@@ -33,9 +33,9 @@ class govuk_jenkins::jobs::deploy_app_downstream (
   $slack_channel = '#govuk-developers',
   $slack_credential_id = 'slack-notification-token',
   $slack_team_domain = 'gds',
-  $app_domain = hiera('app_domain')
 ) {
-  $slack_build_server_url = "https://deploy.${app_domain}/"
+  $deploy_jenkins_domain = hiera('deploy_jenkins_domain')
+  $slack_build_server_url = "https://${deploy_jenkins_domain}/"
 
   file { '/etc/jenkins_jobs/jobs/deploy_app_downstream.yaml':
     ensure  => present,

--- a/modules/govuk_jenkins/manifests/jobs/deploy_cdn.pp
+++ b/modules/govuk_jenkins/manifests/jobs/deploy_cdn.pp
@@ -3,7 +3,6 @@
 # Create a file on disk that can be parsed by jenkins-job-builder
 #
 class govuk_jenkins::jobs::deploy_cdn(
-  $app_domain = hiera('app_domain'),
   $enable_slack_notifications = false,
   $services = [],
 ) {
@@ -11,7 +10,8 @@ class govuk_jenkins::jobs::deploy_cdn(
   $environment_variables = $govuk_jenkins::environment_variables
   $slack_team_domain = 'gds'
   $slack_room = 'govuk-deploy'
-  $slack_build_server_url = "https://deploy.${app_domain}/"
+  $deploy_jenkins_domain = hiera('deploy_jenkins_domain')
+  $slack_build_server_url = "https://${deploy_jenkins_domain}/"
 
   file { '/etc/jenkins_jobs/jobs/deploy_cdn.yaml':
     ensure  => present,

--- a/modules/govuk_jenkins/manifests/jobs/deploy_puppet.pp
+++ b/modules/govuk_jenkins/manifests/jobs/deploy_puppet.pp
@@ -17,12 +17,12 @@ class govuk_jenkins::jobs::deploy_puppet (
   $auth_token = undef,
   $commitish   = 'release',
   $enable_slack_notifications = false,
-  $app_domain = hiera('app_domain')
 ) {
   $environment_variables = $govuk_jenkins::environment_variables
   $slack_team_domain = 'gds'
   $slack_room = 'govuk-deploy'
-  $slack_build_server_url = "https://deploy.${app_domain}/"
+  $deploy_jenkins_domain = hiera('deploy_jenkins_domain')
+  $slack_build_server_url = "https://${deploy_jenkins_domain}/"
 
   file { '/etc/jenkins_jobs/jobs/deploy_puppet.yaml':
     ensure  => present,

--- a/modules/govuk_jenkins/manifests/jobs/email_alert_check.pp
+++ b/modules/govuk_jenkins/manifests/jobs/email_alert_check.pp
@@ -24,12 +24,13 @@ class govuk_jenkins::jobs::email_alert_check (
   $sentry_dsn = undef,
 ) {
 
+  $deploy_jenkins_domain = hiera('deploy_jenkins_domain')
   $medical_safety_check_name = 'medical_safety_email_alert_check'
   $medical_safety_service_description = 'Medical Safety Email alert check'
-  $medical_safety_job_url = "https://deploy.blue.${::aws_environment}.govuk.digital/job/medical-safety-email-alert-check/"
+  $medical_safety_job_url = "https://${deploy_jenkins_domain}/job/medical-safety-email-alert-check/"
   $travel_advice_check_name = 'travel_advice_email_alert_check'
   $travel_advice_service_description = 'Travel Advice email alert check'
-  $travel_advice_job_url = "https://deploy.blue.${::aws_environment}.govuk.digital/job/travel-advice-email-alert-check/"
+  $travel_advice_job_url = "https://${deploy_jenkins_domain}/job/travel-advice-email-alert-check/"
 
   file {
     '/etc/jenkins_jobs/jobs/medical_safety_email_alert_check.yaml':

--- a/modules/govuk_jenkins/manifests/jobs/email_alert_check.pp
+++ b/modules/govuk_jenkins/manifests/jobs/email_alert_check.pp
@@ -20,7 +20,6 @@ class govuk_jenkins::jobs::email_alert_check (
   $google_oauth_credentials = undef,
   $google_client_id = undef,
   $google_client_secret = undef,
-  $app_domain = hiera('app_domain'),
   $sentry_dsn = undef,
 ) {
 

--- a/modules/govuk_jenkins/manifests/jobs/enhanced_ecommerce_search_api.pp
+++ b/modules/govuk_jenkins/manifests/jobs/enhanced_ecommerce_search_api.pp
@@ -3,7 +3,6 @@
 # Create a file on disk that can be parsed by jenkins-job-builder
 #
 class govuk_jenkins::jobs::enhanced_ecommerce_search_api (
-  $app_domain = hiera('app_domain'),
   $auth_username = undef,
   $auth_password = undef,
   $rate_limit_token = undef,

--- a/modules/govuk_jenkins/manifests/jobs/enhanced_ecommerce_search_api.pp
+++ b/modules/govuk_jenkins/manifests/jobs/enhanced_ecommerce_search_api.pp
@@ -11,7 +11,8 @@ class govuk_jenkins::jobs::enhanced_ecommerce_search_api (
 ) {
   $job_name = 'enhanced_ecommerce_search_api'
   $service_description = 'Enhanced Ecommerce ETL from Search API to Google Analytics'
-  $job_url = "https://deploy.blue.${::aws_environment}.govuk.digital/job/${job_name}/"
+  $deploy_jenkins_domain = hiera('deploy_jenkins_domain')
+  $job_url = "https://${deploy_jenkins_domain}/job/${job_name}/"
   $target_application = 'search-api'
 
   file { '/etc/jenkins_jobs/jobs/enhanced_ecommerce_search_api.yaml':

--- a/modules/govuk_jenkins/manifests/jobs/publishing_api_archive_events.pp
+++ b/modules/govuk_jenkins/manifests/jobs/publishing_api_archive_events.pp
@@ -5,12 +5,11 @@
 #
 # === Parameters:
 #
-class govuk_jenkins::jobs::publishing_api_archive_events(
-  $app_domain = hiera('app_domain'),
-) {
+class govuk_jenkins::jobs::publishing_api_archive_events {
   $check_name = 'publishing_api_archive_events'
   $service_description = 'Periodically archive publishing-api events to S3'
-  $job_url = "https://deploy.${app_domain}/job/Publishing_API_Archive_Events/"
+  $deploy_jenkins_domain = hiera('deploy_jenkins_domain')
+  $job_url = "https://${deploy_jenkins_domain}/job/Publishing_API_Archive_Events/"
 
   file { '/etc/jenkins_jobs/jobs/publishing_api_archive_events.yaml':
     ensure  => present,

--- a/modules/govuk_jenkins/manifests/jobs/search_api_fetch_analytics_data.pp
+++ b/modules/govuk_jenkins/manifests/jobs/search_api_fetch_analytics_data.pp
@@ -4,7 +4,6 @@
 #
 class govuk_jenkins::jobs::search_api_fetch_analytics_data (
   $ga_auth_password = undef,
-  $app_domain = hiera('app_domain'),
   $skip_page_traffic_load = false,
   $cron_schedule = '5 4 * * *',
 ) {

--- a/modules/govuk_jenkins/manifests/jobs/search_api_fetch_analytics_data.pp
+++ b/modules/govuk_jenkins/manifests/jobs/search_api_fetch_analytics_data.pp
@@ -19,7 +19,8 @@ class govuk_jenkins::jobs::search_api_fetch_analytics_data (
     notify  => Exec['jenkins_jobs_update'],
   }
 
-  $job_url = "https://deploy.blue.${::aws_environment}.govuk.digital/job/${job_name}/"
+  $deploy_jenkins_domain = hiera('deploy_jenkins_domain')
+  $job_url = "https://${deploy_jenkins_domain}/job/${job_name}/"
 
   @@icinga::passive_check { "${check_name}_${::hostname}":
     service_description => $service_description,

--- a/modules/govuk_jenkins/manifests/jobs/search_api_reindex_with_new_schema.pp
+++ b/modules/govuk_jenkins/manifests/jobs/search_api_reindex_with_new_schema.pp
@@ -3,7 +3,6 @@
 # Test rebuilding the search indexes and reindexing all content
 #
 class govuk_jenkins::jobs::search_api_reindex_with_new_schema (
-  $app_domain = hiera('app_domain'),
   $icinga_check_enabled = false,
   $cron_schedule = undef,
 ) {
@@ -12,7 +11,8 @@ class govuk_jenkins::jobs::search_api_reindex_with_new_schema (
   $service_description = 'Rebuild new Search API indexes with up to date settings and mappings and reindex all content from the existing indexes.'
   $job_name = 'search_api_reindex_with_new_schema'
   $job_display_name = 'Search API reindex with new schema'
-  $job_url = "https://deploy.${app_domain}/job/search-reindex-with-new-schema/"
+  $deploy_jenkins_domain = hiera('deploy_jenkins_domain')
+  $job_url = "https://${deploy_jenkins_domain}/job/search-reindex-with-new-schema/"
   $target_application = 'search-api'
 
   file { '/etc/jenkins_jobs/jobs/search_api_reindex_with_new_schema.yaml':

--- a/modules/govuk_jenkins/manifests/jobs/search_generate_sitemaps.pp
+++ b/modules/govuk_jenkins/manifests/jobs/search_generate_sitemaps.pp
@@ -4,10 +4,11 @@
 #
 class govuk_jenkins::jobs::search_generate_sitemaps{
   $app_domain = hiera('app_domain')
+  $deploy_jenkins_domain = hiera('deploy_jenkins_domain')
 
   $service_description = 'Runs a rake task on Search API that generates the sitemap files. It is safe to re-run in-hours.'
   $job_slug = 'search_generate_sitemaps'
-  $job_url = "https://deploy.blue.${::aws_environment}.govuk.digital/job/${job_slug}/"
+  $job_url = "https://${deploy_jenkins_domain}/job/${job_slug}/"
 
   file { '/etc/jenkins_jobs/jobs/search_generate_sitemaps.yaml':
     ensure  => present,

--- a/modules/govuk_jenkins/manifests/jobs/search_generate_sitemaps.pp
+++ b/modules/govuk_jenkins/manifests/jobs/search_generate_sitemaps.pp
@@ -3,7 +3,6 @@
 # Create a file on disk that can be parsed by jenkins-job-builder
 #
 class govuk_jenkins::jobs::search_generate_sitemaps{
-  $app_domain = hiera('app_domain')
   $deploy_jenkins_domain = hiera('deploy_jenkins_domain')
 
   $service_description = 'Runs a rake task on Search API that generates the sitemap files. It is safe to re-run in-hours.'

--- a/modules/govuk_jenkins/manifests/jobs/search_relevancy_metrics_etl.pp
+++ b/modules/govuk_jenkins/manifests/jobs/search_relevancy_metrics_etl.pp
@@ -16,7 +16,8 @@ class govuk_jenkins::jobs::search_relevancy_metrics_etl (
 ) {
   $check_name = 'search-relevancy-metrics-etl'
   $service_description = 'Search Relevancy Metrics ETL'
-  $job_url = "https://deploy.blue.${::aws_environment}.govuk.digital/job/search_relevancy_metrics_etl/"
+  $deploy_jenkins_domain = hiera('deploy_jenkins_domain')
+  $job_url = "https://${deploy_jenkins_domain}/job/search_relevancy_metrics_etl/"
 
   file { '/etc/jenkins_jobs/jobs/search_relevancy_metrics_etl.yaml':
     ensure  => present,

--- a/modules/govuk_jenkins/manifests/jobs/search_relevancy_metrics_etl.pp
+++ b/modules/govuk_jenkins/manifests/jobs/search_relevancy_metrics_etl.pp
@@ -12,7 +12,6 @@
 #
 class govuk_jenkins::jobs::search_relevancy_metrics_etl (
   $cron_schedule = undef,
-  $app_domain = hiera('app_domain'),
 ) {
   $check_name = 'search-relevancy-metrics-etl'
   $service_description = 'Search Relevancy Metrics ETL'

--- a/modules/govuk_jenkins/manifests/jobs/search_relevancy_rank_evaluation.pp
+++ b/modules/govuk_jenkins/manifests/jobs/search_relevancy_rank_evaluation.pp
@@ -15,7 +15,8 @@ class govuk_jenkins::jobs::search_relevancy_rank_evaluation (
 ) {
   $check_name = 'search-relevancy-rank-evaluation'
   $service_description = 'Search Relevancy Rank Evaluation'
-  $job_url = "https://deploy.blue.${::aws_environment}.govuk.digital/job/search_relevancy_rank_evaluation/"
+  $deploy_jenkins_domain = hiera('deploy_jenkins_domain')
+  $job_url = "https://${deploy_jenkins_domain}/job/search_relevancy_rank_evaluation/"
 
   file { '/etc/jenkins_jobs/jobs/search_relevancy_rank_evaluation.yaml':
     ensure  => present,

--- a/modules/govuk_jenkins/manifests/jobs/search_relevancy_rank_evaluation.pp
+++ b/modules/govuk_jenkins/manifests/jobs/search_relevancy_rank_evaluation.pp
@@ -11,7 +11,6 @@
 #
 class govuk_jenkins::jobs::search_relevancy_rank_evaluation (
   $cron_schedule = undef,
-  $app_domain = hiera('app_domain'),
 ) {
   $check_name = 'search-relevancy-rank-evaluation'
   $service_description = 'Search Relevancy Rank Evaluation'

--- a/modules/govuk_jenkins/manifests/jobs/smart_answers_broken_links_report.pp
+++ b/modules/govuk_jenkins/manifests/jobs/smart_answers_broken_links_report.pp
@@ -15,7 +15,8 @@ class govuk_jenkins::jobs::smart_answers_broken_links_report (
 ) {
   $check_name = 'smart-answers-broken-links-report'
   $service_description = 'Smart Answers Broken Links Report'
-  $job_url = "https://deploy.blue.${::aws_environment}.govuk.digital/job/smart_answers_broken_links_report/"
+  $deploy_jenkins_domain = hiera('deploy_jenkins_domain')
+  $job_url = "https://${deploy_jenkins_domain}/job/smart_answers_broken_links_report/"
 
   file { '/etc/jenkins_jobs/jobs/smart_answers_broken_links_report.yaml':
     ensure  => present,

--- a/modules/govuk_jenkins/manifests/jobs/smart_answers_broken_links_report.pp
+++ b/modules/govuk_jenkins/manifests/jobs/smart_answers_broken_links_report.pp
@@ -11,7 +11,6 @@
 #
 class govuk_jenkins::jobs::smart_answers_broken_links_report (
   $cron_schedule = undef,
-  $app_domain = hiera('app_domain'),
 ) {
   $check_name = 'smart-answers-broken-links-report'
   $service_description = 'Smart Answers Broken Links Report'

--- a/modules/govuk_jenkins/manifests/jobs/smokey.pp
+++ b/modules/govuk_jenkins/manifests/jobs/smokey.pp
@@ -12,7 +12,7 @@ class govuk_jenkins::jobs::smokey (
 ) {
   $environment_variables = $govuk_jenkins::environment_variables
   $smokey_task = "test:${environment}"
-  $app_domain = hiera('app_domain')
+  $deploy_jenkins_domain = hiera('deploy_jenkins_domain')
 
   include govuk::apps::smokey
 
@@ -25,14 +25,7 @@ class govuk_jenkins::jobs::smokey (
     require => Class['govuk::apps::smokey'],
   }
 
-  if ($::aws_environment != 'integration') {
-    $hosting_env_domain = "blue.${::aws_environment}.govuk.digital"
-  }
-  else {
-    $hosting_env_domain = $app_domain
-  }
-
-  $job_url = "https://deploy.${hosting_env_domain}/job/smokey/"
+  $job_url = "https://${deploy_jenkins_domain}/job/smokey/"
 
   @@icinga::passive_check { "smokey_${::hostname}":
     service_description => $service_description,

--- a/modules/govuk_jenkins/manifests/jobs/sync_assets_s3.pp
+++ b/modules/govuk_jenkins/manifests/jobs/sync_assets_s3.pp
@@ -3,11 +3,10 @@
 # Sync assets from Production to Staging/Integration. Intended to run only from
 # Production.
 #
-class govuk_jenkins::jobs::sync_assets_s3 (
-  $app_domain = hiera('app_domain'),
-) {
+class govuk_jenkins::jobs::sync_assets_s3 {
   $check_name = 'sync_assets_s3_from_prod_to_staging_and_integration'
-  $job_url = "https://deploy.${app_domain}/job/sync_assets_s3/"
+  $deploy_jenkins_domain = hiera('deploy_jenkins_domain')
+  $job_url = "https://${deploy_jenkins_domain}/job/sync_assets_s3/"
   $service_description = 'Sync assets in S3 from Production to Staging and Integration'
 
   file { '/etc/jenkins_jobs/jobs/sync_assets_s3.yaml':

--- a/modules/govuk_jenkins/manifests/jobs/transition_import_hits.pp
+++ b/modules/govuk_jenkins/manifests/jobs/transition_import_hits.pp
@@ -21,7 +21,8 @@ class govuk_jenkins::jobs::transition_import_hits(
 
   $check_name = 'transition-import-hits'
 
-  $job_url = "https://deploy.blue.${::aws_environment}.govuk.digital/job/transition_import_hits/"
+  $deploy_jenkins_domain = hiera('deploy_jenkins_domain')
+  $job_url = "https://${deploy_jenkins_domain}/job/transition_import_hits/"
 
   @@icinga::passive_check { "${check_name}_${::hostname}":
     service_description => $service_description,

--- a/modules/govuk_jenkins/manifests/jobs/transition_import_hits.pp
+++ b/modules/govuk_jenkins/manifests/jobs/transition_import_hits.pp
@@ -9,7 +9,6 @@
 #
 class govuk_jenkins::jobs::transition_import_hits(
   $s3_bucket = '',
-  $app_domain = hiera('app_domain'),
 ) {
   $service_description = 'Import daily hits into Transition'
 

--- a/modules/govuk_jenkins/manifests/jobs/update_cdn_dictionaries.pp
+++ b/modules/govuk_jenkins/manifests/jobs/update_cdn_dictionaries.pp
@@ -3,7 +3,6 @@
 # Create a file on disk that can be parsed by jenkins-job-builder
 #
 class govuk_jenkins::jobs::update_cdn_dictionaries(
-  $app_domain = hiera('app_domain'),
   $allow_deploy_to_mirror = true,
   $services = [],
 ) {
@@ -11,7 +10,8 @@ class govuk_jenkins::jobs::update_cdn_dictionaries(
   $environment_variables = $govuk_jenkins::environment_variables
   $slack_team_domain = 'gds'
   $slack_room = 'govuk-deploy'
-  $slack_build_server_url = "https://deploy.${app_domain}/"
+  $deploy_jenkins_domain = hiera('deploy_jenkins_domain')
+  $slack_build_server_url = "https://${deploy_jenkins_domain}/"
 
   file { '/etc/jenkins_jobs/jobs/update_cdn_dictionaries.yaml':
     ensure  => present,

--- a/modules/govuk_jenkins/manifests/jobs/user_monitor.pp
+++ b/modules/govuk_jenkins/manifests/jobs/user_monitor.pp
@@ -15,6 +15,7 @@ class govuk_jenkins::jobs::user_monitor (
 ) {
 
   $service_description = 'Check that correct users have access'
+  $deploy_jenkins_domain = hiera('deploy_jenkins_domain')
 
   file { '/etc/jenkins_jobs/jobs/user_monitor.yaml':
     ensure  => present,
@@ -33,7 +34,7 @@ class govuk_jenkins::jobs::user_monitor (
       service_description => $service_description,
       host_name           => $::fqdn,
       freshness_threshold => 5400, # 90 minutes
-      action_url          => "https://deploy.${::aws_stackname}.${::aws_environment}.govuk.digital/job/user-monitor/",
+      action_url          => "https://${deploy_jenkins_domain}/job/user-monitor/",
       notes_url           => monitoring_docs_url(user-monitor);
   }
 }

--- a/modules/govuk_jenkins/manifests/jobs/user_monitor.pp
+++ b/modules/govuk_jenkins/manifests/jobs/user_monitor.pp
@@ -10,7 +10,6 @@
 class govuk_jenkins::jobs::user_monitor (
   $github_token = undef,
   $sentry_auth_token = undef,
-  $app_domain = hiera('app_domain'),
   $enable_icinga_check = false,
 ) {
 

--- a/modules/govuk_jenkins/manifests/jobs/validate_published_dns.pp
+++ b/modules/govuk_jenkins/manifests/jobs/validate_published_dns.pp
@@ -8,11 +8,11 @@
 #
 class govuk_jenkins::jobs::validate_published_dns (
   $run_daily = false,
-  $app_domain = hiera('app_domain'),
 ){
   $check_name = 'validate_published_dns'
   $service_description = 'Check that the published DNS records match those in the govuk-dns-config repo'
-  $job_url = "https://deploy.${app_domain}/job/Validate_published_DNS/"
+  $deploy_jenkins_domain = hiera('deploy_jenkins_domain')
+  $job_url = "https://${deploy_jenkins_domain}/job/Validate_published_DNS/"
 
   file { '/etc/jenkins_jobs/jobs/validate_published_dns.yaml':
     ensure  => present,

--- a/modules/govuk_jenkins/manifests/jobs/whitehall_run_broken_link_checker.pp
+++ b/modules/govuk_jenkins/manifests/jobs/whitehall_run_broken_link_checker.pp
@@ -3,7 +3,6 @@
 # Create a file on disk that can be parsed by jenkins-job-builder
 #
 class govuk_jenkins::jobs::whitehall_run_broken_link_checker {
-  $app_domain = hiera('app_domain')
   $deploy_jenkins_domain = hiera('deploy_jenkins_domain')
 
   $service_description = 'Runs a rake task on Whitehall that generates a broken link report'

--- a/modules/govuk_jenkins/manifests/jobs/whitehall_run_broken_link_checker.pp
+++ b/modules/govuk_jenkins/manifests/jobs/whitehall_run_broken_link_checker.pp
@@ -4,10 +4,11 @@
 #
 class govuk_jenkins::jobs::whitehall_run_broken_link_checker {
   $app_domain = hiera('app_domain')
+  $deploy_jenkins_domain = hiera('deploy_jenkins_domain')
 
   $service_description = 'Runs a rake task on Whitehall that generates a broken link report'
   $job_slug = 'whitehall_run_broken_link_checker'
-  $job_url = "https://deploy.blue.${::aws_environment}.govuk.digital/job/${job_slug}"
+  $job_url = "https://${deploy_jenkins_domain}/job/${job_slug}"
 
   file { '/etc/jenkins_jobs/jobs/whitehall_run_broken_link_checker.yaml':
     ensure  => present,

--- a/spec/fixtures/hieradata/common.yaml
+++ b/spec/fixtures/hieradata/common.yaml
@@ -1,5 +1,6 @@
 app_domain: 'environment.example.com'
 app_domain_internal: 'dev.govuk-internal.digital'
+deploy_jenkins_domain: 'deploy.example.govuk.digital'
 
 apt_mirror_hostname: 'apt.publishing.service.gov.uk'
 apt_mirror_gpg_key_fingerprint: '0000111122223333444455556666777788889999'


### PR DESCRIPTION
This resolves a number of cases where Icinga has broken links in Production/Staging or Integration environments. It introduces a global hieradata approach which allows it to also resolve a variety of different techniques to set these links.

Adding global hieradata is frowned upon. I consider this a special circumstance since this task is normally achieved with a global hieradata (`app_domain`) and is only needed due to debt introduced by integration having a different configuration to other environments. This global hieradata is preferable to having a variety of logic in many different jobs.

I've given this a test run in integration and it applied to Jenkins and monitoring machines. It resolved the 5 broken links there.