### PR TITLE
Make CDN cache clear Jenkins task equivalent to cache-clear service

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -162,7 +162,6 @@ govuk_jenkins::jobs::mirror_github_repositories::cron_schedule: '0 */2 * * *' # 
 govuk_jenkins::jobs::content_data_api::rake_etl_main_process_cron_schedule: '0 13 * * *'
 
 govuk_jenkins::jobs::clear_cdn_cache::website_root_url: 'www.integration.publishing.service.gov.uk'
-govuk_jenkins::jobs::clear_cdn_cache::assets_root_url: 'assets.integration.publishing.service.gov.uk'
 
 govuk_jenkins::jobs::content_publisher_whitehall_import::enable_slack_notifications: true
 

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -305,7 +305,6 @@ govuk_jenkins::jobs::athena_fastly_logs_check::databases: ['govuk_www', 'govuk_a
 govuk_jenkins::jobs::content_data_api::rake_etl_main_process_cron_schedule: '0 7 * * *'
 
 govuk_jenkins::jobs::clear_cdn_cache::website_root_url: 'www.gov.uk'
-govuk_jenkins::jobs::clear_cdn_cache::assets_root_url: 'assets.publishing.service.gov.uk'
 
 govuk_jenkins::jobs::run_related_links_generation::cron_schedule: '0 8 9,23 * *'
 govuk_jenkins::jobs::run_related_links_ingestion::cron_schedule: '0 8 11,25 * *'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -285,7 +285,6 @@ govuk_jenkins::jobs::athena_fastly_logs_check::s3_results_bucket: 'govuk-staging
 govuk_jenkins::jobs::content_data_api::rake_etl_main_process_cron_schedule: '0 11 * * *'
 
 govuk_jenkins::jobs::clear_cdn_cache::website_root_url: 'www.staging.publishing.service.gov.uk'
-govuk_jenkins::jobs::clear_cdn_cache::assets_root_url: 'assets.staging.publishing.service.gov.uk'
 
 govuk_jenkins::jobs::network_config_deploy::environments:
   - 'carrenza-staging'

--- a/modules/govuk_jenkins/manifests/jobs/clear_cdn_cache.pp
+++ b/modules/govuk_jenkins/manifests/jobs/clear_cdn_cache.pp
@@ -4,7 +4,6 @@
 #
 class govuk_jenkins::jobs::clear_cdn_cache(
   $website_root_url = nil,
-  $assets_root_url = nil,
 ) {
   file { '/etc/jenkins_jobs/jobs/clear_cdn_cache.yaml':
     ensure  => present,

--- a/modules/govuk_jenkins/templates/jobs/clear_cdn_cache.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/clear_cdn_cache.yaml.erb
@@ -4,7 +4,7 @@
     display-name: Clear CDN cache
     project-type: freestyle
     description: >
-      Clears pages from the Fastly CDN cache
+      Clears pages from the Fastly CDN cache and internal varnish cache
     properties:
       - build-discarder:
           num-to-keep: 30
@@ -18,12 +18,23 @@
 
           for url in $URLS; do
             if [[ "${url:0:1}" == "/" ]]; then
+              local_varnish_url="http://localhost:7999${url}"
               cdn_url="<%= @website_root_url -%>${url}"
             elif [[ $url =~ "://" ]]; then
+              # don't clear absolute URLs from our local varnish as they won't
+              # match, we assume they're for assets
+              local_varnish_url=""
               cdn_url=$url
             else
               echo "expected $url to be an absolute path or absolute URL"
               exit 1
+            fi
+
+            if [ -n "$local_varnish_url" ]; then
+              echo $local_varnish_url
+              for node in `govuk_node_list -c cache`; do
+                ssh deploy@$node "curl -fs -o /dev/null -w \"HTTP response: %{http_code}\n\" -X PURGE $local_varnish_url"
+              done
             fi
 
             ssh deploy@$(govuk_node_list --single-node -c cache) "curl -fs -w \"HTTP response: %{http_code}\n\" -X PURGE $cdn_url"
@@ -38,9 +49,10 @@
             /vehicle-tax
           description: >
             Enter a list of paths (space separated) to GOV.UK pages to clear
-            them from CDN. Full URLs can be used for items not on the main
-            gov.uk hostname. This defaults to 10 pages that were once the 10 most
-            popular pages on GOV.UK according to our analytics.
+            them from CDN. Enter full URLs to clear only from CDN (such as
+            items not on the main gov.uk hostname, such as assets). This
+            defaults to 10 pages that were once the 10 most popular pages on
+            GOV.UK according to our analytics.
     wrappers:
       - ansicolor:
           colormap: xterm

--- a/modules/govuk_jenkins/templates/jobs/clear_cdn_cache.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/clear_cdn_cache.yaml.erb
@@ -4,7 +4,7 @@
     display-name: Clear CDN cache
     project-type: freestyle
     description: >
-      Clears the CDN cache for the 10 most popular pages on GOV.UK.
+      Clears pages from the Fastly CDN cache
     properties:
       - build-discarder:
           num-to-keep: 30
@@ -12,34 +12,35 @@
       - shell: |
           #!/usr/bin/env bash
 
-          set -ex
+          # f argument disables globbing, which we don't want to happen
+          # on our URL inputs
+          set -exf
 
-          declare -a hostnames=(
-            "<%= @website_root_url -%>"
-            "<%= @assets_root_url -%>"
-          )
+          for url in $URLS; do
+            if [[ "${url:0:1}" == "/" ]]; then
+              cdn_url="<%= @website_root_url -%>${url}"
+            elif [[ $url =~ "://" ]]; then
+              cdn_url=$url
+            else
+              echo "expected $url to be an absolute path or absolute URL"
+              exit 1
+            fi
 
-          # 10 most popular pages based on GA 1-year stats
-          declare -a paths=(
-            "/"
-            "/check-mot-history"
-            "/coronavirus"
-            "/get-coronavirus-test"
-            "/log-in-register-hmrc-online-services"
-            "/report-covid19-result"
-            "/search/all"
-            "/sign-in-universal-credit"
-            "/sold-bought-vehicle"
-            "/vehicle-tax"
-          )
-
-          for node in `govuk_node_list -c cache`; do
-            for hostname in "${hostnames[@]}"; do
-              for path in "${paths[@]}"; do
-                ssh deploy@$node "curl -s -X PURGE $hostname$path"
-              done
-            done
+            ssh deploy@$(govuk_node_list --single-node -c cache) "curl -fs -w \"HTTP response: %{http_code}\n\" -X PURGE $cdn_url"
           done
+    parameters:
+      - text:
+          name: URLS
+          default: >
+            / /check-mot-history /coronavirus /get-coronavirus-test
+            /log-in-register-hmrc-online-services /report-covid19-result
+            /search/all /sign-in-universal-credit /sold-bought-vehicle
+            /vehicle-tax
+          description: >
+            Enter a list of paths (space separated) to GOV.UK pages to clear
+            them from CDN. Full URLs can be used for items not on the main
+            gov.uk hostname. This defaults to 10 pages that were once the 10 most
+            popular pages on GOV.UK according to our analytics.
     wrappers:
       - ansicolor:
           colormap: xterm

--- a/modules/govuk_jenkins/templates/jobs/clear_cdn_cache.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/clear_cdn_cache.yaml.erb
@@ -34,10 +34,12 @@
               echo $local_varnish_url
               for node in `govuk_node_list -c cache`; do
                 ssh deploy@$node "curl -fs -o /dev/null -w \"HTTP response: %{http_code}\n\" -X PURGE $local_varnish_url"
+                ssh deploy@$node "curl -fs -o /dev/null -w \"HTTP response: %{http_code}\n\" -H 'GOVUK-Account-Session-Exists: 1' -X PURGE $local_varnish_url"
               done
             fi
 
             ssh deploy@$(govuk_node_list --single-node -c cache) "curl -fs -w \"HTTP response: %{http_code}\n\" -X PURGE $cdn_url"
+            ssh deploy@$(govuk_node_list --single-node -c cache) "curl -fs -w \"HTTP response: %{http_code}\n\" -H 'GOVUK-Account-Session-Exists: 1' -X PURGE $cdn_url"
           done
     parameters:
       - text:

--- a/modules/govuk_jenkins/templates/jobs/clear_varnish_cache.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/clear_varnish_cache.yaml.erb
@@ -4,7 +4,7 @@
     display-name: Clear varnish cache
     project-type: freestyle
     description: >
-      Clears varnish caches for GOV.UK.
+      Clears the entire varnish cache for GOV.UK's own hosted varnish
     properties:
       - build-discarder:
           num-to-keep: 30


### PR DESCRIPTION
Trello: https://trello.com/c/TX9wLihh/101-cache-clearing-app-only-clears-path-not-query-strings

This updates the "Clear CDN Cache" Jenkins task so that it can be equivalent of functionality to the cache-clearing-service's: [`cache:clear`task](https://github.com/alphagov/cache-clearing-service/blob/64a4bebe97497102f286bfab6e613e33f61f0183/lib/tasks/cache.rake#L18-L22 which is done to reduce dependencies on that tool ahead of ideas to retire it.

There's more details in the commits, but essentially what this does is:

- moves the hardcoded urls into a Jenkins parameter, so any collection of URLs can be cleared
- automatically clears from internal varnish too, where applicable
- will accept a full URL (as per cache-clearing service) to clear items such as assets.

Once this is merged, I'll look at removing references in dev docs to cache-clearing service to reduce the coupling of that to day-to-day operations