### PR TITLE
Support play.http.secret and play.crypto.secret

### DIFF
--- a/modules/licensify/templates/gds-licensify-admin-config.conf.erb
+++ b/modules/licensify/templates/gds-licensify-admin-config.conf.erb
@@ -9,6 +9,7 @@ include "application"
 # The secret key is used to secure cryptographics functions.
 # If you deploy your application to several instances be sure to use the same key!
 play.crypto.secret="<%= @application_secret %>"
+play.http.secret.key="<%= @application_secret %>"
 
 # Root logger:
 logger.root=ERROR

--- a/modules/licensify/templates/gds-licensify-config.conf.erb
+++ b/modules/licensify/templates/gds-licensify-config.conf.erb
@@ -9,6 +9,7 @@ include "application"
 # The secret key is used to secure cryptographics functions.
 # If you deploy your application to several instances be sure to use the same key!
 play.crypto.secret="<%= @application_secret %>"
+play.http.secret.key="<%= @application_secret %>"
 
 # Set session cookies to https only (not set in dev)
 session.secure=true

--- a/modules/licensify/templates/gds-licensify-feed-config.conf.erb
+++ b/modules/licensify/templates/gds-licensify-feed-config.conf.erb
@@ -9,6 +9,7 @@ include "application"
 # The secret key is used to secure cryptographics functions.
 # If you deploy your application to several instances be sure to use the same key!
 play.crypto.secret="<%= @application_secret %>"
+play.http.secret.key="<%= @application_secret %>"
 
 # Set session cookies to https only (not set in dev)
 session.secure=true


### PR DESCRIPTION
We're [upgrading from Play 2.5 to Play 2.6](https://github.com/alphagov/licensify/pull/510), and the config flag for the session cookie secret has changed its name.

In this commit we're setting both the old name and the new name to the same value, so it will be forwards and backwards compatible.

Once the new version of Licensify is released we should remove the play.crypto.secret value.