### PR TITLE
Add redis_host and redis_port vars for Feedback

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -545,6 +545,9 @@ govuk::apps::email_alert_service::rabbitmq::queue_size_warning_threshold: 5
 govuk::apps::email_alert_service::enable_unpublishing_queue_consumer: true
 govuk::apps::email_alert_service::enable_subscriber_list_update_queue_consumers: true
 
+govuk::apps::feedback::redis_host: "%{hiera('sidekiq_host')}"
+govuk::apps::feedback::redis_port: "%{hiera('sidekiq_port')}"
+
 govuk::apps::finder_frontend::enabled: true
 govuk::apps::finder_frontend::unicorn_worker_processes: "6"
 


### PR DESCRIPTION
Rails assets are failing to precompile for a [Redis upgrade to 5.0.4](https://github.com/alphagov/feedback/pull/1500) + [logs](https://ci.integration.publishing.service.gov.uk/job/feedback/job/dependabot%252Fbundler%252Fredis-5.0.4/3/console). The build only appears to fail on Jenkins and therefore seems to be a configuration issue.

This change should mean that the [redis_host and redis_port variables](https://github.com/alphagov/govuk-puppet/blob/2a32ee4c583a4d1aa4f04a5b88c96084280562bb/modules/govuk/manifests/apps/feedback.pp#L66-L67) are set.

Thanks @leenagupte for helping me to investigate this!