### PR TITLE
Point Collections Publisher to dedicated RDS instance on Integration

### DIFF
--- a/hieradata_aws/class/integration/backend.yaml
+++ b/hieradata_aws/class/integration/backend.yaml
@@ -36,6 +36,8 @@ govuk::apps::travel_advice_publisher::mongodb_nodes:
 govuk::apps::travel_advice_publisher::mongodb_username: "%{hiera('shared_documentdb_user')}"
 govuk::apps::travel_advice_publisher::mongodb_password: "%{hiera('shared_documentdb_password')}"
 
+govuk::apps::collections_publisher::db_hostname: "collections-publisher-mysql"
+govuk::apps::collections_publisher::db_password: "%{hiera('govuk::node::s_collections_publisher_db_admin::mysql_db_password')}"
 govuk::apps::content_data_admin::db_hostname: "content-data-admin-postgres"
 govuk::apps::content_publisher::db_hostname: "content-publisher-postgres"
 govuk::apps::content_tagger::db_hostname: "content-tagger-postgres"


### PR DESCRIPTION
We're not ready to apply this to all environments yet, so can't
make the changes in the [common.yaml][].

[common.yaml]: 
https://github.com/alphagov/govuk-puppet/blob/fdf2678eab4f498f1daa0bc3e765996c6002d665/hieradata_aws/common.yaml#L473-475

Trello: 
https://trello.com/c/OnPpEYlk/59-run-integration-applications-on-postgres-13-and-mysql-8