### PR TITLE
Remove ASSET_HOST for Static

### DIFF
--- a/hieradata_aws/class/draft_frontend.yaml
+++ b/hieradata_aws/class/draft_frontend.yaml
@@ -7,6 +7,5 @@ govuk::apps::government_frontend::vhost: 'draft-government-frontend'
 govuk::apps::service_manual_frontend::vhost: 'draft-service-manual-frontend'
 govuk::apps::smartanswers::vhost: 'draft-smartanswers'
 
-govuk::apps::static::asset_host: "https://draft-origin.%{hiera('app_domain')}"
 govuk::apps::static::draft_environment: true
 govuk::apps::static::vhost: 'draft-static'

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -767,7 +767,6 @@ govuk::apps::smokey::smokey_signon_password: "%{hiera('smokey_signon_password')}
 govuk::apps::smokey::smokey_bearer_token: "%{hiera('smokey_bearer_token')}"
 govuk::apps::smokey::rate_limit_token: "%{hiera('smokey_rate_limit_token')}"
 
-govuk::apps::static::asset_host: "%{hiera('govuk::deploy::config::website_root')}"
 govuk::apps::static::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::static::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::static::unicorn_worker_processes: "8"

--- a/modules/govuk/manifests/apps/static.pp
+++ b/modules/govuk/manifests/apps/static.pp
@@ -28,10 +28,6 @@
 #   The bearer token to use when communicating with Publishing API.
 #   Default: undef
 #
-# [*asset_host*]
-#   The URL that will be used as a prefix for statics assets.
-#   Default: undef
-#
 # [*ga_universal_id*]
 #   The Google Analytics ID.
 #   Default: undef
@@ -79,7 +75,6 @@ class govuk::apps::static(
   $draft_environment = false,
   $secret_key_base = undef,
   $publishing_api_bearer_token = undef,
-  $asset_host = undef,
   $ga_universal_id = undef,
   $redis_host = undef,
   $redis_port = undef,
@@ -138,9 +133,6 @@ class govuk::apps::static(
     "${title}-PUBLISHING_API_BEARER_TOKEN":
       varname => 'PUBLISHING_API_BEARER_TOKEN',
       value   => $publishing_api_bearer_token;
-    "${title}-ASSET_HOST":
-      varname => 'ASSET_HOST',
-      value   => $asset_host;
     "${title}-GOOGLE_TAG_MANAGER_ID":
         varname => 'GOOGLE_TAG_MANAGER_ID',
         value   => $google_tag_manager_id;


### PR DESCRIPTION
This is the second attempt at removing ASSET_HOSTS for Static. See commit ba498b06303d2be55bdda94093fd6e06d9486d48 for the original context. This change was orginially rolled back as it caused leaking of internal domains in the redirection URL produced for the favicon.ico on the assets domain. The internal domain was then flagged by Google's Unsafe Browsing feature and prevented users from loading any page using the favico.ico on the assets domain.

This leak was caused by Rails falling back to using the X-Forwarded-Host header as the redirect host. This was being incorrectly set as our internal origin domain by Nginx.

We've now implemented [changes to Fastly](https://github.com/alphagov/govuk-cdn-config/pull/414) and [Ngnix](https://github.com/alphagov/govuk-puppet/pull/11837) to properly forward the correct X-Forwarded-Host header and should prevent the leaked domain from occuring again. 

This reverts commit bdd867fd71f753fc56d356cba9303e713208cd53, reversing changes made to dff49b92ab41910133ef8a899d5e728d81daa6d5.