### PR TITLE
Update to temporarily disable unattended reboots

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1133,7 +1133,7 @@ govuk_sudo::sudo_conf:
     content: 'ubuntu ALL=(ALL) NOPASSWD:ALL'
 
 govuk_unattended_reboot::alert_hostname: 'alert'
-govuk_unattended_reboot::enabled: true
+govuk_unattended_reboot::enabled: false
 govuk_unattended_reboot::mongodb::enabled: true
 
 govuk_unattended_reboot::monitoring_basic_auth:


### PR DESCRIPTION
So that the docker_management machine can be rebooted. As per docs [1]

[1]: https://docs.publishing.service.gov.uk/manual/alerts/rebooting-machines.html#rebooting-docker_management-machines