### PR TITLE
Revert "Remove ASSET_HOST for Static"

### DIFF
--- a/hieradata_aws/class/draft_frontend.yaml
+++ b/hieradata_aws/class/draft_frontend.yaml
@@ -7,5 +7,6 @@ govuk::apps::government_frontend::vhost: 'draft-government-frontend'
 govuk::apps::service_manual_frontend::vhost: 'draft-service-manual-frontend'
 govuk::apps::smartanswers::vhost: 'draft-smartanswers'
 
+govuk::apps::static::asset_host: "https://draft-origin.%{hiera('app_domain')}"
 govuk::apps::static::draft_environment: true
 govuk::apps::static::vhost: 'draft-static'

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -767,6 +767,7 @@ govuk::apps::smokey::smokey_signon_password: "%{hiera('smokey_signon_password')}
 govuk::apps::smokey::smokey_bearer_token: "%{hiera('smokey_bearer_token')}"
 govuk::apps::smokey::rate_limit_token: "%{hiera('smokey_rate_limit_token')}"
 
+govuk::apps::static::asset_host: "%{hiera('govuk::deploy::config::website_root')}"
 govuk::apps::static::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::static::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::static::unicorn_worker_processes: "8"

--- a/modules/govuk/manifests/apps/static.pp
+++ b/modules/govuk/manifests/apps/static.pp
@@ -28,6 +28,10 @@
 #   The bearer token to use when communicating with Publishing API.
 #   Default: undef
 #
+# [*asset_host*]
+#   The URL that will be used as a prefix for statics assets.
+#   Default: undef
+#
 # [*ga_universal_id*]
 #   The Google Analytics ID.
 #   Default: undef
@@ -72,6 +76,7 @@ class govuk::apps::static(
   $draft_environment = false,
   $secret_key_base = undef,
   $publishing_api_bearer_token = undef,
+  $asset_host = undef,
   $ga_universal_id = undef,
   $redis_host = undef,
   $redis_port = undef,
@@ -129,6 +134,9 @@ class govuk::apps::static(
     "${title}-PUBLISHING_API_BEARER_TOKEN":
       varname => 'PUBLISHING_API_BEARER_TOKEN',
       value   => $publishing_api_bearer_token;
+    "${title}-ASSET_HOST":
+      varname => 'ASSET_HOST',
+      value   => $asset_host;
     "${title}-GOOGLE_TAG_MANAGER_ID":
         varname => 'GOOGLE_TAG_MANAGER_ID',
         value   => $google_tag_manager_id;


### PR DESCRIPTION
Reverts alphagov/govuk-puppet#11801

We're currently experiencing an incident with Static, a factor of this is that we're somehow exposing the govuk.digital hostname with assets in production.

We think reverting this can resolve the problem temporarily while a fuller fix is developed.