### PR TITLE
Revert "Use the governmentdigitalservice docker hub account instead of govuk"

### DIFF
--- a/modules/govuk_containers/manifests/gemstash.pp
+++ b/modules/govuk_containers/manifests/gemstash.pp
@@ -11,7 +11,7 @@
 #   The docker image version use.
 #
 class govuk_containers::gemstash(
-  $gemstash_image = 'governmentdigitalservice/gemstash-alpine',
+  $gemstash_image = 'govuk/gemstash-alpine',
   # TODO publish a specific version and use that here
   $gemstash_image_version = 'latest',
 ) {


### PR DESCRIPTION
Reverts alphagov/govuk-puppet#11849

Reverting until the issue with pushing this image is solved.

https://trello.com/c/6JRYK8hU/2982-push-to-pull-from-governmentdigitalservice-docker-org-3