### PR TITLE
Make logrotate aware of disk space

### DIFF
--- a/modules/logrotate/templates/logrotate.conf.erb
+++ b/modules/logrotate/templates/logrotate.conf.erb
@@ -43,6 +43,16 @@
     # Remove empty .1 log files. There seems to be an issue where logrotate
     # will refuse to rotate the logs if an empty .1 log file exists.
     find <%= @matches %>* -wholename '/var/log/*' -name '*.1' -size 0 -delete
+    # Remove files bigger than $SIZE in chronological order while use of  
+    # disk space on the logging partition is greater than $MAX_USE
+    SIZE='300M'
+    MAX_USE=85
+    for file in $(find <%= @matches %>* -type f -size +$SIZE -exec ls -tr {} +); do
+      USE=$(df /var/log --output=pcent | sed -n '2p' | tr -d %)
+        if [ $USE -gt $MAX_USE ]; then
+          rm $file
+        fi
+    done;
   endscript
   lastaction
     # Clean up files older than maximum rotation. No-op unless "rotate" value is reduced,


### PR DESCRIPTION
Delete logs files above a threshold in size in chronological order
while disk space usage is above a given threshold.