### PR TITLE
Point Publishing API to dedicated RDS instance on Integration

### DIFF
--- a/hieradata_aws/class/integration/publishing_api.yaml
+++ b/hieradata_aws/class/integration/publishing_api.yaml
@@ -1,0 +1,3 @@
+---
+
+govuk::apps::publishing_api::db_hostname: "publishing-api-postgres"


### PR DESCRIPTION
We're not ready to apply this to all environment yet, so can't make the changes in the [common.yaml][].

[common.yaml]: https://github.com/alphagov/govuk-puppet/blob/fdf2678eab4f498f1daa0bc3e765996c6002d665/hieradata_aws/common.yaml#L659-L661

Trello: https://trello.com/c/OnPpEYlk/59-run-integration-applications-on-postgres-13-and-mysql-8