### PR TITLE
Content Publisher post-DB switch configuration changes on prod

### DIFF
--- a/hieradata_aws/class/integration/backend.yaml
+++ b/hieradata_aws/class/integration/backend.yaml
@@ -38,7 +38,6 @@ govuk::apps::travel_advice_publisher::mongodb_password: "%{hiera('shared_documen
 
 govuk::apps::collections_publisher::db_hostname: "collections-publisher-mysql"
 govuk::apps::contacts::db_hostname: "contacts-admin-mysql"
-govuk::apps::content_publisher::db_hostname: "content-publisher-postgres"
 govuk::apps::content_tagger::db_hostname: "content-tagger-postgres"
 govuk::apps::link_checker_api::db_hostname: "link-checker-api-postgres"
 govuk::apps::local_links_manager::db_hostname: "local-links-manager-postgres"

--- a/hieradata_aws/class/integration/content_publisher_db_admin.yaml
+++ b/hieradata_aws/class/integration/content_publisher_db_admin.yaml
@@ -1,6 +1,7 @@
 govuk_env_sync::tasks:
   "pull_content_publisher_production_daily":
-    ensure: "present"
+    # Temporarily disabled due to issues restoring Postgres 13 databases (https://trello.com/c/9tdzkMIG)
+    ensure: "disabled"
     hour: "0"
     minute: "0"
     action: "pull"
@@ -10,7 +11,7 @@ govuk_env_sync::tasks:
     database_hostname: "content-publisher-postgres"
     temppath: "/tmp/content_publisher_production"
     url: "govuk-production-database-backups"
-    path: "postgresql-backend"
+    path: "content-publisher-postgres"
     transformation_sql_filename: "content_publisher.sql"
   "push_content_publisher_production_daily":
     ensure: "present"

--- a/hieradata_aws/class/integration/db_admin.yaml
+++ b/hieradata_aws/class/integration/db_admin.yaml
@@ -308,8 +308,9 @@ govuk_env_sync::tasks:
     temppath: "/tmp/search_admin_production"
     url: "govuk-integration-database-backups"
     path: "mysql"
+  # TODO: remove this rule once it's been run on target machines
   "pull_content_publisher_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "3"
     minute: "45"
     action: "pull"
@@ -321,8 +322,9 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
     transformation_sql_filename: "content_publisher.sql"
+  # TODO: remove this rule once it's been run on target machines
   "push_content_publisher_production_integration_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "4"
     minute: "45"
     action: "push"

--- a/hieradata_aws/class/production/content_publisher_db_admin.yaml
+++ b/hieradata_aws/class/production/content_publisher_db_admin.yaml
@@ -1,13 +1,13 @@
-# govuk_env_sync::tasks:
-#   "push_content_publisher_production_daily":
-#     ensure: "present"
-#     hour: "23"
-#     minute: "0"
-#     action: "push"
-#     dbms: "postgresql"
-#     storagebackend: "s3"
-#     database: "content_publisher_production"
-#     database_hostname: "content-publisher-postgres"
-#     temppath: "/tmp/content_publisher_production"
-#     url: "govuk-production-database-backups"
-#     path: "content-publisher-postgres"
+govuk_env_sync::tasks:
+  "push_content_publisher_production_daily":
+    ensure: "present"
+    hour: "23"
+    minute: "0"
+    action: "push"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "content_publisher_production"
+    database_hostname: "content-publisher-postgres"
+    temppath: "/tmp/content_publisher_production"
+    url: "govuk-production-database-backups"
+    path: "content-publisher-postgres"

--- a/hieradata_aws/class/production/db_admin.yaml
+++ b/hieradata_aws/class/production/db_admin.yaml
@@ -73,8 +73,9 @@ govuk_env_sync::tasks:
     temppath: "/tmp/content_data_admin_production_push"
     url: "govuk-production-database-backups"
     path: "postgresql-backend"
+  # TODO: remove this rule once it's been run on target machines
   "push_content_publisher_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "0"
     minute: "45"
     action: "push"
@@ -85,8 +86,9 @@ govuk_env_sync::tasks:
     temppath: "/tmp/content_publisher_production"
     url: "govuk-production-database-backups"
     path: "postgresql-backend"
