### PR TITLE
Retire manuals-frontend (step 1)

### DIFF
--- a/hieradata_aws/class/cache.yaml
+++ b/hieradata_aws/class/cache.yaml
@@ -26,7 +26,6 @@ router::nginx::app_specific_static_asset_routes:
   '/assets/frontend/': 'frontend'
   '/assets/government-frontend/': 'government-frontend'
   '/assets/licencefinder/': 'licencefinder'
-  '/assets/manuals-frontend/': 'manuals-frontend'
   '/assets/service-manual-frontend/': 'service-manual-frontend'
   '/assets/smartanswers/': 'smartanswers'
   '/assets/static/': 'static'

--- a/hieradata_aws/class/draft_cache.yaml
+++ b/hieradata_aws/class/draft_cache.yaml
@@ -28,7 +28,6 @@ router::nginx::app_specific_static_asset_routes:
   '/assets/feedback/': 'feedback'
   '/assets/frontend/': 'draft-frontend'
   '/assets/government-frontend/': 'draft-government-frontend'
-  '/assets/manuals-frontend/': 'draft-manuals-frontend'
   '/assets/service-manual-frontend/': 'draft-service-manual-frontend'
   '/assets/smartanswers/': 'draft-smartanswers'
   '/assets/static/': 'draft-static'

--- a/hieradata_aws/class/draft_frontend.yaml
+++ b/hieradata_aws/class/draft_frontend.yaml
@@ -4,7 +4,6 @@ govuk::apps::collections::vhost: 'draft-collections'
 govuk::apps::email_alert_frontend::vhost: 'draft-email-alert-frontend'
 govuk::apps::frontend::vhost: 'draft-frontend'
 govuk::apps::government_frontend::vhost: 'draft-government-frontend'
-govuk::apps::manuals_frontend::vhost: 'draft-manuals-frontend'
 govuk::apps::service_manual_frontend::vhost: 'draft-service-manual-frontend'
 govuk::apps::smartanswers::vhost: 'draft-smartanswers'
 

--- a/hieradata_aws/class/integration/ci_master.yaml
+++ b/hieradata_aws/class/integration/ci_master.yaml
@@ -38,7 +38,6 @@ govuk_jenkins::jobs::deploy_app_downstream::applications:
   link-checker-api: {}
   local-links-manager: {}
   locations-api: {}
-  manuals-frontend: {}
   manuals-publisher: {}
   mapit: {}
   maslow: {}

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -186,7 +186,6 @@ deployable_applications: &deployable_applications
   link-checker-api: {}
   locations-api: {}
   local-links-manager: {}
-  manuals-frontend: {}
   manuals-publisher: {}
   mapit: {}
   maslow: {}
@@ -952,7 +951,6 @@ govuk_ci::master::pipeline_jobs:
   link-checker-api: {}
   local-links-manager: {}
   locations-api: {}
-  manuals-frontend: {}
   mapit: {}
   publishing-api: {}
   release: {}
@@ -1114,7 +1112,6 @@ govuk_jenkins::jobs::deploy_app_downstream::applications:
   info-frontend: {}
   local-links-manager: {}
   locations-api: {}
-  manuals-frontend: {}
   manuals-publisher: {}
   maslow: {}
   publisher: {}
@@ -1239,7 +1236,6 @@ grafana::dashboards::application_dashboards:
       - frontend
       - government-frontend
       - info-frontend
-      - manuals-frontend
       - publishing-api
       - smartanswers
       - whitehall-frontend
@@ -1288,7 +1284,6 @@ grafana::dashboards::application_dashboards:
     show_memcached: true
     show_postgres_stats: true
   locations-api: {}
-  manuals-frontend: {}
   manuals-publisher:
     show_sidekiq_graphs: true
     has_workers: true
@@ -1353,7 +1348,6 @@ grafana::dashboards::application_dashboards:
       - finder-frontend
       - frontend
       - government-frontend
-      - manuals-frontend
       - smartanswers
       - whitehall-frontend
   support:

--- a/modules/govuk/manifests/apps/manuals_frontend.pp
+++ b/modules/govuk/manifests/apps/manuals_frontend.pp
@@ -29,6 +29,7 @@ class govuk::apps::manuals_frontend(
   $secret_key_base = undef,
 ) {
   govuk::app { 'manuals-frontend':
+    ensure                     => 'absent',
     app_type                   => 'rack',
     port                       => $port,
     sentry_dsn                 => $sentry_dsn,
@@ -37,21 +38,5 @@ class govuk::apps::manuals_frontend(
     vhost                      => $vhost,
     has_liveness_health_check  => true,
     has_readiness_health_check => true,
-  }
-
-  Govuk::App::Envvar {
-    app => 'manuals-frontend',
-  }
-
-  govuk::app::envvar { "${title}-PUBLISHING_API_BEARER_TOKEN":
-    varname => 'PUBLISHING_API_BEARER_TOKEN',
-    value   => $publishing_api_bearer_token,
-  }
-
-  if $secret_key_base != undef {
-    govuk::app::envvar { "${title}-SECRET_KEY_BASE":
-      varname => 'SECRET_KEY_BASE',
-      value   => $secret_key_base,
-    }
   }
 }


### PR DESCRIPTION
This marks manuals-frontend as `absent` and removes various references from hieradata.

[trello](https://trello.com/c/OtjBZRjL/1131-manuals-deprecate-manuals-frontend)