### PR TITLE
Fix Slack notifications by using shared 'slack-notification-token'

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_cdn.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_cdn.yaml.erb
@@ -30,9 +30,8 @@
       <% if @enable_slack_notifications %>
       - slack:
           team-domain: <%= @slack_team_domain %>
-          auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN']%>
-          auth-token-id: slack-token
-          auth-token-credential-id: slack-token
+          auth-token-id: slack-notification-token
+          auth-token-credential-id: slack-notification-token
           build-server-url: <%= @slack_build_server_url %>
           notify-start: false
           notify-success: true

--- a/modules/govuk_jenkins/templates/jobs/deploy_puppet.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_puppet.yaml.erb
@@ -45,9 +45,8 @@
         <%- if @enable_slack_notifications -%>
         - slack:
             team-domain: <%= @slack_team_domain %>
-            auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN']%>
-            auth-token-id: slack-token
-            auth-token-credential-id: slack-token
+            auth-token-id: slack-notification-token
+            auth-token-credential-id: slack-notification-token
             build-server-url: <%= @slack_build_server_url %>
             notify-start: true
             notify-success: true

--- a/modules/govuk_jenkins/templates/jobs/mirror_github_repositories.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/mirror_github_repositories.yaml.erb
@@ -22,7 +22,6 @@
         <%- if @enable_slack_notifications -%>
         - slack:
             team-domain: <%= @slack_team_domain %>
-            auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN']%>
             auth-token-id: 'slack-notification-token'
             auth-token-credential-id: 'slack-notification-token'
             build-server-url: <%= @slack_build_server_url %>

--- a/modules/govuk_jenkins/templates/jobs/update_cdn_dictionaries.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/update_cdn_dictionaries.yaml.erb
@@ -29,9 +29,8 @@
     publishers:
       - slack:
           team-domain: <%= @slack_team_domain %>
-          auth-token: <%= @environment_variables['SECOND_LINE_SLACK_AUTH_TOKEN']%>
-          auth-token-id: slack-token
-          auth-token-credential-id: slack-token
+          auth-token-id: slack-notification-token
+          auth-token-credential-id: slack-notification-token
           build-server-url: <%= @slack_build_server_url %>
           notify-start: false
           notify-success: true


### PR DESCRIPTION
Some of our Slack notifications have been broken since at least
February 2021:
https://github.com/alphagov/govuk-puppet/pull/10922#issuecomment-772484768

Testing the `SECOND_LINE_SLACK_AUTH_TOKEN` token against
https://slack.com/api/auth.test, it doesn't appear to be valid.
But the `slack-notification-token` (added at some point in the
past, in the Jenkins UI: https://github.com/jenkinsci/slack-plugin/issues/270#issuecomment-276176109)
DOES seem to work.

We can see in the UI for any of the jobs in this commit, that the
'Integration Token' is set, and the 'Integration Token Credential
ID' is not set. Clicking 'Test Connection', we see a client error.
If we clear the 'Integration Token' field, and instead set the
'Integration Token Credential ID' to 'slack-notification-token',
the 'Test Connection' succeeds, and we see the test message come
through to Slack successfully.

This commit therefore removes the reliance on API keys stored in
govuk-secrets, and instead makes reference to a shared secret
stored in Jenkins itself. This should fix Slack notifications for
4 different jobs.

![](https://user-images.githubusercontent.com/5111927/180235908-3bf5f3bb-387b-45c3-a736-e1ef8fb6512f.png)

Trello: https://trello.com/c/aGpBjdHG/2899-fix-slack-notifications-for-failed-jenkins-jobs3