### PR TITLE
Fix error pages on the fallback CDN

### DIFF
--- a/modules/govuk_crawler/templates/govuk_sync_mirror.erb
+++ b/modules/govuk_crawler/templates/govuk_sync_mirror.erb
@@ -37,8 +37,9 @@ function get_error_page() {
   # Grab the 503 error page
   log "user.info" "Grabbing the latest error page"
 
-  test -d ${MIRROR_ROOT}/error || mkdir ${MIRROR_ROOT}/error/
-  curl -sf https://${STATIC_HOSTNAME}/templates/503.html.erb -o ${MIRROR_ROOT}/error/503.html
+  website_mirror_dir=${MIRROR_ROOT}/www.*
+  test -d ${website_mirror_dir}/error || mkdir ${website_mirror_dir}/error/
+  curl -sf https://${STATIC_HOSTNAME}/templates/503.html.erb -o ${website_mirror_dir}/error/503.html
 }
 
 function write_timestamps() {

--- a/modules/govuk_crawler/templates/govuk_sync_mirror.erb
+++ b/modules/govuk_crawler/templates/govuk_sync_mirror.erb
@@ -37,9 +37,9 @@ function get_error_page() {
   # Grab the 503 error page
   log "user.info" "Grabbing the latest error page"
 
-  website_mirror_dir=${MIRROR_ROOT}/www.*
-  test -d ${website_mirror_dir}/error || mkdir ${website_mirror_dir}/error/
-  curl -sf https://${STATIC_HOSTNAME}/templates/503.html.erb -o ${website_mirror_dir}/error/503.html
+  website_mirror_dir="${MIRROR_ROOT}"/www.*
+  mkdir -p "${website_mirror_dir}/error/"
+  curl -sf "https://${STATIC_HOSTNAME}/templates/503.html.erb" -o "${website_mirror_dir}/error/503.html"
 }
 
 function write_timestamps() {


### PR DESCRIPTION
The crawler itself can't find our error pages (obviously they're not in
the site map).

Instead, we've got a little hack in the govuk_sync_mirror mirror script
where we fetch the error page from static just before we upload the
mirrored files to S3.

Unfortunately, we're not putting the file in the right place. The
directory structure in S3 looks like:

```
.
├── error
│   └── 503.html
└── www.gov.uk
    └── error
        └── 503.html
```

/error/503.html is the file we're uploading, but /www.gov.uk/error/503.html
is the file that gets served by CloudFront.

The file in /www.gov.uk/error/ hasn't been updated since 2019
(presumably when the crawler stopped running on Carrenza?). This means
it's referring to a bunch of assets on assets.publishing.service.gov.uk
which don't exist anymore (because we moved them to www.gov.uk), so the
error pages end up unstyled. This is reproducible here at the moment:

https://d1v9gv6rnax070.cloudfront.net/404

(Note the response header: last-modified: Fri, 21 Jun 2019 16:26:16 GMT)

If we put the error page in the right place, that should get us an
up-to-date mirror of the file.

Note that I'm using `www.*` because the directory has a different name
in different environments (it's www.integration.publishing.service.gov.uk
in integration, www.gov.uk in production). The glob sorts that out for
us.

Draft until:

- [x] Trello card created to represent this change
- [x] Trello card has acceptance criteria that ensure this gets deployed

Trello: https://trello.com/c/cjPz75uK/2593-fix-error-pages-on-the-fallback-cdn