### PR TITLE
Reduce storage of closed PR branches

### DIFF
--- a/modules/govuk_ci/templates/application_build_job.xml.erb
+++ b/modules/govuk_ci/templates/application_build_job.xml.erb
@@ -17,8 +17,8 @@
   </icon>
   <orphanedItemStrategy class="com.cloudbees.hudson.plugins.folder.computed.DefaultOrphanedItemStrategy" plugin="cloudbees-folder@6.5.1">
     <pruneDeadBranches>true</pruneDeadBranches>
-    <daysToKeep>30</daysToKeep>
-    <numToKeep>50</numToKeep>
+    <daysToKeep>5</daysToKeep>
+    <numToKeep>10</numToKeep>
   </orphanedItemStrategy>
   <triggers/>
   <disabled>false</disabled>


### PR DESCRIPTION
We currently store up to 50 builds for a project after a PR has been merged and for up-to 30 days.

This seems unnecessary as we rarely look at these after they are merged.

The motivation for this change is the frequency that we run out of disk space on Jenkins.