### PR TITLE
Use amazonmq instead of rabbit mq on integration [Do not merge yet]

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -446,6 +446,7 @@ govuk::apps::bouncer::unicorn_worker_processes: "8"
 
 govuk::apps::cache_clearing_service::enabled: true
 govuk::apps::cache_clearing_service::rabbitmq::enabled: true
+govuk::apps::cache_clearing_service::rabbitmq_url: ""
 govuk::apps::cache_clearing_service::rabbitmq_hosts: [rabbitmq]
 govuk::apps::cache_clearing_service::rabbitmq::queue_size_critical_threshold: 100000
 govuk::apps::cache_clearing_service::rabbitmq::queue_size_warning_threshold: 80000
@@ -487,6 +488,7 @@ govuk::apps::content_data_api::db_hostname: "content-data-api-postgresql-primary
 govuk::apps::content_data_api::db::lb_ip_range: "%{hiera('environment_ip_prefix')}.0.0/16"
 govuk::apps::content_data_api::rabbitmq_hosts:
   - rabbitmq
+govuk::apps::content_data_api::rabbitmq_url: ""
 govuk::apps::content_data_api::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::content_data_api::redis_port: "%{hiera('sidekiq_port')}"
 
@@ -531,6 +533,7 @@ govuk::apps::email_alert_frontend::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::email_alert_frontend::redis_port: "%{hiera('sidekiq_port')}"
 
 govuk::apps::email_alert_service::enabled: true
+govuk::apps::email_alert_service::rabbitmq_url: ""
 govuk::apps::email_alert_service::rabbitmq_hosts:
   - rabbitmq
 govuk::apps::email_alert_service::redis_host: "%{hiera('sidekiq_host')}"
@@ -648,6 +651,9 @@ govuk::apps::publishing_api::unicorn_worker_processes: "8"
 govuk::apps::publishing_api::content_store: "https://content-store.%{hiera('app_domain')}"
 govuk::apps::publishing_api::db_hostname: "publishing-api-postgres"
 govuk::apps::publishing_api::draft_content_store: "https://draft-content-store.%{hiera('app_domain')}"
+# AmazonMQ requires an amqps:// URL
+govuk::apps::publishing_api::rabbitmq_url: ""
+# Separate variables for self-hosted RabbitMQ
 govuk::apps::publishing_api::rabbitmq_hosts:
   - rabbitmq
 govuk::apps::publishing_api::rabbitmq_password: "%{hiera('govuk::apps::publishing_api::rabbitmq::amqp_pass')}"
@@ -665,6 +671,7 @@ govuk::apps::release::github_username: "govuk-ci"
 govuk::apps::search_api::enable_bulk_reindex_listener: true
 govuk::apps::search_api::enable_publishing_listener: true
 govuk::apps::search_api::enable_govuk_index_listener: true
+govuk::apps::search_api::rabbitmq_url: ""
 govuk::apps::search_api::rabbitmq::enable_bulk_reindex_listener: true
 govuk::apps::search_api::rabbitmq::enable_govuk_index_listener: true
 govuk::apps::search_api::rabbitmq::enable_publishing_listener: true

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -14,7 +14,7 @@ environment_ip_prefix: '10.1'
 govuk::apps::account_api::account_oauth_provider_uri: 'https://oidc.integration.account.gov.uk/'
 govuk::apps::asset_manager::aws_s3_bucket_name: 'govuk-assets-integration'
 govuk::apps::asset_manager::aws_region: 'eu-west-1'
-govuk::apps::cache_clearing_service::rabbitmq_url: "amqps://cache_clearing_service:%{hiera('govuk_publishing_amazonmq::passwords::cache_clearing_service')}@publishingmq.integration.govuk-internal.digital:5671/"
+govuk::apps::cache_clearing_service::rabbitmq_url: "amqps://cache_clearing_service:%{hiera('govuk_publishing_amazonmq::passwords::cache_clearing_service')}@publishingmq.integration.govuk-internal.digital:5671/publishing"
 govuk::apps::ckan::ckan_site_url: 'https://ckan.integration.publishing.service.gov.uk'
 govuk::apps::ckan::s3_bucket_name: "datagovuk-integration-ckan-organogram"
 govuk::apps::ckan::s3_aws_region_name: "eu-west-1"
