### PR TITLE
Fix S3 backup path for MySQL apps on Integration

### DIFF
--- a/hieradata_aws/class/integration/db_admin.yaml
+++ b/hieradata_aws/class/integration/db_admin.yaml
@@ -178,7 +178,7 @@ govuk_env_sync::tasks:
     database: "release_production"
     temppath: "/tmp/release_production"
     url: "govuk-integration-database-backups"
-    path: "mysql-backend"
+    path: "mysql"
   "push_release_integration_daily":
     ensure: "present"
     hour: "0"
@@ -211,7 +211,7 @@ govuk_env_sync::tasks:
     database: "signon_production"
     temppath: "/tmp/signon_production"
     url: "govuk-integration-database-backups"
-    path: "mysql-backend"
+    path: "mysql"
   "pull_whitehall_staging_daily":
     ensure: "present"
     hour: "1"
@@ -233,7 +233,7 @@ govuk_env_sync::tasks:
     database: "whitehall_production"
     temppath: "/tmp/whitehall_integration"
     url: "govuk-integration-database-backups"
-    path: "mysql-backend"
+    path: "mysql"
   "pull_licensify_staging_daily": &pull_licensify
     ensure: "present"
     hour: "5"
@@ -299,7 +299,7 @@ govuk_env_sync::tasks:
     database: "collections_publisher_production"
     temppath: "/tmp/collections_publisher_production"
     url: "govuk-integration-database-backups"
-    path: "mysql-backend"
+    path: "mysql"
   "pull_contacts_production_daily":
     ensure: "present"
     hour: "4"
@@ -321,7 +321,7 @@ govuk_env_sync::tasks:
     database: "contacts_production"
     temppath: "/tmp/contacts_production"
     url: "govuk-integration-database-backups"
-    path: "mysql-backend"
+    path: "mysql"
   "pull_search_admin_production_daily":
     ensure: "present"
     hour: "2"
@@ -343,7 +343,7 @@ govuk_env_sync::tasks:
     database: "search_admin_production"
     temppath: "/tmp/search_admin_production"
     url: "govuk-integration-database-backups"
-    path: "mysql-backend"
+    path: "mysql"
   "pull_content_publisher_production_daily":
     ensure: "present"
     hour: "3"


### PR DESCRIPTION
These were mistakenly set to 'mysql-backend' on all but the
Release app, which was correctly set to 'mysql' (and indeed this
is the convention used in [Staging][] and [Production][]).

We hadn't noticed until now as these Integration 'backups' aren't
used anywhere. However, for a short period, we're pulling from
these shared backups onto the new app-specific DB admin machines,
e.g. https://github.com/alphagov/govuk-puppet/blob/e3ed901700ba69d0195d7529c7961b56100bb83e/hieradata_aws/class/integration/collections_publisher_db_admin.yaml#L13

We noticed that after govuk_env_sync had run, the new databases
were still empty, and thus we investigated and found this path
mismatch as the root cause. Collections Publisher, for example,
was attempting to pull its SQL dump from the `mysql` path in S3,
whereas the backup lived in a `mysql-backend` path.

Trello: https://trello.com/c/OnPpEYlk/59-run-integration-applications-on-postgres-13-and-mysql-8

[Staging]: https://github.com/alphagov/govuk-puppet/blob/d91c92fea87dcdd33cb9353f8334c95673599fa5/hieradata_aws/class/staging/db_admin.yaml#L238
[Production]: https://github.com/alphagov/govuk-puppet/blob/d91c92fea87dcdd33cb9353f8334c95673599fa5/hieradata_aws/class/production/db_admin.yaml#L24