### PR TITLE
Add new Jenkins deploy role in Staging

### DIFF
--- a/hieradata_aws/class/staging/jenkins.yaml
+++ b/hieradata_aws/class/staging/jenkins.yaml
@@ -26,6 +26,16 @@ jenkins_admin_permission_list: &jenkins_admin_permission_list
   - 'hudson.model.View.Read'
   - 'hudson.scm.SCM.Tag'
 
+jenkins_deploy_permission_list: &jenkins_deploy_permission_list
+  - 'hudson.model.Hudson.Read'
+  - 'hudson.model.Item.Build'
+  - 'hudson.model.Item.Cancel'
+  - 'hudson.model.Item.Create'
+  - 'hudson.model.Item.Discover'
+  - 'hudson.model.Item.Read'
+  - 'hudson.model.View.Read'
+  - 'hudson.scm.SCM.Tag'
+
 govuk_jenkins::config::manage_permissions_github_teams: true
 govuk_jenkins::config::user_permissions:
   -
@@ -44,6 +54,9 @@ govuk_jenkins::config::user_permissions:
     permissions:
       - 'hudson.model.Item.Build'
       - 'hudson.model.Item.Read'
+  -
+    user: 'alphagov*GOV.UK Production Deploy'
+    permissions: *jenkins_deploy_permission_list
 
 govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::athena_fastly_logs_check


### PR DESCRIPTION
We are adding a new level of access, which allows engineers to deploy
code but not administer related systems. This uses the new Github
team https://github.com/orgs/alphagov/teams/gov-uk-production-deploy

See below for permission definitions:

`hudson.model.Hudson.Read` - The read permission is necessary for viewing almost all pages of Jenkins. This permission is useful when you don’t want unauthenticated users to see Jenkins pages: revoke this permission from the anonymous user, then add "authenticated" pseudo-user and grant the read access.
`hudson.model.Item.Build` - This permission grants the ability to start a new build.
`hudson.model.Item.Cancel` - This permission grants the ability to cancel a scheduled, or abort a running, build.
`hudson.model.Item.Create` - Create a new job.
`hudson.model.Item.Discover` - This permission grants discover access to jobs. Lower than read permissions, it allows you to redirect anonymous users to the login page when they try to access a job url. Without it they would get a 404 error and wouldn't be able to discover project names. This permission is implied by Job/Read.
`hudson.model.Item.Read` - See a job. (You may deny this permission but allow Discover to force an anonymous user to log in to see the job.)
`hudson.model.View.Read` - This permission allows users to see views (implied by generic read access).
`hudson.scm.SCM.Tag` - This permission allows users to create a new tag in the source code repository for a given build.

Trello card: https://trello.com/c/docwZ4Gm/2892-implement-production-deploy-access-5