### PR TITLE
Add GA4 tracking ENV VARS to Staging

### DIFF
--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -226,6 +226,9 @@ govuk::apps::specialist_publisher::aws_s3_bucket_name: 'govuk-staging-specialist
 govuk::apps::specialist_publisher::enabled: true
 govuk::apps::specialist_publisher::govuk_notify_template_id: "112842bb-d8a4-4511-90de-57dc5c8f27ec"
 govuk::apps::static::ga_universal_id: 'UA-26179049-20'
+govuk::apps::static::google_tag_manager_auth: "oJWs562CxSIjZKn_GlB5Bw"
+govuk::apps::static::google_tag_manager_id: "GTM-MG7HG5W"
+govuk::apps::static::google_tag_manager_preview: "env-5"
 govuk::apps::static::govuk_personalisation_manage_uri: 'https://integration.account.gov.uk?link=manage-account'
 govuk::apps::static::govuk_personalisation_security_uri: 'https://integration.account.gov.uk?link=security-privacy'
 govuk::apps::static::govuk_personalisation_feedback_uri: 'https://signin.account.gov.uk/support'


### PR DESCRIPTION
Add GA4 tracking ENV VARS to Staging for deployment.

[Deploying Puppet Doc](https://docs.publishing.service.gov.uk/manual/deploy-puppet.html)

[Trello](https://trello.com/c/dWRggQ2x/208-add-ga4-env-vars-for-staging-deploy)
[Trello - Values](https://trello.com/c/YgdDINY2/61-set-up-gtm-container-with-custom-environments#comment-620ba0da0f13a04efb848e26)