### PR TITLE
Disable Smokey in Jenkins

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/smokey.pp
+++ b/modules/govuk_jenkins/manifests/jobs/smokey.pp
@@ -27,7 +27,7 @@ class govuk_jenkins::jobs::smokey (
   include govuk::apps::smokey
 
   file { '/etc/jenkins_jobs/jobs/smokey.yaml':
-    ensure  => present,
+    ensure  => absent,
     content => template('govuk_jenkins/jobs/smokey.yaml.erb'),
     notify  => Exec['jenkins_jobs_update'],
     require => Class['govuk::apps::smokey'],


### PR DESCRIPTION
Smokey is running in Kubernetes now and is no longer required in Jenkins.

Trello card: https://trello.com/c/ahTC4Wjj/3134-disable-smokey-in-jenkins-2