### PR TITLE
Remove authenticating-proxy MongoDB

### DIFF
--- a/hieradata_aws/class/cache.yaml
+++ b/hieradata_aws/class/cache.yaml
@@ -1,10 +1,5 @@
 ---
 
-govuk::apps::authenticating_proxy::mongodb_nodes:
-  - 'router-backend-1'
-  - 'router-backend-2'
-  - 'router-backend-3'
-
 govuk::apps::router::mongodb_name: 'router'
 govuk::apps::router::mongodb_nodes:
   - 'router-backend-1'

--- a/hieradata_aws/class/draft_cache.yaml
+++ b/hieradata_aws/class/draft_cache.yaml
@@ -1,10 +1,5 @@
 ---
 
-govuk::apps::authenticating_proxy::mongodb_nodes:
-  - 'router-backend-1'
-  - 'router-backend-2'
-  - 'router-backend-3'
-
 govuk::apps::router_api::oauth_id: "%{hiera('govuk::apps::router_api::draft_oauth_id')}"
 govuk::apps::router_api::oauth_secret: "%{hiera('govuk::apps::router_api::draft_oauth_secret')}"
 

--- a/modules/govuk/manifests/apps/authenticating_proxy.pp
+++ b/modules/govuk/manifests/apps/authenticating_proxy.pp
@@ -22,12 +22,6 @@
 #   The port of the database server to use in the DATABASE_URL.
 #   Default: undef
 #
-# [*mongodb_nodes*]
-#   Array of mongo cluster hostnames for the application to connect to.
-#
-# [*mongodb_name*]
-#   The name of the MongoDB database to use
-#
 # [*port*]
 #   The port that it is served on.
 #
@@ -63,8 +57,6 @@ class govuk::apps::authenticating_proxy(
   $db_password = undef,
   $db_port = undef,
   $db_name = 'authenticating_proxy_production',
-  $mongodb_nodes,
-  $mongodb_name = 'authenticating_proxy_production',
   $port,
   $sentry_dsn = undef,
   $govuk_upstream_uri = 'http://localhost:3054',
@@ -77,11 +69,6 @@ class govuk::apps::authenticating_proxy(
   $app_name = 'authenticating-proxy'
 
   include govuk_postgresql::client #installs libpq-dev package needed for pg gem
-
-  govuk::app::envvar::mongodb_uri { $app_name:
-    hosts    => $mongodb_nodes,
-    database => $mongodb_name,
-  }
 
   govuk::app::envvar::database_url { $app_name:
     type     => 'postgresql',

--- a/spec/fixtures/hieradata/common.yaml
+++ b/spec/fixtures/hieradata/common.yaml
@@ -21,7 +21,6 @@ gdal::repo::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"
 
 govuk::apps::router::mongodb_name: ['router']
 govuk::apps::router::mongodb_nodes: ['localhost']
-govuk::apps::authenticating_proxy::mongodb_nodes: ['localhost']
 
 govuk_awscloudwatch::apt_mirror_hostname: "%{hiera('apt_mirror_hostname')}"
 govuk_awscloudwatch::apt_mirror_gpg_key_fingerprint: "%{hiera('apt_mirror_fingerprint')}"


### PR DESCRIPTION
We migrated authenticating-proxy to use Postgres instead in https://github.com/alphagov/govuk-puppet/pull/11967 so the nodes and access is no longer needed.