### PR TITLE
Add support for RDS access (leave mongo access vars in place for now)

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -555,6 +555,12 @@ govuk::apps::frontend::unicorn_worker_processes: "4"
 
 govuk::apps::government_frontend::unicorn_worker_processes: "8"
 
+govuk::apps::imminence::db_hostname: "imminence-postgres"
+govuk::apps::imminence::db_password: "%{hiera('govuk::apps::imminence::db::password')}"
+govuk::apps::imminence::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
+govuk::apps::imminence::db::allow_auth_from_lb: true
+govuk::apps::imminence::db::lb_ip_range: "%{hiera('environment_ip_prefix')}.0.0/16"
+
 govuk::apps::link_checker_api::db_hostname: "link-checker-api-postgres"
 govuk::apps::link_checker_api::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 govuk::apps::link_checker_api::db::allow_auth_from_lb: true
@@ -808,6 +814,7 @@ govuk_awscloudwatch::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_finger
 govuk::apps::content_data_api::db::rds: true
 govuk::apps::content_tagger::db::rds: true
 govuk::apps::email_alert_api::db::rds: true
+govuk::apps::imminence::db::rds: true
 govuk::apps::link_checker_api::db::rds: true
 govuk::apps::local_links_manager::db::rds: true
 govuk::apps::locations_api::db::rds: true
@@ -869,6 +876,7 @@ govuk::node::s_content_data_api_db_admin::apt_mirror_hostname: "%{hiera('apt_mir
 govuk::node::s_content_publisher_db_admin::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk::node::s_content_tagger_db_admin::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk::node::s_email_alert_api_db_admin::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk::node::s_imminence_db_admin::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk::node::s_link_checker_api_db_admin::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk::node::s_local_links_manager_db_admin::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk::node::s_locations_api_db_admin::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"

--- a/modules/govuk/manifests/apps/imminence.pp
+++ b/modules/govuk/manifests/apps/imminence.pp
@@ -19,6 +19,21 @@
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
+# [*db_hostname*]
+#   The hostname of the database server to use in the DATABASE_URL.
+#
+# [*db_username*]
+#   The username to use in the DATABASE_URL.
+#
+# [*db_password*]
+#   The password for the database.
+#
+# [*db_name*]
+#   The database name to use in the DATABASE_URL.
+#
+# [*db_port*]
+#   The port of the database server to use in the DATABASE_URL.
+#   Default: undef
 #
 # [*mongodb_nodes*]
 #   An array of MongoDB instance hostnames
@@ -50,6 +65,11 @@ class govuk::apps::imminence(
   $port,
   $enable_procfile_worker = true,
   $sentry_dsn = undef,
+  $db_hostname = undef,
+  $db_username = 'imminence',
+  $db_password = undef,
+  $db_port = undef,
+  $db_name = 'imminence_production',
   $mongodb_nodes = undef,
   $mongodb_name = 'imminence_production',
   $redis_host = undef,
@@ -62,6 +82,8 @@ class govuk::apps::imminence(
 ) {
 
   $app_name = 'imminence'
+
+  include govuk_postgresql::client #installs libpq-dev package needed for pg gem
 
   Govuk::App::Envvar {
     ensure => $ensure,
@@ -118,6 +140,15 @@ class govuk::apps::imminence(
   govuk::app::envvar::mongodb_uri { $app_name:
     hosts    => $mongodb_nodes,
     database => $mongodb_name,
+  }
+
+  govuk::app::envvar::database_url { $app_name:
+    type     => 'postgis',
+    username => $db_username,
+    password => $db_password,
+    host     => $db_hostname,
+    port     => $db_port,
+    database => $db_name,
   }
 
   govuk::procfile::worker { $app_name:

--- a/modules/govuk/manifests/apps/imminence/db.pp
+++ b/modules/govuk/manifests/apps/imminence/db.pp
@@ -1,0 +1,35 @@
+# == Class: govuk::apps::imminence::db
+#
+# === Parameters
+#
+# [*password*]
+#   The DB instance password.
+#
+# [*backend_ip_range*]
+#   Backend IP addresses to allow access to the database.
+#
+# [*allow_auth_from_lb*]
+#   Whether to allow this user to authenticate for this database from
+#   the load balancer using its password.
+#   Default: false
+#
+# [*lb_ip_range*]
+#   Network range for the load balancer.
+#
+class govuk::apps::imminence::db (
+  $password = undef,
+  $backend_ip_range = undef,
+  $allow_auth_from_lb = false,
+  $lb_ip_range = undef,
+  $rds = false,
+) {
+  govuk_postgresql::db { 'imminence_production':
+    user                    => 'imminence',
+    password                => $password,
+    allow_auth_from_backend => true,
+    backend_ip_range        => $backend_ip_range,
+    allow_auth_from_lb      => $allow_auth_from_lb,
+    lb_ip_range             => $lb_ip_range,
+    rds                     => $rds,
+  }
+}

--- a/modules/govuk/manifests/node/s_imminence_db_admin.pp
+++ b/modules/govuk/manifests/node/s_imminence_db_admin.pp
@@ -1,0 +1,45 @@
+# == Class: govuk_node::s_imminence_db_admin
+#
+# This machine class is used to administer the Imminence
+# PostgreSQL RDS instances.
+#
+# === Parameters
+#
+# [*postgres_host*]
+#   Hostname of the RDS database to use.
+#   Default: undef
+#
+# [*postgres_user*]
+#   The PostgreSQL user to use for administering the database.
+#   Default: undef
+#
+# [*postgres_password*]
+#   The password corresponding to the above `postgres_user`.
+#   Default: undef
+#
+# [*postgres_port*]
+#   The port with which to connect to the `postgres_host`.
+#   Default: '5432'
+#
+class govuk::node::s_imminence_db_admin(
+  $postgres_host        = undef,
+  $postgres_user        = undef,
+  $postgres_password    = undef,
+  $postgres_port        = '5432',
+  $apt_mirror_hostname,
+) {
+  include govuk_env_sync
+  include ::govuk::node::s_base
+
+  # include the common config/tooling required for our app-specific DB admin class
+  class { '::govuk::nodes::postgresql_db_admin':
+    postgres_host       => $postgres_host,
+    postgres_user       => $postgres_user,
+    postgres_password   => $postgres_password,
+    postgres_port       => $postgres_port,
+    apt_mirror_hostname => $apt_mirror_hostname,
+  } ->
+
+  # include all PostgreSQL classes that create databases and users
+  class { '::govuk::apps::imminence::db': }
+}

--- a/spec/fixtures/hieradata/common.yaml
+++ b/spec/fixtures/hieradata/common.yaml
@@ -44,6 +44,7 @@ govuk::node::s_content_data_api_db_admin::apt_mirror_hostname: "%{hiera('apt_mir
 govuk::node::s_content_publisher_db_admin::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk::node::s_content_tagger_db_admin::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk::node::s_email_alert_api_db_admin::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
+govuk::node::s_imminence_db_admin::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk::node::s_link_checker_api_db_admin::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk::node::s_local_links_manager_db_admin::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk::node::s_locations_api_db_admin::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"


### PR DESCRIPTION
Adds puppet config to allow Imminence to talk to RDS, needed for the Postgres switch.

Imminence PR:
https://github.com/alphagov/imminence/pull/766

Related PRS:
https://github.com/alphagov/govuk-aws-data/pull/1124
https://github.com/alphagov/govuk-aws/pull/1653
https://github.com/alphagov/govuk-secrets/pull/1401

Trello Card:
https://trello.com/c/R6Lb3vYa/1611-move-imminence-away-from-mongodb-onto-postgres