### PR TITLE
Remove account_confirm_email_url variable

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -38,7 +38,6 @@ govuk::apps::email_alert_api::govuk_notify_template_id: '1fc69d3a-09a2-40f9-852b
 govuk::apps::email_alert_api::govuk_notify_recipients:
   - email-alert-api-integration@digital.cabinet-office.gov.uk
 govuk::apps::email_alert_frontend::subscription_management_enabled: true
-govuk::apps::email_alert_frontend::account_confirm_email_url: "https://www.account.staging.publishing.service.gov.uk/account/confirmation/new"
 govuk::apps::email_alert_frontend::account_change_email_url: "https://www.account.staging.publishing.service.gov.uk/account/manage"
 govuk::apps::feedback::govuk_notify_reply_to_id: 'fee22233-2f28-4b0b-8b6c-4410979f2275'
 govuk::apps::feedback::govuk_notify_template_id: 'eb9ba220-7d74-4aab-975a-bdbe718f69a3'

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -190,7 +190,6 @@ govuk::apps::govuk_crawler_worker::crawler_threads: '32'
 govuk::apps::email_alert_api::db::backend_ip_range: '10.13.3.0/24'
 govuk::apps::email_alert_api::govuk_notify_template_id: 'cb633abc-6ae6-4843-ae6f-82ca500b6de2'
 govuk::apps::email_alert_api::govuk_notify_recipients: '*'
-govuk::apps::email_alert_frontend::account_confirm_email_url: "https://www.account.publishing.service.gov.uk/account/confirmation/new"
 govuk::apps::email_alert_frontend::account_change_email_url: "https://www.account.publishing.service.gov.uk/account/manage"
 govuk::apps::feedback::govuk_notify_reply_to_id: 'e8b2d8a6-db5f-4346-9fbd-49b16b531e1c'
 govuk::apps::feedback::govuk_notify_template_id: '54168fa9-3946-4860-a2f8-27ddbb14babe'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -169,7 +169,6 @@ govuk::apps::email_alert_api::govuk_notify_recipients:
   - email-alert-api-staging@digital.cabinet-office.gov.uk
 govuk::apps::email_alert_frontend::subscription_management_enabled: true
 govuk::apps::email_alert_frontend::account_auth_enabled: true
-govuk::apps::email_alert_frontend::account_confirm_email_url: "https://www.account.staging.publishing.service.gov.uk/account/confirmation/new"
 govuk::apps::email_alert_frontend::account_change_email_url: "https://www.account.staging.publishing.service.gov.uk/account/manage"
 govuk::apps::feedback::govuk_notify_reply_to_id: 'd1f54751-80a8-420a-9077-d34c7d6cc734'
 govuk::apps::feedback::govuk_notify_template_id: '8a8d98c0-42c8-4f56-b61f-77c89417a171'

--- a/modules/govuk/manifests/apps/email_alert_frontend.pp
+++ b/modules/govuk/manifests/apps/email_alert_frontend.pp
@@ -50,9 +50,6 @@
 # [*account_auth_enabled*]
 #   Whether users can log in with their GOV.UK Account.
 #
-# [*account_confirm_email_url*]
-#   URL a user who needs to confirm their account should go to (eg, to request another confirmation email).
-#
 # [*account_change_email_enabled*]
 #   URL a user who needs to change their email address should go to.
 #
@@ -73,7 +70,6 @@ class govuk::apps::email_alert_frontend(
   $subscription_management_enabled = false,
   $account_api_bearer_token = undef,
   $account_auth_enabled = false,
-  $account_confirm_email_url = undef,
   $account_change_email_url = undef,
   $plek_account_manager_uri = undef,
 ) {
@@ -115,9 +111,6 @@ class govuk::apps::email_alert_frontend(
     "${title}-EMAIL_ALERT_AUTH_TOKEN":
         varname => 'EMAIL_ALERT_AUTH_TOKEN',
         value   => $email_alert_auth_token;
-    "${title}-GOVUK_ACCOUNT_CONFIRM_EMAIL_URL":
-        varname => 'GOVUK_ACCOUNT_CONFIRM_EMAIL_URL',
-        value   => $account_confirm_email_url;
     "${title}-GOVUK_ACCOUNT_CHANGE_EMAIL_URL":
         varname => 'GOVUK_ACCOUNT_CHANGE_EMAIL_URL',
         value   => $account_change_email_url;


### PR DESCRIPTION
In https://github.com/alphagov/email-alert-frontend/pull/1134 we changed
the email alert frontend to redirect users through DI's auth service if
they have an unconfirmed email address. This means we no longer need to
provide the link to confirm email addresses to the app.

https://trello.com/c/2LIY7ITS/1018-remove-email-confirmation-prompt-from-email-alert-frontend