### PR TITLE
Empty-out the list of apps_using_rabbitmq on integration

### DIFF
--- a/hieradata_aws/class/integration/rabbitmq.yaml
+++ b/hieradata_aws/class/integration/rabbitmq.yaml
@@ -1,10 +1,4 @@
 ---
 
-govuk::node::s_rabbitmq::apps_using_rabbitmq:
-  - account_api
-  - backdrop_write
-  - email_alert_service
-  - publishing_api
-  - content_data_api
-  - cache_clearing_service
-  - search_api
+govuk::node::s_rabbitmq::apps_using_rabbitmq: []
+


### PR DESCRIPTION
As part of our [Trial AmazonMQ deployment process on integration](https://trello.com/b/NHxZVLsg/govuk-publishing-platform-team-doing) epic, we need to remove Icinga alerts relating to the existing self-hosted RabbitMQ.

This PR has the effect of removing all the queue / consumer monitoring for each app. I've verified it by [deploying this branch](https://deploy.integration.publishing.service.gov.uk/job/Deploy_Puppet/5303/console)  and running `govuk_puppet --test` on each of the RabbitMQ instances and (crucially) the monitoring instance. The outstanding queue-specific alerts in Icinga are now cleared. 

There are still some lingering alerts coming from the RabbitMQ boxes themselves, relating to dead nodes & high watermarks, but they should disappear once we decommission the EC2 instances in a subsequent PR on govuk-aws