### PR TITLE
Give account-api a bearer token for publishing-api

### DIFF
--- a/modules/govuk/manifests/apps/account_api.pp
+++ b/modules/govuk/manifests/apps/account_api.pp
@@ -79,6 +79,9 @@
 # [*email_alert_api_bearer_token*]
 #   Bearer token for communication with the email-alert-api
 #
+# [*publishing_api_bearer_token*]
+#   Bearer token for communication with the publishing-api
+#
 # [*session_secret*]
 #   Secret used to secure user session data
 #
@@ -120,6 +123,7 @@ class govuk::apps::account_api (
   $account_oauth_private_key = undef,
   $plek_account_manager_uri = undef,
   $email_alert_api_bearer_token = undef,
+  $publishing_api_bearer_token = undef,
   $session_secret = undef,
   $govuk_notify_api_key = undef,
   $govuk_notify_template_id = undef,
@@ -183,6 +187,9 @@ class govuk::apps::account_api (
     "${title}-EMAIL_ALERT_API_BEARER_TOKEN":
         varname => 'EMAIL_ALERT_API_BEARER_TOKEN',
         value   => $email_alert_api_bearer_token;
+    "${title}-PUBLISHING_API_BEARER_TOKEN":
+        varname => 'PUBLISHING_API_BEARER_TOKEN',
+        value   => $publishing_api_bearer_token;
     "${title}-SESSION_SECRET":
         varname => 'SESSION_SECRET',
         value   => $session_secret;


### PR DESCRIPTION
So far we've used special-route-publisher to publish the
account-related routes (/sign-in, /sign-in/callback, /sign-out, and
/account/home).

These pages shouldn't appear in search, so the special route format
works for them.

But now we want to publish a "sorting hat" page---a routing page to
other government accounts---and this *should* appear in search.  We
can't use a special route for this.  We've decided to publish it as a
help page (as that's the closest matching format), but with some
custom behaviour which makes it unsuitable to publish through
mainstream publisher.

So we'll publish it directly from account-api, which means account-api
needs a bearer token for the publishing-api.

---

[Trello card](https://trello.com/c/FbsTQJ0z/1008-build-sorting-hat-page-v1)