### PR TITLE
Remove manifest for Vitalie

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -555,7 +555,6 @@ users::usernames:
   - simonhughesdon
   - stephenford
   - stevenradford
-  - vitaliemogoreanu
   - williamfranklin
 
 nginx::config::stack_network_prefix: '10.1.0'

--- a/modules/users/manifests/vitaliemogoreanu.pp
+++ b/modules/users/manifests/vitaliemogoreanu.pp
@@ -1,9 +1,0 @@
-# Creates vitaliemogoreanu user
-class users::vitaliemogoreanu {
-  govuk_user { 'vitaliemogoreanu':
-    ensure   => absent,
-    fullname => 'Vitalie Mogoreanu',
-    email    => 'vitalie.mogoreanu@digital.cabinet-office.gov.uk',
-    ssh_key  => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDLHmgSmPmHeIGoYEmm+xM572CenLG5wx1/9K5z9h1iTAwv4gY+Qarn1OJBYnY4v9T0o6vs14Grlu0Zu8XaRZrmfE+KnuxqAihj1V2hWAcoXiuPLGhweOY3FuLUfShd6yNENBTK1LCRHn6X/3CFt0v/EVXIjBG/CZjAqKW3xySHG8YHIMBodjpUNgY2440042JbiNEsisr1EV7W6OdmnnmY8pY1g/y4S3IavlVfS6dklHIksNR1Kb2RsYHRuenC+OStrJXAoSZTXsfuUW/4BfeKwL1u1tIRx1Zf7NkvbaFoEkOlq1+yYMI7XC50h+jHsXNxZPCMZvVuv5f3e65KuOkhdbFR/OhCWs2htlUhGzfZoTIxJ6xKCRKetK/ybkrBxXcFKpAqwAH89jG4nXBpBRulNuqWev4B6w1ehf6Qh46c+hUTWkJeY0u4zi5ufD/tqp/TBXXL8XBaUxIoq0PKhy2IiJs71oLxYU1GoYZ50MITxKSSSthjBcDi+Kzll2Hj0hB+GaIEzzvWAUH8yDtnFK2NdqjbLt3Lkz+GfeDO1SMk6qLwcXilVB9tFKacWWlPslajw6m+ywfXHLMERL8e8FjJK4w2srM+YZ4siet4+hBG5ApsJVcglnnyrzaaM1Bs8wHy+vtGoSPyxus3B/n2OnrWD5BTwhpCXTqjWnTkcS0ORQ== vitalie.mogoreanu@digital.cabinet-office.gov.uk',
-  }
-}


### PR DESCRIPTION
Depends on: https://github.com/alphagov/govuk-puppet/pull/11472

Also removes integration access.