### PR TITLE
Remove `content_data_api_re_run` job from Staging & Integration

### DIFF
--- a/hieradata_aws/class/integration/jenkins.yaml
+++ b/hieradata_aws/class/integration/jenkins.yaml
@@ -25,7 +25,6 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::govuk_taxonomy_supervised_learning
   - govuk_jenkins::jobs::monitor_taxonomy_health
   - govuk_jenkins::jobs::passive_checks
-  - govuk_jenkins::jobs::content_data_api_re_run
   - govuk_jenkins::jobs::publication_delay_report
   - govuk_jenkins::jobs::publish_special_routes
   - govuk_jenkins::jobs::record_taxonomy_metrics

--- a/hieradata_aws/class/staging/jenkins.yaml
+++ b/hieradata_aws/class/staging/jenkins.yaml
@@ -85,7 +85,6 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::passive_checks
   - govuk_jenkins::jobs::publication_delay_report
   - govuk_jenkins::jobs::record_superfluous_taggings_metrics
-  - govuk_jenkins::jobs::content_data_api_re_run
   - govuk_jenkins::jobs::publish_special_routes
   - govuk_jenkins::jobs::record_taxonomy_metrics
   - govuk_jenkins::jobs::remove_emergency_banner


### PR DESCRIPTION
The job hasn't succeeded for almost 6 months in Staging, and for an entire year in Integration! It is not worth fixing as this job only exists to fix a race condition where Production was a day or two behind (see #10437).

We'll keep the hack in Production, and allow Staging & Integration to receive the most up-to-date results through the nightly env sync. We shouldn't accept having perpetually failing jobs in any environment.

- Job on Staging: ![Job on Staging](https://user-images.githubusercontent.com/5111927/215437810-c66de700-df0e-43a0-9eb0-f4470d6a8a1e.png)
- Job on Integration: ![Job on Integration](https://user-images.githubusercontent.com/5111927/215437813-6dd8100f-3863-47cb-975b-60d275f0be76.png)