### PR TITLE
Remove unneeded account env vars from email-alert-frontend

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -38,7 +38,6 @@ govuk::apps::email_alert_api::govuk_notify_template_id: '1fc69d3a-09a2-40f9-852b
 govuk::apps::email_alert_api::govuk_notify_recipients:
   - email-alert-api-integration@digital.cabinet-office.gov.uk
 govuk::apps::email_alert_frontend::subscription_management_enabled: true
-govuk::apps::email_alert_frontend::govuk_personalisation_manage_uri: 'https://integration.account.gov.uk?link=manage-account'
 govuk::apps::feedback::govuk_notify_survey_signup_reply_to_id: 'fee22233-2f28-4b0b-8b6c-4410979f2275'
 govuk::apps::feedback::govuk_notify_survey_signup_template_id: 'eb9ba220-7d74-4aab-975a-bdbe718f69a3'
 govuk::apps::feedback::govuk_notify_accessible_format_request_reply_to_id: '77941cb6-f3a2-4b0d-b09c-64572858cb50'

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -190,7 +190,6 @@ govuk::apps::govuk_crawler_worker::crawler_threads: '32'
 govuk::apps::email_alert_api::db::backend_ip_range: '10.13.3.0/24'
 govuk::apps::email_alert_api::govuk_notify_template_id: 'cb633abc-6ae6-4843-ae6f-82ca500b6de2'
 govuk::apps::email_alert_api::govuk_notify_recipients: '*'
-govuk::apps::email_alert_frontend::govuk_personalisation_manage_uri: 'https://account.gov.uk?link=manage-account'
 govuk::apps::feedback::govuk_notify_survey_signup_reply_to_id: 'e8b2d8a6-db5f-4346-9fbd-49b16b531e1c'
 govuk::apps::feedback::govuk_notify_survey_signup_template_id: '54168fa9-3946-4860-a2f8-27ddbb14babe'
 

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -178,8 +178,6 @@ govuk::apps::email_alert_api::govuk_notify_recipients:
   - michael.s.walker+accounts-qa-9@digital.cabinet-office.gov.uk
   - michael.s.walker+accounts-qa-10@digital.cabinet-office.gov.uk
 govuk::apps::email_alert_frontend::subscription_management_enabled: true
-govuk::apps::email_alert_frontend::account_auth_enabled: true
-govuk::apps::email_alert_frontend::govuk_personalisation_manage_uri: 'https://integration.account.gov.uk?link=manage-account'
 govuk::apps::feedback::govuk_notify_survey_signup_reply_to_id: 'd1f54751-80a8-420a-9077-d34c7d6cc734'
 govuk::apps::feedback::govuk_notify_survey_signup_template_id: '8a8d98c0-42c8-4f56-b61f-77c89417a171'
 

--- a/modules/govuk/manifests/apps/email_alert_frontend.pp
+++ b/modules/govuk/manifests/apps/email_alert_frontend.pp
@@ -47,12 +47,6 @@
 #   The bearer token to use when communicating with Account API.
 #   Default: undef
 #
-# [*account_auth_enabled*]
-#   Whether users can log in with their GOV.UK Account.
-#
-# [*govuk_personalisation_manage_uri*]
-#   URI for the account management page.
-#
 
 class govuk::apps::email_alert_frontend(
   $vhost = 'email-alert-frontend',
@@ -66,8 +60,6 @@ class govuk::apps::email_alert_frontend(
   $email_alert_auth_token = undef,
   $subscription_management_enabled = false,
   $account_api_bearer_token = undef,
-  $account_auth_enabled = false,
-  $govuk_personalisation_manage_uri = undef,
 ) {
   $app_name = 'email-alert-frontend'
 
@@ -107,22 +99,12 @@ class govuk::apps::email_alert_frontend(
     "${title}-EMAIL_ALERT_AUTH_TOKEN":
         varname => 'EMAIL_ALERT_AUTH_TOKEN',
         value   => $email_alert_auth_token;
-    "${title}-GOVUK-PERSONALISATION-MANAGE-URI":
-      varname => 'GOVUK_PERSONALISATION_MANAGE_URI',
-      value   => $govuk_personalisation_manage_uri;
   }
 
   if $subscription_management_enabled {
     govuk::app::envvar { "${title}-SUBSCRIPTION_MANAGEMENT_ENABLED":
       varname => 'SUBSCRIPTION_MANAGEMENT_ENABLED',
       value   => 'yes';
-    }
-  }
-
-  if $account_auth_enabled {
-    govuk::app::envvar { "${title}-FEATURE_FLAG_GOVUK_ACCOUNT":
-      varname => 'FEATURE_FLAG_GOVUK_ACCOUNT',
-      value   => 'enabled';
     }
   }
 }


### PR DESCRIPTION
- `account_auth_enabled`: it's now switched on in all environments, so
we don't need to be able to toggle it per-environment any more.

- `govuk_personalisation_manage_uri`: the link to change your email
address no longer shows for account users, so we don't need this; the
URL for the link in the sidebar comes from static, and so doesn't use
this env var.