### PR TITLE
Remove `whitehall_fe` database user

### DIFF
--- a/modules/govuk/manifests/apps/whitehall/db.pp
+++ b/modules/govuk/manifests/apps/whitehall/db.pp
@@ -8,11 +8,4 @@ class govuk::apps::whitehall::db (
     host     => '%',
     password => $mysql_whitehall_admin,
   }
-
-  govuk_mysql::user { 'whitehall_fe@%':
-    password_hash => mysql_password($whitehall_fe_password),
-    table         => 'whitehall_production.*',
-    privileges    => ['SELECT'],
-    require       => Mysql::Db['whitehall_production'],
-  }
 }


### PR DESCRIPTION
This was used by Whitehall Frontend as a read-only way of accessing the Whitehall MySQL database.  This can be removed as Whitehall no longer has a frontend mode.