### PR TITLE
Install Terraform 1.1.5 on Jenkins.

### DIFF
--- a/modules/govuk_jenkins/manifests/packages/tfenv.pp
+++ b/modules/govuk_jenkins/manifests/packages/tfenv.pp
@@ -10,7 +10,7 @@
 #
 #
 class govuk_jenkins::packages::tfenv (
-  $terraform_versions = ['0.11.14', '0.11.15', '0.12.30', '0.13.6'],
+  $terraform_versions = ['0.11.14', '0.11.15', '0.12.30', '0.13.6', '1.1.5'],
 ){
 
   include ::tfenv


### PR DESCRIPTION
So that we can deploy the `infra-security` module again. See alphagov/govuk-aws#1547.