### PR TITLE
Fix Slack links to Staging/Production environments

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/deploy_app_downstream.pp
+++ b/modules/govuk_jenkins/manifests/jobs/deploy_app_downstream.pp
@@ -39,8 +39,7 @@ class govuk_jenkins::jobs::deploy_app_downstream (
   $slack_credential_id = 'slack-notification-token',
   $slack_team_domain = 'gds',
 ) {
-  $deploy_jenkins_domain = hiera('deploy_jenkins_domain')
-  $slack_build_server_url = "https://${deploy_jenkins_domain}/"
+  $slack_build_server_url = "https://${deploy_url}/"
   $app_domain = hiera('app_domain_internal')
 
   file { '/etc/jenkins_jobs/jobs/deploy_app_downstream.yaml':


### PR DESCRIPTION
The 'Open' link on Slack notifications from Jenkins points to the wrong domain. Using the `deploy_url` instead of `deploy_jenkins_domain` should fix the issue.

https://trello.com/c/jWiTpppP/3012-fix-slack-links-to-staging-production-environments-3