### PR TITLE
Increase nginx timeout duration on hmrc manuals api 

### DIFF
--- a/modules/govuk/manifests/apps/hmrc_manuals_api.pp
+++ b/modules/govuk/manifests/apps/hmrc_manuals_api.pp
@@ -63,6 +63,7 @@ class govuk::apps::hmrc_manuals_api(
     has_readiness_health_check => true,
     log_format_is_json         => true,
     override_search_location   => $override_search_location,
+    read_timeout               => 300,
   }
 
   unless $ensure == 'absent' {
@@ -95,7 +96,10 @@ class govuk::apps::hmrc_manuals_api(
         value   => $oauth_secret;
       "${title}-PUBLISHING_API_BEARER_TOKEN":
         varname => 'PUBLISHING_API_BEARER_TOKEN',
-        value   => $publishing_api_bearer_token,
+        value   => $publishing_api_bearer_token;
+      "${title}-UNICORN_TIMEOUT":
+        varname => 'UNICORN_TIMEOUT',
+        value   => 300;
     }
 
   }


### PR DESCRIPTION
Publication of HMRC manuals via HMRC Manuals API is currently degraded. See zendesk [ticket](https://govuk.zendesk.com/agent/tickets/4712404)

See the following error:
```
ec2-integration-blue-backend-ip-10-1-6-26:/var/log/nginx$ tail -n 50 hmrc-manuals-api-error.log
upstream timed out (110: Connection timed out) while reading response header from upstream
```