### PR TITLE
Increase freshness_threshold for Search API Reindex Icinga alert

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/search_api_reindex_with_new_schema.pp
+++ b/modules/govuk_jenkins/manifests/jobs/search_api_reindex_with_new_schema.pp
@@ -25,7 +25,7 @@ class govuk_jenkins::jobs::search_api_reindex_with_new_schema (
     @@icinga::passive_check { "${check_name}_${::hostname}":
       service_description => $service_description,
       host_name           => $::fqdn,
-      freshness_threshold => 619200,
+      freshness_threshold => 691200,
       action_url          => $job_url,
       notes_url           => monitoring_docs_url(search-reindex-failed),
     }


### PR DESCRIPTION
[Trello](https://trello.com/c/FZYIiWzV/340-investigate-search-related-warnings-on-integration)

We have been getting lots of 'WARNING: Freshness threshold exceeded' Icinga warnings for:

'Rebuild new Search API indexes with up to date settings and mappings and reindex all content from the existing indexes.'

According to the docs [1] 'The purpose of freshness checking is to ensure that host and service checks are being provided passively by external applications on a regular basis. Freshness checking is useful when you want to ensure that passive checks are being received as frequently as you want'.

For passive checks, The freshness threshold is based on the last time a check result was received [2]:
(last check result time + check interval) > current time

The `freshness_threshold` was set to `619200` which works out at just over a week (7.16 days). The job runs on Mondays at 9pm and takes 2.5 hours so the number seems to be slightly low. It has been increased to 8 days (`691200` seconds... which looks confusingly like the previous number but it is different!).

[1](https://assets.nagios.com/downloads/nagioscore/docs/nagioscore/3/en/freshness.html)
[2](https://icinga.com/docs/icinga-2/latest/doc/08-advanced-topics/)