### PR TITLE
Add MySQL client to MySQL DB Admin machines

### DIFF
--- a/modules/govuk/manifests/node/s_collections_publisher_db_admin.pp
+++ b/modules/govuk/manifests/node/s_collections_publisher_db_admin.pp
@@ -21,6 +21,7 @@ class govuk::node::s_collections_publisher_db_admin(
 ) {
   include ::govuk::node::s_base
   include govuk_env_sync
+  include ::mysql::client
 
   file { '/root/.my.cnf':
     ensure  => 'present',

--- a/modules/govuk/manifests/node/s_contacts_admin_db_admin.pp
+++ b/modules/govuk/manifests/node/s_contacts_admin_db_admin.pp
@@ -21,6 +21,7 @@ class govuk::node::s_contacts_admin_db_admin(
 ) {
   include ::govuk::node::s_base
   include govuk_env_sync
+  include ::mysql::client
 
   file { '/root/.my.cnf':
     ensure  => 'present',

--- a/modules/govuk/manifests/node/s_release_db_admin.pp
+++ b/modules/govuk/manifests/node/s_release_db_admin.pp
@@ -21,6 +21,7 @@ class govuk::node::s_release_db_admin(
 ) {
   include ::govuk::node::s_base
   include govuk_env_sync
+  include ::mysql::client
 
   file { '/root/.my.cnf':
     ensure  => 'present',

--- a/modules/govuk/manifests/node/s_search_admin_db_admin.pp
+++ b/modules/govuk/manifests/node/s_search_admin_db_admin.pp
@@ -21,6 +21,7 @@ class govuk::node::s_search_admin_db_admin(
 ) {
   include ::govuk::node::s_base
   include govuk_env_sync
+  include ::mysql::client
 
   file { '/root/.my.cnf':
     ensure  => 'present',

--- a/modules/govuk/manifests/node/s_signon_db_admin.pp
+++ b/modules/govuk/manifests/node/s_signon_db_admin.pp
@@ -21,6 +21,7 @@ class govuk::node::s_signon_db_admin(
 ) {
   include ::govuk::node::s_base
   include govuk_env_sync
+  include ::mysql::client
 
   file { '/root/.my.cnf':
     ensure  => 'present',

--- a/modules/govuk/manifests/node/s_whitehall_db_admin.pp
+++ b/modules/govuk/manifests/node/s_whitehall_db_admin.pp
@@ -21,6 +21,7 @@ class govuk::node::s_whitehall_db_admin(
 ) {
   include ::govuk::node::s_base
   include govuk_env_sync
+  include ::mysql::client
 
   file { '/root/.my.cnf':
     ensure  => 'present',


### PR DESCRIPTION
Trello: https://trello.com/c/7Tr2EOzG/67-decide-how-well-do-the-signon-mysql-migration-in-production

By not installing the mysql::db creation [1] we lost the installation of the
MySQL client on these machines. This client is needed for govuk_env_sync
to dump and restore the databases.

[1]: https://github.com/alphagov/govuk-puppet/commit/a55a8566ee5fe8726c0b4f150e968637c7c4f79e