### PR TITLE
Disable unattended reboots

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1175,7 +1175,7 @@ govuk_sudo::sudo_conf:
     content: 'ubuntu ALL=(ALL) NOPASSWD:ALL'
 
 govuk_unattended_reboot::alert_hostname: 'alert'
-govuk_unattended_reboot::enabled: true
+govuk_unattended_reboot::enabled: false
 govuk_unattended_reboot::mongodb::enabled: true
 
 govuk_unattended_reboot::monitoring_basic_auth:


### PR DESCRIPTION
We want to reboot the docker_management management machine. The
docker_management machine manages locks for unattended reboots of other
machines. If this machine is down, then multiple machines in high
availability groups may  choose to reboot themselves at the same time.