### PR TITLE
Point Link Checker API to dedicated RDS instance on Integration

### DIFF
--- a/hieradata_aws/class/integration/backend.yaml
+++ b/hieradata_aws/class/integration/backend.yaml
@@ -37,3 +37,4 @@ govuk::apps::travel_advice_publisher::mongodb_username: "%{hiera('shared_documen
 govuk::apps::travel_advice_publisher::mongodb_password: "%{hiera('shared_documentdb_password')}"
 
 govuk::apps::content_publisher::db_hostname: "content-publisher-postgres"
+govuk::apps::link_checker_api::db_hostname: "link-checker-api-postgres"


### PR DESCRIPTION
We're not ready to apply this to all environment yet, so can't make the changes in the [common.yaml][].

[common.yaml]: https://github.com/alphagov/govuk-puppet/blob/fdf2678eab4f498f1daa0bc3e765996c6002d665/hieradata_aws/common.yaml#L508-L510

Trello: https://trello.com/c/OnPpEYlk/59-run-integration-applications-on-postgres-13-and-mysql-8

### Testing Link Checker API

I've tested this by using the "Check Links" button in Whitehall on integration. My assumption is that Whitehall (integration) uses Link Checker API (integration), and therefore is an effective way to test that the app still works as expected.

I've also used the `dbconsole` to verify that the `version()` is now Postgres 13.