### PR TITLE
Add Plek env var for account manager to email-alert-frontend

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -533,6 +533,7 @@ govuk::apps::email_alert_api::unicorn_worker_processes: '10'
 
 govuk::apps::email_alert_frontend::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::email_alert_frontend::redis_port: "%{hiera('sidekiq_port')}"
+govuk::apps::email_alert_frontend::plek_account_manager_uri: "%{hiera('govuk::apps::account_api::plek_account_manager_uri')}"
 
 govuk::apps::email_alert_service::enabled: true
 govuk::apps::email_alert_service::rabbitmq_hosts:

--- a/modules/govuk/manifests/apps/email_alert_frontend.pp
+++ b/modules/govuk/manifests/apps/email_alert_frontend.pp
@@ -56,6 +56,10 @@
 # [*account_change_email_enabled*]
 #   URL a user who needs to change their email address should go to.
 #
+# [*plek_account_manager_uri*]
+#   Path to the GOV.UK Account Manager
+#
+
 class govuk::apps::email_alert_frontend(
   $vhost = 'email-alert-frontend',
   $port,
@@ -71,6 +75,7 @@ class govuk::apps::email_alert_frontend(
   $account_auth_enabled = false,
   $account_confirm_email_url = undef,
   $account_change_email_url = undef,
+  $plek_account_manager_uri = undef,
 ) {
   $app_name = 'email-alert-frontend'
 
@@ -116,6 +121,9 @@ class govuk::apps::email_alert_frontend(
     "${title}-GOVUK_ACCOUNT_CHANGE_EMAIL_URL":
         varname => 'GOVUK_ACCOUNT_CHANGE_EMAIL_URL',
         value   => $account_change_email_url;
+    "${title}-PLEK-ACCOUNT-MANAGER-URI":
+      varname => 'PLEK_SERVICE_ACCOUNT_MANAGER_URI',
+      value   => $plek_account_manager_uri;
   }
 
   if $subscription_management_enabled {


### PR DESCRIPTION
We are making the email management pages look like the account if the
user's signed in through the account. Therefore there will be links from
`email-alert-frontend` back to the account manager and account feedback
page which is what this env var is needed for.


----

https://trello.com/c/F0ZDY0RC