### PR TITLE
Remove ASSET_HOST for Whitehall

### DIFF
--- a/hieradata_aws/class/whitehall_frontend.yaml
+++ b/hieradata_aws/class/whitehall_frontend.yaml
@@ -1,5 +1,4 @@
 ---
-govuk::apps::whitehall::asset_host: "%{hiera('govuk::deploy::config::website_root')}"
 govuk::apps::whitehall::configure_frontend: true
 govuk::apps::whitehall::vhost: 'whitehall-frontend'
 govuk::apps::whitehall::vhost_protected: false

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1463,6 +1463,7 @@ rcs::tmptime: '7'
 router::assets_origin::whitehall_uploaded_assets_routes:
   - '/government/placeholder'
   - '~ ^/government/uploads/system/uploads/attachment_data/file/[0-9]+/.*/preview$'
+  - '~ ^/assets/whitehall/'
 
 router::assets_origin::asset_manager_uploaded_assets_routes:
   - '/government/uploads/'

--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -22,10 +22,6 @@
 #   Rack limit for how many form parameters it will parse.
 #   Default: undef
 #
-# [*asset_host*]
-#   The URL that will be used as a prefix for whitehall assets.
-#   Default: undef
-#
 # [*asset_manager_bearer_token*]
 #   The bearer token to use when communicating with Asset Manager.
 #   Default: undef
@@ -152,7 +148,6 @@ class govuk::apps::whitehall(
   $admin_db_username = undef,
   $admin_key_space_limit = undef,
   $asset_manager_bearer_token = undef,
-  $asset_host = undef,
   $basic_auth_credentials = undef,
   $configure_frontend = false,
   $configure_admin = false,
@@ -389,14 +384,6 @@ class govuk::apps::whitehall(
     "${title}-RUMMAGER_BEARER_TOKEN":
       varname => 'RUMMAGER_BEARER_TOKEN',
       value   => $rummager_bearer_token;
-  }
-
-  if $asset_host != undef {
-    govuk::app::envvar {
-      "${title}-ASSET_HOST":
-        varname => 'ASSET_HOST',
-        value   => $asset_host;
-    }
   }
 
   if $basic_auth_credentials != undef {


### PR DESCRIPTION
ASSET_HOST was set originally to deal with [CSV asset preview pages](https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/560889/LEMPRD_201610180000-CSV-GOVUK.csv/preview) that were hosted on the assets.publishing.service.gov.uk domain, but rendered by Whitehall. A proxy is set up to now also forward Whitehall asset (css, js etc) requests on the asset domain. This means that we can use relative paths for assets as they are now able to be served on the same domain.