### PR TITLE
Fix puppet failing for jenkins in staging

### DIFF
--- a/modules/govuk_jenkins/manifests/init.pp
+++ b/modules/govuk_jenkins/manifests/init.pp
@@ -136,6 +136,21 @@ class govuk_jenkins (
     provider => 'pip3',
   }
 
+  package { 'certifi':
+    ensure   => '2021.10.8',
+    provider => pip3,
+  }
+
+  package { 'Jinja2':
+    ensure   => '2.11.2',
+    provider => pip3,
+  }
+
+  package { 'MarkupSafe':
+    ensure   => '1.1.1',
+    provider => pip3,
+  }
+
 
   # Runtime dependency of: https://github.com/alphagov/search-analytics
   ensure_packages(['libffi-dev'])

--- a/modules/govuk_jenkins/manifests/package.pp
+++ b/modules/govuk_jenkins/manifests/package.pp
@@ -55,6 +55,7 @@ class govuk_jenkins::package (
     repo               => false,
     install_java       => false,
     configure_firewall => false,
+    cli                => false,
     config_hash        => $config,
     manage_user        => false,
     manage_group       => false,


### PR DESCRIPTION
The jenkins server was rebuilt a few days ago, and it revealed that the jenkins-job-builder and jenkins install manifests weren't working correctly.
This PR pins some python packages to versions that work on Python 3.4, and disable cli helper creation in the external jenkins module we use, since that is now broken (it doesn't work with the version of jenkins we use)