### PR TITLE
Update: postgres 9.6 apt repos for aptly

### DIFF
--- a/modules/govuk/manifests/node/s_apt.pp
+++ b/modules/govuk/manifests/node/s_apt.pp
@@ -92,7 +92,7 @@ class govuk::node::s_apt (
       release  => 'trusty',
       key      => '8507EFA5';
     'postgresql':
-      location => 'http://apt.postgresql.org/pub/repos/apt/',
+      location => 'http://apt-archive.postgresql.org/pub/repos/apt/',
       release  => 'trusty-pgdg',
       key      => 'B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8';
     'puppetlabs-trusty':


### PR DESCRIPTION
The postgres 9.6 trusty apt repos has been deprecated and moved to the
apt-archive url.

Details:
- https://www.postgresql.org/about/news/announcing-apt-archivepostgresqlorg-2024/
- https://apt-archive.postgresql.org/