### PR TITLE
Revert "Remove redundant GoLang versions"

### DIFF
--- a/modules/golang/manifests/init.pp
+++ b/modules/golang/manifests/init.pp
@@ -13,6 +13,8 @@ class golang {
 
   goenv::version { [
     '1.7.1',   # Used by alphagov/govuk_crawler_worker
+    '1.17.8',  # Used by alphagov/router (remove once router is running latest)
+    '1.18.3',  # Used by alphagov/router (remove once router is running latest)
     '1.19.2',  # Used by alphagov/router
     ]: }
 


### PR DESCRIPTION
Reverts alphagov/govuk-puppet#11864

While not listed, it appears other tools reference at least GoLang 1.17.8 - so this needs to be pulled for now until it can be audited.