### PR TITLE
Resolve quirky hostnames for assets vhost

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1475,7 +1475,7 @@ router::assets_origin::asset_manager_uploaded_assets_routes:
   - '/media/'
 
 router::assets_origin::vhost_aliases:
-  - 'assets.publishing.service.gov.uk'
+  - "assets.%{hiera('app_domain')}"
 
 router::assets_origin::website_root: "%{hiera('govuk::deploy::config::website_root')}"
 

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1475,7 +1475,6 @@ router::assets_origin::asset_manager_uploaded_assets_routes:
   - '/media/'
 
 router::assets_origin::vhost_aliases:
-  - 'assets.digital.cabinet-office.gov.uk'
   - 'assets.publishing.service.gov.uk'
   - 'assets.production.govuk.digital'
 

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1476,7 +1476,6 @@ router::assets_origin::asset_manager_uploaded_assets_routes:
 
 router::assets_origin::vhost_aliases:
   - 'assets.publishing.service.gov.uk'
-  - 'assets.production.govuk.digital'
 
 router::assets_origin::website_root: "%{hiera('govuk::deploy::config::website_root')}"
 


### PR DESCRIPTION
This removes 3 somewhat odd hostnames that we had set as vhost aliases for assets-origin and replaces them with an environment specific one.

The ones removed are:

- assets.digital.cabinet-office.gov.uk - this was migrated to transition in 2016 and no longer served from this vhost
- assets.production.govuk.digital - there is not a DNS record for this hostname and there probably shouldn't be as we should only use `assets-origin.<environment>.govuk.digital` as public traffic should go through the CDN

The remaining one, `assets.publishing.service.gov.uk` is replaced with one that changes based on the environment you are. As we only had a production one for this it wouldn't work in the normal way origin servers behave and thus had an inconsistent CDN configuration.

The motivation for making this change is to make the CDN configuration consistent across our CDN services.