### PR TITLE
Add code repository mirroring job

### DIFF
--- a/hieradata_aws/class/integration/jenkins.yaml
+++ b/hieradata_aws/class/integration/jenkins.yaml
@@ -23,6 +23,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::enhanced_ecommerce_search_api
   - govuk_jenkins::jobs::govuk_content_api_docs
   - govuk_jenkins::jobs::govuk_taxonomy_supervised_learning
+  - govuk_jenkins::jobs::mirror_github_repositories
   - govuk_jenkins::jobs::monitor_taxonomy_health
   - govuk_jenkins::jobs::passive_checks
   - govuk_jenkins::jobs::content_data_api_re_run
@@ -71,6 +72,8 @@ govuk_jenkins::jobs::deploy_cdn::services:
   - performanceplatform
   - www
   - www-eks
+
+govuk_jenkins::jobs::mirror_github_repositories::enable_slack_notifications: true
 
 govuk_jenkins::jobs::update_cdn_dictionaries::services:
   - assets

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -156,6 +156,9 @@ govuk_cdnlogs::bouncer_monitoring_enabled: false
 govuk_jenkins::job_builder::environment: 'integration'
 
 govuk_jenkins::jobs::athena_fastly_logs_check::s3_results_bucket: 'govuk-integration-fastly-logs-monitoring'
+
+govuk_jenkins::jobs::mirror_github_repositories::cron_schedule: '0 */2 * * *' # every 2 hours
+
 govuk_jenkins::jobs::content_data_api::rake_etl_main_process_cron_schedule: '0 13 * * *'
 
 govuk_jenkins::jobs::clear_cdn_cache::website_root_url: 'www.integration.publishing.service.gov.uk'

