### PR TITLE
Disable Transition env-sync pull processes for Postgres 13

### DIFF
--- a/hieradata_aws/class/integration/transition_db_admin.yaml
+++ b/hieradata_aws/class/integration/transition_db_admin.yaml
@@ -12,7 +12,8 @@ govuk_env_sync::tasks:
     url: "govuk-integration-database-backups"
     path: "transition-postgresql"
   "pull_transition_integration_daily":
-    ensure: "present"
+    # Temporarily disabled due to issues restoring Postgres 13 databases (https://trello.com/c/9tdzkMIG)
+    ensure: "disabled"
     hour: "6"
     minute: "0"
     action: "pull"

--- a/hieradata_aws/class/staging/transition_db_admin.yaml
+++ b/hieradata_aws/class/staging/transition_db_admin.yaml
@@ -1,6 +1,7 @@
 govuk_env_sync::tasks:
   "pull_transition_production_daily":
-    ensure: "present"
+    # Temporarily disabled due to issues restoring Postgres 13 databases (https://trello.com/c/9tdzkMIG)
+    ensure: "disabled"
     hour: "4"
     minute: "30"
     action: "pull"


### PR DESCRIPTION
This has been put in place so the env sync process doesn't delete the
database each night and cause errors.

Should be removed following: https://trello.com/c/9tdzkMIG