### PR TITLE
Set build name for run_rake_task jobs

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/run_rake_task.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/run_rake_task.yaml.erb
@@ -14,6 +14,8 @@
     wrappers:
       - ansicolor:
           colormap: xterm
+      - build-name:
+          name: '#${BUILD_NUMBER}: ${ENV,var="TARGET_APPLICATION"} ${ENV,var="RAKE_TASK"}'
       - timestamps
     parameters:
       - choice:


### PR DESCRIPTION
Seeing only a build number makes it hard to distinguish and find the task to see output.