### PR TITLE
Simplify monitoring of content-data-api RDS

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1436,6 +1436,7 @@ monitoring::checks::cache::servers:
   - 'backend-redis-002'
 
 monitoring::checks::rds::servers:
+   - 'content-data-api-postgresql-primary'
    - 'postgresql-primary'
    - 'postgresql-standby'
    - 'transition-postgresql-primary'

--- a/modules/govuk/manifests/apps/content_data_api/db.pp
+++ b/modules/govuk/manifests/apps/content_data_api/db.pp
@@ -14,11 +14,4 @@ class govuk::apps::content_data_api::db (
     rds        => true,
     extensions => ['plpgsql'],
   }
-
-  @@monitoring::checks::rds_config { "content-data-api-postgresql-primary_${::hostname}":
-    memory_warning   => 2,
-    memory_critical  => 1,
-    storage_warning  => 50,
-    storage_critical => 25,
-  }
 }

--- a/modules/monitoring/manifests/checks/rds.pp
+++ b/modules/monitoring/manifests/checks/rds.pp
@@ -53,8 +53,11 @@ class monitoring::checks::rds (
       monitoring::checks::rds_config { $servers:
         region => $region,
       }
-      Monitoring::Checks::Rds_config <<| |>> {
-        region => $region,
+      Monitoring::Checks::Rds_config['content-data-api-postgresql-primary'] {
+        memory_warning   => 2,
+        memory_critical  => 1,
+        storage_warning  => 50,
+        storage_critical => 25,
       }
     }
 }


### PR DESCRIPTION
In e760f8eb we changed the way puppet creates the Icinga checks for
content-data's RDS instance. The goal was to have content-data
configured with different thresholds to the other instances (i.e. when
it should warn about memory / storage).

We did this by using the `@@` puppet syntax to "export" the resource:

https://puppet.com/docs/puppet/3.8/lang_exported.html

This meant that every instance of content-data-api would ask for a check
to be placed on the monitoring box.

This was fine for a long time, because we only had one instance of
content-data-api. When we scaled it up to two instances, we discovered
that puppet was unhappy because resources have to have unique names.
Both instances of content-data-api wanted to export the same Icinga
resource, with the same name.

We fixed this in ec0525e3 by appending the hostname of the content-data
instance to the title of the resource. Unfortunately, the resource uses
`$title` to look up the name of the database instance it's monitoring in
CloudWatch (it should be `content-data-api-postgresql-primary`). Having
the hostname on the end breaks this lookup, causing the check to fail.

This is a confusing situation, but what we want is actually quite
simple.

No matter how many instances of content-data we have, there will only be
one RDS instance of `content-data-api-postgresql-primary`. So there
should only be one check. Adding it to `monitoring::checks::rds::servers:`
isn't enough on its own, because the thresholds for the checks need to
be slightly different (which was the original motivation behind
exporting the resource from content-data-api). Instead, we can create
the resource like we do with all the other RDS servers, and then
immediately override its attributes using:

```
Monitoring::Checks::Rds_config['content-data-api-postgresql-primary'] {
  memory_warning   => 2,
  memory_critical  => 1,
  storage_warning  => 50,
  storage_critical => 25,
}
```

This feels a little bit hacky, because it's hard coding details of
content-data-api-postgresql-primary in the monitoring class (rather than
putting them in hieradata). But it gets the effect we want without the
confusing situation where the number of checks scales with the number of
content-data-api instances.

I've tested this on integration and the correct files are created with
the correct thresholds.

Supersedes #11237