### PR TITLE
Remove unused $mysql_backup_hour / $mysql_backup_min parameters

### DIFF
--- a/modules/govuk/manifests/node/s_db_admin.pp
+++ b/modules/govuk/manifests/node/s_db_admin.pp
@@ -19,8 +19,6 @@ class govuk::node::s_db_admin(
   $mysql_db_host        = undef,
   $mysql_db_password    = undef,
   $mysql_db_user        = undef,
-  $mysql_backup_hour    = 9,
-  $mysql_backup_min     = 10,
   $postgres_host        = undef,
   $postgres_user        = undef,
   $postgres_password    = undef,


### PR DESCRIPTION
These were introduced in 1ab83692a64e548e1a388a75d4b84d754ce103a5 but are no longer referenced anywhere.