### PR TITLE
Update Jenkins Slack plugin to v2.23

### DIFF
--- a/hieradata_aws/class/integration/ci_master.yaml
+++ b/hieradata_aws/class/integration/ci_master.yaml
@@ -369,7 +369,7 @@ govuk_jenkins::plugins:
   sitemonitor:
     version: '0.6'
   slack:
-    version: '2.20'
+    version: '2.23'
   snakeyaml-api:
     version: '1.29.1'
   ssh-agent:

--- a/hieradata_aws/class/jenkins.yaml
+++ b/hieradata_aws/class/jenkins.yaml
@@ -290,7 +290,7 @@ govuk_jenkins::plugins:
   sitemonitor:
     version: '0.6'
   slack:
-    version: '2.20'
+    version: '2.23'
   snakeyaml-api:
     version: '1.29.1'
   ssh-agent:


### PR DESCRIPTION
[Trello card](https://trello.com/c/DfHMPCl9/2972-fix-slack-alerts-for-failures-in-the-continuous-deployment-pipeline-5)

The `Deploy_App_Downstream` Jenkins job is configured to send us a Slack notification on failure[^1], but this is not working. I think the root cause is that we’re relying on functionality introduced in v2.23[^2] of the Slack plugin for Jenkins (i.e. the OnEveryFailure option).

I don't think `jenkins-job-builder` needs upgrading - support for the "notify every failure" option was added in v3.1.0[^3], which we're already using[^4].

[^1]: [https://github.com/alphagov/govuk-puppet/blob/4bb428ce2134f6646bce6abb5b56c319f897a41a/modules/govuk_jenkins/templates/jobs/deploy_app_downstream.yaml.erb](https://github.com/alphagov/govuk-puppet/blob/4bb428ce2134f6646bce6abb5b56c319f897a41a/modules/govuk_jenkins/templates/jobs/deploy_app_downstream.yaml.erb#L106)
[^2]: https://github.com/jenkinsci/slack-plugin/releases/tag/slack-2.23
[^3]: https://groups.google.com/g/jenkins-job-builder/c/enJ_grH_s-k?pli=1
[^4]: [https://github.com/alphagov/govuk-puppet/blob/32c1bbbb10067078c1406170666a135b4a10aaea/modules/govuk_jenkins/manifests/job_builder.pp](https://github.com/alphagov/govuk-puppet/blob/32c1bbbb10067078c1406170666a135b4a10aaea/modules/govuk_jenkins/manifests/job_builder.pp#L46)