### PR TITLE
Add environment variables to account-api to use Digital Identity

### DIFF
--- a/modules/govuk/manifests/apps/account_api.pp
+++ b/modules/govuk/manifests/apps/account_api.pp
@@ -66,6 +66,9 @@
 # [*account_oauth_client_secret*]
 #   Client secret for the Transition Checker in GOV.UK Account Manager
 #
+# [*account_oauth_private_key*]
+#   RSA private key for communication with the Digital Identity auth service.
+#
 # [*plek_account_manager_uri*]
 #   Path to the GOV.UK Account Manager
 #
@@ -109,6 +112,7 @@ class govuk::apps::account_api (
   $enable_publishing_queue_listener = false,
   $account_oauth_client_id = undef,
   $account_oauth_client_secret = undef,
+  $account_oauth_private_key = undef,
   $plek_account_manager_uri = undef,
   $email_alert_api_bearer_token = undef,
   $session_signing_key = undef,
@@ -162,6 +166,9 @@ class govuk::apps::account_api (
     "${title}-ACCOUNT-OAUTH-CLIENT-SECRET":
         varname => 'GOVUK_ACCOUNT_OAUTH_CLIENT_SECRET',
         value   => $account_oauth_client_secret;
+    "${title}-ACCOUNT-OAUTH-PRIVATE_KEY":
+        varname => 'GOVUK_ACCOUNT_OAUTH_PRIVATE_KEY',
+        value   => $account_oauth_private_key;
     "${title}-PLEK-ACCOUNT-MANAGER-URI":
         varname => 'PLEK_SERVICE_ACCOUNT_MANAGER_URI',
         value   => $plek_account_manager_uri;

--- a/modules/govuk/manifests/apps/account_api.pp
+++ b/modules/govuk/manifests/apps/account_api.pp
@@ -60,6 +60,10 @@
 #   Run the worker which processes publishing updates.
 #   Default: false
 #
+# [*account_oauth_provider_uri*]
+#   URI of the OAuth / OpenID Connect provider.
+#   "#{account_oauth_provider_uri}/.well-known/openid-configuration" should exist.
+#
 # [*account_oauth_client_id*]
 #   Client ID for the Transition Checker in GOV.UK Account Manager
 #
@@ -110,6 +114,7 @@ class govuk::apps::account_api (
   $rabbitmq_password = 'account_api',
   $enable_procfile_worker = false,
   $enable_publishing_queue_listener = false,
+  $account_oauth_provider_uri = undef,
   $account_oauth_client_id = undef,
   $account_oauth_client_secret = undef,
   $account_oauth_private_key = undef,
@@ -160,6 +165,9 @@ class govuk::apps::account_api (
     "${title}-GDS_SSO_OAUTH_SECRET":
       varname => 'GDS_SSO_OAUTH_SECRET',
       value   => $oauth_secret;
+    "${title}-ACCOUNT-OAUTH-PROVIDER-URI":
+        varname => 'GOVUK_ACCOUNT_OAUTH_PROVIDER_URI',
+        value   => $account_oauth_provider_uri;
     "${title}-ACCOUNT-OAUTH-CLIENT-ID":
         varname => 'GOVUK_ACCOUNT_OAUTH_CLIENT_ID',
         value   => $account_oauth_client_id;


### PR DESCRIPTION
The DI auth service is not the account-manager, so we need a new env var holding its URL; and it uses RSA keypair auth (not client ID / secret auth), so we need a new env var holding that.

---

[Trello card](https://trello.com/c/ZvDGaba4/958-use-di-auth-in-integration-give-feedback-on-their-documentation)