### PR TITLE
Remove apps from jenkins ci

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -969,7 +969,6 @@ govuk_ci::master::pipeline_jobs:
   gds_zendesk: {}
   govuk-cdn-config: {}
   govuk-dummy_content_store: {}
-  govuk_document_types: {}
   govuk-guix: {}
   govuk-jenkinslib: {}
   govuk_message_queue_consumer: {}

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -967,7 +967,6 @@ govuk_ci::master::pipeline_jobs:
   gds-api-adapters: {}
   gds-sso: {}
   gds_zendesk: {}
-  govuk_ab_testing: {}
   govuk-cdn-config: {}
   govuk-dummy_content_store: {}
   govuk_document_types: {}


### PR DESCRIPTION
Govuk_document_types and govuk_ab_testing have both been migrated to use github actions, so this PR removes these apps from the list of registered jenkins pipelines. 

[Trello](https://trello.com/c/QrxjshEm/270-move-ruby-gems-from-jenkins-to-github-actions)