### PR TITLE
Stop daily backups of MongoDB in integration

### DIFF
--- a/modules/mongodb/manifests/aws_backup.pp
+++ b/modules/mongodb/manifests/aws_backup.pp
@@ -11,7 +11,7 @@
 #   Name of the bucket to backup to.
 #
 class mongodb::aws_backup (
-  $ensure     = 'present',
+  $ensure     = 'absent',
   $backup_dir = '/var/lib/mongodb/backup',
   $bucket     = undef,
 ) {

--- a/modules/mongodb/spec/classes/mongodb__aws_backup_spec.rb
+++ b/modules/mongodb/spec/classes/mongodb__aws_backup_spec.rb
@@ -3,8 +3,8 @@ require_relative '../../../../spec_helper'
 describe 'mongodb::aws_backup', :type => :class do
   context "default settings" do
     let(:params){{ 'bucket' => 'my-bucket' }}
-    it { is_expected.to contain_file('/var/lib/mongodb/backup').with_ensure('directory') }
-    it { is_expected.to contain_file('/usr/local/bin/mongodump-to-s3').with_ensure('present') }
+    it { is_expected.to contain_file('/var/lib/mongodb/backup').with_ensure('absent') }
+    it { is_expected.to contain_file('/usr/local/bin/mongodump-to-s3').with_ensure('absent') }
     it { is_expected.to contain_cron__crondotdee('mongodump-to-s3') }
   end
 end


### PR DESCRIPTION
This script is only used to populate data that govuk-docker used for data replication - this has recently been updated so that it now uses data from the govuk-env-sync process.

Once we can confirm this job no longer runs we can proceed to remove the associated code.

See https://github.com/alphagov/govuk-docker/pull/640/commits/c998b4d9811c59b642f4d5389781128eebad3227 for more information.

Trello card: https://trello.com/c/mOYRWDOc/3084-modify-govuk-docker-so-that-it-uses-the-govuk-env-sync-backups-3