### PR TITLE
Remove Korny

### DIFF
--- a/modules/users/manifests/kornysietsma.pp
+++ b/modules/users/manifests/kornysietsma.pp
@@ -1,6 +1,7 @@
 # Creates the user kornysietsma 
 class users::kornysietsma {
   govuk_user { 'kornysietsma':
+    ensure   => absent,
     fullname => 'Korny Sietsma',
     email    => 'korny.sietsma@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMGnvB7OoYNp/VKsp44hy6OpahuRTxWxZYQgmOJslJ0V korny.sietsma@digital.cabinet-office.gov.uk',


### PR DESCRIPTION
This will remove Korny's account from hosts managed by Puppet.

Part 2 will follow, in which the configuration manifest for Korny's account will be removed.