### PR TITLE
Quick work around for creating MySQL 8 users/roles/databases

### DIFF
--- a/modules/govuk/manifests/apps/whitehall/db.pp
+++ b/modules/govuk/manifests/apps/whitehall/db.pp
@@ -3,16 +3,44 @@ class govuk::apps::whitehall::db (
   $mysql_whitehall_admin = '',
   $whitehall_fe_password = '',
 ){
-  mysql::db { 'whitehall_production':
-    user     => 'whitehall',
-    host     => '%',
-    password => $mysql_whitehall_admin,
+
+  $hashed_whitehall_admin_password = mysql_password($mysql_whitehall_admin)
+  $mysql_command = 'mysql --defaults-extra-file=/root/.my.cnf'
+
+  exec { 'create_whitehall_user':
+    command => "${mysql_command} -e \"CREATE USER IF NOT EXISTS 'whitehall'@'%' IDENTIFIED WITH 'mysql_native_password' AS '${hashed_whitehall_admin_password}';\"";
   }
 
-  govuk_mysql::user { 'whitehall_fe@%':
-    password_hash => mysql_password($whitehall_fe_password),
-    table         => 'whitehall_production.*',
-    privileges    => ['SELECT'],
-    require       => Mysql::Db['whitehall_production'],
+  exec { 'create_whitehall_production_db':
+    command => "${mysql_command} -e \"CREATE DATABASE IF NOT EXISTS whitehall_production;\"";
   }
+
+  exec { 'grant_whitehall_user':
+    command => "${mysql_command} -e \"GRANT ALL ON whitehall_production.* TO 'whitehall'@'%';\"",
+    require => [ Exec['create_whitehall_user'], Exec['create_whitehall_production_db'] ];
+  }
+
+  $hashed_whitehall_fe_password = mysql_password($whitehall_fe_password)
+
+  exec { 'create_whitehall_fe_user':
+    command => "${mysql_command} -h whitehall-mysql -e \"CREATE USER IF NOT EXISTS 'whitehall_fe'@'%' IDENTIFIED WITH 'mysql_native_password' AS '${hashed_whitehall_fe_password}';\"";
+  }
+
+  exec { 'grant_whitehall_fe_user':
+    command => "${mysql_command} -e \"GRANT SELECT ON whitehall_production.* TO 'whitehall_fe'@'%';\"",
+    require => [ Exec['create_whitehall_fe_user'], Exec['create_whitehall_production_db'] ];
+  }
+
+  # mysql::db { 'whitehall_production':
+  #   user     => 'whitehall',
+  #   host     => '%',
+  #   password => $mysql_whitehall_admin,
+  # }
+  #
+  # govuk_mysql::user { 'whitehall_fe@%':
+  #   password_hash => mysql_password($whitehall_fe_password),
+  #   table         => 'whitehall_production.*',
+  #   privileges    => ['SELECT'],
+  #   require       => Mysql::Db['whitehall_production'],
+  # }
 }


### PR DESCRIPTION
Trello: https://trello.com/c/HjK4AbUS/49-configure-puppet-for-new-db-admin-mysql-instances

The mysql puppet version we use does not have the correct syntax for
creating users for MySQL 8 [1] (well not in a version that is compatible with
Puppet 3.x, which is understandable)

[1]: https://github.com/puppetlabs/puppetlabs-mysql/pull/1092

This runs the commands to do these tasks without utilising the puppet
module and instead running the queries directly.

This worked (after a bit of trial and error) on a Whitehall DB Admin
box:

```
kevindew@ec2-integration-blue-whitehall_db_admin-ip-10-1-5-75:~$ govuk_puppet --test
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Loading facts
Info: Caching catalog for i-0a640e087db1a2f7a
Info: Applying configuration version 'c61812e33b1338ea166bac466374c58daae2a454'
Notice: /Stage[main]/Govuk::Apps::Whitehall::Db/Exec[create_whitehall_user]/returns: executed successfully
Notice: /Stage[main]/Govuk::Apps::Whitehall::Db/Exec[create_whitehall_fe_user]/returns: executed successfully
Notice: /Stage[main]/Govuk::Apps::Whitehall::Db/Exec[create_whitehall_production_db]/returns: executed successfully
Notice: /Stage[main]/Govuk::Apps::Whitehall::Db/Exec[grant_whitehall_fe_user]/returns: executed successfully
Notice: /Stage[main]/Govuk::Apps::Whitehall::Db/Exec[grant_whitehall_user]/returns: executed successfully
Notice: Finished catalog run in 7.01 seconds
```

There's a few things about this though which don't make it suitable as a
merge contender currently:

1) This uses syntax that isn't understood by MySQL 5.6 - so it will
   error when ran on an existing box, it'll need some way to alternate
   between approaches
2) I'm not sure I've got puppet dependencies set-up particularly
   elegantly, I couldn't remember how things worked and guessed a bit
   with require - I think some commands should depend on the MySQL
   package but that didn't work for me. It might be better to just have
   one script of MySQL that's executed rather than a bunch of commands
3) I'm not sure how to get it to not execute every puppet run, like the
   MySQL module currently does - I don't think it'll be

This does rely on the mysql_password function that I believe the puppet
module exposes.

The alternative to do something like this is creating the database and
users on the machines manually - this isn't the most arduous process as
they are created very infrequently