### PR TITLE
Local Links Manager post-DB switch configuration changes on prod 

### DIFF
--- a/hieradata_aws/class/integration/backend.yaml
+++ b/hieradata_aws/class/integration/backend.yaml
@@ -38,7 +38,6 @@ govuk::apps::travel_advice_publisher::mongodb_password: "%{hiera('shared_documen
 
 govuk::apps::collections_publisher::db_hostname: "collections-publisher-mysql"
 govuk::apps::contacts::db_hostname: "contacts-admin-mysql"
-govuk::apps::local_links_manager::db_hostname: "local-links-manager-postgres"
 govuk::apps::release::db_hostname: "release-mysql"
 govuk::apps::search_admin::db_hostname: "search-admin-mysql"
 govuk::apps::service_manual_publisher::db_hostname: "service-manual-publisher-postgres"

--- a/hieradata_aws/class/integration/db_admin.yaml
+++ b/hieradata_aws/class/integration/db_admin.yaml
@@ -26,7 +26,7 @@ govuk_env_sync::tasks:
     url: "govuk-integration-database-backups"
     path: "postgresql-backend"
   "pull_local-links-manager_staging_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "5"
     minute: "00"
     action: "pull"
@@ -37,8 +37,9 @@ govuk_env_sync::tasks:
     temppath: "/tmp/local-links-manager_integration"
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
+  # TODO: remove this rule once it's been run on target machines
   "push_local-links-manager_integration_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "6"
     minute: "00"
     action: "push"

--- a/hieradata_aws/class/integration/local_links_manager_db_admin.yaml
+++ b/hieradata_aws/class/integration/local_links_manager_db_admin.yaml
@@ -1,6 +1,7 @@
 govuk_env_sync::tasks:
   "pull_local_links_manager_production_daily":
-    ensure: "present"
+    # Temporarily disabled due to issues restoring Postgres 13 databases (https://trello.com/c/9tdzkMIG)
+    ensure: "disabled"
     hour: "0"
     minute: "0"
     action: "pull"
@@ -10,7 +11,7 @@ govuk_env_sync::tasks:
     database_hostname: "local-links-manager-postgres"
     temppath: "/tmp/local_links_manager_production"
     url: "govuk-production-database-backups"
-    path: "postgresql-backend"
+    path: "local-links-manager-postgres"
   "push_local_links_manager_production_daily":
     ensure: "present"
     hour: "5"

--- a/hieradata_aws/class/production/db_admin.yaml
+++ b/hieradata_aws/class/production/db_admin.yaml
@@ -147,8 +147,9 @@ govuk_env_sync::tasks:
     temppath: "/tmp/govuk_content_production"
     url: "govuk-production-database-backups"
     path: "mongo-normal"
+  # TODO: remove this rule once it's been run on target machines
   "push_local-links-manager_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "3"
     minute: "0"
     action: "push"

--- a/hieradata_aws/class/production/local_links_manager_db_admin.yaml
+++ b/hieradata_aws/class/production/local_links_manager_db_admin.yaml
@@ -1,13 +1,13 @@
-# govuk_env_sync::tasks:
-#   "push_local_links_manager_production_daily":
-#     ensure: "present"
-#     hour: "23"
-#     minute: "0"
-#     action: "push"
-#     dbms: "postgresql"
-#     storagebackend: "s3"
-#     database: "local-links-manager_production"
-#     database_hostname: "local-links-manager-postgres"
-#     temppath: "/tmp/local_links_manager_production"
-#     url: "govuk-production-database-backups"
-#     path: "local-links-manager-postgres"
+govuk_env_sync::tasks:
+  "push_local_links_manager_production_daily":
+    ensure: "present"
+    hour: "23"
+    minute: "0"
+    action: "push"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "local-links-manager_production"
+    database_hostname: "local-links-manager-postgres"
+    temppath: "/tmp/local_links_manager_production"
+    url: "govuk-production-database-backups"
+    path: "local-links-manager-postgres"

