### PR TITLE
Install ChromeDriver alongside Google Chrome on test/CI machines

### DIFF
--- a/modules/govuk/manifests/node/s_jenkins.pp
+++ b/modules/govuk/manifests/node/s_jenkins.pp
@@ -22,7 +22,7 @@ class govuk::node::s_jenkins (
   $jenkins_api_token = undef,
   $environment_variables = {},
 ) inherits govuk::node::s_base {
-  include google_chrome
+  include govuk_chromedriver
   include nginx
   include govuk_postgresql::client
   include govuk_rbenv::all

--- a/modules/govuk/manifests/node/s_monitoring.pp
+++ b/modules/govuk/manifests/node/s_monitoring.pp
@@ -17,7 +17,7 @@ class govuk::node::s_monitoring (
 
   validate_bool($enable_fastly_metrics, $offsite_backups)
 
-  include google_chrome
+  include govuk_chromedriver
   include govuk_rbenv::all
   include ::selenium
   include ::govuk_cdnlogs

--- a/modules/govuk_chromedriver/files/install-chromedriver.sh
+++ b/modules/govuk_chromedriver/files/install-chromedriver.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -eu
+
+##
+# Install ChromeDriver
+#
+# Keeps ChromeDriver installation up-to-date with the currently installed
+# major version of Google Chrome.
+#
+# This script is idempotent. It will only install ChromeDriver if:
+#   - ChromeDriver is not currently installed, or
+#   - the currently installed major version does not match Google Chrome
+#
+# Note: this script *does not* perform minor version updates of ChromeDriver
+##
+
+# Major version of Google Chrome installed on the machine (e.g. 98)
+chrome_version=$(google-chrome --version | grep -Po "(?<=\s)[0-9]+")
+
+# Major version of ChromeDriver, if installed
+is_installed () { command -v "$1" >/dev/null 2>&1; }
+chromedriver_version=$( ! is_installed chromedriver || chromedriver --version | grep -Po "(?<=\s)[0-9]+" )
+
+# Install ChromeDriver if it's missing or doesn't match the Google Chrome major version
+if [ "$chrome_version" != "$chromedriver_version" ]; then
+
+  # Create a unique temporary directory to work in
+  workdir=$(mktemp -d)
+
+  # Clean up after ourselves whenever the script exits
+  # trap covers scenarios where "set -eu" causes us to exit early, as well as successful script completion
+  trap 'rm -rf "$workdir"' EXIT
+
+  # Find out which version of ChromeDriver is required for compatibility with the installed Chrome version
+  required_version=$(curl "https://chromedriver.storage.googleapis.com/LATEST_RELEASE_$chrome_version")
+
+  # Download & install ChromeDriver
+  wget "https://chromedriver.storage.googleapis.com/$required_version/chromedriver_linux64.zip" -O "$workdir/chromedriver.zip"
+  unzip "$workdir/chromedriver.zip" -d "$workdir/unzipped"
+  mv "$workdir/unzipped/chromedriver" "/usr/local/bin/chromedriver"
+  chmod +x "/usr/local/bin/chromedriver"
+  echo "Installed $(chromedriver --version)"
+
+fi

--- a/modules/govuk_chromedriver/manifests/init.pp
+++ b/modules/govuk_chromedriver/manifests/init.pp
@@ -1,0 +1,18 @@
+# == Class: govuk_chromedriver
+#
+# Installs Google Chrome and its associated ChromeDriver
+# Used by Selenium tests which need to drive a browser
+#
+class govuk_chromedriver {
+  require google_chrome
+
+  # Copy the install-chromedriver.sh script on to the machine
+  file { '/usr/sbin/install-chromedriver':
+    ensure => file,
+    source => 'puppet:///modules/govuk_chromedriver/install-chromedriver.sh',
+    mode   => '0755',
+  } # and then execute it (-> denotes a dependency)
+  -> exec { 'install-chromedriver':
+    command => '/usr/sbin/install-chromedriver',
+  }
+}

--- a/modules/govuk_chromedriver/spec/classes/govuk_chromedriver_spec.rb
+++ b/modules/govuk_chromedriver/spec/classes/govuk_chromedriver_spec.rb
@@ -1,0 +1,14 @@
+require_relative '../../../../spec_helper'
+
+describe 'govuk_chromedriver', :type => :class do
+
+  it { is_expected.to compile }
+
+  it { is_expected.to compile.with_all_deps }
+
+  it { is_expected.to contain_class('govuk_chromedriver') }
+
+  it { is_expected.to contain_file('/usr/sbin/install-chromedriver').with_ensure('file') }
+
+  it { is_expected.to contain_exec('install-chromedriver') }
+end

--- a/modules/govuk_testing_tools/manifests/init.pp
+++ b/modules/govuk_testing_tools/manifests/init.pp
@@ -3,7 +3,7 @@
 # Installs packages required by testing environments such as CI agents
 #
 class govuk_testing_tools {
-  include google_chrome
+  include govuk_chromedriver
   include imagemagick
   include selenium
   include ::govuk_testing_tools::xvfb


### PR DESCRIPTION
This adds a module `govuk_chromedriver` which can be included to install Google Chrome alongside a compatible version of ChromeDriver, ready for use by Selenium browser tests.

This is being introduced so that there is always a usable version of ChromeDriver available on CI machines which need to run tests. In the past, CI machines have had a system-wide version of Google Chrome available for use, but no accompanying ChromeDriver. Instead each application has had to use the `webdrivers` gem to install its own version of ChromeDriver locally.

This change represents a deliberate shift in responsibility. Where previously applications were responsible for sourcing their own ChromeDriver (and hence depended on the `webdrivers` gem), we've now decided that it be the responsibility of the underlying operating environment to provide it.

In real terms, this means that the GOV.UK development environment – [govuk-docker] – and the CI environment need to have ChromeDriver installed.

[govuk-docker]: https://github.com/alphagov/govuk-docker/pull/577

---

Trello: https://trello.com/c/qC0SfSAm