### PR TITLE
Add GTM env vars to government frontend

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -44,6 +44,9 @@ govuk::apps::feedback::govuk_notify_accessible_format_request_reply_to_id: '7794
 govuk::apps::feedback::govuk_notify_accessible_format_request_template_id: '47cef7ea-0849-48aa-9676-0ee0f7baa4ae'
 govuk::apps::frontend::govuk_notify_template_id: '1fc69d3a-09a2-40f9-852b-03f6fcef5340'
 govuk::apps::frontend::govuk_personalisation_manage_uri: 'https://integration.account.gov.uk?link=manage-account'
+govuk::apps::government_frontend::google_tag_manager_auth: "C7iYdcsOlYgGmiUJjZKrHQ"
+govuk::apps::government_frontend::google_tag_manager_id: "GTM-MG7HG5W"
+govuk::apps::government_frontend::google_tag_manager_preview: "env-4"
 govuk::apps::govuk_crawler_worker::enabled: false
 govuk::apps::govuk_crawler_worker::disable_during_data_sync: true
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true

--- a/modules/govuk/manifests/apps/government_frontend.pp
+++ b/modules/govuk/manifests/apps/government_frontend.pp
@@ -36,6 +36,15 @@
 # [*cpu_critical*]
 #   CPU usage percentage that alerts are sounded at
 #
+# [*google_tag_manager_id*]
+#   The ID for the Google Tag Manager account
+#
+# [*google_tag_manager_preview*]
+#   Allows a tag to be previewed in the Google Tag Manager interface
+#
+# [*google_tag_manager_auth*]
+#   The identifier of an environment for Google Tag Manager
+#
 class govuk::apps::government_frontend(
   $vhost = 'government-frontend',
   $port,
@@ -46,6 +55,9 @@ class govuk::apps::government_frontend(
   $unicorn_worker_processes = undef,
   $cpu_warning = 150,
   $cpu_critical = 200,
+  $google_tag_manager_id = undef,
+  $google_tag_manager_preview = undef,
+  $google_tag_manager_auth = undef,
 ) {
   Govuk::App::Envvar {
     app => 'government-frontend',
@@ -55,6 +67,15 @@ class govuk::apps::government_frontend(
     "${title}-ACCOUNT_API_BEARER_TOKEN":
         varname => 'ACCOUNT_API_BEARER_TOKEN',
         value   => $account_api_bearer_token;
+    "${title}-GOOGLE_TAG_MANAGER_ID":
+        varname => 'GOOGLE_TAG_MANAGER_ID',
+        value   => $google_tag_manager_id;
+    "${title}-GOOGLE_TAG_MANAGER_PREVIEW":
+        varname => 'GOOGLE_TAG_MANAGER_PREVIEW',
+        value   => $google_tag_manager_preview;
+    "${title}-GOOGLE_TAG_MANAGER_AUTH":
+        varname => 'GOOGLE_TAG_MANAGER_AUTH',
+        value   => $google_tag_manager_auth;
     "${title}-PUBLISHING_API_BEARER_TOKEN":
         varname => 'PUBLISHING_API_BEARER_TOKEN',
         value   => $publishing_api_bearer_token;


### PR DESCRIPTION
We want to test GA4 tracking in integration only.

Environment variables provided here: https://trello.com/c/YgdDINY2/61-set-up-gtm-container-with-custom-environments
Trello: https://trello.com/c/kBaHV7MG/784-ga4-add-gtm-environment-variables-to-integration