### PR TITLE
Fix 'remove_old_jenkins_jobs.sh' script

### DIFF
--- a/modules/govuk_ci/templates/usr/local/bin/remove_old_jenkins_jobs.sh.erb
+++ b/modules/govuk_ci/templates/usr/local/bin/remove_old_jenkins_jobs.sh.erb
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -eu
+
 dirs_to_keep='<%= (@pipeline_jobs.keys + @job_builder_jobs.map { |job| job.split("::").last }).join("\n") %>'
 
 cd /var/lib/jenkins/jobs

--- a/modules/govuk_ci/templates/usr/local/bin/remove_old_jenkins_jobs.sh.erb
+++ b/modules/govuk_ci/templates/usr/local/bin/remove_old_jenkins_jobs.sh.erb
@@ -2,4 +2,5 @@
 
 dirs_to_keep='<%= (@pipeline_jobs.keys + @job_builder_jobs.map { |job| job.split("::").last }).join("\n") %>'
 
-ls -A /var/lib/jenkins/jobs | grep -ivxF "$dirs_to_keep" | xargs rm -rf
+cd /var/lib/jenkins/jobs
+ls -A . | grep -ivxF "$dirs_to_keep" | xargs sudo rm -rf


### PR DESCRIPTION
Follow-on from #11630. A couple of small bugs in the original
script, that could not be detected until we attempted to perform
the delete on CI:

1) The directories passed to `xargs` were missing the
   `/var/lib/jenkins/jobs` prefix, so we were attempting to `rm`
   the directories from whatever directory we were in at the time
   of running the script. I've fixed this with a `cd` prior to
   attempting any deletions.
   NB: this only 'changes directory' within the context of the script.
   It doesn't change the working directory of the user running the script.
2) We need to run the `rm` as `sudo`.

Trello: https://trello.com/c/I4md269I/268-clean-up-dead-jobs-in-ci