### PR TITLE
Forward draft-assets traffic to internal LBs instead of public LBs.

### DIFF
--- a/modules/router/manifests/draft_assets.pp
+++ b/modules/router/manifests/draft_assets.pp
@@ -18,14 +18,8 @@ class router::draft_assets(
 ) {
   $whitehall_uploaded_assets_routes = hiera('router::assets_origin::whitehall_uploaded_assets_routes', [])
   $asset_manager_uploaded_assets_routes = hiera('router::assets_origin::asset_manager_uploaded_assets_routes', [])
-
   $upstream_ssl = true
-
-  if $::aws_environment == 'integration'{
-    $app_domain = hiera('app_domain_internal')
-  } else {
-    $app_domain = hiera('app_domain')
-  }
+  $app_domain = hiera('app_domain_internal')
 
   nginx::config::site { $vhost_name:
     content => template('router/draft-assets.conf.erb'),


### PR DESCRIPTION
The public load balancers for whitehall-frontend were removed in https://github.com/alphagov/govuk-aws/pull/1572.

This should fix asset preview pages in draft (Content Preview), which have been broken since 5 Apr when the above was merged. (https://github.com/alphagov/govuk-aws/commit/f122845).

Examples of broken draft assets preview pages:
- https://draft-assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1120394/HMRC_ePCS_spending_over_500_for_October_2022.csv/preview
- https://draft-assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1106432/HMRC_Senior_Officials_Travel_April_to_June_2022.csv/preview

Rollout: will test on staging to confirm the fix.