### PR TITLE
Point Account API to dedicated RDS instance on Integration

### DIFF
--- a/hieradata_aws/class/integration/account.yaml
+++ b/hieradata_aws/class/integration/account.yaml
@@ -1,0 +1,1 @@
+govuk::apps::account_api::db_hostname: "account-api-postgres"


### PR DESCRIPTION
We're not ready to apply this to all environments yet, so can't
make the changes in the [common.yaml][].

Note that we do not have to worry about the data sync - see
https://github.com/alphagov/govuk-puppet/pull/11364.

[common.yaml]: https://github.com/alphagov/govuk-puppet/blob/fdf2678eab4f498f1daa0bc3e765996c6002d665/hieradata_aws/common.yaml#L817

Trello: https://trello.com/c/OnPpEYlk/59-run-integration-applications-on-postgres-13-and-mysql-8