### PR TITLE
Stop monitoring rabbitmq for consumerless queues on integration

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -447,6 +447,7 @@ govuk::apps::bouncer::unicorn_worker_processes: "8"
 govuk::apps::cache_clearing_service::enabled: true
 govuk::apps::cache_clearing_service::rabbitmq::enabled: true
 govuk::apps::cache_clearing_service::rabbitmq_url: ""
+govuk::apps::cache_clearing_service::monitor_rabbitmq_consumers: true
 govuk::apps::cache_clearing_service::rabbitmq_hosts: [rabbitmq]
 govuk::apps::cache_clearing_service::rabbitmq::queue_size_critical_threshold: 100000
 govuk::apps::cache_clearing_service::rabbitmq::queue_size_warning_threshold: 80000
@@ -489,6 +490,7 @@ govuk::apps::content_data_api::db::lb_ip_range: "%{hiera('environment_ip_prefix'
 govuk::apps::content_data_api::rabbitmq_hosts:
   - rabbitmq
 govuk::apps::content_data_api::rabbitmq_url: ""
+govuk::apps::content_data_api::monitor_rabbitmq_consumers: true
 govuk::apps::content_data_api::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::content_data_api::redis_port: "%{hiera('sidekiq_port')}"
 
@@ -534,6 +536,7 @@ govuk::apps::email_alert_frontend::redis_port: "%{hiera('sidekiq_port')}"
 
 govuk::apps::email_alert_service::enabled: true
 govuk::apps::email_alert_service::rabbitmq_url: ""
+govuk::apps::email_alert_service::monitor_rabbitmq_consumers: true
 govuk::apps::email_alert_service::rabbitmq_hosts:
   - rabbitmq
 govuk::apps::email_alert_service::redis_host: "%{hiera('sidekiq_host')}"
@@ -653,6 +656,7 @@ govuk::apps::publishing_api::db_hostname: "publishing-api-postgres"
 govuk::apps::publishing_api::draft_content_store: "https://draft-content-store.%{hiera('app_domain')}"
 # AmazonMQ requires an amqps:// URL
 govuk::apps::publishing_api::rabbitmq_url: ""
+govuk::apps::publishing_api::monitor_rabbitmq_consumers: true
 # Separate variables for self-hosted RabbitMQ
 govuk::apps::publishing_api::rabbitmq_hosts:
   - rabbitmq
@@ -672,6 +676,7 @@ govuk::apps::search_api::enable_bulk_reindex_listener: true
 govuk::apps::search_api::enable_publishing_listener: true
 govuk::apps::search_api::enable_govuk_index_listener: true
 govuk::apps::search_api::rabbitmq_url: ""
+govuk::apps::search_api::monitor_rabbitmq_consumers: true
 govuk::apps::search_api::rabbitmq::enable_bulk_reindex_listener: true
 govuk::apps::search_api::rabbitmq::enable_govuk_index_listener: true
 govuk::apps::search_api::rabbitmq::enable_publishing_listener: true

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -15,6 +15,7 @@ govuk::apps::account_api::account_oauth_provider_uri: 'https://oidc.integration.
 govuk::apps::asset_manager::aws_s3_bucket_name: 'govuk-assets-integration'
 govuk::apps::asset_manager::aws_region: 'eu-west-1'
 govuk::apps::cache_clearing_service::rabbitmq_url: "amqps://cache_clearing_service:%{hiera('govuk_publishing_amazonmq::passwords::cache_clearing_service')}@publishingmq.integration.govuk-internal.digital:5671/publishing"
+govuk::apps::cache_clearing_service::monitor_rabbitmq_consumers: false
 govuk::apps::ckan::ckan_site_url: 'https://ckan.integration.publishing.service.gov.uk'
 govuk::apps::ckan::s3_bucket_name: "datagovuk-integration-ckan-organogram"
 govuk::apps::ckan::s3_aws_region_name: "eu-west-1"
