### PR TITLE
Remove old performance platform config

### DIFF
--- a/hieradata_aws/class/integration/jenkins.yaml
+++ b/hieradata_aws/class/integration/jenkins.yaml
@@ -67,14 +67,12 @@ govuk_jenkins::jobs::deploy_cdn::enable_slack_notifications: true
 govuk_jenkins::jobs::deploy_cdn::services:
   - assets
   - assets-eks
-  - performanceplatform
   - www
   - www-eks
 
 govuk_jenkins::jobs::update_cdn_dictionaries::services:
   - assets
   - assets-eks
-  - performanceplatform
   - www
   - www-eks
 

--- a/hieradata_aws/class/production/jenkins.yaml
+++ b/hieradata_aws/class/production/jenkins.yaml
@@ -124,7 +124,6 @@ govuk_jenkins::jobs::deploy_cdn::services:
   - assets
   - assets-eks
   - mirror
-  - performanceplatform
   - servicegovuk
   - tldredirect
   - www
@@ -134,7 +133,6 @@ govuk_jenkins::jobs::update_cdn_dictionaries::services:
   - assets
   - assets-eks
   - mirror
-  - performanceplatform
   - www
   - www-eks
 

--- a/hieradata_aws/class/staging/jenkins.yaml
+++ b/hieradata_aws/class/staging/jenkins.yaml
@@ -114,7 +114,6 @@ govuk_jenkins::jobs::deploy_cdn::services:
   - assets
   - assets-eks
   - mirror
-  - performanceplatform
   - www
   - www-eks
 
@@ -122,7 +121,6 @@ govuk_jenkins::jobs::update_cdn_dictionaries::services:
   - assets
   - assets-eks
   - mirror
-  - performanceplatform
   - www
   - www-eks
 

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1001,9 +1001,6 @@ govuk_ci::master::pipeline_jobs:
   middleman-search: {}
   omniauth-gds: {}
   optic14n: {}
-  performanceplatform-client.py: {}
-  performanceplatform-collector: {}
-  performanceplatform-documentation: {}
   plek: {}
   publishing-e2e-tests: {}
   rack-logstasher: {}

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -157,8 +157,6 @@ govuk::apps::content_publisher::google_tag_manager_preview: "env-2"
 govuk::apps::content_publisher::govuk_notify_template_id: "e00e89f5-b622-4dcb-8f30-e6c70231a940"
 govuk::apps::collections_publisher::govuk_notify_template_id: "e00e89f5-b622-4dcb-8f30-e6c70231a940"
 govuk::apps::collections_publisher::publish_without_2i_email: "mainstream-force-publishing-alerts@digital.cabinet-office.gov.uk"
-govuk::apps::content_store::performance_platform_big_screen_view_url: 'https://performance-platform-big-screen-view-production.cloudapps.digital'
-govuk::apps::content_store::performance_platform_spotlight_url: 'https://performance-platform-spotlight-production.cloudapps.digital'
 
 govuk::apps::contacts::ensure: 'present'
 govuk::apps::collections_publisher::ensure: 'present'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -161,8 +161,6 @@ govuk::apps::content_publisher::enabled: true
 govuk::apps::content_publisher::govuk_notify_template_id: "112842bb-d8a4-4511-90de-57dc5c8f27ec"
 govuk::apps::collections_publisher::govuk_notify_template_id: "112842bb-d8a4-4511-90de-57dc5c8f27ec"
 govuk::apps::collections_publisher::publish_without_2i_email: "mainstream-publisher-notifications-staging@digital.cabinet-office.gov.uk"
-govuk::apps::content_store::performance_platform_big_screen_view_url: 'https://performance-platform-big-screen-view-staging.cloudapps.digital'
-govuk::apps::content_store::performance_platform_spotlight_url: 'https://performance-platform-spotlight-staging.cloudapps.digital'
 
 govuk::apps::email_alert_api::db::backend_ip_range: '10.12.3.0/24'
 govuk::apps::email_alert_api::govuk_notify_template_id: '2844a647-6bf1-4b01-a25c-569d2cc00849'

--- a/modules/govuk/manifests/apps/content_store.pp
+++ b/modules/govuk/manifests/apps/content_store.pp
@@ -14,14 +14,6 @@
 #   The mongo database to be used. Overriden in development
 #   to be 'content_store_development'.
 #
-# [*performance_platform_big_screen_view_url*]
-#   Performance platform big screen view url
-#   Default: undef
-#
-# [*performance_platform_spotlight_url*]
-#   Performance platform spotlight url
-#   Default: undef
-#
 # [*vhost*]
 #   Virtual host for this application.
 #   Default: content-store
@@ -62,8 +54,6 @@ class govuk::apps::content_store(
   $mongodb_name,
   $vhost = 'content-store',
   $default_ttl = '300',
-  $performance_platform_big_screen_view_url = undef,
-  $performance_platform_spotlight_url = undef,
   $publishing_api_bearer_token = undef,
   $secret_key_base = undef,
   $sentry_dsn = undef,
@@ -128,12 +118,6 @@ class govuk::apps::content_store(
     "${title}-ROUTER_API_BEARER_TOKEN":
         varname => 'ROUTER_API_BEARER_TOKEN',
         value   => $router_api_bearer_token;
-    "${title}-PERFORMANCEPLATFORM_BIG_SCREEN_VIEW":
-      varname => 'PLEK_SERVICE_PERFORMANCEPLATFORM_BIG_SCREEN_VIEW_URI',
-      value   => $performance_platform_big_screen_view_url;
-    "${title}-PERFORMANCEPLATFORM_SPOTLIGHT":
-      varname => 'PLEK_SERVICE_SPOTLIGHT_URI',
-      value   => $performance_platform_spotlight_url;
     "${title}-RUMMAGER_URI":
       varname => 'PLEK_SERVICE_RUMMAGER_URI',
       value   => $plek_service_rummager_uri;


### PR DESCRIPTION
This removes a few places where there is unnecessary performance platform references still in puppet code.

I started this with the motivation to remove performanceplatform from the list of deployable CDN services, but extended it to catch a couple of other cases.

I wasn't brave enough to consider the removal of the stuff related to backdrop - so there's definitely more in there.