### PR TITLE
Remove thread count alerts

### DIFF
--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -321,7 +321,7 @@ define govuk::app::config (
     }
     if $alert_when_threads_exceed {
       @@icinga::check::graphite { "check_${title}_app_thread_count_${::hostname}":
-        ensure                     => $ensure,
+        ensure                     => absent,
         target                     => "${::fqdn_metrics}.processes-app-${title_underscore}.ps_count.threads",
         warning                    => $alert_when_threads_exceed,
         critical                   => $alert_when_threads_exceed,

--- a/modules/govuk/manifests/procfile/worker.pp
+++ b/modules/govuk/manifests/procfile/worker.pp
@@ -132,6 +132,7 @@ define govuk::procfile::worker (
 
       if $alert_when_threads_exceed {
         @@icinga::check::graphite { "check_app_${title}_procfile_worker_thread_count_${::hostname}":
+          ensure    => absent,
           target    => "${::fqdn_metrics}.processes-app-worker-${title_underscore}.ps_count.threads",
           warning   => $alert_when_threads_exceed,
           critical  => $alert_when_threads_exceed,


### PR DESCRIPTION
These are rarely actionable, so let's try removing them.

The default warning level of 100 threads is a bit arbitrary and it's not clear what value to increase things to if this is consistently breached.

We currently have an alert for a router instance because the thread count is 102.

These are the current levels for apps where specified:

- Asset manager: 165
- Cache clearing service: 250
- Content store: 155
- Email alert api: 100

Defaults are:

- apps: 100
- workers: 50