### PR TITLE
Enable CD for Specialist Publisher

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1124,6 +1124,7 @@ govuk_jenkins::jobs::deploy_app_downstream::applications:
   sidekiq-monitoring: {}
   smartanswers:
     repository: 'smart-answers'
+  specialist-publisher: {}
   support: {}
   travel-advice-publisher: {}
   whitehall:


### PR DESCRIPTION
For the ticket on [enabling CD for specialist publisher](https://trello.com/c/NfdjEbQi/261-enable-continuous-deployment-for-specialist-publisher).

[Similar to PR on Manuals Publisher](https://github.com/alphagov/govuk-puppet/pull/10871). 

Dependent on:

- https://github.com/alphagov/specialist-publisher/pull/2029
- https://github.com/alphagov/specialist-publisher/pull/2032
- https://github.com/alphagov/specialist-publisher/pull/2035
- https://github.com/alphagov/specialist-publisher/pull/2036
- https://github.com/alphagov/govuk-saas-config/pull/110