### PR TITLE
Temporarily point to the 'postgresql-backend'/'mysql' S3 paths

### DIFF
--- a/hieradata_aws/class/integration/collections_publisher_db_admin.yaml
+++ b/hieradata_aws/class/integration/collections_publisher_db_admin.yaml
@@ -10,7 +10,7 @@ govuk_env_sync::tasks:
     database_hostname: "collections-publisher-mysql"
     temppath: "/tmp/collections_publisher_production"
     url: "govuk-production-database-backups"
-    path: "collections-publisher-mysql"
+    path: "mysql"
   # "push_collections_publisher_production_daily":
   #   ensure: "present"
   #   hour: "5"

--- a/hieradata_aws/class/integration/contacts_admin_db_admin.yaml
+++ b/hieradata_aws/class/integration/contacts_admin_db_admin.yaml
@@ -10,7 +10,7 @@ govuk_env_sync::tasks:
     database_hostname: "contacts-admin-mysql"
     temppath: "/tmp/contacts_admin_production"
     url: "govuk-production-database-backups"
-    path: "contacts-admin-mysql"
+    path: "mysql"
   # "push_contacts_admin_production_daily":
   #   ensure: "present"
   #   hour: "5"

--- a/hieradata_aws/class/integration/content_data_admin_db_admin.yaml
+++ b/hieradata_aws/class/integration/content_data_admin_db_admin.yaml
@@ -10,7 +10,7 @@ govuk_env_sync::tasks:
     database_hostname: "content-data-admin-postgresql"
     temppath: "/tmp/content_data_admin_production"
     url: "govuk-production-database-backups"
-    path: "content-data-admin-postgresql"
+    path: "postgresql-backend"
   # "push_content_data_admin_production_daily":
   #   ensure: "present"
   #   hour: "5"

--- a/hieradata_aws/class/integration/content_publisher_db_admin.yaml
+++ b/hieradata_aws/class/integration/content_publisher_db_admin.yaml
@@ -10,7 +10,7 @@ govuk_env_sync::tasks:
     database_hostname: "content-publisher-postgresql"
     temppath: "/tmp/content_publisher_production"
     url: "govuk-production-database-backups"
-    path: "content-publisher-postgresql"
+    path: "postgresql-backend"
     transformation_sql_filename: "content_publisher.sql"
   # "push_content_publisher_production_daily":
   #   ensure: "present"

--- a/hieradata_aws/class/integration/content_tagger_db_admin.yaml
+++ b/hieradata_aws/class/integration/content_tagger_db_admin.yaml
@@ -10,7 +10,7 @@ govuk_env_sync::tasks:
     database_hostname: "content-tagger-postgresql"
     temppath: "/tmp/content_tagger_production"
     url: "govuk-production-database-backups"
-    path: "content-tagger-postgresql"
+    path: "postgresql-backend"
   # "push_content_tagger_production_daily":
   #   ensure: "present"
   #   hour: "5"

--- a/hieradata_aws/class/integration/email_alert_api_db_admin.yaml
+++ b/hieradata_aws/class/integration/email_alert_api_db_admin.yaml
@@ -10,7 +10,7 @@ govuk_env_sync::tasks:
     database_hostname: "email-alert-api-postgresql"
     temppath: "/tmp/email_alert_api_production"
     url: "govuk-production-database-backups"
-    path: "email-alert-api-postgresql"
+    path: "postgresql-backend"
     transformation_sql_filename: "anonymise_email_addresses.sql"
   # "push_email_alert_api_production_daily":
   #   ensure: "present"

--- a/hieradata_aws/class/integration/link_checker_api_db_admin.yaml
+++ b/hieradata_aws/class/integration/link_checker_api_db_admin.yaml
@@ -10,7 +10,7 @@ govuk_env_sync::tasks:
     database_hostname: "link-checker-api-postgresql"
     temppath: "/tmp/link_checker_api_production"
     url: "govuk-production-database-backups"
-    path: "link-checker-api-postgresql"
+    path: "postgresql-backend"
   # "push_link_checker_api_production_daily":
   #   ensure: "present"
   #   hour: "5"

--- a/hieradata_aws/class/integration/local_links_manager_db_admin.yaml
+++ b/hieradata_aws/class/integration/local_links_manager_db_admin.yaml
@@ -10,7 +10,7 @@ govuk_env_sync::tasks:
     database_hostname: "local-links-manager-postgresql"
     temppath: "/tmp/local_links_manager_production"
     url: "govuk-production-database-backups"
