### PR TITLE
[Merge after testing complete] Enable ckan workers and remove blanket redirect

### DIFF
--- a/hieradata_aws/class/integration/ckan.yaml
+++ b/hieradata_aws/class/integration/ckan.yaml
@@ -3,13 +3,11 @@
 govuk_solr::disable: true
 govuk_solr6::present: true
 
-govuk::apps::ckan::blanket_redirect_url: https://find-data-beta-integration.cloudapps.digital/ckan_maintenance
+govuk::apps::ckan::enable_harvester_fetch: true
+govuk::apps::ckan::enable_harvester_gather: true
 
-govuk::apps::ckan::enable_harvester_fetch: false
-govuk::apps::ckan::enable_harvester_gather: false
-
-govuk::apps::ckan::cronjobs::enable: false
-govuk::apps::ckan::cronjobs::enable_solr_reindex: false
+govuk::apps::ckan::cronjobs::enable: true
+govuk::apps::ckan::cronjobs::enable_solr_reindex: true
 
 govuk::apps::ckan::solr_core: ckan
 govuk::apps::ckan::solr_core_configset: ckan28

--- a/hieradata_aws/class/production/ckan.yaml
+++ b/hieradata_aws/class/production/ckan.yaml
@@ -5,13 +5,11 @@ govuk_solr6::present: true
 
 govuk::apps::ckan::enabled: true
 
-govuk::apps::ckan::blanket_redirect_url: https://data.gov.uk/ckan_maintenance
+govuk::apps::ckan::enable_harvester_fetch: true
+govuk::apps::ckan::enable_harvester_gather: true
 
-govuk::apps::ckan::enable_harvester_fetch: false
-govuk::apps::ckan::enable_harvester_gather: false
-
-govuk::apps::ckan::cronjobs::enable: false
-govuk::apps::ckan::cronjobs::enable_solr_reindex: false
+govuk::apps::ckan::cronjobs::enable: true
+govuk::apps::ckan::cronjobs::enable_solr_reindex: true
 
 govuk::apps::ckan::solr_core: ckan
 govuk::apps::ckan::solr_core_configset: ckan28

--- a/hieradata_aws/class/staging/ckan.yaml
+++ b/hieradata_aws/class/staging/ckan.yaml
@@ -5,13 +5,11 @@ govuk_solr6::present: true
 
 govuk::apps::ckan::enabled: true
 
-govuk::apps::ckan::blanket_redirect_url: https://find-data-beta-staging.cloudapps.digital/ckan_maintenance
+govuk::apps::ckan::enable_harvester_fetch: true
+govuk::apps::ckan::enable_harvester_gather: true
 
-govuk::apps::ckan::enable_harvester_fetch: false
-govuk::apps::ckan::enable_harvester_gather: false
-
-govuk::apps::ckan::cronjobs::enable: false
-govuk::apps::ckan::cronjobs::enable_solr_reindex: false
+govuk::apps::ckan::cronjobs::enable: true
+govuk::apps::ckan::cronjobs::enable_solr_reindex: true
 
 govuk::apps::ckan::solr_core: ckan
 govuk::apps::ckan::solr_core_configset: ckan28


### PR DESCRIPTION
## What

Enable CKAN workers and remove the blanket redirect which goes to the maintenance page.

## Reference 

https://trello.com/c/lkdK9QM2/71-do-the-postgres-upgrade-for-ckan