### PR TITLE
FIx govuk_crawler script

### DIFF
--- a/modules/govuk_crawler/templates/govuk_sync_mirror.erb
+++ b/modules/govuk_crawler/templates/govuk_sync_mirror.erb
@@ -5,6 +5,8 @@ TARGETS="<%= @targets.flatten.join(' ') -%>"
 MIRROR_ROOT="<%= @mirror_root -%>"
 GOVUK_APP_DOMAIN=$(cat /etc/govuk/env.d/GOVUK_APP_DOMAIN)
 STATIC_HOSTNAME="static.${GOVUK_APP_DOMAIN}"
+GOVUK_WEBSITE_ROOT=$(cat /etc/govuk/env.d/GOVUK_WEBSITE_ROOT)
+GOVUK_WEBSITE_DIR="${GOVUK_WEBSITE_ROOT##https://}"
 PROGRAM_NAME=$(basename $0)
 
 # Nagios defaults, assume failed
@@ -37,9 +39,9 @@ function get_error_page() {
   # Grab the 503 error page
   log "user.info" "Grabbing the latest error page"
 
-  website_mirror_dir="${MIRROR_ROOT}"/www.*
-  mkdir -p "${website_mirror_dir}/error/"
-  curl -sf "https://${STATIC_HOSTNAME}/templates/503.html.erb" -o "${website_mirror_dir}/error/503.html"
+  website_mirror_dir="${MIRROR_ROOT}/${GOVUK_WEBSITE_DIR}"
+  sudo -u deploy mkdir -p "${website_mirror_dir}/error/"
+  sudo -u deploy curl -sf "https://${STATIC_HOSTNAME}/templates/503.html.erb" -o "${website_mirror_dir}/error/503.html"
 }
 
 function write_timestamps() {


### PR DESCRIPTION
In https://github.com/alphagov/govuk-puppet/pull/11412 we were trying to use globbing on `mkdir -p` to get around having to work out what the base mirror directory was called. It's environment dependent and is the website hostname, so www.gov.uk and www.staging.publishing.service.gov.uk
on production and staging respectively.

We were trying to get around this by using `www.*` and hoping it would expand to the right thing, so that we could create an error subdirectory in whatever existed.

The first problem was that the /mnt/crawler_worker directory (and children) are owned by the deploy user, so the creation failed. The second is that the `mkdir -p www.*/error/`command created a directory called (literally) `www.*`, which is not what we want at all.

So, I've switched this around to manually get the directory name from the `GOVUK_WEBSITE_ROOT` environment variable and use it to construct the path.

If `${GOVUK_WEBSITE_ROOT}` is "https://www.gov.uk", then:
`"${GOVUK_WEBSITE_ROOT##https://}"` gives "www.gov.uk"

We then need to use the deploy user to create the directory and grab the error file from static.