### PR TITLE
Fix missing use of feature flag on Collections

### DIFF
--- a/modules/govuk/manifests/apps/collections.pp
+++ b/modules/govuk/manifests/apps/collections.pp
@@ -62,6 +62,14 @@ class govuk::apps::collections(
     app => 'collections',
   }
 
+  if $unreleased_features_enabled {
+    govuk::app::envvar {
+      "${title}-UNRELEASED_FEATURES":
+        varname => 'UNRELEASED_FEATURES',
+        value   => '1';
+    }
+  }
+
   govuk::app::envvar {
     "${title}-EMAIL_ALERT_API_BEARER_TOKEN":
         varname => 'EMAIL_ALERT_API_BEARER_TOKEN',


### PR DESCRIPTION
The env var was set previously in puppet, but we didn't configure for it to be available to the app. [1]

1 https://github.com/alphagov/govuk-puppet/pull/11781