### PR TITLE
Authenticate Fastly cache purge requests

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -154,7 +154,7 @@ govuk_jenkins::jobs::athena_fastly_logs_check::s3_results_bucket: 'govuk-integra
 
 govuk_jenkins::jobs::content_data_api::rake_etl_main_process_cron_schedule: '0 13 * * *'
 
-govuk_jenkins::jobs::clear_cdn_cache::website_root_url: 'www.integration.publishing.service.gov.uk'
+govuk_jenkins::jobs::clear_cdn_cache::website_root_url: 'https://www.integration.publishing.service.gov.uk'
 
 govuk_jenkins::jobs::content_publisher_whitehall_import::enable_slack_notifications: true
 

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -305,7 +305,7 @@ govuk_jenkins::jobs::athena_fastly_logs_check::s3_results_bucket: 'govuk-product
 govuk_jenkins::jobs::athena_fastly_logs_check::databases: ['govuk_www', 'govuk_assets', 'bouncer']
 govuk_jenkins::jobs::content_data_api::rake_etl_main_process_cron_schedule: '0 7 * * *'
 
-govuk_jenkins::jobs::clear_cdn_cache::website_root_url: 'www.gov.uk'
+govuk_jenkins::jobs::clear_cdn_cache::website_root_url: 'https://www.gov.uk'
 
 govuk_jenkins::jobs::run_related_links_generation::cron_schedule: '0 8 9,23 * *'
 govuk_jenkins::jobs::run_related_links_ingestion::cron_schedule: '0 8 11,25 * *'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -285,7 +285,7 @@ govuk_jenkins::job_builder::environment: 'staging'
 govuk_jenkins::jobs::athena_fastly_logs_check::s3_results_bucket: 'govuk-staging-fastly-logs-monitoring'
 govuk_jenkins::jobs::content_data_api::rake_etl_main_process_cron_schedule: '0 11 * * *'
 
-govuk_jenkins::jobs::clear_cdn_cache::website_root_url: 'www.staging.publishing.service.gov.uk'
+govuk_jenkins::jobs::clear_cdn_cache::website_root_url: 'https://www.staging.publishing.service.gov.uk'
 
 govuk_jenkins::jobs::network_config_deploy::environments:
   - 'carrenza-staging'

--- a/modules/govuk_jenkins/manifests/jobs/clear_cdn_cache.pp
+++ b/modules/govuk_jenkins/manifests/jobs/clear_cdn_cache.pp
@@ -3,6 +3,7 @@
 # Create a file on disk that can be parsed by jenkins-job-builder
 #
 class govuk_jenkins::jobs::clear_cdn_cache(
+  $fastly_api_token = undef,
   $website_root_url = nil,
 ) {
   file { '/etc/jenkins_jobs/jobs/clear_cdn_cache.yaml':

--- a/modules/govuk_jenkins/templates/jobs/clear_cdn_cache.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/clear_cdn_cache.yaml.erb
@@ -30,6 +30,12 @@
               exit 1
             fi
 
+            if [[ "${cdn_url:0:8}" != "https://" ]]; then
+              # Ensure the Fastly API token is not sent over a plaintext connection
+              echo "expected $cdn_url to be an HTTPS URL"
+              exit 1
+            fi
+
             if [ -n "$local_varnish_url" ]; then
               echo $local_varnish_url
               for node in `govuk_node_list -c cache`; do
@@ -38,8 +44,8 @@
               done
             fi
 
-            ssh deploy@$(govuk_node_list --single-node -c cache) "curl -fs -w \"HTTP response: %{http_code}\n\" -X PURGE $cdn_url"
-            ssh deploy@$(govuk_node_list --single-node -c cache) "curl -fs -w \"HTTP response: %{http_code}\n\" -H 'GOVUK-Account-Session-Exists: 1' -X PURGE $cdn_url"
+            curl -fs -w "HTTP response: %{http_code}\n" -H "Fastly-Key: $FASTLY_API_TOKEN" -X PURGE $cdn_url
+            curl -fs -w "HTTP response: %{http_code}\n" -H "Fastly-Key: $FASTLY_API_TOKEN" -H 'GOVUK-Account-Session-Exists: 1' -X PURGE $cdn_url
           done
     parameters:
       - text:
@@ -58,3 +64,10 @@
     wrappers:
       - ansicolor:
           colormap: xterm
+      - inject-passwords:
+          global: false
+          mask-password-params: true
+          job-passwords:
+            - name: FASTLY_API_TOKEN
+              password:
+                '<%= @fastly_api_token %>'


### PR DESCRIPTION
[Trello card](https://trello.com/c/O5Wy2X9w/2946-authenticate-fastly-purge-requests-with-an-api-token-3)

We are updating our Fastly configuration to authenticate cache purge requests using API tokens instead of an IP address allowlist[^1].

This PR updates the Jenkins job for clearing the CDN cache to use API tokens already added to the `govuk-secrets` repo[^2] to authenticate the purge requests. Because we are now sending secret API tokens with the purge requests, a check has been added to the script to ensure that requests are only sent over HTTPS.

As a result of this change, we no longer need to `ssh` to an allowlisted node before issuing a `PURGE` request to Fastly, so this extra step has been removed.

This branch has been deployed to integration for testing purposes: https://deploy.integration.publishing.service.gov.uk/job/clear-cdn-cache/

[^1]: https://docs.fastly.com/en/guides/authenticating-api-purge-requests
[^2]: https://github.com/alphagov/govuk-secrets/pull/1325