### PR TITLE
Whitehall staging: use new RDS instance

### DIFF
--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -243,6 +243,10 @@ govuk::apps::travel_advice_publisher::mongodb_username: "%{hiera('govuk::apps::a
 govuk::apps::travel_advice_publisher::mongodb_password: "%{hiera('govuk::apps::asset_manager::mongodb_password')}"
 govuk::apps::whitehall::govuk_notify_template_id: "112842bb-d8a4-4511-90de-57dc5c8f27ec"
 govuk::apps::whitehall::aws_s3_bucket_name: 'govuk-staging-whitehall-csvs'
+# DB hostname for whitehall backend
+govuk::apps::whitehall::admin_db_hostname: 'whitehall-mysql'
+# DB hostname for whitehall frontend
+govuk::apps::whitehall::db_hostname: 'whitehall-mysql'
 
 govuk::apps::contacts::ensure: 'present'
 govuk::apps::collections_publisher::ensure: 'present'


### PR DESCRIPTION
This PR switches the staging instance of Whitehall over to use the new RDS instance.

Trello: https://trello.com/c/i3BsE6o6

