### PR TITLE
Add index selection to Search Reindex job

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/search_reindex_with_new_schema.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/search_reindex_with_new_schema.yaml.erb
@@ -15,8 +15,20 @@
       - build-discarder:
           days-to-keep: 30
           artifact-num-to-keep: 5
+    parameters:
+      - choice:
+          name: SEARCH_INDEX
+          description: The search index to reindex. Defaults to all.
+          choices:
+              - all
+              - detailed
+              - government
+              - govuk
+              - licence-finder
+              - metasearch
+              - page-traffic
     builders:
-        - shell: ssh deploy@$(govuk_node_list -c search --single-node) "cd /var/apps/<%= @target_application %> && govuk_setenv <%= @target_application %> bundle exec rake search:migrate_schema SEARCH_INDEX=all"
+        - shell: ssh deploy@$(govuk_node_list -c search --single-node) "cd /var/apps/<%= @target_application %> && govuk_setenv <%= @target_application %> bundle exec rake search:migrate_schema SEARCH_INDEX=\"$SEARCH_INDEX\""
     wrappers:
       - ansicolor:
           colormap: xterm


### PR DESCRIPTION
This will allow us to select the index to reindex, which will be faster than reindexing everything when only one is required.

Also will allow us to remove a section of the developer documentation where a single index can only be reindexed by running a rake task.

Screenshot from Jenkins:
![Screenshot of Jenkins showing the Reindex Search job, with a dropdown menu offering a choice of all the indices available to reindex](https://user-images.githubusercontent.com/6329861/153900247-1c01f64a-96af-4579-ae07-622c40c29fdd.png)