### PR TITLE
Remove Data_Sync_Complete cron triggers on Jenkins.

### DIFF
--- a/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/data_sync_complete_integration.yaml.erb
@@ -13,10 +13,6 @@
       - build-discarder:
           days-to-keep: 30
           artifact-num-to-keep: 5
-    triggers:
-      - timed: |
-            TZ=Europe/London
-            H 7 * * 1-5
     builders:
        - shell: |
           # Update routes in Router

--- a/modules/govuk_jenkins/templates/jobs/data_sync_complete_staging.yaml.erb
+++ b/modules/govuk_jenkins/templates/jobs/data_sync_complete_staging.yaml.erb
@@ -9,12 +9,6 @@
     <%- end -%>
     logrotate:
       numToKeep: 10
-    <%- if @aws -%>
-    triggers:
-      - timed: |
-          TZ=Europe/London
-          H 7 * * 1-5
-    <%- end %>
     properties:
       - build-discarder:
           days-to-keep: 30


### PR DESCRIPTION
Some of the functionality of this job is no longer needed; the rest is handled in https://github.com/alphagov/govuk-helm-charts/pull/1118.

Holding off on deleting the jobs entirely for a couple of days just so that it's easy to run them manually if it turns out I've missed something.