### PR TITLE
Ignore Manuals Frontend from LB checks

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -248,10 +248,12 @@ monitoring::checks::lb::loadbalancers: # prefer "internal"
   blue-draft-frontend-internal:
     healthyhosts_ignore:
       - draft-fron-draft-finder-frontend # no idea what this is
+      - draft-fron-draft-manuals-fronten # in the process of being deprecated
   blue-email-alert-api-internal: {}
   blue-frontend-internal:
     healthyhosts_ignore:
       - frontend-i-designprinciples # no idea what this is
+      - frontend-i-manuals-frontend # in the process of being deprecated
       - frontend-i-spotlight # no idea what this is
   blue-graphite-internal:
     healthyhosts_warning: 0

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -414,10 +414,12 @@ monitoring::checks::lb::loadbalancers: # prefer "internal"
   blue-draft-frontend-internal:
     healthyhosts_ignore:
       - draft-fron-draft-finder-frontend # no idea what this is
+      - draft-fron-draft-manuals-fronten # in the process of being deprecated
   blue-email-alert-api-internal: {}
   blue-frontend-internal:
     healthyhosts_ignore:
       - frontend-i-designprinciples # no idea what this is
+      - frontend-i-manuals-frontend # in the process of being deprecated
       - frontend-i-spotlight # no idea what this is
   blue-graphite-internal:
     healthyhosts_warning: 0


### PR DESCRIPTION
Manuals Frontend is being retired. This was originally only applied to
Production, now ignores the checks for Staging and Integration.

The missing characters for `draft-fron-draft-manuals-fronten` is intentional.
Target group names seems to have a char limit.