### PR TITLE
Change `ensure` to "present" for CKAN sync, not "enabled"

### DIFF
--- a/hieradata_aws/class/integration/db_admin.yaml
+++ b/hieradata_aws/class/integration/db_admin.yaml
@@ -11,7 +11,7 @@ govuk_env_sync::tasks:
     url: "govuk-production-database-backups"
     path: "postgresql-backend"
   "pull_ckan_production":
-    ensure: "enabled"
+    ensure: "present"
     hour: "0"
     minute: "0"
     action: "pull"


### PR DESCRIPTION
We're getting an error about the passive check associated with this
job.  The error is confusing, it says that we can't specify more than
one of `content`, `source`, or `target` - but it's clear that it's
something to do with this job.

Since all the other jobs use `ensure: "present"` and not `ensure:
"enabled"`, I think that line is at fault here.