### PR TITLE
Show env and tag in Slack message when deploying Puppet

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -160,6 +160,8 @@ govuk_jenkins::jobs::content_publisher_whitehall_import::enable_slack_notificati
 govuk_jenkins::jobs::deploy_app_downstream::deploy_environment: 'staging'
 govuk_jenkins::jobs::deploy_app_downstream::deploy_url: 'deploy.blue.staging.govuk.digital'
 
+govuk_jenkins::jobs::deploy_puppet::deploy_environment: 'integration'
+
 govuk_jenkins::jobs::deploy_smokey_downstream::deploy_url: 'deploy.blue.staging.govuk.digital'
 
 govuk_jenkins::jobs::deploy_dns::gce_project_id: 'govuk-integration'

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -558,3 +558,5 @@ postfix::rewrite_mail_list: 'machine.email.carrenza'
 nginx::config::stack_network_prefix: '10.13.0'
 
 govuk_jenkins::jobs::deploy_app::deploy_downstream: false
+
+govuk_jenkins::jobs::deploy_puppet::deploy_environment: 'production'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -316,6 +316,8 @@ govuk_jenkins::jobs::data_sync_complete_staging::signon_domains_to_migrate:
 govuk_jenkins::jobs::deploy_app_downstream::deploy_environment: 'production'
 govuk_jenkins::jobs::deploy_app_downstream::deploy_url: 'deploy.blue.production.govuk.digital'
 
+govuk_jenkins::jobs::deploy_puppet::deploy_environment: 'staging'
+
 govuk_jenkins::jobs::deploy_smokey_downstream::deploy_url: 'deploy.blue.production.govuk.digital'
 
 govuk_jenkins::jobs::deploy_dns::gce_client_name: 'govuk-dns-deploy'

--- a/modules/govuk_jenkins/manifests/jobs/deploy_puppet.pp
+++ b/modules/govuk_jenkins/manifests/jobs/deploy_puppet.pp
@@ -13,10 +13,15 @@
 # [*commitish*]
 #   The commitish that the job should deploy by default. Defaults to 'release'
 #
+# [*deploy_environment*]
+#   The name of the environment in which Puppet is being deployed.
+#   This is used to make the Slack message more useful.
+#
 class govuk_jenkins::jobs::deploy_puppet (
   $auth_token = undef,
   $commitish   = 'release',
   $enable_slack_notifications = false,
+  $deploy_environment = undef,
 ) {
   $environment_variables = $govuk_jenkins::environment_variables
   $slack_team_domain = 'gds'

--- a/modules/govuk_jenkins/templates/jobs/deploy_puppet.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_puppet.yaml.erb
@@ -58,6 +58,7 @@
             notify-repeated-failure: false
             include-test-summary: false
             room: <%= @slack_room %>
+            custom-message: "Deploying $TAG to <%= @deploy_environment %>"
         <%- end -%>
     wrappers:
         - ansicolor:


### PR DESCRIPTION
Takes inspiration from #11819. See at a glance which environment and which release is being deployed.