### PR TITLE
Add automated rake task

### DIFF
--- a/hieradata_aws/class/integration/jenkins.yaml
+++ b/hieradata_aws/class/integration/jenkins.yaml
@@ -8,6 +8,7 @@ govuk_jenkins::config::theme_environment_name: 'AWS Integration'
 govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::ask_export
   - govuk_jenkins::jobs::athena_fastly_logs_check
+  - govuk_jenkins::jobs::automated_rake_task
   - govuk_jenkins::jobs::clear_cdn_cache
   - govuk_jenkins::jobs::clear_frontend_memcache
   - govuk_jenkins::jobs::clear_template_cache

--- a/hieradata_aws/class/production/jenkins.yaml
+++ b/hieradata_aws/class/production/jenkins.yaml
@@ -41,6 +41,7 @@ govuk_jenkins::config::user_permissions:
 govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::ask_export
   - govuk_jenkins::jobs::athena_fastly_logs_check
+  - govuk_jenkins::jobs::automated_rake_task
   - govuk_jenkins::jobs::bouncer_cdn
   - govuk_jenkins::jobs::check_sentry_errors
   - govuk_jenkins::jobs::clear_cdn_cache
@@ -125,4 +126,3 @@ govuk_jenkins::jobs::user_monitor::enable_icinga_check: true
 
 govuk_jenkins::jobs::validate_published_dns::app_domain: blue.production.govuk.digital
 govuk_jenkins::jobs::validate_published_dns::run_daily: true
-

--- a/hieradata_aws/class/staging/jenkins.yaml
+++ b/hieradata_aws/class/staging/jenkins.yaml
@@ -47,6 +47,7 @@ govuk_jenkins::config::user_permissions:
 
 govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::athena_fastly_logs_check
+  - govuk_jenkins::jobs::automated_rake_task
   - govuk_jenkins::jobs::clear_cdn_cache
   - govuk_jenkins::jobs::clear_frontend_memcache
   - govuk_jenkins::jobs::clear_template_cache

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1083,6 +1083,7 @@ govuk_jenkins::jobs::smokey::signon_password: "%{hiera('smokey_signon_password')
 govuk_jenkins::jobs::smokey::smokey_govuk_account_email: "%{hiera('smokey_govuk_account_email')}"
 govuk_jenkins::jobs::smokey::smokey_govuk_account_password: "%{hiera('smokey_govuk_account_password')}"
 
+govuk_jenkins::jobs::automated_rake_task::applications: *deployable_applications
 govuk_jenkins::jobs::run_rake_task::applications: *deployable_applications
 govuk_jenkins::jobs::deploy_app::applications: *deployable_applications
 

