### PR TITLE
Add Learn to Rank Jenkins job to prod and staging

### DIFF
--- a/hieradata_aws/class/production/jenkins.yaml
+++ b/hieradata_aws/class/production/jenkins.yaml
@@ -72,6 +72,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::run_whitehall_data_migrations
   - govuk_jenkins::jobs::search_api_fetch_analytics_data
   - govuk_jenkins::jobs::search_api_index_checks
+  - govuk_jenkins::jobs::search_api_learn_to_rank
   - govuk_jenkins::jobs::search_api_reindex_with_new_schema
   - govuk_jenkins::jobs::search_generate_sitemaps
   - govuk_jenkins::jobs::search_relevancy_rank_evaluation

--- a/hieradata_aws/class/staging/jenkins.yaml
+++ b/hieradata_aws/class/staging/jenkins.yaml
@@ -74,6 +74,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::run_whitehall_data_migrations
   - govuk_jenkins::jobs::search_api_fetch_analytics_data
   - govuk_jenkins::jobs::search_api_index_checks
+  - govuk_jenkins::jobs::search_api_learn_to_rank
   - govuk_jenkins::jobs::search_api_reindex_with_new_schema
   - govuk_jenkins::jobs::search_relevancy_rank_evaluation
   - govuk_jenkins::jobs::search_relevancy_metrics_etl


### PR DESCRIPTION
This enables the Search API's Learn to Rank Jenkins job on the production and staging deploy Jenkins. This job has already been enabled and tested in integration.