### PR TITLE
Put conditionals into alphabetical order

### DIFF
--- a/modules/govuk_env_sync/files/govuk_env_sync.sh
+++ b/modules/govuk_env_sync/files/govuk_env_sync.sh
@@ -338,13 +338,12 @@ function restore_elasticsearch {
 
 function dump_postgresql {
   # Check which postgres instance the database needs to restore into
-  # (transition, or postgresql-primary).
-  if [ "${database}" == 'transition_production' ]; then
-    db_hostname='transition-postgresql-primary'
+  if [ "${database}" == 'content_data_api_production' ]; then
+    db_hostname='content-data-api-postgresql-primary'
   elif [ "${database}" == 'content_performance_manager_production' ]; then
     db_hostname='content-data-api-postgresql-primary'
-  elif [ "${database}" == 'content_data_api_production' ]; then
-    db_hostname='content-data-api-postgresql-primary'
+  elif [ "${database}" == 'transition_production' ]; then
+    db_hostname='transition-postgresql-primary'
   else
     db_hostname='postgresql-primary'
   fi


### PR DESCRIPTION
We'll soon be creating a number of different {app}_db_admin
machines, all of which will require their own conditional in this
`dump_postgresql` function. We should start as we mean to go on,
and put these in an alphabetical order to ease maintenance.

Note that in future we hope to refactor away the need to have
these conditionals.