### PR TITLE
Use the governmentdigitalservice docker hub account instead of govuk

### DIFF
--- a/modules/govuk_containers/manifests/gemstash.pp
+++ b/modules/govuk_containers/manifests/gemstash.pp
@@ -11,7 +11,7 @@
 #   The docker image version use.
 #
 class govuk_containers::gemstash(
-  $gemstash_image = 'govuk/gemstash-alpine',
+  $gemstash_image = 'governmentdigitalservice/gemstash-alpine',
   # TODO publish a specific version and use that here
   $gemstash_image_version = 'latest',
 ) {


### PR DESCRIPTION
We're consolidating all of GDS' Docker account usage so that it goes through governmentdigitalservice. This org has multiple owners and a process for requesting additional seats, etc, unlike the govuk org which has a 3 seat limit.

https://trello.com/c/6JRYK8hU/2982-push-to-pull-from-governmentdigitalservice-docker-org-3