### PR TITLE
Re enable harvesting on integration and staging

### DIFF
--- a/hieradata_aws/class/integration/ckan.yaml
+++ b/hieradata_aws/class/integration/ckan.yaml
@@ -5,11 +5,11 @@ govuk_solr6::present: true
 
 govuk::apps::ckan::blanket_redirect_url: https://find-data-beta-integration.cloudapps.digital/ckan_maintenance
 
-govuk::apps::ckan::enable_harvester_fetch: false
-govuk::apps::ckan::enable_harvester_gather: false
+govuk::apps::ckan::enable_harvester_fetch: true
+govuk::apps::ckan::enable_harvester_gather: true
 
-govuk::apps::ckan::cronjobs::enable: false
-govuk::apps::ckan::cronjobs::enable_solr_reindex: false
+govuk::apps::ckan::cronjobs::enable: true
+govuk::apps::ckan::cronjobs::enable_solr_reindex: true
 
 govuk::apps::ckan::solr_core: ckan
 govuk::apps::ckan::solr_core_configset: ckan28

--- a/hieradata_aws/class/staging/ckan.yaml
+++ b/hieradata_aws/class/staging/ckan.yaml
@@ -7,11 +7,11 @@ govuk::apps::ckan::enabled: true
 
 govuk::apps::ckan::blanket_redirect_url: https://find-data-beta-staging.cloudapps.digital/ckan_maintenance
 
-govuk::apps::ckan::enable_harvester_fetch: false
-govuk::apps::ckan::enable_harvester_gather: false
+govuk::apps::ckan::enable_harvester_fetch: true
+govuk::apps::ckan::enable_harvester_gather: true
 
-govuk::apps::ckan::cronjobs::enable: false
-govuk::apps::ckan::cronjobs::enable_solr_reindex: false
+govuk::apps::ckan::cronjobs::enable: true
+govuk::apps::ckan::cronjobs::enable_solr_reindex: true
 
 govuk::apps::ckan::solr_core: ckan
 govuk::apps::ckan::solr_core_configset: ckan28

--- a/modules/govuk/manifests/apps/ckan.pp
+++ b/modules/govuk/manifests/apps/ckan.pp
@@ -104,7 +104,7 @@ class govuk::apps::ckan (
   $collectd_process_regex = '\/gunicorn .* \/var\/ckan\/ckan29\.ini'
   $fetch_process_regex = '\/python \.\/venv3\/bin\/ckan -c \/var\/ckan\/ckan29\.ini harvester fetch-consumer'
   $gather_process_regex = '\/python \.\/venv3\/bin\/ckan -c \/var\/ckan\/ckan29\.ini harvester gather-consumer'
-  $pycsw_cmd = 'ckan ckan-pycsw'
+  $pycsw_cmd = "ckan -c ${ckan_ini} ckan-pycsw"
 
   $request_timeout = 60
 

--- a/modules/govuk/manifests/apps/ckan/cronjobs.pp
+++ b/modules/govuk/manifests/apps/ckan/cronjobs.pp
@@ -59,7 +59,7 @@ class govuk::apps::ckan::cronjobs(
   }
 
   govuk::apps::ckan::ckan_cronjob { 'Environment Agency harvester stop existing processes':
-    ensure       => $ensure,
+    ensure       => 'absent',
     ckan_command => 'harvester job-abort environment-agency-data-sharing-platform',
     weekday      => '5',
     hour         => '15',
@@ -67,7 +67,7 @@ class govuk::apps::ckan::cronjobs(
   }
 
   govuk::apps::ckan::ckan_cronjob { 'Environment Agency harvester run':
-    ensure       => $ensure,
+    ensure       => 'absent',
     ckan_command => 'harvester run-test environment-agency-data-sharing-platform',
     weekday      => '5',
     hour         => '16',


### PR DESCRIPTION
## What

Re-enable the harvest workers on Integration and Staging so that they can be tested before deploying CKAN 2.9 upgrade to production.

## Reference

https://trello.com/c/DZJFi8z5/2613-create-prs-to-prep-for-29-upgrade