### PR TITLE
Run a Redis 6 container instance in CI 

### DIFF
--- a/modules/govuk_ci/manifests/agent.pp
+++ b/modules/govuk_ci/manifests/agent.pp
@@ -20,7 +20,6 @@ class govuk_ci::agent(
 
   include ::clamav
   include ::clamav::cron_freshclam
-  include ::govuk_ci::agent::redis
   include ::govuk_ci::agent::docker
   include ::golang
   include ::govuk_ci::agent::gcloud
@@ -28,6 +27,7 @@ class govuk_ci::agent(
   include ::govuk_ci::agent::mongodb
   include ::govuk_ci::agent::mysql
   include ::govuk_ci::agent::postgresql
+  include ::govuk_ci::agent::redis
   include ::govuk_ci::agent::rabbitmq
   include ::govuk_ci::agent::solr
   include ::govuk_ci::cleanup

--- a/modules/govuk_ci/manifests/agent/redis.pp
+++ b/modules/govuk_ci/manifests/agent/redis.pp
@@ -10,6 +10,13 @@
 class govuk_ci::agent::redis(
   $conf_maxmemory = '256mb',
 ) {
+  # Docker instances of Redis server versions that are installed in
+  # parallel with the Ubuntu Trusty version
+  include ::govuk_docker
+  ::govuk_containers::ci_redis { 'ci-redis-6':
+    version => '6',
+    port    => 63796,
+  }
 
   class {'::redis':
     conf_maxmemory => $conf_maxmemory,

--- a/modules/govuk_containers/manifests/ci_redis.pp
+++ b/modules/govuk_containers/manifests/ci_redis.pp
@@ -1,0 +1,30 @@
+# == Resource: govuk_containers::ci_redis
+#
+# Install and run a dockerised Redis server, intended for CI purposes
+#
+# === Parameters
+#
+# [*version*]
+#   The version of the Redis Docker image to use
+#
+# [*port*]
+#   The port that the Redis server will be exposed on
+#
+define govuk_containers::ci_redis(
+  $ensure = 'present',
+  $version = '6',
+  $port = 63796
+) {
+  ::docker::run { $title:
+    ensure => $ensure,
+    ports  => ["127.0.0.1:${port}:6379"],
+    image  => "redis:${version}",
+  }
+
+  @@icinga::check { "check_${title}_running_${::hostname}":
+    ensure              => $ensure,
+    check_command       => "check_nrpe!check_tcp!127.0.0.1 ${port}",
+    service_description => "Docker Redis ${version} not accepting TCP connections",
+    host_name           => $::fqdn,
+  }
+}

--- a/modules/govuk_containers/spec/defines/govuk_containers__ci_redis_spec.rb
+++ b/modules/govuk_containers/spec/defines/govuk_containers__ci_redis_spec.rb
@@ -1,0 +1,14 @@
+require_relative '../../../../spec_helper'
+
+describe 'govuk_containers::ci_redis', :type => :define do
+  let(:title) { "ci-redis-instance" }
+
+  let(:pre_condition) { <<-EOS
+    include ::govuk_python
+    include ::govuk_docker
+    EOS
+  }
+  it { is_expected.to compile }
+
+  it { is_expected.to compile.with_all_deps }
+end


### PR DESCRIPTION
Trello: https://trello.com/c/JXAvbpOX/1103-upgrade-apps-to-sidekiq-v6

On our Jenkins CI machines we run Redis 2.8.4 😭, this finally caught up
to us with tests for GOV.UK apps that use Sidekiq 6 and makes use of
newer Redis features.

This applies the same approach we've used to get around ancient versions
of PostgreSQL, MongoDB and MySQL and sets up a containerised version of
Redis so our apps can use an equivalent to version as the production
runtime.

This sets-up a Redis 6 container that runs on the CI machines (we are
using Redis 6 via ElastiCache in production). Rails applications can use
this by setting up an env var e.g:

```
  govuk.setEnvar("REDIS_URL", "redis://127.0.0.1:63796")
```

I set the port number to be 63796 to reflect 6379 as the regular Redis
port and 6 to signify the version.

An example of this running successfully is: https://ci.integration.publishing.service.gov.uk/job/travel-advice-publisher/job/sidekiq-6-kevin/6/