### PR TITLE
(Re-)remove account-api from list of apps_using_rabbitmq

### DIFF
--- a/hieradata_aws/class/integration/rabbitmq.yaml
+++ b/hieradata_aws/class/integration/rabbitmq.yaml
@@ -1,5 +1,3 @@
 ---
 
-govuk::node::s_rabbitmq::apps_using_rabbitmq:
-  - account_api
-
+govuk::node::s_rabbitmq::apps_using_rabbitmq: []


### PR DESCRIPTION
[Trello card](https://trello.com/c/5eOP2MuY/449-re-remove-account-api-from-the-list-of-appsusingrabbitmq-in-integration)
We emptied out the list of apps_using_rabbitmq in integration, in #11938 
Looks like this line for account-api mistakenly crept back in, in #11958

Account-api [removed their RabbitMQ consumer process in Jan 2022](https://github.com/alphagov/account-api/commit/53c59a57710f0ea8bebfcc781926efc470c04de5), and we [terminated all the RabbitMQ nodes in integration in Dec 2022](https://github.com/alphagov/govuk-aws-data/pull/1141) 

There's no reason for this line to have been reinstated, it's a mistake.