### PR TITLE
Remove monitoring of public lb of static and support-api

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -264,9 +264,6 @@ monitoring::checks::lb::loadbalancers: # prefer "internal"
   blue-transition-db-admin:
     healthyhosts_warning: 0
   blue-whitehall-frontend: {}
-  govuk-static-public: {}
-  govuk-support-api-public:
-    healthyhosts_warning: 0
   licensify-backend-internal:
     healthyhosts_warning: 0
   whitehall-backend-internal: {}

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -455,8 +455,6 @@ monitoring::checks::lb::loadbalancers: # prefer "internal"
   blue-transition-db-admin:
     healthyhosts_warning: 0
   blue-whitehall-frontend: {}
-  govuk-static-public: {}
-  govuk-support-api-public: {}
   licensify-backend-internal:
     healthyhosts_warning: 0
   whitehall-backend-internal: {}

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -438,8 +438,6 @@ monitoring::checks::lb::loadbalancers: # prefer "internal"
   blue-transition-db-admin:
     healthyhosts_warning: 0
   blue-whitehall-frontend: {}
-  govuk-static-public: {}
-  govuk-support-api-public: {}
   licensify-backend-internal:
     healthyhosts_warning: 0
   whitehall-backend-internal: {}


### PR DESCRIPTION
Following the removal of the publib load balancers of static and
support-api in https://github.com/alphagov/govuk-aws/pull/1572
we don't need to monitor those anymore.