### PR TITLE
Point Content Data Admin to dedicated RDS instance on Integration

### DIFF
--- a/hieradata_aws/class/integration/backend.yaml
+++ b/hieradata_aws/class/integration/backend.yaml
@@ -36,6 +36,7 @@ govuk::apps::travel_advice_publisher::mongodb_nodes:
 govuk::apps::travel_advice_publisher::mongodb_username: "%{hiera('shared_documentdb_user')}"
 govuk::apps::travel_advice_publisher::mongodb_password: "%{hiera('shared_documentdb_password')}"
 
+govuk::apps::content_data_admin::db_hostname: "content-data-admin-postgres"
 govuk::apps::content_publisher::db_hostname: "content-publisher-postgres"
 govuk::apps::link_checker_api::db_hostname: "link-checker-api-postgres"
 govuk::apps::support_api::db_hostname: "support-api-postgres"


### PR DESCRIPTION
We're not ready to apply this to all environment yet, so can't make the changes in the [common.yaml][].

[common.yaml]: https://github.com/alphagov/govuk-puppet/blob/fdf2678eab4f498f1daa0bc3e765996c6002d665/hieradata_aws/common.yaml#L483-L485

Trello: https://trello.com/c/OnPpEYlk/59-run-integration-applications-on-postgres-13-and-mysql-8