### PR TITLE
Upgrade all Jenkins plugins without compatibility issues

### DIFF
--- a/hieradata_aws/class/integration/ci_master.yaml
+++ b/hieradata_aws/class/integration/ci_master.yaml
@@ -155,31 +155,31 @@ govuk_jenkins::plugins:
   analysis-model-api:
     version: '10.3.0'
   ansicolor:
-    version: '0.5.3'
+    version: '1.0.0'
   ant:
-    version: '1.9'
+    version: '1.11'
   antisamy-markup-formatter:
     version: '2.1'
   apache-httpcomponents-client-4-api:
     version: '4.5.13-1.0'
   authentication-tokens:
-    version: '1.3'
+    version: '1.4'
   bootstrap4-api:
     version: '4.6.0-3'
   bootstrap5-api:
     version: '5.1.0-1'
   bouncycastle-api:
-    version: '2.17'
+    version: '2.23'
   brakeman:
     version: '0.12'
   branch-api:
     version: '2.6.5'
   build-name-setter:
-    version: '2.0.1'
+    version: '2.2.0'
   build-pipeline-plugin:
     version: '1.5.8'
   caffeine-api:
-    version: '2.9.1-23.v51c4e2c879c8'
+    version: '2.9.2-29.v717aac953ff3'
   checks-api:
     version: '1.7.2'
   cloudbees-folder:
@@ -189,7 +189,7 @@ govuk_jenkins::plugins:
   code-coverage-api:
     version: '1.4.0'
   command-launcher:
-    version: '1.3'
+    version: '1.6'
   conditional-buildstep:
     version: '1.4.1'
   copyartifact:
@@ -205,17 +205,17 @@ govuk_jenkins::plugins:
   display-url-api:
     version: '2.3.5'
   docker-commons:
-    version: '1.14'
+    version: '1.17'
   docker-workflow:
     version: '1.18'
   durable-task:
-    version: '1.29'
+    version: '1.39'
   echarts-api:
-    version: '5.1.2-8'
+    version: '5.1.2-9'
   envinject-api:
-    version: '1.5'
+    version: '1.7'
   envinject:
-    version: '2.1.6'
+    version: '2.4.0'
   external-monitor-job:
     version: '1.7'
   findbugs:
@@ -233,9 +233,9 @@ govuk_jenkins::plugins:
   github-api:
     version: '1.123'
   github-branch-source:
-    version: '2.5.3'
+    version: '2.11.2'
   github:
-    version: '1.33.1'
+    version: '1.34.0'
   github-oauth:
     version: '0.33'
   git-server:
@@ -245,13 +245,13 @@ govuk_jenkins::plugins:
   google-oauth-plugin:
     version: '0.8'
   gradle:
-    version: '1.32'
+    version: '1.37.1'
   greenballs:
-    version: '1.15'
+    version: '1.15.1'
   groovy:
-    version: '2.2'
+    version: '2.4'
   handlebars:
-    version: '1.1.1'
+    version: '3.0.8'
   htmlpublisher:
     version: '1.25'
   jackson2-api:
@@ -259,7 +259,7 @@ govuk_jenkins::plugins:
   javadoc:
     version: '1.6'
   jdk-tool:
-    version: '1.2'
+    version: '1.5'
   jenkinswalldisplay:
     version: '0.6.34'
   jjwt-api:
@@ -269,13 +269,13 @@ govuk_jenkins::plugins:
   jquery-detached:
     version: '1.2.1'
   jquery:
-    version: '1.12.4-0'
+    version: '1.12.4-1'
   jsch:
     version: '0.1.55.2'
   junit:
     version: '1.52'
   ldap:
-    version: '1.20'
+    version: '2.7'
   lockable-resources:
     version: '2.11'
   mailer:
@@ -291,45 +291,45 @@ govuk_jenkins::plugins:
   momentjs:
     version: '1.1.1'
   monitoring:
-    version: '1.77.0'
+    version: '1.88.0'
   naginator:
