### PR TITLE
Delete old Vagrant credentials.

### DIFF
--- a/hieradata_aws/vagrant.yaml
+++ b/hieradata_aws/vagrant.yaml
@@ -7,19 +7,10 @@ backup::offsite::monitoring::offsite_fqdn: backup.gov.uk
 backup::offsite::monitoring::offsite_hostname: backup0.provider0
 backup::offsite::monitoring::monitor_cdn_logs_disk: true
 
-assets::ssh_authorized_key::key: 'AAAAB3NzaC1yc2EAAAADAQABAAAAYQDCIfGHdqJj9IMkdwXtieDW15ZnR9GAqcnUwjQOMvySEst54705ekxcKwjRFTaYmawlifQTOgFDPkMwp72s2Zd+0ZiR7lfSzBQctbCptS/SgTNNltvplVt8nUbz9H0jLy8='
+assets::ssh_authorized_key::key: 'hunter2'
 assets::ssh_private_key::key: |
   -----BEGIN RSA PRIVATE KEY-----
-  MIIBygIBAAJhAMIh8Yd2omP0gyR3Be2J4NbXlmdH0YCpydTCNA4y/JISy3njvTl6
-  TFwrCNEVNpiZrCWJ9BM6AUM+QzCnvazZl37RmJHuV9LMFBy1sKm1L9KBM02W2+mV
-  W3ydRvP0fSMvLwIDAQABAmBJXgqp52v32rC1V0YmP7V5fICbB8lllsVwYvTJaPuL
-  OQ8tQaSB1HaHXrw2SI4ZnfmIszZjgn6vMkX6sJ3ZJ24GjEwMnLQerkLjvQRVLkDz
-  akBdiSIEELnOKBb11MJ9QAECMQDhJk6Y8ijOaY8bPollNE/+Srlp4HT+/QkS+Os1
-  5GSQyjxbgwJ0hKNZ5+K/ktNjsoECMQDcu6KYyHv+k/0Lle64tRTAwDrY6ihVG24T
-  qSx1Rvk2rycnj43o9vFd5KK83B6lqa8CMDXHVqLFxOV45UvWpi7cTfcplhwqFwgJ
-  HK/BcT1QLo0/ISeipWV7gSEqeEjWI1P/AQIwRQgpgb6xiJyfts/dKMb5Bo8X2F7i
-  3jsF4gA2dzcLGZ8Nj8HFj+Yq9kJa4tW0f/rhAjEA2RpJoFDSBgqOrQlWvbv0emGC
-  /LeZ4erY43uylcslv0IdeARWGNLw7x8dq++QO530
+  hunter2
   -----END RSA PRIVATE KEY-----
 
 base::shell::shell_prompt_string: 'dev'
@@ -82,13 +73,7 @@ govuk_postgresql::server::snakeoil_ssl_certificate: |
 
 govuk_postgresql::server::snakeoil_ssl_key: |
   -----BEGIN RSA PRIVATE KEY-----
-  MIIBOwIBAAJBANhJ8HJJ0Mla40J298UxZJDh4gAXAUSN74r4N5vWH9ZKdZZoGsV/
-  kDNUmH6mbUMUYM2ln/Is3F3k3vojHnDrMpsCAwEAAQJAYUxR2HgQbqRuW7X9HD5u
-  CSc0benrbhWTzyZ+jaIzzEf6b3iLlbgvdkt8jiFXJ5ZCGaiEw0pKQ0KUbIGWQiKR
-  QQIhAP3fDAOm5U49wRwGJSI84X9VAjiDbmxX72BzDzkMZ8mrAiEA2ho4BzoUEtb3
-  0pg8DxWSvyfcd3+QG4n9RvZy/RDMqtECIQCJogTXbgHfGye4U7SKDUuLRsD/dnHF
-  Fx9VwMs9+HXEJQIhANlG73Q7ps3R/Jd/c62vVz86LceafG0C/iCY2ptEBjFRAiA2
-  vxBODhF5cvyO/S2jUuvApGU4dU2KULT5Dv3/Lh/Otg==
+  hunter2
   -----END RSA PRIVATE KEY-----
 
 govuk_postgresql::wal_e::backup::enabled: true
