### PR TITLE
Comment out pull_ckan_daily env sync tasks

### DIFF
--- a/hieradata_aws/class/integration/ckan_db_admin.yaml
+++ b/hieradata_aws/class/integration/ckan_db_admin.yaml
@@ -1,16 +1,16 @@
 govuk_env_sync::tasks:
-  "pull_ckan_production_daily":
-    ensure: "present"
-    hour: "0"
-    minute: "0"
-    action: "pull"
-    dbms: "postgresql"
-    storagebackend: "s3"
-    database: "ckan_production"
-    database_hostname: "ckan-postgres"
-    temppath: "/tmp/ckan_production"
-    url: "govuk-production-database-backups"
-    path: "ckan-postgres"
+  # "pull_ckan_production_daily":
+  #   ensure: "present"
+  #   hour: "0"
+  #   minute: "0"
+  #   action: "pull"
+  #   dbms: "postgresql"
+  #   storagebackend: "s3"
+  #   database: "ckan_production"
+  #   database_hostname: "ckan-postgres"
+  #   temppath: "/tmp/ckan_production"
+  #   url: "govuk-production-database-backups"
+  #   path: "ckan-postgres"
   "push_ckan_production_daily":
     ensure: "present"
     hour: "5"

--- a/hieradata_aws/class/staging/ckan_db_admin.yaml
+++ b/hieradata_aws/class/staging/ckan_db_admin.yaml
@@ -1,16 +1,16 @@
 govuk_env_sync::tasks:
-  "pull_ckan_production_daily":
-    ensure: "present"
-    hour: "0"
-    minute: "0"
-    action: "pull"
-    dbms: "postgresql"
-    storagebackend: "s3"
-    database: "ckan_production"
-    database_hostname: "ckan-postgres"
-    temppath: "/tmp/ckan_production"
-    url: "govuk-production-database-backups"
-    path: "ckan-postgres"
+  # "pull_ckan_production_daily":
+  #   ensure: "present"
+  #   hour: "0"
+  #   minute: "0"
+  #   action: "pull"
+  #   dbms: "postgresql"
+  #   storagebackend: "s3"
+  #   database: "ckan_production"
+  #   database_hostname: "ckan-postgres"
+  #   temppath: "/tmp/ckan_production"
+  #   url: "govuk-production-database-backups"
+  #   path: "ckan-postgres"
   "push_ckan_production_daily":
     ensure: "present"
     hour: "5"


### PR DESCRIPTION
These are currently not working due to the postgres 13 upgrade -
the old pg_restore client doesn't like restoring dumps created by the
new pg_dump thing.

It's a bit involved fixing the script, and it's christmas time. So we're
just going to stop the restore bit of the sync process for now and come
back to it in the new year.