### PR TITLE
Move Jenkins GOV.UK repo mirroring job to Production

### DIFF
--- a/hieradata_aws/class/integration/jenkins.yaml
+++ b/hieradata_aws/class/integration/jenkins.yaml
@@ -23,7 +23,6 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::enhanced_ecommerce_search_api
   - govuk_jenkins::jobs::govuk_content_api_docs
   - govuk_jenkins::jobs::govuk_taxonomy_supervised_learning
-  - govuk_jenkins::jobs::mirror_github_repositories
   - govuk_jenkins::jobs::monitor_taxonomy_health
   - govuk_jenkins::jobs::passive_checks
   - govuk_jenkins::jobs::content_data_api_re_run
@@ -72,8 +71,6 @@ govuk_jenkins::jobs::deploy_cdn::services:
   - performanceplatform
   - www
   - www-eks
-
-govuk_jenkins::jobs::mirror_github_repositories::enable_slack_notifications: true
 
 govuk_jenkins::jobs::update_cdn_dictionaries::services:
   - assets

--- a/hieradata_aws/class/production/jenkins.yaml
+++ b/hieradata_aws/class/production/jenkins.yaml
@@ -70,6 +70,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::run_related_links_generation
   - govuk_jenkins::jobs::run_related_links_ingestion
   - govuk_jenkins::jobs::run_whitehall_data_migrations
+  - govuk_jenkins::jobs::mirror_github_repositories
   - govuk_jenkins::jobs::search_api_fetch_analytics_data
   - govuk_jenkins::jobs::search_api_index_checks
   - govuk_jenkins::jobs::search_api_learn_to_rank
@@ -118,6 +119,8 @@ govuk_jenkins::jobs::update_cdn_dictionaries::services:
   - www-eks
 
 govuk_jenkins::jobs::deploy_puppet::enable_slack_notifications: true
+
+govuk_jenkins::jobs::mirror_github_repositories::enable_slack_notifications: true
 
 govuk_jenkins::jobs::search_api_learn_to_rank::train_instance_type: ml.c5.xlarge
 govuk_jenkins::jobs::search_api_learn_to_rank::train_instance_count: 1

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -157,8 +157,6 @@ govuk_jenkins::job_builder::environment: 'integration'
 
 govuk_jenkins::jobs::athena_fastly_logs_check::s3_results_bucket: 'govuk-integration-fastly-logs-monitoring'
 
-govuk_jenkins::jobs::mirror_github_repositories::cron_schedule: '0 */2 * * *' # every 2 hours
-
 govuk_jenkins::jobs::content_data_api::rake_etl_main_process_cron_schedule: '0 13 * * *'
 
 govuk_jenkins::jobs::clear_cdn_cache::website_root_url: 'www.integration.publishing.service.gov.uk'

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -309,6 +309,8 @@ govuk_jenkins::jobs::clear_cdn_cache::website_root_url: 'www.gov.uk'
 govuk_jenkins::jobs::run_related_links_generation::cron_schedule: '0 8 9,23 * *'
 govuk_jenkins::jobs::run_related_links_ingestion::cron_schedule: '0 8 11,25 * *'
 
+govuk_jenkins::jobs::mirror_github_repositories::cron_schedule: '0 */2 * * *' # every 2 hours
+
 govuk_jenkins::jobs::search_fetch_analytics_data::skip_page_traffic_load: true
 govuk_jenkins::jobs::search_fetch_analytics_data::cron_schedule: '30 8 * * 1-5'
 


### PR DESCRIPTION
We move the Jenkins GOV.UK repo mirroring job to Production since
the job uses an SSH Key which is a poweruser in CodeCommit.

We don't want integration users to have access to the poweruser
privileges.

Trello: https://trello.com/c/QlPzhn6A/2814-move-code-repository-mirroring-off-of-concourse