### PR TITLE
Remove unused $stderr_log_json variable

### DIFF
--- a/modules/govuk/manifests/procfile/worker.pp
+++ b/modules/govuk/manifests/procfile/worker.pp
@@ -46,7 +46,6 @@ define govuk::procfile::worker (
   $respawn_timeout = 20,
   $process_regex = "sidekiq .* ${title}(.*\\.gov\\.uk)? ",
   $stdout_log_json = true,
-  $stderr_log_json = false,
 ) {
   validate_re($ensure, '^(present|absent)$', '$ensure must be "present" or "absent"')
 


### PR DESCRIPTION
Trello: https://trello.com/c/TEXZQpu9/439-sidekiq-6-log-files-arent-reaching-logit

This variable was left from a previous iteration of the code in https://github.com/alphagov/govuk-puppet/pull/11968 that was removed. I left this behind.