### PR TITLE
Remove latest ruby versions

### DIFF
--- a/modules/govuk_rbenv/manifests/all.pp
+++ b/modules/govuk_rbenv/manifests/all.pp
@@ -38,10 +38,7 @@ class govuk_rbenv::all (
     '2.7.6',
     '3.0.3',
     '3.0.4',
-    '3.0.5',
     '3.1.2',
-    '3.1.3',
-    '3.2.0',
   ]
 
   govuk_rbenv::install_ruby_version { $ruby_versions:
@@ -58,14 +55,10 @@ class govuk_rbenv::all (
   }
 
   rbenv::alias { '3.0':
-    to_version => '3.0.5',
+    to_version => '3.0.4',
   }
 
   rbenv::alias { '3.1':
-    to_version => '3.1.3',
-  }
-
-  rbenv::alias { '3.2':
-    to_version => '3.2.0',
+    to_version => '3.1.2',
   }
 }


### PR DESCRIPTION
Reverts alphagov/govuk-puppet#11963

When running `$ govuk_puppet --test` with the latest ruby versions on integration, it fails with
```
Error: /usr/bin/env -uRUBYOPT -uBUNDLE_GEMFILE -uGEM_HOME -uGEM_PATH /usr/bin/rbenv exec gem install bundler -v '1.16.2' returned 1 instead of one of [0]
Error: /Stage[main]/Govuk_rbenv::All/Govuk_rbenv::Install_ruby_version[3.2.0]/Rbenv::Version[3.2.0]/Exec[install bundler for 3.2.0]/returns: change from notrun to 0 failed: /usr/bin/env -uRUBYOPT -uBUNDLE_GEMFILE -uGEM_HOME -uGEM_PATH /usr/bin/rbenv exec gem install bundler -v '1.16.2' returned 1 instead of one of [0]
Notice: /Stage[main]/Govuk_rbenv::All/Govuk_rbenv::Install_ruby_version[3.2.0]/Rbenv::Version[3.2.0]/Rbenv::Rehash[3.2.0]/Exec[rbenv rehash for 3.2.0]: Dependency Exec[install bundler for 3.2.0] has failures: true
Warning: /Stage[main]/Govuk_rbenv::All/Govuk_rbenv::Install_ruby_version[3.2.0]/Rbenv::Version[3.2.0]/Rbenv::Rehash[3.2.0]/Exec[rbenv rehash for 3.2.0]: Skipping because of failed dependencies
Notice: /Stage[main]/Govuk_rbenv::All/Rbenv::Alias[3.2]/File[/usr/lib/rbenv/versions/3.2]: Dependency Exec[install bundler for 3.2.0] has failures: true
Warning: /Stage[main]/Govuk_rbenv::All/Rbenv::Alias[3.2]/File[/usr/lib/rbenv/versions/3.2]: Skipping because of failed dependencies
```
```
Notice: /Stage[main]/Govuk_rbenv::All/Govuk_rbenv::Install_ruby_version[3.2.0]/Rbenv::Version[3.2.0]/Exec[install bundler for 3.2.0]/returns: ERROR:  While executing gem ... (Gem::Exception)
Notice: /Stage[main]/Govuk_rbenv::All/Govuk_rbenv::Install_ruby_version[3.2.0]/Rbenv::Version[3.2.0]/Exec[install bundler for 3.2.0]/returns:     OpenSSL is not available. Install OpenSSL and rebuild Ruby or use non-HTTPS sources (Gem::Exception)
```

Trello card: https://trello.com/c/J4lMTZYC/3070-install-ruby-version-320-5
