### PR TITLE
Remove middleman-search from Jenkins

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -973,7 +973,6 @@ govuk_ci::master::pipeline_jobs:
       - 'integration'
       - 'staging'
       - 'production'
-  middleman-search: {}
   smokey: {}
 
 govuk_ci::master::ci_agents:


### PR DESCRIPTION
Trello: https://trello.com/c/QrxjshEm/270-move-ruby-gems-from-jenkins-to-github-actions

This tool is no longer being built by Jenkins [1] (it didn't actually have a test suite so was always a bit of an odd-fit here)

[1]: https://github.com/alphagov/middleman-search/pull/10