### PR TITLE
Remove code associated with 'high memory for procfile worker'

### DIFF
--- a/modules/govuk/manifests/apps/email_alert_api.pp
+++ b/modules/govuk/manifests/apps/email_alert_api.pp
@@ -138,10 +138,8 @@ class govuk::apps::email_alert_api(
   include govuk_postgresql::client #installs libpq-dev package needed for pg gem
 
   govuk::procfile::worker {'email-alert-api':
-    ensure                    => $ensure,
-    enable_service            => $enable_procfile_worker,
-    memory_warning_threshold  => 8000,
-    memory_critical_threshold => 10000,
+    ensure         => $ensure,
+    enable_service => $enable_procfile_worker,
   }
 
   Govuk::App::Envvar {

--- a/modules/govuk/manifests/apps/search_api.pp
+++ b/modules/govuk/manifests/apps/search_api.pp
@@ -180,9 +180,7 @@ class govuk::apps::search_api(
   }
 
   govuk::procfile::worker { 'search-api':
-    enable_service            => $enable_procfile_worker,
-    memory_warning_threshold  => 1000,
-    memory_critical_threshold => 1500,
+    enable_service => $enable_procfile_worker,
   }
 
   govuk::procfile::worker { 'search-api-publishing-queue-listener':

--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -317,11 +317,9 @@ class govuk::apps::whitehall(
     }
 
     govuk::procfile::worker { 'whitehall-admin':
-      setenv_as                 => $app_name,
-      enable_service            => $enable_procfile_worker,
-      process_count             => $procfile_worker_process_count,
-      memory_warning_threshold  => 4000,
-      memory_critical_threshold => 14000,
+      setenv_as      => $app_name,
+      enable_service => $enable_procfile_worker,
+      process_count  => $procfile_worker_process_count,
     }
 
     govuk::app::envvar {

--- a/modules/govuk/manifests/procfile/worker.pp
+++ b/modules/govuk/manifests/procfile/worker.pp
@@ -31,14 +31,6 @@
 #   The regex to use for the CollectD Process plugin.
 #   Default: "sidekiq .* ${title}(.*\\.gov\\.uk)? "
 #
-# [*memory_warning_threshold*]
-#   Memory use, in MB, at which Icinga should generate a warning.
-#   Default: 2000MB
-#
-# [*memory_critical_threshold*]
-#   Memory use, in MB, at which Icinga should generate a critical alert.
-#   Default: 4000MB
-#
 define govuk::procfile::worker (
   $enable_service = true,
   $ensure = present,
@@ -48,8 +40,6 @@ define govuk::procfile::worker (
   $respawn_count = 5,
   $respawn_timeout = 20,
   $process_regex = "sidekiq .* ${title}(.*\\.gov\\.uk)? ",
-  $memory_warning_threshold = 2000,
-  $memory_critical_threshold = 4000,
 ) {
   validate_re($ensure, '^(present|absent)$', '$ensure must be "present" or "absent"')
 
@@ -101,29 +91,6 @@ define govuk::procfile::worker (
         desc      => "No processes found for ${service_name}",
         host_name => $::fqdn,
         from      => '30seconds',
-      }
-
-      # Check memory thresholds are approximately right
-      validate_integer($memory_warning_threshold, 12000, 100)
-      validate_integer($memory_critical_threshold, 14000, 200)
-
-      # Use the International System of Units (SI) value of 1 million bytes in a MB
-      # as it makes it simpler to evaluate memory usage when looking at our
-      # metrics, which record memory usage in bytes
-      $si_megabyte = 1000000
-      $memory_warning_threshold_bytes = $memory_warning_threshold * $si_megabyte
-      $memory_critical_threshold_bytes = $memory_critical_threshold * $si_megabyte
-
-      @@icinga::check::graphite { "check_${title_underscore}_app_worker_mem_usage${::hostname}":
-        ensure                     => absent,
-        target                     => "${::fqdn_metrics}.processes-app-worker-${title_underscore}.ps_rss",
-        warning                    => $memory_warning_threshold_bytes,
-        critical                   => $memory_critical_threshold_bytes,
-        desc                       => "high memory for ${service_name}",
-        host_name                  => $::fqdn,
-        event_handler              => "govuk_procfile_worker_high_memory!${service_name}",
-        notes_url                  => monitoring_docs_url(high-memory-for-application),
-        attempts_before_hard_state => 10,
       }
     }
   } else {


### PR DESCRIPTION
This was disabled in #11947, so now we can remove the code.

Trello: https://trello.com/c/12p4D0if/3068-remove-high-memory-for-appname-procfile-worker-alert