### PR TITLE
Only do daily backups of MongoDB in integration

### DIFF
--- a/modules/mongodb/spec/classes/mongodb__aws_backup_spec.rb
+++ b/modules/mongodb/spec/classes/mongodb__aws_backup_spec.rb
@@ -5,6 +5,6 @@ describe 'mongodb::aws_backup', :type => :class do
     let(:params){{ 'bucket' => 'my-bucket' }}
     it { is_expected.to contain_file('/var/lib/mongodb/backup').with_ensure('directory') }
     it { is_expected.to contain_file('/usr/local/bin/mongodump-to-s3').with_ensure('present') }
-    it { is_expected.to contain_cron__crondotdee('mongodump-to-s3').with_minute('*/30') }
+    it { is_expected.to contain_cron__crondotdee('mongodump-to-s3') }
   end
 end

--- a/modules/mongodb/templates/mongodump-to-s3.erb
+++ b/modules/mongodb/templates/mongodump-to-s3.erb
@@ -32,13 +32,8 @@ function exit_trap() {
 
 trap exit_trap EXIT
 
-if [[ "$(date +%H:%M)" == "<%= @daily_time -%>" ]]; then
-  BUCKET_KEY='mongodb/daily/<%= @aws_migration -%>'
-  echo "Creating 'daily' backup for long term storage"
-else
-  BUCKET_KEY='mongodb/regular/<%= @aws_migration -%>'
-  echo "Creating 'regular' backup for point in time restores"
-fi
+BUCKET_KEY='mongodb/daily/<%= @aws_migration -%>'
+echo "Creating 'daily' backup for long term storage"
 
 # Create a list of members in the cluster.
 members=( $(mongo --quiet --eval 'rs.conf().members.forEach(function(x){ print(x.host) })') )
@@ -69,7 +64,7 @@ fi
 my_name=( $( mongo --quiet --eval 'rs.isMaster().me') )
 
 # Only run if I am the elected member.
-if [ "${my_name}" == "${secondary}" ] 
+if [ "${my_name}" == "${secondary}" ]
  then
   echo "Starting backup"
   /usr/bin/mongodump -o <%= @backup_dir -%>/mongodump >/dev/null


### PR DESCRIPTION
Trello: https://trello.com/c/rFIPmgBl/107-turn-off-hourly-mongodb-backups

We only run this script in integration and it only seems to have the
purpose of populating the files that are used for a govuk-docker
replication task [1] (which itself is a bit weird, it's unclear why it
doesn't use env sync backups like everything else... but yaks).

Because of this it seems rather superfluous to be generating backups
every 30 mins.

This changes the script to only run once a day, it is set to run at 8am
to be out the way of the database syncs.

I simplified the test a bit as it seemed unnecessary for the test to be
coupled with the time this task runs.

[1]: https://github.com/alphagov/govuk-docker/blob/6004cdc44ff60fc59e9b7aa156737621ff780a6d/bin/replicate-mongodb.sh#L52-L54