### PR TITLE
Clarify that gatling machines are safe to reboot

### DIFF
--- a/hieradata_aws/class/gatling.yaml
+++ b/hieradata_aws/class/gatling.yaml
@@ -1,0 +1,2 @@
+govuk_safe_to_reboot::can_reboot: 'yes'
+govuk_safe_to_reboot::reason: 'only used for ad-hoc load testing'


### PR DESCRIPTION
Currently seeing an [Icinga alert][] complaining that the `gatling`
machine does not have a `govuk_safe_to_reboot` value:

```
Some machines have an unknown `govuk_safe_to_reboot` value (should be one of `careful`, `no`, `yes` or `overnight`):

- ip-10-12-5-164.eu-west-1.compute.internal
```

Specifying a value here. Assume it's safe to reboot, as there is
nothing critical relying on it.

[Icinga alert]: https://alert.blue.staging.govuk.digital/extinfo.cgi?type=2&host=ip-10-12-5-36.eu-west-1.compute.internal&service=At+least+1+machine+requires+reboots+due+to+apt+updates