### PR TITLE
Mark a user who has left govuk as ensure => absent

### DIFF
--- a/modules/users/manifests/rodrigohilgenbergbastos.pp
+++ b/modules/users/manifests/rodrigohilgenbergbastos.pp
@@ -1,6 +1,7 @@
 # Creates the Rodrigo Hilgenberg Bastos user
 class users::rodrigohilgenbergbastos {
   govuk_user { 'rodrigohilgenbergbastos':
+    ensure   => absent,
     fullname => 'Rodrigo Hilgenberg-Bastos',
     email    => 'rodrigo.hilgenberg-bastos@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPG81OnfSzscT2E03HhVRnbkq3cA+0MLL51Y+QGJkOwl rodrigo.hilgenberg-bastos@digital.cabinet-office.gov.uk',


### PR DESCRIPTION
As per https://docs.publishing.service.gov.uk/manual/removing-a-user-from-puppet.html

[Trello](https://trello.com/c/5277gawK/1553-leaver-rodrigo-hilgenber-bastos-tech-role)