### PR TITLE
Remove logic for inferring membership of the DR VDCs.

### DIFF
--- a/modules/govuk/lib/facter/vdc.rb
+++ b/modules/govuk/lib/facter/vdc.rb
@@ -2,12 +2,6 @@
 
 Facter.add("vdc") do
   setcode do
-    env_octet = Facter.value(:ipaddress).split('.')[2].to_i
-    vdc = Facter.value(:domain).split('.').first
-    if env_octet > 7
-      vdc + '_dr'
-    else
-      vdc
-    end
+    Facter.value(:domain).split('.').first
   end
 end

--- a/modules/icinga/manifests/client.pp
+++ b/modules/icinga/manifests/client.pp
@@ -48,19 +48,12 @@ class icinga::client (
     ],
   }
 
-  if ($::vdc == 'licensify') or ($::vdc =~ /^*_dr$/) {
-    $parents = "vpn_gateway_${::vdc}"
-  } else {
-    $parents = undef
-  }
-
   $display_name = "${::aws_migration} (${::ipaddress_eth0})"
 
   @@icinga::host { $::fqdn:
     hostalias      => $::fqdn,
     address        => $host_ipaddress,
     display_name   => $display_name,
-    parents        => $parents,
     contact_groups => $contact_groups,
   }
 


### PR DESCRIPTION
The disaster-recovery VDCs (VMWare "virtual datacentres") no longer exist; they were part of the old VMWare-based installation when parts of GOV.UK were hosted in Carrenza and UKCloud.

This logic had a bug where the heuristic for telling whether a machine was a DR machine or not was based on the IP address of whichever network interface happens to be returned as `:ipaddress`. For VMs which have Docker installed on them, this can be the host address on the Docker network rather than the VM's eth0 interface. So the logic then has a 1 - 7/256 ≈ 97% chance of wrongly appending `_dr` to the value of the `:vdc` Puppet fact for that node.

This would have gone harmlessly unnoticed, except that [/modules/icinga/manifests/client.pp:51](https://github.com/alphagov/govuk-puppet/blob/50ef199/modules/icinga/manifests/client.pp#L51) uses the presence of the `_dr` suffix as another heuristic to infer that it should add the (long-since-deleted) VPN gateway for the corresponding (also long-since deleted) VDC as a "parent" to the node's host configuration in Icinga. This causes Icinga to fail to start up because it fails to validate its configuration, which breaks pretty much all the monitoring in the whole environment.

Also remove the offending condition from the module that generates the Icinga config. It's entirely obsolete since we no longer have any Puppet nodes running in UKCloud (Skyscape) or Carrenza (6degrees). This doesn't affect the [Icinga check that monitors the Licensify edge gateway in UKCloud](https://docs.publishing.service.gov.uk/manual/vpn.html#vpn-between-aws-and-ukcloud-for-licensify-civica-payment-status-requests).

Tested: deployed temporarily in integration and successfully ran puppet agent on the monitoring, puppetmaster and db_admin machines.