### PR TITLE
Ship procfile worker logs to Logit to replace lack of Sidekiq file logs

### DIFF
--- a/modules/govuk/manifests/app.pp
+++ b/modules/govuk/manifests/app.pp
@@ -438,6 +438,7 @@ define govuk::app (
     fields => {'application' => $title},
   }
 
+  # This configuration will become redundant once all Sidekiq versions are >= 6
   @filebeat::prospector { "${title}_sidekiq_json_log":
     paths  => ["/var/apps/${title}/log/sidekiq*.log"],
     fields => {'application' => $title},

--- a/modules/govuk/manifests/apps/ckan.pp
+++ b/modules/govuk/manifests/apps/ckan.pp
@@ -146,28 +146,31 @@ class govuk::apps::ckan (
     }
 
     govuk::procfile::worker { 'harvester_fetch_consumer':
-      ensure         => $toggled_harvester_fetch,
-      setenv_as      => 'ckan',
-      enable_service => $enable_harvester_fetch,
-      process_type   => 'harvester_fetch_consumer',
-      respawn_count  => 15,
-      process_regex  => $fetch_process_regex,
+      ensure          => $toggled_harvester_fetch,
+      setenv_as       => 'ckan',
+      enable_service  => $enable_harvester_fetch,
+      process_type    => 'harvester_fetch_consumer',
+      respawn_count   => 15,
+      process_regex   => $fetch_process_regex,
+      stdout_log_json => false,
     }
 
     govuk::procfile::worker { 'harvester_gather_consumer':
-      ensure         => $toggled_harvester_gather,
-      setenv_as      => 'ckan',
-      enable_service => $enable_harvester_gather,
-      process_type   => 'harvester_gather_consumer',
-      process_regex  => $gather_process_regex,
+      ensure          => $toggled_harvester_gather,
+      setenv_as       => 'ckan',
+      enable_service  => $enable_harvester_gather,
+      process_type    => 'harvester_gather_consumer',
+      process_regex   => $gather_process_regex,
+      stdout_log_json => false,
     }
 
     govuk::procfile::worker { 'pycsw_web':
-      ensure         => present,
-      setenv_as      => 'ckan',
-      enable_service => running,
-      process_type   => 'pycsw_web',
-      process_regex  => 'pycsw\.wsgi',
+      ensure          => present,
+      setenv_as       => 'ckan',
+      enable_service  => running,
+      process_type    => 'pycsw_web',
+      process_regex   => 'pycsw\.wsgi',
+      stdout_log_json => false,
     }
 
     class { 'cronjobs':

--- a/modules/govuk/manifests/apps/content_data_api.pp
+++ b/modules/govuk/manifests/apps/content_data_api.pp
@@ -155,17 +155,19 @@ class govuk::apps::content_data_api(
   }
 
   govuk::procfile::worker { "${app_name}-publishing-api-consumer":
-    enable_service => $enable_procfile_worker,
-    setenv_as      => $app_name,
-    process_type   => 'publishing-api-consumer',
-    process_regex  => '\/rake publishing_api:consumer',
+    enable_service  => $enable_procfile_worker,
+    setenv_as       => $app_name,
+    process_type    => 'publishing-api-consumer',
+    process_regex   => '\/rake publishing_api:consumer',
+    stdout_log_json => false,
   }
 
   govuk::procfile::worker { 'content-data-api-bulk-import-publishing-api-consumer':
-    enable_service => $enable_procfile_worker,
-    setenv_as      => $app_name,
-    process_type   => 'bulk-import-publishing-api-consumer',
-    process_regex  => '\/rake publishing_api:bulk_import_consumer',
+    enable_service  => $enable_procfile_worker,
+    setenv_as       => $app_name,
+    process_type    => 'bulk-import-publishing-api-consumer',
+    process_regex   => '\/rake publishing_api:bulk_import_consumer',
+    stdout_log_json => false,
   }
 
   govuk::app::envvar {

--- a/modules/govuk/manifests/apps/email_alert_service.pp
+++ b/modules/govuk/manifests/apps/email_alert_service.pp
@@ -69,24 +69,27 @@ class govuk::apps::email_alert_service(
   }
 
   govuk::procfile::worker { 'email-alert-service-unpublishing-queue-consumer':
-    setenv_as      => $app_name,
-    enable_service => $enable_unpublishing_queue_consumer,
-    process_type   => 'unpublishing-queue-consumer',
-    process_regex  => '\/rake message_queues:unpublishing_consumer',
+    setenv_as       => $app_name,
+    enable_service  => $enable_unpublishing_queue_consumer,
+    process_type    => 'unpublishing-queue-consumer',
+    process_regex   => '\/rake message_queues:unpublishing_consumer',
+    stdout_log_json => false,
   }
 
   govuk::procfile::worker { 'email-alert-service-subscriber-list-details-update-minor-consumer':
-    setenv_as      => $app_name,
-    enable_service => $enable_subscriber_list_update_queue_consumers,
-    process_type   => 'subscriber-list-details-update-minor-consumer',
-    process_regex  => '\/rake message_queues:subscriber_list_details_update_minor_consumer',
+    setenv_as       => $app_name,
+    enable_service  => $enable_subscriber_list_update_queue_consumers,
+    process_type    => 'subscriber-list-details-update-minor-consumer',
+    process_regex   => '\/rake message_queues:subscriber_list_details_update_minor_consumer',
+    stdout_log_json => false,
   }
 
   govuk::procfile::worker { 'email-alert-service-subscriber-list-details-update-major-consumer':
-    setenv_as      => $app_name,
-    enable_service => $enable_subscriber_list_update_queue_consumers,
-    process_type   => 'subscriber-list-details-update-major-consumer',
-    process_regex  => '\/rake message_queues:subscriber_list_details_update_major_consumer',
+    setenv_as       => $app_name,
+    enable_service  => $enable_subscriber_list_update_queue_consumers,
+    process_type    => 'subscriber-list-details-update-major-consumer',
+    process_regex   => '\/rake message_queues:subscriber_list_details_update_major_consumer',
+    stdout_log_json => false,
   }
 
   Govuk::App::Envvar {

--- a/modules/govuk/manifests/apps/search_api.pp
+++ b/modules/govuk/manifests/apps/search_api.pp
@@ -184,24 +184,27 @@ class govuk::apps::search_api(
   }
 
   govuk::procfile::worker { 'search-api-publishing-queue-listener':
-    setenv_as      => $app_name,
-    enable_service => $enable_publishing_listener,
-    process_type   => 'publishing-queue-listener',
-    process_regex  => '\/rake message_queue:listen_to_publishing_queue',
+    setenv_as       => $app_name,
+    enable_service  => $enable_publishing_listener,
+    process_type    => 'publishing-queue-listener',
+    process_regex   => '\/rake message_queue:listen_to_publishing_queue',
+    stdout_log_json => false,
   }
 
   govuk::procfile::worker { 'search-api-govuk-index-queue-listener':
-    setenv_as      => $app_name,
-    enable_service => $enable_govuk_index_listener,
-    process_type   => 'govuk-index-queue-listener',
-    process_regex  => '\/rake message_queue:insert_data_into_govuk',
+    setenv_as       => $app_name,
+    enable_service  => $enable_govuk_index_listener,
+    process_type    => 'govuk-index-queue-listener',
+    process_regex   => '\/rake message_queue:insert_data_into_govuk',
+    stdout_log_json => false,
   }
 
   govuk::procfile::worker { 'search-api-bulk-reindex-queue-listener':
-    setenv_as      => $app_name,
-    enable_service => $enable_bulk_reindex_listener,
-    process_type   => 'bulk-reindex-queue-listener',
-    process_regex  => '\/rake message_queue:bulk_insert_data_into_govuk',
+    setenv_as       => $app_name,
+    enable_service  => $enable_bulk_reindex_listener,
+    process_type    => 'bulk-reindex-queue-listener',
+    process_regex   => '\/rake message_queue:bulk_insert_data_into_govuk',
+    stdout_log_json => false,
   }
 
   Govuk::App::Envvar {

--- a/modules/govuk/manifests/deploy/config.pp
+++ b/modules/govuk/manifests/deploy/config.pp
@@ -136,6 +136,7 @@ class govuk::deploy::config(
     'GOVUK_WEBSITE_ROOT': value         => $website_root;
     'GOVUK_CSP_REPORT_ONLY': value      => $csp_report_only_value;
     'GOVUK_CSP_REPORT_URI': value       => $csp_report_uri;
+    # This env var can be removed once all GOV.UK apps are using Sidekiq >= 6
     'SIDEKIQ_LOGFILE': value            => $sidekiq_logfile;
     'GOVUK_SIDEKIQ_JSON_LOGGING': value => '1';
   }


### PR DESCRIPTION
Trello: https://trello.com/c/TEXZQpu9/439-sidekiq-6-log-files-arent-reaching-logit

This configures govuk::procfile::worker to utilise filebeat to ship log
files. The motivation for adding this is that GOV.UK apps that use
Sidekiq >= 6 are not having their logs shipped to logit.

The most common usage of govuk::procfile::worker is for Sidekiq and
prior to version 6 GOV.UK wrote Sidekiq logs to a file
(log/sidekiq.json). With Sidekiq 6 there is no longer the ability to
write to a logfile [1]. While there have previously been stdout and
stderr log files created as part of a govuk::procfile::worker process
these have not been configured to use filebeat.

While Sidekiq is the most common usage of govuk::procfile::worker it is
not the only one - it is used for running other background tasks like
RabbitMQ consumers - and thus some compromises were made so it wasn't
Sidekiq specific. This mostly impacts the tagging of logs which will now
use the process name from the procfile (generally "worker") rather than
a tag of "sidekiq".

The expectation is that GOV.UK Sidekiq logging will be in JSON so this
is the default in the class. For other uses of this class there's a good
chance that this will need to be set to false (see next commit).

In experimenting with this I investigated whether to ship stderr logs as
well as stdout and became concerned that this might create a yak shave.
From my brief testing there seemed to be a lot of junk in stderr
(search-api logged a Ruby warning every 4 seconds 😭) and there seemed
to be some duplications (presumably a consequence of our stdout/stderr
munging in GovukLogging [2]). As these logs weren't previously shipped
adding this seemed to be more adding a new feature that fixing something
lost so I stepped away from it.

[1]: https://www.mikeperham.com/2019/09/03/welcome-to-sidekiq-6.0/
[2]: https://github.com/alphagov/govuk_app_config/blob/13083f8f8563c4703c14fe8175ca35646ec64442/lib/govuk_app_config/govuk_logging.rb#L7-L26