### PR TITLE
Create an SSH user for me with access to integration only

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -496,6 +496,7 @@ users::usernames:
   - alexandrujurubita
   - alexnewton
   - alexsmith
+  - alistairdavidson
   - andysellick
   - benjamineskola
   - benthorner

--- a/modules/users/manifests/alistairdavidson.pp
+++ b/modules/users/manifests/alistairdavidson.pp
@@ -1,0 +1,8 @@
+# Creates the alistairdavidson user
+class users::alistairdavidson {
+  govuk_user { 'alistairdavidson':
+    fullname => 'Alistair Davidson',
+    email    => 'alistair.davidson@digital.cabinet-office.gov.uk',
+    ssh_key  => 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBG1kbWXb/GHt31zGfbjxHJQE3Hx/0F/G15VbYc7nkUj alistair.davidson@digital.cabinet-office.gov.uk',
+  }
+}


### PR DESCRIPTION
As per the instructions in the ['Get started on GOV.UK' dev docs](https://docs.publishing.service.gov.uk/manual/get-started.html)