-    path: "local-links-manager-postgresql"
+    path: "postgresql-backend"
   # "push_local_links_manager_production_daily":
   #   ensure: "present"
   #   hour: "5"

--- a/hieradata_aws/class/integration/publishing_api_db_admin.yaml
+++ b/hieradata_aws/class/integration/publishing_api_db_admin.yaml
@@ -10,7 +10,7 @@ govuk_env_sync::tasks:
     database_hostname: "publishing-api-postgresql"
     temppath: "/tmp/publishing_api_production"
     url: "govuk-production-database-backups"
-    path: "publishing-api-postgresql"
+    path: "postgresql-backend"
     transformation_sql_filename: "sanitise_publishing_api_production.sql"
   # "push_publishing_api_production_daily":
   #   ensure: "present"

--- a/hieradata_aws/class/integration/release_db_admin.yaml
+++ b/hieradata_aws/class/integration/release_db_admin.yaml
@@ -10,7 +10,7 @@ govuk_env_sync::tasks:
     database_hostname: "release-mysql"
     temppath: "/tmp/release_production"
     url: "govuk-production-database-backups"
-    path: "release-mysql"
+    path: "mysql"
   # "push_release_production_daily":
   #   ensure: "present"
   #   hour: "5"

--- a/hieradata_aws/class/integration/search_admin_db_admin.yaml
+++ b/hieradata_aws/class/integration/search_admin_db_admin.yaml
@@ -10,7 +10,7 @@ govuk_env_sync::tasks:
     database_hostname: "search-admin-mysql"
     temppath: "/tmp/search_admin_production"
     url: "govuk-production-database-backups"
-    path: "search-admin-mysql"
+    path: "mysql"
   # "push_search_admin_production_daily":
   #   ensure: "present"
   #   hour: "5"

--- a/hieradata_aws/class/integration/service_manual_publisher_db_admin.yaml
+++ b/hieradata_aws/class/integration/service_manual_publisher_db_admin.yaml
@@ -10,7 +10,7 @@ govuk_env_sync::tasks:
     database_hostname: "service-manual-publisher-postgresql"
     temppath: "/tmp/service_manual_publisher_production"
     url: "govuk-production-database-backups"
-    path: "service-manual-publisher-postgresql"
+    path: "postgresql-backend"
   # "push_service_manual_publisher_production_daily":
   #   ensure: "present"
   #   hour: "5"

--- a/hieradata_aws/class/integration/signon_db_admin.yaml
+++ b/hieradata_aws/class/integration/signon_db_admin.yaml
@@ -10,7 +10,7 @@ govuk_env_sync::tasks:
     database_hostname: "signon-mysql"
     temppath: "/tmp/signon_production"
     url: "govuk-production-database-backups"
-    path: "signon-mysql"
+    path: "mysql"
   # "push_signon_production_daily":
   #   ensure: "present"
   #   hour: "5"

--- a/hieradata_aws/class/integration/support_api_db_admin.yaml
+++ b/hieradata_aws/class/integration/support_api_db_admin.yaml
@@ -10,7 +10,7 @@ govuk_env_sync::tasks:
     database_hostname: "support-api-postgresql"
     temppath: "/tmp/support_api_production"
     url: "govuk-production-database-backups"
-    path: "support-api-postgresql"
+    path: "postgresql-backend"
   # "push_support_api_production_daily":
   #   ensure: "present"
   #   hour: "5"

--- a/hieradata_aws/class/integration/whitehall_db_admin.yaml
+++ b/hieradata_aws/class/integration/whitehall_db_admin.yaml
@@ -10,7 +10,7 @@ govuk_env_sync::tasks:
     database_hostname: "whitehall-mysql"
     temppath: "/tmp/whitehall_production"
     url: "govuk-production-database-backups"
-    path: "whitehall-mysql"
+    path: "mysql"
   # "push_whitehall_production_daily":
   #   ensure: "present"
   #   hour: "5"

--- a/hieradata_aws/class/staging/collections_publisher_db_admin.yaml
+++ b/hieradata_aws/class/staging/collections_publisher_db_admin.yaml
@@ -10,7 +10,7 @@ govuk_env_sync::tasks:
     database_hostname: "collections-publisher-mysql"
     temppath: "/tmp/collections_publisher_production"
     url: "govuk-production-database-backups"
