### PR TITLE
Standardise Smokey environments for Staging / Prod

### DIFF
--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -323,7 +323,7 @@ govuk_jenkins::jobs::signon_cron_rake_tasks::rake_users_send_suspension_reminder
 
 govuk_jenkins::jobs::smart_answers_broken_links_report::cron_schedule: '30 1 1,15 * *' # every 1st and 15th of the month at 1:30 AM
 
-govuk_jenkins::jobs::smokey::environment: production_aws
+govuk_jenkins::jobs::smokey::environment: production
 
 govuk_jenkins::jobs::data_sync_complete_production::signon_domains_to_migrate:
   -
@@ -471,7 +471,7 @@ monitoring::pagerduty_drill::enabled: true
 
 monitoring::uptime_collector::environment: 'production'
 
-monitoring::checks::smokey::environment: 'production_aws'
+monitoring::checks::smokey::environment: 'production'
 monitoring::checks::smokey::features:
   check_ab_testing:
     feature: ab_testing

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -297,7 +297,7 @@ govuk_jenkins::jobs::search_fetch_analytics_data::cron_schedule: '30 8 * * 1-5'
 govuk_jenkins::jobs::search_relevancy_rank_evaluation::cron_schedule: '45 */3 * * *' # every three hours
 govuk_jenkins::jobs::search_relevancy_metrics_etl::cron_schedule: 'H 1,7,13,19 * * *' # every six hours
 
-govuk_jenkins::jobs::smokey::environment: staging_aws
+govuk_jenkins::jobs::smokey::environment: staging
 
 govuk_jenkins::jobs::data_sync_complete_staging::signon_domains_to_migrate:
   -
@@ -449,7 +449,7 @@ monitoring::contacts::notify_slack: true
 monitoring::contacts::slack_channel: '#govuk-alerts-staging'
 monitoring::contacts::slack_username: 'Staging (AWS)'
 
-monitoring::checks::smokey::environment: 'staging_aws'
+monitoring::checks::smokey::environment: 'staging'
 monitoring::checks::smokey::disable_during_data_sync: true
 monitoring::checks::smokey::features:
   check_ab_testing:


### PR DESCRIPTION
https://trello.com/c/LnE7dZdj/257-survey-actions-for-smokey

These are the same [^1] [^2]. Now that we operate entirely on AWS
we can dispense with the "_aws" suffix.

[^1]: https://github.com/alphagov/smokey/blob/0c09a9e40a7fa8984ffc9264aab2b892a6cb0735/config/cucumber.yml#L4-L7
[^2]: https://github.com/alphagov/smokey/blob/ba3829983c91478c0702442d9c03f85c49904bd4/features/support/env.rb#L19
