### PR TITLE
Remove service manuals frontend (part 1)

### DIFF
--- a/hieradata_aws/class/cache.yaml
+++ b/hieradata_aws/class/cache.yaml
@@ -26,7 +26,6 @@ router::nginx::app_specific_static_asset_routes:
   '/assets/frontend/': 'frontend'
   '/assets/government-frontend/': 'government-frontend'
   '/assets/licencefinder/': 'licencefinder'
-  '/assets/service-manual-frontend/': 'service-manual-frontend'
   '/assets/smartanswers/': 'smartanswers'
   '/assets/static/': 'static'
   '/assets/whitehall/': 'whitehall-frontend'

--- a/hieradata_aws/class/draft_cache.yaml
+++ b/hieradata_aws/class/draft_cache.yaml
@@ -28,7 +28,6 @@ router::nginx::app_specific_static_asset_routes:
   '/assets/feedback/': 'feedback'
   '/assets/frontend/': 'draft-frontend'
   '/assets/government-frontend/': 'draft-government-frontend'
-  '/assets/service-manual-frontend/': 'draft-service-manual-frontend'
   '/assets/smartanswers/': 'draft-smartanswers'
   '/assets/static/': 'draft-static'
   '/assets/whitehall/': 'draft-whitehall-frontend'

--- a/hieradata_aws/class/draft_frontend.yaml
+++ b/hieradata_aws/class/draft_frontend.yaml
@@ -4,7 +4,6 @@ govuk::apps::collections::vhost: 'draft-collections'
 govuk::apps::email_alert_frontend::vhost: 'draft-email-alert-frontend'
 govuk::apps::frontend::vhost: 'draft-frontend'
 govuk::apps::government_frontend::vhost: 'draft-government-frontend'
-govuk::apps::service_manual_frontend::vhost: 'draft-service-manual-frontend'
 govuk::apps::smartanswers::vhost: 'draft-smartanswers'
 
 govuk::apps::static::draft_environment: true

--- a/hieradata_aws/class/integration/ci_master.yaml
+++ b/hieradata_aws/class/integration/ci_master.yaml
@@ -49,7 +49,6 @@ govuk_jenkins::jobs::deploy_app_downstream::applications:
   search-admin: {}
   search-api: {}
   service-manual-publisher: {}
-  service-manual-frontend: {}
   short-url-manager: {}
   sidekiq-monitoring: {}
   signon: {}

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1291,7 +1291,6 @@ grafana::dashboards::application_dashboards:
       - whitehall-frontend
   search-admin:
     show_mysql_stats: true
-  service-manual-frontend: {}
   service-manual-publisher: {}
   short-url-manager: {}
   sidekiq-monitoring: {}

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -968,7 +968,6 @@ govuk_ci::master::pipeline_jobs:
   router: {}
   router-api: {}
   search-api: {}
-  service-manual-frontend: {}
   smartanswers:
     repository: 'smart-answers'
   static: {}
@@ -1081,7 +1080,6 @@ govuk_jenkins::jobs::deploy_app_downstream::applications:
   publishing-api: {}
   release: {}
   short-url-manager: {}
-  service-manual-frontend: {}
   service-manual-publisher: {}
   sidekiq-monitoring: {}
   signon: {}

--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -190,7 +190,6 @@ deployable_applications: &deployable_applications
   router-api: {}
   search-api: {}
   search-admin: {}
-  service-manual-frontend: {}
   service-manual-publisher: {}
   short-url-manager: {}
   sidekiq-monitoring: {}

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -260,11 +260,13 @@ monitoring::checks::lb::loadbalancers: # prefer "internal"
     healthyhosts_ignore:
       - draft-fron-draft-finder-frontend # no idea what this is
       - draft-fron-draft-manuals-fronten # in the process of being deprecated
+      - draft-fron-draft-service-manual # in the process of being deprecated
   blue-email-alert-api-internal: {}
   blue-frontend-internal:
     healthyhosts_ignore:
       - frontend-i-designprinciples # no idea what this is
       - frontend-i-manuals-frontend # in the process of being deprecated