@@ -26,7 +26,7 @@ govuk::apps::content_data_admin::google_tag_manager_id: 'GTM-NZG8SF2'
 govuk::apps::content_data_admin::aws_csv_export_bucket_name: 'govuk-integration-content-data-csvs'
 govuk::apps::content_data_admin::govuk_notify_template_id: "759acac6-da53-4a19-b591-b7538c7c39de"
 govuk::apps::content_data_api::etl_healthcheck_enabled_from_hour: '14'
-govuk::apps::content_data_api::rabbitmq_url: "amqps://content_data_api:%{hiera('govuk_publishing_amazonmq::passwords::content_data_api')}@publishingmq.integration.govuk-internal.digital:5671/"
+govuk::apps::content_data_api::rabbitmq_url: "amqps://content_data_api:%{hiera('govuk_publishing_amazonmq::passwords::content_data_api')}@publishingmq.integration.govuk-internal.digital:5671/publishing"
 govuk::apps::content_publisher::aws_s3_bucket: "govuk-integration-content-publisher-activestorage"
 govuk::apps::content_publisher::google_tag_manager_auth: "xTPyDeRcMiXFWvscgkLowg"
 govuk::apps::content_publisher::google_tag_manager_id: "GTM-NQXC4TG"
@@ -43,7 +43,7 @@ govuk::apps::email_alert_api::govuk_notify_recipients:
 govuk::apps::email_alert_frontend::subscription_management_enabled: true
 govuk::apps::email_alert_frontend::govuk_personalisation_manage_uri: 'https://integration.account.gov.uk?link=manage-account'
 govuk::apps::email_alert_frontend::govuk_personalisation_your_account_uri: 'https://integration.account.gov.uk'
-govuk::apps::email_alert_service::rabbitmq_url: "amqps://email_alert_service:%{hiera('govuk_publishing_amazonmq::passwords::email_alert_service')}@publishingmq.integration.govuk-internal.digital:5671/"
+govuk::apps::email_alert_service::rabbitmq_url: "amqps://email_alert_service:%{hiera('govuk_publishing_amazonmq::passwords::email_alert_service')}@publishingmq.integration.govuk-internal.digital:5671/publishing"
 govuk::apps::feedback::govuk_notify_survey_signup_reply_to_id: 'fee22233-2f28-4b0b-8b6c-4410979f2275'
 govuk::apps::feedback::govuk_notify_survey_signup_template_id: 'eb9ba220-7d74-4aab-975a-bdbe718f69a3'
 govuk::apps::feedback::govuk_notify_accessible_format_request_reply_to_id: '93109fea-34d9-4c38-ac7e-1ebc75e7416b'
@@ -67,10 +67,10 @@ govuk::apps::publisher::email_group_force_publish_alerts: 'mainstream-publisher-
 govuk::apps::publisher::fact_check_subject_prefix: 'dev'
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-integration'
 govuk::apps::publishing_api::content_api_prototype: true
-govuk::apps::publishing_api::rabbitmq_url: "amqps://publishing_api:%{hiera('govuk_publishing_amazonmq::passwords::publishing_api')}@publishingmq.integration.govuk-internal.digital:5671/"
+govuk::apps::publishing_api::rabbitmq_url: "amqps://publishing_api:%{hiera('govuk_publishing_amazonmq::passwords::publishing_api')}@publishingmq.integration.govuk-internal.digital:5671/publishing"
 govuk::apps::router::sentry_environment: 'integration'
 govuk::apps::search_admin::govuk_notify_template_id: "759acac6-da53-4a19-b591-b7538c7c39de"
