### PR TITLE
Increase smartanswers unicorn works 4 => 8

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -756,7 +756,7 @@ govuk::apps::specialist_publisher::enabled: true
 govuk::apps::specialist_publisher::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::specialist_publisher::redis_port: "%{hiera('sidekiq_port')}"
 
-govuk::apps::smartanswers::unicorn_worker_processes: "4"
+govuk::apps::smartanswers::unicorn_worker_processes: "8"
 govuk::apps::smartanswers::zendesk_client_username: 'zd-api-govt@digital.cabinet-office.gov.uk/token'
 
 govuk::apps::smokey::smokey_signon_email: "%{hiera('smokey_signon_email')}"


### PR DESCRIPTION
There is a chance that a new smart-answer may attract an increase in traffic. 
This PR is prepared in case we need to quickly act and increase capacity by doubling unicorn workers.

[trello](https://trello.com/c/kFcg5KBm/91-prep-a-pr-to-double-the-number-of-unicorns-just-in-case-unprecedented-traffic)