### PR TITLE
Add GOV.UK Notify env vars to Account API

### DIFF
--- a/modules/govuk/manifests/apps/account_api.pp
+++ b/modules/govuk/manifests/apps/account_api.pp
@@ -75,6 +75,12 @@
 # [*session_signing_key*]
 #   Secret key to sign user session data with
 #
+# [*govuk_notify_api_key*]
+#   API key for GOV.UK Notify
+#
+# [*govuk_notify_template_id*]
+#   Template ID for GOV.UK Notify
+#
 # [*redis_host*]
 #   Redis host for Sidekiq.
 #   Default: undef
@@ -106,6 +112,8 @@ class govuk::apps::account_api (
   $plek_account_manager_uri = undef,
   $email_alert_api_bearer_token = undef,
   $session_signing_key = undef,
+  $govuk_notify_api_key = undef,
+  $govuk_notify_template_id = undef,
   $redis_host = undef,
   $redis_port = undef,
 ) {
@@ -163,6 +171,12 @@ class govuk::apps::account_api (
     "${title}-SESSION_SIGNING_KEY":
         varname => 'SESSION_SIGNING_KEY',
         value   => $session_signing_key;
+    "${title}-GOVUK_NOTIFY_API_KEY":
+        varname => 'GOVUK_NOTIFY_API_KEY',
+        value   => $govuk_notify_api_key;
+    "${title}-GOVUK_NOTIFY_TEMPLATE_ID":
+        varname => 'GOVUK_NOTIFY_TEMPLATE_ID',
+        value   => $govuk_notify_template_id;
   }
 
   govuk::app::envvar::rabbitmq { 'account-api':


### PR DESCRIPTION
We are going to start sending emails for account events.  Most of the
emails will continue to be sent from the auth service (currently our
Account Manager, later Digital Identify), but those will be
generically worded.  We'll use account-api to send more specific
emails relating to what a user has been doing on GOV.UK (eg, when they
first activate a Transition Checker email subscription).

---

[Trello card](https://trello.com/c/aqRJqOKQ/914-send-brexit-checker-specific-welcome-email-when-someone-first-confirms-their-address)