--- a/modules/govuk_jenkins/manifests/jobs/mirror_github_repositories.pp
+++ b/modules/govuk_jenkins/manifests/jobs/mirror_github_repositories.pp
@@ -1,0 +1,43 @@
+# == Class: govuk_jenkins::jobs::mirror_github_repositories
+#
+# Manages the process of backing up our GitHub code repositories to AWS CodeCommit.
+#
+# === Parameters:
+#
+# [* aws_codecommit_user_id *]
+#   IAM user with privileges to assume the role in aws_role_arn
+#
+# [* aws_role_arn *]
+#   IAM role with privileges to create, list and push to CodeCommit repositories
+#
+# [* cron_schedule *]
+#   The cron schedule to specify how often this task will run
+#   Default: undef
+#
+# [* mirror_repos_github_api_token *]
+#   A personal access token with `read:org` and `repo` scope
+#
+# [* ssh_private_key *]
+#   A private key attached to the IAM user in aws_codecommit_user_id
+#
+class govuk_jenkins::jobs::mirror_github_repositories (
+  $aws_codecommit_user_id = undef,
+  $aws_role_arn = undef,
+  $cron_schedule = undef,
+  $enable_slack_notifications = false,
+  $environment_variables = $govuk_jenkins::environment_variables,
+  $mirror_repos_github_api_token = undef,
+  $ssh_private_key = undef,
+) {
+
+  $slack_team_domain = 'govuk'
+  $slack_room = '2ndline'
+  $deploy_jenkins_domain = hiera('deploy_jenkins_domain')
+  $slack_build_server_url = "https://${deploy_jenkins_domain}/"
+
+  file { '/etc/jenkins_jobs/jobs/mirror_github_repositories.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/mirror_github_repositories.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+}

--- a/modules/govuk_jenkins/templates/jobs/mirror_github_repositories.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/mirror_github_repositories.yaml.erb
@@ -1,0 +1,60 @@
+---
+- scm:
+    name: mirror-github-repositories
+    scm:
+        - git:
+            url: git@github.com:alphagov/govuk-repo-mirror.git
+            branches:
+              - main
+            wipe-workspace: false
+- job:
+    name: Mirror_Github_Repositories
+    display-name: Mirror GitHub repositories
+    project-type: freestyle
+    description: "This job performs a backup of our GitHub repositories to AWS CodeCommit"
+    properties:
+        - github:
+            url: https://github.com/alphagov/govuk-repo-mirror/
+        - build-discarder:
+            days-to-keep: 30
+            artifact-num-to-keep: 5
+        - slack:
+            team-domain: <%= @slack_team_domain %>
+            auth-token-id: 'slack-notification-token'
+            auth-token-credential-id: 'slack-notification-token'
+            build-server-url: <%= @slack_build_server_url %>
+            notify-start: false
+            notify-success: false
+            notify-aborted: true
+            notify-notbuilt: true
+            notify-unstable: false
+            notify-failure: true
+            notify-backtonormal: false
+            notify-repeatedfailure: false
+            include-test-summary: false
+            include-custom-message: true
+            custom-message: "Mirror Github job to AWS CodeCommit failed"
+            room: <%= @slack_room %>
+    scm:
+      - mirror-github-repositories
+    builders:
+      - shell: |
+          echo "GITHUB_SSH_PRIVATE_KEY:"
+          echo ${GITHUB_SSH_PRIVATE_KEY}
+          export GITHUB_ACCESS_TOKEN=<%= @mirror_repos_github_api_token %>
+          export ROLE_ARN=<%= @aws_role_arn %>
+          export AWS_CODECOMMIT_USER_ID=<%= @aws_codecommit_user_id %>
+          export BUNDLE_BIN_PATH="${HOME}/bundles/${JOB_NAME}"
+          export BUNDLE_PATH="${HOME}/bundles/${JOB_NAME}"
+          bundle install --deployment --path "${HOME}/bundles/${JOB_NAME}"
+          ./mirror_repos
+    wrappers:
+      - inject-passwords:
+          global: false
+          mask-password-params: true
+          job-passwords:
+            - name: GIT_SSH_PRIVATE_KEY
+              password:
+                '<%= @ssh_private_key %>'
+    triggers:
+      - timed: <%= @cron_schedule %>

--- a/modules/govuk_jenkins/templates/jobs/mirror_github_repositories.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/mirror_github_repositories.yaml.erb
@@ -39,8 +39,10 @@
       - mirror-github-repositories
     builders:
       - shell: |
-          echo "GITHUB_SSH_PRIVATE_KEY:"
-          echo ${GITHUB_SSH_PRIVATE_KEY}
+          set -ex
+          echo ${GIT_SSH_PRIVATE_KEY} | sed -E 's/(-+(BEGIN|END) RSA PRIVATE KEY-+) *| +/\1\n/g' > /tmp/git_ssh_private_key.pem
+          chmod 600 /tmp/git_ssh_private_key.pem
+          export GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no -i /tmp/git_ssh_private_key.pem"
           export GITHUB_ACCESS_TOKEN=<%= @mirror_repos_github_api_token %>
           export ROLE_ARN=<%= @aws_role_arn %>
           export AWS_CODECOMMIT_USER_ID=<%= @aws_codecommit_user_id %>

--- a/modules/govuk_jenkins/templates/jobs/mirror_github_repositories.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/mirror_github_repositories.yaml.erb
@@ -46,6 +46,7 @@
           export GITHUB_ACCESS_TOKEN=<%= @mirror_repos_github_api_token %>
           export ROLE_ARN=<%= @aws_role_arn %>
           export AWS_CODECOMMIT_USER_ID=<%= @aws_codecommit_user_id %>
+          export ENSURE_DEFAULT_BRANCH=false
           export BUNDLE_BIN_PATH="${HOME}/bundles/${JOB_NAME}"
           export BUNDLE_PATH="${HOME}/bundles/${JOB_NAME}"
           bundle install --deployment --path "${HOME}/bundles/${JOB_NAME}"


### PR DESCRIPTION
This job was previously on Concourse, which is no longer supported on GOV.UK. We've therefore taken the decision to move it to Jenkins.

See commits for details. Dependent on https://github.com/alphagov/govuk-secrets/pull/1260.

Trello: https://trello.com/c/QlPzhn6A/2814-move-code-repository-mirroring-off-of-concourse