### PR TITLE
Add Jenkins "view only" permissions in Production

### DIFF
--- a/hieradata_aws/class/production/jenkins.yaml
+++ b/hieradata_aws/class/production/jenkins.yaml
@@ -29,6 +29,11 @@ jenkins_deploy_permission_list: &jenkins_deploy_permission_list
   - 'hudson.model.View.Read'
   - 'hudson.scm.SCM.Tag'
 
+jenkins_integration_permission_list: &jenkins_integration_permission_list
+  - 'hudson.model.Hudson.Read'
+  - 'hudson.model.Item.Read'
+  - 'hudson.model.View.Read'
+
 govuk_jenkins::config::manage_permissions_github_teams: true
 govuk_jenkins::config::user_permissions:
   -
@@ -50,6 +55,9 @@ govuk_jenkins::config::user_permissions:
   -
     user: 'alphagov*GOV.UK Production Deploy'
     permissions: *jenkins_deploy_permission_list
+  -
+    user: 'alphagov*GOV.UK'
+    permissions: *jenkins_integration_permission_list
 
 govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::ask_export


### PR DESCRIPTION
As covered in our access levels spreadsheet (https://docs.google.com/spreadsheets/d/1oqy7tKpB8mHBhHQ9jAZu0NR0GKKZXOqtQGBKHYVnpmk/edit?pli=1#gid=0),
those with Integration access should be able to view builds in Jenkins
Staging and Production. This uses the GOV.UK Github team which people
are added to when they first join the programme.

See below for permission definitions:

`hudson.model.Hudson.Read` - The read permission is necessary for viewing almost all pages of Jenkins. This permission is useful when you don’t want unauthenticated users to see Jenkins pages: revoke this permission from the anonymous user, then add "authenticated" pseudo-user and grant the read access.
`hudson.model.Item.Read` - See a job. (You may deny this permission but allow Discover to force an anonymous user to log in to see the job.)
`hudson.model.View.Read` - This permission allows users to see views (implied by generic read access).

This has already been tested and added for Staging in https://github.com/alphagov/govuk-puppet/pull/11687/commits/8c9bbcae6c5d15d00ee4c07d446d10b1a022fdaa

Trello card: https://trello.com/c/docwZ4Gm/2892-implement-production-deploy-access-5