### PR TITLE
Add general cleanup class to CI to prevent FS resources exhaustion

### DIFF
--- a/hieradata_aws/class/integration/ci_agent.yaml
+++ b/hieradata_aws/class/integration/ci_agent.yaml
@@ -7,6 +7,7 @@ mongodb::server::replicaset_members:
 
 clamav::use_service: false
 
+govuk_ci::agent::cleanup::jenkins_workspace_max_age: '30'
 govuk_ci::agent::postgresql::mapit_role_password: 'mapit'
 govuk_ci::agent::postgresql::email_alert_api_role_password: 'email-alert-api'
 govuk_ci::agent::gdal_version: "2.4.4"

--- a/modules/govuk_ci/manifests/agent.pp
+++ b/modules/govuk_ci/manifests/agent.pp
@@ -42,6 +42,7 @@ class govuk_ci::agent(
   include ::govuk_ci::agent::postgresql
   include ::govuk_ci::agent::rabbitmq
   include ::govuk_ci::agent::solr
+  include ::govuk_ci::cleanup
   include ::govuk_ci::credentials
   include ::govuk_ci::limits
   include ::govuk_jenkins::packages::terraform

--- a/modules/govuk_ci/manifests/cleanup.pp
+++ b/modules/govuk_ci/manifests/cleanup.pp
@@ -1,0 +1,18 @@
+# == Class: govuk_ci::cleanup
+#
+#  General cleanup of filesystem.
+#
+# === Parameters:
+#
+# [*jenkins_workspace_max_age*]
+#   Maximum age -in days- of Jenkins workspaces before they are deleted by the cleanup job.
+#
+class govuk_ci::cleanup (
+  $jenkins_workspace_max_age = 90,
+){
+  cron::crondotdee { 'clean_up_workspace':
+    command => 'find /var/lib/jenkins/workspace/ -maxdepth 1 -mindepth 1 -type d -mtime +$jenkins_workspace_max_age -exec rm -rf {} \;',
+    hour    => 7,
+    minute  => 25,
+  }
+}

--- a/modules/govuk_ci/manifests/master.pp
+++ b/modules/govuk_ci/manifests/master.pp
@@ -34,6 +34,7 @@ class govuk_ci::master (
   validate_hash($pipeline_jobs)
   validate_hash($environment_variables)
 
+  include ::govuk_ci::cleanup
   include ::govuk_ci::credentials
   include ::govuk_ci::limits
 


### PR DESCRIPTION
This add a daily run script that get rid of workspaces in jenkins
that are older than jenkins_worspace_max_age.
Over time the accumulation of files in the workspaces can lead to
inodes or space exhaustion on the filesystem. This script should
keep this under control.

Trello: https://trello.com/c/JwTIJsk1/2920-stop-low-available-disk-inodes-alert-3