### PR TITLE
Update Signon to use the new RDS instance on production

### DIFF
--- a/hieradata_aws/class/production/db_admin.yaml
+++ b/hieradata_aws/class/production/db_admin.yaml
@@ -143,8 +143,9 @@ govuk_env_sync::tasks:
     temppath: "/tmp/short_url_manager_production"
     url: "govuk-production-database-backups"
     path: "mongo-normal"
+  # TODO: remove this rule once it's been run on target machines
   "push_signon_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "0"
     minute: "30"
     action: "push"

--- a/hieradata_aws/class/production/signon_db_admin.yaml
+++ b/hieradata_aws/class/production/signon_db_admin.yaml
@@ -1,13 +1,13 @@
-# govuk_env_sync::tasks:
-#   "push_signon_production_daily":
-#     ensure: "present"
-#     hour: "23"
-#     minute: "0"
-#     action: "push"
-#     dbms: "mysql"
-#     storagebackend: "s3"
-#     database: "signon_production"
-#     database_hostname: "signon-mysql"
-#     temppath: "/tmp/signon_production"
-#     url: "govuk-production-database-backups"
-#     path: "signon-mysql"
+govuk_env_sync::tasks:
+  "push_signon_production_daily":
+    ensure: "present"
+    hour: "23"
+    minute: "0"
+    action: "push"
+    dbms: "mysql"
+    storagebackend: "s3"
+    database: "signon_production"
+    database_hostname: "signon-mysql"
+    temppath: "/tmp/signon_production"
+    url: "govuk-production-database-backups"
+    path: "signon-mysql"

--- a/hieradata_aws/class/staging/backend.yaml
+++ b/hieradata_aws/class/staging/backend.yaml
@@ -35,5 +35,3 @@ govuk::apps::travel_advice_publisher::mongodb_nodes:
   - 'shared-documentdb'
 govuk::apps::travel_advice_publisher::mongodb_username: "%{hiera('shared_documentdb_user')}"
 govuk::apps::travel_advice_publisher::mongodb_password: "%{hiera('shared_documentdb_password')}"
-
-govuk::apps::signon::db_hostname: "signon-mysql"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -728,9 +728,7 @@ govuk::apps::sidekiq_monitoring::travel_advice_publisher_redis_port: "%{hiera('g
 govuk::apps::sidekiq_monitoring::whitehall_redis_host: "%{hiera('govuk::apps::whitehall::redis_host')}"
 govuk::apps::sidekiq_monitoring::whitehall_redis_port: "%{hiera('govuk::apps::whitehall::redis_port')}"
 
-# TODO: switch to "signon-mysql" and uncomment the 'push'
-# `govuk_env_sync::tasks` tasks when we're ready to switch to the dedicated RDS instance
-govuk::apps::signon::db_hostname: 'mysql-primary'
+govuk::apps::signon::db_hostname: 'signon-mysql'
 govuk::apps::signon::db_name: 'signon_production'
 govuk::apps::signon::db_password: "%{hiera('govuk::apps::signon::db::mysql_signonotron')}"
 govuk::apps::signon::db_username: 'signon'

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -69,7 +69,6 @@ govuk::apps::search_api::tensorflow_sagemaker_endpoint: 'govuk-integration-searc
 govuk::apps::service_manual_publisher::govuk_notify_template_id: "759acac6-da53-4a19-b591-b7538c7c39de"
 govuk::apps::short_url_manager::govuk_notify_template_id: "759acac6-da53-4a19-b591-b7538c7c39de"
 govuk::apps::short_url_manager::instance_name: 'integration'
-govuk::apps::signon::db_hostname: "signon-mysql"
 govuk::apps::signon::db_password: "%{hiera('govuk::node::s_signon_db_admin::mysql_db_password')}"
 govuk::apps::signon::instance_name: 'integration'
 govuk::apps::signon::govuk_notify_template_id: "759acac6-da53-4a19-b591-b7538c7c39de"

--- a/modules/govuk/manifests/node/s_db_admin.pp
+++ b/modules/govuk/manifests/node/s_db_admin.pp
@@ -61,6 +61,5 @@ class govuk::node::s_db_admin(
     content => template('govuk/mysql_my.cnf.erb'),
   }
   # include all the MySQL database classes that add users
-  -> class { '::govuk::apps::signon::db': }
   -> class { '::govuk::apps::whitehall::db': }
 }


### PR DESCRIPTION
This PR updates the app to use the new RDS instance. Uncomments the env sync push job and marks the previous env sync jobs as absent on the previous db admin.

Some cleanup work will be required to remove all the jobs marked as absent once puppet has run.