### PR TITLE
Set repo for licensify-admin and licensify-feed in Deploy_App_Downstream.

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1054,6 +1054,10 @@ govuk_jenkins::jobs::deploy_app_downstream::applications:
   hmrc-manuals-api: {}
   imminence: {}
   info-frontend: {}
+  licensify-admin:
+    repository: 'licensify'
+  licensify-feed:
+    repository: 'licensify'
   link-checker-api: {}
   local-links-manager: {}
   locations-api: {}


### PR DESCRIPTION
This should fix Deploy_App_Downstream failing because it infers the wrong value for `$REPO`.