-govuk::apps::search_api::rabbitmq_url: "amqps://search_api:%{hiera('govuk_publishing_amazonmq::passwords::search_api')}@publishingmq.integration.govuk-internal.digital:5671/"
+govuk::apps::search_api::rabbitmq_url: "amqps://search_api:%{hiera('govuk_publishing_amazonmq::passwords::search_api')}@publishingmq.integration.govuk-internal.digital:5671/publishing"
 govuk::apps::search_api::elasticsearch_hosts: 'https://vpc-blue-elasticsearch6-domain-uolbxqjhkiqmg5w3gg7gio5sty.eu-west-1.es.amazonaws.com'
 govuk::apps::search_api::relevancy_bucket_name: 'govuk-integration-search-relevancy'
 govuk::apps::search_api::sitemaps_bucket_name: 'govuk-integration-sitemaps'

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -14,6 +14,7 @@ environment_ip_prefix: '10.1'
 govuk::apps::account_api::account_oauth_provider_uri: 'https://oidc.integration.account.gov.uk/'
 govuk::apps::asset_manager::aws_s3_bucket_name: 'govuk-assets-integration'
 govuk::apps::asset_manager::aws_region: 'eu-west-1'
+govuk::apps::cache_clearing_service::rabbitmq_url: "amqps://cache_clearing_service:%{hiera('govuk_publishing_amazonmq::passwords::cache_clearing_service')}@publishingmq.integration.govuk-internal.digital:5671/"
 govuk::apps::ckan::ckan_site_url: 'https://ckan.integration.publishing.service.gov.uk'
 govuk::apps::ckan::s3_bucket_name: "datagovuk-integration-ckan-organogram"
 govuk::apps::ckan::s3_aws_region_name: "eu-west-1"
@@ -25,6 +26,7 @@ govuk::apps::content_data_admin::google_tag_manager_id: 'GTM-NZG8SF2'
 govuk::apps::content_data_admin::aws_csv_export_bucket_name: 'govuk-integration-content-data-csvs'
 govuk::apps::content_data_admin::govuk_notify_template_id: "759acac6-da53-4a19-b591-b7538c7c39de"
 govuk::apps::content_data_api::etl_healthcheck_enabled_from_hour: '14'
+govuk::apps::content_data_api::rabbitmq_url: "amqps://content_data_api:%{hiera('govuk_publishing_amazonmq::passwords::content_data_api')}@publishingmq.integration.govuk-internal.digital:5671/"
 govuk::apps::content_publisher::aws_s3_bucket: "govuk-integration-content-publisher-activestorage"
 govuk::apps::content_publisher::google_tag_manager_auth: "xTPyDeRcMiXFWvscgkLowg"
 govuk::apps::content_publisher::google_tag_manager_id: "GTM-NQXC4TG"
@@ -41,6 +43,7 @@ govuk::apps::email_alert_api::govuk_notify_recipients:
 govuk::apps::email_alert_frontend::subscription_management_enabled: true
 govuk::apps::email_alert_frontend::govuk_personalisation_manage_uri: 'https://integration.account.gov.uk?link=manage-account'
 govuk::apps::email_alert_frontend::govuk_personalisation_your_account_uri: 'https://integration.account.gov.uk'
+govuk::apps::email_alert_service::rabbitmq_url: "amqps://email_alert_service:%{hiera('govuk_publishing_amazonmq::passwords::email_alert_service')}@publishingmq.integration.govuk-internal.digital:5671/"
 govuk::apps::feedback::govuk_notify_survey_signup_reply_to_id: 'fee22233-2f28-4b0b-8b6c-4410979f2275'
 govuk::apps::feedback::govuk_notify_survey_signup_template_id: 'eb9ba220-7d74-4aab-975a-bdbe718f69a3'
 govuk::apps::feedback::govuk_notify_accessible_format_request_reply_to_id: '93109fea-34d9-4c38-ac7e-1ebc75e7416b'
@@ -64,8 +67,10 @@ govuk::apps::publisher::email_group_force_publish_alerts: 'mainstream-publisher-
 govuk::apps::publisher::fact_check_subject_prefix: 'dev'
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-integration'
 govuk::apps::publishing_api::content_api_prototype: true
+govuk::apps::publishing_api::rabbitmq_url: "amqps://publishing_api:%{hiera('govuk_publishing_amazonmq::passwords::publishing_api')}@publishingmq.integration.govuk-internal.digital:5671/"
 govuk::apps::router::sentry_environment: 'integration'
 govuk::apps::search_admin::govuk_notify_template_id: "759acac6-da53-4a19-b591-b7538c7c39de"
