### PR TITLE
Change verification strategy for ci-master nodes

### DIFF
--- a/modules/govuk_jenkins/templates/ssh_slave_config.xml.erb
+++ b/modules/govuk_jenkins/templates/ssh_slave_config.xml.erb
@@ -12,7 +12,7 @@
     <credentialsId><%= @credentials_id %></credentialsId>
     <maxNumRetries>0</maxNumRetries>
     <retryWaitTime>0</retryWaitTime>
-    <sshHostKeyVerificationStrategy class="hudson.plugins.sshslaves.verifiers.KnownHostsFileKeyVerificationStrategy"/>
+    <sshHostKeyVerificationStrategy class="hudson.plugins.sshslaves.verifiers.NonVerifyingKeyVerificationStrategy"/>
   </launcher>
   <label><%= @labels %></label>
   <nodeProperties/>


### PR DESCRIPTION
Change the verification strategy for ci-master nodes from "known hosts file verification strategy" to
"non verifying verification strategy".
This will prevent errors when jenkins tries to connect to one of its nodes which ssh key has changed because it was reprovisioned. Note that in general it's a bad idea to disable
'StrictHostKeyChecking' but in this case we were already trying to bypass this check by deleting the known_hosts file. By disabling the check we don't have to care about managing the known_hosts file.

Trello: https://trello.com/c/RUWdTgH6/2975-change-how-ssh-host-keys-are-managed-on-jenkins-5