### PR TITLE
Fix tests and filenames not matching

### DIFF
--- a/modules/govuk_containers/spec/defines/govuk_containers__ci_mysql_spec.rb
+++ b/modules/govuk_containers/spec/defines/govuk_containers__ci_mysql_spec.rb
@@ -1,7 +1,7 @@
 require_relative '../../../../spec_helper'
 
-describe 'govuk_containers::ci_postgresql', :type => :define do
-  let(:title) { "ci-postgresql-instance" }
+describe 'govuk_containers::ci_mysql', :type => :define do
+  let(:title) { "ci-mysql-instance" }
 
   let(:pre_condition) { <<-EOS
     include ::govuk_python

--- a/modules/govuk_containers/spec/defines/govuk_containers__ci_postgresql_spec.rb
+++ b/modules/govuk_containers/spec/defines/govuk_containers__ci_postgresql_spec.rb
@@ -1,7 +1,7 @@
 require_relative '../../../../spec_helper'
 
-describe 'govuk_containers::ci_mysql', :type => :define do
-  let(:title) { "ci-mysql-instance" }
+describe 'govuk_containers::ci_postgresql', :type => :define do
+  let(:title) { "ci-postgresql-instance" }
 
   let(:pre_condition) { <<-EOS
     include ::govuk_python


### PR DESCRIPTION
This fixes an error I made in https://github.com/alphagov/govuk-puppet/commit/7c8b3208d8948c24ffe6bfc2734a5b0e6c6529ac
where I put the mysql tests in the postgresql file and vice-versa. Such
a doofus.