### PR TITLE
Remove remainder of thread count alerting config

### DIFF
--- a/modules/govuk/manifests/app.pp
+++ b/modules/govuk/manifests/app.pp
@@ -223,10 +223,6 @@
 # [*collectd_process_regex*]
 #   Regex to use to identify the process.
 #
-# [*alert_when_threads_exceed*]
-#   If set, alert using Icinga if the number of threads exceeds the value specified.
-#   Default: 100
-#
 # [*alert_when_file_handles_exceed*]
 #   If set, alert using Icinga if the number of file handles exceeds
 #   the value specified.
@@ -294,7 +290,6 @@ define govuk::app (
   $cpu_warning = 150,
   $cpu_critical = 200,
   $collectd_process_regex = undef,
-  $alert_when_threads_exceed = 100,
   $alert_when_file_handles_exceed = 500,
   $override_search_location = undef,
   $monitor_unicornherder = undef,
@@ -374,7 +369,6 @@ define govuk::app (
     cpu_warning                         => $cpu_warning,
     cpu_critical                        => $cpu_critical,
     collectd_process_regex              => $collectd_process_regex,
-    alert_when_threads_exceed           => $alert_when_threads_exceed,
     alert_when_file_handles_exceed      => $alert_when_file_handles_exceed,
     override_search_location            => $override_search_location,
     monitor_unicornherder               => $monitor_unicornherder,

--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -120,7 +120,6 @@ define govuk::app::config (
   $cpu_warning = 150,
   $cpu_critical = 200,
   $collectd_process_regex = undef,
-  $alert_when_threads_exceed = undef,
   $alert_when_file_handles_exceed = undef,
   $override_search_location = undef,
   $monitor_unicornherder = undef,
@@ -319,18 +318,7 @@ define govuk::app::config (
       host_name      => $::fqdn,
       contact_groups => $additional_check_contact_groups,
     }
-    if $alert_when_threads_exceed {
-      @@icinga::check::graphite { "check_${title}_app_thread_count_${::hostname}":
-        ensure                     => absent,
-        target                     => "${::fqdn_metrics}.processes-app-${title_underscore}.ps_count.threads",
-        warning                    => $alert_when_threads_exceed,
-        critical                   => $alert_when_threads_exceed,
-        desc                       => "Thread count for ${title_underscore} exceeds ${alert_when_threads_exceed}",
-        host_name                  => $::fqdn,
-        attempts_before_hard_state => 3,
-        contact_groups             => $additional_check_contact_groups,
-      }
-    }
+
     if $alert_when_file_handles_exceed {
       @@icinga::check::graphite { "check_${title}_app_file_handles_count_${::hostname}":
         ensure                     => $ensure,

--- a/modules/govuk/manifests/apps/asset_manager.pp
+++ b/modules/govuk/manifests/apps/asset_manager.pp
@@ -100,7 +100,6 @@ class govuk::apps::asset_manager(
       depends_on_nfs             => true,
       nginx_extra_config         => template('govuk/asset_manager_extra_nginx_config.conf.erb'),
       unicorn_worker_processes   => $unicorn_worker_processes,
-      alert_when_threads_exceed  => 165,
       cpu_warning                => 350,
       cpu_critical               => 400,
       read_timeout               => 60,

--- a/modules/govuk/manifests/apps/cache_clearing_service.pp
+++ b/modules/govuk/manifests/apps/cache_clearing_service.pp
@@ -48,13 +48,12 @@ class govuk::apps::cache_clearing_service (
   $app_name = 'cache-clearing-service'
 
   govuk::app { $app_name:
-    ensure                    => $ensure,
-    app_type                  => 'bare',
-    enable_nginx_vhost        => false,
-    sentry_dsn                => $sentry_dsn,
-    command                   => 'bundle exec foreman start',
-    collectd_process_regex    => 'cache-clearing-service/.*rake message_queue:consumer',
-    alert_when_threads_exceed => 250,
+    ensure                 => $ensure,
+    app_type               => 'bare',
+    enable_nginx_vhost     => false,
+    sentry_dsn             => $sentry_dsn,
+    command                => 'bundle exec foreman start',
+    collectd_process_regex => 'cache-clearing-service/.*rake message_queue:consumer',
   }
 
   Govuk::App::Envvar {

--- a/modules/govuk/manifests/apps/content_store.pp
+++ b/modules/govuk/manifests/apps/content_store.pp
@@ -86,7 +86,6 @@ class govuk::apps::content_store(
     log_format_is_json         => true,
     vhost                      => $vhost,
     unicorn_worker_processes   => $unicorn_worker_processes,
-    alert_when_threads_exceed  => 155,
   }
 
   Govuk::App::Envvar {

--- a/modules/govuk/manifests/apps/email_alert_api.pp
+++ b/modules/govuk/manifests/apps/email_alert_api.pp
@@ -140,7 +140,6 @@ class govuk::apps::email_alert_api(
   govuk::procfile::worker {'email-alert-api':
     ensure                    => $ensure,
     enable_service            => $enable_procfile_worker,
-    alert_when_threads_exceed => 100,
     memory_warning_threshold  => 8000,
     memory_critical_threshold => 10000,
   }

--- a/modules/govuk/manifests/procfile/worker.pp
+++ b/modules/govuk/manifests/procfile/worker.pp
@@ -27,10 +27,6 @@
 #   This variable is used by the govuk/procfile-worker.conf.erb template.
 #   Default: 1
 #
-# [*alert_when_threads_exceed*]
-#   If set, alert using Icinga if the number of threads exceeds the value specified.
-#   Default: 50
-#
 # [*process_regex*]
 #   The regex to use for the CollectD Process plugin.
 #   Default: "sidekiq .* ${title}(.*\\.gov\\.uk)? "
@@ -49,7 +45,6 @@ define govuk::procfile::worker (
   $process_type = 'worker',
   $setenv_as = $title,
   $process_count = 1,
-  $alert_when_threads_exceed = 50,
   $respawn_count = 5,
   $respawn_timeout = 20,
   $process_regex = "sidekiq .* ${title}(.*\\.gov\\.uk)? ",
@@ -128,17 +123,6 @@ define govuk::procfile::worker (
         event_handler              => "govuk_procfile_worker_high_memory!${service_name}",
         notes_url                  => monitoring_docs_url(high-memory-for-application),
         attempts_before_hard_state => 10,
-      }
-
-      if $alert_when_threads_exceed {
-        @@icinga::check::graphite { "check_app_${title}_procfile_worker_thread_count_${::hostname}":
-          ensure    => absent,
-          target    => "${::fqdn_metrics}.processes-app-worker-${title_underscore}.ps_count.threads",
-          warning   => $alert_when_threads_exceed,
-          critical  => $alert_when_threads_exceed,
-          desc      => "Thread count for ${service_name} exceeds ${alert_when_threads_exceed}",
-          host_name => $::fqdn,
-        }
       }
     }
   } else {


### PR DESCRIPTION
In https://github.com/alphagov/govuk-puppet/pull/11634 we removed thread count alerting as we weren't finding any value in it.

This is a follow up to remove the puppet config now that the alerts have been removed.