### PR TITLE
Add AmazonMQ Grafana dashboard

### DIFF
--- a/modules/grafana/files/dashboards_aws/aws-amazonmq.json
+++ b/modules/grafana/files/dashboards_aws/aws-amazonmq.json
@@ -126,7 +126,7 @@
                 "showDisabledItems": false
               },
               "period": "",
-              "refId": "A",
+              "refId": "B",
               "region": "$region",
               "statistics": [
                 "Average"
@@ -159,7 +159,7 @@
                 "showDisabledItems": false
               },
               "period": "",
-              "refId": "A",
+              "refId": "C",
               "region": "$region",
               "statistics": [
                 "Average"
@@ -192,7 +192,7 @@
                 "showDisabledItems": false
               },
               "period": "",
-              "refId": "A",
+              "refId": "D",
               "region": "$region",
               "statistics": [
                 "Average"

--- a/modules/grafana/files/dashboards_aws/aws-amazonmq.json
+++ b/modules/grafana/files/dashboards_aws/aws-amazonmq.json
@@ -1,0 +1,382 @@
+{
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "4.5.2"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "cloudwatch",
+      "name": "CloudWatch",
+      "version": "1.0.0"
+    }
+  ],
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "hideControls": false,
+  "id": null,
+  "links": [],
+  "refresh": "10s",
+  "rows": [
+    {
+      "editable": true,
+      "collapse": false,
+      "height": "300px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "CloudWatch",
+          "fill": 0,
+          "id": 1,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "spaceLength": 10,
+          "span": 12,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "Total Messages",
+              "application": {
+                "filter": ""
+              },
+              "dimensions": {
+                "Broker": "$broker",
+                "VirtualHost": "$virtual_host",
+                "Queue": "$queue"
+              },
+              "functions": [],
+              "group": {
+                "filter": ""
+              },
+              "host": {
+                "filter": ""
+              },
+              "item": {
+                "filter": ""
+              },
+              "metricName": "MessageCount",
+              "mode": 0,
+              "namespace": "AWS/AmazonMQ",
+              "options": {
+                "showDisabledItems": false
+              },
+              "period": "",
+              "refId": "A",
+              "region": "$region",
+              "statistics": [
+                "Average"
+              ]
+            },
+            {
+              "alias": "Ready Messages",
+              "application": {
+                "filter": ""
+              },
+              "dimensions": {
+                "Broker": "$broker",
+                "VirtualHost": "$virtual_host",
+                "Queue": "$queue"
+              },
+              "functions": [],
+              "group": {
+                "filter": ""
+              },
+              "host": {
+                "filter": ""
+              },
+              "item": {
+                "filter": ""
+              },
+              "metricName": "MessageReadyCount",
+              "mode": 0,
+              "namespace": "AWS/AmazonMQ",
+              "options": {
+                "showDisabledItems": false
+              },
+              "period": "",
+              "refId": "A",
+              "region": "$region",
+              "statistics": [
+                "Average"
+              ]
+            },
+            {
+              "alias": "Unack'ed Messages",
+              "application": {
+                "filter": ""
+              },
+              "dimensions": {
+                "Broker": "$broker",
+                "VirtualHost": "$virtual_host",
+                "Queue": "$queue"
+              },
+              "functions": [],
+              "group": {
+                "filter": ""
+              },
+              "host": {
+                "filter": ""
+              },
+              "item": {
+                "filter": ""
+              },
+              "metricName": "MessageUnacknowledgedCount",
+              "mode": 0,
+              "namespace": "AWS/AmazonMQ",
+              "options": {
+                "showDisabledItems": false
+              },
+              "period": "",
+              "refId": "A",
+              "region": "$region",
+              "statistics": [
+                "Average"
+              ]
+            },
+            {
+              "alias": "Consumers",
+              "application": {
+                "filter": ""
+              },
+              "dimensions": {
+                "Broker": "$broker",
+                "VirtualHost": "$virtual_host",
+                "Queue": "$queue"
+              },
+              "functions": [],
+              "group": {
+                "filter": ""
+              },
+              "host": {
+                "filter": ""
+              },
+              "item": {
+                "filter": ""
+              },
+              "metricName": "ConsumerCount",
+              "mode": 0,
+              "namespace": "AWS/AmazonMQ",
+              "options": {
+                "showDisabledItems": false
+              },
+              "period": "",
+              "refId": "A",
+              "region": "$region",
+              "statistics": [
+                "Average"
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Messages & Consumers",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": "queue",
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "Queue: $queue",
+      "titleSize": "h4"
+    }
+  ],
+  "schemaVersion": 14,
+  "style": "dark",
+  "tags": [
+    "cloudwatch"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "tags": [],
+          "text": "eu-west-1",
+          "value": "eu-west-1"
+        },
+        "datasource": "CloudWatch",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Region",
+        "multi": false,
+        "name": "region",
+        "options": [],
+        "query": "regions()",
+        "refresh": 1,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "tags": [],
+          "text": "PublishingMQ",
+          "value": "PublishingMQ"
+        },
+        "datasource": "CloudWatch",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Broker",
+        "multi": true,
+        "name": "broker",
+        "options": [],
+        "query": "dimension_values($region, AWS/AmazonMQ, ConsumerCount, Broker)",
+        "refresh": 1,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "tags": [],
+          "text": "publishing",
+          "value": "publishing"
+        },
+        "datasource": "CloudWatch",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Virtual Host",
+        "multi": false,
+        "name": "virtual_host",
+        "options": [],
+        "query": "dimension_values($region, AWS/AmazonMQ, ConsumerCount, VirtualHost)",
+        "refresh": 1,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": "*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": "CloudWatch",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Queue",
+        "multi": true,
+        "name": "queue",
+        "options": [],
+        "query": "dimension_values($region, AWS/AmazonMQ, ConsumerCount, Queue)",
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "AWS AmazonMQ",
+  "version": 9
+}

