### PR TITLE
Remove asset_bom_removal-rails job

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -972,7 +972,6 @@ govuk_ci::master::pipeline_jobs:
   support: {}
   transition: {}
   # Other repositories
-  asset_bom_removal-rails: {}
   backdrop-transactions-explorer-collector: {}
   deprecated_columns: {}
   gds-api-adapters: {}


### PR DESCRIPTION
It is [no longer used anywhere](https://github.com/search?q=org%3Aalphagov+asset_bom_removal-rails+-repo%3Aalphagov%2Fasset_bom_removal-rails+-repo%3Aalphagov%2Fgovuk-dependency-analysis&type=code).