### PR TITLE
Mark env sync pull jobs as present for small postgres DBs

### DIFF
--- a/hieradata_aws/class/integration/content_data_admin_db_admin.yaml
+++ b/hieradata_aws/class/integration/content_data_admin_db_admin.yaml
@@ -1,7 +1,6 @@
 govuk_env_sync::tasks:
   "pull_content_data_admin_production_daily":
-  # Temporarily disabled due to issues restoring Postgres 13 databases (https://trello.com/c/9tdzkMIG)
-    ensure: "disabled"
+    ensure: "present"
     hour: "0"
     minute: "0"
     action: "pull"

--- a/hieradata_aws/class/integration/content_publisher_db_admin.yaml
+++ b/hieradata_aws/class/integration/content_publisher_db_admin.yaml
@@ -1,7 +1,6 @@
 govuk_env_sync::tasks:
   "pull_content_publisher_production_daily":
-    # Temporarily disabled due to issues restoring Postgres 13 databases (https://trello.com/c/9tdzkMIG)
-    ensure: "disabled"
+    ensure: "present"
     hour: "0"
     minute: "0"
     action: "pull"

--- a/hieradata_aws/class/integration/content_tagger_db_admin.yaml
+++ b/hieradata_aws/class/integration/content_tagger_db_admin.yaml
@@ -1,7 +1,6 @@
 govuk_env_sync::tasks:
   "pull_content_tagger_production_daily":
-   # Temporarily disabled due to issues restoring Postgres 13 databases (https://trello.com/c/9tdzkMIG)
-    ensure: "disabled"
+    ensure: "present"
     hour: "0"
     minute: "0"
     action: "pull"

--- a/hieradata_aws/class/integration/link_checker_api_db_admin.yaml
+++ b/hieradata_aws/class/integration/link_checker_api_db_admin.yaml
@@ -1,7 +1,6 @@
 govuk_env_sync::tasks:
   "pull_link_checker_api_production_daily":
-    # Temporarily disabled due to issues restoring Postgres 13 databases (https://trello.com/c/9tdzkMIG)
-    ensure: "disabled"
+    ensure: "present"
     hour: "0"
     minute: "0"
     action: "pull"

--- a/hieradata_aws/class/integration/local_links_manager_db_admin.yaml
+++ b/hieradata_aws/class/integration/local_links_manager_db_admin.yaml
@@ -1,7 +1,6 @@
 govuk_env_sync::tasks:
   "pull_local_links_manager_production_daily":
-    # Temporarily disabled due to issues restoring Postgres 13 databases (https://trello.com/c/9tdzkMIG)
-    ensure: "disabled"
+    ensure: "present"
     hour: "0"
     minute: "0"
     action: "pull"

--- a/hieradata_aws/class/integration/service_manual_publisher_db_admin.yaml
+++ b/hieradata_aws/class/integration/service_manual_publisher_db_admin.yaml
@@ -1,7 +1,6 @@
 govuk_env_sync::tasks:
   "pull_service_manual_publisher_production_daily":
-    # Temporarily disabled due to issues restoring Postgres 13 databases (https://trello.com/c/9tdzkMIG)
-    ensure: "disabled"
+    ensure: "present"
     hour: "0"
     minute: "0"
     action: "pull"

--- a/hieradata_aws/class/staging/content_data_admin_db_admin.yaml
+++ b/hieradata_aws/class/staging/content_data_admin_db_admin.yaml
@@ -1,7 +1,6 @@
 govuk_env_sync::tasks:
   "pull_content_data_admin_production_daily":
-    # Temporarily disabled due to issues restoring Postgres 13 databases (https://trello.com/c/9tdzkMIG)
-    ensure: "disabled"
+    ensure: "present"
     hour: "0"
     minute: "0"
     action: "pull"

--- a/hieradata_aws/class/staging/content_publisher_db_admin.yaml
+++ b/hieradata_aws/class/staging/content_publisher_db_admin.yaml
@@ -1,7 +1,6 @@
 govuk_env_sync::tasks:
   "pull_content_publisher_production_daily":
-    # Temporarily disabled due to issues restoring Postgres 13 databases (https://trello.com/c/9tdzkMIG)
-    ensure: "disabled"
+    ensure: "present"
     hour: "0"
     minute: "0"
     action: "pull"

--- a/hieradata_aws/class/staging/content_tagger_db_admin.yaml
+++ b/hieradata_aws/class/staging/content_tagger_db_admin.yaml
@@ -1,7 +1,6 @@
 govuk_env_sync::tasks:
   "pull_content_tagger_production_daily":
-   # Temporarily disabled due to issues restoring Postgres 13 databases (https://trello.com/c/9tdzkMIG)
-    ensure: "disabled"
+    ensure: "present"
     hour: "0"
     minute: "0"
     action: "pull"

--- a/hieradata_aws/class/staging/link_checker_api_db_admin.yaml
+++ b/hieradata_aws/class/staging/link_checker_api_db_admin.yaml
@@ -1,7 +1,6 @@
 govuk_env_sync::tasks:
   "pull_link_checker_api_production_daily":
-    # Temporarily disabled due to issues restoring Postgres 13 databases (https://trello.com/c/9tdzkMIG)
-    ensure: "disabled"
+    ensure: "present"
     hour: "0"
     minute: "0"
     action: "pull"

--- a/hieradata_aws/class/staging/local_links_manager_db_admin.yaml
+++ b/hieradata_aws/class/staging/local_links_manager_db_admin.yaml
@@ -1,7 +1,6 @@
 govuk_env_sync::tasks:
   "pull_local_links_manager_production_daily":
-    # Temporarily disabled due to issues restoring Postgres 13 databases (https://trello.com/c/9tdzkMIG)
-    ensure: "disabled"
+    ensure: "present"
     hour: "0"
     minute: "0"
     action: "pull"

--- a/hieradata_aws/class/staging/service_manual_publisher_db_admin.yaml
+++ b/hieradata_aws/class/staging/service_manual_publisher_db_admin.yaml
@@ -1,7 +1,6 @@
 govuk_env_sync::tasks:
   "pull_service_manual_publisher_production_daily":
-     # Temporarily disabled due to issues restoring Postgres 13 databases (https://trello.com/c/9tdzkMIG)
-    ensure: "disabled"
+    ensure: "present"
     hour: "0"
     minute: "0"
     action: "pull"


### PR DESCRIPTION
These jobs were disabled while the env sync was being fixed.

This PR should not be merged until https://trello.com/c/9tdzkMIG/ has been completed.