### PR TITLE
remove integration envvars

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -31,9 +31,6 @@ govuk::apps::content_publisher::google_tag_manager_id: "GTM-NQXC4TG"
 govuk::apps::content_publisher::google_tag_manager_preview: "env-6"
 govuk::apps::content_publisher::email_address_override: "content-publisher-notifications-integration@digital.cabinet-office.gov.uk"
 govuk::apps::content_publisher::govuk_notify_template_id: "759acac6-da53-4a19-b591-b7538c7c39de"
-govuk::apps::collections::google_tag_manager_auth: "C7iYdcsOlYgGmiUJjZKrHQ"
-govuk::apps::collections::google_tag_manager_id: "GTM-MG7HG5W"
-govuk::apps::collections::google_tag_manager_preview: "env-4"
 govuk::apps::collections_publisher::govuk_notify_template_id: "759acac6-da53-4a19-b591-b7538c7c39de"
 govuk::apps::collections_publisher::publish_without_2i_email: "mainstream-publisher-notifications-integration@digital.cabinet-office.gov.uk"
 govuk::apps::collections_publisher::unreleased_features_enabled: true
@@ -47,15 +44,9 @@ govuk::apps::feedback::govuk_notify_survey_signup_reply_to_id: 'fee22233-2f28-4b
 govuk::apps::feedback::govuk_notify_survey_signup_template_id: 'eb9ba220-7d74-4aab-975a-bdbe718f69a3'
 govuk::apps::feedback::govuk_notify_accessible_format_request_reply_to_id: '93109fea-34d9-4c38-ac7e-1ebc75e7416b'
 govuk::apps::feedback::govuk_notify_accessible_format_request_template_id: '47cef7ea-0849-48aa-9676-0ee0f7baa4ae'
-govuk::apps::frontend::google_tag_manager_auth: "C7iYdcsOlYgGmiUJjZKrHQ"
-govuk::apps::frontend::google_tag_manager_id: "GTM-MG7HG5W"
-govuk::apps::frontend::google_tag_manager_preview: "env-4"
 govuk::apps::frontend::govuk_notify_template_id: '1fc69d3a-09a2-40f9-852b-03f6fcef5340'
 govuk::apps::frontend::govuk_personalisation_manage_uri: 'https://integration.account.gov.uk?link=manage-account'
 govuk::apps::frontend::govuk_personalisation_your_account_uri: 'https://www.integration.publishing.service.gov.uk/account/home'
-govuk::apps::government_frontend::google_tag_manager_auth: "C7iYdcsOlYgGmiUJjZKrHQ"
-govuk::apps::government_frontend::google_tag_manager_id: "GTM-MG7HG5W"
-govuk::apps::government_frontend::google_tag_manager_preview: "env-4"
 govuk::apps::govuk_crawler_worker::enabled: false
 govuk::apps::govuk_crawler_worker::disable_during_data_sync: true
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true

--- a/modules/govuk/manifests/apps/collections.pp
+++ b/modules/govuk/manifests/apps/collections.pp
@@ -31,15 +31,7 @@
 # [*memcache_servers*]
 #   URL of a shared memcache cluster.
 #
