### PR TITLE
Auto-delete jobs removed from `govuk_ci::master::pipeline_jobs`

### DIFF
--- a/hieradata_aws/class/integration/ci_master.yaml
+++ b/hieradata_aws/class/integration/ci_master.yaml
@@ -139,10 +139,11 @@ govuk_jenkins::config::views:
 govuk_jenkins::config::create_agent_role: true
 govuk_jenkins::config::executors: '0'
 
-govuk_jenkins::job_builder::jobs:
+govuk_jenkins::job_builder::jobs: &job_builder_jobs
   - govuk_jenkins::jobs::deploy_app_downstream
   - govuk_jenkins::jobs::deploy_puppet_downstream
   - govuk_jenkins::jobs::build_fpm_package
+govuk_ci::master::job_builder_jobs: *job_builder_jobs
 
 govuk_jenkins::jobs::deploy_app_downstream::jenkins_downstream_api_password: "%{hiera('govuk_jenkins::jobs::deploy_app_downstream::ci_jenkins_downstream_api_password')}"
 

--- a/modules/govuk_ci/manifests/master.pp
+++ b/modules/govuk_ci/manifests/master.pp
@@ -46,6 +46,15 @@ class govuk_ci::master (
 
   # Add pipeline jobs from applications hash in Hieradata
   create_resources(govuk_ci::job, $pipeline_jobs)
+  # Manually delete all jobs which aren't in the hash
+  file { '/usr/local/bin/remove_old_jenkins_jobs':
+    ensure  => present,
+    mode    => '0755',
+    content => template('govuk_ci/usr/local/bin/remove_old_jenkins_jobs.sh.erb'),
+  }
+  exec { 'single run of remove_old_jenkins_jobs after adding pipeline jobs':
+    command => '/usr/local/bin/remove_old_jenkins_jobs',
+  }
 
   # Only add this configuration for CI master Jenkins instances
   file { '/var/lib/jenkins/github-plugin-configuration.xml':

--- a/modules/govuk_ci/manifests/master.pp
+++ b/modules/govuk_ci/manifests/master.pp
@@ -4,6 +4,12 @@
 #
 # === Parameters:
 #
+# [*pipeline_jobs*]
+#   Hash of applications to create jobs for
+#
+# [*job_builder_jobs*]
+#   Array of jobs created with the Job Builder plugin
+#
 # [*github_client_id*]
 #   The Github client ID is used as the user to authenticate against Github.
 #
@@ -18,6 +24,7 @@ class govuk_ci::master (
   $github_client_secret_encrypted,
   $jenkins_api_token,
   $pipeline_jobs = {},
+  $job_builder_jobs = [],
   $environment_variables = {},
   $ci_agents = {},
   $credentials_id,

--- a/modules/govuk_ci/templates/usr/local/bin/remove_old_jenkins_jobs.sh.erb
+++ b/modules/govuk_ci/templates/usr/local/bin/remove_old_jenkins_jobs.sh.erb
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+dirs_to_keep='<%= @pipeline_jobs.keys.join("\n") %>'
+
+ls -A /var/lib/jenkins/jobs | grep -vF "$dirs_to_keep" | xargs rm -rf

--- a/modules/govuk_ci/templates/usr/local/bin/remove_old_jenkins_jobs.sh.erb
+++ b/modules/govuk_ci/templates/usr/local/bin/remove_old_jenkins_jobs.sh.erb
@@ -2,4 +2,4 @@
 
 dirs_to_keep='<%= (@pipeline_jobs.keys + @job_builder_jobs.map { |job| job.split("::").last }).join("\n") %>'
 
-ls -A /var/lib/jenkins/jobs | grep -vF "$dirs_to_keep" | xargs rm -rf
+ls -A /var/lib/jenkins/jobs | grep -ivxF "$dirs_to_keep" | xargs rm -rf

--- a/modules/govuk_ci/templates/usr/local/bin/remove_old_jenkins_jobs.sh.erb
+++ b/modules/govuk_ci/templates/usr/local/bin/remove_old_jenkins_jobs.sh.erb
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-dirs_to_keep='<%= @pipeline_jobs.keys.join("\n") %>'
+dirs_to_keep='<%= (@pipeline_jobs.keys + @job_builder_jobs.map { |job| job.split("::").last }).join("\n") %>'
 
 ls -A /var/lib/jenkins/jobs | grep -vF "$dirs_to_keep" | xargs rm -rf


### PR DESCRIPTION
When we remove jobs from the hieradata ([1]), the job doesn't
actually get deleted in Jenkins ([2]). The process to remove the
job is manual ([3]). Consequently, there are a number of jobs in
Jenkins which should be deleted:

> ![Screenshot of Jenkins jobs, ordered by "Last Success"](https://user-images.githubusercontent.com/5111927/162483000-b536d1ad-002a-4d60-80a8-fa01ac321d03.png)
> Just 18 out of 51 repositories have had a (successful) build in the past 3 months.
> This is a sign that many of these are no longer active, and should be deleted.

Rather than rely on developers manually removing things from two
places, we can use Puppet to manage the resources. Taking
inspiration from a StackOverflow suggestion ([4]), updated to use
the older Puppet 3 syntax, we can have Puppet manage the
`/var/lib/jenkins/jobs` directory on the `ci_master` machine,
instructing it to purge any directories it finds within, _apart_
from those we've explicitly told it to keep.

[1]: https://github.com/alphagov/govuk-puppet/commit/876b7e188bcb3564557dad301bf4ccbd14a856a6
[2]: https://ci.integration.publishing.service.gov.uk/job/govuk_app_config/
[3]: https://docs.publishing.service.gov.uk/manual/retiring-an-application.html#12-remove-jobs-in-ci
[4]: https://stackoverflow.com/questions/44721855/delete-unmanaged-files-of-a-directory-via-puppet

Trello: https://trello.com/c/I4md269I/268-clean-up-dead-jobs-in-ci