### PR TITLE
Add cron schedule for the related links ingestion job

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -164,6 +164,8 @@ govuk_jenkins::jobs::smokey::environment: integration
 govuk_jenkins::jobs::deploy_dns::gce_project_id: 'govuk-integration'
 
 govuk_jenkins::jobs::run_related_links_generation::cron_schedule: '0 8 9,23 * *'
+govuk_jenkins::jobs::run_related_links_ingestion::cron_schedule: '0 8 11,25 * *'
+
 govuk_jenkins::jobs::search_api_fetch_analytics_data::skip_page_traffic_load: true
 govuk_jenkins::jobs::search_api_fetch_analytics_data::cron_schedule: '30 9 * * 1-5'
 

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -302,6 +302,8 @@ govuk_jenkins::jobs::clear_cdn_cache::website_root_url: 'www.gov.uk'
 govuk_jenkins::jobs::clear_cdn_cache::assets_root_url: 'assets.publishing.service.gov.uk'
 
 govuk_jenkins::jobs::run_related_links_generation::cron_schedule: '0 8 9,23 * *'
+govuk_jenkins::jobs::run_related_links_ingestion::cron_schedule: '0 8 11,25 * *'
+
 govuk_jenkins::jobs::search_fetch_analytics_data::skip_page_traffic_load: true
 govuk_jenkins::jobs::search_fetch_analytics_data::cron_schedule: '30 8 * * 1-5'
 


### PR DESCRIPTION
This PR adds a schedule for the related links ingestion job, so that ingestion runs automatically. 

**DO NOT MERGE** until Data Labs team is finished with their weighted related links A/B test.

cc @maxf 