### PR TITLE
Licensify - Remove deprecated configuration property

### DIFF
--- a/modules/licensify/templates/gds-licensify-admin-config.conf.erb
+++ b/modules/licensify/templates/gds-licensify-admin-config.conf.erb
@@ -8,7 +8,6 @@ include "application"
 # ~~~~~
 # The secret key is used to secure cryptographics functions.
 # If you deploy your application to several instances be sure to use the same key!
-play.crypto.secret="<%= @application_secret %>"
 play.http.secret.key="<%= @application_secret %>"
 
 # Root logger:

--- a/modules/licensify/templates/gds-licensify-config.conf.erb
+++ b/modules/licensify/templates/gds-licensify-config.conf.erb
@@ -8,7 +8,6 @@ include "application"
 # ~~~~~
 # The secret key is used to secure cryptographics functions.
 # If you deploy your application to several instances be sure to use the same key!
-play.crypto.secret="<%= @application_secret %>"
 play.http.secret.key="<%= @application_secret %>"
 
 # Set session cookies to https only (not set in dev)

--- a/modules/licensify/templates/gds-licensify-feed-config.conf.erb
+++ b/modules/licensify/templates/gds-licensify-feed-config.conf.erb
@@ -8,7 +8,6 @@ include "application"
 # ~~~~~
 # The secret key is used to secure cryptographics functions.
 # If you deploy your application to several instances be sure to use the same key!
-play.crypto.secret="<%= @application_secret %>"
 play.http.secret.key="<%= @application_secret %>"
 
 # Set session cookies to https only (not set in dev)


### PR DESCRIPTION
As part of the Licensify Play 2.5 to 2.6 migration, we added the new play.http.secret.key parameter, and kept the existing one so that we could seamlessly change version

Now that we're running on newer Play versions, the older play.crypto.secret is no longer needed, and is bringing up deprecation warnings when deploying a new release of Licensify