### PR TITLE
Pin boto3 and botocore to known working versions

### DIFF
--- a/modules/govuk_scripts/manifests/init.pp
+++ b/modules/govuk_scripts/manifests/init.pp
@@ -42,9 +42,9 @@ class govuk_scripts {
   # Make sure boto3 is installed for Python3 as required by govuk_node_list_aws
   exec { 'check_boto':
     path    => ['/usr/bin', '/usr/sbin'],
-    command => '/usr/bin/pip3 install boto3',
+    command => '/usr/bin/pip3 install botocore==1.21.3 boto3==1.18.3',
     require => Class['base::packages'],
-    unless  => 'test -d /usr/local/lib/python3.4/dist-packages/boto3',
+    unless  => 'test -d /usr/local/lib/python3.4/dist-packages/boto3-1.18.3.dist-info -a -d botocore-1.21.3.dist-info',
   }
 
   $app_domain_internal = hiera('app_domain_internal')


### PR DESCRIPTION
An upgrade of botocore and boto3 seems to have broken the
govuk_node_list script. This pins those modules to known working
versions.