### PR TITLE
Remove DNS deploy job from jenkins

### DIFF
--- a/hieradata_aws/class/production/jenkins.yaml
+++ b/hieradata_aws/class/production/jenkins.yaml
@@ -68,7 +68,6 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::configure_github_repos
   - govuk_jenkins::jobs::deploy_app
   - govuk_jenkins::jobs::deploy_cdn
-  - govuk_jenkins::jobs::deploy_dns
   - govuk_jenkins::jobs::deploy_puppet
   - govuk_jenkins::jobs::monitor_taxonomy_health
   - govuk_jenkins::jobs::email_alert_check


### PR DESCRIPTION
DNS config moved to Terraform Cloud, so this is no longer necessary.