### PR TITLE
Updated s3cmd version 2.2

### DIFF
--- a/modules/govuk_crawler/manifests/init.pp
+++ b/modules/govuk_crawler/manifests/init.pp
@@ -151,7 +151,7 @@ class govuk_crawler(
 
   # Needed to copy to AWS S3
   package { 's3cmd':
-        ensure   => present,
+        ensure   => '2.2.0',
         provider => pip,
   }
 


### PR DESCRIPTION
Update s3cmd to attempt to resolve mime-type issue:
https://trello.com/c/RmUQlkKO/2798-fix-incorrect-mime-type-for-govuk-homepage-being-served-from-static-mirror-5

Ref:
1. https://github.com/s3tools/s3cmd/issues/643