### PR TITLE
Remove Ed Kerry manifest file and integration mention

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -316,7 +316,6 @@ users::usernames:
   - deborahchua
   - dilwoarhussain
   - duncangarmonsway
-  - edwardkerry
   - grahamlewis
   - hannalaakso
   - jamesrobinson

--- a/modules/users/manifests/edwardkerry.pp
+++ b/modules/users/manifests/edwardkerry.pp
@@ -1,9 +1,0 @@
-# Creates the user edwardkerry
-class users::edwardkerry {
-  govuk_user { 'edwardkerry':
-    ensure   =>  absent,
-    fullname => 'Edward Kerry',
-    email    => 'edward.kerry@digital.cabinet-office.gov.uk',
-    ssh_key  => 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAID03eorNCOM7OWdZuXosiT7m1/QDtdTL34LJ1JRJJlcs edward.kerry@digital.cabinet-office.gov.uk',
-  }
-}


### PR DESCRIPTION

Phase 2 of removing Ed from puppet - now ensure absent has been run, remove manifest and integration mention.

https://trello.com/c/fddTOOFn/1737-leaver-ed-kerry-tech-role-start-on-1st-february-2023-some-draft-prs-in-the-comment-to-get-started-with