### PR TITLE
Upgrade insecure Jenkins plugins

### DIFF
--- a/hieradata_aws/class/integration/ci_master.yaml
+++ b/hieradata_aws/class/integration/ci_master.yaml
@@ -254,8 +254,6 @@ govuk_jenkins::plugins:
     version: '1.1.1'
   htmlpublisher:
     version: '1.25'
-  icon-shim:
-    version: '2.0.3'
   jackson2-api:
     version: '2.12.4'
   javadoc:
@@ -272,8 +270,6 @@ govuk_jenkins::plugins:
     version: '1.2.1'
   jquery:
     version: '1.12.4-0'
-  jquery-ui:
-    version: '1.0.2'
   jsch:
     version: '0.1.55.2'
   junit:

--- a/hieradata_aws/class/integration/ci_master.yaml
+++ b/hieradata_aws/class/integration/ci_master.yaml
@@ -173,7 +173,7 @@ govuk_jenkins::plugins:
   brakeman:
     version: '0.12'
   branch-api:
-    version: '2.0.21'
+    version: '2.6.5'
   build-name-setter:
     version: '2.0.1'
   build-pipeline-plugin:
@@ -183,11 +183,11 @@ govuk_jenkins::plugins:
   checks-api:
     version: '1.7.2'
   cloudbees-folder:
-    version: '6.5.1'
+    version: '6.16'
   cobertura:
-    version: '1.13'
+    version: '1.16'
   code-coverage-api:
-    version: '1.0.11'
+    version: '1.4.0'
   command-launcher:
     version: '1.3'
   conditional-buildstep:
@@ -199,7 +199,7 @@ govuk_jenkins::plugins:
   credentials:
     version: '2.5'
   data-tables-api:
-    version: '1.10.25-1'
+    version: '1.10.25-3'
   description-setter:
     version: '1.10'
   display-url-api:
@@ -222,8 +222,10 @@ govuk_jenkins::plugins:
     version: '5.0.0'
   font-awesome-api:
     version: '5.15.3-4'
+  forensics-api:
+    version: '1.3.0'
   generic-webhook-trigger:
-    version: '1.67'
+    version: '1.74'
   git-client:
     version: '3.9.0'
   git:
@@ -237,7 +239,7 @@ govuk_jenkins::plugins:
   github-oauth:
     version: '0.33'
   git-server:
-    version: '1.7'
+    version: '1.10'
   google-container-registry-auth:
     version: '0.3'
   google-oauth-plugin:
@@ -251,7 +253,7 @@ govuk_jenkins::plugins:
   handlebars:
     version: '1.1.1'
   htmlpublisher:
-    version: '1.18'
+    version: '1.25'
   icon-shim:
     version: '2.0.3'
   jackson2-api:
@@ -279,13 +281,13 @@ govuk_jenkins::plugins:
   ldap:
     version: '1.20'
   lockable-resources:
-    version: '2.5'
+    version: '2.11'
   mailer:
     version: '1.34'
   mapdb-api:
     version: '1.0.9.0'
   matrix-auth:
-    version: '2.3'
+    version: '2.6.8'
   matrix-project:
     version: '1.19'
   maven-plugin:
@@ -347,7 +349,7 @@ govuk_jenkins::plugins:
   resource-disposer:
     version: '0.12'
   role-strategy:
-    version: '2.11'
+    version: '3.2.0'
   ruby:
     version: '1.2'
   rubyMetrics:
@@ -373,19 +375,19 @@ govuk_jenkins::plugins:
   ssh-credentials:
     version: '1.19'
   sshd:
-    version: '3.0.3'
+    version: '3.1.0'
   ssh-slaves:
     version: '1.29.4'
   structs:
     version: '1.23'
   swarm:
-    version: '3.17'
+    version: '3.27'
   text-finder:
     version: '1.11'
   throttle-concurrents:
     version: '2.0.1'
   timestamper:
-    version: '1.9'
+    version: '1.13'
   token-macro:
     version: '266.v44a80cf277fd'
   trilead-api:
@@ -407,15 +409,15 @@ govuk_jenkins::plugins:
   workflow-basic-steps:
     version: '2.15'
   workflow-cps-global-lib:
-    version: '2.13'
+    version: '2.21'
   workflow-cps:
