### PR TITLE
Remove docker from search machines

### DIFF
--- a/modules/govuk/manifests/node/s_search.pp
+++ b/modules/govuk/manifests/node/s_search.pp
@@ -11,8 +11,6 @@ class govuk::node::s_search inherits govuk::node::s_base {
 
   include nginx
 
-  include ::govuk_docker
-
   # The catchall vhost throws a 500, except for healthcheck requests.
   nginx::config::vhost::default { 'default': }
 


### PR DESCRIPTION
We used to use docker to serve tensorflow for Learning to Rank. We moved to using AWS Sagemaker and [retired the tensorflow container](https://github.com/alphagov/govuk-puppet/search?q=remove+tensorflow&type=issues).

We should therefore be able to remove docker from these machines and save a few ounces of CO2 here and there.