### PR TITLE
Set python37 version to 1 to deploy on CI agents

### DIFF
--- a/hieradata_aws/class/integration/ci_agent.yaml
+++ b/hieradata_aws/class/integration/ci_agent.yaml
@@ -16,6 +16,7 @@ postgresql::globals::version: '9.6'
 postgresql::globals::postgis_version: '3.1.1'
 govuk_postgresql::server::enable_collectd: false
 govuk_python3::govuk_python_version: '3.6.12'
+govuk_python37::govuk_python_version: '1'
 
 govuk_mysql::server::innodb_flush_log_at_trx_commit: 2
 govuk_mysql::server::innodb_buffer_pool_size_proportion: 0.05


### PR DESCRIPTION
## What

Update version number to 1 on CI agents for govuk-python-3.7 as it was was packaged as version 1

https://github.com/alphagov/packager/blob/main/fpm/recipes/govuk-python-3.7.15/recipe.rb#L4