### PR TITLE
When setting Plek URL for `search`, also set it for `search-api`.

### DIFF
--- a/modules/govuk/manifests/app/config.pp
+++ b/modules/govuk/manifests/app/config.pp
@@ -197,6 +197,9 @@ define govuk::app::config (
 
     if $override_search_location {
       govuk::app::envvar {
+        "${title}-PLEK_SERVICE_SEARCH_API_URI":
+          varname => 'PLEK_SERVICE_SEARCH_API_URI',
+          value   => $override_search_location;
         "${title}-PLEK_SERVICE_SEARCH_URI":
           varname => 'PLEK_SERVICE_SEARCH_URI',
           value   => $override_search_location;

--- a/modules/govuk/manifests/node/s_draft_frontend.pp
+++ b/modules/govuk/manifests/node/s_draft_frontend.pp
@@ -29,5 +29,6 @@ class govuk::node::s_draft_frontend() inherits govuk::node::s_base {
     'PLEK_SERVICE_LICENSIFY_URI': value => "https://licensify.${app_domain_internal}";
     'PLEK_SERVICE_MAPIT_URI': value => "https://mapit.${app_domain_internal}";
     'PLEK_SERVICE_SEARCH_URI': value => "https://search.${app_domain_internal}";
+    'PLEK_SERVICE_SEARCH_API_URI': value => "https://search-api.${app_domain_internal}";
   }
 }


### PR DESCRIPTION
`search-api` has been the canonical name for the Search API service for a long time now. We've only been getting away with not setting this because most of the client code was never updated to use the new name.

See alphagov/gds-api-adapters#1170.