### PR TITLE
Stop spamming #govuk-developers

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/deploy_app_downstream.pp
+++ b/modules/govuk_jenkins/manifests/jobs/deploy_app_downstream.pp
@@ -30,7 +30,7 @@ class govuk_jenkins::jobs::deploy_app_downstream (
   $github_api_token = undef,
   $smokey_pre_check = true,
   $release_app_bearer_token = undef,
-  $slack_channel = 'govuk-deploy',
+  $slack_channel = 'govuk-deploy,govuk-2ndline-tech',
   $slack_credential_id = 'slack-notification-token',
   $slack_team_domain = 'gds',
 ) {

--- a/modules/govuk_jenkins/manifests/jobs/deploy_app_downstream.pp
+++ b/modules/govuk_jenkins/manifests/jobs/deploy_app_downstream.pp
@@ -30,7 +30,7 @@ class govuk_jenkins::jobs::deploy_app_downstream (
   $github_api_token = undef,
   $smokey_pre_check = true,
   $release_app_bearer_token = undef,
-  $slack_channel = 'govuk-deploy,govuk-developers',
+  $slack_channel = 'govuk-deploy',
   $slack_credential_id = 'slack-notification-token',
   $slack_team_domain = 'gds',
 ) {


### PR DESCRIPTION
A lot of `Deploy_App_Downstream` jobs are failing at the moment due to issues with Smokey - each failure causes a new notification to be sent to `#govuk-developers`, which is noisy and unhelpful. Let's stop that, at least until we've fixed the issue with Smokey.