### PR TITLE
Fix missing reference to Jenkins job in production

### DIFF
--- a/hieradata_aws/class/production/jenkins.yaml
+++ b/hieradata_aws/class/production/jenkins.yaml
@@ -74,7 +74,6 @@ govuk_jenkins::job_builder::jobs:
   - govuk_jenkins::jobs::record_superfluous_taggings_metrics
   - govuk_jenkins::jobs::record_taxonomy_metrics
   - govuk_jenkins::jobs::publishing_api_archive_events
-  - govuk_jenkins::jobs::mirror_github_repositories
   - govuk_jenkins::jobs::search_api_fetch_analytics_data
   - govuk_jenkins::jobs::search_api_index_checks
   - govuk_jenkins::jobs::search_api_learn_to_rank


### PR DESCRIPTION
This reference to mirror_github_repositories wasn't removed when the modules files were deleted. This causes puppet runs to error in Production.