### PR TITLE
Remove duplicate key from integration config

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -392,7 +392,6 @@ govuk::apps::info_frontend::port: 3085
 govuk::apps::email_alert_api::port: 3088
 # email-alert-api sidekiq monitoring uses 3089
 govuk::apps::government_frontend::port: 3090
-govuk::apps::locations_api::port: 3091
 govuk::apps::publishing_api::port: 3093
 govuk::apps::email_alert_frontend::port: 3099
 govuk::apps::backdrop_read::port: 3101
@@ -879,8 +878,6 @@ govuk::node::s_gatling::repo: 'git@github.com:alphagov/govuk-load-testing.git'
 govuk::node::s_gatling::ssh_public_key: "%{hiera('govuk_jenkins::ssh_key::public_key')}"
 govuk::node::s_gatling::ssh_private_key: "%{hiera('govuk_jenkins::ssh_key::private_key')}"
 
-govuk::node::s_graphite::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
-
 govuk::node::s_licensing_backend::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk::node::s_licensing_backend::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
@@ -977,7 +974,6 @@ govuk_ci::master::pipeline_jobs:
       - 'staging'
       - 'production'
   middleman-search: {}
-  search-api: {}
   smokey: {}
 
 govuk_ci::master::ci_agents:

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -173,8 +173,6 @@ govuk_jenkins::jobs::signon_cron_rake_tasks::rake_users_send_suspension_reminder
 
 govuk_jenkins::jobs::smokey::environment: integration
 
-govuk_jenkins::jobs::deploy_dns::gce_project_id: 'govuk-integration'
-
 govuk_jenkins::jobs::run_related_links_generation::cron_schedule: '0 8 9,23 * *'
 govuk_jenkins::jobs::run_related_links_ingestion::cron_schedule: '0 8 11,25 * *'
 


### PR DESCRIPTION
There are a few duplicate keys in hieradata_aws configs.
I used yamllint for checking the files.
`yamllint -d "{rules: {key-duplicates: enable}}" hieradata_aws/*.yaml`

Trello card: https://trello.com/c/oUuP3Crp/2872-govuk-puppet-hieradataaws-integrationyaml-file-2