### PR TITLE
Update deploy-lag-badger job to use main branch

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/run_deploy_lag_badger.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/run_deploy_lag_badger.yaml.erb
@@ -5,7 +5,7 @@
         - git:
             url: git@github.com:alphagov/govuk-deploy-lag-badger.git
             branches:
-              - master
+              - main
 
 - job:
     name: run-deploy-lag-badger


### PR DESCRIPTION
This is in preparation to switch the [deploy-lag-badger-repo](https://github.com/alphagov/govuk-deploy-lag-badger) to use
`main` as its default branch.

Trello card: https://trello.com/c/Ms8fjnrD/2857-3-audit-and-rename-default-branches-to-main