### PR TITLE
Enable Crumb Issuer proxy compatibility

### DIFF
--- a/modules/govuk_jenkins/templates/config/config.xml.erb
+++ b/modules/govuk_jenkins/templates/config/config.xml.erb
@@ -154,7 +154,7 @@
   <label></label>
   <%- if @csrf_version -%>
   <crumbIssuer class="hudson.security.csrf.DefaultCrumbIssuer">
-    <excludeClientIPFromCrumb>false</excludeClientIPFromCrumb>
+    <excludeClientIPFromCrumb>true</excludeClientIPFromCrumb>
   </crumbIssuer>
   <%- end -%>
   <nodeProperties/>


### PR DESCRIPTION
This should hopefully fix the 403 response error we have been seeing when trying to load pages in Jenkins.
note from https://github.com/jenkinsci/jenkins/blob/master/core/src/main/resources/hudson/security/csrf/DefaultCrumbIssuer/help-excludeClientIPFromCrumb.html using this option makes the nonce value easier to forge.

![Screenshot 2023-01-27 at 10 08 02](https://user-images.githubusercontent.com/19667619/215062679-561ba784-ffcf-449e-8bdd-19f8e3afc36a.png)
