### PR TITLE
Add Grafana dashboards for Licensify apps

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1239,6 +1239,9 @@ grafana::dashboards::application_dashboards:
   info-frontend: {}
   licencefinder:
     docs_name: 'licence-finder'
+  licensify: {}
+  licensify-admin: {}
+  licensify-feed: {}
   link-checker-api:
     show_sidekiq_graphs: true
     has_workers: true

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -262,6 +262,9 @@ grafana::dashboards::application_dashboards:
   info-frontend: {}
   licencefinder:
     docs_name: 'licence-finder'
+  licensify: {}
+  licensify-admin: {}
+  licensify-feed: {}
   link-checker-api:
     show_sidekiq_graphs: true
     has_workers: true


### PR DESCRIPTION
We currently don't have application dashboards for these.

https://trello.com/c/5F0Jt2CC/53-add-grafana-dashboards-for-licensify-apps
