### PR TITLE
Add Becka Lelew to users

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -345,6 +345,7 @@ users::usernames:
   - andydriver
   - andysellick
   - barbaraslawinska
+  - beckalelew
   - benjamineskola
   - benthorner
   - brucebolt

--- a/modules/users/manifests/beckalelew.pp
+++ b/modules/users/manifests/beckalelew.pp
@@ -1,0 +1,8 @@
+# Creates the user beckalelew
+class users::beckalelew {
+  govuk_user { 'beckalelew':
+    fullname => 'Becka Lelew',
+    email    => 'becka.lelew@digital.cabinet-office.gov.uk',
+    ssh_key  => 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIR1nueOVbg2PVlCMgAlgNJ+N+2tJcuEvDBMyoGsXgOT becka.lelew@digital.cabinet-office.gov.uk',
+  }
+}


### PR DESCRIPTION
Add Becka Lelew to users to enable access to SSH into integration.
As per getting started intructions: https://docs.publishing.service.gov.uk/manual/get-started.html