### PR TITLE
Remove scheduled daily deploy of Smokey

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/smokey_deploy.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/smokey_deploy.yaml.erb
@@ -25,7 +25,3 @@
             sh -x deploy.sh
         - trigger-builds:
             - project: Deploy_Smokey_Downstream
-    triggers:
-        - timed: |
-            TZ=Europe/London
-            H 9 * * *


### PR DESCRIPTION
We've now made it so that merging a Smokey PR will [trigger](https://github.com/alphagov/govuk-puppet/blob/main/modules/govuk_jenkins/templates/jobs/deploy_smokey_downstream.yaml.erb#L12) a deploy of Smokey
so we don't need this anymore.

https://trello.com/c/JcY1L7so/2942-automatically-run-smokeydeploy-when-a-smokey-change-is-merged-3