### PR TITLE
Point authenticating-proxy to documentdb in integration

### DIFF
--- a/hieradata_aws/class/integration/draft_cache.yaml
+++ b/hieradata_aws/class/integration/draft_cache.yaml
@@ -1,0 +1,7 @@
+---
+
+govuk::apps::authenticating_proxy::mongodb_name: 'authenticating_proxy_production'
+govuk::apps::authenticating_proxy::mongodb_nodes:
+  - 'authenticating-proxy-documentdb'
+govuk::apps::authenticating_proxy::mongodb_username: "%{hiera('authenticating_proxy_documentdb_user')}"
+govuk::apps::authenticating_proxy::mongodb_password: "%{hiera('authenticating_proxy_documentdb_password')}"

--- a/modules/govuk/manifests/apps/authenticating_proxy.pp
+++ b/modules/govuk/manifests/apps/authenticating_proxy.pp
@@ -12,6 +12,14 @@
 # [*mongodb_name*]
 #   The name of the MongoDB database to use
 #
+# [*mongodb_username*]
+#   The username to use when connecting to the MongoDB database
+#   (needed for DocumentDB, which always requires username)
+#
+# [*mongodb_password*]
+#   The password to use when connecting to the MongoDB database
+#   (needed for DocumentDB, which always requires password)
+#
 # [*port*]
 #   The port that it is served on.
 #
@@ -42,8 +50,10 @@
 #   Scheme to use for signon URI.
 #   Default: 'https'
 class govuk::apps::authenticating_proxy(
-  $mongodb_nodes,
+  $mongodb_nodes = undef,
   $mongodb_name = 'authenticating_proxy_production',
+  $mongodb_username = '',
+  $mongodb_password = '',
   $port,
   $sentry_dsn = undef,
   $govuk_upstream_uri = 'http://localhost:3054',
@@ -58,6 +68,8 @@ class govuk::apps::authenticating_proxy(
   govuk::app::envvar::mongodb_uri { $app_name:
     hosts    => $mongodb_nodes,
     database => $mongodb_name,
+    username => $mongodb_username,
+    password => $mongodb_password,
   }
 
   govuk::app { $app_name:


### PR DESCRIPTION
As part of moving our apps away from Mongo 2.6, it would be useful to test moving the authenticating proxy app in integration away from the EC2 Mongo 2.6 cluster and onto the DocumentDB authenticating-proxy-documentdb-integration cluster that will be created by this PR:

https://github.com/alphagov/govuk-aws/pull/1556

This change adds a new draft-cache yaml file to the heiradata in the integration class that should (for integration) override the existing mongodb cluster information.

When deployed, authenticating proxy will lose the existing information in integration. There's no env sync for AP from staging down to integration, so it won't automatically be populated. However, it's possible this might not make any difference (since the data in AP is transient anyway), and it should be possible to export from the existing mongo and import manually.

https://trello.com/c/lSpntlfk/81-mongo-26-has-reached-end-of-life