### PR TITLE
Allow Locations API to be deployed

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1298,6 +1298,7 @@ grafana::dashboards::application_dashboards:
     instance_prefix: 'backend'
     show_memcached: true
     show_postgres_stats: true
+  locations-api: {}
   manuals-frontend: {}
   manuals-publisher:
     show_sidekiq_graphs: true

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -99,6 +99,9 @@ node_class: &node_class
       - manuals-frontend
       - service-manual-frontend
       - static
+  locations_api:
+    apps:
+      - locations-api
   mapit:
     apps:
       - mapit

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -99,6 +99,9 @@ node_class: &node_class
       - manuals-frontend
       - service-manual-frontend
       - static
+  locations_api:
+    apps:
+      - locations-api
   mapit:
     apps:
       - mapit


### PR DESCRIPTION
As per: https://github.com/alphagov/govuk-puppet/blob/main/docs/adding-a-new-app.md#enable-your-app-in-all-environments

Seemed to have been missed from https://github.com/alphagov/govuk-puppet/pull/11540

https://trello.com/c/1d58bNhV/2853-create-locationsapi-nodes

Also adds Locations API grafana dashboards as instructed in https://github.com/alphagov/govuk-puppet/blob/main/docs/adding-a-new-app.md#enable-the-deployment-dashboard
