### PR TITLE
Add Locations API to CI

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -931,6 +931,7 @@ govuk_ci::master::pipeline_jobs:
     repository: 'licence-finder'
   link-checker-api: {}
   local-links-manager: {}
+  locations-api: {}
   manuals-frontend: {}
   mapit: {}
   publishing-api: {}


### PR DESCRIPTION
This will allow us to build the new [Locations API application](https://github.com/alphagov/locations-api) in CI. The application is not yet deployable, so it does not need adding anywhere else.

[Trello card](https://trello.com/c/yGHQYoWC)