### PR TITLE
Increase proxy buffer size in nginx for all machines

### DIFF
--- a/hieradata_aws/class/draft_cache.yaml
+++ b/hieradata_aws/class/draft_cache.yaml
@@ -35,9 +35,5 @@ router::nginx::app_specific_static_asset_routes:
 
 router::nginx::check_requests_warning: '@0'
 router::nginx::check_requests_critical: '@0'
-router::nginx::proxy_busy_buffers_size: '16k'
-router::nginx::proxy_buffers: '8 8k'
-router::nginx::proxy_buffer_size: '8k'
 
 varnish::environment_ip_prefix: "%{hiera('environment_ip_prefix')}"
-

--- a/modules/nginx/manifests/config/vhost/proxy.pp
+++ b/modules/nginx/manifests/config/vhost/proxy.pp
@@ -73,6 +73,24 @@
 #   Boolean, whether Nginx should serve a robots.txt that
 #   prevents crawlers from indexing the thing being proxied.
 #
+# [*proxy_busy_buffers_size*]
+#
+#  limits the total size of buffers that can be busy sending a response to the client while the response is not yet fully read
+#
+# Default: '16k'
+#
+# [*proxy_buffers*]
+#
+#  Sets the number and size of the buffers used for reading a response from the proxied server, for a single connection
+#
+# Default: '8 8k'
+#
+# [*proxy_buffer_size*]
+#
+#  Sets the size of the buffer used for reading the first part of the response received from the proxied server
+#
+# Default: '8k'
+#
 define nginx::config::vhost::proxy(
   $to,
   $to_ssl = false,
@@ -95,6 +113,9 @@ define nginx::config::vhost::proxy(
   $proxy_http_version_1_1_enabled = false,
   $http_host = undef,
   $deny_crawlers = false,
+  $proxy_busy_buffers_size = '16k',
+  $proxy_buffers = '8 8k',
+  $proxy_buffer_size = '8k',
 ) {
   validate_re($ensure, '^(absent|present)$', 'Invalid ensure value')
 

--- a/modules/nginx/templates/proxy-vhost.conf
+++ b/modules/nginx/templates/proxy-vhost.conf
@@ -103,6 +103,9 @@ server {
   <%- end -%>
 
   location / {
+    proxy_busy_buffers_size <%= @proxy_busy_buffers_size -%>;
+    proxy_buffers <%= @proxy_buffers -%>;
+    proxy_buffer_size <%= @proxy_buffer_size -%>;
     <%- if @protected && @protected_location == "/" -%>
     deny all;
     auth_basic            "Enter the GOV.UK username/password (not your personal username/password)";

--- a/modules/router/manifests/nginx.pp
+++ b/modules/router/manifests/nginx.pp
@@ -53,19 +53,19 @@
 #
 #  limits the total size of buffers that can be busy sending a response to the client while the response is not yet fully read
 #
-# Default: '8k'
+# Default: '16k'
 #
 # [*proxy_buffers*]
 #
 #  Sets the number and size of the buffers used for reading a response from the proxied server, for a single connection
 #
-# Default: '8 4k'
+# Default: '8 8k'
 #
 # [*proxy_buffer_size*]
 #
 #  Sets the size of the buffer used for reading the first part of the response received from the proxied server
 #
-# Default: '4k'
+# Default: '8k'
 #
 class router::nginx (
   $app_specific_static_asset_routes = {},
@@ -76,9 +76,9 @@ class router::nginx (
   $check_requests_warning = '@25',
   $check_requests_critical = '@10',
   $robotstxt = '',
-  $proxy_busy_buffers_size = '8k',
-  $proxy_buffers = '8 4k',
-  $proxy_buffer_size = '4k',
+  $proxy_busy_buffers_size = '16k',
+  $proxy_buffers = '8 8k',
+  $proxy_buffer_size = '8k',
 ) {
   validate_array($rate_limit_tokens)
 


### PR DESCRIPTION
## What

Increases the cache size in nginx to allow larger headers to be served.

## Why

A change to the way CSS is loaded sees the `preload` header increase in size with the additional CSS files. This causes nginx to throw the error `upstream sent too big header while reading response header from upstream`, resulting in a 502 error being shown when any page with headers > 8k is requested.

<details>
<summary>The headers being served by Rails</summary>

```
HTTP/1.1 200 OK
Cache-Control: max-age=300, public
Content-Length: 132980
Content-Security-Policy-Report-Only: default-src https: 'self' *.publishing.service.gov.uk *.integration.publishing.service.gov.uk www.gov.uk *.dev.gov.uk; img-src 'self' data: *.publishing.service.gov.uk *.integration.publishing.service.gov.uk www.gov.uk *.dev.gov.uk www.google-analytics.com ssl.google-analytics.com stats.g.doubleclick.net www.googletagmanager.com www.region1.google-analytics.com region1.google-analytics.com lux.speedcurve.com assets.digital.cabinet-office.gov.uk; script-src 'self' *.publishing.service.gov.uk *.integration.publishing.service.gov.uk www.gov.uk *.dev.gov.uk www.google-analytics.com ssl.google-analytics.com stats.g.doubleclick.net www.googletagmanager.com www.region1.google-analytics.com region1.google-analytics.com www.gstatic.com www.signin.service.gov.uk *.ytimg.com www.youtube.com www.youtube-nocookie.com hmrc-uk.digital.nuance.com 'unsafe-inline'; style-src 'self' *.publishing.service.gov.uk *.integration.publishing.service.gov.uk www.gov.uk *.dev.gov.uk www.gstatic.com 'unsafe-inline'; font-src 'self' *.publishing.service.gov.uk *.integration.publishing.service.gov.uk www.gov.uk *.dev.gov.uk data:; connect-src 'self' *.publishing.service.gov.uk *.integration.publishing.service.gov.uk www.gov.uk *.dev.gov.uk www.google-analytics.com ssl.google-analytics.com stats.g.doubleclick.net www.googletagmanager.com www.region1.google-analytics.com region1.google-analytics.com lux.speedcurve.com www.tax.service.gov.uk hmrc-uk.digital.nuance.com hmpowebchat.klick2contact.com omni.eckoh.uk www.signin.service.gov.uk; object-src 'none'; frame-src 'self' *.publishing.service.gov.uk *.integration.publishing.service.gov.uk www.gov.uk *.dev.gov.uk www.youtube.com www.youtube-nocookie.com; report-uri https://jhpno0hk6b.execute-api.eu-west-2.amazonaws.com/production
Content-Type: text/html; charset=utf-8
Date: Mon, 10 Oct 2022 16:40:41 GMT
Etag: W/"3d6a3c3fb1f4ce03f228fdf44f1426e6"
Link: </assets/frontend/application-d42059f34041309702a0d3cb82f112f27c2e53e707203693edc51b70bcd643f4.css>; rel=preload; as=style; nopush,</assets/frontend/govuk_publishing_components/components/_contextual-sidebar-d991370ed34851c8b78e264015ee11b51614278596a88c56874531a5e8a6e527.css>; rel=preload; as=style; nopush,</assets/frontend/govuk_publishing_components/components/_panel-4354b39e053c20c317b93bce1d8b8d4237b3f86bcfa580b866c765692ae576b2.css>; rel=preload; as=style; nopush,</assets/frontend/govuk_publishing_components/components/_related-navigation-9329557b2da33f58a0462fdaf21ebacd678b96f58a8d2b3750b81b162646abda.css>; rel=preload; as=style; nopush,</assets/frontend/govuk_publishing_components/components/_table-73c86bab73dc2e4b1de8b8a664da05eb4b097acd0cbbbf0aa4b7a6d3131e82da.css>; rel=preload; as=style; nopush,</assets/frontend/govuk_publishing_components/components/_tabs-dd8363f1e5dbb6623d475f495b8dd2236c0e99599c7ff38fe6d3df003a814b4d.css>; rel=preload; as=style; nopush,</assets/frontend/components/_calendar-c88570b50dfbf87c90f9576f069457c9d27377a02981fb1eeea126e279a0372e.css>; rel=preload; as=style; nopush,</assets/frontend/components/_metadata-9c2a471ab96889042332242cabaafc05d740c1f70cff2a8c7512d2a091cb98e3.css>; rel=preload; as=style; nopush,</assets/frontend/components/_subscribe-015422ecbcf995a4ab612950684c69b83905e006e78b1eccba73e6d8414b0c34.css>; rel=preload; as=style; nopush,</assets/frontend/views/_calendars-a777d375ae45f659ebcfdb411e135d38f6fdf1a8b64e74b2ecb2056002548d40.css>; rel=preload; as=style; nopush,</assets/frontend/print-4999bb4fdea0b565c697e98b104fb7bd59065c43de8ef05798bf71279618e981.css>; rel=preload; as=style; nopush,</assets/frontend/application-59e464d1abbfafb73b54000cc712f83a1911aa09481df608980e22e67b242618.js>; rel=preload; as=script; nopush
Permissions-Policy: interest-cohort=()
Server: nginx
Strict-Transport-Security: max-age=31536000; preload
Vary: Accept-Encoding
Via: 1.1 router
X-Content-Type-Options: nosniff
X-Frame-Options: ALLOWALL
X-Request-Id: 39e4381a-3f17-4a8a-a68a-d12edf3c947e
X-Runtime: 0.196028
```

</details>


The error wasn't present on the draft stack because that has had the proxy buffer size increased in #11715 - so this pull request makes that change to the other stacks as well to prevent this error occurring in the future.
