### PR TITLE
Update description for PagerDuty test drill

### DIFF
--- a/modules/monitoring/manifests/pagerduty_drill.pp
+++ b/modules/monitoring/manifests/pagerduty_drill.pp
@@ -43,7 +43,7 @@ class monitoring::pagerduty_drill (
     @@icinga::check { "pagerduty_drill_on_${::hostname}":
       check_command              => "check_nrpe!check_file_not_exists!${filename}",
       use                        => 'govuk_urgent_priority',
-      service_description        => 'PagerDuty test drill in progress',
+      service_description        => 'PagerDuty test drill. Developers: escalate this alert. SMT: resolve this alert.',
       host_name                  => $::fqdn,
       notes_url                  => monitoring_docs_url(pagerduty),
       attempts_before_hard_state => 1,


### PR DESCRIPTION
The PagerDuty drill appears as the following (for example):

```
CRITICAL: 'PagerDuty test drill in progress' on 'ip-10-13-5-163.eu-west-1.compute.internal'
```

There is often confusion regarding what should be done with this alert once called.

By including some instructions in the alert itself, we should remove this confusion.

The alert will ow appear as:

```
CRITICAL: 'PagerDuty test drill. Developers: escalate this alert. SMT: resolve this alert.' on 'ip-10-13-5-163.eu-west-1.compute.internal'
```