### PR TITLE
Add Referrer-Policy header

### DIFF
--- a/modules/nginx/spec/defines/nginx__config__vhost__proxy_spec.rb
+++ b/modules/nginx/spec/defines/nginx__config__vhost__proxy_spec.rb
@@ -104,6 +104,11 @@ describe 'nginx::config::vhost::proxy', :type => :define do
       is_expected.to contain_nginx__config__site('rabbit')
         .with_content(/add_header X-Content-Type-Options \"nosniff\";/)
     end
+
+    it 'should add the Referrer-Policy header' do
+      is_expected.to contain_nginx__config__site('rabbit')
+        .with_content(/add_header Referrer-Policy \"strict-origin-when-cross-origin\";/)
+    end
   end
 
   context 'if in aws and deny_crawlers set to true' do

--- a/modules/nginx/templates/proxy-vhost.conf
+++ b/modules/nginx/templates/proxy-vhost.conf
@@ -83,6 +83,7 @@ server {
   proxy_read_timeout <%= @read_timeout %>;
 
   add_header X-Content-Type-Options "nosniff";
+  add_header Referrer-Policy "strict-origin-when-cross-origin";
 
   access_log <%= @logpath %>/<%= @access_log %> timed_combined;
   access_log <%= @logpath %>/<%= @json_access_log %> json_event;


### PR DESCRIPTION
The Referrer-Policy HTTP header controls how much referrer information (sent with the Referer header) should be included with requests.

This commit sets the header to "strict-origin-when-cross-origin" to aid in security.

The header will not allow any information to be sent when a scheme downgrade happens (the user is navigating from HTTPS to HTTP).

Trello: https://trello.com/c/2Q31FJne/2927-investigate-adding-referrer-policy-header