### PR TITLE
Remove `finder_frontend::account_api_bearer_token`.

### DIFF
--- a/modules/govuk/manifests/apps/finder_frontend.pp
+++ b/modules/govuk/manifests/apps/finder_frontend.pp
@@ -15,16 +15,12 @@
 # [*email_alert_api_bearer_token*]
 #   Bearer token for communication with the email-alert-api
 #
-# [*account_api_bearer_token*]
-#   Bearer token for communication with the account-api
-#
 class govuk::apps::finder_frontend(
   $port,
   $enabled = false,
   $sentry_dsn = undef,
   $secret_key_base = undef,
   $email_alert_api_bearer_token = undef,
-  $account_api_bearer_token = undef,
   $unicorn_worker_processes = undef,
 ) {
 
@@ -50,9 +46,6 @@ class govuk::apps::finder_frontend(
   }
 
   govuk::app::envvar {
-    "${title}-ACCOUNT_API_BEARER_TOKEN":
-        varname => 'ACCOUNT_API_BEARER_TOKEN',
-        value   => $account_api_bearer_token;
     "${title}-EMAIL_ALERT_API_BEARER_TOKEN":
         varname => 'EMAIL_ALERT_API_BEARER_TOKEN',
         value   => $email_alert_api_bearer_token;


### PR DESCRIPTION
This is no longer used.as of https://github.com/alphagov/finder-frontend/pull/2974.

Corresponding secrets removed in https://github.com/alphagov/govuk-secrets/pull/1433.