### PR TITLE
Remove deprecated usage of bundle install

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/user_monitor.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/user_monitor.yaml.erb
@@ -27,7 +27,8 @@
             export SENTRY_AUTH_TOKEN=<%= @sentry_auth_token %>
             export FASTLY_AUTH_TOKEN=<%= @fastly_auth_token %>
             export PAGERDUTY_AUTH_TOKEN=<%= @pagerduty_auth_token %>
-            bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
+            bundle config set --local path "${HOME}/bundles/${JOB_NAME}" deployment true
+            bundle install
             bundle exec rake run
     publishers:
       - trigger-parameterized-builds:


### PR DESCRIPTION
We have upgraded [govuk-user-reviewer](https://github.com/alphagov/govuk-user-reviewer) to Ruby 3.2.0 and requires a Bundler version of 2.1 or above which no longer supports the use of --path and --deployment.