### PR TITLE
Add postgis ci container

### DIFF
--- a/modules/govuk_ci/manifests/agent/postgresql.pp
+++ b/modules/govuk_ci/manifests/agent/postgresql.pp
@@ -21,6 +21,11 @@ class govuk_ci::agent::postgresql (
     version => '13',
     port    => 54313,
   }
+  ::govuk_containers::ci_postgis { 'ci-postgis-14':
+    version         => '14',
+    postgis_version => '3.2',
+    port            => 54414,
+  }
 
   contain ::govuk_postgresql::mirror
   include ::govuk_postgresql::server::standalone

--- a/modules/govuk_containers/manifests/ci_postgis.pp
+++ b/modules/govuk_containers/manifests/ci_postgis.pp
@@ -1,0 +1,35 @@
+# == Resource: govuk_containers::ci_postgis
+#
+# Install and run a dockerised PostgreSQL server, intended for CI purposes
+#
+# === Parameters
+#
+# [*version*]
+#   The version of PostgreSQL the PostGIS Docker image should be based on
+#
+# [*postgis_version*]
+#   The version of PostGIS the PostGIS Docker image should be based on
+#
+# [*port*]
+#   The port that the PostgreSQL server will be exposed on
+#
+define govuk_containers::ci_postgis(
+  $ensure = 'present',
+  $version = '14',
+  $postgis_version = '3.2',
+  $port = 54414
+) {
+  ::docker::run { $title:
+    ensure => $ensure,
+    ports  => ["127.0.0.1:${port}:5432"],
+    image  => "postgis/postgis:${version}-${postgis_version}",
+    env    => ['"POSTGRES_HOST_AUTH_METHOD=trust"'],
+  }
+
+  @@icinga::check { "check_${title}_running_${::hostname}":
+    ensure              => $ensure,
+    check_command       => "check_nrpe!check_tcp!127.0.0.1 ${port}",
+    service_description => "Docker PostgreSQL ${version} with PostGIS ${postgis_version} not accepting TCP connections",
+    host_name           => $::fqdn,
+  }
+}

--- a/modules/govuk_containers/spec/defines/govuk_containers__ci_postgis_spec.rb
+++ b/modules/govuk_containers/spec/defines/govuk_containers__ci_postgis_spec.rb
@@ -1,0 +1,14 @@
+require_relative '../../../../spec_helper'
+
+describe 'govuk_containers::ci_postgis', :type => :define do
+  let(:title) { "ci-postgis-instance" }
+
+  let(:pre_condition) { <<-EOS
+    include ::govuk_python
+    include ::govuk_docker
+    EOS
+  }
+  it { is_expected.to compile }
+
+  it { is_expected.to compile.with_all_deps }
+end


### PR DESCRIPTION
Adds a container running postgres 14 with postgis 3.2 (by default) to the CI agents. This is necessary to run the tests for the Mongo->Postgresql conversion for imminence. If we decide to go ahead with that, it'll be necessary to merge this into the main branch.

Related PR:
https://github.com/alphagov/imminence/pull/766