### PR TITLE
Remove rodrigo hb

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -415,7 +415,6 @@ users::usernames:
   - rebeccapearce
   - richardtowers
   - rochtrinque
-  - rodrigohilgenbergbastos
   - roryhurley
   - rosafox
   - ryanbrooks

--- a/modules/users/manifests/rodrigohilgenbergbastos.pp
+++ b/modules/users/manifests/rodrigohilgenbergbastos.pp
@@ -1,9 +1,0 @@
-# Creates the Rodrigo Hilgenberg Bastos user
-class users::rodrigohilgenbergbastos {
-  govuk_user { 'rodrigohilgenbergbastos':
-    ensure   => absent,
-    fullname => 'Rodrigo Hilgenberg-Bastos',
-    email    => 'rodrigo.hilgenberg-bastos@digital.cabinet-office.gov.uk',
-    ssh_key  => 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPG81OnfSzscT2E03HhVRnbkq3cA+0MLL51Y+QGJkOwl rodrigo.hilgenberg-bastos@digital.cabinet-office.gov.uk',
-  }
-}


### PR DESCRIPTION
Now removing user's manifest and entry in integration hieradata following deployment of change to ensure => absent, to remove the user's home directories on ssh machines.

As per instructions [here](https://docs.publishing.service.gov.uk/manual/removing-a-user-from-puppet.html)

[Trello ](https://trello.com/c/5277gawK/1553-leaver-rodrigo-hilgenber-bastos-tech-role)