### PR TITLE
Remove govuk_app_config from Jenkins CI

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -959,7 +959,6 @@ govuk_ci::master::pipeline_jobs:
   gds-sso: {}
   gds_zendesk: {}
   govuk_ab_testing: {}
-  govuk_app_config: {}
   govuk-cdn-config: {}
   govuk-csp-forwarder: {}
   govuk-dummy_content_store: {}


### PR DESCRIPTION
This repo is now built by GitHub Actions so no longer needs to be
registered as a pipeline in our Jenkins CI.