### PR TITLE
Set a 5 minute TTL on GOV.UK pages

### DIFF
--- a/modules/govuk/manifests/apps/content_store.pp
+++ b/modules/govuk/manifests/apps/content_store.pp
@@ -61,7 +61,7 @@ class govuk::apps::content_store(
   $mongodb_nodes,
   $mongodb_name,
   $vhost = 'content-store',
-  $default_ttl = '600',
+  $default_ttl = '300',
   $performance_platform_big_screen_view_url = undef,
   $performance_platform_spotlight_url = undef,
   $publishing_api_bearer_token = undef,

--- a/modules/govuk/manifests/node/s_cache.pp
+++ b/modules/govuk/manifests/node/s_cache.pp
@@ -103,7 +103,7 @@ class govuk::node::s_cache (
 
   class { 'varnish':
     storage_size  => join([$varnish_storage_size,'M'],''),
-    default_ttl   => '900',
+    default_ttl   => '300',
     upstream_port => $varnish_upstream_port,
     strip_cookies => $strip_cookies,
   }

--- a/modules/varnish/manifests/init.pp
+++ b/modules/varnish/manifests/init.pp
@@ -11,7 +11,7 @@
 #   or `Expires`). This is passed as the `-t` argument to the [`varnishd`](https://www.varnish-cache.org/docs/3.0/reference/varnishd.html?highlight=default_ttl)
 #   command when it is started up.
 #
-#   Default: 900
+#   Default: 300
 #
 # [*strip_cookies*]
 #   Whether cookies should be stripped from inbound requests and outbound responses.
@@ -34,7 +34,7 @@
 #   The first two octets of the IP range we're on.
 #
 class varnish (
-    $default_ttl  = 900,
+    $default_ttl  = 300,
     $strip_cookies = true,
     $storage_size = '512M',
     $upstream_port = 3054,


### PR DESCRIPTION
This implements [RFC 144](https://github.com/alphagov/govuk-rfcs/blob/main/rfc-144-consistent-cache-expiry.md) which will enable us to merge https://github.com/alphagov/govuk-puppet/pull/11537 and explore sunsetting the [cache-clearing-service](https://docs.publishing.service.gov.uk/repos/cache-clearing-service.html).

We've not seen a performance impact from decreasing the TTL from 30 -> 20 -> 10 minutes so far. Our cache hit rate at Fastly is still at the same level.

https://trello.com/c/OaUhq6uI/722