### PR TITLE
Reduce content-store ttl to 20 mins

### DIFF
--- a/modules/govuk/manifests/apps/content_store.pp
+++ b/modules/govuk/manifests/apps/content_store.pp
@@ -61,7 +61,7 @@ class govuk::apps::content_store(
   $mongodb_nodes,
   $mongodb_name,
   $vhost = 'content-store',
-  $default_ttl = '1800',
+  $default_ttl = '1200',
   $performance_platform_big_screen_view_url = undef,
   $performance_platform_spotlight_url = undef,
   $publishing_api_bearer_token = undef,


### PR DESCRIPTION
This will reduce the TTL on content items to 20 minutes.

Content Store provides a max-age directive which is honoured by frontend applications.