### PR TITLE
Correct signon database sync path

### DIFF
--- a/hieradata_aws/class/staging/signon_db_admin.yaml
+++ b/hieradata_aws/class/staging/signon_db_admin.yaml
@@ -10,4 +10,4 @@ govuk_env_sync::tasks:
     database_hostname: "signon-mysql"
     temppath: "/tmp/signon_production"
     url: "govuk-production-database-backups"
-    path: "mysql"
+    path: "signon-mysql"


### PR DESCRIPTION
This was reading from the old location for database dumps and thus restoring signon from a progressively older database (25th January). This corrects the path to the new one defined in https://github.com/alphagov/govuk-puppet/blob/b9cecd0885b573e29a5042cef3258ce260909023/hieradata_aws/class/integration/signon_db_admin.yaml#L13