### PR TITLE
Remove redundant whitehall healthcheck docs link

### DIFF
--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -214,7 +214,6 @@ class govuk::apps::whitehall(
     port                       => $port,
     sentry_dsn                 => $sentry_dsn,
     log_format_is_json         => true,
-    health_check_custom_doc    => true,
     has_liveness_health_check  => true,
     has_readiness_health_check => true,
     depends_on_nfs             => true,


### PR DESCRIPTION
https://trello.com/c/fRihmgQ8/266-add-top-level-guidance-about-where-we-write-tests-on-govuk

This just links to the main doc for healthchecks [^1].

[^1]: https://github.com/alphagov/govuk-developer-docs/blob/cd289536bc50da3133c426ca8b02c570b30f663b/source/manual/alerts/whitehall-app-healthcheck-not-ok.html.md