+      - frontend-i-service-manual-fronte # in the process of being deprecated
       - frontend-i-spotlight # no idea what this is
   blue-graphite-internal:
     healthyhosts_warning: 0

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -446,11 +446,13 @@ monitoring::checks::lb::loadbalancers: # prefer "internal"
     healthyhosts_ignore:
       - draft-fron-draft-finder-frontend # no idea what this is
       - draft-fron-draft-manuals-fronten # in the process of being deprecated
+      - draft-fron-draft-service-manual # in the process of being deprecated
   blue-email-alert-api-internal: {}
   blue-frontend-internal:
     healthyhosts_ignore:
       - frontend-i-designprinciples # no idea what this is
       - frontend-i-manuals-frontend # in the process of being deprecated
+      - frontend-i-service-manual-fronte # in the process of being deprecated
       - frontend-i-spotlight # no idea what this is
   blue-graphite-internal:
     healthyhosts_warning: 0

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -427,11 +427,13 @@ monitoring::checks::lb::loadbalancers: # prefer "internal"
     healthyhosts_ignore:
       - draft-fron-draft-finder-frontend # no idea what this is
       - draft-fron-draft-manuals-fronten # in the process of being deprecated
+      - draft-fron-draft-service-manual # in the process of being deprecated
   blue-email-alert-api-internal: {}
   blue-frontend-internal:
     healthyhosts_ignore:
       - frontend-i-designprinciples # no idea what this is
       - frontend-i-manuals-frontend # in the process of being deprecated
+      - frontend-i-service-manual-fronte # in the process of being deprecated
       - frontend-i-spotlight # no idea what this is
   blue-graphite-internal:
     healthyhosts_warning: 0

--- a/modules/govuk/manifests/apps/service_manual_frontend.pp
+++ b/modules/govuk/manifests/apps/service_manual_frontend.pp
@@ -36,6 +36,7 @@ class govuk::apps::service_manual_frontend(
     }
 
     govuk::app { 'service-manual-frontend':
+      ensure                     => 'absent',
       app_type                   => 'rack',
       port                       => $port,
       sentry_dsn                 => $sentry_dsn,

--- a/modules/govuk/manifests/apps/service_manual_frontend.pp
+++ b/modules/govuk/manifests/apps/service_manual_frontend.pp
@@ -33,6 +33,7 @@ class govuk::apps::service_manual_frontend(
   if $enabled {
     govuk::app { 'service-manual-frontend':
       ensure                     => 'absent',
+      monitor_unicornherder      => false, # in the process of being deprecated
       app_type                   => 'rack',
       port                       => $port,
       sentry_dsn                 => $sentry_dsn,

--- a/modules/govuk/manifests/apps/service_manual_frontend.pp
+++ b/modules/govuk/manifests/apps/service_manual_frontend.pp
@@ -31,10 +31,6 @@ class govuk::apps::service_manual_frontend(
   $secret_key_base = undef,
 ) {
   if $enabled {
-    Govuk::App::Envvar {
-      app => 'service-manual-frontend',
-    }
-
     govuk::app { 'service-manual-frontend':
       ensure                     => 'absent',
       app_type                   => 'rack',
@@ -46,12 +42,6 @@ class govuk::apps::service_manual_frontend(
       asset_pipeline             => true,
       asset_pipeline_prefixes    => ['assets/service-manual-frontend'],
       vhost                      => $vhost,
-    }
-
-    govuk::app::envvar {
-      "${title}-SECRET_KEY_BASE":
-        varname => 'SECRET_KEY_BASE',
-        value   => $secret_key_base;
     }
   }
 }


### PR DESCRIPTION
We moved the rendering to `government-frontend` so this app can be retired.

[Trello card](https://trello.com/c/gICwB7Ej/1195-retire-service-manuals-frontend-app-m)