### PR TITLE
Change ESM method of authentication from static to token based

### DIFF
--- a/hieradata_aws/common.trusty.yaml
+++ b/hieradata_aws/common.trusty.yaml
@@ -38,5 +38,4 @@ apt::sources:
       deb: true
 
 base::esm_repo: true
-base::esm::esm_user: "%{hiera('base::esm::esm_trusty_user')}"
-base::esm::esm_password: "%{hiera('base::esm::esm_trusty_password')}"
+base::esm::esm_token: "%{hiera('base::esm::esm_trusty_token')}"

--- a/modules/base/manifests/esm.pp
+++ b/modules/base/manifests/esm.pp
@@ -20,7 +20,7 @@ class base::esm (
   file { '/etc/apt/auth.conf':
     ensure => absent,
   }
- exec { "ubuntu-advantage attach token":
+  exec { "ubuntu-advantage attach token":
     command => "ubuntu-advantage attach ${esm_token}",
     path    => ['/bin','/sbin','/usr/bin','/usr/sbin'],
     require => Package['ubuntu-advantage-tools'],

--- a/modules/base/manifests/esm.pp
+++ b/modules/base/manifests/esm.pp
@@ -20,7 +20,7 @@ class base::esm (
   file { '/etc/apt/auth.conf':
     ensure => absent,
   }
-  exec { "ubuntu-advantage attach token":
+  exec { 'ubuntu-advantage attach token':
     command => "ubuntu-advantage attach ${esm_token}",
     path    => ['/bin','/sbin','/usr/bin','/usr/sbin'],
     require => Package['ubuntu-advantage-tools'],

--- a/modules/base/manifests/esm.pp
+++ b/modules/base/manifests/esm.pp
@@ -4,29 +4,29 @@
 #
 # === Parameters
 #
-# [*esm_user*]
-#   username for ESM repo.
-#
-# [*esm_password*]
-#   password for ESM repo.
+# [*esm_token*]
+#   Token for ESM repo.
 #
 class base::esm (
-  $esm_user,
-  $esm_password,
+  $esm_token,
 ) {
-  file { '/etc/apt/auth.conf':
-    ensure  => file,
-    content => template('base/90ubuntu-advantage.erb'),
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0600',
-  }
   file { '/etc/apt/apt.conf.d/51ubuntu-advantage-esm':
     ensure => file,
     source => 'puppet:///modules/base/51ubuntu-advantage-esm',
     owner  => 'root',
     group  => 'root',
     mode   => '0644',
+  }
+  file { '/etc/apt/auth.conf':
+    ensure => absent,
+  }
+ exec { "ubuntu-advantage attach token":
+    command => "ubuntu-advantage attach ${esm_token}",
+    path    => ['/bin','/sbin','/usr/bin','/usr/sbin'],
+    require => Package['ubuntu-advantage-tools'],
+  }
+  package { 'ubuntu-advantage-tools':
+    ensure  => latest,
   }
   package { 'apt-transport-https':
     ensure  => present,

--- a/modules/base/templates/90ubuntu-advantage.erb
+++ b/modules/base/templates/90ubuntu-advantage.erb
@@ -1,1 +1,0 @@
-machine esm.ubuntu.com/ login <%= @esm_user %> password <%= @esm_password %>


### PR DESCRIPTION
We used to authenticate to the ESM repo using a static set of creds for all the machines. This seems to not work anymore.
There is another method that uses a token to setup a unique set of creds for each machine that is working fine though.