### PR TITLE
Move email-alert-api db hostname declaration

### DIFF
--- a/hieradata_aws/class/integration/backend.yaml
+++ b/hieradata_aws/class/integration/backend.yaml
@@ -39,7 +39,6 @@ govuk::apps::travel_advice_publisher::mongodb_password: "%{hiera('shared_documen
 govuk::apps::content_data_admin::db_hostname: "content-data-admin-postgres"
 govuk::apps::content_publisher::db_hostname: "content-publisher-postgres"
 govuk::apps::content_tagger::db_hostname: "content-tagger-postgres"
-govuk::apps::email_alert_api::db_hostname: "email-alert-api-postgres"
 govuk::apps::link_checker_api::db_hostname: "link-checker-api-postgres"
 govuk::apps::local_links_manager::db_hostname: "local-links-manager-postgres"
 govuk::apps::service_manual_publisher::db_hostname: "service-manual-publisher-postgres"

--- a/hieradata_aws/class/integration/email_alert_api.yaml
+++ b/hieradata_aws/class/integration/email_alert_api.yaml
@@ -1,3 +1,4 @@
 ---
 logrotate::conf::days_to_keep: 7
 nginx::logging::days_to_keep: 7
+govuk::apps::email_alert_api::db_hostname: "email-alert-api-postgres"


### PR DESCRIPTION
Email Alert API lives on a different class of machine (email_alert_api),
not 'backend' like many of the other apps.
This commit fixes #11393.

Trello: https://trello.com/c/OnPpEYlk/59-run-integration-applications-on-postgres-13-and-mysql-8