### PR TITLE
Add govuk_notify_survey_signup_template_id variable to Feedback

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -41,6 +41,7 @@ govuk::apps::email_alert_frontend::subscription_management_enabled: true
 govuk::apps::email_alert_frontend::govuk_personalisation_manage_uri: 'https://account-management.integration.auth.ida.digital.cabinet-office.gov.uk/?link=manage-account'
 govuk::apps::feedback::govuk_notify_reply_to_id: 'fee22233-2f28-4b0b-8b6c-4410979f2275'
 govuk::apps::feedback::govuk_notify_template_id: 'eb9ba220-7d74-4aab-975a-bdbe718f69a3'
+govuk::apps::feedback::govuk_notify_survey_signup_template_id: 'eb9ba220-7d74-4aab-975a-bdbe718f69a3'
 govuk::apps::frontend::govuk_notify_template_id: '1fc69d3a-09a2-40f9-852b-03f6fcef5340'
 govuk::apps::frontend::memcache_servers: 'frontend-memcached:11211'
 govuk::apps::frontend::feature_flag_save_a_page: true

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -193,6 +193,7 @@ govuk::apps::email_alert_api::govuk_notify_recipients: '*'
 govuk::apps::email_alert_frontend::account_change_email_url: "https://www.account.publishing.service.gov.uk/account/manage"
 govuk::apps::feedback::govuk_notify_reply_to_id: 'e8b2d8a6-db5f-4346-9fbd-49b16b531e1c'
 govuk::apps::feedback::govuk_notify_template_id: '54168fa9-3946-4860-a2f8-27ddbb14babe'
+govuk::apps::feedback::govuk_notify_survey_signup_template_id: '54168fa9-3946-4860-a2f8-27ddbb14babe'
 
 # https://docs.google.com/document/d/1kdRhmMUIyNZQmgo4FvXswJaDN2CWS2vlH9PVu21a68k/edit#
 govuk::apps::finder_frontend::unicorn_worker_processes: 48

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -172,6 +172,7 @@ govuk::apps::email_alert_frontend::account_auth_enabled: true
 govuk::apps::email_alert_frontend::account_change_email_url: "https://www.account.staging.publishing.service.gov.uk/account/manage"
 govuk::apps::feedback::govuk_notify_reply_to_id: 'd1f54751-80a8-420a-9077-d34c7d6cc734'
 govuk::apps::feedback::govuk_notify_template_id: '8a8d98c0-42c8-4f56-b61f-77c89417a171'
+govuk::apps::feedback::govuk_notify_survey_signup_template_id: '8a8d98c0-42c8-4f56-b61f-77c89417a171'
 
 # https://github.com/alphagov/govuk-aws-data/pull/827
 govuk::apps::finder_frontend::unicorn_worker_processes: 24

--- a/modules/govuk/manifests/apps/feedback.pp
+++ b/modules/govuk/manifests/apps/feedback.pp
@@ -27,6 +27,9 @@
 # [*govuk_notify_template_id*]
 #   Template ID for GOV.UK Notify
 #
+# [*govuk_notify_survey_signup_template_id*]
+#   Survey signup template ID for GOV.UK Notify
+#
 # [*govuk_notify_reply_to_id*]
 #   Email address reply_to ID for GOV.UK Notify
 #
@@ -42,6 +45,7 @@ class govuk::apps::feedback(
   $google_private_key = undef,
   $govuk_notify_api_key,
   $govuk_notify_template_id,
+  $govuk_notify_survey_signup_template_id,
   $govuk_notify_reply_to_id,
 ) {
   $app_name = 'feedback'
@@ -116,6 +120,11 @@ class govuk::apps::feedback(
   govuk::app::envvar { "${title}-GOVUK_NOTIFY_TEMPLATE_ID":
     varname => 'GOVUK_NOTIFY_TEMPLATE_ID',
     value   => $govuk_notify_template_id,
+  }
+
+  govuk::app::envvar { "${title}-GOVUK_NOTIFY_SURVEY_SIGNUP_TEMPLATE_ID":
+    varname => 'GOVUK_NOTIFY_SURVEY_SIGNUP_TEMPLATE_ID',
+    value   => $govuk_notify_survey_signup_template_id,
   }
 
   govuk::app::envvar { "${title}-GOVUK_NOTIFY_REPLY_TO_ID":


### PR DESCRIPTION
This PR adds a new Environment Variable for Feedback called
govuk_notify_survey_signup_template_id.

At this point this is a duplicate for the existing
govuk_notify_template_id

Feedback is currently only using one email template. To allow us to add
more this makes the name of the existing template more specific.

Once this and the related renaming in Feedback have both been deployed,
the previous govuk_notify_template_id can be removed