### PR TITLE
Add average column to Uptime Dashboard

### DIFF
--- a/modules/grafana/files/dashboards/application_uptime.json
+++ b/modules/grafana/files/dashboards/application_uptime.json
@@ -56,6 +56,10 @@
               "refId": "A",
               "target": "aliasByNode(summarize(stats.gauges.uptime.*, '1d', 'avg'), 3)",
               "textEditor": false
+            },
+            {
+              "refId": "B",
+              "target": "alias(averageSeries(summarize(stats.gauges.uptime.*, '1d', 'avg')), 'Average')"
             }
           ],
           "title": "Uptimes",


### PR DESCRIPTION
Each week, the Platform Health team calculate the average uptime for the publishing applications.

Adding an average column to the uptime metrics Grafana dashboard reduce the number of calculations needed to be done.

Screenshot before:
![Screenshot of publishing application uptime dashboard, showing a percentage uptime on one day for 5 applications with no average column](https://user-images.githubusercontent.com/6329861/137878164-48b82119-4d66-4d31-9895-65d9f61f7840.png)

Screenshot after:
![Screenshot of publishing application uptime dashboard, showing a percentage uptime on one day for 5 applications with an additional column at the right giving the average of all 5 publishing application's uptime](https://user-images.githubusercontent.com/6329861/137878267-ae164375-8ba2-49ee-b790-2916d843cbe8.png)