### PR TITLE
Add missing properties for the push/pull env sync tasks

### DIFF
--- a/hieradata_aws/class/integration/ckan_db_admin.yaml
+++ b/hieradata_aws/class/integration/ckan_db_admin.yaml
@@ -1,6 +1,16 @@
 govuk_env_sync::tasks:
   "pull_ckan_staging_daily":
     ensure: "absent"
+    hour: "2"
+    minute: "30"
+    action: "pull"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "ckan_production"
+    database_hostname: "ckan-postgres"
+    temppath: "/tmp/ckan_staging"
+    url: "govuk-staging-database-backups"
+    path: "ckan-postgres"
   "pull_ckan_production_daily":
     ensure: "present"
     hour: "0"

--- a/hieradata_aws/class/integration/collections_publisher_db_admin.yaml
+++ b/hieradata_aws/class/integration/collections_publisher_db_admin.yaml
@@ -1,6 +1,16 @@
 govuk_env_sync::tasks:
   "pull_collections_publisher_staging_daily":
     ensure: "absent"
+    hour: "2"
+    minute: "30"
+    action: "pull"
+    dbms: "mysql"
+    storagebackend: "s3"
+    database: "collections_publisher_production"
+    database_hostname: "collections-publisher-mysql"
+    temppath: "/tmp/collections_publisher_staging"
+    url: "govuk-staging-database-backups"
+    path: "collections-publisher-mysql"
   "pull_collections_publisher_production_daily":
     ensure: "present"
     hour: "0"

--- a/hieradata_aws/class/integration/contacts_admin_db_admin.yaml
+++ b/hieradata_aws/class/integration/contacts_admin_db_admin.yaml
@@ -1,6 +1,16 @@
 govuk_env_sync::tasks:
   "pull_contacts_admin_staging_daily":
     ensure: "absent"
+    hour: "2"
+    minute: "30"
+    action: "pull"
+    dbms: "mysql"
+    storagebackend: "s3"
+    database: "contacts_production"
+    database_hostname: "contacts-admin-mysql"
+    temppath: "/tmp/contacts_admin_staging"
+    url: "govuk-staging-database-backups"
+    path: "contacts-admin-mysql"
   "pull_contacts_admin_production_daily":
     ensure: "present"
     hour: "0"

--- a/hieradata_aws/class/integration/content_data_admin_db_admin.yaml
+++ b/hieradata_aws/class/integration/content_data_admin_db_admin.yaml
@@ -1,6 +1,16 @@
 govuk_env_sync::tasks:
   "pull_content_data_admin_staging_daily":
     ensure: "absent"
+    hour: "2"
+    minute: "30"
+    action: "pull"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "content_data_admin_production"
+    database_hostname: "content-data-admin-postgres"
+    temppath: "/tmp/content_data_admin_staging"
+    url: "govuk-staging-database-backups"
+    path: "content-data-admin-postgres"
   "pull_content_data_admin_production_daily":
     ensure: "present"
     hour: "0"

--- a/hieradata_aws/class/integration/content_data_api_db_admin.yaml
+++ b/hieradata_aws/class/integration/content_data_api_db_admin.yaml
@@ -1,6 +1,16 @@
 govuk_env_sync::tasks:
   "pull_content_data_api_staging_daily":
     ensure: "absent"
+    hour: "2"
+    minute: "30"
+    action: "pull"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "content_performance_manager_production"
+    database_hostname: "content-data-api-postgresql-primary"
+    temppath: "/tmp/content_data_api_staging"
+    url: "govuk-staging-database-backups"
+    path: "content-data-api-postgresql"
   # Use the new Content Data API name here, to avoid issues with
   # changing the name later
   "pull_content_data_api_production_daily":

--- a/hieradata_aws/class/integration/content_publisher_db_admin.yaml
+++ b/hieradata_aws/class/integration/content_publisher_db_admin.yaml
@@ -1,6 +1,17 @@
 govuk_env_sync::tasks:
   "pull_content_publisher_staging_daily":
     ensure: "absent"
+    hour: "2"
+    minute: "30"
+    action: "pull"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "content_publisher_production"
+    database_hostname: "content-publisher-postgres"
+    temppath: "/tmp/content_publisher_staging"
+    url: "govuk-staging-database-backups"
+    path: "content-publisher-postgres"
+    transformation_sql_filename: "content_publisher.sql"
   "pull_content_publisher_production_daily":
     ensure: "present"
     hour: "0"

