### PR TITLE
Removed unused GTM vars

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -48,9 +48,6 @@ govuk::apps::feedback::govuk_notify_accessible_format_request_template_id: '47ce
 govuk::apps::frontend::govuk_notify_template_id: '1fc69d3a-09a2-40f9-852b-03f6fcef5340'
 govuk::apps::frontend::govuk_personalisation_manage_uri: 'https://integration.account.gov.uk?link=manage-account'
 govuk::apps::frontend::govuk_personalisation_your_account_uri: 'https://integration.account.gov.uk'
-govuk::apps::government_frontend::google_tag_manager_auth: "C7iYdcsOlYgGmiUJjZKrHQ"
-govuk::apps::government_frontend::google_tag_manager_id: "GTM-MG7HG5W"
-govuk::apps::government_frontend::google_tag_manager_preview: "env-4"
 govuk::apps::govuk_crawler_worker::enabled: false
 govuk::apps::govuk_crawler_worker::disable_during_data_sync: true
 govuk::apps::hmrc_manuals_api::allow_unknown_hmrc_manual_slugs: true


### PR DESCRIPTION
## What
Remove unused Google Tag Manager env vars.

## Why
They were originally added for testing GTM configuration on government-frontend, but the approach has changed and these vars have been unused for some time.

Added in: https://github.com/alphagov/govuk-puppet/pull/11550

