### PR TITLE
Set correct repo name for licensify-admin and licensify-feed.

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -176,8 +176,10 @@ deployable_applications: &deployable_applications
   licencefinder:
     repository: 'licence-finder'
   licensify: {}
-  licensify-admin: {}
-  licensify-feed: {}
+  licensify-admin:
+    repository: 'licensify'
+  licensify-feed:
+    repository: 'licensify'
   link-checker-api: {}
   locations-api: {}
   local-links-manager: {}


### PR DESCRIPTION
This should fix the failures in the Deploy_App_Downstream job for Licensify / GOV.UK Licensing.