### PR TITLE
Remove PostgreSQL configuration from DB Admin machines

### DIFF
--- a/modules/govuk/manifests/node/s_db_admin.pp
+++ b/modules/govuk/manifests/node/s_db_admin.pp
@@ -19,10 +19,6 @@ class govuk::node::s_db_admin(
   $mysql_db_host        = undef,
   $mysql_db_password    = undef,
   $mysql_db_user        = undef,
-  $postgres_host        = undef,
-  $postgres_user        = undef,
-  $postgres_password    = undef,
-  $postgres_port        = '5432',
 ) {
   include ::govuk::node::s_base
   include govuk_env_sync
@@ -71,18 +67,4 @@ class govuk::node::s_db_admin(
   -> class { '::govuk::apps::search_admin::db': }
   -> class { '::govuk::apps::signon::db': }
   -> class { '::govuk::apps::whitehall::db': }
-
-  ### PostgreSQL ###
-
-  # include the common config/tooling required for our DB admin class
-  class { '::govuk::nodes::postgresql_db_admin':
-    postgres_host       => $postgres_host,
-    postgres_user       => $postgres_user,
-    postgres_password   => $postgres_password,
-    postgres_port       => $postgres_port,
-    apt_mirror_hostname => $apt_mirror_hostname,
-  }
-
-  # include all PostgreSQL classes that create databases and users
-  -> class { '::govuk::apps::ckan::db': }
 }


### PR DESCRIPTION
Trello: https://trello.com/c/ewzHAr6A/56-remove-postgresql-primary-and-postgresql-standby-infrastructure-and-configuration

This is an alternative to: https://github.com/alphagov/govuk-puppet/pull/11461
which used Puppet to try remove PostgreSQL and it's config.

We've since learnt that this isn't possible, if `postgresql::server`
gets called with `package_ensure => absent` it will still try to create
directories [1] and thus puppet will error.

Therefore I am taking a simpler option here and just removing the config
with an intention to recycle the boxes to remove the stuff that isn't
needed anymore (which I'll plan to do after the MySQL configuration is
removed).

[1]: https://github.com/puppetlabs/puppetlabs-postgresql/blob/6a07decd104dc1e004135bae6403e516cf13bbe2/manifests/server/initdb.pp#L24-L29