### PR TITLE
Remove unused Notify variables for Feedback

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -39,9 +39,7 @@ govuk::apps::email_alert_api::govuk_notify_recipients:
   - email-alert-api-integration@digital.cabinet-office.gov.uk
 govuk::apps::email_alert_frontend::subscription_management_enabled: true
 govuk::apps::email_alert_frontend::govuk_personalisation_manage_uri: 'https://account-management.integration.auth.ida.digital.cabinet-office.gov.uk/?link=manage-account'
-govuk::apps::feedback::govuk_notify_reply_to_id: 'fee22233-2f28-4b0b-8b6c-4410979f2275'
 govuk::apps::feedback::govuk_notify_survey_signup_reply_to_id: 'fee22233-2f28-4b0b-8b6c-4410979f2275'
-govuk::apps::feedback::govuk_notify_template_id: 'eb9ba220-7d74-4aab-975a-bdbe718f69a3'
 govuk::apps::feedback::govuk_notify_survey_signup_template_id: 'eb9ba220-7d74-4aab-975a-bdbe718f69a3'
 govuk::apps::frontend::govuk_notify_template_id: '1fc69d3a-09a2-40f9-852b-03f6fcef5340'
 govuk::apps::govuk_crawler_worker::enabled: false

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -191,9 +191,7 @@ govuk::apps::email_alert_api::db::backend_ip_range: '10.13.3.0/24'
 govuk::apps::email_alert_api::govuk_notify_template_id: 'cb633abc-6ae6-4843-ae6f-82ca500b6de2'
 govuk::apps::email_alert_api::govuk_notify_recipients: '*'
 govuk::apps::email_alert_frontend::account_change_email_url: "https://www.account.publishing.service.gov.uk/account/manage"
-govuk::apps::feedback::govuk_notify_reply_to_id: 'e8b2d8a6-db5f-4346-9fbd-49b16b531e1c'
 govuk::apps::feedback::govuk_notify_survey_signup_reply_to_id: 'e8b2d8a6-db5f-4346-9fbd-49b16b531e1c'
-govuk::apps::feedback::govuk_notify_template_id: '54168fa9-3946-4860-a2f8-27ddbb14babe'
 govuk::apps::feedback::govuk_notify_survey_signup_template_id: '54168fa9-3946-4860-a2f8-27ddbb14babe'
 
 # https://docs.google.com/document/d/1kdRhmMUIyNZQmgo4FvXswJaDN2CWS2vlH9PVu21a68k/edit#

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -170,9 +170,7 @@ govuk::apps::email_alert_api::govuk_notify_recipients:
 govuk::apps::email_alert_frontend::subscription_management_enabled: true
 govuk::apps::email_alert_frontend::account_auth_enabled: true
 govuk::apps::email_alert_frontend::account_change_email_url: "https://www.account.staging.publishing.service.gov.uk/account/manage"
-govuk::apps::feedback::govuk_notify_reply_to_id: 'd1f54751-80a8-420a-9077-d34c7d6cc734'
 govuk::apps::feedback::govuk_notify_survey_signup_reply_to_id: 'd1f54751-80a8-420a-9077-d34c7d6cc734'
-govuk::apps::feedback::govuk_notify_template_id: '8a8d98c0-42c8-4f56-b61f-77c89417a171'
 govuk::apps::feedback::govuk_notify_survey_signup_template_id: '8a8d98c0-42c8-4f56-b61f-77c89417a171'
 
 # https://github.com/alphagov/govuk-aws-data/pull/827

--- a/modules/govuk/manifests/apps/feedback.pp
+++ b/modules/govuk/manifests/apps/feedback.pp
@@ -24,14 +24,8 @@
 #   The API key to allow this app to talk to GOV.UK Notify and send emails
 #   to people who want to sign up to take a survey
 #
-# [*govuk_notify_template_id*]
-#   Template ID for GOV.UK Notify
-#
 # [*govuk_notify_survey_signup_template_id*]
 #   Survey signup template ID for GOV.UK Notify
-#
-# [*govuk_notify_reply_to_id*]
-#   Email address reply_to ID for GOV.UK Notify
 #
 # [*govuk_notify_survey_signup_reply_to_id*]
 #   Survey signup email address reply_to ID for GOV.UK Notify
@@ -47,9 +41,7 @@ class govuk::apps::feedback(
   $google_client_email = undef,
   $google_private_key = undef,
   $govuk_notify_api_key,
-  $govuk_notify_template_id,
   $govuk_notify_survey_signup_template_id,
-  $govuk_notify_reply_to_id,
   $govuk_notify_survey_signup_reply_to_id,
 ) {
   $app_name = 'feedback'
@@ -121,19 +113,9 @@ class govuk::apps::feedback(
     value   => $govuk_notify_api_key,
   }
 
-  govuk::app::envvar { "${title}-GOVUK_NOTIFY_TEMPLATE_ID":
-    varname => 'GOVUK_NOTIFY_TEMPLATE_ID',
-    value   => $govuk_notify_template_id,
-  }
-
   govuk::app::envvar { "${title}-GOVUK_NOTIFY_SURVEY_SIGNUP_TEMPLATE_ID":
     varname => 'GOVUK_NOTIFY_SURVEY_SIGNUP_TEMPLATE_ID',
     value   => $govuk_notify_survey_signup_template_id,
-  }
-
-  govuk::app::envvar { "${title}-GOVUK_NOTIFY_REPLY_TO_ID":
-    varname => 'GOVUK_NOTIFY_REPLY_TO_ID',
-    value   => $govuk_notify_reply_to_id,
   }
 
   govuk::app::envvar { "${title}-GOVUK_NOTIFY_SURVEY_SIGNUP_REPLY_TO_ID":


### PR DESCRIPTION
These generic variables were replaced with more survey specific
variables and can now be removed.

### Related changes:
https://github.com/alphagov/feedback/pull/1301
https://github.com/alphagov/feedback/pull/1295
https://github.com/alphagov/govuk-puppet/pull/11294
https://github.com/alphagov/govuk-puppet/pull/11283

[trello](https://trello.com/c/ic6yuAJg/900-accessibleformatrequest-remove-unused-notify-variables-from-puppet)