### PR TITLE
Enable CD for Transition

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1090,6 +1090,7 @@ govuk_jenkins::jobs::deploy_app_downstream::applications:
   specialist-publisher: {}
   support: {}
   support-api: {}
+  transition: {}
   travel-advice-publisher: {}
   whitehall:
     healthcheck_urls:


### PR DESCRIPTION
This enables continuous deployment for the Transition app.

[Trello card](https://trello.com/c/VgRHbI98)