### PR TITLE
Use updated bundler command

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/medical_safety_email_alert_check.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/medical_safety_email_alert_check.yaml.erb
@@ -21,7 +21,9 @@
               ) || echo "Cloning failed. Re-using directory from previous run."
 
               cd email-alert-monitoring
-              bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
+              bundle config set --local path "${HOME}/bundles/${JOB_NAME}"
+              bundle config set --local deployment true
+              bundle install
               bundle exec rake run_medical_alerts
             unstable-return: 1
     publishers:

--- a/modules/govuk_jenkins/templates/jobs/travel_advice_email_alert_check.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/travel_advice_email_alert_check.yaml.erb
@@ -22,7 +22,9 @@
               ) || echo "Cloning failed. Re-using directory from previous run."
 
               cd email-alert-monitoring
-              bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
+              bundle config set --local path "${HOME}/bundles/${JOB_NAME}"
+              bundle config set --local deployment true
+              bundle install
               bundle exec rake run_travel_alerts
             unstable-return: 1
     publishers:


### PR DESCRIPTION
bundle install flags `--path` and `--deployment` are deprecated so we should stop using them. We also think that this command could be causing an issue when installing Ruby 3.1.2 gems for Email Alert Monitor.

Deprecate warnings:

```
[DEPRECATED] The `--deployment` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set deployment 'true'`, and stop using this flag
[DEPRECATED] The `--path` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set path '/var/lib/jenkins/bundles/medical-safety-email-alert-check'`, and stop using this flag
```

Trello:
https://trello.com/c/wbq6cawk/1611-upgrade-ruby-for-email-alert-monitoring