### PR TITLE
Add GTM env vars to static

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -44,9 +44,6 @@ govuk::apps::feedback::govuk_notify_accessible_format_request_reply_to_id: '7794
 govuk::apps::feedback::govuk_notify_accessible_format_request_template_id: '47cef7ea-0849-48aa-9676-0ee0f7baa4ae'
 govuk::apps::frontend::govuk_notify_template_id: '1fc69d3a-09a2-40f9-852b-03f6fcef5340'
 govuk::apps::frontend::govuk_personalisation_manage_uri: 'https://integration.account.gov.uk?link=manage-account'
-govuk::apps::government_frontend::google_tag_manager_auth: "C7iYdcsOlYgGmiUJjZKrHQ"
-govuk::apps::government_frontend::google_tag_manager_id: "GTM-MG7HG5W"
-govuk::apps::government_frontend::google_tag_manager_preview: "env-4"
 govuk::apps::govuk_crawler_worker::enabled: false
 govuk::apps::govuk_crawler_worker::disable_during_data_sync: true
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true
@@ -81,6 +78,9 @@ govuk::apps::specialist_publisher::aws_s3_bucket_name: 'govuk-integration-specia
 govuk::apps::specialist_publisher::publish_pre_production_finders: true
 govuk::apps::specialist_publisher::govuk_notify_template_id: "759acac6-da53-4a19-b591-b7538c7c39de"
 govuk::apps::static::ga_universal_id: 'UA-26179049-22'
+govuk::apps::static::google_tag_manager_auth: "C7iYdcsOlYgGmiUJjZKrHQ"
+govuk::apps::static::google_tag_manager_id: "GTM-MG7HG5W"
+govuk::apps::static::google_tag_manager_preview: "env-4"
 govuk::apps::static::govuk_personalisation_manage_uri: 'https://integration.account.gov.uk?link=manage-account'
 govuk::apps::static::govuk_personalisation_security_uri: 'https://integration.account.gov.uk?link=security-privacy'
 govuk::apps::static::govuk_personalisation_feedback_uri: 'https://signin.account.gov.uk/support'

--- a/modules/govuk/manifests/apps/government_frontend.pp
+++ b/modules/govuk/manifests/apps/government_frontend.pp
@@ -36,15 +36,6 @@
 # [*cpu_critical*]
 #   CPU usage percentage that alerts are sounded at
 #
-# [*google_tag_manager_id*]
-#   The ID for the Google Tag Manager account
-#
-# [*google_tag_manager_preview*]
-#   Allows a tag to be previewed in the Google Tag Manager interface
-#
-# [*google_tag_manager_auth*]
-#   The identifier of an environment for Google Tag Manager
-#
 class govuk::apps::government_frontend(
   $vhost = 'government-frontend',
   $port,
@@ -55,9 +46,6 @@ class govuk::apps::government_frontend(
   $unicorn_worker_processes = undef,
   $cpu_warning = 150,
   $cpu_critical = 200,
-  $google_tag_manager_id = undef,
-  $google_tag_manager_preview = undef,
-  $google_tag_manager_auth = undef,
 ) {
   Govuk::App::Envvar {
     app => 'government-frontend',
@@ -67,15 +55,6 @@ class govuk::apps::government_frontend(
     "${title}-ACCOUNT_API_BEARER_TOKEN":
         varname => 'ACCOUNT_API_BEARER_TOKEN',
         value   => $account_api_bearer_token;
-    "${title}-GOOGLE_TAG_MANAGER_ID":
-        varname => 'GOOGLE_TAG_MANAGER_ID',
-        value   => $google_tag_manager_id;
-    "${title}-GOOGLE_TAG_MANAGER_PREVIEW":
-        varname => 'GOOGLE_TAG_MANAGER_PREVIEW',
-        value   => $google_tag_manager_preview;
-    "${title}-GOOGLE_TAG_MANAGER_AUTH":
-        varname => 'GOOGLE_TAG_MANAGER_AUTH',
-        value   => $google_tag_manager_auth;
     "${title}-PUBLISHING_API_BEARER_TOKEN":
         varname => 'PUBLISHING_API_BEARER_TOKEN',
         value   => $publishing_api_bearer_token;

--- a/modules/govuk/manifests/apps/static.pp
+++ b/modules/govuk/manifests/apps/static.pp
@@ -48,6 +48,15 @@
 #   The number of unicorn worker processes to run.
 #   Default: undef
 #
+# # [*google_tag_manager_id*]
+#   The ID for the Google Tag Manager account
+#
+# [*google_tag_manager_preview*]
+#   Allows a tag to be previewed in the Google Tag Manager interface
+#
+# [*google_tag_manager_auth*]
+#   The identifier of an environment for Google Tag Manager
+#
 # [*govuk_personalisation_manage_uri*]
 #   URI for the account management page.
 #
@@ -69,6 +78,9 @@ class govuk::apps::static(
   $redis_host = undef,
   $redis_port = undef,
   $unicorn_worker_processes = undef,
+  $google_tag_manager_id = undef,
+  $google_tag_manager_preview = undef,
+  $google_tag_manager_auth = undef,
   $govuk_personalisation_manage_uri = undef,
   $govuk_personalisation_security_uri = undef,
   $govuk_personalisation_feedback_uri = undef,
@@ -121,6 +133,15 @@ class govuk::apps::static(
     "${title}-ASSET_HOST":
       varname => 'ASSET_HOST',
       value   => $asset_host;
+    "${title}-GOOGLE_TAG_MANAGER_ID":
+        varname => 'GOOGLE_TAG_MANAGER_ID',
+        value   => $google_tag_manager_id;
+    "${title}-GOOGLE_TAG_MANAGER_PREVIEW":
+        varname => 'GOOGLE_TAG_MANAGER_PREVIEW',
+        value   => $google_tag_manager_preview;
+    "${title}-GOOGLE_TAG_MANAGER_AUTH":
+        varname => 'GOOGLE_TAG_MANAGER_AUTH',
+        value   => $google_tag_manager_auth;
     "${title}-GOVUK-PERSONALISATION-MANAGE-URI":
       varname => 'GOVUK_PERSONALISATION_MANAGE_URI',
       value   => $govuk_personalisation_manage_uri;


### PR DESCRIPTION
We want to test our GTM set up in integration. We are conditionally rendering the GTM script in the presence of the env vars added here. The GTM component has been added to a template in static. Previous pr added the env vars to the rendering app which didn't work because the [`if`](https://github.com/alphagov/static/blob/73ff6c4059f0f3b98ff72583ed06bb5c38aa8dc6/app/views/root/_gem_base.html.erb#L36) logic has already been run by the time government frontend is rendering the page. 

This pr reverts [this](https://github.com/alphagov/govuk-puppet/pull/11550) pr which added the env vars to government frontend
https://trello.com/c/kBaHV7MG/784-ga4-add-gtm-environment-variables-to-integration