### PR TITLE
Revert "Delay slow-running jobs to start at 7am instead of 3am"

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/record_superfluous_taggings_metrics.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/record_superfluous_taggings_metrics.yaml.erb
@@ -12,7 +12,7 @@
     triggers:
       - timed: |
           TZ=Europe/London
-          H 7 * * *
+          H 3 * * *
     properties:
       - build-discarder:
           days-to-keep: 30

--- a/spec/fixtures/hieradata/common.yaml
+++ b/spec/fixtures/hieradata/common.yaml
@@ -71,7 +71,7 @@ govuk_jenkins::config::github_web_uri: wibble
 govuk_jenkins::jobs::deploy_app::applications: *deployable_applications
 govuk_jenkins::jobs::deploy_app_downstream::applications: *deployable_applications
 govuk_jenkins::jobs::run_rake_task::applications: *deployable_applications
-govuk_jenkins::jobs::content_data_api_re_run::re_run_rake_etl_main_process_cron_schedule: '0 7 * * *'
+govuk_jenkins::jobs::content_data_api_re_run::re_run_rake_etl_main_process_cron_schedule: '0 3 * * *'
 
 govuk_jenkins::packages::gcloud::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk_jenkins::packages::gcloud::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"


### PR DESCRIPTION
Reverts #11266

#11270 fixes the underlying problem, so this workaround is no longer needed.