### PR TITLE
Bump CPU thresholds for content-store in Staging

### DIFF
--- a/hieradata_aws/class/staging/content_store.yaml
+++ b/hieradata_aws/class/staging/content_store.yaml
@@ -1,0 +1,2 @@
+govuk::apps::content_store::cpu_warning: 250
+govuk::apps::content_store::cpu_critical: 300

--- a/modules/govuk/manifests/apps/content_store.pp
+++ b/modules/govuk/manifests/apps/content_store.pp
@@ -47,6 +47,14 @@
 #   rummager URL envvar
 #   Default: undef
 #
+# [*cpu_warning*]
+#   CPU usage percentage that warning alerts are sounded at
+#   Default: undef
+#
+# [*cpu_critical*]
+#   CPU usage percentage that critical alerts are sounded at
+#   Default: undef
+#
 
 class govuk::apps::content_store(
   $port,
@@ -63,6 +71,8 @@ class govuk::apps::content_store(
   $oauth_secret = undef,
   $router_api_bearer_token = undef,
   $plek_service_rummager_uri = undef,
+  $cpu_warning = undef,
+  $cpu_critical = undef,
 ) {
   $app_name = 'content-store'
 
@@ -76,6 +86,8 @@ class govuk::apps::content_store(
     log_format_is_json         => true,
     vhost                      => $vhost,
     unicorn_worker_processes   => $unicorn_worker_processes,
+    cpu_warning                => $cpu_warning,
+    cpu_critical               => $cpu_critical,
   }
 
   Govuk::App::Envvar {


### PR DESCRIPTION
The content-store app is handling more traffic on Staging than Production, because the GoReplay traffic replay from Production is replaying traffic to both the EC2 and EKS platforms, but both platforms are using the EC2 content store.

We're therefore regularly seeing CPU warnings for content-store on Staging. They seem to spike to no higher than around 220%, and none of the requests seem to error, so Content Store is coping with the demand.

We should therefore be able to set a comfortable limit of say 250%, but we only want to apply this to Staging, where we're in this weird world of double platforms. Therefore I've made the thresholds a configurable field that is set in YAML.

I did consider duplicating the `staging/content_store.yaml` into a `staging/draft_content_store.yaml` file, but we've only seen the alert on the non-draft content store, which makes sense as the bulk of the traffic is replayed from (public) production content store requests.

Trello: https://trello.com/c/T2aatFyl/1516-high-cpu-usage-for-content-store-app-on-staging