### PR TITLE
Remove deprecated usage of bundle install

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/check_sentry_errors.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/check_sentry_errors.yaml.erb
@@ -24,7 +24,8 @@
     builders:
         - shell: |
             export SENTRY_AUTH_TOKEN=<%= @sentry_auth_token %>
-            bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
+            bundle config set --local path "${HOME}/bundles/${JOB_NAME}" deployment true
+            bundle install
             bundle exec rake run
     publishers:
         - trigger-parameterized-builds:


### PR DESCRIPTION
We are upgrading govuk-sentry-monitor to use Ruby 3.2.0 and requires a Bundler version of 2.1 or above which no longer supports the use of --path and --deployment.

Related PR https://github.com/alphagov/govuk-sentry-monitor/pull/9

Trello card: https://trello.com/c/e5BZBWyK/3075-bump-platform-reliability-repos-ruby-versions-to-v3xx-5