### PR TITLE
Revert "Add user danmoore to integration"

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -298,7 +298,6 @@ users::usernames:
   - cristinarotaru
   - cynthiaanyaeriuba
   - danielkaraj
-  - danmoore
   - davidgisbey
   - davidmays
   - deborahchua

--- a/modules/users/manifests/danmoore.pp
+++ b/modules/users/manifests/danmoore.pp
@@ -1,8 +1,0 @@
-# Creates the danmoore user
-class users::danmoore {
-  govuk_user { 'danmoore':
-    fullname => 'Dan Moore',
-    email    => 'dan.moore@digital.cabinet-office.gov.uk',
-    ssh_key  => 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIF9exfPUcNvwA72BF+dRQ0BncR9KMzbXjSZY4BQnYg04 dan.moore@digital.cabinet-office.gov.uk',
-  }
-}


### PR DESCRIPTION
Reverts alphagov/govuk-puppet#12108

Dan has now left, potentially temporarily but we're still doing the off-boarding process.

This wasn't ever run in any environments (puppet seems to have failed to auto-deploy) so we can skip the ensure => absent process