### PR TITLE
Switch on 2SV features for Signon in integration

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -82,6 +82,8 @@ govuk::apps::short_url_manager::instance_name: 'integration'
 govuk::apps::signon::db_password: "%{hiera('govuk::node::s_signon_db_admin::mysql_db_password')}"
 govuk::apps::signon::instance_name: 'integration'
 govuk::apps::signon::govuk_notify_template_id: "759acac6-da53-4a19-b591-b7538c7c39de"
+govuk::apps::signon::permit_2sv_exemption_feature: "1"
+govuk::apps::signon::mandate_2sv_for_organisation_feature: "1"
 govuk::apps::smartanswers::expose_govspeak: true
 govuk::apps::specialist_publisher::aws_region: 'eu-west-1'
 govuk::apps::specialist_publisher::aws_s3_bucket_name: 'govuk-integration-specialist-publisher-csvs'

--- a/modules/govuk/manifests/apps/signon.pp
+++ b/modules/govuk/manifests/apps/signon.pp
@@ -72,6 +72,12 @@
 # [*govuk_notify_template_id*]
 #   The template ID used to send email via GOV.UK Notify.
 #
+# [*permit_2sv_exemption_feature*]
+#   Temporary feature flag to switch on exemption from 2-step verification
+#
+# [*mandate_2sv_for_organisation_feature*]
+#   Temporary feature flag to switch on mandating 2-step verification at an organisation level
+#
 class govuk::apps::signon(
   $active_record_encryption_primary_key = undef,
   $active_record_encryption_key_derivation_salt = undef,
@@ -94,6 +100,8 @@ class govuk::apps::signon(
   $unicorn_worker_processes = undef,
   $govuk_notify_api_key = undef,
   $govuk_notify_template_id = undef,
+  $permit_2sv_exemption_feature = undef,
+  $mandate_2sv_for_organisation_feature = undef,
 ) {
   $app_name = 'signon'
 
@@ -141,6 +149,12 @@ class govuk::apps::signon(
     "${title}-GOVUK_NOTIFY_TEMPLATE_ID":
       varname => 'GOVUK_NOTIFY_TEMPLATE_ID',
       value   => $govuk_notify_template_id;
+    "${title}-PERMIT_2SV_EXEMPTION":
+      varname => 'PERMIT_2SV_EXEMPTION',
+      value   => $permit_2sv_exemption_feature;
+    "${title}-MANDATE_2SV_FOR_ORGANISATION":
+      varname => 'MANDATE_2SV_FOR_ORGANISATION',
+      value   => $mandate_2sv_for_organisation_feature;
   }
 
   govuk::app::envvar::redis { $app_name:


### PR DESCRIPTION
We have recently introduced some new 2-step verification (2SV) features in Signon that are currently behind feature flags.

This sets the environment variables to switch them on in integration, so they can be demonstrated outside of production.