### PR TITLE
Add SSH key and access to integration for chrislowis

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -314,6 +314,7 @@ users::usernames:
   - callumknights
   - catalinailie
   - chrisbanks
+  - chrislowis
   - chrisroos
   - christopherashton
   - chriswhitehouse

--- a/modules/users/manifests/chrislowis.pp
+++ b/modules/users/manifests/chrislowis.pp
@@ -1,0 +1,8 @@
+# Creates the chrislowis user
+class users::chrislowis {
+  govuk_user { 'chrislowis':
+    fullname => 'Chris Lowis',
+    email    => 'chris.lowis@digital.cabinet-office.gov.uk',
+    ssh_key  => 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEgamNNn/84WNKyZ9B4wPoV/9oEu3KSyuGGj6JG0Umtu chris.lowis@digital.cabinet-office.gov.uk',
+  }
+}


### PR DESCRIPTION
Following the "get started" guide[1] this commit allows me to access integration using the public key added to the chrislowis.pp manifest.

[1] https://docs.publishing.service.gov.uk/manual/get-started.html