### PR TITLE
Use govuk_personalisation in email-alert-frontend

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -38,7 +38,7 @@ govuk::apps::email_alert_api::govuk_notify_template_id: '1fc69d3a-09a2-40f9-852b
 govuk::apps::email_alert_api::govuk_notify_recipients:
   - email-alert-api-integration@digital.cabinet-office.gov.uk
 govuk::apps::email_alert_frontend::subscription_management_enabled: true
-govuk::apps::email_alert_frontend::account_change_email_url: "https://www.account.staging.publishing.service.gov.uk/account/manage"
+govuk::apps::email_alert_frontend::govuk_personalisation_manage_uri: 'https://account-management.integration.auth.ida.digital.cabinet-office.gov.uk/?link=manage-account'
 govuk::apps::feedback::govuk_notify_reply_to_id: 'fee22233-2f28-4b0b-8b6c-4410979f2275'
 govuk::apps::feedback::govuk_notify_template_id: 'eb9ba220-7d74-4aab-975a-bdbe718f69a3'
 govuk::apps::frontend::govuk_notify_template_id: '1fc69d3a-09a2-40f9-852b-03f6fcef5340'

--- a/modules/govuk/manifests/apps/email_alert_frontend.pp
+++ b/modules/govuk/manifests/apps/email_alert_frontend.pp
@@ -50,11 +50,11 @@
 # [*account_auth_enabled*]
 #   Whether users can log in with their GOV.UK Account.
 #
-# [*account_change_email_enabled*]
-#   URL a user who needs to change their email address should go to.
-#
 # [*plek_account_manager_uri*]
 #   Path to the GOV.UK Account Manager
+#
+# [*govuk_personalisation_manage_uri*]
+#   URI for the account management page.
 #
 
 class govuk::apps::email_alert_frontend(
@@ -70,8 +70,8 @@ class govuk::apps::email_alert_frontend(
   $subscription_management_enabled = false,
   $account_api_bearer_token = undef,
   $account_auth_enabled = false,
-  $account_change_email_url = undef,
   $plek_account_manager_uri = undef,
+  $govuk_personalisation_manage_uri = undef,
 ) {
   $app_name = 'email-alert-frontend'
 
@@ -111,12 +111,12 @@ class govuk::apps::email_alert_frontend(
     "${title}-EMAIL_ALERT_AUTH_TOKEN":
         varname => 'EMAIL_ALERT_AUTH_TOKEN',
         value   => $email_alert_auth_token;
-    "${title}-GOVUK_ACCOUNT_CHANGE_EMAIL_URL":
-        varname => 'GOVUK_ACCOUNT_CHANGE_EMAIL_URL',
-        value   => $account_change_email_url;
     "${title}-PLEK-ACCOUNT-MANAGER-URI":
       varname => 'PLEK_SERVICE_ACCOUNT_MANAGER_URI',
       value   => $plek_account_manager_uri;
+    "${title}-GOVUK-PERSONALISATION-MANAGE-URI":
+      varname => 'GOVUK_PERSONALISATION_MANAGE_URI',
+      value   => $govuk_personalisation_manage_uri;
   }
 
   if $subscription_management_enabled {


### PR DESCRIPTION
In https://github.com/alphagov/email-alert-frontend/pull/1135 we switched
the email-alert-frontend to use `govuk_personalisation` when finding the
URL to redirect users to when changing their email address.

Set the required environment variables for this to work, and remove the
old ones. Note these are currently only set for integration. When we want
roll out changes further we'll need to update staging and production too.

The new URL is taken from https://github.com/alphagov/govuk-puppet/commit/c5300e6e90d9315a52a080b7d59cd437bb2cbacf

https://trello.com/c/u35RYZZW/1030-use-govukpersonalisation-for-change-email-link-in-email-alert-frontend