### PR TITLE
Disable old Elasticsearch index copy cronjobs.

### DIFF
--- a/hieradata_aws/class/integration/search.yaml
+++ b/hieradata_aws/class/integration/search.yaml
@@ -1,6 +1,6 @@
 govuk_env_sync::tasks:
   "pull_es6_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "3"
     minute: "24"
     action: "pull"
@@ -11,7 +11,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging"
     path: "elasticsearch6"
   "push_es6_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "4"
     minute: "24"
     action: "push"

--- a/hieradata_aws/class/production/search.yaml
+++ b/hieradata_aws/class/production/search.yaml
@@ -1,6 +1,6 @@
 govuk_env_sync::tasks:
   "push_es6_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "0"
     minute: "20"
     action: "push"

--- a/hieradata_aws/class/staging/search.yaml
+++ b/hieradata_aws/class/staging/search.yaml
@@ -3,7 +3,7 @@
 # than integration being a day behind).
 govuk_env_sync::tasks:
   "pull_es6_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "1"
     minute: "24"
     action: "pull"
@@ -14,7 +14,7 @@ govuk_env_sync::tasks:
     url: "govuk-production"
     path: "elasticsearch6"
   "push_es6_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "2"
     minute: "24"
     action: "push"


### PR DESCRIPTION
These are obsoleted by https://github.com/alphagov/govuk-helm-charts/pull/1165.

https://trello.com/c/Nq4oZAOE