### PR TITLE
Add Locations API to list that allows deploy on merge

### DIFF
--- a/hieradata_aws/class/integration/ci_master.yaml
+++ b/hieradata_aws/class/integration/ci_master.yaml
@@ -37,6 +37,7 @@ govuk_jenkins::jobs::deploy_app_downstream::applications:
   licensify-feed: {}
   link-checker-api: {}
   local-links-manager: {}
+  locations-api: {}
   manuals-frontend: {}
   manuals-publisher: {}
   mapit: {}


### PR DESCRIPTION
When merging a Locations API PR, the new release is not
automatically deployed to Integration. The build fails with:

```
ERROR: Value for choice parameter 'TARGET_APPLICATION' is 'locations-api', but valid choices are [-- Choose an app, account-api, asset-manager, authenticating-proxy, bouncer, cache-clearing-service, ckan, collections, collections-publisher, contacts, content-publisher, content-tagger, content-store, email-alert-api, email-alert-frontend, email-alert-service, feedback, finder-frontend, frontend, government-frontend, govuk-content-schemas, govuk_crawler_worker, govuk-puppet, hmrc-manuals-api, imminence, info-frontend, content-data-admin, content-data-api, licencefinder, licensify, licensify-admin, licensify-feed, link-checker-api, local-links-manager, manuals-frontend, manuals-publisher, mapit, maslow, publisher, publishing-api, release, router, router-api, search-admin, search-api, service-manual-publisher, service-manual-frontend, short-url-manager, sidekiq-monitoring, signon, smartanswers, specialist-publisher, static, support-api, support, transition, travel-advice-publisher, whitehall]

```

This commit should fix that.

Trello: https://trello.com/c/gPRVvLXh/2848-set-up-remaining-infrastructure-for-locations-api-5