--- a/modules/grafana/manifests/dashboards.pp
+++ b/modules/grafana/manifests/dashboards.pp
@@ -39,6 +39,7 @@ class grafana::dashboards (
   })
 
   file {
+    "${dashboard_directory}/aws-amazonmq.json": source => 'puppet:///modules/grafana/dashboards_aws/aws-amazonmq.json';
     "${dashboard_directory}/aws-auto-scaling.json": source => 'puppet:///modules/grafana/dashboards_aws/aws-auto-scaling.json';
     "${dashboard_directory}/aws-ec2.json": source => 'puppet:///modules/grafana/dashboards_aws/aws-ec2.json';
     "${dashboard_directory}/aws-efs.json": source => 'puppet:///modules/grafana/dashboards_aws/aws-efs.json';

--- a/modules/grafana/manifests/datasources.pp
+++ b/modules/grafana/manifests/datasources.pp
@@ -29,7 +29,7 @@ class grafana::datasources(
     \"name\":\"CloudWatch\",
     \"type\":\"cloudwatch\",
     \"access\":\"proxy\",
-    \"jsonData\":{\"authType\":\"arn\", \"defaultRegion\":\"eu-west-1\", \"assumeRoleArn\":\"\", \"timeField\":\"@timestamp\"}
+    \"jsonData\":{\"authType\":\"arn\", \"defaultRegion\":\"eu-west-1\", \"assumeRoleArn\":\"\", \"timeField\":\"@timestamp\", \"customMetricsNamespaces\": \"AWS/AmazonMQ\"}
   }"
 
   $cloudwatchsourceadd = shellquote([

--- a/modules/grafana/manifests/datasources.pp
+++ b/modules/grafana/manifests/datasources.pp
@@ -29,7 +29,7 @@ class grafana::datasources(
     \"name\":\"CloudWatch\",
     \"type\":\"cloudwatch\",
     \"access\":\"proxy\",
-    \"jsonData\":{\"authType\":\"arn\", \"defaultRegion\":\"eu-west-1\", \"assumeRoleArn\":\"\", \"timeField\":\"@timestamp\", \"customMetricsNamespaces\": \"AWS/AmazonMQ\"}
+    \"jsonData\":{\"authType\":\"arn\", \"defaultRegion\":\"eu-west-1\", \"assumeRoleArn\":\"\", \"timeField\":\"@timestamp\"}
   }"
 
   $cloudwatchsourceadd = shellquote([


### PR DESCRIPTION
[Trello card](https://trello.com/c/Dj9II4RC/418-repoint-the-grafana-dashboards-at-amazonmq)

Replicate as much as possible from the existing RabbitMQ dashboard into a new AWS/AmazonMQ dashboard, pulling metrics from CloudWatch.

This new dashboard shows message counts (ready / unack'ed / total) and consumer counts for each queue.
It was not possible to bring across the exchange publish rates from the existing RabbitMQ dashboard, as CloudWatch does not expose those metrics.

It's been [deployed on integration](https://grafana.blue.integration.govuk.digital/dashboard/file/aws-amazonmq.json?orgId=1) and works (although there hasn't been much activity to graph, we published some docs around 12 noon on Jan 12th):
![image](https://user-images.githubusercontent.com/134501/212332292-eeb61cee-8781-4b62-aa96-b236d0e86681.png)
