### PR TITLE
Add Docker powered PostgreSQL & MySQL servers to CI Agents

### DIFF
--- a/modules/govuk_ci/manifests/agent/mysql.pp
+++ b/modules/govuk_ci/manifests/agent/mysql.pp
@@ -3,6 +3,14 @@
 # Installs and configures mysql-server
 #
 class govuk_ci::agent::mysql {
+  # Docker instances of MySQL server versions that are installed in parallel
+  # with the Ubuntu Trusty version
+  include ::govuk_docker
+  ::govuk_containers::ci_mysql { 'ci-mysql-8':
+    tag  => '8',
+    port => 33068,
+  }
+
   contain ::govuk_mysql::server
 
   # We want to run MySQL on a ramdisk, so this creates the directory so that it

--- a/modules/govuk_ci/manifests/agent/postgresql.pp
+++ b/modules/govuk_ci/manifests/agent/postgresql.pp
@@ -14,6 +14,14 @@ class govuk_ci::agent::postgresql (
   $mapit_role_password = 'mapit',
   $email_alert_api_role_password = 'email-alert-api',
 ) {
+  # Docker instances of PostgreSQL server versions that are installed in
+  # parallel with the Ubuntu Trusty version
+  include ::govuk_docker
+  ::govuk_containers::ci_postgresql { 'ci-postgresql-13':
+    version => '13',
+    port    => 54313,
+  }
+
   contain ::govuk_postgresql::mirror
   include ::govuk_postgresql::server::standalone
   include ::postgresql::server::contrib

--- a/modules/govuk_containers/manifests/ci_mysql.pp
+++ b/modules/govuk_containers/manifests/ci_mysql.pp
@@ -1,0 +1,32 @@
+# == Resource: govuk_containers::ci_mysql
+#
+# Install and run a dockerised MySQL server, intended for CI purposes
+#
+# === Parameters
+#
+# [*version*]
+#   The version of the MySQL Docker image to use
+#
+# [*port*]
+#   The port that the MySQL server will be exposed on
+#
+define govuk_containers::ci_mysql(
+  $ensure = 'present',
+  $version = '8',
+  $port = 33068
+) {
+  ::docker::run { $title:
+    ensure  => $ensure,
+    ports   => ["127.0.0.1:${port}:3306"],
+    image   => "mysql:${version}",
+    env     => ['"MYSQL_ROOT_PASSWORD=root"'],
+    command => '--default-authentication-plugin=mysql_native_password',
+  }
+
+  @@icinga::check { "check_${title}_running_${::hostname}":
+    ensure              => $ensure,
+    check_command       => "check_nrpe!check_tcp!127.0.0.1 ${port}",
+    service_description => "Docker MySQL ${version} not accepting TCP connections",
+    host_name           => $::fqdn,
+  }
+}

--- a/modules/govuk_containers/manifests/ci_postgresql.pp
+++ b/modules/govuk_containers/manifests/ci_postgresql.pp
@@ -1,0 +1,31 @@
+# == Resource: govuk_containers::ci_postgresql
+#
+# Install and run a dockerised PostgreSQL server, intended for CI purposes
+#
+# === Parameters
+#
+# [*version*]
+#   The version of the PostgreSQL Docker image to use
+#
+# [*port*]
+#   The port that the PostgreSQL server will be exposed on
+#
+define govuk_containers::ci_postgresql(
+  $ensure = 'present',
+  $version = '13',
+  $port = 54313
+) {
+  ::docker::run { $title:
+    ensure => $ensure,
+    ports  => ["127.0.0.1:${port}:5432"],
+    image  => "postgres:${version}",
+    env    => ['"POSTGRES_HOST_AUTH_METHOD=trust"'],
+  }
+
+  @@icinga::check { "check_${title}_running_${::hostname}":
+    ensure              => $ensure,
+    check_command       => "check_nrpe!check_tcp!127.0.0.1 ${port}",
+    service_description => "Docker PostgreSQL ${version} not accepting TCP connections",
+    host_name           => $::fqdn,
+  }
+}

--- a/modules/govuk_containers/manifests/elasticsearch.pp
+++ b/modules/govuk_containers/manifests/elasticsearch.pp
@@ -41,15 +41,16 @@ define govuk_containers::elasticsearch(
     volumes => ['/usr/share/elasticsearch/data', '/usr/share/elasticsearch/import', "/etc/elasticsearch-docker-${image_version}.yml:/usr/share/elasticsearch/config/elasticsearch.yml"],
   }
 
+  # FIXME: once this has been run in production this definition and the source file can be removed.
   @icinga::nrpe_config { "check_dockerised_elasticsearch_${image_version}_responding":
-    ensure => $ensure,
+    ensure => 'absent',
     source => 'puppet:///modules/govuk_containers/nrpe_check_dockerised_elasticsearch_responding.cfg',
   }
 
   @@icinga::check { "check_dockerised_elasticsearch_${image_version}_responding_${::hostname}":
     ensure              => $ensure,
-    check_command       => "check_nrpe!check_dockerised_elasticsearch_responding!${elasticsearch_port}",
-    service_description => 'dockerised elasticsearch port not responding',
+    check_command       => "check_nrpe!check_tcp!127.0.0.1 ${elasticsearch_port}",
+    service_description => "Docker Elasticsearch ${image_version} not accepting TCP connections",
     host_name           => $::fqdn,
   }
 }

--- a/modules/govuk_containers/spec/defines/govuk_containers__ci_mysql_spec.rb
+++ b/modules/govuk_containers/spec/defines/govuk_containers__ci_mysql_spec.rb
@@ -1,0 +1,14 @@
+require_relative '../../../../spec_helper'
+
+describe 'govuk_containers::ci_postgresql', :type => :define do
+  let(:title) { "ci-postgresql-instance" }
+
+  let(:pre_condition) { <<-EOS
+    include ::govuk_python
+    include ::govuk_docker
+    EOS
+  }
+  it { is_expected.to compile }
+
+  it { is_expected.to compile.with_all_deps }
+end

--- a/modules/govuk_containers/spec/defines/govuk_containers__ci_postgresql_spec.rb
+++ b/modules/govuk_containers/spec/defines/govuk_containers__ci_postgresql_spec.rb
@@ -1,0 +1,14 @@
+require_relative '../../../../spec_helper'
+
+describe 'govuk_containers::ci_mysql', :type => :define do
+  let(:title) { "ci-mysql-instance" }
+
+  let(:pre_condition) { <<-EOS
+    include ::govuk_python
+    include ::govuk_docker
+    EOS
+  }
+  it { is_expected.to compile }
+
+  it { is_expected.to compile.with_all_deps }
+end

--- a/modules/icinga/files/etc/nagios/nrpe.d/check_tcp.cfg
+++ b/modules/icinga/files/etc/nagios/nrpe.d/check_tcp.cfg
@@ -1,0 +1,1 @@
+command[check_tcp]=/usr/lib/nagios/plugins/check_tcp -H $ARG1$ -p $ARG2$ -w 5 -c 10


### PR DESCRIPTION
Trello: https://trello.com/c/oRrpsveM/64-investigating-running-current-version-of-postgresql-and-mysql-on-govuk-ci

This adds puppet defined types to run and monitor PostgreSQL and MySQL
servers via Docker, without a peristent storage layer and with no access
control 😬.

It then uses these defined types to install PostgreSQL 13 and MySQL 8 on all
the CI Agent boxes, as part of the configuration for other database
tooling. Those versions have been chosen as they're the DB versions
we're aspiring to upgrade GOV.UK to use.

The expectation is that apps will make use of these databases by setting
environment variables in their puppet configuration. These are some
examples I've tested:

```
govuk.setEnvar("TEST_DATABASE_URL", "postgresql://postgres@127.0.0.1:54313/content-publisher-test")
govuk.setEnvar("TEST_DATABASE_URL", "mysql2://root:root@127.0.0.1:33068/whitehall_test")
```

Note: MySQL seems to struggle with localhost hostname but works with an
IP addreess (I think it tries to use a local socket when it sees the
hostname)

I've tried this out on a couple of builds: https://github.com/alphagov/content-publisher/commit/29adf45706b340ed3f00412cb27f15a8bea9f545 and https://github.com/alphagov/whitehall/commit/49729b8cdcec1091d6be9ec7729a8927c1dafbc4

---

These changes have been made so that applications can run their tests against
database versions that are newer than what Ubuntu Trusty supports. I've
put this together with a degree of optimism that the configuration for
these versions will work for other versions, so that the same defined
type can be used multiple times.

A couple of caveats:

- I run the database servers on the port that we expose rather than
  mapping their original port to the exposed one (-p 33068:3306) as the
  images are configured to expose their default port and this clashes
  with pre-existing MySQL/PostgreSQL installations.
- For older versions of MySQL client to connect to newer ones I seem to
  need to set `--default-authentication-plugin=mysql_native_password`
  otherwise there's an error of `Authentication plugin
  'caching_sha2_password' cannot be loaded`.