### PR TITLE
Fix jenkins url

### DIFF
--- a/modules/govuk_jenkins/manifests/config.pp
+++ b/modules/govuk_jenkins/manifests/config.pp
@@ -9,9 +9,9 @@
 #
 # [*url_prefix*]
 #   The prefix used on the URL to access the Jenkins instance. Default is 'deploy',
-#   which would create "https://deploy.${app_domain}"
+#   which would create "https://deploy.${deploy_jenkins_domain}"
 #
-# [*app_domain*]
+# [*deploy_jenkins_domain*]
 #   The domain name applied to the Jenkins instance URL
 #
 # [*banner_colour_background*]
@@ -90,7 +90,7 @@
 #
 class govuk_jenkins::config (
   $url_prefix = 'deploy',
-  $app_domain = hiera('app_domain'),
+  $deploy_jenkins_domain = hiera('deploy_jenkins_domain'),
   $banner_colour_background = 'black',
   $banner_colour_text = 'white',
   $banner_string = 'Jenkins',
@@ -115,7 +115,7 @@ class govuk_jenkins::config (
   $markup_formatter_version = '2.1',
 ) {
 
-  $url = "${url_prefix}.${app_domain}"
+  $url = "${url_prefix}.${deploy_jenkins_domain}"
 
   validate_array($admins)
   validate_array($user_permissions)

--- a/modules/govuk_jenkins/templates/config/jenkins.model.JenkinsLocationConfiguration.xml.erb
+++ b/modules/govuk_jenkins/templates/config/jenkins.model.JenkinsLocationConfiguration.xml.erb
@@ -1,5 +1,5 @@
 <?xml version='1.1' encoding='UTF-8'?>
 <jenkins.model.JenkinsLocationConfiguration>
-  <adminAddress>webops@digital.cabinet-office.gov.uk</adminAddress>
+  <adminAddress>2nd-line-support@digital.cabinet-office.gov.uk</adminAddress>
   <jenkinsUrl>https://<%= @url -%>/</jenkinsUrl>
 </jenkins.model.JenkinsLocationConfiguration>


### PR DESCRIPTION
The 'Open' link on Slack notifications from Jenkins points to the wrong domain

https://trello.com/c/jWiTpppP/3012-fix-slack-links-to-staging-production-environments-3