### PR TITLE
Disable ckan user creation for API and web

### DIFF
--- a/modules/govuk/templates/ckan/ckan.ini.erb
+++ b/modules/govuk/templates/ckan/ckan.ini.erb
@@ -61,8 +61,8 @@ ckan.auth.user_create_groups = false
 ckan.auth.user_create_organizations = true
 ckan.auth.user_delete_groups = false
 ckan.auth.user_delete_organizations = true
-ckan.auth.create_user_via_api = true
-ckan.auth.create_user_via_web = true
+ckan.auth.create_user_via_api = false
+ckan.auth.create_user_via_web = false
 ckan.auth.roles_that_cascade_to_sub_groups = admin
 
 ## User Account Creation Setting


### PR DESCRIPTION
## What 

The upgrade of CKAN caused an issue with log ins which will need to be investigated. So have had to downgrade to mitigate security vulnerability around user creation.

## Reference 

https://trello.com/c/ouCltnih/1595-handle-ckan-user-security-vulnerability