### PR TITLE
Introduce monitoring_host variable

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1090,6 +1090,7 @@ govuk_jenkins::jobs::deploy_lambda_app::lambda_apps:
 
 govuk_postgresql::server::configure_env_sync_user: true
 
+govuk_rabbitmq::monitoring_host: 'localhost'
 govuk_rabbitmq::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk_rabbitmq::repo::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 

--- a/hieradata_aws/vagrant_credentials.yaml
+++ b/hieradata_aws/vagrant_credentials.yaml
@@ -156,6 +156,7 @@ govuk_postgresql::wal_e::backup::aws_secret_access_key: 'thisisafakekey'
 govuk_postgresql::wal_e::backup::s3_bucket_url: 's3://foo/bar'
 
 govuk_rabbitmq::monitoring_password: monitoring
+govuk_rabbitmq::monitoring_host: localhost
 govuk_rabbitmq::root_password: root
 
 http_username: 'username'

--- a/hieradata_aws/vagrant_credentials.yaml
+++ b/hieradata_aws/vagrant_credentials.yaml
@@ -163,6 +163,7 @@ http_username: 'username'
 http_password: 'password'
 
 icinga::plugin::check_rabbitmq_consumers::monitoring_password: "%{hiera('govuk_rabbitmq::monitoring_password')}"
+icinga::plugin::check_rabbitmq_consumers::monitoring_host: "%{hiera('govuk_rabbitmq::monitoring_host')}"
 
 mysql_nagios: 'icAdipalapcebquoskurdibVufGuirWu'
 mysql_replica_password: 'YCnaJ5h42rTGqdpgCUct4EzjAfwQUkhN'

--- a/modules/collectd/manifests/plugin/rabbitmq.pp
+++ b/modules/collectd/manifests/plugin/rabbitmq.pp
@@ -8,8 +8,12 @@
 # [*monitoring_password*]
 #   The password to the 'monitoring' user which can access monitoring information from RabbitMQ.
 #
