### PR TITLE
Remove puppet_auth_token and hardcode jenkins_downstream_api_user

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/deploy_smokey_downstream.pp
+++ b/modules/govuk_jenkins/manifests/jobs/deploy_smokey_downstream.pp
@@ -14,7 +14,7 @@
 #   The URL of the downstream Jenkins.
 #
 class govuk_jenkins::jobs::deploy_smokey_downstream (
-  $jenkins_downstream_api_user = undef,
+  $jenkins_downstream_api_user = 'jenkins_api_user',
   $jenkins_downstream_api_password = undef,
   $deploy_url = undef,
 ) {

--- a/modules/govuk_jenkins/manifests/jobs/deploy_smokey_downstream.pp
+++ b/modules/govuk_jenkins/manifests/jobs/deploy_smokey_downstream.pp
@@ -13,14 +13,10 @@
 # [*deploy_url*]
 #   The URL of the downstream Jenkins.
 #
-# [*puppet_auth_token*]
-#   This token is used to authenticate with the downstream deploy job.
-#
 class govuk_jenkins::jobs::deploy_smokey_downstream (
   $jenkins_downstream_api_user = undef,
   $jenkins_downstream_api_password = undef,
   $deploy_url = undef,
-  $puppet_auth_token = undef,
 ) {
   file { '/etc/jenkins_jobs/jobs/deploy_smokey_downstream.yaml':
     ensure  => present,

--- a/modules/govuk_jenkins/templates/jobs/deploy_smokey_downstream.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_smokey_downstream.yaml.erb
@@ -12,7 +12,7 @@
           # Deploy to downstream environment
           CRUMB=$(curl https://<%= @jenkins_downstream_api_user %>:<%= @jenkins_downstream_api_password %>@<%= @deploy_url %>/crumbIssuer/api/json | jq --raw-output '. | .crumb')
 
-          curl -f -H "Jenkins-Crumb:$CRUMB" -XPOST https://<%= @jenkins_downstream_api_user %>:<%= @jenkins_downstream_api_password %>@<%= @deploy_url %>/job/Smokey_Deploy/build -d token=<%= @puppet_auth_token %>
+          curl -f -H "Jenkins-Crumb:$CRUMB" -XPOST https://<%= @jenkins_downstream_api_user %>:<%= @jenkins_downstream_api_password %>@<%= @deploy_url %>/job/Smokey_Deploy/build
 
     wrappers:
         - ansicolor:


### PR DESCRIPTION
puppet_auth_token was added in https://github.com/alphagov/govuk-puppet/pull/11792 but isn't actually needed.

https://trello.com/c/JcY1L7so/2942-automatically-run-smokeydeploy-when-a-smokey-change-is-merged-3