### PR TITLE
Update Publish_Single_Special_Route job's default branch

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/publish_special_routes.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/publish_special_routes.yaml.erb
@@ -67,7 +67,7 @@
       - string:
           name: SPECIAL_ROUTE_PUBLISHER_BRANCH
           description: Branch of special-route-publisher to use.
-          default: master
+          default: main
 
 - job:
     name: Unpublish_Single_Special_Route


### PR DESCRIPTION
This was missed previously in https://github.com/alphagov/govuk-puppet/pull/11641/commits/74689a48de50e69bd3c83c5a8b398960eca1d57d

Trello card: https://trello.com/c/Ms8fjnrD/2857-3-audit-and-rename-default-branches-to-main