### PR TITLE
Update Release to use the new RDS instance on production

### DIFF
--- a/hieradata_aws/class/integration/backend.yaml
+++ b/hieradata_aws/class/integration/backend.yaml
@@ -36,5 +36,4 @@ govuk::apps::travel_advice_publisher::mongodb_nodes:
 govuk::apps::travel_advice_publisher::mongodb_username: "%{hiera('shared_documentdb_user')}"
 govuk::apps::travel_advice_publisher::mongodb_password: "%{hiera('shared_documentdb_password')}"
 
-govuk::apps::release::db_hostname: "release-mysql"
 govuk::apps::search_admin::db_hostname: "search-admin-mysql"

--- a/hieradata_aws/class/production/db_admin.yaml
+++ b/hieradata_aws/class/production/db_admin.yaml
@@ -193,8 +193,9 @@ govuk_env_sync::tasks:
     hour: "1"
     minute: "45"
     database: "licensify-audit"
+  # TODO: remove this rule once it's been run on target machines
   "push_release_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "0"
     minute: "15"
     action: "push"
@@ -238,8 +239,9 @@ govuk_env_sync::tasks:
     <<: *pull_licensify
     ensure: "disabled"
     database: "licensify-audit"
+  # TODO: remove this rule once it's been run on target machines
   "pull_release_production":
-    ensure: "disabled"
+    ensure: "absent"
     hour: "0"
     minute: "00"
     action: "pull"

--- a/hieradata_aws/class/production/release_db_admin.yaml
+++ b/hieradata_aws/class/production/release_db_admin.yaml
@@ -1,13 +1,13 @@
-# govuk_env_sync::tasks:
-#   "push_release_production_daily":
-#     ensure: "present"
-#     hour: "23"
-#     minute: "0"
-#     action: "push"
-#     dbms: "mysql"
-#     storagebackend: "s3"
-#     database: "release_production"
-#     database_hostname: "release-mysql"
-#     temppath: "/tmp/release_production"
-#     url: "govuk-production-database-backups"
-#     path: "release-mysql"
+govuk_env_sync::tasks:
+  "push_release_production_daily":
+    ensure: "present"
+    hour: "23"
+    minute: "0"
+    action: "push"
+    dbms: "mysql"
+    storagebackend: "s3"
+    database: "release_production"
+    database_hostname: "release-mysql"
+    temppath: "/tmp/release_production"
+    url: "govuk-production-database-backups"
+    path: "release-mysql"

--- a/hieradata_aws/class/staging/backend.yaml
+++ b/hieradata_aws/class/staging/backend.yaml
@@ -36,6 +36,5 @@ govuk::apps::travel_advice_publisher::mongodb_nodes:
 govuk::apps::travel_advice_publisher::mongodb_username: "%{hiera('shared_documentdb_user')}"
 govuk::apps::travel_advice_publisher::mongodb_password: "%{hiera('shared_documentdb_password')}"
 
-govuk::apps::release::db_hostname: "release-mysql"
 govuk::apps::search_admin::db_hostname: "search-admin-mysql"
 govuk::apps::signon::db_hostname: "signon-mysql"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -652,9 +652,7 @@ govuk::apps::publishing_api::db::allow_auth_from_lb: true
 govuk::apps::publishing_api::db::lb_ip_range: "%{hiera('environment_ip_prefix')}.0.0/16"
 govuk::apps::publishing_api::govuk_content_schemas_path: '/data/apps/govuk-content-schemas/current'
 
-# TODO: switch to "release-mysql" and uncomment the 'push'
-# `govuk_env_sync::tasks` tasks when we're ready to switch to the dedicated RDS instance
-govuk::apps::release::db_hostname: "mysql-primary"
+govuk::apps::release::db_hostname: "release-mysql"
 govuk::apps::release::db_username: "release"
 govuk::apps::release::db_password: "%{hiera('govuk::apps::release::db::mysql_release')}"
 govuk::apps::release::github_username: "govuk-ci"

--- a/modules/govuk/manifests/node/s_db_admin.pp
+++ b/modules/govuk/manifests/node/s_db_admin.pp
@@ -61,7 +61,6 @@ class govuk::node::s_db_admin(
     content => template('govuk/mysql_my.cnf.erb'),
   }
   # include all the MySQL database classes that add users
-  -> class { '::govuk::apps::release::db': }
   -> class { '::govuk::apps::search_admin::db': }
   -> class { '::govuk::apps::signon::db': }
   -> class { '::govuk::apps::whitehall::db': }


### PR DESCRIPTION
This PR updates the app to use the new RDS instance. Uncomments the env sync push job and marks the previous env sync jobs as absent on the previous db admin.

Some cleanup work will be required to remove all the jobs marked as absent once puppet has run.