+govuk::apps::search_api::rabbitmq_url: "amqps://search_api:%{hiera('govuk_publishing_amazonmq::passwords::search_api')}@publishingmq.integration.govuk-internal.digital:5671/"
 govuk::apps::search_api::elasticsearch_hosts: 'https://vpc-blue-elasticsearch6-domain-uolbxqjhkiqmg5w3gg7gio5sty.eu-west-1.es.amazonaws.com'
 govuk::apps::search_api::relevancy_bucket_name: 'govuk-integration-search-relevancy'
 govuk::apps::search_api::sitemaps_bucket_name: 'govuk-integration-sitemaps'

--- a/modules/govuk/manifests/app/envvar/rabbitmq.pp
+++ b/modules/govuk/manifests/app/envvar/rabbitmq.pp
@@ -17,11 +17,16 @@
 #   The RabbitMQ vhost.
 #   Default: "/"
 #
+# [*url*]
+#   URL of the RabbitMQ broker, including username and password
+#   Default: ""
+# 
 define govuk::app::envvar::rabbitmq (
   $hosts,
   $user,
   $password,
   $vhost = '/',
+  $url = '',
 ) {
 
   validate_array($hosts)
@@ -46,5 +51,8 @@ define govuk::app::envvar::rabbitmq (
     "${title}-RABBITMQ_PASSWORD":
       varname => 'RABBITMQ_PASSWORD',
       value   => $password;
+    "${title}-RABBITMQ_URL":
+      varname => 'RABBITMQ_URL',
+      value   => $url;
   }
 }

--- a/modules/govuk/manifests/apps/cache_clearing_service.pp
+++ b/modules/govuk/manifests/apps/cache_clearing_service.pp
@@ -24,6 +24,10 @@
 #   RabbitMQ password.
 #   Default: cache_clearing_service
 #
+# [*rabbitmq_url*]
+#   RabbitMQ URL, including username and password.
+#   Default: ''
+#
 # [*puppetdb_node_url*]
 #   The `nodes` endpoint URL for Puppet DB
 #
