### PR TITLE
Change account Latency SLO to 2s up from 850ms

### DIFF
--- a/modules/monitoring/manifests/checks/accounts_slos.pp
+++ b/modules/monitoring/manifests/checks/accounts_slos.pp
@@ -28,7 +28,7 @@ class monitoring::checks::accounts_slos (
       args           => '--dropfirst -6',
   }
 
-    $latency_bad_metric = 'transformNull(offset(scale(removeBelowValue(maxSeries(stats.timers.*.nginx_logs.account-api.time_request.upper_90),0.850),0),1))'
+    $latency_bad_metric = 'transformNull(offset(scale(removeBelowValue(maxSeries(stats.timers.*.nginx_logs.account-api.time_request.upper_90),2.0),0),1))'
     $latency_all_metric = 'offset(scale(transformNull(maxSeries(stats.timers.*.nginx_logs.account-api.time_request.upper_90)),0),1)'
     $alert_warning_slow_http_response_rate = 0.01
 


### PR DESCRIPTION
[Trello](https://trello.com/c/6nZ62Hhd/1312-decide-what-should-we-do-about-the-latency-alerts)

**Why?**

Our latency error budget has collapsed recently. Before this change, bad
latency was defined as, a recorded instance of an error when:

The 90th percentile of traffic (so stripping outliers) exceeded 850ms
response times within any moving 10 min window.

Trouble is, we're way over that. We're seeing much closer to 2000ms
responses.

Running `stats.timers.*.nginx_logs.account-api.time_request.upper_90` in
graphite shows the issue.

Looking at the account service dashboard:
https://grafana.blue.production.govuk.digital/dashboard/file/account-api.json?refresh=5s&orgId=1

we can see that the `internal/autentication callback` controller and
method is the real outlier here.

Stepping through that we can see the oidc_client.callback on [L17][1]
calls out to the DI tokens endpoint.

We time this, you can see the results with the following graphite query
`stats.timers.govuk.app.account-api.*.oidc_client.tokens.upper_90`.

It seems that is frequently taking about 1800ms to respond. Auth say
their current target is close to ~3000ms, and that there are cold start
issues currently. So let's bump this up a bit so we get less noise, but
can still track big changes.

[1]: https://github.com/alphagov/account-api/blob/main/app/controllers/internal/authentication_controller.rb#L17