### PR TITLE
Ship jumpbox logs to cloudwatch

### DIFF
--- a/modules/govuk/files/node/s_jumpbox/amazon-cloudwatch-agent.json
+++ b/modules/govuk/files/node/s_jumpbox/amazon-cloudwatch-agent.json
@@ -1,0 +1,18 @@
+{
+  "agent": {
+    "run_as_user": "root"
+  },
+  "logs": {
+    "logs_collected": {
+      "files": {
+        "collect_list": [
+          {
+            "file_path": "/var/log/auth.log",
+            "log_group_name": "auth-log",
+            "log_stream_name": "{instance_id}"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/modules/govuk/manifests/node/s_jumpbox.pp
+++ b/modules/govuk/manifests/node/s_jumpbox.pp
@@ -9,4 +9,15 @@ class govuk::node::s_jumpbox inherits govuk::node::s_base {
     source => 'puppet:///modules/govuk/node/s_jumpbox/ssh-proxy',
   }
 
+  file { 'amazon-cloudwatch-agent.json':
+    ensure => 'present',
+    path   =>  '/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json',
+    mode   => '0644',
+    source => 'puppet:///modules/govuk/node/s_jumpbox/amazon-cloudwatch-agent.json',
+  }
+
+  service { 'amazon-cloudwatch-agent':
+    ensure    => 'running',
+    subscribe => File['amazon-cloudwatch-agent.json'],
+  }
 }

--- a/modules/govuk/manifests/node/s_jumpbox.pp
+++ b/modules/govuk/manifests/node/s_jumpbox.pp
@@ -1,6 +1,8 @@
 # FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
 class govuk::node::s_jumpbox inherits govuk::node::s_base {
 
+  include govuk_awscloudwatch
+
   file { '/usr/local/bin/ssh-proxy':
     ensure => 'present',
     mode   => '0775',


### PR DESCRIPTION
When a user uses ssh to connect to a linux server, the server stores a log in /var/log/auth.log

We should ship these logs to Splunk, so we have a proper audit trail of who's used ssh to connect to which machines.

The cyber security team recommend shipping logs to AWS CloudWatch Logs first, and then using their [centralised-security-logging-service](https://github.com/alphagov/centralised-security-logging-service) to ship them on to Splunk.

Initially just doing this for the jumpboxes is valuable enough. We may decide to do it for the other servers later on.

Depends on https://github.com/alphagov/govuk-aws/pull/1549

https://trello.com/c/3PEIdbKp/2608-ship-ssh-logs-from-jumpboxes-to-splunk