### PR TITLE
Remove Eric from integration

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -503,7 +503,6 @@ users::usernames:
   - deborahchua
   - duncangarmonsway
   - edwardkerry
-  - ericyoung
   - fredericfrancois
   - grahamlewis
   - huwdiprose


### PR DESCRIPTION
Follows on from: https://github.com/alphagov/govuk-user-reviewer/pull/560

Eric left GOV.UK on Wednesday.