### PR TITLE
Remove export to s3 bucket ask service

### DIFF
--- a/hieradata_aws/class/integration/jenkins.yaml
+++ b/hieradata_aws/class/integration/jenkins.yaml
@@ -54,10 +54,8 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::whitehall_publisher_notifications
 
 govuk_jenkins::jobs::ask_export::smart_survey_config: 'draft'
-govuk_jenkins::jobs::ask_export::aws_region: 'eu-west-1'
 govuk_jenkins::jobs::ask_export::folder_id_cabinet_office: '1RH44n_9Ps_Syeq7o-xJFuFVKN-kkZMsW'
 govuk_jenkins::jobs::ask_export::folder_id_third_party: '1RH44n_9Ps_Syeq7o-xJFuFVKN-kkZMsW'
-govuk_jenkins::jobs::ask_export::s3_bucket_name_gcs_public_questions: 'govuk-uk-integration-ask-export'
 govuk_jenkins::jobs::ask_export::run_daily: false
 
 govuk_jenkins::jobs::search_api_learn_to_rank::train_instance_type: ml.c5.xlarge

--- a/hieradata_aws/class/production/jenkins.yaml
+++ b/hieradata_aws/class/production/jenkins.yaml
@@ -116,7 +116,6 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::whitehall_run_broken_link_checker
 
 govuk_jenkins::jobs::ask_export::smart_survey_config: 'live'
-govuk_jenkins::jobs::ask_export::aws_region: 'eu-west-2'
 govuk_jenkins::jobs::ask_export::run_daily: true
 
 govuk_jenkins::jobs::deploy_cdn::enable_slack_notifications: true

--- a/modules/govuk_jenkins/manifests/jobs/ask_export.pp
+++ b/modules/govuk_jenkins/manifests/jobs/ask_export.pp
@@ -29,18 +29,6 @@
 # [*folder_id_third_party*]
 #   ID of the folder for third party export
 #
-# [*aws_region*]
-#   Region that the s3 bucket is in
-#
-# [*aws_access_key*]
-#   Access key needed for the AWS account
-#
-# [*aws_secret_access_key*]
-#   Secret access key for authentication of AWS account
-#
-# [*s3_bucket_name_gcs_public_questions*]
-#   Name of the bucket where responses are held
-#
 # [*run_daily*]
 #   A flag to decide whether the job runs every day or not
 #
@@ -53,10 +41,6 @@ class govuk_jenkins::jobs::ask_export (
   $google_private_key = undef,
   $folder_id_cabinet_office = undef,
   $folder_id_third_party = undef,
-  $aws_region = undef,
-  $aws_access_key = undef,
-  $aws_secret_access_key = undef,
-  $s3_bucket_name_gcs_public_questions = undef,
   $run_daily = false,
 ) {
 

--- a/modules/govuk_jenkins/templates/jobs/ask_export.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/ask_export.yaml.erb
@@ -52,12 +52,10 @@
       - shell: |
           set -e
           export SMART_SURVEY_CONFIG=<%= @smart_survey_config %>
-          export AWS_REGION=<%= @aws_region %>
           export GOOGLE_ACCOUNT_TYPE='service_account'
           export GOOGLE_CLOUD_PROJECT='govuk-ask-export-1589383422955'
           export FOLDER_ID_CABINET_OFFICE=<%= @folder_id_cabinet_office %>
           export FOLDER_ID_THIRD_PARTY=<%= @folder_id_third_party %>
-          export S3_BUCKET_NAME_GCS_PUBLIC_QUESTIONS=<%= @s3_bucket_name_gcs_public_questions %>
           bundle install --deployment
           bundle exec rake run_exports
           bundle exec rake run_cleanup
@@ -84,9 +82,3 @@
             - name: GOOGLE_PRIVATE_KEY
               password:
                 '<%= @google_private_key %>'
-            - name: AWS_ACCESS_KEY
-              password:
-                '<%= @aws_access_key %>'
-            - name: AWS_SECRET_ACCESS_KEY
-              password:
-                '<%= @aws_secret_access_key %>'


### PR DESCRIPTION
[Trello](https://trello.com/c/SOvnuRh1/224-no-longer-export-ask-service-data-to-s3)

There was a critical alert in Production due to the Ask data export failing to export to S3. [Logs here](https://deploy.blue.production.govuk.digital/job/govuk-ask-export/289/console)

 Given that we do not own the bucket and suspect that it isn't in use, we have decided to remove exporting the Ask Service data to S3. The data will continue to be exported to Google Drive.

Do not merge until [the govuk-ask-export](https://github.com/alphagov/govuk-ask-export/pull/62) changes have been merged.