--- a/hieradata_aws/class/integration/content_tagger_db_admin.yaml
+++ b/hieradata_aws/class/integration/content_tagger_db_admin.yaml
@@ -1,6 +1,16 @@
 govuk_env_sync::tasks:
   "pull_content_tagger_staging_daily":
     ensure: "absent"
+    hour: "2"
+    minute: "30"
+    action: "pull"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "content_tagger_production"
+    database_hostname: "content-tagger-postgres"
+    temppath: "/tmp/content_tagger_staging"
+    url: "govuk-staging-database-backups"
+    path: "content-tagger-postgres"
   "pull_content_tagger_production_daily":
     ensure: "present"
     hour: "0"

--- a/hieradata_aws/class/integration/email_alert_api_db_admin.yaml
+++ b/hieradata_aws/class/integration/email_alert_api_db_admin.yaml
@@ -1,6 +1,17 @@
 govuk_env_sync::tasks:
   "pull_email_alert_api_staging_daily":
     ensure: "absent"
+    hour: "2"
+    minute: "30"
+    action: "pull"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "email-alert-api_production"
+    database_hostname: "email-alert-api-postgres"
+    temppath: "/tmp/email_alert_api_staging"
+    url: "govuk-staging-database-backups"
+    path: "email-alert-api-postgres"
+    transformation_sql_filename: "anonymise_email_addresses.sql"
   "pull_email_alert_api_production_daily":
     ensure: "present"
     hour: "0"

--- a/hieradata_aws/class/integration/imminence_db_admin.yaml
+++ b/hieradata_aws/class/integration/imminence_db_admin.yaml
@@ -1,6 +1,16 @@
 govuk_env_sync::tasks:
   "pull_imminence_staging_daily":
     ensure: "absent"
+    hour: "2"
+    minute: "30"
+    action: "pull"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "imminence_production"
+    database_hostname: "imminence-postgres"
+    temppath: "/tmp/imminence_staging"
+    url: "govuk-staging-database-backups"
+    path: "imminence-postgres"
   "pull_imminence_production_daily":
     ensure: "present"
     hour: "0"

--- a/hieradata_aws/class/integration/link_checker_api_db_admin.yaml
+++ b/hieradata_aws/class/integration/link_checker_api_db_admin.yaml
@@ -1,6 +1,16 @@
 govuk_env_sync::tasks:
   "pull_link_checker_api_staging_daily":
     ensure: "absent"
+    hour: "2"
+    minute: "30"
+    action: "pull"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "link_checker_api_production"
+    database_hostname: "link-checker-api-postgres"
+    temppath: "/tmp/link_checker_api_staging"
+    url: "govuk-staging-database-backups"
+    path: "link-checker-api-postgres"
   "pull_link_checker_api_production_daily":
     ensure: "present"
     hour: "0"

--- a/hieradata_aws/class/integration/local_links_manager_db_admin.yaml
+++ b/hieradata_aws/class/integration/local_links_manager_db_admin.yaml
@@ -1,6 +1,16 @@
 govuk_env_sync::tasks:
   "pull_local_links_manager_staging_daily":
     ensure: "absent"
+    hour: "2"
+    minute: "30"
+    action: "pull"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "local-links-manager_production"
+    database_hostname: "local-links-manager-postgres"
+    temppath: "/tmp/local_links_manager_staging"
+    url: "govuk-staging-database-backups"
+    path: "local-links-manager-postgres"
   "pull_local_links_manager_production_daily":
     ensure: "present"
     hour: "0"

--- a/hieradata_aws/class/integration/locations_api_db_admin.yaml
+++ b/hieradata_aws/class/integration/locations_api_db_admin.yaml
@@ -1,6 +1,16 @@
 govuk_env_sync::tasks:
   "pull_locations_api_staging_daily":
     ensure: "absent"
+    hour: "2"
+    minute: "30"
+    action: "pull"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "locations_api_production"
+    database_hostname: "locations-api-postgres"
+    temppath: "/tmp/locations_api_staging"
+    url: "govuk-staging-database-backups"
+    path: "locations-api-postgres"
   "pull_locations_api_production_daily":
     ensure: "present"
     hour: "0"

