### PR TITLE
Disable Email Alert API staging syncing

### DIFF
--- a/hieradata_aws/class/staging/db_admin.yaml
+++ b/hieradata_aws/class/staging/db_admin.yaml
@@ -96,7 +96,8 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
   "pull_email_alert_api_production_daily":
-    ensure: "present"
+    # Temporarily disabled for migration to Postgres 13
+    ensure: "disabled"
     hour: "1"
     minute: "30"
     action: "pull"

--- a/hieradata_aws/class/staging/email_alert_api_db_admin.yaml
+++ b/hieradata_aws/class/staging/email_alert_api_db_admin.yaml
@@ -1,6 +1,7 @@
 govuk_env_sync::tasks:
   "pull_email_alert_api_production_daily":
-    ensure: "present"
+    # Temporarily disabled for migration to Postgres 13
+    ensure: "disabled"
     hour: "0"
     minute: "0"
     action: "pull"


### PR DESCRIPTION
Trello: https://trello.com/c/9ltcpegV/90-do-production-and-staging-upgrade-for-email-alert-api

This has been disabled so that this database can be migrated overnight.