### PR TITLE
Remove cache invalidation emergency banner downstream jobs

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_emergency_banner.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_emergency_banner.yaml.erb
@@ -35,12 +35,6 @@
               DEPLOY_TASK=deploy
               TAG=release
             block: true
-          - project: clear-frontend-memcache
-            block: true
-          - project: clear-varnish-cache
-            block: true
-          - project: clear-cdn-cache
-            block: true
     wrappers:
       - ansicolor:
           colormap: xterm

--- a/modules/govuk_jenkins/templates/jobs/remove_emergency_banner.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/remove_emergency_banner.yaml.erb
@@ -22,12 +22,6 @@
               DEPLOY_TASK=deploy
               TAG=release
             block: true
-          - project: clear-frontend-memcache
-            block: true
-          - project: clear-varnish-cache
-            block: true
-          - project: clear-cdn-cache
-            block: true
     wrappers:
       - ansicolor:
           colormap: xterm


### PR DESCRIPTION
This commit removes the cache invalidation logic from the add/remove emergency banner jobs, in order to implement RFC 144 [1].

We no longer need to clear the caches as the TTL on GOV.UK pages has been reduced to 5 minutes. We can therefore wait 5 minutes for the banner to appear on all GOV.UK pages.

I have kept the jobs to purge the varnish / Fastly caches in Jenkins as we may need them in future.

[1]: https://github.com/alphagov/govuk-rfcs/blob/main/rfc-144-consistent-cache-expiry.md

https://trello.com/c/OaUhq6uI/722-replatform-emergency-banner