### PR TITLE
Remove unused Windows WMI Agent plugin from Jenkins

### DIFF
--- a/hieradata_aws/class/integration/ci_master.yaml
+++ b/hieradata_aws/class/integration/ci_master.yaml
@@ -396,8 +396,6 @@ govuk_jenkins::plugins:
     version: '9.5.0'
   warnings:
     version: '5.0.1'
-  windows-slaves:
-    version: '1.8'
   workflow-aggregator:
     version: '2.6'
   workflow-api:

--- a/hieradata_aws/class/jenkins.yaml
+++ b/hieradata_aws/class/jenkins.yaml
@@ -325,8 +325,6 @@ govuk_jenkins::plugins:
     version: '9.5.0'
   warnings:
     version: '5.0.1'
-  windows-slaves:
-    version: '1.8'
   workflow-aggregator:
     version: '2.6'
   workflow-api:


### PR DESCRIPTION
This plugin is unmaintained and we don't use it; best to remove to avoid future issues.

(This change won't actually uninstall the plugin now that it's been installed, because the Jenkins module doesn't seem to support that; it'll need to be manually removed. This just means it won't be automatically installed.)

https://trello.com/c/pCKvKF2J/2583-upgrade-jenkins-plugins-to-versions-without-security-vulnerabilities-5
