### PR TITLE
Add Alex Whitehead-Smith

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -496,6 +496,7 @@ router::nginx::check_requests_critical: '@0.25'
 users::usernames:
   - alexandrujurubita
   - alexnewton
+  - alexsmith
   - andysellick
   - benjamineskola
   - benthorner

--- a/modules/users/manifests/alexsmith.pp
+++ b/modules/users/manifests/alexsmith.pp
@@ -1,0 +1,8 @@
+# Create the alexsmith user
+class users::alexsmith {
+  govuk_user { 'alexsmith':
+    fullname => 'Alex Smith',
+    email    => 'alex.smith@digital.cabinet-office.gov.uk',
+    ssh_key  => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDPnVeHa2j0uuoiUd4ffZ092o58xb8eKvRpm3WTWDJ2AkVP/YfPHOj3OH7U2SMYzfTbDKjsMEm3V+XtqlErg5vfENZXGRyALrbwUORCzSELENq+hxLyNmYs/kBFj+SEL2nZ7f3fYZ7b/9xvVli2hARytMZ8ltRTSUBhkuRA8MgSj18M7xF8PJ3tc1+Cm6yf5XpzPqVVM2mpI3xXWyC/Phkj0TWjoJZpjbd56qUyfOgBuLxM1ALUqRa3APTDocHgxDClyE+iPB1ZxyUXPkPq9Qie4OSAuwNs+j1vpMadZz9weBdYT7X34lclgfW+xRjluAuuid8qmZsh1VZTtPyMjchCSOiTGQgDBrBk3S0Wu7RbZ/AQqx3vY6S06JEe10hseeh3ltSoryYhOiiZmXuz8wbvsxhR3HYFd5oUUcLuxsRU1cnc+vjf+zLgWAl+WHIi0oN2ezRlgIYXCFYfhdMZNKnB5sPr4hkn/rnID+BkzQvpevzZy1BxWsPtcDXxydGVfm5XB05GMvXUou94opZKYMcTkNHFgMlEpW0ssKbFOUBsv3x7fidIkf7sDDT1couqvB8h+EzHbXmf5cN/5ybjuINqU6i2Vmd0BaiGCuf7EhfuKEvVOPyMqgi9QR47jLcAHrMD75f8RV1B5QrmOSX/O/+5frnVd2Rk2GDwLfsZdaLslw== alex.smith@digital.cabinet-office.gov.uk',
+  }
+}


### PR DESCRIPTION
Add myself to the integration environment.

Note that I've created everything under my old surname (Smith). This is so my SSH username matches the username on my GDS laptop, which will hopefully prevent me having to type in my username every time I want to use it. The email address given here is an alias to the one on my Google account.

Hopefully this doesn't cause problems with the details in the [user monitor](alphagov/govuk-user-reviewer#568). If it does, I'll update that as well so it's all the same.