### PR TITLE
Update Search Admin to use the new RDS instance on production

### DIFF
--- a/hieradata_aws/class/integration/backend.yaml
+++ b/hieradata_aws/class/integration/backend.yaml
@@ -35,5 +35,3 @@ govuk::apps::travel_advice_publisher::mongodb_nodes:
   - 'shared-documentdb'
 govuk::apps::travel_advice_publisher::mongodb_username: "%{hiera('shared_documentdb_user')}"
 govuk::apps::travel_advice_publisher::mongodb_password: "%{hiera('shared_documentdb_password')}"
-
-govuk::apps::search_admin::db_hostname: "search-admin-mysql"

--- a/hieradata_aws/class/production/db_admin.yaml
+++ b/hieradata_aws/class/production/db_admin.yaml
@@ -95,8 +95,9 @@ govuk_env_sync::tasks:
     temppath: "/tmp/maslow_production"
     url: "govuk-production-database-backups"
     path: "mongo-normal"
+  # TODO: remove this rule once it's been run on target machines
   "push_search_admin_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "0"
     minute: "20"
     action: "push"
@@ -107,8 +108,9 @@ govuk_env_sync::tasks:
     temppath: "/tmp/search_admin_production"
     url: "govuk-production-database-backups"
     path: "mysql"
+  # TODO: remove this rule once it's been run on target machines
   "pull_search_admin_production_daily":
-    ensure: "disabled"
+    ensure: "absent"
     hour: "0"
     minute: "20"
     action: "pull"

--- a/hieradata_aws/class/production/search_admin_db_admin.yaml
+++ b/hieradata_aws/class/production/search_admin_db_admin.yaml
@@ -1,13 +1,13 @@
-# govuk_env_sync::tasks:
-#   "push_search_admin_production_daily":
-#     ensure: "present"
-#     hour: "23"
-#     minute: "0"
-#     action: "push"
-#     dbms: "mysql"
-#     storagebackend: "s3"
-#     database: "search_admin_production"
-#     database_hostname: "search-admin-mysql"
-#     temppath: "/tmp/search_admin_production"
-#     url: "govuk-production-database-backups"
-#     path: "search-admin-mysql"
+govuk_env_sync::tasks:
+  "push_search_admin_production_daily":
+    ensure: "present"
+    hour: "23"
+    minute: "0"
+    action: "push"
+    dbms: "mysql"
+    storagebackend: "s3"
+    database: "search_admin_production"
+    database_hostname: "search-admin-mysql"
+    temppath: "/tmp/search_admin_production"
+    url: "govuk-production-database-backups"
+    path: "search-admin-mysql"

--- a/hieradata_aws/class/staging/backend.yaml
+++ b/hieradata_aws/class/staging/backend.yaml
@@ -36,5 +36,4 @@ govuk::apps::travel_advice_publisher::mongodb_nodes:
 govuk::apps::travel_advice_publisher::mongodb_username: "%{hiera('shared_documentdb_user')}"
 govuk::apps::travel_advice_publisher::mongodb_password: "%{hiera('shared_documentdb_password')}"
 
-govuk::apps::search_admin::db_hostname: "search-admin-mysql"
 govuk::apps::signon::db_hostname: "signon-mysql"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -669,9 +669,7 @@ govuk::apps::search_api::redis_port: '6379'
 govuk::apps::search_api::unicorn_worker_processes: "9"
 
 govuk::apps::search_admin::db_name: 'search_admin_production'
-# TODO: switch to "search-admin-mysql" and uncomment the 'push'
-# `govuk_env_sync::tasks` tasks when we're ready to switch to the dedicated RDS instance
-govuk::apps::search_admin::db_hostname: 'mysql-primary'
+govuk::apps::search_admin::db_hostname: 'search-admin-mysql'
 govuk::apps::search_admin::db_password: "%{hiera('govuk::apps::search_admin::db::mysql_search_admin')}"
 govuk::apps::search_admin::db_username: 'search_admin'
 govuk::apps::search_admin::redis_host: "%{hiera('sidekiq_host')}"

--- a/modules/govuk/manifests/node/s_db_admin.pp
+++ b/modules/govuk/manifests/node/s_db_admin.pp
@@ -61,7 +61,6 @@ class govuk::node::s_db_admin(
     content => template('govuk/mysql_my.cnf.erb'),
   }
   # include all the MySQL database classes that add users
-  -> class { '::govuk::apps::search_admin::db': }
   -> class { '::govuk::apps::signon::db': }
   -> class { '::govuk::apps::whitehall::db': }
 }


### PR DESCRIPTION
This PR updates the app to use the new RDS instance. Uncomments the env sync push job and marks the previous env sync jobs as absent on the previous db admin.

Some cleanup work will be required to remove all the jobs marked as absent once puppet has run.