### PR TITLE
Mark "push/pull staging" env sync jobs as absent

### DIFF
--- a/hieradata_aws/class/integration/ckan_db_admin.yaml
+++ b/hieradata_aws/class/integration/ckan_db_admin.yaml
@@ -1,4 +1,6 @@
 govuk_env_sync::tasks:
+  "pull_ckan_staging_daily":
+    ensure: "absent"
   "pull_ckan_production_daily":
     ensure: "present"
     hour: "0"

--- a/hieradata_aws/class/integration/collections_publisher_db_admin.yaml
+++ b/hieradata_aws/class/integration/collections_publisher_db_admin.yaml
@@ -1,4 +1,6 @@
 govuk_env_sync::tasks:
+  "pull_collections_publisher_staging_daily":
+    ensure: "absent"
   "pull_collections_publisher_production_daily":
     ensure: "present"
     hour: "0"

--- a/hieradata_aws/class/integration/contacts_admin_db_admin.yaml
+++ b/hieradata_aws/class/integration/contacts_admin_db_admin.yaml
@@ -1,4 +1,6 @@
 govuk_env_sync::tasks:
+  "pull_contacts_admin_staging_daily":
+    ensure: "absent"
   "pull_contacts_admin_production_daily":
     ensure: "present"
     hour: "0"

--- a/hieradata_aws/class/integration/content_data_admin_db_admin.yaml
+++ b/hieradata_aws/class/integration/content_data_admin_db_admin.yaml
@@ -1,4 +1,6 @@
 govuk_env_sync::tasks:
+  "pull_content_data_admin_staging_daily":
+    ensure: "absent"
   "pull_content_data_admin_production_daily":
     ensure: "present"
     hour: "0"

--- a/hieradata_aws/class/integration/content_data_api_db_admin.yaml
+++ b/hieradata_aws/class/integration/content_data_api_db_admin.yaml
@@ -1,4 +1,6 @@
 govuk_env_sync::tasks:
+  "pull_content_data_api_staging_daily":
+    ensure: "absent"
   # Use the new Content Data API name here, to avoid issues with
   # changing the name later
   "pull_content_data_api_production_daily":

--- a/hieradata_aws/class/integration/content_publisher_db_admin.yaml
+++ b/hieradata_aws/class/integration/content_publisher_db_admin.yaml
@@ -1,4 +1,6 @@
 govuk_env_sync::tasks:
+  "pull_content_publisher_staging_daily":
+    ensure: "absent"
   "pull_content_publisher_production_daily":
     ensure: "present"
     hour: "0"

--- a/hieradata_aws/class/integration/content_tagger_db_admin.yaml
+++ b/hieradata_aws/class/integration/content_tagger_db_admin.yaml
@@ -1,4 +1,6 @@
 govuk_env_sync::tasks:
+  "pull_content_tagger_staging_daily":
+    ensure: "absent"
   "pull_content_tagger_production_daily":
     ensure: "present"
     hour: "0"

--- a/hieradata_aws/class/integration/email_alert_api_db_admin.yaml
+++ b/hieradata_aws/class/integration/email_alert_api_db_admin.yaml
@@ -1,4 +1,6 @@
 govuk_env_sync::tasks:
+  "pull_email_alert_api_staging_daily":
+    ensure: "absent"
   "pull_email_alert_api_production_daily":
     ensure: "present"
     hour: "0"

--- a/hieradata_aws/class/integration/imminence_db_admin.yaml
+++ b/hieradata_aws/class/integration/imminence_db_admin.yaml
@@ -1,4 +1,6 @@
 govuk_env_sync::tasks:
+  "pull_imminence_staging_daily":
+    ensure: "absent"
   "pull_imminence_production_daily":
     ensure: "present"
     hour: "0"

--- a/hieradata_aws/class/integration/link_checker_api_db_admin.yaml
+++ b/hieradata_aws/class/integration/link_checker_api_db_admin.yaml
@@ -1,4 +1,6 @@
 govuk_env_sync::tasks:
