### PR TITLE
Add locations_api machine class to rake task options

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/automated_rake_task.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/automated_rake_task.yaml.erb
@@ -37,8 +37,8 @@
             - draft_frontend
             - email_alert_api
             - frontend
-            - router_backend
             - publishing_api
+            - router_backend
             - search
             - whitehall_backend
             - whitehall_frontend

--- a/modules/govuk_jenkins/templates/jobs/automated_rake_task.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/automated_rake_task.yaml.erb
@@ -37,6 +37,7 @@
             - draft_frontend
             - email_alert_api
             - frontend
+            - locations_api
             - publishing_api
             - router_backend
             - search


### PR DESCRIPTION
We now need to be able to run rake tasks on the `locations_api` machines, which host the `locations-api` app.

Trello: https://trello.com/c/iy6P2rvX/2875-warm-up-locations-api-cache-5