### PR TITLE
Remove compute_body and compute_header from sanitise_whitehall

### DIFF
--- a/modules/govuk_env_sync/files/transformation_sql/sanitise_whitehall.sql
+++ b/modules/govuk_env_sync/files/transformation_sql/sanitise_whitehall.sql
@@ -50,7 +50,5 @@ WHERE id IN (
 UPDATE govspeak_contents
 INNER JOIN attachments ON attachments.id = govspeak_contents.html_attachment_id
 INNER JOIN editions ON attachments.attachable_id = editions.id
-SET govspeak_contents.body = @lipsum_body,
-    govspeak_contents.computed_body_html = NULL,
-    govspeak_contents.computed_headers_html = NULL
+SET govspeak_contents.body = @lipsum_body
 WHERE attachments.attachable_type = 'EDITION' AND editions.access_limited = 1;


### PR DESCRIPTION
The `computed_body_html' and `computed_headers_html` have been removed from the whitehall database following :
https://github.com/alphagov/whitehall/commit/1b4391b328cd3b20afdb54622d9c62833cf7bb09

This breaks the sanitisation part of the database dump. Removing the now absent fields from the sanitisation process will fix the database dump process.