### PR TITLE
Update gpg key for aptly repo

### DIFF
--- a/modules/govuk/manifests/node/s_apt.pp
+++ b/modules/govuk/manifests/node/s_apt.pp
@@ -44,7 +44,7 @@ class govuk::node::s_apt (
     'aptly':
       location => 'http://repo.aptly.info',
       release  => 'squeeze',
-      key      => 'ED75B5A4483DA07C';
+      key      => 'A0546A43624A8331';
     'duplicity':
       location => 'http://ppa.launchpad.net/duplicity-team/ppa/ubuntu',
       release  => 'trusty',


### PR DESCRIPTION
The key for this repo has been rotated on 2022-03-15