### PR TITLE
Add missing link to docs for GCP mirror sync job

### DIFF
--- a/modules/monitoring/manifests/checks/mirror.pp
+++ b/modules/monitoring/manifests/checks/mirror.pp
@@ -48,6 +48,7 @@ class monitoring::checks::mirror (
     icinga::check { 'check_mirror_file_sync':
       check_command       => "check_mirror_file_sync!${google_application_credentials_file_path}!${gcp_mirror_sync_project_id}",
       service_description => 'Check status of latest GCP mirror sync job',
+      notes_url           => monitoring_docs_url(check-status-gcp-mirror-sync-job),
       use                 => 'govuk_normal_priority',
       check_interval      => 1440,
       host_name           => $::fqdn,


### PR DESCRIPTION
This PR adds a missing link to the [existing docs](https://docs.publishing.service.gov.uk/manual/alerts/check-status-gcp-mirror-sync-job.html) describing what to do when the GCP mirror sync job fails.