### PR TITLE
Add a docker container to run MongoDB 3.6 in CI

### DIFF
--- a/modules/govuk_ci/manifests/agent/mongodb.pp
+++ b/modules/govuk_ci/manifests/agent/mongodb.pp
@@ -3,7 +3,13 @@
 # Installs and configures mongodb-server
 #
 class govuk_ci::agent::mongodb {
+  # Docker instances of MongoDB versions that are installed in
+  # parallel with the Ubuntu Trusty version
+  include ::govuk_docker
+  ::govuk_containers::ci_mongodb { 'ci-mongodb-3.6':
+    version => '3.6',
+    port    => 27036,
+  }
 
   include ::mongodb::server
-
 }

--- a/modules/govuk_containers/manifests/ci_mongodb.pp
+++ b/modules/govuk_containers/manifests/ci_mongodb.pp
@@ -1,0 +1,30 @@
+# == Resource: govuk_containers::ci_mongodb
+#
+# Install and run a dockerised MongoDB server, intended for CI purposes
+#
+# === Parameters
+#
+# [*version*]
+#   The version of the MongoDB Docker image to use
+#
+# [*port*]
+#   The port that the MongoDB server will be exposed on
+#
+define govuk_containers::ci_mongodb(
+  $ensure = 'present',
+  $version = '3.6',
+  $port = 27036
+) {
+  ::docker::run { $title:
+    ensure => $ensure,
+    ports  => ["127.0.0.1:${port}:27017"],
+    image  => "mongo:${version}",
+  }
+
+  @@icinga::check { "check_${title}_running_${::hostname}":
+    ensure              => $ensure,
+    check_command       => "check_nrpe!check_tcp!127.0.0.1 ${port}",
+    service_description => "Docker MongoDB ${version} not accepting TCP connections",
+    host_name           => $::fqdn,
+  }
+}

--- a/modules/govuk_containers/spec/defines/govuk_containers__ci_mongodb_spec.rb
+++ b/modules/govuk_containers/spec/defines/govuk_containers__ci_mongodb_spec.rb
@@ -1,0 +1,14 @@
+require_relative '../../../../spec_helper'
+
+describe 'govuk_containers::ci_mongodb', :type => :define do
+  let(:title) { "ci-mongodb-instance" }
+
+  let(:pre_condition) { <<-EOS
+    include ::govuk_python
+    include ::govuk_docker
+    EOS
+  }
+  it { is_expected.to compile }
+
+  it { is_expected.to compile.with_all_deps }
+end


### PR DESCRIPTION
We use MongoDB 3.6 via AWS Document DB, however we only have MongoDB 2.6
and 3.2 currently available for CI. This adds a Docker container running
3.6 so that apps can test against it.

This allows unblocking the Ruby Mongo Driver updating to versions newer than 2.15, see: https://github.com/alphagov/maslow/pull/779 for an example of the issue and this solving it.