### PR TITLE
Fix problem when provisioning new `monitoring` machine instance

### DIFF
--- a/lib/tasks/icinga_checks.rake
+++ b/lib/tasks/icinga_checks.rake
@@ -1,13 +1,13 @@
 desc "Test icinga::checks are unique per machine"
 task :icinga_checks do
   $stderr.puts '---> Checking icinga::check titles are sufficiently unique'
-  bad_lines = %x{grep -rnF --include '*.pp' 'icinga::check[\s|\{]' . | grep -Ev '^./modules/(icinga|monitoring/manifests/checks)' | grep -vF hostname}
+  bad_lines = %x{grep -rnF --include '*.pp' 'icinga::check \{' . | grep -Ev '^./modules/(icinga|monitoring/manifests/checks)' | grep -vF hostname}
   if !bad_lines.empty? then
     $stderr.puts bad_lines
     fail 'ERROR: icinga::check resource titles should be unique per machine. Normally you can achieve this by adding ${::hostname} eg "check_widgets_${::hostname}".'
   end
   $stderr.puts '---> Checking icinga::passive_check titles are sufficiently unique'
-  bad_lines = %x{grep -rnF --include '*.pp' 'icinga::passive_check[\s|\{]' . | grep -Ev '^./modules/(icinga|monitoring/manifests/checks)' | grep -vF hostname}
+  bad_lines = %x{grep -rnF --include '*.pp' 'icinga::passive_check \{' . | grep -Ev '^./modules/(icinga|monitoring/manifests/checks)' | grep -vF hostname}
   if !bad_lines.empty? then
     $stderr.puts bad_lines
     fail 'ERROR: icinga::passive_check resource titles should be unique per machine. Normally you can achieve this by adding ${::hostname} eg "check_widgets_${::hostname}".'

--- a/lib/tasks/icinga_checks.rake
+++ b/lib/tasks/icinga_checks.rake
@@ -12,4 +12,10 @@ task :icinga_checks do
     $stderr.puts bad_lines
     fail 'ERROR: icinga::passive_check resource titles should be unique per machine. Normally you can achieve this by adding ${::hostname} eg "check_widgets_${::hostname}".'
   end
+  $stderr.puts '---> Checking icinga::checks do not include hostnames for monitoring class'
+  bad_lines = %x{grep -rnF --include '*.pp' 'icinga::check \{' . | grep -E '^./modules/(monitoring/manifests/checks)' | grep -F hostname}
+  if !bad_lines.empty? then
+    $stderr.puts bad_lines
+    fail 'ERROR: icinga::check resource titles should not contain the hostname for checks running on the monitoring machine class.'
+  end
 end

--- a/modules/govuk/manifests/apps/email_alert_api/checks.pp
+++ b/modules/govuk/manifests/apps/email_alert_api/checks.pp
@@ -24,7 +24,7 @@ class govuk::apps::email_alert_api::checks(
       latency_critical => '86400'; # 24 hours
   }
 
