### PR TITLE
[Merge during db upgrade] Set up blanket redirect to CKAN maintenance

### DIFF
--- a/hieradata_aws/class/integration/ckan.yaml
+++ b/hieradata_aws/class/integration/ckan.yaml
@@ -3,10 +3,13 @@
 govuk_solr::disable: true
 govuk_solr6::present: true
 
-govuk::apps::ckan::enable_harvester_gather: true
+govuk::apps::ckan::blanket_redirect_url: https://find-data-beta-integration.cloudapps.digital/ckan_maintenance
 
-govuk::apps::ckan::cronjobs::enable: true
-govuk::apps::ckan::cronjobs::enable_solr_reindex: true
+govuk::apps::ckan::enable_harvester_fetch: false
+govuk::apps::ckan::enable_harvester_gather: false
+
+govuk::apps::ckan::cronjobs::enable: false
+govuk::apps::ckan::cronjobs::enable_solr_reindex: false
 
 govuk::apps::ckan::solr_core: ckan
 govuk::apps::ckan::solr_core_configset: ckan28

--- a/hieradata_aws/class/production/ckan.yaml
+++ b/hieradata_aws/class/production/ckan.yaml
@@ -5,11 +5,13 @@ govuk_solr6::present: true
 
 govuk::apps::ckan::enabled: true
 
-govuk::apps::ckan::enable_harvester_fetch: true
-govuk::apps::ckan::enable_harvester_gather: true
+govuk::apps::ckan::blanket_redirect_url: https://data.gov.uk/ckan_maintenance
 
-govuk::apps::ckan::cronjobs::enable: true
-govuk::apps::ckan::cronjobs::enable_solr_reindex: true
+govuk::apps::ckan::enable_harvester_fetch: false
+govuk::apps::ckan::enable_harvester_gather: false
+
+govuk::apps::ckan::cronjobs::enable: false
+govuk::apps::ckan::cronjobs::enable_solr_reindex: false
 
 govuk::apps::ckan::solr_core: ckan
 govuk::apps::ckan::solr_core_configset: ckan28

--- a/hieradata_aws/class/staging/ckan.yaml
+++ b/hieradata_aws/class/staging/ckan.yaml
@@ -5,11 +5,13 @@ govuk_solr6::present: true
 
 govuk::apps::ckan::enabled: true
 
-govuk::apps::ckan::enable_harvester_fetch: true
-govuk::apps::ckan::enable_harvester_gather: true
+govuk::apps::ckan::blanket_redirect_url: https://find-data-beta-staging.cloudapps.digital/ckan_maintenance
 
-govuk::apps::ckan::cronjobs::enable: true
-govuk::apps::ckan::cronjobs::enable_solr_reindex: true
+govuk::apps::ckan::enable_harvester_fetch: false
+govuk::apps::ckan::enable_harvester_gather: false
+
+govuk::apps::ckan::cronjobs::enable: false
+govuk::apps::ckan::cronjobs::enable_solr_reindex: false
 
 govuk::apps::ckan::solr_core: ckan
 govuk::apps::ckan::solr_core_configset: ckan28


### PR DESCRIPTION
## What

Redirect all requests to CKAN towards the CKAN maintenance page on DGU find.

The same settings were used during the last upgrade of CKAN.

## Reference 

https://trello.com/c/ErFCmF8I/32-plan-the-process-for-upgrading-databases-via-an-aws-engine-upgrade