### PR TITLE
Add smokey deploy job to CI

### DIFF
--- a/hieradata_aws/class/integration/ci_master.yaml
+++ b/hieradata_aws/class/integration/ci_master.yaml
@@ -66,6 +66,8 @@ govuk_jenkins::jobs::deploy_app_downstream::applications:
 govuk_jenkins::jobs::deploy_app_downstream::deploy_url: 'deploy.integration.publishing.service.gov.uk'
 govuk_jenkins::jobs::deploy_app_downstream::smokey_pre_check: false
 
+govuk_jenkins::jobs::smokey_deploy::deploy_url: 'deploy.integration.publishing.service.gov.uk'
+
 jenkins_admin_permission_list: &jenkins_admin_permission_list
   - 'hudson.model.Hudson.Administer'
   - 'hudson.model.Hudson.Read'
@@ -142,9 +144,12 @@ govuk_jenkins::job_builder::jobs: &job_builder_jobs
   - govuk_jenkins::jobs::deploy_app_downstream
   - govuk_jenkins::jobs::deploy_puppet_downstream
   - govuk_jenkins::jobs::build_fpm_package
+  - govuk_jenkins::jobs::smokey_deploy
 govuk_ci::master::job_builder_jobs: *job_builder_jobs
 
 govuk_jenkins::jobs::deploy_app_downstream::jenkins_downstream_api_password: "%{hiera('govuk_jenkins::jobs::deploy_app_downstream::ci_jenkins_downstream_api_password')}"
+
+govuk_jenkins::jobs::smokey_deploy::jenkins_downstream_api_password: "%{hiera('govuk_jenkins::jobs::deploy_app_downstream::ci_jenkins_downstream_api_password')}"
 
 jenkins::params::default_plugins: []
 

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -161,6 +161,8 @@ govuk_jenkins::jobs::content_publisher_whitehall_import::enable_slack_notificati
 
 govuk_jenkins::jobs::deploy_app_downstream::deploy_url: 'deploy.blue.staging.govuk.digital'
 
+govuk_jenkins::jobs::smokey_deploy::deploy_url: 'deploy.blue.staging.govuk.digital'
+
 govuk_jenkins::jobs::deploy_dns::gce_project_id: 'govuk-integration'
 govuk_jenkins::jobs::deploy_dns::zones:
   - 'dnstest.alphagov.co.uk'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -313,6 +313,8 @@ govuk_jenkins::jobs::data_sync_complete_staging::signon_domains_to_migrate:
 
 govuk_jenkins::jobs::deploy_app_downstream::deploy_url: 'deploy.blue.production.govuk.digital'
 
+govuk_jenkins::jobs::smokey_deploy::deploy_url: 'deploy.blue.production.govuk.digital'
+
 govuk_jenkins::jobs::deploy_dns::gce_client_name: 'govuk-dns-deploy'
 govuk_jenkins::jobs::deploy_dns::gce_project_id: 'govuk-staging-160211'
 

--- a/modules/govuk_jenkins/templates/jobs/smokey_deploy.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/smokey_deploy.yaml.erb
@@ -23,6 +23,9 @@
         - shell: |
             export DEPLOY_TO=$(govuk_node_list -c monitoring)
             sh -x deploy.sh
+            # Deploy to downstream environment using same credentials as Deploy_App_Downstream job
+            CRUMB=$(curl https://<%= @jenkins_downstream_api_user %>:<%= @jenkins_downstream_api_password %>@<%= @deploy_url %>/crumbIssuer/api/json | jq --raw-output '. | .crumb')
+            curl -f -H "Jenkins-Crumb:$CRUMB" -XPOST https://<%= @jenkins_downstream_api_user %>:<%= @jenkins_downstream_api_password %>@<%= @deploy_url %>/job/Smokey_Deploy/build"
     triggers:
         - timed: |
             TZ=Europe/London


### PR DESCRIPTION
This job is needed so that smokey is deployed downstream when changes are merged.

https://trello.com/c/JcY1L7so/2942-automatically-run-smokeydeploy-when-a-smokey-change-is-merged-3