### PR TITLE
Pause Content-data-api Database Sync

### DIFF
--- a/hieradata_aws/class/integration/content_data_api_db_admin.yaml
+++ b/hieradata_aws/class/integration/content_data_api_db_admin.yaml
@@ -2,7 +2,7 @@ govuk_env_sync::tasks:
   # Use the new Content Data API name here, to avoid issues with
   # changing the name later
   "pull_content_data_api_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "0"
     minute: "0"
     action: "pull"

--- a/hieradata_aws/class/staging/content_data_api_db_admin.yaml
+++ b/hieradata_aws/class/staging/content_data_api_db_admin.yaml
@@ -2,7 +2,7 @@ govuk_env_sync::tasks:
   # Use the new Content Data API name here, to avoid issues with
   # changing the name later
   "pull_content_data_api_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "0"
     minute: "0"
     action: "pull"


### PR DESCRIPTION
Pause the database sync for Content-data-api in integration
and staging since we updated the PSQL database to 13.3 in
integration and staging already. Production PSQL is still
on 9.6.

Ref:
1. [trello card](https://trello.com/c/arZ9y2T5/62-plan-production-upgrade-for-content-data-api)