### PR TITLE
DRY up the app-specific DB admin box configuration

### DIFF
--- a/modules/govuk/manifests/node/s_content_data_api_db_admin.pp
+++ b/modules/govuk/manifests/node/s_content_data_api_db_admin.pp
@@ -31,50 +31,14 @@ class govuk::node::s_content_data_api_db_admin(
   include govuk_env_sync
   include ::govuk::node::s_base
 
-  # This allows easy administration of the PostgreSQL backend:
-  # https://www.postgresql.org/docs/9.3/static/libpq-pgpass.html
-  file { '/root/.pgpass':
-    ensure  => present,
-    mode    => '0600',
-    content => "${postgres_host}:5432:*:${postgres_user}:${postgres_password}",
-  }
-
-  # Unfortunately, the prior art for configuring db-admin style
-  # machines seems to involve a redundant PostgreSQL service, just to
-  # satisfy the Puppet module used to configure PostgreSQL running on
-  # the RDS instance. Some of the below configuration relates to this.
-
-  # Connect to the RDS instance when performing Puppet operations
-  $default_connect_settings = {
-    'PGUSER'     => $postgres_user,
-    'PGPASSWORD' => $postgres_password,
-    'PGHOST'     => $postgres_host,
-    'PGPORT'     => $postgres_port,
-  }
-
-  apt::source { 'postgresql':
-    ensure       => present,
-    location     => "http://${apt_mirror_hostname}/postgresql",
-    release      => "${::lsbdistcodename}-pgdg",
-    architecture => $::architecture,
-    key          => 'B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8',
+  # include the common config/tooling required for our app-specific DB admin class
+  class { '::govuk::nodes::postgresql_db_admin':
+    postgres_host       => $postgres_host,
+    postgres_user       => $postgres_user,
+    postgres_password   => $postgres_password,
+    postgres_port       => $postgres_port,
+    apt_mirror_hostname => $apt_mirror_hostname,
   } ->
-
-  # We don't actually want to run a local PostgreSQL server, just
-  # configure the RDS one
-  class { '::postgresql::server':
-    default_connect_settings => $default_connect_settings,
-    service_manage           => false,
-  } ->
-
-  service { 'postgresql':
-    ensure  => stopped,
-  }
-
-  include ::govuk_postgresql::server::not_slave
-
-  # Ensure the client class is installed
-  class { '::govuk_postgresql::client': } ->
 
   # include all PostgreSQL classes that create databases and users
   class { '::govuk::apps::content_data_api::db': }

--- a/modules/govuk/manifests/node/s_transition_db_admin.pp
+++ b/modules/govuk/manifests/node/s_transition_db_admin.pp
@@ -14,43 +14,14 @@ class govuk::node::s_transition_db_admin(
   include govuk_env_sync
   include ::govuk::node::s_base
 
-  ### PostgreSQL ###
-
-  $default_connect_settings = {
-    'PGUSER'     => $postgres_user,
-    'PGPASSWORD' => $postgres_password,
-    'PGHOST'     => $postgres_host,
-    'PGPORT'     => $postgres_port,
-  }
-
-  # To manage remote databases using the puppetlabs-postgresql module we require
-  # a local PostgreSQL server instance to be installed
-  apt::source { 'postgresql':
-    ensure       => present,
-    location     => "http://${apt_mirror_hostname}/postgresql",
-    release      => "${::lsbdistcodename}-pgdg",
-    architecture => $::architecture,
-    key          => 'B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8',
+  # include the common config/tooling required for our app-specific DB admin class
+  class { '::govuk::nodes::postgresql_db_admin':
+    postgres_host       => $postgres_host,
+    postgres_user       => $postgres_user,
+    postgres_password   => $postgres_password,
+    postgres_port       => $postgres_port,
+    apt_mirror_hostname => $apt_mirror_hostname,
   } ->
-
-  class { '::postgresql::server':
-    default_connect_settings => $default_connect_settings,
-  } ->
-
-  # This allows easy administration of the PostgreSQL backend:
-  # https://www.postgresql.org/docs/9.3/static/libpq-pgpass.html
-  file { '/root/.pgpass':
-    ensure  => present,
-    mode    => '0600',
-    content => "${postgres_host}:5432:*:${postgres_user}:${postgres_password}",
-  }
-
-  # This class collects the resources that are exported by the
-  # govuk_postgresql::server::db defined type
-  include ::govuk_postgresql::server::not_slave
-
-  # Ensure the client class is installed
-  class { '::govuk_postgresql::client': } ->
 
   # include all PostgreSQL classes that create databases and users
   class { '::govuk::apps::transition::postgresql_db': } ->
@@ -59,5 +30,4 @@ class govuk::node::s_transition_db_admin(
   class { '::govuk::apps::bouncer::postgresql_role': }
 
   $postgres_backup_desc = 'RDS Transition PostgreSQL backup to S3'
-
 }

--- a/modules/govuk/manifests/nodes/postgresql_db_admin.pp
+++ b/modules/govuk/manifests/nodes/postgresql_db_admin.pp
@@ -1,0 +1,79 @@
+# == Class: govuk::nodes::postgresql_db_admin
+#
+# This class installs the tooling for a node to be a PostgreSQL
+# db_admin machine.
+#
+# === Parameters
+#
+# [*postgres_host*]
+#   Hostname of the RDS database to use.
+#   Default: undef
+#
+# [*postgres_user*]
+#   The PostgreSQL user to use for admisistering the database.
+#   Default: undef
+#
+# [*postgres_password*]
+#   The password corresponding to the above `postgres_user`.
+#   Default: undef
+#
+# [*postgres_port*]
+#   The port with which to connect to the `postgres_host`.
+#   Default: '5432'
+#
+# [*apt_mirror_hostname*]
+#   The hostname for the apt mirror to add to enable fetching specific
+#   packages
+#
+class govuk::nodes::postgresql_db_admin(
+  $postgres_host        = undef,
+  $postgres_user        = undef,
+  $postgres_password    = undef,
+  $postgres_port        = '5432',
+  $apt_mirror_hostname,
+) {
+  # This allows easy administration of the PostgreSQL backend:
+  # https://www.postgresql.org/docs/9.3/static/libpq-pgpass.html
+  file { '/root/.pgpass':
+    ensure  => present,
+    mode    => '0600',
+    content => "${postgres_host}:5432:*:${postgres_user}:${postgres_password}",
+  }
+
+  # Unfortunately, the prior art for configuring db-admin style
+  # machines seems to involve a redundant PostgreSQL service, just to
+  # satisfy the Puppet module used to configure PostgreSQL running on
+  # the RDS instance. Some of the below configuration relates to this.
+
+  # Connect to the RDS instance when performing Puppet operations
+  $default_connect_settings = {
+    'PGUSER'     => $postgres_user,
+    'PGPASSWORD' => $postgres_password,
+    'PGHOST'     => $postgres_host,
+    'PGPORT'     => $postgres_port,
+  }
+
+  apt::source { 'postgresql':
+    ensure       => present,
+    location     => "http://${apt_mirror_hostname}/postgresql",
+    release      => "${::lsbdistcodename}-pgdg",
+    architecture => $::architecture,
+    key          => 'B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8',
+  } ->
+
+  # We don't actually want to run a local PostgreSQL server, just
+  # configure the RDS one
+  class { '::postgresql::server':
+    default_connect_settings => $default_connect_settings,
+    service_manage           => false,
+  } ->
+
+  service { 'postgresql':
+    ensure  => stopped,
+  }
+
+  include ::govuk_postgresql::server::not_slave
+
+  # Ensure the client class is installed
+  class { '::govuk_postgresql::client': }
+}


### PR DESCRIPTION
We're about to create many app-specific DB admin boxes, all of
which will have the same configuration on the node itself, so it
makes sense to encapsulate this in one place.

I did consider leaving the existing db_admin node untouched, as
we will eventually remove the Postgres code from it when every
Postgres-powered app is using its own RDS instance. However, it
uses the same code we've just encapsulated (albeit in a slightly
different order), so there's little harm in making this optimisation
now.