### PR TITLE
Mark Bhupinder as ensure => absent

### DIFF
--- a/modules/users/manifests/bhupindergill.pp
+++ b/modules/users/manifests/bhupindergill.pp
@@ -1,6 +1,7 @@
 # Creates the user bhupindergill
 class users::bhupindergill {
   govuk_user { 'bhupindergill':
+    ensure   => absent,
     fullname => 'Bhupinder Gill',
     email    => 'bhupinder.gill@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAH2celZRdqiHn5GGkQxZY/7MKOjMq376i7Dv4vkTCFB bhupinder.gill@digital.cabinet-office.gov.uk',


### PR DESCRIPTION
Bhupinder has left GDS. Marking as absent to ensure removal of
his home directories etc on the GOV.UK nodes, as per:
https://docs.publishing.service.gov.uk/manual/removing-a-user-from-puppet.html

Trello: https://trello.com/c/nKmH7cjm/1398-leaver-bhupinder-gill-tech-role