@@ -111,37 +96,7 @@ mongodb::s3backup::backup::private_gpg_key: |
   -----BEGIN PGP PRIVATE KEY BLOCK-----
   Version: GnuPG v1
 
-  lQH+BFcOBVsBBACyaMMZhxpGSpGxea/Cko6vanVKHQrzPRKcg5Mw2wErypZ3cxsV
-  8Mbtw9gG5RFxfHICThc6VzXZctrSmSY48zcvrC2aj4Z3oIdu6ZLqz50ZNEfauHuT
-  9ydtSq7pFLg8v40DBmHeqpElPC3LsOrBWgpRB9u6E91m1a7Cy5waTKpU0QARAQAB
-  /gMDArVorwaqKoL3YKq9V4NQi4nLSJYruqsW279TgoIYtalgbSriaiObSqeKCjIr
-  M4EkYonNHX5PQNTzXPVQTiVGcUbX++y4F4/cMkbtaE97UDIBnVcW1N/E6DvF3ov5
-  jRbGersaW+COEA86Sy0VT/BeA4ktxgvdLdlMwzGjRD7wiwHnpIQENQzqsAR6LesQ
-  b0M2+cZOtGKa896dDh4/MWP1ScKWCeTAp64rN+lFP0hmrG8yhvtrs4zrBqIoLWn9
-  ZBR1MgWktFy5SyZfho/LJ3SE+VBy58XNCiaUXsmyX7kH/rmgub8eTNhuG9OE2Ulz
-  KYFpO2SmUluRsPmrlrnWrsr86CdMV9Cn2WozyMi8gmtYY4NC/xiwguJ3GSKMP7ca
-  TaiA7AkonB7y19qml3LpYcknfv2vY1GaxnJogUkq75Nb6zBEDXJrP35A1LfCjwRq
-  +WuzqDHi6M1fswkP/u31mr5PRtRLcENs0LBm5Rz4iIHEtCVIdW1tIERpbmdlciA8
-  aHVtbS5kaW5nZXJAZXhhbXBsZS5jb20+iL4EEwECACgFAlcOBVsCGwMFCRLMAwAG
-  CwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJELYLUObb4ur/zOcD/j7c8UxeJUif
-  Y1q5zR/lrJF8PGIosf6qEQhMUJXciezkIsWx2xcCBMndAYCWGCsYvmkSEdqCTEtg
-  2rdF6iRLo4BeNA6pHOL0LtOdPOFBGXX/sxpN+Ehhvy71eAeS5RZo78CWNVOCaS0z
-  uw8T4ZScQTQG6CbcbjEGoMrRC/SlBHNQnQH+BFcOBVsBBADAHMSaawcGV6BRSMLf
-  BoR0BM+cMz46vvfldD2Io+Pwfl0qNeb9MNTK42Zm4GJjMY6IIUYrJAs66l/a1K+i
-  5XQN1afZtleHjfQLK+RAO2v4JJhlsKrVK8tpPsby+jnJZH+qr+Op10wxZQqKdzNz
-  g3eJCTm1vC8h3TFhkExM5xXSQwARAQAB/gMDArVorwaqKoL3YCBWqJ2k04dCf+pf
-  XDYrd44ZyXntH6UC4DUBdaeU7XgUA+hRx6p9z3OWBYelXAGi3O4HTIqHMJrWGgXy
-  uEoQEnknQx5DwTcfk2JdK2yU8gNIsU6m2kvTSu9hAWHRXQtf4opotWbNhEyhZRXc
-  XVdjLt6VXf+xNBZL0Tnyo2X725eJUROb5/wbjSt0ciN7A+iR8w1zbexvVjXSkvLp
-  W9fbVd6M+6lqkqCrkAZtaavRqI1JuRc6sVKwrJGe7gv7ZuRVhxil1s8vj0OQpG+4
-  ScTrjfW8atrWrkpQGbvP3gCkznsfF2SqzxLnkm7kq09fJtu1Z5sN/FPE3h7xmZ8+
-  Ne4HRbM2O2SAGKvtHKvs/tJ0ihDEMk8yNTF9CpvVq3pIcXwI/wd2129cgrZGr0i6
-  Dw1ahVCBzO2sjmQ14g9WJOQE65r8eTzMZvRVL3/+b674uqO1KkTpULChxlYC/KDZ
-  AdmkctfoixaIiKUEGAECAA8FAlcOBVsCGwwFCRLMAwAACgkQtgtQ5tvi6v8YFgP+
-  KMdz0WhCeMy5gHKOwDQ5QiN+yTz4wSVbn8iI4bqA8+FFYKdZDu5DTVKkAfZl84+n
-  TKUTpBkgafLTB+CSmFBYuFT/r4M+5JVrVy5cBqeEspY3OmpjcsZHIrBkoF+naJQV
-  Ez/E3CEAE2MU6kwYzOv/IR8DRQJmdJDAp/KXrBi9y9A=
-  =iGOp
+  hunter2
   -----END PGP PRIVATE KEY BLOCK-----
 
