### PR TITLE
Revert "Match pull/push time for Publishing API and Content Store"

### DIFF
--- a/hieradata_aws/class/integration/mongo.yaml
+++ b/hieradata_aws/class/integration/mongo.yaml
@@ -1,8 +1,8 @@
 govuk_env_sync::tasks:
   "pull_content_store_daily":
     ensure: "present"
-    hour: "1"
-    minute: "30"
+    hour: "4"
+    minute: "16"
     action: "pull"
     dbms: "mongo"
     storagebackend: "s3"
@@ -12,8 +12,8 @@ govuk_env_sync::tasks:
     path: "mongo-api"
   "pull_draft_content_store_daily":
     ensure: "present"
-    hour: "1"
-    minute: "30"
+    hour: "4"
+    minute: "16"
     action: "pull"
     dbms: "mongo"
     storagebackend: "s3"
@@ -46,7 +46,7 @@ govuk_env_sync::tasks:
   "push_content_store_daily":
     ensure: "present"
     hour: "0"
-    minute: "0"
+    minute: "16"
     action: "push"
     dbms: "mongo"
     storagebackend: "s3"
@@ -56,8 +56,8 @@ govuk_env_sync::tasks:
     path: "mongo-api"
   "push_draft_content_store_daily":
     ensure: "present"
-    hour: "0"
-    minute: "0"
+    hour: "1"
+    minute: "16"
     action: "push"
     dbms: "mongo"
     storagebackend: "s3"

--- a/hieradata_aws/class/integration/publishing_api_db_admin.yaml
+++ b/hieradata_aws/class/integration/publishing_api_db_admin.yaml
@@ -1,7 +1,7 @@
 govuk_env_sync::tasks:
   "pull_publishing_api_staging_daily":
     ensure: "absent"
-    hour: "1"
+    hour: "2"
     minute: "30"
     action: "pull"
     dbms: "postgresql"
@@ -14,8 +14,8 @@ govuk_env_sync::tasks:
     transformation_sql_filename: "sanitise_publishing_api_production.sql"
   "pull_publishing_api_production_daily":
     ensure: "present"
-    hour: "1"
-    minute: "30"
+    hour: "0"
+    minute: "0"
     action: "pull"
     dbms: "postgresql"
     storagebackend: "s3"
@@ -27,7 +27,7 @@ govuk_env_sync::tasks:
     transformation_sql_filename: "sanitise_publishing_api_production.sql"
   "push_publishing_api_integration_daily":
     ensure: "present"
-    hour: "0"
+    hour: "5"
     minute: "0"
     action: "push"
     dbms: "postgresql"

--- a/hieradata_aws/class/production/mongo.yaml
+++ b/hieradata_aws/class/production/mongo.yaml
@@ -13,7 +13,7 @@ govuk_env_sync::tasks:
   "push_content_store_daily":
     ensure: "present"
     hour: "0"
-    minute: "0"
+    minute: "16"
     action: "push"
     dbms: "mongo"
     storagebackend: "s3"
@@ -23,8 +23,8 @@ govuk_env_sync::tasks:
     path: "mongo-api"
   "push_draft_content_store_daily":
     ensure: "present"
-    hour: "0"
-    minute: "0"
+    hour: "1"
+    minute: "16"
     action: "push"
     dbms: "mongo"
     storagebackend: "s3"

--- a/hieradata_aws/class/production/publishing_api_db_admin.yaml
+++ b/hieradata_aws/class/production/publishing_api_db_admin.yaml
@@ -1,7 +1,7 @@
 govuk_env_sync::tasks:
   "push_publishing_api_production_daily":
     ensure: "present"
-    hour: "0"
+    hour: "23"
     minute: "0"
     action: "push"
     dbms: "postgresql"

--- a/hieradata_aws/class/staging/mongo.yaml
+++ b/hieradata_aws/class/staging/mongo.yaml
@@ -1,8 +1,8 @@
 govuk_env_sync::tasks:
   "pull_content_store_daily":
     ensure: "present"
-    hour: "1"
-    minute: "30"
+    hour: "1" 
+    minute: "16"
     action: "pull"
     dbms: "mongo"
     storagebackend: "s3"
@@ -12,8 +12,8 @@ govuk_env_sync::tasks:
     path: "mongo-api"
   "pull_draft_content_store_daily":
     ensure: "present"
-    hour: "1"
-    minute: "30"
+    hour: "2" 
+    minute: "16"
     action: "pull"
     dbms: "mongo"
     storagebackend: "s3"
@@ -24,7 +24,7 @@ govuk_env_sync::tasks:
   "push_content_store_daily":
     ensure: "present"
     hour: "0"
-    minute: "0"
+    minute: "12"
     action: "push"
     dbms: "mongo"
     storagebackend: "s3"
@@ -34,8 +34,8 @@ govuk_env_sync::tasks:
     path: "mongo-api"
   "push_draft_content_store_daily":
     ensure: "present"
-    hour: "0"
-    minute: "0"
+    hour: "1"
+    minute: "12"
     action: "push"
     dbms: "mongo"
     storagebackend: "s3"

--- a/hieradata_aws/class/staging/publishing_api_db_admin.yaml
+++ b/hieradata_aws/class/staging/publishing_api_db_admin.yaml
@@ -1,8 +1,8 @@
 govuk_env_sync::tasks:
   "pull_publishing_api_production_daily":
     ensure: "present"
-    hour: "1"
-    minute: "30"
+    hour: "0"
+    minute: "0"
     action: "pull"
     dbms: "postgresql"
     storagebackend: "s3"
@@ -13,8 +13,8 @@ govuk_env_sync::tasks:
     path: "publishing-api-postgres"
   "push_publishing_api_staging_daily":
     ensure: "absent"
-    hour: "0"
-    minute: "0"
+    hour: "2"
+    minute: "30"
     action: "push"
     dbms: "postgresql"
     storagebackend: "s3"


### PR DESCRIPTION
Reverting the change to environment sync times as we don't believe this solved the original problem.

Issues we have found include:
- we don't believe both database dump jobs (Publishing API and Content Store) occur at the same time, meaning the data remains out of sync
- the reloading of data happens at a fixed time of 01:30, but we have seen last modified timestamps for the backups as late as 03:52, meaning we reload the previous day's data
- shifting the reloading time later will cause issues with the Content Store migration work (the Mongo to Postgres sync will need to be shifted later)

Therefore we have decided to put this work on hold until both Content Store is migrated to Postgres and the data sync has been migrated to Kubernetes.

Reverts alphagov/govuk-puppet#12124

[Trello card](https://trello.com/c/HRwJTf6S)