### PR TITLE
Remove Kelvin, part 1

### DIFF
--- a/modules/users/manifests/kelvingan.pp
+++ b/modules/users/manifests/kelvingan.pp
@@ -1,6 +1,7 @@
 # Create the kelvingan user
 class users::kelvingan {
   govuk_user { 'kelvingan':
+    ensure   => absent,
     fullname => 'Kelvin Gan',
     email    => 'kelvin.gan@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDCUw2VAu3XgWepMdarEvhA/IPdtUme14JhbwBD44qym kelvin.gan@digital.cabinet-office.gov.uk',


### PR DESCRIPTION
This will remove Kelvin's account from hosts managed by Puppet.

Part 2 will follow, in which the configuration manifest for Kelvin's account will be removed.

Trello: https://trello.com/c/T4eVv8T7/2049-mover-kelvin-gan-tech-role

Following this guide: https://docs.publishing.service.gov.uk/manual/removing-a-user-from-puppet.html