### PR TITLE
Don't sync account-api data from production to staging / integration

### DIFF
--- a/hieradata_aws/class/integration/account_api_db_admin.yaml
+++ b/hieradata_aws/class/integration/account_api_db_admin.yaml
@@ -1,16 +1,4 @@
-govuk_env_sync::tasks:
-  "pull_account_api_production_daily":
-    ensure: "present"
-    hour: "0"
-    minute: "0"
-    action: "pull"
-    dbms: "postgresql"
-    storagebackend: "s3"
-    database: "account-api_production"
-    database_hostname: "account-api-postgresql"
-    temppath: "/tmp/account_api_production"
-    url: "govuk-production-database-backups"
-    path: "account-api-postgresql"
+# govuk_env_sync::tasks:
   # "push_account_api_production_daily":
   #   ensure: "present"
   #   hour: "5"

--- a/hieradata_aws/class/staging/account_api_db_admin.yaml
+++ b/hieradata_aws/class/staging/account_api_db_admin.yaml
@@ -1,16 +1,4 @@
-govuk_env_sync::tasks:
-  "pull_account_api_production_daily":
-    ensure: "present"
-    hour: "0"
-    minute: "0"
-    action: "pull"
-    dbms: "postgresql"
-    storagebackend: "s3"
-    database: "account-api_production"
-    database_hostname: "account-api-postgresql"
-    temppath: "/tmp/account_api_production"
-    url: "govuk-production-database-backups"
-    path: "account-api-postgresql"
+# govuk_env_sync::tasks:
   # "push_account_api_production_daily":
   #   ensure: "present"
   #   hour: "5"


### PR DESCRIPTION
The account-api database contains real user data (eg email addresses),
and we haven't implemented a sanitisation step (like we have for
email-alert-api).  Furthermore, this data is of limited use in other
environments as the subject identifiers won't match the non-production
Digital Identity service.

So we don't sync this data to staging and integration.

---

[Trello card](https://trello.com/c/kMRRFmAh/43-configure-puppet-for-new-db-admin-postgresql-instances)