-    version: '2.70'
+    version: '2.93'
   workflow-durable-task-step:
     version: '2.28'
   workflow-job:
-    version: '2.32'
+    version: '2.41'
   workflow-multibranch:
-    version: '2.21'
+    version: '2.26'
   workflow-scm-step:
     version: '2.13'
   workflow-step-api:

--- a/hieradata_aws/class/integration/ci_master.yaml
+++ b/hieradata_aws/class/integration/ci_master.yaml
@@ -153,13 +153,13 @@ govuk_jenkins::plugins:
   analysis-core:
     version: '1.96'
   analysis-model-api:
-    version: '5.1.1'
+    version: '10.3.0'
   ansicolor:
     version: '0.5.3'
   ant:
     version: '1.9'
   antisamy-markup-formatter:
-    version: '1.5'
+    version: '2.1'
   apache-httpcomponents-client-4-api:
     version: '4.5.13-1.0'
   authentication-tokens:
@@ -393,7 +393,7 @@ govuk_jenkins::plugins:
   violations:
     version: '0.7.11'
   warnings-ng:
-    version: '5.1.0'
+    version: '9.5.0'
   warnings:
     version: '5.0.1'
   windows-slaves:

--- a/hieradata_aws/class/jenkins.yaml
+++ b/hieradata_aws/class/jenkins.yaml
@@ -111,8 +111,6 @@ govuk_jenkins::plugins:
     version: '1.27'
   credentials:
     version: '2.5'
-  cvs:
-    version: '2.19'
   data-tables-api:
     version: '1.10.25-3'
   description-setter:
@@ -175,12 +173,6 @@ govuk_jenkins::plugins:
     version: '1.1.1'
   htmlpublisher:
     version: '1.25'
-  icon-shim:
-    version: '2.0.3'
-  instant-messaging:
-    version: '1.42'
-  ircbot:
-    version: '2.36'
   jackson2-api:
     version: '2.12.4'
   javadoc:
@@ -197,8 +189,6 @@ govuk_jenkins::plugins:
     version: '1.2.1'
   jquery:
     version: '1.12.4-0'
-  jquery-ui:
-    version: '1.0.2'
   jsch:
     version: '0.1.55.2'
   junit:
@@ -291,8 +281,6 @@ govuk_jenkins::plugins:
     version: '1.5'
   scm-api:
     version: '2.6.5'
-  scm-sync-configuration:
-    version: '0.0.10'
   script-security:
     version: '1.78'
   show-build-parameters:
@@ -315,8 +303,6 @@ govuk_jenkins::plugins:
     version: '1.29.4'
   structs:
     version: '1.23'
-  subversion:
-    version: '2.14.4'
   swarm:
     version: '3.27'
   text-finder:

--- a/hieradata_aws/class/jenkins.yaml
+++ b/hieradata_aws/class/jenkins.yaml
@@ -58,13 +58,13 @@ govuk_jenkins::plugins:
   analysis-core:
     version: '1.96'
   analysis-model-api:
-    version: '5.1.1'
+    version: '10.3.0'
   ansicolor:
     version: '0.5.3'
   ant:
     version: '1.9'
   antisamy-markup-formatter:
-    version: '1.5'
+    version: '2.1'
   apache-httpcomponents-client-4-api:
     version: '4.5.13-1.0'
   authentication-tokens:
@@ -322,7 +322,7 @@ govuk_jenkins::plugins:
   violations:
     version: '0.7.11'
   warnings-ng:
-    version: '5.1.0'
+    version: '9.5.0'
   warnings:
     version: '5.0.1'
   windows-slaves:

--- a/hieradata_aws/class/jenkins.yaml
+++ b/hieradata_aws/class/jenkins.yaml
@@ -80,7 +80,7 @@ govuk_jenkins::plugins:
   brakeman:
     version: '0.12'
   branch-api:
-    version: '2.0.21'
+    version: '2.6.5'
   build-name-setter:
     version: '2.0.1'
   build-pipeline-plugin:
@@ -90,17 +90,17 @@ govuk_jenkins::plugins:
   build-user-vars-plugin:
     version: '1.5'
   build-with-parameters:
-    version: '1.4'
+    version: '1.5.1'
   caffeine-api:
     version: '2.9.1-23.v51c4e2c879c8'
   checks-api:
     version: '1.7.2'
   cloudbees-folder:
