### PR TITLE
Set unattended reboot to false

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1179,7 +1179,7 @@ govuk_sudo::sudo_conf:
     content: 'ubuntu ALL=(ALL) NOPASSWD:ALL'
 
 govuk_unattended_reboot::alert_hostname: 'alert'
-govuk_unattended_reboot::enabled: true
+govuk_unattended_reboot::enabled: false
 govuk_unattended_reboot::mongodb::enabled: true
 
 govuk_unattended_reboot::monitoring_basic_auth:


### PR DESCRIPTION
As per
https://docs.publishing.service.gov.uk/manual/alerts/rebooting-machines.html#rebooting-docker-management
in order to reboot docker-management