### PR TITLE
Add golang 1.17.8

### DIFF
--- a/modules/golang/manifests/init.pp
+++ b/modules/golang/manifests/init.pp
@@ -7,15 +7,16 @@ class golang {
   include govuk_ppa
 
   class { 'goenv':
-    global_version => '1.17.7',
+    global_version => '1.17.8',
     require        => Class['govuk_ppa'],
   }
 
   goenv::version { [
     '1.7.1',   # Used by alphagov/govuk_crawler_worker
     '1.12.1',  # Used by alphagov/govuk-csp-forwarder
-    '1.17.6',  # Used by alphagov/router (remove once router is running 1.17.7)
-    '1.17.7',  # Used by alphagov/router
+    '1.17.6',  # Used by alphagov/router (remove once router is running latest)
+    '1.17.7',  # Used by alphagov/router (remove once router is running latest)
+    '1.17.8',  # Used by alphagov/router
     ]: }
 
   package { ['godep']:


### PR DESCRIPTION
Adds the latest version of go which [addresses a CVE](https://groups.google.com/g/golang-announce/c/RP1hfrBYVuk) regarding nested regexes

## Background

Router is built on CI machines; the artefact is then [uploaded to S3](https://github.com/alphagov/router/blob/main/Jenkinsfile#L68) for use in deployment.

In deployment, the artefact is [retrieved from S3](https://github.com/alphagov/govuk-app-deployment/blob/master/router%2Fconfig%2Fdeploy.rb#L30) and uploaded to the cache machines prior to a restart.

The updated version of golang is [only uploaded to Jenkins and CI agents](https://github.com/alphagov/govuk-puppet/search?q=golang).