### PR TITLE
Add EMAIL_ADDRESS_OVERRIDE env var to Whitehall

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -103,6 +103,7 @@ govuk::apps::url_arbiter::db::backend_ip_range: '10.1.3.0/24'
 govuk::apps::whitehall::basic_auth_credentials: "%{hiera('http_username')}:%{hiera('http_password')}"
 govuk::apps::whitehall::highlight_words_to_avoid: true
 govuk::apps::whitehall::govuk_notify_template_id: "759acac6-da53-4a19-b591-b7538c7c39de"
+govuk::apps::whitehall::email_address_override: "whitehall-emails-integration@digital.cabinet-office.gov.uk"
 govuk::apps::whitehall::aws_s3_bucket_name: 'govuk-integration-whitehall-csvs'
 
 licensify::apps::configfile::mongo_database_reference_name: 'licensify-refdata'

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -236,6 +236,7 @@ govuk::apps::travel_advice_publisher::mongodb_nodes: "%{hiera('govuk::apps::asse
 govuk::apps::travel_advice_publisher::mongodb_username: "%{hiera('govuk::apps::asset_manager::mongodb_username')}"
 govuk::apps::travel_advice_publisher::mongodb_password: "%{hiera('govuk::apps::asset_manager::mongodb_password')}"
 govuk::apps::whitehall::govuk_notify_template_id: "112842bb-d8a4-4511-90de-57dc5c8f27ec"
+govuk::apps::whitehall::email_address_override: "whitehall-emails-staging@digital.cabinet-office.gov.uk"
 govuk::apps::whitehall::aws_s3_bucket_name: 'govuk-staging-whitehall-csvs'
 # DB hostname for whitehall backend
 govuk::apps::whitehall::admin_db_hostname: 'whitehall-mysql'

--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -135,6 +135,9 @@
 # [*govuk_notify_template_id*]
 #   The template ID used to send email via GOV.UK Notify.
 #
+# [*email_address_override*]
+#   An email address that intercepted Notify emails can be sent to
+#
 # [*aws_region*]
 #   The Region for AWS to access S3 buckets.
 #
@@ -182,6 +185,7 @@ class govuk::apps::whitehall(
   $backend_unicorn_worker_processes = 4,
   $govuk_notify_api_key = undef,
   $govuk_notify_template_id = undef,
+  $email_address_override = undef,
   $aws_region = 'eu-west-1',
   $aws_s3_bucket_name = undef,
 ) {
@@ -350,6 +354,9 @@ class govuk::apps::whitehall(
       "${title}-GOVUK_NOTIFY_TEMPLATE_ID":
         varname => 'GOVUK_NOTIFY_TEMPLATE_ID',
         value   => $govuk_notify_template_id;
+      "${title}-EMAIL_ADDRESS_OVERRIDE":
+        varname => 'EMAIL_ADDRESS_OVERRIDE',
+        value   => $email_address_override;
       "${title}-AWS_REGION":
         varname => 'AWS_REGION',
         value   => $aws_region;


### PR DESCRIPTION
In combination with PR alphagov/whitehall#7240, this will result in emails being sent from Whitehall in integration and staging to be intercepted and routed to the defined email address.

Trello: https://trello.com/c/FIzGBARz/1020-allow-devs-to-see-whitehall-emails-sent-in-integration-staging-environments