### PR TITLE
Configure support-api env sync jobs

### DIFF
--- a/hieradata_aws/class/integration/db_admin.yaml
+++ b/hieradata_aws/class/integration/db_admin.yaml
@@ -1,16 +1,4 @@
 govuk_env_sync::tasks:
-  "pull_support-contacts_integration_daily":
-    ensure: "absent"
-    hour: "1"
-    minute: "15"
-    action: "pull"
-    dbms: "postgresql"
-    storagebackend: "s3"
-    database: "support_contacts_production"
-    database_hostname: "postgresql-primary"
-    temppath: "/tmp/support-contacts_integration_daily"
-    url: "govuk-production-database-backups"
-    path: "postgresql-backend"
   "push_content-register_production_integration_daily":
     ensure: "present"
     hour: "1"
@@ -45,18 +33,6 @@ govuk_env_sync::tasks:
     database: "organisations-publisher_production"
     database_hostname: "postgresql-primary"
     temppath: "/tmp/organisations-publisher_production"
-    url: "govuk-integration-database-backups"
-    path: "postgresql-backend"
-  "push_support_contacts_integration_daily":
-    ensure: "absent"
-    hour: "2"
-    minute: "30"
-    action: "push"
-    dbms: "postgresql"
-    storagebackend: "s3"
-    database: "support_contacts_production"
-    database_hostname: "postgresql-primary"
-    temppath: "/tmp/support_contacts_production"
     url: "govuk-integration-database-backups"
     path: "postgresql-backend"
   "push_release_integration_daily":

--- a/hieradata_aws/class/integration/support_api_db_admin.yaml
+++ b/hieradata_aws/class/integration/support_api_db_admin.yaml
@@ -1,7 +1,6 @@
 govuk_env_sync::tasks:
   "pull_support_api_production_daily":
-    # Temporarily disabled due to issues restoring Postgres 13 databases (https://trello.com/c/9tdzkMIG)
-    ensure: "disabled"
+    ensure: "present"
     hour: "0"
     minute: "0"
     action: "pull"

--- a/hieradata_aws/class/production/db_admin.yaml
+++ b/hieradata_aws/class/production/db_admin.yaml
@@ -161,18 +161,6 @@ govuk_env_sync::tasks:
     temppath: "/tmp/signon_production"
     url: "govuk-production-database-backups"
     path: "mysql"
-  "push_support-contacts_production_daily":
-    ensure: "absent"
-    hour: "2"
-    minute: "30"
-    action: "push"
-    dbms: "postgresql"
-    storagebackend: "s3"
-    database: "support_contacts_production"
-    database_hostname: "postgresql-primary"
-    temppath: "/tmp/"
-    url: "govuk-production-database-backups"
-    path: "postgresql-backend"
   "push_travel_advice_publisher_production":
     ensure: "present"
     hour: "1"

--- a/hieradata_aws/class/production/support_api_db_admin.yaml
+++ b/hieradata_aws/class/production/support_api_db_admin.yaml
@@ -1,7 +1,6 @@
 govuk_env_sync::tasks:
   "push_support_api_production_daily":
-    # Temporarily disabled due to issues restoring Postgres 13 databases (https://trello.com/c/9tdzkMIG)
-    ensure: "disabled"
+    ensure: "present"
     hour: "23"
     minute: "0"
     action: "push"

--- a/hieradata_aws/class/staging/db_admin.yaml
+++ b/hieradata_aws/class/staging/db_admin.yaml
@@ -1,16 +1,4 @@
 govuk_env_sync::tasks:
-  "pull_support_contacts_production_daily":
-    ensure: "absent"
-    hour: "2"
-    minute: "3"
-    action: "pull"
-    dbms: "postgresql"
-    storagebackend: "s3"
-    database: "support_contacts_production"
-    database_hostname: "postgresql-primary"
-    temppath: "/tmp/support_contacts_production"
-    url: "govuk-production-database-backups"
-    path: "postgresql-backend"
   "pull_licensify_production_daily": &pull_licensify
     ensure: "present"
     hour: "4"

--- a/hieradata_aws/class/staging/support_api_db_admin.yaml
+++ b/hieradata_aws/class/staging/support_api_db_admin.yaml
@@ -1,7 +1,6 @@
 govuk_env_sync::tasks:
   "pull_support_api_production_daily":
-    # Temporarily disabled due to issues restoring Postgres 13 databases (https://trello.com/c/9tdzkMIG)
-    ensure: "disabled"
+    ensure: "present"
     hour: "0"
     minute: "0"
     action: "pull"


### PR DESCRIPTION
This PR removes Support-API environment sync jobs that have been marked absent on the db_admin machine.

It enables these jobs on the new suport_api_db_admin machine, where they are currently disabled.