### PR TITLE
Remove remaining gems from Jenkins CI

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -951,10 +951,7 @@ govuk_ci::master::pipeline_jobs:
   support: {}
   transition: {}
   # Other repositories
-  gds-api-adapters: {}
-  gds-sso: {}
   govuk-jenkinslib: {}
-  govuk_sidekiq: {}
   licensify:
     branches_to_exclude:
       - 'release*'


### PR DESCRIPTION
These gems are now built with GitHub Actions.