### PR TITLE
Remove unreleased_features_flag for collections

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -31,7 +31,6 @@ govuk::apps::content_publisher::google_tag_manager_id: "GTM-NQXC4TG"
 govuk::apps::content_publisher::google_tag_manager_preview: "env-6"
 govuk::apps::content_publisher::email_address_override: "content-publisher-notifications-integration@digital.cabinet-office.gov.uk"
 govuk::apps::content_publisher::govuk_notify_template_id: "759acac6-da53-4a19-b591-b7538c7c39de"
-govuk::apps::collections::unreleased_features_enabled: true
 govuk::apps::collections_publisher::govuk_notify_template_id: "759acac6-da53-4a19-b591-b7538c7c39de"
 govuk::apps::collections_publisher::publish_without_2i_email: "mainstream-publisher-notifications-integration@digital.cabinet-office.gov.uk"
 govuk::apps::collections_publisher::unreleased_features_enabled: true

--- a/modules/govuk/manifests/apps/collections.pp
+++ b/modules/govuk/manifests/apps/collections.pp
@@ -31,9 +31,6 @@
 # [*memcache_servers*]
 #   URL of a shared memcache cluster.
 #
-# [*unreleased_features_enabled*]
-#   Whether unreleased features should be enabled
-#
 
 class govuk::apps::collections(
   $vhost = 'collections',
@@ -43,7 +40,6 @@ class govuk::apps::collections(
   $sentry_dsn = undef,
   $email_alert_api_bearer_token = undef,
   $memcache_servers = undef,
-  $unreleased_features_enabled = false,
 ) {
   govuk::app { 'collections':
     app_type                   => 'rack',

--- a/modules/govuk/manifests/apps/collections.pp
+++ b/modules/govuk/manifests/apps/collections.pp
@@ -58,14 +58,6 @@ class govuk::apps::collections(
     app => 'collections',
   }
 
-  if $unreleased_features_enabled {
-    govuk::app::envvar {
-      "${title}-UNRELEASED_FEATURES":
-        varname => 'UNRELEASED_FEATURES',
-        value   => '1';
-    }
-  }
-
   govuk::app::envvar {
     "${title}-EMAIL_ALERT_API_BEARER_TOKEN":
         varname => 'EMAIL_ALERT_API_BEARER_TOKEN',


### PR DESCRIPTION
## What

Remove the env var set in Puppet which triggered whether the Cost of living page was shown on each environment.

## Why

This is un-used code and we should tidy up.

## How

Revert PRs:

* https://github.com/alphagov/govuk-puppet/pull/11781
* https://github.com/alphagov/govuk-puppet/pull/11786

[Trello](https://trello.com/c/b4INV89F/1298-remove-puppet-env-var-for-feature-flag) 
