### PR TITLE
Add GA4 tracking ENV VARS to Production

### DIFF
--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -238,6 +238,9 @@ govuk::apps::specialist_publisher::aws_s3_bucket_name: 'govuk-production-special
 govuk::apps::specialist_publisher::enabled: true
 govuk::apps::specialist_publisher::govuk_notify_template_id: "e00e89f5-b622-4dcb-8f30-e6c70231a940"
 govuk::apps::static::ga_universal_id: 'UA-26179049-1'
+govuk::apps::static::google_tag_manager_auth: "oSryE57NbEZexEB0vGGuS"
+govuk::apps::static::google_tag_manager_id: "GTM-MG7HG5W"
+govuk::apps::static::google_tag_manager_preview: "env-1"
 govuk::apps::static::govuk_personalisation_manage_uri: 'https://account.gov.uk?link=manage-account'
 govuk::apps::static::govuk_personalisation_security_uri: 'https://account.gov.uk?link=security-privacy'
 govuk::apps::static::govuk_personalisation_feedback_uri: 'https://signin.account.gov.uk/support'


### PR DESCRIPTION
Add GA4 tracking ENV VARS to Staging for deployment.

[Deploying Puppet Doc](https://docs.publishing.service.gov.uk/manual/deploy-puppet.html)

[Trello](https://trello.com/c/esJ3q1lG/214-add-ga4-env-vars-for-production-deploy)
[Trello - Values](https://trello.com/c/YgdDINY2/61-set-up-gtm-container-with-custom-environments#comment-620ba0da0f13a04efb848e26)