### PR TITLE
Give feedback rate-limit-redis location in all environments.

### DIFF
--- a/hieradata_aws/class/frontend.yaml
+++ b/hieradata_aws/class/frontend.yaml
@@ -1,3 +1,5 @@
 ---
 govuk::apps::collections::memcache_servers: 'frontend-memcached:11211'
+govuk::apps::feedback::redis_host: 'rate-limit-redis'
+govuk::apps::feedback::redis_port: '6379'
 govuk::apps::frontend::memcache_servers: 'frontend-memcached:11211'

--- a/hieradata_aws/class/integration/frontend.yaml
+++ b/hieradata_aws/class/integration/frontend.yaml
@@ -1,4 +1,0 @@
----
-
-govuk::apps::feedback::redis_host: 'rate-limit-redis'
-govuk::apps::feedback::redis_port: '6379'


### PR DESCRIPTION
Move the new variables to allow feedback to see the redis-rate-limit elasticache cluster into the common frontend configuration so that it can be used in all environments.

https://trello.com/c/9qqjfqVo/1186-add-app-level-rate-limiting-to-feedback