### PR TITLE
Fix cron schedule for the LTR jenkins job

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/search_api_learn_to_rank.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/search_api_learn_to_rank.yaml.erb
@@ -18,7 +18,7 @@
     triggers:
       - timed: |
           TZ=Europe/London
-          0 22 * * SUN
+          0 22 * * 7
     properties:
       - build-discarder:
           days-to-keep: 30


### PR DESCRIPTION
This fixes the invalid cron pattern which caused the build trigger to not be added to the Search API Learn to rank (LTR) Jenkins job.