### PR TITLE
Port SpeedCurve LUX version check to Jenkins

### DIFF
--- a/hieradata_aws/class/production/jenkins.yaml
+++ b/hieradata_aws/class/production/jenkins.yaml
@@ -78,6 +78,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::send_bulk_email
   - govuk_jenkins::jobs::signon_cron_rake_tasks
   - govuk_jenkins::jobs::smart_answers_broken_links_report
+  - govuk_jenkins::jobs::speedcurve_lux_js_version_check
   - govuk_jenkins::jobs::sync_assets_s3
   - govuk_jenkins::jobs::smokey
   - govuk_jenkins::jobs::smokey_deploy

--- a/modules/govuk_jenkins/manifests/jobs/speedcurve_lux_js_version_check.pp
+++ b/modules/govuk_jenkins/manifests/jobs/speedcurve_lux_js_version_check.pp
@@ -1,0 +1,26 @@
+# == Class: govuk_jenkins::jobs::speedcurve_lux_js_version_check
+#
+# Create a file on disk that can be parsed by jenkins-job-builder
+#
+class govuk_jenkins::jobs::speedcurve_lux_js_version_check {
+  $deploy_jenkins_domain = hiera('deploy_jenkins_domain')
+  $job_url = "https://${deploy_jenkins_domain}/job/speedcurve-lux-js-version-check/"
+  $service_description = 'SpeedCurve LUX JavaScript version check'
+
+  file {
+    '/etc/jenkins_jobs/jobs/speedcurve_lux_js_version_check.yaml':
+      ensure  => present,
+      content => template('govuk_jenkins/jobs/speedcurve_lux_js_version_check.yaml.erb'),
+      notify  => Exec['jenkins_jobs_update'];
+  }
+
+  @@icinga::passive_check { "speedcurve_lux_js_version_check_${::hostname}":
+    service_description     => $service_description,
+    host_name               => $::fqdn,
+    freshness_threshold     => 86400, # 24 hours
+    freshness_alert_level   => 'warning',
+    freshness_alert_message => 'SpeedCurve LUX JavaScript version check has stopped running or is unstable',
+    action_url              => $job_url,
+    notes_url               => monitoring_docs_url(speedcurve-lux-js-version-check),
+  }
+}

--- a/modules/govuk_jenkins/templates/jobs/speedcurve_lux_js_version_check.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/speedcurve_lux_js_version_check.yaml.erb
@@ -1,0 +1,39 @@
+---
+- job:
+    name: speedcurve-lux-js-version-check
+    display-name: SpeedCurve LUX JS version check
+    project-type: freestyle
+    description: 'Job to verify that GOV.UK is using the current JS version of Speedcurve LUX'
+    logrotate:
+      numToKeep: 100
+    triggers:
+      - timed: |
+          TZ=Europe/London
+          H 10,16 * * *
+    properties:
+      - build-discarder:
+          days-to-keep: 30
+          artifact-num-to-keep: 5
+    builders:
+      - shell: |
+          #!/usr/bin/env bash
+          set -e
+
+          # we grep against the version GOV.UK is currently using in
+          # https://github.com/alphagov/govuk_publishing_components/blob/master/app/assets/javascripts/govuk_publishing_components/vendor/lux/lux-reporter.js
+          curl -s https://cdn.speedcurve.com/js/lux.js\?id\=47044334 | grep 't="216"'
+    publishers:
+      - trigger-parameterized-builds:
+        - project: Success_Passive_Check
+          condition: 'SUCCESS'
+          predefined-parameters: |
+            NSCA_CHECK_DESCRIPTION=<%= @service_description %>
+            NSCA_OUTPUT=<%= @service_description %> success
+        - project: Failure_Passive_Check
+          condition: 'FAILED'
+          predefined-parameters: |
+            NSCA_CHECK_DESCRIPTION=<%= @service_description %>
+            NSCA_OUTPUT=<%= @service_description %> failed
+    wrappers:
+      - ansicolor:
+          colormap: xterm


### PR DESCRIPTION
This ports the concourse pipeline from
https://github.com/alphagov/govuk-speedcurve-lux-js-monitor into a
Jenkins job. This has been done due to the imminent retirement of the
GDS Concourse pipeline.

The check itself is a little unusual. It checks that the version of
lux.js which SpeedCurve serve matches the one this script has. The
theory is that if this job starts alerting someone will go update the
lux.js file in govuk_publishing_components and then update the version
number in here. There isn't however any guarantees that the version
number in this file matches what GOV.UK is serving.

I've set this check to only run in production, this seems the most
appropriate place for something that is environment ambivalent.