### PR TITLE
Reduce Content Store TTL to 10 minutes

### DIFF
--- a/modules/govuk/manifests/apps/content_store.pp
+++ b/modules/govuk/manifests/apps/content_store.pp
@@ -61,7 +61,7 @@ class govuk::apps::content_store(
   $mongodb_nodes,
   $mongodb_name,
   $vhost = 'content-store',
-  $default_ttl = '1200',
+  $default_ttl = '600',
   $performance_platform_big_screen_view_url = undef,
   $performance_platform_spotlight_url = undef,
   $publishing_api_bearer_token = undef,


### PR DESCRIPTION
We saw no impact to our cache hit ratio at the CDN when
reducing the TTL from 30 to 20 minutes.

This partially implements RFC 144 - the goal
is to get down to 5 minutes as the default for
most pages.