### PR TITLE
Set ARP garbage collection threshold to 0

### DIFF
--- a/modules/govuk_harden/files/sysctl.d/60-govuk-base.conf
+++ b/modules/govuk_harden/files/sysctl.d/60-govuk-base.conf
@@ -18,3 +18,11 @@ fs.inotify.max_user_instances=1024
 
 # Disallow core dumping by setuid and setgid programs
 fs.suid_dumpable = 0
+
+# Set ARP garbage collection threshold to 0.
+# This is the default in newer versions of the linux kernel.
+# The default in older versions was 128. This means the ARP
+# cache can sometimes become stale resulting in packets being
+# sent to the wrong MAC addresses:
+net.ipv4.neigh.default.gc_thresh1=0
+net.ipv6.neigh.default.gc_thresh1=0


### PR DESCRIPTION
Following on from a discussion with AWS Support:

> There is a third theory I would like to look into as the most likely suspect and we should prioritize looking into this one over the others:
>
> The highly likely possibility that these clients are excessively caching ARP entries, such that if a new load balancer node (or any AWS resource for that matter) with same IP address as a past resource spins up, and your client's stored ARP entry for that IP points to a different previously cached MAC address; the traffic from these clients going to that IP would go into a black-hole.
>
> The ARP cache in Linux is automatically pruned/cleaned up by something called garbage collector, and there are rules set in the Kernel defining when this is done. I believe that your clients Linux kernel version is affected by poor default configurations of the garbage collector where gc_thresh1 is set to 128. This means that garbage collector would only run if there are more than 128 ARP entries, the client likely doesn’t have that many hosts in ARP and as a result the ARP cache is never refreshed automatically.
>
> This would explain why the issue resolved its self after you replaced the client EC2 instances, because new instances start with a fresh ARP cache.
>
> ----
>
> To validate this theory, please run and share the output of the following from one or more affected clients.
>
> $ arp -a
> $ sudo sysctl -a | grep "default.gc_"
>
> If your instance is affected by this, I'm expecting the arp command to show < 128 entries, and the sysctl command to show something like the following:
> net.ipv4.neigh.default.gc_interval = 30
> net.ipv4.neigh.default.gc_stale_time = 60
> net.ipv4.neigh.default.gc_thresh1 = 128
> net.ipv4.neigh.default.gc_thresh2 = 512
> net.ipv4.neigh.default.gc_thresh3 = 1024
> net.ipv6.neigh.default.gc_interval = 30
> net.ipv6.neigh.default.gc_stale_time = 60
> net.ipv6.neigh.default.gc_thresh1 = 128
> net.ipv6.neigh.default.gc_thresh2 = 512
> net.ipv6.neigh.default.gc_thresh3 = 1024
>
> If we see "thresh1 = 128", you can expect repeat issues in future as resources come and go in your VPC.
>
> ----
>
> To disable aggressive ARP caching behavior in Linux for both IPv4 and IPv6, run the following:
>
> $ sudo sysctl -w net.ipv4.neigh.default.gc_thresh1=0
> $ sudo sysctl -w net.ipv6.neigh.default.gc_thresh1=0
>
> You can run this command to make settings take effect; the garbage collector should now clear things out within a minute.
>
> $ sudo sysctl -p
>
> To make the values persist after reboot (permanent),
> Just add the following lines to the /etc/sysctl.conf file and save.
>
> net.ipv4.neigh.default.gc_thresh1=0
> net.ipv6.neigh.default.gc_thresh1=0
>
> Now, no matter how few ARP entries there are in the ARP table, the garbage collector will run every 30 seconds, and if there is an entry older than 60 seconds, it will be refreshed thus reducing the likelihood of stale ARP entries becoming an issue in AWS VPC.
>
> If your settings are affected, then you should patch this in your bootstrap script for new instance launches.
> Or
> In later Linux kernel versions, a default of thresh1=0 was implemented, so using the latest kernel should have the same effect.

We're doing this in govuk_harden because that's the only place where we currently override sysctl settings, and we didn't want to have to wire up a whole new class. It's not the _right_ place to be doing this, because technically this isn't security hardening, it's just network tuning. Fight me.