### PR TITLE
Initialise rbenv before attempting to set the ruby version

### DIFF
--- a/modules/govuk_crawler/templates/seed-crawler-wrapper.erb
+++ b/modules/govuk_crawler/templates/seed-crawler-wrapper.erb
@@ -20,7 +20,7 @@ trap send_nsca EXIT
 
 export GOVUK_CRAWLER_AMQP_PASS='<%= @amqp_pass %>'
 
-OUTPUT=`rbenv shell 2.6.3 && <%= @seeder_script_path %> <%= @seeder_script_args %>`
+OUTPUT=`eval "$(rbenv init -)" && rbenv shell 2.6.3 && <%= @seeder_script_path %> <%= @seeder_script_args %>`
 
 logger -p local3.info -t seed-crawler-wrapper "$OUTPUT"
 


### PR DESCRIPTION
The `rbenv shell 2.6.3` command was added in #11214.
However, if I SSH into a mirrorer instance, run
`sudo su - govuk-crawler` and then run
`/usr/local/bin/seed-crawler-wrapper` (which is owned by
`govuk-crawler` user, hence why we assume that identity),
I get the following error:

> rbenv: no such command `shell'

This is apparently because the rbenv init script hasn't been
called:
https://github.com/rbenv/rbenv/issues/142#issuecomment-2687963

I've built this to Integration and re-ran the above steps, then did a `ls -lsatr /mnt/crawler_worker/www.integration.publishing.service.gov.uk` and can see that the 'last modified' date on each of the mirrored files has now updated to November 23rd, so this fix appears to work.

Trello: https://trello.com/c/QGIayBqP/2784-fix-the-govuk-crawler-3