### PR TITLE
Raise threshold for the gov-frontend CPU usage alert.

### DIFF
--- a/modules/govuk/manifests/apps/government_frontend.pp
+++ b/modules/govuk/manifests/apps/government_frontend.pp
@@ -44,8 +44,8 @@ class govuk::apps::government_frontend(
   $account_api_bearer_token = undef,
   $publishing_api_bearer_token = undef,
   $unicorn_worker_processes = undef,
-  $cpu_warning = 150,
-  $cpu_critical = 200,
+  $cpu_warning = 300,
+  $cpu_critical = 300,
 ) {
   Govuk::App::Envvar {
     app => 'government-frontend',


### PR DESCRIPTION
This alert is unactionable, but deleting it is more faff than just increasing the threshold.