### PR TITLE
Check if jq is installed before proceeding

### DIFF
--- a/tools/reboot-cache-instances.sh
+++ b/tools/reboot-cache-instances.sh
@@ -33,6 +33,12 @@ then
   show_help
 fi
 
+if ! [ -x "$(command -v jq)" ]
+then
+  echo "[Error] You must install 'jq' before running this script."
+  show_help
+fi
+
 echo "Going to reboot $instance_private_dns_name in $govuk_env"
 
 instance_id=$(aws ec2 describe-instances \


### PR DESCRIPTION
The reboot-cache-instances.sh script relies on [jq] being
installed. If it isn't installed, the script would fail after
saying "Going to reboot $instance_private_dns_name in $govuk_env",
where it is not clear whether anything happened at the AWS end,
which is unnecessarily stressful!

[jq]: https://formulae.brew.sh/formula/jq