### PR TITLE
Add repository name for Contacts Admin downstream job

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1112,6 +1112,7 @@ govuk_jenkins::jobs::deploy_app_downstream::applications:
   contacts:
     healthcheck_urls:
       - "https://contacts-admin.%{hiera('app_domain_internal')}/healthcheck/ready"
+    repository: "contacts-admin"
   content-data-admin:
     healthcheck_urls:
       - "https://content-data.%{hiera('app_domain_internal')}/healthcheck/ready"


### PR DESCRIPTION
Continuous deployment of Contacts Admin is currently failing ([example run](https://deploy.integration.publishing.service.gov.uk/job/Deploy_App_Downstream/5874/console)) due to the following error:

```
Could not resolve to a Repository with the name 'alphagov/contacts'
```

This application's repo name does not match it's deployed name. Therefore we [need to specify the repository name](https://github.com/alphagov/govuk-puppet/blob/8c7851b7973da5b86877f92f45d77f54de0b42f4/modules/govuk_jenkins/templates/jobs/deploy_app_downstream.yaml.erb#L41) to enable it to be pulled by the downstream deployment job.