### PR TITLE
Add explicit host header to check_http calls

### DIFF
--- a/modules/icinga/files/etc/nagios/nrpe.d/check_app_up.cfg
+++ b/modules/icinga/files/etc/nagios/nrpe.d/check_app_up.cfg
@@ -1,1 +1,1 @@
-command[check_app_up]=/usr/lib/nagios/plugins/check_http -w 5 -c 10 -I 127.0.0.1 -p $ARG1$ -u $ARG2$ -k 'Accept: */*'
+command[check_app_up]=/usr/lib/nagios/plugins/check_http -w 5 -c 10 -I 127.0.0.1 -H 127.0.0.1 -p $ARG1$ -u $ARG2$ -k 'Accept: */*'


### PR DESCRIPTION
https://nagios-plugins.org/doc/man/check_http.html

> -H, --hostname=ADDRESS
        Host name argument for servers using host headers (virtual host)
        Append a port to include it in the header (eg: example.com:5000)

By default, the version of check_http we're using doesn't send a Host
header. Licensify is very strict about this, which causes the check to
fail:

```
> GET /licence-management/feed/process-applications HTTP/1.0
> User-Agent: check_http/v1.5 (nagios-plugins 1.5)
> Connection: close
> Accept: */*

< HTTP/1.1 400 Bad Request
< Date: Tue, 30 Nov 2021 12:58:10 GMT
< Connection: close
< Content-Type: text/plain; charset=UTF-8
< Content-Length: 41
<
< Request is missing required `Host` header
```

Since we're already specifying `-I 127.0.0.1` it makes sense to always
send that as the host. This should keep Licensify happy.