### PR TITLE
Add env vars for encryption secrets for signon

### DIFF
--- a/modules/govuk/manifests/apps/signon.pp
+++ b/modules/govuk/manifests/apps/signon.pp
@@ -4,6 +4,12 @@
 #
 # === Parameters
 #
+# [*active_record_primary_key*]
+#   The active record primary key used for the encrypted otp_secret_keys
+#
+# [*active_record_key_derivation_salt*]
+#   The active record key derivation salt used for the encrypted otp_secret_keys  
+#
 # [*db_hostname*]
 #   The hostname of the database server to use in the DATABASE_URL.
 #
@@ -67,6 +73,8 @@
 #   The template ID used to send email via GOV.UK Notify.
 #
 class govuk::apps::signon(
+  $active_record_primary_key = undef,
+  $active_record_key_derivation_salt = undef,
   $db_hostname = undef,
   $db_name = undef,
   $db_password = undef,
@@ -112,6 +120,12 @@ class govuk::apps::signon(
   }
 
   govuk::app::envvar {
+    "${title}-ACTIVE_RECORD_PRIMARY_KEY":
+      varname => 'ACTIVE_RECORD_PRIMARY_KEY',
+      value   => $active_record_primary_key;
+    "${title}-ACTIVE_RECORD_KEY_DERIVATION_SALT":
+      varname => 'ACTIVE_RECORD_KEY_DERIVATION_SALT',
+      value   => $active_record_key_derivation_salt;
     "${title}-DEVISE_PEPPER":
       varname => 'DEVISE_PEPPER',
       value   => $devise_pepper;


### PR DESCRIPTION
Done as part of the work to encrypt the otp_secret_keys in signon

Trello: https://trello.com/c/cikBzyF1/246-encrypt-2fa-secret-keys-in-sign-on