### PR TITLE
Add missing asset_pipeline declaration to apps

### DIFF
--- a/modules/govuk/manifests/app.pp
+++ b/modules/govuk/manifests/app.pp
@@ -166,8 +166,7 @@
 #
 # [*asset_pipeline*]
 # should we enable some asset pipeline specific rules in the
-# nginx config. Set this value to true to create assets when the app is deployed.
-#
+# nginx config. Set this value to true for this config to be generated.
 #
 # [*asset_pipeline_prefixes*]
 # the path prefixes from which assets are served.  This should

--- a/modules/govuk/manifests/apps/local_links_manager.pp
+++ b/modules/govuk/manifests/apps/local_links_manager.pp
@@ -134,6 +134,7 @@ class govuk::apps::local_links_manager(
     has_liveness_health_check  => true,
     has_readiness_health_check => true,
     unicorn_worker_processes   => $unicorn_worker_processes,
+    asset_pipeline             => true,
   }
 
   Govuk::App::Envvar {

--- a/modules/govuk/manifests/apps/manuals_publisher.pp
+++ b/modules/govuk/manifests/apps/manuals_publisher.pp
@@ -103,6 +103,7 @@ class govuk::apps::manuals_publisher(
     has_liveness_health_check  => true,
     has_readiness_health_check => true,
     log_format_is_json         => true,
+    asset_pipeline             => true,
     nginx_extra_config         => 'client_max_body_size 500m;',
   }
 

--- a/modules/govuk/manifests/apps/maslow.pp
+++ b/modules/govuk/manifests/apps/maslow.pp
@@ -65,6 +65,7 @@ class govuk::apps::maslow(
     has_liveness_health_check  => true,
     has_readiness_health_check => true,
     log_format_is_json         => true,
+    asset_pipeline             => true,
   }
 
   unless $ensure == 'absent' {

--- a/modules/govuk/manifests/apps/service_manual_publisher.pp
+++ b/modules/govuk/manifests/apps/service_manual_publisher.pp
@@ -95,6 +95,7 @@ class govuk::apps::service_manual_publisher(
     vhost_ssl_only             => true,
     has_liveness_health_check  => true,
     has_readiness_health_check => true,
+    asset_pipeline             => true,
   }
 
   unless $ensure == 'absent' {

--- a/modules/govuk/manifests/apps/short_url_manager.pp
+++ b/modules/govuk/manifests/apps/short_url_manager.pp
@@ -100,6 +100,7 @@ class govuk::apps::short_url_manager(
     has_liveness_health_check  => true,
     has_readiness_health_check => true,
     log_format_is_json         => true,
+    asset_pipeline             => true,
   }
 
   govuk::procfile::worker { $app_name:


### PR DESCRIPTION
These apps all serve assets but, as they missed the asset_pipeline
declaration, they didn't set the appropriate cache headers and gzip
compression on the assets.

Given this has been missing for years the effects of this will be rather
modest, it'll just mean that users of these apps request assets less
frequently and they have lower data usage.

This came to our attention in experimenting with: https://github.com/alphagov/manuals-publisher/pull/2003
