### PR TITLE
Run mongodb check with python2.7

### DIFF
--- a/modules/mongodb/files/nagios-plugin-mongodb/check_mongodb.py
+++ b/modules/mongodb/files/nagios-plugin-mongodb/check_mongodb.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/opt/python2.7/bin/python
 
 #
 # A MongoDB Nagios check script


### PR DESCRIPTION
We're getting an error in Icinga:

    No module named pymongo

This is because the deploy user runs this with python 3, but we only
have the module installed for python 2.7.

This has to be specifically the version of python 2.7 in /opt, `env
python2` doesn't find the module either - we have other checks which
use this path too (like a few of the check_aws_* ones), so it's not
particularly weird.

```
michaelswalker@ec2-integration-blue-ci_agent-ip-10-1-5-68:~$ sudo su - deploy
deploy@ec2-integration-blue-ci_agent-ip-10-1-5-68:~$ /opt/python2.7/bin/python /usr/lib/nagios/plugins/check_mongodb.py
OK - Connection took 0 seconds
```