### PR TITLE
Update interval for licensify VPN check

### DIFF
--- a/modules/monitoring/manifests/checks.pp
+++ b/modules/monitoring/manifests/checks.pp
@@ -242,10 +242,13 @@ class monitoring::checks (
 
   if ($::aws_environment == 'production') {
     icinga::check { 'check_uk_cloud_vpn_up':
-      check_command       => 'check_uk_cloud_vpn!www.civicaepay.co.uk!/ReadingXML/QueryPayments/QueryPayments.asmx',
-      host_name           => $::fqdn,
-      service_description => 'check that the VPN between UKCloud/Licensify and AWS is still up',
-      notes_url           => monitoring_docs_url(vpn-down),
+      check_command              => 'check_uk_cloud_vpn!www.civicaepay.co.uk!/ReadingXML/QueryPayments/QueryPayments.asmx',
+      host_name                  => $::fqdn,
+      service_description        => 'check that the VPN between UKCloud/Licensify and AWS is still up',
+      notes_url                  => monitoring_docs_url(vpn-down),
+      check_interval             => 90,
+      retry_interval             => 5,
+      attempts_before_hard_state => 5,
     }
   }
 


### PR DESCRIPTION
This alert has a very low user impact, and has a tendency to "go away"
after about an hour, so we can increase the check the window to 90 minutes
and hope that we never see the alert.