-  @@icinga::check::graphite { 'email-alert-api-unprocessed-content-changes':
+  @@icinga::check::graphite { "email-alert-api-unprocessed-content-changes_${::hostname}":
     ensure    => $ensure,
     host_name => $::fqdn,
     target    => 'transformNull(keepLastValue(averageSeries(stats.gauges.govuk.app.email-alert-api.*.content_changes.unprocessed_total)))',
@@ -35,7 +35,7 @@ class govuk::apps::email_alert_api::checks(
     notes_url => monitoring_docs_url(email-alert-api-unprocessed-work),
   }
 
-  @@icinga::check::graphite { 'email-alert-api-critical-digest-runs':
+  @@icinga::check::graphite { "email-alert-api-critical-digest-runs_${::hostname}":
     ensure    => $ensure,
     host_name => $::fqdn,
     target    => 'transformNull(keepLastValue(averageSeries(stats.gauges.govuk.app.email-alert-api.*.digest_runs.critical_total)))',
@@ -46,7 +46,7 @@ class govuk::apps::email_alert_api::checks(
     notes_url => monitoring_docs_url(email-alert-api-unprocessed-work),
   }
 
-  @@icinga::check::graphite { 'email-alert-api-unprocessed-messages':
+  @@icinga::check::graphite { "email-alert-api-unprocessed-messages_${::hostname}":
     ensure    => $ensure,
     host_name => $::fqdn,
     target    => 'transformNull(keepLastValue(averageSeries(stats.gauges.govuk.app.email-alert-api.*.messages.unprocessed_total)))',

--- a/modules/govuk/manifests/apps/publisher/unprocessed_emails_count_check.pp
+++ b/modules/govuk/manifests/apps/publisher/unprocessed_emails_count_check.pp
@@ -12,7 +12,7 @@
 class govuk::apps::publisher::unprocessed_emails_count_check(
   $ensure = present,
 ) {
-  @@icinga::check::graphite { 'check_publisher_unprocessed_fact_check_emails':
+  @@icinga::check::graphite { "check_publisher_unprocessed_fact_check_emails_${::hostname}":
     ensure    => $ensure,
     host_name => $::fqdn,
     target    => 'summarize(stats.gauges.govuk.app.publisher.*.unprocessed_emails.count,"5min","max")',

--- a/modules/govuk_jenkins/manifests/jobs/athena_fastly_logs_check/icinga_database_check.pp
+++ b/modules/govuk_jenkins/manifests/jobs/athena_fastly_logs_check/icinga_database_check.pp
@@ -24,8 +24,7 @@ define govuk_jenkins::jobs::athena_fastly_logs_check::icinga_database_check (
   $jenkins_url = undef,
   $service_description = undef,
 ) {
-  @@icinga::passive_check {
-    "athena_fastly_logs_check_${name}_${::hostname}":
+  @@icinga::passive_check { "athena_fastly_logs_check_${name}_${::hostname}":
       service_description     => regsubst($service_description, '\$\{DATABASE\}', $name),
       host_name               => $::fqdn,
       freshness_threshold     => 86400, # 24 hours

--- a/modules/govuk_jenkins/manifests/jobs/email_alert_check.pp
+++ b/modules/govuk_jenkins/manifests/jobs/email_alert_check.pp
@@ -42,8 +42,7 @@ class govuk_jenkins::jobs::email_alert_check (
       notify  => Exec['jenkins_jobs_update'];
   }
 
-  @@icinga::passive_check {
-    "${medical_safety_check_name}_${::hostname}":
+  @@icinga::passive_check { "${medical_safety_check_name}_${::hostname}":
       service_description     => $medical_safety_service_description,
       host_name               => $::fqdn,
       freshness_threshold     => 5400, # 90 minutes

--- a/modules/govuk_jenkins/manifests/jobs/user_monitor.pp
+++ b/modules/govuk_jenkins/manifests/jobs/user_monitor.pp
@@ -27,8 +27,7 @@ class govuk_jenkins::jobs::user_monitor (
     false => 'absent'
   }
 
-  @@icinga::passive_check {
-    "user_monitor_${::hostname}":
+  @@icinga::passive_check { "user_monitor_${::hostname}":
       ensure              => $icinga_check_ensure,
       service_description => $service_description,
       host_name           => $::fqdn,

--- a/modules/govuk_jenkins/manifests/ssh_slave.pp
+++ b/modules/govuk_jenkins/manifests/ssh_slave.pp
@@ -66,7 +66,7 @@ define govuk_jenkins::ssh_slave (
   }
 
   include icinga::client::check_jenkins_agent
-  @@icinga::check { "check_jenkins_agent_status_${agent_name}":
+  @@icinga::check { "check_jenkins_agent_status_${agent_name}_${::hostname}":
     check_command       => "check_nrpe!check_jenkins_agent!${agent_name}",
     service_description => "${title} is not connected to the Jenkins master",
     host_name           => $::fqdn,

--- a/modules/icinga/manifests/smokey_loop.pp
+++ b/modules/icinga/manifests/smokey_loop.pp
@@ -4,7 +4,7 @@ define icinga::smokey_loop(
   $ensure = present,
   $notes_url = undef
 ) {
-  icinga::check { "smokey_loop_for_${feature}":
+  icinga::check { "smokey_loop_for_${feature}_${::hostname}":
     ensure              => $ensure,
     check_command       => "run_smokey_tests!${feature}",
     service_description => "Smokey loop for ${feature}",

--- a/modules/icinga/spec/defines/icinga__smokey_loop_spec.rb
+++ b/modules/icinga/spec/defines/icinga__smokey_loop_spec.rb
@@ -14,6 +14,6 @@ describe 'icinga::smokey_loop', :type => :define do
   }}
   it {
     is_expected.to contain_file('/etc/icinga/conf.d/icinga_host_test_host.blah.blah/'\
-      'smokey_loop_for_test_feature.cfg')
+      'smokey_loop_for_test_feature_test_host.cfg')
   }
 end

--- a/modules/monitoring/manifests/checks.pp
+++ b/modules/monitoring/manifests/checks.pp
@@ -69,7 +69,7 @@ class monitoring::checks (
 
   include icinga::client::check_json_healthcheck
 
-  icinga::check { "content_data_api_search_${::hostname}":
+  icinga::check { 'content_data_api_search':
     check_command              => "check_app_health!check_json_healthcheck!443 ${content_data_api_search_path} ${content_data_api_hostname} https",
     service_description        => 'search healthcheck for content-data-api',
     use                        => 'govuk_urgent_priority',
@@ -80,7 +80,7 @@ class monitoring::checks (
     retry_interval             => 1,
   }
 
-  icinga::check { "content_data_api_metrics_${::hostname}":
+  icinga::check { 'content_data_api_metrics':
     check_command              => "check_app_health!check_json_healthcheck!443 ${content_data_api_metrics_path} ${content_data_api_hostname} https",
     service_description        => 'metrics healthcheck for content-data-api',
     use                        => 'govuk_urgent_priority',
@@ -91,7 +91,7 @@ class monitoring::checks (
     retry_interval             => 1,
   }
 
-  icinga::check { "signon_api_tokens_${::hostname}":
+  icinga::check { 'signon_api_tokens':
     check_command       => "check_app_health!check_json_healthcheck!443 /healthcheck/api-tokens signon.${app_domain} https",
     service_description => 'expiring API tokens in Signon',
     host_name           => $::fqdn,
@@ -99,7 +99,7 @@ class monitoring::checks (
     check_period        => $signon_api_tokens_check_period,
   }
 
-  icinga::check { "publisher_scheduled_publishing_${::hostname}":
+  icinga::check { 'publisher_scheduled_publishing':
     check_command       => "check_app_health!check_json_healthcheck!443 /healthcheck/scheduled-publishing publisher.${app_domain} https",
     service_description => 'more items scheduled for publication than in queue for publisher',
     host_name           => $::fqdn,
@@ -107,7 +107,7 @@ class monitoring::checks (
     check_period        => $publisher_scheduled_publishing_check_period,
   }
 
-  icinga::check { "search_api_reranker_${::hostname}":
+  icinga::check { 'search_api_reranker':
     check_command       => "check_app_health!check_json_healthcheck!443 /healthcheck/reranker search-api.${app_domain_internal} https",
     service_description => 'search reranker healthcheck is not ok',
     host_name           => $::fqdn,
@@ -115,14 +115,14 @@ class monitoring::checks (
     check_period        => $search_api_reranker_check_period,
   }
 
-  icinga::check { "search_api_elasticsearch_diskspace_${::hostname}":
+  icinga::check { 'search_api_elasticsearch_diskspace':
     check_command       => "check_app_health!check_json_healthcheck!443 /healthcheck/elasticsearch-diskspace search-api.${app_domain_internal} https",
     service_description => 'elasticsearch diskspace is too low',
     host_name           => $::fqdn,
     check_period        => $search_api_elasticsearch_diskspace_check_period,
   }
 
-  icinga::check { "content_publisher_government_data_${::hostname}":
+  icinga::check { 'content_publisher_government_data':
     check_command       => "check_app_health!check_json_healthcheck!443 /healthcheck/government-data content-publisher.${app_domain} https",
     service_description => 'content-publisher government data check is not ok',
     host_name           => $::fqdn,

--- a/modules/monitoring/manifests/checks/whitehall.pp
+++ b/modules/monitoring/manifests/checks/whitehall.pp
@@ -19,7 +19,7 @@ class monitoring::checks::whitehall ($check_period = undef) {
     require => Icinga::Plugin['check_http_timeout_noncrit'],
   }
 
-  icinga::check { "check_whitehall_overdue_from_${::hostname}":
+  icinga::check { 'check_whitehall_overdue':
     check_command              => 'check_whitehall_overdue',
     service_description        => 'overdue publications in Whitehall',
     use                        => 'govuk_urgent_priority',
@@ -37,7 +37,7 @@ class monitoring::checks::whitehall ($check_period = undef) {
     require => Icinga::Plugin['check_http_timeout_noncrit'],
   }
 
-  icinga::check { "check_whitehall_scheduled_from_${::hostname}":
+  icinga::check { 'check_whitehall_scheduled':
     check_command              => 'check_whitehall_scheduled',
     service_description        => 'scheduled publications in Whitehall not queued',
     use                        => 'govuk_urgent_priority',

--- a/modules/monitoring/manifests/network_checks.pp
+++ b/modules/monitoring/manifests/network_checks.pp
@@ -20,7 +20,7 @@ define monitoring::network_checks (
       use                 => 'third-party-host',
     }
 
-    icinga::check { "check_ping_${title}":
+    icinga::check { "check_ping_${title}_${::hostname}":
       check_command       => 'check_ping!100.0,20%!500.0,60%',
       notification_period => '24x7',
       use                 => 'govuk_high_priority',

--- a/modules/monitoring/manifests/uptime_collector.pp
+++ b/modules/monitoring/manifests/uptime_collector.pp
@@ -33,7 +33,7 @@ class monitoring::uptime_collector($environment = '') {
     enable => true,
   }
 
-  @@icinga::check { 'check_uptime_collector_running':
+  @@icinga::check { "check_uptime_collector_running_${::hostname}":
     check_command       => 'check_nrpe!check_proc_running_with_arg!ruby /usr/local/bin/govuk_uptime_collector',
     service_description => 'govuk_uptime_collector not running',
     host_name           => $::fqdn,


### PR DESCRIPTION
Puppet fails when a new instance of the `monitoring` machine class is created.  This causes multiple problems, including the inability to SSH into the new machine.

The errors were caused by Icinga check titles either not being unique (where they should've been) or including the hostname where this caused a check to not be found in the Puppet catalog.

This fixes the errors by ensuring the titles for Icinga check resources are unique where required, and not unique for checks running solely on the `monitoring` class where the test including the other machine instance(s) hostnames would not be found in the Puppet catalog.

[Trello card](https://trello.com/c/R5qp0I7o)