### PR TITLE
Ensure namevar for content-data-api rds_config is unique

### DIFF
--- a/modules/govuk/manifests/apps/content_data_api/db.pp
+++ b/modules/govuk/manifests/apps/content_data_api/db.pp
@@ -15,7 +15,7 @@ class govuk::apps::content_data_api::db (
     extensions => ['plpgsql'],
   }
 
-  @@monitoring::checks::rds_config { 'content-data-api-postgresql-primary':
+  @@monitoring::checks::rds_config { "content-data-api-postgresql-primary_${::hostname}":
     memory_warning   => 2,
     memory_critical  => 1,
     storage_warning  => 50,


### PR DESCRIPTION
Namevar for exported resources must be unique; until now there had never been more than one instance with this resource so it was never an issue, but this is a requirement if we ever want to scale this up.
