### PR TITLE
Update manifest file for leaver

### DIFF
--- a/modules/users/manifests/sivasubramanian.pp
+++ b/modules/users/manifests/sivasubramanian.pp
@@ -1,6 +1,7 @@
 # Creates the sivasubramanian user
 class users::sivasubramanian {
   govuk_user { 'sivasubramanian':
+    ensure   => absent,
     fullname => 'Siva Subramanian',
     email    => 'siva.subramanian@digital.cabinet-office.gov.uk',
     ssh_key  => 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBzg5BFA6p4HlZQs0y9jEv7Y+G3bCbRjfCObrKEImn9H siva.subramanian@thoughtworks.com',


### PR DESCRIPTION
This change marks leaver `sivasubramanian` as absent in manifest. 

See steps 1 & 2 in [Remove a user from Puppet](https://docs.publishing.service.gov.uk/manual/removing-a-user-from-puppet.html)