### PR TITLE
Remove old cookie exceptions from varnish config

### DIFF
--- a/modules/varnish/templates/default.vcl.erb
+++ b/modules/varnish/templates/default.vcl.erb
@@ -83,9 +83,7 @@ sub vcl_recv {
   # With the exception of:
   #   - Licensing
   #   - email-alert-frontend (for subscription management)
-  #   - frontend (for sessions across funding registration form)
-  #   - smart answers coronavirus find support flow
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/brexit-eu-funding" && req.url !~ "^/find-coronavirus-support" && req.url !~ "^/sign-in/callback")
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/sign-in/callback")
   {
     unset req.http.Cookie;
   }
@@ -122,7 +120,7 @@ sub vcl_fetch {
 
   <% if @strip_cookies %>
   # Strip cookies from outbound requests. Corresponding rule in vcl_recv{}
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/brexit-eu-funding" && req.url !~ "^/find-coronavirus-support" && req.url !~ "^/sign-in/callback") {
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/sign-in/callback") {
     unset beresp.http.Set-Cookie;
   }
   <% end %>


### PR DESCRIPTION
These two cookie exceptions are no longer required because the services
that used them have been decomissioned.

Removing /find-coronavirus-support alphagov/smart-answers#5585
Removing /brexit-eu-funding alphagov/frontend#2263