### PR TITLE
[DO NOT MERGE] Revert "Pause Content-data-api Database Sync"

### DIFF
--- a/hieradata_aws/class/integration/content_data_api_db_admin.yaml
+++ b/hieradata_aws/class/integration/content_data_api_db_admin.yaml
@@ -2,7 +2,7 @@ govuk_env_sync::tasks:
   # Use the new Content Data API name here, to avoid issues with
   # changing the name later
   "pull_content_data_api_production_daily":
-    ensure: "absent"
+    ensure: "present"
     hour: "0"
     minute: "0"
     action: "pull"

--- a/hieradata_aws/class/staging/content_data_api_db_admin.yaml
+++ b/hieradata_aws/class/staging/content_data_api_db_admin.yaml
@@ -2,7 +2,7 @@ govuk_env_sync::tasks:
   # Use the new Content Data API name here, to avoid issues with
   # changing the name later
   "pull_content_data_api_production_daily":
-    ensure: "absent"
+    ensure: "present"
     hour: "0"
     minute: "0"
     action: "pull"


### PR DESCRIPTION
Reverts alphagov/govuk-puppet#11415 after govuk_env_sync supports restoring Postgres 13.3

Ref:
1. [trello card](https://trello.com/c/jOAYUG1M/92-unpause-content-data-api-database-syncing-for-staging-and-integration)