### PR TITLE
Downgrade to python 3.6 for CKAN

### DIFF
--- a/hieradata_aws/class/ckan.yaml
+++ b/hieradata_aws/class/ckan.yaml
@@ -8,4 +8,4 @@ govuk::apps::ckan::enable_harvester_gather: true
 
 govuk_solr6::present: false
 
-govuk_python37::govuk_python_version: '1'
+govuk_python3::govuk_python_version: '3.6.12'

--- a/modules/govuk/manifests/node/s_ckan.pp
+++ b/modules/govuk/manifests/node/s_ckan.pp
@@ -18,7 +18,7 @@ class govuk::node::s_ckan inherits govuk::node::s_base {
     both       => 1024,
   }
 
-  include govuk_python37
+  include govuk_python3
   include nginx
   include postgresql::lib::devel
   include govuk_java::openjdk8::jre


### PR DESCRIPTION
There appears to be an issue connecting to clients after the python upgrade. So downgrade it back to 3.6.12