### PR TITLE
Enable continuous deployment for Link Checker API

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1107,6 +1107,7 @@ govuk_jenkins::jobs::deploy_app_downstream::applications:
   hmrc-manuals-api: {}
   imminence: {}
   info-frontend: {}
+  link-checker-api: {}
   local-links-manager: {}
   locations-api: {}
   manuals-publisher: {}


### PR DESCRIPTION
This will actually make the application continuously deployed.

Dependent on the following being merged:
- https://github.com/alphagov/link-checker-api/pull/559
- https://github.com/alphagov/link-checker-api/pull/560
- https://github.com/alphagov/govuk-saas-config/pull/125

[Trello card](https://trello.com/c/xyWyqqhq/15-enable-continuous-deployment-for-link-checker-api)