### PR TITLE
Revert "Remove "vcloud-launcher" related code"

### DIFF
--- a/hieradata_aws/vagrant.yaml
+++ b/hieradata_aws/vagrant.yaml
@@ -61,6 +61,7 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::run_rake_task
   - govuk_jenkins::jobs::deploy_cdn
   - govuk_jenkins::jobs::deploy_puppet
+  - govuk_jenkins::jobs::launch_vms
   - govuk_jenkins::jobs::passive_checks
   - govuk_jenkins::jobs::publish_special_routes
   - govuk_jenkins::jobs::run_whitehall_data_migrations

--- a/load_nodes.rb
+++ b/load_nodes.rb
@@ -1,0 +1,65 @@
+require 'yaml'
+
+# Load node definitions from the vcloud-launcher YAML in the
+# govuk-provisioning repo parallel to this.
+def load_nodes
+  yaml_dir = File.expand_path(
+    "../../govuk-provisioning/vcloud-launcher/*integration_carrenza/",
+    __FILE__
+  )
+  yaml_local = File.expand_path("../nodes.local.yaml", __FILE__)
+
+  # DEPRECATED
+  json_local = File.expand_path("../nodes.local.json", __FILE__)
+  if File.exists?(json_local)
+    $stderr.puts "ERROR: nodes.local.json is deprecated. Please convert it to YAML"
+    exit 1
+  end
+
+  unless Dir.glob(yaml_dir).any?
+    puts "Unable to find nodes in 'govuk-provisioning' repo"
+    puts
+    return {}
+  end
+
+  yaml_files = Dir.glob(
+    File.join(yaml_dir, "*.yaml")
+  )
+
+  nodes = Hash[
+    yaml_files.flat_map { |yaml_file|
+      YAML::load_file(yaml_file).fetch('vapps').map { |vapp|
+        name    = vapp.fetch('name')
+        template = vapp.fetch('vapp_template_name')
+        vm      = vapp.fetch('vm')
+        network = vm.fetch('network_connections').first
+        vdc     = network.fetch('name').downcase
+
+        name = "#{name}.#{vdc}"
+        config = {
+          'ip' => network.fetch('ip_address'),
+        }
+
+        config['box_dist'] = ['precise', 'trusty', 'xenial'].find { |dist| vapp['vapp_template_name'].include? dist }
+
+        [name, config]
+      }
+    }
+  ]
+
+  # Local YAML file can override node properties like "memory". It should
+  # look like:
+  #
+  # ---
+  # machine1.vdc1:
+  #   memory: 128
+  # machine2.vdc2:
+  #   memory: 4096
+  #
+  if File.exists?(yaml_local)
+    nodes_local = YAML::load_file(yaml_local)
+    nodes_local.each { |k,v| nodes[k].merge!(v) if nodes.has_key?(k) }
+  end
+
+  Hash[nodes.sort]
+end

