### PR TITLE
Update Contacts Admin to use the new RDS instance on prod

### DIFF
--- a/hieradata_aws/class/backend.yaml
+++ b/hieradata_aws/class/backend.yaml
@@ -1,9 +1,6 @@
 ---
 
 govuk::apps::contacts::vhost: contacts-admin
-# TODO: switch to "contacts-admin-mysql" and uncomment the 'push'
-# `govuk_env_sync::tasks` tasks when we're ready to switch to the dedicated RDS instance
-govuk::apps::contacts::db_hostname: 'mysql-primary'
 govuk::apps::contacts::db_username: 'contacts'
 govuk::apps::contacts::db_password: "%{hiera('govuk::apps::contacts::db::mysql_contacts_admin')}"
 

--- a/hieradata_aws/class/integration/backend.yaml
+++ b/hieradata_aws/class/integration/backend.yaml
@@ -36,6 +36,5 @@ govuk::apps::travel_advice_publisher::mongodb_nodes:
 govuk::apps::travel_advice_publisher::mongodb_username: "%{hiera('shared_documentdb_user')}"
 govuk::apps::travel_advice_publisher::mongodb_password: "%{hiera('shared_documentdb_password')}"
 
-govuk::apps::contacts::db_hostname: "contacts-admin-mysql"
 govuk::apps::release::db_hostname: "release-mysql"
 govuk::apps::search_admin::db_hostname: "search-admin-mysql"

--- a/hieradata_aws/class/production/contacts_admin_db_admin.yaml
+++ b/hieradata_aws/class/production/contacts_admin_db_admin.yaml
@@ -1,13 +1,13 @@
-# govuk_env_sync::tasks:
-#   "push_contacts_admin_production_daily":
-#     ensure: "present"
-#     hour: "23"
-#     minute: "0"
-#     action: "push"
-#     dbms: "mysql"
-#     storagebackend: "s3"
-#     database: "contacts_production"
-#     database_hostname: "contacts-admin-mysql"
-#     temppath: "/tmp/contacts_admin_production"
-#     url: "govuk-production-database-backups"
-#     path: "contacts-admin-mysql"
+govuk_env_sync::tasks:
+  "push_contacts_admin_production_daily":
+    ensure: "present"
+    hour: "23"
+    minute: "0"
+    action: "push"
+    dbms: "mysql"
+    storagebackend: "s3"
+    database: "contacts_production"
+    database_hostname: "contacts-admin-mysql"
+    temppath: "/tmp/contacts_admin_production"
+    url: "govuk-production-database-backups"
+    path: "contacts-admin-mysql"

--- a/hieradata_aws/class/production/db_admin.yaml
+++ b/hieradata_aws/class/production/db_admin.yaml
@@ -25,8 +25,9 @@ govuk_env_sync::tasks:
     temppath: "/tmp/collections_publisher_production"
     url: "govuk-production-database-backups"
     path: "mysql"
+  # TODO: remove this rule once it's been run on target machines
   "push_contacts_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "0"
     minute: "14"
     action: "push"
@@ -37,8 +38,9 @@ govuk_env_sync::tasks:
     temppath: "/tmp/contacts_production"
     url: "govuk-production-database-backups"
     path: "mysql"
+  # TODO: remove this rule once it's been run on target machines
   "pull_contacts_production_daily":
-    ensure: "disabled"
+    ensure: "absent"
     hour: "1"
     minute: "15"
     action: "pull"

--- a/hieradata_aws/class/staging/backend.yaml
+++ b/hieradata_aws/class/staging/backend.yaml
@@ -36,7 +36,6 @@ govuk::apps::travel_advice_publisher::mongodb_nodes:
 govuk::apps::travel_advice_publisher::mongodb_username: "%{hiera('shared_documentdb_user')}"
 govuk::apps::travel_advice_publisher::mongodb_password: "%{hiera('shared_documentdb_password')}"
 
-govuk::apps::contacts::db_hostname: "contacts-admin-mysql"
 govuk::apps::release::db_hostname: "release-mysql"
 govuk::apps::search_admin::db_hostname: "search-admin-mysql"
 govuk::apps::signon::db_hostname: "signon-mysql"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -473,6 +473,7 @@ govuk::apps::collections_publisher::jwt_auth_secret: "%{hiera('jwt_auth_secret')
 govuk::apps::collections_publisher::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::collections_publisher::redis_port: "%{hiera('sidekiq_port')}"
 
+govuk::apps::contacts::db_hostname: "contacts-admin-mysql"
 govuk::apps::contacts::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::contacts::redis_port: "%{hiera('sidekiq_port')}"
 

--- a/modules/govuk/manifests/node/s_db_admin.pp
+++ b/modules/govuk/manifests/node/s_db_admin.pp
@@ -61,7 +61,6 @@ class govuk::node::s_db_admin(
     content => template('govuk/mysql_my.cnf.erb'),
   }
   # include all the MySQL database classes that add users
-  -> class { '::govuk::apps::contacts::db': }
   -> class { '::govuk::apps::release::db': }
   -> class { '::govuk::apps::search_admin::db': }
   -> class { '::govuk::apps::signon::db': }


### PR DESCRIPTION
This PR updates the app to use the new RDS instance. Uncomments the env sync push job and marks the previous env sync jobs as absent on the previous db admin.

Some cleanup work will be required to remove all the jobs marked as absent once puppet has run.