### PR TITLE
Pass through existing X-Forwarded-Host header

### DIFF
--- a/modules/nginx/templates/etc/nginx/nginx.conf.erb
+++ b/modules/nginx/templates/etc/nginx/nginx.conf.erb
@@ -85,6 +85,12 @@ http {
     gzip_types          text/css text/xml application/x-javascript application/atom+xml text/plain;
     gzip_vary           on;
 
+    # Map the passed in X-Forwarded-Host if present and default to the server host otherwise.
+    map $http_x_forwarded_host $proxy_add_x_forwarded_host {
+      default $http_x_forwarded_host;
+      ''      $http_host;
+    }
+
     include /etc/nginx/conf.d/*.conf;
     include /etc/nginx/sites-enabled/*;
 }

--- a/modules/router/templates/assets_origin.conf.erb
+++ b/modules/router/templates/assets_origin.conf.erb
@@ -14,7 +14,7 @@ server {
 <% end -%>
   proxy_set_header X-Real-IP $remote_addr;
   proxy_set_header X-Forwarded-Server $host;
-  proxy_set_header X-Forwarded-Host $host;
+  proxy_set_header X-Forwarded-Host $proxy_add_x_forwarded_host;
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 <% if @real_ip_header != '' -%>
 

--- a/modules/router/templates/router_include.conf.erb
+++ b/modules/router/templates/router_include.conf.erb
@@ -3,7 +3,7 @@ keepalive_timeout 120;
 proxy_set_header Host $http_host;
 proxy_set_header X-Real-IP $remote_addr;
 proxy_set_header X-Forwarded-Server $host;
-proxy_set_header X-Forwarded-Host $http_host;
+proxy_set_header X-Forwarded-Host $proxy_add_x_forwarded_host;
 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 proxy_redirect off;
 <% if @real_ip_header != '' -%>


### PR DESCRIPTION
For assets and www pass through the exisiting X-Forwarded-Host header if present on the client request. This ensures X-Forwarded-Host represents the original host (from Fastly). Previously we re-set the header to the Nginx host, which break redirects in Rails as it uses the header to determine the original host for the client request.