### PR TITLE
Remove Bouncer minimum request rate alert

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -186,7 +186,6 @@ govuk_jenkins::ssh_key::public_key: 'AAAAB3NzaC1yc2EAAAADAQABAAACAQDQBl40cv64wBa
 
 govuk::node::s_asset_master::copy_attachments_hour: 11
 
-govuk::node::s_bouncer::minimum_request_rate: 0.1
 govuk::node::s_cache::real_ip_header: 'X-Forwarded-For'
 govuk::node::s_cache::protect_cache_servers: true
 govuk::node::s_mirrorer::daily_queue_purge: true

--- a/modules/govuk/manifests/node/s_bouncer.pp
+++ b/modules/govuk/manifests/node/s_bouncer.pp
@@ -3,29 +3,9 @@
 # Sets up a machine to run the bouncer app and redirect old domains
 # to GOV.UK.
 #
-# === Parameters
-#
-# [*minimum_request_rate*]
-#   The Graphite metric value for minimum number of requests that
-#   we would expect to see.
-#
-class govuk::node::s_bouncer (
-  $minimum_request_rate = 3,
-) inherits govuk::node::s_base {
+class govuk::node::s_bouncer inherits govuk::node::s_base {
 
   include govuk_bouncer::gor
   include govuk::node::s_app_server
   include nginx
-
-  $warning_threshold = 1.2 * $minimum_request_rate
-
-  @@icinga::check::graphite { "check_nginx_requests_${::hostname}":
-    target              => "${::fqdn_metrics}.nginx.nginx_requests",
-    warning             => "@${warning_threshold}",
-    critical            => "@${minimum_request_rate}",
-    desc                => 'Minimum HTTP request rate for bouncer',
-    host_name           => $::fqdn,
-    notes_url           => monitoring_docs_url(nginx-requests-too-low),
-    notification_period => 'inoffice',
-  }
 }


### PR DESCRIPTION
This alert has been around for a long time and just causes noise on
2ndline, with no real value. The minimum requests threshold is arbitrary
and I can't really think of a way in which this is useful, as a low
amount of requests doesn't mean there is a problem.

Also, the frequency we're seeing the alert means that it's likely to be
ignored, even if there was an issue.