### PR TITLE
Revert "Add gtag env var details"

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -85,7 +85,6 @@ govuk::apps::static::ga_universal_id: 'UA-26179049-22'
 govuk::apps::static::google_tag_manager_auth: "C7iYdcsOlYgGmiUJjZKrHQ"
 govuk::apps::static::google_tag_manager_id: "GTM-MG7HG5W"
 govuk::apps::static::google_tag_manager_preview: "env-4"
-govuk::apps::static::gtag_id: "G-9BX34Z34D0"
 govuk::apps::static::govuk_personalisation_manage_uri: 'https://integration.account.gov.uk?link=manage-account'
 govuk::apps::static::govuk_personalisation_security_uri: 'https://integration.account.gov.uk?link=security-privacy'
 govuk::apps::static::govuk_personalisation_feedback_uri: 'https://signin.account.gov.uk/support'

--- a/modules/govuk/manifests/apps/static.pp
+++ b/modules/govuk/manifests/apps/static.pp
@@ -53,9 +53,6 @@
 # [*google_tag_manager_auth*]
 #   The identifier of an environment for Google Tag Manager
 #
-# [*gtag_id*]
-#   The ID for a Google Tag account
-#
 # [*govuk_personalisation_manage_uri*]
 #   URI for the account management page.
 #
@@ -82,7 +79,6 @@ class govuk::apps::static(
   $google_tag_manager_id = undef,
   $google_tag_manager_preview = undef,
   $google_tag_manager_auth = undef,
-  $gtag_id = undef,
   $govuk_personalisation_manage_uri = undef,
   $govuk_personalisation_security_uri = undef,
   $govuk_personalisation_feedback_uri = undef,
@@ -142,9 +138,6 @@ class govuk::apps::static(
     "${title}-GOOGLE_TAG_MANAGER_AUTH":
         varname => 'GOOGLE_TAG_MANAGER_AUTH',
         value   => $google_tag_manager_auth;
-    "${title}-GTAG_ID":
-        varname => 'GTAG_ID',
-        value   => $gtag_id;
     "${title}-GOVUK-PERSONALISATION-MANAGE-URI":
       varname => 'GOVUK_PERSONALISATION_MANAGE_URI',
       value   => $govuk_personalisation_manage_uri;


### PR DESCRIPTION
Reverts alphagov/govuk-puppet#11838 as we no longer need to be testing GTAG on integration.

Also reverts https://github.com/alphagov/govuk-puppet/pull/11826 - these were related changes that should have been in one PR originally.