### PR TITLE
Stop duplicate full post-deploy Smokey runs

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
@@ -69,9 +69,6 @@
                     current-parameters: true
         <% end %>
     publishers:
-        - trigger:
-            project: Smokey
-            threshold: UNSTABLE
         - text-finder:
             regexp: "DOCKER TAG FAILED"
             also-check-console-output: true


### PR DESCRIPTION
https://trello.com/c/vIt6bDXI/258-stop-full-post-deploy-runs-of-smokey

**Deadline for discussion: 2022-04-13**

Currently we run Smokey in 3 different ways:

1. A "full" run of Smokey after each deployment, triggered by the
Deploy_App job (see commit). This runs all of the scenarios.

2. A partial run of Smokey as part of a Continuous Deployment. This
is triggered by the Deploy_App_Downstream job [^1].

3. Continuous "full" runs of Smokey as part of the Smokey Loop [^2].
Each feature has its own alert in Icinga.

This commit removes the first way we run Smokey:

- It's not necessary for continuously deployed apps, where the 
full, duplicate run blocks the CD pipeline.

- For manually deployed apps, it's still possible to run Smokey
manually after a deployment has completed.

Making this change will help to simplify and clarify the purpose of
Smokey as we work towards guidance on what tests go in it and a
general high-level testing strategy for GOV.UK. It will not affect
the third use case (alerting) of Smokey[^3].

Note about manual deployments
=============================

While having to run Smokey manually for manually deployed apps is
slightly less convenient, it also has advantages:

- It ensures the deployer is looking at a run of Smokey that is
definitely associated with their deployment. At the moment it's too
easy to not check if your deployment triggered the last run.

- It allows the deployer to do a partial run of Smokey - assuming
they've added support for this [^4].*

- It creates a stronger mental association between doing a deploy
and running Smokey - as opposed to passively checking it's passed,
which is easier to forget as it requires less thought.

*We could change Deploy_App to do this but we would have to do it
for every app. It makes more sense to invest effort in moving apps
to Continuous Deployment instead.

[^1]: https://github.com/alphagov/govuk-puppet/blob/77f85be19ceed239f6d652cc07207266b165fb9f/modules/govuk_jenkins/templates/jobs/deploy_app_downstream.yaml.erb#L14
[^2]: https://docs.publishing.service.gov.uk/manual/alerts/smokey-loop-tests.html
[^3]: https://github.com/alphagov/govuk-puppet/pull/11610
[^4]: https://github.com/alphagov/smokey/blob/main/docs/writing-tests.md