### PR TITLE
Temporarily disable Publishing API env sync tasks in staging

### DIFF
--- a/hieradata_aws/class/staging/db_admin.yaml
+++ b/hieradata_aws/class/staging/db_admin.yaml
@@ -108,7 +108,8 @@ govuk_env_sync::tasks:
     url: "govuk-production-database-backups"
     path: "postgresql-backend"
   "pull_publishing_api_production_daily":
-    ensure: "present"
+    # Temporarily disabled for running a 24+ hour AWS DMS sync
+    ensure: "disabled"
     hour: "3"
     minute: "45"
     action: "pull"

--- a/hieradata_aws/class/staging/publishing_api_db_admin.yaml
+++ b/hieradata_aws/class/staging/publishing_api_db_admin.yaml
@@ -1,6 +1,7 @@
 govuk_env_sync::tasks:
   "pull_publishing_api_production_daily":
-    ensure: "present"
+    # Temporarily disabled for running a 24+ hour AWS DMS sync
+    ensure: "disabled"
     hour: "0"
     minute: "0"
     action: "pull"


### PR DESCRIPTION
Trello: https://trello.com/c/yxkJl7Tv/84-do-production-and-staging-upgrade-for-publishing-api

Over the weekend we're going to be running an AWS Database Migration
Service sync between the postgresql-primary RDS instance to the
publishing-api-postgres RDS instance. The env sync process would break
this job as it drops and rebuilds databases. Therefore it is to be
disabled.

I plan to reinstate these jobs on Monday following the migration.