### PR TITLE
Ignore "no healthy targets" for Manuals Frontend

### DIFF
--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -433,10 +433,12 @@ monitoring::checks::lb::loadbalancers: # prefer "internal"
   blue-draft-frontend-internal:
     healthyhosts_ignore:
       - draft-fron-draft-finder-frontend # no idea what this is
+      - draft-fron-draft-manuals-fronten # in the process of being deprecated
   blue-email-alert-api-internal: {}
   blue-frontend-internal:
     healthyhosts_ignore:
       - frontend-i-designprinciples # no idea what this is
+      - frontend-i-manuals-frontend" # in the process of being deprecated
       - frontend-i-spotlight # no idea what this is
   blue-graphite-internal:
     healthyhosts_warning: 0


### PR DESCRIPTION
Manuals Frontend is in the process of being deprecated.

We currently have a "AWS LB Healthy Hosts" error for this application, as the load balancer cannot find any healthy targets.

The alert is currently acknowledged (so we don't see it), but as the alert is shared with all other frontend applications, this means we are also hiding alerts for other (non-deprecated) applications.

This will hide the alert for just Manuals Frontend, so the alert can be un-acknowledged.