### PR TITLE
Email Alert API use dedicated RDS instance in staging

### DIFF
--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -164,6 +164,7 @@ govuk::apps::content_store::performance_platform_big_screen_view_url: 'https://p
 govuk::apps::content_store::performance_platform_spotlight_url: 'https://performance-platform-spotlight-staging.cloudapps.digital'
 
 govuk::apps::email_alert_api::db::backend_ip_range: '10.12.3.0/24'
+govuk::apps::email_alert_api::db_hostname: "email-alert-api-postgres"
 govuk::apps::email_alert_api::govuk_notify_template_id: '2844a647-6bf1-4b01-a25c-569d2cc00849'
 govuk::apps::email_alert_api::govuk_notify_recipients:
   - email-alert-api-staging@digital.cabinet-office.gov.uk


### PR DESCRIPTION
Trello: https://trello.com/c/GRGnnikf/63-plan-production-upgrade-for-email-alert-api-postgresql-database

This is opened as a draft PR so that it can be merged in at the point of switching staging over to this new instance

This changes the db hostname so the Email Alert API application will use
the new instance in the staging environment.