### PR TITLE
Remove references to govuk-csp-forwarder

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -969,7 +969,6 @@ govuk_ci::master::pipeline_jobs:
   gds_zendesk: {}
   govuk_ab_testing: {}
   govuk-cdn-config: {}
-  govuk-csp-forwarder: {}
   govuk-dummy_content_store: {}
   govuk_document_types: {}
   govuk-guix: {}

--- a/modules/golang/manifests/init.pp
+++ b/modules/golang/manifests/init.pp
@@ -13,7 +13,6 @@ class golang {
 
   goenv::version { [
     '1.7.1',   # Used by alphagov/govuk_crawler_worker
-    '1.12.1',  # Used by alphagov/govuk-csp-forwarder
     '1.17.8',  # Used by alphagov/router (remove once router is running latest)
     '1.18.3',  # Used by alphagov/router
     ]: }


### PR DESCRIPTION
We are retiring this repository.

Trello card: https://trello.com/c/bgDwxO6a/2917-check-if-govuk-csp-forwarder-is-still-needed-and-retire-if-not-2