-mongodb::s3backup::backup::private_gpg_key_fingerprint: 'CB77872D51ADD27CF75BD63CB60B50E6DBE2EAFF'
+mongodb::s3backup::backup::private_gpg_key_fingerprint: 'ABADCAFE'

--- a/hieradata_aws/vagrant_credentials.yaml
+++ b/hieradata_aws/vagrant_credentials.yaml
@@ -23,70 +23,46 @@ backup::server::backup_private_key: |
 
 collectd::plugin::postgresql::password: 'password'
 
-govuk::apps::bouncer::postgresql_role::password: 'sKnvsmsAEeviNNl3Ded90NzxoT7eFI6Qd1cOVmaA'
-govuk::apps::ckan::db::password: 'goh8Deev3peki7liuxool7mo'
+govuk::apps::bouncer::postgresql_role::password: 'hunter2'
+govuk::apps::ckan::db::password: 'hunter2'
 govuk::apps::ckan::db_password: "%{hiera('govuk::apps::ckan::db::password')}"
 govuk::apps::ckan::secret: "foobar"
-govuk::apps::collections_publisher::db::mysql_password: 'BeDrefCoopdevAynhagmimUmdicuvKas'
+govuk::apps::collections_publisher::db::mysql_password: 'hunter2'
 govuk::apps::collections_publisher::db_password: "%{hiera('govuk::apps::collections_publisher::db::mysql_password')}"
-govuk::apps::contacts::db::mysql_contacts_frontend: 'DfM7oUW8Hsn9g23WZW3Hvv4wmr69deQX'
-govuk::apps::contacts::db::mysql_contacts_admin: 'DO7910Lz5ohJukmnvC6GrN3e4jtUP82l'
-govuk::apps::content_data_admin::db::password: 'FrkwKJGjLAjbznLtPhFjVy7YEonLKJTr'
+govuk::apps::contacts::db::mysql_contacts_frontend: 'hunter2'
+govuk::apps::contacts::db::mysql_contacts_admin: 'hunter2'
+govuk::apps::content_data_admin::db::password: 'hunter2'
 govuk::apps::content_data_admin::db_password: "%{hiera('govuk::apps::content_data_admin::db::password')}"
 govuk::apps::content_data_api::db_password: "%{hiera('govuk::apps::content_data_api::db::password')}"
-govuk::apps::content_data_api::db::password: 'jo6Kah0kuokaighoughePhooch1Eequu'
-govuk::apps::content_publisher::db::password: 'a7NnCu8JNPcKsYDFJpC3HpbxsdZYttMt'
+govuk::apps::content_data_api::db::password: 'hunter2'
+govuk::apps::content_publisher::db::password: 'hunter2'
 govuk::apps::content_publisher::db_password: "%{hiera('govuk::apps::content_publisher::db::password')}"
 govuk::apps::content_tagger::db_password: "%{hiera('govuk::apps::content_tagger::db::password')}"
-govuk::apps::content_tagger::db::password: '6bab0d694abaabc64f4b40fcd7e51'
-govuk::apps::email_alert_api::db::password: '8WB3h7RXohmTvmU7bmmDK4ppsd8BU7Ki'
+govuk::apps::content_tagger::db::password: 'hunter2'
+govuk::apps::email_alert_api::db::password: 'hunter2'
 
