### PR TITLE
Update default branch name in Jenkin jobs

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/bouncer_cdn.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/bouncer_cdn.yaml.erb
@@ -5,7 +5,7 @@
         - git:
             url: git@github.com:alphagov/govuk-cdn-config.git
             branches:
-              - master
+              - main
 
 - job:
     name: Bouncer_CDN

--- a/modules/govuk_jenkins/templates/jobs/check_cdn_ip_ranges.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/check_cdn_ip_ranges.yaml.erb
@@ -5,7 +5,7 @@
         - git:
             url: git@github.com:alphagov/govuk-provisioning.git
             branches:
-              - master
+              - main
             wipe-workspace: false
 
 - job:

--- a/modules/govuk_jenkins/templates/jobs/check_github_ip_ranges.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/check_github_ip_ranges.yaml.erb
@@ -5,7 +5,7 @@
         - git:
             url: git@github.com:alphagov/govuk-provisioning.git
             branches:
-              - master
+              - main
             wipe-workspace: false
 
 - job:

--- a/modules/govuk_jenkins/templates/jobs/deploy_cdn.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_cdn.yaml.erb
@@ -67,4 +67,4 @@
         - string:
             name: GOVUK_CDN_CONFIG_BRANCH
             description: Branch of govuk-cdn-config to use.
-            default: master
+            default: main

--- a/modules/govuk_jenkins/templates/jobs/search_fetch_analytics_data.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/search_fetch_analytics_data.yaml.erb
@@ -5,7 +5,7 @@
         - git:
             url: git@github.com:alphagov/search-analytics.git
             branches:
-              - master
+              - main
 
 - job:
     name: <%= @job_name %>

--- a/modules/govuk_jenkins/templates/jobs/update_cdn_dictionaries.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/update_cdn_dictionaries.yaml.erb
@@ -5,7 +5,7 @@
         - git:
             url: git@github.com:alphagov/govuk-cdn-config.git
             branches:
-              - master
+              - main
             wipe-workspace: false
             clean:
                 after: true


### PR DESCRIPTION
We are updating various repos so that their default branch will be `main`.
See individual commits for details.

Trello card: https://trello.com/c/Ms8fjnrD/2857-3-audit-and-rename-default-branches-to-main