--- a/hieradata_aws/class/integration/publishing_api_db_admin.yaml
+++ b/hieradata_aws/class/integration/publishing_api_db_admin.yaml
@@ -1,6 +1,17 @@
 govuk_env_sync::tasks:
   "pull_publishing_api_staging_daily":
     ensure: "absent"
+    hour: "2"
+    minute: "30"
+    action: "pull"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "publishing_api_production"
+    database_hostname: "publishing-api-postgres"
+    temppath: "/tmp/publishing_api_staging"
+    url: "govuk-staging-database-backups"
+    path: "publishing-api-postgres"
+    transformation_sql_filename: "sanitise_publishing_api_production.sql"
   "pull_publishing_api_production_daily":
     ensure: "present"
     hour: "0"

--- a/hieradata_aws/class/integration/release_db_admin.yaml
+++ b/hieradata_aws/class/integration/release_db_admin.yaml
@@ -1,6 +1,16 @@
 govuk_env_sync::tasks:
   "pull_release_staging_daily":
     ensure: "absent"
+    hour: "2"
+    minute: "30"
+    action: "pull"
+    dbms: "mysql"
+    storagebackend: "s3"
+    database: "release_production"
+    database_hostname: "release-mysql"
+    temppath: "/tmp/release_staging"
+    url: "govuk-staging-database-backups"
+    path: "release-mysql"
   "pull_release_production_daily":
     ensure: "present"
     hour: "0"

--- a/hieradata_aws/class/integration/search_admin_db_admin.yaml
+++ b/hieradata_aws/class/integration/search_admin_db_admin.yaml
@@ -1,6 +1,16 @@
 govuk_env_sync::tasks:
   "pull_search_admin_staging_daily":
     ensure: "absent"
+    hour: "2"
+    minute: "30"
+    action: "pull"
+    dbms: "mysql"
+    storagebackend: "s3"
+    database: "search_admin_production"
+    database_hostname: "search-admin-mysql"
+    temppath: "/tmp/search_admin_staging"
+    url: "govuk-staging-database-backups"
+    path: "search-admin-mysql"
   "pull_search_admin_production_daily":
     ensure: "present"
     hour: "0"

--- a/hieradata_aws/class/integration/service_manual_publisher_db_admin.yaml
+++ b/hieradata_aws/class/integration/service_manual_publisher_db_admin.yaml
@@ -1,6 +1,16 @@
 govuk_env_sync::tasks:
   "pull_service_manual_publisher_staging_daily":
     ensure: "absent"
+    hour: "2"
+    minute: "30"
+    action: "pull"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "service-manual-publisher_production"
+    database_hostname: "service-manual-publisher-postgres"
+    temppath: "/tmp/service_manual_publisher_staging"
+    url: "govuk-staging-database-backups"
+    path: "service-manual-publisher-postgres"
   "pull_service_manual_publisher_production_daily":
     ensure: "present"
     hour: "0"

--- a/hieradata_aws/class/integration/support_api_db_admin.yaml
+++ b/hieradata_aws/class/integration/support_api_db_admin.yaml
@@ -1,6 +1,16 @@
 govuk_env_sync::tasks:
   "pull_support_api_staging_daily":
     ensure: "absent"
+    hour: "2"
+    minute: "30"
+    action: "pull"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "support_contacts_production"
+    database_hostname: "support-api-postgres"
+    temppath: "/tmp/support_api_staging"
+    url: "govuk-staging-database-backups"
+    path: "support-api-postgres"
   "pull_support_api_production_daily":
     ensure: "present"
     hour: "0"

--- a/hieradata_aws/class/integration/transition_db_admin.yaml
+++ b/hieradata_aws/class/integration/transition_db_admin.yaml
@@ -1,6 +1,16 @@
 govuk_env_sync::tasks:
   "pull_transition_staging_daily":
     ensure: "absent"
+    hour: "2"
+    minute: "30"
+    action: "pull"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "transition_production"
+    database_hostname: "transition-postgresql-primary"
+    temppath: "/tmp/transition_staging"
+    url: "govuk-staging-database-backups"
+    path: "transition-postgresql"
   "pull_transition_production_daily":
     ensure: "present"
     hour: "6"
