### PR TITLE
Add go version 1.17.7 for Router

### DIFF
--- a/modules/golang/manifests/init.pp
+++ b/modules/golang/manifests/init.pp
@@ -7,16 +7,14 @@ class golang {
   include govuk_ppa
 
   class { 'goenv':
-    global_version => '1.15.8',
+    global_version => '1.17.7',
     require        => Class['govuk_ppa'],
   }
 
   goenv::version { [
     '1.7.1',   # Used by alphagov/govuk_crawler_worker
-    '1.11.13', # Used by alphagov/router
     '1.12.1',  # Used by alphagov/govuk-csp-forwarder
-    '1.15.8',  # Used by alphagov/router
-    '1.17.6',  # Used by alphagov/router
+    '1.17.6',  # Used by alphagov/router (remove once router is running 1.17.7)
     '1.17.7',  # Used by alphagov/router
     ]: }
 

--- a/modules/golang/manifests/init.pp
+++ b/modules/golang/manifests/init.pp
@@ -17,6 +17,7 @@ class golang {
     '1.12.1',  # Used by alphagov/govuk-csp-forwarder
     '1.15.8',  # Used by alphagov/router
     '1.17.6',  # Used by alphagov/router
+    '1.17.7',  # Used by alphagov/router
     ]: }
 
   package { ['godep']:


### PR DESCRIPTION
Related PR to update router to use go version 1.17.7: https://github.com/alphagov/router/pull/254