### PR TITLE
Set the correct instance id in RDS checks for content-data-api

### DIFF
--- a/modules/govuk/manifests/apps/content_data_api/db.pp
+++ b/modules/govuk/manifests/apps/content_data_api/db.pp
@@ -16,6 +16,7 @@ class govuk::apps::content_data_api::db (
   }
 
   @@monitoring::checks::rds_config { "content-data-api-postgresql-primary_${::hostname}":
+    instance_id      => 'content-data-api-postgresql-primary',
     memory_warning   => 2,
     memory_critical  => 1,
     storage_warning  => 50,

--- a/modules/monitoring/manifests/checks/rds_config.pp
+++ b/modules/monitoring/manifests/checks/rds_config.pp
@@ -8,10 +8,13 @@
 #   Which AWS region should be checked ['us-east-1','eu-west-1']
 #
 # [*cpu_warning*]
-#   Defines the percentage of cpu usage for which a warning alert will be triggered. 
+#   Defines the percentage of cpu usage for which a warning alert will be triggered.
 #
 # [*cpu_critical*]
-#  Defines the percentage of cpu usage for which a critical alert will be triggered. 
+#  Defines the percentage of cpu usage for which a critical alert will be triggered.
+#
+# [*instance_id*]
+# Defines the name of the Database instance in AWS. It is used to look up metrics in CloudWatch.
 #
 # [*memory_warning*]
 #  Defines the percentage of free usable memory that will trigger a warning.
@@ -23,13 +26,14 @@ define monitoring::checks::rds_config (
   $region = undef,
   $cpu_warning = 80,
   $cpu_critical = 90,
+  $instance_id = undef,
   $memory_warning = 2,
   $memory_critical = 1,
   $storage_warning = 20,
   $storage_critical = 10,
 ){
   icinga::check { "check_aws_rds_cpu-${title}":
-    check_command       => "check_aws_rds_cpu!${region}!${cpu_warning}!${cpu_critical}!${::aws_stackname}-${title}",
+    check_command       => "check_aws_rds_cpu!${region}!${cpu_warning}!${cpu_critical}!${::aws_stackname}-${instance_id}",
     host_name           => $::fqdn,
     service_description => "${title} - AWS RDS CPU Utilization",
     notes_url           => monitoring_docs_url(aws-rds-cpu),
@@ -37,7 +41,7 @@ define monitoring::checks::rds_config (
   }
 
   icinga::check { "check_aws_rds_memory-${title}":
-    check_command       => "check_aws_rds_memory!${region}!${memory_warning}!${memory_critical}!${::aws_stackname}-${title}",
+    check_command       => "check_aws_rds_memory!${region}!${memory_warning}!${memory_critical}!${::aws_stackname}-${instance_id}",
     host_name           => $::fqdn,
     service_description => "${title} - AWS RDS Memory Utilization",
     notes_url           => monitoring_docs_url(aws-rds-memory),
@@ -45,7 +49,7 @@ define monitoring::checks::rds_config (
   }
 
   icinga::check { "check_aws_rds_storage-${title}":
-    check_command       => "check_aws_rds_storage!${region}!${storage_warning}!${storage_critical}!${::aws_stackname}-${title}",
+    check_command       => "check_aws_rds_storage!${region}!${storage_warning}!${storage_critical}!${::aws_stackname}-${instance_id}",
     host_name           => $::fqdn,
     service_description => "${title} - AWS RDS Storage Utilization",
     notes_url           => monitoring_docs_url(aws-rds-storage),


### PR DESCRIPTION
# What's changed and why?

This value used to be set to title, but title was [updated to be unique](ec0525e38ea5ed509cf0e945a37ee56ad4276f4f) to allow more instances to be monitored.

We need to allow title to remain unique but still point the check at the correct instance.

See errors:
https://alert.staging.govuk.digital/cgi-bin/icinga/extinfo.cgi?type=2&host=ip-10-12-5-36.eu-west-1.compute.internal&service=content-data-api-postgresql-primary_ip-10-12-4-10+-+AWS+RDS+CPU+Utilization
https://alert.blue.production.govuk.digital/cgi-bin/icinga/extinfo.cgi?type=2&host=ip-10-13-5-163.eu-west-1.compute.internal&service=content-data-api-postgresql-primary_ip-10-13-4-79+-+AWS+RDS+Memory+Utilization
https://alert.blue.production.govuk.digital/cgi-bin/icinga/extinfo.cgi?type=2&host=ip-10-13-5-163.eu-west-1.compute.internal&service=content-data-api-postgresql-primary_ip-10-13-4-79+-+AWS+RDS+Storage+Utilization