### PR TITLE
Rewrite ckan healthcheck

### DIFF
--- a/modules/govuk/templates/ckan/nginx.conf.erb
+++ b/modules/govuk/templates/ckan/nginx.conf.erb
@@ -76,6 +76,10 @@ location ~ "^\/publisher(.*)" {
   return 301 /organization$1$query_string;
 }
 
+location /_healthcheck {
+  rewrite /_healthcheck /healthcheck last;
+}
+
 location /csw {
   <%- if @protected -%>
   deny all;


### PR DESCRIPTION
## What

A healthcheck is failing as it is attempting to go to `_healthcheck` so add a rewrite in nginx to return the response from `healthcheck` endpoint.

## Reference 

https://trello.com/c/7HPu6jyN/2647-deployment-of-ckan-29-steps