### PR TITLE
Update deploy_app job's default branch to "main"

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
@@ -40,7 +40,7 @@
               export APP_DEPLOYMENT_GIT_URL="git@github.com:alphagov/govuk-app-deployment.git"
             fi
 
-            git clone ${APP_DEPLOYMENT_GIT_URL} --branch ${APP_DEPLOYMENT_BRANCH:-master} --single-branch --depth 1 ./
+            git clone ${APP_DEPLOYMENT_GIT_URL} --branch ${APP_DEPLOYMENT_BRANCH:-main} --single-branch --depth 1 ./
             ./jenkins.sh
         <% if @deploy_downstream %>
         - conditional-step:
@@ -121,7 +121,7 @@
         - string:
             name: APP_DEPLOYMENT_BRANCH
             description: Branch of govuk-app-deployment to use.
-            default: master
+            default: main
         - bool:
             name: DEPLOY_FROM_AWS_CODECOMMIT
             default: false


### PR DESCRIPTION
We are switching the [govuk-app-deployment](https://github.com/alphagov/govuk-app-deployment) repo to use
`main` as its default branch.

Trello card: https://trello.com/c/Ms8fjnrD/2857-3-audit-and-rename-default-branches-to-main