### PR TITLE
Exclude electoral page from traffic replay

### DIFF
--- a/hieradata_aws/class/production/cache.yaml
+++ b/hieradata_aws/class/production/cache.yaml
@@ -8,6 +8,7 @@ router::gor::http_disallow_url:
   - 'apply-for-a-licence/payment'
   - 'apply-for-a-licence/redirect'
   - 'apply-for-a-licence/uploaded'
+  - 'contact-electoral-registration-office'
   - 'sign-in/callback'
 govuk_safe_to_reboot::can_reboot: 'careful'
 govuk_safe_to_reboot::reason: 'Handles requests, traffic should be drained before restarting'

--- a/hieradata_aws/class/staging/cache.yaml
+++ b/hieradata_aws/class/staging/cache.yaml
@@ -8,4 +8,5 @@ router::gor::http_disallow_url:
   - 'apply-for-a-licence/payment'
   - 'apply-for-a-licence/redirect'
   - 'apply-for-a-licence/uploaded'
+  - 'contact-electoral-registration-office'
   - 'sign-in/callback'


### PR DESCRIPTION
It uses an external API that doesn't need to be hit twice for each request.

Is tested by https://github.com/alphagov/smokey/pull/874