### PR TITLE
Add pentester usernames to hieradata

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -408,6 +408,9 @@ users::usernames:
   - ollietreend
   - oliverroberts
   - patrickcartlidge
+  - pentesterd
+  - pentestero
+  - pentesterp
   - peterhattyar
   - peterhartshorn
   - rebeccapearce


### PR DESCRIPTION
As per https://docs.publishing.service.gov.uk/manual/get-started.html#create-a-user-to-ssh-into-integration

This should enable their SSH access.

Note that there is a `pentest_usernames` array we could set instead, but that appears to be used only in conjunction with an allow-list of `pentest_machines`. Since we don't want to restrict the testers to only one or two defined machines, we'll use the standard `usernames` property. See
https://github.com/alphagov/govuk-puppet/blob/737f3054276bf73a0033949458cee6710adec296/modules/users/manifests/init.pp#L79-L82

Trello: https://trello.com/c/OapOcUjZ/3006-manage-the-it-health-check