### PR TITLE
Disable failing Jenkins cronjobs.

### DIFF
--- a/hieradata_aws/production.yaml
+++ b/hieradata_aws/production.yaml
@@ -306,9 +306,6 @@ govuk_jenkins::jobs::content_data_api::rake_etl_main_process_cron_schedule: '0 7
 
 govuk_jenkins::jobs::clear_cdn_cache::website_root_url: 'https://www.gov.uk'
 
-govuk_jenkins::jobs::run_related_links_generation::cron_schedule: '0 8 9,23 * *'
-govuk_jenkins::jobs::run_related_links_ingestion::cron_schedule: '0 8 11,25 * *'
-
 govuk_jenkins::jobs::mirror_github_repositories::cron_schedule: '0 */2 * * *' # every 2 hours
 
 govuk_jenkins::jobs::search_fetch_analytics_data::skip_page_traffic_load: true
@@ -322,8 +319,6 @@ govuk_jenkins::jobs::signon_cron_rake_tasks::rake_oauth_access_grants_delete_exp
 govuk_jenkins::jobs::signon_cron_rake_tasks::rake_organisations_fetch_frequency: '0 3 * * *'
 govuk_jenkins::jobs::signon_cron_rake_tasks::rake_users_suspend_inactive_frequency: '0 4 * * *'
 govuk_jenkins::jobs::signon_cron_rake_tasks::rake_users_send_suspension_reminders_frequency: '0 6 * * *'
-
-govuk_jenkins::jobs::smart_answers_broken_links_report::cron_schedule: '30 1 1,15 * *' # every 1st and 15th of the month at 1:30 AM
 
 govuk_jenkins::jobs::smokey::environment: production
 

--- a/modules/govuk_jenkins/templates/jobs/record_taxonomy_metrics.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/record_taxonomy_metrics.yaml.erb
@@ -8,8 +8,6 @@
       about the Topic Taxonomy to statsd.
     logrotate:
       daysToKeep: 30
-    triggers:
-      - timed: 'H/30 * * * *'
     properties:
       - build-discarder:
           days-to-keep: 30


### PR DESCRIPTION
These don't work since we switched to k8s. Some of them already run as k8s cronjobs, others still need porting.

This should help avoid Jenkins executor slots getting tied up with stuck jobs, which caused the travel alert freshness alert to fire because it had to wait too long to start.

This is mainly a handover note/reminder for in-hours on Monday. I haven't tested it so check the agent run succeeds in integration/staging before rolling it to prod.