+  "pull_link_checker_api_staging_daily":
+    ensure: "absent"
   "pull_link_checker_api_production_daily":
     ensure: "present"
     hour: "0"

--- a/hieradata_aws/class/integration/local_links_manager_db_admin.yaml
+++ b/hieradata_aws/class/integration/local_links_manager_db_admin.yaml
@@ -1,4 +1,6 @@
 govuk_env_sync::tasks:
+  "pull_local_links_manager_staging_daily":
+    ensure: "absent"
   "pull_local_links_manager_production_daily":
     ensure: "present"
     hour: "0"

--- a/hieradata_aws/class/integration/locations_api_db_admin.yaml
+++ b/hieradata_aws/class/integration/locations_api_db_admin.yaml
@@ -1,4 +1,6 @@
 govuk_env_sync::tasks:
+  "pull_locations_api_staging_daily":
+    ensure: "absent"
   "pull_locations_api_production_daily":
     ensure: "present"
     hour: "0"

--- a/hieradata_aws/class/integration/publishing_api_db_admin.yaml
+++ b/hieradata_aws/class/integration/publishing_api_db_admin.yaml
@@ -1,4 +1,6 @@
 govuk_env_sync::tasks:
+  "pull_publishing_api_staging_daily":
+    ensure: "absent"
   "pull_publishing_api_production_daily":
     ensure: "present"
     hour: "0"

--- a/hieradata_aws/class/integration/release_db_admin.yaml
+++ b/hieradata_aws/class/integration/release_db_admin.yaml
@@ -1,4 +1,6 @@
 govuk_env_sync::tasks:
+  "pull_release_staging_daily":
+    ensure: "absent"
   "pull_release_production_daily":
     ensure: "present"
     hour: "0"

--- a/hieradata_aws/class/integration/search_admin_db_admin.yaml
+++ b/hieradata_aws/class/integration/search_admin_db_admin.yaml
@@ -1,4 +1,6 @@
 govuk_env_sync::tasks:
+  "pull_search_admin_staging_daily":
+    ensure: "absent"
   "pull_search_admin_production_daily":
     ensure: "present"
     hour: "0"

--- a/hieradata_aws/class/integration/service_manual_publisher_db_admin.yaml
+++ b/hieradata_aws/class/integration/service_manual_publisher_db_admin.yaml
@@ -1,4 +1,6 @@
 govuk_env_sync::tasks:
+  "pull_service_manual_publisher_staging_daily":
+    ensure: "absent"
   "pull_service_manual_publisher_production_daily":
     ensure: "present"
     hour: "0"

--- a/hieradata_aws/class/integration/support_api_db_admin.yaml
+++ b/hieradata_aws/class/integration/support_api_db_admin.yaml
@@ -1,4 +1,6 @@
 govuk_env_sync::tasks:
+  "pull_support_api_staging_daily":
+    ensure: "absent"
   "pull_support_api_production_daily":
     ensure: "present"
     hour: "0"

--- a/hieradata_aws/class/integration/transition_db_admin.yaml
+++ b/hieradata_aws/class/integration/transition_db_admin.yaml
@@ -1,4 +1,6 @@
 govuk_env_sync::tasks:
+  "pull_transition_staging_daily":
+    ensure: "absent"
   "pull_transition_production_daily":
     ensure: "present"
     hour: "6"

--- a/hieradata_aws/class/staging/ckan_db_admin.yaml
+++ b/hieradata_aws/class/staging/ckan_db_admin.yaml
@@ -11,3 +11,5 @@ govuk_env_sync::tasks:
     temppath: "/tmp/ckan_production"
     url: "govuk-production-database-backups"
     path: "ckan-postgres"
+  "push_ckan_staging_daily":
+    ensure: "absent"

