### PR TITLE
Remove references to the previous RDS instances

### DIFF
--- a/docs/adding-a-new-app.md
+++ b/docs/adding-a-new-app.md
@@ -241,7 +241,7 @@ If your app does not use a database, skip this subsection.
 Add the following configuration to `hieradata_aws/common.yaml`:
 
 ```yaml
-govuk::apps::my_app::db_hostname: "postgresql-primary"
+govuk::apps::my_app::db_hostname: "#{your-app-name}-postgres"
 govuk::apps::my_app::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 govuk::apps::my_app::db::allow_auth_from_lb: true
 govuk::apps::my_app::db::lb_ip_range: "%{hiera('environment_ip_prefix')}.0.0/16"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1468,8 +1468,6 @@ monitoring::checks::rds::servers:
    # list, the override will also need to be removed.
    - 'content-data-api-postgresql-primary'
 
-   - 'postgresql-primary'
-   - 'postgresql-standby'
    - 'transition-postgresql-primary'
    - 'transition-postgresql-standby'
    - 'mysql-primary'


### PR DESCRIPTION
Our new RDS instances hostnames are split between these two conventions:

- app-name-postgres
- app-name-postgresql-primary

As the first is the most common one, I've updated the docs to use that as the default.

postgresql-primary and postgresql-standby are referenced in a couple of files. As we're removing the instances they can
should be removed or updated.