### PR TITLE
Rename ckan config files without 29 suffix

### DIFF
--- a/modules/govuk/manifests/apps/ckan.pp
+++ b/modules/govuk/manifests/apps/ckan.pp
@@ -97,10 +97,10 @@ class govuk::apps::ckan (
   $ckan_home = '/var/ckan'
   $pycsw_config = "${ckan_home}/pycsw.cfg"
 
-  $ckan_ini = "${ckan_home}/ckan29.ini"
-  $who_ini = "${ckan_home}/who29.ini"
-  $govuk_ckan_ini = 'govuk/ckan/ckan29.ini.erb'
-  $govuk_who_ini = 'govuk/ckan/who29.ini.erb'
+  $ckan_ini = "${ckan_home}/ckan.ini"
+  $who_ini = "${ckan_home}/who.ini"
+  $govuk_ckan_ini = 'govuk/ckan/ckan.ini.erb'
+  $govuk_who_ini = 'govuk/ckan/who.ini.erb'
   $collectd_process_regex = '\/gunicorn -p /var/run/ckan/unicornherder.pid'
   $fetch_process_regex = '\/ckan .* harvester fetch-consumer'
   $gather_process_regex = '\/ckan .* harvester gather-consumer'


### PR DESCRIPTION
## What

ckan29.ini and who29.ini were used to enable deployment of both CKAN 2.8 and CKAN 2.9, now that we have deployed CKAN 2.9, the suffix is no longer needed as the files have been renamed without the 29 suffix.

## Reference 

https://trello.com/c/7HPu6jyN/2647-deployment-of-ckan-29-steps