### PR TITLE
Fix hieradata for RDS checks

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1433,7 +1433,11 @@ monitoring::checks::cache::servers:
   - 'backend-redis-002'
 
 monitoring::checks::rds::servers:
+   # NOTE: content-data-api-postgresql-primary is overridden in
+   # modules/monitoring/manifests/checks/rds.pp. If it is removed from this
+   # list, the override will also need to be removed.
    - 'content-data-api-postgresql-primary'
+
    - 'postgresql-primary'
    - 'postgresql-standby'
    - 'transition-postgresql-primary'

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -460,6 +460,7 @@ monitoring::edge::enabled: true
 monitoring::pagerduty_drill::enabled: true
 
 monitoring::checks::rds::servers:
+   - 'content-data-api-postgresql-primary'
    - 'postgresql-primary'
    - 'postgresql-standby'
    - 'transition-postgresql-primary'

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -459,15 +459,6 @@ monitoring::contacts::slack_username: 'Production (AWS)'
 monitoring::edge::enabled: true
 monitoring::pagerduty_drill::enabled: true
 
-monitoring::checks::rds::servers:
-   - 'content-data-api-postgresql-primary'
-   - 'postgresql-primary'
-   - 'postgresql-standby'
-   - 'transition-postgresql-primary'
-   - 'transition-postgresql-standby'
-   - 'mysql-primary'
-   - 'mysql-replica'
-
 monitoring::checks::smokey::environment: 'production_aws'
 monitoring::uptime_collector::environment: 'production'
 

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -443,6 +443,7 @@ monitoring::contacts::slack_username: 'Staging (AWS)'
 
 
 monitoring::checks::rds::servers:
+   - 'content-data-api-postgresql-primary'
    - 'postgresql-primary'
    - 'postgresql-standby'
    - 'transition-postgresql-primary'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -441,17 +441,6 @@ monitoring::contacts::notify_slack: true
 monitoring::contacts::slack_channel: '#govuk-alerts-staging'
 monitoring::contacts::slack_username: 'Staging (AWS)'
 
-
-monitoring::checks::rds::servers:
-   - 'content-data-api-postgresql-primary'
-   - 'postgresql-primary'
-   - 'postgresql-standby'
-   - 'transition-postgresql-primary'
-   - 'transition-postgresql-standby'
-   - 'mysql-primary'
-   - 'mysql-replica'
-
-
 monitoring::checks::smokey::environment: 'staging_aws'
 monitoring::checks::smokey::disable_during_data_sync: true
 monitoring::checks::smokey::features:


### PR DESCRIPTION
I'd added content-data-api to common.yaml, but I hadn't realised it was overridden to the same value in staging.yaml and production.yaml.

Because I'm overriding this specifically in `modules/monitoring/manifests/checks/rds.pp` this causes puppet to error on staging and production (where the value is missing).

To fix this, I've removed the unnecessary overrides in staging / prod, and added a comment to warn people that the override exists.