@@ -15,7 +25,7 @@ govuk_env_sync::tasks:
     path: "transition-postgresql"
   "push_transition_integration_daily":
     ensure: "present"
-    hour: "3"
+    hour: "5"
     minute: "0"
     action: "push"
     dbms: "postgresql"

--- a/hieradata_aws/class/staging/ckan_db_admin.yaml
+++ b/hieradata_aws/class/staging/ckan_db_admin.yaml
@@ -13,3 +13,13 @@ govuk_env_sync::tasks:
     path: "ckan-postgres"
   "push_ckan_staging_daily":
     ensure: "absent"
+    hour: "2"
+    minute: "30"
+    action: "push"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "ckan_production"
+    database_hostname: "ckan-postgres"
+    temppath: "/tmp/ckan_staging"
+    url: "govuk-staging-database-backups"
+    path: "ckan-postgres"

--- a/hieradata_aws/class/staging/collections_publisher_db_admin.yaml
+++ b/hieradata_aws/class/staging/collections_publisher_db_admin.yaml
@@ -13,3 +13,13 @@ govuk_env_sync::tasks:
     path: "collections-publisher-mysql"
   "push_collections_publisher_staging_daily":
     ensure: "absent"
+    hour: "2"
+    minute: "30"
+    action: "push"
+    dbms: "mysql"
+    storagebackend: "s3"
+    database: "collections_publisher_production"
+    database_hostname: "collections-publisher-mysql"
+    temppath: "/tmp/collections_publisher_staging"
+    url: "govuk-staging-database-backups"
+    path: "collections-publisher-mysql"

--- a/hieradata_aws/class/staging/contacts_admin_db_admin.yaml
+++ b/hieradata_aws/class/staging/contacts_admin_db_admin.yaml
@@ -13,3 +13,13 @@ govuk_env_sync::tasks:
     path: "contacts-admin-mysql"
   "push_contacts_admin_staging_daily":
     ensure: "absent"
+    hour: "2"
+    minute: "30"
+    action: "push"
+    dbms: "mysql"
+    storagebackend: "s3"
+    database: "contacts_production"
+    database_hostname: "contacts-admin-mysql"
+    temppath: "/tmp/contacts_admin_staging"
+    url: "govuk-staging-database-backups"
+    path: "contacts-admin-mysql"

--- a/hieradata_aws/class/staging/content_data_admin_db_admin.yaml
+++ b/hieradata_aws/class/staging/content_data_admin_db_admin.yaml
@@ -13,3 +13,13 @@ govuk_env_sync::tasks:
     path: "content-data-admin-postgres"
   "push_content_data_admin_staging_daily":
     ensure: "absent"
+    hour: "2"
+    minute: "30"
+    action: "push"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "content_data_admin_production"
+    database_hostname: "content-data-admin-postgres"
+    temppath: "/tmp/content_data_admin_staging"
+    url: "govuk-staging-database-backups"
+    path: "content-data-admin-postgres"

--- a/hieradata_aws/class/staging/content_data_api_db_admin.yaml
+++ b/hieradata_aws/class/staging/content_data_api_db_admin.yaml
@@ -15,3 +15,13 @@ govuk_env_sync::tasks:
     path: "content-data-api-postgresql"
   "push_content_data_api_staging_daily":
     ensure: "absent"
+    hour: "2"
+    minute: "30"
+    action: "push"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "content_performance_manager_production"
+    database_hostname: "content-data-api-postgresql-primary"
+    temppath: "/tmp/content_data_api_staging"
+    url: "govuk-staging-database-backups"
+    path: "content-data-api-postgresql"

--- a/hieradata_aws/class/staging/content_publisher_db_admin.yaml
+++ b/hieradata_aws/class/staging/content_publisher_db_admin.yaml
@@ -13,3 +13,13 @@ govuk_env_sync::tasks:
     path: "content-publisher-postgres"
   "push_content_publisher_staging_daily":
     ensure: "absent"
+    hour: "2"
+    minute: "30"
+    action: "push"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "content_publisher_production"
+    database_hostname: "content-publisher-postgres"
+    temppath: "/tmp/content_publisher_staging"
+    url: "govuk-staging-database-backups"
+    path: "content-publisher-postgres"

