### PR TITLE
Account API post-DB switch configuration changes on prod

### DIFF
--- a/hieradata_aws/class/integration/account.yaml
+++ b/hieradata_aws/class/integration/account.yaml
@@ -1,1 +1,0 @@
-govuk::apps::account_api::db_hostname: "account-api-postgres"

--- a/hieradata_aws/class/production/account_api_db_admin.yaml
+++ b/hieradata_aws/class/production/account_api_db_admin.yaml
@@ -1,13 +1,13 @@
-# govuk_env_sync::tasks:
-#   "push_account_api_production_daily":
-#     ensure: "present"
-#     hour: "23"
-#     minute: "0"
-#     action: "push"
-#     dbms: "postgresql"
-#     storagebackend: "s3"
-#     database: "account-api_production"
-#     database_hostname: "account-api-postgres"
-#     temppath: "/tmp/account_api_production"
-#     url: "govuk-production-database-backups"
-#     path: "account-api-postgres"
+govuk_env_sync::tasks:
+  "push_account_api_production_daily":
+    ensure: "present"
+    hour: "23"
+    minute: "0"
+    action: "push"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "account-api_production"
+    database_hostname: "account-api-postgres"
+    temppath: "/tmp/account_api_production"
+    url: "govuk-production-database-backups"
+    path: "account-api-postgres"

--- a/hieradata_aws/class/production/db_admin.yaml
+++ b/hieradata_aws/class/production/db_admin.yaml
@@ -1,6 +1,7 @@
 govuk_env_sync::tasks:
+  # TODO: remove this rule once it's been run on target machines
   "push_account_api_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "0"
     minute: "52"
     action: "push"

--- a/hieradata_aws/class/staging/account.yaml
+++ b/hieradata_aws/class/staging/account.yaml
@@ -1,1 +1,0 @@
-govuk::apps::account_api::db_hostname: "account-api-postgres"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -810,9 +810,7 @@ govuk::apps::transition::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::travel_advice_publisher::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::travel_advice_publisher::redis_port: "%{hiera('sidekiq_port')}"
 
-# TODO: switch to "account-api-postgresql" and uncomment the 'push'
-# `govuk_env_sync::tasks` tasks when we're ready to switch to the dedicated RDS instance
-govuk::apps::account_api::db_hostname: "postgresql-primary"
+govuk::apps::account_api::db_hostname: "account-api-postgres"
 govuk::apps::account_api::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 govuk::apps::account_api::db::allow_auth_from_lb: true
 govuk::apps::account_api::db::lb_ip_range: "%{hiera('environment_ip_prefix')}.0.0/16"

--- a/modules/govuk/manifests/node/s_db_admin.pp
+++ b/modules/govuk/manifests/node/s_db_admin.pp
@@ -84,7 +84,6 @@ class govuk::node::s_db_admin(
   }
 
   # include all PostgreSQL classes that create databases and users
-  -> class { '::govuk::apps::account_api::db': }
   -> class { '::govuk::apps::ckan::db': }
   -> class { '::govuk::apps::content_data_admin::db': }
   -> class { '::govuk::apps::content_publisher::db': }


### PR DESCRIPTION
This is opened as a draft PR it is intended to be merged in as part of the production DB upgrade. 

This updates the db hostname, sets up the env sync config for the new Account API RDS instance and removes the previous config from the main DB Admin instance.

Trello: https://trello.com/c/st7HeiYK/60-plan-production-upgrade-for-small-postgresql-databases