### PR TITLE
Add gtag env var for static

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -85,6 +85,7 @@ govuk::apps::static::ga_universal_id: 'UA-26179049-22'
 govuk::apps::static::google_tag_manager_auth: "C7iYdcsOlYgGmiUJjZKrHQ"
 govuk::apps::static::google_tag_manager_id: "GTM-MG7HG5W"
 govuk::apps::static::google_tag_manager_preview: "env-4"
+govuk::apps::static::gtag_id: "G-9BX34Z34D0"
 govuk::apps::static::govuk_personalisation_manage_uri: 'https://integration.account.gov.uk?link=manage-account'
 govuk::apps::static::govuk_personalisation_security_uri: 'https://integration.account.gov.uk?link=security-privacy'
 govuk::apps::static::govuk_personalisation_feedback_uri: 'https://signin.account.gov.uk/support'


### PR DESCRIPTION
- will be used on integration to test using gtag instead of GTM
- analytics code is written to look for this variable and use gtag and not GTM if found

Specifically:

- https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-core.js#L13
- https://github.com/alphagov/static/blob/main/app/assets/javascripts/analytics.js.erb#L149