### PR TITLE
Point Signon to dedicated RDS instance on Integration

### DIFF
--- a/docs/create-mysql-db-and-users.md
+++ b/docs/create-mysql-db-and-users.md
@@ -61,7 +61,7 @@ sudo mysql --defaults-extra-file=/root/.my.cnf -e "SHOW DATABASES;"
 sudo mysql --defaults-extra-file=/root/.my.cnf -e "SELECT host, user FROM mysql.user;"
 
 # See which tables are in the database, e.g.
-sudo mysql --defaults-extra-file=/root/.my.cnf -e "USE collections_publisher_sproduction; SHOW TABLES;"
+sudo mysql --defaults-extra-file=/root/.my.cnf -e "USE collections_publisher_production; SHOW TABLES;"
 # Note that this will only be populated after the first data sync has run.
 ```
 

--- a/hieradata_aws/class/integration/signon_db_admin.yaml
+++ b/hieradata_aws/class/integration/signon_db_admin.yaml
@@ -9,7 +9,7 @@ govuk_env_sync::tasks:
     database: "signon_production"
     database_hostname: "signon-mysql"
     temppath: "/tmp/signon_production"
-    url: "govuk-production-database-backups"
+    url: "govuk-integration-database-backups"
     path: "mysql"
   # "push_signon_production_daily":
   #   ensure: "present"

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -69,6 +69,8 @@ govuk::apps::search_api::tensorflow_sagemaker_endpoint: 'govuk-integration-searc
 govuk::apps::service_manual_publisher::govuk_notify_template_id: "759acac6-da53-4a19-b591-b7538c7c39de"
 govuk::apps::short_url_manager::govuk_notify_template_id: "759acac6-da53-4a19-b591-b7538c7c39de"
 govuk::apps::short_url_manager::instance_name: 'integration'
+govuk::apps::signon::db_hostname: "signon-mysql"
+govuk::apps::signon::db_password: "%{hiera('govuk::node::s_signon_db_admin::mysql_db_password')}"
 govuk::apps::signon::instance_name: 'integration'
 govuk::apps::signon::govuk_notify_template_id: "759acac6-da53-4a19-b591-b7538c7c39de"
 govuk::apps::smartanswers::expose_govspeak: true


### PR DESCRIPTION
We're not ready to apply this to all environments yet, so can't
make the changes in the [common.yaml][].

Note that we had to override the password that is used, otherwise
it would use the `govuk::apps::signon::db::mysql_signonotron` value
set [here](https://github.com/alphagov/govuk-puppet/blob/2a74c8b85a43a5193a1b196c6f36387cfb57c6da/hieradata_aws/common.yaml#L757),
otherwise we'd get the following error:

```
ERROR 1045 (28000): Access denied for user 'signon'@'10.1.6.26' (using password: YES
```

Note also that we've applied this to hieradata_aws/integration.yaml,
rather than hieradata_aws/class/integration/backend.yaml (where
[signon is hosted](https://docs.publishing.service.gov.uk/apps/signon.html)),
because the signon DB credentials are configured globally:
https://github.com/alphagov/govuk-puppet/blob/2a74c8b85a43a5193a1b196c6f36387cfb57c6da/hieradata_aws/common.yaml#L755-L757

This goes against the convention established for other apps
([example](https://github.com/alphagov/govuk-puppet/pull/11407/files)),
but is necessary for Signon.

Trello: https://trello.com/c/OnPpEYlk/59-run-integration-applications-on-postgres-13-and-mysql-8

[common.yaml]: https://github.com/alphagov/govuk-puppet/blob/fdf2678eab4f498f1daa0bc3e765996c6002d665/hieradata_aws/common.yaml#L508-L510