### PR TITLE
Remove unused $mysql_backup_desc variable

### DIFF
--- a/modules/govuk/manifests/node/s_db_admin.pp
+++ b/modules/govuk/manifests/node/s_db_admin.pp
@@ -75,8 +75,6 @@ class govuk::node::s_db_admin(
   -> class { '::govuk::apps::signon::db': }
   -> class { '::govuk::apps::whitehall::db': }
 
-  $mysql_backup_desc = 'RDS MySQL backup to S3'
-
   ### PostgreSQL ###
 
   # include the common config/tooling required for our DB admin class


### PR DESCRIPTION
This was added in 1ab83692a64e548e1a388a75d4b84d754ce103a5 but is
no longer referenced anywhere.