### PR TITLE
Remove TLS V1 and TLS V1.1 from the list of ssl_protocols in nginx

### DIFF
--- a/modules/nginx/files/etc/nginx/ssl.conf
+++ b/modules/nginx/files/etc/nginx/ssl.conf
@@ -3,7 +3,7 @@ proxy_set_header          X-Forwarded-Ssl on;
 # WARNING: Any changes to our TLS ciphers or supported protocol versions must
 # be compatible with our CDN configuration. For an example, see:
 # https://github.digital.cabinet-office.gov.uk/gds/cdn-configs/commit/86c42a3
-ssl_protocols             TLSv1 TLSv1.1 TLSv1.2;
+ssl_protocols             TLSv1.2;
 ssl_ciphers               HIGH:!ADH:!kEDH:!aNULL;
 ssl_prefer_server_ciphers on;
 ssl_session_cache         shared:SSL:10m;


### PR DESCRIPTION
Those protocols are now considered unsafe and should not be used.

https://trello.com/c/Eqxi6ssR/3054-remove-tlsv1-and-tlsv11-from-the-list-of-sslprotocols-in-nginx