### PR TITLE
Call pg_dump using Docker

### DIFF
--- a/modules/govuk_env_sync/manifests/sync_script.pp
+++ b/modules/govuk_env_sync/manifests/sync_script.pp
@@ -9,6 +9,13 @@ class govuk_env_sync::sync_script {
       content => 'govuk-backup ALL=(root,postgres) NOPASSWD:/usr/bin/psql,/usr/bin/createdb,/usr/bin/dropdb,/usr/bin/dropuser,/usr/bin/pg_restore,/usr/bin/mysql,/usr/bin/mysqldump,/usr/bin/pg_dump';
   }
 
+  # Docker package
+  # Required for pg_dump
+
+  package { 'docker.io':
+    ensure => installed,
+  }
+
   # sync script
   file { '/usr/local/bin/govuk_env_sync.sh':
     ensure => present,

--- a/modules/govuk_env_sync/manifests/sync_script.pp
+++ b/modules/govuk_env_sync/manifests/sync_script.pp
@@ -6,7 +6,7 @@ class govuk_env_sync::sync_script {
   sudo::conf {
     'govuk-env-sync-commands':
       ensure  => 'present',
-      content => 'govuk-backup ALL=(root,postgres) NOPASSWD:/usr/bin/psql,/usr/bin/createdb,/usr/bin/dropdb,/usr/bin/dropuser,/usr/bin/pg_restore,/usr/bin/mysql,/usr/bin/mysqldump,/usr/bin/pg_dump';
+      content => 'govuk-backup ALL=(root,postgres) NOPASSWD:/usr/bin/psql,/usr/bin/createdb,/usr/bin/dropdb,/usr/bin/dropuser,/usr/bin/pg_restore,/usr/bin/mysql,/usr/bin/mysqldump,/usr/bin/pg_dump,/usr/bin/docker';
   }
 
   # Docker package


### PR DESCRIPTION
This allows us to call pg_dump for any version of postgresql and mean we can use the same script before and after the upgrade of postgresql to 13