### PR TITLE
Add S3 ENV var for whitehall backend healthcheck

### DIFF
--- a/modules/govuk/manifests/node/s_whitehall_backend.pp
+++ b/modules/govuk/manifests/node/s_whitehall_backend.pp
@@ -36,4 +36,8 @@ class govuk::node::s_whitehall_backend (
     max_memory => '12%',
     listen_ip  => '0.0.0.0',
   }
+
+  govuk_envvar {
+    'RUN_S3_HEALTHCHECK_FOR_WHITEHALL_BACKEND': value => 'yes';
+  }
 }


### PR DESCRIPTION
This environment variable will be used to flag that Whitehall Backend
should run the S3 healthcheck.