### PR TITLE
Increase freshness threshold for LTR Jenkins job

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/search_api_learn_to_rank.pp
+++ b/modules/govuk_jenkins/manifests/jobs/search_api_learn_to_rank.pp
@@ -57,7 +57,7 @@ class govuk_jenkins::jobs::search_api_learn_to_rank (
       ensure              => present,
       service_description => $service_description,
       host_name           => $::fqdn,
-      freshness_threshold => 86400,
+      freshness_threshold => 691200,
       action_url          => "https://${deploy_jenkins_domain}/job/search-api-learn-to-rank/",
       notes_url           => monitoring_docs_url(search-api-learn-to-rank),
   }


### PR DESCRIPTION
The the Search API Learn to rank Jenkins job only runs once a week. This extends the freshness threshold to 8 days for the icinga alert that notifies us when the job has failed.