### PR TITLE
Add staging eks as a target for goreplay

### DIFF
--- a/hieradata_aws/class/staging/cache.yaml
+++ b/hieradata_aws/class/staging/cache.yaml
@@ -2,6 +2,7 @@
 router::gor::add_hosts: false
 router::gor::replay_targets:
   'www-origin.integration.publishing.service.gov.uk': {}
+  'www-origin.eks.staging.govuk.digital': {}
 router::gor::http_disallow_url:
   - 'apply-for-a-licence/payment'
   - 'apply-for-a-licence/redirect'


### PR DESCRIPTION
https://trello.com/c/bIw2FkZ9/992-look-into-goreplay-and-add-eks-as-a-target

Following similar logic here,
https://github.com/alphagov/govuk-puppet/commit/52929e9c1d495ab2c20c82a8621a21536b08e142
setting eks staging router as a target from aws staging router.