### PR TITLE
Add Sentry env var for Smokey / Smokey Loop

### DIFF
--- a/modules/govuk/manifests/apps/smokey.pp
+++ b/modules/govuk/manifests/apps/smokey.pp
@@ -34,6 +34,9 @@
 # [*smokey_bearer_token*]
 #   Bearer token for something
 #
+# [*sentry_dsn*]
+#   The URL used by Sentry to report exceptions
+#
 class govuk::apps::smokey (
   $http_username = undef,
   $http_password = undef,
@@ -45,6 +48,7 @@ class govuk::apps::smokey (
   $smokey_govuk_account_email = undef,
   $smokey_govuk_account_password = undef,
   $smokey_bearer_token = undef,
+  $sentry_dsn = undef,
 ){
   $app = 'smokey'
   $app_domain = hiera('app_domain')
@@ -71,6 +75,8 @@ class govuk::apps::smokey (
     'GOVUK_ACCOUNT_EMAIL':      value => $smokey_govuk_account_email;
     'GOVUK_ACCOUNT_PASSWORD':   value => $smokey_govuk_account_password;
     'DBUS_SESSION_BUS_ADDRESS': value => 'disabled:';
+    'SENTRY_DSN':               value => $sentry_dsn;
+    'GOVUK_STATSD_PREFIX':      value => "govuk.app.smokey.${::hostname}";
   }
 
   if ($::aws_environment == 'staging') or ($::aws_environment == 'production') {


### PR DESCRIPTION
https://trello.com/c/LnE7dZdj/257-survey-actions-for-smokey

Relates to: https://github.com/alphagov/smokey/pull/931

The following env vars are required by Sentry / StatsD:

- SENTRY_DSN (will be provided by govuk-secrets)
- SENTRY_CURRENT_ENV (provided on all machines [^1])
- GOVUK_DATA_SYNC_PERIOD (ditto)
- GOVUK_STATSD_PREFIX (added here to match apps [^2])

See govuk_app_config for more details [^3]. Note that _STATSD_HOST
is left as the default of "localhost" since an instance of StatsD
is running on every machine as a proxy.

[^1]: https://github.com/alphagov/govuk-puppet/blob/5b5e249600eeddbd78e5292bdf4a8999c8b35a26/modules/govuk/manifests/deploy/config.pp#L128
[^2]: https://github.com/alphagov/govuk-puppet/blob/5b5e249600eeddbd78e5292bdf4a8999c8b35a26/modules/govuk/manifests/app/config.pp#L189
[^3]: https://github.com/alphagov/govuk_app_config/blob/87e445eccee5fba2449a170d5ba628e8a380fcb8/lib/govuk_app_config/govuk_error/configuration.rb