### PR TITLE
Whitehall: use new RDS instance in all environments

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -575,15 +575,13 @@ govuk::apps::short_url_manager::redis_port: "%{hiera('sidekiq_port')}"
 
 govuk::apps::support_api::zendesk_client_username: 'zd-api-govt@digital.cabinet-office.gov.uk/token'
 
-govuk::apps::whitehall::admin_db_hostname: 'mysql-primary'
+govuk::apps::whitehall::admin_db_hostname: 'whitehall-mysql'
 govuk::apps::whitehall::admin_key_space_limit: '262144'
 govuk::apps::whitehall::admin_db_name: whitehall_production
 govuk::apps::whitehall::admin_db_password: "%{hiera('govuk::apps::whitehall::db::mysql_whitehall_admin')}"
 govuk::apps::whitehall::admin_db_username: whitehall
-# TODO this should be using a replica, but we can change that when we have deployed one
-# TODO: switch to "whitehall-mysql" and uncomment the 'push'
-# `govuk_env_sync::tasks` tasks when we're ready to switch to the dedicated RDS instance
-govuk::apps::whitehall::db_hostname: 'mysql-primary'
+
+govuk::apps::whitehall::db_hostname: 'whitehall-mysql'
 govuk::apps::whitehall::db_name: whitehall_production
 govuk::apps::whitehall::db_password: "%{hiera('govuk::apps::whitehall::db::mysql_whitehall')}"
 govuk::apps::whitehall::db_username: whitehall_fe

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -91,10 +91,6 @@ govuk::apps::whitehall::basic_auth_credentials: "%{hiera('http_username')}:%{hie
 govuk::apps::whitehall::highlight_words_to_avoid: true
 govuk::apps::whitehall::govuk_notify_template_id: "759acac6-da53-4a19-b591-b7538c7c39de"
 govuk::apps::whitehall::aws_s3_bucket_name: 'govuk-integration-whitehall-csvs'
-# DB hostname for whitehall backend
-govuk::apps::whitehall::admin_db_hostname: 'whitehall-mysql'
-# DB hostname for whitehall frontend
-govuk::apps::whitehall::db_hostname: 'whitehall-mysql'
 
 licensify::apps::configfile::mongo_database_reference_name: 'licensify-refdata'
 licensify::apps::configfile::mongo_database_audit_name: 'licensify-audit'


### PR DESCRIPTION
This PR switches **all environments** of Whitehall over to use their new RDS instances – **including production**.

Only merge this when the production database is ready to be switched over.

Trello: https://trello.com/c/i3BsE6o6