### PR TITLE
Update forms hostname for signon db sync

### DIFF
--- a/modules/govuk_env_sync/files/govuk_env_sync.sh
+++ b/modules/govuk_env_sync/files/govuk_env_sync.sh
@@ -555,6 +555,7 @@ function postprocess_signon_production {
   postprocess_mysl_cmd_signon_production "performance.service.gov.uk" "staging.performance.service.gov.uk"
   postprocess_mysl_cmd_signon_production "-production.cloudapps.digital" "-staging.cloudapps.digital"
   postprocess_mysl_cmd_signon_production "-production.london.cloudapps.digital" "-staging.london.cloudapps.digital"
+  postprocess_mysl_cmd_signon_production "admin.forms.service.gov.uk" "admin.staging.forms.service.gov.uk"  
 
   log "Completed the postprocessing for Signon"
 }


### PR DESCRIPTION
Trello: https://trello.com/c/1K1MKClA/203-grant-the-govuk-forms-application-access-to-signon-in-production-staging

This adds the forms service to the list of transformations that are done to signon as part of it's sync from production to staging. This is required so that the forms service can utilise the GOV.UK staging signon service from its staging environment.

An alternative approach could be that we create a staging environment in Signon production, as it's not necessary that the staging app of forms uses the staging app of signon. However this would go against the existing conventions used with other 3rd party applications and thus seems something to only explore if we experience problems.