### PR TITLE
Fix `seed_crawler last run status` Icinga check

### DIFF
--- a/modules/govuk_crawler/templates/seed-crawler-wrapper.erb
+++ b/modules/govuk_crawler/templates/seed-crawler-wrapper.erb
@@ -21,11 +21,11 @@ trap send_nsca EXIT
 export GOVUK_CRAWLER_AMQP_PASS='<%= @amqp_pass %>'
 export RBENV_ROOT=/usr/lib/rbenv
 
-OUTPUT=`eval "$(rbenv init -)" && rbenv shell 2.6.3 && <%= @seeder_script_path %> <%= @seeder_script_args %>`
+OUTPUT=`eval "$(rbenv init -)" && rbenv shell 2.6.3 && <%= @seeder_script_path %> <%= @seeder_script_args %> 2>&1`
+CODE=$?
 
 logger -p local3.info -t seed-crawler-wrapper "$OUTPUT"
 
-CODE=$?
 if [ "$OUTPUT" == "" ]; then
   OUTPUT="Seeder script exited with no output"
 fi


### PR DESCRIPTION
[Trello card](https://trello.com/c/YYBhibdh/3112-check-if-govuk-crawler-is-broken-and-fix-it-if-so)

This fixes a couple of issues with the check:

1. Capture `stderr` in addition to `stdout` (as Ruby exceptions & backtraces are logged to `stderr`)
2. Capture the exit code of the script itself, not the exit code of the call to `logger`