### PR TITLE
Pass OS Places API credentials from hieradata to Puppet class

### DIFF
--- a/modules/govuk/manifests/apps/locations_api.pp
+++ b/modules/govuk/manifests/apps/locations_api.pp
@@ -8,6 +8,12 @@
 # [*secret_key_base*]
 #   The key for Rails to use when signing/encrypting sessions
 #
+# [*os_places_api_key*]
+#   API key used by Locations API to communicate with OS Places API
+#
+# [*os_places_api_secret*]
+#   Corresponding secret for above OS Places API key.
+#
 # [*port*]
 #   What port should the app run on?
 #
@@ -45,6 +51,8 @@
 class govuk::apps::locations_api (
   $enabled = false,
   $secret_key_base = undef,
+  $os_places_api_key = undef,
+  $os_places_api_secret = undef,
   $port,
   $enable_procfile_worker = true,
   $unicorn_worker_processes = undef,
@@ -89,6 +97,12 @@ class govuk::apps::locations_api (
     "${title}-SECRET_KEY_BASE":
       varname => 'SECRET_KEY_BASE',
       value   => $secret_key_base;
+    "${title}-OS_PLACES_API_KEY":
+      varname => 'OS_PLACES_API_KEY',
+      value   => $os_places_api_key;
+    "${title}-OS_PLACES_API_SECRET":
+      varname => 'OS_PLACES_API_SECRET',
+      value   => $os_places_api_secret;
   }
 
   govuk::app::envvar::redis { $app_name:


### PR DESCRIPTION
We were seeing in the logs on `locations_api` machines:

```
[47639b95-b57e-4355-8ec0-6cff48294285] {"exception_class":"OsPlacesApi::MissingOsPlacesApiCredentials","exception_message":"OsPlacesApi::MissingOsPlacesApiCredentials","stacktrace":["lib/os_places_api/access_token_manager.rb:6:in `initialize'","app/controllers/v1/locations_controller.rb:6:in `new'","app/controllers/v1/locations_controller.rb:6:in `index'"]}
```

We've defined the values already in govuk-secrets, but hadn't
done the work to pass the values to the class and declare them
as ENV variables (needed here:
https://github.com/alphagov/locations-api/blob/25e6788cd52f7a74a9a70ab467cde9d21a89fcd7/lib/os_places_api/access_token_manager.rb#L6-L9
)

Trello: https://trello.com/c/gPRVvLXh/2848-set-up-remaining-infrastructure-for-locations-api-5