### PR TITLE
Decommission CI agents 6,7,8

### DIFF
--- a/hieradata_aws/class/integration/aws_hostname/ci-agent-6.yaml
+++ b/hieradata_aws/class/integration/aws_hostname/ci-agent-6.yaml
@@ -1,3 +1,0 @@
----
-govuk_containers::elasticsearch::primary::enable: false
-govuk_containers::elasticsearch::secondary::enable: false

--- a/hieradata_aws/class/integration/aws_hostname/ci-agent-7.yaml
+++ b/hieradata_aws/class/integration/aws_hostname/ci-agent-7.yaml
@@ -1,3 +1,0 @@
----
-govuk_containers::elasticsearch::primary::enable: false
-govuk_containers::elasticsearch::secondary::enable: false

--- a/hieradata_aws/class/integration/aws_hostname/ci-agent-8.yaml
+++ b/hieradata_aws/class/integration/aws_hostname/ci-agent-8.yaml
@@ -1,3 +1,0 @@
----
-govuk_containers::elasticsearch::primary::enable: false
-govuk_containers::elasticsearch::secondary::enable: false

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -993,22 +993,7 @@ govuk_ci::master::ci_agents:
     agent_hostname: ci-agent-5.blue.%{hiera('app_domain_internal')}
     exclusive: true
     executors: 1
-    labels: 'publishing-e2e-tests'
-  ci-agent-6:
-    agent_hostname: ci-agent-6.blue.%{hiera('app_domain_internal')}
-    exclusive: true
-    executors: 1
-    labels: 'publishing-e2e-tests'
-  ci-agent-7:
-    agent_hostname: ci-agent-7.blue.%{hiera('app_domain_internal')}
-    exclusive: true
-    executors: 1
-    labels: 'publishing-e2e-tests'
-  ci-agent-8:
-    agent_hostname: ci-agent-8.blue.%{hiera('app_domain_internal')}
-    exclusive: true
-    executors: 1
-    labels: 'publishing-e2e-tests'
+    labels: 'licensify'
 
 govuk_ci::master::credentials_id: 'jenkins-ssh-slave'
 


### PR DESCRIPTION
These agents were used for E2E tests, but those tests have been retired.

Keeps ci-agent-5 because that's a snowflake used by Licensify: https://github.com/alphagov/licensify/blob/f7d595fc430f4293cf251643158a58705c15aa8b/Jenkinsfile#L7

https://trello.com/c/ToA1bUa4/3027-retire-or-repurpose-ci-agents-that-are-no-longer-used-for-e2e-tests