### PR TITLE
Fix name of `push_govuk_assets` task on Staging

### DIFF
--- a/hieradata_aws/class/staging/db_admin.yaml
+++ b/hieradata_aws/class/staging/db_admin.yaml
@@ -46,6 +46,17 @@ govuk_env_sync::tasks:
     url: "govuk-production-database-backups"
     path: "mongo-normal"
   "push_govuk_assets_production":
+    ensure: "absent"
+    hour: "3"
+    minute: "00"
+    action: "push"
+    dbms: "documentdb"
+    storagebackend: "s3"
+    database: "govuk_assets_production"
+    temppath: "/tmp/govuk_assets_staging"
+    url: "govuk-staging-database-backups"
+    path: "mongo-normal"
+  "push_govuk_assets_staging":
     ensure: "present"
     hour: "3"
     minute: "00"


### PR DESCRIPTION
We're pushing to Staging, not Production.
This fix follows the naming convention used elsewhere, e.g. https://github.com/alphagov/govuk-puppet/blob/e800804a5247477d3373904f4fd9c02b75e0428b/hieradata_aws/class/staging/contacts_admin_db_admin.yaml#L14-L24

Due to Puppet funkiness, we need to explicitly remove any previously declared jobs, with `ensure: absent`. Once this PR has been merged and deployed, we can remove the `push_govuk_assets_production` job for good.