--- a/hieradata_aws/class/staging/content_tagger_db_admin.yaml
+++ b/hieradata_aws/class/staging/content_tagger_db_admin.yaml
@@ -13,3 +13,13 @@ govuk_env_sync::tasks:
     path: "content-tagger-postgres"
   "push_content_tagger_staging_daily":
     ensure: "absent"
+    hour: "2"
+    minute: "30"
+    action: "push"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "content_tagger_production"
+    database_hostname: "content-tagger-postgres"
+    temppath: "/tmp/content_tagger_staging"
+    url: "govuk-staging-database-backups"
+    path: "content-tagger-postgres"

--- a/hieradata_aws/class/staging/email_alert_api_db_admin.yaml
+++ b/hieradata_aws/class/staging/email_alert_api_db_admin.yaml
@@ -13,3 +13,13 @@ govuk_env_sync::tasks:
     path: "email-alert-api-postgres"
   "push_email_alert_api_staging_daily":
     ensure: "absent"
+    hour: "2"
+    minute: "30"
+    action: "push"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "email-alert-api_production"
+    database_hostname: "email-alert-api-postgres"
+    temppath: "/tmp/email_alert_api_staging"
+    url: "govuk-staging-database-backups"
+    path: "email-alert-api-postgres"

--- a/hieradata_aws/class/staging/imminence_db_admin.yaml
+++ b/hieradata_aws/class/staging/imminence_db_admin.yaml
@@ -13,3 +13,13 @@ govuk_env_sync::tasks:
     path: "imminence-postgres"
   "push_imminence_staging_daily":
     ensure: "absent"
+    hour: "2"
+    minute: "30"
+    action: "push"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "imminence_production"
+    database_hostname: "imminence-postgres"
+    temppath: "/tmp/imminence_staging"
+    url: "govuk-staging-database-backups"
+    path: "imminence-postgres"

--- a/hieradata_aws/class/staging/link_checker_api_db_admin.yaml
+++ b/hieradata_aws/class/staging/link_checker_api_db_admin.yaml
@@ -13,3 +13,13 @@ govuk_env_sync::tasks:
     path: "link-checker-api-postgres"
   "push_link_checker_api_staging_daily":
     ensure: "absent"
+    hour: "2"
+    minute: "30"
+    action: "push"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "link_checker_api_production"
+    database_hostname: "link-checker-api-postgres"
+    temppath: "/tmp/link_checker_api_staging"
+    url: "govuk-staging-database-backups"
+    path: "link-checker-api-postgres"

--- a/hieradata_aws/class/staging/local_links_manager_db_admin.yaml
+++ b/hieradata_aws/class/staging/local_links_manager_db_admin.yaml
@@ -13,3 +13,13 @@ govuk_env_sync::tasks:
     path: "local-links-manager-postgres"
   "push_local_links_manager_staging_daily":
     ensure: "absent"
+    hour: "2"
+    minute: "30"
+    action: "push"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "local-links-manager_production"
+    database_hostname: "local-links-manager-postgres"
+    temppath: "/tmp/local_links_manager_staging"
+    url: "govuk-staging-database-backups"
+    path: "local-links-manager-postgres"

--- a/hieradata_aws/class/staging/locations_api_db_admin.yaml
+++ b/hieradata_aws/class/staging/locations_api_db_admin.yaml
@@ -13,3 +13,13 @@ govuk_env_sync::tasks:
     path: "locations-api-postgres"
   "push_locations_api_staging_daily":
     ensure: "absent"
+    hour: "2"
+    minute: "30"
+    action: "push"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "locations_api_production"
+    database_hostname: "locations-api-postgres"
+    temppath: "/tmp/locations_api_staging"
+    url: "govuk-staging-database-backups"
+    path: "locations-api-postgres"

--- a/hieradata_aws/class/staging/publishing_api_db_admin.yaml
+++ b/hieradata_aws/class/staging/publishing_api_db_admin.yaml
@@ -13,3 +13,13 @@ govuk_env_sync::tasks:
     path: "publishing-api-postgres"
   "push_publishing_api_staging_daily":
     ensure: "absent"
+    hour: "2"
+    minute: "30"
+    action: "push"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "publishing_api_production"
+    database_hostname: "publishing-api-postgres"
+    temppath: "/tmp/publishing_api_staging"
+    url: "govuk-staging-database-backups"
+    path: "publishing-api-postgres"

