### PR TITLE
Remove Becka Lelew

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -286,7 +286,6 @@ users::usernames:
   - anniecavalla
   - ashleyburnett
   - barbaraslawinska
-  - beckalelew
   - brucebolt
   - callumknights
   - catalinailie

--- a/modules/users/manifests/beckalelew.pp
+++ b/modules/users/manifests/beckalelew.pp
@@ -1,9 +1,0 @@
-# Creates the user beckalelew
-class users::beckalelew {
-  govuk_user { 'beckalelew':
-    fullname => 'Becka Lelew',
-    email    => 'becka.lelew@digital.cabinet-office.gov.uk',
-    ssh_key  => 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOUzfoH86Pby61x10zbeYEEfupbDslZQHSbultbZWssn becka.lelew@digital.cabinet-office.gov.uk',
-    ensure   => absent,
-  }
-}


### PR DESCRIPTION
Phase 2 of removing Becka from Puppet.

Step 5 of this guide:
https://docs.publishing.service.gov.uk/manual/removing-a-user-from-puppet.html