### PR TITLE
Set account home environment variables

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -42,6 +42,7 @@ govuk::apps::email_alert_api::govuk_notify_recipients:
   - email-alert-api-integration@digital.cabinet-office.gov.uk
 govuk::apps::email_alert_frontend::subscription_management_enabled: true
 govuk::apps::email_alert_frontend::govuk_personalisation_manage_uri: 'https://integration.account.gov.uk?link=manage-account'
+govuk::apps::email_alert_frontend::govuk_personalisation_your_account_uri: 'https://www.integration.publishing.service.gov.uk/account/home'
 govuk::apps::feedback::govuk_notify_survey_signup_reply_to_id: 'fee22233-2f28-4b0b-8b6c-4410979f2275'
 govuk::apps::feedback::govuk_notify_survey_signup_template_id: 'eb9ba220-7d74-4aab-975a-bdbe718f69a3'
 govuk::apps::feedback::govuk_notify_accessible_format_request_reply_to_id: '93109fea-34d9-4c38-ac7e-1ebc75e7416b'
@@ -51,6 +52,7 @@ govuk::apps::frontend::google_tag_manager_id: "GTM-MG7HG5W"
 govuk::apps::frontend::google_tag_manager_preview: "env-4"
 govuk::apps::frontend::govuk_notify_template_id: '1fc69d3a-09a2-40f9-852b-03f6fcef5340'
 govuk::apps::frontend::govuk_personalisation_manage_uri: 'https://integration.account.gov.uk?link=manage-account'
+govuk::apps::frontend::govuk_personalisation_your_account_uri: 'https://www.integration.publishing.service.gov.uk/account/home'
 govuk::apps::government_frontend::google_tag_manager_auth: "C7iYdcsOlYgGmiUJjZKrHQ"
 govuk::apps::government_frontend::google_tag_manager_id: "GTM-MG7HG5W"
 govuk::apps::government_frontend::google_tag_manager_preview: "env-4"

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -192,6 +192,7 @@ govuk::apps::email_alert_api::db::backend_ip_range: '10.13.3.0/24'
 govuk::apps::email_alert_api::govuk_notify_template_id: 'cb633abc-6ae6-4843-ae6f-82ca500b6de2'
 govuk::apps::email_alert_api::govuk_notify_recipients: '*'
 govuk::apps::email_alert_frontend::govuk_personalisation_manage_uri: 'https://account.gov.uk?link=manage-account'
+govuk::apps::email_alert_frontend::govuk_personalisation_your_account_uri: 'https://www.gov.uk/account/home'
 govuk::apps::feedback::govuk_notify_survey_signup_reply_to_id: 'e8b2d8a6-db5f-4346-9fbd-49b16b531e1c'
 govuk::apps::feedback::govuk_notify_survey_signup_template_id: '54168fa9-3946-4860-a2f8-27ddbb14babe'
 govuk::apps::feedback::govuk_notify_accessible_format_request_reply_to_id: 'b5baae45-0a68-4b63-91a1-66b05640d27e'
@@ -202,6 +203,7 @@ govuk::apps::finder_frontend::unicorn_worker_processes: 48
 
 govuk::apps::frontend::govuk_notify_template_id: 'cb633abc-6ae6-4843-ae6f-82ca500b6de2'
 govuk::apps::frontend::govuk_personalisation_manage_uri: 'https://account.gov.uk?link=manage-account'
+govuk::apps::frontend::govuk_personalisation_your_account_uri: 'https://www.gov.uk/account/home'
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::licencefinder::elasticsearch_uri: 'https://vpc-blue-elasticsearch6-domain-2hnib7uydv3tgebhabx74gdelq.eu-west-1.es.amazonaws.com'
 govuk::apps::link_checker_api::govuk_basic_auth_credentials: "%{hiera('http_username')}:%{hiera('http_password')}"

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -170,6 +170,7 @@ govuk::apps::email_alert_api::govuk_notify_recipients:
   - email-alert-api-staging@digital.cabinet-office.gov.uk
 govuk::apps::email_alert_frontend::subscription_management_enabled: true
 govuk::apps::email_alert_frontend::govuk_personalisation_manage_uri: 'https://staging.account.gov.uk?link=manage-account'
+govuk::apps::email_alert_frontend::govuk_personalisation_your_account_uri: 'https://www.staging.publishing.service.gov.uk/account/home'
 govuk::apps::feedback::govuk_notify_survey_signup_reply_to_id: 'd1f54751-80a8-420a-9077-d34c7d6cc734'
 govuk::apps::feedback::govuk_notify_survey_signup_template_id: '8a8d98c0-42c8-4f56-b61f-77c89417a171'
 govuk::apps::feedback::govuk_notify_accessible_format_request_reply_to_id: 'd33f7857-7514-4458-81b9-0995f48e2ac5'
