### PR TITLE
Adds RDS stats to MySQL db application dashboards

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1207,9 +1207,11 @@ grafana::dashboards::application_dashboards:
     instance_prefix: 'frontend'
     show_memcached: true
   collections-publisher:
+    show_mysql_stats: true
     show_sidekiq_graphs: true
     has_workers: true
   contacts:
+    show_mysql_stats: true
     docs_name: 'contacts-admin'
   content-data-admin:
     show_postgres_stats: true
@@ -1301,7 +1303,8 @@ grafana::dashboards::application_dashboards:
     has_workers: true
     instance_prefix: 'publishing_api'
     show_memcached: true
-  release: {}
+  release:
+    show_mysql_stats: true
   router: {}
   router-api: {}
   search-api:
@@ -1321,12 +1324,14 @@ grafana::dashboards::application_dashboards:
       - collections
       - finder-frontend
       - whitehall-frontend
-  search-admin: {}
+  search-admin:
+    show_mysql_stats: true
   service-manual-frontend: {}
   service-manual-publisher: {}
   short-url-manager: {}
   sidekiq-monitoring: {}
   signon:
+    show_mysql_stats: true
     show_sidekiq_graphs: true
     has_workers: true
   smartanswers:
@@ -1360,6 +1365,7 @@ grafana::dashboards::application_dashboards:
     show_sidekiq_graphs: true
     has_workers: true
   whitehall:
+    show_mysql_stats: true
     show_sidekiq_graphs: true
     has_workers: true
     error_threshold: 50

--- a/modules/grafana/manifests/dashboards/application_dashboard.pp
+++ b/modules/grafana/manifests/dashboards/application_dashboard.pp
@@ -48,6 +48,7 @@ define grafana::dashboards::application_dashboard (
   $show_sidekiq_graphs = false,
   $show_controller_errors = true,
   $show_postgres_stats = false,
+  $show_mysql_stats = false,
   $show_response_times = false,
   $show_slow_requests = true,
   $dependent_app_5xx_errors = undef,
@@ -111,17 +112,17 @@ define grafana::dashboards::application_dashboard (
     $memcached_row = []
   }
 
-  if $show_postgres_stats {
-    $postgres_stats_row = [
+  if $show_postgres_stats or $show_mysql_stats {
+    $database_stats_row = [
       [
-        'postgres_stats']
+        'database_stats']
     ]
   } else {
-    $postgres_stats_row = []
+    $database_stats_row = []
   }
 
   $panel_partials = concat(
-    $postgres_stats_row,
+    $database_stats_row,
     [
       ['processor_count'],
       ['error_counts_table', 'links']

--- a/modules/grafana/templates/dashboards/application_dashboard_panels/_database_stats.json.erb
+++ b/modules/grafana/templates/dashboards/application_dashboard_panels/_database_stats.json.erb
@@ -1,0 +1,9 @@
+{
+  "content": "- [AWS RDS Stats for databases](/dashboard/file/aws-rds.json?orgId=1&var-region=eu-west-1&var-dbinstanceidentifier=<%= "#{@app_name}-#{@show_postgres_stats ? "postgres" : "mysql"}" %>)",
+  "id": 77,
+  "links": [],
+  "mode": "markdown",
+  "span": 12,
+  "title": "",
+  "type": "text"
+}

--- a/modules/grafana/templates/dashboards/application_dashboard_panels/_postgres_stats.json.erb
+++ b/modules/grafana/templates/dashboards/application_dashboard_panels/_postgres_stats.json.erb
@@ -1,9 +1,0 @@
-{
-  "content": "- [AWS RDS Stats for databases](/dashboard/file/aws-rds.json?orgId=1&var-region=eu-west-1&var-dbinstanceidentifier=<%= @app_name %>-postgres)",
-  "id": 77,
-  "links": [],
-  "mode": "markdown",
-  "span": 12,
-  "title": "",
-  "type": "text"
-}

--- a/modules/grafana/templates/dashboards/application_dashboard_template.json.erb
+++ b/modules/grafana/templates/dashboards/application_dashboard_template.json.erb
@@ -12,7 +12,7 @@
       <%= ',' if i > 0 %> {
         "collapse": false,
         "editable": true,
-        "height": <%= row.last == "postgres_stats" ? 50 : 250 %>,
+        "height": <%= row.last == "database_stats" ? 50 : 250 %>,
         "panels": [
           <% row.each_with_index do |panel_name, j| %>
             <%= ',' if j > 0 %> <%= scope.function_template(["grafana/dashboards/application_dashboard_panels/_#{panel_name}.json.erb"]) %>


### PR DESCRIPTION
We've added the stats for Postgres applications [1], this now does the
same for MySQL apps.

### Added RDS link, e.g Whitehall

<img width="796" alt="Screenshot 2022-01-28 at 12 56 24" src="https://user-images.githubusercontent.com/24479188/151550933-24805e33-b217-49c4-9432-e3fe4bcff143.png">

### Link destination

<img width="1154" alt="Screenshot 2022-01-28 at 12 56 32" src="https://user-images.githubusercontent.com/24479188/151550958-3b8b74a1-cdd2-425b-8fdb-4295b634306b.png">

Trello:
https://trello.com/c/VWpD8SvY/55-remove-mysql-primary-and-mysql-standby-infrastructure-and-configuration

[1]: https://github.com/alphagov/govuk-puppet/commit/c4c55c97679568a48a4d18abf39eb99bd1b8d82b