--- a/hieradata_aws/class/staging/collections_publisher_db_admin.yaml
+++ b/hieradata_aws/class/staging/collections_publisher_db_admin.yaml
@@ -11,3 +11,5 @@ govuk_env_sync::tasks:
     temppath: "/tmp/collections_publisher_production"
     url: "govuk-production-database-backups"
     path: "collections-publisher-mysql"
+  "push_collections_publisher_staging_daily":
+    ensure: "absent"

--- a/hieradata_aws/class/staging/contacts_admin_db_admin.yaml
+++ b/hieradata_aws/class/staging/contacts_admin_db_admin.yaml
@@ -11,3 +11,5 @@ govuk_env_sync::tasks:
     temppath: "/tmp/contacts_admin_production"
     url: "govuk-production-database-backups"
     path: "contacts-admin-mysql"
+  "push_contacts_admin_staging_daily":
+    ensure: "absent"

--- a/hieradata_aws/class/staging/content_data_admin_db_admin.yaml
+++ b/hieradata_aws/class/staging/content_data_admin_db_admin.yaml
@@ -11,3 +11,5 @@ govuk_env_sync::tasks:
     temppath: "/tmp/content_data_admin_production"
     url: "govuk-production-database-backups"
     path: "content-data-admin-postgres"
+  "push_content_data_admin_staging_daily":
+    ensure: "absent"

--- a/hieradata_aws/class/staging/content_data_api_db_admin.yaml
+++ b/hieradata_aws/class/staging/content_data_api_db_admin.yaml
@@ -13,3 +13,5 @@ govuk_env_sync::tasks:
     temppath: "/tmp/content_data_api_production"
     url: "govuk-production-database-backups"
     path: "content-data-api-postgresql"
+  "push_content_data_api_staging_daily":
+    ensure: "absent"

--- a/hieradata_aws/class/staging/content_publisher_db_admin.yaml
+++ b/hieradata_aws/class/staging/content_publisher_db_admin.yaml
@@ -11,3 +11,5 @@ govuk_env_sync::tasks:
     temppath: "/tmp/content_publisher_production"
     url: "govuk-production-database-backups"
     path: "content-publisher-postgres"
+  "push_content_publisher_staging_daily":
+    ensure: "absent"

--- a/hieradata_aws/class/staging/content_tagger_db_admin.yaml
+++ b/hieradata_aws/class/staging/content_tagger_db_admin.yaml
@@ -11,3 +11,5 @@ govuk_env_sync::tasks:
     temppath: "/tmp/content_tagger_production"
     url: "govuk-production-database-backups"
     path: "content-tagger-postgres"
+  "push_content_tagger_staging_daily":
+    ensure: "absent"

--- a/hieradata_aws/class/staging/email_alert_api_db_admin.yaml
+++ b/hieradata_aws/class/staging/email_alert_api_db_admin.yaml
@@ -11,3 +11,5 @@ govuk_env_sync::tasks:
     temppath: "/tmp/email_alert_api_production"
     url: "govuk-production-database-backups"
     path: "email-alert-api-postgres"
+  "push_email_alert_api_staging_daily":
+    ensure: "absent"

--- a/hieradata_aws/class/staging/imminence_db_admin.yaml
+++ b/hieradata_aws/class/staging/imminence_db_admin.yaml
@@ -11,3 +11,5 @@ govuk_env_sync::tasks:
     temppath: "/tmp/imminence_production"
     url: "govuk-production-database-backups"
     path: "imminence-postgres"
+  "push_imminence_staging_daily":
+    ensure: "absent"

--- a/hieradata_aws/class/staging/link_checker_api_db_admin.yaml
+++ b/hieradata_aws/class/staging/link_checker_api_db_admin.yaml
@@ -11,3 +11,5 @@ govuk_env_sync::tasks:
     temppath: "/tmp/link_checker_api_production"
     url: "govuk-production-database-backups"
     path: "link-checker-api-postgres"
