### PR TITLE
Fix job status for deploy_terraform_govuk_aws job

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_terraform_govuk_aws.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_terraform_govuk_aws.yaml.erb
@@ -33,14 +33,10 @@
         - build-name:
             name: '${ENV,var="ENVIRONMENT"} ${ENV,var="STACKNAME"} ${ENV,var="PROJECT"} ${ENV,var="COMMAND"}'
     builders:
-        - shell: |
-            ./jenkins.sh
-
-    publishers:
-        - text-finder:
-            regexp: "Plan.*\\d* to add, \\d* to change, \\d* to destroy."
-            also-check-console-output: true
-            unstable-if-found: true
+        - shell:
+            command: |
+              ./jenkins.sh
+            unstable-return: 2
 
     parameters:
         - string:


### PR DESCRIPTION
It seems that the output of terraform apply has changed with
new version of terraform where there is a plan before apply
so we regex on `Plan ..` to mark a build as unstable, terraform
apply builds are marked as unstable.

The solution is to remove this regex and add a -detailed-exitcode
option to terraform plans so that the exit code is 2 when there
are changes to be applied and Jenkins will interpret exit code 2
as unstable builds.