### PR TITLE
switch publishing api to read from its own version of schemas

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -656,7 +656,7 @@ govuk::apps::publishing_api::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::publishing_api::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 govuk::apps::publishing_api::db::allow_auth_from_lb: true
 govuk::apps::publishing_api::db::lb_ip_range: "%{hiera('environment_ip_prefix')}.0.0/16"
-govuk::apps::publishing_api::govuk_content_schemas_path: '/data/apps/govuk-content-schemas/current'
+govuk::apps::publishing_api::govuk_content_schemas_path: '/data/apps/publishing-api/current/content_schemas'
 
 govuk::apps::release::db_hostname: "release-mysql"
 govuk::apps::release::db_username: "release"


### PR DESCRIPTION
This is part of work to merge content schemas into publishing api. As publishing api is the only application for which content schemas is a runtime dependency, this is the only change required to switch an application over outside of CI configuration.

Do not merge yet: depends on [the PR in publishing api](https://github.com/alphagov/publishing-api/pull/2184) that actually merges content schemas in.

[Trello](https://trello.com/c/ZUK2duYI/361-add-govuk-content-schemas-to-publishing-api-repo)