### PR TITLE
Add Daniel Mountford to Integration

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -505,6 +505,7 @@ users::usernames:
   - chrisbanks
   - christopherashton
   - danacotoran
+  - danielmountford
   - deborahchua
   - duncangarmonsway
   - edwardkerry

--- a/modules/users/manifests/danielmountford.pp
+++ b/modules/users/manifests/danielmountford.pp
@@ -1,0 +1,8 @@
+# Creates danielmountford user
+class users::danielmountford {
+  govuk_user { 'danielmountford':
+    fullname => 'Daniel Mountford',
+    email    => 'daniel.mountford@digital.cabinet-office.gov.uk',
+    ssh_key  => 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHJdYJWGQZtTexTom86C8v8VM6MxihJUJ7u8OzZlhPAb daniel.mountford@digital.cabinet-office.gov.uk',
+  }
+}


### PR DESCRIPTION
Prompted by @spikeheap in https://github.com/alphagov/govuk-puppet/pull/11264, this PR creates an SSH user for me, and adds it to the list of integration users, following the Get started on GOV.UK manual.

