### PR TITLE
Update Github production team name

### DIFF
--- a/hieradata_aws/class/production/jenkins.yaml
+++ b/hieradata_aws/class/production/jenkins.yaml
@@ -40,7 +40,7 @@ govuk_jenkins::config::user_permissions:
     user: 'jenkins_api_user'
     permissions: *jenkins_admin_permission_list
   -
-    user: 'alphagov*GOV.UK Production'
+    user: 'alphagov*GOV.UK Production Admin'
     permissions: *jenkins_admin_permission_list
   -
     user: 'anonymous'

--- a/hieradata_aws/class/staging/jenkins.yaml
+++ b/hieradata_aws/class/staging/jenkins.yaml
@@ -47,7 +47,7 @@ govuk_jenkins::config::user_permissions:
     user: 'jenkins_api_user'
     permissions: *jenkins_admin_permission_list
   -
-    user: 'alphagov*GOV.UK Production'
+    user: 'alphagov*GOV.UK Production Admin'
     permissions: *jenkins_admin_permission_list
   -
     user: 'anonymous'


### PR DESCRIPTION
As covered in [RFC 146 - Implement "Production Deploy Access"](https://github.com/alphagov/govuk-rfcs/blob/main/rfc-146-production-deploy-access.md ) ,
we are renaming the production team name from "GOV.UK Production"
to "GOV.UK Production Admin". This should ensure there is no
ambiguity between this level of access and "Production Deploy" access.

Trello card: https://trello.com/c/docwZ4Gm/2892-implement-production-deploy-access-5