### PR TITLE
Skip SSH key strength check for ECDSA keys

### DIFF
--- a/modules/users/spec/classes/users_spec.rb
+++ b/modules/users/spec/classes/users_spec.rb
@@ -53,7 +53,7 @@ user_list.each do |username|
         if key != 'ssh-rsa REPLACE ME'
           expect(SSHKey.valid_ssh_public_key? key).to be true
           key_strength = SSHKey.ssh_public_key_bits key
-          next if key.match(/^ssh-ed25519/)
+          next if key.match(/^(ssh-ed25519|ecdsa-sha2-)/)
           expect(key_strength).to be >= 4096, "SSH key for #{user[:name]} is only #{key_strength} bits and must be stronger"
         end
       end


### PR DESCRIPTION
This appears only to be relevant for RSA and DSA keys and was already being ignored for newer Ed25519 keys, but ECDSA keys were still being checked.
