### PR TITLE
Create SSH user for Ryan Brooks

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -534,6 +534,7 @@ users::usernames:
   - richardtowers
   - rochtrinque
   - rosafox
+  - ryanbrooks
   - seanrankine
   - simonhughesdon
   - stephenford

--- a/modules/users/manifests/ryanbrooks.pp
+++ b/modules/users/manifests/ryanbrooks.pp
@@ -1,0 +1,7 @@
+class users::ryanbrooks {
+  govuk_user { 'ryanbrooks':
+    fullname => 'Ryan Brooks',
+    email    => 'ryan.brooks@digital.cabinet-office.gov.uk',
+    ssh_key  => 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKMvyB1xRc7UdzcDlPvoUGx+LbDbNU1272IjRK9sRUWP ryan.brooks@digital.cabinet-office.gov.uk',
+  }
+}

--- a/modules/users/manifests/ryanbrooks.pp
+++ b/modules/users/manifests/ryanbrooks.pp
@@ -1,3 +1,4 @@
+# Create the ryanbrooks user
 class users::ryanbrooks {
   govuk_user { 'ryanbrooks':
     fullname => 'Ryan Brooks',


### PR DESCRIPTION
This PR creates an SSH user for me, and adds it to the list of integration users, following the [Get started on GOV.UK](https://docs.publishing.service.gov.uk/manual/get-started.html#create-a-user-to-ssh-into-integration) manual.

I've assumed the username _isn't_ my Github username because other entries seem to follow the full-name pattern instead, but just shout if I should change this.