### PR TITLE
Move from backend-redis to rate-limit-redis in integration.

### DIFF
--- a/hieradata_aws/class/integration/feedback.yaml
+++ b/hieradata_aws/class/integration/feedback.yaml
@@ -1,4 +1,0 @@
----
-
-govuk::apps::feedback::redis_host: 'backend-redis'
-govuk::apps::feedback::redis_port: '6379'

--- a/hieradata_aws/class/integration/frontend.yaml
+++ b/hieradata_aws/class/integration/frontend.yaml
@@ -1,0 +1,4 @@
+---
+
+govuk::apps::feedback::redis_host: 'rate-limit-redis'
+govuk::apps::feedback::redis_port: '6379'

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -46,8 +46,6 @@ govuk::apps::feedback::govuk_notify_survey_signup_reply_to_id: 'fee22233-2f28-4b
 govuk::apps::feedback::govuk_notify_survey_signup_template_id: 'eb9ba220-7d74-4aab-975a-bdbe718f69a3'
 govuk::apps::feedback::govuk_notify_accessible_format_request_reply_to_id: '93109fea-34d9-4c38-ac7e-1ebc75e7416b'
 govuk::apps::feedback::govuk_notify_accessible_format_request_template_id: '47cef7ea-0849-48aa-9676-0ee0f7baa4ae'
-govuk::apps::feedback::redis_host: 'backend-redis'
-govuk::apps::feedback::redis_port: '6379'
 govuk::apps::frontend::google_tag_manager_auth: "C7iYdcsOlYgGmiUJjZKrHQ"
 govuk::apps::frontend::google_tag_manager_id: "GTM-MG7HG5W"
 govuk::apps::frontend::google_tag_manager_preview: "env-4"


### PR DESCRIPTION
Move feedback from using the shared backend redis cluster to a new cluster (only in integration for the moment).

Fixes temporary work in https://github.com/alphagov/govuk-puppet/pull/11633 
...and resolves https://github.com/alphagov/govuk-puppet/issues/11658

https://trello.com/c/9qqjfqVo/1186-add-app-level-rate-limiting-to-feedback