### PR TITLE
Updated Oliver Roberts ssh key for govuk-puppet

### DIFF
--- a/modules/users/manifests/oliverroberts.pp
+++ b/modules/users/manifests/oliverroberts.pp
@@ -3,6 +3,6 @@ class users::oliverroberts {
   govuk_user { 'oliverroberts':
     fullname => 'Oliver Roberts',
     email    => 'oliver.roberts@digital.cabinet-office.gov.uk',
-    ssh_key  => 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJbKL7LVndmZJ5s7s8/2U2yz0P+LVirH0fPnqpFQQU6t oliver.roberts@digital.cabinet-office.gov.uk',
+    ssh_key  => 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJbKL7LVndmZJ5s7s8/2U2yz0P+LVirH0fPnqpFQQU6t ollyroberts@github.com',
   }
 }


### PR DESCRIPTION
modified the ssh key being used in oliveroberts.pp