### PR TITLE
Update default branch name in Jenkin jobs

### DIFF
--- a/modules/govuk/manifests/node/s_gatling.pp
+++ b/modules/govuk/manifests/node/s_gatling.pp
@@ -14,7 +14,7 @@
 #
 # [*commit*]
 #  The version of the repository where GOV.UK defines its load tests
-#  Default = 'master'
+#  Default = 'main'
 #
 # [*ssh_public_key*]
 #  ssh public key of user which has access to govuk-load-testing repo
@@ -27,7 +27,7 @@
 class govuk::node::s_gatling (
   $root_dir                       = '/usr/local/bin/gatling/results',
   $repo                           = 'https://github.com/alphagov/govuk-load-testing.git',
-  $commit                         = 'master',
+  $commit                         = 'main',
   $apt_mirror_hostname            = undef,
   $apt_mirror_gpg_key_fingerprint = undef,
   $ssh_public_key                 = undef,

--- a/modules/govuk_jenkins/templates/jobs/build_fpm_package.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/build_fpm_package.yaml.erb
@@ -5,7 +5,7 @@
         - git:
             url: https://github.com/alphagov/packager
             branches:
-              - master
+              - main
             wipe-workspace: true
 
 - job:

--- a/modules/govuk_jenkins/templates/jobs/deploy_dns.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_dns.yaml.erb
@@ -5,7 +5,7 @@
         - git:
             url: git@github.com:alphagov/govuk-dns.git
             branches:
-              - master
+              - main
             wipe-workspace: true
             clean:
                 after: true

--- a/modules/govuk_jenkins/templates/jobs/validate_published_dns.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/validate_published_dns.yaml.erb
@@ -5,7 +5,7 @@
         - git:
             url: git@github.com:alphagov/govuk-dns.git
             branches:
-              - master
+              - main
             wipe-workspace: true
             clean:
                 after: true
@@ -28,7 +28,7 @@
         - shell: |
             set -e
             rm -rf govuk-dns-config
-            git clone --branch master --depth 1 git@github.com:alphagov/govuk-dns-config.git
+            git clone --branch main --depth 1 git@github.com:alphagov/govuk-dns-config.git
             cp "./govuk-dns-config/${ZONEFILE}" .
             bundle install --path "${HOME}/bundles/${JOB_NAME}"
             bundle exec rake validate_dns


### PR DESCRIPTION
We are updating various repos so that their default branch will be `main`.
See individual commits for details.

Trello card: https://trello.com/c/Ms8fjnrD/2857-3-audit-and-rename-default-branches-to-main