### PR TITLE
Make Smokey job names more descriptive

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/smokey.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/smokey.yaml.erb
@@ -42,3 +42,5 @@
     wrappers:
       - ansicolor:
           colormap: xterm
+      - build-name:
+          name: '#${BUILD_NUMBER}: ${ENV,var="TARGET_APPLICATION"}'


### PR DESCRIPTION
Following on from the success of #11455, we can make a similar
change to our Smokey builds, so that it is easy to see whether
a build was for the entire test suite or for a particular app.

Screenshot:

<img width="146" alt="Screenshot 2022-01-25 at 09 35 07" src="https://user-images.githubusercontent.com/5111927/150950671-477544d7-412b-4af0-9982-9b943db7870e.png">

I did also try including the user's name, as we have the [build user vars](https://plugins.jenkins.io/build-user-vars-plugin/) plugin, but I don't think it's compatible with Jenkins Job Builder jobs.
