### PR TITLE
CSV previews should work with modern urls

### DIFF
--- a/hieradata_aws/common.yaml
+++ b/hieradata_aws/common.yaml
@@ -1338,6 +1338,7 @@ rcs::tmptime: '7'
 router::assets_origin::whitehall_uploaded_assets_routes:
   - '/government/placeholder'
   - '~ ^/government/uploads/system/uploads/attachment_data/file/[0-9]+/.*/preview$'
+  - '~ ^/media/[0-9]+/.*/preview$'
   - '~ ^/assets/whitehall/'
 
 router::assets_origin::asset_manager_uploaded_assets_routes:


### PR DESCRIPTION
We are migrating away from legacy url path in whitehall assets. Router and nginx config has a special list of urls that are directed to frontend instead of whitehall. The change is to include the new url in the configuration.

After adding the new url to whitehall_uploaded_assets_routes, it will be used by both assets-origin and draft-assets.