### PR TITLE
Update Deploy_Terraform_GOVUK_AWS job's default branch

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_terraform_govuk_aws.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_terraform_govuk_aws.yaml.erb
@@ -91,8 +91,8 @@
         - string:
             name: GOVUK_AWS_BRANCH
             description: Branch of govuk-aws to use.
-            default: master
+            default: main
         - string:
             name: GOVUK_AWS_DATA_BRANCH
             description: Branch of govuk-aws-data to use.
-            default: master
+            default: main


### PR DESCRIPTION
We are updating the [govuk-aws](https://github.com/alphagov/govuk-aws) and [govuk-aws-data](https://github.com/alphagov/govuk-aws-data) repos to use
`main` as the default branch.

Trello card: https://trello.com/c/Ms8fjnrD/2857-3-audit-and-rename-default-branches-to-main