### PR TITLE
Mark Dilwoar Hussain Absent

### DIFF
--- a/modules/users/manifests/dilwoarhussain.pp
+++ b/modules/users/manifests/dilwoarhussain.pp
@@ -1,6 +1,7 @@
 # Creates the dilwoarhussain user
 class users::dilwoarhussain {
   govuk_user { 'dilwoarhussain':
+    ensure   => absent,
     fullname => 'Dilwoar Hussain',
     email    => 'dilwoar.hussain@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILfSLn+Npn0CmPuRJPLWNy+1kSTB6309/QpdGMo3L9/o dilwoar.hussain@digital.cabinet-office.gov.uk',


### PR DESCRIPTION
Dilwoar has left GDS, phase one of removal from Puppet.

https://docs.publishing.service.gov.uk/manual/removing-a-user-from-puppet.html