### PR TITLE
Remove ckan blanket redirect from Staging and Integration

### DIFF
--- a/hieradata_aws/class/integration/ckan.yaml
+++ b/hieradata_aws/class/integration/ckan.yaml
@@ -3,9 +3,6 @@
 govuk_solr::disable: true
 govuk_solr6::present: true
 
-govuk::apps::ckan::blanket_redirect_url: https://find-data-beta-integration.cloudapps.digital/ckan_maintenance
-
-govuk::apps::ckan::enable_harvester_fetch: true
 govuk::apps::ckan::enable_harvester_gather: true
 
 govuk::apps::ckan::cronjobs::enable: true

--- a/hieradata_aws/class/staging/ckan.yaml
+++ b/hieradata_aws/class/staging/ckan.yaml
@@ -5,8 +5,6 @@ govuk_solr6::present: true
 
 govuk::apps::ckan::enabled: true
 
-govuk::apps::ckan::blanket_redirect_url: https://find-data-beta-staging.cloudapps.digital/ckan_maintenance
-
 govuk::apps::ckan::enable_harvester_fetch: true
 govuk::apps::ckan::enable_harvester_gather: true
 


### PR DESCRIPTION
## What

Remove the blanket redirect from CKAN from Staging and Integration to allow for a E2E testing.

## Reference 

https://trello.com/c/7HPu6jyN/2647-deployment-of-ckan-29-steps