### PR TITLE
govuk-python-3.7 was packaged as version 1

### DIFF
--- a/hieradata_aws/class/ckan.yaml
+++ b/hieradata_aws/class/ckan.yaml
@@ -8,4 +8,4 @@ govuk::apps::ckan::enable_harvester_gather: true
 
 govuk_solr6::present: false
 
-govuk_python37::govuk_python_version: '3.7'
+govuk_python37::govuk_python_version: '1'


### PR DESCRIPTION
## What

Update version number to 1, as govuk-python-3.7 was packaged as version 1 not 3.7.15

https://github.com/alphagov/packager/blob/main/fpm/recipes/govuk-python-3.7.15/recipe.rb#L4