### PR TITLE
Improve deletion of expired graphite metrics

### DIFF
--- a/modules/govuk/templates/node/s_graphite/remove_old_whisper_data.erb
+++ b/modules/govuk/templates/node/s_graphite/remove_old_whisper_data.erb
@@ -8,7 +8,7 @@ find $whisper_dir -type f -mtime +730 -delete
 # Delete directories where none of the files inside have been modified in the
 # last 14 days. This effectively removes stats about machines which no longer
 # exist.
-for dir in $whisper_dir/*; do
+for dir in $whisper_dir/*/**; do
   if [[ ! -z $dir && -z "$(find $dir -mtime -14)" && $? -eq 0 ]]; then
     rm -rf $dir;
   fi


### PR DESCRIPTION
..by checking for empty whisper directories at _all_ levels under $whisper_dir,…not just first-level

While trying to remove old publishing queues & exchanges from the RabbitMQ Grafana dashboards ([Trello card](https://trello.com/c/gbdgXSJr/481-delete-the-queues-which-have-moved-to-amazonmq-from-the-rabbitmq-grafana-dashboard)), we found they are auto-generated from the Grafana stats. Those stats are stored in a hierarchical directory structure on the Graphite box. There's a cron job to clear up old directories, generated by `remove_old_whisper_data.erb`, that aims to clear up, amongst other things, any directories in which all the files are older than 14 days. 

However, it looks like many sub-directories under `$whisper_dir/rabbitmq_default` are not getting deleted, even though all the RabbitMQ EC2 instances were terminated over a month ago.

It looks like CI agents are creating temporary rabbitmq instances (presumably for running some tests against) and then reporting their metrics to graphite, which end up under subdirectories of this `rabbitmq_default` directory

Because the `remove_old_whisper_data script` only checks for 1st level subdirectories of `$whisper_dir`, this means that none of the subdirectories will ever get deleted (except possibly after 2yrs due to line 6 & line 26?) and we will therefore never get rid of the inactive queues & graphs from the rabbitmq dashboard.

This PR changes the list of directories which are checked for modification times of over 14 days old, to be *all* subdirectories of `$whisper_dir`.

A test run on integration found that this will remove 4911 subdirs including many from IP addresses which no longer exist (e.g. 10.1.4.80).