### PR TITLE
Always create env.d dir for govuk_env_sync module

### DIFF
--- a/modules/govuk_env_sync/manifests/aws_auth.pp
+++ b/modules/govuk_env_sync/manifests/aws_auth.pp
@@ -12,13 +12,6 @@ class govuk_env_sync::aws_auth(
   $aws_region = $govuk_env_sync::aws_region
   $app_domain_internal = hiera('app_domain_internal')
 
-  file { "${conf_dir}/env.d":
-    ensure => directory,
-    owner  => $user,
-    group  => $user,
-    mode   => '0770',
-  }
-
   file { "${conf_dir}/env.d/AWS_REGION":
     content => $aws_region,
     owner   => $user,

--- a/modules/govuk_env_sync/manifests/init.pp
+++ b/modules/govuk_env_sync/manifests/init.pp
@@ -24,6 +24,13 @@ class govuk_env_sync(
     mode    => '0770',
   }
 
+  file { "${conf_dir}/env.d":
+    ensure => directory,
+    owner  => $user,
+    group  => $user,
+    mode   => '0770',
+  }
+
   create_resources(govuk_env_sync::task, $tasks)
   create_resources(govuk_env_sync::s3_sync_task, $s3_sync_tasks)
 


### PR DESCRIPTION
This directory is only created if there's a task.  But not all of the
db-admin machines have any tasks right now: a lot of them are
commented out.

This is a problem because the document_db_credentials value is set in
govuk-secrets, so the govuk_env_sync::documentdb_auth resource gets
pulled in, and that expects this directory to exist.

Since not creating the directory seems of little value, always create
it, even if nothing needs it.