### PR TITLE
Bump Linux kernel to 'linux-image-4.4.0-231-generic'

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -265,7 +265,7 @@ base::packages::packages:
   - 'libxml2-dev'
   - 'libxslt1-dev'
   - 'liblzma-dev'
-  - 'linux-image-4.4.0-224-generic'
+  - 'linux-image-4.4.0-231-generic'
   - 'logtail'
   - 'mailutils'
   - 'man-db'


### PR DESCRIPTION
See https://ubuntu.com/security/notices/USN-5557-1

Trello: https://trello.com/c/ty5mtAL7/2960-look-into-linux-kernel-vulnerabilities