### PR TITLE
Add gtag env var details

### DIFF
--- a/modules/govuk/manifests/apps/static.pp
+++ b/modules/govuk/manifests/apps/static.pp
@@ -57,6 +57,9 @@
 # [*google_tag_manager_auth*]
 #   The identifier of an environment for Google Tag Manager
 #
+# [*gtag_id*]
+#   The ID for a Google Tag account
+#
 # [*govuk_personalisation_manage_uri*]
 #   URI for the account management page.
 #
@@ -84,6 +87,7 @@ class govuk::apps::static(
   $google_tag_manager_id = undef,
   $google_tag_manager_preview = undef,
   $google_tag_manager_auth = undef,
+  $gtag_id = undef,
   $govuk_personalisation_manage_uri = undef,
   $govuk_personalisation_security_uri = undef,
   $govuk_personalisation_feedback_uri = undef,
@@ -146,6 +150,9 @@ class govuk::apps::static(
     "${title}-GOOGLE_TAG_MANAGER_AUTH":
         varname => 'GOOGLE_TAG_MANAGER_AUTH',
         value   => $google_tag_manager_auth;
+    "${title}-GTAG_ID":
+        varname => 'GTAG_ID',
+        value   => $gtag_id;
     "${title}-GOVUK-PERSONALISATION-MANAGE-URI":
       varname => 'GOVUK_PERSONALISATION_MANAGE_URI',
       value   => $govuk_personalisation_manage_uri;


### PR DESCRIPTION
Add the missing bits to make the `gtag_id` env var work on integration, as originally added in: https://github.com/alphagov/govuk-puppet/pull/11826

This is for testing of gtag on integration only.