-    path: "collections-publisher-mysql"
+    path: "mysql"
   # "push_collections_publisher_production_daily":
   #   ensure: "present"
   #   hour: "5"

--- a/hieradata_aws/class/staging/contacts_admin_db_admin.yaml
+++ b/hieradata_aws/class/staging/contacts_admin_db_admin.yaml
@@ -10,7 +10,7 @@ govuk_env_sync::tasks:
     database_hostname: "contacts-admin-mysql"
     temppath: "/tmp/contacts_admin_production"
     url: "govuk-production-database-backups"
-    path: "contacts-admin-mysql"
+    path: "mysql"
   # "push_contacts_admin_production_daily":
   #   ensure: "present"
   #   hour: "5"

--- a/hieradata_aws/class/staging/content_data_admin_db_admin.yaml
+++ b/hieradata_aws/class/staging/content_data_admin_db_admin.yaml
@@ -10,7 +10,7 @@ govuk_env_sync::tasks:
     database_hostname: "content-data-admin-postgresql"
     temppath: "/tmp/content_data_admin_production"
     url: "govuk-production-database-backups"
-    path: "content-data-admin-postgresql"
+    path: "postgresql-backend"
   # "push_content_data_admin_production_daily":
   #   ensure: "present"
   #   hour: "5"

--- a/hieradata_aws/class/staging/content_publisher_db_admin.yaml
+++ b/hieradata_aws/class/staging/content_publisher_db_admin.yaml
@@ -10,7 +10,7 @@ govuk_env_sync::tasks:
     database_hostname: "content-publisher-postgresql"
     temppath: "/tmp/content_publisher_production"
     url: "govuk-production-database-backups"
-    path: "content-publisher-postgresql"
+    path: "postgresql-backend"
   # "push_content_publisher_production_daily":
   #   ensure: "present"
   #   hour: "5"

--- a/hieradata_aws/class/staging/content_tagger_db_admin.yaml
+++ b/hieradata_aws/class/staging/content_tagger_db_admin.yaml
@@ -10,7 +10,7 @@ govuk_env_sync::tasks:
     database_hostname: "content-tagger-postgresql"
     temppath: "/tmp/content_tagger_production"
     url: "govuk-production-database-backups"
-    path: "content-tagger-postgresql"
+    path: "postgresql-backend"
   # "push_content_tagger_production_daily":
   #   ensure: "present"
   #   hour: "5"

--- a/hieradata_aws/class/staging/email_alert_api_db_admin.yaml
+++ b/hieradata_aws/class/staging/email_alert_api_db_admin.yaml
@@ -10,7 +10,7 @@ govuk_env_sync::tasks:
     database_hostname: "email-alert-api-postgresql"
     temppath: "/tmp/email_alert_api_production"
     url: "govuk-production-database-backups"
-    path: "email-alert-api-postgresql"
+    path: "postgresql-backend"
   # "push_email_alert_api_production_daily":
   #   ensure: "present"
   #   hour: "5"

--- a/hieradata_aws/class/staging/link_checker_api_db_admin.yaml
+++ b/hieradata_aws/class/staging/link_checker_api_db_admin.yaml
@@ -10,7 +10,7 @@ govuk_env_sync::tasks:
     database_hostname: "link-checker-api-postgresql"
     temppath: "/tmp/link_checker_api_production"
     url: "govuk-production-database-backups"
-    path: "link-checker-api-postgresql"
+    path: "postgresql-backend"
   # "push_link_checker_api_production_daily":
   #   ensure: "present"
   #   hour: "5"

--- a/hieradata_aws/class/staging/local_links_manager_db_admin.yaml
+++ b/hieradata_aws/class/staging/local_links_manager_db_admin.yaml
@@ -10,7 +10,7 @@ govuk_env_sync::tasks:
     database_hostname: "local-links-manager-postgresql"
     temppath: "/tmp/local_links_manager_production"
     url: "govuk-production-database-backups"
-    path: "local-links-manager-postgresql"
+    path: "postgresql-backend"
   # "push_local_links_manager_production_daily":
   #   ensure: "present"
   #   hour: "5"