@@ -27,6 +28,7 @@ govuk::apps::content_data_admin::aws_csv_export_bucket_name: 'govuk-integration-
 govuk::apps::content_data_admin::govuk_notify_template_id: "759acac6-da53-4a19-b591-b7538c7c39de"
 govuk::apps::content_data_api::etl_healthcheck_enabled_from_hour: '14'
 govuk::apps::content_data_api::rabbitmq_url: "amqps://content_data_api:%{hiera('govuk_publishing_amazonmq::passwords::content_data_api')}@publishingmq.integration.govuk-internal.digital:5671/publishing"
+govuk::apps::content_data_api::monitor_rabbitmq_consumers: false
 govuk::apps::content_publisher::aws_s3_bucket: "govuk-integration-content-publisher-activestorage"
 govuk::apps::content_publisher::google_tag_manager_auth: "xTPyDeRcMiXFWvscgkLowg"
 govuk::apps::content_publisher::google_tag_manager_id: "GTM-NQXC4TG"
@@ -44,6 +46,7 @@ govuk::apps::email_alert_frontend::subscription_management_enabled: true
 govuk::apps::email_alert_frontend::govuk_personalisation_manage_uri: 'https://integration.account.gov.uk?link=manage-account'
 govuk::apps::email_alert_frontend::govuk_personalisation_your_account_uri: 'https://integration.account.gov.uk'
 govuk::apps::email_alert_service::rabbitmq_url: "amqps://email_alert_service:%{hiera('govuk_publishing_amazonmq::passwords::email_alert_service')}@publishingmq.integration.govuk-internal.digital:5671/publishing"
+govuk::apps::email_alert_service::monitor_rabbitmq_consumers: false
 govuk::apps::feedback::govuk_notify_survey_signup_reply_to_id: 'fee22233-2f28-4b0b-8b6c-4410979f2275'
 govuk::apps::feedback::govuk_notify_survey_signup_template_id: 'eb9ba220-7d74-4aab-975a-bdbe718f69a3'
 govuk::apps::feedback::govuk_notify_accessible_format_request_reply_to_id: '93109fea-34d9-4c38-ac7e-1ebc75e7416b'
@@ -68,9 +71,11 @@ govuk::apps::publisher::fact_check_subject_prefix: 'dev'
 govuk::apps::publishing_api::event_log_aws_bucketname: 'govuk-publishing-api-event-log-integration'
 govuk::apps::publishing_api::content_api_prototype: true
 govuk::apps::publishing_api::rabbitmq_url: "amqps://publishing_api:%{hiera('govuk_publishing_amazonmq::passwords::publishing_api')}@publishingmq.integration.govuk-internal.digital:5671/publishing"
+govuk::apps::publishing_api::monitor_rabbitmq_consumers: false
 govuk::apps::router::sentry_environment: 'integration'
 govuk::apps::search_admin::govuk_notify_template_id: "759acac6-da53-4a19-b591-b7538c7c39de"
 govuk::apps::search_api::rabbitmq_url: "amqps://search_api:%{hiera('govuk_publishing_amazonmq::passwords::search_api')}@publishingmq.integration.govuk-internal.digital:5671/publishing"
+govuk::apps::search_api::monitor_rabbitmq_consumers: false
 govuk::apps::search_api::elasticsearch_hosts: 'https://vpc-blue-elasticsearch6-domain-uolbxqjhkiqmg5w3gg7gio5sty.eu-west-1.es.amazonaws.com'
 govuk::apps::search_api::relevancy_bucket_name: 'govuk-integration-search-relevancy'
 govuk::apps::search_api::sitemaps_bucket_name: 'govuk-integration-sitemaps'

--- a/modules/govuk/manifests/apps/cache_clearing_service/rabbitmq.pp
+++ b/modules/govuk/manifests/apps/cache_clearing_service/rabbitmq.pp
@@ -39,17 +39,19 @@ class govuk::apps::cache_clearing_service::rabbitmq (
     true  => 'present',
     false => 'absent',
   }
