### PR TITLE
Point Whitehall to dedicated RDS instance on Integration

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -91,6 +91,10 @@ govuk::apps::whitehall::basic_auth_credentials: "%{hiera('http_username')}:%{hie
 govuk::apps::whitehall::highlight_words_to_avoid: true
 govuk::apps::whitehall::govuk_notify_template_id: "759acac6-da53-4a19-b591-b7538c7c39de"
 govuk::apps::whitehall::aws_s3_bucket_name: 'govuk-integration-whitehall-csvs'
+# DB hostname for whitehall backend
+govuk::apps::whitehall::admin_db_hostname: 'whitehall-mysql'
+# DB hostname for whitehall frontend
+govuk::apps::whitehall::db_hostname: 'whitehall-mysql'
 
 licensify::apps::configfile::mongo_database_reference_name: 'licensify-refdata'
 licensify::apps::configfile::mongo_database_audit_name: 'licensify-audit'


### PR DESCRIPTION
We're not ready to apply this to all environment yet, so can't make the changes in the [common.yaml]( https://github.com/alphagov/govuk-puppet/blob/fdf2678eab4f498f1daa0bc3e765996c6002d665/hieradata_aws/common.yaml#L589-L597).

### Whitehall 'frontend' vs 'backend'

Note that there are two machine classes which run Whitehall: `whitehall_backend` and `whitehall_frontend`.

They each use different database config keys in the hieradata:

- `whitehall_backend` uses `govuk::apps::whitehall::admin_db_hostname`
- `whitehall_frontend` uses `govuk::apps::whitehall::db_hostname`

---

Trello: https://trello.com/c/OnPpEYlk/59-run-integration-applications-on-postgres-13-and-mysql-8