### PR TITLE
Support API use dedicated RDS instance in staging

### DIFF
--- a/hieradata_aws/class/staging/backend.yaml
+++ b/hieradata_aws/class/staging/backend.yaml
@@ -35,3 +35,5 @@ govuk::apps::travel_advice_publisher::mongodb_nodes:
   - 'shared-documentdb'
 govuk::apps::travel_advice_publisher::mongodb_username: "%{hiera('shared_documentdb_user')}"
 govuk::apps::travel_advice_publisher::mongodb_password: "%{hiera('shared_documentdb_password')}"
+
+govuk::apps::support_api::db_hostname: "support-api-postgres"


### PR DESCRIPTION
This changes the db hostname so the Support API application will use
the new instance in the staging environment.

Trello: https://trello.com/c/sX5WXAJZ/65-plan-production-upgrade-for-support-api-postgresql-database