### PR TITLE
Disable workers for migrated EKS applications

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -519,7 +519,7 @@ govuk::apps::content_tagger::db_hostname: "content-tagger-postgres"
 govuk::apps::content_tagger::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 govuk::apps::content_tagger::db::allow_auth_from_lb: true
 govuk::apps::content_tagger::db::lb_ip_range: "%{hiera('environment_ip_prefix')}.0.0/16"
-govuk::apps::content_tagger::enable_procfile_worker: true
+govuk::apps::content_tagger::enable_procfile_worker: false
 govuk::apps::content_tagger::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::content_tagger::redis_port: "%{hiera('sidekiq_port')}"
 
@@ -810,7 +810,7 @@ govuk::apps::account_api::db_hostname: "account-api-postgres"
 govuk::apps::account_api::db::backend_ip_range: "%{hiera('environment_ip_prefix')}.3.0/24"
 govuk::apps::account_api::db::allow_auth_from_lb: true
 govuk::apps::account_api::db::lb_ip_range: "%{hiera('environment_ip_prefix')}.0.0/16"
-govuk::apps::account_api::enable_procfile_worker: true
+govuk::apps::account_api::enable_procfile_worker: false
 govuk::apps::account_api::redis_host: "%{hiera('sidekiq_host')}"
 govuk::apps::account_api::redis_port: "%{hiera('sidekiq_port')}"
 

--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -247,7 +247,7 @@ govuk::apps::support_api::zendesk_anonymous_ticket_email: 'zd-api-public@digital
 govuk::apps::support_api::pp_data_url: 'https://www.performance.service.gov.uk'
 govuk::apps::support_api::aws_s3_bucket_name: 'govuk-production-support-api-csvs'
 govuk::apps::support_api::govuk_notify_template_id: "e00e89f5-b622-4dcb-8f30-e6c70231a940"
-govuk::apps::travel_advice_publisher::enable_procfile_worker: true
+govuk::apps::travel_advice_publisher::enable_procfile_worker: false
 govuk::apps::whitehall::govuk_notify_template_id: "e00e89f5-b622-4dcb-8f30-e6c70231a940"
 govuk::apps::whitehall::aws_s3_bucket_name: 'govuk-production-whitehall-csvs'
 

--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -234,7 +234,7 @@ govuk::apps::support::aws_s3_bucket_name: 'govuk-staging-support-api-csvs'
 govuk::apps::support_api::pp_data_url: 'https://www.staging.performance.service.gov.uk'
 govuk::apps::support_api::aws_s3_bucket_name: 'govuk-staging-support-api-csvs'
 govuk::apps::support_api::govuk_notify_template_id: "112842bb-d8a4-4511-90de-57dc5c8f27ec"
-govuk::apps::travel_advice_publisher::enable_procfile_worker: true
+govuk::apps::travel_advice_publisher::enable_procfile_worker: false
 govuk::apps::travel_advice_publisher::mongodb_nodes: "%{hiera('govuk::apps::asset_manager::mongodb_nodes')}"
 govuk::apps::travel_advice_publisher::mongodb_username: "%{hiera('govuk::apps::asset_manager::mongodb_username')}"
 govuk::apps::travel_advice_publisher::mongodb_password: "%{hiera('govuk::apps::asset_manager::mongodb_password')}"

