### PR TITLE
Disable the CKAN env_syncs on Integration and Staging

### DIFF
--- a/hieradata_aws/class/integration/ckan_db_admin.yaml
+++ b/hieradata_aws/class/integration/ckan_db_admin.yaml
@@ -12,7 +12,7 @@ govuk_env_sync::tasks:
     url: "govuk-staging-database-backups"
     path: "ckan-postgres"
   "pull_ckan_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "0"
     minute: "0"
     action: "pull"
@@ -24,7 +24,7 @@ govuk_env_sync::tasks:
     url: "govuk-production-database-backups"
     path: "ckan-postgres"
   "push_ckan_integration_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "5"
     minute: "0"
     action: "push"

--- a/hieradata_aws/class/staging/ckan_db_admin.yaml
+++ b/hieradata_aws/class/staging/ckan_db_admin.yaml
@@ -1,6 +1,6 @@
 govuk_env_sync::tasks:
   "pull_ckan_production_daily":
-    ensure: "present"
+    ensure: "absent"
     hour: "0"
     minute: "0"
     action: "pull"


### PR DESCRIPTION
The env_syncs are causing problems with db locks on the new cluster platform, its not necessary to have them in sync every night, so if a database needs to be restored from production it will be done manually.