### PR TITLE
Update branch for the LTR jenkins job

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/search_api_learn_to_rank.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/search_api_learn_to_rank.yaml.erb
@@ -5,7 +5,7 @@
       - git:
           url: git@github.com:alphagov/search-api.git
           branches:
-            - migrate-ltr-to-jenkins
+            - main
 - job:
     name: search-api-learn-to-rank
     display-name: Search API Learn to Rank


### PR DESCRIPTION
This updates the branch reference to 'main' instead of the development branch. This job previous referenced the development branch, as to all the concourse pipeline to still function concurrently whilst the migration took place. However, now concourse pipeline is no longer needed and changes have been merged in to main.