### PR TITLE
Remove deprecated usage of bundle install

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/validate_published_dns.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/validate_published_dns.yaml.erb
@@ -30,7 +30,8 @@
             rm -rf govuk-dns-config
             git clone --branch main --depth 1 git@github.com:alphagov/govuk-dns-config.git
             cp "./govuk-dns-config/${ZONEFILE}" .
-            bundle install --path "${HOME}/bundles/${JOB_NAME}"
+            bundle config set --local path "${HOME}/bundles/${JOB_NAME}"
+            bundle install
             bundle exec rake validate_dns
     wrappers:
         - ansicolor:


### PR DESCRIPTION
We recently upgraded `govuk-dns` to Ruby version 3.2.0 and the `Validate_published_DNS` Jenkins jobs are now failing with:

```
[DEPRECATED] The `--path` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set --local path '/var/lib/jenkins/bundles/Validate_published_DNS'`, and stop using this flag
Bundler 2.4.1 is running, but your lockfile was generated with 2.1.4. Installing Bundler 2.1.4 and restarting using that version.
Fetching gem metadata from https://rubygems.org/.
Fetching bundler 2.1.4

Retrying download gem from https://rubygems.org/ due to error (2/4): Bundler::PermissionError There was an error while trying to write to `/usr/lib/rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/cache/bundler-2.1.4.gem`. It is likely that you need to grant write permissions for that path.
```

The use of --path and --deployment are deprecated in Bundler 2.1 and greater and dropped from Bundler 3.

Related PR https://github.com/alphagov/govuk-dns/pull/104

Trello card: https://trello.com/c/e5BZBWyK/3075-bump-platform-reliability-repos-ruby-versions-to-v3xx-5