--- a/modules/govuk_jenkins/manifests/jobs/launch_vms.pp
+++ b/modules/govuk_jenkins/manifests/jobs/launch_vms.pp
@@ -1,0 +1,41 @@
+# == Class: govuk_jenkins::jobs::launch_vms
+#
+# Create a file on disk that can be parsed by jenkins-job-builder
+#
+# [*vcloud_properties*]
+#   A hash containing the vCloud organisation name and the environment
+#   identifier to launch VMs.
+#
+# [*vcloud_properties_dr*]
+#   A hash containing the vCloud organisation name and the environment
+#   identifier to launch VMs for disaster recovery.
+#
+# [*vcloud_properties_licensify*]
+#   A hash containing the vCloud organisation name and the environment
+#   identifier to launch VMs for Licensify.
+#
+class govuk_jenkins::jobs::launch_vms (
+  $vcloud_properties = {},
+  $vcloud_properties_dr = {},
+  $vcloud_properties_licensify = {},
+) {
+  validate_hash($vcloud_properties, $vcloud_properties_dr, $vcloud_properties_licensify)
+
+  file { '/etc/jenkins_jobs/jobs/launch_vms.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/launch_vms.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+
+  file { '/etc/jenkins_jobs/jobs/launch_vms_dr.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/launch_vms_dr.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+
+  file { '/etc/jenkins_jobs/jobs/launch_vms_licensify.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/launch_vms_licensify.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+}

--- a/modules/govuk_jenkins/manifests/jobs/vapps.pp
+++ b/modules/govuk_jenkins/manifests/jobs/vapps.pp
@@ -1,0 +1,39 @@
+# == Class: govuk_jenkins::jobs::vapps
+#
+# Creates templates for jenkins-job-builder jobs which start and stop vApps.
+#
+# === Parameters
+#
+# [*vcloud_properties*]
+#   A hash containing details of which vCloud Director instance to operate on. Should include:
+#     - username: vCloud Director username
+#     - password: vCloud Director password
+#     - org: vCloud Director organisation to login to
+#     - env: Name of environment in `govuk-provisioning/vcloud-launcher/`
+#     - host: Hostname that the vCloud Director API runs on
+#
+class govuk_jenkins::jobs::vapps (
+  $vcloud_properties = {},
+  $vcloud_properties_dr = {},
+) {
+  file { '/etc/jenkins_jobs/jobs/start_vapps.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/start_vapps.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+  file { '/etc/jenkins_jobs/jobs/stop_vapps.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/stop_vapps.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+  file { '/etc/jenkins_jobs/jobs/start_vapps_dr.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/start_vapps_dr.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+  file { '/etc/jenkins_jobs/jobs/stop_vapps_dr.yaml':
+    ensure  => present,
+    content => template('govuk_jenkins/jobs/stop_vapps_dr.yaml.erb'),
+    notify  => Exec['jenkins_jobs_update'],
+  }
+}

--- a/modules/govuk_jenkins/templates/jobs/launch_vms.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/launch_vms.yaml.erb
@@ -1,0 +1,46 @@
+---
+- scm:
+    name: govuk-provisioning_Launch_VMs
+    scm:
+        - git:
+            url: git@github.com:alphagov/govuk-provisioning.git
+            branches:
+              - master
+- job:
+    name: Launch_VMs
+    display-name: Launch_VMs
+    project-type: freestyle
+    description: |
+      Job to launch virtual machines in <%= @environment -%>.
+      If you are running this to bring up a new machine you will need to be signing certs on the puppetmaster
+      with `fab <%= @environment -%> puppet.sign_certificates`
+    properties:
+        - github:
+            url: https://github.digital.cabinet-office.gov.uk/gds/alphagov-deployment/
+        - inject:
+            properties-content: |
+              VCLOUD_ORG=<%= @vcloud_properties['organisation'] %>
+              VCLOUD_ENV=<%= @vcloud_properties['environment'] %>
+              VCLOUD_USERNAME=${USERNAME}@${VCLOUD_ORG}
+              VCLOUD_HOST=<%= @vcloud_properties['host'] %>
+        - build-discarder:
+            days-to-keep: 30
+            artifact-num-to-keep: 5
+    scm:
+      - govuk-provisioning_Launch_VMs
+    builders:
+        - shell: |
+            ./vcloud-launcher/jenkins.sh
+    parameters:
+        - string:
+            name: USERNAME
+            description: your vcloud username. This should be an email address.
+            default: false
+        - string:
+            name: CONFIG_GLOB
+            description: glob for config files.
+            default: "*.yaml"
+        - password:
+            name: VCLOUD_PASSWORD
+            description: your vcloud password
+            default: false

--- a/modules/govuk_jenkins/templates/jobs/launch_vms_dr.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/launch_vms_dr.yaml.erb
@@ -1,0 +1,46 @@
+---
+- scm:
+    name: govuk-provisioning_Launch_VMs_DR
+    scm:
+        - git:
+            url: git@github.com:alphagov/govuk-provisioning.git
+            branches:
+              - master
+- job:
+    name: Launch_VMs_DR
+    display-name: Launch VMs for disaster recovery
+    project-type: freestyle
+    description: |
+      Job to launch disaster recovery virtual machines in <%= @environment -%>.
+      If you are running this to bring up a new machine you will need to be signing certs on the puppetmaster
+      with `fab <%= @environment -%> puppet.sign_certificates`
+    properties:
+        - github:
+            url: https://github.digital.cabinet-office.gov.uk/gds/alphagov-deployment/
+        - inject:
+            properties-content: |
+              VCLOUD_ORG=<%= @vcloud_properties_dr['organisation'] %>
+              VCLOUD_ENV=<%= @vcloud_properties_dr['environment'] %>
+              VCLOUD_USERNAME=${USERNAME}@${VCLOUD_ORG}
+              VCLOUD_HOST=<%= @vcloud_properties['host'] %>
+        - build-discarder:
+            days-to-keep: 30
+            artifact-num-to-keep: 5
+    scm:
+      - govuk-provisioning_Launch_VMs_DR
+    builders:
+        - shell: |
+            ./vcloud-launcher/jenkins.sh
+    parameters:
+        - string:
+            name: USERNAME
+            description: your vcloud username. This should be an email address
+            default: false
+        - string:
+            name: CONFIG_GLOB
+            description: glob for config files.
+            default: "*.yaml"
+        - password:
+            name: VCLOUD_PASSWORD
+            description: your vcloud password
+            default: false

--- a/modules/govuk_jenkins/templates/jobs/launch_vms_licensify.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/launch_vms_licensify.yaml.erb
@@ -1,0 +1,46 @@
+---
+- scm:
+    name: govuk-provisioning_Launch_VMs_Licensify
+    scm:
+        - git:
+            url: git@github.com:alphagov/govuk-provisioning.git
+            branches:
+              - master
+- job:
+    name: Launch_VMs_Licensify
+    display-name: Launch VMs for Licensify
+    project-type: freestyle
+    description: |
+      Job to launch Licensify virtual machines in <%= @environment -%>.
+      If you are running this to bring up a new machine you will need to be signing certs on the puppetmaster
+      with `fab <%= @environment -%> puppet.sign_certificates`
+    properties:
+        - github:
+            url: https://github.digital.cabinet-office.gov.uk/gds/alphagov-deployment/
+        - inject:
+            properties-content: |
+              VCLOUD_ORG=<%= @vcloud_properties_licensify['organisation'] %>
+              VCLOUD_ENV=<%= @vcloud_properties_licensify['environment'] %>
+              VCLOUD_USERNAME=${USERNAME}@${VCLOUD_ORG}
+              VCLOUD_HOST=<%= @vcloud_properties_licensify['host'] %>
+        - build-discarder:
+            days-to-keep: 30
+            artifact-num-to-keep: 5
+    scm:
+      - govuk-provisioning_Launch_VMs_Licensify
+    builders:
+        - shell: |
+            ./vcloud-launcher/jenkins.sh
+    parameters:
+        - string:
+            name: USERNAME
+            description: your vcloud username
+            default: false
+        - string:
+            name: CONFIG_GLOB
+            description: glob for config files.
+            default: "licensify.yaml"
+        - password:
+            name: VCLOUD_PASSWORD
+            description: your vcloud password
+            default: false

--- a/modules/govuk_jenkins/templates/jobs/start_vapps.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/start_vapps.yaml.erb
@@ -1,0 +1,47 @@
+---
+- scm:
+    name: govuk-provisioning_start_vapps
+    scm:
+        - git:
+            url: git@github.com:alphagov/govuk-provisioning.git
+            branches:
+                - master
+            skip-tag: true
+            wipe-workspace: false
+
+- job:
+    name: start_vapps
+    display-name: Start vApps
+    description: |
+        Starts all vApps in vCloud Director.
+        Requires vApps to be owned by the vCloud user that this script runs under,
+        otherwise the vApps are not visible to the script.
+        This job is always safe to run and is the first thing to do if the
+        environment isn't working.
+    project-type: freestyle
+    properties:
+        - inject:
+            properties-content: |
+              USERNAME=<%= @vcloud_properties['username'] %>
+              VCLOUD_ORG=<%= @vcloud_properties['org'] %>
+              VCLOUD_ENV=<%= @vcloud_properties['env'] %>
+              VCLOUD_USERNAME=${USERNAME}@${VCLOUD_ORG}
+              VCLOUD_HOST=<%= @vcloud_properties['host'] %>
+        - build-discarder:
+            days-to-keep: 30
+            artifact-num-to-keep: 5
+    scm:
+        - govuk-provisioning_start_vapps
+    wrappers:
+        - inject-passwords:
+            global: false
+            mask-password-params: true
+            job-passwords:
+                - name: VCLOUD_PASSWORD
+                  password: '<%= @vcloud_properties['password'] -%>'
+    builders:
+        - shell: |
+            cd tools/start_stop_vapps/
+            ./run.sh ./start_stop_all_vapps.rb start
+    triggers:
+        - timed: '30 3 * * 1-5'

--- a/modules/govuk_jenkins/templates/jobs/start_vapps_dr.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/start_vapps_dr.yaml.erb
@@ -1,0 +1,45 @@
+---
+- scm:
+    name: govuk-provisioning_start_vapps_dr
+    scm:
+        - git:
+            url: git@github.com:alphagov/govuk-provisioning.git
+            branches:
+                - master
+            skip-tag: true
+            wipe-workspace: false
+
+- job:
+    name: start_vapps_dr
+    display-name: Start vApps DR
+    description: |
+        Starts all DR vApps in vCloud Director.
+        Requires vApps to be owned by the vCloud user that this script runs under,
+        otherwise the vApps are not visible to the script.
+    project-type: freestyle
+    properties:
+        - inject:
+            properties-content: |
+              USERNAME=<%= @vcloud_properties_dr['username'] %>
+              VCLOUD_ORG=<%= @vcloud_properties_dr['org'] %>
+              VCLOUD_ENV=<%= @vcloud_properties_dr['env'] %>
+              VCLOUD_USERNAME=${USERNAME}@${VCLOUD_ORG}
+              VCLOUD_HOST=<%= @vcloud_properties_dr['host'] %>
+        - build-discarder:
+            days-to-keep: 30
+            artifact-num-to-keep: 5
+    scm:
+        - govuk-provisioning_start_vapps_dr
+    wrappers:
+        - inject-passwords:
+            global: false
+            mask-password-params: true
+            job-passwords:
+                - name: VCLOUD_PASSWORD
+                  password: '<%= @vcloud_properties_dr['password'] -%>'
+    builders:
+        - shell: |
+            cd tools/start_stop_vapps/
+            ./run.sh ./start_stop_all_vapps.rb start
+    triggers:
+        - timed: '30 3 * * 1-5'

--- a/modules/govuk_jenkins/templates/jobs/stop_vapps.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/stop_vapps.yaml.erb
@@ -1,0 +1,46 @@
+---
+- scm:
+    name: govuk-provisioning_stop_vapps
+    scm:
+        - git:
+            url: git@github.com:alphagov/govuk-provisioning.git
+            branches:
+                - master
+            skip-tag: true
+            wipe-workspace: false
+
+- job:
+    name: stop_vapps
+    display-name: Stop vApps
+    description: |
+        Stops all non-critical vApps in vCloud Director.
+        Can be used to save money by running automatically every evening.
+        Requires vApps to be owned by the vCloud user that this script runs under,
+        otherwise the vApps are not visible to the script.
+    project-type: freestyle
+    properties:
+        - inject:
+            properties-content: |
+              USERNAME=<%= @vcloud_properties['username'] %>
+              VCLOUD_ORG=<%= @vcloud_properties['org'] %>
+              VCLOUD_ENV=<%= @vcloud_properties['env'] %>
+              VCLOUD_USERNAME=${USERNAME}@${VCLOUD_ORG}
+              VCLOUD_HOST=<%= @vcloud_properties['host'] %>
+        - build-discarder:
+            days-to-keep: 30
+            artifact-num-to-keep: 5
+    scm:
+        - govuk-provisioning_stop_vapps
+    wrappers:
+        - inject-passwords:
+            global: false
+            mask-password-params: true
+            job-passwords:
+                - name: VCLOUD_PASSWORD
+                  password: '<%= @vcloud_properties['password'] -%>'
+    builders:
+        - shell: |
+            cd tools/start_stop_vapps/
+            ./run.sh ./start_stop_all_vapps.rb stop
+    triggers:
+        - timed: '0 19 * * 1-5'

--- a/modules/govuk_jenkins/templates/jobs/stop_vapps_dr.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/stop_vapps_dr.yaml.erb
@@ -1,0 +1,46 @@
+---
+- scm:
+    name: govuk-provisioning_stop_vapps_dr
+    scm:
+        - git:
+            url: git@github.com:alphagov/govuk-provisioning.git
+            branches:
+                - master
+            skip-tag: true
+            wipe-workspace: false
+
+- job:
+    name: stop_vapps_dr
+    display-name: Stop vApps DR
+    description: |
+        Stops all non-critical DR vApps in vCloud Director.
+        Can be used to save money by running automatically every evening.
+        Requires vApps to be owned by the vCloud user that this script runs under,
+        otherwise the vApps are not visible to the script.
+    project-type: freestyle
+    properties:
+        - inject:
+            properties-content: |
+              USERNAME=<%= @vcloud_properties_dr['username'] %>
+              VCLOUD_ORG=<%= @vcloud_properties_dr['org'] %>
+              VCLOUD_ENV=<%= @vcloud_properties_dr['env'] %>
+              VCLOUD_USERNAME=${USERNAME}@${VCLOUD_ORG}
+              VCLOUD_HOST=<%= @vcloud_properties_dr['host'] %>
+        - build-discarder:
+            days-to-keep: 30
+            artifact-num-to-keep: 5
+    scm:
+        - govuk-provisioning_stop_vapps_dr
+    wrappers:
+        - inject-passwords:
+            global: false
+            mask-password-params: true
+            job-passwords:
+                - name: VCLOUD_PASSWORD
+                  password: '<%= @vcloud_properties_dr['password'] -%>'
+    builders:
+        - shell: |
+            cd tools/start_stop_vapps/
+            ./run.sh ./start_stop_all_vapps.rb stop
+    triggers:
+        - timed: '0 19 * * 1-5'


### PR DESCRIPTION
Reverts alphagov/govuk-puppet#11879

It was causing Puppet failures all over Integration, along the lines of:

```
$ govuk_puppet --test
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Loading facts
Dump was interrupted and may be inconsistent.
Device "veth01c4956" does not exist.
Device "veth01c4956" does not exist.
Device "veth026c1df" does not exist.
Device "veth026c1df" does not exist.
Device "veth0ddec5d" does not exist.
Device "veth0ddec5d" does not exist.
Device "veth0face8a" does not exist.
Device "veth0face8a" does not exist.
Device "veth233ead8" does not exist.
Device "veth233ead8" does not exist.
Device "veth302c91e" does not exist.
Device "veth302c91e" does not exist.
Device "veth33caa5a" does not exist.
Device "veth33caa5a" does not exist.
Device "veth34c4a61" does not exist.
Device "veth34c4a61" does not exist.
Device "veth398a803" does not exist.
Device "veth398a803" does not exist.
```