### PR TITLE
Enable CD for signon

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1118,6 +1118,7 @@ govuk_jenkins::jobs::deploy_app_downstream::applications:
   service-manual-frontend: {}
   service-manual-publisher: {}
   sidekiq-monitoring: {}
+  signon: {}
   smartanswers:
     repository: 'smart-answers'
   specialist-publisher: {}


### PR DESCRIPTION
Do not merge yet, depends on:

* [Require production access to merge publishing api](https://github.com/alphagov/govuk-saas-config/pull/124)
* [Adding PR template](https://github.com/alphagov/signon/pull/1960)
* which in turn depends on various PRs to increase test coverage

[Trello](https://trello.com/c/jBtHWHBh/14-enable-continuous-deployment-for-signon)