### PR TITLE
Remove healthchecks

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -201,6 +201,7 @@ deployable_applications: &deployable_applications
   smartanswers:
     repository: 'smart-answers'
   specialist-publisher: {}
+  spotlight: {}
   static: {}
   support: {}
   support-api: {}
@@ -1043,6 +1044,7 @@ govuk_ci::master::pipeline_jobs:
   slimmer: {}
   smokey: {}
   special-route-publisher: {}
+  spotlight-performance: {}
   ubuntu_unused_kernels: {}
 
 govuk_ci::master::ci_agents:

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -90,6 +90,9 @@ govuk::apps::whitehall::highlight_words_to_avoid: true
 govuk::apps::whitehall::govuk_notify_template_id: "759acac6-da53-4a19-b591-b7538c7c39de"
 govuk::apps::whitehall::aws_s3_bucket_name: 'govuk-integration-whitehall-csvs'
 
+govuk::apps::design_principles::ensure: 'absent'
+govuk::apps::spotlight::ensure: 'absent'
+
 licensify::apps::configfile::mongo_database_reference_name: 'licensify-refdata'
 licensify::apps::configfile::mongo_database_audit_name: 'licensify-audit'
 licensify::apps::configfile::mongo_database_slaveok: 'false'

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -172,6 +172,8 @@ govuk::apps::service_manual_publisher::ensure: 'present'
 govuk::apps::short_url_manager::ensure: 'present'
 govuk::apps::specialist_publisher::ensure: 'present'
 govuk::apps::travel_advice_publisher::ensure: 'present'
+govuk::apps::design_principles::ensure: 'absent'
+govuk::apps::spotlight::ensure: 'absent'
 
 govuk::apps::govuk_crawler_worker::blacklist_paths:
   - '/apply-for-a-licence'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -257,6 +257,8 @@ govuk::apps::service_manual_publisher::ensure: 'present'
 govuk::apps::short_url_manager::ensure: 'present'
 govuk::apps::specialist_publisher::ensure: 'present'
 govuk::apps::travel_advice_publisher::ensure: 'present'
+govuk::apps::design_principles::ensure: 'absent'
+govuk::apps::spotlight::ensure: 'absent'
 
 govuk_search::monitoring::es_port: '80'
 govuk_search::monitoring::es_host: 'vpc-blue-elasticsearch6-domain-uibh77cu2kiudtl76uhseobfzq.eu-west-1.es.amazonaws.com'

--- a/modules/govuk/manifests/apps/spotlight.pp
+++ b/modules/govuk/manifests/apps/spotlight.pp
@@ -1,0 +1,63 @@
+# == Class: govuk::apps::spotlight
+#
+# Spotlight is a frontend application for the Performance Platform.
+#
+# === Parameters
+#
+# [*alert_5xx_warning_rate*]
+#   The 5xx error percentage that should generate a warning
+#
+# [*alert_5xx_critical_rate*]
+#   The 5xx error percentage that should generate a critical
+#
+# [*enabled*]
+#   Should the app exist?
+#
+# [*port*]
+#   What port should the app run on?
+
+# [*publishing_api_bearer_token*]
+#   The bearer token to use when communicating with Publishing API.
+#   Default: undef
+#
+# [*nagios_memory_warning*]
+#   Memory use at which Nagios should generate a warning.
+#
+# [*nagios_memory_critical*]
+#   Memory use at which Nagios should generate a critical alert.
+#
+class govuk::apps::spotlight (
+  $alert_5xx_warning_rate,
+  $alert_5xx_critical_rate,
+  $enabled = false,
+  $port = '3057',
+  $publishing_api_bearer_token = undef,
+  $nagios_memory_warning = undef,
+  $nagios_memory_critical = undef,
+) {
+
+  if $enabled {
+    govuk::app { 'spotlight':
+      ensure                     => 'absent',
+      alert_5xx_warning_rate     => $alert_5xx_warning_rate,
+      alert_5xx_critical_rate    => $alert_5xx_critical_rate,
+      app_type                   => 'bare',
+      command                    => '/usr/bin/node app/server',
+      port                       => $port,
+      vhost_ssl_only             => true,
+      health_check_path          => '/_status',
+      log_format_is_json         => true,
+      nagios_memory_warning      => $nagios_memory_warning,
+      nagios_memory_critical     => $nagios_memory_critical,
+      has_liveness_health_check  => false,
+      has_readiness_health_check => false,
+    }
+
+    govuk::app::envvar { "${title}-PUBLISHING_API_BEARER_TOKEN":
+      ensure  => 'absent',
+      app     => 'spotlight',
+      varname => 'PUBLISHING_API_BEARER_TOKEN',
+      value   => $publishing_api_bearer_token,
+    }
+  }
+}


### PR DESCRIPTION
For retired applications to prevent effect on the availability metrics.

[Trello card](https://trello.com/c/jmzw2yjL/2792-remove-healthchecks-for-retired-applications-3)