### PR TITLE
Update styling for GOV.UK Jenkins branding 💅

### DIFF
--- a/modules/govuk_jenkins/templates/userContent/govuk.css.erb
+++ b/modules/govuk_jenkins/templates/userContent/govuk.css.erb
@@ -5,10 +5,10 @@
   font-weight: bold;
   display: inline-block;
   background-color: <%= @theme_colour %>;
-  margin: 3px 0 0 3px;
-  padding: 1px 3px;
+  margin: 0 8px 0 0;
+  padding: 2px 8px;
   color: <%= @theme_text_colour %>;
-  border-radius: 3px;
+  border-radius: 5px;
 }
 
 #jenkins-home-link {
@@ -16,7 +16,7 @@
   margin-left: 6px;
   display: inline-block;
   height: 47px;
-  padding-left: 2em;
+  padding: 0 1em 0 2.75em;
 }
 
 #jenkins-home-link img {
@@ -28,49 +28,11 @@
   color: white;
   font-weight: normal;
   font-family: "GillSans", "Gill Sans MT", "Gill Sans", "Helvetica Neue", Arial, sans-serif;
-  font-size: 20px;
+  font-size: 24px;
   display: inline-block;
-  padding: 15px 0 0;
+  padding: 7px 0 0;
 }
 
 #jenkins-home-link:hover::after {
   text-decoration: underline;
-}
-
-/* Jenkins 1 */
-#top-panel {
-  background: #222;
-  height: 52px;
-}
-
-#top-panel table {
-  border-bottom: 5px solid <%= @theme_colour %>;
-}
-
-#top-panel table td {
-  height: 47px;
-}
-
-/* Jenkins 2 */
-div#header {
-  background: #222;
-  height: 52px;
-  border-bottom: 5px solid <%= @theme_colour %>;
-}
-
-div#header .logo {
-  margin-left: 10px;
-}
-
-div#header #jenkins-home-link::after {
-  padding: 18px 0 0 18px;
-}
-
-div#header .searchbox, div#header .login {
-  padding: 12px 11px 0;
-}
-
-div#header #visible-am-button {
-  height: 47px;
-  line-height: 47px;
 }


### PR DESCRIPTION
Since we upgraded Jenkins the styling has been a bit janky. This applies
some rather crude styling fixes that sorts this out.

This code is totally coupled to Jenkins and will likely go a bit janky
again next time Jenkins changes styles. This should be ok though as this
happens so infrequently.

A bunch of the old styles here were no longer having an affect so they
have been removed.

---

Before:

![Screenshot 2021-09-15 at 12 22 45](https://user-images.githubusercontent.com/282717/133424657-4d55375e-ecb6-44b1-9983-809c1bbdacc8.png)

After:

![Screenshot 2021-09-15 at 12 17 59](https://user-images.githubusercontent.com/282717/133424675-6c4c8f2d-6b56-4171-a246-3b8b6a2e187e.png)

