### PR TITLE
Improve AmazonMQ Grafana dashboards

### DIFF
--- a/modules/grafana/files/dashboards_aws/aws-amazonmq.json
+++ b/modules/grafana/files/dashboards_aws/aws-amazonmq.json
@@ -92,11 +92,11 @@
               "options": {
                 "showDisabledItems": false
               },
-              "period": "",
+              "period": "1m",
               "refId": "A",
               "region": "$region",
               "statistics": [
-                "Average"
+                "Sum"
               ]
             },
             {
@@ -125,11 +125,11 @@
               "options": {
                 "showDisabledItems": false
               },
-              "period": "",
+              "period": "1m",
               "refId": "B",
               "region": "$region",
               "statistics": [
-                "Average"
+                "Sum"
               ]
             },
             {
@@ -158,11 +158,11 @@
               "options": {
                 "showDisabledItems": false
               },
-              "period": "",
+              "period": "1m",
               "refId": "C",
               "region": "$region",
               "statistics": [
-                "Average"
+                "Sum"
               ]
             },
             {
@@ -191,7 +191,7 @@
               "options": {
                 "showDisabledItems": false
               },
-              "period": "",
+              "period": "1m",
               "refId": "D",
               "region": "$region",
               "statistics": [

--- a/modules/grafana/files/dashboards_aws/aws-amazonmq.json
+++ b/modules/grafana/files/dashboards_aws/aws-amazonmq.json
@@ -67,6 +67,118 @@
           "steppedLine": false,
           "targets": [
             {
+              "alias": "Publish Rates",
+              "application": {
+                "filter": ""
+              },
+              "dimensions": {
+                "Broker": "$broker"
+              },
+              "functions": [],
+              "group": {
+                "filter": ""
+              },
+              "host": {
+                "filter": ""
+              },
+              "item": {
+                "filter": ""
+              },
+              "metricName": "PublishRate",
+              "mode": 0,
+              "namespace": "AWS/AmazonMQ",
+              "options": {
+                "showDisabledItems": false
+              },
+              "period": "1m",
+              "refId": "A",
+              "region": "$region",
+              "statistics": [
+                "Maximum"
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Message Publishing Rates (all queues)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": "broker",
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "Broker: $broker",
+      "titleSize": "h4"
+    },
+    {
+      "editable": true,
+      "collapse": false,
+      "height": "300px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "CloudWatch",
+          "fill": 0,
+          "id": 1,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "spaceLength": 10,
+          "span": 12,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
               "alias": "Total Messages",
               "application": {
                 "filter": ""

--- a/modules/grafana/files/dashboards_aws/aws-amazonmq.json
+++ b/modules/grafana/files/dashboards_aws/aws-amazonmq.json
@@ -67,7 +67,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "alias": "Publish Rates",
+              "alias": "Messages Published per second",
               "application": {
                 "filter": ""
               },
@@ -96,12 +96,43 @@
               "statistics": [
                 "Maximum"
               ]
+            },
+            {
+              "alias": "Total Messages in all queues",
+              "application": {
+                "filter": ""
+              },
+              "dimensions": {
+                "Broker": "$broker"
+              },
+              "functions": [],
+              "group": {
+                "filter": ""
+              },
+              "host": {
+                "filter": ""
+              },
+              "item": {
+                "filter": ""
+              },
+              "metricName": "MessageCount",
+              "mode": 0,
+              "namespace": "AWS/AmazonMQ",
+              "options": {
+                "showDisabledItems": false
+              },
+              "period": "1m",
+              "refId": "A",
+              "region": "$region",
+              "statistics": [
+                "Sum"
+              ]
             }
           ],
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Message Publishing Rates (all queues)",
+          "title": "Message Count & Publishing Rate (all queues)",
           "tooltip": {
             "shared": true,
             "sort": 0,


### PR DESCRIPTION
([Trello card](https://trello.com/c/YKLnRC4A/486-improve-queue-activity-metrics-for-the-amazonmq-grafana-dashboards)) - This PR:

* Adds a broker-wide graph to the AmazonMQ Grafana dashboard, showing PublishRate and MessageCount totalled across all queues on the broker
* Shortens the aggregation period of all AmazonMQ metrics to 1m
* Changes the aggregation to a Sum instead of an average

Screenshot from integration after this branch was [deployed](https://deploy.integration.publishing.service.gov.uk/job/Deploy_Puppet/5516/console):
![broker-panel-on-grafana](https://user-images.githubusercontent.com/134501/221186116-0361bc2b-b153-426e-9a2e-adb35e206e19.png)

 