### PR TITLE
Revert "Add interest cohort permission policy"

### DIFF
--- a/modules/nginx/files/etc/nginx/add-permissions-policy.conf
+++ b/modules/nginx/files/etc/nginx/add-permissions-policy.conf
@@ -1,1 +1,0 @@
-add_header Permissions-Policy interest-cohort=();

--- a/modules/nginx/templates/proxy-vhost.conf
+++ b/modules/nginx/templates/proxy-vhost.conf
@@ -52,8 +52,6 @@ server {
   # Send the Strict-Transport-Security header
   include /etc/nginx/add-sts.conf;
 
-  include /etc/nginx/add-permissions-policy.conf;
-
   <%- if port == 443 -%>
   listen              443 ssl<%= $is_default_vhost ? " default_server" : "" %>;
   ssl_certificate     /etc/nginx/ssl/<%= @name %>.crt;


### PR DESCRIPTION
This reverts commit 29b91807ba98c83b5f1d741c9178d51128d96c3f.

This was intended to prevent GOV.UK content being used as part of the
FLoC proposal [1]. Google has since replaced the FLoC proposal with a
new Topics API [2]. We therefore no longer have a need to set this
header.

[1]: https://github.com/WICG/floc
[2]: https://blog.google/products/chrome/get-know-new-topics-api-privacy-sandbox/