### PR TITLE
Run app healthchecks as part of CD pipeline

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1076,12 +1076,17 @@ govuk_jenkins::jobs::deploy_app::applications: *deployable_applications
 
 govuk_jenkins::jobs::deploy_app_downstream::applications:
   account-api: {}
-  authenticating-proxy: {}
+  authenticating-proxy:
+    healthcheck_urls:
+      - "https://draft-origin.%{hiera('app_domain')}/healthcheck/ready"
   bouncer: {}
-  cache-clearing-service: {}
+  cache-clearing-service:
+    healthcheck_urls: [] # done implicitly as part of app restart script
   collections: {}
   collections-publisher: {}
-  content-data-admin: {}
+  content-data-admin:
+    healthcheck_urls:
+      - "https://content-data.%{hiera('app_domain_internal')}/healthcheck/ready"
   content-data-api: {}
   content-publisher: {}
   email-alert-frontend: {}
@@ -1105,7 +1110,10 @@ govuk_jenkins::jobs::deploy_app_downstream::applications:
     repository: 'smart-answers'
   support: {}
   travel-advice-publisher: {}
-  whitehall: {}
+  whitehall:
+    healthcheck_urls:
+      - "https://whitehall-admin.%{hiera('app_domain_internal')}/healthcheck/ready"
+      - "https://whitehall-frontend.%{hiera('app_domain_internal')}/healthcheck/ready"
 
 govuk_jenkins::jobs::deploy_lambda_app::lambda_apps:
   - 'email_alert_notifications'

--- a/modules/govuk_jenkins/manifests/jobs/deploy_app_downstream.pp
+++ b/modules/govuk_jenkins/manifests/jobs/deploy_app_downstream.pp
@@ -36,6 +36,7 @@ class govuk_jenkins::jobs::deploy_app_downstream (
 ) {
   $deploy_jenkins_domain = hiera('deploy_jenkins_domain')
   $slack_build_server_url = "https://${deploy_jenkins_domain}/"
+  $app_domain = hiera('app_domain_internal')
 
   file { '/etc/jenkins_jobs/jobs/deploy_app_downstream.yaml':
     ensure  => present,

--- a/modules/govuk_jenkins/templates/jobs/deploy_app_downstream.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_app_downstream.yaml.erb
@@ -30,13 +30,29 @@
           fi
 
           # Workaround for our inconsistent repo vs. deployment naming
+          # and multiple / different healthcheck URLs
           case "$TARGET_APPLICATION" in
           <% @applications.keys.each do |app| %>
+            <% default_healthcheck_urls = [
+              "https://#{app}.#{@app_domain}/healthcheck/ready"
+            ] %>
+
             <%= app %>)
               REPO="<%= @applications[app].fetch("repository", app) %>"
+
+              HEALTHCHECK_URLS="<%= @applications[app].fetch(
+                "healthcheck_urls", default_healthcheck_urls
+              ).join(" ")%>"
               ;;
           <% end %>
           esac
+
+          <% if @smokey_pre_check %>
+          # Check healthcheck endpoints return 200 OK
+          for url in $HEALTHCHECK_URLS; do
+            curl --fail $url;
+          done
+          <% end %>
 
           # Check release to deploy is genuine and we're not going backwards
           GITHUB_API="https://api.github.com/repos/alphagov/$REPO"


### PR DESCRIPTION
https://trello.com/c/USH1B9K1/243-investigate-drying-up-deployment-healthchecks-out-of-smokey

One of the consequences of the CD RFC [1].

Currently these are written as bespoke scenarios in Smokey [2],
which is more work and confuses the purpose of the smoke tests
and leads to duplicate Icinga alerts. This makes the healthchecks
part of the CD pipeline so we can remove the bespoke scenarios.

Some apps don't support a web-based healthcheck, such as Cache
Clearing Service. In such cases we can use an empty array of URLs
to represent this. Other apps use a custom (Contacts Admin) or
even multiple domains, which we need to set explicitly.

Note that, unlike the existing scenario for Whitehall [3], this
tests both the Admin and Frontend instances due to the distinct
functionality. Conversely, it's not worth testing draft instances
of frontend apps as they behave the same as non-draft instances.

[1]: https://github.com/alphagov/govuk-rfcs/blob/main/rfc-128-continuous-deployment.md#healthy-deployments
[2]: https://github.com/alphagov/smokey/blob/cae82f827db5153f5545c342bd0f6ff19289e189/features/authenticating_proxy.feature
[3]: https://github.com/alphagov/smokey/blob/cae82f827db5153f5545c342bd0f6ff19289e189/features/whitehall.feature#L37-L41