### PR TITLE
WIP: Remove 'whitehall_fe' MySQL user

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -591,18 +591,14 @@ govuk::apps::whitehall::admin_key_space_limit: '262144'
 govuk::apps::whitehall::admin_db_name: whitehall_production
 govuk::apps::whitehall::admin_db_password: "%{hiera('govuk::apps::whitehall::db::mysql_whitehall_admin')}"
 govuk::apps::whitehall::admin_db_username: whitehall
-# TODO this should be using a replica, but we can change that when we have deployed one
 # TODO: switch to "whitehall-mysql" and uncomment the 'push'
 # `govuk_env_sync::tasks` tasks when we're ready to switch to the dedicated RDS instance
 govuk::apps::whitehall::db_hostname: 'mysql-primary'
 govuk::apps::whitehall::db_name: whitehall_production
 govuk::apps::whitehall::db_password: "%{hiera('govuk::apps::whitehall::db::mysql_whitehall')}"
-govuk::apps::whitehall::db_username: whitehall_fe
 govuk::apps::whitehall::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
 govuk::apps::whitehall::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::whitehall::redis_port: "%{hiera('sidekiq_port')}"
-
-govuk::apps::whitehall::db::whitehall_fe_password: "%{hiera('mysql_whitehall_frontend')}"
 
 # FIXME: The API can be crawled when https://github.com/alphagov/govuk_crawler_worker/issues/97 is fixed.
 govuk::apps::govuk_crawler_worker::blacklist_paths:

--- a/modules/govuk/manifests/apps/whitehall/db.pp
+++ b/modules/govuk/manifests/apps/whitehall/db.pp
@@ -1,18 +1,10 @@
 # FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
 class govuk::apps::whitehall::db (
   $mysql_whitehall_admin = '',
-  $whitehall_fe_password = '',
 ){
   mysql::db { 'whitehall_production':
     user     => 'whitehall',
     host     => '%',
     password => $mysql_whitehall_admin,
-  }
-
-  govuk_mysql::user { 'whitehall_fe@%':
-    password_hash => mysql_password($whitehall_fe_password),
-    table         => 'whitehall_production.*',
-    privileges    => ['SELECT'],
-    require       => Mysql::Db['whitehall_production'],
   }
 }


### PR DESCRIPTION
Searching for 'whitehall_fe' across the entire GOV.UK codebase
results in just the references removed in this commit. It seems
that the plan was to have a whitehall_fe user, reading from the
MySQL replica database, but this never happened (and the replicas
have now been removed [CITE]).

In da5dd0b35de257f775e1e19d50c2f9cf76d4a970, the whitehall_fe
settings were moved (four years ago), with the commit message even
then hinting that this might not be being used anywhere.
It looks like the user was originally added in 2013, in c6bad68c0005a06e4bd0419b26494a509920a3b3.
There is no corresponding PR and no explanation other than
"Puppet definitions for new whitehall mysql boxes".

I believe the 'whitehall_fe' user is not currently used (and am
not sure if it was ever used). We can simplify the setup of our
DB admin / RDS instances by cutting out this unnecessary user.

A complication is in the hieradata_aws/common.yaml, where we now
have `whitehall::admin_db_name` and `whitehall::db_name` (and
passwords). It seems the `db_name` variants were intended for use
by this 'frontend' user, and so can be dropped, leaving us with
just the 'admin' variants. But by convention, we should then
rename 'admin_db_name' to just 'db_name', in line with other apps.