### PR TITLE
Remove apps from jenkins ci

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -977,7 +977,6 @@ govuk_ci::master::pipeline_jobs:
   govuk_personalisation: {}
   govuk-provisioning: {}
   govuk_seed_crawler: {}
-  govuk_schemas: {}
   govuk_sidekiq: {}
   govuk-taxonomy-supervised-learning: {}
   govuk_taxonomy_helpers: {}

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -981,7 +981,6 @@ govuk_ci::master::pipeline_jobs:
   govuk_sidekiq: {}
   govuk-taxonomy-supervised-learning: {}
   govuk_taxonomy_helpers: {}
-  govuk_test: {}
   licensify:
     branches_to_exclude:
       - 'release*'

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1008,7 +1008,6 @@ govuk_ci::master::pipeline_jobs:
   plek: {}
   publishing-e2e-tests: {}
   rack-logstasher: {}
-  rails_translation_manager: {}
   router-data: {}
   scss-lint-govuk: {}
   search-api: {}


### PR DESCRIPTION
As per RFC-123 we're moving away from Jenkins for testing and publishing our gems via github actions.

The following apps:

* rails_translation_manager
* govuk_schemas
* govuk_test

have now been switched over to use github actions.

This PR therefore removes jenkins CI for each of them.

[Trello](https://trello.com/c/QrxjshEm/270-move-ruby-gems-from-jenkins-to-github-actions)