### PR TITLE
Set healthcheck request user agent

### DIFF
--- a/modules/icinga/files/usr/lib/nagios/plugins/check_json_healthcheck
+++ b/modules/icinga/files/usr/lib/nagios/plugins/check_json_healthcheck
@@ -97,7 +97,10 @@ def json_request(request_url):
     """
     return Request(request_url,
                    data=None,
-                   headers={"Accept": "application/json"})
+                   headers={
+                    "Accept": "application/json",
+                    "User-Agent": "GOV.UK JSON Healthcheck / Python"
+                   })
 
 
 class HealthCheckInfo(object):


### PR DESCRIPTION
I stumbled across a bunch of requests in logs and was a bit stumped as to what was making them. They were using the default user agent of "Python-urllib/3.4".

By adding a bit more context, we can more clearly differentiate between scripts that people run vs inherent parts of our infrastructure.

I've chosen this user agent as it sort of aligns with the other similar existing one "Smokey / Ruby".