### PR TITLE
Ensure the Fastly API token is only sent to GOV.UK URLs

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/clear_cdn_cache.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/clear_cdn_cache.yaml.erb
@@ -35,6 +35,13 @@
               echo "expected $cdn_url to be an HTTPS URL"
               exit 1
             fi
+            
+            cdn_domain=`echo $cdn_url | awk -F[/:] '{print $4}'`
+            if [[ "${cdn_domain: -6}" != "gov.uk" ]]; then
+              # Ensure the Fastly API token is only sent to GOV.UK URLs
+              echo "expected $cdn_url to be a GOV.UK URL"
+              exit 1
+            fi
 
             if [ -n "$local_varnish_url" ]; then
               echo $local_varnish_url


### PR DESCRIPTION
This PR is to allow Fastly API tokens to be sent to GOV.UK URLs only in the Clear CDN Cache job in Jenkins. 

Trello: https://trello.com/c/Fs4Kz4Ky/2978-update-jenkins-clear-cdn-cache-job-to-only-accept-govuk-urls-2