### PR TITLE
Re-enable Signon data sync & remove Cyber ITHC users

### DIFF
--- a/hieradata_aws/class/staging/db_admin.yaml
+++ b/hieradata_aws/class/staging/db_admin.yaml
@@ -288,7 +288,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "mysql"
   "pull_signon_production_daily":
-    ensure: "disabled"
+    ensure: "present"
     hour: "1"
     minute: "30"
     action: "pull"

--- a/modules/users/manifests/davidcliff.pp
+++ b/modules/users/manifests/davidcliff.pp
@@ -1,6 +1,7 @@
 # Creates davidcliff user
 class users::davidcliff {
   govuk_user { 'davidcliff':
+    ensure   => absent,
     fullname => 'David Cliff',
     email    => 'david.cliff@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCqXjcdnD4NLCCgmYRsee/PwN9yYFswcojkOX1QJ59cnnLw8h3YnG5BaFvEMk04f4SB+sxhIFBnqK6m1XbVF9/u9KL2Bo6Y2+cd9UT166I1nWPsQ76n3z8ADvqECMgxbJ3Vw7c6llvA45GvMjiqleBBM2D3GmMVtl0OB8z4kr5EKWh5TtPWkYMlYbjOpHeOifeDA5VOUAz76+9CFb3Mc7gzouAgZlTeb7LuyX4SmSC4fJ2sUjCbRd/alMu83wuKh0q5POpv05EKUvxzSwKsnT0HNwtdVhHiXtYUpCwxljSfa7UIW3vywYxqghmzJzrZWxotALFVWrw+thzknl3+a172FUhkIJ7sW7kl/HL8OgvV5bsbMcgWvkUGDmQzftjNLXTtIXNNuxKYX21OL4EXeMHikBvDLhD9YZ3Sk4dVdcuuyD8y73QAGE1qUZyUIuxNMMz6HyhB6buBe/GNcsG9iKlqyBDVZxM9zT3JxwMUOk2QHHxsxcgosvih9nXL5Rzj6BuLAj/MOP4+4mxslYvDb+MwtJSdM/t3PkPfg2YbiJh6rrStiGGTm0BaEVveAYROlHT4ULRp3oTWCyk9aQ/RdMECs+mQ2rn4ozwmJPdAO+ZJDn9YKERDxdHYlLen1cO2gs31wi3TCnwa0fjjYaCHDWzUswIp2NDSXChpTVZjzKoEvQ==',

--- a/modules/users/manifests/ovasiqbal.pp
+++ b/modules/users/manifests/ovasiqbal.pp
@@ -1,6 +1,7 @@
 # Creates ovasiqbal user
 class users::ovasiqbal {
   govuk_user { 'ovasiqbal':
+    ensure   => absent,
     fullname => 'Ovas Iqbal',
     email    => 'ovas.iqbal@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC9kI6Dv5GgmlGgHymBnCAAZabXaR8Df+OMZJN1iw/w7R4l9jqvPNa+G9Te5X5BE2TVLATsucd6jTzIDAIz2xGpWnEFt+I8REVKXfCHBKAoBLaIHqBOoW6U+eTvC8pUWMpjXSda2d6Ew/Ggj3R+VylyR4Ouq2cgxK3Dxlg1cm7nc34V0HsPZdxqzMR1BUGzDnUk+ehrgArsuNj1pxnmMK3YkoftLPIeIrBzfqQ7p6sg/k1eWwPumfoGQegA8fYaJshpM8wxIbL7N6EJ9GTg2PJMsN11BF7ko0qax+qwisAWOvXupm315U0D3LQ6Ikv88+SItqdalKu0Qkyt3Q22a1TM+uzfzrcc5Q0ZQmvtzftioCzkjw8bpDciagXMD7Q8rl5E35syzmR3jeiymamw31BBpRsAGHhWQoGY8xscvEUJKnXuWSb7Q9CG89MTOcfHgEWpx46bmjFqKSENOC9EcjlF7UxF7+aYvAC/3vWt1FiBF5Sw6BnjbanyCovR1TSqr7LogoJ95nY7oxUXrLnDmDGrF9z8MnXtTrDLBt6upttumb5O1uTbmrFVKPRDryYGgH81/YSLjeoRjj1NhruVGO7gRbzJe9fRWLgsWDGgxWlr1xqnxfD6sNSLmEJ0+x1FYwTtxM2CdzfrkqIT5q3y0BqbcdvWxlqE9bquy6NZd3tLHw==',

--- a/modules/users/manifests/samuelpritchard.pp
+++ b/modules/users/manifests/samuelpritchard.pp
@@ -1,6 +1,7 @@
 # Creates samuelpritchard user
 class users::samuelpritchard {
   govuk_user { 'samuelpritchard':
+    ensure   => absent,
     fullname => 'Samuel Pritchard',
     email    => 'samuel.pritchard@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDNNsdJTe3Z6n+Qa2i8bVAnT7Db/23tOCKnBmeSBtqkU1EyVL2ByV22qm6SqvOqPCokuXFeY+0llkDWps9K/ZOEAlhGIZ6iRZQVeuc4O37g1Jd5Pe+ITAorqhSXpEzefr2rbR4zfKqI2eQs1LxT+RRrx+e4JqTucGBqIxJofuz2Wka06dXzFtUYv/3wPs5KAdGnLGawnQRhE0LibeSP5ut2NJ0xTkbWBoBgyWMKrzR0+iyqFNR9RghcJLvcmFK/J6KpGrc+FcJQKbQGBkMyR6+Tfs9rwnoOW4JyIpM5XkkhXFrBxVckM1vR6Wt0cNJPlNBBngw9TytnIgijbyjixru3rJd2RU1yjvC5a1SMwhyfYaZAJlNCuJmNDTwKTXeoi5hi7nqmNP7EoywWz+y1Z6BHu02waclYvkMMozU7/Nn6j6EIltbghsNiFL4I2amQDcfRMjjhYqV7wzhPsGV4OSlOwvziEO9kbyl2nPJtYAMKQd5Ox8e8Y6Xu7qFnOJGLKLMr2FZm+xCh8IO5428YbziIqo8JUSQknFaTW+wQYPxbNys7oyeOd5OH8pkvzwyyQYEu83AiMcwzbqLwBdNxoQ0Q17pQw+jnFuPq4EgMrGupI8hwYRVzR9AkQtOABZ0hi9sSDT4VAxQvbcymnCed3MGMi4urnASOXWcHQXgfaxPK2w==',


### PR DESCRIPTION
It's taken a while, as the GOV.UK ITHC was delayed and then we had an accounts-specific ITHC, but at last everything is done.

This reverts the changes in #11279