### PR TITLE
Switch Publishing API to new RDS instance in production

### DIFF
--- a/hieradata_aws/class/integration/publishing_api.yaml
+++ b/hieradata_aws/class/integration/publishing_api.yaml
@@ -1,3 +1,0 @@
----
-
-govuk::apps::publishing_api::db_hostname: "publishing-api-postgres"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -654,9 +654,7 @@ govuk::apps::licencefinder::mongodb_nodes:
 
 govuk::apps::publishing_api::unicorn_worker_processes: "8"
 govuk::apps::publishing_api::content_store: "https://content-store.%{hiera('app_domain')}"
-# TODO: switch to "publishing-api-postgresql" and uncomment the 'push'
-# `govuk_env_sync::tasks` tasks when we're ready to switch to the dedicated RDS instance
-govuk::apps::publishing_api::db_hostname: "postgresql-primary"
+govuk::apps::publishing_api::db_hostname: "publishing-api-postgres"
 govuk::apps::publishing_api::draft_content_store: "https://draft-content-store.%{hiera('app_domain')}"
 govuk::apps::publishing_api::rabbitmq_hosts:
   - rabbitmq

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -208,7 +208,6 @@ govuk::apps::publisher::email_group_force_publish_alerts: 'mainstream-publisher-
 govuk::apps::publisher::fact_check_subject_prefix: 'staging'
 govuk::apps::publisher::fact_check_reply_to_id: '88f713ff-7de0-43a6-8221-8721bedd103c'
 govuk::apps::publisher::fact_check_reply_to_address: 'govuk-fact-check-staging@digital.cabinet-office.gov.uk'
-govuk::apps::publishing_api::db_hostname: 'publishing-api-postgres'
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-staging'
 govuk::apps::router::sentry_environment: 'staging'
 govuk::apps::search_admin::govuk_notify_template_id: "112842bb-d8a4-4511-90de-57dc5c8f27ec"


### PR DESCRIPTION
Trello: https://trello.com/c/tRtDucM6/64-plan-production-upgrade-for-publishing-api-postgresql-database

This is opened as a draft PR so that it can be merged in at the point of switching production over to this new instance.

This completes the switch across the three environments by setting the
same value in all environments and allowing the environmental specific
configuration to be removed.