### PR TITLE
Disable mirror sync in Staging

### DIFF
--- a/hieradata_aws/staging.yaml
+++ b/hieradata_aws/staging.yaml
@@ -277,9 +277,9 @@ govuk_cdnlogs::bouncer_monitoring_enabled: false
 govuk_cdnlogs::warning_cdn_freshness: 86400   # 1 day
 govuk_cdnlogs::critical_cdn_freshness: 172800 # 2 days
 
-govuk_crawler::seed_enable: true
+govuk_crawler::seed_enable: false
 govuk_crawler::start_hour: 20
-govuk_crawler::sync_enable: true
+govuk_crawler::sync_enable: false
 govuk_crawler::targets:
   - 's3://govuk-staging-mirror/'
 


### PR DESCRIPTION
This allows us to test the mirror sync jobs that have been ported to EKS.