### PR TITLE
Include tfenv for deploy DNS jenkins job

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/deploy_dns.pp
+++ b/modules/govuk_jenkins/manifests/jobs/deploy_dns.pp
@@ -28,7 +28,8 @@ class govuk_jenkins::jobs::deploy_dns (
 
   validate_array($zones)
 
-  contain '::govuk_jenkins::packages::terraform'
+  include ::govuk_jenkins::packages::terraform
+  include ::govuk_jenkins::packages::tfenv
 
   file { '/etc/jenkins_jobs/jobs/deploy_dns.yaml':
     ensure  => present,


### PR DESCRIPTION
Should fix the deploy DNS job not having the correct terraform version