-govuk::apps::link_checker_api::db::password: 'r8I6kP13TypUPiCR4izTImbaF7Li/Oh4VZFTSYR3j7A='
+govuk::apps::link_checker_api::db::password: 'hunter2'
 govuk::apps::link_checker_api::db_password: "%{hiera('govuk::apps::link_checker_api::db::password')}"
-govuk::apps::local_links_manager::db::password: 'a192e3fcb901b069aa6c45438faecdc48b30f8a6'
+govuk::apps::local_links_manager::db::password: 'hunter2'
 govuk::apps::local_links_manager::db_password: "%{hiera('govuk::apps::local_links_manager::db::password')}"
-govuk::apps::maslow::secret_key_base: 'a06f64da7e2fa4289722d21a8cbc9fdbc26510be9be2a48803d6dc95459a1a176f70425e6fb6597549b0b951b6a0cca5abe2f0155929e912ad251064eea267c8'
+govuk::apps::maslow::secret_key_base: 'hunter2'
 govuk::apps::publishing_api::db_password: "%{hiera('govuk::apps::publishing_api::db::password')}"
-govuk::apps::publishing_api::db::password: 'jgt8923jg8923jg289jg2389fj2389fj3289j'
-govuk::apps::release::db::mysql_release: 'AlxLdicrdDEx20Yekkn4AXGAG2ksIQU1'
-govuk::apps::router_api::secret_key_base: '05ddf7c150a3c850705c86b270895d92a71779cdee752077c8d76d89fb657b018043e918bfc5abe8b914c1094158d9ffbb2264aa1301da5d2e6dde0995afd65d'
-govuk::apps::search_admin::db::mysql_search_admin: 'KrafvoginjuxwycjiwegFaicsyecvi'
+govuk::apps::publishing_api::db::password: 'hunter2'
+govuk::apps::release::db::mysql_release: 'hunter2'
+govuk::apps::router_api::secret_key_base: 'hunter2'
+govuk::apps::search_admin::db::mysql_search_admin: 'hunter2'
 govuk::apps::service_manual_publisher::db_password: "%{hiera('govuk::apps::service_manual_publisher::db::password')}"
-govuk::apps::service_manual_publisher::db::password: '3H3lpsZenSZAdI3zQGCAcdYEUTbcECvMtZ4VoK3v'
-govuk::apps::signon::devise_secret_key: '1e0310b9f18fc6ba34145829addcfd3f100c91f12e31ce071bd582981d44fc6ee1bd9a899e05e7cea9189aa54b6132eb36f4ade9c17b5535ba13bf5909b2a79e'
-govuk::apps::signon::db::mysql_signonotron: 'Yo68brC26TBdCf2NzCmwszv9UHtqbH8G'
-govuk::apps::support_api::db::password: '6ba55037a05b6d7061d5401305bd0c43'
-govuk::apps::transition::postgresql_db::password: 'ood8Michej4phaquuchi'
-govuk::apps::transition::db_password: 'ood8Michej4phaquuchi'
-govuk::apps::whitehall::db::mysql_whitehall_admin: 'lB2gKNzWLBt75P8qBEtKkkCapePqAvd2'
+govuk::apps::service_manual_publisher::db::password: 'hunter2'
+govuk::apps::signon::devise_secret_key: 'hunter2'
+govuk::apps::signon::db::mysql_signonotron: 'hunter2'
+govuk::apps::support_api::db::password: 'hunter2'
+govuk::apps::transition::postgresql_db::password: 'hunter2'
+govuk::apps::transition::db_password: 'hunter2'
+govuk::apps::whitehall::db::mysql_whitehall_admin: 'hunter2'
 
 govuk_cdnlogs::server_key: |
   -----BEGIN RSA PRIVATE KEY-----
