### PR TITLE
Switch Ask Export task to use main branch

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/ask_export.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/ask_export.yaml.erb
@@ -5,8 +5,7 @@
       - git:
           url: git@github.com:alphagov/govuk-ask-export.git
           branches:
-            - master
-
+            - main
 - job:
     name: govuk-ask-export
     display-name: GOV.UK Ask Export


### PR DESCRIPTION
Trello: https://trello.com/c/pmiW3jZk/249-tech-spike-ask-contingency-plan-port-the-script-we-run-on-concourse-to-jenkins

Ask is currently using the master branch as a default but I'm going to
update this to main.