### PR TITLE
Unsnowflake psql repo management for content_data_api_db_admin

### DIFF
--- a/hieradata_aws/class/content_data_api_db_admin.yaml
+++ b/hieradata_aws/class/content_data_api_db_admin.yaml
@@ -1,4 +1,0 @@
----
-postgresql::globals::version: '9.6'
-postgresql::globals::manage_package_repo: true
-postgresql::server::role::rds: true


### PR DESCRIPTION
This was introduced by: https://github.com/alphagov/govuk-puppet/commit/3a50455082b295aecd8284b490df4d332294482a

This is no longer relevant however as the govuk_env_script has
now been modified to use a docker instance with the adequate
pg_dump version.

Additionally the repo configured by puppet has been deprecated
and no longer works.