### PR TITLE
Update Patrick Cartlidge public key

### DIFF
--- a/modules/users/manifests/patrickcartlidge.pp
+++ b/modules/users/manifests/patrickcartlidge.pp
@@ -3,6 +3,6 @@ class users::patrickcartlidge {
   govuk_user { 'patrickcartlidge':
     fullname => 'Patrick Cartlidge',
     email    => 'patrick.cartlidge@digital.cabinet-office.gov.uk',
-    ssh_key  => 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINTzaSh3QhBF+unD1Hc4T6lda19gK3CUj8gEYRL9SOhy patrick.cartlidge@digital.cabinet-office.gov.uk',
+    ssh_key  => 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIH9YWJ+K4Qd7Z3QohW/KVVM5zH3iO+Qwgpv2jkIv2hg+ patrick.cartlidge@digital.cabinet-office.gov.uk',
   }
 }


### PR DESCRIPTION
Update Patrick Cartlidge public key as device was replaced before being able to get the old public key from it.