### PR TITLE
Update icinga graphite links to correct URL.

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1377,11 +1377,10 @@ grafana::dashboards::application_dashboards:
 
 grub2::recordfail_timeout: 5
 
+icinga::check::graphite_hostname: "graphite.%{hiera('app_domain_internal')}"
 icinga::client::config::allowed_hosts: "10.0.0.0/8"
 icinga::config::http_username: "%{hiera('http_username')}"
 icinga::config::http_password: "%{hiera('http_password')}"
-
-icinga::config::graphite_hostname: "graphite.%{hiera('app_domain_internal')}"
 
 limits::entries:
   'default_core':

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -358,6 +358,8 @@ govuk_sudo::sudo_conf:
 
 grafana::dashboards::machine_suffix_metrics: '_production'
 
+icinga::check::graphite_hostname: "graphite.blue.%{hiera('app_domain_internal')}"
+
 licensify::apps::configfile::mongo_database_reference_name: 'licensify-refdata'
 licensify::apps::configfile::mongo_database_audit_name: 'licensify-audit'
 licensify::apps::configfile::mongo_database_slaveok: 'false'

--- a/modules/icinga/manifests/check.pp
+++ b/modules/icinga/manifests/check.pp
@@ -28,6 +28,9 @@
 #   The title of a `Icinga::Timeperiod` resource describing when this
 #   service should be actively checked.
 #
+# [*graphite_hostname*]
+#   The hostname of the graphite system in this enviroment.
+#
 # [*notification_period*]
 #   The title of a `Icinga::Timeperiod` resource.
 #
@@ -64,6 +67,7 @@ define icinga::check (
   $service_description        = undef,
   $check_command              = undef,
   $check_period               = undef,
+  $graphite_hostname          = '',
   $notification_period        = undef,
   $use                        = 'govuk_regular_service',
   $action_url                 = undef,
@@ -79,6 +83,7 @@ define icinga::check (
   validate_re($service_description, '^(\w|\s|\-|/|\[|\]|:|\.)*$', "Icinga check \"${service_description}\" contains invalid characters")
 
   $app_domain = hiera('app_domain')
+
   $graph_width = 1000
   $graph_height = 600
 
@@ -95,7 +100,7 @@ define icinga::check (
     }
 
     if $linked_metric {
-      $action_url_real = "https://graphite.${app_domain}/render/?\
+      $action_url_real = "https://${graphite_hostname}/render/?\
 width=${graph_width}&height=${graph_height}&target=${linked_metric}"
     } else {
       $action_url_real = $action_url

--- a/modules/icinga/spec/defines/icinga__check_spec.rb
+++ b/modules/icinga/spec/defines/icinga__check_spec.rb
@@ -113,7 +113,7 @@ describe 'icinga::check', :type => :define do
 
     it {
       is_expected.to contain_file('/etc/icinga/conf.d/icinga_host_bruce-forsyth/linking_to_metrics.cfg').
-        with_content(/^\s*action_url\s+https:\/\/graphite\.environment\.example\.com\/render\/\?width=\d+&height=\d+&target=stats.cache-1.nginx_logs.www-origin.http_200$/)
+        with_content(/^\s*action_url\s+https:\/\/graphite\.test\.govuk-internal\.digital\/render\/\?width=\d+&height=\d+&target=stats.cache-1.nginx_logs.www-origin.http_200$/)
     }
   end
 end

--- a/spec/fixtures/hieradata/common.yaml
+++ b/spec/fixtures/hieradata/common.yaml
@@ -138,6 +138,8 @@ hosts::production::management::hosts:
   jumpbox-1:
     ip: '10.1.0.100'
 
+icinga::check::graphite_hostname: "graphite.test.govuk-internal.digital"
+
 mongodb::repository::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 mongodb::repository::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 mongodb::s3backup::backup::private_gpg_key_fingerprint: 'CB77872D51ADD27CF75BD63CB60B50E6DBE2EAFF'


### PR DESCRIPTION
## What
Point icinga graphite links to the AWS origin (production.govuk.digital)

## Why
Icinga graphite links point to the publishing hostname, so currently broken.