### PR TITLE
Remove recent leavers manifests and integration access

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -342,7 +342,6 @@ router::nginx::check_requests_critical: '@0.25'
 users::usernames:
   - agadufrat
   - alessiatosi
-  - alexbaker
   - alexnewton
   - alexwhiteheadsmith
   - alistairdavidson
@@ -382,7 +381,6 @@ users::usernames:
   - kevindew
   - kooghanwilliams
   - leenagupte
-  - lukewiltshire
   - matthewgregory
   - marcpomfret
   - maxfroumentin
@@ -402,7 +400,6 @@ users::usernames:
   - ryanbrooks
   - samsimpson
   - seanrankine
-  - seunadiomowo
   - simonhughesdon
   - stevenradford
 

--- a/modules/users/manifests/alexbaker.pp
+++ b/modules/users/manifests/alexbaker.pp
@@ -1,9 +1,0 @@
-# Creates the alexbaker user
-class users::alexbaker {
-  govuk_user { 'alexbaker':
-    ensure   => absent,
-    fullname => 'Alex Baker',
-    email    => 'alex.baker@digital.cabinet-office.gov.uk',
-    ssh_key  => 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDbCzicUco2TIwas6wuHr2B1d5wsXX3FlrZLsydhs3L1 alex.baker@digital.cabinet-office.gov.uk',
-  }
-}

--- a/modules/users/manifests/lukewiltshire.pp
+++ b/modules/users/manifests/lukewiltshire.pp
@@ -1,9 +1,0 @@
-# Creates the lukewiltshire user
-class users::lukewiltshire {
-  govuk_user { 'lukewiltshire':
-    ensure   => absent,
-    fullname => 'Luke Wiltshire',
-    email    => 'luke.wiltshire@digital.cabinet-office.gov.uk',
-    ssh_key  => 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIWJU1ku2E3LkeMTgKURjMBiv4MyvS+9Lg99vHIk+MPE luke.wiltshire@digital.cabinet-office.gov.uk',
-  }
-}

--- a/modules/users/manifests/seunadiomowo.pp
+++ b/modules/users/manifests/seunadiomowo.pp
@@ -1,9 +1,0 @@
-# Creates the seunadiomowo user
-class users::seunadiomowo {
-  govuk_user { 'seunadiomowo':
-    ensure   => absent,
-    fullname => 'Seun Adiomowo',
-    email    => 'seun.adiomowo@digital.cabinet-office.gov.uk',
-    ssh_key  => 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAfwn2PHZxtS6mR3wSHAVf9D3dF270pLYwuwb5HQD+8Q seunadiomowo@Seuns-MBP',
-  }
-}


### PR DESCRIPTION
Alex Baker, Luke Wiltshire and Seun Adiomowo have recently left GDS.

Trello cards: [Alex](https://trello.com/c/5ZDAtkcm/1415-leaver-alex-baker-tech-role), [Luke](https://trello.com/c/rk7P7jqI/1416-leaver-luke-wiltshire-tech-role) and [Seun](https://trello.com/c/zMCJNlLR/1414-leaver-seun-adiomowo-tech-role).