### PR TITLE
Content Tagger post-DB switch configuration changes on prod 

### DIFF
--- a/hieradata_aws/class/integration/backend.yaml
+++ b/hieradata_aws/class/integration/backend.yaml
@@ -38,7 +38,6 @@ govuk::apps::travel_advice_publisher::mongodb_password: "%{hiera('shared_documen
 
 govuk::apps::collections_publisher::db_hostname: "collections-publisher-mysql"
 govuk::apps::contacts::db_hostname: "contacts-admin-mysql"
-govuk::apps::content_tagger::db_hostname: "content-tagger-postgres"
 govuk::apps::link_checker_api::db_hostname: "link-checker-api-postgres"
 govuk::apps::local_links_manager::db_hostname: "local-links-manager-postgres"
 govuk::apps::release::db_hostname: "release-mysql"

--- a/hieradata_aws/class/integration/content_tagger_db_admin.yaml
+++ b/hieradata_aws/class/integration/content_tagger_db_admin.yaml
@@ -1,6 +1,7 @@
 govuk_env_sync::tasks:
   "pull_content_tagger_production_daily":
-    ensure: "present"
+   # Temporarily disabled due to issues restoring Postgres 13 databases (https://trello.com/c/9tdzkMIG)
+    ensure: "disabled"
     hour: "0"
     minute: "0"
     action: "pull"
@@ -10,7 +11,7 @@ govuk_env_sync::tasks:
     database_hostname: "content-tagger-postgres"
     temppath: "/tmp/content_tagger_production"
     url: "govuk-production-database-backups"
-    path: "postgresql-backend"
+    path: "content-tagger-postgres"
   "push_content_tagger_production_daily":
     ensure: "present"
     hour: "5"

--- a/hieradata_aws/class/integration/db_admin.yaml
+++ b/hieradata_aws/class/integration/db_admin.yaml
@@ -348,7 +348,8 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "pull_content_tagger_production_daily":
-    ensure: "present"
+   # TODO: remove this rule once it's been run on target machines
+    ensure: "absent"
     hour: "3"
     minute: "0"
     action: "pull"
@@ -360,7 +361,8 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "push_content_tagger_production_integration_daily":
-    ensure: "present"
+   # TODO: remove this rule once it's been run on target machines
+    ensure: "absent"
     hour: "3"
     minute: "30"
     action: "push"

--- a/hieradata_aws/class/production/content_tagger_db_admin.yaml
+++ b/hieradata_aws/class/production/content_tagger_db_admin.yaml
@@ -1,13 +1,13 @@
-# govuk_env_sync::tasks:
-#   "push_content_tagger_production_daily":
-#     ensure: "present"
-#     hour: "23"
-#     minute: "0"
-#     action: "push"
-#     dbms: "postgresql"
-#     storagebackend: "s3"
-#     database: "content_tagger_production"
-#     database_hostname: "content-tagger-postgres"
-#     temppath: "/tmp/content_tagger_production"
-#     url: "govuk-production-database-backups"
-#     path: "content-tagger-postgres"
+govuk_env_sync::tasks:
+  "push_content_tagger_production_daily":
+    ensure: "present"
+    hour: "23"
+    minute: "0"
+    action: "push"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "content_tagger_production"
+    database_hostname: "content-tagger-postgres"
+    temppath: "/tmp/content_tagger_production"
+    url: "govuk-production-database-backups"
+    path: "content-tagger-postgres"

--- a/hieradata_aws/class/production/db_admin.yaml
+++ b/hieradata_aws/class/production/db_admin.yaml
@@ -100,7 +100,8 @@ govuk_env_sync::tasks:
     url: "govuk-production-database-backups"
     path: "postgresql-backend"
   "push_content_tagger_production_daily":
-    ensure: "present"
+   # TODO: remove this rule once it's been run on target machines
+    ensure: "absent"
     hour: "0"
     minute: "6"
     action: "push"
@@ -112,7 +113,8 @@ govuk_env_sync::tasks:
     url: "govuk-production-database-backups"
     path: "postgresql-backend"
   "pull_content_tagger_production_daily":
-    ensure: "disabled"
+   # TODO: remove this rule once it's been run on target machines
+    ensure: "absent"
     hour: "1"
     minute: "30"
     action: "pull"

