### PR TITLE
Move PagerDuty drill to Mondays

### DIFF
--- a/modules/monitoring/manifests/pagerduty_drill.pp
+++ b/modules/monitoring/manifests/pagerduty_drill.pp
@@ -25,7 +25,7 @@ class monitoring::pagerduty_drill (
     cron { 'pagerduty_drill_start':
       ensure  => present,
       user    => 'root',
-      weekday => 'wednesday',
+      weekday => 'monday',
       hour    => 10,
       minute  => 0,
       command => '/usr/local/bin/govuk_pagerduty_drill_start',
@@ -34,7 +34,7 @@ class monitoring::pagerduty_drill (
     cron { 'pagerduty_drill_stop':
       ensure  => present,
       user    => 'root',
-      weekday => 'wednesday',
+      weekday => 'monday',
       hour    => 10,
       minute  => 15,
       command => "rm -f ${filename}",


### PR DESCRIPTION
We've changed our shift pattern from Wednesday-Tuesday to Monday-Sunday, so should move the drill to the beginning of the new shift pattern.