### PR TITLE
Change time to 9am

### DIFF
--- a/modules/monitoring/manifests/pagerduty_drill.pp
+++ b/modules/monitoring/manifests/pagerduty_drill.pp
@@ -26,7 +26,7 @@ class monitoring::pagerduty_drill (
       ensure  => present,
       user    => 'root',
       weekday => 'wednesday',
-      hour    => 10,
+      hour    => 9,
       minute  => 0,
       command => '/usr/local/bin/govuk_pagerduty_drill_start',
     }
@@ -35,7 +35,7 @@ class monitoring::pagerduty_drill (
       ensure  => present,
       user    => 'root',
       weekday => 'wednesday',
-      hour    => 10,
+      hour    => 9,
       minute  => 15,
       command => "rm -f ${filename}",
     }


### PR DESCRIPTION
The drill has started firing at 11am instead of 10am due to the clocks going forward. Let's fix that.

This is a temporary workaround - long term we should [fix this outside of Puppet](https://trello.com/c/atcbGHh1/159-move-pagerduty-drill-out-of-puppet).