-  MIIEowIBAAKCAQEAqQGS8cE6fDexFazOlkWgiS2UbyYI2cVp5IUuU+ZmNpSpeKHm
-  SNtAEf/YP7gbCvnWbl+5ieTi/SN7IHTd4v4P57B5XHoTV3geh7HLXxbzcZnoC+VD
-  k0ezJ2ckdqXxB/c/AQjNytyV4GnATTLsNSh8TLg9quFZQPHm8cKVyl1caXWN4vKx
-  OkF1w4sSYa9fWKzQe+Ps50f/XhHSVmL/v3gKFs3PloNxg+0Pq9Tcoy04YI11wnto
-  lJooSXM1FMQMRFn6p4Dt98H4TDPzhacjlQdpwHHkyjiElqC09VOyI+a04B7Ozugy
-  zO9dgrzajUbGKcFaz+UvBMg4DniXIc0KHazoewIDAQABAoIBAQCTP7fTwtM+Hxe/
-  Fsz3yLpSStAk9zKG6qWUYSU4HGm57FSrsgN+PujXxd2XxsRpD7xwdh6lsjLC8wL4
-  CFq6xzj8WJmkpQftEc8n0xSqSMjalYnDs4Do9XN2RTtT1Mjoc9cFA7KpqP88g2b0
-  3AVJW3jRL0UreSPWnezlfvAbXLSDfGm4sC83ml28/2KYuZ2zynSvF88QZPrx5as5
-  aozbEjefRuPrOPUkrbCsrVA3BVt8N69E3y1I7PNPcPfh4Tr11aqYD41XscDsl8mu
-  nQOsAFDGLXEXQWqc/2P2bE7ryPZtVSSPu9BNNBMYze4aruDEU/g3st6lkqCViWcq
-  kJJ30U/BAoGBANqHO+Is3bRoCqs8Fh8K8UlWOHkrTLqsscJpMuJvDkUse8Sb7MX0
-  rK2gKKXgx109oqzHWPV/MeCy+2VD/i0DdtbwU619xxTfcaQg6CCt3/7ssZEH8D5s
-  Lk7H6CdIqb9Q+0GZrWY3WO8fmO8dNCOJXKm7LYsLgSMDuQI56BBZlgSpAoGBAMX8
-  dgQCv38vk9g3fsnYzkQopPyDBlF8BT4AbC5u7A/DSTkl5NcmAVvZEtM6KxhDtATE
-  xG7HdWNPpcc7Bg1YvGa+NwmIIjIbNmIWXWhCHMwWRkHpeT3xA9XJfmJqgkxGZxkx
-  SFtP5YQwviJiFI59pyaQf4QoZqvX+Ei5hQuEshaDAoGAE+qhXZLDPg8BcevPBFNF
-  /G4cRYbZvmXA6bwWxCZlAY71VMz1PnF3T3e6XKvo36mfauncRLur+xO079zLjKS1
-  Lw/GQJinDVL0E4ZgQaI3OQ+ve01i6v2HFu0HTpVDy0kBLVBpSlifBWQ21wwtVVPO
-  mzWRCAwrX9qWAQrwCJVxo8kCgYB6JoLhgpiHbeE3ezW8bwkDwFfaezRAvdW2JSiZ
-  lVILf58DpT+FBiu8cTdOHwtLkynT71qKRoFEXnWXb/ER9vd2JFFsjhMa+vMYnVfP
-  5UpDGFMMg3GMJ9EH66MQMUpmqOEfB+rue2LNpg0IxZ6NMzUXc/tYnFyMFVlX9S4C
-  p0IA5QKBgB+OqjnpxaQ2DuWhl3y0TYqScm/Yz7IsBmvsO+caTDtGvHWgdS/5oAKk
-  H9t6TbuK+Gq3gyao5Kqijwx6pYmZ2EGRg6Az0gMX6vUFZ+/M8Ot5K3x0a0OkU/6f
-  b94UN2GCqz46Cb1YwV+P7NTolctUt25wJiydC47gr2UwiGxK0nwL
+  hunter2
   -----END RSA PRIVATE KEY-----
 govuk_cdnlogs::server_crt: |
   -----BEGIN CERTIFICATE-----
@@ -117,24 +93,24 @@ govuk_cdnlogs::server_crt: |
   SWxT6CtXBLz/pX7S1nkT58Anunp3H2jdt0P4llBxsA==
   -----END CERTIFICATE-----
 