@@ -37,6 +41,7 @@ class govuk::apps::cache_clearing_service (
   $rabbitmq_hosts = ['localhost'],
   $rabbitmq_user = 'cache_clearing_service',
   $rabbitmq_password = 'cache_clearing_service',
+  $rabbitmq_url = '',
   $puppetdb_node_url = undef,
   $aws_region = 'eu-west-1',
 ) {
@@ -66,6 +71,7 @@ class govuk::apps::cache_clearing_service (
     hosts    => $rabbitmq_hosts,
     user     => $rabbitmq_user,
     password => $rabbitmq_password,
+    url      => $rabbitmq_url,
   }
 
   govuk::app::envvar {

--- a/modules/govuk/manifests/apps/cache_clearing_service/rabbitmq.pp
+++ b/modules/govuk/manifests/apps/cache_clearing_service/rabbitmq.pp
@@ -21,12 +21,17 @@
 #   The RabbitMQ queue to set up for workers of this type to read from
 #   (default: 'cache_clearing_service')
 #
+# [*rabbitmq_url*]
+#   RabbitMQ URL, including username and password.
+#   Default: ''
+#
 class govuk::apps::cache_clearing_service::rabbitmq (
   $enabled = false,
   $amqp_user  = 'cache_clearing_service',
   $amqp_pass = 'cache_clearing_service',
   $amqp_exchange = 'published_documents',
   $amqp_queue = 'cache_clearing_service',
+  $rabbitmq_url = '',
   $queue_size_critical_threshold,
   $queue_size_warning_threshold,
 ) {

--- a/modules/govuk/manifests/apps/content_data_api.pp
+++ b/modules/govuk/manifests/apps/content_data_api.pp
@@ -58,6 +58,10 @@
 #   RabbitMQ hosts to connect to.
 #   Default: localhost
 #
+# [*rabbitmq_url*]
+#   RabbitMQ URL, including username and password.
+#   Default: ''
+#
 # [*rabbitmq_user*]
 #   RabbitMQ username.
 #   This is a required parameter
@@ -111,6 +115,7 @@ class govuk::apps::content_data_api(
   $port,
   $publishing_api_bearer_token = undef,
   $rabbitmq_hosts = ['localhost'],
+  $rabbitmq_url = '',
   $rabbitmq_vhost = '/',
   $rabbitmq_password = undef,
   $rabbitmq_user = undef,
@@ -194,6 +199,9 @@ class govuk::apps::content_data_api(
     "${title}-RABBITMQ_PASSWORD":
       varname => 'RABBITMQ_PASSWORD',
       value   => $rabbitmq_password;
+    "${title}-RABBITMQ_URL":
+      varname => 'RABBITMQ_URL',
+      value   => $rabbitmq_url;
     "${title}-RABBITMQ_QUEUE":
       varname => 'RABBITMQ_QUEUE',
       value   => $rabbitmq_queue;

--- a/modules/govuk/manifests/apps/content_data_api/rabbitmq.pp
+++ b/modules/govuk/manifests/apps/content_data_api/rabbitmq.pp
@@ -33,6 +33,10 @@
 #   The RabbitMQ queue to recieve unprocessed messages.
 #   (default: 'content_data_api_dead_letter_queue')
 #
+# [*rabbitmq_url*]
+#   RabbitMQ URL, including username and password.
+#   Default: ''
+#
 class govuk::apps::content_data_api::rabbitmq (
   $amqp_user  = 'content_data_api',
   $amqp_pass = undef,
@@ -40,7 +44,8 @@ class govuk::apps::content_data_api::rabbitmq (
   $amqp_dlx = 'content_data_api_dlx',
   $amqp_queue = 'content_data_api',
   $amqp_bulk_importing_queue = 'content_data_api_govuk_importer',
-  $amqp_dead_letter_queue = 'content_data_api_dead_letter_queue'
+  $amqp_dead_letter_queue = 'content_data_api_dead_letter_queue',
+  $rabbitmq_url = '',
 ) {
 
   govuk_rabbitmq::exchange { "${amqp_dlx}@/":

--- a/modules/govuk/manifests/apps/email_alert_service.pp
+++ b/modules/govuk/manifests/apps/email_alert_service.pp
@@ -21,6 +21,10 @@
 #   RabbitMQ password.
 #   Default: email_alert_service
 #
+# [*rabbitmq_url*]
+#   RabbitMQ URL, including username and password.
+#   Default: ''
+#
 # [*sentry_dsn*]
 #   The URL used by Sentry to report exceptions
 #
@@ -40,6 +44,7 @@ class govuk::apps::email_alert_service(
   $rabbitmq_hosts = ['localhost'],
   $rabbitmq_user = 'email_alert_service',
   $rabbitmq_password = 'email_alert_service',
+  $rabbitmq_url = '',
   $sentry_dsn = undef,
   $redis_host = undef,
   $email_alert_api_bearer_token = undef,
@@ -94,6 +99,7 @@ class govuk::apps::email_alert_service(
     hosts    => $rabbitmq_hosts,
     user     => $rabbitmq_user,
     password => $rabbitmq_password,
+    url      => $rabbitmq_url,
   }
 
   govuk::app::envvar::redis { 'email-alert-service':

--- a/modules/govuk/manifests/apps/email_alert_service/rabbitmq.pp
+++ b/modules/govuk/manifests/apps/email_alert_service/rabbitmq.pp
@@ -36,6 +36,10 @@
 #   The number of unprocessed messages which can build up before triggering
 #   a warning.
 #
+# [*rabbitmq_url*]
+#   RabbitMQ URL, including username and password.
+#   Default: ''
+#
 class govuk::apps::email_alert_service::rabbitmq (
   $ensure = 'present',
   $amqp_user  = 'email_alert_service',
@@ -47,6 +51,7 @@ class govuk::apps::email_alert_service::rabbitmq (
   $ampq_subscriber_list_update_major_queue = 'subscriber_list_details_update_major',
   $queue_size_critical_threshold,
   $queue_size_warning_threshold,
+  $rabbitmq_url = '',
 ) {
 
   govuk_rabbitmq::queue_with_binding { $amqp_major_change_queue:

--- a/modules/govuk/manifests/apps/publishing_api.pp
+++ b/modules/govuk/manifests/apps/publishing_api.pp
@@ -83,6 +83,10 @@
 #   RabbitMQ hosts to connect to.
 #   Default: localhost
 #
+# [*rabbitmq_url*]
+#   RabbitMQ URL, including username and password.
+#   Default: ''
+#
 # [*rabbitmq_user*]
 #   RabbitMQ username.
 #
@@ -128,6 +132,7 @@ class govuk::apps::publishing_api(
   $oauth_id = undef,
   $oauth_secret = undef,
   $rabbitmq_hosts = ['localhost'],
+  $rabbitmq_url = '',
   $rabbitmq_user = 'publishing_api',
   $rabbitmq_password = undef,
   $event_log_aws_bucketname = undef,
@@ -177,6 +182,7 @@ class govuk::apps::publishing_api(
       hosts    => $rabbitmq_hosts,
       user     => $rabbitmq_user,
       password => $rabbitmq_password,
+      url      => $rabbitmq_url,
     }
 
     govuk::app::envvar {

--- a/modules/govuk/manifests/apps/publishing_api/rabbitmq.pp
+++ b/modules/govuk/manifests/apps/publishing_api/rabbitmq.pp
@@ -20,11 +20,16 @@
 # [*configure_test_exchange*]
 #   Whether or not to set up a test exchange for development (default: false)
 #
+# [*rabbitmq_url*]
+#   RabbitMQ URL, including username and password.
+#   Default: ''
+#
 class govuk::apps::publishing_api::rabbitmq (
   $amqp_user  = 'publishing_api',
   $amqp_pass  = 'publishing_api',
   $amqp_exchange = 'published_documents',
   $configure_test_exchange = false,
+  $rabbitmq_url = '',
 ) {
   rabbitmq_user { $amqp_user:
     password => $amqp_pass,

--- a/modules/govuk/manifests/apps/search_api.pp
+++ b/modules/govuk/manifests/apps/search_api.pp
@@ -37,6 +37,10 @@
 #   RabbitMQ hosts to connect to.
 #   Default: localhost
 #
+# [*rabbitmq_url*]
+#   RabbitMQ URL, including username and password.
+#   Default: ''
+#
 # [*rabbitmq_user*]
 #   RabbitMQ username.
 #   This is a required parameter
@@ -122,6 +126,7 @@ class govuk::apps::search_api(
   $google_export_web_property_id = undef,
   $google_export_custom_data_source_id = undef,
   $rabbitmq_hosts = ['localhost'],
+  $rabbitmq_url = '',
   $rabbitmq_password = 'search-api',
   $redis_host = undef,
   $redis_port = undef,
@@ -166,6 +171,7 @@ class govuk::apps::search_api(
     hosts    => $rabbitmq_hosts,
     user     => $rabbitmq_user,
     password => $rabbitmq_password,
+    url      => $rabbitmq_url,
   }
 
   govuk::app::envvar::redis { 'search-api':

--- a/modules/govuk/manifests/apps/search_api/rabbitmq.pp
+++ b/modules/govuk/manifests/apps/search_api/rabbitmq.pp
@@ -19,11 +19,16 @@
 # [*enable_bulk_reindex_listener*]
 #   Whether or not to configure the queue for the govuk bulk indexer
 #
+# [*rabbitmq_url*]
+#   RabbitMQ URL, including username and password.
+#   Default: ''
+#
 class govuk::apps::search_api::rabbitmq (
   $password  = 'search-api',
   $enable_govuk_index_listener = false,
   $enable_publishing_listener = false,
   $enable_bulk_reindex_listener = false,
+  $rabbitmq_url = '',
 ) {
 
   $amqp_exchange = 'published_documents'


### PR DESCRIPTION
Supply `RABBITMQ_URL` env var to publishing-api, search-api, email-alert-service, cache-clearing-service, and content-data-api on integration only. 

This URL points to the new AmazonMQ broker in integration. When this is merged, publishing-api will start publishing messages to AmazonMQ instead of the existing RabbitMQ. 

The consuming apps will ignore the `RABBITMQ_URL` env var and stay consuming from the existing RabbitMQ until the [corresponding new version of govuk_message_queue_consumer](https://github.com/alphagov/govuk_message_queue_consumer/pull/80) is released. 