### PR TITLE
Ensure govuk_sync_mirror doesn't fail if error page can't be downloaded

### DIFF
--- a/modules/govuk_crawler/templates/govuk_sync_mirror.erb
+++ b/modules/govuk_crawler/templates/govuk_sync_mirror.erb
@@ -56,7 +56,7 @@ EOF
 
 log "user.info" "Starting to synchronise GOV.UK to mirror: <%= @targets.flatten.join(' ') -%>"
 
-get_error_page
+get_error_page || true
 
 write_timestamps
 


### PR DESCRIPTION
The script fails when it's trying to download some error pages from `static.production.govuk-internal.digital`, which would have ceased to exist a few months back.

Tested in staging. Logs show no errors and reported `govuk_sync_mirror: Started uploading to s3://govuk-staging-mirror/`

The files in S3 are now being updated

<kbd><img width="1074" alt="Screenshot 2023-06-09 at 12 21 31" src="https://github.com/alphagov/govuk-puppet/assets/38078064/346c3d60-3ad8-4cd0-8180-2cd7b04ba92e"></kbd>