### PR TITLE
Stop building e2e tests in CI

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -977,7 +977,6 @@ govuk_ci::master::pipeline_jobs:
       - 'staging'
       - 'production'
   middleman-search: {}
-  publishing-e2e-tests: {}
   search-api: {}
   smokey: {}
 


### PR DESCRIPTION
Trello: https://trello.com/c/amnaU0V9/853-decommission-the-publishing-end-to-end-tests

This is not needed since the e2e tests were retired [1].

This doesn't fully remove the e2e tests from this repo, it leaves CI agents 5-8 online and tagged to `publishing-e2e-tests`. This leave a decision about whether to take those boxes offline or to re-purpose them as generic CI agents so that we can run more concurrent builds. This task is being delegated to the Platform Reliability team.

[1]: https://github.com/alphagov/govuk-jenkinslib/commit/e99c76c19fb2c815bcb75e0ea55eac2933d62bc8