-govuk_ci::credentials::rubygems_api_key: 'rubygemskey'
-govuk_ci::credentials::pypi_username: 'pipyusername'
-govuk_ci::credentials::pypi_test_password: 'passwordtest'
-govuk_ci::credentials::pypi_live_password: 'passwordlive'
+govuk_ci::credentials::rubygems_api_key: 'hunter2'
+govuk_ci::credentials::pypi_username: 'hunter2'
+govuk_ci::credentials::pypi_test_password: 'hunter2'
+govuk_ci::credentials::pypi_live_password: 'hunter2'
 
-govuk_ci::master::github_client_id: 'bellathecat'
-govuk_ci::master::github_client_secret_encrypted: 'sheisfurry'
-govuk_ci::master::jenkins_api_token: 'thisisatoken'
+govuk_ci::master::github_client_id: 'hunter2'
+govuk_ci::master::github_client_secret_encrypted: 'hunter2'
+govuk_ci::master::jenkins_api_token: 'hunter2'
 
-govuk_ci::agent::master_ssh_key: 'key'
+govuk_ci::agent::master_ssh_key: 'hunter2'
 
 
 govuk_htpasswd::http_users:
-  betademo: 'N04wQhwGA777s'
-  govuk:  '$apr1$S6ZNQMaM$K1QdclQvrI33AKAPui5Ft1'
+  betademo: 'hunter2'
+  govuk:  'hunter2'
 
-govuk_mysql::server::debian_sys_maint::mysql_debian_sys_maint: 'Pengeequ3Tee0eeFiex0Neeboo0laiMe'
-govuk_mysql::server::monitoring::collectd_mysql_password: 'password'
+govuk_mysql::server::debian_sys_maint::mysql_debian_sys_maint: 'hunter2'
+govuk_mysql::server::monitoring::collectd_mysql_password: 'hunter2'
 
 govuk_jenkins::config::environment_variables:
   ORGANISATION: development
@@ -149,7 +125,7 @@ govuk_jenkins::ssh_key::private_key: |
 govuk_jenkins::ssh_key::public_key: |
   In other environments, this should be replaced with a real public key
 
-govuk_postgresql::env_sync_user::password: 'XB4MMvdTy0nU/AeoygnPuYGAabiSihUHif3BPP0SjIM='
+govuk_postgresql::env_sync_user::password: 'hunter2'
 
 govuk_postgresql::wal_e::backup::aws_access_key_id: '123456789'
 govuk_postgresql::wal_e::backup::aws_secret_access_key: 'thisisafakekey'
@@ -163,13 +139,13 @@ http_password: 'password'
 
 icinga::plugin::check_rabbitmq_consumers::monitoring_password: "%{hiera('govuk_rabbitmq::monitoring_password')}"
 
-mysql_nagios: 'icAdipalapcebquoskurdibVufGuirWu'
-mysql_replica_password: 'YCnaJ5h42rTGqdpgCUct4EzjAfwQUkhN'
-mysql_root: 'T6J6wHjns2UdjVE1dLOu7BdIIq1NDVS9'
-mysql_whitehall_frontend: 'j853efpuopGcsvqV70JCcwoy0n3GSmNu'
+mysql_nagios: 'hunter2'
+mysql_replica_password: 'hunter2'
+mysql_root: 'hunter2'
+mysql_whitehall_frontend: 'hunter2'
 
 # This encrypted password was generated with `mkpasswd --method=sha-512` and a password of 'password'
-users::root_password_encrypted: '$6$gwBpG15Z0dCJ$.8BBgOp4zu6vOwxckV1RiQ73hz440NKY4TC/ViUELkDMhvfDfHyIiFg2guwKcmjsxd4AZLDz7Va3IUK4WCDn31'
+users::root_password_encrypted: 'hunter2'
 
 wildcard_publishing_certificate: |
     -----BEGIN CERTIFICATE-----
@@ -199,31 +175,7 @@ wildcard_publishing_certificate: |
 
 wildcard_publishing_key: |
     -----BEGIN RSA PRIVATE KEY-----
