### PR TITLE
Remove govuk_content_schemas_path env variable for publishing api

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -656,7 +656,6 @@ govuk::apps::publishing_api::redis_port: "%{hiera('sidekiq_port')}"
 govuk::apps::publishing_api::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 govuk::apps::publishing_api::db::allow_auth_from_lb: true
 govuk::apps::publishing_api::db::lb_ip_range: "%{hiera('environment_ip_prefix')}.0.0/16"
-govuk::apps::publishing_api::govuk_content_schemas_path: '/data/apps/publishing-api/current/content_schemas'
 
 govuk::apps::release::db_hostname: "release-mysql"
 govuk::apps::release::db_username: "release"

--- a/modules/govuk/manifests/apps/publishing_api.pp
+++ b/modules/govuk/manifests/apps/publishing_api.pp
@@ -90,9 +90,6 @@
 #   A password to connect to RabbitMQ:
 #   https://github.com/alphagov/publishing-api/blob/master/config/rabbitmq.yml
 #
-# [*govuk_content_schemas_path*]
-#   The path for generated content-schemas
-#
 # [*event_log_aws_bucketname*]
 #   The S3 bucket used to store the event logs.
 #
@@ -133,7 +130,6 @@ class govuk::apps::publishing_api(
   $rabbitmq_hosts = ['localhost'],
   $rabbitmq_user = 'publishing_api',
   $rabbitmq_password = undef,
-  $govuk_content_schemas_path = '',
   $event_log_aws_bucketname = undef,
   $event_log_aws_username   = undef,
   $event_log_aws_access_id  = undef,
@@ -208,9 +204,6 @@ class govuk::apps::publishing_api(
       "${title}-GDS_SSO_OAUTH_SECRET":
         varname => 'GDS_SSO_OAUTH_SECRET',
         value   => $oauth_secret;
-      "${title}-GOVUK_CONTENT_SCHEMAS_PATH":
-        varname => 'GOVUK_CONTENT_SCHEMAS_PATH',
-        value   => $govuk_content_schemas_path;
       "${title}-EVENT_LOG_AWS_BUCKETNAME":
         varname => 'EVENT_LOG_AWS_BUCKETNAME',
         value   => $event_log_aws_bucketname;


### PR DESCRIPTION
This is no longer required as [publishing api uses](https://github.com/alphagov/publishing-api/blob/ce4de24fd643bbd2d0a5c80724c284037b845cc1/config/initializers/govuk_schemas.rb\#L1) the newly introduced [directly configurable content schemas path](https://github.com/alphagov/govuk_schemas/commit/a02616d4181c472b2b6b0878d7ef98749d15c776) introduced in govuk_schemas. This bypasses the env variable, so we can now remove this.

[Trello](https://trello.com/c/ZUK2duYI/361-add-govuk-content-schemas-to-publishing-api-repo)