### PR TITLE
Enable sync pull postgres

### DIFF
--- a/hieradata_aws/class/integration/ckan_db_admin.yaml
+++ b/hieradata_aws/class/integration/ckan_db_admin.yaml
@@ -1,16 +1,16 @@
 govuk_env_sync::tasks:
-  # "pull_ckan_production_daily":
-  #   ensure: "present"
-  #   hour: "0"
-  #   minute: "0"
-  #   action: "pull"
-  #   dbms: "postgresql"
-  #   storagebackend: "s3"
-  #   database: "ckan_production"
-  #   database_hostname: "ckan-postgres"
-  #   temppath: "/tmp/ckan_production"
-  #   url: "govuk-production-database-backups"
-  #   path: "ckan-postgres"
+   "pull_ckan_production_daily":
+     ensure: "present"
+     hour: "0"
+     minute: "0"
+     action: "pull"
+     dbms: "postgresql"
+     storagebackend: "s3"
+     database: "ckan_production"
+     database_hostname: "ckan-postgres"
+     temppath: "/tmp/ckan_production"
+     url: "govuk-production-database-backups"
+     path: "ckan-postgres"
   "push_ckan_production_daily":
     ensure: "present"
     hour: "5"

--- a/hieradata_aws/class/integration/content_data_api_db_admin.yaml
+++ b/hieradata_aws/class/integration/content_data_api_db_admin.yaml
@@ -2,7 +2,7 @@ govuk_env_sync::tasks:
   # Use the new Content Data API name here, to avoid issues with
   # changing the name later
   "pull_content_data_api_production_daily":
-    ensure: "absent"
+    ensure: "present"
     hour: "0"
     minute: "0"
     action: "pull"

--- a/hieradata_aws/class/integration/email_alert_api_db_admin.yaml
+++ b/hieradata_aws/class/integration/email_alert_api_db_admin.yaml
@@ -1,7 +1,6 @@
 govuk_env_sync::tasks:
   "pull_email_alert_api_production_daily":
-    # Temporarily disabled due to issues restoring Postgres 13 databases (https://trello.com/c/9tdzkMIG)
-    ensure: "disabled"
+    ensure: "present"
     hour: "0"
     minute: "0"
     action: "pull"

--- a/hieradata_aws/class/integration/publishing_api_db_admin.yaml
+++ b/hieradata_aws/class/integration/publishing_api_db_admin.yaml
@@ -1,7 +1,6 @@
 govuk_env_sync::tasks:
   "pull_publishing_api_production_daily":
-    # Temporarily disabled due to issues restoring Postgres 13 databases (https://trello.com/c/9tdzkMIG)
-    ensure: "disabled"
+    ensure: "present"
     hour: "0"
     minute: "0"
     action: "pull"

--- a/hieradata_aws/class/integration/transition_db_admin.yaml
+++ b/hieradata_aws/class/integration/transition_db_admin.yaml
@@ -1,6 +1,18 @@
 govuk_env_sync::tasks:
+  "pull_transition_integration_daily":
+    ensure: "present"
+    hour: "6"
+    minute: "0"
+    action: "pull"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "transition_production"
+    database_hostname: "transition-postgresql-primary"
+    temppath: "/tmp/transition_production"
+    url: "govuk-production-database-backups"
+    path: "transition-postgresql"
   "push_transition_integration_daily":
-    ensure: "absent"
+    ensure: "present"
     hour: "3"
     minute: "0"
     action: "push"
@@ -10,17 +22,4 @@ govuk_env_sync::tasks:
     database_hostname: "transition-postgresql-primary"
     temppath: "/tmp/transition_production"
     url: "govuk-integration-database-backups"
-    path: "transition-postgresql"
-  "pull_transition_integration_daily":
-    # Temporarily disabled due to issues restoring Postgres 13 databases (https://trello.com/c/9tdzkMIG)
-    ensure: "disabled"
-    hour: "6"
-    minute: "0"
-    action: "pull"
-    dbms: "postgresql"
-    storagebackend: "s3"
-    database: "transition_production"
-    database_hostname: "transition-postgresql-primary"
-    temppath: "/tmp/transition_production"
-    url: "govuk-staging-database-backups"
     path: "transition-postgresql"

--- a/hieradata_aws/class/staging/ckan_db_admin.yaml
+++ b/hieradata_aws/class/staging/ckan_db_admin.yaml
@@ -1,16 +1,16 @@
 govuk_env_sync::tasks:
-  # "pull_ckan_production_daily":
-  #   ensure: "present"
-  #   hour: "0"
-  #   minute: "0"
-  #   action: "pull"
-  #   dbms: "postgresql"
-  #   storagebackend: "s3"
-  #   database: "ckan_production"
-  #   database_hostname: "ckan-postgres"
-  #   temppath: "/tmp/ckan_production"
-  #   url: "govuk-production-database-backups"
-  #   path: "ckan-postgres"
+  "pull_ckan_production_daily":
+    ensure: "present"
+    hour: "0"
+    minute: "0"
+    action: "pull"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "ckan_production"
+    database_hostname: "ckan-postgres"
+    temppath: "/tmp/ckan_production"
+    url: "govuk-production-database-backups"
+    path: "ckan-postgres"
   "push_ckan_production_daily":
     ensure: "present"
     hour: "5"

--- a/hieradata_aws/class/staging/content_data_api_db_admin.yaml
+++ b/hieradata_aws/class/staging/content_data_api_db_admin.yaml
@@ -2,7 +2,7 @@ govuk_env_sync::tasks:
   # Use the new Content Data API name here, to avoid issues with
   # changing the name later
   "pull_content_data_api_production_daily":
-    ensure: "absent"
+    ensure: "present"
     hour: "0"
     minute: "0"
     action: "pull"

--- a/hieradata_aws/class/staging/email_alert_api_db_admin.yaml
+++ b/hieradata_aws/class/staging/email_alert_api_db_admin.yaml
@@ -1,7 +1,6 @@
 govuk_env_sync::tasks:
   "pull_email_alert_api_production_daily":
-    # Temporarily disabled due to issues restoring Postgres 13 databases (https://trello.com/c/9tdzkMIG)
-    ensure: "disabled"
+    ensure: "present"
     hour: "0"
     minute: "0"
     action: "pull"

--- a/hieradata_aws/class/staging/publishing_api_db_admin.yaml
+++ b/hieradata_aws/class/staging/publishing_api_db_admin.yaml
@@ -1,7 +1,6 @@
 govuk_env_sync::tasks:
   "pull_publishing_api_production_daily":
-    # Temporarily disabled due to issues restoring Postgres 13 databases (https://trello.com/c/9tdzkMIG)
-    ensure: "disabled"
+    ensure: "present"
     hour: "0"
     minute: "0"
     action: "pull"

--- a/hieradata_aws/class/staging/transition_db_admin.yaml
+++ b/hieradata_aws/class/staging/transition_db_admin.yaml
@@ -1,7 +1,6 @@
 govuk_env_sync::tasks:
   "pull_transition_production_daily":
-    # Temporarily disabled due to issues restoring Postgres 13 databases (https://trello.com/c/9tdzkMIG)
-    ensure: "disabled"
+    ensure: "present"
     hour: "4"
     minute: "30"
     action: "pull"


### PR DESCRIPTION
## What 

Enable govuk_env_sync script to be run on postgres machines.

## Reference 

https://trello.com/c/9tdzkMIG/31-ensure-the-govukenvsync-process-works-with-postgresql-13-and-mysql-8