### PR TITLE
[DO NOT MERGE] Standardise CD healthcheck for auth proxy

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1076,9 +1076,7 @@ govuk_jenkins::jobs::deploy_app::applications: *deployable_applications
 
 govuk_jenkins::jobs::deploy_app_downstream::applications:
   account-api: {}
-  authenticating-proxy:
-    healthcheck_urls:
-      - "https://draft-origin.%{hiera('app_domain')}/healthcheck/ready"
+  authenticating-proxy: {}
   bouncer: {}
   cache-clearing-service:
     healthcheck_urls: [] # done implicitly as part of app restart script


### PR DESCRIPTION
https://trello.com/c/USH1B9K1/243-investigate-drying-up-deployment-healthchecks-out-of-smokey

Depends on: https://github.com/alphagov/govuk-aws-data/pull/914

Previously we had to call the /healthcheck endpoint indirectly via
the draft-origin, since this app didn't have its own domain. We can
remove the override since it does now have an internal domain.