### PR TITLE
Add the ws-cleanup plugin to the app build job template

### DIFF
--- a/modules/govuk_ci/templates/application_build_job.xml.erb
+++ b/modules/govuk_ci/templates/application_build_job.xml.erb
@@ -22,6 +22,14 @@
   </orphanedItemStrategy>
   <triggers/>
   <disabled>false</disabled>
+  <buildWrappers>
+    <hudson.plugins.ws__cleanup.PreBuildCleanup plugin="ws-cleanup@0.39">
+      <deleteDirs>false</deleteDirs>
+      <cleanupParameter/>
+      <externalDelete/>
+      <disableDeferredWipeout>false</disableDeferredWipeout>
+    </hudson.plugins.ws__cleanup.PreBuildCleanup>
+  </buildWrappers>
   <sources class="jenkins.branch.MultiBranchProject$BranchSourceList" plugin="branch-api@2.0.21">
     <data>
       <jenkins.branch.BranchSource>


### PR DESCRIPTION
The [rails_translation_manager job](https://ci.integration.publishing.service.gov.uk/job/rails_translation_manager/)
passes successfully on new branches, but on every subsequent build
it will fail with a long log of unrelated errors along the lines
of:
> error: wrong index v2 file size in .git/objects/pack/pack-b360de1f7cfbce9b7fa4b4c11ea4dc4daea3d1f7.idx

We've confirmed that manually deleting the workspace for the
master branch for Rails Translation Manager (on a specific ci-agent)
causes the build to clone everything from scratch, so fixes the
issue.
There is a plugin - WS Cleanup - which is installed on all of our
Jenkins environments: https://github.com/alphagov/govuk-puppet/blob/1ee7892b65b2edf91682261186b1b57041e82a8c/hieradata_aws/class/integration/ci_master.yaml#L421-L422

We can see that for [certain jobs](https://ci.integration.publishing.service.gov.uk/job/Deploy_App_Downstream/configure),
this plugin provides an option to "Delete workspace before build starts".
There is no such option on the rails_translation_manager job (nor
any job built from this application_build_job.xml.erb template).

Visiting https://ci.integration.publishing.service.gov.uk/job/Deploy_App_Downstream/config.xml,
I was able to get the XML of the job which _does_ have the option.
(I had to enable the option in the UI first, as otherwise it was
missing from the XML). I have then copied and pasted the relevant
XML into the app job template.

This should fix the rails_translation_manager builds.

Trello: https://trello.com/c/Pq7ffzxM/2752-investigate-rails-translation-manager-failing-builds