### PR TITLE
Remove post-deploy Icinga alert for Smokey

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/smokey.pp
+++ b/modules/govuk_jenkins/manifests/jobs/smokey.pp
@@ -10,26 +10,12 @@
 class govuk_jenkins::jobs::smokey (
   $environment = 'production',
 ) {
-  $environment_variables = $govuk_jenkins::environment_variables
-  $smokey_task = "test:${environment}"
-  $deploy_jenkins_domain = hiera('deploy_jenkins_domain')
-
   include govuk::apps::smokey
-
-  $service_description = 'Smokey'
 
   file { '/etc/jenkins_jobs/jobs/smokey.yaml':
     ensure  => present,
     content => template('govuk_jenkins/jobs/smokey.yaml.erb'),
     notify  => Exec['jenkins_jobs_update'],
     require => Class['govuk::apps::smokey'],
-  }
-
-  $job_url = "https://${deploy_jenkins_domain}/job/smokey/"
-
-  @@icinga::passive_check { "smokey_${::hostname}":
-    service_description => $service_description,
-    host_name           => $::fqdn,
-    action_url          => $job_url,
   }
 }

--- a/modules/govuk_jenkins/templates/jobs/smokey.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/smokey.yaml.erb
@@ -17,18 +17,6 @@
       - build-discarder:
           days-to-keep: 30
           artifact-num-to-keep: 5
-    publishers:
-      - trigger-parameterized-builds:
-          - project: Success_Passive_Check
-            condition: SUCCESS
-            predefined-parameters: |
-                NSCA_CHECK_DESCRIPTION=<%= @service_description %>
-                NSCA_OUTPUT=<%= @service_description %> success
-          - project: Failure_Passive_Check
-            condition: FAILED
-            predefined-parameters: |
-                NSCA_CHECK_DESCRIPTION=<%= @service_description %>
-                NSCA_OUTPUT=<%= @service_description %> failed
     parameters:
       - string:
           name: TARGET_APPLICATION


### PR DESCRIPTION
https://trello.com/c/vIt6bDXI/258-stop-full-post-deploy-runs-of-smokey

Smokey is run twice after most deployments:

1. A full run triggered by the Deploy_App job [^1].

2. A partial run triggered by the Deploy_App_Downstream
   job (for CD apps).

This commit removes a single Icinga alert that would be updated
every time the job runs. The introduction of (2) has made this
meaningless: it's unclear if the status of the alert relates to
a full or partial run of Smokey.

We also run Smokey in a continuous "loop", with an Icinga alert
for each feature. These more fine-grained Smokey Loop alerts also
make the general one we're removing here redundant i.e. we should
just remove it instead of fixing it.

As I was making this change I noticed a bunch of variables that
aren't used anymore so I've removed them.

[^1]: https://github.com/alphagov/govuk-puppet/blob/a5d4360ff18dc64e4edef3992875d978f8492874/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb#L73