### PR TITLE
Fix formatting of description of Deploy DNS job for GCP

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_dns.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_dns.yaml.erb
@@ -67,13 +67,11 @@
             name: GOOGLE_OAUTH_ACCESS_TOKEN
             default: false
             description: |
-              This is required for the GCP provider
+              This is required for the GCP provider.
 
-              Generate a token with using the gcloud CLI (https://cloud.google.com/sdk/docs/quickstart#mac)
+              Generate a token with using the gcloud CLI (https://cloud.google.com/sdk/docs/quickstart#mac).
 
-              gcloud config set project <%= @gce_project_id %>
-              gcloud auth login --brief
-              gcloud auth print-access-token
+              Run: gcloud config set project <%= @gce_project_id %>; gcloud auth login --brief; gcloud auth print-access-token
         - choice:
             name: ACTION
             description: Choose whether to plan (default) or apply


### PR DESCRIPTION
The description is displayed on a single line.  It currently looks like this:

<img width="1662" alt="Screenshot 2021-07-27 at 14 17 30" src="https://user-images.githubusercontent.com/75235/127160168-e0d88716-74a5-46d4-9e3d-0ed7fb5afa16.png">

Not realising it was three separate commands at first, I copied the whole `gcloud` command, which didn't work.  So, change each line to be a sentence ending with a full stop, and separate the commands with semicolons, to make it easier to read.