### PR TITLE
Add unreleased_features_flag for collections

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -31,6 +31,7 @@ govuk::apps::content_publisher::google_tag_manager_id: "GTM-NQXC4TG"
 govuk::apps::content_publisher::google_tag_manager_preview: "env-6"
 govuk::apps::content_publisher::email_address_override: "content-publisher-notifications-integration@digital.cabinet-office.gov.uk"
 govuk::apps::content_publisher::govuk_notify_template_id: "759acac6-da53-4a19-b591-b7538c7c39de"
+govuk::apps::collections::unreleased_features_enabled: true
 govuk::apps::collections_publisher::govuk_notify_template_id: "759acac6-da53-4a19-b591-b7538c7c39de"
 govuk::apps::collections_publisher::publish_without_2i_email: "mainstream-publisher-notifications-integration@digital.cabinet-office.gov.uk"
 govuk::apps::collections_publisher::unreleased_features_enabled: true

--- a/modules/govuk/manifests/apps/collections.pp
+++ b/modules/govuk/manifests/apps/collections.pp
@@ -31,6 +31,9 @@
 # [*memcache_servers*]
 #   URL of a shared memcache cluster.
 #
+# [*unreleased_features_enabled*]
+#   Whether unreleased features should be enabled
+#
 
 class govuk::apps::collections(
   $vhost = 'collections',
@@ -40,6 +43,7 @@ class govuk::apps::collections(
   $sentry_dsn = undef,
   $email_alert_api_bearer_token = undef,
   $memcache_servers = undef,
+  $unreleased_features_enabled = false,
 ) {
   govuk::app { 'collections':
     app_type                   => 'rack',


### PR DESCRIPTION
On integration only, we want to be able to show new features such as the Cost of living support page, and hide on staging and production.

[Trello](https://trello.com/c/0rJHy0zc/1236-page-is-on-production-and-hidden-viewable-only-on-integration-m)