-    MIIEpQIBAAKCAQEAtzWdoTKnLLE7rPf7xvFMdiQOc88BStmaXgpLQNi35KKCu2um
-    ybPOlYoz+uSnrOinXS3v8iauhv1DZq5YbC3w5HcN+jJRFj6kGyZwI87qHS7pBKw3
-    KqhC4dyhppb3o+/lhTti/zkM47ES0OoAkn0hISqe2ynpYFAnseVlyMNRCF/Ur3CN
-    H6hZgGOV02rxy43GYrfe+/7qLCkrDA6k7ZKbKJxIYSlPXCSOOs2uOTcV20pttMeO
-    lCTpXh7gg7MjcJzA8G029QcwBXi66Dc13QoR96YLmIohSz5GCpZK09Iqww+qU/Jq
-    ME/rUlotsWrRzmZ3vVw+oKsQ1r91PVib43yHJQIDAQABAoIBAQCgh4omxItWzbTM
-    Sj2Cg8vLeKxxLOClBSYNYFev6jS3UO3b6ueptLM+tGn3XILPLsv3CVlFhD9IaIG2
-    Zu1zXI3GocrNf2ktZJXGdFeuCI96IrBqN7ve1LBF11yM65rxOjKSGwcTOpngqDck
-    duUpdhqhRQcMYhzrF1Cwv5//2aQXAORvJziIjMrKHSMOnvG9UHQQNTMqr1EnmrBm
-    FIDYhUbZa4dpubWsv6QxuVyavr0GwVali8KvqVfPEjWFnyyZe4bj7h76DgwD10qQ
-    nVdJeiRHqO+PDhrTS+BNb+ml34/CE0OgUXErNvKKRzJfNfu4GoWub5gMe9TwPdWV
-    PvK+mVwBAoGBAOmWntoPpssErRzyxDd/liLYNV+O7eRhyqEuFGuc9OQzRTrLMwC3
-    oEp8wlQw9swQddD771JIrJiDcngZdDV6kGIWhLZIJTWPiUP0eI5Ieje8YxurZ1tC
-    oKNfo6LAz26S5f6CWQZttARPUHdIFewbIykvsFCpSf4hj6yENzb+WkBxAoGBAMjJ
-    l4gx3RewiEN4ksEEsygjimZ2HT0KJ++mdim1BSUGYIk/OJMW+eHNLU/QWZNO3i6P
-    LYIleCPO3AkDXk3uc4K7bak5oNPvQFviF1pM8PD6OMa7251Ma3mcrlzwYAInlv5C
-    WQtTujotFCQ6ya9/qgfTjPGfILpZOyu20+Un2Av1AoGAe6g28+1xOOyC0F5cLZ0n
-    V87pgmrh2RND98uzF70Bj4Ts01Ea8PhErOoa3gMFw8W6+SVF7mN2q0563MVs1ZrK
-    sIKHQxAyUoZn/kd/QqNvv+3E8bLthkxhSdupftFffoPZqcBLbLHKqLVsPZk1scYz
-    +Ou8BRd5ikUuD//2UvCXyqECgYEAlI6bABislX92gj0uj4MTrwoEt2SCo4vlGmoW
-    GSum38sFF+bfy+x++7Mb6GamL9h1iQtER3vDlPLTWBPW7WAUtNBKBZ/uv3/QJWt1
-    jclJp3HrGhcaGRrWlgb39ymeT1nNXNfoG/pZ2ftKYLfiS2fwfJPoP0lWJKoqnmBK
-    DM1bCxUCgYEA1ufYLRzhBg+G8OhIqGVHomGwFYH+WG9O55RWQP/5WzUOj0OBbcJG
-    Nuk9iPrsQshka6tdipdB2BLv3pVfbnruZc+AKOnlTxDtZg2y9dfWmV9ijDqmUns5
-    bIcipc38fdjMSxGVye4yxCpXaWsss6HxVed0ZVWhOkwvsW/j5QJ18Hk=
+    hunter2
     -----END RSA PRIVATE KEY-----
 
 www_crt: |
@@ -254,29 +206,5 @@ www_crt: |
 
 www_key: |
     -----BEGIN RSA PRIVATE KEY-----