--- a/hieradata_aws/class/staging/publishing_api_db_admin.yaml
+++ b/hieradata_aws/class/staging/publishing_api_db_admin.yaml
@@ -10,7 +10,7 @@ govuk_env_sync::tasks:
     database_hostname: "publishing-api-postgresql"
     temppath: "/tmp/publishing_api_production"
     url: "govuk-production-database-backups"
-    path: "publishing-api-postgresql"
+    path: "postgresql-backend"
   # "push_publishing_api_production_daily":
   #   ensure: "present"
   #   hour: "5"

--- a/hieradata_aws/class/staging/release_db_admin.yaml
+++ b/hieradata_aws/class/staging/release_db_admin.yaml
@@ -10,7 +10,7 @@ govuk_env_sync::tasks:
     database_hostname: "release-mysql"
     temppath: "/tmp/release_production"
     url: "govuk-production-database-backups"
-    path: "release-mysql"
+    path: "mysql"
   # "push_release_production_daily":
   #   ensure: "present"
   #   hour: "5"

--- a/hieradata_aws/class/staging/search_admin_db_admin.yaml
+++ b/hieradata_aws/class/staging/search_admin_db_admin.yaml
@@ -10,7 +10,7 @@ govuk_env_sync::tasks:
     database_hostname: "search-admin-mysql"
     temppath: "/tmp/search_admin_production"
     url: "govuk-production-database-backups"
-    path: "search-admin-mysql"
+    path: "mysql"
   # "push_search_admin_production_daily":
   #   ensure: "present"
   #   hour: "5"

--- a/hieradata_aws/class/staging/service_manual_publisher_db_admin.yaml
+++ b/hieradata_aws/class/staging/service_manual_publisher_db_admin.yaml
@@ -10,7 +10,7 @@ govuk_env_sync::tasks:
     database_hostname: "service-manual-publisher-postgresql"
     temppath: "/tmp/service_manual_publisher_production"
     url: "govuk-production-database-backups"
-    path: "service-manual-publisher-postgresql"
+    path: "postgresql-backend"
   # "push_service_manual_publisher_production_daily":
   #   ensure: "present"
   #   hour: "5"

--- a/hieradata_aws/class/staging/signon_db_admin.yaml
+++ b/hieradata_aws/class/staging/signon_db_admin.yaml
@@ -10,7 +10,7 @@ govuk_env_sync::tasks:
     database_hostname: "signon-mysql"
     temppath: "/tmp/signon_production"
     url: "govuk-production-database-backups"
-    path: "signon-mysql"
+    path: "mysql"
   # "push_signon_production_daily":
   #   ensure: "present"
   #   hour: "5"

--- a/hieradata_aws/class/staging/support_api_db_admin.yaml
+++ b/hieradata_aws/class/staging/support_api_db_admin.yaml
@@ -10,7 +10,7 @@ govuk_env_sync::tasks:
     database_hostname: "support-api-postgresql"
     temppath: "/tmp/support_api_production"
     url: "govuk-production-database-backups"
-    path: "support-api-postgresql"
+    path: "postgresql-backend"
   # "push_support_api_production_daily":
   #   ensure: "present"
   #   hour: "5"

--- a/hieradata_aws/class/staging/whitehall_db_admin.yaml
+++ b/hieradata_aws/class/staging/whitehall_db_admin.yaml
@@ -10,7 +10,7 @@ govuk_env_sync::tasks:
     database_hostname: "whitehall-mysql"
     temppath: "/tmp/whitehall_production"
     url: "govuk-production-database-backups"
-    path: "whitehall-mysql"
+    path: "mysql"
   # "push_whitehall_production_daily":
   #   ensure: "present"
   #   hour: "5"


### PR DESCRIPTION
At time of writing, there won't be anything in
`s3://govuk-production-database-backups/${APP_NAME}-${DB_ENGINE}`,
until production backups start pushing there. Therefore, we need
to pull from the existing backup source, which depending on DB
engine is one of the following:

- s3://govuk-production-database-backups/postgresql-backend
- s3://govuk-production-database-backups/mysql

When production backups start pushing to the new S3 paths, we
can revert this commit and then un-comment the 'pull' tasks.

Trello:

- https://trello.com/c/kMRRFmAh/43-configure-puppet-for-new-db-admin-postgresql-instances
- https://trello.com/c/HjK4AbUS/49-configure-puppet-for-new-db-admin-mysql-instances