### PR TITLE
Enable CD for publishing api

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1112,6 +1112,7 @@ govuk_jenkins::jobs::deploy_app_downstream::applications:
   manuals-publisher: {}
   maslow: {}
   publisher: {}
+  publishing-api: {}
   release: {}
   short-url-manager: {}
   service-manual-frontend: {}


### PR DESCRIPTION
Requires merging first: 

* Publishing api PRs to remove legacy / unused endpoints (various) 👍 
* [Add PR template](https://github.com/alphagov/publishing-api/pull/2098) to publishing api 👍 
* [Require prod access for merging](https://github.com/alphagov/govuk-saas-config/pull/115) in saas-config 👍 

[Ticket](https://trello.com/c/FNtolpuM/13-enable-continuous-deployment-for-publishing-api)