--- a/hieradata_aws/class/staging/backend.yaml
+++ b/hieradata_aws/class/staging/backend.yaml
@@ -36,5 +36,4 @@ govuk::apps::travel_advice_publisher::mongodb_nodes:
 govuk::apps::travel_advice_publisher::mongodb_username: "%{hiera('shared_documentdb_user')}"
 govuk::apps::travel_advice_publisher::mongodb_password: "%{hiera('shared_documentdb_password')}"
 
-govuk::apps::local_links_manager::db_hostname: "local-links-manager-postgres"
 govuk::apps::service_manual_publisher::db_hostname: "service-manual-publisher-postgres"

--- a/hieradata_aws/class/staging/db_admin.yaml
+++ b/hieradata_aws/class/staging/db_admin.yaml
@@ -12,8 +12,9 @@ govuk_env_sync::tasks:
     temppath: "/tmp/link_checker_api_production"
     url: "govuk-production-database-backups"
     path: "postgresql-backend"
+  # TODO: remove this rule once it's been run on target machines
   "pull_local-links-manager_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "3"
     minute: "30"
     action: "pull"
@@ -24,8 +25,9 @@ govuk_env_sync::tasks:
     temppath: "/tmp/local-links-manager_production"
     url: "govuk-production-database-backups"
     path: "postgresql-backend"
+  # TODO: remove this rule once it's been run on target machines
   "push_local-links-manager_staging_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "4"
     minute: "30"
     action: "push"

--- a/hieradata_aws/class/staging/local_links_manager_db_admin.yaml
+++ b/hieradata_aws/class/staging/local_links_manager_db_admin.yaml
@@ -1,6 +1,7 @@
 govuk_env_sync::tasks:
   "pull_local_links_manager_production_daily":
-    ensure: "present"
+    # Temporarily disabled due to issues restoring Postgres 13 databases (https://trello.com/c/9tdzkMIG)
+    ensure: "disabled"
     hour: "0"
     minute: "0"
     action: "pull"
@@ -10,7 +11,7 @@ govuk_env_sync::tasks:
     database_hostname: "local-links-manager-postgres"
     temppath: "/tmp/local_links_manager_production"
     url: "govuk-production-database-backups"
-    path: "postgresql-backend"
+    path: "local-links-manager-postgres"
   "push_local_links_manager_production_daily":
     ensure: "present"
     hour: "5"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -622,9 +622,7 @@ govuk::apps::imminence::unicorn_worker_processes: "8"
 
 govuk::apps::info_frontend::enabled: true
 
-# TODO: switch to "local-links-manager-postgresql" and uncomment the 'push'
-# `govuk_env_sync::tasks` tasks when we're ready to switch to the dedicated RDS instance
-govuk::apps::local_links_manager::db_hostname: "postgresql-primary"
+govuk::apps::local_links_manager::db_hostname: "local-links-manager-postgres"
 govuk::apps::local_links_manager::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 govuk::apps::local_links_manager::db::allow_auth_from_lb: true
 govuk::apps::local_links_manager::db::lb_ip_range: "%{hiera('environment_ip_prefix')}.0.0/16"

--- a/modules/govuk/manifests/node/s_db_admin.pp
+++ b/modules/govuk/manifests/node/s_db_admin.pp
@@ -85,7 +85,6 @@ class govuk::node::s_db_admin(
 
   # include all PostgreSQL classes that create databases and users
   -> class { '::govuk::apps::ckan::db': }
-  -> class { '::govuk::apps::local_links_manager::db': }
   -> class { '::govuk::apps::service_manual_publisher::db': }
   -> class { '::govuk::apps::support_api::db': }
 }


### PR DESCRIPTION
This is opened as a draft PR it is intended to be merged in as part of the production DB upgrade.

This updates the db hostname, sets up the env sync config for the new Local Links Manager RDS instance and removes the previous config from the main DB Admin instance.

Trello: https://trello.com/c/st7HeiYK/60-plan-production-upgrade-for-small-postgresql-databases