### PR TITLE
Add GTM env vars to frontend and collections

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -31,6 +31,9 @@ govuk::apps::content_publisher::google_tag_manager_id: "GTM-NQXC4TG"
 govuk::apps::content_publisher::google_tag_manager_preview: "env-6"
 govuk::apps::content_publisher::email_address_override: "content-publisher-notifications-integration@digital.cabinet-office.gov.uk"
 govuk::apps::content_publisher::govuk_notify_template_id: "759acac6-da53-4a19-b591-b7538c7c39de"
+govuk::apps::collections::google_tag_manager_auth: "C7iYdcsOlYgGmiUJjZKrHQ"
+govuk::apps::collections::google_tag_manager_id: "GTM-MG7HG5W"
+govuk::apps::collections::google_tag_manager_preview: "env-4"
 govuk::apps::collections_publisher::govuk_notify_template_id: "759acac6-da53-4a19-b591-b7538c7c39de"
 govuk::apps::collections_publisher::publish_without_2i_email: "mainstream-publisher-notifications-integration@digital.cabinet-office.gov.uk"
 govuk::apps::collections_publisher::unreleased_features_enabled: true
@@ -43,6 +46,9 @@ govuk::apps::feedback::govuk_notify_survey_signup_reply_to_id: 'fee22233-2f28-4b
 govuk::apps::feedback::govuk_notify_survey_signup_template_id: 'eb9ba220-7d74-4aab-975a-bdbe718f69a3'
 govuk::apps::feedback::govuk_notify_accessible_format_request_reply_to_id: '93109fea-34d9-4c38-ac7e-1ebc75e7416b'
 govuk::apps::feedback::govuk_notify_accessible_format_request_template_id: '47cef7ea-0849-48aa-9676-0ee0f7baa4ae'
+govuk::apps::frontend::google_tag_manager_auth: "C7iYdcsOlYgGmiUJjZKrHQ"
+govuk::apps::frontend::google_tag_manager_id: "GTM-MG7HG5W"
+govuk::apps::frontend::google_tag_manager_preview: "env-4"
 govuk::apps::frontend::govuk_notify_template_id: '1fc69d3a-09a2-40f9-852b-03f6fcef5340'
 govuk::apps::frontend::govuk_personalisation_manage_uri: 'https://integration.account.gov.uk?link=manage-account'
 govuk::apps::government_frontend::google_tag_manager_auth: "C7iYdcsOlYgGmiUJjZKrHQ"

--- a/modules/govuk/manifests/apps/collections.pp
+++ b/modules/govuk/manifests/apps/collections.pp
@@ -31,6 +31,15 @@
 # [*memcache_servers*]
 #   URL of a shared memcache cluster.
 #
+# [*google_tag_manager_id*]
+#   The ID for the Google Tag Manager account
+#
+# [*google_tag_manager_preview*]
+#   Allows a tag to be previewed in the Google Tag Manager interface
+#
+# [*google_tag_manager_auth*]
+#   The identifier of an environment for Google Tag Manager
+#
 class govuk::apps::collections(
   $vhost = 'collections',
   $port,
@@ -39,6 +48,9 @@ class govuk::apps::collections(
   $sentry_dsn = undef,
   $email_alert_api_bearer_token = undef,
   $memcache_servers = undef,
+  $google_tag_manager_id = undef,
+  $google_tag_manager_preview = undef,
+  $google_tag_manager_auth = undef,
 ) {
   govuk::app { 'collections':
     app_type                   => 'rack',
@@ -64,6 +76,15 @@ class govuk::apps::collections(
     "${title}-SECRET_KEY_BASE":
         varname => 'SECRET_KEY_BASE',
         value   => $secret_key_base;
+    "${title}-GOOGLE_TAG_MANAGER_ID":
+        varname => 'GOOGLE_TAG_MANAGER_ID',
+        value   => $google_tag_manager_id;
+    "${title}-GOOGLE_TAG_MANAGER_PREVIEW":
+        varname => 'GOOGLE_TAG_MANAGER_PREVIEW',
+        value   => $google_tag_manager_preview;
+    "${title}-GOOGLE_TAG_MANAGER_AUTH":
+        varname => 'GOOGLE_TAG_MANAGER_AUTH',
+        value   => $google_tag_manager_auth;
     # MEMCACHE_SERVERS is used by "Dalli", our memcached client gem
     # https://github.com/petergoldstein/dalli/blob/1fbef3c/lib/dalli/client.rb#L35
     "${title}-MEMCACHE_SERVERS":

--- a/modules/govuk/manifests/apps/frontend.pp
+++ b/modules/govuk/manifests/apps/frontend.pp
@@ -63,6 +63,15 @@
 # [*elections_api_key*]
 #   API key for the Elections API
 #
+# [*google_tag_manager_id*]
+#   The ID for the Google Tag Manager account
+#
+# [*google_tag_manager_preview*]
+#   Allows a tag to be previewed in the Google Tag Manager interface
+#
+# [*google_tag_manager_auth*]
+#   The identifier of an environment for Google Tag Manager
+#
 class govuk::apps::frontend(
   $vhost = 'frontend',
   $port,
@@ -81,6 +90,9 @@ class govuk::apps::frontend(
   $memcache_servers = undef,
   $elections_api_url = undef,
   $elections_api_key = undef,
+  $google_tag_manager_id = undef,
+  $google_tag_manager_preview = undef,
+  $google_tag_manager_auth = undef,
 ) {
   $app_name = 'frontend'
 
@@ -117,6 +129,15 @@ class govuk::apps::frontend(
     "${title}-PUBLISHING_API_BEARER_TOKEN":
       varname => 'PUBLISHING_API_BEARER_TOKEN',
       value   => $publishing_api_bearer_token;
+    "${title}-GOOGLE_TAG_MANAGER_ID":
+      varname => 'GOOGLE_TAG_MANAGER_ID',
+      value   => $google_tag_manager_id;
+    "${title}-GOOGLE_TAG_MANAGER_PREVIEW":
+      varname => 'GOOGLE_TAG_MANAGER_PREVIEW',
+      value   => $google_tag_manager_preview;
+    "${title}-GOOGLE_TAG_MANAGER_AUTH":
+      varname => 'GOOGLE_TAG_MANAGER_AUTH',
+      value   => $google_tag_manager_auth;
     "${title}-GOVUK_NOTIFY_API_KEY":
         varname => 'GOVUK_NOTIFY_API_KEY',
         value   => $govuk_notify_api_key;


### PR DESCRIPTION
## What
Add some env vars to `frontend` and `collections` for GA4 testing purposes.

## Why
We want to test some of the new GA4 stuff on integration only in these applications and the code will depend on these variables to work. This involves some repetition, which ideally would be avoided, but this is a temporary measure for testing purposes.

PR based on previous work: https://github.com/alphagov/govuk-puppet/pull/11550
