### PR TITLE
Update Collections Publisher to use the new RDS instance on prod

### DIFF
--- a/hieradata_aws/class/integration/backend.yaml
+++ b/hieradata_aws/class/integration/backend.yaml
@@ -36,7 +36,6 @@ govuk::apps::travel_advice_publisher::mongodb_nodes:
 govuk::apps::travel_advice_publisher::mongodb_username: "%{hiera('shared_documentdb_user')}"
 govuk::apps::travel_advice_publisher::mongodb_password: "%{hiera('shared_documentdb_password')}"
 
-govuk::apps::collections_publisher::db_hostname: "collections-publisher-mysql"
 govuk::apps::contacts::db_hostname: "contacts-admin-mysql"
 govuk::apps::release::db_hostname: "release-mysql"
 govuk::apps::search_admin::db_hostname: "search-admin-mysql"

--- a/hieradata_aws/class/production/collections_publisher_db_admin.yaml
+++ b/hieradata_aws/class/production/collections_publisher_db_admin.yaml
@@ -1,13 +1,13 @@
-# govuk_env_sync::tasks:
-#   "push_collections_publisher_production_daily":
-#     ensure: "present"
-#     hour: "23"
-#     minute: "0"
-#     action: "push"
-#     dbms: "mysql"
-#     storagebackend: "s3"
-#     database: "collections_publisher_production"
-#     database_hostname: "collections-publisher-mysql"
-#     temppath: "/tmp/collections_publisher_production"
-#     url: "govuk-production-database-backups"
-#     path: "collections-publisher-mysql"
+govuk_env_sync::tasks:
+  "push_collections_publisher_production_daily":
+    ensure: "present"
+    hour: "23"
+    minute: "0"
+    action: "push"
+    dbms: "mysql"
+    storagebackend: "s3"
+    database: "collections_publisher_production"
+    database_hostname: "collections-publisher-mysql"
+    temppath: "/tmp/collections_publisher_production"
+    url: "govuk-production-database-backups"
+    path: "collections-publisher-mysql"

--- a/hieradata_aws/class/production/db_admin.yaml
+++ b/hieradata_aws/class/production/db_admin.yaml
@@ -1,6 +1,7 @@
 govuk_env_sync::tasks:
+  # TODO: remove this rule once it's been run on target machines
   "push_collections_publisher_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "0"
     minute: "12"
     action: "push"
@@ -11,8 +12,9 @@ govuk_env_sync::tasks:
     temppath: "/tmp/collections_publisher_production"
     url: "govuk-production-database-backups"
     path: "mysql"
+  # TODO: remove this rule once it's been run on target machines
   "pull_collections_publisher_production_daily":
-    ensure: "disabled"
+    ensure: "absent"
     hour: "1"
     minute: "00"
     action: "pull"

--- a/hieradata_aws/class/staging/backend.yaml
+++ b/hieradata_aws/class/staging/backend.yaml
@@ -36,7 +36,6 @@ govuk::apps::travel_advice_publisher::mongodb_nodes:
 govuk::apps::travel_advice_publisher::mongodb_username: "%{hiera('shared_documentdb_user')}"
 govuk::apps::travel_advice_publisher::mongodb_password: "%{hiera('shared_documentdb_password')}"
 
-govuk::apps::collections_publisher::db_hostname: "collections-publisher-mysql"
 govuk::apps::contacts::db_hostname: "contacts-admin-mysql"
 govuk::apps::release::db_hostname: "release-mysql"
 govuk::apps::search_admin::db_hostname: "search-admin-mysql"

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -468,9 +468,7 @@ govuk::apps::ckan::s3_aws_secret_access_key: "%{hiera('s3_aws_secret_access_key'
 
 govuk::apps::collections::unicorn_worker_processes: 8
 
-# TODO: switch to "collections-publisher-mysql" and uncomment the 'push'
-# `govuk_env_sync::tasks` tasks when we're ready to switch to the dedicated RDS instance
-govuk::apps::collections_publisher::db_hostname: "mysql-primary"
+govuk::apps::collections_publisher::db_hostname: "collections-publisher-mysql"
 govuk::apps::collections_publisher::jwt_auth_secret: "%{hiera('jwt_auth_secret')}"
 govuk::apps::collections_publisher::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::collections_publisher::redis_port: "%{hiera('sidekiq_port')}"

--- a/modules/govuk/manifests/node/s_db_admin.pp
+++ b/modules/govuk/manifests/node/s_db_admin.pp
@@ -61,7 +61,6 @@ class govuk::node::s_db_admin(
     content => template('govuk/mysql_my.cnf.erb'),
   }
   # include all the MySQL database classes that add users
-  -> class { '::govuk::apps::collections_publisher::db': }
   -> class { '::govuk::apps::contacts::db': }
   -> class { '::govuk::apps::release::db': }
   -> class { '::govuk::apps::search_admin::db': }


### PR DESCRIPTION
This PR updates the app to use the new RDS instance. Uncomments the env sync push job and marks the previous env sync jobs as absent on the previous db admin.

Some cleanup work will be required to remove all the jobs marked as absent once puppet has run.