### PR TITLE
Run PagerDuty drill on every shift change

### DIFF
--- a/modules/monitoring/manifests/pagerduty_drill.pp
+++ b/modules/monitoring/manifests/pagerduty_drill.pp
@@ -25,8 +25,8 @@ class monitoring::pagerduty_drill (
     cron { 'pagerduty_drill_start':
       ensure  => present,
       user    => 'root',
-      weekday => 'wednesday',
-      hour    => 10,
+      weekday => absent,
+      hour    => [10, 18],
       minute  => 0,
       command => '/usr/local/bin/govuk_pagerduty_drill_start',
     }
@@ -34,8 +34,8 @@ class monitoring::pagerduty_drill (
     cron { 'pagerduty_drill_stop':
       ensure  => present,
       user    => 'root',
-      weekday => 'wednesday',
-      hour    => 10,
+      weekday => absent,
+      hour    => [10, 18],
       minute  => 15,
       command => "rm -f ${filename}",
     }


### PR DESCRIPTION
We usually only run the drill on Wednesday mornings, when there is
a handover of support from one team to the next. Over the
Christmas period, support changes on a more granular basis; there
are different first responders between 9:30-17:30 and 17:30-9:30,
with rotations happening twice per day.

This change will be reverted on or around the 4th of January.

Note that the weekday must be set to absent, otherwise it will
not automatically reset to '*', it would just stay as Wednesday.
See https://puppet.com/docs/puppet/5.5/types/cron.html