### PR TITLE
Stop checking status of the now-empty RabbitMQ load balancer in integration

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -269,7 +269,6 @@ monitoring::checks::lb::loadbalancers: # prefer "internal"
   blue-publishing-api-internal: {}
   blue-puppetmaster:
     healthyhosts_warning: 0
-  blue-rabbitmq-internal: {}
   blue-router-api: {}
   blue-search: {}
   blue-transition-db-admin:


### PR DESCRIPTION
Part of [Trial AmazonMQ deployment process on integration](https://trello.com/c/oqsXryjz/389-update-monitoring-alerting-from-rabbitmq-amazonmq) epic. 

We've [removed all existing RabbitMQ EC2 instances on integration](https://github.com/alphagov/govuk-aws/pull/1676), but now the monitoring server is triggering alerts that the corresponding load balancer does not have any healthy instances attached.

This PR removes `blue-rabbitmq-internal` from the integration load balancer checks