### PR TITLE
Let Dilwoar Back In 🥲

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -369,6 +369,7 @@ users::usernames:
   - danacotoran
   - davidgisbey
   - deborahchua
+  - dilwoarhussain
   - duncangarmonsway
   - edwardkerry
   - fredericfrancois

--- a/modules/users/manifests/dilwoarhussain.pp
+++ b/modules/users/manifests/dilwoarhussain.pp
@@ -1,0 +1,8 @@
+# Creates the dilwoarhussain user
+class users::dilwoarhussain {
+  govuk_user { 'dilwoarhussain':
+    fullname => 'Dilwoar Hussain',
+    email    => 'dilwoar.hussain@digital.cabinet-office.gov.uk',
+    ssh_key  => 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILfSLn+Npn0CmPuRJPLWNy+1kSTB6309/QpdGMo3L9/o dilwoar.hussain@digital.cabinet-office.gov.uk',
+  }
+}


### PR DESCRIPTION
Production access was remove when Dilwoar left for career break.

This change adds Dilwoar back in.