### PR TITLE
Stop using Jenkins CI on govspeak repo

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -959,7 +959,6 @@ govuk_ci::master::pipeline_jobs:
   gds-api-adapters: {}
   gds-sso: {}
   gds_zendesk: {}
-  govspeak: {}
   govuk_ab_testing: {}
   govuk_app_config: {}
   govuk-cdn-config: {}


### PR DESCRIPTION
The govspeak gem is being switched over to use GitHub Actions instead of Jenkins for CI. It's therefore no longer necessary for Jenkins to have a pipeline job defined for the `govspeak` repository.

This change is a clean-up task following alphagov/govspeak#234
