### PR TITLE
Add unless_vg/createonly to physical volume creation to fix ci-agent 5

### DIFF
--- a/modules/govuk_lvm/manifests/init.pp
+++ b/modules/govuk_lvm/manifests/init.pp
@@ -33,13 +33,15 @@ define govuk_lvm(
     $filesystem = "/dev/${vg}/${title}"
 
     physical_volume { $pv:
-      ensure => $ensure,
+      ensure    => $ensure,
+      unless_vg => $vg,
     }
 
     volume_group { $vg:
       ensure           => $ensure,
       physical_volumes => $pv,
       require          => Physical_volume[$pv],
+      createonly       => true,
     }
 
     logical_volume { $title:


### PR DESCRIPTION
Agent 5 has the pvs for the volume groups the wrong way round, and is failing to swap them, which causes a puppet run failure. This addition tells puppet only to create the volume groups if they don't exist, don't try to fiddle with existing VGs.