-    version: '1.18'
+    version: '1.18.1'
   next-build-number:
-    version: '1.5'
+    version: '1.6'
   nodelabelparameter:
-    version: '1.7.2'
+    version: '1.9.0'
   oauth-credentials:
-    version: '0.3'
+    version: '0.4'
   okhttp-api:
     version: '3.14.9'
   pam-auth:
-    version: '1.4.1'
+    version: '1.6'
   parameterized-trigger:
     version: '2.41'
   pipeline-build-step:
-    version: '2.9'
+    version: '2.15'
   pipeline-graph-analysis:
-    version: '1.9'
+    version: '1.11'
   pipeline-input-step:
-    version: '2.10'
+    version: '2.12'
   pipeline-milestone-step:
-    version: '1.3.1'
+    version: '1.3.2'
   pipeline-model-api:
-    version: '1.3.8'
+    version: '1.9.1'
   pipeline-model-declarative-agent:
     version: '1.1.1'
   pipeline-model-definition:
     version: '1.3.8'
   pipeline-model-extensions:
-    version: '1.3.8'
+    version: '1.9.1'
   pipeline-rest-api:
-    version: '2.11'
+    version: '2.19'
   pipeline-stage-step:
-    version: '2.3'
+    version: '2.5'
   pipeline-stage-tags-metadata:
-    version: '1.3.8'
+    version: '1.9.1'
   pipeline-stage-view:
-    version: '2.11'
+    version: '2.19'
   plain-credentials:
     version: '1.7'
   plugin-util-api:
@@ -341,9 +341,9 @@ govuk_jenkins::plugins:
   rake:
     version: '1.8.0'
   rebuild:
-    version: '1.31'
+    version: '1.32'
   resource-disposer:
-    version: '0.12'
+    version: '0.16'
   role-strategy:
     version: '3.2.0'
   ruby:
@@ -359,7 +359,7 @@ govuk_jenkins::plugins:
   script-security:
     version: '1.78'
   simple-theme-plugin:
-    version: '0.5.1'
+    version: '0.7'
   sitemonitor:
     version: '0.6'
   slack:
@@ -367,7 +367,7 @@ govuk_jenkins::plugins:
   snakeyaml-api:
     version: '1.29.1'
   ssh-agent:
-    version: '1.17'
+    version: '1.23'
   ssh-credentials:
     version: '1.19'
   sshd:
@@ -379,9 +379,9 @@ govuk_jenkins::plugins:
   swarm:
     version: '3.27'
   text-finder:
-    version: '1.11'
+    version: '1.16'
   throttle-concurrents:
-    version: '2.0.1'
+    version: '2.4'
   timestamper:
     version: '1.13'
   token-macro:
@@ -397,19 +397,19 @@ govuk_jenkins::plugins:
   warnings:
     version: '5.0.1'
   windows-slaves:
-    version: '1.4'
+    version: '1.8'
   workflow-aggregator:
-    version: '2.5'
+    version: '2.6'
   workflow-api:
     version: '2.46'
   workflow-basic-steps:
-    version: '2.15'
+    version: '2.24'
   workflow-cps-global-lib:
     version: '2.21'
   workflow-cps:
     version: '2.93'
   workflow-durable-task-step:
-    version: '2.28'
+    version: '2.39'
   workflow-job:
     version: '2.41'
   workflow-multibranch:
@@ -421,7 +421,7 @@ govuk_jenkins::plugins:
   workflow-support:
     version: '3.8'
   ws-cleanup:
-    version: '0.37'
+    version: '0.39'
 
 lv:
   data:

--- a/hieradata_aws/class/jenkins.yaml
+++ b/hieradata_aws/class/jenkins.yaml
@@ -60,15 +60,15 @@ govuk_jenkins::plugins:
   analysis-model-api:
     version: '10.3.0'
   ansicolor:
-    version: '0.5.3'
+    version: '1.0.0'
   ant:
