### PR TITLE
Add Feedback accessible format request email template and reply to ids

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -40,7 +40,7 @@ govuk::apps::email_alert_api::govuk_notify_recipients:
 govuk::apps::email_alert_frontend::subscription_management_enabled: true
 govuk::apps::feedback::govuk_notify_survey_signup_reply_to_id: 'fee22233-2f28-4b0b-8b6c-4410979f2275'
 govuk::apps::feedback::govuk_notify_survey_signup_template_id: 'eb9ba220-7d74-4aab-975a-bdbe718f69a3'
-govuk::apps::feedback::govuk_notify_accessible_format_request_reply_to_id: '77941cb6-f3a2-4b0d-b09c-64572858cb50'
+govuk::apps::feedback::govuk_notify_accessible_format_request_reply_to_id: '93109fea-34d9-4c38-ac7e-1ebc75e7416b'
 govuk::apps::feedback::govuk_notify_accessible_format_request_template_id: '47cef7ea-0849-48aa-9676-0ee0f7baa4ae'
 govuk::apps::frontend::govuk_notify_template_id: '1fc69d3a-09a2-40f9-852b-03f6fcef5340'
 govuk::apps::frontend::govuk_personalisation_manage_uri: 'https://integration.account.gov.uk?link=manage-account'

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -192,6 +192,8 @@ govuk::apps::email_alert_api::govuk_notify_template_id: 'cb633abc-6ae6-4843-ae6f
 govuk::apps::email_alert_api::govuk_notify_recipients: '*'
 govuk::apps::feedback::govuk_notify_survey_signup_reply_to_id: 'e8b2d8a6-db5f-4346-9fbd-49b16b531e1c'
 govuk::apps::feedback::govuk_notify_survey_signup_template_id: '54168fa9-3946-4860-a2f8-27ddbb14babe'
+govuk::apps::feedback::govuk_notify_accessible_format_request_reply_to_id: 'b5baae45-0a68-4b63-91a1-66b05640d27e'
+govuk::apps::feedback::govuk_notify_accessible_format_request_template_id: 'ceefedd7-3214-4774-8b57-f27c89aac90d'
 
 # https://docs.google.com/document/d/1kdRhmMUIyNZQmgo4FvXswJaDN2CWS2vlH9PVu21a68k/edit#
 govuk::apps::finder_frontend::unicorn_worker_processes: 48

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -170,6 +170,8 @@ govuk::apps::email_alert_api::govuk_notify_recipients:
 govuk::apps::email_alert_frontend::subscription_management_enabled: true
 govuk::apps::feedback::govuk_notify_survey_signup_reply_to_id: 'd1f54751-80a8-420a-9077-d34c7d6cc734'
 govuk::apps::feedback::govuk_notify_survey_signup_template_id: '8a8d98c0-42c8-4f56-b61f-77c89417a171'
+govuk::apps::feedback::govuk_notify_accessible_format_request_reply_to_id: 'd33f7857-7514-4458-81b9-0995f48e2ac5'
+govuk::apps::feedback::govuk_notify_accessible_format_request_template_id: 'b67971ed-a249-4afa-b05e-9adad9da551a'
 
 # https://github.com/alphagov/govuk-aws-data/pull/827
 govuk::apps::finder_frontend::unicorn_worker_processes: 24


### PR DESCRIPTION
Adding AccesssibleFormatRequest Notify variables for Feedback for Staging and Production.

This PR also updates Integration's reply_to id.

This follows https://github.com/alphagov/govuk-puppet/pull/11300 which first introduced the env vars and added them to the manifest.

[tello](https://trello.com/c/7JeL3Ob8/1113-add-notify-email-template-and-reply-to-ids-to-puppet-for-staging-and-production)