### PR TITLE
Revert "Add chriswhitehouse to integration.yml"

### DIFF
--- a/chriswhitehouse.pp
+++ b/chriswhitehouse.pp
@@ -1,8 +1,0 @@
-# Creates the chriswhitehouse user
-class users::chriswhitehouse {
-  govuk_user { 'chriswhitehouse':
-    fullname => 'Chris Whitehouse',
-    email    => 'chris.whitehouse@digital.cabinet-office.gov.uk',
-    ssh_key  => 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKWx9UP3V8w/dw2eQ/h7fKVpVn/nRJNDC2+N9SSlEqsR chris.whitehouse@digital.cabinet-office.gov.uk',
-  }
-}

--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -315,7 +315,6 @@ users::usernames:
   - catalinailie
   - chrisbanks
   - christopherashton
-  - chriswhitehouse
   - conorlowney
   - danielkaraj
   - davidgisbey


### PR DESCRIPTION
Reverts alphagov/govuk-puppet#12017

This is missing a file and causing issues for an env sync revert we're trying to push through, so let's revert the PR in the meantime.