### PR TITLE
Add new Jenkins deploy role in Production

### DIFF
--- a/hieradata_aws/class/production/jenkins.yaml
+++ b/hieradata_aws/class/production/jenkins.yaml
@@ -19,6 +19,16 @@ jenkins_admin_permission_list: &jenkins_admin_permission_list
   - 'hudson.model.View.Read'
   - 'hudson.scm.SCM.Tag'
 
+jenkins_deploy_permission_list: &jenkins_deploy_permission_list
+  - 'hudson.model.Hudson.Read'
+  - 'hudson.model.Item.Build'
+  - 'hudson.model.Item.Cancel'
+  - 'hudson.model.Item.Create'
+  - 'hudson.model.Item.Discover'
+  - 'hudson.model.Item.Read'
+  - 'hudson.model.View.Read'
+  - 'hudson.scm.SCM.Tag'
+
 govuk_jenkins::config::manage_permissions_github_teams: true
 govuk_jenkins::config::user_permissions:
   -
@@ -37,6 +47,9 @@ govuk_jenkins::config::user_permissions:
     permissions:
       - 'hudson.model.Item.Build'
       - 'hudson.model.Item.Read'
+  -
+    user: 'alphagov*GOV.UK Production Deploy'
+    permissions: *jenkins_deploy_permission_list
 
 govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::ask_export


### PR DESCRIPTION
Similar to https://github.com/alphagov/govuk-puppet/pull/11679
which has been tested in `staging`, this can now be added to
`production`.

Trello card: https://trello.com/c/docwZ4Gm/2892-implement-production-deploy-access-5