### PR TITLE
Fix bug in sync script

### DIFF
--- a/modules/govuk_crawler/templates/govuk_sync_mirror.erb
+++ b/modules/govuk_crawler/templates/govuk_sync_mirror.erb
@@ -46,8 +46,8 @@ function write_timestamps() {
   upload_time=$(date +%s)
 
   cat <<EOF > timestamps.txt
-  upload_time=$upload_time
-  EOF
+upload_time=$upload_time
+EOF
 
   sudo mv timestamps.txt $website_mirror_dir
 }


### PR DESCRIPTION
Introduced in https://github.com/alphagov/govuk-puppet/pull/11521

The indentation was causing and error:
/usr/local/bin/govuk_sync_mirror: line 95: warning: here-document at line 48 delimited by end-of-file (wanted `EOF')
/usr/local/bin/govuk_sync_mirror: line 96: syntax error: unexpected end of file