### PR TITLE
Add the Ask Export job to production

### DIFF
--- a/hieradata_aws/class/production/jenkins.yaml
+++ b/hieradata_aws/class/production/jenkins.yaml
@@ -39,6 +39,7 @@ govuk_jenkins::config::user_permissions:
       - 'hudson.model.Item.Read'
 
 govuk_jenkins::job_builder::jobs:
+  - govuk_jenkins::jobs::ask_export
   - govuk_jenkins::jobs::athena_fastly_logs_check
   - govuk_jenkins::jobs::bouncer_cdn
   - govuk_jenkins::jobs::check_sentry_errors
@@ -90,6 +91,10 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::validate_published_dns
   - govuk_jenkins::jobs::whitehall_publisher_notifications
   - govuk_jenkins::jobs::whitehall_run_broken_link_checker
+
+govuk_jenkins::jobs::ask_export::smart_survey_config: 'live'
+govuk_jenkins::jobs::ask_export::aws_region: 'eu-west-2'
+govuk_jenkins::jobs::ask_export::run_daily: true
 
 govuk_jenkins::jobs::deploy_cdn::enable_slack_notifications: true
 govuk_jenkins::jobs::deploy_cdn::services:


### PR DESCRIPTION
https://github.com/alphagov/govuk-puppet/pull/11346 added a new job to jenkins to export data for the ask service. This adds that same job into production with all the variables it needs

To mirror the functionality in Concourse this will run daily at about 1am. This job won't work until [this secrets PR](https://github.com/alphagov/govuk-secrets/pull/1225) is merged

Trello - https://trello.com/c/pmiW3jZk/249-tech-spike-ask-contingency-plan-port-the-script-we-run-on-concourse-to-jenkins