### PR TITLE
Prevent env specific TLS certs alerts appearing in wrong env

### DIFF
--- a/modules/monitoring/manifests/checks.pp
+++ b/modules/monitoring/manifests/checks.pp
@@ -151,25 +151,31 @@ class monitoring::checks (
     notes_url           => monitoring_docs_url(renew-tls-certificate),
   }
 
-  icinga::check { 'check_www_cert_valid_at_edge':
-    check_command       => 'check_ssl_cert!www.gov.uk!www.gov.uk!30',
-    host_name           => $::fqdn,
-    service_description => 'check the www.gov.uk TLS certificate at EDGE is valid and not due to expire',
-    notes_url           => monitoring_docs_url(renew-tls-certificate),
+  if ($::aws_environment == 'production') {
+    icinga::check { 'check_www_cert_valid_at_edge':
+      check_command       => 'check_ssl_cert!www.gov.uk!www.gov.uk!30',
+      host_name           => $::fqdn,
+      service_description => 'check the www.gov.uk TLS certificate at EDGE is valid and not due to expire',
+      notes_url           => monitoring_docs_url(renew-tls-certificate),
+    }
   }
 
-  icinga::check { 'check_www_staging_cert_valid_at_edge':
-    check_command       => 'check_ssl_cert!www.staging.publishing.service.gov.uk!www.staging.publishing.service.gov.uk!30',
-    host_name           => $::fqdn,
-    service_description => 'check the www.staging.publishing.service.gov.uk TLS certificate at EDGE is valid and not due to expire',
-    notes_url           => monitoring_docs_url(renew-tls-certificate),
+  if ($::aws_environment == 'staging') {
+    icinga::check { 'check_www_staging_cert_valid_at_edge':
+      check_command       => 'check_ssl_cert!www.staging.publishing.service.gov.uk!www.staging.publishing.service.gov.uk!30',
+      host_name           => $::fqdn,
+      service_description => 'check the www.staging.publishing.service.gov.uk TLS certificate at EDGE is valid and not due to expire',
+      notes_url           => monitoring_docs_url(renew-tls-certificate),
+    }
   }
 
-  icinga::check { 'check_www_integration_cert_valid_at_edge':
-    check_command       => 'check_ssl_cert!www.integration.publishing.service.gov.uk!www.integration.publishing.service.gov.uk!30',
-    host_name           => $::fqdn,
-    service_description => 'check the www.integration.publishing.service.gov.uk TLS certificate at EDGE is valid and not due to expire',
-    notes_url           => monitoring_docs_url(renew-tls-certificate),
+  if ($::aws_environment == 'integration') {
+    icinga::check { 'check_www_integration_cert_valid_at_edge':
+      check_command       => 'check_ssl_cert!www.integration.publishing.service.gov.uk!www.integration.publishing.service.gov.uk!30',
+      host_name           => $::fqdn,
+      service_description => 'check the www.integration.publishing.service.gov.uk TLS certificate at EDGE is valid and not due to expire',
+      notes_url           => monitoring_docs_url(renew-tls-certificate),
+    }
   }
 
   icinga::check { 'check_wildcard_cert_valid':


### PR DESCRIPTION
Icinga was showing an alert for GOV.UK's TLS cert at the edge expiring,
but it showed up as an individual alert across each environment.

These should only apply to the env the cert supplies.