### PR TITLE
Remove FACT_CHECK_ADDRESS_FORMAT env var

### DIFF
--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -211,7 +211,6 @@ govuk::apps::link_checker_api::govuk_basic_auth_credentials: "%{hiera('http_user
 govuk::apps::local_links_manager::local_links_manager_passive_checks: true
 govuk::apps::local_links_manager::run_links_ga_export: true
 
-govuk::apps::publisher::fact_check_address_format: 'factcheck+production-{id}@alphagov.co.uk'
 govuk::apps::publisher::fact_check_reply_to_id: 'e739d23a-b761-44af-9a99-a1eba0b75c7e'
 govuk::apps::publisher::fact_check_reply_to_address: 'govuk-fact-check@digital.cabinet-office.gov.uk'
 govuk::apps::publisher::email_group_dev: 'govuk-dev@digital.cabinet-office.gov.uk'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -192,7 +192,6 @@ govuk::apps::manuals_publisher::mongodb_password: "%{hiera('govuk::apps::asset_m
 govuk::apps::maslow::mongodb_nodes: "%{hiera('govuk::apps::asset_manager::mongodb_nodes')}"
 govuk::apps::maslow::mongodb_username: "%{hiera('govuk::apps::asset_manager::mongodb_username')}"
 govuk::apps::maslow::mongodb_password: "%{hiera('govuk::apps::asset_manager::mongodb_password')}"
-govuk::apps::publisher::fact_check_address_format: 'factcheck+staging-{id}@alphagov.co.uk'
 govuk::apps::publisher::mongodb_nodes: "%{hiera('govuk::apps::asset_manager::mongodb_nodes')}"
 govuk::apps::publisher::mongodb_username: "%{hiera('govuk::apps::asset_manager::mongodb_username')}"
 govuk::apps::publisher::mongodb_password: "%{hiera('govuk::apps::asset_manager::mongodb_password')}"

--- a/modules/govuk/manifests/apps/publisher.pp
+++ b/modules/govuk/manifests/apps/publisher.pp
@@ -60,9 +60,6 @@
 # [*oauth_secret*]
 #   The OAuth secret used by GDS-SSO to authenticate the app to GOV.UK Signon
 #
-# [*fact_check_address_format*]
-#   The address format used for sending fact checks
-#
 # [*fact_check_username*]
 #   The username to use for Basic Auth for fact check
 #
@@ -121,7 +118,6 @@ class govuk::apps::publisher(
     $sentry_dsn = undef,
     $oauth_id = undef,
     $oauth_secret = undef,
-    $fact_check_address_format = undef,
     $fact_check_subject_prefix = undef,
     $fact_check_username = undef,
     $fact_check_password = undef,
@@ -214,9 +210,6 @@ class govuk::apps::publisher(
       "${title}-GDS_SSO_OAUTH_SECRET":
         varname => 'GDS_SSO_OAUTH_SECRET',
         value   => $oauth_secret;
-      "${title}-FACT_CHECK_ADDRESS_FORMAT":
-        varname => 'FACT_CHECK_ADDRESS_FORMAT',
-        value   => $fact_check_address_format;
       "${title}-FACT_CHECK_SUBJECT_PREFIX":
         varname => 'FACT_CHECK_SUBJECT_PREFIX',
         value   => $fact_check_subject_prefix;


### PR DESCRIPTION
This env var has no longer had an effect since the corresponding code was removed in August 2020 [1]. We can now remove this env var.

The motivation for making this change was to make it clearer that the alphagov.co.uk is not used as part of fact-checking as this was a recent point of confusion.

[1]: https://github.com/alphagov/publisher/commit/c72119346523e3a89067ad3fac1d74abf5dd0df1