### PR TITLE
Add `locations_api` machine class to rake task options

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/run_rake_task.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/run_rake_task.yaml.erb
@@ -37,8 +37,9 @@
             - draft_frontend
             - email_alert_api
             - frontend
-            - router_backend
+            - locations_api
             - publishing_api
+            - router_backend
             - search
             - whitehall_backend
             - whitehall_frontend


### PR DESCRIPTION
We now need to be able to run rake tasks on the `locations_api`
machines, which host the `locations-api` app.

This was the original intention of #11683, which edited the wrong file - although that file needed updating too, so no harm done.

https://trello.com/c/iy6P2rvX/2875-warm-up-locations-api-cache-5