### PR TITLE
Remove recent leavers home directories

### DIFF
--- a/modules/users/manifests/alexbaker.pp
+++ b/modules/users/manifests/alexbaker.pp
@@ -1,6 +1,7 @@
 # Creates the alexbaker user
 class users::alexbaker {
   govuk_user { 'alexbaker':
+    ensure   => absent,
     fullname => 'Alex Baker',
     email    => 'alex.baker@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDbCzicUco2TIwas6wuHr2B1d5wsXX3FlrZLsydhs3L1 alex.baker@digital.cabinet-office.gov.uk',

--- a/modules/users/manifests/lukewiltshire.pp
+++ b/modules/users/manifests/lukewiltshire.pp
@@ -1,6 +1,7 @@
 # Creates the lukewiltshire user
 class users::lukewiltshire {
   govuk_user { 'lukewiltshire':
+    ensure   => absent,
     fullname => 'Luke Wiltshire',
     email    => 'luke.wiltshire@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIWJU1ku2E3LkeMTgKURjMBiv4MyvS+9Lg99vHIk+MPE luke.wiltshire@digital.cabinet-office.gov.uk',

--- a/modules/users/manifests/seunadiomowo.pp
+++ b/modules/users/manifests/seunadiomowo.pp
@@ -1,6 +1,7 @@
 # Creates the seunadiomowo user
 class users::seunadiomowo {
   govuk_user { 'seunadiomowo':
+    ensure   => absent,
     fullname => 'Seun Adiomowo',
     email    => 'seun.adiomowo@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAfwn2PHZxtS6mR3wSHAVf9D3dF270pLYwuwb5HQD+8Q seunadiomowo@Seuns-MBP',


### PR DESCRIPTION
This removes the home directories for Alex Baker, Luke Wiltshire and Seun Adiomowo by marking them as absent.

Trello cards: [Alex](https://trello.com/c/5ZDAtkcm/1415-leaver-alex-baker-tech-role), [Luke](https://trello.com/c/rk7P7jqI/1416-leaver-luke-wiltshire-tech-role) and [Seun](https://trello.com/c/zMCJNlLR/1414-leaver-seun-adiomowo-tech-role).