### PR TITLE
Remove Ruby 3.1

### DIFF
--- a/modules/govuk_rbenv/manifests/all.pp
+++ b/modules/govuk_rbenv/manifests/all.pp
@@ -36,7 +36,6 @@ class govuk_rbenv::all (
     '2.7.3',
     '2.7.5',
     '3.0.3',
-    '3.1.0',
   ]
 
   govuk_rbenv::install_ruby_version { $ruby_versions:
@@ -54,9 +53,5 @@ class govuk_rbenv::all (
 
   rbenv::alias { '3.0':
     to_version => '3.0.3',
-  }
-
-  rbenv::alias { '3.1':
-    to_version => '3.1.0',
   }
 }


### PR DESCRIPTION
Running `govuk_puppet --test` after applying #11488 led to failures
in Ruby 3.1 (but not the earlier versions):

```
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Loading facts
Info: Caching catalog for i-095c8a179e3e3f5bc
Info: Applying configuration version 'd41db95ca4f3d290c836aa078509e069decb4be3'
Notice: /Stage[main]/Nginx::Config/Exec[nginx_configtest]/returns: executed successfully
Info: Class[Nginx::Config]: Scheduling refresh of Class[Nginx::Service]
Notice: /Stage[main]/Govuk_rbenv::All/Govuk_rbenv::Install_ruby_version[2.7.5]/Rbenv::Version[2.7.5]/Package[rbenv-ruby-2.7.5]/ensure: ensure changed 'purged' to 'latest'
Notice: /Stage[main]/Govuk_rbenv::All/Govuk_rbenv::Install_ruby_version[2.7.5]/Rbenv::Version[2.7.5]/File[/usr/lib/rbenv/versions/2.7.5/etc]/ensure: created
Notice: /Stage[main]/Govuk_rbenv::All/Govuk_rbenv::Install_ruby_version[2.6.9]/Rbenv::Version[2.6.9]/Package[rbenv-ruby-2.6.9]/ensure: ensure changed 'purged' to 'latest'
Notice: /Stage[main]/Govuk_rbenv::All/Govuk_rbenv::Install_ruby_version[2.6.9]/Rbenv::Version[2.6.9]/File[/usr/lib/rbenv/versions/2.6.9/etc]/ensure: created
Notice: /Stage[main]/Govuk_rbenv::All/Govuk_rbenv::Install_ruby_version[2.6.9]/Rbenv::Version[2.6.9]/File[/usr/lib/rbenv/versions/2.6.9/etc/gemrc]/ensure: created
Info: /Stage[main]/Govuk_rbenv::All/Govuk_rbenv::Install_ruby_version[2.6.9]/Rbenv::Version[2.6.9]/File[/usr/lib/rbenv/versions/2.6.9/etc/gemrc]: Scheduling refresh of Exec[install bundler for 2.6.9]
Notice: /Stage[main]/Govuk_rbenv::All/Govuk_rbenv::Install_ruby_version[2.7.5]/Rbenv::Version[2.7.5]/File[/usr/lib/rbenv/versions/2.7.5/etc/gemrc]/ensure: created
Info: /Stage[main]/Govuk_rbenv::All/Govuk_rbenv::Install_ruby_version[2.7.5]/Rbenv::Version[2.7.5]/File[/usr/lib/rbenv/versions/2.7.5/etc/gemrc]: Scheduling refresh of Exec[install bundler for 2.7.5]
Notice: /Stage[main]/Govuk_rbenv::All/Govuk_rbenv::Install_ruby_version[2.6.9]/Rbenv::Version[2.6.9]/Exec[install bundler for 2.6.9]/returns: executed successfully
Info: /Stage[main]/Govuk_rbenv::All/Govuk_rbenv::Install_ruby_version[2.6.9]/Rbenv::Version[2.6.9]/Exec[install bundler for 2.6.9]: Scheduling refresh of Rbenv::Rehash[2.6.9]
Notice: /Stage[main]/Govuk_rbenv::All/Govuk_rbenv::Install_ruby_version[2.6.9]/Rbenv::Version[2.6.9]/Exec[install bundler for 2.6.9]: Triggered 'refresh' from 1 events
Info: /Stage[main]/Govuk_rbenv::All/Govuk_rbenv::Install_ruby_version[2.6.9]/Rbenv::Version[2.6.9]/Exec[install bundler for 2.6.9]: Scheduling refresh of Rbenv::Rehash[2.6.9]
Notice: /Stage[main]/Govuk_rbenv::All/Govuk_rbenv::Install_ruby_version[3.1.0]/Rbenv::Version[3.1.0]/Package[rbenv-ruby-3.1.0]/ensure: ensure changed 'purged' to 'latest'
Notice: /Stage[main]/Govuk_rbenv::All/Govuk_rbenv::Install_ruby_version[3.1.0]/Rbenv::Version[3.1.0]/File[/usr/lib/rbenv/versions/3.1.0/etc]/ensure: created
Notice: /Stage[main]/Govuk_rbenv::All/Govuk_rbenv::Install_ruby_version[3.1.0]/Rbenv::Version[3.1.0]/File[/usr/lib/rbenv/versions/3.1.0/etc/gemrc]/ensure: created
Info: /Stage[main]/Govuk_rbenv::All/Govuk_rbenv::Install_ruby_version[3.1.0]/Rbenv::Version[3.1.0]/File[/usr/lib/rbenv/versions/3.1.0/etc/gemrc]: Scheduling refresh of Exec[install bundler for 3.1.0]
Notice: /Stage[main]/Govuk_rbenv::All/Govuk_rbenv::Install_ruby_version[3.1.0]/Rbenv::Version[3.1.0]/Exec[install bundler for 3.1.0]/returns: ERROR:  While executing gem ... (Gem::Exception)
Notice: /Stage[main]/Govuk_rbenv::All/Govuk_rbenv::Install_ruby_version[3.1.0]/Rbenv::Version[3.1.0]/Exec[install bundler for 3.1.0]/returns:     OpenSSL is not available. Install OpenSSL and rebuild Ruby (preferred) or use non-HTTPS sources
Error: /usr/bin/env -uRUBYOPT -uBUNDLE_GEMFILE -uGEM_HOME -uGEM_PATH /usr/bin/rbenv exec gem install bundler -v '1.16.2' returned 1 instead of one of [0]
Error: /Stage[main]/Govuk_rbenv::All/Govuk_rbenv::Install_ruby_version[3.1.0]/Rbenv::Version[3.1.0]/Exec[install bundler for 3.1.0]/returns: change from notrun to 0 failed: /usr/bin/env -uRUBYOPT -uBUNDLE_GEMFILE -uGEM_HOME -uGEM_PATH /usr/bin/rbenv exec gem install bundler -v '1.16.2' returned 1 instead of one of [0]
Notice: /Stage[main]/Govuk_rbenv::All/Govuk_rbenv::Install_ruby_version[3.1.0]/Rbenv::Version[3.1.0]/Exec[install bundler for 3.1.0]/returns: ERROR:  While executing gem ... (Gem::Exception)
Notice: /Stage[main]/Govuk_rbenv::All/Govuk_rbenv::Install_ruby_version[3.1.0]/Rbenv::Version[3.1.0]/Exec[install bundler for 3.1.0]/returns:     OpenSSL is not available. Install OpenSSL and rebuild Ruby (preferred) or use non-HTTPS sources
Error: /Stage[main]/Govuk_rbenv::All/Govuk_rbenv::Install_ruby_version[3.1.0]/Rbenv::Version[3.1.0]/Exec[install bundler for 3.1.0]: Failed to call refresh: /usr/bin/env -uRUBYOPT -uBUNDLE_GEMFILE -uGEM_HOME -uGEM_PATH /usr/bin/rbenv exec gem install bundler -v '1.16.2' returned 1 instead of one of [0]
Error: /Stage[main]/Govuk_rbenv::All/Govuk_rbenv::Install_ruby_version[3.1.0]/Rbenv::Version[3.1.0]/Exec[install bundler for 3.1.0]: /usr/bin/env -uRUBYOPT -uBUNDLE_GEMFILE -uGEM_HOME -uGEM_PATH /usr/bin/rbenv exec gem install bundler -v '1.16.2' returned 1 instead of one of [0]
Notice: /Stage[main]/Govuk_rbenv::All/Govuk_rbenv::Install_ruby_version[3.1.0]/Rbenv::Version[3.1.0]/Rbenv::Rehash[3.1.0]/Exec[rbenv rehash for 3.1.0]: Dependency Exec[install bundler for 3.1.0] has failures: true
Warning: /Stage[main]/Govuk_rbenv::All/Govuk_rbenv::Install_ruby_version[3.1.0]/Rbenv::Version[3.1.0]/Rbenv::Rehash[3.1.0]/Exec[rbenv rehash for 3.1.0]: Skipping because of failed dependencies
Notice: /Stage[main]/Govuk_rbenv::All/Rbenv::Alias[3.1]/File[/usr/lib/rbenv/versions/3.1]: Dependency Exec[install bundler for 3.1.0] has failures: true
Warning: /Stage[main]/Govuk_rbenv::All/Rbenv::Alias[3.1]/File[/usr/lib/rbenv/versions/3.1]: Skipping because of failed dependencies
Notice: /Stage[main]/Govuk_rbenv::All/Govuk_rbenv::Install_ruby_version[2.7.5]/Rbenv::Version[2.7.5]/Exec[install bundler for 2.7.5]/returns: executed successfully
Info: /Stage[main]/Govuk_rbenv::All/Govuk_rbenv::Install_ruby_version[2.7.5]/Rbenv::Version[2.7.5]/Exec[install bundler for 2.7.5]: Scheduling refresh of Rbenv::Rehash[2.7.5]
Notice: /Stage[main]/Govuk_rbenv::All/Govuk_rbenv::Install_ruby_version[2.7.5]/Rbenv::Version[2.7.5]/Exec[install bundler for 2.7.5]: Triggered 'refresh' from 1 events
Info: /Stage[main]/Govuk_rbenv::All/Govuk_rbenv::Install_ruby_version[2.7.5]/Rbenv::Version[2.7.5]/Exec[install bundler for 2.7.5]: Scheduling refresh of Rbenv::Rehash[2.7.5]
Info: Rbenv::Rehash[2.7.5]: Scheduling refresh of Exec[rbenv rehash for 2.7.5]
Notice: /Stage[main]/Govuk_rbenv::All/Govuk_rbenv::Install_ruby_version[2.7.5]/Rbenv::Version[2.7.5]/Rbenv::Rehash[2.7.5]/Exec[rbenv rehash for 2.7.5]: Triggered 'refresh' from 1 events
Notice: /Stage[main]/Govuk_rbenv::All/Govuk_rbenv::Install_ruby_version[3.0.3]/Rbenv::Version[3.0.3]/Package[rbenv-ruby-3.0.3]/ensure: ensure changed 'purged' to 'latest'
Notice: /Stage[main]/Govuk_rbenv::All/Govuk_rbenv::Install_ruby_version[3.0.3]/Rbenv::Version[3.0.3]/File[/usr/lib/rbenv/versions/3.0.3/etc]/ensure: created
Notice: /Stage[main]/Govuk_rbenv::All/Govuk_rbenv::Install_ruby_version[3.0.3]/Rbenv::Version[3.0.3]/File[/usr/lib/rbenv/versions/3.0.3/etc/gemrc]/ensure: created
Info: /Stage[main]/Govuk_rbenv::All/Govuk_rbenv::Install_ruby_version[3.0.3]/Rbenv::Version[3.0.3]/File[/usr/lib/rbenv/versions/3.0.3/etc/gemrc]: Scheduling refresh of Exec[install bundler for 3.0.3]
Notice: /Stage[main]/Govuk_rbenv::All/Govuk_rbenv::Install_ruby_version[3.0.3]/Rbenv::Version[3.0.3]/Exec[install bundler for 3.0.3]/returns: executed successfully
Info: /Stage[main]/Govuk_rbenv::All/Govuk_rbenv::Install_ruby_version[3.0.3]/Rbenv::Version[3.0.3]/Exec[install bundler for 3.0.3]: Scheduling refresh of Rbenv::Rehash[3.0.3]
Notice: /Stage[main]/Govuk_rbenv::All/Govuk_rbenv::Install_ruby_version[3.0.3]/Rbenv::Version[3.0.3]/Exec[install bundler for 3.0.3]: Triggered 'refresh' from 1 events
Info: /Stage[main]/Govuk_rbenv::All/Govuk_rbenv::Install_ruby_version[3.0.3]/Rbenv::Version[3.0.3]/Exec[install bundler for 3.0.3]: Scheduling refresh of Rbenv::Rehash[3.0.3]
Info: Rbenv::Rehash[3.0.3]: Scheduling refresh of Exec[rbenv rehash for 3.0.3]
Notice: /Stage[main]/Govuk_rbenv::All/Govuk_rbenv::Install_ruby_version[3.0.3]/Rbenv::Version[3.0.3]/Rbenv::Rehash[3.0.3]/Exec[rbenv rehash for 3.0.3]: Triggered 'refresh' from 1 events
Info: Rbenv::Rehash[2.6.9]: Scheduling refresh of Exec[rbenv rehash for 2.6.9]
Notice: /Stage[main]/Govuk_rbenv::All/Govuk_rbenv::Install_ruby_version[2.6.9]/Rbenv::Version[2.6.9]/Rbenv::Rehash[2.6.9]/Exec[rbenv rehash for 2.6.9]: Triggered 'refresh' from 1 events
Notice: /Stage[main]/Govuk_rbenv::All/Rbenv::Alias[2.6]/File[/usr/lib/rbenv/versions/2.6]/target: target changed '2.6.6' to '2.6.9'
Notice: /Stage[main]/Govuk_rbenv::All/Rbenv::Alias[3.0]/File[/usr/lib/rbenv/versions/3.0]/ensure: created
Notice: /Stage[main]/Govuk_rbenv::All/Rbenv::Alias[2.7]/File[/usr/lib/rbenv/versions/2.7]/target: target changed '2.7.3' to '2.7.5'
Info: Class[Nginx::Service]: Scheduling refresh of Service[nginx]
Notice: /Stage[main]/Nginx::Service/Service[nginx]: Triggered 'refresh' from 1 events
Notice: Finished catalog run in 63.60 seconds
```

This should be investigated at a later date. For now, we want to unblock the
upgrading of repos to their latest patch versions (as opposed to this minor
version upgrade, which is more substantial).

Trello: https://trello.com/c/ZMrLumn8/2837-upgrade-ruby-for-our-apps-5