### PR TITLE
Fix removal of CKAN harvest cron jobs

### DIFF
--- a/modules/govuk/manifests/apps/ckan/cronjobs.pp
+++ b/modules/govuk/manifests/apps/ckan/cronjobs.pp
@@ -62,6 +62,24 @@ class govuk::apps::ckan::cronjobs(
     minute         => '30',
   }
 
+  govuk::apps::ckan::paster_cronjob { 'Environment Agency harvester stop existing processes':
+    ensure         => 'absent',
+    paster_command => 'harvester job_abort environment-agency-data-sharing-platform',
+    plugin         => 'ckanext-harvest',
+    weekday        => '5',
+    hour           => '13',
+    minute         => '55',
+  }
+
+  govuk::apps::ckan::paster_cronjob { 'Environment Agency harvester run':
+    ensure         => 'absent',
+    paster_command => 'harvester run_test environment-agency-data-sharing-platform',
+    plugin         => 'ckanext-harvest',
+    weekday        => '5',
+    hour           => '14',
+    minute         => '0',
+  }
+
   govuk::apps::ckan::paster_cronjob { 'Vale of White Horse harvester stop existing processes':
     ensure         => $ensure,
     paster_command => 'harvester job_abort vale-of-white-horse-district-council-2',


### PR DESCRIPTION
This reverts https://github.com/alphagov/govuk-puppet/pull/11198/files#
and updating `ensure` to `absent` which is the value required to
remove a job, see https://puppet.com/docs/puppet/7/types/file.html#file-attribute-ensure

It's also worth keeping the job around rather than deleting completely
as the organisation might want it re-enabled in future.