### PR TITLE
[DO NOT MERGE] Reduce GET/POST form rate limit from 6rpm/cache to 2rpm/cache

### DIFF
--- a/modules/router/templates/rate-limiting.conf.erb
+++ b/modules/router/templates/rate-limiting.conf.erb
@@ -21,7 +21,7 @@ map "$http_Rate_Limit_Token:$request_method" $post_limit_req {
   default    "";
 }
 
-limit_req_zone $post_limit_req zone=contact:5m rate=6r/m;
+limit_req_zone $post_limit_req zone=contact:5m rate=2r/m;
 
 # Return 429 (Too Many Requests) instead of the default 503.
 limit_req_status 429;


### PR DESCRIPTION
## WHAT

Reduces the POST rate limit per nginx instance from 6 rpm to 2 rpm on routes like the contact us form, where there is a restful GET/POST pair (get the form, post the form contents to the same url).

## WHY

This was set when we had fewer nginx instances on the front end, and since they can't share state, the effective max rate is currently 36 * 6 rpm (or 216 rpm) per ip address. This reduces it a little to 72 rpm per ip address. Still a lot, but a bit safer against single-point DoS attacks on these endpoints.

### Trello

https://trello.com/c/GwaWxtZh/1152-contact-form-has-no-rate-limiting