+  $monitor_consumers = govuk::apps::cache_clearing_service::monitor_rabbitmq_consumers
 
   $high_queue = "${amqp_queue}-high" # major, unpublish
   $medium_queue = "${amqp_queue}-medium" # minor, republish
   $low_queue = "${amqp_queue}-low" # links
 
   govuk_rabbitmq::queue_with_binding { $high_queue:
-    ensure        => $ensure,
-    amqp_exchange => $amqp_exchange,
-    amqp_queue    => $high_queue,
-    routing_key   => '*.major',
-    durable       => true,
+    ensure            => $ensure,
+    amqp_exchange     => $amqp_exchange,
+    amqp_queue        => $high_queue,
+    routing_key       => '*.major',
+    durable           => true,
+    monitor_consumers => $monitor_consumers,
   }
 
   rabbitmq_binding { "binding_unpublish_${amqp_exchange}@${high_queue}@/":
@@ -64,11 +66,12 @@ class govuk::apps::cache_clearing_service::rabbitmq (
   }
 
   govuk_rabbitmq::queue_with_binding { $medium_queue:
-    ensure        => $ensure,
-    amqp_exchange => $amqp_exchange,
-    amqp_queue    => $medium_queue,
-    routing_key   => '*.minor',
-    durable       => true,
+    ensure            => $ensure,
+    amqp_exchange     => $amqp_exchange,
+    amqp_queue        => $medium_queue,
+    routing_key       => '*.minor',
+    durable           => true,
+    monitor_consumers => $monitor_consumers,
   }
 
   rabbitmq_binding { "binding_republish_${amqp_exchange}@${medium_queue}@/":
@@ -83,11 +86,12 @@ class govuk::apps::cache_clearing_service::rabbitmq (
   }
 
   govuk_rabbitmq::queue_with_binding { $low_queue:
-    ensure        => $ensure,
-    amqp_exchange => $amqp_exchange,
-    amqp_queue    => $low_queue,
-    routing_key   => '*.links',
-    durable       => true,
+    ensure            => $ensure,
+    amqp_exchange     => $amqp_exchange,
+    amqp_queue        => $low_queue,
+    routing_key       => '*.links',
+    durable           => true,
+    monitor_consumers => $monitor_consumers,
   }
 
   rabbitmq_policy { "${low_queue}-ttl@/":

--- a/modules/govuk/manifests/apps/cache_clearing_service/rabbitmq.pp
+++ b/modules/govuk/manifests/apps/cache_clearing_service/rabbitmq.pp
@@ -39,7 +39,7 @@ class govuk::apps::cache_clearing_service::rabbitmq (
     true  => 'present',
     false => 'absent',
   }
-  $monitor_consumers = govuk::apps::cache_clearing_service::monitor_rabbitmq_consumers
+  $monitor_consumers = $::govuk::apps::cache_clearing_service::monitor_rabbitmq_consumers
 
   $high_queue = "${amqp_queue}-high" # major, unpublish
   $medium_queue = "${amqp_queue}-medium" # minor, republish

--- a/modules/govuk/manifests/apps/content_data_api/rabbitmq.pp
+++ b/modules/govuk/manifests/apps/content_data_api/rabbitmq.pp
@@ -79,7 +79,7 @@ class govuk::apps::content_data_api::rabbitmq (
     amqp_queue        => $amqp_queue,
     routing_key       => '*.major',
     durable           => true,
-    monitor_consumers => $monitor_consumers
+    monitor_consumers => $monitor_consumers,
   }
 
   rabbitmq_binding { "binding_minor_${amqp_exchange}@${amqp_queue}@/":

--- a/modules/govuk/manifests/apps/content_data_api/rabbitmq.pp
+++ b/modules/govuk/manifests/apps/content_data_api/rabbitmq.pp
@@ -52,7 +52,7 @@ class govuk::apps::content_data_api::rabbitmq (
     type     => 'topic',
   }
 
-  $monitor_consumers = govuk::apps::cache_clearing_service::monitor_rabbitmq_consumers
+  $monitor_consumers = $::govuk::apps::cache_clearing_service::monitor_rabbitmq_consumers
 
   govuk_rabbitmq::queue_with_binding { $amqp_dead_letter_queue:
     ensure            => 'present',

--- a/modules/govuk/manifests/apps/content_data_api/rabbitmq.pp
+++ b/modules/govuk/manifests/apps/content_data_api/rabbitmq.pp
@@ -52,6 +52,8 @@ class govuk::apps::content_data_api::rabbitmq (
     type     => 'topic',
   }
 
+  $monitor_consumers = govuk::apps::cache_clearing_service::monitor_rabbitmq_consumers
+
   govuk_rabbitmq::queue_with_binding { $amqp_dead_letter_queue:
     ensure            => 'present',
     amqp_exchange     => $amqp_dlx,
@@ -72,11 +74,12 @@ class govuk::apps::content_data_api::rabbitmq (
   }
 
   govuk_rabbitmq::queue_with_binding { $amqp_queue:
-    ensure        => 'present',
-    amqp_exchange => $amqp_exchange,
-    amqp_queue    => $amqp_queue,
-    routing_key   => '*.major',
-    durable       => true,
+    ensure            => 'present',
+    amqp_exchange     => $amqp_exchange,
+    amqp_queue        => $amqp_queue,
+    routing_key       => '*.major',
+    durable           => true,
+    monitor_consumers => $monitor_consumers
   }
 
   rabbitmq_binding { "binding_minor_${amqp_exchange}@${amqp_queue}@/":
@@ -120,11 +123,12 @@ class govuk::apps::content_data_api::rabbitmq (
   }
 
   govuk_rabbitmq::queue_with_binding { $amqp_bulk_importing_queue:
-    ensure        => 'present',
-    amqp_exchange => $amqp_exchange,
-    amqp_queue    => $amqp_bulk_importing_queue,
-    routing_key   => '*.bulk.data-warehouse',
-    durable       => true,
+    ensure            => 'present',
+    amqp_exchange     => $amqp_exchange,
+    amqp_queue        => $amqp_bulk_importing_queue,
+    routing_key       => '*.bulk.data-warehouse',
+    durable           => true,
+    monitor_consumers => $monitor_consumers,
   }
 
   govuk_rabbitmq::consumer { $amqp_user:

--- a/modules/govuk/manifests/apps/email_alert_service/rabbitmq.pp
+++ b/modules/govuk/manifests/apps/email_alert_service/rabbitmq.pp
@@ -54,7 +54,7 @@ class govuk::apps::email_alert_service::rabbitmq (
   $rabbitmq_url = '',
 ) {
 
-  $monitor_consumers = govuk::apps::email_alert_service::monitor_rabbitmq_consumers
+  $monitor_consumers = $::govuk::apps::email_alert_service::monitor_rabbitmq_consumers
 
   govuk_rabbitmq::queue_with_binding { $amqp_major_change_queue:
     ensure            => $ensure,

--- a/modules/govuk/manifests/apps/email_alert_service/rabbitmq.pp
+++ b/modules/govuk/manifests/apps/email_alert_service/rabbitmq.pp
@@ -54,36 +54,42 @@ class govuk::apps::email_alert_service::rabbitmq (
   $rabbitmq_url = '',
 ) {
 
+  $monitor_consumers = govuk::apps::email_alert_service::monitor_rabbitmq_consumers
+
   govuk_rabbitmq::queue_with_binding { $amqp_major_change_queue:
-    ensure        => $ensure,
-    amqp_exchange => $amqp_exchange,
-    amqp_queue    => $amqp_major_change_queue,
-    routing_key   => '*.major.#',
-    durable       => true,
+    ensure            => $ensure,
+    amqp_exchange     => $amqp_exchange,
+    amqp_queue        => $amqp_major_change_queue,
+    routing_key       => '*.major.#',
+    durable           => true,
+    monitor_consumers => $monitor_consumers,
   } ->
 
   govuk_rabbitmq::queue_with_binding { $ampq_subscriber_list_update_minor_queue:
-    ensure        => $ensure,
-    amqp_exchange => $amqp_exchange,
-    amqp_queue    => $ampq_subscriber_list_update_minor_queue,
-    routing_key   => '*.minor.#',
-    durable       => true,
+    ensure            => $ensure,
+    amqp_exchange     => $amqp_exchange,
+    amqp_queue        => $ampq_subscriber_list_update_minor_queue,
+    routing_key       => '*.minor.#',
+    durable           => true,
+    monitor_consumers => $monitor_consumers,
   } ->
 
   govuk_rabbitmq::queue_with_binding { $ampq_subscriber_list_update_major_queue:
-    ensure        => $ensure,
-    amqp_exchange => $amqp_exchange,
-    amqp_queue    => $ampq_subscriber_list_update_major_queue,
-    routing_key   => '*.major.#',
-    durable       => true,
+    ensure            => $ensure,
+    amqp_exchange     => $amqp_exchange,
+    amqp_queue        => $ampq_subscriber_list_update_major_queue,
+    routing_key       => '*.major.#',
+    durable           => true,
+    monitor_consumers => $monitor_consumers,
   } ->
 
   govuk_rabbitmq::queue_with_binding { $amqp_unpublishing_queue:
-    ensure        => $ensure,
-    amqp_exchange => $amqp_exchange,
-    amqp_queue    => $amqp_unpublishing_queue,
-    routing_key   => '*.unpublish.#',
-    durable       => true,
+    ensure            => $ensure,
+    amqp_exchange     => $amqp_exchange,
+    amqp_queue        => $amqp_unpublishing_queue,
+    routing_key       => '*.unpublish.#',
+    durable           => true,
+    monitor_consumers => $monitor_consumers,
   } ->
 
   govuk_rabbitmq::monitor_messages {"${amqp_major_change_queue}_message_monitoring":

--- a/modules/govuk/manifests/apps/search_api/rabbitmq.pp
+++ b/modules/govuk/manifests/apps/search_api/rabbitmq.pp
@@ -32,7 +32,7 @@ class govuk::apps::search_api::rabbitmq (
 ) {
 
   $amqp_exchange = 'published_documents'
-  $monitor_consumers = govuk::apps::search_api::monitor_rabbitmq_consumers
+  $monitor_consumers = $::govuk::apps::search_api::monitor_rabbitmq_consumers
 
   govuk_rabbitmq::queue_with_binding { 'search_api_to_be_indexed':
     amqp_exchange     => $amqp_exchange,

--- a/modules/govuk/manifests/apps/search_api/rabbitmq.pp
+++ b/modules/govuk/manifests/apps/search_api/rabbitmq.pp
@@ -32,19 +32,22 @@ class govuk::apps::search_api::rabbitmq (
 ) {
 
   $amqp_exchange = 'published_documents'
+  $monitor_consumers = govuk::apps::search_api::monitor_rabbitmq_consumers
 
   govuk_rabbitmq::queue_with_binding { 'search_api_to_be_indexed':
-    amqp_exchange => $amqp_exchange,
-    amqp_queue    => 'search_api_to_be_indexed',
-    routing_key   => '*.links',
-    durable       => true,
+    amqp_exchange     => $amqp_exchange,
+    amqp_queue        => 'search_api_to_be_indexed',
+    routing_key       => '*.links',
+    durable           => true,
+    monitor_consumers => $monitor_consumers,
   }
 
   govuk_rabbitmq::queue_with_binding { 'search_api_govuk_index':
-    amqp_exchange => $amqp_exchange,
-    amqp_queue    => 'search_api_govuk_index',
-    routing_key   => '*.*',
-    durable       => true,
+    amqp_exchange     => $amqp_exchange,
+    amqp_queue        => 'search_api_govuk_index',
+    routing_key       => '*.*',
+    durable           => true,
+    monitor_consumers => $monitor_consumers,
   }
 
   # When we want to manually refresh data in search, we can run a task in
@@ -57,10 +60,11 @@ class govuk::apps::search_api::rabbitmq (
   # the flexibility to stop/throttle these messages if they become a problem.
   if $enable_bulk_reindex_listener {
     govuk_rabbitmq::queue_with_binding { 'search_api_bulk_reindex':
-      amqp_exchange => $amqp_exchange,
-      amqp_queue    => 'search_api_bulk_reindex',
-      routing_key   => '*.bulk.reindex',
-      durable       => true,
+      amqp_exchange     => $amqp_exchange,
+      amqp_queue        => 'search_api_bulk_reindex',
+      routing_key       => '*.bulk.reindex',
+      durable           => true,
+      monitor_consumers => $monitor_consumers,
     }
   }
 

--- a/modules/govuk/manifests/apps/search_api/rabbitmq.pp
+++ b/modules/govuk/manifests/apps/search_api/rabbitmq.pp
@@ -33,6 +33,8 @@ class govuk::apps::search_api::rabbitmq (
 
   $amqp_exchange = 'published_documents'
   $monitor_consumers = $::govuk::apps::search_api::monitor_rabbitmq_consumers
+  info("$::govuk::apps::search_api::monitor_rabbitmq_consumers = ${::govuk::apps::search_api::monitor_rabbitmq_consumers}")
+  info("$monitor_consumers = ${monitor_consumers}")
 
   govuk_rabbitmq::queue_with_binding { 'search_api_to_be_indexed':
     amqp_exchange     => $amqp_exchange,

--- a/modules/govuk_rabbitmq/manifests/queue_with_binding.pp
+++ b/modules/govuk_rabbitmq/manifests/queue_with_binding.pp
@@ -71,11 +71,10 @@ define govuk_rabbitmq::queue_with_binding (
     arguments        => {},
   }
 
-  if $monitor_consumers {
-    govuk_rabbitmq::monitor_consumers {"${title}_${amqp_queue}_consumer_monitoring":
-      ensure            => $ensure,
-      rabbitmq_hostname => 'localhost',
-      rabbitmq_queue    => $amqp_queue,
-    }
+  govuk_rabbitmq::monitor_consumers {"${title}_${amqp_queue}_consumer_monitoring":
+    ensure            => $monitor_consumers ? { true => $ensure, false => 'absent' }
+    rabbitmq_hostname => 'localhost',
+    rabbitmq_queue    => $amqp_queue,
   }
+
 }

--- a/modules/govuk_rabbitmq/manifests/queue_with_binding.pp
+++ b/modules/govuk_rabbitmq/manifests/queue_with_binding.pp
@@ -72,7 +72,7 @@ define govuk_rabbitmq::queue_with_binding (
   }
 
   govuk_rabbitmq::monitor_consumers {"${title}_${amqp_queue}_consumer_monitoring":
-    ensure            => $monitor_consumers ? { true => $ensure, false => 'absent' }
+    ensure            => $monitor_consumers ? { true => $ensure, false => 'absent' },
     rabbitmq_hostname => 'localhost',
     rabbitmq_queue    => $amqp_queue,
   }

--- a/modules/govuk_rabbitmq/manifests/queue_with_binding.pp
+++ b/modules/govuk_rabbitmq/manifests/queue_with_binding.pp
@@ -71,8 +71,13 @@ define govuk_rabbitmq::queue_with_binding (
     arguments        => {},
   }
 
+
+  $ensure_monitoring = $monitor_consumers ? {
+    true  => $ensure,
+    false => 'absent',
+  }
   govuk_rabbitmq::monitor_consumers {"${title}_${amqp_queue}_consumer_monitoring":
-    ensure            => $monitor_consumers ? { true => $ensure, false => 'absent' },
+    ensure            => $ensure_monitoring,
     rabbitmq_hostname => 'localhost',
     rabbitmq_queue    => $amqp_queue,
   }


### PR DESCRIPTION
In integration, all the apps that were publishing to, or consuming from, self-hosted RabbitMQ, are [now connecting to AmazonMQ](https://github.com/alphagov/govuk-puppet/pull/11930) instead. 

Icinga in integration has since been showing lots of alerts, as there are monitoring processes still configured to check RabbitMQ queues for activity, and alert if there are no consumers.

This PR introduces a `$monitor_rabbitmq_consumers` variable in hiera data for each application, which is then set to false in integration only. This should stop those alerts. 