### PR TITLE
Add transformation SQL files to the new db-admin machines

### DIFF
--- a/hieradata_aws/class/integration/content_publisher_db_admin.yaml
+++ b/hieradata_aws/class/integration/content_publisher_db_admin.yaml
@@ -11,6 +11,7 @@ govuk_env_sync::tasks:
     temppath: "/tmp/content_publisher_production"
     url: "govuk-production-database-backups"
     path: "content-publisher-postgresql"
+    transformation_sql_filename: "content_publisher.sql"
   # "push_content_publisher_production_daily":
   #   ensure: "present"
   #   hour: "5"

--- a/hieradata_aws/class/integration/email_alert_api_db_admin.yaml
+++ b/hieradata_aws/class/integration/email_alert_api_db_admin.yaml
@@ -11,6 +11,7 @@ govuk_env_sync::tasks:
     temppath: "/tmp/email_alert_api_production"
     url: "govuk-production-database-backups"
     path: "email-alert-api-postgresql"
+    transformation_sql_filename: "anonymise_email_addresses.sql"
   # "push_email_alert_api_production_daily":
   #   ensure: "present"
   #   hour: "5"

--- a/hieradata_aws/class/integration/publishing_api_db_admin.yaml
+++ b/hieradata_aws/class/integration/publishing_api_db_admin.yaml
@@ -11,6 +11,7 @@ govuk_env_sync::tasks:
     temppath: "/tmp/publishing_api_production"
     url: "govuk-production-database-backups"
     path: "publishing-api-postgresql"
+    transformation_sql_filename: "sanitise_publishing_api_production.sql"
   # "push_publishing_api_production_daily":
   #   ensure: "present"
   #   hour: "5"

--- a/hieradata_aws/class/staging/whitehall_db_admin.yaml
+++ b/hieradata_aws/class/staging/whitehall_db_admin.yaml
@@ -23,3 +23,4 @@ govuk_env_sync::tasks:
   #   temppath: "/tmp/whitehall_production"
   #   url: "govuk-staging-database-backups"
   #   path: "whitehall-mysql"
+  #   pre_dump_transformation_sql_filename: "sanitise_whitehall.sql"


### PR DESCRIPTION
These were missed from the main db-admin hieradata.

---

[Trello card](https://trello.com/c/kMRRFmAh/43-configure-puppet-for-new-db-admin-postgresql-instances)