### PR TITLE
Remove CKAN redirect from production

### DIFF
--- a/hieradata_aws/class/production/ckan.yaml
+++ b/hieradata_aws/class/production/ckan.yaml
@@ -5,8 +5,6 @@ govuk_solr6::present: true
 
 govuk::apps::ckan::enabled: true
 
-govuk::apps::ckan::blanket_redirect_url: https://data.gov.uk/ckan_maintenance
-
 govuk::apps::ckan::enable_harvester_fetch: false
 govuk::apps::ckan::enable_harvester_gather: false
 


### PR DESCRIPTION
## What

Remove the CKAN redirect from production when Staging testing is complete.

## Reference

https://trello.com/c/7HPu6jyN/2647-deployment-of-ckan-29-steps