### PR TITLE
Match pull/push time for Publishing API and Content Store

### DIFF
--- a/hieradata_aws/class/integration/mongo.yaml
+++ b/hieradata_aws/class/integration/mongo.yaml
@@ -1,8 +1,8 @@
 govuk_env_sync::tasks:
   "pull_content_store_daily":
     ensure: "present"
-    hour: "4"
-    minute: "16"
+    hour: "1"
+    minute: "30"
     action: "pull"
     dbms: "mongo"
     storagebackend: "s3"
@@ -12,8 +12,8 @@ govuk_env_sync::tasks:
     path: "mongo-api"
   "pull_draft_content_store_daily":
     ensure: "present"
-    hour: "4"
-    minute: "16"
+    hour: "1"
+    minute: "30"
     action: "pull"
     dbms: "mongo"
     storagebackend: "s3"
@@ -46,7 +46,7 @@ govuk_env_sync::tasks:
   "push_content_store_daily":
     ensure: "present"
     hour: "0"
-    minute: "16"
+    minute: "0"
     action: "push"
     dbms: "mongo"
     storagebackend: "s3"
@@ -56,8 +56,8 @@ govuk_env_sync::tasks:
     path: "mongo-api"
   "push_draft_content_store_daily":
     ensure: "present"
-    hour: "1"
-    minute: "16"
+    hour: "0"
+    minute: "0"
     action: "push"
     dbms: "mongo"
     storagebackend: "s3"

--- a/hieradata_aws/class/integration/publishing_api_db_admin.yaml
+++ b/hieradata_aws/class/integration/publishing_api_db_admin.yaml
@@ -1,7 +1,7 @@
 govuk_env_sync::tasks:
   "pull_publishing_api_staging_daily":
     ensure: "absent"
-    hour: "2"
+    hour: "1"
     minute: "30"
     action: "pull"
     dbms: "postgresql"
@@ -14,8 +14,8 @@ govuk_env_sync::tasks:
     transformation_sql_filename: "sanitise_publishing_api_production.sql"
   "pull_publishing_api_production_daily":
     ensure: "present"
-    hour: "0"
-    minute: "0"
+    hour: "1"
+    minute: "30"
     action: "pull"
     dbms: "postgresql"
     storagebackend: "s3"
@@ -27,7 +27,7 @@ govuk_env_sync::tasks:
     transformation_sql_filename: "sanitise_publishing_api_production.sql"
   "push_publishing_api_integration_daily":
     ensure: "present"
-    hour: "5"
+    hour: "0"
     minute: "0"
     action: "push"
     dbms: "postgresql"

--- a/hieradata_aws/class/production/mongo.yaml
+++ b/hieradata_aws/class/production/mongo.yaml
@@ -13,7 +13,7 @@ govuk_env_sync::tasks:
   "push_content_store_daily":
     ensure: "present"
     hour: "0"
-    minute: "16"
+    minute: "0"
     action: "push"
     dbms: "mongo"
     storagebackend: "s3"
@@ -23,8 +23,8 @@ govuk_env_sync::tasks:
     path: "mongo-api"
   "push_draft_content_store_daily":
     ensure: "present"
-    hour: "1"
-    minute: "16"
+    hour: "0"
+    minute: "0"
     action: "push"
     dbms: "mongo"
     storagebackend: "s3"

--- a/hieradata_aws/class/production/publishing_api_db_admin.yaml
+++ b/hieradata_aws/class/production/publishing_api_db_admin.yaml
@@ -1,7 +1,7 @@
 govuk_env_sync::tasks:
   "push_publishing_api_production_daily":
     ensure: "present"
-    hour: "23"
+    hour: "0"
     minute: "0"
     action: "push"
     dbms: "postgresql"

--- a/hieradata_aws/class/staging/mongo.yaml
+++ b/hieradata_aws/class/staging/mongo.yaml
@@ -1,8 +1,8 @@
 govuk_env_sync::tasks:
   "pull_content_store_daily":
     ensure: "present"
-    hour: "1" 
-    minute: "16"
+    hour: "1"
+    minute: "30"
     action: "pull"
     dbms: "mongo"
     storagebackend: "s3"
@@ -12,8 +12,8 @@ govuk_env_sync::tasks:
     path: "mongo-api"
   "pull_draft_content_store_daily":
     ensure: "present"
-    hour: "2" 
-    minute: "16"
+    hour: "1"
+    minute: "30"
     action: "pull"
     dbms: "mongo"
     storagebackend: "s3"
@@ -24,7 +24,7 @@ govuk_env_sync::tasks:
   "push_content_store_daily":
     ensure: "present"
     hour: "0"
-    minute: "12"
+    minute: "0"
     action: "push"
     dbms: "mongo"
     storagebackend: "s3"
@@ -34,8 +34,8 @@ govuk_env_sync::tasks:
     path: "mongo-api"
   "push_draft_content_store_daily":
     ensure: "present"
-    hour: "1"
-    minute: "12"
+    hour: "0"
+    minute: "0"
     action: "push"
     dbms: "mongo"
     storagebackend: "s3"

--- a/hieradata_aws/class/staging/publishing_api_db_admin.yaml
+++ b/hieradata_aws/class/staging/publishing_api_db_admin.yaml
@@ -1,8 +1,8 @@
 govuk_env_sync::tasks:
   "pull_publishing_api_production_daily":
     ensure: "present"
-    hour: "0"
-    minute: "0"
+    hour: "1"
+    minute: "30"
     action: "pull"
     dbms: "postgresql"
     storagebackend: "s3"
@@ -13,8 +13,8 @@ govuk_env_sync::tasks:
     path: "publishing-api-postgres"
   "push_publishing_api_staging_daily":
     ensure: "absent"
-    hour: "2"
-    minute: "30"
+    hour: "0"
+    minute: "0"
     action: "push"
     dbms: "postgresql"
     storagebackend: "s3"


### PR DESCRIPTION
As part of the daily data sync between our environments, we currently pull the Publishing API database before Content Store.

This means the data within can be out-of-sync when pushed to the next environment.  One issue that arises is the `payload_version` (a value sent from Publishing API to Content Store, to make sure we don't overwrite newer content) is mismatched.

Therefore updating the data sync so we pull from Content Store and Publishing API at exactly the same time (00:00), then push to the next environment at exactly the same time (01:30).

This will resolve any issues resulting from data mismatch.

[Trello card](https://trello.com/c/HRwJTf6S)