### PR TITLE
Upgrade Nodejs to 12.22.1

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1467,7 +1467,7 @@ nginx::package::nginx_version: "1.14.0-1~trusty"
 
 nodejs::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 nodejs::repo::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
-nodejs::version: '12.18.2-1nodesource1'
+nodejs::version: '12.22.1-1nodesource1'
 
 ntp::server_list:
   - 'ntp.ubuntu.com'


### PR DESCRIPTION
This upgrade has done because it's becoming somewhat common for NodeJS
utilities to require Node 12.20 or over since that is when native
support for imports landed.

I've published the repo of this to aptly and tested installing it on a
machine.

I've not yet investigated whether NodeJS 14 or 16 will run on Ubuntu
Trusty (12 wasn't supported on there but still runs) and upgrade to
those is a bit more involved as it involves updating the Aptly repo. We
may have to consider that from May 2022 when NodeJS 12 reaches EOL.