### PR TITLE
Mark remaning postgresql env_sync db_admin jobs as absent

### DIFF
--- a/hieradata_aws/class/integration/db_admin.yaml
+++ b/hieradata_aws/class/integration/db_admin.yaml
@@ -1,6 +1,6 @@
 govuk_env_sync::tasks:
   "push_content-register_production_integration_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "1"
     minute: "45"
     action: "push"
@@ -12,7 +12,7 @@ govuk_env_sync::tasks:
     url: "govuk-integration-database-backups"
     path: "postgresql-backend"
   "push_email_alert_monitor_integration_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "1"
     minute: "10"
     action: "push"
@@ -24,7 +24,7 @@ govuk_env_sync::tasks:
     url: "govuk-integration-database-backups"
     path: "postgresql-backend"
   "push_organisations_publisher_integration_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "1"
     minute: "10"
     action: "push"


### PR DESCRIPTION
All applications have been migrated from postgresql-primary to use individual postgresql databases. These environmental synchronisation tasks can now be marked as absent on the db_admin machine as they are now run via app-specific DB instances.

content_register and organisations_publisher are both archived repositories.

[trello](https://trello.com/c/ewzHAr6A/56-remove-postgresql-primary-and-postgresql-standby-infrastructure-and-configuration)