### PR TITLE
Configure govuk_seed_crawler binary to live in /usr/local/bin

### DIFF
--- a/modules/govuk_crawler/manifests/init.pp
+++ b/modules/govuk_crawler/manifests/init.pp
@@ -144,7 +144,7 @@ class govuk_crawler(
   # This explicitly requires 'base::packages' so that nokogiri will build
   exec { 'gem install govuk_seed_crawler':
     environment => ['RBENV_VERSION=2.6.3'],
-    command     => 'gem install govuk_seed_crawler -v 3.0.0',
+    command     => 'gem install govuk_seed_crawler -v 3.0.0 --bindir /usr/local/bin',
     unless      => 'gem list | grep "govuk_seed_crawler.*3.0.0"',
     require     => Class['base::packages'],
   }


### PR DESCRIPTION
In the following PR from July 2021, govuk_seed_crawler was upgraded
to use Ruby version 2.6.3:
https://github.com/alphagov/govuk_seed_crawler/pull/10

This required making the following changes in govuk-puppet:

- https://github.com/alphagov/govuk-puppet/pull/11214
- https://github.com/alphagov/govuk-puppet/pull/11215

The above changes meant that govuk_seed_crawler was installed with
Ruby version 2.6.3, rather than with the system Ruby (1.9.3).
This change caused the [seed-crawler binary][binary] to be
installed in a different location (`/usr/lib/rbenv/versions/2.6.3/bin`).

Consequently, the script could not be [invoked][], as it wasn't
in its expected place, so our seed crawler has not worked since
these changes were introduced±.

± As an example, the homepage was last updated on 17th July:
`"LastModified": "2021-07-17T01:27:25+00:00",`. Whilst these PRs
weren't merged until 22nd July, the crawler takes several days to
complete its processing of all the sitemap URLs, so I expect the
seed crawler was still working between 17th and 22nd July.

Trello: https://trello.com/c/QGIayBqP/2784-fix-the-govuk-crawler

[binary]: https://github.com/alphagov/govuk_seed_crawler/blob/af3f9aa0b5a6bfdf857380b68f331e5a7e440e74/bin/seed-crawler#L1
[invoked]: https://github.com/alphagov/govuk-puppet/blob/18c30ffd1a8fcd8bf39f48d9ac83dddbcf6a932f/modules/govuk_crawler/templates/seed-crawler-wrapper.erb#L23