+  # TODO: remove this rule once it's been run on target machines
   "pull_content_publisher_production_daily":
-    ensure: "disabled"
+    ensure: "absent"
     hour: "2"
     minute: "00"
     action: "pull"

--- a/hieradata_aws/class/staging/backend.yaml
+++ b/hieradata_aws/class/staging/backend.yaml
@@ -36,7 +36,6 @@ govuk::apps::travel_advice_publisher::mongodb_nodes:
 govuk::apps::travel_advice_publisher::mongodb_username: "%{hiera('shared_documentdb_user')}"
 govuk::apps::travel_advice_publisher::mongodb_password: "%{hiera('shared_documentdb_password')}"
 
-govuk::apps::content_publisher::db_hostname: "content-publisher-postgres"
 govuk::apps::content_tagger::db_hostname: "content-tagger-postgres"
 govuk::apps::link_checker_api::db_hostname: "link-checker-api-postgres"
 govuk::apps::local_links_manager::db_hostname: "local-links-manager-postgres"

--- a/hieradata_aws/class/staging/content_publisher_db_admin.yaml
+++ b/hieradata_aws/class/staging/content_publisher_db_admin.yaml
@@ -1,6 +1,7 @@
 govuk_env_sync::tasks:
   "pull_content_publisher_production_daily":
-    ensure: "present"
+    # Temporarily disabled due to issues restoring Postgres 13 databases (https://trello.com/c/9tdzkMIG)
+    ensure: "disabled"
     hour: "0"
     minute: "0"
     action: "pull"
@@ -10,7 +11,7 @@ govuk_env_sync::tasks:
     database_hostname: "content-publisher-postgres"
     temppath: "/tmp/content_publisher_production"
     url: "govuk-production-database-backups"
-    path: "postgresql-backend"
+    path: "content-publisher-postgres"
   "push_content_publisher_production_daily":
     ensure: "present"
     hour: "5"

--- a/hieradata_aws/class/staging/db_admin.yaml
+++ b/hieradata_aws/class/staging/db_admin.yaml
@@ -61,8 +61,9 @@ govuk_env_sync::tasks:
     temppath: "/tmp/content_data_admin_production_push"
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
+  # TODO: remove this rule once it's been run on target machines
   "push_content_publisher_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "2"
     minute: "45"
     action: "push"
@@ -133,8 +134,9 @@ govuk_env_sync::tasks:
     temppath: "/tmp/service-manual-publisher_production"
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
+  # TODO: remove this rule once it's been run on target machines
   "pull_content_publisher_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "1"
     minute: "45"
     action: "pull"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -501,9 +501,7 @@ govuk::apps::content_data_api::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::content_data_api::db_name: "content_performance_manager_production"
 govuk::apps::content_data_api::db_username: "content_performance_manager"
 
-# TODO: switch to "content-publisher-postgresql" and uncomment the 'push'
-# `govuk_env_sync::tasks` tasks when we're ready to switch to the dedicated RDS instance
-govuk::apps::content_publisher::db_hostname: "postgresql-primary"
+govuk::apps::content_publisher::db_hostname: "content-publisher-postgres"
 govuk::apps::content_publisher::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 govuk::apps::content_publisher::db::allow_auth_from_lb: true
 govuk::apps::content_publisher::db::lb_ip_range: "%{hiera('environment_ip_prefix')}.0.0/16"

--- a/modules/govuk/manifests/node/s_db_admin.pp
+++ b/modules/govuk/manifests/node/s_db_admin.pp
@@ -85,7 +85,6 @@ class govuk::node::s_db_admin(
 
   # include all PostgreSQL classes that create databases and users
   -> class { '::govuk::apps::ckan::db': }
-  -> class { '::govuk::apps::content_publisher::db': }
   -> class { '::govuk::apps::content_tagger::db': }
   -> class { '::govuk::apps::link_checker_api::db': }
   -> class { '::govuk::apps::local_links_manager::db': }


### PR DESCRIPTION
This is opened as a draft PR it is intended to be merged in as part of the production DB upgrade.

This updates the db hostname, sets up the env sync config for the new Content Publisher RDS instance and removes the previous config from the main DB Admin instance.

Trello: https://trello.com/c/st7HeiYK/60-plan-production-upgrade-for-small-postgresql-databases