### PR TITLE
Set account manage / security URI env vars for static in integration

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -78,6 +78,8 @@ govuk::apps::specialist_publisher::aws_s3_bucket_name: 'govuk-integration-specia
 govuk::apps::specialist_publisher::publish_pre_production_finders: true
 govuk::apps::specialist_publisher::govuk_notify_template_id: "759acac6-da53-4a19-b591-b7538c7c39de"
 govuk::apps::static::ga_universal_id: 'UA-26179049-22'
+govuk::apps::static::govuk_personalisation_manage_uri: 'https://account-management.integration.auth.ida.digital.cabinet-office.gov.uk/?link=manage-account'
+govuk::apps::static::govuk_personalisation_security_uri: 'https://account-management.integration.auth.ida.digital.cabinet-office.gov.uk/?link=security-privacy'
 govuk::apps::support::aws_s3_bucket_name: 'govuk-integration-support-api-csvs'
 govuk::apps::support_api::aws_s3_bucket_name: 'govuk-integration-support-api-csvs'
 govuk::apps::support_api::govuk_notify_template_id: "759acac6-da53-4a19-b591-b7538c7c39de"

--- a/modules/govuk/manifests/apps/static.pp
+++ b/modules/govuk/manifests/apps/static.pp
@@ -51,6 +51,12 @@
 # [*plek_account_manager_uri*]
 #   Path to the GOV.UK Account Manager
 #
+# [*govuk_personalisation_manage_uri*]
+#   URI for the account management page.  If unset, this is derived from plek_account_manager_uri.
+#
+# [*govuk_personalisation_security_uri*]
+#   URI for the account security page.  If unset, this is derived from plek_account_manager_uri.
+#
 class govuk::apps::static(
   $vhost = 'static',
   $port,
@@ -64,6 +70,8 @@ class govuk::apps::static(
   $redis_port = undef,
   $unicorn_worker_processes = undef,
   $plek_account_manager_uri = undef,
+  $govuk_personalisation_manage_uri = undef,
+  $govuk_personalisation_security_uri = undef,
 ) {
   $enable_ssl = hiera('nginx_enable_ssl', true)
   $app_name = 'static'
@@ -116,6 +124,12 @@ class govuk::apps::static(
     "${title}-PLEK-ACCOUNT-MANAGER-URI":
       varname => 'PLEK_SERVICE_ACCOUNT_MANAGER_URI',
       value   => $plek_account_manager_uri;
+    "${title}-GOVUK-PERSONALISATION-MANAGE-URI":
+      varname => 'GOVUK_PERSONALISATION_MANAGE_URI',
+      value   => $govuk_personalisation_manage_uri;
+    "${title}-GOVUK-PERSONALISATION-SECURITY-URI":
+      varname => 'GOVUK_PERSONALISATION_SECURITY_URI',
+      value   => $govuk_personalisation_security_uri;
   }
 
   if $ga_universal_id != undef {


### PR DESCRIPTION
Note: the security page isn't implemented yet, but this will be the URI.

These env vars are used by govuk_personalisation to determine the URLs
which ultimately appear in the account template returned by static.

When Digital Identity settle on a permanent URI scheme, we may be able
to simplify further (eg, if their stuff is all at
`https://manage.${environment}.account.gov.uk/${path}`).

---

[Trello card](https://trello.com/c/ZvDGaba4/958-use-di-auth-in-integration-give-feedback-on-their-documentation)