### PR TITLE
Mark env sync jobs as absent for Signon on db_admin

### DIFF
--- a/hieradata_aws/class/integration/db_admin.yaml
+++ b/hieradata_aws/class/integration/db_admin.yaml
@@ -71,8 +71,9 @@ govuk_env_sync::tasks:
     temppath: "/tmp/release_staging"
     url: "govuk-staging-database-backups"
     path: "mysql"
+  # TODO: remove this rule once it's been run on target machines
   "push_signon_integration_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "1"
     minute: "15"
     action: "push"


### PR DESCRIPTION
This PR marks the job for db admin as absent.

They can be removed after puppet has run.

