### PR TITLE
Bugfix: Clear Static templates in clear-template-cache job

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/clear_template_cache.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/clear_template_cache.yaml.erb
@@ -15,7 +15,7 @@
           set -ex
 
           for node in `govuk_node_list -c frontend`; do
-            ssh deploy@$node "rm -f /var/apps/static/public/templates/{wrapper,homepage,header_footer_only,core_layout}.html.erb"
+            ssh deploy@$node "rm -f /var/apps/static/public/templates/*.html.erb"
             ssh deploy@$node "rm -rf /var/apps/{,government-}frontend/tmp/cache/*"
           done
 


### PR DESCRIPTION
The templates were added to and renamed over the past 8 months.
This led to a confusing to investigate problem where old templates were served by Static due to caching.

This clears all cached templates when running the clear-template-cache job.

This is a short-term fix. The longer term fix is to stop storing the static templates in four layers of caches.