### PR TITLE
Back up the account-api database

### DIFF
--- a/hieradata_aws/class/production/db_admin.yaml
+++ b/hieradata_aws/class/production/db_admin.yaml
@@ -1,4 +1,16 @@
 govuk_env_sync::tasks:
+  "push_account_api_production_daily":
+    ensure: "present"
+    hour: "0"
+    minute: "52"
+    action: "push"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "account-api_production"
+    database_hostname: "postgresql-primary"
+    temppath: "/tmp/account-api_production"
+    url: "govuk-production-database-backups"
+    path: "postgresql-backend"
   "push_ckan_production_daily":
     ensure: "present"
     hour: "23"


### PR DESCRIPTION
We missed this when we set up the app.  I picked the time of 0:52
arbitrarily: some push jobs are at hour 0, some at hour 23, and their
minutes are all over the place.