### PR TITLE
Switch Email Alert API to new RDS instance in production

### DIFF
--- a/hieradata_aws/class/integration/email_alert_api.yaml
+++ b/hieradata_aws/class/integration/email_alert_api.yaml
@@ -1,4 +1,3 @@
 ---
 logrotate::conf::days_to_keep: 7
 nginx::logging::days_to_keep: 7
-govuk::apps::email_alert_api::db_hostname: "email-alert-api-postgres"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -533,9 +533,7 @@ govuk::apps::email_alert_api::db::allow_auth_from_lb: true
 govuk::apps::email_alert_api::db::lb_ip_range: "%{hiera('environment_ip_prefix')}.0.0/16"
 govuk::apps::email_alert_api::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::email_alert_api::redis_port: "%{hiera('sidekiq_port')}"
-# TODO: switch to "email-alert-api-postgresql" and uncomment the 'push'
-# `govuk_env_sync::tasks` tasks when we're ready to switch to the dedicated RDS instance
-govuk::apps::email_alert_api::db_hostname: "postgresql-primary"
+govuk::apps::email_alert_api::db_hostname: "email-alert-api-postgres"
 govuk::apps::email_alert_api::db_password: "%{hiera('govuk::apps::email_alert_api::db::password')}"
 govuk::apps::email_alert_api::unicorn_worker_processes: '10'
 govuk::apps::email_alert_api::govuk_personalisation_feedback_uri: "%{hiera('govuk::apps::static::govuk_personalisation_feedback_uri')}"

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -164,7 +164,6 @@ govuk::apps::content_store::performance_platform_big_screen_view_url: 'https://p
 govuk::apps::content_store::performance_platform_spotlight_url: 'https://performance-platform-spotlight-staging.cloudapps.digital'
 
 govuk::apps::email_alert_api::db::backend_ip_range: '10.12.3.0/24'
-govuk::apps::email_alert_api::db_hostname: "email-alert-api-postgres"
 govuk::apps::email_alert_api::govuk_notify_template_id: '2844a647-6bf1-4b01-a25c-569d2cc00849'
 govuk::apps::email_alert_api::govuk_notify_recipients:
   - email-alert-api-staging@digital.cabinet-office.gov.uk


### PR DESCRIPTION
Trello: https://trello.com/c/GRGnnikf/63-plan-production-upgrade-for-email-alert-api-postgresql-database

This is opened as a draft PR so that it can be merged in at the point of switching production over to this new instance.

This completes the switch across the three environments by setting the
same value in all environments and allowing the environmental specific
configuration to be removed.