-    MIIEpQIBAAKCAQEAtzWdoTKnLLE7rPf7xvFMdiQOc88BStmaXgpLQNi35KKCu2um
-    ybPOlYoz+uSnrOinXS3v8iauhv1DZq5YbC3w5HcN+jJRFj6kGyZwI87qHS7pBKw3
-    KqhC4dyhppb3o+/lhTti/zkM47ES0OoAkn0hISqe2ynpYFAnseVlyMNRCF/Ur3CN
-    H6hZgGOV02rxy43GYrfe+/7qLCkrDA6k7ZKbKJxIYSlPXCSOOs2uOTcV20pttMeO
-    lCTpXh7gg7MjcJzA8G029QcwBXi66Dc13QoR96YLmIohSz5GCpZK09Iqww+qU/Jq
-    ME/rUlotsWrRzmZ3vVw+oKsQ1r91PVib43yHJQIDAQABAoIBAQCgh4omxItWzbTM
-    Sj2Cg8vLeKxxLOClBSYNYFev6jS3UO3b6ueptLM+tGn3XILPLsv3CVlFhD9IaIG2
-    Zu1zXI3GocrNf2ktZJXGdFeuCI96IrBqN7ve1LBF11yM65rxOjKSGwcTOpngqDck
-    duUpdhqhRQcMYhzrF1Cwv5//2aQXAORvJziIjMrKHSMOnvG9UHQQNTMqr1EnmrBm
-    FIDYhUbZa4dpubWsv6QxuVyavr0GwVali8KvqVfPEjWFnyyZe4bj7h76DgwD10qQ
-    nVdJeiRHqO+PDhrTS+BNb+ml34/CE0OgUXErNvKKRzJfNfu4GoWub5gMe9TwPdWV
-    PvK+mVwBAoGBAOmWntoPpssErRzyxDd/liLYNV+O7eRhyqEuFGuc9OQzRTrLMwC3
-    oEp8wlQw9swQddD771JIrJiDcngZdDV6kGIWhLZIJTWPiUP0eI5Ieje8YxurZ1tC
-    oKNfo6LAz26S5f6CWQZttARPUHdIFewbIykvsFCpSf4hj6yENzb+WkBxAoGBAMjJ
-    l4gx3RewiEN4ksEEsygjimZ2HT0KJ++mdim1BSUGYIk/OJMW+eHNLU/QWZNO3i6P
-    LYIleCPO3AkDXk3uc4K7bak5oNPvQFviF1pM8PD6OMa7251Ma3mcrlzwYAInlv5C
-    WQtTujotFCQ6ya9/qgfTjPGfILpZOyu20+Un2Av1AoGAe6g28+1xOOyC0F5cLZ0n
-    V87pgmrh2RND98uzF70Bj4Ts01Ea8PhErOoa3gMFw8W6+SVF7mN2q0563MVs1ZrK
-    sIKHQxAyUoZn/kd/QqNvv+3E8bLthkxhSdupftFffoPZqcBLbLHKqLVsPZk1scYz
-    +Ou8BRd5ikUuD//2UvCXyqECgYEAlI6bABislX92gj0uj4MTrwoEt2SCo4vlGmoW
-    GSum38sFF+bfy+x++7Mb6GamL9h1iQtER3vDlPLTWBPW7WAUtNBKBZ/uv3/QJWt1
-    jclJp3HrGhcaGRrWlgb39ymeT1nNXNfoG/pZ2ftKYLfiS2fwfJPoP0lWJKoqnmBK
-    DM1bCxUCgYEA1ufYLRzhBg+G8OhIqGVHomGwFYH+WG9O55RWQP/5WzUOj0OBbcJG
-    Nuk9iPrsQshka6tdipdB2BLv3pVfbnruZc+AKOnlTxDtZg2y9dfWmV9ijDqmUns5
-    bIcipc38fdjMSxGVye4yxCpXaWsss6HxVed0ZVWhOkwvsW/j5QJ18Hk=
+    hunter2
     -----END RSA PRIVATE KEY-----


### PR DESCRIPTION
The Vagrant environment is long-dead (and only ever would have been run locally) but it's not a good look to have any kind of private key or password checked into a public repo (even if it's just for testing), so let's clean it up.

Addresses #12155, with credit to @annaobarz for bringing this to our attention.