### PR TITLE
Remove env sync tasks for Email Alert API on DB Admin

### DIFF
--- a/hieradata_aws/class/integration/db_admin.yaml
+++ b/hieradata_aws/class/integration/db_admin.yaml
@@ -23,20 +23,6 @@ govuk_env_sync::tasks:
     temppath: "/tmp/content_data_admin_production_push"
     url: "govuk-integration-database-backups"
     path: "postgresql-backend"
-  # TODO: remove this rule once it's been run on target machines
-  "pull_email_alert_api_production_daily":
-    ensure: "absent"
-    hour: "1"
-    minute: "30"
-    action: "pull"
-    dbms: "postgresql"
-    storagebackend: "s3"
-    database: "email-alert-api_production"
-    database_hostname: "postgresql-primary"
-    temppath: "/tmp/email-alert-api_production"
-    url: "govuk-production-database-backups"
-    path: "postgresql-backend"
-    transformation_sql_filename: "anonymise_email_addresses.sql"
   "pull_local-links-manager_staging_daily":
     ensure: "present"
     hour: "5"
@@ -95,19 +81,6 @@ govuk_env_sync::tasks:
     database: "content-register_production"
     database_hostname: "postgresql-primary"
     temppath: "/tmp/content-register_production"
-    url: "govuk-integration-database-backups"
-    path: "postgresql-backend"
-  # TODO: remove this rule once it's been run on target machines
-  "push_email_alert_api_integration_daily":
-    ensure: "absent"
-    hour: "4"
-    minute: "15"
-    action: "push"
-    dbms: "postgresql"
-    storagebackend: "s3"
-    database: "email-alert-api_production"
-    database_hostname: "postgresql-primary"
-    temppath: "/tmp/email-alert-api_production"
     url: "govuk-integration-database-backups"
     path: "postgresql-backend"
   "push_email_alert_monitor_integration_daily":

--- a/hieradata_aws/class/production/db_admin.yaml
+++ b/hieradata_aws/class/production/db_admin.yaml
@@ -119,19 +119,6 @@ govuk_env_sync::tasks:
     temppath: "/tmp/content_tagger_production"
     url: "govuk-production-database-backups"
     path: "postgresql-backend"
-  # TODO: remove this rule once it's been run on target machines
-  "push_email_alert_api_production_daily":
-    ensure: "absent"
-    hour: "23"
-    minute: "00"
-    action: "push"
-    dbms: "postgresql"
-    storagebackend: "s3"
-    database: "email-alert-api_production"
-    database_hostname: "postgresql-primary"
-    temppath: "/tmp/email-alert-api_production"
-    url: "govuk-production-database-backups"
-    path: "postgresql-backend"
   "push_govuk_assets_production":
     ensure: "present"
     hour: "1"
@@ -358,19 +345,6 @@ govuk_env_sync::tasks:
     temppath: "/tmp/release_production"
     url: "govuk-production-database-backups"
     path: "mysql"
-  # TODO: remove this rule once it's been run on target machines
-  "pull_email_alert_api_production":
-    ensure: "absent"
-    hour: "0"
-    minute: "00"
-    action: "pull"
-    dbms: "postgresql"
-    storagebackend: "s3"
-    database: "email-alert-api_production"
-    database_hostname: "postgresql-primary"
-    temppath: "/tmp/email-alert-api_production"
-    url: "govuk-production-database-backups"
-    path: "postgresql-backend"
   # The pull_*_production configs below are not run automatically. The
   # ensure:disabled means that they are present on the db_admin machine but
   # without crontab entries. This allows for manual restores when needed.

--- a/hieradata_aws/class/staging/db_admin.yaml
+++ b/hieradata_aws/class/staging/db_admin.yaml
@@ -95,19 +95,6 @@ govuk_env_sync::tasks:
     temppath: "/tmp/content_tagger_production"
     url: "govuk-staging-database-backups"
     path: "postgresql-backend"
-  # TODO: remove this rule once it's been run on target machines
-  "pull_email_alert_api_production_daily":
-    ensure: "absent"
-    hour: "1"
-    minute: "30"
-    action: "pull"
-    dbms: "postgresql"
-    storagebackend: "s3"
-    database: "email-alert-api_production"
-    database_hostname: "postgresql-primary"
-    temppath: "/tmp/email-alert-api_production"
-    url: "govuk-production-database-backups"
-    path: "postgresql-backend"
   "pull_support_contacts_production_daily":
     ensure: "present"
     hour: "2"


### PR DESCRIPTION
Trello: https://trello.com/c/9ltcpegV/90-do-production-and-staging-upgrade-for-email-alert-api

This follows on from: https://github.com/alphagov/govuk-puppet/pull/11411

This removes the config that has been deleted from our DB Admin boxes.