### PR TITLE
Update ckan add python 3.7

### DIFF
--- a/hieradata_aws/class/ckan.yaml
+++ b/hieradata_aws/class/ckan.yaml
@@ -8,4 +8,4 @@ govuk::apps::ckan::enable_harvester_gather: true
 
 govuk_solr6::present: false
 
-govuk_python3::govuk_python_version: '3.6.12'
+govuk_python37::govuk_python_version: '3.7'

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1103,6 +1103,9 @@ govuk_python::apt_source::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_f
 govuk_python3::apt_source::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk_python3::apt_source::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
+govuk_python37::apt_source::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk_python37::apt_source::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
+
 govuk_sudo::sudo_conf:
   deploy_docker_image:
     content: 'deploy ALL=NOPASSWD:/usr/bin/docker image *'

--- a/modules/govuk/manifests/node/s_ckan.pp
+++ b/modules/govuk/manifests/node/s_ckan.pp
@@ -18,7 +18,7 @@ class govuk::node::s_ckan inherits govuk::node::s_base {
     both       => 1024,
   }
 
-  include govuk_python3
+  include govuk_python37
   include nginx
   include postgresql::lib::devel
   include govuk_java::openjdk8::jre

--- a/modules/govuk/templates/ckan/ckan.ini.erb
+++ b/modules/govuk/templates/ckan/ckan.ini.erb
@@ -61,8 +61,8 @@ ckan.auth.user_create_groups = false
 ckan.auth.user_create_organizations = true
 ckan.auth.user_delete_groups = false
 ckan.auth.user_delete_organizations = true
-ckan.auth.create_user_via_api = false
-ckan.auth.create_user_via_web = false
+ckan.auth.create_user_via_api = true
+ckan.auth.create_user_via_web = true
 ckan.auth.roles_that_cascade_to_sub_groups = admin
 
 ## User Account Creation Setting

--- a/modules/govuk/templates/ckan/nginx.conf.erb
+++ b/modules/govuk/templates/ckan/nginx.conf.erb
@@ -34,6 +34,10 @@ location ~ /fanstatic/vendor/(:version:.*/)?font-awesome/fonts/fontawesome-webfo
     # Used for: internationalisation of form controls
     "/i18n",
 
+    # Used by: ckan.publishing.service.gov.uk
+    # Used for: finding members
+    "/2/util/user/autocomplete",
+
     # Used by: datagovuk_publish
     # Used for: ckan_v26_ckan_org_sync
     "/action/organization_list",

--- a/modules/govuk_ci/manifests/agent.pp
+++ b/modules/govuk_ci/manifests/agent.pp
@@ -38,6 +38,7 @@ class govuk_ci::agent(
   include ::govuk_jenkins::user
   include ::govuk_rbenv::all
   include ::govuk_python3
+  include ::govuk_python37
   include ::govuk_sysdig
   include ::govuk_testing_tools
   include ::yarn

--- a/modules/govuk_python37/manifests/apt_source.pp
+++ b/modules/govuk_python37/manifests/apt_source.pp
@@ -1,0 +1,17 @@
+# == Class: govuk_python::apt_source
+#
+# govuk-python apt source
+#
+class govuk_python37::apt_source (
+  $apt_mirror_hostname,
+  $apt_mirror_gpg_key_fingerprint,
+) {
+
+  apt::source { 'govuk-python37':
+    location     => "http://${apt_mirror_hostname}/govuk-python-3.7",
+    release      => 'stable',
+    architecture => $::architecture,
+    repos        => 'main',
+    key          => $apt_mirror_gpg_key_fingerprint,
+  }
+}

--- a/modules/govuk_python37/manifests/init.pp
+++ b/modules/govuk_python37/manifests/init.pp
@@ -1,0 +1,18 @@
+# FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
+class govuk_python37 (
+  $govuk_python_version = '3.7',
+) {
+
+  include govuk_python37::apt_source
+  include govuk_python::python
+
+  Class['python::install'] -> Package <| provider == 'pip' and ensure != absent |>
+
+  ensure_packages(
+    ['govuk-python-3.7'],
+    {
+      ensure  => $govuk_python_version,
+      require => Apt::Source['govuk-python37'],
+    }
+  )
+}


### PR DESCRIPTION
## What 

Add python 3.7 to CKAN and CI agent machines and also upgrade CKAN to 2.9.7

## Reference 

https://trello.com/c/ouCltnih/1595-handle-ckan-user-security-vulnerability