+  "push_link_checker_api_staging_daily":
+    ensure: "absent"

--- a/hieradata_aws/class/staging/local_links_manager_db_admin.yaml
+++ b/hieradata_aws/class/staging/local_links_manager_db_admin.yaml
@@ -11,3 +11,5 @@ govuk_env_sync::tasks:
     temppath: "/tmp/local_links_manager_production"
     url: "govuk-production-database-backups"
     path: "local-links-manager-postgres"
+  "push_local_links_manager_staging_daily":
+    ensure: "absent"

--- a/hieradata_aws/class/staging/locations_api_db_admin.yaml
+++ b/hieradata_aws/class/staging/locations_api_db_admin.yaml
@@ -11,3 +11,5 @@ govuk_env_sync::tasks:
     temppath: "/tmp/locations_api_production"
     url: "govuk-production-database-backups"
     path: "locations-api-postgres"
+  "push_locations_api_staging_daily":
+    ensure: "absent"

--- a/hieradata_aws/class/staging/publishing_api_db_admin.yaml
+++ b/hieradata_aws/class/staging/publishing_api_db_admin.yaml
@@ -11,3 +11,5 @@ govuk_env_sync::tasks:
     temppath: "/tmp/publishing_api_production"
     url: "govuk-production-database-backups"
     path: "publishing-api-postgres"
+  "push_publishing_api_staging_daily":
+    ensure: "absent"

--- a/hieradata_aws/class/staging/release_db_admin.yaml
+++ b/hieradata_aws/class/staging/release_db_admin.yaml
@@ -11,3 +11,5 @@ govuk_env_sync::tasks:
     temppath: "/tmp/release_production"
     url: "govuk-production-database-backups"
     path: "release-mysql"
+  "push_release_staging_daily":
+    ensure: "absent"

--- a/hieradata_aws/class/staging/search_admin_db_admin.yaml
+++ b/hieradata_aws/class/staging/search_admin_db_admin.yaml
@@ -11,3 +11,5 @@ govuk_env_sync::tasks:
     temppath: "/tmp/search_admin_production"
     url: "govuk-production-database-backups"
     path: "search-admin-mysql"
+  "push_search_admin_staging_daily":
+    ensure: "absent"

--- a/hieradata_aws/class/staging/service_manual_publisher_db_admin.yaml
+++ b/hieradata_aws/class/staging/service_manual_publisher_db_admin.yaml
@@ -11,3 +11,5 @@ govuk_env_sync::tasks:
     temppath: "/tmp/service_manual_publisher_production"
     url: "govuk-production-database-backups"
     path: "service-manual-publisher-postgres"
+  "push_service_manual_publisher_staging_daily":
+    ensure: "absent"

--- a/hieradata_aws/class/staging/support_api_db_admin.yaml
+++ b/hieradata_aws/class/staging/support_api_db_admin.yaml
@@ -11,3 +11,5 @@ govuk_env_sync::tasks:
     temppath: "/tmp/support_api_production"
     url: "govuk-production-database-backups"
     path: "support-api-postgres"
+  "push_support_api_staging_daily":
+    ensure: "absent"

--- a/hieradata_aws/class/staging/transition_db_admin.yaml
+++ b/hieradata_aws/class/staging/transition_db_admin.yaml
@@ -11,3 +11,5 @@ govuk_env_sync::tasks:
     temppath: "/tmp/transition_production"
     url: "govuk-production-database-backups"
     path: "transition-postgresql"
+  "push_transition_staging_daily":
+    ensure: "absent"


### PR DESCRIPTION
These jobs were reverted in #12018, but without `ensure => absent`, the jobs continue to exist, meaning multiple push/pull jobs run simultaneously and the env sync fails to work properly.

There was a miscommunication as we thought the `ensure => absent` step had already been done - apologies.

Trello: https://trello.com/c/42WqbBy7/3082-lock-down-access-to-production-database-dumps-investigation