### PR TITLE
Enable email-alert-service unpublishing messages in staging

### DIFF
--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -178,6 +178,7 @@ govuk::apps::email_alert_api::govuk_notify_recipients:
   - michael.s.walker+accounts-qa-9@digital.cabinet-office.gov.uk
   - michael.s.walker+accounts-qa-10@digital.cabinet-office.gov.uk
 govuk::apps::email_alert_frontend::subscription_management_enabled: true
+govuk::apps::email_alert_service::enable_unpublishing_queue_consumer: true
 govuk::apps::feedback::govuk_notify_survey_signup_reply_to_id: 'd1f54751-80a8-420a-9077-d34c7d6cc734'
 govuk::apps::feedback::govuk_notify_survey_signup_template_id: '8a8d98c0-42c8-4f56-b61f-77c89417a171'
 


### PR DESCRIPTION
Depends on https://github.com/alphagov/email-alert-service/pull/481

---

We're only enabling this in one environment for now for testing
purposes.

---

[Trello card](https://trello.com/c/mQNmwCo2/1140-send-users-an-email-when-a-single-page-is-unpublished)