### PR TITLE
Add GoLang 1.19.2 for Router

### DIFF
--- a/modules/golang/manifests/init.pp
+++ b/modules/golang/manifests/init.pp
@@ -14,7 +14,8 @@ class golang {
   goenv::version { [
     '1.7.1',   # Used by alphagov/govuk_crawler_worker
     '1.17.8',  # Used by alphagov/router (remove once router is running latest)
-    '1.18.3',  # Used by alphagov/router
+    '1.18.3',  # Used by alphagov/router (remove once router is running latest)
+    '1.19.2',  # Used by alphagov/router
     ]: }
 
   package { ['godep']:


### PR DESCRIPTION
Router is running on 1.19.2, but the update cycle for it hasn't been followed to the specs in Router's [readme](https://github.com/alphagov/router#updating-the-version-of-go), so we're a bit behind here.

This shouldn't cause immediate problems but may explain some flakey test behaviour in router's CI pipeline.

I'm aware we now have three versions listed for Router. This is to ensure that nothing falls over when everything is updated. I'll submit a follow up PR that removes the extra versions once all in.

Work related to: https://trello.com/c/lIF8IVxq/1392-bug-investigate-broken-router-builds