-# [*google_tag_manager_id*]
-#   The ID for the Google Tag Manager account
-#
-# [*google_tag_manager_preview*]
-#   Allows a tag to be previewed in the Google Tag Manager interface
-#
-# [*google_tag_manager_auth*]
-#   The identifier of an environment for Google Tag Manager
-#
+
 class govuk::apps::collections(
   $vhost = 'collections',
   $port,
@@ -48,9 +40,6 @@ class govuk::apps::collections(
   $sentry_dsn = undef,
   $email_alert_api_bearer_token = undef,
   $memcache_servers = undef,
-  $google_tag_manager_id = undef,
-  $google_tag_manager_preview = undef,
-  $google_tag_manager_auth = undef,
 ) {
   govuk::app { 'collections':
     app_type                   => 'rack',
@@ -76,15 +65,6 @@ class govuk::apps::collections(
     "${title}-SECRET_KEY_BASE":
         varname => 'SECRET_KEY_BASE',
         value   => $secret_key_base;
-    "${title}-GOOGLE_TAG_MANAGER_ID":
-        varname => 'GOOGLE_TAG_MANAGER_ID',
-        value   => $google_tag_manager_id;
-    "${title}-GOOGLE_TAG_MANAGER_PREVIEW":
-        varname => 'GOOGLE_TAG_MANAGER_PREVIEW',
-        value   => $google_tag_manager_preview;
-    "${title}-GOOGLE_TAG_MANAGER_AUTH":
-        varname => 'GOOGLE_TAG_MANAGER_AUTH',
-        value   => $google_tag_manager_auth;
     # MEMCACHE_SERVERS is used by "Dalli", our memcached client gem
     # https://github.com/petergoldstein/dalli/blob/1fbef3c/lib/dalli/client.rb#L35
     "${title}-MEMCACHE_SERVERS":

--- a/modules/govuk/manifests/apps/frontend.pp
+++ b/modules/govuk/manifests/apps/frontend.pp
@@ -66,15 +66,7 @@
 # [*elections_api_key*]
 #   API key for the Elections API
 #
-# [*google_tag_manager_id*]
-#   The ID for the Google Tag Manager account
-#
-# [*google_tag_manager_preview*]
-#   Allows a tag to be previewed in the Google Tag Manager interface
-#
-# [*google_tag_manager_auth*]
-#   The identifier of an environment for Google Tag Manager
-#
+
 class govuk::apps::frontend(
   $vhost = 'frontend',
   $port,
@@ -94,9 +86,6 @@ class govuk::apps::frontend(
   $memcache_servers = undef,
   $elections_api_url = undef,
   $elections_api_key = undef,
-  $google_tag_manager_id = undef,
-  $google_tag_manager_preview = undef,
-  $google_tag_manager_auth = undef,
 ) {
   $app_name = 'frontend'
 
@@ -133,15 +122,6 @@ class govuk::apps::frontend(
     "${title}-PUBLISHING_API_BEARER_TOKEN":
       varname => 'PUBLISHING_API_BEARER_TOKEN',
       value   => $publishing_api_bearer_token;
-    "${title}-GOOGLE_TAG_MANAGER_ID":
-      varname => 'GOOGLE_TAG_MANAGER_ID',
-      value   => $google_tag_manager_id;
-    "${title}-GOOGLE_TAG_MANAGER_PREVIEW":
-      varname => 'GOOGLE_TAG_MANAGER_PREVIEW',
-      value   => $google_tag_manager_preview;
-    "${title}-GOOGLE_TAG_MANAGER_AUTH":
-      varname => 'GOOGLE_TAG_MANAGER_AUTH',
-      value   => $google_tag_manager_auth;
     "${title}-GOVUK_NOTIFY_API_KEY":
         varname => 'GOVUK_NOTIFY_API_KEY',
         value   => $govuk_notify_api_key;

--- a/modules/govuk/manifests/apps/government_frontend.pp
+++ b/modules/govuk/manifests/apps/government_frontend.pp
@@ -36,15 +36,6 @@
 # [*cpu_critical*]
 #   CPU usage percentage that alerts are sounded at
 #
-# [*google_tag_manager_id*]
-#   The ID for the Google Tag Manager account
-#
-# [*google_tag_manager_preview*]
-#   Allows a tag to be previewed in the Google Tag Manager interface
-#
-# [*google_tag_manager_auth*]
-#   The identifier of an environment for Google Tag Manager
-#
 class govuk::apps::government_frontend(
   $vhost = 'government-frontend',
   $port,
@@ -55,9 +46,6 @@ class govuk::apps::government_frontend(
   $unicorn_worker_processes = undef,
   $cpu_warning = 150,
   $cpu_critical = 200,
-  $google_tag_manager_id = undef,
-  $google_tag_manager_preview = undef,
-  $google_tag_manager_auth = undef,
 ) {
   Govuk::App::Envvar {
     app => 'government-frontend',
@@ -67,15 +55,6 @@ class govuk::apps::government_frontend(
     "${title}-ACCOUNT_API_BEARER_TOKEN":
         varname => 'ACCOUNT_API_BEARER_TOKEN',
         value   => $account_api_bearer_token;
-    "${title}-GOOGLE_TAG_MANAGER_ID":
-        varname => 'GOOGLE_TAG_MANAGER_ID',
-        value   => $google_tag_manager_id;
-    "${title}-GOOGLE_TAG_MANAGER_PREVIEW":
-        varname => 'GOOGLE_TAG_MANAGER_PREVIEW',
-        value   => $google_tag_manager_preview;
-    "${title}-GOOGLE_TAG_MANAGER_AUTH":
-        varname => 'GOOGLE_TAG_MANAGER_AUTH',
-        value   => $google_tag_manager_auth;
     "${title}-PUBLISHING_API_BEARER_TOKEN":
         varname => 'PUBLISHING_API_BEARER_TOKEN',
         value   => $publishing_api_bearer_token;


### PR DESCRIPTION
We are cleaning up the integration environment variables that were added to various parts of puppet and are no longer needed. We believe that we only need to retain the environment variables for `static` currently.  

This PR removes the variables for collections, frontend and government-frontend. 

[Trello](https://trello.com/c/N0ceaUnp/52-clean-up-puppet-environment-variables)