### PR TITLE
Remove 'Smokey' pipeline job

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -982,7 +982,6 @@ govuk_ci::master::pipeline_jobs:
       - 'integration'
       - 'staging'
       - 'production'
-  smokey: {}
 
 govuk_ci::master::ci_agents:
   ci-agent-1:


### PR DESCRIPTION
Smokey CI now runs on GitHub Actions, so there is no need for this job anymore.