### PR TITLE
Add Keith Lawrence for integration SSH access

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -529,6 +529,7 @@ users::usernames:
   - jonathanhallam
   - jonathonshire
   - jonkirwan
+  - keithlawrence
   - kelvingan
   - kentsang
   - kevindew

--- a/modules/users/manifests/keithlawrence.pp
+++ b/modules/users/manifests/keithlawrence.pp
@@ -1,0 +1,10 @@
+# Create the keithlawrence user
+class users::keithlawrence {
+  govuk_user { 'keithlawrence':
+    fullname => 'Keith Lawrence',
+    email    => 'keith.lawrence@digital.cabinet-office.gov.uk',
+    ssh_key  => [
+      'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDZpRIEv2s97S8aviYVQg2xqGZSdACQmJbz5CYtsIhv0 keith.lawrence@digital.cabinet-office.gov.uk',
+    ],
+  }
+}


### PR DESCRIPTION
Creates an SSH user for me, and adds it to the list of integration users as per the Get started on GOV.UK manual.