### PR TITLE
Mark pull_release_staging_daily job as absent

### DIFF
--- a/hieradata_aws/class/integration/db_admin.yaml
+++ b/hieradata_aws/class/integration/db_admin.yaml
@@ -61,8 +61,9 @@ govuk_env_sync::tasks:
     temppath: "/tmp/release_integration"
     url: "govuk-integration-database-backups"
     path: "mysql"
+  # TODO: remove this rule once it's been run on target machines
   "pull_release_staging_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "1"
     minute: "30"
     action: "pull"


### PR DESCRIPTION
This job is no longer required as the release database has been moved from a shared RDS instance (accessed using `db_admin`) to a single RDS instance (which is accessed with `release_db_admin`).

[Trello card](https://trello.com/c/YJ17PINp)