### PR TITLE
Bump git version from 1.9.1 to 2.29.0

### DIFF
--- a/hieradata_aws/common.trusty.yaml
+++ b/hieradata_aws/common.trusty.yaml
@@ -5,7 +5,7 @@ apt::sources:
     release: '%{::lsbdistcodename}'
     repos: 'main'
     key:
-      id: 'A1715D88E1DF1F24'
+      id: 'E1DD270288B4E6030699E45FA1715D88E1DF1F24'
       server: 'keyserver.ubuntu.com'
     include:
       src: false

--- a/hieradata_aws/common.trusty.yaml
+++ b/hieradata_aws/common.trusty.yaml
@@ -1,5 +1,15 @@
 ---
 apt::sources:
+  git:
+    location: 'https://ppa.launchpadcontent.net/git-core/ppa/ubuntu'
+    release: '%{::lsbdistcodename}'
+    repos: 'main'
+    key:
+      id: 'A1715D88E1DF1F24'
+      server: 'keyserver.ubuntu.com'
+    include:
+      src: false
+      deb: true
   ubuntu:
     location: 'http://gb.archive.ubuntu.com/ubuntu/'
     release: '%{::lsbdistcodename}'

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -255,7 +255,6 @@ base::packages::packages:
   - 'dnsutils'
   - 'dstat'
   - 'gettext'
-  - 'git'
   - 'htop'
   - 'iftop'
   - 'iotop'

--- a/modules/base/manifests/init.pp
+++ b/modules/base/manifests/init.pp
@@ -27,6 +27,7 @@ class base (
   include curl
   include govuk_python
   include govuk::deploy
+  include govuk_apt::latest_git
   include govuk_apt::unused_kernels
   include govuk_apt::package_blacklist
   include govuk_awscli

--- a/modules/govuk_apt/manifests/latest_git.pp
+++ b/modules/govuk_apt/manifests/latest_git.pp
@@ -1,0 +1,10 @@
+# == Class: govuk_apt::latest_git
+#
+# Class to install latest available version of Git. See
+# https://launchpad.net/~git-core/+archive/ubuntu/ppa/+index#
+#
+class govuk_apt::latest_git {
+  package { 'git':
+    ensure  => latest,
+  }
+}


### PR DESCRIPTION
In order to move code repository mirroring from Concourse to
Jenkins, we need to set up the SSH key associated with the
codecommit git pushes ([1]).

However, the `GIT_SSH_COMMAND` technique we want to use is
not supported in versions of Git below 2.3.0 ([2]).

Our Ubuntu Trusty machines are currently on Git version 1.9.1.
This commit adds the Ubuntu Git PPA to the system ([3]), such
that running `sudo apt-get update` followed by `sudo apt-get
install git` will install the latest version of Git available
on Trusty ("1:2.29.0-0ppa1~ubuntu14.04.1").

Trello: https://trello.com/c/QlPzhn6A/2814-move-code-repository-mirroring-off-of-concourse

[1]: https://github.com/alphagov/govuk-repo-mirror/blob/740c9e57a3fec67f03e980ad07d977b93ece24ce/concourse.yml#L79-L85
[2]: https://stackoverflow.com/a/29754018
[3]: https://launchpad.net/~git-core/+archive/ubuntu/ppa/+index#