### PR TITLE
Remove redundant fallback for app healthchecks

### DIFF
--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -434,17 +434,8 @@ define govuk::app::config (
         contact_groups      => $additional_check_contact_groups,
       }
     }
-  } elsif $has_liveness_health_check {
-    @@icinga::check { "check_app_${title}_up_on_${::hostname}":
-      ensure              => $ensure,
-      check_command       => "check_app_health!check_app_up!${port} /healthcheck/live",
-      check_period        => $check_period,
-      service_description => "${title} app healthcheck",
-      host_name           => $::fqdn,
-      notes_url           => monitoring_docs_url(app-healthcheck-not-ok),
-      contact_groups      => $additional_check_contact_groups,
-    }
   }
+
   if ($app_type == 'rack') or $monitor_unicornherder {
     @@icinga::check { "check_app_${title}_unicornherder_up_${::hostname}":
       ensure              => $ensure,
@@ -455,6 +446,7 @@ define govuk::app::config (
       contact_groups      => $additional_check_contact_groups,
     }
   }
+
   if $app_type == 'rack' {
     include icinga::client::check_unicorn_ruby_version
     @@icinga::check { "check_app_${title}_unicorn_ruby_version_${::hostname}":
@@ -466,6 +458,7 @@ define govuk::app::config (
       contact_groups      => $additional_check_contact_groups,
     }
   }
+
   @@icinga::check { "check_app_${title}_upstart_up_${::hostname}":
     ensure              => $ensure,
     check_command       => "check_nrpe!check_upstart_status!${title}",


### PR DESCRIPTION
https://trello.com/c/fRihmgQ8/266-add-top-level-guidance-about-where-we-write-tests-on-govuk

This was added in [^1] without explanation.

I've checked and all apps have has_readiness_health_check set to
true wherever has_liveness_health_checkset is also set to true,
so this conditional branch is never used in practice.

I think it's clearer to have the alert work with just one type of
healthcheck and require someone adding an app to add both. This
means we can simplify the documentation for the alert.

[^1]: https://github.com/alphagov/govuk-puppet/commit/50c30a600617df809238715cb6c398b60cdea2aa