### PR TITLE
Add Ask export job

### DIFF
--- a/hieradata_aws/class/integration/jenkins.yaml
+++ b/hieradata_aws/class/integration/jenkins.yaml
@@ -6,6 +6,7 @@ govuk_jenkins::config::theme_text_colour: 'white'
 govuk_jenkins::config::theme_environment_name: 'AWS Integration'
 
 govuk_jenkins::job_builder::jobs:
+  - govuk_jenkins::jobs::ask_export
   - govuk_jenkins::jobs::athena_fastly_logs_check
   - govuk_jenkins::jobs::clear_cdn_cache
   - govuk_jenkins::jobs::clear_frontend_memcache
@@ -49,6 +50,13 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::transition_load_site_config
   - govuk_jenkins::jobs::user_monitor
   - govuk_jenkins::jobs::whitehall_publisher_notifications
+
+govuk_jenkins::jobs::ask_export::smart_survey_config: 'draft'
+govuk_jenkins::jobs::ask_export::aws_region: 'eu-west-1'
+govuk_jenkins::jobs::ask_export::folder_id_cabinet_office: '1RH44n_9Ps_Syeq7o-xJFuFVKN-kkZMsW'
+govuk_jenkins::jobs::ask_export::folder_id_third_party: '1RH44n_9Ps_Syeq7o-xJFuFVKN-kkZMsW'
+govuk_jenkins::jobs::ask_export::s3_bucket_name_gcs_public_questions: 'govuk-uk-integration-ask-export'
+govuk_jenkins::jobs::ask_export::run_daily: false
 
 govuk_jenkins::jobs::deploy_cdn::enable_slack_notifications: true
 govuk_jenkins::jobs::deploy_cdn::services:

--- a/modules/govuk_jenkins/manifests/jobs/ask_export.pp
+++ b/modules/govuk_jenkins/manifests/jobs/ask_export.pp
@@ -1,0 +1,40 @@
+# == Class: govuk_jenkins::jobs::ask_export
+#
+# This job exports responses from the Ask service so that they can be used by the relevant departments
+#
+#
+class govuk_jenkins::jobs::ask_export (
+  $smart_survey_api_token = undef,
+  $smart_survey_api_token_secret = undef,
+  $smart_survey_config = undef,
+  $google_client_id = undef,
+  $google_client_email = undef,
+  $google_private_key = undef,
+  $folder_id_cabinet_office = undef,
+  $folder_id_third_party = undef,
+  $aws_region = undef,
+  $aws_access_key = undef,
+  $aws_secret_access_key = undef,
+  $s3_bucket_name_gcs_public_questions = undef,
+  $run_daily = undef,
+) {
+
+
+  $service_description = 'Ask Service data export'
+  $deploy_jenkins_domain = hiera('deploy_jenkins_domain')
+
+  file { '/etc/jenkins_jobs/jobs/ask_export.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/ask_export.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'];
+  }
+
+  @@icinga::passive_check { "ask_export_${::hostname}":
+      ensure              => present,
+      service_description => $service_description,
+      host_name           => $::fqdn,
+      freshness_threshold => 5400, # 90 minutes
+      action_url          => "https://${deploy_jenkins_domain}/job/ask-export/",
+      notes_url           => monitoring_docs_url(ask-export);
+  }
+}

--- a/modules/govuk_jenkins/templates/jobs/ask_export.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/ask_export.yaml.erb
@@ -1,0 +1,81 @@
+---
+- scm:
+    name: govuk-ask-export
+    scm:
+      - git:
+          url: git@github.com:alphagov/govuk-ask-export.git
+          branches:
+            - master
+
+- job:
+    name: govuk-ask-export
+    display-name: GOV.UK Ask Export
+    project-type: freestyle
+    <% prod_description = "This job exports responses from the Ask service so that they can be used by the relevant departments" %>
+    <% integration_description = "This is for testing so doesn't run unless you tell it to" %>
+    description: <%= @run_daily ? prod_description : integration_description %>
+    scm:
+      - govuk-ask-export
+    logrotate:
+        numToKeep: 100
+    <% if @run_daily %>
+      triggers:
+        - timed: |
+            TZ=Europe/London
+            0 1 * * *
+    <% end %>
+    properties:
+      - build-discarder:
+          days-to-keep: 30
+          artifact-num-to-keep: 5
+    parameters:
+      - string:
+          name: SINCE_TIME
+          description: The time (or date time to start this export from) - defaults to midnight of the previous day
+          default: 00:00
+      - string:
+          name: UNTIL_TIME
+          description: The time (or date time to end this export) - defaults to midnight of the current day
+          default: 00:00
+    builders:
+      - shell: |
+          set -e
+          export SMART_SURVEY_CONFIG=<%= @smart_survey_config %>
+          export AWS_REGION=<%= @aws_region %>
+          export GOOGLE_ACCOUNT_TYPE='service_account'
+          export GOOGLE_CLOUD_PROJECT='govuk-ask-export-1589383422955'
+          export FOLDER_ID_CABINET_OFFICE=<%= @folder_id_cabinet_office %>
+          export FOLDER_ID_THIRD_PARTY=<%= @folder_id_third_party %>
+          export S3_BUCKET_NAME_GCS_PUBLIC_QUESTIONS=<%= @s3_bucket_name_gcs_public_questions %>
+          bundle install --deployment
+          bundle exec rake run_exports
+          bundle exec rake run_cleanup
+          bundle exec rake delete_data
+    wrappers:
+      - ansicolor:
+          colormap: xterm
+      - inject-passwords:
+          global: false
+          mask-password-params: true
+          job-passwords:
+            - name: SMART_SURVEY_API_TOKEN
+              password:
+                '<%= @smart_survey_api_token %>'
+            - name: SMART_SURVEY_API_TOKEN_SECRET
+              password:
+                '<%= @smart_survey_api_token_secret %>'
+            - name: GOOGLE_CLIENT_ID
+              password:
+                '<%= @google_client_id %>'
+            - name: GOOGLE_CLIENT_EMAIL
+              password:
+                '<%= @google_client_email %>'
+            - name: GOOGLE_PRIVATE_KEY
+              password:
+                '<%= @google_private_key %>'
+            - name: AWS_ACCESS_KEY
+              password:
+                '<%= @aws_access_key %>'
+            - name: AWS_SECRET_ACCESS_KEY
+              password:
+                '<%= @aws_secret_access_key %>'


### PR DESCRIPTION
Our instance of concourse is being shut down on the 15th of December and the pipelines need moving over to Jenkins so that they can still be run. This migrates the Ask export job which is responsible for pulling data from the Ask service into google sheets and an S3 bucket.

At the moment we've only added a test job in integration that can only be run manually. As such there are some conditionals that are needed to specify how often the job is run and to alter job descriptions between environments. There'll be follow up work to create the regularly running job in production along with related icinga alerts.

This job won't be able to run until [these secrets changes](https://github.com/alphagov/govuk-secrets/pull/1224) are merged

Trello - https://trello.com/c/pmiW3jZk/249-tech-spike-ask-contingency-plan-port-the-script-we-run-on-concourse-to-jenkins

## How to review 

- Deploy this branch to integration specifying that it uses the `ask-export` branch of secrets rather than `main`
- Manually run puppet on the Jenkins machine
- Check job appears with correct description and cron timings
- Manually run job, check test folders for successful export (you'll need access to the relevant google drive folder)
- Put everything back to how how you found it

Paired with @Rosa-Fox and @kevindew 



