### PR TITLE
Stop dumping staging databases to S3

### DIFF
--- a/hieradata_aws/class/staging/account_api_db_admin.yaml
+++ b/hieradata_aws/class/staging/account_api_db_admin.yaml
@@ -1,6 +1,6 @@
 govuk_env_sync::tasks:
   "push_account_api_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "5"
     minute: "0"
     action: "push"

--- a/hieradata_aws/class/staging/ckan_db_admin.yaml
+++ b/hieradata_aws/class/staging/ckan_db_admin.yaml
@@ -12,7 +12,7 @@ govuk_env_sync::tasks:
     url: "govuk-production-database-backups"
     path: "ckan-postgres"
   "push_ckan_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "5"
     minute: "0"
     action: "push"

--- a/hieradata_aws/class/staging/collections_publisher_db_admin.yaml
+++ b/hieradata_aws/class/staging/collections_publisher_db_admin.yaml
@@ -12,7 +12,7 @@ govuk_env_sync::tasks:
     url: "govuk-production-database-backups"
     path: "mysql"
   "push_collections_publisher_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "5"
     minute: "0"
     action: "push"

--- a/hieradata_aws/class/staging/contacts_admin_db_admin.yaml
+++ b/hieradata_aws/class/staging/contacts_admin_db_admin.yaml
@@ -12,7 +12,7 @@ govuk_env_sync::tasks:
     url: "govuk-production-database-backups"
     path: "mysql"
   "push_contacts_admin_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "5"
     minute: "0"
     action: "push"

--- a/hieradata_aws/class/staging/content_data_admin_db_admin.yaml
+++ b/hieradata_aws/class/staging/content_data_admin_db_admin.yaml
@@ -12,7 +12,7 @@ govuk_env_sync::tasks:
     url: "govuk-production-database-backups"
     path: "content-data-admin-postgres"
   "push_content_data_admin_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "5"
     minute: "0"
     action: "push"

--- a/hieradata_aws/class/staging/content_data_api_db_admin.yaml
+++ b/hieradata_aws/class/staging/content_data_api_db_admin.yaml
@@ -14,7 +14,7 @@ govuk_env_sync::tasks:
     url: "govuk-production-database-backups"
     path: "content-data-api-postgresql"
   "push_content_data_api_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "5"
     minute: "0"
     action: "push"

--- a/hieradata_aws/class/staging/content_publisher_db_admin.yaml
+++ b/hieradata_aws/class/staging/content_publisher_db_admin.yaml
@@ -12,7 +12,7 @@ govuk_env_sync::tasks:
     url: "govuk-production-database-backups"
     path: "content-publisher-postgres"
   "push_content_publisher_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "5"
     minute: "0"
     action: "push"

--- a/hieradata_aws/class/staging/content_tagger_db_admin.yaml
+++ b/hieradata_aws/class/staging/content_tagger_db_admin.yaml
@@ -12,7 +12,7 @@ govuk_env_sync::tasks:
     url: "govuk-production-database-backups"
     path: "content-tagger-postgres"
   "push_content_tagger_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "5"
     minute: "0"
     action: "push"

--- a/hieradata_aws/class/staging/email_alert_api_db_admin.yaml
+++ b/hieradata_aws/class/staging/email_alert_api_db_admin.yaml
@@ -12,7 +12,7 @@ govuk_env_sync::tasks:
     url: "govuk-production-database-backups"
     path: "email-alert-api-postgres"
   "push_email_alert_api_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "5"
     minute: "0"
     action: "push"

--- a/hieradata_aws/class/staging/link_checker_api_db_admin.yaml
+++ b/hieradata_aws/class/staging/link_checker_api_db_admin.yaml
@@ -12,7 +12,7 @@ govuk_env_sync::tasks:
     url: "govuk-production-database-backups"
     path: "link-checker-api-postgres"
   "push_link_checker_api_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "5"
     minute: "0"
     action: "push"

--- a/hieradata_aws/class/staging/local_links_manager_db_admin.yaml
+++ b/hieradata_aws/class/staging/local_links_manager_db_admin.yaml
@@ -12,7 +12,7 @@ govuk_env_sync::tasks:
     url: "govuk-production-database-backups"
     path: "local-links-manager-postgres"
   "push_local_links_manager_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "5"
     minute: "0"
     action: "push"

--- a/hieradata_aws/class/staging/publishing_api_db_admin.yaml
+++ b/hieradata_aws/class/staging/publishing_api_db_admin.yaml
@@ -12,7 +12,7 @@ govuk_env_sync::tasks:
     url: "govuk-production-database-backups"
     path: "publishing-api-postgres"
   "push_publishing_api_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "5"
     minute: "0"
     action: "push"

--- a/hieradata_aws/class/staging/release_db_admin.yaml
+++ b/hieradata_aws/class/staging/release_db_admin.yaml
@@ -12,7 +12,7 @@ govuk_env_sync::tasks:
     url: "govuk-production-database-backups"
     path: "mysql"
   "push_release_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "5"
     minute: "0"
     action: "push"

--- a/hieradata_aws/class/staging/search_admin_db_admin.yaml
+++ b/hieradata_aws/class/staging/search_admin_db_admin.yaml
@@ -12,7 +12,7 @@ govuk_env_sync::tasks:
     url: "govuk-production-database-backups"
     path: "mysql"
   "push_search_admin_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "5"
     minute: "0"
     action: "push"

--- a/hieradata_aws/class/staging/service_manual_publisher_db_admin.yaml
+++ b/hieradata_aws/class/staging/service_manual_publisher_db_admin.yaml
@@ -12,7 +12,7 @@ govuk_env_sync::tasks:
     url: "govuk-production-database-backups"
     path: "service-manual-publisher-postgres"
   "push_service_manual_publisher_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "5"
     minute: "0"
     action: "push"

--- a/hieradata_aws/class/staging/signon_db_admin.yaml
+++ b/hieradata_aws/class/staging/signon_db_admin.yaml
@@ -12,7 +12,7 @@ govuk_env_sync::tasks:
     url: "govuk-production-database-backups"
     path: "mysql"
   "push_signon_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "5"
     minute: "0"
     action: "push"

--- a/hieradata_aws/class/staging/support_api_db_admin.yaml
+++ b/hieradata_aws/class/staging/support_api_db_admin.yaml
@@ -12,7 +12,7 @@ govuk_env_sync::tasks:
     url: "govuk-production-database-backups"
     path: "support-api-postgres"
   "push_support_api_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "5"
     minute: "0"
     action: "push"

--- a/hieradata_aws/class/staging/transition_db_admin.yaml
+++ b/hieradata_aws/class/staging/transition_db_admin.yaml
@@ -12,7 +12,7 @@ govuk_env_sync::tasks:
     url: "govuk-production-database-backups"
     path: "transition-postgresql"
   "push_transition_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "5"
     minute: "30"
     action: "push"


### PR DESCRIPTION
The template script which was used to set up DB Admin machines included a "push" env_sync task to dump staging databases into a staging S3 bucket.

It's since become apparent that, in most cases, these staging dumps aren't used and are therefore not needed. This is because all integration environments (with the exception of Whitehall) pull data directly from the production S3 bucket.

Trello: https://trello.com/c/Ur7mYFEc