### PR TITLE
Prepare to remove mysql replica

### DIFF
--- a/hieradata_aws/class/frontend.yaml
+++ b/hieradata_aws/class/frontend.yaml
@@ -1,8 +1,3 @@
 ---
 govuk::apps::collections::memcache_servers: 'frontend-memcached:11211'
-
-govuk::apps::contacts::db_hostname: 'mysql-replica'
-govuk::apps::contacts::db_username: 'contacts_fe'
-govuk::apps::contacts::db_password: "%{hiera('govuk::apps::contacts::db::mysql_contacts_frontend')}"
-
 govuk::apps::frontend::memcache_servers: 'frontend-memcached:11211'

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1450,7 +1450,6 @@ monitoring::checks::rds::servers:
    - 'transition-postgresql-primary'
    - 'transition-postgresql-standby'
    - 'mysql-primary'
-   - 'mysql-replica'
 
 monitoring::checks::mirror::gcp_mirror_sync_project_id: "%{hiera('monitoring::gcp_mirror_sync_project_id')}"
 monitoring::checks::mirror::gcp_mirror_sync_transfer_job_auth_json: "%{hiera('monitoring::gcp_mirror_sync_transfer_job_auth_json')}"

--- a/modules/govuk_mysql/README.md
+++ b/modules/govuk_mysql/README.md
@@ -1,3 +1,0 @@
-Please see the opsmanual for details about how to setup MySQL replication:
-
-https://github.digital.cabinet-office.gov.uk/pages/gds/opsmanual/infrastructure/howto/setup-mysql-replication.html


### PR DESCRIPTION
Remove some confusing hieradata, monitoring of mysql-replica, and a confusing README.

This is preparation for https://github.com/alphagov/govuk-aws/pull/1491 in which I propose we remove the mysql replicas.

More detail in the commit messages.