### PR TITLE
Upgrade kernel to Xenial LTS in integration and staging

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -4,7 +4,7 @@ app_domain_internal: "integration.govuk-internal.digital"
 deploy_jenkins_domain: "deploy.integration.publishing.service.gov.uk"
 
 base::shell::shell_prompt_string: 'integration'
-base::supported_kernel::enabled: false
+base::supported_kernel::enabled: true
 
 cron::weekly_dow: 1
 cron::daily_hour: 6

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -5,7 +5,7 @@ app_domain_internal: "staging.govuk-internal.digital"
 backup::server::backup_hour: 9
 
 base::shell::shell_prompt_string: 'staging'
-base::supported_kernel::enabled: false
+base::supported_kernel::enabled: true
 
 cron::daily_hour: 6
 


### PR DESCRIPTION
We want to fix a potential kernel bug in our current running
version of the kernel, Trusty LTS.
https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1715812
Deploying first to integration and staging to check that it
doesn't break anything.