### PR TITLE
Reduce Integration and Staging Cert Edge Expiry Check

### DIFF
--- a/modules/monitoring/manifests/checks.pp
+++ b/modules/monitoring/manifests/checks.pp
@@ -162,7 +162,7 @@ class monitoring::checks (
 
   if ($::aws_environment == 'staging') {
     icinga::check { 'check_www_staging_cert_valid_at_edge':
-      check_command       => 'check_ssl_cert!www.staging.publishing.service.gov.uk!www.staging.publishing.service.gov.uk!30',
+      check_command       => 'check_ssl_cert!www.staging.publishing.service.gov.uk!www.staging.publishing.service.gov.uk!25',
       host_name           => $::fqdn,
       service_description => 'check the www.staging.publishing.service.gov.uk TLS certificate at EDGE is valid and not due to expire',
       notes_url           => monitoring_docs_url(renew-tls-certificate),
@@ -171,7 +171,7 @@ class monitoring::checks (
 
   if ($::aws_environment == 'integration') {
     icinga::check { 'check_www_integration_cert_valid_at_edge':
-      check_command       => 'check_ssl_cert!www.integration.publishing.service.gov.uk!www.integration.publishing.service.gov.uk!30',
+      check_command       => 'check_ssl_cert!www.integration.publishing.service.gov.uk!www.integration.publishing.service.gov.uk!25',
       host_name           => $::fqdn,
       service_description => 'check the www.integration.publishing.service.gov.uk TLS certificate at EDGE is valid and not due to expire',
       notes_url           => monitoring_docs_url(renew-tls-certificate),


### PR DESCRIPTION
Since we are now using Fastly Letsencrypt certs in [integration](https://github.com/alphagov/govuk-dns-config/pull/763) and [staging](https://github.com/alphagov/govuk-dns-config/pull/764) and these are automatically renewed only when there are 30 days left, we want to reduce the alert time for the certificate expiry in these environment.

The production certificate is with globalsign and is renewed between 90 and 120 days before expiry so there is no need to change the threshold there.

Ref:
1. [Fastly SSL/TLS Doc](https://docs.fastly.com/en/guides/serving-https-traffic-using-fastly-managed-certificates#certificate-management-and-renewals)