### PR TITLE
Remove absent jobs post DB upgrade

### DIFF
--- a/hieradata_aws/class/integration/db_admin.yaml
+++ b/hieradata_aws/class/integration/db_admin.yaml
@@ -234,19 +234,6 @@ govuk_env_sync::tasks:
     temppath: "/tmp/search_admin_production"
     url: "govuk-integration-database-backups"
     path: "mysql"
-  # TODO: remove this rule once it's been run on target machines
-  "pull_service-manual-publisher_staging":
-    ensure: "absent"
-    hour: "2"
-    minute: "55"
-    action: "pull"
-    dbms: "postgresql"
-    storagebackend: "s3"
-    database: "service-manual-publisher_production"
-    database_hostname: "postgresql-primary"
-    temppath: "/tmp/service-manual-publisher_production"
-    url: "govuk-staging-database-backups"
-    path: "postgresql-backend"
   "pull_maslow_production":
     ensure: "present"
     hour: "2"

--- a/hieradata_aws/class/production/db_admin.yaml
+++ b/hieradata_aws/class/production/db_admin.yaml
@@ -1,17 +1,4 @@
 govuk_env_sync::tasks:
-  # TODO: remove this rule once it's been run on target machines
-  "push_account_api_production_daily":
-    ensure: "absent"
-    hour: "0"
-    minute: "52"
-    action: "push"
-    dbms: "postgresql"
-    storagebackend: "s3"
-    database: "account-api_production"
-    database_hostname: "postgresql-primary"
-    temppath: "/tmp/account-api_production"
-    url: "govuk-production-database-backups"
-    path: "postgresql-backend"
   "push_collections_publisher_production_daily":
     ensure: "present"
     hour: "0"

--- a/hieradata_aws/class/staging/db_admin.yaml
+++ b/hieradata_aws/class/staging/db_admin.yaml
@@ -11,19 +11,6 @@ govuk_env_sync::tasks:
     temppath: "/tmp/support_contacts_production"
     url: "govuk-production-database-backups"
     path: "postgresql-backend"
-  # TODO: remove this rule once it's been run on target machines
-  "push_content_publisher_production_daily":
-    ensure: "absent"
-    hour: "2"
-    minute: "45"
-    action: "push"
-    dbms: "postgresql"
-    storagebackend: "s3"
-    database: "content_publisher_production"
-    database_hostname: "postgresql-primary"
-    temppath: "/tmp/content_publisher_production"
-    url: "govuk-staging-database-backups"
-    path: "postgresql-backend"
   "pull_licensify_production_daily": &pull_licensify
     ensure: "present"
     hour: "4"


### PR DESCRIPTION
Now puppet has run on each environment and marked each job as absent, we are able to remove the push/pull env sync jobs from the db_admin files. These jobs were marked as absent and can now be removed.