--- a/modules/govuk/manifests/apps/asset_manager.pp
+++ b/modules/govuk/manifests/apps/asset_manager.pp
@@ -53,7 +53,7 @@
 class govuk::apps::asset_manager(
   $enabled = true,
   $port,
-  $enable_procfile_worker = true,
+  $enable_procfile_worker = false,
   $sentry_dsn = undef,
   $oauth_id = undef,
   $oauth_secret = undef,

--- a/modules/govuk/manifests/apps/collections_publisher.pp
+++ b/modules/govuk/manifests/apps/collections_publisher.pp
@@ -82,7 +82,7 @@ class govuk::apps::collections_publisher(
   $sentry_dsn = undef,
   $oauth_id = undef,
   $oauth_secret = undef,
-  $enable_procfile_worker = true,
+  $enable_procfile_worker = false,
   $link_checker_api_bearer_token = undef,
   $publishing_api_bearer_token = undef,
   $email_alert_api_bearer_token = undef,

--- a/modules/govuk/manifests/apps/content_data_admin.pp
+++ b/modules/govuk/manifests/apps/content_data_admin.pp
@@ -98,7 +98,7 @@ class govuk::apps::content_data_admin (
   $google_tag_manager_auth = undef,
   $redis_host = undef,
   $redis_port = undef,
-  $enable_procfile_worker = true,
+  $enable_procfile_worker = false,
   $aws_access_key_id = undef,
   $aws_secret_access_key = undef,
   $aws_region = 'eu-west-1',

--- a/modules/govuk/manifests/apps/content_data_api.pp
+++ b/modules/govuk/manifests/apps/content_data_api.pp
@@ -104,7 +104,7 @@ class govuk::apps::content_data_api(
   $db_name = 'content_data_api_production',
   $db_password = undef,
   $db_username = 'content_data_api',
-  $enable_procfile_worker = true,
+  $enable_procfile_worker = false,
   $etl_healthcheck_enabled = true,
   $etl_healthcheck_enabled_from_hour = undef,
   $google_analytics_govuk_view_id = undef,

--- a/modules/govuk/manifests/apps/content_publisher.pp
+++ b/modules/govuk/manifests/apps/content_publisher.pp
@@ -121,7 +121,7 @@ class govuk::apps::content_publisher (
   $asset_manager_bearer_token = undef,
   $redis_host = undef,
   $redis_port = undef,
-  $enable_procfile_worker = true,
+  $enable_procfile_worker = false,
   $govuk_notify_api_key = undef,
   $govuk_notify_template_id = undef,
   $email_address_override = undef,

--- a/modules/govuk/manifests/apps/content_tagger.pp
+++ b/modules/govuk/manifests/apps/content_tagger.pp
@@ -78,7 +78,7 @@ class govuk::apps::content_tagger(
   $publishing_api_bearer_token = undef,
   $redis_host = undef,
   $redis_port = undef,
-  $enable_procfile_worker = true,
+  $enable_procfile_worker = false,
   $override_search_location = undef
 ) {
   $app_name = 'content-tagger'

--- a/modules/govuk/manifests/apps/email_alert_api.pp
+++ b/modules/govuk/manifests/apps/email_alert_api.pp
@@ -88,7 +88,7 @@ class govuk::apps::email_alert_api(
   $port,
   $enabled = false,
   $enable_public_proxy = true,
-  $enable_procfile_worker = true,
+  $enable_procfile_worker = false,
   $sidekiq_retry_critical = '200',
   $sidekiq_retry_warning = '100',
   $sidekiq_queue_size_critical = '100000',

--- a/modules/govuk/manifests/apps/imminence.pp
+++ b/modules/govuk/manifests/apps/imminence.pp
@@ -63,7 +63,7 @@
 class govuk::apps::imminence(
   $ensure = 'present',
   $port,
-  $enable_procfile_worker = true,
+  $enable_procfile_worker = false,
   $sentry_dsn = undef,
   $db_hostname = undef,
   $db_username = 'imminence',

--- a/modules/govuk/manifests/apps/link_checker_api.pp
+++ b/modules/govuk/manifests/apps/link_checker_api.pp
@@ -77,7 +77,7 @@ class govuk::apps::link_checker_api (
   $db_port = undef,
   $db_name = 'link_checker_api_production',
   $enabled = false,
-  $enable_procfile_worker = true,
+  $enable_procfile_worker = false,
   $sentry_dsn = undef,
   $google_api_key = undef,
   $oauth_id = undef,

--- a/modules/govuk/manifests/apps/locations_api.pp
+++ b/modules/govuk/manifests/apps/locations_api.pp
@@ -58,7 +58,7 @@ class govuk::apps::locations_api (
   $os_places_api_secret = undef,
   $os_places_api_postcodes_per_second = '3',
   $port,
-  $enable_procfile_worker = true,
+  $enable_procfile_worker = false,
   $unicorn_worker_processes = undef,
   $db_hostname = undef,
   $db_username = 'locations_api',

--- a/modules/govuk/manifests/apps/manuals_publisher.pp
+++ b/modules/govuk/manifests/apps/manuals_publisher.pp
@@ -76,7 +76,7 @@ class govuk::apps::manuals_publisher(
   $port,
   $asset_manager_bearer_token = undef,
   $email_alert_api_bearer_token = undef,
-  $enable_procfile_worker = true,
+  $enable_procfile_worker = false,
   $sentry_dsn = undef,
   $mongodb_nodes,
   $mongodb_name,

--- a/modules/govuk/manifests/apps/publisher.pp
+++ b/modules/govuk/manifests/apps/publisher.pp
@@ -103,7 +103,7 @@
 class govuk::apps::publisher(
     $ensure = 'present',
     $port,
-    $enable_procfile_worker = true,
+    $enable_procfile_worker = false,
     $publishing_api_bearer_token = undef,
     $asset_manager_bearer_token = undef,
     $secret_key_base = undef,

--- a/modules/govuk/manifests/apps/publishing_api.pp
+++ b/modules/govuk/manifests/apps/publishing_api.pp
@@ -128,7 +128,7 @@ class govuk::apps::publishing_api(
   $db_name = 'publishing_api_production',
   $redis_host = undef,
   $redis_port = undef,
-  $enable_procfile_worker = true,
+  $enable_procfile_worker = false,
   $oauth_id = undef,
   $oauth_secret = undef,
   $rabbitmq_hosts = ['localhost'],

--- a/modules/govuk/manifests/apps/search_admin.pp
+++ b/modules/govuk/manifests/apps/search_admin.pp
@@ -83,7 +83,7 @@ class govuk::apps::search_admin(
   $secret_key_base = undef,
   $rummager_bearer_token = undef,
   $override_search_location = undef,
-  $enable_procfile_worker = true,
+  $enable_procfile_worker = false,
   $redis_host = undef,
   $redis_port = undef,
   $govuk_notify_api_key = undef,

--- a/modules/govuk/manifests/apps/search_api.pp
+++ b/modules/govuk/manifests/apps/search_api.pp
@@ -111,7 +111,7 @@
 class govuk::apps::search_api(
   $rabbitmq_user,
   $port,
-  $enable_procfile_worker = true,
+  $enable_procfile_worker = false,
   $enable_govuk_index_listener = false,
   $enable_bulk_reindex_listener = false,
   $enable_publishing_listener = false,

--- a/modules/govuk/manifests/apps/short_url_manager.pp
+++ b/modules/govuk/manifests/apps/short_url_manager.pp
@@ -84,7 +84,7 @@ class govuk::apps::short_url_manager(
   $secret_key_base = undef,
   $govuk_notify_api_key = undef,
   $govuk_notify_template_id = undef,
-  $enable_procfile_worker = true,
+  $enable_procfile_worker = false,
 ) {
 
   $app_name = 'short-url-manager'

--- a/modules/govuk/manifests/apps/signon.pp
+++ b/modules/govuk/manifests/apps/signon.pp
@@ -87,7 +87,7 @@ class govuk::apps::signon(
   $db_username = undef,
   $devise_pepper = undef,
   $devise_secret_key = undef,
-  $enable_procfile_worker = true,
+  $enable_procfile_worker = false,
   $sentry_dsn = undef,
   $instance_name = undef,
   $port,

--- a/modules/govuk/manifests/apps/specialist_publisher.pp
+++ b/modules/govuk/manifests/apps/specialist_publisher.pp
@@ -95,7 +95,7 @@ class govuk::apps::specialist_publisher(
   $asset_manager_bearer_token = undef,
   $sentry_dsn = undef,
   $enabled = false,
-  $enable_procfile_worker = true,
+  $enable_procfile_worker = false,
   $mongodb_nodes,
   $mongodb_name,
   $mongodb_username = '',

--- a/modules/govuk/manifests/apps/support.pp
+++ b/modules/govuk/manifests/apps/support.pp
@@ -69,7 +69,7 @@ class govuk::apps::support(
   $ensure = 'present',
   $emergency_contact_details = undef,
   $sentry_dsn = undef,
-  $enable_procfile_worker = true,
+  $enable_procfile_worker = false,
   $oauth_id = undef,
   $oauth_secret = undef,
   $port,

--- a/modules/govuk/manifests/apps/support_api.pp
+++ b/modules/govuk/manifests/apps/support_api.pp
@@ -90,7 +90,7 @@ class govuk::apps::support_api(
   $db_name = undef,
   $db_password = undef,
   $db_username = undef,
-  $enable_procfile_worker = true,
+  $enable_procfile_worker = false,
   $sentry_dsn = undef,
   $oauth_id = undef,
   $oauth_secret = undef,

--- a/modules/govuk/manifests/apps/transition.pp
+++ b/modules/govuk/manifests/apps/transition.pp
@@ -64,7 +64,7 @@
 class govuk::apps::transition(
   $ensure = 'present',
   $port,
-  $enable_procfile_worker = true,
+  $enable_procfile_worker = false,
   $oauth_id = undef,
   $oauth_secret = undef,
   $redis_host = undef,

--- a/modules/govuk/manifests/apps/travel_advice_publisher.pp
+++ b/modules/govuk/manifests/apps/travel_advice_publisher.pp
@@ -73,7 +73,7 @@
 class govuk::apps::travel_advice_publisher(
   $ensure = 'present',
   $asset_manager_bearer_token = undef,
-  $enable_procfile_worker = true,
+  $enable_procfile_worker = false,
   $sentry_dsn = undef,
   $mongodb_name = undef,
   $mongodb_nodes = undef,

--- a/modules/govuk/manifests/apps/whitehall.pp
+++ b/modules/govuk/manifests/apps/whitehall.pp
@@ -159,7 +159,7 @@ class govuk::apps::whitehall(
   $db_password = undef,
   $db_username = undef,
   $email_alert_api_bearer_token = undef,
-  $enable_procfile_worker = true,
+  $enable_procfile_worker = false,
   $sentry_dsn = undef,
   $highlight_words_to_avoid = false,
   $oauth_id = undef,


### PR DESCRIPTION
This disables the Sidekiq workers for application that are now running on EKS. This prevents workers in EC2 from processing jobs, as they still have access to the same Redis instance with the queues.