### PR TITLE
Correct ENV variable declaration for sidekiq-monitoring

### DIFF
--- a/modules/govuk/manifests/apps/sidekiq_monitoring.pp
+++ b/modules/govuk/manifests/apps/sidekiq_monitoring.pp
@@ -405,6 +405,10 @@ class govuk::apps::sidekiq_monitoring (
     content => template('govuk/sidekiq_monitoring_nginx_config.conf.erb'),
   }
 
+  Govuk::App::Envvar {
+    app => $app_name,
+  }
+
   govuk::app::envvar {
     "${app_name}-SESSION-KEY":
       varname => 'SESSION_KEY',


### PR DESCRIPTION
https://github.com/alphagov/govuk-puppet/pull/12005 was missing a call to `Govuk::App::Envvar` which led to the following error running puppet:

```
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Must pass app to Govuk::App::Envvar[sidekiq-monitoring-SESSION-KEY] at /usr/share/puppet/production/current/modules/govuk/manifests/apps/sidekiq_monitoring.pp:412 on node i-0ea83cfb2b359c202
```

[Trello card](https://trello.com/c/aVx282Rt)