### PR TITLE
Remove content-store from govuk-uptime-collector list

### DIFF
--- a/modules/monitoring/templates/govuk-uptime-collector.conf.erb
+++ b/modules/monitoring/templates/govuk-uptime-collector.conf.erb
@@ -6,4 +6,4 @@ respawn
 env RBENV_VERSION=2.6
 env PATH=/usr/lib/rbenv/shims:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
-exec govuk_uptime_collector <%= @environment %> content-store hmrc-manuals-api link-checker-api manuals-publisher publishing-api specialist-publisher travel-advice-publisher whitehall-admin:healthcheck/overdue
+exec govuk_uptime_collector <%= @environment %> hmrc-manuals-api link-checker-api manuals-publisher publishing-api specialist-publisher travel-advice-publisher whitehall-admin:healthcheck/overdue


### PR DESCRIPTION
By removing the public load balancer of content-store as per
https://github.com/alphagov/govuk-aws/pull/1572 we also removed
the public hostname for content-store.
This breaks govuk-uptime-collector which depends on this hostname
for the check url of content-store.
The solution is to simply remove content-store from the list of
services monitored by govuk-uptime-collector, it should probably
never have been there in the first place as evidenced by :
https://docs.publishing.service.gov.uk/manual/uptime-metrics.html