@@ -180,6 +181,7 @@ govuk::apps::finder_frontend::unicorn_worker_processes: 24
 
 govuk::apps::frontend::govuk_notify_template_id: '2844a647-6bf1-4b01-a25c-569d2cc00849'
 govuk::apps::frontend::govuk_personalisation_manage_uri: 'https://integration.account.gov.uk?link=manage-account'
+govuk::apps::frontend::govuk_personalisation_your_account_uri: 'https://www.staging.publishing.service.gov.uk/account/home'
 govuk::apps::govuk_crawler_worker::disable_during_data_sync: true
 govuk::apps::hmrc_manuals_api::publish_topics: false
 govuk::apps::licencefinder::elasticsearch_uri: 'https://vpc-blue-elasticsearch6-domain-uibh77cu2kiudtl76uhseobfzq.eu-west-1.es.amazonaws.com'

--- a/modules/govuk/manifests/apps/email_alert_frontend.pp
+++ b/modules/govuk/manifests/apps/email_alert_frontend.pp
@@ -50,6 +50,9 @@
 # [*govuk_personalisation_manage_uri*]
 #   URI for the account management page.
 #
+# [*govuk_personalisation_your_account_uri*]
+#   URI for the account home page.
+#
 
 class govuk::apps::email_alert_frontend(
   $vhost = 'email-alert-frontend',
@@ -64,6 +67,7 @@ class govuk::apps::email_alert_frontend(
   $subscription_management_enabled = false,
   $account_api_bearer_token = undef,
   $govuk_personalisation_manage_uri = undef,
+  $govuk_personalisation_your_account_uri = undef,
 ) {
   $app_name = 'email-alert-frontend'
 
@@ -106,6 +110,9 @@ class govuk::apps::email_alert_frontend(
     "${title}-GOVUK-PERSONALISATION-MANAGE-URI":
       varname => 'GOVUK_PERSONALISATION_MANAGE_URI',
       value   => $govuk_personalisation_manage_uri;
+    "${title}-GOVUK-PERSONALISATION-YOUR-ACCOUNT-URI":
+      varname => 'GOVUK_PERSONALISATION_YOUR_ACCOUNT_URI',
+      value   => $govuk_personalisation_your_account_uri;
   }
 
   if $subscription_management_enabled {

--- a/modules/govuk/manifests/apps/frontend.pp
+++ b/modules/govuk/manifests/apps/frontend.pp
@@ -54,6 +54,9 @@
 # [*govuk_personalisation_manage_uri*]
 #   URI for the account management page.
 #
+# [*govuk_personalisation_your_account_uri*]
+#   URI for the account home page.
+#
 # [*memcache_servers*]
 #   URL of a shared memcache cluster.
 #
@@ -87,6 +90,7 @@ class govuk::apps::frontend(
   $govuk_notify_api_key = undef,
   $govuk_notify_template_id = undef,
   $govuk_personalisation_manage_uri = undef,
+  $govuk_personalisation_your_account_uri = undef,
   $memcache_servers = undef,
   $elections_api_url = undef,
   $elections_api_key = undef,
@@ -147,6 +151,9 @@ class govuk::apps::frontend(
     "${title}-GOVUK-PERSONALISATION-MANAGE-URI":
         varname => 'GOVUK_PERSONALISATION_MANAGE_URI',
         value   => $govuk_personalisation_manage_uri;
+    "${title}-GOVUK-PERSONALISATION-YOUR-ACCOUNT-URI":
+      varname => 'GOVUK_PERSONALISATION_YOUR_ACCOUNT_URI',
+      value   => $govuk_personalisation_your_account_uri;
     # MEMCACHE_SERVERS is used by "Dalli", our memcached client gem
     # https://github.com/petergoldstein/dalli/blob/1fbef3c/lib/dalli/client.rb#L35
     "${title}-MEMCACHE_SERVERS":


### PR DESCRIPTION
These are used by `govuk_personalisation` [[1]] to populate links to the
account home page.

We are in the process of moving the account home page from
`www.gov.uk/account/home` (served by Frontend) to an app on the DI side,
which is part of separating out central account features from the
`www.gov.uk` relying party.

To do so, we'll update `govuk_personalisation` with the new link and
change the controller in Frontend that currently serves that page to
redirect on to the new one. This allows us to do an environment aware
redirect.

Before we can update `govuk_personalisation` we need to set these
environment variables to override the URIs generated by 
`govuk_personalisation`. 

This won't have any effect on where apps send
users at the moment.

---
[Jira](https://govukverify.atlassian.net/browse/GUA-72)

[1]: https://github.com/alphagov/govuk_personalisation