### PR TITLE
Set blanket redirect ckan

### DIFF
--- a/hieradata_aws/class/integration/ckan.yaml
+++ b/hieradata_aws/class/integration/ckan.yaml
@@ -3,6 +3,8 @@
 govuk_solr::disable: true
 govuk_solr6::present: true
 
+govuk::apps::ckan::blanket_redirect_url: https://find-data-beta-integration.cloudapps.digital/ckan_maintenance
+
 govuk::apps::ckan::enable_harvester_fetch: true
 govuk::apps::ckan::enable_harvester_gather: true
 

--- a/hieradata_aws/class/integration/ckan.yaml
+++ b/hieradata_aws/class/integration/ckan.yaml
@@ -5,11 +5,11 @@ govuk_solr6::present: true
 
 govuk::apps::ckan::blanket_redirect_url: https://find-data-beta-integration.cloudapps.digital/ckan_maintenance
 
-govuk::apps::ckan::enable_harvester_fetch: true
-govuk::apps::ckan::enable_harvester_gather: true
+govuk::apps::ckan::enable_harvester_fetch: false
+govuk::apps::ckan::enable_harvester_gather: false
 
-govuk::apps::ckan::cronjobs::enable: true
-govuk::apps::ckan::cronjobs::enable_solr_reindex: true
+govuk::apps::ckan::cronjobs::enable: false
+govuk::apps::ckan::cronjobs::enable_solr_reindex: false
 
 govuk::apps::ckan::solr_core: ckan
 govuk::apps::ckan::solr_core_configset: ckan28


### PR DESCRIPTION
## What

Redirect requests to Find CKAN maintenance page during the process of switching over. 
Also turn off CKAN processes and cronjobs.
Test this on Integration first.

## Reference 

https://trello.com/c/VATqueLs/1224-setup-blanket-redirect-for-ckan-to-find-ckan-maintenance-page