--- a/modules/govuk_jenkins/manifests/jobs/automated_rake_task.pp
+++ b/modules/govuk_jenkins/manifests/jobs/automated_rake_task.pp
@@ -1,0 +1,14 @@
+# == Class: govuk_jenkins::jobs::automated_rake_task
+#
+# Create a file on disk that can be parsed by jenkins-job-builder
+#
+class govuk_jenkins::jobs::automated_rake_task(
+  $applications = undef,
+) {
+
+  file { '/etc/jenkins_jobs/jobs/automated_rake_task.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/automated_rake_task.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+}

--- a/modules/govuk_jenkins/templates/jobs/automated_rake_task.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/automated_rake_task.yaml.erb
@@ -1,0 +1,47 @@
+---
+- job:
+    name: automated-rake-task
+    display-name: Runs a rake task (only for use in automation)
+    project-type: freestyle
+    description: "For running automated rake task on an application. This job should NOT be run by humans."
+    concurrent: true
+    properties:
+      - build-discarder:
+          days-to-keep: 30
+          artifact-num-to-keep: 5
+    builders:
+      - shell: ssh deploy@$(govuk_node_list -c $MACHINE_CLASS --single-node) "cd /var/apps/$TARGET_APPLICATION && govuk_setenv $TARGET_APPLICATION bundle exec rake $RAKE_TASK"
+    wrappers:
+      - ansicolor:
+          colormap: xterm
+      - build-name:
+          name: '#${BUILD_NUMBER}: ${ENV,var="TARGET_APPLICATION"} ${ENV,var="RAKE_TASK"}'
+      - timestamps
+    parameters:
+      - choice:
+          name: TARGET_APPLICATION
+          description: Choose the application to run the rake task in
+          choices: <%= ['-- Choose an app'] + @applications.keys %>
+      - choice:
+          name: MACHINE_CLASS
+          description: Choose the machine class this app is running on
+          choices:
+            - account
+            - api
+            - backend
+            - bouncer
+            - calculators_frontend
+            - content_store
+            - draft_cache
+            - draft_content_store
+            - draft_frontend
+            - email_alert_api
+            - frontend
+            - router_backend
+            - publishing_api
+            - search
+            - whitehall_backend
+            - whitehall_frontend
+      - string:
+          name: RAKE_TASK
+          description: Name of rake task to run (try `-T` to print the tasks)

--- a/modules/govuk_jenkins/templates/jobs/content_data_api.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/content_data_api.yaml.erb
@@ -6,7 +6,7 @@
     description: "<p>Run the etl:main rake task.</p>"
     builders:
       - trigger-builds:
-          - project: run-rake-task
+          - project: automated-rake-task
             block: true
             predefined-parameters: |
               TARGET_APPLICATION=content-data-api

--- a/modules/govuk_jenkins/templates/jobs/content_data_api_re_run.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/content_data_api_re_run.yaml.erb
@@ -6,7 +6,7 @@
     description: "<p>Rerun the etl:main rake task to populate missing data.</p>"
     builders:
       - trigger-builds:
-          - project: run-rake-task
+          - project: automated-rake-task
             block: true
             predefined-parameters: |
               TARGET_APPLICATION=content-data-api

--- a/modules/govuk_jenkins/templates/jobs/enhanced_ecommerce.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/enhanced_ecommerce.yaml.erb
@@ -10,7 +10,7 @@
           artifact-num-to-keep: 5
     builders:
       - trigger-builds:
-          - project: run-rake-task
+          - project: automated-rake-task
             block: true
             predefined-parameters: |
               TARGET_APPLICATION=<%= @target_application %>

--- a/modules/govuk_jenkins/templates/jobs/monitor_taxonomy_health.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/monitor_taxonomy_health.yaml.erb
@@ -16,7 +16,7 @@
           artifact-num-to-keep: 5
     builders:
       - trigger-builds:
-          - project: run-rake-task
+          - project: automated-rake-task
             block: true
             predefined-parameters: |
               TARGET_APPLICATION=content-tagger

--- a/modules/govuk_jenkins/templates/jobs/publication_delay_report.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/publication_delay_report.yaml.erb
@@ -9,7 +9,7 @@
           artifact-num-to-keep: 30
     builders:
       - trigger-builds:
-          - project: run-rake-task
+          - project: automated-rake-task
             block: true
             predefined-parameters: |
               TARGET_APPLICATION=content-store

--- a/modules/govuk_jenkins/templates/jobs/publishing_api_archive_events.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/publishing_api_archive_events.yaml.erb
@@ -10,7 +10,7 @@
           artifact-num-to-keep: 5
     builders:
       - trigger-builds:
-          - project: run-rake-task
+          - project: automated-rake-task
             block: true
             predefined-parameters: |
               TARGET_APPLICATION=publishing-api

--- a/modules/govuk_jenkins/templates/jobs/record_superfluous_taggings_metrics.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/record_superfluous_taggings_metrics.yaml.erb
@@ -19,7 +19,7 @@
           artifact-num-to-keep: 5
     builders:
       - trigger-builds:
-          - project: run-rake-task
+          - project: automated-rake-task
             block: true
             predefined-parameters: |
               TARGET_APPLICATION=content-tagger

--- a/modules/govuk_jenkins/templates/jobs/record_taxonomy_metrics.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/record_taxonomy_metrics.yaml.erb
@@ -16,7 +16,7 @@
           artifact-num-to-keep: 5
     builders:
       - trigger-builds:
-          - project: run-rake-task
+          - project: automated-rake-task
             block: true
             predefined-parameters: |
               TARGET_APPLICATION=content-tagger

--- a/modules/govuk_jenkins/templates/jobs/remove_emergency_banner.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/remove_emergency_banner.yaml.erb
@@ -10,7 +10,7 @@
           num-to-keep: 30
     builders:
       - trigger-builds:
-          - project: run-rake-task
+          - project: automated-rake-task
             block: true
             predefined-parameters: |
               TARGET_APPLICATION=static

--- a/modules/govuk_jenkins/templates/jobs/run_whitehall_data_migrations.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/run_whitehall_data_migrations.yaml.erb
@@ -10,7 +10,7 @@
           artifact-num-to-keep: 5
     builders:
       - trigger-builds:
-          - project: run-rake-task
+          - project: automated-rake-task
             block: true
             predefined-parameters: |
               TARGET_APPLICATION=whitehall

--- a/modules/govuk_jenkins/templates/jobs/search_generate_sitemaps.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/search_generate_sitemaps.yaml.erb
@@ -10,7 +10,7 @@
           artifact-num-to-keep: 5
     builders:
       - trigger-builds:
-          - project: run-rake-task
+          - project: automated-rake-task
             block: true
             predefined-parameters: |
               TARGET_APPLICATION=search-api

--- a/modules/govuk_jenkins/templates/jobs/search_index_checks.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/search_index_checks.yaml.erb
@@ -15,7 +15,7 @@
             artifact-num-to-keep: 5
     builders:
       - trigger-builds:
-          - project: run-rake-task
+          - project: automated-rake-task
             block: true
             predefined-parameters: |
               TARGET_APPLICATION=<%= @target_application %>

--- a/modules/govuk_jenkins/templates/jobs/search_relevancy_metrics_etl.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/search_relevancy_metrics_etl.yaml.erb
@@ -10,7 +10,7 @@
     <p>Get in touch with the search team for more details.</p>"
     builders:
       - trigger-builds:
-          - project: run-rake-task
+          - project: automated-rake-task
             block: true
             predefined-parameters: |
               TARGET_APPLICATION=search-api

--- a/modules/govuk_jenkins/templates/jobs/search_relevancy_rank_evaluation.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/search_relevancy_rank_evaluation.yaml.erb
@@ -7,7 +7,7 @@
     <p>Get in touch with the search team for more details.</p>"
     builders:
       - trigger-builds:
-          - project: run-rake-task
+          - project: automated-rake-task
             block: true
             predefined-parameters: |
               TARGET_APPLICATION=search-api

--- a/modules/govuk_jenkins/templates/jobs/signon_cron_rake_tasks.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/signon_cron_rake_tasks.yaml.erb
@@ -6,7 +6,7 @@
     description: "<p>Regularly run the oauth_access_grants:delete_expired rake task for signon.</p>"
     builders:
         - trigger-builds:
-            - project: run-rake-task
+            - project: automated-rake-task
               block: true
               predefined-parameters: |
                 TARGET_APPLICATION=signon
@@ -27,7 +27,7 @@
           artifact-num-to-keep: 5
     builders:
         - trigger-builds:
-            - project: run-rake-task
+            - project: automated-rake-task
               block: true
               predefined-parameters: |
                 TARGET_APPLICATION=signon
@@ -44,7 +44,7 @@
     description: "<p>Regularly run the users:suspend_inactive rake task for signon.</p>"
     builders:
         - trigger-builds:
-            - project: run-rake-task
+            - project: automated-rake-task
               block: true
               predefined-parameters: |
                 TARGET_APPLICATION=signon
@@ -61,7 +61,7 @@
     description: "<p>Regularly run the users:send_suspension_reminders rake task for signon.</p>"
     builders:
         - trigger-builds:
-            - project: run-rake-task
+            - project: automated-rake-task
               block: true
               predefined-parameters: |
                 TARGET_APPLICATION=signon

--- a/modules/govuk_jenkins/templates/jobs/smart_answers_broken_links_report.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/smart_answers_broken_links_report.yaml.erb
@@ -6,7 +6,7 @@
     description: "<p>Searches Smart Answer flows for broken links, by quering link checker api and sends a report to zendesk</p>"
     builders:
       - trigger-builds:
-          - project: run-rake-task
+          - project: automated-rake-task
             block: true
             predefined-parameters: |
               TARGET_APPLICATION=smartanswers

--- a/modules/govuk_jenkins/templates/jobs/whitehall_publisher_notifications.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/whitehall_publisher_notifications.yaml.erb
@@ -6,7 +6,7 @@
     description: "<p>Regularly run the publisher_notifications:send rake task for whitehall publisher.</p>"
     builders:
         - trigger-builds:
-            - project: run-rake-task
+            - project: automated-rake-task
               block: true
               predefined-parameters: |
                 TARGET_APPLICATION=whitehall

--- a/modules/govuk_jenkins/templates/jobs/whitehall_run_broken_link_checker.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/whitehall_run_broken_link_checker.yaml.erb
@@ -10,7 +10,7 @@
           artifact-num-to-keep: 5
     builders:
       - trigger-builds:
-          - project: run-rake-task
+          - project: automated-rake-task
             block: true
             predefined-parameters: |
               TARGET_APPLICATION=whitehall

--- a/spec/fixtures/hieradata/common.yaml
+++ b/spec/fixtures/hieradata/common.yaml
@@ -81,6 +81,7 @@ govuk_jenkins::config::github_web_uri: wibble
 
 govuk_jenkins::jobs::deploy_app::applications: *deployable_applications
 govuk_jenkins::jobs::deploy_app_downstream::applications: *deployable_applications
+govuk_jenkins::jobs::automated_rake_task::applications: *deployable_applications
 govuk_jenkins::jobs::run_rake_task::applications: *deployable_applications
 govuk_jenkins::jobs::content_data_api_re_run::re_run_rake_etl_main_process_cron_schedule: '0 3 * * *'
 


### PR DESCRIPTION
This duplicates the run-rake-task Jenkins job which has been run 225,038 times in one environment.

We'd like to see what jobs are run manually vs automated so we have a better idea of the necessity for a manual job runner and the features we'll need to implement to replace the manual rake tasks.

The second commit changes all the automated jobs to trigger the automated-rake-task job so we don't need to update our docs / manual workflow to use a different job.

Example of the job in integration (deployed branch): https://deploy.integration.publishing.service.gov.uk/job/search_api_index_checks/145154/downstreambuildview/
