### PR TITLE
Update regex for sidekiq-monitoring collectd metrics

### DIFF
--- a/modules/govuk/manifests/apps/sidekiq_monitoring.pp
+++ b/modules/govuk/manifests/apps/sidekiq_monitoring.pp
@@ -267,7 +267,7 @@ class govuk::apps::sidekiq_monitoring (
     command                => 'bundle exec foreman start',
     enable_nginx_vhost     => false,
     hasrestart             => true,
-    collectd_process_regex => '/data/apps/sidekiq-monitoring/shared/bundle/ruby/.*/bin/rackup .*',
+    collectd_process_regex => 'GOVUK_APP_NAME=.* bundle exec rackup -p .*',
   }
 
   concat::fragment { "${app_name}_lb_healthcheck_live":


### PR DESCRIPTION
Update regex to match the sidekiq-monitoring processes in CollectD.

CollectD not being able to match the processes was causing Unknown errors on every environment (1 for each backend machine), with the line: UNKNOWN: INTERNAL ERROR: RuntimeError: no valid datapoints. You could replicate this by running the graphite check manually on monitoring, and you could see there were no datapoints in the graphite graph. Post this change you see data in the graph, the unknown error clears, and running the graphite check on monitoring gives you a metric.