### PR TITLE
Update assets path for contacts-admin

### DIFF
--- a/modules/govuk/manifests/apps/contacts.pp
+++ b/modules/govuk/manifests/apps/contacts.pp
@@ -105,7 +105,7 @@ class govuk::apps::contacts(
     has_readiness_health_check => true,
     vhost_protected            => $vhost_protected,
     asset_pipeline             => true,
-    asset_pipeline_prefixes    => ['contacts-assets'],
+    asset_pipeline_prefixes    => ['assets/contacts-admin'],
     vhost_aliases              => $extra_aliases,
     repo_name                  => 'contacts-admin',
     nginx_extra_config         => '


### PR DESCRIPTION
This corrects the previously incorrect asset path (contacts defaults to "/assets") which has meant that the assets haven't been set with the correct cache headers. This updates this path to match the new one introduced in: https://github.com/alphagov/contacts-admin/pull/959