-    version: '1.9'
+    version: '1.11'
   antisamy-markup-formatter:
     version: '2.1'
   apache-httpcomponents-client-4-api:
     version: '4.5.13-1.0'
   authentication-tokens:
-    version: '1.3'
+    version: '1.4'
   badge:
     version: '1.8'
   bootstrap4-api:
@@ -76,23 +76,23 @@ govuk_jenkins::plugins:
   bootstrap5-api:
     version: '5.1.0-1'
   bouncycastle-api:
-    version: '2.20'
+    version: '2.23'
   brakeman:
     version: '0.12'
   branch-api:
     version: '2.6.5'
   build-name-setter:
-    version: '2.0.1'
+    version: '2.2.0'
   build-pipeline-plugin:
     version: '1.5.8'
   build-token-root:
-    version: '1.4'
+    version: '1.7'
   build-user-vars-plugin:
-    version: '1.5'
+    version: '1.7'
   build-with-parameters:
     version: '1.5.1'
   caffeine-api:
-    version: '2.9.1-23.v51c4e2c879c8'
+    version: '2.9.2-29.v717aac953ff3'
   checks-api:
     version: '1.7.2'
   cloudbees-folder:
@@ -102,7 +102,7 @@ govuk_jenkins::plugins:
   code-coverage-api:
     version: '1.4.0'
   command-launcher:
-    version: '1.3'
+    version: '1.6'
   conditional-buildstep:
     version: '1.4.1'
   copyartifact:
@@ -118,7 +118,7 @@ govuk_jenkins::plugins:
   display-url-api:
     version: '2.3.5'
   docker-commons:
-    version: '1.14'
+    version: '1.17'
   docker-workflow:
     version: '1.18'
   downstream-buildview:
@@ -126,13 +126,13 @@ govuk_jenkins::plugins:
   durable-task:
     version: '1.39'
   echarts-api:
-    version: '5.1.2-8'
+    version: '5.1.2-9'
   email-ext:
     version: '2.83'
   envinject-api:
-    version: '1.5'
+    version: '1.7'
   envinject:
-    version: '2.1.6'
+    version: '2.4.0'
   external-monitor-job:
     version: '1.7'
   findbugs:
@@ -150,9 +150,9 @@ govuk_jenkins::plugins:
   github-api:
     version: '1.123'
   github-branch-source:
-    version: '2.5.3'
+    version: '2.11.2'
   github:
-    version: '1.33.1'
+    version: '1.34.0'
   github-oauth:
     version: '0.33'
   git-server:
@@ -162,15 +162,15 @@ govuk_jenkins::plugins:
   google-oauth-plugin:
     version: '0.8'
   gradle:
-    version: '1.32'
+    version: '1.37.1'
   greenballs:
-    version: '1.15'
+    version: '1.15.1'
   groovy:
-    version: '2.2'
+    version: '2.4'
   groovy-postbuild:
-    version: '2.4.3'
+    version: '2.5'
   handlebars:
-    version: '1.1.1'
+    version: '3.0.8'
   htmlpublisher:
     version: '1.25'
   jackson2-api:
@@ -178,7 +178,7 @@ govuk_jenkins::plugins:
   javadoc:
     version: '1.6'
   jdk-tool:
-    version: '1.2'
+    version: '1.5'
   jenkinswalldisplay:
     version: '0.6.34'
   jjwt-api:
@@ -188,13 +188,13 @@ govuk_jenkins::plugins:
   jquery-detached:
     version: '1.2.1'
   jquery:
-    version: '1.12.4-0'
+    version: '1.12.4-1'
   jsch:
     version: '0.1.55.2'
   junit:
     version: '1.52'
   ldap:
-    version: '2.0'
+    version: '2.7'
   lockable-resources:
     version: '2.11'
   mailer:
@@ -210,47 +210,47 @@ govuk_jenkins::plugins:
   momentjs:
     version: '1.1.1'
   monitoring:
