### PR TITLE
Mark Sid Elangovan as absent

### DIFF
--- a/modules/users/manifests/sidelangovan.pp
+++ b/modules/users/manifests/sidelangovan.pp
@@ -1,6 +1,7 @@
 # Creates the sidelangovan user
 class users::sidelangovan {
   govuk_user { 'sidelangovan':
+    ensure   => absent,
     fullname => 'sid elangovan',
     email    => 'sid.elangovan@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHWdLamK0evD8DdBEwC3JEcJr85t0FTpam0fxiOM7j2v sid.elangovan@digital.cabinet-office.gov.uk',


### PR DESCRIPTION
## Description 

As per the docs here https://docs.publishing.service.gov.uk/manual/removing-a-user-from-puppet.html. We need to mark users as absent before removal.

## Trello card 

https://trello.com/c/0WFQYdlL/1845-leaver-sid-elangovan-tech-role