### PR TITLE
Explicitly do shallow clones

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,11 +11,13 @@ node {
 
   try {
     stage("Checkout") {
-      govuk.checkoutFromGitHubWithSSH(REPOSITORY)
+      govuk.checkoutFromGitHubWithSSH(REPOSITORY, [shallow: true])
     }
 
     stage("Merge main") {
-      govuk.mergeIntoBranch("main")
+      // this will only succeed on a merge if the PR is less than 50 commits
+      // ahead of main.
+      govuk.mergeIntoBranch("main", [fetchBranch: true, mergeDepth: 50])
     }
 
     stage("Bundle install") {


### PR DESCRIPTION
Previously this repo relied on shallow clone behaviour implicitly and based on branch. This broke when
https://github.com/alphagov/govuk-jenkinslib/pull/117 was merged which subtly changed the implicit behaviour.

To resolve this we are now doing a shallow clone explicitly.

There is a chance this may have a problem with tagging as per references in govuk-jenkinslib [1], however I don't think this will be the case because [2] indicates this has been doing shallow clones on the main branch. But I'll probably only find this out after merge.

[1]: https://github.com/alphagov/govuk-jenkinslib/commit/1bd45aaf6ca9ef79da0a5cf6633811583e93b766
[2]: https://github.com/alphagov/govuk-jenkinslib/blob/b91f44c46a7078336c284257afffb6acb78827c3/vars/govuk.groovy#L387