### PR TITLE
Update Richard Towers' ssh key

### DIFF
--- a/modules/users/manifests/richardtowers.pp
+++ b/modules/users/manifests/richardtowers.pp
@@ -3,6 +3,6 @@ class users::richardtowers {
   govuk_user { 'richardtowers':
     fullname => 'Richard Towers',
     email    => 'richard.towers@digital.cabinet-office.gov.uk',
-    ssh_key  => 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXmBraPYRMsCCj0Hw1q73SW8d4hBXcoZMxdifRqVYs4/4GZqaJJbWKRaQ2eRAN6yeHgkAWdsrPx6NBbq12QGRIVpNF6C3eaIVQaU+fdOWepFi9dDbFWymPFspWC1pSwXBl/A3k4JbwyCsaUO7TfjzL4XB3CYjVkopmlvjjQTHBB8sdSm922A/czEK6DAqmDXrU5iDaiauN/dXx2qk9El6dfTyXDFXADgFXN3rMvPGY+V8UPSGUDSkB5K+SjyrtbkP+QaKvavoyHF/k+Tvib7Wp3fZgcBF9vQZ9tTQ22CBd4YJbrUSqMCVNFMpc09WDHw/o15acmUtKdfvbbowdPuyt2mUzkJsj5brfHTs22uHln5Bojs3RcnO74mO8aEIJ0WmbExM/Um4wuBrSOSAxxBsktnVAKkEfb2XtbYLEruyp9z/ycPELBf4iaES3pgbBVogvX+cq8TPSOSu7x8hM3+Cvkw7j07GhZsmTQEHERKPnHMa+LeaXkKAQOecHPUQZ6HhVDHuEI9agQ0GVufsUs3asOcwIZwXSLvXGymbsgnhogpxU9Cy5CXZtsPfZWSbq5n+OuRDKjT19Eks/8fSenvSuIaDkKZbCuhEwIutvTO3rZmzm/7vFnGA0YTkJX5qKNDgvtPDJJkn2MuEwyRbSCX2CH66WOEfkCE4MJqDthjERBw== richard.towers@digital.cabinet-office.gov.uk',
+    ssh_key  => 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBznmW+hlnSqCeuYFIMSI+hRSQdngjMWWQ9HWipd33sj richard.towers@digital.cabinet-office.gov.uk',
   }
 }


### PR DESCRIPTION
I had my GDS macbook rebuilt a while back, but didn't get around to replacing my SSH key.

From what I can see in other files, it looks like we're fine with EdDSA keys now, so switching from RSA.

This is the same public key I use for GitHub, which you can check here - https://github.com/richardtowers.keys