### PR TITLE
Use new Docker Enterprise user for builds

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
@@ -85,6 +85,11 @@
                 credential-id: govukci-docker-hub
                 username: DOCKER_HUB_USERNAME
                 password: DOCKER_HUB_PASSWORD
+        - credentials-binding:
+            - username-password-separated:
+                credential-id: govukci-docker-enterprise-hub
+                username: DOCKER_HUB_USERNAME
+                password: DOCKER_HUB_PASSWORD
         - timestamps
     parameters:
         - choice:


### PR DESCRIPTION
We have a new user `govukdockerci` which has been added to our
Enterprise hub and is an owner of the `govuk` organisation.
This should allow us to push without any limits. We will continue
to push to the existing govuk organisation that is owned by the
`govukci` user. These credentials have been stored in Jenkins CI
and govuk-secrets.

Related commit: https://github.com/alphagov/govuk-jenkinslib/commit/0617724150162937cc86517a6db1c04b79714543

Trello card: https://trello.com/c/I2IRWNSU/2897-look-into-docker-pull-rate-limits-3