### PR TITLE
Add ability to restore from multiple postgres dump versions

### DIFF
--- a/modules/govuk_env_sync/files/govuk_env_sync.sh
+++ b/modules/govuk_env_sync/files/govuk_env_sync.sh
@@ -358,7 +358,25 @@ function dump_postgresql {
 }
 
 function output_restore_sql {
-  pg_restore -j 2 "${dumpfile}" | sed -r "${sed_cmds}"
+  PG_RESTORE_VERSION='13.4'
+  DUMPFILE_VERSION=$(file "${dumpfile}" | awk '{print $NF}')
+
+  case $DUMPFILE_VERSION in
+    v1.13-0)
+      PG_RESTORE_VERSION='9.6.22'
+      ;;
+    v1.14-0)
+      PG_RESTORE_VERSION='13.4'
+      ;;
+    *)
+      exit 1
+      ;;
+  esac
+  sudo docker run --rm --net=host  \
+	  -v "${tempdir}:/tmp/" \
+	  -v "/root/.pgpass:/tmp/.pgpass" -e PGPASSFILE=/tmp/.pgpass \
+	  "postgres:$PG_RESTORE_VERSION" \
+	  pg_restore -j 2  -f - "/tmp/${filename}" | sed -r "${sed_cmds}"	
   if [ "${transformation_sql_file:-}" ]; then
     # pg_dump/pg_restore sets search_path to ''. Reset it to the default so
     # that the transform script doesn't need to prefix table names with

--- a/modules/govuk_env_sync/files/govuk_env_sync.sh
+++ b/modules/govuk_env_sync/files/govuk_env_sync.sh
@@ -377,7 +377,7 @@ function output_restore_sql {
 	  -v "${tempdir}:/tmp/" \
 	  -v "/root/.pgpass:/tmp/.pgpass" -e PGPASSFILE=/tmp/.pgpass \
 	  "postgres:$PG_RESTORE_VERSION" \
-	  pg_restore -j 2  -f - "/tmp/${filename}" | sed -r "${sed_cmds}"	
+	  pg_restore -j 2  -f /dev/stdout "/tmp/${filename}" | sed -r "${sed_cmds}"	
   if [ "${transformation_sql_file:-}" ]; then
     # pg_dump/pg_restore sets search_path to ''. Reset it to the default so
     # that the transform script doesn't need to prefix table names with

--- a/modules/govuk_env_sync/files/govuk_env_sync.sh
+++ b/modules/govuk_env_sync/files/govuk_env_sync.sh
@@ -369,6 +369,7 @@ function output_restore_sql {
       PG_RESTORE_VERSION='13.4'
       ;;
     *)
+      >&2 echo "${DUMPFILE_VERSION} is not a supported dump file version"
       exit 1
       ;;
   esac


### PR DESCRIPTION
We now run pg_restore in docker which allow us to select the
version of pg_restore according the type of dump being restored.