### PR TITLE
Prevent "high memory for <app-name>-procofile-worker" warning

### DIFF
--- a/modules/govuk/manifests/procfile/worker.pp
+++ b/modules/govuk/manifests/procfile/worker.pp
@@ -115,6 +115,7 @@ define govuk::procfile::worker (
       $memory_critical_threshold_bytes = $memory_critical_threshold * $si_megabyte
 
       @@icinga::check::graphite { "check_${title_underscore}_app_worker_mem_usage${::hostname}":
+        ensure                     => absent,
         target                     => "${::fqdn_metrics}.processes-app-worker-${title_underscore}.ps_rss",
         warning                    => $memory_warning_threshold_bytes,
         critical                   => $memory_critical_threshold_bytes,


### PR DESCRIPTION
Platform Health removed the parent app memory alerts in https://trello.com/c/nfzw7FvL/2458-remove-app-memory-alerts-2. We forgot to clear up the app's workers while we were there.

It was agreed that these kinds of alerts aren't actionable and are just added noise. What happens when we have high memory for a worker? It is rarely a useful indicator of anything.

This commit ensures that the alert/warning is removed. We can then clear up the associated code.

Trello: https://trello.com/c/12p4D0if/3068-remove-high-memory-for-appname-procfile-worker-alert