### PR TITLE
Add plek env var for account manager

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -528,6 +528,7 @@ govuk::apps::email_alert_api::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::email_alert_api::db_hostname: "postgresql-primary"
 govuk::apps::email_alert_api::db_password: "%{hiera('govuk::apps::email_alert_api::db::password')}"
 govuk::apps::email_alert_api::unicorn_worker_processes: '10'
+govuk::apps::email_alert_api::plek_account_manager_uri: "%{hiera('govuk::apps::account_api::plek_account_manager_uri')}"
 
 govuk::apps::email_alert_frontend::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::email_alert_frontend::redis_port: "%{hiera('sidekiq_port')}"

--- a/modules/govuk/manifests/apps/email_alert_api.pp
+++ b/modules/govuk/manifests/apps/email_alert_api.pp
@@ -81,6 +81,9 @@
 #   The bearer token to use when communicating with Publishing API.
 #   Default: undef
 #
+# [*plek_account_manager_uri*]
+#   Path to the GOV.UK Account Manager
+#
 class govuk::apps::email_alert_api(
   $port,
   $enabled = false,
@@ -113,6 +116,7 @@ class govuk::apps::email_alert_api(
   $aws_region = 'eu-west-1',
   $account_api_bearer_token = undef,
   $publishing_api_bearer_token = undef,
+  $plek_account_manager_uri = undef,
 ) {
 
   $ensure = $enabled ? {
@@ -213,6 +217,9 @@ class govuk::apps::email_alert_api(
     "${title}-PUBLISHING_API_BEARER_TOKEN":
       varname => 'PUBLISHING_API_BEARER_TOKEN',
       value   => $publishing_api_bearer_token;
+    "${title}-PLEK-ACCOUNT-MANAGER-URI":
+      varname => 'PLEK_SERVICE_ACCOUNT_MANAGER_URI',
+      value   => $plek_account_manager_uri;
   }
 
   if $govuk_notify_recipients {


### PR DESCRIPTION
This is so we can show the correct feedback URL in
https://github.com/alphagov/email-alert-api/pull/1670

---

[Trello card](https://trello.com/c/wUYJLuJ1/1064-implement-confirm-you-want-to-get-emails-page-account-linking-logic)