### PR TITLE
Redis access for Feedback in integration only

### DIFF
--- a/hieradata_aws/class/integration/feedback.yaml
+++ b/hieradata_aws/class/integration/feedback.yaml
@@ -1,0 +1,4 @@
+---
+
+govuk::apps::feedback::redis_host: 'backend-redis'
+govuk::apps::feedback::redis_port: '6379'

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -46,6 +46,8 @@ govuk::apps::feedback::govuk_notify_survey_signup_reply_to_id: 'fee22233-2f28-4b
 govuk::apps::feedback::govuk_notify_survey_signup_template_id: 'eb9ba220-7d74-4aab-975a-bdbe718f69a3'
 govuk::apps::feedback::govuk_notify_accessible_format_request_reply_to_id: '93109fea-34d9-4c38-ac7e-1ebc75e7416b'
 govuk::apps::feedback::govuk_notify_accessible_format_request_template_id: '47cef7ea-0849-48aa-9676-0ee0f7baa4ae'
+govuk::apps::feedback::redis_host: 'backend-redis'
+govuk::apps::feedback::redis_port: '6379'
 govuk::apps::frontend::google_tag_manager_auth: "C7iYdcsOlYgGmiUJjZKrHQ"
 govuk::apps::frontend::google_tag_manager_id: "GTM-MG7HG5W"
 govuk::apps::frontend::google_tag_manager_preview: "env-4"

--- a/modules/govuk/manifests/apps/feedback.pp
+++ b/modules/govuk/manifests/apps/feedback.pp
@@ -36,6 +36,14 @@
 # [*govuk_notify_accessible_format_request_reply_to_id*]
 #   Accessible format request email address reply_to ID for GOV.UK Notify
 #
+# [*redis_host*]
+#   Redis host for Rack::Attack.
+#   Default: undef
+#
+# [*redis_port*]
+#   Redis port for Rack::Attack.
+#   Default: undef
+#
 class govuk::apps::feedback(
   $port,
   $sentry_dsn = undef,
@@ -51,6 +59,8 @@ class govuk::apps::feedback(
   $govuk_notify_survey_signup_reply_to_id,
   $govuk_notify_accessible_format_request_template_id = undef,
   $govuk_notify_accessible_format_request_reply_to_id = undef,
+  $redis_host = undef,
+  $redis_port = undef,
 ) {
   $app_name = 'feedback'
 
@@ -139,5 +149,10 @@ class govuk::apps::feedback(
   govuk::app::envvar { "${title}-GOVUK_NOTIFY_ACCESSIBLE_FORMAT_REQUEST_REPLY_TO_ID":
     varname => 'GOVUK_NOTIFY_ACCESSIBLE_FORMAT_REQUEST_REPLY_TO_ID',
     value   => $govuk_notify_accessible_format_request_reply_to_id,
+  }
+
+  govuk::app::envvar::redis { $app_name:
+    host => $redis_host,
+    port => $redis_port,
   }
 }

--- a/modules/govuk/manifests/apps/feedback.pp
+++ b/modules/govuk/manifests/apps/feedback.pp
@@ -151,8 +151,10 @@ class govuk::apps::feedback(
     value   => $govuk_notify_accessible_format_request_reply_to_id,
   }
 
-  govuk::app::envvar::redis { $app_name:
-    host => $redis_host,
-    port => $redis_port,
+  if $redis_host != undef {
+    govuk::app::envvar::redis { $app_name:
+      host => $redis_host,
+      port => $redis_port,
+    }
   }
 }


### PR DESCRIPTION
## WHAT

Allow Feedback to use the shared REDIS backend so that Rack::Attack has a backing cache.

## WHY

Adding rate-limiting to Feedback app via Rack::Attack - for testing we just need quick access to a redis cluster, so use the shared one. We won't do this in production because we want to avoid shared backing instances, especially one that might have to defend against a DoS.

https://trello.com/c/9qqjfqVo/1186-add-app-level-rate-limiting-to-feedback

Feedback PR: https://github.com/alphagov/feedback/pull/1390