+# [*monitoring_host*]
+#   The host of the RabbitMQ process.
+#
 class collectd::plugin::rabbitmq (
   $monitoring_password,
+  $monitoring_host,
   ){
 
   @package { 'collectd-rabbitmq':

--- a/modules/collectd/templates/etc/collectd/conf.d/rabbitmq.conf.erb
+++ b/modules/collectd/templates/etc/collectd/conf.d/rabbitmq.conf.erb
@@ -9,7 +9,7 @@ LoadPlugin python
     Username "monitoring"
     Password "<%= @monitoring_password %>"
     Realm "RabbitMQ Management"
-    Host "localhost"
+    Host "<%= @monitoring_host %>"
     Port "15672"
   </Module>
 </Plugin>

--- a/modules/govuk_ci/manifests/agent/rabbitmq.pp
+++ b/modules/govuk_ci/manifests/agent/rabbitmq.pp
@@ -2,10 +2,10 @@
 #
 # Installs and configures rabbitmq-server
 #
-class govuk_ci::agent::rabbitmq {
+class govuk_ci::agent::rabbitmq (
   $monitoring_password => lookup('govuk_rabbitmq::monitoring_password'),
   $monitoring_host     => 'localhost',
-  }
+)
 
   contain ::govuk_rabbitmq
   rabbitmq_user {

--- a/modules/govuk_ci/manifests/agent/rabbitmq.pp
+++ b/modules/govuk_ci/manifests/agent/rabbitmq.pp
@@ -3,7 +3,7 @@
 # Installs and configures rabbitmq-server
 #
 class govuk_ci::agent::rabbitmq (
-  $monitoring_password = lookup('govuk_rabbitmq::monitoring_password'),
+  $monitoring_password = ::govuk_rabbitmq::monitoring_password,
   $monitoring_host     = 'localhost',
 )
 {

--- a/modules/govuk_ci/manifests/agent/rabbitmq.pp
+++ b/modules/govuk_ci/manifests/agent/rabbitmq.pp
@@ -3,11 +3,11 @@
 # Installs and configures rabbitmq-server
 #
 class govuk_ci::agent::rabbitmq {
-  contain ::govuk_rabbitmq {
-    monitoring_password => lookup('govuk_rabbitmq::monitoring_password'),
-    monitoring_host     => 'localhost',
+  $monitoring_password => lookup('govuk_rabbitmq::monitoring_password'),
+  $monitoring_host     => 'localhost',
   }
 
+  contain ::govuk_rabbitmq
   rabbitmq_user {
     'email_alert_service_test':
       password => 'email_alert_service_test';

--- a/modules/govuk_ci/manifests/agent/rabbitmq.pp
+++ b/modules/govuk_ci/manifests/agent/rabbitmq.pp
@@ -3,8 +3,8 @@
 # Installs and configures rabbitmq-server
 #
 class govuk_ci::agent::rabbitmq (
-  $monitoring_password => lookup('govuk_rabbitmq::monitoring_password'),
-  $monitoring_host     => 'localhost',
+  $monitoring_password = lookup('govuk_rabbitmq::monitoring_password'),
+  $monitoring_host     = 'localhost',
 )
 
   contain ::govuk_rabbitmq

--- a/modules/govuk_ci/manifests/agent/rabbitmq.pp
+++ b/modules/govuk_ci/manifests/agent/rabbitmq.pp
@@ -6,7 +6,7 @@ class govuk_ci::agent::rabbitmq (
   $monitoring_password = lookup('govuk_rabbitmq::monitoring_password'),
   $monitoring_host     = 'localhost',
 )
-
+{
   contain ::govuk_rabbitmq
   rabbitmq_user {
     'email_alert_service_test':

--- a/modules/govuk_ci/manifests/agent/rabbitmq.pp
+++ b/modules/govuk_ci/manifests/agent/rabbitmq.pp
@@ -4,6 +4,7 @@
 #
 class govuk_ci::agent::rabbitmq {
   contain ::govuk_rabbitmq
+
   rabbitmq_user {
     'email_alert_service_test':
       password => 'email_alert_service_test';

--- a/modules/govuk_ci/manifests/agent/rabbitmq.pp
+++ b/modules/govuk_ci/manifests/agent/rabbitmq.pp
@@ -2,10 +2,7 @@
 #
 # Installs and configures rabbitmq-server
 #
-class govuk_ci::agent::rabbitmq (
-  $monitoring_password = ::govuk_rabbitmq::monitoring_password,
-  $monitoring_host     = 'localhost',
-)
+class govuk_ci::agent::rabbitmq
 {
   contain ::govuk_rabbitmq
   rabbitmq_user {

--- a/modules/govuk_ci/manifests/agent/rabbitmq.pp
+++ b/modules/govuk_ci/manifests/agent/rabbitmq.pp
@@ -3,7 +3,10 @@
 # Installs and configures rabbitmq-server
 #
 class govuk_ci::agent::rabbitmq {
-  contain ::govuk_rabbitmq
+  contain ::govuk_rabbitmq {
+    monitoring_password => lookup('govuk_rabbitmq::monitoring_password'),
+    monitoring_host     => 'localhost',
+  }
 
   rabbitmq_user {
     'email_alert_service_test':

--- a/modules/govuk_ci/manifests/agent/rabbitmq.pp
+++ b/modules/govuk_ci/manifests/agent/rabbitmq.pp
@@ -2,8 +2,7 @@
 #
 # Installs and configures rabbitmq-server
 #
-class govuk_ci::agent::rabbitmq
-{
+class govuk_ci::agent::rabbitmq {
   contain ::govuk_rabbitmq
   rabbitmq_user {
     'email_alert_service_test':

--- a/modules/govuk_rabbitmq/manifests/init.pp
+++ b/modules/govuk_rabbitmq/manifests/init.pp
@@ -2,7 +2,7 @@
 class govuk_rabbitmq (
   $monitoring_password,
   $root_password,
-  $monitoring_host = 'localhost',
+  $monitoring_host,
   $aws_clustering = false,
   $federation = false,
 ) {

--- a/modules/govuk_rabbitmq/manifests/init.pp
+++ b/modules/govuk_rabbitmq/manifests/init.pp
@@ -1,6 +1,7 @@
 # FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
 class govuk_rabbitmq (
   $monitoring_password,
+  $monitoring_host,
   $root_password,
   $aws_clustering = false,
   $federation = false,
@@ -13,6 +14,7 @@ class govuk_rabbitmq (
   class { 'govuk_rabbitmq::monitoring' :
     monitoring_user     => $monitoring_user,
     monitoring_password => $monitoring_password,
+    monitoring_host     => $monitoring_host,
   }
 
   include govuk_rabbitmq::repo
@@ -91,5 +93,6 @@ class govuk_rabbitmq (
 
   class { 'collectd::plugin::rabbitmq':
     monitoring_password => $monitoring_password,
+    monitoring_host     => $monitoring_host,
   }
 }

--- a/modules/govuk_rabbitmq/manifests/init.pp
+++ b/modules/govuk_rabbitmq/manifests/init.pp
@@ -1,8 +1,8 @@
 # FIXME: This class needs better documentation as per https://docs.puppetlabs.com/guides/style_guide.html#puppet-doc
 class govuk_rabbitmq (
   $monitoring_password,
-  $monitoring_host,
   $root_password,
+  $monitoring_host = 'localhost',
   $aws_clustering = false,
   $federation = false,
 ) {

--- a/modules/govuk_rabbitmq/manifests/monitoring.pp
+++ b/modules/govuk_rabbitmq/manifests/monitoring.pp
@@ -2,6 +2,7 @@
 class govuk_rabbitmq::monitoring (
   $monitoring_user,
   $monitoring_password,
+  $monitoring_host,
 ) {
 
   include icinga::plugin::check_http_timeout_noncrit

--- a/modules/govuk_rabbitmq/templates/check_rabbitmq_dead_nodes.cfg.erb
+++ b/modules/govuk_rabbitmq/templates/check_rabbitmq_dead_nodes.cfg.erb
@@ -1,1 +1,1 @@
-command[check_rabbitmq_dead_nodes]=/usr/lib/nagios/plugins/check_http_timeout_noncrit -a '<%= @monitoring_user %>:<%= @monitoring_password %>' -I '127.0.0.1' -p 15672 -u '/api/nodes' -r '"running":false' --invert-regex
+command[check_rabbitmq_dead_nodes]=/usr/lib/nagios/plugins/check_http_timeout_noncrit -a '<%= @monitoring_user %>:<%= @monitoring_password %>' -I '<%= @monitoring_host %>' -p 15672 -u '/api/nodes' -r '"running":false' --invert-regex

--- a/modules/govuk_rabbitmq/templates/check_rabbitmq_network_partition.cfg.erb
+++ b/modules/govuk_rabbitmq/templates/check_rabbitmq_network_partition.cfg.erb
@@ -1,1 +1,1 @@
-command[check_rabbitmq_network_partition]=/usr/lib/nagios/plugins/check_http_timeout_noncrit -a '<%= @monitoring_user %>:<%= @monitoring_password %>' -I '127.0.0.1' -p 15672 -u '/api/nodes' -s '"partitions":[]'
+command[check_rabbitmq_network_partition]=/usr/lib/nagios/plugins/check_http_timeout_noncrit -a '<%= @monitoring_user %>:<%= @monitoring_password %>' -I '<%=@monitoring_host %>' -p 15672 -u '/api/nodes' -s '"partitions":[]'

--- a/spec/fixtures/hieradata/common.yaml
+++ b/spec/fixtures/hieradata/common.yaml
@@ -113,6 +113,7 @@ govuk_prometheus_node_exporter::repo::apt_mirror_hostname: "%{hiera('apt_mirror_
 govuk_prometheus_node_exporter::repo::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 govuk_rabbitmq::monitoring_password: 'rabbit_monitor'
+govuk_rabbitmq::monitoring_host: 'localhost'
 govuk_rabbitmq::root_password: 'rabbit_root'
 govuk_rabbitmq::repo::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk_rabbitmq::repo::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"


### PR DESCRIPTION
This will allow us to switch from self-hosted rabbitMQ (for which we install the monitoring plugin on the same EC2 instance as the rabbitMQ process, and therefore points to localhost) and AmazonMQ (for which we will monitor from publishing api, so the host needs to point to the AmazonMQ instance).