-    version: '1.77.0'
+    version: '1.88.0'
   naginator:
-    version: '1.18'
+    version: '1.18.1'
   next-build-number:
-    version: '1.5'
+    version: '1.6'
   nodelabelparameter:
-    version: '1.7.2'
+    version: '1.9.0'
   oauth-credentials:
-    version: '0.3'
+    version: '0.4'
   okhttp-api:
     version: '3.14.9'
   pam-auth:
-    version: '1.5.1'
+    version: '1.6'
   parameterized-scheduler:
-    version: '0.6.3'
+    version: '1.0'
   parameterized-trigger:
     version: '2.41'
   pipeline-build-step:
-    version: '2.9'
+    version: '2.15'
   pipeline-graph-analysis:
-    version: '1.9'
+    version: '1.11'
   pipeline-input-step:
-    version: '2.10'
+    version: '2.12'
   pipeline-milestone-step:
-    version: '1.3.1'
+    version: '1.3.2'
   pipeline-model-api:
-    version: '1.3.8'
+    version: '1.9.1'
   pipeline-model-declarative-agent:
     version: '1.1.1'
   pipeline-model-definition:
     version: '1.3.8'
   pipeline-model-extensions:
-    version: '1.3.8'
+    version: '1.9.1'
   pipeline-rest-api:
-    version: '2.11'
+    version: '2.19'
   pipeline-stage-step:
-    version: '2.3'
+    version: '2.5'
   pipeline-stage-tags-metadata:
-    version: '1.3.8'
+    version: '1.9.1'
   pipeline-stage-view:
-    version: '2.11'
+    version: '2.19'
   plain-credentials:
     version: '1.7'
   plugin-util-api:
@@ -262,9 +262,9 @@ govuk_jenkins::plugins:
   rake:
     version: '1.8.0'
   rebuild:
-    version: '1.31'
+    version: '1.32'
   resource-disposer:
-    version: '0.12'
+    version: '0.16'
   role-strategy:
     version: '3.2.0'
   ruby:
@@ -286,7 +286,7 @@ govuk_jenkins::plugins:
   show-build-parameters:
     version: '1.0'
   simple-theme-plugin:
-    version: '0.5.1'
+    version: '0.7'
   sitemonitor:
     version: '0.6'
   slack:
@@ -294,11 +294,11 @@ govuk_jenkins::plugins:
   snakeyaml-api:
     version: '1.29.1'
   ssh-agent:
-    version: '1.17'
+    version: '1.23'
   ssh-credentials:
     version: '1.19'
   sshd:
-    version: '3.0.4'
+    version: '3.1.0'
   ssh-slaves:
     version: '1.29.4'
   structs:
@@ -306,9 +306,9 @@ govuk_jenkins::plugins:
   swarm:
     version: '3.27'
   text-finder:
-    version: '1.11'
+    version: '1.16'
   throttle-concurrents:
-    version: '2.0.1'
+    version: '2.4'
   timestamper:
     version: '1.13'
   token-macro:
@@ -326,13 +326,13 @@ govuk_jenkins::plugins:
   warnings:
     version: '5.0.1'
   windows-slaves:
-    version: '1.4'
+    version: '1.8'
   workflow-aggregator:
-    version: '2.5'
+    version: '2.6'
   workflow-api:
     version: '2.46'
   workflow-basic-steps:
-    version: '2.15'
+    version: '2.24'
   workflow-cps-global-lib:
     version: '2.21'
   workflow-cps:
@@ -350,4 +350,4 @@ govuk_jenkins::plugins:
   workflow-support:
     version: '3.8'
   ws-cleanup:
-    version: '0.37'
+    version: '0.39'


### PR DESCRIPTION
These are all the plugins with available upgrades, excluding the ones marked as incompatible (which will need manual intervention).

https://trello.com/c/pCKvKF2J/2583-upgrade-jenkins-plugins-to-versions-without-security-vulnerabilities-5
