### PR TITLE
Enable email-alert-service unpublishing worker in all environments

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -541,6 +541,7 @@ govuk::apps::email_alert_service::rabbitmq_hosts:
 govuk::apps::email_alert_service::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::email_alert_service::rabbitmq::queue_size_critical_threshold: 25
 govuk::apps::email_alert_service::rabbitmq::queue_size_warning_threshold: 5
+govuk::apps::email_alert_service::enable_unpublishing_queue_consumer: true
 
 govuk::apps::finder_frontend::enabled: true
 govuk::apps::finder_frontend::unicorn_worker_processes: "6"

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -38,7 +38,6 @@ govuk::apps::email_alert_api::govuk_notify_template_id: '1fc69d3a-09a2-40f9-852b
 govuk::apps::email_alert_api::govuk_notify_recipients:
   - email-alert-api-integration@digital.cabinet-office.gov.uk
 govuk::apps::email_alert_frontend::subscription_management_enabled: true
-govuk::apps::email_alert_service::enable_unpublishing_queue_consumer: true
 govuk::apps::feedback::govuk_notify_survey_signup_reply_to_id: 'fee22233-2f28-4b0b-8b6c-4410979f2275'
 govuk::apps::feedback::govuk_notify_survey_signup_template_id: 'eb9ba220-7d74-4aab-975a-bdbe718f69a3'
 govuk::apps::feedback::govuk_notify_accessible_format_request_reply_to_id: '77941cb6-f3a2-4b0d-b09c-64572858cb50'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -178,7 +178,6 @@ govuk::apps::email_alert_api::govuk_notify_recipients:
   - michael.s.walker+accounts-qa-9@digital.cabinet-office.gov.uk
   - michael.s.walker+accounts-qa-10@digital.cabinet-office.gov.uk
 govuk::apps::email_alert_frontend::subscription_management_enabled: true
-govuk::apps::email_alert_service::enable_unpublishing_queue_consumer: true
 govuk::apps::feedback::govuk_notify_survey_signup_reply_to_id: 'd1f54751-80a8-420a-9077-d34c7d6cc734'
 govuk::apps::feedback::govuk_notify_survey_signup_template_id: '8a8d98c0-42c8-4f56-b61f-77c89417a171'
 


### PR DESCRIPTION
[Trello](https://trello.com/c/mQNmwCo2/1140-send-users-an-email-when-a-single-page-is-unpublished)