### PR TITLE
Update Slack channel for Deploy_app_downstream job

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/deploy_app_downstream.pp
+++ b/modules/govuk_jenkins/manifests/jobs/deploy_app_downstream.pp
@@ -30,7 +30,7 @@ class govuk_jenkins::jobs::deploy_app_downstream (
   $github_api_token = undef,
   $smokey_pre_check = true,
   $release_app_bearer_token = undef,
-  $slack_channel = '#govuk-developers',
+  $slack_channel = 'govuk-deploy,govuk-developers',
   $slack_credential_id = 'slack-notification-token',
   $slack_team_domain = 'gds',
 ) {

--- a/modules/govuk_jenkins/templates/jobs/deploy_app_downstream.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_app_downstream.yaml.erb
@@ -109,6 +109,6 @@
             auth-token-credential-id: <%= @slack_credential_id %>
             build-server-url: <%= @slack_build_server_url %>
             notify-every-failure: true
-            room: "<%= @slack_channel %>"
+            room: <%= @slack_channel %>
             include-custom-message: true
             custom-message: "Automatic deployment failed for $TARGET_APPLICATION $TAG"


### PR DESCRIPTION
[Trello card](https://trello.com/c/DfHMPCl9/2972-fix-slack-alerts-for-failures-in-the-continuous-deployment-pipeline-5)

If any step in the continuous deployment pipeline fails, we should receive a Slack notification.

Notifications for the `Deploy_App` job appear to be working, but when `Deploy_App_Downstream` fails, we don't get notified on Slack. Here's an example of a failed job for which we received no notification: https://deploy.integration.publishing.service.gov.uk/job/Deploy_App_Downstream/7394/

After comparing the configuration of this job against one with Slack notifications that do work (`Deploy_CDN`), I noticed the following differences:

- `Deploy_CDN` posts to the `#govuk-deploy` channel, `Deploy_App_Downstream` posts to `#govuk-developers` (maybe the Jenkins app doesn't have permission to post in `#govuk-developers`?)
- In the YAML for `Deploy_CDN`, the channel is specified as `govuk-deploy`. In the YAML for `Deploy_App_Downstream`, the channel is specified as `"#govuk-developers"`, with quotes and a leading `#`.

I don't think either of these differences should have caused this issue, but I also can't think of anything else that might have done so.

This PR changes the configuration of `Deploy_App_Downstream` to try to post to both `govuk-deploy` and `govuk-developers` (comma-separated lists of channels are supported according to [the `jenkins-job-builder` docs](https://jenkins-job-builder.readthedocs.io/en/latest/publishers.html#publishers.slack)), and removes the quotes and the leading `#`, in case that was the source of the issue.