### PR TITLE
Update publisher to allow organogram file download

### DIFF
--- a/modules/govuk/templates/ckan/nginx.conf.erb
+++ b/modules/govuk/templates/ckan/nginx.conf.erb
@@ -72,8 +72,12 @@ location /api/3<%= path %> {
 <% end %>
 
 # Redirect publisher to organization for CKAN 2.9 in case it has been bookmarked
-location ~ "^\/publisher(.*)" {
-  return 301 /organization$1$query_string;
+location ~ "^\/publisher\/(.*)" {
+  return 301 /organization/$1$is_args$args;
+}
+# match this exactly as /publisher-files is also in use for organogram files
+location = "/publisher" {
+  return 301 /organization;
 }
 
 location /_healthcheck {


### PR DESCRIPTION
## What

Update the nginx redirect rule for `/publisher` as `/publisher-files` is used to download the organogram template file, so match the route with a trailing slash or match the route exactly.

## Reference 

https://trello.com/c/7zEm64rz/2672-the-link-to-the-organogram-template-is-a-404