### PR TITLE
Point Email Alert API to dedicated RDS instance on Integration

### DIFF
--- a/hieradata_aws/class/integration/backend.yaml
+++ b/hieradata_aws/class/integration/backend.yaml
@@ -39,6 +39,7 @@ govuk::apps::travel_advice_publisher::mongodb_password: "%{hiera('shared_documen
 govuk::apps::content_data_admin::db_hostname: "content-data-admin-postgres"
 govuk::apps::content_publisher::db_hostname: "content-publisher-postgres"
 govuk::apps::content_tagger::db_hostname: "content-tagger-postgres"
+govuk::apps::email_alert_api::db_hostname: "email-alert-api-postgres"
 govuk::apps::link_checker_api::db_hostname: "link-checker-api-postgres"
 govuk::apps::service_manual_publisher::db_hostname: "service-manual-publisher-postgres"
 govuk::apps::support_api::db_hostname: "support-api-postgres"


### PR DESCRIPTION
We're not ready to apply this to all environments yet, so can't
make the changes in the [common.yaml][].

[common.yaml]: https://github.com/alphagov/govuk-puppet/blob/fdf2678eab4f498f1daa0bc3e765996c6002d665/hieradata_aws/common.yaml

Trello: https://trello.com/c/OnPpEYlk/59-run-integration-applications-on-postgres-13-and-mysql-8