### PR TITLE
Update docker-ce to last supported Trusty release 💀

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1074,7 +1074,7 @@ govuk_crawler::alert_hostname: 'alert'
 govuk_crawler::amqp_host: 'localhost'
 govuk_crawler::site_root: "https://www.%{hiera('app_domain')}"
 
-govuk_docker::version: "17.09.0~ce-0~ubuntu"
+govuk_docker::version: "18.06.1~ce~3-0~ubuntu"
 govuk_docker::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk_docker::repo::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 


### PR DESCRIPTION
This version of docker-ce is the last one that supports Trusty on a
3.x Linux Kernel [1].

I'm upgrading as we seem to be experiencing an issue with aufs (see
below) on one of our machines. My investigation indicates that this may
potentially be a bug in docker-ce that was fixed in 17.12.1 and 18.03 [2].
So I expect updating to 18.06.1 will resolve it - if not at least we're
on a more recent version.

```
17:45:53  driver "aufs" failed to remove root filesystem for 1689bc31da539840e42f29043cd62bd7ebab3da05d0d5094aafcaebb90ea1958: could not remove diff path for id 0be2d29298c44335f47beb6a20151f1fa1b9516a551f7a6beea00b62aa880faf: error preparing atomic delete: rename /var/lib/docker/aufs/diff/0be2d29298c44335f47beb6a20151f1fa1b9516a551f7a6beea00b62aa880faf /var/lib/docker/aufs/diff/0be2d29298c44335f47beb6a20151f1fa1b9516a551f7a6beea00b62aa880faf-removing: device or resource busy
```

I've been running this on integration for around an hour and it seems to have resolved the problem, as well as not introducing any new ones.

[1]: https://docs.docker.com/engine/release-notes/18.06/
[2]: https://github.com/moby/moby/issues/21704