### PR TITLE
Ensure the app memory Icinga checks are absent

### DIFF
--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -319,6 +319,9 @@ define govuk::app::config (
       host_name      => $::fqdn,
       contact_groups => $additional_check_contact_groups,
     }
+    @@icinga::check::graphite { "check_${title}_app_mem_usage${::hostname}":
+      ensure => 'absent',
+    }
     if $alert_when_threads_exceed {
       @@icinga::check::graphite { "check_${title}_app_thread_count_${::hostname}":
         ensure                     => $ensure,

--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -320,7 +320,15 @@ define govuk::app::config (
       contact_groups => $additional_check_contact_groups,
     }
     @@icinga::check::graphite { "check_${title}_app_mem_usage${::hostname}":
-      ensure => 'absent',
+      ensure                     => 'absent',
+      target                     => "movingMedian(${::fqdn_metrics}.processes-app-${title_underscore}.ps_rss,\"5min\")",
+      warning                    => 700 * 1000000,
+      critical                   => 800 * 1000000,
+      desc                       => "high memory for ${title} app",
+      host_name                  => $::fqdn,
+      event_handler              => "govuk_app_high_memory!${title}",
+      attempts_before_hard_state => 3,
+      contact_groups             => $additional_check_contact_groups,
     }
     if $alert_when_threads_exceed {
       @@icinga::check::graphite { "check_${title}_app_thread_count_${::hostname}":


### PR DESCRIPTION
These were removed in #11034, but they weren't set to
`ensure => 'absent'`, therefore the files themselves weren't
removed; Puppet just no longer cares about the files. This means
we're still seeing Icinga alerts concerning 'high memory for
whitehall-admin-procfile-worker', for example.

We first need to ensure absence, and once this has run in all
environments, we should be safe to remove this code.