### PR TITLE
Update LUX check to use latest version number

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/speedcurve_lux_js_version_check.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/speedcurve_lux_js_version_check.yaml.erb
@@ -21,7 +21,7 @@
 
           # we grep against the version GOV.UK is currently using in
           # https://github.com/alphagov/govuk_publishing_components/blob/master/app/assets/javascripts/govuk_publishing_components/vendor/lux/lux-reporter.js
-          curl -s https://cdn.speedcurve.com/js/lux.js\?id\=47044334 | grep 't="216"'
+          curl -s https://cdn.speedcurve.com/js/lux.js\?id\=47044334 | grep 'V="301"'
     publishers:
       - trigger-parameterized-builds:
         - project: Success_Passive_Check


### PR DESCRIPTION
Update the LUX check to use the latest version number, which is updated in https://github.com/alphagov/govuk_publishing_components/pull/2773.

Speedcurve's minified JavaScript also had the variable name changed, so this has been updated as well.