### PR TITLE
Add missing `g` to GTM auth code

### DIFF
--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -237,7 +237,7 @@ govuk::apps::specialist_publisher::aws_s3_bucket_name: 'govuk-production-special
 govuk::apps::specialist_publisher::enabled: true
 govuk::apps::specialist_publisher::govuk_notify_template_id: "e00e89f5-b622-4dcb-8f30-e6c70231a940"
 govuk::apps::static::ga_universal_id: 'UA-26179049-1'
-govuk::apps::static::google_tag_manager_auth: "oSryE57NbEZexEB0vGGuS"
+govuk::apps::static::google_tag_manager_auth: "oSryE57NbEZexEB0vGGuSg"
 govuk::apps::static::google_tag_manager_id: "GTM-MG7HG5W"
 govuk::apps::static::google_tag_manager_preview: "env-1"
 govuk::apps::static::govuk_personalisation_manage_uri: 'https://account.gov.uk?link=manage-account'


### PR DESCRIPTION
## What
Fix the typo in the GTM auto code.
## Why
The correct GTM auth code is: `oSryE57NbEZexEB0vGGuSg`. However, the original entry was copied from [this `SUMMARY` section](https://trello.com/c/YgdDINY2/61-set-up-gtm-container-with-custom-environments#comment-620ba0da0f13a04efb848e26) where the ending `g` is missing...

<img width="513" alt="Screenshot 2022-09-22 at 11 26 51" src="https://user-images.githubusercontent.com/44037625/191723774-bc884c9f-3d84-4ff9-9c57-c29f5a08a594.png">
