### PR TITLE
Add X-Content-Type-Options header to nosniff

### DIFF
--- a/modules/nginx/spec/defines/nginx__config__vhost__proxy_spec.rb
+++ b/modules/nginx/spec/defines/nginx__config__vhost__proxy_spec.rb
@@ -99,6 +99,11 @@ describe 'nginx::config::vhost::proxy', :type => :define do
       is_expected.to contain_nginx__config__site('rabbit')
         .with_content(/proxy_set_header GOVUK-Request-Id \$govuk_request_id;/)
     end
+
+    it 'should add the X-Content-Type-Options header' do
+      is_expected.to contain_nginx__config__site('rabbit')
+        .with_content(/add_header X-Content-Type-Options \"nosniff\";/)
+    end
   end
 
   context 'if in aws and deny_crawlers set to true' do

--- a/modules/nginx/templates/proxy-vhost.conf
+++ b/modules/nginx/templates/proxy-vhost.conf
@@ -82,6 +82,8 @@ server {
   proxy_connect_timeout 1s;
   proxy_read_timeout <%= @read_timeout %>;
 
+  add_header X-Content-Type-Options "nosniff";
+
   access_log <%= @logpath %>/<%= @access_log %> timed_combined;
   access_log <%= @logpath %>/<%= @json_access_log %> json_event;
   error_log <%= @logpath %>/<%= @error_log %>;


### PR DESCRIPTION
The X-Content-Type-Options response HTTP header is a marker used by the server to indicate that the MIME types advertised in the Content-Type headers should be followed and not be changed.