### PR TITLE
Add warning to deploy and rake task Jenkins jobs about EKS

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb
@@ -4,7 +4,9 @@
     concurrent: true
     display-name: Deploy_App
     project-type: freestyle
-    description: "<% if @environment != 'integration' %><a href=\"http://www.flickr.com/photos/fatty/9158066939/\">\r\n  <img src=\"https://farm3.staticflickr.com/2835/9158066939_374360ed56_n.jpg\">\r\n</a>\r\n<% end %><h2>You can monitor the application health using the <a href=\"https://grafana.<%= @app_domain %>/#/dashboard/file/application_http_error_codes.json\">4XX and 5XX status dashboard</a></h2>\r\n"
+    description: |
+      <h2>⚠️ This is only for deploying applications to EC2⚠️</h2>
+      <p>Most GOV.UK applications run on EKS, you can trigger deployments to EKS via the "Deploy" GitHub Action.</p>
     <%- if @auth_token -%>
     auth-token: <%= @auth_token %>
     <%- end -%>

--- a/modules/govuk_jenkins/templates/jobs/run_rake_task.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/run_rake_task.yaml.erb
@@ -3,7 +3,10 @@
     name: run-rake-task
     display-name: Run rake task
     project-type: freestyle
-    description: "Run a rake task on an application."
+    description: |
+      <p>Run a rake task on an application.</p>
+      <h2>⚠️ This is only for EC2 - most applications have been migrated to EKS ⚠️</h2>
+      <p>See <a href="https://docs.publishing.service.gov.uk/manual/running-rake-tasks.html#run-a-rake-task-on-eks">Run a rake task in EKS</a>.</p>
     concurrent: true
     properties:
       - build-discarder:


### PR DESCRIPTION
Most applications have now been migrated to EKS and don't use jenkins to deploy or run rake tasks. These messages are to avoid confusion.