### PR TITLE
Move proxy buffer headers to proxy nginx location

### DIFF
--- a/modules/nginx/templates/proxy-vhost.conf
+++ b/modules/nginx/templates/proxy-vhost.conf
@@ -103,9 +103,6 @@ server {
   <%- end -%>
 
   location / {
-    proxy_busy_buffers_size <%= @proxy_busy_buffers_size -%>;
-    proxy_buffers <%= @proxy_buffers -%>;
-    proxy_buffer_size <%= @proxy_buffer_size -%>;
     <%- if @protected && @protected_location == "/" -%>
     deny all;
     auth_basic            "Enter the GOV.UK username/password (not your personal username/password)";
@@ -142,6 +139,10 @@ server {
 
   <%- end -%>
   location @app {
+    proxy_busy_buffers_size <%= @proxy_busy_buffers_size -%>;
+    proxy_buffers <%= @proxy_buffers -%>;
+    proxy_buffer_size <%= @proxy_buffer_size -%>;
+
     proxy_pass <%= @to_proto -%><%= @name %>-proxy;
     <%= @extra_app_config %>
   }


### PR DESCRIPTION
Trello: https://trello.com/c/tULparMS/368-5114260-502-error-when-logging-into-sign-on-integration-on-google-chrome-government-digital-service-gds

Previously the proxy buffer headers were set in the root location (/) of the nginx declaration and not the declaration used to proxy a request. This meant that these headers weren't having any effect and hadn't resolved the problem.

Moving these headers to the proxy declaration means they have an effect.