### PR TITLE
Add AccessibleFormatRequest Notify variables for Feedback in Integration

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -41,6 +41,8 @@ govuk::apps::email_alert_frontend::subscription_management_enabled: true
 govuk::apps::email_alert_frontend::govuk_personalisation_manage_uri: 'https://integration.account.gov.uk?link=manage-account'
 govuk::apps::feedback::govuk_notify_survey_signup_reply_to_id: 'fee22233-2f28-4b0b-8b6c-4410979f2275'
 govuk::apps::feedback::govuk_notify_survey_signup_template_id: 'eb9ba220-7d74-4aab-975a-bdbe718f69a3'
+govuk::apps::feedback::govuk_notify_accessible_format_request_reply_to_id: '77941cb6-f3a2-4b0d-b09c-64572858cb50'
+govuk::apps::feedback::govuk_notify_accessible_format_request_template_id: '47cef7ea-0849-48aa-9676-0ee0f7baa4ae'
 govuk::apps::frontend::govuk_notify_template_id: '1fc69d3a-09a2-40f9-852b-03f6fcef5340'
 govuk::apps::frontend::govuk_personalisation_manage_uri: 'https://integration.account.gov.uk?link=manage-account'
 govuk::apps::govuk_crawler_worker::enabled: false

--- a/modules/govuk/manifests/apps/feedback.pp
+++ b/modules/govuk/manifests/apps/feedback.pp
@@ -30,6 +30,12 @@
 # [*govuk_notify_survey_signup_reply_to_id*]
 #   Survey signup email address reply_to ID for GOV.UK Notify
 #
+# [*govuk_notify_accessible_format_request_template_id*]
+#   Accessible format request template ID for GOV.UK Notify
+#
+# [*govuk_notify_accessible_format_request_reply_to_id*]
+#   Accessible format request email address reply_to ID for GOV.UK Notify
+#
 class govuk::apps::feedback(
   $port,
   $sentry_dsn = undef,
@@ -43,6 +49,8 @@ class govuk::apps::feedback(
   $govuk_notify_api_key,
   $govuk_notify_survey_signup_template_id,
   $govuk_notify_survey_signup_reply_to_id,
+  $govuk_notify_accessible_format_request_template_id,
+  $govuk_notify_accessible_format_request_reply_to_id,
 ) {
   $app_name = 'feedback'
 
@@ -121,5 +129,15 @@ class govuk::apps::feedback(
   govuk::app::envvar { "${title}-GOVUK_NOTIFY_SURVEY_SIGNUP_REPLY_TO_ID":
     varname => 'GOVUK_NOTIFY_SURVEY_SIGNUP_REPLY_TO_ID',
     value   => $govuk_notify_survey_signup_reply_to_id,
+  }
+
+  govuk::app::envvar { "${title}-GOVUK_NOTIFY_ACCESSIBLE_FORMAT_REQUEST_TEMPLATE_ID":
+    varname => 'GOVUK_NOTIFY_ACCESSIBLE_FORMAT_REQUEST_TEMPLATE_ID',
+    value   => $govuk_notify_accessible_format_request_template_id,
+  }
+
+  govuk::app::envvar { "${title}-GOVUK_NOTIFY_ACCESSIBLE_FORMAT_REQUEST_REPLY_TO_ID":
+    varname => 'GOVUK_NOTIFY_ACCESSIBLE_FORMAT_REQUEST_REPLY_TO_ID',
+    value   => $govuk_notify_accessible_format_request_reply_to_id,
   }
 }


### PR DESCRIPTION
Adding AccesssibleFormatRequest Notify variables for Feedback - only in Integration for testing purposes.

[trello](https://trello.com/c/T2bVLToL/897-accessibleformatrequest-add-notify-integration)