### PR TITLE
Fix Licensing config following licensify#508

### DIFF
--- a/modules/licensify/templates/gds-licensify-admin-config.conf.erb
+++ b/modules/licensify/templates/gds-licensify-admin-config.conf.erb
@@ -8,7 +8,7 @@ include "application"
 # ~~~~~
 # The secret key is used to secure cryptographics functions.
 # If you deploy your application to several instances be sure to use the same key!
-application.secret="<%= @application_secret %>"
+play.crypto.secret="<%= @application_secret %>"
 
 # Root logger:
 logger.root=ERROR

--- a/modules/licensify/templates/gds-licensify-config.conf.erb
+++ b/modules/licensify/templates/gds-licensify-config.conf.erb
@@ -8,7 +8,7 @@ include "application"
 # ~~~~~
 # The secret key is used to secure cryptographics functions.
 # If you deploy your application to several instances be sure to use the same key!
-application.secret="<%= @application_secret %>"
+play.crypto.secret="<%= @application_secret %>"
 
 # Set session cookies to https only (not set in dev)
 session.secure=true

--- a/modules/licensify/templates/gds-licensify-feed-config.conf.erb
+++ b/modules/licensify/templates/gds-licensify-feed-config.conf.erb
@@ -8,7 +8,7 @@ include "application"
 # ~~~~~
 # The secret key is used to secure cryptographics functions.
 # If you deploy your application to several instances be sure to use the same key!
-application.secret="<%= @application_secret %>"
+play.crypto.secret="<%= @application_secret %>"
 
 # Set session cookies to https only (not set in dev)
 session.secure=true


### PR DESCRIPTION
In https://github.com/alphagov/licensify/pull/508 we changed the config
value we read the secret from application.secret to play.crypto.secret
in preparation for the upgrade from Play 2.5 to Play 2.6.

This looks like it has caused the code to fall back to the version of
the config in the licensing git repo, instead of the one in puppet,
which means that pre-deployment session cookies aren't decrypting
properly.

Using play.crypto.secret will mean the code gets the "correct" original
value for the cookie (from puppet). New sessions since the broken
release will be broken, but old sessions should work again.