### PR TITLE
Improve flow of cache reboot script

### DIFF
--- a/tools/reboot-cache-instances.sh
+++ b/tools/reboot-cache-instances.sh
@@ -43,8 +43,9 @@ echo "It has instance_id $instance_id"
 
 asg_name=$(aws autoscaling describe-auto-scaling-instances --instance-ids "$instance_id" | jq .AutoScalingInstances[0].AutoScalingGroupName -r)
 
+echo "Setting $instance_id to standby in ASG $asg_name"
 aws autoscaling enter-standby --instance-ids "$instance_id" \
-  --auto-scaling-group-name "$asg_name" --should-decrement-desired-capacity
+  --auto-scaling-group-name "$asg_name" --should-decrement-desired-capacity | jq .Activities[0].Cause -r
 
 function instanceState {
   aws autoscaling describe-auto-scaling-instances --instance-ids "$instance_id" | jq .AutoScalingInstances[0].LifecycleState -r
@@ -79,7 +80,7 @@ done
 
 echo "Putting instance back into service..."
 
-aws autoscaling exit-standby --instance-ids "$instance_id" --auto-scaling-group-name "$asg_name"
+aws autoscaling exit-standby --instance-ids "$instance_id" --auto-scaling-group-name "$asg_name" | jq .Activities[0].Cause -r
 
 until [ "$(instanceState)" == "InService" ]
 do


### PR DESCRIPTION
This change outputs some information from the commands to [enter](https://docs.aws.amazon.com/cli/latest/reference/autoscaling/enter-standby.html) and [exit](https://docs.aws.amazon.com/cli/latest/reference/autoscaling/exit-standby.html) standby from the autoscaling group. If we don't do this, (as happens currently) the json response is shown in a separate screen which disappears altogether once
dismissed.

The other benefit of this change is that the script will no longer block waiting for the json response to be dismissed, which means that reboots will require slightly less attention from an operator.

The output of this command is shown below with the new lines highlighted

`gds aws govuk-integration-poweruser -- ./tools/reboot-cache-instances.sh -e integration ip-11.22.33.44.region.compute.internal`

## Output:

Going to reboot ip-11.22.33.44.region.compute.internal in integration
It has instance_id `<instance id>`

> Setting `<instance id>` to standby in ASG `<asg-name>`
> At 2021-09-03T11:07:29Z instance `<instance id>` was moved to standby in response to a user request, shrinking the capacity from 18 to 17.

Waiting for instance to be in Standby state (currently EnteringStandby)
Waiting for requests to complete... 30 seconds
Rebooting instance via ssh

Running command: ssh -J username@jumpbox.domain username@ip-11.22.33.44.region.compute.internal -o CheckHostIP=no -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no sudo shutdown -r now

Warning: Permanently added 'ip-11.22.33.44.region.compute.internal' (RSA) to the list of known hosts.
Rebooted, waiting for instance to come back up...

Running command: ssh -J username@jumpbox.domain username@ip-11.22.33.44.region.compute.internal -o CheckHostIP=no -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no curl -s -o /dev/null -w '%{http_code}' localhost:80/_healthcheck_www

Warning: Permanently added 'ip-11.22.33.44.region.compute.internal' (RSA) to the list of known hosts.
Putting instance back into service...

> At 2021-09-03T11:13:36Z instance `<instance id>` was moved out of standby in response to a user request, increasing the capacity from 17 to 18.

Waiting for instance to enter service...
Done!