### PR TITLE
Remove Kelvin, part 2

### DIFF
--- a/hieradata_aws/integration.yaml
+++ b/hieradata_aws/integration.yaml
@@ -317,7 +317,6 @@ users::usernames:
   - jonkirwan
   - kashifatcha
   - keithlawrence
-  - kelvingan
   - kentsang
   - kevindew
   - kooghanwilliams

--- a/modules/users/manifests/kelvingan.pp
+++ b/modules/users/manifests/kelvingan.pp
@@ -1,9 +1,0 @@
-# Create the kelvingan user
-class users::kelvingan {
-  govuk_user { 'kelvingan':
-    ensure   => absent,
-    fullname => 'Kelvin Gan',
-    email    => 'kelvin.gan@digital.cabinet-office.gov.uk',
-    ssh_key  => 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDCUw2VAu3XgWepMdarEvhA/IPdtUme14JhbwBD44qym kelvin.gan@digital.cabinet-office.gov.uk',
-  }
-}


### PR DESCRIPTION
Part 1: #12130
Part 2: this PR

This removes the configuration manifest for Kelvin's account, and removes them from integration users.

As per this guide: https://docs.publishing.service.gov.uk/manual/removing-a-user-from-puppet.html

Trello: https://trello.com/c/T4eVv8T7/2049-mover-kelvin-gan-tech-role