### PR TITLE
Add `ensure => absent` for user

### DIFF
--- a/modules/users/manifests/kylesimmons.pp
+++ b/modules/users/manifests/kylesimmons.pp
@@ -1,6 +1,7 @@
 # Creates the kylesimmons user
 class users::kylesimmons {
   govuk_user { 'kylesimmons':
+    ensure   => absent,
     fullname => 'Kyle Simmons',
     email    => 'kyle.simmons@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKz99jgxT80k+NOG0WBsO7yurQnPUe7QHnUz+F9AzqIu kyle.simmons@digital.cabinet-office.gov.uk',


### PR DESCRIPTION
Marks user "Kyle Simmons" as absent. 
Follows Step 2 in [Remove a user from Puppet](https://docs.publishing.service.gov.uk/manual/removing-a-user-from-puppet.html)