### PR TITLE
Replace deprecated usage of bundle install

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/publish_special_routes.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/publish_special_routes.yaml.erb
@@ -27,7 +27,8 @@
         - shell: |
             export GOVUK_APP_DOMAIN=<%= @app_domain %>
             export PUBLISHING_API_BEARER_TOKEN=<%= @publishing_api_bearer_token %>
-            bundle install --path "${HOME}/bundles/${JOB_NAME}"
+            bundle config set --local path "${HOME}/bundles/${JOB_NAME}"
+            bundle install
             bundle exec rake publish_special_routes
     wrappers:
         - ansicolor:
@@ -55,7 +56,8 @@
         - shell: |
             export GOVUK_APP_DOMAIN=<%= @app_domain %>
             export PUBLISHING_API_BEARER_TOKEN=<%= @publishing_api_bearer_token %>
-            bundle install --path "${HOME}/bundles/${JOB_NAME}"
+            bundle config set --local path "${HOME}/bundles/${JOB_NAME}"
+            bundle install
             bundle exec rake publish_one_special_route["${BASE_PATH}"]
     wrappers:
         - ansicolor:
@@ -86,7 +88,8 @@
         - shell: |
             export GOVUK_APP_DOMAIN=<%= @app_domain %>
             export PUBLISHING_API_BEARER_TOKEN=<%= @publishing_api_bearer_token %>
-            bundle install --path "${HOME}/bundles/${JOB_NAME}"
+            bundle config set --local path "${HOME}/bundles/${JOB_NAME}"
+            bundle install
             bundle exec rake unpublish_one_special_route["${BASE_PATH}","${ALTERNATIVE_PATH}"]
     wrappers:
         - ansicolor:


### PR DESCRIPTION
The `--path` flag is deprecated because it relies on being remembered across bundler invocations.

Therefore updating the Special Route Publisher job to not use this deprecated flag.

Related to [Trello card](https://trello.com/c/PgJxJILW).