### PR TITLE
Update config for imminence so integration will connect to a new imminence-documentdb cluster

### DIFF
--- a/hieradata_aws/class/integration/backend.yaml
+++ b/hieradata_aws/class/integration/backend.yaml
@@ -1,5 +1,11 @@
 ---
 
+govuk::apps::imminence::mongodb_name: 'imminence_production'
+govuk::apps::imminence::mongodb_nodes:
+  - 'imminence-documentdb'
+govuk::apps::imminence::mongodb_username: "%{hiera('imminence_documentdb_user')}"
+govuk::apps::imminence::mongodb_password: "%{hiera('imminence_documentdb_password')}"
+
 govuk::apps::manuals_publisher::mongodb_name: 'govuk_content_production'
 govuk::apps::manuals_publisher::mongodb_nodes:
   - 'shared-documentdb'

--- a/modules/govuk/manifests/apps/imminence.pp
+++ b/modules/govuk/manifests/apps/imminence.pp
@@ -26,6 +26,14 @@
 # [*mongodb_name*]
 #   The name of the MongoDB database to use
 #
+# [*mongodb_username*]
+#   The username to use when logging to the MongoDB database,
+#   only needed if the app uses documentdb rather than mongodb
+#
+# [*mongodb_password*]
+#   The password to use when logging to the MongoDB database
+#   only needed if the app uses documentdb rather than mongodb
+#
 # [*oauth_id*]
 #   The OAuth ID used by GDS-SSO to identify the app to GOV.UK Signon
 #
@@ -52,6 +60,8 @@ class govuk::apps::imminence(
   $sentry_dsn = undef,
   $mongodb_nodes = undef,
   $mongodb_name = 'imminence_production',
+  $mongodb_username = '',
+  $mongodb_password = '',
   $redis_host = undef,
   $redis_port = undef,
   $oauth_id = undef,
@@ -118,6 +128,8 @@ class govuk::apps::imminence(
   govuk::app::envvar::mongodb_uri { $app_name:
     hosts    => $mongodb_nodes,
     database => $mongodb_name,
+    username => $mongodb_username,
+    password => $mongodb_password,    
   }
 
   govuk::procfile::worker { $app_name:


### PR DESCRIPTION
As part of moving our apps away from Mongo 2.6, it would be useful to test moving the imminence app in integration away from the EC2 Mongo 2.6 cluster and onto the DocumentDB imminence-documentdb-integration cluster that will be created by this PR:

https://github.com/alphagov/govuk-aws/pull/1555

This change adds a new imminence-specific file to the heiradata in the integration class that should (for integration) override the existing mongodb cluster information.

When deployed, imminence will lose the existing information in integration until an env sync is done, at which point the sync should be going into the imminence documentdb cluster.

Concerns:

https://github.com/alphagov/govuk-puppet/pull/11573/files#diff-5b5aa948d59a4b8ab656f91eee5d216d21aade137e36c531106d581d32b23847R62-R63. I've left password and username unset in the hope that if they're not set (as in staging and production), the app won't try to send them (username and password appear to not be used for the mongo EC2 cluster). If it does send them (as.. blank? null?), there's a change we might see a problem in staging/production if this version of puppet is deployed there.