### PR TITLE
Mark Badger job as absent

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/run_deploy_lag_badger.pp
+++ b/modules/govuk_jenkins/manifests/jobs/run_deploy_lag_badger.pp
@@ -12,7 +12,7 @@ class govuk_jenkins::jobs::run_deploy_lag_badger (
 ) {
 
   file { '/etc/jenkins_jobs/jobs/run_deploy_lag_badger.yaml':
-    ensure  => present,
+    ensure  => absent,
     content => template('govuk_jenkins/jobs/run_deploy_lag_badger.yaml.erb'),
     notify  => Exec['jenkins_jobs_update'],
   }


### PR DESCRIPTION
The apps are now deployed to Kubernetes and these messages aren't useful anymore.

The next PR will be to remove the job.