### PR TITLE
Remove Smokey from the Deploy_App_Downstream job

### DIFF
--- a/modules/govuk_jenkins/manifests/jobs/deploy_app_downstream.pp
+++ b/modules/govuk_jenkins/manifests/jobs/deploy_app_downstream.pp
@@ -33,7 +33,7 @@ class govuk_jenkins::jobs::deploy_app_downstream (
   $deploy_url = undef,
   $deploy_environment = undef,
   $github_api_token = undef,
-  $smokey_pre_check = true,
+  $smokey_pre_check = false,
   $release_app_bearer_token = undef,
   $slack_channel = 'govuk-deploy,govuk-2ndline-tech',
   $slack_credential_id = 'slack-notification-token',


### PR DESCRIPTION
We no longer need to run Smokey in EC2 as it's now running on Kubernetes. This should stop it from running as part of the deploy app downstream job.

Trello card: https://trello.com/c/ahTC4Wjj/3134-disable-smokey-in-jenkins-2