--- a/hieradata_aws/class/staging/release_db_admin.yaml
+++ b/hieradata_aws/class/staging/release_db_admin.yaml
@@ -13,3 +13,13 @@ govuk_env_sync::tasks:
     path: "release-mysql"
   "push_release_staging_daily":
     ensure: "absent"
+    hour: "2"
+    minute: "30"
+    action: "push"
+    dbms: "mysql"
+    storagebackend: "s3"
+    database: "release_production"
+    database_hostname: "release-mysql"
+    temppath: "/tmp/release_staging"
+    url: "govuk-staging-database-backups"
+    path: "release-mysql"

--- a/hieradata_aws/class/staging/search_admin_db_admin.yaml
+++ b/hieradata_aws/class/staging/search_admin_db_admin.yaml
@@ -13,3 +13,13 @@ govuk_env_sync::tasks:
     path: "search-admin-mysql"
   "push_search_admin_staging_daily":
     ensure: "absent"
+    hour: "2"
+    minute: "30"
+    action: "push"
+    dbms: "mysql"
+    storagebackend: "s3"
+    database: "search_admin_production"
+    database_hostname: "search-admin-mysql"
+    temppath: "/tmp/search_admin_staging"
+    url: "govuk-staging-database-backups"
+    path: "search-admin-mysql"

--- a/hieradata_aws/class/staging/service_manual_publisher_db_admin.yaml
+++ b/hieradata_aws/class/staging/service_manual_publisher_db_admin.yaml
@@ -13,3 +13,13 @@ govuk_env_sync::tasks:
     path: "service-manual-publisher-postgres"
   "push_service_manual_publisher_staging_daily":
     ensure: "absent"
+    hour: "2"
+    minute: "30"
+    action: "push"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "service-manual-publisher_production"
+    database_hostname: "service-manual-publisher-postgres"
+    temppath: "/tmp/service_manual_publisher_staging"
+    url: "govuk-staging-database-backups"
+    path: "service-manual-publisher-postgres"

--- a/hieradata_aws/class/staging/support_api_db_admin.yaml
+++ b/hieradata_aws/class/staging/support_api_db_admin.yaml
@@ -13,3 +13,13 @@ govuk_env_sync::tasks:
     path: "support-api-postgres"
   "push_support_api_staging_daily":
     ensure: "absent"
+    hour: "0"
+    minute: "0"
+    action: "push"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "support_contacts_production"
+    database_hostname: "support-api-postgres"
+    temppath: "/tmp/support_api_staging"
+    url: "govuk-staging-database-backups"
+    path: "support-api-postgres"

--- a/hieradata_aws/class/staging/transition_db_admin.yaml
+++ b/hieradata_aws/class/staging/transition_db_admin.yaml
@@ -1,8 +1,8 @@
 govuk_env_sync::tasks:
   "pull_transition_production_daily":
     ensure: "present"
-    hour: "4"
-    minute: "30"
+    hour: "0"
+    minute: "0"
     action: "pull"
     dbms: "postgresql"
     storagebackend: "s3"
@@ -13,3 +13,13 @@ govuk_env_sync::tasks:
     path: "transition-postgresql"
   "push_transition_staging_daily":
     ensure: "absent"
+    hour: "2"
+    minute: "30"
+    action: "push"
+    dbms: "postgresql"
+    storagebackend: "s3"
+    database: "transition_production"
+    database_hostname: "transition-postgresql-primary"
+    temppath: "/tmp/transition_staging"
+    url: "govuk-staging-database-backups"
+    path: "transition-postgresql"


### PR DESCRIPTION
Follow-on from #12023, which unfortunately didn't work.

Even though we're setting `ensure => absent` on these, Puppet won't synchronise unless we pass the mandatory fields (hour, minute etc).

I've taken the original values from #12010.

This does at least have the advantage of having all the configs lined up ready, such that we can swap `ensure => absent` for `ensure => present` for the push/pulls from Staging, and `ensure => present` for `ensure => absent` for the push/pulls from Production which we're hoping to lock down.

Trello: https://trello.com/c/42WqbBy7/3082-lock-down-access-to-production-database-dumps-investigation