### PR TITLE
Mark cache_clearing_service AmazonMQ monitoring as absent

### DIFF
--- a/modules/govuk/manifests/apps/cache_clearing_service/amazonmq_monitoring.pp
+++ b/modules/govuk/manifests/apps/cache_clearing_service/amazonmq_monitoring.pp
@@ -13,37 +13,37 @@ class govuk::apps::cache_clearing_service::amazonmq_monitoring (
 
   # Consumer counts
   govuk_amazonmq::monitor_consumers { 'cache_clearing_service-high_consumer_monitoring':
-    ensure     => present,
+    ensure     => absent,
     queue_name => 'cache_clearing_service-high',
   }
 
   govuk_amazonmq::monitor_consumers { 'cache_clearing_service-medium_consumer_monitoring':
-    ensure     => present,
+    ensure     => absent,
     queue_name => 'cache_clearing_service-medium',
   }
 
   govuk_amazonmq::monitor_consumers { 'cache_clearing_service-low_consumer_monitoring':
-    ensure     => present,
+    ensure     => absent,
     queue_name => 'cache_clearing_service-low',
   }
 
   # Message counts
   govuk_amazonmq::monitor_messages { 'cache_clearing_service-high_message_monitoring':
-    ensure             => present,
+    ensure             => absent,
     queue_name         => 'cache_clearing_service-high',
     critical_threshold => $queue_size_critical_threshold,
     warning_threshold  => $queue_size_warning_threshold,
   }
 
   govuk_amazonmq::monitor_messages { 'cache_clearing_service-medium_message_monitoring':
-    ensure             => present,
+    ensure             => absent,
     queue_name         => 'cache_clearing_service-medium',
     critical_threshold => $queue_size_critical_threshold,
     warning_threshold  => $queue_size_warning_threshold,
   }
 
   govuk_amazonmq::monitor_messages { 'cache_clearing_service-low_message_monitoring':
-    ensure             => present,
+    ensure             => absent,
     queue_name         => 'cache_clearing_service-low',
     critical_threshold => $queue_size_critical_threshold,
     warning_threshold  => $queue_size_warning_threshold,


### PR DESCRIPTION
We are removing cache_clearing_service from AmazonMQ consumers https://github.com/alphagov/govuk-aws/pull/1740  and retiring the app.

In preparation to remove cache_clearing_service AmazonMQ monitoring.

[GIFT week summer 2023 card](https://trello.com/c/ENPwB2vT/41-retire-cache-clearing-service)
[Tech debt card](https://trello.com/c/TX9wLihh/101-cache-clearing-app-exists-and-we-dont-think-its-necessary-replacing-cache-clearing-app-only-clears-path-not-query-strings)
