### PR TITLE
Add explicit Puppet is disabled message to lock file.

### DIFF
--- a/modules/puppet/templates/govuk_puppet
+++ b/modules/puppet/templates/govuk_puppet
@@ -183,6 +183,7 @@ if [[ " ${puppet_args} " =~ "--disable " ]]; then
     exit 1
   fi
 
+  lock_reason="Puppet is disabled :: $lock_reason"
   write_lock
   exit 0
 fi


### PR DESCRIPTION
so that govuk_puppet --test gives more of a clue when puppet has been disabled for the less experienced among us.