### PR TITLE
Add manually added jobs to the 'remove_old_jenkins_jobs' allowlist

### DIFF
--- a/modules/govuk_ci/manifests/master.pp
+++ b/modules/govuk_ci/manifests/master.pp
@@ -50,6 +50,7 @@ class govuk_ci::master (
   # Manually add jobs that we do not want to included in the 'Deploy App' job
   govuk_ci::job { 'govuk-dns': }
   govuk_ci::job { 'govuk-dns-config': }
+  $manually_added_jobs = ['govuk-dns', 'govuk-dns-config'] # keep in sync with above
 
   # Add pipeline jobs from applications hash in Hieradata
   create_resources(govuk_ci::job, $pipeline_jobs)

--- a/modules/govuk_ci/templates/usr/local/bin/remove_old_jenkins_jobs.sh.erb
+++ b/modules/govuk_ci/templates/usr/local/bin/remove_old_jenkins_jobs.sh.erb
@@ -2,7 +2,7 @@
 
 set -eu
 
-dirs_to_keep='<%= (@pipeline_jobs.keys + @job_builder_jobs.map { |job| job.split("::").last }).join("\n") %>'
+dirs_to_keep='<%= (@manually_added_jobs + @pipeline_jobs.keys + @job_builder_jobs.map { |job| job.split("::").last }).join("\n") %>'
 
 cd /var/lib/jenkins/jobs
 ls -A . | grep -ivxF "$dirs_to_keep" | xargs sudo rm -rf


### PR DESCRIPTION
The 'remove_old_jenkins_jobs' script is removing the govuk-dns
and govuk-dns-config jobs because they don't appear in either the
`pipeline_jobs` hash nor the `job_builder_jobs` array. govuk-dns
and govuk-dns-config are special cases in that they are the only
jobs declared with the `govuk_ci::job` helper.

Trello: https://trello.com/c/I4md269I/268-clean-up-dead-jobs-in-ci