### PR TITLE
Increase locations-api unicorn workers to match Mapit

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -574,7 +574,7 @@ govuk::apps::locations_api::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::locations_api::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::locations_api::db_hostname: "locations-api-postgres"
 govuk::apps::locations_api::db_password: "%{hiera('govuk::apps::locations_api::db::password')}"
-govuk::apps::locations_api::unicorn_worker_processes: '10'
+govuk::apps::locations_api::unicorn_worker_processes: '16'
 
 govuk::apps::manuals_publisher::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::manuals_publisher::redis_port: "%{hiera('sidekiq_port')}"


### PR DESCRIPTION
We are not sure how many unicorn works we need yet, but to start
with we can match what Mapit has for now.

Trello card: https://trello.com/c/wlqX8SKd/2907-make-locations-api-match-mapit-numbers-for-unicorn-workers-1