### PR TITLE
Point Content Publisher to dedicated RDS instance on Integration

### DIFF
--- a/hieradata_aws/class/integration/backend.yaml
+++ b/hieradata_aws/class/integration/backend.yaml
@@ -35,3 +35,5 @@ govuk::apps::travel_advice_publisher::mongodb_nodes:
   - 'shared-documentdb'
 govuk::apps::travel_advice_publisher::mongodb_username: "%{hiera('shared_documentdb_user')}"
 govuk::apps::travel_advice_publisher::mongodb_password: "%{hiera('shared_documentdb_password')}"
+
+govuk::apps::content_publisher::db_hostname: "content-publisher-postgres"


### PR DESCRIPTION
We're not ready to apply this to all environments yet, so can't make the changes in the [common.yaml][].

[common.yaml]: https://github.com/alphagov/govuk-puppet/blob/fdf2678eab4f498f1daa0bc3e765996c6002d665/hieradata_aws/common.yaml#L508-L510

Trello: https://trello.com/c/OnPpEYlk/59-run-integration-applications-on-postgres-13-and-mysql-8

---

## Steps to test

1. Connect to the DB admin machine: `gds govuk connect ssh -e integration content_publisher_db_admin`
1. Connect to the Postgres database: `sudo psql -U aws_db_admin -h content-publisher-postgres --no-password content_publisher_production` (command [inspired by govuk_env_sync](https://github.com/alphagov/govuk-puppet/blob/305a66caa249c39aa27e838c5552ba8097961625/modules/govuk_env_sync/files/govuk_env_sync.sh#L406))
1. Use the [`\dt` command](https://www.postgresqltutorial.com/postgresql-show-tables/) to see which tables exist. Confirm that these are as would be expected of the app.

Then to switch over:

1. Push up a [govuk-puppet branch](https://github.com/alphagov/govuk-puppet/pull/11378) that changes the database host for the app on Integration
1. [Build the branch](https://deploy.integration.publishing.service.gov.uk/job/Deploy_Puppet/)
1. SSH into the `backend` machine (this is the machine Content Publisher runs on, [according to the dev docs](https://docs.publishing.service.gov.uk/apps/content-publisher.html)): `gds govuk connect ssh -e integration backend`
1. Run `govuk_puppet --test` to make the database host change take effect

Finally, I sense-checked by:

1. Check it is using the new database: `govuk_app_dbconsole content-publisher`, then running `SELECT version();`. It should say Postgres 13.
1. [Trying out the app](https://content-publisher.integration.publishing.service.gov.uk/) and making sure it still works.