### PR TITLE
Whitehall production: configure env_sync for new RDS instance

### DIFF
--- a/hieradata_aws/class/production/db_admin.yaml
+++ b/hieradata_aws/class/production/db_admin.yaml
@@ -70,7 +70,7 @@ govuk_env_sync::tasks:
     url: "govuk-production-database-backups"
     path: "mongo-normal"
   "push_whitehall_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "1"
     minute: "00"
     action: "push"
@@ -247,7 +247,7 @@ govuk_env_sync::tasks:
     ensure: "disabled"
     database: "licensify-audit"
   "pull_whitehall_production_daily":
-    ensure: "disabled"
+    ensure: "absent"
     hour: "0"
     minute: "00"
     action: "pull"

--- a/hieradata_aws/class/production/whitehall_db_admin.yaml
+++ b/hieradata_aws/class/production/whitehall_db_admin.yaml
@@ -1,13 +1,13 @@
-# govuk_env_sync::tasks:
-#   "push_whitehall_production_daily":
-#     ensure: "present"
-#     hour: "23"
-#     minute: "0"
-#     action: "push"
-#     dbms: "mysql"
-#     storagebackend: "s3"
-#     database: "whitehall_production"
-#     database_hostname: "whitehall-mysql"
-#     temppath: "/tmp/whitehall_production"
-#     url: "govuk-production-database-backups"
-#     path: "whitehall-mysql"
+govuk_env_sync::tasks:
+  "push_whitehall_production_daily":
+    ensure: "present"
+    hour: "1"
+    minute: "00"
+    action: "push"
+    dbms: "mysql"
+    storagebackend: "s3"
+    database: "whitehall_production"
+    database_hostname: "whitehall-mysql"
+    temppath: "/tmp/whitehall_production"
+    url: "govuk-production-database-backups"
+    path: "whitehall-mysql"

--- a/hieradata_aws/class/staging/whitehall_db_admin.yaml
+++ b/hieradata_aws/class/staging/whitehall_db_admin.yaml
@@ -10,7 +10,7 @@ govuk_env_sync::tasks:
     database_hostname: "whitehall-mysql"
     temppath: "/tmp/whitehall_production"
     url: "govuk-production-database-backups"
-    path: "mysql"
+    path: "whitehall-mysql"
   "push_whitehall_staging_daily":
     ensure: "present"
     hour: "0"


### PR DESCRIPTION
This PR configures env_sync tasks to run on the new Whitehall DB Admin instance **in production,** and removes them from the main DB Admin machine.

I've re-used the existing configuration as it was on the main DB Admin machine – which is why the scheduled task times have changed.

This PR **should not be merged** before #11481, where env_sync is configured in staging

Trello: https://trello.com/c/i3BsE6o6