### PR TITLE
Update default branch name in Jenkin jobs

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/check_sentry_errors.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/check_sentry_errors.yaml.erb
@@ -5,7 +5,7 @@
         - git:
             url: git@github.com:alphagov/govuk-sentry-monitor.git
             branches:
-              - master
+              - main
             wipe-workspace: false
 
 - job:

--- a/modules/govuk_jenkins/templates/jobs/configure_github_repos.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/configure_github_repos.yaml.erb
@@ -5,7 +5,7 @@
         - git:
             url: git@github.com:alphagov/govuk-saas-config.git
             branches:
-              - master
+              - main
 
 - job:
     name: configure-github-repos

--- a/modules/govuk_jenkins/templates/jobs/govuk_content_api_docs.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/govuk_content_api_docs.yaml.erb
@@ -6,7 +6,7 @@
           url: git@github.com:alphagov/govuk-content-api-docs.git
           basedir: govuk-content-api-docs
           branches:
-            - master
+            - main
 - job:
     name: govuk-content-api-docs
     display-name: Publish GOV.UK Content API Docs

--- a/modules/govuk_jenkins/templates/jobs/publish_special_routes.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/publish_special_routes.yaml.erb
@@ -36,7 +36,7 @@
       - string:
           name: SPECIAL_ROUTE_PUBLISHER_BRANCH
           description: Branch of special-route-publisher to use.
-          default: master
+          default: main
 
 - job:
     name: Publish_Single_Special_Route
@@ -101,4 +101,4 @@
       - string:
           name: SPECIAL_ROUTE_PUBLISHER_BRANCH
           description: Branch of special-route-publisher to use.
-          default: master
+          default: main

--- a/modules/govuk_jenkins/templates/jobs/user_monitor.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/user_monitor.yaml.erb
@@ -5,7 +5,7 @@
         - git:
             url: git@github.com:alphagov/govuk-user-reviewer.git
             branches:
-              - master
+              - main
 
 - job:
     name: user-monitor


### PR DESCRIPTION
We are updating various repos so that their default branch will be `main`.
See individual commits for details.

Trello card: https://trello.com/c/Ms8fjnrD/2857-3-audit-and-rename-default-branches-to-main