--- a/hieradata_aws/class/staging/backend.yaml
+++ b/hieradata_aws/class/staging/backend.yaml
@@ -36,7 +36,6 @@ govuk::apps::travel_advice_publisher::mongodb_nodes:
 govuk::apps::travel_advice_publisher::mongodb_username: "%{hiera('shared_documentdb_user')}"
 govuk::apps::travel_advice_publisher::mongodb_password: "%{hiera('shared_documentdb_password')}"
 
-govuk::apps::content_tagger::db_hostname: "content-tagger-postgres"
 govuk::apps::link_checker_api::db_hostname: "link-checker-api-postgres"
 govuk::apps::local_links_manager::db_hostname: "local-links-manager-postgres"
 govuk::apps::service_manual_publisher::db_hostname: "service-manual-publisher-postgres"

--- a/hieradata_aws/class/staging/content_tagger_db_admin.yaml
+++ b/hieradata_aws/class/staging/content_tagger_db_admin.yaml
@@ -1,6 +1,7 @@
 govuk_env_sync::tasks:
   "pull_content_tagger_production_daily":
-    ensure: "present"
+   # Temporarily disabled due to issues restoring Postgres 13 databases (https://trello.com/c/9tdzkMIG)
+    ensure: "disabled"
     hour: "0"
     minute: "0"
     action: "pull"
@@ -10,7 +11,7 @@ govuk_env_sync::tasks:
     database_hostname: "content-tagger-postgres"
     temppath: "/tmp/content_tagger_production"
     url: "govuk-production-database-backups"
-    path: "postgresql-backend"
+    path: "content-tagger-postgres"
   "push_content_tagger_production_daily":
     ensure: "present"
     hour: "5"

--- a/hieradata_aws/class/staging/db_admin.yaml
+++ b/hieradata_aws/class/staging/db_admin.yaml
@@ -75,7 +75,8 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "pull_content_tagger_production_daily":
-    ensure: "present"
+   # TODO: remove this rule once it's been run on target machines
+    ensure: "absent"
     hour: "2"
     minute: "7"
     action: "pull"
@@ -87,7 +88,8 @@ govuk_env_sync::tasks:
     url: "govuk-production-database-backups"
     path: "postgresql-backend"
   "push_content_tagger_production_daily":
-    ensure: "present"
+   # TODO: remove this rule once it's been run on target machines
+    ensure: "absent"
     hour: "2"
     minute: "30"
     action: "push"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -513,9 +513,7 @@ govuk::apps::content_publisher::redis_port: "%{hiera('sidekiq_port')}"
 
 govuk::apps::content_store::unicorn_worker_processes: "15"
 
-# TODO: switch to "content-tagger-postgresql" and uncomment the 'push'
-# `govuk_env_sync::tasks` tasks when we're ready to switch to the dedicated RDS instance
-govuk::apps::content_tagger::db_hostname: "postgresql-primary"
+govuk::apps::content_tagger::db_hostname: "content-tagger-postgres"
 govuk::apps::content_tagger::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 govuk::apps::content_tagger::db::allow_auth_from_lb: true
 govuk::apps::content_tagger::db::lb_ip_range: "%{hiera('environment_ip_prefix')}.0.0/16"

--- a/modules/govuk/manifests/node/s_db_admin.pp
+++ b/modules/govuk/manifests/node/s_db_admin.pp
@@ -85,7 +85,6 @@ class govuk::node::s_db_admin(
 
   # include all PostgreSQL classes that create databases and users
   -> class { '::govuk::apps::ckan::db': }
-  -> class { '::govuk::apps::content_tagger::db': }
   -> class { '::govuk::apps::link_checker_api::db': }
   -> class { '::govuk::apps::local_links_manager::db': }
   -> class { '::govuk::apps::service_manual_publisher::db': }


### PR DESCRIPTION
This is opened as a draft PR it is intended to be merged in as part of the production DB upgrade.

This updates the db hostname, sets up the env sync config for the new Content Tagger RDS instance and removes the previous config from the main DB Admin instance.

Trello: https://trello.com/c/st7HeiYK/60-plan-production-upgrade-for-small-postgresql-databases