### PR TITLE
Pin s3transfer version

### DIFF
--- a/modules/govuk_scripts/manifests/init.pp
+++ b/modules/govuk_scripts/manifests/init.pp
@@ -42,9 +42,9 @@ class govuk_scripts {
   # Make sure boto3 is installed for Python3 as required by govuk_node_list_aws
   exec { 'check_boto':
     path    => ['/usr/bin', '/usr/sbin'],
-    command => '/usr/bin/pip3 install botocore==1.21.3 boto3==1.18.3',
+    command => '/usr/bin/pip3 install botocore==1.21.3 boto3==1.21.3 s3transfer==0.5.0',
     require => Class['base::packages'],
-    unless  => 'test -d /usr/local/lib/python3.4/dist-packages/boto3-1.18.3.dist-info -a -d botocore-1.21.3.dist-info',
+    unless  => 'test -d /usr/local/lib/python3.4/dist-packages/boto3-1.21.3.dist-info -a -d botocore-1.21.3.dist-info -a -d s3transfer-0.5.0.dist-info',
   }
 
   $app_domain_internal = hiera('app_domain_internal')


### PR DESCRIPTION
Unfortunately, the [script to test that Fastly logs are being processed](https://github.com/alphagov/govuk-puppet/blob/main/modules/monitoring/files/usr/lib/nagios/plugins/check_cdn_log_s3_freshness) is not currently working. The versions of boto3 and botocore were recently pinned to fix a similar issue in govuk_node_list_aws.

In digging into this, I found a later version of boto3 that would install, and discovered that later versions of s3transfer are responsible for breaking the log checking script.

I've tested both govuk_node_list_aws and check_cdn_log_s3_freshness with these versions and all seems OK. 🤞

We need to update our python versions and undo this pinning!