### PR TITLE
Remove Publishing API env sync tasks from DB Admin

### DIFF
--- a/hieradata_aws/class/integration/db_admin.yaml
+++ b/hieradata_aws/class/integration/db_admin.yaml
@@ -132,19 +132,6 @@ govuk_env_sync::tasks:
     temppath: "/tmp/organisations-publisher_production"
     url: "govuk-integration-database-backups"
     path: "postgresql-backend"
-  # TODO: remove this rule once it's been run on target machines
-  "push_publishing_api_integration_daily":
-    ensure: "absent"
-    hour: "4"
-    minute: "30"
-    action: "push"
-    dbms: "postgresql"
-    storagebackend: "s3"
-    database: "publishing_api_production"
-    database_hostname: "postgresql-primary"
-    temppath: "/tmp/publishing_api_production"
-    url: "govuk-integration-database-backups"
-    path: "postgresql-backend"
   "push_service_manual_publisher_integration_daily":
     ensure: "present"
     hour: "2"
@@ -261,20 +248,6 @@ govuk_env_sync::tasks:
     database: "licensify-refdata"
     hour: "6"
     minute: "30"
-  # TODO: remove this rule once it's been run on target machines
-  "pull_publishing_api_production_daily":
-    ensure: "absent"
-    hour: "2"
-    minute: "40"
-    action: "pull"
-    dbms: "postgresql"
-    storagebackend: "s3"
-    database: "publishing_api_production"
-    database_hostname: "postgresql-primary"
-    temppath: "/tmp/publishing_api_production"
-    url: "govuk-production-database-backups"
-    path: "postgresql-backend"
-    transformation_sql_filename: "sanitise_publishing_api_production.sql"
   "pull_govuk_assets_production":
     ensure: "present"
     hour: "3"

--- a/hieradata_aws/class/production/db_admin.yaml
+++ b/hieradata_aws/class/production/db_admin.yaml
@@ -165,19 +165,6 @@ govuk_env_sync::tasks:
     temppath: "/tmp/local-links-manager_production"
     url: "govuk-production-database-backups"
     path: "postgresql-backend"
-  # TODO: remove this rule once it's been run on target machines
-  "push_publishing_api_production_daily":
-    ensure: "absent"
-    hour: "2"
-    minute: "00"
-    action: "push"
-    dbms: "postgresql"
-    storagebackend: "s3"
-    database: "publishing_api_production"
-    database_hostname: "postgresql-primary"
-    temppath: "/tmp/publishing_api_production"
-    url: "govuk-production-database-backups"
-    path: "postgresql-backend"
   "push_whitehall_production_daily":
     ensure: "present"
     hour: "1"
@@ -427,19 +414,6 @@ govuk_env_sync::tasks:
     temppath: "/tmp/whitehall_production"
     url: "govuk-production-database-backups"
     path: "mysql"
-  # TODO: remove this rule once it's been run on target machines
-  "pull_publishing_api_production":
-    ensure: "absent"
-    hour: "0"
-    minute: "00"
-    action: "pull"
-    dbms: "postgresql"
-    database_hostname: "postgresql-primary"
-    storagebackend: "s3"
-    database: "publishing_api_production"
-    temppath: "/tmp/publishing_api_production"
-    url: "govuk-production-database-backups"
-    path: "postgresql-backend"
   "pull_release_production":
     ensure: "disabled"
     hour: "0"

--- a/hieradata_aws/class/staging/db_admin.yaml
+++ b/hieradata_aws/class/staging/db_admin.yaml
@@ -107,19 +107,6 @@ govuk_env_sync::tasks:
     temppath: "/tmp/email-alert-api_production"
     url: "govuk-production-database-backups"
     path: "postgresql-backend"
-  # TODO: remove this rule once it's been run on target machines
-  "pull_publishing_api_production_daily":
-    ensure: "absent"
-    hour: "3"
-    minute: "45"
-    action: "pull"
-    dbms: "postgresql"
-    storagebackend: "s3"
-    database: "publishing_api_production"
-    database_hostname: "postgresql-primary"
-    temppath: "/tmp/publishing_api_production"
-    url: "govuk-production-database-backups"
-    path: "postgresql-backend"
   "pull_support_contacts_production_daily":
     ensure: "present"
     hour: "2"


### PR DESCRIPTION
Trello: https://trello.com/c/yxkJl7Tv/84-do-production-and-staging-upgrade-for-publishing-api

Follow up from: https://github.com/alphagov/govuk-puppet/pull/11420. I'll mark this as Do Not Merge until Puppet has run in production

This is to remove the configuration for these tasks once Puppet has been
run in their environment.