### PR TITLE
WIP: Restart Jenkins safely

### DIFF
--- a/modules/govuk_jenkins/manifests/init.pp
+++ b/modules/govuk_jenkins/manifests/init.pp
@@ -170,4 +170,11 @@ class govuk_jenkins (
     require => Class['govuk_jenkins::user'],
   }
 
+  service { "jenkins":
+    ensure     => running,
+    # provider   => 'upstart',
+    # hasrestart => false,
+    restart    => '/etc/init.d/jenkins safeRestart',
+  }
+
 }


### PR DESCRIPTION
Jenkins is currently restarting every 30 minutes or so, which
causes some jobs to hang (namely, jobs which trigger downstream
"Run rake task" jobs, which complete successfully but the status
is never reported back upstream).

It looks as though there is a setting to restart Jenkins only when
it is safe to do so, i.e. no active jobs:
https://devops.stackexchange.com/questions/3104/how-to-safe-restart-jenkins/3115

It also looks possible to provide our own custom 'restart' command
to services managed by Puppet:
https://stackoverflow.com/questions/62221676/puppet-conditional-restart-of-service

I'm almost certain this code isn't in the right place or has the
wrong syntax, but am capturing here while fresh in my mind.

Trello: https://trello.com/c/LDyL0Tso/1209-jenkins-jobs-getting-stuck