### PR TITLE
Install Terraform version 0.12

### DIFF
--- a/modules/govuk_jenkins/manifests/packages/tfenv.pp
+++ b/modules/govuk_jenkins/manifests/packages/tfenv.pp
@@ -10,7 +10,7 @@
 #
 #
 class govuk_jenkins::packages::tfenv (
-  $terraform_versions = ['0.11.14', '0.11.15', '0.13.6'],
+  $terraform_versions = ['0.11.14', '0.11.15', '0.12.30', '0.13.6'],
 ){
 
   include ::tfenv


### PR DESCRIPTION
We need TF version 12 to upgrade from 0.11 to 0.13. HashiCorp don't recommend upgrading more than one major (minor) version at a time.