### PR TITLE
Stop using Jenkins CI on govuk_publishing_components

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -970,7 +970,6 @@ govuk_ci::master::pipeline_jobs:
   govuk_message_queue_consumer: {}
   govuk_personalisation: {}
   govuk-provisioning: {}
-  govuk_publishing_components: {}
   govuk_seed_crawler: {}
   govuk_schemas: {}
   govuk_sidekiq: {}


### PR DESCRIPTION
The govuk_publishing_components gem is being switched over to use GitHub Actions instead of Jenkins for CI. It's therefore no longer necessary for Jenkins to have a pipeline job defined for the `govuk_publishing_components` repository.

This change is a clean-up task following alphagov/govuk_publishing_components#2630