### PR TITLE
Update default branch name in Jenkin job

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_lambda_app.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_lambda_app.yaml.erb
@@ -5,7 +5,7 @@
         - git:
             url: git@github.com:alphagov/govuk-lambda-app-deployment.git
             branches:
-              - master
+              - main
             wipe-workspace: true
 
 - job:


### PR DESCRIPTION
We are updating https://github.com/alphagov/govuk-lambda-app-deployment
to use `main` as the default branch name.

Trello card: https://trello.com/c/Ms8fjnrD/2857-3-audit-and-rename-default-branches-to-main