-    version: '6.5.1'
+    version: '6.16'
   cobertura:
-    version: '1.13'
+    version: '1.16'
   code-coverage-api:
-    version: '1.0.11'
+    version: '1.4.0'
   command-launcher:
     version: '1.3'
   conditional-buildstep:
@@ -112,9 +112,9 @@ govuk_jenkins::plugins:
   credentials:
     version: '2.5'
   cvs:
-    version: '2.14'
+    version: '2.19'
   data-tables-api:
-    version: '1.10.25-1'
+    version: '1.10.25-3'
   description-setter:
     version: '1.10'
   display-url-api:
@@ -126,11 +126,11 @@ govuk_jenkins::plugins:
   downstream-buildview:
     version: '1.9'
   durable-task:
-    version: '1.29'
+    version: '1.39'
   echarts-api:
     version: '5.1.2-8'
   email-ext:
-    version: '2.66'
+    version: '2.83'
   envinject-api:
     version: '1.5'
   envinject:
@@ -141,8 +141,10 @@ govuk_jenkins::plugins:
     version: '5.0.0'
   font-awesome-api:
     version: '5.15.3-4'
+  forensics-api:
+    version: '1.3.0'
   generic-webhook-trigger:
-    version: '1.67'
+    version: '1.74'
   git-client:
     version: '3.9.0'
   git:
@@ -156,7 +158,7 @@ govuk_jenkins::plugins:
   github-oauth:
     version: '0.33'
   git-server:
-    version: '1.7'
+    version: '1.10'
   google-container-registry-auth:
     version: '0.3'
   google-oauth-plugin:
@@ -172,13 +174,13 @@ govuk_jenkins::plugins:
   handlebars:
     version: '1.1.1'
   htmlpublisher:
-    version: '1.18'
+    version: '1.25'
   icon-shim:
     version: '2.0.3'
   instant-messaging:
-    version: '1.35'
+    version: '1.42'
   ircbot:
-    version: '2.30'
+    version: '2.36'
   jackson2-api:
     version: '2.12.4'
   javadoc:
@@ -204,13 +206,13 @@ govuk_jenkins::plugins:
   ldap:
     version: '2.0'
   lockable-resources:
-    version: '2.5'
+    version: '2.11'
   mailer:
     version: '1.34'
   mapdb-api:
     version: '1.0.9.0'
   matrix-auth:
-    version: '2.6.6'
+    version: '2.6.8'
   matrix-project:
     version: '1.19'
   maven-plugin:
@@ -274,7 +276,7 @@ govuk_jenkins::plugins:
   resource-disposer:
     version: '0.12'
   role-strategy:
-    version: '2.11'
+    version: '3.2.0'
   ruby:
     version: '1.2'
   rubyMetrics:
@@ -316,13 +318,13 @@ govuk_jenkins::plugins:
   subversion:
     version: '2.14.4'
   swarm:
-    version: '3.17'
+    version: '3.27'
   text-finder:
     version: '1.11'
   throttle-concurrents:
     version: '2.0.1'
   timestamper:
-    version: '1.9'
+    version: '1.13'
   token-macro:
     version: '266.v44a80cf277fd'
   translation:
@@ -346,15 +348,15 @@ govuk_jenkins::plugins:
   workflow-basic-steps:
     version: '2.15'
   workflow-cps-global-lib:
-    version: '2.13'
-  workflow-cps:
-    version: '2.70'
-  workflow-durable-task-step:
-    version: '2.28'
-  workflow-job:
-    version: '2.32'
-  workflow-multibranch:
     version: '2.21'
+  workflow-cps:
+    version: '2.93'
+  workflow-durable-task-step:
+    version: '2.39'
+  workflow-job:
+    version: '2.41'
+  workflow-multibranch:
+    version: '2.26'
   workflow-scm-step:
     version: '2.13'
   workflow-step-api:


### PR DESCRIPTION
Upgrading Jenkins plugins with known security vulnerabilities, excluding those with compatibility issues that may make upgrades more difficult.

Also taking the opportunity to remove some unused plugins.

https://trello.com/c/pCKvKF2J/2583-upgrade-jenkins-plugins-to-versions-without-security-vulnerabilities-5

