### PR TITLE
Add trailing slash to integration OIDC provider

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -11,7 +11,7 @@ cron::daily_hour: 6
 
 environment_ip_prefix: '10.1'
 
-govuk::apps::account_api::account_oauth_provider_uri: 'https://oidc.integration.account.gov.uk'
+govuk::apps::account_api::account_oauth_provider_uri: 'https://oidc.integration.account.gov.uk/'
 # TODO: remove after DI migration
 govuk::apps::account_api::plek_account_manager_uri: 'https://www.account.staging.publishing.service.gov.uk'
 govuk::apps::asset_manager::aws_s3_bucket_name: 'govuk-assets-integration'


### PR DESCRIPTION
This has to exactly match the value returned in the metadata.